### PR TITLE
[luci] NEG service

### DIFF
--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -916,6 +916,12 @@ public:
     return loco::NodeShape{output_shape};
   }
 
+  loco::NodeShape visit(const luci::CircleNeg *node) final
+  {
+    auto x_shape = loco::shape_get(node->x()).as<loco::TensorShape>();
+    return loco::NodeShape{x_shape};
+  }
+
   loco::NodeShape visit(const luci::CircleNotEqual *node) final
   {
     const auto x_shape = loco::shape_get(node->x()).as<loco::TensorShape>();

--- a/compiler/luci/service/src/CircleTypeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleTypeInferenceRule.cpp
@@ -194,6 +194,8 @@ struct TypeInferenceAlgorithm final : public luci::CircleNodeVisitor<loco::DataT
     return loco::dtype_get(node->input());
   }
 
+  loco::DataType visit(const luci::CircleNeg *node) final { return loco::dtype_get(node->x()); }
+
   loco::DataType visit(const luci::CircleNotEqual *) final { return loco::DataType::BOOL; }
 
   loco::DataType visit(const luci::CirclePack *node) final


### PR DESCRIPTION
This enables shape and type inference for NEG operator

For #1034
Draft #1049 

ONE-DCO-1.0-Signed-off-by: Andrey Kvochko <a.kvochko@samsung.com>