### PR TITLE
[onert] Enable int64 input tensor with Split

### DIFF
--- a/runtime/onert/backend/cpu/ops/SplitLayer.cc
+++ b/runtime/onert/backend/cpu/ops/SplitLayer.cc
@@ -91,6 +91,10 @@ void SplitLayer::run()
   {
     split<int32_t>();
   }
+  else if (_input->data_type() == OperandType::INT64)
+  {
+    split<int64_t>();
+  }
   else
   {
     throw std::runtime_error{"Split: unsupported input type"};


### PR DESCRIPTION
This enables int64 input tensor with `Split`.

This is required to run our large test model.

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>