### PR TITLE
[onert] Remove backend context from Permute node

### DIFF
--- a/runtime/onert/core/include/ir/operation/Permute.h
+++ b/runtime/onert/core/include/ir/operation/Permute.h
@@ -44,31 +44,18 @@ public:
     COPY
   };
 
-  struct Param
-  {
-    const backend::BackendContext *input_backend_ctx;
-    const backend::BackendContext *output_backend_ctx;
-  };
-
 public:
   void accept(OperationVisitor &v) const override;
   OpCode opcode() const final { return OpCode::Permute; }
 
 public:
-  Permute(const OperandIndex &input, const OperandIndex &output,
-          const backend::BackendContext *input_backend_ctx,
-          const backend::BackendContext *output_backend_ctx, Type type,
-          DataType data_type = DataType::FLOAT32);
+  Permute(const OperandIndex &input, const OperandIndex &output, Type type);
 
 public:
-  const Param &param() const { return _param; }
-  DataType getDataType() const { return _dataType; }
   Type getPermuteType() const { return _type; }
 
 private:
-  Param _param;
   Type _type;
-  DataType _dataType;
 };
 
 } // namespace operation

--- a/runtime/onert/core/src/backend/controlflow/KernelGenerator.h
+++ b/runtime/onert/core/src/backend/controlflow/KernelGenerator.h
@@ -50,6 +50,9 @@ public:
   void visit(const ir::operation::While &) override;
 
 private:
+  std::shared_ptr<backend::ITensor> getTensor(const ir::OperandIndex &index);
+
+private:
   const ir::Operands &_operand_ctx;
   TensorBuilderSet _tensor_builder_set;
   std::shared_ptr<exec::ExecutorMap> _executor_map;

--- a/runtime/onert/core/src/compiler/HEScheduler.cc
+++ b/runtime/onert/core/src/compiler/HEScheduler.cc
@@ -270,7 +270,9 @@ int64_t HEScheduler::getOpTime(const backend::Backend *backend, const std::strin
 int64_t HEScheduler::getPermuteTime(const backend::Backend *src_backend,
                                     const backend::Backend *dst_backend, bool quant, uint32_t size)
 {
+  // TODO Change it to getOperationExecTime()
   const auto time = _exec_time->getPermuteTime(src_backend, dst_backend, quant, size);
+
   if (time != _exec_time->NOT_FOUND)
     return time;
 
@@ -410,6 +412,7 @@ int64_t HEScheduler::DFSChildrenMaxRank(const ir::OperationIndex &index)
         {
           continue;
         }
+        // TODO Change it to controlflow backend
         auto transfer_cost =
             getPermuteTime(backend, other_backend, quant, operand.info().total_size());
         avg_transfer_cost += transfer_cost;

--- a/runtime/onert/core/src/exec/ExecutionObservers.cc
+++ b/runtime/onert/core/src/exec/ExecutionObservers.cc
@@ -19,7 +19,6 @@
 #include <string>
 
 #include "util/logging.h"
-#include "ir/operation/Permute.h"
 #include "exec/IExecutor.h"
 #include "misc/polymorphic_downcast.h"
 #include "ir/OpSequence.h"
@@ -61,11 +60,8 @@ void ProfileObserver::handleEnd(IExecutor *exec, const ir::OpSequence *op_seq,
   }
   if (node_name == "Permute")
   {
-    auto *permute_node = nnfw::misc::polymorphic_downcast<const ir::operation::Permute *>(node);
-    assert(permute_node != nullptr);
-    _et->updatePermuteTime(permute_node->param().input_backend_ctx->backend(),
-                           permute_node->param().output_backend_ctx->backend(), is_quantized, size,
-                           timer_res);
+    // TODO Change it to updateOperationExecTime()
+    _et->updatePermuteTime(backend, backend, is_quantized, size, timer_res);
   }
   else
   {

--- a/runtime/onert/core/src/ir/operation/Permute.cc
+++ b/runtime/onert/core/src/ir/operation/Permute.cc
@@ -29,11 +29,8 @@ namespace operation
 
 void Permute::accept(OperationVisitor &v) const { v.visit(*this); }
 
-Permute::Permute(const OperandIndex &input, const OperandIndex &output,
-                 const backend::BackendContext *input_backend_ctx,
-                 const backend::BackendContext *output_backend_ctx, Type type, DataType data_type)
-    : Operation{OperandConstraint::createExact(1u)}, _param{input_backend_ctx, output_backend_ctx},
-      _type{type}, _dataType{data_type}
+Permute::Permute(const OperandIndex &input, const OperandIndex &output, Type type)
+    : Operation{OperandConstraint::createExact(1u)}, _type{type}
 {
   setInputs({input});
   setOutputs({output});

--- a/runtime/onert/core/src/ir/pass/PermutationInsertionPass.cc
+++ b/runtime/onert/core/src/ir/pass/PermutationInsertionPass.cc
@@ -162,9 +162,6 @@ OperationIndex PermutationInsertionPass::insertPermute(const OperandIndex &opera
   out_operand_li->addUsePermuteFactor(factor);
   _lowered_graph.setLowerInfo(out_operand_index, std::move(out_operand_li));
 
-  auto input_backend_ctx = _lowered_graph.backend_contexts().at(input_backend).get();
-  auto output_backend_ctx = _lowered_graph.backend_contexts().at(output_backend).get();
-
   // Insert permute operation to the graph
   const auto input_layout =
       _lowered_graph.getLowerInfo(operand_index)->def_factors().getOnlyElement().layout();
@@ -184,8 +181,7 @@ OperationIndex PermutationInsertionPass::insertPermute(const OperandIndex &opera
       return Permute::Type::COPY;
     }
   }();
-  auto insert_node = std::make_unique<Permute>(operand_index, out_operand_index, input_backend_ctx,
-                                               output_backend_ctx, permute_type);
+  auto insert_node = std::make_unique<Permute>(operand_index, out_operand_index, permute_type);
 
   auto node_index = _graph.operations().push(std::move(insert_node));
   const auto &node = _graph.operations().at(node_index);


### PR DESCRIPTION
For issue : #927
Draft PR : #889

This commit removes backend context from Permute node.

Signed-off-by: ragmani <ragmani0216@gmail.com>