### PR TITLE
[docs] Fix how-to-build-runtime

### DIFF
--- a/docs/howto/how-to-build-runtime.md
+++ b/docs/howto/how-to-build-runtime.md
@@ -29,11 +29,11 @@ git \
 graphviz \
 hdf5-tools \
 lcov \
-libatlas-base-dev\
+libatlas-base-dev \
 libboost-all-dev \
 libgflags-dev \
 libgoogle-glog-dev \
-libgtest-dev\
+libgtest-dev \
 libhdf5-dev \
 libprotobuf-dev \
 protobuf-compiler \


### PR DESCRIPTION
This will fix how-to-build-runtime with adding a space so that copy-paste works

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>