### PR TITLE
[luci] Enable ResizeBilinear operator in import

### DIFF
--- a/compiler/luci/import/include/luci/Import/Nodes.h
+++ b/compiler/luci/import/include/luci/Import/Nodes.h
@@ -71,6 +71,7 @@
 #include "Nodes/CircleRelu.h"
 #include "Nodes/CircleReluN1To1.h"
 #include "Nodes/CircleReshape.h"
+#include "Nodes/CircleResizeBilinear.h"
 #include "Nodes/CircleResizeNearestNeighbor.h"
 #include "Nodes/CircleRsqrt.h"
 #include "Nodes/CircleSelect.h"

--- a/compiler/luci/import/include/luci/Import/Nodes/CircleResizeBilinear.h
+++ b/compiler/luci/import/include/luci/Import/Nodes/CircleResizeBilinear.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __LUCI_IMPORT_OP_CIRCLE_RESIZE_BILINEAR_H__
+#define __LUCI_IMPORT_OP_CIRCLE_RESIZE_BILINEAR_H__
+
+#include "luci/Import/GraphBuilder.h"
+
+namespace luci
+{
+
+class CircleResizeBilinearGraphBuilder : public GraphBuilder
+{
+public:
+  bool validate(const ValidateArgs &args) const final;
+
+private:
+  CircleNode *build_node(const circle::OperatorT &op, const std::vector<CircleNode *> &inputs,
+                         loco::Graph *graph) const final;
+};
+
+} // namespace luci
+
+#endif // __LUCI_IMPORT_OP_CIRCLE_RESIZE_BILINEAR_H__

--- a/compiler/luci/import/src/GraphBuilderRegistry.cpp
+++ b/compiler/luci/import/src/GraphBuilderRegistry.cpp
@@ -80,6 +80,7 @@ GraphBuilderRegistry::GraphBuilderRegistry()
   CIRCLE_NODE(RELU, CircleReluGraphBuilder);                                               // 19
   CIRCLE_NODE(RELU_N1_TO_1, CircleReluN1To1GraphBuilder);                                  // 20
   CIRCLE_NODE(RESHAPE, CircleReshapeGraphBuilder);                                         // 22
+  CIRCLE_NODE(RESIZE_BILINEAR, CircleResizeBilinearGraphBuilder);                          // 23
   CIRCLE_NODE(RESIZE_NEAREST_NEIGHBOR, CircleResizeNearestNeighborGraphBuilder);           // 97
   CIRCLE_NODE(RSQRT, CircleRsqrtGraphBuilder);                                             // 76
   CIRCLE_NODE(SELECT, CircleSelectGraphBuilder);                                           // 64
@@ -115,7 +116,6 @@ GraphBuilderRegistry::GraphBuilderRegistry()
   // BuiltinOperator_LSH_PROJECTION = 15,
   // BuiltinOperator_LSTM = 16,
   // BuiltinOperator_RELU6 = 21,
-  // BuiltinOperator_RESIZE_BILINEAR = 23,
   // BuiltinOperator_RNN = 24,
   // BuiltinOperator_SVDF = 27,
   // BuiltinOperator_CONCAT_EMBEDDINGS = 29,

--- a/compiler/luci/import/src/Nodes/CircleResizeBilinear.cpp
+++ b/compiler/luci/import/src/Nodes/CircleResizeBilinear.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Import/Nodes/CircleResizeBilinear.h"
+
+#include <luci/IR/Nodes/CircleConst.h>
+#include <luci/IR/Nodes/CircleResizeBilinear.h>
+
+namespace luci
+{
+
+bool CircleResizeBilinearGraphBuilder::validate(const ValidateArgs &args) const
+{
+  if (args.op.inputs.size() != 2)
+    return false;
+
+  if (args.op.outputs.size() != 1)
+    return false;
+
+  return true;
+}
+
+CircleNode *CircleResizeBilinearGraphBuilder::build_node(const circle::OperatorT &op,
+                                                         const std::vector<CircleNode *> &inputs,
+                                                         loco::Graph *graph) const
+{
+  auto *node = graph->nodes()->create<CircleResizeBilinear>();
+  node->input(inputs[0]);
+  node->size(inputs[1]);
+
+  const auto *options = op.builtin_options.AsResizeBilinearOptions();
+  node->align_corners(options->align_corners);
+  node->half_pixel_centers(options->half_pixel_centers);
+
+  return node;
+}
+
+} // namespace luci


### PR DESCRIPTION
This enables import of ResizeBilinear operator in luci

For #1476
Draft #1498 

ONE-DCO-1.0-Signed-off-by: Andrey Kvochko <a.kvochko@samsung.com>