### PR TITLE
[circlechef] Fix static analysis warning

### DIFF
--- a/compiler/circlechef/circle/src/Convert.h
+++ b/compiler/circlechef/circle/src/Convert.h
@@ -42,6 +42,9 @@ template <typename DT> std::vector<DT> extract_buffer(const circle::Buffer *buff
 
 template <typename T> std::vector<T> as_index_vector(const flatbuffers::Vector<T> *flat_array)
 {
+  if (flat_array == nullptr)
+    throw std::runtime_error("flat_array is nullptr");
+
   std::vector<T> ret(flat_array->Length());
   for (uint32_t i = 0; i < flat_array->Length(); i++)
   {


### PR DESCRIPTION
This commit will fix warning when `flat_array` is `nullptr`.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>