### PR TITLE
[onert] removed assert in dynamic shape infererence

### DIFF
--- a/runtime/onert/core/src/util/shapeinf/Reshape.cc
+++ b/runtime/onert/core/src/util/shapeinf/Reshape.cc
@@ -124,7 +124,6 @@ void DynamicInferer::visit(const ir::operation::Reshape &op)
   // set output shape and output buffer
   setShape(output, output_shape);
 
-  assert(output->buffer() == nullptr);
   _dynamic_tensor_manager->allocate(output_ind, output_shape);
   assert(output->buffer() != nullptr);
 }

--- a/runtime/onert/core/src/util/shapeinf/Tanh.cc
+++ b/runtime/onert/core/src/util/shapeinf/Tanh.cc
@@ -58,7 +58,6 @@ void DynamicInferer::visit(const ir::operation::Tanh &op)
   // set output shape and output buffer
   setShape(output, output_shape);
 
-  assert(output->buffer() == nullptr);
   _dynamic_tensor_manager->allocate(output_ind, output_shape);
   assert(output->buffer() != nullptr);
 }


### PR DESCRIPTION
This remvoes checking of `tensor->buffer() == nullptr`
since `buffer != nullptr` when executor runs _multiple times_ after one compilation.

special thanks to @ragmani :cherry_blossom: 

parent issue: #56 
draft : #52 

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>