### PR TITLE
[loco] Introduce _must_cast for template argument

### DIFF
--- a/compiler/loco/include/loco/IR/CastHelpers.h
+++ b/compiler/loco/include/loco/IR/CastHelpers.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef __LOCO_IR_MUST_CAST_H__
-#define __LOCO_IR_MUST_CAST_H__
+#ifndef __LOCO_IR_CAST_HELPERS_H__
+#define __LOCO_IR_CAST_HELPERS_H__
 
 #include <string>
 #include <stdexcept>
@@ -38,4 +38,4 @@ template <typename T, typename ARG> T _must_cast(ARG arg)
 
 } // namespace loco
 
-#endif // __LOCO_IR_MUST_CAST_H__
+#endif // __LOCO_IR_CAST_HELPERS_H__

--- a/compiler/loco/include/loco/IR/Node.h
+++ b/compiler/loco/include/loco/IR/Node.h
@@ -23,7 +23,7 @@
 #include "loco/IR/Dialect.h"
 #include "loco/IR/NodePool.forward.h"
 #include "loco/IR/Graph.forward.h"
-#include "loco/IR/MustCast.h"
+#include "loco/IR/CastHelpers.h"
 
 #include <array>
 #include <memory>


### PR DESCRIPTION
This will introduce _must_cast() with an argument to reduce duplicate codes

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>