### PR TITLE
[pota-value-test] Set correct input dtype

### DIFF
--- a/compiler/pota-quantization-value-test/test_fake_wquant.sh
+++ b/compiler/pota-quantization-value-test/test_fake_wquant.sh
@@ -45,7 +45,7 @@ while [ "$1" != "" ]; do
 
     # Run circle-quantizer with --quantize_dequantize_weights
     "${CIRCLE_QUANTIZER_PATH}" \
-      --quantize_dequantize_weights float "${DTYPE}" "${GRANULARITY}" \
+      --quantize_dequantize_weights float32 "${DTYPE}" "${GRANULARITY}" \
       "${WORKDIR}/${MODELNAME}.circle" \
       "${TESTCASE_FILE}.fake_quantized.circle" 
 

--- a/compiler/pota-quantization-value-test/test_quantization.sh
+++ b/compiler/pota-quantization-value-test/test_quantization.sh
@@ -45,7 +45,7 @@ while [ "$1" != "" ]; do
 
     # Run circle-quantizer with --quantize_with_minmax
     "${CIRCLE_QUANTIZER_PATH}" \
-      --quantize_with_minmax float "${DTYPE}" "${GRANULARITY}" \
+      --quantize_with_minmax float32 "${DTYPE}" "${GRANULARITY}" \
       "${TESTCASE_FILE}.minmax_recorded.circle" \
       "${TESTCASE_FILE}.quantized.circle" 
 


### PR DESCRIPTION
This sets correct input dtype

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>