### PR TITLE
Rename PARALLEL_BUILD to ALL_PROC_BUILD

### DIFF
--- a/Makefile.template
+++ b/Makefile.template
@@ -4,7 +4,7 @@ BUILD_TYPE?=Debug
 CROSS_BUILD?=0
 HOST_OS?=linux
 TARGET_OS?=linux
-PARALLEL_BUILD?=1
+ALL_PROC_BUILD?=1
 COVERAGE_BUILD?=0
 BENCHMARK_ACL_BUILD?=0
 OPTIONS?=
@@ -78,7 +78,7 @@ ifneq ($(ANDROID_BOOST_ROOT),)
   OPTIONS+= -DANDROID_BOOST_ROOT=$(ANDROID_BOOST_ROOT)
 endif
 
-ifeq ($(PARALLEL_BUILD),1)
+ifeq ($(ALL_PROC_BUILD),1)
 	# Get number of processors (linux only for now)
 	ifeq ($(HOST_OS),linux)
 		NPROCS?=$(shell grep -c ^processor /proc/cpuinfo)
@@ -140,7 +140,7 @@ endif
 	touch $(TIMESTAMP_CONFIGURE)
 
 build_internal: $(BUILD_FOLDER)
-	NNFW_WORKSPACE="$(WORKSPACE)" NPROCS="$(NPROCS)" PARALLEL_BUILD="$(PARALLEL_BUILD)" ./nnfw build
+	NNFW_WORKSPACE="$(WORKSPACE)" NPROCS="$(NPROCS)" ALL_PROC_BUILD="$(ALL_PROC_BUILD)" ./nnfw build
 	rm -rf $(BUILD_ALIAS)
 	ln -s $(BUILD_FOLDER) $(BUILD_ALIAS)
 	touch $(TIMESTAMP_BUILD)

--- a/infra/nnfw/command/build
+++ b/infra/nnfw/command/build
@@ -11,9 +11,9 @@ fi
 # TODO Use argument instead of environment variable
 HOST_OS=${HOST_OS:-linux}
 NPROCS=${NPROCS:-1}
-PARALLEL_BUILD=${PARALLEL_BUILD:-1}
+ALL_PROC_BUILD=${ALL_PROC_BUILD:-1}
 
-if [ "${PARALLEL_BUILD}" == "1" ]; then
+if [ "${ALL_PROC_BUILD}" == "1" ]; then
   # Get number of processors (linux only for now)
   if [ "${HOST_OS}" == "linux" ]; then
     NPROCS="$(grep -c ^processor /proc/cpuinfo)"


### PR DESCRIPTION
This commit renames top level option `PARALLEL_BUILD` to `ALL_PROC_BUILD`
which describes its role better.

Signed-off-by: Cheongyo Bahk <ch.bahk@samsung.com>

---

IMHO, option name `PARALLEL_BUILD` is ambiguous as it does not describe its role correctly. Parallel build possible with setting `NPROCS`.

What it actually does is to set `NPROCS` as a number of cpu processor in host system.

Please propose better name if you have :)