### PR TITLE
[luci] Revise CircleReduceMax

### DIFF
--- a/compiler/luci/export/src/CircleOperationExporter.cpp
+++ b/compiler/luci/export/src/CircleOperationExporter.cpp
@@ -1050,7 +1050,8 @@ void OperationExporter::visit(luci::CircleReduceAny *node)
 void OperationExporter::visit(luci::CircleReduceMax *node)
 {
   uint32_t op_idx = md.registerBuiltinOpcode(circle::BuiltinOperator_REDUCE_MAX);
-  std::vector<int32_t> inputs_vec{get_tensor_index(node->input()), get_tensor_index(node->axis())};
+  std::vector<int32_t> inputs_vec{get_tensor_index(node->input()),
+                                  get_tensor_index(node->reduction_indices())};
   std::vector<int32_t> outputs_vec{get_tensor_index(static_cast<loco::Node *>(node))};
   auto inputs = builder.CreateVector(inputs_vec);
   auto outputs = builder.CreateVector(outputs_vec);

--- a/compiler/luci/import/src/Nodes/CircleReduceMax.cpp
+++ b/compiler/luci/import/src/Nodes/CircleReduceMax.cpp
@@ -53,7 +53,7 @@ CircleNode *CircleReduceMaxGraphBuilder::build_node(const circle::OperatorT &op,
 {
   auto *node = graph->nodes()->create<CircleReduceMax>();
   node->input(inputs[0]);
-  node->axis(inputs[1]);
+  node->reduction_indices(inputs[1]);
 
   const auto *options = op.builtin_options.AsReducerOptions();
   node->keep_dims(options->keep_dims);

--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleReduceMax.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleReduceMax.h
@@ -34,8 +34,8 @@ public:
   loco::Node *input(void) const { return at(0)->node(); }
   void input(loco::Node *node) { at(0)->node(node); }
 
-  loco::Node *axis(void) const { return at(1)->node(); }
-  void axis(loco::Node *node) { at(1)->node(node); }
+  loco::Node *reduction_indices(void) const { return at(1)->node(); }
+  void reduction_indices(loco::Node *node) { at(1)->node(node); }
 
 public:
   bool keep_dims(void) const { return _keep_dims; }

--- a/compiler/luci/lang/src/Nodes/CircleReduceMax.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleReduceMax.test.cpp
@@ -29,7 +29,7 @@ TEST(CircleReduceMaxTest, constructor_P)
   ASSERT_EQ(luci::CircleOpcode::REDUCE_MAX, reduce_max_node.opcode());
 
   ASSERT_EQ(nullptr, reduce_max_node.input());
-  ASSERT_EQ(nullptr, reduce_max_node.axis());
+  ASSERT_EQ(nullptr, reduce_max_node.reduction_indices());
 
   ASSERT_FALSE(reduce_max_node.keep_dims());
 }
@@ -40,14 +40,14 @@ TEST(CircleReduceMaxTest, input_NEG)
   luci::CircleReduceMax node;
 
   reduce_max_node.input(&node);
-  reduce_max_node.axis(&node);
+  reduce_max_node.reduction_indices(&node);
   ASSERT_NE(nullptr, reduce_max_node.input());
-  ASSERT_NE(nullptr, reduce_max_node.axis());
+  ASSERT_NE(nullptr, reduce_max_node.reduction_indices());
 
   reduce_max_node.input(nullptr);
-  reduce_max_node.axis(nullptr);
+  reduce_max_node.reduction_indices(nullptr);
   ASSERT_EQ(nullptr, reduce_max_node.input());
-  ASSERT_EQ(nullptr, reduce_max_node.axis());
+  ASSERT_EQ(nullptr, reduce_max_node.reduction_indices());
 
   reduce_max_node.keep_dims(true);
   ASSERT_TRUE(reduce_max_node.keep_dims());

--- a/compiler/luci/logex/src/FormattedGraph.cpp
+++ b/compiler/luci/logex/src/FormattedGraph.cpp
@@ -850,7 +850,7 @@ bool CircleNodeSummaryBuilder::summary(const luci::CircleReduceMax *node,
                                        locop::NodeSummary &s) const
 {
   s.args().append("input", tbl()->lookup(node->input()));
-  s.args().append("axis", tbl()->lookup(node->axis()));
+  s.args().append("reduction_indices", tbl()->lookup(node->reduction_indices()));
   s.args().append("keep_dims", node->keep_dims() ? "true" : "false");
   s.state(locop::NodeSummary::State::Complete);
   return true;

--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -1250,7 +1250,7 @@ public:
 
   loco::NodeShape visit(const luci::CircleReduceMax *node) final
   {
-    auto output_shape = infer_reducer(node->input(), node->axis(), node->keep_dims());
+    auto output_shape = infer_reducer(node->input(), node->reduction_indices(), node->keep_dims());
     return loco::NodeShape{output_shape};
   }
 


### PR DESCRIPTION
This will revise CircleReduceMax second input accessor axis to reduction_indices

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>