### PR TITLE
[luci] Revise readverify with higher LUCI_LOG

### DIFF
--- a/compiler/luci/tests/readverify.sh
+++ b/compiler/luci/tests/readverify.sh
@@ -8,7 +8,7 @@
 VERIFY_SOURCE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # set LOG enable to execute/test luci/logex codes
-export LUCI_LOG=1
+export LUCI_LOG=100
 
 WORKDIR="$1"; shift
 VERIFY_BINARY_PATH="$1"; shift


### PR DESCRIPTION
This will revise readverify script with higher LUCI_LOG to include VERBOSE codes
- 100 is chosen to some huge value that value 100 itself is not important
- this is needed as the purpose of widen testing

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>