### PR TITLE
[luci] Shape,dtype inf ReduceAny

### DIFF
--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -796,6 +796,12 @@ public:
     return loco::NodeShape{output_shape};
   }
 
+  loco::NodeShape visit(const luci::CircleReduceAny *node) final
+  {
+    auto output_shape = infer_reducer(node->input(), node->reduction_indices(), node->keep_dims());
+    return loco::NodeShape{output_shape};
+  }
+
   loco::NodeShape visit(const luci::CircleReduceProd *node) final
   {
     auto output_shape = infer_reducer(node->input(), node->reduction_indices(), node->keep_dims());

--- a/compiler/luci/service/src/CircleTypeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleTypeInferenceRule.cpp
@@ -162,6 +162,11 @@ struct TypeInferenceAlgorithm final : public luci::CircleNodeVisitor<loco::DataT
 
   loco::DataType visit(const luci::CircleMul *node) final { return loco::dtype_get(node->x()); }
 
+  loco::DataType visit(const luci::CircleReduceAny *node) final
+  {
+    return loco::dtype_get(node->input());
+  }
+
   loco::DataType visit(const luci::CircleReduceProd *node) final
   {
     return loco::dtype_get(node->input());


### PR DESCRIPTION
This will enable shape and dtype inference for ReduceAny IR

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>