### PR TITLE
[luci] Support ResizeBilinear operator in logex

### DIFF
--- a/compiler/luci/logex/src/FormattedGraph.cpp
+++ b/compiler/luci/logex/src/FormattedGraph.cpp
@@ -247,6 +247,7 @@ private:
   IMPLEMENT(luci::CircleRelu6)
   IMPLEMENT(luci::CircleReluN1To1)
   IMPLEMENT(luci::CircleReshape)
+  IMPLEMENT(luci::CircleResizeBilinear)
   IMPLEMENT(luci::CircleResizeNearestNeighbor)
   IMPLEMENT(luci::CircleRsqrt)
   IMPLEMENT(luci::CircleSelect)
@@ -839,6 +840,17 @@ bool CircleNodeSummaryBuilder::summary(const luci::CircleReshape *node, locop::N
   s.args().append("shape", tbl()->lookup(node->shape()));
   // TODO Show newShape info
   s.state(locop::NodeSummary::State::PartiallyKnown);
+  return true;
+}
+
+bool CircleNodeSummaryBuilder::summary(const luci::CircleResizeBilinear *node,
+                                       locop::NodeSummary &s) const
+{
+  s.args().append("input", tbl()->lookup(node->input()));
+  s.args().append("size", tbl()->lookup(node->size()));
+  s.args().append("align_corners", node->align_corners() ? "true" : "false");
+  s.args().append("half_pixel_centers", node->half_pixel_centers() ? "true" : "false");
+  s.state(locop::NodeSummary::State::Complete);
   return true;
 }
 


### PR DESCRIPTION
This adds support of ResizeBilinear operator in logex

For #1476 
Draft #1498 

ONE-DCO-1.0-Signed-off-by: Andrey Kvochko <a.kvochko@samsung.com>