### PR TITLE
[onert] use isOptionalInputTensor function in base_loader.h

### DIFF
--- a/runtime/onert/frontend/base_loader/include/base_loader.h
+++ b/runtime/onert/frontend/base_loader/include/base_loader.h
@@ -265,7 +265,7 @@ template <typename LoaderDomain, typename SpecificLoader>
 ir::OperandIndex
 BaseLoader<LoaderDomain, SpecificLoader>::BaseLoader::tensorIdxToOperandIdx(int32_t tensorIdx)
 {
-  return tensorIdx == -1 ? ir::OperandIndex() : _tensor_to_operand[tensorIdx];
+  return isOptionalInputTensor(tensorIdx) ? ir::OperandIndex() : _tensor_to_operand[tensorIdx];
 }
 
 template <typename LoaderDomain, typename SpecificLoader>


### PR DESCRIPTION
I found there is a comparision with `-1` directly for checking
optional tensor. It should use `isOptionalTensor`.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>