### PR TITLE
[luci] Put CircleSin sort order

### DIFF
--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -928,13 +928,6 @@ public:
     return loco::NodeShape{input_shape};
   }
 
-  loco::NodeShape visit(const luci::CircleSin *node) final
-  {
-    auto x_shape = loco::shape_get(node->x()).as<loco::TensorShape>();
-
-    return loco::NodeShape{x_shape};
-  }
-
   loco::NodeShape visit(const luci::CircleSelect *node) final
   {
     auto t_shape = loco::shape_get(node->t()).as<loco::TensorShape>();
@@ -955,6 +948,13 @@ public:
     }
 
     return loco::NodeShape{t_shape};
+  }
+
+  loco::NodeShape visit(const luci::CircleSin *node) final
+  {
+    auto x_shape = loco::shape_get(node->x()).as<loco::TensorShape>();
+
+    return loco::NodeShape{x_shape};
   }
 
   loco::NodeShape visit(const luci::CircleSlice *node) final


### PR DESCRIPTION
This will put shape inference of CircleSin in alphabetical sort order

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>