### PR TITLE
[tflchef] Chef Operand without shape

### DIFF
--- a/compiler/tflchef/core/src/ModelChef.cpp
+++ b/compiler/tflchef/core/src/ModelChef.cpp
@@ -377,11 +377,15 @@ GeneratedModel cook(const ::tflchef::ModelRecipe &model_recipe)
       assert(operand.has_name());
 
       assert(operand.has_type());
-      assert(operand.has_shape());
 
-      std::vector<int32_t> dims = as_dims(operand.shape());
+      flatbuffers::Offset<flatbuffers::Vector<int32_t>> shape;
+      std::vector<int32_t> dims;
+      if (operand.has_shape())
+      {
+        dims = as_dims(operand.shape());
+        shape = flatbuffer_builder->CreateVector(dims);
+      }
 
-      auto shape = flatbuffer_builder->CreateVector(dims);
       auto name = flatbuffer_builder->CreateString(operand.name());
 
       buffer_index = 0;
@@ -399,7 +403,8 @@ GeneratedModel cook(const ::tflchef::ModelRecipe &model_recipe)
         assert(chef != nullptr);
 
         // Create Data
-        auto data_vec = chef->generate(element_count(dims));
+        int32_t count = (element_count(dims) > 0) ? element_count(dims) : filler.arg_size();
+        auto data_vec = chef->generate(count);
         auto data = flatbuffer_builder->CreateVector(data_vec);
 
         // Create Buffer
@@ -624,11 +629,15 @@ GeneratedModel cook(const ::tflchef::ModelRecipe &model_recipe)
       assert(operand.has_name());
 
       assert(operand.has_type());
-      assert(operand.has_shape());
 
-      std::vector<int32_t> dims = as_dims(operand.shape());
+      std::vector<int32_t> dims;
+      flatbuffers::Offset<flatbuffers::Vector<int32_t>> shape;
+      if (operand.has_shape())
+      {
+        dims = as_dims(operand.shape());
+        shape = flatbuffer_builder->CreateVector(dims);
+      }
 
-      auto shape = flatbuffer_builder->CreateVector(dims);
       auto name = flatbuffer_builder->CreateString(operand.name());
 
       // Create Buffer if filler is specified
@@ -644,7 +653,8 @@ GeneratedModel cook(const ::tflchef::ModelRecipe &model_recipe)
         assert(chef != nullptr);
 
         // Create Data
-        auto data_vec = chef->generate(element_count(dims));
+        int32_t count = (element_count(dims) > 0) ? element_count(dims) : filler.arg_size();
+        auto data_vec = chef->generate(count);
         auto data = flatbuffer_builder->CreateVector(data_vec);
 
         // Create Buffer

--- a/compiler/tflchef/tests/no_shape/test.recipe
+++ b/compiler/tflchef/tests/no_shape/test.recipe
@@ -1,0 +1,40 @@
+operand {
+  name: "indices"
+  type: INT32
+  shape { dim: 4 }
+}
+operand {
+  name: "depth"
+  type: INT32
+  filler { tag: "explicit" arg: "0" }
+}
+operand {
+  name: "on_value"
+  type: INT32
+  filler { tag: "explicit" arg: "1" }
+}
+operand {
+  name: "off_value"
+  type: INT32
+  filler { tag: "explicit" arg: "0" }
+}
+operand {
+  name: "ofm"
+  type: INT32
+  shape { dim: 4 dim: 3 }
+}
+operation {
+  type: "OneHot"
+  onehot_options {
+    axis: -1
+  }
+  input: "indices"
+  input: "depth"
+  input: "on_value"
+  input: "off_value"
+  output: "ofm"
+}
+input: "indices"
+input: "on_value"
+input: "off_value"
+output: "ofm"

--- a/compiler/tflchef/tests/no_shape/test.recipe
+++ b/compiler/tflchef/tests/no_shape/test.recipe
@@ -6,16 +6,19 @@ operand {
 operand {
   name: "depth"
   type: INT32
+  # shape is intentionally omitted here
   filler { tag: "explicit" arg: "0" }
 }
 operand {
   name: "on_value"
   type: INT32
+  # shape is intentionally omitted here
   filler { tag: "explicit" arg: "1" }
 }
 operand {
   name: "off_value"
   type: INT32
+  # shape is intentionally omitted here
   filler { tag: "explicit" arg: "0" }
 }
 operand {

--- a/compiler/tflchef/tflite/src/RecipeChef.cpp
+++ b/compiler/tflchef/tflite/src/RecipeChef.cpp
@@ -104,11 +104,14 @@ std::unique_ptr<ModelRecipe> generate_recipe(const tflite::Model *model)
     operand->set_name(tensor_name(tensor));
     operand->set_type(as_tflchef_type(tensor->type()));
 
-    std::vector<int32_t> dims = as_index_vector(tensor->shape());
-    ::tflchef::TensorShape *shape = operand->mutable_shape();
-    for (auto dim : dims)
+    if (tensor->shape())
     {
-      shape->add_dim(dim);
+      std::vector<int32_t> dims = as_index_vector(tensor->shape());
+      ::tflchef::TensorShape *shape = operand->mutable_shape();
+      for (auto dim : dims)
+      {
+        shape->add_dim(dim);
+      }
     }
 
     // filler for weights, bias and so on


### PR DESCRIPTION
This will enable to chef an Operand without shape information

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>