### PR TITLE
[luci] Shape,dtype inf for LogSoftmax IR

### DIFF
--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -1016,6 +1016,13 @@ public:
     return loco::NodeShape{input_shape};
   }
 
+  loco::NodeShape visit(const luci::CircleLogSoftmax *node) final
+  {
+    auto input_shape = loco::shape_get(node->logits()).as<loco::TensorShape>();
+
+    return loco::NodeShape{input_shape};
+  }
+
   loco::NodeShape visit(const luci::CircleMaximum *node) final
   {
     auto x_shape = loco::shape_get(node->x()).as<loco::TensorShape>();

--- a/compiler/luci/service/src/CircleTypeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleTypeInferenceRule.cpp
@@ -216,6 +216,11 @@ struct TypeInferenceAlgorithm final : public luci::CircleNodeVisitor<loco::DataT
     return loco::dtype_get(node->x());
   }
 
+  loco::DataType visit(const luci::CircleLogSoftmax *node) final
+  {
+    return loco::dtype_get(node->logits());
+  }
+
   loco::DataType visit(const luci::CircleMaximum *node) final { return loco::dtype_get(node->x()); }
 
   loco::DataType visit(const luci::CircleMaxPool2D *node) final


### PR DESCRIPTION
This will enable shape and dtype inference for LogSoftmax IR

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>