### PR TITLE
[onert] Fix DynamicTensorManager applyShape

### DIFF
--- a/runtime/onert/core/src/backend/cpu_common/DynamicTensorManager.cc
+++ b/runtime/onert/core/src/backend/cpu_common/DynamicTensorManager.cc
@@ -76,7 +76,8 @@ void DynamicTensorManager::applyShape(const ir::OperandIndex &ind, const ir::Sha
       allocTensorMem();
     }
     else
-    { // when buffer with same size was already allocated, do nothing
+    { // when buffer with same size was already allocated, shape could differ
+      setShape(tensor.get(), new_shape);
     }
   }
 }


### PR DESCRIPTION
When `applyShape` is called and with same size buffer, the shape could
still differ. So this commit makes it set the new shape for that case.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>