### PR TITLE
[packaging] add circle-verify to preset

### DIFF
--- a/infra/packaging/preset/20200508
+++ b/infra/packaging/preset/20200508
@@ -22,7 +22,7 @@ function preset_configure()
   REQUIRED_UNITS+=("luci")
   # Tools
   REQUIRED_UNITS+=("tflite2circle" "circle2circle" "tflchef" "circlechef")
-  REQUIRED_UNITS+=("tf2tfliteV2" "luci-interpreter")
+  REQUIRED_UNITS+=("tf2tfliteV2" "luci-interpreter" "circle-verify")
   REQUIRED_UNITS+=("record-minmax")
 
   # TODO Use "nncc configure" and "nncc build"


### PR DESCRIPTION
This commit adds circle-verify to preset. `circlechef` uses this in tests
Related : #2068 

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>