### PR TITLE
[runtime] remove dynamic tensor check in acl backend

### DIFF
--- a/runtime/onert/backend/acl_cl/KernelGenerator.cc
+++ b/runtime/onert/backend/acl_cl/KernelGenerator.cc
@@ -807,19 +807,9 @@ void KernelGenerator::visit(const ir::operation::ExpandDims &node)
 {
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(ir::operation::ExpandDims::Input::INPUT)};
-  const auto axis_index{node.getInputs().at(ir::operation::ExpandDims::Input::AXIS)};
 
   auto output_alloc = _tensor_builder->at(output_index).get();
   auto input_alloc = _tensor_builder->at(input_index).get();
-  auto axis_alloc = _tensor_builder->at(axis_index).get();
-
-  if (output_alloc->is_dynamic())
-  {
-    // TODO Support dynamic tensor
-    UNUSED_RELEASE(axis_index);
-    UNUSED_RELEASE(axis_alloc);
-    throw std::runtime_error("acl_cl backend does not support ExpandDims op with dynamic tensor");
-  }
 
   auto fn = std::make_unique<::arm_compute::CLReshapeLayer>();
 

--- a/runtime/onert/backend/acl_neon/KernelGenerator.cc
+++ b/runtime/onert/backend/acl_neon/KernelGenerator.cc
@@ -1950,19 +1950,9 @@ void KernelGenerator::visit(const ir::operation::ExpandDims &node)
 {
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(ir::operation::ExpandDims::Input::INPUT)};
-  const auto axis_index{node.getInputs().at(ir::operation::ExpandDims::Input::AXIS)};
 
   auto output_alloc = _tensor_builder->at(output_index).get();
   auto input_alloc = _tensor_builder->at(input_index).get();
-  auto axis_alloc = _tensor_builder->at(axis_index).get();
-
-  if (output_alloc->is_dynamic())
-  {
-    // TODO Support dynamic tensor
-    UNUSED_RELEASE(axis_index);
-    UNUSED_RELEASE(axis_alloc);
-    throw std::runtime_error("acl_neon backend does not support ExpandDims op with dynamic tensor");
-  }
 
   auto fn = std::make_unique<::arm_compute::NEReshapeLayer>();
 

--- a/runtime/onert/core/include/backend/ITensor.h
+++ b/runtime/onert/core/include/backend/ITensor.h
@@ -51,7 +51,7 @@ public:
    *        the outpus shape cannot be known and the output shape is calculated during
    *        kernel execution-time.
    */
-  virtual bool is_dynamic() const { return false; /* default */ }
+  virtual bool is_dynamic() const { throw std::runtime_error("not yet implemented"); }
 };
 
 } // namespace backend


### PR DESCRIPTION
This removes dynamic tensor check in acl backend.

`isDynamic()` is to check if tensor is dynamic or not _when a backend supports dynamic tensor_.

_acl_ does not currently know what dynamic tensor is, 
so even calling `isDynamic()` won't be allowed.

Part of #56

ONE-DCO-1.0-Signed-off-by: hyunsik-yoon <hyunsik.yoon.1024@gmail.com>
