### PR TITLE
[luci] Update export of BCQ operations

### DIFF
--- a/compiler/luci/export/src/CircleOperationExporter.cpp
+++ b/compiler/luci/export/src/CircleOperationExporter.cpp
@@ -1762,7 +1762,8 @@ void OperationExporter::visit(luci::CircleBCQFullyConnected *node)
   // Make input, output and options for operator
   std::vector<int32_t> inputs_vec{
       get_tensor_index(node->input()), get_tensor_index(node->weights_scales()),
-      get_tensor_index(node->weights_binary()), get_tensor_index(node->bias())};
+      get_tensor_index(node->weights_binary()), get_tensor_index(node->bias()),
+      get_tensor_index(node->weights_clusters())};
   std::vector<int32_t> outputs_vec{get_tensor_index(static_cast<loco::Node *>(node))};
   auto inputs = builder.CreateVector(inputs_vec);
   auto outputs = builder.CreateVector(outputs_vec);
@@ -1780,9 +1781,9 @@ void OperationExporter::visit(luci::CircleBCQGather *node)
   uint32_t op_idx = md.registerBuiltinOpcode(circle::BuiltinOperator_BCQ_GATHER);
 
   // Make input, output and options for operator
-  std::vector<int32_t> inputs_vec{get_tensor_index(node->input_scales()),
-                                  get_tensor_index(node->input_binary()),
-                                  get_tensor_index(node->indices())};
+  std::vector<int32_t> inputs_vec{
+      get_tensor_index(node->input_scales()), get_tensor_index(node->input_binary()),
+      get_tensor_index(node->indices()), get_tensor_index(node->input_clusters())};
   std::vector<int32_t> outputs_vec{get_tensor_index(static_cast<loco::Node *>(node))};
   auto inputs = builder.CreateVector(inputs_vec);
   auto outputs = builder.CreateVector(outputs_vec);


### PR DESCRIPTION
Parent Issue : #1907

As BCQ operations have one more input, this commit will enable
handling the additional input in `luci/export`

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>