### PR TITLE
[onert] use 0 to 99 range when generating random input for int32

### DIFF
--- a/runtime/libs/misc/src/RandomGenerator.cpp
+++ b/runtime/libs/misc/src/RandomGenerator.cpp
@@ -57,12 +57,12 @@ template <> bool RandomGenerator::generate<bool>(void)
 
 template <> int32_t RandomGenerator::generate<int32_t>(void)
 {
-  // Instead of INT_MAX, 4096 is chosen because int32_t input does not mean
+  // Instead of INT_MAX, 99 is chosen because int32_t input does not mean
   // that the model can have any value in int32_t can hold.
   // For example, one_hot operation gets indices as int32_t tensor.
   // However, we usually expect it would hold a value in [0..depth).
   // In our given model, depth was 10137.
-  const int int32_random_max = 4096;
+  const int int32_random_max = 99;
   std::uniform_int_distribution<> dist(0, int32_random_max);
   return dist(_rand);
 }

--- a/tools/nnpackage_tool/gen_golden/gen_golden.py
+++ b/tools/nnpackage_tool/gen_golden/gen_golden.py
@@ -100,7 +100,7 @@ if __name__ == '__main__':
                     np.array(np.random.randint(2, size=this_shape), this_dtype))
             elif this_dtype == np.int32:
                 input_values.append(
-                    np.array(np.random.randint(-(2**15), 2**15, this_shape, "int32")))
+                    np.array(np.random.randint(0, 99, this_shape, "int32")))
 
         # get output values by running
         config = tf.compat.v1.ConfigProto()
@@ -142,7 +142,7 @@ if __name__ == '__main__':
                     np.array(np.random.randint(2, size=this_shape), this_dtype))
             elif this_dtype == np.int32:
                 input_values.append(
-                    np.array(np.random.randint(-(2**15), 2**15, this_shape, this_dtype)))
+                    np.array(np.random.randint(0, 99, this_shape, this_dtype)))
             interpreter.set_tensor(input_details[idx]['index'], input_values[idx])
 
         # get output values by running


### PR DESCRIPTION
Some input of int32 is used as index. (e.g. OneHot, Gather, ...)
Thus, it will not generate negative value and will generate smaller
max value to increase possibility to run given model.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>