### PR TITLE
[nnfwapi] Add TCs for `nnfw_output_tensorinfo`

### DIFF
--- a/tests/nnfw_api/src/ValidationTestAddModelLoaded.cc
+++ b/tests/nnfw_api/src/ValidationTestAddModelLoaded.cc
@@ -43,6 +43,14 @@ TEST_F(ValidationTestAddModelLoaded, get_output_size)
   ASSERT_EQ(size, 1);
 }
 
+TEST_F(ValidationTestAddModelLoaded, output_tensorinfo)
+{
+  nnfw_tensorinfo tensor_info;
+  ASSERT_EQ(nnfw_output_tensorinfo(_session, 0, &tensor_info), NNFW_STATUS_NO_ERROR);
+  ASSERT_EQ(tensor_info.rank, 1);
+  ASSERT_EQ(tensor_info.dims[0], 1);
+}
+
 TEST_F(ValidationTestAddModelLoaded, neg_run_001)
 {
   ASSERT_EQ(nnfw_run(_session), NNFW_STATUS_ERROR);
@@ -76,4 +84,10 @@ TEST_F(ValidationTestAddModelLoaded, neg_load_model)
   ASSERT_EQ(nnfw_load_model_from_file(
                 _session, NNPackages::get().getModelAbsolutePath(NNPackages::ADD).c_str()),
             NNFW_STATUS_ERROR);
+}
+
+TEST_F(ValidationTestAddModelLoaded, neg_output_tensorinfo)
+{
+  // tensor_info is null
+  ASSERT_EQ(nnfw_output_tensorinfo(_session, 0, nullptr), NNFW_STATUS_ERROR);
 }

--- a/tests/nnfw_api/src/ValidationTestAddSessionPrepared.cc
+++ b/tests/nnfw_api/src/ValidationTestAddSessionPrepared.cc
@@ -63,6 +63,14 @@ TEST_F(ValidationTestAddSessionPrepared, get_output_size)
   ASSERT_EQ(size, 1);
 }
 
+TEST_F(ValidationTestAddSessionPrepared, output_tensorinfo)
+{
+  nnfw_tensorinfo tensor_info;
+  ASSERT_EQ(nnfw_output_tensorinfo(_session, 0, &tensor_info), NNFW_STATUS_NO_ERROR);
+  ASSERT_EQ(tensor_info.rank, 1);
+  ASSERT_EQ(tensor_info.dims[0], 1);
+}
+
 TEST_F(ValidationTestAddSessionPrepared, neg_set_input_001)
 {
   ASSERT_EQ(nnfw_set_input(_session, 0, NNFW_TYPE_TENSOR_FLOAT32, nullptr, 1), NNFW_STATUS_ERROR);

--- a/tests/nnfw_api/src/ValidationTestSessionCreated.cc
+++ b/tests/nnfw_api/src/ValidationTestSessionCreated.cc
@@ -115,3 +115,12 @@ TEST_F(ValidationTestSessionCreated, neg_get_output_size)
   ASSERT_EQ(nnfw_output_size(_session, &size), NNFW_STATUS_ERROR);
   ASSERT_EQ(size, 10000);
 }
+
+TEST_F(ValidationTestSessionCreated, neg_output_tensorinfo)
+{
+  nnfw_tensorinfo tensor_info;
+  // model is not loaded
+  ASSERT_EQ(nnfw_output_tensorinfo(_session, 0, &tensor_info), NNFW_STATUS_ERROR);
+  // model is not loaded and tensor_info is null
+  ASSERT_EQ(nnfw_output_tensorinfo(_session, 0, nullptr), NNFW_STATUS_ERROR);
+}

--- a/tests/nnfw_api/src/ValidationTestSingleSession.cc
+++ b/tests/nnfw_api/src/ValidationTestSingleSession.cc
@@ -91,3 +91,10 @@ TEST_F(ValidationTestSingleSession, neg_query_info_u32)
 {
   ASSERT_EQ(nnfw_query_info_u32(nullptr, NNFW_INFO_ID_VERSION, nullptr), NNFW_STATUS_ERROR);
 }
+
+TEST_F(ValidationTestSingleSession, neg_output_tensorinfo)
+{
+  nnfw_tensorinfo tensor_info;
+  ASSERT_EQ(nnfw_output_tensorinfo(nullptr, 0, &tensor_info), NNFW_STATUS_ERROR);
+  ASSERT_EQ(nnfw_output_tensorinfo(nullptr, 0, nullptr), NNFW_STATUS_ERROR);
+}


### PR DESCRIPTION
Add some TCs for `nnfw_output_tensorinfo` with a static model.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>