### PR TITLE
[luci] Enable SpaceToDepth operator in import

### DIFF
--- a/compiler/luci/import/include/luci/Import/Nodes.h
+++ b/compiler/luci/import/include/luci/Import/Nodes.h
@@ -72,6 +72,7 @@
 #include "Nodes/CircleSlice.h"
 #include "Nodes/CircleSoftmax.h"
 #include "Nodes/CircleSpaceToBatchND.h"
+#include "Nodes/CircleSpaceToDepth.h"
 #include "Nodes/CircleSplit.h"
 #include "Nodes/CircleSplitV.h"
 #include "Nodes/CircleSquare.h"

--- a/compiler/luci/import/include/luci/Import/Nodes/CircleSpaceToDepth.h
+++ b/compiler/luci/import/include/luci/Import/Nodes/CircleSpaceToDepth.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __LUCI_IMPORT_OP_CIRCLE_SPACETODEPTH_H__
+#define __LUCI_IMPORT_OP_CIRCLE_SPACETODEPTH_H__
+
+#include "luci/Import/GraphBuilder.h"
+
+namespace luci
+{
+
+class CircleSpaceToDepthGraphBuilder : public GraphBuilder
+{
+public:
+  bool validate(const ValidateArgs &args) const final;
+
+private:
+  CircleNode *build_node(const circle::OperatorT &op, const std::vector<CircleNode *> &inputs,
+                         loco::Graph *graph) const final;
+};
+
+} // namespace luci
+
+#endif // __LUCI_IMPORT_OP_CIRCLE_SPACETODEPTH_H__

--- a/compiler/luci/import/src/GraphBuilderRegistry.cpp
+++ b/compiler/luci/import/src/GraphBuilderRegistry.cpp
@@ -81,6 +81,7 @@ GraphBuilderRegistry::GraphBuilderRegistry()
   CIRCLE_NODE(SLICE, CircleSliceGraphBuilder);                          // 65
   CIRCLE_NODE(SOFTMAX, CircleSoftmaxGraphBuilder);                      // 25
   CIRCLE_NODE(SPACE_TO_BATCH_ND, CircleSpaceToBatchNDGraphBuilder);     // 38
+  CIRCLE_NODE(SPACE_TO_DEPTH, CircleSpaceToDepthGraphBuilder);          // 26
   CIRCLE_NODE(SPLIT, CircleSplitGraphBuilder);                          // 49
   CIRCLE_NODE(SPLIT_V, CircleSplitVGraphBuilder);                       // 102
   CIRCLE_NODE(SQUARE, CircleSquareGraphBuilder);                        // 92
@@ -111,7 +112,6 @@ GraphBuilderRegistry::GraphBuilderRegistry()
   // BuiltinOperator_RELU6 = 21,
   // BuiltinOperator_RESIZE_BILINEAR = 23,
   // BuiltinOperator_RNN = 24,
-  // BuiltinOperator_SPACE_TO_DEPTH = 26,
   // BuiltinOperator_SVDF = 27,
   // BuiltinOperator_CONCAT_EMBEDDINGS = 29,
   // BuiltinOperator_SKIP_GRAM = 30,

--- a/compiler/luci/import/src/Nodes/CircleSpaceToDepth.cpp
+++ b/compiler/luci/import/src/Nodes/CircleSpaceToDepth.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Import/Nodes/CircleSpaceToDepth.h"
+
+#include <luci/IR/Nodes/CircleSpaceToDepth.h>
+
+#include <loco.h>
+
+#include <cassert>
+
+namespace luci
+{
+
+bool CircleSpaceToDepthGraphBuilder::validate(const ValidateArgs &args) const
+{
+  const auto &inputs = args.op.inputs;
+  if (inputs.size() != 1)
+    return false;
+
+  // TODO do attribute checks
+
+  return true;
+}
+
+CircleNode *CircleSpaceToDepthGraphBuilder::build_node(const circle::OperatorT &,
+                                                       const std::vector<CircleNode *> &inputs,
+                                                       loco::Graph *graph) const
+{
+  auto *node = graph->nodes()->create<CircleSpaceToDepth>();
+  node->input(inputs[0]);
+
+  const auto *options = op.builtin_options.AsSpaceToDepthOptions();
+  node->block_size(options->block_size);
+
+  return node;
+}
+
+} // namespace luci

--- a/compiler/luci/import/src/Nodes/CircleSpaceToDepth.cpp
+++ b/compiler/luci/import/src/Nodes/CircleSpaceToDepth.cpp
@@ -36,7 +36,7 @@ bool CircleSpaceToDepthGraphBuilder::validate(const ValidateArgs &args) const
   return true;
 }
 
-CircleNode *CircleSpaceToDepthGraphBuilder::build_node(const circle::OperatorT &,
+CircleNode *CircleSpaceToDepthGraphBuilder::build_node(const circle::OperatorT &op,
                                                        const std::vector<CircleNode *> &inputs,
                                                        loco::Graph *graph) const
 {


### PR DESCRIPTION
This enables import of SpaceToDepth operator in luci

For #1126 
Draft #1206 

ONE-DCO-1.0-Signed-off-by: Andrey Kvochko <a.kvochko@samsung.com>