### PR TITLE
[record-minmax] Use own built HDF5 package

### DIFF
--- a/compiler/record-minmax/CMakeLists.txt
+++ b/compiler/record-minmax/CMakeLists.txt
@@ -1,9 +1,4 @@
-# TODO This will be nnas_find_package
-find_package(HDF5 COMPONENTS CXX QUIET CONFIG)
-
-if(NOT HDF5_FOUND)
-  find_package(HDF5 COMPONENTS CXX QUIET MODULE)
-endif(NOT HDF5_FOUND)
+nnas_find_package(HDF5 COMPONENTS STATIC QUIET)
 
 if(NOT HDF5_FOUND)
   message(STATUS "Build record-minmax: FAILED (missing HDF5)")


### PR DESCRIPTION
This commit makes record-minmax use own built HDF5 package

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>