### PR TITLE
[luci/service] ResizeNearestNeighbor support for shape and type inference

### DIFF
--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -1196,6 +1196,34 @@ public:
     return loco::NodeShape{output_shape};
   }
 
+  loco::NodeShape visit(const luci::CircleResizeNearestNeighbor *node) final
+  {
+    auto input_shape = loco::shape_get(node->input()).as<loco::TensorShape>();
+
+    if (input_shape.rank() != 4)
+      INTERNAL_EXN("Expected ResizeNearesNeighbor input to have rank 4");
+
+    auto *const_node = loco::must_cast<luci::CircleConst *>(node->size());
+
+    if (const_node->dtype() != loco::DataType::S32)
+      INTERNAL_EXN("Only S32 datatype is supported for ResizeNearesNeighbor size");
+
+    if (const_node->rank() != 1)
+      INTERNAL_EXN("Expected size tensor of rank 1");
+
+    if (const_node->dim(0).value() != 2)
+      INTERNAL_EXN("Expected size tensor with shape [2]");
+
+    loco::TensorShape output_shape;
+    output_shape.rank(4);
+    output_shape.dim(0) = input_shape.dim(0);
+    output_shape.dim(1) = const_node->at<loco::DataType::S32>(0);
+    output_shape.dim(2) = const_node->at<loco::DataType::S32>(1);
+    output_shape.dim(3) = input_shape.dim(3);
+
+    return loco::NodeShape{output_shape};
+  }
+
   loco::NodeShape visit(const luci::CircleRsqrt *node) final
   {
     auto input_shape = loco::shape_get(node->x()).as<loco::TensorShape>();

--- a/compiler/luci/service/src/CircleTypeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleTypeInferenceRule.cpp
@@ -271,6 +271,11 @@ struct TypeInferenceAlgorithm final : public luci::CircleNodeVisitor<loco::DataT
     return loco::dtype_get(node->tensor());
   }
 
+  loco::DataType visit(const luci::CircleResizeNearestNeighbor *node) final
+  {
+    return loco::dtype_get(node->input());
+  }
+
   loco::DataType visit(const luci::CircleRsqrt *node) final { return loco::dtype_get(node->x()); }
 
   loco::DataType visit(const luci::CircleSelect *node) final

--- a/compiler/luci/service/src/TestGraph.h
+++ b/compiler/luci/service/src/TestGraph.h
@@ -139,6 +139,13 @@ private:
     node->perm(arg2);
   };
 
+  void setInput(luci::CircleResizeNearestNeighbor *node, luci::CircleNode *input,
+                luci::CircleNode *size)
+  {
+    node->input(input);
+    node->size(size);
+  };
+
   // arity 3
   void setInput(luci::CircleNode *, luci::CircleNode *, luci::CircleNode *, luci::CircleNode *)
   {


### PR DESCRIPTION
Add shape and type inference support for ResizeNearestNeighbor operator

ONE-DCO-1.0-Signed-off-by: Vladimir Plazun v.plazun@samsung.com