### PR TITLE
[oneapi] Fix invalid call of input/output size

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -271,6 +271,9 @@ NNFW_STATUS nnfw_session::set_output(uint32_t index, NNFW_TYPE /*type*/, void *b
 
 NNFW_STATUS nnfw_session::input_size(uint32_t *number)
 {
+  if (isStateInitialized()) // Model is not loaded
+    return NNFW_STATUS_ERROR;
+
   try
   {
     if (number == nullptr)
@@ -290,6 +293,9 @@ NNFW_STATUS nnfw_session::input_size(uint32_t *number)
 
 NNFW_STATUS nnfw_session::output_size(uint32_t *number)
 {
+  if (isStateInitialized()) // Model is not loaded
+    return NNFW_STATUS_ERROR;
+
   try
   {
     if (number == nullptr)

--- a/tests/nnfw_api/src/ValidationTestAddModelLoaded.cc
+++ b/tests/nnfw_api/src/ValidationTestAddModelLoaded.cc
@@ -24,6 +24,20 @@ TEST_F(ValidationTestAddModelLoaded, prepare_001)
   ASSERT_EQ(nnfw_prepare(_session), NNFW_STATUS_NO_ERROR);
 }
 
+TEST_F(ValidationTestAddModelLoaded, get_input_size)
+{
+  uint32_t size = 0;
+  ASSERT_EQ(nnfw_input_size(_session, &size), NNFW_STATUS_NO_ERROR);
+  ASSERT_EQ(size, 1);
+}
+
+TEST_F(ValidationTestAddModelLoaded, get_output_size)
+{
+  uint32_t size = 0;
+  ASSERT_EQ(nnfw_output_size(_session, &size), NNFW_STATUS_NO_ERROR);
+  ASSERT_EQ(size, 1);
+}
+
 TEST_F(ValidationTestAddModelLoaded, neg_run_001)
 {
   ASSERT_EQ(nnfw_run(_session), NNFW_STATUS_ERROR);

--- a/tests/nnfw_api/src/ValidationTestSessionCreated.cc
+++ b/tests/nnfw_api/src/ValidationTestSessionCreated.cc
@@ -77,3 +77,17 @@ TEST_F(ValidationTestSessionCreated, neg_set_output_001)
   // Invalid state
   ASSERT_EQ(nnfw_set_output(_session, 0, NNFW_TYPE_TENSOR_FLOAT32, nullptr, 0), NNFW_STATUS_ERROR);
 }
+
+TEST_F(ValidationTestSessionCreated, neg_get_input_size)
+{
+  uint32_t size = 10000;
+  ASSERT_EQ(nnfw_input_size(_session, &size), NNFW_STATUS_ERROR);
+  ASSERT_EQ(size, 10000);
+}
+
+TEST_F(ValidationTestSessionCreated, neg_get_output_size)
+{
+  uint32_t size = 10000;
+  ASSERT_EQ(nnfw_output_size(_session, &size), NNFW_STATUS_ERROR);
+  ASSERT_EQ(size, 10000);
+}

--- a/tests/nnfw_api/src/ValidationTestSingleSession.cc
+++ b/tests/nnfw_api/src/ValidationTestSingleSession.cc
@@ -58,3 +58,17 @@ TEST_F(ValidationTestSingleSession, neg_set_output_002)
   ASSERT_EQ(nnfw_set_output(nullptr, 0, NNFW_TYPE_TENSOR_FLOAT32, buffer, sizeof(buffer)),
             NNFW_STATUS_ERROR);
 }
+
+TEST_F(ValidationTestSingleSession, neg_get_input_size)
+{
+  uint32_t size = 10000;
+  ASSERT_EQ(nnfw_input_size(nullptr, &size), NNFW_STATUS_ERROR);
+  ASSERT_EQ(size, 10000);
+}
+
+TEST_F(ValidationTestSingleSession, neg_get_output_size)
+{
+  uint32_t size = 10000;
+  ASSERT_EQ(nnfw_output_size(nullptr, &size), NNFW_STATUS_ERROR);
+  ASSERT_EQ(size, 10000);
+}


### PR DESCRIPTION
Fix when `nnfw_input_size` was called before model loading.
And add some test cases.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>