### PR TITLE
[luci] Export fix shape_status

### DIFF
--- a/compiler/luci/export/src/CircleTensorExporter.cpp
+++ b/compiler/luci/export/src/CircleTensorExporter.cpp
@@ -131,8 +131,7 @@ void allocateCircleTensor(CircleNode *node, CircleTensorContext &ctx)
   tensor_info.dtype(to_circle_tensortype(luci::node_dtype(node)));
   if (node->shape_status() == ShapeStatus::VALID)
     tensor_info.shape(to_shape_description(luci::node_shape(node)));
-  else
-    tensor_info.shape_status(node->shape_status());
+  tensor_info.shape_status(node->shape_status());
 
   tensor_info.content(dynamic_cast<luci::CircleConst *>(node));
   tensor_info.quantparam(node->quantparam());


### PR DESCRIPTION
This will fix export for shape_status so that tensor_info will know shape_status as it will use this value to save or not

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>