### PR TITLE
[res] TF example for BatchNorm, FusedBatchNorm

### DIFF
--- a/res/TensorFlowPythonExamples/examples/batch_normalization/__init__.py
+++ b/res/TensorFlowPythonExamples/examples/batch_normalization/__init__.py
@@ -1,0 +1,9 @@
+import tensorflow as tf
+
+mean = tf.compat.v1.constant([1., 2., 3.])
+variance = tf.compat.v1.constant([4., 5., 6.])
+offset = tf.compat.v1.constant([7., 8., 9.])
+scale = tf.compat.v1.constant([10., 11., 12.])
+
+in_ = tf.compat.v1.placeholder(dtype=tf.float32, shape=(3, 3), name="Hole")
+bn_ = tf.nn.batch_normalization(in_, mean, variance, offset, scale, 1e-5)

--- a/res/TensorFlowPythonExamples/examples/fused_batch_norm/__init__.py
+++ b/res/TensorFlowPythonExamples/examples/fused_batch_norm/__init__.py
@@ -1,0 +1,10 @@
+import tensorflow as tf
+
+scale = tf.compat.v1.constant([1., 2., 3.])
+offset = tf.compat.v1.constant([4., 5., 6.])
+mean = tf.constant([1., 2., 3.])
+variance = tf.constant([4., 5., 6.])
+
+in_ = tf.compat.v1.placeholder(dtype=tf.float32, shape=(3, 3, 3, 3), name="Hole")
+fbn_ = tf.compat.v1.nn.fused_batch_norm(
+    in_, scale, offset, mean, variance, is_training=False)


### PR DESCRIPTION
This will introduce TensorFlowPythonExamples for batch_normalization and fused_batch_norm

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>
ONE-DCO-1.0-Signed-off-by: Alexander Efimov a.efimov@samsung.com