### PR TITLE
[onert] Introduce option for ruy threads

### DIFF
--- a/compute/cker/include/cker/ruy/RuySupport.h
+++ b/compute/cker/include/cker/ruy/RuySupport.h
@@ -18,6 +18,7 @@
 #ifndef __NNFW_CKER_RUY_RUY_SUPPORT_H__
 #define __NNFW_CKER_RUY_RUY_SUPPORT_H__
 
+#include <util/ConfigSource.h>
 #include <ruy/context.h>
 #include "cker/Types.h"
 
@@ -38,7 +39,7 @@ struct RuyContext
 public:
   RuyContext() : ruy_context_(new ruy::Context)
   {
-    SetMaxNumThreads(kDefaultNumThreadpoolThreads);
+    SetMaxNumThreads(onert::util::getConfigInt(onert::util::config::RUY_THREADS));
 #ifdef USE_RUY_GEMV
     ruy_context_->cache_policy = ruy::kCacheLHSOnNarrowMul;
 #endif

--- a/runtime/onert/core/include/util/Config.lst
+++ b/runtime/onert/core/include/util/Config.lst
@@ -35,6 +35,7 @@ CONFIG(OP_SEQ_MAX_NODE         , int          , "0")
 CONFIG(TRACE_FILEPATH          , std::string  , "")
 CONFIG(DELETE_CACHED_DATA      , bool         , "0")
 CONFIG(FP16_ENABLE             , bool         , "0")
+CONFIG(RUY_THREADS             , int          , "-1")
 
 // Auto-generate all operations
 


### PR DESCRIPTION
This commit introduces option to set number of ruy threads
- Use 4 ruy threads by default

ONE-DCO-1.0-Signed-off-by: JiHwan Yeo <jihwan.yeo@samsung.com>