### PR TITLE
[luci_interpreter] Introduce kernels

### DIFF
--- a/compiler/luci-interpreter/src/CMakeLists.txt
+++ b/compiler/luci-interpreter/src/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(core)
+add_subdirectory(kernels)
 
 set(SOURCES
     "${LUCI_INTERPRETER_INCLUDE_DIR}/luci_interpreter/Interpreter.h"
@@ -12,6 +13,7 @@ target_include_directories(luci_interpreter PUBLIC "${LUCI_INTERPRETER_INCLUDE_D
 target_include_directories(luci_interpreter PRIVATE "${LUCI_INTERPRETER_SOURCE_DIR}")
 target_link_libraries(luci_interpreter PUBLIC luci_lang)
 target_link_libraries(luci_interpreter PRIVATE luci_interpreter_core)
+target_link_libraries(luci_interpreter PRIVATE luci_interpreter_kernels)
 target_link_libraries(luci_interpreter PRIVATE nncc_common)
 
 install(TARGETS luci_interpreter DESTINATION lib)

--- a/compiler/luci-interpreter/src/kernels/CMakeLists.txt
+++ b/compiler/luci-interpreter/src/kernels/CMakeLists.txt
@@ -1,0 +1,24 @@
+nnas_find_package(TensorFlowSource EXACT 2.1.0 QUIET)
+nnas_find_package(TensorFlowGEMMLowpSource EXACT 2.1.0 QUIET)
+nnas_find_package(TensorFlowEigenSource EXACT 2.1.0 QUIET)
+
+if (NOT TensorFlowSource_FOUND OR
+    NOT TensorFlowGEMMLowpSource_FOUND OR
+    NOT TensorFlowEigenSource_FOUND)
+  return()
+endif ()
+
+set(SOURCES
+    Utils.h
+    Utils.cpp)
+
+add_library(luci_interpreter_kernels STATIC ${SOURCES})
+set_target_properties(luci_interpreter_kernels PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_include_directories(luci_interpreter_kernels PUBLIC ${LUCI_INTERPRETER_SOURCE_DIR})
+target_include_directories(luci_interpreter_kernels SYSTEM PRIVATE
+    "${TensorFlowGEMMLowpSource_DIR}"
+    "${TensorFlowEigenSource_DIR}"
+    "${TensorFlowSource_DIR}")
+target_link_libraries(luci_interpreter_kernels
+    PUBLIC luci_interpreter_core
+    PRIVATE nncc_common)

--- a/compiler/luci-interpreter/src/kernels/Utils.cpp
+++ b/compiler/luci-interpreter/src/kernels/Utils.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "kernels/Utils.h"
+
+namespace luci_interpreter
+{
+namespace kernels
+{
+
+} // namespace kernels
+} // namespace luci_interpreter

--- a/compiler/luci-interpreter/src/kernels/Utils.h
+++ b/compiler/luci-interpreter/src/kernels/Utils.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef LUCI_INTERPRETER_KERNELS_UTILS_H
+#define LUCI_INTERPRETER_KERNELS_UTILS_H
+
+namespace luci_interpreter
+{
+namespace kernels
+{
+
+} // namespace kernels
+} // namespace luci_interpreter
+
+#endif // LUCI_INTERPRETER_KERNELS_UTILS_H


### PR DESCRIPTION
Draft PR #205.

Add empty `luci_interpreter_kernels` library with dependency on TensorFlow sources.

ONE-DCO-1.0-Signed-off-by: Sergei Barannikov <s.barannikov@samsung.com>