### PR TITLE
[luci] Enable test for zero dim shape

### DIFF
--- a/compiler/luci/tests/test.lst
+++ b/compiler/luci/tests/test.lst
@@ -145,6 +145,7 @@ addread(Net_Dangle_001)
 addread(Net_InstanceNorm_001)
 addread(Net_InstanceNorm_002)
 addread(Net_UnpackAdd_001)
+addread(Net_ZeroDim_001)
 
 # from res/CircleRecipes
 addread(BatchMatMul_000)
@@ -297,6 +298,7 @@ addwrite(Net_Dangle_001)
 addwrite(Net_InstanceNorm_001)
 addwrite(Net_InstanceNorm_002)
 addwrite(Net_UnpackAdd_001)
+addwrite(Net_ZeroDim_001)
 
 # from res/CircleRecipes
 addwrite(BatchMatMul_000)


### PR DESCRIPTION
This will enable Net_ZeroDim_001 that has zero dim value shape

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>