### PR TITLE
[onert] remove _available_backends vector in BackendManager

### DIFF
--- a/runtime/onert/core/include/compiler/BackendManager.h
+++ b/runtime/onert/core/include/compiler/BackendManager.h
@@ -41,7 +41,14 @@ public:
   backend::Backend *get(const std::string &key);
   const backend::Backend *get(const std::string &key) const;
   const backend::Backend *getControlflow() const;
-  const std::vector<const backend::Backend *> &getAll() const { return _available_backends; };
+  const std::vector<const backend::Backend *> getAll() const
+  {
+    std::vector<const backend::Backend *> v;
+    for (const auto &p : _gen_map)
+      v.emplace_back(p.second.get());
+    return v;
+  }
+  size_t num_backends() const { return _gen_map.size(); }
   /**
    * @brief load backend plugin
    *
@@ -55,7 +62,6 @@ private:
   BackendManager();
 
 private:
-  std::vector<const backend::Backend *> _available_backends;
   std::map<std::string, std::unique_ptr<void, dlhandle_destroy_t>> _handle_map;
   std::map<std::string, std::unique_ptr<backend::Backend, backend_destroy_t>> _gen_map;
   /**

--- a/runtime/onert/core/src/compiler/BackendManager.cc
+++ b/runtime/onert/core/src/compiler/BackendManager.cc
@@ -58,14 +58,12 @@ void BackendManager::loadControlflowBackend()
 
   auto backend_object =
       std::unique_ptr<backend::Backend, backend_destroy_t>(backend_create(), backend_destroy);
-  auto backend_object_raw = backend_object.get();
   bool initialized = backend_object->config()->initialize(); // Call initialize here?
   if (!initialized)
   {
     throw std::runtime_error(backend::controlflow::Config::ID + " backend initialization failed");
   }
   _gen_map.emplace(backend_object->config()->id(), std::move(backend_object));
-  _available_backends.push_back(backend_object_raw);
 }
 
 void BackendManager::loadBackend(const std::string &backend)
@@ -109,7 +107,6 @@ void BackendManager::loadBackend(const std::string &backend)
 
       auto backend_object =
           std::unique_ptr<backend::Backend, backend_destroy_t>(backend_create(), backend_destroy);
-      auto backend_object_raw = backend_object.get();
       bool initialized = backend_object->config()->initialize(); // Call initialize here?
       if (!initialized)
       {
@@ -119,7 +116,6 @@ void BackendManager::loadBackend(const std::string &backend)
         return;
       }
       _gen_map.emplace(backend_object->config()->id(), std::move(backend_object));
-      _available_backends.push_back(backend_object_raw);
     }
 
     // Save backend handle (avoid warning by handle lost without dlclose())

--- a/runtime/onert/core/src/ir/LoweredGraph.cc
+++ b/runtime/onert/core/src/ir/LoweredGraph.cc
@@ -65,7 +65,7 @@ LoweredGraph::LoweredGraph(const Graph &graph, const compiler::CompilerOptions &
     _backend_contexts.emplace(backend, backend->newContext(_graph, _graph.getKernelBuilder(),
                                                            options.executor == "Linear"));
   }
-  if (backend_manager.getAll().size() == 0)
+  if (backend_manager.num_backends() == 0)
     throw std::runtime_error{"No available backends loaded."};
 
   // TODO Move "schedule" phase out of here


### PR DESCRIPTION
BackendManager has all available backends in _gen_map.
It also keeps _available_backend in vector.
_available_backend is used in getAll(), which are used only
in `DotDumper` and for getting the number of backends.

It will remove `_available_backends` member.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>