### PR TITLE
[luci] Support no_shape in import/export

### DIFF
--- a/compiler/luci/export/src/CircleTensorExporter.cpp
+++ b/compiler/luci/export/src/CircleTensorExporter.cpp
@@ -53,6 +53,9 @@ public:
   const ShapeDescription &shape(void) const { return _shape; }
   void shape(const ShapeDescription &shape) { _shape = shape; }
 
+  void no_shape(void) { _no_shape = true; }
+  bool no_shape(void) const { return _no_shape; }
+
 public:
   luci::CircleConst *content(void) const { return _content; }
   void content(luci::CircleConst *c) { _content = c; }
@@ -65,6 +68,7 @@ private:
 
   circle::TensorType _dtype{circle::TensorType_FLOAT32};
   ShapeDescription _shape{};
+  bool _no_shape{false};
 
   luci::CircleConst *_content = nullptr;
   luci::CircleQuantParam *_quantparam = nullptr;
@@ -121,7 +125,10 @@ void allocateCircleTensor(CircleNode *node, CircleTensorContext &ctx)
 
   tensor_info.name(tensor_name);
   tensor_info.dtype(to_circle_tensortype(luci::node_dtype(node)));
-  tensor_info.shape(to_shape_description(luci::node_shape(node)));
+  if (node->no_shape())
+    tensor_info.no_shape();
+  else
+    tensor_info.shape(to_shape_description(luci::node_shape(node)));
 
   tensor_info.content(dynamic_cast<luci::CircleConst *>(node));
   tensor_info.quantparam(node->quantparam());
@@ -221,7 +228,9 @@ void exportOpDefinedTensor(const CircleTensoInfo &info, FlatBufferBuilder &build
                            SerializedModelData &md, SerializedGraphData &gd)
 {
   // Create and register output tensor shape
-  auto shape_offset = encodeShape(builder, info.shape());
+  flatbuffers::Offset<Vector<int32_t>> shape_offset;
+  if (!info.no_shape())
+    shape_offset = encodeShape(builder, info.shape());
 
   // encode and register output tensor buffer
   auto buffer =

--- a/compiler/luci/import/src/GraphBuilder.cpp
+++ b/compiler/luci/import/src/GraphBuilder.cpp
@@ -55,6 +55,12 @@ void GraphBuilder::build(const circle::OperatorT &op, GraphBuilderContext *conte
   {
     context->nodefinder()->enroll(outputs[0], node);
   }
+
+  // mark no_shape
+  auto tensors_ptr = context->reader()->tensors_ptr();
+  assert(tensors_ptr != nullptr);
+  if (tensors_ptr->Get(outputs[0]) == nullptr)
+    node->no_shape(true);
 }
 
 } // namespace luci

--- a/compiler/luci/import/src/Importer.cpp
+++ b/compiler/luci/import/src/Importer.cpp
@@ -59,6 +59,11 @@ void convert_graph(const luci::GraphBuilderSource &source, luci::CircleReader &r
 
     luci::copy_tensor_attributes(tensor, input_node);
 
+    auto tensors_ptr = reader.tensors_ptr();
+    assert(tensors_ptr != nullptr);
+    if (!tensors_ptr->Get(input)->shape())
+      input_node->no_shape(true);
+
     INFO(l) << "[luci] NodeFinder INPUT(" << input << ") = " << input_node << std::endl;
     nodefinder->enroll(input, input_node);
 

--- a/compiler/luci/import/src/Nodes/CircleConst.cpp
+++ b/compiler/luci/import/src/Nodes/CircleConst.cpp
@@ -100,6 +100,12 @@ CircleConst *create_circleconst(GraphBuilderContext *context, int32_t tensor_ind
       throw oops::UserExn("Unsupported tensor type", circle::EnumNameTensorType(const_tensor.type));
   }
 
+  // (4) mark no_shape
+  auto tensors_ptr = context->reader()->tensors_ptr();
+  assert(tensors_ptr != nullptr);
+  if (!tensors_ptr->Get(tensor_index)->shape())
+    const_node->no_shape(true);
+
   return const_node;
 }
 

--- a/compiler/luci/import/src/Nodes/CircleCustom.cpp
+++ b/compiler/luci/import/src/Nodes/CircleCustom.cpp
@@ -58,6 +58,12 @@ void CircleCustomGraphBuilder::build(const circle::OperatorT &op,
     copy_tensor_attributes(output_tensor, node);
   }
 
+  // mark no_shape
+  auto tensors_ptr = context->reader()->tensors_ptr();
+  assert(tensors_ptr != nullptr);
+  if (tensors_ptr->Get(outputs[0]) == nullptr)
+    node->no_shape(true);
+
   context->nodefinder()->enroll(outputs[0], node);
 }
 

--- a/compiler/luci/import/src/Nodes/CircleIf.cpp
+++ b/compiler/luci/import/src/Nodes/CircleIf.cpp
@@ -122,6 +122,12 @@ void CircleIfGraphBuilder::build(const circle::OperatorT &op, GraphBuilderContex
     nodeout->input(node);
     nodeout->index(n);
 
+    // mark no_shape
+    auto tensors_ptr = context->reader()->tensors_ptr();
+    assert(tensors_ptr != nullptr);
+    if (tensors_ptr->Get(outputs[n]) == nullptr)
+      nodeout->no_shape(true);
+
     context->nodefinder()->enroll(outputs[n], nodeout);
   }
 }

--- a/compiler/luci/import/src/Nodes/CircleSplit.cpp
+++ b/compiler/luci/import/src/Nodes/CircleSplit.cpp
@@ -103,6 +103,12 @@ void CircleSplitGraphBuilder::build(const circle::OperatorT &op, GraphBuilderCon
     nodeout->input(node);
     nodeout->index(n);
 
+    // mark no_shape
+    auto tensors_ptr = context->reader()->tensors_ptr();
+    assert(tensors_ptr != nullptr);
+    if (tensors_ptr->Get(outputs[n]) == nullptr)
+      nodeout->no_shape(true);
+
     context->nodefinder()->enroll(outputs[n], nodeout);
   }
 }

--- a/compiler/luci/import/src/Nodes/CircleSplitV.cpp
+++ b/compiler/luci/import/src/Nodes/CircleSplitV.cpp
@@ -105,6 +105,12 @@ void CircleSplitVGraphBuilder::build(const circle::OperatorT &op,
     nodeout->input(node);
     nodeout->index(n);
 
+    // mark no_shape
+    auto tensors_ptr = context->reader()->tensors_ptr();
+    assert(tensors_ptr != nullptr);
+    if (tensors_ptr->Get(outputs[n]) == nullptr)
+      nodeout->no_shape(true);
+
     context->nodefinder()->enroll(outputs[n], nodeout);
   }
 }

--- a/compiler/luci/import/src/Nodes/CircleTopKV2.cpp
+++ b/compiler/luci/import/src/Nodes/CircleTopKV2.cpp
@@ -101,6 +101,12 @@ void CircleTopKV2GraphBuilder::build(const circle::OperatorT &op,
     nodeout->topkv2(node);
     nodeout->index(n);
 
+    // mark no_shape
+    auto tensors_ptr = context->reader()->tensors_ptr();
+    assert(tensors_ptr != nullptr);
+    if (tensors_ptr->Get(outputs[n]) == nullptr)
+      nodeout->no_shape(true);
+
     context->nodefinder()->enroll(outputs[n], nodeout);
   }
 }

--- a/compiler/luci/import/src/Nodes/CircleUnpack.cpp
+++ b/compiler/luci/import/src/Nodes/CircleUnpack.cpp
@@ -114,6 +114,12 @@ void CircleUnpackGraphBuilder::build(const circle::OperatorT &op,
     nodeout->unpack(node);
     nodeout->index(n);
 
+    // mark no_shape
+    auto tensors_ptr = context->reader()->tensors_ptr();
+    assert(tensors_ptr != nullptr);
+    if (tensors_ptr->Get(outputs[n]) == nullptr)
+      nodeout->no_shape(true);
+
     context->nodefinder()->enroll(outputs[n], nodeout);
   }
 }

--- a/compiler/luci/import/src/Nodes/CircleWhile.cpp
+++ b/compiler/luci/import/src/Nodes/CircleWhile.cpp
@@ -118,6 +118,12 @@ void CircleWhileGraphBuilder::build(const circle::OperatorT &op, GraphBuilderCon
         node->quantparam(std::move(quantparam));
     }
 
+    // mark no_shape
+    auto tensors_ptr = context->reader()->tensors_ptr();
+    assert(tensors_ptr != nullptr);
+    if (tensors_ptr->Get(outputs[n]) == nullptr)
+      nodeout->no_shape(true);
+
     context->nodefinder()->enroll(outputs[n], nodeout);
   }
 }


### PR DESCRIPTION
This will support CircleNode without shape in import and export

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>