### PR TITLE
[runtime] Removing const_cast of shape inference

### DIFF
--- a/runtime/onert/core/src/util/ShapeInference.cc
+++ b/runtime/onert/core/src/util/ShapeInference.cc
@@ -210,7 +210,7 @@ void StaticInferer::visit(const ir::operation::Add &op)
   const auto rhs_idx{op.getInputs().at(ir::operation::Add::Input::RHS)};
   const auto &rhs = _operands.at(rhs_idx);
   const auto output_idx = op.getOutputs().at(0);
-  ir::Operand &output = const_cast<ir::Operands &>(_operands).at(output_idx);
+  ir::Operand &output = _operands.at(output_idx);
 
   if (lhs.info().memAllocType() == ir::MemAllocType::DYNAMIC ||
       rhs.info().memAllocType() == ir::MemAllocType::DYNAMIC)


### PR DESCRIPTION
This removes `const_cast` of `Add` operation in shape inference.

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>