### PR TITLE
[onert] use uname -m instead of uname -p

### DIFF
--- a/Makefile.template
+++ b/Makefile.template
@@ -1,5 +1,5 @@
-HOST_ARCH?=$(shell uname -p)
-TARGET_ARCH?=$(shell uname -p)
+HOST_ARCH?=$(shell uname -m)
+TARGET_ARCH?=$(shell uname -m)
 BUILD_TYPE?=Debug
 CROSS_BUILD?=0
 HOST_OS?=linux


### PR DESCRIPTION
Use uname -m because it is portable and gives better result on
mac os and windows.

```
$ uname --help
  ...
  -m, --machine            print the machine hardware name
  -p, --processor          print the processor type (non-portable)
  -i, --hardware-platform  print the hardware platform (non-portable)
```

On mac os,
`uname -p` returns `i386` while `uname -m` returns `x86_64`.

On linux,
both `uname -p` and `uname -m` returns `x86_64`.

On windows (mingw),
`uname -p` returns `unknown`, while `uname -m` returns `x86_64`.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>