### PR TITLE
[onert] Move inference code to compier & exec dir

### DIFF
--- a/runtime/onert/backend/cpu/KernelGenerator.cc
+++ b/runtime/onert/backend/cpu/KernelGenerator.cc
@@ -79,6 +79,7 @@
 #include <memory>
 #include <util/Utils.h>
 #include <util/logging.h>
+#include <exec/DynamicShapeInference.h>
 
 #include <stdexcept>
 
@@ -106,7 +107,7 @@ void KernelGenerator::visit(const ir::OpSequence &op_seq)
   assert(_tensor_builder->tensorRegistry());
 
   auto dyn_tensor_manager = _tensor_builder->dynamicTensorManager();
-  auto dyn_shape_inferer = std::make_unique<shape_inference::DynamicInferer>(
+  auto dyn_shape_inferer = std::make_unique<exec::DynamicInferer>(
       _ctx, dyn_tensor_manager, _tensor_builder->tensorRegistry());
 
   // TODO Always returning FunctionSequenceForDynamicBackend may cause performance issue

--- a/runtime/onert/core/include/compiler/StaticShapeInference.h
+++ b/runtime/onert/core/include/compiler/StaticShapeInference.h
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_COMPILER_STATIC_SHAPE_INFERENCE_H__
+#define __ONERT_COMPILER_STATIC_SHAPE_INFERENCE_H__
+
+#include "ir/OperationVisitor.h"
+#include "ir/OpSequence.h"
+#include "ir/LoweredGraph.h"
+#include "ir/Index.h"
+
+#include <memory>
+#include <unordered_map>
+
+namespace onert
+{
+namespace compiler
+{
+
+/**
+ * @brief Class to infer shape before running kernels. It does the following:
+ *        - re-calculate and set output shape at compile time (before running kernels)
+ *        - if calculation cannot be done at compile time, mark the outputs to be dynamic, meaning
+ *          shapes of outputs will be calculated during running kernels
+ */
+class StaticInferer : public ir::OperationVisitor
+{
+public:
+  StaticInferer(
+      const ir::SubgraphIndex &subg_idx,
+      const std::unordered_map<ir::SubgraphIndex, std::unique_ptr<ir::LoweredGraph>> &lowered_subgs)
+      : _lowered_subgs(lowered_subgs), _operands(lowered_subgs.at(subg_idx)->graph().operands()),
+        _operations(lowered_subgs.at(subg_idx)->graph().operations())
+  { /* empty */
+  }
+  virtual ~StaticInferer() = default;
+
+public:
+  /**
+   * @brief Infer shape of operands beloning to ops and set the output shape.
+   *        If output shape cannot be known without running op, mark it so that it can be allocated
+   *        when running kernel.
+   * @param op_seq sequence of operations
+   */
+  void infer(const ir::OpSequence &op_seq)
+  {
+    for (const auto &operation_idx : op_seq.operations())
+    {
+      _operations.at(operation_idx).accept(*this);
+    }
+  }
+
+  void dump();
+
+private:
+  // TODO Define visitors for operations. List them in alphabetic order.
+  void visit(const ir::operation::Abs &op);
+  void visit(const ir::operation::Add &op);
+  void visit(const ir::operation::ArgMax &op);
+  void visit(const ir::operation::BatchMatMul &op);
+  void visit(const ir::operation::BroadcastTo &op);
+  void visit(const ir::operation::Cast &op);
+  void visit(const ir::operation::Comparison &op);
+  void visit(const ir::operation::Concat &op);
+  void visit(const ir::operation::Conv2D &op);
+  void visit(const ir::operation::Cos &op);
+  void visit(const ir::operation::Div &op);
+  void visit(const ir::operation::Exp &op);
+  void visit(const ir::operation::ExpandDims &op);
+  void visit(const ir::operation::Fill &op);
+  void visit(const ir::operation::FullyConnected &op);
+  void visit(const ir::operation::FusedBatchNorm &op);
+  void visit(const ir::operation::Gather &op);
+  void visit(const ir::operation::If &op);
+  void visit(const ir::operation::Log &op);
+  void visit(const ir::operation::LogicalNot &op);
+  void visit(const ir::operation::LogicalOr &op);
+  void visit(const ir::operation::Logistic &op);
+  void visit(const ir::operation::MatrixBandPart &op);
+  void visit(const ir::operation::Max &op);
+  void visit(const ir::operation::Mean &op);
+  void visit(const ir::operation::Min &op);
+  void visit(const ir::operation::Mul &op);
+  void visit(const ir::operation::Neg &op);
+  void visit(const ir::operation::OneHot &op);
+  void visit(const ir::operation::Pack &op);
+  void visit(const ir::operation::Pad &op);
+  void visit(const ir::operation::Permute &op);
+  void visit(const ir::operation::Pow &op);
+  void visit(const ir::operation::Range &op);
+  void visit(const ir::operation::ReduceAll &op);
+  void visit(const ir::operation::ReduceMin &op);
+  void visit(const ir::operation::ReduceProd &op);
+  void visit(const ir::operation::ReduceSum &op);
+  void visit(const ir::operation::Reshape &op);
+  void visit(const ir::operation::Round &op);
+  void visit(const ir::operation::RSQRT &op);
+  void visit(const ir::operation::Reverse &op);
+  void visit(const ir::operation::Select &op);
+  void visit(const ir::operation::Shape &op);
+  void visit(const ir::operation::Sin &op);
+  void visit(const ir::operation::Slice &op);
+  void visit(const ir::operation::Softmax &op);
+  void visit(const ir::operation::Split &op);
+  void visit(const ir::operation::Squeeze &op);
+  void visit(const ir::operation::StridedSlice &op);
+  void visit(const ir::operation::Sub &op);
+  void visit(const ir::operation::SquaredDifference &op);
+  void visit(const ir::operation::Tanh &op);
+  void visit(const ir::operation::Tile &op);
+  void visit(const ir::operation::Transpose &op);
+  void visit(const ir::operation::Unpack &op);
+  void visit(const ir::operation::While &op);
+  void visit(const ir::operation::ZerosLike &op);
+
+private:
+  /**
+   * @brief Performs shape inference for arithmetic operation
+   */
+  void handleBinaryArithmeticOp(const ir::Operation &op, const ir::OperandIndex lhs_idx,
+                                const ir::OperandIndex rhs_idx);
+
+  /**
+   * @brief Performs shape inference for unary op whose output shape is
+   *        always same with input shape
+   */
+  void handleSimpleUnaryOp(const ir::Operation &op, const ir::OperandIndex input_idx);
+
+private:
+  const std::unordered_map<ir::SubgraphIndex, std::unique_ptr<ir::LoweredGraph>> &_lowered_subgs;
+  // _operands and _operations can be changed by controlflow operation
+  ir::Operands &_operands;     // operands of current subgraph
+  ir::Operations &_operations; // operations of current subgraph
+};
+
+} // namespace compiler
+} // namespace onert
+
+#endif // __ONERT_COMPILER_STATIC_SHAPE_INFERENCE_H__

--- a/runtime/onert/core/include/exec/DynamicShapeInference.h
+++ b/runtime/onert/core/include/exec/DynamicShapeInference.h
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_EXEC_DYNAMIC_SHAPE_INFERENCE_H__
+#define __ONERT_EXEC_DYNAMIC_SHAPE_INFERENCE_H__
+
+#include "ir/Operands.h"
+#include "ir/OperationVisitor.h"
+#include "ir/Index.h"
+#include "backend/IDynamicTensorManager.h"
+#include "backend/ITensorManager.h"
+#include "backend/ITensorRegistry.h"
+
+#include <map>
+
+namespace onert
+{
+namespace exec
+{
+
+/**
+ * @brief Class to infer shape of output tensor at execution time and
+ *        allocate memory fo output tensor if needed
+ */
+class DynamicInferer : public ir::OperationVisitor
+{
+public:
+  DynamicInferer(const ir::Operands &operands, backend::IDynamicTensorManager *tensor_manager,
+                 const std::shared_ptr<backend::ITensorRegistry> &tensor_registry)
+      : _operands(operands), _dynamic_tensor_manager(tensor_manager),
+        _tensor_registry(tensor_registry)
+  {
+    UNUSED_RELEASE(_operands);
+    UNUSED_RELEASE(_dynamic_tensor_manager);
+    UNUSED_RELEASE(_tensor_registry);
+  }
+
+public:
+  // TODO Define visitors for operations. List them in alphabetic order.
+  // Remove TODO when any op starting from the alphabet is added
+  void visit(const ir::operation::Abs &op);
+  void visit(const ir::operation::Add &op);
+  void visit(const ir::operation::ArgMax &op);
+  void visit(const ir::operation::BatchMatMul &op);
+  void visit(const ir::operation::BroadcastTo &op);
+  void visit(const ir::operation::Cast &op);
+  void visit(const ir::operation::Comparison &op);
+  void visit(const ir::operation::Concat &op);
+  void visit(const ir::operation::Conv2D &op);
+  void visit(const ir::operation::Cos &op);
+  void visit(const ir::operation::Div &op);
+  void visit(const ir::operation::Exp &op);
+  void visit(const ir::operation::ExpandDims &op);
+  void visit(const ir::operation::Fill &op);
+  void visit(const ir::operation::FullyConnected &op);
+  void visit(const ir::operation::FusedBatchNorm &op);
+  void visit(const ir::operation::Gather &op);
+  void visit(const ir::operation::Log &op);
+  void visit(const ir::operation::LogicalNot &op);
+  void visit(const ir::operation::LogicalOr &op);
+  void visit(const ir::operation::Logistic &op);
+  void visit(const ir::operation::MatrixBandPart &op);
+  void visit(const ir::operation::Max &op);
+  void visit(const ir::operation::Mean &op);
+  void visit(const ir::operation::Min &op);
+  void visit(const ir::operation::Mul &op);
+  void visit(const ir::operation::Neg &op);
+  void visit(const ir::operation::OneHot &op);
+  void visit(const ir::operation::Pack &op);
+  void visit(const ir::operation::Pad &op);
+  void visit(const ir::operation::Permute &op);
+  void visit(const ir::operation::Pow &op);
+  // TODO write op starting from Q
+  void visit(const ir::operation::Range &op);
+  void visit(const ir::operation::ReduceAll &op);
+  void visit(const ir::operation::ReduceMin &op);
+  void visit(const ir::operation::ReduceProd &op);
+  void visit(const ir::operation::ReduceSum &op);
+  void visit(const ir::operation::Reshape &op);
+  void visit(const ir::operation::Round &op);
+  void visit(const ir::operation::RSQRT &op);
+  void visit(const ir::operation::Reverse &op);
+  void visit(const ir::operation::Select &op);
+  void visit(const ir::operation::Shape &op);
+  void visit(const ir::operation::Sin &op);
+  void visit(const ir::operation::Slice &op);
+  void visit(const ir::operation::Softmax &op);
+  void visit(const ir::operation::Split &op);
+  void visit(const ir::operation::Squeeze &op);
+  void visit(const ir::operation::StridedSlice &op);
+  void visit(const ir::operation::Sub &op);
+  void visit(const ir::operation::SquaredDifference &op);
+  void visit(const ir::operation::Tanh &op);
+  void visit(const ir::operation::Tile &op);
+  void visit(const ir::operation::Transpose &op);
+  void visit(const ir::operation::Unpack &op);
+  // TODO write op starting from V
+  void visit(const ir::operation::ZerosLike &op);
+
+private:
+  /**
+   * @brief Performs shape inference and memory allocation for arithmetic operation
+   */
+  void handleBinaryArithmeticOp(const ir::Operation &op, const ir::OperandIndex lhs_idx,
+                                const ir::OperandIndex rhs_idx);
+  /**
+   * @brief Performs shape inference and memory allocation for unary op whose output shape is
+   *        always same with input shape
+   */
+  void handleSimpleUnaryOp(const ir::Operation &op, const ir::OperandIndex input_idx);
+
+private:
+  /**
+   * @brief To get operand-level info, e.g., ir::Operand::isConstant()
+   */
+  const ir::Operands &_operands;
+  /**
+   * @brief To allocate memory for output tensor if needed
+   */
+  backend::IDynamicTensorManager *_dynamic_tensor_manager;
+  /**
+   * @brief To get tensor object and access tensor-level info, e.g., ITensor::buffer()
+   */
+  std::shared_ptr<backend::ITensorRegistry> _tensor_registry;
+};
+
+} // namespace exec
+} // namespace onert
+
+#endif // __ONERT_EXEC_DYNAMIC_SHAPE_INFERENCE_H__

--- a/runtime/onert/core/include/exec/FunctionSequence.h
+++ b/runtime/onert/core/include/exec/FunctionSequence.h
@@ -22,7 +22,8 @@
 #include <functional>
 
 #include "exec/IFunction.h"
-#include "util/ShapeInference.h"
+#include "exec/DynamicShapeInference.h"
+#include "ir/Operations.h"
 
 #include <memory>
 
@@ -82,10 +83,9 @@ protected:
 class FunctionSequenceForDynamicBackend : public FunctionSequence
 {
 public:
-  FunctionSequenceForDynamicBackend(
-      const ir::OpSequence &op_seq, const ir::Operations &operations,
-      std::unique_ptr<shape_inference::DynamicInferer> dyn_shape_inferer,
-      backend::IDynamicTensorManager *dyn_tensor_manager)
+  FunctionSequenceForDynamicBackend(const ir::OpSequence &op_seq, const ir::Operations &operations,
+                                    std::unique_ptr<DynamicInferer> dyn_shape_inferer,
+                                    backend::IDynamicTensorManager *dyn_tensor_manager)
       : _op_seq(op_seq), _operations_ctx(operations),
         _dyn_shape_inferer(std::move(dyn_shape_inferer)), _dyn_tensor_manager(dyn_tensor_manager)
   { /* empty */
@@ -97,7 +97,7 @@ private:
   const ir::OpSequence &_op_seq;
   const ir::Operations &_operations_ctx;
   /// @brief shape inferer at execution time
-  std::unique_ptr<shape_inference::DynamicInferer> _dyn_shape_inferer;
+  std::unique_ptr<DynamicInferer> _dyn_shape_inferer;
   backend::IDynamicTensorManager *_dyn_tensor_manager;
 };
 

--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -26,6 +26,7 @@
 #include "compiler/IScheduler.h"
 #include "compiler/ManualScheduler.h"
 #include "compiler/HEScheduler.h"
+#include "compiler/StaticShapeInference.h"
 #include "exec/ExecTime.h"
 #include "ir/operation/LowerInfo.h"
 #include "dumper/dot/DotDumper.h"
@@ -33,7 +34,6 @@
 #include "interp/InterpExecutor.h"
 #include "util/ConfigSource.h"
 #include "util/logging.h"
-#include "util/ShapeInference.h"
 #include "ir/OperationDumper.h"
 #include "misc/string_helpers.h"
 
@@ -211,7 +211,7 @@ void Compiler::compile(void)
   // Shape inference.
   {
     const auto primary_subg_idx = ir::SubgraphIndex{0};
-    shape_inference::StaticInferer inferer(primary_subg_idx, lowered_subgs);
+    StaticInferer inferer(primary_subg_idx, lowered_subgs);
     lowered_subgs.at(primary_subg_idx)
         ->iterateTopolOpSeqs([&](const ir::OpSequenceIndex &, const ir::OpSequence &op_seq) {
           inferer.infer(op_seq);

--- a/runtime/onert/core/src/compiler/StaticShapeInference.cc
+++ b/runtime/onert/core/src/compiler/StaticShapeInference.cc
@@ -1,0 +1,1434 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "compiler/StaticShapeInference.h"
+#include "util/ShapeInference.h"
+#include "util/logging.h"
+
+#include <sstream>
+
+namespace onert
+{
+namespace compiler
+{
+
+void StaticInferer::handleBinaryArithmeticOp(const ir::Operation &op,
+                                             const ir::OperandIndex lhs_idx,
+                                             const ir::OperandIndex rhs_idx)
+{
+  const auto &lhs = _operands.at(lhs_idx);
+  const auto &rhs = _operands.at(rhs_idx);
+
+  const auto output_idx = op.getOutputs().at(0);
+  ir::Operand &output = _operands.at(output_idx);
+
+  if (lhs.info().isDynamic() || rhs.info().isDynamic())
+  {
+    output.info().setDynamic();
+    return;
+  }
+
+  // re-sizing output shape
+  ir::Shape new_shape = shape_inference::inferEltwiseShape(lhs.info().shape(), rhs.info().shape());
+  output.info().shape(new_shape);
+}
+
+void StaticInferer::handleSimpleUnaryOp(const ir::Operation &op, const ir::OperandIndex input_idx)
+{
+  const auto &input = _operands.at(input_idx);
+
+  // get mutable output operand
+  const auto output_idx = op.getOutputs().at(0);
+  ir::Operand &output = _operands.at(output_idx);
+
+  // if input is dynamic, output also becomes dynamic
+  if (input.info().isDynamic())
+  {
+    output.info().setDynamic();
+    return;
+  }
+
+  // re-sizing output shape
+  ir::Shape new_shape = input.info().shape();
+  output.info().shape(new_shape);
+}
+
+void StaticInferer::dump()
+{
+  auto get_shape_str = [](const ir::Shape &shape) {
+    std::stringstream sstream;
+    sstream << "shape : {";
+    for (int i = 0; i < shape.rank(); i++)
+    {
+      if (i == 0)
+        sstream << shape.dim(i);
+      else
+        sstream << " " << shape.dim(i);
+    }
+    sstream << "}";
+    return sstream.str();
+  };
+
+  for (const auto &pair : _lowered_subgs)
+  {
+    const auto index = pair.first;
+    const auto &lowered_subg = pair.second;
+    VERBOSE(StaticInferer) << "SubGraph #" << index.value() << std::endl;
+    lowered_subg->graph().operands().iterate(
+        [&](const ir::OperandIndex &ind, const ir::Operand &operand) {
+          VERBOSE(StaticInferer) << "Operand #" << ind.value() << ", "
+                                 << (operand.info().isDynamic() ? "Dynamic" : "Static") << ", "
+                                 << get_shape_str(operand.info().shape()) << std::endl;
+        });
+  }
+}
+
+void StaticInferer::visit(const ir::operation::Abs &op)
+{
+  handleSimpleUnaryOp(op, op.getInputs().at(ir::operation::Abs::Input::INPUT));
+}
+
+void StaticInferer::visit(const ir::operation::Add &op)
+{
+  handleBinaryArithmeticOp(op, op.getInputs().at(ir::operation::Add::Input::LHS),
+                           op.getInputs().at(ir::operation::Add::Input::RHS));
+}
+
+void StaticInferer::visit(const ir::operation::ArgMax &op)
+{
+  const auto input_idx{op.getInputs().at(ir::operation::ArgMax::Input::INPUT)};
+  const auto &input = _operands.at(input_idx);
+
+  // get mutable output operand
+  const auto output_idx = op.getOutputs().at(0);
+  ir::Operand &output = _operands.at(output_idx);
+
+  // if input is dynamic, output also becomes dynamic
+  if (input.info().isDynamic())
+  {
+    output.info().setDynamic();
+    return;
+  }
+
+  const auto rank = input.info().shape().rank();
+  const auto axis = ((op.param().axis < 0) ? rank + op.param().axis : op.param().axis);
+
+  assert(0 <= axis && axis < rank);
+
+  // re-sizing output shape
+  ir::Shape new_shape = shape_inference::argMaxShapes(input.info().shape(), axis, rank);
+  output.info().shape(new_shape);
+}
+
+void StaticInferer::visit(const ir::operation::BatchMatMul &op)
+{
+  const auto lhs_index = op.getInputs().at(ir::operation::BatchMatMul::Input::LHS);
+  const auto rhs_index = op.getInputs().at(ir::operation::BatchMatMul::Input::RHS);
+  const auto output_index = op.getOutputs().at(0);
+  const auto lhs = _operands.at(lhs_index);
+  const auto rhs = _operands.at(rhs_index);
+  auto &output = _operands.at(output_index);
+
+  if (lhs.info().isDynamic() || rhs.info().isDynamic())
+  {
+    output.info().setDynamic();
+    return;
+  }
+
+  auto new_shape = shape_inference::inferBatchMatMulShape(lhs.shape(), rhs.shape(), op.param());
+  output.info().shape(new_shape);
+}
+
+void StaticInferer::visit(const ir::operation::BroadcastTo &op)
+{
+  const auto input_idx{op.getInputs().at(ir::operation::BroadcastTo::Input::INPUT)};
+  const auto &input = _operands.at(input_idx);
+
+  // get mutable output operand
+  const auto output_idx = op.getOutputs().at(0);
+  ir::Operand &output = _operands.at(output_idx);
+
+  // if input is dynamic, output also becomes dynamic.
+  if (input.info().isDynamic())
+  {
+    output.info().setDynamic();
+    return;
+  }
+
+  const auto shape_idx{op.getInputs().at(ir::operation::BroadcastTo::Input::SHAPE)};
+  const auto &shape = _operands.at(shape_idx);
+
+  if (!shape.isConstant())
+  {
+    output.info().setDynamic();
+    return;
+  }
+
+  // assert(shape.typeInfo().type() == ir::DataType::INT32);
+  auto shape_buffer = reinterpret_cast<const int32_t *>(shape.data()->base());
+
+  // re-sizing output shape
+  ir::Shape new_shape = shape_inference::inferBroadcastToShape(shape.info().shape(), shape_buffer);
+  output.info().shape(new_shape);
+}
+
+void StaticInferer::visit(const ir::operation::Cast &op)
+{
+  handleSimpleUnaryOp(op, op.getInputs().at(ir::operation::Cast::Input::INPUT));
+}
+
+void StaticInferer::visit(const ir::operation::Comparison &op)
+{
+  handleBinaryArithmeticOp(op, op.getInputs().at(ir::operation::Comparison::Input::INPUT0),
+                           op.getInputs().at(ir::operation::Comparison::Input::INPUT1));
+}
+
+void StaticInferer::visit(const ir::operation::Concat &op)
+{
+  const auto input_count = op.getInputs().size();
+
+  const auto output_idx = op.getOutputs().at(0);
+  ir::Operand &output = _operands.at(output_idx);
+
+  shape_inference::Shapes input_shapes;
+  for (uint32_t i = 0; i < input_count; i++)
+  {
+    const auto input_idx{op.getInputs().at(i)};
+    const auto &input = _operands.at(input_idx);
+
+    if (input.info().isDynamic())
+    {
+      output.info().setDynamic();
+      return;
+    }
+
+    input_shapes.emplace_back(input.shape());
+  }
+
+  ir::Shape out_shape = shape_inference::inferConcatShape(input_shapes, op.param());
+
+  // re-sizing output shape
+  output.info().shape(out_shape);
+}
+
+void StaticInferer::visit(const ir::operation::Conv2D &op)
+{
+  const auto input_idx{op.getInputs().at(ir::operation::Conv2D::Input::INPUT)};
+  const auto &input = _operands.at(input_idx);
+  const auto ker_idx{op.getInputs().at(ir::operation::Conv2D::Input::KERNEL)};
+  const auto &ker = _operands.at(ker_idx);
+  const auto output_idx = op.getOutputs().at(0);
+  ir::Operand &output = _operands.at(output_idx);
+
+  if (input.info().isDynamic() || ker.info().isDynamic())
+  {
+    output.info().setDynamic();
+    return;
+  }
+
+  // re-sizing output shape
+  ir::Shape new_shape =
+      shape_inference::inferConv2DShape(input.info().shape(), ker.info().shape(), op.param());
+  output.info().shape(new_shape);
+}
+
+void StaticInferer::visit(const ir::operation::Cos &op)
+{
+  handleSimpleUnaryOp(op, op.getInputs().at(ir::operation::Cos::Input::INPUT));
+}
+
+void StaticInferer::visit(const ir::operation::Div &op)
+{
+  handleBinaryArithmeticOp(op, op.getInputs().at(ir::operation::Div::Input::LHS),
+                           op.getInputs().at(ir::operation::Div::Input::RHS));
+}
+
+void StaticInferer::visit(const ir::operation::Exp &op)
+{
+  handleSimpleUnaryOp(op, op.getInputs().at(ir::operation::Exp::Input::INPUT));
+}
+
+void StaticInferer::visit(const ir::operation::ExpandDims &op)
+{
+  const auto input_idx{op.getInputs().at(ir::operation::ExpandDims::Input::INPUT)};
+  const auto &input = _operands.at(input_idx);
+  const auto axis_idx{op.getInputs().at(ir::operation::ExpandDims::Input::AXIS)};
+  const auto &axis = _operands.at(axis_idx);
+  const auto output_idx = op.getOutputs().at(0);
+  ir::Operand &output = _operands.at(output_idx);
+
+  if (input.info().isDynamic())
+  {
+    output.info().setDynamic();
+    return;
+  }
+
+  if (!axis.isConstant())
+  {
+    output.info().setDynamic();
+    return;
+  }
+
+  // even when axis is constant, output shape should be recalculated since user might call
+  // nnfw_set_input_tensorinfo(input, some_new_shape)
+  auto axis_buf = reinterpret_cast<const int32_t *>(axis.data()->base());
+  assert(axis_buf);
+
+  // re-sizing output shape
+  ir::Shape new_shape = shape_inference::inferExpandDimsShape(input.info().shape(), axis_buf[0]);
+  output.info().shape(new_shape);
+}
+
+void StaticInferer::visit(const ir::operation::Fill &op)
+{
+  const auto input_idx{op.getInputs().at(ir::operation::Fill::Input::INPUT)};
+  const auto &input = _operands.at(input_idx);
+  const auto output_idx = op.getOutputs().at(0);
+  ir::Operand &output = _operands.at(output_idx);
+
+  if (input.info().isDynamic())
+  {
+    output.info().setDynamic();
+    return;
+  }
+
+  if (!input.isConstant())
+  {
+    output.info().setDynamic();
+    return;
+  }
+
+  assert(input.typeInfo().type() == ir::DataType::INT32);
+
+  auto input_buf = reinterpret_cast<const int32_t *>(input.data()->base());
+  assert(input_buf);
+
+  // re-sizing output shape
+  ir::Shape new_shape = shape_inference::inferFillShape(input.info().shape(), input_buf);
+  output.info().shape(new_shape);
+}
+
+void StaticInferer::visit(const ir::operation::FullyConnected &op)
+{
+  const auto input_idx{op.getInputs().at(ir::operation::FullyConnected::Input::INPUT)};
+  const auto &input = _operands.at(input_idx);
+
+  const auto ker_idx{op.getInputs().at(ir::operation::FullyConnected::Input::WEIGHT)};
+  const auto &ker = _operands.at(ker_idx);
+
+  // get mutable output operand
+  const auto output_idx = op.getOutputs().at(0);
+  ir::Operand &output = _operands.at(output_idx);
+
+  // if input or ker is dynamic, output also becomes dynamic
+  if (input.info().isDynamic() || ker.info().isDynamic())
+  {
+    output.info().setDynamic();
+    return;
+  }
+
+  // re-sizing output shape
+  ir::Shape new_shape =
+      shape_inference::inferFullyConnectedShape(input.info().shape(), ker.info().shape());
+  output.info().shape(new_shape);
+}
+
+void StaticInferer::visit(const ir::operation::FusedBatchNorm &op)
+{
+  handleSimpleUnaryOp(op, op.getInputs().at(ir::operation::FusedBatchNorm::Input::INPUT));
+}
+
+void StaticInferer::visit(const ir::operation::Gather &op)
+{
+  const auto input_idx{op.getInputs().at(ir::operation::Gather::Input::INPUT)};
+  const auto &input = _operands.at(input_idx);
+
+  // get mutable output operand
+  const auto output_idx = op.getOutputs().at(0);
+  ir::Operand &output = _operands.at(output_idx);
+
+  const auto indices_idx{op.getInputs().at(ir::operation::Gather::Input::INDICES)};
+  const auto &indices = _operands.at(indices_idx);
+
+  // if input is dynamic, output also becomes dynamic
+  if (input.info().isDynamic() || indices.info().isDynamic())
+  {
+    output.info().setDynamic();
+    return;
+  }
+
+  const auto rank = input.info().shape().rank();
+  const auto axis = ((op.param().axis < 0) ? rank + op.param().axis : op.param().axis);
+
+  assert(0 <= axis && axis < rank);
+
+  // re-sizing output shape
+  ir::Shape new_shape =
+      shape_inference::gatherShapes(input.info().shape(), indices.info().shape(), axis, rank);
+  output.info().shape(new_shape);
+}
+
+void StaticInferer::visit(const ir::operation::If &op)
+{
+  auto &then_graph = _lowered_subgs.at(op.param().then_subg_index)->graph();
+  auto &else_graph = _lowered_subgs.at(op.param().else_subg_index)->graph();
+  const std::vector<ir::OperandIndex> inputs{op.getInputs().begin() + 1, op.getInputs().end()};
+  const auto &outputs = op.getOutputs();
+
+  // re-sizing input shapes of then subgraph
+  const auto &then_inputs = then_graph.getInputs();
+  assert(inputs.size() == then_inputs.size());
+  for (size_t i = 0; i < inputs.size(); ++i)
+  {
+    auto &then_input = then_graph.operands().at(then_inputs.at(i));
+    if (_operands.at(inputs.at(i)).info().isDynamic())
+    {
+      then_input.info().setDynamic();
+    }
+    else
+    {
+      auto new_shape = _operands.at(inputs.at(i)).info().shape();
+      then_input.info().shape(new_shape);
+    }
+  }
+
+  // re-sizing input shapes of else subgraph
+  const auto &else_inputs = else_graph.getInputs();
+  assert(inputs.size() == else_inputs.size());
+  for (size_t i = 0; i < inputs.size(); ++i)
+  {
+    auto &else_input = else_graph.operands().at(else_inputs.at(i));
+    if (_operands.at(inputs.at(i)).info().isDynamic())
+    {
+      else_input.info().setDynamic();
+    }
+    else
+    {
+      const auto &new_shape = _operands.at(inputs.at(i)).info().shape();
+      else_input.info().shape(new_shape);
+    }
+  }
+
+  // re-sizing operands of then subgraph
+  StaticInferer then_inferer(op.param().then_subg_index, _lowered_subgs);
+  _lowered_subgs.at(op.param().then_subg_index)
+      ->iterateTopolOpSeqs([&](const ir::OpSequenceIndex &, const ir::OpSequence &op_seq) {
+        then_inferer.infer(op_seq);
+      });
+
+  // re-sizing operands of else subgraph
+  StaticInferer else_inferer(op.param().else_subg_index, _lowered_subgs);
+  _lowered_subgs.at(op.param().else_subg_index)
+      ->iterateTopolOpSeqs([&](const ir::OpSequenceIndex &, const ir::OpSequence &op_seq) {
+        else_inferer.infer(op_seq);
+      });
+
+  // re-sizing output shapes
+  const auto &then_outputs = _lowered_subgs.at(op.param().then_subg_index)->graph().getOutputs();
+  const auto &else_outputs = _lowered_subgs.at(op.param().else_subg_index)->graph().getOutputs();
+  assert(outputs.size() == then_outputs.size());
+  assert(outputs.size() == else_outputs.size());
+  for (size_t i = 0; i < outputs.size(); ++i)
+  {
+    const auto &then_output = then_graph.operands().at(then_outputs.at(i));
+    const auto &else_output = else_graph.operands().at(else_outputs.at(i));
+    auto &output = _operands.at(outputs.at(i));
+    if (!then_output.info().isDynamic() && !else_output.info().isDynamic() &&
+        then_output.shape() == else_output.shape())
+    {
+      output.info().shape(then_output.shape());
+    }
+    else
+    {
+      output.info().setDynamic();
+    }
+  }
+}
+
+void StaticInferer::visit(const ir::operation::Log &op)
+{
+  handleSimpleUnaryOp(op, op.getInputs().at(ir::operation::Log::Input::INPUT));
+}
+
+void StaticInferer::visit(const ir::operation::LogicalNot &op)
+{
+  handleSimpleUnaryOp(op, op.getInputs().at(ir::operation::LogicalNot::Input::INPUT));
+}
+
+void StaticInferer::visit(const ir::operation::LogicalOr &op)
+{
+  handleBinaryArithmeticOp(op, op.getInputs().at(ir::operation::LogicalOr::Input::INPUT0),
+                           op.getInputs().at(ir::operation::LogicalOr::Input::INPUT1));
+}
+
+void StaticInferer::visit(const ir::operation::Logistic &op)
+{
+  handleSimpleUnaryOp(op, op.getInputs().at(ir::operation::Logistic::Input::INPUT));
+}
+
+void StaticInferer::visit(const ir::operation::MatrixBandPart &op)
+{
+  handleSimpleUnaryOp(op, op.getInputs().at(ir::operation::MatrixBandPart::Input::INPUT));
+}
+
+void StaticInferer::visit(const ir::operation::Max &op)
+{
+  handleBinaryArithmeticOp(op, op.getInputs().at(ir::operation::Max::Input::LHS),
+                           op.getInputs().at(ir::operation::Max::Input::RHS));
+}
+
+void StaticInferer::visit(const ir::operation::Mean &op)
+{
+  const auto input_idx{op.getInputs().at(ir::operation::Mean::Input::INPUT)};
+  const auto &input = _operands.at(input_idx);
+
+  const auto axes_idx{op.getInputs().at(ir::operation::Mean::Input::AXES)};
+  const auto &axes = _operands.at(axes_idx);
+
+  // get mutable output operand
+  const auto output_idx = op.getOutputs().at(0);
+  ir::Operand &output = _operands.at(output_idx);
+
+  // if input is dynamic, output also becomes dynamic
+  if (input.info().isDynamic() || axes.info().isDynamic())
+  {
+    output.info().setDynamic();
+    return;
+  }
+
+  if (!axes.isConstant())
+  {
+    output.info().setDynamic();
+    return;
+  }
+
+  std::vector<int32_t> axes_vec;
+  for (size_t i = 0; i < axes.shape().num_elements(); ++i)
+  {
+    switch (axes.typeInfo().type())
+    {
+      case ir::DataType::INT32:
+      {
+        axes_vec.emplace_back(reinterpret_cast<const int32_t *>(axes.data()->base())[i]);
+        break;
+      }
+      case ir::DataType::INT64:
+      {
+        axes_vec.emplace_back(reinterpret_cast<const int64_t *>(axes.data()->base())[i]);
+        break;
+      }
+      default:
+        throw std::runtime_error("StaticInferer Mean: Not supported data type");
+        break;
+    }
+  }
+  const auto keep_dims = op.param().keep_dims;
+
+  ir::Shape output_shape =
+      shape_inference::inferReduceShapes(input.info().shape(), axes_vec, keep_dims);
+
+  output.info().shape(output_shape);
+}
+
+void StaticInferer::visit(const ir::operation::Min &op)
+{
+  handleBinaryArithmeticOp(op, op.getInputs().at(ir::operation::Min::Input::LHS),
+                           op.getInputs().at(ir::operation::Min::Input::RHS));
+}
+
+void StaticInferer::visit(const ir::operation::Mul &op)
+{
+  handleBinaryArithmeticOp(op, op.getInputs().at(ir::operation::Mul::Input::LHS),
+                           op.getInputs().at(ir::operation::Mul::Input::RHS));
+}
+
+void StaticInferer::visit(const ir::operation::Neg &op)
+{
+  handleSimpleUnaryOp(op, op.getInputs().at(ir::operation::Neg::Input::INPUT));
+}
+
+void StaticInferer::visit(const ir::operation::OneHot &op)
+{
+  const auto indice_idx{op.getInputs().at(ir::operation::OneHot::Input::INDICES)};
+  const auto &indice = _operands.at(indice_idx);
+  const auto depth_idx{op.getInputs().at(ir::operation::OneHot::Input::DEPTH)};
+  const auto &depth = _operands.at(depth_idx);
+
+  const auto axis = op.param().axis;
+
+  auto output_idx = op.getOutputs().at(0);
+  ir::Operand &output = _operands.at(output_idx);
+
+  if (indice.info().isDynamic() || depth.info().isDynamic() || !depth.isConstant())
+  {
+    output.info().setDynamic();
+    return;
+  }
+
+  const auto *depth_buf = reinterpret_cast<const int32_t *>(depth.data()->base());
+  assert(depth_buf);
+  // re-sizing output shape
+  ir::Shape new_shape = shape_inference::onehotShape(indice.info().shape(), *depth_buf, axis);
+  output.info().shape(new_shape);
+}
+
+void StaticInferer::visit(const ir::operation::Pack &op)
+{
+  bool is_any_of_inputs_dynamic = [&]() -> bool {
+    for (uint32_t i = 0; i < op.getInputs().size(); ++i)
+    {
+      const auto &input = _operands.at(op.getInputs().at(i));
+      if (input.info().isDynamic())
+      {
+        return true;
+      }
+    }
+    return false;
+  }();
+
+  const auto input_idx{op.getInputs().at(0)};
+  const auto &input = _operands.at(input_idx);
+
+  // get mutable output operand
+  const auto output_idx = op.getOutputs().at(0);
+  ir::Operand &output = _operands.at(output_idx);
+
+  // if input is dynamic, output also becomes dynamic
+  if (is_any_of_inputs_dynamic)
+  {
+    output.info().setDynamic();
+    return;
+  }
+
+  const auto rank = input.shape().rank() + 1;
+  const auto axis = ((op.param().axis < 0) ? rank + op.param().axis : op.param().axis);
+  const auto num = op.param().num;
+
+  assert(0 <= axis && axis < rank);
+
+  // re-sizing output shape
+  ir::Shape new_shape = shape_inference::packShapes(input.info().shape(), axis, rank, num);
+  output.info().shape(new_shape);
+}
+
+void StaticInferer::visit(const ir::operation::Pad &op)
+{
+  const auto input_idx{op.getInputs().at(ir::operation::Pad::Input::INPUT)};
+  const auto &input = _operands.at(input_idx);
+
+  const auto pad_idx{op.getInputs().at(ir::operation::Pad::Input::PAD)};
+  const auto &pad = _operands.at(pad_idx);
+
+  // get mutable output operand
+  const auto output_idx = op.getOutputs().at(0);
+  ir::Operand &output = _operands.at(output_idx);
+
+  // if input is dynamic or pad is dynamic, output also becomes dynamic
+  if (input.info().isDynamic() || pad.info().isDynamic())
+  {
+    output.info().setDynamic();
+    return;
+  }
+
+  // if pad is not constant, output also becomes dynamic
+  if (!pad.isConstant())
+  {
+    output.info().setDynamic();
+    return;
+  }
+
+  // re-sizing output shape
+  const auto new_shape = shape_inference::inferPadShape(
+      input.shape(), reinterpret_cast<const int32_t *>(pad.data()->base()),
+      pad.shape().num_elements());
+  output.info().shape(new_shape);
+}
+
+void StaticInferer::visit(const ir::operation::Permute &op)
+{
+  const auto input_idx{op.getInputs().at(0)};
+  const auto &input = _operands.at(input_idx);
+  const auto output_idx = op.getOutputs().at(0);
+  ir::Operand &output = _operands.at(output_idx);
+
+  if (input.info().isDynamic())
+  {
+    output.info().setDynamic();
+    return;
+  }
+
+  // re-sizing output shape
+  // Permute is a special operation that layouts of input/output may be different on backend
+  // However, it is not applied here, so input/output have the same layout of frontend. Because
+  // "ExecutorFactory" would convert shape of input/output accoding to the layouts when registering
+  // operand info to "TensorBuilder" after calling "StaticInferer"
+  const auto new_shape = input.info().shape();
+  output.info().shape(new_shape);
+}
+
+void StaticInferer::visit(const ir::operation::Pow &op)
+{
+  handleBinaryArithmeticOp(op, op.getInputs().at(ir::operation::Pow::Input::LHS),
+                           op.getInputs().at(ir::operation::Pow::Input::RHS));
+}
+
+void StaticInferer::visit(const ir::operation::Range &op)
+{
+  const auto start_idx{op.getInputs().at(ir::operation::Range::Input::START)};
+  const auto limit_idx{op.getInputs().at(ir::operation::Range::Input::LIMIT)};
+  const auto delta_idx{op.getInputs().at(ir::operation::Range::Input::DELTA)};
+  const auto &start_op = _operands.at(start_idx);
+  const auto &limit_op = _operands.at(limit_idx);
+  const auto &delta_op = _operands.at(delta_idx);
+
+  // get mutable output operand
+  const auto output_idx = op.getOutputs().at(0);
+  ir::Operand &output = _operands.at(output_idx);
+  // if any input is dynamic, output also becomes dynamic
+  if (start_op.info().isDynamic() || limit_op.info().isDynamic() || delta_op.info().isDynamic())
+  {
+    output.info().setDynamic();
+    return;
+  }
+
+  ir::Shape new_shape;
+  if (start_op.isConstant() && limit_op.isConstant() && delta_op.isConstant())
+  {
+    assert(start_op.typeInfo().type() == limit_op.typeInfo().type() &&
+           start_op.typeInfo().type() == delta_op.typeInfo().type());
+    if (output.typeInfo().type() == ir::DataType::FLOAT32)
+    {
+      new_shape = shape_inference::inferRangeShape<float>(
+          start_op.asScalar<float>(), limit_op.asScalar<float>(), delta_op.asScalar<float>());
+    }
+    else if (output.typeInfo().type() == ir::DataType::INT32)
+    {
+      new_shape = shape_inference::inferRangeShape<int32_t>(
+          start_op.asScalar<int32_t>(), limit_op.asScalar<int32_t>(), delta_op.asScalar<int32_t>());
+    }
+    assert(output.shape() == new_shape);
+  }
+  else
+  {
+    output.info().setDynamic();
+  }
+}
+
+void StaticInferer::visit(const ir::operation::ReduceAll &op)
+{
+  const auto input_idx{op.getInputs().at(ir::operation::ReduceAll::Input::INPUT)};
+  const auto &input = _operands.at(input_idx);
+
+  const auto axes_idx{op.getInputs().at(ir::operation::ReduceAll::Input::AXES)};
+  const auto &axes = _operands.at(axes_idx);
+
+  // get mutable output operand
+  const auto output_idx = op.getOutputs().at(0);
+  ir::Operand &output = _operands.at(output_idx);
+
+  // if input is dynamic, output also becomes dynamic
+  if (input.info().isDynamic())
+  {
+    output.info().setDynamic();
+    return;
+  }
+
+  std::vector<int32_t> axes_vec;
+  for (size_t i = 0; i < axes.shape().num_elements(); ++i)
+  {
+    switch (axes.typeInfo().type())
+    {
+      case ir::DataType::INT32:
+      {
+        axes_vec.emplace_back(reinterpret_cast<const int32_t *>(axes.data()->base())[i]);
+        break;
+      }
+      case ir::DataType::INT64:
+      {
+        axes_vec.emplace_back(reinterpret_cast<const int64_t *>(axes.data()->base())[i]);
+        break;
+      }
+      default:
+        throw std::runtime_error("StaticInferer ReduceAll: Not supported data type");
+        break;
+    }
+  }
+  const auto keep_dims = op.param().keep_dims;
+
+  // re-sizing output shape
+  ir::Shape new_shape =
+      shape_inference::inferReduceShapes(input.info().shape(), axes_vec, keep_dims);
+  output.info().shape(new_shape);
+}
+
+void StaticInferer::visit(const ir::operation::ReduceMin &op)
+{
+  const auto input_idx{op.getInputs().at(ir::operation::ReduceMin::Input::INPUT)};
+  const auto &input = _operands.at(input_idx);
+
+  const auto axes_idx{op.getInputs().at(ir::operation::ReduceMin::Input::AXES)};
+  const auto &axes = _operands.at(axes_idx);
+
+  // get mutable output operand
+  const auto output_idx = op.getOutputs().at(0);
+  ir::Operand &output = _operands.at(output_idx);
+
+  // if input is dynamic, output also becomes dynamic
+  if (input.info().isDynamic())
+  {
+    output.info().setDynamic();
+    return;
+  }
+
+  std::vector<int32_t> axes_vec;
+  for (size_t i = 0; i < axes.shape().num_elements(); ++i)
+  {
+    switch (axes.typeInfo().type())
+    {
+      case ir::DataType::INT32:
+      {
+        axes_vec.emplace_back(reinterpret_cast<const int32_t *>(axes.data()->base())[i]);
+        break;
+      }
+      case ir::DataType::INT64:
+      {
+        axes_vec.emplace_back(reinterpret_cast<const int64_t *>(axes.data()->base())[i]);
+        break;
+      }
+      default:
+        throw std::runtime_error("StaticInferer ReduceMin: Not supported data type");
+        break;
+    }
+  }
+  const auto keep_dims = op.param().keep_dims;
+
+  // re-sizing output shape
+  ir::Shape new_shape =
+      shape_inference::inferReduceShapes(input.info().shape(), axes_vec, keep_dims);
+  output.info().shape(new_shape);
+}
+
+void StaticInferer::visit(const ir::operation::ReduceProd &op)
+{
+  const auto input_idx{op.getInputs().at(ir::operation::ReduceProd::Input::INPUT)};
+  const auto &input = _operands.at(input_idx);
+
+  const auto axes_idx{op.getInputs().at(ir::operation::ReduceProd::Input::AXES)};
+  const auto &axes = _operands.at(axes_idx);
+
+  // get mutable output operand
+  const auto output_idx = op.getOutputs().at(0);
+  ir::Operand &output = _operands.at(output_idx);
+
+  // if input is dynamic, output also becomes dynamic
+  if (input.info().isDynamic())
+  {
+    output.info().setDynamic();
+    return;
+  }
+
+  std::vector<int32_t> axes_vec;
+  for (size_t i = 0; i < axes.shape().num_elements(); ++i)
+  {
+    switch (axes.typeInfo().type())
+    {
+      case ir::DataType::INT32:
+      {
+        axes_vec.emplace_back(reinterpret_cast<const int32_t *>(axes.data()->base())[i]);
+        break;
+      }
+      case ir::DataType::INT64:
+      {
+        axes_vec.emplace_back(reinterpret_cast<const int64_t *>(axes.data()->base())[i]);
+        break;
+      }
+      default:
+        throw std::runtime_error("StaticInferer ReduceProd: Not supported data type");
+        break;
+    }
+  }
+  const auto keep_dims = op.param().keep_dims;
+
+  // re-sizing output shape
+  ir::Shape new_shape =
+      shape_inference::inferReduceShapes(input.info().shape(), axes_vec, keep_dims);
+  output.info().shape(new_shape);
+}
+
+void StaticInferer::visit(const ir::operation::ReduceSum &op)
+{
+  const auto input_idx{op.getInputs().at(ir::operation::ReduceSum::Input::INPUT)};
+  const auto &input = _operands.at(input_idx);
+
+  const auto axes_idx{op.getInputs().at(ir::operation::ReduceSum::Input::AXES)};
+  const auto &axes = _operands.at(axes_idx);
+
+  // get mutable output operand
+  const auto output_idx = op.getOutputs().at(0);
+  ir::Operand &output = _operands.at(output_idx);
+
+  // if input is dynamic, output also becomes dynamic
+  if (input.info().isDynamic())
+  {
+    output.info().setDynamic();
+    return;
+  }
+
+  std::vector<int32_t> axes_vec;
+  for (size_t i = 0; i < axes.shape().num_elements(); ++i)
+  {
+    switch (axes.typeInfo().type())
+    {
+      case ir::DataType::INT32:
+      {
+        axes_vec.emplace_back(reinterpret_cast<const int32_t *>(axes.data()->base())[i]);
+        break;
+      }
+      case ir::DataType::INT64:
+      {
+        axes_vec.emplace_back(reinterpret_cast<const int64_t *>(axes.data()->base())[i]);
+        break;
+      }
+      default:
+        throw std::runtime_error("StaticInferer ReduceSum: Not supported data type");
+        break;
+    }
+  }
+  const auto keep_dims = op.param().keep_dims;
+
+  // re-sizing output shape
+  ir::Shape new_shape =
+      shape_inference::inferReduceShapes(input.info().shape(), axes_vec, keep_dims);
+  output.info().shape(new_shape);
+}
+
+void StaticInferer::visit(const ir::operation::Reshape &op)
+{
+  const auto input_idx{op.getInputs().at(ir::operation::Reshape::Input::INPUT)};
+  const auto &input = _operands.at(input_idx);
+
+  // get mutable output operand
+  const auto output_idx = op.getOutputs().at(0);
+  ir::Operand &output = _operands.at(output_idx);
+
+  // if input is dynamic, output also becomes dynamic
+  if (input.info().isDynamic())
+  {
+    output.info().setDynamic();
+    return;
+  }
+
+  // New shape is given by second input tensor
+  if (op.getInputs().size() == 2)
+  {
+    // Let's check the second input
+    const auto shape_idx{op.getInputs().at(ir::operation::Reshape::Input::SHAPE)};
+    const auto &shape = _operands.at(shape_idx);
+
+    if (shape.isConstant())
+    {
+      const auto *shape_buf = reinterpret_cast<const int32_t *>(shape.data()->base());
+      assert(shape_buf);
+
+      ir::Shape new_shape = shape_inference::inferReshapeShape(
+          shape_buf, shape.shape().num_elements(), input.shape().num_elements());
+
+      // if shape is from Const, TFLC put the shape of output into tensor
+      if (new_shape != output.shape())
+      {
+        // change on output shape
+        output.info().shape(new_shape);
+      }
+    }
+    else
+    {
+      // if shape is NOT Const, set output shape to be dynamic_
+      output.info().setDynamic();
+    }
+  }
+  // New shape is given by option
+  else if (op.param().new_shape.size() != 0)
+  {
+    // Let's check the new_shape option
+    auto shape = op.param().new_shape;
+    ir::Shape new_shape = shape_inference::inferReshapeShape(shape.data(), shape.size(),
+                                                             input.shape().num_elements());
+
+    if (new_shape != output.shape())
+    {
+      // change on output shape
+      output.info().shape(new_shape);
+    }
+  }
+  else
+  {
+    throw std::runtime_error("Reshape: new shape is missing");
+    return;
+  }
+}
+
+void StaticInferer::visit(const ir::operation::Reverse &op)
+{
+  handleSimpleUnaryOp(op, op.getInputs().at(ir::operation::Reverse::Input::INPUT));
+}
+
+void StaticInferer::visit(const ir::operation::Round &op)
+{
+  handleSimpleUnaryOp(op, op.getInputs().at(ir::operation::Round::Input::INPUT));
+}
+
+void StaticInferer::visit(const ir::operation::RSQRT &op)
+{
+  handleSimpleUnaryOp(op, op.getInputs().at(ir::operation::RSQRT::Input::INPUT));
+}
+
+void StaticInferer::visit(const ir::operation::Select &op)
+{
+  const auto input_cond_idx{op.getInputs().at(ir::operation::Select::Input::CONDITION)};
+  const auto &input_cond = _operands.at(input_cond_idx);
+
+  const auto input_true_idx{op.getInputs().at(ir::operation::Select::Input::INPUT_TRUE)};
+  const auto &input_true = _operands.at(input_true_idx);
+
+  const auto input_false_idx{op.getInputs().at(ir::operation::Select::Input::INPUT_FALSE)};
+  const auto &input_false = _operands.at(input_false_idx);
+
+  auto output_idx = op.getOutputs().at(0);
+  ir::Operand &output = _operands.at(output_idx);
+
+  if (input_cond.info().isDynamic() || input_true.info().isDynamic() ||
+      input_false.info().isDynamic())
+  {
+    output.info().setDynamic();
+    return;
+  }
+
+  // Select output shpae
+  ir::Shape new_shape = shape_inference::inferSelectShape(
+      input_cond.info().shape(), input_true.info().shape(), input_false.info().shape());
+  output.info().shape(new_shape);
+}
+
+void StaticInferer::visit(const ir::operation::Shape &op)
+{
+  const auto input_idx{op.getInputs().at(0)};
+  const auto &input = _operands.at(input_idx);
+
+  // get mutable output operand
+  const auto output_idx = op.getOutputs().at(0);
+  ir::Operand &output = _operands.at(output_idx);
+
+  // if input is dynamic, output also becomes dynamic
+  if (input.info().isDynamic())
+  {
+    output.info().setDynamic();
+    return;
+  }
+
+  // re-sizing output shape
+  ir::Shape output_shape;
+  output_shape.append(input.info().shape().rank());
+
+  output.info().shape(output_shape);
+}
+
+void StaticInferer::visit(const ir::operation::Sin &op)
+{
+  handleSimpleUnaryOp(op, op.getInputs().at(ir::operation::Sin::Input::INPUT));
+}
+
+void StaticInferer::visit(const ir::operation::Slice &op)
+{
+  const auto input_index{op.getInputs().at(ir::operation::Slice::Input::INPUT)};
+  const auto &input = _operands.at(input_index);
+  const auto begins_index{op.getInputs().at(ir::operation::Slice::Input::BEGINS)};
+  const auto &begins = _operands.at(begins_index);
+  const auto sizes_index{op.getInputs().at(ir::operation::Slice::Input::SIZES)};
+  const auto &sizes = _operands.at(sizes_index);
+  const auto output_index = op.getOutputs().at(0);
+  ir::Operand &output = _operands.at(output_index);
+
+  if (input.info().isDynamic() || begins.info().isDynamic() || sizes.info().isDynamic())
+  {
+    output.info().setDynamic();
+    return;
+  }
+
+  // Whether input is constant or not does not affect whether output is dynamic or not
+  if (!(begins.isConstant() && sizes.isConstant()))
+  {
+    output.info().setDynamic();
+    return;
+  }
+
+  auto begins_buf = reinterpret_cast<const int32_t *>(begins.data()->base());
+  auto sizes_buf = reinterpret_cast<const int32_t *>(sizes.data()->base());
+
+  ir::Shape new_shape =
+      shape_inference::inferSliceShape(input.info().shape(), begins_buf, sizes_buf);
+  output.info().shape(new_shape);
+}
+
+void StaticInferer::visit(const ir::operation::Softmax &op)
+{
+  handleSimpleUnaryOp(op, op.getInputs().at(ir::operation::Softmax::Input::INPUT));
+}
+
+void StaticInferer::visit(const ir::operation::Split &op)
+{
+  const auto input_idx{op.getInputs().at(0)};
+  const auto &input = _operands.at(input_idx);
+
+  const auto axis = op.param().axis;
+  const auto num_splits = op.param().num_splits;
+
+  if (input.info().isDynamic())
+  {
+    for (int out_tensor_idx = 0; out_tensor_idx < num_splits; out_tensor_idx++)
+    {
+      const auto output_idx = op.getOutputs().at(out_tensor_idx);
+      ir::Operand &output = _operands.at(output_idx);
+      output.info().setDynamic();
+    }
+    return;
+  }
+
+  const auto rank = input.info().shape().rank();
+  auto axis_resolved = axis < 0 ? axis + rank : axis;
+
+  assert(0 <= axis_resolved && axis_resolved < rank);
+
+  ir::Shape new_shape =
+      shape_inference::inferSplitShape(input.info().shape(), axis_resolved, num_splits);
+  auto output_teonsors = op.getOutputs();
+  for (auto output_idx : output_teonsors)
+  {
+    ir::Operand &output = _operands.at(output_idx);
+    output.info().shape(new_shape);
+  }
+}
+
+void StaticInferer::visit(const ir::operation::SquaredDifference &op)
+{
+  handleBinaryArithmeticOp(op, op.getInputs().at(ir::operation::SquaredDifference::Input::LHS),
+                           op.getInputs().at(ir::operation::SquaredDifference::Input::RHS));
+}
+
+void StaticInferer::visit(const ir::operation::Squeeze &op)
+{
+  const auto input_idx{op.getInputs().at(ir::operation::Squeeze::Input::INPUT)};
+  const auto &input = _operands.at(input_idx);
+
+  const auto output_idx = op.getOutputs().at(0);
+  ir::Operand &output = _operands.at(output_idx);
+
+  if (input.info().isDynamic())
+  {
+    output.info().setDynamic();
+    return;
+  }
+
+  // Squeeze output shpae
+  ir::Shape new_shape = shape_inference::inferSqueezeShape(input.info().shape(), op.param());
+  output.info().shape(new_shape);
+}
+
+void StaticInferer::visit(const ir::operation::StridedSlice &op)
+{
+  const auto input_index{op.getInputs().at(ir::operation::StridedSlice::Input::INPUT)};
+  const auto &input = _operands.at(input_index);
+  const auto starts_index{op.getInputs().at(ir::operation::StridedSlice::Input::STARTS)};
+  const auto &starts = _operands.at(starts_index);
+  const auto ends_index{op.getInputs().at(ir::operation::StridedSlice::Input::ENDS)};
+  const auto &ends = _operands.at(ends_index);
+  const auto strides_index{op.getInputs().at(ir::operation::StridedSlice::Input::STRIDES)};
+  const auto &strides = _operands.at(strides_index);
+  const auto output_index = op.getOutputs().at(0);
+  ir::Operand &output = _operands.at(output_index);
+
+  if (input.info().isDynamic() || starts.info().isDynamic() || ends.info().isDynamic() ||
+      strides.info().isDynamic())
+  {
+    output.info().setDynamic();
+    return;
+  }
+
+  if (!(starts.isConstant() && ends.isConstant() && strides.isConstant()))
+  {
+    output.info().setDynamic();
+    return;
+  }
+
+  const auto begin_mask = op.param().begin_mask;
+  const auto end_mask = op.param().end_mask;
+  const auto shrink_axis_mask = op.param().shrink_axis_mask;
+  const auto rank = input.info().shape().rank();
+
+  auto starts_buf = reinterpret_cast<const uint32_t *>(starts.data()->base());
+  auto ends_buf = reinterpret_cast<const uint32_t *>(ends.data()->base());
+  auto strides_buf = reinterpret_cast<const uint32_t *>(strides.data()->base());
+
+  auto op_params = shape_inference::buildStridedSliceParams(
+      starts_buf, ends_buf, strides_buf, begin_mask, end_mask, shrink_axis_mask, rank);
+
+  ir::Shape new_shape =
+      shape_inference::inferStridedSliceShape(input.info().shape(), op_params, rank);
+  output.info().shape(new_shape);
+}
+
+void StaticInferer::visit(const ir::operation::Sub &op)
+{
+  handleBinaryArithmeticOp(op, op.getInputs().at(ir::operation::Sub::Input::LHS),
+                           op.getInputs().at(ir::operation::Sub::Input::RHS));
+}
+
+void StaticInferer::visit(const ir::operation::Tanh &op)
+{
+  handleSimpleUnaryOp(op, op.getInputs().at(ir::operation::Tanh::Input::INPUT));
+}
+
+void StaticInferer::visit(const ir::operation::Tile &op)
+{
+  const auto input_idx{op.getInputs().at(ir::operation::Tile::Input::INPUT)};
+  const auto &input = _operands.at(input_idx);
+
+  const auto multiplier_idx{op.getInputs().at(ir::operation::Tile::Input::MULTIPLES)};
+  const auto &multiplier = _operands.at(multiplier_idx);
+
+  const auto output_idx = op.getOutputs().at(0);
+  ir::Operand &output = _operands.at(output_idx);
+
+  if (input.info().isDynamic())
+  {
+    output.info().setDynamic();
+    return;
+  }
+
+  if (!multiplier.isConstant())
+  {
+    output.info().setDynamic();
+    return;
+  }
+
+  auto multiplier_buffer = reinterpret_cast<const int32_t *>(multiplier.data()->base());
+  assert(multiplier_buffer);
+
+  // re-sizing output shape
+  auto new_shape = shape_inference::inferTileShape(input.info().shape(), multiplier_buffer);
+  output.info().shape(new_shape);
+}
+
+void StaticInferer::visit(const ir::operation::Transpose &op)
+{
+  const auto input_idx{op.getInputs().at(ir::operation::Transpose::Input::INPUT)};
+  const auto &input = _operands.at(input_idx);
+
+  // get mutable output operand
+  const auto output_idx = op.getOutputs().at(0);
+  ir::Operand &output = _operands.at(output_idx);
+  const auto perm{op.param().perm};
+  // const auto rank{op.param().rank};
+  // if input is dynamic, output also becomes dynamic
+  if (input.info().isDynamic())
+  {
+    output.info().setDynamic();
+    return;
+  }
+  // set output shape, based on input and params
+  ir::Shape new_shape = shape_inference::inferTransposeShape(input.info().shape(), perm);
+  output.info().shape(new_shape);
+}
+
+void StaticInferer::visit(const ir::operation::Unpack &op)
+{
+  const auto input_idx{op.getInputs().at(0)};
+  const auto &input = _operands.at(input_idx);
+  const auto num = op.param().num;
+
+  // if input is dynamic, output also becomes dynamic
+  if (input.info().isDynamic())
+  {
+    for (int out_tensor_idx = 0; out_tensor_idx < num; out_tensor_idx++)
+    {
+      const auto output_idx = op.getOutputs().at(out_tensor_idx);
+      ir::Operand &output = _operands.at(output_idx);
+      output.info().setDynamic();
+    }
+
+    return;
+  }
+
+  const auto rank = input.shape().rank();
+  const auto axis = ((op.param().axis < 0) ? rank + op.param().axis : op.param().axis);
+
+  assert(axis < rank);
+  if (axis < 0)
+  {
+    for (int out_tensor_idx = 0; out_tensor_idx < num; out_tensor_idx++)
+    {
+      const auto output_idx = op.getOutputs().at(out_tensor_idx);
+      ir::Operand &output = _operands.at(output_idx);
+      output.info().setDynamic();
+    }
+
+    return;
+  }
+
+  ir::Shape new_shape = shape_inference::unpackShapes(input.info().shape(), axis, rank);
+
+  // re-sizing output shape
+  for (int out_tensor_idx = 0; out_tensor_idx < num; out_tensor_idx++)
+  {
+    const auto output_idx = op.getOutputs().at(out_tensor_idx);
+    ir::Operand &output = _operands.at(output_idx);
+    output.info().shape(new_shape);
+  }
+}
+
+void StaticInferer::visit(const ir::operation::While &op)
+{
+  auto &cond_graph = _lowered_subgs.at(op.param().cond_subg_index)->graph();
+  auto &body_graph = _lowered_subgs.at(op.param().body_subg_index)->graph();
+  const auto inputs = op.getInputs();
+  const auto &outputs = op.getOutputs();
+
+  // re-sizing input shapes of then subgraph
+  const auto &cond_inputs = cond_graph.getInputs();
+  assert(inputs.size() == cond_inputs.size());
+  for (size_t i = 0; i < inputs.size(); ++i)
+  {
+    const auto &input = _operands.at(inputs.at(i));
+    auto &cond_input = cond_graph.operands().at(cond_inputs.at(i));
+    if (input.info().isDynamic())
+    {
+      cond_input.info().setDynamic();
+    }
+    else
+    {
+      auto new_shape = input.info().shape();
+      cond_input.info().shape(new_shape);
+    }
+  }
+
+  // re-sizing input shapes of body subgraph
+  const auto &body_inputs = body_graph.getInputs();
+  assert(cond_inputs.size() == body_inputs.size());
+  for (size_t i = 0; i < cond_inputs.size(); ++i)
+  {
+    const auto &cond_input = cond_graph.operands().at(cond_inputs.at(i));
+    auto &body_input = body_graph.operands().at(body_inputs.at(i));
+    if (cond_input.info().isDynamic())
+    {
+      body_input.info().setDynamic();
+    }
+    else
+    {
+      const auto &new_shape = cond_input.info().shape();
+      body_input.info().shape(new_shape);
+    }
+  }
+
+  // re-sizing operands of body subgraph
+  StaticInferer body_inferer(op.param().body_subg_index, _lowered_subgs);
+  _lowered_subgs.at(op.param().body_subg_index)
+      ->iterateTopolOpSeqs([&](const ir::OpSequenceIndex &, const ir::OpSequence &op_seq) {
+        body_inferer.infer(op_seq);
+      });
+
+  // Check whether while operation's shapes are predictable
+  // If any of shape of body outputs and cond inputs are different, non-constant operands would be
+  // set to dynamic
+  bool check_unpredictable_dynamic = false;
+  const auto &body_outputs = body_graph.getOutputs();
+  assert(body_outputs.size() == cond_inputs.size());
+  for (size_t i = 0; i < body_outputs.size(); ++i)
+  {
+    const auto &body_output = body_graph.operands().at(body_outputs.at(i));
+    auto &cond_input = cond_graph.operands().at(cond_inputs.at(i));
+    if ((cond_input.info().isDynamic() != body_output.info().isDynamic()) ||
+        (cond_input.shape() != body_output.shape()))
+    {
+      check_unpredictable_dynamic = true;
+      break;
+    }
+  }
+
+  if (check_unpredictable_dynamic)
+  {
+    // Set inputs of body subgraph
+    for (const auto &input_index : body_inputs)
+    {
+      auto &input = body_graph.operands().at(input_index);
+      if (!input.isConstant())
+      {
+        input.info().setDynamic();
+      }
+    }
+
+    // Set inputs of cond subgraph
+    for (const auto &input_index : cond_inputs)
+    {
+      auto &input = cond_graph.operands().at(input_index);
+      if (!input.isConstant())
+      {
+        input.info().setDynamic();
+      }
+    }
+
+    // Set non-constant operands of body subgraph to dynamic
+    StaticInferer body_inferer(op.param().body_subg_index, _lowered_subgs);
+    _lowered_subgs.at(op.param().body_subg_index)
+        ->iterateTopolOpSeqs([&](const ir::OpSequenceIndex &, const ir::OpSequence &op_seq) {
+          body_inferer.infer(op_seq);
+        });
+  }
+
+  // re-sizing operands of cond subgraph
+  // If check_unpredictable_dynamic is true, non-constant operands of cond subgraph would be set to
+  // dynamic
+  StaticInferer cond_inferer(op.param().cond_subg_index, _lowered_subgs);
+  _lowered_subgs.at(op.param().cond_subg_index)
+      ->iterateTopolOpSeqs([&](const ir::OpSequenceIndex &, const ir::OpSequence &op_seq) {
+        cond_inferer.infer(op_seq);
+      });
+
+  // re-sizing outputs of while operation
+  // If check_unpredictable_dynamic is true, outputs of while operation would be set to dynamic
+  assert(cond_inputs.size() == outputs.size());
+  for (size_t i = 0; i < cond_inputs.size(); ++i)
+  {
+    const auto &cond_input = cond_graph.operands().at(cond_inputs.at(i));
+    auto &output = _operands.at(outputs.at(i));
+    if (cond_input.info().isDynamic())
+    {
+      output.info().setDynamic();
+    }
+    else
+    {
+      const auto new_shape = cond_input.info().shape();
+      output.info().shape(new_shape);
+    }
+  }
+}
+
+void StaticInferer::visit(const ir::operation::ZerosLike &op)
+{
+  handleSimpleUnaryOp(op, op.getInputs().at(ir::operation::ZerosLike::Input::INPUT));
+}
+
+} // namespace compiler
+
+} // namespace onert

--- a/runtime/onert/core/src/exec/DynamicShapeInference.cc
+++ b/runtime/onert/core/src/exec/DynamicShapeInference.cc
@@ -1,0 +1,1240 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "exec/DynamicShapeInference.h"
+#include "util/ShapeInference.h"
+
+namespace onert
+{
+namespace exec
+{
+
+void DynamicInferer::handleBinaryArithmeticOp(const ir::Operation &op,
+                                              const ir::OperandIndex lhs_idx,
+                                              const ir::OperandIndex rhs_idx)
+{
+  auto lhs = _tensor_registry->getITensor(lhs_idx);
+  auto lhs_shape = lhs->getShape();
+
+  auto rhs = _tensor_registry->getITensor(rhs_idx);
+  auto rhs_shape = rhs->getShape();
+
+  /*
+    Here, the state after compilation (satic shape inference) could be one of the following:
+
+              lhs       rhs              output     execution-time shape inf required
+      ------------------------------------------    ---------------------------------
+      case 1) static    static           static      X
+      case 2) one or both are dynamic    dynamic     O
+
+    Then nnfw_apply_tensorinf() could change one or both inputs dynamic.
+    So, in this method, we have one more state and we have to re-calculate shape for this shape.
+
+      case 3) one or both are dynamic    static      O
+
+    So, only when all inputs are static, we can skip dynamic shape inference.
+  */
+  if ((!lhs->is_dynamic()) && (!rhs->is_dynamic()))
+    return;
+
+  auto output_idx = op.getOutputs().at(0);
+  auto output = _tensor_registry->getITensor(output_idx);
+
+  ir::Shape new_shape = shape_inference::inferEltwiseShape(lhs_shape, rhs_shape);
+
+  _dynamic_tensor_manager->applyShape(output_idx, new_shape);
+  assert(output->buffer() != nullptr);
+}
+
+void DynamicInferer::handleSimpleUnaryOp(const ir::Operation &op, const ir::OperandIndex input_ind)
+{
+  // check if input is not dynamic
+  auto input = _tensor_registry->getITensor(input_ind);
+  auto output_shape = input->getShape();
+
+  /*
+    Here, the state after compilation (satic shape inference) could be one of the following:
+
+              input      output    execution-time shape inf required
+      -------------------------    ---------------------------------
+      case 1) static     static      X
+      case 2) dynamic    dynamic     O
+
+    Then nnfw_apply_tensorinf() could change input dynamic.
+    So, in this method, we have one more state and we have to re-calculate shape for this shape.
+
+      case 3) dynamic    static      O
+
+    So, only when input is static, we can skip dynamic shape inference.
+  */
+  if (!input->is_dynamic())
+    return;
+
+  auto output_ind = op.getOutputs().at(0);
+  auto output = _tensor_registry->getITensor(output_ind);
+
+  _dynamic_tensor_manager->applyShape(output_ind, output_shape);
+  assert(output->buffer() != nullptr);
+}
+
+void DynamicInferer::visit(const ir::operation::Abs &op)
+{
+  handleSimpleUnaryOp(op, op.getInputs().at(ir::operation::Abs::INPUT));
+}
+
+void DynamicInferer::visit(const ir::operation::Add &op)
+{
+  handleBinaryArithmeticOp(op, op.getInputs().at(ir::operation::Add::Input::LHS),
+                           op.getInputs().at(ir::operation::Add::Input::RHS));
+}
+
+void DynamicInferer::visit(const ir::operation::ArgMax &op)
+{
+  const auto input_idx{op.getInputs().at(ir::operation::ArgMax::Input::INPUT)};
+  const auto &input = _tensor_registry->getITensor(input_idx);
+  auto input_shape = input->getShape();
+
+  if (!input->is_dynamic())
+    return;
+
+  const auto rank = input_shape.rank();
+  const auto axis = ((op.param().axis < 0) ? rank + op.param().axis : op.param().axis);
+
+  assert(0 <= axis && axis < rank);
+
+  auto output_ind = op.getOutputs().at(0);
+  auto output = _tensor_registry->getITensor(output_ind);
+
+  ir::Shape new_shape = shape_inference::argMaxShapes(input_shape, axis, rank);
+
+  _dynamic_tensor_manager->applyShape(output_ind, new_shape);
+  assert(output->buffer() != nullptr);
+}
+
+void DynamicInferer::visit(const ir::operation::BatchMatMul &op)
+{
+  const auto lhs_index = op.getInputs().at(ir::operation::BatchMatMul::Input::LHS);
+  const auto rhs_index = op.getInputs().at(ir::operation::BatchMatMul::Input::RHS);
+  auto lhs = _tensor_registry->getITensor(lhs_index);
+  auto rhs = _tensor_registry->getITensor(rhs_index);
+
+  if (!lhs->is_dynamic() && !rhs->is_dynamic())
+    return;
+
+  const auto output_index = op.getOutputs().at(0);
+  auto output = _tensor_registry->getITensor(output_index);
+
+  auto lhs_shape = lhs->getShape();
+  auto rhs_shape = rhs->getShape();
+  // TODO
+
+  auto new_shape = shape_inference::inferBatchMatMulShape(lhs_shape, rhs_shape, op.param());
+  _dynamic_tensor_manager->applyShape(output_index, new_shape);
+}
+
+void DynamicInferer::visit(const ir::operation::BroadcastTo &op)
+{
+  auto output_ind = op.getOutputs().at(0);
+  auto output = _tensor_registry->getITensor(output_ind);
+
+  auto input_idx = op.getInputs().at(ir::operation::BroadcastTo::INPUT);
+  auto input = _tensor_registry->getITensor(input_idx);
+
+  if ((!input->is_dynamic()) && (!output->is_dynamic()))
+    return;
+
+  auto shape_idx = op.getInputs().at(ir::operation::Tile::Input::MULTIPLES);
+  const auto &shape = _tensor_registry->getITensor(shape_idx);
+
+  assert(shape); // It shouldn't be 0.
+
+  auto output_shape = shape_inference::inferBroadcastToShape(
+      shape->getShape(), reinterpret_cast<const int32_t *>(shape->buffer()));
+
+  // set output shape and output buffer
+  _dynamic_tensor_manager->applyShape(output_ind, output_shape);
+  assert(output->buffer() != nullptr);
+}
+
+void DynamicInferer::visit(const ir::operation::Cast &op)
+{
+  handleSimpleUnaryOp(op, op.getInputs().at(ir::operation::Cast::INPUT));
+}
+
+void DynamicInferer::visit(const ir::operation::Comparison &op)
+{
+  handleBinaryArithmeticOp(op, op.getInputs().at(ir::operation::Comparison::Input::INPUT0),
+                           op.getInputs().at(ir::operation::Comparison::Input::INPUT1));
+}
+
+void DynamicInferer::visit(const ir::operation::Concat &op)
+{
+  /*
+    The state after compilation (satic shape inference) could be one of the following:
+
+              inputs                  output        execution-time shape inf required
+      ------------------------------------------    ---------------------------------
+      case 1) all static              static         X
+      case 2) at least on is dynamic  dynamic        O
+
+    Then nnfw_apply_tensorinf() could change one or both inputs dynamic.
+    So, in this method, we have one more state and we have to re-calculate shape for this shape.
+
+      case 3) at least on is dynamic  static         O
+
+    So, only when all inputs are static, we can skip dynamic shape inference.
+  */
+  bool all_static = true;
+  for (auto input_ind : op.getInputs())
+  {
+    auto input = _tensor_registry->getITensor(input_ind);
+    if (input->is_dynamic())
+    {
+      all_static = false;
+      break;
+    }
+  }
+
+  if (all_static)
+    return;
+
+  // sanity check
+  {
+    auto isConcatible = [](const backend::ITensor *input1, const backend::ITensor *input2,
+                           int32_t axis) {
+      if (input1->num_dimensions() != input2->num_dimensions())
+        return false;
+
+      for (size_t i = 0; i < input1->num_dimensions(); i++)
+      {
+        auto positive_axis = (axis >= 0) ? axis : axis + input1->num_dimensions();
+
+        if (i != positive_axis)
+          if (input1->dimension(i) != input2->dimension(i))
+            return false;
+      }
+
+      return true;
+    };
+
+    auto first_input_ind = op.getInputs().at(0);
+    auto first_input = _tensor_registry->getITensor(first_input_ind);
+
+    for (auto input_ind : op.getInputs())
+    {
+      auto input = _tensor_registry->getITensor(input_ind);
+      if (input != first_input && !isConcatible(first_input.get(), input.get(), op.param().axis))
+        throw std::runtime_error("input shapes does not matched for concat");
+    }
+  }
+
+  // getting output shape
+  onert::shape_inference::Shapes in_shapes;
+  for (auto input_ind : op.getInputs())
+  {
+    auto input = _tensor_registry->getITensor(input_ind);
+    ir::Shape shape = input->getShape();
+
+    in_shapes.emplace_back(shape);
+  }
+
+  auto output_ind = op.getOutputs().at(0);
+  auto output = _tensor_registry->getITensor(output_ind);
+  auto output_shape = shape_inference::inferConcatShape(in_shapes, op.param());
+
+  _dynamic_tensor_manager->applyShape(output_ind, output_shape);
+}
+
+void DynamicInferer::visit(const ir::operation::Conv2D &op)
+{
+  // check if input is not dynamic
+  auto input_ind = op.getInputs().at(ir::operation::Conv2D::INPUT);
+  auto input = _tensor_registry->getITensor(input_ind);
+
+  auto ker_ind = op.getInputs().at(ir::operation::Conv2D::KERNEL);
+  auto ker = _tensor_registry->getITensor(ker_ind);
+
+  if ((!input->is_dynamic()) && (!ker->is_dynamic()))
+    return;
+
+  ir::Shape input_shape = input->getShape();
+  ir::Shape ker_shape = ker->getShape();
+
+  auto output_ind = op.getOutputs().at(0);
+  auto output = _tensor_registry->getITensor(output_ind);
+
+  ir::Shape output_shape = shape_inference::inferConv2DShape(input_shape, ker_shape, op.param());
+
+  _dynamic_tensor_manager->applyShape(output_ind, output_shape);
+  assert(output->buffer() != nullptr);
+}
+
+void DynamicInferer::visit(const ir::operation::Cos &op)
+{
+  handleSimpleUnaryOp(op, op.getInputs().at(ir::operation::Cos::Input::INPUT));
+}
+
+void DynamicInferer::visit(const ir::operation::Div &op)
+{
+  handleBinaryArithmeticOp(op, op.getInputs().at(ir::operation::Div::Input::LHS),
+                           op.getInputs().at(ir::operation::Div::Input::RHS));
+}
+
+void DynamicInferer::visit(const ir::operation::Exp &op)
+{
+  handleSimpleUnaryOp(op, op.getInputs().at(ir::operation::Exp::Input::INPUT));
+}
+
+void DynamicInferer::visit(const ir::operation::ExpandDims &op)
+{
+  // check if input is not dynamic
+  auto input_ind = op.getInputs().at(ir::operation::ExpandDims::INPUT);
+  auto input = _tensor_registry->getITensor(input_ind);
+
+  // check if output is not dynamic, meaning when 1st input is static and 2nd input is const
+  auto output_ind = op.getOutputs().at(0);
+  auto output = _tensor_registry->getITensor(output_ind);
+
+  /*
+    Here, the state after compilation (satic shape inference) could be one of the following:
+
+              input1     input2      output     execution-time shape inf required
+              -----------------------------     --------------------------------
+      case 1) static     const       static      X
+      case 2) static    placeholder  dynamic     O
+      case 3) dynamic    const       dynamic     O
+      case 4) dynamic   placeholder  dynamic     O
+
+    Then nnfw_apply_tensorinf() could change input dynamic.
+    So, in this method, we could have one more state and we have to re-calculate shape
+    for this shape.
+
+      case 5) dynamic    const       static       O
+
+    So, only when input1 and ouput are static, we can skip dynamic shape inference.
+  */
+  if ((!input->is_dynamic()) && (!output->is_dynamic()))
+    return;
+
+  ir::Shape input_shape = input->getShape();
+
+  auto axis_ind = op.getInputs().at(ir::operation::ExpandDims::AXIS);
+  auto axis = _tensor_registry->getITensor(axis_ind);
+  auto axis_buf = reinterpret_cast<const int32_t *>(axis->buffer());
+  assert(axis_buf);
+
+  auto output_shape = shape_inference::inferExpandDimsShape(input_shape, axis_buf[0]);
+
+  _dynamic_tensor_manager->applyShape(output_ind, output_shape);
+  assert(output->buffer() != nullptr);
+}
+
+void DynamicInferer::visit(const ir::operation::Fill &op)
+{
+  // check if output is not dynamic
+  auto output_ind = op.getOutputs().at(0);
+  auto output = _tensor_registry->getITensor(output_ind);
+  auto input_ind = op.getInputs().at(ir::operation::Fill::Input::INPUT);
+  auto input = _tensor_registry->getITensor(input_ind);
+  ir::Shape input_shape = input->getShape();
+
+  if ((!input->is_dynamic()) && (!output->is_dynamic()))
+    return;
+
+  assert(input.get()->data_type() == ir::DataType::INT32);
+
+  auto input_buf = reinterpret_cast<const int32_t *>(input->buffer());
+  assert(input_buf);
+
+  auto output_shape = shape_inference::inferFillShape(input_shape, input_buf);
+
+  _dynamic_tensor_manager->applyShape(output_ind, output_shape);
+  assert(output->buffer() != nullptr);
+}
+
+void DynamicInferer::visit(const ir::operation::FullyConnected &op)
+{
+  const auto input_idx{op.getInputs().at(ir::operation::FullyConnected::Input::INPUT)};
+  const auto &input = _tensor_registry->getITensor(input_idx);
+
+  const auto ker_idx{op.getInputs().at(ir::operation::FullyConnected::Input::WEIGHT)};
+  const auto &ker = _tensor_registry->getITensor(ker_idx);
+
+  if (!input->is_dynamic() && !ker->is_dynamic())
+    return;
+
+  auto input_shape = input->getShape();
+  auto ker_shape = ker->getShape();
+
+  ir::Shape new_shape = shape_inference::inferFullyConnectedShape(input_shape, ker_shape);
+
+  auto output_ind = op.getOutputs().at(0);
+  auto output = _tensor_registry->getITensor(output_ind);
+
+  _dynamic_tensor_manager->applyShape(output_ind, new_shape);
+  assert(output->buffer() != nullptr);
+}
+
+void DynamicInferer::visit(const ir::operation::FusedBatchNorm &op)
+{
+  handleSimpleUnaryOp(op, op.getInputs().at(ir::operation::FusedBatchNorm::Input::INPUT));
+}
+
+void DynamicInferer::visit(const ir::operation::Gather &op)
+{
+  const auto input_idx{op.getInputs().at(ir::operation::Gather::Input::INPUT)};
+  const auto &input = _tensor_registry->getITensor(input_idx);
+  auto input_shape = input->getShape();
+
+  const auto indices_idx{op.getInputs().at(ir::operation::Gather::Input::INDICES)};
+  const auto &indices = _tensor_registry->getITensor(indices_idx);
+  auto indices_shape = indices->getShape();
+
+  if (!(input->is_dynamic()) && !(indices->is_dynamic()))
+    return;
+
+  const auto rank = input_shape.rank();
+  const auto axis = ((op.param().axis < 0) ? rank + op.param().axis : op.param().axis);
+
+  assert(0 <= axis && axis < rank);
+
+  ir::Shape new_shape = shape_inference::gatherShapes(input_shape, indices_shape, axis, rank);
+
+  auto output_ind = op.getOutputs().at(0);
+  auto output = _tensor_registry->getITensor(output_ind);
+
+  _dynamic_tensor_manager->applyShape(output_ind, new_shape);
+  assert(output->buffer() != nullptr);
+}
+
+void DynamicInferer::visit(const ir::operation::Log &op)
+{
+  handleSimpleUnaryOp(op, op.getInputs().at(ir::operation::Log::Input::INPUT));
+}
+
+void DynamicInferer::visit(const ir::operation::LogicalNot &op)
+{
+  handleSimpleUnaryOp(op, op.getInputs().at(ir::operation::LogicalNot::Input::INPUT));
+}
+
+void DynamicInferer::visit(const ir::operation::LogicalOr &op)
+{
+  handleBinaryArithmeticOp(op, op.getInputs().at(ir::operation::LogicalOr::Input::INPUT0),
+                           op.getInputs().at(ir::operation::LogicalOr::Input::INPUT1));
+}
+
+void DynamicInferer::visit(const ir::operation::Logistic &op)
+{
+  handleSimpleUnaryOp(op, op.getInputs().at(ir::operation::Logistic::INPUT));
+}
+
+void DynamicInferer::visit(const ir::operation::MatrixBandPart &op)
+{
+  handleSimpleUnaryOp(op, op.getInputs().at(ir::operation::MatrixBandPart::INPUT));
+}
+
+void DynamicInferer::visit(const ir::operation::Max &op)
+{
+  handleBinaryArithmeticOp(op, op.getInputs().at(ir::operation::Max::Input::LHS),
+                           op.getInputs().at(ir::operation::Max::Input::RHS));
+}
+
+void DynamicInferer::visit(const ir::operation::Mean &op)
+{
+  const auto input_idx{op.getInputs().at(ir::operation::Mean::Input::INPUT)};
+  const auto &input = _tensor_registry->getITensor(input_idx);
+
+  const auto axes_idx{op.getInputs().at(ir::operation::Mean::Input::AXES)};
+  const auto &axes = _tensor_registry->getITensor(axes_idx);
+
+  if ((!input->is_dynamic()) && !(axes->is_dynamic()))
+  {
+    return;
+  }
+
+  auto input_shape = input->getShape();
+
+  auto output_ind = op.getOutputs().at(0);
+  auto output = _tensor_registry->getITensor(output_ind);
+
+  std::vector<int32_t> axes_vec;
+  for (uint32_t i = 0; i < axes->getShape().num_elements(); ++i)
+  {
+    const auto buffer = axes->buffer() + axes->calcOffset({i});
+    switch (axes->data_type())
+    {
+      case ir::DataType::INT32:
+      {
+        axes_vec.emplace_back(*reinterpret_cast<const int32_t *>(buffer));
+        break;
+      }
+      case ir::DataType::INT64:
+      {
+        axes_vec.emplace_back(*reinterpret_cast<const int64_t *>(buffer));
+        break;
+      }
+      default:
+        throw std::runtime_error("DynamicInferer Mean: Not supported data type");
+        break;
+    }
+  }
+  const auto keep_dims = op.param().keep_dims;
+
+  ir::Shape output_shape = shape_inference::inferReduceShapes(input_shape, axes_vec, keep_dims);
+  _dynamic_tensor_manager->applyShape(output_ind, output_shape);
+  assert(output->buffer() != nullptr);
+}
+
+void DynamicInferer::visit(const ir::operation::Min &op)
+{
+  handleBinaryArithmeticOp(op, op.getInputs().at(ir::operation::Min::Input::LHS),
+                           op.getInputs().at(ir::operation::Min::Input::RHS));
+}
+
+void DynamicInferer::visit(const ir::operation::Mul &op)
+{
+  handleBinaryArithmeticOp(op, op.getInputs().at(ir::operation::Mul::Input::LHS),
+                           op.getInputs().at(ir::operation::Mul::Input::RHS));
+}
+
+void DynamicInferer::visit(const ir::operation::Neg &op)
+{
+  handleSimpleUnaryOp(op, op.getInputs().at(ir::operation::Neg::Input::INPUT));
+}
+
+void DynamicInferer::visit(const ir::operation::OneHot &op)
+{
+  auto output_ind = op.getOutputs().at(0);
+  auto output = _tensor_registry->getITensor(output_ind);
+
+  auto indices_ind = op.getInputs().at(ir::operation::OneHot::INDICES);
+  const auto &indices = _tensor_registry->getITensor(indices_ind);
+  auto indices_shape = indices->getShape();
+
+  auto depth_ind = op.getInputs().at(ir::operation::OneHot::DEPTH);
+  const auto &depth = _tensor_registry->getITensor(depth_ind);
+
+  if (!indices->is_dynamic() && !depth->is_dynamic())
+  {
+    return;
+  }
+
+  int32_t *depth_buf = reinterpret_cast<int32_t *>(depth->buffer());
+  assert(depth_buf);
+  const auto axis_val = op.param().axis;
+
+  ir::Shape new_shape = shape_inference::onehotShape(indices_shape, *depth_buf, axis_val);
+  _dynamic_tensor_manager->applyShape(output_ind, new_shape);
+  assert(output->buffer() != nullptr);
+}
+
+void DynamicInferer::visit(const ir::operation::Pack &op)
+{
+  bool is_any_of_inputs_dynamic = [&]() -> bool {
+    for (uint32_t i = 0; i < op.getInputs().size(); ++i)
+    {
+      const auto &input = _tensor_registry->getITensor(op.getInputs().at(i));
+      if (input->is_dynamic())
+      {
+        return true;
+      }
+    }
+    return false;
+  }();
+
+  const auto input_idx{op.getInputs().at(0)};
+  const auto &input = _tensor_registry->getITensor(input_idx);
+  auto input_shape = input->getShape();
+
+  auto output_ind = op.getOutputs().at(0);
+  auto output = _tensor_registry->getITensor(output_ind);
+
+  if (!is_any_of_inputs_dynamic && !output->is_dynamic())
+    return;
+
+  const auto rank = input_shape.rank() + 1;
+  const auto axis = ((op.param().axis < 0) ? rank + op.param().axis : op.param().axis);
+  const auto num = op.param().num;
+
+  assert(0 <= axis && axis < rank);
+
+  ir::Shape new_shape = shape_inference::packShapes(input_shape, axis, rank, num);
+
+  _dynamic_tensor_manager->applyShape(output_ind, new_shape);
+  assert(output->buffer() != nullptr);
+}
+
+void DynamicInferer::visit(const ir::operation::Pad &op)
+{
+  // check if output is not dynamic
+  auto output_ind = op.getOutputs().at(0);
+  auto output = _tensor_registry->getITensor(output_ind);
+
+  auto input_ind = op.getInputs().at(ir::operation::Pad::Input::INPUT);
+  auto input = _tensor_registry->getITensor(input_ind);
+
+  auto pad_ind = op.getInputs().at(ir::operation::Pad::Input::PAD);
+  auto pad = _tensor_registry->getITensor(pad_ind);
+
+  // check if input and output are not dynamic
+  if ((!input->is_dynamic()) && (!output->is_dynamic()))
+    return;
+
+  int32_t *pad_buf = reinterpret_cast<int32_t *>(pad->buffer());
+  assert(pad_buf);
+
+  auto output_shape =
+      shape_inference::inferPadShape(input->getShape(), pad_buf, pad->getShape().num_elements());
+
+  // change output shape and reallocate output tensor memory
+  _dynamic_tensor_manager->applyShape(output_ind, output_shape);
+  assert(output->buffer() != nullptr);
+}
+
+void DynamicInferer::visit(const ir::operation::Permute &op)
+{
+  const auto input_idx{op.getInputs().at(0)};
+  auto input = _tensor_registry->getITensor(input_idx);
+  auto input_shape = input->getShape();
+
+  // check if input is not dynamic
+  if (!input->is_dynamic())
+    return;
+
+  // getting output shapes
+  auto new_shape = input_shape;
+  // Permute is a special operation that layouts of input/output may be different
+  assert(new_shape.rank() <= ir::Shape::MAX_RANK);
+  if (new_shape.rank() >= 4)
+  {
+    if (op.getPermuteType() == ir::operation::Permute::Type::NHWC_TO_NCHW)
+    {
+      // Permutation changing layout beyond 4-D is not supported yet
+      assert(new_shape.rank() == 4);
+      new_shape.dim(1) = input_shape.dim(3);
+      new_shape.dim(2) = input_shape.dim(1);
+      new_shape.dim(3) = input_shape.dim(2);
+    }
+    else if (op.getPermuteType() == ir::operation::Permute::Type::NCHW_TO_NHWC)
+    {
+      // Permutation changing layout beyond 4-D is not supported yet
+      assert(new_shape.rank() == 4);
+      new_shape.dim(1) = input_shape.dim(2);
+      new_shape.dim(2) = input_shape.dim(3);
+      new_shape.dim(3) = input_shape.dim(1);
+    }
+  }
+
+  // Apply output shape for output tensor
+  auto output_ind = op.getOutputs().at(0);
+  auto output = _tensor_registry->getITensor(output_ind);
+  _dynamic_tensor_manager->applyShape(output_ind, new_shape);
+  assert(output->buffer() != nullptr);
+}
+
+void DynamicInferer::visit(const ir::operation::Pow &op)
+{
+  handleBinaryArithmeticOp(op, op.getInputs().at(ir::operation::Pow::Input::LHS),
+                           op.getInputs().at(ir::operation::Pow::Input::RHS));
+}
+
+void DynamicInferer::visit(const ir::operation::Range &op)
+{
+  // check if output is not dynamic
+  auto output_ind = op.getOutputs().at(0);
+  auto output = _tensor_registry->getITensor(output_ind);
+
+  // from op, access the buffer of second input to read new shape
+  auto start_idx = op.getInputs().at(ir::operation::Range::Input::START);
+  auto start_tensor = _tensor_registry->getITensor(start_idx);
+
+  auto limit_idx = op.getInputs().at(ir::operation::Range::Input::LIMIT);
+  auto limit_tensor = _tensor_registry->getITensor(limit_idx);
+
+  auto delta_idx = op.getInputs().at(ir::operation::Range::Input::DELTA);
+  auto delta_tensor = _tensor_registry->getITensor(delta_idx);
+
+  if (!start_tensor->is_dynamic() && !limit_tensor->is_dynamic() && !delta_tensor->is_dynamic() &&
+      !output->is_dynamic())
+    return;
+
+  ir::Shape new_shape;
+  if (output->data_type() == ir::DataType::FLOAT32)
+  {
+    new_shape =
+        shape_inference::inferRangeShape<float>(*reinterpret_cast<float *>(start_tensor->buffer()),
+                                                *reinterpret_cast<float *>(limit_tensor->buffer()),
+                                                *reinterpret_cast<float *>(delta_tensor->buffer()));
+  }
+  else if (output->data_type() == ir::DataType::INT32)
+  {
+    new_shape = shape_inference::inferRangeShape<int32_t>(
+        *reinterpret_cast<int32_t *>(start_tensor->buffer()),
+        *reinterpret_cast<int32_t *>(limit_tensor->buffer()),
+        *reinterpret_cast<int32_t *>(delta_tensor->buffer()));
+  }
+  _dynamic_tensor_manager->applyShape(output_ind, new_shape);
+  assert(output->buffer() != nullptr);
+}
+
+void DynamicInferer::visit(const ir::operation::ReduceAll &op)
+{
+  const auto input_idx{op.getInputs().at(ir::operation::ReduceAll::Input::INPUT)};
+  const auto &input = _tensor_registry->getITensor(input_idx);
+  auto input_shape = input->getShape();
+
+  const auto axes_idx{op.getInputs().at(ir::operation::ReduceAll::Input::AXES)};
+  const auto &axes = _tensor_registry->getITensor(axes_idx);
+
+  if (!input->is_dynamic())
+    return;
+
+  std::vector<int32_t> axes_vec;
+  for (uint32_t i = 0; i < axes->getShape().num_elements(); ++i)
+  {
+    const auto buffer = axes->buffer() + axes->calcOffset({i});
+    switch (axes->data_type())
+    {
+      case ir::DataType::INT32:
+      {
+        axes_vec.emplace_back(*reinterpret_cast<const int32_t *>(buffer));
+        break;
+      }
+      case ir::DataType::INT64:
+      {
+        axes_vec.emplace_back(*reinterpret_cast<const int64_t *>(buffer));
+        break;
+      }
+      default:
+        throw std::runtime_error("DynamicInferer ReduceAll: Not supported data type");
+        break;
+    }
+  }
+  const auto keep_dims = op.param().keep_dims;
+
+  auto output_ind = op.getOutputs().at(0);
+  auto output = _tensor_registry->getITensor(output_ind);
+
+  ir::Shape new_shape = shape_inference::inferReduceShapes(input_shape, axes_vec, keep_dims);
+
+  _dynamic_tensor_manager->applyShape(output_ind, new_shape);
+  assert(output->buffer() != nullptr);
+}
+
+void DynamicInferer::visit(const ir::operation::ReduceMin &op)
+{
+  const auto input_idx{op.getInputs().at(ir::operation::ReduceMin::Input::INPUT)};
+  const auto &input = _tensor_registry->getITensor(input_idx);
+  auto input_shape = input->getShape();
+
+  const auto axes_idx{op.getInputs().at(ir::operation::ReduceMin::Input::AXES)};
+  const auto &axes = _tensor_registry->getITensor(axes_idx);
+
+  if (!input->is_dynamic())
+    return;
+
+  std::vector<int32_t> axes_vec;
+  for (uint32_t i = 0; i < axes->getShape().num_elements(); ++i)
+  {
+    const auto buffer = axes->buffer() + axes->calcOffset({i});
+    switch (axes->data_type())
+    {
+      case ir::DataType::INT32:
+      {
+        axes_vec.emplace_back(*reinterpret_cast<const int32_t *>(buffer));
+        break;
+      }
+      case ir::DataType::INT64:
+      {
+        axes_vec.emplace_back(*reinterpret_cast<const int64_t *>(buffer));
+        break;
+      }
+      default:
+        throw std::runtime_error("DynamicInferer ReduceMin: Not supported data type");
+        break;
+    }
+  }
+  const auto keep_dims = op.param().keep_dims;
+
+  auto output_ind = op.getOutputs().at(0);
+  auto output = _tensor_registry->getITensor(output_ind);
+
+  ir::Shape new_shape = shape_inference::inferReduceShapes(input_shape, axes_vec, keep_dims);
+
+  _dynamic_tensor_manager->applyShape(output_ind, new_shape);
+  assert(output->buffer() != nullptr);
+}
+
+void DynamicInferer::visit(const ir::operation::ReduceProd &op)
+{
+  const auto input_idx{op.getInputs().at(ir::operation::ReduceProd::Input::INPUT)};
+  const auto &input = _tensor_registry->getITensor(input_idx);
+  auto input_shape = input->getShape();
+
+  const auto axes_idx{op.getInputs().at(ir::operation::ReduceProd::Input::AXES)};
+  const auto &axes = _tensor_registry->getITensor(axes_idx);
+
+  if (!input->is_dynamic())
+    return;
+
+  std::vector<int32_t> axes_vec;
+  for (uint32_t i = 0; i < axes->getShape().num_elements(); ++i)
+  {
+    const auto buffer = axes->buffer() + axes->calcOffset({i});
+    switch (axes->data_type())
+    {
+      case ir::DataType::INT32:
+      {
+        axes_vec.emplace_back(*reinterpret_cast<const int32_t *>(buffer));
+        break;
+      }
+      case ir::DataType::INT64:
+      {
+        axes_vec.emplace_back(*reinterpret_cast<const int64_t *>(buffer));
+        break;
+      }
+      default:
+        throw std::runtime_error("DynamicInferer ReduceProd: Not supported data type");
+        break;
+    }
+  }
+  const auto keep_dims = op.param().keep_dims;
+
+  auto output_ind = op.getOutputs().at(0);
+  auto output = _tensor_registry->getITensor(output_ind);
+
+  ir::Shape new_shape = shape_inference::inferReduceShapes(input_shape, axes_vec, keep_dims);
+
+  _dynamic_tensor_manager->applyShape(output_ind, new_shape);
+  assert(output->buffer() != nullptr);
+}
+
+void DynamicInferer::visit(const ir::operation::ReduceSum &op)
+{
+  const auto input_idx{op.getInputs().at(ir::operation::ReduceSum::Input::INPUT)};
+  const auto &input = _tensor_registry->getITensor(input_idx);
+  auto input_shape = input->getShape();
+
+  const auto axes_idx{op.getInputs().at(ir::operation::ReduceSum::Input::AXES)};
+  const auto &axes = _tensor_registry->getITensor(axes_idx);
+
+  if (!input->is_dynamic())
+    return;
+
+  std::vector<int32_t> axes_vec;
+  for (uint32_t i = 0; i < axes->getShape().num_elements(); ++i)
+  {
+    const auto buffer = axes->buffer() + axes->calcOffset({i});
+    switch (axes->data_type())
+    {
+      case ir::DataType::INT32:
+      {
+        axes_vec.emplace_back(*reinterpret_cast<const int32_t *>(buffer));
+        break;
+      }
+      case ir::DataType::INT64:
+      {
+        axes_vec.emplace_back(*reinterpret_cast<const int64_t *>(buffer));
+        break;
+      }
+      default:
+        throw std::runtime_error("DynamicInferer ReduceSum: Not supported data type");
+        break;
+    }
+  }
+  const auto keep_dims = op.param().keep_dims;
+
+  auto output_ind = op.getOutputs().at(0);
+  auto output = _tensor_registry->getITensor(output_ind);
+
+  ir::Shape new_shape = shape_inference::inferReduceShapes(input_shape, axes_vec, keep_dims);
+
+  _dynamic_tensor_manager->applyShape(output_ind, new_shape);
+  assert(output->buffer() != nullptr);
+}
+
+void DynamicInferer::visit(const ir::operation::Reshape &op)
+{
+  // check if output is not dynamic
+  auto output_ind = op.getOutputs().at(0);
+  auto output = _tensor_registry->getITensor(output_ind);
+
+  auto input_ind = op.getInputs().at(ir::operation::Reshape::Input::INPUT);
+  auto input = _tensor_registry->getITensor(input_ind);
+
+  /*
+    Here, the state after compilation (satic shape inference) could be one of the following:
+
+              input1   input2 (or option)   output     execution-time shape inf required
+              ------------------------------------     --------------------------------
+      case 1) static         const          static       X
+      case 2) static      placeholder       dynamic      O
+      case 3) dynamic        const          dynamic      O
+      case 4) dynamic     placeholder       dynamic      O
+
+    Then nnfw_apply_tensorinf() could change input dynamic.
+    So, in this method, we could have one more state and we have to re-calculate shape
+    for this shape.
+
+      case 5) dynamic    const       static       O
+
+    So, only when both input1 and ouput are static, we can skip dynamic shape inference.
+  */
+  if ((!input->is_dynamic()) && (!output->is_dynamic()))
+    return;
+
+  // New shape is given by second input tensor
+  if (op.getInputs().size() == 2)
+  {
+    // from op, access the buffer of second input to read new shape
+    auto new_shape_ind = op.getInputs().at(ir::operation::Reshape::Input::SHAPE);
+
+    // getting output shape by reading new_shape tensor buffer
+    auto new_shape = _tensor_registry->getITensor(new_shape_ind);
+    assert(new_shape);
+
+    int32_t *new_shape_buf = reinterpret_cast<int32_t *>(new_shape->buffer());
+    assert(new_shape_buf);
+
+    auto output_shape = shape_inference::inferReshapeShape(
+        new_shape_buf, new_shape->getShape().num_elements(), input->getShape().num_elements());
+
+    // if shape is changed, change output shape and reallocate output tensor memory
+    if (output_shape != output->getShape() || output->buffer() == nullptr)
+    {
+      // change on output shape
+      _dynamic_tensor_manager->applyShape(output_ind, output_shape);
+    }
+    assert(output->buffer() != nullptr);
+  }
+  // New shape is given by option
+  else if (op.param().new_shape.size() != 0)
+  {
+    // Let's check the new_shape option
+    auto shape = op.param().new_shape;
+    auto output_shape = shape_inference::inferReshapeShape(shape.data(), shape.size(),
+                                                           input->getShape().num_elements());
+
+    // if shape is changed, change output shape and reallocate output tensor memory
+    if (output_shape != output->getShape() || output->buffer() == nullptr)
+    {
+      // change on output shape
+      _dynamic_tensor_manager->applyShape(output_ind, output_shape);
+    }
+    assert(output->buffer() != nullptr);
+  }
+  else
+  {
+    throw std::runtime_error("Reshape: new shape is missing");
+    return;
+  }
+}
+
+void DynamicInferer::visit(const ir::operation::Reverse &op)
+{
+  handleSimpleUnaryOp(op, op.getInputs().at(ir::operation::Reverse::INPUT));
+}
+
+void DynamicInferer::visit(const ir::operation::Round &op)
+{
+  handleSimpleUnaryOp(op, op.getInputs().at(ir::operation::Round::Input::INPUT));
+}
+
+void DynamicInferer::visit(const ir::operation::RSQRT &op)
+{
+  handleSimpleUnaryOp(op, op.getInputs().at(ir::operation::RSQRT::INPUT));
+}
+
+void DynamicInferer::visit(const ir::operation::Select &op)
+{
+  const auto input_cond_idx = op.getInputs().at(ir::operation::Select::Input::CONDITION);
+  const auto &input_cond = _tensor_registry->getITensor(input_cond_idx);
+
+  const auto input_true_idx = op.getInputs().at(ir::operation::Select::Input::INPUT_TRUE);
+  const auto &input_true = _tensor_registry->getITensor(input_true_idx);
+
+  const auto input_false_idx = op.getInputs().at(ir::operation::Select::Input::INPUT_FALSE);
+  const auto &input_false = _tensor_registry->getITensor(input_false_idx);
+
+  if ((!input_cond->is_dynamic()) && (!input_true->is_dynamic()) && (!input_false->is_dynamic()))
+  {
+    return;
+  }
+
+  auto input_cond_shape = input_cond->getShape();
+  auto input_true_shape = input_true->getShape();
+  auto input_false_shape = input_false->getShape();
+
+  // Select output shpae
+  ir::Shape new_shape =
+      shape_inference::inferSelectShape(input_cond_shape, input_true_shape, input_false_shape);
+
+  auto output_ind = op.getOutputs().at(0);
+  auto output = _tensor_registry->getITensor(output_ind);
+
+  _dynamic_tensor_manager->applyShape(output_ind, new_shape);
+  assert(output->buffer() != nullptr);
+}
+
+void DynamicInferer::visit(const ir::operation::Shape &op)
+{
+  const auto input_idx{op.getInputs().at(0)};
+  const auto &input = _tensor_registry->getITensor(input_idx);
+  auto input_shape = input->getShape();
+
+  if (!input->is_dynamic())
+    return;
+
+  auto output_ind = op.getOutputs().at(0);
+  auto output = _tensor_registry->getITensor(output_ind);
+
+  ir::Shape output_shape;
+  output_shape.append(input_shape.rank());
+
+  _dynamic_tensor_manager->applyShape(output_ind, output_shape);
+  assert(output->buffer() != nullptr);
+}
+
+void DynamicInferer::visit(const ir::operation::Sin &op)
+{
+  handleSimpleUnaryOp(op, op.getInputs().at(ir::operation::Sin::Input::INPUT));
+}
+
+void DynamicInferer::visit(const ir::operation::Slice &op)
+{
+  const auto input_index{op.getInputs().at(ir::operation::Slice::Input::INPUT)};
+  const auto input = _tensor_registry->getITensor(input_index);
+  const auto begins_index{op.getInputs().at(ir::operation::Slice::Input::BEGINS)};
+  const auto begins = _tensor_registry->getITensor(begins_index);
+  const auto sizes_index{op.getInputs().at(ir::operation::Slice::Input::SIZES)};
+  const auto sizes = _tensor_registry->getITensor(sizes_index);
+  auto output_index = op.getOutputs().at(0);
+  auto output = _tensor_registry->getITensor(output_index);
+
+  if (!(input->is_dynamic() || begins->is_dynamic() || sizes->is_dynamic() || output->is_dynamic()))
+  {
+    return;
+  }
+
+  ir::Shape input_shape = input->getShape();
+  auto begins_buf = reinterpret_cast<const int32_t *>(begins->buffer());
+  auto sizes_buf = reinterpret_cast<const int32_t *>(sizes->buffer());
+
+  ir::Shape new_shape = shape_inference::inferSliceShape(input_shape, begins_buf, sizes_buf);
+
+  _dynamic_tensor_manager->applyShape(output_index, new_shape);
+  assert(output->buffer() != nullptr);
+}
+
+void DynamicInferer::visit(const ir::operation::Softmax &op)
+{
+  handleSimpleUnaryOp(op, op.getInputs().at(ir::operation::Softmax::INPUT));
+}
+
+void DynamicInferer::visit(const ir::operation::Split &op)
+{
+  const auto input_idx{op.getInputs().at(ir::operation::Split::Input::INPUT)};
+  const auto &input = _tensor_registry->getITensor(input_idx);
+
+  if (!input->is_dynamic())
+  {
+    return;
+  }
+
+  auto input_shape = input->getShape();
+
+  const auto axis = op.param().axis;
+  const auto num_splits = op.param().num_splits;
+  const auto rank = input_shape.rank();
+  auto axis_resolved = axis < 0 ? axis + rank : axis;
+
+  assert(0 <= axis_resolved && axis_resolved < rank);
+
+  ir::Shape new_shape = shape_inference::inferSplitShape(input_shape, axis_resolved, num_splits);
+  for (int out_tensor_idx = 0; out_tensor_idx < num_splits; out_tensor_idx++)
+  {
+    auto output_ind = op.getOutputs().at(out_tensor_idx);
+    auto output = _tensor_registry->getITensor(output_ind);
+
+    _dynamic_tensor_manager->applyShape(output_ind, new_shape);
+    assert(output->buffer() != nullptr);
+  }
+}
+
+void DynamicInferer::visit(const ir::operation::SquaredDifference &op)
+{
+  handleBinaryArithmeticOp(op, op.getInputs().at(ir::operation::SquaredDifference::Input::LHS),
+                           op.getInputs().at(ir::operation::SquaredDifference::Input::RHS));
+}
+
+void DynamicInferer::visit(const ir::operation::Squeeze &op)
+{
+  const auto input_idx{op.getInputs().at(ir::operation::Squeeze::Input::INPUT)};
+  const auto &input = _tensor_registry->getITensor(input_idx);
+
+  if (!input->is_dynamic())
+  {
+    return;
+  }
+
+  auto input_shape = input->getShape();
+
+  // Squeeze output shpae
+  ir::Shape new_shape = shape_inference::inferSqueezeShape(input_shape, op.param());
+
+  auto output_ind = op.getOutputs().at(0);
+  auto output = _tensor_registry->getITensor(output_ind);
+
+  _dynamic_tensor_manager->applyShape(output_ind, new_shape);
+  assert(output->buffer() != nullptr);
+}
+
+void DynamicInferer::visit(const ir::operation::StridedSlice &op)
+{
+
+  const auto input_index{op.getInputs().at(ir::operation::StridedSlice::Input::INPUT)};
+  auto input = _tensor_registry->getITensor(input_index);
+  ir::Shape input_shape = input->getShape();
+
+  const auto starts_index{op.getInputs().at(ir::operation::StridedSlice::Input::STARTS)};
+  auto starts = _tensor_registry->getITensor(starts_index);
+
+  const auto ends_index{op.getInputs().at(ir::operation::StridedSlice::Input::ENDS)};
+  auto ends = _tensor_registry->getITensor(ends_index);
+
+  const auto strides_index{op.getInputs().at(ir::operation::StridedSlice::Input::STRIDES)};
+  auto strides = _tensor_registry->getITensor(strides_index);
+
+  if (!(input->is_dynamic() || starts->is_dynamic() || ends->is_dynamic() || strides->is_dynamic()))
+  {
+    return;
+  }
+
+  const auto begin_mask = op.param().begin_mask;
+  const auto end_mask = op.param().end_mask;
+  const auto shrink_axis_mask = op.param().shrink_axis_mask;
+  const auto rank = input_shape.rank();
+
+  auto op_params = shape_inference::buildStridedSliceParams(
+      reinterpret_cast<uint32_t *>(starts->buffer()), reinterpret_cast<uint32_t *>(ends->buffer()),
+      reinterpret_cast<uint32_t *>(strides->buffer()), begin_mask, end_mask, shrink_axis_mask,
+      rank);
+
+  auto output_index = op.getOutputs().at(0);
+  auto output = _tensor_registry->getITensor(output_index);
+
+  ir::Shape output_shape =
+      onert::shape_inference::inferStridedSliceShape(input_shape, op_params, rank);
+
+  _dynamic_tensor_manager->applyShape(output_index, output_shape);
+  assert(output->buffer() != nullptr);
+}
+
+void DynamicInferer::visit(const ir::operation::Sub &op)
+{
+  handleBinaryArithmeticOp(op, op.getInputs().at(ir::operation::Sub::Input::LHS),
+                           op.getInputs().at(ir::operation::Sub::Input::RHS));
+}
+
+void DynamicInferer::visit(const ir::operation::Tanh &op)
+{
+  handleSimpleUnaryOp(op, op.getInputs().at(ir::operation::Tanh::INPUT));
+}
+
+void DynamicInferer::visit(const ir::operation::Tile &op)
+{
+  auto output_ind = op.getOutputs().at(0);
+  auto output = _tensor_registry->getITensor(output_ind);
+
+  auto input_idx = op.getInputs().at(ir::operation::Tile::Input::INPUT);
+  auto input = _tensor_registry->getITensor(input_idx);
+
+  auto multiplier_idx = op.getInputs().at(ir::operation::Tile::Input::MULTIPLES);
+  auto multiplier = _tensor_registry->getITensor(multiplier_idx);
+
+  if ((!input->is_dynamic()) && (!output->is_dynamic()))
+    return;
+
+  auto input_shape = input->getShape();
+  auto multiplier_buffer = reinterpret_cast<const int32_t *>(multiplier->buffer());
+  assert(multiplier_buffer);
+
+  auto output_shape = shape_inference::inferTileShape(input_shape, multiplier_buffer);
+
+  // set output shape and output buffer
+  _dynamic_tensor_manager->applyShape(output_ind, output_shape);
+  assert(output->buffer() != nullptr);
+}
+
+void DynamicInferer::visit(const ir::operation::Transpose &op)
+{
+  // check if output is not dynamic
+  auto output_ind = op.getOutputs().at(0);
+  auto output = _tensor_registry->getITensor(output_ind);
+
+  // from op, access the buffer of second input to read new shape
+  auto input_ind = op.getInputs().at(ir::operation::Transpose::Input::INPUT);
+  auto input_tensor = _tensor_registry->getITensor(input_ind);
+  auto input_shape = input_tensor->getShape();
+
+  if (!input_tensor->is_dynamic())
+    return;
+
+  const auto perm{op.param().perm};
+  // set output shape, based on input and params
+  ir::Shape new_shape = shape_inference::inferTransposeShape(input_shape, perm);
+
+  _dynamic_tensor_manager->applyShape(output_ind, new_shape);
+  assert(output->buffer() != nullptr);
+}
+
+void DynamicInferer::visit(const ir::operation::Unpack &op)
+{
+  // check if output is not dynamic
+  const auto input_idx{op.getInputs().at(0)};
+  const auto &input = _tensor_registry->getITensor(input_idx);
+
+  if (!input->is_dynamic())
+    return;
+
+  auto input_shape = input->getShape();
+
+  const auto rank = input_shape.rank();
+  const auto axis = ((op.param().axis < 0) ? rank + op.param().axis : op.param().axis);
+  const auto num = op.param().num;
+
+  assert(0 <= axis && axis < rank);
+
+  ir::Shape new_shape = shape_inference::unpackShapes(input_shape, axis, rank);
+
+  for (int out_tensor_idx = 0; out_tensor_idx < num; out_tensor_idx++)
+  {
+    auto output_ind = op.getOutputs().at(out_tensor_idx);
+    auto output = _tensor_registry->getITensor(output_ind);
+
+    _dynamic_tensor_manager->applyShape(output_ind, new_shape);
+
+    assert(output->buffer() != nullptr);
+  }
+}
+
+void DynamicInferer::visit(const ir::operation::ZerosLike &op)
+{
+  handleSimpleUnaryOp(op, op.getInputs().at(ir::operation::ZerosLike::INPUT));
+}
+
+} // namespace exec
+} // namespace onert

--- a/runtime/onert/core/src/exec/FunctionSequence.cc
+++ b/runtime/onert/core/src/exec/FunctionSequence.cc
@@ -19,7 +19,6 @@
 #include "ir/Operation.h"
 #include "backend/IDynamicTensorManager.h"
 #include "backend/ITensorRegistry.h"
-#include "util/ShapeInference.h"
 
 namespace onert
 {


### PR DESCRIPTION
For #1616
After #2364

This commit moves static inference code to `compiler` directory and
dynamic inference code to `exec` directory.

(remaining work: remove `util/shapeinf` directory)

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>