### PR TITLE
[luci] Add type/shape inference for BCQ operations

### DIFF
--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -1570,6 +1570,62 @@ public:
   }
 
   // Circle Only
+  loco::NodeShape visit(const luci::CircleBCQFullyConnected *node) final
+  {
+    loco::TensorShape out_shape;
+    loco::TensorShape weights_shape;
+
+    auto input_shape = loco::shape_get(node->input()).as<loco::TensorShape>();
+    auto weights_scales_shape = loco::shape_get(node->weights_scales()).as<loco::TensorShape>();
+    auto weights_binary_shape = loco::shape_get(node->weights_binary()).as<loco::TensorShape>();
+
+    weights_shape.rank(2);
+    weights_shape.dim(0) = weights_binary_shape.dim(0);
+    weights_shape.dim(1) = weights_binary_shape.dim(2).value() * 32;
+
+    LUCI_ASSERT(input_shape.rank() >= 2, "Input rank should be at least 2");
+    LUCI_ASSERT(weights_shape.rank() == 2, "Incompatible weights rank for BCQ fully connected");
+
+    uint32_t input_size = 1;
+    for (uint32_t i = 0; i < input_shape.rank(); i++)
+    {
+      input_size = input_size * input_shape.dim(i).value();
+    }
+    const uint32_t batch_size = input_size / weights_shape.dim(1).value();
+
+    out_shape.rank(2);
+    out_shape.dim(0) = batch_size;
+    out_shape.dim(1) = weights_shape.dim(0);
+
+    return loco::NodeShape{out_shape};
+  }
+
+  loco::NodeShape visit(const luci::CircleBCQGather *node) final
+  {
+    loco::TensorShape input_shape;
+    loco::TensorShape output_shape;
+
+    const auto input_scales_shape = loco::shape_get(node->input_scales()).as<loco::TensorShape>();
+    const auto input_binary_shape = loco::shape_get(node->input_binary()).as<loco::TensorShape>();
+    const auto indices_shape = loco::shape_get(node->indices()).as<loco::TensorShape>();
+    auto axis = node->axis();
+
+    input_shape.rank(2);
+    input_shape.dim(0) = input_binary_shape.dim(0);
+    input_shape.dim(1) = input_binary_shape.dim(2).value() * 32;
+
+    output_shape.rank(input_shape.rank() - 1 + indices_shape.rank());
+    int32_t outdim_index = 0;
+    for (int32_t i = 0; i < axis; ++i)
+      output_shape.dim(outdim_index++) = input_shape.dim(i);
+    for (uint32_t i = 0; i < indices_shape.rank(); ++i)
+      output_shape.dim(outdim_index++) = indices_shape.dim(i);
+    for (uint32_t i = axis + 1; i < indices_shape.rank(); ++i)
+      output_shape.dim(outdim_index++) = input_shape.dim(i);
+
+    return loco::NodeShape{output_shape};
+  }
+
   loco::NodeShape visit(const luci::CircleInstanceNorm *node) final
   {
     auto input_shape = loco::shape_get(node->input()).as<loco::TensorShape>();

--- a/compiler/luci/service/src/CircleTypeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleTypeInferenceRule.cpp
@@ -349,6 +349,13 @@ struct TypeInferenceAlgorithm final : public luci::CircleNodeVisitor<loco::DataT
   }
 
   // Circle Only
+  loco::DataType visit(const luci::CircleBCQFullyConnected *) final
+  {
+    return loco::DataType::FLOAT32;
+  }
+
+  loco::DataType visit(const luci::CircleBCQGather *) final { return loco::DataType::FLOAT32; }
+
   loco::DataType visit(const luci::CircleInstanceNorm *node) final
   {
     return loco::dtype_get(node->input());


### PR DESCRIPTION
Parent Issue : #1079

This commit will add type/shape inference for BCQ operations

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>