### PR TITLE
[luci] Ignore CircleOutputDummy for export

### DIFF
--- a/compiler/luci/export/src/CircleOperationExporter.cpp
+++ b/compiler/luci/export/src/CircleOperationExporter.cpp
@@ -91,6 +91,7 @@ public:
   // Virtual
   void visit(luci::CircleInput *) final {}
   void visit(luci::CircleOutput *) final {}
+  void visit(luci::CircleOutputDummy *) final {}
   // Virtual for multiple-outputs
   void visit(luci::CircleIfOut *) final {}
   void visit(luci::CircleUnpackOut *) final {}
@@ -762,6 +763,10 @@ void exportNode(loco::Node *node, flatbuffers::FlatBufferBuilder &builder, Seria
 {
   // TODO Use explicit tagging to prevent possible mistake
   auto isNoOp = [](loco::Node *node) {
+    if (dynamic_cast<luci::CircleOutputDummy *>(node) != nullptr)
+      return true;
+    if (dynamic_cast<luci::CircleOutput *>(node) != nullptr)
+      return true;
     // If there is only one input and the TensorIndex for the input is same
     // as the TensorIndex of the output then this node is just a dummy node
     if (node->arity() == 1)

--- a/compiler/luci/export/src/CircleTensorExporter.cpp
+++ b/compiler/luci/export/src/CircleTensorExporter.cpp
@@ -97,7 +97,6 @@ void allocateCircleTensor(CircleNode *node, CircleTensorContext &ctx)
 
   if (isNoOp(node))
   {
-    set_tensor_index(node, get_tensor_index(node->arg(0)));
     return;
   }
 


### PR DESCRIPTION
This will revise export to ignore CircleOutDummy
- explictly also ignore for CircleOutput while Op export

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>