### PR TITLE
[runtime] Remove consturctor of operandInfo with implicit param

### DIFF
--- a/runtime/onert/backend/acl_common/AclTensorBuilder.h
+++ b/runtime/onert/backend/acl_common/AclTensorBuilder.h
@@ -195,7 +195,7 @@ void AclTensorBuilder<T_ITensor, T_Tensor, T_SubTensor>::registerTensorInfo(
       offset = {offset[0], offset[2], offset[3], offset[1]};
     }
     auto new_shape = permuteShape(shape, frontend_layout, backend_layout);
-    ir::OperandInfo oi{new_shape, obj.typeInfo()};
+    auto oi = ir::OperandInfo::createStaticInfo(new_shape, obj.typeInfo());
     _tensor_info_map.emplace(ind, oi);
 
     _apply_dim_correction_map.emplace(ind, true);

--- a/runtime/onert/core/include/backend/ITensorRegister.h
+++ b/runtime/onert/core/include/backend/ITensorRegister.h
@@ -73,7 +73,7 @@ protected:
     const auto frontend_layout = frontendLayout();
     const auto backend_layout = backendLayout(index);
     ir::OperandInfo backend_info{permuteShape(obj.shape(), frontend_layout, backend_layout),
-                                 obj.typeInfo()};
+                                 obj.typeInfo(), obj.info().memAllocType()};
     tensor_builder()->registerTensorInfo(index, backend_info, backend_layout, obj.isConstant());
   }
 

--- a/runtime/onert/core/include/ir/Operand.h
+++ b/runtime/onert/core/include/ir/Operand.h
@@ -35,7 +35,8 @@ namespace ir
 class Operand
 {
 public:
-  explicit Operand(const Shape &shape, const TypeInfo &type) : _info{shape, type}, _const{false}
+  explicit Operand(const Shape &shape, const TypeInfo &type)
+      : _info{shape, type, MemAllocType::STATIC}, _const{false}
   {
     // DO NOTHING
   }

--- a/runtime/onert/core/include/ir/OperandInfo.h
+++ b/runtime/onert/core/include/ir/OperandInfo.h
@@ -58,19 +58,7 @@ public:
    * @brief Construct a new OperandInfo object (deleted)
    */
   OperandInfo() = delete;
-  /**
-   * @brief     Construct a new OperandInfo object
-   * @param[in] shape     Tensor shape
-   * @param[in] typeInfo  Tensor data type
-   *
-   * @todo Deprecated this constructor because setting member var implicitly can cause bug later.
-   *       Please use the third constructor. (This constor needs for now not to break previous code)
-   */
-  OperandInfo(const Shape &shape, const TypeInfo &typeInfo)
-      : _shape(shape), _typeInfo(typeInfo), _alloc_type(MemAllocType::STATIC)
-  {
-    // DO NOTHING
-  }
+
   /**
    * @brief     Construct a new OperandInfo object
    * @param[in] shape     Tensor shape
@@ -87,6 +75,14 @@ public:
    * @param[in] origin info for copy
    */
   OperandInfo(const OperandInfo &origin) = default;
+
+  /**
+   * @brief Create a static OperandInfo object
+   */
+  static OperandInfo createStaticInfo(const Shape &shape, const TypeInfo &typeInfo)
+  {
+    return OperandInfo(shape, typeInfo, MemAllocType::STATIC);
+  }
 
 public:
   /**

--- a/runtime/onert/core/src/compiler/ExecutorFactory.cc
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.cc
@@ -128,7 +128,7 @@ void ExecutorFactory::runTensorRegistration(ir::LoweredGraph *lowered_graph,
             const auto frontend_layout = op_seq.getLayout();
             const auto backend_layout = operand_lower_info.layout();
             ir::OperandInfo backend_info{permuteShape(obj.shape(), frontend_layout, backend_layout),
-                                         obj.typeInfo()};
+                                         obj.typeInfo(), obj.info().memAllocType()};
             tensor_builder->registerTensorInfo(index, backend_info, backend_layout,
                                                obj.isConstant());
           }

--- a/runtime/onert/core/src/exec/Execution.cc
+++ b/runtime/onert/core/src/exec/Execution.cc
@@ -51,7 +51,7 @@ void Execution::setInput(const ir::IOIndex &index, const void *buffer, size_t le
 void Execution::setInput(const ir::IOIndex &index, const ir::TypeInfo &type, const ir::Shape &shape,
                          const void *buffer, size_t length, ir::Layout layout)
 {
-  const ir::OperandInfo info{shape, type};
+  auto info = ir::OperandInfo::createStaticInfo(shape, type);
 
   if (length < info.total_size())
   {
@@ -79,7 +79,7 @@ void Execution::setOutput(const ir::IOIndex &index, void *buffer, size_t length,
 void Execution::setOutput(const ir::IOIndex &index, const ir::TypeInfo &type,
                           const ir::Shape &shape, void *buffer, size_t length, ir::Layout layout)
 {
-  const ir::OperandInfo info{shape, type};
+  auto info = ir::OperandInfo::createStaticInfo(shape, type);
 
   if (length < info.total_size())
   {

--- a/runtime/onert/core/src/interp/operations/AvgPool2D.cc
+++ b/runtime/onert/core/src/interp/operations/AvgPool2D.cc
@@ -49,7 +49,8 @@ void prepareAvgPool2D(ExecEnv *env, const ir::Operation &node)
         nnfw::misc::polymorphic_downcast<const ir::operation::AvgPool2D &>(node);
     const auto infered_output_shapes =
         shape_inference::inferAvgPoolShape(in_tensor->tensorInfo().shape(), avgpool_node.param());
-    env->allocateIfNeeded(out_index, {infered_output_shapes[0], output_info.typeInfo()});
+    env->allocateIfNeeded(out_index, ir::OperandInfo::createStaticInfo(infered_output_shapes[0],
+                                                                       output_info.typeInfo()));
   }
   else
   {

--- a/runtime/onert/core/src/interp/operations/BinaryArithmeticOps.cc
+++ b/runtime/onert/core/src/interp/operations/BinaryArithmeticOps.cc
@@ -67,7 +67,8 @@ template <typename node_type> void prepareAdd(ExecEnv *env, const ir::Operation 
       throw std::runtime_error{"Interp(Add): Fail to brodcasting"};
     }
 
-    auto output_info = ir::OperandInfo(out_shape, lhs_tensor->tensorInfo().typeInfo());
+    auto output_info =
+        ir::OperandInfo::createStaticInfo(out_shape, lhs_tensor->tensorInfo().typeInfo());
     // We can handle already allocated (ex. model output)
     env->allocateIfNeeded(out_index, output_info);
   }

--- a/runtime/onert/core/src/interp/operations/Concat.cc
+++ b/runtime/onert/core/src/interp/operations/Concat.cc
@@ -61,8 +61,8 @@ void prepareConcat(ExecEnv *env, const ir::Operation &node)
   // Make output tensor info using first input tensor info, and accumulated axis dimension value
   auto out_shape = first_tensor->tensorInfo().shape();
   out_shape.dim(axis) = out_axis_dimension;
-  env->allocateIfNeeded(out_index,
-                        ir::OperandInfo{out_shape, first_tensor->tensorInfo().typeInfo()});
+  env->allocateIfNeeded(out_index, ir::OperandInfo::createStaticInfo(
+                                       out_shape, first_tensor->tensorInfo().typeInfo()));
 
   auto out_tensor = env->tensorAt(out_index);
   UNUSED_RELEASE(out_tensor);

--- a/runtime/onert/core/src/interp/operations/Conv2D.cc
+++ b/runtime/onert/core/src/interp/operations/Conv2D.cc
@@ -57,7 +57,8 @@ void prepareConv2D(ExecEnv *env, const ir::Operation &node)
     const auto &conv_node = nnfw::misc::polymorphic_downcast<const ir::operation::Conv2D &>(node);
     const auto infered_output_shapes = shape_inference::inferConv2DShape(
         in_tensor->tensorInfo().shape(), kernel_tensor->tensorInfo().shape(), conv_node.param());
-    env->allocateIfNeeded(out_index, {infered_output_shapes[0], output_info.typeInfo()});
+    env->allocateIfNeeded(out_index, ir::OperandInfo::createStaticInfo(infered_output_shapes[0],
+                                                                       output_info.typeInfo()));
   }
   else
   {

--- a/runtime/onert/core/src/interp/operations/DepthwiseConv2D.cc
+++ b/runtime/onert/core/src/interp/operations/DepthwiseConv2D.cc
@@ -62,7 +62,8 @@ void prepareDepthwiseConv(ExecEnv *env, const ir::Operation &node)
     const auto infered_output_shapes = shape_inference::inferDepthwiseConv2DShape(
         in_tensor->tensorInfo().shape(), kernel_tensor->tensorInfo().shape(),
         depth_conv_node.param());
-    env->allocateIfNeeded(out_index, {infered_output_shapes[0], output_info.typeInfo()});
+    env->allocateIfNeeded(out_index, ir::OperandInfo::createStaticInfo(infered_output_shapes[0],
+                                                                       output_info.typeInfo()));
   }
   else
   {

--- a/runtime/onert/core/src/interp/operations/FullyConnected.cc
+++ b/runtime/onert/core/src/interp/operations/FullyConnected.cc
@@ -59,7 +59,8 @@ void prepareFC(ExecEnv *env, const ir::Operation &node)
   ir::Shape output_shape(2);
   output_shape.dim(0) = batch_size;
   output_shape.dim(1) = num_units;
-  const ir::OperandInfo out_info{output_shape, in_tensor->tensorInfo().typeInfo()};
+  const auto out_info =
+      ir::OperandInfo::createStaticInfo(output_shape, in_tensor->tensorInfo().typeInfo());
   env->allocateIfNeeded(out_index, out_info);
 
   auto out_tensor = env->tensorAt(out_index);

--- a/runtime/onert/core/src/interp/operations/MaxPool2D.cc
+++ b/runtime/onert/core/src/interp/operations/MaxPool2D.cc
@@ -49,7 +49,8 @@ void prepareMaxPool2D(ExecEnv *env, const ir::Operation &node)
         nnfw::misc::polymorphic_downcast<const ir::operation::MaxPool2D &>(node);
     const auto infered_output_shapes =
         shape_inference::inferMaxPoolShape(in_tensor->tensorInfo().shape(), maxpool_node.param());
-    env->allocateIfNeeded(out_index, {infered_output_shapes[0], output_info.typeInfo()});
+    env->allocateIfNeeded(out_index, ir::OperandInfo::createStaticInfo(infered_output_shapes[0],
+                                                                       output_info.typeInfo()));
   }
   else
   {

--- a/runtime/onert/core/src/interp/operations/Softmax.cc
+++ b/runtime/onert/core/src/interp/operations/Softmax.cc
@@ -81,7 +81,7 @@ void prepareSoftMax(ExecEnv *env, const ir::Operation &node)
   const auto output_shape = env->graph().operands().at(in_index).info().shape();
   const auto output_type = env->graph().operands().at(out_index).info().typeInfo();
 
-  const ir::OperandInfo output_info{output_shape, output_type};
+  const auto output_info = ir::OperandInfo::createStaticInfo(output_shape, output_type);
   env->allocateIfNeeded(out_index, output_info);
 
   auto out_tensor = env->tensorAt(out_index);


### PR DESCRIPTION
This removes one constructor of `OperandInfo` whose third param is implicitly initialized param because such implicitly initialized param sometimes cause unexpected bug.
Instead, a helper method to create static operand info is added.

For #56
Draft #52

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>