### PR TITLE
[onert] Change length of sink to use size of output tensor

### DIFF
--- a/runtime/onert/core/src/exec/ExecutorBase.cc
+++ b/runtime/onert/core/src/exec/ExecutorBase.cc
@@ -255,8 +255,16 @@ void ExecutorBase::execute(const IODescription &desc)
     output.info.shape(
         convertShape(output_tensor_shape, _output_tensors[n]->layout(), output.layout));
 
+    size_t sink_length =
+        output.info.shape().num_elements() * ir::sizeOfDataType(output.info.typeInfo().type());
+    assert(sink_length ==
+           _output_tensors[n]->getShape().num_elements() *
+               ir::sizeOfDataType(_output_tensors[n]->data_type()));
+    if (output.size < sink_length)
+      throw std::runtime_error("ExecutorBase: output buffer size is less than output tensor size");
+
     sinks.at(n) =
-        sink(output_index, output.info.typeInfo(), output.buffer, output.size, output.layout);
+        sink(output_index, output.info.typeInfo(), output.buffer, sink_length, output.layout);
 
     auto getter = [&](::onert::backend::ITensor &tensor) { sinks.at(n)->pull(tensor); };
 


### PR DESCRIPTION
For issue #2075

This commit changes length of sink to use size of output tensor.

Signed-off-by: ragmani <ragmani0216@gmail.com>