### PR TITLE
[luci/service] Added Logical_And operator support in luci/service

### DIFF
--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -601,6 +601,12 @@ public:
     return loco::NodeShape{input_shape};
   }
 
+  loco::NodeShape visit(const luci::CircleLogicalAnd *node) final
+  {
+    const auto input_shape = loco::shape_get(node->x()).as<loco::TensorShape>();
+    return loco::NodeShape{input_shape};
+  }
+
   loco::NodeShape visit(const luci::CircleLogicalNot *node) final
   {
     const auto input_shape = loco::shape_get(node->x()).as<loco::TensorShape>();

--- a/compiler/luci/service/src/CircleTypeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleTypeInferenceRule.cpp
@@ -109,6 +109,11 @@ struct TypeInferenceAlgorithm final : public luci::CircleNodeVisitor<loco::DataT
     return loco::dtype_get(node->input(1));
   }
 
+  loco::DataType visit(const luci::CircleLogicalAnd *node) final
+  {
+    return loco::dtype_get(node->x());
+  }
+
   loco::DataType visit(const luci::CircleLogicalNot *node) final
   {
     return loco::dtype_get(node->x());


### PR DESCRIPTION
Added files to support Logical_And operator in luci/service. Ref #456 

ONE-DCO-1.0-Signed-off-by: Sunchit Sharma <sun.sharma@samsung.com>