### PR TITLE
[oneapi] Update `nnfw_set_output` description

### DIFF
--- a/runtime/onert/api/include/nnfw.h
+++ b/runtime/onert/api/include/nnfw.h
@@ -246,8 +246,10 @@ NNFW_STATUS nnfw_set_input(nnfw_session *session, uint32_t index, NNFW_TYPE type
 /**
  * @brief       Set output buffer
  *
- * This function should be called after {@link nnfw_prepare}, and before first inference
- * on session by {@link nnfw_run}. Application can reuse buffer for many inferences.
+ * This function must be called after {@link nnfw_prepare}, \p buffer given to this function can be
+ * reused for many inferences. \p length must be greater or equal than the operand requires. An
+ * output operand can have unspecified shape and deduced dynamically during the execution. You must
+ * provide \p buffer large enough.
  *
  * @param[in]   session Session from inference output is to be extracted
  * @param[in]   index   Index of output to be set (0-indexed)


### PR DESCRIPTION
This commit updates `nnfw_set_output` description.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>