### PR TITLE
[luci] Negative tests for CircleTransposeConv +3

### DIFF
--- a/compiler/luci/lang/src/Nodes/CircleTransposeConv.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleTransposeConv.test.cpp
@@ -17,6 +17,7 @@
 #include "luci/IR/Nodes/CircleTransposeConv.h"
 
 #include "luci/IR/CircleDialect.h"
+#include "luci/IR/CircleNodeVisitor.h"
 
 #include <gtest/gtest.h>
 
@@ -30,4 +31,68 @@ TEST(CircleTransposeConvTest, constructor_P)
   ASSERT_EQ(nullptr, trc_node.inputSizes());
   ASSERT_EQ(nullptr, trc_node.filter());
   ASSERT_EQ(nullptr, trc_node.outBackprop());
+
+  ASSERT_EQ(luci::Padding::UNDEFINED, trc_node.padding());
+  ASSERT_EQ(1, trc_node.stride()->h());
+  ASSERT_EQ(1, trc_node.stride()->w());
+}
+
+TEST(CircleTransposeConvTest, input_NEG)
+{
+  luci::CircleTransposeConv trc_node;
+  luci::CircleTransposeConv node;
+
+  trc_node.inputSizes(&node);
+  trc_node.filter(&node);
+  trc_node.outBackprop(&node);
+  ASSERT_NE(nullptr, trc_node.inputSizes());
+  ASSERT_NE(nullptr, trc_node.filter());
+  ASSERT_NE(nullptr, trc_node.outBackprop());
+
+  trc_node.inputSizes(nullptr);
+  trc_node.filter(nullptr);
+  trc_node.outBackprop(nullptr);
+  ASSERT_EQ(nullptr, trc_node.inputSizes());
+  ASSERT_EQ(nullptr, trc_node.filter());
+  ASSERT_EQ(nullptr, trc_node.outBackprop());
+
+  trc_node.padding(luci::Padding::SAME);
+  ASSERT_NE(luci::Padding::UNDEFINED, trc_node.padding());
+
+  trc_node.stride()->h(2);
+  trc_node.stride()->w(2);
+  ASSERT_EQ(2, trc_node.stride()->h());
+  ASSERT_EQ(2, trc_node.stride()->w());
+}
+
+TEST(CircleTransposeConvTest, arity_NEG)
+{
+  luci::CircleTransposeConv trc_node;
+
+  ASSERT_NO_THROW(trc_node.arg(2));
+  ASSERT_THROW(trc_node.arg(3), std::out_of_range);
+}
+
+TEST(CircleTransposeConvTest, visit_mutable_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeMutableVisitor<void>
+  {
+  };
+
+  luci::CircleTransposeConv trc_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(trc_node.accept(&tv), std::exception);
+}
+
+TEST(CircleTransposeConvTest, visit_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeVisitor<void>
+  {
+  };
+
+  luci::CircleTransposeConv trc_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(trc_node.accept(&tv), std::exception);
 }

--- a/compiler/luci/lang/src/Nodes/CircleUnpack.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleUnpack.test.cpp
@@ -17,6 +17,7 @@
 #include "luci/IR/Nodes/CircleUnpack.h"
 
 #include "luci/IR/CircleDialect.h"
+#include "luci/IR/CircleNodeVisitor.h"
 
 #include <gtest/gtest.h>
 
@@ -30,4 +31,53 @@ TEST(CircleUnpackTest, constructor)
   ASSERT_EQ(nullptr, unpack_node.value());
   ASSERT_EQ(0, unpack_node.num());
   ASSERT_EQ(0, unpack_node.axis());
+}
+
+TEST(CircleUnpackTest, input_NEG)
+{
+  luci::CircleUnpack unpack_node;
+  luci::CircleUnpack node;
+
+  unpack_node.value(&node);
+  ASSERT_NE(nullptr, unpack_node.value());
+
+  unpack_node.value(nullptr);
+  ASSERT_EQ(nullptr, unpack_node.value());
+
+  unpack_node.num(1);
+  unpack_node.axis(1);
+  ASSERT_NE(0, unpack_node.num());
+  ASSERT_NE(0, unpack_node.axis());
+}
+
+TEST(CircleUnpackTest, arity_NEG)
+{
+  luci::CircleUnpack unpack_node;
+
+  ASSERT_NO_THROW(unpack_node.arg(0));
+  ASSERT_THROW(unpack_node.arg(1), std::out_of_range);
+}
+
+TEST(CircleUnpackTest, visit_mutable_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeMutableVisitor<void>
+  {
+  };
+
+  luci::CircleUnpack unpack_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(unpack_node.accept(&tv), std::exception);
+}
+
+TEST(CircleUnpackTest, visit_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeVisitor<void>
+  {
+  };
+
+  luci::CircleUnpack unpack_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(unpack_node.accept(&tv), std::exception);
 }

--- a/compiler/luci/lang/src/Nodes/CircleWhile.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleWhile.test.cpp
@@ -17,6 +17,7 @@
 #include "luci/IR/Nodes/CircleWhile.h"
 
 #include "luci/IR/CircleDialect.h"
+#include "luci/IR/CircleNodeVisitor.h"
 
 #include <gtest/gtest.h>
 
@@ -59,4 +60,28 @@ TEST(CircleWhileTestDeath, invalid_input_set_index_NEG)
   luci::CircleWhile while_node(2, 2);
 
   EXPECT_ANY_THROW(while_node.input(100, nullptr));
+}
+
+TEST(CircleWhileTestDeath, visit_mutable_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeMutableVisitor<void>
+  {
+  };
+
+  luci::CircleWhile while_node(2, 2);
+
+  TestVisitor tv;
+  ASSERT_THROW(while_node.accept(&tv), std::exception);
+}
+
+TEST(CircleWhileTestDeath, visit_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeVisitor<void>
+  {
+  };
+
+  luci::CircleWhile while_node(2, 2);
+
+  TestVisitor tv;
+  ASSERT_THROW(while_node.accept(&tv), std::exception);
 }

--- a/compiler/luci/lang/src/Nodes/CircleZerosLike.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleZerosLike.test.cpp
@@ -17,6 +17,7 @@
 #include "luci/IR/Nodes/CircleZerosLike.h"
 
 #include "luci/IR/CircleDialect.h"
+#include "luci/IR/CircleNodeVisitor.h"
 
 #include <gtest/gtest.h>
 
@@ -28,4 +29,48 @@ TEST(CircleZerosLikeTest, constructor_P)
   ASSERT_EQ(luci::CircleOpcode::ZEROS_LIKE, node.opcode());
 
   ASSERT_EQ(nullptr, node.input());
+}
+
+TEST(CircleZerosLikeTest, input_NEG)
+{
+  luci::CircleZerosLike zeros_node;
+  luci::CircleZerosLike node;
+
+  zeros_node.input(&node);
+  ASSERT_NE(nullptr, zeros_node.input());
+
+  zeros_node.input(nullptr);
+  ASSERT_EQ(nullptr, zeros_node.input());
+}
+
+TEST(CircleZerosLikeTest, arity_NEG)
+{
+  luci::CircleZerosLike zeros_node;
+
+  ASSERT_NO_THROW(zeros_node.arg(0));
+  ASSERT_THROW(zeros_node.arg(1), std::out_of_range);
+}
+
+TEST(CircleZerosLikeTest, visit_mutable_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeMutableVisitor<void>
+  {
+  };
+
+  luci::CircleZerosLike zeros_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(zeros_node.accept(&tv), std::exception);
+}
+
+TEST(CircleZerosLikeTest, visit_NEG)
+{
+  struct TestVisitor final : public luci::CircleNodeVisitor<void>
+  {
+  };
+
+  luci::CircleZerosLike zeros_node;
+
+  TestVisitor tv;
+  ASSERT_THROW(zeros_node.accept(&tv), std::exception);
 }


### PR DESCRIPTION
This will add some negative tests for CircleTransposeConv, CircleUnpack, CircleWhile and CircleZerosLike IR

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>