### PR TITLE
[onert] use same style for handling small size tensor

### DIFF
--- a/runtime/onert/backend/cpu/ops/OperationUtils.h
+++ b/runtime/onert/backend/cpu/ops/OperationUtils.h
@@ -85,12 +85,12 @@ inline nnfw::cker::Shape getTensorShape(const IPortableTensor *tensor)
     return nnfw::cker::Shape();
 
   assert(tensor->layout() == ir::Layout::NHWC);
-  const int maxSmallSize = 8;
-  int32_t raw_shape_small[maxSmallSize];
+  constexpr int kMaxSmallSize = 8;
+  int32_t raw_shape_small[kMaxSmallSize];
   std::vector<int32_t> raw_shape_vec;
   auto rank = tensor->num_dimensions();
   int32_t *data = nullptr;
-  if (rank > maxSmallSize)
+  if (rank > kMaxSmallSize)
   {
     raw_shape_vec.resize(rank);
     data = raw_shape_vec.data();


### PR DESCRIPTION
It will use `constexpr` and the name of `kMaxSmallSize` for consistency.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>