### PR TITLE
[onert] support zeros_like nnapi frontend

### DIFF
--- a/runtime/libs/tflite/port/1.13.1/src/nnapi_delegate.cpp
+++ b/runtime/libs/tflite/port/1.13.1/src/nnapi_delegate.cpp
@@ -891,6 +891,13 @@ TfLiteStatus AddOpsAndParams(
         nnapi_version = 12;  // require NNAPI 1.2
         nn_op_type = ANEURALNETWORKS_SELECT;
         break;
+      case tflite::BuiltinOperator_ZEROS_LIKE:
+        CHECK_NN(ANeuralNetworksModel_addOperationEx(
+            nn_model, ANEURALNETWORKS_ZEROS_LIKE_EX,
+            static_cast<uint32_t>(augmented_inputs.size()),
+            augmented_inputs.data(), static_cast<uint32_t>(node.outputs->size),
+            reinterpret_cast<uint32_t*>(node.outputs->data)));
+        continue; // _EX operator should use `continue` to skip addOperanation.
       case tflite::BuiltinOperator_CONCAT_EMBEDDINGS:
       case tflite::BuiltinOperator_LSH_PROJECTION:
       case tflite::BuiltinOperator_BIDIRECTIONAL_SEQUENCE_RNN:
@@ -954,7 +961,7 @@ TfLiteStatus AddOpsAndParams(
       case tflite::BuiltinOperator_FLOOR_DIV:
       case tflite::BuiltinOperator_REDUCE_ANY:
       case tflite::BuiltinOperator_SQUARE:
-      case tflite::BuiltinOperator_ZEROS_LIKE:
+      //case tflite::BuiltinOperator_ZEROS_LIKE:
       case tflite::BuiltinOperator_FILL:
       case tflite::BuiltinOperator_FLOOR_MOD:
       case tflite::BuiltinOperator_RANGE:

--- a/runtime/nnapi-header/include/NeuralNetworksEx.h
+++ b/runtime/nnapi-header/include/NeuralNetworksEx.h
@@ -424,7 +424,22 @@ typedef enum {
 
   ANEURALNETWORKS_SELECT_V2_EX = 50030,
 
-  ANEURALNETWORKS_ZERO_LIKE_EX = 50031,
+  /**
+   * Make the output tensor same shape to the input tensor and fill zero for all elements.
+   *
+   * Supported tensor {@link OperandCode}:
+   * * {@link ANEURALNETWORKS_TENSOR_FLOAT32, ANEURALNETWORKS_TENSOR_INT32}
+   *
+   * Supported tensor rank: up to 4
+   *
+   * Inputs:
+   * * 0: A tensor.
+   *
+   * Outputs:
+   * * 0: The output tensor, of the same {@link OperandCode} and dimensions as
+   *      the input tensor.
+   */
+  ANEURALNETWORKS_ZEROS_LIKE_EX = 50031,
 
   ANEURALNETWORKS_COS_EX = 50032,
 

--- a/runtime/onert/frontend/nnapi/wrapper/OperationFactory.cc
+++ b/runtime/onert/frontend/nnapi/wrapper/OperationFactory.cc
@@ -2029,6 +2029,18 @@ OperationFactory::OperationFactory()
 
     return new operation::Fill{inputs, outputs};
   };
+
+  _map[ANEURALNETWORKS_ZEROS_LIKE_EX] = [](const OperationFactory::Param &init_param, Operands &) {
+    assert(init_param.input_count == 1 && init_param.output_count == 1);
+
+    OperandIndexSequence outputs{init_param.outputs[0]};
+
+    // Each input should be interpreted as follows:
+    //  0 -> input Tensor Index
+    OperandIndexSequence inputs{init_param.inputs[0]};
+
+    return new operation::ZerosLike{inputs, outputs};
+  };
 }
 
 Operation *OperationFactory::create(ANeuralNetworksOperationType type,

--- a/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_cl
+++ b/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_cl
@@ -110,3 +110,5 @@ GeneratedTests.transpose_v1_2
 GeneratedTests.transpose_v1_2_quant8
 GeneratedTests.transpose_v1_2_zero_sized
 GeneratedTests.transpose_v1_2_zero_sized_quant8
+GeneratedTests.zeros_like_ex_2D_float
+GeneratedTests.zeros_like_ex_4D_int32

--- a/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_neon
+++ b/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_neon
@@ -154,3 +154,5 @@ GeneratedTests.transpose_v1_2
 GeneratedTests.transpose_v1_2_quant8
 GeneratedTests.transpose_v1_2_zero_sized
 GeneratedTests.transpose_v1_2_zero_sized_quant8
+GeneratedTests.zeros_like_ex_2D_float
+GeneratedTests.zeros_like_ex_4D_int32

--- a/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_cl
+++ b/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_cl
@@ -110,3 +110,5 @@ GeneratedTests.transpose_v1_2
 GeneratedTests.transpose_v1_2_quant8
 GeneratedTests.transpose_v1_2_zero_sized
 GeneratedTests.transpose_v1_2_zero_sized_quant8
+GeneratedTests.zeros_like_ex_2D_float
+GeneratedTests.zeros_like_ex_4D_int32

--- a/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_neon
+++ b/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_neon
@@ -146,3 +146,5 @@ GeneratedTests.transpose_v1_2
 GeneratedTests.transpose_v1_2_quant8
 GeneratedTests.transpose_v1_2_zero_sized
 GeneratedTests.transpose_v1_2_zero_sized_quant8
+GeneratedTests.zeros_like_ex_2D_float
+GeneratedTests.zeros_like_ex_4D_int32

--- a/tests/nnapi/nnapi_gtest.skip.armv7l-tizen.acl_cl
+++ b/tests/nnapi/nnapi_gtest.skip.armv7l-tizen.acl_cl
@@ -58,3 +58,5 @@ GeneratedTests.svdf*
 GeneratedTests.tanh_v1_2
 GeneratedTests.transpose_conv_ex_*
 GeneratedTests.transpose_v1_2*
+GeneratedTests.zeros_like_ex_2D_float
+GeneratedTests.zeros_like_ex_4D_int32

--- a/tests/nnapi/nnapi_gtest.skip.noarch.interp
+++ b/tests/nnapi/nnapi_gtest.skip.noarch.interp
@@ -472,3 +472,5 @@ GeneratedTests.unpack_ex_3D_float_1
 GeneratedTests.unpack_ex_3D_float_2
 GeneratedTests.unpack_ex_3D_int_1
 GeneratedTests.unpack_ex_3D_int_2
+GeneratedTests.zeros_like_ex_2D_float
+GeneratedTests.zeros_like_ex_4D_int32

--- a/tests/nnapi/specs/Ex/zeros_like_ex_2D_float.mod.py
+++ b/tests/nnapi/specs/Ex/zeros_like_ex_2D_float.mod.py
@@ -1,0 +1,15 @@
+# model
+model = Model()
+i1 = Input("op1", "TENSOR_FLOAT32", "{2, 3}")
+i2 = Output("op2", "TENSOR_FLOAT32", "{2, 3}")
+model = model.Operation("ZEROS_LIKE_EX", i1).To(i2)
+
+# Example 1. Input in operand 0,
+input0 = {i1: # input 0
+          [-2.0, -1.0, 0.0, 1.0, 2.0, 3.0]}
+
+output0 = {i2: # output 0
+           [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]}
+
+# Instantiate an example
+Example((input0, output0))

--- a/tests/nnapi/specs/Ex/zeros_like_ex_4D_int32.mod.py
+++ b/tests/nnapi/specs/Ex/zeros_like_ex_4D_int32.mod.py
@@ -1,0 +1,15 @@
+# model
+model = Model()
+i1 = Input("op1", "TENSOR_INT32", "{1, 2, 2, 1}")
+i2 = Output("op2", "TENSOR_INT32", "{1, 2, 2, 1}")
+model = model.Operation("ZEROS_LIKE_EX", i1).To(i2)
+
+# Example 1. Input in operand 0,
+input0 = {i1: # input 0
+          [-2, -1, 0, 3]}
+
+output0 = {i2: # output 0
+           [0, 0, 0, 0]}
+
+# Instantiate an example
+Example((input0, output0))


### PR DESCRIPTION
- It supports zeros_like nnapi frontend.
- ANEURAL_NETWORRKS_ZERO_LIKE_EX -> ANEURALNETWORKS_ZEROS_LIKE_EX.
- nnapi tests for zeros_like are added.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>