### PR TITLE
[luci] Supports when input of CircleGather has a dynamic shape

### DIFF
--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -792,6 +792,11 @@ public:
     const auto positions_shape = loco::shape_get(node->indices()).as<loco::TensorShape>();
     int32_t axis = node->axis();
 
+    // If CircleGather input has a dynamic shape, it can't inference this shape. So, it returns the
+    // shape that node already has.
+    if (input_shape.rank() == 0 || positions_shape.rank() == 0)
+      return own_shape(node);
+
     if (axis < 0)
       axis += input_shape.rank();
 


### PR DESCRIPTION
This commit supports when input of CircleGather has a dynamic shape

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>