### PR TITLE
[nncc] Add HDF5 related option to cmake

### DIFF
--- a/infra/nncc/CMakeLists.txt
+++ b/infra/nncc/CMakeLists.txt
@@ -101,6 +101,8 @@ option(DOWNLOAD_ABSEIL "Download Abseil-cpp source" ON)
 
 option(DOWNLOAD_GTEST "Download Google Test source" ON)
 option(BUILD_GTEST "Build Google Test from the downloaded source" ON)
+option(DOWNLOAD_HDF5 "Download HDF5 source" ON)
+option(BUILD_HDF5 "Build HDF5 from the downloaded source" ON)
 
 nnas_find_package(GTest QUIET)
 


### PR DESCRIPTION
This commit adds HDF5 related option to cmake

Draft: #2989 
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>