### PR TITLE
[onert] Remove copies between unused tensors in IfLayer

### DIFF
--- a/runtime/onert/core/src/backend/controlflow/KernelGenerator.cc
+++ b/runtime/onert/core/src/backend/controlflow/KernelGenerator.cc
@@ -83,8 +83,8 @@ void KernelGenerator::visit(const ir::operation::If &node)
   const auto cond_tensor = input_tensors.front();
   input_tensors.erase(input_tensors.begin());
   auto fn = std::make_unique<::onert::backend::controlflow::kernel::IfLayer>(
-      cond_tensor, input_tensors, output_tensors, outputs_dyn_alloc_info, then_subg_index,
-      else_subg_index, _executor_map);
+      cond_tensor, input_tensors, output_tensors, node.getOutputs(), _graph, outputs_dyn_alloc_info,
+      then_subg_index, else_subg_index, _executor_map);
 
   _return_fn = std::move(fn);
 }

--- a/runtime/onert/core/src/backend/controlflow/kernel/IfLayer.h
+++ b/runtime/onert/core/src/backend/controlflow/kernel/IfLayer.h
@@ -34,8 +34,9 @@ class IfLayer : public ::onert::exec::IFunction
 {
 public:
   IfLayer(const std::shared_ptr<backend::ITensor> &cond_tensor,
-          std::vector<std::shared_ptr<backend::ITensor>> input_tensors,
-          std::vector<std::shared_ptr<backend::ITensor>> output_tensors,
+          const std::vector<std::shared_ptr<backend::ITensor>> input_tensors,
+          const std::vector<std::shared_ptr<backend::ITensor>> output_tensors,
+          const ir::OperandIndexSequence &output_indices, const ir::Graph &graph,
           const exec::DynAllocInfoMap &outputs_dyn_alloc_info,
           const ir::SubgraphIndex &then_subg_index, const ir::SubgraphIndex &else_subg_index,
           exec::ExecutorMap *executor_map);
@@ -47,6 +48,8 @@ private:
   const std::shared_ptr<backend::ITensor> _cond_tensor;
   const std::vector<std::shared_ptr<backend::ITensor>> _input_tensors;
   const std::vector<std::shared_ptr<backend::ITensor>> _output_tensors;
+  const ir::OperandIndexSequence &_output_indices;
+  const ir::Graph &_graph;
   const exec::DynAllocInfoMap _outputs_dyn_alloc_info;
   const ir::SubgraphIndex _then_subg_index;
   const ir::SubgraphIndex _else_subg_index;


### PR DESCRIPTION
For issue #2501
Draft PR #2530 

This commit removes copies between unused tensors in IfLayer to reduce using resources.

Signed-off-by: ragmani <ragmani0216@gmail.com>