### PR TITLE
[record-minmax] Use percentile instead of moving avg

### DIFF
--- a/compiler/record-minmax/CMakeLists.txt
+++ b/compiler/record-minmax/CMakeLists.txt
@@ -21,3 +21,7 @@ target_link_libraries(record-minmax luci_export)
 target_link_libraries(record-minmax luci_interpreter)
 
 install(TARGETS record-minmax DESTINATION bin)
+
+nnas_find_package(GTest REQUIRED)
+GTest_AddTest(record_minmax_function_test "${CMAKE_CURRENT_SOURCE_DIR}/tests/RecordFunction.test.cpp")
+target_include_directories(record_minmax_function_test PRIVATE include)

--- a/compiler/record-minmax/driver/Driver.cpp
+++ b/compiler/record-minmax/driver/Driver.cpp
@@ -78,6 +78,9 @@ int entry(const int argc, char **argv)
   if (arser["--mode"])
     mode = arser.get<std::string>("--mode");
 
+  if (mode != "percentile" && mode != "moving_average")
+    throw std::runtime_error("Unsupported mode");
+
   RecordMinMax rmm;
 
   // Initialize interpreter and observer

--- a/compiler/record-minmax/driver/Driver.cpp
+++ b/compiler/record-minmax/driver/Driver.cpp
@@ -43,11 +43,40 @@ int entry(const int argc, char **argv)
       .required(true)
       .help("Output model filepath");
 
+  arser.add_argument("--min_percentile")
+      .nargs(1)
+      .type(arser::DataType::FLOAT)
+      .help("Record n'th percentile of min");
+
+  arser.add_argument("--max_percentile")
+      .nargs(1)
+      .type(arser::DataType::FLOAT)
+      .help("Record n'th percentile of max");
+
+  arser.add_argument("--mode")
+      .nargs(1)
+      .type(arser::DataType::STR)
+      .help("Record mode. percentile (default) or moving_average");
+
   arser.parse(argc, argv);
 
   auto input_model_path = arser.get<std::string>("--input_model");
   auto input_data_path = arser.get<std::string>("--input_data");
   auto output_model_path = arser.get<std::string>("--output_model");
+
+  // Default values
+  std::string mode("percentile");
+  float min_percentile = 1.0;
+  float max_percentile = 99.0;
+
+  if (arser["--min_percentile"])
+    min_percentile = arser.get<float>("--min_percentile");
+
+  if (arser["--max_percentile"])
+    max_percentile = arser.get<float>("--max_percentile");
+
+  if (arser["--mode"])
+    mode = arser.get<std::string>("--mode");
 
   RecordMinMax rmm;
 
@@ -55,7 +84,7 @@ int entry(const int argc, char **argv)
   rmm.initialize(input_model_path);
 
   // Profile min/max while executing the given input data
-  rmm.profileData(input_data_path);
+  rmm.profileData(mode, input_data_path, min_percentile, max_percentile);
 
   // Save profiled values to the model
   rmm.saveModel(output_model_path);

--- a/compiler/record-minmax/include/RecordFunction.h
+++ b/compiler/record-minmax/include/RecordFunction.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <vector>
+#include <cassert>
+#include <algorithm>
+#include <cmath>
+#include <numeric>
+#include <stdexcept>
+
+namespace record_minmax
+{
+
+/**
+ * @brief  getNthPercentile calculates the n-th percentile of input vector (0.0 <= n <= 100.0)
+ *         linear interpolation is used when the desired percentile lies between two data points
+ */
+float getNthPercentile(std::vector<float> &vector, float percentile)
+{
+  assert(!vector.empty());
+
+  if (percentile < 0 || percentile > 100)
+    throw std::runtime_error("Percentile must be ranged from 0 to 100");
+
+  if (percentile == 0.0)
+    return vector.front();
+
+  if (percentile == 100.0)
+    return vector.back();
+
+  std::vector<float> copy;
+  copy.assign(vector.begin(), vector.end());
+  std::sort(copy.begin(), copy.end());
+
+  int i = static_cast<int>(std::floor((copy.size() - 1) * percentile / 100.0));
+
+  float percent_i = static_cast<float>(i) / static_cast<float>(copy.size() - 1);
+  float fraction = (percentile / 100.0 - percent_i) / ((i + 1.0) / (copy.size() - 1.0) - percent_i);
+  float res = copy[i] + fraction * (copy[i + 1] - copy[i]);
+  return res;
+}
+
+/**
+ * @brief  getMovingAverage calculates the weighted moving average of input vector
+ *         The initial value is the first element of the vector
+ */
+float getMovingAverage(std::vector<float> &vector, float alpha)
+{
+  assert(!vector.empty());
+  assert(alpha >= 0.0 && alpha <= 1.0);
+
+  float curr_avg = vector[0];
+  for (size_t i = 1; i < vector.size(); i++)
+  {
+    curr_avg = curr_avg * alpha + vector[i] * (1.0 - alpha);
+  }
+  return curr_avg;
+}
+
+} // namespace record_minmax

--- a/compiler/record-minmax/include/RecordFunction.h
+++ b/compiler/record-minmax/include/RecordFunction.h
@@ -30,8 +30,6 @@ namespace record_minmax
  */
 float getNthPercentile(std::vector<float> &vector, float percentile)
 {
-  assert(!vector.empty());
-
   if (percentile < 0 || percentile > 100)
     throw std::runtime_error("Percentile must be ranged from 0 to 100");
 
@@ -41,15 +39,22 @@ float getNthPercentile(std::vector<float> &vector, float percentile)
   if (percentile == 100.0)
     return vector.back();
 
+  if (vector.empty())
+    throw std::runtime_error("Percentile must take a non-empty vector as an argument");
+
+  if (vector.size() == 1)
+    return vector[0];
+
   std::vector<float> copy;
   copy.assign(vector.begin(), vector.end());
   std::sort(copy.begin(), copy.end());
 
-  int i = static_cast<int>(std::floor((copy.size() - 1) * percentile / 100.0));
+  int index = static_cast<int>(std::floor((copy.size() - 1) * percentile / 100.0));
 
-  float percent_i = static_cast<float>(i) / static_cast<float>(copy.size() - 1);
-  float fraction = (percentile / 100.0 - percent_i) / ((i + 1.0) / (copy.size() - 1.0) - percent_i);
-  float res = copy[i] + fraction * (copy[i + 1] - copy[i]);
+  float percent_i = static_cast<float>(index) / static_cast<float>(copy.size() - 1);
+  float fraction =
+      (percentile / 100.0 - percent_i) / ((index + 1.0) / (copy.size() - 1.0) - percent_i);
+  float res = copy[index] + fraction * (copy[index + 1] - copy[index]);
   return res;
 }
 

--- a/compiler/record-minmax/include/RecordMinMax.h
+++ b/compiler/record-minmax/include/RecordMinMax.h
@@ -36,7 +36,8 @@ public:
 
   void initialize(const std::string &input_model_path);
 
-  void profileData(const std::string &input_data_path);
+  void profileData(const std::string &mode, const std::string &input_data_path,
+                   float min_percentile, float max_percentile);
 
   void saveModel(const std::string &output_model_path);
 

--- a/compiler/record-minmax/src/RecordMinMax.cpp
+++ b/compiler/record-minmax/src/RecordMinMax.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "RecordMinMax.h"
+#include "RecordFunction.h"
 #include "CircleExpContract.h"
 #include "MinMaxObserver.h"
 #include "HDF5Importer.h"
@@ -35,23 +36,6 @@ using DataType = luci_interpreter::DataType;
 
 namespace
 {
-
-/**
- * @brief  getMovingAverage calculates the weighted moving average of input vector
- *         The initial value is the first element of the vector
- */
-float getMovingAverage(std::vector<float> &vector, float alpha)
-{
-  assert(!vector.empty());
-  assert(alpha >= 0.0 && alpha <= 1.0);
-
-  float curr_avg = vector[0];
-  for (size_t i = 1; i < vector.size(); i++)
-  {
-    curr_avg = curr_avg * alpha + vector[i] * (1.0 - alpha);
-  }
-  return curr_avg;
-}
 
 /**
  * @brief  getTensorSize will return size in bytes
@@ -114,7 +98,8 @@ void RecordMinMax::initialize(const std::string &input_model_path)
   _interpreter->attachObserver(_observer.get());
 }
 
-void RecordMinMax::profileData(const std::string &input_data_path)
+void RecordMinMax::profileData(const std::string &mode, const std::string &input_data_path,
+                               float min_percentile, float max_percentile)
 {
   HDF5Importer importer(input_data_path);
   importer.importGroup();
@@ -160,9 +145,17 @@ void RecordMinMax::profileData(const std::string &input_data_path)
     auto node = iter->first;
     auto minmax = iter->second;
 
-    float min = getMovingAverage(minmax.min_vector, 0.9);
-    float max = getMovingAverage(minmax.max_vector, 0.9);
-
+    float min, max;
+    if (mode == "percentile")
+    {
+      min = getNthPercentile(minmax.min_vector, min_percentile);
+      max = getNthPercentile(minmax.max_vector, max_percentile);
+    }
+    else if (mode == "moving_average")
+    {
+      min = getMovingAverage(minmax.min_vector, 0.9);
+      max = getMovingAverage(minmax.max_vector, 0.9);
+    }
     auto quantparam = std::make_unique<luci::CircleQuantParam>();
     quantparam->min.push_back(min);
     quantparam->max.push_back(max);

--- a/compiler/record-minmax/src/RecordMinMax.cpp
+++ b/compiler/record-minmax/src/RecordMinMax.cpp
@@ -156,6 +156,7 @@ void RecordMinMax::profileData(const std::string &mode, const std::string &input
       min = getMovingAverage(minmax.min_vector, 0.9);
       max = getMovingAverage(minmax.max_vector, 0.9);
     }
+    assert(mode == "percentile" || mode == "moving_average");
     auto quantparam = std::make_unique<luci::CircleQuantParam>();
     quantparam->min.push_back(min);
     quantparam->max.push_back(max);

--- a/compiler/record-minmax/tests/RecordFunction.test.cpp
+++ b/compiler/record-minmax/tests/RecordFunction.test.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "RecordFunction.h"
+
+#include <vector>
+#include <cmath>
+
+#include <gtest/gtest.h>
+
+namespace record_minmax
+{
+
+#define EXPECT_FLOAT_NEAR(exp, val) EXPECT_NEAR(exp, val, 1e-5 + 1e-5 * std::abs(exp))
+
+TEST(GetNthPercentileTest, Edge)
+{
+  std::vector<float> input{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+
+  EXPECT_FLOAT_NEAR(0, getNthPercentile(input, 0));
+  EXPECT_FLOAT_NEAR(9, getNthPercentile(input, 100));
+}
+
+TEST(GetNthPercentileTest, Simple)
+{
+  std::vector<float> input{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+
+  for (float i = 1; i <= 99; i++)
+  {
+    EXPECT_FLOAT_NEAR(0.09 * i, getNthPercentile(input, i));
+  }
+
+  for (float i = 0.5; i <= 99.5; i++)
+  {
+    EXPECT_FLOAT_NEAR(0.09 * std::floor(i) + 0.045, getNthPercentile(input, i));
+  }
+}
+
+TEST(GetNthPercentileTest, Float)
+{
+  std::vector<float> input{8.48424583,  89.39998456, 65.83323245, 87.85243858, 68.85414866,
+                           98.40591775, 16.74266565, 25.09415131, 74.54084952, 29.70536481,
+                           49.26803928, 79.49602425, 53.69395631, 73.73140271, 99.81245733,
+                           46.76997646, 78.37688474, 10.43076744, 30.39480496, 14.30875609,
+                           86.72073486, 17.97364969, 14.66724564, 0.47818459,  17.77138025,
+                           85.68981239, 22.18322696, 78.81541331, 93.04085581, 40.2147895};
+
+  EXPECT_FLOAT_NEAR(2.799942346802177, getNthPercentile(input, 1));
+  EXPECT_FLOAT_NEAR(7.768503955476342, getNthPercentile(input, 3.14));
+  EXPECT_FLOAT_NEAR(99.40456084968194, getNthPercentile(input, 99));
+}
+
+TEST(GetNthPercentileTest, FloatWithNegative)
+{
+  std::vector<float> input{-41.51575417, 39.39998456,  15.83323245,  37.85243858,  18.85414866,
+                           48.40591775,  -33.25733435, -24.90584869, 24.54084952,  -20.29463519,
+                           -0.73196072,  29.49602425,  3.69395631,   23.73140271,  49.81245733,
+                           -3.23002354,  28.37688474,  -39.56923256, -19.60519504, -35.69124391,
+                           36.72073486,  -32.02635031, -35.33275436, -49.52181541, -32.22861975,
+                           35.68981239,  -27.81677304, 28.81541331,  43.04085581,  -9.7852105};
+
+  EXPECT_FLOAT_NEAR(-47.20005765319782, getNthPercentile(input, 1));
+  EXPECT_FLOAT_NEAR(-42.23149604452366, getNthPercentile(input, 3.14));
+  EXPECT_FLOAT_NEAR(49.40456084968194, getNthPercentile(input, 99));
+}
+
+TEST(GetNthPercentileTest, OutOfBoundary_NEG)
+{
+  std::vector<float> input{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+
+  EXPECT_THROW(getNthPercentile(input, -1), std::runtime_error);
+  EXPECT_THROW(getNthPercentile(input, 101), std::runtime_error);
+}
+
+} // namespace record_minmax

--- a/compiler/record-minmax/tests/RecordFunction.test.cpp
+++ b/compiler/record-minmax/tests/RecordFunction.test.cpp
@@ -77,12 +77,28 @@ TEST(GetNthPercentileTest, FloatWithNegative)
   EXPECT_FLOAT_NEAR(49.40456084968194, getNthPercentile(input, 99));
 }
 
+TEST(GetNthPercentileTest, SigleElement)
+{
+  std::vector<float> input{33};
+
+  EXPECT_FLOAT_NEAR(33, getNthPercentile(input, 0));
+  EXPECT_FLOAT_NEAR(33, getNthPercentile(input, 50));
+  EXPECT_FLOAT_NEAR(33, getNthPercentile(input, 100));
+}
+
 TEST(GetNthPercentileTest, OutOfBoundary_NEG)
 {
   std::vector<float> input{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
   EXPECT_THROW(getNthPercentile(input, -1), std::runtime_error);
   EXPECT_THROW(getNthPercentile(input, 101), std::runtime_error);
+}
+
+TEST(GetNthPercentileTest, EmptyVector_NEG)
+{
+  std::vector<float> input;
+
+  EXPECT_THROW(getNthPercentile(input, 10), std::runtime_error);
 }
 
 } // namespace record_minmax


### PR DESCRIPTION
This uses percentile for recording instead of moving avg

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>