### PR TITLE
[onert] rename LowerInfoMap's operation to op_seq

### DIFF
--- a/runtime/onert/core/include/ir/LowerInfoMap.h
+++ b/runtime/onert/core/include/ir/LowerInfoMap.h
@@ -32,7 +32,7 @@ namespace ir
 
 struct LowerInfoMap
 {
-  std::unordered_map<OpSequenceIndex, std::unique_ptr<operation::LowerInfo>> operation;
+  std::unordered_map<OpSequenceIndex, std::unique_ptr<operation::LowerInfo>> op_seq;
   OperandIndexMap<std::unique_ptr<operand::LowerInfo>> operand;
 };
 

--- a/runtime/onert/core/src/compiler/ExecutorFactory.cc
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.cc
@@ -73,7 +73,7 @@ void ExecutorFactory::initializeBackendContext(ir::LoweredGraph *lowered_graph)
   // Build lists for operations
   lowered_graph->op_seqs().iterate(
       [&](const ir::OpSequenceIndex &op_seq_index, const ir::OpSequence &op_seq) {
-        auto &op_seq_li = lowered_graph->getLowerInfo()->operation;
+        auto &op_seq_li = lowered_graph->getLowerInfo()->op_seq;
         auto backend = op_seq_li.at(op_seq_index)->backend();
         for (auto &element : op_seq.operations())
         {

--- a/runtime/onert/core/src/exec/DataflowExecutor.cc
+++ b/runtime/onert/core/src/exec/DataflowExecutor.cc
@@ -150,7 +150,7 @@ void DataflowExecutor::executeImpl()
     auto op_seq_index = _job_to_op_seq[job_index];
     auto op_seq = &_lowered_graph->op_seqs().at(op_seq_index);
     const backend::Backend *backend =
-        _lowered_graph->getLowerInfo()->operation.at(op_seq_index)->backend();
+        _lowered_graph->getLowerInfo()->op_seq.at(op_seq_index)->backend();
 
     _subject.notifyJobBegin(this, op_seq, backend);
 

--- a/runtime/onert/core/src/exec/ParallelExecutor.cc
+++ b/runtime/onert/core/src/exec/ParallelExecutor.cc
@@ -73,7 +73,7 @@ void ParallelExecutor::executeImpl()
   // Init scheduler
   // TODO Consider to have distinct backend set in LowerInfoMap
   ir::BackendSet backends;
-  for (auto &itr : _lowered_graph->getLowerInfo()->operation)
+  for (auto &itr : _lowered_graph->getLowerInfo()->op_seq)
   {
     backends.add(itr.second->backend());
   }
@@ -121,7 +121,7 @@ void ParallelExecutor::executeImpl()
     auto job_index = job->index();
     auto op_sequence_index = _job_to_op_seq[job_index];
     auto op_seq = &_lowered_graph->op_seqs().at(op_sequence_index);
-    auto backend = _lowered_graph->getLowerInfo()->operation.at(op_sequence_index)->backend();
+    auto backend = _lowered_graph->getLowerInfo()->op_seq.at(op_sequence_index)->backend();
     auto setup = [&, op_seq, backend]() { _subject.notifyJobBegin(this, op_seq, backend); };
     auto teardown = [&, job_index, op_seq, backend]() {
       _subject.notifyJobEnd(this, op_seq, backend);

--- a/runtime/onert/core/src/ir/LoweredGraph.cc
+++ b/runtime/onert/core/src/ir/LoweredGraph.cc
@@ -137,8 +137,8 @@ LoweredGraph::LoweredGraph(const Graph &graph, const compiler::CompilerOptions &
 
 const operation::LowerInfo *LoweredGraph::getLowerInfo(const OpSequenceIndex &op_seq_index) const
 {
-  auto itr = _lower_info_map.operation.find(op_seq_index);
-  if (itr == _lower_info_map.operation.end())
+  auto itr = _lower_info_map.op_seq.find(op_seq_index);
+  if (itr == _lower_info_map.op_seq.end())
     return nullptr;
   return itr->second.get();
 }
@@ -146,12 +146,12 @@ const operation::LowerInfo *LoweredGraph::getLowerInfo(const OpSequenceIndex &op
 void LoweredGraph::setLowerInfo(const OpSequenceIndex &op_seq_index,
                                 std::unique_ptr<operation::LowerInfo> &&lower_info)
 {
-  _lower_info_map.operation.insert(std::make_pair(op_seq_index, std::move(lower_info)));
+  _lower_info_map.op_seq.insert(std::make_pair(op_seq_index, std::move(lower_info)));
 }
 
 void LoweredGraph::removeLowerInfo(const OpSequenceIndex &op_seq_index)
 {
-  auto &op_seq_lower_info = _lower_info_map.operation;
+  auto &op_seq_lower_info = _lower_info_map.op_seq;
   assert(op_seq_lower_info.find(op_seq_index) != op_seq_lower_info.end());
   for (auto it = op_seq_lower_info.begin(); it != op_seq_lower_info.end(); ++it)
   {


### PR DESCRIPTION
It renames LowerInfoMap's member operation to op_seq as it is a map of
OpSequenceIndex to LowerInfo.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>