### PR TITLE
[oneapi] Let create session tests be fixture tests

### DIFF
--- a/tests/nnfw_api/src/ValidationTestSingleSession.cc
+++ b/tests/nnfw_api/src/ValidationTestSingleSession.cc
@@ -14,17 +14,16 @@
  * limitations under the License.
  */
 
-#include <gtest/gtest.h>
-#include <nnfw_dev.h>
+#include "NNPackages.h"
+#include "fixtures.h"
 
-TEST(nnfw_create_session, Test_001)
+TEST_F(ValidationTestSingleSession, create_001)
 {
-  nnfw_session *session = nullptr;
-  ASSERT_EQ(nnfw_create_session(&session), NNFW_STATUS_NO_ERROR);
-  ASSERT_EQ(nnfw_close_session(session), NNFW_STATUS_NO_ERROR);
+  ASSERT_EQ(nnfw_create_session(&_session), NNFW_STATUS_NO_ERROR);
+  ASSERT_EQ(nnfw_close_session(_session), NNFW_STATUS_NO_ERROR);
 }
 
-TEST(nnfw_create_session, Negative_001)
+TEST_F(ValidationTestSingleSession, neg_create_001)
 {
   ASSERT_EQ(nnfw_create_session(nullptr), NNFW_STATUS_ERROR);
 }

--- a/tests/nnfw_api/src/fixtures.h
+++ b/tests/nnfw_api/src/fixtures.h
@@ -46,23 +46,26 @@ protected:
   void SetUp() override {}
 };
 
-class ValidationTestSessionCreated : public ValidationTest
+class ValidationTestSingleSession : public ValidationTest
+{
+protected:
+  nnfw_session *_session = nullptr;
+};
+
+class ValidationTestSessionCreated : public ValidationTestSingleSession
 {
 protected:
   void SetUp() override
   {
-    ValidationTest::SetUp();
+    ValidationTestSingleSession::SetUp();
     ASSERT_EQ(nnfw_create_session(&_session), NNFW_STATUS_NO_ERROR);
   }
 
   void TearDown() override
   {
     ASSERT_EQ(nnfw_close_session(_session), NNFW_STATUS_NO_ERROR);
-    ValidationTest::TearDown();
+    ValidationTestSingleSession::TearDown();
   }
-
-protected:
-  nnfw_session *_session = nullptr;
 };
 
 template <int PackageNo> class ValidationTestModelLoaded : public ValidationTestSessionCreated


### PR DESCRIPTION
For the consistency, `create_session` tests are now `TEST_F` tests.

Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>