### PR TITLE
[onert] ConstantInsertionPass will update constant operand one by one

### DIFF
--- a/runtime/onert/core/include/ir/OperandIndexSequence.h
+++ b/runtime/onert/core/include/ir/OperandIndexSequence.h
@@ -52,6 +52,11 @@ public:
 public:
   std::vector<OperandIndex>::const_iterator begin(void) const { return _set.begin(); }
   std::vector<OperandIndex>::const_iterator end(void) const { return _set.end(); }
+  // Standard c++ uses `cbegin` for const_iterator and `begin` for mutable iterator.
+  // However, our project uses `begin` for const_iterator in several data structures.
+  // Thus, I introduced `mbegin` for mutable iterator.
+  std::vector<OperandIndex>::iterator mbegin(void) { return _set.begin(); }
+  std::vector<OperandIndex>::iterator mend(void) { return _set.end(); }
 
 private:
   std::vector<OperandIndex> _set;

--- a/runtime/onert/core/include/ir/Operation.h
+++ b/runtime/onert/core/include/ir/Operation.h
@@ -53,6 +53,7 @@ public:
 public:
   void replaceInput(const OperandIndex &from, const OperandIndex &to);
   void replaceOutput(const OperandIndex &from, const OperandIndex &to);
+  OperandIndexSequence &getInputs() { return _inputs; }
   const OperandIndexSequence &getInputs() const { return _inputs; }
   const OperandIndexSequence &getOutputs() const { return _outputs; }
   // It's for only input/output tensors but const data.

--- a/runtime/onert/core/src/ir/pass/ConstantInsertionPass.cc
+++ b/runtime/onert/core/src/ir/pass/ConstantInsertionPass.cc
@@ -35,8 +35,9 @@ void ConstantInsertionPass::callback(const OperationIndex &node_index, Operation
   const auto layout = op_seq_lower_info->layout();
   const auto factor = operand::PermuteFactor{backend, layout};
 
-  for (const auto input : node.getInputs())
+  for (auto it = node.getInputs().mbegin(); it != node.getInputs().mend(); ++it)
   {
+    const auto input = *it;
     auto &object = _graph.operands().at(input);
 
     if (object.isConstant())
@@ -59,8 +60,8 @@ void ConstantInsertionPass::callback(const OperationIndex &node_index, Operation
         _lowered_graph.op_seqs().at(op_sequence_index).replaceInput(input, replaced_input);
       }
 
-      // Update node
-      node.replaceInput(input, replaced_input);
+      // Update current input operand only. Don't update all input node in this operation.
+      *it = replaced_input;
 
       // Update operand
       auto &replaced_object = _graph.operands().at(replaced_input);


### PR DESCRIPTION
When a operation uses a same constant operand multiple times, ConstantInsertionPass
behave wrongly. It will update the internal data one by one, instead of updating
all occurrences within a operation if a new operand is created.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>