### PR TITLE
[onert] Change getting CompilerOptions from Graph to Subgraphs

### DIFF
--- a/runtime/onert/core/include/compiler/Compiler.h
+++ b/runtime/onert/core/include/compiler/Compiler.h
@@ -62,7 +62,7 @@ struct CompilerOptions
   bool fp16_enable;        //< Whether fp16 mode ON/OFF
 };
 
-CompilerOptions fetchCompilerOptionsFromGlobalConfig(const ir::Graph &graph);
+CompilerOptions fetchCompilerOptionsFromGlobalConfig(const ir::Subgraphs &subgs);
 
 /**
  * @brief Class to compile graph model

--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -55,9 +55,13 @@ std::set<ir::OpCode> getControlFlowOp(const ir::Graph &graph)
   return cf_op_codes;
 }
 
-CompilerOptions fetchCompilerOptionsFromGlobalConfig(const ir::Graph &graph)
+CompilerOptions fetchCompilerOptionsFromGlobalConfig(const ir::Subgraphs &subgs)
 {
-  const auto cf_ops = getControlFlowOp(graph);
+  std::set<ir::OpCode> cf_ops;
+  subgs.iterate([&](const ir::SubgraphIndex &, const ir::Graph &graph) {
+    const auto ops = getControlFlowOp(graph);
+    cf_ops.insert(ops.cbegin(), ops.cend());
+  });
   CompilerOptions options;
 
   options.backend_list = nnfw::misc::split(util::getConfigString(util::config::BACKENDS), ';');
@@ -101,6 +105,7 @@ CompilerOptions fetchCompilerOptionsFromGlobalConfig(const ir::Graph &graph)
     }
 
     // Index to Backend
+    // TODO Support multiple subgraphs for manual scheduling
     auto map_str = util::getConfigString(util::config::OP_BACKEND_MAP);
     auto key_val_list = nnfw::misc::split(map_str, ';');
     for (const auto &key_val_str : key_val_list)
@@ -115,7 +120,9 @@ CompilerOptions fetchCompilerOptionsFromGlobalConfig(const ir::Graph &graph)
       const auto &val = key_val.at(1);
       auto key = static_cast<uint32_t>(std::stoi(key_str));
 
-      graph.operations().at(ir::OperationIndex{key}); // Check if exist, or this wil throw
+      subgs.at(ir::SubgraphIndex{0})
+          ->operations()
+          .at(ir::OperationIndex{key}); // Check if exist, or this wil throw
       ms_options.index_to_backend.emplace(ir::OperationIndex{key}, val);
     }
   }
@@ -125,12 +132,10 @@ CompilerOptions fetchCompilerOptionsFromGlobalConfig(const ir::Graph &graph)
 Compiler::Compiler(const std::shared_ptr<ir::Subgraphs> &subgs)
     : _subgraphs{subgs}, _executors{nullptr}, _state{State::CREATED}
 {
-
   // Set default values for CompilerOptions
   // All these default values should not be fetched from Env, when we stop supporting Android NN
   // API.
-  // TODO Support multiple subgraphs
-  _options = fetchCompilerOptionsFromGlobalConfig(*primary_subgraph());
+  _options = fetchCompilerOptionsFromGlobalConfig(*subgs);
 }
 
 void Compiler::enableToFp16() { _options.fp16_enable = true; }

--- a/runtime/onert/test/core/compiler/Scheduler.cc
+++ b/runtime/onert/test/core/compiler/Scheduler.cc
@@ -371,7 +371,9 @@ TEST_P(SchedulerTestWithExecutorParam, straight_graph_known_exec_time)
   setExecutor(GetParam());
 
   // Prepare graph
+  ir::Subgraphs subgs;
   auto graph(createStraightGraph());
+  subgs.push(ir::SubgraphIndex{0}, graph);
   OperationIndex add_op_idx(0), sub_op_idx(1), mul_op_idx(2);
 
   // Set default execution and transfer time
@@ -392,7 +394,7 @@ TEST_P(SchedulerTestWithExecutorParam, straight_graph_known_exec_time)
     // Test scheduler
     auto backend_contexts = buildBackendContexts(*graph);
     auto scheduler = compiler::HEScheduler(backend_contexts,
-                                           compiler::fetchCompilerOptionsFromGlobalConfig(*graph));
+                                           compiler::fetchCompilerOptionsFromGlobalConfig(subgs));
     const auto br = scheduler.schedule(*graph);
     ASSERT_EQ(br->getBackend(add_op_idx)->config()->id(), "cpu");
     ASSERT_EQ(br->getBackend(sub_op_idx)->config()->id(), "gpu");
@@ -408,7 +410,7 @@ TEST_P(SchedulerTestWithExecutorParam, straight_graph_known_exec_time)
     // Test scheduler
     auto backend_contexts = buildBackendContexts(*graph);
     auto scheduler = compiler::HEScheduler(backend_contexts,
-                                           compiler::fetchCompilerOptionsFromGlobalConfig(*graph));
+                                           compiler::fetchCompilerOptionsFromGlobalConfig(subgs));
     const auto br = scheduler.schedule(*graph);
     ASSERT_EQ(br->getBackend(add_op_idx)->config()->id(), "cpu");
     ASSERT_EQ(br->getBackend(sub_op_idx)->config()->id(), "cpu");
@@ -423,7 +425,9 @@ TEST_P(SchedulerTestWithExecutorParam, branched_graph_known_exec_time)
   setExecutor(GetParam());
 
   // Prepare graph
+  ir::Subgraphs subgs;
   auto graph(createBranchedGraph());
+  subgs.push(ir::SubgraphIndex{0}, graph);
   OperationIndex add_op_idx(0), mul1_op_idx(1), mul2_op_idx(2), fc1_op_idx(3), fc2_op_idx(4),
       sub_op_idx(5);
 
@@ -449,7 +453,7 @@ TEST_P(SchedulerTestWithExecutorParam, branched_graph_known_exec_time)
     // Test scheduler
     auto backend_contexts = buildBackendContexts(*graph);
     auto scheduler = compiler::HEScheduler(backend_contexts,
-                                           compiler::fetchCompilerOptionsFromGlobalConfig(*graph));
+                                           compiler::fetchCompilerOptionsFromGlobalConfig(subgs));
     const auto br = scheduler.schedule(*graph);
 
     std::string branch1_expected_backend("npu"), branch2_expected_backend("npu");
@@ -484,7 +488,7 @@ TEST_P(SchedulerTestWithExecutorParam, branched_graph_known_exec_time)
     // Test scheduler
     auto backend_contexts = buildBackendContexts(*graph);
     auto scheduler = compiler::HEScheduler(backend_contexts,
-                                           compiler::fetchCompilerOptionsFromGlobalConfig(*graph));
+                                           compiler::fetchCompilerOptionsFromGlobalConfig(subgs));
     const auto br = scheduler.schedule(*graph);
     ASSERT_EQ(br->getBackend(add_op_idx)->config()->id(), "npu");
     ASSERT_EQ(br->getBackend(mul1_op_idx)->config()->id(), "npu");
@@ -510,7 +514,9 @@ TEST_F(SchedulerTest, branched_graph_profiling_mode)
   setExecutor(DATAFLOW);
 
   // Prepare graph
+  ir::Subgraphs subgs;
   auto graph(createBranchedGraph());
+  subgs.push(ir::SubgraphIndex{0}, graph);
   OperationIndex add_op_idx(0), mul1_op_idx(1), mul2_op_idx(2), fc1_op_idx(3), fc2_op_idx(4),
       sub_op_idx(5);
 
@@ -533,7 +539,7 @@ TEST_F(SchedulerTest, branched_graph_profiling_mode)
     // Test scheduler
     auto backend_contexts = buildBackendContexts(*graph);
     auto scheduler = compiler::HEScheduler(backend_contexts,
-                                           compiler::fetchCompilerOptionsFromGlobalConfig(*graph));
+                                           compiler::fetchCompilerOptionsFromGlobalConfig(subgs));
     const auto br = scheduler.schedule(*graph);
     ASSERT_EQ(br->getBackend(mul1_op_idx)->config()->id(), "npu");
     ASSERT_EQ(br->getBackend(mul2_op_idx)->config()->id(), "npu");
@@ -556,7 +562,7 @@ TEST_F(SchedulerTest, branched_graph_profiling_mode)
     // Test scheduler
     auto backend_contexts = buildBackendContexts(*graph);
     auto scheduler = compiler::HEScheduler(backend_contexts,
-                                           compiler::fetchCompilerOptionsFromGlobalConfig(*graph));
+                                           compiler::fetchCompilerOptionsFromGlobalConfig(subgs));
     const auto br = scheduler.schedule(*graph);
     ASSERT_NE(br->getBackend(add_op_idx)->config()->id(),
               br->getBackend(mul1_op_idx)->config()->id());


### PR DESCRIPTION
For issue : #344
Draft PR : #154

This commit changes getting CompilerOptions from Graph to Subgraphs.

Signed-off-by: ragmani <ragmani0216@gmail.com>