### PR TITLE
[mio-tflite] Use TFSource 2.3.0-rc0

### DIFF
--- a/compiler/mio-tflite/CMakeLists.txt
+++ b/compiler/mio-tflite/CMakeLists.txt
@@ -5,19 +5,18 @@ if(NOT FlatBuffers_FOUND)
 endif(NOT FlatBuffers_FOUND)
 
 # TODO recover official release version
-# nnas_find_package(TensorFlowSource EXACT 2.2.0 QUIET)
-#
-# if(NOT TensorFlowSource_FOUND)
-#   return()
-# endif(NOT TensorFlowSource_FOUND)
+# NOTE we cannot use version number like "2.3.0-rc0" for find_package()
+#      use TensorFlowSource-2.3.0-rc0 as config itself
+# nnas_find_package(TensorFlowSource EXACT 2.3.0 QUIET)
+nnas_find_package(TensorFlowSource-2.3.0-rc0 QUIET)
+
+if(NOT TensorFlowSource_FOUND)
+  return()
+endif(NOT TensorFlowSource_FOUND)
 
 message(STATUS "Build mio-tflite: TRUE")
 
-# TODO recover official release verison
-# set(SCHEMA_FILE "${TensorFlowSource_DIR}/tensorflow/lite/schema/schema.fbs")
-set(TFL_SCHEMA_PATH "${NNAS_PROJECT_SOURCE_DIR}/res/TensorFlowLiteSchema")
-set(TFL_SPECIFIC_HASH "e5023a1738cce7efcdf9d87863b85c80ab2f8c9e")
-set(SCHEMA_FILE "${TFL_SCHEMA_PATH}/${TFL_SPECIFIC_HASH}/schema.fbs")
+set(SCHEMA_FILE "${TensorFlowSource_DIR}/tensorflow/lite/schema/schema.fbs")
 
 # NOTE Use copy of schema.fbs as to provide unified way for circle also
 add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/schema.fbs"


### PR DESCRIPTION
This will revise mio-tflite to use TensorFlow source version 2.3.0-rc0

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>