### PR TITLE
[tf2tfliteV2-value-pbtxt] Change method of pip call

### DIFF
--- a/compiler/tf2tfliteV2-value-pbtxt-test/CMakeLists.txt
+++ b/compiler/tf2tfliteV2-value-pbtxt-test/CMakeLists.txt
@@ -43,8 +43,8 @@ set(REQUIREMENTS_BIN_PATH "${CMAKE_CURRENT_BINARY_DIR}/${REQUIREMENTS_FILE}")
 add_custom_command(
   OUTPUT ${REQUIREMENTS_BIN_PATH}
   COMMAND ${CMAKE_COMMAND} -E copy ${REQUIREMENTS_SRC_PATH} ${REQUIREMENTS_BIN_PATH}
-  COMMAND ${VIRTUALENV}/bin/pip install --upgrade pip setuptools --timeout 100
-  COMMAND ${VIRTUALENV}/bin/pip install -r requirements.txt --upgrade --timeout 100
+  COMMAND ${VIRTUALENV}/bin/python -m pip install --upgrade pip setuptools --timeout 100
+  COMMAND ${VIRTUALENV}/bin/python -m pip install -r requirements.txt --upgrade --timeout 100
   DEPENDS ${VIRTUALENV} ${REQUIREMENTS_SRC_PATH}
 )
 


### PR DESCRIPTION
This changes is from shebang length limit

Related: #149

Signed-off-by: seongwoo <mhs4670go@naver.com>