### PR TITLE
[luci-interpreter] Use optimized kernels for Conv2D

### DIFF
--- a/compiler/luci-interpreter/src/kernels/CMakeLists.txt
+++ b/compiler/luci-interpreter/src/kernels/CMakeLists.txt
@@ -1,6 +1,7 @@
 nnas_find_package(TensorFlowSource EXACT 2.1.0 QUIET)
 nnas_find_package(TensorFlowGEMMLowpSource EXACT 2.1.0 QUIET)
 nnas_find_package(TensorFlowEigenSource EXACT 2.1.0 QUIET)
+find_package(Threads REQUIRED)
 nnas_find_package(GTest REQUIRED)
 
 if (NOT TensorFlowSource_FOUND OR
@@ -42,7 +43,7 @@ target_include_directories(luci_interpreter_kernels SYSTEM PRIVATE
     "${TensorFlowSource_DIR}")
 target_link_libraries(luci_interpreter_kernels
     PUBLIC luci_interpreter_core
-    PRIVATE nncc_common)
+    PRIVATE nncc_common Threads::Threads)
 
 
 set(TEST_SOURCES

--- a/compiler/luci-interpreter/src/kernels/Conv2D.h
+++ b/compiler/luci-interpreter/src/kernels/Conv2D.h
@@ -21,6 +21,8 @@
 #include "core/KernelParams.h"
 #include "core/Tensor.h"
 
+#include <memory>
+
 namespace luci_interpreter
 {
 
@@ -45,6 +47,7 @@ private:
   const Tensor *const _filter;
   const Tensor *const _bias;
   Tensor *const _output;
+  std::unique_ptr<Tensor> _im2col;
   int32_t _padding_height{};
   int32_t _padding_width{};
 };


### PR DESCRIPTION
Use [legacy] optimized kernels for `Conv2D`.

ONE-DCO-1.0-Signed-off-by: Sergei Barannikov <s.barannikov@samsung.com>
