### PR TITLE
Remove -funsafe-math-optimizations option on armv7 linux build

### DIFF
--- a/infra/nnfw/cmake/buildtool/config/config_armv7l-linux.cmake
+++ b/infra/nnfw/cmake/buildtool/config/config_armv7l-linux.cmake
@@ -12,7 +12,6 @@ set(FLAGS_COMMON ${FLAGS_COMMON}
     "-mcpu=cortex-a7"
     "-mfloat-abi=hard"
     "-mfpu=neon-vfpv4"
-    "-funsafe-math-optimizations"
     "-ftree-vectorize"
     "-mfp16-format=ieee"
     )


### PR DESCRIPTION
- This commit removes `-funsafe-math-optimizations` option on armv7 linux build
  - `-funsafe-math-optimizations` option makes some models run slower

ONE-DCO-1.0-Signed-off-by: JiHwan Yeo <jihwan.yeo@samsung.com>