### PR TITLE
[nnfwapi] Test: Add a check for input_tensorinfo

### DIFF
--- a/tests/nnfw_api/src/ModelTestInputReshaping.cc
+++ b/tests/nnfw_api/src/ModelTestInputReshaping.cc
@@ -64,9 +64,13 @@ TEST_F(TestInputReshapingAddModelLoaded, reshaping_2x2_to_4x2)
   res = nnfw_prepare(_session);
   ASSERT_EQ(res, NNFW_STATUS_NO_ERROR);
 
-  nnfw_tensorinfo ti_output; // Static inference result will be stored
+  nnfw_tensorinfo ti_input = {}; // Static inference result will be stored
+  nnfw_input_tensorinfo(_session, 0, &ti_input);
+  ASSERT_TRUE(tensorInfoEqual(ti, ti_input));
+
+  nnfw_tensorinfo ti_output = {}; // Static inference result will be stored
   nnfw_output_tensorinfo(_session, 0, &ti_output);
-  ASSERT_TRUE(tensorInfoEqual(ti, ti_output));
+  ASSERT_TRUE(tensorInfoEqual(ti, ti_output)); // input/output shapes are same with for this model
 
   res = nnfw_set_input(_session, 0, NNFW_TYPE_TENSOR_FLOAT32, input1.data(),
                        sizeof(float) * input1.size());


### PR DESCRIPTION
Add a check for `nnfw_input_tensorinfo`, after calling
`nnfw_apply_tensorinfo` and `nnfw_prepare`.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>