### PR TITLE
[oneapi] Add negative tests for input output size

### DIFF
--- a/tests/nnfw_api/src/ValidationTestAddModelLoaded.cc
+++ b/tests/nnfw_api/src/ValidationTestAddModelLoaded.cc
@@ -54,3 +54,13 @@ TEST_F(ValidationTestAddModelLoaded, neg_set_output_001)
 {
   ASSERT_EQ(nnfw_set_output(_session, 0, NNFW_TYPE_TENSOR_FLOAT32, nullptr, 0), NNFW_STATUS_ERROR);
 }
+
+TEST_F(ValidationTestAddModelLoaded, neg_get_input_size)
+{
+  ASSERT_EQ(nnfw_input_size(_session, nullptr), NNFW_STATUS_ERROR);
+}
+
+TEST_F(ValidationTestAddModelLoaded, neg_get_output_size)
+{
+  ASSERT_EQ(nnfw_output_size(_session, nullptr), NNFW_STATUS_ERROR);
+}

--- a/tests/nnfw_api/src/ValidationTestAddSessionPrepared.cc
+++ b/tests/nnfw_api/src/ValidationTestAddSessionPrepared.cc
@@ -49,6 +49,20 @@ TEST_F(ValidationTestAddSessionPrepared, set_input_001)
             NNFW_STATUS_NO_ERROR);
 }
 
+TEST_F(ValidationTestAddSessionPrepared, get_input_size)
+{
+  uint32_t size = 0;
+  ASSERT_EQ(nnfw_input_size(_session, &size), NNFW_STATUS_NO_ERROR);
+  ASSERT_EQ(size, 1);
+}
+
+TEST_F(ValidationTestAddSessionPrepared, get_output_size)
+{
+  uint32_t size = 0;
+  ASSERT_EQ(nnfw_output_size(_session, &size), NNFW_STATUS_NO_ERROR);
+  ASSERT_EQ(size, 1);
+}
+
 TEST_F(ValidationTestAddSessionPrepared, neg_set_input_001)
 {
   ASSERT_EQ(nnfw_set_input(_session, 0, NNFW_TYPE_TENSOR_FLOAT32, nullptr, 1), NNFW_STATUS_ERROR);
@@ -78,6 +92,16 @@ TEST_F(ValidationTestAddSessionPrepared, neg_set_output_002)
   char input[1]; // buffer size is too small
   ASSERT_EQ(nnfw_set_output(_session, 0, NNFW_TYPE_TENSOR_FLOAT32, input, sizeof(input)),
             NNFW_STATUS_ERROR);
+}
+
+TEST_F(ValidationTestAddSessionPrepared, neg_get_input_size)
+{
+  ASSERT_EQ(nnfw_input_size(_session, nullptr), NNFW_STATUS_ERROR);
+}
+
+TEST_F(ValidationTestAddSessionPrepared, neg_get_output_size)
+{
+  ASSERT_EQ(nnfw_output_size(_session, nullptr), NNFW_STATUS_ERROR);
 }
 
 // TODO Validation check when "nnfw_run" is called without input & output tensor setting


### PR DESCRIPTION
Add 6 tests for `nnfw_input_size` and `nnfw_output_size`.

- Add 4 negative tests for the case when `size` is NULL
- Add 2 positive tests to PREPARED state

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>