### PR TITLE
[tests/tool] Fix wrong error handling with noexept in tflite_run

### DIFF
--- a/tests/tools/tflite_run/src/args.cc
+++ b/tests/tools/tflite_run/src/args.cc
@@ -23,17 +23,26 @@ namespace TFLiteRun
 
 Args::Args(const int argc, char **argv) noexcept
 {
-  Initialize();
-  Parse(argc, argv);
+  try
+  {
+    Initialize();
+    Parse(argc, argv);
+  }
+  catch (const std::exception &e)
+  {
+    std::cerr << "error during paring args" << e.what() << '\n';
+    exit(1);
+  }
 }
 
 void Args::Initialize(void)
 {
+  try
+  {
+    // General options
+    po::options_description general("General options");
 
-  // General options
-  po::options_description general("General options");
-
-  // clang-format off
+    // clang-format off
   general.add_options()
     ("help,h", "Display available options")
     ("input,i", po::value<std::string>()->default_value(""), "Input filename")
@@ -48,10 +57,17 @@ void Args::Initialize(void)
     ("write_report,p", po::value<bool>()->default_value(false), "Write report")
     ("validate", po::value<bool>()->default_value(true), "Validate tflite model")
     ;
-  // clang-format on
+    // clang-format on
 
-  _options.add(general);
-  _positional.add("tflite", 1);
+    _options.add(general);
+    _positional.add("tflite", 1);
+  }
+  catch (const std::bad_cast &e)
+  {
+    std::cerr << "error by bad cast during initialization of boost::program_options" << e.what()
+              << '\n';
+    exit(1);
+  }
 }
 
 void Args::Parse(const int argc, char **argv)


### PR DESCRIPTION
This commit fixes wrong error handling with noexept in tflite_run.

Signed-off-by: ragmani <ragmani0216@gmail.com>