### PR TITLE
[oneapi] Do not print package_dir in error

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -86,7 +86,7 @@ NNFW_STATUS nnfw_session::load_model_from_file(const char *package_dir)
 
   if (!null_terminating(package_dir, MAX_PATH_LENGTH))
   {
-    std::cerr << "nnpackage path is too long: " << package_dir << std::endl;
+    std::cerr << "nnpackage path is too long" << std::endl;
     return NNFW_STATUS_ERROR;
   }
 


### PR DESCRIPTION
Printing `package_dir` could be dangerous since we don't no the length
of it. It should not be printed.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>