### PR TITLE
[onert] Fix nnpkg_test.sh to fail on 'not comparable'

### DIFF
--- a/tests/scripts/nnpkg_test.sh
+++ b/tests/scripts/nnpkg_test.sh
@@ -111,13 +111,26 @@ expected="$nnpkg/metadata/tc/expected.h5"
 
 echo -n "[Compare] $nnpkg "
 
-if $difftool -d 0.001 -v "$dumped" "$expected" /value >& "$dumped.log"; then
-  echo -e "\tPass"
-  rm "$dumped" "$dumped.log"
-else
+test_fail()
+{
   echo -e "\tFail"
   [ $delete_dumped_on_failure ] && rm "$dumped"
   cat "$dumped.log"
   rm "$dumped.log"
   exit 3
+}
+
+test_pass()
+{
+  echo -e "\tPass"
+  cat "$dumped.log"
+  rm "$dumped" "$dumped.log"
+}
+
+if ! $difftool -d 0.001 -v "$dumped" "$expected" /value >& "$dumped.log"; then
+  test_fail
+elif grep "not comparable" "$dumped.log" > /dev/null; then
+  test_fail
+else
+  test_pass
 fi


### PR DESCRIPTION
- Issue
   - Test passes when it's 'not comparable'(dimension unmatch, rank unmatch, zero tensor..)
- Changes
   - Fail on 'not comparable'
   - Print `dumped.log` even if it passes, to check
- related issue : #2623

ONE-DCO-1.0-Signed-off-by: dayo09 <dayg502@gmail.com>