### PR TITLE
[luci-interpreter] Rework observing functionality support

### DIFF
--- a/compiler/luci-interpreter/include/luci_interpreter/Interpreter.h
+++ b/compiler/luci-interpreter/include/luci_interpreter/Interpreter.h
@@ -59,8 +59,14 @@ private:
   void createKernels(const loco::Graph *graph);
 
   const loco::Graph *_main_graph = nullptr;
-  std::unique_ptr<class TensorMap> _tensor_map;
-  std::unique_ptr<class KernelMap> _kernel_map;
+  std::unique_ptr<class TensorMap> _node_to_tensor;
+
+  // Kernels, in execution order.
+  std::vector<std::unique_ptr<class Kernel>> _kernels;
+
+  // Observer functionality support.
+  std::unique_ptr<struct RuntimeToIR> _runtime_to_ir;
+  std::unique_ptr<class Hook> _hook;
   std::vector<ExecutionObserver *> _observers;
 };
 

--- a/compiler/luci-interpreter/include/luci_interpreter/Interpreter.h
+++ b/compiler/luci-interpreter/include/luci_interpreter/Interpreter.h
@@ -66,7 +66,7 @@ private:
 
   // Observer functionality support.
   std::unique_ptr<struct RuntimeToIR> _runtime_to_ir;
-  std::unique_ptr<class Hook> _hook;
+  std::unique_ptr<class EventNotifier> _event_notifier;
   std::vector<ExecutionObserver *> _observers;
 };
 

--- a/compiler/luci-interpreter/src/CMakeLists.txt
+++ b/compiler/luci-interpreter/src/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SOURCES
     KernelBuilder.h
     KernelBuilder.cpp
     KernelMap.h
+    RuntimeToIR.h
     TensorMap.h)
 
 add_library(luci_interpreter SHARED ${SOURCES})

--- a/compiler/luci-interpreter/src/RuntimeToIR.h
+++ b/compiler/luci-interpreter/src/RuntimeToIR.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef LUCI_INTERPRETER_RUNTIMETOIR_H
+#define LUCI_INTERPRETER_RUNTIMETOIR_H
+
+#include "luci_interpreter/core/Tensor.h"
+
+#include <luci/IR/CircleNode.h>
+
+#include <unordered_map>
+
+namespace luci_interpreter
+{
+
+// Maps runtime entities back to IR entities. It is used to implement observing functionality.
+struct RuntimeToIR
+{
+  std::unordered_map<Tensor *, const luci::CircleNode *> tensor_to_node;
+};
+
+} // namespace luci_interpreter
+
+#endif // LUCI_INTERPRETER_RUNTIMETOIR_H

--- a/compiler/luci-interpreter/src/core/CMakeLists.txt
+++ b/compiler/luci-interpreter/src/core/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(SOURCES
     "${LUCI_INTERPRETER_INCLUDE_DIR}/luci_interpreter/core/DataType.h"
     "${LUCI_INTERPRETER_INCLUDE_DIR}/luci_interpreter/core/Tensor.h"
-    Hook.h
+    EventNotifier.h
     Kernel.h
     KernelParams.h
     Tensor.cpp)

--- a/compiler/luci-interpreter/src/core/CMakeLists.txt
+++ b/compiler/luci-interpreter/src/core/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(SOURCES
     "${LUCI_INTERPRETER_INCLUDE_DIR}/luci_interpreter/core/DataType.h"
     "${LUCI_INTERPRETER_INCLUDE_DIR}/luci_interpreter/core/Tensor.h"
+    Hook.h
     Kernel.h
     KernelParams.h
     Tensor.cpp)

--- a/compiler/luci-interpreter/src/core/EventNotifier.h
+++ b/compiler/luci-interpreter/src/core/EventNotifier.h
@@ -14,21 +14,21 @@
  * limitations under the License.
  */
 
-#ifndef LUCI_INTERPRETER_CORE_HOOK_H
-#define LUCI_INTERPRETER_CORE_HOOK_H
+#ifndef LUCI_INTERPRETER_CORE_EVENTNOTIFIER_H
+#define LUCI_INTERPRETER_CORE_EVENTNOTIFIER_H
 
 namespace luci_interpreter
 {
 
 // Used at execution stage to tell the interpreter that the runtime state has changed in some way.
-class Hook
+class EventNotifier
 {
 public:
-  virtual ~Hook() = default;
+  virtual ~EventNotifier() = default;
 
   virtual void postTensorWrite(Tensor *tensor) const = 0;
 };
 
 } // namespace luci_interpreter
 
-#endif // LUCI_INTERPRETER_CORE_HOOK_H
+#endif // LUCI_INTERPRETER_CORE_EVENTNOTIFIER_H

--- a/compiler/luci-interpreter/src/core/Hook.h
+++ b/compiler/luci-interpreter/src/core/Hook.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef LUCI_INTERPRETER_CORE_HOOK_H
+#define LUCI_INTERPRETER_CORE_HOOK_H
+
+namespace luci_interpreter
+{
+
+// Used at execution stage to tell the interpreter that the runtime state has changed in some way.
+class Hook
+{
+public:
+  virtual ~Hook() = default;
+
+  virtual void postTensorWrite(Tensor *tensor) const = 0;
+};
+
+} // namespace luci_interpreter
+
+#endif // LUCI_INTERPRETER_CORE_HOOK_H


### PR DESCRIPTION
Draft PR #1980.

Add a layer of abstraction to avoid dependency of runtime entities on IR entities.

ONE-DCO-1.0-Signed-off-by: Sergei Barannikov <s.barannikov@samsung.com>