### PR TITLE
[onert] Use IPortableTensor in two new ops

### DIFF
--- a/runtime/onert/backend/cpu/KernelGenerator.cc
+++ b/runtime/onert/backend/cpu/KernelGenerator.cc
@@ -1329,9 +1329,9 @@ void KernelGenerator::visit(const ir::operation::BroadcastTo &node)
   const auto input_index{node.getInputs().at(ir::operation::BroadcastTo::INPUT)};
   const auto shape_index{node.getInputs().at(ir::operation::BroadcastTo::SHAPE)};
 
-  auto output_alloc = _tensor_builder->at(output_index).get();
-  auto input_alloc = _tensor_builder->at(input_index).get();
-  auto shape_alloc = _tensor_builder->at(shape_index).get();
+  auto output_alloc = _tensor_builder->portableAt(output_index).get();
+  auto input_alloc = _tensor_builder->portableAt(input_index).get();
+  auto shape_alloc = _tensor_builder->portableAt(shape_index).get();
 
   auto fn = std::make_unique<ops::BroadcastToLayer>();
 
@@ -1344,10 +1344,10 @@ void KernelGenerator::visit(const ir::operation::FusedBatchNorm &node)
 {
   const auto ofm_index{node.getOutputs().at(0)};
 
-  auto output_alloc = _tensor_builder->at(ofm_index).get();
-  std::vector<const Tensor *> input_allocs;
+  auto output_alloc = _tensor_builder->portableAt(ofm_index).get();
+  std::vector<const IPortableTensor *> input_allocs;
   for (auto &ifm_idx : node.getInputs())
-    input_allocs.emplace_back(_tensor_builder->at(ifm_idx).get());
+    input_allocs.emplace_back(_tensor_builder->portableAt(ifm_idx).get());
 
   const auto epsilon = node.param().epsilon;
   const auto is_training = node.param().is_training;

--- a/runtime/onert/backend/cpu/ops/BroadcastToLayer.cc
+++ b/runtime/onert/backend/cpu/ops/BroadcastToLayer.cc
@@ -32,7 +32,8 @@ BroadcastToLayer::BroadcastToLayer() : _input(nullptr), _shape(nullptr), _output
   // DO NOTHING
 }
 
-void BroadcastToLayer::configure(const Tensor *input, const Tensor *shape, Tensor *output)
+void BroadcastToLayer::configure(const IPortableTensor *input, const IPortableTensor *shape,
+                                 IPortableTensor *output)
 {
   _input = input;
   _shape = shape;

--- a/runtime/onert/backend/cpu/ops/BroadcastToLayer.h
+++ b/runtime/onert/backend/cpu/ops/BroadcastToLayer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_OPS_BROADCASTLAYER_H__
 #define __ONERT_BACKEND_CPU_OPS_BROADCASTLAYER_H__
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 #include "OperationUtils.h"
 
 #include <exec/IFunction.h>
@@ -37,14 +37,15 @@ public:
   BroadcastToLayer();
 
 public:
-  void configure(const Tensor *input, const Tensor *shape, Tensor *output);
+  void configure(const IPortableTensor *input, const IPortableTensor *shape,
+                 IPortableTensor *output);
 
   void run();
 
 private:
-  const Tensor *_input;
-  const Tensor *_shape;
-  Tensor *_output;
+  const IPortableTensor *_input;
+  const IPortableTensor *_shape;
+  IPortableTensor *_output;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/FusedBatchNormLayer.cc
+++ b/runtime/onert/backend/cpu/ops/FusedBatchNormLayer.cc
@@ -74,8 +74,9 @@ void FusedBatchNormLayer::run()
   }
 }
 
-void FusedBatchNormLayer::configure(const std::vector<const Tensor *> &inputs, float epsilon,
-                                    bool is_training, std::string data_format, Tensor *output)
+void FusedBatchNormLayer::configure(const std::vector<const IPortableTensor *> &inputs,
+                                    float epsilon, bool is_training, std::string data_format,
+                                    IPortableTensor *output)
 {
   assert(inputs.size() > 0);
   assert(output != nullptr);

--- a/runtime/onert/backend/cpu/ops/FusedBatchNormLayer.h
+++ b/runtime/onert/backend/cpu/ops/FusedBatchNormLayer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_OPS_FUSEDBATCHNORM_LAYER_H__
 #define __ONERT_BACKEND_CPU_OPS_FUSEDBATCHNORM_LAYER_H__
 
-#include "../Tensor.h"
+#include <backend/IPortableTensor.h>
 #include "OperationUtils.h"
 
 #include <exec/IFunction.h>
@@ -50,14 +50,14 @@ public:
 public:
   void fusedbatchnormFloat32();
 
-  void configure(const std::vector<const Tensor *> &inputs, float epsilon, bool is_training,
-                 std::string data_format, Tensor *output);
+  void configure(const std::vector<const IPortableTensor *> &inputs, float epsilon,
+                 bool is_training, std::string data_format, IPortableTensor *output);
 
   void run();
 
 private:
-  std::vector<const Tensor *> _inputs;
-  Tensor *_output;
+  std::vector<const IPortableTensor *> _inputs;
+  IPortableTensor *_output;
   float _epsilon;
   bool _is_training;
   std::string _data_format;


### PR DESCRIPTION
Use `IPortableTensor` for sharing tensors between backends.

Part of #2835

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>