### PR TITLE
[onert] add shape inference for (reduce_)mean.

### DIFF
--- a/runtime/onert/core/include/util/ShapeInference.h
+++ b/runtime/onert/core/include/util/ShapeInference.h
@@ -129,6 +129,7 @@ private:
   void visit(const ir::operation::LogicalOr &op);
   void visit(const ir::operation::Logistic &op);
   void visit(const ir::operation::Max &op);
+  void visit(const ir::operation::Mean &op);
   void visit(const ir::operation::Min &op);
   void visit(const ir::operation::Mul &op);
   void visit(const ir::operation::Neg &op);
@@ -210,9 +211,10 @@ public:
   void visit(const ir::operation::Log &op);
   void visit(const ir::operation::LogicalOr &op);
   void visit(const ir::operation::Logistic &op);
-  void visit(const ir::operation::Mul &op);
-  void visit(const ir::operation::Min &op);
   void visit(const ir::operation::Max &op);
+  void visit(const ir::operation::Mean &op);
+  void visit(const ir::operation::Min &op);
+  void visit(const ir::operation::Mul &op);
   void visit(const ir::operation::Neg &op);
   // TODO write op starting from O
   void visit(const ir::operation::Pack &op);

--- a/runtime/onert/core/src/util/shapeinf/Mean.cc
+++ b/runtime/onert/core/src/util/shapeinf/Mean.cc
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "util/ShapeInference.h"
+
+namespace onert
+{
+namespace shape_inference
+{
+
+void StaticInferer::visit(const ir::operation::Mean &op)
+{
+  const auto input_idx{op.getInputs().at(0)};
+  const auto &input = _operands.at(input_idx);
+
+  // get mutable output operand
+  const auto output_idx = op.getOutputs().at(0);
+  ir::Operand &output = _operands.at(output_idx);
+
+  // if input is dynamic, output also becomes dynamic
+  if (input.info().isDynamic())
+  {
+    output.info().setDynamic();
+    return;
+  }
+
+  const auto axis = op.param().axes;
+  const auto keep_dims = op.param().keep_dims;
+
+  ir::Shape output_shape = inferReduceShapes(input.info().shape(), axis, keep_dims);
+
+  output.info().shape(output_shape);
+}
+void DynamicInferer::visit(const ir::operation::Mean &op)
+{
+  const auto input_idx{op.getInputs().at(0)};
+  const auto &input = _tensor_registry->getITensor(input_idx);
+
+  if (!input->is_dynamic())
+  {
+    return;
+  }
+
+  auto input_shape = getShape(input.get());
+
+  auto output_ind = op.getOutputs().at(0);
+  auto output = _tensor_registry->getITensor(output_ind);
+
+  const auto axis = op.param().axes;
+  const auto keep_dims = op.param().keep_dims;
+
+  ir::Shape output_shape = inferReduceShapes(input_shape, axis, keep_dims);
+  _dynamic_tensor_manager->applyShape(output_ind, output_shape);
+  assert(output->buffer() != nullptr);
+}
+} // namespace shape_inference
+} // namespace onert

--- a/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_cl
+++ b/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_cl
@@ -98,6 +98,8 @@ GeneratedTests.reduce_any_2D_nnfw
 GeneratedTests.reduce_any_3
 GeneratedTests.reduce_any_4
 GeneratedTests.reduce_any_4D_nnfw
+GeneratedTests.reduce_mean_dynamic_1_nnfw
+GeneratedTests.reduce_mean_dynamic_2_nnfw
 GeneratedTests.reduce_prod
 GeneratedTests.reduce_prod_2
 GeneratedTests.reduce_prod_2D_float_nnfw

--- a/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_neon
+++ b/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_neon
@@ -123,6 +123,8 @@ GeneratedTests.reduce_any_4
 GeneratedTests.reduce_any_4D_nnfw
 GeneratedTests.reduce_max_2D_int32_nnfw
 GeneratedTests.reduce_max_quant8
+GeneratedTests.reduce_mean_dynamic_1_nnfw
+GeneratedTests.reduce_mean_dynamic_2_nnfw
 GeneratedTests.reduce_prod
 GeneratedTests.reduce_prod_2
 GeneratedTests.reduce_prod_2D_float_nnfw

--- a/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_cl
+++ b/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_cl
@@ -98,6 +98,8 @@ GeneratedTests.reduce_any_2D_nnfw
 GeneratedTests.reduce_any_3
 GeneratedTests.reduce_any_4
 GeneratedTests.reduce_any_4D_nnfw
+GeneratedTests.reduce_mean_dynamic_1_nnfw
+GeneratedTests.reduce_mean_dynamic_2_nnfw
 GeneratedTests.reduce_prod
 GeneratedTests.reduce_prod_2
 GeneratedTests.reduce_prod_2D_float_nnfw

--- a/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_neon
+++ b/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_neon
@@ -122,6 +122,8 @@ GeneratedTests.reduce_any_4
 GeneratedTests.reduce_any_4D_nnfw
 GeneratedTests.reduce_max_2D_int32_nnfw
 GeneratedTests.reduce_max_quant8
+GeneratedTests.reduce_mean_dynamic_1_nnfw
+GeneratedTests.reduce_mean_dynamic_2_nnfw
 GeneratedTests.reduce_prod
 GeneratedTests.reduce_prod_2
 GeneratedTests.reduce_prod_2D_float_nnfw

--- a/tests/nnapi/nnapi_gtest.skip.noarch.interp
+++ b/tests/nnapi/nnapi_gtest.skip.noarch.interp
@@ -321,6 +321,8 @@ GeneratedTests.reduce_max_quant8_2
 GeneratedTests.reduce_max_quant8_2_nnfw
 GeneratedTests.reduce_max_quant8_3
 GeneratedTests.reduce_max_quant8_4
+GeneratedTests.reduce_mean_dynamic_1_nnfw
+GeneratedTests.reduce_mean_dynamic_2_nnfw
 GeneratedTests.reduce_min
 GeneratedTests.reduce_min_2
 GeneratedTests.reduce_min_3

--- a/tests/nnapi/specs/V1_2/reduce_mean_dynamic_1_nnfw.mod.py
+++ b/tests/nnapi/specs/V1_2/reduce_mean_dynamic_1_nnfw.mod.py
@@ -1,0 +1,68 @@
+#
+# Copyright (C) 2018 The Android Open Source Project
+# Copyright (C) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+'''
+Testing (Reduce)Mean op when the input is dynamic.
+    input[1, 3, 4, 1] shape [4]
+          |             |
+          +-------------+
+          |
+       Reshape (added by DynamicInputGenerator since it generates its output to be dynamic)
+          |
+          |        axis = 2    keepDims = True
+          |             |             |
+          +-------------+-------------+
+          |
+          |
+          | dynamic tensor at compilation time but the shape will be [1, 3, 4, 1] at execution time
+          |
+      ReduceMean
+          |
+        output (dynamic tensor, [1, 3, 1, 1] at execution time)
+'''
+
+import dynamic_tensor
+
+model = Model()
+
+model_input_shape = [1, 3, 4, 1]
+
+dynamic_layer = dynamic_tensor.DynamicInputGenerator(model, model_input_shape, "TENSOR_FLOAT32")
+test_node_input = dynamic_layer.getTestNodeInput()
+
+# write REDUCE_MEAN test. input is `test_input`
+
+# note output shape is used by expected output's shape
+model_output = Output("output", "TENSOR_FLOAT32", "{1, 3, 1, 1}")
+
+axis = Int32Scalar("axis", 2)
+keepDims = Int32Scalar("keepDims", 1)
+
+model.Operation("MEAN", test_node_input, axis, keepDims).To(model_output)
+
+model_input_data = [1.0, 2.0, 3.0, 4.0,
+                    1.0, 2.0, 3.0, 4.0,
+                    1.0, 2.0, 3.0, 4.0]
+
+model_output_data = [2.5, 2.5, 2.5]
+
+Example({
+    dynamic_layer.getModelInput() : model_input_data,
+    dynamic_layer.getShapeInput() : model_input_shape,
+
+    model_output: model_output_data,
+})

--- a/tests/nnapi/specs/V1_2/reduce_mean_dynamic_2_nnfw.mod.py
+++ b/tests/nnapi/specs/V1_2/reduce_mean_dynamic_2_nnfw.mod.py
@@ -1,0 +1,68 @@
+#
+# Copyright (C) 2018 The Android Open Source Project
+# Copyright (C) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+'''
+Testing (Reduce)Mean op when the input is dynamic.
+    input[1, 3, 4, 1] shape [4]
+          |             |
+          +-------------+
+          |
+       Reshape (added by DynamicInputGenerator since it generates its output to be dynamic)
+          |
+          |        axis = 2    keepDims = False
+          |             |             |
+          +-------------+-------------+
+          |
+          |
+          | dynamic tensor at compilation time but the shape will be [1, 3, 4, 1] at execution time
+          |
+      ReduceMean
+          |
+        output (dynamic tensor, [1, 3, 1] at execution time)
+'''
+
+import dynamic_tensor
+
+model = Model()
+
+model_input_shape = [1, 3, 4, 1]
+
+dynamic_layer = dynamic_tensor.DynamicInputGenerator(model, model_input_shape, "TENSOR_FLOAT32")
+test_node_input = dynamic_layer.getTestNodeInput()
+
+# write REDUCE_MEAN test. input is `test_input`
+
+# note output shape is used by expected output's shape
+model_output = Output("output", "TENSOR_FLOAT32", "{1, 3, 1}")
+
+axis = Int32Scalar("axis", 2)
+keepDims = Int32Scalar("axis", 0)
+
+model.Operation("MEAN", test_node_input, axis, keepDims).To(model_output)
+
+model_input_data = [1.0, 2.0, 3.0, 4.0,
+                    1.0, 2.0, 3.0, 4.0,
+                    1.0, 2.0, 3.0, 4.0]
+
+model_output_data = [2.5, 2.5, 2.5]
+
+Example({
+    dynamic_layer.getModelInput() : model_input_data,
+    dynamic_layer.getShapeInput() : model_input_shape,
+
+    model_output: model_output_data,
+})


### PR DESCRIPTION
add shape inference for (reduce_)mean and adds it's tc.

ONE-DCO-1.0-Signed-off-by: H Kim <hyunjun2.kim@samsung.com>

Issue: #2056