### PR TITLE
[circle-inspect] Introduce tensor dump option

### DIFF
--- a/compiler/circle-inspect/driver/Driver.cpp
+++ b/compiler/circle-inspect/driver/Driver.cpp
@@ -37,6 +37,7 @@ int entry(int argc, char **argv)
     std::cerr << "   --operators : dump operators in circle file" << std::endl;
     std::cerr << "   --conv2d_weight : dump Conv2D series weight operators in circle file"
               << std::endl;
+    std::cerr << "   --tensors : dump tensors in circle file" << std::endl;
     return 255;
   }
 
@@ -51,6 +52,11 @@ int entry(int argc, char **argv)
   argparse["--conv2d_weight"] = [&](void) {
     // dump Conv2D, DepthwiseConv2D weight operators
     return std::move(stdex::make_unique<circleinspect::DumpConv2DWeight>());
+  };
+
+  argparse["--tensors"] = [&](void) {
+    // dump all tensors
+    return std::move(stdex::make_unique<circleinspect::DumpTensors>());
   };
 
   std::vector<std::unique_ptr<circleinspect::DumpInterface>> dumps;

--- a/compiler/circle-inspect/src/Dump.cpp
+++ b/compiler/circle-inspect/src/Dump.cpp
@@ -18,6 +18,8 @@
 #include "Reader.h"
 
 #include <ostream>
+#include <string>
+#include <vector>
 
 namespace circleinspect
 {
@@ -128,6 +130,142 @@ void DumpConv2DWeight::run(std::ostream &os, const circle::Model *model)
 
       auto op_name = reader.opcode_name(op);
       os << op_name << "," << weight_op_name << std::endl;
+    }
+  }
+}
+
+} // namespace circleinspect
+
+namespace
+{
+
+template <typename CNTNR>
+void print_comma_sepearted(std::ostream &os, const flatbuffers::Vector<CNTNR> *vec)
+{
+  if (vec == nullptr)
+    return;
+  for (auto iter = vec->begin(); iter != vec->end(); iter++)
+  {
+    if (iter != vec->begin())
+      os << ", ";
+    os << *iter;
+  }
+}
+
+void print_buffer(std::ostream &os, uint32_t buff_idx, const flatbuffers::Vector<uint8_t> *data_ptr,
+                  const circle::TensorType &type)
+{
+  if (data_ptr == nullptr)
+    return;
+
+  os << " └── buffer" << std::endl;
+  os << "     ├── index : " << buff_idx << std::endl;
+  size_t buff_size = data_ptr->size();
+  os << "     ├── size  : " << buff_size << std::endl;
+  os << "     └── data  : ";
+  switch (type)
+  {
+    case circle::TensorType_UINT8:
+    {
+      const uint8_t *buff_data_ui8 = reinterpret_cast<const uint8_t *>(data_ptr->data());
+      for (uint32_t idx = 0; idx < buff_size / sizeof(uint8_t); idx++)
+      {
+        os << static_cast<const uint32_t>(buff_data_ui8[idx]) << ", ";
+      }
+      break;
+    }
+    case circle::TensorType_INT32:
+    {
+      const int32_t *buff_data_i32 = reinterpret_cast<const int32_t *>(data_ptr->data());
+      for (uint32_t idx = 0; idx < buff_size / sizeof(int32_t); idx++)
+      {
+        os << buff_data_i32[idx] << ", ";
+      }
+      break;
+    }
+    case circle::TensorType_INT64:
+    {
+      const int64_t *buff_data_i64 = reinterpret_cast<const int64_t *>(data_ptr->data());
+      for (uint32_t idx = 0; idx < buff_size / sizeof(int64_t); idx++)
+      {
+        os << buff_data_i64[idx] << ", ";
+      }
+      break;
+    }
+    case circle::TensorType_FLOAT32:
+    {
+      const float *buff_data_f32 = reinterpret_cast<const float *>(data_ptr->data());
+      for (uint32_t idx = 0; idx < buff_size / sizeof(float); idx++)
+      {
+        os << buff_data_f32[idx] << ", ";
+      }
+      break;
+    }
+    default:
+      throw std::runtime_error("NYI tensor type : " + std::to_string(type));
+  }
+  os << std::endl;
+}
+
+} // namepsace
+
+namespace circleinspect
+{
+
+void DumpTensors::run(std::ostream &os, const circle::Model *model)
+{
+  circleinspect::Reader reader(model);
+  uint32_t num_subgraph = reader.num_subgraph();
+  auto buffers = reader.buffers();
+
+  for (uint32_t subgraph_idx = 0; subgraph_idx < num_subgraph; subgraph_idx++)
+  {
+    reader.select_subgraph(subgraph_idx);
+
+    auto tensors = reader.tensors();
+    for (const auto &tensor : *tensors)
+    {
+      os << std::string(50, '-') << std::endl;
+      os << "[" << tensor->name()->str() << "]" << std::endl;
+      auto buff_idx = tensor->buffer();
+      auto buff_data_ptr = reader.buffers()->Get(buff_idx)->data();
+      auto quant_param = tensor->quantization();
+      std::string print_format = (!buff_data_ptr && !quant_param) ? "└──" : "├──";
+
+      // shape
+      auto shape = tensor->shape();
+      os << " " + print_format + " shape : (";
+      ::print_comma_sepearted(os, shape);
+      os << ")" << std::endl;
+
+      // quantization paramters
+      if (quant_param)
+      {
+        std::string print_format1 = buff_data_ptr ? "├──" : "└──";
+        std::string print_format2 = buff_data_ptr ? "│" : " ";
+        os << " " + print_format1 + " quantization" << std::endl;
+        auto min = quant_param->min();
+        auto max = quant_param->max();
+        auto scale = quant_param->scale();
+        auto zero_point = quant_param->zero_point();
+
+        os << " " + print_format2 + "   ├── min        : ";
+        ::print_comma_sepearted(os, min);
+        os << std::endl;
+        os << " " + print_format2 + "   ├── max        : ";
+        ::print_comma_sepearted(os, max);
+        os << std::endl;
+        os << " " + print_format2 + "   ├── scale      : ";
+        ::print_comma_sepearted(os, scale);
+        os << std::endl;
+        os << " " + print_format2 + "   └── zero_point : ";
+        ::print_comma_sepearted(os, zero_point);
+        os << std::endl;
+      }
+
+      // buffer
+      print_buffer(os, buff_idx, buff_data_ptr, tensor->type());
+      os << std::endl;
     }
   }
 }

--- a/compiler/circle-inspect/src/Dump.h
+++ b/compiler/circle-inspect/src/Dump.h
@@ -51,6 +51,15 @@ public:
   void run(std::ostream &os, const circle::Model *model);
 };
 
+class DumpTensors final : public DumpInterface
+{
+public:
+  DumpTensors() = default;
+
+public:
+  void run(std::ostream &os, const circle::Model *model);
+};
+
 } // namespace circleinspect
 
 #endif // __DUMP_H__


### PR DESCRIPTION
This commit introduces tensor dump option

```shell
$ ./circle-inspect --tensors ../luci/tests/Conv2D_000.circle
--------------------------------------------------
[ifm]
 └── shape : (1, 3, 3, 2)

--------------------------------------------------
[ker]
 ├── shape : (1, 1, 1, 2)
 └── buffer
     ├── index : 3
     ├── size  : 8
     └── data  : 0.153624, 0.168178, 

--------------------------------------------------
[bias]
 ├── shape : (1)
 └── buffer
     ├── index : 4
     ├── size  : 4
     └── data  : -1.98097, 

--------------------------------------------------
[ofm]
 └── shape : (1, 3, 3, 1)

```
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>