### PR TITLE
[luci] Negative tests for CircleRsqrt +3

### DIFF
--- a/compiler/luci/lang/src/Nodes/CircleRsqrt.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleRsqrt.test.cpp
@@ -17,6 +17,7 @@
 #include "luci/IR/Nodes/CircleRsqrt.h"
 
 #include "luci/IR/CircleDialect.h"
+#include "luci/IR/CircleNodeVisitor.h"
 
 #include <gtest/gtest.h>
 
@@ -28,4 +29,48 @@ TEST(CircleRsqrtTest, constructor)
   ASSERT_EQ(luci::CircleOpcode::RSQRT, rsqrt_node.opcode());
 
   ASSERT_EQ(nullptr, rsqrt_node.x());
+}
+
+TEST(CircleRsqrtTest, input_NEG)
+{
+  luci::CircleRsqrt rsqrt_node;
+  luci::CircleRsqrt node;
+
+  rsqrt_node.x(&node);
+  ASSERT_NE(nullptr, rsqrt_node.x());
+
+  rsqrt_node.x(nullptr);
+  ASSERT_EQ(nullptr, rsqrt_node.x());
+}
+
+TEST(CircleRsqrtTest, arity_NEG)
+{
+  luci::CircleRsqrt rsqrt_node;
+
+  ASSERT_NO_THROW(rsqrt_node.arg(0));
+  ASSERT_THROW(rsqrt_node.arg(1), std::out_of_range);
+}
+
+TEST(CircleRsqrtTest, visit_mutable_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeMutableVisitor<void>
+  {
+  };
+
+  luci::CircleRsqrt rsqrt_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(rsqrt_node.accept(&tv), std::exception);
+}
+
+TEST(CircleRsqrtTest, visit_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeVisitor<void>
+  {
+  };
+
+  luci::CircleRsqrt rsqrt_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(rsqrt_node.accept(&tv), std::exception);
 }

--- a/compiler/luci/lang/src/Nodes/CircleScatterNd.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleScatterNd.test.cpp
@@ -17,6 +17,7 @@
 #include "luci/IR/Nodes/CircleScatterNd.h"
 
 #include "luci/IR/CircleDialect.h"
+#include "luci/IR/CircleNodeVisitor.h"
 
 #include <gtest/gtest.h>
 
@@ -30,4 +31,56 @@ TEST(CircleScatterNdTest, constructor_P)
   ASSERT_EQ(nullptr, scatter_nd_node.indices());
   ASSERT_EQ(nullptr, scatter_nd_node.updates());
   ASSERT_EQ(nullptr, scatter_nd_node.shape());
+}
+
+TEST(CircleScatterNdTest, input_NEG)
+{
+  luci::CircleScatterNd scatter_nd_node;
+  luci::CircleScatterNd node;
+
+  scatter_nd_node.indices(&node);
+  scatter_nd_node.updates(&node);
+  scatter_nd_node.shape(&node);
+  ASSERT_NE(nullptr, scatter_nd_node.indices());
+  ASSERT_NE(nullptr, scatter_nd_node.updates());
+  ASSERT_NE(nullptr, scatter_nd_node.shape());
+
+  scatter_nd_node.indices(nullptr);
+  scatter_nd_node.updates(nullptr);
+  scatter_nd_node.shape(nullptr);
+  ASSERT_EQ(nullptr, scatter_nd_node.indices());
+  ASSERT_EQ(nullptr, scatter_nd_node.updates());
+  ASSERT_EQ(nullptr, scatter_nd_node.shape());
+}
+
+TEST(CircleScatterNdTest, arity_NEG)
+{
+  luci::CircleScatterNd scatter_nd_node;
+
+  ASSERT_NO_THROW(scatter_nd_node.arg(2));
+  ASSERT_THROW(scatter_nd_node.arg(3), std::out_of_range);
+}
+
+TEST(CircleScatterNdTest, visit_mutable_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeMutableVisitor<void>
+  {
+  };
+
+  luci::CircleScatterNd scatter_nd_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(scatter_nd_node.accept(&tv), std::exception);
+}
+
+TEST(CircleScatterNdTest, visit_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeVisitor<void>
+  {
+  };
+
+  luci::CircleScatterNd scatter_nd_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(scatter_nd_node.accept(&tv), std::exception);
 }

--- a/compiler/luci/lang/src/Nodes/CircleSelect.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleSelect.test.cpp
@@ -17,6 +17,7 @@
 #include "luci/IR/Nodes/CircleSelect.h"
 
 #include "luci/IR/CircleDialect.h"
+#include "luci/IR/CircleNodeVisitor.h"
 
 #include <gtest/gtest.h>
 
@@ -30,4 +31,56 @@ TEST(CircleSelectTest, constructor)
   ASSERT_EQ(nullptr, select_node.condition());
   ASSERT_EQ(nullptr, select_node.t());
   ASSERT_EQ(nullptr, select_node.e());
+}
+
+TEST(CircleSelectTest, input_NEG)
+{
+  luci::CircleSelect select_node;
+  luci::CircleSelect node;
+
+  select_node.condition(&node);
+  select_node.t(&node);
+  select_node.e(&node);
+  ASSERT_NE(nullptr, select_node.condition());
+  ASSERT_NE(nullptr, select_node.t());
+  ASSERT_NE(nullptr, select_node.e());
+
+  select_node.condition(nullptr);
+  select_node.t(nullptr);
+  select_node.e(nullptr);
+  ASSERT_EQ(nullptr, select_node.condition());
+  ASSERT_EQ(nullptr, select_node.t());
+  ASSERT_EQ(nullptr, select_node.e());
+}
+
+TEST(CircleSelectTest, arity_NEG)
+{
+  luci::CircleSelect select_node;
+
+  ASSERT_NO_THROW(select_node.arg(2));
+  ASSERT_THROW(select_node.arg(3), std::out_of_range);
+}
+
+TEST(CircleSelectTest, visit_mutable_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeMutableVisitor<void>
+  {
+  };
+
+  luci::CircleSelect select_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(select_node.accept(&tv), std::exception);
+}
+
+TEST(CircleSelectTest, visit_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeVisitor<void>
+  {
+  };
+
+  luci::CircleSelect select_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(select_node.accept(&tv), std::exception);
 }

--- a/compiler/luci/lang/src/Nodes/CircleShape.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleShape.test.cpp
@@ -17,6 +17,7 @@
 #include "luci/IR/Nodes/CircleShape.h"
 
 #include "luci/IR/CircleDialect.h"
+#include "luci/IR/CircleNodeVisitor.h"
 
 #include <gtest/gtest.h>
 
@@ -29,4 +30,51 @@ TEST(CircleShapeTest, constructor)
 
   ASSERT_EQ(nullptr, shape_node.input());
   ASSERT_EQ(loco::DataType::S32, shape_node.out_type());
+}
+
+TEST(CircleShapeTest, input_NEG)
+{
+  luci::CircleShape shape_node;
+  luci::CircleShape node;
+
+  shape_node.input(&node);
+  ASSERT_NE(nullptr, shape_node.input());
+
+  shape_node.input(nullptr);
+  ASSERT_EQ(nullptr, shape_node.input());
+
+  shape_node.out_type(loco::DataType::U8);
+  ASSERT_NE(loco::DataType::S32, shape_node.out_type());
+}
+
+TEST(CircleShapeTest, arity_NEG)
+{
+  luci::CircleShape shape_node;
+
+  ASSERT_NO_THROW(shape_node.arg(0));
+  ASSERT_THROW(shape_node.arg(1), std::out_of_range);
+}
+
+TEST(CircleShapeTest, visit_mutable_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeMutableVisitor<void>
+  {
+  };
+
+  luci::CircleShape shape_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(shape_node.accept(&tv), std::exception);
+}
+
+TEST(CircleShapeTest, visit_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeVisitor<void>
+  {
+  };
+
+  luci::CircleShape shape_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(shape_node.accept(&tv), std::exception);
 }


### PR DESCRIPTION
This will add some negative tests for CircleRsqrt, CircleScatterNd, CircleSelect and CircleShape IR

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>