### PR TITLE
[nnfwapi] Implement `set_input_tensorinfo`

### DIFF
--- a/runtime/onert/api/src/nnfw_api.cc
+++ b/runtime/onert/api/src/nnfw_api.cc
@@ -260,6 +260,13 @@ NNFW_STATUS nnfw_apply_tensorinfo(nnfw_session *session, uint32_t index,
   return session->apply_tensorinfo(index, tensor_info);
 }
 
+NNFW_STATUS nnfw_set_input_tensorinfo(nnfw_session *session, uint32_t index,
+                                      const nnfw_tensorinfo *tensor_info)
+{
+  NNFW_RETURN_ERROR_IF_NULL(session);
+  return session->set_input_tensorinfo(index, tensor_info);
+}
+
 /*
  * Set available backends
  *

--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -430,6 +430,12 @@ NNFW_STATUS nnfw_session::apply_tensorinfo(uint32_t index, nnfw_tensorinfo ti)
   return NNFW_STATUS_NO_ERROR;
 }
 
+NNFW_STATUS nnfw_session::set_input_tensorinfo(uint32_t index, const nnfw_tensorinfo *ti)
+{
+  nnfw_tensorinfo ti_copy = *ti;
+  return apply_tensorinfo(index, ti_copy);
+}
+
 NNFW_STATUS nnfw_session::input_tensorinfo(uint32_t index, nnfw_tensorinfo *ti)
 {
   try

--- a/runtime/onert/api/src/nnfw_api_internal.h
+++ b/runtime/onert/api/src/nnfw_api_internal.h
@@ -76,7 +76,8 @@ public:
   NNFW_STATUS set_input_layout(uint32_t index, NNFW_LAYOUT layout);
   NNFW_STATUS set_output_layout(uint32_t index, NNFW_LAYOUT layout);
 
-  NNFW_STATUS apply_tensorinfo(uint32_t index, nnfw_tensorinfo ti);
+  NNFW_STATUS apply_tensorinfo(uint32_t index, nnfw_tensorinfo ti); // Will be deprecated
+  NNFW_STATUS set_input_tensorinfo(uint32_t index, const nnfw_tensorinfo *ti);
 
   NNFW_STATUS input_tensorinfo(uint32_t index, nnfw_tensorinfo *ti);
   NNFW_STATUS output_tensorinfo(uint32_t index, nnfw_tensorinfo *ti);


### PR DESCRIPTION
Implement `nnfw_set_input_tensorinfo` which is just redirecting to
`nnfw_apply_tensorinfo`.

Part of #1728

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>