### PR TITLE
[onert] Move BackendSet to exec

### DIFF
--- a/runtime/onert/core/src/exec/BackendSet.h
+++ b/runtime/onert/core/src/exec/BackendSet.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef __ONERT_IR_BACKEND_SET_H__
-#define __ONERT_IR_BACKEND_SET_H__
+#ifndef __ONERT_EXEC_BACKEND_SET_H__
+#define __ONERT_EXEC_BACKEND_SET_H__
 
 #include "util/Set.h"
 
@@ -29,12 +29,12 @@ class Backend;
 
 namespace onert
 {
-namespace ir
+namespace exec
 {
 
 using BackendSet = util::Set<const backend::Backend *>;
 
-} // namespace ir
+} // namespace exec
 } // namespace onert
 
-#endif // __ONERT_IR_BACKEND_SET_H__
+#endif // __ONERT_EXEC_BACKEND_SET_H__

--- a/runtime/onert/core/src/exec/ParallelExecutor.cc
+++ b/runtime/onert/core/src/exec/ParallelExecutor.cc
@@ -71,7 +71,7 @@ void ParallelExecutor::executeImpl()
 {
   // Init scheduler
   // TODO Consider to have distinct backend set in LowerInfoMap
-  ir::BackendSet backends;
+  BackendSet backends;
   for (auto &itr : _lowered_graph->getLowerInfo()->op_seq)
   {
     backends.add(itr.second->backend());

--- a/runtime/onert/core/src/exec/ParallelScheduler.cc
+++ b/runtime/onert/core/src/exec/ParallelScheduler.cc
@@ -26,7 +26,7 @@ namespace onert
 namespace exec
 {
 
-ParallelScheduler::ParallelScheduler(const ir::BackendSet &backends)
+ParallelScheduler::ParallelScheduler(const BackendSet &backends)
 {
   assert(!backends.empty());
 

--- a/runtime/onert/core/src/exec/ParallelScheduler.h
+++ b/runtime/onert/core/src/exec/ParallelScheduler.h
@@ -21,7 +21,7 @@
 #include <memory>
 
 #include "exec/IFunction.h"
-#include "ir/BackendSet.h"
+#include "BackendSet.h"
 #include "ThreadPool.h"
 
 namespace onert
@@ -37,7 +37,7 @@ public:
    *
    * @param backends Backend set
    */
-  ParallelScheduler(const ir::BackendSet &backends);
+  ParallelScheduler(const BackendSet &backends);
   /**
    * @brief Assign a task to the given backend
    *


### PR DESCRIPTION
It is only used by `exec`.

- Change namespace and move directory from `ir::BackendSet` to
  `exec::BackendSet`.
- Move it from `include` to `src`.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>