### PR TITLE
[onert] Remove rank info from kernels of controlflow

### DIFF
--- a/runtime/onert/core/include/exec/IPermuteFunction.h
+++ b/runtime/onert/core/include/exec/IPermuteFunction.h
@@ -51,10 +51,8 @@ public:
   {
     assert(_src_tensors.size() > 0);
     assert(_src_tensors.size() == _dst_tensors.size());
-    assert(_src_tensors.size() == _ranks.size());
     auto src_it = _src_tensors.begin();
     auto dst_it = _dst_tensors.begin();
-    auto rank_it = _ranks.begin();
     while (src_it != _src_tensors.end())
     {
       const auto src_tensor = *src_it;
@@ -64,24 +62,25 @@ public:
         // TODO Change to permute in parallel
         assert(underlying_type(src_tensor->data_type()) ==
                underlying_type(dst_tensor->data_type()));
+        const auto rank = src_tensor->num_dimensions();
         switch (src_tensor->data_type())
         {
           case ir::DataType::FLOAT32:
-            permute<float>(src_tensor, dst_tensor, *rank_it);
+            permute<float>(src_tensor, dst_tensor, rank);
             break;
           case ir::DataType::INT32:
-            permute<int32_t>(src_tensor, dst_tensor, *rank_it);
+            permute<int32_t>(src_tensor, dst_tensor, rank);
             break;
           case ir::DataType::UINT32:
-            permute<uint32_t>(src_tensor, dst_tensor, *rank_it);
+            permute<uint32_t>(src_tensor, dst_tensor, rank);
             break;
           case ir::DataType::BOOL8:
           case ir::DataType::QUANT_UINT8_ASYMM:
           case ir::DataType::UINT8:
-            permute<uint8_t>(src_tensor, dst_tensor, *rank_it);
+            permute<uint8_t>(src_tensor, dst_tensor, rank);
             break;
           case ir::DataType::QUANT_INT8_SYMM:
-            permute<int8_t>(src_tensor, dst_tensor, *rank_it);
+            permute<int8_t>(src_tensor, dst_tensor, rank);
             break;
           default:
             throw std::runtime_error("IPermuteFunction: Not supported data type");
@@ -90,7 +89,6 @@ public:
       }
       src_it++;
       dst_it++;
-      rank_it++;
     }
   }
 

--- a/runtime/onert/core/src/backend/controlflow/KernelGenerator.cc
+++ b/runtime/onert/core/src/backend/controlflow/KernelGenerator.cc
@@ -88,12 +88,10 @@ void KernelGenerator::visit(const ir::operation::Permute &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(0)};
 
-  const auto &shape = _operand_ctx.at(output_index).shape();
   std::vector<std::shared_ptr<ITensor>> output_tensors{getTensor(output_index)};
   std::vector<std::shared_ptr<ITensor>> input_tensors{getTensor(input_index)};
-  std::vector<size_t> ranks{static_cast<size_t>(shape.rank())};
 
-  auto fn = std::make_unique<kernel::PermuteLayer>(input_tensors, output_tensors, ranks);
+  auto fn = std::make_unique<kernel::PermuteLayer>(input_tensors, output_tensors);
 
   _return_fn = std::move(fn);
 }

--- a/runtime/onert/core/src/backend/controlflow/kernel/IfLayer.cc
+++ b/runtime/onert/core/src/backend/controlflow/kernel/IfLayer.cc
@@ -59,19 +59,6 @@ void IfLayer::run()
     return ret;
   };
 
-  std::vector<size_t> input_ranks;
-  for (size_t i = 0; i < _input_tensors.size(); ++i)
-  {
-    auto rank = _input_tensors.at(i)->num_dimensions();
-    input_ranks.emplace_back(rank);
-  }
-  std::vector<size_t> output_ranks;
-  for (size_t i = 0; i < _output_tensors.size(); ++i)
-  {
-    auto rank = _output_tensors.at(i)->num_dimensions();
-    output_ranks.emplace_back(rank);
-  }
-
   if (getResultCond(_cond_tensor.get()))
   {
     auto then_exec = dynamic_cast<exec::ExecutorBase *>(_executor_map->at(_then_subg_index).get());
@@ -83,9 +70,9 @@ void IfLayer::run()
     const auto &then_input_tensors = then_exec->getInputTensors();
     const auto &then_output_tensors = then_exec->getOutputTensors();
     const auto permute_op_input_to_then_input =
-        std::make_shared<PermuteLayer>(_input_tensors, then_input_tensors, input_ranks);
+        std::make_shared<PermuteLayer>(_input_tensors, then_input_tensors);
     const auto permute_then_output_to_op_output =
-        std::make_shared<PermuteLayer>(then_output_tensors, _output_tensors, output_ranks);
+        std::make_shared<PermuteLayer>(then_output_tensors, _output_tensors);
 
     // Remove copying of unused tensor
     permute_op_input_to_then_input->prepare();
@@ -106,9 +93,9 @@ void IfLayer::run()
     const auto &else_input_tensors = else_exec->getInputTensors();
     const auto &else_output_tensors = else_exec->getOutputTensors();
     const auto permute_op_input_to_else_input =
-        std::make_shared<PermuteLayer>(_input_tensors, else_input_tensors, input_ranks);
+        std::make_shared<PermuteLayer>(_input_tensors, else_input_tensors);
     const auto permute_else_output_to_op_output =
-        std::make_shared<PermuteLayer>(else_output_tensors, _output_tensors, output_ranks);
+        std::make_shared<PermuteLayer>(else_output_tensors, _output_tensors);
 
     // Remove copying of unused tensor
     permute_op_input_to_else_input->prepare();

--- a/runtime/onert/core/src/backend/controlflow/kernel/PermuteLayer.h
+++ b/runtime/onert/core/src/backend/controlflow/kernel/PermuteLayer.h
@@ -32,14 +32,11 @@ class PermuteLayer : public onert::exec::IPermuteFunction
 {
 public:
   PermuteLayer(const std::vector<std::shared_ptr<onert::backend::ITensor>> &src_tensors,
-               const std::vector<std::shared_ptr<onert::backend::ITensor>> &dst_tensors,
-               std::vector<size_t> ranks)
+               const std::vector<std::shared_ptr<onert::backend::ITensor>> &dst_tensors)
   {
     assert(src_tensors.size() == dst_tensors.size());
-    assert(src_tensors.size() == ranks.size());
     _src_tensors = src_tensors;
     _dst_tensors = dst_tensors;
-    _ranks = ranks;
   }
 
   void optimize() override
@@ -47,20 +44,17 @@ public:
     // Remove copying of tensor as nullptr
     auto src_it = _src_tensors.begin();
     auto dst_it = _dst_tensors.begin();
-    auto rank_it = _ranks.begin();
     while (src_it != _src_tensors.end())
     {
       if ((*src_it == *dst_it) || (*src_it == nullptr || *dst_it == nullptr))
       {
         src_it = _src_tensors.erase(src_it);
         dst_it = _dst_tensors.erase(dst_it);
-        rank_it = _ranks.erase(rank_it);
       }
       else
       {
         ++src_it;
         ++dst_it;
-        ++rank_it;
       }
     }
   }

--- a/runtime/onert/core/src/backend/controlflow/kernel/WhileLayer.cc
+++ b/runtime/onert/core/src/backend/controlflow/kernel/WhileLayer.cc
@@ -38,13 +38,6 @@ WhileLayer::WhileLayer(std::vector<std::shared_ptr<backend::ITensor>> input_tens
       _input_tensors{input_tensors}, _output_tensors{output_tensors}, _executor_map{executor_map}
 {
   // At this point, executor_map may not have executors of cond subg and body subg
-  for (size_t i = 0; i < input_tensors.size(); ++i)
-  {
-    auto rank = input_tensors.at(i)->num_dimensions();
-    // TODO Remove this when applying dynamic tensor
-    assert(rank == output_tensors.at(i)->num_dimensions());
-    _ranks.emplace_back(rank);
-  }
 }
 
 void WhileLayer::run()
@@ -70,13 +63,13 @@ void WhileLayer::run()
   const auto &body_output_tensors = body_exec->getOutputTensors();
 
   const auto permute_op_input_to_cond_input =
-      std::make_shared<PermuteLayer>(_input_tensors, cond_input_tensors, _ranks);
+      std::make_shared<PermuteLayer>(_input_tensors, cond_input_tensors);
   const auto permute_cond_input_to_body_input =
-      std::make_shared<PermuteLayer>(cond_input_tensors, body_input_tensors, _ranks);
+      std::make_shared<PermuteLayer>(cond_input_tensors, body_input_tensors);
   const auto permute_body_output_to_cond_input =
-      std::make_shared<PermuteLayer>(body_output_tensors, cond_input_tensors, _ranks);
+      std::make_shared<PermuteLayer>(body_output_tensors, cond_input_tensors);
   const auto permute_cond_input_to_op_output =
-      std::make_shared<PermuteLayer>(cond_input_tensors, _output_tensors, _ranks);
+      std::make_shared<PermuteLayer>(cond_input_tensors, _output_tensors);
 
   // Remove copying of unused tensor
   permute_op_input_to_cond_input->prepare();

--- a/runtime/onert/core/src/backend/controlflow/kernel/WhileLayer.h
+++ b/runtime/onert/core/src/backend/controlflow/kernel/WhileLayer.h
@@ -56,7 +56,6 @@ private:
   const ir::SubgraphIndex _body_subg_index;
   const std::vector<std::shared_ptr<backend::ITensor>> _input_tensors;
   const std::vector<std::shared_ptr<backend::ITensor>> _output_tensors;
-  std::vector<size_t> _ranks;
   const std::shared_ptr<exec::ExecutorMap> &_executor_map;
 };
 


### PR DESCRIPTION
For issue #1255
Draft PR #1372

This commit removes rank information from kernels of controlflow.

Signed-off-by: ragmani <ragmani0216@gmail.com>