### PR TITLE
Add tensor type argument for DynamicInputGenerator

### DIFF
--- a/tests/nnapi/nnapi_test_generator/android-10/dynamic_tensor.py
+++ b/tests/nnapi/nnapi_test_generator/android-10/dynamic_tensor.py
@@ -75,13 +75,13 @@ from test_generator import Internal
 
 class DynamicInputGenerator:
 
-    def __init__(self, model, model_input_shape_list):
+    def __init__(self, model, model_input_shape_list, tensor_type):
         self.new_shape = 0
         self.model_input = 0
         self.test_input = 0
 
         # any shape that can be reshaped into model_input_shape
-        self.model_input = Input("model_input", "TENSOR_FLOAT32",
+        self.model_input = Input("model_input", tensor_type,
                                  self.__getShapeInStr(model_input_shape_list))
 
         # add Reshape to make input of Abs dynamic
@@ -89,7 +89,7 @@ class DynamicInputGenerator:
         self.new_shape   = Input("new_shape", "TENSOR_INT32", new_shape_str)
 
         # shape not known since it is dynamic. Use a scalar {} just like TFL Converter.
-        self.test_input = Internal("internal1", "TENSOR_FLOAT32", "{}")
+        self.test_input = Internal("internal1", tensor_type, "{}")
         model.Operation("RESHAPE", self.model_input, self.new_shape).To(self.test_input)
 
     # convert, e.g., [1, 2, 3] to "{1, 2, 3}"

--- a/tests/nnapi/specs/Ex/cos_ex_dynamic_nnfw.mod.py
+++ b/tests/nnapi/specs/Ex/cos_ex_dynamic_nnfw.mod.py
@@ -41,7 +41,7 @@ model = Model()
 
 model_input_shape = [1, 2, 3]
 
-dynamic_layer = dynamic_tensor.DynamicInputGenerator(model, model_input_shape)
+dynamic_layer = dynamic_tensor.DynamicInputGenerator(model, model_input_shape, "TENSOR_FLOAT32")
 
 test_node_input = dynamic_layer.getTestNodeInput()
 

--- a/tests/nnapi/specs/Ex/round_ex_dynamic_nnfw.mod.py
+++ b/tests/nnapi/specs/Ex/round_ex_dynamic_nnfw.mod.py
@@ -41,7 +41,7 @@ model = Model()
 
 model_input_shape = [1, 2, 3]
 
-dynamic_layer = dynamic_tensor.DynamicInputGenerator(model, model_input_shape)
+dynamic_layer = dynamic_tensor.DynamicInputGenerator(model, model_input_shape, "TENSOR_FLOAT32")
 
 test_node_input = dynamic_layer.getTestNodeInput()
 

--- a/tests/nnapi/specs/V1_0/add_dynamic_nnfw.mod.py
+++ b/tests/nnapi/specs/V1_0/add_dynamic_nnfw.mod.py
@@ -28,7 +28,7 @@ model = Model()
 
 model_input1_shape = [3, 4]   # first input shape of Add. 12 float32s
 
-dynamic_layer = dynamic_tensor.DynamicInputGenerator(model, model_input1_shape)
+dynamic_layer = dynamic_tensor.DynamicInputGenerator(model, model_input1_shape, "TENSOR_FLOAT32")
 
 test_node_input = dynamic_layer.getTestNodeInput() # first input of Add is dynamic tensor
 

--- a/tests/nnapi/specs/V1_0/concat_dynamic_nnfw.mod.py
+++ b/tests/nnapi/specs/V1_0/concat_dynamic_nnfw.mod.py
@@ -21,7 +21,7 @@ import dynamic_tensor
 model = Model()
 
 input1_shape = [2, 3]
-dynamic_layer = dynamic_tensor.DynamicInputGenerator(model, input1_shape)
+dynamic_layer = dynamic_tensor.DynamicInputGenerator(model, input1_shape, "TENSOR_FLOAT32")
 
 input1 = dynamic_layer.getTestNodeInput()
 input2 = Input("op2", "TENSOR_FLOAT32", "{2, 3}")

--- a/tests/nnapi/specs/V1_0/logistic_dynamic_nnfw.mod.py
+++ b/tests/nnapi/specs/V1_0/logistic_dynamic_nnfw.mod.py
@@ -42,7 +42,7 @@ model = Model()
 
 model_input_shape = [1, 2, 3]
 
-dynamic_layer = dynamic_tensor.DynamicInputGenerator(model, model_input_shape)
+dynamic_layer = dynamic_tensor.DynamicInputGenerator(model, model_input_shape, "TENSOR_FLOAT32")
 
 test_node_input = dynamic_layer.getTestNodeInput()
 

--- a/tests/nnapi/specs/V1_0/softmax_dynamic_nnfw.mod.py
+++ b/tests/nnapi/specs/V1_0/softmax_dynamic_nnfw.mod.py
@@ -44,7 +44,7 @@ model_input_shape = [2, 5]
 
 beta = Float32Scalar("beta", 1.)
 
-dynamic_layer = dynamic_tensor.DynamicInputGenerator(model, model_input_shape)
+dynamic_layer = dynamic_tensor.DynamicInputGenerator(model, model_input_shape, "TENSOR_FLOAT32")
 
 test_node_input = dynamic_layer.getTestNodeInput()
 

--- a/tests/nnapi/specs/V1_2/abs_dynamic_nnfw.mod.py
+++ b/tests/nnapi/specs/V1_2/abs_dynamic_nnfw.mod.py
@@ -42,7 +42,7 @@ model = Model()
 
 model_input_shape = [1, 2, 3]
 
-dynamic_layer = dynamic_tensor.DynamicInputGenerator(model, model_input_shape)
+dynamic_layer = dynamic_tensor.DynamicInputGenerator(model, model_input_shape, "TENSOR_FLOAT32")
 
 test_node_input = dynamic_layer.getTestNodeInput()
 

--- a/tests/nnapi/specs/V1_2/cast_dynamic_float32_to_int32_nnfw.mod.py
+++ b/tests/nnapi/specs/V1_2/cast_dynamic_float32_to_int32_nnfw.mod.py
@@ -42,7 +42,7 @@ model = Model()
 
 model_input_shape = [1, 2, 3]
 
-dynamic_layer = dynamic_tensor.DynamicInputGenerator(model, model_input_shape)
+dynamic_layer = dynamic_tensor.DynamicInputGenerator(model, model_input_shape, "TENSOR_FLOAT32")
 
 test_node_input = dynamic_layer.getTestNodeInput()
 

--- a/tests/nnapi/specs/V1_2/exp_dynamic_nnfw.mod.py
+++ b/tests/nnapi/specs/V1_2/exp_dynamic_nnfw.mod.py
@@ -41,7 +41,7 @@ model = Model()
 
 model_input_shape = [1, 2, 3]
 
-dynamic_layer = dynamic_tensor.DynamicInputGenerator(model, model_input_shape)
+dynamic_layer = dynamic_tensor.DynamicInputGenerator(model, model_input_shape, "TENSOR_FLOAT32")
 
 test_node_input = dynamic_layer.getTestNodeInput()
 

--- a/tests/nnapi/specs/V1_2/log_dynamic_nnfw.mod.py
+++ b/tests/nnapi/specs/V1_2/log_dynamic_nnfw.mod.py
@@ -41,7 +41,7 @@ model = Model()
 
 model_input_shape = [1, 2, 3]
 
-dynamic_layer = dynamic_tensor.DynamicInputGenerator(model, model_input_shape)
+dynamic_layer = dynamic_tensor.DynamicInputGenerator(model, model_input_shape, "TENSOR_FLOAT32")
 
 test_node_input = dynamic_layer.getTestNodeInput()
 

--- a/tests/nnapi/specs/V1_2/neg_dynamic_nnfw.mod.py
+++ b/tests/nnapi/specs/V1_2/neg_dynamic_nnfw.mod.py
@@ -41,7 +41,7 @@ model = Model()
 
 model_input_shape = [1, 2, 3]
 
-dynamic_layer = dynamic_tensor.DynamicInputGenerator(model, model_input_shape)
+dynamic_layer = dynamic_tensor.DynamicInputGenerator(model, model_input_shape, "TENSOR_FLOAT32")
 
 test_node_input = dynamic_layer.getTestNodeInput()
 

--- a/tests/nnapi/specs/V1_2/sub_dynamic_nnfw.mod.py
+++ b/tests/nnapi/specs/V1_2/sub_dynamic_nnfw.mod.py
@@ -21,7 +21,7 @@ model = Model()
 
 model_input1_shape = [3, 4]   # first input shape of Sub. 12 float32s
 
-dynamic_layer = dynamic_tensor.DynamicInputGenerator(model, model_input1_shape)
+dynamic_layer = dynamic_tensor.DynamicInputGenerator(model, model_input1_shape, "TENSOR_FLOAT32")
 
 test_node_input = dynamic_layer.getTestNodeInput() # first input of Sub is dynamic tensor
 

--- a/tests/nnapi/specs/V1_2/tanh_v1_dynamic_nnfw.mod.py
+++ b/tests/nnapi/specs/V1_2/tanh_v1_dynamic_nnfw.mod.py
@@ -37,7 +37,7 @@ model = Model()
 
 model_input_shape = [2, 2]
 
-dynamic_layer = dynamic_tensor.DynamicInputGenerator(model, model_input_shape)
+dynamic_layer = dynamic_tensor.DynamicInputGenerator(model, model_input_shape, "TENSOR_FLOAT32")
 
 test_node_input = dynamic_layer.getTestNodeInput()
 


### PR DESCRIPTION
- tensor type of DynamicInputGenerator was fixed
- It needs to be delivered an argument as tensor type to support the other types

Signed-off-by: dev-hue <hue.kim@samsung.com>