### PR TITLE
[luci] Update shape status when ShapeInference was successed

### DIFF
--- a/compiler/luci/export/src/TypeBridge.cpp
+++ b/compiler/luci/export/src/TypeBridge.cpp
@@ -93,6 +93,10 @@ void copy_shape_dtype(loco::Graph *graph)
         {
           node->dim(r) = loco::Dimension(shape.dim(r).value());
         }
+
+        // ShapeStatus should be update only when the status was UNDEFINED
+        if (node->shape_status() == ShapeStatus::UNDEFINED)
+          node->shape_status(ShapeStatus::VALID);
       }
     }
   }


### PR DESCRIPTION
When nodes are newly created by `luci::XXXPass`, their `ShapeStatus` are `UNDEFINED`.
However, if `ShapeInference` was successful, the status should be updated to `VALID`.
This commit will update those `ShapeStatus` when shape and dtype are copied.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>