### PR TITLE
[onert] modifying DynamicTensorManager::allocate(..)

### DIFF
--- a/runtime/onert/backend/cpu/DynamicTensorManager.h
+++ b/runtime/onert/backend/cpu/DynamicTensorManager.h
@@ -37,6 +37,12 @@ public:
 
   virtual ~DynamicTensorManager() = default;
 
+  /**
+   * @brief Allocate memory for dynamic tensor.
+   *        If allocated memory is already set to the tensor and
+   *          if size of existing tensor's memory and new shape is same, memory will not allocated.
+   *          if different, previous memory will be deallocated and memory will be allocated.
+   */
   void allocate(const ir::OperandIndex &ind, const ir::Shape &new_shape) override;
   void buildTensor(const ir::OperandIndex &ind, const ir::OperandInfo &tensor_info);
   void changeShape(const ir::OperandIndex &, const ir::Shape &) override;

--- a/runtime/onert/backend/cpu_common/MemoryManager.cc
+++ b/runtime/onert/backend/cpu_common/MemoryManager.cc
@@ -78,6 +78,16 @@ std::shared_ptr<cpu_common::Allocator> DynamicMemoryManager::allocate(const ir::
   return mem_alloc;
 }
 
+void DynamicMemoryManager::deallocate(const ir::OperandIndex &ind)
+{
+  auto find = _mem_alloc_map.find(ind);
+  if (find == _mem_alloc_map.end())
+    throw std::runtime_error("Cannot find Allocator for the requested index");
+
+  auto alloc = find->second;
+  alloc.reset();
+}
+
 void DynamicMemoryManager::deallocate(void)
 {
   for (auto &mem_alloc : _mem_alloc_map)

--- a/runtime/onert/backend/cpu_common/MemoryManager.h
+++ b/runtime/onert/backend/cpu_common/MemoryManager.h
@@ -59,6 +59,7 @@ public:
   virtual ~DynamicMemoryManager() = default;
 
   std::shared_ptr<cpu_common::Allocator> allocate(const ir::OperandIndex &ind, uint32_t capacity);
+  void deallocate(const ir::OperandIndex &ind);
   void deallocate(void);
 
 private:


### PR DESCRIPTION
`DynamicTensorManager::allocate(..)` now checks now if memory is already allocated. If not or new size is different from old size, it will allocate.

for https://github.com/Samsung/ONE/pull/952#discussion_r427018811 
parent #56 
draft #52

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>