### PR TITLE
[oneapi] Unref Graph after compilation

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.h
+++ b/runtime/onert/api/src/nnfw_api_internal.h
@@ -81,7 +81,7 @@ public:
   NNFW_STATUS set_config(const char *key, const char *value);
 
 private:
-  std::shared_ptr<onert::ir::Graph> primary_subgraph();
+  onert::ir::Graph *primary_subgraph();
 
 private:
   std::shared_ptr<onert::ir::Subgraphs> _subgraphs;

--- a/runtime/onert/core/include/ir/Subgraphs.h
+++ b/runtime/onert/core/include/ir/Subgraphs.h
@@ -122,6 +122,13 @@ public:
    */
   size_t count() { return _subgraphs.size(); }
 
+  /**
+   * @brief Return the primary subgraph
+   *
+   * @return std::shared_ptr<Graph> Primary sugraph
+   */
+  std::shared_ptr<Graph> primary() const { return _subgraphs.at(SubgraphIndex{0}); }
+
 private:
   std::unordered_map<SubgraphIndex, std::shared_ptr<Graph>> _subgraphs;
 };

--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -196,7 +196,11 @@ void Compiler::compile(void)
     {
       CachedDataDeleter(graph.operands()).run();
     }
+
+    graph.setSubgraphs(nullptr);
   });
+
+  _subgraphs.reset();
 
   /*************************************************************
    *  Backend independent analysis & optimization phase finished


### PR DESCRIPTION
Unref Graph after compilation since it is no longer used after
compilation.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>