### PR TITLE
[onert] Manage UserTensor in controlflow backend

### DIFF
--- a/runtime/onert/core/include/backend/ITensorRegistry.h
+++ b/runtime/onert/core/include/backend/ITensorRegistry.h
@@ -17,6 +17,8 @@
 #ifndef __ONERT_BACKEND_ITENSOR_REGISTRY__
 #define __ONERT_BACKEND_ITENSOR_REGISTRY__
 
+#include <memory>
+
 #include "ir/Index.h"
 #include "backend/ITensor.h"
 
@@ -33,10 +35,17 @@ struct ITensorRegistry
   virtual ~ITensorRegistry() = default;
 
   /**
-   * @brief Returns pointer of ITensor
+   * @brief Returns pointer of ITensor among managed and external tensors
    * @note  Return tensor cannot be used longer than dynamic tensor manager
    */
   virtual std::shared_ptr<ITensor> getITensor(const ir::OperandIndex &) = 0;
+  /**
+   * @brief Returns pointer of ITensor among managed tensors
+   *
+   * Unlike @c getITensor , this function only searches from managed tensors
+   * @note  Return tensor cannot be used longer than dynamic tensor manager
+   */
+  virtual std::shared_ptr<ITensor> getManagedITensor(const ir::OperandIndex &) = 0;
 };
 
 } // namespace backend
@@ -67,6 +76,11 @@ public:
     auto external_tensor = _external.find(ind);
     if (external_tensor != _external.end())
       return external_tensor->second;
+    return getManagedTensor(ind);
+  }
+
+  std::shared_ptr<ITensor> getManagedITensor(const ir::OperandIndex &ind) override
+  {
     return getManagedTensor(ind);
   }
 

--- a/runtime/onert/core/src/backend/controlflow/Backend.h
+++ b/runtime/onert/core/src/backend/controlflow/Backend.h
@@ -66,7 +66,7 @@ public:
     auto tb = std::make_shared<TensorBuilder>();
     context->tensor_builder = tb;
     context->constant_initializer = std::make_shared<ConstantInitializer>(operands, tb);
-    context->kernel_gen = std::make_shared<KernelGenerator>(graph);
+    context->kernel_gen = std::make_shared<KernelGenerator>(graph, tb);
     context->tensor_register = nullptr;
     context->optimizer = nullptr;
     return context;

--- a/runtime/onert/core/src/backend/controlflow/DynamicTensorManager.cc
+++ b/runtime/onert/core/src/backend/controlflow/DynamicTensorManager.cc
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "DynamicTensorManager.h"
+
+#include "util/logging.h"
+
+namespace onert
+{
+namespace backend
+{
+namespace controlflow
+{
+
+DynamicTensorManager::DynamicTensorManager(const std::shared_ptr<cpu_common::TensorRegistry> &reg,
+                                           const std::shared_ptr<UserTensorRegistry> &user_reg)
+    : _dynamic_mem_mgr{new cpu_common::DynamicMemoryManager()}, _tensors{reg},
+      _user_tensors{user_reg}
+{
+  // DO NOTHING
+}
+
+void DynamicTensorManager::applyShape(const ir::OperandIndex &ind, const ir::Shape &new_shape)
+{
+  // NOTE Handle user tensors first
+  auto user_tensor = _user_tensors->getManagedTensor(ind);
+  if (user_tensor)
+  {
+    // User tensors cannot be reallocated.
+    auto buffer_size = user_tensor->total_size();
+    auto new_size = new_shape.num_elements() * sizeOfDataType(user_tensor->data_type());
+    if (buffer_size < new_size)
+      throw std::runtime_error{"ExecutorBase: output buffer size is less than output tensor size"};
+    user_tensor->setShape(new_shape);
+  }
+
+  // NOTE Then handle managed tensors
+  auto tensor = _tensors->getManagedTensor(ind);
+  assert(tensor);
+
+  bool previously_dynamic = tensor->is_dynamic();
+
+  auto allocTensorMem = [&](bool overwrite = false) {
+    auto capacity = tensor->total_size();
+    auto alloc = _dynamic_mem_mgr->allocate(ind, capacity);
+
+    if (overwrite)
+      tensor->overwriteBuffer(alloc);
+    else
+      tensor->setBuffer(alloc);
+  };
+
+  if (!previously_dynamic)
+  {
+    // TODO deallocate tensor->buffer()
+    // issue is that staticTensorManager might have allocate this memory
+    tensor->setShape(new_shape);
+    tensor->set_dynamic();
+    allocTensorMem(true);
+  }
+  else if (tensor->buffer() == nullptr)
+  {
+    tensor->setShape(new_shape);
+    tensor->set_dynamic();
+    allocTensorMem();
+  }
+  // when buffer was already allocated and new_shape requires different size
+  else
+  {
+    auto previous_size = tensor->total_size();
+    auto new_size = new_shape.num_elements() * sizeOfDataType(tensor->data_type());
+    if (previous_size != new_size)
+    {
+      _dynamic_mem_mgr->deallocate(ind);
+
+      tensor->setShape(new_shape);
+      tensor->set_dynamic();
+      allocTensorMem(true);
+    }
+    else
+    { // when buffer with same size was already allocated, shape could differ
+      tensor->setShape(new_shape);
+    }
+  }
+}
+
+void DynamicTensorManager::buildTensor(const ir::OperandIndex &ind,
+                                       const ir::OperandInfo &tensor_info,
+                                       ir::Layout backend_layout)
+{
+  assert(_tensors->getManagedTensor(ind) == nullptr);
+  auto tensor = std::make_shared<cpu_common::Tensor>(tensor_info, backend_layout);
+  _tensors->setManagedTensor(ind, tensor);
+}
+
+void DynamicTensorManager::planDealloc(ir::OperationIndex op_ind, ir::OperandIndex operand_ind)
+{
+  auto find = _dealloc_tensor_map.find(op_ind);
+  if (find != _dealloc_tensor_map.end())
+  {
+    auto &input_set = find->second;
+    input_set.emplace(operand_ind);
+  }
+  else
+  {
+    _dealloc_tensor_map.emplace(
+        std::make_pair(op_ind, std::unordered_set<ir::OperandIndex>{operand_ind}));
+  }
+}
+
+void DynamicTensorManager::deallocInput(ir::OperationIndex op_ind)
+{
+  auto find = _dealloc_tensor_map.find(op_ind);
+  if (find == _dealloc_tensor_map.end())
+    return;
+
+  auto &input_set = find->second;
+  for (auto input_ind : input_set)
+  {
+    if (!_tensors->getManagedTensor(input_ind)->is_dynamic())
+      continue;
+
+    _dynamic_mem_mgr->deallocate(input_ind);
+    VERBOSE(DynamicTensorManager) << "Deallocating #" << input_ind.value()
+                                  << " (input of op_ind: " << op_ind.value() << ")" << std::endl;
+  }
+}
+
+void DynamicTensorManager::deallocSubgraphOutput(ir::OperandIndex output_ind)
+{
+  if (!_tensors->getManagedTensor(output_ind)->is_dynamic())
+    return;
+
+  _dynamic_mem_mgr->deallocate(output_ind);
+  VERBOSE(DynamicTensorManager) << "Deallocating #" << output_ind.value()
+                                << " (output of a subgraph)" << std::endl;
+}
+
+} // namespace controlflow
+} // namespace backend
+} // namespace onert

--- a/runtime/onert/core/src/backend/controlflow/DynamicTensorManager.h
+++ b/runtime/onert/core/src/backend/controlflow/DynamicTensorManager.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_BACKEND_CONTROLFLOW_DYNAMICTENSOR_MANAGER_H__
+#define __ONERT_BACKEND_CONTROLFLOW_DYNAMICTENSOR_MANAGER_H__
+
+#include "UserTensorRegistry.h"
+
+#include <backend/IDynamicTensorManager.h>
+#include <backend/cpu_common/MemoryManager.h>
+#include <backend/cpu_common/TensorRegistry.h>
+#include <ir/OperandInfo.h>
+#include <ir/Operation.h>
+#include <ir/Index.h>
+
+namespace onert
+{
+namespace backend
+{
+namespace controlflow
+{
+
+// TODO Find optimized algorithm to manage memory.
+
+/**
+ * @brief Class to manage dynamic tensor and its memory
+ */
+class DynamicTensorManager : public backend::IDynamicTensorManager
+{
+public:
+  DynamicTensorManager(const std::shared_ptr<cpu_common::TensorRegistry> &reg,
+                       const std::shared_ptr<UserTensorRegistry> &user_reg);
+
+  virtual ~DynamicTensorManager() = default;
+
+  void applyShape(const ir::OperandIndex &ind, const ir::Shape &new_shape) override;
+
+  void buildTensor(const ir::OperandIndex &ind, const ir::OperandInfo &tensor_info,
+                   ir::Layout backend_layout);
+
+  void planDealloc(ir::OperationIndex op_ind, ir::OperandIndex operand_ind) override;
+  void deallocInput(ir::OperationIndex op_ind) override;
+  void deallocSubgraphOutput(ir::OperandIndex ind) override;
+
+private:
+  /**
+   * @brief Memory manager for dynamic tensor.
+   * @todo  DynamicMemoryManager is not optimized. Optimized one is needed
+   */
+  std::shared_ptr<cpu_common::DynamicMemoryManager> _dynamic_mem_mgr;
+  const std::shared_ptr<cpu_common::TensorRegistry> _tensors;
+  const std::shared_ptr<UserTensorRegistry> _user_tensors;
+
+  // contains list of dynamic tensor index, which can be deallocated after running operation
+  // note: this map could contain static tensor index too. Careful use is required.
+  std::unordered_map<ir::OperationIndex, std::unordered_set<ir::OperandIndex>> _dealloc_tensor_map;
+};
+
+} // namespace controlflow
+} // namespace backend
+} // namespace onert
+
+#endif // __ONERT_BACKEND_CONTROLFLOW_DYNAMICTENSOR_MANAGER_H__

--- a/runtime/onert/core/src/backend/controlflow/KernelGenerator.cc
+++ b/runtime/onert/core/src/backend/controlflow/KernelGenerator.cc
@@ -22,6 +22,7 @@
 #include "kernel/WhileLayer.h"
 #include "kernel/PermuteLayer.h"
 #include "exec/ExecutorBase.h"
+#include "exec/FunctionSequence.h"
 
 namespace onert
 {
@@ -30,8 +31,9 @@ namespace backend
 namespace controlflow
 {
 
-KernelGenerator::KernelGenerator(const ir::Graph &graph)
-    : _graph{graph}, _tensor_builder_set{}, _executor_map{nullptr}
+KernelGenerator::KernelGenerator(const ir::Graph &graph,
+                                 const std::shared_ptr<TensorBuilder> &tensor_builder)
+    : _graph{graph}, _tensor_builder{tensor_builder}, _tensor_builder_set{}, _executor_map{nullptr}
 {
   UNUSED_RELEASE(_graph);
   UNUSED_RELEASE(_tensor_builder_set);
@@ -41,7 +43,17 @@ KernelGenerator::KernelGenerator(const ir::Graph &graph)
 void KernelGenerator::visit(const ir::OpSequence &op_seq)
 {
   assert(!_return_fn_seq);
-  _return_fn_seq = std::make_unique<exec::FunctionSequence>();
+  assert(_tensor_builder->dynamicTensorManager());
+  assert(_tensor_builder->tensorRegistry());
+
+  auto dyn_tensor_manager = _tensor_builder->dynamicTensorManager();
+  auto dyn_shape_inferer = std::make_unique<exec::DynamicInferer>(
+      _graph.operands(), dyn_tensor_manager, _tensor_builder->tensorRegistry());
+
+  // TODO Always returning FunctionSequenceForDynamicBackend may cause performance issue
+  _return_fn_seq = std::make_unique<exec::FunctionSequenceForDynamicBackend>(
+      op_seq, _graph.operations(), std::move(dyn_shape_inferer), dyn_tensor_manager);
+
   for (const auto &op_idx : op_seq.operations())
   {
     const auto &node = _graph.operations().at(op_idx);

--- a/runtime/onert/core/src/backend/controlflow/KernelGenerator.h
+++ b/runtime/onert/core/src/backend/controlflow/KernelGenerator.h
@@ -21,6 +21,8 @@
 #include <backend/ITensorBuilder.h>
 #include <exec/IExecutor.h>
 #include <ir/Graph.h>
+#include "TensorBuilder.h"
+#include "compiler/TensorBuilders.h"
 
 #include "compiler/TensorBuilders.h"
 
@@ -34,7 +36,7 @@ namespace controlflow
 class KernelGenerator : public IKernelGenerator
 {
 public:
-  KernelGenerator(const ir::Graph &graph);
+  KernelGenerator(const ir::Graph &graph, const std::shared_ptr<TensorBuilder> &tensor_builder);
 
   void setTensorBuilderSet(const compiler::TensorBuilders &tensor_builder_set)
   {
@@ -59,6 +61,7 @@ private:
 
 private:
   const ir::Graph &_graph;
+  std::shared_ptr<TensorBuilder> _tensor_builder;
   compiler::TensorBuilders _tensor_builder_set;
   exec::ExecutorMap *_executor_map;
 };

--- a/runtime/onert/core/src/backend/controlflow/TensorBuilder.cc
+++ b/runtime/onert/core/src/backend/controlflow/TensorBuilder.cc
@@ -28,9 +28,9 @@ namespace controlflow
 {
 
 TensorBuilder::TensorBuilder()
-    : _tensor_reg{new cpu_common::TensorRegistry()},
+    : _tensor_reg{new cpu_common::TensorRegistry()}, _user_tensor_reg{new UserTensorRegistry()},
       _static_tensor_mgr{new cpu_common::StaticTensorManager(_tensor_reg)},
-      _dynamic_tensor_mgr{new cpu_common::DynamicTensorManager(_tensor_reg)}
+      _dynamic_tensor_mgr{new DynamicTensorManager(_tensor_reg, _user_tensor_reg)}
 {
   /* empty */
 }
@@ -91,7 +91,16 @@ void TensorBuilder::allocate()
 
 std::shared_ptr<ITensor> TensorBuilder::tensorAt(const ir::OperandIndex &ind)
 {
-  return _tensor_reg->getITensor(ind);
+  // NOTE Find from User Tensor Registry first
+  // FIXME There may be both user tensor and managed tensor for a `ind` which is a waste
+  auto user_tensor = _user_tensor_reg->getITensor(ind);
+  auto tensor = _tensor_reg->getITensor(ind);
+  if (user_tensor)
+  {
+    return user_tensor;
+  }
+  else
+    return tensor;
 }
 
 void TensorBuilder::iterate(const IterateFunction &fn) { _static_tensor_mgr->iterate(fn); }
@@ -109,6 +118,12 @@ std::unique_ptr<ITensorManager> TensorBuilder::releaseStaticTensorManager(void)
 std::unique_ptr<ITensorManager> TensorBuilder::releaseDynamicTensorManager(void)
 {
   return std::move(_dynamic_tensor_mgr);
+}
+
+void TensorBuilder::setUserTensor(const ir::OperandIndex &ind,
+                                  const std::shared_ptr<UserTensor> &tensor)
+{
+  _user_tensor_reg->setManagedTensor(ind, tensor);
 }
 
 } // namespace controlflow

--- a/runtime/onert/core/src/backend/controlflow/TensorBuilder.h
+++ b/runtime/onert/core/src/backend/controlflow/TensorBuilder.h
@@ -17,7 +17,6 @@
 #ifndef __ONERT_BACKEND_CONTROLFLOW_TENSOR_BUILDER_H__
 #define __ONERT_BACKEND_CONTROLFLOW_TENSOR_BUILDER_H__
 
-#include <backend/cpu_common/DynamicTensorManager.h>
 #include <backend/cpu_common/StaticTensorManager.h>
 #include <backend/cpu_common/TensorRegistry.h>
 #include <backend/cpu_common/Tensor.h>
@@ -26,6 +25,9 @@
 #include <ir/OperandIndexMap.h>
 
 #include <unordered_map>
+
+#include "DynamicTensorManager.h"
+#include "UserTensorRegistry.h"
 
 namespace onert
 {
@@ -81,13 +83,15 @@ public:
    * @return shared_ptr<operand::Tensor>
    */
   std::shared_ptr<cpu_common::Tensor> at(const ir::OperandIndex &ind);
+  void setUserTensor(const ir::OperandIndex &ind, const std::shared_ptr<UserTensor> &tensor);
 
   std::shared_ptr<ITensorRegistry> tensorRegistry() override { return _tensor_reg; }
 
 private:
   const std::shared_ptr<cpu_common::TensorRegistry> _tensor_reg;
+  const std::shared_ptr<UserTensorRegistry> _user_tensor_reg;
   std::unique_ptr<cpu_common::StaticTensorManager> _static_tensor_mgr;
-  std::unique_ptr<cpu_common::DynamicTensorManager> _dynamic_tensor_mgr;
+  std::unique_ptr<DynamicTensorManager> _dynamic_tensor_mgr;
   ir::OperandIndexMap<ir::OperandInfo> _tensor_info_map;
   ir::OperandIndexMap<ir::Layout> _tensor_layout_map;
 };

--- a/runtime/onert/core/src/backend/controlflow/UserTensorRegistry.h
+++ b/runtime/onert/core/src/backend/controlflow/UserTensorRegistry.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_BACKEND_CONTROLFLOW_USER_TENSOR_REGISTRY__
+#define __ONERT_BACKEND_CONTROLFLOW_USER_TENSOR_REGISTRY__
+
+#include "backend/ITensorRegistry.h"
+#include "UserTensor.h"
+
+namespace onert
+{
+namespace backend
+{
+namespace controlflow
+{
+
+using UserTensorRegistry = PortableTensorRegistryTemplate<UserTensor>;
+
+} // namespace controlflow
+} // namespace backend
+} // namespace onert
+
+#endif // __ONERT_BACKEND_CONTROLFLOW_USER_TENSOR_REGISTRY__


### PR DESCRIPTION
Not only `cpu_common::UserTensor`, `UserTensor` is supported in
controlflow backend. As a workaround, two tensor registries are exist
for both types of tensors.

- Introduce `ITensorRegistry::getManagedITensor`
- Introduce `controlflow::DynamicTensorManager`
    - Bascially a copy of `cpu_common::DynamicTensorManager`
    - `UserTensor` handling is added

Draft PR : #2835

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>