### PR TITLE
[luci] Enable importing for BCQ operations

### DIFF
--- a/compiler/luci/import/include/luci/Import/Nodes/CircleBCQFullyConnected.h
+++ b/compiler/luci/import/include/luci/Import/Nodes/CircleBCQFullyConnected.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __LUCI_IMPORT_OP_CIRCLE_BCQFULLYCONNECTED_H__
+#define __LUCI_IMPORT_OP_CIRCLE_BCQFULLYCONNECTED_H__
+
+#include "luci/Import/GraphBuilder.h"
+
+namespace luci
+{
+
+class CircleBCQFullyConnectedGraphBuilder : public GraphBuilder
+{
+public:
+  bool validate(const ValidateArgs &args) const final;
+
+private:
+  CircleNode *build_node(const circle::OperatorT &op, const std::vector<CircleNode *> &inputs,
+                         loco::Graph *graph) const final;
+};
+
+} // namespace luci
+
+#endif // __LUCI_IMPORT_OP_CIRCLE_BCQFULLYCONNECTED_H__

--- a/compiler/luci/import/include/luci/Import/Nodes/CircleBCQGather.h
+++ b/compiler/luci/import/include/luci/Import/Nodes/CircleBCQGather.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __LUCI_IMPORT_OP_CIRCLE_BCQGATHER_H__
+#define __LUCI_IMPORT_OP_CIRCLE_BCQGATHER_H__
+
+#include "luci/Import/GraphBuilder.h"
+
+namespace luci
+{
+
+class CircleBCQGatherGraphBuilder : public GraphBuilder
+{
+public:
+  bool validate(const ValidateArgs &args) const final;
+
+private:
+  CircleNode *build_node(const circle::OperatorT &op, const std::vector<CircleNode *> &inputs,
+                         loco::Graph *graph) const final;
+};
+
+} // namespace luci
+
+#endif // __LUCI_IMPORT_OP_CIRCLE_BCQGATHER_H__

--- a/compiler/luci/import/src/Nodes/CircleBCQFullyConnected.cpp
+++ b/compiler/luci/import/src/Nodes/CircleBCQFullyConnected.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Import/Nodes/CircleBCQFullyConnected.h"
+
+#include <luci/IR/Nodes/CircleBCQFullyConnected.h>
+
+#include <loco.h>
+
+namespace luci
+{
+
+bool CircleBCQFullyConnectedGraphBuilder::validate(const ValidateArgs &args) const
+{
+  if (args.op.inputs.size() != 4)
+    return false;
+
+  return true;
+}
+
+CircleNode *CircleBCQFullyConnectedGraphBuilder::build_node(const circle::OperatorT &op,
+                                                            const std::vector<CircleNode *> &inputs,
+                                                            loco::Graph *graph) const
+{
+  auto *node = graph->nodes()->create<CircleBCQFullyConnected>();
+
+  node->input(inputs[0]);
+  node->weights_scales(inputs[1]);
+  node->weights_binary(inputs[2]);
+  node->bias(inputs[3]);
+
+  const auto *options = op.builtin_options.AsBCQFullyConnectedOptions();
+  node->weights_hidden_size(options->weights_hidden_size);
+  node->fusedActivationFunction(luci_actfunc(options->fused_activation_function));
+
+  return node;
+}
+
+} // namespace luci

--- a/compiler/luci/import/src/Nodes/CircleBCQGather.cpp
+++ b/compiler/luci/import/src/Nodes/CircleBCQGather.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Import/Nodes/CircleBCQGather.h"
+
+#include <luci/IR/Nodes/CircleBCQGather.h>
+
+#include <loco.h>
+
+namespace luci
+{
+
+bool CircleBCQGatherGraphBuilder::validate(const ValidateArgs &args) const
+{
+  if (args.op.inputs.size() != 3)
+    return false;
+
+  return true;
+}
+
+CircleNode *CircleBCQGatherGraphBuilder::build_node(const circle::OperatorT &op,
+                                                    const std::vector<CircleNode *> &inputs,
+                                                    loco::Graph *graph) const
+{
+  auto *node = graph->nodes()->create<CircleBCQGather>();
+
+  node->input_scales(inputs[0]);
+  node->input_binary(inputs[1]);
+  node->indices(inputs[2]);
+
+  const auto *options = op.builtin_options.AsBCQGatherOptions();
+  node->input_hidden_size(options->input_hidden_size);
+  node->axis(options->axis);
+
+  return node;
+}
+
+} // namespace luci


### PR DESCRIPTION
Parent Issue : #1799

This commit will enable missing importing codes for BCQ operations

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>