### PR TITLE
[DRAFT] Input/Output tensor copy elimination

### DIFF
--- a/runtime/onert/backend/cpu/Config.h
+++ b/runtime/onert/backend/cpu/Config.h
@@ -37,6 +37,7 @@ public:
   bool supportPermutation() override { return true; }
   bool supportDynamicTensor() override { return true; }
   bool supportFP16() override { return false; }
+  bool supportExternalTensor() override { return true; }
 
   std::unique_ptr<util::ITimer> timer() override { return std::make_unique<util::CPUTimer>(); }
 };

--- a/runtime/onert/backend/cpu/DynamicTensorManager.cc
+++ b/runtime/onert/backend/cpu/DynamicTensorManager.cc
@@ -31,7 +31,7 @@ DynamicTensorManager::DynamicTensorManager(const std::shared_ptr<TensorRegistry>
 
 void DynamicTensorManager::allocate(const ir::OperandIndex &ind, const ir::Shape &new_shape)
 {
-  auto tensor = (*_tensors)[ind];
+  auto tensor = _tensors->getManagedTensor(ind);
   assert(tensor);
 
   auto allocTensorMem = [&]() {
@@ -60,14 +60,14 @@ void DynamicTensorManager::allocate(const ir::OperandIndex &ind, const ir::Shape
 void DynamicTensorManager::buildTensor(const ir::OperandIndex &ind,
                                        const ir::OperandInfo &tensor_info)
 {
-  assert(_tensors->find(ind) == _tensors->end());
+  assert(_tensors->getITensor(ind) == nullptr);
   auto tensor = std::make_shared<operand::Tensor>(tensor_info);
-  (*_tensors)[ind] = tensor;
+  _tensors->setManagedTensor(ind, tensor);
 }
 
 void DynamicTensorManager::changeShape(const ir::OperandIndex &ind, const ir::Shape &new_shape)
 {
-  auto tensor = (*_tensors)[ind];
+  auto tensor = _tensors->getITensor(ind);
   assert(tensor);
 
   setShape(tensor.get(), new_shape);

--- a/runtime/onert/backend/cpu/KernelGenerator.cc
+++ b/runtime/onert/backend/cpu/KernelGenerator.cc
@@ -148,10 +148,10 @@ void KernelGenerator::visit(const ir::operation::Conv2D &node)
                                             ker_width, ker_height);
   const auto activation = node.param().activation;
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto ifm_alloc = _tensor_builder->at(ifm_index).get();
-  auto ker_alloc = _tensor_builder->at(ker_index).get();
-  auto bias_alloc = _tensor_builder->at(bias_index).get();
+  auto ofm_alloc = _tensor_builder->tensorAt(ofm_index).get();
+  auto ifm_alloc = _tensor_builder->tensorAt(ifm_index).get();
+  auto ker_alloc = _tensor_builder->tensorAt(ker_index).get();
+  auto bias_alloc = _tensor_builder->tensorAt(bias_index).get();
 
   auto fn = std::make_unique<::onert::backend::cpu::kernel::ConvolutionLayer>();
 
@@ -183,10 +183,10 @@ void KernelGenerator::visit(const ir::operation::DepthwiseConv2D &node)
   const auto multiplier = node.param().multiplier;
   const auto activation = node.param().activation;
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto ifm_alloc = _tensor_builder->at(ifm_index).get();
-  auto ker_alloc = _tensor_builder->at(ker_index).get();
-  auto bias_alloc = _tensor_builder->at(bias_index).get();
+  auto ofm_alloc = _tensor_builder->tensorAt(ofm_index).get();
+  auto ifm_alloc = _tensor_builder->tensorAt(ifm_index).get();
+  auto ker_alloc = _tensor_builder->tensorAt(ker_index).get();
+  auto bias_alloc = _tensor_builder->tensorAt(bias_index).get();
 
   auto fn = std::make_unique<::onert::backend::cpu::kernel::DepthwiseConvolutionLayer>();
 
@@ -212,8 +212,8 @@ void KernelGenerator::visit(const ir::operation::MaxPool2D &node)
       ir::calculatePadding(node.param().padding, ifm_shape, ofm_shape, stride, kw, kh);
   const auto activation = node.param().activation;
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto ifm_alloc = _tensor_builder->at(ifm_index).get();
+  auto ofm_alloc = _tensor_builder->tensorAt(ofm_index).get();
+  auto ifm_alloc = _tensor_builder->tensorAt(ifm_index).get();
 
   auto fn = std::make_unique<::onert::backend::cpu::kernel::MaxPoolLayer>();
 
@@ -237,8 +237,8 @@ void KernelGenerator::visit(const ir::operation::AvgPool2D &node)
       ir::calculatePadding(node.param().padding, ifm_shape, ofm_shape, stride, kw, kh);
   const auto activation = node.param().activation;
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto ifm_alloc = _tensor_builder->at(ifm_index).get();
+  auto ofm_alloc = _tensor_builder->tensorAt(ofm_index).get();
+  auto ifm_alloc = _tensor_builder->tensorAt(ifm_index).get();
 
   auto fn = std::make_unique<::onert::backend::cpu::kernel::AvgPoolLayer>();
 
@@ -256,11 +256,11 @@ void KernelGenerator::visit(const ir::operation::Concat &node)
   const auto axis =
       ::onert::backend::cpu::kernel::getAxis(rank, node.param().axis, _current_op_seq_layout);
 
-  auto output_alloc = _tensor_builder->at(ofm_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(ofm_index).get();
 
-  std::vector<const operand::Tensor *> input_tensors;
+  std::vector<const ITensor *> input_tensors;
   for (auto &ifm_idx : node.getInputs())
-    input_tensors.emplace_back(_tensor_builder->at(ifm_idx).get());
+    input_tensors.emplace_back(_tensor_builder->tensorAt(ifm_idx).get());
 
   auto fn = std::make_unique<::onert::backend::cpu::kernel::ConcatLayer>();
 
@@ -275,9 +275,9 @@ void KernelGenerator::visit(const ir::operation::Fill &node)
   const auto input_index{node.getInputs().at(ir::operation::Fill::Input::INPUT)};
   const auto value_index{node.getInputs().at(ir::operation::Fill::Input::VALUE)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
-  auto value_alloc = _tensor_builder->at(value_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto input_alloc = _tensor_builder->tensorAt(input_index).get();
+  auto value_alloc = _tensor_builder->tensorAt(value_index).get();
 
   auto fn = std::make_unique<::onert::backend::cpu::kernel::FillLayer>();
 
@@ -296,10 +296,10 @@ void KernelGenerator::visit(const ir::operation::FullyConnected &node)
   const auto bias_index{node.getInputs().at(FullyConnected::Input::BIAS)};
   const auto activation = node.param().activation;
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
-  auto weight_alloc = _tensor_builder->at(weight_index).get();
-  auto bias_alloc = _tensor_builder->at(bias_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto input_alloc = _tensor_builder->tensorAt(input_index).get();
+  auto weight_alloc = _tensor_builder->tensorAt(weight_index).get();
+  auto bias_alloc = _tensor_builder->tensorAt(bias_index).get();
 
   auto fn = std::make_unique<::onert::backend::cpu::kernel::FullyConnectedLayer>();
 
@@ -313,16 +313,16 @@ void KernelGenerator::visit(const ir::operation::Reshape &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(ir::operation::Reshape::Input::INPUT)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto input_alloc = _tensor_builder->tensorAt(input_index).get();
 
   // optional 2nd input
-  operand::Tensor *shape_alloc = nullptr;
+  ITensor *shape_alloc = nullptr;
 
   if (node.getInputs().size() == 2)
   {
     const auto shape_index{node.getInputs().at(ir::operation::Reshape::Input::SHAPE)};
-    shape_alloc = _tensor_builder->at(shape_index).get();
+    shape_alloc = _tensor_builder->tensorAt(shape_index).get();
   }
 
   auto fn = std::make_unique<::onert::backend::cpu::kernel::ReshapeLayer>();
@@ -336,8 +336,8 @@ void KernelGenerator::visit(const ir::operation::Squeeze &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(ir::operation::Squeeze::Input::INPUT)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto input_alloc = _tensor_builder->tensorAt(input_index).get();
 
   // Squeeze can share same kernel with reshape
   auto fn = std::make_unique<::onert::backend::cpu::kernel::ReshapeLayer>();
@@ -354,8 +354,8 @@ void KernelGenerator::visit(const ir::operation::Softmax &node)
 
   const auto beta = node.param().beta;
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto input_alloc = _tensor_builder->tensorAt(input_index).get();
 
   auto fn = std::make_unique<::onert::backend::cpu::kernel::SoftMaxLayer>();
 
@@ -372,9 +372,9 @@ void KernelGenerator::visit(const ir::operation::Add &node)
 
   const auto activation = node.param().activation;
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto lhs_alloc = _tensor_builder->at(lhs_index).get();
-  auto rhs_alloc = _tensor_builder->at(rhs_index).get();
+  auto ofm_alloc = _tensor_builder->tensorAt(ofm_index).get();
+  auto lhs_alloc = _tensor_builder->tensorAt(lhs_index).get();
+  auto rhs_alloc = _tensor_builder->tensorAt(rhs_index).get();
 
   auto fn = std::make_unique<::onert::backend::cpu::kernel::AddLayer>();
 
@@ -389,9 +389,9 @@ void KernelGenerator::visit(const ir::operation::Comparison &node)
   const auto lhs_index{node.getInputs().at(ir::operation::Comparison::Input::INPUT0)};
   const auto rhs_index{node.getInputs().at(ir::operation::Comparison::Input::INPUT1)};
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto lhs_alloc = _tensor_builder->at(lhs_index).get();
-  auto rhs_alloc = _tensor_builder->at(rhs_index).get();
+  auto ofm_alloc = _tensor_builder->tensorAt(ofm_index).get();
+  auto lhs_alloc = _tensor_builder->tensorAt(lhs_index).get();
+  auto rhs_alloc = _tensor_builder->tensorAt(rhs_index).get();
 
   auto comparison_type = node.param().comparison_type;
 
@@ -408,9 +408,9 @@ void KernelGenerator::visit(const ir::operation::Gather &node)
   const auto input_index{node.getInputs().at(ir::operation::Gather::Input::INPUT)};
   const auto indices_index{node.getInputs().at(ir::operation::Gather::Input::INDICES)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
-  auto indices_alloc = _tensor_builder->at(indices_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto input_alloc = _tensor_builder->tensorAt(input_index).get();
+  auto indices_alloc = _tensor_builder->tensorAt(indices_index).get();
 
   const auto backend_layout = output_alloc->layout();
   UNUSED_RELEASE(backend_layout);
@@ -448,9 +448,9 @@ void KernelGenerator::visit(const ir::operation::Sub &node)
 
   const auto activation = node.param().activation;
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto lhs_alloc = _tensor_builder->at(lhs_index).get();
-  auto rhs_alloc = _tensor_builder->at(rhs_index).get();
+  auto ofm_alloc = _tensor_builder->tensorAt(ofm_index).get();
+  auto lhs_alloc = _tensor_builder->tensorAt(lhs_index).get();
+  auto rhs_alloc = _tensor_builder->tensorAt(rhs_index).get();
 
   auto fn = std::make_unique<::onert::backend::cpu::kernel::SubLayer>();
 
@@ -468,9 +468,9 @@ void KernelGenerator::visit(const ir::operation::Mul &node)
 
   const auto activation = node.param().activation;
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto lhs_alloc = _tensor_builder->at(lhs_index).get();
-  auto rhs_alloc = _tensor_builder->at(rhs_index).get();
+  auto ofm_alloc = _tensor_builder->tensorAt(ofm_index).get();
+  auto lhs_alloc = _tensor_builder->tensorAt(lhs_index).get();
+  auto rhs_alloc = _tensor_builder->tensorAt(rhs_index).get();
 
   auto fn = std::make_unique<::onert::backend::cpu::kernel::MulLayer>();
 
@@ -489,8 +489,8 @@ void KernelGenerator::visit(const ir::operation::OneHot &node)
   const auto off_value = node.param().off_value;
   const auto axis = node.param().axis;
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto indices_alloc = _tensor_builder->at(indices_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto indices_alloc = _tensor_builder->tensorAt(indices_index).get();
 
   assert(indices_alloc->data_type() == OperandType::INT32);
   assert(axis <= static_cast<int>(indices_alloc->num_dimensions()));
@@ -511,9 +511,9 @@ void KernelGenerator::visit(const ir::operation::Div &node)
 
   const auto activation = node.param().activation;
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto lhs_alloc = _tensor_builder->at(lhs_index).get();
-  auto rhs_alloc = _tensor_builder->at(rhs_index).get();
+  auto ofm_alloc = _tensor_builder->tensorAt(ofm_index).get();
+  auto lhs_alloc = _tensor_builder->tensorAt(lhs_index).get();
+  auto rhs_alloc = _tensor_builder->tensorAt(rhs_index).get();
 
   auto fn = std::make_unique<::onert::backend::cpu::kernel::DivLayer>();
 
@@ -593,7 +593,7 @@ void KernelGenerator::visit(const ir::operation::Custom &node)
       const auto &operand = _ctx.at(idx);
       // TODO make sure using `_current_op_seq_layout` is correct for custom operations
       types.emplace_back(get_type_info(operand));
-      auto in_alloc = _tensor_builder->at(idx)->buffer();
+      auto in_alloc = _tensor_builder->tensorAt(idx)->buffer();
       allocs.emplace_back(in_alloc);
     }
   };
@@ -616,8 +616,8 @@ void KernelGenerator::visit(const ir::operation::Exp &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(ir::operation::Exp::Input::INPUT)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto input_alloc = _tensor_builder->tensorAt(input_index).get();
 
   auto fn = std::make_unique<::onert::backend::cpu::kernel::ExpLayer>();
 
@@ -632,9 +632,9 @@ void KernelGenerator::visit(const ir::operation::ExpandDims &node)
   const auto input_index{node.getInputs().at(ir::operation::ExpandDims::Input::INPUT)};
   const auto axis_index{node.getInputs().at(ir::operation::ExpandDims::Input::AXIS)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
-  auto axis_alloc = _tensor_builder->at(axis_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto input_alloc = _tensor_builder->tensorAt(input_index).get();
+  auto axis_alloc = _tensor_builder->tensorAt(axis_index).get();
 
   auto fn = std::make_unique<::onert::backend::cpu::kernel::ExpandDimsLayer>();
 
@@ -648,8 +648,8 @@ void KernelGenerator::visit(const ir::operation::Logistic &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(ir::operation::Logistic::Input::INPUT)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto input_alloc = _tensor_builder->tensorAt(input_index).get();
 
   auto fn = std::make_unique<::onert::backend::cpu::kernel::LogisticLayer>();
 
@@ -663,8 +663,8 @@ void KernelGenerator::visit(const ir::operation::Tanh &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(ir::operation::Tanh::Input::INPUT)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto input_alloc = _tensor_builder->tensorAt(input_index).get();
 
   auto fn = std::make_unique<::onert::backend::cpu::kernel::TanhLayer>();
 
@@ -683,11 +683,11 @@ void KernelGenerator::visit(const ir::operation::Pack &node)
 
   assert(-rank <= axis && axis < rank);
 
-  auto output_alloc = _tensor_builder->at(ofm_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(ofm_index).get();
 
-  std::vector<const operand::Tensor *> input_tensors;
+  std::vector<const ITensor *> input_tensors;
   for (auto &ifm_idx : node.getInputs())
-    input_tensors.emplace_back(_tensor_builder->at(ifm_idx).get());
+    input_tensors.emplace_back(_tensor_builder->tensorAt(ifm_idx).get());
 
   auto fn = std::make_unique<::onert::backend::cpu::kernel::PackLayer>();
 
@@ -706,11 +706,11 @@ void KernelGenerator::visit(const ir::operation::Unpack &node)
 
   assert(-rank <= axis && axis < rank);
 
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto input_alloc = _tensor_builder->tensorAt(input_index).get();
 
-  std::vector<operand::Tensor *> output_tensors;
+  std::vector<ITensor *> output_tensors;
   for (auto &output_idx : node.getOutputs())
-    output_tensors.emplace_back(_tensor_builder->at(output_idx).get());
+    output_tensors.emplace_back(_tensor_builder->tensorAt(output_idx).get());
 
   auto fn = std::make_unique<::onert::backend::cpu::kernel::UnpackLayer>();
 
@@ -728,8 +728,8 @@ void KernelGenerator::visit(const ir::operation::Pad &node)
   const auto output_index{node.getOutputs().at(0)};
   assert(_ctx.at(pad_index).data());
 
-  auto input = _tensor_builder->at(input_index).get();
-  auto output = _tensor_builder->at(output_index).get();
+  auto input = _tensor_builder->tensorAt(input_index).get();
+  auto output = _tensor_builder->tensorAt(output_index).get();
   auto pad_rank = _ctx.at(pad_index).shape().dim(0);
   auto pad_base = reinterpret_cast<const int32_t *>(_ctx.at(pad_index).data()->base());
 
@@ -746,9 +746,9 @@ void KernelGenerator::visit(const ir::operation::Max &node)
   const auto lhs_index{node.getInputs().at(ir::operation::Max::Input::LHS)};
   const auto rhs_index{node.getInputs().at(ir::operation::Max::Input::RHS)};
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto lhs_alloc = _tensor_builder->at(lhs_index).get();
-  auto rhs_alloc = _tensor_builder->at(rhs_index).get();
+  auto ofm_alloc = _tensor_builder->tensorAt(ofm_index).get();
+  auto lhs_alloc = _tensor_builder->tensorAt(lhs_index).get();
+  auto rhs_alloc = _tensor_builder->tensorAt(rhs_index).get();
 
   auto fn = std::make_unique<::onert::backend::cpu::kernel::MaxLayer>();
 
@@ -763,9 +763,9 @@ void KernelGenerator::visit(const ir::operation::Min &node)
   const auto lhs_index{node.getInputs().at(ir::operation::Min::Input::LHS)};
   const auto rhs_index{node.getInputs().at(ir::operation::Min::Input::RHS)};
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto lhs_alloc = _tensor_builder->at(lhs_index).get();
-  auto rhs_alloc = _tensor_builder->at(rhs_index).get();
+  auto ofm_alloc = _tensor_builder->tensorAt(ofm_index).get();
+  auto lhs_alloc = _tensor_builder->tensorAt(lhs_index).get();
+  auto rhs_alloc = _tensor_builder->tensorAt(rhs_index).get();
 
   auto fn = std::make_unique<::onert::backend::cpu::kernel::MinLayer>();
 
@@ -779,8 +779,8 @@ void KernelGenerator::visit(const ir::operation::Cast &node)
   const auto ofm_index{node.getOutputs().at(0)};
   const auto ifm_index{node.getInputs().at(ir::operation::Cast::Input::INPUT)};
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto ifm_alloc = _tensor_builder->at(ifm_index).get();
+  auto ofm_alloc = _tensor_builder->tensorAt(ofm_index).get();
+  auto ifm_alloc = _tensor_builder->tensorAt(ifm_index).get();
 
   auto fn = std::make_unique<::onert::backend::cpu::kernel::CastLayer>();
 
@@ -794,8 +794,8 @@ void KernelGenerator::visit(const ir::operation::Transpose &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(0)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto input_alloc = _tensor_builder->tensorAt(input_index).get();
   auto rank = node.param().rank;
 
   auto fn = std::make_unique<::onert::backend::cpu::kernel::TransposeLayer>();
@@ -810,8 +810,8 @@ void KernelGenerator::visit(const ir::operation::ReduceSum &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(0)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto input_alloc = _tensor_builder->tensorAt(input_index).get();
 
   auto fn = std::make_unique<kernel::ReduceLayer>();
 
@@ -842,8 +842,8 @@ void KernelGenerator::visit(const ir::operation::ReduceMax &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(0)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto input_alloc = _tensor_builder->tensorAt(input_index).get();
 
   auto fn = std::make_unique<kernel::ReduceLayer>();
 
@@ -858,8 +858,8 @@ void KernelGenerator::visit(const ir::operation::ReduceMin &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(0)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto input_alloc = _tensor_builder->tensorAt(input_index).get();
 
   auto fn = std::make_unique<kernel::ReduceLayer>();
 
@@ -876,10 +876,10 @@ void KernelGenerator::visit(const ir::operation::Select &node)
   const auto true_index{node.getInputs().at(ir::operation::Select::Input::INPUT_TRUE)};
   const auto false_index{node.getInputs().at(ir::operation::Select::Input::INPUT_FALSE)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto condition_alloc = _tensor_builder->at(condition_index).get();
-  auto true_alloc = _tensor_builder->at(true_index).get();
-  auto false_alloc = _tensor_builder->at(false_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto condition_alloc = _tensor_builder->tensorAt(condition_index).get();
+  auto true_alloc = _tensor_builder->tensorAt(true_index).get();
+  auto false_alloc = _tensor_builder->tensorAt(false_index).get();
 
   auto fn = std::make_unique<kernel::SelectLayer>();
 
@@ -895,10 +895,10 @@ void KernelGenerator::visit(const ir::operation::Slice &node)
   const auto begins_index{node.getInputs().at(ir::operation::Slice::Input::BEGINS)};
   const auto sizes_index{node.getInputs().at(ir::operation::Slice::Input::SIZES)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
-  auto begins_alloc = _tensor_builder->at(begins_index).get();
-  auto sizes_alloc = _tensor_builder->at(sizes_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto input_alloc = _tensor_builder->tensorAt(input_index).get();
+  auto begins_alloc = _tensor_builder->tensorAt(begins_index).get();
+  auto sizes_alloc = _tensor_builder->tensorAt(sizes_index).get();
 
   auto fn = std::make_unique<::onert::backend::cpu::kernel::SliceLayer>();
 
@@ -915,11 +915,11 @@ void KernelGenerator::visit(const ir::operation::StridedSlice &node)
   const auto ends_index{node.getInputs().at(ir::operation::StridedSlice::Input::ENDS)};
   const auto strides_index{node.getInputs().at(ir::operation::StridedSlice::Input::STRIDES)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
-  auto starts_alloc = _tensor_builder->at(starts_index).get();
-  auto ends_alloc = _tensor_builder->at(ends_index).get();
-  auto strides_alloc = _tensor_builder->at(strides_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto input_alloc = _tensor_builder->tensorAt(input_index).get();
+  auto starts_alloc = _tensor_builder->tensorAt(starts_index).get();
+  auto ends_alloc = _tensor_builder->tensorAt(ends_index).get();
+  auto strides_alloc = _tensor_builder->tensorAt(strides_index).get();
 
   auto begin_mask = node.param().begin_mask;
   auto end_mask = node.param().end_mask;
@@ -946,11 +946,11 @@ void KernelGenerator::visit(const ir::operation::Split &node)
   assert(0 <= axis_resolved && axis_resolved < rank);
 
   const auto input_idx{node.getInputs().at(ir::operation::Split::Input::INPUT)};
-  auto in_tensor = _tensor_builder->at(input_idx).get();
+  auto in_tensor = _tensor_builder->tensorAt(input_idx).get();
 
-  std::vector<operand::Tensor *> out_tensors;
+  std::vector<ITensor *> out_tensors;
   for (auto &output_idx : node.getOutputs())
-    out_tensors.emplace_back(_tensor_builder->at(output_idx).get());
+    out_tensors.emplace_back(_tensor_builder->tensorAt(output_idx).get());
 
   auto fn = std::make_unique<::onert::backend::cpu::kernel::SplitLayer>();
 
@@ -964,8 +964,8 @@ void KernelGenerator::visit(const ir::operation::Abs &node)
   const auto ofm_index{node.getOutputs().at(0)};
   const auto ifm_index{node.getInputs().at(ir::operation::Abs::Input::INPUT)};
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto ifm_alloc = _tensor_builder->at(ifm_index).get();
+  auto ofm_alloc = _tensor_builder->tensorAt(ofm_index).get();
+  auto ifm_alloc = _tensor_builder->tensorAt(ifm_index).get();
 
   auto fn = std::make_unique<::onert::backend::cpu::kernel::AbsLayer>();
 
@@ -979,8 +979,8 @@ void KernelGenerator::visit(const ir::operation::Sin &node)
   const auto ofm_index{node.getOutputs().at(0)};
   const auto ifm_index{node.getInputs().at(ir::operation::Sin::Input::INPUT)};
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto ifm_alloc = _tensor_builder->at(ifm_index).get();
+  auto ofm_alloc = _tensor_builder->tensorAt(ofm_index).get();
+  auto ifm_alloc = _tensor_builder->tensorAt(ifm_index).get();
 
   auto fn = std::make_unique<::onert::backend::cpu::kernel::SinLayer>();
 
@@ -994,8 +994,8 @@ void KernelGenerator::visit(const ir::operation::Cos &node)
   const auto ofm_index{node.getOutputs().at(0)};
   const auto ifm_index{node.getInputs().at(ir::operation::Cos::Input::INPUT)};
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto ifm_alloc = _tensor_builder->at(ifm_index).get();
+  auto ofm_alloc = _tensor_builder->tensorAt(ofm_index).get();
+  auto ifm_alloc = _tensor_builder->tensorAt(ifm_index).get();
 
   auto fn = std::make_unique<::onert::backend::cpu::kernel::CosLayer>();
 
@@ -1009,8 +1009,8 @@ void KernelGenerator::visit(const ir::operation::RSQRT &node)
   const auto ofm_index{node.getOutputs().at(0)};
   const auto ifm_index{node.getInputs().at(ir::operation::RSQRT::Input::INPUT)};
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto ifm_alloc = _tensor_builder->at(ifm_index).get();
+  auto ofm_alloc = _tensor_builder->tensorAt(ofm_index).get();
+  auto ifm_alloc = _tensor_builder->tensorAt(ifm_index).get();
 
   auto fn = std::make_unique<::onert::backend::cpu::kernel::RsqrtLayer>();
 
@@ -1024,8 +1024,8 @@ void KernelGenerator::visit(const ir::operation::Shape &node)
   const auto ofm_index{node.getOutputs().at(0)};
   const auto ifm_index{node.getInputs().at(ir::operation::Shape::Input::INPUT)};
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto ifm_alloc = _tensor_builder->at(ifm_index).get();
+  auto ofm_alloc = _tensor_builder->tensorAt(ofm_index).get();
+  auto ifm_alloc = _tensor_builder->tensorAt(ifm_index).get();
 
   auto fn = std::make_unique<::onert::backend::cpu::kernel::ShapeLayer>();
 
@@ -1039,8 +1039,8 @@ void KernelGenerator::visit(const ir::operation::ReduceProd &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(0)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto input_alloc = _tensor_builder->tensorAt(input_index).get();
 
   auto fn = std::make_unique<kernel::ReduceLayer>();
 
@@ -1056,9 +1056,9 @@ void KernelGenerator::visit(const ir::operation::Reverse &node)
   const auto input_index{node.getInputs().at(ir::operation::Reverse::INPUT)};
   const auto axis_index{node.getInputs().at(ir::operation::Reverse::AXIS)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
-  auto axis_alloc = _tensor_builder->at(axis_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto input_alloc = _tensor_builder->tensorAt(input_index).get();
+  auto axis_alloc = _tensor_builder->tensorAt(axis_index).get();
 
   auto fn = std::make_unique<kernel::ReverseLayer>();
 
@@ -1072,8 +1072,8 @@ void KernelGenerator::visit(const ir::operation::Neg &node)
   const auto ofm_index{node.getOutputs().at(0)};
   const auto ifm_index{node.getInputs().at(ir::operation::Neg::Input::INPUT)};
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto ifm_alloc = _tensor_builder->at(ifm_index).get();
+  auto ofm_alloc = _tensor_builder->tensorAt(ofm_index).get();
+  auto ifm_alloc = _tensor_builder->tensorAt(ifm_index).get();
 
   auto fn = std::make_unique<::onert::backend::cpu::kernel::NegLayer>();
 
@@ -1089,8 +1089,8 @@ void KernelGenerator::visit(const ir::operation::ArgMax &node)
 
   const auto axis = node.param().axis;
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto input_alloc = _tensor_builder->tensorAt(input_index).get();
 
   auto fn = std::make_unique<::onert::backend::cpu::kernel::ArgMinMaxLayer>();
 
@@ -1105,9 +1105,9 @@ void KernelGenerator::visit(const ir::operation::Pow &node)
   const auto lhs_index{node.getInputs().at(ir::operation::Pow::LHS)};
   const auto rhs_index{node.getInputs().at(ir::operation::Pow::RHS)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto lhs_alloc = _tensor_builder->at(lhs_index).get();
-  auto rhs_alloc = _tensor_builder->at(rhs_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto lhs_alloc = _tensor_builder->tensorAt(lhs_index).get();
+  auto rhs_alloc = _tensor_builder->tensorAt(rhs_index).get();
 
   auto fn = std::make_unique<::onert::backend::cpu::kernel::PowLayer>();
 
@@ -1121,8 +1121,8 @@ void KernelGenerator::visit(const ir::operation::Log &node)
   const auto ofm_index{node.getOutputs().at(0)};
   const auto ifm_index{node.getInputs().at(ir::operation::Log::Input::INPUT)};
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto ifm_alloc = _tensor_builder->at(ifm_index).get();
+  auto ofm_alloc = _tensor_builder->tensorAt(ofm_index).get();
+  auto ifm_alloc = _tensor_builder->tensorAt(ifm_index).get();
 
   auto fn = std::make_unique<::onert::backend::cpu::kernel::LogLayer>();
 
@@ -1136,8 +1136,8 @@ void KernelGenerator::visit(const ir::operation::Round &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(ir::operation::Round::INPUT)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto input_alloc = _tensor_builder->tensorAt(input_index).get();
 
   auto fn = std::make_unique<::onert::backend::cpu::kernel::RoundLayer>();
 
@@ -1151,8 +1151,8 @@ void KernelGenerator::visit(const ir::operation::LogicalNot &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(ir::operation::LogicalNot::INPUT)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto input_alloc = _tensor_builder->tensorAt(input_index).get();
 
   auto fn = std::make_unique<::onert::backend::cpu::kernel::LogicalNotLayer>();
 
@@ -1168,8 +1168,8 @@ void KernelGenerator::visit(const ir::operation::Mean &node)
 
   const auto axes = node.param().axes;
   const auto keep_dims = node.param().keep_dims;
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto input_alloc = _tensor_builder->tensorAt(input_index).get();
 
   auto fn = std::make_unique<::onert::backend::cpu::kernel::MeanLayer>();
 

--- a/runtime/onert/backend/cpu/StaticTensorManager.cc
+++ b/runtime/onert/backend/cpu/StaticTensorManager.cc
@@ -34,7 +34,7 @@ StaticTensorManager::StaticTensorManager(const std::shared_ptr<TensorRegistry> &
 
 void StaticTensorManager::allocateConsts(void)
 {
-  for (auto &pair : (*_tensors))
+  for (auto &pair : _tensors->managed_tensors())
   {
     const auto &ind = pair.first;
     auto tensor = pair.second;
@@ -54,7 +54,7 @@ void StaticTensorManager::allocateNonconsts(void)
 {
   _nonconst_mgr->allocate();
 
-  for (auto &pair : (*_tensors))
+  for (auto &pair : _tensors->managed_tensors())
   {
     const auto &ind = pair.first;
     auto tensor = pair.second;
@@ -76,18 +76,18 @@ void StaticTensorManager::deallocateNonconsts(void) { _nonconst_mgr->deallocate(
 void StaticTensorManager::buildTensor(const ir::OperandIndex &ind,
                                       const ir::OperandInfo &tensor_info, bool as_const)
 {
-  assert(_tensors->find(ind) == _tensors->end());
+  assert(_tensors->getITensor(ind) == nullptr);
   auto tensor = std::make_shared<operand::Tensor>(tensor_info);
-  (*_tensors)[ind] = tensor;
+  _tensors->setManagedTensor(ind, tensor);
   _as_constants[ind] = as_const;
 }
 
 void StaticTensorManager::claimPlan(const ir::OperandIndex &ind, uint32_t size)
 {
-  assert(_tensors->find(ind) != _tensors->end());
+  assert(_tensors->getManagedTensor(ind) != nullptr);
 
   // This method is called only when a tensor has proper shape
-  assert(!(*_tensors)[ind]->is_dynamic());
+  assert(!_tensors->getManagedTensor(ind)->is_dynamic());
 
   if (!_as_constants[ind])
     _nonconst_mgr->claimPlan(ind, size);
@@ -95,10 +95,10 @@ void StaticTensorManager::claimPlan(const ir::OperandIndex &ind, uint32_t size)
 
 void StaticTensorManager::releasePlan(const ir::OperandIndex &ind)
 {
-  assert(_tensors->find(ind) != _tensors->end());
+  assert(_tensors->getManagedTensor(ind) != nullptr);
 
   // This method is called only when a tensor is not dynamic
-  assert(!(*_tensors)[ind]->is_dynamic());
+  assert(!_tensors->getManagedTensor(ind)->is_dynamic());
 
   if (!_as_constants[ind])
     _nonconst_mgr->releasePlan(ind);
@@ -106,7 +106,7 @@ void StaticTensorManager::releasePlan(const ir::OperandIndex &ind)
 
 void StaticTensorManager::iterate(const std::function<void(const ir::OperandIndex &)> &fn)
 {
-  for (const auto &it : (*_tensors))
+  for (const auto &it : _tensors->managed_tensors())
     fn(it.first);
 }
 

--- a/runtime/onert/backend/cpu/TensorBuilder.cc
+++ b/runtime/onert/backend/cpu/TensorBuilder.cc
@@ -91,20 +91,14 @@ void TensorBuilder::allocate()
 
 std::shared_ptr<ITensor> TensorBuilder::tensorAt(const ir::OperandIndex &ind)
 {
-  auto found = _tensor_reg->find(ind);
-  if (found == _tensor_reg->end())
-    return nullptr;
-
-  return found->second;
+  return _tensor_reg->getITensor(ind);
 }
 
 void TensorBuilder::iterate(const IterateFunction &fn) { _static_tensor_mgr->iterate(fn); }
 
 std::shared_ptr<operand::Tensor> TensorBuilder::at(const ir::OperandIndex &ind)
 {
-  auto found = _tensor_reg->find(ind);
-  assert(found != _tensor_reg->end());
-  return found->second;
+  return _tensor_reg->getManagedTensor(ind);
 }
 
 std::unique_ptr<ITensorManager> TensorBuilder::releaseStaticTensorManager(void)

--- a/runtime/onert/backend/cpu/TensorBuilder.cc
+++ b/runtime/onert/backend/cpu/TensorBuilder.cc
@@ -52,6 +52,11 @@ void TensorBuilder::registerTensorInfo(const ir::OperandIndex &ind, const ir::Op
   }
 }
 
+void TensorBuilder::setExternalTensor(const ir::OperandIndex &ind, const std::shared_ptr<ITensor> &tensor)
+{
+  _tensor_reg->setExternalTensor(ind, tensor);
+}
+
 void TensorBuilder::notifyFirstUse(const ir::OperandIndex &ind)
 {
   assert(_tensor_info_map.find(ind) != _tensor_info_map.end());

--- a/runtime/onert/backend/cpu/TensorBuilder.cc
+++ b/runtime/onert/backend/cpu/TensorBuilder.cc
@@ -52,7 +52,8 @@ void TensorBuilder::registerTensorInfo(const ir::OperandIndex &ind, const ir::Op
   }
 }
 
-void TensorBuilder::setExternalTensor(const ir::OperandIndex &ind, const std::shared_ptr<ITensor> &tensor)
+void TensorBuilder::setExternalTensor(const ir::OperandIndex &ind,
+                                      const std::shared_ptr<ITensor> &tensor)
 {
   _tensor_reg->setExternalTensor(ind, tensor);
 }

--- a/runtime/onert/backend/cpu/TensorBuilder.h
+++ b/runtime/onert/backend/cpu/TensorBuilder.h
@@ -49,7 +49,8 @@ public:
    */
   void registerTensorInfo(const ir::OperandIndex &ind, const ir::OperandInfo &info,
                           ir::Layout backend_layout, bool as_const) override;
-  void setExternalTensor(const ir::OperandIndex &ind, const std::shared_ptr<ITensor> &tensor) override;
+  void setExternalTensor(const ir::OperandIndex &ind,
+                         const std::shared_ptr<ITensor> &tensor) override;
 
   void notifyFirstUse(const ir::OperandIndex &) override;
   void notifyLastUse(const ir::OperandIndex &) override;

--- a/runtime/onert/backend/cpu/TensorBuilder.h
+++ b/runtime/onert/backend/cpu/TensorBuilder.h
@@ -49,6 +49,7 @@ public:
    */
   void registerTensorInfo(const ir::OperandIndex &ind, const ir::OperandInfo &info,
                           ir::Layout backend_layout, bool as_const) override;
+  void setExternalTensor(const ir::OperandIndex &ind, const std::shared_ptr<ITensor> &tensor) override;
 
   void notifyFirstUse(const ir::OperandIndex &) override;
   void notifyLastUse(const ir::OperandIndex &) override;

--- a/runtime/onert/backend/cpu/TensorRegistry.h
+++ b/runtime/onert/backend/cpu/TensorRegistry.h
@@ -30,6 +30,7 @@ namespace backend
 namespace cpu
 {
 
+#if 0
 class TensorRegistry : public ITensorRegistry,
                        public ir::OperandIndexMap<std::shared_ptr<operand::Tensor>>
 {
@@ -38,8 +39,11 @@ public:
    * @brief Returns pointer of ITensor
    * @note  Returned tensor cannot be used longer than dynamic tensor manager
    */
-  ITensor *getITensor(const ir::OperandIndex &ind) override { return at(ind).get(); }
+  std::shared_ptr<ITensor> getITensor(const ir::OperandIndex &ind) override { return at(ind); }
 };
+#endif
+
+using TensorRegistry = TensorRegistryTemplate<operand::Tensor>;
 
 } // namespace cpu
 } // namespace backend

--- a/runtime/onert/backend/cpu/kernel/AbsLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/AbsLayer.cc
@@ -43,7 +43,7 @@ void AbsLayer::absFloat32()
 
 void AbsLayer::absQuant8() { throw std::runtime_error{"NYI"}; }
 
-void AbsLayer::configure(const operand::Tensor *input, operand::Tensor *output)
+void AbsLayer::configure(const ITensor *input, ITensor *output)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/kernel/AbsLayer.h
+++ b/runtime/onert/backend/cpu/kernel/AbsLayer.h
@@ -40,7 +40,7 @@ public:
 
   void absQuant8();
 
-  void configure(const operand::Tensor *input, operand::Tensor *output);
+  void configure(const ITensor *input, ITensor *output);
 
   void run();
   void runSync()
@@ -51,8 +51,8 @@ public:
   }
 
 private:
-  const operand::Tensor *_input;
-  operand::Tensor *_output;
+  const ITensor *_input;
+  ITensor *_output;
 };
 
 } // namespace kernel

--- a/runtime/onert/backend/cpu/kernel/AddLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/AddLayer.cc
@@ -55,7 +55,8 @@ void AddLayer::addFloat32()
       convertTensorToCkerShape(_rhs), reinterpret_cast<const float *>(_rhs->buffer()),
       convertTensorToCkerShape(_output), reinterpret_cast<float *>(_output->buffer()));
 
-  std::cout << "ADDLAYER OUT : " << *reinterpret_cast<const float *>(_output->buffer()) << std::endl;
+  std::cout << "ADDLAYER OUT : " << *reinterpret_cast<const float *>(_output->buffer())
+            << std::endl;
 }
 
 void AddLayer::addQuant8()
@@ -71,8 +72,8 @@ void AddLayer::addQuant8()
   throw std::runtime_error{"NYI"};
 }
 
-void AddLayer::configure(const ITensor *lhs, const ITensor *rhs,
-                         const ir::Activation activation, ITensor *output)
+void AddLayer::configure(const ITensor *lhs, const ITensor *rhs, const ir::Activation activation,
+                         ITensor *output)
 {
   assert(lhs != nullptr);
   assert(rhs != nullptr);

--- a/runtime/onert/backend/cpu/kernel/AddLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/AddLayer.cc
@@ -47,10 +47,15 @@ void AddLayer::addFloat32()
     return;
   }
 
+  std::cout << "ADDLAYER LHS : " << *reinterpret_cast<const float *>(_lhs->buffer()) << std::endl;
+  std::cout << "ADDLAYER RHS : " << *reinterpret_cast<const float *>(_rhs->buffer()) << std::endl;
+
   nnfw::cker::BinaryArithmeticOp(
       op_params, convertTensorToCkerShape(_lhs), reinterpret_cast<const float *>(_lhs->buffer()),
       convertTensorToCkerShape(_rhs), reinterpret_cast<const float *>(_rhs->buffer()),
       convertTensorToCkerShape(_output), reinterpret_cast<float *>(_output->buffer()));
+
+  std::cout << "ADDLAYER OUT : " << *reinterpret_cast<const float *>(_output->buffer()) << std::endl;
 }
 
 void AddLayer::addQuant8()

--- a/runtime/onert/backend/cpu/kernel/AddLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/AddLayer.cc
@@ -66,8 +66,8 @@ void AddLayer::addQuant8()
   throw std::runtime_error{"NYI"};
 }
 
-void AddLayer::configure(const operand::Tensor *lhs, const operand::Tensor *rhs,
-                         const ir::Activation activation, operand::Tensor *output)
+void AddLayer::configure(const ITensor *lhs, const ITensor *rhs,
+                         const ir::Activation activation, ITensor *output)
 {
   assert(lhs != nullptr);
   assert(rhs != nullptr);

--- a/runtime/onert/backend/cpu/kernel/AddLayer.h
+++ b/runtime/onert/backend/cpu/kernel/AddLayer.h
@@ -44,8 +44,8 @@ public:
 
   void addQuant8();
 
-  void configure(const operand::Tensor *lhs, const operand::Tensor *rhs,
-                 const ir::Activation activation, operand::Tensor *output);
+  void configure(const ITensor *lhs, const ITensor *rhs,
+                 const ir::Activation activation, ITensor *output);
 
   void run();
   void runSync()
@@ -56,9 +56,9 @@ public:
   }
 
 private:
-  const operand::Tensor *_lhs;
-  const operand::Tensor *_rhs;
-  operand::Tensor *_output;
+  const ITensor *_lhs;
+  const ITensor *_rhs;
+  ITensor *_output;
 
   ir::Activation _activation{ir::Activation::NONE};
 };

--- a/runtime/onert/backend/cpu/kernel/AddLayer.h
+++ b/runtime/onert/backend/cpu/kernel/AddLayer.h
@@ -44,8 +44,8 @@ public:
 
   void addQuant8();
 
-  void configure(const ITensor *lhs, const ITensor *rhs,
-                 const ir::Activation activation, ITensor *output);
+  void configure(const ITensor *lhs, const ITensor *rhs, const ir::Activation activation,
+                 ITensor *output);
 
   void run();
   void runSync()

--- a/runtime/onert/backend/cpu/kernel/ArgMinMaxLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/ArgMinMaxLayer.cc
@@ -44,7 +44,7 @@ template <typename T> std::function<bool(T, T)> GetComparefunction(bool is_arg_m
 }
 }
 
-void ArgMinMaxLayer::configure(const operand::Tensor *input, operand::Tensor *output, int32_t axis,
+void ArgMinMaxLayer::configure(const ITensor *input, ITensor *output, int32_t axis,
                                bool is_arg_max)
 {
   _input = input;

--- a/runtime/onert/backend/cpu/kernel/ArgMinMaxLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/ArgMinMaxLayer.cc
@@ -44,8 +44,7 @@ template <typename T> std::function<bool(T, T)> GetComparefunction(bool is_arg_m
 }
 }
 
-void ArgMinMaxLayer::configure(const ITensor *input, ITensor *output, int32_t axis,
-                               bool is_arg_max)
+void ArgMinMaxLayer::configure(const ITensor *input, ITensor *output, int32_t axis, bool is_arg_max)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/kernel/ArgMinMaxLayer.h
+++ b/runtime/onert/backend/cpu/kernel/ArgMinMaxLayer.h
@@ -36,8 +36,7 @@ public:
   ArgMinMaxLayer() : _input(nullptr), _output(nullptr), _axis(-1), _is_arg_max(true) {}
 
 public:
-  void configure(const ITensor *indices, ITensor *output, int32_t axis,
-                 bool is_arg_max);
+  void configure(const ITensor *indices, ITensor *output, int32_t axis, bool is_arg_max);
 
   void run();
   void runSync()

--- a/runtime/onert/backend/cpu/kernel/ArgMinMaxLayer.h
+++ b/runtime/onert/backend/cpu/kernel/ArgMinMaxLayer.h
@@ -36,7 +36,7 @@ public:
   ArgMinMaxLayer() : _input(nullptr), _output(nullptr), _axis(-1), _is_arg_max(true) {}
 
 public:
-  void configure(const operand::Tensor *indices, operand::Tensor *output, int32_t axis,
+  void configure(const ITensor *indices, ITensor *output, int32_t axis,
                  bool is_arg_max);
 
   void run();
@@ -48,8 +48,8 @@ public:
   }
 
 private:
-  const operand::Tensor *_input;
-  operand::Tensor *_output;
+  const ITensor *_input;
+  ITensor *_output;
   int32_t _axis;
   bool _is_arg_max;
 };

--- a/runtime/onert/backend/cpu/kernel/AvgPoolLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/AvgPoolLayer.cc
@@ -73,12 +73,12 @@ void AvgPoolLayer::averagePoolQuant8()
                           reinterpret_cast<uint8_t *>(_output->buffer()));
 }
 
-void AvgPoolLayer::configure(const operand::Tensor *input, const uint32_t paddingLeft,
+void AvgPoolLayer::configure(const ITensor *input, const uint32_t paddingLeft,
                              const uint32_t paddingRight, const uint32_t paddingTop,
                              const uint32_t paddingBottom, const uint32_t strideWidth,
                              const uint32_t strideHeight, const uint32_t kernelWidth,
                              const uint32_t kernelHeight, const ir::Activation activation,
-                             operand::Tensor *output)
+                             ITensor *output)
 {
   assert(input != nullptr);
   assert(output != nullptr);

--- a/runtime/onert/backend/cpu/kernel/AvgPoolLayer.h
+++ b/runtime/onert/backend/cpu/kernel/AvgPoolLayer.h
@@ -41,12 +41,12 @@ public:
 
   void averagePoolQuant8();
 
-  void configure(const operand::Tensor *input, const uint32_t paddingLeft,
+  void configure(const ITensor *input, const uint32_t paddingLeft,
                  const uint32_t paddingRight, const uint32_t paddingTop,
                  const uint32_t paddingBottom, const uint32_t strideWidth,
                  const uint32_t strideHeight, const uint32_t kernelWidth,
                  const uint32_t kernelHeight, const ir::Activation activation,
-                 operand::Tensor *output);
+                 ITensor *output);
 
   void run();
   void runSync()
@@ -57,8 +57,8 @@ public:
   }
 
 private:
-  const operand::Tensor *_input;
-  operand::Tensor *_output;
+  const ITensor *_input;
+  ITensor *_output;
 
   uint32_t _paddingLeft;
   uint32_t _paddingTop;

--- a/runtime/onert/backend/cpu/kernel/AvgPoolLayer.h
+++ b/runtime/onert/backend/cpu/kernel/AvgPoolLayer.h
@@ -41,12 +41,11 @@ public:
 
   void averagePoolQuant8();
 
-  void configure(const ITensor *input, const uint32_t paddingLeft,
-                 const uint32_t paddingRight, const uint32_t paddingTop,
-                 const uint32_t paddingBottom, const uint32_t strideWidth,
-                 const uint32_t strideHeight, const uint32_t kernelWidth,
-                 const uint32_t kernelHeight, const ir::Activation activation,
-                 ITensor *output);
+  void configure(const ITensor *input, const uint32_t paddingLeft, const uint32_t paddingRight,
+                 const uint32_t paddingTop, const uint32_t paddingBottom,
+                 const uint32_t strideWidth, const uint32_t strideHeight,
+                 const uint32_t kernelWidth, const uint32_t kernelHeight,
+                 const ir::Activation activation, ITensor *output);
 
   void run();
   void runSync()

--- a/runtime/onert/backend/cpu/kernel/CastLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/CastLayer.cc
@@ -30,7 +30,7 @@ CastLayer::CastLayer() : _input(nullptr), _output(nullptr)
   // DO NOTHING
 }
 
-void CastLayer::configure(const operand::Tensor *input, operand::Tensor *output)
+void CastLayer::configure(const ITensor *input, ITensor *output)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/kernel/CastLayer.h
+++ b/runtime/onert/backend/cpu/kernel/CastLayer.h
@@ -40,7 +40,7 @@ public:
   template <typename FromT, typename ToT> void castTensor(const FromT *in, ToT *out);
   template <typename FromT> void castPtr(const FromT *in, DataPtr out);
 
-  void configure(const operand::Tensor *input, operand::Tensor *output);
+  void configure(const ITensor *input, ITensor *output);
 
   void run();
   void runSync()
@@ -51,8 +51,8 @@ public:
   }
 
 private:
-  const operand::Tensor *_input;
-  operand::Tensor *_output;
+  const ITensor *_input;
+  ITensor *_output;
 };
 
 } // namespace kernel

--- a/runtime/onert/backend/cpu/kernel/CompareLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/CompareLayer.cc
@@ -35,7 +35,7 @@ using OpType = onert::ir::operation::Comparison::ComparisonType;
 using namespace onert::backend::cpu;
 
 template <typename T>
-void compareScalar(const operand::Tensor *lhs, const operand::Tensor *rhs, operand::Tensor *output,
+void compareScalar(const ITensor *lhs, const ITensor *rhs, ITensor *output,
                    OpType op_type)
 {
   bool requires_broadcast = !HaveSameShapes(lhs, rhs);
@@ -141,8 +141,8 @@ CompareLayer::CompareLayer()
 
 void CompareLayer::compareQuant8() { throw std::runtime_error{"Compare NYI for quantized"}; }
 
-void CompareLayer::configure(const operand::Tensor *lhs, const operand::Tensor *rhs,
-                             const OpType op_type, operand::Tensor *output)
+void CompareLayer::configure(const ITensor *lhs, const ITensor *rhs,
+                             const OpType op_type, ITensor *output)
 {
   _lhs = lhs;
   _rhs = rhs;

--- a/runtime/onert/backend/cpu/kernel/CompareLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/CompareLayer.cc
@@ -35,8 +35,7 @@ using OpType = onert::ir::operation::Comparison::ComparisonType;
 using namespace onert::backend::cpu;
 
 template <typename T>
-void compareScalar(const ITensor *lhs, const ITensor *rhs, ITensor *output,
-                   OpType op_type)
+void compareScalar(const ITensor *lhs, const ITensor *rhs, ITensor *output, OpType op_type)
 {
   bool requires_broadcast = !HaveSameShapes(lhs, rhs);
 
@@ -141,8 +140,8 @@ CompareLayer::CompareLayer()
 
 void CompareLayer::compareQuant8() { throw std::runtime_error{"Compare NYI for quantized"}; }
 
-void CompareLayer::configure(const ITensor *lhs, const ITensor *rhs,
-                             const OpType op_type, ITensor *output)
+void CompareLayer::configure(const ITensor *lhs, const ITensor *rhs, const OpType op_type,
+                             ITensor *output)
 {
   _lhs = lhs;
   _rhs = rhs;

--- a/runtime/onert/backend/cpu/kernel/CompareLayer.h
+++ b/runtime/onert/backend/cpu/kernel/CompareLayer.h
@@ -39,8 +39,8 @@ public:
 public:
   void compareQuant8();
 
-  void configure(const operand::Tensor *lhs, const operand::Tensor *rhs,
-                 const ir::operation::Comparison::ComparisonType op_type, operand::Tensor *output);
+  void configure(const ITensor *lhs, const ITensor *rhs,
+                 const ir::operation::Comparison::ComparisonType op_type, ITensor *output);
 
   void run();
   void runSync()
@@ -51,9 +51,9 @@ public:
   }
 
 private:
-  const operand::Tensor *_lhs;
-  const operand::Tensor *_rhs;
-  operand::Tensor *_output;
+  const ITensor *_lhs;
+  const ITensor *_rhs;
+  ITensor *_output;
   ir::operation::Comparison::ComparisonType _op_type;
 };
 

--- a/runtime/onert/backend/cpu/kernel/ConcatLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/ConcatLayer.cc
@@ -72,8 +72,8 @@ void ConcatLayer::concatenationQuant8()
   std::vector<float> input_scales(num_inputs);
   for (uint32_t i = 0; i < num_inputs; i++)
   {
-    input_zeropoints[i] = _inputs[i]->offset();
-    input_scales[i] = _inputs[i]->scale();
+    input_zeropoints[i] = _inputs[i]->data_offset();
+    input_scales[i] = _inputs[i]->data_scale();
   }
 
   nnfw::cker::ConcatenationParams op_params;
@@ -81,8 +81,8 @@ void ConcatLayer::concatenationQuant8()
   op_params.inputs_count = num_inputs;
   op_params.input_zeropoint = input_zeropoints.data();
   op_params.input_scale = input_scales.data();
-  op_params.output_zeropoint = _output->offset();
-  op_params.output_scale = _output->scale();
+  op_params.output_zeropoint = _output->data_offset();
+  op_params.output_scale = _output->data_scale();
 
   std::vector<nnfw::cker::Shape *> inputDimsPtr;
   std::vector<nnfw::cker::Shape> inputDims;
@@ -105,8 +105,8 @@ void ConcatLayer::concatenationQuant8()
                                        reinterpret_cast<uint8_t *>(_output->buffer()));
 }
 
-void ConcatLayer::configure(const std::vector<const operand::Tensor *> &inputs, int32_t axis,
-                            operand::Tensor *output)
+void ConcatLayer::configure(const std::vector<const ITensor *> &inputs, int32_t axis,
+                            ITensor *output)
 {
   assert(inputs.size() > 0);
   assert(output != nullptr);

--- a/runtime/onert/backend/cpu/kernel/ConcatLayer.h
+++ b/runtime/onert/backend/cpu/kernel/ConcatLayer.h
@@ -40,8 +40,8 @@ public:
 
   void concatenationQuant8();
 
-  void configure(const std::vector<const operand::Tensor *> &inputs, int32_t axis,
-                 operand::Tensor *output);
+  void configure(const std::vector<const ITensor *> &inputs, int32_t axis,
+                 ITensor *output);
 
   void run();
   void runSync()
@@ -52,8 +52,8 @@ public:
   }
 
 private:
-  std::vector<const operand::Tensor *> _inputs;
-  operand::Tensor *_output;
+  std::vector<const ITensor *> _inputs;
+  ITensor *_output;
   int32_t _axis;
 };
 

--- a/runtime/onert/backend/cpu/kernel/ConcatLayer.h
+++ b/runtime/onert/backend/cpu/kernel/ConcatLayer.h
@@ -40,8 +40,7 @@ public:
 
   void concatenationQuant8();
 
-  void configure(const std::vector<const ITensor *> &inputs, int32_t axis,
-                 ITensor *output);
+  void configure(const std::vector<const ITensor *> &inputs, int32_t axis, ITensor *output);
 
   void run();
   void runSync()

--- a/runtime/onert/backend/cpu/kernel/ConvolutionLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/ConvolutionLayer.cc
@@ -63,8 +63,10 @@ void ConvolutionLayer::convFloat32()
 
     if (is_replaced_weights)
     {
+      auto kernel_tensor = dynamic_cast<const operand::Tensor *>(_kernel);
+      if (kernel_tensor)
       // TODO Remove const_cast
-      const_cast<operand::Tensor *>(_kernel)->decrease_ref();
+        const_cast<operand::Tensor *>(kernel_tensor)->decrease_ref();
     }
     _prepare = true;
   }
@@ -96,9 +98,9 @@ void ConvolutionLayer::convQuant8()
   op_params.padding_type = getPaddingType(_paddingType);
   op_params.padding_values.width = _paddingLeft;
   op_params.padding_values.height = _paddingTop;
-  op_params.input_offset = -_input->offset();
-  op_params.weights_offset = -_kernel->offset();
-  op_params.output_offset = _output->offset();
+  op_params.input_offset = -_input->data_offset();
+  op_params.weights_offset = -_kernel->data_offset();
+  op_params.output_offset = _output->data_offset();
   op_params.output_multiplier = output_multiplier;
   op_params.output_shift = output_shift;
   op_params.quantized_activation_min = output_activation_min;
@@ -118,12 +120,12 @@ void ConvolutionLayer::convQuant8()
          reinterpret_cast<uint8_t *>(_output->buffer()));
 }
 
-void ConvolutionLayer::configure(const operand::Tensor *input, const operand::Tensor *kernel,
-                                 const operand::Tensor *bias, const ir::PaddingType paddingType,
+void ConvolutionLayer::configure(const ITensor *input, const ITensor *kernel,
+                                 const ITensor *bias, const ir::PaddingType paddingType,
                                  const uint32_t paddingLeft, const uint32_t paddingRight,
                                  const uint32_t paddingTop, const uint32_t paddingBottom,
                                  const uint32_t strideWidth, const uint32_t strideHeight,
-                                 const ir::Activation activation, operand::Tensor *output)
+                                 const ir::Activation activation, ITensor *output)
 {
   _input = input;
   _kernel = kernel;

--- a/runtime/onert/backend/cpu/kernel/ConvolutionLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/ConvolutionLayer.cc
@@ -65,7 +65,7 @@ void ConvolutionLayer::convFloat32()
     {
       auto kernel_tensor = dynamic_cast<const operand::Tensor *>(_kernel);
       if (kernel_tensor)
-      // TODO Remove const_cast
+        // TODO Remove const_cast
         const_cast<operand::Tensor *>(kernel_tensor)->decrease_ref();
     }
     _prepare = true;
@@ -120,12 +120,12 @@ void ConvolutionLayer::convQuant8()
          reinterpret_cast<uint8_t *>(_output->buffer()));
 }
 
-void ConvolutionLayer::configure(const ITensor *input, const ITensor *kernel,
-                                 const ITensor *bias, const ir::PaddingType paddingType,
-                                 const uint32_t paddingLeft, const uint32_t paddingRight,
-                                 const uint32_t paddingTop, const uint32_t paddingBottom,
-                                 const uint32_t strideWidth, const uint32_t strideHeight,
-                                 const ir::Activation activation, ITensor *output)
+void ConvolutionLayer::configure(const ITensor *input, const ITensor *kernel, const ITensor *bias,
+                                 const ir::PaddingType paddingType, const uint32_t paddingLeft,
+                                 const uint32_t paddingRight, const uint32_t paddingTop,
+                                 const uint32_t paddingBottom, const uint32_t strideWidth,
+                                 const uint32_t strideHeight, const ir::Activation activation,
+                                 ITensor *output)
 {
   _input = input;
   _kernel = kernel;

--- a/runtime/onert/backend/cpu/kernel/ConvolutionLayer.h
+++ b/runtime/onert/backend/cpu/kernel/ConvolutionLayer.h
@@ -52,11 +52,11 @@ public:
 
   void convQuant8();
 
-  void configure(const operand::Tensor *input, const operand::Tensor *kernel,
-                 const operand::Tensor *bias, const ir::PaddingType paddingType,
+  void configure(const ITensor *input, const ITensor *kernel,
+                 const ITensor *bias, const ir::PaddingType paddingType,
                  const uint32_t paddingLeft, const uint32_t paddingRight, const uint32_t paddingTop,
                  const uint32_t paddingBottom, const uint32_t strideW, const uint32_t strideH,
-                 const ir::Activation activation, operand::Tensor *output);
+                 const ir::Activation activation, ITensor *output);
 
   void run();
   void runSync()
@@ -67,10 +67,10 @@ public:
   }
 
 private:
-  const operand::Tensor *_input;
-  const operand::Tensor *_kernel;
-  const operand::Tensor *_bias;
-  operand::Tensor *_output;
+  const ITensor *_input;
+  const ITensor *_kernel;
+  const ITensor *_bias;
+  ITensor *_output;
 
   ir::PaddingType _paddingType;
   uint32_t _paddingLeft;

--- a/runtime/onert/backend/cpu/kernel/ConvolutionLayer.h
+++ b/runtime/onert/backend/cpu/kernel/ConvolutionLayer.h
@@ -52,9 +52,9 @@ public:
 
   void convQuant8();
 
-  void configure(const ITensor *input, const ITensor *kernel,
-                 const ITensor *bias, const ir::PaddingType paddingType,
-                 const uint32_t paddingLeft, const uint32_t paddingRight, const uint32_t paddingTop,
+  void configure(const ITensor *input, const ITensor *kernel, const ITensor *bias,
+                 const ir::PaddingType paddingType, const uint32_t paddingLeft,
+                 const uint32_t paddingRight, const uint32_t paddingTop,
                  const uint32_t paddingBottom, const uint32_t strideW, const uint32_t strideH,
                  const ir::Activation activation, ITensor *output);
 

--- a/runtime/onert/backend/cpu/kernel/CosLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/CosLayer.cc
@@ -41,7 +41,7 @@ void CosLayer::cosFloat32()
 
 void CosLayer::cosQuant8() { throw std::runtime_error{"NYI"}; }
 
-void CosLayer::configure(const operand::Tensor *input, operand::Tensor *output)
+void CosLayer::configure(const ITensor *input, ITensor *output)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/kernel/CosLayer.h
+++ b/runtime/onert/backend/cpu/kernel/CosLayer.h
@@ -34,7 +34,7 @@ class CosLayer : public ::onert::exec::IFunction
 public:
   CosLayer();
 
-  void configure(const operand::Tensor *input, operand::Tensor *output);
+  void configure(const ITensor *input, ITensor *output);
 
   void run();
   void runSync()
@@ -48,8 +48,8 @@ private:
   void cosFloat32();
   void cosQuant8();
 
-  const operand::Tensor *_input;
-  operand::Tensor *_output;
+  const ITensor *_input;
+  ITensor *_output;
 };
 
 } // namespace kernel

--- a/runtime/onert/backend/cpu/kernel/DepthwiseConvolutionLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/DepthwiseConvolutionLayer.cc
@@ -80,9 +80,9 @@ void DepthwiseConvolutionLayer::convQuant8()
   op_params.padding_values.width = _paddingLeft;
   op_params.padding_values.height = _paddingTop;
   op_params.depth_multiplier = _multiplier;
-  op_params.input_offset = -_input->offset();
-  op_params.weights_offset = -_kernel->offset();
-  op_params.output_offset = _output->offset();
+  op_params.input_offset = -_input->data_offset();
+  op_params.weights_offset = -_kernel->data_offset();
+  op_params.output_offset = _output->data_offset();
   op_params.output_multiplier = output_multiplier;
   op_params.output_shift = output_shift;
   op_params.quantized_activation_min = output_activation_min;
@@ -96,13 +96,13 @@ void DepthwiseConvolutionLayer::convQuant8()
       reinterpret_cast<uint8_t *>(_output->buffer()));
 }
 
-void DepthwiseConvolutionLayer::configure(const operand::Tensor *input,
-                                          const operand::Tensor *kernel,
-                                          const operand::Tensor *bias, const uint32_t paddingLeft,
+void DepthwiseConvolutionLayer::configure(const ITensor *input,
+                                          const ITensor *kernel,
+                                          const ITensor *bias, const uint32_t paddingLeft,
                                           const uint32_t paddingRight, const uint32_t paddingTop,
                                           const uint32_t paddingBottom, const uint32_t strideWidth,
                                           const uint32_t strideHeight, const uint32_t multiplier,
-                                          const ir::Activation activation, operand::Tensor *output)
+                                          const ir::Activation activation, ITensor *output)
 {
   _input = input;
   _kernel = kernel;

--- a/runtime/onert/backend/cpu/kernel/DepthwiseConvolutionLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/DepthwiseConvolutionLayer.cc
@@ -96,8 +96,7 @@ void DepthwiseConvolutionLayer::convQuant8()
       reinterpret_cast<uint8_t *>(_output->buffer()));
 }
 
-void DepthwiseConvolutionLayer::configure(const ITensor *input,
-                                          const ITensor *kernel,
+void DepthwiseConvolutionLayer::configure(const ITensor *input, const ITensor *kernel,
                                           const ITensor *bias, const uint32_t paddingLeft,
                                           const uint32_t paddingRight, const uint32_t paddingTop,
                                           const uint32_t paddingBottom, const uint32_t strideWidth,

--- a/runtime/onert/backend/cpu/kernel/DepthwiseConvolutionLayer.h
+++ b/runtime/onert/backend/cpu/kernel/DepthwiseConvolutionLayer.h
@@ -41,12 +41,12 @@ public:
 
   void convQuant8();
 
-  void configure(const operand::Tensor *input, const operand::Tensor *kernel,
-                 const operand::Tensor *bias, const uint32_t paddingLeft,
+  void configure(const ITensor *input, const ITensor *kernel,
+                 const ITensor *bias, const uint32_t paddingLeft,
                  const uint32_t paddingRight, const uint32_t paddingTop,
                  const uint32_t paddingBottom, const uint32_t strideW, const uint32_t strideH,
                  const uint32_t multiplier, const ir::Activation activation,
-                 operand::Tensor *output);
+                 ITensor *output);
 
   void run();
   void runSync()
@@ -57,10 +57,10 @@ public:
   }
 
 private:
-  const operand::Tensor *_input;
-  const operand::Tensor *_kernel;
-  const operand::Tensor *_bias;
-  operand::Tensor *_output;
+  const ITensor *_input;
+  const ITensor *_kernel;
+  const ITensor *_bias;
+  ITensor *_output;
 
   uint32_t _paddingLeft;
   uint32_t _paddingTop;

--- a/runtime/onert/backend/cpu/kernel/DepthwiseConvolutionLayer.h
+++ b/runtime/onert/backend/cpu/kernel/DepthwiseConvolutionLayer.h
@@ -41,12 +41,10 @@ public:
 
   void convQuant8();
 
-  void configure(const ITensor *input, const ITensor *kernel,
-                 const ITensor *bias, const uint32_t paddingLeft,
-                 const uint32_t paddingRight, const uint32_t paddingTop,
+  void configure(const ITensor *input, const ITensor *kernel, const ITensor *bias,
+                 const uint32_t paddingLeft, const uint32_t paddingRight, const uint32_t paddingTop,
                  const uint32_t paddingBottom, const uint32_t strideW, const uint32_t strideH,
-                 const uint32_t multiplier, const ir::Activation activation,
-                 ITensor *output);
+                 const uint32_t multiplier, const ir::Activation activation, ITensor *output);
 
   void run();
   void runSync()

--- a/runtime/onert/backend/cpu/kernel/DivLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/DivLayer.cc
@@ -66,8 +66,8 @@ void DivLayer::divQuant8()
   throw std::runtime_error{"Div NYI for quantized"};
 }
 
-void DivLayer::configure(const ITensor *lhs, const ITensor *rhs,
-                         const ir::Activation activation, ITensor *output)
+void DivLayer::configure(const ITensor *lhs, const ITensor *rhs, const ir::Activation activation,
+                         ITensor *output)
 {
   _lhs = lhs;
   _rhs = rhs;

--- a/runtime/onert/backend/cpu/kernel/DivLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/DivLayer.cc
@@ -66,8 +66,8 @@ void DivLayer::divQuant8()
   throw std::runtime_error{"Div NYI for quantized"};
 }
 
-void DivLayer::configure(const operand::Tensor *lhs, const operand::Tensor *rhs,
-                         const ir::Activation activation, operand::Tensor *output)
+void DivLayer::configure(const ITensor *lhs, const ITensor *rhs,
+                         const ir::Activation activation, ITensor *output)
 {
   _lhs = lhs;
   _rhs = rhs;

--- a/runtime/onert/backend/cpu/kernel/DivLayer.h
+++ b/runtime/onert/backend/cpu/kernel/DivLayer.h
@@ -44,8 +44,8 @@ public:
 
   void divQuant8();
 
-  void configure(const ITensor *lhs, const ITensor *rhs,
-                 const ir::Activation activation, ITensor *output);
+  void configure(const ITensor *lhs, const ITensor *rhs, const ir::Activation activation,
+                 ITensor *output);
 
   void run();
   void runSync()

--- a/runtime/onert/backend/cpu/kernel/DivLayer.h
+++ b/runtime/onert/backend/cpu/kernel/DivLayer.h
@@ -44,8 +44,8 @@ public:
 
   void divQuant8();
 
-  void configure(const operand::Tensor *lhs, const operand::Tensor *rhs,
-                 const ir::Activation activation, operand::Tensor *output);
+  void configure(const ITensor *lhs, const ITensor *rhs,
+                 const ir::Activation activation, ITensor *output);
 
   void run();
   void runSync()
@@ -56,9 +56,9 @@ public:
   }
 
 private:
-  const operand::Tensor *_lhs;
-  const operand::Tensor *_rhs;
-  operand::Tensor *_output;
+  const ITensor *_lhs;
+  const ITensor *_rhs;
+  ITensor *_output;
 
   ir::Activation _activation{ir::Activation::NONE};
 };

--- a/runtime/onert/backend/cpu/kernel/ExpLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/ExpLayer.cc
@@ -47,7 +47,7 @@ void ExpLayer::expQuant8()
   throw std::runtime_error{"NYI"};
 }
 
-void ExpLayer::configure(const operand::Tensor *input, operand::Tensor *output)
+void ExpLayer::configure(const ITensor *input, ITensor *output)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/kernel/ExpLayer.h
+++ b/runtime/onert/backend/cpu/kernel/ExpLayer.h
@@ -40,7 +40,7 @@ public:
 
   void expQuant8();
 
-  void configure(const operand::Tensor *input, operand::Tensor *output);
+  void configure(const ITensor *input, ITensor *output);
 
   void run();
   void runSync()
@@ -51,8 +51,8 @@ public:
   }
 
 private:
-  const operand::Tensor *_input;
-  operand::Tensor *_output;
+  const ITensor *_input;
+  ITensor *_output;
 };
 
 } // namespace kernel

--- a/runtime/onert/backend/cpu/kernel/ExpandDimsLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/ExpandDimsLayer.cc
@@ -30,8 +30,8 @@ ExpandDimsLayer::ExpandDimsLayer() : _input(nullptr), _axis(nullptr), _output(nu
   // DO NOTHING
 }
 
-void ExpandDimsLayer::configure(const operand::Tensor *input, const operand::Tensor *axis,
-                                operand::Tensor *output)
+void ExpandDimsLayer::configure(const ITensor *input, const ITensor *axis,
+                                ITensor *output)
 {
   _input = input;
   _axis = axis;

--- a/runtime/onert/backend/cpu/kernel/ExpandDimsLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/ExpandDimsLayer.cc
@@ -30,8 +30,7 @@ ExpandDimsLayer::ExpandDimsLayer() : _input(nullptr), _axis(nullptr), _output(nu
   // DO NOTHING
 }
 
-void ExpandDimsLayer::configure(const ITensor *input, const ITensor *axis,
-                                ITensor *output)
+void ExpandDimsLayer::configure(const ITensor *input, const ITensor *axis, ITensor *output)
 {
   _input = input;
   _axis = axis;

--- a/runtime/onert/backend/cpu/kernel/ExpandDimsLayer.h
+++ b/runtime/onert/backend/cpu/kernel/ExpandDimsLayer.h
@@ -36,8 +36,8 @@ public:
   ExpandDimsLayer();
 
 public:
-  void configure(const operand::Tensor *input, const operand::Tensor *axis,
-                 operand::Tensor *output);
+  void configure(const ITensor *input, const ITensor *axis,
+                 ITensor *output);
 
   void run();
   void runSync()
@@ -48,9 +48,9 @@ public:
   }
 
 private:
-  const operand::Tensor *_input;
-  const operand::Tensor *_axis;
-  operand::Tensor *_output;
+  const ITensor *_input;
+  const ITensor *_axis;
+  ITensor *_output;
 };
 
 } // namespace kernel

--- a/runtime/onert/backend/cpu/kernel/ExpandDimsLayer.h
+++ b/runtime/onert/backend/cpu/kernel/ExpandDimsLayer.h
@@ -36,8 +36,7 @@ public:
   ExpandDimsLayer();
 
 public:
-  void configure(const ITensor *input, const ITensor *axis,
-                 ITensor *output);
+  void configure(const ITensor *input, const ITensor *axis, ITensor *output);
 
   void run();
   void runSync()

--- a/runtime/onert/backend/cpu/kernel/FillLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/FillLayer.cc
@@ -34,8 +34,8 @@ FillLayer::FillLayer() : _input(nullptr), _value(nullptr), _output(nullptr)
   // DO NOTHING
 }
 
-void FillLayer::configure(const operand::Tensor *input, const operand::Tensor *value,
-                          operand::Tensor *output)
+void FillLayer::configure(const ITensor *input, const ITensor *value,
+                          ITensor *output)
 {
   _input = input;
   _value = value;

--- a/runtime/onert/backend/cpu/kernel/FillLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/FillLayer.cc
@@ -34,8 +34,7 @@ FillLayer::FillLayer() : _input(nullptr), _value(nullptr), _output(nullptr)
   // DO NOTHING
 }
 
-void FillLayer::configure(const ITensor *input, const ITensor *value,
-                          ITensor *output)
+void FillLayer::configure(const ITensor *input, const ITensor *value, ITensor *output)
 {
   _input = input;
   _value = value;

--- a/runtime/onert/backend/cpu/kernel/FillLayer.h
+++ b/runtime/onert/backend/cpu/kernel/FillLayer.h
@@ -35,8 +35,7 @@ class FillLayer : public ::onert::exec::IFunction
 public:
   FillLayer();
 
-  void configure(const ITensor *input, const ITensor *value,
-                 ITensor *output);
+  void configure(const ITensor *input, const ITensor *value, ITensor *output);
 
   void run();
   void runSync()

--- a/runtime/onert/backend/cpu/kernel/FillLayer.h
+++ b/runtime/onert/backend/cpu/kernel/FillLayer.h
@@ -35,8 +35,8 @@ class FillLayer : public ::onert::exec::IFunction
 public:
   FillLayer();
 
-  void configure(const operand::Tensor *input, const operand::Tensor *value,
-                 operand::Tensor *output);
+  void configure(const ITensor *input, const ITensor *value,
+                 ITensor *output);
 
   void run();
   void runSync()
@@ -47,9 +47,9 @@ public:
   }
 
 private:
-  const operand::Tensor *_input;
-  const operand::Tensor *_value;
-  operand::Tensor *_output;
+  const ITensor *_input;
+  const ITensor *_value;
+  ITensor *_output;
 };
 
 } // namespace kernel

--- a/runtime/onert/backend/cpu/kernel/FullyConnectedLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/FullyConnectedLayer.cc
@@ -106,8 +106,7 @@ void FullyConnectedLayer::fullyConnectedHybrid()
 }
 
 void FullyConnectedLayer::configure(const ITensor *input, const ITensor *weights,
-                                    const ITensor *bias, ir::Activation activation,
-                                    ITensor *output)
+                                    const ITensor *bias, ir::Activation activation, ITensor *output)
 {
   _input = input;
   _weights = weights;

--- a/runtime/onert/backend/cpu/kernel/FullyConnectedLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/FullyConnectedLayer.cc
@@ -69,9 +69,9 @@ void FullyConnectedLayer::fullyConnectedQuant8()
                                 &output_activation_max);
 
   nnfw::cker::FullyConnectedParams op_params;
-  op_params.input_offset = -_input->offset();
-  op_params.weights_offset = -_weights->offset();
-  op_params.output_offset = _output->offset();
+  op_params.input_offset = -_input->data_offset();
+  op_params.weights_offset = -_weights->data_offset();
+  op_params.output_offset = _output->data_offset();
   op_params.output_multiplier = output_multiplier;
   op_params.output_shift = output_shift;
   op_params.quantized_activation_min = output_activation_min;
@@ -95,7 +95,7 @@ void FullyConnectedLayer::fullyConnectedHybrid()
 
   nnfw::cker::FullyConnectedParams op_params;
   op_params.activation = convertActivationType(_activation);
-  op_params.weights_scale = _weights->scale();
+  op_params.weights_scale = _weights->data_scale();
 
   nnfw::cker::FullyConnectedHybrid(
       op_params, convertTensorToCkerShape(_input),
@@ -105,9 +105,9 @@ void FullyConnectedLayer::fullyConnectedHybrid()
       reinterpret_cast<float *>(_output->buffer()), temp_arena);
 }
 
-void FullyConnectedLayer::configure(const operand::Tensor *input, const operand::Tensor *weights,
-                                    const operand::Tensor *bias, ir::Activation activation,
-                                    operand::Tensor *output)
+void FullyConnectedLayer::configure(const ITensor *input, const ITensor *weights,
+                                    const ITensor *bias, ir::Activation activation,
+                                    ITensor *output)
 {
   _input = input;
   _weights = weights;

--- a/runtime/onert/backend/cpu/kernel/FullyConnectedLayer.h
+++ b/runtime/onert/backend/cpu/kernel/FullyConnectedLayer.h
@@ -52,8 +52,8 @@ public:
 
   void fullyConnectedHybrid();
 
-  void configure(const ITensor *input, const ITensor *weights,
-                 const ITensor *bias, ir::Activation activation, ITensor *output);
+  void configure(const ITensor *input, const ITensor *weights, const ITensor *bias,
+                 ir::Activation activation, ITensor *output);
 
   void run();
   void runSync()

--- a/runtime/onert/backend/cpu/kernel/FullyConnectedLayer.h
+++ b/runtime/onert/backend/cpu/kernel/FullyConnectedLayer.h
@@ -52,8 +52,8 @@ public:
 
   void fullyConnectedHybrid();
 
-  void configure(const operand::Tensor *input, const operand::Tensor *weights,
-                 const operand::Tensor *bias, ir::Activation activation, operand::Tensor *output);
+  void configure(const ITensor *input, const ITensor *weights,
+                 const ITensor *bias, ir::Activation activation, ITensor *output);
 
   void run();
   void runSync()
@@ -64,10 +64,10 @@ public:
   }
 
 private:
-  const operand::Tensor *_input;
-  const operand::Tensor *_weights;
-  const operand::Tensor *_bias;
-  operand::Tensor *_output;
+  const ITensor *_input;
+  const ITensor *_weights;
+  const ITensor *_bias;
+  ITensor *_output;
 
   ir::Activation _activation;
   std::unique_ptr<nnfw::cker::FCTempArena> _temp_arena;

--- a/runtime/onert/backend/cpu/kernel/GatherLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/GatherLayer.cc
@@ -29,8 +29,8 @@ namespace cpu
 namespace kernel
 {
 
-void GatherLayer::configure(const ITensor *input, const ITensor *indices,
-                            ITensor *output, int32_t axis)
+void GatherLayer::configure(const ITensor *input, const ITensor *indices, ITensor *output,
+                            int32_t axis)
 {
   _input = input;
   _indices = indices;

--- a/runtime/onert/backend/cpu/kernel/GatherLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/GatherLayer.cc
@@ -29,8 +29,8 @@ namespace cpu
 namespace kernel
 {
 
-void GatherLayer::configure(const operand::Tensor *input, const operand::Tensor *indices,
-                            operand::Tensor *output, int32_t axis)
+void GatherLayer::configure(const ITensor *input, const ITensor *indices,
+                            ITensor *output, int32_t axis)
 {
   _input = input;
   _indices = indices;

--- a/runtime/onert/backend/cpu/kernel/GatherLayer.h
+++ b/runtime/onert/backend/cpu/kernel/GatherLayer.h
@@ -39,8 +39,8 @@ public:
   }
 
 public:
-  void configure(const operand::Tensor *input, const operand::Tensor *indices,
-                 operand::Tensor *output, int32_t axis);
+  void configure(const ITensor *input, const ITensor *indices,
+                 ITensor *output, int32_t axis);
 
   void run();
   void runSync()
@@ -51,9 +51,9 @@ public:
   }
 
 private:
-  const operand::Tensor *_input;
-  const operand::Tensor *_indices;
-  operand::Tensor *_output;
+  const ITensor *_input;
+  const ITensor *_indices;
+  ITensor *_output;
 
   int32_t _axis;
 };

--- a/runtime/onert/backend/cpu/kernel/GatherLayer.h
+++ b/runtime/onert/backend/cpu/kernel/GatherLayer.h
@@ -39,8 +39,7 @@ public:
   }
 
 public:
-  void configure(const ITensor *input, const ITensor *indices,
-                 ITensor *output, int32_t axis);
+  void configure(const ITensor *input, const ITensor *indices, ITensor *output, int32_t axis);
 
   void run();
   void runSync()

--- a/runtime/onert/backend/cpu/kernel/LogLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/LogLayer.cc
@@ -43,7 +43,7 @@ void LogLayer::logFloat32()
 
 void LogLayer::logQuant8() { throw std::runtime_error{"NYI"}; }
 
-void LogLayer::configure(const operand::Tensor *input, operand::Tensor *output)
+void LogLayer::configure(const ITensor *input, ITensor *output)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/kernel/LogLayer.h
+++ b/runtime/onert/backend/cpu/kernel/LogLayer.h
@@ -40,7 +40,7 @@ public:
 
   void logQuant8();
 
-  void configure(const operand::Tensor *input, operand::Tensor *output);
+  void configure(const ITensor *input, ITensor *output);
 
   void run();
   void runSync()
@@ -51,8 +51,8 @@ public:
   }
 
 private:
-  const operand::Tensor *_input;
-  operand::Tensor *_output;
+  const ITensor *_input;
+  ITensor *_output;
 };
 
 } // namespace kernel

--- a/runtime/onert/backend/cpu/kernel/LogicalNotLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/LogicalNotLayer.cc
@@ -41,7 +41,7 @@ void LogicalNotLayer::logicalNotBool8()
       convertTensorToCkerShape(_output), reinterpret_cast<bool *>(_output->buffer()));
 }
 
-void LogicalNotLayer::configure(const operand::Tensor *input, operand::Tensor *output)
+void LogicalNotLayer::configure(const ITensor *input, ITensor *output)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/kernel/LogicalNotLayer.h
+++ b/runtime/onert/backend/cpu/kernel/LogicalNotLayer.h
@@ -36,7 +36,7 @@ public:
   LogicalNotLayer();
 
 public:
-  void configure(const operand::Tensor *input, operand::Tensor *output);
+  void configure(const ITensor *input, ITensor *output);
 
   void run();
   void runSync()
@@ -50,8 +50,8 @@ private:
   void logicalNotBool8();
 
 private:
-  const operand::Tensor *_input;
-  operand::Tensor *_output;
+  const ITensor *_input;
+  ITensor *_output;
 };
 
 } // namespace kernel

--- a/runtime/onert/backend/cpu/kernel/LogisticLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/LogisticLayer.cc
@@ -47,7 +47,7 @@ void LogisticLayer::logisticQuant8()
   throw std::runtime_error{"NYI"};
 }
 
-void LogisticLayer::configure(const operand::Tensor *input, operand::Tensor *output)
+void LogisticLayer::configure(const ITensor *input, ITensor *output)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/kernel/LogisticLayer.h
+++ b/runtime/onert/backend/cpu/kernel/LogisticLayer.h
@@ -40,7 +40,7 @@ public:
 
   void logisticQuant8();
 
-  void configure(const operand::Tensor *input, operand::Tensor *output);
+  void configure(const ITensor *input, ITensor *output);
 
   void run();
   void runSync()
@@ -51,8 +51,8 @@ public:
   }
 
 private:
-  const operand::Tensor *_input;
-  operand::Tensor *_output;
+  const ITensor *_input;
+  ITensor *_output;
 };
 
 } // namespace kernel

--- a/runtime/onert/backend/cpu/kernel/MaxLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/MaxLayer.cc
@@ -48,8 +48,8 @@ void MaxLayer::maxQuant8()
   throw std::runtime_error("Max NYI for quantized");
 }
 
-void MaxLayer::configure(const operand::Tensor *lhs, const operand::Tensor *rhs,
-                         operand::Tensor *output)
+void MaxLayer::configure(const ITensor *lhs, const ITensor *rhs,
+                         ITensor *output)
 {
   assert(lhs != nullptr);
   assert(rhs != nullptr);

--- a/runtime/onert/backend/cpu/kernel/MaxLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/MaxLayer.cc
@@ -48,8 +48,7 @@ void MaxLayer::maxQuant8()
   throw std::runtime_error("Max NYI for quantized");
 }
 
-void MaxLayer::configure(const ITensor *lhs, const ITensor *rhs,
-                         ITensor *output)
+void MaxLayer::configure(const ITensor *lhs, const ITensor *rhs, ITensor *output)
 {
   assert(lhs != nullptr);
   assert(rhs != nullptr);

--- a/runtime/onert/backend/cpu/kernel/MaxLayer.h
+++ b/runtime/onert/backend/cpu/kernel/MaxLayer.h
@@ -43,7 +43,7 @@ public:
 
   void maxQuant8();
 
-  void configure(const operand::Tensor *lhs, const operand::Tensor *rhs, operand::Tensor *output);
+  void configure(const ITensor *lhs, const ITensor *rhs, ITensor *output);
 
   void run();
   void runSync()
@@ -54,9 +54,9 @@ public:
   }
 
 private:
-  const operand::Tensor *_lhs;
-  const operand::Tensor *_rhs;
-  operand::Tensor *_output;
+  const ITensor *_lhs;
+  const ITensor *_rhs;
+  ITensor *_output;
 };
 
 } // namespace kernel

--- a/runtime/onert/backend/cpu/kernel/MaxPoolLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/MaxPoolLayer.cc
@@ -73,12 +73,12 @@ void MaxPoolLayer::maxPoolQuant8()
                       reinterpret_cast<uint8_t *>(_output->buffer()));
 }
 
-void MaxPoolLayer::configure(const operand::Tensor *input, const uint32_t paddingLeft,
+void MaxPoolLayer::configure(const ITensor *input, const uint32_t paddingLeft,
                              const uint32_t paddingRight, const uint32_t paddingTop,
                              const uint32_t paddingBottom, const uint32_t strideWidth,
                              const uint32_t strideHeight, const uint32_t kernelWidth,
                              const uint32_t kernelHeight, const ir::Activation activation,
-                             operand::Tensor *output)
+                             ITensor *output)
 {
   _input = input;
   _paddingLeft = paddingLeft;

--- a/runtime/onert/backend/cpu/kernel/MaxPoolLayer.h
+++ b/runtime/onert/backend/cpu/kernel/MaxPoolLayer.h
@@ -41,12 +41,12 @@ public:
 
   void maxPoolQuant8();
 
-  void configure(const operand::Tensor *input, const uint32_t paddingLeft,
+  void configure(const ITensor *input, const uint32_t paddingLeft,
                  const uint32_t paddingRight, const uint32_t paddingTop,
                  const uint32_t paddingBottom, const uint32_t strideWidth,
                  const uint32_t strideHeight, const uint32_t kernelWidth,
                  const uint32_t kernelHeight, const ir::Activation activation,
-                 operand::Tensor *output);
+                 ITensor *output);
 
   void run();
   void runSync()
@@ -57,8 +57,8 @@ public:
   }
 
 private:
-  const operand::Tensor *_input;
-  operand::Tensor *_output;
+  const ITensor *_input;
+  ITensor *_output;
 
   uint32_t _paddingLeft;
   uint32_t _paddingTop;

--- a/runtime/onert/backend/cpu/kernel/MaxPoolLayer.h
+++ b/runtime/onert/backend/cpu/kernel/MaxPoolLayer.h
@@ -41,12 +41,11 @@ public:
 
   void maxPoolQuant8();
 
-  void configure(const ITensor *input, const uint32_t paddingLeft,
-                 const uint32_t paddingRight, const uint32_t paddingTop,
-                 const uint32_t paddingBottom, const uint32_t strideWidth,
-                 const uint32_t strideHeight, const uint32_t kernelWidth,
-                 const uint32_t kernelHeight, const ir::Activation activation,
-                 ITensor *output);
+  void configure(const ITensor *input, const uint32_t paddingLeft, const uint32_t paddingRight,
+                 const uint32_t paddingTop, const uint32_t paddingBottom,
+                 const uint32_t strideWidth, const uint32_t strideHeight,
+                 const uint32_t kernelWidth, const uint32_t kernelHeight,
+                 const ir::Activation activation, ITensor *output);
 
   void run();
   void runSync()

--- a/runtime/onert/backend/cpu/kernel/MeanLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/MeanLayer.cc
@@ -50,7 +50,7 @@ void MeanLayer::MeanQuant8()
                           _output->data_offset(), _axes);
 }
 
-void MeanLayer::configure(const operand::Tensor *input, operand::Tensor *output,
+void MeanLayer::configure(const ITensor *input, ITensor *output,
                           const std::vector<int> &axes, bool keep_dims)
 {
   _input = input;

--- a/runtime/onert/backend/cpu/kernel/MeanLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/MeanLayer.cc
@@ -50,8 +50,8 @@ void MeanLayer::MeanQuant8()
                           _output->data_offset(), _axes);
 }
 
-void MeanLayer::configure(const ITensor *input, ITensor *output,
-                          const std::vector<int> &axes, bool keep_dims)
+void MeanLayer::configure(const ITensor *input, ITensor *output, const std::vector<int> &axes,
+                          bool keep_dims)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/kernel/MeanLayer.h
+++ b/runtime/onert/backend/cpu/kernel/MeanLayer.h
@@ -40,8 +40,8 @@ public:
 
   void MeanQuant8();
 
-  void configure(const ITensor *input, ITensor *output,
-                 const std::vector<int> &axes, bool keep_dims);
+  void configure(const ITensor *input, ITensor *output, const std::vector<int> &axes,
+                 bool keep_dims);
 
   void run();
   void runSync()

--- a/runtime/onert/backend/cpu/kernel/MeanLayer.h
+++ b/runtime/onert/backend/cpu/kernel/MeanLayer.h
@@ -40,7 +40,7 @@ public:
 
   void MeanQuant8();
 
-  void configure(const operand::Tensor *input, operand::Tensor *output,
+  void configure(const ITensor *input, ITensor *output,
                  const std::vector<int> &axes, bool keep_dims);
 
   void run();
@@ -52,8 +52,8 @@ public:
   }
 
 private:
-  const operand::Tensor *_input;
-  operand::Tensor *_output;
+  const ITensor *_input;
+  ITensor *_output;
   std::vector<int> _axes;
   bool _keep_dims;
 };

--- a/runtime/onert/backend/cpu/kernel/MinLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/MinLayer.cc
@@ -48,8 +48,7 @@ void MinLayer::minQuant8()
   throw std::runtime_error("Min NYI for quantized");
 }
 
-void MinLayer::configure(const ITensor *lhs, const ITensor *rhs,
-                         ITensor *output)
+void MinLayer::configure(const ITensor *lhs, const ITensor *rhs, ITensor *output)
 {
   assert(lhs != nullptr);
   assert(rhs != nullptr);

--- a/runtime/onert/backend/cpu/kernel/MinLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/MinLayer.cc
@@ -48,8 +48,8 @@ void MinLayer::minQuant8()
   throw std::runtime_error("Min NYI for quantized");
 }
 
-void MinLayer::configure(const operand::Tensor *lhs, const operand::Tensor *rhs,
-                         operand::Tensor *output)
+void MinLayer::configure(const ITensor *lhs, const ITensor *rhs,
+                         ITensor *output)
 {
   assert(lhs != nullptr);
   assert(rhs != nullptr);

--- a/runtime/onert/backend/cpu/kernel/MinLayer.h
+++ b/runtime/onert/backend/cpu/kernel/MinLayer.h
@@ -43,7 +43,7 @@ public:
 
   void minQuant8();
 
-  void configure(const operand::Tensor *lhs, const operand::Tensor *rhs, operand::Tensor *output);
+  void configure(const ITensor *lhs, const ITensor *rhs, ITensor *output);
 
   void run();
   void runSync()
@@ -54,9 +54,9 @@ public:
   }
 
 private:
-  const operand::Tensor *_lhs;
-  const operand::Tensor *_rhs;
-  operand::Tensor *_output;
+  const ITensor *_lhs;
+  const ITensor *_rhs;
+  ITensor *_output;
 };
 
 } // namespace kernel

--- a/runtime/onert/backend/cpu/kernel/MulLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/MulLayer.cc
@@ -66,8 +66,8 @@ void MulLayer::mulQuant8()
   throw std::runtime_error{"Mull NYI for quantized"};
 }
 
-void MulLayer::configure(const ITensor *lhs, const ITensor *rhs,
-                         const ir::Activation activation, ITensor *output)
+void MulLayer::configure(const ITensor *lhs, const ITensor *rhs, const ir::Activation activation,
+                         ITensor *output)
 {
   _lhs = lhs;
   _rhs = rhs;

--- a/runtime/onert/backend/cpu/kernel/MulLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/MulLayer.cc
@@ -66,8 +66,8 @@ void MulLayer::mulQuant8()
   throw std::runtime_error{"Mull NYI for quantized"};
 }
 
-void MulLayer::configure(const operand::Tensor *lhs, const operand::Tensor *rhs,
-                         const ir::Activation activation, operand::Tensor *output)
+void MulLayer::configure(const ITensor *lhs, const ITensor *rhs,
+                         const ir::Activation activation, ITensor *output)
 {
   _lhs = lhs;
   _rhs = rhs;

--- a/runtime/onert/backend/cpu/kernel/MulLayer.h
+++ b/runtime/onert/backend/cpu/kernel/MulLayer.h
@@ -44,8 +44,8 @@ public:
 
   void mulQuant8();
 
-  void configure(const operand::Tensor *lhs, const operand::Tensor *rhs,
-                 const ir::Activation activation, operand::Tensor *output);
+  void configure(const ITensor *lhs, const ITensor *rhs,
+                 const ir::Activation activation, ITensor *output);
 
   void run();
   void runSync()
@@ -56,9 +56,9 @@ public:
   }
 
 private:
-  const operand::Tensor *_lhs;
-  const operand::Tensor *_rhs;
-  operand::Tensor *_output;
+  const ITensor *_lhs;
+  const ITensor *_rhs;
+  ITensor *_output;
 
   ir::Activation _activation{ir::Activation::NONE};
 };

--- a/runtime/onert/backend/cpu/kernel/MulLayer.h
+++ b/runtime/onert/backend/cpu/kernel/MulLayer.h
@@ -44,8 +44,8 @@ public:
 
   void mulQuant8();
 
-  void configure(const ITensor *lhs, const ITensor *rhs,
-                 const ir::Activation activation, ITensor *output);
+  void configure(const ITensor *lhs, const ITensor *rhs, const ir::Activation activation,
+                 ITensor *output);
 
   void run();
   void runSync()

--- a/runtime/onert/backend/cpu/kernel/NegLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/NegLayer.cc
@@ -43,7 +43,7 @@ void NegLayer::negFloat32()
 
 void NegLayer::negQuant8() { throw std::runtime_error{"NYI"}; }
 
-void NegLayer::configure(const operand::Tensor *input, operand::Tensor *output)
+void NegLayer::configure(const ITensor *input, ITensor *output)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/kernel/NegLayer.h
+++ b/runtime/onert/backend/cpu/kernel/NegLayer.h
@@ -40,7 +40,7 @@ public:
 
   void negQuant8();
 
-  void configure(const operand::Tensor *input, operand::Tensor *output);
+  void configure(const ITensor *input, ITensor *output);
 
   void run();
   void runSync()
@@ -51,8 +51,8 @@ public:
   }
 
 private:
-  const operand::Tensor *_input;
-  operand::Tensor *_output;
+  const ITensor *_input;
+  ITensor *_output;
 };
 
 } // namespace kernel

--- a/runtime/onert/backend/cpu/kernel/OneHotLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/OneHotLayer.cc
@@ -39,8 +39,8 @@ void OneHotLayer::oneHotFloat32()
 
 void OneHotLayer::oneHotQuant8() { throw std::runtime_error{"OneHot NYI for quantized"}; }
 
-void OneHotLayer::configure(const ITensor *indices, ITensor *output, int32_t depth,
-                            float on_value, float off_value, int32_t axis)
+void OneHotLayer::configure(const ITensor *indices, ITensor *output, int32_t depth, float on_value,
+                            float off_value, int32_t axis)
 {
   _indices = indices;
   _output = output;

--- a/runtime/onert/backend/cpu/kernel/OneHotLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/OneHotLayer.cc
@@ -39,7 +39,7 @@ void OneHotLayer::oneHotFloat32()
 
 void OneHotLayer::oneHotQuant8() { throw std::runtime_error{"OneHot NYI for quantized"}; }
 
-void OneHotLayer::configure(const operand::Tensor *indices, operand::Tensor *output, int32_t depth,
+void OneHotLayer::configure(const ITensor *indices, ITensor *output, int32_t depth,
                             float on_value, float off_value, int32_t axis)
 {
   _indices = indices;

--- a/runtime/onert/backend/cpu/kernel/OneHotLayer.h
+++ b/runtime/onert/backend/cpu/kernel/OneHotLayer.h
@@ -44,8 +44,8 @@ public:
 
   void oneHotQuant8();
 
-  void configure(const ITensor *indices, ITensor *output, int32_t depth,
-                 float on_value, float off_value, int32_t axis);
+  void configure(const ITensor *indices, ITensor *output, int32_t depth, float on_value,
+                 float off_value, int32_t axis);
 
   void run();
   void runSync()

--- a/runtime/onert/backend/cpu/kernel/OneHotLayer.h
+++ b/runtime/onert/backend/cpu/kernel/OneHotLayer.h
@@ -44,7 +44,7 @@ public:
 
   void oneHotQuant8();
 
-  void configure(const operand::Tensor *indices, operand::Tensor *output, int32_t depth,
+  void configure(const ITensor *indices, ITensor *output, int32_t depth,
                  float on_value, float off_value, int32_t axis);
 
   void run();
@@ -56,8 +56,8 @@ public:
   }
 
 private:
-  const operand::Tensor *_indices;
-  operand::Tensor *_output;
+  const ITensor *_indices;
+  ITensor *_output;
 
   int32_t _depth;
   float _on_value;

--- a/runtime/onert/backend/cpu/kernel/OperationUtils.cc
+++ b/runtime/onert/backend/cpu/kernel/OperationUtils.cc
@@ -29,13 +29,13 @@ namespace cpu
 namespace kernel
 {
 
-uint32_t getNumberOfDimensions(const operand::Tensor *tensor)
+uint32_t getNumberOfDimensions(const ITensor *tensor)
 {
   assert(tensor);
   return tensor->num_dimensions();
 }
 
-uint32_t getNumberOfElements(const operand::Tensor *tensor)
+uint32_t getNumberOfElements(const ITensor *tensor)
 {
   assert(tensor);
   uint32_t count = 1;
@@ -46,7 +46,7 @@ uint32_t getNumberOfElements(const operand::Tensor *tensor)
   return count;
 }
 
-uint32_t getSizeOfDimension(const operand::Tensor *tensor, uint32_t dimensionIdx)
+uint32_t getSizeOfDimension(const ITensor *tensor, uint32_t dimensionIdx)
 {
   assert(tensor);
   if (dimensionIdx >= tensor->num_dimensions())
@@ -78,13 +78,13 @@ void QuantizeMultiplier(double double_multiplier, int32_t *quantized_multiplier,
   *quantized_multiplier = static_cast<int32_t>(q_fixed);
 }
 
-void GetQuantizedConvolutionMultiplier(const operand::Tensor *input, const operand::Tensor *filter,
-                                       const operand::Tensor *bias, const operand::Tensor *output,
+void GetQuantizedConvolutionMultiplier(const ITensor *input, const ITensor *filter,
+                                       const ITensor *bias, const ITensor *output,
                                        double *multiplier)
 {
-  const double input_product_scale = input->scale() * filter->scale();
-  const double bias_scale = bias->scale();
-  const double output_scale = output->scale();
+  const double input_product_scale = input->data_scale() * filter->data_scale();
+  const double bias_scale = bias->data_scale();
+  const double output_scale = output->data_scale();
   // The following conditions must be guaranteed by the training pipeline.
   UNUSED_RELEASE(bias_scale);
   assert(std::abs(input_product_scale - bias_scale) <=
@@ -145,13 +145,13 @@ void CalculateActivationRangeFloat(ir::Activation activation, float *activation_
   }
 }
 
-void CalculateActivationRangeUint8(ir::Activation activation, const operand::Tensor *output,
+void CalculateActivationRangeUint8(ir::Activation activation, const ITensor *output,
                                    int32_t *act_min, int32_t *act_max)
 {
   const int32_t qmin = std::numeric_limits<uint8_t>::min();
   const int32_t qmax = std::numeric_limits<uint8_t>::max();
-  const auto scale = output->scale();
-  const auto zero_point = output->offset();
+  const auto scale = output->data_scale();
+  const auto zero_point = output->data_offset();
   auto quantize = [scale, zero_point](float f) {
     return zero_point + static_cast<int32_t>(std::round(f / scale));
   };
@@ -186,7 +186,7 @@ void CalculateActivationRangeUint8(ir::Activation activation, const operand::Ten
   }
 }
 
-bool HaveSameShapes(const operand::Tensor *input1, const operand::Tensor *input2)
+bool HaveSameShapes(const ITensor *input1, const ITensor *input2)
 {
   if (input1 == input2)
     return true;

--- a/runtime/onert/backend/cpu/kernel/OperationUtils.h
+++ b/runtime/onert/backend/cpu/kernel/OperationUtils.h
@@ -132,10 +132,9 @@ inline int32_t getAxis(uint32_t rank, int32_t axis, ir::Layout frontend_layout)
 
 void QuantizeMultiplier(double double_multiplier, int32_t *quantized_multiplier, int *shift);
 
-void GetQuantizedConvolutionMultiplier(const ITensor *inputDescr,
-                                       const ITensor *filterDescr,
-                                       const ITensor *biasDescr,
-                                       const ITensor *outputDescr, double *multiplier);
+void GetQuantizedConvolutionMultiplier(const ITensor *inputDescr, const ITensor *filterDescr,
+                                       const ITensor *biasDescr, const ITensor *outputDescr,
+                                       double *multiplier);
 
 void QuantizeMultiplierGreaterThanOne(double double_multiplier, int32_t *quantized_multiplier,
                                       int *left_shift);

--- a/runtime/onert/backend/cpu/kernel/OperationUtils.h
+++ b/runtime/onert/backend/cpu/kernel/OperationUtils.h
@@ -51,13 +51,13 @@ union DataPtr {
   void *v;
 };
 
-uint32_t getNumberOfDimensions(const operand::Tensor *tensor);
+uint32_t getNumberOfDimensions(const ITensor *tensor);
 
-uint32_t getNumberOfElements(const operand::Tensor *tensor);
+uint32_t getNumberOfElements(const ITensor *tensor);
 
-uint32_t getSizeOfDimension(const operand::Tensor *tensor, uint32_t dimensionIdx);
+uint32_t getSizeOfDimension(const ITensor *tensor, uint32_t dimensionIdx);
 
-inline nnfw::cker::Shape convertToExtendedCkerShape(const operand::Tensor *tensor)
+inline nnfw::cker::Shape convertToExtendedCkerShape(const ITensor *tensor)
 {
   assert(tensor);
   std::vector<int32_t> raw_shape;
@@ -79,7 +79,7 @@ inline nnfw::cker::Shape convertToExtendedCkerShape(const operand::Tensor *tenso
   return nnfw::cker::GetShape(raw_shape);
 }
 
-inline nnfw::cker::Shape convertTensorToCkerShape(const operand::Tensor *tensor)
+inline nnfw::cker::Shape convertTensorToCkerShape(const ITensor *tensor)
 {
   assert(tensor);
   assert(tensor->layout() == ir::Layout::NHWC);
@@ -132,10 +132,10 @@ inline int32_t getAxis(uint32_t rank, int32_t axis, ir::Layout frontend_layout)
 
 void QuantizeMultiplier(double double_multiplier, int32_t *quantized_multiplier, int *shift);
 
-void GetQuantizedConvolutionMultiplier(const operand::Tensor *inputDescr,
-                                       const operand::Tensor *filterDescr,
-                                       const operand::Tensor *biasDescr,
-                                       const operand::Tensor *outputDescr, double *multiplier);
+void GetQuantizedConvolutionMultiplier(const ITensor *inputDescr,
+                                       const ITensor *filterDescr,
+                                       const ITensor *biasDescr,
+                                       const ITensor *outputDescr, double *multiplier);
 
 void QuantizeMultiplierGreaterThanOne(double double_multiplier, int32_t *quantized_multiplier,
                                       int *left_shift);
@@ -143,10 +143,10 @@ void QuantizeMultiplierGreaterThanOne(double double_multiplier, int32_t *quantiz
 void CalculateActivationRangeFloat(ir::Activation activation, float *activation_min,
                                    float *activation_max);
 
-void CalculateActivationRangeUint8(ir::Activation activation, const operand::Tensor *output,
+void CalculateActivationRangeUint8(ir::Activation activation, const ITensor *output,
                                    int32_t *act_min, int32_t *act_max);
 
-bool HaveSameShapes(const operand::Tensor *input1, const operand::Tensor *input2);
+bool HaveSameShapes(const ITensor *input1, const ITensor *input2);
 
 int32_t CalculateInputRadius(int input_integer_bits, int input_left_shift);
 

--- a/runtime/onert/backend/cpu/kernel/PackLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/PackLayer.cc
@@ -69,8 +69,8 @@ void PackLayer::packQuant8()
   throw std::runtime_error{"NYI"};
 }
 
-void PackLayer::configure(const std::vector<const operand::Tensor *> &inputs, int32_t axis,
-                          operand::Tensor *output)
+void PackLayer::configure(const std::vector<const ITensor *> &inputs, int32_t axis,
+                          ITensor *output)
 {
   assert(inputs.size() > 0);
   assert(output != nullptr);

--- a/runtime/onert/backend/cpu/kernel/PackLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/PackLayer.cc
@@ -69,8 +69,7 @@ void PackLayer::packQuant8()
   throw std::runtime_error{"NYI"};
 }
 
-void PackLayer::configure(const std::vector<const ITensor *> &inputs, int32_t axis,
-                          ITensor *output)
+void PackLayer::configure(const std::vector<const ITensor *> &inputs, int32_t axis, ITensor *output)
 {
   assert(inputs.size() > 0);
   assert(output != nullptr);

--- a/runtime/onert/backend/cpu/kernel/PackLayer.h
+++ b/runtime/onert/backend/cpu/kernel/PackLayer.h
@@ -40,8 +40,8 @@ public:
 
   void packQuant8();
 
-  void configure(const std::vector<const operand::Tensor *> &inputs, int32_t axis,
-                 operand::Tensor *output);
+  void configure(const std::vector<const ITensor *> &inputs, int32_t axis,
+                 ITensor *output);
 
   void run();
   void runSync()
@@ -52,8 +52,8 @@ public:
   }
 
 private:
-  std::vector<const operand::Tensor *> _inputs;
-  operand::Tensor *_output;
+  std::vector<const ITensor *> _inputs;
+  ITensor *_output;
   int32_t _axis;
 };
 

--- a/runtime/onert/backend/cpu/kernel/PackLayer.h
+++ b/runtime/onert/backend/cpu/kernel/PackLayer.h
@@ -40,8 +40,7 @@ public:
 
   void packQuant8();
 
-  void configure(const std::vector<const ITensor *> &inputs, int32_t axis,
-                 ITensor *output);
+  void configure(const std::vector<const ITensor *> &inputs, int32_t axis, ITensor *output);
 
   void run();
   void runSync()

--- a/runtime/onert/backend/cpu/kernel/PadLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/PadLayer.cc
@@ -42,8 +42,8 @@ void PadLayer::padFloat32()
 }
 void PadLayer::padQuant8() { throw std::runtime_error("Quantized Pad isn't supported NYI"); }
 
-void PadLayer::configure(const ITensor *input, ITensor *output,
-                         const int32_t *padData, int32_t padRank, uint8_t *constantValueData)
+void PadLayer::configure(const ITensor *input, ITensor *output, const int32_t *padData,
+                         int32_t padRank, uint8_t *constantValueData)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/kernel/PadLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/PadLayer.cc
@@ -42,7 +42,7 @@ void PadLayer::padFloat32()
 }
 void PadLayer::padQuant8() { throw std::runtime_error("Quantized Pad isn't supported NYI"); }
 
-void PadLayer::configure(const operand::Tensor *input, operand::Tensor *output,
+void PadLayer::configure(const ITensor *input, ITensor *output,
                          const int32_t *padData, int32_t padRank, uint8_t *constantValueData)
 {
   _input = input;

--- a/runtime/onert/backend/cpu/kernel/PadLayer.h
+++ b/runtime/onert/backend/cpu/kernel/PadLayer.h
@@ -43,8 +43,8 @@ public:
 
   void padQuant8();
 
-  void configure(const ITensor *input, ITensor *output, const int32_t *padData,
-                 int32_t padRank, uint8_t *constantValueData = nullptr);
+  void configure(const ITensor *input, ITensor *output, const int32_t *padData, int32_t padRank,
+                 uint8_t *constantValueData = nullptr);
 
   void run();
   void runSync()

--- a/runtime/onert/backend/cpu/kernel/PadLayer.h
+++ b/runtime/onert/backend/cpu/kernel/PadLayer.h
@@ -43,7 +43,7 @@ public:
 
   void padQuant8();
 
-  void configure(const operand::Tensor *input, operand::Tensor *output, const int32_t *padData,
+  void configure(const ITensor *input, ITensor *output, const int32_t *padData,
                  int32_t padRank, uint8_t *constantValueData = nullptr);
 
   void run();
@@ -55,8 +55,8 @@ public:
   }
 
 private:
-  const operand::Tensor *_input;
-  operand::Tensor *_output;
+  const ITensor *_input;
+  ITensor *_output;
 
   int32_t _padData[8];
   int32_t _padRank;

--- a/runtime/onert/backend/cpu/kernel/PowLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/PowLayer.cc
@@ -52,8 +52,8 @@ void PowLayer::powFloat32()
       convertTensorToCkerShape(_output), reinterpret_cast<float *>(_output->buffer()));
 }
 
-void PowLayer::configure(const operand::Tensor *lhs, const operand::Tensor *rhs,
-                         ir::Activation activation, operand::Tensor *output)
+void PowLayer::configure(const ITensor *lhs, const ITensor *rhs,
+                         ir::Activation activation, ITensor *output)
 {
   _lhs = lhs;
   _rhs = rhs;

--- a/runtime/onert/backend/cpu/kernel/PowLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/PowLayer.cc
@@ -52,8 +52,8 @@ void PowLayer::powFloat32()
       convertTensorToCkerShape(_output), reinterpret_cast<float *>(_output->buffer()));
 }
 
-void PowLayer::configure(const ITensor *lhs, const ITensor *rhs,
-                         ir::Activation activation, ITensor *output)
+void PowLayer::configure(const ITensor *lhs, const ITensor *rhs, ir::Activation activation,
+                         ITensor *output)
 {
   _lhs = lhs;
   _rhs = rhs;

--- a/runtime/onert/backend/cpu/kernel/PowLayer.h
+++ b/runtime/onert/backend/cpu/kernel/PowLayer.h
@@ -42,8 +42,8 @@ public:
 public:
   void powFloat32();
 
-  void configure(const ITensor *lhs, const ITensor *rhs,
-                 const ir::Activation activation, ITensor *output);
+  void configure(const ITensor *lhs, const ITensor *rhs, const ir::Activation activation,
+                 ITensor *output);
 
   void run();
   void runSync()

--- a/runtime/onert/backend/cpu/kernel/PowLayer.h
+++ b/runtime/onert/backend/cpu/kernel/PowLayer.h
@@ -42,8 +42,8 @@ public:
 public:
   void powFloat32();
 
-  void configure(const operand::Tensor *lhs, const operand::Tensor *rhs,
-                 const ir::Activation activation, operand::Tensor *output);
+  void configure(const ITensor *lhs, const ITensor *rhs,
+                 const ir::Activation activation, ITensor *output);
 
   void run();
   void runSync()
@@ -54,9 +54,9 @@ public:
   }
 
 private:
-  const operand::Tensor *_lhs;
-  const operand::Tensor *_rhs;
-  operand::Tensor *_output;
+  const ITensor *_lhs;
+  const ITensor *_rhs;
+  ITensor *_output;
 
   ir::Activation _activation{ir::Activation::NONE};
 };

--- a/runtime/onert/backend/cpu/kernel/ReduceLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/ReduceLayer.cc
@@ -33,8 +33,8 @@ namespace
 {
 
 template <typename T>
-void evalLogic(const ITensor *input, ITensor *output, const std::vector<int> &axes,
-               bool keep_dims, T init_value, nnfw::cker::Reduce &reduce_kernel,
+void evalLogic(const ITensor *input, ITensor *output, const std::vector<int> &axes, bool keep_dims,
+               T init_value, nnfw::cker::Reduce &reduce_kernel,
                T reducer(const T current, const T in))
 {
   reduce_kernel.prepare(input->num_dimensions(), axes.size());
@@ -50,8 +50,8 @@ void evalLogic(const ITensor *input, ITensor *output, const std::vector<int> &ax
 }
 
 template <typename T>
-void evalType(const ITensor *input, ITensor *output, const std::vector<int> &axes,
-              bool keep_dims, nnfw::cker::Reduce &reduce_kernel, ReduceType reduce_type)
+void evalType(const ITensor *input, ITensor *output, const std::vector<int> &axes, bool keep_dims,
+              nnfw::cker::Reduce &reduce_kernel, ReduceType reduce_type)
 {
   switch (reduce_type)
   {
@@ -80,9 +80,8 @@ void evalType(const ITensor *input, ITensor *output, const std::vector<int> &axe
 
 // Template specialization for bool type
 template <>
-void evalType<bool>(const ITensor *input, ITensor *output,
-                    const std::vector<int> &axes, bool keep_dims, nnfw::cker::Reduce &reduce_kernel,
-                    ReduceType reduce_type)
+void evalType<bool>(const ITensor *input, ITensor *output, const std::vector<int> &axes,
+                    bool keep_dims, nnfw::cker::Reduce &reduce_kernel, ReduceType reduce_type)
 {
   switch (reduce_type)
   {
@@ -97,8 +96,8 @@ void evalType<bool>(const ITensor *input, ITensor *output,
 }
 
 template <ReduceType reduce_type>
-void evalGeneric(const ITensor *input, ITensor *output,
-                 const std::vector<int> &axes, bool keep_dims, nnfw::cker::Reduce &reduce_kernel)
+void evalGeneric(const ITensor *input, ITensor *output, const std::vector<int> &axes,
+                 bool keep_dims, nnfw::cker::Reduce &reduce_kernel)
 {
   switch (input->data_type())
   {
@@ -123,8 +122,8 @@ ReduceLayer::ReduceLayer()
 
 ReduceLayer::~ReduceLayer() = default;
 
-void ReduceLayer::configure(const ITensor *input, ITensor *output,
-                            ReduceType reduceType, const std::vector<int> &axes, bool keep_dims)
+void ReduceLayer::configure(const ITensor *input, ITensor *output, ReduceType reduceType,
+                            const std::vector<int> &axes, bool keep_dims)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/kernel/ReduceLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/ReduceLayer.cc
@@ -80,7 +80,7 @@ void evalType(const ITensor *input, ITensor *output, const std::vector<int> &axe
 
 // Template specialization for bool type
 template <>
-void evalType<bool>(const operand::Tensor *input, operand::Tensor *output,
+void evalType<bool>(const ITensor *input, ITensor *output,
                     const std::vector<int> &axes, bool keep_dims, nnfw::cker::Reduce &reduce_kernel,
                     ReduceType reduce_type)
 {

--- a/runtime/onert/backend/cpu/kernel/ReduceLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/ReduceLayer.cc
@@ -33,7 +33,7 @@ namespace
 {
 
 template <typename T>
-void evalLogic(const operand::Tensor *input, operand::Tensor *output, const std::vector<int> &axes,
+void evalLogic(const ITensor *input, ITensor *output, const std::vector<int> &axes,
                bool keep_dims, T init_value, nnfw::cker::Reduce &reduce_kernel,
                T reducer(const T current, const T in))
 {
@@ -50,7 +50,7 @@ void evalLogic(const operand::Tensor *input, operand::Tensor *output, const std:
 }
 
 template <typename T>
-void evalType(const operand::Tensor *input, operand::Tensor *output, const std::vector<int> &axes,
+void evalType(const ITensor *input, ITensor *output, const std::vector<int> &axes,
               bool keep_dims, nnfw::cker::Reduce &reduce_kernel, ReduceType reduce_type)
 {
   switch (reduce_type)
@@ -97,7 +97,7 @@ void evalType<bool>(const operand::Tensor *input, operand::Tensor *output,
 }
 
 template <ReduceType reduce_type>
-void evalGeneric(const operand::Tensor *input, operand::Tensor *output,
+void evalGeneric(const ITensor *input, ITensor *output,
                  const std::vector<int> &axes, bool keep_dims, nnfw::cker::Reduce &reduce_kernel)
 {
   switch (input->data_type())
@@ -123,7 +123,7 @@ ReduceLayer::ReduceLayer()
 
 ReduceLayer::~ReduceLayer() = default;
 
-void ReduceLayer::configure(const operand::Tensor *input, operand::Tensor *output,
+void ReduceLayer::configure(const ITensor *input, ITensor *output,
                             ReduceType reduceType, const std::vector<int> &axes, bool keep_dims)
 {
   _input = input;

--- a/runtime/onert/backend/cpu/kernel/ReduceLayer.h
+++ b/runtime/onert/backend/cpu/kernel/ReduceLayer.h
@@ -55,7 +55,7 @@ public:
   ~ReduceLayer();
 
 public:
-  void configure(const operand::Tensor *input, operand::Tensor *output, ReduceType reduceType,
+  void configure(const ITensor *input, ITensor *output, ReduceType reduceType,
                  const std::vector<int> &axes, bool keep_dims);
 
   void run();
@@ -67,8 +67,8 @@ public:
   }
 
 private:
-  const operand::Tensor *_input;
-  operand::Tensor *_output;
+  const ITensor *_input;
+  ITensor *_output;
   ReduceType _reduceType;
   std::vector<int> _axes;
   bool _keep_dims;

--- a/runtime/onert/backend/cpu/kernel/ReshapeLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/ReshapeLayer.cc
@@ -38,8 +38,7 @@ void ReshapeLayer::reshapeGeneric()
   memcpy(_output->buffer(), _input->buffer(), count);
 }
 
-void ReshapeLayer::configure(const ITensor *input, const ITensor *shape,
-                             ITensor *output)
+void ReshapeLayer::configure(const ITensor *input, const ITensor *shape, ITensor *output)
 {
   _input = input;
   /* note : shape is optional. If not provided from model, _shape is nullptr. */

--- a/runtime/onert/backend/cpu/kernel/ReshapeLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/ReshapeLayer.cc
@@ -38,8 +38,8 @@ void ReshapeLayer::reshapeGeneric()
   memcpy(_output->buffer(), _input->buffer(), count);
 }
 
-void ReshapeLayer::configure(const operand::Tensor *input, const operand::Tensor *shape,
-                             operand::Tensor *output)
+void ReshapeLayer::configure(const ITensor *input, const ITensor *shape,
+                             ITensor *output)
 {
   _input = input;
   /* note : shape is optional. If not provided from model, _shape is nullptr. */

--- a/runtime/onert/backend/cpu/kernel/ReshapeLayer.h
+++ b/runtime/onert/backend/cpu/kernel/ReshapeLayer.h
@@ -38,8 +38,8 @@ public:
 public:
   void reshapeGeneric();
 
-  void configure(const operand::Tensor *input, const operand::Tensor *shape,
-                 operand::Tensor *output);
+  void configure(const ITensor *input, const ITensor *shape,
+                 ITensor *output);
 
   void run();
   void runSync()
@@ -50,9 +50,9 @@ public:
   }
 
 private:
-  const operand::Tensor *_input;
-  const operand::Tensor *_shape;
-  operand::Tensor *_output;
+  const ITensor *_input;
+  const ITensor *_shape;
+  ITensor *_output;
 };
 
 } // namespace kernel

--- a/runtime/onert/backend/cpu/kernel/ReshapeLayer.h
+++ b/runtime/onert/backend/cpu/kernel/ReshapeLayer.h
@@ -38,8 +38,7 @@ public:
 public:
   void reshapeGeneric();
 
-  void configure(const ITensor *input, const ITensor *shape,
-                 ITensor *output);
+  void configure(const ITensor *input, const ITensor *shape, ITensor *output);
 
   void run();
   void runSync()

--- a/runtime/onert/backend/cpu/kernel/ReverseLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/ReverseLayer.cc
@@ -54,8 +54,7 @@ void ReverseLayer::run()
   }
 }
 
-void ReverseLayer::configure(const ITensor *input, const ITensor *axis,
-                             ITensor *output)
+void ReverseLayer::configure(const ITensor *input, const ITensor *axis, ITensor *output)
 {
   _input = input;
   _axis = axis;

--- a/runtime/onert/backend/cpu/kernel/ReverseLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/ReverseLayer.cc
@@ -54,8 +54,8 @@ void ReverseLayer::run()
   }
 }
 
-void ReverseLayer::configure(const operand::Tensor *input, const operand::Tensor *axis,
-                             operand::Tensor *output)
+void ReverseLayer::configure(const ITensor *input, const ITensor *axis,
+                             ITensor *output)
 {
   _input = input;
   _axis = axis;

--- a/runtime/onert/backend/cpu/kernel/ReverseLayer.h
+++ b/runtime/onert/backend/cpu/kernel/ReverseLayer.h
@@ -39,8 +39,7 @@ public:
   }
 
 public:
-  void configure(const ITensor *input, const ITensor *axis,
-                 ITensor *output);
+  void configure(const ITensor *input, const ITensor *axis, ITensor *output);
 
   void run();
   void runSync()

--- a/runtime/onert/backend/cpu/kernel/ReverseLayer.h
+++ b/runtime/onert/backend/cpu/kernel/ReverseLayer.h
@@ -39,8 +39,8 @@ public:
   }
 
 public:
-  void configure(const operand::Tensor *input, const operand::Tensor *axis,
-                 operand::Tensor *output);
+  void configure(const ITensor *input, const ITensor *axis,
+                 ITensor *output);
 
   void run();
   void runSync()
@@ -51,9 +51,9 @@ public:
   }
 
 private:
-  const operand::Tensor *_input;
-  const operand::Tensor *_axis;
-  operand::Tensor *_output;
+  const ITensor *_input;
+  const ITensor *_axis;
+  ITensor *_output;
 };
 
 } // namespace kernel

--- a/runtime/onert/backend/cpu/kernel/RoundLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/RoundLayer.cc
@@ -40,7 +40,7 @@ void RoundLayer::roundFloat32()
       convertTensorToCkerShape(_output), reinterpret_cast<float *>(_output->buffer()));
 }
 
-void RoundLayer::configure(const operand::Tensor *input, operand::Tensor *output)
+void RoundLayer::configure(const ITensor *input, ITensor *output)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/kernel/RoundLayer.h
+++ b/runtime/onert/backend/cpu/kernel/RoundLayer.h
@@ -34,7 +34,7 @@ class RoundLayer : public ::onert::exec::IFunction
 public:
   RoundLayer();
 
-  void configure(const operand::Tensor *input, operand::Tensor *output);
+  void configure(const ITensor *input, ITensor *output);
 
   void run();
   void runSync()
@@ -48,8 +48,8 @@ private:
   void roundFloat32();
 
 private:
-  const operand::Tensor *_input;
-  operand::Tensor *_output;
+  const ITensor *_input;
+  ITensor *_output;
 };
 
 } // namespace kernel

--- a/runtime/onert/backend/cpu/kernel/RsqrtLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/RsqrtLayer.cc
@@ -42,7 +42,7 @@ void RsqrtLayer::rsqrtFloat32()
 
 void RsqrtLayer::rsqrtQuant8() { throw std::runtime_error{"NYI : QASYMM8 not supported"}; }
 
-void RsqrtLayer::configure(const operand::Tensor *input, operand::Tensor *output)
+void RsqrtLayer::configure(const ITensor *input, ITensor *output)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/kernel/RsqrtLayer.h
+++ b/runtime/onert/backend/cpu/kernel/RsqrtLayer.h
@@ -34,7 +34,7 @@ class RsqrtLayer : public ::onert::exec::IFunction
 public:
   RsqrtLayer();
 
-  void configure(const operand::Tensor *input, operand::Tensor *output);
+  void configure(const ITensor *input, ITensor *output);
 
   void run();
   void runSync()
@@ -47,8 +47,8 @@ public:
 private:
   void rsqrtFloat32();
   void rsqrtQuant8();
-  const operand::Tensor *_input;
-  operand::Tensor *_output;
+  const ITensor *_input;
+  ITensor *_output;
 };
 
 } // namespace kernel

--- a/runtime/onert/backend/cpu/kernel/SelectLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/SelectLayer.cc
@@ -35,8 +35,8 @@ SelectLayer::SelectLayer()
   // DO NOTHING
 }
 
-void SelectLayer::configure(const operand::Tensor *cond, const operand::Tensor *input_true,
-                            const operand::Tensor *input_false, operand::Tensor *output)
+void SelectLayer::configure(const ITensor *cond, const ITensor *input_true,
+                            const ITensor *input_false, ITensor *output)
 {
   _cond = cond;
   _input_true = input_true;

--- a/runtime/onert/backend/cpu/kernel/SelectLayer.h
+++ b/runtime/onert/backend/cpu/kernel/SelectLayer.h
@@ -36,8 +36,8 @@ public:
   SelectLayer();
 
 public:
-  void configure(const ITensor *cond, const ITensor *input_true,
-                 const ITensor *input_false, ITensor *output);
+  void configure(const ITensor *cond, const ITensor *input_true, const ITensor *input_false,
+                 ITensor *output);
 
   void run();
   void runSync()

--- a/runtime/onert/backend/cpu/kernel/SelectLayer.h
+++ b/runtime/onert/backend/cpu/kernel/SelectLayer.h
@@ -36,8 +36,8 @@ public:
   SelectLayer();
 
 public:
-  void configure(const operand::Tensor *cond, const operand::Tensor *input_true,
-                 const operand::Tensor *input_false, operand::Tensor *output);
+  void configure(const ITensor *cond, const ITensor *input_true,
+                 const ITensor *input_false, ITensor *output);
 
   void run();
   void runSync()
@@ -48,10 +48,10 @@ public:
   }
 
 private:
-  const operand::Tensor *_cond;
-  const operand::Tensor *_input_true;
-  const operand::Tensor *_input_false;
-  operand::Tensor *_output;
+  const ITensor *_cond;
+  const ITensor *_input_true;
+  const ITensor *_input_false;
+  ITensor *_output;
 };
 
 } // namespace kernel

--- a/runtime/onert/backend/cpu/kernel/ShapeLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/ShapeLayer.cc
@@ -32,7 +32,7 @@ ShapeLayer::ShapeLayer() : _input(nullptr), _output(nullptr)
   // DO NOTHING
 }
 
-template <typename T> void GetRawShape(const operand::Tensor *input, T *output_data)
+template <typename T> void GetRawShape(const ITensor *input, T *output_data)
 {
   for (uint32_t i = 0; i < input->num_dimensions(); ++i)
   {
@@ -56,7 +56,7 @@ void ShapeLayer::shape()
   }
 }
 
-void ShapeLayer::configure(const operand::Tensor *input, operand::Tensor *output)
+void ShapeLayer::configure(const ITensor *input, ITensor *output)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/kernel/ShapeLayer.h
+++ b/runtime/onert/backend/cpu/kernel/ShapeLayer.h
@@ -38,7 +38,7 @@ public:
 public:
   void shape();
 
-  void configure(const operand::Tensor *input, operand::Tensor *output);
+  void configure(const ITensor *input, ITensor *output);
 
   void run();
   void runSync()
@@ -49,8 +49,8 @@ public:
   }
 
 private:
-  const operand::Tensor *_input;
-  operand::Tensor *_output;
+  const ITensor *_input;
+  ITensor *_output;
 };
 
 } // namespace kernel

--- a/runtime/onert/backend/cpu/kernel/SinLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/SinLayer.cc
@@ -41,7 +41,7 @@ void SinLayer::sinFloat32()
 
 void SinLayer::sinQuant8() { throw std::runtime_error{"NYI"}; }
 
-void SinLayer::configure(const operand::Tensor *input, operand::Tensor *output)
+void SinLayer::configure(const ITensor *input, ITensor *output)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/kernel/SinLayer.h
+++ b/runtime/onert/backend/cpu/kernel/SinLayer.h
@@ -34,7 +34,7 @@ class SinLayer : public ::onert::exec::IFunction
 public:
   SinLayer();
 
-  void configure(const operand::Tensor *input, operand::Tensor *output);
+  void configure(const ITensor *input, ITensor *output);
 
   void run();
   void runSync()
@@ -48,8 +48,8 @@ private:
   void sinFloat32();
   void sinQuant8();
 
-  const operand::Tensor *_input;
-  operand::Tensor *_output;
+  const ITensor *_input;
+  ITensor *_output;
 };
 
 } // namespace kernel

--- a/runtime/onert/backend/cpu/kernel/SliceLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/SliceLayer.cc
@@ -35,9 +35,8 @@ SliceLayer::SliceLayer() : _input(nullptr), _begin(nullptr), _size(nullptr), _ou
 }
 
 template <typename T>
-void SliceLayer::GetBeginAndSizeVectors(int dimensions, const ITensor *begin,
-                                        const ITensor *size, std::vector<int> *begins,
-                                        std::vector<int> *sizes)
+void SliceLayer::GetBeginAndSizeVectors(int dimensions, const ITensor *begin, const ITensor *size,
+                                        std::vector<int> *begins, std::vector<int> *sizes)
 {
   for (int idx = dimensions - 1; idx >= 0; --idx)
   {
@@ -84,8 +83,8 @@ void SliceLayer::sliceQuant8()
   throw std::runtime_error{"NYI"};
 }
 
-void SliceLayer::configure(const ITensor *input, const ITensor *begin,
-                           const ITensor *size, ITensor *output)
+void SliceLayer::configure(const ITensor *input, const ITensor *begin, const ITensor *size,
+                           ITensor *output)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/kernel/SliceLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/SliceLayer.cc
@@ -35,8 +35,8 @@ SliceLayer::SliceLayer() : _input(nullptr), _begin(nullptr), _size(nullptr), _ou
 }
 
 template <typename T>
-void SliceLayer::GetBeginAndSizeVectors(int dimensions, const operand::Tensor *begin,
-                                        const operand::Tensor *size, std::vector<int> *begins,
+void SliceLayer::GetBeginAndSizeVectors(int dimensions, const ITensor *begin,
+                                        const ITensor *size, std::vector<int> *begins,
                                         std::vector<int> *sizes)
 {
   for (int idx = dimensions - 1; idx >= 0; --idx)
@@ -84,8 +84,8 @@ void SliceLayer::sliceQuant8()
   throw std::runtime_error{"NYI"};
 }
 
-void SliceLayer::configure(const operand::Tensor *input, const operand::Tensor *begin,
-                           const operand::Tensor *size, operand::Tensor *output)
+void SliceLayer::configure(const ITensor *input, const ITensor *begin,
+                           const ITensor *size, ITensor *output)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/kernel/SliceLayer.h
+++ b/runtime/onert/backend/cpu/kernel/SliceLayer.h
@@ -36,8 +36,7 @@ public:
   SliceLayer();
 
 public:
-  void configure(const ITensor *input, const ITensor *begin,
-                 const ITensor *size, ITensor *output);
+  void configure(const ITensor *input, const ITensor *begin, const ITensor *size, ITensor *output);
 
   void run();
   void runSync()
@@ -52,9 +51,8 @@ private:
   void sliceQuant8();
 
   template <typename T>
-  void GetBeginAndSizeVectors(int dimensions, const ITensor *begin,
-                              const ITensor *size, std::vector<int> *begins,
-                              std::vector<int> *sizes);
+  void GetBeginAndSizeVectors(int dimensions, const ITensor *begin, const ITensor *size,
+                              std::vector<int> *begins, std::vector<int> *sizes);
 
 private:
   const ITensor *_input;

--- a/runtime/onert/backend/cpu/kernel/SliceLayer.h
+++ b/runtime/onert/backend/cpu/kernel/SliceLayer.h
@@ -36,8 +36,8 @@ public:
   SliceLayer();
 
 public:
-  void configure(const operand::Tensor *input, const operand::Tensor *begin,
-                 const operand::Tensor *size, operand::Tensor *output);
+  void configure(const ITensor *input, const ITensor *begin,
+                 const ITensor *size, ITensor *output);
 
   void run();
   void runSync()
@@ -52,15 +52,15 @@ private:
   void sliceQuant8();
 
   template <typename T>
-  void GetBeginAndSizeVectors(int dimensions, const operand::Tensor *begin,
-                              const operand::Tensor *size, std::vector<int> *begins,
+  void GetBeginAndSizeVectors(int dimensions, const ITensor *begin,
+                              const ITensor *size, std::vector<int> *begins,
                               std::vector<int> *sizes);
 
 private:
-  const operand::Tensor *_input;
-  const operand::Tensor *_begin;
-  const operand::Tensor *_size;
-  operand::Tensor *_output;
+  const ITensor *_input;
+  const ITensor *_begin;
+  const ITensor *_size;
+  ITensor *_output;
 };
 
 } // namespace kernel

--- a/runtime/onert/backend/cpu/kernel/SoftMaxLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/SoftMaxLayer.cc
@@ -147,8 +147,7 @@ void SoftMaxLayer::softmaxQuant8()
                       descrIn4D, reinterpret_cast<uint8_t *>(_output->buffer()));
 }
 
-void SoftMaxLayer::configure(const ITensor *input, const float beta,
-                             ITensor *output)
+void SoftMaxLayer::configure(const ITensor *input, const float beta, ITensor *output)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/kernel/SoftMaxLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/SoftMaxLayer.cc
@@ -126,13 +126,13 @@ void SoftMaxLayer::softmaxQuant8()
   {
     throw std::runtime_error{"only 2D and 4D tensors supported"};
   }
-  if (_output->offset() != 0 || _output->scale() != 1.f / 256)
+  if (_output->data_offset() != 0 || _output->data_scale() != 1.f / 256)
   {
     throw std::runtime_error{"incorrect scale / offset for output"};
   }
   static const int32_t kScaledDiffIntegerBits = 5;
   const double input_beta_real_multiplier = std::min(
-      1.0 * _beta * _input->scale() * (1 << (31 - kScaledDiffIntegerBits)), (1ll << 31) - 1.0);
+      1.0 * _beta * _input->data_scale() * (1 << (31 - kScaledDiffIntegerBits)), (1ll << 31) - 1.0);
   int32_t input_multiplier = 0;
   int32_t input_left_shift = 0;
   QuantizeMultiplierGreaterThanOne(input_beta_real_multiplier, &input_multiplier,
@@ -147,8 +147,8 @@ void SoftMaxLayer::softmaxQuant8()
                       descrIn4D, reinterpret_cast<uint8_t *>(_output->buffer()));
 }
 
-void SoftMaxLayer::configure(const operand::Tensor *input, const float beta,
-                             operand::Tensor *output)
+void SoftMaxLayer::configure(const ITensor *input, const float beta,
+                             ITensor *output)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/kernel/SoftMaxLayer.h
+++ b/runtime/onert/backend/cpu/kernel/SoftMaxLayer.h
@@ -40,7 +40,7 @@ public:
 
   void softmaxQuant8();
 
-  void configure(const operand::Tensor *input, const float beta, operand::Tensor *output);
+  void configure(const ITensor *input, const float beta, ITensor *output);
 
   void run();
   void runSync()
@@ -51,8 +51,8 @@ public:
   }
 
 private:
-  const operand::Tensor *_input;
-  operand::Tensor *_output;
+  const ITensor *_input;
+  ITensor *_output;
 
   float _beta;
 };

--- a/runtime/onert/backend/cpu/kernel/SplitLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/SplitLayer.cc
@@ -65,8 +65,8 @@ void SplitLayer::splitFloat32()
 
 void SplitLayer::splitQuant8() { throw std::runtime_error{"Split: NYI quant8 type"}; }
 
-void SplitLayer::configure(const operand::Tensor *input, uint16_t num_splits, int16_t axis,
-                           std::vector<operand::Tensor *> &outputs)
+void SplitLayer::configure(const ITensor *input, uint16_t num_splits, int16_t axis,
+                           std::vector<ITensor *> &outputs)
 {
   assert(input != nullptr);
 

--- a/runtime/onert/backend/cpu/kernel/SplitLayer.h
+++ b/runtime/onert/backend/cpu/kernel/SplitLayer.h
@@ -40,8 +40,8 @@ public:
 
   void splitQuant8();
 
-  void configure(const operand::Tensor *input, uint16_t num_splits, int16_t axis,
-                 std::vector<operand::Tensor *> &outputs);
+  void configure(const ITensor *input, uint16_t num_splits, int16_t axis,
+                 std::vector<ITensor *> &outputs);
 
   void run();
   void runSync()
@@ -52,10 +52,10 @@ public:
   }
 
 private:
-  const operand::Tensor *_input;
+  const ITensor *_input;
   uint16_t _num_splits;
   int16_t _axis;
-  std::vector<operand::Tensor *> _outputs;
+  std::vector<ITensor *> _outputs;
 };
 
 } // namespace kernel

--- a/runtime/onert/backend/cpu/kernel/StridedSliceLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/StridedSliceLayer.cc
@@ -58,9 +58,8 @@ void StridedSliceLayer::stridedSliceQuant8()
   throw std::runtime_error{"NYI"};
 }
 
-void StridedSliceLayer::configure(const ITensor *input, const ITensor *begin,
-                                  const ITensor *end, const ITensor *strides,
-                                  ITensor *output, const int32_t begin_mask,
+void StridedSliceLayer::configure(const ITensor *input, const ITensor *begin, const ITensor *end,
+                                  const ITensor *strides, ITensor *output, const int32_t begin_mask,
                                   const int32_t end_mask, const int32_t shrink_axis_mask,
                                   const int32_t rank)
 {

--- a/runtime/onert/backend/cpu/kernel/StridedSliceLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/StridedSliceLayer.cc
@@ -58,9 +58,9 @@ void StridedSliceLayer::stridedSliceQuant8()
   throw std::runtime_error{"NYI"};
 }
 
-void StridedSliceLayer::configure(const operand::Tensor *input, const operand::Tensor *begin,
-                                  const operand::Tensor *end, const operand::Tensor *strides,
-                                  operand::Tensor *output, const int32_t begin_mask,
+void StridedSliceLayer::configure(const ITensor *input, const ITensor *begin,
+                                  const ITensor *end, const ITensor *strides,
+                                  ITensor *output, const int32_t begin_mask,
                                   const int32_t end_mask, const int32_t shrink_axis_mask,
                                   const int32_t rank)
 {

--- a/runtime/onert/backend/cpu/kernel/StridedSliceLayer.h
+++ b/runtime/onert/backend/cpu/kernel/StridedSliceLayer.h
@@ -37,10 +37,9 @@ public:
   StridedSliceLayer();
 
 public:
-  void configure(const ITensor *input, const ITensor *begin,
-                 const ITensor *end, const ITensor *strides,
-                 ITensor *output, const int32_t begin_mask, const int32_t end_mask,
-                 const int32_t shrink_axis_mask, const int32_t rank);
+  void configure(const ITensor *input, const ITensor *begin, const ITensor *end,
+                 const ITensor *strides, ITensor *output, const int32_t begin_mask,
+                 const int32_t end_mask, const int32_t shrink_axis_mask, const int32_t rank);
 
   void run();
   void runSync()

--- a/runtime/onert/backend/cpu/kernel/StridedSliceLayer.h
+++ b/runtime/onert/backend/cpu/kernel/StridedSliceLayer.h
@@ -37,9 +37,9 @@ public:
   StridedSliceLayer();
 
 public:
-  void configure(const operand::Tensor *input, const operand::Tensor *begin,
-                 const operand::Tensor *end, const operand::Tensor *strides,
-                 operand::Tensor *output, const int32_t begin_mask, const int32_t end_mask,
+  void configure(const ITensor *input, const ITensor *begin,
+                 const ITensor *end, const ITensor *strides,
+                 ITensor *output, const int32_t begin_mask, const int32_t end_mask,
                  const int32_t shrink_axis_mask, const int32_t rank);
 
   void run();
@@ -55,11 +55,11 @@ private:
   void stridedSliceQuant8();
 
 private:
-  const operand::Tensor *_input;
-  const operand::Tensor *_begin;
-  const operand::Tensor *_end;
-  const operand::Tensor *_strides;
-  operand::Tensor *_output;
+  const ITensor *_input;
+  const ITensor *_begin;
+  const ITensor *_end;
+  const ITensor *_strides;
+  ITensor *_output;
 
   int32_t _begin_mask;
   int32_t _ellipsis_mask;

--- a/runtime/onert/backend/cpu/kernel/SubLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/SubLayer.cc
@@ -66,8 +66,8 @@ void SubLayer::subQuant8()
   throw std::runtime_error{"NYI"};
 }
 
-void SubLayer::configure(const ITensor *lhs, const ITensor *rhs,
-                         const ir::Activation activation, ITensor *output)
+void SubLayer::configure(const ITensor *lhs, const ITensor *rhs, const ir::Activation activation,
+                         ITensor *output)
 {
   _lhs = lhs;
   _rhs = rhs;

--- a/runtime/onert/backend/cpu/kernel/SubLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/SubLayer.cc
@@ -66,8 +66,8 @@ void SubLayer::subQuant8()
   throw std::runtime_error{"NYI"};
 }
 
-void SubLayer::configure(const operand::Tensor *lhs, const operand::Tensor *rhs,
-                         const ir::Activation activation, operand::Tensor *output)
+void SubLayer::configure(const ITensor *lhs, const ITensor *rhs,
+                         const ir::Activation activation, ITensor *output)
 {
   _lhs = lhs;
   _rhs = rhs;

--- a/runtime/onert/backend/cpu/kernel/SubLayer.h
+++ b/runtime/onert/backend/cpu/kernel/SubLayer.h
@@ -44,8 +44,8 @@ public:
 
   void subQuant8();
 
-  void configure(const operand::Tensor *lhs, const operand::Tensor *rhs,
-                 const ir::Activation activation, operand::Tensor *output);
+  void configure(const ITensor *lhs, const ITensor *rhs,
+                 const ir::Activation activation, ITensor *output);
 
   void run();
   void runSync()
@@ -56,9 +56,9 @@ public:
   }
 
 private:
-  const operand::Tensor *_lhs;
-  const operand::Tensor *_rhs;
-  operand::Tensor *_output;
+  const ITensor *_lhs;
+  const ITensor *_rhs;
+  ITensor *_output;
 
   ir::Activation _activation{ir::Activation::NONE};
 };

--- a/runtime/onert/backend/cpu/kernel/SubLayer.h
+++ b/runtime/onert/backend/cpu/kernel/SubLayer.h
@@ -44,8 +44,8 @@ public:
 
   void subQuant8();
 
-  void configure(const ITensor *lhs, const ITensor *rhs,
-                 const ir::Activation activation, ITensor *output);
+  void configure(const ITensor *lhs, const ITensor *rhs, const ir::Activation activation,
+                 ITensor *output);
 
   void run();
   void runSync()

--- a/runtime/onert/backend/cpu/kernel/TanhLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/TanhLayer.cc
@@ -47,7 +47,7 @@ void TanhLayer::tanhQuant8()
   throw std::runtime_error{"NYI"};
 }
 
-void TanhLayer::configure(const operand::Tensor *input, operand::Tensor *output)
+void TanhLayer::configure(const ITensor *input, ITensor *output)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/kernel/TanhLayer.h
+++ b/runtime/onert/backend/cpu/kernel/TanhLayer.h
@@ -40,7 +40,7 @@ public:
 
   void tanhQuant8();
 
-  void configure(const operand::Tensor *input, operand::Tensor *output);
+  void configure(const ITensor *input, ITensor *output);
 
   void run();
   void runSync()
@@ -51,8 +51,8 @@ public:
   }
 
 private:
-  const operand::Tensor *_input;
-  operand::Tensor *_output;
+  const ITensor *_input;
+  ITensor *_output;
 };
 
 } // namespace kernel

--- a/runtime/onert/backend/cpu/kernel/TransposeLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/TransposeLayer.cc
@@ -54,8 +54,8 @@ void TransposeLayer::transposeQuant8()
   throw std::runtime_error{"NYI"};
 }
 
-void TransposeLayer::configure(const ITensor *input, ITensor *output,
-                               const std::vector<int> &perm, int32_t rank)
+void TransposeLayer::configure(const ITensor *input, ITensor *output, const std::vector<int> &perm,
+                               int32_t rank)
 {
   _input = input;
   _rank = rank;

--- a/runtime/onert/backend/cpu/kernel/TransposeLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/TransposeLayer.cc
@@ -54,7 +54,7 @@ void TransposeLayer::transposeQuant8()
   throw std::runtime_error{"NYI"};
 }
 
-void TransposeLayer::configure(const operand::Tensor *input, operand::Tensor *output,
+void TransposeLayer::configure(const ITensor *input, ITensor *output,
                                const std::vector<int> &perm, int32_t rank)
 {
   _input = input;

--- a/runtime/onert/backend/cpu/kernel/TransposeLayer.h
+++ b/runtime/onert/backend/cpu/kernel/TransposeLayer.h
@@ -40,15 +40,15 @@ public:
 
   void transposeQuant8();
 
-  void configure(const operand::Tensor *input, operand::Tensor *output,
+  void configure(const ITensor *input, ITensor *output,
                  const std::vector<int> &perm, int32_t rank);
 
   void run();
   void runSync() { run(); }
 
 private:
-  const operand::Tensor *_input;
-  operand::Tensor *_output;
+  const ITensor *_input;
+  ITensor *_output;
   std::vector<int> _perm;
   int32_t _rank;
 };

--- a/runtime/onert/backend/cpu/kernel/TransposeLayer.h
+++ b/runtime/onert/backend/cpu/kernel/TransposeLayer.h
@@ -40,8 +40,7 @@ public:
 
   void transposeQuant8();
 
-  void configure(const ITensor *input, ITensor *output,
-                 const std::vector<int> &perm, int32_t rank);
+  void configure(const ITensor *input, ITensor *output, const std::vector<int> &perm, int32_t rank);
 
   void run();
   void runSync() { run(); }

--- a/runtime/onert/backend/cpu/kernel/UnpackLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/UnpackLayer.cc
@@ -69,8 +69,8 @@ void UnpackLayer::unpackQuant8()
   throw std::runtime_error{"Unpack: NYI quant8 type"};
 }
 
-void UnpackLayer::configure(const operand::Tensor *input, uint32_t axis, int32_t num,
-                            std::vector<operand::Tensor *> &outputs)
+void UnpackLayer::configure(const ITensor *input, uint32_t axis, int32_t num,
+                            std::vector<ITensor *> &outputs)
 {
   assert(input != nullptr);
   assert(outputs.size() > 0);

--- a/runtime/onert/backend/cpu/kernel/UnpackLayer.h
+++ b/runtime/onert/backend/cpu/kernel/UnpackLayer.h
@@ -40,8 +40,8 @@ public:
 
   void unpackQuant8();
 
-  void configure(const operand::Tensor *input, uint32_t axis, int32_t num_output,
-                 std::vector<operand::Tensor *> &output);
+  void configure(const ITensor *input, uint32_t axis, int32_t num_output,
+                 std::vector<ITensor *> &output);
 
   void run();
   void runSync()
@@ -52,8 +52,8 @@ public:
   }
 
 private:
-  const operand::Tensor *_input;
-  std::vector<operand::Tensor *> _outputs;
+  const ITensor *_input;
+  std::vector<ITensor *> _outputs;
   uint32_t _axis;
   int32_t _num_output;
 };

--- a/runtime/onert/backend/cpu/operand/Tensor.h
+++ b/runtime/onert/backend/cpu/operand/Tensor.h
@@ -82,8 +82,8 @@ public:
   size_t calcOffset(const ir::Coordinates &coords) const override;
   ir::Layout layout() const override { return ir::Layout::NHWC; }
   ir::DataType data_type() const override { return _info.typeInfo().type(); }
-  float data_scale() const { return _info.typeInfo().scale(); }
-  int32_t data_offset() const { return _info.typeInfo().offset(); }
+  float data_scale() const override { return _info.typeInfo().scale(); }
+  int32_t data_offset() const override { return _info.typeInfo().offset(); }
   bool has_padding() const override { return false; }
   void access(const std::function<void(ITensor &tensor)> &fn) final;
   bool is_dynamic() const override { return _info.isDynamic(); }

--- a/runtime/onert/core/include/backend/IConfig.h
+++ b/runtime/onert/core/include/backend/IConfig.h
@@ -41,6 +41,7 @@ struct IConfig
 
   virtual bool supportDynamicTensor() = 0;
   virtual bool supportFP16() = 0;
+  virtual bool supportExternalTensor() { return false; } // XXX Remove default impl
 
   // Timer is used for backend profiling. In case of default (nullptr) timer profiler won't work.
   virtual std::unique_ptr<util::ITimer> timer() { return nullptr; }

--- a/runtime/onert/core/include/backend/ITensor.h
+++ b/runtime/onert/core/include/backend/ITensor.h
@@ -45,7 +45,7 @@ public:
   virtual size_t calcOffset(const ir::Coordinates &coords) const = 0;
   virtual ir::Layout layout() const = 0;
   virtual ir::DataType data_type() const = 0;
-  virtual float data_scale() const { return 0; } // XXX Remove default impl
+  virtual float data_scale() const { return 0; }    // XXX Remove default impl
   virtual int32_t data_offset() const { return 0; } // XXX Remove default impl
   virtual bool has_padding() const = 0;
   virtual void access(const std::function<void(ITensor &tensor)> &fn) = 0;

--- a/runtime/onert/core/include/backend/ITensor.h
+++ b/runtime/onert/core/include/backend/ITensor.h
@@ -45,6 +45,8 @@ public:
   virtual size_t calcOffset(const ir::Coordinates &coords) const = 0;
   virtual ir::Layout layout() const = 0;
   virtual ir::DataType data_type() const = 0;
+  virtual float data_scale() const { return 0; } // XXX Remove default impl
+  virtual int32_t data_offset() const { return 0; } // XXX Remove default impl
   virtual bool has_padding() const = 0;
   virtual void access(const std::function<void(ITensor &tensor)> &fn) = 0;
 
@@ -115,6 +117,8 @@ public:
   }
   ir::Layout layout() const override { return _layout; }
   ir::DataType data_type() const override { return _info.typeInfo().type(); }
+  float data_scale() const override { return _info.typeInfo().scale(); }
+  int32_t data_offset() const override { return _info.typeInfo().offset(); }
   bool has_padding() const override { return false; }
   bool is_dynamic() const override { return false; }
   void access(const std::function<void(backend::ITensor &tensor)> &fn) override

--- a/runtime/onert/core/include/backend/ITensor.h
+++ b/runtime/onert/core/include/backend/ITensor.h
@@ -25,6 +25,7 @@
 #include "ir/Layout.h"
 #include "ir/Shape.h"
 #include "ir/Coordinates.h"
+#include "ir/OperandInfo.h"
 
 namespace onert
 {
@@ -74,6 +75,62 @@ public:
   {
     throw std::runtime_error("This backend does not support dynamic tensor");
   }
+};
+
+class UserTensor : public ITensor
+{
+public:
+  UserTensor(const ir::OperandInfo &info, ir::Layout layout, uint8_t *buffer, size_t size)
+      : _info{info}, _layout{layout}, _buffer{buffer}, _size{size}
+  {
+  }
+
+  UserTensor(const ir::OperandInfo &info, ir::Layout layout)
+      : _info{info}, _layout{layout}, _buffer{nullptr}, _size{0}
+  {
+  }
+
+public:
+  void setBuffer(uint8_t *buffer, size_t size)
+  {
+    _buffer = buffer;
+    _size = size;
+  }
+
+public:
+  uint8_t *buffer() const override { return _buffer; }
+  size_t total_size() const override { return _size; }
+  size_t dimension(size_t index) const override { return _info.shape().dim(index); }
+  size_t num_dimensions() const override { return _info.shape().rank(); }
+  size_t calcOffset(const ir::Coordinates &coords) const override
+  {
+    size_t rank = num_dimensions();
+    size_t offset = 0;
+    for (size_t i = 0; i < rank; ++i)
+    {
+      offset = offset * dimension(i) + coords[i];
+    }
+    offset *= sizeOfDataType(data_type());
+    return offset;
+  }
+  ir::Layout layout() const override { return _layout; }
+  ir::DataType data_type() const override { return _info.typeInfo().type(); }
+  bool has_padding() const override { return false; }
+  bool is_dynamic() const override { return false; }
+  void access(const std::function<void(backend::ITensor &tensor)> &fn) override
+  {
+    // This is an optional input
+    if (total_size() == 0)
+      return;
+
+    fn(*this);
+  }
+
+private:
+  ir::OperandInfo _info;
+  ir::Layout _layout;
+  uint8_t *_buffer;
+  size_t _size;
 };
 
 /**

--- a/runtime/onert/core/include/backend/ITensorBuilder.h
+++ b/runtime/onert/core/include/backend/ITensorBuilder.h
@@ -54,6 +54,10 @@ struct ITensorBuilder
    */
   virtual void registerTensorInfo(const ir::OperandIndex &ind, const ir::OperandInfo &info,
                                   ir::Layout backend_layout, bool as_const) = 0;
+  virtual void setExternalTensor(const ir::OperandIndex &, const std::shared_ptr<ITensor> &)
+  {
+    throw std::runtime_error{"setExternalTensor NYI"};
+  }
   /**
    * @brief Let the tensor builder know first use(start of lifetime) of a tensor
    *        Must be called before calling @c prepare

--- a/runtime/onert/core/include/backend/ITensorRegistry.h
+++ b/runtime/onert/core/include/backend/ITensorRegistry.h
@@ -20,6 +20,8 @@
 #include "ir/Index.h"
 #include "backend/ITensor.h"
 
+#include "ir/OperandIndexMap.h"
+
 namespace onert
 {
 namespace backend
@@ -36,7 +38,69 @@ struct ITensorRegistry
    * @brief Returns pointer of ITensor
    * @note  Return tensor cannot be used longer than dynamic tensor manager
    */
-  virtual ITensor *getITensor(const ir::OperandIndex &) = 0;
+  virtual std::shared_ptr<ITensor> getITensor(const ir::OperandIndex &) = 0;
+
+  /**
+   * @brief Get the External Tensor object.
+   *
+   * @param ind Index
+   * @return std::shared_ptr<ITensor> ITensor to return
+   */
+	virtual std::shared_ptr<ITensor> getExternalTensor(const ir::OperandIndex &ind) = 0;
+};
+
+
+// XXX accesing map with operator[] creates a shared_ptr(nullptr).
+
+/**
+ * @brief  TensorRegistry template class for the convenience of backend implementations
+ *
+ * @tparam T_Tensor Tensor type. Must be a subclass of @c onert::backend::ITensor .
+ */
+template <typename T_Tensor>
+class TensorRegistryTemplate : public ITensorRegistry
+{
+public:
+	std::shared_ptr<ITensor> getITensor(const ir::OperandIndex &ind) override
+  {
+    static_assert(std::is_base_of<ITensor, T_Tensor>::value, "T_Tensor must derive from ITensor.");
+    auto external_tensor = _external[ind];
+    if (external_tensor) return external_tensor;
+    return _managed[ind];
+  }
+
+	std::shared_ptr<ITensor> getExternalTensor(const ir::OperandIndex &ind) override
+  {
+    return _external[ind];
+  }
+
+	std::shared_ptr<T_Tensor> getManagedTensor(const ir::OperandIndex &ind)
+  {
+    return _managed[ind];
+  }
+
+  void setExternalTensor(const ir::OperandIndex &ind, const std::shared_ptr<ITensor> &tensor)
+  {
+    auto itr = _managed.find(ind);
+    if (itr != _managed.end() && itr->second != nullptr && tensor != nullptr)
+      throw std::runtime_error{"Tried to set an external tensor but a managed tensor already exists."};
+    _external[ind] = tensor;
+  }
+
+  void setManagedTensor(const ir::OperandIndex &ind, const std::shared_ptr<T_Tensor> &tensor)
+  {
+    auto itr = _external.find(ind);
+    if (itr != _external.end() && itr->second != nullptr && tensor != nullptr)
+      throw std::runtime_error{"Tried to set a managed tensor but an external tensor already exists."};
+    _managed[ind] = tensor;
+  }
+
+  const ir::OperandIndexMap<std::shared_ptr<ITensor>> &external_tensors() { return _external; }
+  const ir::OperandIndexMap<std::shared_ptr<T_Tensor>> &managed_tensors() { return _managed; }
+
+private:
+  ir::OperandIndexMap<std::shared_ptr<ITensor>> _external;
+  ir::OperandIndexMap<std::shared_ptr<T_Tensor>> _managed;
 };
 
 } // namespace backend

--- a/runtime/onert/core/include/backend/ITensorRegistry.h
+++ b/runtime/onert/core/include/backend/ITensorRegistry.h
@@ -21,6 +21,7 @@
 #include "backend/ITensor.h"
 
 #include "ir/OperandIndexMap.h"
+#include "util/logging.h"
 
 namespace onert
 {
@@ -81,14 +82,19 @@ public:
 
   void setExternalTensor(const ir::OperandIndex &ind, const std::shared_ptr<ITensor> &tensor)
   {
+    VERBOSE(TensorRegistryTemplate_setExternalTensor) << ind.value() << std::endl;
     auto itr = _managed.find(ind);
     if (itr != _managed.end() && itr->second != nullptr && tensor != nullptr)
-      throw std::runtime_error{"Tried to set an external tensor but a managed tensor already exists."};
+    {
+      _managed.erase(itr);
+      //throw std::runtime_error{"Tried to set an external tensor but a managed tensor already exists."};
+    }
     _external[ind] = tensor;
   }
 
   void setManagedTensor(const ir::OperandIndex &ind, const std::shared_ptr<T_Tensor> &tensor)
   {
+    VERBOSE(TensorRegistryTemplate_setManagedTensor) << ind.value() << std::endl;
     auto itr = _external.find(ind);
     if (itr != _external.end() && itr->second != nullptr && tensor != nullptr)
       throw std::runtime_error{"Tried to set a managed tensor but an external tensor already exists."};

--- a/runtime/onert/core/include/backend/ITensorRegistry.h
+++ b/runtime/onert/core/include/backend/ITensorRegistry.h
@@ -47,9 +47,8 @@ struct ITensorRegistry
    * @param ind Index
    * @return std::shared_ptr<ITensor> ITensor to return
    */
-	virtual std::shared_ptr<ITensor> getExternalTensor(const ir::OperandIndex &ind) = 0;
+  virtual std::shared_ptr<ITensor> getExternalTensor(const ir::OperandIndex &ind) = 0;
 };
-
 
 // XXX accesing map with operator[] creates a shared_ptr(nullptr).
 
@@ -58,27 +57,24 @@ struct ITensorRegistry
  *
  * @tparam T_Tensor Tensor type. Must be a subclass of @c onert::backend::ITensor .
  */
-template <typename T_Tensor>
-class TensorRegistryTemplate : public ITensorRegistry
+template <typename T_Tensor> class TensorRegistryTemplate : public ITensorRegistry
 {
 public:
-	std::shared_ptr<ITensor> getITensor(const ir::OperandIndex &ind) override
+  std::shared_ptr<ITensor> getITensor(const ir::OperandIndex &ind) override
   {
     static_assert(std::is_base_of<ITensor, T_Tensor>::value, "T_Tensor must derive from ITensor.");
     auto external_tensor = _external[ind];
-    if (external_tensor) return external_tensor;
+    if (external_tensor)
+      return external_tensor;
     return _managed[ind];
   }
 
-	std::shared_ptr<ITensor> getExternalTensor(const ir::OperandIndex &ind) override
+  std::shared_ptr<ITensor> getExternalTensor(const ir::OperandIndex &ind) override
   {
     return _external[ind];
   }
 
-	std::shared_ptr<T_Tensor> getManagedTensor(const ir::OperandIndex &ind)
-  {
-    return _managed[ind];
-  }
+  std::shared_ptr<T_Tensor> getManagedTensor(const ir::OperandIndex &ind) { return _managed[ind]; }
 
   void setExternalTensor(const ir::OperandIndex &ind, const std::shared_ptr<ITensor> &tensor)
   {
@@ -97,7 +93,8 @@ public:
     VERBOSE(TensorRegistryTemplate_setManagedTensor) << ind.value() << std::endl;
     auto itr = _external.find(ind);
     if (itr != _external.end() && itr->second != nullptr && tensor != nullptr)
-      throw std::runtime_error{"Tried to set a managed tensor but an external tensor already exists."};
+      throw std::runtime_error{
+          "Tried to set a managed tensor but an external tensor already exists."};
     _managed[ind] = tensor;
   }
 

--- a/runtime/onert/core/include/backend/ITensorRegistry.h
+++ b/runtime/onert/core/include/backend/ITensorRegistry.h
@@ -87,8 +87,7 @@ public:
     if (itr != _managed.end() && itr->second != nullptr && tensor != nullptr)
     {
       // NOTE : OVERWRITE!
-      _managed.erase(itr);
-      //throw std::runtime_error{"Tried to set an external tensor but a managed tensor already exists."};
+      //_managed.erase(itr);
     }
     _external[ind] = tensor;
   }

--- a/runtime/onert/core/include/backend/ITensorRegistry.h
+++ b/runtime/onert/core/include/backend/ITensorRegistry.h
@@ -86,6 +86,7 @@ public:
     auto itr = _managed.find(ind);
     if (itr != _managed.end() && itr->second != nullptr && tensor != nullptr)
     {
+      // NOTE : OVERWRITE!
       _managed.erase(itr);
       //throw std::runtime_error{"Tried to set an external tensor but a managed tensor already exists."};
     }

--- a/runtime/onert/core/include/compiler/Compiler.h
+++ b/runtime/onert/core/include/compiler/Compiler.h
@@ -48,6 +48,7 @@ struct CompilerOptions
 {
   // GENERAL OPTIONS
   std::vector<std::string> backend_list;
+  bool is_primary_subgraph;
 
   // OPTIONS ONLY FOR DEBUGGING/PROFILING
   std::string trace_filepath; //< File path to save trace records

--- a/runtime/onert/core/include/ir/LoweredGraph.h
+++ b/runtime/onert/core/include/ir/LoweredGraph.h
@@ -55,7 +55,8 @@ private:
                        const compiler::CompilerOptions &options);
 
   void
-  manipulateLowerInfo(OperandIndexMap<std::unique_ptr<operand::LowerInfo>> &operands_lower_info, bool is_primary);
+  manipulateLowerInfo(OperandIndexMap<std::unique_ptr<operand::LowerInfo>> &operands_lower_info,
+                      bool is_primary);
   void dumpLowerInfo();
   bool mergeable(const OpSequenceIndex &op_seq_index, const OperationIndex &node_index,
                  Layout layout);

--- a/runtime/onert/core/include/ir/LoweredGraph.h
+++ b/runtime/onert/core/include/ir/LoweredGraph.h
@@ -55,7 +55,7 @@ private:
                        const compiler::CompilerOptions &options);
 
   void
-  manipulateLowerInfo(OperandIndexMap<std::unique_ptr<operand::LowerInfo>> &operands_lower_info);
+  manipulateLowerInfo(OperandIndexMap<std::unique_ptr<operand::LowerInfo>> &operands_lower_info, bool is_primary);
   void dumpLowerInfo();
   bool mergeable(const OpSequenceIndex &op_seq_index, const OperationIndex &node_index,
                  Layout layout);

--- a/runtime/onert/core/include/ir/OperandIndexSequence.h
+++ b/runtime/onert/core/include/ir/OperandIndexSequence.h
@@ -44,6 +44,12 @@ public:
   const OperandIndex &at(IOIndex set_index) const { return _set.at(set_index.value()); }
   const OperandIndex &at(uint32_t index) const { return _set.at(index); }
   bool contains(const OperandIndex &index) const;
+  /**
+   * @brief Replace first occurence
+   *
+   * @param from Index value to replace
+   * @param to Index value to be replaced with
+   */
   void replace(const OperandIndex &from, const OperandIndex &to);
 
 public:

--- a/runtime/onert/core/src/backend/controlflow/Config.h
+++ b/runtime/onert/core/src/backend/controlflow/Config.h
@@ -42,6 +42,7 @@ public:
     return false;
   }
   bool supportFP16() override { return false; }
+  bool supportExternalTensor() override { return true; }
 
   std::unique_ptr<util::ITimer> timer() override { return std::make_unique<util::CPUTimer>(); }
 };

--- a/runtime/onert/core/src/backend/controlflow/TensorBuilder.cc
+++ b/runtime/onert/core/src/backend/controlflow/TensorBuilder.cc
@@ -27,7 +27,7 @@ namespace backend
 namespace controlflow
 {
 
-TensorBuilder::TensorBuilder() : _static_tensor_mgr{new StaticTensorManager()}
+TensorBuilder::TensorBuilder() : _tensor_reg{new TensorRegistry()}, _static_tensor_mgr{new StaticTensorManager()}
 {
   // DO NOTHING
 }

--- a/runtime/onert/core/src/backend/controlflow/TensorBuilder.cc
+++ b/runtime/onert/core/src/backend/controlflow/TensorBuilder.cc
@@ -27,7 +27,8 @@ namespace backend
 namespace controlflow
 {
 
-TensorBuilder::TensorBuilder() : _tensor_reg{new TensorRegistry()}, _static_tensor_mgr{new StaticTensorManager()}
+TensorBuilder::TensorBuilder()
+    : _tensor_reg{new TensorRegistry()}, _static_tensor_mgr{new StaticTensorManager()}
 {
   // DO NOTHING
 }

--- a/runtime/onert/core/src/backend/controlflow/TensorBuilder.cc
+++ b/runtime/onert/core/src/backend/controlflow/TensorBuilder.cc
@@ -83,7 +83,7 @@ void TensorBuilder::allocate()
 
 std::shared_ptr<ITensor> TensorBuilder::tensorAt(const ir::OperandIndex &ind)
 {
-  return _static_tensor_mgr->at(ind);
+  return _tensor_reg->getITensor(ind);
 }
 
 void TensorBuilder::iterate(const IterateFunction &fn) { _static_tensor_mgr->iterate(fn); }

--- a/runtime/onert/core/src/backend/controlflow/TensorBuilder.h
+++ b/runtime/onert/core/src/backend/controlflow/TensorBuilder.h
@@ -22,6 +22,7 @@
 #include <backend/ITensorBuilder.h>
 #include <ir/OperandIndexMap.h>
 #include "StaticTensorManager.h"
+#include "TensorRegistry.h"
 #include <unordered_map>
 
 namespace onert
@@ -68,7 +69,10 @@ public:
 
   std::shared_ptr<operand::Tensor> at(const ir::OperandIndex &ind);
 
+  std::shared_ptr<ITensorRegistry> tensorRegistry() override { return _tensor_reg; }
+
 private:
+  const std::shared_ptr<TensorRegistry> _tensor_reg;
   std::unique_ptr<StaticTensorManager> _static_tensor_mgr;
   ir::OperandIndexMap<ir::OperandInfo> _tensor_info_map;
   ir::OperandIndexMap<ir::Layout> _tensor_layout_map;

--- a/runtime/onert/core/src/backend/controlflow/operand/Tensor.h
+++ b/runtime/onert/core/src/backend/controlflow/operand/Tensor.h
@@ -94,6 +94,64 @@ private:
   std::shared_ptr<Allocator> _allocator;
 };
 
+class UserTensor : public ITensor
+{
+public:
+  UserTensor(const ir::OperandInfo &info, ir::Layout layout, uint8_t *buffer, size_t size)
+      : _info{info}, _layout{layout}, _buffer{buffer}, _size{size}
+  {
+  }
+
+  UserTensor(const ir::OperandInfo &info, ir::Layout layout)
+      : _info{info}, _layout{layout}, _buffer{nullptr}, _size{0}
+  {
+  }
+
+public:
+  void setBuffer(uint8_t *buffer, size_t size)
+  {
+    _buffer = buffer;
+    _size = size;
+  }
+
+public:
+  uint8_t *buffer() const override { return _buffer; }
+  size_t total_size() const override { return _size; }
+  size_t dimension(size_t index) const override { return _info.shape().dim(index); }
+  size_t num_dimensions() const override { return _info.shape().rank(); }
+  size_t calcOffset(const ir::Coordinates &coords) const override
+  {
+    size_t rank = num_dimensions();
+    size_t offset = 0;
+    for (size_t i = 0; i < rank; ++i)
+    {
+      offset = offset * dimension(i) + coords[i];
+    }
+    offset *= sizeOfDataType(data_type());
+    return offset;
+  }
+  ir::Layout layout() const override { return _layout; }
+  ir::DataType data_type() const override { return _info.typeInfo().type(); }
+  float data_scale() const override { return _info.typeInfo().scale(); }
+  int32_t data_offset() const override { return _info.typeInfo().offset(); }
+  bool has_padding() const override { return false; }
+  bool is_dynamic() const override { return false; }
+  void access(const std::function<void(backend::ITensor &tensor)> &fn) override
+  {
+    // This is an optional input
+    if (total_size() == 0)
+      return;
+
+    fn(*this);
+  }
+
+private:
+  ir::OperandInfo _info;
+  ir::Layout _layout;
+  uint8_t *_buffer;
+  size_t _size;
+};
+
 } // namespace operand
 } // namespace controlflow
 } // namespace backend

--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -259,6 +259,8 @@ void Compiler::compile(void)
     auto &lowered_subg = pair.second;
     auto indexed_ranks = lowered_subg->indexed_ranks();
 
+    _options.is_primary_subgraph = (subg_index == ir::SubgraphIndex{0});
+
     onert::dumper::dot::DotDumper dot_dumper_lowered(lowered_subg.get(), dump_level);
     dot_dumper_lowered.dump("after_lower_subg-" + std::to_string(subg_index.value()));
 

--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -67,7 +67,6 @@ CompilerOptions fetchCompilerOptionsFromGlobalConfig(const ir::Subgraphs &subgs)
   // There are two cases to load default backend
   // 1. whether controlflow operation exist in subgraphs for controlflow kernel
   // 2. whether to load 2 or more backends for Permute kernel between different backends
-  if (cf_ops.size() != 0 || options.backend_list.size() > 1)
   {
     options.backend_list.emplace_back(backend::controlflow::Config::ID);
   }
@@ -216,6 +215,7 @@ void Compiler::compile(void)
   // Lower: Assign backend
   std::unordered_map<ir::SubgraphIndex, std::unique_ptr<ir::LoweredGraph>> lowered_subgs;
   _subgraphs->iterate([&](const ir::SubgraphIndex &index, ir::Graph &subg) {
+    _options.is_primary_subgraph = (index == ir::SubgraphIndex{0}); // XXX Need better way
     onert::dumper::dot::DotDumper dot_dumper(subg, dump_level);
     dot_dumper.dump(nnfw::misc::str("before_lower_subg-", index.value()));
 
@@ -259,7 +259,7 @@ void Compiler::compile(void)
     auto &lowered_subg = pair.second;
     auto indexed_ranks = lowered_subg->indexed_ranks();
 
-    _options.is_primary_subgraph = (subg_index == ir::SubgraphIndex{0});
+    _options.is_primary_subgraph = (subg_index == ir::SubgraphIndex{0}); // XXX Need better way
 
     onert::dumper::dot::DotDumper dot_dumper_lowered(lowered_subg.get(), dump_level);
     dot_dumper_lowered.dump("after_lower_subg-" + std::to_string(subg_index.value()));

--- a/runtime/onert/core/src/compiler/ExecutorFactory.cc
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.cc
@@ -121,6 +121,8 @@ void ExecutorFactory::runTensorRegistration(ir::LoweredGraph *lowered_graph,
         const auto &op = *elem.node;
         for (const auto &index : op.getInputs() + op.getOutputs())
         {
+          if ((lowered_graph->graph().getInputs() + lowered_graph->graph().getOutputs()).contains(index))
+            continue;
           if (!tensor_builder->isRegistered(index))
           {
             const auto &operand_lower_info =

--- a/runtime/onert/core/src/compiler/ExecutorFactory.cc
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.cc
@@ -182,7 +182,7 @@ std::vector<std::shared_ptr<backend::ITensor>> ExecutorFactory::initializeModelI
     // Set other tensors as external tensors
     for (auto &tensor_builder : tensor_builders)
     {
-      if (tensor_builder->isRegistered(ind))
+      //if (tensor_builder->isRegistered(ind)) // XXX Workaround : register all controlflow backend tensors
       {
         tensor_builder->setExternalTensor(ind, tensor);
       }

--- a/runtime/onert/core/src/compiler/ExecutorFactory.cc
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.cc
@@ -166,10 +166,8 @@ std::vector<std::shared_ptr<backend::UserTensor>> ExecutorFactory::initializeTen
     ret.push_back(tensor);
     for (auto &tensor_builder : tensor_builders)
     {
-      if (tensor_builder->isRegistered(ind))
-      {
-        tensor_builder->setExternalTensor(ind, tensor);
-      }
+      assert(!tensor_builder->isRegistered(ind)); // I/O tensors must not be registered
+      tensor_builder->setExternalTensor(ind, tensor);
     }
   }
   return ret;

--- a/runtime/onert/core/src/compiler/ExecutorFactory.cc
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.cc
@@ -124,7 +124,8 @@ void ExecutorFactory::runTensorRegistration(ir::LoweredGraph *lowered_graph,
         const auto &op = *elem.node;
         for (const auto &index : op.getInputs() + op.getOutputs())
         {
-          //if ((lowered_graph->graph().getInputs() + lowered_graph->graph().getOutputs()).contains(index))
+          // if ((lowered_graph->graph().getInputs() +
+          // lowered_graph->graph().getOutputs()).contains(index))
           //  continue;
           if (!tensor_builder->isRegistered(index))
           {
@@ -152,7 +153,9 @@ void ExecutorFactory::runTensorRegistration(ir::LoweredGraph *lowered_graph,
   }
 }
 
-std::vector<std::shared_ptr<backend::ITensor>> ExecutorFactory::initializeModelIOTensors(ir::LoweredGraph &lowered_graph, const ir::OperandIndexSequence &indices)
+std::vector<std::shared_ptr<backend::ITensor>>
+ExecutorFactory::initializeModelIOTensors(ir::LoweredGraph &lowered_graph,
+                                          const ir::OperandIndexSequence &indices)
 {
   std::vector<std::shared_ptr<backend::ITensor>> ret;
 
@@ -171,10 +174,13 @@ std::vector<std::shared_ptr<backend::ITensor>> ExecutorFactory::initializeModelI
   for (auto ind : indices)
   {
     const auto &operand = lowered_graph.graph().operands().at(ind);
-    auto tensor = std::make_shared<backend::controlflow::operand::UserTensor>(operand.info(), ir::Layout::NHWC /* FIXME find op_seq for this operand and use frontend_layout */);
+    auto tensor = std::make_shared<backend::controlflow::operand::UserTensor>(
+        operand.info(),
+        ir::Layout::NHWC /* FIXME find op_seq for this operand and use frontend_layout */);
 
     // Add tensor to controlflow TensorRegistry.
-    auto cf_tensor_reg = std::dynamic_pointer_cast<backend::controlflow::TensorRegistry>(cf_tensor_builder->tensorRegistry());
+    auto cf_tensor_reg = std::dynamic_pointer_cast<backend::controlflow::TensorRegistry>(
+        cf_tensor_builder->tensorRegistry());
     assert(cf_tensor_reg);
     cf_tensor_reg->setManagedTensor(ind, tensor);
     ret.push_back(tensor);
@@ -182,7 +188,8 @@ std::vector<std::shared_ptr<backend::ITensor>> ExecutorFactory::initializeModelI
     // Set other tensors as external tensors
     for (auto &tensor_builder : tensor_builders)
     {
-      //if (tensor_builder->isRegistered(ind)) // XXX Workaround : register all controlflow backend tensors
+      // if (tensor_builder->isRegistered(ind)) // XXX Workaround : register all controlflow backend
+      // tensors
       {
         tensor_builder->setExternalTensor(ind, tensor);
       }
@@ -298,8 +305,9 @@ ExecutorFactory::createLinearExecutor(std::unique_ptr<ir::LoweredGraph> lowered_
     });
   }
 
-  auto exec = new exec::LinearExecutor{std::move(lowered_graph), input_tensors, output_tensors, tensor_builders,
-                                       std::move(code_map), order};
+  auto exec =
+      new exec::LinearExecutor{std::move(lowered_graph), input_tensors,       output_tensors,
+                               tensor_builders,          std::move(code_map), order};
 
   if (!options.trace_filepath.empty())
   {
@@ -408,13 +416,14 @@ exec::IExecutor *ExecutorFactory::createDataflowExecutor(
   exec::ExecutorBase *exec = nullptr;
   if (parallel)
   {
-    exec =
-        new exec::ParallelExecutor{std::move(lowered_graph), input_tensors, output_tensors, tensor_builders, std::move(code_map)};
+    exec = new exec::ParallelExecutor{std::move(lowered_graph), input_tensors, output_tensors,
+                                      tensor_builders, std::move(code_map)};
   }
   else
   {
     auto dataflow_exec =
-        new exec::DataflowExecutor{std::move(lowered_graph), input_tensors, output_tensors, tensor_builders, std::move(code_map)};
+        new exec::DataflowExecutor{std::move(lowered_graph), input_tensors, output_tensors,
+                                   tensor_builders, std::move(code_map)};
     if (options.he_profiling_mode)
     {
       std::vector<const backend::Backend *> backends;

--- a/runtime/onert/core/src/compiler/ExecutorFactory.h
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.h
@@ -45,7 +45,7 @@ private:
   static void initializeBackendContext(ir::LoweredGraph *lowered_graph);
   static void runTensorRegistration(ir::LoweredGraph *lowered_graph,
                                     const std::vector<ir::OpSequenceIndex> &order);
-  static std::vector<std::shared_ptr<backend::UserTensor>> initializeTensors(ir::LoweredGraph &lowered_graph, const ir::OperandIndexSequence &indices);
+  static std::vector<std::shared_ptr<backend::ITensor>> initializeModelIOTensors(ir::LoweredGraph &lowered_graph, const ir::OperandIndexSequence &indices);
   static exec::IExecutor *
   createLinearExecutor(std::unique_ptr<ir::LoweredGraph> lowered_graph,
                        const compiler::CompilerOptions &options,

--- a/runtime/onert/core/src/compiler/ExecutorFactory.h
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.h
@@ -19,6 +19,7 @@
 
 #include <unordered_map>
 
+#include "backend/ITensor.h"
 #include "exec/IExecutor.h"
 #include "ir/LoweredGraph.h"
 
@@ -44,6 +45,7 @@ private:
   static void initializeBackendContext(ir::LoweredGraph *lowered_graph);
   static void runTensorRegistration(ir::LoweredGraph *lowered_graph,
                                     const std::vector<ir::OpSequenceIndex> &order);
+  static std::vector<std::shared_ptr<backend::UserTensor>> initializeTensors(ir::LoweredGraph &lowered_graph, const ir::OperandIndexSequence &indices);
   static exec::IExecutor *
   createLinearExecutor(std::unique_ptr<ir::LoweredGraph> lowered_graph,
                        const compiler::CompilerOptions &options,

--- a/runtime/onert/core/src/compiler/ExecutorFactory.h
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.h
@@ -45,7 +45,9 @@ private:
   static void initializeBackendContext(ir::LoweredGraph *lowered_graph);
   static void runTensorRegistration(ir::LoweredGraph *lowered_graph,
                                     const std::vector<ir::OpSequenceIndex> &order);
-  static std::vector<std::shared_ptr<backend::ITensor>> initializeModelIOTensors(ir::LoweredGraph &lowered_graph, const ir::OperandIndexSequence &indices);
+  static std::vector<std::shared_ptr<backend::ITensor>>
+  initializeModelIOTensors(ir::LoweredGraph &lowered_graph,
+                           const ir::OperandIndexSequence &indices);
   static exec::IExecutor *
   createLinearExecutor(std::unique_ptr<ir::LoweredGraph> lowered_graph,
                        const compiler::CompilerOptions &options,

--- a/runtime/onert/core/src/compiler/Linear.cc
+++ b/runtime/onert/core/src/compiler/Linear.cc
@@ -152,6 +152,8 @@ void Linear::planTensors(const ir::LoweredGraph &lowered_graph,
 
   // Prepare scanning
   graph.operands().iterate([&](const ir::OperandIndex &ind, const ir::Operand &obj) {
+    if ((lowered_graph.graph().getInputs() + lowered_graph.graph().getOutputs()).contains(ind))
+      return;
     const auto lower_info = lowered_graph.getLowerInfo(ind);
     // TODO Remove if onert doesn't support anymore such as
     // GeneratedTests.reshape_quant8_weights_as_inputs
@@ -189,10 +191,12 @@ void Linear::planTensors(const ir::LoweredGraph &lowered_graph,
 
   // If a tensor is model output, increase the use of the tensor.
   // This aim is same to above one.
+  /*
   for (const auto &ind : graph.getOutputs())
   {
     uses_map[ind]++;
   }
+  */
 
   // Start scanning to do notify{First|Last}Use for each tensor
 
@@ -207,6 +211,7 @@ void Linear::planTensors(const ir::LoweredGraph &lowered_graph,
   }
 
   // Allocate Model's inputs
+  /*
   VERBOSE(LINEAR) << "TENSORS as MODEL INPUT" << std::endl;
   for (const auto &ind : graph.getInputs())
   {
@@ -215,6 +220,7 @@ void Linear::planTensors(const ir::LoweredGraph &lowered_graph,
       continue;
     tensor_builder->notifyFirstUse(ind);
   }
+  */
 
   // At each operation,
   // 1. Scan DEF of outputs. If the DEF, allocate it
@@ -227,6 +233,8 @@ void Linear::planTensors(const ir::LoweredGraph &lowered_graph,
     {
       for (const auto &ind : op.node->getOutputs())
       {
+        if (lowered_graph.graph().getOutputs().contains(ind))
+          continue;
         assert(def_map.find(ind) != def_map.end());
         if (def_map[ind])
         {
@@ -237,6 +245,8 @@ void Linear::planTensors(const ir::LoweredGraph &lowered_graph,
 
       for (const auto &ind : op.node->getInputs())
       {
+        if (lowered_graph.graph().getInputs().contains(ind))
+          continue;
         assert(uses_map.find(ind) != uses_map.end());
         assert(uses_map[ind] > 0);
         uses_map[ind]--;
@@ -249,6 +259,7 @@ void Linear::planTensors(const ir::LoweredGraph &lowered_graph,
   }
 
   // Dispose and validate
+  /*
   for (const auto &ind : graph.getOutputs())
   {
     --uses_map[ind];
@@ -257,6 +268,7 @@ void Linear::planTensors(const ir::LoweredGraph &lowered_graph,
       tensor_builder_map[ind]->notifyLastUse(ind);
     }
   }
+  */
 
   for (const auto &ind : constants)
   {

--- a/runtime/onert/core/src/compiler/Linear.cc
+++ b/runtime/onert/core/src/compiler/Linear.cc
@@ -152,8 +152,6 @@ void Linear::planTensors(const ir::LoweredGraph &lowered_graph,
 
   // Prepare scanning
   graph.operands().iterate([&](const ir::OperandIndex &ind, const ir::Operand &obj) {
-    if ((lowered_graph.graph().getInputs() + lowered_graph.graph().getOutputs()).contains(ind))
-      return;
     const auto lower_info = lowered_graph.getLowerInfo(ind);
     // TODO Remove if onert doesn't support anymore such as
     // GeneratedTests.reshape_quant8_weights_as_inputs
@@ -191,12 +189,10 @@ void Linear::planTensors(const ir::LoweredGraph &lowered_graph,
 
   // If a tensor is model output, increase the use of the tensor.
   // This aim is same to above one.
-  /*
   for (const auto &ind : graph.getOutputs())
   {
     uses_map[ind]++;
   }
-  */
 
   // Start scanning to do notify{First|Last}Use for each tensor
 
@@ -211,7 +207,6 @@ void Linear::planTensors(const ir::LoweredGraph &lowered_graph,
   }
 
   // Allocate Model's inputs
-  /*
   VERBOSE(LINEAR) << "TENSORS as MODEL INPUT" << std::endl;
   for (const auto &ind : graph.getInputs())
   {
@@ -220,7 +215,6 @@ void Linear::planTensors(const ir::LoweredGraph &lowered_graph,
       continue;
     tensor_builder->notifyFirstUse(ind);
   }
-  */
 
   // At each operation,
   // 1. Scan DEF of outputs. If the DEF, allocate it
@@ -233,8 +227,6 @@ void Linear::planTensors(const ir::LoweredGraph &lowered_graph,
     {
       for (const auto &ind : op.node->getOutputs())
       {
-        if (lowered_graph.graph().getOutputs().contains(ind))
-          continue;
         assert(def_map.find(ind) != def_map.end());
         if (def_map[ind])
         {
@@ -245,8 +237,6 @@ void Linear::planTensors(const ir::LoweredGraph &lowered_graph,
 
       for (const auto &ind : op.node->getInputs())
       {
-        if (lowered_graph.graph().getInputs().contains(ind))
-          continue;
         assert(uses_map.find(ind) != uses_map.end());
         assert(uses_map[ind] > 0);
         uses_map[ind]--;
@@ -259,7 +249,6 @@ void Linear::planTensors(const ir::LoweredGraph &lowered_graph,
   }
 
   // Dispose and validate
-  /*
   for (const auto &ind : graph.getOutputs())
   {
     --uses_map[ind];
@@ -268,7 +257,6 @@ void Linear::planTensors(const ir::LoweredGraph &lowered_graph,
       tensor_builder_map[ind]->notifyLastUse(ind);
     }
   }
-  */
 
   for (const auto &ind : constants)
   {

--- a/runtime/onert/core/src/exec/DataflowExecutor.cc
+++ b/runtime/onert/core/src/exec/DataflowExecutor.cc
@@ -77,9 +77,11 @@ bool DataflowExecutor::noWaitingJobs()
 }
 
 DataflowExecutor::DataflowExecutor(std::unique_ptr<ir::LoweredGraph> lowered_graph,
+                   const std::vector<std::shared_ptr<backend::UserTensor>> &input_tensors,
+                   const std::vector<std::shared_ptr<backend::UserTensor>> &output_tensors,
                                    const backend::TensorBuilderSet &tensor_builders,
                                    compiler::CodeMap &&code_map)
-    : ExecutorBase{std::move(lowered_graph), tensor_builders}, _code_map{std::move(code_map)},
+    : ExecutorBase{std::move(lowered_graph), input_tensors, output_tensors, tensor_builders}, _code_map{std::move(code_map)},
       _profiling{false}
 {
   VERBOSE(DataflowExecutor) << "Constructing Dataflow Executor" << std::endl;

--- a/runtime/onert/core/src/exec/DataflowExecutor.cc
+++ b/runtime/onert/core/src/exec/DataflowExecutor.cc
@@ -77,8 +77,8 @@ bool DataflowExecutor::noWaitingJobs()
 }
 
 DataflowExecutor::DataflowExecutor(std::unique_ptr<ir::LoweredGraph> lowered_graph,
-                   const std::vector<std::shared_ptr<backend::UserTensor>> &input_tensors,
-                   const std::vector<std::shared_ptr<backend::UserTensor>> &output_tensors,
+                   const std::vector<std::shared_ptr<backend::ITensor>> &input_tensors,
+                   const std::vector<std::shared_ptr<backend::ITensor>> &output_tensors,
                                    const backend::TensorBuilderSet &tensor_builders,
                                    compiler::CodeMap &&code_map)
     : ExecutorBase{std::move(lowered_graph), input_tensors, output_tensors, tensor_builders}, _code_map{std::move(code_map)},

--- a/runtime/onert/core/src/exec/DataflowExecutor.cc
+++ b/runtime/onert/core/src/exec/DataflowExecutor.cc
@@ -76,13 +76,13 @@ bool DataflowExecutor::noWaitingJobs()
                      [](const std::unique_ptr<Job> &job) { return job == nullptr; });
 }
 
-DataflowExecutor::DataflowExecutor(std::unique_ptr<ir::LoweredGraph> lowered_graph,
-                   const std::vector<std::shared_ptr<backend::ITensor>> &input_tensors,
-                   const std::vector<std::shared_ptr<backend::ITensor>> &output_tensors,
-                                   const backend::TensorBuilderSet &tensor_builders,
-                                   compiler::CodeMap &&code_map)
-    : ExecutorBase{std::move(lowered_graph), input_tensors, output_tensors, tensor_builders}, _code_map{std::move(code_map)},
-      _profiling{false}
+DataflowExecutor::DataflowExecutor(
+    std::unique_ptr<ir::LoweredGraph> lowered_graph,
+    const std::vector<std::shared_ptr<backend::ITensor>> &input_tensors,
+    const std::vector<std::shared_ptr<backend::ITensor>> &output_tensors,
+    const backend::TensorBuilderSet &tensor_builders, compiler::CodeMap &&code_map)
+    : ExecutorBase{std::move(lowered_graph), input_tensors, output_tensors, tensor_builders},
+      _code_map{std::move(code_map)}, _profiling{false}
 {
   VERBOSE(DataflowExecutor) << "Constructing Dataflow Executor" << std::endl;
 

--- a/runtime/onert/core/src/exec/DataflowExecutor.h
+++ b/runtime/onert/core/src/exec/DataflowExecutor.h
@@ -50,7 +50,10 @@ public:
    * @param code_map OpSequence and its code map
    */
   DataflowExecutor(std::unique_ptr<ir::LoweredGraph> lowered_graph,
-                   const backend::TensorBuilderSet &tensor_builders, compiler::CodeMap &&code_map);
+                   const std::vector<std::shared_ptr<backend::UserTensor>> &input_tensors,
+                   const std::vector<std::shared_ptr<backend::UserTensor>> &output_tensors,
+                   const backend::TensorBuilderSet &tensor_builders,
+                   compiler::CodeMap &&code_map);
 
   void executeImpl() override;
   void setProfilingMode(bool profiling) { _profiling = profiling; }

--- a/runtime/onert/core/src/exec/DataflowExecutor.h
+++ b/runtime/onert/core/src/exec/DataflowExecutor.h
@@ -50,8 +50,8 @@ public:
    * @param code_map OpSequence and its code map
    */
   DataflowExecutor(std::unique_ptr<ir::LoweredGraph> lowered_graph,
-                   const std::vector<std::shared_ptr<backend::UserTensor>> &input_tensors,
-                   const std::vector<std::shared_ptr<backend::UserTensor>> &output_tensors,
+                   const std::vector<std::shared_ptr<backend::ITensor>> &input_tensors,
+                   const std::vector<std::shared_ptr<backend::ITensor>> &output_tensors,
                    const backend::TensorBuilderSet &tensor_builders,
                    compiler::CodeMap &&code_map);
 

--- a/runtime/onert/core/src/exec/DataflowExecutor.h
+++ b/runtime/onert/core/src/exec/DataflowExecutor.h
@@ -52,8 +52,7 @@ public:
   DataflowExecutor(std::unique_ptr<ir::LoweredGraph> lowered_graph,
                    const std::vector<std::shared_ptr<backend::ITensor>> &input_tensors,
                    const std::vector<std::shared_ptr<backend::ITensor>> &output_tensors,
-                   const backend::TensorBuilderSet &tensor_builders,
-                   compiler::CodeMap &&code_map);
+                   const backend::TensorBuilderSet &tensor_builders, compiler::CodeMap &&code_map);
 
   void executeImpl() override;
   void setProfilingMode(bool profiling) { _profiling = profiling; }

--- a/runtime/onert/core/src/exec/ExecutorBase.cc
+++ b/runtime/onert/core/src/exec/ExecutorBase.cc
@@ -17,17 +17,44 @@
 #include "ExecutorBase.h"
 #include "util/logging.h"
 
+#include "backend/controlflow/operand/Tensor.h"
+
 namespace onert
 {
 namespace exec
 {
 
 ExecutorBase::ExecutorBase(std::unique_ptr<ir::LoweredGraph> &&lowered_graph,
-                           const std::vector<std::shared_ptr<backend::UserTensor>> &input_tensors,
-                           const std::vector<std::shared_ptr<backend::UserTensor>> &output_tensors,
+                           const std::vector<std::shared_ptr<backend::ITensor>> &input_tensors,
+                           const std::vector<std::shared_ptr<backend::ITensor>> &output_tensors,
                            const backend::TensorBuilderSet &tensor_builders)
     : _lowered_graph{std::move(lowered_graph)}, _graph{_lowered_graph->graph()}, _input_tensors{input_tensors}, _output_tensors{output_tensors}, _mutex()
 {
+  // TODO Fix the way of knowing whether it is primary or not
+  bool primary_executor = !(_input_tensors.empty() && _output_tensors.empty());
+  if (!primary_executor)
+  {
+    auto build_tensor_list = [&](const onert::ir::OperandIndexSequence &ind_seq) {
+      std::vector<std::shared_ptr<backend::ITensor>> list;
+      for (auto ind : ind_seq)
+      {
+        std::shared_ptr<backend::ITensor> tensor;
+        for (auto &tensor_builder : tensor_builders)
+        {
+          tensor = tensor_builder->tensorAt(ind);
+          if (tensor != nullptr)
+            break;
+        }
+        assert(tensor != nullptr);
+        list.push_back(tensor);
+      }
+      return list;
+    };
+
+    _input_tensors = build_tensor_list(_graph.getInputs());
+    _output_tensors = build_tensor_list(_graph.getOutputs());
+  }
+
   // Prepare each TensorManager on each backend
   for (auto &tensor_builder : tensor_builders)
   {
@@ -42,6 +69,27 @@ ExecutorBase::ExecutorBase(std::unique_ptr<ir::LoweredGraph> &&lowered_graph,
         _tensor_mgrs.insert(std::move(d_tensor_manager));
     }
   }
+}
+
+void ExecutorBase::changeInputShape(const ir::OperandIndex &index, const ir::Shape &new_shape)
+{
+  for (auto &input_tensor : _input_tensors)
+  {
+    auto dyn_alloc_info = _input_to_dyn_alloc_info.find(input_tensor);
+    if (dyn_alloc_info == _input_to_dyn_alloc_info.end())
+      continue;
+
+    // when user-provided input change is stored in _input_to_dyn_alloc_info
+    if (index == dyn_alloc_info->second.ind)
+    {
+      auto dyn_tensor_manager = dyn_alloc_info->second.dyn_tensor_manager;
+      assert(dyn_tensor_manager);
+      dyn_tensor_manager->changeShape(index, new_shape);
+      return;
+    }
+  }
+  throw std::runtime_error("changeInputShape(): Cannot find such index or "
+                           "check if the tensor's backend supports dynamic tensor.");
 }
 
 void ExecutorBase::execute()
@@ -65,16 +113,22 @@ void ExecutorBase::execute(const IODescription &desc)
   assert(_input_tensors.size() == desc.inputs.size());
   for (uint32_t i = 0; i < _input_tensors.size(); ++i)
   {
+    // TODO Remove dynamic_cast
+    auto tensor = std::dynamic_pointer_cast<backend::controlflow::operand::UserTensor>(_input_tensors[i]);
+    assert(tensor);
     // TODO Better design for ITensor? (we need const_cast as ITensor is writable)
-    _input_tensors[i]->setBuffer(static_cast<uint8_t *>(const_cast<void *>(desc.inputs[i]->buffer)),
+    tensor->setBuffer(static_cast<uint8_t *>(const_cast<void *>(desc.inputs[i]->buffer)),
                               desc.inputs[i]->size);
   }
 
   assert(_output_tensors.size() == desc.outputs.size());
   for (uint32_t i = 0; i < _output_tensors.size(); ++i)
   {
+    // TODO Remove dynamic_cast
+    auto tensor = std::dynamic_pointer_cast<backend::controlflow::operand::UserTensor>(_output_tensors[i]);
+    assert(tensor);
     // TODO Better design for ITensor? (we need const_cast as ITensor is writable)
-    _output_tensors[i]->setBuffer(static_cast<uint8_t *>(const_cast<void *>(desc.outputs[i]->buffer)),
+    tensor->setBuffer(static_cast<uint8_t *>(const_cast<void *>(desc.outputs[i]->buffer)),
                                desc.outputs[i]->size);
   }
 

--- a/runtime/onert/core/src/exec/ExecutorBase.cc
+++ b/runtime/onert/core/src/exec/ExecutorBase.cc
@@ -23,53 +23,11 @@ namespace exec
 {
 
 ExecutorBase::ExecutorBase(std::unique_ptr<ir::LoweredGraph> &&lowered_graph,
+                           const std::vector<std::shared_ptr<backend::UserTensor>> &input_tensors,
+                           const std::vector<std::shared_ptr<backend::UserTensor>> &output_tensors,
                            const backend::TensorBuilderSet &tensor_builders)
-    : _lowered_graph{std::move(lowered_graph)}, _graph{_lowered_graph->graph()}, _mutex()
+    : _lowered_graph{std::move(lowered_graph)}, _graph{_lowered_graph->graph()}, _input_tensors{input_tensors}, _output_tensors{output_tensors}, _mutex()
 {
-  auto build_input_tensor_list = [&](const onert::ir::OperandIndexSequence &ind_seq) {
-    std::vector<std::shared_ptr<backend::ITensor>> list;
-    for (auto ind : ind_seq)
-    {
-      std::shared_ptr<backend::ITensor> tensor;
-      for (auto &tensor_builder : tensor_builders)
-      {
-        tensor = tensor_builder->tensorAt(ind);
-        if (tensor != nullptr)
-        {
-          if (tensor_builder->supportDynamicTensor())
-          {
-            DynAllocInfo dyn_alloc_info{ind, tensor_builder->dynamicTensorManager()};
-            _input_to_dyn_alloc_info.emplace(tensor, dyn_alloc_info);
-          }
-          break;
-        }
-      }
-      assert(tensor != nullptr);
-      list.push_back(tensor);
-    }
-    return list;
-  };
-
-  auto build_output_tensor_list = [&](const onert::ir::OperandIndexSequence &ind_seq) {
-    std::vector<std::shared_ptr<backend::ITensor>> list;
-    for (auto ind : ind_seq)
-    {
-      std::shared_ptr<backend::ITensor> tensor;
-      for (auto &tensor_builder : tensor_builders)
-      {
-        tensor = tensor_builder->tensorAt(ind);
-        if (tensor != nullptr)
-          break;
-      }
-      assert(tensor != nullptr);
-      list.push_back(tensor);
-    }
-    return list;
-  };
-
-  _input_tensors = build_input_tensor_list(_graph.getInputs());
-  _output_tensors = build_output_tensor_list(_graph.getOutputs());
-
   // Prepare each TensorManager on each backend
   for (auto &tensor_builder : tensor_builders)
   {
@@ -84,74 +42,6 @@ ExecutorBase::ExecutorBase(std::unique_ptr<ir::LoweredGraph> &&lowered_graph,
         _tensor_mgrs.insert(std::move(d_tensor_manager));
     }
   }
-}
-
-std::unique_ptr<ISource> ExecutorBase::source(const ir::IOIndex &index, const ir::TypeInfo &type,
-                                              const void *buffer, size_t length,
-                                              ir::Layout io_layout)
-{
-  using ir::DataType;
-  switch (type.type())
-  {
-    case DataType::FLOAT32:
-      return source<float>(index, buffer, length, io_layout);
-    case DataType::INT32:
-      return source<int32_t>(index, buffer, length, io_layout);
-    case DataType::UINT32:
-      return source<uint32_t>(index, buffer, length, io_layout);
-    case DataType::BOOL8:
-    case DataType::QUANT8_ASYMM:
-    case DataType::UINT8:
-      return source<uint8_t>(index, buffer, length, io_layout);
-    case DataType::QUANT8_SYMM:
-      return source<int8_t>(index, buffer, length, io_layout);
-    default:
-      throw std::runtime_error("Not supported yet");
-  }
-}
-
-std::unique_ptr<ISink> ExecutorBase::sink(const ir::IOIndex &index, const ir::TypeInfo &type,
-                                          void *buffer, size_t length, ir::Layout io_layout)
-{
-  using ir::DataType;
-  switch (type.type())
-  {
-    case DataType::FLOAT32:
-      return sink<float>(index, buffer, length, io_layout);
-    case DataType::INT32:
-      return sink<int32_t>(index, buffer, length, io_layout);
-    case DataType::UINT32:
-      return sink<uint32_t>(index, buffer, length, io_layout);
-    case DataType::BOOL8:
-    case DataType::QUANT8_ASYMM:
-    case DataType::UINT8:
-      return sink<uint8_t>(index, buffer, length, io_layout);
-    case DataType::QUANT8_SYMM:
-      return sink<int8_t>(index, buffer, length, io_layout);
-    default:
-      throw std::runtime_error("Not supported yet");
-  }
-}
-
-void ExecutorBase::changeInputShape(const ir::OperandIndex &index, const ir::Shape &new_shape)
-{
-  for (auto &input_tensor : _input_tensors)
-  {
-    auto dyn_alloc_info = _input_to_dyn_alloc_info.find(input_tensor);
-    if (dyn_alloc_info == _input_to_dyn_alloc_info.end())
-      continue;
-
-    // when user-provided input change is stored in _input_to_dyn_alloc_info
-    if (index == dyn_alloc_info->second.ind)
-    {
-      auto dyn_tensor_manager = dyn_alloc_info->second.dyn_tensor_manager;
-      assert(dyn_tensor_manager);
-      dyn_tensor_manager->changeShape(index, new_shape);
-      return;
-    }
-  }
-  throw std::runtime_error("changeInputShape(): Cannot find such index or "
-                           "check if the tensor's backend supports dynamic tensor.");
 }
 
 void ExecutorBase::execute()
@@ -172,72 +62,23 @@ void ExecutorBase::execute(const IODescription &desc)
   //       do not need to use mutex (otherwise, use mutex)
   std::lock_guard<std::mutex> lock(_mutex);
 
-  std::vector<std::unique_ptr<ISource>> sources{_graph.getInputs().size()};
-  std::vector<std::unique_ptr<ISink>> sinks{_graph.getOutputs().size()};
-
-  // Set input(s)
-  for (uint32_t n = 0; n < _graph.getInputs().size(); ++n)
+  assert(_input_tensors.size() == desc.inputs.size());
+  for (uint32_t i = 0; i < _input_tensors.size(); ++i)
   {
-    ir::IOIndex input_index{n};
-    ir::OperandIndex index{_graph.getInputs().at(input_index)};
+    // TODO Better design for ITensor? (we need const_cast as ITensor is writable)
+    _input_tensors[i]->setBuffer(static_cast<uint8_t *>(const_cast<void *>(desc.inputs[i]->buffer)),
+                              desc.inputs[i]->size);
+  }
 
-    if (desc.inputs.at(n) == nullptr)
-    {
-      // Optional input
-      continue;
-    }
-
-    const auto operand_li = _lowered_graph->getLowerInfo()->operand.at(index).get();
-    if (operand_li->def_factors().empty())
-    {
-      // This input is not used (i.e. constant, EX. reshape's axis)
-      continue;
-    }
-
-    // when user changes input shape, the input tensor is dynamic and its memory is not allocated.
-    // This code find the info to allocate dynamic tensor, and allocate memory based on
-    // the input shape user set by calling nnfw_apply_tensorinfo(..)
-    auto shape_sig_found = desc.input_shape_signature.find(input_index);
-    if (shape_sig_found != desc.input_shape_signature.end())
-    {
-      auto dyn_alloc_info = _input_to_dyn_alloc_info.find(_input_tensors[n]);
-      if (dyn_alloc_info == _input_to_dyn_alloc_info.end())
-        throw std::runtime_error("Unknown dim is found at execution time for a backend that "
-                                 "does not support dynamic tensor");
-
-      auto changed_input_shape = shape_sig_found->second;
-      auto operand_ind = dyn_alloc_info->second.ind;
-      dyn_alloc_info->second.dyn_tensor_manager->allocate(operand_ind, changed_input_shape);
-    }
-
-    const auto &input = *desc.inputs.at(n);
-    sources.at(n) =
-        source(input_index, input.info.typeInfo(), input.buffer, input.size, input.layout);
-
-    auto setter = [&](::onert::backend::ITensor &tensor) { sources.at(n)->push(tensor); };
-
-    _input_tensors[n]->access(setter);
+  assert(_output_tensors.size() == desc.outputs.size());
+  for (uint32_t i = 0; i < _output_tensors.size(); ++i)
+  {
+    // TODO Better design for ITensor? (we need const_cast as ITensor is writable)
+    _output_tensors[i]->setBuffer(static_cast<uint8_t *>(const_cast<void *>(desc.outputs[i]->buffer)),
+                               desc.outputs[i]->size);
   }
 
   executeImpl();
-
-  // Get output(s)
-  for (uint32_t n = 0; n < _graph.getOutputs().size(); ++n)
-  {
-    ir::IOIndex output_index{n};
-    // Optional output
-    if (desc.outputs.at(n) == nullptr)
-    {
-      continue;
-    }
-    const auto &output = *desc.outputs.at(n);
-    sinks.at(n) =
-        sink(output_index, output.info.typeInfo(), output.buffer, output.size, output.layout);
-
-    auto getter = [&](::onert::backend::ITensor &tensor) { sinks.at(n)->pull(tensor); };
-
-    _output_tensors[n]->access(getter);
-  }
 }
 
 } // namespace exec

--- a/runtime/onert/core/src/exec/ExecutorBase.cc
+++ b/runtime/onert/core/src/exec/ExecutorBase.cc
@@ -28,7 +28,8 @@ ExecutorBase::ExecutorBase(std::unique_ptr<ir::LoweredGraph> &&lowered_graph,
                            const std::vector<std::shared_ptr<backend::ITensor>> &input_tensors,
                            const std::vector<std::shared_ptr<backend::ITensor>> &output_tensors,
                            const backend::TensorBuilderSet &tensor_builders)
-    : _lowered_graph{std::move(lowered_graph)}, _graph{_lowered_graph->graph()}, _input_tensors{input_tensors}, _output_tensors{output_tensors}, _mutex()
+    : _lowered_graph{std::move(lowered_graph)}, _graph{_lowered_graph->graph()},
+      _input_tensors{input_tensors}, _output_tensors{output_tensors}, _mutex()
 {
   // TODO Fix the way of knowing whether it is primary or not
   bool primary_executor = !(_input_tensors.empty() && _output_tensors.empty());
@@ -114,22 +115,24 @@ void ExecutorBase::execute(const IODescription &desc)
   for (uint32_t i = 0; i < _input_tensors.size(); ++i)
   {
     // TODO Remove dynamic_cast
-    auto tensor = std::dynamic_pointer_cast<backend::controlflow::operand::UserTensor>(_input_tensors[i]);
+    auto tensor =
+        std::dynamic_pointer_cast<backend::controlflow::operand::UserTensor>(_input_tensors[i]);
     assert(tensor);
     // TODO Better design for ITensor? (we need const_cast as ITensor is writable)
     tensor->setBuffer(static_cast<uint8_t *>(const_cast<void *>(desc.inputs[i]->buffer)),
-                              desc.inputs[i]->size);
+                      desc.inputs[i]->size);
   }
 
   assert(_output_tensors.size() == desc.outputs.size());
   for (uint32_t i = 0; i < _output_tensors.size(); ++i)
   {
     // TODO Remove dynamic_cast
-    auto tensor = std::dynamic_pointer_cast<backend::controlflow::operand::UserTensor>(_output_tensors[i]);
+    auto tensor =
+        std::dynamic_pointer_cast<backend::controlflow::operand::UserTensor>(_output_tensors[i]);
     assert(tensor);
     // TODO Better design for ITensor? (we need const_cast as ITensor is writable)
     tensor->setBuffer(static_cast<uint8_t *>(const_cast<void *>(desc.outputs[i]->buffer)),
-                               desc.outputs[i]->size);
+                      desc.outputs[i]->size);
   }
 
   executeImpl();

--- a/runtime/onert/core/src/exec/ExecutorBase.h
+++ b/runtime/onert/core/src/exec/ExecutorBase.h
@@ -50,8 +50,8 @@ public:
    * @param tensor_builders Tensor builders that are currently used
    */
   ExecutorBase(std::unique_ptr<ir::LoweredGraph> &&lowered_graph,
-               const std::vector<std::shared_ptr<backend::UserTensor>> &input_tensors,
-               const std::vector<std::shared_ptr<backend::UserTensor>> &output_tensors,
+               const std::vector<std::shared_ptr<backend::ITensor>> &input_tensors,
+               const std::vector<std::shared_ptr<backend::ITensor>> &output_tensors,
                const backend::TensorBuilderSet &tensor_builders);
 
   virtual ~ExecutorBase() = default;
@@ -105,8 +105,8 @@ protected:
   std::shared_ptr<ir::OperationIndexMap<int64_t>> _indexed_ranks;
   std::unique_ptr<ir::LoweredGraph> _lowered_graph;
   const ir::Graph &_graph;
-  std::vector<std::shared_ptr<backend::UserTensor>> _input_tensors;
-  std::vector<std::shared_ptr<backend::UserTensor>> _output_tensors;
+  std::vector<std::shared_ptr<backend::ITensor>> _input_tensors;
+  std::vector<std::shared_ptr<backend::ITensor>> _output_tensors;
   std::unordered_map<std::shared_ptr<backend::ITensor>, DynAllocInfo> _input_to_dyn_alloc_info;
   backend::TensorManagerSet _tensor_mgrs;
   std::mutex _mutex;

--- a/runtime/onert/core/src/exec/ExecutorBase.h
+++ b/runtime/onert/core/src/exec/ExecutorBase.h
@@ -50,6 +50,8 @@ public:
    * @param tensor_builders Tensor builders that are currently used
    */
   ExecutorBase(std::unique_ptr<ir::LoweredGraph> &&lowered_graph,
+               const std::vector<std::shared_ptr<backend::UserTensor>> &input_tensors,
+               const std::vector<std::shared_ptr<backend::UserTensor>> &output_tensors,
                const backend::TensorBuilderSet &tensor_builders);
 
   virtual ~ExecutorBase() = default;
@@ -81,54 +83,6 @@ public:
   }
 
 private:
-  std::unique_ptr<ISource> source(const ir::IOIndex &index, const ir::TypeInfo &type,
-                                  const void *buffer, size_t length, ir::Layout io_layout);
-  std::unique_ptr<ISink> sink(const ir::IOIndex &index, const ir::TypeInfo &type, void *buffer,
-                              size_t length, ir::Layout io_layout);
-
-  template <typename T>
-  std::unique_ptr<ISource> source(const ir::IOIndex &index, const void *buffer, size_t length,
-                                  ir::Layout io_layout)
-  {
-    const auto operand_index = _graph.getInputs().at(index);
-    const auto &operand = _graph.operands().at(operand_index);
-
-    const auto tensor = _input_tensors[index.value()];
-    const auto tensor_layout = tensor->layout();
-
-    if (((io_layout == ir::Layout::NHWC) && (tensor_layout == ir::Layout::NCHW)) ||
-        ((io_layout == ir::Layout::NCHW) && (tensor_layout == ir::Layout::NHWC)))
-    {
-      return std::make_unique<PermutateSource<T>>(buffer, length, operand.shape(), io_layout);
-    }
-    // TODO Change this to return error
-    assert(io_layout != ir::Layout::UNKNOWN ||
-           (tensor_layout != ir::Layout::NCHW && tensor_layout != ir::Layout::NCHW));
-
-    return std::make_unique<CopySource<T>>(buffer, length, operand.shape());
-  }
-
-  template <typename T>
-  std::unique_ptr<ISink> sink(const ir::IOIndex &index, void *buffer, size_t length,
-                              ir::Layout io_layout)
-  {
-    const auto operand_index = _graph.getOutputs().at(index);
-    const auto &operand = _graph.operands().at(operand_index);
-    const auto tensor = _output_tensors[index.value()];
-    const auto tensor_layout = tensor->layout();
-
-    if (((tensor_layout == ir::Layout::NCHW) && (io_layout == ir::Layout::NHWC)) ||
-        ((tensor_layout == ir::Layout::NHWC) && (io_layout == ir::Layout::NCHW)))
-    {
-      return std::make_unique<PermutateSink<T>>(buffer, length, operand.shape(), io_layout);
-    }
-    // TODO Change this to return error
-    assert(io_layout != ir::Layout::UNKNOWN ||
-           (tensor_layout != ir::Layout::NCHW && tensor_layout != ir::Layout::NCHW));
-
-    return std::make_unique<CopySink<T>>(buffer, length, operand.shape());
-  }
-
   void changeInputShape(const ir::OperandIndex &index, const ir::Shape &new_shape) override;
 
 protected:
@@ -151,8 +105,8 @@ protected:
   std::shared_ptr<ir::OperationIndexMap<int64_t>> _indexed_ranks;
   std::unique_ptr<ir::LoweredGraph> _lowered_graph;
   const ir::Graph &_graph;
-  std::vector<std::shared_ptr<backend::ITensor>> _input_tensors;
-  std::vector<std::shared_ptr<backend::ITensor>> _output_tensors;
+  std::vector<std::shared_ptr<backend::UserTensor>> _input_tensors;
+  std::vector<std::shared_ptr<backend::UserTensor>> _output_tensors;
   std::unordered_map<std::shared_ptr<backend::ITensor>, DynAllocInfo> _input_to_dyn_alloc_info;
   backend::TensorManagerSet _tensor_mgrs;
   std::mutex _mutex;

--- a/runtime/onert/core/src/exec/LinearExecutor.h
+++ b/runtime/onert/core/src/exec/LinearExecutor.h
@@ -47,9 +47,12 @@ public:
    * @param code_map OpSequence and its code map
    */
   LinearExecutor(std::unique_ptr<ir::LoweredGraph> lowered_graph,
-                 const backend::TensorBuilderSet &tensor_builders, compiler::CodeMap &&code_map,
+                 const std::vector<std::shared_ptr<backend::UserTensor>> &input_tensors,
+                 const std::vector<std::shared_ptr<backend::UserTensor>> &output_tensors,
+                 const backend::TensorBuilderSet &tensor_builders,
+                 compiler::CodeMap &&code_map,
                  const std::vector<ir::OpSequenceIndex> &order)
-      : ExecutorBase{std::move(lowered_graph), tensor_builders}
+      : ExecutorBase{std::move(lowered_graph), input_tensors, output_tensors, tensor_builders}
   {
     for (auto index : order)
     {

--- a/runtime/onert/core/src/exec/LinearExecutor.h
+++ b/runtime/onert/core/src/exec/LinearExecutor.h
@@ -47,8 +47,8 @@ public:
    * @param code_map OpSequence and its code map
    */
   LinearExecutor(std::unique_ptr<ir::LoweredGraph> lowered_graph,
-                 const std::vector<std::shared_ptr<backend::UserTensor>> &input_tensors,
-                 const std::vector<std::shared_ptr<backend::UserTensor>> &output_tensors,
+                 const std::vector<std::shared_ptr<backend::ITensor>> &input_tensors,
+                 const std::vector<std::shared_ptr<backend::ITensor>> &output_tensors,
                  const backend::TensorBuilderSet &tensor_builders,
                  compiler::CodeMap &&code_map,
                  const std::vector<ir::OpSequenceIndex> &order)

--- a/runtime/onert/core/src/exec/LinearExecutor.h
+++ b/runtime/onert/core/src/exec/LinearExecutor.h
@@ -49,8 +49,7 @@ public:
   LinearExecutor(std::unique_ptr<ir::LoweredGraph> lowered_graph,
                  const std::vector<std::shared_ptr<backend::ITensor>> &input_tensors,
                  const std::vector<std::shared_ptr<backend::ITensor>> &output_tensors,
-                 const backend::TensorBuilderSet &tensor_builders,
-                 compiler::CodeMap &&code_map,
+                 const backend::TensorBuilderSet &tensor_builders, compiler::CodeMap &&code_map,
                  const std::vector<ir::OpSequenceIndex> &order)
       : ExecutorBase{std::move(lowered_graph), input_tensors, output_tensors, tensor_builders}
   {

--- a/runtime/onert/core/src/exec/ParallelExecutor.cc
+++ b/runtime/onert/core/src/exec/ParallelExecutor.cc
@@ -61,9 +61,11 @@ void ParallelExecutor::notify(uint32_t finished_job_id)
 }
 
 ParallelExecutor::ParallelExecutor(std::unique_ptr<ir::LoweredGraph> lowered_graph,
+                   const std::vector<std::shared_ptr<backend::UserTensor>> &input_tensors,
+                   const std::vector<std::shared_ptr<backend::UserTensor>> &output_tensors,
                                    const backend::TensorBuilderSet &tensor_builders,
                                    compiler::CodeMap &&code_map)
-    : DataflowExecutor{std::move(lowered_graph), tensor_builders, std::move(code_map)}
+    : DataflowExecutor{std::move(lowered_graph), input_tensors, output_tensors, tensor_builders, std::move(code_map)}
 {
   VERBOSE(ParallelExecutor) << "Constructing Parallel Executor" << std::endl;
 }

--- a/runtime/onert/core/src/exec/ParallelExecutor.cc
+++ b/runtime/onert/core/src/exec/ParallelExecutor.cc
@@ -61,8 +61,8 @@ void ParallelExecutor::notify(uint32_t finished_job_id)
 }
 
 ParallelExecutor::ParallelExecutor(std::unique_ptr<ir::LoweredGraph> lowered_graph,
-                   const std::vector<std::shared_ptr<backend::UserTensor>> &input_tensors,
-                   const std::vector<std::shared_ptr<backend::UserTensor>> &output_tensors,
+                   const std::vector<std::shared_ptr<backend::ITensor>> &input_tensors,
+                   const std::vector<std::shared_ptr<backend::ITensor>> &output_tensors,
                                    const backend::TensorBuilderSet &tensor_builders,
                                    compiler::CodeMap &&code_map)
     : DataflowExecutor{std::move(lowered_graph), input_tensors, output_tensors, tensor_builders, std::move(code_map)}

--- a/runtime/onert/core/src/exec/ParallelExecutor.cc
+++ b/runtime/onert/core/src/exec/ParallelExecutor.cc
@@ -60,12 +60,13 @@ void ParallelExecutor::notify(uint32_t finished_job_id)
   _cv_jobs.notify_all();
 }
 
-ParallelExecutor::ParallelExecutor(std::unique_ptr<ir::LoweredGraph> lowered_graph,
-                   const std::vector<std::shared_ptr<backend::ITensor>> &input_tensors,
-                   const std::vector<std::shared_ptr<backend::ITensor>> &output_tensors,
-                                   const backend::TensorBuilderSet &tensor_builders,
-                                   compiler::CodeMap &&code_map)
-    : DataflowExecutor{std::move(lowered_graph), input_tensors, output_tensors, tensor_builders, std::move(code_map)}
+ParallelExecutor::ParallelExecutor(
+    std::unique_ptr<ir::LoweredGraph> lowered_graph,
+    const std::vector<std::shared_ptr<backend::ITensor>> &input_tensors,
+    const std::vector<std::shared_ptr<backend::ITensor>> &output_tensors,
+    const backend::TensorBuilderSet &tensor_builders, compiler::CodeMap &&code_map)
+    : DataflowExecutor{std::move(lowered_graph), input_tensors, output_tensors, tensor_builders,
+                       std::move(code_map)}
 {
   VERBOSE(ParallelExecutor) << "Constructing Parallel Executor" << std::endl;
 }

--- a/runtime/onert/core/src/exec/ParallelExecutor.h
+++ b/runtime/onert/core/src/exec/ParallelExecutor.h
@@ -51,7 +51,10 @@ public:
    * @param code_map OpSequence and its code map
    */
   ParallelExecutor(std::unique_ptr<ir::LoweredGraph> lowered_graph,
-                   const backend::TensorBuilderSet &tensor_builders, compiler::CodeMap &&code_map);
+                   const std::vector<std::shared_ptr<backend::UserTensor>> &input_tensors,
+                   const std::vector<std::shared_ptr<backend::UserTensor>> &output_tensors,
+                   const backend::TensorBuilderSet &tensor_builders,
+                   compiler::CodeMap &&code_map);
 
   void executeImpl() override;
 

--- a/runtime/onert/core/src/exec/ParallelExecutor.h
+++ b/runtime/onert/core/src/exec/ParallelExecutor.h
@@ -53,8 +53,7 @@ public:
   ParallelExecutor(std::unique_ptr<ir::LoweredGraph> lowered_graph,
                    const std::vector<std::shared_ptr<backend::ITensor>> &input_tensors,
                    const std::vector<std::shared_ptr<backend::ITensor>> &output_tensors,
-                   const backend::TensorBuilderSet &tensor_builders,
-                   compiler::CodeMap &&code_map);
+                   const backend::TensorBuilderSet &tensor_builders, compiler::CodeMap &&code_map);
 
   void executeImpl() override;
 

--- a/runtime/onert/core/src/exec/ParallelExecutor.h
+++ b/runtime/onert/core/src/exec/ParallelExecutor.h
@@ -51,8 +51,8 @@ public:
    * @param code_map OpSequence and its code map
    */
   ParallelExecutor(std::unique_ptr<ir::LoweredGraph> lowered_graph,
-                   const std::vector<std::shared_ptr<backend::UserTensor>> &input_tensors,
-                   const std::vector<std::shared_ptr<backend::UserTensor>> &output_tensors,
+                   const std::vector<std::shared_ptr<backend::ITensor>> &input_tensors,
+                   const std::vector<std::shared_ptr<backend::ITensor>> &output_tensors,
                    const backend::TensorBuilderSet &tensor_builders,
                    compiler::CodeMap &&code_map);
 

--- a/runtime/onert/core/src/ir/LoweredGraph.cc
+++ b/runtime/onert/core/src/ir/LoweredGraph.cc
@@ -280,7 +280,6 @@ void LoweredGraph::makeOpSequences(
 void LoweredGraph::manipulateLowerInfo(
     OperandIndexMap<std::unique_ptr<operand::LowerInfo>> &operands_lower_info)
 {
-#if 0
   const auto controlflow_backend = compiler::BackendManager::get().getControlflow();
   for (auto index : _graph.getInputs())
   {
@@ -302,7 +301,6 @@ void LoweredGraph::manipulateLowerInfo(
       });
     }
   }
-#endif
 
 #if 0
   // nullptr means external tensor
@@ -317,6 +315,20 @@ void LoweredGraph::manipulateLowerInfo(
   {
     auto &&lower_info = operands_lower_info.at(index);
     lower_info->addUsePermuteFactor(operand::PermuteFactor{io_backend, Layout::NHWC /* XXX Get frontend layout */});
+  }
+#endif
+
+#if 0
+  const auto cf_backend = compiler::BackendManager::get().getControlflow();
+  for (auto index : _graph.getInputs())
+  {
+    auto &&lower_info = operands_lower_info.at(index);
+    lower_info->addDefPermuteFactor(operand::PermuteFactor{cf_backend, Layout::NHWC /* XXX Get frontend layout */});
+  }
+  for (auto index : _graph.getOutputs())
+  {
+    auto &&lower_info = operands_lower_info.at(index);
+    lower_info->addUsePermuteFactor(operand::PermuteFactor{cf_backend, Layout::NHWC /* XXX Get frontend layout */});
   }
 #endif
 

--- a/runtime/onert/core/src/ir/LoweredGraph.cc
+++ b/runtime/onert/core/src/ir/LoweredGraph.cc
@@ -235,6 +235,8 @@ void LoweredGraph::makeOpSequences(
 
         for (auto operand : node.getInputs())
         {
+          if (graph().getInputs().contains(operand))
+            continue;
           auto &&lower_info = operands_lower_info.at(operand);
           lower_info->addUsePermuteFactor(operand::PermuteFactor{backend, backend_layout});
         }
@@ -284,8 +286,8 @@ void LoweredGraph::manipulateLowerInfo(
     // Pick just any one from the uses, here the first one is chosen
     // For the other uses, Permute operations will be inserted later
     auto &&lower_info = operands_lower_info.at(index);
-    assert(lower_info->use_factors().size() > 0);
-    lower_info->addDefPermuteFactor(*lower_info->use_factors().begin());
+    if (!lower_info->use_factors().empty())
+      lower_info->addDefPermuteFactor(*lower_info->use_factors().begin());
   }
   for (auto index : _graph.getOutputs())
   {

--- a/runtime/onert/core/src/ir/LoweredGraph.cc
+++ b/runtime/onert/core/src/ir/LoweredGraph.cc
@@ -235,8 +235,8 @@ void LoweredGraph::makeOpSequences(
 
         for (auto operand : node.getInputs())
         {
-          if (graph().getInputs().contains(operand))
-            continue;
+          //if (graph().getInputs().contains(operand))
+          //  continue;
           auto &&lower_info = operands_lower_info.at(operand);
           lower_info->addUsePermuteFactor(operand::PermuteFactor{backend, backend_layout});
         }
@@ -280,6 +280,7 @@ void LoweredGraph::makeOpSequences(
 void LoweredGraph::manipulateLowerInfo(
     OperandIndexMap<std::unique_ptr<operand::LowerInfo>> &operands_lower_info)
 {
+#if 0
   const auto controlflow_backend = compiler::BackendManager::get().getControlflow();
   for (auto index : _graph.getInputs())
   {
@@ -301,6 +302,23 @@ void LoweredGraph::manipulateLowerInfo(
       });
     }
   }
+#endif
+
+#if 0
+  // nullptr means external tensor
+  // TODO Do a better way to handle I/O tensors
+  const backend::Backend * const io_backend = nullptr;
+  for (auto index : _graph.getInputs())
+  {
+    auto &&lower_info = operands_lower_info.at(index);
+    lower_info->addDefPermuteFactor(operand::PermuteFactor{io_backend, Layout::NHWC /* XXX Get frontend layout */});
+  }
+  for (auto index : _graph.getOutputs())
+  {
+    auto &&lower_info = operands_lower_info.at(index);
+    lower_info->addUsePermuteFactor(operand::PermuteFactor{io_backend, Layout::NHWC /* XXX Get frontend layout */});
+  }
+#endif
 
   // Set LowerInfo for each operand from the operand::LowerInfo holder
   _graph.operands().iterate([&](const OperandIndex &index, Operand &) {

--- a/runtime/onert/core/src/ir/LoweredGraph.cc
+++ b/runtime/onert/core/src/ir/LoweredGraph.cc
@@ -235,7 +235,7 @@ void LoweredGraph::makeOpSequences(
 
         for (auto operand : node.getInputs())
         {
-          //if (graph().getInputs().contains(operand))
+          // if (graph().getInputs().contains(operand))
           //  continue;
           auto &&lower_info = operands_lower_info.at(operand);
           lower_info->addUsePermuteFactor(operand::PermuteFactor{backend, backend_layout});
@@ -286,7 +286,8 @@ void LoweredGraph::manipulateLowerInfo(
     auto &&lower_info = operands_lower_info.at(index);
     if (is_primary)
     {
-      // TODO Rather than handling primary graph specially, let the permute inserted and remove it later
+      // TODO Rather than handling primary graph specially, let the permute inserted and remove it
+      // later
       lower_info->addDefPermuteFactor(operand::PermuteFactor{controlflow_backend, Layout::NHWC});
     }
     else
@@ -302,7 +303,8 @@ void LoweredGraph::manipulateLowerInfo(
     auto &&lower_info = operands_lower_info.at(index);
     if (is_primary)
     {
-      // TODO Rather than handling primary graph specially, let the permute inserted and remove it later
+      // TODO Rather than handling primary graph specially, let the permute inserted and remove it
+      // later
       lower_info->addUsePermuteFactor(operand::PermuteFactor{controlflow_backend, Layout::NHWC});
     }
   }

--- a/runtime/onert/core/src/ir/OperandIndexSequence.cc
+++ b/runtime/onert/core/src/ir/OperandIndexSequence.cc
@@ -51,7 +51,14 @@ bool OperandIndexSequence::contains(const OperandIndex &index) const
 
 void OperandIndexSequence::replace(const OperandIndex &from, const OperandIndex &to)
 {
-  std::replace(_set.begin(), _set.end(), from, to);
+  for (auto &v : _set)
+  {
+    if (v == from)
+    {
+      v = to;
+      break;
+    }
+  }
 }
 
 OperandIndexSequence OperandIndexSequence::operator+(const OperandIndexSequence &other) const

--- a/runtime/onert/core/src/ir/pass/PermutationInsertionPass.cc
+++ b/runtime/onert/core/src/ir/pass/PermutationInsertionPass.cc
@@ -64,10 +64,8 @@ void PermutationInsertionPass::callback(const OperandIndex &index, Operand &obje
     {
       // If some conditions are met, it doesn't have to insert Permute
       // XXX This is just for draft, test if this work
-      if (factor.layout() == def_factor.layout() &&
-          factor.backend()->config()->id() == "cpu" && def_factor.backend()->config()->id() == "controlflow" || // XXX
-          def_factor.backend()->config()->id() == "cpu" && factor.backend()->config()->id() == "controlflow"
-          )
+      if (factor.layout() == def_factor.layout() && factor.backend()->config()->id() == "cpu" &&
+          def_factor.backend()->config()->id() == "controlflow")
       {
         factor_to_index.emplace(factor, index);
         continue;
@@ -198,8 +196,12 @@ OperationIndex PermutationInsertionPass::insertPermute(const OperandIndex &opera
   auto insert_node = std::make_unique<Permute>(operand_index, out_operand_index, input_backend_ctx,
                                                output_backend_ctx, permute_type);
   VERBOSE(PermutationInsertionPass) << "Permute Op inserted " << std::endl;
-  VERBOSE(PermutationInsertionPass) << "  - Input  : Backend '" << input_backend_ctx->backend()->config()->id() << "' Operand " << operand_index.value() << std::endl;
-  VERBOSE(PermutationInsertionPass) << "  - Output : Backend '" << output_backend_ctx->backend()->config()->id() << "' Operand " << out_operand_index.value() << std::endl;
+  VERBOSE(PermutationInsertionPass) << "  - Input  : Backend '"
+                                    << input_backend_ctx->backend()->config()->id() << "' Operand "
+                                    << operand_index.value() << std::endl;
+  VERBOSE(PermutationInsertionPass) << "  - Output : Backend '"
+                                    << output_backend_ctx->backend()->config()->id() << "' Operand "
+                                    << out_operand_index.value() << std::endl;
 
   auto node_index = _graph.operations().push(std::move(insert_node));
   const auto &node = _graph.operations().at(node_index);

--- a/runtime/onert/core/src/ir/pass/PermutationInsertionPass.cc
+++ b/runtime/onert/core/src/ir/pass/PermutationInsertionPass.cc
@@ -185,6 +185,9 @@ OperationIndex PermutationInsertionPass::insertPermute(const OperandIndex &opera
   }();
   auto insert_node = std::make_unique<Permute>(operand_index, out_operand_index, input_backend_ctx,
                                                output_backend_ctx, permute_type);
+  VERBOSE(PermutationInsertionPass) << "Permute Op inserted " << std::endl;
+  VERBOSE(PermutationInsertionPass) << "  - Input  : Backend '" << input_backend_ctx->backend()->config()->id() << "' Operand " << operand_index.value() << std::endl;
+  VERBOSE(PermutationInsertionPass) << "  - Output : Backend '" << output_backend_ctx->backend()->config()->id() << "' Operand " << out_operand_index.value() << std::endl;
 
   auto node_index = _graph.operations().push(std::move(insert_node));
   const auto &node = _graph.operations().at(node_index);

--- a/runtime/onert/core/src/ir/pass/PermutationInsertionPass.cc
+++ b/runtime/onert/core/src/ir/pass/PermutationInsertionPass.cc
@@ -133,8 +133,8 @@ OperationIndex PermutationInsertionPass::insertPermute(const OperandIndex &opera
   }
 
   // Find Permute information
-  auto input_backend =
-      _lowered_graph.getLowerInfo(operand_index)->def_factors().getOnlyElement().backend();
+  auto input_factor = _lowered_graph.getLowerInfo(operand_index)->def_factors().getOnlyElement();
+  auto input_backend = input_factor.backend();
   auto output_backend = factor.backend();
   // NOTE Permute may not have specific layout because the layout of input and output may be
   // different.
@@ -166,8 +166,7 @@ OperationIndex PermutationInsertionPass::insertPermute(const OperandIndex &opera
   auto output_backend_ctx = _lowered_graph.backend_contexts().at(output_backend).get();
 
   // Insert permute operation to the graph
-  const auto input_layout =
-      _lowered_graph.getLowerInfo(operand_index)->def_factors().getOnlyElement().layout();
+  const auto input_layout = input_factor.layout();
   const auto output_layout = factor.layout();
   using Permute = operation::Permute;
   const auto permute_type = [&]() {

--- a/runtime/onert/core/src/ir/pass/PermutationInsertionPass.cc
+++ b/runtime/onert/core/src/ir/pass/PermutationInsertionPass.cc
@@ -59,8 +59,20 @@ void PermutationInsertionPass::callback(const OperandIndex &index, Operand &obje
     }
 
     auto insert_set = operand_li->use_factors() - operand_li->def_factors();
+    auto def_factor = operand_li->def_factors().getOnlyElement();
     for (auto factor : insert_set)
     {
+      // If some conditions are met, it doesn't have to insert Permute
+      // XXX This is just for draft, test if this work
+      if (factor.layout() == def_factor.layout() &&
+          factor.backend()->config()->id() == "cpu" && def_factor.backend()->config()->id() == "controlflow" || // XXX
+          def_factor.backend()->config()->id() == "cpu" && factor.backend()->config()->id() == "controlflow"
+          )
+      {
+        factor_to_index.emplace(factor, index);
+        continue;
+      }
+
       const auto permute_operation_index = insertPermute(index, factor);
       permute_indexes.push_back(permute_operation_index);
       VERBOSE(PermutationInsertionPass) << "Insert 'Permute' operation for operand "

--- a/runtime/onert/core/src/util/ShapeInference.cc
+++ b/runtime/onert/core/src/util/ShapeInference.cc
@@ -386,7 +386,7 @@ void DynamicInferer::visit(const ir::operation::Reshape &op)
 {
   // check if output is not dynamic
   auto output_ind = op.getOutputs().at(0);
-  auto *output = _tensor_registry->getITensor(output_ind);
+  auto *output = _tensor_registry->getITensor(output_ind).get();
   if (!output->is_dynamic())
     return;
 
@@ -417,7 +417,7 @@ void DynamicInferer::visit(const ir::operation::Reshape &op)
   // sanity check
   {
     auto input_ind = op.getInputs().at(ir::operation::Reshape::Input::INPUT);
-    auto input = _tensor_registry->getITensor(input_ind);
+    auto input = _tensor_registry->getITensor(input_ind).get();
     assert(input);
 
     if (!isReshapableShape(input, output_shape))
@@ -438,13 +438,13 @@ void DynamicInferer::visit(const ir::operation::Tanh &op)
 {
   // check if output is not dynamic
   auto output_ind = op.getOutputs().at(0);
-  auto *output = _tensor_registry->getITensor(output_ind);
+  auto *output = _tensor_registry->getITensor(output_ind).get();
   if (!output->is_dynamic())
     return;
 
   // getting output shape
   auto input_ind = op.getInputs().at(ir::operation::Tanh::Input::INPUT);
-  auto *input = _tensor_registry->getITensor(input_ind);
+  auto *input = _tensor_registry->getITensor(input_ind).get();
   auto output_shape = getShape(input);
 
   // set output shape and output buffer


### PR DESCRIPTION
#677 

## TL;DR

- A backend can have `ITensor` of other backends
- `controlflow` backend(builtin backend) is used to manage user tensors
- Running copies on starting execution(Source/Sink) is removed and it will be expressed in Graph IR(Permute layers are added)

## NOTABLE CHANGES

- **Extend `ITensorRegistry` to have external tensor** (tensors that are managed by other backends)
    - This will be also useful for optimizing copies between subgraph calls
    - This will be also useful for optimizing permutes between backends 
    - FUTURE: Do we need a unified TensorRegistry rather than having them for each backend?
- **Use `controlflow` backend's `ITensorBuilder`** for user's I/O tensors
    - So `controlflow` backend will be loaded always
- **Remove Source/Sink(which always required copies) in `ExecutorBase::execute`**
    - Rather than doing this by executor, let's have them in Graph IR!
    - So Permute operations are added when necessary (It is done by `PermutationInsetionPass`)
- We no have some code branch in LoweredGraph/Executor for primary/non-primary  graphs
- cpu backend's layers accept `backend::ITensor` rather than `backend::cpu::operand::Tensor`
    - If a backend wants to avoid copying between backend changes, this is required
    - So `dynamic_cast`s are required to use their own tensor's features
