### PR TITLE
[runtime] Dynamic Tensor: using CodeAndInfo for dynamic tensor

### DIFF
--- a/runtime/onert/core/include/compiler/ExecutionBuilder.h
+++ b/runtime/onert/core/include/compiler/ExecutionBuilder.h
@@ -32,7 +32,14 @@ namespace compiler
 class ExecutionBuilder
 {
 public:
-  void append(const ir::OpSequenceIndex index, CodeAndInfo &&code_and_info)
+  void append(const ir::OpSequenceIndex index,
+              std::unique_ptr<CodeAndInfoForStaticTensor> code_and_info)
+  {
+    _code_map.emplace(index, std::move(code_and_info));
+  }
+
+  void append(const ir::OpSequenceIndex index,
+              std::unique_ptr<CodeAndInfoForDynamicTensor> code_and_info)
   {
     _code_map.emplace(index, std::move(code_and_info));
   }

--- a/runtime/onert/core/include/exec/FunctionSequence.h
+++ b/runtime/onert/core/include/exec/FunctionSequence.h
@@ -22,6 +22,10 @@
 #include <functional>
 
 #include "exec/IFunction.h"
+#include "ir/Operands.h"
+#include "ir/OpSequence.h"
+#include "backend/ITensorRegistry.h"
+#include "backend/IDynamicTensorManager.h"
 #include <memory>
 
 namespace onert
@@ -49,8 +53,23 @@ private:
 public:
   virtual ~FunctionSequence() = default;
 
+  /**
+   * @brief Runs OpSequence with static tensor
+   */
   void run() override;
+
   void runSync() override;
+
+  /**
+   * @brief Runs OpSequence with dynamic tensor
+   *        This will perform shape inference and memory allocation
+   *        when output tensor is a dynamic tensor
+   * @note  parameters are used for shape inference and memory allocation of dynamic tensors
+   */
+  void run(const ir::OpSequence *op_seq, const ir::Operands &operands,
+           backend::IDynamicTensorManager *tensor_manager,
+           std::shared_ptr<backend::ITensorRegistry> &tensor_registry);
+
   void prepare() override;
 
   /**

--- a/runtime/onert/core/src/exec/DataflowExecutor.cc
+++ b/runtime/onert/core/src/exec/DataflowExecutor.cc
@@ -92,7 +92,7 @@ DataflowExecutor::DataflowExecutor(std::unique_ptr<ir::LoweredGraph> lowered_gra
     VERBOSE(DataflowExecutor) << "Create a job #" << next_job_index << " with OpSequenceIndex "
                               << op_seq_index.value() << std::endl;
     _finished_jobs.emplace_back(
-        std::make_unique<Job>(next_job_index, _code_map.at(op_seq_index).fn_seq.get()));
+        std::make_unique<Job>(next_job_index, _code_map.at(op_seq_index)->fn_seq.get()));
     op_seq_to_job[op_seq_index] = next_job_index++;
   });
 

--- a/runtime/onert/core/src/exec/FunctionSequence.cc
+++ b/runtime/onert/core/src/exec/FunctionSequence.cc
@@ -16,11 +16,17 @@
 
 #include "exec/FunctionSequence.h"
 
+#include "ir/Operation.h"
+#include "backend/IDynamicTensorManager.h"
+#include "backend/ITensorRegistry.h"
+#include "util/ShapeInference.h"
+
 namespace onert
 {
 namespace exec
 {
 
+// for OpSequence only with static tensor
 void FunctionSequence::run()
 {
   for (const auto &function : _functions)
@@ -35,6 +41,22 @@ void FunctionSequence::runSync()
   {
     function->runSync();
   }
+}
+
+// for OpSequence with dynamic tensor
+void FunctionSequence::run(const ir::OpSequence *op_seq, const ir::Operands &operands,
+                           backend::IDynamicTensorManager *dynamic_tensor_manager,
+                           std::shared_ptr<backend::ITensorRegistry> &tensor_registry)
+{
+  // TODO Write code to run shape inference and dynamic tensor allocation using params below:
+  (void)op_seq;
+  (void)operands;
+  (void)dynamic_tensor_manager;
+  (void)tensor_registry;
+
+  // TODO Write code to run a function
+
+  throw std::runtime_error("run() with dynamic tensor: Not yet implemented");
 }
 
 void FunctionSequence::prepare()

--- a/runtime/onert/core/src/exec/LinearExecutor.h
+++ b/runtime/onert/core/src/exec/LinearExecutor.h
@@ -61,7 +61,7 @@ public:
   void executeImpl(void) override;
 
 private:
-  std::vector<compiler::CodeAndInfo> _code;
+  std::vector<std::unique_ptr<compiler::CodeAndInfo>> _code;
 };
 
 } // namespace exec


### PR DESCRIPTION
This introduces children for `CodeAndInfo` for static and dynamic tensor. 
Handling dynamic tensor requires more data into `CodeAndInfo` and such data are put into `CodeAndInfoForDynamicTensor`.
Also this PR also includes how the info flows to `FunctionSequence::run()` to show how such data are passed.

For #56
Draft #52

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>