### PR TITLE
[luci/service] ZerosLike type and shape inference support

### DIFF
--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -1241,6 +1241,13 @@ public:
     return loco::NodeShape{input_shape};
   }
 
+  loco::NodeShape visit(const luci::CircleZerosLike *node) final
+  {
+    auto input_shape = loco::shape_get(node->input()).as<loco::TensorShape>();
+
+    return loco::NodeShape{input_shape};
+  }
+
   // Circle Only
   loco::NodeShape visit(const luci::CircleInstanceNorm *node) final
   {

--- a/compiler/luci/service/src/CircleTypeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleTypeInferenceRule.cpp
@@ -269,6 +269,11 @@ struct TypeInferenceAlgorithm final : public luci::CircleNodeVisitor<loco::DataT
     return loco::dtype_get(node->input(0));
   }
 
+  loco::DataType visit(const luci::CircleZerosLike *node) final
+  {
+    return loco::dtype_get(node->input());
+  }
+
   // Circle Only
   loco::DataType visit(const luci::CircleInstanceNorm *node) final
   {


### PR DESCRIPTION
Suport type and shape inference for ZerosLike operator

ONE-DCO-1.0-Signed-off-by: Vladimir Plazun v.plazun@samsung.com