### PR TITLE
[luci-interpreter] Add observing functionality

### DIFF
--- a/compiler/luci-interpreter/include/luci_interpreter/Interpreter.h
+++ b/compiler/luci-interpreter/include/luci_interpreter/Interpreter.h
@@ -30,8 +30,14 @@
 namespace luci_interpreter
 {
 
-class KernelMap;
-class TensorMap;
+class ExecutionObserver
+{
+public:
+  virtual ~ExecutionObserver();
+
+  // Called when the value of a tensor has been updated during execution.
+  virtual void postTensorWrite(const luci::CircleNode *node, const Tensor *tensor);
+};
 
 class Interpreter
 {
@@ -46,13 +52,16 @@ public:
 
   void interpret();
 
+  void attachObserver(ExecutionObserver *observer);
+
 private:
   void createTensors(const loco::Graph *graph);
   void createKernels(const loco::Graph *graph);
 
   const loco::Graph *_main_graph = nullptr;
-  std::unique_ptr<TensorMap> _tensor_map;
-  std::unique_ptr<KernelMap> _kernel_map;
+  std::unique_ptr<class TensorMap> _tensor_map;
+  std::unique_ptr<class KernelMap> _kernel_map;
+  std::vector<ExecutionObserver *> _observers;
 };
 
 } // namespace luci_interpreter

--- a/compiler/luci-interpreter/include/luci_interpreter/core/Tensor.h
+++ b/compiler/luci-interpreter/include/luci_interpreter/core/Tensor.h
@@ -111,7 +111,7 @@ public:
 
   template <typename T> T *data() { return reinterpret_cast<T *>(_data.get()); }
 
-  const std::string &name() { return _name; }
+  const std::string &name() const { return _name; }
 
   void readData(void *data_ptr, size_t data_size) const;
 


### PR DESCRIPTION
Add `ExecutionObserver` class that allows to examine tensor contents during interpretation.

ONE-DCO-1.0-Signed-off-by: Sergei Barannikov <s.barannikov@samsung.com>