### PR TITLE
[onert] add shape inference interface and its test case for SQUARED_DIFF op.

### DIFF
--- a/runtime/onert/core/include/util/ShapeInference.h
+++ b/runtime/onert/core/include/util/ShapeInference.h
@@ -147,6 +147,7 @@ private:
   void visit(const ir::operation::Softmax &op);
   void visit(const ir::operation::StridedSlice &op);
   void visit(const ir::operation::Sub &op);
+  void visit(const ir::operation::SquaredDifference &op);
   void visit(const ir::operation::Tanh &op);
   void visit(const ir::operation::Tile &op);
   void visit(const ir::operation::Transpose &op);
@@ -229,6 +230,7 @@ public:
   void visit(const ir::operation::Softmax &op);
   void visit(const ir::operation::StridedSlice &op);
   void visit(const ir::operation::Sub &op);
+  void visit(const ir::operation::SquaredDifference &op);
   void visit(const ir::operation::Tanh &op);
   void visit(const ir::operation::Tile &op);
   void visit(const ir::operation::Transpose &op);

--- a/runtime/onert/core/src/util/shapeinf/SquaredDifference.cc
+++ b/runtime/onert/core/src/util/shapeinf/SquaredDifference.cc
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "util/ShapeInference.h"
+
+namespace onert
+{
+namespace shape_inference
+{
+
+void StaticInferer::visit(const ir::operation::SquaredDifference &op)
+{
+  handleBinaryArithmeticOp(op, op.getInputs().at(ir::operation::SquaredDifference::Input::LHS),
+                           op.getInputs().at(ir::operation::SquaredDifference::Input::RHS));
+}
+
+void DynamicInferer::visit(const ir::operation::SquaredDifference &op)
+{
+  handleBinaryArithmeticOp(op, op.getInputs().at(ir::operation::SquaredDifference::Input::LHS),
+                           op.getInputs().at(ir::operation::SquaredDifference::Input::RHS));
+}
+} // namespace shape_inference
+} // namespace onert

--- a/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_cl
+++ b/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_cl
@@ -147,6 +147,7 @@ GeneratedTests.slice_zero_sized
 GeneratedTests.slice_zero_sized_quant8
 GeneratedTests.softmax_dynamic_nnfw
 GeneratedTests.sqrt_
+GeneratedTests.squared_difference_ex_dynamic_nnfw
 GeneratedTests.strided_slice_dynamic_nnfw
 GeneratedTests.sub_dynamic_nnfw
 GeneratedTests.sub_v1_2_zero_sized

--- a/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_neon
+++ b/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_neon
@@ -179,6 +179,7 @@ GeneratedTests.space_to_batch_quant8_2
 GeneratedTests.space_to_batch_quant8_2_nnfw
 GeneratedTests.space_to_batch_quant8_3
 GeneratedTests.sqrt_
+GeneratedTests.squared_difference_ex_dynamic_nnfw
 GeneratedTests.strided_slice_dynamic_nnfw
 GeneratedTests.sub_dynamic_nnfw
 GeneratedTests.sub_v1_2_zero_sized

--- a/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_cl
+++ b/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_cl
@@ -147,6 +147,7 @@ GeneratedTests.slice_zero_sized
 GeneratedTests.slice_zero_sized_quant8
 GeneratedTests.softmax_dynamic_nnfw
 GeneratedTests.sqrt_
+GeneratedTests.squared_difference_ex_dynamic_nnfw
 GeneratedTests.strided_slice_dynamic_nnfw
 GeneratedTests.sub_dynamic_nnfw
 GeneratedTests.sub_v1_2_zero_sized

--- a/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_neon
+++ b/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_neon
@@ -171,6 +171,7 @@ GeneratedTests.slice_zero_sized
 GeneratedTests.slice_zero_sized_quant8
 GeneratedTests.softmax_dynamic_nnfw
 GeneratedTests.sqrt_
+GeneratedTests.squared_difference_ex_dynamic_nnfw
 GeneratedTests.strided_slice_dynamic_nnfw
 GeneratedTests.sub_dynamic_nnfw
 GeneratedTests.sub_v1_2_zero_sized

--- a/tests/nnapi/nnapi_gtest.skip.noarch.interp
+++ b/tests/nnapi/nnapi_gtest.skip.noarch.interp
@@ -446,6 +446,7 @@ GeneratedTests.split_quant8_2_relaxed
 GeneratedTests.split_quant8_3
 GeneratedTests.split_quant8_4
 GeneratedTests.sqrt_
+GeneratedTests.squared_difference_ex_dynamic_nnfw
 GeneratedTests.sqrt_1D_float_nnfw
 GeneratedTests.sqrt_2D_float_nnfw
 GeneratedTests.sqrt_3D_float_nnfw

--- a/tests/nnapi/specs/Ex/squared_difference_ex_dynamic_nnfw.mod.py
+++ b/tests/nnapi/specs/Ex/squared_difference_ex_dynamic_nnfw.mod.py
@@ -1,0 +1,45 @@
+import dynamic_tensor
+
+
+# model
+model = Model()
+
+model_input1_shape = [3, 2, 2, 2]
+
+dynamic_layer = dynamic_tensor.DynamicInputGenerator(model, model_input1_shape, "TENSOR_FLOAT32")
+
+test_node_input = dynamic_layer.getTestNodeInput()
+
+i2 = Input("op2", "TENSOR_FLOAT32","{2, 2}")
+t1 = Internal("op3", "TENSOR_FLOAT32", "{}")
+o1 = Output("op3", "TENSOR_FLOAT32", "{3, 2, 2, 2}")
+
+model = model.Operation("SQUARED_DIFFERENCE_EX", test_node_input, i2).To(t1)
+model = model.Operation("SQUARED_DIFFERENCE_EX", t1, i2).To(o1)
+
+model_input1_data = [74.0, 63.0, 103.0, 88.0,
+                      57.0, 9.0, 68.0, 20.0,
+                      121.0, 38.0, 54.0, 119.0,
+                      56.0, 106.0, 98.0, 98.0,
+                      7.0, 89.0, 108.0, 104.0,
+                      20.0, 81.0, 4.0, 124.0]
+model_input2_data = [56.0, 115.0, 115.0, 116.0]
+
+input0 = {
+      dynamic_layer.getModelInput(): model_input1_data,   # input 1
+      dynamic_layer.getShapeInput(): model_input1_shape,
+
+      i2: model_input2_data # input 2
+      }
+
+output0 = {
+      o1: [71824.0, 6702921.0, 841.0, 446224.0,
+            3025.0, 123676640.0, 4384836.0, 82810000.0,
+            17380560.0, 33802596.0, 13003236.0, 11449.0,
+            3136.0, 1156.0, 30276.0, 43264.0,
+            5499025.0, 314721.0, 4356.0, 784.0,
+            1537600.0, 1083681.0, 148986432.0, 2704.0]
+           }
+
+# # Instantiate an example
+Example((input0, output0))


### PR DESCRIPTION
Add shape inference interface and its tc.

ONE-DCO-1.0-Signed-off-by: H Kim <hyunjun2.kim@samsung.com>