### PR TITLE
[luci] Fix wrong shape inference of BCQGather

### DIFF
--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -1670,7 +1670,7 @@ public:
       output_shape.dim(outdim_index++) = input_shape.dim(i);
     for (uint32_t i = 0; i < indices_shape.rank(); ++i)
       output_shape.dim(outdim_index++) = indices_shape.dim(i);
-    for (uint32_t i = axis + 1; i < indices_shape.rank(); ++i)
+    for (uint32_t i = axis + 1; i < input_shape.rank(); ++i)
       output_shape.dim(outdim_index++) = input_shape.dim(i);
 
     return loco::NodeShape{output_shape};


### PR DESCRIPTION
Parent Issue : #1079 

This commit will fix wrong shape inference of `BCQGather`

:tulip: This PR can me merged with one Review :tulip: 

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>