### PR TITLE
[onert] use template parameter for BinaryArithmetic op types

### DIFF
--- a/compute/cker/include/cker/Types.h
+++ b/compute/cker/include/cker/Types.h
@@ -157,7 +157,6 @@ struct ComparisonParams
 
 struct BinaryArithmeticOpParam
 {
-  BinaryArithmeticOpType type;
   // Shape dependent / common to data / op types.
   BroadcastableOpCategory broadcast_category;
   // uint8 inference params.

--- a/runtime/onert/backend/cpu/ops/AddLayer.cc
+++ b/runtime/onert/backend/cpu/ops/AddLayer.cc
@@ -32,7 +32,6 @@ void AddLayer::addFloat32()
   float output_activation_min = 0, output_activation_max = 0;
   CalculateActivationRange(_activation, &output_activation_min, &output_activation_max);
   nnfw::cker::BinaryArithmeticOpParam op_params;
-  op_params.type = nnfw::cker::BinaryArithmeticOpType::ADD;
   op_params.float_activation_max = output_activation_max;
   op_params.float_activation_min = output_activation_min;
 
@@ -40,14 +39,14 @@ void AddLayer::addFloat32()
       nnfw::cker::ProcessBroadcastShapes(getTensorShape(_lhs), getTensorShape(_rhs), &op_params);
   if (need_broadcast)
   {
-    nnfw::cker::BroadcastBinaryArithmeticOp<float>(
+    nnfw::cker::BroadcastBinaryArithmeticOp<nnfw::cker::BinaryArithmeticOpType::ADD>(
         op_params, getTensorShape(_lhs), reinterpret_cast<const float *>(_lhs->buffer()),
         getTensorShape(_rhs), reinterpret_cast<const float *>(_rhs->buffer()),
         getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()));
     return;
   }
 
-  nnfw::cker::BinaryArithmeticOp<float>(
+  nnfw::cker::BinaryArithmeticOp<nnfw::cker::BinaryArithmeticOpType::ADD>(
       op_params, getTensorShape(_lhs), reinterpret_cast<const float *>(_lhs->buffer()),
       getTensorShape(_rhs), reinterpret_cast<const float *>(_rhs->buffer()),
       getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()));
@@ -58,7 +57,6 @@ void AddLayer::addInt32()
   int32_t output_activation_min = 0, output_activation_max = 0;
   CalculateActivationRange(_activation, &output_activation_min, &output_activation_max);
   nnfw::cker::BinaryArithmeticOpParam op_params;
-  op_params.type = nnfw::cker::BinaryArithmeticOpType::ADD;
   op_params.quantized_activation_max = output_activation_max;
   op_params.quantized_activation_min = output_activation_min;
 
@@ -66,14 +64,14 @@ void AddLayer::addInt32()
       nnfw::cker::ProcessBroadcastShapes(getTensorShape(_lhs), getTensorShape(_rhs), &op_params);
   if (need_broadcast)
   {
-    nnfw::cker::BroadcastBinaryArithmeticOp<int32_t>(
+    nnfw::cker::BroadcastBinaryArithmeticOp<nnfw::cker::BinaryArithmeticOpType::ADD>(
         op_params, getTensorShape(_lhs), reinterpret_cast<const int32_t *>(_lhs->buffer()),
         getTensorShape(_rhs), reinterpret_cast<const int32_t *>(_rhs->buffer()),
         getTensorShape(_output), reinterpret_cast<int32_t *>(_output->buffer()));
     return;
   }
 
-  nnfw::cker::BinaryArithmeticOp<int32_t>(
+  nnfw::cker::BinaryArithmeticOp<nnfw::cker::BinaryArithmeticOpType::ADD>(
       op_params, getTensorShape(_lhs), reinterpret_cast<const int32_t *>(_lhs->buffer()),
       getTensorShape(_rhs), reinterpret_cast<const int32_t *>(_rhs->buffer()),
       getTensorShape(_output), reinterpret_cast<int32_t *>(_output->buffer()));
@@ -85,7 +83,6 @@ void AddLayer::addQuant8()
   CalculateActivationRangeUint8(_activation, _output, &output_activation_min,
                                 &output_activation_max);
   nnfw::cker::BinaryArithmeticOpParam op_params;
-  op_params.type = nnfw::cker::BinaryArithmeticOpType::ADD;
   op_params.quantized_activation_max = output_activation_max;
   op_params.quantized_activation_min = output_activation_min;
   // Parameters for scaled quantized computation
@@ -117,14 +114,14 @@ void AddLayer::addQuant8()
       nnfw::cker::ProcessBroadcastShapes(getTensorShape(_lhs), getTensorShape(_rhs), &op_params);
   if (need_broadcast)
   {
-    nnfw::cker::BroadcastBinaryArithmeticOp<uint8_t>(
+    nnfw::cker::BroadcastBinaryArithmeticOp<nnfw::cker::BinaryArithmeticOpType::ADD>(
         op_params, getTensorShape(_lhs), reinterpret_cast<const uint8_t *>(_lhs->buffer()),
         getTensorShape(_rhs), reinterpret_cast<const uint8_t *>(_rhs->buffer()),
         getTensorShape(_output), reinterpret_cast<uint8_t *>(_output->buffer()));
     return;
   }
 
-  nnfw::cker::BinaryArithmeticOp<uint8_t>(
+  nnfw::cker::BinaryArithmeticOp<nnfw::cker::BinaryArithmeticOpType::ADD>(
       op_params, getTensorShape(_lhs), reinterpret_cast<const uint8_t *>(_lhs->buffer()),
       getTensorShape(_rhs), reinterpret_cast<const uint8_t *>(_rhs->buffer()),
       getTensorShape(_output), reinterpret_cast<uint8_t *>(_output->buffer()));

--- a/runtime/onert/backend/cpu/ops/DivLayer.cc
+++ b/runtime/onert/backend/cpu/ops/DivLayer.cc
@@ -32,21 +32,20 @@ void DivLayer::divFloat32()
   float output_activation_min = 0, output_activation_max = 0;
   CalculateActivationRange(_activation, &output_activation_min, &output_activation_max);
   nnfw::cker::BinaryArithmeticOpParam op_params;
-  op_params.type = nnfw::cker::BinaryArithmeticOpType::DIV;
   op_params.float_activation_max = output_activation_max;
   op_params.float_activation_min = output_activation_min;
 
   const bool requires_broadcast = !HaveSameShapes(_lhs, _rhs);
   if (requires_broadcast)
   {
-    nnfw::cker::BroadcastBinaryArithmeticOp(
+    nnfw::cker::BroadcastBinaryArithmeticOp<nnfw::cker::BinaryArithmeticOpType::DIV>(
         op_params, getTensorShape(_lhs), reinterpret_cast<const float *>(_lhs->buffer()),
         getTensorShape(_rhs), reinterpret_cast<const float *>(_rhs->buffer()),
         getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()));
   }
   else
   {
-    nnfw::cker::BinaryArithmeticOp(
+    nnfw::cker::BinaryArithmeticOp<nnfw::cker::BinaryArithmeticOpType::DIV>(
         op_params, getTensorShape(_lhs), reinterpret_cast<const float *>(_lhs->buffer()),
         getTensorShape(_rhs), reinterpret_cast<const float *>(_rhs->buffer()),
         getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()));
@@ -58,7 +57,6 @@ void DivLayer::divQuant8()
   int32_t output_activation_min, output_activation_max;
   CalculateActivationRangeUint8(_activation, _output, &output_activation_min,
                                 &output_activation_max);
-  // nnfw::cker::BinaryArithmeticOpParam op_params;
   // op_params.quantized_activation_max = output_activation_max;
   // op_params.quantized_activation_min = output_activation_min;
 

--- a/runtime/onert/backend/cpu/ops/MulLayer.cc
+++ b/runtime/onert/backend/cpu/ops/MulLayer.cc
@@ -32,7 +32,6 @@ void MulLayer::mulFloat32()
   float output_activation_min = 0, output_activation_max = 0;
   CalculateActivationRange(_activation, &output_activation_min, &output_activation_max);
   nnfw::cker::BinaryArithmeticOpParam op_params;
-  op_params.type = nnfw::cker::BinaryArithmeticOpType::MUL;
   op_params.float_activation_max = output_activation_max;
   op_params.float_activation_min = output_activation_min;
 
@@ -40,14 +39,14 @@ void MulLayer::mulFloat32()
       nnfw::cker::ProcessBroadcastShapes(getTensorShape(_lhs), getTensorShape(_rhs), &op_params);
   if (need_broadcast)
   {
-    nnfw::cker::BroadcastBinaryArithmeticOp(
+    nnfw::cker::BroadcastBinaryArithmeticOp<nnfw::cker::BinaryArithmeticOpType::MUL>(
         op_params, getTensorShape(_lhs), reinterpret_cast<const float *>(_lhs->buffer()),
         getTensorShape(_rhs), reinterpret_cast<const float *>(_rhs->buffer()),
         getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()));
     return;
   }
 
-  nnfw::cker::BinaryArithmeticOp(
+  nnfw::cker::BinaryArithmeticOp<nnfw::cker::BinaryArithmeticOpType::MUL>(
       op_params, getTensorShape(_lhs), reinterpret_cast<const float *>(_lhs->buffer()),
       getTensorShape(_rhs), reinterpret_cast<const float *>(_rhs->buffer()),
       getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()));

--- a/runtime/onert/backend/cpu/ops/PowLayer.cc
+++ b/runtime/onert/backend/cpu/ops/PowLayer.cc
@@ -33,13 +33,12 @@ void PowLayer::powFloat32()
   float output_activation_min = 0, output_activation_max = 0;
   CalculateActivationRange(_activation, &output_activation_min, &output_activation_max);
   nnfw::cker::BinaryArithmeticOpParam op_params;
-  op_params.type = nnfw::cker::BinaryArithmeticOpType::POW;
   op_params.float_activation_max = output_activation_max;
   op_params.float_activation_min = output_activation_min;
 
   if (!HaveSameShapes(_lhs, _rhs))
   {
-    nnfw::cker::BroadcastBinaryArithmeticOp(
+    nnfw::cker::BroadcastBinaryArithmeticOp<nnfw::cker::BinaryArithmeticOpType::POW>(
         op_params, getTensorShape(_lhs), reinterpret_cast<const float *>(_lhs->buffer()),
         getTensorShape(_rhs), reinterpret_cast<const float *>(_rhs->buffer()),
         getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()));

--- a/runtime/onert/backend/cpu/ops/SubLayer.cc
+++ b/runtime/onert/backend/cpu/ops/SubLayer.cc
@@ -32,7 +32,6 @@ void SubLayer::subFloat32()
   float output_activation_min = 0, output_activation_max = 0;
   CalculateActivationRange(_activation, &output_activation_min, &output_activation_max);
   nnfw::cker::BinaryArithmeticOpParam op_params;
-  op_params.type = nnfw::cker::BinaryArithmeticOpType::SUB;
   op_params.float_activation_max = output_activation_max;
   op_params.float_activation_min = output_activation_min;
 
@@ -40,14 +39,14 @@ void SubLayer::subFloat32()
       nnfw::cker::ProcessBroadcastShapes(getTensorShape(_lhs), getTensorShape(_rhs), &op_params);
   if (need_broadcast)
   {
-    nnfw::cker::BroadcastBinaryArithmeticOp(
+    nnfw::cker::BroadcastBinaryArithmeticOp<nnfw::cker::BinaryArithmeticOpType::SUB>(
         op_params, getTensorShape(_lhs), reinterpret_cast<const float *>(_lhs->buffer()),
         getTensorShape(_rhs), reinterpret_cast<const float *>(_rhs->buffer()),
         getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()));
     return;
   }
 
-  nnfw::cker::BinaryArithmeticOp(
+  nnfw::cker::BinaryArithmeticOp<nnfw::cker::BinaryArithmeticOpType::SUB>(
       op_params, getTensorShape(_lhs), reinterpret_cast<const float *>(_lhs->buffer()),
       getTensorShape(_rhs), reinterpret_cast<const float *>(_rhs->buffer()),
       getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()));

--- a/runtime/onert/core/src/interp/operations/BinaryArithmeticOps.cc
+++ b/runtime/onert/core/src/interp/operations/BinaryArithmeticOps.cc
@@ -23,6 +23,7 @@
 #include "ir/operation/Sub.h"
 #include "ir/operation/Mul.h"
 #include "misc/polymorphic_downcast.h"
+#include "cker/Types.h"
 
 namespace onert
 {
@@ -118,10 +119,11 @@ void invoke(const ITensor *lhs_tensor, const ITensor *rhs_tensor, const ITensor 
   const raw_type *rhs_ptr = reinterpret_cast<const raw_type *>(rhs_buffer);
   raw_type *out_ptr = reinterpret_cast<raw_type *>(out_buffer);
 
-  cker_param.type = (op_type == OpType::ADD)
-                        ? nnfw::cker::BinaryArithmeticOpType::ADD
-                        : ((op_type == OpType::SUB) ? nnfw::cker::BinaryArithmeticOpType::SUB
-                                                    : nnfw::cker::BinaryArithmeticOpType::MUL);
+  const auto cker_op_type =
+      (op_type == OpType::ADD)
+          ? nnfw::cker::BinaryArithmeticOpType::ADD
+          : ((op_type == OpType::SUB) ? nnfw::cker::BinaryArithmeticOpType::SUB
+                                      : nnfw::cker::BinaryArithmeticOpType::MUL);
 
   const bool need_broadcast = nnfw::cker::ProcessBroadcastShapes(
       convertShape(lhs_tensor->tensorInfo().shape()),
@@ -132,16 +134,16 @@ void invoke(const ITensor *lhs_tensor, const ITensor *rhs_tensor, const ITensor 
     const auto lhs_shape = convertShape(lhs_tensor->tensorInfo().shape());
     const auto rhs_shape = convertShape(rhs_tensor->tensorInfo().shape());
     const auto out_shape = convertShape(out_tensor->tensorInfo().shape());
-    nnfw::cker::BroadcastBinaryArithmeticOp(cker_param, lhs_shape, lhs_ptr, rhs_shape, rhs_ptr,
-                                            out_shape, out_ptr);
+    nnfw::cker::BroadcastBinaryArithmeticOp<cker_op_type>(cker_param, lhs_shape, lhs_ptr, rhs_shape,
+                                                          rhs_ptr, out_shape, out_ptr);
     return;
   }
 
   const auto lhs_shape = convertShape(lhs_tensor->tensorInfo().shape());
   const auto rhs_shape = convertShape(rhs_tensor->tensorInfo().shape());
   const auto out_shape = convertShape(out_tensor->tensorInfo().shape());
-  nnfw::cker::BinaryArithmeticOp(cker_param, lhs_shape, lhs_ptr, rhs_shape, rhs_ptr, out_shape,
-                                 out_ptr);
+  nnfw::cker::BinaryArithmeticOp<cker_op_type>(cker_param, lhs_shape, lhs_ptr, rhs_shape, rhs_ptr,
+                                               out_shape, out_ptr);
 }
 
 template <typename node_type, typename param_type, OpType op_type>


### PR DESCRIPTION
Previously, it uses runtime parameter for op type (ADD, SUB, ...).
However, it is determined before runtime. It replaces it with
template parameter. It gives about 1~2% improvement for some model.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>