### PR TITLE
[onert] Adding StaticInferer::dump()

### DIFF
--- a/runtime/onert/core/include/util/ShapeInference.h
+++ b/runtime/onert/core/include/util/ShapeInference.h
@@ -95,6 +95,8 @@ public:
    */
   void infer(const ir::OpSequence &op_seq) { op_seq.accept(*this); };
 
+  void dump();
+
 private:
   // TODO Define visitors for operations. List them in alphabetic order.
   // Remove TODO when any op starting from the alphabet is added

--- a/runtime/onert/core/src/ir/LoweredGraph.cc
+++ b/runtime/onert/core/src/ir/LoweredGraph.cc
@@ -126,6 +126,7 @@ LoweredGraph::LoweredGraph(const Graph &graph, const compiler::CompilerOptions &
     shape_inference::StaticInferer inferer(_graph.operands());
     _op_seqs.iterate(
         [&](const ir::OpSequenceIndex &, const ir::OpSequence &op_seq) { inferer.infer(op_seq); });
+    inferer.dump();
   }
 
   // Graph verifications

--- a/runtime/onert/core/src/util/shapeinf/ShapeInference.cc
+++ b/runtime/onert/core/src/util/shapeinf/ShapeInference.cc
@@ -20,6 +20,9 @@
 #include "ir/operation/AvgPool2D.h"
 #include "ir/operation/MaxPool2D.h"
 #include "util/ShapeInference.h"
+#include "util/logging.h"
+
+#include <sstream>
 
 namespace onert
 {
@@ -207,6 +210,29 @@ Shapes inferMaxPoolShape(const ir::Shape &in_shape, const ir::operation::MaxPool
   - Write methods except visit()
   - For visit() of each operator, find each op's C file
 */
+
+void StaticInferer::dump()
+{
+  auto get_shape_str = [](const ir::Shape &shape) {
+    std::stringstream sstream;
+    sstream << "shape : {";
+    for (int i = 0; i < shape.rank(); i++)
+    {
+      if (i == 0)
+        sstream << shape.dim(i);
+      else
+        sstream << " " << shape.dim(i);
+    }
+    sstream << "}";
+    return sstream.str();
+  };
+
+  _operands.iterate([&](const ir::OperandIndex &ind, const ir::Operand &operand) {
+    VERBOSE(StaticInferer) << "Operand #" << ind.value() << ", "
+                           << (operand.info().isDynamic() ? "Dynamic" : "Static") << ", "
+                           << get_shape_str(operand.info().shape()) << std::endl;
+  });
+}
 
 // TODO move this into Add.cc
 void StaticInferer::visit(const ir::operation::Add &op)


### PR DESCRIPTION
This adds `StaticInferer::dump()` for debugging purpose.

parent: #52
draft: #56

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>