### PR TITLE
[runtime] adding comment on nnfw api negative test

### DIFF
--- a/tests/nnfw_api/src/load_model.cc
+++ b/tests/nnfw_api/src/load_model.cc
@@ -35,11 +35,13 @@ TEST_F(ValidationTestSessionCreated, neg_load_session_001)
 TEST_F(ValidationTestSessionCreated, neg_load_session_002)
 {
   ASSERT_EQ(nnfw_load_model_from_file(
-                nullptr, ModelPath::get().getModelAbsolutePath(MODEL_ONE_OP_IN_TFLITE).c_str()),
+                nullptr, // session is null
+                ModelPath::get().getModelAbsolutePath(MODEL_ONE_OP_IN_TFLITE).c_str()),
             NNFW_STATUS_ERROR);
 }
 
 TEST_F(ValidationTestSessionCreated, neg_prepare_001)
 {
+  // nnfw_load_model_from_file was not called
   ASSERT_EQ(nnfw_prepare(_session), NNFW_STATUS_ERROR);
 }


### PR DESCRIPTION
This adds comments for negative tests to explain easily why this tests are negative test.

For https://github.com/Samsung/ONE/pull/36#pullrequestreview-396123026

Signed-off-by: hyunsik-yoon <hyunsik.yoon.1024@gmail.com>