### PR TITLE
[runtime] backend and executor checker

### DIFF
--- a/runtime/onert/api/CMakeLists.txt
+++ b/runtime/onert/api/CMakeLists.txt
@@ -9,7 +9,7 @@ add_library(${ONERT_DEV} SHARED ${API_SRC})
 set(NNFW_API_HEADERS include/nnfw.h include/nnfw_dev.h)
 
 target_link_libraries(${ONERT_DEV} PUBLIC nnfw-nnapi-header)
-target_link_libraries(${ONERT_DEV} PRIVATE onert_core)
+target_link_libraries(${ONERT_DEV} PUBLIC onert_core)
 target_link_libraries(${ONERT_DEV} PRIVATE jsoncpp tflite_loader circle_loader ${LIB_PTHREAD})
 target_link_libraries(${ONERT_DEV} PRIVATE nnfw_common)
 target_link_libraries(${ONERT_DEV} PRIVATE nnfw_coverage)

--- a/runtime/onert/api/include/nnfw_debug.h
+++ b/runtime/onert/api/include/nnfw_debug.h
@@ -19,23 +19,10 @@
 
 #include "nnfw.h"
 
-/**
- * @brief Extension of NNFW_INFO_ID for API in nnfw_debug.h
- */
-typedef enum {
-
-  /* Experimental. Subject to be changed without notice. */
-  NNFW_INFO_BACKENDS,
-
-  /* Experimental. Subject to be changed without notice. */
-  NNFW_INFO_EXECUTOR,
-
-} NNFW_INFO_ID_EX;
-
 NNFW_STATUS nnfw_create_debug_session(nnfw_session **session);
 
 NNFW_STATUS nnfw_set_config(nnfw_session *session, const char *key, const char *value);
 
-NNFW_STATUS nnfw_query_info_str(nnfw_session *session, NNFW_INFO_ID_EX id, char *value);
+NNFW_STATUS nnfw_get_config(nnfw_session *session, const char *key, char *value, size_t value_size);
 
 #endif // __NNFW_DEBUG_H__

--- a/runtime/onert/api/src/nnfw_api_internal.h
+++ b/runtime/onert/api/src/nnfw_api_internal.h
@@ -79,7 +79,7 @@ public:
   NNFW_STATUS set_op_backend(const char *op, const char *backend);
 
   NNFW_STATUS set_config(const char *key, const char *value);
-  NNFW_STATUS get_config_str(const char *key, char *value);
+  NNFW_STATUS get_config(const char *key, char *value, size_t value_size);
 
 private:
   std::shared_ptr<onert::ir::Graph> primary_subgraph();

--- a/runtime/onert/api/src/nnfw_debug.cc
+++ b/runtime/onert/api/src/nnfw_debug.cc
@@ -30,26 +30,7 @@ NNFW_STATUS nnfw_set_config(nnfw_session *session, const char *key, const char *
   return session->set_config(key, value);
 }
 
-NNFW_STATUS nnfw_query_info_str(nnfw_session *session, NNFW_INFO_ID_EX id, char *value)
+NNFW_STATUS nnfw_get_config(nnfw_session *session, const char *key, char *value, size_t value_size)
 {
-  (void)session;
-  switch (id)
-  {
-    case NNFW_INFO_BACKENDS:
-      if (value)
-      {
-        return session->get_config_str(onert::util::config::BACKENDS, value);
-      }
-      break;
-    case NNFW_INFO_EXECUTOR:
-      if (value)
-      {
-        return session->get_config_str(onert::util::config::EXECUTOR, value);
-      }
-      break;
-    default:
-      return NNFW_STATUS_ERROR;
-  }
-  // It should not be reached.
-  return NNFW_STATUS_ERROR;
+  return session->get_config(key, value, value_size);
 }

--- a/tests/nnfw_api/src/ModelTestHelper.h
+++ b/tests/nnfw_api/src/ModelTestHelper.h
@@ -18,31 +18,36 @@
 #define __NNFW_API_MODEL_TEST_HELPER_H__
 
 #include <nnfw_debug.h>
+#include <util/ConfigSource.h>
+#include <misc/string_helpers.h>
 
 #include <cstring>
 #include <stdexcept>
 
 // This should be called after _compiler is created
-static bool only_for_cpu_backend(nnfw_session *session)
+static bool onlyForCpuBackend(nnfw_session *session)
 {
   char backends[128];
-  NNFW_STATUS res = nnfw_query_info_str(session, NNFW_INFO_BACKENDS, backends);
+  NNFW_STATUS res =
+      nnfw_get_config(session, onert::util::config::BACKENDS, backends, sizeof(backends));
   if (res == NNFW_STATUS_ERROR)
     throw std::runtime_error("error while calling nnfw_query_info_str() to get backends");
 
+  auto backend_list = nnfw::misc::split(std::string(backends), ';');
   // first backend should be "cpu"
-  return (strcmp(backends, "cpu") == 0 || strstr(backends, "cpu;") == backends);
+  return (backend_list.size() > 0 && backend_list.at(0) == "cpu");
 }
 
 // This should be called after _compiler is created
-static bool only_for_LinearExecutor(nnfw_session *session)
+static bool onlyForLinearExecutor(nnfw_session *session)
 {
-  char backends[128];
-  NNFW_STATUS res = nnfw_query_info_str(session, NNFW_INFO_EXECUTOR, backends);
+  char executor[128];
+  NNFW_STATUS res =
+      nnfw_get_config(session, onert::util::config::EXECUTOR, executor, sizeof(executor));
   if (res == NNFW_STATUS_ERROR)
     throw std::runtime_error("error while calling nnfw_query_info_str() to get executor");
 
-  return (strcmp(backends, "Linear") == 0);
+  return (strcmp(executor, "Linear") == 0);
 }
 
 #endif // __NNFW_API_MODEL_TEST_HELPER_H__


### PR DESCRIPTION
This adds two method if backend is `cpu` and executor is `Linear`.

This is required when testing dynamic tensors, which is being developed currently for cpu and linear executor only. If the test is run for, e.g., `acl_neon`, or.. `DataFlow`, test will not run.

Please refer to #442 for usage.

ONE-DCO-1.0-Signed-off-by: hyunsik-yoon <hyunsik.yoon.1024@gmail.com>