### PR TITLE
[onert/cpu] Rename tensor shape getter

### DIFF
--- a/runtime/onert/backend/cpu/ops/AbsLayer.cc
+++ b/runtime/onert/backend/cpu/ops/AbsLayer.cc
@@ -36,9 +36,8 @@ AbsLayer::AbsLayer() : _input(nullptr), _output(nullptr)
 
 void AbsLayer::absFloat32()
 {
-  nnfw::cker::Abs(convertTensorToCkerShape(_input),
-                  reinterpret_cast<const float *>(_input->buffer()),
-                  convertTensorToCkerShape(_output), reinterpret_cast<float *>(_output->buffer()));
+  nnfw::cker::Abs(getTensorShape(_input), reinterpret_cast<const float *>(_input->buffer()),
+                  getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()));
 }
 
 void AbsLayer::absQuant8() { throw std::runtime_error{"NYI"}; }

--- a/runtime/onert/backend/cpu/ops/AddLayer.cc
+++ b/runtime/onert/backend/cpu/ops/AddLayer.cc
@@ -36,21 +36,21 @@ void AddLayer::addFloat32()
   op_params.float_activation_max = output_activation_max;
   op_params.float_activation_min = output_activation_min;
 
-  const bool need_broadcast = nnfw::cker::ProcessBroadcastShapes(
-      convertTensorToCkerShape(_lhs), convertTensorToCkerShape(_rhs), &op_params);
+  const bool need_broadcast =
+      nnfw::cker::ProcessBroadcastShapes(getTensorShape(_lhs), getTensorShape(_rhs), &op_params);
   if (need_broadcast)
   {
     nnfw::cker::BroadcastBinaryArithmeticOp(
-        op_params, convertTensorToCkerShape(_lhs), reinterpret_cast<const float *>(_lhs->buffer()),
-        convertTensorToCkerShape(_rhs), reinterpret_cast<const float *>(_rhs->buffer()),
-        convertTensorToCkerShape(_output), reinterpret_cast<float *>(_output->buffer()));
+        op_params, getTensorShape(_lhs), reinterpret_cast<const float *>(_lhs->buffer()),
+        getTensorShape(_rhs), reinterpret_cast<const float *>(_rhs->buffer()),
+        getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()));
     return;
   }
 
   nnfw::cker::BinaryArithmeticOp(
-      op_params, convertTensorToCkerShape(_lhs), reinterpret_cast<const float *>(_lhs->buffer()),
-      convertTensorToCkerShape(_rhs), reinterpret_cast<const float *>(_rhs->buffer()),
-      convertTensorToCkerShape(_output), reinterpret_cast<float *>(_output->buffer()));
+      op_params, getTensorShape(_lhs), reinterpret_cast<const float *>(_lhs->buffer()),
+      getTensorShape(_rhs), reinterpret_cast<const float *>(_rhs->buffer()),
+      getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()));
 }
 
 void AddLayer::addQuant8()

--- a/runtime/onert/backend/cpu/ops/ArgMinMaxLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ArgMinMaxLayer.cc
@@ -58,11 +58,10 @@ void ArgMinMaxLayer::configure(const Tensor *input, Tensor *output, int32_t axis
 
 void ArgMinMaxLayer::run()
 {
-#define TF_LITE_ARG_MIN_MAX(input_type, axis_type, output_type)                                    \
-  ArgMinMax(convertTensorToCkerShape(_input),                                                      \
-            reinterpret_cast<const input_type *>(_input->buffer()),                                \
-            convertTensorToCkerShape(_output), reinterpret_cast<output_type *>(_output->buffer()), \
-            _axis, GetComparefunction<input_type>(_is_arg_max));
+#define TF_LITE_ARG_MIN_MAX(input_type, axis_type, output_type)                                 \
+  ArgMinMax(getTensorShape(_input), reinterpret_cast<const input_type *>(_input->buffer()),     \
+            getTensorShape(_output), reinterpret_cast<output_type *>(_output->buffer()), _axis, \
+            GetComparefunction<input_type>(_is_arg_max));
 
   assert(_output->data_type() == ir::DataType::INT32);
   switch (_input->data_type())

--- a/runtime/onert/backend/cpu/ops/AvgPoolLayer.cc
+++ b/runtime/onert/backend/cpu/ops/AvgPoolLayer.cc
@@ -52,10 +52,9 @@ void AvgPoolLayer::averagePoolFloat32()
   op_params.float_activation_min = output_activation_min;
   op_params.float_activation_max = output_activation_max;
 
-  nnfw::cker::AveragePool(op_params, convertTensorToCkerShape(_input),
+  nnfw::cker::AveragePool(op_params, getTensorShape(_input),
                           reinterpret_cast<const float *>(_input->buffer()),
-                          convertTensorToCkerShape(_output),
-                          reinterpret_cast<float *>(_output->buffer()));
+                          getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()));
 }
 void AvgPoolLayer::averagePoolQuant8()
 {
@@ -67,10 +66,9 @@ void AvgPoolLayer::averagePoolQuant8()
   op_params.quantized_activation_min = output_activation_min;
   op_params.quantized_activation_max = output_activation_max;
 
-  nnfw::cker::AveragePool(op_params, convertTensorToCkerShape(_input),
+  nnfw::cker::AveragePool(op_params, getTensorShape(_input),
                           reinterpret_cast<const uint8_t *>(_input->buffer()),
-                          convertTensorToCkerShape(_output),
-                          reinterpret_cast<uint8_t *>(_output->buffer()));
+                          getTensorShape(_output), reinterpret_cast<uint8_t *>(_output->buffer()));
 }
 
 void AvgPoolLayer::configure(const Tensor *input, const uint32_t paddingLeft,

--- a/runtime/onert/backend/cpu/ops/CastLayer.cc
+++ b/runtime/onert/backend/cpu/ops/CastLayer.cc
@@ -38,8 +38,8 @@ void CastLayer::configure(const Tensor *input, Tensor *output)
 
 template <typename FromT, typename ToT> void CastLayer::castTensor(const FromT *in, ToT *out)
 {
-  auto input_shape = convertTensorToCkerShape(_input);
-  auto output_shape = convertTensorToCkerShape(_output);
+  auto input_shape = getTensorShape(_input);
+  auto output_shape = getTensorShape(_output);
   const auto num_elements = MatchingFlatSize(input_shape, output_shape);
 
   std::transform(in, in + num_elements, out, [](FromT a) { return static_cast<ToT>(a); });

--- a/runtime/onert/backend/cpu/ops/CompareLayer.cc
+++ b/runtime/onert/backend/cpu/ops/CompareLayer.cc
@@ -45,39 +45,39 @@ void compareScalar(const Tensor *lhs, const Tensor *rhs, Tensor *output, OpType 
     {
       case OpType::Equal:
         Broadcast4DSlowEqual(
-            convertToExtendedCkerShape(lhs), reinterpret_cast<const T *>(lhs->buffer()),
-            convertToExtendedCkerShape(rhs), reinterpret_cast<const T *>(rhs->buffer()),
-            convertToExtendedCkerShape(output), reinterpret_cast<bool *>(output->buffer()));
+            getExtendedTensorShape(lhs), reinterpret_cast<const T *>(lhs->buffer()),
+            getExtendedTensorShape(rhs), reinterpret_cast<const T *>(rhs->buffer()),
+            getExtendedTensorShape(output), reinterpret_cast<bool *>(output->buffer()));
         break;
       case OpType::NotEqual:
         Broadcast4DSlowNotEqual(
-            convertToExtendedCkerShape(lhs), reinterpret_cast<const T *>(lhs->buffer()),
-            convertToExtendedCkerShape(rhs), reinterpret_cast<const T *>(rhs->buffer()),
-            convertToExtendedCkerShape(output), reinterpret_cast<bool *>(output->buffer()));
+            getExtendedTensorShape(lhs), reinterpret_cast<const T *>(lhs->buffer()),
+            getExtendedTensorShape(rhs), reinterpret_cast<const T *>(rhs->buffer()),
+            getExtendedTensorShape(output), reinterpret_cast<bool *>(output->buffer()));
         break;
       case OpType::Greater:
         Broadcast4DSlowGreater(
-            convertToExtendedCkerShape(lhs), reinterpret_cast<const T *>(lhs->buffer()),
-            convertToExtendedCkerShape(rhs), reinterpret_cast<const T *>(rhs->buffer()),
-            convertToExtendedCkerShape(output), reinterpret_cast<bool *>(output->buffer()));
+            getExtendedTensorShape(lhs), reinterpret_cast<const T *>(lhs->buffer()),
+            getExtendedTensorShape(rhs), reinterpret_cast<const T *>(rhs->buffer()),
+            getExtendedTensorShape(output), reinterpret_cast<bool *>(output->buffer()));
         break;
       case OpType::GreaterEqual:
         Broadcast4DSlowGreaterEqual(
-            convertToExtendedCkerShape(lhs), reinterpret_cast<const T *>(lhs->buffer()),
-            convertToExtendedCkerShape(rhs), reinterpret_cast<const T *>(rhs->buffer()),
-            convertToExtendedCkerShape(output), reinterpret_cast<bool *>(output->buffer()));
+            getExtendedTensorShape(lhs), reinterpret_cast<const T *>(lhs->buffer()),
+            getExtendedTensorShape(rhs), reinterpret_cast<const T *>(rhs->buffer()),
+            getExtendedTensorShape(output), reinterpret_cast<bool *>(output->buffer()));
         break;
       case OpType::Less:
-        Broadcast4DSlowLess(
-            convertToExtendedCkerShape(lhs), reinterpret_cast<const T *>(lhs->buffer()),
-            convertToExtendedCkerShape(rhs), reinterpret_cast<const T *>(rhs->buffer()),
-            convertToExtendedCkerShape(output), reinterpret_cast<bool *>(output->buffer()));
+        Broadcast4DSlowLess(getExtendedTensorShape(lhs), reinterpret_cast<const T *>(lhs->buffer()),
+                            getExtendedTensorShape(rhs), reinterpret_cast<const T *>(rhs->buffer()),
+                            getExtendedTensorShape(output),
+                            reinterpret_cast<bool *>(output->buffer()));
         break;
       case OpType::LessEqual:
         Broadcast4DSlowLessEqual(
-            convertToExtendedCkerShape(lhs), reinterpret_cast<const T *>(lhs->buffer()),
-            convertToExtendedCkerShape(rhs), reinterpret_cast<const T *>(rhs->buffer()),
-            convertToExtendedCkerShape(output), reinterpret_cast<bool *>(output->buffer()));
+            getExtendedTensorShape(lhs), reinterpret_cast<const T *>(lhs->buffer()),
+            getExtendedTensorShape(rhs), reinterpret_cast<const T *>(rhs->buffer()),
+            getExtendedTensorShape(output), reinterpret_cast<bool *>(output->buffer()));
         break;
       default:
         throw std::runtime_error{"Invalid OpType for CompareLayer"};
@@ -88,40 +88,38 @@ void compareScalar(const Tensor *lhs, const Tensor *rhs, Tensor *output, OpType 
     switch (op_type)
     {
       case OpType::Equal:
-        EqualNoScaling(convertToExtendedCkerShape(lhs), reinterpret_cast<const T *>(lhs->buffer()),
-                       convertToExtendedCkerShape(rhs), reinterpret_cast<const T *>(rhs->buffer()),
-                       convertToExtendedCkerShape(output),
-                       reinterpret_cast<bool *>(output->buffer()));
+        EqualNoScaling(getExtendedTensorShape(lhs), reinterpret_cast<const T *>(lhs->buffer()),
+                       getExtendedTensorShape(rhs), reinterpret_cast<const T *>(rhs->buffer()),
+                       getExtendedTensorShape(output), reinterpret_cast<bool *>(output->buffer()));
         break;
       case OpType::NotEqual:
-        NotEqualNoScaling(
-            convertToExtendedCkerShape(lhs), reinterpret_cast<const T *>(lhs->buffer()),
-            convertToExtendedCkerShape(rhs), reinterpret_cast<const T *>(rhs->buffer()),
-            convertToExtendedCkerShape(output), reinterpret_cast<bool *>(output->buffer()));
+        NotEqualNoScaling(getExtendedTensorShape(lhs), reinterpret_cast<const T *>(lhs->buffer()),
+                          getExtendedTensorShape(rhs), reinterpret_cast<const T *>(rhs->buffer()),
+                          getExtendedTensorShape(output),
+                          reinterpret_cast<bool *>(output->buffer()));
         break;
       case OpType::Greater:
-        GreaterNoScaling(
-            convertToExtendedCkerShape(lhs), reinterpret_cast<const T *>(lhs->buffer()),
-            convertToExtendedCkerShape(rhs), reinterpret_cast<const T *>(rhs->buffer()),
-            convertToExtendedCkerShape(output), reinterpret_cast<bool *>(output->buffer()));
+        GreaterNoScaling(getExtendedTensorShape(lhs), reinterpret_cast<const T *>(lhs->buffer()),
+                         getExtendedTensorShape(rhs), reinterpret_cast<const T *>(rhs->buffer()),
+                         getExtendedTensorShape(output),
+                         reinterpret_cast<bool *>(output->buffer()));
         break;
       case OpType::GreaterEqual:
         GreaterEqualNoScaling(
-            convertToExtendedCkerShape(lhs), reinterpret_cast<const T *>(lhs->buffer()),
-            convertToExtendedCkerShape(rhs), reinterpret_cast<const T *>(rhs->buffer()),
-            convertToExtendedCkerShape(output), reinterpret_cast<bool *>(output->buffer()));
+            getExtendedTensorShape(lhs), reinterpret_cast<const T *>(lhs->buffer()),
+            getExtendedTensorShape(rhs), reinterpret_cast<const T *>(rhs->buffer()),
+            getExtendedTensorShape(output), reinterpret_cast<bool *>(output->buffer()));
         break;
       case OpType::Less:
-        LessNoScaling(convertToExtendedCkerShape(lhs), reinterpret_cast<const T *>(lhs->buffer()),
-                      convertToExtendedCkerShape(rhs), reinterpret_cast<const T *>(rhs->buffer()),
-                      convertToExtendedCkerShape(output),
-                      reinterpret_cast<bool *>(output->buffer()));
+        LessNoScaling(getExtendedTensorShape(lhs), reinterpret_cast<const T *>(lhs->buffer()),
+                      getExtendedTensorShape(rhs), reinterpret_cast<const T *>(rhs->buffer()),
+                      getExtendedTensorShape(output), reinterpret_cast<bool *>(output->buffer()));
         break;
       case OpType::LessEqual:
-        LessEqualNoScaling(
-            convertToExtendedCkerShape(lhs), reinterpret_cast<const T *>(lhs->buffer()),
-            convertToExtendedCkerShape(rhs), reinterpret_cast<const T *>(rhs->buffer()),
-            convertToExtendedCkerShape(output), reinterpret_cast<bool *>(output->buffer()));
+        LessEqualNoScaling(getExtendedTensorShape(lhs), reinterpret_cast<const T *>(lhs->buffer()),
+                           getExtendedTensorShape(rhs), reinterpret_cast<const T *>(rhs->buffer()),
+                           getExtendedTensorShape(output),
+                           reinterpret_cast<bool *>(output->buffer()));
         break;
       default:
         throw std::runtime_error{"Invalid OpType for CompareLayer"};

--- a/runtime/onert/backend/cpu/ops/ConcatLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ConcatLayer.cc
@@ -49,7 +49,7 @@ void ConcatLayer::concatenationFloat32()
 
   for (uint32_t i = 0; i < num_inputs; i++)
   {
-    inputDims.push_back(convertTensorToCkerShape(_inputs[i]));
+    inputDims.push_back(getTensorShape(_inputs[i]));
     inputDimsPtr.push_back(&inputDims[i]);
   }
 
@@ -61,7 +61,7 @@ void ConcatLayer::concatenationFloat32()
   }
 
   nnfw::cker::Concatenation<float>(op_params, inputDimsPtr.data(), inputFloatPtrs.data(),
-                                   convertTensorToCkerShape(_output),
+                                   getTensorShape(_output),
                                    reinterpret_cast<float *>(_output->buffer()));
 }
 void ConcatLayer::concatenationQuant8()
@@ -90,7 +90,7 @@ void ConcatLayer::concatenationQuant8()
   inputDims.reserve(num_inputs);
   for (uint32_t i = 0; i < num_inputs; i++)
   {
-    inputDims.push_back(convertTensorToCkerShape(_inputs[i]));
+    inputDims.push_back(getTensorShape(_inputs[i]));
     inputDimsPtr.push_back(&inputDims[i]);
   }
 
@@ -101,7 +101,7 @@ void ConcatLayer::concatenationQuant8()
   }
 
   nnfw::cker::ConcatenationWithScaling(op_params, inputDimsPtr.data(), inputDataPtrs.data(),
-                                       convertTensorToCkerShape(_output),
+                                       getTensorShape(_output),
                                        reinterpret_cast<uint8_t *>(_output->buffer()));
 }
 

--- a/runtime/onert/backend/cpu/ops/ConvolutionLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ConvolutionLayer.cc
@@ -57,9 +57,8 @@ void ConvolutionLayer::convFloat32()
   if (!_prepare)
   {
     bool is_replaced_weights = false;
-    kernel.prepare(convertTensorToCkerShape(_kernel),
-                   reinterpret_cast<const float *>(_kernel->buffer()), op_params.padding_type,
-                   is_replaced_weights);
+    kernel.prepare(getTensorShape(_kernel), reinterpret_cast<const float *>(_kernel->buffer()),
+                   op_params.padding_type, is_replaced_weights);
 
     if (is_replaced_weights)
     {
@@ -68,11 +67,10 @@ void ConvolutionLayer::convFloat32()
     }
     _prepare = true;
   }
-  kernel(op_params, convertTensorToCkerShape(_input),
-         reinterpret_cast<const float *>(_input->buffer()), convertTensorToCkerShape(_kernel),
-         reinterpret_cast<const float *>(_kernel->buffer()), convertTensorToCkerShape(_bias),
-         reinterpret_cast<const float *>(_bias->buffer()), convertTensorToCkerShape(_output),
-         reinterpret_cast<float *>(_output->buffer()));
+  kernel(op_params, getTensorShape(_input), reinterpret_cast<const float *>(_input->buffer()),
+         getTensorShape(_kernel), reinterpret_cast<const float *>(_kernel->buffer()),
+         getTensorShape(_bias), reinterpret_cast<const float *>(_bias->buffer()),
+         getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()));
 }
 
 void ConvolutionLayer::convQuant8()
@@ -107,15 +105,14 @@ void ConvolutionLayer::convQuant8()
   nnfw::cker::Conv &kernel = *_conv_kernel;
   if (!_prepare)
   {
-    kernel.prepareQuant(convertTensorToCkerShape(_input), convertTensorToCkerShape(_kernel),
-                        convertTensorToCkerShape(_output), _strideWidth, _strideHeight);
+    kernel.prepareQuant(getTensorShape(_input), getTensorShape(_kernel), getTensorShape(_output),
+                        _strideWidth, _strideHeight);
     _prepare = true;
   }
-  kernel(op_params, convertTensorToCkerShape(_input),
-         reinterpret_cast<const uint8_t *>(_input->buffer()), convertTensorToCkerShape(_kernel),
-         reinterpret_cast<const uint8_t *>(_kernel->buffer()), convertTensorToCkerShape(_bias),
-         reinterpret_cast<const int32_t *>(_bias->buffer()), convertTensorToCkerShape(_output),
-         reinterpret_cast<uint8_t *>(_output->buffer()));
+  kernel(op_params, getTensorShape(_input), reinterpret_cast<const uint8_t *>(_input->buffer()),
+         getTensorShape(_kernel), reinterpret_cast<const uint8_t *>(_kernel->buffer()),
+         getTensorShape(_bias), reinterpret_cast<const int32_t *>(_bias->buffer()),
+         getTensorShape(_output), reinterpret_cast<uint8_t *>(_output->buffer()));
 }
 
 void ConvolutionLayer::configure(const Tensor *input, const Tensor *kernel, const Tensor *bias,

--- a/runtime/onert/backend/cpu/ops/CosLayer.cc
+++ b/runtime/onert/backend/cpu/ops/CosLayer.cc
@@ -34,9 +34,8 @@ CosLayer::CosLayer() : _input(nullptr), _output(nullptr)
 
 void CosLayer::cosFloat32()
 {
-  nnfw::cker::Cos(convertTensorToCkerShape(_input),
-                  reinterpret_cast<const float *>(_input->buffer()),
-                  convertTensorToCkerShape(_output), reinterpret_cast<float *>(_output->buffer()));
+  nnfw::cker::Cos(getTensorShape(_input), reinterpret_cast<const float *>(_input->buffer()),
+                  getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()));
 }
 
 void CosLayer::cosQuant8() { throw std::runtime_error{"NYI"}; }

--- a/runtime/onert/backend/cpu/ops/DepthwiseConvolutionLayer.cc
+++ b/runtime/onert/backend/cpu/ops/DepthwiseConvolutionLayer.cc
@@ -52,11 +52,10 @@ void DepthwiseConvolutionLayer::convFloat32()
   op_params.float_activation_max = output_activation_max;
 
   nnfw::cker::DepthwiseConv(
-      op_params, convertTensorToCkerShape(_input),
-      reinterpret_cast<const float *>(_input->buffer()), convertTensorToCkerShape(_kernel),
-      reinterpret_cast<const float *>(_kernel->buffer()), convertTensorToCkerShape(_bias),
-      reinterpret_cast<const float *>(_bias->buffer()), convertTensorToCkerShape(_output),
-      reinterpret_cast<float *>(_output->buffer()));
+      op_params, getTensorShape(_input), reinterpret_cast<const float *>(_input->buffer()),
+      getTensorShape(_kernel), reinterpret_cast<const float *>(_kernel->buffer()),
+      getTensorShape(_bias), reinterpret_cast<const float *>(_bias->buffer()),
+      getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()));
 }
 
 void DepthwiseConvolutionLayer::convQuant8()
@@ -89,11 +88,10 @@ void DepthwiseConvolutionLayer::convQuant8()
   op_params.quantized_activation_max = output_activation_max;
 
   nnfw::cker::DepthwiseConv(
-      op_params, convertTensorToCkerShape(_input),
-      reinterpret_cast<const uint8_t *>(_input->buffer()), convertTensorToCkerShape(_kernel),
-      reinterpret_cast<const uint8_t *>(_kernel->buffer()), convertTensorToCkerShape(_bias),
-      reinterpret_cast<const int32_t *>(_bias->buffer()), convertTensorToCkerShape(_output),
-      reinterpret_cast<uint8_t *>(_output->buffer()));
+      op_params, getTensorShape(_input), reinterpret_cast<const uint8_t *>(_input->buffer()),
+      getTensorShape(_kernel), reinterpret_cast<const uint8_t *>(_kernel->buffer()),
+      getTensorShape(_bias), reinterpret_cast<const int32_t *>(_bias->buffer()),
+      getTensorShape(_output), reinterpret_cast<uint8_t *>(_output->buffer()));
 }
 
 void DepthwiseConvolutionLayer::configure(const Tensor *input, const Tensor *kernel,

--- a/runtime/onert/backend/cpu/ops/DivLayer.cc
+++ b/runtime/onert/backend/cpu/ops/DivLayer.cc
@@ -36,21 +36,21 @@ void DivLayer::divFloat32()
   op_params.float_activation_max = output_activation_max;
   op_params.float_activation_min = output_activation_min;
 
-  const bool need_broadcast = nnfw::cker::ProcessBroadcastShapes(
-      convertTensorToCkerShape(_lhs), convertTensorToCkerShape(_rhs), &op_params);
+  const bool need_broadcast =
+      nnfw::cker::ProcessBroadcastShapes(getTensorShape(_lhs), getTensorShape(_rhs), &op_params);
   if (need_broadcast)
   {
     nnfw::cker::BroadcastBinaryArithmeticOp(
-        op_params, convertTensorToCkerShape(_lhs), reinterpret_cast<const float *>(_lhs->buffer()),
-        convertTensorToCkerShape(_rhs), reinterpret_cast<const float *>(_rhs->buffer()),
-        convertTensorToCkerShape(_output), reinterpret_cast<float *>(_output->buffer()));
+        op_params, getTensorShape(_lhs), reinterpret_cast<const float *>(_lhs->buffer()),
+        getTensorShape(_rhs), reinterpret_cast<const float *>(_rhs->buffer()),
+        getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()));
     return;
   }
 
   nnfw::cker::BinaryArithmeticOp(
-      op_params, convertTensorToCkerShape(_lhs), reinterpret_cast<const float *>(_lhs->buffer()),
-      convertTensorToCkerShape(_rhs), reinterpret_cast<const float *>(_rhs->buffer()),
-      convertTensorToCkerShape(_output), reinterpret_cast<float *>(_output->buffer()));
+      op_params, getTensorShape(_lhs), reinterpret_cast<const float *>(_lhs->buffer()),
+      getTensorShape(_rhs), reinterpret_cast<const float *>(_rhs->buffer()),
+      getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()));
 }
 
 void DivLayer::divQuant8()

--- a/runtime/onert/backend/cpu/ops/ExpLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ExpLayer.cc
@@ -36,9 +36,8 @@ ExpLayer::ExpLayer() : _input(nullptr), _output(nullptr)
 
 void ExpLayer::expFloat32()
 {
-  nnfw::cker::Exp(convertTensorToCkerShape(_input),
-                  reinterpret_cast<const float *>(_input->buffer()),
-                  convertTensorToCkerShape(_output), reinterpret_cast<float *>(_output->buffer()));
+  nnfw::cker::Exp(getTensorShape(_input), reinterpret_cast<const float *>(_input->buffer()),
+                  getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()));
 }
 
 void ExpLayer::expQuant8()

--- a/runtime/onert/backend/cpu/ops/FillLayer.cc
+++ b/runtime/onert/backend/cpu/ops/FillLayer.cc
@@ -46,21 +46,21 @@ void FillLayer::run()
   switch (_output->data_type())
   {
     case OperandType::FLOAT32:
-      nnfw::cker::Fill<float *>(
-          convertTensorToCkerShape(_input), reinterpret_cast<int *>(_input->buffer()),
-          reinterpret_cast<float *>(_value->buffer()), convertTensorToCkerShape(_output),
-          reinterpret_cast<float *>(_output->buffer()));
+      nnfw::cker::Fill<float *>(getTensorShape(_input), reinterpret_cast<int *>(_input->buffer()),
+                                reinterpret_cast<float *>(_value->buffer()),
+                                getTensorShape(_output),
+                                reinterpret_cast<float *>(_output->buffer()));
       break;
     case OperandType::INT32:
-      nnfw::cker::Fill<int32_t *>(
-          convertTensorToCkerShape(_input), reinterpret_cast<int *>(_input->buffer()),
-          reinterpret_cast<int32_t *>(_value->buffer()), convertTensorToCkerShape(_output),
-          reinterpret_cast<int32_t *>(_output->buffer()));
+      nnfw::cker::Fill<int32_t *>(getTensorShape(_input), reinterpret_cast<int *>(_input->buffer()),
+                                  reinterpret_cast<int32_t *>(_value->buffer()),
+                                  getTensorShape(_output),
+                                  reinterpret_cast<int32_t *>(_output->buffer()));
       break;
     case OperandType::UINT32:
       nnfw::cker::Fill<uint32_t *>(
-          convertTensorToCkerShape(_input), reinterpret_cast<int *>(_input->buffer()),
-          reinterpret_cast<uint32_t *>(_value->buffer()), convertTensorToCkerShape(_output),
+          getTensorShape(_input), reinterpret_cast<int *>(_input->buffer()),
+          reinterpret_cast<uint32_t *>(_value->buffer()), getTensorShape(_output),
           reinterpret_cast<uint32_t *>(_output->buffer()));
       break;
     default:

--- a/runtime/onert/backend/cpu/ops/FullyConnectedLayer.cc
+++ b/runtime/onert/backend/cpu/ops/FullyConnectedLayer.cc
@@ -47,11 +47,10 @@ void FullyConnectedLayer::fullyConnectedFloat32()
   op_params.activation = convertActivationType(_activation);
 
   nnfw::cker::FullyConnected(
-      op_params, convertTensorToCkerShape(_input),
-      reinterpret_cast<const float *>(_input->buffer()), convertTensorToCkerShape(_weights),
-      reinterpret_cast<const float *>(_weights->buffer()), convertTensorToCkerShape(_bias),
-      reinterpret_cast<const float *>(_bias ? _bias->buffer() : nullptr),
-      convertTensorToCkerShape(_output), reinterpret_cast<float *>(_output->buffer()));
+      op_params, getTensorShape(_input), reinterpret_cast<const float *>(_input->buffer()),
+      getTensorShape(_weights), reinterpret_cast<const float *>(_weights->buffer()),
+      getTensorShape(_bias), reinterpret_cast<const float *>(_bias ? _bias->buffer() : nullptr),
+      getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()));
 }
 
 // executionMutex is used to protect concurrent access of non-threadsafe resources
@@ -78,11 +77,10 @@ void FullyConnectedLayer::fullyConnectedQuant8()
   op_params.quantized_activation_max = output_activation_max;
 
   nnfw::cker::FullyConnected(
-      op_params, convertTensorToCkerShape(_input),
-      reinterpret_cast<const uint8_t *>(_input->buffer()), convertTensorToCkerShape(_weights),
-      reinterpret_cast<const uint8_t *>(_weights->buffer()), convertTensorToCkerShape(_bias),
-      reinterpret_cast<const int32_t *>(_bias ? _bias->buffer() : nullptr),
-      convertTensorToCkerShape(_output), reinterpret_cast<uint8_t *>(_output->buffer()));
+      op_params, getTensorShape(_input), reinterpret_cast<const uint8_t *>(_input->buffer()),
+      getTensorShape(_weights), reinterpret_cast<const uint8_t *>(_weights->buffer()),
+      getTensorShape(_bias), reinterpret_cast<const int32_t *>(_bias ? _bias->buffer() : nullptr),
+      getTensorShape(_output), reinterpret_cast<uint8_t *>(_output->buffer()));
 }
 
 void FullyConnectedLayer::fullyConnectedHybrid()
@@ -90,7 +88,7 @@ void FullyConnectedLayer::fullyConnectedHybrid()
   nnfw::cker::FCTempArena &temp_arena = *_temp_arena;
   if (!temp_arena.prepared)
   {
-    temp_arena.prepare(convertTensorToCkerShape(_input), convertTensorToCkerShape(_weights));
+    temp_arena.prepare(getTensorShape(_input), getTensorShape(_weights));
   }
 
   nnfw::cker::FullyConnectedParams op_params;
@@ -98,11 +96,10 @@ void FullyConnectedLayer::fullyConnectedHybrid()
   op_params.weights_scale = _weights->data_scale();
 
   nnfw::cker::FullyConnectedHybrid(
-      op_params, convertTensorToCkerShape(_input),
-      reinterpret_cast<const float *>(_input->buffer()), convertTensorToCkerShape(_weights),
-      reinterpret_cast<const int8_t *>(_weights->buffer()), convertTensorToCkerShape(_bias),
-      reinterpret_cast<const float *>(_bias ? _bias->buffer() : nullptr),
-      convertTensorToCkerShape(_output), reinterpret_cast<float *>(_output->buffer()), temp_arena);
+      op_params, getTensorShape(_input), reinterpret_cast<const float *>(_input->buffer()),
+      getTensorShape(_weights), reinterpret_cast<const int8_t *>(_weights->buffer()),
+      getTensorShape(_bias), reinterpret_cast<const float *>(_bias ? _bias->buffer() : nullptr),
+      getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()), temp_arena);
 }
 
 void FullyConnectedLayer::configure(const Tensor *input, const Tensor *weights, const Tensor *bias,

--- a/runtime/onert/backend/cpu/ops/GatherLayer.cc
+++ b/runtime/onert/backend/cpu/ops/GatherLayer.cc
@@ -47,24 +47,21 @@ void GatherLayer::run()
   {
     case OperandType::FLOAT32:
       nnfw::cker::Gather<float>(
-          op_params, convertTensorToCkerShape(_input),
-          reinterpret_cast<const float *>(_input->buffer()), convertTensorToCkerShape(_indices),
-          reinterpret_cast<const int32_t *>(_indices->buffer()), convertTensorToCkerShape(_output),
-          reinterpret_cast<float *>(_output->buffer()));
+          op_params, getTensorShape(_input), reinterpret_cast<const float *>(_input->buffer()),
+          getTensorShape(_indices), reinterpret_cast<const int32_t *>(_indices->buffer()),
+          getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()));
       break;
     case OperandType::QUANT_UINT8_ASYMM:
       nnfw::cker::Gather<uint8_t>(
-          op_params, convertTensorToCkerShape(_input),
-          reinterpret_cast<const uint8_t *>(_input->buffer()), convertTensorToCkerShape(_indices),
-          reinterpret_cast<const int32_t *>(_indices->buffer()), convertTensorToCkerShape(_output),
-          reinterpret_cast<uint8_t *>(_output->buffer()));
+          op_params, getTensorShape(_input), reinterpret_cast<const uint8_t *>(_input->buffer()),
+          getTensorShape(_indices), reinterpret_cast<const int32_t *>(_indices->buffer()),
+          getTensorShape(_output), reinterpret_cast<uint8_t *>(_output->buffer()));
       break;
     case OperandType::INT32:
       nnfw::cker::Gather<int32_t>(
-          op_params, convertTensorToCkerShape(_input),
-          reinterpret_cast<const int32_t *>(_input->buffer()), convertTensorToCkerShape(_indices),
-          reinterpret_cast<const int32_t *>(_indices->buffer()), convertTensorToCkerShape(_output),
-          reinterpret_cast<int32_t *>(_output->buffer()));
+          op_params, getTensorShape(_input), reinterpret_cast<const int32_t *>(_input->buffer()),
+          getTensorShape(_indices), reinterpret_cast<const int32_t *>(_indices->buffer()),
+          getTensorShape(_output), reinterpret_cast<int32_t *>(_output->buffer()));
       break;
     default:
       throw std::runtime_error("Gather NYI for this operand type!");

--- a/runtime/onert/backend/cpu/ops/LogLayer.cc
+++ b/runtime/onert/backend/cpu/ops/LogLayer.cc
@@ -36,9 +36,8 @@ LogLayer::LogLayer() : _input(nullptr), _output(nullptr)
 
 void LogLayer::logFloat32()
 {
-  nnfw::cker::Log(convertTensorToCkerShape(_input),
-                  reinterpret_cast<const float *>(_input->buffer()),
-                  convertTensorToCkerShape(_output), reinterpret_cast<float *>(_output->buffer()));
+  nnfw::cker::Log(getTensorShape(_input), reinterpret_cast<const float *>(_input->buffer()),
+                  getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()));
 }
 
 void LogLayer::logQuant8() { throw std::runtime_error{"NYI"}; }

--- a/runtime/onert/backend/cpu/ops/LogicalNotLayer.cc
+++ b/runtime/onert/backend/cpu/ops/LogicalNotLayer.cc
@@ -36,9 +36,8 @@ LogicalNotLayer::LogicalNotLayer() : _input(nullptr), _output(nullptr)
 
 void LogicalNotLayer::logicalNotBool8()
 {
-  nnfw::cker::LogicalNot(
-      convertTensorToCkerShape(_input), reinterpret_cast<const bool *>(_input->buffer()),
-      convertTensorToCkerShape(_output), reinterpret_cast<bool *>(_output->buffer()));
+  nnfw::cker::LogicalNot(getTensorShape(_input), reinterpret_cast<const bool *>(_input->buffer()),
+                         getTensorShape(_output), reinterpret_cast<bool *>(_output->buffer()));
 }
 
 void LogicalNotLayer::configure(const Tensor *input, Tensor *output)

--- a/runtime/onert/backend/cpu/ops/LogicalOrLayer.cc
+++ b/runtime/onert/backend/cpu/ops/LogicalOrLayer.cc
@@ -30,10 +30,9 @@ namespace ops
 {
 void LogicalOrLayer::lorBool8()
 {
-  nnfw::cker::LogicalOr<bool>(
-      convertTensorToCkerShape(_lhs), reinterpret_cast<const bool *>(_lhs->buffer()),
-      convertTensorToCkerShape(_rhs), reinterpret_cast<const bool *>(_rhs->buffer()),
-      convertTensorToCkerShape(_output), reinterpret_cast<bool *>(_output->buffer()));
+  nnfw::cker::LogicalOr<bool>(getTensorShape(_lhs), reinterpret_cast<const bool *>(_lhs->buffer()),
+                              getTensorShape(_rhs), reinterpret_cast<const bool *>(_rhs->buffer()),
+                              getTensorShape(_output), reinterpret_cast<bool *>(_output->buffer()));
 }
 
 void LogicalOrLayer::configure(const Tensor *lhs, const Tensor *rhs, Tensor *output)

--- a/runtime/onert/backend/cpu/ops/LogisticLayer.cc
+++ b/runtime/onert/backend/cpu/ops/LogisticLayer.cc
@@ -36,9 +36,8 @@ LogisticLayer::LogisticLayer() : _input(nullptr), _output(nullptr)
 
 void LogisticLayer::logisticFloat32()
 {
-  nnfw::cker::Logistic(
-      convertTensorToCkerShape(_input), reinterpret_cast<const float *>(_input->buffer()),
-      convertTensorToCkerShape(_output), reinterpret_cast<float *>(_output->buffer()));
+  nnfw::cker::Logistic(getTensorShape(_input), reinterpret_cast<const float *>(_input->buffer()),
+                       getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()));
 }
 
 void LogisticLayer::logisticQuant8()

--- a/runtime/onert/backend/cpu/ops/MaxLayer.cc
+++ b/runtime/onert/backend/cpu/ops/MaxLayer.cc
@@ -31,19 +31,18 @@ namespace ops
 
 void MaxLayer::maxFloat32()
 {
-  nnfw::cker::Max<float>(
-      convertTensorToCkerShape(_lhs), reinterpret_cast<const float *>(_lhs->buffer()),
-      convertTensorToCkerShape(_rhs), reinterpret_cast<const float *>(_rhs->buffer()),
-      convertTensorToCkerShape(_output), reinterpret_cast<float *>(_output->buffer()));
+  nnfw::cker::Max<float>(getTensorShape(_lhs), reinterpret_cast<const float *>(_lhs->buffer()),
+                         getTensorShape(_rhs), reinterpret_cast<const float *>(_rhs->buffer()),
+                         getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()));
 }
 
 void MaxLayer::maxQuant8()
 {
   // TODO Check whether cker for quant8 max produces correct results
   // nnfw::cker::Max<uint8_t>(
-  //     convertTensorToCkerShape(_lhs), reinterpret_cast<const uint8_t*>(_lhs->buffer()),
-  //     convertTensorToCkerShape(_rhs), reinterpret_cast<const uint8_t*>(_rhs->buffer()),
-  //     convertTensorToCkerShape(_output), reinterpret_cast<uint8_t*>(_output->buffer()));
+  //     getTensorShape(_lhs), reinterpret_cast<const uint8_t*>(_lhs->buffer()),
+  //     getTensorShape(_rhs), reinterpret_cast<const uint8_t*>(_rhs->buffer()),
+  //     getTensorShape(_output), reinterpret_cast<uint8_t*>(_output->buffer()));
 
   throw std::runtime_error("Max NYI for quantized");
 }

--- a/runtime/onert/backend/cpu/ops/MaxPoolLayer.cc
+++ b/runtime/onert/backend/cpu/ops/MaxPoolLayer.cc
@@ -52,9 +52,8 @@ void MaxPoolLayer::maxPoolFloat32()
   op_params.float_activation_min = output_activation_min;
   op_params.float_activation_max = output_activation_max;
 
-  nnfw::cker::MaxPool(op_params, convertTensorToCkerShape(_input),
-                      reinterpret_cast<const float *>(_input->buffer()),
-                      convertTensorToCkerShape(_output),
+  nnfw::cker::MaxPool(op_params, getTensorShape(_input),
+                      reinterpret_cast<const float *>(_input->buffer()), getTensorShape(_output),
                       reinterpret_cast<float *>(_output->buffer()));
 }
 void MaxPoolLayer::maxPoolQuant8()
@@ -67,9 +66,8 @@ void MaxPoolLayer::maxPoolQuant8()
   op_params.quantized_activation_min = output_activation_min;
   op_params.quantized_activation_max = output_activation_max;
 
-  nnfw::cker::MaxPool(op_params, convertTensorToCkerShape(_input),
-                      reinterpret_cast<const uint8_t *>(_input->buffer()),
-                      convertTensorToCkerShape(_output),
+  nnfw::cker::MaxPool(op_params, getTensorShape(_input),
+                      reinterpret_cast<const uint8_t *>(_input->buffer()), getTensorShape(_output),
                       reinterpret_cast<uint8_t *>(_output->buffer()));
 }
 

--- a/runtime/onert/backend/cpu/ops/MeanLayer.cc
+++ b/runtime/onert/backend/cpu/ops/MeanLayer.cc
@@ -36,16 +36,15 @@ MeanLayer::MeanLayer() : _input(nullptr), _output(nullptr), _axes(), _keep_dims(
 
 void MeanLayer::MeanFloat32()
 {
-  nnfw::cker::Mean(
-      convertTensorToCkerShape(_input), reinterpret_cast<const float *>(_input->buffer()),
-      convertTensorToCkerShape(_output), reinterpret_cast<float *>(_output->buffer()), _axes);
+  nnfw::cker::Mean(getTensorShape(_input), reinterpret_cast<const float *>(_input->buffer()),
+                   getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()), _axes);
 }
 
 void MeanLayer::MeanQuant8()
 {
-  nnfw::cker::MeanQ8Asymm(convertTensorToCkerShape(_input),
+  nnfw::cker::MeanQ8Asymm(getTensorShape(_input),
                           reinterpret_cast<const uint8_t *>(_input->buffer()), _input->data_scale(),
-                          _input->data_offset(), convertTensorToCkerShape(_output),
+                          _input->data_offset(), getTensorShape(_output),
                           reinterpret_cast<uint8_t *>(_output->buffer()), _output->data_scale(),
                           _output->data_offset(), _axes);
 }

--- a/runtime/onert/backend/cpu/ops/MinLayer.cc
+++ b/runtime/onert/backend/cpu/ops/MinLayer.cc
@@ -31,19 +31,18 @@ namespace ops
 
 void MinLayer::minFloat32()
 {
-  nnfw::cker::Min<float>(
-      convertTensorToCkerShape(_lhs), reinterpret_cast<const float *>(_lhs->buffer()),
-      convertTensorToCkerShape(_rhs), reinterpret_cast<const float *>(_rhs->buffer()),
-      convertTensorToCkerShape(_output), reinterpret_cast<float *>(_output->buffer()));
+  nnfw::cker::Min<float>(getTensorShape(_lhs), reinterpret_cast<const float *>(_lhs->buffer()),
+                         getTensorShape(_rhs), reinterpret_cast<const float *>(_rhs->buffer()),
+                         getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()));
 }
 
 void MinLayer::minQuant8()
 {
   // TODO Check whether cker for quant8 min produces correct results
   // nnfw::cker::Min<uint8_t>(
-  //     convertTensorToCkerShape(_lhs), reinterpret_cast<const uint8_t*>(_lhs->buffer()),
-  //     convertTensorToCkerShape(_rhs), reinterpret_cast<const uint8_t*>(_rhs->buffer()),
-  //     convertTensorToCkerShape(_output), reinterpret_cast<uint8_t*>(_output->buffer()));
+  //     getTensorShape(_lhs), reinterpret_cast<const uint8_t*>(_lhs->buffer()),
+  //     getTensorShape(_rhs), reinterpret_cast<const uint8_t*>(_rhs->buffer()),
+  //     getTensorShape(_output), reinterpret_cast<uint8_t*>(_output->buffer()));
 
   throw std::runtime_error("Min NYI for quantized");
 }

--- a/runtime/onert/backend/cpu/ops/MulLayer.cc
+++ b/runtime/onert/backend/cpu/ops/MulLayer.cc
@@ -36,21 +36,21 @@ void MulLayer::mulFloat32()
   op_params.float_activation_max = output_activation_max;
   op_params.float_activation_min = output_activation_min;
 
-  const bool need_broadcast = nnfw::cker::ProcessBroadcastShapes(
-      convertTensorToCkerShape(_lhs), convertTensorToCkerShape(_rhs), &op_params);
+  const bool need_broadcast =
+      nnfw::cker::ProcessBroadcastShapes(getTensorShape(_lhs), getTensorShape(_rhs), &op_params);
   if (need_broadcast)
   {
     nnfw::cker::BroadcastBinaryArithmeticOp(
-        op_params, convertTensorToCkerShape(_lhs), reinterpret_cast<const float *>(_lhs->buffer()),
-        convertTensorToCkerShape(_rhs), reinterpret_cast<const float *>(_rhs->buffer()),
-        convertTensorToCkerShape(_output), reinterpret_cast<float *>(_output->buffer()));
+        op_params, getTensorShape(_lhs), reinterpret_cast<const float *>(_lhs->buffer()),
+        getTensorShape(_rhs), reinterpret_cast<const float *>(_rhs->buffer()),
+        getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()));
     return;
   }
 
   nnfw::cker::BinaryArithmeticOp(
-      op_params, convertTensorToCkerShape(_lhs), reinterpret_cast<const float *>(_lhs->buffer()),
-      convertTensorToCkerShape(_rhs), reinterpret_cast<const float *>(_rhs->buffer()),
-      convertTensorToCkerShape(_output), reinterpret_cast<float *>(_output->buffer()));
+      op_params, getTensorShape(_lhs), reinterpret_cast<const float *>(_lhs->buffer()),
+      getTensorShape(_rhs), reinterpret_cast<const float *>(_rhs->buffer()),
+      getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()));
 }
 
 void MulLayer::mulQuant8()

--- a/runtime/onert/backend/cpu/ops/NegLayer.cc
+++ b/runtime/onert/backend/cpu/ops/NegLayer.cc
@@ -36,9 +36,8 @@ NegLayer::NegLayer() : _input(nullptr), _output(nullptr)
 
 void NegLayer::negFloat32()
 {
-  nnfw::cker::Neg(convertTensorToCkerShape(_input),
-                  reinterpret_cast<const float *>(_input->buffer()),
-                  convertTensorToCkerShape(_output), reinterpret_cast<float *>(_output->buffer()));
+  nnfw::cker::Neg(getTensorShape(_input), reinterpret_cast<const float *>(_input->buffer()),
+                  getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()));
 }
 
 void NegLayer::negQuant8() { throw std::runtime_error{"NYI"}; }

--- a/runtime/onert/backend/cpu/ops/OneHotLayer.cc
+++ b/runtime/onert/backend/cpu/ops/OneHotLayer.cc
@@ -31,10 +31,10 @@ namespace ops
 
 void OneHotLayer::oneHotFloat32()
 {
-  nnfw::cker::OneHot<float, int32_t>(
-      _depth, _on_value, _off_value, _axis, convertTensorToCkerShape(_indices),
-      reinterpret_cast<const int32_t *>(_indices->buffer()), convertTensorToCkerShape(_output),
-      reinterpret_cast<float *>(_output->buffer()));
+  nnfw::cker::OneHot<float, int32_t>(_depth, _on_value, _off_value, _axis, getTensorShape(_indices),
+                                     reinterpret_cast<const int32_t *>(_indices->buffer()),
+                                     getTensorShape(_output),
+                                     reinterpret_cast<float *>(_output->buffer()));
 }
 
 void OneHotLayer::oneHotQuant8() { throw std::runtime_error{"OneHot NYI for quantized"}; }

--- a/runtime/onert/backend/cpu/ops/OperationUtils.h
+++ b/runtime/onert/backend/cpu/ops/OperationUtils.h
@@ -57,7 +57,7 @@ uint32_t getNumberOfElements(const Tensor *tensor);
 
 uint32_t getSizeOfDimension(const Tensor *tensor, uint32_t dimensionIdx);
 
-inline nnfw::cker::Shape convertToExtendedCkerShape(const Tensor *tensor)
+inline nnfw::cker::Shape getExtendedTensorShape(const Tensor *tensor)
 {
   assert(tensor);
   std::vector<int32_t> raw_shape;
@@ -79,7 +79,7 @@ inline nnfw::cker::Shape convertToExtendedCkerShape(const Tensor *tensor)
   return nnfw::cker::GetShape(raw_shape);
 }
 
-inline nnfw::cker::Shape convertTensorToCkerShape(const Tensor *tensor)
+inline nnfw::cker::Shape getTensorShape(const Tensor *tensor)
 {
   if (tensor == nullptr)
     return nnfw::cker::Shape();

--- a/runtime/onert/backend/cpu/ops/PackLayer.cc
+++ b/runtime/onert/backend/cpu/ops/PackLayer.cc
@@ -48,7 +48,7 @@ void PackLayer::packFloat32()
 
   for (uint32_t i = 0; i < num_inputs; i++)
   {
-    inputDims.push_back(convertTensorToCkerShape(_inputs[i]));
+    inputDims.push_back(getTensorShape(_inputs[i]));
     inputDimsPtr.push_back(&inputDims[i]);
   }
 
@@ -59,7 +59,7 @@ void PackLayer::packFloat32()
     inputFloatPtrs.emplace_back(reinterpret_cast<const float *>(input->buffer()));
   }
 
-  nnfw::cker::Pack<float>(op_params, inputFloatPtrs.data(), convertTensorToCkerShape(_output),
+  nnfw::cker::Pack<float>(op_params, inputFloatPtrs.data(), getTensorShape(_output),
                           reinterpret_cast<float *>(_output->buffer()));
 }
 

--- a/runtime/onert/backend/cpu/ops/PadLayer.cc
+++ b/runtime/onert/backend/cpu/ops/PadLayer.cc
@@ -35,10 +35,9 @@ PadLayer::PadLayer()
 
 void PadLayer::padFloat32()
 {
-  nnfw::cker::Pad(_padData, _padRank, convertTensorToCkerShape(_input),
-                  reinterpret_cast<const float *>(_input->buffer()),
-                  convertTensorToCkerShape(_output), reinterpret_cast<float *>(_output->buffer()),
-                  _constantValueData.f);
+  nnfw::cker::Pad(_padData, _padRank, getTensorShape(_input),
+                  reinterpret_cast<const float *>(_input->buffer()), getTensorShape(_output),
+                  reinterpret_cast<float *>(_output->buffer()), _constantValueData.f);
 }
 void PadLayer::padQuant8() { throw std::runtime_error("Quantized Pad isn't supported NYI"); }
 

--- a/runtime/onert/backend/cpu/ops/PowLayer.cc
+++ b/runtime/onert/backend/cpu/ops/PowLayer.cc
@@ -40,16 +40,15 @@ void PowLayer::powFloat32()
   if (!HaveSameShapes(_lhs, _rhs))
   {
     nnfw::cker::BroadcastBinaryArithmeticOp(
-        op_params, convertTensorToCkerShape(_lhs), reinterpret_cast<const float *>(_lhs->buffer()),
-        convertTensorToCkerShape(_rhs), reinterpret_cast<const float *>(_rhs->buffer()),
-        convertTensorToCkerShape(_output), reinterpret_cast<float *>(_output->buffer()));
+        op_params, getTensorShape(_lhs), reinterpret_cast<const float *>(_lhs->buffer()),
+        getTensorShape(_rhs), reinterpret_cast<const float *>(_rhs->buffer()),
+        getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()));
     return;
   }
 
-  nnfw::cker::powImpl(
-      convertTensorToCkerShape(_lhs), reinterpret_cast<const float *>(_lhs->buffer()),
-      convertTensorToCkerShape(_rhs), reinterpret_cast<const float *>(_rhs->buffer()),
-      convertTensorToCkerShape(_output), reinterpret_cast<float *>(_output->buffer()));
+  nnfw::cker::powImpl(getTensorShape(_lhs), reinterpret_cast<const float *>(_lhs->buffer()),
+                      getTensorShape(_rhs), reinterpret_cast<const float *>(_rhs->buffer()),
+                      getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()));
 }
 
 void PowLayer::configure(const Tensor *lhs, const Tensor *rhs, ir::Activation activation,

--- a/runtime/onert/backend/cpu/ops/ReLULayer.cc
+++ b/runtime/onert/backend/cpu/ops/ReLULayer.cc
@@ -36,9 +36,8 @@ ReLULayer::ReLULayer() : _input(nullptr), _output(nullptr)
 
 void ReLULayer::reluFloat32()
 {
-  nnfw::cker::ReLU(convertTensorToCkerShape(_input),
-                   reinterpret_cast<const float *>(_input->buffer()),
-                   convertTensorToCkerShape(_output), reinterpret_cast<float *>(_output->buffer()));
+  nnfw::cker::ReLU(getTensorShape(_input), reinterpret_cast<const float *>(_input->buffer()),
+                   getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()));
 }
 
 void ReLULayer::reluQuant8()

--- a/runtime/onert/backend/cpu/ops/ReduceLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ReduceLayer.cc
@@ -39,9 +39,8 @@ void evalLogic(const Tensor *input, Tensor *output, const std::vector<int> &axes
 {
   reduce_kernel.prepare(input->num_dimensions(), axes.size());
   bool result = reduce_kernel.ReduceGeneric<T>(
-      convertTensorToCkerShape(input), reinterpret_cast<const T *>(input->buffer()),
-      convertTensorToCkerShape(output), reinterpret_cast<T *>(output->buffer()), axes, keep_dims,
-      init_value, reducer);
+      getTensorShape(input), reinterpret_cast<const T *>(input->buffer()), getTensorShape(output),
+      reinterpret_cast<T *>(output->buffer()), axes, keep_dims, init_value, reducer);
 
   if (!result)
   {

--- a/runtime/onert/backend/cpu/ops/ReverseLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ReverseLayer.cc
@@ -46,8 +46,8 @@ void ReverseLayer::run()
   {
     case OperandType::FLOAT32:
       nnfw::cker::Reverse<float>(
-          axis, convertTensorToCkerShape(_input), reinterpret_cast<const float *>(_input->buffer()),
-          convertTensorToCkerShape(_output), reinterpret_cast<float *>(_output->buffer()));
+          axis, getTensorShape(_input), reinterpret_cast<const float *>(_input->buffer()),
+          getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()));
       break;
     default:
       throw std::runtime_error{"Reverse: unsupported data type"};

--- a/runtime/onert/backend/cpu/ops/RoundLayer.cc
+++ b/runtime/onert/backend/cpu/ops/RoundLayer.cc
@@ -35,9 +35,8 @@ RoundLayer::RoundLayer() : _input(nullptr), _output(nullptr)
 
 void RoundLayer::roundFloat32()
 {
-  nnfw::cker::Round(
-      convertTensorToCkerShape(_input), reinterpret_cast<const float *>(_input->buffer()),
-      convertTensorToCkerShape(_output), reinterpret_cast<float *>(_output->buffer()));
+  nnfw::cker::Round(getTensorShape(_input), reinterpret_cast<const float *>(_input->buffer()),
+                    getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()));
 }
 
 void RoundLayer::configure(const Tensor *input, Tensor *output)

--- a/runtime/onert/backend/cpu/ops/RsqrtLayer.cc
+++ b/runtime/onert/backend/cpu/ops/RsqrtLayer.cc
@@ -35,9 +35,8 @@ RsqrtLayer::RsqrtLayer() : _input(nullptr), _output(nullptr)
 
 void RsqrtLayer::rsqrtFloat32()
 {
-  nnfw::cker::Rsqrt(
-      convertTensorToCkerShape(_input), reinterpret_cast<const float *>(_input->buffer()),
-      convertTensorToCkerShape(_output), reinterpret_cast<float *>(_output->buffer()));
+  nnfw::cker::Rsqrt(getTensorShape(_input), reinterpret_cast<const float *>(_input->buffer()),
+                    getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()));
 }
 
 void RsqrtLayer::rsqrtQuant8() { throw std::runtime_error{"NYI : QASYMM8 not supported"}; }

--- a/runtime/onert/backend/cpu/ops/SelectLayer.cc
+++ b/runtime/onert/backend/cpu/ops/SelectLayer.cc
@@ -47,12 +47,11 @@ void SelectLayer::configure(const Tensor *cond, const Tensor *input_true, const 
 void SelectLayer::run()
 {
 
-#define KERNEL_SELECT(type, op)                                                                 \
-  nnfw::cker::op(                                                                               \
-      convertTensorToCkerShape(_cond), reinterpret_cast<uint8_t *>(_cond->buffer()),            \
-      convertTensorToCkerShape(_input_true), reinterpret_cast<type *>(_input_true->buffer()),   \
-      convertTensorToCkerShape(_input_false), reinterpret_cast<type *>(_input_false->buffer()), \
-      convertTensorToCkerShape(_output), reinterpret_cast<type *>(_output->buffer()));
+#define KERNEL_SELECT(type, op)                                                                  \
+  nnfw::cker::op(getTensorShape(_cond), reinterpret_cast<uint8_t *>(_cond->buffer()),            \
+                 getTensorShape(_input_true), reinterpret_cast<type *>(_input_true->buffer()),   \
+                 getTensorShape(_input_false), reinterpret_cast<type *>(_input_false->buffer()), \
+                 getTensorShape(_output), reinterpret_cast<type *>(_output->buffer()));
 
 #define KERNEL_SWITCH(type, op)                                                   \
   switch (type)                                                                   \

--- a/runtime/onert/backend/cpu/ops/SinLayer.cc
+++ b/runtime/onert/backend/cpu/ops/SinLayer.cc
@@ -34,9 +34,8 @@ SinLayer::SinLayer() : _input(nullptr), _output(nullptr)
 
 void SinLayer::sinFloat32()
 {
-  nnfw::cker::Sin(convertTensorToCkerShape(_input),
-                  reinterpret_cast<const float *>(_input->buffer()),
-                  convertTensorToCkerShape(_output), reinterpret_cast<float *>(_output->buffer()));
+  nnfw::cker::Sin(getTensorShape(_input), reinterpret_cast<const float *>(_input->buffer()),
+                  getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()));
 }
 
 void SinLayer::sinQuant8() { throw std::runtime_error{"NYI"}; }

--- a/runtime/onert/backend/cpu/ops/SliceLayer.cc
+++ b/runtime/onert/backend/cpu/ops/SliceLayer.cc
@@ -72,7 +72,7 @@ void SliceLayer::sliceFloat32()
     op_params.size[i] = sizes[3 - i];
   }
 
-  nnfw::cker::Slice(op_params, convertToExtendedCkerShape(_input),
+  nnfw::cker::Slice(op_params, getExtendedTensorShape(_input),
                     reinterpret_cast<const float *>(_input->buffer()),
                     reinterpret_cast<float *>(_output->buffer()));
 }

--- a/runtime/onert/backend/cpu/ops/SoftMaxLayer.cc
+++ b/runtime/onert/backend/cpu/ops/SoftMaxLayer.cc
@@ -88,9 +88,8 @@ void SoftMaxLayer::softmaxFloat32()
   {
     nnfw::cker::SoftmaxParams op_params;
     op_params.beta = _beta;
-    nnfw::cker::Softmax(op_params, convertTensorToCkerShape(_input),
-                        reinterpret_cast<const float *>(_input->buffer()),
-                        convertTensorToCkerShape(_output),
+    nnfw::cker::Softmax(op_params, getTensorShape(_input),
+                        reinterpret_cast<const float *>(_input->buffer()), getTensorShape(_output),
                         reinterpret_cast<float *>(_output->buffer()));
   }
   else

--- a/runtime/onert/backend/cpu/ops/SplitLayer.cc
+++ b/runtime/onert/backend/cpu/ops/SplitLayer.cc
@@ -47,7 +47,7 @@ void SplitLayer::splitFloat32()
 
   for (uint32_t i = 0; i < _num_splits; i++)
   {
-    outputDims.push_back(convertTensorToCkerShape(_outputs[i]));
+    outputDims.push_back(getTensorShape(_outputs[i]));
     outputDimsPtr.push_back(&outputDims[i]);
   }
 
@@ -58,9 +58,9 @@ void SplitLayer::splitFloat32()
     outputFloatPtrs.emplace_back(reinterpret_cast<float *>(output->buffer()));
   }
 
-  nnfw::cker::Split<float>(op_params, convertTensorToCkerShape(_input),
-                           reinterpret_cast<float *>(_input->buffer()),
-                           convertTensorToCkerShape(_outputs[0]), outputFloatPtrs.data());
+  nnfw::cker::Split<float>(op_params, getTensorShape(_input),
+                           reinterpret_cast<float *>(_input->buffer()), getTensorShape(_outputs[0]),
+                           outputFloatPtrs.data());
 }
 
 void SplitLayer::splitQuant8() { throw std::runtime_error{"Split: NYI quant8 type"}; }

--- a/runtime/onert/backend/cpu/ops/SquaredDiffLayer.cc
+++ b/runtime/onert/backend/cpu/ops/SquaredDiffLayer.cc
@@ -36,10 +36,9 @@ SqDiffLayer::SqDiffLayer() : _input1(nullptr), _input2(nullptr), _output(nullptr
 
 void SqDiffLayer::SqDiffFloat32()
 {
-  nnfw::cker::SqDiff(
-      convertTensorToCkerShape(_input1), reinterpret_cast<const float *>(_input1->buffer()),
-      convertTensorToCkerShape(_input2), reinterpret_cast<const float *>(_input2->buffer()),
-      convertTensorToCkerShape(_output), reinterpret_cast<float *>(_output->buffer()));
+  nnfw::cker::SqDiff(getTensorShape(_input1), reinterpret_cast<const float *>(_input1->buffer()),
+                     getTensorShape(_input2), reinterpret_cast<const float *>(_input2->buffer()),
+                     getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()));
 }
 
 void SqDiffLayer::configure(const Tensor *input1, const Tensor *input2, Tensor *output)

--- a/runtime/onert/backend/cpu/ops/StridedSliceLayer.cc
+++ b/runtime/onert/backend/cpu/ops/StridedSliceLayer.cc
@@ -43,13 +43,11 @@ void StridedSliceLayer::stridedSliceFloat32()
       reinterpret_cast<uint32_t *>(_strides->buffer()), _begin_mask, _end_mask, _shrink_axis_mask,
       _rank);
 
-  nnfw::cker::checkOutputSize(op_params, convertTensorToCkerShape(_input),
-                              convertTensorToCkerShape(_output), _rank);
+  nnfw::cker::checkOutputSize(op_params, getTensorShape(_input), getTensorShape(_output), _rank);
 
-  nnfw::cker::StridedSlice(op_params, convertTensorToCkerShape(_input),
+  nnfw::cker::StridedSlice(op_params, getTensorShape(_input),
                            reinterpret_cast<const float *>(_input->buffer()),
-                           convertTensorToCkerShape(_output),
-                           reinterpret_cast<float *>(_output->buffer()));
+                           getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()));
 }
 
 void StridedSliceLayer::stridedSliceQuant8()

--- a/runtime/onert/backend/cpu/ops/SubLayer.cc
+++ b/runtime/onert/backend/cpu/ops/SubLayer.cc
@@ -36,21 +36,21 @@ void SubLayer::subFloat32()
   op_params.float_activation_max = output_activation_max;
   op_params.float_activation_min = output_activation_min;
 
-  const bool need_broadcast = nnfw::cker::ProcessBroadcastShapes(
-      convertTensorToCkerShape(_lhs), convertTensorToCkerShape(_rhs), &op_params);
+  const bool need_broadcast =
+      nnfw::cker::ProcessBroadcastShapes(getTensorShape(_lhs), getTensorShape(_rhs), &op_params);
   if (need_broadcast)
   {
     nnfw::cker::BroadcastBinaryArithmeticOp(
-        op_params, convertTensorToCkerShape(_lhs), reinterpret_cast<const float *>(_lhs->buffer()),
-        convertTensorToCkerShape(_rhs), reinterpret_cast<const float *>(_rhs->buffer()),
-        convertTensorToCkerShape(_output), reinterpret_cast<float *>(_output->buffer()));
+        op_params, getTensorShape(_lhs), reinterpret_cast<const float *>(_lhs->buffer()),
+        getTensorShape(_rhs), reinterpret_cast<const float *>(_rhs->buffer()),
+        getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()));
     return;
   }
 
   nnfw::cker::BinaryArithmeticOp(
-      op_params, convertTensorToCkerShape(_lhs), reinterpret_cast<const float *>(_lhs->buffer()),
-      convertTensorToCkerShape(_rhs), reinterpret_cast<const float *>(_rhs->buffer()),
-      convertTensorToCkerShape(_output), reinterpret_cast<float *>(_output->buffer()));
+      op_params, getTensorShape(_lhs), reinterpret_cast<const float *>(_lhs->buffer()),
+      getTensorShape(_rhs), reinterpret_cast<const float *>(_rhs->buffer()),
+      getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()));
 }
 
 void SubLayer::subQuant8()

--- a/runtime/onert/backend/cpu/ops/TanhLayer.cc
+++ b/runtime/onert/backend/cpu/ops/TanhLayer.cc
@@ -36,9 +36,8 @@ TanhLayer::TanhLayer() : _input(nullptr), _output(nullptr)
 
 void TanhLayer::tanhFloat32()
 {
-  nnfw::cker::Tanh(convertTensorToCkerShape(_input),
-                   reinterpret_cast<const float *>(_input->buffer()),
-                   convertTensorToCkerShape(_output), reinterpret_cast<float *>(_output->buffer()));
+  nnfw::cker::Tanh(getTensorShape(_input), reinterpret_cast<const float *>(_input->buffer()),
+                   getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()));
 }
 
 void TanhLayer::tanhQuant8()

--- a/runtime/onert/backend/cpu/ops/TileLayer.cc
+++ b/runtime/onert/backend/cpu/ops/TileLayer.cc
@@ -36,8 +36,7 @@ TileLayer::TileLayer() : _input(nullptr), _multipliers(nullptr), _output(nullptr
 
 void TileLayer::tileFloat32()
 {
-  TileOneDimension(convertTensorToCkerShape(_input),
-                   reinterpret_cast<const float *>(_input->buffer()),
+  TileOneDimension(getTensorShape(_input), reinterpret_cast<const float *>(_input->buffer()),
                    reinterpret_cast<const int *>(_multipliers->buffer()),
                    reinterpret_cast<float *>(_output->buffer()), 0);
 }

--- a/runtime/onert/backend/cpu/ops/TransposeLayer.cc
+++ b/runtime/onert/backend/cpu/ops/TransposeLayer.cc
@@ -43,9 +43,9 @@ void TransposeLayer::transposeFloat32()
     param.perm[i] = _perm[i];
   }
 
-  nnfw::cker::Transpose(
-      param, convertTensorToCkerShape(_input), reinterpret_cast<const float *>(_input->buffer()),
-      convertTensorToCkerShape(_output), reinterpret_cast<float *>(_output->buffer()));
+  nnfw::cker::Transpose(param, getTensorShape(_input),
+                        reinterpret_cast<const float *>(_input->buffer()), getTensorShape(_output),
+                        reinterpret_cast<float *>(_output->buffer()));
 }
 
 void TransposeLayer::transposeQuant8()

--- a/runtime/onert/backend/cpu/ops/UnpackLayer.cc
+++ b/runtime/onert/backend/cpu/ops/UnpackLayer.cc
@@ -47,7 +47,7 @@ void UnpackLayer::unpackFloat32()
 
   for (int32_t i = 0; i < _num_output; i++)
   {
-    outputDims.push_back(convertTensorToCkerShape(_outputs[i]));
+    outputDims.push_back(getTensorShape(_outputs[i]));
     outputDimsPtr.push_back(&outputDims[i]);
   }
 
@@ -58,9 +58,9 @@ void UnpackLayer::unpackFloat32()
     outputFloatPtrs.emplace_back(reinterpret_cast<float *>(output->buffer()));
   }
 
-  nnfw::cker::Unpack<float>(op_params, convertTensorToCkerShape(_input),
+  nnfw::cker::Unpack<float>(op_params, getTensorShape(_input),
                             reinterpret_cast<float *>(_input->buffer()),
-                            convertTensorToCkerShape(_outputs[0]), outputFloatPtrs.data());
+                            getTensorShape(_outputs[0]), outputFloatPtrs.data());
 }
 
 void UnpackLayer::unpackQuant8()

--- a/runtime/onert/backend/cpu/ops/ZerosLikeLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ZerosLikeLayer.cc
@@ -42,7 +42,7 @@ void ZerosLikeLayer::run()
   if (!HaveSameShapes(_input, _output))
     throw std::runtime_error{"ZerosLike: input and output shape don't match."};
 
-  auto element_size = convertTensorToCkerShape(_input).FlatSize();
+  auto element_size = getTensorShape(_input).FlatSize();
 
   switch (_input->data_type())
   {


### PR DESCRIPTION
Rename tensor shape getter
- convertTensorToCkerShape -> getTensorShape
- convertToExtendedCkerShape -> getExtendedTensorShape

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>