### PR TITLE
[onert] Revise backend loading policy

### DIFF
--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -61,10 +61,6 @@ CompilerOptions fetchCompilerOptionsFromGlobalConfig(const ir::Graph &graph)
 
     // Default value for op_backend_all is first element in the backend list
     ms_options.backend_for_all = util::getConfigString(util::config::OP_BACKEND_ALLOPS);
-    if (ms_options.backend_for_all.empty())
-    {
-      ms_options.backend_for_all = options.backend_list.at(0);
-    }
 
 // Opcode to Backend
 #define OP(OpName)                                                                      \

--- a/runtime/onert/core/src/compiler/ManualScheduler.cc
+++ b/runtime/onert/core/src/compiler/ManualScheduler.cc
@@ -39,7 +39,11 @@ std::unique_ptr<BackendResolver> ManualScheduler::schedule(const ir::Graph &grap
   auto backend_resolver = std::make_unique<compiler::BackendResolver>();
 
   // 1. Backend for All operations
-  backend::Backend *backend_all = BackendManager::get().get(_options.backend_for_all);
+  const backend::Backend *backend_all = BackendManager::get().get(_options.backend_for_all);
+  if (!backend_all)
+  {
+    backend_all = BackendManager::get().getAll().at(0);
+  }
   VERBOSE(ManualScheduler) << "Default backend for all ops: " << _options.backend_for_all
                            << std::endl;
 


### PR DESCRIPTION
If loading a backend failed, just skip that backend rather than
throwing. And also, this changes the default backend to be any one of
loaded backends if the default backend config is not given.

Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>