### PR TITLE
[onert] Replace setting and getting dimension with setShape() and getShape() in ITensor

### DIFF
--- a/runtime/onert/backend/cpu/ops/ConvolutionLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ConvolutionLayer.cc
@@ -141,10 +141,10 @@ void ConvolutionLayer::run()
 {
   if (_input->is_dynamic() || _kernel->is_dynamic())
   {
-    const auto ifm_shape = getShape(_input).asFeature(_input->layout());
-    const auto ofm_shape = getShape(_output).asFeature(_input->layout());
+    const auto ifm_shape = _input->getShape().asFeature(_input->layout());
+    const auto ofm_shape = _output->getShape().asFeature(_input->layout());
     // Kernel format is [depth_out, kernel_height, kernel_width, depth_in].
-    const auto ker_shape = getShape(_kernel);
+    const auto ker_shape = _kernel->getShape();
     const auto ker_height = ker_shape.dim(1);
     const auto ker_width = ker_shape.dim(2);
 

--- a/runtime/onert/core/include/backend/ITensor.h
+++ b/runtime/onert/core/include/backend/ITensor.h
@@ -25,6 +25,7 @@
 #include "ir/Layout.h"
 #include "ir/Shape.h"
 #include "ir/Coordinates.h"
+#include "util/Utils.h"
 
 namespace onert
 {
@@ -62,30 +63,22 @@ public:
     throw std::runtime_error("This backend does not support dynamic tensor");
   }
 
-  // set dim when this tensor is dynamic
-  virtual void dimension(size_t /* index */, size_t /* dim */)
+  /**
+   * @brief Set the shape of tenser to new_shape
+   * @note  Higer dimension will be placed on front.
+   */
+  virtual void setShape(const ir::Shape &new_shape)
   {
-    throw std::runtime_error("This backend does not support dynamic tensor");
+    UNUSED_RELEASE(new_shape);
+    throw std::runtime_error("This backend does not support dynamic setShape");
   }
 
-  // set the rank when this tensor is dynamic.
-  virtual void num_dimensions(size_t /*rank*/)
-  {
-    throw std::runtime_error("This backend does not support dynamic tensor");
-  }
+  /**
+   * @brief Get ir::Shape of tensor
+   * @note  Higer dimension will be placed on front.
+   */
+  virtual ir::Shape getShape() const;
 };
-
-/**
- * @brief Set the shape of tenser to new_shape
- * @note  Higer dimension will be placed on front.
- */
-void setShape(ITensor *tensor, const ir::Shape &new_shape);
-
-/**
- * @brief Get ir::Shape of tensor
- * @note  Higer dimension will be placed on front.
- */
-ir::Shape getShape(const ITensor *tensor);
 
 } // namespace backend
 } // namespace onert

--- a/runtime/onert/core/include/backend/cpu_common/Tensor.h
+++ b/runtime/onert/core/include/backend/cpu_common/Tensor.h
@@ -114,23 +114,7 @@ public:
     }
   }
 
-  void dimension(size_t index, size_t dim) override
-  {
-    auto rank = _info.shape().rank();
-    rank = rank == 0 ? 1 : rank;
-    if (!(index < static_cast<size_t>(rank)))
-    {
-      throw std::runtime_error("index should be less than rank");
-    }
-
-    _info.shape().dim(index) = dim;
-  }
-
-  void num_dimensions(size_t rank) override
-  {
-    ir::Shape new_shape(rank); // all dims are initialized to 0 (invalid dim)
-    _info.shape(new_shape);
-  };
+  void setShape(const ir::Shape &new_shape) override;
 
 private:
   ir::OperandInfo _info;

--- a/runtime/onert/core/src/backend/ITensor.cc
+++ b/runtime/onert/core/src/backend/ITensor.cc
@@ -21,22 +21,11 @@ namespace onert
 namespace backend
 {
 
-void setShape(ITensor *tensor, const ir::Shape &new_shape)
+ir::Shape ITensor::getShape() const
 {
-  assert(tensor);
-
-  tensor->num_dimensions(new_shape.rank());
-  for (int i = 0; i < new_shape.rank(); i++)
-    tensor->dimension(i, new_shape.dim(i));
-}
-
-ir::Shape getShape(const ITensor *tensor)
-{
-  assert(tensor);
-
-  onert::ir::Shape shape(tensor->num_dimensions());
-  for (uint32_t d = 0; d < tensor->num_dimensions(); d++)
-    shape.dim(d) = tensor->dimension(d);
+  onert::ir::Shape shape(num_dimensions());
+  for (uint32_t d = 0; d < num_dimensions(); d++)
+    shape.dim(d) = dimension(d);
 
   return shape;
 }

--- a/runtime/onert/core/src/backend/controlflow/kernel/IfLayer.cc
+++ b/runtime/onert/core/src/backend/controlflow/kernel/IfLayer.cc
@@ -98,8 +98,8 @@ void IfLayer::run()
   for (size_t i = 0; i < _output_tensors.size(); ++i)
   {
     const auto output_tensor = _output_tensors.at(i);
-    const auto orig_output_shape = getShape(output_tensor.get());
-    const auto changed_output_shape = getShape(subg_output_tensors.at(i).get());
+    const auto orig_output_shape = output_tensor->getShape();
+    const auto changed_output_shape = subg_output_tensors.at(i)->getShape();
     if (orig_output_shape != changed_output_shape &&
         _outputs_dyn_alloc_info.find(output_tensor) != _outputs_dyn_alloc_info.end())
     {

--- a/runtime/onert/core/src/backend/controlflow/kernel/PermuteLayer.cc
+++ b/runtime/onert/core/src/backend/controlflow/kernel/PermuteLayer.cc
@@ -46,7 +46,7 @@ void PermuteLayer::run()
     if (src_tensor->is_dynamic() || dst_tensor->is_dynamic())
     {
       // getting output shape
-      auto src_shape = getShape(src_tensor.get());
+      auto src_shape = src_tensor->getShape();
 
       // set output shape and output buffer
       ir::Shape new_shape =
@@ -56,8 +56,8 @@ void PermuteLayer::run()
       _dst_dyn_alloc_info_map.at(dst_tensor).dyn_tensor_manager->applyShape(dst_index, new_shape);
       assert(dst_tensor->buffer() != nullptr);
     }
-    assert(exec::convertShape(getShape(src_tensor.get()), src_tensor->layout(),
-                              dst_tensor->layout()) == getShape(dst_tensor.get()));
+    assert(exec::convertShape(src_tensor->getShape(), src_tensor->layout(), dst_tensor->layout()) ==
+           dst_tensor->getShape());
   }
   IPermuteFunction::run();
 }

--- a/runtime/onert/core/src/backend/controlflow/kernel/WhileLayer.cc
+++ b/runtime/onert/core/src/backend/controlflow/kernel/WhileLayer.cc
@@ -103,8 +103,8 @@ void WhileLayer::run()
   for (size_t i = 0; i < _output_tensors.size(); ++i)
   {
     const auto output_tensor = _output_tensors.at(i);
-    const auto orig_output_shape = getShape(output_tensor.get());
-    const auto changed_output_shape = getShape(cond_input_tensors.at(i).get());
+    const auto orig_output_shape = output_tensor->getShape();
+    const auto changed_output_shape = cond_input_tensors.at(i)->getShape();
     if (orig_output_shape != changed_output_shape &&
         _outputs_dyn_alloc_info.find(output_tensor) != _outputs_dyn_alloc_info.end())
     {

--- a/runtime/onert/core/src/backend/cpu_common/DynamicTensorManager.cc
+++ b/runtime/onert/core/src/backend/cpu_common/DynamicTensorManager.cc
@@ -52,13 +52,13 @@ void DynamicTensorManager::applyShape(const ir::OperandIndex &ind, const ir::Sha
   {
     // TODO deallocate tensor->buffer()
     // issue is that staticTensorManager might have allocate this memory
-    setShape(tensor.get(), new_shape);
+    tensor->setShape(new_shape);
     tensor->set_dynamic();
     allocTensorMem(true);
   }
   else if (tensor->buffer() == nullptr)
   {
-    setShape(tensor.get(), new_shape);
+    tensor->setShape(new_shape);
     tensor->set_dynamic();
     allocTensorMem();
   }
@@ -71,13 +71,13 @@ void DynamicTensorManager::applyShape(const ir::OperandIndex &ind, const ir::Sha
     {
       _dynamic_mem_mgr->deallocate(ind);
 
-      setShape(tensor.get(), new_shape);
+      tensor->setShape(new_shape);
       tensor->set_dynamic();
       allocTensorMem(true);
     }
     else
     { // when buffer with same size was already allocated, shape could differ
-      setShape(tensor.get(), new_shape);
+      tensor->setShape(new_shape);
     }
   }
 }

--- a/runtime/onert/core/src/backend/cpu_common/Tensor.cc
+++ b/runtime/onert/core/src/backend/cpu_common/Tensor.cc
@@ -38,6 +38,8 @@ size_t Tensor::calcOffset(const ir::Coordinates &coords) const
 
 void Tensor::access(const std::function<void(ITensor &)> &fn) { fn(*this); }
 
+void Tensor::setShape(const ir::Shape &new_shape) { _info.shape(new_shape); }
+
 } // namespace cpu_common
 } // namespace backend
 } // namespace onert

--- a/runtime/onert/core/src/exec/ExecutorBase.cc
+++ b/runtime/onert/core/src/exec/ExecutorBase.cc
@@ -166,9 +166,9 @@ void ExecutorBase::execute(const std::vector<std::shared_ptr<backend::ITensor>> 
     if (src_tensor != nullptr && input_tensor != nullptr)
     {
       auto dyn_alloc_info = _input_to_dyn_alloc_info.find(_input_tensors[n]);
-      const auto orig_input_shape = getShape(input_tensor.get());
+      const auto orig_input_shape = input_tensor->getShape();
       const auto changed_input_shape =
-          convertShape(getShape(src_tensor.get()), src_tensor->layout(), input_tensor->layout());
+          convertShape(src_tensor->getShape(), src_tensor->layout(), input_tensor->layout());
       if (orig_input_shape != changed_input_shape)
       {
         if (dyn_alloc_info == _input_to_dyn_alloc_info.end())
@@ -247,7 +247,7 @@ void ExecutorBase::execute(const IODescription &desc)
     auto &output = *desc.outputs.at(n);
 
     // set shape of outputDesc to tensor shape since tensor can be dynamic
-    const auto output_tensor_shape = getShape(_output_tensors[n].get());
+    const auto output_tensor_shape = _output_tensors[n]->getShape();
     output.info.shape(
         convertShape(output_tensor_shape, _output_tensors[n]->layout(), output.layout));
 

--- a/runtime/onert/core/src/exec/ExecutorBase.h
+++ b/runtime/onert/core/src/exec/ExecutorBase.h
@@ -127,7 +127,7 @@ private:
     const auto &operand = _graph.operands().at(operand_index);
     const auto tensor = _output_tensors[index.value()];
     const auto tensor_layout = tensor->layout();
-    const auto tensor_shape = convertShape(getShape(tensor.get()), tensor->layout(), io_layout);
+    const auto tensor_shape = convertShape(tensor->getShape(), tensor->layout(), io_layout);
 
     if (((tensor_layout == ir::Layout::NCHW) && (io_layout == ir::Layout::NHWC)) ||
         ((tensor_layout == ir::Layout::NHWC) && (io_layout == ir::Layout::NCHW)))

--- a/runtime/onert/core/src/util/shapeinf/ArgMax.cc
+++ b/runtime/onert/core/src/util/shapeinf/ArgMax.cc
@@ -66,7 +66,7 @@ void DynamicInferer::visit(const ir::operation::ArgMax &op)
 {
   const auto input_idx{op.getInputs().at(ir::operation::ArgMax::Input::INPUT)};
   const auto &input = _tensor_registry->getITensor(input_idx);
-  auto input_shape = getShape(input.get());
+  auto input_shape = input->getShape();
 
   if (!input->is_dynamic())
     return;

--- a/runtime/onert/core/src/util/shapeinf/BatchMatMul.cc
+++ b/runtime/onert/core/src/util/shapeinf/BatchMatMul.cc
@@ -98,8 +98,8 @@ void DynamicInferer::visit(const ir::operation::BatchMatMul &op)
   const auto output_index = op.getOutputs().at(0);
   auto output = _tensor_registry->getITensor(output_index);
 
-  auto lhs_shape = getShape(lhs.get());
-  auto rhs_shape = getShape(rhs.get());
+  auto lhs_shape = lhs->getShape();
+  auto rhs_shape = rhs->getShape();
   // TODO
 
   auto new_shape = inferBatchMatMulShape(lhs_shape, rhs_shape, op.param());

--- a/runtime/onert/core/src/util/shapeinf/Concat.cc
+++ b/runtime/onert/core/src/util/shapeinf/Concat.cc
@@ -142,7 +142,7 @@ void DynamicInferer::visit(const ir::operation::Concat &op)
   for (auto input_ind : op.getInputs())
   {
     auto input = _tensor_registry->getITensor(input_ind);
-    ir::Shape shape = getShape(input.get());
+    ir::Shape shape = input->getShape();
 
     in_shapes.emplace_back(shape);
   }

--- a/runtime/onert/core/src/util/shapeinf/Conv2D.cc
+++ b/runtime/onert/core/src/util/shapeinf/Conv2D.cc
@@ -68,8 +68,8 @@ void DynamicInferer::visit(const ir::operation::Conv2D &op)
   if ((!input->is_dynamic()) && (!ker->is_dynamic()))
     return;
 
-  ir::Shape input_shape = getShape(input.get());
-  ir::Shape ker_shape = getShape(ker.get());
+  ir::Shape input_shape = input->getShape();
+  ir::Shape ker_shape = ker->getShape();
 
   auto output_ind = op.getOutputs().at(0);
   auto output = _tensor_registry->getITensor(output_ind);

--- a/runtime/onert/core/src/util/shapeinf/ExpandDims.cc
+++ b/runtime/onert/core/src/util/shapeinf/ExpandDims.cc
@@ -102,7 +102,7 @@ void DynamicInferer::visit(const ir::operation::ExpandDims &op)
   if ((!input->is_dynamic()) && (!output->is_dynamic()))
     return;
 
-  ir::Shape input_shape = getShape(input.get());
+  ir::Shape input_shape = input->getShape();
 
   auto axis_ind = op.getInputs().at(ir::operation::ExpandDims::AXIS);
   auto axis = _tensor_registry->getITensor(axis_ind);

--- a/runtime/onert/core/src/util/shapeinf/Fill.cc
+++ b/runtime/onert/core/src/util/shapeinf/Fill.cc
@@ -70,7 +70,7 @@ void DynamicInferer::visit(const ir::operation::Fill &op)
   auto output = _tensor_registry->getITensor(output_ind);
   auto input_ind = op.getInputs().at(ir::operation::Fill::Input::INPUT);
   auto input = _tensor_registry->getITensor(input_ind);
-  ir::Shape input_shape = getShape(input.get());
+  ir::Shape input_shape = input->getShape();
 
   if ((!input->is_dynamic()) && (!output->is_dynamic()))
     return;

--- a/runtime/onert/core/src/util/shapeinf/FullyConnected.cc
+++ b/runtime/onert/core/src/util/shapeinf/FullyConnected.cc
@@ -70,8 +70,8 @@ void DynamicInferer::visit(const ir::operation::FullyConnected &op)
   if (!input->is_dynamic() && !ker->is_dynamic())
     return;
 
-  auto input_shape = getShape(input.get());
-  auto ker_shape = getShape(ker.get());
+  auto input_shape = input->getShape();
+  auto ker_shape = ker->getShape();
 
   ir::Shape new_shape = inferFullyConnectedShape(input_shape, ker_shape);
 

--- a/runtime/onert/core/src/util/shapeinf/Gather.cc
+++ b/runtime/onert/core/src/util/shapeinf/Gather.cc
@@ -77,11 +77,11 @@ void DynamicInferer::visit(const ir::operation::Gather &op)
 {
   const auto input_idx{op.getInputs().at(ir::operation::Gather::Input::INPUT)};
   const auto &input = _tensor_registry->getITensor(input_idx);
-  auto input_shape = getShape(input.get());
+  auto input_shape = input->getShape();
 
   const auto indices_idx{op.getInputs().at(ir::operation::Gather::Input::INDICES)};
   const auto &indices = _tensor_registry->getITensor(indices_idx);
-  auto indices_shape = getShape(indices.get());
+  auto indices_shape = indices->getShape();
 
   if (!(input->is_dynamic()) && !(indices->is_dynamic()))
     return;

--- a/runtime/onert/core/src/util/shapeinf/Mean.cc
+++ b/runtime/onert/core/src/util/shapeinf/Mean.cc
@@ -54,7 +54,7 @@ void DynamicInferer::visit(const ir::operation::Mean &op)
     return;
   }
 
-  auto input_shape = getShape(input.get());
+  auto input_shape = input->getShape();
 
   auto output_ind = op.getOutputs().at(0);
   auto output = _tensor_registry->getITensor(output_ind);

--- a/runtime/onert/core/src/util/shapeinf/Onehot.cc
+++ b/runtime/onert/core/src/util/shapeinf/Onehot.cc
@@ -77,7 +77,7 @@ void DynamicInferer::visit(const ir::operation::OneHot &op)
 
   auto indices_ind = op.getInputs().at(ir::operation::OneHot::INDICES);
   const auto &indices = _tensor_registry->getITensor(indices_ind);
-  auto indices_shape = getShape(indices.get());
+  auto indices_shape = indices->getShape();
 
   if (!indices->is_dynamic())
   {

--- a/runtime/onert/core/src/util/shapeinf/Pack.cc
+++ b/runtime/onert/core/src/util/shapeinf/Pack.cc
@@ -73,7 +73,7 @@ void DynamicInferer::visit(const ir::operation::Pack &op)
 {
   const auto input_idx{op.getInputs().at(0)};
   const auto &input = _tensor_registry->getITensor(input_idx);
-  auto input_shape = getShape(input.get());
+  auto input_shape = input->getShape();
 
   if (!input->is_dynamic())
     return;

--- a/runtime/onert/core/src/util/shapeinf/Permute.cc
+++ b/runtime/onert/core/src/util/shapeinf/Permute.cc
@@ -47,7 +47,7 @@ void DynamicInferer::visit(const ir::operation::Permute &op)
 {
   const auto input_idx{op.getInputs().at(0)};
   auto input = _tensor_registry->getITensor(input_idx);
-  auto input_shape = getShape(input.get());
+  auto input_shape = input->getShape();
 
   // check if input is not dynamic
   if (!input->is_dynamic())

--- a/runtime/onert/core/src/util/shapeinf/ReduceAll.cc
+++ b/runtime/onert/core/src/util/shapeinf/ReduceAll.cc
@@ -49,7 +49,7 @@ void DynamicInferer::visit(const ir::operation::ReduceAll &op)
 {
   const auto input_idx{op.getInputs().at(0)};
   const auto &input = _tensor_registry->getITensor(input_idx);
-  auto input_shape = getShape(input.get());
+  auto input_shape = input->getShape();
 
   if (!input->is_dynamic())
     return;

--- a/runtime/onert/core/src/util/shapeinf/ReduceProd.cc
+++ b/runtime/onert/core/src/util/shapeinf/ReduceProd.cc
@@ -49,7 +49,7 @@ void DynamicInferer::visit(const ir::operation::ReduceProd &op)
 {
   const auto input_idx{op.getInputs().at(0)};
   const auto &input = _tensor_registry->getITensor(input_idx);
-  auto input_shape = getShape(input.get());
+  auto input_shape = input->getShape();
 
   if (!input->is_dynamic())
     return;

--- a/runtime/onert/core/src/util/shapeinf/ReduceSum.cc
+++ b/runtime/onert/core/src/util/shapeinf/ReduceSum.cc
@@ -49,7 +49,7 @@ void DynamicInferer::visit(const ir::operation::ReduceSum &op)
 {
   const auto input_idx{op.getInputs().at(0)};
   const auto &input = _tensor_registry->getITensor(input_idx);
-  auto input_shape = getShape(input.get());
+  auto input_shape = input->getShape();
 
   if (!input->is_dynamic())
     return;

--- a/runtime/onert/core/src/util/shapeinf/Reshape.cc
+++ b/runtime/onert/core/src/util/shapeinf/Reshape.cc
@@ -152,10 +152,10 @@ void DynamicInferer::visit(const ir::operation::Reshape &op)
   assert(new_shape->num_dimensions() == 1);
   const auto new_rank = new_shape->dimension(0);
 
-  auto output_shape = convertShape(new_shape_buf, new_rank, getShape(input.get()).num_elements());
+  auto output_shape = convertShape(new_shape_buf, new_rank, input->getShape().num_elements());
 
   // if shape is changed, change output shape and reallocate output tensor memory
-  if (output_shape != getShape(output.get()) || output->buffer() == nullptr)
+  if (output_shape != output->getShape() || output->buffer() == nullptr)
   {
     // change on output shape
     _dynamic_tensor_manager->applyShape(output_ind, output_shape);

--- a/runtime/onert/core/src/util/shapeinf/Shape.cc
+++ b/runtime/onert/core/src/util/shapeinf/Shape.cc
@@ -48,7 +48,7 @@ void DynamicInferer::visit(const ir::operation::Shape &op)
 {
   const auto input_idx{op.getInputs().at(0)};
   const auto &input = _tensor_registry->getITensor(input_idx);
-  auto input_shape = getShape(input.get());
+  auto input_shape = input->getShape();
 
   if (!input->is_dynamic())
     return;

--- a/runtime/onert/core/src/util/shapeinf/ShapeInference.cc
+++ b/runtime/onert/core/src/util/shapeinf/ShapeInference.cc
@@ -325,10 +325,10 @@ void DynamicInferer::handleBinaryArithmeticOp(const ir::Operation &op,
                                               const ir::OperandIndex rhs_idx)
 {
   auto lhs = _tensor_registry->getITensor(lhs_idx);
-  auto lhs_shape = getShape(lhs.get());
+  auto lhs_shape = lhs->getShape();
 
   auto rhs = _tensor_registry->getITensor(rhs_idx);
-  auto rhs_shape = getShape(rhs.get());
+  auto rhs_shape = rhs->getShape();
 
   /*
     Here, the state after compilation (satic shape inference) could be one of the following:
@@ -361,7 +361,7 @@ void DynamicInferer::handleSimpleUnaryOp(const ir::Operation &op, const ir::Oper
 {
   // check if input is not dynamic
   auto input = _tensor_registry->getITensor(input_ind);
-  auto output_shape = getShape(input.get());
+  auto output_shape = input->getShape();
 
   /*
     Here, the state after compilation (satic shape inference) could be one of the following:

--- a/runtime/onert/core/src/util/shapeinf/Slice.cc
+++ b/runtime/onert/core/src/util/shapeinf/Slice.cc
@@ -116,7 +116,7 @@ void DynamicInferer::visit(const ir::operation::Slice &op)
     return;
   }
 
-  ir::Shape input_shape = getShape(input.get());
+  ir::Shape input_shape = input->getShape();
   auto begins_buf = reinterpret_cast<const int32_t *>(begins->buffer());
   auto sizes_buf = reinterpret_cast<const int32_t *>(sizes->buffer());
   const auto rank = input_shape.rank();

--- a/runtime/onert/core/src/util/shapeinf/Split.cc
+++ b/runtime/onert/core/src/util/shapeinf/Split.cc
@@ -80,7 +80,7 @@ void DynamicInferer::visit(const ir::operation::Split &op)
     return;
   }
 
-  auto input_shape = getShape(input.get());
+  auto input_shape = input->getShape();
 
   const auto axis = op.param().axis;
   const auto num_splits = op.param().num_splits;

--- a/runtime/onert/core/src/util/shapeinf/Squeeze.cc
+++ b/runtime/onert/core/src/util/shapeinf/Squeeze.cc
@@ -105,7 +105,7 @@ void DynamicInferer::visit(const ir::operation::Squeeze &op)
     return;
   }
 
-  auto input_shape = getShape(input.get());
+  auto input_shape = input->getShape();
 
   // Squeeze output shpae
   ir::Shape new_shape = inferSqueezeShape(input_shape, op.param());

--- a/runtime/onert/core/src/util/shapeinf/StridedSlice.cc
+++ b/runtime/onert/core/src/util/shapeinf/StridedSlice.cc
@@ -263,7 +263,7 @@ void DynamicInferer::visit(const ir::operation::StridedSlice &op)
 
   const auto input_index{op.getInputs().at(ir::operation::StridedSlice::Input::INPUT)};
   auto input = _tensor_registry->getITensor(input_index);
-  ir::Shape input_shape = getShape(input.get());
+  ir::Shape input_shape = input->getShape();
 
   const auto starts_index{op.getInputs().at(ir::operation::StridedSlice::Input::STARTS)};
   auto starts = _tensor_registry->getITensor(starts_index);

--- a/runtime/onert/core/src/util/shapeinf/Tile.cc
+++ b/runtime/onert/core/src/util/shapeinf/Tile.cc
@@ -79,7 +79,7 @@ void DynamicInferer::visit(const ir::operation::Tile &op)
   if ((!input->is_dynamic()) && (!output->is_dynamic()))
     return;
 
-  auto input_shape = getShape(input.get());
+  auto input_shape = input->getShape();
   auto multiplier_buffer = reinterpret_cast<const int32_t *>(multiplier->buffer());
   assert(multiplier_buffer);
 

--- a/runtime/onert/core/src/util/shapeinf/Transpose.cc
+++ b/runtime/onert/core/src/util/shapeinf/Transpose.cc
@@ -73,7 +73,7 @@ void DynamicInferer::visit(const ir::operation::Transpose &op)
   // from op, access the buffer of second input to read new shape
   auto input_ind = op.getInputs().at(ir::operation::Transpose::Input::INPUT);
   auto input_tensor = _tensor_registry->getITensor(input_ind);
-  auto input_shape = getShape(input_tensor.get());
+  auto input_shape = input_tensor->getShape();
 
   if (!input_tensor->is_dynamic())
     return;
@@ -81,7 +81,6 @@ void DynamicInferer::visit(const ir::operation::Transpose &op)
   const auto perm{op.param().perm};
   // set output shape, based on input and params
   ir::Shape new_shape = inferTransposeShape(input_shape, perm);
-  setShape(output.get(), new_shape);
 
   _dynamic_tensor_manager->applyShape(output_ind, new_shape);
   assert(output->buffer() != nullptr);

--- a/runtime/onert/core/src/util/shapeinf/Unpack.cc
+++ b/runtime/onert/core/src/util/shapeinf/Unpack.cc
@@ -79,7 +79,7 @@ void DynamicInferer::visit(const ir::operation::Unpack &op)
   if (!input->is_dynamic())
     return;
 
-  auto input_shape = getShape(input.get());
+  auto input_shape = input->getShape();
 
   const auto rank = input_shape.rank();
   const auto axis = ((op.param().axis < 0) ? rank + op.param().axis : op.param().axis);


### PR DESCRIPTION
This commit replaces setting and getting dimension with setShape() and getShape() in ITensor
  - Move setShape() and getShape() into ITensor
  - Remove num_dimensions(size_t rank) and dimension(size_t index, size_t dim)
  - Change using the num_dimensions() and dimension() to using setShape() and getShape()

Signed-off-by: ragmani <ragmani0216@gmail.com>