### PR TITLE
[onert] throw error instead exit(-1) in nnfw_api_internal

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -310,8 +310,7 @@ static NNFW_TYPE datatype_to_nnfw_dtype(onert::ir::DataType dt)
     case DataType::UINT32:
     case DataType::QUANT8_SYMM:
     default:
-      std::cerr << "Error: Model has type that runtime API does not support." << std::endl;
-      exit(-1);
+      throw std::runtime_error("Error: Model has type that runtime API does not support.");
   }
 }
 


### PR DESCRIPTION
exit(-1) is replaced with throw to handle errors in consistent way.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>