### PR TITLE
[onert] Revert class name `DotSubgraphInfo`

### DIFF
--- a/runtime/onert/core/src/dumper/dot/DotBuilder.cc
+++ b/runtime/onert/core/src/dumper/dot/DotBuilder.cc
@@ -35,18 +35,18 @@ void DotBuilder::update(const Node &node_info)
   }
 }
 
-void DotBuilder::addOpSequence(const DotOpSequenceInfo &op_sequence_info)
+void DotBuilder::addOpSequence(const DotSubgraphInfo &subgraph_info)
 {
-  _dot << "op_sequence cluster_" << op_sequence_info.index().value() << " {\n";
-  _dot << "  label=\"" << op_sequence_info.label() << "\";\n";
+  _dot << "subgraph cluster_" << subgraph_info.index().value() << " {\n";
+  _dot << "  label=\"" << subgraph_info.label() << "\";\n";
   _dot << "  style=filled;\n";
   _dot << "  color=lightgrey;\n";
   _dot << "  ";
-  for (auto op : op_sequence_info.operations())
+  for (auto op : subgraph_info.operations())
   {
     _dot << "operation" << op.value() << "; ";
   }
-  for (auto op : op_sequence_info.operands())
+  for (auto op : subgraph_info.operands())
   {
     _dot << "operand" << op.value() << "; ";
   }

--- a/runtime/onert/core/src/dumper/dot/DotBuilder.h
+++ b/runtime/onert/core/src/dumper/dot/DotBuilder.h
@@ -25,7 +25,7 @@
 
 #include "OperationNode.h"
 #include "OperandNode.h"
-#include "DotOpSequenceInfo.h"
+#include "DotSubgraphInfo.h"
 
 using Operation = onert::ir::Operation;
 using Object = onert::ir::Operand;
@@ -44,7 +44,7 @@ public:
 
 public:
   void update(const Node &dotinfo);
-  void addOpSequence(const DotOpSequenceInfo &op_sequence_info);
+  void addOpSequence(const DotSubgraphInfo &subgraph_info);
 
   void writeDot(std::ostream &os);
 

--- a/runtime/onert/core/src/dumper/dot/DotDumper.cc
+++ b/runtime/onert/core/src/dumper/dot/DotDumper.cc
@@ -19,7 +19,7 @@
 
 #include "DotDumper.h"
 #include "DotBuilder.h"
-#include "DotOpSequenceInfo.h"
+#include "DotSubgraphInfo.h"
 #include "ir/OpSequence.h"
 #include "ir/OperationIndexMap.h"
 #include "backend/Backend.h"
@@ -155,10 +155,10 @@ void DotDumper::dump(const std::string &tag)
       auto fillcolor = backend_to_fillcolor(lower_info->backend());
       std::string label =
           std::to_string(index.value()) + " [" + lower_info->backend()->config()->id() + "]";
-      DotOpSequenceInfo op_sequence_info{index, op_seq, shown_operand_set};
-      op_sequence_info.label(label);
-      op_sequence_info.fillcolor(fillcolor);
-      dot_builder.addOpSequence(op_sequence_info);
+      DotSubgraphInfo subgraph_info{index, op_seq, shown_operand_set};
+      subgraph_info.label(label);
+      subgraph_info.fillcolor(fillcolor);
+      dot_builder.addOpSequence(subgraph_info);
 
       // Set fillcolor of all operations in the op_seq
       for (const auto &op : op_seq.operations())

--- a/runtime/onert/core/src/dumper/dot/DotSubgraphInfo.cc
+++ b/runtime/onert/core/src/dumper/dot/DotSubgraphInfo.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "DotOpSequenceInfo.h"
+#include "DotSubgraphInfo.h"
 
 #include <sstream>
 
@@ -25,8 +25,8 @@ namespace dumper
 namespace dot
 {
 
-DotOpSequenceInfo::DotOpSequenceInfo(const ir::OpSequenceIndex &index, const ir::OpSequence &op_seq,
-                                     const util::Set<ir::OperandIndex> &shown_operands)
+DotSubgraphInfo::DotSubgraphInfo(const ir::OpSequenceIndex &index, const ir::OpSequence &op_seq,
+                                 const util::Set<ir::OperandIndex> &shown_operands)
     : _index{index}
 {
   for (const auto &element : op_seq.operations())

--- a/runtime/onert/core/src/dumper/dot/DotSubgraphInfo.h
+++ b/runtime/onert/core/src/dumper/dot/DotSubgraphInfo.h
@@ -30,11 +30,11 @@ namespace dumper
 namespace dot
 {
 
-class DotOpSequenceInfo
+class DotSubgraphInfo
 {
 public:
-  DotOpSequenceInfo(const ir::OpSequenceIndex &index, const ir::OpSequence &op_seq,
-                    const util::Set<ir::OperandIndex> &shown_operands);
+  DotSubgraphInfo(const ir::OpSequenceIndex &index, const ir::OpSequence &op_seq,
+                  const util::Set<ir::OperandIndex> &shown_operands);
 
   ir::OpSequenceIndex index() const { return _index; }
   std::string label() const { return _label; }


### PR DESCRIPTION
Rename `DotOpSequenceInfo` to `DotSubgraphInfo`. This was renamed
accidently. And actually this class really means "Subgraph" in dot
format.

The graph was not shown correctly since `subgraph` keyword had been
substituted with `op_sequence`.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>