### PR TITLE
[luci] Shape, dtype inf for MIRROR_PAD

### DIFF
--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -794,6 +794,40 @@ public:
     return loco::NodeShape{output_shape};
   }
 
+  loco::NodeShape visit(const luci::CircleMirrorPad *node) final
+  {
+    const loco::DataType S32 = loco::DataType::S32;
+
+    auto input_shape = loco::shape_get(node->input()).as<loco::TensorShape>();
+    auto paddings = loco::must_cast<luci::CircleConst *>(node->paddings());
+
+    // TODO support non-const case
+    // TODO support other data type
+    LUCI_ASSERT(paddings->dtype() == S32, "Only support int 32 for now");
+    LUCI_ASSERT(paddings->rank() == 2, "paddings should be rank 2")
+
+    int32_t n = paddings->dim(0).value();
+    int32_t v = paddings->dim(1).value();
+
+    LUCI_ASSERT(v == 2, "paddings should be [n, 2]");
+    LUCI_ASSERT(n == int32_t(input_shape.rank()),
+                "paddings [n, 2] should have same value of input rank");
+
+    loco::TensorShape output_shape;
+
+    output_shape.rank(input_shape.rank());
+    for (int32_t ni = 0; ni < n; ++ni)
+    {
+      int32_t idx = ni * 2;
+      int value = input_shape.dim(ni).value();
+      value += paddings->at<S32>(idx + 0); // left
+      value += paddings->at<S32>(idx + 1); // right
+      output_shape.dim(ni) = value;
+    }
+
+    return loco::NodeShape{output_shape};
+  }
+
   loco::NodeShape visit(const luci::CircleMul *node) final
   {
     auto x_shape = loco::shape_get(node->x()).as<loco::TensorShape>();

--- a/compiler/luci/service/src/CircleTypeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleTypeInferenceRule.cpp
@@ -164,6 +164,11 @@ struct TypeInferenceAlgorithm final : public luci::CircleNodeVisitor<loco::DataT
 
   loco::DataType visit(const luci::CircleMinimum *node) final { return loco::dtype_get(node->x()); }
 
+  loco::DataType visit(const luci::CircleMirrorPad *node) final
+  {
+    return loco::dtype_get(node->input());
+  }
+
   loco::DataType visit(const luci::CircleNotEqual *) final { return loco::DataType::BOOL; }
 
   loco::DataType visit(const luci::CirclePack *node) final


### PR DESCRIPTION
This will enable shape and dtype inference for MIRROR_PAD IR

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>