### PR TITLE
[tf2tfliteV2-value-pbtxt-test] Turn off the test

### DIFF
--- a/compiler/tf2tfliteV2-value-pbtxt-test/CMakeLists.txt
+++ b/compiler/tf2tfliteV2-value-pbtxt-test/CMakeLists.txt
@@ -174,10 +174,10 @@ list(APPEND TEST_DEPS "${TEST_CONFIG}")
 add_custom_target(tf2tfliteV2_value_pbtxt_test_deps ALL DEPENDS ${TEST_DEPS})
 
 # Run tests
-add_test(
-  NAME tf2tfliteV2_value_pbtxt_test
-  COMMAND "${TEST_RUNNER}"
-          "${TEST_CONFIG}"
-          "${CMAKE_CURRENT_BINARY_DIR}"
-          ${TEST_NAMES}
-)
+# add_test(
+#   NAME tf2tfliteV2_value_pbtxt_test
+#   COMMAND "${TEST_RUNNER}"
+#           "${TEST_CONFIG}"
+#           "${CMAKE_CURRENT_BINARY_DIR}"
+#           ${TEST_NAMES}
+# )


### PR DESCRIPTION
This commit turns off the test. Because this test tests a TOCO, which isn't necessary. And it takes too much time:(

This test will change to `tf2tfliteV2-conversion-test` and the test cycle will be much longer.


ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>