### PR TITLE
[onert] Introduce ruy profiling on nnpackage_run

### DIFF
--- a/infra/nnfw/cmake/CfgOptionFlags.cmake
+++ b/infra/nnfw/cmake/CfgOptionFlags.cmake
@@ -74,6 +74,7 @@ option(BUILD_TENSORFLOW_LITE "Build TensorFlow Lite from the downloaded source" 
 option(BUILD_GTEST "Download and build Google Test" ON)
 option(BUILD_ARMCOMPUTE "Build ARM Compute from the downloaded source" ON)
 option(BUILD_RUY "Build ruy library from the downloaded source" ON)
+option(PROFILE_RUY "Enable ruy library profiling" OFF)
 
 #
 ## Default sample build configuration

--- a/infra/nnfw/cmake/packages/Ruy/CMakeLists.txt
+++ b/infra/nnfw/cmake/packages/Ruy/CMakeLists.txt
@@ -15,9 +15,18 @@ list(REMOVE_ITEM RUY_SRCS "${RUY_BASE}/example_advanced.cc")
 list(REMOVE_ITEM RUY_SRCS "${RUY_BASE}/tune_tool.cc")
 list(REMOVE_ITEM RUY_SRCS "${RUY_BASE}/pmu.cc")
 
+if(PROFILE_RUY)
+  list(APPEND RUY_SRCS "${RUY_BASE}/profiler/profiler.cc")
+  list(APPEND RUY_SRCS "${RUY_BASE}/profiler/treeview.cc")
+endif(PROFILE_RUY)
+
 list(APPEND RUY_INCLUDES "${RuySource_DIR}")
 
 add_library(ruy STATIC ${RUY_SRCS})
 target_include_directories(ruy SYSTEM PUBLIC ${RUY_INCLUDES})
 target_compile_options(ruy PRIVATE -O3)
 set_property(TARGET ruy PROPERTY POSITION_INDEPENDENT_CODE ON)
+
+if(PROFILE_RUY)
+  target_compile_definitions(ruy PUBLIC RUY_PROFILER)
+endif(PROFILE_RUY)

--- a/tests/tools/nnpackage_run/CMakeLists.txt
+++ b/tests/tools/nnpackage_run/CMakeLists.txt
@@ -40,5 +40,8 @@ else()
 endif()
 target_link_libraries(nnpackage_run ${HDF5_CXX_LIBRARIES})
 target_link_libraries(nnpackage_run nnfw_lib_benchmark)
+if(PROFILE_RUY)
+  target_link_libraries(nnpackage_run ruy)
+endif(PROFILE_RUY)
 
 install(TARGETS nnpackage_run DESTINATION bin)

--- a/tests/tools/nnpackage_run/src/nnpackage_run.cc
+++ b/tests/tools/nnpackage_run/src/nnpackage_run.cc
@@ -22,6 +22,9 @@
 #include "nnfw.h"
 #include "nnfw_util.h"
 #include "nnfw_debug.h"
+#ifdef RUY_PROFILER
+#include "ruy/profiler/profiler.h"
+#endif
 
 #include <cassert>
 #include <chrono>
@@ -78,6 +81,11 @@ int main(const int argc, char **argv)
               << ((version & 0x0000FF00) >> 8) << "." << (version & 0xFF) << ")" << std::endl;
     exit(0);
   }
+
+#ifdef RUY_PROFILER
+  std::unique_ptr<ruy::profiler::ScopeProfile> ruy_profile_{nullptr};
+  ruy_profile_.reset(new ruy::profiler::ScopeProfile);
+#endif
 
   std::unique_ptr<benchmark::MemoryPoller> mp{nullptr};
   if (args.getMemoryPoll())
@@ -254,6 +262,10 @@ int main(const int argc, char **argv)
   // dump output tensors
   if (!args.getDumpFilename().empty())
     H5Formatter(session).dumpOutputs(args.getDumpFilename(), outputs);
+
+#ifdef RUY_PROFILER
+  ruy_profile_ = nullptr;
+#endif
 
   NNPR_ENSURE_STATUS(nnfw_close_session(session));
 


### PR DESCRIPTION
- This commit introduces ruy profiler on nnpackage_run
- Ruy profiler is disabled on default built
  - Set `PROFILE_RUY` to ON if you want to enable ruy profiler

ONE-DCO-1.0-Signed-off-by: JiHwan Yeo <jihwan.yeo@samsung.com>