### PR TITLE
[luci-interpreter] Split method declarations and definitions

### DIFF
--- a/compiler/luci-interpreter/src/KernelBuilder.cpp
+++ b/compiler/luci-interpreter/src/KernelBuilder.cpp
@@ -57,6 +57,36 @@ static std::vector<const loco::Node *> collectOutputNodes(const luci::CircleNode
   return {output_nodes.cbegin(), output_nodes.cend()};
 }
 
+const Tensor *KernelBuilder::getInputTensor(const loco::Node *node) const
+{
+  const Tensor *tensor = _tensor_map.getTensor(node);
+  assert(tensor != nullptr);
+  return tensor;
+}
+
+const Tensor *KernelBuilder::getOptionalInputTensor(const loco::Node *node) const
+{
+  // TODO Revise this when optional inputs are implemented in the IR.
+  return getInputTensor(node);
+}
+
+Tensor *KernelBuilder::getOutputTensor(const loco::Node *node) const
+{
+  Tensor *tensor = _tensor_map.getTensor(node);
+  assert(tensor != nullptr);
+  return tensor;
+}
+
+std::vector<Tensor *>
+KernelBuilder::getOutputTensors(const std::vector<const loco::Node *> &nodes) const
+{
+  std::vector<Tensor *> tensors;
+  tensors.reserve(nodes.size());
+  for (const loco::Node *node : nodes)
+    tensors.push_back(getOutputTensor(node));
+  return tensors;
+}
+
 std::unique_ptr<Kernel> KernelBuilder::visit(const luci::CircleAdd *node)
 {
   assert(node->arity() == 2);

--- a/compiler/luci-interpreter/src/KernelBuilder.h
+++ b/compiler/luci-interpreter/src/KernelBuilder.h
@@ -58,34 +58,13 @@ public:
   std::unique_ptr<Kernel> visit(const luci::CircleUnpack *node) override;
 
 private:
-  const Tensor *getInputTensor(const loco::Node *node) const
-  {
-    const Tensor *tensor = _tensor_map.getTensor(node);
-    assert(tensor != nullptr);
-    return tensor;
-  }
+  const Tensor *getInputTensor(const loco::Node *node) const;
 
-  const Tensor *getOptionalInputTensor(const loco::Node *node) const
-  {
-    // TODO Revise this when optional inputs are implemented in the IR.
-    return getInputTensor(node);
-  }
+  const Tensor *getOptionalInputTensor(const loco::Node *node) const;
 
-  Tensor *getOutputTensor(const loco::Node *node) const
-  {
-    Tensor *tensor = _tensor_map.getTensor(node);
-    assert(tensor != nullptr);
-    return tensor;
-  }
+  Tensor *getOutputTensor(const loco::Node *node) const;
 
-  std::vector<Tensor *> getOutputTensors(const std::vector<const loco::Node *> &nodes) const
-  {
-    std::vector<Tensor *> tensors;
-    tensors.reserve(nodes.size());
-    for (const loco::Node *node : nodes)
-      tensors.push_back(getOutputTensor(node));
-    return tensors;
-  }
+  std::vector<Tensor *> getOutputTensors(const std::vector<const loco::Node *> &nodes) const;
 
 private:
   TensorMap &_tensor_map;


### PR DESCRIPTION
Draft PR #1980.

Extract `KernelBuilder`s method definitions into cpp file.

ONE-DCO-1.0-Signed-off-by: Sergei Barannikov <s.barannikov@samsung.com>
