### PR TITLE
[onert] Remove num_dimensions() from IACLTensor

### DIFF
--- a/runtime/onert/backend/acl_common/IACLTensor.cc
+++ b/runtime/onert/backend/acl_common/IACLTensor.cc
@@ -25,12 +25,6 @@ namespace backend
 namespace acl_common
 {
 
-size_t IACLTensor::num_dimensions() const
-{
-  throw std::runtime_error("No definition of num_dimensions()");
-  return 0;
-}
-
 size_t IACLTensor::dimension(size_t index) const
 {
   // Assume that the front is higher dimensional.

--- a/runtime/onert/backend/acl_common/IACLTensor.h
+++ b/runtime/onert/backend/acl_common/IACLTensor.h
@@ -46,7 +46,6 @@ public:
   uint8_t *buffer() const final { return handle()->buffer(); }
   size_t total_size() const final { return info()->total_size(); }
   size_t dimension(size_t index) const final;
-  size_t num_dimensions() const override;
   size_t calcOffset(const ir::Coordinates &coords) const final;
   ir::Layout layout() const final;
   ir::DataType data_type() const final;


### PR DESCRIPTION
This commit removes num_dimensions() from IACLTensor.

The `num_dimentions()` of `ITensor` is Pure Virtual Function. The `num_dimensions()` of IACLTensor is not necessary.

Signed-off-by: ragmani <ragmani0216@gmail.com>