### PR TITLE
[tflchef] Support optional input tensor expression

### DIFF
--- a/compiler/tflchef/core/src/ModelChef.cpp
+++ b/compiler/tflchef/core/src/ModelChef.cpp
@@ -347,7 +347,14 @@ GeneratedModel cook(const ::tflchef::ModelRecipe &model_recipe)
     // Tensor Name -> Tensor ID mapping (per Graph)
     std::map<std::string, int32_t> symbol_table;
 
-    auto lookup = [&symbol_table](const std::string &name) { return symbol_table.at(name); };
+    auto lookup = [&symbol_table](const std::string &name) {
+      if (symbol_table.find(name) != symbol_table.end())
+        return symbol_table.at(name);
+      else if (name == "")
+        return -1;
+      else
+        throw std::runtime_error("tflchef : input not found in main graph");
+    };
 
     int32_t buffer_start = buffer_vec.size();
     int32_t buffer_index = 0;
@@ -593,7 +600,14 @@ GeneratedModel cook(const ::tflchef::ModelRecipe &model_recipe)
     // Tensor Name -> Tensor ID mapping (per Graph)
     std::map<std::string, int32_t> symbol_table;
 
-    auto lookup = [&symbol_table](const std::string &name) { return symbol_table.at(name); };
+    auto lookup = [&symbol_table](const std::string &name) {
+      if (symbol_table.find(name) != symbol_table.end())
+        return symbol_table.at(name);
+      else if (name == "")
+        return -1;
+      else
+        throw std::runtime_error("tflchef : input not found in subgraph");
+    };
 
     const auto &graph = model_recipe.graph(g);
 

--- a/compiler/tflchef/core/src/ModelChef.cpp
+++ b/compiler/tflchef/core/src/ModelChef.cpp
@@ -351,7 +351,7 @@ GeneratedModel cook(const ::tflchef::ModelRecipe &model_recipe)
       if (symbol_table.find(name) != symbol_table.end())
         return symbol_table.at(name);
       else if (name == "")
-        return -1;
+        return -1; // -1 in TFLite means that optional input tensor is empty.
       else
         throw std::runtime_error("tflchef : input not found in main graph");
     };
@@ -604,7 +604,7 @@ GeneratedModel cook(const ::tflchef::ModelRecipe &model_recipe)
       if (symbol_table.find(name) != symbol_table.end())
         return symbol_table.at(name);
       else if (name == "")
-        return -1;
+        return -1; // -1 in TFLite means that optional input tensor is empty.
       else
         throw std::runtime_error("tflchef : input not found in subgraph");
     };

--- a/compiler/tflchef/tflite/src/RecipeChef.cpp
+++ b/compiler/tflchef/tflite/src/RecipeChef.cpp
@@ -35,9 +35,16 @@ void set_inputs(TFliteImport *import, tflchef::Operation *operation, const tflit
 
   for (auto input : inputs)
   {
-    auto tensor = tensors->Get(input);
-    std::string name = tensor_name(tensor);
-    operation->add_input(name);
+    if (input == -1)
+    {
+      operation->add_input("");
+    }
+    else
+    {
+      auto tensor = tensors->Get(input);
+      std::string name = tensor_name(tensor);
+      operation->add_input(name);
+    }
   }
 }
 


### PR DESCRIPTION
Parent Issue : #2734
Full Draft : #2737

Until now, there is no way to express optional input tensor explicitly in `tflchef`.
This commit will make it possible.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>