### PR TITLE
[onert] Fix wrong stride value is passed for pooling operation

### DIFF
--- a/runtime/onert/frontend/base_loader/include/base_loader.h
+++ b/runtime/onert/frontend/base_loader/include/base_loader.h
@@ -406,8 +406,8 @@ void BaseLoader<LoaderDomain, SpecificLoader>::loadStridesAndPaddings(Param &par
                                                                       const OptionsType *options)
 {
   // Strides
-  param.stride.vertical = options->stride_w();
-  param.stride.horizontal = options->stride_h();
+  param.stride.vertical = options->stride_h();
+  param.stride.horizontal = options->stride_w();
   // Paddings
   if (options->padding() == Padding::Padding_SAME)
     param.padding.type = ir::PaddingType::SAME;


### PR DESCRIPTION
- This commit fixes wrong stride value is passed for pooling operation
  - Stride height and width values are swapped at base_loader

ONE-DCO-1.0-Signed-off-by: JiHwan Yeo <jihwan.yeo@samsung.com>