### PR TITLE
[onert] renaming var: graph -> subg

### DIFF
--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -220,12 +220,12 @@ void Compiler::compile(void)
 
   // Lower: Assign backend
   std::unordered_map<ir::SubgraphIndex, std::unique_ptr<ir::LoweredGraph>> lowered_subgs;
-  _subgraphs->iterate([&](const ir::SubgraphIndex &index, ir::Graph &graph) {
-    onert::dumper::dot::DotDumper dot_dumper(graph, dump_level);
+  _subgraphs->iterate([&](const ir::SubgraphIndex &index, ir::Graph &subg) {
+    onert::dumper::dot::DotDumper dot_dumper(subg, dump_level);
     dot_dumper.dump(nnfw::misc::str("before_lower_subg-", index.value()));
 
     // Lower: Assign backend
-    lowered_subgs[index] = std::make_unique<ir::LoweredGraph>(graph, _options);
+    lowered_subgs[index] = std::make_unique<ir::LoweredGraph>(subg, _options);
 
     // Check backend(s) for subgraph support FP16
     bool backends_support_fp16 = true;
@@ -241,7 +241,7 @@ void Compiler::compile(void)
       Fp32ToFp16Converter(*lowered_subgs[index]).run();
     }
 
-    graph.setSubgraphs(nullptr);
+    subg.setSubgraphs(nullptr);
   });
 
   _subgraphs.reset();


### PR DESCRIPTION
This renames var name from `graph` to `subg`.

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>