### PR TITLE
[luci-interpreter] Add preOperatorExecute and postOperatorExecute events

### DIFF
--- a/compiler/luci-interpreter/include/luci_interpreter/Interpreter.h
+++ b/compiler/luci-interpreter/include/luci_interpreter/Interpreter.h
@@ -37,6 +37,12 @@ public:
 
   // Called when the value of a tensor has been updated during execution.
   virtual void postTensorWrite(const luci::CircleNode *node, const Tensor *tensor);
+
+  // Called before / after executing an operator.
+  // Note that these methods are not called for auxiliary operators (CircleInput, CircleOutput,
+  // CircleConst and Circle*Out).
+  virtual void preOperatorExecute(const luci::CircleNode *node);
+  virtual void postOperatorExecute(const luci::CircleNode *node);
 };
 
 class Interpreter

--- a/compiler/luci-interpreter/src/core/EventNotifier.h
+++ b/compiler/luci-interpreter/src/core/EventNotifier.h
@@ -26,7 +26,9 @@ class EventNotifier
 public:
   virtual ~EventNotifier() = default;
 
-  virtual void postTensorWrite(Tensor *tensor) const = 0;
+  virtual void postTensorWrite(const Tensor *tensor) = 0;
+  virtual void preOperatorExecute(const Kernel *kernel) = 0;
+  virtual void postOperatorExecute(const Kernel *kernel) = 0;
 };
 
 } // namespace luci_interpreter

--- a/compiler/luci-interpreter/src/core/RuntimeGraph.cpp
+++ b/compiler/luci-interpreter/src/core/RuntimeGraph.cpp
@@ -71,7 +71,7 @@ void RuntimeGraph::execute() const
   // Notify the observers that the input tensors have changed.
   if (event_notifier != nullptr)
   {
-    for (Tensor *input_tensor : getInputTensors())
+    for (const Tensor *input_tensor : getInputTensors())
     {
       event_notifier->postTensorWrite(input_tensor);
     }
@@ -79,8 +79,19 @@ void RuntimeGraph::execute() const
 
   for (const auto &kernel : _kernels)
   {
+    if (event_notifier != nullptr)
+    {
+      event_notifier->preOperatorExecute(kernel.get());
+    }
+
     kernel->execute();
-    for (Tensor *tensor : kernel->getOutputTensors())
+
+    if (event_notifier != nullptr)
+    {
+      event_notifier->postOperatorExecute(kernel.get());
+    }
+
+    for (const Tensor *tensor : kernel->getOutputTensors())
     {
       if (event_notifier != nullptr)
       {

--- a/compiler/luci-interpreter/src/loader/GraphLoader.cpp
+++ b/compiler/luci-interpreter/src/loader/GraphLoader.cpp
@@ -182,7 +182,9 @@ void GraphLoader::loadOperators()
 
     if (isExecutableNode(node))
     {
-      _runtime_graph->addKernel(node->accept(&kernel_builder));
+      std::unique_ptr<Kernel> kernel = node->accept(&kernel_builder);
+      _runtime_to_ir.kernel_to_node.emplace(kernel.get(), node);
+      _runtime_graph->addKernel(std::move(kernel));
     }
   }
 }

--- a/compiler/luci-interpreter/src/loader/RuntimeToIR.h
+++ b/compiler/luci-interpreter/src/loader/RuntimeToIR.h
@@ -29,7 +29,8 @@ namespace luci_interpreter
 // Maps runtime entities back to IR entities. It is used to implement observing functionality.
 struct RuntimeToIR
 {
-  std::unordered_map<Tensor *, const luci::CircleNode *> tensor_to_node;
+  std::unordered_map<const Tensor *, const luci::CircleNode *> tensor_to_node;
+  std::unordered_map<const Kernel *, const luci::CircleNode *> kernel_to_node;
 };
 
 } // namespace luci_interpreter


### PR DESCRIPTION
Add `preOperatorExecute` and `postOperatorExecute` methods to `ExecutionObserver`.

ONE-DCO-1.0-Signed-off-by: Sergei Barannikov <s.barannikov@samsung.com>