### PR TITLE
[onert] Avoid preparing cache for ruy kernel on fc layer, cpu

### DIFF
--- a/runtime/onert/backend/cpu/ops/FullyConnectedLayer.cc
+++ b/runtime/onert/backend/cpu/ops/FullyConnectedLayer.cc
@@ -164,6 +164,13 @@ void FullyConnectedLayer::run()
 void FullyConnectedLayer::prepare()
 {
 #ifdef USE_RUY_GEMV
+  // The only fc hybrid will use ruy kernel
+  if (_input->data_type() != OperandType::FLOAT32 ||
+      _weights->data_type() != OperandType::QUANT_INT8_SYMM)
+  {
+    return;
+  }
+
   // NOTE. The condition to enable caching on ruy kernel can be changed according to ruy's version
   const int rows = getTensorShape(_weights).Dims(0);
   if (rows % 4 == 0)

--- a/runtime/onert/backend/cpu/ops/FullyConnectedLayer.cc
+++ b/runtime/onert/backend/cpu/ops/FullyConnectedLayer.cc
@@ -172,6 +172,7 @@ void FullyConnectedLayer::prepare()
     return;
   }
 
+  // TODO Support dynamic input tnesor
   // For now, dynamic input cannot support
   assert(_input->is_dynamic() == false);
 

--- a/runtime/onert/backend/cpu/ops/FullyConnectedLayer.cc
+++ b/runtime/onert/backend/cpu/ops/FullyConnectedLayer.cc
@@ -164,12 +164,16 @@ void FullyConnectedLayer::run()
 void FullyConnectedLayer::prepare()
 {
 #ifdef USE_RUY_GEMV
+  // TODO This is workaround
   // The only fc hybrid will use ruy kernel
   if (_input->data_type() != OperandType::FLOAT32 ||
       _weights->data_type() != OperandType::QUANT_INT8_SYMM)
   {
     return;
   }
+
+  // For now, dynamic input cannot support
+  assert(_input->is_dynamic() == false);
 
   // NOTE. The condition to enable caching on ruy kernel can be changed according to ruy's version
   const int rows = getTensorShape(_weights).Dims(0);


### PR DESCRIPTION
Avoid preparing cache for ruy kernel of fc layer on cpu.
The only fc hybrid will use ruy kernel to cache.

ONE-DCO-1.0-Signed-off-by: Yongseop Kim <yons.kim@samsung.com>