### PR TITLE
[onert] Remove the member `_constants` from TensorBuilders

### DIFF
--- a/runtime/onert/backend/cpu/TensorBuilder.cc
+++ b/runtime/onert/backend/cpu/TensorBuilder.cc
@@ -36,12 +36,9 @@ TensorBuilder::TensorBuilder()
 }
 
 void TensorBuilder::registerTensorInfo(const ir::OperandIndex &ind, const ir::OperandInfo &info,
-                                       ir::Layout layout, bool as_const)
+                                       ir::Layout layout)
 {
   _tensor_info_map.emplace(ind, info);
-
-  if (as_const)
-    _constants.append(ind);
 
   // CPU backend supports only one layout as NHWC
   assert(layout == ir::Layout::NHWC);
@@ -51,7 +48,7 @@ void TensorBuilder::registerTensorInfo(const ir::OperandIndex &ind, const ir::Op
   }
   else
   {
-    _static_tensor_mgr->buildTensor(ind, info, layout, _constants.contains(ind));
+    _static_tensor_mgr->buildTensor(ind, info, layout, info.isConstant());
   }
 }
 

--- a/runtime/onert/backend/cpu/TensorBuilder.h
+++ b/runtime/onert/backend/cpu/TensorBuilder.h
@@ -48,7 +48,7 @@ public:
    * @param[in] layout Operand data layout
    */
   void registerTensorInfo(const ir::OperandIndex &ind, const ir::OperandInfo &info,
-                          ir::Layout backend_layout, bool as_const) override;
+                          ir::Layout backend_layout) override;
 
   void notifyFirstUse(const ir::OperandIndex &) override;
   void notifyLastUse(const ir::OperandIndex &) override;
@@ -90,7 +90,6 @@ private:
   std::unique_ptr<cpu_common::StaticTensorManager> _static_tensor_mgr;
   std::unique_ptr<cpu_common::DynamicTensorManager> _dynamic_tensor_mgr;
   ir::OperandIndexMap<ir::OperandInfo> _tensor_info_map;
-  ir::OperandIndexSequence _constants;
 };
 
 } // namespace cpu

--- a/runtime/onert/core/include/backend/ITensorBuilder.h
+++ b/runtime/onert/core/include/backend/ITensorBuilder.h
@@ -53,7 +53,7 @@ struct ITensorBuilder
    * @param as_const Whether this tensor is constant
    */
   virtual void registerTensorInfo(const ir::OperandIndex &ind, const ir::OperandInfo &info,
-                                  ir::Layout backend_layout, bool as_const) = 0;
+                                  ir::Layout backend_layout) = 0;
 
   /**
    * @brief Check if the tensor has been registered with @c registerTensorInfo

--- a/runtime/onert/core/include/backend/ITensorRegister.h
+++ b/runtime/onert/core/include/backend/ITensorRegister.h
@@ -73,8 +73,8 @@ protected:
     const auto frontend_layout = frontendLayout();
     const auto backend_layout = backendLayout(index);
     ir::OperandInfo backend_info{permuteShape(obj.shape(), frontend_layout, backend_layout),
-                                 obj.typeInfo(), obj.info().memAllocType()};
-    tensor_builder()->registerTensorInfo(index, backend_info, backend_layout, obj.isConstant());
+                                 obj.typeInfo(), obj.info().memAllocType(), obj.isConstant()};
+    tensor_builder()->registerTensorInfo(index, backend_info, backend_layout);
   }
 
 protected:

--- a/runtime/onert/core/include/ir/OperandInfo.h
+++ b/runtime/onert/core/include/ir/OperandInfo.h
@@ -65,8 +65,9 @@ public:
    * @param[in] typeInfo  Tensor data type
    * @param[in] alloc_type  When the thesor needs memory allocation
    */
-  OperandInfo(const Shape &shape, const TypeInfo &typeInfo, MemAllocType alloc_type)
-      : _shape(shape), _typeInfo(typeInfo), _alloc_type(alloc_type), _const(false)
+  OperandInfo(const Shape &shape, const TypeInfo &typeInfo, MemAllocType alloc_type,
+              bool is_const = false)
+      : _shape(shape), _typeInfo(typeInfo), _alloc_type(alloc_type), _const(is_const)
   {
     // DO NOTHING
   }

--- a/runtime/onert/core/src/backend/controlflow/TensorBuilder.cc
+++ b/runtime/onert/core/src/backend/controlflow/TensorBuilder.cc
@@ -36,12 +36,9 @@ TensorBuilder::TensorBuilder()
 }
 
 void TensorBuilder::registerTensorInfo(const ir::OperandIndex &ind, const ir::OperandInfo &info,
-                                       ir::Layout backend_layout, bool as_const)
+                                       ir::Layout backend_layout)
 {
   _tensor_info_map.emplace(ind, info);
-
-  if (as_const)
-    _constants.append(ind);
 
   _tensor_layout_map.insert({ind, backend_layout});
 
@@ -51,7 +48,7 @@ void TensorBuilder::registerTensorInfo(const ir::OperandIndex &ind, const ir::Op
   }
   else
   {
-    _static_tensor_mgr->buildTensor(ind, info, _tensor_layout_map[ind], _constants.contains(ind));
+    _static_tensor_mgr->buildTensor(ind, info, _tensor_layout_map[ind], info.isConstant());
   }
 }
 

--- a/runtime/onert/core/src/backend/controlflow/TensorBuilder.h
+++ b/runtime/onert/core/src/backend/controlflow/TensorBuilder.h
@@ -48,7 +48,7 @@ public:
    * @param[in] layout Operand data layout
    */
   void registerTensorInfo(const ir::OperandIndex &ind, const ir::OperandInfo &info,
-                          ir::Layout backend_layout, bool as_const) override;
+                          ir::Layout backend_layout) override;
 
   void notifyFirstUse(const ir::OperandIndex &) override;
   void notifyLastUse(const ir::OperandIndex &) override;
@@ -90,7 +90,6 @@ private:
   std::unique_ptr<cpu_common::DynamicTensorManager> _dynamic_tensor_mgr;
   ir::OperandIndexMap<ir::OperandInfo> _tensor_info_map;
   ir::OperandIndexMap<ir::Layout> _tensor_layout_map;
-  ir::OperandIndexSequence _constants;
 };
 
 } // namespace controlflow

--- a/runtime/onert/core/src/compiler/ExecutorFactory.cc
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.cc
@@ -169,9 +169,9 @@ void ExecutorFactory::runTensorRegistration(ir::LoweredGraph *lowered_graph,
             const auto frontend_layout = op_seq.getLayout();
             const auto backend_layout = operand_lower_info.layout();
             ir::OperandInfo backend_info{permuteShape(obj.shape(), frontend_layout, backend_layout),
-                                         obj.typeInfo(), obj.info().memAllocType()};
-            tensor_builder->registerTensorInfo(index, backend_info, backend_layout,
-                                               obj.isConstant());
+                                         obj.typeInfo(), obj.info().memAllocType(),
+                                         obj.isConstant()};
+            tensor_builder->registerTensorInfo(index, backend_info, backend_layout);
           }
         }
       }

--- a/runtime/onert/core/src/compiler/Linear.cc
+++ b/runtime/onert/core/src/compiler/Linear.cc
@@ -114,7 +114,7 @@ void Linear::planTensors(const ir::LoweredGraph &lowered_graph,
       const auto info = obj.info();
       const auto backend_layout = factor.layout();
       // TODO Change tensor info to have permuted shape
-      tensor_builder->registerTensorInfo(ind, info, backend_layout, is_const);
+      tensor_builder->registerTensorInfo(ind, info, backend_layout);
     }
 
     tensor_builder_map[ind] = tensor_builder;


### PR DESCRIPTION
Fix #2996

This commit removes the member `_constants` from TensorBuilders.
  - Make TensorBuilders uses `isConstant` of OperandInfo instead of `_constants`
  - Fix wrong checking constant of cpu tensor

Signed-off-by: ragmani <ragmani0216@gmail.com>