### PR TITLE
[luci] Fix static analysis warning

### DIFF
--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -1978,6 +1978,9 @@ public:
       qbits_sum += input_clusters->at<loco::DataType::S32>(i * 2 + 1);
     }
 
+    if (qbits_sum == 0)
+      throw std::runtime_error("Shape inference for CircleBCQGather Fail : sum of qbits is 0");
+
     input_shape.rank(2);
     input_shape.dim(0) = input_binary_shape.dim(0).value() / qbits_sum;
     input_shape.dim(1) = input_binary_shape.dim(1).value() * 32;


### PR DESCRIPTION
If `qbits_sum` is 0, it can cause division by zero error.
This commit will fix it.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>