### PR TITLE
[luci/import] Fix luci/import on OneHot Operator.

### DIFF
--- a/compiler/luci/import/src/Nodes/CircleOneHot.cpp
+++ b/compiler/luci/import/src/Nodes/CircleOneHot.cpp
@@ -45,11 +45,11 @@ bool CircleOneHotGraphBuilder::validate(const ValidateArgs &args) const
 
   if (options->axis < -1 || options->axis > static_cast<int32_t>(indices->shape.size()))
     return false;
-  if (depth->shape.size() != 1)
+  if (depth->shape.size() != 0)
     return false;
-  if (on_value->shape.size() != 1)
+  if (on_value->shape.size() != 0)
     return false;
-  if (off_value->shape.size() != 1)
+  if (off_value->shape.size() != 0)
     return false;
   if (on_value->type != off_value->type)
     return false;


### PR DESCRIPTION
Parent Issue : #668 
Draft PR : #735 

Change depth shape check to validate scalr, not (1)vector.
Change on_value shape check to validate scalr, not (1)vector.
Change off_value shape check to validate scalr, not (1)vector.

ONE-DCO-1.0-Signed-off-by: KiDeuk Bang <rrstrous@nate.com>