### PR TITLE
[arser] Support multiple string argument

### DIFF
--- a/compiler/arser/include/arser/arser.h
+++ b/compiler/arser/include/arser/arser.h
@@ -74,6 +74,10 @@ template <> struct TypeName<std::string>
 {
   static const char *Get() { return "string"; }
 };
+template <> struct TypeName<std::vector<std::string>>
+{
+  static const char *Get() { return "vector<string>"; }
+};
 
 // supported DataType
 enum class DataType
@@ -84,6 +88,7 @@ enum class DataType
   FLOAT_VEC,
   BOOL,
   STR,
+  STR_VEC,
 };
 
 class Arser;
@@ -124,6 +129,9 @@ public:
         break;
       case DataType::STR:
         _type = "string";
+        break;
+      case DataType::STR_VEC:
+        _type = "vector<string>";
         break;
       default:
         throw std::runtime_error("NYI DataType");

--- a/compiler/arser/tests/arser.test.cpp
+++ b/compiler/arser/tests/arser.test.cpp
@@ -206,3 +206,26 @@ TEST(BasicTest, MultipleFloatValue)
 
   EXPECT_THROW(arser.get<std::vector<int>>("--add_float"), std::runtime_error);
 }
+
+TEST(BasicTest, MultipleStringValue)
+{
+  /* arrange */
+  Arser arser;
+
+  arser.add_argument("--three_color")
+      .nargs(3)
+      .type(arser::DataType::STR_VEC)
+      .help("insert your three favorite color");
+
+  Prompt prompt("./color_factory --three_color red blue yellow");
+  /* act */
+  arser.parse(prompt.argc(), prompt.argv());
+  /* assert */
+  EXPECT_TRUE(arser["--three_color"]);
+  std::vector<std::string> values = arser.get<std::vector<std::string>>("--three_color");
+  EXPECT_EQ("red", values.at(0));
+  EXPECT_EQ("blue", values.at(1));
+  EXPECT_EQ("yellow", values.at(2));
+
+  EXPECT_THROW(arser.get<std::vector<std::string>>("--color"), std::runtime_error);
+}


### PR DESCRIPTION
This commit enables arser support string vector type

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>