### PR TITLE
[onert] Support float32 ReLU on cpu backend

### DIFF
--- a/compute/cker/include/cker/operation/ReLU.h
+++ b/compute/cker/include/cker/operation/ReLU.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __NNFW_CKER_RELU_H__
+#define __NNFW_CKER_RELU_H__
+
+#include "cker/Shape.h"
+#include "cker/eigen/Utils.h"
+
+#include <cmath>
+#include <Eigen/Core>
+
+namespace nnfw
+{
+namespace cker
+{
+
+inline void ReLU(const Shape &input_shape, const float *input_data, const Shape &output_shape,
+                 float *output_data)
+{
+  const auto input_map = MapAsVector(input_data, input_shape);
+  auto output_map = MapAsVector(output_data, output_shape);
+  output_map = input_map.cwiseMax(0.0f);
+}
+
+} // namespace cker
+} // namespace nnfw
+
+#endif // __NNFW_CKER_RELU_H__

--- a/runtime/onert/backend/cpu/KernelGenerator.cc
+++ b/runtime/onert/backend/cpu/KernelGenerator.cc
@@ -46,6 +46,7 @@
 #include "kernel/PadLayer.h"
 #include "kernel/PowLayer.h"
 #include "kernel/ReduceLayer.h"
+#include "kernel/ReLULayer.h"
 #include "kernel/ReshapeLayer.h"
 #include "kernel/ReverseLayer.h"
 #include "kernel/RoundLayer.h"
@@ -810,6 +811,21 @@ void KernelGenerator::visit(const ir::operation::ReduceMin &node)
 
   fn->configure(input_alloc, output_alloc, kernel::ReduceType::kMin, node.param().axes,
                 node.param().keep_dims);
+
+  _return_fn = std::move(fn);
+}
+
+void KernelGenerator::visit(const ir::operation::ReLU &node)
+{
+  const auto output_index{node.getOutputs().at(0)};
+  const auto input_index{node.getInputs().at(0)};
+
+  auto output_alloc = _tensor_builder->at(output_index).get();
+  auto input_alloc = _tensor_builder->at(input_index).get();
+
+  auto fn = std::make_unique<kernel::ReLULayer>();
+
+  fn->configure(input_alloc, output_alloc);
 
   _return_fn = std::move(fn);
 }

--- a/runtime/onert/backend/cpu/KernelGenerator.h
+++ b/runtime/onert/backend/cpu/KernelGenerator.h
@@ -73,6 +73,7 @@ public:
   void visit(const ir::operation::ReduceAny &) override;
   void visit(const ir::operation::ReduceMax &) override;
   void visit(const ir::operation::ReduceMin &) override;
+  void visit(const ir::operation::ReLU &) override;
   void visit(const ir::operation::Select &) override;
   void visit(const ir::operation::Slice &) override;
   void visit(const ir::operation::StridedSlice &) override;

--- a/runtime/onert/backend/cpu/ShapeFixer.cc
+++ b/runtime/onert/backend/cpu/ShapeFixer.cc
@@ -164,6 +164,8 @@ void ShapeFixer::visit(const ir::operation::ReduceMax &) { /* DO NOTHING */}
 
 void ShapeFixer::visit(const ir::operation::ReduceMin &) { /* DO NOTHING */}
 
+void ShapeFixer::visit(const ir::operation::ReLU &) { /* DO NOTHING */}
+
 void ShapeFixer::visit(const ir::operation::Select &) { /* DO NOTHING */}
 
 void ShapeFixer::visit(const ir::operation::Slice &) { /* DO NOTHING */}

--- a/runtime/onert/backend/cpu/ShapeFixer.h
+++ b/runtime/onert/backend/cpu/ShapeFixer.h
@@ -68,6 +68,7 @@ public:
   void visit(const ir::operation::ReduceAny &) override;
   void visit(const ir::operation::ReduceMax &) override;
   void visit(const ir::operation::ReduceMin &) override;
+  void visit(const ir::operation::ReLU &) override;
   void visit(const ir::operation::Select &) override;
   void visit(const ir::operation::Slice &) override;
   void visit(const ir::operation::StridedSlice &) override;

--- a/runtime/onert/backend/cpu/kernel/ReLULayer.cc
+++ b/runtime/onert/backend/cpu/kernel/ReLULayer.cc
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ReLULayer.h"
+
+#include "OperationUtils.h"
+
+#include <cker/operation/ReLU.h>
+
+namespace onert
+{
+namespace backend
+{
+namespace cpu
+{
+namespace kernel
+{
+
+ReLULayer::ReLULayer() : _input(nullptr), _output(nullptr)
+{
+  // DO NOTHING
+}
+
+void ReLULayer::reluFloat32()
+{
+  nnfw::cker::ReLU(convertTensorToCkerShape(_input),
+                   reinterpret_cast<const float *>(_input->buffer()),
+                   convertTensorToCkerShape(_output), reinterpret_cast<float *>(_output->buffer()));
+}
+
+void ReLULayer::reluQuant8()
+{
+  // cker quant8 relu is not implemented yet
+  throw std::runtime_error{"NYI"};
+}
+
+void ReLULayer::configure(const operand::Tensor *input, operand::Tensor *output)
+{
+  _input = input;
+  _output = output;
+}
+
+void ReLULayer::run()
+{
+  if (_input->data_type() == OperandType::FLOAT32)
+  {
+    reluFloat32();
+  }
+  else if (_input->data_type() == OperandType::QUANT8_ASYMM)
+  {
+    reluQuant8();
+  }
+}
+
+} // namespace kernel
+} // namespace cpu
+} // namespace backend
+} // namespace onert

--- a/runtime/onert/backend/cpu/kernel/ReLULayer.h
+++ b/runtime/onert/backend/cpu/kernel/ReLULayer.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_BACKEND_CPU_KERNEL_RELULAYER_H__
+#define __ONERT_BACKEND_CPU_KERNEL_RELULAYER_H__
+
+#include "../operand/Tensor.h"
+
+#include <exec/IFunction.h>
+
+namespace onert
+{
+namespace backend
+{
+namespace cpu
+{
+namespace kernel
+{
+
+class ReLULayer : public ::onert::exec::IFunction
+{
+public:
+  ReLULayer();
+
+public:
+  void reluFloat32();
+
+  void reluQuant8();
+
+  void configure(const operand::Tensor *input, operand::Tensor *output);
+
+  void run();
+  void runSync()
+  {
+    // this abstract method is used just for profiling and called for
+    // backend::acl_common::AclFunction
+    run();
+  }
+
+private:
+  const operand::Tensor *_input;
+  operand::Tensor *_output;
+};
+
+} // namespace kernel
+} // namespace cpu
+} // namespace backend
+} // namespace onert
+
+#endif // __ONERT_BACKEND_CPU_KERNEL_RELULAYER_H__

--- a/tests/nnapi/nnapi_gtest.skip.aarch64-linux.cpu
+++ b/tests/nnapi/nnapi_gtest.skip.aarch64-linux.cpu
@@ -142,8 +142,6 @@ GeneratedTests.relu6_float_1
 GeneratedTests.relu6_float_2
 GeneratedTests.relu6_quant8_1
 GeneratedTests.relu6_quant8_2
-GeneratedTests.relu_float_1
-GeneratedTests.relu_float_2
 GeneratedTests.relu_quant8_1
 GeneratedTests.relu_quant8_2
 GeneratedTests.reshape_quant8_weights_as_inputs

--- a/tests/nnapi/nnapi_gtest.skip.armv7l-linux.cpu
+++ b/tests/nnapi/nnapi_gtest.skip.armv7l-linux.cpu
@@ -142,8 +142,6 @@ GeneratedTests.relu6_float_1
 GeneratedTests.relu6_float_2
 GeneratedTests.relu6_quant8_1
 GeneratedTests.relu6_quant8_2
-GeneratedTests.relu_float_1
-GeneratedTests.relu_float_2
 GeneratedTests.relu_quant8_1
 GeneratedTests.relu_quant8_2
 GeneratedTests.reshape_quant8_weights_as_inputs

--- a/tests/nnapi/nnapi_gtest.skip.x86_64-linux.cpu
+++ b/tests/nnapi/nnapi_gtest.skip.x86_64-linux.cpu
@@ -142,8 +142,6 @@ GeneratedTests.relu6_float_1
 GeneratedTests.relu6_float_2
 GeneratedTests.relu6_quant8_1
 GeneratedTests.relu6_quant8_2
-GeneratedTests.relu_float_1
-GeneratedTests.relu_float_2
 GeneratedTests.relu_quant8_1
 GeneratedTests.relu_quant8_2
 GeneratedTests.reshape_quant8_weights_as_inputs


### PR DESCRIPTION
For supporting `while_static.tflite` model

This commit makes cpu backend supports float32 ReLU.

Signed-off-by: ragmani <ragmani0216@gmail.com>