### PR TITLE
[luci] Add `DataType` mixin to `luci::CircleNode`

### DIFF
--- a/compiler/luci/import/include/luci/Import/CircleReader.h
+++ b/compiler/luci/import/include/luci/Import/CircleReader.h
@@ -21,6 +21,7 @@
 
 #include <luci/IR/AttrFusedActFunc.h>
 #include <luci/IR/AttrPadding.h>
+#include <luci/IR/CircleNode.h>
 #include <luci/IR/CircleQuantParam.h>
 
 #include <loco.h>
@@ -44,6 +45,9 @@ FusedActFunc luci_actfunc(const circle::ActivationFunctionType type);
 Padding luci_padding(const circle::Padding padding);
 std::unique_ptr<CircleQuantParam>
 luci_quantparam(const circle::QuantizationParametersT *quantization);
+
+/// @brief Copy common tensor attributes such as name, type, etc. to node.
+void copy_tensor_attributes(const circle::TensorT &tensor, CircleNode *node);
 
 /**
  * @brief Loads Circle file and provides helpers to access attributes

--- a/compiler/luci/import/src/CircleReader.cpp
+++ b/compiler/luci/import/src/CircleReader.cpp
@@ -159,6 +159,19 @@ luci_quantparam(const circle::QuantizationParametersT *quantization)
   return nullptr;
 }
 
+void copy_tensor_attributes(const circle::TensorT &tensor, CircleNode *node)
+{
+  node->name(tensor_name(tensor));
+  node->dtype(luci_datatype(tensor.type));
+  const auto *quantization = tensor.quantization.get();
+  if (quantization != nullptr)
+  {
+    auto quantparam = luci_quantparam(quantization);
+    if (quantparam)
+      node->quantparam(std::move(quantparam));
+  }
+}
+
 circle::BuiltinOperator CircleReader::builtin_code(const circle::OperatorT &op) const
 {
   const auto &op_codes = opcodes();

--- a/compiler/luci/import/src/GraphBuilder.cpp
+++ b/compiler/luci/import/src/GraphBuilder.cpp
@@ -39,16 +39,7 @@ void GraphBuilder::build(const circle::OperatorT &op, GraphBuilderContext *conte
   assert(outputs.size() == 1);
   {
     const circle::TensorT &output_tensor = *tensors[outputs[0]];
-
-    node->name(tensor_name(output_tensor));
-
-    auto quantization = tensor_quantization(output_tensor);
-    if (quantization)
-    {
-      auto quantparam = luci_quantparam(quantization);
-      if (quantparam)
-        node->quantparam(std::move(quantparam));
-    }
+    copy_tensor_attributes(output_tensor, node);
   }
 
   // Register node's only output.

--- a/compiler/luci/import/src/Nodes/CircleCustom.cpp
+++ b/compiler/luci/import/src/Nodes/CircleCustom.cpp
@@ -54,16 +54,7 @@ void CircleCustomGraphBuilder::build(const circle::OperatorT &op,
   assert(outputs.size() == 1);
   {
     const circle::TensorT &output_tensor = *tensors[outputs[0]];
-
-    node->name(tensor_name(output_tensor));
-
-    auto quantization = tensor_quantization(output_tensor);
-    if (quantization)
-    {
-      auto quantparam = luci_quantparam(quantization);
-      if (quantparam)
-        node->quantparam(std::move(quantparam));
-    }
+    copy_tensor_attributes(output_tensor, node);
   }
 
   context->nodefinder()->enroll(outputs[0], node);

--- a/compiler/luci/import/src/Nodes/CircleIf.cpp
+++ b/compiler/luci/import/src/Nodes/CircleIf.cpp
@@ -117,19 +117,10 @@ void CircleIfGraphBuilder::build(const circle::OperatorT &op, GraphBuilderContex
     const circle::TensorT &output_tensor = *tensors[outputs[n]];
 
     auto *nodeout = graph->nodes()->create<CircleIfOut>();
+    copy_tensor_attributes(output_tensor, nodeout);
 
     nodeout->input(node);
     nodeout->index(n);
-
-    nodeout->name(tensor_name(output_tensor));
-
-    auto quantization = tensor_quantization(output_tensor);
-    if (quantization)
-    {
-      auto quantparam = luci_quantparam(quantization);
-      if (quantparam)
-        node->quantparam(std::move(quantparam));
-    }
 
     context->nodefinder()->enroll(outputs[n], nodeout);
   }

--- a/compiler/luci/import/src/Nodes/CircleUnpack.cpp
+++ b/compiler/luci/import/src/Nodes/CircleUnpack.cpp
@@ -109,19 +109,10 @@ void CircleUnpackGraphBuilder::build(const circle::OperatorT &op,
     const circle::TensorT &output_tensor = *tensors[outputs[n]];
 
     auto *nodeout = graph->nodes()->create<CircleUnpackOut>();
+    copy_tensor_attributes(output_tensor, nodeout);
 
     nodeout->unpack(node);
     nodeout->index(n);
-
-    nodeout->name(tensor_name(output_tensor));
-
-    auto quantization = tensor_quantization(output_tensor);
-    if (quantization)
-    {
-      auto quantparam = luci_quantparam(quantization);
-      if (quantparam)
-        node->quantparam(std::move(quantparam));
-    }
 
     context->nodefinder()->enroll(outputs[n], nodeout);
   }

--- a/compiler/luci/lang/include/luci/IR/CircleNodeDecl.h
+++ b/compiler/luci/lang/include/luci/IR/CircleNodeDecl.h
@@ -17,8 +17,9 @@
 #ifndef __LUCI_IR_CIRCLENODEDECL_H__
 #define __LUCI_IR_CIRCLENODEDECL_H__
 
-#include <loco/IR/Node.h>
 #include <loco/IR/Dialect.h>
+#include <loco/IR/Node.h>
+#include <loco/IR/NodeMixins.h>
 
 #include "CircleOpcode.h"
 #include "CircleNodeVisitor.forward.h"
@@ -31,7 +32,7 @@ namespace luci
 
 using NodeName = std::string;
 
-struct CircleNode : public loco::Node
+struct CircleNode : public loco::Node, public loco::NodeMixin<loco::NodeTrait::DataType>
 {
   virtual ~CircleNode() = default;
 

--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleConst.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleConst.h
@@ -33,7 +33,6 @@ namespace luci
  * @note  This will not be exported as a specific op
  */
 class CircleConst final : public FixedArityNode<0, CircleNodeImpl<CircleOpcode::CONST>>,
-                          public loco::NodeMixin<loco::NodeTrait::DataType>,
                           public loco::NodeMixin<loco::NodeTrait::TensorShape>
 {
 public:

--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleInput.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleInput.h
@@ -34,7 +34,6 @@ namespace luci
  * @note  This will not be exported as a specific op
  */
 class CircleInput final : public FixedArityNode<0, CircleNodeImpl<CircleOpcode::CIRCLEINPUT>>,
-                          public loco::NodeMixin<loco::NodeTrait::DataType>,
                           public loco::NodeMixin<loco::NodeTrait::TensorShape>
 {
 public:


### PR DESCRIPTION
Draft PR #205.

Add `DataType` mixin to `CircleNode` and use it in importer.

Signed-off-by: Sergei Barannikov <s.barannikov@samsung.com>