### PR TITLE
[runtime] modify wrong operation name of log message

### DIFF
--- a/runtime/onert/frontend/base_loader/include/base_loader.h
+++ b/runtime/onert/frontend/base_loader/include/base_loader.h
@@ -772,7 +772,7 @@ void BaseLoader<LoaderDomain, SpecificLoader>::loadReduceMax(const Operator *op,
 
   // FIXME Handle ReducerOptions.
   if (!subg.operands().at(axes).isConstant())
-    throw std::runtime_error("ReduceSum: non-constant 'axes' is not supported.");
+    throw std::runtime_error("ReduceMax: non-constant 'axes' is not supported.");
 
   ir::operation::ReduceMax::Param param;
   param.axes = subg.operands().at(axes).template asVector<int>();


### PR DESCRIPTION
I found wrong operation name in log message and modified it

Signed-off-by: sungho22.lee <sungho22.lee@samsung.com>