### PR TITLE
[luci] Remove empty dialect test

### DIFF
--- a/compiler/luci/lang/src/CircleDialect.test.cpp
+++ b/compiler/luci/lang/src/CircleDialect.test.cpp
@@ -27,8 +27,3 @@ TEST(CircleDialectTest, get_P)
   // The return value SHOULD be stable across multiple invocations
   ASSERT_EQ(luci::CircleDialect::get(), d);
 }
-
-TEST(CircleDialectTest, get_N)
-{
-  // TBD
-}


### PR DESCRIPTION
This will remove not implemented negative dialect test placeholder

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>