### PR TITLE
[runtime][dynamic tensor] Make Reshape kernel calculate its output

### DIFF
--- a/runtime/onert/backend/cpu/kernel/ReshapeLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/ReshapeLayer.cc
@@ -16,6 +16,8 @@
 
 #include "ReshapeLayer.h"
 
+#include <util/ShapeInference.h>
+
 namespace onert
 {
 namespace backend
@@ -32,8 +34,22 @@ ReshapeLayer::ReshapeLayer() : _input(nullptr), _shape(nullptr), _output(nullptr
 
 void ReshapeLayer::reshapeGeneric()
 {
-  // TODO use _shape to calculate shape of output when _shape is not nullptr && not constant
+  // if dynamic allocation is needed, allocate output tensor
+  if (_output->is_dynamic())
+  {
+    auto output_shape = shape_inference::dynamic_inf::inferReshape(_shape);
+    _output->info().shape(output_shape);
 
+    // set dynamic tensor's buffer
+    assert(_output->buffer() == nullptr);
+
+    //
+    // TODO Write code for memory allocation
+    //
+    throw std::runtime_error("Not yet implemented.");
+  }
+
+  // perform resize operation
   size_t count = _input->total_size();
   memcpy(_output->buffer(), _input->buffer(), count);
 }

--- a/runtime/onert/backend/cpu/operand/Tensor.h
+++ b/runtime/onert/backend/cpu/operand/Tensor.h
@@ -109,6 +109,8 @@ public:
     }
   }
 
+  ir::OperandInfo &info() { return _info; }
+
 private:
   ir::OperandInfo _info;
   uint8_t *_buffer;

--- a/runtime/onert/core/include/util/ShapeInference.h
+++ b/runtime/onert/core/include/util/ShapeInference.h
@@ -27,6 +27,7 @@
 #include "ir/Index.h"
 #include "ir/Layout.h"
 #include "ir/OperationVisitor.h"
+#include "backend/ITensor.h"
 
 namespace onert
 {
@@ -83,6 +84,23 @@ private:
 private:
   ir::Operands &_operands;
 };
+
+/**
+ * @brief namespace for functions to infer shape during kernel execution
+ * @note   1. If output tensor is dynamic tensor, call these functions at execution time
+ *         2. These functions would have different param list, so it was not designed as visitor
+ */
+namespace dynamic_inf
+{
+
+/**
+ * @brief Infer output shape of Reshape at execution time.
+ */
+ir::Shape inferReshape(const backend::ITensor *new_shape);
+
+// TODO define more function
+
+} // namespace dynamic_inf
 
 } // namespace shape_inference
 } // namespace onert

--- a/runtime/onert/core/src/util/ShapeInference.cc
+++ b/runtime/onert/core/src/util/ShapeInference.cc
@@ -237,5 +237,28 @@ void StaticInferer::visit(const ir::operation::Reshape &op)
   output.info().memAllocType(ir::MemAllocType::DYNAMIC);
 }
 
+/*
+  namespace dynamic_inf starts
+*/
+namespace dynamic_inf
+{
+
+ir::Shape inferReshape(const backend::ITensor *new_shape)
+{
+  assert(new_shape);
+  auto new_rank = new_shape->dimension(0);
+
+  ir::Shape output_shape(new_rank);
+
+  int32_t *shape_buf = reinterpret_cast<int32_t *>(new_shape->buffer());
+  assert(shape_buf);
+  for (size_t d = 0; d < new_rank; d++)
+    output_shape.dim(d) = shape_buf[d];
+
+  return output_shape;
+}
+
+} // namespace dynamic_inf
+
 } // namespace shape_inference
 } // namespace onert


### PR DESCRIPTION
This enables Reshape kernel (CPU) to calculate its output when the second input is not constant.

For #56

Signed-off-by: hyunsik-yoon <hyunsik.yoon.1024@gmail.com>