### PR TITLE
[onert] Make cpu backend ops use IPortableTensor

### DIFF
--- a/runtime/onert/backend/cpu/KernelGenerator.cc
+++ b/runtime/onert/backend/cpu/KernelGenerator.cc
@@ -139,10 +139,10 @@ void KernelGenerator::visit(const ir::operation::Conv2D &node)
   const auto ker_index{node.getInputs().at(Conv2D::Input::KERNEL)};
   const auto bias_index{node.getInputs().at(Conv2D::Input::BIAS)};
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto ifm_alloc = _tensor_builder->at(ifm_index).get();
-  auto ker_alloc = _tensor_builder->at(ker_index).get();
-  auto bias_alloc = _tensor_builder->at(bias_index).get();
+  auto ofm_alloc = _tensor_builder->portableAt(ofm_index).get();
+  auto ifm_alloc = _tensor_builder->portableAt(ifm_index).get();
+  auto ker_alloc = _tensor_builder->portableAt(ker_index).get();
+  auto bias_alloc = _tensor_builder->portableAt(bias_index).get();
 
   const auto stride = node.param().stride;
   const auto activation = node.param().activation;
@@ -196,10 +196,10 @@ void KernelGenerator::visit(const ir::operation::DepthwiseConv2D &node)
   const auto multiplier = node.param().multiplier;
   const auto activation = node.param().activation;
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto ifm_alloc = _tensor_builder->at(ifm_index).get();
-  auto ker_alloc = _tensor_builder->at(ker_index).get();
-  auto bias_alloc = _tensor_builder->at(bias_index).get();
+  auto ofm_alloc = _tensor_builder->portableAt(ofm_index).get();
+  auto ifm_alloc = _tensor_builder->portableAt(ifm_index).get();
+  auto ker_alloc = _tensor_builder->portableAt(ker_index).get();
+  auto bias_alloc = _tensor_builder->portableAt(bias_index).get();
 
   auto fn = std::make_unique<ops::DepthwiseConvolutionLayer>();
 
@@ -225,8 +225,8 @@ void KernelGenerator::visit(const ir::operation::MaxPool2D &node)
       ir::calculatePadding(node.param().padding, ifm_shape, ofm_shape, stride, kw, kh);
   const auto activation = node.param().activation;
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto ifm_alloc = _tensor_builder->at(ifm_index).get();
+  auto ofm_alloc = _tensor_builder->portableAt(ofm_index).get();
+  auto ifm_alloc = _tensor_builder->portableAt(ifm_index).get();
 
   auto fn = std::make_unique<ops::MaxPoolLayer>();
 
@@ -250,8 +250,8 @@ void KernelGenerator::visit(const ir::operation::AvgPool2D &node)
       ir::calculatePadding(node.param().padding, ifm_shape, ofm_shape, stride, kw, kh);
   const auto activation = node.param().activation;
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto ifm_alloc = _tensor_builder->at(ifm_index).get();
+  auto ofm_alloc = _tensor_builder->portableAt(ofm_index).get();
+  auto ifm_alloc = _tensor_builder->portableAt(ifm_index).get();
 
   auto fn = std::make_unique<ops::AvgPoolLayer>();
 
@@ -268,11 +268,11 @@ void KernelGenerator::visit(const ir::operation::Concat &node)
   const auto rank = _ctx.at(ofm_index).shape().rank();
   const auto axis = ops::getAxis(rank, node.param().axis, _current_op_seq_layout);
 
-  auto output_alloc = _tensor_builder->at(ofm_index).get();
+  auto output_alloc = _tensor_builder->portableAt(ofm_index).get();
 
-  std::vector<const Tensor *> input_tensors;
+  std::vector<const IPortableTensor *> input_tensors;
   for (auto &ifm_idx : node.getInputs())
-    input_tensors.emplace_back(_tensor_builder->at(ifm_idx).get());
+    input_tensors.emplace_back(_tensor_builder->portableAt(ifm_idx).get());
 
   auto fn = std::make_unique<ops::ConcatLayer>();
 
@@ -287,9 +287,9 @@ void KernelGenerator::visit(const ir::operation::Fill &node)
   const auto input_index{node.getInputs().at(ir::operation::Fill::Input::INPUT)};
   const auto value_index{node.getInputs().at(ir::operation::Fill::Input::VALUE)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
-  auto value_alloc = _tensor_builder->at(value_index).get();
+  auto output_alloc = _tensor_builder->portableAt(output_index).get();
+  auto input_alloc = _tensor_builder->portableAt(input_index).get();
+  auto value_alloc = _tensor_builder->portableAt(value_index).get();
 
   auto fn = std::make_unique<ops::FillLayer>();
 
@@ -308,10 +308,11 @@ void KernelGenerator::visit(const ir::operation::FullyConnected &node)
   const auto bias_index{node.getInputs().at(FullyConnected::Input::BIAS)};
   const auto activation = node.param().activation;
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
-  auto weight_alloc = _tensor_builder->at(weight_index).get();
-  auto bias_alloc = bias_index.undefined() ? nullptr : _tensor_builder->at(bias_index).get();
+  auto output_alloc = _tensor_builder->portableAt(output_index).get();
+  auto input_alloc = _tensor_builder->portableAt(input_index).get();
+  auto weight_alloc = _tensor_builder->portableAt(weight_index).get();
+  auto bias_alloc =
+      bias_index.undefined() ? nullptr : _tensor_builder->portableAt(bias_index).get();
 
   auto fn = std::make_unique<ops::FullyConnectedLayer>();
 
@@ -325,16 +326,16 @@ void KernelGenerator::visit(const ir::operation::Reshape &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(ir::operation::Reshape::Input::INPUT)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto output_alloc = _tensor_builder->portableAt(output_index).get();
+  auto input_alloc = _tensor_builder->portableAt(input_index).get();
 
   // optional 2nd input
-  Tensor *shape_alloc = nullptr;
+  IPortableTensor *shape_alloc = nullptr;
 
   if (node.getInputs().size() == 2)
   {
     const auto shape_index{node.getInputs().at(ir::operation::Reshape::Input::SHAPE)};
-    shape_alloc = _tensor_builder->at(shape_index).get();
+    shape_alloc = _tensor_builder->portableAt(shape_index).get();
   }
 
   auto fn = std::make_unique<ops::ReshapeLayer>();
@@ -348,8 +349,8 @@ void KernelGenerator::visit(const ir::operation::Squeeze &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(ir::operation::Squeeze::Input::INPUT)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto output_alloc = _tensor_builder->portableAt(output_index).get();
+  auto input_alloc = _tensor_builder->portableAt(input_index).get();
 
   // Squeeze can share same kernel with reshape
   auto fn = std::make_unique<ops::ReshapeLayer>();
@@ -366,8 +367,8 @@ void KernelGenerator::visit(const ir::operation::Softmax &node)
 
   const auto beta = node.param().beta;
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto output_alloc = _tensor_builder->portableAt(output_index).get();
+  auto input_alloc = _tensor_builder->portableAt(input_index).get();
 
   auto fn = std::make_unique<ops::SoftMaxLayer>();
 
@@ -384,9 +385,9 @@ void KernelGenerator::visit(const ir::operation::Add &node)
 
   const auto activation = node.param().activation;
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto lhs_alloc = _tensor_builder->at(lhs_index).get();
-  auto rhs_alloc = _tensor_builder->at(rhs_index).get();
+  auto ofm_alloc = _tensor_builder->portableAt(ofm_index).get();
+  auto lhs_alloc = _tensor_builder->portableAt(lhs_index).get();
+  auto rhs_alloc = _tensor_builder->portableAt(rhs_index).get();
 
   auto fn = std::make_unique<ops::AddLayer>();
 
@@ -401,9 +402,9 @@ void KernelGenerator::visit(const ir::operation::Comparison &node)
   const auto lhs_index{node.getInputs().at(ir::operation::Comparison::Input::INPUT0)};
   const auto rhs_index{node.getInputs().at(ir::operation::Comparison::Input::INPUT1)};
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto lhs_alloc = _tensor_builder->at(lhs_index).get();
-  auto rhs_alloc = _tensor_builder->at(rhs_index).get();
+  auto ofm_alloc = _tensor_builder->portableAt(ofm_index).get();
+  auto lhs_alloc = _tensor_builder->portableAt(lhs_index).get();
+  auto rhs_alloc = _tensor_builder->portableAt(rhs_index).get();
 
   auto comparison_type = node.param().comparison_type;
 
@@ -420,9 +421,9 @@ void KernelGenerator::visit(const ir::operation::Gather &node)
   const auto input_index{node.getInputs().at(ir::operation::Gather::Input::INPUT)};
   const auto indices_index{node.getInputs().at(ir::operation::Gather::Input::INDICES)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
-  auto indices_alloc = _tensor_builder->at(indices_index).get();
+  auto output_alloc = _tensor_builder->portableAt(output_index).get();
+  auto input_alloc = _tensor_builder->portableAt(input_index).get();
+  auto indices_alloc = _tensor_builder->portableAt(indices_index).get();
 
   const auto backend_layout = output_alloc->layout();
   UNUSED_RELEASE(backend_layout);
@@ -460,9 +461,9 @@ void KernelGenerator::visit(const ir::operation::Sub &node)
 
   const auto activation = node.param().activation;
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto lhs_alloc = _tensor_builder->at(lhs_index).get();
-  auto rhs_alloc = _tensor_builder->at(rhs_index).get();
+  auto ofm_alloc = _tensor_builder->portableAt(ofm_index).get();
+  auto lhs_alloc = _tensor_builder->portableAt(lhs_index).get();
+  auto rhs_alloc = _tensor_builder->portableAt(rhs_index).get();
 
   auto fn = std::make_unique<ops::SubLayer>();
 
@@ -480,9 +481,9 @@ void KernelGenerator::visit(const ir::operation::Mul &node)
 
   const auto activation = node.param().activation;
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto lhs_alloc = _tensor_builder->at(lhs_index).get();
-  auto rhs_alloc = _tensor_builder->at(rhs_index).get();
+  auto ofm_alloc = _tensor_builder->portableAt(ofm_index).get();
+  auto lhs_alloc = _tensor_builder->portableAt(lhs_index).get();
+  auto rhs_alloc = _tensor_builder->portableAt(rhs_index).get();
 
   auto fn = std::make_unique<ops::MulLayer>();
 
@@ -501,8 +502,8 @@ void KernelGenerator::visit(const ir::operation::OneHot &node)
   const auto off_value = node.param().off_value;
   const auto axis = node.param().axis;
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto indices_alloc = _tensor_builder->at(indices_index).get();
+  auto output_alloc = _tensor_builder->portableAt(output_index).get();
+  auto indices_alloc = _tensor_builder->portableAt(indices_index).get();
 
   assert(indices_alloc->data_type() == OperandType::INT32);
   assert(axis <= static_cast<int>(indices_alloc->num_dimensions()));
@@ -523,9 +524,9 @@ void KernelGenerator::visit(const ir::operation::Div &node)
 
   const auto activation = node.param().activation;
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto lhs_alloc = _tensor_builder->at(lhs_index).get();
-  auto rhs_alloc = _tensor_builder->at(rhs_index).get();
+  auto ofm_alloc = _tensor_builder->portableAt(ofm_index).get();
+  auto lhs_alloc = _tensor_builder->portableAt(lhs_index).get();
+  auto rhs_alloc = _tensor_builder->portableAt(rhs_index).get();
 
   auto fn = std::make_unique<ops::DivLayer>();
 
@@ -538,10 +539,10 @@ void KernelGenerator::visit(const ir::operation::Einsum &node)
 {
   const auto ofm_index{node.getOutputs().at(0)};
 
-  auto output_alloc = _tensor_builder->at(ofm_index).get();
-  std::vector<const Tensor *> input_allocs;
+  auto output_alloc = _tensor_builder->portableAt(ofm_index).get();
+  std::vector<const IPortableTensor *> input_allocs;
   for (auto &ifm_idx : node.getInputs())
-    input_allocs.emplace_back(_tensor_builder->at(ifm_idx).get());
+    input_allocs.emplace_back(_tensor_builder->portableAt(ifm_idx).get());
 
   const auto equation = node.param().equation;
 
@@ -572,7 +573,7 @@ void KernelGenerator::visit(const ir::operation::Custom &node)
       const auto &operand = _ctx.at(idx);
       // TODO make sure using `_current_op_seq_layout` is correct for custom operations
       types.emplace_back(get_type_info(operand));
-      auto in_alloc = _tensor_builder->at(idx)->buffer();
+      auto in_alloc = _tensor_builder->portableAt(idx)->buffer();
       allocs.emplace_back(in_alloc);
     }
   };
@@ -595,8 +596,8 @@ void KernelGenerator::visit(const ir::operation::Exp &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(ir::operation::Exp::Input::INPUT)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto output_alloc = _tensor_builder->portableAt(output_index).get();
+  auto input_alloc = _tensor_builder->portableAt(input_index).get();
 
   auto fn = std::make_unique<ops::ExpLayer>();
 
@@ -611,9 +612,9 @@ void KernelGenerator::visit(const ir::operation::ExpandDims &node)
   const auto input_index{node.getInputs().at(ir::operation::ExpandDims::Input::INPUT)};
   const auto axis_index{node.getInputs().at(ir::operation::ExpandDims::Input::AXIS)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
-  auto axis_alloc = _tensor_builder->at(axis_index).get();
+  auto output_alloc = _tensor_builder->portableAt(output_index).get();
+  auto input_alloc = _tensor_builder->portableAt(input_index).get();
+  auto axis_alloc = _tensor_builder->portableAt(axis_index).get();
 
   auto fn = std::make_unique<ops::ExpandDimsLayer>();
 
@@ -627,8 +628,8 @@ void KernelGenerator::visit(const ir::operation::Logistic &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(ir::operation::Logistic::Input::INPUT)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto output_alloc = _tensor_builder->portableAt(output_index).get();
+  auto input_alloc = _tensor_builder->portableAt(input_index).get();
 
   auto fn = std::make_unique<ops::LogisticLayer>();
 
@@ -642,8 +643,8 @@ void KernelGenerator::visit(const ir::operation::Tanh &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(ir::operation::Tanh::Input::INPUT)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto output_alloc = _tensor_builder->portableAt(output_index).get();
+  auto input_alloc = _tensor_builder->portableAt(input_index).get();
 
   auto fn = std::make_unique<ops::TanhLayer>();
 
@@ -661,11 +662,11 @@ void KernelGenerator::visit(const ir::operation::Pack &node)
 
   assert(-rank <= axis && axis < rank);
 
-  auto output_alloc = _tensor_builder->at(ofm_index).get();
+  auto output_alloc = _tensor_builder->portableAt(ofm_index).get();
 
-  std::vector<const Tensor *> input_tensors;
+  std::vector<const IPortableTensor *> input_tensors;
   for (auto &ifm_idx : node.getInputs())
-    input_tensors.emplace_back(_tensor_builder->at(ifm_idx).get());
+    input_tensors.emplace_back(_tensor_builder->portableAt(ifm_idx).get());
 
   auto fn = std::make_unique<ops::PackLayer>();
 
@@ -683,11 +684,11 @@ void KernelGenerator::visit(const ir::operation::Unpack &node)
 
   assert(rank == 0 || (-rank <= axis && axis < rank));
 
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto input_alloc = _tensor_builder->portableAt(input_index).get();
 
-  std::vector<Tensor *> output_tensors;
+  std::vector<IPortableTensor *> output_tensors;
   for (auto &output_idx : node.getOutputs())
-    output_tensors.emplace_back(_tensor_builder->at(output_idx).get());
+    output_tensors.emplace_back(_tensor_builder->portableAt(output_idx).get());
 
   auto fn = std::make_unique<ops::UnpackLayer>();
 
@@ -705,8 +706,8 @@ void KernelGenerator::visit(const ir::operation::Pad &node)
   const auto output_index{node.getOutputs().at(0)};
   assert(_ctx.at(pad_index).data());
 
-  auto input = _tensor_builder->at(input_index).get();
-  auto output = _tensor_builder->at(output_index).get();
+  auto input = _tensor_builder->portableAt(input_index).get();
+  auto output = _tensor_builder->portableAt(output_index).get();
   auto pad_rank = _ctx.at(pad_index).shape().dim(0);
   auto pad_base = reinterpret_cast<const int32_t *>(_ctx.at(pad_index).data()->base());
 
@@ -723,9 +724,9 @@ void KernelGenerator::visit(const ir::operation::Max &node)
   const auto lhs_index{node.getInputs().at(ir::operation::Max::Input::LHS)};
   const auto rhs_index{node.getInputs().at(ir::operation::Max::Input::RHS)};
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto lhs_alloc = _tensor_builder->at(lhs_index).get();
-  auto rhs_alloc = _tensor_builder->at(rhs_index).get();
+  auto ofm_alloc = _tensor_builder->portableAt(ofm_index).get();
+  auto lhs_alloc = _tensor_builder->portableAt(lhs_index).get();
+  auto rhs_alloc = _tensor_builder->portableAt(rhs_index).get();
 
   auto fn = std::make_unique<ops::MaxLayer>();
 
@@ -740,9 +741,9 @@ void KernelGenerator::visit(const ir::operation::Min &node)
   const auto lhs_index{node.getInputs().at(ir::operation::Min::Input::LHS)};
   const auto rhs_index{node.getInputs().at(ir::operation::Min::Input::RHS)};
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto lhs_alloc = _tensor_builder->at(lhs_index).get();
-  auto rhs_alloc = _tensor_builder->at(rhs_index).get();
+  auto ofm_alloc = _tensor_builder->portableAt(ofm_index).get();
+  auto lhs_alloc = _tensor_builder->portableAt(lhs_index).get();
+  auto rhs_alloc = _tensor_builder->portableAt(rhs_index).get();
 
   auto fn = std::make_unique<ops::MinLayer>();
 
@@ -756,8 +757,8 @@ void KernelGenerator::visit(const ir::operation::Cast &node)
   const auto ofm_index{node.getOutputs().at(0)};
   const auto ifm_index{node.getInputs().at(ir::operation::Cast::Input::INPUT)};
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto ifm_alloc = _tensor_builder->at(ifm_index).get();
+  auto ofm_alloc = _tensor_builder->portableAt(ofm_index).get();
+  auto ifm_alloc = _tensor_builder->portableAt(ifm_index).get();
 
   auto fn = std::make_unique<ops::CastLayer>();
 
@@ -771,8 +772,8 @@ void KernelGenerator::visit(const ir::operation::Transpose &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(ir::operation::Transpose::Input::INPUT)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto output_alloc = _tensor_builder->portableAt(output_index).get();
+  auto input_alloc = _tensor_builder->portableAt(input_index).get();
 
   auto fn = std::make_unique<ops::TransposeLayer>();
 
@@ -786,8 +787,8 @@ void KernelGenerator::visit(const ir::operation::ReduceSum &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(0)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto output_alloc = _tensor_builder->portableAt(output_index).get();
+  auto input_alloc = _tensor_builder->portableAt(input_index).get();
 
   auto fn = std::make_unique<ops::ReduceLayer>();
 
@@ -802,8 +803,8 @@ void KernelGenerator::visit(const ir::operation::ReduceAll &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(ir::operation::ReduceAll::Input::INPUT)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto output_alloc = _tensor_builder->portableAt(output_index).get();
+  auto input_alloc = _tensor_builder->portableAt(input_index).get();
 
   auto fn = std::make_unique<ops::ReduceLayer>();
 
@@ -818,8 +819,8 @@ void KernelGenerator::visit(const ir::operation::ReduceAny &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(ir::operation::ReduceAny::Input::INPUT)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto output_alloc = _tensor_builder->portableAt(output_index).get();
+  auto input_alloc = _tensor_builder->portableAt(input_index).get();
 
   auto fn = std::make_unique<ops::ReduceLayer>();
 
@@ -834,8 +835,8 @@ void KernelGenerator::visit(const ir::operation::ReduceMax &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(0)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto output_alloc = _tensor_builder->portableAt(output_index).get();
+  auto input_alloc = _tensor_builder->portableAt(input_index).get();
 
   auto fn = std::make_unique<ops::ReduceLayer>();
 
@@ -850,8 +851,8 @@ void KernelGenerator::visit(const ir::operation::ReduceMin &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(0)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto output_alloc = _tensor_builder->portableAt(output_index).get();
+  auto input_alloc = _tensor_builder->portableAt(input_index).get();
 
   auto fn = std::make_unique<ops::ReduceLayer>();
 
@@ -866,8 +867,8 @@ void KernelGenerator::visit(const ir::operation::ReLU &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(0)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto output_alloc = _tensor_builder->portableAt(output_index).get();
+  auto input_alloc = _tensor_builder->portableAt(input_index).get();
 
   auto fn = std::make_unique<ops::ReLULayer>();
 
@@ -883,10 +884,10 @@ void KernelGenerator::visit(const ir::operation::Select &node)
   const auto true_index{node.getInputs().at(ir::operation::Select::Input::INPUT_TRUE)};
   const auto false_index{node.getInputs().at(ir::operation::Select::Input::INPUT_FALSE)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto condition_alloc = _tensor_builder->at(condition_index).get();
-  auto true_alloc = _tensor_builder->at(true_index).get();
-  auto false_alloc = _tensor_builder->at(false_index).get();
+  auto output_alloc = _tensor_builder->portableAt(output_index).get();
+  auto condition_alloc = _tensor_builder->portableAt(condition_index).get();
+  auto true_alloc = _tensor_builder->portableAt(true_index).get();
+  auto false_alloc = _tensor_builder->portableAt(false_index).get();
 
   auto fn = std::make_unique<ops::SelectLayer>();
 
@@ -902,10 +903,10 @@ void KernelGenerator::visit(const ir::operation::Slice &node)
   const auto begins_index{node.getInputs().at(ir::operation::Slice::Input::BEGINS)};
   const auto sizes_index{node.getInputs().at(ir::operation::Slice::Input::SIZES)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
-  auto begins_alloc = _tensor_builder->at(begins_index).get();
-  auto sizes_alloc = _tensor_builder->at(sizes_index).get();
+  auto output_alloc = _tensor_builder->portableAt(output_index).get();
+  auto input_alloc = _tensor_builder->portableAt(input_index).get();
+  auto begins_alloc = _tensor_builder->portableAt(begins_index).get();
+  auto sizes_alloc = _tensor_builder->portableAt(sizes_index).get();
 
   auto fn = std::make_unique<ops::SliceLayer>();
 
@@ -922,11 +923,11 @@ void KernelGenerator::visit(const ir::operation::StridedSlice &node)
   const auto ends_index{node.getInputs().at(ir::operation::StridedSlice::Input::ENDS)};
   const auto strides_index{node.getInputs().at(ir::operation::StridedSlice::Input::STRIDES)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
-  auto starts_alloc = _tensor_builder->at(starts_index).get();
-  auto ends_alloc = _tensor_builder->at(ends_index).get();
-  auto strides_alloc = _tensor_builder->at(strides_index).get();
+  auto output_alloc = _tensor_builder->portableAt(output_index).get();
+  auto input_alloc = _tensor_builder->portableAt(input_index).get();
+  auto starts_alloc = _tensor_builder->portableAt(starts_index).get();
+  auto ends_alloc = _tensor_builder->portableAt(ends_index).get();
+  auto strides_alloc = _tensor_builder->portableAt(strides_index).get();
 
   auto begin_mask = node.param().begin_mask;
   auto end_mask = node.param().end_mask;
@@ -950,11 +951,11 @@ void KernelGenerator::visit(const ir::operation::Split &node)
   const auto axis = ops::getAxis(rank, node.param().axis, _current_op_seq_layout);
   auto axis_resolved = axis < 0 ? axis + rank : axis;
 
-  auto in_tensor = _tensor_builder->at(input_idx).get();
+  auto in_tensor = _tensor_builder->portableAt(input_idx).get();
 
-  std::vector<Tensor *> out_tensors;
+  std::vector<IPortableTensor *> out_tensors;
   for (auto &output_idx : node.getOutputs())
-    out_tensors.emplace_back(_tensor_builder->at(output_idx).get());
+    out_tensors.emplace_back(_tensor_builder->portableAt(output_idx).get());
 
   auto fn = std::make_unique<ops::SplitLayer>();
 
@@ -968,8 +969,8 @@ void KernelGenerator::visit(const ir::operation::Abs &node)
   const auto ofm_index{node.getOutputs().at(0)};
   const auto ifm_index{node.getInputs().at(ir::operation::Abs::Input::INPUT)};
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto ifm_alloc = _tensor_builder->at(ifm_index).get();
+  auto ofm_alloc = _tensor_builder->portableAt(ofm_index).get();
+  auto ifm_alloc = _tensor_builder->portableAt(ifm_index).get();
 
   auto fn = std::make_unique<ops::AbsLayer>();
 
@@ -983,8 +984,8 @@ void KernelGenerator::visit(const ir::operation::Sin &node)
   const auto ofm_index{node.getOutputs().at(0)};
   const auto ifm_index{node.getInputs().at(ir::operation::Sin::Input::INPUT)};
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto ifm_alloc = _tensor_builder->at(ifm_index).get();
+  auto ofm_alloc = _tensor_builder->portableAt(ofm_index).get();
+  auto ifm_alloc = _tensor_builder->portableAt(ifm_index).get();
 
   auto fn = std::make_unique<ops::SinLayer>();
 
@@ -998,8 +999,8 @@ void KernelGenerator::visit(const ir::operation::Cos &node)
   const auto ofm_index{node.getOutputs().at(0)};
   const auto ifm_index{node.getInputs().at(ir::operation::Cos::Input::INPUT)};
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto ifm_alloc = _tensor_builder->at(ifm_index).get();
+  auto ofm_alloc = _tensor_builder->portableAt(ofm_index).get();
+  auto ifm_alloc = _tensor_builder->portableAt(ifm_index).get();
 
   auto fn = std::make_unique<ops::CosLayer>();
 
@@ -1013,8 +1014,8 @@ void KernelGenerator::visit(const ir::operation::RSQRT &node)
   const auto ofm_index{node.getOutputs().at(0)};
   const auto ifm_index{node.getInputs().at(ir::operation::RSQRT::Input::INPUT)};
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto ifm_alloc = _tensor_builder->at(ifm_index).get();
+  auto ofm_alloc = _tensor_builder->portableAt(ofm_index).get();
+  auto ifm_alloc = _tensor_builder->portableAt(ifm_index).get();
 
   auto fn = std::make_unique<ops::RsqrtLayer>();
 
@@ -1028,8 +1029,8 @@ void KernelGenerator::visit(const ir::operation::Shape &node)
   const auto ofm_index{node.getOutputs().at(0)};
   const auto ifm_index{node.getInputs().at(ir::operation::Shape::Input::INPUT)};
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto ifm_alloc = _tensor_builder->at(ifm_index).get();
+  auto ofm_alloc = _tensor_builder->portableAt(ofm_index).get();
+  auto ifm_alloc = _tensor_builder->portableAt(ifm_index).get();
 
   auto fn = std::make_unique<ops::ShapeLayer>();
 
@@ -1043,8 +1044,8 @@ void KernelGenerator::visit(const ir::operation::ReduceProd &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(0)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto output_alloc = _tensor_builder->portableAt(output_index).get();
+  auto input_alloc = _tensor_builder->portableAt(input_index).get();
 
   auto fn = std::make_unique<ops::ReduceLayer>();
 
@@ -1060,9 +1061,9 @@ void KernelGenerator::visit(const ir::operation::Reverse &node)
   const auto input_index{node.getInputs().at(ir::operation::Reverse::INPUT)};
   const auto axis_index{node.getInputs().at(ir::operation::Reverse::AXIS)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
-  auto axis_alloc = _tensor_builder->at(axis_index).get();
+  auto output_alloc = _tensor_builder->portableAt(output_index).get();
+  auto input_alloc = _tensor_builder->portableAt(input_index).get();
+  auto axis_alloc = _tensor_builder->portableAt(axis_index).get();
 
   auto fn = std::make_unique<ops::ReverseLayer>();
 
@@ -1076,8 +1077,8 @@ void KernelGenerator::visit(const ir::operation::Neg &node)
   const auto ofm_index{node.getOutputs().at(0)};
   const auto ifm_index{node.getInputs().at(ir::operation::Neg::Input::INPUT)};
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto ifm_alloc = _tensor_builder->at(ifm_index).get();
+  auto ofm_alloc = _tensor_builder->portableAt(ofm_index).get();
+  auto ifm_alloc = _tensor_builder->portableAt(ifm_index).get();
 
   auto fn = std::make_unique<ops::NegLayer>();
 
@@ -1093,8 +1094,8 @@ void KernelGenerator::visit(const ir::operation::ArgMax &node)
 
   const auto axis = node.param().axis;
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto output_alloc = _tensor_builder->portableAt(output_index).get();
+  auto input_alloc = _tensor_builder->portableAt(input_index).get();
 
   auto fn = std::make_unique<ops::ArgMinMaxLayer>();
 
@@ -1109,9 +1110,9 @@ void KernelGenerator::visit(const ir::operation::Pow &node)
   const auto lhs_index{node.getInputs().at(ir::operation::Pow::LHS)};
   const auto rhs_index{node.getInputs().at(ir::operation::Pow::RHS)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto lhs_alloc = _tensor_builder->at(lhs_index).get();
-  auto rhs_alloc = _tensor_builder->at(rhs_index).get();
+  auto output_alloc = _tensor_builder->portableAt(output_index).get();
+  auto lhs_alloc = _tensor_builder->portableAt(lhs_index).get();
+  auto rhs_alloc = _tensor_builder->portableAt(rhs_index).get();
 
   auto fn = std::make_unique<ops::PowLayer>();
 
@@ -1125,8 +1126,8 @@ void KernelGenerator::visit(const ir::operation::Log &node)
   const auto ofm_index{node.getOutputs().at(0)};
   const auto ifm_index{node.getInputs().at(ir::operation::Log::Input::INPUT)};
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto ifm_alloc = _tensor_builder->at(ifm_index).get();
+  auto ofm_alloc = _tensor_builder->portableAt(ofm_index).get();
+  auto ifm_alloc = _tensor_builder->portableAt(ifm_index).get();
 
   auto fn = std::make_unique<ops::LogLayer>();
 
@@ -1140,8 +1141,8 @@ void KernelGenerator::visit(const ir::operation::Round &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(ir::operation::Round::INPUT)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto output_alloc = _tensor_builder->portableAt(output_index).get();
+  auto input_alloc = _tensor_builder->portableAt(input_index).get();
 
   auto fn = std::make_unique<ops::RoundLayer>();
 
@@ -1155,8 +1156,8 @@ void KernelGenerator::visit(const ir::operation::LogicalNot &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(ir::operation::LogicalNot::INPUT)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto output_alloc = _tensor_builder->portableAt(output_index).get();
+  auto input_alloc = _tensor_builder->portableAt(input_index).get();
 
   auto fn = std::make_unique<ops::LogicalNotLayer>();
 
@@ -1171,9 +1172,9 @@ void KernelGenerator::visit(const ir::operation::LogicalOr &node)
   const auto lhs_index{node.getInputs().at(0)};
   const auto rhs_index{node.getInputs().at(1)};
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto lhs_alloc = _tensor_builder->at(lhs_index).get();
-  auto rhs_alloc = _tensor_builder->at(rhs_index).get();
+  auto ofm_alloc = _tensor_builder->portableAt(ofm_index).get();
+  auto lhs_alloc = _tensor_builder->portableAt(lhs_index).get();
+  auto rhs_alloc = _tensor_builder->portableAt(rhs_index).get();
 
   auto fn = std::make_unique<ops::LogicalOrLayer>();
 
@@ -1189,8 +1190,8 @@ void KernelGenerator::visit(const ir::operation::Mean &node)
 
   const auto axes = node.param().axes;
   const auto keep_dims = node.param().keep_dims;
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto output_alloc = _tensor_builder->portableAt(output_index).get();
+  auto input_alloc = _tensor_builder->portableAt(input_index).get();
 
   auto fn = std::make_unique<ops::MeanLayer>();
 
@@ -1203,8 +1204,8 @@ void KernelGenerator::visit(const ir::operation::ZerosLike &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(ir::operation::ZerosLike::INPUT)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
+  auto output_alloc = _tensor_builder->portableAt(output_index).get();
+  auto input_alloc = _tensor_builder->portableAt(input_index).get();
 
   auto fn = std::make_unique<ops::ZerosLikeLayer>();
 
@@ -1219,10 +1220,10 @@ void KernelGenerator::visit(const ir::operation::Range &node)
   const auto limit_index{node.getInputs().at(ir::operation::Range::LIMIT)};
   const auto delta_index{node.getInputs().at(ir::operation::Range::DELTA)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto start_alloc = _tensor_builder->at(start_index).get();
-  auto limit_alloc = _tensor_builder->at(limit_index).get();
-  auto delta_alloc = _tensor_builder->at(delta_index).get();
+  auto output_alloc = _tensor_builder->portableAt(output_index).get();
+  auto start_alloc = _tensor_builder->portableAt(start_index).get();
+  auto limit_alloc = _tensor_builder->portableAt(limit_index).get();
+  auto delta_alloc = _tensor_builder->portableAt(delta_index).get();
 
   auto fn = std::make_unique<ops::RangeLayer>();
 
@@ -1236,9 +1237,9 @@ void KernelGenerator::visit(const ir::operation::SquaredDifference &node)
   const auto lhs_index{node.getInputs().at(ir::operation::SquaredDifference::Input::LHS)};
   const auto rhs_index{node.getInputs().at(ir::operation::SquaredDifference::Input::RHS)};
 
-  auto ofm_alloc = _tensor_builder->at(ofm_index).get();
-  auto lhs_alloc = _tensor_builder->at(lhs_index).get();
-  auto rhs_alloc = _tensor_builder->at(rhs_index).get();
+  auto ofm_alloc = _tensor_builder->portableAt(ofm_index).get();
+  auto lhs_alloc = _tensor_builder->portableAt(lhs_index).get();
+  auto rhs_alloc = _tensor_builder->portableAt(rhs_index).get();
 
   auto fn = std::make_unique<ops::SqDiffLayer>();
 
@@ -1252,9 +1253,9 @@ void KernelGenerator::visit(const ir::operation::Tile &node)
   const auto input_index{node.getInputs().at(ir::operation::Tile::INPUT)};
   const auto multiples_index{node.getInputs().at(ir::operation::Tile::MULTIPLES)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
-  auto multiples_alloc = _tensor_builder->at(multiples_index).get();
+  auto output_alloc = _tensor_builder->portableAt(output_index).get();
+  auto input_alloc = _tensor_builder->portableAt(input_index).get();
+  auto multiples_alloc = _tensor_builder->portableAt(multiples_index).get();
 
   auto fn = std::make_unique<ops::TileLayer>();
 
@@ -1269,10 +1270,10 @@ void KernelGenerator::visit(const ir::operation::MatrixBandPart &node)
   const auto num_lower_index{node.getInputs().at(ir::operation::MatrixBandPart::NUM_LOWER_DIAG)};
   const auto num_upper_index{node.getInputs().at(ir::operation::MatrixBandPart::NUM_UPPER_DIAG)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
-  auto num_lower_alloc = _tensor_builder->at(num_lower_index).get();
-  auto num_upper_alloc = _tensor_builder->at(num_upper_index).get();
+  auto output_alloc = _tensor_builder->portableAt(output_index).get();
+  auto input_alloc = _tensor_builder->portableAt(input_index).get();
+  auto num_lower_alloc = _tensor_builder->portableAt(num_lower_index).get();
+  auto num_upper_alloc = _tensor_builder->portableAt(num_upper_index).get();
 
   auto fn = std::make_unique<ops::MatrixBandPartLayer>();
 
@@ -1286,9 +1287,9 @@ void KernelGenerator::visit(const ir::operation::BatchMatMul &node)
   const auto lhs_index{node.getInputs().at(ir::operation::BatchMatMul::LHS)};
   const auto rhs_index{node.getInputs().at(ir::operation::BatchMatMul::RHS)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto lhs_alloc = _tensor_builder->at(lhs_index).get();
-  auto rhs_alloc = _tensor_builder->at(rhs_index).get();
+  auto output_alloc = _tensor_builder->portableAt(output_index).get();
+  auto lhs_alloc = _tensor_builder->portableAt(lhs_index).get();
+  auto rhs_alloc = _tensor_builder->portableAt(rhs_index).get();
 
   const auto adj_x = node.param().adj_x;
   const auto adj_y = node.param().adj_y;

--- a/runtime/onert/backend/cpu/ops/AbsLayer.cc
+++ b/runtime/onert/backend/cpu/ops/AbsLayer.cc
@@ -42,7 +42,7 @@ void AbsLayer::absFloat32()
 
 void AbsLayer::absQuant8() { throw std::runtime_error{"NYI"}; }
 
-void AbsLayer::configure(const Tensor *input, Tensor *output)
+void AbsLayer::configure(const IPortableTensor *input, IPortableTensor *output)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/ops/AbsLayer.h
+++ b/runtime/onert/backend/cpu/ops/AbsLayer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_OPS_ABSLAYER_H__
 #define __ONERT_BACKEND_CPU_OPS_ABSLAYER_H__
 
-#include "../Tensor.h"
+#include "backend/IPortableTensor.h"
 
 #include <exec/IFunction.h>
 
@@ -40,13 +40,13 @@ public:
 
   void absQuant8();
 
-  void configure(const Tensor *input, Tensor *output);
+  void configure(const IPortableTensor *input, IPortableTensor *output);
 
   void run();
 
 private:
-  const Tensor *_input;
-  Tensor *_output;
+  const IPortableTensor *_input;
+  IPortableTensor *_output;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/AddLayer.cc
+++ b/runtime/onert/backend/cpu/ops/AddLayer.cc
@@ -127,8 +127,8 @@ void AddLayer::addQuant8()
       getTensorShape(_output), reinterpret_cast<uint8_t *>(_output->buffer()));
 }
 
-void AddLayer::configure(const Tensor *lhs, const Tensor *rhs, const ir::Activation activation,
-                         Tensor *output)
+void AddLayer::configure(const IPortableTensor *lhs, const IPortableTensor *rhs,
+                         const ir::Activation activation, IPortableTensor *output)
 {
   assert(lhs != nullptr);
   assert(rhs != nullptr);

--- a/runtime/onert/backend/cpu/ops/AddLayer.h
+++ b/runtime/onert/backend/cpu/ops/AddLayer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_OPS_ADDLAYER_H__
 #define __ONERT_BACKEND_CPU_OPS_ADDLAYER_H__
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 #include "OperationUtils.h"
 
 #include <exec/IFunction.h>
@@ -46,15 +46,15 @@ public:
 
   void addInt32();
 
-  void configure(const Tensor *lhs, const Tensor *rhs, const ir::Activation activation,
-                 Tensor *output);
+  void configure(const IPortableTensor *lhs, const IPortableTensor *rhs,
+                 const ir::Activation activation, IPortableTensor *output);
 
   void run();
 
 private:
-  const Tensor *_lhs;
-  const Tensor *_rhs;
-  Tensor *_output;
+  const IPortableTensor *_lhs;
+  const IPortableTensor *_rhs;
+  IPortableTensor *_output;
 
   ir::Activation _activation{ir::Activation::NONE};
 };

--- a/runtime/onert/backend/cpu/ops/ArgMinMaxLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ArgMinMaxLayer.cc
@@ -44,7 +44,8 @@ template <typename T> std::function<bool(T, T)> GetComparefunction(bool is_arg_m
 }
 }
 
-void ArgMinMaxLayer::configure(const Tensor *input, Tensor *output, int32_t axis, bool is_arg_max)
+void ArgMinMaxLayer::configure(const IPortableTensor *input, IPortableTensor *output, int32_t axis,
+                               bool is_arg_max)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/ops/ArgMinMaxLayer.h
+++ b/runtime/onert/backend/cpu/ops/ArgMinMaxLayer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_OPS_ARGMINMAXLAYER_H__
 #define __ONERT_BACKEND_CPU_OPS_ARGMINMAXLAYER_H__
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 
 #include <exec/IFunction.h>
 
@@ -36,13 +36,14 @@ public:
   ArgMinMaxLayer() : _input(nullptr), _output(nullptr), _axis(-1), _is_arg_max(true) {}
 
 public:
-  void configure(const Tensor *indices, Tensor *output, int32_t axis, bool is_arg_max);
+  void configure(const IPortableTensor *indices, IPortableTensor *output, int32_t axis,
+                 bool is_arg_max);
 
   void run();
 
 private:
-  const Tensor *_input;
-  Tensor *_output;
+  const IPortableTensor *_input;
+  IPortableTensor *_output;
   int32_t _axis;
   bool _is_arg_max;
 };

--- a/runtime/onert/backend/cpu/ops/AvgPoolLayer.cc
+++ b/runtime/onert/backend/cpu/ops/AvgPoolLayer.cc
@@ -71,12 +71,12 @@ void AvgPoolLayer::averagePoolQuant8()
                           getTensorShape(_output), reinterpret_cast<uint8_t *>(_output->buffer()));
 }
 
-void AvgPoolLayer::configure(const Tensor *input, const uint32_t paddingLeft,
+void AvgPoolLayer::configure(const IPortableTensor *input, const uint32_t paddingLeft,
                              const uint32_t paddingRight, const uint32_t paddingTop,
                              const uint32_t paddingBottom, const uint32_t strideWidth,
                              const uint32_t strideHeight, const uint32_t kernelWidth,
                              const uint32_t kernelHeight, const ir::Activation activation,
-                             Tensor *output)
+                             IPortableTensor *output)
 {
   assert(input != nullptr);
   assert(output != nullptr);

--- a/runtime/onert/backend/cpu/ops/AvgPoolLayer.h
+++ b/runtime/onert/backend/cpu/ops/AvgPoolLayer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_OPS_AVGPOOLLAYER_H__
 #define __ONERT_BACKEND_CPU_OPS_AVGPOOLLAYER_H__
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 #include "OperationUtils.h"
 
 #include <exec/IFunction.h>
@@ -41,17 +41,18 @@ public:
 
   void averagePoolQuant8();
 
-  void configure(const Tensor *input, const uint32_t paddingLeft, const uint32_t paddingRight,
-                 const uint32_t paddingTop, const uint32_t paddingBottom,
-                 const uint32_t strideWidth, const uint32_t strideHeight,
-                 const uint32_t kernelWidth, const uint32_t kernelHeight,
-                 const ir::Activation activation, Tensor *output);
+  void configure(const IPortableTensor *input, const uint32_t paddingLeft,
+                 const uint32_t paddingRight, const uint32_t paddingTop,
+                 const uint32_t paddingBottom, const uint32_t strideWidth,
+                 const uint32_t strideHeight, const uint32_t kernelWidth,
+                 const uint32_t kernelHeight, const ir::Activation activation,
+                 IPortableTensor *output);
 
   void run();
 
 private:
-  const Tensor *_input;
-  Tensor *_output;
+  const IPortableTensor *_input;
+  IPortableTensor *_output;
 
   uint32_t _paddingLeft;
   uint32_t _paddingTop;

--- a/runtime/onert/backend/cpu/ops/BatchMatMulLayer.cc
+++ b/runtime/onert/backend/cpu/ops/BatchMatMulLayer.cc
@@ -51,8 +51,8 @@ void BatchMatMulLayer::batchMatMulFloat32()
                      reinterpret_cast<float *>(_output->buffer()));
 }
 
-void BatchMatMulLayer::configure(const Tensor *lhs, const Tensor *rhs, bool adj_x, bool adj_y,
-                                 Tensor *output)
+void BatchMatMulLayer::configure(const IPortableTensor *lhs, const IPortableTensor *rhs, bool adj_x,
+                                 bool adj_y, IPortableTensor *output)
 {
   assert(lhs != nullptr);
   assert(rhs != nullptr);

--- a/runtime/onert/backend/cpu/ops/BatchMatMulLayer.h
+++ b/runtime/onert/backend/cpu/ops/BatchMatMulLayer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_OPS_BATCH_MATMUL_LAYER_H__
 #define __ONERT_BACKEND_CPU_OPS_BATCH_MATMUL_LAYER_H__
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 #include "OperationUtils.h"
 
 #include <exec/IFunction.h>
@@ -48,14 +48,15 @@ public:
 public:
   void batchMatMulFloat32();
 
-  void configure(const Tensor *lhs, const Tensor *rhs, bool adj_x, bool adj_y, Tensor *output);
+  void configure(const IPortableTensor *lhs, const IPortableTensor *rhs, bool adj_x, bool adj_y,
+                 IPortableTensor *output);
 
   void run();
 
 private:
-  const Tensor *_lhs;
-  const Tensor *_rhs;
-  Tensor *_output;
+  const IPortableTensor *_lhs;
+  const IPortableTensor *_rhs;
+  IPortableTensor *_output;
 
   bool _adj_x;
   bool _adj_y;

--- a/runtime/onert/backend/cpu/ops/CastLayer.cc
+++ b/runtime/onert/backend/cpu/ops/CastLayer.cc
@@ -30,7 +30,7 @@ CastLayer::CastLayer() : _input(nullptr), _output(nullptr)
   // DO NOTHING
 }
 
-void CastLayer::configure(const Tensor *input, Tensor *output)
+void CastLayer::configure(const IPortableTensor *input, IPortableTensor *output)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/ops/CastLayer.h
+++ b/runtime/onert/backend/cpu/ops/CastLayer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_OPS_CASTLAYER_H__
 #define __ONERT_BACKEND_CPU_OPS_CASTLAYER_H__
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 #include "OperationUtils.h"
 
 #include <exec/IFunction.h>
@@ -40,13 +40,13 @@ public:
   template <typename FromT, typename ToT> void castTensor(const FromT *in, ToT *out);
   template <typename FromT> void castPtr(const FromT *in, DataPtr out);
 
-  void configure(const Tensor *input, Tensor *output);
+  void configure(const IPortableTensor *input, IPortableTensor *output);
 
   void run();
 
 private:
-  const Tensor *_input;
-  Tensor *_output;
+  const IPortableTensor *_input;
+  IPortableTensor *_output;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/CompareLayer.cc
+++ b/runtime/onert/backend/cpu/ops/CompareLayer.cc
@@ -35,7 +35,8 @@ using OpType = onert::ir::operation::Comparison::ComparisonType;
 using namespace onert::backend::cpu;
 
 template <typename T>
-void compareScalar(const Tensor *lhs, const Tensor *rhs, Tensor *output, OpType op_type)
+void compareScalar(const IPortableTensor *lhs, const IPortableTensor *rhs, IPortableTensor *output,
+                   OpType op_type)
 {
   bool requires_broadcast = !HaveSameShapes(lhs, rhs);
 
@@ -138,8 +139,8 @@ CompareLayer::CompareLayer()
 
 void CompareLayer::compareQuant8() { throw std::runtime_error{"Compare NYI for quantized"}; }
 
-void CompareLayer::configure(const Tensor *lhs, const Tensor *rhs, const OpType op_type,
-                             Tensor *output)
+void CompareLayer::configure(const IPortableTensor *lhs, const IPortableTensor *rhs,
+                             const OpType op_type, IPortableTensor *output)
 {
   _lhs = lhs;
   _rhs = rhs;

--- a/runtime/onert/backend/cpu/ops/CompareLayer.h
+++ b/runtime/onert/backend/cpu/ops/CompareLayer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_OPS_COMPARELAYER_H__
 #define __ONERT_BACKEND_CPU_OPS_COMPARELAYER_H__
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 
 #include <exec/IFunction.h>
 #include <ir/operation/Comparison.h>
@@ -39,15 +39,15 @@ public:
 public:
   void compareQuant8();
 
-  void configure(const Tensor *lhs, const Tensor *rhs,
-                 const ir::operation::Comparison::ComparisonType op_type, Tensor *output);
+  void configure(const IPortableTensor *lhs, const IPortableTensor *rhs,
+                 const ir::operation::Comparison::ComparisonType op_type, IPortableTensor *output);
 
   void run();
 
 private:
-  const Tensor *_lhs;
-  const Tensor *_rhs;
-  Tensor *_output;
+  const IPortableTensor *_lhs;
+  const IPortableTensor *_rhs;
+  IPortableTensor *_output;
   ir::operation::Comparison::ComparisonType _op_type;
 };
 

--- a/runtime/onert/backend/cpu/ops/ConcatLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ConcatLayer.cc
@@ -104,7 +104,8 @@ void ConcatLayer::concatenationQuant8()
                                        reinterpret_cast<uint8_t *>(_output->buffer()));
 }
 
-void ConcatLayer::configure(const std::vector<const Tensor *> &inputs, int32_t axis, Tensor *output)
+void ConcatLayer::configure(const std::vector<const IPortableTensor *> &inputs, int32_t axis,
+                            IPortableTensor *output)
 {
   assert(inputs.size() > 0);
   assert(output != nullptr);

--- a/runtime/onert/backend/cpu/ops/ConcatLayer.h
+++ b/runtime/onert/backend/cpu/ops/ConcatLayer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_OPS_CONCATLAYER_H__
 #define __ONERT_BACKEND_CPU_OPS_CONCATLAYER_H__
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 
 #include <exec/IFunction.h>
 
@@ -40,13 +40,14 @@ public:
 
   void concatenationQuant8();
 
-  void configure(const std::vector<const Tensor *> &inputs, int32_t axis, Tensor *output);
+  void configure(const std::vector<const IPortableTensor *> &inputs, int32_t axis,
+                 IPortableTensor *output);
 
   void run();
 
 private:
-  std::vector<const Tensor *> _inputs;
-  Tensor *_output;
+  std::vector<const IPortableTensor *> _inputs;
+  IPortableTensor *_output;
   int32_t _axis;
 };
 

--- a/runtime/onert/backend/cpu/ops/ConvolutionLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ConvolutionLayer.cc
@@ -16,6 +16,7 @@
 
 #include "ConvolutionLayer.h"
 
+#include "../Tensor.h"
 #include "ir/Padding.h"
 #include <cker/operation/Conv.h>
 
@@ -63,8 +64,10 @@ void ConvolutionLayer::convFloat32()
 
     if (is_replaced_weights)
     {
-      // TODO Remove const_cast
-      const_cast<Tensor *>(_kernel)->decrease_ref();
+      auto kernel_tensor = dynamic_cast<const Tensor *>(_kernel);
+      if (kernel_tensor)
+        // TODO Remove const_cast
+        const_cast<Tensor *>(kernel_tensor)->decrease_ref();
     }
     _prepare = true;
   }
@@ -116,12 +119,12 @@ void ConvolutionLayer::convQuant8()
          getTensorShape(_output), reinterpret_cast<uint8_t *>(_output->buffer()));
 }
 
-void ConvolutionLayer::configure(const Tensor *input, const Tensor *kernel, const Tensor *bias,
-                                 const ir::PaddingType paddingType, const uint32_t paddingLeft,
-                                 const uint32_t paddingRight, const uint32_t paddingTop,
-                                 const uint32_t paddingBottom, const uint32_t strideWidth,
-                                 const uint32_t strideHeight, const ir::Activation activation,
-                                 Tensor *output)
+void ConvolutionLayer::configure(const IPortableTensor *input, const IPortableTensor *kernel,
+                                 const IPortableTensor *bias, const ir::PaddingType paddingType,
+                                 const uint32_t paddingLeft, const uint32_t paddingRight,
+                                 const uint32_t paddingTop, const uint32_t paddingBottom,
+                                 const uint32_t strideWidth, const uint32_t strideHeight,
+                                 const ir::Activation activation, IPortableTensor *output)
 {
   _input = input;
   _kernel = kernel;

--- a/runtime/onert/backend/cpu/ops/ConvolutionLayer.h
+++ b/runtime/onert/backend/cpu/ops/ConvolutionLayer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_OPS_CONVOLUTIONLAYER_H__
 #define __ONERT_BACKEND_CPU_OPS_CONVOLUTIONLAYER_H__
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 #include "OperationUtils.h"
 
 #include <exec/IFunction.h>
@@ -52,19 +52,20 @@ public:
 
   void convQuant8();
 
-  void configure(const Tensor *input, const Tensor *kernel, const Tensor *bias,
-                 ir::PaddingType _paddingType, const uint32_t paddingLeft,
-                 const uint32_t paddingRight, const uint32_t paddingTop,
+  void configure(const IPortableTensor *input, const IPortableTensor *kernel,
+                 const IPortableTensor *bias, ir::PaddingType _paddingType,
+                 const uint32_t paddingLeft, const uint32_t paddingRight, const uint32_t paddingTop,
                  const uint32_t paddingBottom, const uint32_t strideWidth,
-                 const uint32_t strideHeight, const ir::Activation activation, Tensor *output);
+                 const uint32_t strideHeight, const ir::Activation activation,
+                 IPortableTensor *output);
 
   void run();
 
 private:
-  const Tensor *_input;
-  const Tensor *_kernel;
-  const Tensor *_bias;
-  Tensor *_output;
+  const IPortableTensor *_input;
+  const IPortableTensor *_kernel;
+  const IPortableTensor *_bias;
+  IPortableTensor *_output;
 
   ir::PaddingType _paddingType;
   uint32_t _paddingLeft;

--- a/runtime/onert/backend/cpu/ops/CosLayer.cc
+++ b/runtime/onert/backend/cpu/ops/CosLayer.cc
@@ -40,7 +40,7 @@ void CosLayer::cosFloat32()
 
 void CosLayer::cosQuant8() { throw std::runtime_error{"NYI"}; }
 
-void CosLayer::configure(const Tensor *input, Tensor *output)
+void CosLayer::configure(const IPortableTensor *input, IPortableTensor *output)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/ops/CosLayer.h
+++ b/runtime/onert/backend/cpu/ops/CosLayer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_OPS_COSLAYER_H__
 #define __ONERT_BACKEND_CPU_OPS_COSLAYER_H__
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 
 #include <exec/IFunction.h>
 
@@ -34,7 +34,7 @@ class CosLayer : public ::onert::exec::IFunction
 public:
   CosLayer();
 
-  void configure(const Tensor *input, Tensor *output);
+  void configure(const IPortableTensor *input, IPortableTensor *output);
 
   void run();
 
@@ -42,8 +42,8 @@ private:
   void cosFloat32();
   void cosQuant8();
 
-  const Tensor *_input;
-  Tensor *_output;
+  const IPortableTensor *_input;
+  IPortableTensor *_output;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/DepthwiseConvolutionLayer.cc
+++ b/runtime/onert/backend/cpu/ops/DepthwiseConvolutionLayer.cc
@@ -94,12 +94,13 @@ void DepthwiseConvolutionLayer::convQuant8()
       getTensorShape(_output), reinterpret_cast<uint8_t *>(_output->buffer()));
 }
 
-void DepthwiseConvolutionLayer::configure(const Tensor *input, const Tensor *kernel,
-                                          const Tensor *bias, const uint32_t paddingLeft,
+void DepthwiseConvolutionLayer::configure(const IPortableTensor *input,
+                                          const IPortableTensor *kernel,
+                                          const IPortableTensor *bias, const uint32_t paddingLeft,
                                           const uint32_t paddingRight, const uint32_t paddingTop,
                                           const uint32_t paddingBottom, const uint32_t strideWidth,
                                           const uint32_t strideHeight, const uint32_t multiplier,
-                                          const ir::Activation activation, Tensor *output)
+                                          const ir::Activation activation, IPortableTensor *output)
 {
   _input = input;
   _kernel = kernel;

--- a/runtime/onert/backend/cpu/ops/DepthwiseConvolutionLayer.h
+++ b/runtime/onert/backend/cpu/ops/DepthwiseConvolutionLayer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_KERNEL_CPU_DEPTHWISECONVOLUTIONLAYER_H__
 #define __ONERT_KERNEL_CPU_DEPTHWISECONVOLUTIONLAYER_H__
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 #include "OperationUtils.h"
 
 #include <exec/IFunction.h>
@@ -41,18 +41,20 @@ public:
 
   void convQuant8();
 
-  void configure(const Tensor *input, const Tensor *kernel, const Tensor *bias,
-                 const uint32_t paddingLeft, const uint32_t paddingRight, const uint32_t paddingTop,
+  void configure(const IPortableTensor *input, const IPortableTensor *kernel,
+                 const IPortableTensor *bias, const uint32_t paddingLeft,
+                 const uint32_t paddingRight, const uint32_t paddingTop,
                  const uint32_t paddingBottom, const uint32_t strideW, const uint32_t strideH,
-                 const uint32_t multiplier, const ir::Activation activation, Tensor *output);
+                 const uint32_t multiplier, const ir::Activation activation,
+                 IPortableTensor *output);
 
   void run();
 
 private:
-  const Tensor *_input;
-  const Tensor *_kernel;
-  const Tensor *_bias;
-  Tensor *_output;
+  const IPortableTensor *_input;
+  const IPortableTensor *_kernel;
+  const IPortableTensor *_bias;
+  IPortableTensor *_output;
 
   uint32_t _paddingLeft;
   uint32_t _paddingTop;

--- a/runtime/onert/backend/cpu/ops/DivLayer.cc
+++ b/runtime/onert/backend/cpu/ops/DivLayer.cc
@@ -64,8 +64,8 @@ void DivLayer::divQuant8()
   throw std::runtime_error{"Div NYI for quantized"};
 }
 
-void DivLayer::configure(const Tensor *lhs, const Tensor *rhs, const ir::Activation activation,
-                         Tensor *output)
+void DivLayer::configure(const IPortableTensor *lhs, const IPortableTensor *rhs,
+                         const ir::Activation activation, IPortableTensor *output)
 {
   _lhs = lhs;
   _rhs = rhs;

--- a/runtime/onert/backend/cpu/ops/DivLayer.h
+++ b/runtime/onert/backend/cpu/ops/DivLayer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_OPS_DIVLAYER_H__
 #define __ONERT_BACKEND_CPU_OPS_DIVLAYER_H__
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 #include "OperationUtils.h"
 
 #include <exec/IFunction.h>
@@ -44,15 +44,15 @@ public:
 
   void divQuant8();
 
-  void configure(const Tensor *lhs, const Tensor *rhs, const ir::Activation activation,
-                 Tensor *output);
+  void configure(const IPortableTensor *lhs, const IPortableTensor *rhs,
+                 const ir::Activation activation, IPortableTensor *output);
 
   void run();
 
 private:
-  const Tensor *_lhs;
-  const Tensor *_rhs;
-  Tensor *_output;
+  const IPortableTensor *_lhs;
+  const IPortableTensor *_rhs;
+  IPortableTensor *_output;
 
   ir::Activation _activation{ir::Activation::NONE};
 };

--- a/runtime/onert/backend/cpu/ops/EinsumLayer.cc
+++ b/runtime/onert/backend/cpu/ops/EinsumLayer.cc
@@ -67,8 +67,8 @@ void EinsumLayer::run()
   }
 }
 
-void EinsumLayer::configure(const std::vector<const Tensor *> &inputs, std::string equation,
-                            Tensor *output)
+void EinsumLayer::configure(const std::vector<const IPortableTensor *> &inputs,
+                            std::string equation, IPortableTensor *output)
 {
   assert(inputs.size() > 0);
   assert(output != nullptr);

--- a/runtime/onert/backend/cpu/ops/EinsumLayer.h
+++ b/runtime/onert/backend/cpu/ops/EinsumLayer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_OPS_EINSUM_LAYER_H__
 #define __ONERT_BACKEND_CPU_OPS_EINSUM_LAYER_H__
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 #include "OperationUtils.h"
 
 #include <exec/IFunction.h>
@@ -50,13 +50,14 @@ public:
 public:
   void einsumFloat32();
 
-  void configure(const std::vector<const Tensor *> &inputs, std::string equation, Tensor *output);
+  void configure(const std::vector<const IPortableTensor *> &inputs, std::string equation,
+                 IPortableTensor *output);
 
   void run();
 
 private:
-  std::vector<const Tensor *> _inputs;
-  Tensor *_output;
+  std::vector<const IPortableTensor *> _inputs;
+  IPortableTensor *_output;
 
   std::string _equation;
 

--- a/runtime/onert/backend/cpu/ops/ExpLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ExpLayer.cc
@@ -46,7 +46,7 @@ void ExpLayer::expQuant8()
   throw std::runtime_error{"NYI"};
 }
 
-void ExpLayer::configure(const Tensor *input, Tensor *output)
+void ExpLayer::configure(const IPortableTensor *input, IPortableTensor *output)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/ops/ExpLayer.h
+++ b/runtime/onert/backend/cpu/ops/ExpLayer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_OPS_EXPLAYER_H__
 #define __ONERT_BACKEND_CPU_OPS_EXPLAYER_H__
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 
 #include <exec/IFunction.h>
 
@@ -40,13 +40,13 @@ public:
 
   void expQuant8();
 
-  void configure(const Tensor *input, Tensor *output);
+  void configure(const IPortableTensor *input, IPortableTensor *output);
 
   void run();
 
 private:
-  const Tensor *_input;
-  Tensor *_output;
+  const IPortableTensor *_input;
+  IPortableTensor *_output;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/ExpandDimsLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ExpandDimsLayer.cc
@@ -30,7 +30,8 @@ ExpandDimsLayer::ExpandDimsLayer() : _input(nullptr), _axis(nullptr), _output(nu
   // DO NOTHING
 }
 
-void ExpandDimsLayer::configure(const Tensor *input, const Tensor *axis, Tensor *output)
+void ExpandDimsLayer::configure(const IPortableTensor *input, const IPortableTensor *axis,
+                                IPortableTensor *output)
 {
   _input = input;
   _axis = axis;

--- a/runtime/onert/backend/cpu/ops/ExpandDimsLayer.h
+++ b/runtime/onert/backend/cpu/ops/ExpandDimsLayer.h
@@ -17,7 +17,7 @@
 #ifndef ExpandDi__ONERT_BACKEND_CPU_OPS_EXPANDDIMS_LAYER_H__ms
 #define ExpandDi__ONERT_BACKEND_CPU_OPS_EXPANDDIMS_LAYER_H__ms
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 
 #include <exec/IFunction.h>
 
@@ -36,14 +36,15 @@ public:
   ExpandDimsLayer();
 
 public:
-  void configure(const Tensor *input, const Tensor *axis, Tensor *output);
+  void configure(const IPortableTensor *input, const IPortableTensor *axis,
+                 IPortableTensor *output);
 
   void run();
 
 private:
-  const Tensor *_input;
-  const Tensor *_axis;
-  Tensor *_output;
+  const IPortableTensor *_input;
+  const IPortableTensor *_axis;
+  IPortableTensor *_output;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/FillLayer.cc
+++ b/runtime/onert/backend/cpu/ops/FillLayer.cc
@@ -34,7 +34,8 @@ FillLayer::FillLayer() : _input(nullptr), _value(nullptr), _output(nullptr)
   // DO NOTHING
 }
 
-void FillLayer::configure(const Tensor *input, const Tensor *value, Tensor *output)
+void FillLayer::configure(const IPortableTensor *input, const IPortableTensor *value,
+                          IPortableTensor *output)
 {
   _input = input;
   _value = value;

--- a/runtime/onert/backend/cpu/ops/FillLayer.h
+++ b/runtime/onert/backend/cpu/ops/FillLayer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_OPS_FILLLAYER_H__
 #define __ONERT_BACKEND_CPU_OPS_FILLLAYER_H__
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 
 #include <exec/IFunction.h>
 
@@ -35,14 +35,15 @@ class FillLayer : public ::onert::exec::IFunction
 public:
   FillLayer();
 
-  void configure(const Tensor *input, const Tensor *value, Tensor *output);
+  void configure(const IPortableTensor *input, const IPortableTensor *value,
+                 IPortableTensor *output);
 
   void run();
 
 private:
-  const Tensor *_input;
-  const Tensor *_value;
-  Tensor *_output;
+  const IPortableTensor *_input;
+  const IPortableTensor *_value;
+  IPortableTensor *_output;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/FullyConnectedLayer.cc
+++ b/runtime/onert/backend/cpu/ops/FullyConnectedLayer.cc
@@ -102,8 +102,9 @@ void FullyConnectedLayer::fullyConnectedHybrid()
       getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()), temp_arena);
 }
 
-void FullyConnectedLayer::configure(const Tensor *input, const Tensor *weights, const Tensor *bias,
-                                    ir::Activation activation, Tensor *output)
+void FullyConnectedLayer::configure(const IPortableTensor *input, const IPortableTensor *weights,
+                                    const IPortableTensor *bias, ir::Activation activation,
+                                    IPortableTensor *output)
 {
   _input = input;
   _weights = weights;

--- a/runtime/onert/backend/cpu/ops/FullyConnectedLayer.h
+++ b/runtime/onert/backend/cpu/ops/FullyConnectedLayer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_OPS_FULLYCONNECTEDLAYER_H__
 #define __ONERT_BACKEND_CPU_OPS_FULLYCONNECTEDLAYER_H__
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 #include "OperationUtils.h"
 
 #include <exec/IFunction.h>
@@ -52,16 +52,16 @@ public:
 
   void fullyConnectedHybrid();
 
-  void configure(const Tensor *input, const Tensor *weights, const Tensor *bias,
-                 ir::Activation activation, Tensor *output);
+  void configure(const IPortableTensor *input, const IPortableTensor *weights,
+                 const IPortableTensor *bias, ir::Activation activation, IPortableTensor *output);
 
   void run();
 
 private:
-  const Tensor *_input;
-  const Tensor *_weights;
-  const Tensor *_bias;
-  Tensor *_output;
+  const IPortableTensor *_input;
+  const IPortableTensor *_weights;
+  const IPortableTensor *_bias;
+  IPortableTensor *_output;
 
   ir::Activation _activation;
   std::unique_ptr<nnfw::cker::FCTempArena> _temp_arena;

--- a/runtime/onert/backend/cpu/ops/GatherLayer.cc
+++ b/runtime/onert/backend/cpu/ops/GatherLayer.cc
@@ -29,8 +29,8 @@ namespace cpu
 namespace ops
 {
 
-void GatherLayer::configure(const Tensor *input, const Tensor *indices, Tensor *output,
-                            int32_t axis)
+void GatherLayer::configure(const IPortableTensor *input, const IPortableTensor *indices,
+                            IPortableTensor *output, int32_t axis)
 {
   _input = input;
   _indices = indices;

--- a/runtime/onert/backend/cpu/ops/GatherLayer.h
+++ b/runtime/onert/backend/cpu/ops/GatherLayer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_OPS_GATHERLAYER_H__
 #define __ONERT_BACKEND_CPU_OPS_GATHERLAYER_H__
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 
 #include <exec/IFunction.h>
 
@@ -39,14 +39,15 @@ public:
   }
 
 public:
-  void configure(const Tensor *input, const Tensor *indices, Tensor *output, int32_t axis);
+  void configure(const IPortableTensor *input, const IPortableTensor *indices,
+                 IPortableTensor *output, int32_t axis);
 
   void run();
 
 private:
-  const Tensor *_input;
-  const Tensor *_indices;
-  Tensor *_output;
+  const IPortableTensor *_input;
+  const IPortableTensor *_indices;
+  IPortableTensor *_output;
 
   int32_t _axis;
 };

--- a/runtime/onert/backend/cpu/ops/LogLayer.cc
+++ b/runtime/onert/backend/cpu/ops/LogLayer.cc
@@ -42,7 +42,7 @@ void LogLayer::logFloat32()
 
 void LogLayer::logQuant8() { throw std::runtime_error{"NYI"}; }
 
-void LogLayer::configure(const Tensor *input, Tensor *output)
+void LogLayer::configure(const IPortableTensor *input, IPortableTensor *output)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/ops/LogLayer.h
+++ b/runtime/onert/backend/cpu/ops/LogLayer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_OPS_LOGLAYER_H__
 #define __ONERT_BACKEND_CPU_OPS_LOGLAYER_H__
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 
 #include <exec/IFunction.h>
 
@@ -40,13 +40,13 @@ public:
 
   void logQuant8();
 
-  void configure(const Tensor *input, Tensor *output);
+  void configure(const IPortableTensor *input, IPortableTensor *output);
 
   void run();
 
 private:
-  const Tensor *_input;
-  Tensor *_output;
+  const IPortableTensor *_input;
+  IPortableTensor *_output;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/LogicalNotLayer.cc
+++ b/runtime/onert/backend/cpu/ops/LogicalNotLayer.cc
@@ -40,7 +40,7 @@ void LogicalNotLayer::logicalNotBool8()
                          getTensorShape(_output), reinterpret_cast<bool *>(_output->buffer()));
 }
 
-void LogicalNotLayer::configure(const Tensor *input, Tensor *output)
+void LogicalNotLayer::configure(const IPortableTensor *input, IPortableTensor *output)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/ops/LogicalNotLayer.h
+++ b/runtime/onert/backend/cpu/ops/LogicalNotLayer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_OPS_LOGICALNOTLAYER_H__
 #define __ONERT_BACKEND_CPU_OPS_LOGICALNOTLAYER_H__
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 
 #include <exec/IFunction.h>
 
@@ -36,7 +36,7 @@ public:
   LogicalNotLayer();
 
 public:
-  void configure(const Tensor *input, Tensor *output);
+  void configure(const IPortableTensor *input, IPortableTensor *output);
 
   void run();
 
@@ -44,8 +44,8 @@ private:
   void logicalNotBool8();
 
 private:
-  const Tensor *_input;
-  Tensor *_output;
+  const IPortableTensor *_input;
+  IPortableTensor *_output;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/LogicalOrLayer.cc
+++ b/runtime/onert/backend/cpu/ops/LogicalOrLayer.cc
@@ -46,7 +46,8 @@ void LogicalOrLayer::lorBool8()
   }
 }
 
-void LogicalOrLayer::configure(const Tensor *lhs, const Tensor *rhs, Tensor *output)
+void LogicalOrLayer::configure(const IPortableTensor *lhs, const IPortableTensor *rhs,
+                               IPortableTensor *output)
 {
   assert(lhs != nullptr);
   assert(rhs != nullptr);

--- a/runtime/onert/backend/cpu/ops/LogicalOrLayer.h
+++ b/runtime/onert/backend/cpu/ops/LogicalOrLayer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_OPS_LOGICAL_OR_LAYER_H__
 #define __ONERT_BACKEND_CPU_OPS_LOGICAL_OR_LAYER_H__
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 
 #include <exec/IFunction.h>
 
@@ -38,7 +38,7 @@ public:
   }
 
 public:
-  void configure(const Tensor *_lhs, const Tensor *_rhs, Tensor *output);
+  void configure(const IPortableTensor *_lhs, const IPortableTensor *_rhs, IPortableTensor *output);
 
   void run();
 
@@ -46,9 +46,9 @@ private:
   void lorBool8();
 
 private:
-  const Tensor *_lhs;
-  const Tensor *_rhs;
-  Tensor *_output;
+  const IPortableTensor *_lhs;
+  const IPortableTensor *_rhs;
+  IPortableTensor *_output;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/LogisticLayer.cc
+++ b/runtime/onert/backend/cpu/ops/LogisticLayer.cc
@@ -46,7 +46,7 @@ void LogisticLayer::logisticQuant8()
   throw std::runtime_error{"NYI"};
 }
 
-void LogisticLayer::configure(const Tensor *input, Tensor *output)
+void LogisticLayer::configure(const IPortableTensor *input, IPortableTensor *output)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/ops/LogisticLayer.h
+++ b/runtime/onert/backend/cpu/ops/LogisticLayer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_OPS_LOGISTICLAYER_H__
 #define __ONERT_BACKEND_CPU_OPS_LOGISTICLAYER_H__
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 
 #include <exec/IFunction.h>
 
@@ -40,13 +40,13 @@ public:
 
   void logisticQuant8();
 
-  void configure(const Tensor *input, Tensor *output);
+  void configure(const IPortableTensor *input, IPortableTensor *output);
 
   void run();
 
 private:
-  const Tensor *_input;
-  Tensor *_output;
+  const IPortableTensor *_input;
+  IPortableTensor *_output;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/MatrixBandPartLayer.cc
+++ b/runtime/onert/backend/cpu/ops/MatrixBandPartLayer.cc
@@ -57,8 +57,9 @@ void MatrixBandPartLayer::matrixBandPartFloat32()
 
 void MatrixBandPartLayer::matrixBandPartQuant8() { throw std::runtime_error{"NYI"}; }
 
-void MatrixBandPartLayer::configure(const Tensor *input, const Tensor *num_lower_diag,
-                                    const Tensor *num_upper_diag, Tensor *output)
+void MatrixBandPartLayer::configure(const IPortableTensor *input,
+                                    const IPortableTensor *num_lower_diag,
+                                    const IPortableTensor *num_upper_diag, IPortableTensor *output)
 {
   _input = input;
   _num_lower_diag = num_lower_diag;

--- a/runtime/onert/backend/cpu/ops/MatrixBandPartLayer.h
+++ b/runtime/onert/backend/cpu/ops/MatrixBandPartLayer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_OPS_MATRIXBANDPARTLAYER_H__
 #define __ONERT_BACKEND_CPU_OPS_MATRIXBANDPARTLAYER_H__
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 
 #include <exec/IFunction.h>
 
@@ -40,8 +40,8 @@ public:
 
   void matrixBandPartQuant8();
 
-  void configure(const Tensor *input, const Tensor *num_lower_diag, const Tensor *num_upper_diag,
-                 Tensor *output);
+  void configure(const IPortableTensor *input, const IPortableTensor *num_lower_diag,
+                 const IPortableTensor *num_upper_diag, IPortableTensor *output);
 
   void run();
   void runSync()
@@ -52,10 +52,10 @@ public:
   }
 
 private:
-  const Tensor *_input;
-  const Tensor *_num_lower_diag;
-  const Tensor *_num_upper_diag;
-  Tensor *_output;
+  const IPortableTensor *_input;
+  const IPortableTensor *_num_lower_diag;
+  const IPortableTensor *_num_upper_diag;
+  IPortableTensor *_output;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/MaxLayer.cc
+++ b/runtime/onert/backend/cpu/ops/MaxLayer.cc
@@ -47,7 +47,8 @@ void MaxLayer::maxQuant8()
   throw std::runtime_error("Max NYI for quantized");
 }
 
-void MaxLayer::configure(const Tensor *lhs, const Tensor *rhs, Tensor *output)
+void MaxLayer::configure(const IPortableTensor *lhs, const IPortableTensor *rhs,
+                         IPortableTensor *output)
 {
   assert(lhs != nullptr);
   assert(rhs != nullptr);

--- a/runtime/onert/backend/cpu/ops/MaxLayer.h
+++ b/runtime/onert/backend/cpu/ops/MaxLayer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_OPS_MAXLAYER_H__
 #define __ONERT_BACKEND_CPU_OPS_MAXLAYER_H__
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 
 #include <exec/IFunction.h>
 
@@ -43,14 +43,14 @@ public:
 
   void maxQuant8();
 
-  void configure(const Tensor *lhs, const Tensor *rhs, Tensor *output);
+  void configure(const IPortableTensor *lhs, const IPortableTensor *rhs, IPortableTensor *output);
 
   void run();
 
 private:
-  const Tensor *_lhs;
-  const Tensor *_rhs;
-  Tensor *_output;
+  const IPortableTensor *_lhs;
+  const IPortableTensor *_rhs;
+  IPortableTensor *_output;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/MaxPoolLayer.cc
+++ b/runtime/onert/backend/cpu/ops/MaxPoolLayer.cc
@@ -71,12 +71,12 @@ void MaxPoolLayer::maxPoolQuant8()
                       reinterpret_cast<uint8_t *>(_output->buffer()));
 }
 
-void MaxPoolLayer::configure(const Tensor *input, const uint32_t paddingLeft,
+void MaxPoolLayer::configure(const IPortableTensor *input, const uint32_t paddingLeft,
                              const uint32_t paddingRight, const uint32_t paddingTop,
                              const uint32_t paddingBottom, const uint32_t strideWidth,
                              const uint32_t strideHeight, const uint32_t kernelWidth,
                              const uint32_t kernelHeight, const ir::Activation activation,
-                             Tensor *output)
+                             IPortableTensor *output)
 {
   _input = input;
   _paddingLeft = paddingLeft;

--- a/runtime/onert/backend/cpu/ops/MaxPoolLayer.h
+++ b/runtime/onert/backend/cpu/ops/MaxPoolLayer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_OPS_MAXPOOLLAYER_H__
 #define __ONERT_BACKEND_CPU_OPS_MAXPOOLLAYER_H__
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 #include "OperationUtils.h"
 
 #include <exec/IFunction.h>
@@ -41,17 +41,18 @@ public:
 
   void maxPoolQuant8();
 
-  void configure(const Tensor *input, const uint32_t paddingLeft, const uint32_t paddingRight,
-                 const uint32_t paddingTop, const uint32_t paddingBottom,
-                 const uint32_t strideWidth, const uint32_t strideHeight,
-                 const uint32_t kernelWidth, const uint32_t kernelHeight,
-                 const ir::Activation activation, Tensor *output);
+  void configure(const IPortableTensor *input, const uint32_t paddingLeft,
+                 const uint32_t paddingRight, const uint32_t paddingTop,
+                 const uint32_t paddingBottom, const uint32_t strideWidth,
+                 const uint32_t strideHeight, const uint32_t kernelWidth,
+                 const uint32_t kernelHeight, const ir::Activation activation,
+                 IPortableTensor *output);
 
   void run();
 
 private:
-  const Tensor *_input;
-  Tensor *_output;
+  const IPortableTensor *_input;
+  IPortableTensor *_output;
 
   uint32_t _paddingLeft;
   uint32_t _paddingTop;

--- a/runtime/onert/backend/cpu/ops/MeanLayer.cc
+++ b/runtime/onert/backend/cpu/ops/MeanLayer.cc
@@ -49,8 +49,8 @@ void MeanLayer::MeanQuant8()
                           _output->data_offset(), _axes);
 }
 
-void MeanLayer::configure(const Tensor *input, Tensor *output, const std::vector<int> &axes,
-                          bool keep_dims)
+void MeanLayer::configure(const IPortableTensor *input, IPortableTensor *output,
+                          const std::vector<int> &axes, bool keep_dims)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/ops/MeanLayer.h
+++ b/runtime/onert/backend/cpu/ops/MeanLayer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_OPS_MEANLAYER_H__
 #define __ONERT_BACKEND_CPU_OPS_MEANLAYER_H__
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 
 #include <exec/IFunction.h>
 
@@ -40,13 +40,14 @@ public:
 
   void MeanQuant8();
 
-  void configure(const Tensor *input, Tensor *output, const std::vector<int> &axes, bool keep_dims);
+  void configure(const IPortableTensor *input, IPortableTensor *output,
+                 const std::vector<int> &axes, bool keep_dims);
 
   void run();
 
 private:
-  const Tensor *_input;
-  Tensor *_output;
+  const IPortableTensor *_input;
+  IPortableTensor *_output;
   std::vector<int> _axes;
   bool _keep_dims;
 };

--- a/runtime/onert/backend/cpu/ops/MinLayer.cc
+++ b/runtime/onert/backend/cpu/ops/MinLayer.cc
@@ -29,7 +29,26 @@ namespace cpu
 namespace ops
 {
 
-void MinLayer::configure(const Tensor *lhs, const Tensor *rhs, Tensor *output)
+void MinLayer::minFloat32()
+{
+  nnfw::cker::Min<float>(getTensorShape(_lhs), reinterpret_cast<const float *>(_lhs->buffer()),
+                         getTensorShape(_rhs), reinterpret_cast<const float *>(_rhs->buffer()),
+                         getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()));
+}
+
+void MinLayer::minQuant8()
+{
+  // TODO Check whether cker for quant8 min produces correct results
+  // nnfw::cker::Min<uint8_t>(
+  //     getTensorShape(_lhs), reinterpret_cast<const uint8_t*>(_lhs->buffer()),
+  //     getTensorShape(_rhs), reinterpret_cast<const uint8_t*>(_rhs->buffer()),
+  //     getTensorShape(_output), reinterpret_cast<uint8_t*>(_output->buffer()));
+
+  throw std::runtime_error("Min NYI for quantized");
+}
+
+void MinLayer::configure(const IPortableTensor *lhs, const IPortableTensor *rhs,
+                         IPortableTensor *output)
 {
   assert(lhs != nullptr);
   assert(rhs != nullptr);

--- a/runtime/onert/backend/cpu/ops/MinLayer.h
+++ b/runtime/onert/backend/cpu/ops/MinLayer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_OPS_MINLAYER_H__
 #define __ONERT_BACKEND_CPU_OPS_MINLAYER_H__
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 
 #include <exec/IFunction.h>
 
@@ -39,14 +39,18 @@ public:
   }
 
 public:
-  void configure(const Tensor *lhs, const Tensor *rhs, Tensor *output);
+  void minFloat32();
+
+  void minQuant8();
+
+  void configure(const IPortableTensor *lhs, const IPortableTensor *rhs, IPortableTensor *output);
 
   void run();
 
 private:
-  const Tensor *_lhs;
-  const Tensor *_rhs;
-  Tensor *_output;
+  const IPortableTensor *_lhs;
+  const IPortableTensor *_rhs;
+  IPortableTensor *_output;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/MulLayer.cc
+++ b/runtime/onert/backend/cpu/ops/MulLayer.cc
@@ -65,8 +65,8 @@ void MulLayer::mulQuant8()
   throw std::runtime_error{"Mull NYI for quantized"};
 }
 
-void MulLayer::configure(const Tensor *lhs, const Tensor *rhs, const ir::Activation activation,
-                         Tensor *output)
+void MulLayer::configure(const IPortableTensor *lhs, const IPortableTensor *rhs,
+                         const ir::Activation activation, IPortableTensor *output)
 {
   _lhs = lhs;
   _rhs = rhs;

--- a/runtime/onert/backend/cpu/ops/MulLayer.h
+++ b/runtime/onert/backend/cpu/ops/MulLayer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_OPS_MULLAYER_H__
 #define __ONERT_BACKEND_CPU_OPS_MULLAYER_H__
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 #include "OperationUtils.h"
 
 #include <exec/IFunction.h>
@@ -44,15 +44,15 @@ public:
 
   void mulQuant8();
 
-  void configure(const Tensor *lhs, const Tensor *rhs, const ir::Activation activation,
-                 Tensor *output);
+  void configure(const IPortableTensor *lhs, const IPortableTensor *rhs,
+                 const ir::Activation activation, IPortableTensor *output);
 
   void run();
 
 private:
-  const Tensor *_lhs;
-  const Tensor *_rhs;
-  Tensor *_output;
+  const IPortableTensor *_lhs;
+  const IPortableTensor *_rhs;
+  IPortableTensor *_output;
 
   ir::Activation _activation{ir::Activation::NONE};
 };

--- a/runtime/onert/backend/cpu/ops/NegLayer.cc
+++ b/runtime/onert/backend/cpu/ops/NegLayer.cc
@@ -42,7 +42,7 @@ void NegLayer::negFloat32()
 
 void NegLayer::negQuant8() { throw std::runtime_error{"NYI"}; }
 
-void NegLayer::configure(const Tensor *input, Tensor *output)
+void NegLayer::configure(const IPortableTensor *input, IPortableTensor *output)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/ops/NegLayer.h
+++ b/runtime/onert/backend/cpu/ops/NegLayer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_OPS_NEGLAYER_H__
 #define __ONERT_BACKEND_CPU_OPS_NEGLAYER_H__
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 
 #include <exec/IFunction.h>
 
@@ -40,13 +40,13 @@ public:
 
   void negQuant8();
 
-  void configure(const Tensor *input, Tensor *output);
+  void configure(const IPortableTensor *input, IPortableTensor *output);
 
   void run();
 
 private:
-  const Tensor *_input;
-  Tensor *_output;
+  const IPortableTensor *_input;
+  IPortableTensor *_output;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/OneHotLayer.cc
+++ b/runtime/onert/backend/cpu/ops/OneHotLayer.cc
@@ -39,8 +39,8 @@ void OneHotLayer::oneHotFloat32()
 
 void OneHotLayer::oneHotQuant8() { throw std::runtime_error{"OneHot NYI for quantized"}; }
 
-void OneHotLayer::configure(const Tensor *indices, Tensor *output, int32_t depth, float on_value,
-                            float off_value, int32_t axis)
+void OneHotLayer::configure(const IPortableTensor *indices, IPortableTensor *output, int32_t depth,
+                            float on_value, float off_value, int32_t axis)
 {
   _indices = indices;
   _output = output;

--- a/runtime/onert/backend/cpu/ops/OneHotLayer.h
+++ b/runtime/onert/backend/cpu/ops/OneHotLayer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_OPS_ONEHOTLAYER_H__
 #define __ONERT_BACKEND_CPU_OPS_ONEHOTLAYER_H__
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 
 #include <exec/IFunction.h>
 
@@ -44,14 +44,14 @@ public:
 
   void oneHotQuant8();
 
-  void configure(const Tensor *indices, Tensor *output, int32_t depth, float on_value,
-                 float off_value, int32_t axis);
+  void configure(const IPortableTensor *indices, IPortableTensor *output, int32_t depth,
+                 float on_value, float off_value, int32_t axis);
 
   void run();
 
 private:
-  const Tensor *_indices;
-  Tensor *_output;
+  const IPortableTensor *_indices;
+  IPortableTensor *_output;
 
   int32_t _depth;
   float _on_value;

--- a/runtime/onert/backend/cpu/ops/OperationUtils.cc
+++ b/runtime/onert/backend/cpu/ops/OperationUtils.cc
@@ -29,13 +29,13 @@ namespace cpu
 namespace ops
 {
 
-uint32_t getNumberOfDimensions(const Tensor *tensor)
+uint32_t getNumberOfDimensions(const IPortableTensor *tensor)
 {
   assert(tensor);
   return tensor->num_dimensions();
 }
 
-uint32_t getNumberOfElements(const Tensor *tensor)
+uint32_t getNumberOfElements(const IPortableTensor *tensor)
 {
   assert(tensor);
   uint32_t count = 1;
@@ -46,7 +46,7 @@ uint32_t getNumberOfElements(const Tensor *tensor)
   return count;
 }
 
-uint32_t getSizeOfDimension(const Tensor *tensor, uint32_t dimensionIdx)
+uint32_t getSizeOfDimension(const IPortableTensor *tensor, uint32_t dimensionIdx)
 {
   assert(tensor);
   if (dimensionIdx >= tensor->num_dimensions())
@@ -78,8 +78,9 @@ void QuantizeMultiplier(double double_multiplier, int32_t *quantized_multiplier,
   *quantized_multiplier = static_cast<int32_t>(q_fixed);
 }
 
-void GetQuantizedConvolutionMultiplier(const Tensor *input, const Tensor *filter,
-                                       const Tensor *bias, const Tensor *output, double *multiplier)
+void GetQuantizedConvolutionMultiplier(const IPortableTensor *input, const IPortableTensor *filter,
+                                       const IPortableTensor *bias, const IPortableTensor *output,
+                                       double *multiplier)
 {
   const double input_product_scale = input->data_scale() * filter->data_scale();
   const double bias_scale = (bias != nullptr) ? bias->data_scale() : input_product_scale;
@@ -110,7 +111,7 @@ void QuantizeMultiplierGreaterThanOne(double double_multiplier, int32_t *quantiz
   *quantized_multiplier = static_cast<int32_t>(q_fixed);
 }
 
-void CalculateActivationRangeUint8(ir::Activation activation, const Tensor *output,
+void CalculateActivationRangeUint8(ir::Activation activation, const IPortableTensor *output,
                                    int32_t *act_min, int32_t *act_max)
 {
   const int32_t qmin = std::numeric_limits<uint8_t>::min();
@@ -151,7 +152,7 @@ void CalculateActivationRangeUint8(ir::Activation activation, const Tensor *outp
   }
 }
 
-bool HaveSameShapes(const Tensor *input1, const Tensor *input2)
+bool HaveSameShapes(const IPortableTensor *input1, const IPortableTensor *input2)
 {
   if (input1 == input2)
     return true;

--- a/runtime/onert/backend/cpu/ops/OperationUtils.h
+++ b/runtime/onert/backend/cpu/ops/OperationUtils.h
@@ -17,7 +17,7 @@
 #ifndef __NNFW_SUPPORT_NNAPI_OPERATION_UTILS_H__
 #define __NNFW_SUPPORT_NNAPI_OPERATION_UTILS_H__
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 
 #include <cker/Shape.h>
 #include <cker/Types.h>
@@ -52,13 +52,13 @@ union DataPtr {
   void *v;
 };
 
-uint32_t getNumberOfDimensions(const Tensor *tensor);
+uint32_t getNumberOfDimensions(const IPortableTensor *tensor);
 
-uint32_t getNumberOfElements(const Tensor *tensor);
+uint32_t getNumberOfElements(const IPortableTensor *tensor);
 
-uint32_t getSizeOfDimension(const Tensor *tensor, uint32_t dimensionIdx);
+uint32_t getSizeOfDimension(const IPortableTensor *tensor, uint32_t dimensionIdx);
 
-inline nnfw::cker::Shape getExtendedTensorShape(const Tensor *tensor)
+inline nnfw::cker::Shape getExtendedTensorShape(const IPortableTensor *tensor)
 {
   assert(tensor);
   const int32_t extended_rank = 4;
@@ -79,7 +79,7 @@ inline nnfw::cker::Shape getExtendedTensorShape(const Tensor *tensor)
   return nnfw::cker::Shape(extended_rank, raw_shape);
 }
 
-inline nnfw::cker::Shape getTensorShape(const Tensor *tensor)
+inline nnfw::cker::Shape getTensorShape(const IPortableTensor *tensor)
 {
   if (tensor == nullptr)
     return nnfw::cker::Shape();
@@ -146,9 +146,10 @@ inline int32_t getAxis(uint32_t rank, int32_t axis, ir::Layout frontend_layout)
 
 void QuantizeMultiplier(double double_multiplier, int32_t *quantized_multiplier, int *shift);
 
-void GetQuantizedConvolutionMultiplier(const Tensor *inputDescr, const Tensor *filterDescr,
-                                       const Tensor *biasDescr, const Tensor *outputDescr,
-                                       double *multiplier);
+void GetQuantizedConvolutionMultiplier(const IPortableTensor *inputDescr,
+                                       const IPortableTensor *filterDescr,
+                                       const IPortableTensor *biasDescr,
+                                       const IPortableTensor *outputDescr, double *multiplier);
 
 void QuantizeMultiplierGreaterThanOne(double double_multiplier, int32_t *quantized_multiplier,
                                       int *left_shift);
@@ -187,10 +188,10 @@ void CalculateActivationRange(ir::Activation activation, T *activation_min, T *a
   }
 }
 
-void CalculateActivationRangeUint8(ir::Activation activation, const Tensor *output,
+void CalculateActivationRangeUint8(ir::Activation activation, const IPortableTensor *output,
                                    int32_t *act_min, int32_t *act_max);
 
-bool HaveSameShapes(const Tensor *input1, const Tensor *input2);
+bool HaveSameShapes(const IPortableTensor *input1, const IPortableTensor *input2);
 
 int32_t CalculateInputRadius(int input_integer_bits, int input_left_shift);
 

--- a/runtime/onert/backend/cpu/ops/PackLayer.cc
+++ b/runtime/onert/backend/cpu/ops/PackLayer.cc
@@ -63,7 +63,8 @@ template <typename T> void PackLayer::packImpl()
                       reinterpret_cast<T *>(_output->buffer()));
 }
 
-void PackLayer::configure(const std::vector<const Tensor *> &inputs, int32_t axis, Tensor *output)
+void PackLayer::configure(const std::vector<const IPortableTensor *> &inputs, int32_t axis,
+                          IPortableTensor *output)
 {
   assert(inputs.size() > 0);
   assert(output != nullptr);

--- a/runtime/onert/backend/cpu/ops/PackLayer.h
+++ b/runtime/onert/backend/cpu/ops/PackLayer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_OPS_PACKLAYER_H__
 #define __ONERT_BACKEND_CPU_OPS_PACKLAYER_H__
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 
 #include <exec/IFunction.h>
 
@@ -38,12 +38,13 @@ public:
 public:
   template <typename T> void packImpl();
 
-  void configure(const std::vector<const Tensor *> &inputs, int32_t axis, Tensor *output);
+  void configure(const std::vector<const IPortableTensor *> &inputs, int32_t axis,
+                 IPortableTensor *output);
   void run();
 
 private:
-  std::vector<const Tensor *> _inputs;
-  Tensor *_output;
+  std::vector<const IPortableTensor *> _inputs;
+  IPortableTensor *_output;
   int32_t _axis;
 };
 

--- a/runtime/onert/backend/cpu/ops/PadLayer.cc
+++ b/runtime/onert/backend/cpu/ops/PadLayer.cc
@@ -41,8 +41,8 @@ void PadLayer::padFloat32()
 }
 void PadLayer::padQuant8() { throw std::runtime_error("Quantized Pad isn't supported NYI"); }
 
-void PadLayer::configure(const Tensor *input, Tensor *output, const int32_t *padData,
-                         int32_t padRank, uint8_t *constantValueData)
+void PadLayer::configure(const IPortableTensor *input, IPortableTensor *output,
+                         const int32_t *padData, int32_t padRank, uint8_t *constantValueData)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/ops/PadLayer.h
+++ b/runtime/onert/backend/cpu/ops/PadLayer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_OPS_PADLAYER_H__
 #define __ONERT_BACKEND_CPU_OPS_PADLAYER_H__
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 #include "OperationUtils.h"
 
 #include <exec/IFunction.h>
@@ -43,14 +43,14 @@ public:
 
   void padQuant8();
 
-  void configure(const Tensor *input, Tensor *output, const int32_t *padData, int32_t padRank,
-                 uint8_t *constantValueData = nullptr);
+  void configure(const IPortableTensor *input, IPortableTensor *output, const int32_t *padData,
+                 int32_t padRank, uint8_t *constantValueData = nullptr);
 
   void run();
 
 private:
-  const Tensor *_input;
-  Tensor *_output;
+  const IPortableTensor *_input;
+  IPortableTensor *_output;
 
   int32_t _padData[8];
   int32_t _padRank;

--- a/runtime/onert/backend/cpu/ops/PowLayer.cc
+++ b/runtime/onert/backend/cpu/ops/PowLayer.cc
@@ -50,8 +50,8 @@ void PowLayer::powFloat32()
                       getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()));
 }
 
-void PowLayer::configure(const Tensor *lhs, const Tensor *rhs, ir::Activation activation,
-                         Tensor *output)
+void PowLayer::configure(const IPortableTensor *lhs, const IPortableTensor *rhs,
+                         ir::Activation activation, IPortableTensor *output)
 {
   _lhs = lhs;
   _rhs = rhs;

--- a/runtime/onert/backend/cpu/ops/PowLayer.h
+++ b/runtime/onert/backend/cpu/ops/PowLayer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_OPS_POWLAYER_H__
 #define __ONERT_BACKEND_CPU_OPS_POWLAYER_H__
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 #include "OperationUtils.h"
 
 #include <exec/IFunction.h>
@@ -42,15 +42,15 @@ public:
 public:
   void powFloat32();
 
-  void configure(const Tensor *lhs, const Tensor *rhs, const ir::Activation activation,
-                 Tensor *output);
+  void configure(const IPortableTensor *lhs, const IPortableTensor *rhs,
+                 const ir::Activation activation, IPortableTensor *output);
 
   void run();
 
 private:
-  const Tensor *_lhs;
-  const Tensor *_rhs;
-  Tensor *_output;
+  const IPortableTensor *_lhs;
+  const IPortableTensor *_rhs;
+  IPortableTensor *_output;
 
   ir::Activation _activation{ir::Activation::NONE};
 };

--- a/runtime/onert/backend/cpu/ops/RangeLayer.cc
+++ b/runtime/onert/backend/cpu/ops/RangeLayer.cc
@@ -33,8 +33,8 @@ RangeLayer::RangeLayer() : _start(nullptr), _limit(nullptr), _delta(nullptr), _o
   // DO NOTHING
 }
 
-void RangeLayer::configure(const Tensor *start, const Tensor *limit, const Tensor *delta,
-                           Tensor *output)
+void RangeLayer::configure(const IPortableTensor *start, const IPortableTensor *limit,
+                           const IPortableTensor *delta, IPortableTensor *output)
 {
   _start = start;
   _limit = limit;

--- a/runtime/onert/backend/cpu/ops/RangeLayer.h
+++ b/runtime/onert/backend/cpu/ops/RangeLayer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_OPS_RANGELAYER_H__
 #define __ONERT_BACKEND_CPU_OPS_RANGELAYER_H__
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 
 #include <exec/IFunction.h>
 
@@ -34,15 +34,16 @@ class RangeLayer : public ::onert::exec::IFunction
 public:
   RangeLayer();
 
-  void configure(const Tensor *start, const Tensor *limit, const Tensor *delta, Tensor *output);
+  void configure(const IPortableTensor *start, const IPortableTensor *limit,
+                 const IPortableTensor *delta, IPortableTensor *output);
 
   void run();
 
 private:
-  const Tensor *_start;
-  const Tensor *_limit;
-  const Tensor *_delta;
-  Tensor *_output;
+  const IPortableTensor *_start;
+  const IPortableTensor *_limit;
+  const IPortableTensor *_delta;
+  IPortableTensor *_output;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/ReLULayer.cc
+++ b/runtime/onert/backend/cpu/ops/ReLULayer.cc
@@ -46,7 +46,7 @@ void ReLULayer::reluQuant8()
   throw std::runtime_error{"NYI"};
 }
 
-void ReLULayer::configure(const Tensor *input, Tensor *output)
+void ReLULayer::configure(const IPortableTensor *input, IPortableTensor *output)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/ops/ReLULayer.h
+++ b/runtime/onert/backend/cpu/ops/ReLULayer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_OPS_RELULAYER_H__
 #define __ONERT_BACKEND_CPU_OPS_RELULAYER_H__
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 
 #include <exec/IFunction.h>
 
@@ -40,13 +40,13 @@ public:
 
   void reluQuant8();
 
-  void configure(const Tensor *input, Tensor *output);
+  void configure(const IPortableTensor *input, IPortableTensor *output);
 
   void run();
 
 private:
-  const Tensor *_input;
-  Tensor *_output;
+  const IPortableTensor *_input;
+  IPortableTensor *_output;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/ReduceLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ReduceLayer.cc
@@ -33,8 +33,8 @@ namespace
 {
 
 template <typename T>
-void evalLogic(const Tensor *input, Tensor *output, const std::vector<int> &axes, bool keep_dims,
-               T init_value, nnfw::cker::Reduce &reduce_kernel,
+void evalLogic(const IPortableTensor *input, IPortableTensor *output, const std::vector<int> &axes,
+               bool keep_dims, T init_value, nnfw::cker::Reduce &reduce_kernel,
                T reducer(const T current, const T in))
 {
   reduce_kernel.prepare(input->num_dimensions(), axes.size());
@@ -49,8 +49,8 @@ void evalLogic(const Tensor *input, Tensor *output, const std::vector<int> &axes
 }
 
 template <typename T>
-void evalType(const Tensor *input, Tensor *output, const std::vector<int> &axes, bool keep_dims,
-              nnfw::cker::Reduce &reduce_kernel, ReduceType reduce_type)
+void evalType(const IPortableTensor *input, IPortableTensor *output, const std::vector<int> &axes,
+              bool keep_dims, nnfw::cker::Reduce &reduce_kernel, ReduceType reduce_type)
 {
   switch (reduce_type)
   {
@@ -79,8 +79,9 @@ void evalType(const Tensor *input, Tensor *output, const std::vector<int> &axes,
 
 // Template specialization for bool type
 template <>
-void evalType<bool>(const Tensor *input, Tensor *output, const std::vector<int> &axes,
-                    bool keep_dims, nnfw::cker::Reduce &reduce_kernel, ReduceType reduce_type)
+void evalType<bool>(const IPortableTensor *input, IPortableTensor *output,
+                    const std::vector<int> &axes, bool keep_dims, nnfw::cker::Reduce &reduce_kernel,
+                    ReduceType reduce_type)
 {
   switch (reduce_type)
   {
@@ -100,8 +101,8 @@ void evalType<bool>(const Tensor *input, Tensor *output, const std::vector<int> 
 }
 
 template <ReduceType reduce_type>
-void evalGeneric(const Tensor *input, Tensor *output, const std::vector<int> &axes, bool keep_dims,
-                 nnfw::cker::Reduce &reduce_kernel)
+void evalGeneric(const IPortableTensor *input, IPortableTensor *output,
+                 const std::vector<int> &axes, bool keep_dims, nnfw::cker::Reduce &reduce_kernel)
 {
   switch (input->data_type())
   {
@@ -126,8 +127,8 @@ ReduceLayer::ReduceLayer()
 
 ReduceLayer::~ReduceLayer() = default;
 
-void ReduceLayer::configure(const Tensor *input, Tensor *output, ReduceType reduceType,
-                            const std::vector<int> &axes, bool keep_dims)
+void ReduceLayer::configure(const IPortableTensor *input, IPortableTensor *output,
+                            ReduceType reduceType, const std::vector<int> &axes, bool keep_dims)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/ops/ReduceLayer.h
+++ b/runtime/onert/backend/cpu/ops/ReduceLayer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_OPS_REDUCESUMLAYER_H__
 #define __ONERT_BACKEND_CPU_OPS_REDUCESUMLAYER_H__
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 
 #include <exec/IFunction.h>
 #include <memory>
@@ -56,14 +56,14 @@ public:
   ~ReduceLayer();
 
 public:
-  void configure(const Tensor *input, Tensor *output, ReduceType reduceType,
+  void configure(const IPortableTensor *input, IPortableTensor *output, ReduceType reduceType,
                  const std::vector<int> &axes, bool keep_dims);
 
   void run();
 
 private:
-  const Tensor *_input;
-  Tensor *_output;
+  const IPortableTensor *_input;
+  IPortableTensor *_output;
   ReduceType _reduceType;
   std::vector<int> _axes;
   bool _keep_dims;

--- a/runtime/onert/backend/cpu/ops/ReshapeLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ReshapeLayer.cc
@@ -36,7 +36,8 @@ void ReshapeLayer::reshapeGeneric()
   memcpy(_output->buffer(), _input->buffer(), count);
 }
 
-void ReshapeLayer::configure(const Tensor *input, const Tensor *shape, Tensor *output)
+void ReshapeLayer::configure(const IPortableTensor *input, const IPortableTensor *shape,
+                             IPortableTensor *output)
 {
   _input = input;
   /* note : shape is optional. If not provided from model, _shape is nullptr. */

--- a/runtime/onert/backend/cpu/ops/ReshapeLayer.h
+++ b/runtime/onert/backend/cpu/ops/ReshapeLayer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_OPS_RESHAPELAYER_H__
 #define __ONERT_BACKEND_CPU_OPS_RESHAPELAYER_H__
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 
 #include <exec/IFunction.h>
 
@@ -38,14 +38,15 @@ public:
 public:
   void reshapeGeneric();
 
-  void configure(const Tensor *input, const Tensor *shape, Tensor *output);
+  void configure(const IPortableTensor *input, const IPortableTensor *shape,
+                 IPortableTensor *output);
 
   void run();
 
 private:
-  const Tensor *_input;
-  const Tensor *_shape;
-  Tensor *_output;
+  const IPortableTensor *_input;
+  const IPortableTensor *_shape;
+  IPortableTensor *_output;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/ReverseLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ReverseLayer.cc
@@ -54,7 +54,8 @@ void ReverseLayer::run()
   }
 }
 
-void ReverseLayer::configure(const Tensor *input, const Tensor *axis, Tensor *output)
+void ReverseLayer::configure(const IPortableTensor *input, const IPortableTensor *axis,
+                             IPortableTensor *output)
 {
   _input = input;
   _axis = axis;

--- a/runtime/onert/backend/cpu/ops/ReverseLayer.h
+++ b/runtime/onert/backend/cpu/ops/ReverseLayer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_OPS_REVERSE_LAYER_H__
 #define __ONERT_BACKEND_CPU_OPS_REVERSE_LAYER_H__
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 
 #include <exec/IFunction.h>
 
@@ -39,14 +39,15 @@ public:
   }
 
 public:
-  void configure(const Tensor *input, const Tensor *axis, Tensor *output);
+  void configure(const IPortableTensor *input, const IPortableTensor *axis,
+                 IPortableTensor *output);
 
   void run();
 
 private:
-  const Tensor *_input;
-  const Tensor *_axis;
-  Tensor *_output;
+  const IPortableTensor *_input;
+  const IPortableTensor *_axis;
+  IPortableTensor *_output;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/RoundLayer.cc
+++ b/runtime/onert/backend/cpu/ops/RoundLayer.cc
@@ -39,7 +39,7 @@ void RoundLayer::roundFloat32()
                     getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()));
 }
 
-void RoundLayer::configure(const Tensor *input, Tensor *output)
+void RoundLayer::configure(const IPortableTensor *input, IPortableTensor *output)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/ops/RoundLayer.h
+++ b/runtime/onert/backend/cpu/ops/RoundLayer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_OPS_ROUNDLAYER_H__
 #define __ONERT_BACKEND_CPU_OPS_ROUNDLAYER_H__
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 
 #include <exec/IFunction.h>
 
@@ -34,7 +34,7 @@ class RoundLayer : public ::onert::exec::IFunction
 public:
   RoundLayer();
 
-  void configure(const Tensor *input, Tensor *output);
+  void configure(const IPortableTensor *input, IPortableTensor *output);
 
   void run();
 
@@ -42,8 +42,8 @@ private:
   void roundFloat32();
 
 private:
-  const Tensor *_input;
-  Tensor *_output;
+  const IPortableTensor *_input;
+  IPortableTensor *_output;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/RsqrtLayer.cc
+++ b/runtime/onert/backend/cpu/ops/RsqrtLayer.cc
@@ -41,7 +41,7 @@ void RsqrtLayer::rsqrtFloat32()
 
 void RsqrtLayer::rsqrtQuant8() { throw std::runtime_error{"NYI : QASYMM8 not supported"}; }
 
-void RsqrtLayer::configure(const Tensor *input, Tensor *output)
+void RsqrtLayer::configure(const IPortableTensor *input, IPortableTensor *output)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/ops/RsqrtLayer.h
+++ b/runtime/onert/backend/cpu/ops/RsqrtLayer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_OPS_RSQRTLAYER_H__
 #define __ONERT_BACKEND_CPU_OPS_RSQRTLAYER_H__
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 
 #include <exec/IFunction.h>
 
@@ -34,15 +34,15 @@ class RsqrtLayer : public ::onert::exec::IFunction
 public:
   RsqrtLayer();
 
-  void configure(const Tensor *input, Tensor *output);
+  void configure(const IPortableTensor *input, IPortableTensor *output);
 
   void run();
 
 private:
   void rsqrtFloat32();
   void rsqrtQuant8();
-  const Tensor *_input;
-  Tensor *_output;
+  const IPortableTensor *_input;
+  IPortableTensor *_output;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/SelectLayer.cc
+++ b/runtime/onert/backend/cpu/ops/SelectLayer.cc
@@ -35,8 +35,8 @@ SelectLayer::SelectLayer()
   // DO NOTHING
 }
 
-void SelectLayer::configure(const Tensor *cond, const Tensor *input_true, const Tensor *input_false,
-                            Tensor *output)
+void SelectLayer::configure(const IPortableTensor *cond, const IPortableTensor *input_true,
+                            const IPortableTensor *input_false, IPortableTensor *output)
 {
   _cond = cond;
   _input_true = input_true;

--- a/runtime/onert/backend/cpu/ops/SelectLayer.h
+++ b/runtime/onert/backend/cpu/ops/SelectLayer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_OPS_SELECT_LAYER_H__
 #define __ONERT_BACKEND_CPU_OPS_SELECT_LAYER_H__
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 
 #include <exec/IFunction.h>
 
@@ -36,16 +36,16 @@ public:
   SelectLayer();
 
 public:
-  void configure(const Tensor *cond, const Tensor *input_true, const Tensor *input_false,
-                 Tensor *output);
+  void configure(const IPortableTensor *cond, const IPortableTensor *input_true,
+                 const IPortableTensor *input_false, IPortableTensor *output);
 
   void run();
 
 private:
-  const Tensor *_cond;
-  const Tensor *_input_true;
-  const Tensor *_input_false;
-  Tensor *_output;
+  const IPortableTensor *_cond;
+  const IPortableTensor *_input_true;
+  const IPortableTensor *_input_false;
+  IPortableTensor *_output;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/ShapeLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ShapeLayer.cc
@@ -32,7 +32,7 @@ ShapeLayer::ShapeLayer() : _input(nullptr), _output(nullptr)
   // DO NOTHING
 }
 
-template <typename T> void GetRawShape(const Tensor *input, T *output_data)
+template <typename T> void GetRawShape(const IPortableTensor *input, T *output_data)
 {
   for (uint32_t i = 0; i < input->num_dimensions(); ++i)
   {
@@ -56,7 +56,7 @@ void ShapeLayer::shape()
   }
 }
 
-void ShapeLayer::configure(const Tensor *input, Tensor *output)
+void ShapeLayer::configure(const IPortableTensor *input, IPortableTensor *output)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/ops/ShapeLayer.h
+++ b/runtime/onert/backend/cpu/ops/ShapeLayer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_OPS_SHAPELAYER_H__
 #define __ONERT_BACKEND_CPU_OPS_SHAPELAYER_H__
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 
 #include <exec/IFunction.h>
 
@@ -38,13 +38,13 @@ public:
 public:
   void shape();
 
-  void configure(const Tensor *input, Tensor *output);
+  void configure(const IPortableTensor *input, IPortableTensor *output);
 
   void run();
 
 private:
-  const Tensor *_input;
-  Tensor *_output;
+  const IPortableTensor *_input;
+  IPortableTensor *_output;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/SinLayer.cc
+++ b/runtime/onert/backend/cpu/ops/SinLayer.cc
@@ -40,7 +40,7 @@ void SinLayer::sinFloat32()
 
 void SinLayer::sinQuant8() { throw std::runtime_error{"NYI"}; }
 
-void SinLayer::configure(const Tensor *input, Tensor *output)
+void SinLayer::configure(const IPortableTensor *input, IPortableTensor *output)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/ops/SinLayer.h
+++ b/runtime/onert/backend/cpu/ops/SinLayer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_OPS_SINLAYER_H__
 #define __ONERT_BACKEND_CPU_OPS_SINLAYER_H__
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 
 #include <exec/IFunction.h>
 
@@ -34,7 +34,7 @@ class SinLayer : public ::onert::exec::IFunction
 public:
   SinLayer();
 
-  void configure(const Tensor *input, Tensor *output);
+  void configure(const IPortableTensor *input, IPortableTensor *output);
 
   void run();
 
@@ -42,8 +42,8 @@ private:
   void sinFloat32();
   void sinQuant8();
 
-  const Tensor *_input;
-  Tensor *_output;
+  const IPortableTensor *_input;
+  IPortableTensor *_output;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/SliceLayer.cc
+++ b/runtime/onert/backend/cpu/ops/SliceLayer.cc
@@ -35,8 +35,9 @@ SliceLayer::SliceLayer() : _input(nullptr), _begin(nullptr), _size(nullptr), _ou
 }
 
 template <typename T>
-void SliceLayer::GetBeginAndSizeVectors(int dimensions, const Tensor *begin, const Tensor *size,
-                                        std::vector<int> *begins, std::vector<int> *sizes)
+void SliceLayer::GetBeginAndSizeVectors(int dimensions, const IPortableTensor *begin,
+                                        const IPortableTensor *size, std::vector<int> *begins,
+                                        std::vector<int> *sizes)
 {
   for (int idx = dimensions - 1; idx >= 0; --idx)
   {
@@ -83,8 +84,8 @@ void SliceLayer::sliceQuant8()
   throw std::runtime_error{"NYI"};
 }
 
-void SliceLayer::configure(const Tensor *input, const Tensor *begin, const Tensor *size,
-                           Tensor *output)
+void SliceLayer::configure(const IPortableTensor *input, const IPortableTensor *begin,
+                           const IPortableTensor *size, IPortableTensor *output)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/ops/SliceLayer.h
+++ b/runtime/onert/backend/cpu/ops/SliceLayer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_OPS_SLICELAYER_H__
 #define __ONERT_BACKEND_CPU_OPS_SLICELAYER_H__
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 
 #include <exec/IFunction.h>
 
@@ -36,7 +36,8 @@ public:
   SliceLayer();
 
 public:
-  void configure(const Tensor *input, const Tensor *begin, const Tensor *size, Tensor *output);
+  void configure(const IPortableTensor *input, const IPortableTensor *begin,
+                 const IPortableTensor *size, IPortableTensor *output);
 
   void run();
 
@@ -45,14 +46,15 @@ private:
   void sliceQuant8();
 
   template <typename T>
-  void GetBeginAndSizeVectors(int dimensions, const Tensor *begin, const Tensor *size,
-                              std::vector<int> *begins, std::vector<int> *sizes);
+  void GetBeginAndSizeVectors(int dimensions, const IPortableTensor *begin,
+                              const IPortableTensor *size, std::vector<int> *begins,
+                              std::vector<int> *sizes);
 
 private:
-  const Tensor *_input;
-  const Tensor *_begin;
-  const Tensor *_size;
-  Tensor *_output;
+  const IPortableTensor *_input;
+  const IPortableTensor *_begin;
+  const IPortableTensor *_size;
+  IPortableTensor *_output;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/SoftMaxLayer.cc
+++ b/runtime/onert/backend/cpu/ops/SoftMaxLayer.cc
@@ -146,7 +146,8 @@ void SoftMaxLayer::softmaxQuant8()
                       descrIn4D, reinterpret_cast<uint8_t *>(_output->buffer()));
 }
 
-void SoftMaxLayer::configure(const Tensor *input, const float beta, Tensor *output)
+void SoftMaxLayer::configure(const IPortableTensor *input, const float beta,
+                             IPortableTensor *output)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/ops/SoftMaxLayer.h
+++ b/runtime/onert/backend/cpu/ops/SoftMaxLayer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_OPS_SOFTMAXLAYER_H__
 #define __ONERT_BACKEND_CPU_OPS_SOFTMAXLAYER_H__
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 
 #include <exec/IFunction.h>
 
@@ -40,13 +40,13 @@ public:
 
   void softmaxQuant8();
 
-  void configure(const Tensor *input, const float beta, Tensor *output);
+  void configure(const IPortableTensor *input, const float beta, IPortableTensor *output);
 
   void run();
 
 private:
-  const Tensor *_input;
-  Tensor *_output;
+  const IPortableTensor *_input;
+  IPortableTensor *_output;
 
   float _beta;
 };

--- a/runtime/onert/backend/cpu/ops/SplitLayer.cc
+++ b/runtime/onert/backend/cpu/ops/SplitLayer.cc
@@ -65,8 +65,8 @@ void SplitLayer::splitFloat32()
 
 void SplitLayer::splitQuant8() { throw std::runtime_error{"Split: NYI quant8 type"}; }
 
-void SplitLayer::configure(const Tensor *input, uint16_t num_splits, int16_t axis,
-                           std::vector<Tensor *> &outputs)
+void SplitLayer::configure(const IPortableTensor *input, uint16_t num_splits, int16_t axis,
+                           std::vector<IPortableTensor *> &outputs)
 {
   assert(input != nullptr);
 

--- a/runtime/onert/backend/cpu/ops/SplitLayer.h
+++ b/runtime/onert/backend/cpu/ops/SplitLayer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_OPS_SPLITLAYER_H__
 #define __ONERT_BACKEND_CPU_OPS_SPLITLAYER_H__
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 
 #include <exec/IFunction.h>
 
@@ -40,16 +40,16 @@ public:
 
   void splitQuant8();
 
-  void configure(const Tensor *input, uint16_t num_splits, int16_t axis,
-                 std::vector<Tensor *> &outputs);
+  void configure(const IPortableTensor *input, uint16_t num_splits, int16_t axis,
+                 std::vector<IPortableTensor *> &outputs);
 
   void run();
 
 private:
-  const Tensor *_input;
+  const IPortableTensor *_input;
   uint16_t _num_splits;
   int16_t _axis;
-  std::vector<Tensor *> _outputs;
+  std::vector<IPortableTensor *> _outputs;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/SquaredDiffLayer.cc
+++ b/runtime/onert/backend/cpu/ops/SquaredDiffLayer.cc
@@ -41,7 +41,8 @@ void SqDiffLayer::SqDiffFloat32()
                      getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()));
 }
 
-void SqDiffLayer::configure(const Tensor *input1, const Tensor *input2, Tensor *output)
+void SqDiffLayer::configure(const IPortableTensor *input1, const IPortableTensor *input2,
+                            IPortableTensor *output)
 {
   _input1 = input1;
   _input2 = input2;

--- a/runtime/onert/backend/cpu/ops/SquaredDiffLayer.h
+++ b/runtime/onert/backend/cpu/ops/SquaredDiffLayer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_OPS_SQDIFFLAYER_H__
 #define __ONERT_BACKEND_CPU_OPS_SQDIFFLAYER_H__
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 
 #include <exec/IFunction.h>
 
@@ -38,14 +38,15 @@ public:
 public:
   void SqDiffFloat32();
 
-  void configure(const Tensor *input1, const Tensor *input2, Tensor *output);
+  void configure(const IPortableTensor *input1, const IPortableTensor *input2,
+                 IPortableTensor *output);
 
   void run();
 
 private:
-  const Tensor *_input1;
-  const Tensor *_input2;
-  Tensor *_output;
+  const IPortableTensor *_input1;
+  const IPortableTensor *_input2;
+  IPortableTensor *_output;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/StridedSliceLayer.cc
+++ b/runtime/onert/backend/cpu/ops/StridedSliceLayer.cc
@@ -50,8 +50,9 @@ template <typename T> void StridedSliceLayer::stridedSliceImpl()
                            reinterpret_cast<T *>(_output->buffer()));
 }
 
-void StridedSliceLayer::configure(const Tensor *input, const Tensor *begin, const Tensor *end,
-                                  const Tensor *strides, Tensor *output, const int32_t begin_mask,
+void StridedSliceLayer::configure(const IPortableTensor *input, const IPortableTensor *begin,
+                                  const IPortableTensor *end, const IPortableTensor *strides,
+                                  IPortableTensor *output, const int32_t begin_mask,
                                   const int32_t end_mask, const int32_t shrink_axis_mask)
 {
   _input = input;

--- a/runtime/onert/backend/cpu/ops/StridedSliceLayer.h
+++ b/runtime/onert/backend/cpu/ops/StridedSliceLayer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_OPS_STRIDEDSLICELAYER_H__
 #define __ONERT_BACKEND_CPU_OPS_STRIDEDSLICELAYER_H__
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 #include "OperationUtils.h"
 
 #include <exec/IFunction.h>
@@ -37,8 +37,9 @@ public:
   StridedSliceLayer();
 
 public:
-  void configure(const Tensor *input, const Tensor *begin, const Tensor *end, const Tensor *strides,
-                 Tensor *output, const int32_t begin_mask, const int32_t end_mask,
+  void configure(const IPortableTensor *input, const IPortableTensor *begin,
+                 const IPortableTensor *end, const IPortableTensor *strides,
+                 IPortableTensor *output, const int32_t begin_mask, const int32_t end_mask,
                  const int32_t shrink_axis_mask);
   void run();
 
@@ -46,11 +47,11 @@ private:
   template <typename T> void stridedSliceImpl();
 
 private:
-  const Tensor *_input;
-  const Tensor *_begin;
-  const Tensor *_end;
-  const Tensor *_strides;
-  Tensor *_output;
+  const IPortableTensor *_input;
+  const IPortableTensor *_begin;
+  const IPortableTensor *_end;
+  const IPortableTensor *_strides;
+  IPortableTensor *_output;
 
   int32_t _begin_mask;
   int32_t _ellipsis_mask;

--- a/runtime/onert/backend/cpu/ops/SubLayer.cc
+++ b/runtime/onert/backend/cpu/ops/SubLayer.cc
@@ -65,8 +65,8 @@ void SubLayer::subQuant8()
   throw std::runtime_error{"NYI"};
 }
 
-void SubLayer::configure(const Tensor *lhs, const Tensor *rhs, const ir::Activation activation,
-                         Tensor *output)
+void SubLayer::configure(const IPortableTensor *lhs, const IPortableTensor *rhs,
+                         const ir::Activation activation, IPortableTensor *output)
 {
   _lhs = lhs;
   _rhs = rhs;

--- a/runtime/onert/backend/cpu/ops/SubLayer.h
+++ b/runtime/onert/backend/cpu/ops/SubLayer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_OPS_SUBLAYER_H__
 #define __ONERT_BACKEND_CPU_OPS_SUBLAYER_H__
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 #include "OperationUtils.h"
 
 #include <exec/IFunction.h>
@@ -44,15 +44,15 @@ public:
 
   void subQuant8();
 
-  void configure(const Tensor *lhs, const Tensor *rhs, const ir::Activation activation,
-                 Tensor *output);
+  void configure(const IPortableTensor *lhs, const IPortableTensor *rhs,
+                 const ir::Activation activation, IPortableTensor *output);
 
   void run();
 
 private:
-  const Tensor *_lhs;
-  const Tensor *_rhs;
-  Tensor *_output;
+  const IPortableTensor *_lhs;
+  const IPortableTensor *_rhs;
+  IPortableTensor *_output;
 
   ir::Activation _activation{ir::Activation::NONE};
 };

--- a/runtime/onert/backend/cpu/ops/TanhLayer.cc
+++ b/runtime/onert/backend/cpu/ops/TanhLayer.cc
@@ -46,7 +46,7 @@ void TanhLayer::tanhQuant8()
   throw std::runtime_error{"NYI"};
 }
 
-void TanhLayer::configure(const Tensor *input, Tensor *output)
+void TanhLayer::configure(const IPortableTensor *input, IPortableTensor *output)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/ops/TanhLayer.h
+++ b/runtime/onert/backend/cpu/ops/TanhLayer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_OPS_TANHLAYER_H__
 #define __ONERT_BACKEND_CPU_OPS_TANHLAYER_H__
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 
 #include <exec/IFunction.h>
 
@@ -40,13 +40,13 @@ public:
 
   void tanhQuant8();
 
-  void configure(const Tensor *input, Tensor *output);
+  void configure(const IPortableTensor *input, IPortableTensor *output);
 
   void run();
 
 private:
-  const Tensor *_input;
-  Tensor *_output;
+  const IPortableTensor *_input;
+  IPortableTensor *_output;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/TileLayer.cc
+++ b/runtime/onert/backend/cpu/ops/TileLayer.cc
@@ -47,7 +47,8 @@ void TileLayer::tileQuant8()
   throw std::runtime_error{"NYI"};
 }
 
-void TileLayer::configure(const Tensor *input, const Tensor *multipliers, Tensor *output)
+void TileLayer::configure(const IPortableTensor *input, const IPortableTensor *multipliers,
+                          IPortableTensor *output)
 {
   _input = input;
   _multipliers = multipliers;

--- a/runtime/onert/backend/cpu/ops/TileLayer.h
+++ b/runtime/onert/backend/cpu/ops/TileLayer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_OPS_TILELAYER_H__
 #define __ONERT_BACKEND_CPU_OPS_TILELAYER_H__
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 
 #include <exec/IFunction.h>
 
@@ -40,14 +40,15 @@ public:
 
   void tileQuant8();
 
-  void configure(const Tensor *input, const Tensor *_multipliers, Tensor *output);
+  void configure(const IPortableTensor *input, const IPortableTensor *_multipliers,
+                 IPortableTensor *output);
 
   void run();
 
 private:
-  const Tensor *_input;
-  const Tensor *_multipliers;
-  Tensor *_output;
+  const IPortableTensor *_input;
+  const IPortableTensor *_multipliers;
+  IPortableTensor *_output;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/TransposeLayer.cc
+++ b/runtime/onert/backend/cpu/ops/TransposeLayer.cc
@@ -54,7 +54,8 @@ void TransposeLayer::transposeQuant8()
   throw std::runtime_error{"NYI"};
 }
 
-void TransposeLayer::configure(const Tensor *input, Tensor *output, const std::vector<int> &perm)
+void TransposeLayer::configure(const IPortableTensor *input, IPortableTensor *output,
+                               const std::vector<int> &perm)
 {
   _input = input;
   _perm = perm;

--- a/runtime/onert/backend/cpu/ops/TransposeLayer.h
+++ b/runtime/onert/backend/cpu/ops/TransposeLayer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_OPS_TRANSPOSELAYER_H__
 #define __ONERT_BACKEND_CPU_OPS_TRANSPOSELAYER_H__
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 
 #include <exec/IFunction.h>
 
@@ -40,13 +40,14 @@ public:
 
   void transposeQuant8();
 
-  void configure(const Tensor *input, Tensor *output, const std::vector<int> &perm);
+  void configure(const IPortableTensor *input, IPortableTensor *output,
+                 const std::vector<int> &perm);
 
   void run();
 
 private:
-  const Tensor *_input;
-  Tensor *_output;
+  const IPortableTensor *_input;
+  IPortableTensor *_output;
   std::vector<int> _perm;
 };
 

--- a/runtime/onert/backend/cpu/ops/UnpackLayer.cc
+++ b/runtime/onert/backend/cpu/ops/UnpackLayer.cc
@@ -62,8 +62,8 @@ template <typename T> void UnpackLayer::unpackImpl()
                         getTensorShape(_outputs[0]), outputPtrs.data());
 }
 
-void UnpackLayer::configure(const Tensor *input, uint32_t axis, int32_t num,
-                            std::vector<Tensor *> &outputs)
+void UnpackLayer::configure(const IPortableTensor *input, uint32_t axis, int32_t num,
+                            std::vector<IPortableTensor *> &outputs)
 {
   assert(input != nullptr);
   assert(outputs.size() > 0);

--- a/runtime/onert/backend/cpu/ops/UnpackLayer.h
+++ b/runtime/onert/backend/cpu/ops/UnpackLayer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_OPS_UNPACKLAYER_H__
 #define __ONERT_BACKEND_CPU_OPS_UNPACKLAYER_H__
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 
 #include <exec/IFunction.h>
 
@@ -36,16 +36,16 @@ public:
   UnpackLayer();
 
 public:
-  void configure(const Tensor *input, uint32_t axis, int32_t num_output,
-                 std::vector<Tensor *> &output);
+  void configure(const IPortableTensor *input, uint32_t axis, int32_t num_output,
+                 std::vector<IPortableTensor *> &output);
   void run();
 
 private:
   template <typename T> void unpackImpl();
 
 private:
-  const Tensor *_input;
-  std::vector<Tensor *> _outputs;
+  const IPortableTensor *_input;
+  std::vector<IPortableTensor *> _outputs;
   uint32_t _axis;
   int32_t _num_output;
 };

--- a/runtime/onert/backend/cpu/ops/ZerosLikeLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ZerosLikeLayer.cc
@@ -31,7 +31,7 @@ ZerosLikeLayer::ZerosLikeLayer() : _input(nullptr), _output(nullptr)
   // DO NOTHING
 }
 
-void ZerosLikeLayer::configure(const Tensor *input, Tensor *output)
+void ZerosLikeLayer::configure(const IPortableTensor *input, IPortableTensor *output)
 {
   _input = input;
   _output = output;

--- a/runtime/onert/backend/cpu/ops/ZerosLikeLayer.h
+++ b/runtime/onert/backend/cpu/ops/ZerosLikeLayer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_OPS_ZEROS_LIKE_LAYER_H__
 #define __ONERT_BACKEND_CPU_OPS_ZEROS_LIKE_LAYER_H__
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 
 #include <exec/IFunction.h>
 
@@ -34,13 +34,13 @@ class ZerosLikeLayer : public ::onert::exec::IFunction
 public:
   ZerosLikeLayer();
 
-  void configure(const Tensor *input, Tensor *output);
+  void configure(const IPortableTensor *input, IPortableTensor *output);
 
   void run();
 
 private:
-  const Tensor *_input;
-  Tensor *_output;
+  const IPortableTensor *_input;
+  IPortableTensor *_output;
 };
 
 } // namespace ops

--- a/runtime/onert/core/include/backend/cpu_common/TensorRegistry.h
+++ b/runtime/onert/core/include/backend/cpu_common/TensorRegistry.h
@@ -27,18 +27,6 @@ namespace backend
 namespace cpu_common
 {
 
-#if 0
-class TensorRegistry : public ITensorRegistry, public ir::OperandIndexMap<std::shared_ptr<Tensor>>
-{
-public:
-  /**
-   * @brief Returns pointer of ITensor
-   * @note  Returned tensor cannot be used longer than dynamic tensor manager
-   */
-  std::shared_ptr<ITensor> getITensor(const ir::OperandIndex &ind) override { return at(ind); }
-};
-#endif
-
 using TensorRegistry = PortableTensorRegistryTemplate<cpu_common::Tensor>;
 
 } // namespace cpu_common


### PR DESCRIPTION
Make cpu backend ops use IPortableTensor so it can accept tensors from
other backends.

Draft: #1325

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>