### PR TITLE
[oneapi] Test: Add negative tests

### DIFF
--- a/tests/nnfw_api/src/ValidationTestAddModelLoaded.cc
+++ b/tests/nnfw_api/src/ValidationTestAddModelLoaded.cc
@@ -24,4 +24,9 @@ TEST_F(ValidationTestAddModelLoaded, prepare_001)
   ASSERT_EQ(nnfw_prepare(_session), NNFW_STATUS_NO_ERROR);
 }
 
+TEST_F(ValidationTestAddModelLoaded, neg_run_001)
+{
+  ASSERT_EQ(nnfw_run(_session), NNFW_STATUS_ERROR);
+}
+
 TEST_F(ValidationTest, neg_prepare_001) { ASSERT_EQ(nnfw_prepare(nullptr), NNFW_STATUS_ERROR); }

--- a/tests/nnfw_api/src/ValidationTestSessionCreated.cc
+++ b/tests/nnfw_api/src/ValidationTestSessionCreated.cc
@@ -45,3 +45,9 @@ TEST_F(ValidationTestSessionCreated, neg_prepare_001)
   // nnfw_load_model_from_file was not called
   ASSERT_EQ(nnfw_prepare(_session), NNFW_STATUS_ERROR);
 }
+
+TEST_F(ValidationTestSessionCreated, neg_run_001)
+{
+  // nnfw_load_model_from_file and nnfw_prepare was not called
+  ASSERT_EQ(nnfw_run(_session), NNFW_STATUS_ERROR);
+}


### PR DESCRIPTION
Add 2 negative tests - call `nnfw_run` before `nnfw_prepare`

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>