### PR TITLE
[onert] Make backend::ShapeFixer optional

### DIFF
--- a/runtime/onert/core/src/backend/BackendContext.cc
+++ b/runtime/onert/core/src/backend/BackendContext.cc
@@ -34,6 +34,10 @@ void BackendContext::initialize(const std::vector<OperationInfo> &operation_list
 
 void BackendContext::fixShapes()
 {
+  // shape_fixer is an optional component so it could be nullptr
+  if (!shape_fixer)
+    return;
+
   for (auto &op : _operation_list)
   {
     _graph->operations().at(op.index).accept(*shape_fixer);

--- a/runtime/onert/core/src/backend/controlflow/Backend.h
+++ b/runtime/onert/core/src/backend/controlflow/Backend.h
@@ -70,31 +70,11 @@ public:
     context->tensor_builder = tb;
     context->constant_initializer = std::make_shared<ConstantInitializer>(operands, tb);
     context->kernel_gen = std::make_shared<KernelGenerator>(operands, operations);
-    context->shape_fixer = std::shared_ptr<IShapeFixer>(std::make_shared<EmptyShapeFixer>());
+    context->shape_fixer = nullptr;
     context->tensor_register = nullptr;
     context->optimizer = nullptr;
     return context;
   }
-
-private:
-  class EmptyShapeFixer : public IShapeFixer
-  {
-  public:
-    EmptyShapeFixer() = default;
-
-    void visit(const ir::operation::If &) override
-    {
-      // DO NOTHING
-    }
-    void visit(const ir::operation::Permute &) override
-    {
-      // DO NOTHING
-    }
-    void visit(const ir::operation::While &) override
-    {
-      // DO NOTHING
-    }
-  };
 
 private:
   std::shared_ptr<IConfig> _config;


### PR DESCRIPTION
Make backend::ShapeFixer optional. It was required to check unsupported
operations but it can be checked from KernelGernerator.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>