### PR TITLE
[onert] Fix DotDumper to show multiple edges

### DIFF
--- a/runtime/onert/core/src/dumper/dot/DotBuilder.cc
+++ b/runtime/onert/core/src/dumper/dot/DotBuilder.cc
@@ -29,7 +29,7 @@ DotBuilder::DotBuilder() {}
 void DotBuilder::update(const Node &node_info)
 {
   add(node_info);
-  for (auto edge : node_info.edges())
+  for (auto edge : node_info.out_edges())
   {
     addEdge(node_info, *edge);
   }

--- a/runtime/onert/core/src/dumper/dot/Node.h
+++ b/runtime/onert/core/src/dumper/dot/Node.h
@@ -106,18 +106,18 @@ public:
    *
    * @param[in] dotinfo A node that the new edge will be connected to
    */
-  void addEdge(std::shared_ptr<Node> dotinfo) { _children.emplace_back(dotinfo); }
+  void addOutEdge(Node *dotinfo) { _out_edges.emplace_back(dotinfo); }
   /**
-   * @brief Return list of edges
+   * @brief Return list of out edges
    *
    * @return Edges
    */
-  const std::vector<std::shared_ptr<Node>> &edges() const { return _children; }
+  const std::vector<Node *> &out_edges() const { return _out_edges; }
 
 private:
   std::string _id;
   std::unordered_map<std::string, std::string> _attributes;
-  std::vector<std::shared_ptr<Node>> _children;
+  std::vector<Node *> _out_edges;
 };
 
 } // namespace dot


### PR DESCRIPTION
- Show multiple edges if an operand is used multiple times
  by iterating over operations rather than operands
  (operand does not have order and duplications)
- Change creating a new `shared_ptr` object to a raw pointer of existing
  object
- Variable/method name changes : edge -> out_edge

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>