### PR TITLE
[onert] Rename some functions in ShapeInference.h

### DIFF
--- a/runtime/onert/core/include/util/ShapeInference.h
+++ b/runtime/onert/core/include/util/ShapeInference.h
@@ -44,7 +44,7 @@ using Shapes = std::vector<ir::Shape>;
 
 // Define shape calculation for operations. List them in alphabetic order.
 
-ir::Shape argMaxShapes(const ir::Shape &input_shape, int axis, int rank);
+ir::Shape inferArgMaxShape(const ir::Shape &input_shape, int axis, int rank);
 
 ir::Shape inferAvgPoolShape(const ir::Shape &in_shape, const ir::operation::AvgPool2D::Param &param,
                             ir::Layout layout = ir::Layout::NHWC);
@@ -71,15 +71,15 @@ ir::Shape inferFillShape(const ir::Shape &in_shape, const int32_t *buf);
 
 ir::Shape inferFullyConnectedShape(const ir::Shape &in_shape, const ir::Shape &ker_shape);
 
-ir::Shape gatherShapes(const ir::Shape &input_shape, const ir::Shape &indices_shape, int axis,
-                       int rank);
+ir::Shape inferGatherShape(const ir::Shape &input_shape, const ir::Shape &indices_shape, int axis,
+                           int rank);
 
 ir::Shape inferMaxPoolShape(const ir::Shape &in_shape, const ir::operation::MaxPool2D::Param &param,
                             ir::Layout layout = ir::Layout::NHWC);
 
-ir::Shape onehotShape(const ir::Shape &input_shape, const int depth, int axis);
+ir::Shape inferOnehotShape(const ir::Shape &input_shape, const int depth, int axis);
 
-ir::Shape packShapes(const ir::Shape &input_shape, int axis, int rank, int num);
+ir::Shape inferPackShape(const ir::Shape &input_shape, int axis, int rank, int num);
 
 ir::Shape inferPadShape(const ir::Shape &in_shape, const int32_t *pad_buf, const size_t num_pads);
 
@@ -88,8 +88,8 @@ template <typename T> ir::Shape inferRangeShape(T start_val, T limit_val, T delt
 ir::Shape inferReshapeShape(const int32_t *shape_buf, const int32_t shape_num_elements,
                             const size_t total_num_elements);
 
-ir::Shape inferReduceShapes(const ir::Shape &input_shape, const std::vector<int> &axes,
-                            bool keep_dims);
+ir::Shape inferReduceShape(const ir::Shape &input_shape, const std::vector<int> &axes,
+                           bool keep_dims);
 
 template <float *> ir::Shape inferRangeShape(float *start_val, float *limit_val, float *delta_val);
 
@@ -133,7 +133,7 @@ ir::Shape inferTileShape(const ir::Shape &in_shape, const int32_t *multiplier);
 
 ir::Shape inferTransposeShape(const ir::Shape &in_shape, const std::vector<int> &perm);
 
-ir::Shape unpackShapes(const ir::Shape &input_shape, int axis, int rank);
+ir::Shape inferUnpackShape(const ir::Shape &input_shape, int axis, int rank);
 
 } // namespace shape_inference
 } // namespace onert

--- a/runtime/onert/core/src/compiler/StaticShapeInference.cc
+++ b/runtime/onert/core/src/compiler/StaticShapeInference.cc
@@ -129,7 +129,7 @@ void StaticInferer::visit(const ir::operation::ArgMax &op)
   assert(0 <= axis && axis < rank);
 
   // re-sizing output shape
-  ir::Shape new_shape = shape_inference::argMaxShapes(input.info().shape(), axis, rank);
+  ir::Shape new_shape = shape_inference::inferArgMaxShape(input.info().shape(), axis, rank);
   output.info().shape(new_shape);
 }
 
@@ -377,7 +377,7 @@ void StaticInferer::visit(const ir::operation::Gather &op)
 
   // re-sizing output shape
   ir::Shape new_shape =
-      shape_inference::gatherShapes(input.info().shape(), indices.info().shape(), axis, rank);
+      shape_inference::inferGatherShape(input.info().shape(), indices.info().shape(), axis, rank);
   output.info().shape(new_shape);
 }
 
@@ -538,7 +538,7 @@ void StaticInferer::visit(const ir::operation::Mean &op)
   const auto keep_dims = op.param().keep_dims;
 
   ir::Shape output_shape =
-      shape_inference::inferReduceShapes(input.info().shape(), axes_vec, keep_dims);
+      shape_inference::inferReduceShape(input.info().shape(), axes_vec, keep_dims);
 
   output.info().shape(output_shape);
 }
@@ -581,7 +581,7 @@ void StaticInferer::visit(const ir::operation::OneHot &op)
   const auto *depth_buf = reinterpret_cast<const int32_t *>(depth.data()->base());
   assert(depth_buf);
   // re-sizing output shape
-  ir::Shape new_shape = shape_inference::onehotShape(indice.info().shape(), *depth_buf, axis);
+  ir::Shape new_shape = shape_inference::inferOnehotShape(indice.info().shape(), *depth_buf, axis);
   output.info().shape(new_shape);
 }
 
@@ -620,7 +620,7 @@ void StaticInferer::visit(const ir::operation::Pack &op)
   assert(0 <= axis && axis < rank);
 
   // re-sizing output shape
-  ir::Shape new_shape = shape_inference::packShapes(input.info().shape(), axis, rank, num);
+  ir::Shape new_shape = shape_inference::inferPackShape(input.info().shape(), axis, rank, num);
   output.info().shape(new_shape);
 }
 
@@ -770,7 +770,7 @@ void StaticInferer::visit(const ir::operation::ReduceAll &op)
 
   // re-sizing output shape
   ir::Shape new_shape =
-      shape_inference::inferReduceShapes(input.info().shape(), axes_vec, keep_dims);
+      shape_inference::inferReduceShape(input.info().shape(), axes_vec, keep_dims);
   output.info().shape(new_shape);
 }
 
@@ -817,7 +817,7 @@ void StaticInferer::visit(const ir::operation::ReduceMin &op)
 
   // re-sizing output shape
   ir::Shape new_shape =
-      shape_inference::inferReduceShapes(input.info().shape(), axes_vec, keep_dims);
+      shape_inference::inferReduceShape(input.info().shape(), axes_vec, keep_dims);
   output.info().shape(new_shape);
 }
 
@@ -864,7 +864,7 @@ void StaticInferer::visit(const ir::operation::ReduceProd &op)
 
   // re-sizing output shape
   ir::Shape new_shape =
-      shape_inference::inferReduceShapes(input.info().shape(), axes_vec, keep_dims);
+      shape_inference::inferReduceShape(input.info().shape(), axes_vec, keep_dims);
   output.info().shape(new_shape);
 }
 
@@ -911,7 +911,7 @@ void StaticInferer::visit(const ir::operation::ReduceSum &op)
 
   // re-sizing output shape
   ir::Shape new_shape =
-      shape_inference::inferReduceShapes(input.info().shape(), axes_vec, keep_dims);
+      shape_inference::inferReduceShape(input.info().shape(), axes_vec, keep_dims);
   output.info().shape(new_shape);
 }
 
@@ -1287,7 +1287,7 @@ void StaticInferer::visit(const ir::operation::Unpack &op)
     return;
   }
 
-  ir::Shape new_shape = shape_inference::unpackShapes(input.info().shape(), axis, rank);
+  ir::Shape new_shape = shape_inference::inferUnpackShape(input.info().shape(), axis, rank);
 
   // re-sizing output shape
   for (int out_tensor_idx = 0; out_tensor_idx < num; out_tensor_idx++)

--- a/runtime/onert/core/src/exec/DynamicShapeInference.cc
+++ b/runtime/onert/core/src/exec/DynamicShapeInference.cc
@@ -118,7 +118,7 @@ void DynamicInferer::visit(const ir::operation::ArgMax &op)
   auto output_ind = op.getOutputs().at(0);
   auto output = _tensor_registry->getITensor(output_ind);
 
-  ir::Shape new_shape = shape_inference::argMaxShapes(input_shape, axis, rank);
+  ir::Shape new_shape = shape_inference::inferArgMaxShape(input_shape, axis, rank);
 
   _dynamic_tensor_manager->applyShape(output_ind, new_shape);
   assert(output->buffer() != nullptr);
@@ -411,7 +411,7 @@ void DynamicInferer::visit(const ir::operation::Gather &op)
 
   assert(0 <= axis && axis < rank);
 
-  ir::Shape new_shape = shape_inference::gatherShapes(input_shape, indices_shape, axis, rank);
+  ir::Shape new_shape = shape_inference::inferGatherShape(input_shape, indices_shape, axis, rank);
 
   auto output_ind = op.getOutputs().at(0);
   auto output = _tensor_registry->getITensor(output_ind);
@@ -493,7 +493,7 @@ void DynamicInferer::visit(const ir::operation::Mean &op)
   }
   const auto keep_dims = op.param().keep_dims;
 
-  ir::Shape output_shape = shape_inference::inferReduceShapes(input_shape, axes_vec, keep_dims);
+  ir::Shape output_shape = shape_inference::inferReduceShape(input_shape, axes_vec, keep_dims);
   _dynamic_tensor_manager->applyShape(output_ind, output_shape);
   assert(output->buffer() != nullptr);
 }
@@ -536,7 +536,7 @@ void DynamicInferer::visit(const ir::operation::OneHot &op)
   assert(depth_buf);
   const auto axis_val = op.param().axis;
 
-  ir::Shape new_shape = shape_inference::onehotShape(indices_shape, *depth_buf, axis_val);
+  ir::Shape new_shape = shape_inference::inferOnehotShape(indices_shape, *depth_buf, axis_val);
   _dynamic_tensor_manager->applyShape(output_ind, new_shape);
   assert(output->buffer() != nullptr);
 }
@@ -571,7 +571,7 @@ void DynamicInferer::visit(const ir::operation::Pack &op)
 
   assert(0 <= axis && axis < rank);
 
-  ir::Shape new_shape = shape_inference::packShapes(input_shape, axis, rank, num);
+  ir::Shape new_shape = shape_inference::inferPackShape(input_shape, axis, rank, num);
 
   _dynamic_tensor_manager->applyShape(output_ind, new_shape);
   assert(output->buffer() != nullptr);
@@ -728,7 +728,7 @@ void DynamicInferer::visit(const ir::operation::ReduceAll &op)
   auto output_ind = op.getOutputs().at(0);
   auto output = _tensor_registry->getITensor(output_ind);
 
-  ir::Shape new_shape = shape_inference::inferReduceShapes(input_shape, axes_vec, keep_dims);
+  ir::Shape new_shape = shape_inference::inferReduceShape(input_shape, axes_vec, keep_dims);
 
   _dynamic_tensor_manager->applyShape(output_ind, new_shape);
   assert(output->buffer() != nullptr);
@@ -772,7 +772,7 @@ void DynamicInferer::visit(const ir::operation::ReduceMin &op)
   auto output_ind = op.getOutputs().at(0);
   auto output = _tensor_registry->getITensor(output_ind);
 
-  ir::Shape new_shape = shape_inference::inferReduceShapes(input_shape, axes_vec, keep_dims);
+  ir::Shape new_shape = shape_inference::inferReduceShape(input_shape, axes_vec, keep_dims);
 
   _dynamic_tensor_manager->applyShape(output_ind, new_shape);
   assert(output->buffer() != nullptr);
@@ -816,7 +816,7 @@ void DynamicInferer::visit(const ir::operation::ReduceProd &op)
   auto output_ind = op.getOutputs().at(0);
   auto output = _tensor_registry->getITensor(output_ind);
 
-  ir::Shape new_shape = shape_inference::inferReduceShapes(input_shape, axes_vec, keep_dims);
+  ir::Shape new_shape = shape_inference::inferReduceShape(input_shape, axes_vec, keep_dims);
 
   _dynamic_tensor_manager->applyShape(output_ind, new_shape);
   assert(output->buffer() != nullptr);
@@ -860,7 +860,7 @@ void DynamicInferer::visit(const ir::operation::ReduceSum &op)
   auto output_ind = op.getOutputs().at(0);
   auto output = _tensor_registry->getITensor(output_ind);
 
-  ir::Shape new_shape = shape_inference::inferReduceShapes(input_shape, axes_vec, keep_dims);
+  ir::Shape new_shape = shape_inference::inferReduceShape(input_shape, axes_vec, keep_dims);
 
   _dynamic_tensor_manager->applyShape(output_ind, new_shape);
   assert(output->buffer() != nullptr);
@@ -1218,7 +1218,7 @@ void DynamicInferer::visit(const ir::operation::Unpack &op)
 
   assert(0 <= axis && axis < rank);
 
-  ir::Shape new_shape = shape_inference::unpackShapes(input_shape, axis, rank);
+  ir::Shape new_shape = shape_inference::inferUnpackShape(input_shape, axis, rank);
 
   for (int out_tensor_idx = 0; out_tensor_idx < num; out_tensor_idx++)
   {

--- a/runtime/onert/core/src/util/ShapeInference.cc
+++ b/runtime/onert/core/src/util/ShapeInference.cc
@@ -113,7 +113,7 @@ ir::Shape inferEltwiseShape(const ir::Shape &lhs_shape, const ir::Shape &rhs_sha
   return broadcastShapes(lhs_shape, rhs_shape);
 }
 
-ir::Shape argMaxShapes(const ir::Shape &input_shape, int axis, int rank)
+ir::Shape inferArgMaxShape(const ir::Shape &input_shape, int axis, int rank)
 {
   ir::Shape out_shape;
   for (int idx = 0; idx < rank; ++idx)
@@ -139,8 +139,8 @@ ir::Shape inferAvgPoolShape(const ir::Shape &in_shape, const ir::operation::AvgP
   return ir::Shape{ifm_shape.N, out_h_w.first, out_h_w.second, ifm_shape.C};
 }
 
-ir::Shape inferReduceShapes(const ir::Shape &input_shape, const std::vector<int> &axes,
-                            bool keep_dims)
+ir::Shape inferReduceShape(const ir::Shape &input_shape, const std::vector<int> &axes,
+                           bool keep_dims)
 {
   int num_axis = axes.size();
   int input_num_dims = input_shape.rank();
@@ -390,8 +390,8 @@ ir::Shape inferFullyConnectedShape(const ir::Shape &in_shape, const ir::Shape &k
   return {ir::Shape({static_cast<int32_t>(batch_size), num_units})};
 }
 
-ir::Shape gatherShapes(const ir::Shape &input_shape, const ir::Shape &indices_shape, int axis,
-                       int rank)
+ir::Shape inferGatherShape(const ir::Shape &input_shape, const ir::Shape &indices_shape, int axis,
+                           int rank)
 {
   ir::Shape out_shape;
   const int indices_rank = indices_shape.rank();
@@ -424,7 +424,7 @@ ir::Shape inferMaxPoolShape(const ir::Shape &in_shape, const ir::operation::MaxP
   return ir::Shape{ifm_shape.N, out_h_w.first, out_h_w.second, ifm_shape.C};
 }
 
-ir::Shape onehotShape(const ir::Shape &input_shape, const int depth, int axis)
+ir::Shape inferOnehotShape(const ir::Shape &input_shape, const int depth, int axis)
 {
   assert(depth >= 0);
   const auto rank = input_shape.rank() + 1;
@@ -451,7 +451,7 @@ ir::Shape onehotShape(const ir::Shape &input_shape, const int depth, int axis)
   return newShape;
 }
 
-ir::Shape packShapes(const ir::Shape &input_shape, int axis, int rank, int num)
+ir::Shape inferPackShape(const ir::Shape &input_shape, int axis, int rank, int num)
 {
   ir::Shape out_shape;
   int in_idx = 0;
@@ -931,7 +931,7 @@ ir::Shape inferTransposeShape(const ir::Shape &in_shape, const std::vector<int> 
   return out_shape;
 }
 
-ir::Shape unpackShapes(const ir::Shape &input_shape, int axis, int rank)
+ir::Shape inferUnpackShape(const ir::Shape &input_shape, int axis, int rank)
 {
   ir::Shape out_shape;
 


### PR DESCRIPTION
Some functions in `ShapeInference.h` were renamed like other names. (`inferABCShape(..)`)

Note: We could consider `ABCShape(...)` instead of `inferABCShape(...)`
but I think `inferABCShape(..)` is better since, e.g., the following name is confusing:
- `packShape(..)` : does this mean infer Pack op's shape or packing shape?  :-)

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>