### PR TITLE
[onert] throw runtime error for not-yet-supported optional input tensor

### DIFF
--- a/runtime/onert/frontend/base_loader/include/base_loader.h
+++ b/runtime/onert/frontend/base_loader/include/base_loader.h
@@ -45,6 +45,8 @@ template <typename LoaderDomain, typename SpecificLoader> class BaseLoader
   using Tensor = typename LoaderDomain::Tensor;
   using TensorType = typename LoaderDomain::TensorType;
 
+  bool isOptionalInputTensor(std::int32_t idx) { return idx == -1; }
+
 public:
   /**
    * @brief Construct a new Loader object
@@ -313,6 +315,12 @@ void BaseLoader<LoaderDomain, SpecificLoader>::loadOperationIO(const Operator *o
 {
   for (const std::int32_t idx : *op->inputs())
   {
+    // Optional tensors are not supported yet except for FULLY_CONNECTED.
+    auto builtin_code = _model->operator_codes()->Get(op->opcode_index())->builtin_code();
+    if (isOptionalInputTensor(idx))
+      throw std::runtime_error(std::string("loader doesn't support optional input tensor yet for ")
+                                   .append(EnumNameBuiltinOperator(builtin_code)));
+
     inputs.append(_tensor_to_operand[idx]);
   }
 


### PR DESCRIPTION
It will throw error and print op name if optional input tensor is not
supported for the operator.
    
ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>