### PR TITLE
[onert] Add a throwing runtime error in cker::Fill when not matching output size

### DIFF
--- a/compute/cker/include/cker/operation/Fill.h
+++ b/compute/cker/include/cker/operation/Fill.h
@@ -42,6 +42,10 @@ inline void Fill(const Shape &input_shape, int *input_data, const T value_data,
       output_data[i] = *value_data;
     }
   }
+  else
+  {
+    throw std::runtime_error("Cker Fill.h: output's size is not matched inferred size of output");
+  }
 }
 
 } // namespace cker


### PR DESCRIPTION
For issue #2075

This commit adds a throwing runtime error in cker::Fill when not matching output size.

Signed-off-by: ragmani <ragmani0216@gmail.com>