### PR TITLE
[onert] Remove copies between unused tensors in WhileLayer

### DIFF
--- a/runtime/onert/core/src/backend/controlflow/Backend.h
+++ b/runtime/onert/core/src/backend/controlflow/Backend.h
@@ -47,7 +47,6 @@ public:
                                              bool) const override
   {
     const auto &operands = graph.operands();
-    const auto &operations = graph.operations();
     auto context = std::make_unique<BackendContext>(this, &graph);
     // ControlFlow backend may not build tensors for itself because the backend's operation uses
     // tensors of other baceknd instead
@@ -69,7 +68,7 @@ public:
     auto tb = std::make_shared<TensorBuilder>();
     context->tensor_builder = tb;
     context->constant_initializer = std::make_shared<ConstantInitializer>(operands, tb);
-    context->kernel_gen = std::make_shared<KernelGenerator>(operands, operations);
+    context->kernel_gen = std::make_shared<KernelGenerator>(graph);
     context->shape_fixer = nullptr;
     context->tensor_register = nullptr;
     context->optimizer = nullptr;

--- a/runtime/onert/core/src/backend/controlflow/KernelGenerator.cc
+++ b/runtime/onert/core/src/backend/controlflow/KernelGenerator.cc
@@ -30,13 +30,10 @@ namespace backend
 namespace controlflow
 {
 
-KernelGenerator::KernelGenerator(const ir::Operands &operand_ctx,
-                                 const ir::Operations &operations_ctx)
-    : _operand_ctx{operand_ctx}, _operations_ctx{operations_ctx}, _tensor_builder_set{nullptr},
-      _executor_map{nullptr}
+KernelGenerator::KernelGenerator(const ir::Graph &graph)
+    : _graph{graph}, _tensor_builder_set{nullptr}, _executor_map{nullptr}
 {
-  UNUSED_RELEASE(_operand_ctx);
-  UNUSED_RELEASE(_operations_ctx);
+  UNUSED_RELEASE(_graph);
   UNUSED_RELEASE(_tensor_builder_set);
   UNUSED_RELEASE(_executor_map);
 }
@@ -47,7 +44,7 @@ void KernelGenerator::visit(const ir::OpSequence &op_seq)
   _return_fn_seq = std::make_unique<exec::FunctionSequence>();
   for (const auto &op_idx : op_seq.operations())
   {
-    const auto &node = _operations_ctx.at(op_idx);
+    const auto &node = _graph.operations().at(op_idx);
     node.accept(*this);
     _return_fn_seq->append(releaseFunction());
   }
@@ -149,8 +146,8 @@ void KernelGenerator::visit(const ir::operation::While &node)
   // WhileLayer just set ExecutorMap instead of cond and body executor to avoid complexity of
   // creating executor recusively
   auto fn = std::make_unique<::onert::backend::controlflow::kernel::WhileLayer>(
-      input_tensors, output_tensors, outputs_dyn_alloc_info, cond_subg_index, body_subg_index,
-      _executor_map);
+      input_tensors, output_tensors, node.getOutputs(), _graph, outputs_dyn_alloc_info,
+      cond_subg_index, body_subg_index, _executor_map);
 
   _return_fn = std::move(fn);
 }

--- a/runtime/onert/core/src/backend/controlflow/KernelGenerator.h
+++ b/runtime/onert/core/src/backend/controlflow/KernelGenerator.h
@@ -20,8 +20,7 @@
 #include <backend/IKernelGenerator.h>
 #include <backend/ITensorBuilder.h>
 #include <exec/IExecutor.h>
-#include <ir/Operands.h>
-#include <ir/Operations.h>
+#include <ir/Graph.h>
 
 namespace onert
 {
@@ -33,7 +32,7 @@ namespace controlflow
 class KernelGenerator : public IKernelGenerator
 {
 public:
-  KernelGenerator(const ir::Operands &operand_ctx, const ir::Operations &operations_ctx);
+  KernelGenerator(const ir::Graph &graph);
 
   void setTensorBuilderSet(const TensorBuilderSet &tensor_builder_set)
   {
@@ -57,8 +56,7 @@ private:
   std::shared_ptr<backend::ITensorBuilder> getTensorBuilder(const ir::OperandIndex &index);
 
 private:
-  const ir::Operands &_operand_ctx;
-  const ir::Operations &_operations_ctx;
+  const ir::Graph &_graph;
   TensorBuilderSet _tensor_builder_set;
   exec::ExecutorMap *_executor_map;
 };

--- a/runtime/onert/core/src/backend/controlflow/kernel/WhileLayer.cc
+++ b/runtime/onert/core/src/backend/controlflow/kernel/WhileLayer.cc
@@ -29,28 +29,32 @@ namespace controlflow
 namespace kernel
 {
 
-WhileLayer::WhileLayer(std::vector<std::shared_ptr<backend::ITensor>> input_tensors,
-                       std::vector<std::shared_ptr<backend::ITensor>> output_tensors,
+WhileLayer::WhileLayer(const std::vector<std::shared_ptr<backend::ITensor>> &input_tensors,
+                       const std::vector<std::shared_ptr<backend::ITensor>> &output_tensors,
+                       const ir::OperandIndexSequence &output_indices, const ir::Graph &graph,
                        const exec::DynAllocInfoMap &outputs_dyn_alloc_info,
                        const ir::SubgraphIndex &cond_subg_index,
                        const ir::SubgraphIndex &body_subg_index, exec::ExecutorMap *executor_map)
     : _cond_subg_index{cond_subg_index}, _body_subg_index{body_subg_index},
-      _input_tensors{input_tensors}, _output_tensors{output_tensors},
-      _outputs_dyn_alloc_info{outputs_dyn_alloc_info}, _executor_map{executor_map}
+      _output_indices{output_indices}, _graph{graph}, _input_tensors{input_tensors},
+      _output_tensors{output_tensors}, _outputs_dyn_alloc_info{outputs_dyn_alloc_info},
+      _executor_map{executor_map}
 {
   // At this point, executor_map may not have executors of cond subg and body subg
 }
 
 void WhileLayer::run()
 {
-  // Copy _src_tensors -> inputs of cond subg
+  // Copy "_input_tensors" -> "cond subg inputs"
   // Run cond subg
   // Start loop while output of cond subg is ture
-  // // Copy cond subg inputs -> body subg inputs
+  // // Copy "_input_tensors" -> "body subg inputs" in the first iteration, then copy "body subg
+  // outputs" -> "body subg inputs" in the second or more iterations
   // // Run body subg
-  // // Copy body subg outputs -> cond subg inputs
+  // // Copy "body subg outputs" -> "cond subg inputs"
   // // Run cond subg
-  // Copy cond subg inputs -> _dst_tensors
+  // If there is no loop copy "_input_tensors" -> "_dst_tensors", else copy "cond subg inputs" ->
+  // "_dst_tensors"
   auto cond_exec = dynamic_cast<exec::ExecutorBase *>(_executor_map->at(_cond_subg_index).get());
   auto body_exec = dynamic_cast<exec::ExecutorBase *>(_executor_map->at(_body_subg_index).get());
   if ((cond_exec == nullptr) || (body_exec == nullptr))
@@ -58,28 +62,116 @@ void WhileLayer::run()
     throw std::runtime_error{"While: Invalid condition or body"};
   }
 
-  const auto &cond_input_tensors = cond_exec->getInputTensors();
+  const auto &cond_graph = cond_exec->graph();
   const auto &cond_inputs_dyn_alloc = cond_exec->getInputsDynamicAllocInfo();
-  const auto permute_op_input_to_cond_input =
-      std::make_shared<PermuteLayer>(_input_tensors, cond_input_tensors, cond_inputs_dyn_alloc);
-
-  const auto &body_input_tensors = body_exec->getInputTensors();
+  const auto &body_graph = body_exec->graph();
   const auto &body_inputs_dyn_alloc = body_exec->getInputsDynamicAllocInfo();
-  const auto permute_cond_input_to_body_input =
-      std::make_shared<PermuteLayer>(cond_input_tensors, body_input_tensors, body_inputs_dyn_alloc);
 
-  const auto &body_output_tensors = body_exec->getOutputTensors();
+  std::vector<std::shared_ptr<backend::ITensor>> input_tensors;
+  std::vector<std::shared_ptr<backend::ITensor>> cond_input_tensors;
+  std::vector<std::shared_ptr<backend::ITensor>> body_input_tensors;
+  std::vector<std::shared_ptr<backend::ITensor>> body_output_tensors;
+  std::vector<std::shared_ptr<backend::ITensor>> output_tensors;
+
+  // Add only used tensors in cond subgraph
+  assert(_input_tensors.size() == cond_exec->getInputTensors().size());
+  for (uint32_t i = 0; i < cond_graph.getInputs().size(); ++i)
+  {
+    const auto &cond_input = cond_graph.operands().at(cond_graph.getInputs().at(i));
+    if (cond_input.getUses().size() > 0)
+    {
+      input_tensors.emplace_back(_input_tensors.at(i));
+      cond_input_tensors.emplace_back(cond_exec->getInputTensors().at(i));
+    }
+  }
+  const auto permute_op_input_to_cond_input =
+      std::make_shared<PermuteLayer>(input_tensors, cond_input_tensors, cond_inputs_dyn_alloc);
+
+  // Add only used tensors among outputs of while operation
+  assert(_input_tensors.size() == _output_tensors.size());
+  assert(_output_indices.size() == _output_tensors.size());
+  input_tensors.clear();
+  output_tensors.clear();
+  for (size_t i = 0; i < _output_tensors.size(); ++i)
+  {
+    const auto &output_index = _output_indices.at(i);
+    const auto &output = _graph.operands().at(output_index);
+    if (output.getUses().size() > 0 || _graph.getOutputs().contains(output_index))
+    {
+      input_tensors.emplace_back(_input_tensors.at(i));
+      output_tensors.emplace_back(_output_tensors.at(i));
+    }
+  }
+  const auto permute_op_input_to_op_output =
+      std::make_shared<PermuteLayer>(input_tensors, output_tensors, _outputs_dyn_alloc_info);
+
+  // Add all tensors with unused tensors in body subgraph because unused input tensors will be
+  // copied output tensors in body subgraph
+  assert(_input_tensors.size() == body_exec->getInputTensors().size());
+  input_tensors = _input_tensors;
+  body_input_tensors = body_exec->getInputTensors();
+  const auto permute_op_input_to_body_input =
+      std::make_shared<PermuteLayer>(input_tensors, body_input_tensors, body_inputs_dyn_alloc);
+
+  // Add only used tensors in cond subgraph
+  assert(body_exec->getOutputTensors().size() == cond_exec->getInputTensors().size());
+  body_output_tensors.clear();
+  cond_input_tensors.clear();
+  for (uint32_t i = 0; i < cond_graph.getInputs().size(); ++i)
+  {
+    const auto &cond_input = cond_graph.operands().at(cond_graph.getInputs().at(i));
+    if (cond_input.getUses().size() > 0)
+    {
+      body_output_tensors.emplace_back(body_exec->getOutputTensors().at(i));
+      cond_input_tensors.emplace_back(cond_exec->getInputTensors().at(i));
+    }
+  }
   const auto permute_body_output_to_cond_input = std::make_shared<PermuteLayer>(
       body_output_tensors, cond_input_tensors, cond_inputs_dyn_alloc);
 
-  const auto permute_cond_input_to_op_output =
-      std::make_shared<PermuteLayer>(cond_input_tensors, _output_tensors, _outputs_dyn_alloc_info);
+  // Add only used tensors in body subgraph
+  assert(body_exec->getOutputTensors().size() == body_exec->getInputTensors().size());
+  body_output_tensors.clear();
+  body_input_tensors.clear();
+  for (uint32_t i = 0; i < body_graph.getInputs().size(); ++i)
+  {
+    const auto &body_input_index = body_graph.getInputs().at(i);
+    const auto &body_input = body_graph.operands().at(body_input_index);
+    if (body_input.getUses().size() > 0 &&
+        !body_exec->graph().getOutputs().contains(body_input_index))
+    {
+      body_output_tensors.emplace_back(body_exec->getOutputTensors().at(i));
+      body_input_tensors.emplace_back(body_exec->getInputTensors().at(i));
+    }
+  }
+  const auto permute_body_output_to_body_input = std::make_shared<PermuteLayer>(
+      body_output_tensors, body_input_tensors, body_inputs_dyn_alloc);
+
+  // Add only used tensors among outputs of while operation
+  assert(body_exec->getOutputTensors().size() == _output_tensors.size());
+  assert(_output_indices.size() == _output_tensors.size());
+  body_output_tensors.clear();
+  output_tensors.clear();
+  for (size_t i = 0; i < _output_tensors.size(); ++i)
+  {
+    const auto &output_index = _output_indices.at(i);
+    const auto &output = _graph.operands().at(output_index);
+    if (output.getUses().size() > 0 || _graph.getOutputs().contains(output_index))
+    {
+      body_output_tensors.emplace_back(body_exec->getOutputTensors().at(i));
+      output_tensors.emplace_back(_output_tensors.at(i));
+    }
+  }
+  const auto permute_body_output_to_op_output =
+      std::make_shared<PermuteLayer>(body_output_tensors, output_tensors, _outputs_dyn_alloc_info);
 
   // Remove copying of unused tensor
   permute_op_input_to_cond_input->prepare();
-  permute_cond_input_to_body_input->prepare();
+  permute_op_input_to_op_output->prepare();
+  permute_op_input_to_body_input->prepare();
   permute_body_output_to_cond_input->prepare();
-  permute_cond_input_to_op_output->prepare();
+  permute_body_output_to_body_input->prepare();
+  permute_body_output_to_op_output->prepare();
 
   cond_exec->execute(_input_tensors, permute_op_input_to_cond_input);
 
@@ -91,26 +183,48 @@ void WhileLayer::run()
     return ret;
   };
 
+  auto setOpOutputDynamic = [&](const std::vector<std::shared_ptr<backend::ITensor>> &src_tensors) {
+    assert(_output_tensors.size() == src_tensors.size());
+    for (size_t i = 0; i < _output_tensors.size(); ++i)
+    {
+      const auto output_tensor = _output_tensors.at(i);
+      const auto orig_output_shape = output_tensor->getShape();
+      const auto changed_output_shape = src_tensors.at(i)->getShape();
+      const auto &output_dyn_alloc_info = _outputs_dyn_alloc_info.find(output_tensor);
+      if (orig_output_shape != changed_output_shape &&
+          output_dyn_alloc_info != _outputs_dyn_alloc_info.end() &&
+          (_graph.operands().at(output_dyn_alloc_info->second.ind).getUses().size() > 0 ||
+           _graph.getOutputs().contains(output_dyn_alloc_info->second.ind)))
+      {
+        output_tensor->set_dynamic();
+      }
+    }
+  };
+
+  const auto body_execute_with_op_inputs = [&]() {
+    body_exec->execute(_input_tensors, permute_op_input_to_body_input);
+  };
+
+  const auto body_execute_with_body_outputs = [&]() {
+    body_exec->execute(body_exec->getOutputTensors(), permute_body_output_to_body_input);
+  };
+
+  std::function<void()> body_execute = body_execute_with_op_inputs;
+  const auto cond_execute = [&]() {
+    cond_exec->execute(body_exec->getOutputTensors(), permute_body_output_to_cond_input);
+  };
+  auto permute_to_outputs_fn = permute_op_input_to_op_output;
+
   // Loop while Cond subgraph's output is true
   while (getResultCond(cond_output_tensor.get()))
   {
-    body_exec->execute(cond_input_tensors, permute_cond_input_to_body_input);
-    cond_exec->execute(body_output_tensors, permute_body_output_to_cond_input);
+    body_execute();
+    cond_execute();
+    body_execute = body_execute_with_body_outputs;
+    permute_to_outputs_fn = permute_body_output_to_op_output;
   }
-
-  assert(_output_tensors.size() == cond_input_tensors.size());
-  for (size_t i = 0; i < _output_tensors.size(); ++i)
-  {
-    const auto output_tensor = _output_tensors.at(i);
-    const auto orig_output_shape = output_tensor->getShape();
-    const auto changed_output_shape = cond_input_tensors.at(i)->getShape();
-    if (orig_output_shape != changed_output_shape &&
-        _outputs_dyn_alloc_info.find(output_tensor) != _outputs_dyn_alloc_info.end())
-    {
-      output_tensor->set_dynamic();
-    }
-  }
-  permute_cond_input_to_op_output->run();
+  setOpOutputDynamic(body_exec->getOutputTensors());
+  permute_to_outputs_fn->run();
 }
 
 } // namespace kernel

--- a/runtime/onert/core/src/backend/controlflow/kernel/WhileLayer.h
+++ b/runtime/onert/core/src/backend/controlflow/kernel/WhileLayer.h
@@ -20,6 +20,8 @@
 #include <backend/ITensor.h>
 #include <exec/IExecutor.h>
 #include <exec/IFunction.h>
+#include <ir/OperandIndexSequence.h>
+#include <ir/Graph.h>
 
 namespace onert
 {
@@ -33,8 +35,9 @@ namespace kernel
 class WhileLayer : public ::onert::exec::IFunction
 {
 public:
-  WhileLayer(std::vector<std::shared_ptr<backend::ITensor>> input_tensors,
-             std::vector<std::shared_ptr<backend::ITensor>> output_tensors,
+  WhileLayer(const std::vector<std::shared_ptr<backend::ITensor>> &input_tensors,
+             const std::vector<std::shared_ptr<backend::ITensor>> &output_tensors,
+             const ir::OperandIndexSequence &output_indices, const ir::Graph &graph,
              const exec::DynAllocInfoMap &outputs_dyn_alloc_info,
              const ir::SubgraphIndex &cond_subg_index, const ir::SubgraphIndex &body_subg_index,
              exec::ExecutorMap *executor_map);
@@ -45,6 +48,8 @@ public:
 private:
   const ir::SubgraphIndex _cond_subg_index;
   const ir::SubgraphIndex _body_subg_index;
+  const ir::OperandIndexSequence &_output_indices;
+  const ir::Graph &_graph;
   const std::vector<std::shared_ptr<backend::ITensor>> _input_tensors;
   const std::vector<std::shared_ptr<backend::ITensor>> _output_tensors;
   const exec::DynAllocInfoMap _outputs_dyn_alloc_info;


### PR DESCRIPTION
For issue #2501 
Draft PR #2530 

This commit removes copies between unused tensors in WhileLayer to reduce using resources.
  - Change copying from cond inputs to body inputs to copying from body outputs
  - Remove copies between unused tensors

Signed-off-by: ragmani <ragmani0216@gmail.com>

<Details>

- Before
```bash
$ BACKENDS=cpu ./Product/armv7l-linux.release/out/bin/nnpackage_run while_big --output_sizes '[0, 440]' --shape_run '[0, [1, 10]]' -d output.h5 -m1
... warmup 1 takes 9308.44 ms
... run 1 takes 8064.15 ms
===================================
MODEL_LOAD   takes 726.085 ms
PREPARE      takes 1255.417 ms
EXECUTE      takes 8064.145 ms
- MEAN     :  8064.145 ms
- MAX      :  8064.145 ms
- MIN      :  8064.145 ms
- GEOMEAN  :  8064.145 ms
===================================
RSS
- MODEL_LOAD   takes 311840 kb
- PREPARE      takes 466248 kb
- EXECUTE      takes 340040 kb
- PEAK         takes 466248 kb
===================================
HWM
- MODEL_LOAD   takes 315740 kb
- PREPARE      takes 466248 kb
- EXECUTE      takes 466248 kb
- PEAK         takes 466248 kb
===================================
PSS
- MODEL_LOAD   takes 310210 kb
- PREPARE      takes 464575 kb
- EXECUTE      takes 338615 kb
- PEAK         takes 464575 kb
===================================
```

- After
```bash
$ BACKENDS=cpu ./Product/armv7l-linux.release/out/bin/nnpackage_run while_big --output_sizes '[0, 440]' --shape_run '[0, [1, 10]]' -d output.h5 -m1
... warmup 1 takes 9005.31 ms
... run 1 takes 7751.18 ms
===================================
MODEL_LOAD   takes 748.487 ms
PREPARE      takes 1361.002 ms
EXECUTE      takes 7751.175 ms
- MEAN     :  7751.175 ms
- MAX      :  7751.175 ms
- MIN      :  7751.175 ms
- GEOMEAN  :  7751.175 ms
===================================
RSS
- MODEL_LOAD   takes 312000 kb
- PREPARE      takes 466408 kb
- EXECUTE      takes 337272 kb
- PEAK         takes 466408 kb
===================================
HWM
- MODEL_LOAD   takes 315900 kb
- PREPARE      takes 466408 kb
- EXECUTE      takes 466408 kb
- PEAK         takes 466408 kb
===================================
PSS
- MODEL_LOAD   takes 310860 kb
- PREPARE      takes 464658 kb
- EXECUTE      takes 335527 kb
- PEAK         takes 464658 kb
===================================
```

</Details>