### PR TITLE
[luci] Revise export allocateCircleTensor

### DIFF
--- a/compiler/luci/export/src/CircleTensorExporter.cpp
+++ b/compiler/luci/export/src/CircleTensorExporter.cpp
@@ -82,13 +82,6 @@ struct NoOpDetector final : public luci::CircleNodeMutableVisitor<bool>
   // Output is Virtual that does not produce any Tensor
   bool visit(luci::CircleOutput *) final { return true; }
   bool visit(luci::CircleOutputExclude *) final { return true; }
-  // Ignore Node of multiple outputs
-  bool visit(luci::CircleIf *) final { return true; }
-  bool visit(luci::CircleSplit *) final { return true; }
-  bool visit(luci::CircleSplitV *) final { return true; }
-  bool visit(luci::CircleTopKV2 *) final { return true; }
-  bool visit(luci::CircleUnpack *) final { return true; }
-  bool visit(luci::CircleWhile *) final { return true; }
 
   // Return false by default
   bool visit(luci::CircleNode *) final { return false; }
@@ -198,8 +191,6 @@ private:
 
 void allocateCircleTensor(CircleNode *node, CircleTensorContext &ctx)
 {
-  LOGGER(l);
-
   auto isNoOp = [](loco::Node *node) {
     if (auto circle_node = dynamic_cast<luci::CircleNode *>(node))
     {
@@ -215,28 +206,16 @@ void allocateCircleTensor(CircleNode *node, CircleTensorContext &ctx)
     return;
   }
 
-  auto tensor_index = static_cast<CircleTensorIndex>(ctx.size());
-  // TODO Use Graph-level metadata for Input & Output
-  // auto tensor_name = "t_" + std::to_string(tensor_index);
-  std::string tensor_name = node->name();
-  if (tensor_name.empty())
-    tensor_name = "t_" + std::to_string(tensor_index);
-  INFO(l) << "[luci] Tensor for " << tensor_name << ": " << tensor_index << std::endl;
+  // TODO revise this when loco supports multiple outputs
+  // NOTE this will store all virtual output tensors and skip for the real node
+  if (auto circle_node = dynamic_cast<luci::CircleNode *>(node))
+  {
+    MultiOutputDetector d(ctx);
+    if (circle_node->accept(&d))
+      return;
+  }
 
-  CircleTensoInfo tensor_info;
-
-  tensor_info.name(tensor_name);
-  tensor_info.dtype(to_circle_tensortype(luci::node_dtype(node)));
-  if (node->shape_status() == ShapeStatus::VALID)
-    tensor_info.shape(to_shape_description(luci::node_shape(node)));
-  tensor_info.shape_status(node->shape_status());
-
-  tensor_info.content(dynamic_cast<luci::CircleConst *>(node));
-  tensor_info.quantparam(node->quantparam());
-
-  set_tensor_index(node, tensor_index);
-
-  ctx.emplace_back(tensor_info);
+  allocateCircleTensorInfo(node, ctx);
 }
 
 } // namespace


### PR DESCRIPTION
This will revise allocateCircleTensor to separate NoOp and MultipleOutputOps and use allocateCircleTensorInfo as common method

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>