### PR TITLE
[onert] Modifying code that checks not specified graph output shape

### DIFF
--- a/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksExecution.cc
+++ b/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksExecution.cc
@@ -219,23 +219,19 @@ bool ANeuralNetworksExecution::getOutputOperandRank(uint32_t index, uint32_t *ra
   try
   {
     onert::ir::IOIndex output_index{index};
-    const auto operand_index = getOutputOperandIndex(index);
-    bool unspecified = haveUnspecifiedDims(operand_index);
-
-    // TODO Get unspecified output operand's rank
-    if (unspecified)
-    {
-      throw std::runtime_error{"Unsupport feature"};
-    }
 
     // Check execution is finished
-    // Output rank and shape may be decided after execution if output is unspecified operand
     if (!_execution->isFinished())
     {
       return false;
     }
 
     const auto shape = _execution->getOutputShape(output_index);
+    if (onert::ir::haveUnspecifiedDims(shape))
+    {
+      throw std::runtime_error{"Internal error: Output tensor has unspecified dims"};
+    }
+
     *rank = shape.rank();
   }
   catch (const std::exception &e)
@@ -253,21 +249,19 @@ bool ANeuralNetworksExecution::getOutputOperandDimensions(uint32_t index, uint32
   try
   {
     onert::ir::IOIndex output_index{index};
-    const auto operand_index = getOutputOperandIndex(index);
-    bool unspecified = haveUnspecifiedDims(operand_index);
-    if (unspecified)
-    {
-      throw std::runtime_error{"NYI: Models with unspecified output dimensions"};
-    }
 
     // Check execution is finished
-    // Output rank and shape may be decided after execution if output is unspecified operand
     if (!_execution->isFinished())
     {
       return false;
     }
 
     const auto shape = _execution->getOutputShape(output_index);
+    if (onert::ir::haveUnspecifiedDims(shape))
+    {
+      throw std::runtime_error{"Internal error: Output tensor has unspecified dims"};
+    }
+
     for (int i = 0; i < shape.rank(); i++)
     {
       auto dim = shape.dim(i);


### PR DESCRIPTION
This modifies code that checks if shape of graph output tensor contains unspecified dims.

Previous code checks unspecified dims in `Operand` but now it is not correct. It should be checked from `ITensor`.

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>