### PR TITLE
[luci] Negative tests for CircleDepthToSpace IR

### DIFF
--- a/compiler/luci/lang/src/Nodes/CircleDepthToSpace.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleDepthToSpace.test.cpp
@@ -17,6 +17,7 @@
 #include "luci/IR/Nodes/CircleDepthToSpace.h"
 
 #include "luci/IR/CircleDialect.h"
+#include "luci/IR/CircleNodeVisitor.h"
 
 #include <gtest/gtest.h>
 
@@ -29,4 +30,51 @@ TEST(CircleDepthToSpaceTest, constructor_P)
 
   ASSERT_EQ(nullptr, std_node.input());
   ASSERT_EQ(0, std_node.block_size());
+}
+
+TEST(CircleDepthToSpaceTest, input_NEG)
+{
+  luci::CircleDepthToSpace std_node;
+  luci::CircleDepthToSpace node;
+
+  std_node.input(&node);
+  ASSERT_NE(nullptr, std_node.input());
+
+  std_node.input(nullptr);
+  ASSERT_EQ(nullptr, std_node.input());
+
+  std_node.block_size(2);
+  ASSERT_EQ(2, std_node.block_size());
+}
+
+TEST(CircleDepthToSpaceTest, arity_NEG)
+{
+  luci::CircleDepthToSpace std_node;
+
+  ASSERT_NO_THROW(std_node.arg(0));
+  ASSERT_THROW(std_node.arg(1), std::out_of_range);
+}
+
+TEST(CircleDepthToSpaceTest, visit_mutable_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeMutableVisitor<void>
+  {
+  };
+
+  luci::CircleDepthToSpace std_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(std_node.accept(&tv), std::exception);
+}
+
+TEST(CircleDepthToSpaceTest, visit_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeVisitor<void>
+  {
+  };
+
+  luci::CircleDepthToSpace std_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(std_node.accept(&tv), std::exception);
 }


### PR DESCRIPTION
This will add some negative tests for CircleDepthToSpace IR

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>