### PR TITLE
[runtime] Make Concat throw exception

### DIFF
--- a/runtime/onert/backend/cpu/kernel/ConcatLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/ConcatLayer.cc
@@ -126,6 +126,8 @@ void ConcatLayer::run()
   {
     concatenationQuant8();
   }
+  else
+    throw std::runtime_error("ConcatLayer: Not supported datatype");
 }
 
 } // namespace kernel


### PR DESCRIPTION
This makes `concat` throw exception when output is not supported datatype.

ONE-DCO-1.0-Signed-off-by: hyunsik-yoon <hyunsik.yoon.1024@gmail.com>