### PR TITLE
[luci] Shape, dtype inf for RELU_N1_TO_1

### DIFF
--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -863,6 +863,13 @@ public:
     return loco::NodeShape{input_shape};
   }
 
+  loco::NodeShape visit(const luci::CircleReluN1To1 *node) final
+  {
+    auto input_shape = loco::shape_get(node->features()).as<loco::TensorShape>();
+
+    return loco::NodeShape{input_shape};
+  }
+
   /**
    * @note  CircleReshape has new shape info in two places: 2nd input and attribute.
    *        This shape inference forces both to exist, and match each other.

--- a/compiler/luci/service/src/CircleTypeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleTypeInferenceRule.cpp
@@ -191,6 +191,11 @@ struct TypeInferenceAlgorithm final : public luci::CircleNodeVisitor<loco::DataT
     return loco::dtype_get(node->features());
   }
 
+  loco::DataType visit(const luci::CircleReluN1To1 *node) final
+  {
+    return loco::dtype_get(node->features());
+  }
+
   loco::DataType visit(const luci::CircleReshape *node) final
   {
     return loco::dtype_get(node->tensor());


### PR DESCRIPTION
This will enable shape and dtype inference for RELU_N1_TO_1 IR

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>