### PR TITLE
[luci] Enable ResizeBilinear operator in export

### DIFF
--- a/compiler/luci/export/src/CircleOperationExporter.cpp
+++ b/compiler/luci/export/src/CircleOperationExporter.cpp
@@ -102,6 +102,7 @@ public:
   void visit(luci::CircleRelu6 *) final;
   void visit(luci::CircleReluN1To1 *) final;
   void visit(luci::CircleReshape *) final;
+  void visit(luci::CircleResizeBilinear *) final;
   void visit(luci::CircleResizeNearestNeighbor *) final;
   void visit(luci::CircleRsqrt *) final;
   void visit(luci::CircleSelect *) final;
@@ -1016,6 +1017,27 @@ void OperationExporter::visit(luci::CircleReshape *node)
   // Create the operator.
   auto op_offset = CreateOperator(builder, op_idx, inputs, outputs,
                                   circle::BuiltinOptions_ReshapeOptions, options.Union());
+  gd._operators.push_back(op_offset);
+}
+
+void OperationExporter::visit(luci::CircleResizeBilinear *node)
+{
+  uint32_t op_idx = md.registerBuiltinOpcode(circle::BuiltinOperator_RESIZE_BILINEAR);
+
+  // Create inputs and outputs.
+  std::vector<int32_t> inputs_vec{get_tensor_index(node->input()), get_tensor_index(node->size())};
+
+  std::vector<int32_t> outputs_vec{get_tensor_index(node)};
+  auto inputs = builder.CreateVector(inputs_vec);
+  auto outputs = builder.CreateVector(outputs_vec);
+
+  // Create options.
+  auto options =
+      CreateResizeBilinearOptions(builder, node->align_corners(), node->half_pixel_centers());
+
+  // Create the operator.
+  auto op_offset = CreateOperator(builder, op_idx, inputs, outputs,
+                                  circle::BuiltinOptions_ResizeBilinearOptions, options.Union());
   gd._operators.push_back(op_offset);
 }
 


### PR DESCRIPTION
This enables ResizeBilinear operator in luci export

For #1476 
Draft #1498 

ONE-DCO-1.0-Signed-off-by: Andrey Kvochko <a.kvochko@samsung.com>