### PR TITLE
[onert] support fullyconnected when bias is undefined in backend and kernel

### DIFF
--- a/compute/cker/include/cker/operation/FullyConnected.h
+++ b/compute/cker/include/cker/operation/FullyConnected.h
@@ -148,7 +148,14 @@ inline void FullyConnectedHybrid(const FullyConnectedParams &params, const Shape
   const int num_units = filter_shape.Dims(0);
 
   // Output = bias if bias tensor exists.
-  VectorBatchVectorAssign(bias_data, num_units, batch_size, output_data);
+  if (bias_data)
+  {
+    VectorBatchVectorAssign(bias_data, num_units, batch_size, output_data);
+  }
+  else
+  {
+    ZeroVector(output_data, batch_size * num_units);
+  }
 
   // Save matrix multiplication computation for all zero input.
   if (IsZeroVector(input_data, total_input_size))

--- a/runtime/onert/backend/cpu/ConstantInitializer.cc
+++ b/runtime/onert/backend/cpu/ConstantInitializer.cc
@@ -59,8 +59,11 @@ void ConstantInitializer::visit(const ir::operation::FullyConnected &node)
   registerCopyInitializer(weight_index, weight_obj);
 
   const auto &bias_index = node.getInputs().at(ir::operation::FullyConnected::BIAS);
-  const auto &bias_obj = _operands.at(bias_index);
-  registerCopyInitializer(bias_index, bias_obj);
+  if (!bias_index.undefined())
+  {
+    const auto &bias_obj = _operands.at(bias_index);
+    registerCopyInitializer(bias_index, bias_obj);
+  }
 }
 
 } // namespace cpu

--- a/runtime/onert/backend/cpu/KernelGenerator.cc
+++ b/runtime/onert/backend/cpu/KernelGenerator.cc
@@ -297,7 +297,7 @@ void KernelGenerator::visit(const ir::operation::FullyConnected &node)
   auto output_alloc = _tensor_builder->at(output_index).get();
   auto input_alloc = _tensor_builder->at(input_index).get();
   auto weight_alloc = _tensor_builder->at(weight_index).get();
-  auto bias_alloc = _tensor_builder->at(bias_index).get();
+  auto bias_alloc = bias_index.undefined() ? nullptr : _tensor_builder->at(bias_index).get();
 
   auto fn = std::make_unique<::onert::backend::cpu::kernel::FullyConnectedLayer>();
 

--- a/runtime/onert/backend/cpu/kernel/FullyConnectedLayer.cc
+++ b/runtime/onert/backend/cpu/kernel/FullyConnectedLayer.cc
@@ -50,8 +50,8 @@ void FullyConnectedLayer::fullyConnectedFloat32()
       op_params, convertTensorToCkerShape(_input),
       reinterpret_cast<const float *>(_input->buffer()), convertTensorToCkerShape(_weights),
       reinterpret_cast<const float *>(_weights->buffer()), convertTensorToCkerShape(_bias),
-      reinterpret_cast<const float *>(_bias->buffer()), convertTensorToCkerShape(_output),
-      reinterpret_cast<float *>(_output->buffer()));
+      reinterpret_cast<const float *>(_bias ? _bias->buffer() : nullptr),
+      convertTensorToCkerShape(_output), reinterpret_cast<float *>(_output->buffer()));
 }
 
 // executionMutex is used to protect concurrent access of non-threadsafe resources
@@ -81,8 +81,8 @@ void FullyConnectedLayer::fullyConnectedQuant8()
       op_params, convertTensorToCkerShape(_input),
       reinterpret_cast<const uint8_t *>(_input->buffer()), convertTensorToCkerShape(_weights),
       reinterpret_cast<const uint8_t *>(_weights->buffer()), convertTensorToCkerShape(_bias),
-      reinterpret_cast<const int32_t *>(_bias->buffer()), convertTensorToCkerShape(_output),
-      reinterpret_cast<uint8_t *>(_output->buffer()));
+      reinterpret_cast<const int32_t *>(_bias ? _bias->buffer() : nullptr),
+      convertTensorToCkerShape(_output), reinterpret_cast<uint8_t *>(_output->buffer()));
 }
 
 void FullyConnectedLayer::fullyConnectedHybrid()
@@ -101,8 +101,8 @@ void FullyConnectedLayer::fullyConnectedHybrid()
       op_params, convertTensorToCkerShape(_input),
       reinterpret_cast<const float *>(_input->buffer()), convertTensorToCkerShape(_weights),
       reinterpret_cast<const int8_t *>(_weights->buffer()), convertTensorToCkerShape(_bias),
-      reinterpret_cast<const float *>(_bias->buffer()), convertTensorToCkerShape(_output),
-      reinterpret_cast<float *>(_output->buffer()), temp_arena);
+      reinterpret_cast<const float *>(_bias ? _bias->buffer() : nullptr),
+      convertTensorToCkerShape(_output), reinterpret_cast<float *>(_output->buffer()), temp_arena);
 }
 
 void FullyConnectedLayer::configure(const operand::Tensor *input, const operand::Tensor *weights,

--- a/runtime/onert/backend/cpu/kernel/OperationUtils.h
+++ b/runtime/onert/backend/cpu/kernel/OperationUtils.h
@@ -81,7 +81,9 @@ inline nnfw::cker::Shape convertToExtendedCkerShape(const operand::Tensor *tenso
 
 inline nnfw::cker::Shape convertTensorToCkerShape(const operand::Tensor *tensor)
 {
-  assert(tensor);
+  if (tensor == nullptr)
+    return nnfw::cker::Shape();
+
   assert(tensor->layout() == ir::Layout::NHWC);
   std::vector<int32_t> raw_shape;
   raw_shape.resize(tensor->num_dimensions());


### PR DESCRIPTION
It modifies backend and kernel for fullyconnected w/o bias.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>