### PR TITLE
[luci] Revise dtype inf for Custom Op

### DIFF
--- a/compiler/luci/service/src/CircleTypeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleTypeInferenceRule.cpp
@@ -78,7 +78,7 @@ struct TypeInferenceAlgorithm final : public luci::CircleNodeVisitor<loco::DataT
     {
       return loco::dtype_get(node->inputs(0));
     }
-    return loco::DataType::Unknown;
+    return node->dtype();
   }
 
   loco::DataType visit(const luci::CircleDepthwiseConv2D *node) final


### PR DESCRIPTION
This will revise dtype inference for Custom Op to return node dtype attribute
- return unknown fails for models have different custom op

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>