### PR TITLE
[luci] Fix for release build

### DIFF
--- a/compiler/luci/pass/src/QuantizeDequantizeWeightsPass.cpp
+++ b/compiler/luci/pass/src/QuantizeDequantizeWeightsPass.cpp
@@ -143,8 +143,11 @@ void cal_minmax_per_channel(CircleConst *node, std::vector<float> &min, std::vec
   int channel_dim_index{0};
   int size{0};
 
-  bool ret = get_channel_dim_index(node, dimension, channel_dim_index);
-  assert(ret);
+  if (!get_channel_dim_index(node, dimension, channel_dim_index))
+  {
+    assert(false);
+    return;
+  }
   size = dimension.dim(channel_dim_index).value();
 
   std::vector<bool> has_min_max_value(size, false);
@@ -201,8 +204,11 @@ void wquant_per_channel(CircleConst *node, std::vector<float> &min, std::vector<
   };
   int channel_dim_index{0};
 
-  bool ret = get_channel_dim_index(node, dimension, channel_dim_index);
-  assert(ret);
+  if (!get_channel_dim_index(node, dimension, channel_dim_index))
+  {
+    assert(false);
+    return;
+  }
 
   for (indices[0] = 0; indices[0] < dimension.dim(0).value(); indices[0]++)
   {
@@ -246,8 +252,11 @@ void wdequant_per_channel(CircleConst *node, std::vector<float> &scaling_factor,
   };
   int channel_dim_index{0};
 
-  bool ret = get_channel_dim_index(node, dimension, channel_dim_index);
-  assert(ret);
+  if (!get_channel_dim_index(node, dimension, channel_dim_index))
+  {
+    assert(false);
+    return;
+  }
 
   for (indices[0] = 0; indices[0] < dimension.dim(0).value(); indices[0]++)
   {


### PR DESCRIPTION
This will revise QuantizeDequantizeWeightsPass.cpp to fix release build error showing unused 'ret' variable.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>