### PR TITLE
[onert] Remove unused field

### DIFF
--- a/runtime/onert/backend/cpu/ops/FullyConnectedLayer.h
+++ b/runtime/onert/backend/cpu/ops/FullyConnectedLayer.h
@@ -69,7 +69,6 @@ private:
   std::unique_ptr<nnfw::cker::FCTempArena> _temp_arena;
 
 #ifdef USE_RUY_GEMV
-  bool _is_weights_freed = false;     // weights is already freed?
   uint8_t *_cached_weights = nullptr; // weights to be cached and a key
 #endif
 };


### PR DESCRIPTION
Remove unused field "_is_weights_freed" in FullyConnectedLayer
Fix android (clang) build fail by this unused field

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>