### PR TITLE
[onert] Introduce sequence_index cache to optimize findOperation

### DIFF
--- a/runtime/onert/core/include/ir/OpSequence.h
+++ b/runtime/onert/core/include/ir/OpSequence.h
@@ -66,15 +66,14 @@ public:
 public:
   void remove(const OperationIndex &index);
 
+  bool exist(const OperationIndex &index) const;
+
 public:
   Layout getLayout() const { return _layout; }
 
 public:
   std::vector<OperationIndex>::const_iterator begin() const { return _operations.begin(); }
   std::vector<OperationIndex>::const_iterator end() const { return _operations.end(); }
-
-private:
-  bool exist(const OperationIndex &index) const;
 
 private:
   OperandIndexSequence _inputs;

--- a/runtime/onert/core/include/ir/OpSequences.h
+++ b/runtime/onert/core/include/ir/OpSequences.h
@@ -48,7 +48,6 @@ public:
    * @return OpSequenceIndex
    */
   OpSequenceIndex emplace(std::unique_ptr<OpSequence> &&op_seq);
-
   /**
    * @brief Check if an operation does exist in any OpSequences
    *
@@ -78,7 +77,11 @@ public:
   void removeFromOpSequence(const OperationIndex &operation_index);
 
 private:
+  void cacheSequenceIndex(const OpSequenceIndex &seq_index, const OperationIndex &op_index) const;
+  OpSequenceIndex *findSequenceIndex(const OperationIndex &operation_index) const;
+
   OpSequenceIndex findOperation(const OperationIndex &operation_index) const;
+  mutable std::unordered_map<OperationIndex, OpSequenceIndex> _seq_indexes;
 };
 
 } // namespace ir


### PR DESCRIPTION
- This commit introduces sequence_index cache (`_seq_indexes`) to optimize OpSequences::findOperation
  - `_seq_indexes` saves `OperationIndex` to `OpSequenceIndex` mapping
  - `_seq_indexes` is maintained during insertion, search, and removal of operations
  - `findOperation` returns OpSequenceIndex in constant time if entry is exist in `_seq_indexes`

ONE-DCO-1.0-Signed-off-by: JiHwan Yeo <jihwan.yeo@samsung.com>

---

Related issue : #2655