### PR TITLE
[Doc] Update how-to-contribute.md

### DIFF
--- a/docs/howto/how-to-contribute.md
+++ b/docs/howto/how-to-contribute.md
@@ -17,7 +17,7 @@ This section explains the steps to create a pull request (PR).
 1. Create an issue
 
    Maintainers will accept your contribution only when it is well aligned with the 
-   [roadmap](https://github.com/Samsung/ONE/blob/master/docs/overview/roadmap.md) and design
+   [roadmap](../overview/roadmap.md) and design
    principles of **ONE**. So, it is optional, but recommended for contributors to create an issue
    and have a discussion with maintainers before writing code.
 

--- a/docs/howto/how-to-contribute.md
+++ b/docs/howto/how-to-contribute.md
@@ -17,9 +17,9 @@ This section explains the steps to create a pull request (PR).
 1. Create an issue
 
    Maintainers will accept your contribution only when it is well aligned with the 
-   [roadmap](./overview/roadmap.md) and design principles of **ONE**. So, it is optional, but 
-   recommended for contributors to create an issue and have a discussion with maintainers before 
-   writing code.
+   [roadmap](https://github.com/Samsung/ONE/blob/master/docs/overview/roadmap.md) and design
+   principles of **ONE**. So, it is optional, but recommended for contributors to create an issue
+   and have a discussion with maintainers before writing code.
 
 1. Create a draft PR
 


### PR DESCRIPTION
As reported in #2854, the current **how-to-contribute.md** indicates a wrong direction, so that visitors cannot access the **roadmap** correctly. The proposed commit is to resolve this issue.

_This PR is the same as the my closed PR #2855, but I removed the previous commit history which is not related to this proposal._

Signed-off-by: Peter Moonki Hong <moonki1.hong@samsung.com>