### PR TITLE
[onert] Adding implementation for deallocSubgraphOutput()

### DIFF
--- a/runtime/onert/backend/cpu/DynamicTensorManager.cc
+++ b/runtime/onert/backend/cpu/DynamicTensorManager.cc
@@ -16,6 +16,8 @@
 
 #include "DynamicTensorManager.h"
 
+#include "util/logging.h"
+
 namespace onert
 {
 namespace backend
@@ -90,8 +92,12 @@ void DynamicTensorManager::deallocInput(const ir::Operation *op)
 
 void DynamicTensorManager::deallocSubgraphOutput(ir::OperandIndex output_ind)
 {
-  (void)output_ind;
-  // TODO write code here
+  if (!_tensors->at(output_ind)->is_dynamic())
+    return;
+
+  _dynamic_mem_mgr->deallocate(output_ind);
+  VERBOSE(DynamicTensorManager) << "Deallocating #" << output_ind.value()
+                                << " (output of a subgraph)" << std::endl;
 }
 
 } // namespace cpu

--- a/runtime/onert/core/src/exec/ExecutorBase.h
+++ b/runtime/onert/core/src/exec/ExecutorBase.h
@@ -156,6 +156,7 @@ protected:
   std::vector<std::shared_ptr<backend::ITensor>> _input_tensors;
   std::vector<std::shared_ptr<backend::ITensor>> _output_tensors;
   std::unordered_map<std::shared_ptr<backend::ITensor>, DynAllocInfo> _input_to_dyn_alloc_info;
+  std::unordered_map<std::shared_ptr<backend::ITensor>, DynAllocInfo> _output_to_dyn_alloc_info;
   backend::TensorManagerSet _tensor_mgrs;
   std::mutex _mutex;
 };


### PR DESCRIPTION
This adds the implementation for `DynamicTensorManager::deallocSubgraphOutput(..)`.

grand parent issue: #56
parent issue: #1539

related PR: #1580
draft: #52

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>