### PR TITLE
[onert] strided_slice has 4 inputs, not 3 inputs.

### DIFF
--- a/runtime/onert/core/src/ir/operation/StridedSlice.cc
+++ b/runtime/onert/core/src/ir/operation/StridedSlice.cc
@@ -31,7 +31,7 @@ void StridedSlice::accept(OperationVisitor &v) const { v.visit(*this); }
 
 StridedSlice::StridedSlice(const OperandIndexSequence &inputs, const OperandIndexSequence &outputs,
                            const Param &param)
-    : Operation{OperandConstraint::createExact(3u), inputs, outputs}, _param{param}
+    : Operation{OperandConstraint::createExact(4u), inputs, outputs}, _param{param}
 {
 }
 


### PR DESCRIPTION
It fixes the number of inputs from 3 to 4.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee sg5.lee@samsung.com