### PR TITLE
[onert] Fix debug compile flag and option on tizen

### DIFF
--- a/infra/nnfw/cmake/ApplyCompileFlags.cmake
+++ b/infra/nnfw/cmake/ApplyCompileFlags.cmake
@@ -2,14 +2,8 @@
 # Platform independent compile flag setting
 #
 # flags for build type: debug, release
-if(${ENABLE_COVERAGE})
-  # test-coverage build flag for tizen
-  set(CMAKE_C_FLAGS_DEBUG     "-O -g -DDEBUG")
-  set(CMAKE_CXX_FLAGS_DEBUG   "-O -g -DDEBUG")
-else(${ENABLE_COVERAGE})
-  set(CMAKE_C_FLAGS_DEBUG     "-O0 -g -DDEBUG")
-  set(CMAKE_CXX_FLAGS_DEBUG   "-O0 -g -DDEBUG")
-endif(${ENABLE_COVERAGE})
+set(CMAKE_C_FLAGS_DEBUG     "-O0 -g -DDEBUG")
+set(CMAKE_CXX_FLAGS_DEBUG   "-O0 -g -DDEBUG")
 set(CMAKE_C_FLAGS_RELEASE   "-O2 -DNDEBUG")
 set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG")
 

--- a/infra/nnfw/cmake/buildtool/config/config_aarch64-tizen.cmake
+++ b/infra/nnfw/cmake/buildtool/config/config_aarch64-tizen.cmake
@@ -4,6 +4,10 @@
 
 message(STATUS "Building for AARCH64 Tizen")
 
+# Build flag for tizen
+set(CMAKE_C_FLAGS_DEBUG     "-O -g -DDEBUG")
+set(CMAKE_CXX_FLAGS_DEBUG   "-O -g -DDEBUG")
+
 # TODO : add and use option_tizen if something uncommon comes up
 # include linux common
 include("cmake/buildtool/config/config_linux.cmake")

--- a/infra/nnfw/cmake/buildtool/config/config_armv7l-tizen.cmake
+++ b/infra/nnfw/cmake/buildtool/config/config_armv7l-tizen.cmake
@@ -4,6 +4,10 @@
 
 message(STATUS "Building for ARMv7l(softfp) Tizen")
 
+# Build flag for tizen
+set(CMAKE_C_FLAGS_DEBUG     "-O -g -DDEBUG")
+set(CMAKE_CXX_FLAGS_DEBUG   "-O -g -DDEBUG")
+
 # TODO : add and use option_tizen if something uncommon comes up
 # include linux common
 include("cmake/buildtool/config/config_linux.cmake")

--- a/infra/nnfw/cmake/options/options_aarch64-tizen.cmake
+++ b/infra/nnfw/cmake/options/options_aarch64-tizen.cmake
@@ -3,11 +3,9 @@
 #
 option(BUILD_ARMCOMPUTE "Build ARM Compute from the downloaded source" OFF)
 option(BUILD_TENSORFLOW_LITE "Build TensorFlow Lite from the downloaded source" OFF)
-option(DOWNLOAD_EIGEN "Download Eigen source" OFF)
 option(DOWNLOAD_NEON2SSE "Download NEON2SSE library source" OFF)
 
 option(BUILD_LOGGING "Build logging runtime" OFF)
 option(BUILD_TFLITE_RUN "Build tflite-run" OFF)
-option(BUILD_TFLITE_LOADER_TEST_TOOL "Build tflite loader testing tool" OFF)
 option(GENERATE_RUNTIME_NNAPI_TESTS "Generate NNAPI operation gtest" OFF)
 option(ENVVAR_ONERT_CONFIG "Use environment variable for onert configuration" OFF)


### PR DESCRIPTION
Now tizen gbs debug build always requires -O optimization
Fix build option on aarch64

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>