### PR TITLE
[oneapi] Add load_model negative tests and ..

### DIFF
--- a/tests/nnfw_api/src/ValidationTestAddModelLoaded.cc
+++ b/tests/nnfw_api/src/ValidationTestAddModelLoaded.cc
@@ -64,3 +64,11 @@ TEST_F(ValidationTestAddModelLoaded, neg_get_output_size)
 {
   ASSERT_EQ(nnfw_output_size(_session, nullptr), NNFW_STATUS_ERROR);
 }
+
+TEST_F(ValidationTestAddModelLoaded, neg_load_model)
+{
+  // load model twice
+  ASSERT_EQ(nnfw_load_model_from_file(
+                _session, NNPackages::get().getModelAbsolutePath(NNPackages::ADD).c_str()),
+            NNFW_STATUS_ERROR);
+}

--- a/tests/nnfw_api/src/ValidationTestAddSessionPrepared.cc
+++ b/tests/nnfw_api/src/ValidationTestAddSessionPrepared.cc
@@ -104,4 +104,12 @@ TEST_F(ValidationTestAddSessionPrepared, neg_get_output_size)
   ASSERT_EQ(nnfw_output_size(_session, nullptr), NNFW_STATUS_ERROR);
 }
 
+TEST_F(ValidationTestAddSessionPrepared, neg_load_model)
+{
+  // Load model twice
+  ASSERT_EQ(nnfw_load_model_from_file(
+                _session, NNPackages::get().getModelAbsolutePath(NNPackages::ADD).c_str()),
+            NNFW_STATUS_ERROR);
+}
+
 // TODO Validation check when "nnfw_run" is called without input & output tensor setting

--- a/tests/nnfw_api/src/ValidationTestSessionCreated.cc
+++ b/tests/nnfw_api/src/ValidationTestSessionCreated.cc
@@ -25,6 +25,12 @@ TEST_F(ValidationTestSessionCreated, load_session_001)
             NNFW_STATUS_NO_ERROR);
 }
 
+TEST_F(ValidationTestSessionCreated, close_and_create_again)
+{
+  ASSERT_EQ(nnfw_close_session(_session), NNFW_STATUS_NO_ERROR);
+  ASSERT_EQ(nnfw_create_session(&_session), NNFW_STATUS_NO_ERROR);
+}
+
 TEST_F(ValidationTestSessionCreated, neg_load_session_001)
 {
   ASSERT_EQ(nnfw_load_model_from_file(

--- a/tests/nnfw_api/src/ValidationTestSingleSession.cc
+++ b/tests/nnfw_api/src/ValidationTestSingleSession.cc
@@ -72,3 +72,11 @@ TEST_F(ValidationTestSingleSession, neg_get_output_size)
   ASSERT_EQ(nnfw_output_size(nullptr, &size), NNFW_STATUS_ERROR);
   ASSERT_EQ(size, 10000);
 }
+
+TEST_F(ValidationTestSingleSession, neg_load_model)
+{
+  // Invalid state
+  ASSERT_EQ(nnfw_load_model_from_file(
+                nullptr, NNPackages::get().getModelAbsolutePath(NNPackages::ADD).c_str()),
+            NNFW_STATUS_ERROR);
+}


### PR DESCRIPTION
- Add 3 `nnfw_load_model_from_file` negative tests
- Add a test - close session then create again

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>