### PR TITLE
[infra] Update preset 20200630

### DIFF
--- a/infra/packaging/preset/20200630
+++ b/infra/packaging/preset/20200630
@@ -26,6 +26,7 @@ function preset_configure()
   REQUIRED_UNITS+=("tflite2circle" "circle2circle" "tflchef" "circlechef")
   REQUIRED_UNITS+=("tf2tfliteV2" "luci-interpreter" "circle-verify")
   REQUIRED_UNITS+=("record-minmax" "circle-quantizer")
+  REQUIRED_UNITS+=("one-cmds")
 
   # TODO Use "nncc configure" and "nncc build"
   cmake \
@@ -52,5 +53,5 @@ function preset_install()
   python -m pip --default-timeout=1000 --trusted-host pypi.org --trusted-host files.pythonhost.org \
     install -U pip setuptools
   python -m pip --default-timeout=1000 --trusted-host pypi.org --trusted-host files.pythonhost.org \
-    install tensorflow==2.2.0
+    install tensorflow-cpu==2.3.0rc0
 }


### PR DESCRIPTION
This will update preset 20200630
- add one-cmds for end user commands
- use tensorflow-cpu==2.3.0rc0: it's a bit smaller and our 2.x is 2.3.0rc0

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>