### PR TITLE
[onert] fix Range operation in cpu backend

### DIFF
--- a/compute/cker/include/cker/operation/Range.h
+++ b/compute/cker/include/cker/operation/Range.h
@@ -28,23 +28,36 @@ namespace cker
 {
 template <typename T> inline int GetSize(T start, T limit, T delta)
 {
+  if (!((start > limit && delta < 0) || (start < limit && delta > 0)))
+  {
+    throw std::runtime_error("Range: invalid input values");
+  }
+
   int size = (std::is_integral<T>::value
-                  ? ((std::abs(*limit - *start) + std::abs(*delta) - 1) / std::abs(*delta))
-                  : std::ceil(std::abs((*limit - *start) / *delta)));
+                  ? ((std::abs(limit - start) + std::abs(delta) - 1) / std::abs(delta))
+                  : std::ceil(std::abs((limit - start) / delta)));
   return size;
 }
+
 template <typename T>
-inline void Range(const T start_data, const T limit_data, const T delta_data, T output_data)
+inline void Range(const T *start_data, const T *limit_data, const T *delta_data, T *output_data)
 {
-  const int num_elements = GetSize<T>(start_data, limit_data, delta_data);
-  T start = start_data;
+  const T start_value = *start_data;
+  const T delta_value = *delta_data;
+  const T limit_value = *limit_data;
+
+  const int num_elements = GetSize<T>(start_value, limit_value, delta_value);
+  T value = start_value;
 
   for (int i = 0; i < num_elements; ++i)
   {
-    output_data[i] = *start;
-    *start += *delta_data;
+    output_data[i] = value;
+    value += delta_value;
+
+    assert(value < limit_value);
   }
 }
+
 } // namespace cker
 } // namespace nnfw
 

--- a/runtime/onert/backend/cpu/ops/RangeLayer.cc
+++ b/runtime/onert/backend/cpu/ops/RangeLayer.cc
@@ -47,16 +47,16 @@ void RangeLayer::run()
   switch (_output->data_type())
   {
     case OperandType::FLOAT32:
-      nnfw::cker::Range<float *>(reinterpret_cast<float *>(_start->buffer()),
-                                 reinterpret_cast<float *>(_limit->buffer()),
-                                 reinterpret_cast<float *>(_delta->buffer()),
-                                 reinterpret_cast<float *>(_output->buffer()));
+      nnfw::cker::Range<float>(reinterpret_cast<float *>(_start->buffer()),
+                               reinterpret_cast<float *>(_limit->buffer()),
+                               reinterpret_cast<float *>(_delta->buffer()),
+                               reinterpret_cast<float *>(_output->buffer()));
       break;
     case OperandType::INT32:
-      nnfw::cker::Range<int32_t *>(reinterpret_cast<int32_t *>(_start->buffer()),
-                                   reinterpret_cast<int32_t *>(_limit->buffer()),
-                                   reinterpret_cast<int32_t *>(_delta->buffer()),
-                                   reinterpret_cast<int32_t *>(_output->buffer()));
+      nnfw::cker::Range<int32_t>(reinterpret_cast<int32_t *>(_start->buffer()),
+                                 reinterpret_cast<int32_t *>(_limit->buffer()),
+                                 reinterpret_cast<int32_t *>(_delta->buffer()),
+                                 reinterpret_cast<int32_t *>(_output->buffer()));
       break;
     default:
       throw std::runtime_error{"Range: unsupported data type"};


### PR DESCRIPTION
- instead of using pointer as T, use value as T

ONE-DCO-1.0-Signed-off-by: dayo09 <dayg502@gmail.com>