### PR TITLE
[luci] Introduce TypeBridge in export

### DIFF
--- a/compiler/luci/export/src/CircleExporterImpl.cpp
+++ b/compiler/luci/export/src/CircleExporterImpl.cpp
@@ -16,6 +16,7 @@
 
 #include "CircleExporterImpl.h"
 #include "Optimize.h"
+#include "TypeBridge.h"
 #include "CircleTensorExporter.h"
 #include "CircleOperationExporter.h"
 #include "CircleExporterUtils.h"
@@ -146,6 +147,9 @@ void CircleExporterImpl::exportGraph(loco::Graph *graph)
   // do graph optimization
   optimize(graph);
 
+  // copy shape/dtype inference data to CircleNode
+  copy_shape_dtype(graph);
+
   _builder.Clear();
 
   SerializedModelData md;
@@ -210,6 +214,9 @@ void CircleExporterImpl::exportModule(Module *module)
     auto graph = module->graph(g);
 
     optimize(graph);
+
+    // copy shape/dtype inference data to CircleNode
+    copy_shape_dtype(graph);
 
     SerializedGraphData gd;
 

--- a/compiler/luci/export/src/CircleTensorExporter.cpp
+++ b/compiler/luci/export/src/CircleTensorExporter.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "CircleTensorExporter.h"
+#include "TypeBridge.h"
 
 #include <luci/IR/CircleNodes.h>
 #include <luci/IR/CircleNodeVisitor.h>
@@ -111,8 +112,8 @@ void allocateCircleTensor(CircleNode *node, CircleTensorContext &ctx)
   CircleTensoInfo tensor_info;
 
   tensor_info.name(tensor_name);
-  tensor_info.dtype(TypeInference::get(node));
-  tensor_info.shape(ShapeInference::get(node));
+  tensor_info.dtype(to_circle_tensortype(luci::node_dtype(node)));
+  tensor_info.shape(to_shape_description(luci::node_shape(node)));
 
   tensor_info.content(dynamic_cast<luci::CircleConst *>(node));
   tensor_info.quantparam(node->quantparam());

--- a/compiler/luci/export/src/TypeBridge.cpp
+++ b/compiler/luci/export/src/TypeBridge.cpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "TypeBridge.h"
+
+#include "CircleExporterUtils.h"
+
+#include <luci/IR/CircleNodes.h>
+#include <luci/IR/CircleNodeVisitor.h>
+#include <luci/Service/CircleTypeInference.h>
+#include <luci/Service/CircleShapeInference.h>
+
+#include <loco/Service/TypeInference.h>
+#include <loco/Service/ShapeInference.h>
+
+namespace
+{
+
+/**
+ * @brief CopySelector will return condition of copy shape/type inference to node
+ */
+struct CopySelector final : public luci::CircleNodeVisitor<bool>
+{
+  // return false(don't copy) for nodes that provides shape/type from nature
+  bool visit(const luci::CircleInput *) final { return false; }
+  bool visit(const luci::CircleConst *) final { return false; }
+
+  // default is copy attributes
+  bool visit(const luci::CircleNode *) { return true; }
+};
+
+} // namespace
+
+namespace luci
+{
+
+loco::TensorShape node_shape(CircleNode *node)
+{
+  loco::TensorShape shape;
+
+  shape.rank(node->rank());
+  for (uint32_t r = 0; r < node->rank(); ++r)
+  {
+    shape.dim(r) = loco::Dimension(node->dim(r).value());
+  }
+  return shape;
+}
+
+loco::DataType node_dtype(CircleNode *node) { return node->dtype(); }
+
+void copy_shape_dtype(loco::Graph *graph)
+{
+  /**
+   * @note We will iterate all the nodes in the graph to include dangle nodes
+   */
+  auto nodes = graph->nodes();
+  for (uint32_t n = 0; n < nodes->size(); ++n)
+  {
+    auto node = dynamic_cast<luci::CircleNode *>(nodes->at(n));
+    assert(node != nullptr);
+
+    CopySelector cs;
+    if (node->accept(&cs))
+    {
+      assert(loco::shape_known(node));
+      assert(loco::dtype_known(node));
+
+      node->dtype(loco::dtype_get(node));
+
+      auto shape = loco::shape_get(node).as<loco::TensorShape>();
+      node->rank(shape.rank());
+      for (uint32_t r = 0; r < shape.rank(); ++r)
+      {
+        node->dim(r) = loco::Dimension(shape.dim(r).value());
+      }
+    }
+  }
+}
+
+} // namespace luci

--- a/compiler/luci/export/src/TypeBridge.h
+++ b/compiler/luci/export/src/TypeBridge.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __TYPE_BRIDGE_H__
+#define __TYPE_BRIDGE_H__
+
+#include <luci/IR/CircleNode.h>
+
+#include <loco.h>
+
+namespace luci
+{
+
+/**
+ * @brief  node_shape() will return loco::TensorShape of CircleNode
+ */
+loco::TensorShape node_shape(CircleNode *node);
+
+/**
+ * @brief  node_dtype() will return loco::DataType of CircleNode
+ */
+loco::DataType node_dtype(CircleNode *node);
+
+/**
+ * @brief copy_shape_dtype() will copy shape and dtype inference data to CircleNode
+ */
+void copy_shape_dtype(loco::Graph *graph);
+
+} // namespace luci
+
+#endif // __TYPE_BRIDGE_H__


### PR DESCRIPTION
This will introduce TypeBridge in export to use CircleNode properties for shape and dtype
- inference shape/dtype values will be coped to CircleNode

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>