### PR TITLE
[luci] Negative tests for CircleEqual +2

### DIFF
--- a/compiler/luci/lang/src/Nodes/CircleEqual.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleEqual.test.cpp
@@ -17,16 +17,65 @@
 #include "luci/IR/Nodes/CircleEqual.h"
 
 #include "luci/IR/CircleDialect.h"
+#include "luci/IR/CircleNodeVisitor.h"
 
 #include <gtest/gtest.h>
 
 TEST(CircleEqualTest, constructor_P)
 {
-  luci::CircleEqual or_node;
+  luci::CircleEqual equ_node;
 
-  ASSERT_EQ(luci::CircleDialect::get(), or_node.dialect());
-  ASSERT_EQ(luci::CircleOpcode::EQUAL, or_node.opcode());
+  ASSERT_EQ(luci::CircleDialect::get(), equ_node.dialect());
+  ASSERT_EQ(luci::CircleOpcode::EQUAL, equ_node.opcode());
 
-  ASSERT_EQ(nullptr, or_node.x());
-  ASSERT_EQ(nullptr, or_node.y());
+  ASSERT_EQ(nullptr, equ_node.x());
+  ASSERT_EQ(nullptr, equ_node.y());
+}
+
+TEST(CircleEqualTest, input_NEG)
+{
+  luci::CircleEqual equ_node;
+  luci::CircleEqual node;
+
+  equ_node.x(&node);
+  equ_node.y(&node);
+  ASSERT_NE(nullptr, equ_node.x());
+  ASSERT_NE(nullptr, equ_node.y());
+
+  equ_node.x(nullptr);
+  equ_node.y(nullptr);
+  ASSERT_EQ(nullptr, equ_node.x());
+  ASSERT_EQ(nullptr, equ_node.y());
+}
+
+TEST(CircleEqualTest, arity_NEG)
+{
+  luci::CircleEqual equ_node;
+
+  ASSERT_NO_THROW(equ_node.arg(1));
+  ASSERT_THROW(equ_node.arg(2), std::out_of_range);
+}
+
+TEST(CircleEqualTest, visit_mutable_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeMutableVisitor<void>
+  {
+  };
+
+  luci::CircleEqual equ_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(equ_node.accept(&tv), std::exception);
+}
+
+TEST(CircleEqualTest, visit_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeVisitor<void>
+  {
+  };
+
+  luci::CircleEqual equ_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(equ_node.accept(&tv), std::exception);
 }

--- a/compiler/luci/lang/src/Nodes/CircleExp.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleExp.test.cpp
@@ -17,6 +17,7 @@
 #include "luci/IR/Nodes/CircleExp.h"
 
 #include "luci/IR/CircleDialect.h"
+#include "luci/IR/CircleNodeVisitor.h"
 
 #include <gtest/gtest.h>
 
@@ -28,4 +29,48 @@ TEST(CircleExpTest, constructor)
   ASSERT_EQ(luci::CircleOpcode::EXP, exp_node.opcode());
 
   ASSERT_EQ(nullptr, exp_node.x());
+}
+
+TEST(CircleExpTest, input_NEG)
+{
+  luci::CircleExp exp_node;
+  luci::CircleExp node;
+
+  exp_node.x(&node);
+  ASSERT_NE(nullptr, exp_node.x());
+
+  exp_node.x(nullptr);
+  ASSERT_EQ(nullptr, exp_node.x());
+}
+
+TEST(CircleExpTest, arity_NEG)
+{
+  luci::CircleExp exp_node;
+
+  ASSERT_NO_THROW(exp_node.arg(0));
+  ASSERT_THROW(exp_node.arg(1), std::out_of_range);
+}
+
+TEST(CircleExpTest, visit_mutable_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeMutableVisitor<void>
+  {
+  };
+
+  luci::CircleExp exp_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(exp_node.accept(&tv), std::exception);
+}
+
+TEST(CircleExpTest, visit_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeVisitor<void>
+  {
+  };
+
+  luci::CircleExp exp_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(exp_node.accept(&tv), std::exception);
 }

--- a/compiler/luci/lang/src/Nodes/CircleExpandDims.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleExpandDims.test.cpp
@@ -17,6 +17,7 @@
 #include "luci/IR/Nodes/CircleExpandDims.h"
 
 #include "luci/IR/CircleDialect.h"
+#include "luci/IR/CircleNodeVisitor.h"
 
 #include <gtest/gtest.h>
 
@@ -29,4 +30,52 @@ TEST(CircleExpandDimsTest, constructor_P)
 
   ASSERT_EQ(nullptr, expand_dims.input());
   ASSERT_EQ(nullptr, expand_dims.axis());
+}
+
+TEST(CircleExpandDimsTest, input_NEG)
+{
+  luci::CircleExpandDims expand_dims;
+  luci::CircleExpandDims node;
+
+  expand_dims.input(&node);
+  expand_dims.axis(&node);
+  ASSERT_NE(nullptr, expand_dims.input());
+  ASSERT_NE(nullptr, expand_dims.axis());
+
+  expand_dims.input(nullptr);
+  expand_dims.axis(nullptr);
+  ASSERT_EQ(nullptr, expand_dims.input());
+  ASSERT_EQ(nullptr, expand_dims.axis());
+}
+
+TEST(CircleExpandDimsTest, arity_NEG)
+{
+  luci::CircleExpandDims expand_dims;
+
+  ASSERT_NO_THROW(expand_dims.arg(1));
+  ASSERT_THROW(expand_dims.arg(2), std::out_of_range);
+}
+
+TEST(CircleExpandDimsTest, visit_mutable_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeMutableVisitor<void>
+  {
+  };
+
+  luci::CircleExpandDims expand_dims;
+
+  TestVisitor tv;
+  ASSERT_THROW(expand_dims.accept(&tv), std::exception);
+}
+
+TEST(CircleExpandDimsTest, visit_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeVisitor<void>
+  {
+  };
+
+  luci::CircleExpandDims expand_dims;
+
+  TestVisitor tv;
+  ASSERT_THROW(expand_dims.accept(&tv), std::exception);
 }


### PR DESCRIPTION
This will add some negative tests for CircleEqual, CircleExp and CircleExpandDims IR

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>