### PR TITLE
[onert] Remove unused states of Compiler

### DIFF
--- a/runtime/onert/core/include/compiler/Compiler.h
+++ b/runtime/onert/core/include/compiler/Compiler.h
@@ -34,8 +34,6 @@ namespace compiler
 enum class State
 {
   CREATED, // Before compilation
-  STARTED, // Compile is started
-  LOWERED, // Backend is decided
   COMPILED // Success compilation
 };
 

--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -120,8 +120,6 @@ void Compiler::checkProfilerConditions()
 
 void Compiler::compile(void)
 {
-  _state = State::STARTED;
-
   {
     VERBOSE(Compiler) << std::boolalpha;
     VERBOSE(Compiler) << "==== Compiler Options ====" << std::endl;
@@ -160,6 +158,7 @@ void Compiler::compile(void)
     _executors = std::make_shared<exec::ExecutorMap>();
     _executors->insert(std::make_pair(
         ir::SubgraphIndex{0}, std::make_unique<interp::InterpExecutor>(*primary_subgraph())));
+    _state = State::COMPILED;
     return;
   }
 
@@ -196,8 +195,6 @@ void Compiler::compile(void)
   /*************************************************************
    *  Backend independent analysis & optimization phase finished
    *************************************************************/
-
-  _state = State::LOWERED;
 
   _executors = std::make_shared<exec::ExecutorMap>();
   for (auto &pair : lowered_subgs)


### PR DESCRIPTION
Remove STARTED and LOWERED state of Compiler since transitions to these
states are useless.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>