### PR TITLE
[onert] Remove unused code in ManualScheduler

### DIFF
--- a/runtime/onert/core/src/compiler/ManualScheduler.cc
+++ b/runtime/onert/core/src/compiler/ManualScheduler.cc
@@ -98,10 +98,6 @@ std::unique_ptr<BackendResolver> ManualScheduler::schedule(const ir::Graph &grap
     }
   }
 
-  // 4. Operations that are specially handled
-  //    All configuration above will be ignored(overwritten)
-  op_type_map[ir::OpCode::Permute] = BackendManager::get().get("cpu");
-
   // Dump final assignment
   backend_resolver->iterate([&](const ir::OperationIndex &index, const backend::Backend &backend) {
     VERBOSE(ManualScheduler) << "backend for operation #" << index.value() << ": "


### PR DESCRIPTION
This line does not do anything as `op_type_map` is never used again.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>