### PR TITLE
[onert] Add int64 support for Concat and Compare

### DIFF
--- a/runtime/onert/backend/cpu/ops/CompareLayer.cc
+++ b/runtime/onert/backend/cpu/ops/CompareLayer.cc
@@ -158,6 +158,10 @@ void CompareLayer::run()
   {
     compareScalar<int32_t>(_lhs, _rhs, _output, _op_type);
   }
+  else if (_lhs->data_type() == OperandType::INT64)
+  {
+    compareScalar<int64_t>(_lhs, _rhs, _output, _op_type);
+  }
   else if (_lhs->data_type() == OperandType::BOOL8)
   {
     compareScalar<uint8_t>(_lhs, _rhs, _output, _op_type);

--- a/runtime/onert/backend/cpu/ops/ConcatLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ConcatLayer.cc
@@ -129,6 +129,10 @@ void ConcatLayer::run()
   {
     concatenationGeneral<int32_t>();
   }
+  else if (_output->data_type() == OperandType::INT64)
+  {
+    concatenationGeneral<int64_t>();
+  }
   else
     throw std::runtime_error("Concat: unsupported data type");
 }


### PR DESCRIPTION
This adds `int64` support into `Concat` and `Compare`.

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>