### PR TITLE
[onert] converity: Fix EventRecorder

### DIFF
--- a/runtime/onert/core/src/util/EventRecorder.cc
+++ b/runtime/onert/core/src/util/EventRecorder.cc
@@ -144,7 +144,7 @@ void EventRecorder::writeToFile(std::ostream &os)
 
 void EventRecorder::writeSNPEBenchmark(std::ostream &os)
 {
-  Json::Value root;
+  Json::Value root = Json::Value{Json::objectValue};
   auto &exec_data = root["Execution_Data"] = Json::Value{Json::objectValue};
 
   struct Stat


### PR DESCRIPTION
`Json::Value::operator[]` could throw execption if `Value` type is
non-null and non-object. So I hope this make coverity ensure that
`root` is an object.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>

An alternative for #2563 