### PR TITLE
[res] Add half_pixel_centers attr in ResizeBilinear recipe

### DIFF
--- a/res/TensorFlowLiteRecipes/ResizeBilinear_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/ResizeBilinear_000/test.recipe
@@ -23,6 +23,7 @@ operation {
   output: "ofm"
   resize_bilinear_options {
     align_corners: false
+    half_pixel_centers: false
   }
 }
 input: "ifm1"


### PR DESCRIPTION
This adds half_pixel_centers attribute in ResizeBilinear recipe

For #1476 
Draft #1498 

ONE-DCO-1.0-Signed-off-by: Andrey Kvochko <a.kvochko@samsung.com>