### PR TITLE
[luci] Rename method of CircleTopKV2Out and CircleUnPackOut

### DIFF
--- a/compiler/luci/import/src/Nodes/CircleTopKV2.cpp
+++ b/compiler/luci/import/src/Nodes/CircleTopKV2.cpp
@@ -105,7 +105,7 @@ void CircleTopKV2GraphBuilder::build(const circle::OperatorT &op,
     else
       nodeout->shape_status(ShapeStatus::VALID);
 
-    nodeout->topkv2(node);
+    nodeout->input(node);
     nodeout->index(n);
 
     context->nodefinder()->enroll(outputs[n], nodeout);

--- a/compiler/luci/import/src/Nodes/CircleUnpack.cpp
+++ b/compiler/luci/import/src/Nodes/CircleUnpack.cpp
@@ -118,7 +118,7 @@ void CircleUnpackGraphBuilder::build(const circle::OperatorT &op,
     else
       nodeout->shape_status(ShapeStatus::VALID);
 
-    nodeout->unpack(node);
+    nodeout->input(node);
     nodeout->index(n);
 
     context->nodefinder()->enroll(outputs[n], nodeout);

--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleTopKV2Out.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleTopKV2Out.h
@@ -35,8 +35,8 @@ public:
   CircleTopKV2Out() = default;
 
 public:
-  loco::Node *topkv2(void) const { return at(0)->node(); }
-  void topkv2(loco::Node *node) { at(0)->node(node); }
+  loco::Node *input(void) const { return at(0)->node(); }
+  void input(loco::Node *node) { at(0)->node(node); }
 
 public:
   int32_t index(void) const { return _index; }

--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleUnpackOut.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleUnpackOut.h
@@ -35,8 +35,8 @@ public:
   CircleUnpackOut() = default;
 
 public:
-  loco::Node *unpack(void) const { return at(0)->node(); }
-  void unpack(loco::Node *node) { at(0)->node(node); }
+  loco::Node *input(void) const { return at(0)->node(); }
+  void input(loco::Node *node) { at(0)->node(node); }
 
 public:
   int32_t index(void) const { return _index; }

--- a/compiler/luci/lang/src/Nodes/CircleTopKV2Out.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleTopKV2Out.test.cpp
@@ -27,6 +27,6 @@ TEST(CircleTopKV2OutTest, constructor)
   ASSERT_EQ(luci::CircleDialect::get(), topout_node.dialect());
   ASSERT_EQ(luci::CircleOpcode::CIRCLETOPKV2OUT, topout_node.opcode());
 
-  ASSERT_EQ(nullptr, topout_node.topkv2());
+  ASSERT_EQ(nullptr, topout_node.input());
   ASSERT_EQ(-1, topout_node.index());
 }

--- a/compiler/luci/lang/src/Nodes/CircleUnpackOut.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleUnpackOut.test.cpp
@@ -27,6 +27,6 @@ TEST(CircleUnpackOutTest, constructor)
   ASSERT_EQ(luci::CircleDialect::get(), unpackout_node.dialect());
   ASSERT_EQ(luci::CircleOpcode::CIRCLEUNPACKOUT, unpackout_node.opcode());
 
-  ASSERT_EQ(nullptr, unpackout_node.unpack());
+  ASSERT_EQ(nullptr, unpackout_node.input());
   ASSERT_EQ(0, unpackout_node.index());
 }

--- a/compiler/luci/logex/src/FormattedGraph.cpp
+++ b/compiler/luci/logex/src/FormattedGraph.cpp
@@ -1150,7 +1150,7 @@ bool CircleNodeSummaryBuilder::summary(const luci::CircleSplitVOut *node,
 bool CircleNodeSummaryBuilder::summary(const luci::CircleTopKV2Out *node,
                                        locop::NodeSummary &s) const
 {
-  s.args().append("topkv2", tbl()->lookup(node->topkv2()));
+  s.args().append("topkv2", tbl()->lookup(node->input()));
   s.state(locop::NodeSummary::State::Complete);
   return true;
 }
@@ -1158,7 +1158,7 @@ bool CircleNodeSummaryBuilder::summary(const luci::CircleTopKV2Out *node,
 bool CircleNodeSummaryBuilder::summary(const luci::CircleUnpackOut *node,
                                        locop::NodeSummary &s) const
 {
-  s.args().append("unpack", tbl()->lookup(node->unpack()));
+  s.args().append("unpack", tbl()->lookup(node->input()));
 
   s.state(locop::NodeSummary::State::Complete);
 

--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -1976,7 +1976,7 @@ public:
   {
     const loco::DataType S32 = loco::DataType::S32;
 
-    auto topkv2 = dynamic_cast<const luci::CircleTopKV2 *>(node->topkv2());
+    auto topkv2 = dynamic_cast<const luci::CircleTopKV2 *>(node->input());
     if (topkv2 == nullptr)
       INTERNAL_EXN("CircleSplit IR is not configured correctly");
 
@@ -2001,7 +2001,7 @@ public:
 
   loco::NodeShape visit(const luci::CircleUnpackOut *node) final
   {
-    auto unpack = dynamic_cast<const luci::CircleUnpack *>(node->unpack());
+    auto unpack = dynamic_cast<const luci::CircleUnpack *>(node->input());
     if (unpack == nullptr)
     {
       INTERNAL_EXN("CircleUnpack IR is not configured correctly");

--- a/compiler/luci/service/src/CircleTypeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleTypeInferenceRule.cpp
@@ -479,7 +479,7 @@ struct TypeInferenceAlgorithm final : public luci::CircleNodeVisitor<loco::DataT
   {
     // First output is same as input
     if (node->index() == 0)
-      return loco::dtype_get(node->topkv2());
+      return loco::dtype_get(node->input());
     // Second outout is always S32
     assert(node->index() == 1);
     return loco::DataType::S32;
@@ -487,7 +487,7 @@ struct TypeInferenceAlgorithm final : public luci::CircleNodeVisitor<loco::DataT
 
   loco::DataType visit(const luci::CircleUnpackOut *node) final
   {
-    return loco::dtype_get(node->unpack());
+    return loco::dtype_get(node->input());
   }
 
   loco::DataType visit(const luci::CircleWhileOut *node) final


### PR DESCRIPTION
This commit renames method of CircleTokKV2Out and CircleUnPackOut for
convention

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>