### PR TITLE
[onert] Add shape inference for split op.

### DIFF
--- a/runtime/onert/backend/cpu/KernelGenerator.cc
+++ b/runtime/onert/backend/cpu/KernelGenerator.cc
@@ -922,7 +922,6 @@ void KernelGenerator::visit(const ir::operation::Split &node)
   const auto rank = node.param().rank;
   const auto axis = ops::getAxis(rank, node.param().axis, _current_op_seq_layout);
   auto axis_resolved = axis < 0 ? axis + rank : axis;
-  assert(0 <= axis_resolved && axis_resolved < rank);
 
   const auto input_idx{node.getInputs().at(ir::operation::Split::Input::INPUT)};
   auto in_tensor = _tensor_builder->at(input_idx).get();

--- a/runtime/onert/core/include/util/ShapeInference.h
+++ b/runtime/onert/core/include/util/ShapeInference.h
@@ -157,6 +157,7 @@ private:
   void visit(const ir::operation::Sin &op);
   void visit(const ir::operation::Slice &op);
   void visit(const ir::operation::Softmax &op);
+  void visit(const ir::operation::Split &op);
   void visit(const ir::operation::Squeeze &op);
   void visit(const ir::operation::StridedSlice &op);
   void visit(const ir::operation::Sub &op);
@@ -248,6 +249,7 @@ public:
   void visit(const ir::operation::Sin &op);
   void visit(const ir::operation::Slice &op);
   void visit(const ir::operation::Softmax &op);
+  void visit(const ir::operation::Split &op);
   void visit(const ir::operation::Squeeze &op);
   void visit(const ir::operation::StridedSlice &op);
   void visit(const ir::operation::Sub &op);

--- a/runtime/onert/core/src/compiler/OperationValidator.cc
+++ b/runtime/onert/core/src/compiler/OperationValidator.cc
@@ -1071,6 +1071,9 @@ void OperationValidator::visit(const ir::operation::Split &node)
 {
   const auto input_index{node.getInputs().at(ir::operation::Split::Input::INPUT)};
 
+  if (_ctx.at(input_index).info().isDynamic())
+    return;
+
   const auto &num_splits = node.param().num_splits;
   const auto &input_rank = node.param().rank;
   const auto &axis = node.param().axis < 0 ? node.param().axis + input_rank : node.param().axis;
@@ -1079,8 +1082,6 @@ void OperationValidator::visit(const ir::operation::Split &node)
   OP_REQUIRES(axis >= 0 && axis < input_rank);
   OP_REQUIRES(node.getOutputs().size() == static_cast<uint32_t>(num_splits));
 
-  if (_ctx.at(input_index).info().isDynamic())
-    return;
   OP_REQUIRES(_ctx.at(input_index).shape().dim(axis) % num_splits == 0);
 }
 

--- a/runtime/onert/core/src/util/shapeinf/Split.cc
+++ b/runtime/onert/core/src/util/shapeinf/Split.cc
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "util/ShapeInference.h"
+
+namespace onert
+{
+namespace shape_inference
+{
+
+ir::Shape inferOutputTensors(const ir::Shape input_shape, int axis_value, int num_splits)
+{
+  ir::Shape newShape(input_shape);
+
+  assert(axis_value >= 0);
+  assert(axis_value < input_shape.rank());
+
+  const int input_size = input_shape.dim(axis_value);
+  assert(input_size % num_splits == 0);
+  const int slice_size = input_size / num_splits;
+
+  newShape.dim(axis_value) = slice_size;
+
+  return newShape;
+}
+
+void StaticInferer::visit(const ir::operation::Split &op)
+{
+  const auto input_idx{op.getInputs().at(0)};
+  const auto &input = _operands.at(input_idx);
+
+  const auto axis = op.param().axis;
+  const auto num_splits = op.param().num_splits;
+
+  if (input.info().isDynamic())
+  {
+    for (int out_tensor_idx = 0; out_tensor_idx < num_splits; out_tensor_idx++)
+    {
+      const auto output_idx = op.getOutputs().at(out_tensor_idx);
+      ir::Operand &output = _operands.at(output_idx);
+      output.info().setDynamic();
+    }
+    return;
+  }
+
+  const auto rank = input.info().shape().rank();
+  auto axis_resolved = axis < 0 ? axis + rank : axis;
+
+  assert(0 <= axis_resolved && axis_resolved < rank);
+
+  ir::Shape new_shape = inferOutputTensors(input.info().shape(), axis_resolved, num_splits);
+  auto output_teonsors = op.getOutputs();
+  for (auto output_idx : output_teonsors)
+  {
+    ir::Operand &output = _operands.at(output_idx);
+    output.info().shape(new_shape);
+  }
+}
+
+void DynamicInferer::visit(const ir::operation::Split &op)
+{
+  const auto input_idx{op.getInputs().at(ir::operation::Split::Input::INPUT)};
+  const auto &input = _tensor_registry->getITensor(input_idx);
+
+  if (!input->is_dynamic())
+  {
+    return;
+  }
+
+  auto input_shape = getShape(input.get());
+
+  const auto axis = op.param().axis;
+  const auto num_splits = op.param().num_splits;
+  const auto rank = input_shape.rank();
+  auto axis_resolved = axis < 0 ? axis + rank : axis;
+
+  assert(0 <= axis_resolved && axis_resolved < rank);
+
+  ir::Shape new_shape = inferOutputTensors(input_shape, axis_resolved, num_splits);
+  for (int out_tensor_idx = 0; out_tensor_idx < num_splits; out_tensor_idx++)
+  {
+    auto output_ind = op.getOutputs().at(out_tensor_idx);
+    auto output = _tensor_registry->getITensor(output_ind);
+
+    _dynamic_tensor_manager->applyShape(output_ind, new_shape);
+    assert(output->buffer() != nullptr);
+  }
+}
+} // namespace shape_inference
+} // namespace onert

--- a/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_cl
+++ b/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_cl
@@ -168,6 +168,7 @@ GeneratedTests.strided_slice_dynamic_nnfw
 GeneratedTests.sub_dynamic_nnfw
 GeneratedTests.sub_v1_2_zero_sized
 GeneratedTests.sub_v1_2_zero_sized_quant8
+GeneratedTests.split_dynamic_float_nnfw
 GeneratedTests.svdf
 GeneratedTests.svdf2
 GeneratedTests.svdf_bias_present

--- a/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_neon
+++ b/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_neon
@@ -194,6 +194,7 @@ GeneratedTests.space_to_batch_quant8_1_nnfw
 GeneratedTests.space_to_batch_quant8_2
 GeneratedTests.space_to_batch_quant8_2_nnfw
 GeneratedTests.space_to_batch_quant8_3
+GeneratedTests.split_dynamic_float_nnfw
 GeneratedTests.sqrt_
 GeneratedTests.squared_difference_ex_dynamic_nnfw
 GeneratedTests.strided_slice_dynamic_nnfw

--- a/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_cl
+++ b/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_cl
@@ -168,6 +168,7 @@ GeneratedTests.strided_slice_dynamic_nnfw
 GeneratedTests.sub_dynamic_nnfw
 GeneratedTests.sub_v1_2_zero_sized
 GeneratedTests.sub_v1_2_zero_sized_quant8
+GeneratedTests.split_dynamic_float_nnfw
 GeneratedTests.svdf
 GeneratedTests.svdf2
 GeneratedTests.svdf_bias_present

--- a/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_neon
+++ b/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_neon
@@ -192,6 +192,7 @@ GeneratedTests.strided_slice_dynamic_nnfw
 GeneratedTests.sub_dynamic_nnfw
 GeneratedTests.sub_v1_2_zero_sized
 GeneratedTests.sub_v1_2_zero_sized_quant8
+GeneratedTests.split_dynamic_float_nnfw
 GeneratedTests.svdf
 GeneratedTests.svdf2
 GeneratedTests.svdf_bias_present

--- a/tests/nnapi/nnapi_gtest.skip.noarch.interp
+++ b/tests/nnapi/nnapi_gtest.skip.noarch.interp
@@ -442,6 +442,7 @@ GeneratedTests.split_4D_int32_3_nnfw
 GeneratedTests.split_4D_int32_4_nnfw
 GeneratedTests.split_4D_int32_5_nnfw
 GeneratedTests.split_4D_quant8_nnfw
+GeneratedTests.split_dynamic_float_nnfw
 GeneratedTests.split_float_1
 GeneratedTests.split_float_2
 GeneratedTests.split_float_3

--- a/tests/nnapi/specs/V1_2/split_dynamic_float_nnfw.mod.py
+++ b/tests/nnapi/specs/V1_2/split_dynamic_float_nnfw.mod.py
@@ -1,5 +1,6 @@
 #
 # Copyright (C) 2018 The Android Open Source Project
+# Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/nnapi/specs/V1_2/split_dynamic_float_nnfw.mod.py
+++ b/tests/nnapi/specs/V1_2/split_dynamic_float_nnfw.mod.py
@@ -1,0 +1,51 @@
+#
+# Copyright (C) 2018 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import dynamic_tensor
+
+model = Model()
+
+model_input_shape = [6]
+
+axis = Int32Scalar("axis", 0)
+num_splits = Int32Scalar("num_splits", 3)
+
+output0 = Output("output0", "TENSOR_FLOAT32", "{2}")
+output1 = Output("output1", "TENSOR_FLOAT32", "{2}")
+output2 = Output("output2", "TENSOR_FLOAT32", "{2}")
+
+dynamic_layer = dynamic_tensor.DynamicInputGenerator(model, model_input_shape, "TENSOR_FLOAT32")
+
+test_node_input = dynamic_layer.getTestNodeInput()
+
+model.Operation("SPLIT", test_node_input, axis, num_splits).To([output0, output1, output2])
+
+model_input_data = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+
+output_0_data = [1.0, 2.0]
+output_1_data = [3.0, 4.0]
+output_2_data = [5.0, 6.0]
+
+Example(
+  {
+    dynamic_layer.getModelInput() : model_input_data,
+    dynamic_layer.getShapeInput() : model_input_shape,
+
+    output0: output_0_data,
+    output1: output_1_data,
+    output2: output_2_data,
+  })


### PR DESCRIPTION
Add shape inference for split operation and its tc.

ONE-DCO-1.0-Signed-off-by: H Kim <hyunjun2.kim@samsung.com>