### PR TITLE
[logo] Use must_cast()

### DIFF
--- a/compiler/logo/src/Passes/RemoveForwardNodePass.cpp
+++ b/compiler/logo/src/Passes/RemoveForwardNodePass.cpp
@@ -47,7 +47,7 @@ bool RemoveForwardNodePass::run(loco::Graph *g)
   {
     if (node->dialect() == loco::CanonicalDialect::get())
     {
-      auto canonical_node = dynamic_cast<loco::CanonicalNode *>(node);
+      auto canonical_node = loco::must_cast<loco::CanonicalNode *>(node);
       canonical_node->accept(&collector);
     }
   }

--- a/compiler/logo/src/Passes/ReorderDecodePass.cpp
+++ b/compiler/logo/src/Passes/ReorderDecodePass.cpp
@@ -76,7 +76,7 @@ bool ReorderDecodePass<loco::TensorBiasAdd>::run(loco::Graph *g)
   {
     if (node->dialect() == loco::CanonicalDialect::get())
     {
-      auto canonical_node = dynamic_cast<loco::CanonicalNode *>(node);
+      auto canonical_node = loco::must_cast<loco::CanonicalNode *>(node);
       canonical_node->accept(&collector);
     }
   }
@@ -125,9 +125,7 @@ bool ReorderDecodePass<loco::TensorBiasAdd>::run(loco::Graph *g)
       // Q. Is it better to create an independent transform for this rewriting rule?
       if (isTensorBiasAdd(u))
       {
-        auto old_badd = dynamic_cast<loco::TensorBiasAdd *>(u);
-
-        assert(old_badd != nullptr);
+        auto old_badd = loco::must_cast<loco::TensorBiasAdd *>(u);
 
         /**
          * Let us consider the following example:
@@ -212,7 +210,7 @@ bool ReorderDecodePass<loco::ReLU>::run(loco::Graph *g)
   {
     if (node->dialect() == loco::CanonicalDialect::get())
     {
-      auto canonical_node = dynamic_cast<loco::CanonicalNode *>(node);
+      auto canonical_node = loco::must_cast<loco::CanonicalNode *>(node);
       canonical_node->accept(&collector);
     }
   }

--- a/compiler/logo/src/Passes/ResolveDuplicateReshapePass.cpp
+++ b/compiler/logo/src/Passes/ResolveDuplicateReshapePass.cpp
@@ -61,7 +61,7 @@ bool is_duplicate_reshape(loco::Node *node)
  */
 void remap_input(loco::FixedReshape *reshape)
 {
-  auto input_reshape = dynamic_cast<loco::FixedReshape *>(reshape->input());
+  auto input_reshape = loco::must_cast<loco::FixedReshape *>(reshape->input());
 
   auto volume = [](loco::FixedReshape *node) {
     uint32_t vol = 1;
@@ -94,7 +94,7 @@ bool ResolveDuplicateReshapePass::run(loco::Graph *graph)
   {
     if (is_duplicate_reshape(node))
     {
-      auto node_as_reshape = dynamic_cast<loco::FixedReshape *>(node);
+      auto node_as_reshape = loco::must_cast<loco::FixedReshape *>(node);
 
       remap_input(node_as_reshape);
 

--- a/compiler/logo/src/Passes/SimplifyDomainConversionPass.cpp
+++ b/compiler/logo/src/Passes/SimplifyDomainConversionPass.cpp
@@ -411,7 +411,7 @@ bool SimplifyDomainConversionPass::run(loco::Graph *g)
   {
     if (node->dialect() == loco::CanonicalDialect::get())
     {
-      auto canonical_node = dynamic_cast<loco::CanonicalNode *>(node);
+      auto canonical_node = loco::must_cast<loco::CanonicalNode *>(node);
       canonical_node->accept(&collector);
     }
   }


### PR DESCRIPTION
This will revise logo to use must_cast() instead of dynamic_cast to resolve static analysis warnings

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>