### PR TITLE
[DRAFT] Remove Source/Sink copies at execution begin/end

### DIFF
--- a/runtime/onert/backend/acl_common/AclTensorBuilder.h
+++ b/runtime/onert/backend/acl_common/AclTensorBuilder.h
@@ -63,6 +63,7 @@ public:
   void notifyLastUse(const ir::OperandIndex &) override;
 
   bool isRegistered(const ir::OperandIndex &) const override;
+  std::shared_ptr<backend::ITensorRegistry> tensorRegistry() override { return nullptr; }
 
   void prepare(void) override;
   void allocate() override;

--- a/runtime/onert/backend/cpu/TensorBuilder.cc
+++ b/runtime/onert/backend/cpu/TensorBuilder.cc
@@ -99,6 +99,12 @@ std::shared_ptr<IPortableTensor> TensorBuilder::portableAt(const ir::OperandInde
   return _tensor_reg->getPortableTensor(ind);
 }
 
+bool TensorBuilder::setExternalTensor(const ir::OperandIndex &ind,
+                                      const std::shared_ptr<IPortableTensor> &tensor)
+{
+  return _tensor_reg->setExternalTensor(ind, tensor);
+}
+
 void TensorBuilder::iterate(const IterateFunction &fn) { _static_tensor_mgr->iterate(fn); }
 
 std::shared_ptr<cpu_common::Tensor> TensorBuilder::at(const ir::OperandIndex &ind)

--- a/runtime/onert/backend/cpu/TensorBuilder.h
+++ b/runtime/onert/backend/cpu/TensorBuilder.h
@@ -82,6 +82,8 @@ public:
    */
   std::shared_ptr<cpu_common::Tensor> at(const ir::OperandIndex &ind);
   std::shared_ptr<IPortableTensor> portableAt(const ir::OperandIndex &ind);
+  bool setExternalTensor(const ir::OperandIndex &ind,
+                         const std::shared_ptr<IPortableTensor> &tensor) override;
 
   std::shared_ptr<ITensorRegistry> tensorRegistry() override { return _tensor_reg; }
 

--- a/runtime/onert/core/include/backend/ITensorBuilder.h
+++ b/runtime/onert/core/include/backend/ITensorBuilder.h
@@ -70,10 +70,7 @@ struct ITensorBuilder
    *
    * @note   Backend should implement this when it has StaticTensorManager and DynamicTensorManager
    */
-  virtual std::shared_ptr<backend::ITensorRegistry> tensorRegistry()
-  {
-    throw std::runtime_error("tensorRegistry(): NYI");
-  }
+  virtual std::shared_ptr<backend::ITensorRegistry> tensorRegistry() = 0;
 
 public: // methods for static tensor allocation
   /**
@@ -113,6 +110,18 @@ public: // methods for static tensor allocation
    * @return std::shared_ptr<ITensor> The tensor object
    */
   virtual std::shared_ptr<ITensor> tensorAt(const ir::OperandIndex &ind) = 0;
+
+  /**
+   * @brief Set the External Tensor object
+   *
+   * @return true if succeeded
+   * @return false if failed or unsupported
+   */
+  virtual bool setExternalTensor(const ir::OperandIndex &, const std::shared_ptr<IPortableTensor> &)
+  {
+    return false;
+  }
+
   /**
    * @brief Iterate over tensors
    *

--- a/runtime/onert/core/include/backend/ITensorRegistry.h
+++ b/runtime/onert/core/include/backend/ITensorRegistry.h
@@ -17,6 +17,8 @@
 #ifndef __ONERT_BACKEND_ITENSOR_REGISTRY__
 #define __ONERT_BACKEND_ITENSOR_REGISTRY__
 
+#include <memory>
+
 #include "ir/Index.h"
 #include "backend/ITensor.h"
 
@@ -37,6 +39,7 @@ struct ITensorRegistry
    * @note  Return tensor cannot be used longer than dynamic tensor manager
    */
   virtual std::shared_ptr<ITensor> getITensor(const ir::OperandIndex &) = 0;
+  virtual std::shared_ptr<ITensor> getManagedITensor(const ir::OperandIndex &) = 0;
 };
 
 } // namespace backend
@@ -70,6 +73,11 @@ public:
     return getManagedTensor(ind);
   }
 
+  std::shared_ptr<ITensor> getManagedITensor(const ir::OperandIndex &ind) override
+  {
+    return getManagedTensor(ind);
+  }
+
   std::shared_ptr<IPortableTensor> getPortableTensor(const ir::OperandIndex &ind)
   {
     auto external_tensor = _external.find(ind);
@@ -89,14 +97,17 @@ public:
     return nullptr;
   }
 
-  void setExternalTensor(const ir::OperandIndex &ind,
+  bool setExternalTensor(const ir::OperandIndex &ind,
                          const std::shared_ptr<IPortableTensor> &tensor)
   {
-    auto itr = _managed.find(ind);
-    if (itr != _managed.end() && itr->second != nullptr && tensor != nullptr)
-      throw std::runtime_error{
-          "Tried to set an external tensor but an managed tensor already exists."};
+    // TODO Uncomment this as two tensors for an index is not allowed.
+    //      But now it is temporarily allowed as a workaround. External one hides Managed one.
+    // auto itr = _managed.find(ind);
+    // if (itr != _managed.end() && itr->second != nullptr && tensor != nullptr)
+    //  throw std::runtime_error{
+    //      "Tried to set an external tensor but an managed tensor already exists."};
     _external[ind] = tensor;
+    return true;
   }
 
   void setManagedTensor(const ir::OperandIndex &ind, const std::shared_ptr<T_Tensor> &tensor)

--- a/runtime/onert/core/include/compiler/BackendManager.h
+++ b/runtime/onert/core/include/compiler/BackendManager.h
@@ -22,6 +22,7 @@
 
 #include "ir/Operands.h"
 #include "backend/Backend.h"
+#include "backend/controlflow/Backend.h"
 
 namespace onert
 {
@@ -40,7 +41,7 @@ public:
 public:
   backend::Backend *get(const std::string &key);
   const backend::Backend *get(const std::string &key) const;
-  const backend::Backend *getControlflow() const;
+  const backend::controlflow::Backend *getControlflow() const;
   const std::vector<const backend::Backend *> getAll() const
   {
     std::vector<const backend::Backend *> v;
@@ -64,6 +65,8 @@ private:
 private:
   std::map<std::string, std::unique_ptr<void, dlhandle_destroy_t>> _handle_map;
   std::map<std::string, std::unique_ptr<backend::Backend, backend_destroy_t>> _gen_map;
+  backend::controlflow::Backend *_controlflow;
+
   /**
    * @brief load controlflow backend
    *

--- a/runtime/onert/core/include/compiler/Compiler.h
+++ b/runtime/onert/core/include/compiler/Compiler.h
@@ -48,6 +48,7 @@ struct CompilerOptions
 {
   // GENERAL OPTIONS
   std::vector<std::string> backend_list;
+  bool is_primary_subgraph;
 
   // OPTIONS ONLY FOR DEBUGGING/PROFILING
   std::string trace_filepath; //< File path to save trace records

--- a/runtime/onert/core/include/ir/LoweredGraph.h
+++ b/runtime/onert/core/include/ir/LoweredGraph.h
@@ -64,7 +64,8 @@ private:
                        const compiler::BackendResolver &backend_resolver);
 
   void
-  manipulateLowerInfo(OperandIndexMap<std::unique_ptr<operand::LowerInfo>> &operands_lower_info);
+  manipulateLowerInfo(OperandIndexMap<std::unique_ptr<operand::LowerInfo>> &operands_lower_info,
+                      bool is_primary);
   void dumpLowerInfo();
   bool mergeable(const OpSequenceIndex &op_seq_index, const OperationIndex &node_index,
                  Layout layout, const compiler::BackendResolver &backend_resolver);

--- a/runtime/onert/core/src/backend/controlflow/Backend.h
+++ b/runtime/onert/core/src/backend/controlflow/Backend.h
@@ -66,7 +66,7 @@ public:
     auto tb = std::make_shared<TensorBuilder>();
     context->tensor_builder = tb;
     context->constant_initializer = std::make_shared<ConstantInitializer>(operands, tb);
-    context->kernel_gen = std::make_shared<KernelGenerator>(graph);
+    context->kernel_gen = std::make_shared<KernelGenerator>(graph, tb);
     context->tensor_register = nullptr;
     context->optimizer = nullptr;
     return context;

--- a/runtime/onert/core/src/backend/controlflow/Config.h
+++ b/runtime/onert/core/src/backend/controlflow/Config.h
@@ -39,7 +39,7 @@ public:
   bool supportDynamicTensor() override
   {
     // TODO Make this backend to support dynamic tensor or not to build non-constant tensor
-    return false;
+    return true;
   }
   bool supportFP16() override { return false; }
 

--- a/runtime/onert/core/src/backend/controlflow/DynamicTensorManager.h
+++ b/runtime/onert/core/src/backend/controlflow/DynamicTensorManager.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_BACKEND_CONTROLFLOW_DYNAMICTENSOR_MANAGER_H__
+#define __ONERT_BACKEND_CONTROLFLOW_DYNAMICTENSOR_MANAGER_H__
+
+#include "UserTensorRegistry.h"
+
+#include <backend/IDynamicTensorManager.h>
+#include <backend/cpu_common/MemoryManager.h>
+#include <backend/cpu_common/TensorRegistry.h>
+#include <ir/OperandInfo.h>
+#include <ir/Operation.h>
+#include <ir/Index.h>
+
+namespace onert
+{
+namespace backend
+{
+namespace controlflow
+{
+
+// TODO Find optimized algorithm to manage memory.
+
+/**
+ * @brief Class to manage dynamic tensor and its memory
+ */
+class DynamicTensorManager : public backend::IDynamicTensorManager
+{
+public:
+  DynamicTensorManager(const std::shared_ptr<cpu_common::TensorRegistry> &reg,
+                       const std::shared_ptr<UserTensorRegistry> &user_reg);
+
+  virtual ~DynamicTensorManager() = default;
+
+  void applyShape(const ir::OperandIndex &ind, const ir::Shape &new_shape) override;
+
+  void buildTensor(const ir::OperandIndex &ind, const ir::OperandInfo &tensor_info,
+                   ir::Layout backend_layout);
+
+  void planDealloc(ir::OperationIndex op_ind, ir::OperandIndex operand_ind) override;
+  void deallocInput(ir::OperationIndex op_ind) override;
+  void deallocSubgraphOutput(ir::OperandIndex ind) override;
+
+private:
+  /**
+   * @brief Memory manager for dynamic tensor.
+   * @todo  DynamicMemoryManager is not optimized. Optimized one is needed
+   */
+  std::shared_ptr<cpu_common::DynamicMemoryManager> _dynamic_mem_mgr;
+  const std::shared_ptr<cpu_common::TensorRegistry> _tensors;
+  const std::shared_ptr<UserTensorRegistry> _user_tensors;
+
+  // contains list of dynamic tensor index, which can be deallocated after running operation
+  // note: this map could contain static tensor index too. Careful use is required.
+  std::unordered_map<ir::OperationIndex, std::unordered_set<ir::OperandIndex>> _dealloc_tensor_map;
+};
+
+} // namespace controlflow
+} // namespace backend
+} // namespace onert
+
+#endif // __ONERT_BACKEND_CONTROLFLOW_DYNAMICTENSOR_MANAGER_H__

--- a/runtime/onert/core/src/backend/controlflow/KernelGenerator.h
+++ b/runtime/onert/core/src/backend/controlflow/KernelGenerator.h
@@ -21,6 +21,8 @@
 #include <backend/ITensorBuilder.h>
 #include <exec/IExecutor.h>
 #include <ir/Graph.h>
+#include "TensorBuilder.h"
+#include "compiler/TensorBuilders.h"
 
 #include "compiler/TensorBuilders.h"
 
@@ -34,7 +36,7 @@ namespace controlflow
 class KernelGenerator : public IKernelGenerator
 {
 public:
-  KernelGenerator(const ir::Graph &graph);
+  KernelGenerator(const ir::Graph &graph, const std::shared_ptr<TensorBuilder> &tensor_builder);
 
   void setTensorBuilderSet(const compiler::TensorBuilders &tensor_builder_set)
   {
@@ -59,6 +61,7 @@ private:
 
 private:
   const ir::Graph &_graph;
+  std::shared_ptr<TensorBuilder> _tensor_builder;
   compiler::TensorBuilders _tensor_builder_set;
   exec::ExecutorMap *_executor_map;
 };

--- a/runtime/onert/core/src/backend/controlflow/TensorBuilder.cc
+++ b/runtime/onert/core/src/backend/controlflow/TensorBuilder.cc
@@ -28,9 +28,9 @@ namespace controlflow
 {
 
 TensorBuilder::TensorBuilder()
-    : _tensor_reg{new cpu_common::TensorRegistry()},
+    : _tensor_reg{new cpu_common::TensorRegistry()}, _user_tensor_reg{new UserTensorRegistry()},
       _static_tensor_mgr{new cpu_common::StaticTensorManager(_tensor_reg)},
-      _dynamic_tensor_mgr{new cpu_common::DynamicTensorManager(_tensor_reg)}
+      _dynamic_tensor_mgr{new DynamicTensorManager(_tensor_reg, _user_tensor_reg)}
 {
   /* empty */
 }
@@ -91,7 +91,16 @@ void TensorBuilder::allocate()
 
 std::shared_ptr<ITensor> TensorBuilder::tensorAt(const ir::OperandIndex &ind)
 {
-  return _tensor_reg->getITensor(ind);
+  // NOTE Find from User Tensor Registry first
+  // FIXME There may be both user tensor and managed tensor for a `ind` which is a waste
+  auto user_tensor = _user_tensor_reg->getITensor(ind);
+  auto tensor = _tensor_reg->getITensor(ind);
+  if (user_tensor)
+  {
+    return user_tensor;
+  }
+  else
+    return tensor;
 }
 
 void TensorBuilder::iterate(const IterateFunction &fn) { _static_tensor_mgr->iterate(fn); }
@@ -109,6 +118,12 @@ std::unique_ptr<ITensorManager> TensorBuilder::releaseStaticTensorManager(void)
 std::unique_ptr<ITensorManager> TensorBuilder::releaseDynamicTensorManager(void)
 {
   return std::move(_dynamic_tensor_mgr);
+}
+
+void TensorBuilder::setUserTensor(const ir::OperandIndex &ind,
+                                  const std::shared_ptr<UserTensor> &tensor)
+{
+  _user_tensor_reg->setManagedTensor(ind, tensor);
 }
 
 } // namespace controlflow

--- a/runtime/onert/core/src/backend/controlflow/TensorBuilder.h
+++ b/runtime/onert/core/src/backend/controlflow/TensorBuilder.h
@@ -17,7 +17,6 @@
 #ifndef __ONERT_BACKEND_CONTROLFLOW_TENSOR_BUILDER_H__
 #define __ONERT_BACKEND_CONTROLFLOW_TENSOR_BUILDER_H__
 
-#include <backend/cpu_common/DynamicTensorManager.h>
 #include <backend/cpu_common/StaticTensorManager.h>
 #include <backend/cpu_common/TensorRegistry.h>
 #include <backend/cpu_common/Tensor.h>
@@ -26,6 +25,9 @@
 #include <ir/OperandIndexMap.h>
 
 #include <unordered_map>
+
+#include "DynamicTensorManager.h"
+#include "UserTensorRegistry.h"
 
 namespace onert
 {
@@ -81,13 +83,15 @@ public:
    * @return shared_ptr<operand::Tensor>
    */
   std::shared_ptr<cpu_common::Tensor> at(const ir::OperandIndex &ind);
+  void setUserTensor(const ir::OperandIndex &ind, const std::shared_ptr<UserTensor> &tensor);
 
   std::shared_ptr<ITensorRegistry> tensorRegistry() override { return _tensor_reg; }
 
 private:
   const std::shared_ptr<cpu_common::TensorRegistry> _tensor_reg;
+  const std::shared_ptr<UserTensorRegistry> _user_tensor_reg;
   std::unique_ptr<cpu_common::StaticTensorManager> _static_tensor_mgr;
-  std::unique_ptr<cpu_common::DynamicTensorManager> _dynamic_tensor_mgr;
+  std::unique_ptr<DynamicTensorManager> _dynamic_tensor_mgr;
   ir::OperandIndexMap<ir::OperandInfo> _tensor_info_map;
   ir::OperandIndexMap<ir::Layout> _tensor_layout_map;
 };

--- a/runtime/onert/core/src/backend/controlflow/UserTensor.h
+++ b/runtime/onert/core/src/backend/controlflow/UserTensor.h
@@ -39,7 +39,7 @@ class UserTensor : public IPortableTensor
 {
 public:
   UserTensor(const ir::OperandInfo &info, ir::Layout layout, uint8_t *buffer, size_t size)
-      : _info{info}, _layout{layout}, _buffer{buffer}, _size{size}
+      : _info{info}, _layout{layout}, _buffer{buffer}, _size{size}, _dynamic{false}
   {
   }
 
@@ -64,7 +64,8 @@ public:
   ir::DataType data_type() const override { return _info.typeInfo().type(); }
   float data_scale() const override { return _info.typeInfo().scale(); }
   int32_t data_offset() const override { return _info.typeInfo().offset(); }
-  bool is_dynamic() const override { return false; }
+  bool is_dynamic() const override { return _dynamic; }
+  void set_dynamic() override { _dynamic = true; }
   ir::Shape getShape() const override { return _info.shape(); }
   void setShape(const ir::Shape &new_shape) override { _info.shape(new_shape); }
 
@@ -73,6 +74,7 @@ private:
   ir::Layout _layout;
   uint8_t *_buffer;
   size_t _size;
+  bool _dynamic;
 };
 
 } // namespace controlflow

--- a/runtime/onert/core/src/backend/controlflow/UserTensorRegistry.h
+++ b/runtime/onert/core/src/backend/controlflow/UserTensorRegistry.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_BACKEND_CONTROLFLOW_USER_TENSOR_REGISTRY__
+#define __ONERT_BACKEND_CONTROLFLOW_USER_TENSOR_REGISTRY__
+
+#include "backend/ITensorRegistry.h"
+#include "UserTensor.h"
+
+namespace onert
+{
+namespace backend
+{
+namespace controlflow
+{
+
+using UserTensorRegistry = PortableTensorRegistryTemplate<UserTensor>;
+
+} // namespace controlflow
+} // namespace backend
+} // namespace onert
+
+#endif // __ONERT_BACKEND_CONTROLFLOW_USER_TENSOR_REGISTRY__

--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -181,6 +181,7 @@ void Compiler::compile(void)
   // Lower: Assign backend
   std::unordered_map<ir::SubgraphIndex, std::unique_ptr<ir::LoweredGraph>> lowered_subgs;
   _subgraphs->iterate([&](const ir::SubgraphIndex &index, ir::Graph &subg) {
+    _options.is_primary_subgraph = (index == ir::SubgraphIndex{0});
     onert::dumper::dot::DotDumper dot_dumper(subg, dump_level);
     dot_dumper.dump(nnfw::misc::str("before_lower_subg-", index.value()));
 
@@ -236,6 +237,8 @@ void Compiler::compile(void)
     const auto &subg_index = pair.first;
     auto &lowered_subg = pair.second;
     auto indexed_ranks = lowered_subg->indexed_ranks();
+
+    _options.is_primary_subgraph = (subg_index == ir::SubgraphIndex{0});
 
     onert::dumper::dot::DotDumper dot_dumper_lowered(lowered_subg.get(), dump_level);
     dot_dumper_lowered.dump("after_lower_subg-" + std::to_string(subg_index.value()));

--- a/runtime/onert/core/src/compiler/ExecutorFactory.h
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.h
@@ -19,6 +19,7 @@
 
 #include <unordered_map>
 
+#include "backend/ITensor.h"
 #include "exec/IExecutor.h"
 #include "ir/LoweredGraph.h"
 
@@ -44,6 +45,9 @@ private:
   static void initializeBackendContext(ir::LoweredGraph *lowered_graph);
   static void runTensorRegistration(ir::LoweredGraph *lowered_graph,
                                     const std::vector<ir::OpSequenceIndex> &order);
+  static std::vector<std::shared_ptr<backend::ITensor>>
+  initializeModelIOTensors(ir::LoweredGraph &lowered_graph,
+                           const ir::OperandIndexSequence &indices);
   static exec::IExecutor *
   createLinearExecutor(std::unique_ptr<ir::LoweredGraph> lowered_graph,
                        const compiler::CompilerOptions &options,

--- a/runtime/onert/core/src/compiler/HEScheduler.h
+++ b/runtime/onert/core/src/compiler/HEScheduler.h
@@ -51,7 +51,7 @@ public:
    * @param[in] backend_resolver backend resolver
    */
   HEScheduler(const backend::BackendContexts &backend_contexts, const CompilerOptions &options)
-      : _backend_contexts{backend_contexts}, _is_supported{}, _backends_avail_time{}, _ops_eft{},
+      : _is_supported{}, _backends_avail_time{}, _ops_eft{},
         _op_to_rank{std::make_shared<ir::OperationIndexMap<int64_t>>()},
         _is_profiling_mode{options.he_profiling_mode},
         _is_linear_exec{options.executor == "Linear"},
@@ -161,7 +161,6 @@ private:
   // whether it should assign these backends to these nodes:
   // * It stores false for unsupported nodes
   // * During rank calculation with enabled profiling mode it stores true for supported nodes
-  const backend::BackendContexts &_backend_contexts;
   std::unordered_map<const backend::Backend *, std::unordered_map<std::string, bool>> _is_supported;
   // Finishing and starting time of each backend
   std::unordered_map<const backend::Backend *, std::map<int64_t, int64_t>> _backends_avail_time;

--- a/runtime/onert/core/src/compiler/TensorBuilders.h
+++ b/runtime/onert/core/src/compiler/TensorBuilders.h
@@ -23,6 +23,7 @@
 #include "backend/Backend.h"
 #include "backend/controlflow/Config.h"
 #include "backend/controlflow/TensorBuilder.h"
+#include "util/logging.h"
 
 namespace onert
 {
@@ -64,6 +65,18 @@ public:
   std::shared_ptr<backend::controlflow::TensorBuilder> getControlflowTensorBuilder() const
   {
     return _cf_tensor_builder;
+  }
+
+  std::shared_ptr<backend::ITensor> getITensor(ir::OperandIndex ind)
+  {
+    for (auto &tensor_builder : _tensor_builders)
+    {
+      auto tensor = tensor_builder->tensorAt(ind);
+      VERBOSE_F() << "TENSOR " << ind << " found " << (tensor ? "YES" : "NO") << std::endl;
+      if (tensor)
+        return tensor;
+    }
+    return nullptr;
   }
 
 private:

--- a/runtime/onert/core/src/exec/DataflowExecutor.cc
+++ b/runtime/onert/core/src/exec/DataflowExecutor.cc
@@ -77,10 +77,13 @@ bool DataflowExecutor::noWaitingJobs()
                      [](const std::unique_ptr<Job> &job) { return job == nullptr; });
 }
 
-DataflowExecutor::DataflowExecutor(std::unique_ptr<ir::LoweredGraph> lowered_graph,
-                                   const compiler::TensorBuilders &tensor_builders,
-                                   compiler::CodeMap &&code_map)
-    : ExecutorBase{std::move(lowered_graph), tensor_builders}, _code_map{std::move(code_map)}
+DataflowExecutor::DataflowExecutor(
+    std::unique_ptr<ir::LoweredGraph> lowered_graph,
+    const std::vector<std::shared_ptr<backend::ITensor>> &input_tensors,
+    const std::vector<std::shared_ptr<backend::ITensor>> &output_tensors,
+    const compiler::TensorBuilders &tensor_builders, compiler::CodeMap &&code_map)
+    : ExecutorBase{std::move(lowered_graph), input_tensors, output_tensors, tensor_builders},
+      _code_map{std::move(code_map)}
 {
   VERBOSE(DataflowExecutor) << "Constructing Dataflow Executor" << std::endl;
 

--- a/runtime/onert/core/src/exec/DataflowExecutor.h
+++ b/runtime/onert/core/src/exec/DataflowExecutor.h
@@ -50,6 +50,8 @@ public:
    * @param code_map OpSequence and its code map
    */
   DataflowExecutor(std::unique_ptr<ir::LoweredGraph> lowered_graph,
+                   const std::vector<std::shared_ptr<backend::ITensor>> &input_tensors,
+                   const std::vector<std::shared_ptr<backend::ITensor>> &output_tensors,
                    const compiler::TensorBuilders &tensor_builders, compiler::CodeMap &&code_map);
 
   void executeImpl() override;

--- a/runtime/onert/core/src/exec/ExecutorBase.cc
+++ b/runtime/onert/core/src/exec/ExecutorBase.cc
@@ -17,6 +17,8 @@
 #include "ExecutorBase.h"
 
 #include "backend/ITensor.h"
+#include "backend/controlflow/UserTensor.h"
+#include "backend/cpu_common/Tensor.h"
 #include "util/logging.h"
 
 namespace onert
@@ -25,61 +27,88 @@ namespace exec
 {
 
 ExecutorBase::ExecutorBase(std::unique_ptr<ir::LoweredGraph> &&lowered_graph,
+                           const std::vector<std::shared_ptr<backend::ITensor>> &input_tensors,
+                           const std::vector<std::shared_ptr<backend::ITensor>> &output_tensors,
                            const compiler::TensorBuilders &tensor_builders)
-    : _lowered_graph{std::move(lowered_graph)}, _graph{_lowered_graph->graph()}, _mutex()
+    : _lowered_graph{std::move(lowered_graph)}, _graph{_lowered_graph->graph()},
+      _input_tensors{input_tensors}, _output_tensors{output_tensors}, _mutex()
 {
-  auto build_input_tensor_list = [&](const onert::ir::OperandIndexSequence &ind_seq) {
-    std::vector<std::shared_ptr<backend::ITensor>> list;
-    for (auto ind : ind_seq)
-    {
-      std::shared_ptr<backend::ITensor> tensor;
-      for (auto &tensor_builder : tensor_builders)
+  // TODO Fix the way of knowing whether it is primary or not
+  bool primary_executor = !(_input_tensors.empty() && _output_tensors.empty());
+  if (!primary_executor)
+  {
+    auto build_input_tensor_list = [&](const onert::ir::OperandIndexSequence &ind_seq) {
+      std::vector<std::shared_ptr<backend::ITensor>> list;
+      for (auto ind : ind_seq)
       {
-        tensor = tensor_builder->tensorAt(ind);
-        if (tensor != nullptr)
+        std::shared_ptr<backend::ITensor> tensor;
+        for (auto &tensor_builder : tensor_builders)
         {
-          if (tensor_builder->supportDynamicTensor())
+          tensor = tensor_builder->tensorRegistry()->getManagedITensor(ind);
+          if (tensor != nullptr)
           {
-            DynAllocInfo dyn_alloc_info{ind, tensor_builder->dynamicTensorManager()};
-            _input_to_dyn_alloc_info.emplace(tensor, dyn_alloc_info);
+            if (tensor_builder->supportDynamicTensor())
+            {
+              DynAllocInfo dyn_alloc_info{ind, tensor_builder->dynamicTensorManager()};
+              _input_to_dyn_alloc_info.emplace(tensor, dyn_alloc_info);
+            }
+            break;
           }
-          break;
         }
+        assert(tensor != nullptr);
+        list.push_back(tensor);
       }
-
-      // Controlflow opeartion can make subgraph has unused input.
-      assert(tensor != nullptr || _lowered_graph->graph().getInputs().contains(ind));
-      list.push_back(tensor);
-    }
-    return list;
-  };
-
-  auto build_output_tensor_list = [&](const onert::ir::OperandIndexSequence &ind_seq) {
-    std::vector<std::shared_ptr<backend::ITensor>> list;
-    for (auto ind : ind_seq)
-    {
-      std::shared_ptr<backend::ITensor> tensor;
-      for (auto &tensor_builder : tensor_builders)
+      return list;
+    };
+    auto build_output_tensor_list = [&](const onert::ir::OperandIndexSequence &ind_seq) {
+      std::vector<std::shared_ptr<backend::ITensor>> list;
+      for (auto ind : ind_seq)
       {
-        tensor = tensor_builder->tensorAt(ind);
-        if (tensor != nullptr)
+        std::shared_ptr<backend::ITensor> tensor;
+        for (auto &tensor_builder : tensor_builders)
         {
-          if (tensor_builder->supportDynamicTensor())
+          tensor = tensor_builder->tensorRegistry()->getManagedITensor(ind);
+          if (tensor != nullptr)
           {
-            DynAllocInfo dyn_alloc_info{ind, tensor_builder->dynamicTensorManager()};
-            _output_to_dyn_alloc_info.emplace(tensor, dyn_alloc_info);
+            if (tensor_builder->supportDynamicTensor())
+            {
+              DynAllocInfo dyn_alloc_info{ind, tensor_builder->dynamicTensorManager()};
+              _output_to_dyn_alloc_info.emplace(tensor, dyn_alloc_info);
+            }
+            break;
           }
-          break;
         }
+        assert(tensor != nullptr);
+        list.push_back(tensor);
       }
-      assert(tensor != nullptr);
-      list.push_back(tensor);
-    }
-    return list;
-  };
+      return list;
+    };
+    _input_tensors = build_input_tensor_list(_graph.getInputs());
+    _output_tensors = build_output_tensor_list(_graph.getOutputs());
+  }
+  else
+  {
+    // If primary graph, all the inputs and outputs belong to controlflow backend
+    auto cf_dyn_tensor_builder = tensor_builders.getControlflowTensorBuilder();
+    assert(cf_dyn_tensor_builder);
 
-  _input_tensors = build_input_tensor_list(_graph.getInputs());
-  _output_tensors = build_output_tensor_list(_graph.getOutputs());
+    assert(input_tensors.size() == _graph.getInputs().size());
+    assert(output_tensors.size() == _graph.getOutputs().size());
+    for (uint32_t i = 0; i < input_tensors.size(); i++)
+    {
+      auto tensor = input_tensors[i];
+      auto ind = _graph.getInputs().at(i);
+      DynAllocInfo dyn_alloc_info{ind, cf_dyn_tensor_builder->dynamicTensorManager()};
+      _input_to_dyn_alloc_info.emplace(tensor, dyn_alloc_info);
+    }
+    for (uint32_t i = 0; i < output_tensors.size(); i++)
+    {
+      auto tensor = output_tensors[i];
+      auto ind = _graph.getOutputs().at(i);
+      DynAllocInfo dyn_alloc_info{ind, cf_dyn_tensor_builder->dynamicTensorManager()};
+      _output_to_dyn_alloc_info.emplace(tensor, dyn_alloc_info);
+    }
+  }
 
   // Prepare each TensorManager on each backend
   for (auto &tensor_builder : tensor_builders)
@@ -94,57 +123,6 @@ ExecutorBase::ExecutorBase(std::unique_ptr<ir::LoweredGraph> &&lowered_graph,
       if (d_tensor_manager != nullptr)
         _tensor_mgrs.insert(std::move(d_tensor_manager));
     }
-  }
-}
-
-std::unique_ptr<ISource> ExecutorBase::source(const ir::IOIndex &index, const ir::TypeInfo &type,
-                                              const void *buffer, size_t length,
-                                              ir::Layout io_layout)
-{
-  using ir::DataType;
-  switch (type.type())
-  {
-    case DataType::FLOAT32:
-      return source<float>(index, buffer, length, io_layout);
-    case DataType::INT32:
-      return source<int32_t>(index, buffer, length, io_layout);
-    case DataType::UINT32:
-      return source<uint32_t>(index, buffer, length, io_layout);
-    case DataType::BOOL8:
-    case DataType::QUANT_UINT8_ASYMM:
-    case DataType::UINT8:
-      return source<uint8_t>(index, buffer, length, io_layout);
-    case DataType::QUANT_INT8_SYMM:
-      return source<int8_t>(index, buffer, length, io_layout);
-    case DataType::INT64:
-      return source<int64_t>(index, buffer, length, io_layout);
-    default:
-      throw std::runtime_error("Not supported yet");
-  }
-}
-
-std::unique_ptr<ISink> ExecutorBase::sink(const ir::IOIndex &index, const ir::TypeInfo &type,
-                                          void *buffer, size_t length, ir::Layout io_layout)
-{
-  using ir::DataType;
-  switch (type.type())
-  {
-    case DataType::FLOAT32:
-      return sink<float>(index, buffer, length, io_layout);
-    case DataType::INT32:
-      return sink<int32_t>(index, buffer, length, io_layout);
-    case DataType::UINT32:
-      return sink<uint32_t>(index, buffer, length, io_layout);
-    case DataType::BOOL8:
-    case DataType::QUANT_UINT8_ASYMM:
-    case DataType::UINT8:
-      return sink<uint8_t>(index, buffer, length, io_layout);
-    case DataType::QUANT_INT8_SYMM:
-      return sink<int8_t>(index, buffer, length, io_layout);
-    case DataType::INT64:
-      return sink<int64_t>(index, buffer, length, io_layout);
-    default:
-      throw std::runtime_error("Not supported yet");
   }
 }
 
@@ -203,43 +181,40 @@ void ExecutorBase::execute(const IODescription &desc)
   //       do not need to use mutex (otherwise, use mutex)
   std::lock_guard<std::mutex> lock(_mutex);
 
-  std::vector<std::unique_ptr<ISource>> sources{_graph.getInputs().size()};
-  std::vector<std::unique_ptr<ISink>> sinks{_graph.getOutputs().size()};
-
-  // Set input(s)
-  for (uint32_t n = 0; n < _graph.getInputs().size(); ++n)
+  assert(_input_tensors.size() == desc.inputs.size());
+  for (uint32_t i = 0; i < _input_tensors.size(); ++i)
   {
-    ir::IOIndex input_index{n};
-    ir::OperandIndex index{_graph.getInputs().at(input_index)};
-
-    if (desc.inputs.at(n) == nullptr)
+    // TODO Remove dynamic_cast
+    auto tensor = std::dynamic_pointer_cast<backend::controlflow::UserTensor>(_input_tensors[i]);
+    assert(tensor);
+    auto input_shape = desc.input_shape_signature.find(ir::IOIndex{i});
+    if (input_shape != desc.input_shape_signature.end())
     {
-      // Optional input
-      continue;
+      tensor->set_dynamic();
+      tensor->setShape(input_shape->second);
     }
+    // TODO Better design for ITensor? (we need const_cast as ITensor is writable)
+    tensor->setBuffer(static_cast<uint8_t *>(const_cast<void *>(desc.inputs[i]->buffer)),
+                      desc.inputs[i]->size);
 
-    const auto operand_li = _lowered_graph->getLowerInfo()->operand.at(index).get();
-    if (operand_li->def_factors().empty())
-    {
-      // This input is not used (i.e. constant, EX. reshape's axis)
-      continue;
-    }
+    handleDynamicInputTensor(ir::IOIndex{i}, desc);
+  }
 
-    // If nnfw_set_input_tensorinfo() was called for an input, set change and prepare memory
-    handleDynamicInputTensor(input_index, desc);
-
-    const auto &input = *desc.inputs.at(n);
-    sources.at(n) =
-        source(input_index, input.info.typeInfo(), input.buffer, input.size, input.layout);
-
-    auto setter = [&](::onert::backend::ITensor &tensor) { sources.at(n)->push(tensor); };
-
-    _input_tensors[n]->access(setter);
+  assert(_output_tensors.size() == desc.outputs.size());
+  for (uint32_t i = 0; i < _output_tensors.size(); ++i)
+  {
+    // TODO Remove dynamic_cast
+    auto tensor = std::dynamic_pointer_cast<backend::controlflow::UserTensor>(_output_tensors[i]);
+    assert(tensor);
+    tensor->set_dynamic(); // It can't be resized but shape could change
+    // TODO Better design for ITensor? (we need const_cast as ITensor is writable)
+    tensor->setBuffer(static_cast<uint8_t *>(const_cast<void *>(desc.outputs[i]->buffer)),
+                      desc.outputs[i]->size);
   }
 
   executeImpl();
 
-  // Get output(s)
+  // Update output(s) desc
   for (uint32_t n = 0; n < _graph.getOutputs().size(); ++n)
   {
     ir::IOIndex output_index{n};
@@ -254,34 +229,6 @@ void ExecutorBase::execute(const IODescription &desc)
     const auto output_tensor_shape = _output_tensors[n]->getShape();
     output.info.shape(
         convertShape(output_tensor_shape, _output_tensors[n]->layout(), output.layout));
-
-    size_t sink_length =
-        output.info.shape().num_elements() * ir::sizeOfDataType(output.info.typeInfo().type());
-    assert(sink_length ==
-           _output_tensors[n]->getShape().num_elements() *
-               ir::sizeOfDataType(_output_tensors[n]->data_type()));
-    if (output.size < sink_length)
-      throw std::runtime_error("ExecutorBase: output buffer size is less than output tensor size");
-
-    sinks.at(n) =
-        sink(output_index, output.info.typeInfo(), output.buffer, sink_length, output.layout);
-
-    auto getter = [&](::onert::backend::ITensor &tensor) { sinks.at(n)->pull(tensor); };
-
-    _output_tensors[n]->access(getter);
-
-    // deallocate output tensors if it is dynamic
-    {
-      auto find = _output_to_dyn_alloc_info.find(_output_tensors[n]);
-      if (find != _output_to_dyn_alloc_info.end())
-      {
-        auto &dyn_alloc_info = find->second;
-        auto *dyn_tensor_mgr = dyn_alloc_info.dyn_tensor_manager;
-        auto outut_ind = dyn_alloc_info.ind;
-
-        dyn_tensor_mgr->deallocSubgraphOutput(outut_ind);
-      }
-    }
   }
 }
 

--- a/runtime/onert/core/src/exec/ExecutorBase.h
+++ b/runtime/onert/core/src/exec/ExecutorBase.h
@@ -53,6 +53,8 @@ public:
    * @param tensor_builders Tensor builders that are currently used
    */
   ExecutorBase(std::unique_ptr<ir::LoweredGraph> &&lowered_graph,
+               const std::vector<std::shared_ptr<backend::ITensor>> &input_tensors,
+               const std::vector<std::shared_ptr<backend::ITensor>> &output_tensors,
                const compiler::TensorBuilders &tensor_builders);
 
   virtual ~ExecutorBase() = default;
@@ -91,56 +93,6 @@ public:
   }
 
   const DynAllocInfoMap &getInputsDynamicAllocInfo() const { return _input_to_dyn_alloc_info; }
-
-private:
-  std::unique_ptr<ISource> source(const ir::IOIndex &index, const ir::TypeInfo &type,
-                                  const void *buffer, size_t length, ir::Layout io_layout);
-  std::unique_ptr<ISink> sink(const ir::IOIndex &index, const ir::TypeInfo &type, void *buffer,
-                              size_t length, ir::Layout io_layout);
-
-  template <typename T>
-  std::unique_ptr<ISource> source(const ir::IOIndex &index, const void *buffer, size_t length,
-                                  ir::Layout io_layout)
-  {
-    const auto operand_index = _graph.getInputs().at(index);
-    const auto &operand = _graph.operands().at(operand_index);
-
-    const auto tensor = _input_tensors[index.value()];
-    const auto tensor_layout = tensor->layout();
-
-    if (((io_layout == ir::Layout::NHWC) && (tensor_layout == ir::Layout::NCHW)) ||
-        ((io_layout == ir::Layout::NCHW) && (tensor_layout == ir::Layout::NHWC)))
-    {
-      return std::make_unique<PermutateSource<T>>(buffer, length, operand.shape(), io_layout);
-    }
-    // TODO Change this to return error
-    assert(io_layout != ir::Layout::UNKNOWN ||
-           (tensor_layout != ir::Layout::NCHW && tensor_layout != ir::Layout::NCHW));
-
-    return std::make_unique<CopySource<T>>(buffer, length, operand.shape());
-  }
-
-  template <typename T>
-  std::unique_ptr<ISink> sink(const ir::IOIndex &index, void *buffer, size_t length,
-                              ir::Layout io_layout)
-  {
-    const auto operand_index = _graph.getOutputs().at(index);
-    const auto &operand = _graph.operands().at(operand_index);
-    const auto tensor = _output_tensors[index.value()];
-    const auto tensor_layout = tensor->layout();
-    const auto tensor_shape = convertShape(tensor->getShape(), tensor->layout(), io_layout);
-
-    if (((tensor_layout == ir::Layout::NCHW) && (io_layout == ir::Layout::NHWC)) ||
-        ((tensor_layout == ir::Layout::NHWC) && (io_layout == ir::Layout::NCHW)))
-    {
-      return std::make_unique<PermutateSink<T>>(buffer, length, tensor_shape, io_layout);
-    }
-    // TODO Change this to return error
-    assert(io_layout != ir::Layout::UNKNOWN ||
-           (tensor_layout != ir::Layout::NCHW && tensor_layout != ir::Layout::NCHW));
-
-    return std::make_unique<CopySink<T>>(buffer, length, operand.shape());
-  }
 
 protected:
   ExecutionObservee _subject;

--- a/runtime/onert/core/src/exec/IPermuteFunction.h
+++ b/runtime/onert/core/src/exec/IPermuteFunction.h
@@ -129,7 +129,7 @@ private:
           assert(src_tensor.layout() == dst_tensor.layout());
           if (!src_tensor.has_padding() && !dst_tensor.has_padding())
           {
-            assert(src_size == dst_tensor.total_size());
+            assert(src_size <= dst_tensor.total_size());
             memcpy(dst_buffer, src_buffer, src_size);
             return;
           }

--- a/runtime/onert/core/src/exec/LinearExecutor.h
+++ b/runtime/onert/core/src/exec/LinearExecutor.h
@@ -47,9 +47,11 @@ public:
    * @param code_map OpSequence and its code map
    */
   LinearExecutor(std::unique_ptr<ir::LoweredGraph> lowered_graph,
+                 const std::vector<std::shared_ptr<backend::ITensor>> &input_tensors,
+                 const std::vector<std::shared_ptr<backend::ITensor>> &output_tensors,
                  const compiler::TensorBuilders &tensor_builders, compiler::CodeMap &&code_map,
                  const std::vector<ir::OpSequenceIndex> &order)
-      : ExecutorBase{std::move(lowered_graph), tensor_builders}
+      : ExecutorBase{std::move(lowered_graph), input_tensors, output_tensors, tensor_builders}
   {
     for (auto index : order)
     {

--- a/runtime/onert/core/src/exec/ParallelExecutor.cc
+++ b/runtime/onert/core/src/exec/ParallelExecutor.cc
@@ -59,10 +59,13 @@ void ParallelExecutor::notify(uint32_t finished_job_id)
   _cv_jobs.notify_all();
 }
 
-ParallelExecutor::ParallelExecutor(std::unique_ptr<ir::LoweredGraph> lowered_graph,
-                                   const compiler::TensorBuilders &tensor_builders,
-                                   compiler::CodeMap &&code_map)
-    : DataflowExecutor{std::move(lowered_graph), tensor_builders, std::move(code_map)}
+ParallelExecutor::ParallelExecutor(
+    std::unique_ptr<ir::LoweredGraph> lowered_graph,
+    const std::vector<std::shared_ptr<backend::ITensor>> &input_tensors,
+    const std::vector<std::shared_ptr<backend::ITensor>> &output_tensors,
+    const compiler::TensorBuilders &tensor_builders, compiler::CodeMap &&code_map)
+    : DataflowExecutor{std::move(lowered_graph), input_tensors, output_tensors, tensor_builders,
+                       std::move(code_map)}
 {
   VERBOSE(ParallelExecutor) << "Constructing Parallel Executor" << std::endl;
 }

--- a/runtime/onert/core/src/exec/ParallelExecutor.h
+++ b/runtime/onert/core/src/exec/ParallelExecutor.h
@@ -51,6 +51,8 @@ public:
    * @param code_map OpSequence and its code map
    */
   ParallelExecutor(std::unique_ptr<ir::LoweredGraph> lowered_graph,
+                   const std::vector<std::shared_ptr<backend::ITensor>> &input_tensors,
+                   const std::vector<std::shared_ptr<backend::ITensor>> &output_tensors,
                    const compiler::TensorBuilders &tensor_builders, compiler::CodeMap &&code_map);
 
   void executeImpl() override;

--- a/runtime/onert/core/src/ir/pass/PermutationInsertionPass.cc
+++ b/runtime/onert/core/src/ir/pass/PermutationInsertionPass.cc
@@ -62,27 +62,23 @@ void PermutationInsertionPass::callback(const OperandIndex &index, Operand &obje
     auto insert_set = operand_li->use_factors() - operand_li->def_factors();
     auto def_factor = operand_li->def_factors().getOnlyElement();
 
-    auto compatible_backends = [](auto /* backend1 */, auto /* backend2 */) {
-      // TODO If other issues for Permute elimination are resolved, enable this
-      return false;
-      /*
+    auto compatible_backends = [](auto backend1, auto backend2) {
       // TODO This is a workaround for not inserting Permute between cpu and controlflow.
       //      To be general, we need another way of checking they are compatible.
       const auto cf = backend::controlflow::Config::ID;
       const auto cpu = "cpu";
       const auto id1 = backend1->config()->id();
       const auto id2 = backend2->config()->id();
-      return (id1 == cpu && id2 == cf) // Allows no-Permute for Model inputs
-          || (id1 == cf && id2 == cpu); // Allows no-Permute for Model outputs
-          */
+      return (id1 == cpu && id2 == cf); // Allows no-Permute for Model inputs
+      //|| (id1 == cf && id2 == cpu); // Allows no-Permute for Model outputs
     };
 
     for (auto factor : insert_set)
     {
+      // Check exceptional cases that Permute ops are not inserted
       if (factor.layout() == def_factor.layout() &&
           compatible_backends(factor.backend(), def_factor.backend()))
       {
-        // For this factor we can just reuse existing operand - Permute is not added.
         VERBOSE(PermutationInsertionPass) << "Permutation Insertion is skipped for operand "
                                           << index << " / as the tensor is compatible with backend "
                                           << factor.backend()->config()->id() << std::endl;

--- a/runtime/onert/core/src/ir/pass/PermutationInsertionPass.cc
+++ b/runtime/onert/core/src/ir/pass/PermutationInsertionPass.cc
@@ -60,8 +60,36 @@ void PermutationInsertionPass::callback(const OperandIndex &index, Operand &obje
     }
 
     auto insert_set = operand_li->use_factors() - operand_li->def_factors();
+    auto def_factor = operand_li->def_factors().getOnlyElement();
+
+    auto compatible_backends = [](auto /* backend1 */, auto /* backend2 */) {
+      // TODO If other issues for Permute elimination are resolved, enable this
+      return false;
+      /*
+      // TODO This is a workaround for not inserting Permute between cpu and controlflow.
+      //      To be general, we need another way of checking they are compatible.
+      const auto cf = backend::controlflow::Config::ID;
+      const auto cpu = "cpu";
+      const auto id1 = backend1->config()->id();
+      const auto id2 = backend2->config()->id();
+      return (id1 == cpu && id2 == cf) // Allows no-Permute for Model inputs
+          || (id1 == cf && id2 == cpu); // Allows no-Permute for Model outputs
+          */
+    };
+
     for (auto factor : insert_set)
     {
+      if (factor.layout() == def_factor.layout() &&
+          compatible_backends(factor.backend(), def_factor.backend()))
+      {
+        // For this factor we can just reuse existing operand - Permute is not added.
+        VERBOSE(PermutationInsertionPass) << "Permutation Insertion is skipped for operand "
+                                          << index << " / as the tensor is compatible with backend "
+                                          << factor.backend()->config()->id() << std::endl;
+        factor_to_index.emplace(factor, index);
+        continue;
+      }
+
       const auto permute_operation_index = insertPermute(index, factor);
       permute_indexes.push_back(permute_operation_index);
       const auto &permute_operation = _graph.operations().at(permute_operation_index);
@@ -145,7 +173,8 @@ OperationIndex PermutationInsertionPass::insertPermute(const OperandIndex &opera
   // different.
   const auto permute_node_layout = Layout::UNKNOWN;
   // NOTE If one backend supports several layout, the backend must support Permute operation
-  auto permute_node_backend = compiler::BackendManager::get().getControlflow();
+  const onert::backend::Backend *permute_node_backend =
+      compiler::BackendManager::get().getControlflow();
   if (input_backend == output_backend)
   {
     permute_node_backend = input_backend;

--- a/runtime/onert/core/src/ir/pass/PermutationOperationPass.cc
+++ b/runtime/onert/core/src/ir/pass/PermutationOperationPass.cc
@@ -19,6 +19,7 @@
 #include "backend/Backend.h"
 #include "backend/IConfig.h"
 #include "ir/Graph.h"
+#include "util/logging.h"
 
 namespace onert
 {
@@ -199,7 +200,9 @@ void PermutationOperationPass::changeToKeepLayout(const Operation &node)
       lower_info->addUsePermuteFactor(new_factor);
 
       // Whether if node's input is an input of model or a constant
-      if (_graph.operands().at(input).getDef().size() == 0)
+      if (_graph.operands().at(input).getDef().size() == 0 &&
+          (lower_info->def_factors().size() == 1 &&
+           lower_info->def_factors().getOnlyElement() == removed_factor))
       {
         assert(_graph.getInputs().contains(input) || _graph.operands().at(input).isConstant());
         lower_info->removeDefPermuteFactor(removed_factor);


### PR DESCRIPTION
Remove Source/Sink copies at execution begin/end, and make user's buffers as a `UserTensor` of `controlflow` backend and insert Permute to the graph instead of Source/Sink.

This is pre-work before Input/Output tensor copy elimination(but this work is like 90% and actual copy elimination is just 10%).

This also includes many other bug fixes.

Rebased version of #1325