### PR TITLE
[gen-core] use internal HDF5

### DIFF
--- a/compiler/gen-core/CMakeLists.txt
+++ b/compiler/gen-core/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(HDF5 COMPONENTS CXX QUIET)
+nnas_find_package(HDF5 QUIET)
 
 if(NOT HDF5_FOUND)
   return()


### PR DESCRIPTION
This commit make common-artifacts use internal HDF5

Related : #2809
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>