### PR TITLE
[onert] ShapeFixer code of ConvertOps for fp16 on acl_cl

### DIFF
--- a/runtime/onert/backend/acl_cl/ShapeFixer.cc
+++ b/runtime/onert/backend/acl_cl/ShapeFixer.cc
@@ -426,6 +426,10 @@ void ShapeFixer::visit(const ir::operation::Max &node)
   }
 }
 
+void ShapeFixer::visit(const ir::operation::ConvertFp32ToFp16 &) { /* DO NOTHING */}
+
+void ShapeFixer::visit(const ir::operation::ConvertFp16ToFp32 &) { /* DO NOTHING */}
+
 } // namespace acl_cl
 } // namespace backend
 } // namespace onert

--- a/runtime/onert/backend/acl_cl/ShapeFixer.h
+++ b/runtime/onert/backend/acl_cl/ShapeFixer.h
@@ -97,6 +97,8 @@ public:
   void visit(const ir::operation::Pad &) override;
   void visit(const ir::operation::Min &) override;
   void visit(const ir::operation::Max &) override;
+  void visit(const ir::operation::ConvertFp32ToFp16 &) override;
+  void visit(const ir::operation::ConvertFp16ToFp32 &) override;
 
 private:
   const ir::Operands &_ctx;


### PR DESCRIPTION
ShapeFixer code of ConvertOps for fp16 on acl_cl by `DO NOTHING`

Signed-off-by: Yongseop Kim <yons.kim@samsung.com>