### PR TITLE
[circledump] Add half_pixel_centers attr in ResizeBilinear

### DIFF
--- a/compiler/circledump/src/OpPrinter.cpp
+++ b/compiler/circledump/src/OpPrinter.cpp
@@ -184,6 +184,7 @@ public:
       os << "    ";
       os << std::boolalpha;
       os << "align_corners(" << resize_params->align_corners() << ")";
+      os << "half_pixel_centers(" << resize_params->half_pixel_centers() << ")";
       os << std::endl;
     }
   }


### PR DESCRIPTION
This enables dumping of half_pixel_centers attr in ResizeBilinear

For #1476
Draf #1498 

ONE-DCO-1.0-Signed-off-by: Andrey Kvochko <a.kvochko@samsung.com>