### PR TITLE
[oneapi] Fix when set_input buffer is null

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -201,6 +201,20 @@ NNFW_STATUS nnfw_session::run()
 NNFW_STATUS nnfw_session::set_input(uint32_t index, NNFW_TYPE /*type*/, const void *buffer,
                                     size_t length)
 {
+  if (!isStatePrepared())
+  {
+    std::cerr << "Error during nnfw_session::set_input : invalid state" << std::endl;
+    return NNFW_STATUS_ERROR;
+  }
+
+  if (!buffer && length != 0)
+  {
+    std::cerr
+        << "Error during nnfw_session::set_input : given buffer is NULL but the length is not 0"
+        << std::endl;
+    return NNFW_STATUS_ERROR;
+  }
+
   try
   {
     _execution->setInput(onert::ir::IOIndex(index), buffer, length);

--- a/runtime/onert/core/src/exec/Execution.cc
+++ b/runtime/onert/core/src/exec/Execution.cc
@@ -56,6 +56,8 @@ void Execution::setInput(const ir::IOIndex &index, const void *buffer, size_t le
   const auto input_index = primary_subgraph().getInputs().at(index);
   const auto info = primary_subgraph().operands().at(input_index).info();
 
+  // TODO handle when (!buffer && length != 0) : setting the input as an optional tensor
+
   // check if size enough for input is passed
   // if input_shape_sig is set, input_shape_sig overrides shape in info
   // note: input_shape_sig contains shape passed by nnfw_apply_tensorinfo()

--- a/tests/nnfw_api/src/ValidationTestAddModelLoaded.cc
+++ b/tests/nnfw_api/src/ValidationTestAddModelLoaded.cc
@@ -30,3 +30,8 @@ TEST_F(ValidationTestAddModelLoaded, neg_run_001)
 }
 
 TEST_F(ValidationTest, neg_prepare_001) { ASSERT_EQ(nnfw_prepare(nullptr), NNFW_STATUS_ERROR); }
+
+TEST_F(ValidationTestAddModelLoaded, neg_set_input_001)
+{
+  ASSERT_EQ(nnfw_set_input(_session, 0, NNFW_TYPE_TENSOR_FLOAT32, nullptr, 0), NNFW_STATUS_ERROR);
+}

--- a/tests/nnfw_api/src/ValidationTestAddSessionPrepared.cc
+++ b/tests/nnfw_api/src/ValidationTestAddSessionPrepared.cc
@@ -42,4 +42,23 @@ TEST_F(ValidationTestAddSessionPrepared, run_001)
   ASSERT_EQ(nnfw_run(_session), NNFW_STATUS_NO_ERROR);
 }
 
+TEST_F(ValidationTestAddSessionPrepared, set_input_001)
+{
+  char input[32];
+  ASSERT_EQ(nnfw_set_input(_session, 0, NNFW_TYPE_TENSOR_FLOAT32, input, sizeof(input)),
+            NNFW_STATUS_NO_ERROR);
+}
+
+TEST_F(ValidationTestAddSessionPrepared, neg_set_input_001)
+{
+  ASSERT_EQ(nnfw_set_input(_session, 0, NNFW_TYPE_TENSOR_FLOAT32, nullptr, 1), NNFW_STATUS_ERROR);
+}
+
+TEST_F(ValidationTestAddSessionPrepared, neg_set_input_002)
+{
+  char input[1]; // buffer size is too small
+  ASSERT_EQ(nnfw_set_input(_session, 0, NNFW_TYPE_TENSOR_FLOAT32, input, sizeof(input)),
+            NNFW_STATUS_ERROR);
+}
+
 // TODO Validation check when "nnfw_run" is called without input & output tensor setting

--- a/tests/nnfw_api/src/ValidationTestSessionCreated.cc
+++ b/tests/nnfw_api/src/ValidationTestSessionCreated.cc
@@ -51,3 +51,9 @@ TEST_F(ValidationTestSessionCreated, neg_run_001)
   // nnfw_load_model_from_file and nnfw_prepare was not called
   ASSERT_EQ(nnfw_run(_session), NNFW_STATUS_ERROR);
 }
+
+TEST_F(ValidationTestSessionCreated, neg_set_input_001)
+{
+  // Invalid state
+  ASSERT_EQ(nnfw_set_input(_session, 0, NNFW_TYPE_TENSOR_FLOAT32, nullptr, 0), NNFW_STATUS_ERROR);
+}

--- a/tests/nnfw_api/src/ValidationTestSingleSession.cc
+++ b/tests/nnfw_api/src/ValidationTestSingleSession.cc
@@ -32,3 +32,16 @@ TEST_F(ValidationTestSingleSession, neg_run_001)
 {
   ASSERT_EQ(nnfw_run(nullptr), NNFW_STATUS_ERROR);
 }
+
+TEST_F(ValidationTestSingleSession, neg_set_input_001)
+{
+  // Invalid session
+  ASSERT_EQ(nnfw_set_input(nullptr, 0, NNFW_TYPE_TENSOR_FLOAT32, nullptr, 0), NNFW_STATUS_ERROR);
+}
+
+TEST_F(ValidationTestSingleSession, neg_set_input_002)
+{
+  char input[32];
+  ASSERT_EQ(nnfw_set_input(nullptr, 0, NNFW_TYPE_TENSOR_FLOAT32, input, sizeof(input)),
+            NNFW_STATUS_ERROR);
+}


### PR DESCRIPTION
- Return error code when argument `buffer` of `nnfw_set_input` is null
  but the length is not 0
- Return error code when the session is not the valid state
- Add 7 TCs for `nnfw_set_input` (6 negative tests)

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>