### PR TITLE
[loco] Introduce must()

### DIFF
--- a/compiler/loco/include/loco/IR/Node.h
+++ b/compiler/loco/include/loco/IR/Node.h
@@ -146,12 +146,12 @@ Subst<SubstQualifier::Default> replace(Node *node);
 /**
  * @brief A helper dynamic_cast that throws when failed
  */
-template <typename T> T must(Node *node)
+template <typename T> T must_cast(Node *node)
 {
   auto cast_node = dynamic_cast<T>(node);
   if (cast_node == nullptr)
   {
-    std::string msg = "loco::must() failed to cast: ";
+    std::string msg = "loco::must_cast() failed to cast: ";
     msg += typeid(T).name();
     throw std::invalid_argument(msg.c_str());
   }

--- a/compiler/loco/src/IR/MockupNode.h
+++ b/compiler/loco/src/IR/MockupNode.h
@@ -63,15 +63,9 @@ public:
   const loco::Dialect *dialect(void) const final { return MockDialect::get(); }
   uint32_t opnum(void) const final { return 1; }
 
-  uint32_t arity(void) const final { return 1; }
-  Node *arg(uint32_t N) const final { return _arg.node(); }
-  void drop(void) final { _arg.node(nullptr); }
-
-  Node *in(void)const { return _arg.node(); }
-  void in(Node *node) { _arg.node(node); }
-
-private:
-  loco::Use _arg{this};
+  uint32_t arity(void) const final { return 0; }
+  Node *arg(uint32_t) const final { return nullptr; }
+  void drop(void) final {}
 };
 
 } // namespace

--- a/compiler/loco/src/IR/Node.test.cpp
+++ b/compiler/loco/src/IR/Node.test.cpp
@@ -106,5 +106,5 @@ TEST(NodeTest, cast_with_must_NEG)
   Mockup2Node mockupnode;
   loco::Node *node = &mockupnode;
 
-  ASSERT_THROW(loco::must<MockupNode *>(node), std::invalid_argument);
+  ASSERT_THROW(loco::must_cast<MockupNode *>(node), std::invalid_argument);
 }


### PR DESCRIPTION
This will introduce must() method that provides as a helper to dynamic_cast with throw when failed

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>