### PR TITLE
[luci] Update ShapeInference of BCQ operations

### DIFF
--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -1927,29 +1927,21 @@ public:
   loco::NodeShape visit(const luci::CircleBCQFullyConnected *node) final
   {
     loco::TensorShape out_shape;
-    loco::TensorShape weights_shape;
 
     auto input_shape = loco::shape_get(node->input()).as<loco::TensorShape>();
-    auto weights_scales_shape = loco::shape_get(node->weights_scales()).as<loco::TensorShape>();
-    auto weights_binary_shape = loco::shape_get(node->weights_binary()).as<loco::TensorShape>();
+    auto weights_clusters = loco::must_cast<luci::CircleConst *>(node->weights_clusters());
 
-    weights_shape.rank(2);
-    weights_shape.dim(0) = weights_binary_shape.dim(0);
-    weights_shape.dim(1) = weights_binary_shape.dim(2).value() * 32;
+    LUCI_ASSERT(input_shape.rank() == 2, "Input rank of BCQFullyConnected should be 2");
 
-    LUCI_ASSERT(input_shape.rank() >= 2, "Input rank should be at least 2");
-    LUCI_ASSERT(weights_shape.rank() == 2, "Incompatible weights rank for BCQ fully connected");
-
-    uint32_t input_size = 1;
-    for (uint32_t i = 0; i < input_shape.rank(); i++)
+    int32_t qbits_sum = 0;
+    for (uint32_t i = 0; i < weights_clusters->dim(0).value(); ++i)
     {
-      input_size = input_size * input_shape.dim(i).value();
+      qbits_sum += weights_clusters->at<loco::DataType::S32>(i * 2 + 1);
     }
-    const uint32_t batch_size = input_size / weights_shape.dim(1).value();
 
     out_shape.rank(2);
-    out_shape.dim(0) = batch_size;
-    out_shape.dim(1) = weights_shape.dim(0);
+    out_shape.dim(0) = qbits_sum;
+    out_shape.dim(1) = input_shape.dim(1);
 
     return loco::NodeShape{out_shape};
   }
@@ -1959,14 +1951,20 @@ public:
     loco::TensorShape input_shape;
     loco::TensorShape output_shape;
 
-    const auto input_scales_shape = loco::shape_get(node->input_scales()).as<loco::TensorShape>();
     const auto input_binary_shape = loco::shape_get(node->input_binary()).as<loco::TensorShape>();
     const auto indices_shape = loco::shape_get(node->indices()).as<loco::TensorShape>();
     auto axis = node->axis();
 
+    auto input_clusters = loco::must_cast<luci::CircleConst *>(node->input_clusters());
+    auto qbits_sum = 0;
+    for (uint32_t i = 0; i < input_clusters->dim(0).value(); ++i)
+    {
+      qbits_sum += input_clusters->at<loco::DataType::S32>(i * 2 + 1);
+    }
+
     input_shape.rank(2);
-    input_shape.dim(0) = input_binary_shape.dim(0);
-    input_shape.dim(1) = input_binary_shape.dim(2).value() * 32;
+    input_shape.dim(0) = input_binary_shape.dim(0).value() / qbits_sum;
+    input_shape.dim(1) = input_binary_shape.dim(1).value() * 32;
 
     output_shape.rank(input_shape.rank() - 1 + indices_shape.rank());
     int32_t outdim_index = 0;


### PR DESCRIPTION
Parent Issue : #1907

The format and interpretation of BCQ operations is different from previous one.
Accordingly, inference logic of BCQ operations are also different.
This commit will apply changes of shape inference logic.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>