### PR TITLE
MinLayer supports INT32 type on cpu backend

### DIFF
--- a/runtime/onert/backend/cpu/ops/MinLayer.cc
+++ b/runtime/onert/backend/cpu/ops/MinLayer.cc
@@ -60,9 +60,10 @@ void MinLayer::run()
   }
   else if (_lhs->data_type() == OperandType::INT32)
   {
-    nnfw::cker::Min<int32_t>(getTensorShape(_lhs), reinterpret_cast<const int32_t *>(_lhs->buffer()),
-                             getTensorShape(_rhs), reinterpret_cast<const int32_t *>(_rhs->buffer()),
-                             getTensorShape(_output), reinterpret_cast<int32_t *>(_output->buffer()));
+    nnfw::cker::Min<int32_t>(
+        getTensorShape(_lhs), reinterpret_cast<const int32_t *>(_lhs->buffer()),
+        getTensorShape(_rhs), reinterpret_cast<const int32_t *>(_rhs->buffer()),
+        getTensorShape(_output), reinterpret_cast<int32_t *>(_output->buffer()));
   }
   else
   {

--- a/runtime/onert/backend/cpu/ops/MinLayer.cc
+++ b/runtime/onert/backend/cpu/ops/MinLayer.cc
@@ -29,31 +29,6 @@ namespace cpu
 namespace ops
 {
 
-void MinLayer::minFloat32()
-{
-  nnfw::cker::Min<float>(getTensorShape(_lhs), reinterpret_cast<const float *>(_lhs->buffer()),
-                         getTensorShape(_rhs), reinterpret_cast<const float *>(_rhs->buffer()),
-                         getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()));
-}
-
-void MinLayer::minInt32()
-{
-  nnfw::cker::Min<int32_t>(getTensorShape(_lhs), reinterpret_cast<const int32_t *>(_lhs->buffer()),
-                           getTensorShape(_rhs), reinterpret_cast<const int32_t *>(_rhs->buffer()),
-                           getTensorShape(_output), reinterpret_cast<int32_t *>(_output->buffer()));
-}
-
-void MinLayer::minQuant8()
-{
-  // TODO Check whether cker for quant8 min produces correct results
-  // nnfw::cker::Min<uint8_t>(
-  //     getTensorShape(_lhs), reinterpret_cast<const uint8_t*>(_lhs->buffer()),
-  //     getTensorShape(_rhs), reinterpret_cast<const uint8_t*>(_rhs->buffer()),
-  //     getTensorShape(_output), reinterpret_cast<uint8_t*>(_output->buffer()));
-
-  throw std::runtime_error("Min NYI for quantized");
-}
-
 void MinLayer::configure(const Tensor *lhs, const Tensor *rhs, Tensor *output)
 {
   assert(lhs != nullptr);
@@ -69,15 +44,25 @@ void MinLayer::run()
 {
   if (_lhs->data_type() == OperandType::FLOAT32)
   {
-    minFloat32();
+    nnfw::cker::Min<float>(getTensorShape(_lhs), reinterpret_cast<const float *>(_lhs->buffer()),
+                           getTensorShape(_rhs), reinterpret_cast<const float *>(_rhs->buffer()),
+                           getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()));
   }
   else if (_lhs->data_type() == OperandType::QUANT_UINT8_ASYMM)
   {
-    minQuant8();
+    // TODO Check whether cker for quant8 min produces correct results
+    // nnfw::cker::Min<uint8_t>(
+    //     getTensorShape(_lhs), reinterpret_cast<const uint8_t*>(_lhs->buffer()),
+    //     getTensorShape(_rhs), reinterpret_cast<const uint8_t*>(_rhs->buffer()),
+    //     getTensorShape(_output), reinterpret_cast<uint8_t*>(_output->buffer()));
+
+    throw std::runtime_error("Min NYI for quantized");
   }
   else if (_lhs->data_type() == OperandType::INT32)
   {
-    minInt32();
+    nnfw::cker::Min<int32_t>(getTensorShape(_lhs), reinterpret_cast<const int32_t *>(_lhs->buffer()),
+                             getTensorShape(_rhs), reinterpret_cast<const int32_t *>(_rhs->buffer()),
+                             getTensorShape(_output), reinterpret_cast<int32_t *>(_output->buffer()));
   }
   else
   {

--- a/runtime/onert/backend/cpu/ops/MinLayer.cc
+++ b/runtime/onert/backend/cpu/ops/MinLayer.cc
@@ -36,6 +36,14 @@ void MinLayer::minFloat32()
                          getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()));
 }
 
+void MinLayer::minInt32()
+{
+  nnfw::cker::Min<int32_t>(getTensorShape(_lhs), reinterpret_cast<const int32_t *>(_lhs->buffer()),
+                           getTensorShape(_rhs), reinterpret_cast<const int32_t *>(_rhs->buffer()),
+                           getTensorShape(_output), reinterpret_cast<int32_t *>(_output->buffer()));
+
+}
+
 void MinLayer::minQuant8()
 {
   // TODO Check whether cker for quant8 min produces correct results
@@ -67,6 +75,10 @@ void MinLayer::run()
   else if (_lhs->data_type() == OperandType::QUANT_UINT8_ASYMM)
   {
     minQuant8();
+  }
+  else if (_lhs->data_type() == OperandType::INT32)
+  {
+    minInt32();
   }
   else
   {

--- a/runtime/onert/backend/cpu/ops/MinLayer.cc
+++ b/runtime/onert/backend/cpu/ops/MinLayer.cc
@@ -41,7 +41,6 @@ void MinLayer::minInt32()
   nnfw::cker::Min<int32_t>(getTensorShape(_lhs), reinterpret_cast<const int32_t *>(_lhs->buffer()),
                            getTensorShape(_rhs), reinterpret_cast<const int32_t *>(_rhs->buffer()),
                            getTensorShape(_output), reinterpret_cast<int32_t *>(_output->buffer()));
-
 }
 
 void MinLayer::minQuant8()

--- a/runtime/onert/backend/cpu/ops/MinLayer.h
+++ b/runtime/onert/backend/cpu/ops/MinLayer.h
@@ -39,11 +39,6 @@ public:
   }
 
 public:
-  void minFloat32();
-
-  void minQuant8();
-
-  void minInt32();
 
   void configure(const Tensor *lhs, const Tensor *rhs, Tensor *output);
 

--- a/runtime/onert/backend/cpu/ops/MinLayer.h
+++ b/runtime/onert/backend/cpu/ops/MinLayer.h
@@ -43,6 +43,8 @@ public:
 
   void minQuant8();
 
+  void minInt32();
+
   void configure(const Tensor *lhs, const Tensor *rhs, Tensor *output);
 
   void run();

--- a/runtime/onert/backend/cpu/ops/MinLayer.h
+++ b/runtime/onert/backend/cpu/ops/MinLayer.h
@@ -39,7 +39,6 @@ public:
   }
 
 public:
-
   void configure(const Tensor *lhs, const Tensor *rhs, Tensor *output);
 
   void run();


### PR DESCRIPTION
- MinLayer supports INT32 type on cpu backend

ONE-DCO-1.0-Signed-off-by: Chunseok Lee <chunseok.lee@samsung.com>