### PR TITLE
[luci-interpreter] Fix static analysis warning

### DIFF
--- a/compiler/luci-interpreter/src/kernels/TransposeConv.h
+++ b/compiler/luci-interpreter/src/kernels/TransposeConv.h
@@ -55,7 +55,7 @@ private:
   // The scaling factor from input to output (aka the 'real multiplier') can
   // be represented as a fixed point multiplier plus a left shift.
   int32_t _output_multiplier = 0;
-  int _output_shift;
+  int _output_shift = 0;
 };
 
 } // namespace kernels


### PR DESCRIPTION
`_output_shift` is not initialized.
This commit will fix it.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>