### PR TITLE
[res/TensorFlowLiteRecipes] Fix OneHot Operation Recipe

### DIFF
--- a/res/TensorFlowLiteRecipes/OneHot_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/OneHot_000/test.recipe
@@ -1,28 +1,28 @@
 operand {
   name: "indices"
   type: INT32
-  shape: { dim: 3 }
+  shape { dim: 3 }
 }
 operand {
   name: "depth"
   type: INT32
-  shape: {}
-  filler: { tag: "explicit" arg: "3" }
+  shape {}
+  filler { tag: "explicit" arg: "3" }
 }
 operand {
   name: "on_value"
   type: FLOAT32
-  shape: {}
+  shape {}
 }
 operand {
   name: "off_value"
   type: FLOAT32
-  shape: {}
+  shape {}
 }
 operand {
   name: "ofm"
   type: FLOAT32
-  shape: { dim: 3 dim: 3 }
+  shape { dim: 3 dim: 3 }
 }
 operation {
   type: "OneHot"
@@ -36,7 +36,6 @@ operation {
   output: "ofm"
 }
 input: "indices"
-input: "depth"
 input: "on_value"
 input: "off_value"
 output: "ofm"

--- a/res/TensorFlowLiteRecipes/OneHot_001/test.recipe
+++ b/res/TensorFlowLiteRecipes/OneHot_001/test.recipe
@@ -1,28 +1,28 @@
 operand {
   name: "indices"
   type: INT32
-  shape: { dim: 4 }
+  shape { dim: 4 }
 }
 operand {
   name: "depth"
   type: INT32
-  shape: {}
-  filler: { tag: "explicit" arg: "3" }
+  shape {}
+  filler { tag: "explicit" arg: "3" }
 }
 operand {
   name: "on_value"
   type: FLOAT32
-  shape: {}
+  shape {}
 }
 operand {
   name: "off_value"
   type: FLOAT32
-  shape: {}
+  shape {}
 }
 operand {
   name: "ofm"
   type: FLOAT32
-  shape: { dim: 4 dim: 3 }
+  shape { dim: 4 dim: 3 }
 }
 operation {
   type: "OneHot"
@@ -36,7 +36,6 @@ operation {
   output: "ofm"
 }
 input: "indices"
-input: "depth"
 input: "on_value"
 input: "off_value"
 output: "ofm"

--- a/res/TensorFlowLiteRecipes/OneHot_002/test.recipe
+++ b/res/TensorFlowLiteRecipes/OneHot_002/test.recipe
@@ -1,28 +1,28 @@
 operand {
   name: "indices"
   type: INT32
-  shape: { dim: 2 dim: 2 }
+  shape { dim: 2 dim: 2 }
 }
 operand {
   name: "depth"
   type: INT32
-  shape: {}
-  filler: { tag: "explicit" arg: "3" }
+  shape {}
+  filler { tag: "explicit" arg: "3" }
 }
 operand {
   name: "on_value"
   type: FLOAT32
-  shape: {}
+  shape {}
 }
 operand {
   name: "off_value"
   type: FLOAT32
-  shape: {}
+  shape {}
 }
 operand {
   name: "ofm"
   type: FLOAT32
-  shape: { dim: 2 dim: 2 dim: 3 }
+  shape { dim: 2 dim: 2 dim: 3 }
 }
 operation {
   type: "OneHot"
@@ -36,7 +36,6 @@ operation {
   output: "ofm"
 }
 input: "indices"
-input: "depth"
 input: "on_value"
 input: "off_value"
 output: "ofm"


### PR DESCRIPTION
Parent Issue : #277
Draft PR : #735

This will fix TensorFlowLiteRecipes for `OneHot` Operation.
To load data on constant value on depth.

ONE-DCO-1.0-Signed-off-by: KiDeuk Bang <rrstrous@nate.com>