### PR TITLE
[onert] Separate ConstantInsertionPass

### DIFF
--- a/runtime/onert/core/src/ir/LoweredGraph.cc
+++ b/runtime/onert/core/src/ir/LoweredGraph.cc
@@ -20,6 +20,7 @@
 #include <sstream>
 #include "util/logging.h"
 #include "pass/ConstantInsertionPass.h"
+#include "pass/ConstantLoweringPass.h"
 #include "pass/PermutationOperationPass.h"
 #include "pass/PermutationInsertionPass.h"
 #include "ir/GraphIterator.h"
@@ -95,6 +96,9 @@ LoweredGraph::LoweredGraph(const Graph &graph, const compiler::CompilerOptions &
 
     pass::ConstantInsertionPass ci_pass(*this);
     ci_pass.run();
+
+    pass::ConstantLoweringPass cl_pass(*this);
+    cl_pass.run();
 
     // Set LowerInfo for each operand from the operand::LowerInfo holder
     manipulateLowerInfo(operands_lower_info);
@@ -288,6 +292,7 @@ void LoweredGraph::manipulateLowerInfo(
     auto &&lower_info = operands_lower_info.at(index);
     if (_graph.operands().at(index).isConstant())
     {
+      // In case of that a constant is Graph's output and not input or output of any operation
       lower_info->addDefPermuteFactor(operand::PermuteFactor{
           default_backend,
           Layout::NHWC // TODO Get frontend layout of this node from IR

--- a/runtime/onert/core/src/ir/pass/ConstantInsertionPass.cc
+++ b/runtime/onert/core/src/ir/pass/ConstantInsertionPass.cc
@@ -50,9 +50,6 @@ void ConstantInsertionPass::callback(const OperationIndex &node_index, Operation
         const_cast<std::list<OperationIndex> &>(new_object.getUses().list()).clear();
         const auto new_index = _graph.operands().emplace(new_object);
         _replace_operands_map[key] = new_index;
-
-        _lowered_graph.setLowerInfo(new_index, std::make_unique<operand::LowerInfo>());
-        _lowered_graph.getLowerInfo(new_index)->addDefPermuteFactor(factor);
       }
 
       const auto replaced_input = _replace_operands_map[key];
@@ -69,10 +66,6 @@ void ConstantInsertionPass::callback(const OperationIndex &node_index, Operation
       auto &replaced_object = _graph.operands().at(replaced_input);
       replaced_object.appendUse(node_index);
 
-      // Update lower_info
-      auto replaced_lower_info = _lowered_graph.getLowerInfo(replaced_input);
-      replaced_lower_info->addUsePermuteFactor(factor);
-
       // Remove this node from def and uses of origin operand
       if (object.getDef().contains(node_index))
       {
@@ -84,7 +77,6 @@ void ConstantInsertionPass::callback(const OperationIndex &node_index, Operation
       if (object.getDef().size() == 0 && object.getUses().size() == 0)
       {
         _graph.removeOperand(input);
-        _lowered_graph.removeLowerInfo(input);
       }
     }
   }

--- a/runtime/onert/core/src/ir/pass/ConstantLoweringPass.cc
+++ b/runtime/onert/core/src/ir/pass/ConstantLoweringPass.cc
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ConstantLoweringPass.h"
+
+#include "backend/Backend.h"
+#include <ir/Graph.h>
+#include <ir/operand/PermuteFactor.h>
+#include <util/Utils.h>
+
+namespace onert
+{
+namespace ir
+{
+namespace pass
+{
+
+void ConstantLoweringPass::callback(const OperationIndex &node_index, Operation &node)
+{
+  const auto &op_sequence_index = _lowered_graph.op_seqs().getOperation(node_index);
+  const auto op_seq_lower_info = _lowered_graph.getLowerInfo(op_sequence_index);
+  const auto backend = op_seq_lower_info->backend();
+  const auto layout = op_seq_lower_info->layout();
+  const auto factor = operand::PermuteFactor{backend, layout};
+
+  // Now this runtime does not support the node making output of operation as constant
+  for (const auto input : node.getInputs())
+  {
+    auto &object = _graph.operands().at(input);
+    if (object.isConstant())
+    {
+      // All constant operand are already assinged at each backend. So a constant has `def` and
+      // `use` as the same PermuteFactor
+      _lowered_graph.setLowerInfo(input, std::make_unique<operand::LowerInfo>());
+      _lowered_graph.getLowerInfo(input)->addDefPermuteFactor(factor);
+      _lowered_graph.getLowerInfo(input)->addUsePermuteFactor(factor);
+    }
+  }
+}
+
+} // namespace pass
+} // namespace ir
+} // namespace onert

--- a/runtime/onert/core/src/ir/pass/ConstantLoweringPass.h
+++ b/runtime/onert/core/src/ir/pass/ConstantLoweringPass.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_GRAPH_PASS_CONSTANT_LOWERING_PASS_H__
+#define __ONERT_GRAPH_PASS_CONSTANT_LOWERING_PASS_H__
+
+#include <ir/Index.h>
+#include "LoweredOperationPass.h"
+
+namespace onert
+{
+namespace ir
+{
+namespace pass
+{
+
+class ConstantLoweringPass : public LoweredOperationPass
+{
+public:
+  using LoweredOperationPass::LoweredOperationPass;
+
+public:
+  std::string id() final { return "ConstantLoweringPass"; }
+
+public:
+  void callback(const OperationIndex &index, Operation &node) final;
+};
+
+} // namespace pass
+} // namespace ir
+} // namespace onert
+
+#endif // __ONERT_GRAPH_PASS_CONSTANT_LOWERING_PASS_H__


### PR DESCRIPTION
For https://github.com/Samsung/ONE/issues/982#issuecomment-630565939

This commit separates ConstantInsertionPass into itself and ConstantLoweringPass
  - ConstantInsertionPass : Assign constant operand at each backend
  - ConstantLoweringPass : Add lowered info of all contant operand

Signed-off-by: ragmani <ragmani0216@gmail.com>