### PR TITLE
[record-minmax] Import/export of circle model

### DIFF
--- a/compiler/record-minmax/CMakeLists.txt
+++ b/compiler/record-minmax/CMakeLists.txt
@@ -14,3 +14,5 @@ target_include_directories(record-minmax PRIVATE ${Boost_INCLUDE_DIRS})
 
 target_link_libraries(record-minmax ${Boost_LIBRARIES})
 target_link_libraries(record-minmax safemain)
+target_link_libraries(record-minmax luci_import)
+target_link_libraries(record-minmax luci_export)

--- a/compiler/record-minmax/README.md
+++ b/compiler/record-minmax/README.md
@@ -4,7 +4,7 @@ _record-minmax_ is a tool to embed min/max values of activations to the circle m
 
 ## Usage
 
-This will run with the path to the input model (.circle), input data (.h5), and the output model (.circle).
+This will run with the path to the input model (.circle), a pack of input data (.h5), and the output model (.circle).
 
 ```
 $ ./record-minmax <path_to_input_model> <path_to_input_data> <path_to_output_model>

--- a/compiler/record-minmax/driver/Driver.cpp
+++ b/compiler/record-minmax/driver/Driver.cpp
@@ -26,7 +26,10 @@ int entry(const int argc, char **argv)
   auto input_data_path = args.getInputDataFilePath();
   auto output_model_path = args.getOutputModelFilePath();
 
-  RecordMinMax rmm(input_model_path);
+  RecordMinMax rmm;
+
+  // Initialize interpreter and observer
+  rmm.initialize(input_model_path);
 
   // Profile min/max while executing the given input data
   rmm.profileData(input_data_path);

--- a/compiler/record-minmax/include/RecordMinMax.h
+++ b/compiler/record-minmax/include/RecordMinMax.h
@@ -14,25 +14,31 @@
  * limitations under the License.
  */
 
-#include "Args.h"
-#include "RecordMinMax.h"
+#ifndef __RECORD_MINMAX_H__
+#define __RECORD_MINMAX_H__
 
-int entry(const int argc, char **argv)
+#include <luci/IR/Module.h>
+
+#include <memory>
+
+namespace record_minmax
 {
-  using namespace record_minmax;
 
-  Args args(argc, argv);
-  auto input_model_path = args.getInputModelFilePath();
-  auto input_data_path = args.getInputDataFilePath();
-  auto output_model_path = args.getOutputModelFilePath();
+class RecordMinMax
+{
+public:
+  explicit RecordMinMax(const std::string &input_model_path);
 
-  RecordMinMax rmm(input_model_path);
+  ~RecordMinMax() = default;
 
-  // Profile min/max while executing the given input data
-  rmm.profileData(input_data_path);
+  void profileData(const std::string &input_data_path);
 
-  // Save profiled values to the model
-  rmm.saveModel(output_model_path);
+  void saveModel(const std::string &output_model_path);
 
-  return EXIT_SUCCESS;
-}
+private:
+  std::unique_ptr<luci::Module> _module;
+};
+
+} // namespace record_minmax
+
+#endif // __RECORD_MINMAX_H__

--- a/compiler/record-minmax/include/RecordMinMax.h
+++ b/compiler/record-minmax/include/RecordMinMax.h
@@ -27,9 +27,11 @@ namespace record_minmax
 class RecordMinMax
 {
 public:
-  explicit RecordMinMax(const std::string &input_model_path);
+  explicit RecordMinMax() = default;
 
   ~RecordMinMax() = default;
+
+  void initialize(const std::string &input_model_path);
 
   void profileData(const std::string &input_data_path);
 

--- a/compiler/record-minmax/requires.cmake
+++ b/compiler/record-minmax/requires.cmake
@@ -1,1 +1,2 @@
+require("luci")
 require("safemain")

--- a/compiler/record-minmax/src/CircleExpContract.cpp
+++ b/compiler/record-minmax/src/CircleExpContract.cpp
@@ -29,7 +29,7 @@ bool CircleExpContract::store(const char *ptr, const size_t size) const
   if (!ptr)
     INTERNAL_EXN("Graph was not serialized by FlatBuffer for some reason");
 
-  std::ofstream fs(_filepath.c_str(), std::ofstream::binary);
+  std::ofstream fs(_filepath, std::ofstream::binary);
   fs.write(ptr, size);
 
   return fs.good();

--- a/compiler/record-minmax/src/CircleExpContract.cpp
+++ b/compiler/record-minmax/src/CircleExpContract.cpp
@@ -14,25 +14,25 @@
  * limitations under the License.
  */
 
-#include "Args.h"
-#include "RecordMinMax.h"
+#include "CircleExpContract.h"
 
-int entry(const int argc, char **argv)
+#include <oops/InternalExn.h>
+
+#include <fstream>
+#include <iostream>
+
+namespace record_minmax
 {
-  using namespace record_minmax;
 
-  Args args(argc, argv);
-  auto input_model_path = args.getInputModelFilePath();
-  auto input_data_path = args.getInputDataFilePath();
-  auto output_model_path = args.getOutputModelFilePath();
+bool CircleExpContract::store(const char *ptr, const size_t size) const
+{
+  if (!ptr)
+    INTERNAL_EXN("Graph was not serialized by FlatBuffer for some reason");
 
-  RecordMinMax rmm(input_model_path);
+  std::ofstream fs(_filepath.c_str(), std::ofstream::binary);
+  fs.write(ptr, size);
 
-  // Profile min/max while executing the given input data
-  rmm.profileData(input_data_path);
-
-  // Save profiled values to the model
-  rmm.saveModel(output_model_path);
-
-  return EXIT_SUCCESS;
+  return fs.good();
 }
+
+} // namespace record_minmax

--- a/compiler/record-minmax/src/CircleExpContract.h
+++ b/compiler/record-minmax/src/CircleExpContract.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __RECORD_MINMAX_CIRCLEXPCONTRACT_H__
+#define __RECORD_MINMAX_CIRCLEXPCONTRACT_H__
+
+#include <loco.h>
+#include <luci/CircleExporter.h>
+#include <luci/IR/Module.h>
+
+#include <string>
+
+namespace record_minmax
+{
+
+struct CircleExpContract : public luci::CircleExporter::Contract
+{
+public:
+  CircleExpContract(luci::Module *module, const std::string &filename)
+      : _module(module), _filepath(filename)
+  {
+    // NOTHING TO DO
+  }
+  virtual ~CircleExpContract() = default;
+
+public:
+  loco::Graph *graph(void) const final { return nullptr; }
+  luci::Module *module(void) const final { return _module; };
+
+public:
+  bool store(const char *ptr, const size_t size) const final;
+
+private:
+  luci::Module *_module;
+  const std::string _filepath;
+};
+
+} // namespace record_minmax
+
+#endif // __RECORD_MINMAX_CIRCLEXPCONTRACT_H__

--- a/compiler/record-minmax/src/RecordMinMax.cpp
+++ b/compiler/record-minmax/src/RecordMinMax.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <luci/Importer.h>
+#include <luci/CircleExporter.h>
+
+#include "CircleExpContract.h"
+#include "RecordMinMax.h"
+
+#include <fstream>
+#include <stdexcept>
+
+namespace record_minmax
+{
+
+RecordMinMax::RecordMinMax(const std::string &input_model_path)
+{
+  // Load model from the file
+  std::ifstream fs(input_model_path, std::ifstream::binary);
+  if (fs.fail())
+  {
+    throw std::runtime_error("Cannot open model file \"" + input_model_path + "\".\n");
+  }
+  std::vector<char> model_data((std::istreambuf_iterator<char>(fs)),
+                               std::istreambuf_iterator<char>());
+  _module = luci::Importer().importModule(circle::GetModel(model_data.data()));
+
+  if (_module == nullptr)
+  {
+    throw std::runtime_error("ERROR: Failed to load '" + input_model_path + "'");
+  }
+
+  // TODO: Initialize profiling-supported interpreter
+}
+
+void RecordMinMax::profileData(const std::string &input_data_path)
+{
+  // TODO: Collect min/max data for the given input data (.h5)
+
+  // TODO: Determine the final min/max for each activation
+  //       E.g., using clipping, averaging
+}
+
+void RecordMinMax::saveModel(const std::string &output_model_path)
+{
+  // TODO: Write min/max data to activation tensors in CircleNodes
+
+  // Export to output Circle file
+  luci::CircleExporter exporter;
+  CircleExpContract contract(_module.get(), output_model_path);
+
+  if (!exporter.invoke(&contract))
+  {
+    throw std::runtime_error("ERROR: Failed to export '" + output_model_path + "'");
+  }
+};
+
+} // namespace record_minmax

--- a/compiler/record-minmax/src/RecordMinMax.cpp
+++ b/compiler/record-minmax/src/RecordMinMax.cpp
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
+#include "RecordMinMax.h"
+#include "CircleExpContract.h"
+
 #include <luci/Importer.h>
 #include <luci/CircleExporter.h>
-
-#include "CircleExpContract.h"
-#include "RecordMinMax.h"
 
 #include <fstream>
 #include <stdexcept>
@@ -26,7 +26,7 @@
 namespace record_minmax
 {
 
-RecordMinMax::RecordMinMax(const std::string &input_model_path)
+void RecordMinMax::initialize(const std::string &input_model_path)
 {
   // Load model from the file
   std::ifstream fs(input_model_path, std::ifstream::binary);
@@ -66,6 +66,6 @@ void RecordMinMax::saveModel(const std::string &output_model_path)
   {
     throw std::runtime_error("ERROR: Failed to export '" + output_model_path + "'");
   }
-};
+}
 
 } // namespace record_minmax


### PR DESCRIPTION
This implements import/export of circle model in record-minmax

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to #1605