### PR TITLE
[cmake] Remove ExternalSource_Get function

### DIFF
--- a/infra/cmake/modules/ExternalSourceTools.cmake
+++ b/infra/cmake/modules/ExternalSourceTools.cmake
@@ -107,33 +107,3 @@ function(ExternalSource_Download PREFIX)
 
   set(${PREFIX}_SOURCE_DIR "${OUT_DIR}" PARENT_SCOPE)
 endfunction(ExternalSource_Download)
-
-function(ExternalSource_Get PREFIX DOWNLOAD_FLAG URL)
-  nnas_include(StampTools)
-
-  set(CACHE_DIR "${NNAS_EXTERNALS_DIR}")
-  set(OUT_DIR "${CACHE_DIR}/${PREFIX}")
-  set(STAMP_PATH "${CACHE_DIR}/${PREFIX}.stamp")
-
-  if(NOT EXISTS "${CACHE_DIR}")
-    file(MAKE_DIRECTORY "${CACHE_DIR}")
-  endif(NOT EXISTS "${CACHE_DIR}")
-
-  # Compare URL in STAMP file and the given URL
-  Stamp_Check(URL_CHECK "${STAMP_PATH}" "${URL}")
-
-  # TODO Check MD5 for correctness
-
-  set(SOURCE_GET TRUE)
-
-  if(NOT EXISTS "${OUT_DIR}" OR NOT URL_CHECK)
-    if(NOT DOWNLOAD_FLAG)
-      set(SOURCE_GET FALSE)
-    else(NOT DOWNLOAD_FLAG)
-      ExternalSource_Download(${PREFIX} ${URL} ${ARGN})
-    endif(NOT DOWNLOAD_FLAG)
-  endif()
-
-  set(${PREFIX}_SOURCE_GET ${SOURCE_GET} PARENT_SCOPE)
-  set(${PREFIX}_SOURCE_DIR "${OUT_DIR}" PARENT_SCOPE)
-endfunction(ExternalSource_Get)

--- a/infra/cmake/packages/ARMComputeSourceConfig.cmake
+++ b/infra/cmake/packages/ARMComputeSourceConfig.cmake
@@ -1,10 +1,15 @@
 function(_ARMComputeSource_import)
+  if(NOT ${DOWNLOAD_ARMCOMPUTE})
+    set(ARMComputeSource_FOUND FALSE PARENT_SCOPE)
+    return()
+  endif(NOT ${DOWNLOAD_ARMCOMPUTE})
+
   nnas_include(ExternalSourceTools)
   nnas_include(OptionTools)
 
   envoption(EXTERNAL_DOWNLOAD_SERVER "https://github.com")
   set(ARMCOMPUTE_URL ${EXTERNAL_DOWNLOAD_SERVER}/ARM-software/ComputeLibrary/archive/v19.11.1.tar.gz)
-  ExternalSource_Get(ARMCOMPUTE ${DOWNLOAD_ARMCOMPUTE} ${ARMCOMPUTE_URL})
+  ExternalSource_Download(ARMCOMPUTE ${ARMCOMPUTE_URL})
 
   set(ARMComputeSource_DIR ${ARMCOMPUTE_SOURCE_DIR} PARENT_SCOPE)
   set(ARMComputeSource_FOUND ${ARMCOMPUTE_SOURCE_GET} PARENT_SCOPE)

--- a/infra/cmake/packages/BoostSourceConfig.cmake
+++ b/infra/cmake/packages/BoostSourceConfig.cmake
@@ -1,11 +1,16 @@
 function(_BoostSource_import)
+  if(NOT ${DOWNLOAD_BOOST})
+    set(BoostSource_FOUND FALSE PARENT_SCOPE)
+    return()
+  endif(NOT ${DOWNLOAD_BOOST})
+
   nnas_include(ExternalSourceTools)
   nnas_include(OptionTools)
 
   # EXTERNAL_DOWNLOAD_SERVER will be overwritten by CI server to use mirror server.
   envoption(EXTERNAL_DOWNLOAD_SERVER "http://sourceforge.net")
   set(BOOST_URL ${EXTERNAL_DOWNLOAD_SERVER}/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.gz)
-  ExternalSource_Get(BOOST ${DOWNLOAD_BOOST} ${BOOST_URL})
+  ExternalSource_Download(BOOST ${BOOST_URL})
 
   set(BoostSource_DIR ${BOOST_SOURCE_DIR} PARENT_SCOPE)
   set(BoostSource_FOUND ${BOOST_SOURCE_GET} PARENT_SCOPE)

--- a/infra/cmake/packages/NoniusSourceConfig.cmake
+++ b/infra/cmake/packages/NoniusSourceConfig.cmake
@@ -1,10 +1,15 @@
 function(_NoniusSource_import)
+  if(NOT ${DOWNLOAD_NONIUS})
+    set(NoniusSource_FOUND FALSE PARENT_SCOPE)
+    return()
+  endif(NOT ${DOWNLOAD_NONIUS})
+
   nnas_include(ExternalSourceTools)
   nnas_include(OptionTools)
 
   envoption(EXTERNAL_DOWNLOAD_SERVER "https://github.com")
   set(NONIUS_URL ${EXTERNAL_DOWNLOAD_SERVER}/libnonius/nonius/archive/v1.2.0-beta.1.tar.gz)
-  ExternalSource_Get("NONIUS" ${DOWNLOAD_NONIUS} ${NONIUS_URL})
+  ExternalSource_Download("NONIUS" ${NONIUS_URL})
 
   set(NoniusSource_DIR ${NONIUS_SOURCE_DIR} PARENT_SCOPE)
   set(NoniusSource_FOUND ${NONIUS_SOURCE_GET} PARENT_SCOPE)

--- a/infra/nnfw/cmake/packages/AbslSourceConfig.cmake
+++ b/infra/nnfw/cmake/packages/AbslSourceConfig.cmake
@@ -1,11 +1,16 @@
 function(_AbslSource_import)
+  if(NOT ${DOWNLOAD_ABSL})
+    set(AbslSource_FOUND FALSE PARENT_SCOPE)
+    return()
+  endif(NOT ${DOWNLOAD_ABSL})
+
   nnas_include(ExternalSourceTools)
   nnas_include(OptionTools)
 
   # NOTE The following URL comes from TensorFlow 1.12
   envoption(EXTERNAL_DOWNLOAD_SERVER "https://github.com")
   set(ABSL_URL ${EXTERNAL_DOWNLOAD_SERVER}/abseil/abseil-cpp/archive/389ec3f906f018661a5308458d623d01f96d7b23.tar.gz)
-  ExternalSource_Get("absl" ${DOWNLOAD_ABSL} ${ABSL_URL})
+  ExternalSource_Download("absl" ${ABSL_URL})
 
   set(AbslSource_DIR ${absl_SOURCE_DIR} PARENT_SCOPE)
   set(AbslSource_FOUND ${absl_SOURCE_GET} PARENT_SCOPE)

--- a/infra/nnfw/cmake/packages/EigenSourceConfig.cmake
+++ b/infra/nnfw/cmake/packages/EigenSourceConfig.cmake
@@ -1,11 +1,16 @@
 function(_EigenSource_import)
+  if(NOT ${DOWNLOAD_EIGEN})
+    set(EigenSource_FOUND FALSE PARENT_SCOPE)
+    return()
+  endif(NOT ${DOWNLOAD_EIGEN})
+
   nnas_include(ExternalSourceTools)
   nnas_include(OptionTools)
 
   # NOTE TensorFlow 1.12 downloads Eign from the following URL
   envoption(EXTERNAL_DOWNLOAD_SERVER "https://bitbucket.org")
   set(EIGEN_URL ${EXTERNAL_DOWNLOAD_SERVER}/eigen/eigen/get/88fc23324517.tar.gz)
-  ExternalSource_Get("eigen" ${DOWNLOAD_EIGEN} ${EIGEN_URL})
+  ExternalSource_Download("eigen" ${EIGEN_URL})
 
   set(EigenSource_DIR ${eigen_SOURCE_DIR} PARENT_SCOPE)
   set(EigenSource_FOUND ${eigen_SOURCE_GET} PARENT_SCOPE)

--- a/infra/nnfw/cmake/packages/FarmhashSourceConfig.cmake
+++ b/infra/nnfw/cmake/packages/FarmhashSourceConfig.cmake
@@ -1,11 +1,16 @@
 function(_FarmhashSource_import)
+  if(NOT ${DOWNLOAD_FARMHASH})
+    set(FarmhashSource_FOUND FALSE PARENT_SCOPE)
+    return()
+  endif(NOT ${DOWNLOAD_FARMHASH})
+
   nnas_include(ExternalSourceTools)
   nnas_include(OptionTools)
 
   # NOTE TensorFlow 1.12 downloads farmhash from the following URL
   envoption(EXTERNAL_DOWNLOAD_SERVER "https://github.com")
   set(FARMHASH_URL ${EXTERNAL_DOWNLOAD_SERVER}/google/farmhash/archive/816a4ae622e964763ca0862d9dbd19324a1eaf45.tar.gz)
-  ExternalSource_Get("farmhash" ${DOWNLOAD_FARMHASH} ${FARMHASH_URL})
+  ExternalSource_Download("farmhash" ${FARMHASH_URL})
 
   set(FarmhashSource_DIR ${farmhash_SOURCE_DIR} PARENT_SCOPE)
   set(FarmhashSource_FOUND ${farmhash_SOURCE_GET} PARENT_SCOPE)

--- a/infra/nnfw/cmake/packages/FlatBuffersSourceConfig.cmake
+++ b/infra/nnfw/cmake/packages/FlatBuffersSourceConfig.cmake
@@ -1,11 +1,16 @@
 function(_FlatBuffersSource_import)
+  if(NOT ${DOWNLOAD_FLATBUFFERS})
+    set(FlatBuffersSource_FOUND FALSE PARENT_SCOPE)
+    return()
+  endif(NOT ${DOWNLOAD_FLATBUFFERS})
+
   nnas_include(ExternalSourceTools)
   nnas_include(OptionTools)
 
   # NOTE TensorFlow 1.12 downloads FlatBuffers from the following URL
   envoption(EXTERNAL_DOWNLOAD_SERVER "https://github.com")
   set(FLATBUFFERS_URL ${EXTERNAL_DOWNLOAD_SERVER}/google/flatbuffers/archive/1f5eae5d6a135ff6811724f6c57f911d1f46bb15.tar.gz)
-  ExternalSource_Get("flatbuffers" ${DOWNLOAD_FLATBUFFERS} ${FLATBUFFERS_URL})
+  ExternalSource_Download("flatbuffers" ${FLATBUFFERS_URL})
 
   set(FlatBuffersSource_DIR ${flatbuffers_SOURCE_DIR} PARENT_SCOPE)
   set(FlatBuffersSource_FOUND ${flatbuffers_SOURCE_GET} PARENT_SCOPE)

--- a/infra/nnfw/cmake/packages/GEMMLowpSourceConfig.cmake
+++ b/infra/nnfw/cmake/packages/GEMMLowpSourceConfig.cmake
@@ -1,11 +1,16 @@
 function(_GEMMLowpSource_import)
+  if(NOT ${DOWNLOAD_GEMMLOWP})
+    set(GEMMLowpSource_FOUND FALSE PARENT_SCOPE)
+    return()
+  endif(NOT ${DOWNLOAD_GEMMLOWP})
+
   nnas_include(ExternalSourceTools)
   nnas_include(OptionTools)
 
   # NOTE TensorFlow 1.12 uses the following URL
   envoption(EXTERNAL_DOWNLOAD_SERVER "https://github.com")
   set(GEMMLOWP_URL ${EXTERNAL_DOWNLOAD_SERVER}/google/gemmlowp/archive/38ebac7b059e84692f53e5938f97a9943c120d98.tar.gz)
-  ExternalSource_Get("gemmlowp" ${DOWNLOAD_GEMMLOWP} ${GEMMLOWP_URL})
+  ExternalSource_Download("gemmlowp" ${GEMMLOWP_URL})
 
   set(GEMMLowpSource_DIR ${gemmlowp_SOURCE_DIR} PARENT_SCOPE)
   set(GEMMLowpSource_FOUND ${gemmlowp_SOURCE_GET} PARENT_SCOPE)

--- a/infra/nnfw/cmake/packages/GTestConfig.cmake
+++ b/infra/nnfw/cmake/packages/GTestConfig.cmake
@@ -5,7 +5,7 @@ if(${BUILD_GTEST})
 
   envoption(EXTERNAL_DOWNLOAD_SERVER "https://github.com")
   set(GTEST_URL ${EXTERNAL_DOWNLOAD_SERVER}/google/googletest/archive/release-1.8.0.tar.gz)
-  ExternalSource_Get("gtest" TRUE ${GTEST_URL})
+  ExternalSource_Download("gtest" ${GTEST_URL})
 
   # gtest_SOURCE_DIR is used in gtest subdirectorty's cmake
   set(sourcedir_gtest ${gtest_SOURCE_DIR})

--- a/infra/nnfw/cmake/packages/NEON2SSESourceConfig.cmake
+++ b/infra/nnfw/cmake/packages/NEON2SSESourceConfig.cmake
@@ -1,9 +1,8 @@
 function(_NEON2SSESource_import)
-  # TODO Remove this workaround once target preset is ready
-  if(NOT (TARGET_ARCH_BASE STREQUAL "x86_64"))
+  if(NOT ${DOWNLOAD_NEON2SSE})
     set(NEON2SSESource_FOUND FALSE PARENT_SCOPE)
     return()
-  endif(NOT (TARGET_ARCH_BASE STREQUAL "x86_64"))
+  endif(NOT ${DOWNLOAD_NEON2SSE})
 
   nnas_include(ExternalSourceTools)
   nnas_include(OptionTools)
@@ -11,7 +10,7 @@ function(_NEON2SSESource_import)
   # NOTE TensorFlow 1.12 downloads NEON2SSE from the following URL
   envoption(EXTERNAL_DOWNLOAD_SERVER "https://github.com")
   set(NEON2SSE_URL ${EXTERNAL_DOWNLOAD_SERVER}/intel/ARM_NEON_2_x86_SSE/archive/0f77d9d182265259b135dad949230ecbf1a2633d.tar.gz)
-  ExternalSource_Get("neon_2_sse" ${DOWNLOAD_NEON2SSE} ${NEON2SSE_URL})
+  ExternalSource_Download("neon_2_sse" ${NEON2SSE_URL})
 
   set(NEON2SSESource_DIR ${neon_2_sse_SOURCE_DIR} PARENT_SCOPE)
   set(NEON2SSESource_FOUND ${neon_2_sse_SOURCE_GET} PARENT_SCOPE)

--- a/infra/nnfw/cmake/packages/RuySourceConfig.cmake
+++ b/infra/nnfw/cmake/packages/RuySourceConfig.cmake
@@ -1,11 +1,16 @@
 function(_RuySource_import)
+  if(NOT ${DOWNLOAD_RUY})
+    set(RuySource_DIR FALSE PARENT_SCOPE)
+    return()
+  endif(NOT ${DOWNLOAD_RUY})
+
   nnas_include(ExternalSourceTools)
   nnas_include(OptionTools)
 
   # NOTE Downloads source from latest ruy library (2020-04-10)
   envoption(EXTERNAL_DOWNLOAD_SERVER "https://github.com")
   set(RUY_URL ${EXTERNAL_DOWNLOAD_SERVER}/google/ruy/archive/2e2658f964638ab7aa562d4b48b76007d44e38f0.tar.gz)
-  ExternalSource_Get("ruy" ${DOWNLOAD_RUY} ${RUY_URL})
+  ExternalSource_Download("ruy" ${RUY_URL})
 
   set(RuySource_DIR ${ruy_SOURCE_DIR} PARENT_SCOPE)
   set(RuySource_FOUND ${ruy_SOURCE_GET} PARENT_SCOPE)

--- a/infra/nnfw/cmake/packages/TensorFlowSourceConfig.cmake
+++ b/infra/nnfw/cmake/packages/TensorFlowSourceConfig.cmake
@@ -9,7 +9,7 @@ function(_TensorFlowSource_import)
 
   envoption(EXTERNAL_DOWNLOAD_SERVER "https://github.com")
   set(TENSORFLOW_URL ${EXTERNAL_DOWNLOAD_SERVER}/tensorflow/tensorflow/archive/v1.13.1.tar.gz)
-  ExternalSource_Get("tensorflow" ${DOWNLOAD_TENSORFLOW} ${TENSORFLOW_URL})
+  ExternalSource_Download("tensorflow" ${TENSORFLOW_URL})
 
   set(TensorFlowSource_DIR ${tensorflow_SOURCE_DIR} PARENT_SCOPE)
   set(TensorFlowSource_FOUND ${tensorflow_SOURCE_GET} PARENT_SCOPE)


### PR DESCRIPTION
Remove ExternalSource_Get and use ExternalSource_Download directly (same with nncc)

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>