### PR TITLE
[oneapi/test] Close session on RegressionTest

### DIFF
--- a/tests/nnfw_api/src/RegressionTests.cc
+++ b/tests/nnfw_api/src/RegressionTests.cc
@@ -32,4 +32,7 @@ TEST_F(RegressionTest, github_1535)
   ASSERT_EQ(nnfw_load_model_from_file(session2, package_path.c_str()), NNFW_STATUS_NO_ERROR);
   ASSERT_EQ(nnfw_set_available_backends(session2, "acl_cl"), NNFW_STATUS_NO_ERROR);
   ASSERT_EQ(nnfw_prepare(session2), NNFW_STATUS_NO_ERROR);
+
+  ASSERT_EQ(nnfw_close_session(session1), NNFW_STATUS_NO_ERROR);
+  ASSERT_EQ(nnfw_close_session(session2), NNFW_STATUS_NO_ERROR);
 }


### PR DESCRIPTION
Close sessions on RegressionTest::github_1535 before finish to resovle resource leak issue

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>