### PR TITLE
[luci] Revise AvgPool2D test shape_pass

### DIFF
--- a/compiler/luci/service/src/CircleShapeInferenceRule.test.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.test.cpp
@@ -166,7 +166,8 @@ TEST(CircleShapeInferenceRuleTest, avgpool2d_same)
   ASSERT_FALSE(loco::shape_known(avg_node));
 
   // shape inference
-  shape_pass(graph.graph());
+  while (shape_pass(graph.graph()) == true)
+    ;
 
   // Verify
   {


### PR DESCRIPTION
This will revise AvgPool2D test to run shape_pass like other test codes

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>