### PR TITLE
[nnpackage] Introduce UINT32 type in circle schema

### DIFF
--- a/nnpackage/schema/circle_schema.fbs
+++ b/nnpackage/schema/circle_schema.fbs
@@ -50,6 +50,7 @@ enum TensorType : byte {
   COMPLEX64 = 8,
   INT8 = 9,
   FLOAT64 = 10,
+  UINT32 = 11,
 }
 
 // Custom quantization parameters for experimenting with new quantization


### PR DESCRIPTION
Parent Issue : #438

This commit will introduce `UINT32` type in circle schema

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>