### PR TITLE
[onert] nnapi test generator will use current environment's python

### DIFF
--- a/tests/nnapi/nnapi_test_generator/android-10/cts_generator.py
+++ b/tests/nnapi/nnapi_test_generator/android-10/cts_generator.py
@@ -1,5 +1,6 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
+# Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
 # Copyright 2018, The Android Open Source Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Currently, nnapi tests are generated with system-wide python3.
It requires us to install numpy module in system-wide.

To support vritualenv or something, it changes to use `env`
instead of `/usr/bin/python3`.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>