### PR TITLE
[onert] Add a trace write format (SNPE benchmark)

### DIFF
--- a/runtime/onert/core/CMakeLists.txt
+++ b/runtime/onert/core/CMakeLists.txt
@@ -11,6 +11,7 @@ target_link_libraries(onert_core PRIVATE nnfw_lib_cker)
 target_link_libraries(onert_core PRIVATE nnfw_common)
 target_link_libraries(onert_core PRIVATE nnfw_coverage)
 target_link_libraries(onert_core PRIVATE dl ${LIB_PTHREAD})
+target_link_libraries(onert_core PRIVATE jsoncpp)
 target_link_libraries(onert_core INTERFACE ruy_instrumentation)
 
 if(ENVVAR_ONERT_CONFIG)

--- a/runtime/onert/core/include/util/EventRecorder.h
+++ b/runtime/onert/core/include/util/EventRecorder.h
@@ -50,6 +50,13 @@ struct CounterEvent : public Event
 class EventRecorder
 {
 public:
+  enum class WriteFormat
+  {
+    CHROME_TRACING,
+    SNPE_BENCHMARK
+  };
+
+public:
   EventRecorder() = default;
 
 public:
@@ -59,9 +66,15 @@ public:
 public:
   bool empty() { return _duration_events.empty() && _counter_events.empty(); }
   void writeToFile(std::ostream &os);
+  void setWriteFormat(WriteFormat write_format) { _write_format = write_format; }
+
+private:
+  void writeSNPEBenchmark(std::ostream &os);
+  void writeChromeTrace(std::ostream &os);
 
 private:
   std::mutex _mu;
+  WriteFormat _write_format{WriteFormat::CHROME_TRACING};
   std::vector<DurationEvent> _duration_events;
   std::vector<CounterEvent> _counter_events;
 };

--- a/runtime/onert/core/src/util/EventRecorder.cc
+++ b/runtime/onert/core/src/util/EventRecorder.cc
@@ -228,9 +228,9 @@ void EventRecorder::writeSNPEBenchmark(std::ostream &os)
       {
         auto &name = kv.first;
         auto &val = kv.second;
-        json_tid[name]["Avg_Size"] = val.sum / val.count;
-        json_tid[name]["Max_Size"] = val.max;
-        json_tid[name]["Min_Size"] = val.min;
+        json_tid[name]["Avg_Time"] = val.sum / val.count;
+        json_tid[name]["Max_Time"] = val.max;
+        json_tid[name]["Min_Time"] = val.min;
         json_tid[name]["Runtime"] = tid;
       }
     }

--- a/runtime/onert/core/src/util/EventRecorder.cc
+++ b/runtime/onert/core/src/util/EventRecorder.cc
@@ -18,6 +18,9 @@
 
 #include <sstream>
 #include <vector>
+#include <unordered_map>
+#include <json/json.h>
+#include <assert.h>
 
 namespace
 {
@@ -125,6 +128,119 @@ void EventRecorder::writeToFile(std::ostream &os)
 {
   std::lock_guard<std::mutex> lock{_mu};
 
+  switch (_write_format)
+  {
+    case WriteFormat::CHROME_TRACING:
+      writeChromeTrace(os);
+      break;
+    case WriteFormat::SNPE_BENCHMARK:
+      writeSNPEBenchmark(os);
+      break;
+    default:
+      assert(!"Invalid value");
+      break;
+  }
+}
+
+void EventRecorder::writeSNPEBenchmark(std::ostream &os)
+{
+  Json::Value root;
+  auto &exec_data = root["Execution_Data"] = Json::Value{Json::objectValue};
+
+  struct Stat
+  {
+    uint64_t sum = 0;
+    uint64_t count = 0;
+    uint64_t max = 0;
+    uint64_t min = std::numeric_limits<uint64_t>::max();
+
+    void accumulate(uint64_t val)
+    {
+      sum += val;
+      count++;
+      max = std::max(max, val);
+      min = std::min(min, val);
+    }
+  };
+
+  // Memory
+  {
+    std::unordered_map<std::string, Stat> mem_stats;
+    for (auto &evt : _counter_events)
+    {
+      auto &mem_stat = mem_stats[evt.name];
+      uint64_t val = std::stoull(evt.values["value"]);
+      mem_stat.accumulate(val);
+    }
+
+    auto &mem = exec_data["memory"] = Json::Value{Json::objectValue};
+    for (auto &kv : mem_stats)
+    {
+      auto &key = kv.first;
+      auto &val = kv.second;
+      mem[key]["Avg_Size"] = val.sum / val.count;
+      mem[key]["Max_Size"] = val.max;
+      mem[key]["Min_Size"] = val.min;
+      mem[key]["Runtime"] = "NA";
+    }
+  }
+
+  // Operation Execution Time
+  {
+    // NOTE This assumes _duration_events is sorted by "ts" ascending
+
+    // 2D keys : stats[tid][name]
+    std::unordered_map<std::string, std::unordered_map<std::string, Stat>> stats;
+    std::unordered_map<std::string, std::unordered_map<std::string, uint64_t>> begin_timestamps;
+    for (auto &evt : _duration_events)
+    {
+      auto &stat = stats[evt.tid][evt.name];
+      auto &begin_ts = begin_timestamps[evt.tid][evt.name];
+      uint64_t timestamp = std::stoull(evt.ts);
+      if (evt.ph == "B")
+      {
+        if (begin_ts != 0)
+          throw std::runtime_error{"Invalid Data"};
+        begin_ts = timestamp;
+      }
+      else if (evt.ph == "E")
+      {
+        if (begin_ts == 0 || timestamp < begin_ts)
+          throw std::runtime_error{"Invalid Data"};
+        stat.accumulate(timestamp - begin_ts);
+        begin_ts = 0;
+      }
+      else
+        throw std::runtime_error{"Invalid Data - invalid value for \"ph\" : \"" + evt.ph + "\""};
+    }
+
+    for (auto &kv : begin_timestamps)
+      for (auto &kv2 : kv.second)
+        if (kv2.second != 0)
+          throw std::runtime_error{"Invalid Data - B and E pair does not match."};
+
+    for (auto &kv : stats)
+    {
+      auto &tid = kv.first;
+      auto &map = kv.second;
+      auto &json_tid = exec_data[tid] = Json::Value{Json::objectValue};
+      for (auto &kv : map)
+      {
+        auto &name = kv.first;
+        auto &val = kv.second;
+        json_tid[name]["Avg_Size"] = val.sum / val.count;
+        json_tid[name]["Max_Size"] = val.max;
+        json_tid[name]["Min_Size"] = val.min;
+        json_tid[name]["Runtime"] = tid;
+      }
+    }
+  }
+
+  os << root;
+}
+
+void EventRecorder::writeChromeTrace(std::ostream &os)
+{
   os << "{\n";
   os << "  " << quote("traceEvents") << ": [\n";
 


### PR DESCRIPTION
- Use `jsoncpp` for writing JSON files
- Introduce SNPE Benchmark format and its writer

NOTE : There is no way to enable this from user yet.
       i.e. `setWriteFormat` is never called yet.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>