### PR TITLE
[onert] fix StridedSlice to use inferred shape

### DIFF
--- a/runtime/onert/backend/acl_cl/KernelGenerator.cc
+++ b/runtime/onert/backend/acl_cl/KernelGenerator.cc
@@ -621,7 +621,7 @@ void KernelGenerator::visit(const ir::operation::StridedSlice &node)
   const auto backend_layout = inputData_alloc->layout();
 
   // Set initializers for indices data such as order of inputData
-  int input_rank = node.param().rank;
+  int input_rank = _ctx.at(input_index).shape().rank();
   std::vector<int32_t> starts;
   std::vector<int32_t> ends;
   std::vector<int32_t> strides;

--- a/runtime/onert/backend/acl_neon/KernelGenerator.cc
+++ b/runtime/onert/backend/acl_neon/KernelGenerator.cc
@@ -1705,7 +1705,7 @@ void KernelGenerator::visit(const ir::operation::StridedSlice &node)
   const auto backend_layout = inputData_alloc->layout();
 
   // Set initializers for indices data such as order of inputData
-  int input_rank = node.param().rank;
+  int input_rank = _ctx.at(input_index).shape().rank();
   std::vector<int32_t> starts;
   std::vector<int32_t> ends;
   std::vector<int32_t> strides;

--- a/runtime/onert/backend/cpu/KernelGenerator.cc
+++ b/runtime/onert/backend/cpu/KernelGenerator.cc
@@ -933,12 +933,11 @@ void KernelGenerator::visit(const ir::operation::StridedSlice &node)
   auto begin_mask = node.param().begin_mask;
   auto end_mask = node.param().end_mask;
   auto shrink_axis_mask = node.param().shrink_axis_mask;
-  auto rank = node.param().rank;
 
   auto fn = std::make_unique<ops::StridedSliceLayer>();
 
   fn->configure(input_alloc, starts_alloc, ends_alloc, strides_alloc, output_alloc, begin_mask,
-                end_mask, shrink_axis_mask, rank);
+                end_mask, shrink_axis_mask);
 
   _return_fn = std::move(fn);
 }

--- a/runtime/onert/backend/cpu/ops/StridedSliceLayer.cc
+++ b/runtime/onert/backend/cpu/ops/StridedSliceLayer.cc
@@ -31,8 +31,7 @@ namespace ops
 
 StridedSliceLayer::StridedSliceLayer()
     : _input(nullptr), _begin(nullptr), _end(nullptr), _strides(nullptr), _output(nullptr),
-      _begin_mask(0), _ellipsis_mask(0), _end_mask(0), _new_axis_mask(0), _shrink_axis_mask(0),
-      _rank(0)
+      _begin_mask(0), _ellipsis_mask(0), _end_mask(0), _new_axis_mask(0), _shrink_axis_mask(0)
 {
 }
 
@@ -41,9 +40,10 @@ template <typename T> void StridedSliceLayer::stridedSliceImpl()
   auto op_params = nnfw::cker::buildStridedSliceParams(
       reinterpret_cast<uint32_t *>(_begin->buffer()), reinterpret_cast<uint32_t *>(_end->buffer()),
       reinterpret_cast<uint32_t *>(_strides->buffer()), _begin_mask, _end_mask, _shrink_axis_mask,
-      _rank);
+      getTensorShape(_input).DimensionsCount());
 
-  nnfw::cker::checkOutputSize(op_params, getTensorShape(_input), getTensorShape(_output), _rank);
+  nnfw::cker::checkOutputSize(op_params, getTensorShape(_input), getTensorShape(_output),
+                              getTensorShape(_input).DimensionsCount());
 
   nnfw::cker::StridedSlice(op_params, getTensorShape(_input),
                            reinterpret_cast<const T *>(_input->buffer()), getTensorShape(_output),
@@ -52,8 +52,7 @@ template <typename T> void StridedSliceLayer::stridedSliceImpl()
 
 void StridedSliceLayer::configure(const Tensor *input, const Tensor *begin, const Tensor *end,
                                   const Tensor *strides, Tensor *output, const int32_t begin_mask,
-                                  const int32_t end_mask, const int32_t shrink_axis_mask,
-                                  const int32_t rank)
+                                  const int32_t end_mask, const int32_t shrink_axis_mask)
 {
   _input = input;
   _begin = begin;
@@ -61,7 +60,6 @@ void StridedSliceLayer::configure(const Tensor *input, const Tensor *begin, cons
   _strides = strides;
   _output = output;
 
-  _rank = rank;
   _begin_mask = begin_mask;
   _ellipsis_mask = 0;
   _end_mask = end_mask;
@@ -71,10 +69,6 @@ void StridedSliceLayer::configure(const Tensor *input, const Tensor *begin, cons
 
 void StridedSliceLayer::run()
 {
-  if (_input->is_dynamic())
-  {
-    _rank = _input->num_dimensions();
-  }
   if (_input->data_type() == OperandType::FLOAT32)
   {
     stridedSliceImpl<float>();

--- a/runtime/onert/backend/cpu/ops/StridedSliceLayer.h
+++ b/runtime/onert/backend/cpu/ops/StridedSliceLayer.h
@@ -39,7 +39,7 @@ public:
 public:
   void configure(const Tensor *input, const Tensor *begin, const Tensor *end, const Tensor *strides,
                  Tensor *output, const int32_t begin_mask, const int32_t end_mask,
-                 const int32_t shrink_axis_mask, const int32_t rank);
+                 const int32_t shrink_axis_mask);
   void run();
 
 private:
@@ -57,8 +57,6 @@ private:
   int32_t _end_mask;
   int32_t _new_axis_mask;
   int32_t _shrink_axis_mask;
-
-  int32_t _rank;
 };
 
 } // namespace ops

--- a/runtime/onert/core/include/ir/operation/StridedSlice.h
+++ b/runtime/onert/core/include/ir/operation/StridedSlice.h
@@ -44,7 +44,6 @@ public:
     int32_t begin_mask;
     int32_t end_mask;
     int32_t shrink_axis_mask;
-    int32_t rank;
   };
 
 public:

--- a/runtime/onert/core/src/util/shapeinf/StridedSlice.cc
+++ b/runtime/onert/core/src/util/shapeinf/StridedSlice.cc
@@ -245,7 +245,7 @@ void StaticInferer::visit(const ir::operation::StridedSlice &op)
   const auto begin_mask = op.param().begin_mask;
   const auto end_mask = op.param().end_mask;
   const auto shrink_axis_mask = op.param().shrink_axis_mask;
-  const auto rank = op.param().rank;
+  const auto rank = input.info().shape().rank();
 
   auto starts_buf = reinterpret_cast<const uint32_t *>(starts.data()->base());
   auto ends_buf = reinterpret_cast<const uint32_t *>(ends.data()->base());

--- a/runtime/onert/frontend/base_loader/include/base_loader.h
+++ b/runtime/onert/frontend/base_loader/include/base_loader.h
@@ -1301,7 +1301,6 @@ void BaseLoader<LoaderDomain, SpecificLoader>::loadStridedSlice(const Operator *
   param.begin_mask = options->begin_mask();
   param.end_mask = options->end_mask();
   param.shrink_axis_mask = options->shrink_axis_mask();
-  param.rank = subg.operands().at(inputs.at(0)).shape().rank();
 
   std::unique_ptr<ir::Operation> new_op{new ir::operation::StridedSlice{inputs, outputs, param}};
   subg.addOperation(std::move(new_op));

--- a/runtime/onert/frontend/nnapi/wrapper/OperationFactory.cc
+++ b/runtime/onert/frontend/nnapi/wrapper/OperationFactory.cc
@@ -630,7 +630,6 @@ OperationFactory::OperationFactory()
     param.end_mask = operands.at(OperandIndex{init_param.inputs[5]}).asScalar<std::int32_t>();
     param.shrink_axis_mask =
         operands.at(OperandIndex{init_param.inputs[6]}).asScalar<std::int32_t>();
-    param.rank = operands.at(inputs.at(0)).shape().rank();
 
     return new operation::StridedSlice{inputs, outputs, param};
   };


### PR DESCRIPTION
It fixes StridedSlice to use inferred shape.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>