### PR TITLE
[onert] Do nothing on Permute dynamic inference

### DIFF
--- a/runtime/onert/core/src/exec/DynamicShapeInference.cc
+++ b/runtime/onert/core/src/exec/DynamicShapeInference.cc
@@ -604,45 +604,11 @@ void DynamicInferer::visit(const ir::operation::Pad &op)
   assert(output->buffer() != nullptr);
 }
 
-void DynamicInferer::visit(const ir::operation::Permute &op)
+void DynamicInferer::visit(const ir::operation::Permute & /* op */)
 {
-  const auto input_idx{op.getInputs().at(0)};
-  auto input = _tensor_registry->getITensor(input_idx);
-  auto input_shape = input->getShape();
-
-  // check if input is not dynamic
-  if (!input->is_dynamic())
-    return;
-
-  // getting output shapes
-  auto new_shape = input_shape;
-  // Permute is a special operation that layouts of input/output may be different
-  assert(new_shape.rank() <= ir::Shape::MAX_RANK);
-  if (new_shape.rank() >= 4)
-  {
-    if (op.getPermuteType() == ir::operation::Permute::Type::NHWC_TO_NCHW)
-    {
-      // Permutation changing layout beyond 4-D is not supported yet
-      assert(new_shape.rank() == 4);
-      new_shape.dim(1) = input_shape.dim(3);
-      new_shape.dim(2) = input_shape.dim(1);
-      new_shape.dim(3) = input_shape.dim(2);
-    }
-    else if (op.getPermuteType() == ir::operation::Permute::Type::NCHW_TO_NHWC)
-    {
-      // Permutation changing layout beyond 4-D is not supported yet
-      assert(new_shape.rank() == 4);
-      new_shape.dim(1) = input_shape.dim(2);
-      new_shape.dim(2) = input_shape.dim(3);
-      new_shape.dim(3) = input_shape.dim(1);
-    }
-  }
-
-  // Apply output shape for output tensor
-  auto output_ind = op.getOutputs().at(0);
-  auto output = _tensor_registry->getITensor(output_ind);
-  _dynamic_tensor_manager->applyShape(output_ind, new_shape);
-  assert(output->buffer() != nullptr);
+  // NOTE Permute is a special operation which does not do shape inference before the actual
+  // function(kernel) execution. Shape inference and output allocation will be done in the kernel
+  // on-the-fly, as it must support inter-backend inference/allocation.
 }
 
 void DynamicInferer::visit(const ir::operation::Pow &op)


### PR DESCRIPTION
Re-doing #2874. This work was lost while moving shape inference works.

Do nothing on Permute dynamic shape inference. It will be done in
the kernel.

Part of #2835

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>