### PR TITLE
[luci] Rename method of SplitVOutput and SplitOutput

### DIFF
--- a/compiler/luci/import/src/Nodes/CircleSplit.cpp
+++ b/compiler/luci/import/src/Nodes/CircleSplit.cpp
@@ -107,7 +107,7 @@ void CircleSplitGraphBuilder::build(const circle::OperatorT &op, GraphBuilderCon
     else
       nodeout->shape_status(ShapeStatus::VALID);
 
-    nodeout->input(node);
+    nodeout->split(node);
     nodeout->index(n);
 
     context->nodefinder()->enroll(outputs[n], nodeout);

--- a/compiler/luci/import/src/Nodes/CircleSplitV.cpp
+++ b/compiler/luci/import/src/Nodes/CircleSplitV.cpp
@@ -109,7 +109,7 @@ void CircleSplitVGraphBuilder::build(const circle::OperatorT &op,
     else
       nodeout->shape_status(ShapeStatus::VALID);
 
-    nodeout->input(node);
+    nodeout->splitV(node);
     nodeout->index(n);
 
     context->nodefinder()->enroll(outputs[n], nodeout);

--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleSplitOut.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleSplitOut.h
@@ -34,8 +34,8 @@ public:
   CircleSplitOut() = default;
 
 public:
-  loco::Node *input(void) const { return at(0)->node(); }
-  void input(loco::Node *node) { at(0)->node(node); }
+  loco::Node *split(void) const { return at(0)->node(); }
+  void split(loco::Node *node) { at(0)->node(node); }
 
 public:
   int32_t index(void) const { return _index; }

--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleSplitVOut.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleSplitVOut.h
@@ -35,8 +35,8 @@ public:
   CircleSplitVOut() = default;
 
 public:
-  loco::Node *input(void) const { return at(0)->node(); }
-  void input(loco::Node *node) { at(0)->node(node); }
+  loco::Node *splitV(void) const { return at(0)->node(); }
+  void splitV(loco::Node *node) { at(0)->node(node); }
 
 public:
   int32_t index(void) const { return _index; }

--- a/compiler/luci/lang/src/Nodes/CircleSplitOut.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleSplitOut.test.cpp
@@ -27,6 +27,6 @@ TEST(CircleSplitOutTest, constructor)
   ASSERT_EQ(luci::CircleDialect::get(), vout_node.dialect());
   ASSERT_EQ(luci::CircleOpcode::CIRCLESPLITOUT, vout_node.opcode());
 
-  ASSERT_EQ(nullptr, vout_node.input());
+  ASSERT_EQ(nullptr, vout_node.split());
   ASSERT_EQ(-1, vout_node.index());
 }

--- a/compiler/luci/lang/src/Nodes/CircleSplitVOut.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleSplitVOut.test.cpp
@@ -27,6 +27,6 @@ TEST(CircleSplitVOutTest, constructor)
   ASSERT_EQ(luci::CircleDialect::get(), vout_node.dialect());
   ASSERT_EQ(luci::CircleOpcode::CIRCLESPLITVOUT, vout_node.opcode());
 
-  ASSERT_EQ(nullptr, vout_node.input());
+  ASSERT_EQ(nullptr, vout_node.splitV());
   ASSERT_EQ(-1, vout_node.index());
 }

--- a/compiler/luci/logex/src/FormattedGraph.cpp
+++ b/compiler/luci/logex/src/FormattedGraph.cpp
@@ -1130,7 +1130,7 @@ bool CircleNodeSummaryBuilder::summary(const luci::CircleZerosLike *node,
 bool CircleNodeSummaryBuilder::summary(const luci::CircleSplitOut *node,
                                        locop::NodeSummary &s) const
 {
-  s.args().append("input", tbl()->lookup(node->input()));
+  s.args().append("input", tbl()->lookup(node->split()));
 
   s.state(locop::NodeSummary::State::Complete);
 
@@ -1140,7 +1140,7 @@ bool CircleNodeSummaryBuilder::summary(const luci::CircleSplitOut *node,
 bool CircleNodeSummaryBuilder::summary(const luci::CircleSplitVOut *node,
                                        locop::NodeSummary &s) const
 {
-  s.args().append("input", tbl()->lookup(node->input()));
+  s.args().append("input", tbl()->lookup(node->splitV()));
 
   s.state(locop::NodeSummary::State::Complete);
 

--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -1880,7 +1880,7 @@ public:
   {
     const loco::DataType S32 = loco::DataType::S32;
 
-    auto split = dynamic_cast<const luci::CircleSplit *>(node->input());
+    auto split = dynamic_cast<const luci::CircleSplit *>(node->split());
     if (split == nullptr)
       INTERNAL_EXN("CircleSplit IR is not configured correctly");
 
@@ -1914,7 +1914,7 @@ public:
   {
     const loco::DataType S32 = loco::DataType::S32;
 
-    auto split = dynamic_cast<const luci::CircleSplitV *>(node->input());
+    auto split = dynamic_cast<const luci::CircleSplitV *>(node->splitV());
     if (split == nullptr)
       INTERNAL_EXN("CircleSplit IR is not configured correctly");
 

--- a/compiler/luci/service/src/CircleTypeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleTypeInferenceRule.cpp
@@ -467,12 +467,12 @@ struct TypeInferenceAlgorithm final : public luci::CircleNodeVisitor<loco::DataT
 
   loco::DataType visit(const luci::CircleSplitOut *node) final
   {
-    return loco::dtype_get(node->input());
+    return loco::dtype_get(node->split());
   }
 
   loco::DataType visit(const luci::CircleSplitVOut *node) final
   {
-    return loco::dtype_get(node->input());
+    return loco::dtype_get(node->splitV());
   }
 
   loco::DataType visit(const luci::CircleTopKV2Out *node) final


### PR DESCRIPTION
This commit renames method of SplitVOutput and SplitOutput

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>