### PR TITLE
[luci] rename function validate_shape_dtype

### DIFF
--- a/compiler/luci/service/src/Validate.cpp
+++ b/compiler/luci/service/src/Validate.cpp
@@ -46,7 +46,7 @@ luci::CircleOutput *find_node(std::vector<loco::Node *> nodes, loco::GraphOutput
   return nullptr;
 }
 
-bool validate_shape_type(loco::Graph *g)
+bool validate_shape_dtype(loco::Graph *g)
 {
   LOGGER(l);
 
@@ -98,7 +98,7 @@ bool validate(loco::Graph *g)
   if (!loco::valid(g))
     return false;
 
-  if (!validate_shape_type(g))
+  if (!validate_shape_dtype(g))
     return false;
 
   // TODO add more validation


### PR DESCRIPTION
This will rename function to validate_shape_dtype to reflect it's a dtype

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>