### PR TITLE
[oneapi] Introduce `nnfw_set_input_tensorinfo`

### DIFF
--- a/runtime/onert/api/include/nnfw.h
+++ b/runtime/onert/api/include/nnfw.h
@@ -207,7 +207,7 @@ NNFW_STATUS nnfw_apply_tensorinfo(nnfw_session *session, uint32_t index,
 /**
  * @brief    Set input model's tensor info for resizing
  *
- * This function can be called in any time after calling {@link nnfw_model_load_from_file}. Changing
+ * This function can be called at any time after calling {@link nnfw_model_load_from_file}. Changing
  * input tensor's shape will cause shape inference for the model. There are two different types of
  * shape inference - static and dynamic. Which one to use is depend on the current state of the
  * session.

--- a/runtime/onert/api/include/nnfw.h
+++ b/runtime/onert/api/include/nnfw.h
@@ -194,6 +194,8 @@ NNFW_STATUS nnfw_load_model_from_file(nnfw_session *session, const char *package
  * See {@link nnfw_prepare} for information applying updated tensor info
  * If this function is called many times for same index, tensor info is overwritten
  *
+ * @note This function will be deprecated in 1.7.0. Use {@link nnfw_set_input_tensorinfo} instead.
+ *
  * @param[in] session     Session to the input tensor info is to be set
  * @param[in] index       Index of input to be applied (0-indexed)
  * @param[in] tensor_info Tensor info to be applied
@@ -201,6 +203,28 @@ NNFW_STATUS nnfw_load_model_from_file(nnfw_session *session, const char *package
  */
 NNFW_STATUS nnfw_apply_tensorinfo(nnfw_session *session, uint32_t index,
                                   nnfw_tensorinfo tensor_info);
+
+/**
+ * @brief    Set input model's tensor info for resizing
+ *
+ * This function can be called in any time after calling {@link nnfw_model_load_from_file}. Changing
+ * input tensor's shape will cause shape inference for the model. There are two different types of
+ * shape inference - static and dynamic. Which one to use is depend on the current state of the
+ * session.
+ * When it is called after calling {@link nnfw_model_load_from_file} and before calling {@link
+ * nnfw_prepare}, this info will be used when {@link nnfw_prepare}. And it will perform static shape
+ * inference for all tensors.
+ * When it is called after calling {@link nnfw_prepare} or even after {@link nnfw_run}, this info
+ * will be used when {@link nnfw_run}. And the shapes of the tensors are determined on the fly.
+ * If this function is called many times for the same index, it is overwritten.
+ *
+ * @param[in] session     Session to the input tensor info is to be set
+ * @param[in] index       Index of input to be set (0-indexed)
+ * @param[in] tensor_info Tensor info to be set
+ * @return    @c NNFW_STATUS_NO_ERROR if successful, otherwise return @c NNFW_STATUS_ERROR
+ */
+NNFW_STATUS nnfw_set_input_tensorinfo(nnfw_session *session, uint32_t index,
+                                      const nnfw_tensorinfo *tensor_info);
 
 /**
  * @brief     Prepare session to be ready for inference


### PR DESCRIPTION
Introduce a new API function `nnfw_set_input_tensorinfo`. This will
replace `nnfw_apply_tensorinfo`.

Reasons why introducing a new API:

- The name may be misleading - it can change inputs' info, not all
  tensors
- Function signature - it gets `tensor_info` by value
- Different behavior depend on the session state

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>