### PR TITLE
[onert] Fix Range op's assert() and adds tests for `Range` op

### DIFF
--- a/compute/cker/include/cker/operation/Range.h
+++ b/compute/cker/include/cker/operation/Range.h
@@ -21,6 +21,7 @@
 #include "cker/Shape.h"
 
 #include <cmath>
+#include <stdexcept>
 
 namespace nnfw
 {
@@ -53,8 +54,6 @@ inline void Range(const T *start_data, const T *limit_data, const T *delta_data,
   {
     output_data[i] = value;
     value += delta_value;
-
-    assert(value < limit_value);
   }
 }
 

--- a/compute/test/CMakeLists.txt
+++ b/compute/test/CMakeLists.txt
@@ -1,0 +1,13 @@
+set(TEST_COMPUTE test_compute)
+
+file(GLOB_RECURSE TESTS "*.cc")
+
+add_executable(${TEST_COMPUTE} ${TESTS})
+
+target_link_libraries(${TEST_COMPUTE} nnfw_lib_cker)
+target_link_libraries(${TEST_COMPUTE} gtest)
+target_link_libraries(${TEST_COMPUTE} gtest_main)
+target_link_libraries(${TEST_COMPUTE} ${LIB_PTHREAD} dl)
+add_test(${TEST_COMPUTE} ${TEST_COMPUTE})
+
+install(TARGETS ${TEST_COMPUTE} DESTINATION unittest)

--- a/compute/test/cker/Range.cc
+++ b/compute/test/cker/Range.cc
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2019 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cker/operation/Range.h>
+
+#include <gtest/gtest.h>
+#include <vector>
+
+TEST(CKer_Operation, Range)
+{
+  {
+    const int start = 0;
+    const int limit = 10;
+    const int delta = 1;
+    std::vector<int> actual(10);
+    nnfw::cker::Range<int>(&start, &limit, &delta, actual.data());
+
+    for (int i = 0; i < actual.size(); i++)
+      ASSERT_EQ(actual[i], i);
+  }
+
+  {
+    const int start = 3;
+    const int limit = 18;
+    const int delta = 3;
+    std::vector<int> expected = {3, 6, 9, 12, 15};
+    std::vector<int> actual(expected.size());
+    nnfw::cker::Range<int>(&start, &limit, &delta, actual.data());
+
+    for (int i = 0; i < actual.size(); i++)
+      ASSERT_EQ(actual[i], expected[i]);
+  }
+
+  {
+    const float start = 3;
+    const float limit = 1;
+    const float delta = -0.5;
+    std::vector<float> expected = {
+        3, 2.5, 2, 1.5,
+    };
+    std::vector<float> actual(expected.size());
+    nnfw::cker::Range<float>(&start, &limit, &delta, actual.data());
+
+    for (int i = 0; i < actual.size(); i++)
+      ASSERT_EQ(actual[i], expected[i]);
+  }
+}
+
+TEST(CKer_Operation, neg_Range)
+{
+  {
+    const int start = 212;
+    const int limit = 10;
+    const int delta = 1;
+    std::vector<int> actual(10);
+
+    EXPECT_ANY_THROW(nnfw::cker::Range<int>(&start, &limit, &delta, actual.data()));
+  }
+}

--- a/compute/test/cker/Range.cc
+++ b/compute/test/cker/Range.cc
@@ -55,7 +55,7 @@ TEST(CKer_Operation, Range)
     nnfw::cker::Range<float>(&start, &limit, &delta, actual.data());
 
     for (int i = 0; i < actual.size(); i++)
-      ASSERT_EQ(actual[i], expected[i]);
+      ASSERT_FLOAT_EQ(actual[i], expected[i]);
   }
 }
 


### PR DESCRIPTION
This fixes range's assert and adds tests.

for https://github.com/Samsung/ONE/pull/2424#issuecomment-646397867

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>