### PR TITLE
[luci-interpreter]Add extractShape function on testutil

### DIFF
--- a/compiler/luci-interpreter/src/kernels/TestUtils.cpp
+++ b/compiler/luci-interpreter/src/kernels/TestUtils.cpp
@@ -45,6 +45,17 @@ std::vector<Matcher<float>> ArrayFloatNear(const std::vector<float> &values, flo
   return matchers;
 }
 
+std::vector<int32_t> extractTensorShape(const Tensor &tensor)
+{
+  std::vector<int32_t> result;
+  int dims = tensor.shape().num_dims();
+  for (int i = 0; i < dims; i++)
+  {
+    result.push_back(tensor.shape().dim(i));
+  }
+  return result;
+}
+
 } // namespace testing
 } // namespace kernels
 } // namespace luci_interpreter

--- a/compiler/luci-interpreter/src/kernels/TestUtils.h
+++ b/compiler/luci-interpreter/src/kernels/TestUtils.h
@@ -43,6 +43,8 @@ Tensor makeInputTensor(const Shape &shape, const std::vector<typename DataTypeIm
 Tensor makeOutputTensor(DataType element_type);
 Tensor makeOutputTensor(DataType element_type, float scale, int32_t zero_point);
 
+std::vector<int32_t> extractTensorShape(const Tensor &tensor);
+
 // Returns the corresponding DataType given the type T.
 template <typename T> constexpr DataType getElementType()
 {


### PR DESCRIPTION
Parent Issue : #1088 
Draft PR : #2459 

This commit add extractShape function on luci-interpreter testutils.

ONE-DCO-1.0-Signed-off-by: KiDeuk Bang <rrstrous@nate.com>