### PR TITLE
[oneapi] Fix `nnfw_set_available_backends` impl

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -472,7 +472,15 @@ NNFW_STATUS nnfw_session::set_available_backends(const char *backends)
       return NNFW_STATUS_ERROR;
     }
 
-    _source->set("BACKENDS", backends);
+    // The session must be in the state after model load
+    if (!_compiler)
+      return NNFW_STATUS_ERROR;
+
+    auto &options = _compiler->options();
+
+    using namespace onert::util;
+
+    options.backend_list = nnfw::misc::split(std::string{backends}, ';');
   }
   catch (const std::exception &e)
   {


### PR DESCRIPTION
The implementation of `nnfw_set_available_backends` changes global
configuration, which affects another sessions. This commit fixes it to
affect only the current session.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>