### PR TITLE
[oneapi] gtest: Check the nnpackages first

### DIFF
--- a/tests/nnfw_api/src/NNPackages.h
+++ b/tests/nnfw_api/src/NNPackages.h
@@ -36,8 +36,8 @@ public:
    */
   enum TestPackages
   {
-    DUMMY, // Non-existing directory for negative tests
-    ADD
+    ADD,
+    COUNT
   };
 
   /*
@@ -54,12 +54,27 @@ public:
    * @return std::string The absolute path of model directory
    */
   std::string getModelAbsolutePath(int package_no);
+
+  /**
+   * @brief Get the absolute of the model to find
+   *
+   * @param package_name Package name
+   * @return std::string The absolute path of model directory
+   */
+  std::string getModelAbsolutePath(const char *package_name);
+
   /**
    * @brief Save the current executable's directory based on argv[0] and CWD
    *
    * @param argv0 0th command line argument of the current process
    */
   void init(const char *argv0);
+
+  /**
+   * @brief Check all the nnpackages are installed
+   *        Must be run after @c init .
+   */
+  void checkAll();
 
 private:
   NNPackages() = default;

--- a/tests/nnfw_api/src/ValidationTestSessionCreated.cc
+++ b/tests/nnfw_api/src/ValidationTestSessionCreated.cc
@@ -28,7 +28,7 @@ TEST_F(ValidationTestSessionCreated, load_session_001)
 TEST_F(ValidationTestSessionCreated, neg_load_session_001)
 {
   ASSERT_EQ(nnfw_load_model_from_file(
-                _session, NNPackages::get().getModelAbsolutePath(NNPackages::DUMMY).c_str()),
+                _session, NNPackages::get().getModelAbsolutePath("nonexisting_directory").c_str()),
             NNFW_STATUS_ERROR);
 }
 

--- a/tests/nnfw_api/src/main.cc
+++ b/tests/nnfw_api/src/main.cc
@@ -17,24 +17,8 @@
 #include <iostream>
 #include <stdexcept>
 #include <string>
-#include <dirent.h>
 #include <gtest/gtest.h>
 #include "NNPackages.h"
-
-/**
- * @brief Function to check if test model directories exist before it actually performs the test
- *
- */
-void checkModels()
-{
-  std::string absolute_path = NNPackages::get().getModelAbsolutePath(NNPackages::ADD);
-  DIR *dir = opendir(absolute_path.c_str());
-  if (!dir)
-  {
-    throw std::runtime_error{"Please install the nnpackge for testing: " + absolute_path};
-  }
-  closedir(dir);
-}
 
 int main(int argc, char **argv)
 {
@@ -43,7 +27,7 @@ int main(int argc, char **argv)
 
   try
   {
-    checkModels();
+    NNPackages::get().checkAll();
   }
   catch (std::runtime_error &e)
   {


### PR DESCRIPTION
Before running the tests, it checks if all required nnpackages are
installed.

- Introduce `NNPackages::checkAll` method
- Remove `DUMMY` nnpackage from the list
    - Introduce `NNPackages::getAbsolutePath` that accepts a string
      argument

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>