### PR TITLE
[onert] Refine ICLTensor and CLTensor

### DIFF
--- a/runtime/onert/backend/acl_cl/operand/CLTensor.cc
+++ b/runtime/onert/backend/acl_cl/operand/CLTensor.cc
@@ -43,10 +43,6 @@ arm_compute::CLTensor *CLTensor::handle() { return _cl_tensor.get(); }
 
 arm_compute::CLTensorAllocator *CLTensor::allocator() { return _cl_tensor->allocator(); }
 
-void CLTensor::map(bool blocking) { _cl_tensor->map(blocking); }
-
-void CLTensor::unmap() { _cl_tensor->unmap(); }
-
 void CLTensor::setBuffer(void *host_ptr)
 {
   // Constructs a Buffer on a user-supplied memory

--- a/runtime/onert/backend/acl_cl/operand/CLTensor.h
+++ b/runtime/onert/backend/acl_cl/operand/CLTensor.h
@@ -50,8 +50,6 @@ public:
 
 public:
   arm_compute::CLTensorAllocator *allocator();
-  void map(bool blocking = true);
-  void unmap();
   /** Set given buffer as the buffer of the tensor
    *
    * @note Ownership of the memory is not transferred to this object.

--- a/runtime/onert/backend/acl_cl/operand/ICLTensor.h
+++ b/runtime/onert/backend/acl_cl/operand/ICLTensor.h
@@ -37,9 +37,11 @@ public:
   arm_compute::ICLTensor *handle() override = 0;
 
 public:
+  void access(const std::function<void(ITensor &tensor)> &fn) final;
+
+private:
   void map(cl::CommandQueue &q, bool blocking = true) { return handle()->map(q, blocking); }
   void unmap(cl::CommandQueue &q) { return handle()->unmap(q); }
-  void access(const std::function<void(ITensor &tensor)> &fn) final;
 };
 
 } // namespace operand


### PR DESCRIPTION
- `ICLTensor` : Make `map` and `unmap` private
- `CLTensor` : remove unused methods `map` and `unmap`

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>