### PR TITLE
[onert] Fix missing converting float16 out

### DIFF
--- a/runtime/onert/backend/acl_common/Convert.cc
+++ b/runtime/onert/backend/acl_common/Convert.cc
@@ -211,6 +211,8 @@ ir::DataType asRuntimeDataType(::arm_compute::DataType data_type)
       return ir::DataType::UINT8;
     case ::arm_compute::DataType::QSYMM8:
       return ir::DataType::QUANT8_SYMM;
+    case ::arm_compute::DataType::F16:
+      return ir::DataType::FLOAT16;
     default:
       throw std::runtime_error{"Not supported, yet"};
       break;


### PR DESCRIPTION
Fix https://github.com/Samsung/ONE/issues/489#issue-613077273

This commit fixes missing converting float16 out.

Signed-off-by: ragmani <ragmani0216@gmail.com>