### PR TITLE
[onert] Fix interpreter producing incorrect shape

### DIFF
--- a/runtime/onert/core/src/interp/operations/OperationUtil.h
+++ b/runtime/onert/core/src/interp/operations/OperationUtil.h
@@ -34,18 +34,11 @@ inline nnfw::cker::Shape convertShape(const ir::Shape &shape)
   auto dimensions = std::vector<uint32_t>(shape.dims().begin(), shape.dims().end());
 
   std::vector<int32_t> raw_shape;
-  raw_shape.resize(4);
+  raw_shape.resize(dimensions.size());
 
-  for (uint32_t i = 0; i < 4; ++i)
+  for (uint32_t i = 0; i < dimensions.size(); ++i)
   {
-    if (i >= dimensions.size())
-    {
-      raw_shape[i] = 1;
-    }
-    else
-    {
-      raw_shape[i] = dimensions[i];
-    }
+    raw_shape[i] = dimensions[i];
   }
 
   return nnfw::cker::GetShape(raw_shape);


### PR DESCRIPTION
- `convertShape` make cker::shape of 4D for all ir::Shape
  - cker::shape should have same dimenion as ir::shape
- Fix `convertSahpe` to produce cker::shape with correct dimension

ONE-DCO-1.0-Signed-off-by: JiHwan Yeo <jihwan.yeo@samsung.com>

---

For https://github.com/Samsung/ONE/issues/473#issuecomment-627749356
Part of #652