### PR TITLE
[luci-interpreter] Fix static analysis warnings

### DIFF
--- a/compiler/luci-interpreter/src/kernels/L2Pool2D.h
+++ b/compiler/luci-interpreter/src/kernels/L2Pool2D.h
@@ -42,8 +42,8 @@ private:
   const Tensor *const _input;
   Tensor *const _output;
 
-  int _padding_height;
-  int _padding_width;
+  int _padding_height = 0;
+  int _padding_width = 0;
 };
 
 } // namespace kernels

--- a/compiler/luci-interpreter/src/kernels/TransposeConv.h
+++ b/compiler/luci-interpreter/src/kernels/TransposeConv.h
@@ -54,7 +54,7 @@ private:
 
   // The scaling factor from input to output (aka the 'real multiplier') can
   // be represented as a fixed point multiplier plus a left shift.
-  int32_t _output_multiplier;
+  int32_t _output_multiplier = 0;
   int _output_shift;
 };
 


### PR DESCRIPTION
This commit will fix warnings for uninitialized member variables

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>