### PR TITLE
[onert] Use dynamic casting return to check type in createDataflowExecutor

### DIFF
--- a/runtime/onert/core/src/compiler/ExecutorFactory.cc
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.cc
@@ -305,9 +305,9 @@ exec::IExecutor *ExecutorFactory::createDataflowExecutor(
     auto lower_info = lowered_graph->getLowerInfo(op_seq_index);
     auto kernel_gen = lowered_graph->backend_contexts().at(lower_info->backend())->kernel_gen;
     // Set TensorBuilderSet and ExecutorMap to kernel_gen of control flow
-    if (lower_info->backend()->config()->id() == backend::controlflow::Config::ID)
+    auto cf_kernel_gen = dynamic_cast<backend::controlflow::KernelGenerator *>(kernel_gen.get());
+    if (cf_kernel_gen != nullptr)
     {
-      auto cf_kernel_gen = dynamic_cast<backend::controlflow::KernelGenerator *>(kernel_gen.get());
       assert(cf_kernel_gen != nullptr);
       cf_kernel_gen->setTensorBuilderSet(tensor_builders);
       cf_kernel_gen->setExecutorMap(executor_map);


### PR DESCRIPTION
If downcasting by dynamic_cast to controlflow kernel generator return nullptr, kernel generator is not controlflow kernel generator

Same implementation with createLinearExecutor

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>