### PR TITLE
[onert] Introducing DynamicTensorManager::applyShape() method and related changes

### DIFF
--- a/runtime/onert/backend/cpu/DynamicTensorManager.h
+++ b/runtime/onert/backend/cpu/DynamicTensorManager.h
@@ -44,6 +44,9 @@ public:
 
   virtual ~DynamicTensorManager() = default;
 
+  void applyShape(const ir::OperandIndex &ind, const ir::Shape &new_shape) override;
+
+  // TODO Remove this method. This will be replaced with applyShape(..)
   /**
    * @brief Allocate memory for dynamic tensor.
    *        If allocated memory is already set to the tensor and
@@ -52,6 +55,8 @@ public:
    */
   void allocate(const ir::OperandIndex &ind, const ir::Shape &new_shape) override;
   void buildTensor(const ir::OperandIndex &ind, const ir::OperandInfo &tensor_info);
+
+  // TODO Deprecate this
   void changeShape(const ir::OperandIndex &, const ir::Shape &) override;
 
   void planDealloc(ir::OperationIndex op_ind, ir::OperandIndex operand_ind) override;

--- a/runtime/onert/backend/cpu/Tensor.h
+++ b/runtime/onert/backend/cpu/Tensor.h
@@ -54,6 +54,9 @@ public:
     _allocator = alloc;
   }
 
+  // This works just as setBuffer but it simply overwrite existing Allocator without nullptr check
+  void overwriteBuffer(const std::shared_ptr<cpu_common::Allocator> &alloc) { _allocator = alloc; }
+
 public:
   uint8_t *buffer() const override
   {

--- a/runtime/onert/core/include/backend/IDynamicTensorManager.h
+++ b/runtime/onert/core/include/backend/IDynamicTensorManager.h
@@ -39,6 +39,19 @@ struct IDynamicTensorManager : public ITensorManager
 
 public:
   /**
+   * @brief Set new shape and allocate memory for dynamic tensor.
+   *        If a tensor is dynamic tensor and previously allocated memory exists,
+   *        it will be deallocated.
+   *        If a tensor is static tensor (with previously allocated memory by StaticTensorManager),
+   *        tensor->buffer() will be overwrite to the dynamically allocated memory
+   * @param ind             operand index of a tensor
+   * @param new_shape       tensor's new shape. While allocating memory for this new_shape,
+   *                        tensor's shape is set to new_shape
+   */
+  virtual void applyShape(const ir::OperandIndex &ind, const ir::Shape &new_shape) = 0;
+
+  // TODO Remove This. This will be replaced with applyShape(..)
+  /**
    * @brief Allocate memory for dynamic tensor
    */
   virtual void allocate(const ir::OperandIndex &, const ir::Shape &) = 0;

--- a/runtime/onert/core/src/backend/controlflow/DynamicTensorManager.h
+++ b/runtime/onert/core/src/backend/controlflow/DynamicTensorManager.h
@@ -44,6 +44,11 @@ public:
 
   virtual ~DynamicTensorManager() = default;
 
+  void applyShape(const ir::OperandIndex & /*ind*/, const ir::Shape & /*new_shape*/) override
+  {
+    // TODO Write code later
+  }
+
   /**
    * @brief Allocate memory for dynamic tensor.
    *        If allocated memory is already set to the tensor and

--- a/runtime/onert/core/src/exec/Execution.cc
+++ b/runtime/onert/core/src/exec/Execution.cc
@@ -40,13 +40,9 @@ void Execution::changeInputShape(const ir::IOIndex &index, const ir::Shape &new_
 
   auto shape_sig = _io_desc.input_shape_signature.find(index);
   if (shape_sig != _io_desc.input_shape_signature.end())
-    throw std::runtime_error("Duplicate attempt to change input shape");
-
-  _io_desc.input_shape_signature[index] = new_shape;
-
-  // Modifying Tensor
-  const auto input_index = primary_subgraph().getInputs().at(index);
-  primary_executor()->changeInputShape(input_index, new_shape);
+    shape_sig->second = new_shape; // update with new_shape
+  else
+    _io_desc.input_shape_signature.emplace(std::make_pair(index, new_shape));
 }
 
 // TODO Remove default parameter

--- a/runtime/onert/core/src/exec/ExecutorBase.h
+++ b/runtime/onert/core/src/exec/ExecutorBase.h
@@ -131,6 +131,7 @@ private:
     return std::make_unique<CopySink<T>>(buffer, length, operand.shape());
   }
 
+  // TODO Deprecate this
   void changeInputShape(const ir::OperandIndex &index, const ir::Shape &new_shape) override;
 
 protected:
@@ -159,6 +160,9 @@ protected:
   std::unordered_map<std::shared_ptr<backend::ITensor>, DynAllocInfo> _output_to_dyn_alloc_info;
   backend::TensorManagerSet _tensor_mgrs;
   std::mutex _mutex;
+
+private:
+  void handleDynamicInputTensor(ir::IOIndex input_index, const IODescription &desc);
 };
 
 } // namespace exec


### PR DESCRIPTION
This adds a new method DynamicTensorManager::applyShape() and fix related changes.

For #1708

This method was a modification of `DynamicTensorManager::allocate()` and the name `allocate()` is not fit for current implementation.

Main change:

When setting shape for dynamic tensor, now the following happens at the same time (like a transaction).
   - `setShape(tensor, new_shape)`
   - `tensor->set_dynamic()`
   - ` allocTensorMem(true);`

_Note_: previously sometimes `setShape` is called with a method and then `allocating` is called later with another method. This hurt integrity of tensor state.
 
**Caution**: _ControlFlow_ also has `DynamicTensorManager`. I am not sure if `applyShape()` can be added without error. So I put empty `applyShape()`.

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>
