### PR TITLE
[DRAFT][onert] Adjust calling order of `StaticInferer` in multiple subgraphs

### DIFF
--- a/runtime/onert/core/include/util/ShapeInference.h
+++ b/runtime/onert/core/include/util/ShapeInference.h
@@ -27,7 +27,7 @@
 #include "ir/operation/Reshape.h"
 #include "ir/operation/RSQRT.h"
 #include "ir/operation/StridedSlice.h"
-#include "ir/Graph.h"
+#include "ir/LoweredGraph.h"
 #include "ir/Index.h"
 #include "ir/Layout.h"
 #include "ir/OperationVisitor.h"
@@ -87,8 +87,13 @@ ir::Shape inferMaxPoolShape(const ir::Shape &in_shape, const ir::operation::MaxP
 class StaticInferer : public ir::OperationVisitor
 {
 public:
-  StaticInferer(ir::Graph &graph)
-      : _operands(graph.operands()), _operations(graph.operations()) { /* empty */}
+  StaticInferer(
+      const std::unordered_map<ir::SubgraphIndex, std::unique_ptr<ir::LoweredGraph>> &lowered_subgs)
+      : _lowered_subgs(lowered_subgs),
+        _operands(lowered_subgs.at(ir::SubgraphIndex{0})->graph().operands()),
+        _operations(lowered_subgs.at(ir::SubgraphIndex{0})->graph().operations())
+  { /* empty */
+  }
   virtual ~StaticInferer() = default;
 
 public:
@@ -167,8 +172,10 @@ private:
   void handleSimpleUnaryOp(const ir::Operation &op, const ir::OperandIndex input_idx);
 
 private:
-  ir::Operands &_operands;
-  ir::Operations &_operations;
+  const std::unordered_map<ir::SubgraphIndex, std::unique_ptr<ir::LoweredGraph>> &_lowered_subgs;
+  // _operands and _operations can be changed by controlflow operation
+  ir::Operands &_operands;     // operands of current subgraph
+  ir::Operations &_operations; // operations of current subgraph
 };
 
 // TODO After implement several Ops, check if this class can be merged with StaticInferer

--- a/runtime/onert/core/include/util/ShapeInference.h
+++ b/runtime/onert/core/include/util/ShapeInference.h
@@ -88,10 +88,10 @@ class StaticInferer : public ir::OperationVisitor
 {
 public:
   StaticInferer(
+      const ir::SubgraphIndex &subg_idx,
       const std::unordered_map<ir::SubgraphIndex, std::unique_ptr<ir::LoweredGraph>> &lowered_subgs)
-      : _lowered_subgs(lowered_subgs),
-        _operands(lowered_subgs.at(ir::SubgraphIndex{0})->graph().operands()),
-        _operations(lowered_subgs.at(ir::SubgraphIndex{0})->graph().operations())
+      : _lowered_subgs(lowered_subgs), _operands(lowered_subgs.at(subg_idx)->graph().operands()),
+        _operations(lowered_subgs.at(subg_idx)->graph().operations())
   { /* empty */
   }
   virtual ~StaticInferer() = default;

--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -33,6 +33,7 @@
 #include "interp/InterpExecutor.h"
 #include "util/ConfigSource.h"
 #include "util/logging.h"
+#include "util/ShapeInference.h"
 #include "ir/OperationDumper.h"
 #include "misc/string_helpers.h"
 
@@ -248,6 +249,16 @@ void Compiler::compile(void)
   });
 
   _subgraphs.reset();
+
+  // Shape inference.
+  {
+    shape_inference::StaticInferer inferer(lowered_subgs);
+    lowered_subgs.at(ir::SubgraphIndex{0})
+        ->iterateTopolOpSeqs([&](const ir::OpSequenceIndex &, const ir::OpSequence &op_seq) {
+          inferer.infer(op_seq);
+        });
+    inferer.dump();
+  }
 
   /*************************************************************
    *  Backend independent analysis & optimization phase finished

--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -252,8 +252,9 @@ void Compiler::compile(void)
 
   // Shape inference.
   {
-    shape_inference::StaticInferer inferer(lowered_subgs);
-    lowered_subgs.at(ir::SubgraphIndex{0})
+    const auto primary_subg_idx = ir::SubgraphIndex{0};
+    shape_inference::StaticInferer inferer(primary_subg_idx, lowered_subgs);
+    lowered_subgs.at(primary_subg_idx)
         ->iterateTopolOpSeqs([&](const ir::OpSequenceIndex &, const ir::OpSequence &op_seq) {
           inferer.infer(op_seq);
         });

--- a/runtime/onert/core/src/ir/LoweredGraph.cc
+++ b/runtime/onert/core/src/ir/LoweredGraph.cc
@@ -30,7 +30,6 @@
 #include "compiler/BackendResolver.h"
 #include "compiler/ManualScheduler.h"
 #include "compiler/HEScheduler.h"
-#include "util/ShapeInference.h"
 
 namespace onert
 {
@@ -118,14 +117,6 @@ LoweredGraph::LoweredGraph(const Graph &graph, const compiler::CompilerOptions &
     // pe_pass.run();
 
     _op_seqs.dump("merged and sorted operations with permutation", _graph.operations());
-  }
-
-  // Shape inference.
-  {
-    shape_inference::StaticInferer inferer(_graph);
-    iterateTopolOpSeqs(
-        [&](const ir::OpSequenceIndex &, const ir::OpSequence &op_seq) { inferer.infer(op_seq); });
-    inferer.dump();
   }
 
   // Graph verifications

--- a/runtime/onert/core/src/util/shapeinf/ShapeInference.cc
+++ b/runtime/onert/core/src/util/shapeinf/ShapeInference.cc
@@ -232,11 +232,18 @@ void StaticInferer::dump()
     return sstream.str();
   };
 
-  _operands.iterate([&](const ir::OperandIndex &ind, const ir::Operand &operand) {
-    VERBOSE(StaticInferer) << "Operand #" << ind.value() << ", "
-                           << (operand.info().isDynamic() ? "Dynamic" : "Static") << ", "
-                           << get_shape_str(operand.info().shape()) << std::endl;
-  });
+  for (const auto &pair : _lowered_subgs)
+  {
+    const auto index = pair.first;
+    const auto &lowered_subg = pair.second;
+    VERBOSE(StaticInferer) << "SubGraph #" << index.value() << std::endl;
+    lowered_subg->graph().operands().iterate(
+        [&](const ir::OperandIndex &ind, const ir::Operand &operand) {
+          VERBOSE(StaticInferer) << "Operand #" << ind.value() << ", "
+                                 << (operand.info().isDynamic() ? "Dynamic" : "Static") << ", "
+                                 << get_shape_str(operand.info().shape()) << std::endl;
+        });
+  }
 }
 
 /*

--- a/runtime/onert/core/src/util/shapeinf/While.cc
+++ b/runtime/onert/core/src/util/shapeinf/While.cc
@@ -23,18 +23,120 @@ namespace shape_inference
 
 void StaticInferer::visit(const ir::operation::While &op)
 {
-  for (const auto input_idx : op.getInputs())
+  auto &cond_graph = _lowered_subgs.at(op.param().cond_subg_index)->graph();
+  auto &body_graph = _lowered_subgs.at(op.param().body_subg_index)->graph();
+  const auto inputs = op.getInputs();
+  const auto &outputs = op.getOutputs();
+
+  // re-sizing input shapes of then subgraph
+  const auto &cond_inputs = cond_graph.getInputs();
+  assert(inputs.size() == cond_inputs.size());
+  for (size_t i = 0; i < inputs.size(); ++i)
   {
-    if (_operands.at(input_idx).info().isDynamic())
+    const auto &input = _operands.at(inputs.at(i));
+    auto &cond_input = cond_graph.operands().at(cond_inputs.at(i));
+    if (input.info().isDynamic())
     {
-      for (const auto output_idx : op.getOutputs())
-      {
-        _operands.at(output_idx).info().setDynamic();
-      }
-      return;
+      cond_input.info().setDynamic();
+    }
+    else
+    {
+      auto new_shape = input.info().shape();
+      cond_input.info().shape(new_shape);
     }
   }
-  // While operation cannot infer shape of outputs without outputs of child subgraph
+
+  // re-sizing input shapes of body subgraph
+  const auto &body_inputs = body_graph.getInputs();
+  assert(cond_inputs.size() == body_inputs.size());
+  for (size_t i = 0; i < cond_inputs.size(); ++i)
+  {
+    const auto &cond_input = cond_graph.operands().at(cond_inputs.at(i));
+    auto &body_input = body_graph.operands().at(body_inputs.at(i));
+    if (cond_input.info().isDynamic())
+    {
+      body_input.info().setDynamic();
+    }
+    else
+    {
+      const auto &new_shape = cond_input.info().shape();
+      body_input.info().shape(new_shape);
+    }
+  }
+
+  // re-sizing operands of body subgraph
+  StaticInferer body_inferer(op.param().body_subg_index, _lowered_subgs);
+  _lowered_subgs.at(op.param().body_subg_index)
+      ->iterateTopolOpSeqs([&](const ir::OpSequenceIndex &, const ir::OpSequence &op_seq) {
+        body_inferer.infer(op_seq);
+      });
+
+  // Check whether while operation's shapes are predictable
+  // If any of shape of body outputs and cond inputs are different, non-constant operands would be
+  // set to dynamic
+  bool check_unpredictable_dynamic = false;
+  const auto &body_outputs = body_graph.getOutputs();
+  assert(body_outputs.size() == cond_inputs.size());
+  for (size_t i = 0; i < body_outputs.size(); ++i)
+  {
+    const auto &body_output = body_graph.operands().at(body_outputs.at(i));
+    auto &cond_input = cond_graph.operands().at(cond_inputs.at(i));
+    if ((cond_input.info().isDynamic() != body_output.info().isDynamic()) ||
+        (cond_input.shape() != body_output.shape()))
+    {
+      check_unpredictable_dynamic = true;
+      break;
+    }
+  }
+
+  if (check_unpredictable_dynamic)
+  {
+    // Set inputs of body subgraph
+    for (const auto &input_index : body_inputs)
+    {
+      body_graph.operands().at(input_index).info().setDynamic();
+    }
+
+    // Set inputs of cond subgraph
+    for (const auto &input_index : cond_inputs)
+    {
+      cond_graph.operands().at(input_index).info().setDynamic();
+    }
+
+    // Set non-constant operands of body subgraph to dynamic
+    StaticInferer body_inferer(op.param().body_subg_index, _lowered_subgs);
+    _lowered_subgs.at(op.param().body_subg_index)
+        ->iterateTopolOpSeqs([&](const ir::OpSequenceIndex &, const ir::OpSequence &op_seq) {
+          body_inferer.infer(op_seq);
+        });
+  }
+
+  // re-sizing operands of cond subgraph
+  // If check_unpredictable_dynamic is true, non-constant operands of cond subgraph would be set to
+  // dynamic
+  StaticInferer cond_inferer(op.param().cond_subg_index, _lowered_subgs);
+  _lowered_subgs.at(op.param().cond_subg_index)
+      ->iterateTopolOpSeqs([&](const ir::OpSequenceIndex &, const ir::OpSequence &op_seq) {
+        cond_inferer.infer(op_seq);
+      });
+
+  // re-sizing outputs of while operation
+  // If check_unpredictable_dynamic is true, outputs of while operation would be set to dynamic
+  assert(cond_inputs.size() == outputs.size());
+  for (size_t i = 0; i < cond_inputs.size(); ++i)
+  {
+    const auto &cond_input = cond_graph.operands().at(cond_inputs.at(i));
+    auto &output = _operands.at(outputs.at(i));
+    if (cond_input.info().isDynamic())
+    {
+      output.info().setDynamic();
+    }
+    else
+    {
+      const auto new_shape = cond_input.info().shape();
+      output.info().shape(new_shape);
+    }
+  }
 }
 
 } // namespace shape_inference


### PR DESCRIPTION
For issue #1999

This draft adjusts calling order of `StaticInferer` in multiple subgraphs

Signed-off-by: ragmani <ragmani0216@gmail.com>