### PR TITLE
[luci] Use input_count for While type inf

### DIFF
--- a/compiler/luci/service/src/CircleTypeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleTypeInferenceRule.cpp
@@ -408,7 +408,7 @@ struct TypeInferenceAlgorithm final : public luci::CircleNodeVisitor<loco::DataT
   loco::DataType visit(const luci::CircleWhile *node) final
   {
     // Type of While is not used. Just use input 0
-    assert(node->arity() > 0);
+    assert(node->input_count() > 0);
     return loco::dtype_get(node->input(0));
   }
 


### PR DESCRIPTION
This will revise CircleWhile type inference to use input_count() instead of arity()

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>