### PR TITLE
[runtime] Adding APIs to change input shape before execution

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -361,7 +361,11 @@ NNFW_STATUS nnfw_session::apply_tensorinfo(uint32_t index, nnfw_tensorinfo ti)
   }
   else // when called after nnfw_session::prepare() but before excute()
   {
-    throw std::runtime_error("Not yet implemented");
+    onert::ir::Shape new_shape(ti.rank);
+    for (int32_t i = 0; i < ti.rank; i++)
+      new_shape.dim(i) = ti.dims[i];
+
+    _execution->changeInputShape(onert::ir::IOIndex(index), new_shape);
   }
 
   return NNFW_STATUS_NO_ERROR;

--- a/runtime/onert/core/include/exec/Execution.h
+++ b/runtime/onert/core/include/exec/Execution.h
@@ -52,6 +52,14 @@ public:
    * @return  Graph object
    */
   const ir::Graph &primary_subgraph() const { return primary_executor()->graph(); }
+
+  /**
+   * @brief     Change input shape
+   * @param[in] index   Input index
+   * @param[in] new_shape shape to change
+   */
+  void changeInputShape(const ir::IOIndex &index, const ir::Shape &new_shape);
+
   /**
    * @brief     Set input data's information
    * @param[in] index   Input index

--- a/runtime/onert/core/include/exec/IExecutor.h
+++ b/runtime/onert/core/include/exec/IExecutor.h
@@ -53,6 +53,14 @@ struct IExecutor
   virtual const ir::Graph &graph() = 0;
 
   /**
+   * @brief Change input tensor shape right before execution
+   */
+  virtual void changeInputShape(const ir::OperandIndex &, const ir::Shape &)
+  {
+    throw std::runtime_error("changeTensorShape is not yet implemented for this executor.");
+  }
+
+  /**
    * @brief     Set an ordering on operations
    * @param[in] ranks   The table encoding the ordering
    */

--- a/runtime/onert/core/include/exec/IODescription.h
+++ b/runtime/onert/core/include/exec/IODescription.h
@@ -18,8 +18,10 @@
 #define __ONERT_EXEC_IO_DESCRIPTION_H__
 
 #include <vector>
+#include <unordered_map>
 
 #include "ir/OperandInfo.h"
+#include "ir/Index.h"
 
 namespace onert
 {
@@ -58,6 +60,8 @@ struct IODescription
 {
   std::vector<std::unique_ptr<InputDesc>> inputs;
   std::vector<std::unique_ptr<OutputDesc>> outputs;
+  // Contains shape of input set by apply_tensorinfo
+  std::unordered_map<ir::IOIndex, ir::Shape> input_shape_signature;
 };
 
 } // namespace exec

--- a/runtime/onert/core/src/exec/Execution.cc
+++ b/runtime/onert/core/src/exec/Execution.cc
@@ -32,6 +32,23 @@ Execution::Execution(const std::shared_ptr<ExecutorMap> &executors) : _executors
   _io_desc.outputs.resize(primary_subg.getOutputs().size());
 }
 
+void Execution::changeInputShape(const ir::IOIndex &index, const ir::Shape &new_shape)
+{
+  // This should be called BEFORE setInput.
+  if (_io_desc.inputs.at(index.value()) != 0)
+    throw std::runtime_error("Error in calling order");
+
+  auto shape_sig = _io_desc.input_shape_signature.find(index);
+  if (shape_sig != _io_desc.input_shape_signature.end())
+    throw std::runtime_error("Duplicate attempt to change input shape");
+
+  _io_desc.input_shape_signature[index] = new_shape;
+
+  // Modifying Tensor
+  const auto input_index = primary_subgraph().getInputs().at(index);
+  primary_executor()->changeInputShape(input_index, new_shape);
+}
+
 // TODO Remove default parameter
 void Execution::setInput(const ir::IOIndex &index, const void *buffer, size_t length,
                          ir::Layout layout)


### PR DESCRIPTION
This adds APIs to change input shape after compilation && before execution.

For #88
Draft #52

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>