### PR TITLE
[mio-tflite] Upgrade to 2.2.0

### DIFF
--- a/compiler/mio-tflite/CMakeLists.txt
+++ b/compiler/mio-tflite/CMakeLists.txt
@@ -4,7 +4,7 @@ if(NOT FlatBuffers_FOUND)
   return()
 endif(NOT FlatBuffers_FOUND)
 
-nnas_find_package(TensorFlowSource EXACT 2.1.0 QUIET)
+nnas_find_package(TensorFlowSource EXACT 2.2.0 QUIET)
 
 if(NOT TensorFlowSource_FOUND)
   return()


### PR DESCRIPTION
This will upgrade mio-tflite to use TensorFlow Source 2.2.0

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>