### PR TITLE
[onert] Make FunctionSequence::run() handle dynamic tensor

### DIFF
--- a/runtime/onert/core/include/exec/FunctionSequence.h
+++ b/runtime/onert/core/include/exec/FunctionSequence.h
@@ -78,10 +78,10 @@ public: // context for dynamic tensor
    * @note  Calling this does not mean that run() will handle dynamic tensor.
    *        enableDynamicShapeInferer(true) will make run() will handle dynamic tensor.
    */
-  void dynamicTensorContext(const ir::OpSequence *op_seq, const ir::Operations *operations,
-                            std::unique_ptr<exec::DynamicInferer> dynamic_shape_inferer,
-                            std::shared_ptr<backend::ITensorRegistry> tensor_registry,
-                            backend::IDynamicTensorManager *dynamic_tensor_manager)
+  void setDynamicTensorContext(const ir::OpSequence *op_seq, const ir::Operations *operations,
+                               std::unique_ptr<exec::DynamicInferer> dynamic_shape_inferer,
+                               std::shared_ptr<backend::ITensorRegistry> tensor_registry,
+                               backend::IDynamicTensorManager *dynamic_tensor_manager)
   {
     _op_seq = op_seq;
     _operations = operations;


### PR DESCRIPTION
This makes `FunctionSequence::run()` handle dynamic tensor.

Please refer to #2943 for the background. 
In summary,
- we should decide if we'll call dynamic shape inferer or not **at execution time**.
- previous way (deciding `FunctionSequence` or `FunctionSequenceForDynamicTensor` at compilation time) does not work.

So, I'd like to use `FunctionSequence` only, and remove `FunctionSequenceForDynamicTensor`.

draft: #2957

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>