### PR TITLE
[TensorFlowPythonExamples] fix placeholder shape in expand_dims_00

### DIFF
--- a/res/TensorFlowPythonExamples/examples/expand_dims_00/__init__.py
+++ b/res/TensorFlowPythonExamples/examples/expand_dims_00/__init__.py
@@ -3,7 +3,7 @@ import tensorflow as tf
 # example 1 where input has all known dims and axis is const
 
 in_ = tf.compat.v1.placeholder(dtype=tf.int32, shape=(2, 3), name="Hole")
-axis_ = tf.compat.v1.placeholder(dtype=tf.int32, shape=0, name="Axis")
+axis_ = tf.compat.v1.placeholder(dtype=tf.int32, shape=(), name="Axis")
 expand_dim_ = tf.compat.v1.expand_dims(in_, axis_, name="ExpandDims")
 
 # note: the code above will produce tflite file where output of ExpandDims is int32 scalar,


### PR DESCRIPTION
This commit fixes shape of placeholder in expand_dims_00

scalar is () or [], not 0.

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>