### PR TITLE
[onert] Change naming replacing inputs

### DIFF
--- a/runtime/onert/core/include/ir/OpSequence.h
+++ b/runtime/onert/core/include/ir/OpSequence.h
@@ -58,8 +58,11 @@ public:
   const OperandIndexSequence &getOutputs() const { return _outputs; }
   void setInputs(const OperandIndexSequence &indexes) { _inputs = indexes; }
   void setOutputs(const OperandIndexSequence &indexes) { _outputs = indexes; }
-  void replaceInput(const OperandIndex &from, const OperandIndex &to) { _inputs.replace(from, to); }
-  void replaceOutput(const OperandIndex &from, const OperandIndex &to)
+  void replaceInputs(const OperandIndex &from, const OperandIndex &to)
+  {
+    _inputs.replace(from, to);
+  }
+  void replaceOutputs(const OperandIndex &from, const OperandIndex &to)
   {
     _outputs.replace(from, to);
   }

--- a/runtime/onert/core/include/ir/Operation.h
+++ b/runtime/onert/core/include/ir/Operation.h
@@ -51,8 +51,8 @@ public:
   virtual OpCode opcode() const = 0;
 
 public:
-  void replaceInput(const OperandIndex &from, const OperandIndex &to);
-  void replaceOutput(const OperandIndex &from, const OperandIndex &to);
+  void replaceInputs(const OperandIndex &from, const OperandIndex &to);
+  void replaceOutputs(const OperandIndex &from, const OperandIndex &to);
   OperandIndexSequence &getInputs() { return _inputs; }
   const OperandIndexSequence &getInputs() const { return _inputs; }
   const OperandIndexSequence &getOutputs() const { return _outputs; }

--- a/runtime/onert/core/src/compiler/Fp32ToFp16Converter.cc
+++ b/runtime/onert/core/src/compiler/Fp32ToFp16Converter.cc
@@ -222,7 +222,19 @@ void Fp32ToFp16Converter::appendNewOpSeqForConvertFp32ToFp16(const ir::OpSequenc
 {
   // OpSeq's input set is included in the first operation's input set
   const ir::OperandIndexSequence op_seq_inputs = op_seq.getInputs(); // copied
-  for (const auto &op_seq_input_ind : op_seq_inputs)
+
+  // Remove duplicated input
+  // NOTE Please do not change sequence of op_seq_inputs. It can change the sequence of inputs of
+  // Subgraph
+  ir::OperandIndexSequence no_dup_inputs;
+  for (const auto &ind : op_seq_inputs)
+  {
+    if (!no_dup_inputs.contains(ind))
+    {
+      no_dup_inputs.append(ind);
+    }
+  }
+  for (const auto &op_seq_input_ind : no_dup_inputs)
   {
     if (checkOperandType(op_seq_input_ind) == false)
       continue;
@@ -290,7 +302,19 @@ void Fp32ToFp16Converter::appendNewOpSeqForConvertFp16ToFp32(const ir::OpSequenc
 {
   // OpSeq's output set is included in the last operation's output set
   const ir::OperandIndexSequence op_seq_outputs = op_seq.getOutputs(); // copied
-  for (const auto &op_seq_output_ind : op_seq_outputs)
+
+  // Remove duplicated input
+  // NOTE Please do not change sequence of op_seq_outputs. It can change the sequence of outputs of
+  // Subgraph
+  ir::OperandIndexSequence no_dup_outputs;
+  for (const auto &ind : op_seq_outputs)
+  {
+    if (!no_dup_outputs.contains(ind))
+    {
+      no_dup_outputs.append(ind);
+    }
+  }
+  for (const auto &op_seq_output_ind : no_dup_outputs)
   {
     if (checkOperandType(op_seq_output_ind) == false)
       continue;
@@ -535,8 +559,8 @@ void Fp32ToFp16Converter::manipulateInput(const ir::OpSequenceIndex &op_seq_ind,
 
   auto &new_op_obj = operands.at(new_op_ind);
 
-  op_seq.replaceInput(op_seq_input_ind, new_op_ind);
-  first_node.replaceInput(op_seq_input_ind, new_op_ind);
+  op_seq.replaceInputs(op_seq_input_ind, new_op_ind);
+  first_node.replaceInputs(op_seq_input_ind, new_op_ind);
 
   // op_seq_obj doesn't have uses/def
   input_obj.removeUse(first_node_ind);
@@ -562,8 +586,8 @@ void Fp32ToFp16Converter::manipulateOutput(const ir::OpSequenceIndex &op_seq_ind
 
   auto &new_op_obj = operands.at(new_op_ind);
 
-  op_seq.replaceOutput(op_seq_output_ind, new_op_ind);
-  last_node.replaceOutput(op_seq_output_ind, new_op_ind);
+  op_seq.replaceOutputs(op_seq_output_ind, new_op_ind);
+  last_node.replaceOutputs(op_seq_output_ind, new_op_ind);
 
   // op_seq_obj doesn't have uses/def
   output_obj.removeDef(last_node_ind);
@@ -668,7 +692,7 @@ void Fp32ToFp16Converter::removeContiguousConvertOpSequences()
   auto list_to_delete_op_seqs = getListOpSequences(opseq_map_to_delete);
   auto list_to_delete_ops = findOperationsToDelete(list_to_delete_op_seqs);
 
-  // Before deleting, manipulateInputs of OpSeq & Operation
+  // Before deleting, manipulateInput of OpSeq & Operation
   manipulateContiguousOpSequences(input_to_op_seqs, opseq_map_to_delete);
 
   // Delete OpSequences & Operations & obj's use/def & operands

--- a/runtime/onert/core/src/ir/Operation.cc
+++ b/runtime/onert/core/src/ir/Operation.cc
@@ -41,12 +41,12 @@ void Operation::setInputs(const OperandIndexSequence &indexes)
 
 void Operation::setOutputs(const OperandIndexSequence &indexes) { _outputs = indexes; }
 
-void Operation::replaceInput(const OperandIndex &from, const OperandIndex &to)
+void Operation::replaceInputs(const OperandIndex &from, const OperandIndex &to)
 {
   _inputs.replace(from, to);
 }
 
-void Operation::replaceOutput(const OperandIndex &from, const OperandIndex &to)
+void Operation::replaceOutputs(const OperandIndex &from, const OperandIndex &to)
 {
   _outputs.replace(from, to);
 }

--- a/runtime/onert/core/src/ir/pass/ConstantInsertionPass.cc
+++ b/runtime/onert/core/src/ir/pass/ConstantInsertionPass.cc
@@ -57,7 +57,9 @@ void ConstantInsertionPass::callback(const OperationIndex &node_index, Operation
       // Update op_seq
       if (_lowered_graph.op_seqs().at(op_sequence_index).getInputs().contains(input))
       {
-        _lowered_graph.op_seqs().at(op_sequence_index).replaceInput(input, replaced_input);
+        // If op_seqs has inputs as the same constant operand and the inputs is replaced all at
+        // once, there is no problem because this doesn't change using iterator.
+        _lowered_graph.op_seqs().at(op_sequence_index).replaceInputs(input, replaced_input);
       }
 
       // Update current input operand only. Don't update all input node in this operation.

--- a/runtime/onert/core/src/ir/pass/PermutationInsertionPass.cc
+++ b/runtime/onert/core/src/ir/pass/PermutationInsertionPass.cc
@@ -102,10 +102,16 @@ void PermutationInsertionPass::callback(const OperandIndex &index, Operand &obje
       if (index != new_index)
       {
         // Update from op_seq
-        _lowered_graph.op_seqs().at(op_seq_index).replaceInput(index, new_index);
+        // An Opsequnce's can have inputs as the same operand.
+        // But, there is no problem that the same inputs must be replaced all at once because an
+        // Opsequnce's inputs have the same PermuteFactor.
+        _lowered_graph.op_seqs().at(op_seq_index).replaceInputs(index, new_index);
 
         // Update from operation
-        operation.replaceInput(index, new_index);
+        // An operation can have inputs as the same operand.
+        // But, there is no problem that the same inputs must be replaced all at once because An
+        // operation's inputs have the same PermuteFactor.
+        operation.replaceInputs(index, new_index);
 
         // Update from operand
         remove_list.push_back(


### PR DESCRIPTION
Related issues : #1321 #1324 

This commit changes naming replaceing inputs from replaceInput to replaceInputs
  - Change naming
  - Remove duplicated calling for the same input

Signed-off-by: ragmani <ragmani0216@gmail.com>