### PR TITLE
[runtime] Removing _subgraphs check in nnfw_api_internal.cc

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -324,7 +324,7 @@ NNFW_STATUS nnfw_session::apply_tensorinfo(uint32_t index, nnfw_tensorinfo ti)
 {
   // sanity check
   {
-    if (!_subgraphs || !primary_subgraph() || primary_subgraph()->isBuildingPhase())
+    if (!primary_subgraph() || primary_subgraph()->isBuildingPhase())
     {
       std::cerr << "Error during apply_tensorinfo : "
                 << "prepare should be run after load_model" << std::endl;


### PR DESCRIPTION
This removes `_subgraphs` check inside `apply_tensorinfo()`
 since the same check is done inside `primary_subgraph()`.

Also, `_subgraphs` seems to be invalid at execution time.

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>