### PR TITLE
[luci] Enable ResizeBilinear in services

### DIFF
--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -1237,6 +1237,34 @@ public:
     return loco::NodeShape{output_shape};
   }
 
+  loco::NodeShape visit(const luci::CircleResizeBilinear *node) final
+  {
+    auto input_shape = loco::shape_get(node->input()).as<loco::TensorShape>();
+
+    if (input_shape.rank() != 4)
+      INTERNAL_EXN("Expected ResizeBilinear input to have rank 4");
+
+    auto *const_node = loco::must_cast<luci::CircleConst *>(node->size());
+
+    if (const_node->dtype() != loco::DataType::S32)
+      INTERNAL_EXN("Only S32 datatype is supported for ResizeBilinear size");
+
+    if (const_node->rank() != 1)
+      INTERNAL_EXN("Expected size tensor of rank 1");
+
+    if (const_node->dim(0).value() != 2)
+      INTERNAL_EXN("Expected size tensor with shape [2]");
+
+    loco::TensorShape output_shape;
+    output_shape.rank(4);
+    output_shape.dim(0) = input_shape.dim(0);
+    output_shape.dim(1) = const_node->at<loco::DataType::S32>(0);
+    output_shape.dim(2) = const_node->at<loco::DataType::S32>(1);
+    output_shape.dim(3) = input_shape.dim(3);
+
+    return loco::NodeShape{output_shape};
+  }
+
   loco::NodeShape visit(const luci::CircleResizeNearestNeighbor *node) final
   {
     auto input_shape = loco::shape_get(node->input()).as<loco::TensorShape>();

--- a/compiler/luci/service/src/CircleShapeInferenceRule.test.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.test.cpp
@@ -579,3 +579,47 @@ TEST(CircleShapeInferenceRuleTest, CircleResizeNearestNeighbor)
     ASSERT_EQ(3, shape.dim(3));
   }
 }
+
+TEST(CircleShapeInferenceRuleTest, CircleResizeBilinear)
+{
+  luci::test::TestGraph graph;
+  auto size_const = graph.append<luci::CircleConst>();
+  size_const->dtype(loco::DataType::S32);
+  size_const->rank(1);
+  size_const->dim(0) = 2;
+  size_const->size<loco::DataType::S32>(2);
+  size_const->at<loco::DataType::S32>(0) = 16;
+  size_const->at<loco::DataType::S32>(1) = 16;
+  auto resize_node = graph.append<luci::CircleResizeBilinear>(graph.input_node, size_const);
+  graph.complete();
+
+  {
+    auto input_node = graph.input_node;
+    input_node->shape({1, 4, 4, 3});
+    luci::test::graph_input_shape(input_node);
+  }
+  {
+    auto output_node = graph.output_node;
+    output_node->from(resize_node);
+    luci::test::graph_output_shape(output_node);
+  }
+
+  // pre-check
+  ASSERT_FALSE(loco::shape_known(resize_node));
+
+  // shape inference
+  while (shape_pass(graph.graph()) == true)
+    ;
+
+  // Verify
+  {
+    ASSERT_TRUE(loco::shape_known(resize_node));
+
+    auto shape = loco::shape_get(resize_node).as<loco::TensorShape>();
+    ASSERT_EQ(4, shape.rank());
+    ASSERT_EQ(1, shape.dim(0));
+    ASSERT_EQ(16, shape.dim(1));
+    ASSERT_EQ(16, shape.dim(2));
+    ASSERT_EQ(3, shape.dim(3));
+  }
+}

--- a/compiler/luci/service/src/CircleTypeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleTypeInferenceRule.cpp
@@ -271,6 +271,8 @@ struct TypeInferenceAlgorithm final : public luci::CircleNodeVisitor<loco::DataT
     return loco::dtype_get(node->tensor());
   }
 
+  loco::DataType visit(const luci::CircleResizeBilinear *) final { return loco::DataType::FLOAT32; }
+
   loco::DataType visit(const luci::CircleResizeNearestNeighbor *node) final
   {
     return loco::dtype_get(node->input());

--- a/compiler/luci/service/src/TestGraph.h
+++ b/compiler/luci/service/src/TestGraph.h
@@ -139,6 +139,12 @@ private:
     node->perm(arg2);
   };
 
+  void setInput(luci::CircleResizeBilinear *node, luci::CircleNode *input, luci::CircleNode *size)
+  {
+    node->input(input);
+    node->size(size);
+  };
+
   void setInput(luci::CircleResizeNearestNeighbor *node, luci::CircleNode *input,
                 luci::CircleNode *size)
   {


### PR DESCRIPTION
This enables ResizeBilinear support in services

For #1476
Draft #1498 

ONE-DCO-1.0-Signed-off-by: Andrey Kvochko <a.kvochko@samsung.com>