### PR TITLE
[luci] Initialize CircleTensorInfo members

### DIFF
--- a/compiler/luci/export/src/CircleTensorExporter.cpp
+++ b/compiler/luci/export/src/CircleTensorExporter.cpp
@@ -63,8 +63,8 @@ public:
 private:
   std::string _name;
 
-  circle::TensorType _dtype;
-  ShapeDescription _shape;
+  circle::TensorType _dtype{circle::TensorType_FLOAT32};
+  ShapeDescription _shape{};
 
   luci::CircleConst *_content = nullptr;
   luci::CircleQuantParam *_quantparam = nullptr;


### PR DESCRIPTION
This will initialize CircleTensorInfo members to resolve static analysis warnings

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>