### PR TITLE
[luci/logex] Added Ceil Operator Support

### DIFF
--- a/compiler/luci/logex/src/FormattedGraph.cpp
+++ b/compiler/luci/logex/src/FormattedGraph.cpp
@@ -201,6 +201,7 @@ private:
   IMPLEMENT(luci::CircleBatchMatMul)
   IMPLEMENT(luci::CircleBatchToSpaceND)
   IMPLEMENT(luci::CircleCast)
+  IMPLEMENT(luci::CircleCeil)
   IMPLEMENT(luci::CircleConcatenation)
   IMPLEMENT(luci::CircleConst)
   IMPLEMENT(luci::CircleConv2D)
@@ -398,6 +399,13 @@ bool CircleNodeSummaryBuilder::summary(const luci::CircleCast *node, locop::Node
   s.args().append("x", tbl()->lookup(node->x()));
   s.args().append("in_data_type", to_str(node->in_data_type()));
   s.args().append("out_data_type", to_str(node->out_data_type()));
+  s.state(locop::NodeSummary::State::Complete);
+  return true;
+}
+
+bool CircleNodeSummaryBuilder::summary(const luci::CircleCeil *node, locop::NodeSummary &s) const
+{
+  s.args().append("x", tbl()->lookup(node->x()));
   s.state(locop::NodeSummary::State::Complete);
   return true;
 }


### PR DESCRIPTION
Added code to support Ceil Op in luci logex. Ref #2102

ONE-DCO-1.0-Signed-off-by: Sunchit Sharma <sun.sharma@samsung.com>