### PR TITLE
[onert] Remove dependency with misc feature shape

### DIFF
--- a/runtime/onert/core/include/ir/Shape.h
+++ b/runtime/onert/core/include/ir/Shape.h
@@ -18,7 +18,6 @@
 #define __ONERT_IR_SHAPE_H__
 
 #include "ir/Layout.h"
-#include "misc/feature/Shape.h"
 
 #include <cassert>
 #include <cstdint>
@@ -30,8 +29,43 @@ namespace onert
 namespace ir
 {
 
-// TODO Remove this dependency.
-using FeatureShape = nnfw::misc::feature::Shape;
+/**
+ * @brief  Structure to have values of dimensions for feature
+ */
+struct FeatureShape
+{
+  int32_t N; /**< The batch value  */
+  int32_t C; /**< The depth value  */
+  int32_t H; /**< The height value */
+  int32_t W; /**< The width value  */
+
+  /**
+   * @brief  Construct FeatureShape object using default constrcutor
+   */
+  FeatureShape() = default;
+  /**
+   * @brief  Construct FeatureShape object with three values of dimensions
+   * @param[in]  depth  The depth value
+   * @param[in]  height The height value
+   * @param[in]  width  The width value
+   */
+  FeatureShape(int32_t depth, int32_t height, int32_t width) : N{1}, C{depth}, H{height}, W{width}
+  {
+    // DO NOTHING
+  }
+  /**
+   * @brief  Construct FeatureShape object with four values of dimensions
+   * @param[in]  batch  The batch value
+   * @param[in]  depth  The depth value
+   * @param[in]  height The height value
+   * @param[in]  width  The width value
+   */
+  FeatureShape(int32_t batch, int32_t depth, int32_t height, int32_t width)
+      : N{batch}, C{depth}, H{height}, W{width}
+  {
+    // DO NOTHING
+  }
+};
 
 struct Shape
 {

--- a/runtime/onert/core/src/exec/IPermuteFunction.h
+++ b/runtime/onert/core/src/exec/IPermuteFunction.h
@@ -17,6 +17,7 @@
 #ifndef __ONERT_EXEC_I_PERMUTE_FUNCTION_H__
 #define __ONERT_EXEC_I_PERMUTE_FUNCTION_H__
 
+#include "feature/IndexIterator.h"
 #include "feature/nchw/Reader.h"
 #include "feature/nchw/View.h"
 #include "feature/nhwc/Reader.h"
@@ -27,7 +28,6 @@
 #include "ir/Index.h"
 #include "ir/Shape.h"
 #include <memory>
-#include <misc/feature/IndexIterator.h>
 #include <typeinfo>
 #include "util/Utils.h"
 #include <vector>
@@ -187,7 +187,7 @@ private:
                 shape.W = dst_tensor.dimension(3);
                 const feature::nhwc::Reader<T> from(&src_tensor);
                 feature::nchw::View<T> into(&dst_tensor);
-                ::nnfw::misc::feature::iterate(shape)
+                feature::iterate(shape)
                     << [&](uint32_t batch, uint32_t ch, uint32_t row, uint32_t col) {
                          const auto value = from.at(batch, row, col, ch);
                          into.at(batch, ch, row, col) = value;
@@ -203,7 +203,7 @@ private:
                 shape.W = src_tensor.dimension(3);
                 const feature::nchw::Reader<T> from(&src_tensor);
                 feature::nhwc::View<T> into(&dst_tensor);
-                ::nnfw::misc::feature::iterate(shape)
+                feature::iterate(shape)
                     << [&](uint32_t batch, uint32_t ch, uint32_t row, uint32_t col) {
                          const auto value = from.at(batch, ch, row, col);
                          into.at(batch, row, col, ch) = value;

--- a/runtime/onert/core/src/exec/Sink.h
+++ b/runtime/onert/core/src/exec/Sink.h
@@ -129,7 +129,7 @@ protected:
           {
             const exec::feature::nchw::Reader<T> from(&tensor);
             exec::feature::nhwc::View<T> into(shape, _output_buffer, _output_size);
-            ::nnfw::misc::feature::iterate(shape)
+            feature::iterate(shape)
                 << [&](uint32_t batch, uint32_t ch, uint32_t row, uint32_t col) {
                      const auto value = from.at(batch, ch, row, col);
                      into.at(batch, row, col, ch) = value;
@@ -139,7 +139,7 @@ protected:
           {
             const exec::feature::nhwc::Reader<T> from(&tensor);
             exec::feature::nchw::View<T> into(shape, _output_buffer, _output_size);
-            ::nnfw::misc::feature::iterate(shape)
+            feature::iterate(shape)
                 << [&](uint32_t batch, uint32_t ch, uint32_t row, uint32_t col) {
                      const auto value = from.at(batch, row, col, ch);
                      into.at(batch, ch, row, col) = value;

--- a/runtime/onert/core/src/exec/Source.h
+++ b/runtime/onert/core/src/exec/Source.h
@@ -17,6 +17,7 @@
 #ifndef __ONERT_EXEC_SOURCE_H__
 #define __ONERT_EXEC_SOURCE_H__
 
+#include "feature/IndexIterator.h"
 #include "feature/nchw/Reader.h"
 #include "feature/nchw/View.h"
 #include "feature/nhwc/Reader.h"
@@ -25,7 +26,6 @@
 #include <cassert>
 #include <memory>
 #include "util/Utils.h"
-#include <misc/feature/IndexIterator.h>
 #include <ir/Layout.h>
 #include "ir/Shape.h"
 
@@ -134,7 +134,7 @@ protected:
           {
             const exec::feature::nchw::Reader<T> from(shape, _input_buffer, _input_size);
             exec::feature::nhwc::View<T> into(&tensor);
-            ::nnfw::misc::feature::iterate(shape)
+            feature::iterate(shape)
                 << [&](uint32_t batch, uint32_t ch, uint32_t row, uint32_t col) {
                      const auto value = from.at(batch, ch, row, col);
                      into.at(batch, row, col, ch) = value;
@@ -144,7 +144,7 @@ protected:
           {
             const exec::feature::nhwc::Reader<T> from(shape, _input_buffer, _input_size);
             exec::feature::nchw::View<T> into(&tensor);
-            ::nnfw::misc::feature::iterate(shape)
+            feature::iterate(shape)
                 << [&](uint32_t batch, uint32_t ch, uint32_t row, uint32_t col) {
                      const auto value = from.at(batch, row, col, ch);
                      into.at(batch, ch, row, col) = value;

--- a/runtime/onert/core/src/exec/feature/IndexIterator.h
+++ b/runtime/onert/core/src/exec/feature/IndexIterator.h
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file     IndexIterator.h
+ * @brief    This file contains IndexIterator class
+ */
+
+#ifndef __ONERT_EXEC_FEATURE_INDEX_ITERATOR_H__
+#define __ONERT_EXEC_FEATURE_INDEX_ITERATOR_H__
+
+#include "ir/Shape.h"
+
+namespace onert
+{
+namespace exec
+{
+namespace feature
+{
+
+/**
+ * @brief  Class to iterate Callable with Index of feature
+ */
+class IndexIterator
+{
+public:
+  /**
+   * @brief     Construct IndexIterator object with Shape of feature
+   * @param[in] shape Shape reference of feature
+   */
+  IndexIterator(const ir::FeatureShape &shape) : _shape{shape}
+  {
+    // DO NOTHING
+  }
+
+public:
+  /**
+   * @brief     Call a function iterated
+   * @param[in] cb  A callback function
+   * @return    Current IndexIterator object
+   */
+  template <typename Callable> IndexIterator &iter(Callable cb)
+  {
+    for (int32_t batch = 0; batch < _shape.N; ++batch)
+    {
+      for (int32_t ch = 0; ch < _shape.C; ++ch)
+      {
+        for (int32_t row = 0; row < _shape.H; ++row)
+        {
+          for (int32_t col = 0; col < _shape.W; ++col)
+          {
+            cb(batch, ch, row, col);
+          }
+        }
+      }
+    }
+
+    return (*this);
+  }
+
+private:
+  /**
+   * @brief Shape for feature
+   */
+  const ir::FeatureShape _shape;
+};
+
+/**
+ * @brief     Create an object of IndexIterator for feature
+ * @param[in] Shape reference of feature
+ * @return    Created IndexIterator object
+ */
+static inline IndexIterator iterate(const ir::FeatureShape &shape) { return IndexIterator{shape}; }
+
+/**
+ * @brief     Call a function iterated using IndexIterator of feature
+ *            Overloaded operator<<
+ * @param[in] it  An IndexIterator reference
+ * @param[in] cb  A callback function
+ * @return    created IndexIterator object
+ */
+template <typename Callable> IndexIterator &operator<<(IndexIterator &&it, Callable cb)
+{
+  return it.iter(cb);
+}
+
+} // namespace feature
+} // namespace exec
+} // namespace onert
+
+#endif // __ONERT_EXEC_FEATURE_INDEX_ITERATOR_H__

--- a/runtime/onert/core/src/exec/feature/nchw/Reader.h
+++ b/runtime/onert/core/src/exec/feature/nchw/Reader.h
@@ -22,7 +22,7 @@
 #include <cassert>
 
 #include "backend/ITensor.h"
-#include "misc/feature/Shape.h"
+#include "ir/Shape.h"
 
 namespace onert
 {
@@ -37,7 +37,7 @@ template <typename T> class Reader final : public feature::Reader<T>
 {
 public:
   // Construct for buffer of model inputs
-  Reader(const ::nnfw::misc::feature::Shape &shape, const T *ptr, size_t len)
+  Reader(const ir::FeatureShape &shape, const T *ptr, size_t len)
       : _shape{shape}, _ptr{reinterpret_cast<const uint8_t *>(ptr)}, _len{len}
   {
     assert(shape.N * shape.C * shape.H * shape.W * sizeof(T) == len);
@@ -104,8 +104,8 @@ private:
 
 private:
   // TODO Remove _shape
-  nnfw::misc::feature::Shape _shape;
-  using Strides = nnfw::misc::feature::Shape;
+  ir::FeatureShape _shape;
+  using Strides = ir::FeatureShape;
   Strides _strides;
   const uint8_t *_ptr;
   size_t _len;

--- a/runtime/onert/core/src/exec/feature/nchw/View.h
+++ b/runtime/onert/core/src/exec/feature/nchw/View.h
@@ -19,8 +19,8 @@
 
 #include "../Reader.h"
 
-#include "misc/feature/Shape.h"
 #include "backend/ITensor.h"
+#include "ir/Shape.h"
 #include "util/logging.h"
 
 #include <cassert>
@@ -38,7 +38,7 @@ template <typename T> class View final : public feature::Reader<T>
 {
 public:
   // Construct for buffer of model inputs
-  View(const ::nnfw::misc::feature::Shape &shape, T *ptr, size_t len)
+  View(const ir::FeatureShape &shape, T *ptr, size_t len)
       : _shape{shape}, _ptr{reinterpret_cast<uint8_t *>(ptr)}, _len{len}
   {
     assert(shape.N * shape.C * shape.H * shape.W * sizeof(T) == len);
@@ -122,8 +122,8 @@ private:
 
 private:
   // TODO Remove _shape
-  nnfw::misc::feature::Shape _shape;
-  using Strides = nnfw::misc::feature::Shape;
+  ir::FeatureShape _shape;
+  using Strides = ir::FeatureShape;
   Strides _strides;
   uint8_t *_ptr;
   size_t _len;

--- a/runtime/onert/core/src/exec/feature/nhwc/Reader.h
+++ b/runtime/onert/core/src/exec/feature/nhwc/Reader.h
@@ -22,7 +22,7 @@
 #include <cassert>
 
 #include "backend/ITensor.h"
-#include "misc/feature/Shape.h"
+#include "ir/Shape.h"
 #include "util/Utils.h"
 
 namespace onert
@@ -38,7 +38,7 @@ template <typename T> class Reader final : public feature::Reader<T>
 {
 public:
   // Construct for buffer of model inputs
-  Reader(const ::nnfw::misc::feature::Shape &shape, const T *ptr, size_t len)
+  Reader(const ir::FeatureShape &shape, const T *ptr, size_t len)
       : _shape{shape}, _ptr{reinterpret_cast<const uint8_t *>(ptr)}, _len{len}
   {
     UNUSED_RELEASE(len); // Workaround for unused variable in release mode
@@ -106,8 +106,8 @@ private:
 
 private:
   // TODO Remove _shape
-  nnfw::misc::feature::Shape _shape;
-  using Strides = nnfw::misc::feature::Shape;
+  ir::FeatureShape _shape;
+  using Strides = ir::FeatureShape;
   Strides _strides;
   const uint8_t *_ptr;
   size_t _len;

--- a/runtime/onert/core/src/exec/feature/nhwc/View.h
+++ b/runtime/onert/core/src/exec/feature/nhwc/View.h
@@ -23,7 +23,7 @@
 #include <cstddef>
 
 #include "backend/ITensor.h"
-#include "misc/feature/Shape.h"
+#include "ir/Shape.h"
 #include "util/Utils.h"
 
 namespace onert
@@ -39,7 +39,7 @@ template <typename T> class View final : public feature::Reader<T>
 {
 public:
   // Construct for buffer of model inputs
-  View(const ::nnfw::misc::feature::Shape &shape, T *ptr, size_t len)
+  View(const ir::FeatureShape &shape, T *ptr, size_t len)
       : _shape{shape}, _ptr{reinterpret_cast<uint8_t *>(ptr)}, _len{len}
   {
     UNUSED_RELEASE(len); // Workaround for unused variable in release mode
@@ -125,8 +125,8 @@ private:
 
 private:
   // TODO Remove _shape
-  nnfw::misc::feature::Shape _shape;
-  using Strides = nnfw::misc::feature::Shape;
+  ir::FeatureShape _shape;
+  using Strides = ir::FeatureShape;
   Strides _strides;
   uint8_t *_ptr;
   size_t _len;


### PR DESCRIPTION
Remove misc::feature::Shape dependency from onert core headers

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>