### PR TITLE
[onert] Apply adding default lower_info for unused non-constant output of Graph

### DIFF
--- a/runtime/onert/core/src/ir/LoweredGraph.cc
+++ b/runtime/onert/core/src/ir/LoweredGraph.cc
@@ -325,9 +325,9 @@ void LoweredGraph::manipulateLowerInfo(
   for (auto index : _graph.getOutputs())
   {
     auto &&lower_info = operands_lower_info.at(index);
-    if (_graph.operands().at(index).isConstant())
+    if (lower_info->def_factors().size() == 0)
     {
-      // In case of that a constant is Graph's output and not input or output of any operation
+      // In case of that an operand is Graph's output and not input or output of any operation
       lower_info->addDefPermuteFactor(operand::PermuteFactor{
           controlflow_backend,
           Layout::NHWC // TODO Get frontend layout of this node from IR


### PR DESCRIPTION
This commit Applies adding default lower_info for unused non-constant output of Graph
  - Orgin : Applying for only unused constant output of Graph
  - Changes : Applying for all unused output of Graph

Signed-off-by: ragmani <ragmani0216@gmail.com>