### PR TITLE
[res] TensorFlowLiteRecipes for no options

### DIFF
--- a/res/TensorFlowLiteRecipes/Cast_001/test.recipe
+++ b/res/TensorFlowLiteRecipes/Cast_001/test.recipe
@@ -1,0 +1,18 @@
+operand {
+  name: "ifm"
+  type: FLOAT32
+  shape { dim: 1 dim: 3 dim: 3 dim: 2 }
+}
+operand {
+  name: "ofm"
+  type: INT32
+  shape { dim: 1 dim: 3 dim: 3 dim: 2 }
+}
+operation {
+  type: "Cast"
+  # cast_options was intentionally omitted here
+  input: "ifm"
+  output: "ofm"
+}
+input: "ifm"
+output: "ofm"

--- a/res/TensorFlowLiteRecipes/Reshape_003/test.recipe
+++ b/res/TensorFlowLiteRecipes/Reshape_003/test.recipe
@@ -1,0 +1,18 @@
+operand {
+  name: "ifm"
+  type: FLOAT32
+  shape { dim: 1 dim: 1 dim: 1 dim: 10 }
+}
+operand {
+  name: "ofm"
+  type: FLOAT32
+  shape { dim: 10 }
+}
+operation {
+  type: "Reshape"
+  # reshape_options is intentionally omitted here
+  input: "ifm"
+  output: "ofm"
+}
+input: "ifm"
+output: "ofm"


### PR DESCRIPTION
This will introduce TensorFlowLiteRecipes for Cast and Reshape with no options

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>