### PR TITLE
[onert] DynamicTensor: Fix wrong iteration loop

### DIFF
--- a/runtime/onert/core/src/exec/FunctionSequence.cc
+++ b/runtime/onert/core/src/exec/FunctionSequence.cc
@@ -78,6 +78,8 @@ void FunctionSequenceForDynamicBackend::run()
 
     // run kernel
     function->run();
+
+    op_iter++;
   }
 }
 


### PR DESCRIPTION
Previously iterator does not increase, making test with more than 2 operator not working. 
This fixes the bug.

while working on #56 

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>