### PR TITLE
[onert] Revise TensorBuilderSet

### DIFF
--- a/runtime/onert/core/include/backend/ITensorBuilder.h
+++ b/runtime/onert/core/include/backend/ITensorBuilder.h
@@ -158,17 +158,4 @@ public: // methods for dynamic tensor allocation
 } // namespace backend
 } // namespace onert
 
-#include <unordered_set>
-#include <memory>
-
-namespace onert
-{
-namespace backend
-{
-
-using TensorBuilderSet = std::unordered_set<std::shared_ptr<backend::ITensorBuilder>>;
-
-} // namespace backend
-} // namespace onert
-
 #endif // __ONERT_BACKEND_ITENSOR_BUILDER_H__

--- a/runtime/onert/core/src/backend/controlflow/KernelGenerator.cc
+++ b/runtime/onert/core/src/backend/controlflow/KernelGenerator.cc
@@ -31,7 +31,7 @@ namespace controlflow
 {
 
 KernelGenerator::KernelGenerator(const ir::Graph &graph)
-    : _graph{graph}, _tensor_builder_set{nullptr}, _executor_map{nullptr}
+    : _graph{graph}, _tensor_builder_set{}, _executor_map{nullptr}
 {
   UNUSED_RELEASE(_graph);
   UNUSED_RELEASE(_tensor_builder_set);

--- a/runtime/onert/core/src/backend/controlflow/KernelGenerator.h
+++ b/runtime/onert/core/src/backend/controlflow/KernelGenerator.h
@@ -22,6 +22,8 @@
 #include <exec/IExecutor.h>
 #include <ir/Graph.h>
 
+#include "compiler/TensorBuilders.h"
+
 namespace onert
 {
 namespace backend
@@ -34,7 +36,7 @@ class KernelGenerator : public IKernelGenerator
 public:
   KernelGenerator(const ir::Graph &graph);
 
-  void setTensorBuilderSet(const TensorBuilderSet &tensor_builder_set)
+  void setTensorBuilderSet(const compiler::TensorBuilders &tensor_builder_set)
   {
     _tensor_builder_set = tensor_builder_set;
   }
@@ -57,7 +59,7 @@ private:
 
 private:
   const ir::Graph &_graph;
-  TensorBuilderSet _tensor_builder_set;
+  compiler::TensorBuilders _tensor_builder_set;
   exec::ExecutorMap *_executor_map;
 };
 

--- a/runtime/onert/core/src/compiler/ExecutorFactory.cc
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.cc
@@ -220,11 +220,7 @@ ExecutorFactory::createLinearExecutor(std::unique_ptr<ir::LoweredGraph> lowered_
   Linear::dump(*lowered_graph, order);
   Linear::planTensors(*lowered_graph, order);
 
-  backend::TensorBuilderSet tensor_builders;
-  for (const auto &e : lowered_graph->backend_contexts())
-  {
-    tensor_builders.insert(e.second->tensor_builder);
-  }
+  TensorBuilders tensor_builders{lowered_graph->backend_contexts(), true};
 
   for (auto &tensor_builder : tensor_builders)
   {
@@ -310,11 +306,7 @@ exec::IExecutor *ExecutorFactory::createDataflowExecutor(
   auto order = Linear::linearize(*lowered_graph);
   runTensorRegistration(lowered_graph.get(), order);
 
-  backend::TensorBuilderSet tensor_builders;
-  for (const auto &e : lowered_graph->backend_contexts())
-  {
-    tensor_builders.insert(e.second->tensor_builder);
-  }
+  TensorBuilders tensor_builders{lowered_graph->backend_contexts(), true};
 
   // To make tensors never be deallocated, this is a workaround to use static memory planner
   for (auto &tensor_builder : tensor_builders)

--- a/runtime/onert/core/src/compiler/TensorBuilders.h
+++ b/runtime/onert/core/src/compiler/TensorBuilders.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_COMPILER_TENSOR_BUILDER_H__
+#define __ONERT_COMPILER_TENSOR_BUILDER_H__
+
+#include <unordered_set>
+#include <memory>
+#include "backend/BackendContext.h"
+#include "backend/Backend.h"
+#include "backend/controlflow/Config.h"
+#include "backend/controlflow/TensorBuilder.h"
+
+namespace onert
+{
+namespace compiler
+{
+
+class TensorBuilders
+{
+public:
+  TensorBuilders() = default;
+
+  TensorBuilders(const onert::backend::BackendContexts &backend_contexts, bool include_controlflow)
+  {
+    for (const auto &e : backend_contexts)
+    {
+      if (e.first->config()->id() == backend::controlflow::Config::ID)
+      {
+        _cf_tensor_builder = std::dynamic_pointer_cast<backend::controlflow::TensorBuilder>(
+            e.second->tensor_builder);
+        if (include_controlflow)
+          _tensor_builders.insert(e.second->tensor_builder);
+      }
+      else
+      {
+        _tensor_builders.insert(e.second->tensor_builder);
+      }
+    }
+  }
+
+  std::unordered_set<std::shared_ptr<onert::backend::ITensorBuilder>>::const_iterator begin() const
+  {
+    return _tensor_builders.cbegin();
+  }
+  std::unordered_set<std::shared_ptr<onert::backend::ITensorBuilder>>::const_iterator end() const
+  {
+    return _tensor_builders.cend();
+  }
+
+  std::shared_ptr<backend::controlflow::TensorBuilder> getControlflowTensorBuilder() const
+  {
+    return _cf_tensor_builder;
+  }
+
+private:
+  std::unordered_set<std::shared_ptr<backend::ITensorBuilder>> _tensor_builders;
+  std::shared_ptr<backend::controlflow::TensorBuilder> _cf_tensor_builder;
+};
+
+} // namespace compiler
+} // namespace onert
+
+#endif // __ONERT_COMPILER_TENSOR_BUILDER_H__

--- a/runtime/onert/core/src/compiler/TensorBuilders.h
+++ b/runtime/onert/core/src/compiler/TensorBuilders.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef __ONERT_COMPILER_TENSOR_BUILDER_H__
-#define __ONERT_COMPILER_TENSOR_BUILDER_H__
+#ifndef __ONERT_COMPILER_TENSOR_BUILDERS_H__
+#define __ONERT_COMPILER_TENSOR_BUILDERS_H__
 
 #include <unordered_set>
 #include <memory>
@@ -74,4 +74,4 @@ private:
 } // namespace compiler
 } // namespace onert
 
-#endif // __ONERT_COMPILER_TENSOR_BUILDER_H__
+#endif // __ONERT_COMPILER_TENSOR_BUILDERS_H__

--- a/runtime/onert/core/src/exec/DataflowExecutor.cc
+++ b/runtime/onert/core/src/exec/DataflowExecutor.cc
@@ -78,7 +78,7 @@ bool DataflowExecutor::noWaitingJobs()
 }
 
 DataflowExecutor::DataflowExecutor(std::unique_ptr<ir::LoweredGraph> lowered_graph,
-                                   const backend::TensorBuilderSet &tensor_builders,
+                                   const compiler::TensorBuilders &tensor_builders,
                                    compiler::CodeMap &&code_map)
     : ExecutorBase{std::move(lowered_graph), tensor_builders}, _code_map{std::move(code_map)}
 {

--- a/runtime/onert/core/src/exec/DataflowExecutor.h
+++ b/runtime/onert/core/src/exec/DataflowExecutor.h
@@ -50,7 +50,7 @@ public:
    * @param code_map OpSequence and its code map
    */
   DataflowExecutor(std::unique_ptr<ir::LoweredGraph> lowered_graph,
-                   const backend::TensorBuilderSet &tensor_builders, compiler::CodeMap &&code_map);
+                   const compiler::TensorBuilders &tensor_builders, compiler::CodeMap &&code_map);
 
   void executeImpl() override;
 

--- a/runtime/onert/core/src/exec/ExecutorBase.cc
+++ b/runtime/onert/core/src/exec/ExecutorBase.cc
@@ -25,7 +25,7 @@ namespace exec
 {
 
 ExecutorBase::ExecutorBase(std::unique_ptr<ir::LoweredGraph> &&lowered_graph,
-                           const backend::TensorBuilderSet &tensor_builders)
+                           const compiler::TensorBuilders &tensor_builders)
     : _lowered_graph{std::move(lowered_graph)}, _graph{_lowered_graph->graph()}, _mutex()
 {
   auto build_input_tensor_list = [&](const onert::ir::OperandIndexSequence &ind_seq) {

--- a/runtime/onert/core/src/exec/ExecutorBase.h
+++ b/runtime/onert/core/src/exec/ExecutorBase.h
@@ -36,6 +36,7 @@
 #include "backend/ITensorManager.h"
 #include "backend/ITensorBuilder.h"
 #include "exec/ExecutionObservee.h"
+#include "compiler/TensorBuilders.h"
 #include <list>
 
 namespace onert
@@ -52,7 +53,7 @@ public:
    * @param tensor_builders Tensor builders that are currently used
    */
   ExecutorBase(std::unique_ptr<ir::LoweredGraph> &&lowered_graph,
-               const backend::TensorBuilderSet &tensor_builders);
+               const compiler::TensorBuilders &tensor_builders);
 
   virtual ~ExecutorBase() = default;
 

--- a/runtime/onert/core/src/exec/LinearExecutor.h
+++ b/runtime/onert/core/src/exec/LinearExecutor.h
@@ -47,7 +47,7 @@ public:
    * @param code_map OpSequence and its code map
    */
   LinearExecutor(std::unique_ptr<ir::LoweredGraph> lowered_graph,
-                 const backend::TensorBuilderSet &tensor_builders, compiler::CodeMap &&code_map,
+                 const compiler::TensorBuilders &tensor_builders, compiler::CodeMap &&code_map,
                  const std::vector<ir::OpSequenceIndex> &order)
       : ExecutorBase{std::move(lowered_graph), tensor_builders}
   {

--- a/runtime/onert/core/src/exec/ParallelExecutor.cc
+++ b/runtime/onert/core/src/exec/ParallelExecutor.cc
@@ -60,7 +60,7 @@ void ParallelExecutor::notify(uint32_t finished_job_id)
 }
 
 ParallelExecutor::ParallelExecutor(std::unique_ptr<ir::LoweredGraph> lowered_graph,
-                                   const backend::TensorBuilderSet &tensor_builders,
+                                   const compiler::TensorBuilders &tensor_builders,
                                    compiler::CodeMap &&code_map)
     : DataflowExecutor{std::move(lowered_graph), tensor_builders, std::move(code_map)}
 {

--- a/runtime/onert/core/src/exec/ParallelExecutor.h
+++ b/runtime/onert/core/src/exec/ParallelExecutor.h
@@ -51,7 +51,7 @@ public:
    * @param code_map OpSequence and its code map
    */
   ParallelExecutor(std::unique_ptr<ir::LoweredGraph> lowered_graph,
-                   const backend::TensorBuilderSet &tensor_builders, compiler::CodeMap &&code_map);
+                   const compiler::TensorBuilders &tensor_builders, compiler::CodeMap &&code_map);
 
   void executeImpl() override;
 


### PR DESCRIPTION
- Move it to `compiler`
- Rename to `TensorBuilders`
- Extend it to have a helper for controlflow
- Not able to add backends after construction

Part of #2835

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>