### PR TITLE
[onert] Fix RegressionTest failure on x86_64

### DIFF
--- a/tests/nnfw_api/src/RegressionTests.cc
+++ b/tests/nnfw_api/src/RegressionTests.cc
@@ -30,7 +30,7 @@ TEST_F(RegressionTest, github_1535)
   nnfw_session *session2 = nullptr;
   ASSERT_EQ(nnfw_create_session(&session2), NNFW_STATUS_NO_ERROR);
   ASSERT_EQ(nnfw_load_model_from_file(session2, package_path.c_str()), NNFW_STATUS_NO_ERROR);
-  ASSERT_EQ(nnfw_set_available_backends(session2, "acl_cl"), NNFW_STATUS_NO_ERROR);
+  ASSERT_EQ(nnfw_set_available_backends(session2, "cpu"), NNFW_STATUS_NO_ERROR);
   ASSERT_EQ(nnfw_prepare(session2), NNFW_STATUS_NO_ERROR);
 
   ASSERT_EQ(nnfw_close_session(session1), NNFW_STATUS_NO_ERROR);


### PR DESCRIPTION
On x86_64, there is no `acl_cl` backend so it does not have any backends
loaded. It caused the failure for `session2`,  so this commit reivses
`session2` backend to `cpu`.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>