### PR TITLE
[onert] Introduce `ITensor` quant methods

### DIFF
--- a/runtime/onert/backend/acl_common/IACLTensor.cc
+++ b/runtime/onert/backend/acl_common/IACLTensor.cc
@@ -60,6 +60,18 @@ ir::DataType IACLTensor::data_type() const
   return acl_common::asRuntimeDataType(info()->data_type());
 }
 
+float IACLTensor::data_scale() const
+{
+  // FIXME What if quantization info is non-uniform?
+  return info()->quantization_info().uniform().scale;
+}
+
+int32_t IACLTensor::data_offset() const
+{
+  // FIXME What if quantization info is non-uniform?
+  return info()->quantization_info().uniform().offset;
+}
+
 } // namespace acl_common
 } // namespace backend
 } // namespace onert

--- a/runtime/onert/backend/acl_common/IACLTensor.h
+++ b/runtime/onert/backend/acl_common/IACLTensor.h
@@ -49,6 +49,8 @@ public:
   size_t calcOffset(const ir::Coordinates &coords) const final;
   ir::Layout layout() const final;
   ir::DataType data_type() const final;
+  float data_scale() const override;
+  int32_t data_offset() const override;
   bool has_padding() const override { return info()->has_padding(); }
   bool is_dynamic() const override { return false; }
 

--- a/runtime/onert/core/include/backend/ITensor.h
+++ b/runtime/onert/core/include/backend/ITensor.h
@@ -44,6 +44,8 @@ public:
   virtual size_t calcOffset(const ir::Coordinates &coords) const = 0;
   virtual ir::Layout layout() const = 0;
   virtual ir::DataType data_type() const = 0;
+  virtual float data_scale() const = 0;
+  virtual int32_t data_offset() const = 0;
   virtual bool has_padding() const = 0;
   virtual void access(const std::function<void(ITensor &tensor)> &fn) = 0;
 

--- a/runtime/onert/core/include/backend/cpu_common/Tensor.h
+++ b/runtime/onert/core/include/backend/cpu_common/Tensor.h
@@ -81,8 +81,8 @@ public:
   size_t calcOffset(const ir::Coordinates &coords) const override;
   ir::Layout layout() const override { return ir::Layout::NHWC; }
   ir::DataType data_type() const override { return _info.typeInfo().type(); }
-  float data_scale() const { return _info.typeInfo().scale(); }
-  int32_t data_offset() const { return _info.typeInfo().offset(); }
+  float data_scale() const override { return _info.typeInfo().scale(); }
+  int32_t data_offset() const override { return _info.typeInfo().offset(); }
   bool has_padding() const override { return false; }
   void access(const std::function<void(ITensor &tensor)> &fn) final;
   bool is_dynamic() const override { return _info.isDynamic(); }

--- a/runtime/onert/core/src/interp/Tensor.h
+++ b/runtime/onert/core/src/interp/Tensor.h
@@ -125,6 +125,8 @@ public:
   bool is_dynamic() const override { return false; }
   bool has_padding() const override { return false; }
   ir::DataType data_type() const override { return _info.typeInfo().type(); }
+  float data_scale() const override { return _info.typeInfo().scale(); }
+  int32_t data_offset() const override { return _info.typeInfo().offset(); }
   const ir::OperandInfo &tensorInfo() const override { return _info; }
   uint64_t num_elements() const override { return _info.shape().num_elements(); };
 
@@ -165,6 +167,8 @@ public:
   bool is_dynamic() const override { return false; }
   bool has_padding() const override { return false; }
   ir::DataType data_type() const override { return _info.typeInfo().type(); }
+  float data_scale() const override { return _info.typeInfo().scale(); }
+  int32_t data_offset() const override { return _info.typeInfo().offset(); }
   const ir::OperandInfo &tensorInfo() const override { return _info; }
   uint64_t num_elements() const override { return _info.shape().num_elements(); };
 


### PR DESCRIPTION
Introduce `ITensor` qunatization interface methods - `data_scale` and
`data_offset`.

This will be used in #1964, and this is part of #1325.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>