### PR TITLE
[onert] Support new_shape option for reshape opration

### DIFF
--- a/runtime/onert/core/include/ir/operation/Reshape.h
+++ b/runtime/onert/core/include/ir/operation/Reshape.h
@@ -37,12 +37,22 @@ public:
     SHAPE = 1
   };
 
+  struct Param
+  {
+    std::vector<int32_t> new_shape;
+  };
+
 public:
-  Reshape(const OperandIndexSequence &inputs, const OperandIndexSequence &outputs);
+  Reshape(const OperandIndexSequence &inputs, const OperandIndexSequence &outputs,
+          const Param &param);
 
 public:
   void accept(OperationVisitor &v) const override;
   OpCode opcode() const final { return OpCode::Reshape; }
+  const Param &param() const { return _param; }
+
+private:
+  Param _param;
 };
 
 } // namespace operation

--- a/runtime/onert/core/src/ir/operation/Reshape.cc
+++ b/runtime/onert/core/src/ir/operation/Reshape.cc
@@ -29,8 +29,9 @@ namespace operation
 
 void Reshape::accept(OperationVisitor &v) const { v.visit(*this); }
 
-Reshape::Reshape(const OperandIndexSequence &inputs, const OperandIndexSequence &outputs)
-    : Operation{OperandConstraint::createExact(1u), inputs, outputs}
+Reshape::Reshape(const OperandIndexSequence &inputs, const OperandIndexSequence &outputs,
+                 const Param &param)
+    : Operation{OperandConstraint::createExact(2u), inputs, outputs}, _param(param)
 {
 }
 

--- a/runtime/onert/frontend/base_loader/include/base_loader.h
+++ b/runtime/onert/frontend/base_loader/include/base_loader.h
@@ -482,10 +482,21 @@ void BaseLoader<LoaderDomain, SpecificLoader>::loadReshape(const Operator *op, i
 
   loadOperationIO(op, inputs, outputs);
 
-  // const auto *options = op->builtin_options_as_ReshapeOptions();
-  // No params
+  ir::operation::Reshape::Param param{};
+  const auto *options = op->builtin_options_as_ReshapeOptions();
+  if (options != nullptr)
+  {
+    const auto *new_shape = options->new_shape();
+    if (new_shape)
+    {
+      for (uint i = 0; i < new_shape->Length(); ++i)
+      {
+        param.new_shape.push_back(new_shape->Get(i));
+      }
+    }
+  }
 
-  std::unique_ptr<ir::Operation> new_op(new ir::operation::Reshape(inputs, outputs));
+  std::unique_ptr<ir::Operation> new_op(new ir::operation::Reshape(inputs, outputs, param));
   subg.addOperation(std::move(new_op));
 }
 

--- a/runtime/onert/frontend/nnapi/wrapper/OperationFactory.cc
+++ b/runtime/onert/frontend/nnapi/wrapper/OperationFactory.cc
@@ -365,7 +365,9 @@ OperationFactory::OperationFactory()
     OperandIndexSequence inputs{init_param.inputs[0], init_param.inputs[1]};
     OperandIndexSequence outputs{init_param.outputs[0]};
 
-    return new operation::Reshape{inputs, outputs};
+    operation::Reshape::Param param{};
+
+    return new operation::Reshape{inputs, outputs, param};
   };
 
   _map[ANEURALNETWORKS_FULLY_CONNECTED] = [](const OperationFactory::Param &init_param,


### PR DESCRIPTION
This commit supports new_shape option for reshape opration
- Add `new_shape` param in reshape IR
- Read `new_shape` option in base_loader

ONE-DCO-1.0-Signed-off-by: JiHwan Yeo <jihwan.yeo@samsung.com>

---

For issue : #2393