### PR TITLE
[onert] Find a model has dynamic tensor at compilation time

### DIFF
--- a/runtime/onert/core/include/compiler/StaticShapeInference.h
+++ b/runtime/onert/core/include/compiler/StaticShapeInference.h
@@ -54,16 +54,28 @@ public:
    *        If output shape cannot be known without running op, mark it so that it can be allocated
    *        when running kernel.
    * @param op_seq sequence of operations
+   * @return @c true if op_seq's input or output has any dynamic tensor; @c false otherwise.
    */
-  void infer(const ir::OpSequence &op_seq)
+  bool infer(const ir::OpSequence &op_seq)
   {
+    bool has_dynamic_tensor = false;
+
+    _return_has_dynamic_tensor = false; // this is used as a return value inside operation's visit()
+
     for (const auto &operation_idx : op_seq.operations())
     {
       _operations.at(operation_idx).accept(*this);
+
+      has_dynamic_tensor = has_dynamic_tensor || _return_has_dynamic_tensor;
     }
+
+    return has_dynamic_tensor;
   }
 
   void dump();
+
+private:
+  bool _return_has_dynamic_tensor;
 
 private:
   // TODO Define visitors for operations. List them in alphabetic order.

--- a/runtime/onert/core/include/ir/OpSequence.h
+++ b/runtime/onert/core/include/ir/OpSequence.h
@@ -81,8 +81,8 @@ public:
    *        or dynamic output;
    *        @c false if all operations' inputs and outputs are static tensors
    */
-  void hasDynamicTensor(bool hasDynamicTensor) { _has_dynamic_tensor = hasDynamicTensor; }
-  bool hasDynamicTensor() const { return _has_dynamic_tensor; }
+  void has_dynamic_tensor(bool has_dynamic_tensor) { _has_dynamic_tensor = has_dynamic_tensor; }
+  bool has_dynamic_tensor() const { return _has_dynamic_tensor; }
 
 private:
   OperandIndexSequence _inputs;

--- a/runtime/onert/core/include/ir/OpSequence.h
+++ b/runtime/onert/core/include/ir/OpSequence.h
@@ -75,6 +75,15 @@ public:
   std::vector<OperationIndex>::const_iterator begin() const { return _operations.begin(); }
   std::vector<OperationIndex>::const_iterator end() const { return _operations.end(); }
 
+public:
+  /**
+   * @brief Set @c true if any operation in this opSequence has dynamic input
+   *        or dynamic output;
+   *        @c false if all operations' inputs and outputs are static tensors
+   */
+  void hasDynamicTensor(bool hasDynamicTensor) { _has_dynamic_tensor = hasDynamicTensor; }
+  bool hasDynamicTensor() const { return _has_dynamic_tensor; }
+
 private:
   OperandIndexSequence _inputs;
   OperandIndexSequence _outputs;
@@ -82,6 +91,9 @@ private:
 
 private:
   Layout _layout;
+
+private:
+  bool _has_dynamic_tensor;
 };
 
 std::string getStrFromOpSeq(const OpSequence &op_seq, const Operations &operations);

--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -215,7 +215,7 @@ void Compiler::compile(void)
     lowered_subgs.at(primary_subg_idx)
         ->iterateTopolOpSeqs([&](const ir::OpSequenceIndex &, ir::OpSequence &op_seq) {
           auto has_dynamic_tensor = inferer.infer(op_seq);
-          op_seq.hasDynamicTensor(has_dynamic_tensor);
+          op_seq.has_dynamic_tensor(has_dynamic_tensor);
         });
     inferer.dump();
   }

--- a/runtime/onert/core/src/compiler/StaticShapeInference.cc
+++ b/runtime/onert/core/src/compiler/StaticShapeInference.cc
@@ -441,7 +441,7 @@ void StaticInferer::visit(const ir::operation::If &op)
   _lowered_subgs.at(op.param().then_subg_index)
       ->iterateTopolOpSeqs([&](const ir::OpSequenceIndex &, ir::OpSequence &op_seq) {
         bool has_dynamic_tensor = then_inferer.infer(op_seq);
-        op_seq.hasDynamicTensor(has_dynamic_tensor);
+        op_seq.has_dynamic_tensor(has_dynamic_tensor);
       });
 
   // re-sizing operands of else subgraph
@@ -449,7 +449,7 @@ void StaticInferer::visit(const ir::operation::If &op)
   _lowered_subgs.at(op.param().else_subg_index)
       ->iterateTopolOpSeqs([&](const ir::OpSequenceIndex &, ir::OpSequence &op_seq) {
         bool has_dynamic_tensor = else_inferer.infer(op_seq);
-        op_seq.hasDynamicTensor(has_dynamic_tensor);
+        op_seq.has_dynamic_tensor(has_dynamic_tensor);
       });
 
   // re-sizing output shapes
@@ -1388,7 +1388,7 @@ void StaticInferer::visit(const ir::operation::While &op)
   _lowered_subgs.at(op.param().body_subg_index)
       ->iterateTopolOpSeqs([&](const ir::OpSequenceIndex &, ir::OpSequence &op_seq) {
         bool has_dynamic_tensor = body_inferer.infer(op_seq);
-        op_seq.hasDynamicTensor(has_dynamic_tensor);
+        op_seq.has_dynamic_tensor(has_dynamic_tensor);
       });
 
   // Check whether while operation's shapes are predictable
@@ -1436,7 +1436,7 @@ void StaticInferer::visit(const ir::operation::While &op)
     _lowered_subgs.at(op.param().body_subg_index)
         ->iterateTopolOpSeqs([&](const ir::OpSequenceIndex &, ir::OpSequence &op_seq) {
           bool has_dynamic_tensor = body_inferer.infer(op_seq);
-          op_seq.hasDynamicTensor(has_dynamic_tensor);
+          op_seq.has_dynamic_tensor(has_dynamic_tensor);
         });
   }
 
@@ -1447,7 +1447,7 @@ void StaticInferer::visit(const ir::operation::While &op)
   _lowered_subgs.at(op.param().cond_subg_index)
       ->iterateTopolOpSeqs([&](const ir::OpSequenceIndex &, ir::OpSequence &op_seq) {
         bool has_dynamic_tensor = cond_inferer.infer(op_seq);
-        op_seq.hasDynamicTensor(has_dynamic_tensor);
+        op_seq.has_dynamic_tensor(has_dynamic_tensor);
       });
 
   // re-sizing outputs of while operation


### PR DESCRIPTION
For #2943 
Related PR: #3042
draft: #2957

This commit make `StaticShapeInferer` (at compilation time) find if a model has dynamic tensor or not and keep the boolean flag into `OpSequence`.

If a model has dynamic tensor (e.g., `reshape` op's output tensor if the 2nd input is not const),
executor will use this flag (in next PR) to run `DynamicShapeInferer` at execution time.

Since `FunctionSequence` (generated from `OpSequence`) is the unit of `run()`,
I put `OpSequence` to keep this flag.

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>
