### PR TITLE
[tflchef] Revise reverse chef of some Ops

### DIFF
--- a/compiler/tflchef/tflite/src/Op/Add.cpp
+++ b/compiler/tflchef/tflite/src/Op/Add.cpp
@@ -17,6 +17,7 @@
 #include "Add.h"
 
 #include "Convert.h"
+#include "FillerHelper.h"
 
 namespace tflchef
 {
@@ -24,7 +25,13 @@ namespace tflchef
 void TFliteOpAdd::filler(const tflite::Operator *op, TFliteImport *import,
                          tflchef::ModelRecipe *model_recipe) const
 {
-  // Nothing to do with filler
+  // Add may have constant input
+
+  const std::vector<int32_t> &inputs = as_index_vector(op->inputs());
+  assert(inputs.size() == 2);
+
+  fill_tensor_to_import(inputs[0], import);
+  fill_tensor_to_import(inputs[1], import);
 }
 
 tflchef::Operation *TFliteOpAdd::build(const tflite::Operator *op, TFliteImport *import,

--- a/compiler/tflchef/tflite/src/Op/Sub.cpp
+++ b/compiler/tflchef/tflite/src/Op/Sub.cpp
@@ -17,6 +17,7 @@
 #include "Sub.h"
 
 #include "Convert.h"
+#include "FillerHelper.h"
 
 namespace tflchef
 {
@@ -24,7 +25,13 @@ namespace tflchef
 void TFliteOpSub::filler(const tflite::Operator *op, TFliteImport *import,
                          tflchef::ModelRecipe *model_recipe) const
 {
-  // Nothing to do with filler
+  // Sub may have constant input
+
+  const std::vector<int32_t> &inputs = as_index_vector(op->inputs());
+  assert(inputs.size() == 2);
+
+  fill_tensor_to_import(inputs[0], import);
+  fill_tensor_to_import(inputs[1], import);
 }
 
 tflchef::Operation *TFliteOpSub::build(const tflite::Operator *op, TFliteImport *import,


### PR DESCRIPTION
This will revise reverse chef of some Ops
- Add, Sub, Reshape may have constant input, thuse provide filler
- Reshape option can be null

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>