### PR TITLE
[onert] checking dynamic in assert of Tensor::increase_ref()

### DIFF
--- a/runtime/onert/backend/cpu/operand/Tensor.h
+++ b/runtime/onert/backend/cpu/operand/Tensor.h
@@ -91,7 +91,10 @@ public:
 
   void increase_ref()
   {
-    assert(_buffer != nullptr || _allocator != nullptr);
+    assert(is_dynamic() ||
+           // when not dynamic
+           (_buffer != nullptr || _allocator != nullptr));
+
     ++_num_references;
   }
   void decrease_ref()


### PR DESCRIPTION
This adds code to check dynamic tensor inside `Tensor::increase_ref()`.
When a tensor is dynamic, its memory is `null` before execution.

Parent issue: #56 
Draft: #52 

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>