### PR TITLE
[tests/tools] Introduce args into nnapi_test

### DIFF
--- a/tests/tools/nnapi_test/CMakeLists.txt
+++ b/tests/tools/nnapi_test/CMakeLists.txt
@@ -1,5 +1,10 @@
 list(APPEND SOURCES "src/nnapi_test.cc")
+list(APPEND SOURCES "src/args.cc")
+
+nnfw_find_package(Boost REQUIRED program_options)
 
 add_executable(nnapi_test ${SOURCES})
+target_include_directories(nnapi_test PRIVATE ${Boost_INCLUDE_DIRS})
 target_link_libraries(nnapi_test nnfw_lib_tflite)
+target_link_libraries(nnapi_test ${Boost_PROGRAM_OPTIONS_LIBRARY})
 install(TARGETS nnapi_test DESTINATION bin)

--- a/tests/tools/nnapi_test/src/args.cc
+++ b/tests/tools/nnapi_test/src/args.cc
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "args.h"
+
+#include <iostream>
+
+namespace nnapi_test
+{
+
+Args::Args(const int argc, char **argv)
+{
+  Initialize();
+  try
+  {
+    Parse(argc, argv);
+  }
+  catch (const std::exception &e)
+  {
+    std::cerr << "The argments that cannot be parsed: " << e.what() << '\n';
+    print(argv);
+    exit(255);
+  }
+}
+
+void Args::print(char **argv)
+{
+  std::cout << "nnapi_test\n\n";
+  std::cout << "Usage: " << argv[0] << " <.tflite> [<options>]\n\n";
+  std::cout << _options;
+  std::cout << "\n";
+}
+
+void Args::Initialize(void)
+{
+  // General options
+  po::options_description general("General options", 100);
+
+  // clang-format off
+  general.add_options()
+    ("help,h", "Print available options")
+    ("tflite", po::value<std::string>()->required())
+    ("seed", po::value<int>()->default_value(0), "The seed of random inputs")
+    ("num_runs", po::value<int>()->default_value(2), "The number of runs")
+    ;
+  // clang-format on
+
+  _options.add(general);
+  _positional.add("tflite", 1);
+  _positional.add("seed", 2);
+}
+
+void Args::Parse(const int argc, char **argv)
+{
+  po::variables_map vm;
+  po::store(po::command_line_parser(argc, argv).options(_options).positional(_positional).run(),
+            vm);
+
+  if (vm.count("help"))
+  {
+    print(argv);
+
+    exit(0);
+  }
+
+  po::notify(vm);
+  if (vm.count("tflite"))
+  {
+    _tflite_filename = vm["tflite"].as<std::string>();
+
+    if (_tflite_filename.empty())
+    {
+      std::cerr << "Please specify tflite file.\n";
+      print(argv);
+      exit(255);
+    }
+    else
+    {
+      if (access(_tflite_filename.c_str(), F_OK) == -1)
+      {
+        std::cerr << "tflite file not found: " << _tflite_filename << "\n";
+        exit(255);
+      }
+    }
+  }
+
+  if (vm.count("seed"))
+  {
+    _seed = vm["seed"].as<int>();
+  }
+
+  if (vm.count("num_runs"))
+  {
+    _num_runs = vm["num_runs"].as<int>();
+    if (_num_runs < 0)
+    {
+      std::cerr << "num_runs value must be greater than 0.\n";
+      exit(255);
+    }
+  }
+}
+
+} // end of namespace nnapi_test

--- a/tests/tools/nnapi_test/src/args.h
+++ b/tests/tools/nnapi_test/src/args.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __NNAPI_TEST_ARGS_H__
+#define __NNAPI_TEST_ARGS_H__
+
+#include <boost/program_options.hpp>
+#include <string>
+
+namespace po = boost::program_options;
+
+namespace nnapi_test
+{
+
+class Args
+{
+public:
+  Args(const int argc, char **argv);
+  void print(char **argv);
+
+  const std::string &getTfliteFilename(void) const { return _tflite_filename; }
+  const int getSeed(void) const { return _seed; }
+  const int getNumRuns(void) const { return _num_runs; }
+
+private:
+  void Initialize();
+  void Parse(const int argc, char **argv);
+
+private:
+  po::positional_options_description _positional;
+  po::options_description _options;
+
+  std::string _tflite_filename;
+  int _seed;
+  int _num_runs;
+};
+
+} // end of namespace nnapi_test
+
+#endif // __NNAPI_TEST_ARGS_H__

--- a/tests/tools/nnapi_test/src/nnapi_test.cc
+++ b/tests/tools/nnapi_test/src/nnapi_test.cc
@@ -23,24 +23,21 @@
 #include <iostream>
 #include <stdexcept>
 
+#include "args.h"
+
 using namespace tflite;
 using namespace nnfw::tflite;
+using namespace nnapi_test;
 
 int main(const int argc, char **argv)
 {
-  if (argc < 2)
-  {
-    std::cerr << "nnapi_test\n\n";
-    std::cerr << "Usage: " << argv[0] << " <.tflite>\nOR\n";
-    std::cerr << "Usage: " << argv[0] << " <.tflite> <seed>\n\n";
-    return 1;
-  }
+  Args args(argc, argv);
 
-  const auto filename = argv[1];
+  const auto filename = args.getTfliteFilename();
 
   StderrReporter error_reporter;
 
-  auto model = FlatBufferModel::BuildFromFile(filename, &error_reporter);
+  auto model = FlatBufferModel::BuildFromFile(filename.c_str(), &error_reporter);
 
   if (model == nullptr)
   {
@@ -52,14 +49,11 @@ int main(const int argc, char **argv)
 
   try
   {
-    int32_t seed = 0;
-    if (argc == 3)
-    {
-      seed = std::atoi(argv[2]);
-    }
+    const auto seed = static_cast<uint32_t>(args.getSeed());
     auto runner = nnfw::tflite::RandomTestRunner::make(seed);
+    const auto num_runs = static_cast<size_t>(args.getNumRuns());
     runner.compile(builder);
-    return runner.run(2);
+    return runner.run(num_runs);
   }
   catch (const std::exception &e)
   {


### PR DESCRIPTION
For https://github.com/Samsung/ONE/pull/2928#pullrequestreview-443677589

This commit introduces args into nnapi_test.
  - Added options: tflite, seed, num_runs

Signed-off-by: ragmani <ragmani0216@gmail.com>