### PR TITLE
[onert] OneHot will store depth and on/off value in input tensor

### DIFF
--- a/compute/ARMComputeEx/arm_compute/core/CPP/kernels/CPPOneHotKernelEx.h
+++ b/compute/ARMComputeEx/arm_compute/core/CPP/kernels/CPPOneHotKernelEx.h
@@ -68,28 +68,28 @@ public:
   /** Set the input and output of the kernel.
    *
    * @param[in]  indices     A tensor for indices. Data types supported: S32
+   * @param[in]  depth       A tensor for depth. Data types supported: S32
+   * @param[in]  on_value    A tensor for on_value. Data types supported: F32
+   * @param[in]  off_value   A tensor for off_value. Data types supported: F32*
    * @param[out] output      A tensor for computed value of one hot operator
-   * @param[in]  depth       An int value for depth
-   * @param[in]  on_value    A float value for on_value
-   * @param[in]  off_value   A float value for off_value
    * @param[in]  axis        An int value for axis
    */
-  void configure(const ITensor *indices, ITensor *output, const int depth, const float on_value,
-                 const float off_value, const int axis);
+  void configure(const ITensor *indices, const ITensor *depth, const ITensor *on_value,
+                 const ITensor *off_value, ITensor *output, const int axis);
 
   /** Static function to check if given info will lead to a valid configuration of @ref
    * CPPOneHotKernelEx
    *
    * @param[in]  indices     A tensor for indices. Data types supported: S32
-   * @param[in]  depth       An int value for depth
-   * @param[in]  on_value    A float value for on_value
-   * @param[in]  off_value   A float value for off_value
+   * @param[in]  depth       A tensor for depth. Data types supported: S32
+   * @param[in]  on_value    A tensor for on_value. Data types supported: F32
+   * @param[in]  off_value   A tensor for off_value. Data types supported: F32*
    * @param[in]  axis        An int value for axis
    *
    * @return a status
    */
-  static Status validate(const ITensor *indices, const int depth, const float on_value,
-                         const float off_value, const int axis);
+  static Status validate(const ITensor *indices, const ITensor *depth, const ITensor *on_value,
+                         const ITensor *off_value, const int axis);
 
   // Inherited methods overridden:
   void run(const Window &window, const ThreadInfo &info) override;
@@ -100,10 +100,10 @@ private:
   template <typename T> void run_one_hot();
 
   const ITensor *_indices;
+  const ITensor *_depth;
+  const ITensor *_on_value;
+  const ITensor *_off_value;
   ITensor *_output;
-  int _depth;
-  float _on_value;
-  float _off_value;
   int _axis;
 };
 } // namespace arm_compute

--- a/compute/ARMComputeEx/arm_compute/runtime/CPP/functions/CPPOneHotEx.h
+++ b/compute/ARMComputeEx/arm_compute/runtime/CPP/functions/CPPOneHotEx.h
@@ -55,14 +55,14 @@ public:
   /** Configure the one_hot function
    *
    * @param[in]  indices     A tensor for indices. Data types supported: S32
+   * @param[in]  depth       A tensor for depth. Data types supported: S32
+   * @param[in]  on_value    A tensor for on_value. Data types supported: F32
+   * @param[in]  off_value   A tensor for off_value. Data types supported: F32
    * @param[out] output      A tensor for computed value of one hot operator
-   * @param[in]  depth       An int value for depth
-   * @param[in]  on_value    A float value for on_value
-   * @param[in]  off_value   A float value for off_value
    * @param[in]  axis        An int value for axis
    */
-  void configure(const ITensor *indices, ITensor *output, const int depth, const float on_value,
-                 const float off_value, const int axis);
+  void configure(const ITensor *indices, const ITensor *depth, const ITensor *on_value,
+                 const ITensor *off_value, ITensor *output, const int axis);
 };
 }
 #endif /* __ARM_COMPUTE_CPPONEHOT_EX_H__ */

--- a/compute/ARMComputeEx/src/runtime/CPP/functions/CPPOneHotEx.cpp
+++ b/compute/ARMComputeEx/src/runtime/CPP/functions/CPPOneHotEx.cpp
@@ -45,10 +45,10 @@
 
 using namespace arm_compute;
 
-void CPPOneHotEx::configure(const ITensor *indices, ITensor *output, const int depth,
-                            const float on_value, const float off_value, const int axis)
+void CPPOneHotEx::configure(const ITensor *indices, const ITensor *depth, const ITensor *on_value,
+                            const ITensor *off_value, ITensor *output, const int axis)
 {
   auto k = arm_compute::support::cpp14::make_unique<CPPOneHotKernelEx>();
-  k->configure(indices, output, depth, on_value, off_value, axis);
+  k->configure(indices, depth, on_value, off_value, output, axis);
   _kernel = std::move(k);
 }

--- a/runtime/libs/tflite/port/1.13.1/src/nnapi_delegate.cpp
+++ b/runtime/libs/tflite/port/1.13.1/src/nnapi_delegate.cpp
@@ -856,7 +856,6 @@ TfLiteStatus AddOpsAndParams(
         nn_op_type = ANEURALNETWORKS_ABS;
         break;
       case tflite::BuiltinOperator_ONE_HOT:
-        add_one_hot_tensor_inputs_as_scalar();
         add_one_hot_params(node.builtin_data);
         CHECK_NN(ANeuralNetworksModel_addOperationEx(
             nn_model, ANEURALNETWORKS_ONE_HOT_EX,

--- a/runtime/libs/tflite/port/1.13.1/src/nnapi_delegate_ex_AddOpsAndParams_lambda.inc
+++ b/runtime/libs/tflite/port/1.13.1/src/nnapi_delegate_ex_AddOpsAndParams_lambda.inc
@@ -147,23 +147,6 @@
       }
     };
 
-    auto add_one_hot_tensor_inputs_as_scalar = [subgraph, &node, &augmented_inputs,
-                                                &add_scalar_float32]() {
-      assert(augmented_inputs.size() == 4);
-      const auto on_value_idx = node.inputs->data[2];
-      const auto off_value_idx = node.inputs->data[3];
-      const auto on_value_tensor = subgraph->tensor(on_value_idx);
-      const auto off_value_tensor = subgraph->tensor(off_value_idx);
-      assert(on_value_tensor->type == kTfLiteFloat32);
-      assert(off_value_tensor->type == kTfLiteFloat32);
-      const auto on_value = *on_value_tensor->data.f;
-      const auto off_value = *off_value_tensor->data.f;
-      augmented_inputs.pop_back();
-      augmented_inputs.pop_back();
-      add_scalar_float32(on_value);
-      add_scalar_float32(off_value);
-    };
-
     auto add_one_hot_params = [&add_scalar_int32](void* data) {
       const auto* builtin = reinterpret_cast<TfLiteOneHotParams*>(data);
       add_scalar_int32(builtin->axis);

--- a/runtime/nnapi-header/include/NeuralNetworksEx.h
+++ b/runtime/nnapi-header/include/NeuralNetworksEx.h
@@ -334,11 +334,14 @@ typedef enum {
    *
    * Supported tensor rank: up to 4
    *
+   * Supported tensor type {@link OperandCode} for on_value and off_value:
+   * * {@link ANEURALNETWORKS_TENSOR_FLOAT32}
+   *
    * Inputs:
    * * 0: An {@link ANEURALNETWORKS_INT32} tensor, specifying the indices.
    * * 1: An {@link ANEURALNETWORKS_INT32} scalar, specifying the depth.
-   * * 2: A scalar, specifying the on_value.
-   * * 3: A scalar, specifying the off_value.
+   * * 2: A tensor, specifying the on_value.
+   * * 3: A tensor, specifying the off_value.
    * * 4: An {@link ANEURALNETWORKS_INT32} scalar, specifying the axis to fill. Optional.
    *      (default: -1, a new inner-most axis).
    *

--- a/runtime/onert/backend/acl_neon/KernelGenerator.cc
+++ b/runtime/onert/backend/acl_neon/KernelGenerator.cc
@@ -2016,17 +2016,20 @@ void KernelGenerator::visit(const ir::operation::OneHot &node)
 {
   const auto out_idx{node.getOutputs().at(0)};
   const auto indices_idx{node.getInputs().at(ir::operation::OneHot::Input::INDICES)};
-  const auto depth = node.param().depth;
-  const auto on_value = node.param().on_value;
-  const auto off_value = node.param().off_value;
+  const auto depth_idx{node.getInputs().at(ir::operation::OneHot::Input::DEPTH)};
+  const auto onvalue_idx{node.getInputs().at(ir::operation::OneHot::Input::ON_VALUE)};
+  const auto offvalue_idx{node.getInputs().at(ir::operation::OneHot::Input::OFF_VALUE)};
   const auto axis = node.param().axis;
 
   auto output_tensor = _tensor_builder->at(out_idx).get();
   auto indices_tensor = _tensor_builder->at(indices_idx).get();
+  auto depth_tensor = _tensor_builder->at(depth_idx).get();
+  auto onvalue_tensor = _tensor_builder->at(onvalue_idx).get();
+  auto offvalue_tensor = _tensor_builder->at(offvalue_idx).get();
 
   auto fn = std::make_unique<::arm_compute::CPPOneHotEx>();
-  fn->configure(indices_tensor->handle(), output_tensor->handle(), depth, on_value, off_value,
-                axis);
+  fn->configure(indices_tensor->handle(), depth_tensor->handle(), onvalue_tensor->handle(),
+                offvalue_tensor->handle(), output_tensor->handle(), axis);
   auto acl_fn = asAclFunction(std::move(fn));
   _return_fn = std::move(acl_fn);
 }

--- a/runtime/onert/backend/cpu/KernelGenerator.cc
+++ b/runtime/onert/backend/cpu/KernelGenerator.cc
@@ -535,21 +535,24 @@ void KernelGenerator::visit(const ir::operation::OneHot &node)
 {
   const auto output_index{node.getOutputs().at(0)};
   const auto indices_index{node.getInputs().at(ir::operation::OneHot::INDICES)};
+  const auto depth_index{node.getInputs().at(ir::operation::OneHot::Input::DEPTH)};
+  const auto onvalue_index{node.getInputs().at(ir::operation::OneHot::Input::ON_VALUE)};
+  const auto offvalue_index{node.getInputs().at(ir::operation::OneHot::Input::OFF_VALUE)};
 
-  const auto depth = node.param().depth;
-  const auto on_value = node.param().on_value;
-  const auto off_value = node.param().off_value;
   const auto axis = node.param().axis;
 
   auto output_alloc = _tensor_builder->portableAt(output_index).get();
   auto indices_alloc = _tensor_builder->portableAt(indices_index).get();
+  auto depth_alloc = _tensor_builder->portableAt(depth_index).get();
+  auto onvalue_alloc = _tensor_builder->portableAt(onvalue_index).get();
+  auto offvalue_alloc = _tensor_builder->portableAt(offvalue_index).get();
 
   assert(indices_alloc->data_type() == OperandType::INT32);
   assert(axis <= static_cast<int>(indices_alloc->num_dimensions()));
 
   auto fn = std::make_unique<ops::OneHotLayer>();
 
-  fn->configure(indices_alloc, output_alloc, depth, on_value, off_value, axis);
+  fn->configure(indices_alloc, depth_alloc, onvalue_alloc, offvalue_alloc, output_alloc, axis);
 
   _return_fn = std::move(fn);
 }

--- a/runtime/onert/backend/cpu/ops/OneHotLayer.cc
+++ b/runtime/onert/backend/cpu/ops/OneHotLayer.cc
@@ -29,18 +29,19 @@ namespace cpu
 namespace ops
 {
 
-void OneHotLayer::oneHotFloat32()
+template <typename T> void OneHotLayer::oneHotImpl()
 {
-  nnfw::cker::OneHot<float, int32_t>(_depth, _on_value, _off_value, _axis, getTensorShape(_indices),
-                                     reinterpret_cast<const int32_t *>(_indices->buffer()),
-                                     getTensorShape(_output),
-                                     reinterpret_cast<float *>(_output->buffer()));
+  // It assumes index is int32_t type.
+  nnfw::cker::OneHot<T, int32_t>(
+      *reinterpret_cast<const int32_t *>(_depth->buffer()),
+      *reinterpret_cast<T *>(_on_value->buffer()), *reinterpret_cast<T *>(_off_value->buffer()),
+      _axis, getTensorShape(_indices), reinterpret_cast<const int32_t *>(_indices->buffer()),
+      getTensorShape(_output), reinterpret_cast<T *>(_output->buffer()));
 }
 
-void OneHotLayer::oneHotQuant8() { throw std::runtime_error{"OneHot NYI for quantized"}; }
-
-void OneHotLayer::configure(const IPortableTensor *indices, IPortableTensor *output, int32_t depth,
-                            float on_value, float off_value, int32_t axis)
+void OneHotLayer::configure(const IPortableTensor *indices, const IPortableTensor *depth,
+                            const IPortableTensor *on_value, const IPortableTensor *off_value,
+                            IPortableTensor *output, const int32_t axis)
 {
   _indices = indices;
   _output = output;
@@ -54,11 +55,7 @@ void OneHotLayer::run()
 {
   if (_output->data_type() == OperandType::FLOAT32)
   {
-    oneHotFloat32();
-  }
-  else if (_output->data_type() == OperandType::QUANT_UINT8_ASYMM)
-  {
-    oneHotQuant8();
+    oneHotImpl<float>();
   }
   else
   {

--- a/runtime/onert/backend/cpu/ops/OneHotLayer.h
+++ b/runtime/onert/backend/cpu/ops/OneHotLayer.h
@@ -34,28 +34,28 @@ class OneHotLayer : public ::onert::exec::IFunction
 {
 public:
   OneHotLayer()
-      : _indices(nullptr), _output(nullptr), _depth(0), _on_value(1), _off_value(0), _axis(-1)
+      : _indices(nullptr), _depth(nullptr), _on_value(nullptr), _off_value(nullptr),
+        _output(nullptr), _axis(-1)
   {
     // DO NOTHING
   }
 
 public:
-  void oneHotFloat32();
+  template <typename T> void oneHotImpl();
 
-  void oneHotQuant8();
-
-  void configure(const IPortableTensor *indices, IPortableTensor *output, int32_t depth,
-                 float on_value, float off_value, int32_t axis);
+  void configure(const IPortableTensor *indices, const IPortableTensor *depth,
+                 const IPortableTensor *on_value, const IPortableTensor *off_value,
+                 IPortableTensor *output, int32_t axis);
 
   void run();
 
 private:
   const IPortableTensor *_indices;
+  const IPortableTensor *_depth;
+  const IPortableTensor *_on_value;
+  const IPortableTensor *_off_value;
   IPortableTensor *_output;
 
-  int32_t _depth;
-  float _on_value;
-  float _off_value;
   int32_t _axis;
 };
 

--- a/runtime/onert/core/include/ir/operation/OneHot.h
+++ b/runtime/onert/core/include/ir/operation/OneHot.h
@@ -39,9 +39,6 @@ public:
 
   struct Param
   {
-    int depth;       // comes from input tensor, not from OneHotOptions
-    float on_value;  // comes from input tensor, not from OneHotOptions
-    float off_value; // comes from input tensor, not from OneHotOptions
     int axis;
   };
 

--- a/runtime/onert/frontend/base_loader/include/base_loader.h
+++ b/runtime/onert/frontend/base_loader/include/base_loader.h
@@ -1537,30 +1537,13 @@ void BaseLoader<LoaderDomain, SpecificLoader>::loadOneHot(const Operator *op, ir
   if (op->inputs()->size() != 4 || op->outputs()->size() != 1)
     throw std::runtime_error("OneHot Op has wrong number of input or output tensors.");
 
-  enum
-  {
-    INDICES = 0,
-    DEPTH = 1,
-    ON_VALUE = 2,
-    OFF_VALUE = 3,
-  };
-
   // Set input and output tensors
   ir::OperandIndexSequence inputs, outputs;
-  inputs.append(tensorIdxToOperandIdx(op->inputs()->Get(INDICES)));
-  outputs.append(tensorIdxToOperandIdx(op->outputs()->Get(0)));
+  loadOperationIO(op, inputs, outputs);
 
-  // Set parameters
-  // depth, on_value and off_value are scalar though it is passed as inputs
-  auto depth_opidx = tensorIdxToOperandIdx(op->inputs()->Get(DEPTH));
-  auto on_value_opidx = tensorIdxToOperandIdx(op->inputs()->Get(ON_VALUE));
-  auto off_value_opidx = tensorIdxToOperandIdx(op->inputs()->Get(OFF_VALUE));
-  const auto depth = subg.operands().at(depth_opidx).template asScalar<int>();
-  const auto on_value = subg.operands().at(on_value_opidx).template asScalar<float>();
-  const auto off_value = subg.operands().at(off_value_opidx).template asScalar<float>();
+  // Set parameter
   const auto axis = op->builtin_options_as_OneHotOptions()->axis();
-  std::unique_ptr<ir::Operation> new_op(
-      new ir::operation::OneHot(inputs, outputs, {depth, on_value, off_value, axis}));
+  std::unique_ptr<ir::Operation> new_op(new ir::operation::OneHot(inputs, outputs, {axis}));
   subg.addOperation(std::move(new_op));
 }
 

--- a/runtime/onert/frontend/nnapi/wrapper/OperationFactory.cc
+++ b/runtime/onert/frontend/nnapi/wrapper/OperationFactory.cc
@@ -1945,17 +1945,18 @@ OperationFactory::OperationFactory()
     // Each input should be interpreted as follows:
     //
     // 0 -> indices tensor
-    // 1 -> depth scalar
-    // 2 -> on_value scalar
-    // 3 -> off_value scalar
+    // 1 -> depth tensor
+    // 2 -> on_value tensor
+    // 3 -> off_value tensor
     // 4 -> axis scalar
-    OperandIndexSequence inputs{init_param.inputs[0]};
+    OperandIndexSequence inputs;
+    for (uint32_t n = 0; n < init_param.input_count - 1; ++n)
+    {
+      inputs.append(OperandIndex{init_param.inputs[n]});
+    }
     OperandIndexSequence outputs{init_param.outputs[0]};
 
     operation::OneHot::Param param;
-    param.depth = operands.at(OperandIndex{init_param.inputs[1]}).asScalar<std::int32_t>();
-    param.on_value = operands.at(OperandIndex{init_param.inputs[2]}).asScalar<float>();
-    param.off_value = operands.at(OperandIndex{init_param.inputs[3]}).asScalar<float>();
     param.axis = operands.at(OperandIndex{init_param.inputs[4]}).asScalar<std::int32_t>();
 
     return new operation::OneHot{inputs, outputs, param};

--- a/tests/nnapi/specs/Ex/one_hot_ex_dynamic_nnfw.mod.py
+++ b/tests/nnapi/specs/Ex/one_hot_ex_dynamic_nnfw.mod.py
@@ -27,9 +27,10 @@ model = Model()
 indice_shape = [2, 2]
 indice_input = [1, 2, 0, 2]
 
-depth = Int32Scalar("depth", 3)
-onvalue = Float32Scalar("on", 1.) # default value is 1.
-offvalue = Float32Scalar("off", 0.) # default value is 0.
+depth = Input("depth", "TENSOR_INT32", "{1}")
+onvalue = Input("onvalue", "TENSOR_FLOAT32", "{1}")
+offvalue = Input("offvalue", "TENSOR_FLOAT32", "{1}")
+
 axis0 = Int32Scalar("axis", -1) # default value is -1.
 model_output0 = Output("output", "TENSOR_FLOAT32", "{2, 2, 3}")
 
@@ -43,10 +44,17 @@ model_output_data = ([0., 1., 0.,
                       1., 0., 0.,
                       0., 0., 1.,])
 
+depth_data = [3]
+onvalue_data = [1.]
+offvalue_data = [0.]
+
 Example(
   {
     dynamic_layer.getModelInput() : indice_input,
     dynamic_layer.getShapeInput() : indice_shape,
+    depth : depth_data,
+    onvalue : onvalue_data,
+    offvalue : offvalue_data,
 
     model_output0 : model_output_data,
   })


### PR DESCRIPTION
OneHot had stored depth and on/off value in param.
It works for constant float input.
However, it need to be updated to cover those cases:

- other data types like int32, quantized 8bit
- depth and on/off values is determined at runtime

Thus, it will save depth and on/off value as input tensor like tflite does.

It includes the change in NeuralNetworksEx.h.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>