### PR TITLE
[onert/interp] Handle optional input on tensor manager

### DIFF
--- a/runtime/onert/core/src/interp/ExecEnv.h
+++ b/runtime/onert/core/src/interp/ExecEnv.h
@@ -70,10 +70,26 @@ public:
 
   /**
    * @brief     Return tensor pointer in environment
-   * @param[in] index Tensor index
+   * @param[in] index         Tensor index
+   *            can_optional  @c True if tensor can be optional input, otherwise @c false
    * @return    Tensor pointer
    */
-  const ITensor *tensorAt(const ir::OperandIndex index) const { return _tensors.at(index).get(); }
+  const ITensor *tensorAt(const ir::OperandIndex index, bool can_optional = false) const
+  {
+    if (_tensors.find(index) == _tensors.end())
+    {
+      // It may optional input,
+      // otherwise input is not set by runtime user
+      if (can_optional)
+      {
+        return nullptr;
+      }
+
+      throw std::runtime_error{"ExecEnv: Input is not set"};
+    }
+
+    return _tensors.at(index).get();
+  }
 
   /**
    * @brief     Check environment contains tensor

--- a/runtime/onert/core/src/interp/InterpExecutor.cc
+++ b/runtime/onert/core/src/interp/InterpExecutor.cc
@@ -40,11 +40,17 @@ void InterpExecutor::execute(const exec::IODescription &desc)
   {
     ir::IOIndex index{n};
     const auto input_index = _graph.getInputs().at(index);
-    const auto &input = *desc.inputs.at(n);
 
-    auto input_tensor = std::make_shared<ROTensor>(input.info);
+    const auto input = desc.inputs.at(n).get();
+    if (input == nullptr)
+    {
+      // Optional input
+      continue;
+    }
+
+    auto input_tensor = std::make_shared<ROTensor>(input->info);
     input_tensor->setData(std::make_shared<const ir::ExternalData>(
-        reinterpret_cast<const uint8_t *>(input.buffer), input.size));
+        reinterpret_cast<const uint8_t *>(input->buffer), input->size));
     tensor_map[input_index] = input_tensor;
   }
 
@@ -52,11 +58,16 @@ void InterpExecutor::execute(const exec::IODescription &desc)
   {
     ir::IOIndex index{n};
     const auto output_index = _graph.getOutputs().at(index);
-    const auto &output = *desc.outputs.at(n);
+    const auto output = desc.outputs.at(n).get();
+    if (output == nullptr)
+    {
+      // Optional output
+      continue;
+    }
 
-    auto output_tensor = std::make_shared<Tensor>(output.info);
-    output_tensor->setBuffer(
-        std::make_shared<ExternalBuffer>(reinterpret_cast<uint8_t *>(output.buffer), output.size));
+    auto output_tensor = std::make_shared<Tensor>(output->info);
+    output_tensor->setBuffer(std::make_shared<ExternalBuffer>(
+        reinterpret_cast<uint8_t *>(output->buffer), output->size));
     tensor_map[output_index] = output_tensor;
   }
 


### PR DESCRIPTION
If optional input, tensor manager ExecEnv tensorAt return nullptr
Throw exception if general input is not set.

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>