### PR TITLE
[onert] Introducing ConstMemoryManager

### DIFF
--- a/runtime/onert/core/include/backend/cpu_common/MemoryManager.h
+++ b/runtime/onert/core/include/backend/cpu_common/MemoryManager.h
@@ -29,6 +29,9 @@ namespace backend
 namespace cpu_common
 {
 
+/**
+ * @brief MemoryManager for static tensors whose memory is allocated at compilation phase
+ */
 class MemoryManager : public backend::IMemoryManager
 {
 public:
@@ -53,6 +56,25 @@ private:
   std::shared_ptr<Allocator> _mem_alloc;
 };
 
+/**
+ * @brief MemoryManager for constant tensors
+ */
+class ConstMemoryManager
+{
+public:
+  ConstMemoryManager() = default;
+  virtual ~ConstMemoryManager() = default;
+
+  std::shared_ptr<Allocator> allocate(const ir::OperandIndex &ind, uint32_t capacity);
+  void deallocate(void);
+
+private:
+  ir::OperandIndexMap<std::shared_ptr<Allocator>> _mem_alloc_map;
+};
+
+/**
+ * @brief MemoryManager for dynamic tensors whose memory is allocated at execution phase
+ */
 class DynamicMemoryManager
 {
 public:

--- a/runtime/onert/core/include/backend/cpu_common/StaticTensorManager.h
+++ b/runtime/onert/core/include/backend/cpu_common/StaticTensorManager.h
@@ -51,7 +51,7 @@ public:
   void iterate(const std::function<void(const ir::OperandIndex &)> &fn);
 
 private:
-  std::unique_ptr<DynamicMemoryManager> _const_mgr;
+  std::unique_ptr<ConstMemoryManager> _const_mgr;
   std::unique_ptr<MemoryManager> _nonconst_mgr;
   const std::shared_ptr<TensorRegistry> _tensors;
   ir::OperandIndexMap<bool> _as_constants;

--- a/runtime/onert/core/src/backend/cpu_common/MemoryManager.cc
+++ b/runtime/onert/core/src/backend/cpu_common/MemoryManager.cc
@@ -70,6 +70,23 @@ uint8_t *MemoryManager::getBuffer(const ir::OperandIndex &ind) const
   return _mem_alloc->base() + mem_blk.offset;
 }
 
+std::shared_ptr<cpu_common::Allocator> ConstMemoryManager::allocate(const ir::OperandIndex &ind,
+                                                                    uint32_t capacity)
+{
+  auto mem_alloc = std::make_shared<cpu_common::Allocator>(capacity);
+  _mem_alloc_map[ind] = mem_alloc;
+  return mem_alloc;
+}
+
+void ConstMemoryManager::deallocate(void)
+{
+  for (auto &mem_alloc : _mem_alloc_map)
+  {
+    // Release memory buffer of mem_alloc
+    mem_alloc.second->release();
+  }
+}
+
 std::shared_ptr<cpu_common::Allocator> DynamicMemoryManager::allocate(const ir::OperandIndex &ind,
                                                                       uint32_t capacity)
 {

--- a/runtime/onert/core/src/backend/cpu_common/StaticTensorManager.cc
+++ b/runtime/onert/core/src/backend/cpu_common/StaticTensorManager.cc
@@ -26,7 +26,7 @@ namespace cpu_common
 {
 
 StaticTensorManager::StaticTensorManager(const std::shared_ptr<TensorRegistry> &reg)
-    : _const_mgr{new DynamicMemoryManager()}, _nonconst_mgr{new MemoryManager()}, _tensors{reg}
+    : _const_mgr{new ConstMemoryManager()}, _nonconst_mgr{new MemoryManager()}, _tensors{reg}
 {
   // DO NOTHING
 }


### PR DESCRIPTION
`DynamicMemoryManager` was originally used for managing _const_ tensors and later, used for _dynamic_ tensors.

This PR creates `ConstMemoryManager`, which is a copy of `DynamicMemoryManager`. However, `deallocate(ind)` method, which was written only for _dynamic_ tensors, was removed from `ConstMemoryManager`.

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>