### PR TITLE
[tflchef] Add half_pixel_centers attr in ResizeBilinear

### DIFF
--- a/compiler/tflchef/core/src/Op/ResizeBilinear.cpp
+++ b/compiler/tflchef/core/src/Op/ResizeBilinear.cpp
@@ -31,6 +31,7 @@ flatbuffers::Offset<void> ResizeBilinearChef::value(flatbuffers::FlatBufferBuild
   tflite::ResizeBilinearOptionsBuilder options_builder{fbb};
 
   options_builder.add_align_corners(options.align_corners());
+  options_builder.add_half_pixel_centers(options.half_pixel_centers());
 
   return options_builder.Finish().Union();
 }

--- a/compiler/tflchef/proto/tflchef.proto
+++ b/compiler/tflchef/proto/tflchef.proto
@@ -347,6 +347,7 @@ message ResizeNearestNeighborOptions {
 
 message ResizeBilinearOptions {
   optional bool align_corners = 1 [default = false];
+  optional bool half_pixel_centers = 2 [default = false];
 }
 
 message Operation {

--- a/compiler/tflchef/tflite/src/Op/ResizeBilinear.cpp
+++ b/compiler/tflchef/tflite/src/Op/ResizeBilinear.cpp
@@ -51,6 +51,7 @@ tflchef::Operation *TFliteOpResizeBilinear::build(const tflite::Operator *op, TF
   auto op_options = operation->mutable_resize_bilinear_options();
 
   op_options->set_align_corners(op_params->align_corners());
+  op_options->set_half_pixel_centers(op_params->half_pixel_centers());
 
   return operation;
 }


### PR DESCRIPTION
This adds support for half_pixel_centers attribute of ResizeBilinear op in tflchef

For #1476 
Draft #1498 

ONE-DCO-1.0-Signed-off-by: Andrey Kvochko <a.kvochko@samsung.com>