### PR TITLE
[CircleRecipes] Add BatchMatMul_000 rule

### DIFF
--- a/res/CircleRecipes/BatchMatMul_000/test.rule
+++ b/res/CircleRecipes/BatchMatMul_000/test.rule
@@ -1,0 +1,5 @@
+# To check if BatchMatMul exists
+
+RULE    "VERIFY_FILE_FORMAT"      $(verify_file_format) '=' 1
+
+RULE    "BATCH_MATMUL_EXIST"      $(op_count BATCH_MATMUL) '=' 1


### PR DESCRIPTION
This commit adds BatchMatMul_000 rule

This rule is for expending `circle2circle-dredd-recipe-test` to support `CircleRecipe` as well.
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>