### PR TITLE
[mir] Fix compiler warnings

### DIFF
--- a/compiler/mir/src/mir_caffe2_importer/CMakeLists.txt
+++ b/compiler/mir/src/mir_caffe2_importer/CMakeLists.txt
@@ -25,4 +25,4 @@ set(MIR_CAFFE2_IMPORTER_SOURCES
 add_library(mir_caffe2_importer STATIC ${MIR_CAFFE2_IMPORTER_SOURCES})
 set_target_properties(mir_caffe2_importer PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_include_directories(mir_caffe2_importer PUBLIC ../../include/mir_caffe2_importer)
-target_link_libraries(mir_caffe2_importer PUBLIC mir PRIVATE caffe2proto)
+target_link_libraries(mir_caffe2_importer PUBLIC mir PRIVATE caffe2proto nncc_common)

--- a/compiler/mir/src/mir_caffe2_importer/caffe2_op_creator.cpp
+++ b/compiler/mir/src/mir_caffe2_importer/caffe2_op_creator.cpp
@@ -247,7 +247,7 @@ static mir::TensorVariant createTensor(const OperatorDef &op)
 //
 
 std::vector<mir::Operation::Output *>
-Caffe2OpCreator::convertConstant(const std::vector<mir::Operation::Output *> &inputs,
+Caffe2OpCreator::convertConstant(const std::vector<mir::Operation::Output *> &,
                                  const ::caffe2::OperatorDef &op)
 {
   // Constant may not contain any data if it is a fake input.
@@ -521,7 +521,7 @@ Caffe2OpCreator::convertClip(const std::vector<mir::Operation::Output *> &inputs
 
 std::vector<mir::Operation::Output *>
 Caffe2OpCreator::convertReshape(const std::vector<mir::Operation::Output *> &inputs,
-                                const ::caffe2::OperatorDef &op)
+                                const ::caffe2::OperatorDef &)
 {
   auto shape_op = dynamic_cast<mir::ops::ConstantOp *>(inputs[1]->getNode());
   if (shape_op == nullptr)

--- a/compiler/mir/src/mir_caffe2_importer/caffe2_proto_helper.cpp
+++ b/compiler/mir/src/mir_caffe2_importer/caffe2_proto_helper.cpp
@@ -27,7 +27,7 @@ const ::caffe2::Argument &findArgumentByName(RepArgument args, const std::string
   throw std::runtime_error("Can't find argument with name: " + name);
 }
 
-const bool hasArgument(RepArgument args, const std::string &name)
+bool hasArgument(RepArgument args, const std::string &name)
 {
   for (auto &arg : args)
     if (arg.name() == name)

--- a/compiler/mir/src/mir_caffe2_importer/caffe2_proto_helper.h
+++ b/compiler/mir/src/mir_caffe2_importer/caffe2_proto_helper.h
@@ -26,7 +26,7 @@ using RepArgument = const ::google::protobuf::RepeatedPtrField<::caffe2::Argumen
 
 const ::caffe2::Argument &findArgumentByName(RepArgument args, const std::string &name);
 
-const bool hasArgument(RepArgument args, const std::string &name);
+bool hasArgument(RepArgument args, const std::string &name);
 
 int getSingleArgument(const ::caffe2::OperatorDef &op, const std::string &argument_name,
                       int default_value);

--- a/compiler/mir/src/mir_caffe_importer/CMakeLists.txt
+++ b/compiler/mir/src/mir_caffe_importer/CMakeLists.txt
@@ -13,4 +13,4 @@ set(MIR_CAFFE_IMPORTER_SOURCES
 add_library(mir_caffe_importer STATIC ${MIR_CAFFE_IMPORTER_SOURCES})
 set_target_properties(mir_caffe_importer PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_include_directories(mir_caffe_importer PUBLIC ../../include/mir_caffe_importer)
-target_link_libraries(mir_caffe_importer PUBLIC mir PRIVATE caffeproto)
+target_link_libraries(mir_caffe_importer PUBLIC mir PRIVATE caffeproto nncc_common)

--- a/compiler/mir/src/mir_caffe_importer/caffe_importer.cpp
+++ b/compiler/mir/src/mir_caffe_importer/caffe_importer.cpp
@@ -145,7 +145,7 @@ std::unique_ptr<mir::Graph> CaffeImporter::importModel()
 
   setGraphOutputs(graph.get());
 
-  return std::move(graph);
+  return graph;
 }
 
 std::unique_ptr<mir::Graph> CaffeImporter::importModelFromBinaryFile(const std::string &filename)

--- a/compiler/mir/src/mir_caffe_importer/caffe_op_creator.cpp
+++ b/compiler/mir/src/mir_caffe_importer/caffe_op_creator.cpp
@@ -618,7 +618,7 @@ CaffeOpCreator::convertEmbed(const caffe::LayerParameter &layer,
 }
 
 std::vector<mir::Operation::Output *>
-CaffeOpCreator::convertSigmoid(const caffe::LayerParameter &layer,
+CaffeOpCreator::convertSigmoid(const caffe::LayerParameter &,
                                const std::vector<mir::Operation::Output *> &inputs)
 {
   auto result = createOp<ops::SigmoidOp>(inputs[0]);
@@ -626,7 +626,7 @@ CaffeOpCreator::convertSigmoid(const caffe::LayerParameter &layer,
 }
 
 std::vector<mir::Operation::Output *>
-CaffeOpCreator::convertTanH(const caffe::LayerParameter &layer,
+CaffeOpCreator::convertTanH(const caffe::LayerParameter &,
                             const std::vector<mir::Operation::Output *> &inputs)
 {
   auto tanh = createOp<ops::TanhOp>(inputs[0]);

--- a/compiler/mir/src/mir_onnx_importer/AttributeHelpers.h
+++ b/compiler/mir/src/mir_onnx_importer/AttributeHelpers.h
@@ -96,7 +96,7 @@ T getAttributeValue(const onnx::NodeProto &node, const std::string &name, T defa
 {
   const auto *attribute = findAttribute(node, name);
   if (attribute == nullptr)
-    return std::move(default_value);
+    return default_value;
   return getAttributeValue<T>(*attribute);
 }
 

--- a/compiler/mir/src/mir_onnx_importer/CMakeLists.txt
+++ b/compiler/mir/src/mir_onnx_importer/CMakeLists.txt
@@ -110,7 +110,7 @@ add_library(mir_onnx_importer STATIC ${MIR_ONNX_IMPORTER_SOURCES})
 set_target_properties(mir_onnx_importer PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_include_directories(mir_onnx_importer PUBLIC ../../include/mir_onnx_importer)
 target_include_directories(mir_onnx_importer PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(mir_onnx_importer PUBLIC mir mir_onnx_proto PRIVATE mir_interpreter)
+target_link_libraries(mir_onnx_importer PUBLIC mir mir_onnx_proto PRIVATE mir_interpreter nncc_common)
 
 nnas_find_package(GTest REQUIRED)
 

--- a/compiler/mir/src/mir_onnx_importer/ONNXImporterImpl.cpp
+++ b/compiler/mir/src/mir_onnx_importer/ONNXImporterImpl.cpp
@@ -152,7 +152,6 @@ void ONNXImporterImpl::createGraphInputs()
 {
   const auto &graph = _model->graph();
   const auto &initializer = graph.initializer();
-  const auto &value_info = graph.value_info();
 
   // Create all initializer Tensors
   for (const auto &tensor : initializer)

--- a/compiler/mir/src/mir_onnx_importer/Op/Pad.cpp
+++ b/compiler/mir/src/mir_onnx_importer/Op/Pad.cpp
@@ -42,7 +42,7 @@ void convertPadAttrName(const std::string &pad_attr_name, const onnx::NodeProto 
     throw std::runtime_error("Not supported Pad mode attribute!");
 
   const int num_dims = input->getShape().rank();
-  assert(pads.size() == num_dims * 2);
+  assert(static_cast<int>(pads.size()) == num_dims * 2);
   mir::PadOpAttributes attributes(num_dims);
   for (int i = 0; i < num_dims; i++)
   {

--- a/compiler/mir/src/mir_onnx_importer/Op/Transpose.cpp
+++ b/compiler/mir/src/mir_onnx_importer/Op/Transpose.cpp
@@ -33,7 +33,7 @@ void convertTransposeV1(const onnx::NodeProto &onnx_node, ConverterContext *cont
   assert(inputs.size() == 1);
   auto input = inputs[0];
 
-  const auto num_axes = input->getShape().rank();
+  const int num_axes = input->getShape().rank();
   std::vector<std::size_t> axis_order(num_axes);
   const auto *perm_attr = findAttribute(onnx_node, "perm");
 
@@ -45,7 +45,7 @@ void convertTransposeV1(const onnx::NodeProto &onnx_node, ConverterContext *cont
   else
   {
     const auto perm = getAttributeValue<std::vector<std::int64_t>>(*perm_attr);
-    assert(perm.size() == num_axes);
+    assert(static_cast<int>(perm.size()) == num_axes);
     std::copy(perm.cbegin(), perm.cend(), axis_order.begin());
   }
 

--- a/compiler/mir/src/mir_tflite_importer/CMakeLists.txt
+++ b/compiler/mir/src/mir_tflite_importer/CMakeLists.txt
@@ -18,4 +18,4 @@ set(MIR_TFLITE_IMPORTER_SOURCES
 add_library(mir_tflite_importer STATIC ${MIR_TFLITE_IMPORTER_SOURCES})
 set_target_properties(mir_tflite_importer PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_include_directories(mir_tflite_importer PUBLIC ../../include/mir_tflite_importer)
-target_link_libraries(mir_tflite_importer PUBLIC mir PRIVATE mir_tflite_schema)
+target_link_libraries(mir_tflite_importer PUBLIC mir PRIVATE mir_tflite_schema nncc_common)

--- a/compiler/mir/src/mir_tflite_importer/tflite_op_creator.cpp
+++ b/compiler/mir/src/mir_tflite_importer/tflite_op_creator.cpp
@@ -286,7 +286,7 @@ TFLiteOpCreator::convertReshape(const tflite::ReshapeOptionsT *opts,
   // TODO: we should also support "-1" values in new_shape, which means that correct
   // shape values must be calculated. Better do it in the shape inference module.
   Shape new_shape(opts->new_shape.size());
-  for (int i = 0; i < opts->new_shape.size(); ++i)
+  for (int i = 0; i < static_cast<int>(opts->new_shape.size()); ++i)
   {
     new_shape.dim(i) = opts->new_shape[i];
   }
@@ -639,7 +639,7 @@ TFLiteOpCreator::convertShape(const tflite::ShapeOptionsT *opts,
 }
 
 std::vector<mir::Operation::Output *>
-TFLiteOpCreator::convertHardSwish(const tflite::HardSwishOptionsT *opts,
+TFLiteOpCreator::convertHardSwish(const tflite::HardSwishOptionsT *,
                                   const std::vector<mir::Operation::Output *> &inputs)
 {
   auto result = createOp<ops::HardSwishOp>(inputs[0])->getOutput(0);


### PR DESCRIPTION
Link with the library which carries the `-Wall` option and fix warnings emitted by `g++-9.3`.

ONE-DCO-1.0-Signed-off-by: Sergei Barannikov <s.barannikov@samsung.com>
