### PR TITLE
[luci] Fix for unused var release build error

### DIFF
--- a/compiler/luci/export/src/CircleTensorExporter.cpp
+++ b/compiler/luci/export/src/CircleTensorExporter.cpp
@@ -132,6 +132,7 @@ private:
   {
     auto outs = loco::succs(node);
     assert(outs.size() == count);
+    (void)count; // for unused variable error in release build
     for (auto out : outs)
     {
       auto circle_out = loco::must_cast<luci::CircleNode *>(out);


### PR DESCRIPTION
This will fix unused variable error in release build in export

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>