### PR TITLE
[onert] Set unknown dim (unspecified dim) to -1

### DIFF
--- a/runtime/onert/core/include/ir/Shape.h
+++ b/runtime/onert/core/include/ir/Shape.h
@@ -25,6 +25,12 @@
 #include <vector>
 #include <algorithm>
 
+#ifdef UNSPECIFIED_DIM
+#error UNSPECIFIED_DIM is already defined
+#endif
+
+#define UNSPECIFIED_DIM -1
+
 namespace onert
 {
 namespace ir

--- a/runtime/onert/core/include/ir/Shape.h
+++ b/runtime/onert/core/include/ir/Shape.h
@@ -25,10 +25,6 @@
 #include <vector>
 #include <algorithm>
 
-#ifdef UNSPECIFIED_DIM
-#error UNSPECIFIED_DIM is already defined
-#endif
-
 namespace onert
 {
 namespace ir

--- a/runtime/onert/core/include/ir/Shape.h
+++ b/runtime/onert/core/include/ir/Shape.h
@@ -29,8 +29,6 @@
 #error UNSPECIFIED_DIM is already defined
 #endif
 
-#define UNSPECIFIED_DIM -1
-
 namespace onert
 {
 namespace ir
@@ -42,6 +40,8 @@ using FeatureShape = nnfw::misc::feature::Shape;
 struct Shape
 {
 public:
+  static const int32_t UNSPECIFIED_DIM = -1;
+
   Shape() = default;
 
   explicit Shape(int rank) : _dimensions(rank) {}

--- a/runtime/onert/core/src/ir/Shape.cc
+++ b/runtime/onert/core/src/ir/Shape.cc
@@ -73,11 +73,9 @@ void Shape::extendRank(int to_rank)
 
 uint64_t Shape::num_elements() const
 {
-  constexpr int32_t unspecified_dim = -1;
-
   // if dimension is 0, it means unspecified and cannot calculate the total number of elements
   if (std::any_of(_dimensions.begin(), _dimensions.end(),
-                  [](const int32_t &v) { return (v == unspecified_dim); }))
+                  [](const int32_t &v) { return v == UNSPECIFIED_DIM; }))
     throw std::runtime_error("num_elements() cannot calculate when any dimension is unspecified");
 
   return std::accumulate(_dimensions.cbegin(), _dimensions.cend(), UINT64_C(1),
@@ -105,10 +103,8 @@ Shape permuteShape(const Shape &shape, Layout frontend_layout, Layout backend_la
 
 bool haveUnspecifiedDims(const ir::Shape &shape)
 {
-  constexpr int32_t unspecified_dim = -1;
-
   for (int n = 0; n < shape.rank(); n++)
-    if (shape.dim(n) == unspecified_dim)
+    if (shape.dim(n) == UNSPECIFIED_DIM)
       return true;
   return false;
 }

--- a/runtime/onert/core/src/ir/Shape.cc
+++ b/runtime/onert/core/src/ir/Shape.cc
@@ -104,7 +104,7 @@ Shape permuteShape(const Shape &shape, Layout frontend_layout, Layout backend_la
 bool haveUnspecifiedDims(const ir::Shape &shape)
 {
   for (int n = 0; n < shape.rank(); n++)
-    if (shape.dim(n) == UNSPECIFIED_DIM)
+    if (shape.dim(n) == Shape::UNSPECIFIED_DIM)
       return true;
   return false;
 }

--- a/runtime/onert/core/src/ir/Shape.cc
+++ b/runtime/onert/core/src/ir/Shape.cc
@@ -73,10 +73,12 @@ void Shape::extendRank(int to_rank)
 
 uint64_t Shape::num_elements() const
 {
+  constexpr int32_t unspecified_dim = -1;
+
   // if dimension is 0, it means unspecified and cannot calculate the total number of elements
   if (std::any_of(_dimensions.begin(), _dimensions.end(),
-                  [](const int32_t &v) { return (v == 0); }))
-    throw std::runtime_error("num_elements() cannot calculate when a dimension is unspecified");
+                  [](const int32_t &v) { return (v == unspecified_dim); }))
+    throw std::runtime_error("num_elements() cannot calculate when any dimension is unspecified");
 
   return std::accumulate(_dimensions.cbegin(), _dimensions.cend(), UINT64_C(1),
                          std::multiplies<uint64_t>());
@@ -103,8 +105,10 @@ Shape permuteShape(const Shape &shape, Layout frontend_layout, Layout backend_la
 
 bool haveUnspecifiedDims(const ir::Shape &shape)
 {
+  constexpr int32_t unspecified_dim = -1;
+
   for (int n = 0; n < shape.rank(); n++)
-    if (shape.dim(n) == 0)
+    if (shape.dim(n) == unspecified_dim)
       return true;
   return false;
 }

--- a/runtime/onert/frontend/base_loader/include/base_loader.h
+++ b/runtime/onert/frontend/base_loader/include/base_loader.h
@@ -268,7 +268,7 @@ ir::OperandIndex BaseLoader<LoaderDomain, SpecificLoader>::loadOperand(const Ten
     for (const auto &sig_dim : *tensor_shape_sig)
     {
       if (sig_dim == -1)
-        shape.dim(i) = UNSPECIFIED_DIM;
+        shape.dim(i) = ir::Shape::UNSPECIFIED_DIM;
       i++;
     }
   }

--- a/runtime/onert/frontend/base_loader/include/base_loader.h
+++ b/runtime/onert/frontend/base_loader/include/base_loader.h
@@ -18,6 +18,7 @@
 #define __BASE_LOADER_BASE_LOADER_H__
 
 #include "ir/Graph.h"
+#include "ir/Shape.h"
 #include "ir/Operations.Include.h"
 
 #include "flatbuffers/flexbuffers.h"
@@ -263,13 +264,11 @@ ir::OperandIndex BaseLoader<LoaderDomain, SpecificLoader>::loadOperand(const Ten
   const auto *tensor_shape_sig = tensor->shape_signature();
   if (tensor_shape_sig != nullptr)
   {
-    constexpr int32_t unspecified_dim = -1;
-
     int i = 0;
     for (const auto &sig_dim : *tensor_shape_sig)
     {
       if (sig_dim == -1)
-        shape.dim(i) = unspecified_dim;
+        shape.dim(i) = UNSPECIFIED_DIM;
       i++;
     }
   }

--- a/runtime/onert/frontend/base_loader/include/base_loader.h
+++ b/runtime/onert/frontend/base_loader/include/base_loader.h
@@ -263,11 +263,13 @@ ir::OperandIndex BaseLoader<LoaderDomain, SpecificLoader>::loadOperand(const Ten
   const auto *tensor_shape_sig = tensor->shape_signature();
   if (tensor_shape_sig != nullptr)
   {
+    constexpr int32_t unspecified_dim = -1;
+
     int i = 0;
     for (const auto &sig_dim : *tensor_shape_sig)
     {
       if (sig_dim == -1)
-        shape.dim(i) = -1;
+        shape.dim(i) = unspecified_dim;
       i++;
     }
   }

--- a/runtime/onert/test/ir/Shape.cc
+++ b/runtime/onert/test/ir/Shape.cc
@@ -45,12 +45,10 @@ TEST(ShapeTest, basic_test)
 TEST(ShapeTest, neg_basic_test)
 {
   {
-    constexpr int32_t unspecified_dim = -1;
-
     onert::ir::Shape shape(2);
 
     shape.dim(0) = 1;
-    shape.dim(1) = unspecified_dim;
+    shape.dim(1) = UNSPECIFIED_DIM;
 
     ASSERT_EQ(shape.rank(), 2);
     ASSERT_EQ(onert::ir::rankMaybeUnspecified(shape), false);

--- a/runtime/onert/test/ir/Shape.cc
+++ b/runtime/onert/test/ir/Shape.cc
@@ -45,10 +45,12 @@ TEST(ShapeTest, basic_test)
 TEST(ShapeTest, neg_basic_test)
 {
   {
+    constexpr int32_t unspecified_dim = -1;
+
     onert::ir::Shape shape(2);
 
     shape.dim(0) = 1;
-    shape.dim(1) = 0; // unspecified
+    shape.dim(1) = unspecified_dim;
 
     ASSERT_EQ(shape.rank(), 2);
     ASSERT_EQ(onert::ir::rankMaybeUnspecified(shape), false);

--- a/runtime/onert/test/ir/Shape.cc
+++ b/runtime/onert/test/ir/Shape.cc
@@ -48,7 +48,7 @@ TEST(ShapeTest, neg_basic_test)
     onert::ir::Shape shape(2);
 
     shape.dim(0) = 1;
-    shape.dim(1) = UNSPECIFIED_DIM;
+    shape.dim(1) = onert::ir::Shape::UNSPECIFIED_DIM;
 
     ASSERT_EQ(shape.rank(), 2);
     ASSERT_EQ(onert::ir::rankMaybeUnspecified(shape), false);


### PR DESCRIPTION
This set unknown dim to `0` in `base_loader`. Previously it was `-1`.

In nnapi, `dim (== 0)` is treated as unspecified dim. So this commit aligns with nnapi's approach.

Refer to https://github.com/Samsung/ONE/pull/1394/files

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>