### PR TITLE
[luci] Negative tests for CircleSpaceToBatchND +3

### DIFF
--- a/compiler/luci/lang/src/Nodes/CircleSpaceToBatchND.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleSpaceToBatchND.test.cpp
@@ -17,6 +17,7 @@
 #include "luci/IR/Nodes/CircleSpaceToBatchND.h"
 
 #include "luci/IR/CircleDialect.h"
+#include "luci/IR/CircleNodeVisitor.h"
 
 #include <gtest/gtest.h>
 
@@ -30,4 +31,56 @@ TEST(CircleSpaceToBatchNDTest, constructor)
   ASSERT_EQ(nullptr, stb_node.input());
   ASSERT_EQ(nullptr, stb_node.block_shape());
   ASSERT_EQ(nullptr, stb_node.paddings());
+}
+
+TEST(CircleSpaceToBatchNDTest, input_NEG)
+{
+  luci::CircleSpaceToBatchND stb_node;
+  luci::CircleSpaceToBatchND node;
+
+  stb_node.input(&node);
+  stb_node.block_shape(&node);
+  stb_node.paddings(&node);
+  ASSERT_NE(nullptr, stb_node.input());
+  ASSERT_NE(nullptr, stb_node.block_shape());
+  ASSERT_NE(nullptr, stb_node.paddings());
+
+  stb_node.input(nullptr);
+  stb_node.block_shape(nullptr);
+  stb_node.paddings(nullptr);
+  ASSERT_EQ(nullptr, stb_node.input());
+  ASSERT_EQ(nullptr, stb_node.block_shape());
+  ASSERT_EQ(nullptr, stb_node.paddings());
+}
+
+TEST(CircleSpaceToBatchNDTest, arity_NEG)
+{
+  luci::CircleSpaceToBatchND stb_node;
+
+  ASSERT_NO_THROW(stb_node.arg(2));
+  ASSERT_THROW(stb_node.arg(3), std::out_of_range);
+}
+
+TEST(CircleSpaceToBatchNDTest, visit_mutable_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeMutableVisitor<void>
+  {
+  };
+
+  luci::CircleSpaceToBatchND stb_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(stb_node.accept(&tv), std::exception);
+}
+
+TEST(CircleSpaceToBatchNDTest, visit_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeVisitor<void>
+  {
+  };
+
+  luci::CircleSpaceToBatchND stb_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(stb_node.accept(&tv), std::exception);
 }

--- a/compiler/luci/lang/src/Nodes/CircleSpaceToDepth.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleSpaceToDepth.test.cpp
@@ -17,6 +17,7 @@
 #include "luci/IR/Nodes/CircleSpaceToDepth.h"
 
 #include "luci/IR/CircleDialect.h"
+#include "luci/IR/CircleNodeVisitor.h"
 
 #include <gtest/gtest.h>
 
@@ -28,4 +29,48 @@ TEST(CircleSpaceToDepthTest, constructor)
   ASSERT_EQ(luci::CircleOpcode::SPACE_TO_DEPTH, std_node.opcode());
 
   ASSERT_EQ(nullptr, std_node.input());
+}
+
+TEST(CircleSpaceToDepthTest, input_NEG)
+{
+  luci::CircleSpaceToDepth std_node;
+  luci::CircleSpaceToDepth node;
+
+  std_node.input(&node);
+  ASSERT_NE(nullptr, std_node.input());
+
+  std_node.input(nullptr);
+  ASSERT_EQ(nullptr, std_node.input());
+}
+
+TEST(CircleSpaceToDepthTest, arity_NEG)
+{
+  luci::CircleSpaceToDepth std_node;
+
+  ASSERT_NO_THROW(std_node.arg(0));
+  ASSERT_THROW(std_node.arg(1), std::out_of_range);
+}
+
+TEST(CircleSpaceToDepthTest, visit_mutable_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeMutableVisitor<void>
+  {
+  };
+
+  luci::CircleSpaceToDepth std_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(std_node.accept(&tv), std::exception);
+}
+
+TEST(CircleSpaceToDepthTest, visit_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeVisitor<void>
+  {
+  };
+
+  luci::CircleSpaceToDepth std_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(std_node.accept(&tv), std::exception);
 }

--- a/compiler/luci/lang/src/Nodes/CircleSplit.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleSplit.test.cpp
@@ -17,6 +17,7 @@
 #include "luci/IR/Nodes/CircleSplit.h"
 
 #include "luci/IR/CircleDialect.h"
+#include "luci/IR/CircleNodeVisitor.h"
 
 #include <gtest/gtest.h>
 
@@ -30,4 +31,55 @@ TEST(CircleSplitTest, constructor)
   ASSERT_EQ(nullptr, split_node.input());
   ASSERT_EQ(nullptr, split_node.split_dim());
   ASSERT_EQ(0, split_node.num_split());
+}
+
+TEST(CircleSplitTest, input_NEG)
+{
+  luci::CircleSplit split_node;
+  luci::CircleSplit node;
+
+  split_node.input(&node);
+  split_node.split_dim(&node);
+  ASSERT_NE(nullptr, split_node.input());
+  ASSERT_NE(nullptr, split_node.split_dim());
+
+  split_node.input(nullptr);
+  split_node.split_dim(nullptr);
+  ASSERT_EQ(nullptr, split_node.input());
+  ASSERT_EQ(nullptr, split_node.split_dim());
+
+  split_node.num_split(100);
+  ASSERT_NE(0, split_node.num_split());
+}
+
+TEST(CircleSplitTest, arity_NEG)
+{
+  luci::CircleSplit split_node;
+
+  ASSERT_NO_THROW(split_node.arg(1));
+  ASSERT_THROW(split_node.arg(2), std::out_of_range);
+}
+
+TEST(CircleSplitTest, visit_mutable_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeMutableVisitor<void>
+  {
+  };
+
+  luci::CircleSplit split_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(split_node.accept(&tv), std::exception);
+}
+
+TEST(CircleSplitTest, visit_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeVisitor<void>
+  {
+  };
+
+  luci::CircleSplit split_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(split_node.accept(&tv), std::exception);
 }

--- a/compiler/luci/lang/src/Nodes/CircleSplitV.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleSplitV.test.cpp
@@ -17,6 +17,7 @@
 #include "luci/IR/Nodes/CircleSplitV.h"
 
 #include "luci/IR/CircleDialect.h"
+#include "luci/IR/CircleNodeVisitor.h"
 
 #include <gtest/gtest.h>
 
@@ -31,4 +32,59 @@ TEST(CircleSplitVTest, constructor)
   ASSERT_EQ(nullptr, splitv_node.size_splits());
   ASSERT_EQ(nullptr, splitv_node.split_dim());
   ASSERT_EQ(0, splitv_node.num_split());
+}
+
+TEST(CircleSplitVTest, input_NEG)
+{
+  luci::CircleSplitV splitv_node;
+  luci::CircleSplitV node;
+
+  splitv_node.input(&node);
+  splitv_node.size_splits(&node);
+  splitv_node.split_dim(&node);
+  ASSERT_NE(nullptr, splitv_node.input());
+  ASSERT_NE(nullptr, splitv_node.size_splits());
+  ASSERT_NE(nullptr, splitv_node.split_dim());
+
+  splitv_node.input(nullptr);
+  splitv_node.size_splits(nullptr);
+  splitv_node.split_dim(nullptr);
+  ASSERT_EQ(nullptr, splitv_node.input());
+  ASSERT_EQ(nullptr, splitv_node.size_splits());
+  ASSERT_EQ(nullptr, splitv_node.split_dim());
+
+  splitv_node.num_split(100);
+  ASSERT_NE(0, splitv_node.num_split());
+}
+
+TEST(CircleSplitVTest, arity_NEG)
+{
+  luci::CircleSplitV splitv_node;
+
+  ASSERT_NO_THROW(splitv_node.arg(2));
+  ASSERT_THROW(splitv_node.arg(3), std::out_of_range);
+}
+
+TEST(CircleSplitVTest, visit_mutable_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeMutableVisitor<void>
+  {
+  };
+
+  luci::CircleSplitV splitv_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(splitv_node.accept(&tv), std::exception);
+}
+
+TEST(CircleSplitVTest, visit_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeVisitor<void>
+  {
+  };
+
+  luci::CircleSplitV splitv_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(splitv_node.accept(&tv), std::exception);
 }


### PR DESCRIPTION
This will add some negative tests for CircleSpaceToBatchND, CircleSpaceToDepth, CircleSplit and CircleSplitV IR

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>