### PR TITLE
[luci] Introduce new input for BCQ operations

### DIFF
--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleBCQFullyConnected.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleBCQFullyConnected.h
@@ -30,7 +30,7 @@ namespace luci
  * @brief BCQ_FULLY_CONNECTED in Circle
  */
 class CircleBCQFullyConnected final
-    : public FixedArityNode<4, CircleNodeImpl<CircleOpcode::BCQ_FULLY_CONNECTED>>,
+    : public FixedArityNode<5, CircleNodeImpl<CircleOpcode::BCQ_FULLY_CONNECTED>>,
       public LuciNodeMixin<LuciNodeTrait::FusedActFunc>,
       public LuciNodeMixin<LuciNodeTrait::Bias>
 {
@@ -46,6 +46,9 @@ public:
 
   loco::Node *bias(void) const override { return at(3)->node(); }
   void bias(loco::Node *node) override { at(3)->node(node); }
+
+  loco::Node *weights_clusters(void) const { return at(4)->node(); }
+  void weights_clusters(loco::Node *node) { at(4)->node(node); }
 
 public:
   int32_t weights_hidden_size(void) const { return _weights_hidden_size; }

--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleBCQGather.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleBCQGather.h
@@ -28,7 +28,7 @@ namespace luci
 /**
  * @brief BCQ_GATHER in Circle
  */
-class CircleBCQGather final : public FixedArityNode<3, CircleNodeImpl<CircleOpcode::BCQ_GATHER>>
+class CircleBCQGather final : public FixedArityNode<4, CircleNodeImpl<CircleOpcode::BCQ_GATHER>>
 {
 public:
   loco::Node *input_scales(void) const { return at(0)->node(); }
@@ -39,6 +39,9 @@ public:
 
   loco::Node *indices(void) const { return at(2)->node(); }
   void indices(loco::Node *node) { at(2)->node(node); }
+
+  loco::Node *input_clusters(void) const { return at(3)->node(); }
+  void input_clusters(loco::Node *node) { at(3)->node(node); }
 
 public:
   int32_t axis(void) const { return _axis; }


### PR DESCRIPTION
Parent Issue : #1907

In new BCQ, `clusters` will be given as new input.
This commit will apply this change.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>