### PR TITLE
[luci] Shape, dtype inference for Log

### DIFF
--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -893,6 +893,13 @@ public:
     return loco::NodeShape{input_shape};
   }
 
+  loco::NodeShape visit(const luci::CircleLog *node) final
+  {
+    auto x_shape = loco::shape_get(node->x()).as<loco::TensorShape>();
+
+    return loco::NodeShape{x_shape};
+  }
+  
   loco::NodeShape visit(const luci::CircleLogicalAnd *node) final
   {
     const auto input_shape = loco::shape_get(node->x()).as<loco::TensorShape>();

--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -899,7 +899,7 @@ public:
 
     return loco::NodeShape{x_shape};
   }
-  
+
   loco::NodeShape visit(const luci::CircleLogicalAnd *node) final
   {
     const auto input_shape = loco::shape_get(node->x()).as<loco::TensorShape>();

--- a/compiler/luci/service/src/CircleTypeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleTypeInferenceRule.cpp
@@ -172,6 +172,8 @@ struct TypeInferenceAlgorithm final : public luci::CircleNodeVisitor<loco::DataT
     return loco::dtype_get(node->input());
   }
 
+  loco::DataType visit(const luci::CircleLog *node) final { return loco::dtype_get(node->x()); }
+
   loco::DataType visit(const luci::CircleLogicalAnd *node) final
   {
     return loco::dtype_get(node->x());


### PR DESCRIPTION
This will enable shape and dtype inference for Log Op

ONE-DCO-1.0-Signed-off-by: Kishore Chandra Sahoo <kishore.cs@samsung.com>