### PR TITLE
[cker] Fix uninitializied feild in eigen_spatial_convolutions-inl.h

### DIFF
--- a/compute/cker/include/cker/eigen/eigen_spatial_convolutions-inl.h
+++ b/compute/cker/include/cker/eigen/eigen_spatial_convolutions-inl.h
@@ -651,7 +651,7 @@ private:
   internal::TensorIntDivisor<Index> m_fastInputRowStride;
   internal::TensorIntDivisor<Index> m_fastInputColStride;
 
-  Index m_otherStride;
+  // Index m_otherStride; // Unused this field
   Index m_colStride;
   internal::TensorIntDivisor<Index> m_fastNumPatches;
   internal::TensorIntDivisor<Index> m_fastColStride;


### PR DESCRIPTION
For issue #2522

This commit fixes uninitializied feild in eigen_spatial_convolutions-inl.h
  - make an unused feild `m_otherStride` to comment

Signed-off-by: ragmani <ragmani0216@gmail.com>