### PR TITLE
[tests/tools] Fix wrong error handling in tflite_loader tool

### DIFF
--- a/tests/tools/tflite_loader/src/args.cc
+++ b/tests/tools/tflite_loader/src/args.cc
@@ -69,14 +69,23 @@ void Args::Parse(const int argc, char **argv)
     exit(0);
   }
 
-  if (vm.count("tflite"))
+  try
   {
-    _tflite_filename = vm["tflite"].as<std::string>();
-  }
+    if (vm.count("tflite"))
+    {
+      _tflite_filename = vm["tflite"].as<std::string>();
+    }
 
-  if (vm.count("data"))
+    if (vm.count("data"))
+    {
+      _data_filenames = vm["data"].as<std::vector<std::string>>();
+    }
+  }
+  catch (const std::bad_cast &e)
   {
-    _data_filenames = vm["data"].as<std::vector<std::string>>();
+    std::cerr << e.what() << '\n';
+    print(argv);
+    exit(1);
   }
 }
 


### PR DESCRIPTION
For issue #2522 

This commit fixes wrong error handling with noexept in tflite_loader tool
  - Add try-catch with std::bad_cast

Signed-off-by: ragmani <ragmani0216@gmail.com>