### PR TITLE
[onert] enable optional input tensor for BCQFullyConnected

### DIFF
--- a/runtime/onert/core/src/ir/operation/BCQFullyConnected.cc
+++ b/runtime/onert/core/src/ir/operation/BCQFullyConnected.cc
@@ -31,7 +31,7 @@ void BCQFullyConnected::accept(OperationVisitor &v) const { v.visit(*this); }
 
 BCQFullyConnected::BCQFullyConnected(const OperandIndexSequence &inputs,
                                      const OperandIndexSequence &outputs, const Param &param)
-    : Operation{OperandConstraint::createInRange(4u, 5u), inputs, outputs}, _param{param}
+    : Operation{OperandConstraint::createExact(5u), inputs, outputs}, _param{param}
 {
 }
 

--- a/runtime/onert/core/src/ir/operation/BCQGather.cc
+++ b/runtime/onert/core/src/ir/operation/BCQGather.cc
@@ -31,7 +31,7 @@ void BCQGather::accept(OperationVisitor &v) const { v.visit(*this); }
 
 BCQGather::BCQGather(const OperandIndexSequence &inputs, const OperandIndexSequence &outputs,
                      const Param &param)
-    : Operation{OperandConstraint::createInRange(3u, 4u), inputs, outputs}, _param{param}
+    : Operation{OperandConstraint::createExact(4u), inputs, outputs}, _param{param}
 {
 }
 

--- a/runtime/onert/frontend/base_loader/include/base_loader.h
+++ b/runtime/onert/frontend/base_loader/include/base_loader.h
@@ -56,7 +56,7 @@ protected:
 
 protected:
   bool isOptionalInputTensor(std::int32_t idx) { return idx == -1; }
-  virtual std::vector<BuiltinOperator> getOptionalInputOplist() = 0;
+  virtual bool allowOptionalInputTensor(BuiltinOperator) = 0;
 
 public:
   /**
@@ -383,9 +383,7 @@ void BaseLoader<LoaderDomain, SpecificLoader>::loadOperationIO(const Operator *o
     // Optional tensors are not supported yet except for FULLY_CONNECTED and BCQ_FULLY_CONNECTED
     auto check_optional_input = [&]() {
       auto builtin_code = _model->operator_codes()->Get(op->opcode_index())->builtin_code();
-      auto allowed = static_cast<SpecificLoader *>(this)->getOptionalInputOplist();
-      if (isOptionalInputTensor(idx) &&
-          std::find(allowed.begin(), allowed.end(), builtin_code) == allowed.end())
+      if (isOptionalInputTensor(idx) && !allowOptionalInputTensor(builtin_code))
         throw std::runtime_error(
             std::string("loader doesn't support optional input tensor yet for ")
                 .append(EnumNameBuiltinOperator(builtin_code)));

--- a/runtime/onert/frontend/circle/src/circle_loader.cc
+++ b/runtime/onert/frontend/circle/src/circle_loader.cc
@@ -72,6 +72,12 @@ class CircleLoader final : public base_loader::BaseLoader<LoaderDomain, CircleLo
 public:
   using BaseLoader::BaseLoader;
 
+  std::vector<BuiltinOperator> getOptionalInputOplist() override
+  {
+    return {BuiltinOperator::BuiltinOperator_FULLY_CONNECTED,
+            BuiltinOperator::BuiltinOperator_BCQ_FULLY_CONNECTED};
+  }
+
   std::unique_ptr<ir::Graph> loadSubgraph(const circle::SubGraph *circle_subg)
   {
     auto subg = std::make_unique<ir::Graph>();

--- a/runtime/onert/frontend/circle/src/circle_loader.cc
+++ b/runtime/onert/frontend/circle/src/circle_loader.cc
@@ -72,10 +72,16 @@ class CircleLoader final : public base_loader::BaseLoader<LoaderDomain, CircleLo
 public:
   using BaseLoader::BaseLoader;
 
-  std::vector<BuiltinOperator> getOptionalInputOplist() override
+  bool allowOptionalInputTensor(BuiltinOperator op) override
   {
-    return {BuiltinOperator::BuiltinOperator_FULLY_CONNECTED,
-            BuiltinOperator::BuiltinOperator_BCQ_FULLY_CONNECTED};
+    switch (op)
+    {
+      case BuiltinOperator::BuiltinOperator_FULLY_CONNECTED:
+      case BuiltinOperator::BuiltinOperator_BCQ_FULLY_CONNECTED:
+        return true;
+      default:
+        return false;
+    }
   }
 
   std::unique_ptr<ir::Graph> loadSubgraph(const circle::SubGraph *circle_subg)

--- a/runtime/onert/frontend/tflite/src/tflite_loader.cc
+++ b/runtime/onert/frontend/tflite/src/tflite_loader.cc
@@ -65,9 +65,15 @@ class TFLiteLoader final : public base_loader::BaseLoader<LoaderDomain, TFLiteLo
 public:
   using BaseLoader::BaseLoader;
 
-  std::vector<BuiltinOperator> getOptionalInputOplist() override
+  bool allowOptionalInputTensor(BuiltinOperator op) override
   {
-    return {BuiltinOperator::BuiltinOperator_FULLY_CONNECTED};
+    switch (op)
+    {
+      case BuiltinOperator::BuiltinOperator_FULLY_CONNECTED:
+        return true;
+      default:
+        return false;
+    }
   }
 
   std::unique_ptr<ir::Graph> loadSubgraph(const onert_tflite::SubGraph *tflite_subg)

--- a/runtime/onert/frontend/tflite/src/tflite_loader.cc
+++ b/runtime/onert/frontend/tflite/src/tflite_loader.cc
@@ -65,6 +65,11 @@ class TFLiteLoader final : public base_loader::BaseLoader<LoaderDomain, TFLiteLo
 public:
   using BaseLoader::BaseLoader;
 
+  std::vector<BuiltinOperator> getOptionalInputOplist() override
+  {
+    return {BuiltinOperator::BuiltinOperator_FULLY_CONNECTED};
+  }
+
   std::unique_ptr<ir::Graph> loadSubgraph(const onert_tflite::SubGraph *tflite_subg)
   {
     auto subg = std::make_unique<ir::Graph>();


### PR DESCRIPTION
- BCQFullyConnected's bias is an optional
- Make getOptionalInputOplist() for tflite_loader.cc and circle_loader.cc, which gets optional tensor input supporting operation list.

ONE-DCO-1.0-Signed-off-by: dayo09 <dayg502@gmail.com>