### PR TITLE
[circle2circle-dredd-recipe-test] Enable resolve_customop_matmul pass

### DIFF
--- a/compiler/circle2circle-dredd-recipe-test/test.lst
+++ b/compiler/circle2circle-dredd-recipe-test/test.lst
@@ -6,12 +6,14 @@
 #
 # fuse_instnorm
 # resolve_customop_batchmatmul
+# resolve_customop_matmul
 
 ## TFLITE RECIPE
 
 Add(Net_InstanceNorm_001 PASS fuse_instnorm)
 # Add(Net_InstanceNorm_002 PASS fuse_instnorm)
 Add(BatchMatMulV2_000 PASS resolve_customop_batchmatmul)
+Add(MatMul_000 PASS resolve_customop_matmul)
 
 ## CIRCLE RECIPE
 


### PR DESCRIPTION
This enables resolve_customop_matmul pass for MatMul_000 recipe in
circle2circle-dredd-recipe-test

For #1854 
Draft #2121 

ONE-DCO-1.0-Signed-off-by: Andrey Kvochko <a.kvochko@samsung.com>