### PR TITLE
[circledump] Add Sum operation to circledump

### DIFF
--- a/compiler/circledump/src/OpPrinter.cpp
+++ b/compiler/circledump/src/OpPrinter.cpp
@@ -416,6 +416,7 @@ OpPrinterRegistry::OpPrinterRegistry()
   _op_map[circle::BuiltinOperator_SPLIT_V] = make_unique<SplitVPrinter>();
   _op_map[circle::BuiltinOperator_STRIDED_SLICE] = make_unique<StridedSlicePrinter>();
   _op_map[circle::BuiltinOperator_SUB] = make_unique<SubPrinter>();
+  _op_map[circle::BuiltinOperator_SUM] = make_unique<ReducerPrinter>();
   _op_map[circle::BuiltinOperator_CUSTOM] = make_unique<CustomOpPrinter>();
 }
 


### PR DESCRIPTION
Parent Issue : #628
Full Draft PR : #678

This commit will add `Sum` operation printer in `circledump`

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>