### PR TITLE
[luci] Change Custom Op ShapeInferenceRule

### DIFF
--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -464,14 +464,7 @@ public:
 
   loco::NodeShape visit(const luci::CircleCustom *node) final
   {
-    loco::TensorShape shape;
-
-    shape.rank(node->rank());
-    for (uint32_t r = 0; r < shape.rank(); r++)
-    {
-      shape.dim(r).set(node->dim(r).value());
-    }
-
+    loco::TensorShape shape = own_shape(node);
     return loco::NodeShape{shape};
   }
 


### PR DESCRIPTION
This commit changes Custom Op ShapeInferenceRule

Custom op always has its output shape.
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>