### PR TITLE
[onert] Introduce INT64 type into core and loader

### DIFF
--- a/runtime/onert/core/include/exec/IPermuteFunction.h
+++ b/runtime/onert/core/include/exec/IPermuteFunction.h
@@ -82,6 +82,9 @@ public:
           case ir::DataType::QUANT_INT8_SYMM:
             permute<int8_t>(src_tensor, dst_tensor, rank);
             break;
+          case ir::DataType::INT64:
+            permute<int64_t>(src_tensor, dst_tensor, rank);
+            break;
           default:
             throw std::runtime_error("IPermuteFunction: Not supported data type");
             break;

--- a/runtime/onert/core/include/ir/DataType.h
+++ b/runtime/onert/core/include/ir/DataType.h
@@ -34,6 +34,7 @@ enum class DataType
   UINT8 = 5,
   QUANT_INT8_SYMM = 6,
   FLOAT16 = 7,
+  INT64 = 8,
 };
 
 size_t sizeOfDataType(DataType data_type);

--- a/runtime/onert/core/src/backend/IConstantInitializer.cc
+++ b/runtime/onert/core/src/backend/IConstantInitializer.cc
@@ -57,6 +57,9 @@ void IConstantInitializer::registerCopyInitializer(const ir::OperandIndex &index
     case DataType::FLOAT16:
       _init_map[index] = copyInit<float16>;
       break;
+    case DataType::INT64:
+      _init_map[index] = copyInit<int64_t>;
+      break;
     default:
       throw std::runtime_error("Not supported, yet");
       break;

--- a/runtime/onert/core/src/exec/ExecutorBase.cc
+++ b/runtime/onert/core/src/exec/ExecutorBase.cc
@@ -116,6 +116,8 @@ std::unique_ptr<ISource> ExecutorBase::source(const ir::IOIndex &index, const ir
       return source<uint8_t>(index, buffer, length, io_layout);
     case DataType::QUANT_INT8_SYMM:
       return source<int8_t>(index, buffer, length, io_layout);
+    case DataType::INT64:
+      return source<int64_t>(index, buffer, length, io_layout);
     default:
       throw std::runtime_error("Not supported yet");
   }
@@ -139,6 +141,8 @@ std::unique_ptr<ISink> ExecutorBase::sink(const ir::IOIndex &index, const ir::Ty
       return sink<uint8_t>(index, buffer, length, io_layout);
     case DataType::QUANT_INT8_SYMM:
       return sink<int8_t>(index, buffer, length, io_layout);
+    case DataType::INT64:
+      return sink<int64_t>(index, buffer, length, io_layout);
     default:
       throw std::runtime_error("Not supported yet");
   }

--- a/runtime/onert/core/src/ir/DataType.cc
+++ b/runtime/onert/core/src/ir/DataType.cc
@@ -44,6 +44,8 @@ size_t sizeOfDataType(DataType data_type)
       return sizeof(int8_t);
     case DataType::FLOAT16:
       return sizeof(float16);
+    case DataType::INT64:
+      return sizeof(int64_t);
     default:
       throw std::runtime_error{"Unsupported type size"};
   }

--- a/runtime/onert/frontend/base_loader/include/base_loader.h
+++ b/runtime/onert/frontend/base_loader/include/base_loader.h
@@ -255,6 +255,8 @@ BaseLoader<LoaderDomain, SpecificLoader>::BaseLoader::tensorTypeToDataType(const
       return ir::DataType::QUANT_UINT8_ASYMM;
     case TensorType::TensorType_INT8:
       return ir::DataType::QUANT_INT8_SYMM;
+    case TensorType::TensorType_INT64:
+      return ir::DataType::INT64;
     default:
       throw std::runtime_error(
           std::string("Unsupported tensor type: ").append(EnumNameTensorType(type)));
@@ -1611,8 +1613,9 @@ void BaseLoader<LoaderDomain, SpecificLoader>::loadArgMax(const Operator *op, ir
 
   if (!axisOperand.isConstant())
     throw std::runtime_error("ArgMax: non-constant 'axis' is not supported.");
-  if (!(axisOperand.operandSize() == 4 && axisOperand.typeInfo().type() == ir::DataType::INT32))
-    throw std::runtime_error("ArgMax: `axis` with an int32 element is only supported.");
+  if (!(axisOperand.operandSize() == 4 && (axisOperand.typeInfo().type() == ir::DataType::INT32 ||
+                                           axisOperand.typeInfo().type() == ir::DataType::INT64)))
+    throw std::runtime_error("ArgMax: `axis` with an int32 or int64 element is only supported.");
 
   ir::operation::ArgMax::Param param;
   param.axis = axisOperand.template asVector<int>()[0];


### PR DESCRIPTION
For issue #2275 

This commit introduces INT64 type into core and loader.
This commit does not introduce INT64 type into nnfw api and nn api.

Signed-off-by: ragmani <ragmani0216@gmail.com>