### PR TITLE
[luci] fix for loop condition in ResolveCustomOpAddPass

### DIFF
--- a/compiler/luci/pass/src/ResolveCustomOpAddPass.cpp
+++ b/compiler/luci/pass/src/ResolveCustomOpAddPass.cpp
@@ -20,7 +20,7 @@
 
 #include <luci/IR/CircleNodes.h>
 #include <luci/IR/AttrFusedActFunc.h>
-
+#include <iostream>
 namespace
 {
 
@@ -28,7 +28,7 @@ namespace
 // NOTE This function assumes there is only one BroadcastTo node among its inputs.
 int32_t get_broadcastTo_index_among_inputs_of(luci::CircleCustom *cop)
 {
-  for (uint32_t idx = 0; cop->numInputs(); idx++)
+  for (uint32_t idx = 0; idx < cop->numInputs(); idx++)
   {
     auto input = dynamic_cast<const luci::CircleCustomOut *>(cop->inputs(idx));
     if (input)

--- a/compiler/luci/pass/src/ResolveCustomOpAddPass.cpp
+++ b/compiler/luci/pass/src/ResolveCustomOpAddPass.cpp
@@ -20,7 +20,7 @@
 
 #include <luci/IR/CircleNodes.h>
 #include <luci/IR/AttrFusedActFunc.h>
-#include <iostream>
+
 namespace
 {
 


### PR DESCRIPTION
This commit fixes for-loop condition in ResolveCustomOpAddPass

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>