### PR TITLE
[onert] Remove `IFunction::runSync`

### DIFF
--- a/runtime/onert/api/src/CustomKernel.h
+++ b/runtime/onert/api/src/CustomKernel.h
@@ -50,7 +50,6 @@ public:
   virtual void configure(backend::custom::CustomKernelConfigParams &&inParams);
 
   void run() override;
-  void runSync() override { run(); }
 };
 
 } // namespace custom

--- a/runtime/onert/backend/acl_common/AclFunction.h
+++ b/runtime/onert/backend/acl_common/AclFunction.h
@@ -41,7 +41,6 @@ public:
 
 public:
   void run() override { _func->run(); }
-  void runSync() override { run(); }
   void prepare() override { _func->prepare(); }
 
 private:
@@ -52,9 +51,6 @@ class AclClFunction : public AclFunction
 {
 public:
   using AclFunction::AclFunction;
-
-public:
-  void runSync() final { run(); }
 };
 
 } // namespace acl_common

--- a/runtime/onert/backend/cpu/ops/AbsLayer.h
+++ b/runtime/onert/backend/cpu/ops/AbsLayer.h
@@ -43,12 +43,6 @@ public:
   void configure(const Tensor *input, Tensor *output);
 
   void run();
-  void runSync()
-  {
-    // this abstract method is used just for profiling and called for
-    // backend::acl_common::AclFunction
-    run();
-  }
 
 private:
   const Tensor *_input;

--- a/runtime/onert/backend/cpu/ops/AddLayer.h
+++ b/runtime/onert/backend/cpu/ops/AddLayer.h
@@ -48,12 +48,6 @@ public:
                  Tensor *output);
 
   void run();
-  void runSync()
-  {
-    // this abstract method is used just for profiling and called for
-    // backend::acl_common::AclFunction
-    run();
-  }
 
 private:
   const Tensor *_lhs;

--- a/runtime/onert/backend/cpu/ops/ArgMinMaxLayer.h
+++ b/runtime/onert/backend/cpu/ops/ArgMinMaxLayer.h
@@ -39,12 +39,6 @@ public:
   void configure(const Tensor *indices, Tensor *output, int32_t axis, bool is_arg_max);
 
   void run();
-  void runSync()
-  {
-    // this abstract method is used just for profiling and called for
-    // backend::acl_common::AclFunction
-    run();
-  }
 
 private:
   const Tensor *_input;

--- a/runtime/onert/backend/cpu/ops/AvgPoolLayer.h
+++ b/runtime/onert/backend/cpu/ops/AvgPoolLayer.h
@@ -48,12 +48,6 @@ public:
                  const ir::Activation activation, Tensor *output);
 
   void run();
-  void runSync()
-  {
-    // this abstract method is used just for profiling and called for
-    // backend::acl_common::AclFunction
-    run();
-  }
 
 private:
   const Tensor *_input;

--- a/runtime/onert/backend/cpu/ops/CastLayer.h
+++ b/runtime/onert/backend/cpu/ops/CastLayer.h
@@ -43,12 +43,6 @@ public:
   void configure(const Tensor *input, Tensor *output);
 
   void run();
-  void runSync()
-  {
-    // this abstract method is used just for profiling and called for
-    // backend::acl_common::AclFunction
-    run();
-  }
 
 private:
   const Tensor *_input;

--- a/runtime/onert/backend/cpu/ops/CompareLayer.h
+++ b/runtime/onert/backend/cpu/ops/CompareLayer.h
@@ -43,12 +43,6 @@ public:
                  const ir::operation::Comparison::ComparisonType op_type, Tensor *output);
 
   void run();
-  void runSync()
-  {
-    // this abstract method is used just for profiling and called for
-    // backend::acl_common::AclFunction
-    run();
-  }
 
 private:
   const Tensor *_lhs;

--- a/runtime/onert/backend/cpu/ops/ConcatLayer.h
+++ b/runtime/onert/backend/cpu/ops/ConcatLayer.h
@@ -43,12 +43,6 @@ public:
   void configure(const std::vector<const Tensor *> &inputs, int32_t axis, Tensor *output);
 
   void run();
-  void runSync()
-  {
-    // this abstract method is used just for profiling and called for
-    // backend::acl_common::AclFunction
-    run();
-  }
 
 private:
   std::vector<const Tensor *> _inputs;

--- a/runtime/onert/backend/cpu/ops/ConvolutionLayer.h
+++ b/runtime/onert/backend/cpu/ops/ConvolutionLayer.h
@@ -59,12 +59,6 @@ public:
                  const ir::Activation activation, Tensor *output);
 
   void run();
-  void runSync()
-  {
-    // this abstract method is used just for profiling and called for
-    // backend::acl_common::AclFunction
-    run();
-  }
 
 private:
   const Tensor *_input;

--- a/runtime/onert/backend/cpu/ops/CosLayer.h
+++ b/runtime/onert/backend/cpu/ops/CosLayer.h
@@ -37,12 +37,6 @@ public:
   void configure(const Tensor *input, Tensor *output);
 
   void run();
-  void runSync()
-  {
-    // this abstract method is used just for profiling and called for
-    // backend::acl_common::AclFunction
-    run();
-  }
 
 private:
   void cosFloat32();

--- a/runtime/onert/backend/cpu/ops/DepthwiseConvolutionLayer.h
+++ b/runtime/onert/backend/cpu/ops/DepthwiseConvolutionLayer.h
@@ -47,12 +47,6 @@ public:
                  const uint32_t multiplier, const ir::Activation activation, Tensor *output);
 
   void run();
-  void runSync()
-  {
-    // this abstract method is used just for profiling and called for
-    // backend::acl_common::AclFunction
-    run();
-  }
 
 private:
   const Tensor *_input;

--- a/runtime/onert/backend/cpu/ops/DivLayer.h
+++ b/runtime/onert/backend/cpu/ops/DivLayer.h
@@ -48,12 +48,6 @@ public:
                  Tensor *output);
 
   void run();
-  void runSync()
-  {
-    // this abstract method is used just for profiling and called for
-    // backend::acl_common::AclFunction
-    run();
-  }
 
 private:
   const Tensor *_lhs;

--- a/runtime/onert/backend/cpu/ops/ExpLayer.h
+++ b/runtime/onert/backend/cpu/ops/ExpLayer.h
@@ -43,12 +43,6 @@ public:
   void configure(const Tensor *input, Tensor *output);
 
   void run();
-  void runSync()
-  {
-    // this abstract method is used just for profiling and called for
-    // backend::acl_common::AclFunction
-    run();
-  }
 
 private:
   const Tensor *_input;

--- a/runtime/onert/backend/cpu/ops/ExpandDimsLayer.h
+++ b/runtime/onert/backend/cpu/ops/ExpandDimsLayer.h
@@ -39,12 +39,6 @@ public:
   void configure(const Tensor *input, const Tensor *axis, Tensor *output);
 
   void run();
-  void runSync()
-  {
-    // this abstract method is used just for profiling and called for
-    // backend::acl_common::AclFunction
-    run();
-  }
 
 private:
   const Tensor *_input;

--- a/runtime/onert/backend/cpu/ops/FillLayer.h
+++ b/runtime/onert/backend/cpu/ops/FillLayer.h
@@ -38,12 +38,6 @@ public:
   void configure(const Tensor *input, const Tensor *value, Tensor *output);
 
   void run();
-  void runSync()
-  {
-    // this abstract method is used just for profiling and called for
-    // backend::acl_common::AclFunction
-    run();
-  }
 
 private:
   const Tensor *_input;

--- a/runtime/onert/backend/cpu/ops/FullyConnectedLayer.h
+++ b/runtime/onert/backend/cpu/ops/FullyConnectedLayer.h
@@ -56,12 +56,6 @@ public:
                  ir::Activation activation, Tensor *output);
 
   void run();
-  void runSync()
-  {
-    // this abstract method is used just for profiling and called for
-    // backend::acl_common::AclFunction
-    run();
-  }
 
 private:
   const Tensor *_input;

--- a/runtime/onert/backend/cpu/ops/GatherLayer.h
+++ b/runtime/onert/backend/cpu/ops/GatherLayer.h
@@ -42,12 +42,6 @@ public:
   void configure(const Tensor *input, const Tensor *indices, Tensor *output, int32_t axis);
 
   void run();
-  void runSync()
-  {
-    // this abstract method is used just for profiling and called for
-    // backend::acl_common::AclFunction
-    run();
-  }
 
 private:
   const Tensor *_input;

--- a/runtime/onert/backend/cpu/ops/LogLayer.h
+++ b/runtime/onert/backend/cpu/ops/LogLayer.h
@@ -43,12 +43,6 @@ public:
   void configure(const Tensor *input, Tensor *output);
 
   void run();
-  void runSync()
-  {
-    // this abstract method is used just for profiling and called for
-    // backend::acl_common::AclFunction
-    run();
-  }
 
 private:
   const Tensor *_input;

--- a/runtime/onert/backend/cpu/ops/LogicalNotLayer.h
+++ b/runtime/onert/backend/cpu/ops/LogicalNotLayer.h
@@ -39,12 +39,6 @@ public:
   void configure(const Tensor *input, Tensor *output);
 
   void run();
-  void runSync()
-  {
-    // this abstract method is used just for profiling and called for
-    // backend::acl_common::AclFunction
-    run();
-  }
 
 private:
   void logicalNotBool8();

--- a/runtime/onert/backend/cpu/ops/LogicalOrLayer.h
+++ b/runtime/onert/backend/cpu/ops/LogicalOrLayer.h
@@ -41,7 +41,6 @@ public:
   void configure(const Tensor *_lhs, const Tensor *_rhs, Tensor *output);
 
   void run();
-  void runSync() { run(); }
 
 private:
   void lorBool8();

--- a/runtime/onert/backend/cpu/ops/LogisticLayer.h
+++ b/runtime/onert/backend/cpu/ops/LogisticLayer.h
@@ -43,12 +43,6 @@ public:
   void configure(const Tensor *input, Tensor *output);
 
   void run();
-  void runSync()
-  {
-    // this abstract method is used just for profiling and called for
-    // backend::acl_common::AclFunction
-    run();
-  }
 
 private:
   const Tensor *_input;

--- a/runtime/onert/backend/cpu/ops/MaxLayer.h
+++ b/runtime/onert/backend/cpu/ops/MaxLayer.h
@@ -46,12 +46,6 @@ public:
   void configure(const Tensor *lhs, const Tensor *rhs, Tensor *output);
 
   void run();
-  void runSync()
-  {
-    // this abstract method is used just for profiling and called for
-    // backend::acl_common::AclFunction
-    run();
-  }
 
 private:
   const Tensor *_lhs;

--- a/runtime/onert/backend/cpu/ops/MaxPoolLayer.h
+++ b/runtime/onert/backend/cpu/ops/MaxPoolLayer.h
@@ -48,12 +48,6 @@ public:
                  const ir::Activation activation, Tensor *output);
 
   void run();
-  void runSync()
-  {
-    // this abstract method is used just for profiling and called for
-    // backend::acl_common::AclFunction
-    run();
-  }
 
 private:
   const Tensor *_input;

--- a/runtime/onert/backend/cpu/ops/MeanLayer.h
+++ b/runtime/onert/backend/cpu/ops/MeanLayer.h
@@ -43,12 +43,6 @@ public:
   void configure(const Tensor *input, Tensor *output, const std::vector<int> &axes, bool keep_dims);
 
   void run();
-  void runSync()
-  {
-    // this abstract method is used just for profiling and called for
-    // backend::acl_common::AclFunction
-    run();
-  }
 
 private:
   const Tensor *_input;

--- a/runtime/onert/backend/cpu/ops/MinLayer.h
+++ b/runtime/onert/backend/cpu/ops/MinLayer.h
@@ -46,12 +46,6 @@ public:
   void configure(const Tensor *lhs, const Tensor *rhs, Tensor *output);
 
   void run();
-  void runSync()
-  {
-    // this abstract method is used just for profiling and called for
-    // backend::acl_common::AclFunction
-    run();
-  }
 
 private:
   const Tensor *_lhs;

--- a/runtime/onert/backend/cpu/ops/MulLayer.h
+++ b/runtime/onert/backend/cpu/ops/MulLayer.h
@@ -48,12 +48,6 @@ public:
                  Tensor *output);
 
   void run();
-  void runSync()
-  {
-    // this abstract method is used just for profiling and called for
-    // backend::acl_common::AclFunction
-    run();
-  }
 
 private:
   const Tensor *_lhs;

--- a/runtime/onert/backend/cpu/ops/NegLayer.h
+++ b/runtime/onert/backend/cpu/ops/NegLayer.h
@@ -43,12 +43,6 @@ public:
   void configure(const Tensor *input, Tensor *output);
 
   void run();
-  void runSync()
-  {
-    // this abstract method is used just for profiling and called for
-    // backend::acl_common::AclFunction
-    run();
-  }
 
 private:
   const Tensor *_input;

--- a/runtime/onert/backend/cpu/ops/OneHotLayer.h
+++ b/runtime/onert/backend/cpu/ops/OneHotLayer.h
@@ -48,12 +48,6 @@ public:
                  float off_value, int32_t axis);
 
   void run();
-  void runSync()
-  {
-    // this abstract method is used just for profiling and called for
-    // backend::acl_common::AclFunction
-    run();
-  }
 
 private:
   const Tensor *_indices;

--- a/runtime/onert/backend/cpu/ops/PackLayer.h
+++ b/runtime/onert/backend/cpu/ops/PackLayer.h
@@ -43,12 +43,6 @@ public:
   void configure(const std::vector<const Tensor *> &inputs, int32_t axis, Tensor *output);
 
   void run();
-  void runSync()
-  {
-    // this abstract method is used just for profiling and called for
-    // backend::acl_common::AclFunction
-    run();
-  }
 
 private:
   std::vector<const Tensor *> _inputs;

--- a/runtime/onert/backend/cpu/ops/PadLayer.h
+++ b/runtime/onert/backend/cpu/ops/PadLayer.h
@@ -47,12 +47,6 @@ public:
                  uint8_t *constantValueData = nullptr);
 
   void run();
-  void runSync()
-  {
-    // this abstract method is used just for profiling and called for
-    // backend::acl_common::AclFunction
-    run();
-  }
 
 private:
   const Tensor *_input;

--- a/runtime/onert/backend/cpu/ops/PowLayer.h
+++ b/runtime/onert/backend/cpu/ops/PowLayer.h
@@ -46,12 +46,6 @@ public:
                  Tensor *output);
 
   void run();
-  void runSync()
-  {
-    // this abstract method is used just for profiling and called for
-    // backend::acl_common::AclFunction
-    run();
-  }
 
 private:
   const Tensor *_lhs;

--- a/runtime/onert/backend/cpu/ops/RangeLayer.h
+++ b/runtime/onert/backend/cpu/ops/RangeLayer.h
@@ -37,7 +37,6 @@ public:
   void configure(const Tensor *start, const Tensor *limit, const Tensor *delta, Tensor *output);
 
   void run();
-  void runSync() { run(); }
 
 private:
   const Tensor *_start;

--- a/runtime/onert/backend/cpu/ops/ReLULayer.h
+++ b/runtime/onert/backend/cpu/ops/ReLULayer.h
@@ -43,12 +43,6 @@ public:
   void configure(const Tensor *input, Tensor *output);
 
   void run();
-  void runSync()
-  {
-    // this abstract method is used just for profiling and called for
-    // backend::acl_common::AclFunction
-    run();
-  }
 
 private:
   const Tensor *_input;

--- a/runtime/onert/backend/cpu/ops/ReduceLayer.h
+++ b/runtime/onert/backend/cpu/ops/ReduceLayer.h
@@ -60,12 +60,6 @@ public:
                  const std::vector<int> &axes, bool keep_dims);
 
   void run();
-  void runSync()
-  {
-    // this abstract method is used just for profiling and called for
-    // backend::acl_common::AclFunction
-    run();
-  }
 
 private:
   const Tensor *_input;

--- a/runtime/onert/backend/cpu/ops/ReshapeLayer.h
+++ b/runtime/onert/backend/cpu/ops/ReshapeLayer.h
@@ -41,12 +41,6 @@ public:
   void configure(const Tensor *input, const Tensor *shape, Tensor *output);
 
   void run();
-  void runSync()
-  {
-    // this abstract method is used just for profiling and called for
-    // backend::acl_common::AclFunction
-    run();
-  }
 
 private:
   const Tensor *_input;

--- a/runtime/onert/backend/cpu/ops/ReverseLayer.h
+++ b/runtime/onert/backend/cpu/ops/ReverseLayer.h
@@ -42,12 +42,6 @@ public:
   void configure(const Tensor *input, const Tensor *axis, Tensor *output);
 
   void run();
-  void runSync()
-  {
-    // this abstract method is used just for profiling and called for
-    // backend::acl_common::AclFunction
-    run();
-  }
 
 private:
   const Tensor *_input;

--- a/runtime/onert/backend/cpu/ops/RoundLayer.h
+++ b/runtime/onert/backend/cpu/ops/RoundLayer.h
@@ -37,12 +37,6 @@ public:
   void configure(const Tensor *input, Tensor *output);
 
   void run();
-  void runSync()
-  {
-    // this abstract method is used just for profiling and called for
-    // backend::acl_common::AclFunction
-    run();
-  }
 
 private:
   void roundFloat32();

--- a/runtime/onert/backend/cpu/ops/RsqrtLayer.h
+++ b/runtime/onert/backend/cpu/ops/RsqrtLayer.h
@@ -37,12 +37,6 @@ public:
   void configure(const Tensor *input, Tensor *output);
 
   void run();
-  void runSync()
-  {
-    // this abstract method is used just for profiling and called for
-    // backend::acl_common::AclFunction
-    run();
-  }
 
 private:
   void rsqrtFloat32();

--- a/runtime/onert/backend/cpu/ops/SelectLayer.h
+++ b/runtime/onert/backend/cpu/ops/SelectLayer.h
@@ -40,12 +40,6 @@ public:
                  Tensor *output);
 
   void run();
-  void runSync()
-  {
-    // this abstract method is used just for profiling and called for
-    // backend::acl_common::AclFunction
-    run();
-  }
 
 private:
   const Tensor *_cond;

--- a/runtime/onert/backend/cpu/ops/ShapeLayer.h
+++ b/runtime/onert/backend/cpu/ops/ShapeLayer.h
@@ -41,12 +41,6 @@ public:
   void configure(const Tensor *input, Tensor *output);
 
   void run();
-  void runSync()
-  {
-    // this abstract method is used just for profiling and called for
-    // backend::acl_common::AclFunction
-    run();
-  }
 
 private:
   const Tensor *_input;

--- a/runtime/onert/backend/cpu/ops/SinLayer.h
+++ b/runtime/onert/backend/cpu/ops/SinLayer.h
@@ -37,12 +37,6 @@ public:
   void configure(const Tensor *input, Tensor *output);
 
   void run();
-  void runSync()
-  {
-    // this abstract method is used just for profiling and called for
-    // backend::acl_common::AclFunction
-    run();
-  }
 
 private:
   void sinFloat32();

--- a/runtime/onert/backend/cpu/ops/SliceLayer.h
+++ b/runtime/onert/backend/cpu/ops/SliceLayer.h
@@ -39,12 +39,6 @@ public:
   void configure(const Tensor *input, const Tensor *begin, const Tensor *size, Tensor *output);
 
   void run();
-  void runSync()
-  {
-    // this abstract method is used just for profiling and called for
-    // backend::acl_common::AclFunction
-    run();
-  }
 
 private:
   void sliceFloat32();

--- a/runtime/onert/backend/cpu/ops/SoftMaxLayer.h
+++ b/runtime/onert/backend/cpu/ops/SoftMaxLayer.h
@@ -43,12 +43,6 @@ public:
   void configure(const Tensor *input, const float beta, Tensor *output);
 
   void run();
-  void runSync()
-  {
-    // this abstract method is used just for profiling and called for
-    // backend::acl_common::AclFunction
-    run();
-  }
 
 private:
   const Tensor *_input;

--- a/runtime/onert/backend/cpu/ops/SplitLayer.h
+++ b/runtime/onert/backend/cpu/ops/SplitLayer.h
@@ -44,12 +44,6 @@ public:
                  std::vector<Tensor *> &outputs);
 
   void run();
-  void runSync()
-  {
-    // this abstract method is used just for profiling and called for
-    // backend::acl_common::AclFunction
-    run();
-  }
 
 private:
   const Tensor *_input;

--- a/runtime/onert/backend/cpu/ops/SquaredDiffLayer.h
+++ b/runtime/onert/backend/cpu/ops/SquaredDiffLayer.h
@@ -41,12 +41,6 @@ public:
   void configure(const Tensor *input1, const Tensor *input2, Tensor *output);
 
   void run();
-  void runSync()
-  {
-    // this abstract method is used just for profiling and called for
-    // backend::acl_common::AclFunction
-    run();
-  }
 
 private:
   const Tensor *_input1;

--- a/runtime/onert/backend/cpu/ops/StridedSliceLayer.h
+++ b/runtime/onert/backend/cpu/ops/StridedSliceLayer.h
@@ -42,12 +42,6 @@ public:
                  const int32_t shrink_axis_mask, const int32_t rank);
 
   void run();
-  void runSync()
-  {
-    // this abstract method is used just for profiling and called for
-    // backend::acl_common::AclFunction
-    run();
-  }
 
 private:
   void stridedSliceFloat32();

--- a/runtime/onert/backend/cpu/ops/SubLayer.h
+++ b/runtime/onert/backend/cpu/ops/SubLayer.h
@@ -48,12 +48,6 @@ public:
                  Tensor *output);
 
   void run();
-  void runSync()
-  {
-    // this abstract method is used just for profiling and called for
-    // backend::acl_common::AclFunction
-    run();
-  }
 
 private:
   const Tensor *_lhs;

--- a/runtime/onert/backend/cpu/ops/TanhLayer.h
+++ b/runtime/onert/backend/cpu/ops/TanhLayer.h
@@ -43,12 +43,6 @@ public:
   void configure(const Tensor *input, Tensor *output);
 
   void run();
-  void runSync()
-  {
-    // this abstract method is used just for profiling and called for
-    // backend::acl_common::AclFunction
-    run();
-  }
 
 private:
   const Tensor *_input;

--- a/runtime/onert/backend/cpu/ops/TileLayer.h
+++ b/runtime/onert/backend/cpu/ops/TileLayer.h
@@ -43,12 +43,6 @@ public:
   void configure(const Tensor *input, const Tensor *_multipliers, Tensor *output);
 
   void run();
-  void runSync()
-  {
-    // this abstract method is used just for profiling and called for
-    // backend::acl_common::AclFunction
-    run();
-  }
 
 private:
   const Tensor *_input;

--- a/runtime/onert/backend/cpu/ops/TransposeLayer.h
+++ b/runtime/onert/backend/cpu/ops/TransposeLayer.h
@@ -43,7 +43,6 @@ public:
   void configure(const Tensor *input, Tensor *output, const std::vector<int> &perm, int32_t rank);
 
   void run();
-  void runSync() { run(); }
 
 private:
   const Tensor *_input;

--- a/runtime/onert/backend/cpu/ops/UnpackLayer.h
+++ b/runtime/onert/backend/cpu/ops/UnpackLayer.h
@@ -44,12 +44,6 @@ public:
                  std::vector<Tensor *> &output);
 
   void run();
-  void runSync()
-  {
-    // this abstract method is used just for profiling and called for
-    // backend::acl_common::AclFunction
-    run();
-  }
 
 private:
   const Tensor *_input;

--- a/runtime/onert/backend/cpu/ops/ZerosLikeLayer.h
+++ b/runtime/onert/backend/cpu/ops/ZerosLikeLayer.h
@@ -37,12 +37,6 @@ public:
   void configure(const Tensor *input, Tensor *output);
 
   void run();
-  void runSync()
-  {
-    // this abstract method is used just for profiling and called for
-    // backend::acl_common::AclFunction
-    run();
-  }
 
 private:
   const Tensor *_input;

--- a/runtime/onert/core/include/exec/FunctionSequence.h
+++ b/runtime/onert/core/include/exec/FunctionSequence.h
@@ -52,7 +52,6 @@ public:
   virtual ~FunctionSequence() = default;
 
   void run() override;
-  void runSync() override;
   void prepare() override;
 
   /**

--- a/runtime/onert/core/include/exec/IFunction.h
+++ b/runtime/onert/core/include/exec/IFunction.h
@@ -27,7 +27,6 @@ class IFunction
 public:
   virtual ~IFunction() = default;
   virtual void run() = 0;
-  virtual void runSync() = 0;
   virtual void prepare() {}
 };
 

--- a/runtime/onert/core/include/exec/IPermuteFunction.h
+++ b/runtime/onert/core/include/exec/IPermuteFunction.h
@@ -92,13 +92,6 @@ public:
     }
   }
 
-  virtual void runSync() override
-  {
-    // this abstract method is used just for profiling and called for
-    // backend::acl_common::AclFunction
-    run();
-  }
-
   virtual void prepare() override { optimize(); }
 
   virtual void optimize() = 0;

--- a/runtime/onert/core/include/exec/NopFunction.h
+++ b/runtime/onert/core/include/exec/NopFunction.h
@@ -40,12 +40,6 @@ public:
   {
     // DO NOTHING
   }
-  void runSync() override
-  {
-    // this abstract method is used just for profiling and called for
-    // backend::acl_common::AclFunction
-    run();
-  }
 };
 
 } // namespace exec

--- a/runtime/onert/core/src/backend/controlflow/kernel/IfLayer.h
+++ b/runtime/onert/core/src/backend/controlflow/kernel/IfLayer.h
@@ -44,14 +44,6 @@ public:
 
   void run() override;
 
-  void runSync() override
-  {
-    // TODO Optimize
-    // this abstract method is used just for profiling and called for
-    // backend::acl_common::AclFunction
-    run();
-  }
-
 private:
   const std::shared_ptr<backend::ITensor> _cond_tensor;
   const std::vector<std::shared_ptr<backend::ITensor>> _input_tensors;

--- a/runtime/onert/core/src/backend/controlflow/kernel/WhileLayer.h
+++ b/runtime/onert/core/src/backend/controlflow/kernel/WhileLayer.h
@@ -43,14 +43,6 @@ public:
 
   void run() override;
 
-  void runSync() override
-  {
-    // TODO Optimize
-    // this abstract method is used just for profiling and called for
-    // backend::acl_common::AclFunction
-    run();
-  }
-
 private:
   const ir::SubgraphIndex _cond_subg_index;
   const ir::SubgraphIndex _body_subg_index;

--- a/runtime/onert/core/src/compiler/ExecutorFactory.cc
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.cc
@@ -56,12 +56,6 @@ public:
     _config->sync();
   }
 
-  void runSync() override
-  {
-    _fn->run();
-    _config->sync();
-  }
-
   void prepare() override { _fn->prepare(); }
 
 private:

--- a/runtime/onert/core/src/exec/FunctionSequence.cc
+++ b/runtime/onert/core/src/exec/FunctionSequence.cc
@@ -35,14 +35,6 @@ void FunctionSequence::run()
   }
 }
 
-void FunctionSequence::runSync()
-{
-  for (const auto &function : _functions)
-  {
-    function->runSync();
-  }
-}
-
 void FunctionSequence::prepare()
 {
   for (const auto &function : _functions)

--- a/runtime/onert/core/src/exec/ParallelExecutor.cc
+++ b/runtime/onert/core/src/exec/ParallelExecutor.cc
@@ -42,7 +42,6 @@ public:
     _fn->run();
     _teardown();
   }
-  void runSync() override { throw("runSync is needed just for profiling in Dataflow executor"); }
 
 private:
   IFunction *_fn;


### PR DESCRIPTION
Now that we handle synchronous run in a different way since #1831, we
can remove this method.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>