### PR TITLE
[onert] Adding int64 into IPermuteFunction.h

### DIFF
--- a/runtime/onert/core/include/exec/IPermuteFunction.h
+++ b/runtime/onert/core/include/exec/IPermuteFunction.h
@@ -260,6 +260,8 @@ private:
         return typeid(int32_t);
       case ir::DataType::UINT32:
         return typeid(uint32_t);
+      case ir::DataType::INT64:
+        return typeid(int64_t);
       case ir::DataType::BOOL8:
       case ir::DataType::QUANT_UINT8_ASYMM:
       case ir::DataType::UINT8:


### PR DESCRIPTION
This adds `int64` into underlying_type() method of `IPermuteFunction.h`.
(FYI, `permute<>()` in this file already has `int64` support.)

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>