### PR TITLE
[onert] Introduce logging macro VERBOSE_F

### DIFF
--- a/runtime/onert/core/include/util/logging.h
+++ b/runtime/onert/core/include/util/logging.h
@@ -60,4 +60,8 @@ static Context &ctx = Context::get();
   if (::onert::util::logging::ctx.enabled()) \
   std::cout << "[" << #name << "] "
 
+#define VERBOSE_F()                          \
+  if (::onert::util::logging::ctx.enabled()) \
+  std::cout << "[" << __func__ << "] "
+
 #endif // __ONERT_UTIL_LOGGING_H__


### PR DESCRIPTION
Introduce logging macro `VERBOSE_F` for developers' covenience.
Note that `__func__` is standard since C++11 which is equivalent of
non-standard extension `__FUNCTION__`.

Usage example:

```cpp
void doSomething()
{
  VERBOSE_F() << "YOUR MESSAGE" << std::endl;
}
```

Output:

```
[doSomething] YOUR MESSAGE
```

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>