### PR TITLE
[luci] Revise create_circleconst

### DIFF
--- a/compiler/luci/import/src/Nodes/CircleConst.cpp
+++ b/compiler/luci/import/src/Nodes/CircleConst.cpp
@@ -81,6 +81,14 @@ CircleConst *create_circleconst(GraphBuilderContext *context, int32_t tensor_ind
     return nullptr;
   }
 
+  // if tensor_index is used as output to some other operator, this is not a constant
+  auto tensoroutputs = context->tensoroutputs();
+  if (tensoroutputs->find(tensor_index))
+  {
+    // other operator output tensor
+    return nullptr;
+  }
+
   uint32_t num_elements = 1;
   for (uint32_t r = 0; r < const_dims.size(); ++r)
   {


### PR DESCRIPTION
This will revise import create_circleconst() method to skip creation of CircleConst if the tensor is output of some other operator

ONE-DCO-1.0-ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>