### PR TITLE
[onert] CMake: Specify boost components

### DIFF
--- a/runtime/contrib/style_transfer_app/CMakeLists.txt
+++ b/runtime/contrib/style_transfer_app/CMakeLists.txt
@@ -20,7 +20,7 @@ if(JPEG_FOUND)
   list(APPEND STYLE_TRANSFER_APP_SRCS "src/jpeg_helper.cc")
 endif(JPEG_FOUND)
 
-nnfw_find_package(Boost REQUIRED)
+nnfw_find_package(Boost REQUIRED program_options system filesystem)
 
 add_executable(style_transfer_app ${STYLE_TRANSFER_APP_SRCS})
 target_include_directories(style_transfer_app PRIVATE src)

--- a/tests/tools/nnpackage_run/CMakeLists.txt
+++ b/tests/tools/nnpackage_run/CMakeLists.txt
@@ -10,7 +10,7 @@ list(APPEND NNPACKAGE_RUN_SRCS "src/nnpackage_run.cc")
 list(APPEND NNPACKAGE_RUN_SRCS "src/args.cc")
 list(APPEND NNPACKAGE_RUN_SRCS "src/nnfw_util.cc")
 
-nnfw_find_package(Boost REQUIRED)
+nnfw_find_package(Boost REQUIRED program_options)
 nnfw_find_package(Ruy QUIET)
 nnfw_find_package(HDF5 COMPONENTS CXX QUIET)
 

--- a/tests/tools/tflite_loader/CMakeLists.txt
+++ b/tests/tools/tflite_loader/CMakeLists.txt
@@ -11,7 +11,7 @@ endif(NOT BUILD_ONERT)
 list(APPEND SOURCES "src/tflite_loader.cc")
 list(APPEND SOURCES "src/args.cc")
 
-nnfw_find_package(Boost REQUIRED)
+nnfw_find_package(Boost REQUIRED program_options system filesystem)
 
 add_executable(tflite_loader_test_tool ${SOURCES})
 target_include_directories(tflite_loader_test_tool PRIVATE ${Boost_INCLUDE_DIRS})

--- a/tests/tools/tflite_run/CMakeLists.txt
+++ b/tests/tools/tflite_run/CMakeLists.txt
@@ -7,7 +7,7 @@ list(APPEND TFLITE_RUN_SRCS "src/args.cc")
 list(APPEND TFLITE_RUN_SRCS "src/tensor_dumper.cc")
 list(APPEND TFLITE_RUN_SRCS "src/tensor_loader.cc")
 
-nnfw_find_package(Boost REQUIRED)
+nnfw_find_package(Boost REQUIRED program_options)
 
 add_executable(tflite_run ${TFLITE_RUN_SRCS})
 target_include_directories(tflite_run PRIVATE src)

--- a/tools/kbenchmark/CMakeLists.txt
+++ b/tools/kbenchmark/CMakeLists.txt
@@ -8,7 +8,7 @@ if(NOT Nonius_FOUND)
   return()
 endif(NOT Nonius_FOUND)
 
-nnfw_find_package(Boost QUIET)
+nnfw_find_package(Boost REQUIRED program_options system filesystem)
 
 if(NOT Boost_FOUND)
   return()


### PR DESCRIPTION
When components are specified and if `${Boost_DIR}` is already cached,
it sometimes does not work properly. This is to fix macOS build.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>