### PR TITLE
[luci] Support U32 type in luci

### DIFF
--- a/compiler/luci/export/src/CircleTensorExporter.cpp
+++ b/compiler/luci/export/src/CircleTensorExporter.cpp
@@ -180,6 +180,10 @@ flatbuffers::Offset<circle::Buffer> encodeOpBuffer(FlatBufferBuilder &builder, l
   {
     return encodeOpBufferByDType<loco::DataType::U8>(builder, c);
   }
+  else if (c->dtype() == loco::DataType::U32)
+  {
+    return encodeOpBufferByDType<loco::DataType::U32>(builder, c);
+  }
 
   INTERNAL_EXN_V("Unsupported datatype", oops::to_uint32(c->dtype()));
 }

--- a/compiler/luci/import/src/Nodes/CircleConst.cpp
+++ b/compiler/luci/import/src/Nodes/CircleConst.cpp
@@ -88,6 +88,10 @@ CircleConst *create_circleconst(GraphBuilderContext *context, int32_t tensor_ind
       copy_data<loco::DataType::S32>(buffer, num_elements, const_node);
       break;
 
+    case loco::DataType::U32:
+      copy_data<loco::DataType::U32>(buffer, num_elements, const_node);
+      break;
+
     default:
       throw oops::UserExn("Unsupported tensor type", circle::EnumNameTensorType(const_tensor.type));
   }

--- a/compiler/luci/lang/src/Nodes/CircleConst.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleConst.cpp
@@ -73,6 +73,7 @@ template <loco::DataType DT> typename loco::DataTypeImpl<DT>::Type &CircleConst:
 INSTANTIATE(loco::DataType::S32);
 INSTANTIATE(loco::DataType::FLOAT32);
 INSTANTIATE(loco::DataType::U8);
+INSTANTIATE(loco::DataType::U32);
 
 #undef INSTANTIATE
 

--- a/compiler/luci/service/src/CircleTypeInference.cpp
+++ b/compiler/luci/service/src/CircleTypeInference.cpp
@@ -34,7 +34,8 @@ circle::TensorType translateLocoTypeToCircle(loco::DataType dtype)
     case loco::DataType::U8:
       return circle::TensorType_UINT8;
     //  case loco::DataType::U16: unsupported
-    //  case loco::DataType::U32: unsupported
+    case loco::DataType::U32:
+      return circle::TensorType_UINT32;
     //  case loco::DataType::U64: unsupported
     case loco::DataType::S8:
       return circle::TensorType_INT8;


### PR DESCRIPTION
Parent Issue : #438

This commit will enable supporting U32 datatype in `luci`

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>