### PR TITLE
[onert] Remove CachedDataDeleter use in Compiler

### DIFF
--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -187,16 +187,6 @@ void Compiler::compile(void)
       Fp32ToFp16Converter(*lowered_subgs[index]).run();
     }
 
-    // NOTE. Current datas' reference of constant operands is 2 because of
-    // original graph and lowered graph.
-    // To delete cached data, this doing should be done for the original graph
-    // at this line and then once again for the lowered graph in ExecutorFactory
-    // TODO. Delete this code as code for disconnecting btw Graph and nnfw session lands
-    if (_options.delete_cached_data)
-    {
-      CachedDataDeleter(graph.operands()).run();
-    }
-
     graph.setSubgraphs(nullptr);
   });
 


### PR DESCRIPTION
Remove CachedDataDeleter use in Compiler as this should not be exist and
now it is ready to get removed.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>