### PR TITLE
[circlechef] Support optional input tensor expression

### DIFF
--- a/compiler/circlechef/circle/src/RecipeChef.cpp
+++ b/compiler/circlechef/circle/src/RecipeChef.cpp
@@ -35,9 +35,16 @@ void set_inputs(CircleImport *import, circlechef::Operation *operation, const ci
 
   for (auto input : inputs)
   {
-    auto tensor = tensors->Get(input);
-    std::string name = tensor_name(tensor);
-    operation->add_input(name);
+    if (input == -1)
+    {
+      operation->add_input("");
+    }
+    else
+    {
+      auto tensor = tensors->Get(input);
+      std::string name = tensor_name(tensor);
+      operation->add_input(name);
+    }
   }
 }
 

--- a/compiler/circlechef/core/src/ModelChef.cpp
+++ b/compiler/circlechef/core/src/ModelChef.cpp
@@ -352,7 +352,7 @@ GeneratedModel cook(const ::circlechef::ModelRecipe &model_recipe)
       if (symbol_table.find(name) != symbol_table.end())
         return symbol_table.at(name);
       else if (name == "")
-        return -1;
+        return -1; // -1 in Circle means that optional input tensor is empty.
       else
         throw std::runtime_error("circlechef : input not found in main graph");
     };
@@ -600,7 +600,7 @@ GeneratedModel cook(const ::circlechef::ModelRecipe &model_recipe)
       if (symbol_table.find(name) != symbol_table.end())
         return symbol_table.at(name);
       else if (name == "")
-        return -1;
+        return -1; // -1 in Circle means that optional input tensor is empty.
       else
         throw std::runtime_error("circlechef : input not found in subgraph");
     };

--- a/compiler/circlechef/core/src/ModelChef.cpp
+++ b/compiler/circlechef/core/src/ModelChef.cpp
@@ -348,7 +348,14 @@ GeneratedModel cook(const ::circlechef::ModelRecipe &model_recipe)
     // Tensor Name -> Tensor ID mapping (per Graph)
     std::map<std::string, int32_t> symbol_table;
 
-    auto lookup = [&symbol_table](const std::string &name) { return symbol_table.at(name); };
+    auto lookup = [&symbol_table](const std::string &name) {
+      if (symbol_table.find(name) != symbol_table.end())
+        return symbol_table.at(name);
+      else if (name == "")
+        return -1;
+      else
+        throw std::runtime_error("circlechef : input not found in main graph");
+    };
 
     int32_t buffer_start = buffer_vec.size();
     int32_t buffer_index = 0;
@@ -589,7 +596,14 @@ GeneratedModel cook(const ::circlechef::ModelRecipe &model_recipe)
     // Tensor Name -> Tensor ID mapping (per Graph)
     std::map<std::string, int32_t> symbol_table;
 
-    auto lookup = [&symbol_table](const std::string &name) { return symbol_table.at(name); };
+    auto lookup = [&symbol_table](const std::string &name) {
+      if (symbol_table.find(name) != symbol_table.end())
+        return symbol_table.at(name);
+      else if (name == "")
+        return -1;
+      else
+        throw std::runtime_error("circlechef : input not found in subgraph");
+    };
 
     const auto &graph = model_recipe.graph(g);
 


### PR DESCRIPTION
Parent Issue : #2734
Full Draft : #2737

Until now, there is no way to express optional input tensor explicitly in `circlechef`.
This commit will make it possible.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>