### PR TITLE
[nnfwapi] Use `nnfw_set_tensorinfo`

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -382,7 +382,8 @@ NNFW_STATUS nnfw_session::apply_tensorinfo(uint32_t index, nnfw_tensorinfo ti)
   {
     if (isStateInitialized())
     {
-      std::cerr << "Error during apply_tensorinfo : should be run after load_model" << std::endl;
+      std::cerr << "Error during set_input_tensorinfo : should be run after load_model"
+                << std::endl;
       return NNFW_STATUS_ERROR;
     }
 

--- a/runtime/onert/core/include/exec/IODescription.h
+++ b/runtime/onert/core/include/exec/IODescription.h
@@ -62,7 +62,7 @@ struct IODescription
 {
   std::vector<std::unique_ptr<InputDesc>> inputs;
   std::vector<std::unique_ptr<OutputDesc>> outputs;
-  // Contains shape of input set by apply_tensorinfo
+  // Contains shape of input set by set_input_tensorinfo
   std::unordered_map<ir::IOIndex, ir::Shape> input_shape_signature;
 };
 

--- a/runtime/onert/core/src/exec/Execution.cc
+++ b/runtime/onert/core/src/exec/Execution.cc
@@ -56,7 +56,7 @@ void Execution::setInput(const ir::IOIndex &index, const void *buffer, size_t le
 
   // check if size enough for input is passed
   // if input_shape_sig is set, input_shape_sig overrides shape in info
-  // note: input_shape_sig contains shape passed by nnfw_apply_tensorinfo()
+  // note: input_shape_sig contains shape passed by nnfw_set_input_tensorinfo()
   {
     auto input_shape_sig = _io_desc.input_shape_signature.find(index);
     auto size_required = (input_shape_sig != _io_desc.input_shape_signature.end())

--- a/runtime/onert/core/src/exec/ExecutorBase.cc
+++ b/runtime/onert/core/src/exec/ExecutorBase.cc
@@ -225,7 +225,7 @@ void ExecutorBase::execute(const IODescription &desc)
       continue;
     }
 
-    // If nnfw_apply_tensorinfo() was called for an input, set change and prepare memory
+    // If nnfw_set_input_tensorinfo() was called for an input, set change and prepare memory
     handleDynamicInputTensor(input_index, desc);
 
     const auto &input = *desc.inputs.at(n);
@@ -287,17 +287,17 @@ void ExecutorBase::execute(const IODescription &desc)
 
 /**
  * @brief Changes tensor shape and allocate memory
- *        if input shape was changed by nnfw_apply_tensorinfo()
+ *        if input shape was changed by nnfw_set_input_tensorinfo()
  *
  * @note  Cases are:
- *        1) static operand -> nnfw_apply_tensorinfo() -> execute() -> execute()
+ *        1) static operand -> nnfw_set_input_tensorinfo() -> execute() -> execute()
  *                                                        (a)          (b)
  *
  *           at (a), operand is static, tensor is static - memory dealloc is not needed
  *                   (DynamicTensorManager cannot dealloc memory allocated by StaticTensorManager)
  *           at (b), operand is static, tensor is dynamic - memory dealloc is needed
  *
- *        2) dynamic operand -> nnfw_apply_tensorinfo() -> execute() -> execute()
+ *        2) dynamic operand -> nnfw_set_input_tensorinfo() -> execute() -> execute()
  *                                                         (a)          (b)
  *
  *           at (a), operand is dynamic, tensor is dynamic - memory dealloc is not needed

--- a/runtime/onert/core/src/util/shapeinf/ExpandDims.cc
+++ b/runtime/onert/core/src/util/shapeinf/ExpandDims.cc
@@ -62,7 +62,7 @@ void StaticInferer::visit(const ir::operation::ExpandDims &op)
   }
 
   // even when axis is constant, output shape should be recalculated since user might call
-  // nnfw_apply_tensorinfo(input, some_new_shape)
+  // nnfw_set_input_tensorinfo(input, some_new_shape)
   auto axis_buf = reinterpret_cast<const int32_t *>(axis.data()->base());
   assert(axis_buf);
 

--- a/tests/nnfw_api/src/ModelTestDynamicTensor.cc
+++ b/tests/nnfw_api/src/ModelTestDynamicTensor.cc
@@ -208,8 +208,29 @@ TEST_F(TestDynamicTensorReshapeModelLoaded, neg_reshape_multiple_executions)
 //    Trying to set unknown dim to other value before calling nnfw_prepare()
 //
 
-using TestInputUnknownDimInputConcatModelLoaded =
-    ValidationTestModelLoaded<NNPackages::UNKNOWN_DIM_INPUT_CONCAT>;
+class TestInputUnknownDimInputConcatModelLoaded
+    : public ValidationTestModelLoaded<NNPackages::UNKNOWN_DIM_INPUT_CONCAT>
+{
+protected:
+  void prepare_apply_set_input_output(const std::vector<float> &input0,
+                                      const std::vector<float> &input1,
+                                      std::vector<float> *actual_output, nnfw_tensorinfo input0_ti)
+  {
+    ASSERT_EQ(nnfw_prepare(_session), NNFW_STATUS_NO_ERROR);
+    ASSERT_EQ(nnfw_set_input_tensorinfo(_session, 0, &input0_ti), NNFW_STATUS_NO_ERROR);
+
+    ASSERT_EQ(nnfw_set_input(_session, 0, NNFW_TYPE_TENSOR_FLOAT32, input0.data(),
+                             sizeof(float) * input0.size()),
+              NNFW_STATUS_NO_ERROR);
+    ASSERT_EQ(nnfw_set_input(_session, 1, NNFW_TYPE_TENSOR_FLOAT32, input1.data(),
+                             sizeof(float) * input1.size()),
+              NNFW_STATUS_NO_ERROR);
+
+    ASSERT_EQ(nnfw_set_output(_session, 0, NNFW_TYPE_TENSOR_FLOAT32, actual_output->data(),
+                              sizeof(float) * actual_output->size()),
+              NNFW_STATUS_NO_ERROR);
+  }
+};
 
 /**
  * @brief Testing the following model:
@@ -298,7 +319,7 @@ TEST_F(TestInputUnknownDimInputConcatModelLoaded, neg_concat_input0_to_wrong_sha
 }
 
 //
-// test about calling nnfw_apply_tensorinfo() after compilation
+// test about calling nnfw_set_input_tensorinfo() after compilation
 //
 
 /**
@@ -311,7 +332,7 @@ TEST_F(TestInputUnknownDimInputConcatModelLoaded, neg_concat_input0_to_wrong_sha
  *
  *        Calling sequence:
  *        - nnfw_prepare()
- *        - nnfw_apply_tensorinfo(#0, [2, 2, 3]) // This will make #3 tensor's shape [2, 2, 3]
+ *        - nnfw_set_input_tensorinfo(#0, [2, 2, 3]) // This will make #3 tensor's shape [2, 2, 3]
  *        - nnfw_set_input()
  *        - nnfw_run()
  *
@@ -320,7 +341,7 @@ TEST_F(TestInputUnknownDimInputConcatModelLoaded, neg_concat_input0_to_wrong_sha
 using TestDynamicTensorApplyTensorInfoBinaryOp =
     ValidationTestModelLoaded<NNPackages::ADD_UNSPECIFIED_RANK_INPUTS>;
 
-TEST_F(TestDynamicTensorApplyTensorInfoBinaryOp, apply_tensorinfo_after_compilation_add)
+TEST_F(TestDynamicTensorApplyTensorInfoBinaryOp, set_input_tensorinfo_after_compilation_add)
 {
   ASSERT_EQ(nnfw_set_available_backends(_session, "cpu"), NNFW_STATUS_NO_ERROR);
 
@@ -342,7 +363,7 @@ TEST_F(TestDynamicTensorApplyTensorInfoBinaryOp, apply_tensorinfo_after_compilat
 
   ASSERT_EQ(nnfw_prepare(_session), NNFW_STATUS_NO_ERROR);
 
-  ASSERT_EQ(nnfw_apply_tensorinfo(_session, 0, input0_ti), NNFW_STATUS_NO_ERROR);
+  ASSERT_EQ(nnfw_set_input_tensorinfo(_session, 0, &input0_ti), NNFW_STATUS_NO_ERROR);
 
   set_input_output(_session, input0, input1, &actual_output);
 
@@ -363,7 +384,7 @@ TEST_F(TestDynamicTensorApplyTensorInfoBinaryOp, apply_tensorinfo_after_compilat
  *
  *        Calling sequence:
  *        - nnfw_prepare()
- *        - nnfw_apply_tensorinfo(#0, [20, 50])
+ *        - nnfw_set_input_tensorinfo(#0, [20, 50])
  *        - nnfw_set_input()
  *        - nnfw_run()
  *
@@ -371,7 +392,7 @@ TEST_F(TestDynamicTensorApplyTensorInfoBinaryOp, apply_tensorinfo_after_compilat
  */
 using TestDynamicTensorApplyTensorInfoUnaryOp = ValidationTestModelLoaded<NNPackages::NEG>;
 
-TEST_F(TestDynamicTensorApplyTensorInfoUnaryOp, apply_tensorinfo_after_compilation_neg)
+TEST_F(TestDynamicTensorApplyTensorInfoUnaryOp, set_input_tensorinfo_after_compilation_neg)
 {
   ASSERT_EQ(nnfw_set_available_backends(_session, "cpu"), NNFW_STATUS_NO_ERROR);
 
@@ -396,7 +417,7 @@ TEST_F(TestDynamicTensorApplyTensorInfoUnaryOp, apply_tensorinfo_after_compilati
 
   ASSERT_EQ(nnfw_prepare(_session), NNFW_STATUS_NO_ERROR);
 
-  ASSERT_EQ(nnfw_apply_tensorinfo(_session, 0, input0_ti), NNFW_STATUS_NO_ERROR);
+  ASSERT_EQ(nnfw_set_input_tensorinfo(_session, 0, &input0_ti), NNFW_STATUS_NO_ERROR);
 
   set_input_output(_session, input0, &actual_output);
 

--- a/tests/nnfw_api/src/ModelTestInputReshaping.cc
+++ b/tests/nnfw_api/src/ModelTestInputReshaping.cc
@@ -45,7 +45,7 @@ TEST_F(TestInputReshapingAddModelLoaded, reshaping_2x2_to_4x2)
 
   /*
   testing sequence and what's been done:
-    1. nnfw_apply_tensorinfo : set input shape to different shape (static inference)
+    1. nnfw_set_input_tensorinfo : set input shape to different shape (static inference)
     2. nnfw_prepare
     3. nnfw_set_input
     4. nnfw_run
@@ -59,7 +59,7 @@ TEST_F(TestInputReshapingAddModelLoaded, reshaping_2x2_to_4x2)
     ti.dims[0] = 4;
     ti.dims[1] = 2;
   }
-  res = nnfw_apply_tensorinfo(_session, 0, ti);
+  res = nnfw_set_input_tensorinfo(_session, 0, &ti);
 
   res = nnfw_prepare(_session);
   ASSERT_EQ(res, NNFW_STATUS_NO_ERROR);


### PR DESCRIPTION
Use `nnfw_set_tensorinfo` rather than `nnfw_applytensorinfo`.
`nnfw_applytensorinfo` will be deprecated in 1.7.0.

They both do the same thing but `nnfw_applytensorinfo`'s name is
misleading and there was a little fix in its signature.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>