### PR TITLE
[onert] Support int32 type in AddLayer of cpu

### DIFF
--- a/runtime/onert/backend/cpu/ops/AddLayer.h
+++ b/runtime/onert/backend/cpu/ops/AddLayer.h
@@ -44,6 +44,8 @@ public:
 
   void addQuant8();
 
+  void addInt32();
+
   void configure(const Tensor *lhs, const Tensor *rhs, const ir::Activation activation,
                  Tensor *output);
 

--- a/runtime/onert/backend/cpu/ops/OperationUtils.cc
+++ b/runtime/onert/backend/cpu/ops/OperationUtils.cc
@@ -144,6 +144,41 @@ void CalculateActivationRangeFloat(ir::Activation activation, float *activation_
   }
 }
 
+// TODO Unify this with CalculateActivationRangeFloat
+void CalculateActivationRangeInt32(ir::Activation activation, int32_t *activation_min,
+                                   int32_t *activation_max)
+{
+  if (activation == ir::Activation::RELU)
+  {
+    *activation_min = 0;
+    *activation_max = std::numeric_limits<int32_t>::max();
+  }
+  else if (activation == ir::Activation::RELU6)
+  {
+    *activation_min = 0;
+    *activation_max = 6;
+  }
+  else if (activation == ir::Activation::RELU1)
+  {
+    *activation_min = -1;
+    *activation_max = 1;
+  }
+  else if (activation == ir::Activation::SIGMOID)
+  {
+    *activation_min = 0;
+    *activation_max = 1;
+  }
+  else if (activation == ir::Activation::NONE)
+  {
+    *activation_min = std::numeric_limits<int32_t>::lowest();
+    *activation_max = std::numeric_limits<int32_t>::max();
+  }
+  else
+  {
+    std::cout << "Unsupported fused activation function." << std::endl;
+  }
+}
+
 void CalculateActivationRangeUint8(ir::Activation activation, const Tensor *output,
                                    int32_t *act_min, int32_t *act_max)
 {

--- a/runtime/onert/backend/cpu/ops/OperationUtils.h
+++ b/runtime/onert/backend/cpu/ops/OperationUtils.h
@@ -144,6 +144,9 @@ void QuantizeMultiplierGreaterThanOne(double double_multiplier, int32_t *quantiz
 void CalculateActivationRangeFloat(ir::Activation activation, float *activation_min,
                                    float *activation_max);
 
+void CalculateActivationRangeInt32(ir::Activation activation, int32_t *activation_min,
+                                   int32_t *activation_max);
+
 void CalculateActivationRangeUint8(ir::Activation activation, const Tensor *output,
                                    int32_t *act_min, int32_t *act_max);
 


### PR DESCRIPTION
For issue #2075

This commit makes AddLayer of cpu supports int32 type.

NNAPI supports int32 of Add operation since API level 30.

Signed-off-by: ragmani <ragmani0216@gmail.com>