### PR TITLE
[onert] Enhancing memory management for dynamic tensor

### DIFF
--- a/runtime/onert/core/include/backend/cpu_common/Tensor.h
+++ b/runtime/onert/core/include/backend/cpu_common/Tensor.h
@@ -57,6 +57,16 @@ public:
   // This works just as setBuffer but it simply overwrite existing Allocator without nullptr check
   void overwriteBuffer(const std::shared_ptr<Allocator> &alloc) { _allocator = alloc; }
 
+  /**
+   * @brief Mark this tensor does not have memory.
+   *        Real memory deallocation should be done by caller.
+   */
+  void resetBuffer()
+  {
+    _allocator.reset();
+    _buffer = nullptr;
+  }
+
 public:
   uint8_t *buffer() const override
   {

--- a/runtime/onert/core/src/backend/cpu_common/DynamicTensorManager.cc
+++ b/runtime/onert/core/src/backend/cpu_common/DynamicTensorManager.cc
@@ -115,10 +115,13 @@ void DynamicTensorManager::deallocInput(ir::OperationIndex op_ind)
   auto &input_set = find->second;
   for (auto input_ind : input_set)
   {
-    if (!_tensors->getManagedTensor(input_ind)->is_dynamic())
+    auto *tensor = _tensors->getManagedTensor(input_ind).get();
+    if (!tensor->is_dynamic())
       continue;
 
     _dynamic_mem_mgr->deallocate(input_ind);
+    tensor->resetBuffer();
+
     VERBOSE(DynamicTensorManager) << "Deallocating #" << input_ind.value()
                                   << " (input of op_ind: " << op_ind.value() << ")" << std::endl;
   }
@@ -126,10 +129,13 @@ void DynamicTensorManager::deallocInput(ir::OperationIndex op_ind)
 
 void DynamicTensorManager::deallocSubgraphOutput(ir::OperandIndex output_ind)
 {
-  if (!_tensors->getManagedTensor(output_ind)->is_dynamic())
+  auto *tensor = _tensors->getManagedTensor(output_ind).get();
+  if (!tensor->is_dynamic())
     return;
 
   _dynamic_mem_mgr->deallocate(output_ind);
+  tensor->resetBuffer();
+
   VERBOSE(DynamicTensorManager) << "Deallocating #" << output_ind.value()
                                 << " (output of a subgraph)" << std::endl;
 }


### PR DESCRIPTION
This fixes some (possible) memory issue of dynamic tensor like the following:

0. `DynamicMemoryManager::_mem_alloc_map` now stores tensors only when they are allocated.
1. `allocate()` checks if the tensor is already allocated, preventing duplicate applcations
2. When calling `deallocate(tensor_index)`, its memory is explicitly released
   - Previously, its ref count was decreased so the memory might not be released if other still hold the shared_ref.
3. After `deallocInput()` and `deallocSubghraphOutput()`, input/output tensors are explicitly marked as "the tensor does not have memory allocated". 
   - Previously, the tensor might have `_allocator` even after `dealloc()`, and `Tensor::allocator != nullptr`, which is not our expectation.

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>
