### PR TITLE
[luci] Shape, dtype inf for SHAPE

### DIFF
--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -950,6 +950,18 @@ public:
     return loco::NodeShape{t_shape};
   }
 
+  loco::NodeShape visit(const luci::CircleShape *node) final
+  {
+    auto input_shape = loco::shape_get(node->input()).as<loco::TensorShape>();
+
+    loco::TensorShape output_shape;
+
+    output_shape.rank(1);
+    output_shape.dim(0) = input_shape.rank();
+
+    return loco::NodeShape{output_shape};
+  }
+
   loco::NodeShape visit(const luci::CircleSin *node) final
   {
     auto x_shape = loco::shape_get(node->x()).as<loco::TensorShape>();

--- a/compiler/luci/service/src/CircleTypeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleTypeInferenceRule.cpp
@@ -200,6 +200,8 @@ struct TypeInferenceAlgorithm final : public luci::CircleNodeVisitor<loco::DataT
     return loco::dtype_get(node->t());
   }
 
+  loco::DataType visit(const luci::CircleShape *node) final { return node->out_type(); }
+
   loco::DataType visit(const luci::CircleSin *node) final { return loco::dtype_get(node->x()); }
 
   loco::DataType visit(const luci::CircleSlice *node) final


### PR DESCRIPTION
This will enable shape and dtype inference for SHAPE Op

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>