### PR TITLE
[onert/1.5] Use flatbuffers dev package on gbs build

### DIFF
--- a/infra/nnfw/cmake/packages/TensorFlowLiteConfig.cmake
+++ b/infra/nnfw/cmake/packages/TensorFlowLiteConfig.cmake
@@ -56,6 +56,10 @@ message(STATUS "Found TensorFlow Lite: TRUE (include: ${TFLITE_INCLUDE_DIR}, lib
 add_library(tensorflow-lite INTERFACE)
 target_include_directories(tensorflow-lite SYSTEM INTERFACE ${TFLITE_INCLUDE_DIR})
 target_link_libraries(tensorflow-lite INTERFACE ${TFLITE_LIB})
+find_library(FLATBUFFERS_LIB NAMES flatbuffers)
+if(FLATBUFFERS_LIB)
+  target_link_libraries(tensorflow-lite INTERFACE ${FLATBUFFERS_LIB})
+endif(FLATBUFFERS_LIB)
 
 # Prefer -pthread to -lpthread
 set(THREADS_PREFER_PTHREAD_FLAG TRUE)

--- a/packaging/nnfw.spec
+++ b/packaging/nnfw.spec
@@ -17,7 +17,7 @@ Source2001: nnfw.pc.in
 
 %{!?build_type:     %define build_type      Release}
 %{!?coverage_build: %define coverage_build  0}
-%{!?test_build:     %define test_build      1}
+%{!?test_build:     %define test_build      0}
 %{!?extra_option:   %define extra_option    %{nil}}
 %if %{coverage_build} == 1
 %define test_build 1


### PR DESCRIPTION
GBS build uses flatbuffers devel package and link libflatbuffers.so to use tensorflow lite
Change test build default: not build

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>