### PR TITLE
[onert] DynamicTensor: Adding ExecutorBase::changeTensor()

### DIFF
--- a/runtime/onert/backend/cpu/DynamicTensorManager.cc
+++ b/runtime/onert/backend/cpu/DynamicTensorManager.cc
@@ -50,6 +50,16 @@ void DynamicTensorManager::buildTensor(const ir::OperandIndex &ind,
   (*_tensors)[ind] = tensor;
 }
 
+void DynamicTensorManager::changeShape(const ir::OperandIndex &ind, const ir::Shape &new_shape)
+{
+  auto tensor = (*_tensors)[ind];
+  assert(tensor);
+
+  setShape(tensor.get(), new_shape);
+  // once the shape is changed, the output of operations using this tensor should be re-calculated
+  tensor->set_dynamic();
+}
+
 } // namespace cpu
 } // namespace backend
 } // namespace onert

--- a/runtime/onert/backend/cpu/DynamicTensorManager.h
+++ b/runtime/onert/backend/cpu/DynamicTensorManager.h
@@ -39,6 +39,7 @@ public:
 
   void allocate(const ir::OperandIndex &ind, const ir::Shape &new_shape) override;
   void buildTensor(const ir::OperandIndex &ind, const ir::OperandInfo &tensor_info);
+  void changeShape(const ir::OperandIndex &, const ir::Shape &) override;
 
 private:
   /**

--- a/runtime/onert/backend/cpu/operand/Tensor.h
+++ b/runtime/onert/backend/cpu/operand/Tensor.h
@@ -87,6 +87,7 @@ public:
   bool has_padding() const override { return false; }
   void access(const std::function<void(ITensor &tensor)> &fn) final;
   bool is_dynamic() const override { return _info.memAllocType() == ir::MemAllocType::DYNAMIC; }
+  void set_dynamic() override { _info.memAllocType(ir::MemAllocType::DYNAMIC); }
 
   void increase_ref()
   {

--- a/runtime/onert/core/include/backend/IDynamicTensorManager.h
+++ b/runtime/onert/core/include/backend/IDynamicTensorManager.h
@@ -41,6 +41,12 @@ public:
    * @brief Allocate memory for dynamic tensor
    */
   virtual void allocate(const ir::OperandIndex &, const ir::Shape &) = 0;
+
+  /**
+   * @brief Change shape of tensor, which makes the tensor "dynamic"
+   * @note  This should be called before execution.
+   */
+  virtual void changeShape(const ir::OperandIndex &, const ir::Shape &) = 0;
 };
 
 } // namespace backend

--- a/runtime/onert/core/include/backend/ITensor.h
+++ b/runtime/onert/core/include/backend/ITensor.h
@@ -54,6 +54,9 @@ public:
    */
   virtual bool is_dynamic() const { throw std::runtime_error("not yet implemented"); }
 
+  /// @brief set this tensor dynamic
+  virtual void set_dynamic() { throw std::runtime_error("not yet implemented"); }
+
   // set dim when this tensor is dynamic
   virtual void dimension(size_t /* index */, size_t /* dim */)
   {

--- a/runtime/onert/core/src/exec/ExecutorBase.h
+++ b/runtime/onert/core/src/exec/ExecutorBase.h
@@ -30,6 +30,7 @@
 #include "compiler/OperandContext.h"
 #include "exec/ExecTime.h"
 #include "exec/IFunction.h"
+#include "backend/IDynamicTensorManager.h"
 #include "backend/ITensorManager.h"
 #include "backend/ITensorBuilder.h"
 #include "exec/ExecutionObservee.h"
@@ -127,6 +128,8 @@ private:
 
     return std::make_unique<CopySink<T>>(buffer, length, operand.shape());
   }
+
+  void changeInputShape(const ir::OperandIndex &index, const ir::Shape &new_shape) override;
 
 protected:
   /**


### PR DESCRIPTION
This adds `ExecutorBase::changeTensor()` which calls `DynamicTensorManager::changeTensor()`.
This changes the shape of tensor, which makes the tensor "dynamic"

After #455
Parent issue: #88
Draft: #52

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>