### PR TITLE
[onert] Remove configure decl of If/WhileLayer

### DIFF
--- a/runtime/onert/core/src/backend/controlflow/kernel/IfLayer.h
+++ b/runtime/onert/core/src/backend/controlflow/kernel/IfLayer.h
@@ -41,8 +41,6 @@ public:
           const std::shared_ptr<exec::ExecutorMap> &executor_map);
 
 public:
-  void configure();
-
   void run() override;
 
 private:

--- a/runtime/onert/core/src/backend/controlflow/kernel/WhileLayer.h
+++ b/runtime/onert/core/src/backend/controlflow/kernel/WhileLayer.h
@@ -40,8 +40,6 @@ public:
              const std::shared_ptr<exec::ExecutorMap> &executor_map);
 
 public:
-  void configure();
-
   void run() override;
 
 private:


### PR DESCRIPTION
Remove `configure` method declaration of If/WhileLayer of controlflow
backend which does not have implementation.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>