### PR TITLE
[onert] Support INT8 type in base_loader

### DIFF
--- a/runtime/onert/frontend/base_loader/include/base_loader.h
+++ b/runtime/onert/frontend/base_loader/include/base_loader.h
@@ -233,6 +233,8 @@ BaseLoader<LoaderDomain, SpecificLoader>::BaseLoader::tensorTypeToDataType(const
       return ir::DataType::BOOL8;
     case TensorType::TensorType_UINT8:
       return ir::DataType::QUANT_UINT8_ASYMM;
+    case TensorType::TensorType_INT8:
+      return ir::DataType::QUANT_INT8_SYMM;
     default:
       throw std::runtime_error(
           std::string("Unsupported tensor type: ").append(EnumNameTensorType(type)));


### PR DESCRIPTION
This commit supports INT8 type in base_loader
- INT8 type is supported in tflite_schema and circle_schema

ONE-DCO-1.0-Signed-off-by: JiHwan Yeo <jihwan.yeo@samsung.com>