### PR TITLE
[tools] CMake: Unify linking boost

### DIFF
--- a/tests/tools/nnpackage_run/CMakeLists.txt
+++ b/tests/tools/nnpackage_run/CMakeLists.txt
@@ -37,17 +37,7 @@ endif()
 target_link_libraries(nnpackage_run onert_core onert tflite_loader)
 target_link_libraries(nnpackage_run tensorflow-lite ${LIB_PTHREAD} dl nnfw_lib_tflite jsoncpp)
 target_link_libraries(nnpackage_run nnfw-dev)
-if(BUILD_BOOST)
-  # We have to use Boost::program_options, instead of boost_program_optinos
-  # Boost::program_options provides the full path for our own built boost.
-  target_link_libraries(nnpackage_run Boost::program_options)
-else()
-  # We cannot use `Boost::program_options` on aarch64
-  # because it uses boost 1.65.1, which requires cmake >= 3.9.3
-  # to identify Boost::program_options imported target correctly,
-  # However, it uses cmake 3.5. (old version).
-  target_link_libraries(nnpackage_run boost_program_options)
-endif()
+target_link_libraries(nnpackage_run ${Boost_PROGRAM_OPTIONS_LIBRARY})
 target_link_libraries(nnpackage_run nnfw_lib_benchmark)
 if(Ruy_FOUND AND PROFILE_RUY)
   target_link_libraries(nnpackage_run ruy_instrumentation)

--- a/tests/tools/tflite_run/CMakeLists.txt
+++ b/tests/tools/tflite_run/CMakeLists.txt
@@ -14,17 +14,7 @@ target_include_directories(tflite_run PRIVATE src)
 target_include_directories(tflite_run PRIVATE ${Boost_INCLUDE_DIRS})
 
 target_link_libraries(tflite_run tensorflow-lite ${LIB_PTHREAD} dl nnfw_lib_tflite)
-if(BUILD_BOOST)
-  # We have to use Boost::program_options, instead of boost_program_optinos
-  # Boost::program_options provides the full path for our own built boost.
-  target_link_libraries(tflite_run Boost::program_options)
-else()
-  # We cannot use `Boost::program_options` on aarch64
-  # because it uses boost 1.65.1, which requires cmake >= 3.9.3
-  # to identify Boost::program_options imported target correctly,
-  # However, it uses cmake 3.5. (old version).
-  target_link_libraries(tflite_run boost_program_options)
-endif()
+target_link_libraries(tflite_run ${Boost_PROGRAM_OPTIONS_LIBRARY})
 
 target_link_libraries(tflite_run nnfw_lib_benchmark)
 


### PR DESCRIPTION
Use variable `${Boost_PROGRAM_OPTIONS_LIBRARY}` rather than plain
strings. This may resolve both cases(if-else branch).

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>