### PR TITLE
[luci] Enable BatchMatMul test

### DIFF
--- a/compiler/luci/tests/test.lst
+++ b/compiler/luci/tests/test.lst
@@ -142,6 +142,7 @@ addread(Net_InstanceNorm_002)
 addread(Net_UnpackAdd_001)
 
 # from res/CircleRecipes
+addread(BatchMatMul_000)
 addread(InstanceNorm_000)
 
 addwrite(Abs_000)
@@ -288,4 +289,5 @@ addwrite(Net_InstanceNorm_002)
 addwrite(Net_UnpackAdd_001)
 
 # from res/CircleRecipes
+addwrite(BatchMatMul_000)
 addwrite(InstanceNorm_000)


### PR DESCRIPTION
This commit enables BatchMatMul test in luci

Draft : 1869
Related : #1802
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>