### PR TITLE
[onert] Adds shape inference for Tile op and its test case.

### DIFF
--- a/runtime/onert/core/include/util/ShapeInference.h
+++ b/runtime/onert/core/include/util/ShapeInference.h
@@ -142,6 +142,7 @@ private:
   void visit(const ir::operation::Softmax &op);
   void visit(const ir::operation::Sub &op);
   void visit(const ir::operation::Tanh &op);
+  void visit(const ir::operation::Tile &op);
   void visit(const ir::operation::Unpack &op);
   // TODO write op starting from V
   void visit(const ir::operation::While &op);
@@ -218,6 +219,7 @@ public:
   void visit(const ir::operation::Softmax &op);
   void visit(const ir::operation::Sub &op);
   void visit(const ir::operation::Tanh &op);
+  void visit(const ir::operation::Tile &op);
   void visit(const ir::operation::Unpack &op);
   // TODO write op starting from V
   void visit(const ir::operation::ZerosLike &op);

--- a/runtime/onert/core/src/util/shapeinf/Tile.cc
+++ b/runtime/onert/core/src/util/shapeinf/Tile.cc
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "util/ShapeInference.h"
+
+namespace onert
+{
+namespace shape_inference
+{
+
+ir::Shape inferTileShape(const ir::Shape &in_shape, const int32_t *multiplier)
+{
+  // assert(in_shape.rank() == multiplier.rank());
+  ir::Shape new_Shape(in_shape.rank());
+
+  for (int i = 0; i < in_shape.rank(); ++i)
+  {
+    assert(multiplier[i]); // multiplier[i] shuld not be 0.
+    new_Shape.dim(i) = in_shape.dim(i) * multiplier[i];
+  }
+  return new_Shape;
+}
+
+void StaticInferer::visit(const ir::operation::Tile &op)
+{
+  const auto input_idx{op.getInputs().at(ir::operation::Tile::Input::INPUT)};
+  const auto &input = _operands.at(input_idx);
+
+  const auto multiplier_idx{op.getInputs().at(ir::operation::Tile::Input::MULTIPLES)};
+  const auto &multiplier = _operands.at(multiplier_idx);
+
+  const auto output_idx = op.getOutputs().at(0);
+  ir::Operand &output = _operands.at(output_idx);
+
+  if (input.info().isDynamic())
+  {
+    output.info().setDynamic();
+    return;
+  }
+
+  if (!multiplier.isConstant())
+  {
+    output.info().setDynamic();
+    return;
+  }
+
+  auto multiplier_buffer = reinterpret_cast<const int32_t *>(multiplier.data()->base());
+  assert(multiplier_buffer);
+
+  // re-sizing output shape
+  auto new_shape = inferTileShape(input.info().shape(), multiplier_buffer);
+  output.info().shape(new_shape);
+}
+
+void DynamicInferer::visit(const ir::operation::Tile &op)
+{
+  auto output_ind = op.getOutputs().at(0);
+  auto output = _tensor_registry->getITensor(output_ind);
+
+  auto input_idx = op.getInputs().at(ir::operation::Tile::Input::INPUT);
+  auto input = _tensor_registry->getITensor(input_idx);
+
+  auto multiplier_idx = op.getInputs().at(ir::operation::Tile::Input::MULTIPLES);
+  auto multiplier = _tensor_registry->getITensor(multiplier_idx);
+
+  if ((!input->is_dynamic()) && (!output->is_dynamic()))
+    return;
+
+  auto input_shape = getShape(input.get());
+  auto multiplier_buffer = reinterpret_cast<const int32_t *>(multiplier->buffer());
+  assert(multiplier_buffer);
+
+  auto output_shape = inferTileShape(input_shape, multiplier_buffer);
+
+  // set output shape and output buffer
+  _dynamic_tensor_manager->applyShape(output_ind, output_shape);
+  assert(output->buffer() != nullptr);
+}
+}
+}

--- a/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_cl
+++ b/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_cl
@@ -153,13 +153,16 @@ GeneratedTests.tanh_v1_2_zero_sized
 GeneratedTests.tanh_v1_2_zero_sized_quant8
 GeneratedTests.tanh_v1_dynamic_nnfw
 GeneratedTests.tile_1
+GeneratedTests.tile_1_dynamic_float32_nnfw
 GeneratedTests.tile_1_float16
 GeneratedTests.tile_1_quant8
 GeneratedTests.tile_2
+GeneratedTests.tile_2_dynamic_float32_nnfw
 GeneratedTests.tile_2_float16
 GeneratedTests.tile_2_quant8
 GeneratedTests.tile_2_int32
 GeneratedTests.tile_3
+GeneratedTests.tile_3_dynamic_float32_nnfw
 GeneratedTests.tile_3_float16
 GeneratedTests.tile_3_quant8
 GeneratedTests.tile_3_int32

--- a/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_neon
+++ b/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_neon
@@ -185,13 +185,16 @@ GeneratedTests.tanh_v1_2_zero_sized
 GeneratedTests.tanh_v1_2_zero_sized_quant8
 GeneratedTests.tanh_v1_dynamic_nnfw
 GeneratedTests.tile_1
+GeneratedTests.tile_1_dynamic_float32_nnfw
 GeneratedTests.tile_1_float16
 GeneratedTests.tile_1_quant8
 GeneratedTests.tile_2
+GeneratedTests.tile_2_dynamic_float32_nnfw
 GeneratedTests.tile_2_float16
 GeneratedTests.tile_2_quant8
 GeneratedTests.tile_2_int32
 GeneratedTests.tile_3
+GeneratedTests.tile_3_dynamic_float32_nnfw
 GeneratedTests.tile_3_float16
 GeneratedTests.tile_3_quant8
 GeneratedTests.tile_3_int32

--- a/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_cl
+++ b/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_cl
@@ -153,13 +153,16 @@ GeneratedTests.tanh_v1_2_zero_sized
 GeneratedTests.tanh_v1_2_zero_sized_quant8
 GeneratedTests.tanh_v1_dynamic_nnfw
 GeneratedTests.tile_1
+GeneratedTests.tile_1_dynamic_float32_nnfw
 GeneratedTests.tile_1_float16
 GeneratedTests.tile_1_quant8
 GeneratedTests.tile_2
+GeneratedTests.tile_2_dynamic_float32_nnfw
 GeneratedTests.tile_2_float16
 GeneratedTests.tile_2_quant8
 GeneratedTests.tile_2_int32
 GeneratedTests.tile_3
+GeneratedTests.tile_3_dynamic_float32_nnfw
 GeneratedTests.tile_3_float16
 GeneratedTests.tile_3_quant8
 GeneratedTests.tile_3_int32

--- a/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_neon
+++ b/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_neon
@@ -177,13 +177,16 @@ GeneratedTests.tanh_v1_2_zero_sized
 GeneratedTests.tanh_v1_2_zero_sized_quant8
 GeneratedTests.tanh_v1_dynamic_nnfw
 GeneratedTests.tile_1
+GeneratedTests.tile_1_dynamic_float32_nnfw
 GeneratedTests.tile_1_float16
 GeneratedTests.tile_1_quant8
 GeneratedTests.tile_2
+GeneratedTests.tile_2_dynamic_float32_nnfw
 GeneratedTests.tile_2_float16
 GeneratedTests.tile_2_quant8
 GeneratedTests.tile_2_int32
 GeneratedTests.tile_3
+GeneratedTests.tile_3_dynamic_float32_nnfw
 GeneratedTests.tile_3_float16
 GeneratedTests.tile_3_quant8
 GeneratedTests.tile_3_int32

--- a/tests/nnapi/nnapi_gtest.skip.noarch.interp
+++ b/tests/nnapi/nnapi_gtest.skip.noarch.interp
@@ -494,13 +494,16 @@ GeneratedTests.tanh_v1_2_zero_sized
 GeneratedTests.tanh_v1_2_zero_sized_quant8
 GeneratedTests.tanh_v1_dynamic_nnfw
 GeneratedTests.tile_1
+GeneratedTests.tile_1_dynamic_float32_nnfw
 GeneratedTests.tile_1_float16
 GeneratedTests.tile_1_quant8
 GeneratedTests.tile_2
+GeneratedTests.tile_2_dynamic_float32_nnfw
 GeneratedTests.tile_2_float16
 GeneratedTests.tile_2_quant8
 GeneratedTests.tile_2_int32
 GeneratedTests.tile_3
+GeneratedTests.tile_3_dynamic_float32_nnfw
 GeneratedTests.tile_3_float16
 GeneratedTests.tile_3_quant8
 GeneratedTests.tile_3_int32

--- a/tests/nnapi/specs/V1_2/tile_1_dynamic_float32_nnfw.mod.py
+++ b/tests/nnapi/specs/V1_2/tile_1_dynamic_float32_nnfw.mod.py
@@ -1,0 +1,33 @@
+#
+# Copyright (C) 2018 The Android Open Source Project
+# Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# If multiplier is from input, the output shape of tile cannot be decided at compilation time.
+# Therefore, its output is "dynamic tensor"
+#
+
+input0 = Input("input0", "TENSOR_FLOAT32", "{3}")
+multi0 =  Input("input1", "TENSOR_INT32", "{}")
+output0 = Output("output", "TENSOR_FLOAT32", "{6}")
+
+model0 = Model().Operation("TILE", input0, multi0).To(output0)
+
+Example({
+    input0: [1.2, -3.4, 5.6],
+    multi0: [2],
+    output0: [1.2, -3.4, 5.6, 1.2, -3.4, 5.6],
+})

--- a/tests/nnapi/specs/V1_2/tile_2_dynamic_float32_nnfw.mod.py
+++ b/tests/nnapi/specs/V1_2/tile_2_dynamic_float32_nnfw.mod.py
@@ -1,0 +1,36 @@
+#
+# Copyright (C) 2018 The Android Open Source Project
+# Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# If multiplier is from input, the output shape of tile cannot be decided at compilation time.
+# Therefore, its output is "dynamic tensor"
+#
+
+input0 = Input("input0", "TENSOR_FLOAT32", "{2, 3}")
+multi0 =  Input("input1", "TENSOR_INT32", "{2}")
+output0 = Output("output", "TENSOR_FLOAT32", "{4, 3}")
+model0 = Model().Operation("TILE", input0, multi0).To(output0)
+
+Example({
+    input0: [11, 12, 13,
+                21, 22, 23],
+    multi0: [2, 1],
+    output0: [11, 12, 13,
+              21, 22, 23,
+              11, 12, 13,
+              21, 22, 23],
+})

--- a/tests/nnapi/specs/V1_2/tile_3_dynamic_float32_nnfw.mod.py
+++ b/tests/nnapi/specs/V1_2/tile_3_dynamic_float32_nnfw.mod.py
@@ -1,0 +1,37 @@
+#
+# Copyright (C) 2018 The Android Open Source Project
+# Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# If multiplier is from input, the output shape of tile cannot be decided at compilation time.
+# Therefore, its output is "dynamic tensor"
+#
+
+input0 = Input("input0", "TENSOR_FLOAT32", "{1, 2, 3}")
+multi0 =  Input("input1", "TENSOR_INT32", "{3}")
+output0 = Output("output", "TENSOR_FLOAT32", "{2, 6, 3}")
+
+model0 = Model().Operation("TILE", input0, multi0).To(output0)
+
+Example({
+    input0: [11, 12, 13,
+             21, 22, 23],
+    multi0: [2, 3, 1],
+    output0: [11, 12, 13, 21, 22, 23, 11, 12, 13,
+              21, 22, 23, 11, 12, 13, 21, 22, 23,
+              11, 12, 13, 21, 22, 23, 11, 12, 13,
+              21, 22, 23, 11, 12, 13, 21, 22, 23],
+})


### PR DESCRIPTION
Adds Shape inference for Tile Op. to support dynamic tensor.


ONE-DCO-1.0-Signed-off-by: H Kim <hyunjun2.kim@samsung.com>