### PR TITLE
[onert][cker] Introduce checking constant into OperandInfo

### DIFF
--- a/runtime/onert/backend/cpu/ops/ConvolutionLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ConvolutionLayer.cc
@@ -56,21 +56,6 @@ void ConvolutionLayer::convFloat32()
   op_params.float_activation_max = output_activation_max;
 
   nnfw::cker::Conv &kernel = *_conv_kernel;
-  if (!_prepare)
-  {
-    bool is_replaced_weights = false;
-    kernel.prepare(getTensorShape(_kernel), reinterpret_cast<const float *>(_kernel->buffer()),
-                   op_params.padding_type, is_replaced_weights);
-
-    if (is_replaced_weights)
-    {
-      auto kernel_tensor = dynamic_cast<const Tensor *>(_kernel);
-      if (kernel_tensor)
-        // TODO Remove const_cast
-        const_cast<Tensor *>(kernel_tensor)->decrease_ref();
-    }
-    _prepare = true;
-  }
   kernel(op_params, getTensorShape(_input), reinterpret_cast<const float *>(_input->buffer()),
          getTensorShape(_kernel), reinterpret_cast<const float *>(_kernel->buffer()),
          getTensorShape(_bias), reinterpret_cast<const float *>(_bias->buffer()),
@@ -105,14 +90,9 @@ void ConvolutionLayer::convQuant8()
   op_params.output_shift = output_shift;
   op_params.quantized_activation_min = output_activation_min;
   op_params.quantized_activation_max = output_activation_max;
+  op_params.is_replaced_weights = true;
 
   nnfw::cker::Conv &kernel = *_conv_kernel;
-  if (!_prepare)
-  {
-    kernel.prepareQuant(getTensorShape(_input), getTensorShape(_kernel), getTensorShape(_output),
-                        _strideWidth, _strideHeight);
-    _prepare = true;
-  }
   kernel(op_params, getTensorShape(_input), reinterpret_cast<const uint8_t *>(_input->buffer()),
          getTensorShape(_kernel), reinterpret_cast<const uint8_t *>(_kernel->buffer()),
          getTensorShape(_bias), reinterpret_cast<const int32_t *>(_bias->buffer()),
@@ -182,6 +162,36 @@ void ConvolutionLayer::run()
   {
     throw std::runtime_error{"Conv: unsupported data type"};
   }
+}
+
+void ConvolutionLayer::prepare()
+{
+  if (_prepare)
+    return;
+
+  nnfw::cker::Conv &kernel = *_conv_kernel;
+  if (_input->data_type() == OperandType::FLOAT32 && _kernel->is_constant())
+  {
+    bool is_transposed = false;
+    kernel.prepare(getTensorShape(_kernel), reinterpret_cast<const float *>(_kernel->buffer()),
+                   getPaddingType(_paddingType), is_transposed);
+
+    // Decrease reference of _kernel(weights) only when _kernel is constant
+    if (is_transposed)
+    {
+      auto kernel_tensor = dynamic_cast<const Tensor *>(_kernel);
+      if (kernel_tensor)
+        // TODO Remove const_cast
+        const_cast<Tensor *>(kernel_tensor)->decrease_ref();
+    }
+  }
+  else if (_input->data_type() == OperandType::QUANT_UINT8_ASYMM && _kernel->is_constant() &&
+           !_input->is_dynamic() && !_output->is_dynamic())
+  {
+    kernel.prepareQuant(getTensorShape(_input), getTensorShape(_kernel), getTensorShape(_output),
+                        _strideWidth, _strideHeight);
+  }
+  _prepare = true;
 }
 
 #undef ANDROID_NN_CONV_PARAMETERS

--- a/runtime/onert/backend/cpu/ops/ConvolutionLayer.h
+++ b/runtime/onert/backend/cpu/ops/ConvolutionLayer.h
@@ -61,6 +61,8 @@ public:
 
   void run() override;
 
+  void prepare() override;
+
 private:
   const IPortableTensor *_input;
   const IPortableTensor *_kernel;

--- a/runtime/onert/core/include/backend/ITensor.h
+++ b/runtime/onert/core/include/backend/ITensor.h
@@ -51,6 +51,14 @@ public:
   virtual void access(const std::function<void(ITensor &tensor)> &fn) = 0;
 
   /**
+   * @brief Return true if the tensor is constant
+   */
+  virtual bool is_constant() const
+  {
+    throw std::runtime_error("This backend does not support checking constant");
+  }
+
+  /**
    * @brief Return true if the tensor needs dynamic allocation, meaning that during compile-time
    *        the outpus shape cannot be known and the output shape is calculated during
    *        kernel execution-time.

--- a/runtime/onert/core/include/backend/cpu_common/Tensor.h
+++ b/runtime/onert/core/include/backend/cpu_common/Tensor.h
@@ -93,6 +93,7 @@ public:
   ir::DataType data_type() const override { return _info.typeInfo().type(); }
   float data_scale() const override { return _info.typeInfo().scale(); }
   int32_t data_offset() const override { return _info.typeInfo().offset(); }
+  bool is_constant() const override { return _info.isConstant(); }
   bool is_dynamic() const override { return _info.isDynamic(); }
   void set_dynamic() override { _info.setDynamic(); }
 

--- a/runtime/onert/core/include/ir/Operand.h
+++ b/runtime/onert/core/include/ir/Operand.h
@@ -36,7 +36,7 @@ class Operand
 {
 public:
   explicit Operand(const Shape &shape, const TypeInfo &type)
-      : _info{shape, type, MemAllocType::STATIC}, _const{false}
+      : _info{shape, type, MemAllocType::STATIC}
   {
     // DO NOTHING
   }
@@ -62,7 +62,7 @@ public:
   void data(std::shared_ptr<Data> &&data)
   {
     _data = std::move(data);
-    _const = true;
+    _info.setAsConstant();
   }
   const Data *data(void) const { return _data.get(); }
 
@@ -72,7 +72,7 @@ public:
    * @brief Get true if Operand is const, otherwise @c false
    a @return @c true if Operand is const, otherwise @c false
    */
-  bool isConstant(void) const { return _const; }
+  bool isConstant(void) const { return _info.isConstant(); }
 
 public:
   template <typename T, typename... Args> void data(Args &&... args)
@@ -103,7 +103,6 @@ public:
 private:
   OperandInfo _info;
   std::shared_ptr<Data> _data;
-  bool _const;
 
   OperationIndexSet _uses;
   OperationIndexSet _def; // size is 0 (constant) or 1 (from def operation)

--- a/runtime/onert/core/include/ir/OperandInfo.h
+++ b/runtime/onert/core/include/ir/OperandInfo.h
@@ -66,7 +66,7 @@ public:
    * @param[in] alloc_type  When the thesor needs memory allocation
    */
   OperandInfo(const Shape &shape, const TypeInfo &typeInfo, MemAllocType alloc_type)
-      : _shape(shape), _typeInfo(typeInfo), _alloc_type(alloc_type)
+      : _shape(shape), _typeInfo(typeInfo), _alloc_type(alloc_type), _const(false)
   {
     // DO NOTHING
   }
@@ -115,6 +115,12 @@ public:
   size_t total_size() const { return _shape.num_elements() * sizeOfDataType(_typeInfo.type()); }
 
   MemAllocType memAllocType() const { return _alloc_type; }
+  void setAsConstant() { _const = true; }
+  bool isConstant() const
+  {
+    assert(!isDynamic());
+    return _const;
+  }
   bool isDynamic() const { return _alloc_type == MemAllocType::DYNAMIC; }
   void setDynamic() { _alloc_type = MemAllocType::DYNAMIC; }
 
@@ -123,6 +129,7 @@ private:
   TypeInfo _typeInfo;
 
   MemAllocType _alloc_type;
+  bool _const;
 };
 
 } // namespace ir


### PR DESCRIPTION
This commit introduces checking constant into OperandInfo.
  - Introduce isConstant() into OperandInfo
  - Add is_constant() into ITensor
  - Make cpu::ConvolutionLayer uses is_constant() of Tensor.
  - Apply constant and dynamic for ConvolutionLayer::prepare()

Signed-off-by: ragmani <ragmani0216@gmail.com>