### PR TITLE
[circledump] Enable OneHot Op

### DIFF
--- a/compiler/circledump/src/OpPrinter.cpp
+++ b/compiler/circledump/src/OpPrinter.cpp
@@ -440,6 +440,7 @@ OpPrinterRegistry::OpPrinterRegistry()
   // There is no Option for LOGISTIC
   _op_map[circle::BuiltinOperator_MAX_POOL_2D] = make_unique<Pool2DPrinter>();
   _op_map[circle::BuiltinOperator_MUL] = make_unique<MulPrinter>();
+  _op_map[circle::BuiltinOperator_ONE_HOT] = make_unique<OneHotPrinter>();
   _op_map[circle::BuiltinOperator_PACK] = make_unique<PackPrinter>();
   // There is no Option for Pad
   // There is no Option for ReLU and ReLU6


### PR DESCRIPTION
Parent Issue : #668 
Draft PR : #735 

This commit will enable `onehot` operation options in circledump

Signed-off-by: struss <rrstrous@nate.com>