### PR TITLE
[onert] Add topological sorted iterating method into LoweredGraph

### DIFF
--- a/runtime/onert/core/include/ir/LoweredGraph.h
+++ b/runtime/onert/core/include/ir/LoweredGraph.h
@@ -51,6 +51,9 @@ public:
   void removeLowerInfo(const OperandIndex &index);
   OpSequences &op_seqs() { return _op_seqs; }
   const OpSequences &op_seqs() const { return _op_seqs; }
+  void iterateTopolOpSeqs(
+      const std::function<void(const OpSequenceIndex &, const OpSequence &)> &fn) const;
+  void iterateTopolOpSeqs(const std::function<void(const OpSequenceIndex &, OpSequence &)> &fn);
   const backend::BackendContexts &backend_contexts() { return _backend_contexts; }
   const backend::BackendContexts &backend_contexts() const { return _backend_contexts; }
   std::shared_ptr<ir::OperationIndexMap<int64_t>> indexed_ranks() { return _indexed_ranks; }

--- a/runtime/onert/core/src/compiler/ExecutorFactory.cc
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.cc
@@ -234,8 +234,8 @@ ExecutorFactory::createLinearExecutor(std::unique_ptr<ir::LoweredGraph> lowered_
   ExecutionBuilder builder;
 
   // Generate kernels
-  lowered_graph->op_seqs().iterate([&](const ir::OpSequenceIndex &op_seq_index,
-                                       const ir::OpSequence &op_seq) {
+  lowered_graph->iterateTopolOpSeqs([&](const ir::OpSequenceIndex &op_seq_index,
+                                        const ir::OpSequence &op_seq) {
     auto lower_info = lowered_graph->getLowerInfo(op_seq_index);
     auto kernel_gen = lowered_graph->backend_contexts().at(lower_info->backend())->kernel_gen;
     // Set TensorBuilderSet and ExecutorMap to kernel_gen of control flow
@@ -336,8 +336,8 @@ exec::IExecutor *ExecutorFactory::createDataflowExecutor(
   ExecutionBuilder builder;
 
   // Generate kernels
-  lowered_graph->op_seqs().iterate([&](const ir::OpSequenceIndex &op_seq_index,
-                                       const ir::OpSequence &op_seq) {
+  lowered_graph->iterateTopolOpSeqs([&](const ir::OpSequenceIndex &op_seq_index,
+                                        const ir::OpSequence &op_seq) {
     auto lower_info = lowered_graph->getLowerInfo(op_seq_index);
     auto kernel_gen = lowered_graph->backend_contexts().at(lower_info->backend())->kernel_gen;
     // Set TensorBuilderSet and ExecutorMap to kernel_gen of control flow


### PR DESCRIPTION
For issue #1940
Draft PR #1941

This commit adds topological sorted iterating method into LoweredGraph.
  - Add topological sorted iterating method
  - Apply the method

Signed-off-by: ragmani <ragmani0216@gmail.com>