### PR TITLE
[luci] Introduce IndexTensorOutputs

### DIFF
--- a/compiler/luci/import/include/luci/Import/GraphBuilderContext.h
+++ b/compiler/luci/import/include/luci/Import/GraphBuilderContext.h
@@ -24,6 +24,7 @@
 #include <loco.h>
 
 #include <map>
+#include <set>
 
 namespace luci
 {
@@ -48,13 +49,29 @@ private:
 };
 
 /**
+ * @brief  Set of Tensor Index of outputs of operators
+ *         including graph input nodes
+ */
+class IndexTensorOutputs
+{
+public:
+  void enroll(TensorIndex idx);
+
+  bool find(TensorIndex idx);
+
+private:
+  std::set<TensorIndex> _set;
+};
+
+/**
  * @brief Class to store context to build loco graph IR from TensorFlow
  */
 class GraphBuilderContext
 {
 public:
-  GraphBuilderContext(loco::Graph *g, CircleReader *reader, IndexNodeFinder *nodefinder)
-      : _g(g), _reader(reader), _indexnodefinder(nodefinder)
+  GraphBuilderContext(loco::Graph *g, CircleReader *reader, IndexNodeFinder *nodefinder,
+                      IndexTensorOutputs *tensoroutputs)
+      : _g(g), _reader(reader), _indexnodefinder(nodefinder), _indextensoroutputs(tensoroutputs)
   {
     // DO NOTHING
   }
@@ -67,11 +84,13 @@ public:
   CircleReader *reader() { return _reader; }
 
   IndexNodeFinder *nodefinder() { return _indexnodefinder; }
+  IndexTensorOutputs *tensoroutputs() { return _indextensoroutputs; }
 
 private:
   loco::Graph *_g;
   CircleReader *_reader;
   IndexNodeFinder *_indexnodefinder;
+  IndexTensorOutputs *_indextensoroutputs;
 };
 
 } // namespace luci

--- a/compiler/luci/import/src/GraphBuilderContext.cpp
+++ b/compiler/luci/import/src/GraphBuilderContext.cpp
@@ -45,4 +45,18 @@ CircleNode *IndexNodeFinder::node(TensorIndex idx) const
   return (iter != _table.end()) ? iter->second : nullptr;
 }
 
+void IndexTensorOutputs::enroll(TensorIndex idx)
+{
+  auto iter = _set.find(idx);
+  if (iter != _set.end())
+  {
+    LOGGER(l);
+    INFO(l) << "[luci] TensorOutputs SKIP (" << idx << ") existing" << std::endl;
+    return;
+  }
+  _set.insert(idx);
+}
+
+bool IndexTensorOutputs::find(TensorIndex idx) { return (_set.find(idx) != _set.end()); }
+
 } // namespace luci

--- a/compiler/luci/import/src/Importer.cpp
+++ b/compiler/luci/import/src/Importer.cpp
@@ -42,8 +42,9 @@ void convert_graph(const luci::GraphBuilderSource &source, luci::CircleReader &r
   LOGGER(l);
 
   auto nodefinder = std::make_unique<luci::IndexNodeFinder>();
+  auto tensoroutputs = std::make_unique<luci::IndexTensorOutputs>();
 
-  luci::GraphBuilderContext gb_context(graph, &reader, nodefinder.get());
+  luci::GraphBuilderContext gb_context(graph, &reader, nodefinder.get(), tensoroutputs.get());
 
   const auto &operators = reader.operators();
   const auto &tensors = reader.tensors();


### PR DESCRIPTION
This will introduce IndexTensorOutputs in GraphBuilderContext to cache Tensor index that are outputs of operators

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>