### PR TITLE
DRAFT/WIP : Use FuncionSequence when a model has static tensors only

### DIFF
--- a/runtime/onert/backend/acl_cl/KernelGenerator.cc
+++ b/runtime/onert/backend/acl_cl/KernelGenerator.cc
@@ -58,6 +58,8 @@ void KernelGenerator::visit(const ir::OpSequence &op_seq)
   //      (all derivatives have the same implementation for this)
   assert(!_return_fn_seq);
   _return_fn_seq = std::make_unique<exec::FunctionSequence>();
+  _return_fn_seq->enableDynamicShapeInferer(false);
+
   _current_op_seq_layout = op_seq.getLayout();
   for (const auto &operation_idx : op_seq.operations())
   {

--- a/runtime/onert/backend/acl_neon/KernelGenerator.cc
+++ b/runtime/onert/backend/acl_neon/KernelGenerator.cc
@@ -58,6 +58,8 @@ void KernelGenerator::visit(const ir::OpSequence &op_seq)
   //      (all derivatives have the same implementation for this)
   assert(!_return_fn_seq);
   _return_fn_seq = std::make_unique<exec::FunctionSequence>();
+  _return_fn_seq->enableDynamicShapeInferer(false);
+
   _current_op_seq_layout = op_seq.getLayout();
   for (const auto &operation_idx : op_seq.operations())
   {

--- a/runtime/onert/backend/cpu/KernelGenerator.cc
+++ b/runtime/onert/backend/cpu/KernelGenerator.cc
@@ -132,12 +132,22 @@ void KernelGenerator::visit(const ir::OpSequence &op_seq)
   assert(_tensor_builder->tensorRegistry());
 
   auto dyn_tensor_manager = _tensor_builder->dynamicTensorManager();
-  auto dyn_shape_inferer = std::make_unique<exec::DynamicShapeInferer>(
+  auto dyn_shape_inferer = std::make_shared<exec::DynamicShapeInferer>(
       _ctx, dyn_tensor_manager, _tensor_builder->tensorRegistry());
 
-  // TODO Always returning FunctionSequenceForDynamicBackend may cause performance issue
-  _return_fn_seq = std::make_unique<exec::FunctionSequenceForDynamicBackend>(
-      op_seq, _operations_ctx, std::move(dyn_shape_inferer), dyn_tensor_manager);
+  _return_fn_seq = std::make_unique<exec::FunctionSequence>();
+
+  // Prepare to handle dynamic tensors later
+  auto dyn_ctx = std::make_shared<exec::FunctionSequence::DynamicTensorCtx>();
+  {
+    dyn_ctx->op_seq = &op_seq;
+    dyn_ctx->operations = &_operations_ctx;
+    dyn_ctx->dynamic_shape_inferer = std::move(dyn_shape_inferer);
+    dyn_ctx->tensor_registry = _tensor_builder->tensorRegistry();
+    dyn_ctx->dynamic_tensor_manager = _tensor_builder->dynamicTensorManager();
+
+    _return_fn_seq->dynamic_tensor_ctx(dyn_ctx);
+  }
 
   _current_op_seq_layout = op_seq.getLayout();
   for (const auto &operation_idx : op_seq.operations())

--- a/runtime/onert/core/src/backend/controlflow/KernelGenerator.cc
+++ b/runtime/onert/core/src/backend/controlflow/KernelGenerator.cc
@@ -47,12 +47,22 @@ void KernelGenerator::visit(const ir::OpSequence &op_seq)
   assert(_tensor_builder->tensorRegistry());
 
   auto dyn_tensor_manager = _tensor_builder->dynamicTensorManager();
-  auto dyn_shape_inferer = std::make_unique<exec::DynamicInferer>(
+  auto dyn_shape_inferer = std::make_unique<exec::DynamicShapeInferer>(
       _graph.operands(), dyn_tensor_manager, _tensor_builder->tensorRegistry());
 
-  // TODO Always returning FunctionSequenceForDynamicBackend may cause performance issue
-  _return_fn_seq = std::make_unique<exec::FunctionSequenceForDynamicBackend>(
-      op_seq, _graph.operations(), std::move(dyn_shape_inferer), dyn_tensor_manager);
+  _return_fn_seq = std::make_unique<exec::FunctionSequence>();
+
+  // Prepare to handle dynamic tensors later
+  auto dyn_ctx = std::make_shared<exec::FunctionSequence::DynamicTensorCtx>();
+  {
+    dyn_ctx->op_seq = &op_seq;
+    dyn_ctx->operations = &_graph.operations();
+    dyn_ctx->dynamic_shape_inferer = std::move(dyn_shape_inferer);
+    dyn_ctx->tensor_registry = _tensor_builder->tensorRegistry();
+    dyn_ctx->dynamic_tensor_manager = _tensor_builder->dynamicTensorManager();
+
+    _return_fn_seq->dynamic_tensor_ctx(dyn_ctx);
+  }
 
   for (const auto &op_idx : op_seq.operations())
   {

--- a/runtime/onert/core/src/exec/DataflowExecutor.cc
+++ b/runtime/onert/core/src/exec/DataflowExecutor.cc
@@ -126,6 +126,8 @@ void DataflowExecutor::executeImpl()
 {
   assert(noWaitingJobs());
 
+  bool dynamic_input_exists = hasDynamicInput();
+
   // Execution setup
   _waiting_jobs.swap(_finished_jobs); // Move finished jobs to waiting jobs
 
@@ -153,6 +155,10 @@ void DataflowExecutor::executeImpl()
         _lowered_graph->getLowerInfo()->op_seq.at(op_seq_index)->backend();
 
     _subject.notifyJobBegin(this, op_seq, backend);
+
+    // check if FunctionSequence needs to handle dynamic tensor
+    bool handle_dynamic_tensor = op_seq->has_dynamic_tensor() || dynamic_input_exists;
+    job->fn_seq()->enableDynamicShapeInferer(handle_dynamic_tensor);
 
     job->run();
 

--- a/runtime/onert/core/src/exec/LinearExecutor.cc
+++ b/runtime/onert/core/src/exec/LinearExecutor.cc
@@ -49,7 +49,13 @@ void LinearExecutor::executeImpl()
     ruy::profiler::ScopeLabel label(seq_to_label(op_seq, _graph.operations()));
 #endif
     _subject.notifyJobBegin(this, op_seq, backend);
-    code.fn_seq->run();
+
+    auto &fn_seq = code.fn_seq;
+    bool handle_dynamic_tensor = op_seq->has_dynamic_tensor() || hasDynamicInput();
+
+    fn_seq->enableDynamicShapeInferer(handle_dynamic_tensor);
+    fn_seq->run();
+
     _subject.notifyJobEnd(this, op_seq, backend);
   }
   _subject.notifyModelEnd(this);


### PR DESCRIPTION
**DRAFT/WIP**

For #2943

This draft make `FunctionSequence` to be used when a model has static tensors only.

Previously, with CPU backend, FunctionSequenceForDynamicTensor was always used and this make some performance overhead with, e.g., `deallocInput()` (/cc @glistening)

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>