### PR TITLE
[circle-tensordump] Fix bug on dumping uint8

### DIFF
--- a/compiler/circle-tensordump/src/Dump.cpp
+++ b/compiler/circle-tensordump/src/Dump.cpp
@@ -95,7 +95,7 @@ void print_buffer(std::ostream &os, uint32_t buff_idx, const flatbuffers::Vector
   os << std::endl;
 }
 
-} // namepsace
+} // namespace
 
 namespace circletensordump
 {
@@ -177,7 +177,7 @@ H5::PredType hdf5_dtype_cast(const circle::TensorType &circle_type)
   {
     case circle::TensorType_UINT8:
     {
-      return H5::PredType::NATIVE_INT8;
+      return H5::PredType::NATIVE_UINT8;
     }
     case circle::TensorType_INT32:
     {


### PR DESCRIPTION
This fixes a bug on dumping uint8 values

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>