### PR TITLE
[onert] Support qassym8 in TransposeLayer

### DIFF
--- a/runtime/onert/backend/cpu/ops/TransposeLayer.cc
+++ b/runtime/onert/backend/cpu/ops/TransposeLayer.cc
@@ -50,8 +50,17 @@ template <typename T> void TransposeLayer::transpose()
 
 void TransposeLayer::transposeQuant8()
 {
-  // cker quant8 tanh is not implemented yet
-  throw std::runtime_error{"NYI"};
+  if (_input->data_offset() != _output->data_offset())
+  {
+    throw std::runtime_error("TransposeLayer : qassym8 input and output offsets unmatched");
+  }
+
+  if (_input->data_scale() != _output->data_scale())
+  {
+    throw std::runtime_error("TransposeLayer : qassym8 input and output scales unmatched");
+  }
+
+  transpose<uint8_t>();
 }
 
 void TransposeLayer::configure(const IPortableTensor *input, IPortableTensor *output,

--- a/tests/nnapi/nnapi_gtest.skip.aarch64-linux.cpu
+++ b/tests/nnapi/nnapi_gtest.skip.aarch64-linux.cpu
@@ -218,7 +218,6 @@ GeneratedTests.transpose_conv_ex_float_1
 GeneratedTests.transpose_conv_ex_float_2
 GeneratedTests.transpose_conv_ex_float_3
 GeneratedTests.transpose_conv_ex_float_4
-GeneratedTests.transpose_quant8_1
 GeneratedTests.transpose_v1_2
 GeneratedTests.transpose_v1_2_quant8
 GeneratedTests.transpose_v1_2_zero_sized

--- a/tests/nnapi/nnapi_gtest.skip.armv7l-linux.cpu
+++ b/tests/nnapi/nnapi_gtest.skip.armv7l-linux.cpu
@@ -218,7 +218,6 @@ GeneratedTests.transpose_conv_ex_float_1
 GeneratedTests.transpose_conv_ex_float_2
 GeneratedTests.transpose_conv_ex_float_3
 GeneratedTests.transpose_conv_ex_float_4
-GeneratedTests.transpose_quant8_1
 GeneratedTests.transpose_v1_2
 GeneratedTests.transpose_v1_2_quant8
 GeneratedTests.transpose_v1_2_zero_sized

--- a/tests/nnapi/nnapi_gtest.skip.x86_64-linux.cpu
+++ b/tests/nnapi/nnapi_gtest.skip.x86_64-linux.cpu
@@ -217,7 +217,6 @@ GeneratedTests.transpose_conv_ex_float_1
 GeneratedTests.transpose_conv_ex_float_2
 GeneratedTests.transpose_conv_ex_float_3
 GeneratedTests.transpose_conv_ex_float_4
-GeneratedTests.transpose_quant8_1
 GeneratedTests.transpose_v1_2
 GeneratedTests.transpose_v1_2_quant8
 GeneratedTests.transpose_v1_2_zero_sized


### PR DESCRIPTION
- Quantized input and output tensor's offset should match.
- Same transpose operation

ONE-DCO-1.0-Signed-off-by: dayo09 <dayg502@gmail.com>