### PR TITLE
[luci] Enable ScatterNd operator in services

### DIFF
--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -1389,6 +1389,31 @@ public:
     return loco::NodeShape{input_shape};
   }
 
+  loco::NodeShape visit(const luci::CircleScatterNd *node) final
+  {
+    loco::TensorShape output_shape;
+
+    auto shape_node = loco::must_cast<luci::CircleConst *>(node->shape());
+
+    const loco::DataType S32 = loco::DataType::S32;
+    const loco::DataType S64 = loco::DataType::S64;
+
+    std::vector<int64_t> vect_shape;
+
+    if (shape_node->dtype() == S32)
+      vect_shape = vector_from_constant<S32>(shape_node);
+    else if (shape_node->dtype() == S64)
+      vect_shape = vector_from_constant<S64>(shape_node);
+    else
+      LUCI_ASSERT(false, "Only support int32/int64 for shape()");
+
+    output_shape.rank(vect_shape.size());
+    for (uint32_t i = 0; i < vect_shape.size(); ++i)
+      output_shape.dim(i) = vect_shape[i];
+
+    return loco::NodeShape{output_shape};
+  }
+
   loco::NodeShape visit(const luci::CircleSelect *node) final
   {
     auto t_shape = loco::shape_get(node->t()).as<loco::TensorShape>();

--- a/compiler/luci/service/src/CircleTypeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleTypeInferenceRule.cpp
@@ -315,6 +315,11 @@ struct TypeInferenceAlgorithm final : public luci::CircleNodeVisitor<loco::DataT
 
   loco::DataType visit(const luci::CircleRsqrt *node) final { return loco::dtype_get(node->x()); }
 
+  loco::DataType visit(const luci::CircleScatterNd *node) final
+  {
+    return loco::dtype_get(node->updates());
+  }
+
   loco::DataType visit(const luci::CircleSelect *node) final
   {
     assert(loco::dtype_get(node->t()) == loco::dtype_get(node->e()));


### PR DESCRIPTION
This enables support for ScatterNd operator in luci services

For #1711
Draft #1920

ONE-DCO-1.0-Signed-off-by: Andrey Kvochko <a.kvochko@samsung.com>