### PR TITLE
[exo] Use must_cast

### DIFF
--- a/compiler/exo/src/Dialect/Service/CircleTypeInferenceRule.cpp
+++ b/compiler/exo/src/Dialect/Service/CircleTypeInferenceRule.cpp
@@ -49,7 +49,7 @@ bool CircleTypeInferenceRule::infer(const loco::Node *node, loco::DataType &dtyp
 
   TypeInferenceAlgorithm alg;
 
-  dtype = dynamic_cast<const CircleNode *>(node)->accept(&alg);
+  dtype = loco::must_cast<const CircleNode *>(node)->accept(&alg);
   assert(dtype != loco::DataType::Unknown);
 
   return true;

--- a/compiler/exo/src/Dialect/Service/TFLTypeInferenceRule.cpp
+++ b/compiler/exo/src/Dialect/Service/TFLTypeInferenceRule.cpp
@@ -132,7 +132,7 @@ bool TFLTypeInferenceRule::infer(const loco::Node *node, loco::DataType &dtype) 
 
   TypeInferenceAlgorithm alg;
 
-  dtype = dynamic_cast<const TFLNode *>(node)->accept(&alg);
+  dtype = loco::must_cast<const TFLNode *>(node)->accept(&alg);
   assert(dtype != loco::DataType::Unknown);
 
   return true;


### PR DESCRIPTION
This will revise exo to use must_cast() to resolve static analysis warnings

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>