### PR TITLE
[oneapi] Download nnpackages before nnfw_api_test

### DIFF
--- a/tests/nnfw_api/CMakeLists.txt
+++ b/tests/nnfw_api/CMakeLists.txt
@@ -23,10 +23,3 @@ target_link_libraries(${RUNTIME_NNFW_API_TEST} gtest gmock)
 target_link_libraries(${RUNTIME_NNFW_API_TEST} ${LIB_PTHREAD} dl)
 
 install(TARGETS ${RUNTIME_NNFW_API_TEST} DESTINATION unittest)
-
-# Install sample models for test
-set(RUNTIME_NNFW_API_TEST_MODEL_DIR "${RUNTIME_NNFW_API_TEST}_models")
-file(MAKE_DIRECTORY ${RUNTIME_NNFW_API_TEST_MODEL_DIR})
-install(DIRECTORY ../../nnpackage/examples/one_op_in_tflite
-        DESTINATION unittest/${RUNTIME_NNFW_API_TEST_MODEL_DIR}
-        OPTIONAL)

--- a/tests/nnfw_api/src/fixtures.h
+++ b/tests/nnfw_api/src/fixtures.h
@@ -53,8 +53,8 @@ protected:
   void SetUp() override
   {
     ValidationTestSessionCreated::SetUp();
-    ASSERT_EQ(nnfw_load_model_from_file(
-                  _session, ModelPath::get().getModelAbsolutePath(MODEL_ONE_OP_IN_TFLITE).c_str()),
+    ASSERT_EQ(nnfw_load_model_from_file(_session,
+                                        ModelPath::get().getModelAbsolutePath(MODEL_ADD).c_str()),
               NNFW_STATUS_NO_ERROR);
     ASSERT_NE(_session, nullptr);
   }

--- a/tests/nnfw_api/src/load_model.cc
+++ b/tests/nnfw_api/src/load_model.cc
@@ -20,9 +20,9 @@
 TEST_F(ValidationTestSessionCreated, load_session_001)
 {
   // Existing model must
-  ASSERT_EQ(nnfw_load_model_from_file(
-                _session, ModelPath::get().getModelAbsolutePath(MODEL_ONE_OP_IN_TFLITE).c_str()),
-            NNFW_STATUS_NO_ERROR);
+  ASSERT_EQ(
+      nnfw_load_model_from_file(_session, ModelPath::get().getModelAbsolutePath(MODEL_ADD).c_str()),
+      NNFW_STATUS_NO_ERROR);
 }
 
 TEST_F(ValidationTestSessionCreated, neg_load_session_001)

--- a/tests/nnfw_api/src/main.cc
+++ b/tests/nnfw_api/src/main.cc
@@ -27,7 +27,7 @@
  */
 void checkModels()
 {
-  std::string absolute_path = ModelPath::get().getModelAbsolutePath(MODEL_ONE_OP_IN_TFLITE);
+  std::string absolute_path = ModelPath::get().getModelAbsolutePath(MODEL_ADD);
   DIR *dir = opendir(absolute_path.c_str());
   if (!dir)
   {

--- a/tests/nnfw_api/src/model_path.cc
+++ b/tests/nnfw_api/src/model_path.cc
@@ -20,7 +20,7 @@
 #include <libgen.h>
 #include <string.h>
 
-const char *MODEL_ONE_OP_IN_TFLITE = "one_op_in_tflite";
+const char *MODEL_ADD = "add";
 
 ModelPath &ModelPath::get()
 {
@@ -51,5 +51,6 @@ void ModelPath::init(const char *argv0)
 
 std::string ModelPath::getModelAbsolutePath(const char *model_dir)
 {
-  return _base_path + "/nnfw_api_gtest_models/" + model_dir;
+  // Model dir is nested
+  return _base_path + "/nnfw_api_gtest_models/" + model_dir + "/" + model_dir;
 }

--- a/tests/nnfw_api/src/model_path.h
+++ b/tests/nnfw_api/src/model_path.h
@@ -19,7 +19,7 @@
 
 #include <string>
 
-extern const char *MODEL_ONE_OP_IN_TFLITE;
+extern const char *MODEL_ADD;
 
 /**
  * @brief A helper class to find models for testing

--- a/tests/scripts/oneapi_test/install_oneapi_test_nnpackages.sh
+++ b/tests/scripts/oneapi_test/install_oneapi_test_nnpackages.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+
+# TODO Reuse the fuction in run_test.sh. This is its duplication.
+function need_download()
+{
+    LOCAL_PATH=$1
+    REMOTE_URL=$2
+    if [ ! -e $LOCAL_PATH ]; then
+        return 0;
+    fi
+    # Ignore checking md5 in cache
+    if [ ! -z $IGNORE_MD5 ] && [ "$IGNORE_MD5" == "1" ]; then
+        return 1
+    fi
+
+    LOCAL_HASH=$(md5sum $LOCAL_PATH | awk '{ print $1 }')
+    REMOTE_HASH=$(curl -ss $REMOTE_URL | md5sum  | awk '{ print $1 }')
+    # TODO Emit an error when Content-MD5 field was not found. (Server configuration issue)
+    if [ "$LOCAL_HASH" != "$REMOTE_HASH" ]; then
+        echo "Downloaded file is outdated or incomplete."
+        return 0
+    fi
+    return 1
+}
+
+# TODO Reuse the fuction in run_test.sh. This is its duplication.
+download_tests()
+{
+    SELECTED_TESTS=$@
+
+    echo ""
+    echo "Downloading tests:"
+    echo "======================"
+    for TEST_NAME in $SELECTED_TESTS; do
+        echo $TEST_NAME
+    done
+    echo "======================"
+
+    for TEST_NAME in $SELECTED_TESTS; do
+        # Test configure initialization
+        MODELFILE_SERVER_PATH=""
+        MODELFILE_NAME=""
+        source $TEST_ROOT_PATH/$TEST_NAME/config.sh
+
+        TEST_CACHE_PATH=$CACHE_ROOT_PATH/$TEST_NAME
+        MODELFILE=$TEST_CACHE_PATH/$MODELFILE_NAME
+        MODELFILE_URL="$MODELFILE_SERVER/$MODELFILE_NAME"
+        if [ -n  "$FIXED_MODELFILE_SERVER" ]; then
+            MODELFILE_URL="$FIXED_MODELFILE_SERVER/$MODELFILE_NAME"
+        fi
+
+        # Download model file
+        if [ ! -e $TEST_CACHE_PATH ]; then
+            mkdir -p $TEST_CACHE_PATH
+        fi
+
+        # Download unless we have it in cache (Also check md5sum)
+        if need_download "$MODELFILE" "$MODELFILE_URL"; then
+            echo ""
+            echo "Download test file for $TEST_NAME"
+            echo "======================"
+
+            rm -f $MODELFILE # Remove invalid file if exists
+            pushd $TEST_CACHE_PATH
+            wget -nv $MODELFILE_URL
+            if [ "${MODELFILE_NAME##*.}" == "zip" ]; then
+                unzip -o $MODELFILE_NAME
+            fi
+            popd
+        fi
+
+    done
+}
+
+usage()
+{
+    echo "Usage: $0 --modelfile-server=MODELFILE_SERVER --install-path=INSTALL_DIR"
+    echo "  MODELFILE_SERVER : Base URL of the model file server"
+    echo "  INSTALL_DIR      : Path to be installed"
+    exit 1
+}
+
+while [[ $# -gt 0 ]]
+do
+    key="$(echo $1 | awk '{print tolower($0)}')"
+    case "$key" in
+        -?|-h|--help)
+            usage
+            exit 1
+            ;;
+        --modelfile-server)
+            MODELFILE_SERVER="$2"
+            shift
+            ;;
+        --modelfile-server=*)
+            MODELFILE_SERVER="${1#*=}"
+            ;;
+        --install-dir)
+            INSTALL_DIR="$2"
+            shift
+            ;;
+        --install-dir=*)
+            INSTALL_DIR="${1#*=}"
+            ;;
+        *)
+            echo "Invalid option '$1'"
+            usage
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+if [ -z "$MODELFILE_SERVER" ]; then
+    echo "Please specify a value for --modelfile-server or MODELFILE_SERVER(env)."
+    usage
+    exit 1
+fi
+
+if [ -z "$INSTALL_DIR" ]; then
+    echo "Please specify a value for --install-dir or INSTALL_DIR(env)."
+    usage
+    exit 1
+fi
+
+set -e
+
+THIS_SCRIPT_DIR=$(realpath $(dirname ${BASH_SOURCE}))
+source ${THIS_SCRIPT_DIR}/../common.sh
+
+CACHE_ROOT_PATH=$INSTALL_DIR
+FIXED_MODELFILE_SERVER="${MODELFILE_SERVER:-}"
+TEST_ROOT_PATH=${THIS_SCRIPT_DIR}/models
+
+# All models in the directory are the target models
+pushd ${TEST_ROOT_PATH}
+MODELS=$(ls -d */)
+popd
+
+download_tests $MODELS
+
+set +e

--- a/tests/scripts/oneapi_test/models/add/config.sh
+++ b/tests/scripts/oneapi_test/models/add/config.sh
@@ -1,0 +1,1 @@
+MODELFILE_NAME="add.zip"

--- a/tests/scripts/unittest.sh
+++ b/tests/scripts/unittest.sh
@@ -74,6 +74,15 @@ for TEST_BIN in `find $UNITTEST_TEST_DIR -maxdepth 1 -type f -executable`; do
     echo "============================================"
     TEMP_UNITTEST_RESULT=0
 
+    # This test requires test model installation
+    if [ "$(basename $TEST_BIN)" == "nnfw_api_gtest" ] && [ ! -d "${TEST_BIN}_models" ]; then
+        ONEAPI_TEST_MODEL_INSTALLER=$(dirname $BASH_SOURCE)/oneapi_test/install_oneapi_test_nnpackages.sh
+        $ONEAPI_TEST_MODEL_INSTALLER --install-dir ${TEST_BIN}_models
+        if [[ $? -ne 0 ]]; then
+            echo "FAILED : oneapi test model installation"
+        fi
+    fi
+
     if [ "$UNITTEST_RUN_ALL" == "true" ]; then
         for TEST_LIST_VERBOSE_LINE in $($TEST_BIN --gtest_list_tests); do
             if [[ $TEST_LIST_VERBOSE_LINE == *\. ]]; then


### PR DESCRIPTION
- Introduce `install_oneapi_test_nnpackages.sh` and it is called from
  `unittest.sh`
- Just like framework tests, this has its own model directory
  (contains config.sh files)
- Downloaded filese are compressed nnpackages(.zip)
- Rename `one_op_tflite` to `add` which is its real name
- Do not install `one_op_tflite` with CMake install

Resolve #32

Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>