### PR TITLE
[onert] remove code that wouldn't be executed in ConstantInsertionPass

### DIFF
--- a/runtime/onert/core/src/ir/pass/ConstantInsertionPass.cc
+++ b/runtime/onert/core/src/ir/pass/ConstantInsertionPass.cc
@@ -66,18 +66,14 @@ void ConstantInsertionPass::callback(const OperationIndex &node_index, Operation
       auto &replaced_object = _graph.operands().at(replaced_input);
       replaced_object.appendUse(node_index);
 
-      // Remove this node from def and uses of origin operand
-      if (object.getDef().contains(node_index))
-      {
-        object.removeDef(node_index);
-      }
+      // Remove this node from uses of origin operand
+      // Constant operand has no def.
+      assert(object.getDef().size() == 0);
       object.removeUse(node_index);
 
       // Remove origin operand
-      if (object.getDef().size() == 0 && object.getUses().size() == 0)
-      {
+      if (object.getUses().size() == 0)
         _graph.removeOperand(input);
-      }
     }
   }
 


### PR DESCRIPTION
For constant operand, operand._def.size() = 0.
Thus the conditional code is removed, and it is now changed to assert.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>