### PR TITLE
[onert] Change implementation of Event Recorder

### DIFF
--- a/runtime/libs/misc/include/misc/EventRecorder.h
+++ b/runtime/libs/misc/include/misc/EventRecorder.h
@@ -22,7 +22,7 @@
 #include <mutex>
 
 #include <ostream>
-#include <sstream>
+#include <vector>
 
 struct Event
 {
@@ -57,12 +57,13 @@ public:
   void emit(const CounterEvent &evt);
 
 public:
-  bool empty() { return _ss.str().empty(); }
+  bool empty() { return _duration_events.empty() && _counter_events.empty(); }
   void writeToFile(std::ostream &os);
 
 private:
   std::mutex _mu;
-  std::stringstream _ss;
+  std::vector<DurationEvent> _duration_events;
+  std::vector<CounterEvent> _counter_events;
 };
 
 #endif // __EVENT_RECORDER_H__

--- a/runtime/libs/misc/src/EventRecorder.cpp
+++ b/runtime/libs/misc/src/EventRecorder.cpp
@@ -111,14 +111,14 @@ void EventRecorder::emit(const DurationEvent &evt)
 {
   std::lock_guard<std::mutex> lock{_mu};
 
-  _ss << "    " << object(evt) << ",\n";
+  _duration_events.push_back(evt);
 }
 
 void EventRecorder::emit(const CounterEvent &evt)
 {
   std::lock_guard<std::mutex> lock{_mu};
 
-  _ss << "    " << object(evt) << ",\n";
+  _counter_events.push_back(evt);
 }
 
 void EventRecorder::writeToFile(std::ostream &os)
@@ -128,7 +128,15 @@ void EventRecorder::writeToFile(std::ostream &os)
   os << "{\n";
   os << "  " << quote("traceEvents") << ": [\n";
 
-  os << _ss.str();
+  for (auto &evt : _duration_events)
+  {
+    os << "    " << object(evt) << ",\n";
+  }
+
+  for (auto &evt : _counter_events)
+  {
+    os << "    " << object(evt) << ",\n";
+  }
 
   os << "    { }\n";
   os << "  ]\n";


### PR DESCRIPTION
Do not convert it to string, save it as structured data and convert it
to string when it is written in a file. There are two advantages.

- Reduce profiling overhead between each OpSequence
  (Approximately 350us to 85us)
- Stored data can be expressed in another format (#1688)

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>