### PR TITLE
[res] Adjust Where recipes to TFLite

### DIFF
--- a/res/TensorFlowLiteRecipes/Where_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/Where_000/test.recipe
@@ -6,7 +6,10 @@ operand {
 operand {
   name: "ofm"
   type: INT64
-  shape { } # output shape is 2d, but partially unknown, because first dimension depends on number of "true" values in input so in our case it is (?, 3)
+  # Output shape is 2d, but partially unknown,
+  # because first dimension depends on number of "true" values in input.
+  # In this case it is (?, 3)
+  shape { }
 }
 operation {
   type: "Where"

--- a/res/TensorFlowLiteRecipes/Where_001/test.recipe
+++ b/res/TensorFlowLiteRecipes/Where_001/test.recipe
@@ -6,7 +6,7 @@ operand {
 operand {
   name: "ofm"
   type: INT64
-  # no output shape in this recipe
+  # shape is intentionally omitted
 }
 operation {
   type: "Where"

--- a/res/TensorFlowLiteRecipes/Where_001/test.recipe
+++ b/res/TensorFlowLiteRecipes/Where_001/test.recipe
@@ -6,7 +6,7 @@ operand {
 operand {
   name: "ofm"
   type: INT64
-  shape { } # output shape is 2d, but partially unknown, because first dimension depends on number of "true" values in input so in our case it is (?, 3)
+  # no output shape in this recipe
 }
 operation {
   type: "Where"


### PR DESCRIPTION
- removed redundant inputs from Where_000 recipe
- added Where_000 test with no shape in output tensor

ONE-DCO-1.0-Signed-off-by: Alexander Efimov <a.efimov@samsung.com>