### PR TITLE
[luci] Introduce shape_status to CircleNode

### DIFF
--- a/compiler/luci/lang/include/luci/IR/CircleNodeDecl.h
+++ b/compiler/luci/lang/include/luci/IR/CircleNodeDecl.h
@@ -20,6 +20,7 @@
 #include <loco/IR/Dialect.h>
 #include <loco/IR/Node.h>
 #include <loco/IR/NodeMixins.h>
+#include <luci/IR/PropertyShapeStatus.h>
 
 #include "CircleOpcode.h"
 #include "CircleNodeVisitor.forward.h"
@@ -56,11 +57,15 @@ struct CircleNode : public loco::Node,
   bool no_shape(void) const { return _no_shape; }
   void no_shape(bool ns) { _no_shape = ns; }
 
+  ShapeStatus shape_status(void) const { return _shape_status; }
+  void shape_status(ShapeStatus ss) { _shape_status = ss; }
+
 private:
   NodeName _name;
   std::unique_ptr<CircleQuantParam> _quantparam;
   /// @brief _no_shape is true if tensor has no shape
   bool _no_shape{false};
+  ShapeStatus _shape_status{ShapeStatus::UNDEFINED};
 };
 
 template <CircleOpcode Code> struct CircleNodeImpl : public CircleNode

--- a/compiler/luci/lang/include/luci/IR/PropertyShapeStatus.h
+++ b/compiler/luci/lang/include/luci/IR/PropertyShapeStatus.h
@@ -23,13 +23,13 @@ namespace luci
 /**
  * @brief  ShapeStatus is to remember circle node shape status.
  * @note   This is not an attribute from the file but inner status of a node.
- *         Shape with [] is scalar but somtimes it acts as dynamic shape.
+ *         Shape with [] is scalar but sometimes it acts as dynamic shape.
  */
 enum class ShapeStatus
 {
   UNDEFINED, // Shape status is undefined
 
-  NOSHAPE, // shape is unknown; to distinguish from scala
+  NOSHAPE, // shape is unknown; to distinguish from scalar
   VALID,   // shape is valid
 };
 

--- a/compiler/luci/lang/include/luci/IR/PropertyShapeStatus.h
+++ b/compiler/luci/lang/include/luci/IR/PropertyShapeStatus.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __LUCI_IR_PROPERTY_SHAPE_STATUS_H__
+#define __LUCI_IR_PROPERTY_SHAPE_STATUS_H__
+
+namespace luci
+{
+
+/**
+ * @brief  ShapeStatus is to remember circle node shape status.
+ * @note   This is not an attribute from the file but inner status of a node.
+ *         Shape with [] is scalar but somtimes it acts as dynamic shape.
+ */
+enum class ShapeStatus
+{
+  UNDEFINED, // Shape status is undefined
+
+  NOSHAPE, // shape is unknown; to distinguish from scala
+  VALID,   // shape is valid
+};
+
+} // namespace luci
+
+#endif // __LUCI_IR_PROPERTY_SHAPE_STATUS_H__


### PR DESCRIPTION
This will introduce shape_status to CircleNode as node shape status

ONE-DCO-1.0-ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>