### PR TITLE
[onert] Fix a error called on non-final destructor of TensorRegistry

### DIFF
--- a/runtime/onert/core/include/backend/ITensorRegistry.h
+++ b/runtime/onert/core/include/backend/ITensorRegistry.h
@@ -28,6 +28,11 @@ namespace backend
 struct ITensorRegistry
 {
   /**
+   * @brief Deconstruct itself
+   */
+  virtual ~ITensorRegistry() = default;
+
+  /**
    * @brief Returns pointer of ITensor
    * @note  Return tensor cannot be used longer than dynamic tensor manager
    */


### PR DESCRIPTION
Fix https://github.com/Samsung/ONE/issues/566#issue-613975125

This commit fixes a error called on non-final destructor of TensorRegistry.

Signed-off-by: ragmani <ragmani0216@gmail.com>