### PR TITLE
[onert] Revising add_dynamic.mod.py

### DIFF
--- a/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_cl
+++ b/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_cl
@@ -1,6 +1,6 @@
 GeneratedTests.abs_
 GeneratedTests.abs_dynamic_nnfw
-GeneratedTests.add_dynamic
+GeneratedTests.add_dynamic_nnfw
 GeneratedTests.cast_float16_to_float16
 GeneratedTests.cast_float16_to_float32
 GeneratedTests.cast_float16_to_float32_relaxed

--- a/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_neon
+++ b/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_neon
@@ -1,6 +1,6 @@
 GeneratedTests.abs_
 GeneratedTests.abs_dynamic_nnfw
-GeneratedTests.add_dynamic
+GeneratedTests.add_dynamic_nnfw
 GeneratedTests.cast_float16_to_float16
 GeneratedTests.cast_float16_to_float32
 GeneratedTests.cast_float16_to_float32_relaxed

--- a/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_cl
+++ b/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_cl
@@ -1,6 +1,6 @@
 GeneratedTests.abs_
 GeneratedTests.abs_dynamic_nnfw
-GeneratedTests.add_dynamic
+GeneratedTests.add_dynamic_nnfw
 GeneratedTests.cast_float16_to_float16
 GeneratedTests.cast_float16_to_float32
 GeneratedTests.cast_float16_to_float32_relaxed

--- a/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_neon
+++ b/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_neon
@@ -1,6 +1,6 @@
 GeneratedTests.abs_
 GeneratedTests.abs_dynamic_nnfw
-GeneratedTests.add_dynamic
+GeneratedTests.add_dynamic_nnfw
 GeneratedTests.cast_float16_to_float16
 GeneratedTests.cast_float16_to_float32
 GeneratedTests.cast_float16_to_float32_relaxed

--- a/tests/nnapi/nnapi_gtest.skip.noarch.interp
+++ b/tests/nnapi/nnapi_gtest.skip.noarch.interp
@@ -5,7 +5,7 @@ GeneratedTests.abs_3D_float_nnfw
 GeneratedTests.abs_4D_float_nnfw
 GeneratedTests.abs_dynamic_nnfw
 GeneratedTests.add_broadcast_quant8
-GeneratedTests.add_dynamic
+GeneratedTests.add_dynamic_nnfw
 GeneratedTests.add_quant8
 GeneratedTests.argmax_1
 GeneratedTests.argmax_1_quant8

--- a/tests/nnapi/specs/V1_0/add_dynamic_nnfw.mod.py
+++ b/tests/nnapi/specs/V1_0/add_dynamic_nnfw.mod.py
@@ -34,7 +34,7 @@ test_node_input = dynamic_layer.getTestNodeInput() # first input of Add is dynam
 
 # model definition
 i2 = Input("op2", "TENSOR_FLOAT32", "{1, 4}") # second input of Add. 4 float32s
-t1 = Internal("op3", "TENSOR_FLOAT32", "{}") # result of first Add1. dynamic and shape is not known
+t1 = Internal("op3", "TENSOR_FLOAT32", "{}") # result of first Add. dynamic and shape is not known
 act = Int32Scalar("act", 0) # an int32_t scalar activation
 o1 = Output("op3", "TENSOR_FLOAT32", "{3, 4}")
 

--- a/tests/nnapi/specs/V1_0/add_dynamic_nnfw.mod.py
+++ b/tests/nnapi/specs/V1_0/add_dynamic_nnfw.mod.py
@@ -32,9 +32,9 @@ dynamic_layer = dynamic_tensor.DynamicInputGenerator(model, model_input1_shape)
 
 test_node_input = dynamic_layer.getTestNodeInput() # first input of Add is dynamic tensor
 
-# model
+# model definition
 i2 = Input("op2", "TENSOR_FLOAT32", "{1, 4}") # second input of Add. 4 float32s
-t1 = Internal("op3", "TENSOR_FLOAT32", "{1}") # result of first Add1. dynamic and shape is not known
+t1 = Internal("op3", "TENSOR_FLOAT32", "{}") # result of first Add1. dynamic and shape is not known
 act = Int32Scalar("act", 0) # an int32_t scalar activation
 o1 = Output("op3", "TENSOR_FLOAT32", "{3, 4}")
 


### PR DESCRIPTION
This PR contains the following change on `add_dynamic.mod.py`:

1) renames `add_dynamic.mod.py` to `add_dynamic_nnfw.mod.py` since this test was not from AOSP

2) fix internal tensor shape from "{1}" to `"{}"` since this is dynamic tensor and the rank is not known.

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>