### PR TITLE
[luci] Update FuseBCQPass

### DIFF
--- a/compiler/luci/pass/src/FuseBCQPass.cpp
+++ b/compiler/luci/pass/src/FuseBCQPass.cpp
@@ -125,7 +125,7 @@ public:
 
     if (_do_w_x[prefix]->dtype() == loco::DataType::S32)
       return _do_w_x[prefix]->at<loco::DataType::S32>(0) == 1;
-    else if(_do_w_x[prefix]->dtype() == loco::DataType::BOOL)
+    else if (_do_w_x[prefix]->dtype() == loco::DataType::BOOL)
       return _do_w_x[prefix]->at<loco::DataType::BOOL>(0);
     else
       throw std::runtime_error("do_w_x should be int or bool");

--- a/compiler/luci/pass/src/FuseBCQPass.cpp
+++ b/compiler/luci/pass/src/FuseBCQPass.cpp
@@ -125,8 +125,10 @@ public:
 
     if (_do_w_x[prefix]->dtype() == loco::DataType::S32)
       return _do_w_x[prefix]->at<loco::DataType::S32>(0) == 1;
-    else
+    else if(_do_w_x[prefix]->dtype() == loco::DataType::BOOL)
       return _do_w_x[prefix]->at<loco::DataType::BOOL>(0);
+    else
+      throw std::runtime_error("do_w_x should be int or bool");
   }
 
   luci::CircleConst *get_alpha(luci::CircleConst *node)


### PR DESCRIPTION
This commit will update following things
- Add a new rule for finding prefix of node name
- Handle when `do_w_x` is `int32` type

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>