### PR TITLE
[onert] Move random input generation into randomgen

### DIFF
--- a/tests/tools/nnpackage_run/CMakeLists.txt
+++ b/tests/tools/nnpackage_run/CMakeLists.txt
@@ -9,6 +9,7 @@ endif(NOT BUILD_ONERT)
 list(APPEND NNPACKAGE_RUN_SRCS "src/nnpackage_run.cc")
 list(APPEND NNPACKAGE_RUN_SRCS "src/args.cc")
 list(APPEND NNPACKAGE_RUN_SRCS "src/nnfw_util.cc")
+list(APPEND NNPACKAGE_RUN_SRCS "src/randomgen.cc")
 
 nnfw_find_package(Boost REQUIRED program_options)
 nnfw_find_package(Ruy QUIET)

--- a/tests/tools/nnpackage_run/src/h5formatter.cc
+++ b/tests/tools/nnpackage_run/src/h5formatter.cc
@@ -18,10 +18,8 @@
 #include "nnfw.h"
 #include "nnfw_util.h"
 
-#include <cassert>
 #include <iostream>
 #include <stdexcept>
-#include <cstdlib>
 #include <H5Cpp.h>
 
 namespace nnpkg_run
@@ -31,7 +29,7 @@ static const char *h5_value_grpname = "value";
 void H5Formatter::loadInputs(const std::string &filename, std::vector<Allocation> &inputs)
 {
   uint32_t num_inputs;
-  NNPR_ENSURE_STATUS(nnfw_input_size(session, &num_inputs));
+  NNPR_ENSURE_STATUS(nnfw_input_size(session_, &num_inputs));
   try
   {
     // Turn off the automatic error printing.
@@ -42,7 +40,7 @@ void H5Formatter::loadInputs(const std::string &filename, std::vector<Allocation
     for (uint32_t i = 0; i < num_inputs; ++i)
     {
       nnfw_tensorinfo ti;
-      NNPR_ENSURE_STATUS(nnfw_input_tensorinfo(session, i, &ti));
+      NNPR_ENSURE_STATUS(nnfw_input_tensorinfo(session_, i, &ti));
       // allocate memory for data
       auto bufsz = bufsize_for(&ti);
       inputs[i].alloc(bufsz);
@@ -81,8 +79,8 @@ void H5Formatter::loadInputs(const std::string &filename, std::vector<Allocation
         default:
           throw std::runtime_error("nnpkg_run can load f32, i32, qasymm8, bool and uint8.");
       }
-      NNPR_ENSURE_STATUS(nnfw_set_input(session, i, ti.dtype, inputs[i].data(), bufsz));
-      NNPR_ENSURE_STATUS(nnfw_set_input_layout(session, i, NNFW_LAYOUT_CHANNELS_LAST));
+      NNPR_ENSURE_STATUS(nnfw_set_input(session_, i, ti.dtype, inputs[i].data(), bufsz));
+      NNPR_ENSURE_STATUS(nnfw_set_input_layout(session_, i, NNFW_LAYOUT_CHANNELS_LAST));
     }
   }
   catch (const H5::Exception &e)
@@ -100,7 +98,7 @@ void H5Formatter::loadInputs(const std::string &filename, std::vector<Allocation
 void H5Formatter::dumpOutputs(const std::string &filename, std::vector<Allocation> &outputs)
 {
   uint32_t num_outputs;
-  NNPR_ENSURE_STATUS(nnfw_output_size(session, &num_outputs));
+  NNPR_ENSURE_STATUS(nnfw_output_size(session_, &num_outputs));
   try
   {
     // Turn off the automatic error printing.
@@ -111,7 +109,7 @@ void H5Formatter::dumpOutputs(const std::string &filename, std::vector<Allocatio
     for (uint32_t i = 0; i < num_outputs; i++)
     {
       nnfw_tensorinfo ti;
-      NNPR_ENSURE_STATUS(nnfw_output_tensorinfo(session, i, &ti));
+      NNPR_ENSURE_STATUS(nnfw_output_tensorinfo(session_, i, &ti));
       std::vector<hsize_t> dims(ti.rank);
       for (uint32_t j = 0; j < ti.rank; ++j)
       {

--- a/tests/tools/nnpackage_run/src/randomgen.cc
+++ b/tests/tools/nnpackage_run/src/randomgen.cc
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2019 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "randomgen.h"
+#include "nnfw.h"
+#include "nnfw_util.h"
+#include "misc/RandomGenerator.h"
+
+#include <iostream>
+
+namespace nnpkg_run
+{
+
+template <class T> void randomData(nnfw::misc::RandomGenerator &randgen, void *data, uint64_t size)
+{
+  for (uint64_t i = 0; i < size; i++)
+    reinterpret_cast<T *>(data)[i] = randgen.generate<T>();
+}
+
+void RandomGenerator::generate(std::vector<Allocation> &inputs)
+{
+  // generate random data
+  const int seed = 1;
+  nnfw::misc::RandomGenerator randgen{seed, 0.0f, 2.0f};
+  for (uint32_t i = 0; i < inputs.size(); ++i)
+  {
+    nnfw_tensorinfo ti;
+    NNPR_ENSURE_STATUS(nnfw_input_tensorinfo(session_, i, &ti));
+    auto input_size_in_bytes = bufsize_for(&ti);
+    inputs[i].alloc(input_size_in_bytes);
+    switch (ti.dtype)
+    {
+      case NNFW_TYPE_TENSOR_FLOAT32:
+        randomData<float>(randgen, inputs[i].data(), num_elems(&ti));
+        break;
+      case NNFW_TYPE_TENSOR_QUANT8_ASYMM:
+        randomData<uint8_t>(randgen, inputs[i].data(), num_elems(&ti));
+        break;
+      case NNFW_TYPE_TENSOR_BOOL:
+        randomData<bool>(randgen, inputs[i].data(), num_elems(&ti));
+        break;
+      case NNFW_TYPE_TENSOR_UINT8:
+        randomData<uint8_t>(randgen, inputs[i].data(), num_elems(&ti));
+        break;
+      case NNFW_TYPE_TENSOR_INT32:
+        randomData<int32_t>(randgen, inputs[i].data(), num_elems(&ti));
+        break;
+      case NNFW_TYPE_TENSOR_INT64:
+        randomData<int64_t>(randgen, inputs[i].data(), num_elems(&ti));
+        break;
+      default:
+        std::cerr << "Not supported input type" << std::endl;
+        std::exit(-1);
+    }
+    NNPR_ENSURE_STATUS(
+        nnfw_set_input(session_, i, ti.dtype, inputs[i].data(), input_size_in_bytes));
+    NNPR_ENSURE_STATUS(nnfw_set_input_layout(session_, i, NNFW_LAYOUT_CHANNELS_LAST));
+  }
+};
+
+} // end of namespace nnpkg_run

--- a/tests/tools/nnpackage_run/src/randomgen.h
+++ b/tests/tools/nnpackage_run/src/randomgen.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef __NNPACKAGE_RUN_H5FORMATTER_H__
-#define __NNPACKAGE_RUN_H5FORMATTER_H__
+#ifndef __NNPACKAGE_RUN_RANDOMGEN_H__
+#define __NNPACKAGE_RUN_RANDOMGEN_H__
 
 #include <string>
 #include <vector>
@@ -26,16 +26,15 @@ struct nnfw_session;
 
 namespace nnpkg_run
 {
-class H5Formatter
+class RandomGenerator
 {
 public:
-  H5Formatter(nnfw_session *sess) : session_(sess) {}
-  void loadInputs(const std::string &filename, std::vector<Allocation> &inputs);
-  void dumpOutputs(const std::string &filename, std::vector<Allocation> &outputs);
+  RandomGenerator(nnfw_session *sess) : session_(sess) {}
+  void generate(std::vector<Allocation> &inputs);
 
 private:
   nnfw_session *session_;
 };
 } // end of namespace
 
-#endif // __NNPACKAGE_RUN_H5FORMATTER_H__
+#endif // __NNPACKAGE_RUN_RANDOMGEN_H__


### PR DESCRIPTION
It moves random input generation code into randomgen.*.
Also, it cleans up trivials - put header in order, removing blank lines.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>