### PR TITLE
[res] Adding concat example in TensorFlowPythonExamples

### DIFF
--- a/res/TensorFlowPythonExamples/examples/concat/__init__.py
+++ b/res/TensorFlowPythonExamples/examples/concat/__init__.py
@@ -1,0 +1,7 @@
+import tensorflow as tf
+
+in1_ = tf.compat.v1.placeholder(dtype=tf.float32, shape=(2, 3, 4), name="Hole1")
+in2_ = tf.compat.v1.placeholder(dtype=tf.float32, shape=(2, 2, 4), name="Hole2")
+concat_ = tf.compat.v1.concat([in1_, in2_], axis=-2)
+
+# note that tflite file also contain axis = -2


### PR DESCRIPTION
This adds _concat_ example, of which `axis = -2`, into _TensorFlowPythonExamples._

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>