### PR TITLE
[onert] Adding DynamicInferer for Reshape op

### DIFF
--- a/runtime/onert/core/include/util/ShapeInference.h
+++ b/runtime/onert/core/include/util/ShapeInference.h
@@ -149,7 +149,7 @@ public:
   // TODO write op starting from M
   // TODO write op starting from N
   // TODO write op starting from P
-  // TODO write op starting from R
+  void visit(const ir::operation::Reshape &op);
   // TODO write op starting from S
   void visit(const ir::operation::Tanh &op);
   // TODO write op starting from U

--- a/runtime/onert/core/src/util/ShapeInference.cc
+++ b/runtime/onert/core/src/util/ShapeInference.cc
@@ -338,6 +338,33 @@ void StaticInferer::visit(const ir::operation::Tanh &op)
 // TODO write op starting from U
 // TODO write op starting from Z
 
+} // namespace shape_inference
+} // namespace onert
+
+// helper for DynamicInferer
+namespace
+{
+
+using namespace onert;
+
+bool isReshapableShape(const backend::ITensor *input, ir::Shape &shape)
+{
+  size_t input_elem_conut = 1;
+  {
+    for (size_t axis = 0; axis < input->num_dimensions(); axis++)
+      input_elem_conut *= input->dimension(axis);
+  }
+
+  return (input_elem_conut == shape.num_elements());
+}
+
+} // namespace
+
+namespace onert
+{
+namespace shape_inference
+{
+
 /*
  * DynamicInferer
 
@@ -355,7 +382,57 @@ void StaticInferer::visit(const ir::operation::Tanh &op)
 // TODO write op starting from M
 // TODO write op starting from N
 // TODO write op starting from P
-// TODO write op starting from R
+
+void DynamicInferer::visit(const ir::operation::Reshape &op)
+{
+  // check if output is not dynamic
+  auto output_ind = op.getOutputs().at(0);
+  auto *output = _tensor_registry->getITensor(output_ind);
+  if (!output->is_dynamic())
+    return;
+
+  // from op, access the buffer of second input to read new shape
+  auto new_shape_ind = op.getInputs().at(ir::operation::Reshape::Input::SHAPE);
+  auto &new_shape_op = _operands.at(new_shape_ind);
+
+  // if shape is from Const, TFLC put the shape of output into tensor
+  if (new_shape_op.isConstant())
+  {
+    // no change on output shape
+    return;
+  }
+
+  // getting output shape by reading new_shape tensor buffer
+  auto new_shape = _tensor_registry->getITensor(new_shape_ind);
+  assert(new_shape);
+
+  int32_t *new_shape_buf = reinterpret_cast<int32_t *>(new_shape->buffer());
+  assert(new_shape_buf);
+
+  auto new_rank = new_shape->dimension(0);
+
+  ir::Shape output_shape(new_rank);
+  for (size_t d = 0; d < new_rank; d++)
+    output_shape.dim(d) = new_shape_buf[d];
+
+  // sanity check
+  {
+    auto input_ind = op.getInputs().at(ir::operation::Reshape::Input::INPUT);
+    auto input = _tensor_registry->getITensor(input_ind);
+    assert(input);
+
+    if (!isReshapableShape(input, output_shape))
+      throw std::runtime_error("Reshape: 2nd param is not compatible with the shape of input");
+  }
+
+  // set output shape and output buffer
+  setShape(output, output_shape);
+
+  assert(output->buffer() == nullptr);
+  _dynamic_tensor_manager->allocate(output_ind, output_shape);
+  assert(output->buffer() != nullptr);
+}
+
 // TODO write op starting from S
 
 void DynamicInferer::visit(const ir::operation::Tanh &op)


### PR DESCRIPTION
This adds `DynamicInferer` for `Reshape` op.

:family: parent #56 
:beer: draft #52 

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>