### PR TITLE
[runtime] Dynamic Tensor: getter of dynamicTensor object

### DIFF
--- a/runtime/onert/backend/cpu/TensorBuilder.h
+++ b/runtime/onert/backend/cpu/TensorBuilder.h
@@ -69,6 +69,9 @@ public:
   void iterate(const IterateFunction &fn) override;
 
   std::unique_ptr<ITensorManager> releaseStaticTensorManager(void) override;
+
+  IDynamicTensorManager *dynamicTensorManager(void) override { return _dynamic_tensor_mgr.get(); }
+
   std::unique_ptr<ITensorManager> releaseDynamicTensorManager(void) override;
 
   /**

--- a/runtime/onert/core/include/backend/ITensorBuilder.h
+++ b/runtime/onert/core/include/backend/ITensorBuilder.h
@@ -26,6 +26,7 @@
 #include "ITensor.h"
 #include "ITensorManager.h"
 #include "ITensorRegistry.h"
+#include "IDynamicTensorManager.h"
 
 namespace onert
 {
@@ -111,6 +112,20 @@ struct ITensorBuilder
    * @return std::unique_ptr<ITensorManager> Tensor Manager object
    */
   virtual std::unique_ptr<ITensorManager> releaseStaticTensorManager(void) = 0;
+
+  /**
+   * @brief Get dynamicTensorManager. If a backend does not support dynamic tensor, exception
+   *        will be thrown.
+   *
+   * @return pointer of IDynamicTensorManager object
+   *
+   * @note   Since it is a pointer, its life time is from the cration of TensorBuilder
+   *         to the end of execution
+   */
+  virtual IDynamicTensorManager *dynamicTensorManager(void)
+  {
+    throw std::runtime_error("dynamicTensorManager(): NYI");
+  }
 
   /**
    * @brief Release dynamic @c ITensorManger object which was built


### PR DESCRIPTION
This adds getter of dynamicTensor object.
dynamicTensor object will be used later to allocate dynamic tensor (output of op) during shape inference at execution time.

For #56
Draft #52

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>