### PR TITLE
[luci] Fix unused variable in CircleWhileGraphBuilder

### DIFF
--- a/compiler/luci/import/src/Nodes/CircleWhile.cpp
+++ b/compiler/luci/import/src/Nodes/CircleWhile.cpp
@@ -67,8 +67,7 @@ void CircleWhileGraphBuilder::build(const circle::OperatorT &op, GraphBuilderCon
   const std::vector<int32_t> &inputs = op.inputs;
   const std::vector<int32_t> &outputs = op.outputs;
   const auto &tensors = context->reader()->tensors();
-  auto tensors_ptr = context->reader()->tensors_ptr();
-  assert(tensors_ptr != nullptr);
+  assert(context->reader()->tensors_ptr() != nullptr);
 
   std::vector<CircleNode *> input_nodes;
   for (const int32_t input_tensor_index : inputs)


### PR DESCRIPTION
This commit fixes unused variable in CircleWhileGraphBuilder.

Signed-off-by: ragmani <ragmani0216@gmail.com>