### PR TITLE
[locoex-customop] Use must_cast

### DIFF
--- a/compiler/locoex-customop/src/Service/COpShapeInferenceRule.cpp
+++ b/compiler/locoex-customop/src/Service/COpShapeInferenceRule.cpp
@@ -37,7 +37,7 @@ bool COpShapeInferenceRule::infer(const loco::Node *node, loco::NodeShape &shape
   assert(node->dialect() == COpDialect::get());
   assert(dynamic_cast<const COpNode *>(node) != nullptr);
 
-  auto cop_call = dynamic_cast<const COpCall *>(node);
+  auto cop_call = loco::must_cast<const COpCall *>(node);
 
   // Note that the shape of custom op is considered as TensorShape
   // TODO Decide how to deal with this shape error cases


### PR DESCRIPTION
This will revise locoex-customop to use must_cast() to resolve static analysis warnings

Related : #587
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>