### PR TITLE
[tflchef] Constant filler for UINT8 & INT32

### DIFF
--- a/compiler/tflchef/core/src/DataChef.def
+++ b/compiler/tflchef/core/src/DataChef.def
@@ -6,6 +6,8 @@
 //  "TYPE" SHOULD BE an enum tag of tflchef::TensorType
 DATA_CHEF(FLOAT32, constant, ConstantDataChefFactory<float>)
 DATA_CHEF(BOOL, constant, ConstantDataChefFactory<bool>)
+DATA_CHEF(UINT8, constant, ConstantDataChefFactory<uint8_t>)
+DATA_CHEF(INT32, constant, ConstantDataChefFactory<int32_t>)
 DATA_CHEF(INT32, explicit, ExplicitDataChefFactory<int>)
 DATA_CHEF(UINT8, explicit, ExplicitDataChefFactory<uint8_t>)
 DATA_CHEF(BOOL, explicit, ExplicitDataChefFactory<bool>)


### PR DESCRIPTION
This commit adds constant data filler for UINT8 and INT32 data types.

Signed-off-by: Cheongyo Bahk <cg.bahk@gmail.com>

---

For #195 
Draft #202 