### PR TITLE
[tflite_run] tflite_run can be built for android

### DIFF
--- a/infra/nnfw/cmake/options/options_aarch64-android.cmake
+++ b/infra/nnfw/cmake/options/options_aarch64-android.cmake
@@ -8,6 +8,8 @@ option(BUILD_ANDROID_TFLITE "Enable android support for TensorFlow Lite" ON)
 option(BUILD_ANDROID_BENCHMARK_APP "Enable Android Benchmark App" ON)
 option(DOWNLOAD_NEON2SSE "Download NEON2SSE library source" OFF)
 # Need boost library
+option(DOWNLOAD_BOOST "Download boost source" OFF)
+option(BUILD_BOOST "Build boost source" OFF)
 option(BUILD_RUNTIME_NNAPI_TEST "Build Runtime NN API Generated Test" OFF)
 option(BUILD_NNPACKAGE_RUN "Build nnpackge_run" OFF)
 option(BUILD_TFLITE_RUN "Build tflite-run" OFF)

--- a/tests/tools/tflite_run/CMakeLists.txt
+++ b/tests/tools/tflite_run/CMakeLists.txt
@@ -14,7 +14,18 @@ target_include_directories(tflite_run PRIVATE src)
 target_include_directories(tflite_run PRIVATE ${Boost_INCLUDE_DIRS})
 
 target_link_libraries(tflite_run tensorflow-lite ${LIB_PTHREAD} dl nnfw_lib_tflite)
-target_link_libraries(tflite_run boost_program_options)
+if(BUILD_BOOST)
+  # We have to use Boost::program_options, instead of boost_program_optinos
+  # Boost::program_options provides the full path for our own built boost.
+  target_link_libraries(tflite_run Boost::program_options)
+else()
+  # We cannot use `Boost::program_options` on aarch64
+  # because it uses boost 1.65.1, which requires cmake >= 3.9.3
+  # to identify Boost::program_options imported target correctly,
+  # However, it uses cmake 3.5. (old version).
+  target_link_libraries(tflite_run boost_program_options)
+endif()
+
 target_link_libraries(tflite_run nnfw_lib_benchmark)
 
 install(TARGETS tflite_run DESTINATION bin)


### PR DESCRIPTION
Now `tflite_run` can be built for android if you enable
`DOWNLOAD_BOOST`, `BUILD_BOOST` and `BUILD_TFLITE`.

Note I disabled them deliberately because I don't want to
make CI busy for `tflite_run`.

Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>