### PR TITLE
[luci] Use must_cast for copy_shape_dtype

### DIFF
--- a/compiler/luci/export/src/TypeBridge.cpp
+++ b/compiler/luci/export/src/TypeBridge.cpp
@@ -69,8 +69,7 @@ void copy_shape_dtype(loco::Graph *graph)
   auto nodes = graph->nodes();
   for (uint32_t n = 0; n < nodes->size(); ++n)
   {
-    auto node = dynamic_cast<luci::CircleNode *>(nodes->at(n));
-    assert(node != nullptr);
+    auto node = loco::must_cast<luci::CircleNode *>(nodes->at(n));
 
     CopySelector cs;
     if (node->accept(&cs))


### PR DESCRIPTION
This will fix copy_shape_dtype() to use must_cast() for static analysis reports

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>