### PR TITLE
[onert] unify hasUnknownDims and haveUnspecifiedDim

### DIFF
--- a/runtime/onert/core/include/ir/Shape.h
+++ b/runtime/onert/core/include/ir/Shape.h
@@ -36,7 +36,7 @@ using FeatureShape = nnfw::misc::feature::Shape;
 struct Shape
 {
 public:
-  static const int32_t UNSPECIFIED_DIM = -1;
+  static int32_t const UNSPECIFIED_DIM;
 
   Shape() = default;
 
@@ -83,13 +83,15 @@ public:
   void extendRank(int to_rank);
 
   /**
-   * @brief Check if shape has unknown dim (-1)
+   * @brief Find out if any dimension is unspecified. If the rank is not specified, it returns
+   * false.
+   * \see https://developer.android.com/ndk/reference/struct/a-neural-networks-operand-type
    * @note  base_loader set dim to -1 when there is unknown dim in input tensor
    */
-  bool hasUnknownDim() const
+  bool hasUnspecifiedDims() const
   {
-    constexpr int32_t UNKNOWN_DIM = -1;
-    return (std::find(_dimensions.begin(), _dimensions.end(), UNKNOWN_DIM) != _dimensions.end());
+    return (std::find(_dimensions.begin(), _dimensions.end(), UNSPECIFIED_DIM) !=
+            _dimensions.end());
   }
 
 private:
@@ -107,12 +109,6 @@ Shape permuteShape(const Shape &shape, Layout frontend_layout, Layout backend_la
 * \see https://developer.android.com/ndk/reference/struct/a-neural-networks-operand-type
 */
 inline bool rankMaybeUnspecified(const ir::Shape &shape) { return (shape.rank() == 0); }
-
-/**
-* @brief Find out if any dimension is unspecified. If the rank is not specified, it returns false.
-* \see https://developer.android.com/ndk/reference/struct/a-neural-networks-operand-type
-*/
-bool haveUnspecifiedDims(const ir::Shape &shape);
 
 } // namespace ir
 } // namespace onert

--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -126,7 +126,7 @@ void setInputToDynamicTensor(ir::Graph &subgraph)
   for (auto input_ind : input_inds)
   {
     auto &input = subgraph.operands().at(input_ind);
-    if (input.info().shape().hasUnknownDim())
+    if (input.info().shape().hasUnspecifiedDims())
       input.info().setDynamic();
   }
 }

--- a/runtime/onert/core/src/ir/Shape.cc
+++ b/runtime/onert/core/src/ir/Shape.cc
@@ -26,6 +26,8 @@ namespace onert
 namespace ir
 {
 
+int32_t const Shape::UNSPECIFIED_DIM = -1;
+
 FeatureShape Shape::asFeature(Layout layout) const
 {
   assert(rank() == 4);
@@ -99,14 +101,6 @@ Shape permuteShape(const Shape &shape, Layout frontend_layout, Layout backend_la
     backend_shape.dim(3) = shape.dim(1);
   }
   return backend_shape;
-}
-
-bool haveUnspecifiedDims(const ir::Shape &shape)
-{
-  for (int n = 0; n < shape.rank(); n++)
-    if (shape.dim(n) == Shape::UNSPECIFIED_DIM)
-      return true;
-  return false;
 }
 
 } // namespace ir

--- a/runtime/onert/frontend/nnapi/execution.cc
+++ b/runtime/onert/frontend/nnapi/execution.cc
@@ -96,7 +96,7 @@ int ANeuralNetworksExecution_setInput(ANeuralNetworksExecution *execution, int32
   // LSTM operation's some inputs can be optional input
   if ((buffer == nullptr) && (length == 0))
   {
-    if (execution->haveUnspecifiedDims(operand_index))
+    if (execution->hasUnspecifiedDims(operand_index))
     {
       return ANEURALNETWORKS_NO_ERROR;
     }
@@ -131,7 +131,7 @@ int ANeuralNetworksExecution_setInput(ANeuralNetworksExecution *execution, int32
   }
   else
   {
-    if (execution->haveUnspecifiedDims(operand_index))
+    if (execution->hasUnspecifiedDims(operand_index))
     {
       VERBOSE(NNAPI::Execution) << "setInput: Unspecified dimension value" << std::endl;
       return ANEURALNETWORKS_BAD_DATA;
@@ -208,7 +208,7 @@ int ANeuralNetworksExecution_setOutput(ANeuralNetworksExecution *execution, int3
   }
   else
   {
-    if (execution->haveUnspecifiedDims(operand_index))
+    if (execution->hasUnspecifiedDims(operand_index))
     {
       VERBOSE(NNAPI::Execution) << "setOutput: Unspecified dimension value" << std::endl;
       return ANEURALNETWORKS_BAD_DATA;
@@ -323,7 +323,7 @@ int ANeuralNetworksExecution_setInputFromMemory(ANeuralNetworksExecution *execut
   }
   else
   {
-    if (execution->haveUnspecifiedDims(operand_index))
+    if (execution->hasUnspecifiedDims(operand_index))
     {
       VERBOSE(NNAPI::Execution) << "setInputFromMemory: Unspecified dimension value" << std::endl;
       return ANEURALNETWORKS_BAD_DATA;
@@ -399,7 +399,7 @@ int ANeuralNetworksExecution_setOutputFromMemory(ANeuralNetworksExecution *execu
   }
   else
   {
-    if (execution->haveUnspecifiedDims(operand_index))
+    if (execution->hasUnspecifiedDims(operand_index))
     {
       VERBOSE(NNAPI::Execution) << "setOutputFromMemory: Unspecified dimension value" << std::endl;
       return ANEURALNETWORKS_BAD_DATA;

--- a/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksExecution.cc
+++ b/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksExecution.cc
@@ -87,7 +87,7 @@ bool ANeuralNetworksExecution::compareShape(const ANeuralNetworksOperandType *ty
                                             const onert::ir::OperandIndex index) noexcept
 {
   // Passed shape should be specified
-  if (haveUnspecifiedDims(index))
+  if (hasUnspecifiedDims(index))
   {
     return false;
   }
@@ -98,11 +98,11 @@ bool ANeuralNetworksExecution::compareShape(const ANeuralNetworksOperandType *ty
   return operand_shape == shape_from_type;
 }
 
-bool ANeuralNetworksExecution::haveUnspecifiedDims(const onert::ir::OperandIndex index) noexcept
+bool ANeuralNetworksExecution::hasUnspecifiedDims(const onert::ir::OperandIndex index) noexcept
 {
   const auto operand_shape = _execution->primary_subgraph().operands().at(index).shape();
 
-  return onert::ir::haveUnspecifiedDims(operand_shape);
+  return operand_shape.hasUnspecifiedDims();
 }
 
 size_t ANeuralNetworksExecution::getOperandSize(const onert::ir::OperandIndex index) noexcept
@@ -227,7 +227,7 @@ bool ANeuralNetworksExecution::getOutputOperandRank(uint32_t index, uint32_t *ra
     }
 
     const auto shape = _execution->getOutputShape(output_index);
-    if (onert::ir::haveUnspecifiedDims(shape))
+    if (shape.hasUnspecifiedDims())
     {
       throw std::runtime_error{"Internal error: Output tensor has unspecified dims"};
     }
@@ -257,7 +257,7 @@ bool ANeuralNetworksExecution::getOutputOperandDimensions(uint32_t index, uint32
     }
 
     const auto shape = _execution->getOutputShape(output_index);
-    if (onert::ir::haveUnspecifiedDims(shape))
+    if (shape.hasUnspecifiedDims())
     {
       throw std::runtime_error{"Internal error: Output tensor has unspecified dims"};
     }

--- a/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksExecution.h
+++ b/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksExecution.h
@@ -46,7 +46,7 @@ public:
                        const onert::ir::OperandIndex index) noexcept;
   bool compareShape(const ANeuralNetworksOperandType *type,
                     const onert::ir::OperandIndex index) noexcept;
-  bool haveUnspecifiedDims(const onert::ir::OperandIndex index) noexcept;
+  bool hasUnspecifiedDims(const onert::ir::OperandIndex index) noexcept;
   size_t getOperandSize(const onert::ir::OperandIndex index) noexcept;
   const std::shared_ptr<onert::exec::Execution> instance(void) noexcept;
 

--- a/runtime/onert/test/ir/Shape.cc
+++ b/runtime/onert/test/ir/Shape.cc
@@ -30,7 +30,7 @@ TEST(ShapeTest, basic_test)
     ASSERT_EQ(shape.rank(), 3);
     ASSERT_EQ(shape.num_elements(), 6);
     ASSERT_EQ(onert::ir::rankMaybeUnspecified(shape), false);
-    ASSERT_EQ(onert::ir::haveUnspecifiedDims(shape), false);
+    ASSERT_EQ(shape.hasUnspecifiedDims(), false);
   }
   {
     onert::ir::Shape shape; // scalar or rank is unspecified
@@ -38,7 +38,7 @@ TEST(ShapeTest, basic_test)
     ASSERT_EQ(shape.rank(), 0);
     ASSERT_EQ(shape.num_elements(), 1);
     ASSERT_EQ(onert::ir::rankMaybeUnspecified(shape), true);
-    ASSERT_EQ(onert::ir::haveUnspecifiedDims(shape), false);
+    ASSERT_EQ(shape.hasUnspecifiedDims(), false);
   }
 }
 
@@ -52,7 +52,7 @@ TEST(ShapeTest, neg_basic_test)
 
     ASSERT_EQ(shape.rank(), 2);
     ASSERT_EQ(onert::ir::rankMaybeUnspecified(shape), false);
-    ASSERT_EQ(onert::ir::haveUnspecifiedDims(shape), true);
+    ASSERT_EQ(shape.hasUnspecifiedDims(), true);
     EXPECT_ANY_THROW(shape.num_elements());
   }
 }


### PR DESCRIPTION
Shape has two functions which have same implementation with different name.
It unifies them to `hasUnspecifiedDims()`.

Also, `num_elements()` throws runtime error when it meets dim = 0,
as well as unspecified (-1).

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>