### PR TITLE
[onert] Allow unused input of subgraph

### DIFF
--- a/runtime/onert/core/src/backend/controlflow/kernel/IfLayer.cc
+++ b/runtime/onert/core/src/backend/controlflow/kernel/IfLayer.cc
@@ -87,6 +87,11 @@ void IfLayer::run()
     PermuteTensorsLayer permute_then_output_to_op_output{then_output_tensors, _output_tensors,
                                                          output_ranks};
 
+    // Remove copying of unused tensor
+    permute_op_input_to_then_input.prepare();
+    permute_then_output_to_op_output.prepare();
+
+    // Copy & run
     permute_op_input_to_then_input.run();
     then_exec->execute();
     permute_then_output_to_op_output.run();
@@ -106,6 +111,11 @@ void IfLayer::run()
     PermuteTensorsLayer permute_else_output_to_op_output{else_output_tensors, _output_tensors,
                                                          output_ranks};
 
+    // Remove copying of unused tensor
+    permute_op_input_to_else_input.prepare();
+    permute_else_output_to_op_output.prepare();
+
+    // Copy & run
     permute_op_input_to_else_input.run();
     else_exec->execute();
     permute_else_output_to_op_output.run();

--- a/runtime/onert/core/src/backend/controlflow/kernel/PermuteTensorsLayer.h
+++ b/runtime/onert/core/src/backend/controlflow/kernel/PermuteTensorsLayer.h
@@ -35,6 +35,8 @@ public:
                       const std::vector<std::shared_ptr<onert::backend::ITensor>> &dst_tensors,
                       std::vector<size_t> ranks)
   {
+    assert(src_tensors.size() == dst_tensors.size());
+    assert(src_tensors.size() == ranks.size());
     _src_tensors = src_tensors;
     _dst_tensors = dst_tensors;
     _ranks = ranks;
@@ -42,7 +44,25 @@ public:
 
   void optimize() override
   {
-    // DO NOTHING
+    // Remove copying of tensor as nullptr
+    auto src_it = _src_tensors.begin();
+    auto dst_it = _dst_tensors.begin();
+    auto rank_it = _ranks.begin();
+    while (src_it != _src_tensors.end())
+    {
+      if (*src_it == nullptr || *dst_it == nullptr)
+      {
+        src_it = _src_tensors.erase(src_it);
+        dst_it = _dst_tensors.erase(dst_it);
+        rank_it = _ranks.erase(rank_it);
+      }
+      else
+      {
+        ++src_it;
+        ++dst_it;
+        ++rank_it;
+      }
+    }
   }
 };
 

--- a/runtime/onert/core/src/backend/controlflow/kernel/WhileLayer.cc
+++ b/runtime/onert/core/src/backend/controlflow/kernel/WhileLayer.cc
@@ -78,6 +78,12 @@ void WhileLayer::run()
                                                         _ranks};
   PermuteTensorsLayer permute_cond_input_to_op_output{cond_input_tensors, _dst_tensors, _ranks};
 
+  // Remove copying of unused tensor
+  permute_op_input_to_cond_input.prepare();
+  permute_cond_input_to_body_input.prepare();
+  permute_body_output_to_cond_input.prepare();
+  permute_cond_input_to_op_output.prepare();
+
   permute_op_input_to_cond_input.run();
   cond_exec->execute();
 

--- a/runtime/onert/core/src/compiler/Linear.cc
+++ b/runtime/onert/core/src/compiler/Linear.cc
@@ -163,6 +163,16 @@ void Linear::planTensors(const ir::LoweredGraph &lowered_graph,
       return;
     }
 
+    // Unused input of subgraph
+    // TODO Register unused input as nullptr in tensor_builder
+    if (lower_info->def_factors().size() == 0 && lower_info->use_factors().size() == 0 &&
+        graph.getInputs().contains(ind))
+    {
+      VERBOSE(LINEAR) << "Operand #" << ind.value() << " will not be used. no more process."
+                      << std::endl;
+      return;
+    }
+
     uses_map[ind] = obj.getUses().size();
     def_map[ind] = obj.getDef().size(); // should be 1 or 0
 

--- a/runtime/onert/core/src/exec/ExecutorBase.cc
+++ b/runtime/onert/core/src/exec/ExecutorBase.cc
@@ -44,7 +44,9 @@ ExecutorBase::ExecutorBase(std::unique_ptr<ir::LoweredGraph> &&lowered_graph,
           break;
         }
       }
-      assert(tensor != nullptr);
+
+      // Controlflow opeartion can make subgraph has unused input.
+      assert(tensor != nullptr || _lowered_graph->graph().getInputs().contains(ind));
       list.push_back(tensor);
     }
     return list;

--- a/runtime/onert/core/src/ir/LoweredGraph.cc
+++ b/runtime/onert/core/src/ir/LoweredGraph.cc
@@ -285,8 +285,12 @@ void LoweredGraph::manipulateLowerInfo(
     // Pick just any one from the uses, here the first one is chosen
     // For the other uses, Permute operations will be inserted later
     auto &&lower_info = operands_lower_info.at(index);
-    assert(lower_info->use_factors().size() > 0);
-    lower_info->addDefPermuteFactor(*lower_info->use_factors().begin());
+    if (!(lower_info->def_factors().size() == 0 && lower_info->use_factors().size() == 0))
+    {
+      // In case of not that Graph's input is not used in any operation and not the graph's output.
+      // In other words, it is not unused input in Graph.
+      lower_info->addDefPermuteFactor(*lower_info->use_factors().begin());
+    }
   }
   for (auto index : _graph.getOutputs())
   {


### PR DESCRIPTION
For issue : #1044
Draft PR : #1100

This commit allows unused input of subgraph.
  - Remove an assertion to check unused input
  - Optimize copying of unused input in controlflow kernels

Signed-off-by: ragmani <ragmani0216@gmail.com>