### PR TITLE
[TensorFlowPythonExamples] Add max_pool_with_argmax operator

### DIFF
--- a/res/TensorFlowPythonExamples/examples/max_pool_with_argmax/__init__.py
+++ b/res/TensorFlowPythonExamples/examples/max_pool_with_argmax/__init__.py
@@ -1,0 +1,5 @@
+import tensorflow as tf
+
+in_ = tf.compat.v1.placeholder(dtype=tf.float32, shape=(1, 4, 4, 1), name="Hole")
+op_ = tf.compat.v1.nn.max_pool_with_argmax(
+    in_, ksize=[1, 2, 2, 1], strides=[1, 1, 1, 1], padding="VALID")


### PR DESCRIPTION
This commit adds max_pool_with_argmax operator to TensorFlowPythonExamples

Related : #1676
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>