### PR TITLE
[oneapi] Handle errors on model_load_from_file

### DIFF
--- a/runtime/onert/api/include/nnfw.h
+++ b/runtime/onert/api/include/nnfw.h
@@ -177,6 +177,8 @@ NNFW_STATUS nnfw_close_session(nnfw_session *session);
 /**
  * @brief     Load model from nnpackage file or directory
  *
+ * The length of \p package_file_path must not execeed 1024 bytes including zero at the end.
+ *
  * @param[in] session           nnfw_session loading the given nnpackage file/dir
  * @param[in] package_file_path Path to the nnpackage file or unzipped directory to be loaded
  *

--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -35,6 +35,7 @@
  */
 #define MAX_BACKEND_NAME_LENGTH 32
 #define MAX_OP_NAME_LENGTH 64
+#define MAX_PATH_LENGTH 1024
 
 // Is null-terminating in length ?
 static bool null_terminating(const char *str, uint32_t length)
@@ -76,6 +77,18 @@ NNFW_STATUS nnfw_session::load_model_from_file(const char *package_dir)
 {
   if (!isStateInitialized())
     return NNFW_STATUS_ERROR;
+
+  if (!package_dir)
+  {
+    std::cerr << "package_dir is null." << std::endl;
+    return NNFW_STATUS_ERROR;
+  }
+
+  if (!null_terminating(package_dir, MAX_PATH_LENGTH))
+  {
+    std::cerr << "nnpackage path is too long: " << package_dir << std::endl;
+    return NNFW_STATUS_ERROR;
+  }
 
   // TODO : add support for zipped package file load
   DIR *dir;

--- a/tests/nnfw_api/src/ValidationTestSessionCreated.cc
+++ b/tests/nnfw_api/src/ValidationTestSessionCreated.cc
@@ -40,6 +40,20 @@ TEST_F(ValidationTestSessionCreated, neg_load_session_002)
       NNFW_STATUS_ERROR);
 }
 
+TEST_F(ValidationTestSessionCreated, neg_load_session_003)
+{
+  ASSERT_EQ(nnfw_load_model_from_file(_session, nullptr), NNFW_STATUS_ERROR);
+}
+
+TEST_F(ValidationTestSessionCreated, neg_load_session_004)
+{
+  // Too long path
+  const std::string long_path(1024, 'x');
+  ASSERT_EQ(nnfw_load_model_from_file(
+                _session, NNPackages::get().getModelAbsolutePath(long_path.c_str()).c_str()),
+            NNFW_STATUS_ERROR);
+}
+
 TEST_F(ValidationTestSessionCreated, neg_prepare_001)
 {
   // nnfw_load_model_from_file was not called


### PR DESCRIPTION
Handle errors on `nnfw_load_model_from_file`

- Return an error when `package_dir` is NULL
- Limit the length of `package_dir`
- Add 2 negative TCs

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>