### PR TITLE
[onert] Remove TODO comment in ManualScheduler

### DIFF
--- a/runtime/onert/core/src/compiler/ManualScheduler.cc
+++ b/runtime/onert/core/src/compiler/ManualScheduler.cc
@@ -65,9 +65,7 @@ std::unique_ptr<BackendResolver> ManualScheduler::schedule(const ir::Graph &grap
   std::unordered_map<ir::OpCode, backend::Backend *> op_type_map;
   for (auto &pair : manual_options.opcode_to_backend)
   {
-    op_type_map.emplace(
-        pair.first, BackendManager::get().get(
-                        pair.second)); // TODO Ensure this backend is available in backend contexts
+    op_type_map.emplace(pair.first, BackendManager::get().get(pair.second));
   }
   // By default, Custom uses cpu backend
   op_type_map[ir::OpCode::Custom] = BackendManager::get().get("cpu");


### PR DESCRIPTION
Remove TODO comment "Ensure this backend is available in backend
contexts" which has been done from #1413.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>