### PR TITLE
[onert] Allow permutation for rank < 4

### DIFF
--- a/runtime/onert/core/src/ir/pass/PermutationOperationPass.cc
+++ b/runtime/onert/core/src/ir/pass/PermutationOperationPass.cc
@@ -50,7 +50,7 @@ void PermutationOperationPass::changeToKeepLayout(const Operation &node)
   }
 
   // Permutation changing layout beyond 4-D is not supported yet
-  assert(output_obj.shape().rank() == 4);
+  assert(output_obj.shape().rank() <= 4);
 
   // Divide op_seq based on target operation
   {


### PR DESCRIPTION
Change assert condition on layout check on permutation to rank <= 4

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>