### PR TITLE
[loco] Remove redundant std::move

### DIFF
--- a/compiler/loco/src/IR/Graph.cpp
+++ b/compiler/loco/src/IR/Graph.cpp
@@ -37,7 +37,7 @@ std::unique_ptr<loco::TensorShape> make_tensor_shape(std::initializer_list<loco:
     assert(axis == dims.size());
   }
 
-  return std::move(tensor_shape);
+  return tensor_shape;
 }
 
 } // namespace


### PR DESCRIPTION
Issue #903.

Remove `std::move` which causes a warning with `-Wall`.

ONE-DCO-1.0-Signed-off-by: Sergei Barannikov <s.barannikov@samsung.com>