### PR TITLE
[circle-tensordump] Use own built HDF5 package

### DIFF
--- a/compiler/circle-tensordump/CMakeLists.txt
+++ b/compiler/circle-tensordump/CMakeLists.txt
@@ -2,12 +2,7 @@ if(NOT TARGET mio_circle)
   return()
 endif(NOT TARGET mio_circle)
 
-# TODO This will be nnas_find_package
-find_package(HDF5 COMPONENTS CXX QUIET CONFIG)
-
-if(NOT HDF5_FOUND)
-  find_package(HDF5 COMPONENTS CXX QUIET MODULE)
-endif(NOT HDF5_FOUND)
+nnas_find_package(HDF5 QUIET)
 
 if(NOT HDF5_FOUND)
   return()


### PR DESCRIPTION
This commit makes circle-tensordump use own built HDF5 package

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>