### PR TITLE
Revert "[luci] Add `--no-cache-dir` option of pip in tests using pip (#2352)

### DIFF
--- a/compiler/luci-value-test/CMakeLists.txt
+++ b/compiler/luci-value-test/CMakeLists.txt
@@ -29,8 +29,8 @@ set(REQUIREMENTS_BIN_PATH "${CMAKE_CURRENT_BINARY_DIR}/${REQUIREMENTS_FILE}")
 add_custom_command(
   OUTPUT ${REQUIREMENTS_BIN_PATH}
   COMMAND ${CMAKE_COMMAND} -E copy ${REQUIREMENTS_SRC_PATH} ${REQUIREMENTS_BIN_PATH}
-  COMMAND ${VIRTUALENV}/bin/python -m pip install --upgrade pip setuptools --no-cache-dir --timeout 100
-  COMMAND ${VIRTUALENV}/bin/python -m pip install -r requirements.txt --no-cache-dir --upgrade --timeout 100
+  COMMAND ${VIRTUALENV}/bin/python -m pip install --upgrade pip setuptools --timeout 100
+  COMMAND ${VIRTUALENV}/bin/python -m pip install -r requirements.txt --upgrade --timeout 100
   DEPENDS ${VIRTUALENV} ${REQUIREMENTS_SRC_PATH}
 )
 

--- a/compiler/record-minmax-conversion-test/CMakeLists.txt
+++ b/compiler/record-minmax-conversion-test/CMakeLists.txt
@@ -29,8 +29,8 @@ set(REQUIREMENTS_BIN_PATH "${CMAKE_CURRENT_BINARY_DIR}/${REQUIREMENTS_FILE}")
 add_custom_command(
   OUTPUT ${REQUIREMENTS_BIN_PATH}
   COMMAND ${CMAKE_COMMAND} -E copy ${REQUIREMENTS_SRC_PATH} ${REQUIREMENTS_BIN_PATH}
-  COMMAND ${VIRTUALENV}/bin/python -m pip install --upgrade pip setuptools --no-cache-dir --timeout 100
-  COMMAND ${VIRTUALENV}/bin/python -m pip install -r requirements.txt --no-cache-dir --upgrade --timeout 100
+  COMMAND ${VIRTUALENV}/bin/python -m pip install --upgrade pip setuptools --timeout 100
+  COMMAND ${VIRTUALENV}/bin/python -m pip install -r requirements.txt --upgrade --timeout 100
   DEPENDS ${VIRTUALENV} ${REQUIREMENTS_SRC_PATH}
 )
 

--- a/compiler/tf2tfliteV2-conversion-test/CMakeLists.txt
+++ b/compiler/tf2tfliteV2-conversion-test/CMakeLists.txt
@@ -35,8 +35,8 @@ set(REQUIREMENTS_BIN_PATH "${CMAKE_CURRENT_BINARY_DIR}/${REQUIREMENTS_FILE}")
 add_custom_command(
   OUTPUT ${REQUIREMENTS_BIN_PATH}
   COMMAND ${CMAKE_COMMAND} -E copy ${REQUIREMENTS_SRC_PATH} ${REQUIREMENTS_BIN_PATH}
-  COMMAND ${VIRTUALENV}/bin/python -m pip install --upgrade pip setuptools --no-cache-dir --timeout 100
-  COMMAND ${VIRTUALENV}/bin/python -m pip install -r requirements.txt --no-cache-dir --upgrade --timeout 100
+  COMMAND ${VIRTUALENV}/bin/python -m pip install --upgrade pip setuptools --timeout 100
+  COMMAND ${VIRTUALENV}/bin/python -m pip install -r requirements.txt --upgrade --timeout 100
   DEPENDS ${VIRTUALENV} ${REQUIREMENTS_SRC_PATH}
 )
 


### PR DESCRIPTION
This reverts commit 587e3d13aa38dac6a342bfd6bffb3e2c0e6a90df.

#2352 did not fix https://github.com/Samsung/ONE/issues/457#issuecomment-645172551.