### PR TITLE
[runtime] move location of calling buildTensor(..) in CPU backend

### DIFF
--- a/runtime/onert/backend/cpu/TensorBuilder.cc
+++ b/runtime/onert/backend/cpu/TensorBuilder.cc
@@ -40,6 +40,9 @@ void TensorBuilder::registerTensorInfo(const ir::OperandIndex &ind, const ir::Op
 
   if (as_const)
     _constants.append(ind);
+
+  // TODO consider dynamic tensor
+  _static_tensor_mgr->buildTensor(ind, info, _constants.contains(ind));
 }
 
 void TensorBuilder::notifyFirstUse(const ir::OperandIndex &ind)
@@ -47,7 +50,8 @@ void TensorBuilder::notifyFirstUse(const ir::OperandIndex &ind)
   assert(_tensor_info_map.find(ind) != _tensor_info_map.end());
   const auto tensor_info = _tensor_info_map.at(ind);
   const auto size = tensor_info.total_size();
-  _static_tensor_mgr->buildTensor(ind, tensor_info, _constants.contains(ind));
+
+  // TODO consider dynamic tensor
   _static_tensor_mgr->claimPlan(ind, size);
 }
 


### PR DESCRIPTION
This moves invocation of `buildTensor()` 
from `notifyFirstUse()` to `registerTensorInfo()`.

1. why?
   - `registerTensorInfo()` is called by all executors but `notifyFirstUse()` maybe _not_ (in case of future _DataflowExecutor_. Current _DataflowExecutor_ calls `notifyFirstUse()` as workaround.)
   - `buildTensor()` should be called for both static/dynamic tensors.
   - for the above reason, `notifyFirstUse()` is not the right place to call `buildTensor()`
1. Putting `buildTensor()` into `registerTensorInfo()` is correct?
   - the role of `buildTensor()` is currently (1) create an empty tensor object (2) set `tensorInfo`. So, I guess it is OK to put `buildTensor()` into `registerTensorInfo()`
   - better way could be adding a new method, e.g., `tensorBuilder::buildTensors()`. However `aclTensorBuilder` already has this (`buildTensors()`) as a private member and `buildTensors()` is called in `Prepare(..)`, which is somewhat different from how CPU backend works.
   - So I think currently it is OK to put `buildTensor()` to `registerTensorInfo()` of CPU backend.

For #56
Draft #52

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>