### PR TITLE
[luci] fix custom op test

### DIFF
--- a/compiler/luci/lang/src/Nodes/CircleCustom.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleCustom.test.cpp
@@ -41,5 +41,5 @@ TEST(CircleCustomTest, invalidIndex_NEG)
 {
   luci::CircleCustom custom_node(2);
 
-  ASSERT_DEATH(custom_node.arg(5), "");
+  EXPECT_ANY_THROW(custom_node.arg(5));
 }


### PR DESCRIPTION
This commit fixes custom op test. It is for catching out of range of vector.

Related : #72 
Signed-off-by: seongwoo <mhs4670go@naver.com>