### PR TITLE
[onert] Fix getReducerAxes bug

### DIFF
--- a/runtime/onert/backend/cpu/ops/OperationUtils.cc
+++ b/runtime/onert/backend/cpu/ops/OperationUtils.cc
@@ -244,13 +244,13 @@ std::vector<int32_t> getReducerAxes(const IPortableTensor *axes)
     case ir::DataType::INT32:
     {
       for (size_t i = 0; i < axes->dimension(0); ++i)
-        ret.emplace_back(*reinterpret_cast<const int32_t *>(axes->buffer()) + i);
+        ret.emplace_back(*(reinterpret_cast<const int32_t *>(axes->buffer()) + i));
       break;
     }
     case ir::DataType::INT64:
     {
       for (size_t i = 0; i < axes->dimension(0); ++i)
-        ret.emplace_back(*reinterpret_cast<const int64_t *>(axes->buffer()) + i);
+        ret.emplace_back(*(reinterpret_cast<const int64_t *>(axes->buffer()) + i));
       break;
     }
     default:


### PR DESCRIPTION
getReducerAxes return invalid vector because of pointer operation bug

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>