### PR TITLE
[onert] Move calling StaticInferer into LoweredGraph

### DIFF
--- a/runtime/onert/core/src/compiler/ExecutorFactory.cc
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.cc
@@ -32,7 +32,6 @@
 #include "backend/ITensorRegister.h"
 #include <memory>
 #include "compiler/CachedDataDeleter.h"
-#include "util/ShapeInference.h"
 
 namespace onert
 {
@@ -156,13 +155,6 @@ ExecutorFactory::createLinearExecutor(std::unique_ptr<ir::LoweredGraph> lowered_
 
   // linearize
   assert(!lowered_graph->graph().isBuildingPhase());
-
-  // Shape inference.
-  {
-    shape_inference::StaticInferer inferer(lowered_graph->graph().operands());
-    lowered_graph->op_seqs().iterate(
-        [&](const ir::OpSequenceIndex &, const ir::OpSequence &op_seq) { inferer.infer(op_seq); });
-  }
 
   for (auto &pair : backend_contexts)
   {

--- a/runtime/onert/core/src/ir/LoweredGraph.cc
+++ b/runtime/onert/core/src/ir/LoweredGraph.cc
@@ -29,6 +29,7 @@
 #include "compiler/BackendResolver.h"
 #include "compiler/ManualScheduler.h"
 #include "compiler/HEScheduler.h"
+#include "util/ShapeInference.h"
 
 namespace onert
 {
@@ -114,6 +115,13 @@ LoweredGraph::LoweredGraph(const Graph &graph, const compiler::CompilerOptions &
 
     // TODO merge perm op_seqs if possible
     _op_seqs.dump("merged and sorted operations with permutation");
+  }
+
+  // Shape inference.
+  {
+    shape_inference::StaticInferer inferer(_graph.operands());
+    _op_seqs.iterate(
+        [&](const ir::OpSequenceIndex &, const ir::OpSequence &op_seq) { inferer.infer(op_seq); });
   }
 
   // Graph verifications


### PR DESCRIPTION
This commit moves calling StaticInferer into LoweredGraph.

Signed-off-by: ragmani <ragmani0216@gmail.com>