### PR TITLE
[onert] cpu: Add an assertion in KernelGenerator

### DIFF
--- a/runtime/onert/backend/cpu/KernelGenerator.cc
+++ b/runtime/onert/backend/cpu/KernelGenerator.cc
@@ -122,6 +122,12 @@ void KernelGenerator::visit(const ir::OpSequence &op_seq)
 
     for (const auto &ind : (node.getInputs() | ir::Remove::UNDEFINED) + node.getOutputs())
     {
+      auto portable_tensor = _tensor_builder->portableAt(ind);
+      if (portable_tensor)
+      {
+        assert(portable_tensor->layout() == ir::Layout::NHWC);
+      }
+
       auto tensor = _tensor_builder->at(ind);
       if (tensor)
       {


### PR DESCRIPTION
Add an assertion to check if tensors' layouts are NHWC in `backend::cpu::KernelGenerator`.

This is useful since we are going to reuse tensors from other backends.
So there may be some chance that we have non-NHWC tensors accidentally.

It has been discussed in #2492.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>