### PR TITLE
[onert] Make Controlflow backend always loaded

### DIFF
--- a/runtime/onert/core/include/compiler/BackendManager.h
+++ b/runtime/onert/core/include/compiler/BackendManager.h
@@ -52,7 +52,7 @@ public:
   void loadBackend(const std::string &backend);
 
 private:
-  BackendManager() = default;
+  BackendManager();
 
 private:
   std::vector<const backend::Backend *> _available_backends;

--- a/runtime/onert/core/src/compiler/BackendManager.cc
+++ b/runtime/onert/core/src/compiler/BackendManager.cc
@@ -38,6 +38,8 @@ BackendManager &BackendManager::get()
   return object;
 }
 
+BackendManager::BackendManager() { loadControlflowBackend(); }
+
 void BackendManager::loadControlflowBackend()
 {
   // Add controlflow Backend
@@ -66,11 +68,7 @@ void BackendManager::loadBackend(const std::string &backend)
     return;
   }
 
-  if (backend == backend::controlflow::Config::ID)
-  {
-    loadControlflowBackend();
-  }
-  else
+  // TODO Remove indentation
   {
     const std::string backend_so = "libbackend_" + backend + ".so";
     void *handle = dlopen(backend_so.c_str(), RTLD_LAZY | RTLD_LOCAL);

--- a/runtime/onert/core/src/ir/LoweredGraph.cc
+++ b/runtime/onert/core/src/ir/LoweredGraph.cc
@@ -41,6 +41,13 @@ LoweredGraph::LoweredGraph(const Graph &graph, const compiler::CompilerOptions &
 {
   // Build backend contexts
   auto &backend_manager = compiler::BackendManager::get();
+
+  // Always create Controlflow backend context
+  auto cf_backend = backend_manager.getControlflow();
+  _backend_contexts.emplace(cf_backend, cf_backend->newContext(_graph, _graph.getKernelBuilder(),
+                                                               options.executor == "Linear"));
+
+  // Create contexts for other backends
   for (auto backend_str : options.backend_list)
   {
     backend_manager.loadBackend(backend_str);


### PR DESCRIPTION
Make Controlflow backend always loaded, this is to use this backend for
input/output which is part of #1325.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>