### PR TITLE
[onert] remove mbegin() and mend() from OperandIndexSequence

### DIFF
--- a/runtime/onert/core/include/ir/OperandIndexSequence.h
+++ b/runtime/onert/core/include/ir/OperandIndexSequence.h
@@ -64,11 +64,6 @@ public:
 public:
   std::vector<OperandIndex>::const_iterator begin(void) const { return _vec.begin(); }
   std::vector<OperandIndex>::const_iterator end(void) const { return _vec.end(); }
-  // Standard c++ uses `cbegin` for const_iterator and `begin` for mutable iterator.
-  // However, our project uses `begin` for const_iterator in several data structures.
-  // Thus, I introduced `mbegin` for mutable iterator.
-  std::vector<OperandIndex>::iterator mbegin(void) { return _vec.begin(); }
-  std::vector<OperandIndex>::iterator mend(void) { return _vec.end(); }
 
 private:
   std::vector<OperandIndex> _vec;


### PR DESCRIPTION
It removes mbegin() and mend() which is not used any longer.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>