### PR TITLE
Append delay/sleep to runner between runs

### DIFF
--- a/runtime/libs/benchmark/include/benchmark/Phase.h
+++ b/runtime/libs/benchmark/include/benchmark/Phase.h
@@ -40,15 +40,10 @@ struct Phase
 
 struct PhaseOption
 {
-  PhaseOption() : memory(false), memory_gpu(false) {}
-  PhaseOption(bool m) : memory(m) {}
-  PhaseOption(bool m, int64_t ms) : memory(m), memory_gpu(false), memory_interval(ms) {}
-  PhaseOption(bool m, bool mg) : memory(m), memory_gpu(mg) {}
-  PhaseOption(bool m, bool mg, int64_t ms) : memory(m), memory_gpu(mg), memory_interval(ms) {}
-
   bool memory = false;
-  bool memory_gpu = false;     // very specific...
-  int64_t memory_interval = 5; // ms
+  bool memory_gpu = false; // very specific...
+  int run_delay = -1;      // ms
+  int memory_interval = 5; // ms
 };
 
 } // namespace benchmark

--- a/runtime/libs/benchmark/src/Phases.cpp
+++ b/runtime/libs/benchmark/src/Phases.cpp
@@ -17,8 +17,10 @@
 #include "benchmark/Phases.h"
 #include "benchmark/Types.h"
 
+#include <thread>
 #include <chrono>
 #include <cassert>
+#include <iostream>
 
 namespace
 {
@@ -36,7 +38,8 @@ namespace benchmark
 {
 
 Phases::Phases(const PhaseOption &option)
-    : _option(option), _mem_poll(std::chrono::milliseconds(5), option.memory_gpu)
+    : _option(option),
+      _mem_poll(std::chrono::milliseconds(option.memory_interval), option.memory_gpu)
 {
   // DO NOTHING
 }
@@ -72,6 +75,11 @@ void Phases::run(const std::string &tag, const PhaseFunc &exec, const PhaseFunc 
 
     if (post)
       (*post)(phase, i);
+
+    if (_option.run_delay > 0 && p == PhaseEnum::EXECUTE && i != loop_num - 1)
+    {
+      std::this_thread::sleep_for(std::chrono::milliseconds(_option.run_delay));
+    }
   }
 
   if (p == PhaseEnum::END_OF_PHASE)

--- a/tests/tools/nnpackage_run/src/args.cc
+++ b/tests/tools/nnpackage_run/src/args.cc
@@ -123,6 +123,7 @@ void Args::Initialize(void)
         "e.g. '[0, 40, 2, 80]' to set 0th tensor to 40 and 2nd tensor to 80.\n")
     ("num_runs,r", po::value<int>()->default_value(1), "The number of runs")
     ("warmup_runs,w", po::value<int>()->default_value(0), "The number of warmup runs")
+    ("run_delay,t", po::value<int>()->default_value(-1), "Delay time(ms) between runs (as default no delay")
     ("gpumem_poll,g", po::value<bool>()->default_value(false), "Check gpu memory polling separately")
     ("mem_poll,m", po::value<bool>()->default_value(false), "Check memory polling")
     ("write_report,p", po::value<bool>()->default_value(false),
@@ -247,6 +248,11 @@ void Args::Parse(const int argc, char **argv)
     if (vm.count("warmup_runs"))
     {
       _warmup_runs = vm["warmup_runs"].as<int>();
+    }
+
+    if (vm.count("run_delay"))
+    {
+      _run_delay = vm["run_delay"].as<int>();
     }
 
     if (vm.count("gpumem_poll"))

--- a/tests/tools/nnpackage_run/src/args.h
+++ b/tests/tools/nnpackage_run/src/args.h
@@ -42,6 +42,7 @@ public:
 #endif
   const int getNumRuns(void) const { return _num_runs; }
   const int getWarmupRuns(void) const { return _warmup_runs; }
+  const int getRunDelay(void) const { return _run_delay; }
   std::unordered_map<uint32_t, uint32_t> getOutputSizes(void) const { return _output_sizes; }
   const bool getGpuMemoryPoll(void) const { return _gpumem_poll; }
   const bool getMemoryPoll(void) const { return _mem_poll; }
@@ -67,6 +68,7 @@ private:
   TensorShapeMap _shape_run;
   int _num_runs;
   int _warmup_runs;
+  int _run_delay;
   std::unordered_map<uint32_t, uint32_t> _output_sizes;
   bool _gpumem_poll;
   bool _mem_poll;

--- a/tests/tools/nnpackage_run/src/nnpackage_run.cc
+++ b/tests/tools/nnpackage_run/src/nnpackage_run.cc
@@ -93,7 +93,8 @@ int main(const int argc, char **argv)
     ruy::profiler::ScopeProfile ruy_profile;
 #endif
 
-    benchmark::Phases phases(benchmark::PhaseOption{args.getMemoryPoll(), args.getGpuMemoryPoll()});
+    benchmark::Phases phases(
+        benchmark::PhaseOption{args.getMemoryPoll(), args.getGpuMemoryPoll(), args.getRunDelay()});
 
     nnfw_session *session = nullptr;
     NNPR_ENSURE_STATUS(nnfw_create_session(&session));

--- a/tests/tools/tflite_run/src/args.cc
+++ b/tests/tools/tflite_run/src/args.cc
@@ -52,6 +52,7 @@ void Args::Initialize(void)
     ("tflite", po::value<std::string>()->required())
     ("num_runs,r", po::value<int>()->default_value(1), "The number of runs")
     ("warmup_runs,w", po::value<int>()->default_value(0), "The number of warmup runs")
+    ("run_delay,t", po::value<int>()->default_value(-1), "Delay time(ms) between runs (as default no delay")
     ("gpumem_poll,g", po::value<bool>()->default_value(false), "Check gpu memory polling separately")
     ("mem_poll,m", po::value<bool>()->default_value(false), "Check memory polling")
     ("write_report,p", po::value<bool>()->default_value(false), "Write report")
@@ -162,6 +163,11 @@ void Args::Parse(const int argc, char **argv)
   if (vm.count("warmup_runs"))
   {
     _warmup_runs = vm["warmup_runs"].as<int>();
+  }
+
+  if (vm.count("run_delay"))
+  {
+    _run_delay = vm["run_delay"].as<int>();
   }
 
   if (vm.count("gpumem_poll"))

--- a/tests/tools/tflite_run/src/args.h
+++ b/tests/tools/tflite_run/src/args.h
@@ -38,6 +38,7 @@ public:
   const std::vector<int> &getInputShapes(void) const { return _input_shapes; }
   const int getNumRuns(void) const { return _num_runs; }
   const int getWarmupRuns(void) const { return _warmup_runs; }
+  const int getRunDelay(void) const { return _run_delay; }
   const bool getGpuMemoryPoll(void) const { return _gpumem_poll; }
   const bool getMemoryPoll(void) const { return _mem_poll; }
   const bool getWriteReport(void) const { return _write_report; }
@@ -58,6 +59,7 @@ private:
   std::vector<int> _input_shapes;
   int _num_runs;
   int _warmup_runs;
+  int _run_delay;
   bool _gpumem_poll;
   bool _mem_poll;
   bool _write_report;

--- a/tests/tools/tflite_run/src/tflite_run.cc
+++ b/tests/tools/tflite_run/src/tflite_run.cc
@@ -83,7 +83,8 @@ int main(const int argc, char **argv)
 
   std::chrono::milliseconds t_model_load(0), t_prepare(0);
 
-  benchmark::Phases phases(benchmark::PhaseOption{args.getMemoryPoll(), args.getGpuMemoryPoll()});
+  benchmark::Phases phases(
+      benchmark::PhaseOption{args.getMemoryPoll(), args.getGpuMemoryPoll(), args.getRunDelay()});
 
   std::unique_ptr<FlatBufferModel> model;
   std::unique_ptr<Interpreter> interpreter;

--- a/tests/tools/tflite_run_2_2_0/src/args.cc
+++ b/tests/tools/tflite_run_2_2_0/src/args.cc
@@ -52,6 +52,7 @@ void Args::Initialize(void)
     ("tflite", po::value<std::string>()->required())
     ("num_runs,r", po::value<int>()->default_value(1), "The number of runs")
     ("warmup_runs,w", po::value<int>()->default_value(0), "The number of warmup runs")
+    ("run_delay,t", po::value<int>()->default_value(-1), "Delay time(ms) between runs (as default no delay")
     ("gpumem_poll,g", po::value<bool>()->default_value(false), "Check gpu memory polling separately")
     ("mem_poll,m", po::value<bool>()->default_value(false), "Check memory polling")
     ("write_report,p", po::value<bool>()->default_value(false), "Write report")
@@ -162,6 +163,11 @@ void Args::Parse(const int argc, char **argv)
   if (vm.count("warmup_runs"))
   {
     _warmup_runs = vm["warmup_runs"].as<int>();
+  }
+
+  if (vm.count("run_delay"))
+  {
+    _run_delay = vm["run_delay"].as<int>();
   }
 
   if (vm.count("gpumem_poll"))

--- a/tests/tools/tflite_run_2_2_0/src/args.h
+++ b/tests/tools/tflite_run_2_2_0/src/args.h
@@ -38,6 +38,7 @@ public:
   const std::vector<int> &getInputShapes(void) const { return _input_shapes; }
   const int getNumRuns(void) const { return _num_runs; }
   const int getWarmupRuns(void) const { return _warmup_runs; }
+  const int getRunDelay(void) const { return _run_delay; }
   const bool getGpuMemoryPoll(void) const { return _gpumem_poll; }
   const bool getMemoryPoll(void) const { return _mem_poll; }
   const bool getWriteReport(void) const { return _write_report; }
@@ -58,6 +59,7 @@ private:
   std::vector<int> _input_shapes;
   int _num_runs;
   int _warmup_runs;
+  int _run_delay;
   bool _gpumem_poll;
   bool _mem_poll;
   bool _write_report;

--- a/tests/tools/tflite_run_2_2_0/src/tflite_run_2_2_0.cc
+++ b/tests/tools/tflite_run_2_2_0/src/tflite_run_2_2_0.cc
@@ -83,7 +83,8 @@ int main(const int argc, char **argv)
 
   std::chrono::milliseconds t_model_load(0), t_prepare(0);
 
-  benchmark::Phases phases(benchmark::PhaseOption{args.getMemoryPoll(), args.getGpuMemoryPoll()});
+  benchmark::Phases phases(
+      benchmark::PhaseOption{args.getMemoryPoll(), args.getGpuMemoryPoll(), args.getRunDelay()});
 
   std::unique_ptr<tflite::FlatBufferModel> model;
   std::unique_ptr<tflite::Interpreter> interpreter;


### PR DESCRIPTION
Append delay/sleep to nnpackage_run, tflite_run and tflite_run_2_2_0
between runs as ms units

ONE-DCO-1.0-Signed-off-by: Yongseop Kim <yons.kim@samsung.com>