### PR TITLE
[onert] Change cpu backend impl to use ITensor

### DIFF
--- a/runtime/onert/backend/cpu/KernelGenerator.cc
+++ b/runtime/onert/backend/cpu/KernelGenerator.cc
@@ -149,10 +149,10 @@ void KernelGenerator::visit(const ir::operation::Conv2D &node)
                                             ker_width, ker_height);
   const auto activation = node.param().activation;
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto ifm_alloc = _tensor_builder->at(ifm_index).get();
-  auto ker_alloc = _tensor_builder->at(ker_index).get();
-  auto bias_alloc = _tensor_builder->at(bias_index).get();
+  auto ofm_alloc = _tensor_builder->tensorAt(ofm_index).get();
+  auto ifm_alloc = _tensor_builder->tensorAt(ifm_index).get();
+  auto ker_alloc = _tensor_builder->tensorAt(ker_index).get();
+  auto bias_alloc = _tensor_builder->tensorAt(bias_index).get();
 
   auto fn = std::make_unique<ops::ConvolutionLayer>();
 
@@ -184,10 +184,10 @@ void KernelGenerator::visit(const ir::operation::DepthwiseConv2D &node)
   const auto multiplier = node.param().multiplier;
   const auto activation = node.param().activation;
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto ifm_alloc = _tensor_builder->at(ifm_index).get();
-  auto ker_alloc = _tensor_builder->at(ker_index).get();
-  auto bias_alloc = _tensor_builder->at(bias_index).get();
+  auto ofm_alloc = _tensor_builder->tensorAt(ofm_index).get();
+  auto ifm_alloc = _tensor_builder->tensorAt(ifm_index).get();
+  auto ker_alloc = _tensor_builder->tensorAt(ker_index).get();
+  auto bias_alloc = _tensor_builder->tensorAt(bias_index).get();
 
   auto fn = std::make_unique<ops::DepthwiseConvolutionLayer>();
 
@@ -213,8 +213,8 @@ void KernelGenerator::visit(const ir::operation::MaxPool2D &node)
       ir::calculatePadding(node.param().padding, ifm_shape, ofm_shape, stride, kw, kh);
   const auto activation = node.param().activation;
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto ifm_alloc = _tensor_builder->at(ifm_index).get();
+  auto ofm_alloc = _tensor_builder->tensorAt(ofm_index).get();
+  auto ifm_alloc = _tensor_builder->tensorAt(ifm_index).get();
 
   auto fn = std::make_unique<ops::MaxPoolLayer>();
 
@@ -238,8 +238,8 @@ void KernelGenerator::visit(const ir::operation::AvgPool2D &node)
       ir::calculatePadding(node.param().padding, ifm_shape, ofm_shape, stride, kw, kh);
   const auto activation = node.param().activation;
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto ifm_alloc = _tensor_builder->at(ifm_index).get();
+  auto ofm_alloc = _tensor_builder->tensorAt(ofm_index).get();
+  auto ifm_alloc = _tensor_builder->tensorAt(ifm_index).get();
 
   auto fn = std::make_unique<ops::AvgPoolLayer>();
 
@@ -256,11 +256,11 @@ void KernelGenerator::visit(const ir::operation::Concat &node)
   const auto rank = _ctx.at(ofm_index).shape().rank();
   const auto axis = ops::getAxis(rank, node.param().axis, _current_op_seq_layout);
 
-  auto output_alloc = _tensor_builder->at(ofm_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(ofm_index).get();
 
-  std::vector<const Tensor *> input_tensors;
+  std::vector<const ITensor *> input_tensors;
   for (auto &ifm_idx : node.getInputs())
-    input_tensors.emplace_back(_tensor_builder->at(ifm_idx).get());
+    input_tensors.emplace_back(_tensor_builder->tensorAt(ifm_idx).get());
 
   auto fn = std::make_unique<ops::ConcatLayer>();
 
@@ -275,9 +275,9 @@ void KernelGenerator::visit(const ir::operation::Fill &node)
   const auto input_index{node.getInputs().at(ir::operation::Fill::Input::INPUT)};
   const auto value_index{node.getInputs().at(ir::operation::Fill::Input::VALUE)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
-  auto value_alloc = _tensor_builder->at(value_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto input_alloc = _tensor_builder->tensorAt(input_index).get();
+  auto value_alloc = _tensor_builder->tensorAt(value_index).get();
 
   auto fn = std::make_unique<ops::FillLayer>();
 
@@ -296,10 +296,10 @@ void KernelGenerator::visit(const ir::operation::FullyConnected &node)
   const auto bias_index{node.getInputs().at(FullyConnected::Input::BIAS)};
   const auto activation = node.param().activation;
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
-  auto weight_alloc = _tensor_builder->at(weight_index).get();
-  auto bias_alloc = bias_index.undefined() ? nullptr : _tensor_builder->at(bias_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto input_alloc = _tensor_builder->tensorAt(input_index).get();
+  auto weight_alloc = _tensor_builder->tensorAt(weight_index).get();
+  auto bias_alloc = bias_index.undefined() ? nullptr : _tensor_builder->tensorAt(bias_index).get();
 
   auto fn = std::make_unique<ops::FullyConnectedLayer>();
 
@@ -313,16 +313,16 @@ void KernelGenerator::visit(const ir::operation::Reshape &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(ir::operation::Reshape::Input::INPUT)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto input_alloc = _tensor_builder->tensorAt(input_index).get();
 
   // optional 2nd input
-  Tensor *shape_alloc = nullptr;
+  ITensor *shape_alloc = nullptr;
 
   if (node.getInputs().size() == 2)
   {
     const auto shape_index{node.getInputs().at(ir::operation::Reshape::Input::SHAPE)};
-    shape_alloc = _tensor_builder->at(shape_index).get();
+    shape_alloc = _tensor_builder->tensorAt(shape_index).get();
   }
 
   auto fn = std::make_unique<ops::ReshapeLayer>();
@@ -336,8 +336,8 @@ void KernelGenerator::visit(const ir::operation::Squeeze &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(ir::operation::Squeeze::Input::INPUT)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto input_alloc = _tensor_builder->tensorAt(input_index).get();
 
   // Squeeze can share same kernel with reshape
   auto fn = std::make_unique<ops::ReshapeLayer>();
@@ -354,8 +354,8 @@ void KernelGenerator::visit(const ir::operation::Softmax &node)
 
   const auto beta = node.param().beta;
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto input_alloc = _tensor_builder->tensorAt(input_index).get();
 
   auto fn = std::make_unique<ops::SoftMaxLayer>();
 
@@ -372,9 +372,9 @@ void KernelGenerator::visit(const ir::operation::Add &node)
 
   const auto activation = node.param().activation;
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto lhs_alloc = _tensor_builder->at(lhs_index).get();
-  auto rhs_alloc = _tensor_builder->at(rhs_index).get();
+  auto ofm_alloc = _tensor_builder->tensorAt(ofm_index).get();
+  auto lhs_alloc = _tensor_builder->tensorAt(lhs_index).get();
+  auto rhs_alloc = _tensor_builder->tensorAt(rhs_index).get();
 
   auto fn = std::make_unique<ops::AddLayer>();
 
@@ -389,9 +389,9 @@ void KernelGenerator::visit(const ir::operation::Comparison &node)
   const auto lhs_index{node.getInputs().at(ir::operation::Comparison::Input::INPUT0)};
   const auto rhs_index{node.getInputs().at(ir::operation::Comparison::Input::INPUT1)};
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto lhs_alloc = _tensor_builder->at(lhs_index).get();
-  auto rhs_alloc = _tensor_builder->at(rhs_index).get();
+  auto ofm_alloc = _tensor_builder->tensorAt(ofm_index).get();
+  auto lhs_alloc = _tensor_builder->tensorAt(lhs_index).get();
+  auto rhs_alloc = _tensor_builder->tensorAt(rhs_index).get();
 
   auto comparison_type = node.param().comparison_type;
 
@@ -408,9 +408,9 @@ void KernelGenerator::visit(const ir::operation::Gather &node)
   const auto input_index{node.getInputs().at(ir::operation::Gather::Input::INPUT)};
   const auto indices_index{node.getInputs().at(ir::operation::Gather::Input::INDICES)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
-  auto indices_alloc = _tensor_builder->at(indices_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto input_alloc = _tensor_builder->tensorAt(input_index).get();
+  auto indices_alloc = _tensor_builder->tensorAt(indices_index).get();
 
   const auto backend_layout = output_alloc->layout();
   UNUSED_RELEASE(backend_layout);
@@ -448,9 +448,9 @@ void KernelGenerator::visit(const ir::operation::Sub &node)
 
   const auto activation = node.param().activation;
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto lhs_alloc = _tensor_builder->at(lhs_index).get();
-  auto rhs_alloc = _tensor_builder->at(rhs_index).get();
+  auto ofm_alloc = _tensor_builder->tensorAt(ofm_index).get();
+  auto lhs_alloc = _tensor_builder->tensorAt(lhs_index).get();
+  auto rhs_alloc = _tensor_builder->tensorAt(rhs_index).get();
 
   auto fn = std::make_unique<ops::SubLayer>();
 
@@ -468,9 +468,9 @@ void KernelGenerator::visit(const ir::operation::Mul &node)
 
   const auto activation = node.param().activation;
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto lhs_alloc = _tensor_builder->at(lhs_index).get();
-  auto rhs_alloc = _tensor_builder->at(rhs_index).get();
+  auto ofm_alloc = _tensor_builder->tensorAt(ofm_index).get();
+  auto lhs_alloc = _tensor_builder->tensorAt(lhs_index).get();
+  auto rhs_alloc = _tensor_builder->tensorAt(rhs_index).get();
 
   auto fn = std::make_unique<ops::MulLayer>();
 
@@ -489,8 +489,8 @@ void KernelGenerator::visit(const ir::operation::OneHot &node)
   const auto off_value = node.param().off_value;
   const auto axis = node.param().axis;
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto indices_alloc = _tensor_builder->at(indices_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto indices_alloc = _tensor_builder->tensorAt(indices_index).get();
 
   assert(indices_alloc->data_type() == OperandType::INT32);
   assert(axis <= static_cast<int>(indices_alloc->num_dimensions()));
@@ -511,9 +511,9 @@ void KernelGenerator::visit(const ir::operation::Div &node)
 
   const auto activation = node.param().activation;
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto lhs_alloc = _tensor_builder->at(lhs_index).get();
-  auto rhs_alloc = _tensor_builder->at(rhs_index).get();
+  auto ofm_alloc = _tensor_builder->tensorAt(ofm_index).get();
+  auto lhs_alloc = _tensor_builder->tensorAt(lhs_index).get();
+  auto rhs_alloc = _tensor_builder->tensorAt(rhs_index).get();
 
   auto fn = std::make_unique<ops::DivLayer>();
 
@@ -542,7 +542,7 @@ void KernelGenerator::visit(const ir::operation::Custom &node)
       const auto &operand = _ctx.at(idx);
       // TODO make sure using `_current_op_seq_layout` is correct for custom operations
       types.emplace_back(get_type_info(operand));
-      auto in_alloc = _tensor_builder->at(idx)->buffer();
+      auto in_alloc = _tensor_builder->tensorAt(idx)->buffer();
       allocs.emplace_back(in_alloc);
     }
   };
@@ -565,8 +565,8 @@ void KernelGenerator::visit(const ir::operation::Exp &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(ir::operation::Exp::Input::INPUT)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto input_alloc = _tensor_builder->tensorAt(input_index).get();
 
   auto fn = std::make_unique<ops::ExpLayer>();
 
@@ -581,9 +581,9 @@ void KernelGenerator::visit(const ir::operation::ExpandDims &node)
   const auto input_index{node.getInputs().at(ir::operation::ExpandDims::Input::INPUT)};
   const auto axis_index{node.getInputs().at(ir::operation::ExpandDims::Input::AXIS)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
-  auto axis_alloc = _tensor_builder->at(axis_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto input_alloc = _tensor_builder->tensorAt(input_index).get();
+  auto axis_alloc = _tensor_builder->tensorAt(axis_index).get();
 
   auto fn = std::make_unique<ops::ExpandDimsLayer>();
 
@@ -597,8 +597,8 @@ void KernelGenerator::visit(const ir::operation::Logistic &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(ir::operation::Logistic::Input::INPUT)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto input_alloc = _tensor_builder->tensorAt(input_index).get();
 
   auto fn = std::make_unique<ops::LogisticLayer>();
 
@@ -612,8 +612,8 @@ void KernelGenerator::visit(const ir::operation::Tanh &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(ir::operation::Tanh::Input::INPUT)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto input_alloc = _tensor_builder->tensorAt(input_index).get();
 
   auto fn = std::make_unique<ops::TanhLayer>();
 
@@ -631,11 +631,11 @@ void KernelGenerator::visit(const ir::operation::Pack &node)
 
   assert(-rank <= axis && axis < rank);
 
-  auto output_alloc = _tensor_builder->at(ofm_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(ofm_index).get();
 
-  std::vector<const Tensor *> input_tensors;
+  std::vector<const ITensor *> input_tensors;
   for (auto &ifm_idx : node.getInputs())
-    input_tensors.emplace_back(_tensor_builder->at(ifm_idx).get());
+    input_tensors.emplace_back(_tensor_builder->tensorAt(ifm_idx).get());
 
   auto fn = std::make_unique<ops::PackLayer>();
 
@@ -653,11 +653,11 @@ void KernelGenerator::visit(const ir::operation::Unpack &node)
 
   assert(rank == 0 || (-rank <= axis && axis < rank));
 
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto input_alloc = _tensor_builder->tensorAt(input_index).get();
 
-  std::vector<Tensor *> output_tensors;
+  std::vector<ITensor *> output_tensors;
   for (auto &output_idx : node.getOutputs())
-    output_tensors.emplace_back(_tensor_builder->at(output_idx).get());
+    output_tensors.emplace_back(_tensor_builder->tensorAt(output_idx).get());
 
   auto fn = std::make_unique<ops::UnpackLayer>();
 
@@ -675,8 +675,8 @@ void KernelGenerator::visit(const ir::operation::Pad &node)
   const auto output_index{node.getOutputs().at(0)};
   assert(_ctx.at(pad_index).data());
 
-  auto input = _tensor_builder->at(input_index).get();
-  auto output = _tensor_builder->at(output_index).get();
+  auto input = _tensor_builder->tensorAt(input_index).get();
+  auto output = _tensor_builder->tensorAt(output_index).get();
   auto pad_rank = _ctx.at(pad_index).shape().dim(0);
   auto pad_base = reinterpret_cast<const int32_t *>(_ctx.at(pad_index).data()->base());
 
@@ -693,9 +693,9 @@ void KernelGenerator::visit(const ir::operation::Max &node)
   const auto lhs_index{node.getInputs().at(ir::operation::Max::Input::LHS)};
   const auto rhs_index{node.getInputs().at(ir::operation::Max::Input::RHS)};
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto lhs_alloc = _tensor_builder->at(lhs_index).get();
-  auto rhs_alloc = _tensor_builder->at(rhs_index).get();
+  auto ofm_alloc = _tensor_builder->tensorAt(ofm_index).get();
+  auto lhs_alloc = _tensor_builder->tensorAt(lhs_index).get();
+  auto rhs_alloc = _tensor_builder->tensorAt(rhs_index).get();
 
   auto fn = std::make_unique<ops::MaxLayer>();
 
@@ -710,9 +710,9 @@ void KernelGenerator::visit(const ir::operation::Min &node)
   const auto lhs_index{node.getInputs().at(ir::operation::Min::Input::LHS)};
   const auto rhs_index{node.getInputs().at(ir::operation::Min::Input::RHS)};
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto lhs_alloc = _tensor_builder->at(lhs_index).get();
-  auto rhs_alloc = _tensor_builder->at(rhs_index).get();
+  auto ofm_alloc = _tensor_builder->tensorAt(ofm_index).get();
+  auto lhs_alloc = _tensor_builder->tensorAt(lhs_index).get();
+  auto rhs_alloc = _tensor_builder->tensorAt(rhs_index).get();
 
   auto fn = std::make_unique<ops::MinLayer>();
 
@@ -726,8 +726,8 @@ void KernelGenerator::visit(const ir::operation::Cast &node)
   const auto ofm_index{node.getOutputs().at(0)};
   const auto ifm_index{node.getInputs().at(ir::operation::Cast::Input::INPUT)};
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto ifm_alloc = _tensor_builder->at(ifm_index).get();
+  auto ofm_alloc = _tensor_builder->tensorAt(ofm_index).get();
+  auto ifm_alloc = _tensor_builder->tensorAt(ifm_index).get();
 
   auto fn = std::make_unique<ops::CastLayer>();
 
@@ -741,8 +741,8 @@ void KernelGenerator::visit(const ir::operation::Transpose &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(0)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto input_alloc = _tensor_builder->tensorAt(input_index).get();
   auto rank = node.param().rank;
 
   auto fn = std::make_unique<ops::TransposeLayer>();
@@ -757,8 +757,8 @@ void KernelGenerator::visit(const ir::operation::ReduceSum &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(0)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto input_alloc = _tensor_builder->tensorAt(input_index).get();
 
   auto fn = std::make_unique<ops::ReduceLayer>();
 
@@ -773,8 +773,8 @@ void KernelGenerator::visit(const ir::operation::ReduceAll &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(ir::operation::ReduceAll::Input::INPUT)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto input_alloc = _tensor_builder->tensorAt(input_index).get();
 
   auto fn = std::make_unique<ops::ReduceLayer>();
 
@@ -789,8 +789,8 @@ void KernelGenerator::visit(const ir::operation::ReduceAny &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(ir::operation::ReduceAny::Input::INPUT)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto input_alloc = _tensor_builder->tensorAt(input_index).get();
 
   auto fn = std::make_unique<ops::ReduceLayer>();
 
@@ -805,8 +805,8 @@ void KernelGenerator::visit(const ir::operation::ReduceMax &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(0)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto input_alloc = _tensor_builder->tensorAt(input_index).get();
 
   auto fn = std::make_unique<ops::ReduceLayer>();
 
@@ -821,8 +821,8 @@ void KernelGenerator::visit(const ir::operation::ReduceMin &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(0)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto input_alloc = _tensor_builder->tensorAt(input_index).get();
 
   auto fn = std::make_unique<ops::ReduceLayer>();
 
@@ -837,8 +837,8 @@ void KernelGenerator::visit(const ir::operation::ReLU &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(0)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto input_alloc = _tensor_builder->tensorAt(input_index).get();
 
   auto fn = std::make_unique<ops::ReLULayer>();
 
@@ -854,10 +854,10 @@ void KernelGenerator::visit(const ir::operation::Select &node)
   const auto true_index{node.getInputs().at(ir::operation::Select::Input::INPUT_TRUE)};
   const auto false_index{node.getInputs().at(ir::operation::Select::Input::INPUT_FALSE)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto condition_alloc = _tensor_builder->at(condition_index).get();
-  auto true_alloc = _tensor_builder->at(true_index).get();
-  auto false_alloc = _tensor_builder->at(false_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto condition_alloc = _tensor_builder->tensorAt(condition_index).get();
+  auto true_alloc = _tensor_builder->tensorAt(true_index).get();
+  auto false_alloc = _tensor_builder->tensorAt(false_index).get();
 
   auto fn = std::make_unique<ops::SelectLayer>();
 
@@ -873,10 +873,10 @@ void KernelGenerator::visit(const ir::operation::Slice &node)
   const auto begins_index{node.getInputs().at(ir::operation::Slice::Input::BEGINS)};
   const auto sizes_index{node.getInputs().at(ir::operation::Slice::Input::SIZES)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
-  auto begins_alloc = _tensor_builder->at(begins_index).get();
-  auto sizes_alloc = _tensor_builder->at(sizes_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto input_alloc = _tensor_builder->tensorAt(input_index).get();
+  auto begins_alloc = _tensor_builder->tensorAt(begins_index).get();
+  auto sizes_alloc = _tensor_builder->tensorAt(sizes_index).get();
 
   auto fn = std::make_unique<ops::SliceLayer>();
 
@@ -893,11 +893,11 @@ void KernelGenerator::visit(const ir::operation::StridedSlice &node)
   const auto ends_index{node.getInputs().at(ir::operation::StridedSlice::Input::ENDS)};
   const auto strides_index{node.getInputs().at(ir::operation::StridedSlice::Input::STRIDES)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
-  auto starts_alloc = _tensor_builder->at(starts_index).get();
-  auto ends_alloc = _tensor_builder->at(ends_index).get();
-  auto strides_alloc = _tensor_builder->at(strides_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto input_alloc = _tensor_builder->tensorAt(input_index).get();
+  auto starts_alloc = _tensor_builder->tensorAt(starts_index).get();
+  auto ends_alloc = _tensor_builder->tensorAt(ends_index).get();
+  auto strides_alloc = _tensor_builder->tensorAt(strides_index).get();
 
   auto begin_mask = node.param().begin_mask;
   auto end_mask = node.param().end_mask;
@@ -923,11 +923,11 @@ void KernelGenerator::visit(const ir::operation::Split &node)
   assert(0 <= axis_resolved && axis_resolved < rank);
 
   const auto input_idx{node.getInputs().at(ir::operation::Split::Input::INPUT)};
-  auto in_tensor = _tensor_builder->at(input_idx).get();
+  auto in_tensor = _tensor_builder->tensorAt(input_idx).get();
 
-  std::vector<Tensor *> out_tensors;
+  std::vector<ITensor *> out_tensors;
   for (auto &output_idx : node.getOutputs())
-    out_tensors.emplace_back(_tensor_builder->at(output_idx).get());
+    out_tensors.emplace_back(_tensor_builder->tensorAt(output_idx).get());
 
   auto fn = std::make_unique<ops::SplitLayer>();
 
@@ -941,8 +941,8 @@ void KernelGenerator::visit(const ir::operation::Abs &node)
   const auto ofm_index{node.getOutputs().at(0)};
   const auto ifm_index{node.getInputs().at(ir::operation::Abs::Input::INPUT)};
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto ifm_alloc = _tensor_builder->at(ifm_index).get();
+  auto ofm_alloc = _tensor_builder->tensorAt(ofm_index).get();
+  auto ifm_alloc = _tensor_builder->tensorAt(ifm_index).get();
 
   auto fn = std::make_unique<ops::AbsLayer>();
 
@@ -956,8 +956,8 @@ void KernelGenerator::visit(const ir::operation::Sin &node)
   const auto ofm_index{node.getOutputs().at(0)};
   const auto ifm_index{node.getInputs().at(ir::operation::Sin::Input::INPUT)};
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto ifm_alloc = _tensor_builder->at(ifm_index).get();
+  auto ofm_alloc = _tensor_builder->tensorAt(ofm_index).get();
+  auto ifm_alloc = _tensor_builder->tensorAt(ifm_index).get();
 
   auto fn = std::make_unique<ops::SinLayer>();
 
@@ -971,8 +971,8 @@ void KernelGenerator::visit(const ir::operation::Cos &node)
   const auto ofm_index{node.getOutputs().at(0)};
   const auto ifm_index{node.getInputs().at(ir::operation::Cos::Input::INPUT)};
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto ifm_alloc = _tensor_builder->at(ifm_index).get();
+  auto ofm_alloc = _tensor_builder->tensorAt(ofm_index).get();
+  auto ifm_alloc = _tensor_builder->tensorAt(ifm_index).get();
 
   auto fn = std::make_unique<ops::CosLayer>();
 
@@ -986,8 +986,8 @@ void KernelGenerator::visit(const ir::operation::RSQRT &node)
   const auto ofm_index{node.getOutputs().at(0)};
   const auto ifm_index{node.getInputs().at(ir::operation::RSQRT::Input::INPUT)};
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto ifm_alloc = _tensor_builder->at(ifm_index).get();
+  auto ofm_alloc = _tensor_builder->tensorAt(ofm_index).get();
+  auto ifm_alloc = _tensor_builder->tensorAt(ifm_index).get();
 
   auto fn = std::make_unique<ops::RsqrtLayer>();
 
@@ -1001,8 +1001,8 @@ void KernelGenerator::visit(const ir::operation::Shape &node)
   const auto ofm_index{node.getOutputs().at(0)};
   const auto ifm_index{node.getInputs().at(ir::operation::Shape::Input::INPUT)};
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto ifm_alloc = _tensor_builder->at(ifm_index).get();
+  auto ofm_alloc = _tensor_builder->tensorAt(ofm_index).get();
+  auto ifm_alloc = _tensor_builder->tensorAt(ifm_index).get();
 
   auto fn = std::make_unique<ops::ShapeLayer>();
 
@@ -1016,8 +1016,8 @@ void KernelGenerator::visit(const ir::operation::ReduceProd &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(0)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto input_alloc = _tensor_builder->tensorAt(input_index).get();
 
   auto fn = std::make_unique<ops::ReduceLayer>();
 
@@ -1033,9 +1033,9 @@ void KernelGenerator::visit(const ir::operation::Reverse &node)
   const auto input_index{node.getInputs().at(ir::operation::Reverse::INPUT)};
   const auto axis_index{node.getInputs().at(ir::operation::Reverse::AXIS)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
-  auto axis_alloc = _tensor_builder->at(axis_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto input_alloc = _tensor_builder->tensorAt(input_index).get();
+  auto axis_alloc = _tensor_builder->tensorAt(axis_index).get();
 
   auto fn = std::make_unique<ops::ReverseLayer>();
 
@@ -1049,8 +1049,8 @@ void KernelGenerator::visit(const ir::operation::Neg &node)
   const auto ofm_index{node.getOutputs().at(0)};
   const auto ifm_index{node.getInputs().at(ir::operation::Neg::Input::INPUT)};
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto ifm_alloc = _tensor_builder->at(ifm_index).get();
+  auto ofm_alloc = _tensor_builder->tensorAt(ofm_index).get();
+  auto ifm_alloc = _tensor_builder->tensorAt(ifm_index).get();
 
   auto fn = std::make_unique<ops::NegLayer>();
 
@@ -1066,8 +1066,8 @@ void KernelGenerator::visit(const ir::operation::ArgMax &node)
 
   const auto axis = node.param().axis;
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto input_alloc = _tensor_builder->tensorAt(input_index).get();
 
   auto fn = std::make_unique<ops::ArgMinMaxLayer>();
 
@@ -1082,9 +1082,9 @@ void KernelGenerator::visit(const ir::operation::Pow &node)
   const auto lhs_index{node.getInputs().at(ir::operation::Pow::LHS)};
   const auto rhs_index{node.getInputs().at(ir::operation::Pow::RHS)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto lhs_alloc = _tensor_builder->at(lhs_index).get();
-  auto rhs_alloc = _tensor_builder->at(rhs_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto lhs_alloc = _tensor_builder->tensorAt(lhs_index).get();
+  auto rhs_alloc = _tensor_builder->tensorAt(rhs_index).get();
 
   auto fn = std::make_unique<ops::PowLayer>();
 
@@ -1098,8 +1098,8 @@ void KernelGenerator::visit(const ir::operation::Log &node)
   const auto ofm_index{node.getOutputs().at(0)};
   const auto ifm_index{node.getInputs().at(ir::operation::Log::Input::INPUT)};
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto ifm_alloc = _tensor_builder->at(ifm_index).get();
+  auto ofm_alloc = _tensor_builder->tensorAt(ofm_index).get();
+  auto ifm_alloc = _tensor_builder->tensorAt(ifm_index).get();
 
   auto fn = std::make_unique<ops::LogLayer>();
 
@@ -1113,8 +1113,8 @@ void KernelGenerator::visit(const ir::operation::Round &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(ir::operation::Round::INPUT)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto input_alloc = _tensor_builder->tensorAt(input_index).get();
 
   auto fn = std::make_unique<ops::RoundLayer>();
 
@@ -1128,8 +1128,8 @@ void KernelGenerator::visit(const ir::operation::LogicalNot &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(ir::operation::LogicalNot::INPUT)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto input_alloc = _tensor_builder->tensorAt(input_index).get();
 
   auto fn = std::make_unique<ops::LogicalNotLayer>();
 
@@ -1144,9 +1144,9 @@ void KernelGenerator::visit(const ir::operation::LogicalOr &node)
   const auto lhs_index{node.getInputs().at(0)};
   const auto rhs_index{node.getInputs().at(1)};
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto lhs_alloc = _tensor_builder->at(lhs_index).get();
-  auto rhs_alloc = _tensor_builder->at(rhs_index).get();
+  auto ofm_alloc = _tensor_builder->tensorAt(ofm_index).get();
+  auto lhs_alloc = _tensor_builder->tensorAt(lhs_index).get();
+  auto rhs_alloc = _tensor_builder->tensorAt(rhs_index).get();
 
   auto fn = std::make_unique<ops::LogicalOrLayer>();
 
@@ -1162,8 +1162,8 @@ void KernelGenerator::visit(const ir::operation::Mean &node)
 
   const auto axes = node.param().axes;
   const auto keep_dims = node.param().keep_dims;
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto input_alloc = _tensor_builder->tensorAt(input_index).get();
 
   auto fn = std::make_unique<ops::MeanLayer>();
 
@@ -1176,8 +1176,8 @@ void KernelGenerator::visit(const ir::operation::ZerosLike &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(ir::operation::ZerosLike::INPUT)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto input_alloc = _tensor_builder->tensorAt(input_index).get();
 
   auto fn = std::make_unique<ops::ZerosLikeLayer>();
 
@@ -1192,10 +1192,10 @@ void KernelGenerator::visit(const ir::operation::Range &node)
   const auto limit_index{node.getInputs().at(ir::operation::Range::LIMIT)};
   const auto delta_index{node.getInputs().at(ir::operation::Range::DELTA)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto start_alloc = _tensor_builder->at(start_index).get();
-  auto limit_alloc = _tensor_builder->at(limit_index).get();
-  auto delta_alloc = _tensor_builder->at(delta_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto start_alloc = _tensor_builder->tensorAt(start_index).get();
+  auto limit_alloc = _tensor_builder->tensorAt(limit_index).get();
+  auto delta_alloc = _tensor_builder->tensorAt(delta_index).get();
 
   auto fn = std::make_unique<ops::RangeLayer>();
 
@@ -1209,9 +1209,9 @@ void KernelGenerator::visit(const ir::operation::SquaredDifference &node)
   const auto lhs_index{node.getInputs().at(ir::operation::SquaredDifference::Input::LHS)};
   const auto rhs_index{node.getInputs().at(ir::operation::SquaredDifference::Input::RHS)};
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto lhs_alloc = _tensor_builder->at(lhs_index).get();
-  auto rhs_alloc = _tensor_builder->at(rhs_index).get();
+  auto ofm_alloc = _tensor_builder->tensorAt(ofm_index).get();
+  auto lhs_alloc = _tensor_builder->tensorAt(lhs_index).get();
+  auto rhs_alloc = _tensor_builder->tensorAt(rhs_index).get();
 
   auto fn = std::make_unique<ops::SqDiffLayer>();
 
@@ -1225,9 +1225,9 @@ void KernelGenerator::visit(const ir::operation::Tile &node)
   const auto input_index{node.getInputs().at(ir::operation::Tile::INPUT)};
   const auto multiples_index{node.getInputs().at(ir::operation::Tile::MULTIPLES)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
-  auto multiples_alloc = _tensor_builder->at(multiples_index).get();
+  auto output_alloc = _tensor_builder->tensorAt(output_index).get();
+  auto input_alloc = _tensor_builder->tensorAt(input_index).get();
+  auto multiples_alloc = _tensor_builder->tensorAt(multiples_index).get();
 
   auto fn = std::make_unique<ops::TileLayer>();
 

--- a/runtime/onert/backend/cpu/ops/AbsLayer.cc
+++ b/runtime/onert/backend/cpu/ops/AbsLayer.cc
@@ -42,7 +42,7 @@ void AbsLayer::absFloat32()
 
 void AbsLayer::absQuant8() { throw std::runtime_error{"NYI"}; }
 
-void AbsLayer::configure(const Tensor *input, Tensor *output)
+void AbsLayer::configure(const ITensor *input, ITensor *output)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/ops/AbsLayer.h
+++ b/runtime/onert/backend/cpu/ops/AbsLayer.h
@@ -40,13 +40,13 @@ public:
 
   void absQuant8();
 
-  void configure(const Tensor *input, Tensor *output);
+  void configure(const ITensor *input, ITensor *output);
 
   void run();
 
 private:
-  const Tensor *_input;
-  Tensor *_output;
+  const ITensor *_input;
+  ITensor *_output;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/AddLayer.cc
+++ b/runtime/onert/backend/cpu/ops/AddLayer.cc
@@ -66,8 +66,8 @@ void AddLayer::addQuant8()
   throw std::runtime_error{"NYI"};
 }
 
-void AddLayer::configure(const Tensor *lhs, const Tensor *rhs, const ir::Activation activation,
-                         Tensor *output)
+void AddLayer::configure(const ITensor *lhs, const ITensor *rhs, const ir::Activation activation,
+                         ITensor *output)
 {
   assert(lhs != nullptr);
   assert(rhs != nullptr);

--- a/runtime/onert/backend/cpu/ops/AddLayer.h
+++ b/runtime/onert/backend/cpu/ops/AddLayer.h
@@ -44,15 +44,15 @@ public:
 
   void addQuant8();
 
-  void configure(const Tensor *lhs, const Tensor *rhs, const ir::Activation activation,
-                 Tensor *output);
+  void configure(const ITensor *lhs, const ITensor *rhs, const ir::Activation activation,
+                 ITensor *output);
 
   void run();
 
 private:
-  const Tensor *_lhs;
-  const Tensor *_rhs;
-  Tensor *_output;
+  const ITensor *_lhs;
+  const ITensor *_rhs;
+  ITensor *_output;
 
   ir::Activation _activation{ir::Activation::NONE};
 };

--- a/runtime/onert/backend/cpu/ops/ArgMinMaxLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ArgMinMaxLayer.cc
@@ -44,7 +44,7 @@ template <typename T> std::function<bool(T, T)> GetComparefunction(bool is_arg_m
 }
 }
 
-void ArgMinMaxLayer::configure(const Tensor *input, Tensor *output, int32_t axis, bool is_arg_max)
+void ArgMinMaxLayer::configure(const ITensor *input, ITensor *output, int32_t axis, bool is_arg_max)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/ops/ArgMinMaxLayer.h
+++ b/runtime/onert/backend/cpu/ops/ArgMinMaxLayer.h
@@ -36,13 +36,13 @@ public:
   ArgMinMaxLayer() : _input(nullptr), _output(nullptr), _axis(-1), _is_arg_max(true) {}
 
 public:
-  void configure(const Tensor *indices, Tensor *output, int32_t axis, bool is_arg_max);
+  void configure(const ITensor *indices, ITensor *output, int32_t axis, bool is_arg_max);
 
   void run();
 
 private:
-  const Tensor *_input;
-  Tensor *_output;
+  const ITensor *_input;
+  ITensor *_output;
   int32_t _axis;
   bool _is_arg_max;
 };

--- a/runtime/onert/backend/cpu/ops/AvgPoolLayer.cc
+++ b/runtime/onert/backend/cpu/ops/AvgPoolLayer.cc
@@ -71,12 +71,12 @@ void AvgPoolLayer::averagePoolQuant8()
                           getTensorShape(_output), reinterpret_cast<uint8_t *>(_output->buffer()));
 }
 
-void AvgPoolLayer::configure(const Tensor *input, const uint32_t paddingLeft,
+void AvgPoolLayer::configure(const ITensor *input, const uint32_t paddingLeft,
                              const uint32_t paddingRight, const uint32_t paddingTop,
                              const uint32_t paddingBottom, const uint32_t strideWidth,
                              const uint32_t strideHeight, const uint32_t kernelWidth,
                              const uint32_t kernelHeight, const ir::Activation activation,
-                             Tensor *output)
+                             ITensor *output)
 {
   assert(input != nullptr);
   assert(output != nullptr);

--- a/runtime/onert/backend/cpu/ops/AvgPoolLayer.h
+++ b/runtime/onert/backend/cpu/ops/AvgPoolLayer.h
@@ -41,17 +41,17 @@ public:
 
   void averagePoolQuant8();
 
-  void configure(const Tensor *input, const uint32_t paddingLeft, const uint32_t paddingRight,
+  void configure(const ITensor *input, const uint32_t paddingLeft, const uint32_t paddingRight,
                  const uint32_t paddingTop, const uint32_t paddingBottom,
                  const uint32_t strideWidth, const uint32_t strideHeight,
                  const uint32_t kernelWidth, const uint32_t kernelHeight,
-                 const ir::Activation activation, Tensor *output);
+                 const ir::Activation activation, ITensor *output);
 
   void run();
 
 private:
-  const Tensor *_input;
-  Tensor *_output;
+  const ITensor *_input;
+  ITensor *_output;
 
   uint32_t _paddingLeft;
   uint32_t _paddingTop;

--- a/runtime/onert/backend/cpu/ops/CastLayer.cc
+++ b/runtime/onert/backend/cpu/ops/CastLayer.cc
@@ -30,7 +30,7 @@ CastLayer::CastLayer() : _input(nullptr), _output(nullptr)
   // DO NOTHING
 }
 
-void CastLayer::configure(const Tensor *input, Tensor *output)
+void CastLayer::configure(const ITensor *input, ITensor *output)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/ops/CastLayer.h
+++ b/runtime/onert/backend/cpu/ops/CastLayer.h
@@ -40,13 +40,13 @@ public:
   template <typename FromT, typename ToT> void castTensor(const FromT *in, ToT *out);
   template <typename FromT> void castPtr(const FromT *in, DataPtr out);
 
-  void configure(const Tensor *input, Tensor *output);
+  void configure(const ITensor *input, ITensor *output);
 
   void run();
 
 private:
-  const Tensor *_input;
-  Tensor *_output;
+  const ITensor *_input;
+  ITensor *_output;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/CompareLayer.cc
+++ b/runtime/onert/backend/cpu/ops/CompareLayer.cc
@@ -35,7 +35,7 @@ using OpType = onert::ir::operation::Comparison::ComparisonType;
 using namespace onert::backend::cpu;
 
 template <typename T>
-void compareScalar(const Tensor *lhs, const Tensor *rhs, Tensor *output, OpType op_type)
+void compareScalar(const ITensor *lhs, const ITensor *rhs, ITensor *output, OpType op_type)
 {
   bool requires_broadcast = !HaveSameShapes(lhs, rhs);
 
@@ -138,8 +138,8 @@ CompareLayer::CompareLayer()
 
 void CompareLayer::compareQuant8() { throw std::runtime_error{"Compare NYI for quantized"}; }
 
-void CompareLayer::configure(const Tensor *lhs, const Tensor *rhs, const OpType op_type,
-                             Tensor *output)
+void CompareLayer::configure(const ITensor *lhs, const ITensor *rhs, const OpType op_type,
+                             ITensor *output)
 {
   _lhs = lhs;
   _rhs = rhs;

--- a/runtime/onert/backend/cpu/ops/CompareLayer.h
+++ b/runtime/onert/backend/cpu/ops/CompareLayer.h
@@ -39,15 +39,15 @@ public:
 public:
   void compareQuant8();
 
-  void configure(const Tensor *lhs, const Tensor *rhs,
-                 const ir::operation::Comparison::ComparisonType op_type, Tensor *output);
+  void configure(const ITensor *lhs, const ITensor *rhs,
+                 const ir::operation::Comparison::ComparisonType op_type, ITensor *output);
 
   void run();
 
 private:
-  const Tensor *_lhs;
-  const Tensor *_rhs;
-  Tensor *_output;
+  const ITensor *_lhs;
+  const ITensor *_rhs;
+  ITensor *_output;
   ir::operation::Comparison::ComparisonType _op_type;
 };
 

--- a/runtime/onert/backend/cpu/ops/ConcatLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ConcatLayer.cc
@@ -105,7 +105,8 @@ void ConcatLayer::concatenationQuant8()
                                        reinterpret_cast<uint8_t *>(_output->buffer()));
 }
 
-void ConcatLayer::configure(const std::vector<const Tensor *> &inputs, int32_t axis, Tensor *output)
+void ConcatLayer::configure(const std::vector<const ITensor *> &inputs, int32_t axis,
+                            ITensor *output)
 {
   assert(inputs.size() > 0);
   assert(output != nullptr);

--- a/runtime/onert/backend/cpu/ops/ConcatLayer.h
+++ b/runtime/onert/backend/cpu/ops/ConcatLayer.h
@@ -40,13 +40,13 @@ public:
 
   void concatenationQuant8();
 
-  void configure(const std::vector<const Tensor *> &inputs, int32_t axis, Tensor *output);
+  void configure(const std::vector<const ITensor *> &inputs, int32_t axis, ITensor *output);
 
   void run();
 
 private:
-  std::vector<const Tensor *> _inputs;
-  Tensor *_output;
+  std::vector<const ITensor *> _inputs;
+  ITensor *_output;
   int32_t _axis;
 };
 

--- a/runtime/onert/backend/cpu/ops/ConvolutionLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ConvolutionLayer.cc
@@ -62,8 +62,10 @@ void ConvolutionLayer::convFloat32()
 
     if (is_replaced_weights)
     {
-      // TODO Remove const_cast
-      const_cast<Tensor *>(_kernel)->decrease_ref();
+      auto kernel_tensor = dynamic_cast<const Tensor *>(_kernel);
+      if (kernel_tensor)
+        // TODO Remove const_cast
+        const_cast<Tensor *>(kernel_tensor)->decrease_ref();
     }
     _prepare = true;
   }
@@ -115,12 +117,12 @@ void ConvolutionLayer::convQuant8()
          getTensorShape(_output), reinterpret_cast<uint8_t *>(_output->buffer()));
 }
 
-void ConvolutionLayer::configure(const Tensor *input, const Tensor *kernel, const Tensor *bias,
+void ConvolutionLayer::configure(const ITensor *input, const ITensor *kernel, const ITensor *bias,
                                  const ir::PaddingType paddingType, const uint32_t paddingLeft,
                                  const uint32_t paddingRight, const uint32_t paddingTop,
                                  const uint32_t paddingBottom, const uint32_t strideWidth,
                                  const uint32_t strideHeight, const ir::Activation activation,
-                                 Tensor *output)
+                                 ITensor *output)
 {
   _input = input;
   _kernel = kernel;

--- a/runtime/onert/backend/cpu/ops/ConvolutionLayer.h
+++ b/runtime/onert/backend/cpu/ops/ConvolutionLayer.h
@@ -52,19 +52,19 @@ public:
 
   void convQuant8();
 
-  void configure(const Tensor *input, const Tensor *kernel, const Tensor *bias,
+  void configure(const ITensor *input, const ITensor *kernel, const ITensor *bias,
                  const ir::PaddingType paddingType, const uint32_t paddingLeft,
                  const uint32_t paddingRight, const uint32_t paddingTop,
                  const uint32_t paddingBottom, const uint32_t strideW, const uint32_t strideH,
-                 const ir::Activation activation, Tensor *output);
+                 const ir::Activation activation, ITensor *output);
 
   void run();
 
 private:
-  const Tensor *_input;
-  const Tensor *_kernel;
-  const Tensor *_bias;
-  Tensor *_output;
+  const ITensor *_input;
+  const ITensor *_kernel;
+  const ITensor *_bias;
+  ITensor *_output;
 
   ir::PaddingType _paddingType;
   uint32_t _paddingLeft;

--- a/runtime/onert/backend/cpu/ops/CosLayer.cc
+++ b/runtime/onert/backend/cpu/ops/CosLayer.cc
@@ -40,7 +40,7 @@ void CosLayer::cosFloat32()
 
 void CosLayer::cosQuant8() { throw std::runtime_error{"NYI"}; }
 
-void CosLayer::configure(const Tensor *input, Tensor *output)
+void CosLayer::configure(const ITensor *input, ITensor *output)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/ops/CosLayer.h
+++ b/runtime/onert/backend/cpu/ops/CosLayer.h
@@ -34,7 +34,7 @@ class CosLayer : public ::onert::exec::IFunction
 public:
   CosLayer();
 
-  void configure(const Tensor *input, Tensor *output);
+  void configure(const ITensor *input, ITensor *output);
 
   void run();
 
@@ -42,8 +42,8 @@ private:
   void cosFloat32();
   void cosQuant8();
 
-  const Tensor *_input;
-  Tensor *_output;
+  const ITensor *_input;
+  ITensor *_output;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/DepthwiseConvolutionLayer.cc
+++ b/runtime/onert/backend/cpu/ops/DepthwiseConvolutionLayer.cc
@@ -94,12 +94,12 @@ void DepthwiseConvolutionLayer::convQuant8()
       getTensorShape(_output), reinterpret_cast<uint8_t *>(_output->buffer()));
 }
 
-void DepthwiseConvolutionLayer::configure(const Tensor *input, const Tensor *kernel,
-                                          const Tensor *bias, const uint32_t paddingLeft,
+void DepthwiseConvolutionLayer::configure(const ITensor *input, const ITensor *kernel,
+                                          const ITensor *bias, const uint32_t paddingLeft,
                                           const uint32_t paddingRight, const uint32_t paddingTop,
                                           const uint32_t paddingBottom, const uint32_t strideWidth,
                                           const uint32_t strideHeight, const uint32_t multiplier,
-                                          const ir::Activation activation, Tensor *output)
+                                          const ir::Activation activation, ITensor *output)
 {
   _input = input;
   _kernel = kernel;

--- a/runtime/onert/backend/cpu/ops/DepthwiseConvolutionLayer.h
+++ b/runtime/onert/backend/cpu/ops/DepthwiseConvolutionLayer.h
@@ -41,18 +41,18 @@ public:
 
   void convQuant8();
 
-  void configure(const Tensor *input, const Tensor *kernel, const Tensor *bias,
+  void configure(const ITensor *input, const ITensor *kernel, const ITensor *bias,
                  const uint32_t paddingLeft, const uint32_t paddingRight, const uint32_t paddingTop,
                  const uint32_t paddingBottom, const uint32_t strideW, const uint32_t strideH,
-                 const uint32_t multiplier, const ir::Activation activation, Tensor *output);
+                 const uint32_t multiplier, const ir::Activation activation, ITensor *output);
 
   void run();
 
 private:
-  const Tensor *_input;
-  const Tensor *_kernel;
-  const Tensor *_bias;
-  Tensor *_output;
+  const ITensor *_input;
+  const ITensor *_kernel;
+  const ITensor *_bias;
+  ITensor *_output;
 
   uint32_t _paddingLeft;
   uint32_t _paddingTop;

--- a/runtime/onert/backend/cpu/ops/DivLayer.cc
+++ b/runtime/onert/backend/cpu/ops/DivLayer.cc
@@ -66,8 +66,8 @@ void DivLayer::divQuant8()
   throw std::runtime_error{"Div NYI for quantized"};
 }
 
-void DivLayer::configure(const Tensor *lhs, const Tensor *rhs, const ir::Activation activation,
-                         Tensor *output)
+void DivLayer::configure(const ITensor *lhs, const ITensor *rhs, const ir::Activation activation,
+                         ITensor *output)
 {
   _lhs = lhs;
   _rhs = rhs;

--- a/runtime/onert/backend/cpu/ops/DivLayer.h
+++ b/runtime/onert/backend/cpu/ops/DivLayer.h
@@ -44,15 +44,15 @@ public:
 
   void divQuant8();
 
-  void configure(const Tensor *lhs, const Tensor *rhs, const ir::Activation activation,
-                 Tensor *output);
+  void configure(const ITensor *lhs, const ITensor *rhs, const ir::Activation activation,
+                 ITensor *output);
 
   void run();
 
 private:
-  const Tensor *_lhs;
-  const Tensor *_rhs;
-  Tensor *_output;
+  const ITensor *_lhs;
+  const ITensor *_rhs;
+  ITensor *_output;
 
   ir::Activation _activation{ir::Activation::NONE};
 };

--- a/runtime/onert/backend/cpu/ops/ExpLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ExpLayer.cc
@@ -46,7 +46,7 @@ void ExpLayer::expQuant8()
   throw std::runtime_error{"NYI"};
 }
 
-void ExpLayer::configure(const Tensor *input, Tensor *output)
+void ExpLayer::configure(const ITensor *input, ITensor *output)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/ops/ExpLayer.h
+++ b/runtime/onert/backend/cpu/ops/ExpLayer.h
@@ -40,13 +40,13 @@ public:
 
   void expQuant8();
 
-  void configure(const Tensor *input, Tensor *output);
+  void configure(const ITensor *input, ITensor *output);
 
   void run();
 
 private:
-  const Tensor *_input;
-  Tensor *_output;
+  const ITensor *_input;
+  ITensor *_output;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/ExpandDimsLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ExpandDimsLayer.cc
@@ -30,7 +30,7 @@ ExpandDimsLayer::ExpandDimsLayer() : _input(nullptr), _axis(nullptr), _output(nu
   // DO NOTHING
 }
 
-void ExpandDimsLayer::configure(const Tensor *input, const Tensor *axis, Tensor *output)
+void ExpandDimsLayer::configure(const ITensor *input, const ITensor *axis, ITensor *output)
 {
   _input = input;
   _axis = axis;

--- a/runtime/onert/backend/cpu/ops/ExpandDimsLayer.h
+++ b/runtime/onert/backend/cpu/ops/ExpandDimsLayer.h
@@ -36,14 +36,14 @@ public:
   ExpandDimsLayer();
 
 public:
-  void configure(const Tensor *input, const Tensor *axis, Tensor *output);
+  void configure(const ITensor *input, const ITensor *axis, ITensor *output);
 
   void run();
 
 private:
-  const Tensor *_input;
-  const Tensor *_axis;
-  Tensor *_output;
+  const ITensor *_input;
+  const ITensor *_axis;
+  ITensor *_output;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/FillLayer.cc
+++ b/runtime/onert/backend/cpu/ops/FillLayer.cc
@@ -34,7 +34,7 @@ FillLayer::FillLayer() : _input(nullptr), _value(nullptr), _output(nullptr)
   // DO NOTHING
 }
 
-void FillLayer::configure(const Tensor *input, const Tensor *value, Tensor *output)
+void FillLayer::configure(const ITensor *input, const ITensor *value, ITensor *output)
 {
   _input = input;
   _value = value;

--- a/runtime/onert/backend/cpu/ops/FillLayer.h
+++ b/runtime/onert/backend/cpu/ops/FillLayer.h
@@ -35,14 +35,14 @@ class FillLayer : public ::onert::exec::IFunction
 public:
   FillLayer();
 
-  void configure(const Tensor *input, const Tensor *value, Tensor *output);
+  void configure(const ITensor *input, const ITensor *value, ITensor *output);
 
   void run();
 
 private:
-  const Tensor *_input;
-  const Tensor *_value;
-  Tensor *_output;
+  const ITensor *_input;
+  const ITensor *_value;
+  ITensor *_output;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/FullyConnectedLayer.cc
+++ b/runtime/onert/backend/cpu/ops/FullyConnectedLayer.cc
@@ -102,8 +102,8 @@ void FullyConnectedLayer::fullyConnectedHybrid()
       getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()), temp_arena);
 }
 
-void FullyConnectedLayer::configure(const Tensor *input, const Tensor *weights, const Tensor *bias,
-                                    ir::Activation activation, Tensor *output)
+void FullyConnectedLayer::configure(const ITensor *input, const ITensor *weights,
+                                    const ITensor *bias, ir::Activation activation, ITensor *output)
 {
   _input = input;
   _weights = weights;

--- a/runtime/onert/backend/cpu/ops/FullyConnectedLayer.h
+++ b/runtime/onert/backend/cpu/ops/FullyConnectedLayer.h
@@ -52,16 +52,16 @@ public:
 
   void fullyConnectedHybrid();
 
-  void configure(const Tensor *input, const Tensor *weights, const Tensor *bias,
-                 ir::Activation activation, Tensor *output);
+  void configure(const ITensor *input, const ITensor *weights, const ITensor *bias,
+                 ir::Activation activation, ITensor *output);
 
   void run();
 
 private:
-  const Tensor *_input;
-  const Tensor *_weights;
-  const Tensor *_bias;
-  Tensor *_output;
+  const ITensor *_input;
+  const ITensor *_weights;
+  const ITensor *_bias;
+  ITensor *_output;
 
   ir::Activation _activation;
   std::unique_ptr<nnfw::cker::FCTempArena> _temp_arena;

--- a/runtime/onert/backend/cpu/ops/GatherLayer.cc
+++ b/runtime/onert/backend/cpu/ops/GatherLayer.cc
@@ -29,7 +29,7 @@ namespace cpu
 namespace ops
 {
 
-void GatherLayer::configure(const Tensor *input, const Tensor *indices, Tensor *output,
+void GatherLayer::configure(const ITensor *input, const ITensor *indices, ITensor *output,
                             int32_t axis)
 {
   _input = input;

--- a/runtime/onert/backend/cpu/ops/GatherLayer.h
+++ b/runtime/onert/backend/cpu/ops/GatherLayer.h
@@ -39,14 +39,14 @@ public:
   }
 
 public:
-  void configure(const Tensor *input, const Tensor *indices, Tensor *output, int32_t axis);
+  void configure(const ITensor *input, const ITensor *indices, ITensor *output, int32_t axis);
 
   void run();
 
 private:
-  const Tensor *_input;
-  const Tensor *_indices;
-  Tensor *_output;
+  const ITensor *_input;
+  const ITensor *_indices;
+  ITensor *_output;
 
   int32_t _axis;
 };

--- a/runtime/onert/backend/cpu/ops/LogLayer.cc
+++ b/runtime/onert/backend/cpu/ops/LogLayer.cc
@@ -42,7 +42,7 @@ void LogLayer::logFloat32()
 
 void LogLayer::logQuant8() { throw std::runtime_error{"NYI"}; }
 
-void LogLayer::configure(const Tensor *input, Tensor *output)
+void LogLayer::configure(const ITensor *input, ITensor *output)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/ops/LogLayer.h
+++ b/runtime/onert/backend/cpu/ops/LogLayer.h
@@ -40,13 +40,13 @@ public:
 
   void logQuant8();
 
-  void configure(const Tensor *input, Tensor *output);
+  void configure(const ITensor *input, ITensor *output);
 
   void run();
 
 private:
-  const Tensor *_input;
-  Tensor *_output;
+  const ITensor *_input;
+  ITensor *_output;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/LogicalNotLayer.cc
+++ b/runtime/onert/backend/cpu/ops/LogicalNotLayer.cc
@@ -40,7 +40,7 @@ void LogicalNotLayer::logicalNotBool8()
                          getTensorShape(_output), reinterpret_cast<bool *>(_output->buffer()));
 }
 
-void LogicalNotLayer::configure(const Tensor *input, Tensor *output)
+void LogicalNotLayer::configure(const ITensor *input, ITensor *output)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/ops/LogicalNotLayer.h
+++ b/runtime/onert/backend/cpu/ops/LogicalNotLayer.h
@@ -36,7 +36,7 @@ public:
   LogicalNotLayer();
 
 public:
-  void configure(const Tensor *input, Tensor *output);
+  void configure(const ITensor *input, ITensor *output);
 
   void run();
 
@@ -44,8 +44,8 @@ private:
   void logicalNotBool8();
 
 private:
-  const Tensor *_input;
-  Tensor *_output;
+  const ITensor *_input;
+  ITensor *_output;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/LogicalOrLayer.cc
+++ b/runtime/onert/backend/cpu/ops/LogicalOrLayer.cc
@@ -35,7 +35,7 @@ void LogicalOrLayer::lorBool8()
                               getTensorShape(_output), reinterpret_cast<bool *>(_output->buffer()));
 }
 
-void LogicalOrLayer::configure(const Tensor *lhs, const Tensor *rhs, Tensor *output)
+void LogicalOrLayer::configure(const ITensor *lhs, const ITensor *rhs, ITensor *output)
 {
   assert(lhs != nullptr);
   assert(rhs != nullptr);

--- a/runtime/onert/backend/cpu/ops/LogicalOrLayer.h
+++ b/runtime/onert/backend/cpu/ops/LogicalOrLayer.h
@@ -38,7 +38,7 @@ public:
   }
 
 public:
-  void configure(const Tensor *_lhs, const Tensor *_rhs, Tensor *output);
+  void configure(const ITensor *_lhs, const ITensor *_rhs, ITensor *output);
 
   void run();
 
@@ -46,9 +46,9 @@ private:
   void lorBool8();
 
 private:
-  const Tensor *_lhs;
-  const Tensor *_rhs;
-  Tensor *_output;
+  const ITensor *_lhs;
+  const ITensor *_rhs;
+  ITensor *_output;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/LogisticLayer.cc
+++ b/runtime/onert/backend/cpu/ops/LogisticLayer.cc
@@ -46,7 +46,7 @@ void LogisticLayer::logisticQuant8()
   throw std::runtime_error{"NYI"};
 }
 
-void LogisticLayer::configure(const Tensor *input, Tensor *output)
+void LogisticLayer::configure(const ITensor *input, ITensor *output)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/ops/LogisticLayer.h
+++ b/runtime/onert/backend/cpu/ops/LogisticLayer.h
@@ -40,13 +40,13 @@ public:
 
   void logisticQuant8();
 
-  void configure(const Tensor *input, Tensor *output);
+  void configure(const ITensor *input, ITensor *output);
 
   void run();
 
 private:
-  const Tensor *_input;
-  Tensor *_output;
+  const ITensor *_input;
+  ITensor *_output;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/MaxLayer.cc
+++ b/runtime/onert/backend/cpu/ops/MaxLayer.cc
@@ -47,7 +47,7 @@ void MaxLayer::maxQuant8()
   throw std::runtime_error("Max NYI for quantized");
 }
 
-void MaxLayer::configure(const Tensor *lhs, const Tensor *rhs, Tensor *output)
+void MaxLayer::configure(const ITensor *lhs, const ITensor *rhs, ITensor *output)
 {
   assert(lhs != nullptr);
   assert(rhs != nullptr);

--- a/runtime/onert/backend/cpu/ops/MaxLayer.h
+++ b/runtime/onert/backend/cpu/ops/MaxLayer.h
@@ -43,14 +43,14 @@ public:
 
   void maxQuant8();
 
-  void configure(const Tensor *lhs, const Tensor *rhs, Tensor *output);
+  void configure(const ITensor *lhs, const ITensor *rhs, ITensor *output);
 
   void run();
 
 private:
-  const Tensor *_lhs;
-  const Tensor *_rhs;
-  Tensor *_output;
+  const ITensor *_lhs;
+  const ITensor *_rhs;
+  ITensor *_output;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/MaxPoolLayer.cc
+++ b/runtime/onert/backend/cpu/ops/MaxPoolLayer.cc
@@ -71,12 +71,12 @@ void MaxPoolLayer::maxPoolQuant8()
                       reinterpret_cast<uint8_t *>(_output->buffer()));
 }
 
-void MaxPoolLayer::configure(const Tensor *input, const uint32_t paddingLeft,
+void MaxPoolLayer::configure(const ITensor *input, const uint32_t paddingLeft,
                              const uint32_t paddingRight, const uint32_t paddingTop,
                              const uint32_t paddingBottom, const uint32_t strideWidth,
                              const uint32_t strideHeight, const uint32_t kernelWidth,
                              const uint32_t kernelHeight, const ir::Activation activation,
-                             Tensor *output)
+                             ITensor *output)
 {
   _input = input;
   _paddingLeft = paddingLeft;

--- a/runtime/onert/backend/cpu/ops/MaxPoolLayer.h
+++ b/runtime/onert/backend/cpu/ops/MaxPoolLayer.h
@@ -41,17 +41,17 @@ public:
 
   void maxPoolQuant8();
 
-  void configure(const Tensor *input, const uint32_t paddingLeft, const uint32_t paddingRight,
+  void configure(const ITensor *input, const uint32_t paddingLeft, const uint32_t paddingRight,
                  const uint32_t paddingTop, const uint32_t paddingBottom,
                  const uint32_t strideWidth, const uint32_t strideHeight,
                  const uint32_t kernelWidth, const uint32_t kernelHeight,
-                 const ir::Activation activation, Tensor *output);
+                 const ir::Activation activation, ITensor *output);
 
   void run();
 
 private:
-  const Tensor *_input;
-  Tensor *_output;
+  const ITensor *_input;
+  ITensor *_output;
 
   uint32_t _paddingLeft;
   uint32_t _paddingTop;

--- a/runtime/onert/backend/cpu/ops/MeanLayer.cc
+++ b/runtime/onert/backend/cpu/ops/MeanLayer.cc
@@ -49,7 +49,7 @@ void MeanLayer::MeanQuant8()
                           _output->data_offset(), _axes);
 }
 
-void MeanLayer::configure(const Tensor *input, Tensor *output, const std::vector<int> &axes,
+void MeanLayer::configure(const ITensor *input, ITensor *output, const std::vector<int> &axes,
                           bool keep_dims)
 {
   _input = input;

--- a/runtime/onert/backend/cpu/ops/MeanLayer.h
+++ b/runtime/onert/backend/cpu/ops/MeanLayer.h
@@ -40,13 +40,14 @@ public:
 
   void MeanQuant8();
 
-  void configure(const Tensor *input, Tensor *output, const std::vector<int> &axes, bool keep_dims);
+  void configure(const ITensor *input, ITensor *output, const std::vector<int> &axes,
+                 bool keep_dims);
 
   void run();
 
 private:
-  const Tensor *_input;
-  Tensor *_output;
+  const ITensor *_input;
+  ITensor *_output;
   std::vector<int> _axes;
   bool _keep_dims;
 };

--- a/runtime/onert/backend/cpu/ops/MinLayer.cc
+++ b/runtime/onert/backend/cpu/ops/MinLayer.cc
@@ -47,7 +47,7 @@ void MinLayer::minQuant8()
   throw std::runtime_error("Min NYI for quantized");
 }
 
-void MinLayer::configure(const Tensor *lhs, const Tensor *rhs, Tensor *output)
+void MinLayer::configure(const ITensor *lhs, const ITensor *rhs, ITensor *output)
 {
   assert(lhs != nullptr);
   assert(rhs != nullptr);

--- a/runtime/onert/backend/cpu/ops/MinLayer.h
+++ b/runtime/onert/backend/cpu/ops/MinLayer.h
@@ -43,14 +43,14 @@ public:
 
   void minQuant8();
 
-  void configure(const Tensor *lhs, const Tensor *rhs, Tensor *output);
+  void configure(const ITensor *lhs, const ITensor *rhs, ITensor *output);
 
   void run();
 
 private:
-  const Tensor *_lhs;
-  const Tensor *_rhs;
-  Tensor *_output;
+  const ITensor *_lhs;
+  const ITensor *_rhs;
+  ITensor *_output;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/MulLayer.cc
+++ b/runtime/onert/backend/cpu/ops/MulLayer.cc
@@ -66,8 +66,8 @@ void MulLayer::mulQuant8()
   throw std::runtime_error{"Mull NYI for quantized"};
 }
 
-void MulLayer::configure(const Tensor *lhs, const Tensor *rhs, const ir::Activation activation,
-                         Tensor *output)
+void MulLayer::configure(const ITensor *lhs, const ITensor *rhs, const ir::Activation activation,
+                         ITensor *output)
 {
   _lhs = lhs;
   _rhs = rhs;

--- a/runtime/onert/backend/cpu/ops/MulLayer.h
+++ b/runtime/onert/backend/cpu/ops/MulLayer.h
@@ -44,15 +44,15 @@ public:
 
   void mulQuant8();
 
-  void configure(const Tensor *lhs, const Tensor *rhs, const ir::Activation activation,
-                 Tensor *output);
+  void configure(const ITensor *lhs, const ITensor *rhs, const ir::Activation activation,
+                 ITensor *output);
 
   void run();
 
 private:
-  const Tensor *_lhs;
-  const Tensor *_rhs;
-  Tensor *_output;
+  const ITensor *_lhs;
+  const ITensor *_rhs;
+  ITensor *_output;
 
   ir::Activation _activation{ir::Activation::NONE};
 };

--- a/runtime/onert/backend/cpu/ops/NegLayer.cc
+++ b/runtime/onert/backend/cpu/ops/NegLayer.cc
@@ -42,7 +42,7 @@ void NegLayer::negFloat32()
 
 void NegLayer::negQuant8() { throw std::runtime_error{"NYI"}; }
 
-void NegLayer::configure(const Tensor *input, Tensor *output)
+void NegLayer::configure(const ITensor *input, ITensor *output)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/ops/NegLayer.h
+++ b/runtime/onert/backend/cpu/ops/NegLayer.h
@@ -40,13 +40,13 @@ public:
 
   void negQuant8();
 
-  void configure(const Tensor *input, Tensor *output);
+  void configure(const ITensor *input, ITensor *output);
 
   void run();
 
 private:
-  const Tensor *_input;
-  Tensor *_output;
+  const ITensor *_input;
+  ITensor *_output;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/OneHotLayer.cc
+++ b/runtime/onert/backend/cpu/ops/OneHotLayer.cc
@@ -39,7 +39,7 @@ void OneHotLayer::oneHotFloat32()
 
 void OneHotLayer::oneHotQuant8() { throw std::runtime_error{"OneHot NYI for quantized"}; }
 
-void OneHotLayer::configure(const Tensor *indices, Tensor *output, int32_t depth, float on_value,
+void OneHotLayer::configure(const ITensor *indices, ITensor *output, int32_t depth, float on_value,
                             float off_value, int32_t axis)
 {
   _indices = indices;

--- a/runtime/onert/backend/cpu/ops/OneHotLayer.h
+++ b/runtime/onert/backend/cpu/ops/OneHotLayer.h
@@ -44,14 +44,14 @@ public:
 
   void oneHotQuant8();
 
-  void configure(const Tensor *indices, Tensor *output, int32_t depth, float on_value,
+  void configure(const ITensor *indices, ITensor *output, int32_t depth, float on_value,
                  float off_value, int32_t axis);
 
   void run();
 
 private:
-  const Tensor *_indices;
-  Tensor *_output;
+  const ITensor *_indices;
+  ITensor *_output;
 
   int32_t _depth;
   float _on_value;

--- a/runtime/onert/backend/cpu/ops/OperationUtils.cc
+++ b/runtime/onert/backend/cpu/ops/OperationUtils.cc
@@ -29,13 +29,13 @@ namespace cpu
 namespace ops
 {
 
-uint32_t getNumberOfDimensions(const Tensor *tensor)
+uint32_t getNumberOfDimensions(const ITensor *tensor)
 {
   assert(tensor);
   return tensor->num_dimensions();
 }
 
-uint32_t getNumberOfElements(const Tensor *tensor)
+uint32_t getNumberOfElements(const ITensor *tensor)
 {
   assert(tensor);
   uint32_t count = 1;
@@ -46,7 +46,7 @@ uint32_t getNumberOfElements(const Tensor *tensor)
   return count;
 }
 
-uint32_t getSizeOfDimension(const Tensor *tensor, uint32_t dimensionIdx)
+uint32_t getSizeOfDimension(const ITensor *tensor, uint32_t dimensionIdx)
 {
   assert(tensor);
   if (dimensionIdx >= tensor->num_dimensions())
@@ -78,8 +78,9 @@ void QuantizeMultiplier(double double_multiplier, int32_t *quantized_multiplier,
   *quantized_multiplier = static_cast<int32_t>(q_fixed);
 }
 
-void GetQuantizedConvolutionMultiplier(const Tensor *input, const Tensor *filter,
-                                       const Tensor *bias, const Tensor *output, double *multiplier)
+void GetQuantizedConvolutionMultiplier(const ITensor *input, const ITensor *filter,
+                                       const ITensor *bias, const ITensor *output,
+                                       double *multiplier)
 {
   const double input_product_scale = input->data_scale() * filter->data_scale();
   const double bias_scale = bias->data_scale();
@@ -144,7 +145,7 @@ void CalculateActivationRangeFloat(ir::Activation activation, float *activation_
   }
 }
 
-void CalculateActivationRangeUint8(ir::Activation activation, const Tensor *output,
+void CalculateActivationRangeUint8(ir::Activation activation, const ITensor *output,
                                    int32_t *act_min, int32_t *act_max)
 {
   const int32_t qmin = std::numeric_limits<uint8_t>::min();
@@ -185,7 +186,7 @@ void CalculateActivationRangeUint8(ir::Activation activation, const Tensor *outp
   }
 }
 
-bool HaveSameShapes(const Tensor *input1, const Tensor *input2)
+bool HaveSameShapes(const ITensor *input1, const ITensor *input2)
 {
   if (input1 == input2)
     return true;

--- a/runtime/onert/backend/cpu/ops/OperationUtils.h
+++ b/runtime/onert/backend/cpu/ops/OperationUtils.h
@@ -51,13 +51,13 @@ union DataPtr {
   void *v;
 };
 
-uint32_t getNumberOfDimensions(const Tensor *tensor);
+uint32_t getNumberOfDimensions(const ITensor *tensor);
 
-uint32_t getNumberOfElements(const Tensor *tensor);
+uint32_t getNumberOfElements(const ITensor *tensor);
 
-uint32_t getSizeOfDimension(const Tensor *tensor, uint32_t dimensionIdx);
+uint32_t getSizeOfDimension(const ITensor *tensor, uint32_t dimensionIdx);
 
-inline nnfw::cker::Shape getExtendedTensorShape(const Tensor *tensor)
+inline nnfw::cker::Shape getExtendedTensorShape(const ITensor *tensor)
 {
   assert(tensor);
   std::vector<int32_t> raw_shape;
@@ -79,7 +79,7 @@ inline nnfw::cker::Shape getExtendedTensorShape(const Tensor *tensor)
   return nnfw::cker::GetShape(raw_shape);
 }
 
-inline nnfw::cker::Shape getTensorShape(const Tensor *tensor)
+inline nnfw::cker::Shape getTensorShape(const ITensor *tensor)
 {
   if (tensor == nullptr)
     return nnfw::cker::Shape();
@@ -134,8 +134,8 @@ inline int32_t getAxis(uint32_t rank, int32_t axis, ir::Layout frontend_layout)
 
 void QuantizeMultiplier(double double_multiplier, int32_t *quantized_multiplier, int *shift);
 
-void GetQuantizedConvolutionMultiplier(const Tensor *inputDescr, const Tensor *filterDescr,
-                                       const Tensor *biasDescr, const Tensor *outputDescr,
+void GetQuantizedConvolutionMultiplier(const ITensor *inputDescr, const ITensor *filterDescr,
+                                       const ITensor *biasDescr, const ITensor *outputDescr,
                                        double *multiplier);
 
 void QuantizeMultiplierGreaterThanOne(double double_multiplier, int32_t *quantized_multiplier,
@@ -144,10 +144,10 @@ void QuantizeMultiplierGreaterThanOne(double double_multiplier, int32_t *quantiz
 void CalculateActivationRangeFloat(ir::Activation activation, float *activation_min,
                                    float *activation_max);
 
-void CalculateActivationRangeUint8(ir::Activation activation, const Tensor *output,
+void CalculateActivationRangeUint8(ir::Activation activation, const ITensor *output,
                                    int32_t *act_min, int32_t *act_max);
 
-bool HaveSameShapes(const Tensor *input1, const Tensor *input2);
+bool HaveSameShapes(const ITensor *input1, const ITensor *input2);
 
 int32_t CalculateInputRadius(int input_integer_bits, int input_left_shift);
 

--- a/runtime/onert/backend/cpu/ops/PackLayer.cc
+++ b/runtime/onert/backend/cpu/ops/PackLayer.cc
@@ -69,7 +69,7 @@ void PackLayer::packQuant8()
   throw std::runtime_error{"NYI"};
 }
 
-void PackLayer::configure(const std::vector<const Tensor *> &inputs, int32_t axis, Tensor *output)
+void PackLayer::configure(const std::vector<const ITensor *> &inputs, int32_t axis, ITensor *output)
 {
   assert(inputs.size() > 0);
   assert(output != nullptr);

--- a/runtime/onert/backend/cpu/ops/PackLayer.h
+++ b/runtime/onert/backend/cpu/ops/PackLayer.h
@@ -40,13 +40,13 @@ public:
 
   void packQuant8();
 
-  void configure(const std::vector<const Tensor *> &inputs, int32_t axis, Tensor *output);
+  void configure(const std::vector<const ITensor *> &inputs, int32_t axis, ITensor *output);
 
   void run();
 
 private:
-  std::vector<const Tensor *> _inputs;
-  Tensor *_output;
+  std::vector<const ITensor *> _inputs;
+  ITensor *_output;
   int32_t _axis;
 };
 

--- a/runtime/onert/backend/cpu/ops/PadLayer.cc
+++ b/runtime/onert/backend/cpu/ops/PadLayer.cc
@@ -41,7 +41,7 @@ void PadLayer::padFloat32()
 }
 void PadLayer::padQuant8() { throw std::runtime_error("Quantized Pad isn't supported NYI"); }
 
-void PadLayer::configure(const Tensor *input, Tensor *output, const int32_t *padData,
+void PadLayer::configure(const ITensor *input, ITensor *output, const int32_t *padData,
                          int32_t padRank, uint8_t *constantValueData)
 {
   _input = input;

--- a/runtime/onert/backend/cpu/ops/PadLayer.h
+++ b/runtime/onert/backend/cpu/ops/PadLayer.h
@@ -43,14 +43,14 @@ public:
 
   void padQuant8();
 
-  void configure(const Tensor *input, Tensor *output, const int32_t *padData, int32_t padRank,
+  void configure(const ITensor *input, ITensor *output, const int32_t *padData, int32_t padRank,
                  uint8_t *constantValueData = nullptr);
 
   void run();
 
 private:
-  const Tensor *_input;
-  Tensor *_output;
+  const ITensor *_input;
+  ITensor *_output;
 
   int32_t _padData[8];
   int32_t _padRank;

--- a/runtime/onert/backend/cpu/ops/PowLayer.cc
+++ b/runtime/onert/backend/cpu/ops/PowLayer.cc
@@ -51,8 +51,8 @@ void PowLayer::powFloat32()
                       getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()));
 }
 
-void PowLayer::configure(const Tensor *lhs, const Tensor *rhs, ir::Activation activation,
-                         Tensor *output)
+void PowLayer::configure(const ITensor *lhs, const ITensor *rhs, ir::Activation activation,
+                         ITensor *output)
 {
   _lhs = lhs;
   _rhs = rhs;

--- a/runtime/onert/backend/cpu/ops/PowLayer.h
+++ b/runtime/onert/backend/cpu/ops/PowLayer.h
@@ -42,15 +42,15 @@ public:
 public:
   void powFloat32();
 
-  void configure(const Tensor *lhs, const Tensor *rhs, const ir::Activation activation,
-                 Tensor *output);
+  void configure(const ITensor *lhs, const ITensor *rhs, const ir::Activation activation,
+                 ITensor *output);
 
   void run();
 
 private:
-  const Tensor *_lhs;
-  const Tensor *_rhs;
-  Tensor *_output;
+  const ITensor *_lhs;
+  const ITensor *_rhs;
+  ITensor *_output;
 
   ir::Activation _activation{ir::Activation::NONE};
 };

--- a/runtime/onert/backend/cpu/ops/RangeLayer.cc
+++ b/runtime/onert/backend/cpu/ops/RangeLayer.cc
@@ -33,8 +33,8 @@ RangeLayer::RangeLayer() : _start(nullptr), _limit(nullptr), _delta(nullptr), _o
   // DO NOTHING
 }
 
-void RangeLayer::configure(const Tensor *start, const Tensor *limit, const Tensor *delta,
-                           Tensor *output)
+void RangeLayer::configure(const ITensor *start, const ITensor *limit, const ITensor *delta,
+                           ITensor *output)
 {
   _start = start;
   _limit = limit;

--- a/runtime/onert/backend/cpu/ops/RangeLayer.h
+++ b/runtime/onert/backend/cpu/ops/RangeLayer.h
@@ -34,15 +34,15 @@ class RangeLayer : public ::onert::exec::IFunction
 public:
   RangeLayer();
 
-  void configure(const Tensor *start, const Tensor *limit, const Tensor *delta, Tensor *output);
+  void configure(const ITensor *start, const ITensor *limit, const ITensor *delta, ITensor *output);
 
   void run();
 
 private:
-  const Tensor *_start;
-  const Tensor *_limit;
-  const Tensor *_delta;
-  Tensor *_output;
+  const ITensor *_start;
+  const ITensor *_limit;
+  const ITensor *_delta;
+  ITensor *_output;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/ReLULayer.cc
+++ b/runtime/onert/backend/cpu/ops/ReLULayer.cc
@@ -46,7 +46,7 @@ void ReLULayer::reluQuant8()
   throw std::runtime_error{"NYI"};
 }
 
-void ReLULayer::configure(const Tensor *input, Tensor *output)
+void ReLULayer::configure(const ITensor *input, ITensor *output)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/ops/ReLULayer.h
+++ b/runtime/onert/backend/cpu/ops/ReLULayer.h
@@ -40,13 +40,13 @@ public:
 
   void reluQuant8();
 
-  void configure(const Tensor *input, Tensor *output);
+  void configure(const ITensor *input, ITensor *output);
 
   void run();
 
 private:
-  const Tensor *_input;
-  Tensor *_output;
+  const ITensor *_input;
+  ITensor *_output;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/ReduceLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ReduceLayer.cc
@@ -33,7 +33,7 @@ namespace
 {
 
 template <typename T>
-void evalLogic(const Tensor *input, Tensor *output, const std::vector<int> &axes, bool keep_dims,
+void evalLogic(const ITensor *input, ITensor *output, const std::vector<int> &axes, bool keep_dims,
                T init_value, nnfw::cker::Reduce &reduce_kernel,
                T reducer(const T current, const T in))
 {
@@ -49,7 +49,7 @@ void evalLogic(const Tensor *input, Tensor *output, const std::vector<int> &axes
 }
 
 template <typename T>
-void evalType(const Tensor *input, Tensor *output, const std::vector<int> &axes, bool keep_dims,
+void evalType(const ITensor *input, ITensor *output, const std::vector<int> &axes, bool keep_dims,
               nnfw::cker::Reduce &reduce_kernel, ReduceType reduce_type)
 {
   switch (reduce_type)
@@ -79,7 +79,7 @@ void evalType(const Tensor *input, Tensor *output, const std::vector<int> &axes,
 
 // Template specialization for bool type
 template <>
-void evalType<bool>(const Tensor *input, Tensor *output, const std::vector<int> &axes,
+void evalType<bool>(const ITensor *input, ITensor *output, const std::vector<int> &axes,
                     bool keep_dims, nnfw::cker::Reduce &reduce_kernel, ReduceType reduce_type)
 {
   switch (reduce_type)
@@ -100,8 +100,8 @@ void evalType<bool>(const Tensor *input, Tensor *output, const std::vector<int> 
 }
 
 template <ReduceType reduce_type>
-void evalGeneric(const Tensor *input, Tensor *output, const std::vector<int> &axes, bool keep_dims,
-                 nnfw::cker::Reduce &reduce_kernel)
+void evalGeneric(const ITensor *input, ITensor *output, const std::vector<int> &axes,
+                 bool keep_dims, nnfw::cker::Reduce &reduce_kernel)
 {
   switch (input->data_type())
   {
@@ -126,7 +126,7 @@ ReduceLayer::ReduceLayer()
 
 ReduceLayer::~ReduceLayer() = default;
 
-void ReduceLayer::configure(const Tensor *input, Tensor *output, ReduceType reduceType,
+void ReduceLayer::configure(const ITensor *input, ITensor *output, ReduceType reduceType,
                             const std::vector<int> &axes, bool keep_dims)
 {
   _input = input;

--- a/runtime/onert/backend/cpu/ops/ReduceLayer.h
+++ b/runtime/onert/backend/cpu/ops/ReduceLayer.h
@@ -56,14 +56,14 @@ public:
   ~ReduceLayer();
 
 public:
-  void configure(const Tensor *input, Tensor *output, ReduceType reduceType,
+  void configure(const ITensor *input, ITensor *output, ReduceType reduceType,
                  const std::vector<int> &axes, bool keep_dims);
 
   void run();
 
 private:
-  const Tensor *_input;
-  Tensor *_output;
+  const ITensor *_input;
+  ITensor *_output;
   ReduceType _reduceType;
   std::vector<int> _axes;
   bool _keep_dims;

--- a/runtime/onert/backend/cpu/ops/ReshapeLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ReshapeLayer.cc
@@ -36,7 +36,7 @@ void ReshapeLayer::reshapeGeneric()
   memcpy(_output->buffer(), _input->buffer(), count);
 }
 
-void ReshapeLayer::configure(const Tensor *input, const Tensor *shape, Tensor *output)
+void ReshapeLayer::configure(const ITensor *input, const ITensor *shape, ITensor *output)
 {
   _input = input;
   /* note : shape is optional. If not provided from model, _shape is nullptr. */

--- a/runtime/onert/backend/cpu/ops/ReshapeLayer.h
+++ b/runtime/onert/backend/cpu/ops/ReshapeLayer.h
@@ -38,14 +38,14 @@ public:
 public:
   void reshapeGeneric();
 
-  void configure(const Tensor *input, const Tensor *shape, Tensor *output);
+  void configure(const ITensor *input, const ITensor *shape, ITensor *output);
 
   void run();
 
 private:
-  const Tensor *_input;
-  const Tensor *_shape;
-  Tensor *_output;
+  const ITensor *_input;
+  const ITensor *_shape;
+  ITensor *_output;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/ReverseLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ReverseLayer.cc
@@ -54,7 +54,7 @@ void ReverseLayer::run()
   }
 }
 
-void ReverseLayer::configure(const Tensor *input, const Tensor *axis, Tensor *output)
+void ReverseLayer::configure(const ITensor *input, const ITensor *axis, ITensor *output)
 {
   _input = input;
   _axis = axis;

--- a/runtime/onert/backend/cpu/ops/ReverseLayer.h
+++ b/runtime/onert/backend/cpu/ops/ReverseLayer.h
@@ -39,14 +39,14 @@ public:
   }
 
 public:
-  void configure(const Tensor *input, const Tensor *axis, Tensor *output);
+  void configure(const ITensor *input, const ITensor *axis, ITensor *output);
 
   void run();
 
 private:
-  const Tensor *_input;
-  const Tensor *_axis;
-  Tensor *_output;
+  const ITensor *_input;
+  const ITensor *_axis;
+  ITensor *_output;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/RoundLayer.cc
+++ b/runtime/onert/backend/cpu/ops/RoundLayer.cc
@@ -39,7 +39,7 @@ void RoundLayer::roundFloat32()
                     getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()));
 }
 
-void RoundLayer::configure(const Tensor *input, Tensor *output)
+void RoundLayer::configure(const ITensor *input, ITensor *output)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/ops/RoundLayer.h
+++ b/runtime/onert/backend/cpu/ops/RoundLayer.h
@@ -34,7 +34,7 @@ class RoundLayer : public ::onert::exec::IFunction
 public:
   RoundLayer();
 
-  void configure(const Tensor *input, Tensor *output);
+  void configure(const ITensor *input, ITensor *output);
 
   void run();
 
@@ -42,8 +42,8 @@ private:
   void roundFloat32();
 
 private:
-  const Tensor *_input;
-  Tensor *_output;
+  const ITensor *_input;
+  ITensor *_output;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/RsqrtLayer.cc
+++ b/runtime/onert/backend/cpu/ops/RsqrtLayer.cc
@@ -41,7 +41,7 @@ void RsqrtLayer::rsqrtFloat32()
 
 void RsqrtLayer::rsqrtQuant8() { throw std::runtime_error{"NYI : QASYMM8 not supported"}; }
 
-void RsqrtLayer::configure(const Tensor *input, Tensor *output)
+void RsqrtLayer::configure(const ITensor *input, ITensor *output)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/ops/RsqrtLayer.h
+++ b/runtime/onert/backend/cpu/ops/RsqrtLayer.h
@@ -34,15 +34,15 @@ class RsqrtLayer : public ::onert::exec::IFunction
 public:
   RsqrtLayer();
 
-  void configure(const Tensor *input, Tensor *output);
+  void configure(const ITensor *input, ITensor *output);
 
   void run();
 
 private:
   void rsqrtFloat32();
   void rsqrtQuant8();
-  const Tensor *_input;
-  Tensor *_output;
+  const ITensor *_input;
+  ITensor *_output;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/SelectLayer.cc
+++ b/runtime/onert/backend/cpu/ops/SelectLayer.cc
@@ -35,8 +35,8 @@ SelectLayer::SelectLayer()
   // DO NOTHING
 }
 
-void SelectLayer::configure(const Tensor *cond, const Tensor *input_true, const Tensor *input_false,
-                            Tensor *output)
+void SelectLayer::configure(const ITensor *cond, const ITensor *input_true,
+                            const ITensor *input_false, ITensor *output)
 {
   _cond = cond;
   _input_true = input_true;

--- a/runtime/onert/backend/cpu/ops/SelectLayer.h
+++ b/runtime/onert/backend/cpu/ops/SelectLayer.h
@@ -36,16 +36,16 @@ public:
   SelectLayer();
 
 public:
-  void configure(const Tensor *cond, const Tensor *input_true, const Tensor *input_false,
-                 Tensor *output);
+  void configure(const ITensor *cond, const ITensor *input_true, const ITensor *input_false,
+                 ITensor *output);
 
   void run();
 
 private:
-  const Tensor *_cond;
-  const Tensor *_input_true;
-  const Tensor *_input_false;
-  Tensor *_output;
+  const ITensor *_cond;
+  const ITensor *_input_true;
+  const ITensor *_input_false;
+  ITensor *_output;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/ShapeLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ShapeLayer.cc
@@ -32,7 +32,7 @@ ShapeLayer::ShapeLayer() : _input(nullptr), _output(nullptr)
   // DO NOTHING
 }
 
-template <typename T> void GetRawShape(const Tensor *input, T *output_data)
+template <typename T> void GetRawShape(const ITensor *input, T *output_data)
 {
   for (uint32_t i = 0; i < input->num_dimensions(); ++i)
   {
@@ -56,7 +56,7 @@ void ShapeLayer::shape()
   }
 }
 
-void ShapeLayer::configure(const Tensor *input, Tensor *output)
+void ShapeLayer::configure(const ITensor *input, ITensor *output)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/ops/ShapeLayer.h
+++ b/runtime/onert/backend/cpu/ops/ShapeLayer.h
@@ -38,13 +38,13 @@ public:
 public:
   void shape();
 
-  void configure(const Tensor *input, Tensor *output);
+  void configure(const ITensor *input, ITensor *output);
 
   void run();
 
 private:
-  const Tensor *_input;
-  Tensor *_output;
+  const ITensor *_input;
+  ITensor *_output;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/SinLayer.cc
+++ b/runtime/onert/backend/cpu/ops/SinLayer.cc
@@ -40,7 +40,7 @@ void SinLayer::sinFloat32()
 
 void SinLayer::sinQuant8() { throw std::runtime_error{"NYI"}; }
 
-void SinLayer::configure(const Tensor *input, Tensor *output)
+void SinLayer::configure(const ITensor *input, ITensor *output)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/ops/SinLayer.h
+++ b/runtime/onert/backend/cpu/ops/SinLayer.h
@@ -34,7 +34,7 @@ class SinLayer : public ::onert::exec::IFunction
 public:
   SinLayer();
 
-  void configure(const Tensor *input, Tensor *output);
+  void configure(const ITensor *input, ITensor *output);
 
   void run();
 
@@ -42,8 +42,8 @@ private:
   void sinFloat32();
   void sinQuant8();
 
-  const Tensor *_input;
-  Tensor *_output;
+  const ITensor *_input;
+  ITensor *_output;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/SliceLayer.cc
+++ b/runtime/onert/backend/cpu/ops/SliceLayer.cc
@@ -35,7 +35,7 @@ SliceLayer::SliceLayer() : _input(nullptr), _begin(nullptr), _size(nullptr), _ou
 }
 
 template <typename T>
-void SliceLayer::GetBeginAndSizeVectors(int dimensions, const Tensor *begin, const Tensor *size,
+void SliceLayer::GetBeginAndSizeVectors(int dimensions, const ITensor *begin, const ITensor *size,
                                         std::vector<int> *begins, std::vector<int> *sizes)
 {
   for (int idx = dimensions - 1; idx >= 0; --idx)
@@ -83,8 +83,8 @@ void SliceLayer::sliceQuant8()
   throw std::runtime_error{"NYI"};
 }
 
-void SliceLayer::configure(const Tensor *input, const Tensor *begin, const Tensor *size,
-                           Tensor *output)
+void SliceLayer::configure(const ITensor *input, const ITensor *begin, const ITensor *size,
+                           ITensor *output)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/ops/SliceLayer.h
+++ b/runtime/onert/backend/cpu/ops/SliceLayer.h
@@ -36,7 +36,7 @@ public:
   SliceLayer();
 
 public:
-  void configure(const Tensor *input, const Tensor *begin, const Tensor *size, Tensor *output);
+  void configure(const ITensor *input, const ITensor *begin, const ITensor *size, ITensor *output);
 
   void run();
 
@@ -45,14 +45,14 @@ private:
   void sliceQuant8();
 
   template <typename T>
-  void GetBeginAndSizeVectors(int dimensions, const Tensor *begin, const Tensor *size,
+  void GetBeginAndSizeVectors(int dimensions, const ITensor *begin, const ITensor *size,
                               std::vector<int> *begins, std::vector<int> *sizes);
 
 private:
-  const Tensor *_input;
-  const Tensor *_begin;
-  const Tensor *_size;
-  Tensor *_output;
+  const ITensor *_input;
+  const ITensor *_begin;
+  const ITensor *_size;
+  ITensor *_output;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/SoftMaxLayer.cc
+++ b/runtime/onert/backend/cpu/ops/SoftMaxLayer.cc
@@ -146,7 +146,7 @@ void SoftMaxLayer::softmaxQuant8()
                       descrIn4D, reinterpret_cast<uint8_t *>(_output->buffer()));
 }
 
-void SoftMaxLayer::configure(const Tensor *input, const float beta, Tensor *output)
+void SoftMaxLayer::configure(const ITensor *input, const float beta, ITensor *output)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/ops/SoftMaxLayer.h
+++ b/runtime/onert/backend/cpu/ops/SoftMaxLayer.h
@@ -40,13 +40,13 @@ public:
 
   void softmaxQuant8();
 
-  void configure(const Tensor *input, const float beta, Tensor *output);
+  void configure(const ITensor *input, const float beta, ITensor *output);
 
   void run();
 
 private:
-  const Tensor *_input;
-  Tensor *_output;
+  const ITensor *_input;
+  ITensor *_output;
 
   float _beta;
 };

--- a/runtime/onert/backend/cpu/ops/SplitLayer.cc
+++ b/runtime/onert/backend/cpu/ops/SplitLayer.cc
@@ -65,8 +65,8 @@ void SplitLayer::splitFloat32()
 
 void SplitLayer::splitQuant8() { throw std::runtime_error{"Split: NYI quant8 type"}; }
 
-void SplitLayer::configure(const Tensor *input, uint16_t num_splits, int16_t axis,
-                           std::vector<Tensor *> &outputs)
+void SplitLayer::configure(const ITensor *input, uint16_t num_splits, int16_t axis,
+                           std::vector<ITensor *> &outputs)
 {
   assert(input != nullptr);
 

--- a/runtime/onert/backend/cpu/ops/SplitLayer.h
+++ b/runtime/onert/backend/cpu/ops/SplitLayer.h
@@ -40,16 +40,16 @@ public:
 
   void splitQuant8();
 
-  void configure(const Tensor *input, uint16_t num_splits, int16_t axis,
-                 std::vector<Tensor *> &outputs);
+  void configure(const ITensor *input, uint16_t num_splits, int16_t axis,
+                 std::vector<ITensor *> &outputs);
 
   void run();
 
 private:
-  const Tensor *_input;
+  const ITensor *_input;
   uint16_t _num_splits;
   int16_t _axis;
-  std::vector<Tensor *> _outputs;
+  std::vector<ITensor *> _outputs;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/SquaredDiffLayer.cc
+++ b/runtime/onert/backend/cpu/ops/SquaredDiffLayer.cc
@@ -41,7 +41,7 @@ void SqDiffLayer::SqDiffFloat32()
                      getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()));
 }
 
-void SqDiffLayer::configure(const Tensor *input1, const Tensor *input2, Tensor *output)
+void SqDiffLayer::configure(const ITensor *input1, const ITensor *input2, ITensor *output)
 {
   _input1 = input1;
   _input2 = input2;

--- a/runtime/onert/backend/cpu/ops/SquaredDiffLayer.h
+++ b/runtime/onert/backend/cpu/ops/SquaredDiffLayer.h
@@ -38,14 +38,14 @@ public:
 public:
   void SqDiffFloat32();
 
-  void configure(const Tensor *input1, const Tensor *input2, Tensor *output);
+  void configure(const ITensor *input1, const ITensor *input2, ITensor *output);
 
   void run();
 
 private:
-  const Tensor *_input1;
-  const Tensor *_input2;
-  Tensor *_output;
+  const ITensor *_input1;
+  const ITensor *_input2;
+  ITensor *_output;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/StridedSliceLayer.cc
+++ b/runtime/onert/backend/cpu/ops/StridedSliceLayer.cc
@@ -56,8 +56,8 @@ void StridedSliceLayer::stridedSliceQuant8()
   throw std::runtime_error{"NYI"};
 }
 
-void StridedSliceLayer::configure(const Tensor *input, const Tensor *begin, const Tensor *end,
-                                  const Tensor *strides, Tensor *output, const int32_t begin_mask,
+void StridedSliceLayer::configure(const ITensor *input, const ITensor *begin, const ITensor *end,
+                                  const ITensor *strides, ITensor *output, const int32_t begin_mask,
                                   const int32_t end_mask, const int32_t shrink_axis_mask,
                                   const int32_t rank)
 {

--- a/runtime/onert/backend/cpu/ops/StridedSliceLayer.h
+++ b/runtime/onert/backend/cpu/ops/StridedSliceLayer.h
@@ -37,9 +37,9 @@ public:
   StridedSliceLayer();
 
 public:
-  void configure(const Tensor *input, const Tensor *begin, const Tensor *end, const Tensor *strides,
-                 Tensor *output, const int32_t begin_mask, const int32_t end_mask,
-                 const int32_t shrink_axis_mask, const int32_t rank);
+  void configure(const ITensor *input, const ITensor *begin, const ITensor *end,
+                 const ITensor *strides, ITensor *output, const int32_t begin_mask,
+                 const int32_t end_mask, const int32_t shrink_axis_mask, const int32_t rank);
 
   void run();
 
@@ -48,11 +48,11 @@ private:
   void stridedSliceQuant8();
 
 private:
-  const Tensor *_input;
-  const Tensor *_begin;
-  const Tensor *_end;
-  const Tensor *_strides;
-  Tensor *_output;
+  const ITensor *_input;
+  const ITensor *_begin;
+  const ITensor *_end;
+  const ITensor *_strides;
+  ITensor *_output;
 
   int32_t _begin_mask;
   int32_t _ellipsis_mask;

--- a/runtime/onert/backend/cpu/ops/SubLayer.cc
+++ b/runtime/onert/backend/cpu/ops/SubLayer.cc
@@ -66,8 +66,8 @@ void SubLayer::subQuant8()
   throw std::runtime_error{"NYI"};
 }
 
-void SubLayer::configure(const Tensor *lhs, const Tensor *rhs, const ir::Activation activation,
-                         Tensor *output)
+void SubLayer::configure(const ITensor *lhs, const ITensor *rhs, const ir::Activation activation,
+                         ITensor *output)
 {
   _lhs = lhs;
   _rhs = rhs;

--- a/runtime/onert/backend/cpu/ops/SubLayer.h
+++ b/runtime/onert/backend/cpu/ops/SubLayer.h
@@ -44,15 +44,15 @@ public:
 
   void subQuant8();
 
-  void configure(const Tensor *lhs, const Tensor *rhs, const ir::Activation activation,
-                 Tensor *output);
+  void configure(const ITensor *lhs, const ITensor *rhs, const ir::Activation activation,
+                 ITensor *output);
 
   void run();
 
 private:
-  const Tensor *_lhs;
-  const Tensor *_rhs;
-  Tensor *_output;
+  const ITensor *_lhs;
+  const ITensor *_rhs;
+  ITensor *_output;
 
   ir::Activation _activation{ir::Activation::NONE};
 };

--- a/runtime/onert/backend/cpu/ops/TanhLayer.cc
+++ b/runtime/onert/backend/cpu/ops/TanhLayer.cc
@@ -46,7 +46,7 @@ void TanhLayer::tanhQuant8()
   throw std::runtime_error{"NYI"};
 }
 
-void TanhLayer::configure(const Tensor *input, Tensor *output)
+void TanhLayer::configure(const ITensor *input, ITensor *output)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/ops/TanhLayer.h
+++ b/runtime/onert/backend/cpu/ops/TanhLayer.h
@@ -40,13 +40,13 @@ public:
 
   void tanhQuant8();
 
-  void configure(const Tensor *input, Tensor *output);
+  void configure(const ITensor *input, ITensor *output);
 
   void run();
 
 private:
-  const Tensor *_input;
-  Tensor *_output;
+  const ITensor *_input;
+  ITensor *_output;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/TileLayer.cc
+++ b/runtime/onert/backend/cpu/ops/TileLayer.cc
@@ -47,7 +47,7 @@ void TileLayer::tileQuant8()
   throw std::runtime_error{"NYI"};
 }
 
-void TileLayer::configure(const Tensor *input, const Tensor *multipliers, Tensor *output)
+void TileLayer::configure(const ITensor *input, const ITensor *multipliers, ITensor *output)
 {
   _input = input;
   _multipliers = multipliers;

--- a/runtime/onert/backend/cpu/ops/TileLayer.h
+++ b/runtime/onert/backend/cpu/ops/TileLayer.h
@@ -40,14 +40,14 @@ public:
 
   void tileQuant8();
 
-  void configure(const Tensor *input, const Tensor *_multipliers, Tensor *output);
+  void configure(const ITensor *input, const ITensor *_multipliers, ITensor *output);
 
   void run();
 
 private:
-  const Tensor *_input;
-  const Tensor *_multipliers;
-  Tensor *_output;
+  const ITensor *_input;
+  const ITensor *_multipliers;
+  ITensor *_output;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/TransposeLayer.cc
+++ b/runtime/onert/backend/cpu/ops/TransposeLayer.cc
@@ -54,7 +54,7 @@ void TransposeLayer::transposeQuant8()
   throw std::runtime_error{"NYI"};
 }
 
-void TransposeLayer::configure(const Tensor *input, Tensor *output, const std::vector<int> &perm,
+void TransposeLayer::configure(const ITensor *input, ITensor *output, const std::vector<int> &perm,
                                int32_t rank)
 {
   _input = input;

--- a/runtime/onert/backend/cpu/ops/TransposeLayer.h
+++ b/runtime/onert/backend/cpu/ops/TransposeLayer.h
@@ -40,13 +40,13 @@ public:
 
   void transposeQuant8();
 
-  void configure(const Tensor *input, Tensor *output, const std::vector<int> &perm, int32_t rank);
+  void configure(const ITensor *input, ITensor *output, const std::vector<int> &perm, int32_t rank);
 
   void run();
 
 private:
-  const Tensor *_input;
-  Tensor *_output;
+  const ITensor *_input;
+  ITensor *_output;
   std::vector<int> _perm;
   int32_t _rank;
 };

--- a/runtime/onert/backend/cpu/ops/UnpackLayer.cc
+++ b/runtime/onert/backend/cpu/ops/UnpackLayer.cc
@@ -69,8 +69,8 @@ void UnpackLayer::unpackQuant8()
   throw std::runtime_error{"Unpack: NYI quant8 type"};
 }
 
-void UnpackLayer::configure(const Tensor *input, uint32_t axis, int32_t num,
-                            std::vector<Tensor *> &outputs)
+void UnpackLayer::configure(const ITensor *input, uint32_t axis, int32_t num,
+                            std::vector<ITensor *> &outputs)
 {
   assert(input != nullptr);
   assert(outputs.size() > 0);

--- a/runtime/onert/backend/cpu/ops/UnpackLayer.h
+++ b/runtime/onert/backend/cpu/ops/UnpackLayer.h
@@ -40,14 +40,14 @@ public:
 
   void unpackQuant8();
 
-  void configure(const Tensor *input, uint32_t axis, int32_t num_output,
-                 std::vector<Tensor *> &output);
+  void configure(const ITensor *input, uint32_t axis, int32_t num_output,
+                 std::vector<ITensor *> &output);
 
   void run();
 
 private:
-  const Tensor *_input;
-  std::vector<Tensor *> _outputs;
+  const ITensor *_input;
+  std::vector<ITensor *> _outputs;
   uint32_t _axis;
   int32_t _num_output;
 };

--- a/runtime/onert/backend/cpu/ops/ZerosLikeLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ZerosLikeLayer.cc
@@ -31,7 +31,7 @@ ZerosLikeLayer::ZerosLikeLayer() : _input(nullptr), _output(nullptr)
   // DO NOTHING
 }
 
-void ZerosLikeLayer::configure(const Tensor *input, Tensor *output)
+void ZerosLikeLayer::configure(const ITensor *input, ITensor *output)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/ops/ZerosLikeLayer.h
+++ b/runtime/onert/backend/cpu/ops/ZerosLikeLayer.h
@@ -34,13 +34,13 @@ class ZerosLikeLayer : public ::onert::exec::IFunction
 public:
   ZerosLikeLayer();
 
-  void configure(const Tensor *input, Tensor *output);
+  void configure(const ITensor *input, ITensor *output);
 
   void run();
 
 private:
-  const Tensor *_input;
-  Tensor *_output;
+  const ITensor *_input;
+  ITensor *_output;
 };
 
 } // namespace ops


### PR DESCRIPTION
In order to reuse tensor from another backend, `***Layer`s
must accept rather cpu's specific tensor(`cpu::Tensor`).
This commit makes cpu backend use `ITensor` in Layer implementations(To
accept tensors from other backends).

Part of #1325

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>