### PR TITLE
[onert] fix wrong index of Pad op in OperationValidator

### DIFF
--- a/runtime/onert/core/src/compiler/OperationValidator.cc
+++ b/runtime/onert/core/src/compiler/OperationValidator.cc
@@ -1003,7 +1003,7 @@ void OperationValidator::visit(const ir::operation::Pad &node)
 {
   const auto input_index{node.getInputs().at(ir::operation::Pad::Input::INPUT)};
   const auto pad_index{node.getInputs().at(ir::operation::Pad::Input::PAD)};
-  const auto output_index{node.getInputs().at(0)};
+  const auto output_index{node.getOutputs().at(0)};
 
   const auto &pad_shape = _ctx.at(pad_index).shape();
   const auto input_rank = static_cast<int32_t>(_ctx.at(input_index).shape().rank());


### PR DESCRIPTION
This fixes wrong index of Pad op in OperationValidator.

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>