### PR TITLE
[runtime] fixing a bug when to call registerTensorInfo

### DIFF
--- a/runtime/onert/core/src/compiler/ExecutorFactory.cc
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.cc
@@ -124,6 +124,14 @@ void ExecutorFactory::runTensorRegistration(ir::LoweredGraph *lowered_graph,
           {
             const auto &operand_lower_info =
                 lowered_graph->getLowerInfo(index)->def_factors().getOnlyElement();
+
+            // E.g., permute (CPU) -> tensor A -> MaxPool2D(acl_cl)
+            // op.getOutputs() of permute (CPU) returns tensor A
+            // but tensor A belongs to the backend of acl_cl.
+            // So, we have to make this tensor NOT registered for CPU.
+            if (operand_lower_info.backend() != backend)
+              continue;
+
             const auto &obj = lowered_graph->graph().operands().at(index);
             const auto frontend_layout = op_seq.getLayout();
             const auto backend_layout = operand_lower_info.layout();


### PR DESCRIPTION
This fixed a bug when to call `registerTensorInfo(...)`.

Previously, e.g., with a graph with `permute (CPU)` -> `tensor A` -> `add (acl_cl)`,
CPU backend's `registerTensorInfo(..)` was called to register `tensor A` while acl_cl's backend also calls its `registerTensorInfo(..)` for `tensor A`.

This fix disables CPU backend's to call `registerTensorInfo(..)` for `tensor A`.

(While fixing CI failure of #481)

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>