### PR TITLE
[luci] Fix typo of namespace

### DIFF
--- a/compiler/luci/lang/src/Module.cpp
+++ b/compiler/luci/lang/src/Module.cpp
@@ -43,4 +43,4 @@ loco::Graph *Module::graph(size_t idx) const
 
 std::unique_ptr<Module> make_module(void) { return std::make_unique<Module>(); }
 
-} // namespace loco
+} // namespace luci


### PR DESCRIPTION
This commit fixes typo of namespace in luci

Signed-off-by: seongwoo <mhs4670go@naver.com>