### PR TITLE
[nnpackage][circle] Fix wrong copied BCQ operations

### DIFF
--- a/nnpackage/schema/circle_schema.fbs
+++ b/nnpackage/schema/circle_schema.fbs
@@ -358,8 +358,8 @@ enum BuiltinOperator : ubyte {
   DENSIFY = 124,
   SEGMENT_SUM = 125,
   BATCH_MATMUL = 126,
-  BCQGatherOptions = 252,
-  BCQFullyConnectedOptions = 253,
+  BCQ_GATHER = 252,
+  BCQ_FULLY_CONNECTED = 253,
   INSTANCE_NORM = 254,
 }
 
@@ -466,6 +466,8 @@ union BuiltinOptions {
   DensifyOptions,
   SegmentSumOptions,
   BatchMatMulOptions,
+  BCQGatherOptions = 252,
+  BCQFullyConnectedOptions = 253,
   InstanceNormOptions = 254,
 }
 


### PR DESCRIPTION
This commit will fix wrong name and add missing options
for BCQ operations

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>