### PR TITLE
[luci/IR] Add half_pixel_centers attr in ResizeBilinear

### DIFF
--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleResizeBilinear.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleResizeBilinear.h
@@ -45,8 +45,12 @@ public:
   bool align_corners() const { return _align_corners; }
   void align_corners(bool value) { _align_corners = value; }
 
+  bool half_pixel_centers() const { return _half_pixel_centers; }
+  void half_pixel_centers(bool value) { _half_pixel_centers = value; }
+
 private:
   bool _align_corners = false;
+  bool _half_pixel_centers = false;
 };
 
 } // namespace luci

--- a/compiler/luci/lang/src/Nodes/CircleResizeBilinear.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleResizeBilinear.test.cpp
@@ -30,4 +30,5 @@ TEST(CircleResizeBilinearTest, constructor)
   ASSERT_EQ(nullptr, resize.input());
   ASSERT_EQ(nullptr, resize.size());
   ASSERT_EQ(false, resize.align_corners());
+  ASSERT_EQ(false, resize.half_pixel_centers());
 }


### PR DESCRIPTION
This adds half_pixel_centers attribute to ResizeBilinear op in luci IR

For #1476 
Draft #1498 

ONE-DCO-1.0-Signed-off-by: Andrey Kvochko <a.kvochko@samsung.com>