### PR TITLE
[nnpkg_run] support building nnpkg_run without hdf5

### DIFF
--- a/tests/tools/nnpackage_run/CMakeLists.txt
+++ b/tests/tools/nnpackage_run/CMakeLists.txt
@@ -6,24 +6,30 @@ if(NOT BUILD_ONERT)
   return()
 endif(NOT BUILD_ONERT)
 
-nnfw_find_package(HDF5 COMPONENTS CXX QUIET)
-if(NOT HDF5_FOUND)
-  message(WARNING "HDF5 NOT found. Install libhdf5-dev or set EXT_HDF5_DIR to build nnpackage_run.")
-  return()
-endif(NOT HDF5_FOUND)
-
 list(APPEND NNPACKAGE_RUN_SRCS "src/nnpackage_run.cc")
 list(APPEND NNPACKAGE_RUN_SRCS "src/args.cc")
-list(APPEND NNPACKAGE_RUN_SRCS "src/h5formatter.cc")
 list(APPEND NNPACKAGE_RUN_SRCS "src/nnfw_util.cc")
 
 nnfw_find_package(Boost REQUIRED)
 nnfw_find_package(Ruy QUIET)
+nnfw_find_package(HDF5 COMPONENTS CXX QUIET)
+
+if (HDF5_FOUND)
+  list(APPEND NNPACKAGE_RUN_SRCS "src/h5formatter.cc")
+endif()
 
 add_executable(nnpackage_run ${NNPACKAGE_RUN_SRCS})
+
+if (HDF5_FOUND)
+  target_compile_definitions(nnpackage_run PRIVATE ONERT_HAVE_HDF5=1)
+  target_include_directories(nnpackage_run PRIVATE ${HDF5_INCLUDE_DIRS})
+  target_link_libraries(nnpackage_run ${HDF5_CXX_LIBRARIES})
+else()
+  message(WARNING "HDF5 NOT found. Install libhdf5-dev or set EXT_HDF5_DIR to support load/dump in nnpackage_run.")
+endif(HDF5_FOUND)
+
 target_include_directories(nnpackage_run PRIVATE src)
 target_include_directories(nnpackage_run PRIVATE ${Boost_INCLUDE_DIRS})
-target_include_directories(nnpackage_run PRIVATE ${HDF5_INCLUDE_DIRS})
 
 target_link_libraries(nnpackage_run onert_core onert tflite_loader)
 target_link_libraries(nnpackage_run tensorflow-lite ${LIB_PTHREAD} dl nnfw_lib_tflite)
@@ -39,7 +45,6 @@ else()
   # However, it uses cmake 3.5. (old version).
   target_link_libraries(nnpackage_run boost_program_options)
 endif()
-target_link_libraries(nnpackage_run ${HDF5_CXX_LIBRARIES})
 target_link_libraries(nnpackage_run nnfw_lib_benchmark)
 if(Ruy_FOUND AND PROFILE_RUY)
   target_link_libraries(nnpackage_run ruy_instrumentation)

--- a/tests/tools/nnpackage_run/src/args.cc
+++ b/tests/tools/nnpackage_run/src/args.cc
@@ -37,8 +37,10 @@ void Args::Initialize(void)
     ("help,h", "Print available options")
     ("version", "Print version and exit immediately")
     ("nnpackage", po::value<std::string>()->required())
+#if defined(ONERT_HAVE_HDF5) && ONERT_HAVE_HDF5 == 1
     ("dump,d", po::value<std::string>()->default_value(""), "Output filename")
     ("load,l", po::value<std::string>()->default_value(""), "Input filename")
+#endif
     ("num_runs,r", po::value<int>()->default_value(1), "The number of runs")
     ("warmup_runs,w", po::value<int>()->default_value(1), "The number of warmup runs")
     ("gpumem_poll,g", po::value<bool>()->default_value(false), "Check gpu memory polling separately")
@@ -88,7 +90,7 @@ void Args::Parse(const int argc, char **argv)
   }
 
   po::notify(vm);
-
+#if defined(ONERT_HAVE_HDF5) && ONERT_HAVE_HDF5 == 1
   if (vm.count("dump"))
   {
     _dump_filename = vm["dump"].as<std::string>();
@@ -98,6 +100,7 @@ void Args::Parse(const int argc, char **argv)
   {
     _load_filename = vm["load"].as<std::string>();
   }
+#endif
 
   if (vm.count("nnpackage"))
   {

--- a/tests/tools/nnpackage_run/src/args.h
+++ b/tests/tools/nnpackage_run/src/args.h
@@ -32,8 +32,10 @@ public:
   void print(void);
 
   const std::string &getPackageFilename(void) const { return _package_filename; }
+#if defined(ONERT_HAVE_HDF5) && ONERT_HAVE_HDF5 == 1
   const std::string &getDumpFilename(void) const { return _dump_filename; }
   const std::string &getLoadFilename(void) const { return _load_filename; }
+#endif
   const int getNumRuns(void) const { return _num_runs; }
   const int getWarmupRuns(void) const { return _warmup_runs; }
   const bool getGpuMemoryPoll(void) const { return _gpumem_poll; }
@@ -50,8 +52,10 @@ private:
   po::options_description _options;
 
   std::string _package_filename;
+#if defined(ONERT_HAVE_HDF5) && ONERT_HAVE_HDF5 == 1
   std::string _dump_filename;
   std::string _load_filename;
+#endif
   int _num_runs;
   int _warmup_runs;
   bool _gpumem_poll;

--- a/tests/tools/nnpackage_run/src/nnpackage_run.cc
+++ b/tests/tools/nnpackage_run/src/nnpackage_run.cc
@@ -17,7 +17,9 @@
 #include "allocation.h"
 #include "args.h"
 #include "benchmark.h"
+#if defined(ONERT_HAVE_HDF5) && ONERT_HAVE_HDF5 == 1
 #include "h5formatter.h"
+#endif
 #include "tflite/Diff.h"
 #include "nnfw.h"
 #include "nnfw_util.h"
@@ -186,10 +188,14 @@ int main(const int argc, char **argv)
       NNPR_ENSURE_STATUS(nnfw_set_input_layout(session, i, NNFW_LAYOUT_CHANNELS_LAST));
     }
   };
+#if defined(ONERT_HAVE_HDF5) && ONERT_HAVE_HDF5 == 1
   if (!args.getLoadFilename().empty())
     H5Formatter(session).loadInputs(args.getLoadFilename(), inputs);
   else
     generateInputs();
+#else
+  generateInputs();
+#endif
 
   // prepare output
 
@@ -230,9 +236,11 @@ int main(const int argc, char **argv)
              },
              args.getNumRuns(), true);
 
+#if defined(ONERT_HAVE_HDF5) && ONERT_HAVE_HDF5 == 1
   // dump output tensors
   if (!args.getDumpFilename().empty())
     H5Formatter(session).dumpOutputs(args.getDumpFilename(), outputs);
+#endif
 
   NNPR_ENSURE_STATUS(nnfw_close_session(session));
 


### PR DESCRIPTION
`nnpackage_run` could be built without hdf5, of course,
it will not be capable of loading and dumping.

If `hdf5` is not found, it will silently build `nnpackage_run`
without loading/dumping functionality.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>