### PR TITLE
[onert] add missing override in supportLayout

### DIFF
--- a/runtime/onert/test/core/compiler/Scheduler.cc
+++ b/runtime/onert/test/core/compiler/Scheduler.cc
@@ -57,7 +57,7 @@ struct MockConfigCPU : public IConfig
   std::string id() override { return "cpu"; }
   bool initialize() override { return true; };
   bool supportPermutation() override { return false; }
-  Layout supportLayout(const Operation &, Layout) { return Layout::UNKNOWN; }
+  Layout supportLayout(const Operation &, Layout) override { return Layout::UNKNOWN; }
   bool supportDynamicTensor() override { return false; }
   bool supportFP16() override { return false; }
 };
@@ -78,7 +78,10 @@ struct MockConfigGPU : public IConfig
   std::string id() override { return "gpu"; }
   bool initialize() override { return true; };
   bool supportPermutation() override { return false; }
-  ir::Layout supportLayout(const ir::Operation &, ir::Layout) { return ir::Layout::UNKNOWN; }
+  ir::Layout supportLayout(const ir::Operation &, ir::Layout) override
+  {
+    return ir::Layout::UNKNOWN;
+  }
   bool supportDynamicTensor() override { return false; }
   bool supportFP16() override { return false; }
 };
@@ -99,7 +102,10 @@ struct MockConfigNPU : public IConfig
   std::string id() override { return "npu"; }
   bool initialize() override { return true; };
   bool supportPermutation() override { return false; }
-  ir::Layout supportLayout(const ir::Operation &, ir::Layout) { return ir::Layout::UNKNOWN; }
+  ir::Layout supportLayout(const ir::Operation &, ir::Layout) override
+  {
+    return ir::Layout::UNKNOWN;
+  }
   bool supportDynamicTensor() override { return false; }
   bool supportFP16() override { return false; }
 };

--- a/runtime/onert/test/core/exec/ExecTime.test.cc
+++ b/runtime/onert/test/core/exec/ExecTime.test.cc
@@ -31,7 +31,10 @@ struct MockConfig : public IConfig
   std::string id() override { return "b1"; }
   bool initialize() override { return true; };
   bool supportPermutation() override { return false; }
-  ir::Layout supportLayout(const ir::Operation &, ir::Layout) { return ir::Layout::UNKNOWN; }
+  ir::Layout supportLayout(const ir::Operation &, ir::Layout) override
+  {
+    return ir::Layout::UNKNOWN;
+  }
   bool supportDynamicTensor() override { return false; }
   bool supportFP16() override { return false; }
 };


### PR DESCRIPTION
There are warnings about missing override.
It add overrides for supportLayout.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>