### PR TITLE
[nnpkgrun] Introduce `--output_sizes`

### DIFF
--- a/tests/tools/nnpackage_run/CMakeLists.txt
+++ b/tests/tools/nnpackage_run/CMakeLists.txt
@@ -32,7 +32,7 @@ target_include_directories(nnpackage_run PRIVATE src)
 target_include_directories(nnpackage_run PRIVATE ${Boost_INCLUDE_DIRS})
 
 target_link_libraries(nnpackage_run onert_core onert tflite_loader)
-target_link_libraries(nnpackage_run tensorflow-lite ${LIB_PTHREAD} dl nnfw_lib_tflite)
+target_link_libraries(nnpackage_run tensorflow-lite ${LIB_PTHREAD} dl nnfw_lib_tflite jsoncpp)
 target_link_libraries(nnpackage_run nnfw-dev)
 if(BUILD_BOOST)
   # We have to use Boost::program_options, instead of boost_program_optinos

--- a/tests/tools/nnpackage_run/src/args.cc
+++ b/tests/tools/nnpackage_run/src/args.cc
@@ -17,6 +17,44 @@
 #include "args.h"
 
 #include <iostream>
+#include <json/json.h>
+
+namespace
+{
+
+// This function parses a json object and returns as a vector of integers
+// For example,
+// [0, [1, 2, 3, 4], 3, 40, 4, []] in JSON
+// is converted to:
+// {
+//  0 -> [1, 2, 3, 4]
+//  3 -> 40
+//  4 -> []
+// } in std::unordered_map. Note that the value type is still Json::Value.
+std::unordered_map<uint32_t, Json::Value> argArrayToMap(const Json::Value &jsonval)
+{
+  if (!jsonval.isArray() || (jsonval.size() % 2 != 0))
+  {
+    std::cerr << "JSON argument must be an even-sized array in JSON\n";
+    exit(1);
+  }
+
+  std::unordered_map<uint32_t, Json::Value> ret;
+  for (uint32_t i = 0; i < jsonval.size(); i += 2)
+  {
+    if (!jsonval[i].isUInt())
+    {
+      std::cerr << "Key values(values in even indices) must be unsigned integers\n";
+      exit(1);
+    }
+    uint32_t key = jsonval[i].asUInt();
+    Json::Value val = jsonval[i + 1];
+    ret[key] = jsonval[i + 1];
+  }
+  return ret;
+}
+
+} // namespace
 
 namespace nnpkg_run
 {
@@ -41,6 +79,10 @@ void Args::Initialize(void)
     ("dump,d", po::value<std::string>()->default_value(""), "Output filename")
     ("load,l", po::value<std::string>()->default_value(""), "Input filename")
 #endif
+    ("output_sizes", po::value<std::string>(),
+        "The output buffer size in JSON 1D array\n"
+        "If not given, the model's output sizes are used\n"
+        "e.g. '[0, 40, 2, 80]' to set 0th tensor to 40 and 2nd tensor to 80.\n")
     ("num_runs,r", po::value<int>()->default_value(1), "The number of runs")
     ("warmup_runs,w", po::value<int>()->default_value(1), "The number of warmup runs")
     ("gpumem_poll,g", po::value<bool>()->default_value(false), "Check gpu memory polling separately")
@@ -120,6 +162,33 @@ void Args::Parse(const int argc, char **argv)
       {
         std::cerr << "nnpackage not found: " << _package_filename << "\n";
       }
+    }
+  }
+
+  if (vm.count("output_sizes"))
+  {
+    auto output_sizes_json_str = vm["output_sizes"].as<std::string>();
+
+    Json::Value root;
+    Json::Reader reader;
+    if (!reader.parse(output_sizes_json_str, root, false))
+    {
+      std::cerr << "Invalid JSON format for output_sizes \"" << output_sizes_json_str << "\"\n";
+      exit(1);
+    }
+
+    auto arg_map = argArrayToMap(root);
+    for (auto &pair : arg_map)
+    {
+      uint32_t key = pair.first;
+      Json::Value &val_json = pair.second;
+      if (!val_json.isUInt())
+      {
+        std::cerr << "All the values in `output_sizes` must be unsigned integers\n";
+        exit(1);
+      }
+      uint32_t val = val_json.asUInt();
+      _output_sizes[key] = val;
     }
   }
 

--- a/tests/tools/nnpackage_run/src/args.h
+++ b/tests/tools/nnpackage_run/src/args.h
@@ -18,6 +18,7 @@
 #define __NNPACKAGE_RUN_ARGS_H__
 
 #include <string>
+#include <unordered_map>
 #include <boost/program_options.hpp>
 
 namespace po = boost::program_options;
@@ -38,6 +39,7 @@ public:
 #endif
   const int getNumRuns(void) const { return _num_runs; }
   const int getWarmupRuns(void) const { return _warmup_runs; }
+  std::unordered_map<uint32_t, uint32_t> getOutputSizes(void) const { return _output_sizes; }
   const bool getGpuMemoryPoll(void) const { return _gpumem_poll; }
   const bool getMemoryPoll(void) const { return _mem_poll; }
   const bool getWriteReport(void) const { return _write_report; }
@@ -58,6 +60,7 @@ private:
 #endif
   int _num_runs;
   int _warmup_runs;
+  std::unordered_map<uint32_t, uint32_t> _output_sizes;
   bool _gpumem_poll;
   bool _mem_poll;
   bool _write_report;


### PR DESCRIPTION
As NNFW API requires user to prepare enough buffer sizes for outputs if
a model is dynamic, this commit introduces an command line option for
`nnpackage_run`.

Usage:

```
./nnpackage_run package_path --output_sizes="[0, 40, 2, 80]"
```

Will allocate 40 bytes for output 0 and 80 bytes for output 1.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>