### PR TITLE
[onert] Apply dynamic tensor for PermuteLayer of controlflow

### DIFF
--- a/runtime/onert/core/include/exec/IExecutor.h
+++ b/runtime/onert/core/include/exec/IExecutor.h
@@ -25,6 +25,7 @@
 #include "IFunction.h"
 #include "IODescription.h"
 #include "ir/OperationIndexMap.h"
+#include "backend/IDynamicTensorManager.h"
 
 namespace onert
 {
@@ -75,6 +76,23 @@ struct IExecutor
 };
 
 using ExecutorMap = std::unordered_map<ir::SubgraphIndex, std::unique_ptr<IExecutor>>;
+
+// TODO Move this structure to suitable place
+/**
+ * @brief Dynamic allocation info for input tensors
+ *        When user sets shape of input having unknown dims after compilation, memory for the input
+ * should be allocated before executing kernels. This struct contains information to allocate
+ * memory.
+ */
+struct DynAllocInfo
+{
+  /// @brief index of input tensor whose memory needs to be allocated at execution time
+  ir::OperandIndex ind;
+  /// @brief dynamic tensor manager that can allocate memory when input tensor is dynamic
+  backend::IDynamicTensorManager *dyn_tensor_manager;
+};
+
+using DynAllocInfoMap = std::unordered_map<std::shared_ptr<backend::ITensor>, DynAllocInfo>;
 
 } // namespace exec
 } // namespace onert

--- a/runtime/onert/core/src/backend/controlflow/KernelGenerator.h
+++ b/runtime/onert/core/src/backend/controlflow/KernelGenerator.h
@@ -53,6 +53,7 @@ public:
 
 private:
   std::shared_ptr<backend::ITensor> getTensor(const ir::OperandIndex &index);
+  std::shared_ptr<backend::ITensorBuilder> getTensorBuilder(const ir::OperandIndex &index);
 
 private:
   const ir::Operands &_operand_ctx;

--- a/runtime/onert/core/src/backend/controlflow/kernel/IfLayer.cc
+++ b/runtime/onert/core/src/backend/controlflow/kernel/IfLayer.cc
@@ -32,18 +32,18 @@ namespace kernel
 IfLayer::IfLayer(const std::shared_ptr<backend::ITensor> &cond_tensor,
                  std::vector<std::shared_ptr<backend::ITensor>> input_tensors,
                  std::vector<std::shared_ptr<backend::ITensor>> output_tensors,
+                 const exec::DynAllocInfoMap &outputs_dyn_alloc_info,
                  const ir::SubgraphIndex &then_subg_index, const ir::SubgraphIndex &else_subg_index,
                  const std::shared_ptr<exec::ExecutorMap> &executor_map)
     : _cond_tensor{cond_tensor}, _input_tensors{input_tensors}, _output_tensors{output_tensors},
-      _then_subg_index{then_subg_index}, _else_subg_index{else_subg_index},
-      _executor_map{executor_map}
+      _outputs_dyn_alloc_info{outputs_dyn_alloc_info}, _then_subg_index{then_subg_index},
+      _else_subg_index{else_subg_index}, _executor_map{executor_map}
 {
   // At this point, executor_map may not have executors of then subg and else subg
 }
 
 void IfLayer::run()
 {
-  // TODO Support dynamic tensor
   // Check condition
   // // If true
   // // // Copy _src_tensors -> then subg's inputs
@@ -59,6 +59,7 @@ void IfLayer::run()
     return ret;
   };
 
+  // TODO Unify duplicated code
   if (getResultCond(_cond_tensor.get()))
   {
     auto then_exec = dynamic_cast<exec::ExecutorBase *>(_executor_map->at(_then_subg_index).get());
@@ -68,18 +69,34 @@ void IfLayer::run()
     }
 
     const auto &then_input_tensors = then_exec->getInputTensors();
+    const auto &then_inputs_dyn_alloc_info = then_exec->getInputsDynamicAllocInfo();
+
+    const auto permute_op_input_to_then_input = std::make_shared<PermuteLayer>(
+        _input_tensors, then_input_tensors, then_inputs_dyn_alloc_info);
+
     const auto &then_output_tensors = then_exec->getOutputTensors();
-    const auto permute_op_input_to_then_input =
-        std::make_shared<PermuteLayer>(_input_tensors, then_input_tensors);
-    const auto permute_then_output_to_op_output =
-        std::make_shared<PermuteLayer>(then_output_tensors, _output_tensors);
+    const auto permute_then_output_to_op_output = std::make_shared<PermuteLayer>(
+        then_output_tensors, _output_tensors, _outputs_dyn_alloc_info);
 
     // Remove copying of unused tensor
     permute_op_input_to_then_input->prepare();
     permute_then_output_to_op_output->prepare();
 
     // Copy & run
+    assert(_input_tensors.size() == then_input_tensors.size());
     then_exec->execute(_input_tensors, permute_op_input_to_then_input);
+    assert(_output_tensors.size() == then_output_tensors.size());
+    for (size_t i = 0; i < _output_tensors.size(); ++i)
+    {
+      const auto output_tensor = _output_tensors.at(i);
+      const auto orig_output_shape = getShape(output_tensor.get());
+      const auto changed_output_shape = getShape(then_output_tensors.at(i).get());
+      if (orig_output_shape != changed_output_shape &&
+          _outputs_dyn_alloc_info.find(output_tensor) != _outputs_dyn_alloc_info.end())
+      {
+        output_tensor->set_dynamic();
+      }
+    }
     permute_then_output_to_op_output->run();
   }
   else
@@ -91,18 +108,33 @@ void IfLayer::run()
     }
 
     const auto &else_input_tensors = else_exec->getInputTensors();
+    const auto &else_inputs_dyn_alloc_info = else_exec->getInputsDynamicAllocInfo();
+    const auto permute_op_input_to_else_input = std::make_shared<PermuteLayer>(
+        _input_tensors, else_input_tensors, else_inputs_dyn_alloc_info);
+
     const auto &else_output_tensors = else_exec->getOutputTensors();
-    const auto permute_op_input_to_else_input =
-        std::make_shared<PermuteLayer>(_input_tensors, else_input_tensors);
-    const auto permute_else_output_to_op_output =
-        std::make_shared<PermuteLayer>(else_output_tensors, _output_tensors);
+    const auto permute_else_output_to_op_output = std::make_shared<PermuteLayer>(
+        else_output_tensors, _output_tensors, _outputs_dyn_alloc_info);
 
     // Remove copying of unused tensor
     permute_op_input_to_else_input->prepare();
     permute_else_output_to_op_output->prepare();
 
     // Copy & run
+    assert(_input_tensors.size() == else_input_tensors.size());
     else_exec->execute(_input_tensors, permute_op_input_to_else_input);
+    assert(_output_tensors.size() == else_output_tensors.size());
+    for (size_t i = 0; i < _output_tensors.size(); ++i)
+    {
+      const auto output_tensor = _output_tensors.at(i);
+      const auto orig_output_shape = getShape(output_tensor.get());
+      const auto changed_output_shape = getShape(else_output_tensors.at(i).get());
+      if (orig_output_shape != changed_output_shape &&
+          _outputs_dyn_alloc_info.find(output_tensor) != _outputs_dyn_alloc_info.end())
+      {
+        output_tensor->set_dynamic();
+      }
+    }
     permute_else_output_to_op_output->run();
   }
 }

--- a/runtime/onert/core/src/backend/controlflow/kernel/IfLayer.h
+++ b/runtime/onert/core/src/backend/controlflow/kernel/IfLayer.h
@@ -36,6 +36,7 @@ public:
   IfLayer(const std::shared_ptr<backend::ITensor> &cond_tensor,
           std::vector<std::shared_ptr<backend::ITensor>> input_tensors,
           std::vector<std::shared_ptr<backend::ITensor>> output_tensors,
+          const exec::DynAllocInfoMap &outputs_dyn_alloc_info,
           const ir::SubgraphIndex &then_subg_index, const ir::SubgraphIndex &else_subg_index,
           const std::shared_ptr<exec::ExecutorMap> &executor_map);
 
@@ -56,6 +57,7 @@ private:
   const std::shared_ptr<backend::ITensor> _cond_tensor;
   const std::vector<std::shared_ptr<backend::ITensor>> _input_tensors;
   const std::vector<std::shared_ptr<backend::ITensor>> _output_tensors;
+  const exec::DynAllocInfoMap _outputs_dyn_alloc_info;
   const ir::SubgraphIndex _then_subg_index;
   const ir::SubgraphIndex _else_subg_index;
   const std::shared_ptr<exec::ExecutorMap> &_executor_map;

--- a/runtime/onert/core/src/backend/controlflow/kernel/PermuteLayer.cc
+++ b/runtime/onert/core/src/backend/controlflow/kernel/PermuteLayer.cc
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "PermuteLayer.h"
+
+#include "exec/ShapeConverter.h"
+
+namespace onert
+{
+namespace backend
+{
+namespace controlflow
+{
+namespace kernel
+{
+
+void PermuteLayer::run()
+{
+  assert(_src_tensors.size() == _dst_tensors.size());
+  // PermuteLayer infers dynamic shape inside itself whenever run is called for the following
+  // reasons:
+  // 1. PermuteLayer has to access dynamic tensor manager for input/output tensors of other backends
+  // 2. Other controlflow operation(If/While) uses this layout for copying tensors of other
+  // subgraphs(with other backends)
+  // 3. This infering code is placed here to avoid duplicated code that can be caused by above 2
+  // reasons
+
+  // check if output is not dynamic
+  for (size_t i = 0; i < _src_tensors.size(); ++i)
+  {
+    auto dst_tensor = _dst_tensors.at(i);
+    auto src_tensor = _src_tensors.at(i);
+    if (src_tensor->is_dynamic() || dst_tensor->is_dynamic())
+    {
+      // getting output shape
+      auto src_shape = getShape(src_tensor.get());
+
+      // set output shape and output buffer
+      ir::Shape new_shape =
+          exec::convertShape(src_shape, src_tensor->layout(), dst_tensor->layout());
+
+      const auto dst_index = _dst_dyn_alloc_info_map.at(dst_tensor).ind;
+      _dst_dyn_alloc_info_map.at(dst_tensor).dyn_tensor_manager->applyShape(dst_index, new_shape);
+      assert(dst_tensor->buffer() != nullptr);
+    }
+    assert(exec::convertShape(getShape(src_tensor.get()), src_tensor->layout(),
+                              dst_tensor->layout()) == getShape(dst_tensor.get()));
+  }
+  IPermuteFunction::run();
+}
+
+} // namespace kernel
+} // namespace controlflow
+} // namespace backend
+} // namespace onert

--- a/runtime/onert/core/src/backend/controlflow/kernel/PermuteLayer.h
+++ b/runtime/onert/core/src/backend/controlflow/kernel/PermuteLayer.h
@@ -18,6 +18,8 @@
 #define __ONERT_BACKEND_CONTROLFLOW_KERNEL_PERMUTELAYER_H__
 
 #include <exec/IPermuteFunction.h>
+#include <backend/ITensorBuilder.h>
+#include <exec/IExecutor.h>
 
 namespace onert
 {
@@ -31,8 +33,10 @@ namespace kernel
 class PermuteLayer : public onert::exec::IPermuteFunction
 {
 public:
-  PermuteLayer(const std::vector<std::shared_ptr<onert::backend::ITensor>> &src_tensors,
-               const std::vector<std::shared_ptr<onert::backend::ITensor>> &dst_tensors)
+  PermuteLayer(const std::vector<std::shared_ptr<ITensor>> &src_tensors,
+               const std::vector<std::shared_ptr<ITensor>> &dst_tensors,
+               const exec::DynAllocInfoMap &dst_dyn_alloc_info_map)
+      : _dst_dyn_alloc_info_map{dst_dyn_alloc_info_map}
   {
     assert(src_tensors.size() == dst_tensors.size());
     _src_tensors = src_tensors;
@@ -58,6 +62,11 @@ public:
       }
     }
   }
+
+  void run() override;
+
+private:
+  const exec::DynAllocInfoMap _dst_dyn_alloc_info_map;
 };
 
 } // namespace kernel

--- a/runtime/onert/core/src/backend/controlflow/kernel/WhileLayer.h
+++ b/runtime/onert/core/src/backend/controlflow/kernel/WhileLayer.h
@@ -35,6 +35,7 @@ class WhileLayer : public ::onert::exec::IFunction
 public:
   WhileLayer(std::vector<std::shared_ptr<backend::ITensor>> input_tensors,
              std::vector<std::shared_ptr<backend::ITensor>> output_tensors,
+             const exec::DynAllocInfoMap &outputs_dyn_alloc_info,
              const ir::SubgraphIndex &cond_subg_index, const ir::SubgraphIndex &body_subg_index,
              const std::shared_ptr<exec::ExecutorMap> &executor_map);
 
@@ -56,6 +57,7 @@ private:
   const ir::SubgraphIndex _body_subg_index;
   const std::vector<std::shared_ptr<backend::ITensor>> _input_tensors;
   const std::vector<std::shared_ptr<backend::ITensor>> _output_tensors;
+  const exec::DynAllocInfoMap _outputs_dyn_alloc_info;
   const std::shared_ptr<exec::ExecutorMap> &_executor_map;
 };
 

--- a/runtime/onert/core/src/exec/ExecutorBase.cc
+++ b/runtime/onert/core/src/exec/ExecutorBase.cc
@@ -201,13 +201,7 @@ void ExecutorBase::execute(const std::vector<std::shared_ptr<backend::ITensor>> 
         }
         else
         {
-          const auto operand_ind = dyn_alloc_info->second.ind;
-          if (orig_input_shape != changed_input_shape)
-          {
-            dyn_alloc_info->second.dyn_tensor_manager->allocate(operand_ind, changed_input_shape);
-            // TODO Move changeInputShape() above allocate()
-            changeInputShape(operand_ind, changed_input_shape);
-          }
+          input_tensor->set_dynamic();
         }
       }
     }

--- a/runtime/onert/core/src/exec/ExecutorBase.h
+++ b/runtime/onert/core/src/exec/ExecutorBase.h
@@ -79,12 +79,17 @@ public:
 
   void addObserver(std::unique_ptr<IExecutionObserver> ref) { _subject.add(std::move(ref)); };
 
-  const std::vector<std::shared_ptr<backend::ITensor>> &getInputTensors() { return _input_tensors; }
+  const std::vector<std::shared_ptr<backend::ITensor>> &getInputTensors() const
+  {
+    return _input_tensors;
+  }
 
-  const std::vector<std::shared_ptr<backend::ITensor>> &getOutputTensors()
+  const std::vector<std::shared_ptr<backend::ITensor>> &getOutputTensors() const
   {
     return _output_tensors;
   }
+
+  const DynAllocInfoMap &getInputsDynamicAllocInfo() const { return _input_to_dyn_alloc_info; }
 
 private:
   std::unique_ptr<ISource> source(const ir::IOIndex &index, const ir::TypeInfo &type,
@@ -140,29 +145,14 @@ private:
   void changeInputShape(const ir::OperandIndex &index, const ir::Shape &new_shape) override;
 
 protected:
-  /**
-   * @brief Dynamic allocation info for input tensors
-   *        When user sets shape of input having unknown dims after compilation, memory for the
-   *        input should be allocated before executing kernels. This struct contains information
-   *        to allocate memory.
-   */
-  struct DynAllocInfo
-  {
-    /// @brief index of input tensor whose memory needs to be allocated at execution time
-    ir::OperandIndex ind;
-
-    /// @brief dynamic tensor manager that can allocate memory when input tensor is dynamic
-    backend::IDynamicTensorManager *dyn_tensor_manager;
-  };
-
   ExecutionObservee _subject;
   std::shared_ptr<ir::OperationIndexMap<int64_t>> _indexed_ranks;
   std::unique_ptr<ir::LoweredGraph> _lowered_graph;
   const ir::Graph &_graph;
   std::vector<std::shared_ptr<backend::ITensor>> _input_tensors;
   std::vector<std::shared_ptr<backend::ITensor>> _output_tensors;
-  std::unordered_map<std::shared_ptr<backend::ITensor>, DynAllocInfo> _input_to_dyn_alloc_info;
-  std::unordered_map<std::shared_ptr<backend::ITensor>, DynAllocInfo> _output_to_dyn_alloc_info;
+  DynAllocInfoMap _input_to_dyn_alloc_info;
+  DynAllocInfoMap _output_to_dyn_alloc_info;
   backend::TensorManagerSet _tensor_mgrs;
   std::mutex _mutex;
 


### PR DESCRIPTION
For issue #1255
Draft PR #1372

This commit applies dynamic tensor for PermuteLayer of controlflow.
  - Move DynAllocInfo in IExecutor.h
  - Apply dynamic tensor for PermuteLayer to allocate dynamic tensor in the layer
  - Modify using PermuteLayer in kernels of controlflow
  - Modify allocating dynamic tensor in execute() of subgraph to only set dynamic

Signed-off-by: ragmani <ragmani0216@gmail.com>