### PR TITLE
[onert] Set default backend to 'cpu'

### DIFF
--- a/runtime/onert/core/include/util/Config.lst
+++ b/runtime/onert/core/include/util/Config.lst
@@ -20,7 +20,7 @@
 
 //     Name                    | Type         | Default
 CONFIG(GRAPH_DOT_DUMP          , int          , "0")
-CONFIG(BACKENDS                , std::string  , "acl_cl;acl_neon;cpu")
+CONFIG(BACKENDS                , std::string  , "cpu;acl_cl;acl_neon")
 CONFIG(OP_BACKEND_ALLOPS       , std::string  , "")
 CONFIG(OP_BACKEND_MAP          , std::string  , "")
 CONFIG(DISABLE_COMPILE         , bool         , "0")


### PR DESCRIPTION
The first backend in BACKENDS is the backend that has the highest
priority. And 'acl_cl' has been the first for the convenience of
testing at the early stages of this project. But we should set it
to 'cpu' as it is the most general(compatible) backend.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>