### PR TITLE
[luci] Negative tests for CircleDepthwiseConv2D + 2

### DIFF
--- a/compiler/luci/lang/src/Nodes/CircleDepthwiseConv2D.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleDepthwiseConv2D.test.cpp
@@ -17,6 +17,7 @@
 #include "luci/IR/Nodes/CircleDepthwiseConv2D.h"
 
 #include "luci/IR/CircleDialect.h"
+#include "luci/IR/CircleNodeVisitor.h"
 
 #include <gtest/gtest.h>
 
@@ -37,4 +38,72 @@ TEST(CircleDepthwiseConv2DTest, constructor_P)
   ASSERT_EQ(1, dw_conv2d_node.dilation()->w());
   ASSERT_EQ(0, dw_conv2d_node.depthMultiplier());
   ASSERT_EQ(luci::FusedActFunc::UNDEFINED, dw_conv2d_node.fusedActivationFunction());
+}
+
+TEST(CircleDepthwiseConv2DTest, input_NEG)
+{
+  luci::CircleDepthwiseConv2D dw_conv2d_node;
+  luci::CircleDepthwiseConv2D node;
+
+  dw_conv2d_node.input(&node);
+  dw_conv2d_node.filter(&node);
+  dw_conv2d_node.bias(&node);
+  ASSERT_NE(nullptr, dw_conv2d_node.input());
+  ASSERT_NE(nullptr, dw_conv2d_node.filter());
+  ASSERT_NE(nullptr, dw_conv2d_node.bias());
+
+  dw_conv2d_node.input(nullptr);
+  dw_conv2d_node.filter(nullptr);
+  dw_conv2d_node.bias(nullptr);
+  ASSERT_EQ(nullptr, dw_conv2d_node.input());
+  ASSERT_EQ(nullptr, dw_conv2d_node.filter());
+  ASSERT_EQ(nullptr, dw_conv2d_node.bias());
+
+  dw_conv2d_node.padding(luci::Padding::SAME);
+  ASSERT_NE(luci::Padding::UNDEFINED, dw_conv2d_node.padding());
+
+  dw_conv2d_node.stride()->h(2);
+  dw_conv2d_node.stride()->w(2);
+  ASSERT_EQ(2, dw_conv2d_node.stride()->h());
+  ASSERT_EQ(2, dw_conv2d_node.stride()->w());
+
+  dw_conv2d_node.dilation()->h(2);
+  dw_conv2d_node.dilation()->w(2);
+  ASSERT_EQ(2, dw_conv2d_node.dilation()->h());
+  ASSERT_EQ(2, dw_conv2d_node.dilation()->w());
+
+  dw_conv2d_node.fusedActivationFunction(luci::FusedActFunc::RELU);
+  ASSERT_NE(luci::FusedActFunc::UNDEFINED, dw_conv2d_node.fusedActivationFunction());
+}
+
+TEST(CircleDepthwiseConv2DTest, arity_NEG)
+{
+  luci::CircleDepthwiseConv2D dw_conv2d_node;
+
+  ASSERT_NO_THROW(dw_conv2d_node.arg(2));
+  ASSERT_THROW(dw_conv2d_node.arg(3), std::out_of_range);
+}
+
+TEST(CircleDepthwiseConv2DTest, visit_mutable_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeMutableVisitor<void>
+  {
+  };
+
+  luci::CircleDepthwiseConv2D dw_conv2d_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(dw_conv2d_node.accept(&tv), std::exception);
+}
+
+TEST(CircleDepthwiseConv2DTest, visit_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeVisitor<void>
+  {
+  };
+
+  luci::CircleDepthwiseConv2D dw_conv2d_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(dw_conv2d_node.accept(&tv), std::exception);
 }

--- a/compiler/luci/lang/src/Nodes/CircleDiv.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleDiv.test.cpp
@@ -17,6 +17,7 @@
 #include "luci/IR/Nodes/CircleDiv.h"
 
 #include "luci/IR/CircleDialect.h"
+#include "luci/IR/CircleNodeVisitor.h"
 
 #include <gtest/gtest.h>
 
@@ -29,4 +30,52 @@ TEST(CircleDivTest, constructor_P)
 
   ASSERT_EQ(nullptr, div_node.x());
   ASSERT_EQ(nullptr, div_node.y());
+}
+
+TEST(CircleDivTest, input_NEG)
+{
+  luci::CircleDiv div_node;
+  luci::CircleDiv node;
+
+  div_node.x(&node);
+  div_node.y(&node);
+  ASSERT_NE(nullptr, div_node.x());
+  ASSERT_NE(nullptr, div_node.y());
+
+  div_node.x(nullptr);
+  div_node.y(nullptr);
+  ASSERT_EQ(nullptr, div_node.x());
+  ASSERT_EQ(nullptr, div_node.y());
+}
+
+TEST(CircleDivTest, arity_NEG)
+{
+  luci::CircleDiv div_node;
+
+  ASSERT_NO_THROW(div_node.arg(1));
+  ASSERT_THROW(div_node.arg(2), std::out_of_range);
+}
+
+TEST(CircleDivTest, visit_mutable_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeMutableVisitor<void>
+  {
+  };
+
+  luci::CircleDiv div_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(div_node.accept(&tv), std::exception);
+}
+
+TEST(CircleDivTest, visit_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeVisitor<void>
+  {
+  };
+
+  luci::CircleDiv div_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(div_node.accept(&tv), std::exception);
 }

--- a/compiler/luci/lang/src/Nodes/CircleElu.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleElu.test.cpp
@@ -17,6 +17,7 @@
 #include "luci/IR/Nodes/CircleElu.h"
 
 #include "luci/IR/CircleDialect.h"
+#include "luci/IR/CircleNodeVisitor.h"
 
 #include <gtest/gtest.h>
 
@@ -28,4 +29,48 @@ TEST(CircleEluTest, constructor_P)
   ASSERT_EQ(luci::CircleOpcode::ELU, elu_node.opcode());
 
   ASSERT_EQ(nullptr, elu_node.features());
+}
+
+TEST(CircleEluTest, input_NEG)
+{
+  luci::CircleElu elu_node;
+  luci::CircleElu node;
+
+  elu_node.features(&node);
+  ASSERT_NE(nullptr, elu_node.features());
+
+  elu_node.features(nullptr);
+  ASSERT_EQ(nullptr, elu_node.features());
+}
+
+TEST(CircleEluTest, arity_NEG)
+{
+  luci::CircleElu elu_node;
+
+  ASSERT_NO_THROW(elu_node.arg(0));
+  ASSERT_THROW(elu_node.arg(1), std::out_of_range);
+}
+
+TEST(CircleEluTest, visit_mutable_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeMutableVisitor<void>
+  {
+  };
+
+  luci::CircleElu elu_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(elu_node.accept(&tv), std::exception);
+}
+
+TEST(CircleEluTest, visit_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeVisitor<void>
+  {
+  };
+
+  luci::CircleElu elu_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(elu_node.accept(&tv), std::exception);
 }


### PR DESCRIPTION
This will add some negative tests for CircleDepthwiseConv2D, CircleDiv and CircleElu IR

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>