### PR TITLE
[tfldump] Add half_pixel_centers attr in ResizeBilinear

### DIFF
--- a/compiler/tfldump/src/OpPrinter.cpp
+++ b/compiler/tfldump/src/OpPrinter.cpp
@@ -184,6 +184,7 @@ public:
       os << "    ";
       os << std::boolalpha;
       os << "align_corners(" << resize_params->align_corners() << ")";
+      os << "half_pixel_centers(" << resize_params->half_pixel_centers() << ")";
       os << std::endl;
     }
   }


### PR DESCRIPTION
This adds support for dumping half_pixel_centers attribute of ResizeBilinear op

For #1476 
Draft #1498 

ONE-DCO-1.0-Signed-off-by: Andrey Kvochko <a.kvochko@samsung.com>