### PR TITLE
[luci] Negative tests for CircleReshape +2

### DIFF
--- a/compiler/luci/lang/src/Nodes/CircleReshape.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleReshape.test.cpp
@@ -17,6 +17,7 @@
 #include "luci/IR/Nodes/CircleReshape.h"
 
 #include "luci/IR/CircleDialect.h"
+#include "luci/IR/CircleNodeVisitor.h"
 
 #include <gtest/gtest.h>
 
@@ -45,4 +46,52 @@ TEST(CircleReshapeTest, alloc_new_shape_P)
   auto &const_reshape = const_cast<const luci::CircleReshape &>(reshape);
   ASSERT_EQ(0, const_reshape.newShape()->dim(0));
   ASSERT_EQ(1, const_reshape.newShape()->dim(1));
+}
+
+TEST(CircleReshapeTest, input_NEG)
+{
+  luci::CircleReshape reshape_node;
+  luci::CircleReshape node;
+
+  reshape_node.tensor(&node);
+  reshape_node.shape(&node);
+  ASSERT_NE(nullptr, reshape_node.tensor());
+  ASSERT_NE(nullptr, reshape_node.shape());
+
+  reshape_node.tensor(nullptr);
+  reshape_node.shape(nullptr);
+  ASSERT_EQ(nullptr, reshape_node.tensor());
+  ASSERT_EQ(nullptr, reshape_node.shape());
+}
+
+TEST(CircleReshapeTest, arity_NEG)
+{
+  luci::CircleReshape reshape_node;
+
+  ASSERT_NO_THROW(reshape_node.arg(1));
+  ASSERT_THROW(reshape_node.arg(2), std::out_of_range);
+}
+
+TEST(CircleReshapeTest, visit_mutable_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeMutableVisitor<void>
+  {
+  };
+
+  luci::CircleReshape reshape_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(reshape_node.accept(&tv), std::exception);
+}
+
+TEST(CircleReshapeTest, visit_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeVisitor<void>
+  {
+  };
+
+  luci::CircleReshape reshape_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(reshape_node.accept(&tv), std::exception);
 }

--- a/compiler/luci/lang/src/Nodes/CircleResizeBilinear.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleResizeBilinear.test.cpp
@@ -17,6 +17,7 @@
 #include "luci/IR/Nodes/CircleResizeBilinear.h"
 
 #include "luci/IR/CircleDialect.h"
+#include "luci/IR/CircleNodeVisitor.h"
 
 #include <gtest/gtest.h>
 
@@ -29,6 +30,59 @@ TEST(CircleResizeBilinearTest, constructor)
 
   ASSERT_EQ(nullptr, resize.input());
   ASSERT_EQ(nullptr, resize.size());
-  ASSERT_EQ(false, resize.align_corners());
-  ASSERT_EQ(false, resize.half_pixel_centers());
+  ASSERT_FALSE(resize.align_corners());
+  ASSERT_FALSE(resize.half_pixel_centers());
+}
+
+TEST(CircleResizeBilinearTest, input_NEG)
+{
+  luci::CircleResizeBilinear resize_node;
+  luci::CircleResizeBilinear node;
+
+  resize_node.input(&node);
+  resize_node.size(&node);
+  ASSERT_NE(nullptr, resize_node.input());
+  ASSERT_NE(nullptr, resize_node.size());
+
+  resize_node.input(nullptr);
+  resize_node.size(nullptr);
+  ASSERT_EQ(nullptr, resize_node.input());
+  ASSERT_EQ(nullptr, resize_node.size());
+
+  resize_node.align_corners(true);
+  ASSERT_TRUE(resize_node.align_corners());
+  resize_node.half_pixel_centers(true);
+  ASSERT_TRUE(resize_node.half_pixel_centers());
+}
+
+TEST(CircleResizeBilinearTest, arity_NEG)
+{
+  luci::CircleResizeBilinear resize_node;
+
+  ASSERT_NO_THROW(resize_node.arg(1));
+  ASSERT_THROW(resize_node.arg(2), std::out_of_range);
+}
+
+TEST(CircleResizeBilinearTest, visit_mutable_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeMutableVisitor<void>
+  {
+  };
+
+  luci::CircleResizeBilinear resize_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(resize_node.accept(&tv), std::exception);
+}
+
+TEST(CircleResizeBilinearTest, visit_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeVisitor<void>
+  {
+  };
+
+  luci::CircleResizeBilinear resize_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(resize_node.accept(&tv), std::exception);
 }

--- a/compiler/luci/lang/src/Nodes/CircleResizeNearestNeighbor.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleResizeNearestNeighbor.test.cpp
@@ -17,6 +17,7 @@
 #include "luci/IR/Nodes/CircleResizeNearestNeighbor.h"
 
 #include "luci/IR/CircleDialect.h"
+#include "luci/IR/CircleNodeVisitor.h"
 
 #include <gtest/gtest.h>
 
@@ -29,5 +30,56 @@ TEST(CircleResizeNearestNeightborTest, constructor)
 
   ASSERT_EQ(nullptr, resize.input());
   ASSERT_EQ(nullptr, resize.size());
-  ASSERT_EQ(false, resize.align_corners());
+  ASSERT_FALSE(resize.align_corners());
+}
+
+TEST(CircleResizeNearestNeightborTest, input_NEG)
+{
+  luci::CircleResizeNearestNeighbor resize_node;
+  luci::CircleResizeNearestNeighbor node;
+
+  resize_node.input(&node);
+  resize_node.size(&node);
+  ASSERT_NE(nullptr, resize_node.input());
+  ASSERT_NE(nullptr, resize_node.size());
+
+  resize_node.input(nullptr);
+  resize_node.size(nullptr);
+  ASSERT_EQ(nullptr, resize_node.input());
+  ASSERT_EQ(nullptr, resize_node.size());
+
+  resize_node.align_corners(true);
+  ASSERT_TRUE(resize_node.align_corners());
+}
+
+TEST(CircleResizeNearestNeightborTest, arity_NEG)
+{
+  luci::CircleResizeNearestNeighbor resize_node;
+
+  ASSERT_NO_THROW(resize_node.arg(1));
+  ASSERT_THROW(resize_node.arg(2), std::out_of_range);
+}
+
+TEST(CircleResizeNearestNeightborTest, visit_mutable_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeMutableVisitor<void>
+  {
+  };
+
+  luci::CircleResizeNearestNeighbor resize_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(resize_node.accept(&tv), std::exception);
+}
+
+TEST(CircleResizeNearestNeightborTest, visit_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeVisitor<void>
+  {
+  };
+
+  luci::CircleResizeNearestNeighbor resize_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(resize_node.accept(&tv), std::exception);
 }


### PR DESCRIPTION
This will add some negative tests for CircleReshape, CircleResizeBilinear and CircleResizeNearestNeighbor IR

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>