### PR TITLE
[onert] Apply external_tensors method to PortableTensorRegistryTemplate

### DIFF
--- a/runtime/onert/core/include/backend/ITensorRegistry.h
+++ b/runtime/onert/core/include/backend/ITensorRegistry.h
@@ -110,6 +110,11 @@ public:
 
   const ir::OperandIndexMap<std::shared_ptr<T_Tensor>> &managed_tensors() { return _managed; }
 
+  const ir::OperandIndexMap<std::shared_ptr<IPortableTensor>> &external_tensors()
+  {
+    return _external;
+  }
+
 private:
   ir::OperandIndexMap<std::shared_ptr<IPortableTensor>> _external;
   ir::OperandIndexMap<std::shared_ptr<T_Tensor>> _managed;


### PR DESCRIPTION
Apply external_tensors method to PortableTensorRegistryTemplate

ONE-DCO-1.0-Signed-off-by: Yongseop Kim <yons.kim@samsung.com>