### PR TITLE
[onert/cmake] Remove copying pre-built acl in cmake

### DIFF
--- a/Makefile.template
+++ b/Makefile.template
@@ -49,11 +49,6 @@ ifeq ($(BENCHMARK_ACL_BUILD),1)
 	OPTIONS+= -DBUILD_BENCHMARK_ACL=1
 endif
 
-ifneq ($(EXT_ACL_FOLDER),)
-	OPTIONS+= -DBUILD_ARMCOMPUTE=OFF
-	OPTIONS+= -DARMCompute_EXTDIR=$(EXT_ACL_FOLDER)
-endif
-
 ifneq ($(EXT_HDF5_DIR),)
   $(info Hello $(EXT_HDF5_DIR))
 	OPTIONS+= -DEXT_HDF5_DIR=$(EXT_HDF5_DIR)
@@ -130,6 +125,13 @@ distclean:
 ### Command (internal)
 ###
 configure_internal:
+# TODO Remove setting EXT_ACL_FOLDER
+#      Construct overlay folder directly outside (with headers?)
+ifneq ($(EXT_ACL_FOLDER),)
+	mkdir -p $(OVERLAY_FOLDER)/lib
+	cp $(EXT_ACL_FOLDER)/* $(OVERLAY_FOLDER)/lib
+endif
+
 	NNFW_WORKSPACE="$(WORKSPACE)" NNFW_INSTALL_PREFIX=$(INSTALL_PATH) ./nnfw configure \
 		-DCMAKE_BUILD_TYPE=$(BUILD_TYPE_LC) \
 		-DNNFW_OVERLAY_DIR=$(OVERLAY_FOLDER) \

--- a/infra/nnfw/cmake/packages/ARMComputeConfig.cmake
+++ b/infra/nnfw/cmake/packages/ARMComputeConfig.cmake
@@ -157,8 +157,7 @@ function(_ARMCompute_Build ARMCompute_INSTALL_PREFIX)
                   WORKING_DIRECTORY ${ARMComputeSource_DIR}
                   RESULT_VARIABLE ARMCompute_BUILD)
 
-  # Install ARMCompute libraries
-  # Ps. CI server will copy below installed libraries to target device to test.
+  # Install ARMCompute libraries to overlay
   execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory "${ARMCompute_INSTALL_PREFIX}"
                   WORKING_DIRECTORY ${ARMComputeSource_DIR}
                   RESULT_VARIABLE ARMCompute_BUILD)
@@ -169,19 +168,7 @@ function(_ARMCompute_Build ARMCompute_INSTALL_PREFIX)
                   RESULT_VARIABLE ARMCompute_BUILD)
 endfunction(_ARMCompute_Build)
 
-
 set(ARMCompute_PREFIX ${EXT_OVERLAY_DIR}/lib)
-
-# This is a workaround for CI issues
-# Ps. CI server will copy below installed libraries to target device to test.
-# TODO Remove this workaround
-if(DEFINED ARMCompute_EXTDIR)
-  execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory "${ARMCompute_PREFIX}")
-  execute_process(COMMAND ${CMAKE_COMMAND} -E copy "${ARMCompute_EXTDIR}/libarm_compute_core.so" "${ARMCompute_PREFIX}"
-                  COMMAND ${CMAKE_COMMAND} -E copy "${ARMCompute_EXTDIR}/libarm_compute.so" "${ARMCompute_PREFIX}"
-                  COMMAND ${CMAKE_COMMAND} -E copy "${ARMCompute_EXTDIR}/libarm_compute_graph.so" "${ARMCompute_PREFIX}")
-endif(DEFINED ARMCompute_EXTDIR)
-
 if(BUILD_ARMCOMPUTE)
   _ARMCompute_Build("${ARMCompute_PREFIX}")
 endif(BUILD_ARMCOMPUTE)


### PR DESCRIPTION
Remove copying pre-built acl in cmake script
Use Makefile on CI
User can use overlay directory by install pre-built acl on overlay directory

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>