### PR TITLE
[luci-interpreter] Skip build if dependencies are missing

### DIFF
--- a/compiler/luci-interpreter/src/CMakeLists.txt
+++ b/compiler/luci-interpreter/src/CMakeLists.txt
@@ -1,3 +1,22 @@
+nnas_find_package(TensorFlowSource EXACT 2.1.0 QUIET)
+nnas_find_package(TensorFlowGEMMLowpSource EXACT 2.1.0 QUIET)
+nnas_find_package(TensorFlowEigenSource EXACT 2.1.0 QUIET)
+
+if (NOT TensorFlowSource_FOUND)
+  message(STATUS "Skipping luci-interpreter: TensorFlow not found")
+  return()
+endif ()
+
+if (NOT TensorFlowGEMMLowpSource_FOUND)
+  message(STATUS "Skipping luci-interpreter: gemmlowp not found")
+  return()
+endif ()
+
+if (NOT TensorFlowEigenSource_FOUND)
+  message(STATUS "Skipping luci-interpreter: Eigen not found")
+  return()
+endif ()
+
 add_subdirectory(core)
 add_subdirectory(kernels)
 add_subdirectory(loader)

--- a/compiler/luci-interpreter/src/kernels/CMakeLists.txt
+++ b/compiler/luci-interpreter/src/kernels/CMakeLists.txt
@@ -1,14 +1,5 @@
-nnas_find_package(TensorFlowSource EXACT 2.1.0 QUIET)
-nnas_find_package(TensorFlowGEMMLowpSource EXACT 2.1.0 QUIET)
-nnas_find_package(TensorFlowEigenSource EXACT 2.1.0 QUIET)
 find_package(Threads REQUIRED)
 nnas_find_package(GTest REQUIRED)
-
-if (NOT TensorFlowSource_FOUND OR
-    NOT TensorFlowGEMMLowpSource_FOUND OR
-    NOT TensorFlowEigenSource_FOUND)
-  return()
-endif ()
 
 set(SOURCES
     Add.h


### PR DESCRIPTION
For issue #2811.

Do not try to build `luci-interpreter` if any of dependencies is missing.

ONE-DCO-1.0-Signed-off-by: Sergei Barannikov <s.barannikov@samsung.com>
