### PR TITLE
[luci] Negative tests for CircleLog +3

### DIFF
--- a/compiler/luci/lang/src/Nodes/CircleLocalResponseNormalization.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleLocalResponseNormalization.test.cpp
@@ -17,6 +17,7 @@
 #include "luci/IR/Nodes/CircleLocalResponseNormalization.h"
 
 #include "luci/IR/CircleDialect.h"
+#include "luci/IR/CircleNodeVisitor.h"
 
 #include <gtest/gtest.h>
 
@@ -33,4 +34,57 @@ TEST(CircleLocalResponseNormalizationTest, constructor_P)
   ASSERT_EQ(1.0f, local_response_normalization_node.bias());
   ASSERT_EQ(1.0f, local_response_normalization_node.alpha());
   ASSERT_EQ(0.5f, local_response_normalization_node.beta());
+}
+
+TEST(CircleLocalResponseNormalizationTest, input_NEG)
+{
+  luci::CircleLocalResponseNormalization local_response_normalization_node;
+  luci::CircleLocalResponseNormalization node;
+
+  local_response_normalization_node.input(&node);
+  ASSERT_NE(nullptr, local_response_normalization_node.input());
+
+  local_response_normalization_node.input(nullptr);
+  ASSERT_EQ(nullptr, local_response_normalization_node.input());
+
+  local_response_normalization_node.radius(100);
+  local_response_normalization_node.bias(100.0f);
+  local_response_normalization_node.alpha(100.0f);
+  local_response_normalization_node.beta(100.0f);
+  ASSERT_NE(5, local_response_normalization_node.radius());
+  ASSERT_NE(1.0f, local_response_normalization_node.bias());
+  ASSERT_NE(1.0f, local_response_normalization_node.alpha());
+  ASSERT_NE(0.5f, local_response_normalization_node.beta());
+}
+
+TEST(CircleLocalResponseNormalizationTest, arity_NEG)
+{
+  luci::CircleLocalResponseNormalization local_response_normalization_node;
+
+  ASSERT_NO_THROW(local_response_normalization_node.arg(0));
+  ASSERT_THROW(local_response_normalization_node.arg(1), std::out_of_range);
+}
+
+TEST(CircleLocalResponseNormalizationTest, visit_mutable_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeMutableVisitor<void>
+  {
+  };
+
+  luci::CircleLocalResponseNormalization local_response_normalization_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(local_response_normalization_node.accept(&tv), std::exception);
+}
+
+TEST(CircleLocalResponseNormalizationTest, visit_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeVisitor<void>
+  {
+  };
+
+  luci::CircleLocalResponseNormalization local_response_normalization_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(local_response_normalization_node.accept(&tv), std::exception);
 }

--- a/compiler/luci/lang/src/Nodes/CircleLog.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleLog.test.cpp
@@ -17,6 +17,7 @@
 #include "luci/IR/Nodes/CircleLog.h"
 
 #include "luci/IR/CircleDialect.h"
+#include "luci/IR/CircleNodeVisitor.h"
 
 #include <gtest/gtest.h>
 
@@ -28,4 +29,48 @@ TEST(CircleLogTest, constructor)
   ASSERT_EQ(luci::CircleOpcode::LOG, log_node.opcode());
 
   ASSERT_EQ(nullptr, log_node.x());
+}
+
+TEST(CircleLogTest, input_NEG)
+{
+  luci::CircleLog log_node;
+  luci::CircleLog node;
+
+  log_node.x(&node);
+  ASSERT_NE(nullptr, log_node.x());
+
+  log_node.x(nullptr);
+  ASSERT_EQ(nullptr, log_node.x());
+}
+
+TEST(CircleLogTest, arity_NEG)
+{
+  luci::CircleLog log_node;
+
+  ASSERT_NO_THROW(log_node.arg(0));
+  ASSERT_THROW(log_node.arg(1), std::out_of_range);
+}
+
+TEST(CircleLogTest, visit_mutable_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeMutableVisitor<void>
+  {
+  };
+
+  luci::CircleLog log_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(log_node.accept(&tv), std::exception);
+}
+
+TEST(CircleLogTest, visit_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeVisitor<void>
+  {
+  };
+
+  luci::CircleLog log_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(log_node.accept(&tv), std::exception);
 }

--- a/compiler/luci/lang/src/Nodes/CircleLogistic.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleLogistic.test.cpp
@@ -17,6 +17,7 @@
 #include "luci/IR/Nodes/CircleLogistic.h"
 
 #include "luci/IR/CircleDialect.h"
+#include "luci/IR/CircleNodeVisitor.h"
 
 #include <gtest/gtest.h>
 
@@ -28,4 +29,48 @@ TEST(CircleLogisticTest, constructor)
   ASSERT_EQ(luci::CircleOpcode::LOGISTIC, logistic_node.opcode());
 
   ASSERT_EQ(nullptr, logistic_node.x());
+}
+
+TEST(CircleLogisticTest, input_NEG)
+{
+  luci::CircleLogistic logistic_node;
+  luci::CircleLogistic node;
+
+  logistic_node.x(&node);
+  ASSERT_NE(nullptr, logistic_node.x());
+
+  logistic_node.x(nullptr);
+  ASSERT_EQ(nullptr, logistic_node.x());
+}
+
+TEST(CircleLogisticTest, arity_NEG)
+{
+  luci::CircleLogistic logistic_node;
+
+  ASSERT_NO_THROW(logistic_node.arg(0));
+  ASSERT_THROW(logistic_node.arg(1), std::out_of_range);
+}
+
+TEST(CircleLogisticTest, visit_mutable_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeMutableVisitor<void>
+  {
+  };
+
+  luci::CircleLogistic logistic_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(logistic_node.accept(&tv), std::exception);
+}
+
+TEST(CircleLogisticTest, visit_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeVisitor<void>
+  {
+  };
+
+  luci::CircleLogistic logistic_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(logistic_node.accept(&tv), std::exception);
 }

--- a/compiler/luci/lang/src/Nodes/CircleMaxPool2D.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleMaxPool2D.test.cpp
@@ -17,6 +17,7 @@
 #include "luci/IR/Nodes/CircleMaxPool2D.h"
 
 #include "luci/IR/CircleDialect.h"
+#include "luci/IR/CircleNodeVisitor.h"
 
 #include <gtest/gtest.h>
 
@@ -28,6 +29,62 @@ TEST(CircleMaxPool2DTest, constructor_P)
   ASSERT_EQ(luci::CircleOpcode::MAX_POOL_2D, maxpool2d_node.opcode());
 
   ASSERT_EQ(nullptr, maxpool2d_node.value());
-  ASSERT_NE(maxpool2d_node.filter(), nullptr);
-  ASSERT_NE(maxpool2d_node.stride(), nullptr);
+  ASSERT_EQ(luci::Padding::UNDEFINED, maxpool2d_node.padding());
+  ASSERT_EQ(1, maxpool2d_node.filter()->h());
+  ASSERT_EQ(1, maxpool2d_node.filter()->w());
+  ASSERT_EQ(1, maxpool2d_node.stride()->h());
+  ASSERT_EQ(1, maxpool2d_node.stride()->w());
+}
+
+TEST(CircleMaxPool2DTest, input_NEG)
+{
+  luci::CircleMaxPool2D maxpool2d_node;
+  luci::CircleMaxPool2D node;
+
+  maxpool2d_node.value(&node);
+  ASSERT_NE(nullptr, maxpool2d_node.value());
+
+  maxpool2d_node.value(nullptr);
+  ASSERT_EQ(nullptr, maxpool2d_node.value());
+
+  maxpool2d_node.filter()->h(2);
+  maxpool2d_node.filter()->w(2);
+  maxpool2d_node.stride()->h(2);
+  maxpool2d_node.stride()->w(2);
+  ASSERT_NE(1, maxpool2d_node.filter()->h());
+  ASSERT_NE(1, maxpool2d_node.filter()->w());
+  ASSERT_NE(1, maxpool2d_node.stride()->h());
+  ASSERT_NE(1, maxpool2d_node.stride()->w());
+}
+
+TEST(CircleMaxPool2DTest, arity_NEG)
+{
+  luci::CircleMaxPool2D maxpool2d_node;
+
+  ASSERT_NO_THROW(maxpool2d_node.arg(0));
+  ASSERT_THROW(maxpool2d_node.arg(1), std::out_of_range);
+}
+
+TEST(CircleMaxPool2DTest, visit_mutable_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeMutableVisitor<void>
+  {
+  };
+
+  luci::CircleMaxPool2D maxpool2d_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(maxpool2d_node.accept(&tv), std::exception);
+}
+
+TEST(CircleMaxPool2DTest, visit_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeVisitor<void>
+  {
+  };
+
+  luci::CircleMaxPool2D maxpool2d_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(maxpool2d_node.accept(&tv), std::exception);
 }


### PR DESCRIPTION
This will add some negative tests for CircleLocalResponseNormalization, CircleLog, CircleLogistic and CircleMaxPool2D IR
- also revise attributes tests for CircleMaxPool2D

ONE-DCO-1.0-ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>