### PR TITLE
[luci-interpreter] Introduce ModuleLoader and GraphLoader

### DIFF
--- a/compiler/luci-interpreter/include/luci_interpreter/Interpreter.h
+++ b/compiler/luci-interpreter/include/luci_interpreter/Interpreter.h
@@ -26,7 +26,6 @@
 
 #include <memory>
 #include <vector>
-#include <unordered_map>
 
 namespace luci_interpreter
 {
@@ -56,18 +55,7 @@ public:
   void attachObserver(ExecutionObserver *observer);
 
 private:
-  // TODO Extract into GraphLoader.
-  void loadTensors(const loco::Graph *graph);
-  void initInputOutputTensors(const loco::Graph *graph);
-  void loadKernels(const loco::Graph *graph);
-
   std::unique_ptr<class RuntimeModule> _runtime_module;
-
-  // TODO Extract into ModuleLoader.
-  class RuntimeGraph *_main_runtime_graph;
-
-  // TODO Extract into GraphLoader.
-  std::unordered_map<const loco::Node *, Tensor *> _node_to_tensor;
 
   // Observer functionality support.
   std::unique_ptr<struct RuntimeToIR> _runtime_to_ir;

--- a/compiler/luci-interpreter/src/CMakeLists.txt
+++ b/compiler/luci-interpreter/src/CMakeLists.txt
@@ -1,19 +1,16 @@
 add_subdirectory(core)
 add_subdirectory(kernels)
+add_subdirectory(loader)
 
 set(SOURCES
     "${LUCI_INTERPRETER_INCLUDE_DIR}/luci_interpreter/Interpreter.h"
-    Interpreter.cpp
-    KernelBuilder.h
-    KernelBuilder.cpp
-    RuntimeToIR.h)
+    Interpreter.cpp)
 
 add_library(luci_interpreter SHARED ${SOURCES})
 target_include_directories(luci_interpreter PUBLIC "${LUCI_INTERPRETER_INCLUDE_DIR}")
 target_include_directories(luci_interpreter PRIVATE "${LUCI_INTERPRETER_SOURCE_DIR}")
-target_link_libraries(luci_interpreter PUBLIC luci_lang)
-target_link_libraries(luci_interpreter PUBLIC luci_interpreter_core)
-target_link_libraries(luci_interpreter PRIVATE luci_interpreter_kernels)
-target_link_libraries(luci_interpreter PRIVATE nncc_common)
+target_link_libraries(luci_interpreter
+    PUBLIC luci_lang luci_interpreter_loader luci_interpreter_core
+    PRIVATE nncc_common)
 
 install(TARGETS luci_interpreter DESTINATION lib)

--- a/compiler/luci-interpreter/src/loader/CMakeLists.txt
+++ b/compiler/luci-interpreter/src/loader/CMakeLists.txt
@@ -1,0 +1,15 @@
+set(SOURCES
+    GraphLoader.h
+    GraphLoader.cpp
+    KernelBuilder.h
+    KernelBuilder.cpp
+    ModuleLoader.h
+    ModuleLoader.cpp
+    RuntimeToIR.h)
+
+add_library(luci_interpreter_loader STATIC ${SOURCES})
+set_target_properties(luci_interpreter_loader PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_include_directories(luci_interpreter_loader PUBLIC "${LUCI_INTERPRETER_SOURCE_DIR}")
+target_link_libraries(luci_interpreter_loader
+    PUBLIC luci_lang luci_interpreter_core
+    PRIVATE luci_interpreter_kernels nncc_common)

--- a/compiler/luci-interpreter/src/loader/GraphLoader.cpp
+++ b/compiler/luci-interpreter/src/loader/GraphLoader.cpp
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "loader/GraphLoader.h"
+
+#include "loader/ModuleLoader.h"
+#include "loader/KernelBuilder.h"
+
+#include <loco/IR/Algorithm.h>
+
+namespace luci_interpreter
+{
+namespace
+{
+
+template <typename NodeT> Shape getNodeShape(const NodeT *node)
+{
+  Shape shape(node->rank());
+  for (uint32_t i = 0; i < node->rank(); ++i)
+  {
+    shape.dim(i) = node->dim(i).value();
+  }
+  return shape;
+}
+
+template <DataType DT> const void *getNodeDataImpl(const luci::CircleConst *node, size_t *data_size)
+{
+  const size_t element_size = getDataTypeSize(DT);
+  const int32_t num_elements = node->size<DT>();
+
+  *data_size = num_elements * element_size;
+  // FIXME There is no good way to get the pointer to the data currently.
+  return &node->at<DT>(0);
+}
+
+const void *getNodeData(const luci::CircleConst *node, size_t *data_size)
+{
+  switch (node->dtype())
+  {
+    case DataType::U8:
+      return getNodeDataImpl<DataType::U8>(node, data_size);
+    case DataType::FLOAT32:
+      return getNodeDataImpl<DataType::FLOAT32>(node, data_size);
+    case DataType::S32:
+      return getNodeDataImpl<DataType::S32>(node, data_size);
+    default:
+      throw std::runtime_error("Unsupported type.");
+  }
+}
+
+bool isExecutableNode(const luci::CircleNode *node)
+{
+  switch (node->opcode())
+  {
+    // These nodes denote inputs / outputs of a graph.
+    case luci::CircleOpcode::CONST:
+    case luci::CircleOpcode::CIRCLEINPUT:
+    case luci::CircleOpcode::CIRCLEOUTPUT:
+    // The following nodes denote outputs of multiple-output nodes.
+    case luci::CircleOpcode::CIRCLESPLITOUT:
+    case luci::CircleOpcode::CIRCLEUNPACKOUT:
+      return false;
+    default:
+      return true;
+  }
+}
+
+bool isTensorProducingNode(const luci::CircleNode *node)
+{
+  switch (node->opcode())
+  {
+    // Output nodes do not produce tensors.
+    case luci::CircleOpcode::CIRCLEOUTPUT:
+    // The following nodes are multiple-output nodes. They do not produce tensors, the tensors
+    // are produced by the corresponding *Out nodes instead.
+    case luci::CircleOpcode::SPLIT:
+    case luci::CircleOpcode::UNPACK:
+      return false;
+    default:
+      return true;
+  }
+}
+
+} // namespace
+
+GraphLoader::GraphLoader(const ModuleLoader &module_loader, const loco::Graph *graph,
+                         RuntimeGraph *runtime_graph, RuntimeToIR &runtime_to_ir)
+    : _module_loader(module_loader), _graph(graph), _runtime_graph(runtime_graph),
+      _runtime_to_ir(runtime_to_ir)
+{
+}
+
+void GraphLoader::loadTensors()
+{
+  for (uint32_t i = 0; i < _graph->nodes()->size(); ++i)
+  {
+    const auto *node = loco::must_cast<const luci::CircleNode *>(_graph->nodes()->at(i));
+
+    if (!isTensorProducingNode(node))
+      continue;
+
+    // Only Input and Const nodes have shapes. Shapes of intermediate tensors will be inferred.
+    Shape shape{};
+    if (const auto *input_node = dynamic_cast<const luci::CircleInput *>(node))
+    {
+      shape = getNodeShape(input_node);
+    }
+    else if (const auto *const_node = dynamic_cast<const luci::CircleConst *>(node))
+    {
+      shape = getNodeShape(const_node);
+    }
+
+    AffineQuantization quantization;
+    if (node->quantparam() != nullptr)
+    {
+      const luci::CircleQuantParam *params = node->quantparam();
+      quantization.scale.assign(params->scale.cbegin(), params->scale.cend());
+      quantization.zero_point.assign(params->zerop.cbegin(), params->zerop.cend());
+    }
+
+    auto tensor = std::make_unique<Tensor>(node->dtype(), std::move(shape), std::move(quantization),
+                                           node->name());
+
+    if (const auto *const_node = dynamic_cast<const luci::CircleConst *>(node))
+    {
+      size_t data_size{};
+      const void *const_data = getNodeData(const_node, &data_size);
+      tensor->writeData(const_data, data_size);
+    }
+
+    _node_to_tensor.emplace(node, tensor.get());
+    _runtime_to_ir.tensor_to_node.emplace(tensor.get(), node);
+
+    _runtime_graph->addTensor(std::move(tensor));
+  }
+}
+
+void GraphLoader::initInputOutputTensors() const
+{
+  auto input_nodes = loco::input_nodes(_graph);
+  std::vector<Tensor *> input_tensors(input_nodes.size());
+  for (size_t i = 0; i < input_nodes.size(); ++i)
+  {
+    input_tensors[i] = _node_to_tensor.at(input_nodes[i]);
+  }
+  _runtime_graph->setInputTensors(input_tensors);
+
+  auto output_nodes = loco::output_nodes(const_cast<loco::Graph *>(_graph));
+  std::vector<Tensor *> output_tensors(output_nodes.size());
+  for (size_t i = 0; i < output_nodes.size(); ++i)
+  {
+    const auto *node = loco::must_cast<const luci::CircleOutput *>(output_nodes[i]);
+    output_tensors[i] = _node_to_tensor.at(node->from());
+  }
+  _runtime_graph->setOutputTensors(output_tensors);
+}
+
+void GraphLoader::loadOperators()
+{
+  KernelBuilder kernel_builder(_module_loader, *this);
+
+  // Create kernels for executable nodes. This has to be done in execution order.
+  for (const loco::Node *loco_node :
+       loco::postorder_traversal(loco::output_nodes(const_cast<loco::Graph *>(_graph))))
+  {
+    const auto *node = loco::must_cast<const luci::CircleNode *>(loco_node);
+
+    if (isExecutableNode(node))
+    {
+      _runtime_graph->addKernel(node->accept(&kernel_builder));
+    }
+  }
+}
+
+void GraphLoader::load()
+{
+  loadTensors();
+  initInputOutputTensors();
+  loadOperators();
+}
+
+} // namespace luci_interpreter

--- a/compiler/luci-interpreter/src/loader/GraphLoader.h
+++ b/compiler/luci-interpreter/src/loader/GraphLoader.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef LUCI_INTERPRETER_LOADER_GRAPHLOADER_H
+#define LUCI_INTERPRETER_LOADER_GRAPHLOADER_H
+
+#include "core/RuntimeGraph.h"
+#include "loader/RuntimeToIR.h"
+
+#include <loco/IR/Graph.h>
+
+#include <unordered_map>
+
+namespace luci_interpreter
+{
+
+class ModuleLoader;
+
+class GraphLoader
+{
+public:
+  GraphLoader(const ModuleLoader &module_loader, const loco::Graph *graph,
+              RuntimeGraph *runtime_graph, RuntimeToIR &runtime_to_ir);
+
+  void load();
+
+  Tensor *getTensorForNode(const loco::Node *node) const { return _node_to_tensor.at(node); }
+
+private:
+  void loadOperators();
+  void initInputOutputTensors() const;
+  void loadTensors();
+
+  const ModuleLoader &_module_loader;
+  const loco::Graph *_graph;
+  RuntimeGraph *_runtime_graph;
+  RuntimeToIR &_runtime_to_ir;
+
+  std::unordered_map<const loco::Node *, Tensor *> _node_to_tensor;
+};
+
+} // namespace luci_interpreter
+
+#endif // LUCI_INTERPRETER_LOADER_GRAPHLOADER_H

--- a/compiler/luci-interpreter/src/loader/KernelBuilder.cpp
+++ b/compiler/luci-interpreter/src/loader/KernelBuilder.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "KernelBuilder.h"
+#include "loader/KernelBuilder.h"
 
 #include "kernels/Add.h"
 #include "kernels/ArgMax.h"
@@ -39,6 +39,8 @@
 #include "kernels/Unpack.h"
 #include "kernels/Transpose.h"
 #include "kernels/TransposeConv.h"
+#include "loader/GraphLoader.h"
+#include "loader/ModuleLoader.h"
 
 #include <stdexcept>
 
@@ -62,7 +64,7 @@ static std::vector<const loco::Node *> collectOutputNodes(const luci::CircleNode
 
 const Tensor *KernelBuilder::getInputTensor(const loco::Node *node) const
 {
-  const Tensor *tensor = _node_to_tensor.at(node);
+  const Tensor *tensor = _graph_loader.getTensorForNode(node);
   assert(tensor != nullptr);
   return tensor;
 }
@@ -75,7 +77,7 @@ const Tensor *KernelBuilder::getOptionalInputTensor(const loco::Node *node) cons
 
 Tensor *KernelBuilder::getOutputTensor(const loco::Node *node) const
 {
-  Tensor *tensor = _node_to_tensor.at(node);
+  Tensor *tensor = _graph_loader.getTensorForNode(node);
   assert(tensor != nullptr);
   return tensor;
 }
@@ -88,6 +90,13 @@ KernelBuilder::getOutputTensors(const std::vector<const loco::Node *> &nodes) co
   for (const loco::Node *node : nodes)
     tensors.push_back(getOutputTensor(node));
   return tensors;
+}
+
+RuntimeGraph *KernelBuilder::getRuntimeGraph(const loco::Graph *graph) const
+{
+  RuntimeGraph *runtime_graph = _module_loader.getRuntimeGraph(graph);
+  assert(runtime_graph != nullptr);
+  return runtime_graph;
 }
 
 std::unique_ptr<Kernel> KernelBuilder::visit(const luci::CircleAdd *node)

--- a/compiler/luci-interpreter/src/loader/KernelBuilder.h
+++ b/compiler/luci-interpreter/src/loader/KernelBuilder.h
@@ -14,25 +14,28 @@
  * limitations under the License.
  */
 
-#ifndef LUCI_INTERPRETER_KERNELBUILDER_H
-#define LUCI_INTERPRETER_KERNELBUILDER_H
+#ifndef LUCI_INTERPRETER_LOADER_KERNELBUILDER_H
+#define LUCI_INTERPRETER_LOADER_KERNELBUILDER_H
 
 #include "core/Kernel.h"
+#include "core/RuntimeGraph.h"
 
 #include <luci/IR/CircleNodeVisitor.h>
 
 #include <memory>
-#include <unordered_map>
 #include <vector>
 
 namespace luci_interpreter
 {
 
+class GraphLoader;
+class ModuleLoader;
+
 class KernelBuilder : public luci::CircleNodeVisitor<std::unique_ptr<Kernel>>
 {
 public:
-  explicit KernelBuilder(std::unordered_map<const loco::Node *, Tensor *> &node_to_tensor)
-      : _node_to_tensor(node_to_tensor)
+  KernelBuilder(const ModuleLoader &module_loader, const GraphLoader &graph_loader)
+      : _module_loader(module_loader), _graph_loader(graph_loader)
   {
   }
 
@@ -72,10 +75,13 @@ private:
 
   std::vector<Tensor *> getOutputTensors(const std::vector<const loco::Node *> &nodes) const;
 
+  RuntimeGraph *getRuntimeGraph(const loco::Graph *graph) const;
+
 private:
-  std::unordered_map<const loco::Node *, Tensor *> &_node_to_tensor;
+  const ModuleLoader &_module_loader;
+  const GraphLoader &_graph_loader;
 };
 
 } // namespace luci_interpreter
 
-#endif // LUCI_INTERPRETER_KERNELBUILDER_H
+#endif // LUCI_INTERPRETER_LOADER_KERNELBUILDER_H

--- a/compiler/luci-interpreter/src/loader/ModuleLoader.cpp
+++ b/compiler/luci-interpreter/src/loader/ModuleLoader.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ModuleLoader.h"
+
+#include "GraphLoader.h"
+
+namespace luci_interpreter
+{
+
+ModuleLoader::ModuleLoader(const luci::Module *module, RuntimeModule *runtime_module,
+                           RuntimeToIR &runtime_to_ir)
+    : _module(module), _runtime_module(runtime_module), _runtime_to_ir(runtime_to_ir)
+{
+}
+
+void ModuleLoader::load()
+{
+  // Runtime graphs have to be created in advance, because they will be needed during the loading
+  // process for control flow nodes.
+  for (size_t i = 0; i < _module->size(); ++i)
+  {
+    _graph_to_runtime_graph.emplace(_module->graph(i), _runtime_module->addGraph());
+  }
+  for (size_t i = 0; i < _module->size(); ++i)
+  {
+    const loco::Graph *graph = _module->graph(i);
+    RuntimeGraph *runtime_graph = _graph_to_runtime_graph.at(graph);
+    GraphLoader loader(*this, graph, runtime_graph, _runtime_to_ir);
+    loader.load();
+  }
+}
+
+} // namespace luci_interpreter

--- a/compiler/luci-interpreter/src/loader/ModuleLoader.h
+++ b/compiler/luci-interpreter/src/loader/ModuleLoader.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef LUCI_INTERPRETER_LOADER_MODULELOADER_H
+#define LUCI_INTERPRETER_LOADER_MODULELOADER_H
+
+#include "core/RuntimeModule.h"
+#include "loader/RuntimeToIR.h"
+
+#include <luci/IR/Module.h>
+
+#include <unordered_map>
+
+namespace luci_interpreter
+{
+
+class ModuleLoader
+{
+public:
+  ModuleLoader(const luci::Module *module, RuntimeModule *runtime_module,
+               RuntimeToIR &runtime_to_ir);
+
+  void load();
+
+  RuntimeGraph *getRuntimeGraph(const loco::Graph *graph) const
+  {
+    return _graph_to_runtime_graph.at(graph);
+  }
+
+private:
+  const luci::Module *_module;
+  RuntimeModule *_runtime_module;
+  RuntimeToIR &_runtime_to_ir;
+  std::unordered_map<const loco::Graph *, RuntimeGraph *> _graph_to_runtime_graph;
+};
+
+} // namespace luci_interpreter
+
+#endif // LUCI_INTERPRETER_LOADER_MODULELOADER_H

--- a/compiler/luci-interpreter/src/loader/RuntimeToIR.h
+++ b/compiler/luci-interpreter/src/loader/RuntimeToIR.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef LUCI_INTERPRETER_RUNTIMETOIR_H
-#define LUCI_INTERPRETER_RUNTIMETOIR_H
+#ifndef LUCI_INTERPRETER_LOADER_RUNTIMETOIR_H
+#define LUCI_INTERPRETER_LOADER_RUNTIMETOIR_H
 
 #include "luci_interpreter/core/Tensor.h"
 
@@ -34,4 +34,4 @@ struct RuntimeToIR
 
 } // namespace luci_interpreter
 
-#endif // LUCI_INTERPRETER_RUNTIMETOIR_H
+#endif // LUCI_INTERPRETER_LOADER_RUNTIMETOIR_H


### PR DESCRIPTION
Draft PR #1980.

Extract part of the `Interpreter` class into `ModuleLoader` and `GraphLoader` classes.

ONE-DCO-1.0-Signed-off-by: Sergei Barannikov <s.barannikov@samsung.com>