### PR TITLE
[runtime] bug fix of releaseDynamicTensorManager()

### DIFF
--- a/runtime/onert/backend/cpu/TensorBuilder.cc
+++ b/runtime/onert/backend/cpu/TensorBuilder.cc
@@ -99,7 +99,7 @@ std::unique_ptr<ITensorManager> TensorBuilder::releaseStaticTensorManager(void)
 
 std::unique_ptr<ITensorManager> TensorBuilder::releaseDynamicTensorManager(void)
 {
-  return std::move(_static_tensor_mgr);
+  return std::move(_dynamic_tensor_mgr);
 }
 
 } // namespace cpu


### PR DESCRIPTION
This fixes wrong return value of `releaseDynamicTensorManager()`.

found while working on #56

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>