### PR TITLE
[luci] Use must_cast for validate_shape_dtype

### DIFF
--- a/compiler/luci/service/src/Validate.cpp
+++ b/compiler/luci/service/src/Validate.cpp
@@ -61,8 +61,7 @@ bool validate_shape_dtype(loco::Graph *g)
     auto circle_output = find_node(output_nodes, out_index);
     assert(circle_output != nullptr);
     assert(circle_output->from() != nullptr);
-    auto circle_node = dynamic_cast<luci::CircleNode *>(circle_output->from());
-    assert(circle_node != nullptr);
+    auto circle_node = loco::must_cast<luci::CircleNode *>(circle_output->from());
     assert(loco::shape_known(circle_node));
 
     // check if output node shape is same as graph output shape


### PR DESCRIPTION
This will revise validate_shape_dtype() to use must_cast() to resolve static analysis warnings

Signed-off-by: SaeHie Park <saehie.park@gmail.com>