### PR TITLE
[onert] Allow empty weight buffer in cpu FC impl

### DIFF
--- a/runtime/onert/backend/cpu/ops/FullyConnectedLayer.cc
+++ b/runtime/onert/backend/cpu/ops/FullyConnectedLayer.cc
@@ -175,9 +175,14 @@ void FullyConnectedLayer::prepare()
     {
       // TODO If it's possible to extract precaching from ruy kernel,
       // place this instead of below code
-      assert(_weights->buffer() != nullptr);
-      // buffer will be used by ruy kernel as a cache key
-      _cached_weights = _weights->buffer();
+
+      // Buffer could be nullptr if it is Model Input. which means that this is not constant,
+      // so it can't be cached
+      if (_weights->buffer() != nullptr)
+      {
+        // buffer will be used by ruy kernel as a cache key
+        _cached_weights = _weights->buffer();
+      }
     }
   }
 #endif


### PR DESCRIPTION
Soon, weight's buffer could be `null` when it is a model input.

Part of #2835

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>