### PR TITLE
[res] Fix TFL Conv2D 001 recipe

### DIFF
--- a/res/TensorFlowLiteRecipes/Conv2D_001/test.recipe
+++ b/res/TensorFlowLiteRecipes/Conv2D_001/test.recipe
@@ -40,5 +40,4 @@ operation {
   output: "ofm"
 }
 input: "ifm"
-input: "ker"
 output: "ofm"


### PR DESCRIPTION
This commit fixes `Conv2D_001` tflite recipe. It denotes constant 'ker'
as graph input.

Signed-off-by: Cheongyo Bahk <cg.bahk@gmail.com>

---

For #185