### PR TITLE
[onert] Introduce IPortableTensor

### DIFF
--- a/runtime/onert/backend/cpu/TensorBuilder.cc
+++ b/runtime/onert/backend/cpu/TensorBuilder.cc
@@ -94,20 +94,19 @@ void TensorBuilder::allocate()
 
 std::shared_ptr<ITensor> TensorBuilder::tensorAt(const ir::OperandIndex &ind)
 {
-  auto found = _tensor_reg->find(ind);
-  if (found == _tensor_reg->end())
-    return nullptr;
+  return _tensor_reg->getITensor(ind);
+}
 
-  return found->second;
+std::shared_ptr<IPortableTensor> TensorBuilder::portableAt(const ir::OperandIndex &ind)
+{
+  return _tensor_reg->getPortableTensor(ind);
 }
 
 void TensorBuilder::iterate(const IterateFunction &fn) { _static_tensor_mgr->iterate(fn); }
 
 std::shared_ptr<cpu_common::Tensor> TensorBuilder::at(const ir::OperandIndex &ind)
 {
-  auto found = _tensor_reg->find(ind);
-  assert(found != _tensor_reg->end());
-  return found->second;
+  return _tensor_reg->getManagedTensor(ind);
 }
 
 std::unique_ptr<ITensorManager> TensorBuilder::releaseStaticTensorManager(void)

--- a/runtime/onert/backend/cpu/TensorBuilder.h
+++ b/runtime/onert/backend/cpu/TensorBuilder.h
@@ -81,6 +81,7 @@ public:
    * @return shared_ptr<Tensor>
    */
   std::shared_ptr<cpu_common::Tensor> at(const ir::OperandIndex &ind);
+  std::shared_ptr<IPortableTensor> portableAt(const ir::OperandIndex &ind);
 
   std::shared_ptr<ITensorRegistry> tensorRegistry() override { return _tensor_reg; }
 

--- a/runtime/onert/core/include/backend/IPortableTensor.h
+++ b/runtime/onert/core/include/backend/IPortableTensor.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_BACKEND_I_PORTABLE_TENSOR_H__
+#define __ONERT_BACKEND_I_PORTABLE_TENSOR_H__
+
+#include "backend/ITensor.h"
+
+namespace onert
+{
+namespace backend
+{
+
+/**
+ * @brief A tensor class that is portable for other backends
+ *
+ * Backends that use derivatives of this interface can reuse each other's tensors without copying.
+ * Here's criterion to be a portable tensor:
+ *   - it must not have any paddings
+ *   - No special operations on @c access method
+ *     - e.g. CL memory must map/unmap to use it from CPU, the memory so it cannot be portable
+ */
+class IPortableTensor : public ITensor
+{
+public:
+  virtual ~IPortableTensor() = default;
+
+public:
+  bool has_padding() const final { return false; }
+  void access(const std::function<void(ITensor &tensor)> &fn) final { fn(*this); }
+};
+
+} // namespace backend
+} // namespace onert
+
+#endif // __ONERT_BACKEND_I_PORTABLE_TENSOR_H__

--- a/runtime/onert/core/include/backend/ITensorRegistry.h
+++ b/runtime/onert/core/include/backend/ITensorRegistry.h
@@ -43,6 +43,7 @@ struct ITensorRegistry
 } // namespace onert
 
 #include "ir/OperandIndexMap.h"
+#include "backend/IPortableTensor.h"
 
 namespace onert
 {
@@ -52,12 +53,12 @@ namespace backend
 /**
  * @brief  TensorRegistry template class for the convenience of backend implementations
  *
- * Unless there is a special reason to implement @c ITensorRegistry on your own, you may just use
- * this default implementation.
+ * If a backend uses @c IPortableTensor , and there is no special reason to implement @c
+ * ITensorRegistry on your own, you may just use this default implementation.
  *
- * @tparam T_Tensor Tensor type. Must be a subclass of @c onert::backend::ITensor .
+ * @tparam T_Tensor Tensor type. Must be a subclass of @c onert::backend::IPortableTensor .
  */
-template <typename T_Tensor> class TensorRegistryTemplate : public ITensorRegistry
+template <typename T_Tensor> class PortableTensorRegistryTemplate : public ITensorRegistry
 {
 public:
   std::shared_ptr<ITensor> getITensor(const ir::OperandIndex &ind) override
@@ -69,6 +70,19 @@ public:
     return getManagedTensor(ind);
   }
 
+  std::shared_ptr<IPortableTensor> getPortableTensor(const ir::OperandIndex &ind)
+  {
+    auto external_tensor = _external.find(ind);
+    if (external_tensor != _external.end())
+    {
+      auto external_portable_tensor =
+          std::dynamic_pointer_cast<IPortableTensor>(external_tensor->second);
+      if (external_portable_tensor)
+        return external_tensor->second;
+    }
+    return std::dynamic_pointer_cast<IPortableTensor>(getManagedTensor(ind));
+  }
+
   std::shared_ptr<T_Tensor> getManagedTensor(const ir::OperandIndex &ind)
   {
     auto tensor = _managed.find(ind);
@@ -77,7 +91,8 @@ public:
     return nullptr;
   }
 
-  void setExternalTensor(const ir::OperandIndex &ind, const std::shared_ptr<ITensor> &tensor)
+  void setExternalTensor(const ir::OperandIndex &ind,
+                         const std::shared_ptr<IPortableTensor> &tensor)
   {
     auto itr = _managed.find(ind);
     if (itr != _managed.end() && itr->second != nullptr && tensor != nullptr)
@@ -98,7 +113,7 @@ public:
   const ir::OperandIndexMap<std::shared_ptr<T_Tensor>> &managed_tensors() { return _managed; }
 
 private:
-  ir::OperandIndexMap<std::shared_ptr<ITensor>> _external;
+  ir::OperandIndexMap<std::shared_ptr<IPortableTensor>> _external;
   ir::OperandIndexMap<std::shared_ptr<T_Tensor>> _managed;
 };
 

--- a/runtime/onert/core/include/backend/cpu_common/Tensor.h
+++ b/runtime/onert/core/include/backend/cpu_common/Tensor.h
@@ -19,7 +19,7 @@
 
 #include "Allocator.h"
 
-#include <backend/ITensor.h>
+#include <backend/IPortableTensor.h>
 #include <ir/OperandInfo.h>
 
 namespace onert
@@ -29,7 +29,7 @@ namespace backend
 namespace cpu_common
 {
 
-class Tensor : public ITensor
+class Tensor : public IPortableTensor
 {
 public:
   Tensor() = delete;
@@ -83,8 +83,6 @@ public:
   ir::DataType data_type() const override { return _info.typeInfo().type(); }
   float data_scale() const override { return _info.typeInfo().scale(); }
   int32_t data_offset() const override { return _info.typeInfo().offset(); }
-  bool has_padding() const override { return false; }
-  void access(const std::function<void(ITensor &tensor)> &fn) final;
   bool is_dynamic() const override { return _info.isDynamic(); }
   void set_dynamic() override { _info.setDynamic(); }
 

--- a/runtime/onert/core/include/backend/cpu_common/TensorRegistry.h
+++ b/runtime/onert/core/include/backend/cpu_common/TensorRegistry.h
@@ -17,11 +17,8 @@
 #ifndef __ONERT_BACKEND_CPU_COMMON_TENSOR_REGISTRY__
 #define __ONERT_BACKEND_CPU_COMMON_TENSOR_REGISTRY__
 
-#include "ir/OperandIndexMap.h"
 #include "backend/ITensorRegistry.h"
 #include "Tensor.h"
-
-#include <memory>
 
 namespace onert
 {
@@ -30,6 +27,7 @@ namespace backend
 namespace cpu_common
 {
 
+#if 0
 class TensorRegistry : public ITensorRegistry, public ir::OperandIndexMap<std::shared_ptr<Tensor>>
 {
 public:
@@ -39,6 +37,9 @@ public:
    */
   std::shared_ptr<ITensor> getITensor(const ir::OperandIndex &ind) override { return at(ind); }
 };
+#endif
+
+using TensorRegistry = PortableTensorRegistryTemplate<cpu_common::Tensor>;
 
 } // namespace cpu_common
 } // namespace backend

--- a/runtime/onert/core/src/backend/controlflow/TensorBuilder.cc
+++ b/runtime/onert/core/src/backend/controlflow/TensorBuilder.cc
@@ -94,20 +94,14 @@ void TensorBuilder::allocate()
 
 std::shared_ptr<ITensor> TensorBuilder::tensorAt(const ir::OperandIndex &ind)
 {
-  auto found = _tensor_reg->find(ind);
-  if (found == _tensor_reg->end())
-    return nullptr;
-
-  return found->second;
+  return _tensor_reg->getITensor(ind);
 }
 
 void TensorBuilder::iterate(const IterateFunction &fn) { _static_tensor_mgr->iterate(fn); }
 
 std::shared_ptr<cpu_common::Tensor> TensorBuilder::at(const ir::OperandIndex &ind)
 {
-  auto found = _tensor_reg->find(ind);
-  assert(found != _tensor_reg->end());
-  return found->second;
+  return _tensor_reg->getManagedTensor(ind);
 }
 
 std::unique_ptr<ITensorManager> TensorBuilder::releaseStaticTensorManager(void)

--- a/runtime/onert/core/src/backend/cpu_common/DynamicTensorManager.cc
+++ b/runtime/onert/core/src/backend/cpu_common/DynamicTensorManager.cc
@@ -33,7 +33,7 @@ DynamicTensorManager::DynamicTensorManager(const std::shared_ptr<TensorRegistry>
 
 void DynamicTensorManager::applyShape(const ir::OperandIndex &ind, const ir::Shape &new_shape)
 {
-  auto tensor = (*_tensors)[ind];
+  auto tensor = _tensors->getManagedTensor(ind);
   assert(tensor);
 
   bool previously_dynamic = tensor->is_dynamic();
@@ -86,9 +86,9 @@ void DynamicTensorManager::buildTensor(const ir::OperandIndex &ind,
                                        const ir::OperandInfo &tensor_info,
                                        ir::Layout backend_layout)
 {
-  assert(_tensors->find(ind) == _tensors->end());
+  assert(_tensors->getManagedTensor(ind));
   auto tensor = std::make_shared<Tensor>(tensor_info, backend_layout);
-  (*_tensors)[ind] = tensor;
+  _tensors->setManagedTensor(ind, tensor);
 }
 
 void DynamicTensorManager::planDealloc(ir::OperationIndex op_ind, ir::OperandIndex operand_ind)
@@ -115,7 +115,7 @@ void DynamicTensorManager::deallocInput(ir::OperationIndex op_ind)
   auto &input_set = find->second;
   for (auto input_ind : input_set)
   {
-    if (!_tensors->at(input_ind)->is_dynamic())
+    if (!_tensors->getManagedTensor(input_ind)->is_dynamic())
       continue;
 
     _dynamic_mem_mgr->deallocate(input_ind);
@@ -126,7 +126,7 @@ void DynamicTensorManager::deallocInput(ir::OperationIndex op_ind)
 
 void DynamicTensorManager::deallocSubgraphOutput(ir::OperandIndex output_ind)
 {
-  if (!_tensors->at(output_ind)->is_dynamic())
+  if (!_tensors->getManagedTensor(output_ind)->is_dynamic())
     return;
 
   _dynamic_mem_mgr->deallocate(output_ind);

--- a/runtime/onert/core/src/backend/cpu_common/Tensor.cc
+++ b/runtime/onert/core/src/backend/cpu_common/Tensor.cc
@@ -36,8 +36,6 @@ size_t Tensor::calcOffset(const ir::Coordinates &coords) const
   return offset;
 }
 
-void Tensor::access(const std::function<void(ITensor &)> &fn) { fn(*this); }
-
 void Tensor::setShape(const ir::Shape &new_shape) { _info.shape(new_shape); }
 
 } // namespace cpu_common


### PR DESCRIPTION
This commit introduces `IPortableTensor` which can be used for
cpu-based no-padding tensors.

Backends that use `IPortableTensor` derivatives can reuse each others'
tensors without copying. This can be done by not adding Permute op in
`PermutationInsertionPass` (Will be implemented).

Part of #1325 (an alternative of #1964)

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>