### PR TITLE
Use version 1.6.0 on android AAR

### DIFF
--- a/runtime/contrib/android/api/build.gradle
+++ b/runtime/contrib/android/api/build.gradle
@@ -8,7 +8,7 @@ android {
         minSdkVersion 26
         targetSdkVersion 29
         versionCode 1
-        versionName "1.0"
+        versionName "1.6.0"
 
         externalNativeBuild {
             ndkBuild {

--- a/tools/update_version/update-version
+++ b/tools/update_version/update-version
@@ -46,3 +46,5 @@ sed -i "s/^Version: .*/Version: $version/" ${nnfw_root}/packaging/nnfw.spec
 IFS=. read M m p <<< $version
 hex=$(printf '0x%08x' $(( (($M << 24)) | (($m << 8)) | $p )))
 sed -i "s/^#define NNFW_VERSION.*/#define NNFW_VERSION $hex/" ${nnfw_root}/runtime/onert/api/include/nnfw_version.h
+
+sed -i "s/versionName .*$/versionName \"$version\"/" ${nnfw_root}/runtime/contrib/android/api/build.gradle


### PR DESCRIPTION
From now on, use the same version as runtime version on android AAR

ONE-DCO-1.0-Signed-off-by: Chunseok Lee <chunseok.lee@samsung.com>