### PR TITLE
[onert] Use the option for DELETE_CACHED_DATA

### DIFF
--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -157,7 +157,7 @@ void Compiler::compile(void)
   // To delete cached data, this doing should be done for the original graph
   // at this line and then once again for the lowered graph in ExecutorFactory
   // TODO. Delete this code as code for disconnecting btw Graph and nnfw session lands
-  if (util::getConfigBool(util::config::DELETE_CACHED_DATA))
+  if (_options.delete_cached_data)
   {
     CachedDataDeleter(_graph->operands()).run();
   }


### PR DESCRIPTION
Use the option for DELETE_CACHED_DATA instead of util::Config

Signed-off-by: Yongseop Kim <yons.kim@samsung.com>