### PR TITLE
[nnfwapi] Test: Add TCs with invalid packages

### DIFF
--- a/tests/nnfw_api/src/NNPackages.cc
+++ b/tests/nnfw_api/src/NNPackages.cc
@@ -25,7 +25,12 @@
 
 // NOTE Must match `enum TestPackages`
 const char *TEST_PACKAGE_NAMES[] = {
-    "add", "input_reshaping_add", "dynamic_tensor_reshape", "unknown_dim_input_concat",
+    "add",
+    "input_reshaping_add",
+    "dynamic_tensor_reshape",
+    "unknown_dim_input_concat",
+    "add_no_manifest",
+    "add_invalid_manifest",
 };
 
 NNPackages &NNPackages::get()

--- a/tests/nnfw_api/src/NNPackages.h
+++ b/tests/nnfw_api/src/NNPackages.h
@@ -41,6 +41,8 @@ public:
     INPUT_RESHAPING_ADD,
     DYNAMIC_TENSOR_RESHAPE,
     UNKNOWN_DIM_INPUT_CONCAT,
+    ADD_NO_MANIFEST,      //< Contains "Add" model but no manifest file
+    ADD_INVALID_MANIFEST, //< Contains "Add" model but the manifest file is broken JSON
     COUNT
   };
 

--- a/tests/nnfw_api/src/ValidationTestSessionCreated.cc
+++ b/tests/nnfw_api/src/ValidationTestSessionCreated.cc
@@ -60,6 +60,24 @@ TEST_F(ValidationTestSessionCreated, neg_load_session_004)
             NNFW_STATUS_ERROR);
 }
 
+TEST_F(ValidationTestSessionCreated, neg_load_invalid_package_1)
+{
+  ASSERT_EQ(
+      nnfw_load_model_from_file(
+          _session, NNPackages::get().getModelAbsolutePath(NNPackages::ADD_NO_MANIFEST).c_str()),
+      NNFW_STATUS_ERROR);
+  ASSERT_EQ(nnfw_prepare(_session), NNFW_STATUS_ERROR);
+}
+
+TEST_F(ValidationTestSessionCreated, neg_load_invalid_package_2)
+{
+  ASSERT_EQ(nnfw_load_model_from_file(
+                _session,
+                NNPackages::get().getModelAbsolutePath(NNPackages::ADD_INVALID_MANIFEST).c_str()),
+            NNFW_STATUS_ERROR);
+  ASSERT_EQ(nnfw_prepare(_session), NNFW_STATUS_ERROR);
+}
+
 TEST_F(ValidationTestSessionCreated, neg_prepare_001)
 {
   // nnfw_load_model_from_file was not called

--- a/tests/scripts/oneapi_test/models/add_invalid_manifest/config.sh
+++ b/tests/scripts/oneapi_test/models/add_invalid_manifest/config.sh
@@ -1,0 +1,1 @@
+MODELFILE_NAME="add_invalid_manifest.zip"

--- a/tests/scripts/oneapi_test/models/add_no_manifest/config.sh
+++ b/tests/scripts/oneapi_test/models/add_no_manifest/config.sh
@@ -1,0 +1,1 @@
+MODELFILE_NAME="add_no_manifest.zip"


### PR DESCRIPTION
- `ADD_NO_MANIFEST` : Contains "Add" model but there is no manifest
  file(metadata)
- `ADD_INVALID_MANIFEST` : Contains "Add" model but the manifest file is
  a broken JSON

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>