### PR TITLE
[circlechef] Introduce BCQ operations circle directory

### DIFF
--- a/compiler/circlechef/circle/src/CircleOpRegistry.h
+++ b/compiler/circlechef/circle/src/CircleOpRegistry.h
@@ -56,6 +56,8 @@ private:
   _circleop_map[circle::BuiltinOperator_##OPCODE] = std::make_unique<CLASS>()
 
     REG_TFL_OP(BATCH_MATMUL, CircleOpBatchMatMul);
+    REG_TFL_OP(BCQ_FULLY_CONNECTED, CircleOpBCQFullyConnected);
+    REG_TFL_OP(BCQ_GATHER, CircleOpBCQGather);
     REG_TFL_OP(INSTANCE_NORM, CircleOpInstanceNorm);
 #undef REG_TFL_OP
   }

--- a/compiler/circlechef/circle/src/Op/BCQFullyConnected.cpp
+++ b/compiler/circlechef/circle/src/Op/BCQFullyConnected.cpp
@@ -24,7 +24,22 @@ namespace circlechef
 void CircleOpBCQFullyConnected::filler(const circle::Operator *op, CircleImport *import,
                                        circlechef::ModelRecipe *model_recipe) const
 {
-  // Nothing to do with filler
+  const std::vector<int32_t> &inputs = as_index_vector(op->inputs());
+
+  import->set_tensor_filler(inputs[1]);
+  import->set_tensor_filler(inputs[3]);
+
+  const circle::Tensor *tensor2 = import->tensors()->Get(inputs[2]);
+  assert(tensor2->type() == circle::TensorType::TensorType_INT32);
+  const circle::Buffer *buffer2 = import->buffers()->Get(tensor2->buffer());
+  auto vec2 = extract_buffer<int32_t>(buffer2);
+  import->set_tensor_filler(inputs[2], vec2);
+
+  const circle::Tensor *tensor4 = import->tensors()->Get(inputs[4]);
+  assert(tensor4->type() == circle::TensorType::TensorType_INT32);
+  const circle::Buffer *buffer4 = import->buffers()->Get(tensor4->buffer());
+  auto vec4 = extract_buffer<int32_t>(buffer4);
+  import->set_tensor_filler(inputs[4], vec4);
 }
 
 circlechef::Operation *CircleOpBCQFullyConnected::build(const circle::Operator *op,

--- a/compiler/circlechef/circle/src/Op/BCQFullyConnected.cpp
+++ b/compiler/circlechef/circle/src/Op/BCQFullyConnected.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "BCQFullyConnected.h"
+
+#include "Convert.h"
+
+namespace circlechef
+{
+
+void CircleOpBCQFullyConnected::filler(const circle::Operator *op, CircleImport *import,
+                                       circlechef::ModelRecipe *model_recipe) const
+{
+  // Nothing to do with filler
+}
+
+circlechef::Operation *CircleOpBCQFullyConnected::build(const circle::Operator *op,
+                                                        CircleImport *import,
+                                                        circlechef::ModelRecipe *model_recipe) const
+{
+  auto op_params = op->builtin_options_as_BCQFullyConnectedOptions();
+  assert(op_params != nullptr);
+
+  auto operation = model_recipe->add_operation();
+
+  operation->set_type("BCQFullyConnected");
+
+  auto op_options = operation->mutable_bcq_fully_connected_options();
+
+  op_options->set_weights_hidden_size(op_params->weights_hidden_size());
+  op_options->set_activation(as_circlechef_activation(op_params->fused_activation_function()));
+
+  return operation;
+}
+
+} // namespace circlechef

--- a/compiler/circlechef/circle/src/Op/BCQFullyConnected.h
+++ b/compiler/circlechef/circle/src/Op/BCQFullyConnected.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __CIRCLE_OP_BCQFULLYCONNECTED_H__
+#define __CIRCLE_OP_BCQFULLYCONNECTED_H__
+
+#include "CircleOpChef.h"
+
+namespace circlechef
+{
+
+/**
+ * @brief circlechef operator builder for BCQFullyConnected
+ */
+class CircleOpBCQFullyConnected : public CircleOpChef
+{
+public:
+  void filler(const circle::Operator *op, CircleImport *import,
+              circlechef::ModelRecipe *model_recipe) const override;
+  circlechef::Operation *build(const circle::Operator *op, CircleImport *import,
+                               circlechef::ModelRecipe *model_recipe) const override;
+};
+
+} // namespace circlechef
+
+#endif // __CIRCLE_OP_BCQFULLYCONNECTED_H__

--- a/compiler/circlechef/circle/src/Op/BCQGather.cpp
+++ b/compiler/circlechef/circle/src/Op/BCQGather.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "BCQGather.h"
+
+namespace circlechef
+{
+
+void CircleOpBCQGather::filler(const circle::Operator *op, CircleImport *import,
+                               circlechef::ModelRecipe *model_recipe) const
+{
+  // Nothing to do with filler
+}
+
+circlechef::Operation *CircleOpBCQGather::build(const circle::Operator *op, CircleImport *import,
+                                                circlechef::ModelRecipe *model_recipe) const
+{
+  auto op_params = op->builtin_options_as_BCQGatherOptions();
+  assert(op_params != nullptr);
+
+  auto operation = model_recipe->add_operation();
+
+  operation->set_type("BCQGather");
+
+  auto op_options = operation->mutable_bcq_gather_options();
+
+  op_options->set_input_hidden_size(op_params->input_hidden_size());
+  op_options->set_axis(op_params->axis());
+
+  return operation;
+}
+
+} // namespace circlechef

--- a/compiler/circlechef/circle/src/Op/BCQGather.cpp
+++ b/compiler/circlechef/circle/src/Op/BCQGather.cpp
@@ -16,13 +16,35 @@
 
 #include "BCQGather.h"
 
+#include "Convert.h"
+
 namespace circlechef
 {
 
 void CircleOpBCQGather::filler(const circle::Operator *op, CircleImport *import,
                                circlechef::ModelRecipe *model_recipe) const
 {
-  // Nothing to do with filler
+  const std::vector<int32_t> &inputs = as_index_vector(op->inputs());
+
+  import->set_tensor_filler(inputs[0]);
+
+  const circle::Tensor *tensor1 = import->tensors()->Get(inputs[1]);
+  assert(tensor1->type() == circle::TensorType::TensorType_INT32);
+  const circle::Buffer *buffer1 = import->buffers()->Get(tensor1->buffer());
+  auto vec1 = extract_buffer<int32_t>(buffer1);
+  import->set_tensor_filler(inputs[1], vec1);
+
+  const circle::Tensor *tensor2 = import->tensors()->Get(inputs[2]);
+  assert(tensor2->type() == circle::TensorType::TensorType_INT32);
+  const circle::Buffer *buffer2 = import->buffers()->Get(tensor2->buffer());
+  auto vec2 = extract_buffer<int32_t>(buffer2);
+  import->set_tensor_filler(inputs[2], vec2);
+
+  const circle::Tensor *tensor3 = import->tensors()->Get(inputs[3]);
+  assert(tensor3->type() == circle::TensorType::TensorType_INT32);
+  const circle::Buffer *buffer3 = import->buffers()->Get(tensor3->buffer());
+  auto vec3 = extract_buffer<int32_t>(buffer3);
+  import->set_tensor_filler(inputs[3], vec3);
 }
 
 circlechef::Operation *CircleOpBCQGather::build(const circle::Operator *op, CircleImport *import,

--- a/compiler/circlechef/circle/src/Op/BCQGather.h
+++ b/compiler/circlechef/circle/src/Op/BCQGather.h
@@ -14,13 +14,26 @@
  * limitations under the License.
  */
 
-#ifndef __CIRCLE_OP_CHEFS_H__
-#define __CIRCLE_OP_CHEFS_H__
+#ifndef __CIRCLE_OP_BCQGATHER_H__
+#define __CIRCLE_OP_BCQGATHER_H__
 
-// In alphabet order
-#include "Op/BatchMatMul.h"
-#include "Op/BCQFullyConnected.h"
-#include "Op/BCQGather.h"
-#include "Op/InstanceNorm.h"
+#include "CircleOpChef.h"
 
-#endif // __CIRCLE_OP_CHEFS_H__
+namespace circlechef
+{
+
+/**
+ * @brief circlechef operator builder for BCQGather
+ */
+class CircleOpBCQGather : public CircleOpChef
+{
+public:
+  void filler(const circle::Operator *op, CircleImport *import,
+              circlechef::ModelRecipe *model_recipe) const override;
+  circlechef::Operation *build(const circle::Operator *op, CircleImport *import,
+                               circlechef::ModelRecipe *model_recipe) const override;
+};
+
+} // namespace circlechef
+
+#endif // __CIRCLE_OP_BCQGATHER_H__


### PR DESCRIPTION
Parent Issue : #1517
Draft : #2739

This commit will add BCQ operations in `circlechef/circle` directory.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>