### PR TITLE
[luci-interpreter] Fix wrong assertion

### DIFF
--- a/compiler/luci-interpreter/src/kernels/Concatenation.cpp
+++ b/compiler/luci-interpreter/src/kernels/Concatenation.cpp
@@ -58,7 +58,7 @@ void Concatenation::configure()
       }
       else
       {
-        assert(tensor->shape().dim(i) == t0->shape().dim(i));
+        assert(tensor->shape().dim(d) == t0->shape().dim(d));
       }
     }
   }


### PR DESCRIPTION
Fix incorrect `assert` in `Concatenation` kernel.

ONE-DCO-1.0-Signed-off-by: Sergei Barannikov <s.barannikov@samsung.com>