### PR TITLE
[nnfwapi] Remove ConfigSource

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -66,8 +66,7 @@ static onert::ir::Layout convertLayout(NNFW_LAYOUT layout)
 
 nnfw_session::nnfw_session()
     : _subgraphs{nullptr}, _execution{nullptr},
-      _kernel_registry{std::make_shared<onert::frontend::custom::KernelRegistry>()},
-      _source{std::make_unique<onert::util::GeneralConfigSource>()}
+      _kernel_registry{std::make_shared<onert::frontend::custom::KernelRegistry>()}
 {
   // DO NOTHING
 }
@@ -169,10 +168,6 @@ NNFW_STATUS nnfw_session::prepare()
 
   try
   {
-    // config_source setting
-    using onert::util::config_source;
-    config_source(std::move(_source));
-
     _subgraphs.reset();
     _compiler->compile();
     std::shared_ptr<onert::exec::ExecutorMap> executors;

--- a/runtime/onert/api/src/nnfw_api_internal.h
+++ b/runtime/onert/api/src/nnfw_api_internal.h
@@ -105,9 +105,6 @@ private:
   std::unique_ptr<onert::compiler::Compiler> _compiler;
   std::shared_ptr<onert::exec::Execution> _execution;
   std::shared_ptr<onert::frontend::custom::KernelRegistry> _kernel_registry;
-
-protected:
-  std::unique_ptr<onert::util::GeneralConfigSource> _source;
 };
 
 #endif // __API_NNFW_API_INTERNAL_H__

--- a/runtime/onert/api/src/nnfw_debug_internal.cc
+++ b/runtime/onert/api/src/nnfw_debug_internal.cc
@@ -19,7 +19,4 @@
 
 #include <memory>
 
-nnfw_debug_session::nnfw_debug_session() : nnfw_session()
-{
-  _source = std::make_unique<onert::util::EnvConfigSource>();
-}
+nnfw_debug_session::nnfw_debug_session() : nnfw_session() {}


### PR DESCRIPTION
nnfwapi does not access to ConfigSource as it is not session based,
and we have an API for setting configuration for each session.
So this commit decouples `IConfigSource` from nnfwapi.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>