### PR TITLE
Compiler FE: Add half_pixel_centers attr in ResizeBilinear

### DIFF
--- a/compiler/circledump/src/OpPrinter.cpp
+++ b/compiler/circledump/src/OpPrinter.cpp
@@ -184,6 +184,7 @@ public:
       os << "    ";
       os << std::boolalpha;
       os << "align_corners(" << resize_params->align_corners() << ")";
+      os << "half_pixel_centers(" << resize_params->half_pixel_centers() << ")";
       os << std::endl;
     }
   }

--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleResizeBilinear.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleResizeBilinear.h
@@ -45,8 +45,12 @@ public:
   bool align_corners() const { return _align_corners; }
   void align_corners(bool value) { _align_corners = value; }
 
+  bool half_pixel_centers() const { return _half_pixel_centers; }
+  void half_pixel_centers(bool value) { _half_pixel_centers = value; }
+
 private:
   bool _align_corners = false;
+  bool _half_pixel_centers = false;
 };
 
 } // namespace luci

--- a/compiler/luci/lang/src/Nodes/CircleResizeBilinear.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleResizeBilinear.test.cpp
@@ -30,4 +30,5 @@ TEST(CircleResizeBilinearTest, constructor)
   ASSERT_EQ(nullptr, resize.input());
   ASSERT_EQ(nullptr, resize.size());
   ASSERT_EQ(false, resize.align_corners());
+  ASSERT_EQ(false, resize.half_pixel_centers());
 }

--- a/compiler/tflchef/core/src/Op/ResizeBilinear.cpp
+++ b/compiler/tflchef/core/src/Op/ResizeBilinear.cpp
@@ -31,6 +31,7 @@ flatbuffers::Offset<void> ResizeBilinearChef::value(flatbuffers::FlatBufferBuild
   tflite::ResizeBilinearOptionsBuilder options_builder{fbb};
 
   options_builder.add_align_corners(options.align_corners());
+  options_builder.add_half_pixel_centers(options.half_pixel_centers());
 
   return options_builder.Finish().Union();
 }

--- a/compiler/tflchef/proto/tflchef.proto
+++ b/compiler/tflchef/proto/tflchef.proto
@@ -347,6 +347,7 @@ message ResizeNearestNeighborOptions {
 
 message ResizeBilinearOptions {
   optional bool align_corners = 1 [default = false];
+  optional bool half_pixel_centers = 2 [default = false];
 }
 
 message Operation {

--- a/compiler/tflchef/tflite/src/Op/ResizeBilinear.cpp
+++ b/compiler/tflchef/tflite/src/Op/ResizeBilinear.cpp
@@ -51,6 +51,7 @@ tflchef::Operation *TFliteOpResizeBilinear::build(const tflite::Operator *op, TF
   auto op_options = operation->mutable_resize_bilinear_options();
 
   op_options->set_align_corners(op_params->align_corners());
+  op_options->set_half_pixel_centers(op_params->half_pixel_centers());
 
   return operation;
 }

--- a/compiler/tfldump/src/OpPrinter.cpp
+++ b/compiler/tfldump/src/OpPrinter.cpp
@@ -184,6 +184,7 @@ public:
       os << "    ";
       os << std::boolalpha;
       os << "align_corners(" << resize_params->align_corners() << ")";
+      os << "half_pixel_centers(" << resize_params->half_pixel_centers() << ")";
       os << std::endl;
     }
   }

--- a/compiler/tflite2circle/src/BuildBuiltinOptions/ResizeBilinearOptions.cpp
+++ b/compiler/tflite2circle/src/BuildBuiltinOptions/ResizeBilinearOptions.cpp
@@ -29,6 +29,7 @@ build_circle_ResizeBilinearOptions(flatbuffers::FlatBufferBuilder &fb, const tfl
 
   circle::ResizeBilinearOptionsBuilder builtin_options_builder{fb};
   builtin_options_builder.add_align_corners(tflite_builtin_options->align_corners());
+  builtin_options_builder.add_half_pixel_centers(tflite_builtin_options->half_pixel_centers());
   return builtin_options_builder.Finish();
 }
 

--- a/res/TensorFlowLiteRecipes/ResizeBilinear_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/ResizeBilinear_000/test.recipe
@@ -23,6 +23,7 @@ operation {
   output: "ofm"
   resize_bilinear_options {
     align_corners: false
+    half_pixel_centers: false
   }
 }
 input: "ifm1"


### PR DESCRIPTION
This adds a missing half_pixel_centers attribute to ResizeBilinear op in compiler frontend

For #1476 
Draft #1498 has been rebased onto the latest master and this pull request, and now reflects these changes 

ONE-DCO-1.0-Signed-off-by: Andrey Kvochko <a.kvochko@samsung.com>