### PR TITLE
[onert] let checkMatching work with scalar

### DIFF
--- a/compute/cker/include/cker/Shape.h
+++ b/compute/cker/include/cker/Shape.h
@@ -260,6 +260,10 @@ template <typename... Ts> inline bool checkMatching(const Shape &shape, Ts... ch
   const Shape check_shapes_array[sizeof...(Ts)] = {std::forward<Ts>(check_shapes)...};
   for (const auto &check_shape : check_shapes_array)
   {
+    if (shape.FlatSize() == 1 && check_shape.FlatSize() == 1)
+    {
+      return true;
+    }
     if (shape.DimensionsCount() != check_shape.DimensionsCount())
     {
       return false;


### PR DESCRIPTION
It will make checkMatching consider 1-element tensor is matching
with scalar (1-element).

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>