### PR TITLE
[{nnpackage|tflite}_run] set warmup number when memory polls

### DIFF
--- a/tests/tools/nnpackage_run/src/args.cc
+++ b/tests/tools/nnpackage_run/src/args.cc
@@ -210,6 +210,11 @@ void Args::Parse(const int argc, char **argv)
   if (vm.count("mem_poll"))
   {
     _mem_poll = vm["mem_poll"].as<bool>();
+    // Instead of EXECUTE to avoid overhead, memory polling runs on WARMUP
+    if (_mem_poll && _warmup_runs == 0)
+    {
+      _warmup_runs = 1;
+    }
   }
 
   if (vm.count("write_report"))

--- a/tests/tools/tflite_run/src/args.cc
+++ b/tests/tools/tflite_run/src/args.cc
@@ -156,6 +156,11 @@ void Args::Parse(const int argc, char **argv)
   if (vm.count("mem_poll"))
   {
     _mem_poll = vm["mem_poll"].as<bool>();
+    // Instead of EXECUTE to avoid overhead, memory polling runs on WARMUP
+    if (_mem_poll && _warmup_runs == 0)
+    {
+      _warmup_runs = 1;
+    }
   }
 
   if (vm.count("write_report"))


### PR DESCRIPTION
Because memory polling runs on warmup to avoid overhead,
enable warmup when memory poll would run

ONE-DCO-1.0-Signed-off-by: Yongseop Kim <yons.kim@samsung.com>