### PR TITLE
[onert] Change frontend layout to layout of subgraph of model

### DIFF
--- a/runtime/onert/core/include/ir/Graph.h
+++ b/runtime/onert/core/include/ir/Graph.h
@@ -64,6 +64,7 @@ public:
   void finishBuilding(void);
   void removeOperand(const OperandIndex &ind) { _operands.remove(ind); }
   bool isBuildingPhase(void) const { return _phase == Phase::BUILDING; }
+  void setLayout(Layout layout) { _layout = layout; }
 
 private:
   void initializeUseDef();
@@ -94,6 +95,7 @@ public:
   Operands &operands() { return _operands; } // TODO Remove this non-const accessor
   const Operations &operations() const { return _operations; }
   Operations &operations() { return _operations; }
+  Layout layout() { return _layout; }
 
 private:
   Phase _phase{Phase::BUILDING};
@@ -102,6 +104,8 @@ private:
   OperandIndexSequence _inputs;
   OperandIndexSequence _outputs;
   std::unordered_map<SubgraphIndex, std::shared_ptr<Graph>> _subgraphs;
+  // TFLite and circle's default layout is NHWC;
+  Layout _layout{Layout::NHWC};
 };
 
 } // namespace ir

--- a/runtime/onert/core/include/ir/LoweredGraph.h
+++ b/runtime/onert/core/include/ir/LoweredGraph.h
@@ -60,7 +60,7 @@ private:
   bool mergeable(const OpSequenceIndex &op_seq_index, const OperationIndex &node_index,
                  Layout layout);
   OpSequenceIndex appendFreshSingleOpSequence(const OperationIndex &node_index,
-                                              const Operation &node, Layout layout);
+                                              const Operation &node);
 
 private:
   Graph _graph;

--- a/runtime/onert/core/src/ir/LoweredGraph.cc
+++ b/runtime/onert/core/src/ir/LoweredGraph.cc
@@ -179,11 +179,11 @@ void LoweredGraph::removeLowerInfo(const OperandIndex &index)
 }
 
 OpSequenceIndex LoweredGraph::appendFreshSingleOpSequence(const OperationIndex &node_index,
-                                                          const Operation &node, Layout layout)
+                                                          const Operation &node)
 {
   // Create a fresh op_seq with one operation, and append it to op_seqs
   // Create a fresh op_seq
-  auto op_seq = std::make_unique<OpSequence>(layout);
+  auto op_seq = std::make_unique<OpSequence>(_graph.layout());
 
   // Add an operation
   op_seq->appendOperation(node_index, node);
@@ -214,9 +214,8 @@ void LoweredGraph::makeOpSequences(
         // LowerInfo for in/output operands
         auto backend = _backend_resolver->getBackend(node_index);
 
-        // TODO How to get frontend layout of this node from IR
-        auto frontend_layout = Layout::NHWC;
-        auto backend_layout = frontend_layout;
+        // Set backend's layout to frontend layout
+        auto backend_layout = _graph.layout();
 
         // The layout of each backend should be set at another place
         // TODO Change setting layout of each backend at another place
@@ -269,7 +268,7 @@ void LoweredGraph::makeOpSequences(
         // so that we can measure a node separately
         if (new_op_seq || is_profiling || !mergeable(op_seq_index, node_index, backend_layout))
         {
-          auto new_op_seq_index = appendFreshSingleOpSequence(node_index, node, frontend_layout);
+          auto new_op_seq_index = appendFreshSingleOpSequence(node_index, node);
 
           // OpSequence LowerInfo
           setLowerInfo(new_op_seq_index,

--- a/runtime/onert/frontend/circle/src/circle_loader.cc
+++ b/runtime/onert/frontend/circle/src/circle_loader.cc
@@ -26,6 +26,19 @@ namespace circle_loader
 namespace
 {
 
+ir::Layout convertDataFormat(circle::DataFormat data_format)
+{
+  switch (data_format)
+  {
+    case circle::DataFormat::DataFormat_CHANNELS_FIRST:
+      return ir::Layout::NCHW;
+    case circle::DataFormat::DataFormat_CHANNELS_LAST:
+      return ir::Layout::NHWC;
+    default:
+      throw std::runtime_error("Unsupported DataFormat");
+  }
+}
+
 struct LoaderDomain
 {
   using Verifier = flatbuffers::Verifier;
@@ -84,7 +97,7 @@ public:
       CircleLoader::loadOperation(op, *subg);
     }
 
-    (void)circle_subg->data_format();
+    subg->setLayout(convertDataFormat(circle_subg->data_format()));
 
     subg->finishBuilding();
 


### PR DESCRIPTION
Draft PR : #49

This commit changes frontend layout from NHWC to layout of subgraph of model.
  - Add converting layout from circle to ir
  - Set frontend layout as layout of circle

Signed-off-by: ragmani <ragmani0216@gmail.com>