### PR TITLE
[tflite2circle] Enable half_pixel_centers attr in ResizeBilinear

### DIFF
--- a/compiler/tflite2circle/src/BuildBuiltinOptions/ResizeBilinearOptions.cpp
+++ b/compiler/tflite2circle/src/BuildBuiltinOptions/ResizeBilinearOptions.cpp
@@ -29,6 +29,7 @@ build_circle_ResizeBilinearOptions(flatbuffers::FlatBufferBuilder &fb, const tfl
 
   circle::ResizeBilinearOptionsBuilder builtin_options_builder{fb};
   builtin_options_builder.add_align_corners(tflite_builtin_options->align_corners());
+  builtin_options_builder.add_half_pixel_centers(tflite_builtin_options->half_pixel_centers());
   return builtin_options_builder.Finish();
 }
 


### PR DESCRIPTION
This enables half_pixel_centers attr of ResizeBilinear op in tflite2circle

For #1476 
Draft #1498 

ONE-DCO-1.0-Signed-off-by: Andrey Kvochko <a.kvochko@samsung.com>