### PR TITLE
[luci] Correct a typo

### DIFF
--- a/compiler/luci/export/src/SerializedData.h
+++ b/compiler/luci/export/src/SerializedData.h
@@ -57,7 +57,7 @@ struct SubGraphContext
   std::vector<int32_t> _inputs;
   /// @brief SubGraph output tensor id
   std::vector<int32_t> _outputs;
-  /// @DataFormat for SubGraph
+  /// @brief DataFormat for SubGraph
   circle::DataFormat _data_format{circle::DataFormat::DataFormat_CHANNELS_LAST};
 };
 


### PR DESCRIPTION
This commit corrects a typo in luci

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>