### PR TITLE
[luci] Add broadcast to Floor Mod shape inference

### DIFF
--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -696,8 +696,11 @@ public:
   loco::NodeShape visit(const luci::CircleFloorMod *node) final
   {
     auto x_shape = loco::shape_get(node->x()).as<loco::TensorShape>();
-    assert(x_shape == loco::shape_get(node->y()).as<loco::TensorShape>());
-    return loco::NodeShape{x_shape};
+    auto y_shape = loco::shape_get(node->y()).as<loco::TensorShape>();
+
+    auto output_shape = broadcast_shape(x_shape, y_shape);
+
+    return output_shape;
   }
 
   loco::NodeShape visit(const luci::CircleFullyConnected *node) final


### PR DESCRIPTION
This adds broadcasting of tensors in floor mod operator

ONE-DCO-1.0-Signed-off-by: Alexander Efimov <a.efimov@samsung.com>