### PR TITLE
[onert] restore REDUCE_PROD in base_loader

### DIFF
--- a/runtime/onert/frontend/base_loader/include/base_loader.h
+++ b/runtime/onert/frontend/base_loader/include/base_loader.h
@@ -1489,6 +1489,9 @@ void BaseLoader<LoaderDomain, SpecificLoader>::loadOperation(const Operator *op,
     case BuiltinOperator::BuiltinOperator_SHAPE:
       loadShape(op, subg);
       return;
+    case BuiltinOperator::BuiltinOperator_REDUCE_PROD:
+      loadReduceProd(op, subg);
+      return;
     case BuiltinOperator::BuiltinOperator_WHILE:
       loadWhile(op, subg);
       return;


### PR DESCRIPTION
REDUCE_PROD implementation in base_loader was removed accidentally.
It restores the implementation.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee sg5.lee@samsung.com