### PR TITLE
[record-minmax] Fix static analysis warning

### DIFF
--- a/compiler/record-minmax/src/RecordMinMax.cpp
+++ b/compiler/record-minmax/src/RecordMinMax.cpp
@@ -68,7 +68,7 @@ template <typename NodeT> size_t getTensorSize(const NodeT *node)
  * @brief  verifyTypeShape checks the type and the shape of CircleInput
  *         This throws an exception if type or shape does not match
  */
-bool verifyTypeShape(const luci::CircleInput *input_node, const DataType &dtype, const Shape &shape)
+void verifyTypeShape(const luci::CircleInput *input_node, const DataType &dtype, const Shape &shape)
 {
   // Type check
   if (dtype != input_node->dtype())


### PR DESCRIPTION
`verifyTypeShape` has no return value but return type of the
function was `bool`.
This commit will fix it to `void` type.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>