### PR TITLE
[runtime] Fixing unittest.sh to get new nnpackage test files

### DIFF
--- a/tests/scripts/unittest.sh
+++ b/tests/scripts/unittest.sh
@@ -75,7 +75,7 @@ for TEST_BIN in `find $UNITTEST_TEST_DIR -maxdepth 1 -type f -executable`; do
     TEMP_UNITTEST_RESULT=0
 
     # This test requires test model installation
-    if [ "$(basename $TEST_BIN)" == "nnfw_api_gtest" ] && [ ! -d "${TEST_BIN}_models" ]; then
+    if [ "$(basename $TEST_BIN)" == "nnfw_api_gtest" ]; then
         ONEAPI_TEST_MODEL_INSTALLER=$(dirname $BASH_SOURCE)/oneapi_test/install_oneapi_test_nnpackages.sh
         $ONEAPI_TEST_MODEL_INSTALLER --install-dir ${TEST_BIN}_models
         if [[ $? -ne 0 ]]; then


### PR DESCRIPTION
Current code skips downloading a new test nnpackage files.
This fixes the bug.

The reason is as follows:

1. When a new test nnpackage, e.g., `abc.zip` is added,
`{TEST_BIN)_models/abc` is created and the nnpackage is downloaded.

2. Next time, another new test nnpackage, e.g., `xyz.zip` is added,
`{TEST_BIN)_models/xyz` is created and the nnpackage is downloaded.
However current code does not download `xyz.zip` since `{TEST_BIN)_models` directory already exists.

ONE-DCO-1.0-Signed-off-by: hyunsik-yoon <hyunsik.yoon.1024@gmail.com>