### PR TITLE
[onert] Change param axes of Mean operation to input

### DIFF
--- a/runtime/onert/backend/acl_cl/KernelGenerator.cc
+++ b/runtime/onert/backend/acl_cl/KernelGenerator.cc
@@ -1790,30 +1790,19 @@ void KernelGenerator::visit(const ir::operation::Mean &node)
 {
   const auto ofm_index{node.getOutputs().at(0)};
   const auto ifm_index{node.getInputs().at(ir::operation::Mean::Input::INPUT)};
-  const auto &axes{node.param().axes};
+  const auto axes_index{node.getInputs().at(ir::operation::Mean::Input::AXES)};
   const auto keep_dims{node.param().keep_dims};
 
   auto ofm_alloc = _tensor_builder->at(ofm_index).get();
   auto ifm_alloc = _tensor_builder->at(ifm_index).get();
-  const auto frontend_layout = _current_op_seq_layout;
-  const auto backend_layout = ifm_alloc->layout();
 
   // Convert to ACL axes taking into account negative values and possible duplicates.
-  std::set<std::uint32_t> acl_axes;
+  const auto &axes = _ctx.at(axes_index);
   const int ifm_rank = _ctx.at(ifm_index).shape().rank();
-  for (int axis : axes)
-  {
-    if (axis < 0)
-      axis += ifm_rank;
-    acl_axes.insert(
-        acl_common::ToARMComputeAxis(ifm_rank, axis, frontend_layout, backend_layout).value());
-  }
-
-  arm_compute::Coordinates reduce_axes;
-  for (const auto axis : acl_axes)
-  {
-    reduce_axes.set(reduce_axes.num_dimensions(), axis);
-  }
+  const auto frontend_layout = _current_op_seq_layout;
+  const auto backend_layout = ifm_alloc->layout();
+  const auto reduce_axes =
+      acl_common::asCoordinates(axes, ifm_rank, frontend_layout, backend_layout);
 
   auto fn = std::make_unique<::arm_compute::CLReduceMean>();
 

--- a/runtime/onert/backend/acl_common/Convert.cc
+++ b/runtime/onert/backend/acl_common/Convert.cc
@@ -177,6 +177,46 @@ namespace acl_common
   }
 }
 
+arm_compute::Coordinates asCoordinates(const ir::Operand &operand, int rank,
+                                       ir::Layout frontend_layout, ir::Layout backend_layout)
+{
+  std::vector<int32_t> axes;
+  switch (operand.typeInfo().type())
+  {
+    case ir::DataType::INT32:
+    {
+      const auto tmp = operand.asVector<int32_t>();
+      axes.insert(axes.begin(), tmp.begin(), tmp.end());
+      break;
+    }
+    case ir::DataType::INT64:
+    {
+      const auto tmp = operand.asVector<int64_t>();
+      axes.insert(axes.begin(), tmp.begin(), tmp.end());
+      break;
+    }
+    default:
+      throw std::runtime_error("asCoordinates: Not supported data type");
+      break;
+  }
+
+  std::unordered_set<int32_t> acl_axes;
+  for (auto axis : axes)
+  {
+    if (axis < 0)
+      axis += rank;
+    acl_axes.insert(ToARMComputeAxis(rank, axis, frontend_layout, backend_layout).value());
+  }
+
+  arm_compute::Coordinates reduce_axes;
+  for (const auto axis : acl_axes)
+  {
+    reduce_axes.set(reduce_axes.num_dimensions(), axis);
+  }
+
+  return reduce_axes;
+}
+
 std::unique_ptr<AclFunction> asAclFunction(std::unique_ptr<::arm_compute::IFunction> &&layer)
 {
   return std::make_unique<AclFunction>(std::move(layer));

--- a/runtime/onert/backend/acl_common/Convert.h
+++ b/runtime/onert/backend/acl_common/Convert.h
@@ -56,6 +56,9 @@ namespace acl_common
 
 ::arm_compute::ActivationLayerInfo asActivationLayerInfo(ir::Activation act_code);
 
+arm_compute::Coordinates asCoordinates(const ir::Operand &operand, int rank,
+                                       ir::Layout frontend_layout, ir::Layout backend_layout);
+
 std::unique_ptr<AclFunction> asAclFunction(std::unique_ptr<::arm_compute::IFunction> &&layer);
 std::unique_ptr<AclClFunction> asAclClFunction(std::unique_ptr<::arm_compute::IFunction> &&layer);
 

--- a/runtime/onert/backend/acl_neon/KernelGenerator.cc
+++ b/runtime/onert/backend/acl_neon/KernelGenerator.cc
@@ -322,30 +322,19 @@ void KernelGenerator::visit(const ir::operation::Mean &node)
 {
   const auto ofm_index{node.getOutputs().at(0)};
   const auto ifm_index{node.getInputs().at(ir::operation::Mean::Input::INPUT)};
-  const auto &axes{node.param().axes};
+  const auto axes_index{node.getInputs().at(ir::operation::Mean::Input::AXES)};
   const auto keep_dims{node.param().keep_dims};
 
   auto ofm_alloc = _tensor_builder->at(ofm_index).get();
   auto ifm_alloc = _tensor_builder->at(ifm_index).get();
-  const auto frontend_layout = _current_op_seq_layout;
-  const auto backend_layout = ifm_alloc->layout();
 
   // Convert to ACL axes taking into account negative values and possible duplicates.
-  std::set<std::uint32_t> acl_axes;
+  const auto &axes = _ctx.at(axes_index);
   const int ifm_rank = _ctx.at(ifm_index).shape().rank();
-  for (int axis : axes)
-  {
-    if (axis < 0)
-      axis += ifm_rank;
-    acl_axes.insert(
-        acl_common::ToARMComputeAxis(ifm_rank, axis, frontend_layout, backend_layout).value());
-  }
-
-  arm_compute::Coordinates fixed_axis;
-  for (const auto axis : acl_axes)
-  {
-    fixed_axis.set(fixed_axis.num_dimensions(), axis);
-  }
+  const auto frontend_layout = _current_op_seq_layout;
+  const auto backend_layout = ifm_alloc->layout();
+  const auto fixed_axis =
+      acl_common::asCoordinates(axes, ifm_rank, frontend_layout, backend_layout);
 
   // NOTE NEReduceMean has a bug that does not support NHWC layout
   //      NEReduceMean intermediate tensors are always NCHW layout

--- a/runtime/onert/core/include/ir/operation/Mean.h
+++ b/runtime/onert/core/include/ir/operation/Mean.h
@@ -31,12 +31,12 @@ class Mean : public Operation
 public:
   enum Input
   {
-    INPUT
+    INPUT,
+    AXES
   };
 
   struct Param
   {
-    std::vector<int> axes;
     bool keep_dims;
   };
 

--- a/runtime/onert/core/src/ir/operation/Mean.cc
+++ b/runtime/onert/core/src/ir/operation/Mean.cc
@@ -31,7 +31,7 @@ void Mean::accept(OperationVisitor &v) const { v.visit(*this); }
 
 Mean::Mean(const OperandIndexSequence &inputs, const OperandIndexSequence &outputs,
            const Param &param)
-    : Operation{OperandConstraint::createExact(1u), inputs, outputs}, _param{param}
+    : Operation{OperandConstraint::createExact(2u), inputs, outputs}, _param{param}
 {
 }
 

--- a/runtime/onert/frontend/base_loader/include/base_loader.h
+++ b/runtime/onert/frontend/base_loader/include/base_loader.h
@@ -860,17 +860,11 @@ void BaseLoader<LoaderDomain, SpecificLoader>::loadMean(const Operator *op, ir::
   ir::OperandIndexSequence outputs;
 
   loadOperationIO(op, inputs, outputs);
-  auto input = inputs.at(0);
-  auto axes = inputs.at(1);
-
-  if (!subg.operands().at(axes).isConstant())
-    throw std::runtime_error("Mean: non-constant 'axes' is not supported.");
 
   ir::operation::Mean::Param param;
-  param.axes = subg.operands().at(axes).template asVector<int>();
   param.keep_dims = op->builtin_options_as_ReducerOptions()->keep_dims();
 
-  std::unique_ptr<ir::Operation> new_op(new ir::operation::Mean({input}, outputs, param));
+  std::unique_ptr<ir::Operation> new_op(new ir::operation::Mean(inputs, outputs, param));
   subg.addOperation(std::move(new_op));
 }
 

--- a/runtime/onert/frontend/nnapi/wrapper/OperationFactory.cc
+++ b/runtime/onert/frontend/nnapi/wrapper/OperationFactory.cc
@@ -1780,12 +1780,9 @@ OperationFactory::OperationFactory()
     //  0 -> ifm Tensor Index
     //  1 -> axis Tensor Index
     //  2 -> keep_dims Index
-    OperandIndexSequence inputs{init_param.inputs[0]};
-    std::vector<std::int32_t> axes =
-        operands.at(OperandIndex{init_param.inputs[1]}).asVector<std::int32_t>();
+    OperandIndexSequence inputs{init_param.inputs[0], init_param.inputs[1]};
 
     operation::Mean::Param param;
-    param.axes.assign(axes.cbegin(), axes.cend());
     param.keep_dims = operands.at(OperandIndex{init_param.inputs[2]}).asScalar<int32_t>() != 0;
 
     return new operation::Mean{inputs, outputs, param};


### PR DESCRIPTION
This commit changes param axes of Mean operation to input.
  - Add helper functions converting axes from buffer for each backends
  - Modify ir::operation::Mean, base_loader, OperationFactory, KernelGenerators

Signed-off-by: ragmani <ragmani0216@gmail.com>