### PR TITLE
[onert] fix wrong inclusion guard in ir/index.h

### DIFF
--- a/runtime/onert/core/include/ir/Index.h
+++ b/runtime/onert/core/include/ir/Index.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef __ONERT_IR_OPERAND_INDEX_H__
-#define __ONERT_IR_OPERAND_INDEX_H__
+#ifndef __ONERT_IR_INDEX_H__
+#define __ONERT_IR_INDEX_H__
 
 #include "util/Index.h"
 
@@ -42,4 +42,4 @@ using SubgraphIndex = ::onert::util::Index<uint32_t, SubgraphIndexTag>;
 } // namespace ir
 } // namespace onert
 
-#endif // __ONERT_IR_OPERAND_INDEX_H__
+#endif // __ONERT_IR_INDEX_H__


### PR DESCRIPTION
It fixes wrong inclusion guard in ir/index.h.
Maybe it has old name's inclusion guard.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>