### PR TITLE
[onert] Set OP_SEQ_MAX_NODE to 1 if RUY_PROFILER is enabled

### DIFF
--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -55,6 +55,9 @@ CompilerOptions fetchCompilerOptionsFromGlobalConfig(const ir::Subgraphs &subgs)
   options.he_profiling_mode = util::getConfigBool(util::config::PROFILING_MODE);
   options.disable_compile = util::getConfigBool(util::config::DISABLE_COMPILE);
   options.fp16_enable = util::getConfigBool(util::config::FP16_ENABLE);
+#ifdef RUY_PROFILER
+  options.op_seq_max_node = 1;
+#endif
 
   {
     // Backend for all


### PR DESCRIPTION
- This commit sets OP_SEQ_MAX_NODE to 1 if RUY_PROFILER is enabled
  - Ruy profiler prints correct result when OP_SEQ_MAX_NODE is set to 1
  - Otherwise, ruy profiler shows incorrect result

ONE-DCO-1.0-Signed-off-by: JiHwan Yeo <jihwan.yeo@samsung.com>