### PR TITLE
[circle2circle dredd] Use CircleBatchMatMul_000

### DIFF
--- a/compiler/circle2circle-dredd-recipe-test/test.lst
+++ b/compiler/circle2circle-dredd-recipe-test/test.lst
@@ -15,4 +15,4 @@ Add(BatchMatMulV2_000 PASS resolve_customop_batchmatmul)
 
 ## CIRCLE RECIPE
 
-Add(BatchMatMul_000)
+Add(CircleBatchMatMul_000)


### PR DESCRIPTION
This will revise to use CircleBatchMatMul_000 for Circle BatchMatMul Op

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>