### PR TITLE
[onert] fix nnpackage_run build error with hdf5 on android

### DIFF
--- a/tests/tools/nnpackage_run/CMakeLists.txt
+++ b/tests/tools/nnpackage_run/CMakeLists.txt
@@ -12,7 +12,7 @@ list(APPEND NNPACKAGE_RUN_SRCS "src/nnfw_util.cc")
 
 nnfw_find_package(Boost REQUIRED program_options)
 nnfw_find_package(Ruy QUIET)
-nnfw_find_package(HDF5 COMPONENTS CXX QUIET)
+nnfw_find_package(HDF5 QUIET)
 
 if (HDF5_FOUND)
   list(APPEND NNPACKAGE_RUN_SRCS "src/h5formatter.cc")


### PR DESCRIPTION
It fixes nnpackage_run build error for android.

It also remvoes parameters COMPONENTS CXX from nnfw_find_package
since c++ binding is searched unconditionally without this parameters.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>