### PR TITLE
[docs] Remove "How to Use API"

### DIFF
--- a/docs/howto/how-to-use-api.md
+++ b/docs/howto/how-to-use-api.md
@@ -1,1 +1,0 @@
-# How to Use API

--- a/docs/howto/index.rst
+++ b/docs/howto/index.rst
@@ -19,6 +19,5 @@ How To
   ./how-to-make-an-application-with-runtime.md
   ./how-to-remote-debugging-with-visual-studio-code.md
   ./how-to-run-package.md
-  ./how-to-use-api.md
   ./how-to-use-nnfw-api.md
   ./how-to-use-nnapi-binding.md


### PR DESCRIPTION
It looks like "How to Use API" means NNFW API which has its document
already.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>