### PR TITLE
[luci] Revise service test

### DIFF
--- a/compiler/luci/service/src/CircleShapeInferenceRule.test.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.test.cpp
@@ -51,35 +51,36 @@ TEST(CircleShapeInferenceRuleTest, minimal_with_CircleRelu)
 {
   // Create a simple network
   luci::test::TestGraph graph;
-  auto tfl_node = graph.append<luci::CircleRelu>(graph.pull);
-  graph.complete(tfl_node);
+  auto relu_node = graph.append<luci::CircleRelu>(graph.input_node);
+  graph.complete(relu_node);
 
   // set shape
   {
-    graph.pull->rank(2);
-    graph.pull->dim(0) = 3;
-    graph.pull->dim(1) = 4;
+    graph.input_node->rank(2);
+    graph.input_node->dim(0) = 3;
+    graph.input_node->dim(1) = 4;
+
+    graph.output_node->rank(2);
+    graph.output_node->dim(0) = 3;
+    graph.output_node->dim(1) = 4;
+
+    luci::test::graph_input_shape(graph.input_node);
+    luci::test::graph_output_shape(graph.output_node);
   }
 
   // pre-check
-  ASSERT_FALSE(loco::shape_known(tfl_node));
+  ASSERT_FALSE(loco::shape_known(relu_node));
 
   // shape inference
-  luci::CircleShapeInferenceRule tfl_rule;
-  loco::CanonicalShapeInferenceRule canonical_rule;
-  loco::MultiDialectShapeInferenceRule rules;
-
-  rules.bind(loco::CanonicalDialect::get(), &canonical_rule)
-      .bind(luci::CircleDialect::get(), &tfl_rule);
-
-  loco::apply(&rules).to(graph.g.get());
+  while (shape_pass(graph.graph()) == true)
+    ;
 
   // Verify
   {
-    ASSERT_TRUE(loco::shape_known(tfl_node));
-    ASSERT_EQ(loco::Domain::Tensor, loco::shape_get(tfl_node).domain());
+    ASSERT_TRUE(loco::shape_known(relu_node));
+    ASSERT_EQ(loco::Domain::Tensor, loco::shape_get(relu_node).domain());
 
-    auto shape = loco::shape_get(tfl_node).as<loco::TensorShape>();
+    auto shape = loco::shape_get(relu_node).as<loco::TensorShape>();
     ASSERT_EQ(2, shape.rank());
     ASSERT_EQ(3, shape.dim(0));
     ASSERT_EQ(4, shape.dim(1));
@@ -91,40 +92,40 @@ TEST(CircleShapeInferenceRuleTest, minimal_with_CircleRelu)
 TEST(CircleShapeInferenceRuleTest, avgpool2d_valid)
 {
   luci::test::TestGraph graph;
-  auto tfl_node = graph.append<luci::CircleAveragePool2D>(graph.pull);
+  auto avg_node = graph.append<luci::CircleAveragePool2D>(graph.input_node);
   graph.complete();
 
-  auto pull = graph.pull;
+  auto input_node = graph.input_node;
   {
-    pull->shape({1, 4, 3, 1});
+    input_node->shape({1, 4, 3, 1});
+    luci::test::graph_input_shape(input_node);
+  }
+  auto output_node = graph.output_node;
+  {
+    output_node->shape({1, 2, 1, 1});
+    luci::test::graph_output_shape(output_node);
   }
   // setting CircleAveragePool2D
   {
-    tfl_node->filter()->h(2);
-    tfl_node->filter()->w(2);
-    tfl_node->stride()->h(2);
-    tfl_node->stride()->w(2);
-    tfl_node->fusedActivationFunction(luci::FusedActFunc::NONE);
-    tfl_node->padding(luci::Padding::VALID);
+    avg_node->filter()->h(2);
+    avg_node->filter()->w(2);
+    avg_node->stride()->h(2);
+    avg_node->stride()->w(2);
+    avg_node->fusedActivationFunction(luci::FusedActFunc::NONE);
+    avg_node->padding(luci::Padding::VALID);
   }
-  ASSERT_FALSE(loco::shape_known(tfl_node));
+  ASSERT_FALSE(loco::shape_known(avg_node));
 
   // shape inference
-  luci::CircleShapeInferenceRule tfl_rule;
-  loco::CanonicalShapeInferenceRule canonical_rule;
-  loco::MultiDialectShapeInferenceRule rules;
-
-  rules.bind(loco::CanonicalDialect::get(), &canonical_rule)
-      .bind(luci::CircleDialect::get(), &tfl_rule);
-
-  loco::apply(&rules).to(graph.g.get());
+  while (shape_pass(graph.graph()) == true)
+    ;
 
   // Verify
   {
-    ASSERT_TRUE(loco::shape_known(tfl_node));
-    ASSERT_EQ(loco::Domain::Tensor, loco::shape_get(tfl_node).domain());
+    ASSERT_TRUE(loco::shape_known(avg_node));
+    ASSERT_EQ(loco::Domain::Tensor, loco::shape_get(avg_node).domain());
 
-    auto shape = loco::shape_get(tfl_node).as<loco::TensorShape>();
+    auto shape = loco::shape_get(avg_node).as<loco::TensorShape>();
     ASSERT_EQ(4, shape.rank());
     ASSERT_EQ(1, shape.dim(0).value());
     ASSERT_EQ(2, shape.dim(1).value());
@@ -136,35 +137,41 @@ TEST(CircleShapeInferenceRuleTest, avgpool2d_valid)
 TEST(CircleShapeInferenceRuleTest, avgpool2d_same)
 {
   luci::test::TestGraph graph;
-  auto tfl_node = graph.append<luci::CircleAveragePool2D>(graph.pull);
+  auto avg_node = graph.append<luci::CircleAveragePool2D>(graph.input_node);
   graph.complete();
 
-  auto pull = graph.pull;
+  auto input_node = graph.input_node;
   {
-    pull->shape({1, 4, 3, 1});
+    input_node->shape({1, 4, 3, 1});
+    luci::test::graph_input_shape(input_node);
+  }
+  auto output_node = graph.output_node;
+  {
+    output_node->shape({1, 2, 2, 1});
+    luci::test::graph_output_shape(output_node);
   }
 
   // setting CircleAveragePool2D
   {
-    tfl_node->filter()->h(2);
-    tfl_node->filter()->w(2);
-    tfl_node->stride()->h(2);
-    tfl_node->stride()->w(2);
-    tfl_node->fusedActivationFunction(luci::FusedActFunc::NONE);
-    tfl_node->padding(luci::Padding::SAME);
+    avg_node->filter()->h(2);
+    avg_node->filter()->w(2);
+    avg_node->stride()->h(2);
+    avg_node->stride()->w(2);
+    avg_node->fusedActivationFunction(luci::FusedActFunc::NONE);
+    avg_node->padding(luci::Padding::SAME);
   }
 
-  ASSERT_FALSE(loco::shape_known(tfl_node));
+  ASSERT_FALSE(loco::shape_known(avg_node));
 
   // shape inference
-  shape_pass(graph.g.get());
+  shape_pass(graph.graph());
 
   // Verify
   {
-    ASSERT_TRUE(loco::shape_known(tfl_node));
-    ASSERT_EQ(loco::Domain::Tensor, loco::shape_get(tfl_node).domain());
+    ASSERT_TRUE(loco::shape_known(avg_node));
+    ASSERT_EQ(loco::Domain::Tensor, loco::shape_get(avg_node).domain());
 
-    auto shape = loco::shape_get(tfl_node).as<loco::TensorShape>();
+    auto shape = loco::shape_get(avg_node).as<loco::TensorShape>();
     ASSERT_EQ(4, shape.rank());
     ASSERT_EQ(1, shape.dim(0).value());
     ASSERT_EQ(2, shape.dim(1).value());
@@ -186,47 +193,51 @@ TEST(CircleShapeInferenceRuleTest, TFAdd_shapeinf_different)
 {
   auto g = loco::make_graph();
 
-  auto x_node = g->nodes()->create<loco::Pull>();
+  auto x_node = g->nodes()->create<luci::CircleInput>();
   {
     x_node->rank(3);
     x_node->dim(0) = 2;
     x_node->dim(1) = 1;
     x_node->dim(2) = 5;
   }
-  auto y_node = g->nodes()->create<loco::Pull>();
+  auto y_node = g->nodes()->create<luci::CircleInput>();
   {
     y_node->rank(2);
     y_node->dim(0) = 3;
     y_node->dim(1) = 5;
   }
-  auto tfl_node = g->nodes()->create<luci::CircleAdd>();
+  auto add_node = g->nodes()->create<luci::CircleAdd>();
   {
-    tfl_node->x(x_node);
-    tfl_node->y(y_node);
+    add_node->x(x_node);
+    add_node->y(y_node);
   }
-  auto push_node = g->nodes()->create<loco::Push>();
+  auto output_node = g->nodes()->create<luci::CircleOutput>();
   {
-    push_node->from(tfl_node);
+    output_node->from(add_node);
   }
 
   auto x_input = g->inputs()->create();
   {
     x_input->name("x");
-    loco::link(x_input, x_node);
+    luci::link(x_input, x_node);
   }
   auto y_input = g->inputs()->create();
   {
     y_input->name("y");
-    loco::link(y_input, y_node);
+    luci::link(y_input, y_node);
   }
   auto output = g->outputs()->create();
   {
     output->name("output");
-    loco::link(output, push_node);
+    luci::link(output, output_node);
   }
 
+  luci::test::graph_input_shape(x_node);
+  luci::test::graph_input_shape(y_node);
+  luci::test::graph_output_shape(output_node);
+
   // pre-check
-  ASSERT_FALSE(loco::shape_known(tfl_node));
+  ASSERT_FALSE(loco::shape_known(add_node));
 
   // shape inference
   while (shape_pass(g.get()) == true)
@@ -234,10 +245,10 @@ TEST(CircleShapeInferenceRuleTest, TFAdd_shapeinf_different)
 
   // Verify
   {
-    ASSERT_TRUE(loco::shape_known(tfl_node));
-    ASSERT_EQ(loco::Domain::Tensor, loco::shape_get(tfl_node).domain());
+    ASSERT_TRUE(loco::shape_known(add_node));
+    ASSERT_EQ(loco::Domain::Tensor, loco::shape_get(add_node).domain());
 
-    auto shape = loco::shape_get(tfl_node).as<loco::TensorShape>();
+    auto shape = loco::shape_get(add_node).as<loco::TensorShape>();
     ASSERT_EQ(3, shape.rank());
     ASSERT_EQ(2, shape.dim(0));
     ASSERT_EQ(3, shape.dim(1));
@@ -249,10 +260,10 @@ TEST(CircleShapeInferenceRuleTest, CircleTranspose_simple)
 {
   luci::test::ExampleGraph<luci::test::ExampleGraphType::CircleTranspose> g;
 
-  g.pull->rank(3);
-  g.pull->dim(0) = 3;
-  g.pull->dim(1) = 8;
-  g.pull->dim(2) = 1;
+  g.input_node->rank(3);
+  g.input_node->dim(0) = 3;
+  g.input_node->dim(1) = 8;
+  g.input_node->dim(2) = 1;
 
   g.const_perm->dtype(loco::DataType::S32);
   g.const_perm->rank(1);
@@ -261,6 +272,9 @@ TEST(CircleShapeInferenceRuleTest, CircleTranspose_simple)
   g.const_perm->at<loco::DataType::S32>(0) = 1;
   g.const_perm->at<loco::DataType::S32>(1) = 2;
   g.const_perm->at<loco::DataType::S32>(2) = 0;
+
+  luci::test::graph_input_shape(g.input_node);
+  luci::test::graph_output_shape(g.output_node);
 
   // pre-check
   ASSERT_FALSE(loco::shape_known(g.transpose_node));
@@ -284,13 +298,20 @@ TEST(CircleShapeInferenceRuleTest, CircleTranspose_simple)
 TEST(CircleShapeInferenceRuleTest, CircleSqueeze)
 {
   luci::test::TestGraph graph;
-  auto squeeze_node = graph.append<luci::CircleSqueeze>(graph.pull);
+  auto squeeze_node = graph.append<luci::CircleSqueeze>(graph.input_node);
   graph.complete();
 
-  auto pull = graph.pull;
+  auto input_node = graph.input_node;
   {
-    pull->shape({1, 4, 3, 1});
+    input_node->shape({1, 4, 3, 1});
   }
+  auto output_node = graph.output_node;
+  {
+    output_node->shape({4, 3, 1});
+  }
+
+  luci::test::graph_input_shape(input_node);
+  luci::test::graph_output_shape(output_node);
 
   squeeze_node->squeeze_dims({0});
 
@@ -316,13 +337,20 @@ TEST(CircleShapeInferenceRuleTest, CircleSqueeze)
 TEST(CircleShapeInferenceRuleTest, CircleSqueezeAll)
 {
   luci::test::TestGraph graph;
-  auto squeeze_node = graph.append<luci::CircleSqueeze>(graph.pull);
+  auto squeeze_node = graph.append<luci::CircleSqueeze>(graph.input_node);
   graph.complete();
 
-  auto pull = graph.pull;
+  auto input_node = graph.input_node;
   {
-    pull->shape({1, 4, 3, 1});
+    input_node->shape({1, 4, 3, 1});
   }
+  auto output_node = graph.output_node;
+  {
+    input_node->shape({4, 3});
+  }
+
+  luci::test::graph_input_shape(input_node);
+  luci::test::graph_output_shape(output_node);
 
   squeeze_node->squeeze_dims({});
 


### PR DESCRIPTION
This will revise service test
- remove unused TestGraph methods with loco Node
- remove unused ExampleGraphType for loco Node
- rename variables to reflect Circle IR
- set GraphInput/GraphOutput shape after graph creation

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>