### PR TITLE
[luci] Revise CircleReduceMin

### DIFF
--- a/compiler/luci/export/src/CircleOperationExporter.cpp
+++ b/compiler/luci/export/src/CircleOperationExporter.cpp
@@ -1063,7 +1063,8 @@ void OperationExporter::visit(luci::CircleReduceMax *node)
 void OperationExporter::visit(luci::CircleReduceMin *node)
 {
   uint32_t op_idx = md.registerBuiltinOpcode(circle::BuiltinOperator_REDUCE_MIN);
-  std::vector<int32_t> inputs_vec{get_tensor_index(node->input()), get_tensor_index(node->axis())};
+  std::vector<int32_t> inputs_vec{get_tensor_index(node->input()),
+                                  get_tensor_index(node->reduction_indices())};
   std::vector<int32_t> outputs_vec{get_tensor_index(static_cast<loco::Node *>(node))};
   auto inputs = builder.CreateVector(inputs_vec);
   auto outputs = builder.CreateVector(outputs_vec);

--- a/compiler/luci/import/src/Nodes/CircleReduceMin.cpp
+++ b/compiler/luci/import/src/Nodes/CircleReduceMin.cpp
@@ -53,7 +53,7 @@ CircleNode *CircleReduceMinGraphBuilder::build_node(const circle::OperatorT &op,
 {
   auto *node = graph->nodes()->create<CircleReduceMin>();
   node->input(inputs[0]);
-  node->axis(inputs[1]);
+  node->reduction_indices(inputs[1]);
 
   const auto *options = op.builtin_options.AsReducerOptions();
   node->keep_dims(options->keep_dims);

--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleReduceMin.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleReduceMin.h
@@ -34,8 +34,8 @@ public:
   loco::Node *input(void) const { return at(0)->node(); }
   void input(loco::Node *node) { at(0)->node(node); }
 
-  loco::Node *axis(void) const { return at(1)->node(); }
-  void axis(loco::Node *node) { at(1)->node(node); }
+  loco::Node *reduction_indices(void) const { return at(1)->node(); }
+  void reduction_indices(loco::Node *node) { at(1)->node(node); }
 
 public:
   bool keep_dims(void) const { return _keep_dims; }

--- a/compiler/luci/lang/src/Nodes/CircleReduceMin.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleReduceMin.test.cpp
@@ -29,7 +29,7 @@ TEST(CircleReduceMinTest, constructor_P)
   ASSERT_EQ(luci::CircleOpcode::REDUCE_MIN, reduce_min_node.opcode());
 
   ASSERT_EQ(nullptr, reduce_min_node.input());
-  ASSERT_EQ(nullptr, reduce_min_node.axis());
+  ASSERT_EQ(nullptr, reduce_min_node.reduction_indices());
 
   ASSERT_FALSE(reduce_min_node.keep_dims());
 }
@@ -40,14 +40,14 @@ TEST(CircleReduceMinTest, input_NEG)
   luci::CircleReduceMin node;
 
   reduce_min_node.input(&node);
-  reduce_min_node.axis(&node);
+  reduce_min_node.reduction_indices(&node);
   ASSERT_NE(nullptr, reduce_min_node.input());
-  ASSERT_NE(nullptr, reduce_min_node.axis());
+  ASSERT_NE(nullptr, reduce_min_node.reduction_indices());
 
   reduce_min_node.input(nullptr);
-  reduce_min_node.axis(nullptr);
+  reduce_min_node.reduction_indices(nullptr);
   ASSERT_EQ(nullptr, reduce_min_node.input());
-  ASSERT_EQ(nullptr, reduce_min_node.axis());
+  ASSERT_EQ(nullptr, reduce_min_node.reduction_indices());
 
   reduce_min_node.keep_dims(true);
   ASSERT_TRUE(reduce_min_node.keep_dims());

--- a/compiler/luci/logex/src/FormattedGraph.cpp
+++ b/compiler/luci/logex/src/FormattedGraph.cpp
@@ -860,7 +860,7 @@ bool CircleNodeSummaryBuilder::summary(const luci::CircleReduceMin *node,
                                        locop::NodeSummary &s) const
 {
   s.args().append("input", tbl()->lookup(node->input()));
-  s.args().append("axis", tbl()->lookup(node->axis()));
+  s.args().append("reduction_indices", tbl()->lookup(node->reduction_indices()));
   s.args().append("keep_dims", node->keep_dims() ? "true" : "false");
   s.state(locop::NodeSummary::State::Complete);
   return true;

--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -1256,7 +1256,7 @@ public:
 
   loco::NodeShape visit(const luci::CircleReduceMin *node) final
   {
-    auto output_shape = infer_reducer(node->input(), node->axis(), node->keep_dims());
+    auto output_shape = infer_reducer(node->input(), node->reduction_indices(), node->keep_dims());
     return loco::NodeShape{output_shape};
   }
 


### PR DESCRIPTION
This will revise CircleReduceMin second input accessor axis to reduction_indices

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>