### PR TITLE
[onert] Fix ExpandDims in DynamicInferer

### DIFF
--- a/runtime/onert/core/src/util/shapeinf/ExpandDims.cc
+++ b/runtime/onert/core/src/util/shapeinf/ExpandDims.cc
@@ -75,24 +75,24 @@ void DynamicInferer::visit(const ir::operation::ExpandDims &op)
 {
   // check if output is not dynamic
   auto output_ind = op.getOutputs().at(0);
-  auto *output = _tensor_registry->getITensor(output_ind);
+  auto output = _tensor_registry->getITensor(output_ind);
   if (!output->is_dynamic())
     return;
 
   // getting output shape
   auto input_ind = op.getInputs().at(ir::operation::ExpandDims::INPUT);
-  auto *input = _tensor_registry->getITensor(input_ind);
-  ir::Shape input_shape = getShape(input);
+  auto input = _tensor_registry->getITensor(input_ind);
+  ir::Shape input_shape = getShape(input.get());
 
   auto axis_ind = op.getInputs().at(ir::operation::ExpandDims::AXIS);
-  auto *axis = _tensor_registry->getITensor(axis_ind);
+  auto axis = _tensor_registry->getITensor(axis_ind);
   auto axis_buf = reinterpret_cast<const int32_t *>(axis->buffer());
   assert(axis_buf);
 
   auto output_shape = onert::shape_inference::inferExpandDimsShape(input_shape, axis_buf[0]);
 
   // set output shape and output buffer
-  setShape(output, output_shape);
+  setShape(output.get(), output_shape);
 
   // assert(output->buffer() == nullptr);
   _dynamic_tensor_manager->allocate(output_ind, output_shape);


### PR DESCRIPTION
Fix compilation failure.
DynamicInferer as `getITensor` return value is now `shared_ptr`.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>