### PR TITLE
[runtime] static shape inference for Concat

### DIFF
--- a/runtime/onert/core/include/util/ShapeInference.h
+++ b/runtime/onert/core/include/util/ShapeInference.h
@@ -40,7 +40,7 @@ Shapes inferEltwiseShape(const ir::Shape &lhs_shape, const ir::Shape &rhs_shape)
 Shapes inferAvgPoolShape(const ir::Shape &in_shape, const ir::operation::AvgPool2D::Param &param,
                          ir::Layout layout = ir::Layout::NHWC);
 
-Shapes inferConcatShape(const Shapes &in_shapes, const ir::operation::Concat::Param &param);
+ir::Shape inferConcatShape(const Shapes &in_shapes, const ir::operation::Concat::Param &param);
 
 Shapes inferMaxPoolShape(const ir::Shape &in_shape, const ir::operation::MaxPool2D::Param &param,
                          ir::Layout layout = ir::Layout::NHWC);
@@ -79,6 +79,7 @@ public:
 private:
   // TODO Define visitors for operations. List them in alphabetic order.
   void visit(const ir::operation::Add &op);
+  void visit(const ir::operation::Concat &op);
   void visit(const ir::operation::Reshape &op);
 
 private:

--- a/runtime/onert/test/util/ShapeInference.cc
+++ b/runtime/onert/test/util/ShapeInference.cc
@@ -206,8 +206,7 @@ TEST(ShapeInference, Concat)
   Shape in3{10, 20, 30, 2, 50};
 
   operation::Concat::Param param{3};
-  auto infered_shapes = onert::shape_inference::inferConcatShape({in1, in2, in3}, param);
-  auto infered_out_shape = infered_shapes[0];
+  auto infered_out_shape = onert::shape_inference::inferConcatShape({in1, in2, in3}, param);
 
   ASSERT_EQ(infered_out_shape.rank(), 5);
   ASSERT_EQ(infered_out_shape.dim(0), 10);


### PR DESCRIPTION
This adds static shape inferencer for `Concat`.

Also return type of previous `inferConcatShape(..)` was modified for performance.

For #56
Draft #52

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>