### PR TITLE
[onert] Allow reallocate dynamic tensor more than twice

### DIFF
--- a/runtime/onert/core/src/backend/cpu_common/DynamicTensorManager.cc
+++ b/runtime/onert/core/src/backend/cpu_common/DynamicTensorManager.cc
@@ -73,7 +73,7 @@ void DynamicTensorManager::applyShape(const ir::OperandIndex &ind, const ir::Sha
 
       setShape(tensor.get(), new_shape);
       tensor->set_dynamic();
-      allocTensorMem();
+      allocTensorMem(true);
     }
     else
     { // when buffer with same size was already allocated, shape could differ

--- a/runtime/onert/core/src/backend/cpu_common/MemoryManager.cc
+++ b/runtime/onert/core/src/backend/cpu_common/MemoryManager.cc
@@ -84,7 +84,8 @@ void DynamicMemoryManager::deallocate(const ir::OperandIndex &ind)
   if (find == _mem_alloc_map.end())
     throw std::runtime_error("Cannot find Allocator for the requested index");
 
-  auto alloc = find->second;
+  // alloc's count decreases
+  auto &alloc = find->second;
   alloc.reset();
 }
 
@@ -92,6 +93,7 @@ void DynamicMemoryManager::deallocate(void)
 {
   for (auto &mem_alloc : _mem_alloc_map)
   {
+    // Release memory buffer of mem_alloc
     mem_alloc.second->release();
   }
 }


### PR DESCRIPTION
For issue : #2075 

This commit makes a dynamic tensor to allows reallocating more than twice.

While operation may reallocate a dynamic tensor more than twice

Signed-off-by: ragmani <ragmani0216@gmail.com>