### PR TITLE
[oneapi] Test: Run only once

### DIFF
--- a/infra/scripts/test_ubuntu_runtime_mixed.sh
+++ b/infra/scripts/test_ubuntu_runtime_mixed.sh
@@ -20,7 +20,7 @@ echo
 ONEAPI_TEST_MODEL_INSTALLER=tests/scripts/oneapi_test/install_oneapi_test_nnpackages.sh
 TEST_BIN=Product/out/unittest_standalone/nnfw_api_gtest
 $ONEAPI_TEST_MODEL_INSTALLER --install-dir ${TEST_BIN}_models
-ONERT_LOG_ENABLE=1 ${TEST_BIN}
+${TEST_BIN}
 echo
 echo "==== Run oneapi_test end ===="
 echo

--- a/infra/scripts/test_ubuntu_runtime_mixed.sh
+++ b/infra/scripts/test_ubuntu_runtime_mixed.sh
@@ -9,6 +9,24 @@ CheckTestPrepared
 TEST_ARCH=$(uname -m | tr '[:upper:]' '[:lower:]')
 TEST_OS="linux"
 
+# oneapi_test
+# NOTE: This test is run here as it does not depend on BACKEND or EXECUTOR
+
+# This test requires test model installation
+pushd ${ROOT_PATH} > /dev/null
+echo
+echo "==== Run oneapi_test begin ===="
+echo
+ONEAPI_TEST_MODEL_INSTALLER=tests/scripts/oneapi_test/install_oneapi_test_nnpackages.sh
+TEST_BIN=Product/out/unittest_standalone/nnfw_api_gtest
+$ONEAPI_TEST_MODEL_INSTALLER --install-dir ${TEST_BIN}_models
+ONERT_LOG_ENABLE=1 ${TEST_BIN}
+echo
+echo "==== Run oneapi_test end ===="
+echo
+popd > /dev/null
+
+
 pushd ${ROOT_PATH}
 
 # NOTE Fixed backend assignment by type of operation

--- a/runtime/onert/core/src/compiler/ManualScheduler.cc
+++ b/runtime/onert/core/src/compiler/ManualScheduler.cc
@@ -30,17 +30,30 @@ namespace compiler
 {
 
 ManualScheduler::ManualScheduler(const backend::BackendContexts &backend_contexts,
-                                 const compiler::ManualSchedulerOptions &options)
+                                 const compiler::CompilerOptions &options)
     : _backend_contexts{backend_contexts}, _options{options}
 {
 }
 
 std::unique_ptr<BackendResolver> ManualScheduler::schedule(const ir::Graph &graph)
 {
+  const auto &manual_options = _options.manual_scheduler_options;
   auto backend_resolver = std::make_unique<compiler::BackendResolver>();
 
+  // This fallback will be used for unavailable backends
+  auto fallback = [&]() -> const backend::Backend * {
+    for (auto backend_id : _options.backend_list)
+    {
+      auto backend = resolveBackend(backend_id);
+      if (backend)
+        return backend;
+    }
+    return nullptr;
+  }();
+  assert(!fallback); // There must be at least one fallback
+
   // 1. Backend for All operations
-  const backend::Backend *backend_all = resolveBackend(_options.backend_for_all);
+  const backend::Backend *backend_all = resolveBackend(manual_options.backend_for_all, fallback);
   VERBOSE(ManualScheduler) << "Default backend for all ops: " << backend_all->config()->id()
                            << std::endl;
 
@@ -50,7 +63,7 @@ std::unique_ptr<BackendResolver> ManualScheduler::schedule(const ir::Graph &grap
 
   // 2. Backend per operation type
   std::unordered_map<ir::OpCode, backend::Backend *> op_type_map;
-  for (auto &pair : _options.opcode_to_backend)
+  for (auto &pair : manual_options.opcode_to_backend)
   {
     op_type_map.emplace(
         pair.first, BackendManager::get().get(
@@ -68,7 +81,7 @@ std::unique_ptr<BackendResolver> ManualScheduler::schedule(const ir::Graph &grap
   });
 
   // 3. Backend per operation
-  for (auto &pair : _options.index_to_backend)
+  for (auto &pair : manual_options.index_to_backend)
   {
     const auto &key = pair.first;
     const auto &val = pair.second;
@@ -100,14 +113,14 @@ std::unique_ptr<BackendResolver> ManualScheduler::schedule(const ir::Graph &grap
   return backend_resolver;
 }
 
-const backend::Backend *ManualScheduler::resolveBackend(const std::string &id)
+const backend::Backend *ManualScheduler::resolveBackend(const std::string &id,
+                                                        const backend::Backend *fallback)
 {
   // Ensure if the backend is available in the backend
   const backend::Backend *backend = BackendManager::get().get(id);
   if (!backend || _backend_contexts.find(backend) == _backend_contexts.end())
   {
-    // Use fallback backend (a random backend that is available)
-    backend = _backend_contexts.begin()->first;
+    backend = fallback;
   }
   return backend;
 }

--- a/runtime/onert/core/src/compiler/ManualScheduler.h
+++ b/runtime/onert/core/src/compiler/ManualScheduler.h
@@ -28,10 +28,15 @@ namespace compiler
 class ManualScheduler : public IScheduler
 {
 public:
-  ManualScheduler(const compiler::ManualSchedulerOptions &options);
+  ManualScheduler(const backend::BackendContexts &backend_contexts,
+                  const compiler::ManualSchedulerOptions &options);
   std::unique_ptr<BackendResolver> schedule(const ir::Graph &graph) override;
 
 private:
+  const backend::Backend *resolveBackend(const std::string &id);
+
+private:
+  const backend::BackendContexts &_backend_contexts;
   compiler::ManualSchedulerOptions _options;
 };
 

--- a/runtime/onert/core/src/compiler/ManualScheduler.h
+++ b/runtime/onert/core/src/compiler/ManualScheduler.h
@@ -29,15 +29,16 @@ class ManualScheduler : public IScheduler
 {
 public:
   ManualScheduler(const backend::BackendContexts &backend_contexts,
-                  const compiler::ManualSchedulerOptions &options);
+                  const compiler::CompilerOptions &options);
   std::unique_ptr<BackendResolver> schedule(const ir::Graph &graph) override;
 
 private:
-  const backend::Backend *resolveBackend(const std::string &id);
+  const backend::Backend *resolveBackend(const std::string &id,
+                                         const backend::Backend *fallback = nullptr);
 
 private:
   const backend::BackendContexts &_backend_contexts;
-  compiler::ManualSchedulerOptions _options;
+  compiler::CompilerOptions _options;
 };
 
 } // namespace compiler

--- a/runtime/onert/core/src/ir/LoweredGraph.cc
+++ b/runtime/onert/core/src/ir/LoweredGraph.cc
@@ -72,7 +72,7 @@ LoweredGraph::LoweredGraph(const Graph &graph, const compiler::CompilerOptions &
   }
   else
   {
-    auto scheduler = compiler::ManualScheduler(_backend_contexts, options.manual_scheduler_options);
+    auto scheduler = compiler::ManualScheduler(_backend_contexts, options);
     _backend_resolver = scheduler.schedule(_graph);
   }
 

--- a/runtime/onert/core/src/ir/LoweredGraph.cc
+++ b/runtime/onert/core/src/ir/LoweredGraph.cc
@@ -72,7 +72,7 @@ LoweredGraph::LoweredGraph(const Graph &graph, const compiler::CompilerOptions &
   }
   else
   {
-    auto scheduler = compiler::ManualScheduler(options.manual_scheduler_options);
+    auto scheduler = compiler::ManualScheduler(_backend_contexts, options.manual_scheduler_options);
     _backend_resolver = scheduler.schedule(_graph);
   }
 

--- a/tests/nnfw_api/CMakeLists.txt
+++ b/tests/nnfw_api/CMakeLists.txt
@@ -22,4 +22,4 @@ target_link_libraries(${RUNTIME_NNFW_API_TEST} nnfw-dev)
 target_link_libraries(${RUNTIME_NNFW_API_TEST} gtest gmock)
 target_link_libraries(${RUNTIME_NNFW_API_TEST} ${LIB_PTHREAD} dl)
 
-install(TARGETS ${RUNTIME_NNFW_API_TEST} DESTINATION unittest)
+install(TARGETS ${RUNTIME_NNFW_API_TEST} DESTINATION unittest_standalone)

--- a/tests/nnfw_api/src/ModelTestInputReshaping.cc
+++ b/tests/nnfw_api/src/ModelTestInputReshaping.cc
@@ -35,14 +35,8 @@ TEST_F(TestInputReshapingAddModelLoaded, reshaping_2x2_to_4x2)
 {
   NNFW_STATUS res = NNFW_STATUS_ERROR;
 
-  // model is already loaded by fixture
-
-  if (!(onlyForCpuBackend(_session) && onlyForLinearExecutor(_session)))
-  {
-    // let's skip this test
-    SUCCEED();
-    return;
-  }
+  ASSERT_EQ(nnfw_set_available_backends(_session, "cpu"), NNFW_STATUS_NO_ERROR);
+  ASSERT_EQ(nnfw_set_config(_session, "EXECUTOR", "Linear"), NNFW_STATUS_NO_ERROR);
 
   // input and output values
   const std::vector<float> input1 = {0, 1, 2, 3, 4, 5, 6, 7}; // of changed shape [4, 2]

--- a/tests/scripts/unittest.sh
+++ b/tests/scripts/unittest.sh
@@ -74,15 +74,6 @@ for TEST_BIN in `find $UNITTEST_TEST_DIR -maxdepth 1 -type f -executable`; do
     echo "============================================"
     TEMP_UNITTEST_RESULT=0
 
-    # This test requires test model installation
-    if [ "$(basename $TEST_BIN)" == "nnfw_api_gtest" ]; then
-        ONEAPI_TEST_MODEL_INSTALLER=$(dirname $BASH_SOURCE)/oneapi_test/install_oneapi_test_nnpackages.sh
-        $ONEAPI_TEST_MODEL_INSTALLER --install-dir ${TEST_BIN}_models
-        if [[ $? -ne 0 ]]; then
-            echo "FAILED : oneapi test model installation"
-        fi
-    fi
-
     if [ "$UNITTEST_RUN_ALL" == "true" ]; then
         for TEST_LIST_VERBOSE_LINE in $($TEST_BIN --gtest_list_tests); do
             if [[ $TEST_LIST_VERBOSE_LINE == *\. ]]; then


### PR DESCRIPTION
All the unitests were based on Env(EXECUTOR and BACKENDS). This commit
makes it to run only once.

- Change installation dir `unittest` to `unittest_standalone`
- Fix unittest TestInputReshapingAddModelLoaded
- Running oneapi test is called from `test_ubuntu_runtime_mixed.sh`
  temporarilly

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>