### PR TITLE
[onert] Remove header dependency on Half

### DIFF
--- a/compute/cker/include/cker/operation/Pow.h
+++ b/compute/cker/include/cker/operation/Pow.h
@@ -20,6 +20,8 @@
 
 #include "cker/Shape.h"
 
+#include <cmath>
+
 namespace nnfw
 {
 namespace cker

--- a/runtime/onert/core/include/backend/IConstantInitializer.h
+++ b/runtime/onert/core/include/backend/IConstantInitializer.h
@@ -195,83 +195,8 @@ protected:
   virtual std::shared_ptr<ITensorBuilder> tensor_builder() const = 0;
 
 public:
-  void registerCopyInitializer(const ir::OperandIndex &index, const ir::Operand &obj)
-  {
-    // For only CONSTANTS
-    // TODO Add to check if tensor has been allocated
-    if (!obj.isConstant())
-      return;
-
-    const auto type = obj.typeInfo().type();
-    using ir::DataType;
-    using ir::float16;
-
-    switch (type)
-    {
-      case DataType::FLOAT32:
-        _init_map[index] = copyInit<float>;
-        break;
-      case DataType::INT32:
-        _init_map[index] = copyInit<int32_t>;
-        break;
-      case DataType::UINT32:
-        _init_map[index] = copyInit<uint32_t>;
-        break;
-      case DataType::BOOL8:
-      case DataType::QUANT_UINT8_ASYMM:
-        _init_map[index] = copyInit<uint8_t>;
-        break;
-      case DataType::QUANT_INT8_SYMM:
-        _init_map[index] = copyInit<int8_t>;
-        break;
-      case DataType::FLOAT16:
-        _init_map[index] = copyInit<float16>;
-        break;
-      default:
-        throw std::runtime_error("Not supported, yet");
-        break;
-    }
-  }
-
-public:
-  void registerPermuteInitializer(const ir::OperandIndex &index, const ir::Operand &obj)
-  {
-    // For only CONSTANTS
-    // TODO Add to check if tensor has been allocated
-    if (!obj.isConstant())
-      return;
-
-    const auto type = obj.typeInfo().type();
-    using ir::DataType;
-    using ir::float16;
-    using namespace std::placeholders;
-
-    switch (type)
-    {
-      case DataType::FLOAT32:
-        _init_map[index] = std::bind(permuteInit<float>, _1, _2, _current_op_seq_layout);
-        break;
-      case DataType::INT32:
-        _init_map[index] = std::bind(permuteInit<int32_t>, _1, _2, _current_op_seq_layout);
-        break;
-      case DataType::UINT32:
-        _init_map[index] = std::bind(permuteInit<uint32_t>, _1, _2, _current_op_seq_layout);
-        break;
-      case DataType::BOOL8:
-      case DataType::QUANT_UINT8_ASYMM:
-        _init_map[index] = std::bind(permuteInit<uint8_t>, _1, _2, _current_op_seq_layout);
-        break;
-      case DataType::QUANT_INT8_SYMM:
-        _init_map[index] = std::bind(permuteInit<int8_t>, _1, _2, _current_op_seq_layout);
-        break;
-      case DataType::FLOAT16:
-        _init_map[index] = std::bind(permuteInit<float16>, _1, _2, _current_op_seq_layout);
-        break;
-      default:
-        throw std::runtime_error("Not supported, yet");
-        break;
-    }
-  }
+  void registerCopyInitializer(const ir::OperandIndex &index, const ir::Operand &obj);
+  void registerPermuteInitializer(const ir::OperandIndex &index, const ir::Operand &obj);
 
 public:
   bool exist(const ir::OperandIndex &ind) { return _init_map.find(ind) != _init_map.end(); }

--- a/runtime/onert/core/include/ir/DataType.h
+++ b/runtime/onert/core/include/ir/DataType.h
@@ -17,15 +17,12 @@
 #ifndef __ONERT_IR_DATATYPE_H__
 #define __ONERT_IR_DATATYPE_H__
 
-#include <stdexcept>
-#include <Half.h>
+#include <cstdlib>
 
 namespace onert
 {
 namespace ir
 {
-
-using float16 = Half;
 
 enum class DataType
 {
@@ -39,28 +36,7 @@ enum class DataType
   FLOAT16 = 7,
 };
 
-inline size_t sizeOfDataType(DataType data_type)
-{
-  switch (data_type)
-  {
-    case DataType::FLOAT32:
-      return sizeof(float);
-    case DataType::INT32:
-      return sizeof(int32_t);
-    case DataType::UINT32:
-      return sizeof(uint32_t);
-    case DataType::BOOL8:
-    case DataType::QUANT_UINT8_ASYMM:
-    case DataType::UINT8:
-      return sizeof(uint8_t);
-    case DataType::QUANT_INT8_SYMM:
-      return sizeof(int8_t);
-    case DataType::FLOAT16:
-      return sizeof(float16);
-    default:
-      throw std::runtime_error{"Unsupported type size"};
-  }
-}
+size_t sizeOfDataType(DataType data_type);
 
 } // namespace ir
 } // namespace onert

--- a/runtime/onert/core/src/backend/IConstantInitializer.cc
+++ b/runtime/onert/core/src/backend/IConstantInitializer.cc
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "backend/IConstantInitializer.h"
+
+#include <Half.h>
+
+using float16 = Half;
+
+namespace onert
+{
+namespace backend
+{
+
+void IConstantInitializer::registerCopyInitializer(const ir::OperandIndex &index,
+                                                   const ir::Operand &obj)
+{
+  // For only CONSTANTS
+  // TODO Add to check if tensor has been allocated
+  if (!obj.isConstant())
+    return;
+
+  const auto type = obj.typeInfo().type();
+  using ir::DataType;
+
+  switch (type)
+  {
+    case DataType::FLOAT32:
+      _init_map[index] = copyInit<float>;
+      break;
+    case DataType::INT32:
+      _init_map[index] = copyInit<int32_t>;
+      break;
+    case DataType::UINT32:
+      _init_map[index] = copyInit<uint32_t>;
+      break;
+    case DataType::BOOL8:
+    case DataType::QUANT_UINT8_ASYMM:
+      _init_map[index] = copyInit<uint8_t>;
+      break;
+    case DataType::QUANT_INT8_SYMM:
+      _init_map[index] = copyInit<int8_t>;
+      break;
+    case DataType::FLOAT16:
+      _init_map[index] = copyInit<float16>;
+      break;
+    default:
+      throw std::runtime_error("Not supported, yet");
+      break;
+  }
+}
+
+void IConstantInitializer::registerPermuteInitializer(const ir::OperandIndex &index,
+                                                      const ir::Operand &obj)
+{
+  // For only CONSTANTS
+  // TODO Add to check if tensor has been allocated
+  if (!obj.isConstant())
+    return;
+
+  const auto type = obj.typeInfo().type();
+  using ir::DataType;
+  using namespace std::placeholders;
+
+  switch (type)
+  {
+    case DataType::FLOAT32:
+      _init_map[index] = std::bind(permuteInit<float>, _1, _2, _current_op_seq_layout);
+      break;
+    case DataType::INT32:
+      _init_map[index] = std::bind(permuteInit<int32_t>, _1, _2, _current_op_seq_layout);
+      break;
+    case DataType::UINT32:
+      _init_map[index] = std::bind(permuteInit<uint32_t>, _1, _2, _current_op_seq_layout);
+      break;
+    case DataType::BOOL8:
+    case DataType::QUANT_UINT8_ASYMM:
+      _init_map[index] = std::bind(permuteInit<uint8_t>, _1, _2, _current_op_seq_layout);
+      break;
+    case DataType::QUANT_INT8_SYMM:
+      _init_map[index] = std::bind(permuteInit<int8_t>, _1, _2, _current_op_seq_layout);
+      break;
+    case DataType::FLOAT16:
+      _init_map[index] = std::bind(permuteInit<float16>, _1, _2, _current_op_seq_layout);
+      break;
+    default:
+      throw std::runtime_error("Not supported, yet");
+      break;
+  }
+}
+
+} // namespace backend
+} // namespace onert

--- a/runtime/onert/core/src/compiler/Fp32ToFp16Converter.cc
+++ b/runtime/onert/core/src/compiler/Fp32ToFp16Converter.cc
@@ -19,16 +19,20 @@
 #include "ir/operation/ConvertFp16ToFp32.h"
 #include "util/logging.h"
 
+#include <Half.h>
+
+using float16 = Half;
+
 namespace
 {
 
 const std::string kAclClBackendConfigId = "acl_cl";
 
-void copyDataFromFp32ToFp16(const float *from, onert::ir::float16 *into, size_t num_elements)
+void copyDataFromFp32ToFp16(const float *from, float16 *into, size_t num_elements)
 {
   for (size_t i = 0; i < num_elements; ++i)
   {
-    into[i] = static_cast<onert::ir::float16>(from[i]);
+    into[i] = static_cast<float16>(from[i]);
   }
 }
 
@@ -430,10 +434,10 @@ void Fp32ToFp16Converter::convertDatas()
       assert(data != nullptr);
 
       size_t num_elements = obj.operandSize() / ir::sizeOfDataType(type);
-      size_t new_ptr_size = num_elements * sizeof(ir::float16);
+      size_t new_ptr_size = num_elements * sizeof(float16);
       auto new_ptr = std::make_unique<uint8_t[]>(new_ptr_size);
       copyDataFromFp32ToFp16(reinterpret_cast<const float *>(data->base()),
-                             reinterpret_cast<ir::float16 *>(new_ptr.get()), num_elements);
+                             reinterpret_cast<float16 *>(new_ptr.get()), num_elements);
       obj.releaseData();
 
       auto new_data = std::make_unique<ir::CachedData>(new_ptr.get(), new_ptr_size);

--- a/runtime/onert/core/src/ir/DataType.cc
+++ b/runtime/onert/core/src/ir/DataType.cc
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ir/DataType.h"
+
+#include <stdexcept>
+#include <Half.h>
+
+using float16 = Half;
+
+namespace onert
+{
+namespace ir
+{
+
+size_t sizeOfDataType(DataType data_type)
+{
+  switch (data_type)
+  {
+    case DataType::FLOAT32:
+      return sizeof(float);
+    case DataType::INT32:
+      return sizeof(int32_t);
+    case DataType::UINT32:
+      return sizeof(uint32_t);
+    case DataType::BOOL8:
+    case DataType::QUANT_UINT8_ASYMM:
+    case DataType::UINT8:
+      return sizeof(uint8_t);
+    case DataType::QUANT_INT8_SYMM:
+      return sizeof(int8_t);
+    case DataType::FLOAT16:
+      return sizeof(float16);
+    default:
+      throw std::runtime_error{"Unsupported type size"};
+  }
+}
+
+} // namespace ir
+} // namespace onert

--- a/runtime/onert/core/src/util/shapeinf/StridedSlice.cc
+++ b/runtime/onert/core/src/util/shapeinf/StridedSlice.cc
@@ -17,6 +17,8 @@
 
 #include "util/ShapeInference.h"
 
+#include <cmath>
+
 namespace onert
 {
 namespace shape_inference


### PR DESCRIPTION
This removes public header dependency on Half. So `Half` headers do not
have to be part of release package.

- Move implementations to source code and move inclusion of `Half.h` to
  source files

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>