### PR TITLE
[onert] support build boost for android

### DIFF
--- a/infra/nnfw/cmake/buildtool/cross/toolchain_aarch64-android.cmake
+++ b/infra/nnfw/cmake/buildtool/cross/toolchain_aarch64-android.cmake
@@ -11,7 +11,8 @@ if(NOT DEFINED NDK_DIR)
 endif(NOT DEFINED NDK_DIR)
 
 set(ANDROID_ABI arm64-v8a)
-set(ANDROID_PLATFORM android-29)
+set(ANDROID_API_LEVEL 29)
+set(ANDROID_PLATFORM android-${ANDROID_API_LEVEL})
 
 # Find package in the host. `nnfw_find_package` won't work without this
 set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE NEVER)


### PR DESCRIPTION
It makes it possible to build boost for android.
boost::program_options are required for tflite_run and nnpackage_run.
Turn on BUILD_BOOST and DOWNLOAD_BOOST cmake option.

Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>