### PR TITLE
[onert] modify shape::num_element() considering dim = 0

### DIFF
--- a/runtime/onert/core/include/ir/Shape.h
+++ b/runtime/onert/core/include/ir/Shape.h
@@ -54,6 +54,9 @@ public:
 
   int32_t &dim(int i) { return _dimensions.at(i); }
 
+  /**
+   * @brief Returns number of elements when rank or dim is specified
+   */
   uint64_t num_elements() const;
 
 public:

--- a/runtime/onert/core/src/ir/Shape.cc
+++ b/runtime/onert/core/src/ir/Shape.cc
@@ -73,9 +73,10 @@ void Shape::extendRank(int to_rank)
 
 uint64_t Shape::num_elements() const
 {
-  // All of the nodes must have non-negative dimension
-  assert(std::all_of(_dimensions.begin(), _dimensions.end(),
-                     [](const int32_t &v) { return (v >= 0); }));
+  // if dimension is 0, it means unspecified and cannot calculate the total number of elements
+  if (std::any_of(_dimensions.begin(), _dimensions.end(),
+                  [](const int32_t &v) { return (v == 0); }))
+    throw std::runtime_error("num_elements() cannot calculate when a dimension is unspecified");
 
   return std::accumulate(_dimensions.cbegin(), _dimensions.cend(), UINT64_C(1),
                          std::multiplies<uint64_t>());

--- a/runtime/onert/test/ir/Shape.cc
+++ b/runtime/onert/test/ir/Shape.cc
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <ir/Shape.h>
+
+#include <gtest/gtest.h>
+
+TEST(ShapeTest, basic_test)
+{
+  {
+    onert::ir::Shape shape(3);
+
+    shape.dim(0) = 1;
+    shape.dim(1) = 2;
+    shape.dim(2) = 3;
+
+    ASSERT_EQ(shape.rank(), 3);
+    ASSERT_EQ(shape.num_elements(), 6);
+    ASSERT_EQ(onert::ir::rankMaybeUnspecified(shape), false);
+    ASSERT_EQ(onert::ir::haveUnspecifiedDims(shape), false);
+  }
+  {
+    onert::ir::Shape shape; // scalar or rank is unspecified
+
+    ASSERT_EQ(shape.rank(), 0);
+    ASSERT_EQ(shape.num_elements(), 1);
+    ASSERT_EQ(onert::ir::rankMaybeUnspecified(shape), true);
+    ASSERT_EQ(onert::ir::haveUnspecifiedDims(shape), false);
+  }
+}
+
+TEST(ShapeTest, neg_basic_test)
+{
+  {
+    onert::ir::Shape shape(2);
+
+    shape.dim(0) = 1;
+    shape.dim(1) = 0; // unspecified
+
+    ASSERT_EQ(shape.rank(), 2);
+    ASSERT_EQ(onert::ir::rankMaybeUnspecified(shape), false);
+    ASSERT_EQ(onert::ir::haveUnspecifiedDims(shape), true);
+    EXPECT_ANY_THROW(shape.num_elements());
+  }
+}


### PR DESCRIPTION
Previously `shape::num_element()` worked when any dim is 0. 
Now it is considered an error.

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>