### PR TITLE
[luci] Fix bug about getting channel dimension's idx

### DIFF
--- a/compiler/luci/pass/src/QuantizeDequantizeWeightsPass.cpp
+++ b/compiler/luci/pass/src/QuantizeDequantizeWeightsPass.cpp
@@ -112,35 +112,35 @@ bool get_channel_dim_index(CircleConst *node, loco::TensorShape &dimension, int 
     auto tw_conv = dynamic_cast<CircleTransposeConv *>(out);
     auto fc = dynamic_cast<CircleFullyConnected *>(out);
 
-    if (conv != nullptr && conv->filter() == node)
+    if ((conv != nullptr && conv->filter() == node) ||
+        (tw_conv != nullptr && tw_conv->filter() == node)) // OHWI
     {
       assert(node->rank() == 4);
       dimension.dim(0).set(node->dim(0).value());
       dimension.dim(1).set(node->dim(1).value());
       dimension.dim(2).set(node->dim(2).value());
       dimension.dim(3).set(node->dim(3).value());
-      channel_dim_index = 3;
+      channel_dim_index = 0; // I set channel_dim_index based on "O"
       return true;
     }
-    else if ((tw_conv != nullptr && tw_conv->filter() == node) ||
-             (dw_conv != nullptr && dw_conv->filter() == node))
+    else if (dw_conv != nullptr && dw_conv->filter() == node) // IHWO
     {
       assert(node->rank() == 4);
       dimension.dim(0).set(node->dim(0).value());
       dimension.dim(1).set(node->dim(1).value());
       dimension.dim(2).set(node->dim(2).value());
       dimension.dim(3).set(node->dim(3).value());
-      channel_dim_index = 2;
+      channel_dim_index = 3; // I set channel_dim_index based on "O"
       return true;
     }
-    else if (fc != nullptr && fc->weights() == node)
+    else if (fc != nullptr && fc->weights() == node) // OI
     {
       assert(node->rank() == 2);
-      dimension.dim(0).set(1);
-      dimension.dim(1).set(1);
-      dimension.dim(2).set(node->dim(0).value());
+      dimension.dim(0).set(node->dim(0).value());
+      dimension.dim(1).set(1); // I set FC layer like CONV
+      dimension.dim(2).set(1);
       dimension.dim(3).set(node->dim(1).value());
-      channel_dim_index = 3;
+      channel_dim_index = 0; // I set channel_dim_index based on "O"
       return true;
     }
     else

--- a/compiler/luci/pass/src/QuantizeDequantizeWeightsPass.cpp
+++ b/compiler/luci/pass/src/QuantizeDequantizeWeightsPass.cpp
@@ -112,6 +112,7 @@ bool get_channel_dim_index(CircleConst *node, loco::TensorShape &dimension, int 
     auto tw_conv = dynamic_cast<CircleTransposeConv *>(out);
     auto fc = dynamic_cast<CircleFullyConnected *>(out);
 
+    // Refer to https://github.com/Samsung/ONE/pull/2448.
     if ((conv != nullptr && conv->filter() == node) ||
         (tw_conv != nullptr && tw_conv->filter() == node)) // OHWI
     {
@@ -120,27 +121,27 @@ bool get_channel_dim_index(CircleConst *node, loco::TensorShape &dimension, int 
       dimension.dim(1).set(node->dim(1).value());
       dimension.dim(2).set(node->dim(2).value());
       dimension.dim(3).set(node->dim(3).value());
-      channel_dim_index = 0; // I set channel_dim_index based on "O"
+      channel_dim_index = 0; // Set channel_dim_index based on "O"
       return true;
     }
-    else if (dw_conv != nullptr && dw_conv->filter() == node) // IHWO
+    else if (dw_conv != nullptr && dw_conv->filter() == node) // IHWC
     {
       assert(node->rank() == 4);
       dimension.dim(0).set(node->dim(0).value());
       dimension.dim(1).set(node->dim(1).value());
       dimension.dim(2).set(node->dim(2).value());
       dimension.dim(3).set(node->dim(3).value());
-      channel_dim_index = 3; // I set channel_dim_index based on "O"
+      channel_dim_index = 3; // Set channel_dim_index based on "C"
       return true;
     }
     else if (fc != nullptr && fc->weights() == node) // OI
     {
       assert(node->rank() == 2);
       dimension.dim(0).set(node->dim(0).value());
-      dimension.dim(1).set(1); // I set FC layer like CONV
+      dimension.dim(1).set(1); // Set FC layer like CONV
       dimension.dim(2).set(1);
       dimension.dim(3).set(node->dim(1).value());
-      channel_dim_index = 0; // I set channel_dim_index based on "O"
+      channel_dim_index = 0; // Set channel_dim_index based on "O"
       return true;
     }
     else

--- a/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
+++ b/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
@@ -150,35 +150,35 @@ bool get_channel_dim_index(CircleConst *node, loco::TensorShape &dimension, int 
     auto tw_conv = dynamic_cast<CircleTransposeConv *>(out);
     auto fc = dynamic_cast<CircleFullyConnected *>(out);
 
-    if (conv != nullptr && conv->filter() == node)
+    if ((conv != nullptr && conv->filter() == node) ||
+        (tw_conv != nullptr && tw_conv->filter() == node)) // OHWI
     {
       assert(node->rank() == 4);
       dimension.dim(0).set(node->dim(0).value());
       dimension.dim(1).set(node->dim(1).value());
       dimension.dim(2).set(node->dim(2).value());
       dimension.dim(3).set(node->dim(3).value());
-      channel_dim_index = 3;
+      channel_dim_index = 0; // I set channel_dim_index based on "O"
       return true;
     }
-    else if ((tw_conv != nullptr && tw_conv->filter() == node) ||
-             (dw_conv != nullptr && dw_conv->filter() == node))
+    else if (dw_conv != nullptr && dw_conv->filter() == node) // IHWO
     {
       assert(node->rank() == 4);
       dimension.dim(0).set(node->dim(0).value());
       dimension.dim(1).set(node->dim(1).value());
       dimension.dim(2).set(node->dim(2).value());
       dimension.dim(3).set(node->dim(3).value());
-      channel_dim_index = 2;
+      channel_dim_index = 3; // I set channel_dim_index based on "O"
       return true;
     }
-    else if (fc != nullptr && fc->weights() == node)
+    else if (fc != nullptr && fc->weights() == node) // OI
     {
       assert(node->rank() == 2);
-      dimension.dim(0).set(1);
-      dimension.dim(1).set(1);
-      dimension.dim(2).set(node->dim(0).value());
+      dimension.dim(0).set(node->dim(0).value());
+      dimension.dim(1).set(1); // I set FC layer like CONV
+      dimension.dim(2).set(1);
       dimension.dim(3).set(node->dim(1).value());
-      channel_dim_index = 3;
+      channel_dim_index = 0; // I set channel_dim_index based on "O"
       return true;
     }
     else

--- a/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
+++ b/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
@@ -150,6 +150,7 @@ bool get_channel_dim_index(CircleConst *node, loco::TensorShape &dimension, int 
     auto tw_conv = dynamic_cast<CircleTransposeConv *>(out);
     auto fc = dynamic_cast<CircleFullyConnected *>(out);
 
+    // Refer to https://github.com/Samsung/ONE/pull/2448.
     if ((conv != nullptr && conv->filter() == node) ||
         (tw_conv != nullptr && tw_conv->filter() == node)) // OHWI
     {
@@ -158,27 +159,27 @@ bool get_channel_dim_index(CircleConst *node, loco::TensorShape &dimension, int 
       dimension.dim(1).set(node->dim(1).value());
       dimension.dim(2).set(node->dim(2).value());
       dimension.dim(3).set(node->dim(3).value());
-      channel_dim_index = 0; // I set channel_dim_index based on "O"
+      channel_dim_index = 0; // Set channel_dim_index based on "O"
       return true;
     }
-    else if (dw_conv != nullptr && dw_conv->filter() == node) // IHWO
+    else if (dw_conv != nullptr && dw_conv->filter() == node) // IHWC
     {
       assert(node->rank() == 4);
       dimension.dim(0).set(node->dim(0).value());
       dimension.dim(1).set(node->dim(1).value());
       dimension.dim(2).set(node->dim(2).value());
       dimension.dim(3).set(node->dim(3).value());
-      channel_dim_index = 3; // I set channel_dim_index based on "O"
+      channel_dim_index = 3; // Set channel_dim_index based on "C"
       return true;
     }
     else if (fc != nullptr && fc->weights() == node) // OI
     {
       assert(node->rank() == 2);
       dimension.dim(0).set(node->dim(0).value());
-      dimension.dim(1).set(1); // I set FC layer like CONV
+      dimension.dim(1).set(1); // Set FC layer like CONV
       dimension.dim(2).set(1);
       dimension.dim(3).set(node->dim(1).value());
-      channel_dim_index = 0; // I set channel_dim_index based on "O"
+      channel_dim_index = 0; // Set channel_dim_index based on "O"
       return true;
     }
     else


### PR DESCRIPTION
- I implemented the dimension's idx based on **TF**
- I didn't catch the dimension difference between **TF** and **TFLite**
- For understanding, I attached a picture as below.
- When I checked **Circle**, it follows the dimension of **TFLite** (If I'm wrong, please let me know.)

![image](https://user-images.githubusercontent.com/14325557/85125361-72c2d180-b266-11ea-8fbb-7430b3fe780c.png)

Signed-off-by: mia park <mia.park@samsung.com>

Related to: #696, https://github.sec.samsung.net/STAR/nnapps/issues/379, https://github.sec.samsung.net/STAR/nnfw/issues/6871#issuecomment-366611
