### PR TITLE
[runtime] make the first char of methods in IConfig to small letter

### DIFF
--- a/runtime/onert/backend/acl_cl/Config.cc
+++ b/runtime/onert/backend/acl_cl/Config.cc
@@ -47,7 +47,7 @@ bool Config::initialize()
   return true;
 }
 
-ir::Layout Config::SupportLayout(const ir::Operation &, ir::Layout frontend_layout)
+ir::Layout Config::supportLayout(const ir::Operation &, ir::Layout frontend_layout)
 {
   const std::string acl_layout_str = util::getConfigString(util::config::ACL_LAYOUT);
   if (acl_layout_str == "NHWC")

--- a/runtime/onert/backend/acl_cl/Config.h
+++ b/runtime/onert/backend/acl_cl/Config.h
@@ -33,8 +33,8 @@ class Config : public IConfig
 public:
   std::string id() override { return "acl_cl"; }
   bool initialize() override;
-  bool SupportPermutation() override { return true; }
-  ir::Layout SupportLayout(const ir::Operation &node, ir::Layout frontend_layout) override;
+  bool supportPermutation() override { return true; }
+  ir::Layout supportLayout(const ir::Operation &node, ir::Layout frontend_layout) override;
   bool supportDynamicTensor() override { return false; }
 
   std::unique_ptr<util::ITimer> timer() override { return std::make_unique<CLTimer>(); }

--- a/runtime/onert/backend/acl_neon/Config.cc
+++ b/runtime/onert/backend/acl_neon/Config.cc
@@ -27,7 +27,7 @@ namespace acl_neon
 
 bool Config::initialize() { return true; }
 
-ir::Layout Config::SupportLayout(const ir::Operation &, ir::Layout frontend_layout)
+ir::Layout Config::supportLayout(const ir::Operation &, ir::Layout frontend_layout)
 {
   const std::string acl_layout_str = util::getConfigString(util::config::ACL_LAYOUT);
   if (acl_layout_str == "NHWC")

--- a/runtime/onert/backend/acl_neon/Config.h
+++ b/runtime/onert/backend/acl_neon/Config.h
@@ -33,8 +33,8 @@ class Config : public IConfig
 public:
   std::string id() override { return "acl_neon"; }
   bool initialize() override;
-  ir::Layout SupportLayout(const ir::Operation &node, ir::Layout frontend_layout) override;
-  bool SupportPermutation() override { return true; }
+  ir::Layout supportLayout(const ir::Operation &node, ir::Layout frontend_layout) override;
+  bool supportPermutation() override { return true; }
   bool supportDynamicTensor() override { return false; }
 
   std::unique_ptr<util::ITimer> timer() override { return std::make_unique<util::CPUTimer>(); }

--- a/runtime/onert/backend/cpu/Config.cc
+++ b/runtime/onert/backend/cpu/Config.cc
@@ -25,7 +25,7 @@ namespace cpu
 
 bool Config::initialize() { return true; }
 
-ir::Layout Config::SupportLayout(const ir::Operation &, ir::Layout) { return ir::Layout::NHWC; }
+ir::Layout Config::supportLayout(const ir::Operation &, ir::Layout) { return ir::Layout::NHWC; }
 
 } // namespace cpu
 } // namespace backend

--- a/runtime/onert/backend/cpu/Config.h
+++ b/runtime/onert/backend/cpu/Config.h
@@ -33,8 +33,8 @@ class Config : public IConfig
 public:
   std::string id() override { return "cpu"; }
   bool initialize() override;
-  ir::Layout SupportLayout(const ir::Operation &node, ir::Layout frontend_layout) override;
-  bool SupportPermutation() override { return true; }
+  ir::Layout supportLayout(const ir::Operation &node, ir::Layout frontend_layout) override;
+  bool supportPermutation() override { return true; }
   bool supportDynamicTensor() override { return true; }
 
   std::unique_ptr<util::ITimer> timer() override { return std::make_unique<util::CPUTimer>(); }

--- a/runtime/onert/core/include/backend/IConfig.h
+++ b/runtime/onert/core/include/backend/IConfig.h
@@ -36,8 +36,8 @@ struct IConfig
   virtual std::string id() = 0;
   virtual bool initialize() = 0;
   // Support permute kernel
-  virtual bool SupportPermutation() = 0;
-  virtual ir::Layout SupportLayout(const ir::Operation &node, ir::Layout frontend_layout) = 0;
+  virtual bool supportPermutation() = 0;
+  virtual ir::Layout supportLayout(const ir::Operation &node, ir::Layout frontend_layout) = 0;
 
   virtual bool supportDynamicTensor() = 0;
 

--- a/runtime/onert/core/src/ir/LoweredGraph.cc
+++ b/runtime/onert/core/src/ir/LoweredGraph.cc
@@ -219,7 +219,7 @@ void LoweredGraph::makeOpSequences(
 
         // The layout of each backend should be set at another place
         // TODO Change setting layout of each backend at another place
-        auto backend_layout = backend->config()->SupportLayout(node, frontend_layout);
+        auto backend_layout = backend->config()->supportLayout(node, frontend_layout);
 
         for (auto operand : node.getInputs())
         {

--- a/runtime/onert/test/core/compiler/Scheduler.cc
+++ b/runtime/onert/test/core/compiler/Scheduler.cc
@@ -56,8 +56,8 @@ struct MockConfigCPU : public IConfig
 {
   std::string id() override { return "cpu"; }
   bool initialize() override { return true; };
-  bool SupportPermutation() override { return false; }
-  Layout SupportLayout(const Operation &, Layout) { return Layout::UNKNOWN; }
+  bool supportPermutation() override { return false; }
+  Layout supportLayout(const Operation &, Layout) { return Layout::UNKNOWN; }
   bool supportDynamicTensor() override { return false; }
 };
 
@@ -76,8 +76,8 @@ struct MockConfigGPU : public IConfig
 {
   std::string id() override { return "gpu"; }
   bool initialize() override { return true; };
-  bool SupportPermutation() override { return false; }
-  ir::Layout SupportLayout(const ir::Operation &, ir::Layout) { return ir::Layout::UNKNOWN; }
+  bool supportPermutation() override { return false; }
+  ir::Layout supportLayout(const ir::Operation &, ir::Layout) { return ir::Layout::UNKNOWN; }
   bool supportDynamicTensor() override { return false; }
 };
 
@@ -96,8 +96,8 @@ struct MockConfigNPU : public IConfig
 {
   std::string id() override { return "npu"; }
   bool initialize() override { return true; };
-  bool SupportPermutation() override { return false; }
-  ir::Layout SupportLayout(const ir::Operation &, ir::Layout) { return ir::Layout::UNKNOWN; }
+  bool supportPermutation() override { return false; }
+  ir::Layout supportLayout(const ir::Operation &, ir::Layout) { return ir::Layout::UNKNOWN; }
   bool supportDynamicTensor() override { return false; }
 };
 

--- a/runtime/onert/test/core/exec/ExecTime.test.cc
+++ b/runtime/onert/test/core/exec/ExecTime.test.cc
@@ -30,8 +30,8 @@ struct MockConfig : public IConfig
 {
   std::string id() override { return "b1"; }
   bool initialize() override { return true; };
-  bool SupportPermutation() override { return false; }
-  ir::Layout SupportLayout(const ir::Operation &, ir::Layout) { return ir::Layout::UNKNOWN; }
+  bool supportPermutation() override { return false; }
+  ir::Layout supportLayout(const ir::Operation &, ir::Layout) { return ir::Layout::UNKNOWN; }
   bool supportDynamicTensor() override { return false; }
 };
 


### PR DESCRIPTION
This modification is made to follow camel case convention.

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>