### PR TITLE
[onert] Nit: Fix bug in IPermuteFunction

### DIFF
--- a/runtime/onert/core/src/exec/IPermuteFunction.h
+++ b/runtime/onert/core/src/exec/IPermuteFunction.h
@@ -141,7 +141,7 @@ private:
           {
             const int32_t copy_len = dst_tensor.dimension(0);
 
-            memcpy(dst_buffer, src_buffer, copy_len);
+            memcpy(dst_buffer, src_buffer, copy_len * sizeof(T));
             break;
           }
           case 2:


### PR DESCRIPTION
Size of the data type must be multiplied for copy size.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>