### PR TITLE
[nnpkg_run] find boost libraries when BUILD_BOOST is on

### DIFF
--- a/tests/tools/nnpackage_run/CMakeLists.txt
+++ b/tests/tools/nnpackage_run/CMakeLists.txt
@@ -30,7 +30,17 @@ target_include_directories(nnpackage_run PRIVATE ${HDF5_INCLUDE_DIRS})
 target_link_libraries(nnpackage_run onert_core onert tflite_loader)
 target_link_libraries(nnpackage_run tensorflow-lite ${LIB_PTHREAD} dl nnfw_lib_tflite)
 target_link_libraries(nnpackage_run nnfw-dev)
-target_link_libraries(nnpackage_run boost_program_options)
+if(BUILD_BOOST)
+  # We have to use Boost::program_options, instead of boost_program_optinos
+  # Boost::program_options provides the full path for our own built boost.
+  target_link_libraries(nnpackage_run Boost::program_options)
+else()
+  # We cannot use `Boost::program_options` on aarch64
+  # because it uses boost 1.65.1, which requires cmake >= 3.9.3
+  # to identify Boost::program_options imported target correctly,
+  # However, it uses cmake 3.5. (old version).
+  target_link_libraries(nnpackage_run boost_program_options)
+endif()
 target_link_libraries(nnpackage_run ${HDF5_CXX_LIBRARIES})
 target_link_libraries(nnpackage_run nnfw_lib_benchmark)
 


### PR DESCRIPTION
We use our own built boost by enabling `BUILD_BOOST` for android.
This patch makes `nnpkg_run` to support `BUILD_BOOST`.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee sg5.lee@samsung.com