### PR TITLE
[luci-interpreter] Add tensor accessors to kernels

### DIFF
--- a/compiler/luci-interpreter/src/core/Kernel.h
+++ b/compiler/luci-interpreter/src/core/Kernel.h
@@ -19,6 +19,8 @@
 
 #include "luci_interpreter/core/Tensor.h"
 
+#include <vector>
+
 namespace luci_interpreter
 {
 
@@ -27,6 +29,9 @@ class Kernel
 {
 public:
   virtual ~Kernel() = default;
+
+  virtual std::vector<const Tensor *> getInputTensors() const = 0;
+  virtual std::vector<Tensor *> getOutputTensors() const = 0;
 
   // Configures the kernel.
   // This function is currently called once for each kernel during interpreter construction,

--- a/compiler/luci-interpreter/src/kernels/Add.h
+++ b/compiler/luci-interpreter/src/kernels/Add.h
@@ -30,6 +30,9 @@ class Add : public KernelWithParams<AddParams>
 public:
   Add(const Tensor *input1, const Tensor *input2, Tensor *output, const AddParams &params);
 
+  std::vector<const Tensor *> getInputTensors() const override { return {_input1, _input2}; }
+  std::vector<Tensor *> getOutputTensors() const override { return {_output}; }
+
   void configure() override;
   void execute() const override;
 

--- a/compiler/luci-interpreter/src/kernels/ArgMax.h
+++ b/compiler/luci-interpreter/src/kernels/ArgMax.h
@@ -30,6 +30,9 @@ class ArgMax : public KernelWithParams<ArgMaxParams>
 public:
   ArgMax(const Tensor *input, const Tensor *axis, Tensor *output, const ArgMaxParams &params);
 
+  std::vector<const Tensor *> getInputTensors() const override { return {_input, _axis}; }
+  std::vector<Tensor *> getOutputTensors() const override { return {_output}; }
+
   void configure() override;
   void execute() const override;
 

--- a/compiler/luci-interpreter/src/kernels/AveragePool2D.h
+++ b/compiler/luci-interpreter/src/kernels/AveragePool2D.h
@@ -30,6 +30,9 @@ class AveragePool2D : public KernelWithParams<Pool2DParams>
 public:
   AveragePool2D(const Tensor *input, Tensor *output, const Pool2DParams &params);
 
+  std::vector<const Tensor *> getInputTensors() const override { return {_input}; }
+  std::vector<Tensor *> getOutputTensors() const override { return {_output}; }
+
   void configure() override;
   void execute() const override;
 

--- a/compiler/luci-interpreter/src/kernels/Concatenation.h
+++ b/compiler/luci-interpreter/src/kernels/Concatenation.h
@@ -31,6 +31,9 @@ public:
   Concatenation(std::vector<const Tensor *> inputs, Tensor *output,
                 const ConcatenationParams &params);
 
+  std::vector<const Tensor *> getInputTensors() const override { return _inputs; }
+  std::vector<Tensor *> getOutputTensors() const override { return {_output}; }
+
   void configure() override;
   void execute() const override;
 

--- a/compiler/luci-interpreter/src/kernels/Conv2D.h
+++ b/compiler/luci-interpreter/src/kernels/Conv2D.h
@@ -33,6 +33,9 @@ public:
   Conv2D(const Tensor *input, const Tensor *filter, const Tensor *bias, Tensor *output,
          const Conv2DParams &params);
 
+  std::vector<const Tensor *> getInputTensors() const override { return {_input, _filter, _bias}; }
+  std::vector<Tensor *> getOutputTensors() const override { return {_output}; }
+
   void configure() override;
   void execute() const override;
 

--- a/compiler/luci-interpreter/src/kernels/DepthwiseConv2D.h
+++ b/compiler/luci-interpreter/src/kernels/DepthwiseConv2D.h
@@ -31,6 +31,9 @@ public:
   DepthwiseConv2D(const Tensor *input, const Tensor *filter, const Tensor *bias, Tensor *output,
                   const DepthwiseConv2DParams &params);
 
+  std::vector<const Tensor *> getInputTensors() const override { return {_input, _filter, _bias}; }
+  std::vector<Tensor *> getOutputTensors() const override { return {_output}; }
+
   void configure() override;
   void execute() const override;
 

--- a/compiler/luci-interpreter/src/kernels/Elu.h
+++ b/compiler/luci-interpreter/src/kernels/Elu.h
@@ -30,6 +30,9 @@ class Elu : public Kernel
 public:
   Elu(const Tensor *input, Tensor *output);
 
+  std::vector<const Tensor *> getInputTensors() const override { return {_input}; }
+  std::vector<Tensor *> getOutputTensors() const override { return {_output}; }
+
   void configure() override;
   void execute() const override;
 

--- a/compiler/luci-interpreter/src/kernels/FullyConnected.h
+++ b/compiler/luci-interpreter/src/kernels/FullyConnected.h
@@ -31,6 +31,9 @@ public:
   FullyConnected(const Tensor *input, const Tensor *weights, const Tensor *bias, Tensor *output,
                  const FullyConnectedParams &params);
 
+  std::vector<const Tensor *> getInputTensors() const override { return {_input, _weights, _bias}; }
+  std::vector<Tensor *> getOutputTensors() const override { return {_output}; }
+
   void configure() override;
   void execute() const override;
 

--- a/compiler/luci-interpreter/src/kernels/LeakyRelu.h
+++ b/compiler/luci-interpreter/src/kernels/LeakyRelu.h
@@ -30,6 +30,9 @@ class LeakyRelu : public KernelWithParams<LeakyReluParams>
 public:
   LeakyRelu(const Tensor *input, Tensor *output, const LeakyReluParams &params);
 
+  std::vector<const Tensor *> getInputTensors() const override { return {_input}; }
+  std::vector<Tensor *> getOutputTensors() const override { return {_output}; }
+
   void configure() override;
   void execute() const override;
 

--- a/compiler/luci-interpreter/src/kernels/Logistic.h
+++ b/compiler/luci-interpreter/src/kernels/Logistic.h
@@ -29,6 +29,9 @@ class Logistic : public Kernel
 public:
   Logistic(const Tensor *input, Tensor *output);
 
+  std::vector<const Tensor *> getInputTensors() const override { return {_input}; }
+  std::vector<Tensor *> getOutputTensors() const override { return {_output}; }
+
   void configure() override;
   void execute() const override;
 

--- a/compiler/luci-interpreter/src/kernels/MaxPool2D.h
+++ b/compiler/luci-interpreter/src/kernels/MaxPool2D.h
@@ -30,6 +30,9 @@ class MaxPool2D : public KernelWithParams<Pool2DParams>
 public:
   MaxPool2D(const Tensor *input, Tensor *output, const Pool2DParams &params);
 
+  std::vector<const Tensor *> getInputTensors() const override { return {_input}; }
+  std::vector<Tensor *> getOutputTensors() const override { return {_output}; }
+
   void configure() override;
   void execute() const override;
 

--- a/compiler/luci-interpreter/src/kernels/Mean.h
+++ b/compiler/luci-interpreter/src/kernels/Mean.h
@@ -32,6 +32,9 @@ class Mean : public KernelWithParams<ReducerParams>
 public:
   Mean(const Tensor *input, const Tensor *axes, Tensor *output, const ReducerParams &params);
 
+  std::vector<const Tensor *> getInputTensors() const override { return {_input, _axes}; }
+  std::vector<Tensor *> getOutputTensors() const override { return {_output}; }
+
   void configure() override;
   void execute() const override;
 

--- a/compiler/luci-interpreter/src/kernels/Mul.h
+++ b/compiler/luci-interpreter/src/kernels/Mul.h
@@ -33,6 +33,9 @@ class Mul : public KernelWithParams<MulParams>
 public:
   Mul(const Tensor *input1, const Tensor *input2, Tensor *output, const MulParams &params);
 
+  std::vector<const Tensor *> getInputTensors() const override { return {_input1, _input2}; }
+  std::vector<Tensor *> getOutputTensors() const override { return {_output}; }
+
   void configure() override;
   void execute() const override;
 

--- a/compiler/luci-interpreter/src/kernels/Pad.h
+++ b/compiler/luci-interpreter/src/kernels/Pad.h
@@ -29,6 +29,9 @@ class Pad : public Kernel
 public:
   Pad(const Tensor *input, const Tensor *paddings, Tensor *output);
 
+  std::vector<const Tensor *> getInputTensors() const override { return {_input, _paddings}; }
+  std::vector<Tensor *> getOutputTensors() const override { return {_output}; }
+
   void configure() override;
   void execute() const override;
 

--- a/compiler/luci-interpreter/src/kernels/Reshape.h
+++ b/compiler/luci-interpreter/src/kernels/Reshape.h
@@ -29,6 +29,9 @@ class Reshape : public Kernel
 public:
   Reshape(const Tensor *input, const Tensor *shape, Tensor *output);
 
+  std::vector<const Tensor *> getInputTensors() const override { return {_input, _shape}; }
+  std::vector<Tensor *> getOutputTensors() const override { return {_output}; }
+
   void configure() override;
   void execute() const override;
 

--- a/compiler/luci-interpreter/src/kernels/Softmax.h
+++ b/compiler/luci-interpreter/src/kernels/Softmax.h
@@ -30,6 +30,9 @@ class Softmax : public KernelWithParams<SoftmaxParams>
 public:
   Softmax(const Tensor *input, Tensor *output, const SoftmaxParams &params);
 
+  std::vector<const Tensor *> getInputTensors() const override { return {_input}; }
+  std::vector<Tensor *> getOutputTensors() const override { return {_output}; }
+
   void configure() override;
   void execute() const override;
 

--- a/compiler/luci-interpreter/src/kernels/Split.h
+++ b/compiler/luci-interpreter/src/kernels/Split.h
@@ -30,6 +30,9 @@ class Split : public Kernel
 public:
   Split(const Tensor *axis, const Tensor *input, std::vector<Tensor *> outputs);
 
+  std::vector<const Tensor *> getInputTensors() const override { return {_axis, _input}; }
+  std::vector<Tensor *> getOutputTensors() const override { return _outputs; }
+
   void configure() override;
   void execute() const override;
 

--- a/compiler/luci-interpreter/src/kernels/Transpose.h
+++ b/compiler/luci-interpreter/src/kernels/Transpose.h
@@ -30,6 +30,9 @@ class Transpose : public Kernel
 public:
   Transpose(const Tensor *input, const Tensor *perm, Tensor *output);
 
+  std::vector<const Tensor *> getInputTensors() const override { return {_input, _perm}; }
+  std::vector<Tensor *> getOutputTensors() const override { return {_output}; }
+
   void configure() override;
   void execute() const override;
 

--- a/compiler/luci-interpreter/src/kernels/TransposeConv.h
+++ b/compiler/luci-interpreter/src/kernels/TransposeConv.h
@@ -28,8 +28,14 @@ namespace kernels
 class TransposeConv : public KernelWithParams<TransposeConvParams>
 {
 public:
-  TransposeConv(const Tensor *outputShape, const Tensor *weights, const Tensor *inputData,
+  TransposeConv(const Tensor *output_shape, const Tensor *filter, const Tensor *input,
                 Tensor *output, const TransposeConvParams &params);
+
+  std::vector<const Tensor *> getInputTensors() const override
+  {
+    return {_output_shape, _filter, _input};
+  }
+  std::vector<Tensor *> getOutputTensors() const override { return {_output}; }
 
   void configure() override;
   void execute() const override;
@@ -40,8 +46,8 @@ private:
 
 private:
   const Tensor *const _output_shape;
-  const Tensor *const _weights;
-  const Tensor *const _input_data;
+  const Tensor *const _filter;
+  const Tensor *const _input;
   Tensor *const _output;
 
   std::unique_ptr<Tensor> _scratch_tensor;

--- a/compiler/luci-interpreter/src/kernels/Unpack.h
+++ b/compiler/luci-interpreter/src/kernels/Unpack.h
@@ -30,6 +30,9 @@ class Unpack : public KernelWithParams<UnpackParams>
 public:
   Unpack(const Tensor *input, std::vector<Tensor *> outputs, const UnpackParams &params);
 
+  std::vector<const Tensor *> getInputTensors() const override { return {_input}; }
+  std::vector<Tensor *> getOutputTensors() const override { return {_outputs}; }
+
   void configure() override;
   void execute() const override;
 


### PR DESCRIPTION
Draft PR #1980.

Add `getInputTensors` and `getOutputTensors` methods to kernels.

ONE-DCO-1.0-Signed-off-by: Sergei Barannikov <s.barannikov@samsung.com>
