### PR TITLE
[luci] Shape/Type inference for Square operation

### DIFF
--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -1020,6 +1020,13 @@ public:
     return loco::NodeShape{input_shape};
   }
 
+  loco::NodeShape visit(const luci::CircleSquare *node) final
+  {
+    auto input_shape = loco::shape_get(node->x()).as<loco::TensorShape>();
+
+    return loco::NodeShape{input_shape};
+  }
+
   loco::NodeShape visit(const luci::CircleSquaredDifference *node) final
   {
     auto x_shape = loco::shape_get(node->x()).as<loco::TensorShape>();

--- a/compiler/luci/service/src/CircleTypeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleTypeInferenceRule.cpp
@@ -198,6 +198,8 @@ struct TypeInferenceAlgorithm final : public luci::CircleNodeVisitor<loco::DataT
 
   loco::DataType visit(const luci::CircleSqrt *node) final { return loco::dtype_get(node->x()); }
 
+  loco::DataType visit(const luci::CircleSquare *node) final { return loco::dtype_get(node->x()); }
+
   loco::DataType visit(const luci::CircleSquaredDifference *node) final
   {
     return loco::dtype_get(node->x());


### PR DESCRIPTION
This enables shape/type inference for Square operation

Signed-off-by: kishore.cs <kishore.cs@samsung.com>

Related to #452 