### PR TITLE
[runtime] Adding comment inside ShapeInference.h/cc

### DIFF
--- a/runtime/onert/core/include/util/ShapeInference.h
+++ b/runtime/onert/core/include/util/ShapeInference.h
@@ -78,9 +78,22 @@ public:
 
 private:
   // TODO Define visitors for operations. List them in alphabetic order.
+  // Remove TODO when any op starting from the alphabet is added
   void visit(const ir::operation::Add &op);
   void visit(const ir::operation::Concat &op);
+  // TODO write op starting from D
+  // TODO write op starting from E
+  // TODO write op starting from F
+  // TODO write op starting from G
+  // TODO write op starting from L
+  // TODO write op starting from M
+  // TODO write op starting from N
+  // TODO write op starting from P
   void visit(const ir::operation::Reshape &op);
+  // TODO write op starting from S
+  // TODO write op starting from T
+  // TODO write op starting from U
+  // TODO write op starting from Z
 
 private:
   ir::Operands &_operands;

--- a/runtime/onert/core/src/util/ShapeInference.cc
+++ b/runtime/onert/core/src/util/ShapeInference.cc
@@ -198,6 +198,9 @@ Shapes inferFullyConnectedShape(const ir::Shape &in_shape, const ir::Shape &ker_
 
 /*
   StaticInferer
+
+  - Define visitors for operations. List them in alphabetic order.
+  - Remove TODO when any op starting from the alphabet is added
 */
 
 void StaticInferer::visit(const ir::operation::Add &op)
@@ -249,6 +252,15 @@ void StaticInferer::visit(const ir::operation::Concat &op)
   output.info().shape(out_shape);
 }
 
+// TODO write op starting from D
+// TODO write op starting from E
+// TODO write op starting from F
+// TODO write op starting from G
+// TODO write op starting from L
+// TODO write op starting from M
+// TODO write op starting from N
+// TODO write op starting from P
+
 void StaticInferer::visit(const ir::operation::Reshape &op)
 {
   const auto input_idx{op.getInputs().at(ir::operation::Reshape::Input::INPUT)};
@@ -285,6 +297,11 @@ void StaticInferer::visit(const ir::operation::Reshape &op)
   // if shape is NOT Const, set output shape to be dynamic_
   output.info().memAllocType(ir::MemAllocType::DYNAMIC);
 }
+
+// TODO write op starting from S
+// TODO write op starting from T
+// TODO write op starting from U
+// TODO write op starting from Z
 
 } // namespace shape_inference
 } // namespace onert


### PR DESCRIPTION
Comment was added inside `ShapeInference.h/cc`. 
The purpose of this comment is to avoid merge conflict.
Only alphabets that seems to have many operations were added due to space limitation.

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>