### PR TITLE
[onert] Make applying dynamic of controlflow operations only in PermuteLayer

### DIFF
--- a/runtime/onert/core/src/backend/controlflow/kernel/IfLayer.cc
+++ b/runtime/onert/core/src/backend/controlflow/kernel/IfLayer.cc
@@ -124,20 +124,6 @@ void IfLayer::run()
 
   // Copy & run
   subg_exec->execute(_input_tensors, permute_op_input_to_subg_input);
-  for (size_t i = 0; i < _output_tensors.size(); ++i)
-  {
-    const auto output_tensor = _output_tensors.at(i);
-    const auto orig_output_shape = output_tensor->getShape();
-    const auto changed_output_shape = subg_exec->getOutputTensors().at(i)->getShape();
-    const auto &output_dyn_alloc_info = _outputs_dyn_alloc_info.find(output_tensor);
-    if (orig_output_shape != changed_output_shape &&
-        _outputs_dyn_alloc_info.find(output_tensor) != _outputs_dyn_alloc_info.end() &&
-        (_graph.operands().at(output_dyn_alloc_info->second.ind).getUses().size() > 0 ||
-         _graph.getOutputs().contains(output_dyn_alloc_info->second.ind)))
-    {
-      output_tensor->set_dynamic();
-    }
-  }
   permute_subg_output_to_op_output->run();
 }
 

--- a/runtime/onert/core/src/backend/controlflow/kernel/PermuteLayer.cc
+++ b/runtime/onert/core/src/backend/controlflow/kernel/PermuteLayer.cc
@@ -52,9 +52,19 @@ void PermuteLayer::run()
       ir::Shape new_shape =
           exec::convertShape(src_shape, src_tensor->layout(), dst_tensor->layout());
 
-      const auto dst_index = _dst_dyn_alloc_info_map.at(dst_tensor).ind;
-      _dst_dyn_alloc_info_map.at(dst_tensor).dyn_tensor_manager->applyShape(dst_index, new_shape);
-      assert(dst_tensor->buffer() != nullptr);
+      try
+      {
+        const auto dst_index = _dst_dyn_alloc_info_map.at(dst_tensor).ind;
+        _dst_dyn_alloc_info_map.at(dst_tensor).dyn_tensor_manager->applyShape(dst_index, new_shape);
+        assert(dst_tensor->buffer() != nullptr);
+      }
+      catch (const std::out_of_range &e)
+      {
+        std::cerr << "Error: out_of_range in PermuteLayer: output's TensorManager does not support "
+                     "dynamic tensor"
+                  << '\n';
+        throw;
+      }
     }
     assert(exec::convertShape(src_tensor->getShape(), src_tensor->layout(), dst_tensor->layout()) ==
            dst_tensor->getShape());

--- a/runtime/onert/core/src/backend/controlflow/kernel/WhileLayer.cc
+++ b/runtime/onert/core/src/backend/controlflow/kernel/WhileLayer.cc
@@ -186,24 +186,6 @@ void WhileLayer::run()
     return ret;
   };
 
-  auto setOpOutputDynamic = [&](const std::vector<std::shared_ptr<backend::ITensor>> &src_tensors) {
-    assert(_output_tensors.size() == src_tensors.size());
-    for (size_t i = 0; i < _output_tensors.size(); ++i)
-    {
-      const auto output_tensor = _output_tensors.at(i);
-      const auto orig_output_shape = output_tensor->getShape();
-      const auto changed_output_shape = src_tensors.at(i)->getShape();
-      const auto &output_dyn_alloc_info = _outputs_dyn_alloc_info.find(output_tensor);
-      if (orig_output_shape != changed_output_shape &&
-          output_dyn_alloc_info != _outputs_dyn_alloc_info.end() &&
-          (_graph.operands().at(output_dyn_alloc_info->second.ind).getUses().size() > 0 ||
-           _graph.getOutputs().contains(output_dyn_alloc_info->second.ind)))
-      {
-        output_tensor->set_dynamic();
-      }
-    }
-  };
-
   const auto body_execute_with_op_inputs = [&]() {
     body_exec->execute(_input_tensors, permute_op_input_to_body_input);
   };
@@ -226,7 +208,6 @@ void WhileLayer::run()
     body_execute = body_execute_with_body_outputs;
     permute_to_outputs_fn = permute_body_output_to_op_output;
   }
-  setOpOutputDynamic(body_exec->getOutputTensors());
   permute_to_outputs_fn->run();
 }
 


### PR DESCRIPTION
This commit makes applying dynamic of controlflow operations only in PermuteLayer.
  - Remove applying dynamic from WhileLayer and IfLayer
  - Add an exception handling of checking surpporting dynamic in PermuteLayer

Signed-off-by: ragmani <ragmani0216@gmail.com>