### PR TITLE
[onert] Remove OperationValidator::visit(Fill) that validates nothing

### DIFF
--- a/runtime/onert/core/src/compiler/OperationValidator.cc
+++ b/runtime/onert/core/src/compiler/OperationValidator.cc
@@ -495,18 +495,6 @@ void OperationValidator::visit(const ir::operation::ExpandDims &node)
   OP_REQUIRES(_ctx.at(axis_index).shape().rank() <= 1);
 }
 
-void OperationValidator::visit(const ir::operation::Fill &node)
-{
-  const auto output_index{node.getOutputs().at(0)};
-  // This validator does not check shape. So checking isDynamic() is skipped.
-
-  const auto input_index{node.getInputs().at(0)};
-  const auto value_index{node.getInputs().at(1)};
-  UNUSED_RELEASE(output_index);
-  UNUSED_RELEASE(input_index);
-  UNUSED_RELEASE(value_index);
-}
-
 void OperationValidator::visit(const ir::operation::Floor &node)
 {
   const auto output_index{node.getOutputs().at(0)};

--- a/runtime/onert/core/src/compiler/OperationValidator.h
+++ b/runtime/onert/core/src/compiler/OperationValidator.h
@@ -63,7 +63,6 @@ public:
   void visit(const ir::operation::EmbeddingLookup &node) override;
   void visit(const ir::operation::Exp &node) override;
   void visit(const ir::operation::ExpandDims &node) override;
-  void visit(const ir::operation::Fill &node) override;
   void visit(const ir::operation::Floor &node) override;
   void visit(const ir::operation::HashtableLookup &node) override;
   void visit(const ir::operation::TransposeConv &node) override;


### PR DESCRIPTION
`Fill` does something, however it does not validate at all.
It removes the implementation.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>