### PR TITLE
[TensorFlowPythonExamples] Add reduce_all operator

### DIFF
--- a/res/TensorFlowPythonExamples/examples/reduce_all/__init__.py
+++ b/res/TensorFlowPythonExamples/examples/reduce_all/__init__.py
@@ -1,0 +1,4 @@
+import tensorflow as tf
+
+input_ = tf.compat.v1.placeholder(dtype=tf.bool, shape=(2, 4), name="Hole")
+op_ = tf.compat.v1.reduce_all(input_, axis=1, keepdims=False)


### PR DESCRIPTION
This commit enables TensorFlowPythonExamples to support reduce_all

Related : #704
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>