### PR TITLE
[moco-tf] Use must_cast

### DIFF
--- a/compiler/moco-tf/src/Canonicalization/PadCanonicalizer.cpp
+++ b/compiler/moco-tf/src/Canonicalization/PadCanonicalizer.cpp
@@ -58,7 +58,7 @@ bool canonicalize_pad(loco::Graph *graph, moco::TFPad *node)
   constant_node->size<loco::DataType::FLOAT32>(1);
   constant_node->at<loco::DataType::FLOAT32>(0) = 0.0f;
 
-  auto const_paddings_node = dynamic_cast<loco::ConstGen *>(node->paddings());
+  auto const_paddings_node = loco::must_cast<loco::ConstGen *>(node->paddings());
   // TODO: support S64 type.
   assert(const_paddings_node->dtype() == loco::DataType::S32);
   assert(const_paddings_node->rank() == 2);


### PR DESCRIPTION
This will revise moco-tf to use must_cast() to resolve static analysis warnings

Related : #587
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>