### PR TITLE
[oneapi_test] Implement realpath command

### DIFF
--- a/tests/scripts/oneapi_test/install_oneapi_test_nnpackages.sh
+++ b/tests/scripts/oneapi_test/install_oneapi_test_nnpackages.sh
@@ -65,11 +65,17 @@ download_tests()
             wget -nv $MODELFILE_URL
             if [ "${MODELFILE_NAME##*.}" == "zip" ]; then
                 unzip -o $MODELFILE_NAME
+                rm *.zip
             fi
             popd
         fi
 
     done
+}
+
+realpath()
+{
+  readlink -e -- "$@"
 }
 
 usage()


### PR DESCRIPTION
This commit implements realpath command using readlink and bug fix.

1. There are some machines that doesn't have realpath command. To cover this machine, we need to use old(?) command.

2. bug fix(`rm *.zip`) is for cleaning working place. 

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>