### PR TITLE
[circle2circle] Follow GTEST argument order

### DIFF
--- a/compiler/circle2circle/src/Circle2Circle.test.cpp
+++ b/compiler/circle2circle/src/Circle2Circle.test.cpp
@@ -25,5 +25,5 @@ TEST(Circle2CircleTest, NoArg_NEG)
 
   ::testing::internal::CaptureStdout();
   int result = entry(1, argv.argv());
-  ASSERT_EQ(result, 255);
+  ASSERT_EQ(255, result);
 }


### PR DESCRIPTION
This commit makes circle2circle follow GTEST argument order

Related : #256 
Signed-off-by: seongwoo <mhs4670go@naver.com>