### PR TITLE
[onert] Move StaticInferer after lineraizing graph

### DIFF
--- a/runtime/onert/core/src/compiler/ExecutorFactory.cc
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.cc
@@ -222,6 +222,15 @@ ExecutorFactory::createLinearExecutor(std::unique_ptr<ir::LoweredGraph> lowered_
    ***********************/
 
   auto order = Linear::linearize(*lowered_graph);
+
+  // Shape inference.
+  {
+    shape_inference::StaticInferer inferer(lowered_graph->graph());
+    lowered_graph->op_seqs().iterate(
+        [&](const ir::OpSequenceIndex &, const ir::OpSequence &op_seq) { inferer.infer(op_seq); });
+    inferer.dump();
+  }
+
   runTensorRegistration(lowered_graph.get(), order);
   Linear::dump(*lowered_graph, order);
   Linear::planTensors(*lowered_graph, order);
@@ -314,6 +323,15 @@ exec::IExecutor *ExecutorFactory::createDataflowExecutor(
   }
 
   auto order = Linear::linearize(*lowered_graph);
+
+  // Shape inference.
+  {
+    shape_inference::StaticInferer inferer(lowered_graph->graph());
+    lowered_graph->op_seqs().iterate(
+        [&](const ir::OpSequenceIndex &, const ir::OpSequence &op_seq) { inferer.infer(op_seq); });
+    inferer.dump();
+  }
+
   runTensorRegistration(lowered_graph.get(), order);
 
   backend::TensorBuilderSet tensor_builders;

--- a/runtime/onert/core/src/ir/LoweredGraph.cc
+++ b/runtime/onert/core/src/ir/LoweredGraph.cc
@@ -121,14 +121,6 @@ LoweredGraph::LoweredGraph(const Graph &graph, const compiler::CompilerOptions &
     _op_seqs.dump("merged and sorted operations with permutation", _graph.operations());
   }
 
-  // Shape inference.
-  {
-    shape_inference::StaticInferer inferer(_graph);
-    _op_seqs.iterate(
-        [&](const ir::OpSequenceIndex &, const ir::OpSequence &op_seq) { inferer.infer(op_seq); });
-    inferer.dump();
-  }
-
   // Graph verifications
   {
     assert(verifier::DAGChecker().verify(_graph));


### PR DESCRIPTION
This commit moves StaticInferer after lineraizing graph.

Signed-off-by: ragmani <ragmani0216@gmail.com>