### PR TITLE
[onert/cpu] Member init MeanLayer class

### DIFF
--- a/runtime/onert/backend/cpu/kernel/MeanLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/MeanLayer.cc
@@ -29,7 +29,7 @@ namespace cpu
 namespace kernel
 {
 
-MeanLayer::MeanLayer() : _input(nullptr), _output(nullptr)
+MeanLayer::MeanLayer() : _input(nullptr), _output(nullptr), _axes(), _keep_dims(false)
 {
   // DO NOTHING
 }


### PR DESCRIPTION
Initizlizer member _axis, _keep_dims in MeanLayer class

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>