### PR TITLE
[onert] don't overwrite tensor dim with tensor signature

### DIFF
--- a/runtime/onert/frontend/base_loader/include/base_loader.h
+++ b/runtime/onert/frontend/base_loader/include/base_loader.h
@@ -268,7 +268,11 @@ ir::OperandIndex BaseLoader<LoaderDomain, SpecificLoader>::loadOperand(const Ten
     for (const auto &sig_dim : *tensor_shape_sig)
     {
       if (sig_dim == -1)
-        shape.dim(i) = ir::Shape::UNSPECIFIED_DIM;
+      {
+        // TODO: save `-1` in tensor signature.
+        // signature is used to allow resizing only for unknown dim.
+        // tensor dim itself should not be overwriiten with `-1`.
+      }
       i++;
     }
   }


### PR DESCRIPTION
Tensor's signature exists when a tensor has unknown (-1) dim.
Signature is used to allow resizing for only unknown dim.

Tensor's shape should not be overwritten with signature.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>