### PR TITLE
[gen_golden] cast to float32 for float32 input

### DIFF
--- a/tools/nnpackage_tool/gen_golden/gen_golden.py
+++ b/tools/nnpackage_tool/gen_golden/gen_golden.py
@@ -92,7 +92,8 @@ if __name__ == '__main__':
                 input_values.append(
                     np.array(np.random.randint(0, 255, this_shape, this_dtype)))
             elif this_dtype == np.float32:
-                input_values.append(np.array(np.random.random_sample(this_shape)))
+                input_values.append(
+                    np.random.random_sample(this_shape).astype(np.float32))
             elif this_dtype == np.bool_:
                 # generate random integer from [0, 2)
                 input_values.append(
@@ -136,7 +137,8 @@ if __name__ == '__main__':
                 input_values.append(
                     np.array(np.random.randint(0, 255, this_shape, this_dtype)))
             elif this_dtype == np.float32:
-                input_values.append(np.array(np.random.random_sample(this_shape)))
+                input_values.append(
+                    np.random.random_sample(this_shape).astype(np.float32))
             elif this_dtype == np.bool_:
                 # generate random integer from [0, 2)
                 input_values.append(


### PR DESCRIPTION
As np.random.random_sample() generates float64 type array,
it it necessary to cast to `float32`.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>