### PR TITLE
[onert] add shape inference for ReduceMin op and its test case.

### DIFF
--- a/runtime/onert/core/include/util/ShapeInference.h
+++ b/runtime/onert/core/include/util/ShapeInference.h
@@ -148,6 +148,7 @@ private:
   void visit(const ir::operation::Pow &op);
   // TODO write op starting from Q
   void visit(const ir::operation::ReduceAll &op);
+  void visit(const ir::operation::ReduceMin &op);
   void visit(const ir::operation::ReduceProd &op);
   void visit(const ir::operation::ReduceSum &op);
   void visit(const ir::operation::Reshape &op);
@@ -239,6 +240,7 @@ public:
   void visit(const ir::operation::Pow &op);
   // TODO write op starting from Q
   void visit(const ir::operation::ReduceAll &op);
+  void visit(const ir::operation::ReduceMin &op);
   void visit(const ir::operation::ReduceProd &op);
   void visit(const ir::operation::ReduceSum &op);
   void visit(const ir::operation::Reshape &op);

--- a/runtime/onert/core/src/util/shapeinf/ReduceMin.cc
+++ b/runtime/onert/core/src/util/shapeinf/ReduceMin.cc
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "util/ShapeInference.h"
+
+namespace onert
+{
+namespace shape_inference
+{
+void StaticInferer::visit(const ir::operation::ReduceMin &op)
+{
+  const auto input_idx{op.getInputs().at(0)};
+  const auto &input = _operands.at(input_idx);
+
+  // get mutable output operand
+  const auto output_idx = op.getOutputs().at(0);
+  ir::Operand &output = _operands.at(output_idx);
+
+  // if input is dynamic, output also becomes dynamic
+  if (input.info().isDynamic())
+  {
+    output.info().setDynamic();
+    return;
+  }
+
+  const auto axes = op.param().axes;
+  const auto keep_dims = op.param().keep_dims;
+
+  // re-sizing output shape
+  ir::Shape new_shape = inferReduceShapes(input.info().shape(), axes, keep_dims);
+  output.info().shape(new_shape);
+}
+
+void DynamicInferer::visit(const ir::operation::ReduceMin &op)
+{
+  const auto input_idx{op.getInputs().at(0)};
+  const auto &input = _tensor_registry->getITensor(input_idx);
+  auto input_shape = getShape(input.get());
+
+  if (!input->is_dynamic())
+    return;
+
+  const auto axes = op.param().axes;
+  const auto keep_dims = op.param().keep_dims;
+
+  auto output_ind = op.getOutputs().at(0);
+  auto output = _tensor_registry->getITensor(output_ind);
+
+  ir::Shape new_shape = inferReduceShapes(input_shape, axes, keep_dims);
+
+  _dynamic_tensor_manager->applyShape(output_ind, new_shape);
+  assert(output->buffer() != nullptr);
+}
+}
+}

--- a/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_cl
+++ b/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_cl
@@ -111,6 +111,7 @@ GeneratedTests.reduce_any_4
 GeneratedTests.reduce_any_4D_nnfw
 GeneratedTests.reduce_mean_dynamic_1_nnfw
 GeneratedTests.reduce_mean_dynamic_2_nnfw
+GeneratedTests.reduce_min_dynamic_nnfw
 GeneratedTests.reduce_prod
 GeneratedTests.reduce_prod_2
 GeneratedTests.reduce_prod_2D_float_nnfw

--- a/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_neon
+++ b/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_neon
@@ -136,6 +136,7 @@ GeneratedTests.reduce_max_2D_int32_nnfw
 GeneratedTests.reduce_max_quant8
 GeneratedTests.reduce_mean_dynamic_1_nnfw
 GeneratedTests.reduce_mean_dynamic_2_nnfw
+GeneratedTests.reduce_min_dynamic_nnfw
 GeneratedTests.reduce_prod
 GeneratedTests.reduce_prod_2
 GeneratedTests.reduce_prod_2D_float_nnfw

--- a/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_cl
+++ b/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_cl
@@ -111,6 +111,7 @@ GeneratedTests.reduce_any_4
 GeneratedTests.reduce_any_4D_nnfw
 GeneratedTests.reduce_mean_dynamic_1_nnfw
 GeneratedTests.reduce_mean_dynamic_2_nnfw
+GeneratedTests.reduce_min_dynamic_nnfw
 GeneratedTests.reduce_prod
 GeneratedTests.reduce_prod_2
 GeneratedTests.reduce_prod_2D_float_nnfw

--- a/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_neon
+++ b/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_neon
@@ -135,6 +135,7 @@ GeneratedTests.reduce_max_2D_int32_nnfw
 GeneratedTests.reduce_max_quant8
 GeneratedTests.reduce_mean_dynamic_1_nnfw
 GeneratedTests.reduce_mean_dynamic_2_nnfw
+GeneratedTests.reduce_min_dynamic_nnfw
 GeneratedTests.reduce_prod
 GeneratedTests.reduce_prod_2
 GeneratedTests.reduce_prod_2D_float_nnfw

--- a/tests/nnapi/nnapi_gtest.skip.noarch.interp
+++ b/tests/nnapi/nnapi_gtest.skip.noarch.interp
@@ -338,6 +338,7 @@ GeneratedTests.reduce_min
 GeneratedTests.reduce_min_2
 GeneratedTests.reduce_min_3
 GeneratedTests.reduce_min_4
+GeneratedTests.reduce_min_dynamic_nnfw
 GeneratedTests.reduce_min_float_1_nnfw
 GeneratedTests.reduce_min_float_2_nnfw
 GeneratedTests.reduce_min_float_nnfw

--- a/tests/nnapi/specs/V1_2/reduce_min_dynamic_nnfw.mod.py
+++ b/tests/nnapi/specs/V1_2/reduce_min_dynamic_nnfw.mod.py
@@ -1,0 +1,60 @@
+#
+# Copyright (C) 2018 The Android Open Source Project
+# Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import dynamic_tensor
+
+model = Model()
+
+model_input_shape = [4, 3, 2]
+
+dynamic_layer = dynamic_tensor.DynamicInputGenerator(model, model_input_shape, "TENSOR_FLOAT32")
+test_node_input = dynamic_layer.getTestNodeInput()
+
+
+axis = Parameter("axis", "TENSOR_INT32", "{4}", [1, 0, -3, -3])
+keepDims = False
+
+# note output shape is used by expected output's shape
+model_output = Output("output", "TENSOR_FLOAT32", "{2}")
+
+model.Operation("REDUCE_MIN", test_node_input, axis, keepDims).To(model_output)
+
+model_input_data = [23.0,  24.0,
+                    13.0,  22.0,
+                     5.0,  18.0,
+
+                     7.0,  8.0,
+                     9.0, 15.0,
+                    11.0, 12.0,
+
+                    3.0, 14.0,
+                    10.0, 16.0,
+                    17.0, 6.0,
+
+                    19.0, 20.0,
+                    21.0, 4.0,
+                     1.0, 2.0]
+
+model_output_data = [1.0, 2.0]
+
+Example({
+    dynamic_layer.getModelInput() : model_input_data,
+    dynamic_layer.getShapeInput() : model_input_shape,
+
+    model_output: model_output_data,
+})


### PR DESCRIPTION
Add shape inference for ReduceMin op and its test case.

Isssue : https://github.com/Samsung/ONE/issues/2281

ONE-DCO-1.0-Signed-off-by: H Kim <hyunjun2.kim@samsung.com>