### PR TITLE
[luci] Remove unused no_shape

### DIFF
--- a/compiler/luci/export/src/CircleTensorExporter.cpp
+++ b/compiler/luci/export/src/CircleTensorExporter.cpp
@@ -53,9 +53,6 @@ public:
   const ShapeDescription &shape(void) const { return _shape; }
   void shape(const ShapeDescription &shape) { _shape = shape; }
 
-  void no_shape(void) { _no_shape = true; }
-  bool no_shape(void) const { return _no_shape; }
-
   luci::ShapeStatus shape_status(void) const { return _shape_status; }
   void shape_status(luci::ShapeStatus ss) { _shape_status = ss; }
 
@@ -71,7 +68,6 @@ private:
 
   circle::TensorType _dtype{circle::TensorType_FLOAT32};
   ShapeDescription _shape{};
-  bool _no_shape{false};
   luci::ShapeStatus _shape_status{luci::ShapeStatus::UNDEFINED};
 
   luci::CircleConst *_content = nullptr;

--- a/compiler/luci/lang/include/luci/IR/CircleNodeDecl.h
+++ b/compiler/luci/lang/include/luci/IR/CircleNodeDecl.h
@@ -54,17 +54,12 @@ struct CircleNode : public loco::Node,
     _quantparam = std::move(quantparam);
   }
 
-  bool no_shape(void) const { return _no_shape; }
-  void no_shape(bool ns) { _no_shape = ns; }
-
   ShapeStatus shape_status(void) const { return _shape_status; }
   void shape_status(ShapeStatus ss) { _shape_status = ss; }
 
 private:
   NodeName _name;
   std::unique_ptr<CircleQuantParam> _quantparam;
-  /// @brief _no_shape is true if tensor has no shape
-  bool _no_shape{false};
   ShapeStatus _shape_status{ShapeStatus::UNDEFINED};
 };
 


### PR DESCRIPTION
This will remove unused no_shape that is replaced by shape_status

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>