### PR TITLE
[onert] introduce pipe to filter OperandIndexSequence

### DIFF
--- a/runtime/onert/core/include/ir/OperandIndexSequence.h
+++ b/runtime/onert/core/include/ir/OperandIndexSequence.h
@@ -27,6 +27,11 @@ namespace onert
 namespace ir
 {
 
+enum class Remove
+{
+  DUPLICATED = 0x1
+};
+
 class OperandIndexSequence
 {
 public:
@@ -45,17 +50,20 @@ public:
   const OperandIndex &at(uint32_t index) const { return _vec.at(index); }
   bool contains(const OperandIndex &index) const;
   void replace(const OperandIndex &from, const OperandIndex &to);
-  OperandIndexSequence asUnique(void) const
+  OperandIndexSequence operator|(ir::Remove filter) const
   {
-    ir::OperandIndexSequence unique;
-    for (const auto &ind : _vec)
+    switch (filter)
     {
-      if (!unique.contains(ind))
+      case ir::Remove::DUPLICATED:
       {
-        unique.append(ind);
+        ir::OperandIndexSequence seq;
+        for (const auto &ind : _vec)
+          if (!seq.contains(ind))
+            seq.append(ind);
+        return seq;
       }
     }
-    return unique;
+    return *this;
   }
 
 public:

--- a/runtime/onert/core/src/compiler/Fp32ToFp16Converter.cc
+++ b/runtime/onert/core/src/compiler/Fp32ToFp16Converter.cc
@@ -223,10 +223,9 @@ void Fp32ToFp16Converter::appendNewOpSeqForConvertFp32ToFp16(const ir::OpSequenc
   // OpSeq's input set is included in the first operation's input set
   const ir::OperandIndexSequence op_seq_inputs = op_seq.getInputs(); // copied
 
-  // Remove duplicated input index
   // NOTE Please do not change sequence of op_seq_inputs. It can change the sequence of inputs of
   // Subgraph
-  for (const auto &op_seq_input_ind : op_seq_inputs.asUnique())
+  for (const auto &op_seq_input_ind : op_seq_inputs | ir::Remove::DUPLICATED)
   {
     if (checkOperandType(op_seq_input_ind) == false)
       continue;
@@ -295,10 +294,9 @@ void Fp32ToFp16Converter::appendNewOpSeqForConvertFp16ToFp32(const ir::OpSequenc
   // OpSeq's output set is included in the last operation's output set
   const ir::OperandIndexSequence op_seq_outputs = op_seq.getOutputs(); // copied
 
-  // Remove duplicated input
   // NOTE Please do not change sequence of op_seq_outputs. It can change the sequence of outputs of
   // Subgraph
-  for (const auto &op_seq_output_ind : op_seq_outputs.asUnique())
+  for (const auto &op_seq_output_ind : op_seq_outputs | ir::Remove::DUPLICATED)
   {
     if (checkOperandType(op_seq_output_ind) == false)
       continue;
@@ -905,7 +903,7 @@ void Fp32ToFp16Converter::deleteContiguousOpSequences(
     VERBOSE(Fp32ToFp16Converter) << "Delete Node #" << first_node_ind.value() << std::endl;
 
     // Uses
-    for (auto &ind : first_node.getInputs().asUnique())
+    for (auto &ind : first_node.getInputs() | ir::Remove::DUPLICATED)
     {
       auto &obj = operands.at(ind);
       obj.removeUse(first_node_ind);
@@ -914,7 +912,7 @@ void Fp32ToFp16Converter::deleteContiguousOpSequences(
     }
 
     // Def
-    for (auto &ind : first_node.getOutputs().asUnique())
+    for (auto &ind : first_node.getOutputs() | ir::Remove::DUPLICATED)
     {
       auto &obj = operands.at(ind);
       obj.removeDef(first_node_ind);

--- a/runtime/onert/core/src/compiler/Linear.cc
+++ b/runtime/onert/core/src/compiler/Linear.cc
@@ -56,7 +56,7 @@ std::vector<ir::OpSequenceIndex> Linear::linearize(const ir::LoweredGraph &lower
     //            |
     //           [4]
     op_seqs.iterate([&](const ir::OpSequenceIndex &op_seq_idx, const ir::OpSequence &op_seq) {
-      for (auto input : op_seq.getInputs().asUnique())
+      for (auto input : op_seq.getInputs() | ir::Remove::DUPLICATED)
       {
         // only valid_inputs
         const auto &operand = operands.at(input);
@@ -87,7 +87,7 @@ std::vector<ir::OpSequenceIndex> Linear::linearize(const ir::LoweredGraph &lower
       visited[index] = true;
 
       // The outputs should be not constants
-      for (auto output : op_seq.getOutputs().asUnique())
+      for (auto output : op_seq.getOutputs() | ir::Remove::DUPLICATED)
       {
         const auto it = input_to_op_seqs.find(output);
         if (it != input_to_op_seqs.end())
@@ -199,7 +199,7 @@ void Linear::planTensors(const ir::LoweredGraph &lowered_graph,
 
   // If a tensor is model output, increase the use of the tensor.
   // This aim is same to above one.
-  for (const auto &ind : graph.getOutputs().asUnique())
+  for (const auto &ind : graph.getOutputs() | ir::Remove::DUPLICATED)
   {
     uses_map[ind]++;
   }
@@ -218,7 +218,7 @@ void Linear::planTensors(const ir::LoweredGraph &lowered_graph,
 
   // Allocate Model's inputs
   VERBOSE(LINEAR) << "TENSORS as MODEL INPUT" << std::endl;
-  for (const auto &ind : graph.getInputs().asUnique())
+  for (const auto &ind : graph.getInputs() | ir::Remove::DUPLICATED)
   {
     auto tensor_builder = tensor_builder_map[ind];
     if (!tensor_builder) // for GeneratedTests.xxx_weights_as_inputs
@@ -235,7 +235,7 @@ void Linear::planTensors(const ir::LoweredGraph &lowered_graph,
     const auto &op_seq = lowered_graph.op_seqs().at(op_seq_ind);
     for (const auto &op : op_seq.operations())
     {
-      for (const auto &ind : op.node->getOutputs().asUnique())
+      for (const auto &ind : op.node->getOutputs() | ir::Remove::DUPLICATED)
       {
         assert(def_map.find(ind) != def_map.end());
         if (def_map[ind])
@@ -245,7 +245,7 @@ void Linear::planTensors(const ir::LoweredGraph &lowered_graph,
         }
       }
 
-      for (const auto &ind : op.node->getInputs().asUnique())
+      for (const auto &ind : op.node->getInputs() | ir::Remove::DUPLICATED)
       {
         assert(uses_map.find(ind) != uses_map.end());
         assert(uses_map[ind] > 0);
@@ -267,7 +267,7 @@ void Linear::planTensors(const ir::LoweredGraph &lowered_graph,
   }
 
   // Dispose and validate
-  for (const auto &ind : graph.getOutputs().asUnique())
+  for (const auto &ind : graph.getOutputs() | ir::Remove::DUPLICATED)
   {
     --uses_map[ind];
     if (uses_map[ind] == 0) // To prevent notifyLastUse from being called twice

--- a/runtime/onert/core/src/ir/GraphIterator.cc
+++ b/runtime/onert/core/src/ir/GraphIterator.cc
@@ -61,7 +61,7 @@ void PostDfsIterator<is_const>::iterate(GraphRef graph, const IterFn &fn) const
       return;
     visited[index] = true;
 
-    for (const auto output : node.getOutputs().asUnique())
+    for (const auto output : node.getOutputs() | Remove::DUPLICATED)
     {
       const auto &operand = graph.operands().at(output);
       for (const auto &use : operand.getUses())

--- a/runtime/onert/core/src/ir/LoweredGraph.cc
+++ b/runtime/onert/core/src/ir/LoweredGraph.cc
@@ -401,7 +401,7 @@ bool LoweredGraph::mergeable(const OpSequenceIndex &op_seq_index, const Operatio
     std::unordered_set<OperationIndex> branched_set;
 
     // Check for branching up
-    for (const auto &input : op_seq.getInputs().asUnique())
+    for (const auto &input : op_seq.getInputs() | Remove::DUPLICATED)
     {
       const auto &input_obj = _graph.operands().at(input);
       for (const auto &def : input_obj.getDef())
@@ -416,7 +416,7 @@ bool LoweredGraph::mergeable(const OpSequenceIndex &op_seq_index, const Operatio
     branched_set.clear();
 
     // Check for branching down
-    for (const auto &output : node.getOutputs().asUnique())
+    for (const auto &output : node.getOutputs() | Remove::DUPLICATED)
     {
       const auto &output_obj = _graph.operands().at(output);
       for (const auto &use : output_obj.getUses())

--- a/runtime/onert/core/src/ir/pass/ConstantInsertionPass.cc
+++ b/runtime/onert/core/src/ir/pass/ConstantInsertionPass.cc
@@ -35,7 +35,7 @@ void ConstantInsertionPass::callback(const OperationIndex &node_index, Operation
   const auto layout = op_seq_lower_info->layout();
   const auto factor = operand::PermuteFactor{backend, layout};
 
-  for (const auto input : node.getInputs().asUnique())
+  for (const auto input : node.getInputs() | Remove::DUPLICATED)
   {
     auto &object = _graph.operands().at(input);
 

--- a/runtime/onert/core/src/ir/pass/ConstantLoweringPass.cc
+++ b/runtime/onert/core/src/ir/pass/ConstantLoweringPass.cc
@@ -37,7 +37,7 @@ void ConstantLoweringPass::callback(const OperationIndex &node_index, Operation 
   const auto factor = operand::PermuteFactor{backend, layout};
 
   // Now this runtime does not support the node making output of operation as constant
-  for (const auto input : node.getInputs().asUnique())
+  for (const auto input : node.getInputs() | Remove::DUPLICATED)
   {
     auto &object = _graph.operands().at(input);
     if (object.isConstant())

--- a/runtime/onert/core/src/ir/pass/PermutationOperationPass.cc
+++ b/runtime/onert/core/src/ir/pass/PermutationOperationPass.cc
@@ -132,7 +132,7 @@ void PermutationOperationPass::changeToKeepLayout(const Operation &node)
     const auto backend = op_seq_li->backend();
     const operand::PermuteFactor removed_factor{backend, backend_layout};
     const operand::PermuteFactor new_factor{backend, frontend_layout};
-    for (const auto &input : node.getInputs().asUnique())
+    for (const auto &input : node.getInputs() | Remove::DUPLICATED)
     {
       bool canRemove = true;
       for (const auto &use : _graph.operands().at(input).getUses())
@@ -165,7 +165,7 @@ void PermutationOperationPass::changeToKeepLayout(const Operation &node)
       }
     }
 
-    for (const auto &output : node.getOutputs().asUnique())
+    for (const auto &output : node.getOutputs() | Remove::DUPLICATED)
     {
       auto lower_info = _lowered_graph.getLowerInfo(output);
       lower_info->removeDefPermuteFactor(removed_factor);

--- a/runtime/onert/core/src/ir/verifier/Verifier.cc
+++ b/runtime/onert/core/src/ir/verifier/Verifier.cc
@@ -51,7 +51,7 @@ bool DAGChecker::verify(const Graph &graph) const
     visited[index] = true;
     on_stack[index] = true;
 
-    for (auto output : node.getOutputs().asUnique())
+    for (auto output : node.getOutputs() | Remove::DUPLICATED)
     {
       const auto &operand = graph.operands().at(output);
       for (const auto &use : operand.getUses())


### PR DESCRIPTION
It uses unix pipe `|` syntax by overloading operator|.

e.g.) getInputs().asUniquie() -> getInputs() | Remove::duplicated.

It will say more loudly it filters out some elements more specifically.

Also, if we introduce more filter it will become:

getInputs() | Remove::duplicated | Remove::optional

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>