### PR TITLE
[onert] Use optimized logistic cpu kernel for aarch64 only

### DIFF
--- a/compute/cker/include/cker/operation/Logistic.h
+++ b/compute/cker/include/cker/operation/Logistic.h
@@ -32,9 +32,18 @@ namespace cker
 inline void Logistic(const Shape &input_shape, const float *input_data, const Shape &output_shape,
                      float *output_data)
 {
+#ifdef __aarch64__
   auto input_map = MapAsVector(input_data, input_shape);
   auto output_map = MapAsVector(output_data, output_shape);
   output_map.array() = input_map.array().unaryExpr(Eigen::internal::scalar_logistic_op<float>());
+#else
+  // Note, this can be done using TANH: (1/2) + (1/2) * TANH(x/2)
+  const int size = MatchingFlatSize(input_shape, output_shape);
+  for (int i = 0; i < size; i++)
+  {
+    output_data[i] = 1.f / (1.f + std::exp(-input_data[i]));
+  }
+#endif
 }
 
 } // namespace cker


### PR DESCRIPTION
- This commit uses optimized logistic cpu kernel for aarch64 only
  - Optimized logistic kernel produces numerical error except for aarch64
  - Use reference kernel in platforms other than aarch64 to deal with value mismatch

ONE-DCO-1.0-Signed-off-by: JiHwan Yeo <jihwan.yeo@samsung.com>