### PR TITLE
[luci] Update lang test of BCQ operations

### DIFF
--- a/compiler/luci/lang/src/Nodes/CircleBCQFullyConnected.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleBCQFullyConnected.test.cpp
@@ -31,6 +31,7 @@ TEST(CircleBCQFullyConnectedTest, constructor)
   ASSERT_EQ(nullptr, bcq_FC_node.weights_scales());
   ASSERT_EQ(nullptr, bcq_FC_node.weights_binary());
   ASSERT_EQ(nullptr, bcq_FC_node.bias());
+  ASSERT_EQ(nullptr, bcq_FC_node.weights_clusters());
 
   ASSERT_EQ(luci::FusedActFunc::UNDEFINED, bcq_FC_node.fusedActivationFunction());
   ASSERT_EQ(0, bcq_FC_node.weights_hidden_size());

--- a/compiler/luci/lang/src/Nodes/CircleBCQGather.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleBCQGather.test.cpp
@@ -30,6 +30,7 @@ TEST(CircleBCQGatherTest, constructor)
   ASSERT_EQ(nullptr, bcq_gather_node.input_scales());
   ASSERT_EQ(nullptr, bcq_gather_node.input_binary());
   ASSERT_EQ(nullptr, bcq_gather_node.indices());
+  ASSERT_EQ(nullptr, bcq_gather_node.input_clusters());
 
   ASSERT_EQ(0, bcq_gather_node.axis());
   ASSERT_EQ(0, bcq_gather_node.input_hidden_size());


### PR DESCRIPTION
Parent Issue : #1907

As BCQ operations have one more input, this commit will update
`lang` tests of BCQ operations to test the additional input.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>