### PR TITLE
[oneapi] Fix when set_output buffer is null

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -230,6 +230,20 @@ NNFW_STATUS nnfw_session::set_input(uint32_t index, NNFW_TYPE /*type*/, const vo
 NNFW_STATUS nnfw_session::set_output(uint32_t index, NNFW_TYPE /*type*/, void *buffer,
                                      size_t length)
 {
+  if (!isStatePrepared())
+  {
+    std::cerr << "Error during nnfw_session::set_output : invalid state" << std::endl;
+    return NNFW_STATUS_ERROR;
+  }
+
+  if (!buffer && length != 0)
+  {
+    std::cerr
+        << "Error during nnfw_session::set_output : given buffer is NULL but the length is not 0"
+        << std::endl;
+    return NNFW_STATUS_ERROR;
+  }
+
   try
   {
     _execution->setOutput(onert::ir::IOIndex(index), buffer, length);

--- a/tests/nnfw_api/src/ValidationTestAddModelLoaded.cc
+++ b/tests/nnfw_api/src/ValidationTestAddModelLoaded.cc
@@ -35,3 +35,8 @@ TEST_F(ValidationTestAddModelLoaded, neg_set_input_001)
 {
   ASSERT_EQ(nnfw_set_input(_session, 0, NNFW_TYPE_TENSOR_FLOAT32, nullptr, 0), NNFW_STATUS_ERROR);
 }
+
+TEST_F(ValidationTestAddModelLoaded, neg_set_output_001)
+{
+  ASSERT_EQ(nnfw_set_output(_session, 0, NNFW_TYPE_TENSOR_FLOAT32, nullptr, 0), NNFW_STATUS_ERROR);
+}

--- a/tests/nnfw_api/src/ValidationTestAddSessionPrepared.cc
+++ b/tests/nnfw_api/src/ValidationTestAddSessionPrepared.cc
@@ -61,4 +61,23 @@ TEST_F(ValidationTestAddSessionPrepared, neg_set_input_002)
             NNFW_STATUS_ERROR);
 }
 
+TEST_F(ValidationTestAddSessionPrepared, set_output_001)
+{
+  char buffer[32];
+  ASSERT_EQ(nnfw_set_input(_session, 0, NNFW_TYPE_TENSOR_FLOAT32, buffer, sizeof(buffer)),
+            NNFW_STATUS_NO_ERROR);
+}
+
+TEST_F(ValidationTestAddSessionPrepared, neg_set_output_001)
+{
+  ASSERT_EQ(nnfw_set_output(_session, 0, NNFW_TYPE_TENSOR_FLOAT32, nullptr, 1), NNFW_STATUS_ERROR);
+}
+
+TEST_F(ValidationTestAddSessionPrepared, neg_set_output_002)
+{
+  char input[1]; // buffer size is too small
+  ASSERT_EQ(nnfw_set_output(_session, 0, NNFW_TYPE_TENSOR_FLOAT32, input, sizeof(input)),
+            NNFW_STATUS_ERROR);
+}
+
 // TODO Validation check when "nnfw_run" is called without input & output tensor setting

--- a/tests/nnfw_api/src/ValidationTestSessionCreated.cc
+++ b/tests/nnfw_api/src/ValidationTestSessionCreated.cc
@@ -57,3 +57,9 @@ TEST_F(ValidationTestSessionCreated, neg_set_input_001)
   // Invalid state
   ASSERT_EQ(nnfw_set_input(_session, 0, NNFW_TYPE_TENSOR_FLOAT32, nullptr, 0), NNFW_STATUS_ERROR);
 }
+
+TEST_F(ValidationTestSessionCreated, neg_set_output_001)
+{
+  // Invalid state
+  ASSERT_EQ(nnfw_set_output(_session, 0, NNFW_TYPE_TENSOR_FLOAT32, nullptr, 0), NNFW_STATUS_ERROR);
+}

--- a/tests/nnfw_api/src/ValidationTestSingleSession.cc
+++ b/tests/nnfw_api/src/ValidationTestSingleSession.cc
@@ -45,3 +45,16 @@ TEST_F(ValidationTestSingleSession, neg_set_input_002)
   ASSERT_EQ(nnfw_set_input(nullptr, 0, NNFW_TYPE_TENSOR_FLOAT32, input, sizeof(input)),
             NNFW_STATUS_ERROR);
 }
+
+TEST_F(ValidationTestSingleSession, neg_set_output_001)
+{
+  // Invalid session
+  ASSERT_EQ(nnfw_set_output(nullptr, 0, NNFW_TYPE_TENSOR_FLOAT32, nullptr, 0), NNFW_STATUS_ERROR);
+}
+
+TEST_F(ValidationTestSingleSession, neg_set_output_002)
+{
+  char buffer[32];
+  ASSERT_EQ(nnfw_set_output(nullptr, 0, NNFW_TYPE_TENSOR_FLOAT32, buffer, sizeof(buffer)),
+            NNFW_STATUS_ERROR);
+}


### PR DESCRIPTION
- Return error code when argument `buffer` of `nnfw_set_output` is null
  but the length is not 0
- Return error code when the session is not the valid state
- Add 7 TCs for `nnfw_set_output` (6 negative tests)

Just the same way with #1485

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>