### PR TITLE
[nnpkg_run] support android by prebuilt hdf5

### DIFF
--- a/Makefile.template
+++ b/Makefile.template
@@ -54,6 +54,11 @@ ifneq ($(EXT_ACL_FOLDER),)
 	OPTIONS+= -DARMCompute_EXTDIR=$(EXT_ACL_FOLDER)
 endif
 
+ifneq ($(EXT_HDF5_DIR),)
+  $(info Hello $(EXT_HDF5_DIR))
+	OPTIONS+= -DEXT_HDF5_DIR=$(EXT_HDF5_DIR)
+endif
+
 ifneq ($(EXTERNAL_VOLUME),)
 	OPTIONS+= -DNNAS_EXTERNALS_DIR=$(EXTERNAL_VOLUME)
 endif

--- a/infra/nnfw/cmake/packages/HDF5Config.cmake
+++ b/infra/nnfw/cmake/packages/HDF5Config.cmake
@@ -1,6 +1,28 @@
+# Don't cache HDF5_*. Otherwise it will use the cached value without searching.
 unset(HDF5_DIR CACHE)
-find_package(HDF5 QUIET)
+unset(HDF5_INCLUDE_DIRS CACHE)
+unset(HDF5_CXX_LIBRARY_hdf5 CACHE)
+unset(HDF5_CXX_LIBRARY_hdf5_cpp CACHE)
 
+# Case 1. external hdf5
+if(DEFINED EXT_HDF5_DIR)
+  find_path(HDF5_INCLUDE_DIRS NAMES H5Cpp.h NO_CMAKE_FIND_ROOT_PATH PATHS "${EXT_HDF5_DIR}/include")
+  find_library(HDF5_CXX_LIBRARY_hdf5 NAMES libhdf5.a PATHS "${EXT_HDF5_DIR}/lib")
+  find_library(HDF5_CXX_LIBRARY_hdf5_cpp NAMES libhdf5_cpp.a PATHS "${EXT_HDF5_DIR}/lib")
+  if (NOT (HDF5_INCLUDE_DIRS AND HDF5_CXX_LIBRARY_hdf5 AND HDF5_CXX_LIBRARY_hdf5_cpp))
+    message(WARNING "Failed to find H5Cpp.h or libhdf5.a or libhdf5_cpp.a")
+    set(HDF5_FOUND FALSE)
+    return()
+  else()
+    # message(FATAL_ERROR "0=${HDF5_INCLUDE_DIRS},1=${HDF5_CXX_LIBRARIES}")
+    set(HDF5_FOUND TRUE)
+    list(APPEND HDF5_CXX_LIBRARIES ${HDF5_CXX_LIBRARY_hdf5_cpp} ${HDF5_CXX_LIBRARY_hdf5})
+    return()
+  endif()
+endif()
+
+# Case 2. search default locations (e.g. system root, ...) for hdf5
+find_package(HDF5 COMPONENTS CXX QUIET)
 if (NOT HDF5_FOUND)
   # Give second chance for some systems where sytem find_package config mode fails
   unset(HDF5_FOUND)
@@ -28,4 +50,4 @@ if (NOT HDF5_FOUND)
 endif()
 
 # Append missing libaec which is required by libsz, which is required by libhdf5
-list(APPEND HDF5_LIBRARIES "aec")
+list(APPEND HDF5_CXX_LIBRARIES "aec")

--- a/tests/tools/nnpackage_run/CMakeLists.txt
+++ b/tests/tools/nnpackage_run/CMakeLists.txt
@@ -6,14 +6,11 @@ if(NOT BUILD_ONERT)
   return()
 endif(NOT BUILD_ONERT)
 
-find_package(HDF5 COMPONENTS CXX QUIET)
+nnfw_find_package(HDF5 COMPONENTS CXX QUIET)
 if(NOT HDF5_FOUND)
-  message(WARNING "HDF5 NOT found. Install libhdf5-dev to build nnpackage_run.")
+  message(WARNING "HDF5 NOT found. Install libhdf5-dev or set EXT_HDF5_DIR to build nnpackage_run.")
   return()
 endif(NOT HDF5_FOUND)
-
-# Append missing libaec, which is required by libsz, which is required by libhdf5.
-list(APPEND HDF5_CXX_LIBRARIES aec)
 
 list(APPEND NNPACKAGE_RUN_SRCS "src/nnpackage_run.cc")
 list(APPEND NNPACKAGE_RUN_SRCS "src/args.cc")


### PR DESCRIPTION
There was no way to run nnpackage_run on android devices.
It enables you to build and run nnpackage_run with prebuilt hdf5 librarary.

nnpackage_run for android is deliverately disabled.
    
To build nnpackage_run on android, you need to
1) specify EXT_HDF5_DIR
2) set BUILD_NNPACKAGE_RUN=ON, DOWNLOAD_BOOST=ON, BUILD_BOOST=ON.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee sg5.lee@samsung.com