### PR TITLE
[onert] Use backend interface to check fp16 support

### DIFF
--- a/runtime/onert/backend/acl_cl/Config.h
+++ b/runtime/onert/backend/acl_cl/Config.h
@@ -36,6 +36,7 @@ public:
   bool supportPermutation() override { return true; }
   ir::Layout supportLayout(const ir::Operation &node, ir::Layout frontend_layout) override;
   bool supportDynamicTensor() override { return false; }
+  bool supportFP16() override { return true; }
 
   std::unique_ptr<util::ITimer> timer() override { return std::make_unique<CLTimer>(); }
 };

--- a/runtime/onert/backend/acl_neon/Config.h
+++ b/runtime/onert/backend/acl_neon/Config.h
@@ -36,6 +36,7 @@ public:
   ir::Layout supportLayout(const ir::Operation &node, ir::Layout frontend_layout) override;
   bool supportPermutation() override { return true; }
   bool supportDynamicTensor() override { return false; }
+  bool supportFP16() override { return false; }
 
   std::unique_ptr<util::ITimer> timer() override { return std::make_unique<util::CPUTimer>(); }
 };

--- a/runtime/onert/backend/cpu/Config.h
+++ b/runtime/onert/backend/cpu/Config.h
@@ -36,6 +36,7 @@ public:
   ir::Layout supportLayout(const ir::Operation &node, ir::Layout frontend_layout) override;
   bool supportPermutation() override { return true; }
   bool supportDynamicTensor() override { return true; }
+  bool supportFP16() override { return false; }
 
   std::unique_ptr<util::ITimer> timer() override { return std::make_unique<util::CPUTimer>(); }
 };

--- a/runtime/onert/core/include/backend/IConfig.h
+++ b/runtime/onert/core/include/backend/IConfig.h
@@ -40,6 +40,7 @@ struct IConfig
   virtual ir::Layout supportLayout(const ir::Operation &node, ir::Layout frontend_layout) = 0;
 
   virtual bool supportDynamicTensor() = 0;
+  virtual bool supportFP16() = 0;
 
   // Timer is used for backend profiling. In case of default (nullptr) timer profiler won't work.
   virtual std::unique_ptr<util::ITimer> timer() { return nullptr; }

--- a/runtime/onert/core/src/backend/controlflow/Config.h
+++ b/runtime/onert/core/src/backend/controlflow/Config.h
@@ -41,6 +41,7 @@ public:
     // TODO Make this backend to support dynamic tensor or not to build non-constant tensor
     return false;
   }
+  bool supportFP16() override { return false; }
 
   std::unique_ptr<util::ITimer> timer() override { return std::make_unique<util::CPUTimer>(); }
 };

--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -206,7 +206,15 @@ void Compiler::compile(void)
     // Lower: Assign backend
     lowered_subgs[index] = std::make_unique<ir::LoweredGraph>(graph, _options);
 
-    if (_options.fp16_enable)
+    // Check backend(s) for subgraph support FP16
+    bool backends_support_fp16 = true;
+    auto &contexts = (*lowered_subgs[index]).backend_contexts();
+    for (auto it = contexts.begin(); it != contexts.end(); it++)
+    {
+      backends_support_fp16 &= it->first->config()->supportFP16();
+    }
+
+    if (_options.fp16_enable && backends_support_fp16)
     {
       // NOTE: the only acl_cl backend enables fp16 mode
       Fp32ToFp16Converter(*lowered_subgs[index]).run();

--- a/runtime/onert/test/core/compiler/Scheduler.cc
+++ b/runtime/onert/test/core/compiler/Scheduler.cc
@@ -59,6 +59,7 @@ struct MockConfigCPU : public IConfig
   bool supportPermutation() override { return false; }
   Layout supportLayout(const Operation &, Layout) { return Layout::UNKNOWN; }
   bool supportDynamicTensor() override { return false; }
+  bool supportFP16() override { return false; }
 };
 
 struct MockBackendCPU : public Backend
@@ -79,6 +80,7 @@ struct MockConfigGPU : public IConfig
   bool supportPermutation() override { return false; }
   ir::Layout supportLayout(const ir::Operation &, ir::Layout) { return ir::Layout::UNKNOWN; }
   bool supportDynamicTensor() override { return false; }
+  bool supportFP16() override { return false; }
 };
 
 struct MockBackendGPU : public Backend
@@ -99,6 +101,7 @@ struct MockConfigNPU : public IConfig
   bool supportPermutation() override { return false; }
   ir::Layout supportLayout(const ir::Operation &, ir::Layout) { return ir::Layout::UNKNOWN; }
   bool supportDynamicTensor() override { return false; }
+  bool supportFP16() override { return false; }
 };
 
 struct MockBackendNPU : public Backend

--- a/runtime/onert/test/core/exec/ExecTime.test.cc
+++ b/runtime/onert/test/core/exec/ExecTime.test.cc
@@ -33,6 +33,7 @@ struct MockConfig : public IConfig
   bool supportPermutation() override { return false; }
   ir::Layout supportLayout(const ir::Operation &, ir::Layout) { return ir::Layout::UNKNOWN; }
   bool supportDynamicTensor() override { return false; }
+  bool supportFP16() override { return false; }
 };
 
 struct MockBackend : public ::onert::backend::Backend


### PR DESCRIPTION
- Introduce backend fp16 support check interface method
- Use Fp32ToFp16Converter if backend support

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>