### PR TITLE
[tfldump] ResizeNearestNeighbor support for tflite dump

### DIFF
--- a/compiler/tfldump/src/OpPrinter.cpp
+++ b/compiler/tfldump/src/OpPrinter.cpp
@@ -174,6 +174,21 @@ public:
   }
 };
 
+class ResizeNearestNeighborPrinter : public OpPrinter
+{
+public:
+  void options(const tflite::Operator *op, std::ostream &os) const override
+  {
+    if (auto *resize_params = op->builtin_options_as_ResizeNearestNeighborOptions())
+    {
+      os << "    ";
+      os << std::boolalpha;
+      os << "align_corners(" << resize_params->align_corners() << ")";
+      os << std::endl;
+    }
+  }
+};
+
 class DepthwiseConv2DPrinter : public OpPrinter
 {
 public:
@@ -543,6 +558,8 @@ OpPrinterRegistry::OpPrinterRegistry()
   _op_map[tflite::BuiltinOperator_REDUCE_MAX] = make_unique<ReducerPrinter>();
   _op_map[tflite::BuiltinOperator_REDUCE_PROD] = make_unique<ReducerPrinter>();
   _op_map[tflite::BuiltinOperator_RESHAPE] = make_unique<ReshapePrinter>();
+  _op_map[tflite::BuiltinOperator_RESIZE_NEAREST_NEIGHBOR] =
+      make_unique<ResizeNearestNeighborPrinter>();
   // There is no Option for SELECT
   _op_map[tflite::BuiltinOperator_SHAPE] = make_unique<ShapePrinter>();
   // There is no Option for SIN


### PR DESCRIPTION
Add tflite dump support for ResizeNearestNeighbor operator

ONE-DCO-1.0-Signed-off-by: Vladimir Plazun v.plazun@samsung.com