### PR TITLE
[onert] Fix getting OpSequence inputs

### DIFF
--- a/runtime/onert/core/src/ir/LoweredGraph.cc
+++ b/runtime/onert/core/src/ir/LoweredGraph.cc
@@ -298,7 +298,15 @@ void LoweredGraph::makeOpSequences(
         else
         {
           op_seq->appendOperation(node_index);
-          op_seq->setInputs(node.getInputs());
+          // Set inputs
+          auto new_inputs = node.getInputs();
+          // Add inputs except outputs of the previous node
+          for (auto ind : op_seq->getInputs())
+          {
+            if (!node.getOutputs().contains(ind))
+              new_inputs.append(ind);
+          }
+          op_seq->setInputs(new_inputs);
 
           VERBOSE(Lower) << "OpSequence#" << op_seq_index.value() << " merges "
                          << "NODE#" << node_index.value() << "(" << node.name() << ")" << std::endl;


### PR DESCRIPTION
As not only the first operation can have inputs, we should count all
the operations other which are not an output of the current
`OpSequence`.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>