### PR TITLE
[luci] Negative tests for CircleLogicalAnd +4

### DIFF
--- a/compiler/luci/lang/src/Nodes/CircleLogicalAnd.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleLogicalAnd.test.cpp
@@ -17,6 +17,7 @@
 #include "luci/IR/Nodes/CircleLogicalAnd.h"
 
 #include "luci/IR/CircleDialect.h"
+#include "luci/IR/CircleNodeVisitor.h"
 
 #include <gtest/gtest.h>
 
@@ -29,4 +30,52 @@ TEST(CircleLogicalAndTest, constructor_P)
 
   ASSERT_EQ(nullptr, and_node.x());
   ASSERT_EQ(nullptr, and_node.y());
+}
+
+TEST(CircleLogicalAndTest, input_NEG)
+{
+  luci::CircleLogicalAnd and_node;
+  luci::CircleLogicalAnd node;
+
+  and_node.x(&node);
+  and_node.y(&node);
+  ASSERT_NE(nullptr, and_node.x());
+  ASSERT_NE(nullptr, and_node.y());
+
+  and_node.x(nullptr);
+  and_node.y(nullptr);
+  ASSERT_EQ(nullptr, and_node.x());
+  ASSERT_EQ(nullptr, and_node.y());
+}
+
+TEST(CircleLogicalAndTest, arity_NEG)
+{
+  luci::CircleLogicalAnd and_node;
+
+  ASSERT_NO_THROW(and_node.arg(1));
+  ASSERT_THROW(and_node.arg(2), std::out_of_range);
+}
+
+TEST(CircleLogicalAndTest, visit_mutable_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeMutableVisitor<void>
+  {
+  };
+
+  luci::CircleLogicalAnd and_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(and_node.accept(&tv), std::exception);
+}
+
+TEST(CircleLogicalAndTest, visit_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeVisitor<void>
+  {
+  };
+
+  luci::CircleLogicalAnd and_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(and_node.accept(&tv), std::exception);
 }

--- a/compiler/luci/lang/src/Nodes/CircleLogicalNot.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleLogicalNot.test.cpp
@@ -17,6 +17,7 @@
 #include "luci/IR/Nodes/CircleLogicalNot.h"
 
 #include "luci/IR/CircleDialect.h"
+#include "luci/IR/CircleNodeVisitor.h"
 
 #include <gtest/gtest.h>
 
@@ -28,4 +29,48 @@ TEST(CircleLogicalNotTest, constructor_P)
   ASSERT_EQ(luci::CircleOpcode::LOGICAL_NOT, not_node.opcode());
 
   ASSERT_EQ(nullptr, not_node.x());
+}
+
+TEST(CircleLogicalNotTest, input_NEG)
+{
+  luci::CircleLogicalNot not_node;
+  luci::CircleLogicalNot node;
+
+  not_node.x(&node);
+  ASSERT_NE(nullptr, not_node.x());
+
+  not_node.x(nullptr);
+  ASSERT_EQ(nullptr, not_node.x());
+}
+
+TEST(CircleLogicalNotTest, arity_NEG)
+{
+  luci::CircleLogicalNot not_node;
+
+  ASSERT_NO_THROW(not_node.arg(0));
+  ASSERT_THROW(not_node.arg(1), std::out_of_range);
+}
+
+TEST(CircleLogicalNotTest, visit_mutable_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeMutableVisitor<void>
+  {
+  };
+
+  luci::CircleLogicalNot not_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(not_node.accept(&tv), std::exception);
+}
+
+TEST(CircleLogicalNotTest, visit_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeVisitor<void>
+  {
+  };
+
+  luci::CircleLogicalNot not_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(not_node.accept(&tv), std::exception);
 }

--- a/compiler/luci/lang/src/Nodes/CircleLogicalOr.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleLogicalOr.test.cpp
@@ -17,6 +17,7 @@
 #include "luci/IR/Nodes/CircleLogicalOr.h"
 
 #include "luci/IR/CircleDialect.h"
+#include "luci/IR/CircleNodeVisitor.h"
 
 #include <gtest/gtest.h>
 
@@ -29,4 +30,52 @@ TEST(CircleLogicalOrTest, constructor_P)
 
   ASSERT_EQ(nullptr, or_node.x());
   ASSERT_EQ(nullptr, or_node.y());
+}
+
+TEST(CircleLogicalOrTest, input_NEG)
+{
+  luci::CircleLogicalOr or_node;
+  luci::CircleLogicalOr node;
+
+  or_node.x(&node);
+  or_node.y(&node);
+  ASSERT_NE(nullptr, or_node.x());
+  ASSERT_NE(nullptr, or_node.y());
+
+  or_node.x(nullptr);
+  or_node.y(nullptr);
+  ASSERT_EQ(nullptr, or_node.x());
+  ASSERT_EQ(nullptr, or_node.y());
+}
+
+TEST(CircleLogicalOrTest, arity_NEG)
+{
+  luci::CircleLogicalOr or_node;
+
+  ASSERT_NO_THROW(or_node.arg(1));
+  ASSERT_THROW(or_node.arg(2), std::out_of_range);
+}
+
+TEST(CircleLogicalOrTest, visit_mutable_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeMutableVisitor<void>
+  {
+  };
+
+  luci::CircleLogicalOr or_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(or_node.accept(&tv), std::exception);
+}
+
+TEST(CircleLogicalOrTest, visit_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeVisitor<void>
+  {
+  };
+
+  luci::CircleLogicalOr or_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(or_node.accept(&tv), std::exception);
 }

--- a/compiler/luci/lang/src/Nodes/CircleNeg.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleNeg.test.cpp
@@ -17,6 +17,7 @@
 #include "luci/IR/Nodes/CircleNeg.h"
 
 #include "luci/IR/CircleDialect.h"
+#include "luci/IR/CircleNodeVisitor.h"
 
 #include <gtest/gtest.h>
 
@@ -28,4 +29,48 @@ TEST(CircleNegTest, constructor)
   ASSERT_EQ(luci::CircleOpcode::NEG, neg_node.opcode());
 
   ASSERT_EQ(nullptr, neg_node.x());
+}
+
+TEST(CircleNegTest, input_NEG)
+{
+  luci::CircleNeg neg_node;
+  luci::CircleNeg node;
+
+  neg_node.x(&node);
+  ASSERT_NE(nullptr, neg_node.x());
+
+  neg_node.x(nullptr);
+  ASSERT_EQ(nullptr, neg_node.x());
+}
+
+TEST(CircleNegTest, arity_NEG)
+{
+  luci::CircleNeg neg_node;
+
+  ASSERT_NO_THROW(neg_node.arg(0));
+  ASSERT_THROW(neg_node.arg(1), std::out_of_range);
+}
+
+TEST(CircleNegTest, visit_mutable_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeMutableVisitor<void>
+  {
+  };
+
+  luci::CircleNeg neg_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(neg_node.accept(&tv), std::exception);
+}
+
+TEST(CircleNegTest, visit_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeVisitor<void>
+  {
+  };
+
+  luci::CircleNeg neg_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(neg_node.accept(&tv), std::exception);
 }

--- a/compiler/luci/lang/src/Nodes/CircleNotEqual.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleNotEqual.test.cpp
@@ -17,6 +17,7 @@
 #include "luci/IR/Nodes/CircleNotEqual.h"
 
 #include "luci/IR/CircleDialect.h"
+#include "luci/IR/CircleNodeVisitor.h"
 
 #include <gtest/gtest.h>
 
@@ -29,4 +30,52 @@ TEST(CircleNotEqualTest, constructor_P)
 
   ASSERT_EQ(nullptr, not_equal_node.x());
   ASSERT_EQ(nullptr, not_equal_node.y());
+}
+
+TEST(CircleNotEqualTest, input_NEG)
+{
+  luci::CircleNotEqual not_equal_node;
+  luci::CircleNotEqual node;
+
+  not_equal_node.x(&node);
+  not_equal_node.y(&node);
+  ASSERT_NE(nullptr, not_equal_node.x());
+  ASSERT_NE(nullptr, not_equal_node.y());
+
+  not_equal_node.x(nullptr);
+  not_equal_node.y(nullptr);
+  ASSERT_EQ(nullptr, not_equal_node.x());
+  ASSERT_EQ(nullptr, not_equal_node.y());
+}
+
+TEST(CircleNotEqualTest, arity_NEG)
+{
+  luci::CircleNotEqual not_equal_node;
+
+  ASSERT_NO_THROW(not_equal_node.arg(1));
+  ASSERT_THROW(not_equal_node.arg(2), std::out_of_range);
+}
+
+TEST(CircleNotEqualTest, visit_mutable_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeMutableVisitor<void>
+  {
+  };
+
+  luci::CircleNotEqual not_equal_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(not_equal_node.accept(&tv), std::exception);
+}
+
+TEST(CircleNotEqualTest, visit_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeVisitor<void>
+  {
+  };
+
+  luci::CircleNotEqual not_equal_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(not_equal_node.accept(&tv), std::exception);
 }


### PR DESCRIPTION
This will add some negative tests for CircleLogicalAnd, CircleLogicalNot, CircleLogicalOr, CircleNeg and CircleNotEqual IR

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>