### PR TITLE
[luci] Shape, dtype infer for Cast Op

### DIFF
--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -358,6 +358,13 @@ public:
     return loco::NodeShape{shape_output};
   }
 
+  loco::NodeShape visit(const luci::CircleCast *node) final
+  {
+    auto x_shape = loco::shape_get(node->x()).as<loco::TensorShape>();
+
+    return loco::NodeShape{x_shape};
+  }
+
   loco::NodeShape visit(const luci::CircleConcatenation *node) final
   {
     // TODO Support when CircleConcatenation has 0 input

--- a/compiler/luci/service/src/CircleTypeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleTypeInferenceRule.cpp
@@ -50,6 +50,8 @@ struct TypeInferenceAlgorithm final : public luci::CircleNodeVisitor<loco::DataT
     return loco::dtype_get(node->input());
   }
 
+  loco::DataType visit(const luci::CircleCast *node) final { return node->out_data_type(); }
+
   loco::DataType visit(const luci::CircleConcatenation *node) final
   {
     // TODO Support when CircleConcatenation has 0 input


### PR DESCRIPTION
This will enable shape and dtype inference for Cast Op

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>