### PR TITLE
[luci/export] Allocate tensors for dangling inputs

### DIFF
--- a/compiler/luci/export/src/CircleExporterUtils.cpp
+++ b/compiler/luci/export/src/CircleExporterUtils.cpp
@@ -166,4 +166,9 @@ CircleTensorIndex get_tensor_index(loco::Node *node)
   return node->annot<CircleTensorIndexAnnotation>()->index();
 }
 
+bool has_tensor_index(loco::Node *node)
+{
+  return node->annot<CircleTensorIndexAnnotation>() != nullptr;
+}
+
 } // namespace luci

--- a/compiler/luci/export/src/CircleExporterUtils.h
+++ b/compiler/luci/export/src/CircleExporterUtils.h
@@ -45,6 +45,7 @@ using CircleTensorIndex = int32_t;
 
 void set_tensor_index(loco::Node *node, const CircleTensorIndex &tensor_id);
 CircleTensorIndex get_tensor_index(loco::Node *node);
+bool has_tensor_index(loco::Node *node);
 
 } // namespace luci
 

--- a/compiler/luci/export/src/CircleTensorExporter.cpp
+++ b/compiler/luci/export/src/CircleTensorExporter.cpp
@@ -256,6 +256,16 @@ void exportOpDefinedTensors(loco::Graph *g, FlatBufferBuilder &builder, Serializ
     allocateCircleTensor(circle_node, tensor_ctx);
   }
 
+  // Allocate tensors for dangling input nodes
+  for (auto node : loco::input_nodes(g))
+  {
+    if (!has_tensor_index(node))
+    {
+      CircleNode *circle_node = dynamic_cast<luci::CircleNode *>(node);
+      allocateCircleTensor(circle_node, tensor_ctx);
+    }
+  }
+
   for (const auto &tensor_info : tensor_ctx)
   {
     exportOpDefinedTensor(tensor_info, builder, md, gd);


### PR DESCRIPTION
This allocates tensors for dangling inputs

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: #263