### PR TITLE
[luci] Use must_cast for import, export

### DIFF
--- a/compiler/luci/export/src/CircleOperationExporter.cpp
+++ b/compiler/luci/export/src/CircleOperationExporter.cpp
@@ -410,8 +410,7 @@ void OperationExporter::visit(luci::CircleIf *node)
     bool found = false;
     for (auto out : if_outs)
     {
-      auto if_out = dynamic_cast<luci::CircleIfOut *>(out);
-      assert(if_out != nullptr);
+      auto if_out = loco::must_cast<luci::CircleIfOut *>(out);
       if (if_out->index() == static_cast<int32_t>(idx))
       {
         outputs_vec.push_back(get_tensor_index(if_out));
@@ -794,8 +793,7 @@ void OperationExporter::visit(luci::CircleUnpack *node)
     bool found = false;
     for (auto out : unpack_outs)
     {
-      auto unpack_out = dynamic_cast<luci::CircleUnpackOut *>(out);
-      assert(unpack_out != nullptr);
+      auto unpack_out = loco::must_cast<luci::CircleUnpackOut *>(out);
       if (unpack_out->index() == index)
       {
         outputs_vec.push_back(get_tensor_index(unpack_out));
@@ -835,8 +833,7 @@ void OperationExporter::visit(luci::CircleWhile *node)
     bool found = false;
     for (auto out : while_outs)
     {
-      auto while_out = dynamic_cast<luci::CircleWhileOut *>(out);
-      assert(while_out != nullptr);
+      auto while_out = loco::must_cast<luci::CircleWhileOut *>(out);
       if (while_out->index() == static_cast<int32_t>(idx))
       {
         outputs_vec.push_back(get_tensor_index(while_out));

--- a/compiler/luci/import/src/PostImport.cpp
+++ b/compiler/luci/import/src/PostImport.cpp
@@ -108,8 +108,7 @@ public:
     {
       if (recognize(node->dialect()))
       {
-        auto cn = dynamic_cast<luci::CircleNode *>(node);
-        assert(cn != nullptr);
+        auto cn = loco::must_cast<luci::CircleNode *>(node);
 
         fix(cn, m, r);
       }
@@ -168,8 +167,8 @@ public:
     auto else_graph_outputs = else_graph->outputs();
     for (size_t idx = 0; idx < then_outputs.size(); ++idx)
     {
-      auto then_out = dynamic_cast<luci::CircleOutput *>(then_outputs.at(idx));
-      auto else_out = dynamic_cast<luci::CircleOutput *>(else_outputs.at(idx));
+      auto then_out = loco::must_cast<luci::CircleOutput *>(then_outputs.at(idx));
+      auto else_out = loco::must_cast<luci::CircleOutput *>(else_outputs.at(idx));
 
       auto then_graph_output = then_graph_outputs->at(then_out->index());
       auto else_graph_output = else_graph_outputs->at(else_out->index());
@@ -215,7 +214,7 @@ public:
     {
       INTERNAL_EXN("CircleWhile COND output must have size 1");
     }
-    auto cond_out = dynamic_cast<luci::CircleOutput *>(cond_outputs.at(0));
+    auto cond_out = loco::must_cast<luci::CircleOutput *>(cond_outputs.at(0));
     if (cond_out->dtype() != loco::DataType::BOOL)
     {
       INTERNAL_EXN("CircleWhile COND output must have bool type");
@@ -227,8 +226,8 @@ public:
     auto body_graph_inputs = body_graph->inputs();
     for (size_t idx = 0; idx < cond_inputs.size(); ++idx)
     {
-      auto cond_in = dynamic_cast<luci::CircleInput *>(cond_inputs.at(idx));
-      auto body_in = dynamic_cast<luci::CircleInput *>(body_inputs.at(idx));
+      auto cond_in = loco::must_cast<luci::CircleInput *>(cond_inputs.at(idx));
+      auto body_in = loco::must_cast<luci::CircleInput *>(body_inputs.at(idx));
 
       auto cond_graph_input = cond_graph_inputs->at(cond_in->index());
       auto body_graph_input = body_graph_inputs->at(body_in->index());
@@ -253,8 +252,8 @@ public:
     auto body_graph_outputs = body_graph->outputs();
     for (size_t idx = 0; idx < cond_inputs.size(); ++idx)
     {
-      auto cond_in = dynamic_cast<luci::CircleInput *>(cond_inputs.at(idx));
-      auto body_out = dynamic_cast<luci::CircleOutput *>(body_outputs.at(idx));
+      auto cond_in = loco::must_cast<luci::CircleInput *>(cond_inputs.at(idx));
+      auto body_out = loco::must_cast<luci::CircleOutput *>(body_outputs.at(idx));
 
       auto cond_graph_input = cond_graph_inputs->at(cond_in->index());
       auto body_graph_output = body_graph_outputs->at(body_out->index());
@@ -298,8 +297,7 @@ public:
     {
       if (recognize(node->dialect()))
       {
-        auto cn = dynamic_cast<luci::CircleNode *>(node);
-        assert(cn != nullptr);
+        auto cn = loco::must_cast<luci::CircleNode *>(node);
 
         eval(cn, m, r);
       }


### PR DESCRIPTION
This will use loco::must_cast() instead of dynamic_cast for import and export to solve static analysis tool warnings

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>