### PR TITLE
[onert] Run OperationValidator against lowered sugbraphs

### DIFF
--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -188,13 +188,6 @@ void Compiler::compile(void)
    * Prepare compilation phase
    ***************************************************/
 
-  // Operation validation check
-  assert(_subgraphs);
-  assert(_subgraphs->at(ir::SubgraphIndex{0}));
-  _subgraphs->iterate([](const onert::ir::SubgraphIndex &, const onert::ir::Graph &graph) {
-    OperationValidator{graph}();
-  });
-
   // mark an input tensor "dynamic" when the tensor has unknown dim
   setInputToDynamicTensor(_subgraphs->primary());
 
@@ -249,6 +242,13 @@ void Compiler::compile(void)
   /*************************************************************
    *  Backend independent analysis & optimization phase finished
    *************************************************************/
+
+  // operation validation
+  for (auto &pair : lowered_subgs)
+  {
+    auto &lowered_subg = pair.second;
+    compiler::OperationValidator{lowered_subg->graph()}();
+  }
 
   _executors = std::make_shared<exec::ExecutorMap>();
   for (auto &pair : lowered_subgs)


### PR DESCRIPTION
This make `OperationValidator` run against lowered subgraphs.

When any input or output tensor shape is not known like `Relu` below, operation validator fails because the input shape of relu is not known. 

```
reshape = Reshape(placeholder1, placeholder2) // the output shape cannot be known at compilation time
out = Relu(reshape)
```

Therefore, `OperationValidator` should run at least after running compile-time shape inferer.

Currently, compile-time shape inferer is done while making lowered graph. Thus `OperationValidator` should run after making lowered graph.

:family: parent issue: #56 
:beer: draft: #52 

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>