### PR TITLE
[luci] use must_cast for export

### DIFF
--- a/compiler/luci/export/src/CircleOperationExporter.cpp
+++ b/compiler/luci/export/src/CircleOperationExporter.cpp
@@ -685,8 +685,7 @@ void OperationExporter::visit(luci::CircleSplit *node)
     bool found = false;
     for (auto out : split_outs)
     {
-      auto split_out = dynamic_cast<luci::CircleSplitOut *>(out);
-      assert(split_out != nullptr);
+      auto split_out = loco::must_cast<luci::CircleSplitOut *>(out);
       if (split_out->index() == index)
       {
         outputs_vec.push_back(get_tensor_index(split_out));
@@ -725,8 +724,7 @@ void OperationExporter::visit(luci::CircleSplitV *node)
     bool found = false;
     for (auto out : split_outs)
     {
-      auto split_out = dynamic_cast<luci::CircleSplitVOut *>(out);
-      assert(split_out != nullptr);
+      auto split_out = loco::must_cast<luci::CircleSplitVOut *>(out);
       if (split_out->index() == index)
       {
         outputs_vec.push_back(get_tensor_index(split_out));


### PR DESCRIPTION
This will revise export to use loco::must_cast() instead of dynamic_cast to resolve static analysis warnings

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>