### PR TITLE
[onert] Modify `ir::OpSequence` to be index based

### DIFF
--- a/runtime/onert/backend/acl_cl/Backend.h
+++ b/runtime/onert/backend/acl_cl/Backend.h
@@ -46,11 +46,12 @@ public:
                                              bool is_linear_executor) const override
   {
     const auto &operands = graph.operands();
+    const auto &operations = graph.operations();
     auto context = std::make_unique<BackendContext>(this, &graph);
     auto tb = std::make_shared<TensorBuilder>(operands, createTensorManager(is_linear_executor));
     context->tensor_builder = tb;
     context->constant_initializer = std::make_shared<ConstantInitializer>(operands, tb);
-    context->kernel_gen = std::make_shared<KernelGenerator>(operands, tb);
+    context->kernel_gen = std::make_shared<KernelGenerator>(operands, operations, tb);
     context->shape_fixer = std::make_shared<ShapeFixer>(operands, tb);
     context->tensor_register = nullptr;
     context->optimizer = std::make_shared<Optimizer>(context.get());

--- a/runtime/onert/backend/acl_cl/KernelGenerator.cc
+++ b/runtime/onert/backend/acl_cl/KernelGenerator.cc
@@ -43,9 +43,11 @@ using ::onert::backend::acl_common::asAclClFunction;
 using ActivationBuilder = ::onert::backend::acl_common::AclActivationBuilder<
     ::arm_compute::ICLTensor, ::arm_compute::CLActivationLayer, acl_common::AclClFunction>;
 
-KernelGenerator::KernelGenerator(const ir::Operands &ctx,
+KernelGenerator::KernelGenerator(const ir::Operands &operands_ctx,
+                                 const ir::Operations &operations_ctx,
                                  const std::shared_ptr<TensorBuilder> &tensor_builder)
-    : _ctx(ctx), _tensor_builder(tensor_builder), _current_op_seq_layout(ir::Layout::UNKNOWN)
+    : _ctx(operands_ctx), _operations_ctx(operations_ctx), _tensor_builder(tensor_builder),
+      _current_op_seq_layout(ir::Layout::UNKNOWN)
 {
   // DO NOTHING
 }
@@ -57,9 +59,9 @@ void KernelGenerator::visit(const ir::OpSequence &op_seq)
   assert(!_return_fn_seq);
   _return_fn_seq = std::make_unique<exec::FunctionSequence>();
   _current_op_seq_layout = op_seq.getLayout();
-  for (const auto &e : op_seq.operations())
+  for (const auto &operation_idx : op_seq.operations())
   {
-    const auto &node = *(e.node);
+    const auto &node = _operations_ctx.at(operation_idx);
     node.accept(*this);
     _return_fn_seq->append(releaseFunction());
   }

--- a/runtime/onert/backend/acl_cl/KernelGenerator.h
+++ b/runtime/onert/backend/acl_cl/KernelGenerator.h
@@ -32,7 +32,8 @@ namespace acl_cl
 class KernelGenerator : public IKernelGenerator
 {
 public:
-  KernelGenerator(const ir::Operands &ctx, const std::shared_ptr<TensorBuilder> &tensor_builder);
+  KernelGenerator(const ir::Operands &operands_ctx, const ir::Operations &operations_ctx,
+                  const std::shared_ptr<TensorBuilder> &tensor_builder);
 
   void visit(const ir::OpSequence &) override;
   void visit(const ir::operation::BatchToSpaceND &) override;
@@ -104,6 +105,7 @@ public:
 
 private:
   const ir::Operands &_ctx;
+  const ir::Operations &_operations_ctx;
   std::shared_ptr<TensorBuilder> _tensor_builder;
   ir::Layout _current_op_seq_layout;
 };

--- a/runtime/onert/backend/acl_neon/Backend.h
+++ b/runtime/onert/backend/acl_neon/Backend.h
@@ -47,11 +47,12 @@ public:
                                              bool is_linear_executor) const override
   {
     const auto &operands = graph.operands();
+    const auto &operations = graph.operations();
     auto context = std::make_unique<BackendContext>(this, &graph);
     auto tb = std::make_shared<TensorBuilder>(operands, createTensorManager(is_linear_executor));
     context->tensor_builder = tb;
     context->constant_initializer = std::make_shared<ConstantInitializer>(operands, tb);
-    context->kernel_gen = std::make_shared<KernelGenerator>(operands, tb);
+    context->kernel_gen = std::make_shared<KernelGenerator>(operands, operations, tb);
     context->shape_fixer = std::make_shared<ShapeFixer>(operands, tb);
     context->tensor_register = nullptr;
     context->optimizer = std::make_shared<Optimizer>(context.get());

--- a/runtime/onert/backend/acl_neon/KernelGenerator.cc
+++ b/runtime/onert/backend/acl_neon/KernelGenerator.cc
@@ -43,9 +43,11 @@ using ::onert::backend::acl_common::asAclFunction;
 using ActivationBuilder = ::onert::backend::acl_common::AclActivationBuilder<
     ::arm_compute::ITensor, ::arm_compute::NEActivationLayer, acl_common::AclFunction>;
 
-KernelGenerator::KernelGenerator(const ir::Operands &ctx,
+KernelGenerator::KernelGenerator(const ir::Operands &operands_ctx,
+                                 const ir::Operations &operations_ctx,
                                  const std::shared_ptr<TensorBuilder> &tensor_builder)
-    : _ctx(ctx), _tensor_builder(tensor_builder), _current_op_seq_layout(ir::Layout::UNKNOWN)
+    : _ctx(operands_ctx), _operations_ctx(operations_ctx), _tensor_builder(tensor_builder),
+      _current_op_seq_layout(ir::Layout::UNKNOWN)
 {
   // DO NOTHING
 }
@@ -57,9 +59,9 @@ void KernelGenerator::visit(const ir::OpSequence &op_seq)
   assert(!_return_fn_seq);
   _return_fn_seq = std::make_unique<exec::FunctionSequence>();
   _current_op_seq_layout = op_seq.getLayout();
-  for (const auto &e : op_seq.operations())
+  for (const auto &operation_idx : op_seq.operations())
   {
-    const auto &node = *(e.node);
+    const auto &node = _operations_ctx.at(operation_idx);
     node.accept(*this);
     _return_fn_seq->append(releaseFunction());
   }

--- a/runtime/onert/backend/acl_neon/KernelGenerator.h
+++ b/runtime/onert/backend/acl_neon/KernelGenerator.h
@@ -32,7 +32,8 @@ namespace acl_neon
 class KernelGenerator : public IKernelGenerator
 {
 public:
-  KernelGenerator(const ir::Operands &ctx, const std::shared_ptr<TensorBuilder> &tensor_builder);
+  KernelGenerator(const ir::Operands &operands_ctx, const ir::Operations &operations_ctx,
+                  const std::shared_ptr<TensorBuilder> &tensor_builder);
 
   void visit(const ir::OpSequence &) override;
   void visit(const ir::operation::Abs &) override;
@@ -102,6 +103,7 @@ public:
 
 private:
   const ir::Operands &_ctx;
+  const ir::Operations &_operations_ctx;
   std::shared_ptr<TensorBuilder> _tensor_builder;
   ir::Layout _current_op_seq_layout;
 };

--- a/runtime/onert/backend/cpu/Backend.h
+++ b/runtime/onert/backend/cpu/Backend.h
@@ -45,11 +45,12 @@ public:
                                              bool) const override
   {
     const auto &operands = graph.operands();
+    const auto &operations = graph.operations();
     auto context = std::make_unique<BackendContext>(this, &graph);
     auto tb = std::make_shared<TensorBuilder>();
     context->tensor_builder = tb;
     context->constant_initializer = std::make_shared<ConstantInitializer>(operands, tb);
-    context->kernel_gen = std::make_shared<KernelGenerator>(operands, tb, kb);
+    context->kernel_gen = std::make_shared<KernelGenerator>(operands, operations, tb, kb);
     context->shape_fixer = std::make_shared<ShapeFixer>(operands);
     context->tensor_register = nullptr;
     context->optimizer = nullptr;

--- a/runtime/onert/backend/cpu/KernelGenerator.h
+++ b/runtime/onert/backend/cpu/KernelGenerator.h
@@ -23,6 +23,7 @@
 #include <backend/CustomKernelBuilder.h>
 #include <backend/IKernelGenerator.h>
 #include <ir/Operands.h>
+#include <ir/Operations.h>
 
 namespace onert
 {
@@ -34,7 +35,8 @@ namespace cpu
 class KernelGenerator : public IKernelGenerator
 {
 public:
-  KernelGenerator(const ir::Operands &ctx, const std::shared_ptr<TensorBuilder> &tensor_builder,
+  KernelGenerator(const ir::Operands &operands_ctx, const ir::Operations &operations_ctx,
+                  const std::shared_ptr<TensorBuilder> &tensor_builder,
                   const std::shared_ptr<custom::IKernelBuilder> &kernel_builder);
 
   using IKernelGenerator::visit;
@@ -101,6 +103,7 @@ public:
 
 private:
   const ir::Operands &_ctx;
+  const ir::Operations &_operations_ctx;
   std::shared_ptr<TensorBuilder> _tensor_builder;
   std::shared_ptr<backend::custom::IKernelBuilder> _kernel_builder;
   ir::Layout _current_op_seq_layout;

--- a/runtime/onert/core/include/backend/IShapeFixer.h
+++ b/runtime/onert/core/include/backend/IShapeFixer.h
@@ -38,9 +38,6 @@ public:
 
 protected:
   using OperationVisitor::visit;
-
-public:
-  void fix(const ir::OpSequence &op_seq) { op_seq.accept(*this); };
 };
 
 } // namespace backend

--- a/runtime/onert/core/include/exec/ExecutionObservers.h
+++ b/runtime/onert/core/include/exec/ExecutionObservers.h
@@ -47,7 +47,10 @@ public:
 class ProfileObserver : public IExecutionObserver
 {
 public:
-  explicit ProfileObserver(std::shared_ptr<ExecTime> et) : _et(std::move(et)) {}
+  explicit ProfileObserver(std::shared_ptr<ExecTime> et, const ir::Graph &graph)
+      : _et(std::move(et)), _graph(graph)
+  {
+  }
   void handleBegin(IExecutor *, const ir::OpSequence *, const backend::Backend *) override;
   void handleEnd(IExecutor *, const ir::OpSequence *, const backend::Backend *) override;
 
@@ -56,12 +59,13 @@ public:
 private:
   std::unique_ptr<util::ITimer> _timer;
   std::shared_ptr<ExecTime> _et;
+  const ir::Graph &_graph;
 };
 
 class ChromeTracingObserver : public IExecutionObserver
 {
 public:
-  ChromeTracingObserver(const std::string &filepath);
+  ChromeTracingObserver(const std::string &filepath, const ir::Graph &graph);
   ~ChromeTracingObserver();
   void handleBegin(IExecutor *) override;
   void handleBegin(IExecutor *, const ir::OpSequence *, const backend::Backend *) override;
@@ -69,12 +73,13 @@ public:
   void handleEnd(IExecutor *) override;
 
 private:
-  static std::string opSequenceTag(const ir::OpSequence *op_seq);
+  static std::string opSequenceTag(const ir::OpSequence *op_seq, const ir::Operations &operations);
 
 private:
   std::ofstream _ofs;
   EventRecorder _recorder;
   EventCollector _collector;
+  const ir::Graph &_graph;
 };
 
 } // namespace exec

--- a/runtime/onert/core/include/exec/FunctionSequence.h
+++ b/runtime/onert/core/include/exec/FunctionSequence.h
@@ -76,11 +76,11 @@ class FunctionSequenceForDynamicBackend : public FunctionSequence
 {
 public:
   FunctionSequenceForDynamicBackend(
-      const ir::OpSequence &op_seq,
+      const ir::OpSequence &op_seq, const ir::Operations &operations,
       std::unique_ptr<shape_inference::DynamicInferer> dyn_shape_inferer,
       backend::IDynamicTensorManager *dyn_tensor_manager)
-      : _op_seq(op_seq), _dyn_shape_inferer(std::move(dyn_shape_inferer)),
-        _dyn_tensor_manager(dyn_tensor_manager)
+      : _op_seq(op_seq), _operations_ctx(operations),
+        _dyn_shape_inferer(std::move(dyn_shape_inferer)), _dyn_tensor_manager(dyn_tensor_manager)
   { /* empty */
   }
 
@@ -88,6 +88,7 @@ public:
 
 private:
   const ir::OpSequence &_op_seq;
+  const ir::Operations &_operations_ctx;
   /// @brief shape inferer at execution time
   std::unique_ptr<shape_inference::DynamicInferer> _dyn_shape_inferer;
   backend::IDynamicTensorManager *_dyn_tensor_manager;

--- a/runtime/onert/core/include/ir/OpSequence.h
+++ b/runtime/onert/core/include/ir/OpSequence.h
@@ -30,19 +30,7 @@ namespace onert
 namespace ir
 {
 
-// To support ValueSwappable, Element doesn't have members which are classes
-// as value(or can have members which are classes as value and the classes
-// support Swappable)
-struct Element
-{
-  OperationIndex index;
-  const Operation *node;
-
-  Element(const OperationIndex *i, const Operation *n) : index{*i}, node{n}
-  {
-    // DO NOTHING
-  }
-};
+class Operations;
 
 class OpSequence
 {
@@ -67,19 +55,13 @@ public:
     _outputs.replace(from, to);
   }
 
-  void appendOperation(const OperationIndex &index, const Operation &node)
-  {
-    _operations.emplace_back(&index, &node);
-  }
+  void appendOperation(const OperationIndex &index) { _operations.emplace_back(index); }
 
-  std::vector<Element> &operations(void) { return _operations; }
+  std::vector<OperationIndex> &operations(void) { return _operations; }
 
-  const std::vector<Element> &operations(void) const { return _operations; }
+  const std::vector<OperationIndex> &operations(void) const { return _operations; }
 
   uint32_t size(void) const { return _operations.size(); }
-
-  // TODO: Impl Dumper instead of this method
-  std::string getStr(void) const;
 
 public:
   void remove(const OperationIndex &index);
@@ -88,8 +70,8 @@ public:
   Layout getLayout() const { return _layout; }
 
 public:
-  std::vector<Element>::const_iterator begin() const { return _operations.begin(); }
-  std::vector<Element>::const_iterator end() const { return _operations.end(); }
+  std::vector<OperationIndex>::const_iterator begin() const { return _operations.begin(); }
+  std::vector<OperationIndex>::const_iterator end() const { return _operations.end(); }
 
 private:
   bool exist(const OperationIndex &index) const;
@@ -97,11 +79,13 @@ private:
 private:
   OperandIndexSequence _inputs;
   OperandIndexSequence _outputs;
-  std::vector<Element> _operations;
+  std::vector<OperationIndex> _operations;
 
 private:
   Layout _layout;
 };
+
+std::string getStrFromOpSeq(const OpSequence &op_seq, const Operations &operations);
 
 } // namespace ir
 } // namespace onert

--- a/runtime/onert/core/include/ir/OpSequences.h
+++ b/runtime/onert/core/include/ir/OpSequences.h
@@ -36,11 +36,10 @@ public:
    * @brief Create an instance of OpSequence with given op and push it to objects
    *
    * @param[in] op_idx Operation index that is emplaced
-   * @param[in] op Operation that is emplaced
    * @param[in] layout OpSequence's layout
    * @return OpSequenceIndex
    */
-  OpSequenceIndex emplace(const OperationIndex &op_index, const Operation &op, Layout layout);
+  OpSequenceIndex emplace(const OperationIndex &op_index, Layout layout);
 
   /**
    * @brief Push an instance of OpSequence to objects
@@ -68,8 +67,9 @@ public:
    * @brief Dump OpSequences
    *
    * @param msg Message that will be displayed
+   * @param graph Graph that has information used for dump
    */
-  void dump(const std::string &msg) const;
+  void dump(const std::string &msg, const Operations &operations) const;
   /**
    * @brief Remove an operation from OpSequence
    *

--- a/runtime/onert/core/include/ir/OperationVisitor.h
+++ b/runtime/onert/core/include/ir/OperationVisitor.h
@@ -37,12 +37,10 @@ struct OperationVisitor
   // This OpSequence node should be handled specially so that
   // Op.lst doesn't have OpSequence
   // TODO Remove by pushing it down to derived classes.
-  virtual void visit(const OpSequence &op_seq)
+  virtual void visit(const OpSequence &)
   {
-    for (const auto &e : op_seq.operations())
-    {
-      e.node->accept(*this);
-    }
+    throw std::runtime_error{
+        "OperationVisitor: This does not privide visit function in OpSequence"};
   }
 };
 

--- a/runtime/onert/core/include/util/ShapeInference.h
+++ b/runtime/onert/core/include/util/ShapeInference.h
@@ -25,7 +25,7 @@
 #include "ir/operation/Conv2D.h"
 #include "ir/operation/DepthwiseConv2D.h"
 #include "ir/operation/Reshape.h"
-#include "ir/Operands.h"
+#include "ir/Graph.h"
 #include "ir/Index.h"
 #include "ir/Layout.h"
 #include "ir/OperationVisitor.h"
@@ -85,7 +85,8 @@ ir::Shape inferMaxPoolShape(const ir::Shape &in_shape, const ir::operation::MaxP
 class StaticInferer : public ir::OperationVisitor
 {
 public:
-  StaticInferer(ir::Operands &operands) : _operands(operands) { /* empty */}
+  StaticInferer(ir::Graph &graph)
+      : _operands(graph.operands()), _operations(graph.operations()) { /* empty */}
   virtual ~StaticInferer() = default;
 
 public:
@@ -95,7 +96,13 @@ public:
    *        when running kernel.
    * @param op_seq sequence of operations
    */
-  void infer(const ir::OpSequence &op_seq) { op_seq.accept(*this); };
+  void infer(const ir::OpSequence &op_seq)
+  {
+    for (const auto &operation_idx : op_seq.operations())
+    {
+      _operations.at(operation_idx).accept(*this);
+    }
+  }
 
   void dump();
 
@@ -128,6 +135,7 @@ private:
 
 private:
   ir::Operands &_operands;
+  ir::Operations &_operations;
 };
 
 // TODO After implement several Ops, check if this class can be merged with StaticInferer

--- a/runtime/onert/core/src/backend/controlflow/Backend.h
+++ b/runtime/onert/core/src/backend/controlflow/Backend.h
@@ -47,6 +47,7 @@ public:
                                              bool) const override
   {
     const auto &operands = graph.operands();
+    const auto &operations = graph.operations();
     auto context = std::make_unique<BackendContext>(this, &graph);
     // ControlFlow backend may not build tensors for itself because the backend's operation uses
     // tensors of other baceknd instead
@@ -68,7 +69,7 @@ public:
     auto tb = std::make_shared<TensorBuilder>();
     context->tensor_builder = tb;
     context->constant_initializer = std::make_shared<ConstantInitializer>(operands, tb);
-    context->kernel_gen = std::make_shared<KernelGenerator>(operands);
+    context->kernel_gen = std::make_shared<KernelGenerator>(operands, operations);
     context->shape_fixer = std::shared_ptr<IShapeFixer>(std::make_shared<EmptyShapeFixer>());
     context->tensor_register = nullptr;
     context->optimizer = nullptr;

--- a/runtime/onert/core/src/backend/controlflow/KernelGenerator.cc
+++ b/runtime/onert/core/src/backend/controlflow/KernelGenerator.cc
@@ -29,10 +29,13 @@ namespace backend
 namespace controlflow
 {
 
-KernelGenerator::KernelGenerator(const ir::Operands &operand_ctx)
-    : _operand_ctx{operand_ctx}, _tensor_builder_set{nullptr}, _executor_map{nullptr}
+KernelGenerator::KernelGenerator(const ir::Operands &operand_ctx,
+                                 const ir::Operations &operations_ctx)
+    : _operand_ctx{operand_ctx}, _operations_ctx{operations_ctx}, _tensor_builder_set{nullptr},
+      _executor_map{nullptr}
 {
   UNUSED_RELEASE(_operand_ctx);
+  UNUSED_RELEASE(_operations_ctx);
   UNUSED_RELEASE(_tensor_builder_set);
   UNUSED_RELEASE(_executor_map);
 }
@@ -41,9 +44,9 @@ void KernelGenerator::visit(const ir::OpSequence &op_seq)
 {
   assert(!_return_fn_seq);
   _return_fn_seq = std::make_unique<exec::FunctionSequence>();
-  for (const auto &e : op_seq.operations())
+  for (const auto &op_idx : op_seq.operations())
   {
-    const auto &node = *(e.node);
+    const auto &node = _operations_ctx.at(op_idx);
     node.accept(*this);
     _return_fn_seq->append(releaseFunction());
   }

--- a/runtime/onert/core/src/backend/controlflow/KernelGenerator.h
+++ b/runtime/onert/core/src/backend/controlflow/KernelGenerator.h
@@ -21,6 +21,7 @@
 #include <backend/ITensorBuilder.h>
 #include <exec/IExecutor.h>
 #include <ir/Operands.h>
+#include <ir/Operations.h>
 
 namespace onert
 {
@@ -32,7 +33,7 @@ namespace controlflow
 class KernelGenerator : public IKernelGenerator
 {
 public:
-  KernelGenerator(const ir::Operands &operand_ctx);
+  KernelGenerator(const ir::Operands &operand_ctx, const ir::Operations &operations_ctx);
 
   void setTensorBuilderSet(const TensorBuilderSet &tensor_builder_set)
   {
@@ -55,6 +56,7 @@ private:
 
 private:
   const ir::Operands &_operand_ctx;
+  const ir::Operations &_operations_ctx;
   TensorBuilderSet _tensor_builder_set;
   std::shared_ptr<exec::ExecutorMap> _executor_map;
 };

--- a/runtime/onert/core/src/compiler/Fp32ToFp16Converter.cc
+++ b/runtime/onert/core/src/compiler/Fp32ToFp16Converter.cc
@@ -253,7 +253,8 @@ void Fp32ToFp16Converter::appendNewOpSeqForConvertFp32ToFp16(const ir::OpSequenc
     _list_fp32_to_fp16.insert(new_op_seq_ind);
 
     VERBOSE(Fp32ToFp16Converter) << "NEW   |Fp32To16]"
-                                 << _lowered_graph.op_seqs().at(new_op_seq_ind).getStr()
+                                 << ir::getStrFromOpSeq(_lowered_graph.op_seqs().at(new_op_seq_ind),
+                                                        _lowered_graph.graph().operations())
                                  << std::endl;
   }
 }
@@ -324,7 +325,8 @@ void Fp32ToFp16Converter::appendNewOpSeqForConvertFp16ToFp32(const ir::OpSequenc
     _list_fp16_to_fp32.insert(new_op_seq_ind);
 
     VERBOSE(Fp32ToFp16Converter) << "NEW   |Fp16To32]"
-                                 << _lowered_graph.op_seqs().at(new_op_seq_ind).getStr()
+                                 << ir::getStrFromOpSeq(_lowered_graph.op_seqs().at(new_op_seq_ind),
+                                                        _lowered_graph.graph().operations())
                                  << std::endl;
   }
 }
@@ -379,12 +381,13 @@ void Fp32ToFp16Converter::convertOperands()
 void Fp32ToFp16Converter::convertOperandsOfOpSequence(ir::OpSequence &op_seq)
 {
   auto &operands = _lowered_graph.graph().operands();
+  const auto &operations = _lowered_graph.graph().operations();
   const auto &op_seq_inputs = _lowered_graph.graph().getInputs();
   const auto &op_seq_outputs = _lowered_graph.graph().getOutputs();
 
-  for (auto &elem : op_seq)
+  for (auto &op_idx : op_seq)
   {
-    auto &node = *(elem.node);
+    const auto &node = operations.at(op_idx);
     for (auto &ind : node.getInputs())
     {
       if (node.opcode() == ir::OpCode::ConvertFp32ToFp16 || op_seq_inputs.contains(ind))
@@ -448,7 +451,8 @@ void Fp32ToFp16Converter::printOpSequences(const std::string &pre_msg, const std
   }
 
   _lowered_graph.op_seqs().iterate([&](const ir::OpSequenceIndex &, const ir::OpSequence &op_seq) {
-    VERBOSE(Fp32ToFp16Converter) << op_seq.getStr() << std::endl;
+    VERBOSE(Fp32ToFp16Converter) << ir::getStrFromOpSeq(op_seq, _lowered_graph.graph().operations())
+                                 << std::endl;
   });
 
   if (post_msg.empty() == false)
@@ -469,7 +473,7 @@ bool Fp32ToFp16Converter::checkOperandsOfOpSequence(const ir::OpSequence &op_seq
   const auto &operations = _lowered_graph.graph().operations();
 
   // the first node's input
-  const auto &first_node_ind = op_seq.operations().at(0).index;
+  const auto &first_node_ind = op_seq.operations().at(0);
   const auto &first_node = operations.at(first_node_ind);
   const auto &first_node_inputs = first_node.getInputs();
   for (const auto &op_seq_input_ind : op_seq.getInputs())
@@ -480,7 +484,7 @@ bool Fp32ToFp16Converter::checkOperandsOfOpSequence(const ir::OpSequence &op_seq
 
   // the last node's output
   size_t last_ind = op_seq.size() - 1;
-  const auto &last_node_ind = op_seq.operations().at(last_ind).index;
+  const auto &last_node_ind = op_seq.operations().at(last_ind);
   const auto &last_node = operations.at(last_node_ind);
   const auto &last_node_outputs = last_node.getOutputs();
   for (const auto &op_seq_output_ind : op_seq.getOutputs())
@@ -532,7 +536,7 @@ void Fp32ToFp16Converter::manipulateInput(const ir::OpSequenceIndex &op_seq_ind,
 
   auto &op_seq = _lowered_graph.op_seqs().at(op_seq_ind);
 
-  auto &first_node_ind = op_seq.operations().at(0).index;
+  auto &first_node_ind = op_seq.operations().at(0);
   auto &first_node = operations.at(first_node_ind);
   assert(first_node.getInputs().contains(op_seq_input_ind));
 
@@ -560,7 +564,7 @@ void Fp32ToFp16Converter::manipulateOutput(const ir::OpSequenceIndex &op_seq_ind
   auto &op_seq = _lowered_graph.op_seqs().at(op_seq_ind);
 
   size_t last_ind = op_seq.size() - 1;
-  auto &last_node_ind = op_seq.operations().at(last_ind).index;
+  auto &last_node_ind = op_seq.operations().at(last_ind);
   auto &last_node = operations.at(last_node_ind);
   assert(last_node.getOutputs().contains(op_seq_output_ind));
 
@@ -627,7 +631,7 @@ ir::OpSequenceIndex Fp32ToFp16Converter::newOpSequence(const ir::OpSequenceIndex
   auto layout = lower_info->layout();
 
   auto op_seq = std::make_unique<ir::OpSequence>(layout);
-  op_seq->appendOperation(node_index, node);
+  op_seq->appendOperation(node_index);
   op_seq->setOutputs(node.getOutputs());
   op_seq->setInputs(node.getInputs());
 
@@ -816,7 +820,7 @@ Fp32ToFp16Converter::findOperationsToDelete(const OpSeqIndexList &list_to_delete
     const auto &op_seq = op_seqs.at(op_seq_ind);
     assert(op_seq.size() == 1);
 
-    const auto &first_node_ind = op_seq.operations().at(0).index;
+    const auto &first_node_ind = op_seq.operations().at(0);
     const auto &first_node = operations.at(first_node_ind);
     assert(first_node.opcode() == ir::OpCode::ConvertFp32ToFp16 ||
            first_node.opcode() == ir::OpCode::ConvertFp16ToFp32);
@@ -896,7 +900,7 @@ void Fp32ToFp16Converter::deleteContiguousOpSequences(
     assert(op_seq.size() == 1);
     VERBOSE(Fp32ToFp16Converter) << "Delete OpSeq #" << op_seq_ind.value() << std::endl;
 
-    auto &first_node_ind = op_seq.operations().at(0).index;
+    auto &first_node_ind = op_seq.operations().at(0);
     auto &first_node = operations.at(first_node_ind);
     assert(first_node.opcode() == ir::OpCode::ConvertFp32ToFp16 ||
            first_node.opcode() == ir::OpCode::ConvertFp16ToFp32);

--- a/runtime/onert/core/src/dumper/dot/DotDumper.cc
+++ b/runtime/onert/core/src/dumper/dot/DotDumper.cc
@@ -155,15 +155,15 @@ void DotDumper::dump(const std::string &tag)
       auto fillcolor = backend_to_fillcolor(lower_info->backend());
       std::string label =
           std::to_string(index.value()) + " [" + lower_info->backend()->config()->id() + "]";
-      DotSubgraphInfo subgraph_info{index, op_seq, shown_operand_set};
+      DotSubgraphInfo subgraph_info{index, op_seq, shown_operand_set, _graph.operations()};
       subgraph_info.label(label);
       subgraph_info.fillcolor(fillcolor);
       dot_builder.addOpSequence(subgraph_info);
 
       // Set fillcolor of all operations in the op_seq
-      for (const auto &op : op_seq.operations())
+      for (const auto &op_idx : op_seq.operations())
       {
-        auto found = operation_nodes.find(op.index);
+        auto found = operation_nodes.find(op_idx);
         if (found != operation_nodes.end())
         {
           auto &&op = found->second;

--- a/runtime/onert/core/src/dumper/dot/DotSubgraphInfo.cc
+++ b/runtime/onert/core/src/dumper/dot/DotSubgraphInfo.cc
@@ -26,13 +26,15 @@ namespace dot
 {
 
 DotSubgraphInfo::DotSubgraphInfo(const ir::OpSequenceIndex &index, const ir::OpSequence &op_seq,
-                                 const util::Set<ir::OperandIndex> &shown_operands)
+                                 const util::Set<ir::OperandIndex> &shown_operands,
+                                 const ir::Operations &operations_ctx)
     : _index{index}
 {
-  for (const auto &element : op_seq.operations())
+  for (const auto &op_idx : op_seq.operations())
   {
-    _operations.insert(element.index);
-    for (auto o : element.node->getInputs())
+    _operations.insert(op_idx);
+    const auto &node = operations_ctx.at(op_idx);
+    for (auto o : node.getInputs())
     {
       // Must be a shown operand, not op_seq's inputs
       if (shown_operands.contains(o) && !op_seq.getInputs().contains(o))
@@ -40,7 +42,7 @@ DotSubgraphInfo::DotSubgraphInfo(const ir::OpSequenceIndex &index, const ir::OpS
         _operands.insert(o);
       }
     }
-    for (auto o : element.node->getOutputs())
+    for (auto o : node.getOutputs())
     {
       // Must be a shown operand, not op_seq's inputs
       if (shown_operands.contains(o) && !op_seq.getOutputs().contains(o))

--- a/runtime/onert/core/src/dumper/dot/DotSubgraphInfo.h
+++ b/runtime/onert/core/src/dumper/dot/DotSubgraphInfo.h
@@ -20,6 +20,7 @@
 #include <unordered_set>
 
 #include "ir/Index.h"
+#include <ir/Operations.h>
 #include "ir/OpSequence.h"
 #include "util/Set.h"
 
@@ -34,7 +35,8 @@ class DotSubgraphInfo
 {
 public:
   DotSubgraphInfo(const ir::OpSequenceIndex &index, const ir::OpSequence &op_seq,
-                  const util::Set<ir::OperandIndex> &shown_operands);
+                  const util::Set<ir::OperandIndex> &shown_operands,
+                  const ir::Operations &operations_ctx);
 
   ir::OpSequenceIndex index() const { return _index; }
   std::string label() const { return _label; }

--- a/runtime/onert/core/src/exec/DataflowExecutor.cc
+++ b/runtime/onert/core/src/exec/DataflowExecutor.cc
@@ -25,19 +25,20 @@ namespace onert
 namespace exec
 {
 
-int64_t DataflowExecutor::calculateRank(const std::vector<ir::Element> &operations)
+int64_t DataflowExecutor::calculateRank(const std::vector<ir::OperationIndex> &operations)
 {
   int64_t rank = 0;
   if (!_indexed_ranks)
   {
     return rank;
   }
-  for (const auto &element : operations)
+  for (const auto &operation_idx : operations)
   {
-    auto it = _indexed_ranks->find(element.index);
+    auto it = _indexed_ranks->find(operation_idx);
     if (it == _indexed_ranks->end())
     {
-      assert(element.node->opcode() == ir::OpCode::Permute && operations.size() == 1);
+      assert(_graph.operations().at(operation_idx).opcode() == ir::OpCode::Permute &&
+             operations.size() == 1);
       // run Permute ASAP for next operations to be ready for other backends
       return std::numeric_limits<int64_t>::max();
     }

--- a/runtime/onert/core/src/exec/DataflowExecutor.h
+++ b/runtime/onert/core/src/exec/DataflowExecutor.h
@@ -56,7 +56,7 @@ public:
   void setProfilingMode(bool profiling) { _profiling = profiling; }
 
 protected:
-  int64_t calculateRank(const std::vector<ir::Element> &operations);
+  int64_t calculateRank(const std::vector<ir::OperationIndex> &operations);
   void emplaceToReadyJobs(const uint32_t &id);
 
 protected:

--- a/runtime/onert/core/src/exec/ExecutionObservers.cc
+++ b/runtime/onert/core/src/exec/ExecutionObservers.cc
@@ -45,16 +45,16 @@ void ProfileObserver::handleEnd(IExecutor *exec, const ir::OpSequence *op_seq,
   const auto timer_res = _timer->getTime();
 
   // NOTE This assumes there is just one operation in a op_seq
-  auto node = op_seq->operations().at(0).node;
-  auto node_name = node->name();
+  const auto &node = _graph.operations().at(op_seq->operations().at(0));
+  auto node_name = node.name();
   VERBOSE(ProfileInfo) << "Time for " << node_name << " : " << timer_res << std::endl;
 
   // fill ExecTime:
-  bool is_quantized = exec->graph().operands().at(node->getInputs().at(0)).typeInfo().type() ==
+  bool is_quantized = exec->graph().operands().at(node.getInputs().at(0)).typeInfo().type() ==
                       ir::DataType::QUANT_UINT8_ASYMM;
 
   uint32_t size = 0;
-  for (const auto &ind : node->getInputs() + node->getOutputs())
+  for (const auto &ind : node.getInputs() + node.getOutputs())
   {
     size += exec->graph().operands().at(ind).info().total_size();
   }
@@ -69,8 +69,8 @@ void ProfileObserver::handleEnd(IExecutor *exec, const ir::OpSequence *op_seq,
   }
 };
 
-ChromeTracingObserver::ChromeTracingObserver(const std::string &filepath)
-    : _ofs{filepath, std::ofstream::out}, _recorder{}, _collector{&_recorder}
+ChromeTracingObserver::ChromeTracingObserver(const std::string &filepath, const ir::Graph &graph)
+    : _ofs{filepath, std::ofstream::out}, _recorder{}, _collector{&_recorder}, _graph{graph}
 {
 }
 
@@ -85,16 +85,16 @@ void ChromeTracingObserver::handleBegin(IExecutor *, const ir::OpSequence *op_se
                                         const backend::Backend *backend)
 {
   std::string backend_id = backend->config()->id();
-  _collector.onEvent(
-      EventCollector::Event{EventCollector::Edge::BEGIN, backend_id, opSequenceTag(op_seq)});
+  _collector.onEvent(EventCollector::Event{EventCollector::Edge::BEGIN, backend_id,
+                                           opSequenceTag(op_seq, _graph.operations())});
 }
 
 void ChromeTracingObserver::handleEnd(IExecutor *, const ir::OpSequence *op_seq,
                                       const backend::Backend *backend)
 {
   std::string backend_id = backend->config()->id();
-  _collector.onEvent(
-      EventCollector::Event{EventCollector::Edge::END, backend_id, opSequenceTag(op_seq)});
+  _collector.onEvent(EventCollector::Event{EventCollector::Edge::END, backend_id,
+                                           opSequenceTag(op_seq, _graph.operations())});
 }
 
 void ChromeTracingObserver::handleEnd(IExecutor *)
@@ -102,14 +102,16 @@ void ChromeTracingObserver::handleEnd(IExecutor *)
   _collector.onEvent(EventCollector::Event{EventCollector::Edge::END, "runtime", "Graph"});
 }
 
-std::string ChromeTracingObserver::opSequenceTag(const ir::OpSequence *op_seq)
+std::string ChromeTracingObserver::opSequenceTag(const ir::OpSequence *op_seq,
+                                                 const ir::Operations &operations)
 {
   if (op_seq->size() == 0)
     return "Empty OpSequence";
 
-  auto first_op = op_seq->operations().at(0);
-  std::string tag = "$" + std::to_string(first_op.index.value());
-  tag += " " + first_op.node->name();
+  const auto &first_op_idx = op_seq->operations().at(0);
+  const auto &first_op_node = operations.at(first_op_idx);
+  std::string tag = "$" + std::to_string(first_op_idx.value());
+  tag += " " + first_op_node.name();
   if (op_seq->size() > 1)
   {
     tag += " (+" + std::to_string(op_seq->size() - 1) + ")";

--- a/runtime/onert/core/src/exec/FunctionSequence.cc
+++ b/runtime/onert/core/src/exec/FunctionSequence.cc
@@ -69,20 +69,20 @@ void FunctionSequenceForDynamicBackend::run()
   if (_op_seq.size() != _functions.size())
     throw std::runtime_error("operation and functions should be mapped one by one");
 
-  auto op_iter = _op_seq.begin();
+  auto op_seq_iter = _op_seq.begin();
   for (const auto &function : _functions)
   {
     // set shape of output and allocate memory when needed
-    auto *op = op_iter->node;
-    op->accept(*_dyn_shape_inferer);
+    auto &op = _operations_ctx.at(*op_seq_iter);
+    op.accept(*_dyn_shape_inferer);
 
     // run kernel
     function->run();
 
     // deallocate input tensors which is no longer used
-    _dyn_tensor_manager->deallocInput(op_iter->index);
+    _dyn_tensor_manager->deallocInput(*op_seq_iter);
 
-    op_iter++;
+    op_seq_iter++;
   }
 }
 

--- a/runtime/onert/core/src/exec/LinearExecutor.cc
+++ b/runtime/onert/core/src/exec/LinearExecutor.cc
@@ -27,9 +27,9 @@ namespace exec
 #ifdef RUY_PROFILER
 namespace
 {
-char *seq_to_label(const onert::ir::OpSequence *op_seq)
+char *seq_to_label(const onert::ir::OpSequence *op_seq, onert::ir::Operations &operations)
 {
-  auto node_name = op_seq->operations().at(0).node->name();
+  auto node_name = operations.at(*op_seq->begin()).name();
   char *cstr = new char[node_name.length() + 1];
   std::strcpy(cstr, node_name.c_str());
   return cstr;
@@ -46,7 +46,7 @@ void LinearExecutor::executeImpl()
     const auto backend = code.lower_info->backend();
 // TODO : Move ruy profiler into ExecutionObserver
 #ifdef RUY_PROFILER
-    ruy::profiler::ScopeLabel label(seq_to_label(op_seq));
+    ruy::profiler::ScopeLabel label(seq_to_label(op_seq), _graph.operations());
 #endif
     _subject.notifyJobBegin(this, op_seq, backend);
     code.fn_seq->run();

--- a/runtime/onert/core/src/ir/OpSequence.cc
+++ b/runtime/onert/core/src/ir/OpSequence.cc
@@ -15,6 +15,8 @@
  */
 
 #include "ir/OpSequence.h"
+
+#include "ir/Operations.h"
 #include "ir/OperationVisitor.h"
 #include <sstream>
 
@@ -49,18 +51,18 @@ OpSequence::OpSequence(Layout layout) : _layout{layout}
 void OpSequence::accept(OperationVisitor &v) const { v.visit(*this); }
 
 // TODO: Impl Dumper instead of this method
-std::string OpSequence::getStr() const
+std::string getStrFromOpSeq(const OpSequence &op_seq, const Operations &operations)
 {
   // "  OpSequence IN(0,1,2) -> { op0(0,1,2:3), op1(3:4), op2(4:5) } -> OUT(5)"
   std::stringstream ss;
-  ss << "  OpSequence IN(" << getStrFromIndice(getInputs()) << ") -> {";
-  for (const auto &elem : _operations)
+  ss << "  OpSequence IN(" << getStrFromIndice(op_seq.getInputs()) << ") -> {";
+  for (const auto &op_idx : op_seq)
   {
-    ss << " " << elem.index.value() << "(" << elem.node->name() << ":"
-       << getStrFromIndice(elem.node->getInputs()) << ":"
-       << getStrFromIndice(elem.node->getOutputs()) << ")";
+    ss << " " << op_idx.value() << "(" << operations.at(op_idx).name() << ":"
+       << getStrFromIndice(operations.at(op_idx).getInputs()) << ":"
+       << getStrFromIndice(operations.at(op_idx).getOutputs()) << ")";
   }
-  ss << " } -> OUT(" << getStrFromIndice(getOutputs()) << ")";
+  ss << " } -> OUT(" << getStrFromIndice(op_seq.getOutputs()) << ")";
   return ss.str();
 }
 
@@ -69,7 +71,7 @@ void OpSequence::remove(const OperationIndex &index)
   assert(exist(index));
   for (auto it = _operations.cbegin(); it != _operations.cend(); ++it)
   {
-    if (it->index == index)
+    if (*it == index)
     {
       _operations.erase(it);
       break;
@@ -79,9 +81,9 @@ void OpSequence::remove(const OperationIndex &index)
 
 bool OpSequence::exist(const OperationIndex &index) const
 {
-  for (const auto &element : _operations)
+  for (const auto &inner_op_idx : _operations)
   {
-    if (element.index == index)
+    if (inner_op_idx == index)
     {
       return true;
     }

--- a/runtime/onert/core/src/ir/OpSequences.cc
+++ b/runtime/onert/core/src/ir/OpSequences.cc
@@ -26,11 +26,10 @@ namespace onert
 namespace ir
 {
 
-OpSequenceIndex OpSequences::emplace(const OperationIndex &index, const Operation &node,
-                                     Layout layout)
+OpSequenceIndex OpSequences::emplace(const OperationIndex &index, Layout layout)
 {
   std::unique_ptr<OpSequence> op_seq = std::make_unique<OpSequence>(layout);
-  op_seq->appendOperation(index, node);
+  op_seq->appendOperation(index);
   return push(std::move(op_seq));
 }
 
@@ -52,11 +51,11 @@ OpSequenceIndex OpSequences::getOperation(const OperationIndex &operation_index)
 }
 
 // TODO: Extract this into external helper function
-void OpSequences::dump(const std::string &msg) const
+void OpSequences::dump(const std::string &msg, const Operations &operations) const
 {
   VERBOSE(OpSequences) << "OpSequences(" << msg << ")" << std::endl;
   iterate([&](const OpSequenceIndex &idx, const OpSequence &op_seq) {
-    VERBOSE(OpSequences) << idx.value() << "] " << op_seq.getStr() << std::endl;
+    VERBOSE(OpSequences) << idx.value() << "] " << getStrFromOpSeq(op_seq, operations) << std::endl;
   });
 }
 
@@ -75,9 +74,9 @@ OpSequenceIndex OpSequences::findOperation(const OperationIndex &operation_index
 {
   OpSequenceIndex ret;
   iterate([&](const OpSequenceIndex &index, const OpSequence &object) {
-    for (const auto &elem : object.operations())
+    for (const auto &op_idx : object.operations())
     {
-      if (elem.index == operation_index)
+      if (op_idx == operation_index)
         ret = index;
     }
   });

--- a/runtime/onert/core/src/ir/pass/PermutationInsertionPass.cc
+++ b/runtime/onert/core/src/ir/pass/PermutationInsertionPass.cc
@@ -195,7 +195,7 @@ OperationIndex PermutationInsertionPass::insertPermute(const OperandIndex &opera
 
   // OpSequence
   {
-    auto op_seq_index = _lowered_graph.op_seqs().emplace(node_index, node, permute_node_layout);
+    auto op_seq_index = _lowered_graph.op_seqs().emplace(node_index, permute_node_layout);
     auto &op_seq = _lowered_graph.op_seqs().at(op_seq_index);
     op_seq.setInputs(node.getInputs());
     op_seq.setOutputs(node.getOutputs());

--- a/runtime/onert/core/src/ir/pass/PermutationOperationPass.cc
+++ b/runtime/onert/core/src/ir/pass/PermutationOperationPass.cc
@@ -59,28 +59,31 @@ void PermutationOperationPass::changeToKeepLayout(const Operation &node)
   // Divide op_seq based on target operation
   {
     auto &prev_op_seq = _lowered_graph.op_seqs().at(op_seq_index);
+    auto &operations = _lowered_graph.graph().operations();
 
     // Create new op_seq and move information from existing op_seq to new op_seq if target
     // node is the end of op_seq
     auto it = prev_op_seq.begin();
     // Find iterator of target node in op_seq
-    while ((it++)->index != node_index)
+    while (*(it++) != node_index)
       ;
     if (it != prev_op_seq.end())
     {
+      const auto &target_op_idx = *it;
+      const auto &target_node = operations.at(target_op_idx);
       const auto &next_op_seq_index =
-          _lowered_graph.op_seqs().emplace(it->index, *it->node, prev_op_seq.getLayout());
+          _lowered_graph.op_seqs().emplace(target_op_idx, prev_op_seq.getLayout());
       auto &next_op_seq = _lowered_graph.op_seqs().at(next_op_seq_index);
-      next_op_seq.setInputs(it->node->getInputs());
-      next_op_seq.setOutputs(it->node->getOutputs());
+      next_op_seq.setInputs(target_node.getInputs());
+      next_op_seq.setOutputs(target_node.getOutputs());
 
       std::vector<OperationIndex> remove_list;
-      remove_list.emplace_back(it->index);
+      remove_list.emplace_back(target_op_idx);
       while (++it != prev_op_seq.end())
       {
-        next_op_seq.appendOperation(it->index, *it->node);
-        next_op_seq.setOutputs(it->node->getOutputs());
-        remove_list.emplace_back(it->index);
+        next_op_seq.appendOperation(target_op_idx);
+        next_op_seq.setOutputs(target_node.getOutputs());
+        remove_list.emplace_back(target_op_idx);
       }
 
       prev_op_seq.setOutputs(node.getOutputs());
@@ -112,12 +115,13 @@ void PermutationOperationPass::changeToKeepLayout(const Operation &node)
     {
       // Update op_seq of target operation if the op_seq exists
       auto &prev_op_seq = _lowered_graph.op_seqs().at(op_seq_index);
-      const auto last_node = (--prev_op_seq.end())->node;
-      prev_op_seq.setOutputs(last_node->getOutputs());
+      const auto &last_node_idx = *(--prev_op_seq.end());
+      const auto &last_node = _lowered_graph.graph().operations().at(last_node_idx);
+      prev_op_seq.setOutputs(last_node.getOutputs());
     }
 
     // Create new op_seq and set information to the op_seq
-    auto new_op_seq_index = _lowered_graph.op_seqs().emplace(node_index, node, frontend_layout);
+    auto new_op_seq_index = _lowered_graph.op_seqs().emplace(node_index, frontend_layout);
     auto &new_op_seq = _lowered_graph.op_seqs().at(new_op_seq_index);
     new_op_seq.setInputs(node.getInputs());
     new_op_seq.setOutputs(node.getOutputs());


### PR DESCRIPTION
This commit modifies `ir::OpSequence` to be index based.
  - Remove "onert::ir::Element"
  - Fix incorrect use of address-of operator
  - Adjust visit functions of `ir::OpSequence` by `OperationVisitor`

Signed-off-by: ragmani <ragmani0216@gmail.com>