### PR TITLE
[onert] Change the internal shape of dynamic_tensor.py

### DIFF
--- a/tests/nnapi/nnapi_test_generator/android-10/dynamic_tensor.py
+++ b/tests/nnapi/nnapi_test_generator/android-10/dynamic_tensor.py
@@ -88,8 +88,8 @@ class DynamicInputGenerator:
         new_shape_str = "{" + str(len(model_input_shape_list)) + "}"
         self.new_shape   = Input("new_shape", "TENSOR_INT32", new_shape_str)
 
-        # shape not known since it is dynamic.. Just use {1}
-        self.test_input = Internal("internal1", "TENSOR_FLOAT32", "{1}")
+        # shape not known since it is dynamic. Use a scalar {} just like TFL Converter.
+        self.test_input = Internal("internal1", "TENSOR_FLOAT32", "{}")
         model.Operation("RESHAPE", self.model_input, self.new_shape).To(self.test_input)
 
     # convert, e.g., [1, 2, 3] to "{1, 2, 3}"


### PR DESCRIPTION
This changes the output shape of `Reshape` in _dynamic_tensor.py_ to scalar. FYI, scalar is used by the shape of TensorFlow Converter.

This solves issue with the comment below mentioned in https://github.com/Samsung/ONE/issues/1315 since scalar meets the req `dimensionCount to 0 and dimensions to NULL`

```
  * Starting at API level 29, a tensor operand type of unspecified rank is 
  * represented by setting dimensionCount to 0 and dimensions to NULL (just as if 
  * it were a scalar operand type). 
```

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>