### PR TITLE
[common-artifacts] Add unsupported Add_001

### DIFF
--- a/compiler/common-artifacts/exclude.lst
+++ b/compiler/common-artifacts/exclude.lst
@@ -8,6 +8,7 @@ optimize(Where_001)
 # tcgenerate : Exclude from test data generation(TestDataGenerator)
 tcgenerate(Abs_000)
 tcgenerate(AddN_000)
+tcgenerate(Add_001) # runtime doesn't support
 tcgenerate(Add_U8_000)
 tcgenerate(All_000)
 tcgenerate(ArgMax_U8_000) 


### PR DESCRIPTION
This commit adds unsupported Add_001 in runtime

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>