### PR TITLE
Introduce circle-quantizer for pota quantization

### DIFF
--- a/compiler/circle-quantizer/CMakeLists.txt
+++ b/compiler/circle-quantizer/CMakeLists.txt
@@ -1,0 +1,15 @@
+file(GLOB_RECURSE SOURCES "src/*.cpp")
+
+add_executable(circle-quantizer "${SOURCES}")
+target_include_directories(circle-quantizer PRIVATE include)
+target_include_directories(circle-quantizer PRIVATE src)
+target_link_libraries(circle-quantizer safemain)
+target_link_libraries(circle-quantizer oops)
+target_link_libraries(circle-quantizer loco)
+target_link_libraries(circle-quantizer mio_circle)
+target_link_libraries(circle-quantizer luci_import)
+target_link_libraries(circle-quantizer luci_service)
+target_link_libraries(circle-quantizer luci_pass)
+target_link_libraries(circle-quantizer luci_export)
+
+install(TARGETS circle-quantizer DESTINATION bin)

--- a/compiler/circle-quantizer/README.md
+++ b/compiler/circle-quantizer/README.md
@@ -1,0 +1,3 @@
+# circle-quantizer
+
+_circle-quantizer_ provides post-training quantization functionalities for Circle models

--- a/compiler/circle-quantizer/include/CircleExpContract.h
+++ b/compiler/circle-quantizer/include/CircleExpContract.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __CIRCLEQUANTIZER_CIRCLEXPCONTRACT_H__
+#define __CIRCLEQUANTIZER_CIRCLEXPCONTRACT_H__
+
+#include <loco.h>
+#include <luci/CircleExporter.h>
+#include <luci/IR/Module.h>
+
+#include <memory>
+#include <string>
+
+struct CircleExpContract : public luci::CircleExporter::Contract
+{
+public:
+  CircleExpContract(luci::Module *module, const std::string &filename)
+      : _module(module), _filepath(filename)
+  {
+    // NOTHING TO DO
+  }
+  virtual ~CircleExpContract() = default;
+
+public:
+  loco::Graph *graph(void) const final { return nullptr; }
+  luci::Module *module(void) const final { return _module; };
+
+public:
+  bool store(const char *ptr, const size_t size) const final;
+
+private:
+  luci::Module *_module;
+  const std::string _filepath;
+};
+
+#endif // __CIRCLEQUANTIZER_CIRCLEXPCONTRACT_H__

--- a/compiler/circle-quantizer/include/Model.h
+++ b/compiler/circle-quantizer/include/Model.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __CIRCLEQUANTIZER_MODEL_H__
+#define __CIRCLEQUANTIZER_MODEL_H__
+
+#include <mio/circle/schema_generated.h>
+
+#include <memory>
+
+namespace circle_quantizer
+{
+
+struct Model
+{
+  virtual ~Model() = default;
+
+  virtual const ::circle::Model *model(void) = 0;
+};
+
+/**
+ * @brief Load Circle model (as a raw Model) from a given path
+ *
+ * @note May return a nullptr
+ */
+std::unique_ptr<Model> load_model(const std::string &path);
+
+} // namespace circle_quantizer
+
+#endif // __CIRCLEQUANTIZER_MODEL_H__

--- a/compiler/circle-quantizer/requires.cmake
+++ b/compiler/circle-quantizer/requires.cmake
@@ -1,0 +1,5 @@
+require("loco")
+require("locop")
+require("safemain")
+require("luci")
+require("oops")

--- a/compiler/circle-quantizer/src/CircleExpContract.cpp
+++ b/compiler/circle-quantizer/src/CircleExpContract.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "CircleExpContract.h"
+
+#include <oops/InternalExn.h>
+
+#include <fstream>
+#include <iostream>
+
+bool CircleExpContract::store(const char *ptr, const size_t size) const
+{
+  if (!ptr)
+    INTERNAL_EXN("Graph was not serialized by FlatBuffer for some reason");
+
+  std::ofstream fs(_filepath.c_str(), std::ofstream::binary);
+  fs.write(ptr, size);
+
+  return fs.good();
+}

--- a/compiler/circle-quantizer/src/CircleQuantizer.cpp
+++ b/compiler/circle-quantizer/src/CircleQuantizer.cpp
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Model.h"
+#include "CircleExpContract.h"
+
+#include <luci/Importer.h>
+#include <luci/CircleOptimizer.h>
+#include <luci/Service/Validate.h>
+#include <luci/CircleExporter.h>
+
+#include <oops/InternalExn.h>
+
+#include <functional>
+#include <iostream>
+#include <map>
+#include <string>
+
+using OptionHook = std::function<int(const char **)>;
+
+using Algorithms = luci::CircleOptimizer::Options::Algorithm;
+using AlgorithmParameters = luci::CircleOptimizer::Options::AlgorithmParameters;
+
+void print_help(const char *progname)
+{
+  std::cerr << "USAGE: " << progname << " [options] input output" << std::endl;
+  std::cerr << "Options: " << std::endl;
+  std::cerr << "   --quantize_with_minmax : Enable QuantizeWithMinMax Pass" << std::endl;
+  std::cerr << "                            ";
+  std::cerr << "Require three following parameters (input_dtype, quantized_dtype, granularity)"
+            << std::endl;
+  std::cerr << "                            ";
+  std::cerr << "Ex: --quantize_with_minmax float32 uint8 layer" << std::endl;
+  std::cerr << "   --quantize_dequantize_weights : Enable QuantizeDequantizeWeights Pass"
+            << std::endl;
+  std::cerr << "                            ";
+  std::cerr << "Require three following parameters (input_dtype, quantized_dtype, granularity)"
+            << std::endl;
+  std::cerr << "                            ";
+  std::cerr << "Ex: --quantize_dequantize_weights float32 uint8 channel" << std::endl;
+  std::cerr << std::endl;
+}
+
+int entry(int argc, char **argv)
+{
+  if (argc < 3)
+  {
+    std::cerr << "ERROR: Failed to parse arguments" << std::endl;
+    std::cerr << std::endl;
+    print_help(argv[0]);
+    return 255;
+  }
+
+  // Simple argument parser (based on map)
+  std::map<std::string, OptionHook> argparse;
+  luci::CircleOptimizer optimizer;
+
+  auto options = optimizer.options();
+
+  // TODO use better parsing library (ex: boost.program_options)
+  argparse["--quantize_dequantize_weights"] = [&options](const char **argv) {
+    options->enable(Algorithms::QuantizeDequantizeWeights);
+
+    if (argv[0] == nullptr || argv[1] == nullptr || argv[2] == nullptr)
+      throw std::runtime_error(
+          "--quantize_dequantize_weights must have three following parameters.");
+
+    std::string input_dtype = argv[0];
+    std::string output_dtype = argv[1];
+    std::string granularity = argv[2];
+
+    if (input_dtype.empty() || output_dtype.empty() || granularity.empty() ||
+        input_dtype.substr(0, 2).compare("--") == 0 ||
+        output_dtype.substr(0, 2).compare("--") == 0 || granularity.substr(0, 2).compare("--") == 0)
+      throw std::runtime_error("Wrong algorithm parameters for --quantize_dequantize_weights.");
+
+    options->param(AlgorithmParameters::Quantize_input_dtype, input_dtype);
+    options->param(AlgorithmParameters::Quantize_output_dtype, output_dtype);
+    options->param(AlgorithmParameters::Quantize_granularity, granularity);
+    return 3;
+  };
+
+  // TODO use better parsing library (ex: boost.program_options)
+  argparse["--quantize_with_minmax"] = [&options](const char **argv) {
+    options->enable(Algorithms::QuantizeWithMinMax);
+
+    if (argv[0] == nullptr || argv[1] == nullptr || argv[2] == nullptr)
+      throw std::runtime_error("--quantize_with_minmax must have three following parameters.");
+
+    std::string input_dtype = argv[0];
+    std::string output_dtype = argv[1];
+    std::string granularity = argv[2];
+
+    if (input_dtype.empty() || output_dtype.empty() || granularity.empty() ||
+        input_dtype.substr(0, 2).compare("--") == 0 ||
+        output_dtype.substr(0, 2).compare("--") == 0 || granularity.substr(0, 2).compare("--") == 0)
+      throw std::runtime_error("Wrong algorithm parameters for --quantize_with_minmax.");
+
+    options->param(AlgorithmParameters::Quantize_input_dtype, input_dtype);
+    options->param(AlgorithmParameters::Quantize_output_dtype, output_dtype);
+    options->param(AlgorithmParameters::Quantize_granularity, granularity);
+    return 3;
+  };
+
+  for (int n = 1; n < argc - 2; ++n)
+  {
+    const std::string tag{argv[n]};
+    auto it = argparse.find(tag);
+    if (it == argparse.end())
+    {
+      std::cerr << "Option '" << tag << "' is not supported" << std::endl;
+      std::cerr << std::endl;
+      print_help(argv[0]);
+      return 255;
+    }
+
+    n += it->second((const char **)&argv[n + 1]);
+  }
+
+  std::string input_path = argv[argc - 2];
+  std::string output_path = argv[argc - 1];
+
+  // Load model from the file
+  std::unique_ptr<circle_quantizer::Model> model = circle_quantizer::load_model(input_path);
+  if (model == nullptr)
+  {
+    std::cerr << "ERROR: Failed to load '" << input_path << "'" << std::endl;
+    return 255;
+  }
+
+  const circle::Model *input_model = model->model();
+  if (input_model == nullptr)
+  {
+    std::cerr << "ERROR: Failed to read '" << input_path << "'" << std::endl;
+    return 255;
+  }
+
+  // Import from input Circle file
+  luci::Importer importer;
+  auto module = importer.importModule(input_model);
+
+  for (size_t idx = 0; idx < module->size(); ++idx)
+  {
+    auto graph = module->graph(idx);
+
+    // quantize the graph
+    optimizer.quantize(graph);
+
+    if (!luci::validate(graph))
+    {
+      std::cerr << "ERROR: Quantized graph is invalid" << std::endl;
+      return 255;
+    }
+  }
+
+  // Export to output Circle file
+  luci::CircleExporter exporter;
+
+  CircleExpContract contract(module.get(), output_path);
+
+  if (!exporter.invoke(&contract))
+  {
+    std::cerr << "ERROR: Failed to export '" << output_path << "'" << std::endl;
+    return 255;
+  }
+
+  return 0;
+}

--- a/compiler/circle-quantizer/src/Model.cpp
+++ b/compiler/circle-quantizer/src/Model.cpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Model.h"
+
+#include <fstream>
+#include <vector>
+
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/stat.h>
+
+namespace
+{
+
+class FileModel final : public circle_quantizer::Model
+{
+public:
+  explicit FileModel(const std::string &filename) : _filename(filename) {}
+
+public:
+  FileModel(const FileModel &) = delete;
+  FileModel(FileModel &&) = delete;
+
+public:
+  const ::circle::Model *model(void) override
+  {
+    std::ifstream file(_filename, std::ios::binary | std::ios::in);
+    if (!file.good())
+      return nullptr;
+
+    file.unsetf(std::ios::skipws);
+
+    std::streampos fileSize;
+    file.seekg(0, std::ios::end);
+    fileSize = file.tellg();
+    file.seekg(0, std::ios::beg);
+
+    // reserve capacity
+    _data.reserve(fileSize);
+
+    // read the data
+    file.read(_data.data(), fileSize);
+    if (file.fail())
+      return nullptr;
+
+    return ::circle::GetModel(_data.data());
+  }
+
+private:
+  const std::string _filename;
+  std::vector<char> _data;
+};
+
+} // namespace
+
+namespace circle_quantizer
+{
+
+std::unique_ptr<Model> load_model(const std::string &path)
+{
+  return std::unique_ptr<Model>{new FileModel(path)};
+}
+
+} // namespace circle_quantizer


### PR DESCRIPTION
This introduces circle-quantizer for post-training affine quantization

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to #2617