### PR TITLE
[i5diff] Use own built HDF5 package

### DIFF
--- a/compiler/i5diff/CMakeLists.txt
+++ b/compiler/i5diff/CMakeLists.txt
@@ -1,9 +1,4 @@
-# TODO This will be nnas_find_package
-find_package(HDF5 COMPONENTS CXX QUIET CONFIG)
-
-if(NOT HDF5_FOUND)
-  find_package(HDF5 COMPONENTS CXX QUIET MODULE)
-endif(NOT HDF5_FOUND)
+nnas_find_package(HDF5 QUIET)
 
 if(NOT HDF5_FOUND)
   return()


### PR DESCRIPTION
This commit makes i5diff use own built HDF5 package

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>