### PR TITLE
[onert] Fix build error on gcc 9.x

### DIFF
--- a/compute/cker/include/cker/Shape.h
+++ b/compute/cker/include/cker/Shape.h
@@ -201,7 +201,7 @@ private:
   int32_t _size;
   union {
     int32_t _dims[kMaxSmallSize];
-    int32_t *_dims_pointer;
+    int32_t *_dims_pointer{nullptr};
   };
 };
 


### PR DESCRIPTION
Fix build error on gcc 9.3.0: maybe-uninitialized error

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>