### PR TITLE
[onert] Fix typo introduced during rsqrt

### DIFF
--- a/runtime/onert/backend/cpu/kernel/RoundLayer.h
+++ b/runtime/onert/backend/cpu/kernel/RoundLayer.h
@@ -39,7 +39,7 @@ public:
   void run();
   void runSync()
   {
-    // this rsqrttract method is used just for profiling and called for
+    // this abstract method is used just for profiling and called for
     // backend::acl_common::AclFunction
     run();
   }

--- a/runtime/onert/backend/cpu/kernel/RsqrtLayer.h
+++ b/runtime/onert/backend/cpu/kernel/RsqrtLayer.h
@@ -39,7 +39,7 @@ public:
   void run();
   void runSync()
   {
-    // this rsqrttract method is used just for profiling and called for
+    // this abstract method is used just for profiling and called for
     // backend::acl_common::AclFunction
     run();
   }


### PR DESCRIPTION
abstract became rsqrttract by replacing `abs` with `rsqrt`.
I searched the all same occurrence and confirmed there is no
similar mis-replacement within `sqrt` implementation PR.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>