### PR TITLE
[onert] Add def_factor to unused inputs in subgraph

### DIFF
--- a/runtime/onert/core/src/ir/LoweredGraph.cc
+++ b/runtime/onert/core/src/ir/LoweredGraph.cc
@@ -312,6 +312,14 @@ void LoweredGraph::manipulateLowerInfo(
       // In other words, it is not unused input in Graph.
       lower_info->addDefPermuteFactor(*lower_info->use_factors().begin());
     }
+    else
+    {
+      // In case of that an operand is Graph's input and not input or output of any operation
+      lower_info->addDefPermuteFactor(operand::PermuteFactor{
+          controlflow_backend,
+          Layout::NHWC // TODO Get frontend layout of this node from IR
+      });
+    }
   }
   for (auto index : _graph.getOutputs())
   {


### PR DESCRIPTION
For issue #2075

This commit adds def_factor to unused inputs in subgraph.

The inputs and outputs of  child subgraphs of while operation are allocated as tensor even if they are not unused in the subgraph. The tensors are used in copying between subgraphs.

Signed-off-by: ragmani <ragmani0216@gmail.com>