### PR TITLE
[oneapi] Test fixtures with templates

### DIFF
--- a/tests/nnfw_api/src/FourOneOpModelSetInput.cc
+++ b/tests/nnfw_api/src/FourOneOpModelSetInput.cc
@@ -17,13 +17,15 @@
 #include "model_path.h"
 #include "fixtures.h"
 
-TEST_F(ValidationTestFourOneOpModelSetInput, run_001)
+using ValidationTestFourAddModelsSetInput = ValidationTestFourModelsSetInput<ModelPath::ADD>;
+
+TEST_F(ValidationTestFourAddModelsSetInput, run_001)
 {
   ASSERT_EQ(nnfw_run(_objects[0].session), NNFW_STATUS_NO_ERROR);
   ASSERT_EQ(nnfw_run(_objects[1].session), NNFW_STATUS_NO_ERROR);
 }
 
-TEST_F(ValidationTestFourOneOpModelSetInput, run_002)
+TEST_F(ValidationTestFourAddModelsSetInput, run_002)
 {
   int rep = 3;
   while (rep--)

--- a/tests/nnfw_api/src/fixtures.h
+++ b/tests/nnfw_api/src/fixtures.h
@@ -65,14 +65,14 @@ protected:
   nnfw_session *_session = nullptr;
 };
 
-class ValidationTestOneOpModelLoaded : public ValidationTestSessionCreated
+template <int PackageNo> class ValidationTestModelLoaded : public ValidationTestSessionCreated
 {
 protected:
   void SetUp() override
   {
     ValidationTestSessionCreated::SetUp();
     ASSERT_EQ(nnfw_load_model_from_file(_session,
-                                        ModelPath::get().getModelAbsolutePath(MODEL_ADD).c_str()),
+                                        ModelPath::get().getModelAbsolutePath(PackageNo).c_str()),
               NNFW_STATUS_NO_ERROR);
     ASSERT_NE(_session, nullptr);
   }
@@ -80,7 +80,7 @@ protected:
   void TearDown() override { ValidationTestSessionCreated::TearDown(); }
 };
 
-class ValidationTestFourOneOpModelSetInput : public ValidationTest
+template <int PackageNo> class ValidationTestFourModelsSetInput : public ValidationTest
 {
 protected:
   static const uint32_t NUM_SESSIONS = 4;
@@ -89,7 +89,7 @@ protected:
   {
     ValidationTest::SetUp();
 
-    auto model_path = ModelPath::get().getModelAbsolutePath(MODEL_ADD);
+    auto model_path = ModelPath::get().getModelAbsolutePath(ModelPath::ADD);
     for (auto &obj : _objects)
     {
       ASSERT_EQ(nnfw_create_session(&obj.session), NNFW_STATUS_NO_ERROR);

--- a/tests/nnfw_api/src/load_model.cc
+++ b/tests/nnfw_api/src/load_model.cc
@@ -20,23 +20,24 @@
 TEST_F(ValidationTestSessionCreated, load_session_001)
 {
   // Existing model must
-  ASSERT_EQ(
-      nnfw_load_model_from_file(_session, ModelPath::get().getModelAbsolutePath(MODEL_ADD).c_str()),
-      NNFW_STATUS_NO_ERROR);
+  ASSERT_EQ(nnfw_load_model_from_file(
+                _session, ModelPath::get().getModelAbsolutePath(ModelPath::ADD).c_str()),
+            NNFW_STATUS_NO_ERROR);
 }
 
 TEST_F(ValidationTestSessionCreated, neg_load_session_001)
 {
   ASSERT_EQ(nnfw_load_model_from_file(
-                _session, ModelPath::get().getModelAbsolutePath("nonexisting_directory").c_str()),
+                _session, ModelPath::get().getModelAbsolutePath(ModelPath::DUMMY).c_str()),
             NNFW_STATUS_ERROR);
 }
 
 TEST_F(ValidationTestSessionCreated, neg_load_session_002)
 {
-  ASSERT_EQ(nnfw_load_model_from_file(nullptr, // session is null
-                                      ModelPath::get().getModelAbsolutePath(MODEL_ADD).c_str()),
-            NNFW_STATUS_ERROR);
+  ASSERT_EQ(
+      nnfw_load_model_from_file(nullptr, // session is null
+                                ModelPath::get().getModelAbsolutePath(ModelPath::ADD).c_str()),
+      NNFW_STATUS_ERROR);
 }
 
 TEST_F(ValidationTestSessionCreated, neg_prepare_001)

--- a/tests/nnfw_api/src/main.cc
+++ b/tests/nnfw_api/src/main.cc
@@ -27,7 +27,7 @@
  */
 void checkModels()
 {
-  std::string absolute_path = ModelPath::get().getModelAbsolutePath(MODEL_ADD);
+  std::string absolute_path = ModelPath::get().getModelAbsolutePath(ModelPath::ADD);
   DIR *dir = opendir(absolute_path.c_str());
   if (!dir)
   {

--- a/tests/nnfw_api/src/model_path.cc
+++ b/tests/nnfw_api/src/model_path.cc
@@ -20,7 +20,8 @@
 #include <libgen.h>
 #include <string.h>
 
-const char *MODEL_ADD = "add";
+// NOTE Must match `enum TestPackages`
+const char *TEST_PACKAGE_NAMES[] = {"nonexisting_package", "add"};
 
 ModelPath &ModelPath::get()
 {
@@ -49,8 +50,9 @@ void ModelPath::init(const char *argv0)
   }
 }
 
-std::string ModelPath::getModelAbsolutePath(const char *model_dir)
+std::string ModelPath::getModelAbsolutePath(int package_no)
 {
+  const char *model_dir = TEST_PACKAGE_NAMES[package_no];
   // Model dir is nested
   return _base_path + "/nnfw_api_gtest_models/" + model_dir + "/" + model_dir;
 }

--- a/tests/nnfw_api/src/model_path.h
+++ b/tests/nnfw_api/src/model_path.h
@@ -19,23 +19,32 @@
 
 #include <string>
 
-extern const char *MODEL_ADD;
-
 /**
  * @brief A helper class to find models for testing
  */
 class ModelPath
 {
 public:
+  /**
+   * @brief Serial numbers for test packages. The numbers are mapped with package names.
+   *        This is useful for creating GTest Fixtures with variable template to do
+   *        different nn packages with no code duplication.
+   */
+  enum TestPackages
+  {
+    DUMMY, // Non-existing directory for negative tests
+    ADD
+  };
+
   static ModelPath &get();
 
   /**
    * @brief Get the Absolute of the model to find
    *
-   * @param model_dir A relative model directory
+   * @param package_no Model's serial number
    * @return std::string The absolute path of model directory
    */
-  std::string getModelAbsolutePath(const char *model_dir);
+  std::string getModelAbsolutePath(int package_no);
   /**
    * @brief Save the current executable's directory based on argv[0] and CWD
    *

--- a/tests/nnfw_api/src/prepare.cc
+++ b/tests/nnfw_api/src/prepare.cc
@@ -15,8 +15,11 @@
  */
 
 #include "fixtures.h"
+#include "model_path.h"
 
-TEST_F(ValidationTestOneOpModelLoaded, prepare_001)
+using ValidationTestAddModelLoaded = ValidationTestModelLoaded<ModelPath::ADD>;
+
+TEST_F(ValidationTestAddModelLoaded, prepare_001)
 {
   ASSERT_EQ(nnfw_prepare(_session), NNFW_STATUS_NO_ERROR);
 }


### PR DESCRIPTION
Test fixtures with templates to support different nn packages without
code duplication.

Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>