### PR TITLE
[onert] Remove unused method from BackendManager

### DIFF
--- a/runtime/onert/core/include/compiler/BackendManager.h
+++ b/runtime/onert/core/include/compiler/BackendManager.h
@@ -59,22 +59,6 @@ private:
   std::map<std::string, std::unique_ptr<void, dlhandle_destroy_t>> _handle_map;
   std::map<std::string, std::unique_ptr<backend::Backend, backend_destroy_t>> _gen_map;
   /**
-   * @brief Allocate an object of a class of a plugin by loading a plugin function, that does
-   * allocation, and calling it
-   *
-   * @param object_of_plugin_class target object
-   * @param obj_creator_func_name name of the plugin function, that allocates an object
-   * @param handle handle of the plugin
-   * @param args arguments to pass to constructor of the plugin class
-   *
-   * @return
-   */
-  template <typename T, class... Types>
-  void loadObjectFromPlugin(std::shared_ptr<T> &object_of_plugin_class,
-                            const std::string obj_creator_func_name, void *handle,
-                            Types &&... args);
-
-  /**
    * @brief load controlflow backend
    *
    * @param backend backend to be loaded

--- a/runtime/onert/core/src/compiler/BackendManager.cc
+++ b/runtime/onert/core/src/compiler/BackendManager.cc
@@ -38,24 +38,6 @@ BackendManager &BackendManager::get()
   return object;
 }
 
-template <typename T, class... Types>
-void BackendManager::loadObjectFromPlugin(std::shared_ptr<T> &object_of_plugin_class,
-                                          const std::string obj_creator_func_name, void *handle,
-                                          Types &&... args)
-{
-  T *(*allocate_obj)(Types && ... Args);
-  // load object creator function
-  allocate_obj = (T * (*)(Types && ... Args))dlsym(handle, obj_creator_func_name.c_str());
-  if (allocate_obj == nullptr)
-  {
-    fprintf(stderr, "BackendManager: unable to open function %s: %s\n",
-            obj_creator_func_name.c_str(), dlerror());
-    abort();
-  }
-
-  object_of_plugin_class.reset(allocate_obj(args...));
-}
-
 void BackendManager::loadControlflowBackend()
 {
   // Add controlflow Backend


### PR DESCRIPTION
Remove unused method `loadObjectFromPlugin` from `BackendManager`.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>