### PR TITLE
[luci] Remove assert with at

### DIFF
--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleIf.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleIf.h
@@ -48,16 +48,8 @@ public:
   Node *cond(void) const { return at(0)->node(); }
   void cond(Node *node) { at(0)->node(node); }
 
-  Node *input(uint32_t index) const
-  {
-    assert(index < input_count());
-    return at(index + 1)->node();
-  }
-  void input(uint32_t index, Node *node)
-  {
-    assert(index < input_count());
-    at(index + 1)->node(node);
-  }
+  Node *input(uint32_t index) const { return at(index + 1)->node(); }
+  void input(uint32_t index, Node *node) { at(index + 1)->node(node); }
 
 public:
   int32_t then_branch(void) const { return _then_branch; }

--- a/compiler/luci/lang/include/luci/IR/VariadicArityNode.h
+++ b/compiler/luci/lang/include/luci/IR/VariadicArityNode.h
@@ -46,11 +46,7 @@ public:
 public:
   uint32_t arity(void) const final { return _args.size(); }
 
-  loco::Node *arg(uint32_t n) const final
-  {
-    assert(n < _args.size());
-    return _args.at(n)->node();
-  }
+  loco::Node *arg(uint32_t n) const final { return _args.at(n)->node(); }
 
   void drop(void) final
   {
@@ -62,11 +58,7 @@ public:
 
 protected:
   // This API allows inherited classes to access "_args" field.
-  loco::Use *at(uint32_t n) const
-  {
-    assert(n < _args.size());
-    return _args.at(n).get();
-  }
+  loco::Use *at(uint32_t n) const { return _args.at(n).get(); }
 
 private:
   std::vector<std::unique_ptr<loco::Use>> _args;

--- a/compiler/luci/lang/src/Nodes/CircleCustom.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleCustom.test.cpp
@@ -41,12 +41,5 @@ TEST(CircleCustomTest, invalidIndex_NEG)
 {
   luci::CircleCustom custom_node(2);
 
-// TODO Fix this not to use '#ifdef'
-#ifdef NDEBUG
-  // release build will throw
   EXPECT_ANY_THROW(custom_node.arg(5));
-#else
-  // debug build will fail with assert
-  ASSERT_DEBUG_DEATH(custom_node.arg(5), "");
-#endif
 }

--- a/compiler/luci/lang/src/Nodes/CircleIf.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleIf.test.cpp
@@ -51,22 +51,12 @@ TEST(CircleIfTestDeath, invalid_input_get_index_NEG)
 {
   luci::CircleIf if_node(2, 2);
 
-// TODO Fix this not to use '#ifdef'
-#ifdef NDEBUG
   EXPECT_ANY_THROW(if_node.input(100));
-#else
-  ASSERT_DEBUG_DEATH(if_node.input(100), "");
-#endif
 }
 
 TEST(CircleIfTestDeath, invalid_input_set_index_NEG)
 {
   luci::CircleIf if_node(2, 2);
 
-// TODO Fix this not to use '#ifdef'
-#ifdef NDEBUG
   EXPECT_ANY_THROW(if_node.input(100, nullptr));
-#else
-  ASSERT_DEBUG_DEATH(if_node.input(100), "");
-#endif
 }


### PR DESCRIPTION
This will remove assertion test with at() method as it will throw with out of bounds access
- test now needs only check with throw

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>