### PR TITLE
[onert] adding shape inference for Tanh

### DIFF
--- a/runtime/onert/core/include/backend/ITensor.h
+++ b/runtime/onert/core/include/backend/ITensor.h
@@ -72,6 +72,12 @@ public:
  */
 void setShape(ITensor *tensor, const ir::Shape &new_shape);
 
+/**
+ * @brief Get ir::Shape of tensor
+ * @note  Higer dimension will be placed on front.
+ */
+ir::Shape getShape(ITensor *tensor);
+
 } // namespace backend
 } // namespace onert
 

--- a/runtime/onert/core/include/util/ShapeInference.h
+++ b/runtime/onert/core/include/util/ShapeInference.h
@@ -110,7 +110,7 @@ private:
   // TODO write op starting from P
   void visit(const ir::operation::Reshape &op);
   // TODO write op starting from S
-  // TODO write op starting from T
+  void visit(const ir::operation::Tanh &op);
   // TODO write op starting from U
   // TODO write op starting from Z
 
@@ -151,7 +151,7 @@ public:
   // TODO write op starting from P
   // TODO write op starting from R
   // TODO write op starting from S
-  // TODO write op starting from T
+  void visit(const ir::operation::Tanh &op);
   // TODO write op starting from U
   // TODO write op starting from Z
 

--- a/runtime/onert/core/src/backend/ITensor.cc
+++ b/runtime/onert/core/src/backend/ITensor.cc
@@ -28,5 +28,14 @@ void setShape(ITensor *tensor, const ir::Shape &new_shape)
     tensor->dimension(i, new_shape.dim(i));
 }
 
+ir::Shape getShape(ITensor *tensor)
+{
+  onert::ir::Shape shape(tensor->num_dimensions());
+  for (uint32_t d = 0; d < tensor->num_dimensions(); d++)
+    shape.dim(d) = tensor->dimension(d);
+
+  return shape;
+}
+
 } // namespace backend
 } // namespace onert


### PR DESCRIPTION
This adds code related to _static_ and _dynamic_ shape inference of `Tanh`.

:family: Parent issue: #56  
:beer: Draft: #52 

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>