### PR TITLE
[onert] Release constant tensor when ruy kernel runs on cpu

### DIFF
--- a/runtime/onert/backend/cpu/ops/FullyConnectedLayer.cc
+++ b/runtime/onert/backend/cpu/ops/FullyConnectedLayer.cc
@@ -111,7 +111,7 @@ void FullyConnectedLayer::fullyConnectedHybrid()
       getTensorShape(_bias), reinterpret_cast<const float *>(_bias ? _bias->buffer() : nullptr),
       getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()), temp_arena);
 
-  if (_cached_weights == nullptr || _freed_weights)
+  if (_cached_weights == nullptr || _is_weights_freed)
     return;
 
   auto weight_tensor = dynamic_cast<const Tensor *>(_weights);
@@ -121,7 +121,7 @@ void FullyConnectedLayer::fullyConnectedHybrid()
     tensor->decrease_ref();
     if (tensor->buffer() == nullptr) // ref == 0?
     {
-      _freed_weights = true;
+      _is_weights_freed = true;
     }
   }
 #endif

--- a/runtime/onert/backend/cpu/ops/FullyConnectedLayer.cc
+++ b/runtime/onert/backend/cpu/ops/FullyConnectedLayer.cc
@@ -101,36 +101,43 @@ void FullyConnectedLayer::fullyConnectedHybrid()
       getTensorShape(_weights), reinterpret_cast<const int8_t *>(_weights->buffer()),
       getTensorShape(_bias), reinterpret_cast<const float *>(_bias ? _bias->buffer() : nullptr),
       getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()), temp_arena);
-
 #ifdef USE_RUY_GEMV
   // very dependent on ruy
   if (_freed_weights)
     return;
 
   const int rows = getTensorShape(_weights).Dims(0);
-  if (rows % 4 == 0)
+  if (rows % 4 != 0)
   {
-    const int total_input_size = getTensorShape(_input).FlatSize();
-    const int input_size = getTensorShape(_weights).Dims(1);
-    const int batch_size = total_input_size / input_size;
-    if (batch_size <= 4)
-    {
-      // TODO Remove const_cast
-      auto weight_tensor = dynamic_cast<const Tensor *>(_weights);
-      if (weight_tensor)
-      {
-        // TODO Remove this workaround
-        // buffer will have deallocated memory address because ruy kernel uses
-        // it as cache key
-        auto tensor = const_cast<Tensor *>(weight_tensor);
-        auto buffer = tensor->buffer();
-        tensor->decrease_ref();
-        tensor->setBuffer(buffer);
-      }
-    }
+    _freed_weights = true;
+    return;
   }
 
-  _freed_weights = true;
+  const int total_input_size = getTensorShape(_input).FlatSize();
+  const int input_size = getTensorShape(_weights).Dims(1);
+  const int batch_size = total_input_size / input_size;
+  if (batch_size > 4)
+  {
+    _freed_weights = true;
+    return;
+  }
+
+  // TODO Remove const_cast
+  auto weight_tensor = dynamic_cast<const Tensor *>(_weights);
+  if (weight_tensor)
+  {
+    // TODO Remove this workaround
+    // buffer will have deallocated memory address because ruy kernel uses
+    // it as cache key
+    auto tensor = const_cast<Tensor *>(weight_tensor);
+    auto buffer = tensor->buffer();
+    tensor->decrease_ref();
+    if (tensor->buffer() == nullptr) // ref == 0?
+    {
+      tensor->setBuffer(buffer);
+      _freed_weights = true;
+    }
+  }
 #endif
 }
 

--- a/runtime/onert/backend/cpu/ops/FullyConnectedLayer.h
+++ b/runtime/onert/backend/cpu/ops/FullyConnectedLayer.h
@@ -57,6 +57,8 @@ public:
 
   void run();
 
+  void prepare() override;
+
 private:
   const IPortableTensor *_input;
   const IPortableTensor *_weights;
@@ -67,7 +69,8 @@ private:
   std::unique_ptr<nnfw::cker::FCTempArena> _temp_arena;
 
 #ifdef USE_RUY_GEMV
-  bool _freed_weights = false;
+  bool _freed_weights = false;        // weights is already freed?
+  uint8_t *_cached_weights = nullptr; // weights to be cached and a key
 #endif
 };
 

--- a/runtime/onert/backend/cpu/ops/FullyConnectedLayer.h
+++ b/runtime/onert/backend/cpu/ops/FullyConnectedLayer.h
@@ -69,7 +69,7 @@ private:
   std::unique_ptr<nnfw::cker::FCTempArena> _temp_arena;
 
 #ifdef USE_RUY_GEMV
-  bool _freed_weights = false;        // weights is already freed?
+  bool _is_weights_freed = false;     // weights is already freed?
   uint8_t *_cached_weights = nullptr; // weights to be cached and a key
 #endif
 };

--- a/runtime/onert/backend/cpu/ops/FullyConnectedLayer.h
+++ b/runtime/onert/backend/cpu/ops/FullyConnectedLayer.h
@@ -65,6 +65,10 @@ private:
 
   ir::Activation _activation;
   std::unique_ptr<nnfw::cker::FCTempArena> _temp_arena;
+
+#ifdef USE_RUY_GEMV
+  bool _freed_weights = false;
+#endif
 };
 
 } // namespace ops


### PR DESCRIPTION
Release constant tensor(weight) after ruy kernel runs on cpu if possible
- if batch size <= 4, ruy kernel caches the weight so that we can
release the weight.

ONE-DCO-1.0-Signed-off-by: Yongseop Kim <yons.kim@samsung.com>