### PR TITLE
[luci] IR modification for Gather operation

### DIFF
--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleGather.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleGather.h
@@ -32,11 +32,11 @@ namespace luci
 class CircleGather final : public FixedArityNode<2, CircleNodeImpl<CircleOpcode::GATHER>>
 {
 public:
-  loco::Node *input(void) const { return at(0)->node(); }
-  void input(loco::Node *node) { at(0)->node(node); }
+  loco::Node *params(void) const { return at(0)->node(); }
+  void params(loco::Node *node) { at(0)->node(node); }
 
-  loco::Node *positions(void) const { return at(1)->node(); }
-  void positions(loco::Node *node) { at(1)->node(node); }
+  loco::Node *indices(void) const { return at(1)->node(); }
+  void indices(loco::Node *node) { at(1)->node(node); }
 
 public:
   int32_t axis(void) const { return _axis; }

--- a/compiler/luci/lang/src/Nodes/CircleGather.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleGather.test.cpp
@@ -27,7 +27,7 @@ TEST(CircleGatherTest, constructor)
   ASSERT_EQ(gather_node.dialect(), luci::CircleDialect::get());
   ASSERT_EQ(gather_node.opcode(), luci::CircleOpcode::GATHER);
 
-  ASSERT_EQ(gather_node.input(), nullptr);
-  ASSERT_EQ(gather_node.positions(), nullptr);
+  ASSERT_EQ(gather_node.params(), nullptr);
+  ASSERT_EQ(gather_node.indices(), nullptr);
   ASSERT_EQ(gather_node.axis(), 0);
 }


### PR DESCRIPTION
Parent Issue : #94 

In TensorFlow, `gather` operation has `params`, `indices` and `axis`.
In TensorFlowLite, `gather` operation has `inputs`, `positions` and `axis`.
As we had decided to follow Tensorflow parameter names,
this commit will fix those names.

Signed-off-by: llFreetimell <seok9311@naver.com>