### PR TITLE
[libbenchmark] fix bug on peakMemory

### DIFF
--- a/runtime/libs/benchmark/src/Result.cpp
+++ b/runtime/libs/benchmark/src/Result.cpp
@@ -82,8 +82,9 @@ uint32_t peakMemory(const uint32_t memory[benchmark::PhaseEnum::END_OF_PHASE]
                     int type)
 {
   using namespace benchmark;
+  // tricky. handle WARMUP as EXECUTE
   return std::max({memory[PhaseEnum::MODEL_LOAD][type], memory[PhaseEnum::PREPARE][type],
-                   memory[PhaseEnum::EXECUTE][type]});
+                   memory[PhaseEnum::WARMUP][type]});
 }
 
 void printResultTime(


### PR DESCRIPTION
- caused by #2204
- handle WARMUP as EXECUTE
  - it's because measuring memory on EXECUTE takes overhead a quite

ONE-DCO-1.0-Signed-off-by: Yongseop Kim <yons.kim@samsung.com>