### PR TITLE
[luci] Negative tests for CircleInstanceNorm +3

### DIFF
--- a/compiler/luci/lang/src/Nodes/CircleInstanceNorm.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleInstanceNorm.test.cpp
@@ -17,6 +17,7 @@
 #include "luci/IR/Nodes/CircleInstanceNorm.h"
 
 #include "luci/IR/CircleDialect.h"
+#include "luci/IR/CircleNodeVisitor.h"
 
 #include <gtest/gtest.h>
 
@@ -32,4 +33,59 @@ TEST(CircleInstanceNormTest, constructor)
   ASSERT_EQ(nullptr, instance_norm.beta());
   ASSERT_FLOAT_EQ(instance_norm.epsilon(), 1e-05);
   ASSERT_EQ(luci::FusedActFunc::UNDEFINED, instance_norm.fusedActivationFunction());
+}
+
+TEST(CircleInstanceNormTest, input_NEG)
+{
+  luci::CircleInstanceNorm instance_norm;
+  luci::CircleInstanceNorm node;
+
+  instance_norm.input(&node);
+  instance_norm.gamma(&node);
+  instance_norm.beta(&node);
+  ASSERT_NE(nullptr, instance_norm.input());
+  ASSERT_NE(nullptr, instance_norm.gamma());
+  ASSERT_NE(nullptr, instance_norm.beta());
+
+  instance_norm.input(nullptr);
+  instance_norm.gamma(nullptr);
+  instance_norm.beta(nullptr);
+  ASSERT_EQ(nullptr, instance_norm.input());
+  ASSERT_EQ(nullptr, instance_norm.gamma());
+  ASSERT_EQ(nullptr, instance_norm.beta());
+
+  instance_norm.fusedActivationFunction(luci::FusedActFunc::RELU);
+  ASSERT_NE(luci::FusedActFunc::UNDEFINED, instance_norm.fusedActivationFunction());
+}
+
+TEST(CircleInstanceNormTest, arity_NEG)
+{
+  luci::CircleInstanceNorm instance_norm;
+
+  ASSERT_NO_THROW(instance_norm.arg(2));
+  ASSERT_THROW(instance_norm.arg(3), std::out_of_range);
+}
+
+TEST(CircleInstanceNormTest, visit_mutable_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeMutableVisitor<void>
+  {
+  };
+
+  luci::CircleInstanceNorm instance_norm;
+
+  TestVisitor tv;
+  ASSERT_THROW(instance_norm.accept(&tv), std::exception);
+}
+
+TEST(CircleInstanceNormTest, visit_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeVisitor<void>
+  {
+  };
+
+  luci::CircleInstanceNorm instance_norm;
+
+  TestVisitor tv;
+  ASSERT_THROW(instance_norm.accept(&tv), std::exception);
 }

--- a/compiler/luci/lang/src/Nodes/CircleL2Pool2D.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleL2Pool2D.test.cpp
@@ -17,6 +17,7 @@
 #include "luci/IR/Nodes/CircleL2Pool2D.h"
 
 #include "luci/IR/CircleDialect.h"
+#include "luci/IR/CircleNodeVisitor.h"
 
 #include <gtest/gtest.h>
 
@@ -28,6 +29,66 @@ TEST(CircleL2Pool2DTest, constructor)
   ASSERT_EQ(luci::CircleOpcode::L2_POOL_2D, l2pool2d_node.opcode());
 
   ASSERT_EQ(nullptr, l2pool2d_node.value());
-  ASSERT_NE(l2pool2d_node.filter(), nullptr);
-  ASSERT_NE(l2pool2d_node.stride(), nullptr);
+  ASSERT_EQ(1, l2pool2d_node.filter()->h());
+  ASSERT_EQ(1, l2pool2d_node.filter()->w());
+  ASSERT_EQ(1, l2pool2d_node.stride()->h());
+  ASSERT_EQ(1, l2pool2d_node.stride()->w());
+  ASSERT_EQ(luci::FusedActFunc::UNDEFINED, l2pool2d_node.fusedActivationFunction());
+}
+
+TEST(CircleL2Pool2DTest, input_NEG)
+{
+  luci::CircleL2Pool2D l2pool2d_node;
+  luci::CircleL2Pool2D node;
+
+  l2pool2d_node.value(&node);
+  ASSERT_NE(nullptr, l2pool2d_node.value());
+
+  l2pool2d_node.value(nullptr);
+  ASSERT_EQ(nullptr, l2pool2d_node.value());
+
+  l2pool2d_node.stride()->h(2);
+  l2pool2d_node.stride()->w(2);
+  ASSERT_EQ(2, l2pool2d_node.stride()->h());
+  ASSERT_EQ(2, l2pool2d_node.stride()->w());
+
+  l2pool2d_node.filter()->h(2);
+  l2pool2d_node.filter()->w(2);
+  ASSERT_EQ(2, l2pool2d_node.filter()->h());
+  ASSERT_EQ(2, l2pool2d_node.filter()->w());
+
+  l2pool2d_node.fusedActivationFunction(luci::FusedActFunc::RELU);
+  ASSERT_NE(luci::FusedActFunc::UNDEFINED, l2pool2d_node.fusedActivationFunction());
+}
+
+TEST(CircleL2Pool2DTest, arity_NEG)
+{
+  luci::CircleL2Pool2D l2pool2d_node;
+
+  ASSERT_NO_THROW(l2pool2d_node.arg(0));
+  ASSERT_THROW(l2pool2d_node.arg(1), std::out_of_range);
+}
+
+TEST(CircleL2Pool2DTest, visit_mutable_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeMutableVisitor<void>
+  {
+  };
+
+  luci::CircleL2Pool2D l2pool2d_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(l2pool2d_node.accept(&tv), std::exception);
+}
+
+TEST(CircleL2Pool2DTest, visit_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeVisitor<void>
+  {
+  };
+
+  luci::CircleL2Pool2D l2pool2d_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(l2pool2d_node.accept(&tv), std::exception);
 }

--- a/compiler/luci/lang/src/Nodes/CircleLess.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleLess.test.cpp
@@ -17,6 +17,7 @@
 #include "luci/IR/Nodes/CircleLess.h"
 
 #include "luci/IR/CircleDialect.h"
+#include "luci/IR/CircleNodeVisitor.h"
 
 #include <gtest/gtest.h>
 
@@ -29,4 +30,52 @@ TEST(CircleLessTest, constructor_P)
 
   ASSERT_EQ(nullptr, less_node.x());
   ASSERT_EQ(nullptr, less_node.y());
+}
+
+TEST(CircleLessTest, input_NEG)
+{
+  luci::CircleLess less_node;
+  luci::CircleLess node;
+
+  less_node.x(&node);
+  less_node.y(&node);
+  ASSERT_NE(nullptr, less_node.x());
+  ASSERT_NE(nullptr, less_node.y());
+
+  less_node.x(nullptr);
+  less_node.y(nullptr);
+  ASSERT_EQ(nullptr, less_node.x());
+  ASSERT_EQ(nullptr, less_node.y());
+}
+
+TEST(CircleLessTest, arity_NEG)
+{
+  luci::CircleLess less_node;
+
+  ASSERT_NO_THROW(less_node.arg(1));
+  ASSERT_THROW(less_node.arg(2), std::out_of_range);
+}
+
+TEST(CircleLessTest, visit_mutable_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeMutableVisitor<void>
+  {
+  };
+
+  luci::CircleLess less_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(less_node.accept(&tv), std::exception);
+}
+
+TEST(CircleLessTest, visit_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeVisitor<void>
+  {
+  };
+
+  luci::CircleLess less_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(less_node.accept(&tv), std::exception);
 }

--- a/compiler/luci/lang/src/Nodes/CircleLessEqual.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleLessEqual.test.cpp
@@ -17,6 +17,7 @@
 #include "luci/IR/Nodes/CircleLessEqual.h"
 
 #include "luci/IR/CircleDialect.h"
+#include "luci/IR/CircleNodeVisitor.h"
 
 #include <gtest/gtest.h>
 
@@ -29,4 +30,52 @@ TEST(CircleLessEqualTest, constructor_P)
 
   ASSERT_EQ(nullptr, less_equal_node.x());
   ASSERT_EQ(nullptr, less_equal_node.y());
+}
+
+TEST(CircleLessEqualTest, input_NEG)
+{
+  luci::CircleLessEqual less_equal_node;
+  luci::CircleLessEqual node;
+
+  less_equal_node.x(&node);
+  less_equal_node.y(&node);
+  ASSERT_NE(nullptr, less_equal_node.x());
+  ASSERT_NE(nullptr, less_equal_node.y());
+
+  less_equal_node.x(nullptr);
+  less_equal_node.y(nullptr);
+  ASSERT_EQ(nullptr, less_equal_node.x());
+  ASSERT_EQ(nullptr, less_equal_node.y());
+}
+
+TEST(CircleLessEqualTest, arity_NEG)
+{
+  luci::CircleLessEqual less_equal_node;
+
+  ASSERT_NO_THROW(less_equal_node.arg(1));
+  ASSERT_THROW(less_equal_node.arg(2), std::out_of_range);
+}
+
+TEST(CircleLessEqualTest, visit_mutable_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeMutableVisitor<void>
+  {
+  };
+
+  luci::CircleLessEqual less_equal_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(less_equal_node.accept(&tv), std::exception);
+}
+
+TEST(CircleLessEqualTest, visit_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeVisitor<void>
+  {
+  };
+
+  luci::CircleLessEqual less_equal_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(less_equal_node.accept(&tv), std::exception);
 }


### PR DESCRIPTION
This will add some negative tests for CircleInstanceNorm, CircleL2Pool2D, CircleLess and CircleLessEqual IR
- and revise CircleL2Pool2D attributes test in CTOR

ONE-DCO-1.0-ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>