### PR TITLE
[onert] Add shape inference for slice and its testcases

### DIFF
--- a/runtime/onert/core/include/util/ShapeInference.h
+++ b/runtime/onert/core/include/util/ShapeInference.h
@@ -142,6 +142,7 @@ private:
   void visit(const ir::operation::RSQRT &op);
   void visit(const ir::operation::Shape &op);
   void visit(const ir::operation::Sin &op);
+  void visit(const ir::operation::Slice &op);
   void visit(const ir::operation::Softmax &op);
   void visit(const ir::operation::StridedSlice &op);
   void visit(const ir::operation::Sub &op);
@@ -223,6 +224,7 @@ public:
   void visit(const ir::operation::RSQRT &op);
   void visit(const ir::operation::Shape &op);
   void visit(const ir::operation::Sin &op);
+  void visit(const ir::operation::Slice &op);
   void visit(const ir::operation::Softmax &op);
   void visit(const ir::operation::StridedSlice &op);
   void visit(const ir::operation::Sub &op);

--- a/runtime/onert/core/src/util/shapeinf/Slice.cc
+++ b/runtime/onert/core/src/util/shapeinf/Slice.cc
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "util/ShapeInference.h"
+
+#include <cmath>
+
+namespace onert
+{
+namespace shape_inference
+{
+
+ir::Shape inferSliceShape(const ir::Shape &input_shape, const int32_t *begins, const int32_t *sizes,
+                          uint32_t rank)
+{
+  ir::Shape out_shape(rank);
+
+  for (uint32_t idx = 0; idx < rank; ++idx)
+  {
+    const auto input_dim = input_shape.dim(idx);
+
+    // begin is zero-based
+    auto begin = begins[idx];
+    if (begin < 0)
+    {
+      begin += rank;
+    }
+    if (begin >= input_dim)
+    {
+      begin = input_dim - 1;
+    }
+
+    // size is one-based
+    auto size = sizes[idx];
+    assert(size >= -1);
+    if (size == -1)
+    {
+      size = input_dim - begin;
+    }
+    // We are not sure what shape's dimension value is 0
+    else if (size == 0)
+    {
+      size = 1;
+    }
+
+    // Clamping
+    if (begin + size > input_dim)
+    {
+      size = input_dim - begin;
+    }
+    out_shape.dim(idx) = size;
+  }
+
+  return out_shape;
+}
+
+void StaticInferer::visit(const ir::operation::Slice &op)
+{
+  const auto input_index{op.getInputs().at(ir::operation::Slice::Input::INPUT)};
+  const auto &input = _operands.at(input_index);
+  const auto begins_index{op.getInputs().at(ir::operation::Slice::Input::BEGINS)};
+  const auto &begins = _operands.at(begins_index);
+  const auto sizes_index{op.getInputs().at(ir::operation::Slice::Input::SIZES)};
+  const auto &sizes = _operands.at(sizes_index);
+  const auto output_index = op.getOutputs().at(0);
+  ir::Operand &output = _operands.at(output_index);
+
+  if (input.info().isDynamic() || begins.info().isDynamic() || sizes.info().isDynamic())
+  {
+    output.info().setDynamic();
+    return;
+  }
+
+  // Whether input is constant or not does not affect whether output is dynamic or not
+  if (!(begins.isConstant() && sizes.isConstant()))
+  {
+    output.info().setDynamic();
+    return;
+  }
+
+  auto begins_buf = reinterpret_cast<const int32_t *>(begins.data()->base());
+  auto sizes_buf = reinterpret_cast<const int32_t *>(sizes.data()->base());
+  const auto rank = op.param().rank;
+
+  ir::Shape new_shape = inferSliceShape(input.info().shape(), begins_buf, sizes_buf, rank);
+  output.info().shape(new_shape);
+}
+
+void DynamicInferer::visit(const ir::operation::Slice &op)
+{
+  const auto input_index{op.getInputs().at(ir::operation::Slice::Input::INPUT)};
+  const auto input = _tensor_registry->getITensor(input_index);
+  const auto begins_index{op.getInputs().at(ir::operation::Slice::Input::BEGINS)};
+  const auto begins = _tensor_registry->getITensor(begins_index);
+  const auto sizes_index{op.getInputs().at(ir::operation::Slice::Input::SIZES)};
+  const auto sizes = _tensor_registry->getITensor(sizes_index);
+  auto output_index = op.getOutputs().at(0);
+  auto output = _tensor_registry->getITensor(output_index);
+
+  if (!(input->is_dynamic() || begins->is_dynamic() || sizes->is_dynamic() || output->is_dynamic()))
+  {
+    return;
+  }
+
+  ir::Shape input_shape = getShape(input.get());
+  auto begins_buf = reinterpret_cast<const int32_t *>(begins->buffer());
+  auto sizes_buf = reinterpret_cast<const int32_t *>(sizes->buffer());
+  const auto rank = input_shape.rank();
+
+  ir::Shape new_shape =
+      onert::shape_inference::inferSliceShape(input_shape, begins_buf, sizes_buf, rank);
+
+  _dynamic_tensor_manager->applyShape(output_index, new_shape);
+  assert(output->buffer() != nullptr);
+}
+
+} // namespace shape_inference
+} // namespace onert

--- a/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_cl
+++ b/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_cl
@@ -140,6 +140,7 @@ GeneratedTests.slice_5
 GeneratedTests.slice_6
 GeneratedTests.slice_7
 GeneratedTests.slice_8
+GeneratedTests.slice_dynamic_nnfw
 GeneratedTests.slice_zero_sized
 GeneratedTests.slice_zero_sized_quant8
 GeneratedTests.softmax_dynamic_nnfw

--- a/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_neon
+++ b/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_neon
@@ -165,6 +165,7 @@ GeneratedTests.slice_5
 GeneratedTests.slice_6
 GeneratedTests.slice_7
 GeneratedTests.slice_8
+GeneratedTests.slice_dynamic_nnfw
 GeneratedTests.slice_zero_sized
 GeneratedTests.slice_zero_sized_quant8
 GeneratedTests.softmax_dynamic_nnfw

--- a/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_cl
+++ b/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_cl
@@ -140,6 +140,7 @@ GeneratedTests.slice_5
 GeneratedTests.slice_6
 GeneratedTests.slice_7
 GeneratedTests.slice_8
+GeneratedTests.slice_dynamic_nnfw
 GeneratedTests.slice_zero_sized
 GeneratedTests.slice_zero_sized_quant8
 GeneratedTests.softmax_dynamic_nnfw

--- a/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_neon
+++ b/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_neon
@@ -164,6 +164,7 @@ GeneratedTests.slice_5
 GeneratedTests.slice_6
 GeneratedTests.slice_7
 GeneratedTests.slice_8
+GeneratedTests.slice_dynamic_nnfw
 GeneratedTests.slice_zero_sized
 GeneratedTests.slice_zero_sized_quant8
 GeneratedTests.softmax_dynamic_nnfw

--- a/tests/nnapi/nnapi_gtest.skip.noarch.interp
+++ b/tests/nnapi/nnapi_gtest.skip.noarch.interp
@@ -392,6 +392,7 @@ GeneratedTests.slice_5
 GeneratedTests.slice_6
 GeneratedTests.slice_7
 GeneratedTests.slice_8
+GeneratedTests.slice_dynamic_nnfw
 GeneratedTests.slice_zero_sized
 GeneratedTests.slice_zero_sized_quant8
 GeneratedTests.softmax_dynamic_nnfw

--- a/tests/nnapi/specs/V1_2/slice_dynamic_nnfw.mod.py
+++ b/tests/nnapi/specs/V1_2/slice_dynamic_nnfw.mod.py
@@ -1,0 +1,66 @@
+#
+# Copyright (C) 2018 The Android Open Source Project
+# Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# refer to tanh_v1_dynamic.mod.py about the structore
+
+# This adds reshape as the first op in a model and
+# returns output of reshape, which is dynamic tensor
+
+'''
+Testing Slice op when the input is dynamic.
+      input [3, 2, 3, 1]  shape [4]  (value of shape will be [3, 2, 3, 1])
+          |             |
+          +-------------+
+          |
+       Reshape (added by DynamicInputGenerator since it generates its output to be dynamic)
+          |
+          | dynamic tensor at compilation time but the shape will be [3, 2, 3, 1] at execution time
+          |
+         Slice
+          |
+        output (dynamic tensor, [2, 1, 3, 1] at execution time)
+'''
+
+import dynamic_tensor
+
+model = Model()
+
+model_input_shape = [3, 2, 3, 1]
+
+dynamic_layer = dynamic_tensor.DynamicInputGenerator(model, model_input_shape, "TENSOR_FLOAT32")
+
+test_node_input = dynamic_layer.getTestNodeInput()
+
+begins = Parameter("begins", "TENSOR_INT32", "{4}", [1, 0, 0, 0])
+sizes = Parameter("sizes", "TENSOR_INT32", "{4}", [2, 1, -1, 1])
+
+# note output shape is used by expected output's shape
+model_output = Output("output", "TENSOR_FLOAT32", "{2, 1, 3, 1}")
+
+model.Operation("SLICE", test_node_input, begins, sizes,).To(model_output)
+
+model_input_data = [1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5, 6, 6, 6]
+model_output_data = [3, 3, 3, 5, 5, 5]
+
+Example({
+    # use these two as input
+    dynamic_layer.getModelInput() : model_input_data,
+    dynamic_layer.getShapeInput() : model_input_shape,
+
+    model_output: model_output_data,
+})
+


### PR DESCRIPTION
This commit adds shape inference for slice and its testcases.

Signed-off-by: ragmani <ragmani0216@gmail.com>