### PR TITLE
[luci-interpreter] Test quantized Pad kernels for ResNet-v1

### DIFF
--- a/compiler/luci-interpreter/src/kernels/Pad.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/Pad.test.cpp
@@ -26,8 +26,7 @@ namespace
 
 using namespace testing;
 
-// for quantized Add, the error shouldn't exceed step
-float GetTolerance(int min, int max) { return (max - min) / 255.0; }
+float GetTolerance(float min, float max) { return (max - min) / 255.0; }
 
 TEST(Pad, Uint8)
 {


### PR DESCRIPTION
Parent Issue: #2730 
Draft PR: #2720

This commit update `Pad` operator test case.

ONE-DCO-1.0-Signed-off-by: KiDeuk Bang <rrstrous@nate.com>