### PR TITLE
[luci] Introduce shape property to CircleNode

### DIFF
--- a/compiler/luci/import/src/CircleReader.cpp
+++ b/compiler/luci/import/src/CircleReader.cpp
@@ -163,6 +163,14 @@ void copy_tensor_attributes(const circle::TensorT &tensor, CircleNode *node)
 {
   node->name(tensor_name(tensor));
   node->dtype(luci_datatype(tensor.type));
+
+  std::vector<int32_t> dims = tensor.shape; // in NHWC
+  node->rank(dims.size());
+  for (uint32_t r = 0; r < dims.size(); ++r)
+  {
+    node->dim(r) = loco::Dimension(dims[r]);
+  }
+
   const auto *quantization = tensor.quantization.get();
   if (quantization != nullptr)
   {

--- a/compiler/luci/import/src/Nodes/CircleConst.cpp
+++ b/compiler/luci/import/src/Nodes/CircleConst.cpp
@@ -61,13 +61,11 @@ CircleConst *create_circleconst(GraphBuilderContext *context, int32_t tensor_ind
 
   INFO(l) << "[luci] NodeFinder const_node(" << tensor_index << ") -> " << const_node << std::endl;
 
-  // (2) set shape to CicleConst
+  // (2) get number of elements
   std::vector<int32_t> const_dims = const_tensor.shape; // in NHWC
-  const_node->rank(const_dims.size());
   uint32_t num_elements = 1;
   for (uint32_t r = 0; r < const_dims.size(); ++r)
   {
-    const_node->dim(r) = loco::Dimension(const_dims[r]);
     num_elements = num_elements * const_dims[r];
   }
 

--- a/compiler/luci/lang/include/luci/IR/CircleNodeDecl.h
+++ b/compiler/luci/lang/include/luci/IR/CircleNodeDecl.h
@@ -32,7 +32,9 @@ namespace luci
 
 using NodeName = std::string;
 
-struct CircleNode : public loco::Node, public loco::NodeMixin<loco::NodeTrait::DataType>
+struct CircleNode : public loco::Node,
+                    public loco::NodeMixin<loco::NodeTrait::DataType>,
+                    public loco::NodeMixin<loco::NodeTrait::TensorShape>
 {
   virtual ~CircleNode() = default;
 

--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleConst.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleConst.h
@@ -32,8 +32,7 @@ namespace luci
  * @brief Class to build tensor data
  * @note  This will not be exported as a specific op
  */
-class CircleConst final : public FixedArityNode<0, CircleNodeImpl<CircleOpcode::CONST>>,
-                          public loco::NodeMixin<loco::NodeTrait::TensorShape>
+class CircleConst final : public FixedArityNode<0, CircleNodeImpl<CircleOpcode::CONST>>
 {
 public:
   CircleConst() = default;

--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleInput.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleInput.h
@@ -33,8 +33,7 @@ namespace luci
  * @brief CircleNode used for Input of the Graph
  * @note  This will not be exported as a specific op
  */
-class CircleInput final : public FixedArityNode<0, CircleNodeImpl<CircleOpcode::CIRCLEINPUT>>,
-                          public loco::NodeMixin<loco::NodeTrait::TensorShape>
+class CircleInput final : public FixedArityNode<0, CircleNodeImpl<CircleOpcode::CIRCLEINPUT>>
 {
 public:
   CircleInput() = default;


### PR DESCRIPTION
This will introduce shape property to CircleNode
- nodes that already had is changed accordingly

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>