### PR TITLE
[packaging] Restore default version

### DIFF
--- a/infra/packaging/build
+++ b/infra/packaging/build
@@ -8,7 +8,7 @@ if [[ -z "${NNAS_PROJECT_PATH}" ]]; then
 fi
 
 # The default preset
-PRESET="20200508"
+PRESET="20191215"
 
 EXTRA_OPTIONS=()
 while [ "$#" -ne 0 ]; do


### PR DESCRIPTION
This commit restores default verison of preset. nnpackage CI test script needs to be updated before changing default version.

Related : #2113

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>