### PR TITLE
Add default tensor_type to DynamicInputGenerator

### DIFF
--- a/tests/nnapi/nnapi_test_generator/android-10/dynamic_tensor.py
+++ b/tests/nnapi/nnapi_test_generator/android-10/dynamic_tensor.py
@@ -75,7 +75,7 @@ from test_generator import Internal
 
 class DynamicInputGenerator:
 
-    def __init__(self, model, model_input_shape_list, tensor_type):
+    def __init__(self, model, model_input_shape_list, tensor_type='TENSOR_FLOAT32'):
         self.new_shape = 0
         self.model_input = 0
         self.test_input = 0

--- a/tests/nnapi/specs/V1_2/argmax_dynamic_nnfw.mod.py
+++ b/tests/nnapi/specs/V1_2/argmax_dynamic_nnfw.mod.py
@@ -42,7 +42,7 @@ model = Model()
 
 model_input_shape = [1, 2, 2, 2]
 
-dynamic_layer = dynamic_tensor.DynamicInputGenerator(model, model_input_shape)
+dynamic_layer = dynamic_tensor.DynamicInputGenerator(model, model_input_shape, "TENSOR_FLOAT32")
 
 test_node_input = dynamic_layer.getTestNodeInput()
 

--- a/tests/nnapi/specs/V1_2/div_dynamic_nnfw.mod.py
+++ b/tests/nnapi/specs/V1_2/div_dynamic_nnfw.mod.py
@@ -40,7 +40,7 @@ model = Model()
 
 model_input1_shape = [3, 4]   # first input shape of Div. 12 float32s
 
-dynamic_layer = dynamic_tensor.DynamicInputGenerator(model, model_input1_shape)
+dynamic_layer = dynamic_tensor.DynamicInputGenerator(model, model_input1_shape, "TENSOR_FLOAT32")
 
 test_node_input = dynamic_layer.getTestNodeInput() # first input of Div is dynamic tensor
 

--- a/tests/nnapi/specs/V1_2/mul_dynamic_nnfw.mod.py
+++ b/tests/nnapi/specs/V1_2/mul_dynamic_nnfw.mod.py
@@ -40,7 +40,7 @@ model = Model()
 
 model_input1_shape = [3, 4]   # first input shape of Mul. 12 float32s
 
-dynamic_layer = dynamic_tensor.DynamicInputGenerator(model, model_input1_shape)
+dynamic_layer = dynamic_tensor.DynamicInputGenerator(model, model_input1_shape, "TENSOR_FLOAT32")
 
 test_node_input = dynamic_layer.getTestNodeInput() # first input of Mul is dynamic tensor
 


### PR DESCRIPTION
I think that `tensor_type` has default value is better than does not have.
But I think `tensor_type` arg needs to be explicit although it has default value.

Signed-off-by: dev-hue <hue.kim@samsung.com>