### PR TITLE
[onert] Move Event classes to onert from misc

### DIFF
--- a/runtime/onert/core/include/exec/ExecutionObservers.h
+++ b/runtime/onert/core/include/exec/ExecutionObservers.h
@@ -22,8 +22,8 @@
 #include "ExecTime.h"
 #include "util/ITimer.h"
 #include "IExecutor.h"
-#include "misc/EventCollector.h"
-#include "misc/EventRecorder.h"
+#include "util/EventCollector.h"
+#include "util/EventRecorder.h"
 
 namespace onert
 {

--- a/runtime/onert/core/include/util/EventCollector.h
+++ b/runtime/onert/core/include/util/EventCollector.h
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-#ifndef __EVENT_COLLECTOR_H__
-#define __EVENT_COLLECTOR_H__
+#ifndef __ONERT_UTIL_EVENT_COLLECTOR_H__
+#define __ONERT_UTIL_EVENT_COLLECTOR_H__
 
-#include "misc/EventRecorder.h"
+#include "util/EventRecorder.h"
 
 class EventCollector
 {
@@ -48,4 +48,4 @@ protected:
   EventRecorder *_rec;
 };
 
-#endif // __EVENT_COLLECTOR_H__
+#endif // __ONERT_UTIL_EVENT_COLLECTOR_H__

--- a/runtime/onert/core/include/util/EventCollectorGlobal.h
+++ b/runtime/onert/core/include/util/EventCollectorGlobal.h
@@ -17,8 +17,8 @@
 #ifndef __ONERT_UTIL_EVENT_COLLECTOR_GLOBAL_H__
 #define __ONERT_UTIL_EVENT_COLLECTOR_GLOBAL_H__
 
-#include "misc/EventRecorder.h"
-#include "misc/EventCollector.h"
+#include "util/EventRecorder.h"
+#include "util/EventCollector.h"
 
 namespace onert
 {

--- a/runtime/onert/core/include/util/EventRecorder.h
+++ b/runtime/onert/core/include/util/EventRecorder.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef __EVENT_RECORDER_H__
-#define __EVENT_RECORDER_H__
+#ifndef __ONERT_UTIL_EVENT_RECORDER_H__
+#define __ONERT_UTIL_EVENT_RECORDER_H__
 
 #include <map>
 #include <memory>
@@ -66,4 +66,4 @@ private:
   std::vector<CounterEvent> _counter_events;
 };
 
-#endif // __EVENT_RECORDER_H__
+#endif // __ONERT_UTIL_EVENT_RECORDER_H__

--- a/runtime/onert/core/src/util/EventCollector.cc
+++ b/runtime/onert/core/src/util/EventCollector.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "misc/EventCollector.h"
+#include "util/EventCollector.h"
 
 // C++ standard libraries
 #include <chrono>

--- a/runtime/onert/core/src/util/EventRecorder.cc
+++ b/runtime/onert/core/src/util/EventRecorder.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "misc/EventRecorder.h"
+#include "util/EventRecorder.h"
 
 #include <sstream>
 #include <vector>


### PR DESCRIPTION
As `EventCollector` and `EventRecorder` are used by only onert, let's
move it to `onert::util`.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>