### PR TITLE
[onert] Use CompilerOptions in set_op_backend

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -22,6 +22,7 @@
 #include "circle_loader.h"
 #include "tflite_loader.h"
 #include "json/json.h"
+#include "ir/OpCode.h"
 #include <fstream>
 #include <iostream>
 #include <string>
@@ -567,6 +568,9 @@ NNFW_STATUS nnfw_session::set_available_backends(const char *backends)
 
 NNFW_STATUS nnfw_session::set_op_backend(const char *op, const char *backend)
 {
+  if (!isStateModelLoaded())
+    return NNFW_STATUS_ERROR;
+
   try
   {
     if (!op || !null_terminating(op, MAX_OP_NAME_LENGTH) || !backend ||
@@ -582,7 +586,8 @@ NNFW_STATUS nnfw_session::set_op_backend(const char *op, const char *backend)
       return NNFW_STATUS_ERROR;
     }
 
-    _source->set(key, backend);
+    auto &opcode_to_backend = _compiler->options().manual_scheduler_options.opcode_to_backend;
+    opcode_to_backend.emplace(onert::ir::toOpCode(op), backend);
   }
   catch (const std::exception &e)
   {

--- a/runtime/onert/core/include/ir/OpCode.h
+++ b/runtime/onert/core/include/ir/OpCode.h
@@ -35,6 +35,7 @@ enum class OpCode
 };
 
 const char *toString(OpCode opcode);
+OpCode toOpCode(const std::string str);
 
 } // namespace ir
 } // namespace onert

--- a/runtime/onert/core/src/ir/OpCode.cc
+++ b/runtime/onert/core/src/ir/OpCode.cc
@@ -33,5 +33,15 @@ const char *toString(OpCode opcode)
   return map.at(opcode);
 }
 
+OpCode toOpCode(const std::string str)
+{
+  static const std::unordered_map<std::string, OpCode> map{
+#define OP(Name) {#Name, OpCode::Name},
+#include "ir/Operations.lst"
+#undef OP
+  };
+  return map.at(str);
+}
+
 } // namespace ir
 } // namespace onert


### PR DESCRIPTION
Use CompilerOptions in set_op_backend rather than ConfigSource.
ConfigSource is affected globally, not just for this session.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>