### PR TITLE
[onert] throw runtime error for unsupported data type in cpu backcend

### DIFF
--- a/runtime/onert/backend/cpu/ops/AbsLayer.cc
+++ b/runtime/onert/backend/cpu/ops/AbsLayer.cc
@@ -58,6 +58,10 @@ void AbsLayer::run()
   {
     absQuant8();
   }
+  else
+  {
+    throw std::runtime_error{"Abs: unsupported data type"};
+  }
 }
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/AddLayer.cc
+++ b/runtime/onert/backend/cpu/ops/AddLayer.cc
@@ -89,6 +89,10 @@ void AddLayer::run()
   {
     addQuant8();
   }
+  else
+  {
+    throw std::runtime_error{"Add: unsupported data type"};
+  }
 }
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/ArgMinMaxLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ArgMinMaxLayer.cc
@@ -77,7 +77,7 @@ void ArgMinMaxLayer::run()
       TF_LITE_ARG_MIN_MAX(int32_t, int32_t, int32_t);
       break;
     default:
-      throw std::runtime_error("ArgMinMax: Only float32, uint8 and int32 are currently supported.");
+      throw std::runtime_error("ArgMinMax: unsupported data type");
   }
 #undef TF_LITE_ARG_MIN_MAX
 }

--- a/runtime/onert/backend/cpu/ops/AvgPoolLayer.cc
+++ b/runtime/onert/backend/cpu/ops/AvgPoolLayer.cc
@@ -104,6 +104,10 @@ void AvgPoolLayer::run()
   {
     averagePoolQuant8();
   }
+  else
+  {
+    throw std::runtime_error{"AvgPool: unsupported data type"};
+  }
 }
 
 #undef AVGPOOLING_PARAMETERS

--- a/runtime/onert/backend/cpu/ops/CastLayer.cc
+++ b/runtime/onert/backend/cpu/ops/CastLayer.cc
@@ -95,7 +95,7 @@ void CastLayer::run()
       castPtr(in.b, out);
       return;
     default:
-      throw std::runtime_error("Not supported input type" +
+      throw std::runtime_error("Cast: unsupported data type" +
                                std::to_string((int)_input->data_type()));
   }
 }

--- a/runtime/onert/backend/cpu/ops/ConcatLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ConcatLayer.cc
@@ -126,7 +126,7 @@ void ConcatLayer::run()
     concatenationQuant8();
   }
   else
-    throw std::runtime_error("ConcatLayer: Not supported datatype");
+    throw std::runtime_error("Concat: unsupported data type");
 }
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/ConvolutionLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ConvolutionLayer.cc
@@ -146,6 +146,10 @@ void ConvolutionLayer::run()
   {
     convQuant8();
   }
+  else
+  {
+    throw std::runtime_error{"Conv: unsupported data type"};
+  }
 }
 
 #undef ANDROID_NN_CONV_PARAMETERS

--- a/runtime/onert/backend/cpu/ops/DepthwiseConvolutionLayer.cc
+++ b/runtime/onert/backend/cpu/ops/DepthwiseConvolutionLayer.cc
@@ -125,6 +125,10 @@ void DepthwiseConvolutionLayer::run()
   {
     convQuant8();
   }
+  else
+  {
+    throw std::runtime_error{"DepthwiseConv: unsupported data type"};
+  }
 }
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/DivLayer.cc
+++ b/runtime/onert/backend/cpu/ops/DivLayer.cc
@@ -85,6 +85,10 @@ void DivLayer::run()
   {
     divQuant8();
   }
+  else
+  {
+    throw std::runtime_error{"Div: unsupported data type"};
+  }
 }
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/ExpLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ExpLayer.cc
@@ -62,6 +62,10 @@ void ExpLayer::run()
   {
     expQuant8();
   }
+  else
+  {
+    throw std::runtime_error{"Exp: unsupported data type"};
+  }
 }
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/FillLayer.cc
+++ b/runtime/onert/backend/cpu/ops/FillLayer.cc
@@ -65,7 +65,6 @@ void FillLayer::run()
       break;
     default:
       throw std::runtime_error{"Fill: unsupported data type"};
-      break;
   }
 }
 

--- a/runtime/onert/backend/cpu/ops/FullyConnectedLayer.cc
+++ b/runtime/onert/backend/cpu/ops/FullyConnectedLayer.cc
@@ -129,6 +129,10 @@ void FullyConnectedLayer::run()
   {
     fullyConnectedQuant8();
   }
+  else
+  {
+    throw std::runtime_error{"FullyConnected: unsupported data type"};
+  }
 }
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/GatherLayer.cc
+++ b/runtime/onert/backend/cpu/ops/GatherLayer.cc
@@ -64,7 +64,7 @@ void GatherLayer::run()
           getTensorShape(_output), reinterpret_cast<int32_t *>(_output->buffer()));
       break;
     default:
-      throw std::runtime_error("Gather NYI for this operand type!");
+      throw std::runtime_error("Gather: unsupported data type");
   }
 }
 

--- a/runtime/onert/backend/cpu/ops/LogLayer.cc
+++ b/runtime/onert/backend/cpu/ops/LogLayer.cc
@@ -58,6 +58,10 @@ void LogLayer::run()
   {
     logQuant8();
   }
+  else
+  {
+    throw std::runtime_error{"Log: unsupported data type"};
+  }
 }
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/LogicalNotLayer.cc
+++ b/runtime/onert/backend/cpu/ops/LogicalNotLayer.cc
@@ -54,7 +54,7 @@ void LogicalNotLayer::run()
   }
   else
   {
-    throw std::runtime_error{"LogicalNot: Unsupported input type"};
+    throw std::runtime_error{"LogicalNot: unsupported data type"};
   }
 }
 

--- a/runtime/onert/backend/cpu/ops/LogicalOrLayer.cc
+++ b/runtime/onert/backend/cpu/ops/LogicalOrLayer.cc
@@ -54,7 +54,7 @@ void LogicalOrLayer::run()
   }
   else
   {
-    throw std::runtime_error{"LogicalOr: Unsupported input data type"};
+    throw std::runtime_error{"LogicalOr: Unsupported data type"};
   }
 }
 

--- a/runtime/onert/backend/cpu/ops/LogisticLayer.cc
+++ b/runtime/onert/backend/cpu/ops/LogisticLayer.cc
@@ -62,6 +62,10 @@ void LogisticLayer::run()
   {
     logisticQuant8();
   }
+  else
+  {
+    throw std::runtime_error{"Logistic: unsupported data type"};
+  }
 }
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/MatrixBandPartLayer.cc
+++ b/runtime/onert/backend/cpu/ops/MatrixBandPartLayer.cc
@@ -66,6 +66,10 @@ void MatrixBandPartLayer::run()
   {
     matrixBandPartQuant8();
   }
+  else
+  {
+    throw std::runtime_error{"MatrixBandpart: unsupported data type"};
+  }
 }
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/MaxLayer.cc
+++ b/runtime/onert/backend/cpu/ops/MaxLayer.cc
@@ -68,6 +68,10 @@ void MaxLayer::run()
   {
     maxQuant8();
   }
+  else
+  {
+    throw std::runtime_error{"Max: unsupported data type"};
+  }
 }
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/MaxPoolLayer.cc
+++ b/runtime/onert/backend/cpu/ops/MaxPoolLayer.cc
@@ -101,6 +101,10 @@ void MaxPoolLayer::run()
   {
     maxPoolQuant8();
   }
+  else
+  {
+    throw std::runtime_error{"MaxPool: unsupported data type"};
+  }
 }
 
 #undef MAXPOOLING_PARAMETERS

--- a/runtime/onert/backend/cpu/ops/MeanLayer.cc
+++ b/runtime/onert/backend/cpu/ops/MeanLayer.cc
@@ -68,6 +68,10 @@ void MeanLayer::run()
   {
     MeanQuant8();
   }
+  else
+  {
+    throw std::runtime_error{"Mean: unsupported data type"};
+  }
 }
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/MinLayer.cc
+++ b/runtime/onert/backend/cpu/ops/MinLayer.cc
@@ -68,6 +68,10 @@ void MinLayer::run()
   {
     minQuant8();
   }
+  else
+  {
+    throw std::runtime_error{"Min: unsupported data type"};
+  }
 }
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/MulLayer.cc
+++ b/runtime/onert/backend/cpu/ops/MulLayer.cc
@@ -85,6 +85,10 @@ void MulLayer::run()
   {
     mulQuant8();
   }
+  else
+  {
+    throw std::runtime_error{"Mul: unsupported data type"};
+  }
 }
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/NegLayer.cc
+++ b/runtime/onert/backend/cpu/ops/NegLayer.cc
@@ -58,6 +58,10 @@ void NegLayer::run()
   {
     negQuant8();
   }
+  else
+  {
+    throw std::runtime_error{"Neg: unsupported data type"};
+  }
 }
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/OneHotLayer.cc
+++ b/runtime/onert/backend/cpu/ops/OneHotLayer.cc
@@ -62,6 +62,10 @@ void OneHotLayer::run()
   {
     oneHotQuant8();
   }
+  else
+  {
+    throw std::runtime_error{"OneHot: unsupported data type"};
+  }
 }
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/PackLayer.cc
+++ b/runtime/onert/backend/cpu/ops/PackLayer.cc
@@ -89,6 +89,10 @@ void PackLayer::run()
   {
     packQuant8();
   }
+  else
+  {
+    throw std::runtime_error{"Pack: unsupported data type"};
+  }
 }
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/PadLayer.cc
+++ b/runtime/onert/backend/cpu/ops/PadLayer.cc
@@ -61,6 +61,10 @@ void PadLayer::run()
   {
     padQuant8();
   }
+  else
+  {
+    throw std::runtime_error{"Pad: unsupported data type"};
+  }
 }
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/PowLayer.cc
+++ b/runtime/onert/backend/cpu/ops/PowLayer.cc
@@ -65,7 +65,7 @@ void PowLayer::run()
   if (_output->data_type() == OperandType::FLOAT32)
     powFloat32();
   else
-    throw std::runtime_error{"Pow supports float32 only."};
+    throw std::runtime_error{"Pow: unsupportted data type"};
 }
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/ReLULayer.cc
+++ b/runtime/onert/backend/cpu/ops/ReLULayer.cc
@@ -62,6 +62,10 @@ void ReLULayer::run()
   {
     reluQuant8();
   }
+  else
+  {
+    throw std::runtime_error{"ReLU: unsupported data type"};
+  }
 }
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/ReduceLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ReduceLayer.cc
@@ -112,7 +112,7 @@ void evalGeneric(const Tensor *input, Tensor *output, const std::vector<int> &ax
     case OperandType::BOOL8:
       return evalType<bool>(input, output, axes, keep_dims, reduce_kernel, reduce_type);
     default:
-      throw std::runtime_error{"Reduce(generic): Unsupported input type"};
+      throw std::runtime_error{"Reduce(generic): unsupported data type"};
   }
 }
 } // namespace

--- a/runtime/onert/backend/cpu/ops/SelectLayer.cc
+++ b/runtime/onert/backend/cpu/ops/SelectLayer.cc
@@ -53,15 +53,15 @@ void SelectLayer::run()
                  getTensorShape(_input_false), reinterpret_cast<type *>(_input_false->buffer()), \
                  getTensorShape(_output), reinterpret_cast<type *>(_output->buffer()));
 
-#define KERNEL_SWITCH(type, op)                                                   \
-  switch (type)                                                                   \
-  {                                                                               \
-    break;                                                                        \
-    case OperandType::FLOAT32:                                                    \
-      KERNEL_SELECT(float, op);                                                   \
-      break;                                                                      \
-    default:                                                                      \
-      throw std::runtime_error{"NYI : not supported input type for SelectLayer"}; \
+#define KERNEL_SWITCH(type, op)                                  \
+  switch (type)                                                  \
+  {                                                              \
+    break;                                                       \
+    case OperandType::FLOAT32:                                   \
+      KERNEL_SELECT(float, op);                                  \
+      break;                                                     \
+    default:                                                     \
+      throw std::runtime_error{"Select: unsupported data type"}; \
   }
 
   auto input_type = _input_true->data_type();

--- a/runtime/onert/backend/cpu/ops/ShapeLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ShapeLayer.cc
@@ -71,7 +71,7 @@ void ShapeLayer::run()
   }
   else
   {
-    throw std::runtime_error{"NYI : not supported input type for ShapeLayer"};
+    throw std::runtime_error{"Shape : unsupported data type"};
   }
 }
 

--- a/runtime/onert/backend/cpu/ops/SliceLayer.cc
+++ b/runtime/onert/backend/cpu/ops/SliceLayer.cc
@@ -102,6 +102,10 @@ void SliceLayer::run()
   {
     sliceQuant8();
   }
+  else
+  {
+    throw std::runtime_error{"Slice: unsupported data type"};
+  }
 }
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/SoftMaxLayer.cc
+++ b/runtime/onert/backend/cpu/ops/SoftMaxLayer.cc
@@ -163,6 +163,10 @@ void SoftMaxLayer::run()
   {
     softmaxQuant8();
   }
+  else
+  {
+    throw std::runtime_error{"SoftMax: unsupported data type"};
+  }
 }
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/SplitLayer.cc
+++ b/runtime/onert/backend/cpu/ops/SplitLayer.cc
@@ -88,7 +88,7 @@ void SplitLayer::run()
   }
   else
   {
-    throw std::runtime_error{"Split: Unsupported input type"};
+    throw std::runtime_error{"Split: unsupported input type"};
   }
 }
 

--- a/runtime/onert/backend/cpu/ops/SquaredDiffLayer.cc
+++ b/runtime/onert/backend/cpu/ops/SquaredDiffLayer.cc
@@ -54,6 +54,10 @@ void SqDiffLayer::run()
   {
     SqDiffFloat32();
   }
+  else
+  {
+    throw std::runtime_error{"SquaredDiff: unsupported data type"};
+  }
 }
 } // namespace ops
 } // namespace cpu

--- a/runtime/onert/backend/cpu/ops/StridedSliceLayer.cc
+++ b/runtime/onert/backend/cpu/ops/StridedSliceLayer.cc
@@ -89,6 +89,10 @@ void StridedSliceLayer::run()
   {
     stridedSliceQuant8();
   }
+  else
+  {
+    throw std::runtime_error{"StridedSlice: unsupported data type"};
+  }
 }
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/SubLayer.cc
+++ b/runtime/onert/backend/cpu/ops/SubLayer.cc
@@ -85,6 +85,10 @@ void SubLayer::run()
   {
     subQuant8();
   }
+  else
+  {
+    throw std::runtime_error{"Sub: unsupported data type"};
+  }
 }
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/TanhLayer.cc
+++ b/runtime/onert/backend/cpu/ops/TanhLayer.cc
@@ -62,6 +62,10 @@ void TanhLayer::run()
   {
     tanhQuant8();
   }
+  else
+  {
+    throw std::runtime_error{"Tanh: unsupported data type"};
+  }
 }
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/TileLayer.cc
+++ b/runtime/onert/backend/cpu/ops/TileLayer.cc
@@ -64,6 +64,10 @@ void TileLayer::run()
   {
     tileQuant8();
   }
+  else
+  {
+    throw std::runtime_error{"Tile: unsupported data type"};
+  }
 }
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/TransposeLayer.cc
+++ b/runtime/onert/backend/cpu/ops/TransposeLayer.cc
@@ -73,6 +73,10 @@ void TransposeLayer::run()
   {
     transposeQuant8();
   }
+  else
+  {
+    throw std::runtime_error{"Transpose: unsupported data type"};
+  }
 }
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/UnpackLayer.cc
+++ b/runtime/onert/backend/cpu/ops/UnpackLayer.cc
@@ -94,7 +94,7 @@ void UnpackLayer::run()
   }
   else
   {
-    throw std::runtime_error{"Unpack: Unsupported input type"};
+    throw std::runtime_error{"Unpack: Unsupported data type"};
   }
 }
 


### PR DESCRIPTION
Some throw runtime error for unsupported data type.
However, some goes without showing error when it meets unsupported data type.
It will throw runtim error.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>