### PR TITLE
[onert] Fix missing tensor_type error for nnapi tests

### DIFF
--- a/tests/nnapi/specs/V1_2/argmax_dynamic_nnfw.mod.py
+++ b/tests/nnapi/specs/V1_2/argmax_dynamic_nnfw.mod.py
@@ -42,7 +42,7 @@ model = Model()
 
 model_input_shape = [1, 2, 2, 2]
 
-dynamic_layer = dynamic_tensor.DynamicInputGenerator(model, model_input_shape)
+dynamic_layer = dynamic_tensor.DynamicInputGenerator(model, model_input_shape, "TENSOR_FLOAT32")
 
 test_node_input = dynamic_layer.getTestNodeInput()
 

--- a/tests/nnapi/specs/V1_2/div_dynamic_nnfw.mod.py
+++ b/tests/nnapi/specs/V1_2/div_dynamic_nnfw.mod.py
@@ -40,7 +40,7 @@ model = Model()
 
 model_input1_shape = [3, 4]   # first input shape of Div. 12 float32s
 
-dynamic_layer = dynamic_tensor.DynamicInputGenerator(model, model_input1_shape)
+dynamic_layer = dynamic_tensor.DynamicInputGenerator(model, model_input1_shape, "TENSOR_FLOAT32")
 
 test_node_input = dynamic_layer.getTestNodeInput() # first input of Div is dynamic tensor
 

--- a/tests/nnapi/specs/V1_2/mul_dynamic_nnfw.mod.py
+++ b/tests/nnapi/specs/V1_2/mul_dynamic_nnfw.mod.py
@@ -40,7 +40,7 @@ model = Model()
 
 model_input1_shape = [3, 4]   # first input shape of Mul. 12 float32s
 
-dynamic_layer = dynamic_tensor.DynamicInputGenerator(model, model_input1_shape)
+dynamic_layer = dynamic_tensor.DynamicInputGenerator(model, model_input1_shape, "TENSOR_FLOAT32")
 
 test_node_input = dynamic_layer.getTestNodeInput() # first input of Mul is dynamic tensor
 


### PR DESCRIPTION
This commit fixes missing tensor_type error for nnapi tests
- `tensor_type` is missing for some nnapi tests after #1807
- This commit will fix #1819

ONE-DCO-1.0-Signed-off-by: JiHwan Yeo <jihwan.yeo@samsung.com>