### PR TITLE
[luci] fix missing virtual destructor in GraphBuilderBase

### DIFF
--- a/compiler/luci/import/include/luci/Import/GraphBuilderBase.h
+++ b/compiler/luci/import/include/luci/Import/GraphBuilderBase.h
@@ -39,6 +39,8 @@ struct GraphBuilderBase
 
   virtual bool validate(const ValidateArgs &) const = 0;
   virtual void build(const circle::OperatorT &op, GraphBuilderContext *context) const = 0;
+
+  virtual ~GraphBuilderBase() = default;
 };
 
 } // namespace luci


### PR DESCRIPTION
Virtual destructor is required for correct deletion of instances
of derived classes through a pointer to base class

ONE-DCO-1.0-Signed-off-by: Vladimir Plazun v.plazun@samsung.com