### PR TITLE
[luci/service] Pow support shape and type inference

### DIFF
--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -956,6 +956,16 @@ public:
     return loco::NodeShape{output_shape};
   }
 
+  loco::NodeShape visit(const luci::CirclePow *node) final
+  {
+    auto x_shape = loco::shape_get(node->x()).as<loco::TensorShape>();
+    auto y_shape = loco::shape_get(node->y()).as<loco::TensorShape>();
+
+    auto output_shape = broadcast_shape(x_shape, y_shape);
+
+    return loco::NodeShape{output_shape};
+  }
+
   loco::NodeShape visit(const luci::CircleRange *node) final
   {
     loco::TensorShape output_shape;

--- a/compiler/luci/service/src/CircleTypeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleTypeInferenceRule.cpp
@@ -185,6 +185,18 @@ struct TypeInferenceAlgorithm final : public luci::CircleNodeVisitor<loco::DataT
 
   loco::DataType visit(const luci::CirclePad *node) final { return loco::dtype_get(node->input()); }
 
+  loco::DataType visit(const luci::CirclePow *node) final
+  {
+    // TODO make sure types cannot differ
+    auto x_type = loco::dtype_get(node->x());
+    auto y_type = loco::dtype_get(node->y());
+
+    if (x_type != y_type)
+      INTERNAL_EXN("Different datatype for x and y are not supported");
+
+    return x_type;
+  }
+
   loco::DataType visit(const luci::CircleRange *node) final
   {
     return loco::dtype_get(node->start());


### PR DESCRIPTION
Add shape and type inference support for Pow operator

ONE-DCO-1.0-Signed-off-by: Vladimir Plazun v.plazun@samsung.com