### PR TITLE
[onert] don't throw divide by zero error in float div

### DIFF
--- a/compute/cker/include/cker/operation/BinaryArithmeticOps.h
+++ b/compute/cker/include/cker/operation/BinaryArithmeticOps.h
@@ -32,6 +32,16 @@ namespace cker
 
 namespace
 {
+template <typename T> T divide(const T &a, const T &b)
+{
+  if (b == 0)
+    throw std::runtime_error("Divide by zero");
+
+  return a / b;
+}
+
+template <> float divide<float>(const float &a, const float &b) { return a / b; }
+
 template <typename T>
 const std::function<T(const T &, const T &)> GetBinaryArtithmeticFn(BinaryArithmeticOpType type)
 {
@@ -51,13 +61,7 @@ const std::function<T(const T &, const T &)> GetBinaryArtithmeticFn(BinaryArithm
     }
     case BinaryArithmeticOpType::DIV:
     {
-      return [](const T &a, const T &b) -> T {
-        if (b == 0)
-        {
-          throw std::runtime_error("Divide by zero");
-        }
-        return a / b;
-      };
+      return divide<T>;
     }
     case BinaryArithmeticOpType::POW:
     {


### PR DESCRIPTION
divide by zero is well defined in IEEE specificaiton.
It should set the output as +Inf or -Inf, instead of throwing error.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>