### PR TITLE
[oneapi] Test: Add checks for static inference

### DIFF
--- a/tests/nnfw_api/src/ModelTestInputReshaping.cc
+++ b/tests/nnfw_api/src/ModelTestInputReshaping.cc
@@ -19,6 +19,7 @@
 
 #include "fixtures.h"
 #include "NNPackages.h"
+#include "common.h"
 
 using TestInputReshapingAddModelLoaded = ValidationTestModelLoaded<NNPackages::INPUT_RESHAPING_ADD>;
 
@@ -44,7 +45,7 @@ TEST_F(TestInputReshapingAddModelLoaded, reshaping_2x2_to_4x2)
 
   /*
   testing sequence and what's been done:
-    1. nnfw_apply_tensorinfo : set input shape to different shape
+    1. nnfw_apply_tensorinfo : set input shape to different shape (static inference)
     2. nnfw_prepare
     3. nnfw_set_input
     4. nnfw_run
@@ -63,6 +64,10 @@ TEST_F(TestInputReshapingAddModelLoaded, reshaping_2x2_to_4x2)
   res = nnfw_prepare(_session);
   ASSERT_EQ(res, NNFW_STATUS_NO_ERROR);
 
+  nnfw_tensorinfo ti_output; // Static inference result will be stored
+  nnfw_output_tensorinfo(_session, 0, &ti_output);
+  ASSERT_TRUE(tensorInfoEqual(ti, ti_output));
+
   res = nnfw_set_input(_session, 0, NNFW_TYPE_TENSOR_FLOAT32, input1.data(),
                        sizeof(float) * input1.size());
   ASSERT_EQ(res, NNFW_STATUS_NO_ERROR);
@@ -70,10 +75,11 @@ TEST_F(TestInputReshapingAddModelLoaded, reshaping_2x2_to_4x2)
                        sizeof(float) * input2.size());
   ASSERT_EQ(res, NNFW_STATUS_NO_ERROR);
 
-  // TODO fix output setting in dynamic way
-  std::vector<float> actual_output(expected.size());
+  uint64_t output_num_elements = tensorInfoNumElements(ti_output);
+  ASSERT_EQ(output_num_elements, expected.size());
+  std::vector<float> actual_output(output_num_elements);
   res = nnfw_set_output(_session, 0, NNFW_TYPE_TENSOR_FLOAT32, actual_output.data(),
-                        sizeof(float) * expected.size());
+                        sizeof(float) * actual_output.size());
   ASSERT_EQ(res, NNFW_STATUS_NO_ERROR);
 
   // Do inference

--- a/tests/nnfw_api/src/common.cc
+++ b/tests/nnfw_api/src/common.cc
@@ -1,0 +1,40 @@
+
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "common.h"
+
+bool tensorInfoEqual(const nnfw_tensorinfo &info1, const nnfw_tensorinfo &info2)
+{
+  if (info1.dtype != info2.dtype)
+    return false;
+  if (info1.rank != info2.rank)
+    return false;
+  for (int i = 0; i < info1.rank; i++)
+    if (info1.dims[i] != info2.dims[i])
+      return false;
+  return true;
+}
+
+uint64_t tensorInfoNumElements(const nnfw_tensorinfo &ti)
+{
+  uint64_t n = 1;
+  for (uint32_t i = 0; i < ti.rank; ++i)
+  {
+    n *= ti.dims[i];
+  }
+  return n;
+}

--- a/tests/nnfw_api/src/common.h
+++ b/tests/nnfw_api/src/common.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __NNFW_API_TEST_COMMON_H__
+#define __NNFW_API_TEST_COMMON_H__
+
+#include <gtest/gtest.h>
+#include <nnfw.h>
+
+bool tensorInfoEqual(const nnfw_tensorinfo &info1, const nnfw_tensorinfo &info2);
+uint64_t tensorInfoNumElements(const nnfw_tensorinfo &info);
+
+#endif // __NNFW_API_TEST_COMMON_H__


### PR DESCRIPTION
Call `nnfw_output_tensorinfo` after `nnfw_prepare` so it fetches changed
shape by static inference.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>