### PR TITLE
[DRAFT][onert] support optional tensor for FULLY_CONNECTED

### DIFF
--- a/runtime/onert/backend/cpu/KernelGenerator.cc
+++ b/runtime/onert/backend/cpu/KernelGenerator.cc
@@ -117,7 +117,7 @@ void KernelGenerator::visit(const ir::OpSequence &op_seq)
     node.accept(*this);
     _return_fn_seq->append(releaseFunction());
 
-    for (const auto &ind : node.getInputs() + node.getOutputs())
+    for (const auto &ind : (node.getInputs() | ir::Remove::UNDEFINED) + node.getOutputs())
     {
       auto tensor = _tensor_builder->at(ind);
       if (tensor)

--- a/runtime/onert/core/include/backend/ITensorRegister.h
+++ b/runtime/onert/core/include/backend/ITensorRegister.h
@@ -50,13 +50,13 @@ protected:
   virtual std::shared_ptr<ITensorBuilder> tensor_builder() const = 0;
 
 protected:
-#define OP(InternalName)                                         \
-  void visit(const ir::operation::InternalName &node) override   \
-  {                                                              \
-    for (const auto &ind : node.getInputs() + node.getOutputs()) \
-    {                                                            \
-      defaultRegisterTensorInfo(ind);                            \
-    }                                                            \
+#define OP(InternalName)                                                                   \
+  void visit(const ir::operation::InternalName &node) override                             \
+  {                                                                                        \
+    for (const auto &ind : (node.getInputs() | ir::Remove::UNDEFINED) + node.getOutputs()) \
+    {                                                                                      \
+      defaultRegisterTensorInfo(ind);                                                      \
+    }                                                                                      \
   }
 #include "ir/Operations.lst"
 #undef OP

--- a/runtime/onert/core/include/ir/OperandIndexSequence.h
+++ b/runtime/onert/core/include/ir/OperandIndexSequence.h
@@ -29,7 +29,8 @@ namespace ir
 
 enum class Remove
 {
-  DUPLICATED = 0x1
+  DUPLICATED = 1,
+  UNDEFINED = 2
 };
 
 class OperandIndexSequence
@@ -59,6 +60,14 @@ public:
         ir::OperandIndexSequence seq;
         for (const auto &ind : _vec)
           if (!seq.contains(ind))
+            seq.append(ind);
+        return seq;
+      }
+      case ir::Remove::UNDEFINED:
+      {
+        ir::OperandIndexSequence seq;
+        for (const auto &ind : _vec)
+          if (!ind.undefined())
             seq.append(ind);
         return seq;
       }

--- a/runtime/onert/core/src/compiler/ExecutorFactory.cc
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.cc
@@ -119,7 +119,7 @@ void ExecutorFactory::runTensorRegistration(ir::LoweredGraph *lowered_graph,
       for (const auto op_idx : op_seq)
       {
         const auto &op = lowered_graph->graph().operations().at(op_idx);
-        for (const auto &index : op.getInputs() + op.getOutputs())
+        for (const auto &index : (op.getInputs() | ir::Remove::UNDEFINED) + op.getOutputs())
         {
           if (!tensor_builder->isRegistered(index))
           {

--- a/runtime/onert/core/src/compiler/Fp32ToFp16Converter.cc
+++ b/runtime/onert/core/src/compiler/Fp32ToFp16Converter.cc
@@ -225,7 +225,8 @@ void Fp32ToFp16Converter::appendNewOpSeqForConvertFp32ToFp16(const ir::OpSequenc
 
   // NOTE Please do not change sequence of op_seq_inputs. It can change the sequence of inputs of
   // Subgraph
-  for (const auto &op_seq_input_ind : op_seq_inputs | ir::Remove::DUPLICATED)
+  for (const auto &op_seq_input_ind :
+       op_seq_inputs | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED)
   {
     if (checkOperandType(op_seq_input_ind) == false)
       continue;
@@ -297,7 +298,8 @@ void Fp32ToFp16Converter::appendNewOpSeqForConvertFp16ToFp32(const ir::OpSequenc
 
   // NOTE Please do not change sequence of op_seq_outputs. It can change the sequence of outputs of
   // Subgraph
-  for (const auto &op_seq_output_ind : op_seq_outputs | ir::Remove::DUPLICATED)
+  for (const auto &op_seq_output_ind :
+       op_seq_outputs | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED)
   {
     if (checkOperandType(op_seq_output_ind) == false)
       continue;
@@ -388,7 +390,7 @@ void Fp32ToFp16Converter::convertOperandsOfOpSequence(ir::OpSequence &op_seq)
   for (auto &op_idx : op_seq)
   {
     const auto &node = operations.at(op_idx);
-    for (auto &ind : node.getInputs())
+    for (auto &ind : node.getInputs() | ir::Remove::UNDEFINED)
     {
       if (node.opcode() == ir::OpCode::ConvertFp32ToFp16 || op_seq_inputs.contains(ind))
         continue;
@@ -476,7 +478,7 @@ bool Fp32ToFp16Converter::checkOperandsOfOpSequence(const ir::OpSequence &op_seq
   const auto &first_node_ind = op_seq.operations().at(0);
   const auto &first_node = operations.at(first_node_ind);
   const auto &first_node_inputs = first_node.getInputs();
-  for (const auto &op_seq_input_ind : op_seq.getInputs())
+  for (const auto &op_seq_input_ind : op_seq.getInputs() | ir::Remove::UNDEFINED)
   {
     if (first_node_inputs.contains(op_seq_input_ind) == false)
       return false;
@@ -768,7 +770,7 @@ Fp32ToFp16Converter::InputToOpSeqs Fp32ToFp16Converter::prepareInputToOpSeqs() c
 
   InputToOpSeqs input_to_op_seqs;
   op_seqs.iterate([&](const ir::OpSequenceIndex &op_seq_idx, const ir::OpSequence &op_seq) {
-    for (auto input : op_seq.getInputs())
+    for (auto input : op_seq.getInputs() | ir::Remove::UNDEFINED)
     {
       auto it = input_to_op_seqs.find(input);
       if (it == input_to_op_seqs.end())
@@ -907,7 +909,7 @@ void Fp32ToFp16Converter::deleteContiguousOpSequences(
     VERBOSE(Fp32ToFp16Converter) << "Delete Node #" << first_node_ind.value() << std::endl;
 
     // Uses
-    for (auto &ind : first_node.getInputs() | ir::Remove::DUPLICATED)
+    for (auto &ind : first_node.getInputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED)
     {
       auto &obj = operands.at(ind);
       obj.removeUse(first_node_ind);
@@ -916,7 +918,7 @@ void Fp32ToFp16Converter::deleteContiguousOpSequences(
     }
 
     // Def
-    for (auto &ind : first_node.getOutputs() | ir::Remove::DUPLICATED)
+    for (auto &ind : first_node.getOutputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED)
     {
       auto &obj = operands.at(ind);
       obj.removeDef(first_node_ind);

--- a/runtime/onert/core/src/compiler/HEScheduler.cc
+++ b/runtime/onert/core/src/compiler/HEScheduler.cc
@@ -35,7 +35,7 @@ namespace compiler
 static uint32_t getOperationsFlattenedIOSize(const ir::Graph &graph, const ir::Operation &node)
 {
   uint32_t size = 0;
-  for (const auto &ind : node.getInputs() + node.getOutputs())
+  for (const auto &ind : (node.getInputs() | ir::Remove::UNDEFINED) + node.getOutputs())
   {
     size += graph.operands().at(ind).info().total_size();
   }
@@ -44,7 +44,7 @@ static uint32_t getOperationsFlattenedIOSize(const ir::Graph &graph, const ir::O
 
 static bool isQuant(const ir::Graph &graph, const ir::Operation &node)
 {
-  for (const auto &input : node.getInputs())
+  for (const auto &input : node.getInputs() | ir::Remove::UNDEFINED)
   {
     const auto &obj = graph.operands().at(input);
     if (obj.typeInfo().type() == ir::DataType::QUANT_UINT8_ASYMM)

--- a/runtime/onert/core/src/compiler/Linear.cc
+++ b/runtime/onert/core/src/compiler/Linear.cc
@@ -56,7 +56,7 @@ std::vector<ir::OpSequenceIndex> Linear::linearize(const ir::LoweredGraph &lower
     //            |
     //           [4]
     op_seqs.iterate([&](const ir::OpSequenceIndex &op_seq_idx, const ir::OpSequence &op_seq) {
-      for (auto input : op_seq.getInputs() | ir::Remove::DUPLICATED)
+      for (auto input : op_seq.getInputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED)
       {
         // only valid_inputs
         const auto &operand = operands.at(input);
@@ -235,7 +235,8 @@ void Linear::planTensors(const ir::LoweredGraph &lowered_graph,
     const auto &op_seq = lowered_graph.op_seqs().at(op_seq_ind);
     for (const auto &op_idx : op_seq.operations())
     {
-      for (const auto &ind : graph.operations().at(op_idx).getOutputs() | ir::Remove::DUPLICATED)
+      for (const auto &ind : graph.operations().at(op_idx).getOutputs() | ir::Remove::DUPLICATED |
+                                 ir::Remove::UNDEFINED)
       {
         assert(def_map.find(ind) != def_map.end());
         if (def_map[ind])
@@ -245,7 +246,8 @@ void Linear::planTensors(const ir::LoweredGraph &lowered_graph,
         }
       }
 
-      for (const auto &ind : graph.operations().at(op_idx).getInputs() | ir::Remove::DUPLICATED)
+      for (const auto &ind : graph.operations().at(op_idx).getInputs() | ir::Remove::DUPLICATED |
+                                 ir::Remove::UNDEFINED)
       {
         assert(uses_map.find(ind) != uses_map.end());
         assert(uses_map[ind] > 0);

--- a/runtime/onert/core/src/ir/Graph.cc
+++ b/runtime/onert/core/src/ir/Graph.cc
@@ -92,7 +92,7 @@ void Graph::initializeUseDef()
       operands().at(output).insertDef(index);
     }
 
-    auto inputs = node.getInputs();
+    auto inputs = node.getInputs() | ir::Remove::UNDEFINED;
     for (auto input : inputs)
     {
       operands().at(input).insertUse(index);

--- a/runtime/onert/core/src/ir/LoweredGraph.cc
+++ b/runtime/onert/core/src/ir/LoweredGraph.cc
@@ -234,7 +234,7 @@ void LoweredGraph::makeOpSequences(
         // TODO Change setting layout of each backend at another place
         auto backend_layout = backend->config()->supportLayout(node, frontend_layout);
 
-        for (auto operand : node.getInputs())
+        for (auto operand : node.getInputs() | ir::Remove::UNDEFINED)
         {
           auto &&lower_info = operands_lower_info.at(operand);
           lower_info->addUsePermuteFactor(operand::PermuteFactor{backend, backend_layout});
@@ -280,7 +280,7 @@ void LoweredGraph::manipulateLowerInfo(
     OperandIndexMap<std::unique_ptr<operand::LowerInfo>> &operands_lower_info)
 {
   const auto controlflow_backend = compiler::BackendManager::get().getControlflow();
-  for (auto index : _graph.getInputs())
+  for (auto index : _graph.getInputs() | ir::Remove::UNDEFINED)
   {
     // Pick just any one from the uses, here the first one is chosen
     // For the other uses, Permute operations will be inserted later
@@ -401,7 +401,7 @@ bool LoweredGraph::mergeable(const OpSequenceIndex &op_seq_index, const Operatio
     std::unordered_set<OperationIndex> branched_set;
 
     // Check for branching up
-    for (const auto &input : op_seq.getInputs() | Remove::DUPLICATED)
+    for (const auto &input : op_seq.getInputs() | Remove::DUPLICATED | ir::Remove::UNDEFINED)
     {
       const auto &input_obj = _graph.operands().at(input);
       for (const auto &def : input_obj.getDef())
@@ -446,7 +446,7 @@ bool LoweredGraph::mergeable(const OpSequenceIndex &op_seq_index, const Operatio
       const auto &n = _graph.operations().at(n_index);
 
       // node's output == op_seq's input?
-      const auto &n_inputs = n.getInputs();
+      const auto &n_inputs = n.getInputs() | ir::Remove::UNDEFINED;
       for (auto input : n_inputs)
       {
         if (node_outputs.contains(input))

--- a/runtime/onert/core/src/ir/pass/ConstantInsertionPass.cc
+++ b/runtime/onert/core/src/ir/pass/ConstantInsertionPass.cc
@@ -35,7 +35,7 @@ void ConstantInsertionPass::callback(const OperationIndex &node_index, Operation
   const auto layout = op_seq_lower_info->layout();
   const auto factor = operand::PermuteFactor{backend, layout};
 
-  for (const auto input : node.getInputs() | Remove::DUPLICATED)
+  for (const auto input : node.getInputs() | Remove::DUPLICATED | ir::Remove::UNDEFINED)
   {
     auto &object = _graph.operands().at(input);
 

--- a/runtime/onert/core/src/ir/pass/ConstantLoweringPass.cc
+++ b/runtime/onert/core/src/ir/pass/ConstantLoweringPass.cc
@@ -37,7 +37,7 @@ void ConstantLoweringPass::callback(const OperationIndex &node_index, Operation 
   const auto factor = operand::PermuteFactor{backend, layout};
 
   // Now this runtime does not support the node making output of operation as constant
-  for (const auto input : node.getInputs() | Remove::DUPLICATED)
+  for (const auto input : node.getInputs() | Remove::DUPLICATED | ir::Remove::UNDEFINED)
   {
     auto &object = _graph.operands().at(input);
     if (object.isConstant())

--- a/runtime/onert/core/src/ir/pass/PermutationOperationPass.cc
+++ b/runtime/onert/core/src/ir/pass/PermutationOperationPass.cc
@@ -136,7 +136,7 @@ void PermutationOperationPass::changeToKeepLayout(const Operation &node)
     const auto backend = op_seq_li->backend();
     const operand::PermuteFactor removed_factor{backend, backend_layout};
     const operand::PermuteFactor new_factor{backend, frontend_layout};
-    for (const auto &input : node.getInputs() | Remove::DUPLICATED)
+    for (const auto &input : node.getInputs() | Remove::DUPLICATED | ir::Remove::UNDEFINED)
     {
       bool canRemove = true;
       for (const auto &use : _graph.operands().at(input).getUses())

--- a/runtime/onert/core/src/ir/verifier/Verifier.cc
+++ b/runtime/onert/core/src/ir/verifier/Verifier.cc
@@ -77,7 +77,7 @@ bool EdgeConsistencyChecker::verify(const Graph &graph) const
   auto &operations = graph.operations();
   uint32_t mismatches = 0;
   operations.iterate([&](const OperationIndex &index, const Operation &node) {
-    for (auto operand_index : node.getInputs())
+    for (auto operand_index : node.getInputs() | ir::Remove::UNDEFINED)
     {
       auto &operand = graph.operands().at(operand_index);
       mismatches += (operand.getUses().contains(index) ? 0 : 1);


### PR DESCRIPTION
It supports `FULLY_CONNECTED` optional `bias` tensor.

It is necessary to modify loader, core, kernel and so on.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>