### PR TITLE
[luci] Inf svc for L2Pool2D

### DIFF
--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -830,6 +830,11 @@ public:
     return loco::NodeShape{input_shape};
   }
 
+  loco::NodeShape visit(const luci::CircleL2Pool2D *node) final
+  {
+    return infer_pool_2d_shape(node);
+  }
+
   loco::NodeShape visit(const luci::CircleLeakyRelu *node) final
   {
     const auto input_shape = loco::shape_get(node->features()).as<loco::TensorShape>();

--- a/compiler/luci/service/src/CircleTypeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleTypeInferenceRule.cpp
@@ -145,6 +145,11 @@ struct TypeInferenceAlgorithm final : public luci::CircleNodeVisitor<loco::DataT
     return loco::dtype_get(node->input(1));
   }
 
+  loco::DataType visit(const luci::CircleL2Pool2D *node) final
+  {
+    return loco::dtype_get(node->value());
+  }
+
   loco::DataType visit(const luci::CircleLeakyRelu *node) final
   {
     return loco::dtype_get(node->features());


### PR DESCRIPTION
This will enable shape, dtype inference for L2Pool2D

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>