### PR TITLE
onert : Set _rank after shape inference

### DIFF
--- a/runtime/onert/backend/cpu/ops/TransposeLayer.cc
+++ b/runtime/onert/backend/cpu/ops/TransposeLayer.cc
@@ -65,6 +65,10 @@ void TransposeLayer::configure(const Tensor *input, Tensor *output, const std::v
 
 void TransposeLayer::run()
 {
+  if (_input->is_dynamic())
+  {
+    _rank = _input->num_dimensions();
+  }
   if (_input->data_type() == OperandType::FLOAT32)
   {
     transposeFloat32();

--- a/runtime/onert/core/src/util/shapeinf/Transpose.cc
+++ b/runtime/onert/core/src/util/shapeinf/Transpose.cc
@@ -51,7 +51,7 @@ void StaticInferer::visit(const ir::operation::Transpose &op)
   const auto output_idx = op.getOutputs().at(0);
   ir::Operand &output = _operands.at(output_idx);
   const auto perm{op.param().perm};
-  // const auto rank{op.param().rank};
+
   // if input is dynamic, output also becomes dynamic
   if (input.info().isDynamic())
   {


### PR DESCRIPTION
In case of dynamic shape, the value of the '_rank' may not be correct.
That's why set '_rank' after shape inference.

Signed-off-by: YiHyunjin <hj0412.yi@samsung.com>