### PR TITLE
[onert]Adding shape inference for simple op

### DIFF
--- a/runtime/onert/core/include/util/ShapeInference.h
+++ b/runtime/onert/core/include/util/ShapeInference.h
@@ -123,6 +123,7 @@ private:
   void visit(const ir::operation::Neg &op);
   // TODO write op starting from P
   void visit(const ir::operation::Reshape &op);
+  void visit(const ir::operation::Round &op);
   void visit(const ir::operation::Softmax &op);
   void visit(const ir::operation::Tanh &op);
   // TODO write op starting from U
@@ -181,6 +182,7 @@ public:
   void visit(const ir::operation::Neg &op);
   // TODO write op starting from P
   void visit(const ir::operation::Reshape &op);
+  void visit(const ir::operation::Round &op);
   void visit(const ir::operation::Softmax &op);
   void visit(const ir::operation::Tanh &op);
   // TODO write op starting from U

--- a/runtime/onert/core/include/util/ShapeInference.h
+++ b/runtime/onert/core/include/util/ShapeInference.h
@@ -114,6 +114,7 @@ private:
   void visit(const ir::operation::Cast &op);
   void visit(const ir::operation::Concat &op);
   // TODO write op starting from D
+  void visit(const ir::operation::Exp &op);
   void visit(const ir::operation::ExpandDims &op);
   // TODO write op starting from F
   // TODO write op starting from G
@@ -171,6 +172,7 @@ public:
   void visit(const ir::operation::Cast &op);
   void visit(const ir::operation::Concat &op);
   // TODO write op starting from D
+  void visit(const ir::operation::Exp &op);
   void visit(const ir::operation::ExpandDims &op);
   // TODO write op starting from F
   // TODO write op starting from G

--- a/runtime/onert/core/include/util/ShapeInference.h
+++ b/runtime/onert/core/include/util/ShapeInference.h
@@ -120,7 +120,7 @@ private:
   // TODO write op starting from G
   void visit(const ir::operation::Logistic &op);
   // TODO write op starting from M
-  // TODO write op starting from N
+  void visit(const ir::operation::Neg &op);
   // TODO write op starting from P
   void visit(const ir::operation::Reshape &op);
   void visit(const ir::operation::Softmax &op);
@@ -178,7 +178,7 @@ public:
   // TODO write op starting from G
   void visit(const ir::operation::Logistic &op);
   // TODO write op starting from M
-  // TODO write op starting from N
+  void visit(const ir::operation::Neg &op);
   // TODO write op starting from P
   void visit(const ir::operation::Reshape &op);
   void visit(const ir::operation::Softmax &op);

--- a/runtime/onert/core/include/util/ShapeInference.h
+++ b/runtime/onert/core/include/util/ShapeInference.h
@@ -118,6 +118,7 @@ private:
   void visit(const ir::operation::ExpandDims &op);
   // TODO write op starting from F
   // TODO write op starting from G
+  void visit(const ir::operation::Log &op);
   void visit(const ir::operation::Logistic &op);
   // TODO write op starting from M
   void visit(const ir::operation::Neg &op);
@@ -177,6 +178,7 @@ public:
   void visit(const ir::operation::ExpandDims &op);
   // TODO write op starting from F
   // TODO write op starting from G
+  void visit(const ir::operation::Log &op);
   void visit(const ir::operation::Logistic &op);
   // TODO write op starting from M
   void visit(const ir::operation::Neg &op);

--- a/runtime/onert/core/src/util/shapeinf/Exp.cc
+++ b/runtime/onert/core/src/util/shapeinf/Exp.cc
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "util/ShapeInference.h"
+
+namespace onert
+{
+namespace shape_inference
+{
+
+void StaticInferer::visit(const ir::operation::Exp &op)
+{
+  handleSimpleUnaryOp(op, op.getInputs().at(ir::operation::Exp::Input::INPUT));
+}
+
+void DynamicInferer::visit(const ir::operation::Exp &op)
+{
+  handleSimpleUnaryOp(op, op.getInputs().at(ir::operation::Exp::Input::INPUT));
+}
+
+} // namespace shape_inference
+} // namespace onert

--- a/runtime/onert/core/src/util/shapeinf/Log.cc
+++ b/runtime/onert/core/src/util/shapeinf/Log.cc
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "util/ShapeInference.h"
+
+namespace onert
+{
+namespace shape_inference
+{
+
+void StaticInferer::visit(const ir::operation::Log &op)
+{
+  handleSimpleUnaryOp(op, op.getInputs().at(ir::operation::Log::Input::INPUT));
+}
+
+void DynamicInferer::visit(const ir::operation::Log &op)
+{
+  handleSimpleUnaryOp(op, op.getInputs().at(ir::operation::Log::Input::INPUT));
+}
+
+} // namespace shape_inference
+} // namespace onert

--- a/runtime/onert/core/src/util/shapeinf/Neg.cc
+++ b/runtime/onert/core/src/util/shapeinf/Neg.cc
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "util/ShapeInference.h"
+
+namespace onert
+{
+namespace shape_inference
+{
+
+void StaticInferer::visit(const ir::operation::Neg &op)
+{
+  handleSimpleUnaryOp(op, op.getInputs().at(ir::operation::Neg::Input::INPUT));
+}
+
+void DynamicInferer::visit(const ir::operation::Neg &op)
+{
+  handleSimpleUnaryOp(op, op.getInputs().at(ir::operation::Neg::Input::INPUT));
+}
+
+} // namespace shape_inference
+} // namespace onert

--- a/runtime/onert/core/src/util/shapeinf/Round.cc
+++ b/runtime/onert/core/src/util/shapeinf/Round.cc
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "util/ShapeInference.h"
+
+namespace onert
+{
+namespace shape_inference
+{
+
+void StaticInferer::visit(const ir::operation::Round &op)
+{
+  handleSimpleUnaryOp(op, op.getInputs().at(ir::operation::Round::Input::INPUT));
+}
+
+void DynamicInferer::visit(const ir::operation::Round &op)
+{
+  handleSimpleUnaryOp(op, op.getInputs().at(ir::operation::Round::Input::INPUT));
+}
+
+} // namespace shape_inference
+} // namespace onert

--- a/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_cl
+++ b/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_cl
@@ -27,6 +27,7 @@ GeneratedTests.conv_quant8_weights_as_inputs
 GeneratedTests.cos_ex_1D_float_nnfw
 GeneratedTests.cos_ex_4D_float_nnfw
 GeneratedTests.exp_
+GeneratedTests.exp_dynamic_nnfw
 GeneratedTests.expand_dims_dynamic_nnfw_1
 GeneratedTests.expand_dims_dynamic_nnfw_2
 GeneratedTests.fill_ex_1D_float

--- a/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_cl
+++ b/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_cl
@@ -61,6 +61,7 @@ GeneratedTests.lstm3_state3
 GeneratedTests.lstm_state
 GeneratedTests.lstm_state2
 GeneratedTests.neg
+GeneratedTests.neg_dynamic_nnfw
 GeneratedTests.pow_2D_float_nnfw
 GeneratedTests.pow_broadcast_float_nnfw
 GeneratedTests.pow_broadcast_float_nnfw_2

--- a/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_cl
+++ b/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_cl
@@ -95,6 +95,7 @@ GeneratedTests.rnn
 GeneratedTests.rnn_state
 GeneratedTests.round_ex_1D_float
 GeneratedTests.round_ex_4D_float
+GeneratedTests.round_ex_dynamic_nnfw
 GeneratedTests.rsqrt
 GeneratedTests.select_v1_2_five_dim
 GeneratedTests.select_v1_2_five_dim_quant8

--- a/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_cl
+++ b/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_cl
@@ -42,6 +42,7 @@ GeneratedTests.gather_float16_6
 GeneratedTests.gather_float16_7
 GeneratedTests.gather_float16_8
 GeneratedTests.log_4D_float_nnfw
+GeneratedTests.log_dynamic_nnfw
 GeneratedTests.logical_not
 GeneratedTests.logical_not_1D_nnfw
 GeneratedTests.logical_not_4D_nnfw

--- a/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_neon
+++ b/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_neon
@@ -44,6 +44,7 @@ GeneratedTests.depthwise_conv_relaxed
 GeneratedTests.equal_boolean
 GeneratedTests.exp_
 GeneratedTests.exp_2D_float_nnfw
+GeneratedTests.exp_dynamic_nnfw
 GeneratedTests.expand_dims_dynamic_nnfw_1
 GeneratedTests.expand_dims_dynamic_nnfw_2
 GeneratedTests.fill_ex_1D_float

--- a/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_neon
+++ b/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_neon
@@ -65,6 +65,7 @@ GeneratedTests.gather_float16_8
 GeneratedTests.greater_equal_boolean
 GeneratedTests.less_boolean
 GeneratedTests.log_4D_float_nnfw
+GeneratedTests.log_dynamic_nnfw
 GeneratedTests.logical_not
 GeneratedTests.logical_not_1D_nnfw
 GeneratedTests.logical_not_4D_nnfw

--- a/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_neon
+++ b/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_neon
@@ -83,6 +83,7 @@ GeneratedTests.lstm3_state3
 GeneratedTests.lstm_state
 GeneratedTests.lstm_state2
 GeneratedTests.neg
+GeneratedTests.neg_dynamic_nnfw
 GeneratedTests.not_equal_boolean
 GeneratedTests.pow_2D_float_nnfw
 GeneratedTests.pow_broadcast_float_nnfw

--- a/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_neon
+++ b/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_neon
@@ -120,6 +120,7 @@ GeneratedTests.rnn
 GeneratedTests.rnn_state
 GeneratedTests.round_ex_1D_float
 GeneratedTests.round_ex_4D_float
+GeneratedTests.round_ex_dynamic_nnfw
 GeneratedTests.rsqrt
 GeneratedTests.select_v1_2_five_dim
 GeneratedTests.select_v1_2_five_dim_quant8

--- a/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_cl
+++ b/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_cl
@@ -27,6 +27,7 @@ GeneratedTests.conv_quant8_weights_as_inputs
 GeneratedTests.cos_ex_1D_float_nnfw
 GeneratedTests.cos_ex_4D_float_nnfw
 GeneratedTests.exp_
+GeneratedTests.exp_dynamic_nnfw
 GeneratedTests.expand_dims_dynamic_nnfw_1
 GeneratedTests.expand_dims_dynamic_nnfw_2
 GeneratedTests.fill_ex_1D_float

--- a/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_cl
+++ b/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_cl
@@ -61,6 +61,7 @@ GeneratedTests.lstm3_state3
 GeneratedTests.lstm_state
 GeneratedTests.lstm_state2
 GeneratedTests.neg
+GeneratedTests.neg_dynamic_nnfw
 GeneratedTests.pow_2D_float_nnfw
 GeneratedTests.pow_broadcast_float_nnfw
 GeneratedTests.pow_broadcast_float_nnfw_2

--- a/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_cl
+++ b/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_cl
@@ -95,6 +95,7 @@ GeneratedTests.rnn
 GeneratedTests.rnn_state
 GeneratedTests.round_ex_1D_float
 GeneratedTests.round_ex_4D_float
+GeneratedTests.round_ex_dynamic_nnfw
 GeneratedTests.rsqrt
 GeneratedTests.select_v1_2_five_dim
 GeneratedTests.select_v1_2_five_dim_quant8

--- a/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_cl
+++ b/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_cl
@@ -42,6 +42,7 @@ GeneratedTests.gather_float16_6
 GeneratedTests.gather_float16_7
 GeneratedTests.gather_float16_8
 GeneratedTests.log_4D_float_nnfw
+GeneratedTests.log_dynamic_nnfw
 GeneratedTests.logical_not
 GeneratedTests.logical_not_1D_nnfw
 GeneratedTests.logical_not_4D_nnfw

--- a/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_neon
+++ b/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_neon
@@ -44,6 +44,7 @@ GeneratedTests.depthwise_conv_relaxed
 GeneratedTests.equal_boolean
 GeneratedTests.exp_
 GeneratedTests.exp_2D_float_nnfw
+GeneratedTests.exp_dynamic_nnfw
 GeneratedTests.expand_dims_dynamic_nnfw_1
 GeneratedTests.expand_dims_dynamic_nnfw_2
 GeneratedTests.fill_ex_1D_float

--- a/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_neon
+++ b/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_neon
@@ -119,6 +119,7 @@ GeneratedTests.rnn
 GeneratedTests.rnn_state
 GeneratedTests.round_ex_1D_float
 GeneratedTests.round_ex_4D_float
+GeneratedTests.round_ex_dynamic_nnfw
 GeneratedTests.rsqrt
 GeneratedTests.select_v1_2_five_dim
 GeneratedTests.select_v1_2_five_dim_quant8

--- a/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_neon
+++ b/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_neon
@@ -64,6 +64,7 @@ GeneratedTests.gather_float16_8
 GeneratedTests.greater_equal_boolean
 GeneratedTests.less_boolean
 GeneratedTests.log_4D_float_nnfw
+GeneratedTests.log_dynamic_nnfw
 GeneratedTests.logical_not
 GeneratedTests.logical_not_1D_nnfw
 GeneratedTests.logical_not_4D_nnfw

--- a/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_neon
+++ b/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_neon
@@ -82,6 +82,7 @@ GeneratedTests.lstm3_state3
 GeneratedTests.lstm_state
 GeneratedTests.lstm_state2
 GeneratedTests.neg
+GeneratedTests.neg_dynamic_nnfw
 GeneratedTests.not_equal_boolean
 GeneratedTests.pow_2D_float_nnfw
 GeneratedTests.pow_broadcast_float_nnfw

--- a/tests/nnapi/nnapi_gtest.skip.noarch.interp
+++ b/tests/nnapi/nnapi_gtest.skip.noarch.interp
@@ -237,6 +237,7 @@ GeneratedTests.neg_3D_float_nnfw
 GeneratedTests.neg_3D_int_nnfw
 GeneratedTests.neg_4D_float_nnfw
 GeneratedTests.neg_4D_int_nnfw
+GeneratedTests.neg_dynamic_nnfw
 GeneratedTests.not_equal_boolean
 GeneratedTests.not_equal_broadcast
 GeneratedTests.not_equal_broadcast_4D_2D_float_nnfw

--- a/tests/nnapi/nnapi_gtest.skip.noarch.interp
+++ b/tests/nnapi/nnapi_gtest.skip.noarch.interp
@@ -343,6 +343,7 @@ GeneratedTests.rnn
 GeneratedTests.rnn_state
 GeneratedTests.round_ex_1D_float
 GeneratedTests.round_ex_4D_float
+GeneratedTests.round_ex_dynamic_nnfw
 GeneratedTests.rsqrt
 GeneratedTests.rsqrt_1D_float_nnfw
 GeneratedTests.rsqrt_2D_float_nnfw

--- a/tests/nnapi/nnapi_gtest.skip.noarch.interp
+++ b/tests/nnapi/nnapi_gtest.skip.noarch.interp
@@ -107,6 +107,7 @@ GeneratedTests.exp_1D_float_nnfw
 GeneratedTests.exp_2D_float_nnfw
 GeneratedTests.exp_3D_float_nnfw
 GeneratedTests.exp_4D_float_nnfw
+GeneratedTests.exp_dynamic_nnfw
 GeneratedTests.expand_dims
 GeneratedTests.expand_dims_2
 GeneratedTests.expand_dims_3

--- a/tests/nnapi/nnapi_gtest.skip.noarch.interp
+++ b/tests/nnapi/nnapi_gtest.skip.noarch.interp
@@ -170,6 +170,7 @@ GeneratedTests.local_response_norm_float_2
 GeneratedTests.local_response_norm_float_3
 GeneratedTests.local_response_norm_float_4
 GeneratedTests.log_4D_float_nnfw
+GeneratedTests.log_dynamic_nnfw
 GeneratedTests.logical_and_1D_nnfw
 GeneratedTests.logical_and_2D_nnfw
 GeneratedTests.logical_and_3D_nnfw

--- a/tests/nnapi/specs/Ex/round_ex_dynamic_nnfw.mod.py
+++ b/tests/nnapi/specs/Ex/round_ex_dynamic_nnfw.mod.py
@@ -1,0 +1,65 @@
+#
+# Copyright (C) 2018 The Android Open Source Project
+# Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# refer to tanh_v1_dynamic.mod.py about the structore
+
+# This adds reshape as the first op in a model and
+# returns output of reshape, which is dynamic tensor
+
+'''
+Testing Round op when the input is dynamic.
+      input [1, 2, 3]  shape [3]  (value of shape will be [1, 2, 3])
+          |             |
+          +-------------+
+          |
+       Reshape (added by DynamicInputGenerator since it generates its output to be dynamic)
+          |
+          | dynamic tensor at compilation time but the shape will be [1, 2, 3] at execution time
+          |
+         Round
+          |
+        output (dynamic tensor, [1, 2, 3] at execution time)
+'''
+
+import dynamic_tensor
+
+model = Model()
+
+model_input_shape = [1, 2, 3]
+
+dynamic_layer = dynamic_tensor.DynamicInputGenerator(model, model_input_shape)
+
+test_node_input = dynamic_layer.getTestNodeInput()
+
+# write ROUND_EX test. input is `test_input`
+
+# note output shape is used by expected output's shape
+model_output = Output("output", "TENSOR_FLOAT32", "{1, 2, 3}")
+
+model.Operation("ROUND_EX", test_node_input).To(model_output)
+
+model_input_data = [0.001, 8.001, 0.999, 9.999, 0.5, -0.001]
+
+model_output_data = [0.0, 8.0, 1.0, 10.0, 0.0, 0.0]
+
+Example({
+    # use these two as input
+    dynamic_layer.getModelInput(): model_input_data,
+    dynamic_layer.getShapeInput() : model_input_shape,
+
+    model_output: model_output_data,
+})

--- a/tests/nnapi/specs/V1_2/exp_dynamic_nnfw.mod.py
+++ b/tests/nnapi/specs/V1_2/exp_dynamic_nnfw.mod.py
@@ -1,0 +1,64 @@
+#
+# Copyright (C) 2018 The Android Open Source Project
+# Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# refer to tanh_v1_dynamic.mod.py about the structore
+
+# This adds reshape as the first op in a model and
+# returns output of reshape, which is dynamic tensor
+
+'''
+Testing Exp op when the input is dynamic.
+      input [1, 2, 3]  shape [3]  (value of shape will be [1, 2, 3])
+          |             |
+          +-------------+
+          |
+       Reshape (added by DynamicInputGenerator since it generates its output to be dynamic)
+          |
+          | dynamic tensor at compilation time but the shape will be [1, 2, 3] at execution time
+          |
+         Exp
+          |
+        output (dynamic tensor, [1, 2, 3] at execution time)
+'''
+
+import dynamic_tensor
+
+model = Model()
+
+model_input_shape = [1, 2, 3]
+
+dynamic_layer = dynamic_tensor.DynamicInputGenerator(model, model_input_shape)
+
+test_node_input = dynamic_layer.getTestNodeInput()
+
+# write EXP test. input is `test_input`
+
+# note output shape is used by expected output's shape
+model_output = Output("output", "TENSOR_FLOAT32", "{1, 2, 3}")
+
+model.Operation("EXP", test_node_input).To(model_output)
+
+model_input_data = [0, 1, 0.5, -1, 10, 20]
+model_output_data = [1.00000000e+00, 2.71828183e+00, 1.64872127e+00, 3.67879441e-01,
+                     2.20264658e+04, 4.85165195e+08]
+Example({
+    # use these two as input
+    dynamic_layer.getModelInput(): model_input_data,
+    dynamic_layer.getShapeInput() : model_input_shape,
+
+    model_output: model_output_data,
+})

--- a/tests/nnapi/specs/V1_2/log_dynamic_nnfw.mod.py
+++ b/tests/nnapi/specs/V1_2/log_dynamic_nnfw.mod.py
@@ -1,0 +1,64 @@
+#
+# Copyright (C) 2018 The Android Open Source Project
+# Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# refer to tanh_v1_dynamic.mod.py about the structore
+
+# This adds reshape as the first op in a model and
+# returns output of reshape, which is dynamic tensor
+
+'''
+Testing Log op when the input is dynamic.
+      input [1, 2, 3]  shape [3]  (value of shape will be [1, 2, 3])
+          |             |
+          +-------------+
+          |
+       Reshape (added by DynamicInputGenerator since it generates its output to be dynamic)
+          |
+          | dynamic tensor at compilation time but the shape will be [1, 2, 3] at execution time
+          |
+         Log
+          |
+        output (dynamic tensor, [1, 2, 3] at execution time)
+'''
+
+import dynamic_tensor
+
+model = Model()
+
+model_input_shape = [1, 2, 3]
+
+dynamic_layer = dynamic_tensor.DynamicInputGenerator(model, model_input_shape)
+
+test_node_input = dynamic_layer.getTestNodeInput()
+
+# write Log test. input is `test_input`
+
+# note output shape is used by expected output's shape
+model_output = Output("output", "TENSOR_FLOAT32", "{1, 2, 3}")
+
+model.Operation("LOG", test_node_input).To(model_output)
+
+model_input_data = [12.0, 36.0, 2.0, 90, 1.0, 0.012]
+model_output_data = [2.4849066497880004, 3.58351893845611, 0.6931471805599453, 4.499809670330265,
+                     0.0, -4.422848629194137]
+Example({
+    # use these two as input
+    dynamic_layer.getModelInput(): model_input_data,
+    dynamic_layer.getShapeInput() : model_input_shape,
+
+    model_output: model_output_data,
+})

--- a/tests/nnapi/specs/V1_2/neg_dynamic_nnfw.mod.py
+++ b/tests/nnapi/specs/V1_2/neg_dynamic_nnfw.mod.py
@@ -1,0 +1,64 @@
+#
+# Copyright (C) 2018 The Android Open Source Project
+# Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# refer to tanh_v1_dynamic.mod.py about the structore
+
+# This adds reshape as the first op in a model and
+# returns output of reshape, which is dynamic tensor
+
+'''
+Testing Neg op when the input is dynamic.
+      input [1, 2, 3]  shape [3]  (value of shape will be [1, 2, 3])
+          |             |
+          +-------------+
+          |
+       Reshape (added by DynamicInputGenerator since it generates its output to be dynamic)
+          |
+          | dynamic tensor at compilation time but the shape will be [1, 2, 3] at execution time
+          |
+         Neg
+          |
+        output (dynamic tensor, [1, 2, 3] at execution time)
+'''
+
+import dynamic_tensor
+
+model = Model()
+
+model_input_shape = [1, 2, 3]
+
+dynamic_layer = dynamic_tensor.DynamicInputGenerator(model, model_input_shape)
+
+test_node_input = dynamic_layer.getTestNodeInput()
+
+# write Neg test. input is `test_input`
+
+# note output shape is used by expected output's shape
+model_output = Output("output", "TENSOR_FLOAT32", "{1, 2, 3}")
+
+model.Operation("NEG", test_node_input).To(model_output)
+
+model_input_data = [-10, 1, 0.5, -1, 30, 20]
+model_output_data = [10, -1, -0.5, 1, -30, -20]
+
+Example({
+    # use these two as input
+    dynamic_layer.getModelInput(): model_input_data,
+    dynamic_layer.getShapeInput() : model_input_shape,
+
+    model_output: model_output_data,
+})


### PR DESCRIPTION
This adds shape inference for simple op(log, exp, neg, round).
If https://github.com/Samsung/ONE/pull/1380 is merged, I will change to handleSimpleUnaryOp. [DONE]

Signed-off-by: YiHyunjin <hj0412.yi@samsung.com>