### PR TITLE
[luci] Shape, dtype inf for Split, SplitV

### DIFF
--- a/compiler/luci/service/src/CircleTypeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleTypeInferenceRule.cpp
@@ -186,6 +186,16 @@ struct TypeInferenceAlgorithm final : public luci::CircleNodeVisitor<loco::DataT
     return loco::dtype_get(node->input());
   }
 
+  loco::DataType visit(const luci::CircleSplit *node) final
+  {
+    return loco::dtype_get(node->input());
+  }
+
+  loco::DataType visit(const luci::CircleSplitV *node) final
+  {
+    return loco::dtype_get(node->input());
+  }
+
   loco::DataType visit(const luci::CircleSqrt *node) final { return loco::dtype_get(node->x()); }
 
   loco::DataType visit(const luci::CircleSquaredDifference *node) final
@@ -295,6 +305,16 @@ struct TypeInferenceAlgorithm final : public luci::CircleNodeVisitor<loco::DataT
     assert(then_graph_output->dtype() == else_graph_output->dtype());
 
     return then_graph_output->dtype();
+  }
+
+  loco::DataType visit(const luci::CircleSplitOut *node) final
+  {
+    return loco::dtype_get(node->input());
+  }
+
+  loco::DataType visit(const luci::CircleSplitVOut *node) final
+  {
+    return loco::dtype_get(node->input());
   }
 
   loco::DataType visit(const luci::CircleUnpackOut *node) final


### PR DESCRIPTION
This will enable shape and dtype inference for Split, SplitV Op

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>