### PR TITLE
[onert] change assert to throw in LogicalOr OperationValidator

### DIFF
--- a/runtime/onert/core/src/compiler/OperationValidator.cc
+++ b/runtime/onert/core/src/compiler/OperationValidator.cc
@@ -1288,12 +1288,8 @@ void OperationValidator::visit(const ir::operation::LogicalOr &node)
   const auto lhs_index{node.getInputs().at(0)};
   const auto rhs_index{node.getInputs().at(1)};
 
-  UNUSED_RELEASE(output_index);
-  UNUSED_RELEASE(lhs_index);
-  UNUSED_RELEASE(rhs_index);
-
-  assert(_ctx.at(lhs_index).typeInfo().type() == _ctx.at(rhs_index).typeInfo().type());
-  assert(_ctx.at(lhs_index).typeInfo().type() == _ctx.at(output_index).typeInfo().type());
+  OP_REQUIRES(_ctx.at(lhs_index).typeInfo().type() == _ctx.at(rhs_index).typeInfo().type());
+  OP_REQUIRES(_ctx.at(lhs_index).typeInfo().type() == _ctx.at(output_index).typeInfo().type());
 }
 
 } // namespace compiler


### PR DESCRIPTION
Recently we've changed to throw runtime error instead of assert.
It updates LogicalOr in OperationValidator.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>