### PR TITLE
[onert] Enable int32 input for Shape op

### DIFF
--- a/runtime/onert/backend/cpu/ops/ShapeLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ShapeLayer.cc
@@ -64,7 +64,7 @@ void ShapeLayer::configure(const Tensor *input, Tensor *output)
 
 void ShapeLayer::run()
 {
-  if (_input->data_type() == OperandType::FLOAT32 ||
+  if (_input->data_type() == OperandType::FLOAT32 || _input->data_type() == OperandType::INT32 ||
       _input->data_type() == OperandType::QUANT_UINT8_ASYMM)
   {
     shape();


### PR DESCRIPTION
This enables `int32` input for Shape op.

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>