### PR TITLE
[luci] Negative tests for CircleStridedSlice +2

### DIFF
--- a/compiler/luci/lang/src/Nodes/CircleStridedSlice.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleStridedSlice.test.cpp
@@ -17,6 +17,7 @@
 #include "luci/IR/Nodes/CircleStridedSlice.h"
 
 #include "luci/IR/CircleDialect.h"
+#include "luci/IR/CircleNodeVisitor.h"
 
 #include <gtest/gtest.h>
 
@@ -37,4 +38,71 @@ TEST(CircleStridedSliceTest, constructor)
   ASSERT_EQ(0, ss_node.ellipsis_mask());
   ASSERT_EQ(0, ss_node.new_axis_mask());
   ASSERT_EQ(0, ss_node.shrink_axis_mask());
+}
+
+TEST(CircleStridedSliceTest, input_NEG)
+{
+  luci::CircleStridedSlice ss_node;
+  luci::CircleStridedSlice node;
+
+  ss_node.input(&node);
+  ss_node.begin(&node);
+  ss_node.end(&node);
+  ss_node.strides(&node);
+  ASSERT_NE(nullptr, ss_node.input());
+  ASSERT_NE(nullptr, ss_node.begin());
+  ASSERT_NE(nullptr, ss_node.end());
+  ASSERT_NE(nullptr, ss_node.strides());
+
+  ss_node.input(nullptr);
+  ss_node.begin(nullptr);
+  ss_node.end(nullptr);
+  ss_node.strides(nullptr);
+  ASSERT_EQ(nullptr, ss_node.input());
+  ASSERT_EQ(nullptr, ss_node.begin());
+  ASSERT_EQ(nullptr, ss_node.end());
+  ASSERT_EQ(nullptr, ss_node.strides());
+
+  ss_node.begin_mask(1);
+  ss_node.end_mask(1);
+  ss_node.ellipsis_mask(1);
+  ss_node.new_axis_mask(1);
+  ss_node.shrink_axis_mask(1);
+  ASSERT_NE(0, ss_node.begin_mask());
+  ASSERT_NE(0, ss_node.end_mask());
+  ASSERT_NE(0, ss_node.ellipsis_mask());
+  ASSERT_NE(0, ss_node.new_axis_mask());
+  ASSERT_NE(0, ss_node.shrink_axis_mask());
+}
+
+TEST(CircleStridedSliceTest, arity_NEG)
+{
+  luci::CircleStridedSlice ss_node;
+
+  ASSERT_NO_THROW(ss_node.arg(3));
+  ASSERT_THROW(ss_node.arg(4), std::out_of_range);
+}
+
+TEST(CircleStridedSliceTest, visit_mutable_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeMutableVisitor<void>
+  {
+  };
+
+  luci::CircleStridedSlice ss_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(ss_node.accept(&tv), std::exception);
+}
+
+TEST(CircleStridedSliceTest, visit_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeVisitor<void>
+  {
+  };
+
+  luci::CircleStridedSlice ss_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(ss_node.accept(&tv), std::exception);
 }

--- a/compiler/luci/lang/src/Nodes/CircleSub.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleSub.test.cpp
@@ -17,6 +17,7 @@
 #include "luci/IR/Nodes/CircleSub.h"
 
 #include "luci/IR/CircleDialect.h"
+#include "luci/IR/CircleNodeVisitor.h"
 
 #include <gtest/gtest.h>
 
@@ -29,4 +30,52 @@ TEST(CircleSubTest, constructor_P)
 
   ASSERT_EQ(nullptr, sub_node.x());
   ASSERT_EQ(nullptr, sub_node.y());
+}
+
+TEST(CircleSubTest, input_NEG)
+{
+  luci::CircleSub sub_node;
+  luci::CircleSub node;
+
+  sub_node.x(&node);
+  sub_node.y(&node);
+  ASSERT_NE(nullptr, sub_node.x());
+  ASSERT_NE(nullptr, sub_node.y());
+
+  sub_node.x(nullptr);
+  sub_node.y(nullptr);
+  ASSERT_EQ(nullptr, sub_node.x());
+  ASSERT_EQ(nullptr, sub_node.y());
+}
+
+TEST(CircleSubTest, arity_NEG)
+{
+  luci::CircleSub sub_node;
+
+  ASSERT_NO_THROW(sub_node.arg(1));
+  ASSERT_THROW(sub_node.arg(2), std::out_of_range);
+}
+
+TEST(CircleSubTest, visit_mutable_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeMutableVisitor<void>
+  {
+  };
+
+  luci::CircleSub sub_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(sub_node.accept(&tv), std::exception);
+}
+
+TEST(CircleSubTest, visit_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeVisitor<void>
+  {
+  };
+
+  luci::CircleSub sub_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(sub_node.accept(&tv), std::exception);
 }

--- a/compiler/luci/lang/src/Nodes/CircleSum.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleSum.test.cpp
@@ -17,6 +17,7 @@
 #include "luci/IR/Nodes/CircleSum.h"
 
 #include "luci/IR/CircleDialect.h"
+#include "luci/IR/CircleNodeVisitor.h"
 
 #include <gtest/gtest.h>
 
@@ -30,4 +31,55 @@ TEST(CircleSumTest, constructor_P)
   ASSERT_EQ(nullptr, sum_node.input());
   ASSERT_EQ(nullptr, sum_node.reduction_indices());
   ASSERT_EQ(false, sum_node.keep_dims());
+}
+
+TEST(CircleSumTest, input_NEG)
+{
+  luci::CircleSum sum_node;
+  luci::CircleSum node;
+
+  sum_node.input(&node);
+  sum_node.reduction_indices(&node);
+  ASSERT_NE(nullptr, sum_node.input());
+  ASSERT_NE(nullptr, sum_node.reduction_indices());
+
+  sum_node.input(nullptr);
+  sum_node.reduction_indices(nullptr);
+  ASSERT_EQ(nullptr, sum_node.input());
+  ASSERT_EQ(nullptr, sum_node.reduction_indices());
+
+  sum_node.keep_dims(true);
+  ASSERT_TRUE(sum_node.keep_dims());
+}
+
+TEST(CircleSumTest, arity_NEG)
+{
+  luci::CircleSum sum_node;
+
+  ASSERT_NO_THROW(sum_node.arg(1));
+  ASSERT_THROW(sum_node.arg(2), std::out_of_range);
+}
+
+TEST(CircleSumTest, visit_mutable_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeMutableVisitor<void>
+  {
+  };
+
+  luci::CircleSum sum_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(sum_node.accept(&tv), std::exception);
+}
+
+TEST(CircleSumTest, visit_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeVisitor<void>
+  {
+  };
+
+  luci::CircleSum sum_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(sum_node.accept(&tv), std::exception);
 }


### PR DESCRIPTION
This will add some negative tests for CircleStridedSlice, CircleSub and CircleSum IR

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>