### PR TITLE
[onert] Remove unused LoweredGraph

### DIFF
--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -157,8 +157,6 @@ void Compiler::compile(void)
   dot_dumper.dump("before_lower");
 
   // Lower: Assign backend
-  auto lowered_graph = std::make_unique<ir::LoweredGraph>(*_graph, _options);
-
   std::unordered_map<ir::SubgraphIndex, std::unique_ptr<ir::LoweredGraph>> lowered_subgs;
   _graph->subgraphs()->iterate([&](const ir::SubgraphIndex &index, ir::Graph &graph) {
     // Lower: Assign backend


### PR DESCRIPTION
Remove unused LoweredGraph which take unnecessary place.

Fix #235

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>