### PR TITLE
[luci-interpreter] Make IR nodes available in `interpret` method

### DIFF
--- a/compiler/luci-interpreter/include/luci_interpreter/Interpreter.h
+++ b/compiler/luci-interpreter/include/luci_interpreter/Interpreter.h
@@ -30,8 +30,8 @@
 namespace luci_interpreter
 {
 
+class KernelMap;
 class TensorMap;
-class Kernel;
 
 class Interpreter
 {
@@ -48,10 +48,11 @@ public:
 
 private:
   void createTensors(const loco::Graph *graph);
-  void createExecutionSequence(const loco::Graph *main_graph);
+  void createKernels(const loco::Graph *graph);
 
+  const loco::Graph *_main_graph = nullptr;
   std::unique_ptr<TensorMap> _tensor_map;
-  std::vector<std::unique_ptr<Kernel>> _execution_sequence;
+  std::unique_ptr<KernelMap> _kernel_map;
 };
 
 } // namespace luci_interpreter

--- a/compiler/luci-interpreter/src/CMakeLists.txt
+++ b/compiler/luci-interpreter/src/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SOURCES
     Interpreter.cpp
     KernelBuilder.h
     KernelBuilder.cpp
+    KernelMap.h
     TensorMap.h)
 
 add_library(luci_interpreter SHARED ${SOURCES})

--- a/compiler/luci-interpreter/src/Interpreter.cpp
+++ b/compiler/luci-interpreter/src/Interpreter.cpp
@@ -151,7 +151,7 @@ Interpreter::Interpreter(const luci::Module *module)
   for (const loco::Node *loco_node :
        loco::postorder_traversal(loco::output_nodes(const_cast<loco::Graph *>(_main_graph))))
   {
-    const auto *node = dynamic_cast<const luci::CircleNode *>(loco_node);
+    const auto *node = loco::must_cast<const luci::CircleNode *>(loco_node);
     assert(node != nullptr);
 
     // These nodes are auxiliary.

--- a/compiler/luci-interpreter/src/Interpreter.cpp
+++ b/compiler/luci-interpreter/src/Interpreter.cpp
@@ -198,7 +198,7 @@ void Interpreter::interpret()
   for (const loco::Node *loco_node :
        loco::postorder_traversal(loco::output_nodes(const_cast<loco::Graph *>(_main_graph))))
   {
-    const auto *node = dynamic_cast<const luci::CircleNode *>(loco_node);
+    const auto *node = loco::must_cast<const luci::CircleNode *>(loco_node);
     assert(node != nullptr);
 
     // These nodes are auxiliary and are not executed.

--- a/compiler/luci-interpreter/src/KernelMap.h
+++ b/compiler/luci-interpreter/src/KernelMap.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef LUCI_INTERPRETER_KERNELMAP_H
+#define LUCI_INTERPRETER_KERNELMAP_H
+
+#include "core/Kernel.h"
+
+#include <luci/IR/CircleNode.h>
+
+#include <cassert>
+#include <unordered_map>
+
+namespace luci_interpreter
+{
+
+class KernelMap
+{
+public:
+  // Associates a node with the kernel.
+  void setKernel(const luci::CircleNode *node, std::unique_ptr<Kernel> kernel)
+  {
+    assert(_kernels.find(node) == _kernels.cend());
+    _kernels.emplace(node, std::move(kernel));
+  }
+
+  // Finds the kernel associated with the node.
+  Kernel *getKernel(const luci::CircleNode *node)
+  {
+    const auto it = _kernels.find(node);
+    assert(it != _kernels.cend());
+    return it->second.get();
+  }
+
+private:
+  std::unordered_map<const luci::CircleNode *, std::unique_ptr<Kernel>> _kernels;
+};
+
+} // namespace luci_interpreter
+
+#endif // LUCI_INTERPRETER_KERNELMAP_H


### PR DESCRIPTION
For issue #1098.

Add a mapping `CircleNode*` -> `Kernel` so that the `interpret` method knows which node it executes when calling a kernel.

ONE-DCO-1.0-Signed-off-by: Sergei Barannikov <s.barannikov@samsung.com>