### PR TITLE
[onert] div will check requires_broadcast with haveSameShape

### DIFF
--- a/runtime/onert/backend/cpu/ops/DivLayer.cc
+++ b/runtime/onert/backend/cpu/ops/DivLayer.cc
@@ -36,21 +36,21 @@ void DivLayer::divFloat32()
   op_params.float_activation_max = output_activation_max;
   op_params.float_activation_min = output_activation_min;
 
-  const bool need_broadcast =
-      nnfw::cker::ProcessBroadcastShapes(getTensorShape(_lhs), getTensorShape(_rhs), &op_params);
-  if (need_broadcast)
+  const bool requires_broadcast = !HaveSameShapes(_lhs, _rhs);
+  if (requires_broadcast)
   {
     nnfw::cker::BroadcastBinaryArithmeticOp(
         op_params, getTensorShape(_lhs), reinterpret_cast<const float *>(_lhs->buffer()),
         getTensorShape(_rhs), reinterpret_cast<const float *>(_rhs->buffer()),
         getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()));
-    return;
   }
-
-  nnfw::cker::BinaryArithmeticOp(
-      op_params, getTensorShape(_lhs), reinterpret_cast<const float *>(_lhs->buffer()),
-      getTensorShape(_rhs), reinterpret_cast<const float *>(_rhs->buffer()),
-      getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()));
+  else
+  {
+    nnfw::cker::BinaryArithmeticOp(
+        op_params, getTensorShape(_lhs), reinterpret_cast<const float *>(_lhs->buffer()),
+        getTensorShape(_rhs), reinterpret_cast<const float *>(_rhs->buffer()),
+        getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()));
+  }
 }
 
 void DivLayer::divQuant8()


### PR DESCRIPTION
Problem:
When div has a tensor with 1 element size and a scalar as inputs,
ProcessBroadcastShapes says broadcast is not required.
However, the path for non-broadcast requires the inputs has same shape.

Solve:
It will check requires_broadcast with haveSameShape as tensorflow lite does.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>