### PR TITLE
[onert] Use flatbuffers dev package on gbs build

### DIFF
--- a/infra/nnfw/cmake/packages/TensorFlowLiteConfig.cmake
+++ b/infra/nnfw/cmake/packages/TensorFlowLiteConfig.cmake
@@ -56,6 +56,10 @@ message(STATUS "Found TensorFlow Lite: TRUE (include: ${TFLITE_INCLUDE_DIR}, lib
 add_library(tensorflow-lite INTERFACE)
 target_include_directories(tensorflow-lite SYSTEM INTERFACE ${TFLITE_INCLUDE_DIR})
 target_link_libraries(tensorflow-lite INTERFACE ${TFLITE_LIB})
+find_library(FLATBUFFERS_LIB NAMES flatbuffers)
+if(FLATBUFFERS_LIB)
+  target_link_libraries(tensorflow-lite INTERFACE ${FLATBUFFERS_LIB})
+endif(FLATBUFFERS_LIB)
 
 # Prefer -pthread to -lpthread
 set(THREADS_PREFER_PTHREAD_FLAG TRUE)


### PR DESCRIPTION
GBS build uses flatbuffers devel package and link libflatbuffers.so to use tensorflow lite

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>