### PR TITLE
[onert] Fix circular dependency of ExecutorMap

### DIFF
--- a/runtime/onert/core/src/backend/controlflow/KernelGenerator.h
+++ b/runtime/onert/core/src/backend/controlflow/KernelGenerator.h
@@ -41,7 +41,8 @@ public:
   }
   void setExecutorMap(const std::shared_ptr<exec::ExecutorMap> &executor_map)
   {
-    _executor_map = executor_map;
+    // FIXME Using shared_ptr's raw pointer!
+    _executor_map = executor_map.get();
   }
 
   using IKernelGenerator::visit;
@@ -59,7 +60,7 @@ private:
   const ir::Operands &_operand_ctx;
   const ir::Operations &_operations_ctx;
   TensorBuilderSet _tensor_builder_set;
-  std::shared_ptr<exec::ExecutorMap> _executor_map;
+  exec::ExecutorMap *_executor_map;
 };
 
 } // namespace controlflow

--- a/runtime/onert/core/src/backend/controlflow/kernel/IfLayer.cc
+++ b/runtime/onert/core/src/backend/controlflow/kernel/IfLayer.cc
@@ -34,7 +34,7 @@ IfLayer::IfLayer(const std::shared_ptr<backend::ITensor> &cond_tensor,
                  std::vector<std::shared_ptr<backend::ITensor>> output_tensors,
                  const exec::DynAllocInfoMap &outputs_dyn_alloc_info,
                  const ir::SubgraphIndex &then_subg_index, const ir::SubgraphIndex &else_subg_index,
-                 const std::shared_ptr<exec::ExecutorMap> &executor_map)
+                 exec::ExecutorMap *executor_map)
     : _cond_tensor{cond_tensor}, _input_tensors{input_tensors}, _output_tensors{output_tensors},
       _outputs_dyn_alloc_info{outputs_dyn_alloc_info}, _then_subg_index{then_subg_index},
       _else_subg_index{else_subg_index}, _executor_map{executor_map}

--- a/runtime/onert/core/src/backend/controlflow/kernel/IfLayer.h
+++ b/runtime/onert/core/src/backend/controlflow/kernel/IfLayer.h
@@ -38,7 +38,7 @@ public:
           std::vector<std::shared_ptr<backend::ITensor>> output_tensors,
           const exec::DynAllocInfoMap &outputs_dyn_alloc_info,
           const ir::SubgraphIndex &then_subg_index, const ir::SubgraphIndex &else_subg_index,
-          const std::shared_ptr<exec::ExecutorMap> &executor_map);
+          exec::ExecutorMap *executor_map);
 
 public:
   void configure();
@@ -52,7 +52,7 @@ private:
   const exec::DynAllocInfoMap _outputs_dyn_alloc_info;
   const ir::SubgraphIndex _then_subg_index;
   const ir::SubgraphIndex _else_subg_index;
-  const std::shared_ptr<exec::ExecutorMap> &_executor_map;
+  exec::ExecutorMap *_executor_map;
 };
 
 } // namespace kernel

--- a/runtime/onert/core/src/backend/controlflow/kernel/WhileLayer.cc
+++ b/runtime/onert/core/src/backend/controlflow/kernel/WhileLayer.cc
@@ -33,8 +33,7 @@ WhileLayer::WhileLayer(std::vector<std::shared_ptr<backend::ITensor>> input_tens
                        std::vector<std::shared_ptr<backend::ITensor>> output_tensors,
                        const exec::DynAllocInfoMap &outputs_dyn_alloc_info,
                        const ir::SubgraphIndex &cond_subg_index,
-                       const ir::SubgraphIndex &body_subg_index,
-                       const std::shared_ptr<exec::ExecutorMap> &executor_map)
+                       const ir::SubgraphIndex &body_subg_index, exec::ExecutorMap *executor_map)
     : _cond_subg_index{cond_subg_index}, _body_subg_index{body_subg_index},
       _input_tensors{input_tensors}, _output_tensors{output_tensors},
       _outputs_dyn_alloc_info{outputs_dyn_alloc_info}, _executor_map{executor_map}

--- a/runtime/onert/core/src/backend/controlflow/kernel/WhileLayer.h
+++ b/runtime/onert/core/src/backend/controlflow/kernel/WhileLayer.h
@@ -37,7 +37,7 @@ public:
              std::vector<std::shared_ptr<backend::ITensor>> output_tensors,
              const exec::DynAllocInfoMap &outputs_dyn_alloc_info,
              const ir::SubgraphIndex &cond_subg_index, const ir::SubgraphIndex &body_subg_index,
-             const std::shared_ptr<exec::ExecutorMap> &executor_map);
+             exec::ExecutorMap *executor_map);
 
 public:
   void configure();
@@ -50,7 +50,7 @@ private:
   const std::vector<std::shared_ptr<backend::ITensor>> _input_tensors;
   const std::vector<std::shared_ptr<backend::ITensor>> _output_tensors;
   const exec::DynAllocInfoMap _outputs_dyn_alloc_info;
-  const std::shared_ptr<exec::ExecutorMap> &_executor_map;
+  exec::ExecutorMap *_executor_map;
 };
 
 } // namespace kernel


### PR DESCRIPTION
Having `shared_ptr` in `controlflow::KernelGenerator` causes circular
dependency. So this commit changes it to be a raw pointer. We may make
it to use `weak_ptr` or make it as a `unique_ptr` later.

Circular dependency was:

```
ExecutorMap -> ... -> LoweredGraph -> BackendContexts -> ... ->
controlflow::KernelGenerator -> ExecutorMap
```

For #2537

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>