### PR TITLE
[api] Change source_config to use set_config

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -142,7 +142,7 @@ NNFW_STATUS nnfw_session::prepare()
   // TODO : add additional setting routine(executor type, backend)
   // Note that we assume acl_cl backend
 
-  _source->set("DELETE_CACHED_DATA", "1");
+  set_config(onert::util::config::DELETE_CACHED_DATA, "1");
 
   try
   {


### PR DESCRIPTION
Change source_config to use set_config api for
DELETE_CACHED_DATA

ONE-DCO-1.0-Signed-off-by: Yongseop Kim <yons.kim@samsung.com>