### PR TITLE
[onert] TC: multiple execution of a model with dynamic tensors

### DIFF
--- a/tests/nnfw_api/src/ModelTestDynamicTensor.cc
+++ b/tests/nnfw_api/src/ModelTestDynamicTensor.cc
@@ -34,6 +34,18 @@ class TestDynamicTensorReshapeModelLoaded
     : public ValidationTestModelLoaded<NNPackages::DYNAMIC_TENSOR_RESHAPE>
 {
 protected:
+  void set_input_output(const std::vector<int> &new_shape, int actual_output_size,
+                        std::vector<float> *actual_output)
+  {
+    NNFW_STATUS res = nnfw_set_input(_session, 0, NNFW_TYPE_TENSOR_INT32, new_shape.data(),
+                                     sizeof(int) * new_shape.size());
+    ASSERT_EQ(res, NNFW_STATUS_NO_ERROR);
+
+    res = nnfw_set_output(_session, 0, NNFW_TYPE_TENSOR_FLOAT32, actual_output->data(),
+                          sizeof(float) * actual_output_size);
+    ASSERT_EQ(res, NNFW_STATUS_NO_ERROR);
+  }
+
   void prepare_and_set_input_output(const std::vector<int> &new_shape, int actual_output_size,
                                     std::vector<float> *actual_output)
   {
@@ -44,16 +56,35 @@ protected:
     res = nnfw_prepare(_session);
     ASSERT_EQ(res, NNFW_STATUS_NO_ERROR);
 
-    res = nnfw_set_input(_session, 0, NNFW_TYPE_TENSOR_INT32, new_shape.data(),
-                         sizeof(int) * new_shape.size());
-    ASSERT_EQ(res, NNFW_STATUS_NO_ERROR);
-
-    res = nnfw_set_output(_session, 0, NNFW_TYPE_TENSOR_FLOAT32, actual_output->data(),
-                          sizeof(float) * actual_output_size);
-    ASSERT_EQ(res, NNFW_STATUS_NO_ERROR);
-
+    set_input_output(new_shape, actual_output_size, actual_output);
     // real test case should start from calling nnfw_run()
   }
+
+  // call this after calling nnfw_prepare()
+  void set_input_output_and_run(const std::vector<int> &new_shape,
+                                const std::vector<float> &expected_output, bool no_run_error = true)
+  {
+    int output_element_num = expected_output.size();
+    std::vector<float> actual_output(output_element_num);
+
+    set_input_output(new_shape, output_element_num, &actual_output);
+
+    // Do inference
+    NNFW_STATUS res = nnfw_run(_session);
+
+    if (no_run_error)
+    {
+      ASSERT_EQ(res, NNFW_STATUS_NO_ERROR);
+
+      // output value check
+      for (int i = 0; i < expected_output.size(); ++i)
+        ASSERT_EQ(expected_output[i], actual_output[i]);
+    }
+    else
+    {
+      ASSERT_EQ(res, NNFW_STATUS_ERROR);
+    }
+  };
 
   void TearDown() override
   {
@@ -94,3 +125,52 @@ TEST_F(TestDynamicTensorReshapeModelLoaded, neg_reshape_to_wrong_3x3)
   NNFW_STATUS res = nnfw_run(_session);
   ASSERT_EQ(res, NNFW_STATUS_ERROR); // run should fail
 }
+
+TEST_F(TestDynamicTensorReshapeModelLoaded, reshape_multiple_executions)
+{
+  ASSERT_EQ(nnfw_set_available_backends(_session, "cpu"), NNFW_STATUS_NO_ERROR);
+
+  NNFW_STATUS res = nnfw_prepare(_session);
+  ASSERT_EQ(res, NNFW_STATUS_NO_ERROR);
+
+  std::vector<int> new_shape;
+  std::vector<float> expected = {-1.5, -1.0, -0.5, 0.5, 1.0, 1.5};
+
+  // let's call multiple times
+  new_shape = {3, 2};
+  set_input_output_and_run(new_shape, expected);
+
+  new_shape = {1, 6};
+  set_input_output_and_run(new_shape, expected);
+
+  new_shape = {6, 1};
+  set_input_output_and_run(new_shape, expected);
+}
+
+TEST_F(TestDynamicTensorReshapeModelLoaded, neg_reshape_multiple_executions)
+{
+  ASSERT_EQ(nnfw_set_available_backends(_session, "cpu"), NNFW_STATUS_NO_ERROR);
+
+  NNFW_STATUS res = nnfw_prepare(_session);
+  ASSERT_EQ(res, NNFW_STATUS_NO_ERROR);
+
+  std::vector<int> new_shape;
+  std::vector<float> expected = {-1.5, -1.0, -0.5, 0.5, 1.0, 1.5};
+
+  // let's call multiple times including the second nnfw_run() to fail
+  new_shape = {3, 2};
+  set_input_output_and_run(new_shape, expected);
+
+  new_shape = {1, 100};                                 // wrong shape
+  set_input_output_and_run(new_shape, expected, false); // Run will fail
+
+  // next run should succeed
+  new_shape = {6, 1};
+  set_input_output_and_run(new_shape, expected);
+}
+
+// TODO add more test including
+
+// Unknown Dimension Test
+
+// Complex Model Test


### PR DESCRIPTION
This adds two test cases for multiple execution of a model with dynamic tensors.

For #56
Draft #52 

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>