### PR TITLE
[luci] Fix CircleArgMax IR test name

### DIFF
--- a/compiler/luci/lang/src/Nodes/CircleArgMax.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleArgMax.test.cpp
@@ -22,11 +22,11 @@
 
 TEST(CircleArgMaxTest, constructor_P)
 {
-  luci::CircleArgMax add_node;
+  luci::CircleArgMax argmax_node;
 
-  ASSERT_EQ(luci::CircleDialect::get(), add_node.dialect());
-  ASSERT_EQ(luci::CircleOpcode::ARG_MAX, add_node.opcode());
+  ASSERT_EQ(luci::CircleDialect::get(), argmax_node.dialect());
+  ASSERT_EQ(luci::CircleOpcode::ARG_MAX, argmax_node.opcode());
 
-  ASSERT_EQ(nullptr, add_node.input());
-  ASSERT_EQ(nullptr, add_node.dimension());
+  ASSERT_EQ(nullptr, argmax_node.input());
+  ASSERT_EQ(nullptr, argmax_node.dimension());
 }


### PR DESCRIPTION
This will fix CircleArgMax IR test name of variable

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>