### PR TITLE
[onert] Move calling StaticInferer after creating LoweredGraphs

### DIFF
--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -33,6 +33,7 @@
 #include "interp/InterpExecutor.h"
 #include "util/ConfigSource.h"
 #include "util/logging.h"
+#include "util/ShapeInference.h"
 #include "ir/OperationDumper.h"
 #include "misc/string_helpers.h"
 
@@ -248,6 +249,16 @@ void Compiler::compile(void)
   });
 
   _subgraphs.reset();
+
+  // Shape inference.
+  {
+    shape_inference::StaticInferer inferer(lowered_subgs);
+    lowered_subgs.at(ir::SubgraphIndex{0})
+        ->iterateTopolOpSeqs([&](const ir::OpSequenceIndex &, const ir::OpSequence &op_seq) {
+          inferer.infer(op_seq);
+        });
+    inferer.dump();
+  }
 
   /*************************************************************
    *  Backend independent analysis & optimization phase finished

--- a/runtime/onert/core/src/ir/LoweredGraph.cc
+++ b/runtime/onert/core/src/ir/LoweredGraph.cc
@@ -30,7 +30,6 @@
 #include "compiler/BackendResolver.h"
 #include "compiler/ManualScheduler.h"
 #include "compiler/HEScheduler.h"
-#include "util/ShapeInference.h"
 
 namespace onert
 {
@@ -118,14 +117,6 @@ LoweredGraph::LoweredGraph(const Graph &graph, const compiler::CompilerOptions &
     // pe_pass.run();
 
     _op_seqs.dump("merged and sorted operations with permutation", _graph.operations());
-  }
-
-  // Shape inference.
-  {
-    shape_inference::StaticInferer inferer(_graph);
-    iterateTopolOpSeqs(
-        [&](const ir::OpSequenceIndex &, const ir::OpSequence &op_seq) { inferer.infer(op_seq); });
-    inferer.dump();
   }
 
   // Graph verifications

--- a/runtime/onert/core/src/util/shapeinf/ShapeInference.cc
+++ b/runtime/onert/core/src/util/shapeinf/ShapeInference.cc
@@ -317,11 +317,18 @@ void StaticInferer::dump()
     return sstream.str();
   };
 
-  _operands.iterate([&](const ir::OperandIndex &ind, const ir::Operand &operand) {
-    VERBOSE(StaticInferer) << "Operand #" << ind.value() << ", "
-                           << (operand.info().isDynamic() ? "Dynamic" : "Static") << ", "
-                           << get_shape_str(operand.info().shape()) << std::endl;
-  });
+  for (const auto &pair : _lowered_subgs)
+  {
+    const auto index = pair.first;
+    const auto &lowered_subg = pair.second;
+    VERBOSE(StaticInferer) << "SubGraph #" << index.value() << std::endl;
+    lowered_subg->graph().operands().iterate(
+        [&](const ir::OperandIndex &ind, const ir::Operand &operand) {
+          VERBOSE(StaticInferer) << "Operand #" << ind.value() << ", "
+                                 << (operand.info().isDynamic() ? "Dynamic" : "Static") << ", "
+                                 << get_shape_str(operand.info().shape()) << std::endl;
+        });
+  }
 }
 
 /*


### PR DESCRIPTION
For issue : #1999
Draft PR : #2003 

This commit moves calling StaticInferer after creating LoweredGraphs.
  - Change StaticInferer to get param LoweredGraphs
  - Move calling StaticInferer
  - Modify dump() of StaticInferer

Signed-off-by: ragmani <ragmani0216@gmail.com>