### PR TITLE
[luci/export] Fix pow options type

### DIFF
--- a/compiler/luci/export/src/CircleOperationExporter.cpp
+++ b/compiler/luci/export/src/CircleOperationExporter.cpp
@@ -867,7 +867,7 @@ void OperationExporter::visit(luci::CirclePow *node)
   std::vector<int32_t> outputs_vec{get_tensor_index(static_cast<loco::Node *>(node))};
   auto inputs = builder.CreateVector(inputs_vec);
   auto outputs = builder.CreateVector(outputs_vec);
-  auto options = CreatePadOptions(builder);
+  auto options = CreatePowOptions(builder);
   auto op_offset = CreateOperator(builder, op_idx, inputs, outputs,
                                   circle::BuiltinOptions_PowOptions, options.Union());
   gd._operators.push_back(op_offset);


### PR DESCRIPTION
`CreatePadOptions` function was used in Pow operator exporter

ONE-DCO-1.0-Signed-off-by: Vladimir Plazun v.plazun@samsung.com