### PR TITLE
[nnfwapi] Update behavior of nnfw_input_tensorinfo

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -453,6 +453,8 @@ NNFW_STATUS nnfw_session::input_tensorinfo(uint32_t index, nnfw_tensorinfo *ti)
     }
     auto opidx = primary_subgraph()->getInputs().at(index);
     auto shape = primary_subgraph()->operands().at(opidx).shape();
+    if (isStatePreparedOrFinishedRun())
+      shape = _execution->getInputShape(onert::ir::IOIndex{index});
     ti->rank = shape.rank();
     for (int j = 0; j < ti->rank; ++j)
     {

--- a/runtime/onert/core/include/exec/Execution.h
+++ b/runtime/onert/core/include/exec/Execution.h
@@ -139,6 +139,7 @@ public:
    */
   bool isFinished(void) const;
 
+  ir::Shape getInputShape(ir::IOIndex ind) const;
   ir::Shape getOutputShape(ir::IOIndex ind) const;
 
 private:

--- a/runtime/onert/core/src/exec/Execution.cc
+++ b/runtime/onert/core/src/exec/Execution.cc
@@ -152,6 +152,20 @@ void Execution::waitFinish()
 
 bool Execution::isFinished(void) const { return finished; }
 
+ir::Shape Execution::getInputShape(ir::IOIndex ind) const
+{
+  auto itr = _io_desc.input_shape_signature.find(ind);
+  if (itr == _io_desc.input_shape_signature.end())
+  {
+    auto operand_idx = primary_subgraph().getInputs().at(ind.value());
+    return primary_subgraph().operands().at(operand_idx).shape();
+  }
+  else
+  {
+    return itr->second;
+  }
+}
+
 ir::Shape Execution::getOutputShape(ir::IOIndex ind) const
 {
   if (!isFinished())

--- a/tests/nnfw_api/src/ModelTestDynamicTensor.cc
+++ b/tests/nnfw_api/src/ModelTestDynamicTensor.cc
@@ -17,6 +17,7 @@
 #include <gtest/gtest.h>
 #include <nnfw_debug.h>
 
+#include "common.h"
 #include "fixtures.h"
 #include "NNPackages.h"
 
@@ -396,6 +397,14 @@ TEST_F(TestDynamicTensorApplyTensorInfoUnaryOp, set_input_tensorinfo_after_compi
 {
   ASSERT_EQ(nnfw_set_available_backends(_session, "cpu"), NNFW_STATUS_NO_ERROR);
 
+  nnfw_tensorinfo input0_ti_original;
+  {
+    input0_ti_original.dtype = NNFW_TYPE_TENSOR_FLOAT32;
+    input0_ti_original.rank = 2;
+    input0_ti_original.dims[0] = 4;
+    input0_ti_original.dims[1] = 4;
+  }
+
   // input reshaping to [20, 50]
   nnfw_tensorinfo input0_ti;
   {
@@ -417,7 +426,21 @@ TEST_F(TestDynamicTensorApplyTensorInfoUnaryOp, set_input_tensorinfo_after_compi
 
   ASSERT_EQ(nnfw_prepare(_session), NNFW_STATUS_NO_ERROR);
 
+  // input shape check
+  {
+    nnfw_tensorinfo ti = {};
+    ASSERT_EQ(nnfw_input_tensorinfo(_session, 0, &ti), NNFW_STATUS_NO_ERROR);
+    ASSERT_TRUE(tensorInfoEqual(input0_ti_original, ti));
+  }
+
   ASSERT_EQ(nnfw_set_input_tensorinfo(_session, 0, &input0_ti), NNFW_STATUS_NO_ERROR);
+
+  // input shape check
+  {
+    nnfw_tensorinfo ti = {};
+    ASSERT_EQ(nnfw_input_tensorinfo(_session, 0, &ti), NNFW_STATUS_NO_ERROR);
+    ASSERT_TRUE(tensorInfoEqual(input0_ti, ti));
+  }
 
   set_input_output(_session, input0, &actual_output);
 


### PR DESCRIPTION
As `nnfw_input_tensorinfo` works differently for each session state,
this commit makes it to work properly for PREPARED and FINISHED state.

For #2293

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>