### PR TITLE
Remove PARALLEL_BUILD option

### DIFF
--- a/Makefile.template
+++ b/Makefile.template
@@ -4,7 +4,6 @@ BUILD_TYPE?=Debug
 CROSS_BUILD?=0
 HOST_OS?=linux
 TARGET_OS?=linux
-PARALLEL_BUILD?=1
 COVERAGE_BUILD?=0
 BENCHMARK_ACL_BUILD?=0
 OPTIONS?=
@@ -78,13 +77,6 @@ ifneq ($(ANDROID_BOOST_ROOT),)
   OPTIONS+= -DANDROID_BOOST_ROOT=$(ANDROID_BOOST_ROOT)
 endif
 
-ifeq ($(PARALLEL_BUILD),1)
-	# Get number of processors (linux only for now)
-	ifeq ($(HOST_OS),linux)
-		NPROCS?=$(shell grep -c ^processor /proc/cpuinfo)
-	endif
-endif
-
 NPROCS?=1
 WORKHOME=$(CURDIR)/Product
 WORKFOLDER=$(TARGET_ARCH_LC)-$(TARGET_OS).$(BUILD_TYPE_LC)
@@ -140,7 +132,7 @@ endif
 	touch $(TIMESTAMP_CONFIGURE)
 
 build_internal: $(BUILD_FOLDER)
-	NNFW_WORKSPACE="$(WORKSPACE)" NPROCS="$(NPROCS)" PARALLEL_BUILD="$(PARALLEL_BUILD)" ./nnfw build
+	NNFW_WORKSPACE="$(WORKSPACE)" NPROCS="$(NPROCS)" ./nnfw build
 	rm -rf $(BUILD_ALIAS)
 	ln -s $(BUILD_FOLDER) $(BUILD_ALIAS)
 	touch $(TIMESTAMP_BUILD)

--- a/infra/nnfw/command/build
+++ b/infra/nnfw/command/build
@@ -11,14 +11,6 @@ fi
 # TODO Use argument instead of environment variable
 HOST_OS=${HOST_OS:-linux}
 NPROCS=${NPROCS:-1}
-PARALLEL_BUILD=${PARALLEL_BUILD:-1}
-
-if [ "${PARALLEL_BUILD}" == "1" ]; then
-  # Get number of processors (linux only for now)
-  if [ "${HOST_OS}" == "linux" ]; then
-    NPROCS="$(grep -c ^processor /proc/cpuinfo)"
-  fi
-fi
 
 cd ${BUILD_PATH}
 make -j ${NPROCS} "$@"


### PR DESCRIPTION
This commit removes `PARALLEL_BUILD` option. `NPROCS` option is explicit
and enough to adjust build parallelism.

ONE-DCO-1.0-Signed-off-by: Cheongyo Bahk <ch.bahk@samsung.com>

---

From discussion on #2725 