### PR TITLE
[onert] Introduce TensorRegistryTemplate

### DIFF
--- a/runtime/onert/core/include/backend/ITensorRegistry.h
+++ b/runtime/onert/core/include/backend/ITensorRegistry.h
@@ -42,4 +42,67 @@ struct ITensorRegistry
 } // namespace backend
 } // namespace onert
 
+#include "ir/OperandIndexMap.h"
+
+namespace onert
+{
+namespace backend
+{
+
+/**
+ * @brief  TensorRegistry template class for the convenience of backend implementations
+ *
+ * Unless there is a special reason to implement @c ITensorRegistry on your own, you may just use
+ * this default implementation.
+ *
+ * @tparam T_Tensor Tensor type. Must be a subclass of @c onert::backend::ITensor .
+ */
+template <typename T_Tensor> class TensorRegistryTemplate : public ITensorRegistry
+{
+public:
+  std::shared_ptr<ITensor> getITensor(const ir::OperandIndex &ind) override
+  {
+    static_assert(std::is_base_of<ITensor, T_Tensor>::value, "T_Tensor must derive from ITensor.");
+    auto external_tensor = _external.find(ind);
+    if (external_tensor != _external.end())
+      return external_tensor->second;
+    return getManagedTensor(ind);
+  }
+
+  std::shared_ptr<T_Tensor> getManagedTensor(const ir::OperandIndex &ind)
+  {
+    auto tensor = _managed.find(ind);
+    if (tensor != _managed.end())
+      return tensor->second;
+    return nullptr;
+  }
+
+  void setExternalTensor(const ir::OperandIndex &ind, const std::shared_ptr<ITensor> &tensor)
+  {
+    auto itr = _managed.find(ind);
+    if (itr != _managed.end() && itr->second != nullptr && tensor != nullptr)
+      throw std::runtime_error{
+          "Tried to set an external tensor but an managed tensor already exists."};
+    _external[ind] = tensor;
+  }
+
+  void setManagedTensor(const ir::OperandIndex &ind, const std::shared_ptr<T_Tensor> &tensor)
+  {
+    auto itr = _external.find(ind);
+    if (itr != _external.end() && itr->second != nullptr && tensor != nullptr)
+      throw std::runtime_error{
+          "Tried to set a managed tensor but an external tensor already exists."};
+    _managed[ind] = tensor;
+  }
+
+  const ir::OperandIndexMap<std::shared_ptr<T_Tensor>> &managed_tensors() { return _managed; }
+
+private:
+  ir::OperandIndexMap<std::shared_ptr<ITensor>> _external;
+  ir::OperandIndexMap<std::shared_ptr<T_Tensor>> _managed;
+};
+
+} // namespace backend
+} // namespace onert
+
 #endif // __ONERT_BACKEND_ITENSOR_REGISTRY__


### PR DESCRIPTION
Introduce `TensorRegistryTemplate` class for the convenience of backend
implementations.

Part of #1325

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>