### PR TITLE
[circledump] Enable Gather operation options

### DIFF
--- a/compiler/circledump/src/OpPrinter.cpp
+++ b/compiler/circledump/src/OpPrinter.cpp
@@ -184,6 +184,21 @@ public:
   }
 };
 
+class GatherPrinter : public OpPrinter
+{
+public:
+  void options(const circle::Operator *op, std::ostream &os) const override
+  {
+    if (auto *params = op->builtin_options_as_GatherOptions())
+    {
+      os << "    ";
+      os << "Axis(" << params->axis() << ") ";
+
+      os << std::endl;
+    }
+  }
+};
+
 class MulPrinter : public OpPrinter
 {
 public:
@@ -293,6 +308,7 @@ OpPrinterRegistry::OpPrinterRegistry()
   _op_map[circle::BuiltinOperator_DEPTHWISE_CONV_2D] = make_unique<DepthwiseConv2DPrinter>();
   _op_map[circle::BuiltinOperator_DIV] = make_unique<DivPrinter>();
   _op_map[circle::BuiltinOperator_FULLY_CONNECTED] = make_unique<FullyConnectedPrinter>();
+  _op_map[circle::BuiltinOperator_GATHER] = make_unique<GatherPrinter>();
   _op_map[circle::BuiltinOperator_MAX_POOL_2D] = make_unique<Pool2DPrinter>();
   _op_map[circle::BuiltinOperator_MUL] = make_unique<MulPrinter>();
   _op_map[circle::BuiltinOperator_PACK] = make_unique<PackPrinter>();


### PR DESCRIPTION
Parent Issue : #94

This commit will enable `gather` operation options in `circledump`

Signed-off-by: llFreetimell <seok9311@naver.com>