### PR TITLE
[onert] introduce ArgMax in base_loader

### DIFF
--- a/runtime/onert/backend/cpu/ShapeFixer.cc
+++ b/runtime/onert/backend/cpu/ShapeFixer.cc
@@ -181,6 +181,8 @@ void ShapeFixer::visit(const ir::operation::ReduceProd &) { /* DO NOTHING */}
 
 void ShapeFixer::visit(const ir::operation::Neg &) { /* DO NOTHING */}
 
+void ShapeFixer::visit(const ir::operation::ArgMax &) { /* DO NOTHING */}
+
 } // namespace cpu
 } // namespace backend
 } // namespace onert

--- a/runtime/onert/backend/cpu/ShapeFixer.h
+++ b/runtime/onert/backend/cpu/ShapeFixer.h
@@ -76,6 +76,7 @@ public:
   void visit(const ir::operation::Shape &) override;
   void visit(const ir::operation::ReduceProd &) override;
   void visit(const ir::operation::Neg &) override;
+  void visit(const ir::operation::ArgMax &) override;
 
 private:
   const ir::Operands &_ctx;

--- a/runtime/onert/core/include/ir/operation/ArgMax.h
+++ b/runtime/onert/core/include/ir/operation/ArgMax.h
@@ -38,6 +38,7 @@ public:
   {
     int axis;
     int rank;
+    DataType output_type;
   };
 
 public:


### PR DESCRIPTION
It introduces ArgMax in base_loader.
  
For test, I filled ShapeFixer (which has empty body) also in this PR.
ShapeFixing is done before model loading.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee sg5.lee@samsung.com