### PR TITLE
[onert] Fix unittest report path

### DIFF
--- a/tests/scripts/unittest.sh
+++ b/tests/scripts/unittest.sh
@@ -27,7 +27,8 @@ function Usage()
 
 get_gtest_option()
 {
-    local output_option="--gtest_output=xml:$UNITTEST_REPORT_DIR/$TEST_BIN.xml"
+    local UNITTEST_REPORT_FILE=$(basename $TEST_BIN)
+    local output_option="--gtest_output=xml:$UNITTEST_REPORT_DIR/$UNITTEST_REPORT_FILE.xml"
     local filter_option
     if [ -r "$TEST_BIN.skip" ]; then
       filter_option="--gtest_filter=-$(grep -v '#' "$TEST_BIN.skip" | tr '\n' ':')"


### PR DESCRIPTION
Remove duplicated directory path from generated report file

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>