### PR TITLE
[onert] catch uncaught exception in event observers

### DIFF
--- a/runtime/onert/core/src/exec/ExecutionObservers.cc
+++ b/runtime/onert/core/src/exec/ExecutionObservers.cc
@@ -74,7 +74,17 @@ ChromeTracingObserver::ChromeTracingObserver(const std::string &filepath, const 
 {
 }
 
-ChromeTracingObserver::~ChromeTracingObserver() { _recorder.writeToFile(_ofs); }
+ChromeTracingObserver::~ChromeTracingObserver()
+{
+  try
+  {
+    _recorder.writeToFile(_ofs);
+  }
+  catch (const std::exception &e)
+  {
+    std::cerr << "E: Fail to record event in ChromeTracingObserver: " << e.what() << std::endl;
+  }
+}
 
 void ChromeTracingObserver::handleBegin(IExecutor *)
 {

--- a/runtime/onert/core/src/util/EventCollectorGlobal.cc
+++ b/runtime/onert/core/src/util/EventCollectorGlobal.cc
@@ -18,6 +18,7 @@
 
 #include <cassert>
 #include <fstream>
+#include <iostream>
 
 #include "util/ConfigSource.h"
 
@@ -35,9 +36,16 @@ EventCollectorGlobal::~EventCollectorGlobal()
 {
   if (!_recorder.empty())
   {
-    // TODO Need better way for saved file path than the hardcoded path
-    std::ofstream ofs{"trace.global.json"};
-    _recorder.writeToFile(ofs);
+    try
+    {
+      // TODO Need better way for saved file path than the hardcoded path
+      std::ofstream ofs{"trace.global.json"};
+      _recorder.writeToFile(ofs);
+    }
+    catch (const std::exception &e)
+    {
+      std::cerr << "E: Fail to record event in EventCollectorGlobal: " << e.what() << std::endl;
+    }
   }
 }
 


### PR DESCRIPTION
Svace complains the destructor could throw exception.
This patch will catch the possible exceptions.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>