### PR TITLE
[onert/test] Fix prepared session test

### DIFF
--- a/tests/nnfw_api/src/ValidationTestAddSessionPrepared.cc
+++ b/tests/nnfw_api/src/ValidationTestAddSessionPrepared.cc
@@ -21,5 +21,25 @@ using ValidationTestAddSessionPrepared = ValidationTestSessionPrepared<NNPackage
 
 TEST_F(ValidationTestAddSessionPrepared, run_001)
 {
+  nnfw_tensorinfo ti_input;
+  std::vector<float> input_buffer;
+  ASSERT_EQ(nnfw_input_tensorinfo(_session, 0, &ti_input), NNFW_STATUS_NO_ERROR);
+  uint64_t input_elements = num_elems(&ti_input);
+  input_buffer.resize(input_elements);
+  ASSERT_EQ(nnfw_set_input(_session, 0, ti_input.dtype, input_buffer.data(),
+                           sizeof(float) * input_elements),
+            NNFW_STATUS_NO_ERROR);
+
+  nnfw_tensorinfo ti_output;
+  std::vector<float> output_buffer;
+  ASSERT_EQ(nnfw_output_tensorinfo(_session, 0, &ti_output), NNFW_STATUS_NO_ERROR);
+  uint64_t output_elements = num_elems(&ti_output);
+  output_buffer.resize(output_elements);
+  ASSERT_EQ(nnfw_set_output(_session, 0, ti_output.dtype, output_buffer.data(),
+                            sizeof(float) * output_elements),
+            NNFW_STATUS_NO_ERROR);
+
   ASSERT_EQ(nnfw_run(_session), NNFW_STATUS_NO_ERROR);
 }
+
+// TODO Validation check when "nnfw_run" is called without input & output tensor setting


### PR DESCRIPTION
Set input & output buffer before calling nnfw_run

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>