### PR TITLE
[loco] Use must_cast

### DIFF
--- a/compiler/loco/src/IR/PermutingCodec.test.cpp
+++ b/compiler/loco/src/IR/PermutingCodec.test.cpp
@@ -180,7 +180,7 @@ TEST(PermutingEncoderTest, feature_clone)
   src_perm->axis(FeatureAxis::Width) = 2;
 
   auto dst_enc = src_enc.clone();
-  auto dst_perm = dynamic_cast<PermutingEncoder<Domain::Feature> *>(dst_enc.get())->perm();
+  auto dst_perm = loco::must_cast<PermutingEncoder<Domain::Feature> *>(dst_enc.get())->perm();
 
   EXPECT_EQ(dst_perm->axis(FeatureAxis::Count), src_perm->axis(FeatureAxis::Count));
   EXPECT_EQ(dst_perm->axis(FeatureAxis::Depth), src_perm->axis(FeatureAxis::Depth));
@@ -415,7 +415,7 @@ TEST(PermutingDecoderTest, feature_clone)
   src_perm->axis(FeatureAxis::Width) = 2;
 
   auto dst_enc = src_enc.clone();
-  auto dst_perm = dynamic_cast<PermutingDecoder<Domain::Feature> *>(dst_enc.get())->perm();
+  auto dst_perm = loco::must_cast<PermutingDecoder<Domain::Feature> *>(dst_enc.get())->perm();
 
   EXPECT_EQ(dst_perm->axis(FeatureAxis::Count), src_perm->axis(FeatureAxis::Count));
   EXPECT_EQ(dst_perm->axis(FeatureAxis::Depth), src_perm->axis(FeatureAxis::Depth));

--- a/compiler/loco/src/Service/TypeInference.cpp
+++ b/compiler/loco/src/Service/TypeInference.cpp
@@ -182,7 +182,7 @@ bool CanonicalTypeInferenceRule::infer(const Node *node, DataType &dtype) const
   assert(dynamic_cast<const loco::CanonicalNode *>(node) != nullptr);
 
   CanonicalTypeForwardAlgorithm alg;
-  dtype = dynamic_cast<const loco::CanonicalNode *>(node)->accept(&alg);
+  dtype = loco::must_cast<const loco::CanonicalNode *>(node)->accept(&alg);
 
   return true;
 }


### PR DESCRIPTION
This will revise loco test and typeinference to use must_cast() to resolve static analysis warnings

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>