### PR TITLE
[onert] Generate kernel of ConvertOps for fp16 on acl_cl

### DIFF
--- a/runtime/onert/backend/acl_cl/KernelGenerator.cc
+++ b/runtime/onert/backend/acl_cl/KernelGenerator.cc
@@ -2018,6 +2018,42 @@ void KernelGenerator::visit(const ir::operation::Max &node)
   _return_fn = std::move(acl_fn);
 }
 
+void KernelGenerator::visit(const ir::operation::ConvertFp32ToFp16 &node)
+{
+  const auto ofm_index{node.getOutputs().at(0)};
+  const auto ifm_index{node.getInputs().at(ir::operation::ConvertFp32ToFp16::Input::INPUT)};
+
+  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
+  auto ifm_alloc = _tensor_builder->at(ifm_index).get();
+
+  auto fn = std::make_unique<::arm_compute::CLDepthConvertLayer>();
+
+  fn->configure(ifm_alloc->handle(), ofm_alloc->handle(), ::arm_compute::ConvertPolicy::SATURATE,
+                0);
+
+  auto acl_fn = asAclClFunction(std::move(fn));
+
+  _return_fn = std::move(acl_fn);
+}
+
+void KernelGenerator::visit(const ir::operation::ConvertFp16ToFp32 &node)
+{
+  const auto ofm_index{node.getOutputs().at(0)};
+  const auto ifm_index{node.getInputs().at(ir::operation::ConvertFp16ToFp32::Input::INPUT)};
+
+  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
+  auto ifm_alloc = _tensor_builder->at(ifm_index).get();
+
+  auto fn = std::make_unique<::arm_compute::CLDepthConvertLayer>();
+
+  fn->configure(ifm_alloc->handle(), ofm_alloc->handle(), ::arm_compute::ConvertPolicy::SATURATE,
+                0);
+
+  auto acl_fn = asAclClFunction(std::move(fn));
+
+  _return_fn = std::move(acl_fn);
+}
+
 } // namespace acl_cl
 } // namespace backend
 } // namespace onert

--- a/runtime/onert/backend/acl_cl/KernelGenerator.h
+++ b/runtime/onert/backend/acl_cl/KernelGenerator.h
@@ -98,6 +98,8 @@ public:
   void visit(const ir::operation::Pad &) override;
   void visit(const ir::operation::Min &) override;
   void visit(const ir::operation::Max &) override;
+  void visit(const ir::operation::ConvertFp32ToFp16 &) override;
+  void visit(const ir::operation::ConvertFp16ToFp32 &) override;
 
 private:
   const ir::Operands &_ctx;


### PR DESCRIPTION
Generate kernel of ConvertOps for fp16 on acl_cl by arm_compute::CLDepthConvertLayer

Signed-off-by: Yongseop Kim <yons.kim@samsung.com>