### PR TITLE
[luci] Shape, dtype inf for FloorMod

### DIFF
--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -544,6 +544,13 @@ public:
     return loco::NodeShape{x_shape};
   }
 
+  loco::NodeShape visit(const luci::CircleFloorMod *node) final
+  {
+    auto x_shape = loco::shape_get(node->x()).as<loco::TensorShape>();
+    assert(x_shape == loco::shape_get(node->y()).as<loco::TensorShape>());
+    return loco::NodeShape{x_shape};
+  }
+
   loco::NodeShape visit(const luci::CircleFullyConnected *node) final
   {
     auto input_shape = loco::shape_get(node->input()).as<loco::TensorShape>();

--- a/compiler/luci/service/src/CircleTypeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleTypeInferenceRule.cpp
@@ -92,6 +92,11 @@ struct TypeInferenceAlgorithm final : public luci::CircleNodeVisitor<loco::DataT
 
   loco::DataType visit(const luci::CircleExp *node) final { return loco::dtype_get(node->x()); }
 
+  loco::DataType visit(const luci::CircleFloorMod *node) final
+  {
+    return loco::dtype_get(node->x());
+  }
+
   loco::DataType visit(const luci::CircleFullyConnected *node) final
   {
     return loco::dtype_get(node->input());


### PR DESCRIPTION
This will enable shape and dtype inference for FloodMod IR

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>