### PR TITLE
[circledump] ResizeNearestNeighbor support for circle dump

### DIFF
--- a/compiler/circledump/src/OpPrinter.cpp
+++ b/compiler/circledump/src/OpPrinter.cpp
@@ -174,6 +174,21 @@ public:
   }
 };
 
+class ResizeNearestNeighborPrinter : public OpPrinter
+{
+public:
+  void options(const circle::Operator *op, std::ostream &os) const override
+  {
+    if (auto *resize_params = op->builtin_options_as_ResizeNearestNeighborOptions())
+    {
+      os << "    ";
+      os << std::boolalpha;
+      os << "align_corners(" << resize_params->align_corners() << ")";
+      os << std::endl;
+    }
+  }
+};
+
 class DepthwiseConv2DPrinter : public OpPrinter
 {
 public:
@@ -574,6 +589,8 @@ OpPrinterRegistry::OpPrinterRegistry()
   _op_map[circle::BuiltinOperator_REDUCE_MAX] = make_unique<ReducerPrinter>();
   _op_map[circle::BuiltinOperator_REDUCE_PROD] = make_unique<ReducerPrinter>();
   _op_map[circle::BuiltinOperator_RESHAPE] = make_unique<ReshapePrinter>();
+  _op_map[circle::BuiltinOperator_RESIZE_NEAREST_NEIGHBOR] =
+      make_unique<ResizeNearestNeighborPrinter>();
   // There is no Option for SELECT
   _op_map[circle::BuiltinOperator_SHAPE] = make_unique<ShapePrinter>();
   // There is no Option for SIN


### PR DESCRIPTION
Add circle dump support for ResizeNearestNeighbor operator

ONE-DCO-1.0-Signed-off-by: Vladimir Plazun v.plazun@samsung.com