### PR TITLE
[luci] Handle optional input tensor for FullyConnected

### DIFF
--- a/compiler/luci/import/src/Nodes/CircleFullyConnected.cpp
+++ b/compiler/luci/import/src/Nodes/CircleFullyConnected.cpp
@@ -42,6 +42,7 @@ CircleNode *CircleFullyConnectedGraphBuilder::build_node(const circle::OperatorT
   node->weights(inputs[1]);
   node->bias(inputs[2]); // bias is optional
 
+  // TODO Find and move to appropriate place for setting optional input
   if (auto bias = dynamic_cast<luci::CircleOutputExclude *>(node->bias()))
   {
     // bias is not used for type inference, but node itself should have a type


### PR DESCRIPTION
Parent Issue : #654 

This commit will add a logic for handling optional input tensor
for `FullyConnected`

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>