### PR TITLE
[res] TensorFlowPythonExamples for ScatterNd

### DIFF
--- a/res/TensorFlowPythonExamples/examples/scatter_nd/__init__.py
+++ b/res/TensorFlowPythonExamples/examples/scatter_nd/__init__.py
@@ -1,0 +1,10 @@
+# This example is a modified example from TF API documentation
+
+import tensorflow as tf
+
+indices = tf.compat.v1.constant([[0], [2]])
+updates = tf.compat.v1.constant([[[5, 5, 5, 5], [6, 6, 6, 6], [7, 7, 7, 7], [8, 8, 8, 8]],
+                                 [[5, 5, 5, 5], [6, 6, 6, 6], [7, 7, 7, 7], [8, 8, 8,
+                                                                             8]]])
+shape = tf.compat.v1.constant([4, 4, 4])
+sc_ = tf.compat.v1.scatter_nd(indices, updates, shape)


### PR DESCRIPTION
This will introduce TensorFlowPythonExamples for ScatterNd op

For #1711
Draft #1920

ONE-DCO-1.0-Signed-off-by: Andrey Kvochko <a.kvochko@samsung.com>