### PR TITLE
[onert] make nnpackage_run receive tensor shape

### DIFF
--- a/runtime/onert/core/include/ir/Shape.h
+++ b/runtime/onert/core/include/ir/Shape.h
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */
+*/
 
 #ifndef __ONERT_IR_SHAPE_H__
 #define __ONERT_IR_SHAPE_H__

--- a/tests/tools/nnpackage_run/src/args.cc
+++ b/tests/tools/nnpackage_run/src/args.cc
@@ -130,11 +130,11 @@ void Args::Initialize(void)
          "{exec}-{nnpkg}-{backend}.csv will be generated.\n"
          "e.g. nnpackage_run-UNIT_Add_000-acl_cl.csv.\n"
          "{nnpkg} name may be changed to realpath if you use symbolic-link.")
-    ("shape_compile", po::value<std::string>()->default_value("[]"),
+    ("shape_prepare", po::value<std::string>()->default_value("[]"),
          "set shape of specified tensor before compilation\n"
          "e.g. '[0, [1, 2], 2, []]' to set 0th tensor to [1, 2] and 2nd tensor to [].\n")
-    ("shape_exec", po::value<std::string>()->default_value("[]"),
-         "set shape of specified tensor right before execution\n"
+    ("shape_run", po::value<std::string>()->default_value("[]"),
+         "set shape of specified tensor right before running\n"
          "e.g. '[1, [1, 2]]` to set 1st tensor to [1, 2].\n")
 
     ;
@@ -262,30 +262,30 @@ void Args::Parse(const int argc, char **argv)
     _write_report = vm["write_report"].as<bool>();
   }
 
-  if (vm.count("shape_compile"))
+  if (vm.count("shape_prepare"))
   {
-    auto shape_str = vm["shape_compile"].as<std::string>();
+    auto shape_str = vm["shape_prepare"].as<std::string>();
     try
     {
-      handleShapeParam(_shape_compile, shape_str);
+      handleShapeParam(_shape_prepare, shape_str);
     }
     catch (const std::exception &e)
     {
-      std::cerr << "error with '--shape_compile' option: " << shape_str << std::endl;
+      std::cerr << "error with '--shape_prepare' option: " << shape_str << std::endl;
       exit(1);
     }
   }
 
-  if (vm.count("shape_exec"))
+  if (vm.count("shape_run"))
   {
-    auto shape_str = vm["shape_exec"].as<std::string>();
+    auto shape_str = vm["shape_run"].as<std::string>();
     try
     {
-      handleShapeParam(_shape_exec, shape_str);
+      handleShapeParam(_shape_run, shape_str);
     }
     catch (const std::exception &e)
     {
-      std::cerr << "error with '--shape_exec' option: " << shape_str << std::endl;
+      std::cerr << "error with '--shape_run' option: " << shape_str << std::endl;
       exit(1);
     }
   }

--- a/tests/tools/nnpackage_run/src/args.cc
+++ b/tests/tools/nnpackage_run/src/args.cc
@@ -54,6 +54,44 @@ std::unordered_map<uint32_t, Json::Value> argArrayToMap(const Json::Value &jsonv
   return ret;
 }
 
+// param shape_str is a form of, e.g., "[1, [2, 3], 3, []"
+void handleShapeParam(nnpkg_run::TensorShapeMap &shape_map, const std::string &shape_str)
+{
+  Json::Value root;
+  Json::Reader reader;
+  if (!reader.parse(shape_str, root, false))
+  {
+    std::cerr << "Invalid JSON format for output_sizes \"" << shape_str << "\"\n";
+    exit(1);
+  }
+
+  auto arg_map = argArrayToMap(root);
+  for (auto &pair : arg_map)
+  {
+    uint32_t key = pair.first;
+    Json::Value &shape_json = pair.second;
+    if (!shape_json.isArray())
+    {
+      std::cerr << "All the values must be list: " << shape_str << "\n";
+      exit(1);
+    }
+
+    std::vector<int> shape;
+    for (auto &dim_json : shape_json)
+    {
+      if (!dim_json.isUInt())
+      {
+        std::cerr << "All the dims should be dim >= 0: " << shape_str << "\n";
+        exit(1);
+      }
+
+      shape.emplace_back(dim_json.asUInt64());
+    }
+
+    shape_map[key] = shape;
+  }
+}
+
 } // namespace
 
 namespace nnpkg_run
@@ -92,6 +130,13 @@ void Args::Initialize(void)
          "{exec}-{nnpkg}-{backend}.csv will be generated.\n"
          "e.g. nnpackage_run-UNIT_Add_000-acl_cl.csv.\n"
          "{nnpkg} name may be changed to realpath if you use symbolic-link.")
+    ("shape_compile", po::value<std::string>()->default_value("[]"),
+         "set shape of specified tensor before compilation\n"
+         "e.g. '[0, [1, 2], 2, []]' to set 0th tensor to [1, 2] and 2nd tensor to [].\n")
+    ("shape_exec", po::value<std::string>()->default_value("[]"),
+         "set shape of specified tensor right before execution\n"
+         "e.g. '[1, [1, 2]]` to set 1st tensor to [1, 2].\n")
+
     ;
   // clang-format on
 
@@ -215,6 +260,34 @@ void Args::Parse(const int argc, char **argv)
   if (vm.count("write_report"))
   {
     _write_report = vm["write_report"].as<bool>();
+  }
+
+  if (vm.count("shape_compile"))
+  {
+    auto shape_str = vm["shape_compile"].as<std::string>();
+    try
+    {
+      handleShapeParam(_shape_compile, shape_str);
+    }
+    catch (const std::exception &e)
+    {
+      std::cerr << "error with '--shape_compile' option: " << shape_str << std::endl;
+      exit(1);
+    }
+  }
+
+  if (vm.count("shape_exec"))
+  {
+    auto shape_str = vm["shape_exec"].as<std::string>();
+    try
+    {
+      handleShapeParam(_shape_exec, shape_str);
+    }
+    catch (const std::exception &e)
+    {
+      std::cerr << "error with '--shape_exec' option: " << shape_str << std::endl;
+      exit(1);
+    }
   }
 }
 

--- a/tests/tools/nnpackage_run/src/args.cc
+++ b/tests/tools/nnpackage_run/src/args.cc
@@ -54,7 +54,7 @@ std::unordered_map<uint32_t, Json::Value> argArrayToMap(const Json::Value &jsonv
   return ret;
 }
 
-// param shape_str is a form of, e.g., "[1, [2, 3], 3, []"
+// param shape_str is a form of, e.g., "[1, [2, 3], 3, []]"
 void handleShapeParam(nnpkg_run::TensorShapeMap &shape_map, const std::string &shape_str)
 {
   Json::Value root;

--- a/tests/tools/nnpackage_run/src/args.h
+++ b/tests/tools/nnpackage_run/src/args.h
@@ -19,12 +19,15 @@
 
 #include <string>
 #include <unordered_map>
+#include <vector>
 #include <boost/program_options.hpp>
 
 namespace po = boost::program_options;
 
 namespace nnpkg_run
 {
+
+using TensorShapeMap = std::unordered_map<int, std::vector<int>>;
 
 class Args
 {
@@ -44,6 +47,8 @@ public:
   const bool getMemoryPoll(void) const { return _mem_poll; }
   const bool getWriteReport(void) const { return _write_report; }
   const bool printVersion(void) const { return _print_version; }
+  const TensorShapeMap &getComillationShapeMap() { return _shape_compile; }
+  const TensorShapeMap &getExecShapeMap() { return _shape_exec; }
 
 private:
   void Initialize();
@@ -58,6 +63,8 @@ private:
   std::string _dump_filename;
   std::string _load_filename;
 #endif
+  TensorShapeMap _shape_compile;
+  TensorShapeMap _shape_exec;
   int _num_runs;
   int _warmup_runs;
   std::unordered_map<uint32_t, uint32_t> _output_sizes;

--- a/tests/tools/nnpackage_run/src/args.h
+++ b/tests/tools/nnpackage_run/src/args.h
@@ -27,7 +27,7 @@ namespace po = boost::program_options;
 namespace nnpkg_run
 {
 
-using TensorShapeMap = std::unordered_map<int, std::vector<int>>;
+using TensorShapeMap = std::unordered_map<uint32_t, std::vector<int>>;
 
 class Args
 {
@@ -47,8 +47,8 @@ public:
   const bool getMemoryPoll(void) const { return _mem_poll; }
   const bool getWriteReport(void) const { return _write_report; }
   const bool printVersion(void) const { return _print_version; }
-  const TensorShapeMap &getComillationShapeMap() { return _shape_compile; }
-  const TensorShapeMap &getExecShapeMap() { return _shape_exec; }
+  const TensorShapeMap &getShapeMapForPrepare() { return _shape_prepare; }
+  const TensorShapeMap &getShapeMapForRun() { return _shape_run; }
 
 private:
   void Initialize();
@@ -63,8 +63,8 @@ private:
   std::string _dump_filename;
   std::string _load_filename;
 #endif
-  TensorShapeMap _shape_compile;
-  TensorShapeMap _shape_exec;
+  TensorShapeMap _shape_prepare;
+  TensorShapeMap _shape_run;
   int _num_runs;
   int _warmup_runs;
   std::unordered_map<uint32_t, uint32_t> _output_sizes;

--- a/tests/tools/nnpackage_run/src/nnpackage_run.cc
+++ b/tests/tools/nnpackage_run/src/nnpackage_run.cc
@@ -159,7 +159,7 @@ int main(const int argc, char **argv)
   verifyOutputTypes();
 
   // set input shape before compilation
-  setTensorInfo(args.getComillationShapeMap());
+  setTensorInfo(args.getShapeMapForPrepare());
 
   // prepare execution
 
@@ -169,7 +169,7 @@ int main(const int argc, char **argv)
   });
 
   // set input shape after compilation and before execution
-  setTensorInfo(args.getExecShapeMap());
+  setTensorInfo(args.getShapeMapForRun());
 
   // prepare input
   std::vector<Allocation> inputs(num_inputs);


### PR DESCRIPTION
This makes nnpakcage_run receive new tensor shapes to call nnfw_set_input_tensorinfo().

To run some model, calling nnfw_set_input_tensorinfo() is required.

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>