### PR TITLE
[luci-interpreter] Dynamic shapes support

### DIFF
--- a/compiler/luci-interpreter/src/Interpreter.cpp
+++ b/compiler/luci-interpreter/src/Interpreter.cpp
@@ -76,8 +76,6 @@ Interpreter::Interpreter(const luci::Module *module)
   _runtime_module = std::make_unique<RuntimeModule>(_event_notifier.get());
   ModuleLoader loader(module, _runtime_module.get(), *_runtime_to_ir);
   loader.load();
-
-  _runtime_module->configure();
 }
 
 Interpreter::~Interpreter() = default;

--- a/compiler/luci-interpreter/src/core/RuntimeGraph.h
+++ b/compiler/luci-interpreter/src/core/RuntimeGraph.h
@@ -43,8 +43,6 @@ public:
 
   void addKernel(std::unique_ptr<Kernel> &&kernel);
 
-  void configure();
-
   void execute() const;
 
 private:

--- a/compiler/luci-interpreter/src/core/RuntimeModule.h
+++ b/compiler/luci-interpreter/src/core/RuntimeModule.h
@@ -45,8 +45,6 @@ public:
     return getMainGraph()->getOutputTensors();
   }
 
-  void configure() { getMainGraph()->configure(); }
-
   void execute() const { getMainGraph()->execute(); }
 
 private:

--- a/compiler/luci-interpreter/src/loader/KernelBuilder.cpp
+++ b/compiler/luci-interpreter/src/loader/KernelBuilder.cpp
@@ -117,8 +117,6 @@ std::unique_ptr<Kernel> KernelBuilder::visit(const luci::CircleAdd *node)
 std::unique_ptr<Kernel> KernelBuilder::visit(const luci::CircleArgMax *node)
 {
   assert(node->arity() == 2);
-  if (dynamic_cast<const luci::CircleConst *>(node->dimension()) == nullptr)
-    throw std::runtime_error("Dynamic dimension is not yet supported.");
   const Tensor *input1 = getInputTensor(node->input());
   const Tensor *input2 = getInputTensor(node->dimension());
   Tensor *output = getOutputTensor(node);
@@ -349,9 +347,6 @@ std::unique_ptr<Kernel> KernelBuilder::visit(const luci::CircleMean *node)
 {
   assert(node->arity() == 2);
 
-  if (dynamic_cast<const luci::CircleConst *>(node->reduction_indices()) == nullptr)
-    throw std::runtime_error("Dynamic axes is not yet supported.");
-
   const Tensor *input = getInputTensor(node->input());
   const Tensor *axes = getInputTensor(node->reduction_indices());
   Tensor *output = getOutputTensor(node);
@@ -385,9 +380,6 @@ std::unique_ptr<Kernel> KernelBuilder::visit(const luci::CirclePad *node)
 {
   assert(node->arity() == 2);
 
-  if (dynamic_cast<const luci::CircleConst *>(node->paddings()) == nullptr)
-    throw std::runtime_error("Dynamic padding is not yet supported.");
-
   const Tensor *input = getInputTensor(node->input());
   const Tensor *paddings = getInputTensor(node->paddings());
   Tensor *output = getOutputTensor(node);
@@ -398,9 +390,6 @@ std::unique_ptr<Kernel> KernelBuilder::visit(const luci::CirclePad *node)
 std::unique_ptr<Kernel> KernelBuilder::visit(const luci::CircleReshape *node)
 {
   assert(node->arity() == 2);
-
-  if (dynamic_cast<const luci::CircleConst *>(node->shape()) == nullptr)
-    throw std::runtime_error("Dynamic shape is not yet supported.");
 
   const Tensor *input = getInputTensor(node->tensor());
   const Tensor *shape = getInputTensor(node->shape());
@@ -429,9 +418,6 @@ std::unique_ptr<Kernel> KernelBuilder::visit(const luci::CircleSplit *node)
   assert(node->arity() == 2);
   assert(output_nodes.size() == static_cast<size_t>(node->num_split()));
 
-  if (dynamic_cast<const luci::CircleConst *>(node->split_dim()) == nullptr)
-    throw std::runtime_error("Dynamic axis is not yet supported.");
-
   const Tensor *axis = getInputTensor(node->split_dim());
   const Tensor *input = getInputTensor(node->input());
   std::vector<Tensor *> outputs = getOutputTensors(output_nodes);
@@ -443,9 +429,6 @@ std::unique_ptr<Kernel> KernelBuilder::visit(const luci::CircleSplit *node)
 std::unique_ptr<Kernel> KernelBuilder::visit(const luci::CircleTransposeConv *node)
 {
   assert(node->arity() == 3);
-
-  if (dynamic_cast<const luci::CircleConst *>(node->inputSizes()) == nullptr)
-    throw std::runtime_error("Dynamic OutputShape is not yet supported.");
 
   const Tensor *input_sizes = getInputTensor(node->inputSizes());
   const Tensor *filter = getInputTensor(node->filter());
@@ -482,8 +465,6 @@ std::unique_ptr<Kernel> KernelBuilder::visit(const luci::CircleTranspose *node)
 {
   assert(node->arity() == 2);
 
-  if (dynamic_cast<const luci::CircleConst *>(node->perm()) == nullptr)
-    throw std::runtime_error("Dynamic perm is not yet supported.");
   const Tensor *input = getInputTensor(node->a());
   const Tensor *perm = getInputTensor(node->perm());
   Tensor *output = getOutputTensor(node);


### PR DESCRIPTION
For issue #2939.

Call `configure` and `execute` methods in interleaved manner.

ONE-DCO-1.0-Signed-off-by: Sergei Barannikov <s.barannikov@samsung.com>