### PR TITLE
[onert] make nnpackage_run receive tensor shape

### DIFF
--- a/tests/tools/nnpackage_run/src/args.h
+++ b/tests/tools/nnpackage_run/src/args.h
@@ -18,12 +18,16 @@
 #define __NNPACKAGE_RUN_ARGS_H__
 
 #include <string>
+#include <map>
+#include <vector>
 #include <boost/program_options.hpp>
 
 namespace po = boost::program_options;
 
 namespace nnpkg_run
 {
+
+using TensorShapeMap = std::map<int, std::vector<int>>;
 
 class Args
 {
@@ -40,6 +44,8 @@ public:
   const bool getMemoryPoll(void) const { return _mem_poll; }
   const bool getWriteReport(void) const { return _write_report; }
   const bool printVersion(void) const { return _print_version; }
+  const TensorShapeMap &getComillationShapeMap() { return _shape_compile; }
+  const TensorShapeMap &getExecShapeMap() { return _shape_exec; }
 
 private:
   void Initialize();
@@ -52,6 +58,8 @@ private:
   std::string _package_filename;
   std::string _dump_filename;
   std::string _load_filename;
+  TensorShapeMap _shape_compile;
+  TensorShapeMap _shape_exec;
   int _num_runs;
   int _warmup_runs;
   bool _gpumem_poll;

--- a/tests/tools/nnpackage_run/src/nnpackage_run.cc
+++ b/tests/tools/nnpackage_run/src/nnpackage_run.cc
@@ -137,8 +137,27 @@ int main(const int argc, char **argv)
     }
   };
 
+  auto setTensorInfo = [session](const TensorShapeMap &tensor_shape_map) {
+    for (auto tensor_shape : tensor_shape_map)
+    {
+      auto ind = tensor_shape.first;
+      auto &shape = tensor_shape.second;
+      nnfw_tensorinfo ti;
+      // to fill dtype
+      NNPR_ENSURE_STATUS(nnfw_input_tensorinfo(session, ind, &ti));
+
+      ti.rank = shape.size();
+      for (int i = 0; i < ti.rank; i++)
+        ti.dims[i] = shape.at(i);
+      NNPR_ENSURE_STATUS(nnfw_set_input_tensorinfo(session, ind, &ti));
+    }
+  };
+
   verifyInputTypes();
   verifyOutputTypes();
+
+  // set input shape before compilation
+  setTensorInfo(args.getComillationShapeMap());
 
   // prepare execution
 
@@ -146,6 +165,9 @@ int main(const int argc, char **argv)
   phases.run("PREPARE", [&](const benchmark::Phase &, uint32_t) {
     NNPR_ENSURE_STATUS(nnfw_prepare(session));
   });
+
+  // set input shape after compilation and before execution
+  setTensorInfo(args.getExecShapeMap());
 
   // prepare input
   std::vector<Allocation> inputs(num_inputs);


### PR DESCRIPTION
This makes `nnpakcage_run` receive new tensor shapes to call `nnfw_set_input_tensorinfo()`.

To run some model, calling `nnfw_set_input_tensorinfo()` is required and with this commit, `nnpackage_run()` receives new tensor shape from command.

parent issue: #2112

Note: `--shape_compile` works but `--shape_exec` does not work because `nnfw_input_tensorinfo()` is not yet fully implemented.

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>
