### PR TITLE
[onert] Make `getITensor` return `shared_ptr`

### DIFF
--- a/runtime/onert/backend/cpu/TensorRegistry.h
+++ b/runtime/onert/backend/cpu/TensorRegistry.h
@@ -38,7 +38,7 @@ public:
    * @brief Returns pointer of ITensor
    * @note  Returned tensor cannot be used longer than dynamic tensor manager
    */
-  ITensor *getITensor(const ir::OperandIndex &ind) override { return at(ind).get(); }
+  std::shared_ptr<ITensor> getITensor(const ir::OperandIndex &ind) override { return at(ind); }
 };
 
 } // namespace cpu

--- a/runtime/onert/core/include/backend/ITensorRegistry.h
+++ b/runtime/onert/core/include/backend/ITensorRegistry.h
@@ -36,7 +36,7 @@ struct ITensorRegistry
    * @brief Returns pointer of ITensor
    * @note  Return tensor cannot be used longer than dynamic tensor manager
    */
-  virtual ITensor *getITensor(const ir::OperandIndex &) = 0;
+  virtual std::shared_ptr<ITensor> getITensor(const ir::OperandIndex &) = 0;
 };
 
 } // namespace backend

--- a/runtime/onert/core/src/util/shapeinf/Add.cc
+++ b/runtime/onert/core/src/util/shapeinf/Add.cc
@@ -45,22 +45,22 @@ void DynamicInferer::visit(const ir::operation::Add &op)
 {
   // check if output is not dynamic
   auto output_ind = op.getOutputs().at(0);
-  auto *output = _tensor_registry->getITensor(output_ind);
+  auto output = _tensor_registry->getITensor(output_ind);
   if (!output->is_dynamic())
     return;
 
   // getting output shape
   const auto lhs_ind{op.getInputs().at(ir::operation::Add::Input::LHS)};
-  auto *lhs = _tensor_registry->getITensor(lhs_ind);
-  auto lhs_shape = getShape(lhs);
+  auto lhs = _tensor_registry->getITensor(lhs_ind);
+  auto lhs_shape = getShape(lhs.get());
 
   const auto rhs_ind{op.getInputs().at(ir::operation::Add::Input::RHS)};
-  auto *rhs = _tensor_registry->getITensor(rhs_ind);
-  auto rhs_shape = getShape(rhs);
+  auto rhs = _tensor_registry->getITensor(rhs_ind);
+  auto rhs_shape = getShape(rhs.get());
 
   // set output shape and output buffer
   ir::Shape new_shape = inferEltwiseShape(lhs_shape, rhs_shape);
-  setShape(output, new_shape);
+  setShape(output.get(), new_shape);
 
   _dynamic_tensor_manager->allocate(output_ind, new_shape);
   assert(output->buffer() != nullptr);

--- a/runtime/onert/core/src/util/shapeinf/Reshape.cc
+++ b/runtime/onert/core/src/util/shapeinf/Reshape.cc
@@ -83,7 +83,7 @@ void DynamicInferer::visit(const ir::operation::Reshape &op)
 {
   // check if output is not dynamic
   auto output_ind = op.getOutputs().at(0);
-  auto *output = _tensor_registry->getITensor(output_ind);
+  auto output = _tensor_registry->getITensor(output_ind);
   if (!output->is_dynamic())
     return;
 
@@ -117,12 +117,12 @@ void DynamicInferer::visit(const ir::operation::Reshape &op)
     auto input = _tensor_registry->getITensor(input_ind);
     assert(input);
 
-    if (!isReshapableShape(input, output_shape))
+    if (!isReshapableShape(input.get(), output_shape))
       throw std::runtime_error("Reshape: 2nd param is not compatible with the shape of input");
   }
 
   // set output shape and output buffer
-  setShape(output, output_shape);
+  setShape(output.get(), output_shape);
 
   _dynamic_tensor_manager->allocate(output_ind, output_shape);
   assert(output->buffer() != nullptr);

--- a/runtime/onert/core/src/util/shapeinf/Tanh.cc
+++ b/runtime/onert/core/src/util/shapeinf/Tanh.cc
@@ -46,17 +46,17 @@ void DynamicInferer::visit(const ir::operation::Tanh &op)
 {
   // check if output is not dynamic
   auto output_ind = op.getOutputs().at(0);
-  auto *output = _tensor_registry->getITensor(output_ind);
+  auto output = _tensor_registry->getITensor(output_ind);
   if (!output->is_dynamic())
     return;
 
   // getting output shape
   auto input_ind = op.getInputs().at(ir::operation::Tanh::Input::INPUT);
-  auto *input = _tensor_registry->getITensor(input_ind);
-  auto output_shape = getShape(input);
+  auto input = _tensor_registry->getITensor(input_ind);
+  auto output_shape = getShape(input.get());
 
   // set output shape and output buffer
-  setShape(output, output_shape);
+  setShape(output.get(), output_shape);
 
   _dynamic_tensor_manager->allocate(output_ind, output_shape);
   assert(output->buffer() != nullptr);


### PR DESCRIPTION
Make `ITensorRegistry::getITensor` return `shared_ptr` rather than a raw
pointer. This method will be used to share ownership with other
backends.

Related : #1325

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>