### PR TITLE
[luci] Revise import Reshape

### DIFF
--- a/compiler/luci/import/src/Nodes/CircleReshape.cpp
+++ b/compiler/luci/import/src/Nodes/CircleReshape.cpp
@@ -66,7 +66,14 @@ CircleNode *CircleReshapeGraphBuilder::build_node(const circle::OperatorT &op,
   if (shape_node == nullptr)
   {
     const auto *options = op.builtin_options.AsReshapeOptions();
-    shape_node = create_shape_node(options->new_shape, graph);
+    if (options != nullptr)
+      shape_node = create_shape_node(options->new_shape, graph);
+    else
+    {
+      shape_node = graph->nodes()->create<CircleOutputDummy>();
+      shape_node->dtype(loco::DataType::S32);
+      shape_node->rank(0);
+    }
   }
 
   auto *node = graph->nodes()->create<CircleReshape>();
@@ -74,7 +81,8 @@ CircleNode *CircleReshapeGraphBuilder::build_node(const circle::OperatorT &op,
   node->shape(shape_node);
 
   const auto *options = op.builtin_options.AsReshapeOptions();
-  setup_shape_attribute(options->new_shape, node);
+  if (options)
+    setup_shape_attribute(options->new_shape, node);
 
   return node;
 }

--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleReshape.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleReshape.h
@@ -38,8 +38,8 @@ public:
   loco::Node *tensor(void) const { return at(0)->node(); }
   void tensor(loco::Node *node) { at(0)->node(node); }
 
-  // TODO Make this input optional. That is, loco system does not emit error
-  //      with this input being null
+  // NOTE shape is optional and can be CircleConst or any other type
+  //      and also can be CircleOutputDummy when reshape option does not exist
   loco::Node *shape(void) const { return at(1)->node(); }
   void shape(loco::Node *node) { at(1)->node(node); }
 


### PR DESCRIPTION
This will revise import of Reshape Op where ReshapeOptions is null
- also update comment in IR

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>