### PR TITLE
[pota-value-test] Update circle quantizer command

### DIFF
--- a/compiler/pota-quantization-value-test/CMakeLists.txt
+++ b/compiler/pota-quantization-value-test/CMakeLists.txt
@@ -94,10 +94,10 @@ add_custom_command(
   OUTPUT ${TEST_CONFIG}
   COMMAND ${CMAKE_COMMAND} -E remove -f ${TEST_CONFIG}
   COMMAND ${CMAKE_COMMAND} -E echo 'RECORD_MINMAX_PATH=\"$<TARGET_FILE:record-minmax>\"' >> ${TEST_CONFIG}
-  COMMAND ${CMAKE_COMMAND} -E echo 'CIRCLE2CIRCLE_PATH=\"$<TARGET_FILE:circle2circle>\"' >> ${TEST_CONFIG}
+  COMMAND ${CMAKE_COMMAND} -E echo 'CIRCLE_QUANTIZER_PATH=\"$<TARGET_FILE:circle-quantizer>\"' >> ${TEST_CONFIG}
   COMMAND ${CMAKE_COMMAND} -E echo 'CIRCLE_TENSORDUMP_PATH=\"$<TARGET_FILE:circle-tensordump>\"' >> ${TEST_CONFIG}
   DEPENDS record-minmax
-  DEPENDS circle2circle
+  DEPENDS circle-quantizer
   DEPENDS circle-tensordump
   COMMENT "Generate test configuration"
 )

--- a/compiler/pota-quantization-value-test/README.md
+++ b/compiler/pota-quantization-value-test/README.md
@@ -8,7 +8,7 @@ Write `test.local.lst` for local test.
 
 #### Step 1. Fake quantization
 
-Run `circle2circle` with `--quantize_dequantize_weights` option.
+Run `circle-quantizer` with `--quantize_dequantize_weights` option.
 
 Dump the fake-quantized model with `circle-tensordump`.
 
@@ -29,7 +29,7 @@ The expected output should include
 
 #### Step 3. Quantization
 
-Run `circle2circle` with `--quantize_with_minmax` option.
+Run `circle-quantizer` with `--quantize_with_minmax` option.
 
 Dump the quantized model with `circle-tensordump`.
 

--- a/compiler/pota-quantization-value-test/requires.cmake
+++ b/compiler/pota-quantization-value-test/requires.cmake
@@ -1,5 +1,5 @@
 require("record-minmax")
-require("circle2circle")
+require("circle-quantizer")
 require("circle-tensordump")
 require("tflite2circle")
 require("tflchef")

--- a/compiler/pota-quantization-value-test/test_fake_wquant.sh
+++ b/compiler/pota-quantization-value-test/test_fake_wquant.sh
@@ -5,7 +5,7 @@
 # HOW TO USE
 #
 # ./test_fake_quantization.sh <path/to/test.config> <path/to/work_dir> <TEST 1> <TEST 2> ...
-# test.config : set ${RECORD_MINMAX_PATH} and ${CIRCLE2CIRCLE_PATH}
+# test.config : set ${RECORD_MINMAX_PATH} and ${CIRCLE_QUANTIZER_PATH}
 # work_dir : build directory of quantization-value-test (ex: build/compiler/quantization-value-test)
 
 SOURCE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -17,7 +17,7 @@ VIRTUALENV="${WORKDIR}/venv"
 
 source "${CONFIG_PATH}"
 
-echo "-- Found CIRCLE2CIRCLE: ${CIRCLE2CIRCLE_PATH}"
+echo "-- Found CIRCLE_QUANTIZER: ${CIRCLE_QUANTIZER_PATH}"
 echo "-- Found CIRCLE_TENSORDUMP: ${CIRCLE_TENSORDUMP_PATH}"
 echo "-- Found workdir: ${WORKDIR}"
 
@@ -43,8 +43,8 @@ while [ "$1" != "" ]; do
     exec 2>&1
     set -ex
 
-    # Run circle2circle with --quantize_dequantize_weights
-    "${CIRCLE2CIRCLE_PATH}" \
+    # Run circle-quantizer with --quantize_dequantize_weights
+    "${CIRCLE_QUANTIZER_PATH}" \
       --quantize_dequantize_weights float "${DTYPE}" "${GRANULARITY}" \
       "${WORKDIR}/${MODELNAME}.circle" \
       "${TESTCASE_FILE}.fake_quantized.circle" 

--- a/compiler/pota-quantization-value-test/test_quantization.sh
+++ b/compiler/pota-quantization-value-test/test_quantization.sh
@@ -5,7 +5,7 @@
 # HOW TO USE
 #
 # ./test_quantization.sh <path/to/test.config> <path/to/work_dir> <TEST 1> <TEST 2> ...
-# test.config : set ${RECORD_MINMAX_PATH} and ${CIRCLE2CIRCLE_PATH}
+# test.config : set ${RECORD_MINMAX_PATH} and ${CIRCLE_QUANTIZER_PATH}
 # work_dir : build directory of quantization-value-test (ex: build/compiler/quantization-value-test)
 
 SOURCE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -17,7 +17,7 @@ VIRTUALENV="${WORKDIR}/venv"
 
 source "${CONFIG_PATH}"
 
-echo "-- Found CIRCLE2CIRCLE: ${CIRCLE2CIRCLE_PATH}"
+echo "-- Found CIRCLE_QUANTIZER: ${CIRCLE_QUANTIZER_PATH}"
 echo "-- Found CIRCLE_TENSORDUMP: ${CIRCLE_TENSORDUMP_PATH}"
 echo "-- Found workdir: ${WORKDIR}"
 
@@ -43,8 +43,8 @@ while [ "$1" != "" ]; do
     exec 2>&1
     set -ex
 
-    # Run circle2circle with --quantize_with_minmax
-    "${CIRCLE2CIRCLE_PATH}" \
+    # Run circle-quantizer with --quantize_with_minmax
+    "${CIRCLE_QUANTIZER_PATH}" \
       --quantize_with_minmax float "${DTYPE}" "${GRANULARITY}" \
       "${TESTCASE_FILE}.minmax_recorded.circle" \
       "${TESTCASE_FILE}.quantized.circle" 


### PR DESCRIPTION
This changes quantizer executable from circle2cirle to circle-quantizer

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to #2617