### PR TITLE
[runtime] Creating FunctionSequenceForDynamicBackend object

### DIFF
--- a/runtime/onert/core/include/util/ShapeInference.h
+++ b/runtime/onert/core/include/util/ShapeInference.h
@@ -127,7 +127,7 @@ class DynamicInferer : public ir::OperationVisitor
 {
 public:
   DynamicInferer(const ir::Operands &operands, backend::IDynamicTensorManager *tensor_manager,
-                 std::shared_ptr<backend::ITensorRegistry> &tensor_registry)
+                 std::shared_ptr<backend::ITensorRegistry> tensor_registry)
       : _operands(operands), _dynamic_tensor_manager(tensor_manager),
         _tensor_registry(tensor_registry)
   {


### PR DESCRIPTION
This creates `FunctionSequenceForDynamicBackend` object. `FunctionSequenceForDynamicBackend` is used as a `FunctionSequence` when the backend supports dynamic tensor.

Parent issue #56
Draft #52
See also: [Previous PR to check what `FunctionSequenceForDynamicBackend` is](https://github.com/Samsung/ONE/pull/610/files#diff-a01ffbfbfc137438970dd03eb52ae14eR75)

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>