### PR TITLE
[onert] Enable dynamic tensor with controlflow operation

### DIFF
--- a/runtime/onert/backend/acl_common/IACLTensor.h
+++ b/runtime/onert/backend/acl_common/IACLTensor.h
@@ -50,6 +50,7 @@ public:
   ir::Layout layout() const final;
   ir::DataType data_type() const final;
   bool has_padding() const override { return info()->has_padding(); }
+  bool is_dynamic() const override { return false; }
 
 public:
   virtual const arm_compute::ITensor *handle() const = 0;

--- a/runtime/onert/core/include/backend/ITensor.h
+++ b/runtime/onert/core/include/backend/ITensor.h
@@ -52,10 +52,7 @@ public:
    *        the outpus shape cannot be known and the output shape is calculated during
    *        kernel execution-time.
    */
-  virtual bool is_dynamic() const
-  {
-    throw std::runtime_error("This backend does not support dynamic tensor");
-  }
+  virtual bool is_dynamic() const = 0;
 
   /// @brief set this tensor dynamic
   virtual void set_dynamic()

--- a/runtime/onert/core/src/backend/controlflow/kernel/IfLayer.cc
+++ b/runtime/onert/core/src/backend/controlflow/kernel/IfLayer.cc
@@ -82,18 +82,18 @@ void IfLayer::run()
 
     const auto &then_input_tensors = then_exec->getInputTensors();
     const auto &then_output_tensors = then_exec->getOutputTensors();
-    PermuteLayer permute_op_input_to_then_input{_input_tensors, then_input_tensors, input_ranks};
-    PermuteLayer permute_then_output_to_op_output{then_output_tensors, _output_tensors,
-                                                  output_ranks};
+    const auto permute_op_input_to_then_input =
+        std::make_shared<PermuteLayer>(_input_tensors, then_input_tensors, input_ranks);
+    const auto permute_then_output_to_op_output =
+        std::make_shared<PermuteLayer>(then_output_tensors, _output_tensors, output_ranks);
 
     // Remove copying of unused tensor
-    permute_op_input_to_then_input.prepare();
-    permute_then_output_to_op_output.prepare();
+    permute_op_input_to_then_input->prepare();
+    permute_then_output_to_op_output->prepare();
 
     // Copy & run
-    permute_op_input_to_then_input.run();
-    then_exec->execute();
-    permute_then_output_to_op_output.run();
+    then_exec->execute(_input_tensors, permute_op_input_to_then_input);
+    permute_then_output_to_op_output->run();
   }
   else
   {
@@ -105,18 +105,18 @@ void IfLayer::run()
 
     const auto &else_input_tensors = else_exec->getInputTensors();
     const auto &else_output_tensors = else_exec->getOutputTensors();
-    PermuteLayer permute_op_input_to_else_input{_input_tensors, else_input_tensors, input_ranks};
-    PermuteLayer permute_else_output_to_op_output{else_output_tensors, _output_tensors,
-                                                  output_ranks};
+    const auto permute_op_input_to_else_input =
+        std::make_shared<PermuteLayer>(_input_tensors, else_input_tensors, input_ranks);
+    const auto permute_else_output_to_op_output =
+        std::make_shared<PermuteLayer>(else_output_tensors, _output_tensors, output_ranks);
 
     // Remove copying of unused tensor
-    permute_op_input_to_else_input.prepare();
-    permute_else_output_to_op_output.prepare();
+    permute_op_input_to_else_input->prepare();
+    permute_else_output_to_op_output->prepare();
 
     // Copy & run
-    permute_op_input_to_else_input.run();
-    else_exec->execute();
-    permute_else_output_to_op_output.run();
+    else_exec->execute(_input_tensors, permute_op_input_to_else_input);
+    permute_else_output_to_op_output->run();
   }
 }
 

--- a/runtime/onert/core/src/backend/controlflow/kernel/WhileLayer.cc
+++ b/runtime/onert/core/src/backend/controlflow/kernel/WhileLayer.cc
@@ -69,19 +69,22 @@ void WhileLayer::run()
   const auto &body_input_tensors = body_exec->getInputTensors();
   const auto &body_output_tensors = body_exec->getOutputTensors();
 
-  PermuteLayer permute_op_input_to_cond_input{_input_tensors, cond_input_tensors, _ranks};
-  PermuteLayer permute_cond_input_to_body_input{cond_input_tensors, body_input_tensors, _ranks};
-  PermuteLayer permute_body_output_to_cond_input{body_output_tensors, cond_input_tensors, _ranks};
-  PermuteLayer permute_cond_input_to_op_output{cond_input_tensors, _output_tensors, _ranks};
+  const auto permute_op_input_to_cond_input =
+      std::make_shared<PermuteLayer>(_input_tensors, cond_input_tensors, _ranks);
+  const auto permute_cond_input_to_body_input =
+      std::make_shared<PermuteLayer>(cond_input_tensors, body_input_tensors, _ranks);
+  const auto permute_body_output_to_cond_input =
+      std::make_shared<PermuteLayer>(body_output_tensors, cond_input_tensors, _ranks);
+  const auto permute_cond_input_to_op_output =
+      std::make_shared<PermuteLayer>(cond_input_tensors, _output_tensors, _ranks);
 
   // Remove copying of unused tensor
-  permute_op_input_to_cond_input.prepare();
-  permute_cond_input_to_body_input.prepare();
-  permute_body_output_to_cond_input.prepare();
-  permute_cond_input_to_op_output.prepare();
+  permute_op_input_to_cond_input->prepare();
+  permute_cond_input_to_body_input->prepare();
+  permute_body_output_to_cond_input->prepare();
+  permute_cond_input_to_op_output->prepare();
 
-  permute_op_input_to_cond_input.run();
-  cond_exec->execute();
+  cond_exec->execute(_input_tensors, permute_op_input_to_cond_input);
 
   assert(cond_exec->getOutputTensors().size() == 1);
   auto &cond_output_tensor = cond_exec->getOutputTensors().at(0);
@@ -94,12 +97,10 @@ void WhileLayer::run()
   // Loop while Cond subgraph's output is true
   while (getResultCond(cond_output_tensor.get()))
   {
-    permute_cond_input_to_body_input.run();
-    body_exec->execute();
-    permute_body_output_to_cond_input.run();
-    cond_exec->execute();
+    body_exec->execute(cond_input_tensors, permute_cond_input_to_body_input);
+    cond_exec->execute(body_output_tensors, permute_body_output_to_cond_input);
   }
-  permute_cond_input_to_op_output.run();
+  permute_cond_input_to_op_output->run();
 }
 
 } // namespace kernel

--- a/runtime/onert/core/src/exec/ExecutorBase.h
+++ b/runtime/onert/core/src/exec/ExecutorBase.h
@@ -31,6 +31,7 @@
 #include "compiler/OperandContext.h"
 #include "exec/ExecTime.h"
 #include "exec/IFunction.h"
+#include <exec/IPermuteFunction.h>
 #include "backend/IDynamicTensorManager.h"
 #include "backend/ITensorManager.h"
 #include "backend/ITensorBuilder.h"
@@ -59,8 +60,12 @@ public:
 
   /**
    * @brief Execute without IODescription
+   *
+   * @param src_tensor Tensor list that will be copied to input tensors of this
+   * @param pre_fn The permutation function that copy from src_tensor to input tensors of this
    */
-  void execute();
+  void execute(const std::vector<std::shared_ptr<backend::ITensor>> &src_tensors,
+               const std::shared_ptr<IPermuteFunction> &pre_fn);
 
   void execute(const IODescription &desc) final;
 

--- a/runtime/onert/core/src/interp/Tensor.h
+++ b/runtime/onert/core/src/interp/Tensor.h
@@ -122,6 +122,7 @@ public:
   size_t num_dimensions() const override { return _info.shape().rank(); }
   size_t calcOffset(const ir::Coordinates &coords) const override;
   ir::Layout layout() const override;
+  bool is_dynamic() const override { return false; }
   bool has_padding() const override { return false; }
   ir::DataType data_type() const override { return _info.typeInfo().type(); }
   const ir::OperandInfo &tensorInfo() const override { return _info; }
@@ -161,6 +162,7 @@ public:
   size_t num_dimensions() const override { return _info.shape().rank(); }
   size_t calcOffset(const ir::Coordinates &coords) const override;
   ir::Layout layout() const override;
+  bool is_dynamic() const override { return false; }
   bool has_padding() const override { return false; }
   ir::DataType data_type() const override { return _info.typeInfo().type(); }
   const ir::OperandInfo &tensorInfo() const override { return _info; }


### PR DESCRIPTION
For issue #1255
Draft PR #1372

This commit enables dynamic tensor with controlflow operation.
  - ExecutorBase's execute() for controlflow
    - Add params: source tensors, pre-IPermuteFunction
    - Enable infering shape of input tensors of subgraphs
    - Move pre-permutation(copying) that copies source tensors to input tensors of subgraphs
  - Introduce is_dynamic() into IACLTensor and interp::Tensor

Signed-off-by: ragmani <ragmani0216@gmail.com>