### PR TITLE
[TensorFlowLiteRecipes] Added Reduce Min to Tensorflow Lite Recipes

### DIFF
--- a/res/TensorFlowLiteRecipes/ReduceMin_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/ReduceMin_000/test.recipe
@@ -1,0 +1,27 @@
+operand {
+  name: "ifm"
+  type: FLOAT32
+  shape { dim: 1 dim: 8 dim: 8 dim: 4 }
+}
+operand {
+  name: "axis"
+  type: INT32
+  shape { dim: 1 }
+  filler { tag: "explicit" arg: "-1" }
+}
+operand {
+  name: "ofm"
+  type: FLOAT32
+  shape { dim: 1 dim: 8 dim: 8 dim: 1 }
+}
+operation {
+  type: "ReduceMin"
+  reduce_min_options {
+    keep_dims: true
+  }
+  input: "ifm"
+  input: "axis"
+  output: "ofm"
+}
+input: "ifm"
+output: "ofm"


### PR DESCRIPTION
Added files to support Reduce min OP in Tensorflow Lite Recipes. Ref #1651

ONE-DCO-1.0-Signed-off-by: Sunchit Sharma <sun.sharma@samsung.com>