### PR TITLE
[onert] Refactor IFunction synchronous run

### DIFF
--- a/runtime/onert/backend/acl_cl/Config.h
+++ b/runtime/onert/backend/acl_cl/Config.h
@@ -20,6 +20,7 @@
 #include "CLTimer.h"
 #include <memory>
 #include <backend/IConfig.h>
+#include <arm_compute/runtime/CL/CLScheduler.h>
 
 namespace onert
 {
@@ -37,6 +38,7 @@ public:
   ir::Layout supportLayout(const ir::Operation &node, ir::Layout frontend_layout) override;
   bool supportDynamicTensor() override { return false; }
   bool supportFP16() override { return true; }
+  void sync() const override { arm_compute::CLScheduler::get().sync(); }
 
   std::unique_ptr<util::ITimer> timer() override { return std::make_unique<CLTimer>(); }
 };

--- a/runtime/onert/backend/acl_common/AclFunction.h
+++ b/runtime/onert/backend/acl_common/AclFunction.h
@@ -19,7 +19,6 @@
 
 #include <exec/IFunction.h>
 #include <arm_compute/runtime/IFunction.h>
-#include <arm_compute/runtime/CL/CLScheduler.h>
 #include <memory>
 
 namespace onert
@@ -55,11 +54,7 @@ public:
   using AclFunction::AclFunction;
 
 public:
-  void runSync() final
-  {
-    run();
-    arm_compute::CLScheduler::get().sync();
-  }
+  void runSync() final { run(); }
 };
 
 } // namespace acl_common

--- a/runtime/onert/core/include/backend/IConfig.h
+++ b/runtime/onert/core/include/backend/IConfig.h
@@ -42,6 +42,8 @@ struct IConfig
   virtual bool supportDynamicTensor() = 0;
   virtual bool supportFP16() = 0;
 
+  virtual void sync() const {}
+
   // Timer is used for backend profiling. In case of default (nullptr) timer profiler won't work.
   virtual std::unique_ptr<util::ITimer> timer() { return nullptr; }
 };

--- a/runtime/onert/core/include/exec/FunctionSequence.h
+++ b/runtime/onert/core/include/exec/FunctionSequence.h
@@ -64,6 +64,14 @@ public:
 
   void iterate(const std::function<void(IFunction &)> &fn);
 
+  template <typename T, typename... Args> void wrap(Args &&... args)
+  {
+    for (auto &function : _functions)
+    {
+      function = std::make_unique<T>(std::move(function), args...);
+    }
+  }
+
 protected:
   std::vector<std::unique_ptr<IFunction>> _functions;
 };

--- a/runtime/onert/core/src/compiler/ExecutorFactory.cc
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.cc
@@ -36,6 +36,44 @@
 
 namespace onert
 {
+namespace
+{
+
+class SyncFunction final : public exec::IFunction
+{
+public:
+  virtual ~SyncFunction() = default;
+  SyncFunction(std::unique_ptr<exec::IFunction> fn, const std::shared_ptr<backend::IConfig> config)
+      : _fn{std::move(fn)}, _config{config}
+  {
+    assert(_fn);
+    assert(_config);
+  }
+
+  void run() override
+  {
+    _fn->run();
+    _config->sync();
+  }
+
+  void runSync() override
+  {
+    _fn->run();
+    _config->sync();
+  }
+
+  void prepare() override { _fn->prepare(); }
+
+private:
+  std::unique_ptr<exec::IFunction> _fn;
+  std::shared_ptr<backend::IConfig> _config;
+};
+
+} // namespace
+} // namespace onert
+
+namespace onert
+{
 namespace compiler
 {
 
@@ -214,6 +252,10 @@ ExecutorFactory::createLinearExecutor(std::unique_ptr<ir::LoweredGraph> lowered_
       cf_kernel_gen->setExecutorMap(executor_map);
     }
     auto fn_seq = kernel_gen->generate(op_seq);
+    if (options.he_profiling_mode)
+    {
+      fn_seq->wrap<SyncFunction>(lower_info->backend()->config());
+    }
     builder.append(op_seq_index, {&op_seq, lower_info, std::move(fn_seq)});
   });
 
@@ -313,6 +355,10 @@ exec::IExecutor *ExecutorFactory::createDataflowExecutor(
       cf_kernel_gen->setExecutorMap(executor_map);
     }
     auto fn_seq = kernel_gen->generate(op_seq);
+    if (options.he_profiling_mode)
+    {
+      fn_seq->wrap<SyncFunction>(lower_info->backend()->config());
+    }
     builder.append(op_seq_index, {&op_seq, lower_info, std::move(fn_seq)});
   });
 
@@ -365,7 +411,6 @@ exec::IExecutor *ExecutorFactory::createDataflowExecutor(
       std::unique_ptr<exec::IExecutionObserver> obs =
           std::make_unique<exec::ProfileObserver>(et, dataflow_exec->graph());
       dataflow_exec->addObserver(std::move(obs));
-      dataflow_exec->setProfilingMode(true);
     }
     exec = dataflow_exec;
   }

--- a/runtime/onert/core/src/exec/DataflowExecutor.cc
+++ b/runtime/onert/core/src/exec/DataflowExecutor.cc
@@ -80,8 +80,7 @@ bool DataflowExecutor::noWaitingJobs()
 DataflowExecutor::DataflowExecutor(std::unique_ptr<ir::LoweredGraph> lowered_graph,
                                    const backend::TensorBuilderSet &tensor_builders,
                                    compiler::CodeMap &&code_map)
-    : ExecutorBase{std::move(lowered_graph), tensor_builders}, _code_map{std::move(code_map)},
-      _profiling{false}
+    : ExecutorBase{std::move(lowered_graph), tensor_builders}, _code_map{std::move(code_map)}
 {
   VERBOSE(DataflowExecutor) << "Constructing Dataflow Executor" << std::endl;
 
@@ -155,10 +154,7 @@ void DataflowExecutor::executeImpl()
 
     _subject.notifyJobBegin(this, op_seq, backend);
 
-    if (_profiling)
-      job->fn()->runSync();
-    else
-      job->run();
+    job->run();
 
     _subject.notifyJobEnd(this, op_seq, backend);
     notify(job_index);

--- a/runtime/onert/core/src/exec/DataflowExecutor.h
+++ b/runtime/onert/core/src/exec/DataflowExecutor.h
@@ -53,7 +53,6 @@ public:
                    const backend::TensorBuilderSet &tensor_builders, compiler::CodeMap &&code_map);
 
   void executeImpl() override;
-  void setProfilingMode(bool profiling) { _profiling = profiling; }
 
 protected:
   int64_t calculateRank(const std::vector<ir::OperationIndex> &operations);
@@ -87,7 +86,6 @@ protected:
 
   /// @brief Which job runs which op and function.
   std::unordered_map<uint32_t, ir::OpSequenceIndex> _job_to_op_seq;
-  bool _profiling;
 };
 
 } // namespace exec


### PR DESCRIPTION
Remove `exec::IFunction::runSync` so we don't need to implement
`runSync` for all functions. Instead, make the compiler to wrap all
functions with `SyncFunction`.

- Do not use `exec::IFunction::runSync`
- Introduce `exec::backend::IConfig::sync`
- Wrap all individual functions with `SyncFunction` during compilation

`exec::IFunction::runSync` will be removed after this.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>