### PR TITLE
[onert] Release all operand Data after constInit

### DIFF
--- a/runtime/onert/core/src/compiler/ExecutorFactory.cc
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.cc
@@ -225,15 +225,10 @@ ExecutorFactory::createLinearExecutor(std::unique_ptr<ir::LoweredGraph> lowered_
     pair.second->initConsts();
   }
 
-  // Note. The best solution is not to use CachedDataDeleter but decreasing reference counts of data
-  // naturally
   if (options.delete_cached_data)
   {
-    CachedDataDeleter cached_data_deleter(lowered_graph->graph().operands());
-    lowered_graph->op_seqs().iterate(
-        [&](const ir::OpSequenceIndex &, const ir::OpSequence &op_seq) {
-          cached_data_deleter.run(op_seq);
-        });
+    lowered_graph->graph().operands().iterate(
+        [](const ir::OperandIndex &, ir::Operand &obj) { obj.releaseData(); });
   }
 
   auto code_map = builder.releaseCodeMap();
@@ -326,11 +321,8 @@ ExecutorFactory::createDataflowExecutor(std::unique_ptr<ir::LoweredGraph> lowere
 
   if (options.delete_cached_data)
   {
-    CachedDataDeleter cached_data_deleter(lowered_graph->graph().operands());
-    lowered_graph->op_seqs().iterate(
-        [&](const ir::OpSequenceIndex &, const ir::OpSequence &op_seq) {
-          cached_data_deleter.run(op_seq);
-        });
+    lowered_graph->graph().operands().iterate(
+        [](const ir::OperandIndex &, ir::Operand &obj) { obj.releaseData(); });
   }
 
   auto code_map = builder.releaseCodeMap();


### PR DESCRIPTION
After Constant Initialization the graph does not have to hold `Data` object for all operands.
After this, `CachedDataDeleter` will be removed.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>