### PR TITLE
[onert] skip ConstantInsertion pass if one backend is used

### DIFF
--- a/runtime/onert/core/src/ir/LoweredGraph.cc
+++ b/runtime/onert/core/src/ir/LoweredGraph.cc
@@ -241,8 +241,6 @@ void LoweredGraph::makeOpSequences(
         {
           auto &&lower_info = operands_lower_info.at(operand);
           lower_info->addUsePermuteFactor(operand::PermuteFactor{backend, backend_layout});
-          if (_graph.operands().at(operand).isConstant())
-            lower_info->addDefPermuteFactor(operand::PermuteFactor{backend, backend_layout});
         }
         for (auto operand : node.getOutputs())
         {


### PR DESCRIPTION
ConstantInsertionPass is required in multiple backends.
It skips ConstantInsertionPass when single backend is used.

It adds DefPermuteFactor for constant input tensor out of
ConstantInsertionPass to fix unittest Trivial.AddThree failure.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>