### PR TITLE
[luci] Use must_cast instead of dynamic_cast

### DIFF
--- a/compiler/luci/pass/src/FuseBCQPass.cpp
+++ b/compiler/luci/pass/src/FuseBCQPass.cpp
@@ -268,7 +268,7 @@ bool FuseBCQPass::run(loco::Graph *g)
         bcq_gather->input_clusters(converter.packed_clusters(params));
 
         const auto binary_hidden_size =
-            dynamic_cast<luci::CircleConst *>(bcq_gather->input_binary())->dim(0).value() * 32;
+            loco::must_cast<luci::CircleConst *>(bcq_gather->input_binary())->dim(0).value() * 32;
         bcq_gather->input_hidden_size(binary_hidden_size);
 
         if (converter.do_w_x(params))
@@ -299,14 +299,14 @@ bool FuseBCQPass::run(loco::Graph *g)
         bcq_fc->weights_clusters(converter.packed_clusters(weights));
 
         const auto binary_hidden_size =
-            dynamic_cast<luci::CircleConst *>(bcq_fc->weights_binary())->dim(1).value() * 32;
+            loco::must_cast<luci::CircleConst *>(bcq_fc->weights_binary())->dim(1).value() * 32;
         bcq_fc->weights_hidden_size(binary_hidden_size);
         bcq_fc->fusedActivationFunction(fully_connected->fusedActivationFunction());
 
         loco::Node *bcq_input = fully_connected->input();
 
         // If input of BCQFullyConnected has more than rank 2, we should reshape it as rank 2
-        const auto original_input = dynamic_cast<luci::CircleNode *>(fully_connected->input());
+        const auto original_input = loco::must_cast<luci::CircleNode *>(fully_connected->input());
         if (original_input->shape_status() == ShapeStatus::VALID && original_input->rank() > 2)
         {
           auto new_shape = g->nodes()->create<luci::CircleConst>();


### PR DESCRIPTION
This commit will prevent `nullptr` error by using `must_cast`
instead of `dynamic_cast`

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>