### PR TITLE
[luci] Revise shape inf of Reshape Op

### DIFF
--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -1141,8 +1141,8 @@ public:
 
   /**
    * @note  CircleReshape has new shape info in two places: 2nd input and attribute.
-   *        This shape inference forces both to exist, and match each other.
-   *        When this condition satisfied, it return the inferred shape
+   *        This shape inference uses shape from input 'shape' node when it's constant.
+   *        If not, shape will be from node itself. shape from attribute is not used.
    *
    * TODO Change this policy when not appropriate
    */


### PR DESCRIPTION
This will revise shape inference of Reshape Op
- 'shape' input maybe not CircleConst
- dump two shape information instead of assert

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>