### PR TITLE
[loco] Support S64 DataType

### DIFF
--- a/compiler/loco/include/loco/IR/DataTypeTraits.h
+++ b/compiler/loco/include/loco/IR/DataTypeTraits.h
@@ -58,6 +58,12 @@ template <> struct DataTypeImpl<DataType::U32>
   using Type = uint32_t;
 };
 
+template <> struct DataTypeImpl<DataType::S64>
+{
+  // Use C++ int64_t type for 64bit integer
+  using Type = int64_t;
+};
+
 template <> struct DataTypeImpl<DataType::FLOAT32>
 {
   // Use C++ float type for IEEE 32-bit floating-point numbers
@@ -87,6 +93,8 @@ inline uint32_t size(DataType data_type)
       return sizeof(DataTypeImpl<DataType::S32>::Type);
     case DataType::U32:
       return sizeof(DataTypeImpl<DataType::U32>::Type);
+    case DataType::S64:
+      return sizeof(DataTypeImpl<DataType::S64>::Type);
     case DataType::FLOAT32:
       return sizeof(DataTypeImpl<DataType::FLOAT32>::Type);
     case DataType::BOOL:


### PR DESCRIPTION
This commit enables loco to support S64 DataType.

Input of MatrixBandPart is `int64`.

Related : #704 
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>