### PR TITLE
[luci/service] LeakyRelu support for type and shape inference

### DIFF
--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -789,6 +789,12 @@ public:
     return loco::NodeShape{input_shape};
   }
 
+  loco::NodeShape visit(const luci::CircleLeakyRelu *node) final
+  {
+    const auto input_shape = loco::shape_get(node->features()).as<loco::TensorShape>();
+    return loco::NodeShape{input_shape};
+  }
+
   loco::NodeShape visit(const luci::CircleLess *node) final
   {
     const auto x_shape = loco::shape_get(node->x()).as<loco::TensorShape>();

--- a/compiler/luci/service/src/CircleTypeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleTypeInferenceRule.cpp
@@ -138,6 +138,11 @@ struct TypeInferenceAlgorithm final : public luci::CircleNodeVisitor<loco::DataT
     return loco::dtype_get(node->input(1));
   }
 
+  loco::DataType visit(const luci::CircleLeakyRelu *node) final
+  {
+    return loco::dtype_get(node->features());
+  }
+
   loco::DataType visit(const luci::CircleLess *) final { return loco::DataType::BOOL; }
 
   loco::DataType visit(const luci::CircleLogicalAnd *node) final


### PR DESCRIPTION
Add type and shape inference support for LeakyRelu operator

ONE-DCO-1.0-Signed-off-by: Vladimir Plazun v.plazun@samsung.com