### PR TITLE
[onert] Remove rank from params of ir for operations

### DIFF
--- a/runtime/onert/backend/acl_neon/KernelGenerator.cc
+++ b/runtime/onert/backend/acl_neon/KernelGenerator.cc
@@ -92,7 +92,7 @@ void KernelGenerator::visit(const ir::operation::ArgMax &node)
   const auto ofm_index{node.getOutputs().at(0)};
   const auto ifm_index{node.getInputs().at(ir::operation::ArgMax::Input::INPUT)};
 
-  const auto ifm_rank = node.param().rank;
+  const auto ifm_rank = _ctx.at(ifm_index).shape().rank();
 
   auto ofm_alloc = _tensor_builder->at(ofm_index).get();
   auto ifm_alloc = _tensor_builder->at(ifm_index).get();
@@ -332,7 +332,7 @@ void KernelGenerator::visit(const ir::operation::Mean &node)
 
   // Convert to ACL axes taking into account negative values and possible duplicates.
   std::set<std::uint32_t> acl_axes;
-  const int ifm_rank = node.param().rank;
+  const int ifm_rank = _ctx.at(ifm_index).shape().rank();
   for (int axis : axes)
   {
     if (axis < 0)
@@ -436,7 +436,7 @@ void KernelGenerator::visit(const ir::operation::Concat &node)
   else
   {
     auto l = std::make_unique<::arm_compute::NEConcatenateLayer>();
-    const auto rank = node.param().rank;
+    const auto rank = _ctx.at(ofm_index).shape().rank();
     const auto frontend_layout = _current_op_seq_layout;
     const auto backend_layout = output_alloc->layout();
     const auto fixed_axis =
@@ -593,9 +593,7 @@ void KernelGenerator::visit(const ir::operation::Gather &node)
   const auto ifm_index{node.getInputs().at(ir::operation::Gather::Input::INPUT)};
   const auto indices_index{node.getInputs().at(ir::operation::Gather::Input::INDICES)};
 
-  const auto ifm_shape = _ctx.at(ifm_index).shape();
-
-  const auto ifm_rank = node.param().rank;
+  const auto ifm_rank = _ctx.at(ifm_index).shape().rank();
   const auto axis_raw = node.param().axis;
   const auto axis_value = (axis_raw < 0 ? (ifm_rank + axis_raw) : axis_raw);
   // Converting in reverse order
@@ -663,7 +661,7 @@ void KernelGenerator::visit(const ir::operation::L2Normalization &node)
 
   const auto &ifm_shape = _ctx.at(ifm_index).shape();
   // TODO Support optional constant dimension that normalization would be performed on
-  const auto normalization_axis = node.param().rank - 1;
+  const auto normalization_axis = _ctx.at(ifm_index).shape().rank() - 1;
   int32_t radius =
       2 * ifm_shape.dim(normalization_axis) + 1; // normSize = depth(last dimension) * 2 + 1
   float alpha = 1.0f;                            // In the implementation to make alpha_ become 1
@@ -1020,7 +1018,7 @@ void KernelGenerator::visit(const ir::operation::Pack &node)
   const auto output_index{node.getOutputs().at(0)};
   auto axis{node.param().axis};
 
-  const auto output_rank = node.param().rank;
+  const auto output_rank = _ctx.at(output_index).shape().rank();
 
   std::vector<ir::OperandIndex> input_indexes;
   for (const auto &input_index : node.getInputs())
@@ -1052,7 +1050,7 @@ void KernelGenerator::visit(const ir::operation::Pad &node)
   const auto output_index{node.getOutputs().at(0)};
   assert(_ctx.at(pad_index).data());
 
-  auto rank = node.param().rank;
+  auto rank = _ctx.at(input_index).shape().rank();
   auto pad_base = _ctx.at(pad_index).data()->base();
 
   auto input = _tensor_builder->at(input_index).get()->handle();
@@ -1169,7 +1167,7 @@ void KernelGenerator::visit(const ir::operation::ReduceMax &node)
 
   // Convert to ACL axes taking into account negative values and possible duplicates.
   std::set<std::uint32_t> acl_axes;
-  const int ifm_rank = node.param().rank;
+  const int ifm_rank = _ctx.at(ifm_index).shape().rank();
   for (int axis : axes)
   {
     if (axis < 0)
@@ -1207,7 +1205,7 @@ void KernelGenerator::visit(const ir::operation::ReduceMin &node)
 
   // Convert to ACL axes taking into account negative values and possible duplicates.
   std::set<std::uint32_t> acl_axes;
-  const int ifm_rank = node.param().rank;
+  const int ifm_rank = _ctx.at(ifm_index).shape().rank();
   for (int axis : axes)
   {
     if (axis < 0)
@@ -1245,7 +1243,7 @@ void KernelGenerator::visit(const ir::operation::ReduceSum &node)
 
   // Convert to ACL axes taking into account negative values and possible duplicates.
   std::set<std::uint32_t> acl_axes;
-  const int input_rank = node.param().rank;
+  const int input_rank = _ctx.at(input_index).shape().rank();
   for (int axis : axes)
   {
     if (axis < 0)
@@ -1540,7 +1538,7 @@ void KernelGenerator::visit(const ir::operation::Split &node)
 
   assert(node.param().num_splits == static_cast<int>(node.getOutputs().size()));
 
-  const auto ifm_rank = node.param().rank;
+  const auto ifm_rank = _ctx.at(ifm_index).shape().rank();
   std::vector<ir::OperandIndex> output_indexes;
   for (const auto &output : node.getOutputs())
     output_indexes.emplace_back(output);
@@ -1637,7 +1635,7 @@ void KernelGenerator::visit(const ir::operation::Slice &node)
   const auto backend_layout = inputData_alloc->layout();
 
   // Set initializers for indices data such as order of inputData
-  int input_rank = node.param().rank;
+  int input_rank = _ctx.at(input_index).shape().rank();
   std::vector<int32_t> starts;
   std::vector<int32_t> ends;
   starts.resize(input_rank, 0);
@@ -1832,7 +1830,7 @@ void KernelGenerator::visit(const ir::operation::Transpose &node)
   const auto frontend_layout = _current_op_seq_layout;
   const auto backend_layout = ifm_alloc->layout();
 
-  const auto rank = node.param().rank;
+  const auto rank = _ctx.at(ifm_idx).shape().rank();
   std::vector<std::int32_t> pv(perm.cbegin(), perm.cend());
   auto backend_pv = ::onert::backend::acl_common::getARMComputePermutationVector(
       rank, pv, frontend_layout, backend_layout);
@@ -1866,7 +1864,7 @@ void KernelGenerator::visit(const ir::operation::Unpack &node)
   const auto input_index{node.getInputs().at(ir::operation::Unpack::Input::INPUT)};
   auto axis{node.param().axis};
 
-  const auto input_rank = node.param().rank;
+  const auto input_rank = _ctx.at(input_index).shape().rank();
 
   std::vector<ir::OperandIndex> output_indexes;
   for (const auto &output_index : node.getOutputs())

--- a/runtime/onert/backend/cpu/ops/TransposeLayer.cc
+++ b/runtime/onert/backend/cpu/ops/TransposeLayer.cc
@@ -29,7 +29,7 @@ namespace cpu
 namespace ops
 {
 
-TransposeLayer::TransposeLayer() : _input(nullptr), _output(nullptr), _perm(), _rank(0)
+TransposeLayer::TransposeLayer() : _input(nullptr), _output(nullptr), _perm()
 {
   // DO NOTHING
 }
@@ -37,8 +37,8 @@ TransposeLayer::TransposeLayer() : _input(nullptr), _output(nullptr), _perm(), _
 void TransposeLayer::transposeFloat32()
 {
   nnfw::cker::TransposeParams param;
-  param.perm_count = _rank;
-  for (int32_t i = 0; i < _rank; i++)
+  param.perm_count = _perm.size();
+  for (size_t i = 0; i < _perm.size(); i++)
   {
     param.perm[i] = _perm[i];
   }
@@ -54,11 +54,9 @@ void TransposeLayer::transposeQuant8()
   throw std::runtime_error{"NYI"};
 }
 
-void TransposeLayer::configure(const Tensor *input, Tensor *output, const std::vector<int> &perm,
-                               int32_t rank)
+void TransposeLayer::configure(const Tensor *input, Tensor *output, const std::vector<int> &perm)
 {
   _input = input;
-  _rank = rank;
   _perm = perm;
   _output = output;
 }

--- a/runtime/onert/backend/cpu/ops/TransposeLayer.h
+++ b/runtime/onert/backend/cpu/ops/TransposeLayer.h
@@ -40,7 +40,7 @@ public:
 
   void transposeQuant8();
 
-  void configure(const Tensor *input, Tensor *output, const std::vector<int> &perm, int32_t rank);
+  void configure(const Tensor *input, Tensor *output, const std::vector<int> &perm);
 
   void run();
 
@@ -48,7 +48,6 @@ private:
   const Tensor *_input;
   Tensor *_output;
   std::vector<int> _perm;
-  int32_t _rank;
 };
 
 } // namespace ops

--- a/runtime/onert/core/include/ir/operation/ArgMax.h
+++ b/runtime/onert/core/include/ir/operation/ArgMax.h
@@ -37,7 +37,6 @@ public:
   struct Param
   {
     int axis;
-    int rank;
     DataType output_type;
   };
 

--- a/runtime/onert/core/include/ir/operation/Concat.h
+++ b/runtime/onert/core/include/ir/operation/Concat.h
@@ -34,7 +34,6 @@ public:
   struct Param
   {
     int32_t axis;
-    int32_t rank;
   };
 
 public:

--- a/runtime/onert/core/include/ir/operation/Gather.h
+++ b/runtime/onert/core/include/ir/operation/Gather.h
@@ -40,7 +40,6 @@ public:
   struct Param
   {
     int32_t axis;
-    int32_t rank;
   };
 
 public:

--- a/runtime/onert/core/include/ir/operation/L2Normalization.h
+++ b/runtime/onert/core/include/ir/operation/L2Normalization.h
@@ -35,24 +35,11 @@ public:
   };
 
 public:
-  struct Param
-  {
-    int32_t rank;
-  };
-
-public:
-  L2Normalization(const OperandIndexSequence &inputs, const OperandIndexSequence &outputs,
-                  const Param &param);
+  L2Normalization(const OperandIndexSequence &inputs, const OperandIndexSequence &outputs);
 
 public:
   void accept(OperationVisitor &v) const override;
   OpCode opcode() const final { return OpCode::L2Normalization; }
-
-public:
-  const Param &param() const { return _param; }
-
-private:
-  Param _param;
 };
 
 } // namespace operation

--- a/runtime/onert/core/include/ir/operation/Mean.h
+++ b/runtime/onert/core/include/ir/operation/Mean.h
@@ -38,7 +38,6 @@ public:
   {
     std::vector<int> axes;
     bool keep_dims;
-    int32_t rank;
   };
 
 public:

--- a/runtime/onert/core/include/ir/operation/Pack.h
+++ b/runtime/onert/core/include/ir/operation/Pack.h
@@ -31,7 +31,6 @@ public:
   {
     int32_t num;
     int32_t axis;
-    int32_t rank;
   };
 
 public:

--- a/runtime/onert/core/include/ir/operation/Pad.h
+++ b/runtime/onert/core/include/ir/operation/Pad.h
@@ -37,23 +37,11 @@ public:
   };
 
 public:
-  struct Param
-  {
-    int32_t rank;
-  };
-
-public:
-  Pad(const OperandIndexSequence &inputs, const OperandIndexSequence &outputs, const Param &param);
+  Pad(const OperandIndexSequence &inputs, const OperandIndexSequence &outputs);
 
 public:
   void accept(OperationVisitor &v) const override;
   OpCode opcode() const final { return OpCode::Pad; }
-
-public:
-  const Param &param() const { return _param; }
-
-private:
-  Param _param;
 };
 
 } // namespace operation

--- a/runtime/onert/core/include/ir/operation/ReduceAll.h
+++ b/runtime/onert/core/include/ir/operation/ReduceAll.h
@@ -40,7 +40,6 @@ public:
   {
     std::vector<int> axes;
     bool keep_dims;
-    int32_t rank;
   };
 
 public:

--- a/runtime/onert/core/include/ir/operation/ReduceAny.h
+++ b/runtime/onert/core/include/ir/operation/ReduceAny.h
@@ -40,7 +40,6 @@ public:
   {
     std::vector<int> axes;
     bool keep_dims;
-    int32_t rank;
   };
 
 public:

--- a/runtime/onert/core/include/ir/operation/ReduceMax.h
+++ b/runtime/onert/core/include/ir/operation/ReduceMax.h
@@ -40,7 +40,6 @@ public:
   {
     std::vector<int> axes;
     bool keep_dims;
-    int32_t rank;
   };
 
 public:

--- a/runtime/onert/core/include/ir/operation/ReduceMin.h
+++ b/runtime/onert/core/include/ir/operation/ReduceMin.h
@@ -40,7 +40,6 @@ public:
   {
     std::vector<int> axes;
     bool keep_dims;
-    int32_t rank;
   };
 
 public:

--- a/runtime/onert/core/include/ir/operation/ReduceProd.h
+++ b/runtime/onert/core/include/ir/operation/ReduceProd.h
@@ -40,7 +40,6 @@ public:
   {
     std::vector<int> axes;
     bool keep_dims;
-    int32_t rank;
   };
 
 public:

--- a/runtime/onert/core/include/ir/operation/ReduceSum.h
+++ b/runtime/onert/core/include/ir/operation/ReduceSum.h
@@ -38,7 +38,6 @@ public:
   {
     std::vector<int> axes;
     bool keep_dims;
-    int32_t rank;
   };
 
 public:

--- a/runtime/onert/core/include/ir/operation/Slice.h
+++ b/runtime/onert/core/include/ir/operation/Slice.h
@@ -37,24 +37,11 @@ public:
   };
 
 public:
-  struct Param
-  {
-    int32_t rank;
-  };
-
-public:
-  Slice(const OperandIndexSequence &inputs, const OperandIndexSequence &outputs,
-        const Param &param);
+  Slice(const OperandIndexSequence &inputs, const OperandIndexSequence &outputs);
 
 public:
   void accept(OperationVisitor &v) const override;
   OpCode opcode() const final { return OpCode::Slice; }
-
-public:
-  const Param &param() const { return _param; }
-
-private:
-  Param _param;
 };
 
 } // namespace operation

--- a/runtime/onert/core/include/ir/operation/Split.h
+++ b/runtime/onert/core/include/ir/operation/Split.h
@@ -36,7 +36,6 @@ public:
   {
     int axis;
     int num_splits;
-    int rank;
   };
 
 public:

--- a/runtime/onert/core/include/ir/operation/Transpose.h
+++ b/runtime/onert/core/include/ir/operation/Transpose.h
@@ -39,7 +39,6 @@ public:
   struct Param
   {
     std::vector<int> perm;
-    int32_t rank;
   };
 
 public:

--- a/runtime/onert/core/include/ir/operation/Unpack.h
+++ b/runtime/onert/core/include/ir/operation/Unpack.h
@@ -36,7 +36,6 @@ public:
   {
     int32_t num;
     int32_t axis;
-    int32_t rank;
   };
 
 public:

--- a/runtime/onert/core/src/compiler/OperationValidator.cc
+++ b/runtime/onert/core/src/compiler/OperationValidator.cc
@@ -1074,9 +1074,9 @@ void OperationValidator::visit(const ir::operation::Split &node)
   if (_ctx.at(input_index).info().isDynamic())
     return;
 
-  const auto &num_splits = node.param().num_splits;
-  const auto &input_rank = node.param().rank;
-  const auto &axis = node.param().axis < 0 ? node.param().axis + input_rank : node.param().axis;
+  const auto num_splits = node.param().num_splits;
+  const auto input_rank = _ctx.at(input_index).shape().rank();
+  const auto axis = node.param().axis < 0 ? node.param().axis + input_rank : node.param().axis;
 
   OP_REQUIRES(num_splits > 0 && num_splits <= 0xFFFF);
   OP_REQUIRES(axis >= 0 && axis < input_rank);

--- a/runtime/onert/core/src/ir/operation/L2Normalization.cc
+++ b/runtime/onert/core/src/ir/operation/L2Normalization.cc
@@ -30,8 +30,8 @@ namespace operation
 void L2Normalization::accept(OperationVisitor &v) const { v.visit(*this); }
 
 L2Normalization::L2Normalization(const OperandIndexSequence &inputs,
-                                 const OperandIndexSequence &outputs, const Param &param)
-    : Operation{OperandConstraint::createExact(1u), inputs, outputs}, _param{param}
+                                 const OperandIndexSequence &outputs)
+    : Operation{OperandConstraint::createExact(1u), inputs, outputs}
 {
 }
 

--- a/runtime/onert/core/src/ir/operation/Pad.cc
+++ b/runtime/onert/core/src/ir/operation/Pad.cc
@@ -27,9 +27,8 @@ namespace operation
 
 void Pad::accept(OperationVisitor &v) const { v.visit(*this); }
 
-Pad::Pad(const OperandIndexSequence &inputs, const OperandIndexSequence &outputs,
-         const Param &param)
-    : Operation{OperandConstraint::createExact(2u), inputs, outputs}, _param{param}
+Pad::Pad(const OperandIndexSequence &inputs, const OperandIndexSequence &outputs)
+    : Operation{OperandConstraint::createExact(2u), inputs, outputs}
 {
 }
 

--- a/runtime/onert/core/src/ir/operation/Slice.cc
+++ b/runtime/onert/core/src/ir/operation/Slice.cc
@@ -26,9 +26,8 @@ namespace operation
 
 void Slice::accept(OperationVisitor &v) const { v.visit(*this); }
 
-Slice::Slice(const OperandIndexSequence &inputs, const OperandIndexSequence &outputs,
-             const Param &param)
-    : Operation{OperandConstraint::createExact(3u), inputs, outputs}, _param{param}
+Slice::Slice(const OperandIndexSequence &inputs, const OperandIndexSequence &outputs)
+    : Operation{OperandConstraint::createExact(3u), inputs, outputs}
 {
 }
 

--- a/runtime/onert/core/src/util/shapeinf/Slice.cc
+++ b/runtime/onert/core/src/util/shapeinf/Slice.cc
@@ -24,9 +24,9 @@ namespace onert
 namespace shape_inference
 {
 
-ir::Shape inferSliceShape(const ir::Shape &input_shape, const int32_t *begins, const int32_t *sizes,
-                          uint32_t rank)
+ir::Shape inferSliceShape(const ir::Shape &input_shape, const int32_t *begins, const int32_t *sizes)
 {
+  const uint32_t rank = input_shape.rank();
   ir::Shape out_shape(rank);
 
   for (uint32_t idx = 0; idx < rank; ++idx)
@@ -84,9 +84,8 @@ void StaticInferer::visit(const ir::operation::Slice &op)
 
   auto begins_buf = reinterpret_cast<const int32_t *>(begins.data()->base());
   auto sizes_buf = reinterpret_cast<const int32_t *>(sizes.data()->base());
-  const auto rank = op.param().rank;
 
-  ir::Shape new_shape = inferSliceShape(input.info().shape(), begins_buf, sizes_buf, rank);
+  ir::Shape new_shape = inferSliceShape(input.info().shape(), begins_buf, sizes_buf);
   output.info().shape(new_shape);
 }
 
@@ -109,10 +108,8 @@ void DynamicInferer::visit(const ir::operation::Slice &op)
   ir::Shape input_shape = input->getShape();
   auto begins_buf = reinterpret_cast<const int32_t *>(begins->buffer());
   auto sizes_buf = reinterpret_cast<const int32_t *>(sizes->buffer());
-  const auto rank = input_shape.rank();
 
-  ir::Shape new_shape =
-      onert::shape_inference::inferSliceShape(input_shape, begins_buf, sizes_buf, rank);
+  ir::Shape new_shape = onert::shape_inference::inferSliceShape(input_shape, begins_buf, sizes_buf);
 
   _dynamic_tensor_manager->applyShape(output_index, new_shape);
   assert(output->buffer() != nullptr);

--- a/runtime/onert/core/src/util/shapeinf/Unpack.cc
+++ b/runtime/onert/core/src/util/shapeinf/Unpack.cc
@@ -55,10 +55,22 @@ void StaticInferer::visit(const ir::operation::Unpack &op)
     return;
   }
 
-  const auto rank = op.param().rank;
+  const auto rank = input.shape().rank();
   const auto axis = ((op.param().axis < 0) ? rank + op.param().axis : op.param().axis);
 
-  assert(0 <= axis && axis < rank);
+  assert(axis < rank);
+  if (axis < 0)
+  {
+    for (int out_tensor_idx = 0; out_tensor_idx < num; out_tensor_idx++)
+    {
+      const auto output_idx = op.getOutputs().at(out_tensor_idx);
+      ir::Operand &output = _operands.at(output_idx);
+      output.info().setDynamic();
+    }
+
+    return;
+  }
+
   ir::Shape new_shape = unpackShapes(input.info().shape(), axis, rank);
 
   // re-sizing output shape

--- a/runtime/onert/frontend/base_loader/include/base_loader.h
+++ b/runtime/onert/frontend/base_loader/include/base_loader.h
@@ -560,7 +560,6 @@ void BaseLoader<LoaderDomain, SpecificLoader>::loadConcatenation(const Operator 
   const auto *options = op->builtin_options_as_ConcatenationOptions();
   // Axis
   param.axis = options->axis();
-  param.rank = subg.operands().at(outputs.at(0)).shape().rank();
   // activation unused
 
   std::unique_ptr<ir::Operation> new_op(new ir::operation::Concat(inputs, outputs, param));
@@ -705,7 +704,6 @@ void BaseLoader<LoaderDomain, SpecificLoader>::loadPack(const Operator *op, ir::
   const auto *options = op->builtin_options_as_PackOptions();
   param.num = options->values_count();
   param.axis = options->axis();
-  param.rank = subg.operands().at(outputs.at(0)).shape().rank();
 
   std::unique_ptr<ir::Operation> new_op(new ir::operation::Pack(inputs, outputs, param));
   subg.addOperation(std::move(new_op));
@@ -836,7 +834,6 @@ void BaseLoader<LoaderDomain, SpecificLoader>::loadTranspose(const Operator *op,
 
   ir::operation::Transpose::Param param;
   param.perm = subg.operands().at(perm).template asVector<int>();
-  param.rank = subg.operands().at(inputs.at(0)).shape().rank();
 
   std::unique_ptr<ir::Operation> new_op(new ir::operation::Transpose({input}, outputs, param));
   subg.addOperation(std::move(new_op));
@@ -858,7 +855,6 @@ void BaseLoader<LoaderDomain, SpecificLoader>::loadMean(const Operator *op, ir::
   ir::operation::Mean::Param param;
   param.axes = subg.operands().at(axes).template asVector<int>();
   param.keep_dims = op->builtin_options_as_ReducerOptions()->keep_dims();
-  param.rank = subg.operands().at(inputs.at(0)).shape().rank();
 
   std::unique_ptr<ir::Operation> new_op(new ir::operation::Mean({input}, outputs, param));
   subg.addOperation(std::move(new_op));
@@ -880,7 +876,6 @@ void BaseLoader<LoaderDomain, SpecificLoader>::loadReduceAll(const Operator *op,
 
   ir::operation::ReduceAll::Param param;
   param.axes = subg.operands().at(axes).template asVector<int>();
-  param.rank = subg.operands().at(inputs.at(0)).shape().rank();
 
   if (op->custom_options() == nullptr)
   {
@@ -916,7 +911,6 @@ void BaseLoader<LoaderDomain, SpecificLoader>::loadReduceAny(const Operator *op,
   ir::operation::ReduceAny::Param param;
   param.axes = subg.operands().at(axes).template asVector<int>();
   param.keep_dims = op->builtin_options_as_ReducerOptions()->keep_dims();
-  param.rank = subg.operands().at(inputs.at(0)).shape().rank();
 
   std::unique_ptr<ir::Operation> new_op(new ir::operation::ReduceAny({input}, outputs, param));
   subg.addOperation(std::move(new_op));
@@ -939,7 +933,6 @@ void BaseLoader<LoaderDomain, SpecificLoader>::loadReduceMax(const Operator *op,
   ir::operation::ReduceMax::Param param;
   param.axes = subg.operands().at(axes).template asVector<int>();
   param.keep_dims = op->builtin_options_as_ReducerOptions()->keep_dims();
-  param.rank = subg.operands().at(inputs.at(0)).shape().rank();
 
   std::unique_ptr<ir::Operation> new_op(new ir::operation::ReduceMax({input}, outputs, param));
   subg.addOperation(std::move(new_op));
@@ -965,10 +958,7 @@ void BaseLoader<LoaderDomain, SpecificLoader>::loadPad(const Operator *op, ir::G
 
   loadOperationIO(op, inputs, outputs);
 
-  ir::operation::Pad::Param param;
-  param.rank = subg.operands().at(inputs.at(0)).shape().rank();
-
-  std::unique_ptr<ir::Operation> new_op(new ir::operation::Pad(inputs, outputs, param));
+  std::unique_ptr<ir::Operation> new_op(new ir::operation::Pad(inputs, outputs));
   subg.addOperation(std::move(new_op));
 }
 
@@ -1017,7 +1007,6 @@ void BaseLoader<LoaderDomain, SpecificLoader>::loadGather(const Operator *op, ir
   loadOperationIO(op, inputs, outputs);
   ir::operation::Gather::Param param;
   param.axis = op->builtin_options_as_GatherOptions()->axis();
-  param.rank = subg.operands().at(inputs.at(0)).shape().rank();
 
   std::unique_ptr<ir::Operation> new_op(new ir::operation::Gather(inputs, outputs, param));
   subg.addOperation(std::move(new_op));
@@ -1106,7 +1095,6 @@ void BaseLoader<LoaderDomain, SpecificLoader>::loadReduceSum(const Operator *op,
   ir::operation::ReduceSum::Param param;
   param.axes = subg.operands().at(axes).template asVector<int>();
   param.keep_dims = op->builtin_options_as_ReducerOptions()->keep_dims();
-  param.rank = subg.operands().at(inputs.at(0)).shape().rank();
 
   std::unique_ptr<ir::Operation> new_op{new ir::operation::ReduceSum{{input}, outputs, param}};
   subg.addOperation(std::move(new_op));
@@ -1290,7 +1278,6 @@ void BaseLoader<LoaderDomain, SpecificLoader>::loadSplit(const Operator *op, ir:
   param.axis = subg.operands().at(axis).template asScalar<int>();
   const auto *options = op->builtin_options_as_SplitOptions();
   param.num_splits = options->num_splits();
-  param.rank = subg.operands().at(input).shape().rank();
 
   std::unique_ptr<ir::Operation> new_op(new ir::operation::Split({input}, outputs, param));
   subg.addOperation(std::move(new_op));
@@ -1304,10 +1291,7 @@ void BaseLoader<LoaderDomain, SpecificLoader>::loadSlice(const Operator *op, ir:
 
   loadOperationIO(op, inputs, outputs);
 
-  ir::operation::Slice::Param param;
-  param.rank = subg.operands().at(inputs.at(0)).shape().rank();
-
-  std::unique_ptr<ir::Operation> new_op{new ir::operation::Slice{inputs, outputs, param}};
+  std::unique_ptr<ir::Operation> new_op{new ir::operation::Slice{inputs, outputs}};
   subg.addOperation(std::move(new_op));
 }
 
@@ -1342,7 +1326,6 @@ void BaseLoader<LoaderDomain, SpecificLoader>::loadUnpack(const Operator *op, ir
   const auto *options = op->builtin_options_as_UnpackOptions();
   param.num = options->num();
   param.axis = options->axis();
-  param.rank = subg.operands().at(inputs.at(0)).shape().rank();
 
   std::unique_ptr<ir::Operation> new_op(new ir::operation::Unpack(inputs, outputs, param));
   subg.addOperation(std::move(new_op));
@@ -1567,7 +1550,6 @@ void BaseLoader<LoaderDomain, SpecificLoader>::loadReduceProd(const Operator *op
   ir::operation::ReduceProd::Param param;
   param.axes = subg.operands().at(axes).template asVector<int>();
   param.keep_dims = op->builtin_options_as_ReducerOptions()->keep_dims();
-  param.rank = subg.operands().at(inputs.at(0)).shape().rank();
 
   std::unique_ptr<ir::Operation> new_op(new ir::operation::ReduceProd({input}, outputs, param));
   subg.addOperation(std::move(new_op));
@@ -1642,7 +1624,6 @@ void BaseLoader<LoaderDomain, SpecificLoader>::loadArgMax(const Operator *op, ir
 
   ir::operation::ArgMax::Param param;
   param.axis = axisOperand.template asVector<int>()[0];
-  param.rank = inputOperand.shape().rank();
   const auto output_type = op->builtin_options_as_ArgMaxOptions()->output_type();
   switch (output_type)
   {

--- a/runtime/onert/frontend/nnapi/wrapper/OperationFactory.cc
+++ b/runtime/onert/frontend/nnapi/wrapper/OperationFactory.cc
@@ -348,7 +348,6 @@ OperationFactory::OperationFactory()
     operation::Concat::Param param;
     const OperandIndex axis_index{init_param.inputs[init_param.input_count - 1]};
     param.axis = operands.at(axis_index).asScalar<int32_t>();
-    param.rank = operands.at(outputs.at(0)).shape().rank();
 
     return new operation::Concat{inputs, outputs, param};
   };
@@ -546,7 +545,6 @@ OperationFactory::OperationFactory()
     operation::ReduceSum::Param param;
     param.axes.assign(axes.cbegin(), axes.cend());
     param.keep_dims = operands.at(OperandIndex{init_param.inputs[2]}).asScalar<int8_t>() != 0;
-    param.rank = operands.at(inputs.at(0)).shape().rank();
 
     return new operation::ReduceSum{inputs, outputs, param};
   };
@@ -576,7 +574,7 @@ OperationFactory::OperationFactory()
     return new operation::Sub{inputs, outputs, param};
   };
 
-  _map[ANEURALNETWORKS_SLICE] = [](const OperationFactory::Param &init_param, Operands &operands) {
+  _map[ANEURALNETWORKS_SLICE] = [](const OperationFactory::Param &init_param, Operands &) {
     assert(init_param.input_count == 3 && init_param.output_count == 1);
 
     OperandIndexSequence outputs{init_param.outputs[0]};
@@ -588,10 +586,7 @@ OperationFactory::OperationFactory()
     //  2 -> Sizes Tensor Index
     OperandIndexSequence inputs{init_param.inputs[0], init_param.inputs[1], init_param.inputs[2]};
 
-    operation::Slice::Param param;
-    param.rank = operands.at(inputs.at(0)).shape().rank();
-
-    return new operation::Slice{inputs, outputs, param};
+    return new operation::Slice{inputs, outputs};
   };
 
   _map[ANEURALNETWORKS_STRIDED_SLICE] = [](const OperationFactory::Param &init_param,
@@ -656,7 +651,6 @@ OperationFactory::OperationFactory()
 
     operation::Transpose::Param param;
     param.perm.assign(perm.cbegin(), perm.cend());
-    param.rank = perm.size();
 
     return new operation::Transpose{inputs, outputs, param};
   };
@@ -945,7 +939,6 @@ OperationFactory::OperationFactory()
     operation::ReduceAll::Param param;
     param.axes.assign(axes.cbegin(), axes.cend());
     param.keep_dims = operands.at(OperandIndex{init_param.inputs[2]}).asScalar<int8_t>() != 0;
-    param.rank = operands.at(inputs.at(0)).shape().rank();
 
     return new operation::ReduceAll{inputs, outputs, param};
   };
@@ -968,7 +961,6 @@ OperationFactory::OperationFactory()
     operation::ReduceAny::Param param;
     param.axes.assign(axes.cbegin(), axes.cend());
     param.keep_dims = operands.at(OperandIndex{init_param.inputs[2]}).asScalar<int8_t>() != 0;
-    param.rank = operands.at(inputs.at(0)).shape().rank();
 
     return new operation::ReduceAny{inputs, outputs, param};
   };
@@ -991,7 +983,6 @@ OperationFactory::OperationFactory()
     operation::ReduceMax::Param param;
     param.axes.assign(axes.cbegin(), axes.cend());
     param.keep_dims = operands.at(OperandIndex{init_param.inputs[2]}).asScalar<int8_t>() != 0;
-    param.rank = operands.at(inputs.at(0)).shape().rank();
 
     return new operation::ReduceMax{inputs, outputs, param};
   };
@@ -1364,7 +1355,7 @@ OperationFactory::OperationFactory()
   };
 
   _map[ANEURALNETWORKS_L2_NORMALIZATION] = [](const OperationFactory::Param &init_param,
-                                              Operands &operands) {
+                                              Operands &) {
     assert(init_param.input_count == 1 && init_param.output_count == 1);
 
     OperandIndexSequence outputs{init_param.outputs[0]};
@@ -1373,10 +1364,7 @@ OperationFactory::OperationFactory()
     //  0 -> input Tensor Index
     OperandIndexSequence inputs{init_param.inputs[0]};
 
-    operation::L2Normalization::Param param;
-    param.rank = operands.at(inputs.at(0)).shape().rank();
-
-    return new operation::L2Normalization{inputs, outputs, param};
+    return new operation::L2Normalization{inputs, outputs};
   };
 
   _map[ANEURALNETWORKS_HASHTABLE_LOOKUP] = [](const OperationFactory::Param &init_param,
@@ -1702,7 +1690,6 @@ OperationFactory::OperationFactory()
 
     operation::Gather::Param param;
     param.axis = operands.at(OperandIndex{init_param.inputs[1]}).asScalar<int32_t>();
-    param.rank = operands.at(inputs.at(0)).shape().rank();
 
     return new operation::Gather{inputs, outputs, param};
   };
@@ -1758,7 +1745,6 @@ OperationFactory::OperationFactory()
 
     operation::ArgMax::Param param;
     param.axis = operands.at(OperandIndex{init_param.inputs[1]}).asScalar<std::int32_t>();
-    param.rank = operands.at(inputs.at(0)).shape().rank();
 
     return new operation::ArgMax{inputs, outputs, param};
   };
@@ -1797,7 +1783,6 @@ OperationFactory::OperationFactory()
     operation::Mean::Param param;
     param.axes.assign(axes.cbegin(), axes.cend());
     param.keep_dims = operands.at(OperandIndex{init_param.inputs[2]}).asScalar<int32_t>() != 0;
-    param.rank = operands.at(inputs.at(0)).shape().rank();
 
     return new operation::Mean{inputs, outputs, param};
   };
@@ -1853,7 +1838,6 @@ OperationFactory::OperationFactory()
     const auto axis_index = OperandIndex{init_param.inputs[init_param.input_count - 1]};
     param.num = operands.at(num_index).asScalar<int32_t>();
     param.axis = operands.at(axis_index).asScalar<int32_t>();
-    param.rank = operands.at(outputs.at(0)).shape().rank();
 
     return new operation::Pack{inputs, outputs, param};
   };
@@ -1876,7 +1860,6 @@ OperationFactory::OperationFactory()
     operation::ReduceMin::Param param;
     param.axes.assign(axes.cbegin(), axes.cend());
     param.keep_dims = operands.at(OperandIndex{init_param.inputs[2]}).asScalar<int8_t>() != 0;
-    param.rank = operands.at(inputs.at(0)).shape().rank();
 
     return new operation::ReduceMin{inputs, outputs, param};
   };
@@ -1899,7 +1882,6 @@ OperationFactory::OperationFactory()
     operation::Split::Param param;
     param.axis = operands.at(OperandIndex{init_param.inputs[1]}).asScalar<std::int32_t>();
     param.num_splits = operands.at(OperandIndex{init_param.inputs[2]}).asScalar<std::int32_t>();
-    param.rank = operands.at(inputs.at(0)).shape().rank();
 
     return new operation::Split{inputs, outputs, param};
   };
@@ -1924,21 +1906,17 @@ OperationFactory::OperationFactory()
     const auto axis_index = OperandIndex{init_param.inputs[2]};
     param.num = operands.at(num_index).asScalar<int32_t>();
     param.axis = operands.at(axis_index).asScalar<int32_t>();
-    param.rank = operands.at(inputs.at(0)).shape().rank();
 
     return new operation::Unpack{inputs, outputs, param};
   };
 
-  _map[ANEURALNETWORKS_PAD] = [](const OperationFactory::Param &init_param, Operands &operands) {
+  _map[ANEURALNETWORKS_PAD] = [](const OperationFactory::Param &init_param, Operands &) {
     assert(init_param.input_count == 2 && init_param.output_count >= 1);
 
     OperandIndexSequence inputs{init_param.inputs[0], init_param.inputs[1]};
     OperandIndexSequence outputs{init_param.outputs[0]};
 
-    operation::Pad::Param param;
-    param.rank = operands.at(inputs.at(0)).shape().rank();
-
-    return new operation::Pad{inputs, outputs, param};
+    return new operation::Pad{inputs, outputs};
   };
 
   _map[ANEURALNETWORKS_MINIMUM] = [](const OperationFactory::Param &init_param, Operands &) {
@@ -2027,7 +2005,6 @@ OperationFactory::OperationFactory()
     operation::ReduceProd::Param param;
     param.axes.assign(axes.cbegin(), axes.cend());
     param.keep_dims = operands.at(OperandIndex{init_param.inputs[2]}).asScalar<int8_t>() != 0;
-    param.rank = operands.at(inputs.at(0)).shape().rank();
 
     return new operation::ReduceProd{inputs, outputs, param};
   };


### PR DESCRIPTION
This commit removes rank from params of ir for operations.
  - Remove rank param from ir
  - Replace using rank with getting shape in backends
  - Adjust shape inference of Pack and Unpack

Signed-off-by: ragmani <ragmani0216@gmail.com>