### PR TITLE
[runtime] Adding DynamicTensor into TensorBuilder

### DIFF
--- a/runtime/onert/backend/acl_common/AclTensorBuilder.h
+++ b/runtime/onert/backend/acl_common/AclTensorBuilder.h
@@ -71,7 +71,7 @@ public:
   std::shared_ptr<ITensor> tensorAt(const ir::OperandIndex &ind) override;
   void iterate(const IterateFunction &fn) override;
 
-  std::unique_ptr<ITensorManager> releaseTensorManager(void) override;
+  std::unique_ptr<ITensorManager> releaseStaticTensorManager(void) override;
 
   std::shared_ptr<T_ITensor> at(const ir::OperandIndex &ind);
 
@@ -341,7 +341,7 @@ void AclTensorBuilder<T_ITensor, T_Tensor, T_SubTensor>::dimCorrection(
 
 template <typename T_ITensor, typename T_Tensor, typename T_SubTensor>
 std::unique_ptr<ITensorManager>
-AclTensorBuilder<T_ITensor, T_Tensor, T_SubTensor>::releaseTensorManager(void)
+AclTensorBuilder<T_ITensor, T_Tensor, T_SubTensor>::releaseStaticTensorManager(void)
 {
   return std::move(_tensor_mgr);
 }

--- a/runtime/onert/backend/cpu/TensorBuilder.cc
+++ b/runtime/onert/backend/cpu/TensorBuilder.cc
@@ -27,7 +27,8 @@ namespace backend
 namespace cpu
 {
 
-TensorBuilder::TensorBuilder() : _static_tensor_mgr{new StaticTensorManager()}
+TensorBuilder::TensorBuilder()
+    : _static_tensor_mgr{new StaticTensorManager()}, _dynamic_tensor_mgr{new DynamicTensorManager()}
 {
   // DO NOTHING
 }
@@ -86,7 +87,12 @@ std::shared_ptr<operand::Tensor> TensorBuilder::at(const ir::OperandIndex &ind)
   return ret;
 }
 
-std::unique_ptr<ITensorManager> TensorBuilder::releaseTensorManager(void)
+std::unique_ptr<ITensorManager> TensorBuilder::releaseStaticTensorManager(void)
+{
+  return std::move(_static_tensor_mgr);
+}
+
+std::unique_ptr<ITensorManager> TensorBuilder::releaseDynamicTensorManager(void)
 {
   return std::move(_static_tensor_mgr);
 }

--- a/runtime/onert/backend/cpu/TensorBuilder.h
+++ b/runtime/onert/backend/cpu/TensorBuilder.h
@@ -17,6 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_TENSOR_BUILDER_H__
 #define __ONERT_BACKEND_CPU_TENSOR_BUILDER_H__
 
+#include "DynamicTensorManager.h"
 #include "StaticTensorManager.h"
 #include "operand/Tensor.h"
 
@@ -59,12 +60,14 @@ public:
 
   void iterate(const IterateFunction &fn) override;
 
-  std::unique_ptr<ITensorManager> releaseTensorManager(void) override;
+  std::unique_ptr<ITensorManager> releaseStaticTensorManager(void) override;
+  std::unique_ptr<ITensorManager> releaseDynamicTensorManager(void) override;
 
   std::shared_ptr<operand::Tensor> at(const ir::OperandIndex &ind);
 
 private:
   std::unique_ptr<StaticTensorManager> _static_tensor_mgr;
+  std::unique_ptr<DynamicTensorManager> _dynamic_tensor_mgr;
   ir::OperandIndexMap<ir::OperandInfo> _tensor_info_map;
   ir::OperandIndexSequence _constants;
 };

--- a/runtime/onert/core/include/backend/ITensorBuilder.h
+++ b/runtime/onert/core/include/backend/ITensorBuilder.h
@@ -55,7 +55,12 @@ struct ITensorBuilder
   virtual std::shared_ptr<ITensor> tensorAt(const ir::OperandIndex &ind) = 0;
   virtual void iterate(const IterateFunction &fn) = 0;
 
-  virtual std::unique_ptr<ITensorManager> releaseTensorManager(void) = 0;
+  virtual std::unique_ptr<ITensorManager> releaseStaticTensorManager(void) = 0;
+
+  virtual std::unique_ptr<ITensorManager> releaseDynamicTensorManager(void)
+  {
+    throw std::runtime_error("releaseDynamicTensorManager() for this backend is not supported");
+  }
 };
 
 } // namespace backend

--- a/runtime/onert/core/src/exec/ExecutorBase.cc
+++ b/runtime/onert/core/src/exec/ExecutorBase.cc
@@ -49,9 +49,11 @@ ExecutorBase::ExecutorBase(std::unique_ptr<ir::LoweredGraph> &&lowered_graph,
   // Prepare each TensorManager on each backend
   for (auto &tensor_builder : tensor_builders)
   {
-    auto tensor_manager = tensor_builder->releaseTensorManager();
+    auto tensor_manager = tensor_builder->releaseStaticTensorManager();
     assert(tensor_manager != nullptr);
     _tensor_mgrs.insert(std::move(tensor_manager));
+
+    // TODO release DynamicTensorManager
   }
 }
 


### PR DESCRIPTION
This adds `DynamicTensor` into `TensorBuilder`. 

FYI, `DynamicTensor` will allocate memory for dynamic tensors (code for this was not committed yet).

For #56
Draft #52

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>