### PR TITLE
[circledump] Support BCQ operations

### DIFF
--- a/compiler/circledump/src/OpPrinter.cpp
+++ b/compiler/circledump/src/OpPrinter.cpp
@@ -453,6 +453,37 @@ public:
   }
 };
 
+class BCQFullyConnectedPrinter : public OpPrinter
+{
+public:
+  void options(const circle::Operator *op, std::ostream &os) const override
+  {
+    if (auto *params = op->builtin_options_as_BCQFullyConnectedOptions())
+    {
+      os << "    ";
+      os << "Activation(" << EnumNameActivationFunctionType(params->fused_activation_function())
+         << ") ";
+      os << "weights_hidden_size(" << params->weights_hidden_size() << ") ";
+      os << std::endl;
+    }
+  }
+};
+
+class BCQGatherPrinter : public OpPrinter
+{
+public:
+  void options(const circle::Operator *op, std::ostream &os) const override
+  {
+    if (auto *params = op->builtin_options_as_BCQGatherOptions())
+    {
+      os << "    ";
+      os << "axis(" << params->axis() << ") ";
+      os << "weights_hidden_size(" << params->input_hidden_size() << ") ";
+      os << std::endl;
+    }
+  }
+};
+
 OpPrinterRegistry::OpPrinterRegistry()
 {
   _op_map[circle::BuiltinOperator_ADD] = make_unique<AddPrinter>();
@@ -494,6 +525,10 @@ OpPrinterRegistry::OpPrinterRegistry()
   // There is no Option for TOPK_V2
   _op_map[circle::BuiltinOperator_WHILE] = make_unique<WhilePrinter>();
   _op_map[circle::BuiltinOperator_CUSTOM] = make_unique<CustomOpPrinter>();
+
+  // Circle only
+  _op_map[circle::BuiltinOperator_BCQ_FULLY_CONNECTED] = make_unique<BCQFullyConnectedPrinter>();
+  _op_map[circle::BuiltinOperator_BCQ_GATHER] = make_unique<BCQGatherPrinter>();
 }
 
 } // namespace circledump


### PR DESCRIPTION
Parent Issue : #1079

This commit will add BCQ operation `OpPrinter` in `circledump`

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>