### PR TITLE
[oneapi] Rename ModelPath to NNPackages

### DIFF
--- a/tests/nnfw_api/src/FourOneOpModelSetInput.cc
+++ b/tests/nnfw_api/src/FourOneOpModelSetInput.cc
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-#include "model_path.h"
+#include "NNPackages.h"
 #include "fixtures.h"
 
-using ValidationTestFourAddModelsSetInput = ValidationTestFourModelsSetInput<ModelPath::ADD>;
+using ValidationTestFourAddModelsSetInput = ValidationTestFourModelsSetInput<NNPackages::ADD>;
 
 TEST_F(ValidationTestFourAddModelsSetInput, run_001)
 {

--- a/tests/nnfw_api/src/NNPackages.cc
+++ b/tests/nnfw_api/src/NNPackages.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "model_path.h"
+#include "NNPackages.h"
 
 #include <unistd.h>
 #include <libgen.h>
@@ -23,13 +23,13 @@
 // NOTE Must match `enum TestPackages`
 const char *TEST_PACKAGE_NAMES[] = {"nonexisting_package", "add"};
 
-ModelPath &ModelPath::get()
+NNPackages &NNPackages::get()
 {
-  static ModelPath instance;
+  static NNPackages instance;
   return instance;
 }
 
-void ModelPath::init(const char *argv0)
+void NNPackages::init(const char *argv0)
 {
   char raw_dir[1024];
   char cwd[1024];
@@ -50,7 +50,7 @@ void ModelPath::init(const char *argv0)
   }
 }
 
-std::string ModelPath::getModelAbsolutePath(int package_no)
+std::string NNPackages::getModelAbsolutePath(int package_no)
 {
   const char *model_dir = TEST_PACKAGE_NAMES[package_no];
   // Model dir is nested

--- a/tests/nnfw_api/src/NNPackages.h
+++ b/tests/nnfw_api/src/NNPackages.h
@@ -20,9 +20,9 @@
 #include <string>
 
 /**
- * @brief A helper class to find models for testing
+ * @brief A helper class to find NN Packages for testing
  */
-class ModelPath
+class NNPackages
 {
 public:
   /**
@@ -36,7 +36,7 @@ public:
     ADD
   };
 
-  static ModelPath &get();
+  static NNPackages &get();
 
   /**
    * @brief Get the Absolute of the model to find
@@ -53,7 +53,7 @@ public:
   void init(const char *argv0);
 
 private:
-  ModelPath() = default;
+  NNPackages() = default;
 
 private:
   std::string _base_path;

--- a/tests/nnfw_api/src/fixtures.h
+++ b/tests/nnfw_api/src/fixtures.h
@@ -21,7 +21,7 @@
 #include <gtest/gtest.h>
 #include <nnfw.h>
 
-#include "model_path.h"
+#include "NNPackages.h"
 
 inline uint64_t num_elems(const nnfw_tensorinfo *ti)
 {
@@ -72,7 +72,7 @@ protected:
   {
     ValidationTestSessionCreated::SetUp();
     ASSERT_EQ(nnfw_load_model_from_file(_session,
-                                        ModelPath::get().getModelAbsolutePath(PackageNo).c_str()),
+                                        NNPackages::get().getModelAbsolutePath(PackageNo).c_str()),
               NNFW_STATUS_NO_ERROR);
     ASSERT_NE(_session, nullptr);
   }
@@ -89,7 +89,7 @@ protected:
   {
     ValidationTest::SetUp();
 
-    auto model_path = ModelPath::get().getModelAbsolutePath(ModelPath::ADD);
+    auto model_path = NNPackages::get().getModelAbsolutePath(NNPackages::ADD);
     for (auto &obj : _objects)
     {
       ASSERT_EQ(nnfw_create_session(&obj.session), NNFW_STATUS_NO_ERROR);

--- a/tests/nnfw_api/src/load_model.cc
+++ b/tests/nnfw_api/src/load_model.cc
@@ -14,21 +14,21 @@
  * limitations under the License.
  */
 
-#include "model_path.h"
+#include "NNPackages.h"
 #include "fixtures.h"
 
 TEST_F(ValidationTestSessionCreated, load_session_001)
 {
   // Existing model must
   ASSERT_EQ(nnfw_load_model_from_file(
-                _session, ModelPath::get().getModelAbsolutePath(ModelPath::ADD).c_str()),
+                _session, NNPackages::get().getModelAbsolutePath(NNPackages::ADD).c_str()),
             NNFW_STATUS_NO_ERROR);
 }
 
 TEST_F(ValidationTestSessionCreated, neg_load_session_001)
 {
   ASSERT_EQ(nnfw_load_model_from_file(
-                _session, ModelPath::get().getModelAbsolutePath(ModelPath::DUMMY).c_str()),
+                _session, NNPackages::get().getModelAbsolutePath(NNPackages::DUMMY).c_str()),
             NNFW_STATUS_ERROR);
 }
 
@@ -36,7 +36,7 @@ TEST_F(ValidationTestSessionCreated, neg_load_session_002)
 {
   ASSERT_EQ(
       nnfw_load_model_from_file(nullptr, // session is null
-                                ModelPath::get().getModelAbsolutePath(ModelPath::ADD).c_str()),
+                                NNPackages::get().getModelAbsolutePath(NNPackages::ADD).c_str()),
       NNFW_STATUS_ERROR);
 }
 

--- a/tests/nnfw_api/src/main.cc
+++ b/tests/nnfw_api/src/main.cc
@@ -19,7 +19,7 @@
 #include <string>
 #include <dirent.h>
 #include <gtest/gtest.h>
-#include "model_path.h"
+#include "NNPackages.h"
 
 /**
  * @brief Function to check if test model directories exist before it actually performs the test
@@ -27,7 +27,7 @@
  */
 void checkModels()
 {
-  std::string absolute_path = ModelPath::get().getModelAbsolutePath(ModelPath::ADD);
+  std::string absolute_path = NNPackages::get().getModelAbsolutePath(NNPackages::ADD);
   DIR *dir = opendir(absolute_path.c_str());
   if (!dir)
   {
@@ -38,7 +38,7 @@ void checkModels()
 
 int main(int argc, char **argv)
 {
-  ModelPath::get().init(argv[0]);
+  NNPackages::get().init(argv[0]);
   ::testing::InitGoogleTest(&argc, argv);
 
   try

--- a/tests/nnfw_api/src/prepare.cc
+++ b/tests/nnfw_api/src/prepare.cc
@@ -15,9 +15,9 @@
  */
 
 #include "fixtures.h"
-#include "model_path.h"
+#include "NNPackages.h"
 
-using ValidationTestAddModelLoaded = ValidationTestModelLoaded<ModelPath::ADD>;
+using ValidationTestAddModelLoaded = ValidationTestModelLoaded<NNPackages::ADD>;
 
 TEST_F(ValidationTestAddModelLoaded, prepare_001)
 {


### PR DESCRIPTION
This class manages NN Packages that are needed for gtests.

Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>