### PR TITLE
[Draft][onert] Introduce optimized broadcast add kernel

### DIFF
--- a/compute/cker/include/cker/Shape.h
+++ b/compute/cker/include/cker/Shape.h
@@ -313,6 +313,19 @@ inline int MatchingFlatSizeSkipDim(const Shape &shape, int skip_dim, const Shape
   return MatchingFlatSizeSkipDim(shape, skip_dim, check_shape_1);
 }
 
+inline int MatchingElementsSize(const Shape &shape, const Shape &check_shape_0,
+                                const Shape &check_shape_1)
+{
+  const int size_1 = shape.FlatSize();
+  const int size_2 = check_shape_0.FlatSize();
+  const int size_3 = check_shape_1.FlatSize();
+  assert(size_1 == size_2);
+  assert(size_2 == size_3);
+  UNUSED_RELEASE(size_2);
+  UNUSED_RELEASE(size_3);
+  return size_1;
+}
+
 } // namespace cker
 } // namespace nnfw
 

--- a/compute/cker/include/cker/Types.h
+++ b/compute/cker/include/cker/Types.h
@@ -66,6 +66,15 @@ struct PaddingValues
   int16_t height;
 };
 
+enum class BroadcastableOpCategory : uint8_t
+{
+  kNone,
+  kNonBroadcast,              // Matching input shapes.
+  kFirstInputBroadcastsFast,  // Fivefold nested loops.
+  kSecondInputBroadcastsFast, // Fivefold nested loops.
+  kGenericBroadcast,          // Fall-back.
+};
+
 struct PoolParams
 {
   FusedActivationFunctionType activation;
@@ -150,7 +159,7 @@ struct BinaryArithmeticOpParam
 {
   BinaryArithmeticOpType type;
   // Shape dependent / common to data / op types.
-  // BroadcastableOpCategory broadcast_category;
+  BroadcastableOpCategory broadcast_category;
   // uint8 inference params.
   int32_t input1_offset;
   int32_t input2_offset;
@@ -179,7 +188,7 @@ struct BinaryArithmeticOpParam
   // broadcast_shape[2] = b2 = a2.
   // broadcast_shape[1] = a3; b3 = 1.
   // broadcast_shape[0] = b4 = a4.
-  // int broadcast_shape[5];
+  int broadcast_shape[5] = {};
 };
 
 struct TransposeParams

--- a/compute/cker/include/cker/operation/BinaryArithmeticOps.h
+++ b/compute/cker/include/cker/operation/BinaryArithmeticOps.h
@@ -72,6 +72,122 @@ const std::function<T(const T &, const T &)> GetBinaryArtithmeticFn(BinaryArithm
 }
 } // namespace
 
+// Consolidates dimensions in broadcast inputs, checks for five-fold pattern.
+//
+// For example, if sequence of dimensions of one input is
+// ..., 1, 3, 1, 7, 9, 5,... and the other is ..., 2, 3, 1, 7, 1, 1, ...
+// we can consolidate these as
+// ..., 1, 3*7, 9*5, ... and 2, 3*7, 1.
+//
+// The category is updated in the less-frequent case of shapes that are
+// not suited to a fivefold-loop broadcast.
+//
+// Falls back to generic pattern when it does not know how to process properly.
+//
+// Returns true iff there is some sort of broadcast, which includes five-fold
+// patterns and falling back to generic broadcast.
+inline bool ProcessBroadcastShapes(const Shape &shape0, const Shape &shape1,
+                                   BinaryArithmeticOpParam *params)
+{
+  const int dims_count = std::max(shape0.DimensionsCount(), shape1.DimensionsCount());
+
+  params->broadcast_category = BroadcastableOpCategory::kGenericBroadcast;
+  Shape scalar_shape(dims_count, 1);
+
+  auto extended_shape0 = Shape::ExtendedShape(dims_count, shape0);
+  auto extended_shape1 = Shape::ExtendedShape(dims_count, shape1);
+
+  // Check for "exact" match, implicitly accepting any scalar shapes.
+  if (extended_shape0 == extended_shape1)
+  {
+    params->broadcast_category = BroadcastableOpCategory::kNonBroadcast;
+    return false;
+  }
+
+  for (int i = dims_count - 1; i >= 0; --i)
+  {
+    if (extended_shape0.Dims(i) == extended_shape1.Dims(i))
+    {
+      continue;
+    }
+    else if (extended_shape0.Dims(i) == 1)
+    {
+      params->broadcast_category = BroadcastableOpCategory::kFirstInputBroadcastsFast;
+      break;
+    }
+    else if (extended_shape1.Dims(i) == 1)
+    {
+      params->broadcast_category = BroadcastableOpCategory::kSecondInputBroadcastsFast;
+      break;
+    }
+    else
+    {
+      // This case is erroneous: there is a dimension that does not match and
+      // is not a broadcast from one shape to the other.
+      params->broadcast_category = BroadcastableOpCategory::kGenericBroadcast;
+      return true;
+    }
+  }
+
+  if (params->broadcast_category != BroadcastableOpCategory::kFirstInputBroadcastsFast &&
+      params->broadcast_category != BroadcastableOpCategory::kSecondInputBroadcastsFast)
+  {
+    return false;
+  }
+
+  // From this point it is assumed contractually that corresponding dimensions
+  // in shape0 and shape1 are either (a) equal or (b) one or other equals 1.
+  const bool swap_inputs =
+      params->broadcast_category == BroadcastableOpCategory::kSecondInputBroadcastsFast;
+  const Shape *shape_a = swap_inputs ? &extended_shape1 : &extended_shape0;
+  const Shape *shape_b = swap_inputs ? &extended_shape0 : &extended_shape1;
+
+  int i = dims_count - 1;
+  params->broadcast_shape[0] = 1;
+  params->broadcast_shape[1] = 1;
+  params->broadcast_shape[2] = 1;
+  params->broadcast_shape[3] = 1;
+  params->broadcast_shape[4] = 1;
+  // y_0 is greedy: include dims if both or neither equal 1: in other words,
+  // test for equality rather than (shape_a->Dims(i) != 1).
+  while (i >= 0 && shape_a->Dims(i) == shape_b->Dims(i))
+  {
+    params->broadcast_shape[4] *= shape_b->Dims(i);
+    --i;
+  }
+  // Here either input_a or input_b has dim of 1 (if i >= 0).  If it is input_b
+  // that has the unit dimension, the next two loops are not entered.
+  while (i >= 0 && shape_a->Dims(i) == 1)
+  {
+    params->broadcast_shape[3] *= shape_b->Dims(i);
+    --i;
+  }
+  while (i >= 0 && shape_a->Dims(i) == shape_b->Dims(i))
+  {
+    params->broadcast_shape[2] *= shape_a->Dims(i);
+    --i;
+  }
+  // Here either input_a or input_b has dim of 1 (if i >= 0).
+  while (i >= 0 && shape_b->Dims(i) == 1)
+  {
+    params->broadcast_shape[1] *= shape_a->Dims(i);
+    --i;
+  }
+  while (i >= 0 && shape_a->Dims(i) == shape_b->Dims(i))
+  {
+    params->broadcast_shape[0] *= shape_b->Dims(i);
+    --i;
+  }
+
+  // Rarer case is when the broadcast dimensions cannot be handled by a fivefold
+  // loop.
+  if (i >= 0)
+  {
+    params->broadcast_category = BroadcastableOpCategory::kGenericBroadcast;
+  }
+  return true;
+}
+
 template <typename T>
 inline void BinaryArithmeticOp(const BinaryArithmeticOpParam &params, const Shape &input1_shape,
                                const T *input1_data, const Shape &input2_shape,
@@ -114,77 +230,40 @@ inline void BinaryArithmeticOp(const BinaryArithmeticOpParam &params, const Shap
 }
 
 template <typename T>
-inline void BroadcastBinaryArithmeticOpSlow(const BinaryArithmeticOpParam &params,
-                                            const Shape &input1_shape, const T *input1_data,
-                                            const Shape &input2_shape, const T *input2_data,
-                                            const Shape &output_shape, T *output_data)
+inline void BroadcastBinaryArithmeticOp(BinaryArithmeticOpParam &params, const Shape &input1_shape,
+                                        const T *input1_data, const Shape &input2_shape,
+                                        const T *input2_data, const Shape &output_shape,
+                                        T *output_data)
 {
-  NdArrayDesc<4> desc1;
-  NdArrayDesc<4> desc2;
-  NdArrayDescsForElementwiseBroadcast(input1_shape, input2_shape, &desc1, &desc2);
-  const Shape extended_output_shape = Shape::ExtendedShape(4, output_shape);
-
-  const auto fn = GetBinaryArtithmeticFn<T>(params.type);
-
-  // Comment from tensorflow lite:
-  //
-  // In Tensorflow, the dimensions are canonically named (batch_number, row,
-  // col, channel), with extents (batches, height, width, depth), with the
-  // trailing dimension changing most rapidly (channels has the smallest stride,
-  // typically 1 element).
-  //
-  // In generated C code, we store arrays with the dimensions reversed. The
-  // first dimension has smallest stride.
-  //
-  // We name our variables by their Tensorflow convention, but generate C code
-  // nesting loops such that the innermost loop has the smallest stride for the
-  // best cache behavior.
-  for (int b = 0; b < extended_output_shape.Dims(0); ++b)
-  {
-    for (int y = 0; y < extended_output_shape.Dims(1); ++y)
-    {
-      for (int x = 0; x < extended_output_shape.Dims(2); ++x)
-      {
-        for (int c = 0; c < extended_output_shape.Dims(3); ++c)
-        {
-          output_data[Offset(extended_output_shape, b, y, x, c)] = ActivationFunctionWithMinMax(
-              fn(input1_data[SubscriptToIndex(desc1, b, y, x, c)],
-                 input2_data[SubscriptToIndex(desc2, b, y, x, c)]),
-              params.quantized_activation_min, params.quantized_activation_max);
-        }
-      }
-    }
-  }
+  reference::BroadcastBinaryArithmeticOpSlow(params, input1_shape, input1_data, input2_shape,
+                                             input2_data, output_shape, output_data,
+                                             GetBinaryArtithmeticFn<T>(params.type));
 }
 
 template <>
-inline void BroadcastBinaryArithmeticOpSlow(const BinaryArithmeticOpParam &params,
-                                            const Shape &input1_shape, const float *input1_data,
-                                            const Shape &input2_shape, const float *input2_data,
-                                            const Shape &output_shape, float *output_data)
+inline void BroadcastBinaryArithmeticOp(BinaryArithmeticOpParam &params, const Shape &input1_shape,
+                                        const float *input1_data, const Shape &input2_shape,
+                                        const float *input2_data, const Shape &output_shape,
+                                        float *output_data)
 {
-  NdArrayDesc<4> desc1;
-  NdArrayDesc<4> desc2;
-  NdArrayDescsForElementwiseBroadcast(input1_shape, input2_shape, &desc1, &desc2);
-  const Shape extended_output_shape = Shape::ExtendedShape(4, output_shape);
-
-  const auto fn = GetBinaryArtithmeticFn<float>(params.type);
-
-  for (int b = 0; b < extended_output_shape.Dims(0); ++b)
+  // Supported type is only float now
+  switch (params.type)
   {
-    for (int y = 0; y < extended_output_shape.Dims(1); ++y)
-    {
-      for (int x = 0; x < extended_output_shape.Dims(2); ++x)
-      {
-        for (int c = 0; c < extended_output_shape.Dims(3); ++c)
-        {
-          output_data[Offset(extended_output_shape, b, y, x, c)] = ActivationFunctionWithMinMax(
-              fn(input1_data[SubscriptToIndex(desc1, b, y, x, c)],
-                 input2_data[SubscriptToIndex(desc2, b, y, x, c)]),
-              params.float_activation_min, params.float_activation_max);
-        }
-      }
-    }
+    case nnfw::cker::BinaryArithmeticOpType::ADD:
+      optimized::BroadcastAddDispatch(params, input1_shape, input1_data, input2_shape, input2_data,
+                                      output_shape, output_data);
+      break;
+    case nnfw::cker::BinaryArithmeticOpType::MUL:
+    case nnfw::cker::BinaryArithmeticOpType::SUB:
+    case nnfw::cker::BinaryArithmeticOpType::DIV:
+    case nnfw::cker::BinaryArithmeticOpType::POW:
+      reference::BroadcastBinaryArithmeticOpSlow(params, input1_shape, input1_data, input2_shape,
+                                                 input2_data, output_shape, output_data,
+                                                 GetBinaryArtithmeticFn<float>(params.type));
+      break;
+    default:
+      assert(false);
+      break;
   }
 }
 

--- a/compute/cker/include/cker/operation/optimized/BinaryArithmeticOps.h
+++ b/compute/cker/include/cker/operation/optimized/BinaryArithmeticOps.h
@@ -18,7 +18,9 @@
 #ifndef __NNFW_CKER_OPTIMIZED_BINARYARITHMETICOPS_H__
 #define __NNFW_CKER_OPTIMIZED_BINARYARITHMETICOPS_H__
 
+#include <functional>
 #include "cker/neon/neon_check.h"
+#include "cker/operation/reference/BinaryArithmeticOps.h"
 #include "cker/Shape.h"
 #include "cker/Types.h"
 #include "cker/Utils.h"
@@ -30,12 +32,11 @@ namespace cker
 namespace optimized
 {
 
-inline void Add(const BinaryArithmeticOpParam &params, const Shape &input1_shape,
-                const float *input1_data, const Shape &input2_shape, const float *input2_data,
-                const Shape &output_shape, float *output_data)
+inline void AddElementwise(int size, const BinaryArithmeticOpParam &params,
+                           const float *input1_data, const float *input2_data, float *output_data)
 {
   int i = 0;
-  const int size = MatchingFlatSize(input1_shape, input2_shape, output_shape);
+
 #ifdef USE_NEON
   const auto activation_min = vdupq_n_f32(params.float_activation_min);
   const auto activation_max = vdupq_n_f32(params.float_activation_max);
@@ -83,6 +84,151 @@ inline void Add(const BinaryArithmeticOpParam &params, const Shape &input1_shape
     output_data[i] =
         ActivationFunctionWithMinMax(x, params.float_activation_min, params.float_activation_max);
   }
+}
+
+inline void Add(const BinaryArithmeticOpParam &params, const Shape &input1_shape,
+                const float *input1_data, const Shape &input2_shape, const float *input2_data,
+                const Shape &output_shape, float *output_data)
+{
+  const int flat_size = MatchingElementsSize(input1_shape, input2_shape, output_shape);
+  AddElementwise(flat_size, params, input1_data, input2_data, output_data);
+}
+
+// Scalar-broadcast add that can be used for inner loop of more general
+// broadcast add, so that, for example, scalar-broadcast with batch will still
+// be fast.
+inline void AddScalarBroadcast(int size, const BinaryArithmeticOpParam &params,
+                               float broadcast_value, const float *input2_data, float *output_data)
+{
+  int i = 0;
+#ifdef USE_NEON
+  const float32x4_t output_activation_min_vector = vdupq_n_f32(params.float_activation_min);
+  const float32x4_t output_activation_max_vector = vdupq_n_f32(params.float_activation_max);
+  const float32x4_t broadcast_value_dup = vdupq_n_f32(broadcast_value);
+  for (; i <= size - 4; i += 4)
+  {
+    const float32x4_t input2_val_original = vld1q_f32(input2_data + i);
+
+    const float32x4_t output = vaddq_f32(input2_val_original, broadcast_value_dup);
+
+    const float32x4_t clamped =
+        vmaxq_f32(output_activation_min_vector, vminq_f32(output_activation_max_vector, output));
+    vst1q_f32(output_data + i, clamped);
+  }
+#endif // NEON
+
+  for (; i < size; ++i)
+  {
+    auto x = broadcast_value + input2_data[i];
+    output_data[i] =
+        ActivationFunctionWithMinMax(x, params.float_activation_min, params.float_activation_max);
+  }
+}
+
+inline void BroadcastAddFivefold(const BinaryArithmeticOpParam &params,
+                                 const Shape & /* unswitched_input1_shape */,
+                                 const float *unswitched_input1_data,
+                                 const Shape & /* unswitched_input2_shape */,
+                                 const float *unswitched_input2_data,
+                                 const Shape & /* output_shape */, float *output_data)
+{
+  const bool use_unswitched =
+      params.broadcast_category == BroadcastableOpCategory::kFirstInputBroadcastsFast;
+
+  const float *input1_data = use_unswitched ? unswitched_input1_data : unswitched_input2_data;
+  const float *input2_data = use_unswitched ? unswitched_input2_data : unswitched_input1_data;
+
+  // Fivefold nested loops. The second input resets its position for each
+  // iteration of the second loop. The first input resets its position at the
+  // beginning of the fourth loop. The innermost loop is an elementwise add of
+  // sections of the arrays.
+  float *output_data_ptr = output_data;
+  const float *input1_data_ptr = input1_data;
+  const float *input2_data_reset = input2_data;
+  // In the fivefold pattern, y0, y2 and y4 are not broadcast, and so shared
+  // between input shapes. y3 for input 1 is always broadcast, and so the
+  // dimension there is 1, whereas optionally y1 might be broadcast for input 2.
+  // Put another way,
+  // input1.shape.FlatSize = y0 * y1 * y2 * y4,
+  // input2.shape.FlatSize = y0 * y2 * y3 * y4.
+  int y0 = params.broadcast_shape[0];
+  int y1 = params.broadcast_shape[1];
+  int y2 = params.broadcast_shape[2];
+  int y3 = params.broadcast_shape[3];
+  int y4 = params.broadcast_shape[4];
+  if (y4 > 1)
+  {
+    // General fivefold pattern, with y4 > 1 so there is a non-broadcast inner
+    // dimension.
+    for (int i0 = 0; i0 < y0; ++i0)
+    {
+      const float *input2_data_ptr = nullptr;
+      for (int i1 = 0; i1 < y1; ++i1)
+      {
+        input2_data_ptr = input2_data_reset;
+        for (int i2 = 0; i2 < y2; ++i2)
+        {
+          for (int i3 = 0; i3 < y3; ++i3)
+          {
+            AddElementwise(y4, params, input1_data_ptr, input2_data_ptr, output_data_ptr);
+            input2_data_ptr += y4;
+            output_data_ptr += y4;
+          }
+          // We have broadcast y4 of input1 data y3 times, and now move on.
+          input1_data_ptr += y4;
+        }
+      }
+      // We have broadcast y2*y3*y4 of input2 data y1 times, and now move on.
+      input2_data_reset = input2_data_ptr;
+    }
+  }
+  else
+  {
+    // Special case of y4 == 1, in which the innermost loop is a single element
+    // and can be combined with the next (y3) as an inner broadcast.
+    //
+    // Note that this handles the case of pure scalar broadcast when
+    // y0 == y1 == y2 == 1. With low overhead it handles cases such as scalar
+    // broadcast with batch (as y2 > 1).
+    //
+    // NOTE The process is the same as the above general case except simplified
+    // for y4 == 1 and the loop over y3 is contained within the
+    // AddScalarBroadcast function.
+    for (int i0 = 0; i0 < y0; ++i0)
+    {
+      const float *input2_data_ptr = nullptr;
+      for (int i1 = 0; i1 < y1; ++i1)
+      {
+        input2_data_ptr = input2_data_reset;
+        for (int i2 = 0; i2 < y2; ++i2)
+        {
+          AddScalarBroadcast(y3, params, *input1_data_ptr, input2_data_ptr, output_data_ptr);
+          input2_data_ptr += y3;
+          output_data_ptr += y3;
+          input1_data_ptr += 1;
+        }
+      }
+      input2_data_reset = input2_data_ptr;
+    }
+  }
+}
+
+inline void BroadcastAddDispatch(const BinaryArithmeticOpParam &params, const Shape &input1_shape,
+                                 const float *input1_data, const Shape &input2_shape,
+                                 const float *input2_data, const Shape &output_shape,
+                                 float *output_data)
+{
+  if (params.broadcast_category == BroadcastableOpCategory::kGenericBroadcast)
+  {
+    // TODO: Use GetBinaryArithmeticFn
+    const std::function<float(const float &, const float &)> fn =
+        [](const float &a, const float &b) -> float { return a + b; };
+    reference::BroadcastBinaryArithmeticOpSlow(params, input1_shape, input1_data, input2_shape,
+                                               input2_data, output_shape, output_data, fn);
+    return;
+  }
+  BroadcastAddFivefold(params, input1_shape, input1_data, input2_shape, input2_data, output_shape,
+                       output_data);
 }
 
 inline void Sub(const BinaryArithmeticOpParam &params, const Shape &input1_shape,

--- a/compute/cker/include/cker/operation/optimized/BinaryArithmeticOps.h
+++ b/compute/cker/include/cker/operation/optimized/BinaryArithmeticOps.h
@@ -236,7 +236,7 @@ inline void Sub(const BinaryArithmeticOpParam &params, const Shape &input1_shape
                 const Shape &output_shape, float *output_data)
 {
   int i = 0;
-  const int size = MatchingFlatSize(input1_shape, input2_shape, output_shape);
+  const int size = MatchingElementsSize(input1_shape, input2_shape, output_shape);
 #ifdef USE_NEON
   const auto activation_min = vdupq_n_f32(params.float_activation_min);
   const auto activation_max = vdupq_n_f32(params.float_activation_max);
@@ -291,7 +291,7 @@ inline void Mul(const BinaryArithmeticOpParam &params, const Shape &input1_shape
                 const Shape &output_shape, float *output_data)
 {
   int i = 0;
-  const int size = MatchingFlatSize(input1_shape, input2_shape, output_shape);
+  const int size = MatchingElementsSize(input1_shape, input2_shape, output_shape);
 #ifdef USE_NEON
   const auto activation_min = vdupq_n_f32(params.float_activation_min);
   const auto activation_max = vdupq_n_f32(params.float_activation_max);

--- a/runtime/onert/backend/cpu/kernel/AddLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/AddLayer.cc
@@ -36,13 +36,14 @@ void AddLayer::addFloat32()
   op_params.float_activation_max = output_activation_max;
   op_params.float_activation_min = output_activation_min;
 
-  if (!HaveSameShapes(_lhs, _rhs))
+  const bool need_broadcast = nnfw::cker::ProcessBroadcastShapes(
+      convertTensorToCkerShape(_lhs), convertTensorToCkerShape(_rhs), &op_params);
+  if (need_broadcast)
   {
-    nnfw::cker::BroadcastBinaryArithmeticOpSlow(
-        op_params, convertToExtendedCkerShape(_lhs),
-        reinterpret_cast<const float *>(_lhs->buffer()), convertToExtendedCkerShape(_rhs),
-        reinterpret_cast<const float *>(_rhs->buffer()), convertToExtendedCkerShape(_output),
-        reinterpret_cast<float *>(_output->buffer()));
+    nnfw::cker::BroadcastBinaryArithmeticOp(
+        op_params, convertTensorToCkerShape(_lhs), reinterpret_cast<const float *>(_lhs->buffer()),
+        convertTensorToCkerShape(_rhs), reinterpret_cast<const float *>(_rhs->buffer()),
+        convertTensorToCkerShape(_output), reinterpret_cast<float *>(_output->buffer()));
     return;
   }
 

--- a/runtime/onert/backend/cpu/kernel/DivLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/DivLayer.cc
@@ -36,9 +36,11 @@ void DivLayer::divFloat32()
   op_params.float_activation_max = output_activation_max;
   op_params.float_activation_min = output_activation_min;
 
-  if (!HaveSameShapes(_lhs, _rhs))
+  const bool need_broadcast = nnfw::cker::ProcessBroadcastShapes(
+      convertTensorToCkerShape(_lhs), convertTensorToCkerShape(_rhs), &op_params);
+  if (need_broadcast)
   {
-    nnfw::cker::BroadcastBinaryArithmeticOpSlow(
+    nnfw::cker::BroadcastBinaryArithmeticOp(
         op_params, convertToExtendedCkerShape(_lhs),
         reinterpret_cast<const float *>(_lhs->buffer()), convertToExtendedCkerShape(_rhs),
         reinterpret_cast<const float *>(_rhs->buffer()), convertToExtendedCkerShape(_output),

--- a/runtime/onert/backend/cpu/kernel/MulLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/MulLayer.cc
@@ -36,9 +36,11 @@ void MulLayer::mulFloat32()
   op_params.float_activation_max = output_activation_max;
   op_params.float_activation_min = output_activation_min;
 
-  if (!HaveSameShapes(_lhs, _rhs))
+  const bool need_broadcast = nnfw::cker::ProcessBroadcastShapes(
+      convertTensorToCkerShape(_lhs), convertTensorToCkerShape(_rhs), &op_params);
+  if (need_broadcast)
   {
-    nnfw::cker::BroadcastBinaryArithmeticOpSlow(
+    nnfw::cker::BroadcastBinaryArithmeticOp(
         op_params, convertToExtendedCkerShape(_lhs),
         reinterpret_cast<const float *>(_lhs->buffer()), convertToExtendedCkerShape(_rhs),
         reinterpret_cast<const float *>(_rhs->buffer()), convertToExtendedCkerShape(_output),

--- a/runtime/onert/backend/cpu/kernel/PowLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/PowLayer.cc
@@ -39,7 +39,7 @@ void PowLayer::powFloat32()
 
   if (!HaveSameShapes(_lhs, _rhs))
   {
-    nnfw::cker::BroadcastBinaryArithmeticOpSlow(
+    nnfw::cker::BroadcastBinaryArithmeticOp(
         op_params, convertToExtendedCkerShape(_lhs),
         reinterpret_cast<const float *>(_lhs->buffer()), convertToExtendedCkerShape(_rhs),
         reinterpret_cast<const float *>(_rhs->buffer()), convertToExtendedCkerShape(_output),

--- a/runtime/onert/backend/cpu/kernel/SubLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/SubLayer.cc
@@ -36,9 +36,11 @@ void SubLayer::subFloat32()
   op_params.float_activation_max = output_activation_max;
   op_params.float_activation_min = output_activation_min;
 
-  if (!HaveSameShapes(_lhs, _rhs))
+  const bool need_broadcast = nnfw::cker::ProcessBroadcastShapes(
+      convertTensorToCkerShape(_lhs), convertTensorToCkerShape(_rhs), &op_params);
+  if (need_broadcast)
   {
-    nnfw::cker::BroadcastBinaryArithmeticOpSlow(
+    nnfw::cker::BroadcastBinaryArithmeticOp(
         op_params, convertToExtendedCkerShape(_lhs),
         reinterpret_cast<const float *>(_lhs->buffer()), convertToExtendedCkerShape(_rhs),
         reinterpret_cast<const float *>(_rhs->buffer()), convertToExtendedCkerShape(_output),

--- a/runtime/onert/core/src/interp/operations/BinaryArithmeticOps.cc
+++ b/runtime/onert/core/src/interp/operations/BinaryArithmeticOps.cc
@@ -123,11 +123,15 @@ void invoke(const ITensor *lhs_tensor, const ITensor *rhs_tensor, const ITensor 
                         : ((op_type == OpType::SUB) ? nnfw::cker::BinaryArithmeticOpType::SUB
                                                     : nnfw::cker::BinaryArithmeticOpType::MUL);
 
-  if (lhs_tensor->tensorInfo().shape() != rhs_tensor->tensorInfo().shape())
+  const bool need_broadcast = nnfw::cker::ProcessBroadcastShapes(
+      convertShape(lhs_tensor->tensorInfo().shape()),
+      convertShape(rhs_tensor->tensorInfo().shape()), &cker_param);
+
+  if (need_broadcast)
   {
-    const auto lhs_shape = convertExtendShape(lhs_tensor->tensorInfo().shape());
-    const auto rhs_shape = convertExtendShape(rhs_tensor->tensorInfo().shape());
-    const auto out_shape = convertExtendShape(out_tensor->tensorInfo().shape());
+    const auto lhs_shape = convertShape(lhs_tensor->tensorInfo().shape());
+    const auto rhs_shape = convertShape(rhs_tensor->tensorInfo().shape());
+    const auto out_shape = convertShape(out_tensor->tensorInfo().shape());
     nnfw::cker::BroadcastBinaryArithmeticOp(cker_param, lhs_shape, lhs_ptr, rhs_shape, rhs_ptr,
                                             out_shape, out_ptr);
     return;

--- a/runtime/onert/core/src/interp/operations/BinaryArithmeticOps.cc
+++ b/runtime/onert/core/src/interp/operations/BinaryArithmeticOps.cc
@@ -128,8 +128,8 @@ void invoke(const ITensor *lhs_tensor, const ITensor *rhs_tensor, const ITensor 
     const auto lhs_shape = convertExtendShape(lhs_tensor->tensorInfo().shape());
     const auto rhs_shape = convertExtendShape(rhs_tensor->tensorInfo().shape());
     const auto out_shape = convertExtendShape(out_tensor->tensorInfo().shape());
-    nnfw::cker::BroadcastBinaryArithmeticOpSlow(cker_param, lhs_shape, lhs_ptr, rhs_shape, rhs_ptr,
-                                                out_shape, out_ptr);
+    nnfw::cker::BroadcastBinaryArithmeticOp(cker_param, lhs_shape, lhs_ptr, rhs_shape, rhs_ptr,
+                                            out_shape, out_ptr);
     return;
   }
 

--- a/runtime/onert/core/src/interp/operations/OperationUtil.h
+++ b/runtime/onert/core/src/interp/operations/OperationUtil.h
@@ -34,18 +34,11 @@ inline nnfw::cker::Shape convertShape(const ir::Shape &shape)
   auto dimensions = std::vector<uint32_t>(shape.dims().begin(), shape.dims().end());
 
   std::vector<int32_t> raw_shape;
-  raw_shape.resize(4);
+  raw_shape.resize(dimensions.size());
 
-  for (uint32_t i = 0; i < 4; ++i)
+  for (uint32_t i = 0; i < dimensions.size(); ++i)
   {
-    if (i >= dimensions.size())
-    {
-      raw_shape[i] = 1;
-    }
-    else
-    {
-      raw_shape[i] = dimensions[i];
-    }
+    raw_shape[i] = dimensions[i];
   }
 
   return nnfw::cker::GetShape(raw_shape);


### PR DESCRIPTION
- This PR introduces optimized broadcast add kernel
- Tensors with different shape may use element-wise kernel
  - ex) ADD([1,1536], [1536])

ONE-DCO-1.0-Signed-off-by: JiHwan Yeo <jihwan.yeo@samsung.com>

---

Related issue : #473