### PR TITLE
[DRAFT/onert] Enable optional input tensor for BCQFullyConnected

### DIFF
--- a/runtime/onert/core/src/ir/operation/BCQFullyConnected.cc
+++ b/runtime/onert/core/src/ir/operation/BCQFullyConnected.cc
@@ -31,7 +31,7 @@ void BCQFullyConnected::accept(OperationVisitor &v) const { v.visit(*this); }
 
 BCQFullyConnected::BCQFullyConnected(const OperandIndexSequence &inputs,
                                      const OperandIndexSequence &outputs, const Param &param)
-    : Operation{OperandConstraint::createInRange(4u, 5u), inputs, outputs}, _param{param}
+    : Operation{OperandConstraint::createExact(5u), inputs, outputs}, _param{param}
 {
 }
 

--- a/runtime/onert/core/src/ir/operation/BCQGather.cc
+++ b/runtime/onert/core/src/ir/operation/BCQGather.cc
@@ -31,7 +31,7 @@ void BCQGather::accept(OperationVisitor &v) const { v.visit(*this); }
 
 BCQGather::BCQGather(const OperandIndexSequence &inputs, const OperandIndexSequence &outputs,
                      const Param &param)
-    : Operation{OperandConstraint::createInRange(3u, 4u), inputs, outputs}, _param{param}
+    : Operation{OperandConstraint::createExact(4u), inputs, outputs}, _param{param}
 {
 }
 

--- a/runtime/onert/frontend/base_loader/include/base_loader.h
+++ b/runtime/onert/frontend/base_loader/include/base_loader.h
@@ -53,7 +53,12 @@ template <typename LoaderDomain, typename SpecificLoader> class BaseLoader
   using Tensor = typename LoaderDomain::Tensor;
   using TensorType = typename LoaderDomain::TensorType;
 
+protected:
   bool isOptionalInputTensor(std::int32_t idx) { return idx == -1; }
+  std::vector<BuiltinOperator> getOptionalInputOplist()
+  {
+    return {BuiltinOperator::BuiltinOperator_FULLY_CONNECTED};
+  }
 
 public:
   /**
@@ -377,10 +382,10 @@ void BaseLoader<LoaderDomain, SpecificLoader>::loadOperationIO(const Operator *o
 {
   for (const std::int32_t idx : *op->inputs())
   {
-    // Optional tensors are not supported yet except for FULLY_CONNECTED.
+    // Optional tensors are not supported yet except for FULLY_CONNECTED and BCQ_FULLY_CONNECTED
     auto check_optional_input = [&]() {
       auto builtin_code = _model->operator_codes()->Get(op->opcode_index())->builtin_code();
-      std::vector<BuiltinOperator> allowed = {BuiltinOperator::BuiltinOperator_FULLY_CONNECTED};
+      auto allowed = static_cast<SpecificLoader *>(this)->getOptionalInputOplist();
       if (isOptionalInputTensor(idx) &&
           std::find(allowed.begin(), allowed.end(), builtin_code) == allowed.end())
         throw std::runtime_error(

--- a/runtime/onert/frontend/base_loader/include/base_loader.h
+++ b/runtime/onert/frontend/base_loader/include/base_loader.h
@@ -55,10 +55,7 @@ template <typename LoaderDomain, typename SpecificLoader> class BaseLoader
 
 protected:
   bool isOptionalInputTensor(std::int32_t idx) { return idx == -1; }
-  std::vector<BuiltinOperator> getOptionalInputOplist()
-  {
-    return {BuiltinOperator::BuiltinOperator_FULLY_CONNECTED};
-  }
+  virtual std::vector<BuiltinOperator> getOptionalInputOplist();
 
 public:
   /**

--- a/runtime/onert/frontend/circle/src/circle_loader.cc
+++ b/runtime/onert/frontend/circle/src/circle_loader.cc
@@ -72,6 +72,12 @@ class CircleLoader final : public base_loader::BaseLoader<LoaderDomain, CircleLo
 public:
   using BaseLoader::BaseLoader;
 
+  std::vector<circle::BuiltinOperator> getOptionalInputOplist()
+  {
+    return {circle::BuiltinOperator::BuiltinOperator_FULLY_CONNECTED,
+            circle::BuiltinOperator::BuiltinOperator_BCQ_FULLY_CONNECTED};
+  }
+
   std::unique_ptr<ir::Graph> loadSubgraph(const circle::SubGraph *circle_subg)
   {
     auto subg = std::make_unique<ir::Graph>();

--- a/runtime/onert/frontend/tflite/src/tflite_loader.cc
+++ b/runtime/onert/frontend/tflite/src/tflite_loader.cc
@@ -65,6 +65,11 @@ class TFLiteLoader final : public base_loader::BaseLoader<LoaderDomain, TFLiteLo
 public:
   using BaseLoader::BaseLoader;
 
+  std::vector<onert_tflite::BuiltinOperator> getOptionalInputOplist()
+  {
+    return {onert_tflite::BuiltinOperator::BuiltinOperator_FULLY_CONNECTED};
+  }
+
   std::unique_ptr<ir::Graph> loadSubgraph(const onert_tflite::SubGraph *tflite_subg)
   {
     auto subg = std::make_unique<ir::Graph>();


### PR DESCRIPTION
- BCQFullyConnected's bias is an optional
- related issue : https://github.sec.samsung.net/STAR/nnfw/issues/11496
- __I just tried this as a draft for bcq test, and isn't complete at all, I need some comments!__

ONE-DCO-1.0-Signed-off-by: dayo09 <dayg502@gmail.com>