### PR TITLE
[onert] Move template instantiation to bottom

### DIFF
--- a/runtime/onert/core/src/ir/GraphIterator.cc
+++ b/runtime/onert/core/src/ir/GraphIterator.cc
@@ -24,14 +24,6 @@ namespace onert
 namespace ir
 {
 
-// Explicit instantiations to have implementation in the source file.
-
-template class DefaultIterator<true>;
-template class DefaultIterator<false>;
-
-template class PostDfsIterator<true>;
-template class PostDfsIterator<false>;
-
 //
 // Graph::DefaultIterator
 //
@@ -113,6 +105,17 @@ void PostDfsIterator<is_const>::iterateOpSeqs(LoweredGraphRef lowered_graph,
   assert(std::all_of(visited.begin(), visited.end(),
                      [](const std::pair<const OpSequenceIndex, bool> &v) { return v.second; }));
 }
+
+// Explicit instantiations to have implementation in the source file.
+// NOTE If these instatiations were in the top of this file, `iterate` is compiled and saved in
+//      `GraphIterator.cc.o` but `iterateOpSeqs`. This happens only when cross-building for Android.
+//      (Maybe a bug of NDK toolchain(clang)?)
+
+template class DefaultIterator<true>;
+template class DefaultIterator<false>;
+
+template class PostDfsIterator<true>;
+template class PostDfsIterator<false>;
 
 } // namespace ir
 } // namespace onert


### PR DESCRIPTION
Move template instantiations for Graph Iterators to bottom. This is a
workaround for Android build(Maybe this is required in the spec or just
a compiler's bug)

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>