### PR TITLE
[onert] support optional tensor in loader

### DIFF
--- a/runtime/onert/core/include/util/Index.h
+++ b/runtime/onert/core/include/util/Index.h
@@ -125,6 +125,12 @@ public:
    */
   bool valid() const { return _index != UNDEFINED; }
   /**
+   * @brief Check whether the value is undefined
+   *
+   * @return true if undefined, false otherwise
+   */
+  bool undefined() const { return _index == UNDEFINED; }
+  /**
    * @brief Return underlying value
    *
    * @return T Underlying value

--- a/runtime/onert/frontend/base_loader/include/base_loader.h
+++ b/runtime/onert/frontend/base_loader/include/base_loader.h
@@ -70,6 +70,7 @@ protected:
   // Helper functions
   ir::Activation convertActivation(ActivationFunctionType type);
   ir::DataType tensorTypeToDataType(TensorType type);
+  ir::OperandIndex tensorIdxToOperandIdx(int32_t tensorIdx);
 
   // Create operands form tflite::Tensor
   ir::OperandIndex loadOperand(const Tensor *tensor, ir::Graph &subg);
@@ -235,6 +236,13 @@ BaseLoader<LoaderDomain, SpecificLoader>::BaseLoader::tensorTypeToDataType(const
 }
 
 template <typename LoaderDomain, typename SpecificLoader>
+ir::OperandIndex
+BaseLoader<LoaderDomain, SpecificLoader>::BaseLoader::tensorIdxToOperandIdx(int32_t tensorIdx)
+{
+  return tensorIdx == -1 ? ir::OperandIndex() : _tensor_to_operand[tensorIdx];
+}
+
+template <typename LoaderDomain, typename SpecificLoader>
 ir::OperandIndex BaseLoader<LoaderDomain, SpecificLoader>::loadOperand(const Tensor *tensor,
                                                                        ir::Graph &subg)
 {
@@ -332,7 +340,7 @@ void BaseLoader<LoaderDomain, SpecificLoader>::loadOperationIO(const Operator *o
 
   for (const std::int32_t idx : *op->outputs())
   {
-    outputs.append(_tensor_to_operand[idx]);
+    outputs.append(tensorIdxToOperandIdx(idx));
   }
 }
 
@@ -1234,14 +1242,14 @@ void BaseLoader<LoaderDomain, SpecificLoader>::loadOneHot(const Operator *op, ir
 
   // Set input and output tensors
   ir::OperandIndexSequence inputs, outputs;
-  inputs.append(_tensor_to_operand[op->inputs()->Get(INDICES)]);
-  outputs.append(_tensor_to_operand[op->outputs()->Get(0)]);
+  inputs.append(tensorIdxToOperandIdx(op->inputs()->Get(INDICES)));
+  outputs.append(tensorIdxToOperandIdx(op->outputs()->Get(0)));
 
   // Set parameters
   // depth, on_value and off_value are scalar though it is passed as inputs
-  auto depth_opidx = _tensor_to_operand[op->inputs()->Get(DEPTH)];
-  auto on_value_opidx = _tensor_to_operand[op->inputs()->Get(ON_VALUE)];
-  auto off_value_opidx = _tensor_to_operand[op->inputs()->Get(OFF_VALUE)];
+  auto depth_opidx = tensorIdxToOperandIdx(op->inputs()->Get(DEPTH));
+  auto on_value_opidx = tensorIdxToOperandIdx(op->inputs()->Get(ON_VALUE));
+  auto off_value_opidx = tensorIdxToOperandIdx(op->inputs()->Get(OFF_VALUE));
   const auto depth = subg.operands().at(depth_opidx).template asScalar<int>();
   const auto on_value = subg.operands().at(on_value_opidx).template asScalar<float>();
   const auto off_value = subg.operands().at(off_value_opidx).template asScalar<float>();

--- a/runtime/onert/frontend/circle/src/circle_loader.cc
+++ b/runtime/onert/frontend/circle/src/circle_loader.cc
@@ -84,12 +84,12 @@ public:
     // Set inputs
     for (const std::int32_t input_ind : *circle_subg->inputs())
     {
-      subg->addInput(_tensor_to_operand[input_ind]);
+      subg->addInput(tensorIdxToOperandIdx(input_ind));
     }
     // Set outputs
     for (const std::int32_t output_ind : *circle_subg->outputs())
     {
-      subg->addOutput(_tensor_to_operand[output_ind]);
+      subg->addOutput(tensorIdxToOperandIdx(output_ind));
     }
     // Create operations
     for (const auto *op : *circle_subg->operators())

--- a/runtime/onert/frontend/tflite/src/tflite_loader.cc
+++ b/runtime/onert/frontend/tflite/src/tflite_loader.cc
@@ -77,12 +77,12 @@ public:
     // Set inputs
     for (const std::int32_t input_ind : *tflite_subg->inputs())
     {
-      subg->addInput(_tensor_to_operand[input_ind]);
+      subg->addInput(tensorIdxToOperandIdx(input_ind));
     }
     // Set outputs
     for (const std::int32_t output_ind : *tflite_subg->outputs())
     {
-      subg->addOutput(_tensor_to_operand[output_ind]);
+      subg->addOutput(tensorIdxToOperandIdx(output_ind));
     }
     // Create operations
     for (const auto *op : *tflite_subg->operators())


### PR DESCRIPTION
Loader can tensor input index `-1`, which is used to specify
the tensor is not given for optional input tensor.
    
It uses `UNDEFINED` for unspecified input tensor index.
It introduces `undefined()` in base index class.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>