### PR TITLE
update-version script is added

### DIFF
--- a/tools/update_version/update-version
+++ b/tools/update_version/update-version
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -eu
+
+progname=$(basename "${BASH_SOURCE[0]}")
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+nnfw_root="$( cd "${script_dir%*/*/*}" && pwd )"
+
+usage() {
+  echo "Usage: $progname version"
+  echo "Update all version information"
+  echo ""
+  echo "Options:"
+  echo "    -h   show this help"
+  echo ""
+  echo "Examples:"
+  echo "    $progname 1.6.0"
+  exit 1
+}
+
+if [ $# -eq 0 ]; then
+  echo "For help, type $progname -h"
+  exit 1
+fi
+
+while getopts "ho:" OPTION; do
+case "${OPTION}" in
+    h) usage;;
+    ?) exit 1;;
+esac
+done
+
+shift $((OPTIND-1))
+
+if [ $# -ne 1 ]; then
+  echo "error: wrong argument (no argument or too many arguments)."
+  echo "For help, type $progname -h"
+  exit 1
+fi
+
+version=$1
+
+sed -i "s/^release = .*/release = \'$version\'/" ${nnfw_root}/docs/conf.py
+sed -i "s/^Version: .*/Version: $version/" ${nnfw_root}/packaging/nnfw.spec
+
+IFS=. read M m p <<< $version
+hex=$(printf '0x%08x' $(( (($M << 24)) | (($m << 8)) | $p )))
+sed -i "s/^#define NNFW_VERSION.*/#define NNFW_VERSION $hex/" ${nnfw_root}/runtime/onert/api/include/nnfw_version.h


### PR DESCRIPTION
There are several files to be updated when version is changed.
`update-version` will do it at once. For example,

$ update-version 1.7.0

It will change tizen spec, nnfw_version, doc_version.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>