### PR TITLE
[nnfwapi] Add a test running twice in a row

### DIFF
--- a/tests/nnfw_api/src/ValidationTestAddSessionPrepared.cc
+++ b/tests/nnfw_api/src/ValidationTestAddSessionPrepared.cc
@@ -19,27 +19,24 @@
 
 using ValidationTestAddSessionPrepared = ValidationTestSessionPrepared<NNPackages::ADD>;
 
-TEST_F(ValidationTestAddSessionPrepared, run_001)
+TEST_F(ValidationTestAddSessionPrepared, run)
 {
-  nnfw_tensorinfo ti_input;
-  std::vector<float> input_buffer;
-  ASSERT_EQ(nnfw_input_tensorinfo(_session, 0, &ti_input), NNFW_STATUS_NO_ERROR);
-  uint64_t input_elements = num_elems(&ti_input);
-  input_buffer.resize(input_elements);
-  ASSERT_EQ(nnfw_set_input(_session, 0, ti_input.dtype, input_buffer.data(),
-                           sizeof(float) * input_elements),
-            NNFW_STATUS_NO_ERROR);
-
-  nnfw_tensorinfo ti_output;
-  std::vector<float> output_buffer;
-  ASSERT_EQ(nnfw_output_tensorinfo(_session, 0, &ti_output), NNFW_STATUS_NO_ERROR);
-  uint64_t output_elements = num_elems(&ti_output);
-  output_buffer.resize(output_elements);
-  ASSERT_EQ(nnfw_set_output(_session, 0, ti_output.dtype, output_buffer.data(),
-                            sizeof(float) * output_elements),
-            NNFW_STATUS_NO_ERROR);
-
+  SetInOutBuffers();
+  _input[0] = 3.0;
   ASSERT_EQ(nnfw_run(_session), NNFW_STATUS_NO_ERROR);
+  ASSERT_FLOAT_EQ(_output[0], 5.0);
+}
+
+TEST_F(ValidationTestAddSessionPrepared, run_twice)
+{
+  SetInOutBuffers();
+  _input[0] = 4.0;
+  ASSERT_EQ(nnfw_run(_session), NNFW_STATUS_NO_ERROR);
+  ASSERT_FLOAT_EQ(_output[0], 6.0);
+
+  _input[0] = 5.0f;
+  ASSERT_EQ(nnfw_run(_session), NNFW_STATUS_NO_ERROR);
+  ASSERT_FLOAT_EQ(_output[0], 7.0);
 }
 
 TEST_F(ValidationTestAddSessionPrepared, set_input_001)

--- a/tests/nnfw_api/src/fixtures.h
+++ b/tests/nnfw_api/src/fixtures.h
@@ -102,6 +102,31 @@ protected:
   }
 
   void TearDown() override { ValidationTestModelLoaded<PackageNo>::TearDown(); }
+
+  void SetInOutBuffers()
+  {
+    nnfw_tensorinfo ti_input;
+    ASSERT_EQ(nnfw_input_tensorinfo(_session, 0, &ti_input), NNFW_STATUS_NO_ERROR);
+    uint64_t input_elements = num_elems(&ti_input);
+    EXPECT_EQ(input_elements, 1);
+    _input.resize(input_elements);
+    ASSERT_EQ(
+        nnfw_set_input(_session, 0, ti_input.dtype, _input.data(), sizeof(float) * input_elements),
+        NNFW_STATUS_NO_ERROR);
+
+    nnfw_tensorinfo ti_output;
+    ASSERT_EQ(nnfw_output_tensorinfo(_session, 0, &ti_output), NNFW_STATUS_NO_ERROR);
+    uint64_t output_elements = num_elems(&ti_output);
+    EXPECT_EQ(output_elements, 1);
+    _output.resize(output_elements);
+    ASSERT_EQ(nnfw_set_output(_session, 0, ti_output.dtype, _output.data(),
+                              sizeof(float) * output_elements),
+              NNFW_STATUS_NO_ERROR);
+  }
+
+protected:
+  std::vector<float> _input;
+  std::vector<float> _output;
 };
 
 template <int PackageNo> class ValidationTestFourModelsSetInput : public ValidationTest


### PR DESCRIPTION
- Add "run_twice" test case
- Create a method `SetInOutBuffers` for the fixture

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>