### PR TITLE
[TensorFlowPythonExamples] Add matrix_band_part

### DIFF
--- a/res/TensorFlowPythonExamples/examples/matrix_band_part/__init__.py
+++ b/res/TensorFlowPythonExamples/examples/matrix_band_part/__init__.py
@@ -1,0 +1,4 @@
+import tensorflow as tf
+
+in_ = tf.compat.v1.placeholder(dtype=tf.float32, shape=(4, 4), name="Hole")
+op_ = tf.compat.v1.matrix_band_part(in_, 1, -1)


### PR DESCRIPTION
This commit adds matrix_band_part to TensorFlowPythonExamples

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>