### PR TITLE
[luci-interpreter] Fix static analysis warning

### DIFF
--- a/compiler/luci-interpreter/src/kernels/LeakyRelu.h
+++ b/compiler/luci-interpreter/src/kernels/LeakyRelu.h
@@ -45,7 +45,7 @@ private:
   Tensor *const _output;
 
 private:
-  uint8_t _q_alpha;
+  uint8_t _q_alpha = 0;
   int32_t _output_multiplier = 0;
   int _output_shift = 0;
 };


### PR DESCRIPTION
`_q_alpha` is not initialized when `LeakyRelu` is constructed.
This commit will fix it.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>