### PR TITLE
[luci] Fix static analysis warning

### DIFF
--- a/compiler/luci/export/src/CircleTensorExporter.cpp
+++ b/compiler/luci/export/src/CircleTensorExporter.cpp
@@ -187,6 +187,9 @@ private:
 
 void allocateCircleTensor(CircleNode *node, CircleTensorContext &ctx)
 {
+  if (node == nullptr)
+    throw std::runtime_error("Allocation is impossible because node is nullptr");
+
   auto isNoOp = [](loco::Node *node) {
     if (auto circle_node = dynamic_cast<luci::CircleNode *>(node))
     {

--- a/compiler/luci/export/src/CircleTensorExporter.cpp
+++ b/compiler/luci/export/src/CircleTensorExporter.cpp
@@ -188,7 +188,7 @@ private:
 void allocateCircleTensor(CircleNode *node, CircleTensorContext &ctx)
 {
   if (node == nullptr)
-    throw std::runtime_error("Allocation is impossible because node is nullptr");
+    throw std::runtime_error("allocateCIrcleTensor Failed : node is nullptr");
 
   auto isNoOp = [](loco::Node *node) {
     if (auto circle_node = dynamic_cast<luci::CircleNode *>(node))


### PR DESCRIPTION
This commit will fix warning when `node` is `nullptr`.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>