### PR TITLE
[onert] Remove cpu Tensor method duplication

### DIFF
--- a/runtime/onert/backend/cpu/kernel/ConcatLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/ConcatLayer.cc
@@ -72,8 +72,8 @@ void ConcatLayer::concatenationQuant8()
   std::vector<float> input_scales(num_inputs);
   for (uint32_t i = 0; i < num_inputs; i++)
   {
-    input_zeropoints[i] = _inputs[i]->offset();
-    input_scales[i] = _inputs[i]->scale();
+    input_zeropoints[i] = _inputs[i]->data_offset();
+    input_scales[i] = _inputs[i]->data_scale();
   }
 
   nnfw::cker::ConcatenationParams op_params;
@@ -81,8 +81,8 @@ void ConcatLayer::concatenationQuant8()
   op_params.inputs_count = num_inputs;
   op_params.input_zeropoint = input_zeropoints.data();
   op_params.input_scale = input_scales.data();
-  op_params.output_zeropoint = _output->offset();
-  op_params.output_scale = _output->scale();
+  op_params.output_zeropoint = _output->data_offset();
+  op_params.output_scale = _output->data_scale();
 
   std::vector<nnfw::cker::Shape *> inputDimsPtr;
   std::vector<nnfw::cker::Shape> inputDims;

--- a/runtime/onert/backend/cpu/kernel/ConvolutionLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/ConvolutionLayer.cc
@@ -96,9 +96,9 @@ void ConvolutionLayer::convQuant8()
   op_params.padding_type = getPaddingType(_paddingType);
   op_params.padding_values.width = _paddingLeft;
   op_params.padding_values.height = _paddingTop;
-  op_params.input_offset = -_input->offset();
-  op_params.weights_offset = -_kernel->offset();
-  op_params.output_offset = _output->offset();
+  op_params.input_offset = -_input->data_offset();
+  op_params.weights_offset = -_kernel->data_offset();
+  op_params.output_offset = _output->data_offset();
   op_params.output_multiplier = output_multiplier;
   op_params.output_shift = output_shift;
   op_params.quantized_activation_min = output_activation_min;

--- a/runtime/onert/backend/cpu/kernel/DepthwiseConvolutionLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/DepthwiseConvolutionLayer.cc
@@ -80,9 +80,9 @@ void DepthwiseConvolutionLayer::convQuant8()
   op_params.padding_values.width = _paddingLeft;
   op_params.padding_values.height = _paddingTop;
   op_params.depth_multiplier = _multiplier;
-  op_params.input_offset = -_input->offset();
-  op_params.weights_offset = -_kernel->offset();
-  op_params.output_offset = _output->offset();
+  op_params.input_offset = -_input->data_offset();
+  op_params.weights_offset = -_kernel->data_offset();
+  op_params.output_offset = _output->data_offset();
   op_params.output_multiplier = output_multiplier;
   op_params.output_shift = output_shift;
   op_params.quantized_activation_min = output_activation_min;

--- a/runtime/onert/backend/cpu/kernel/FullyConnectedLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/FullyConnectedLayer.cc
@@ -69,9 +69,9 @@ void FullyConnectedLayer::fullyConnectedQuant8()
                                 &output_activation_max);
 
   nnfw::cker::FullyConnectedParams op_params;
-  op_params.input_offset = -_input->offset();
-  op_params.weights_offset = -_weights->offset();
-  op_params.output_offset = _output->offset();
+  op_params.input_offset = -_input->data_offset();
+  op_params.weights_offset = -_weights->data_offset();
+  op_params.output_offset = _output->data_offset();
   op_params.output_multiplier = output_multiplier;
   op_params.output_shift = output_shift;
   op_params.quantized_activation_min = output_activation_min;
@@ -95,7 +95,7 @@ void FullyConnectedLayer::fullyConnectedHybrid()
 
   nnfw::cker::FullyConnectedParams op_params;
   op_params.activation = convertActivationType(_activation);
-  op_params.weights_scale = _weights->scale();
+  op_params.weights_scale = _weights->data_scale();
 
   nnfw::cker::FullyConnectedHybrid(
       op_params, convertTensorToCkerShape(_input),

--- a/runtime/onert/backend/cpu/kernel/OperationUtils.cc
+++ b/runtime/onert/backend/cpu/kernel/OperationUtils.cc
@@ -82,9 +82,9 @@ void GetQuantizedConvolutionMultiplier(const operand::Tensor *input, const opera
                                        const operand::Tensor *bias, const operand::Tensor *output,
                                        double *multiplier)
 {
-  const double input_product_scale = input->scale() * filter->scale();
-  const double bias_scale = bias->scale();
-  const double output_scale = output->scale();
+  const double input_product_scale = input->data_scale() * filter->data_scale();
+  const double bias_scale = bias->data_scale();
+  const double output_scale = output->data_scale();
   // The following conditions must be guaranteed by the training pipeline.
   UNUSED_RELEASE(bias_scale);
   assert(std::abs(input_product_scale - bias_scale) <=
@@ -150,8 +150,8 @@ void CalculateActivationRangeUint8(ir::Activation activation, const operand::Ten
 {
   const int32_t qmin = std::numeric_limits<uint8_t>::min();
   const int32_t qmax = std::numeric_limits<uint8_t>::max();
-  const auto scale = output->scale();
-  const auto zero_point = output->offset();
+  const auto scale = output->data_scale();
+  const auto zero_point = output->data_offset();
   auto quantize = [scale, zero_point](float f) {
     return zero_point + static_cast<int32_t>(std::round(f / scale));
   };

--- a/runtime/onert/backend/cpu/kernel/SoftMaxLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/SoftMaxLayer.cc
@@ -126,13 +126,13 @@ void SoftMaxLayer::softmaxQuant8()
   {
     throw std::runtime_error{"only 2D and 4D tensors supported"};
   }
-  if (_output->offset() != 0 || _output->scale() != 1.f / 256)
+  if (_output->data_offset() != 0 || _output->data_scale() != 1.f / 256)
   {
     throw std::runtime_error{"incorrect scale / offset for output"};
   }
   static const int32_t kScaledDiffIntegerBits = 5;
   const double input_beta_real_multiplier = std::min(
-      1.0 * _beta * _input->scale() * (1 << (31 - kScaledDiffIntegerBits)), (1ll << 31) - 1.0);
+      1.0 * _beta * _input->data_scale() * (1 << (31 - kScaledDiffIntegerBits)), (1ll << 31) - 1.0);
   int32_t input_multiplier = 0;
   int32_t input_left_shift = 0;
   QuantizeMultiplierGreaterThanOne(input_beta_real_multiplier, &input_multiplier,

--- a/runtime/onert/backend/cpu/operand/Tensor.h
+++ b/runtime/onert/backend/cpu/operand/Tensor.h
@@ -55,8 +55,6 @@ public:
     assert(_buffer == nullptr && _allocator == nullptr);
     _allocator = alloc;
   }
-  float scale() const { return _info.typeInfo().scale(); }
-  int32_t offset() const { return _info.typeInfo().offset(); }
 
 public:
   uint8_t *buffer() const override


### PR DESCRIPTION
Remove duplications - `scale()` and `offset()`.
Use `data_scale()` and `data_offset()` instead.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>