### PR TITLE
[luci/service] Enable shape/type inference for Floor Op

### DIFF
--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -658,6 +658,12 @@ public:
     return loco::NodeShape{shape};
   }
 
+  loco::NodeShape visit(const luci::CircleFloor *node) final
+  {
+    auto x_shape = loco::shape_get(node->x()).as<loco::TensorShape>();
+    return loco::NodeShape{x_shape};
+  }
+
   loco::NodeShape visit(const luci::CircleFloorDiv *node) final
   {
     auto x_shape = loco::shape_get(node->x()).as<loco::TensorShape>();

--- a/compiler/luci/service/src/CircleTypeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleTypeInferenceRule.cpp
@@ -107,6 +107,8 @@ struct TypeInferenceAlgorithm final : public luci::CircleNodeVisitor<loco::DataT
     return loco::dtype_get(node->value());
   }
 
+  loco::DataType visit(const luci::CircleFloor *node) final { return loco::dtype_get(node->x()); }
+
   loco::DataType visit(const luci::CircleFloorDiv *node) final
   {
     return loco::dtype_get(node->x());


### PR DESCRIPTION
Parent Issue : #1392
Draft PR : #1393

This commit enable shape/type inference for `Floor` in luci/service.

ONE-DCO-1.0-Signed-off-by: KiDeuk Bang <rrstrous@nate.com>