### PR TITLE
[onert] Refine Compiler implementation

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -169,9 +169,7 @@ NNFW_STATUS nnfw_session::prepare()
   try
   {
     _subgraphs.reset();
-    _compiler->compile();
-    std::shared_ptr<onert::exec::ExecutorMap> executors;
-    _compiler->release(executors);
+    std::shared_ptr<onert::exec::ExecutorMap> executors = _compiler->compile();
     _execution = std::make_shared<onert::exec::Execution>(executors);
   }
   catch (const std::exception &e)

--- a/runtime/onert/core/include/compiler/Compiler.h
+++ b/runtime/onert/core/include/compiler/Compiler.h
@@ -77,17 +77,12 @@ public:
 
 public:
   /**
-   * @brief   Run compilation. Compilation result will be saved in _plan
+   * @brief   Do compilation with the options
+   *
+   * @return std::shared_ptr<exec::ExecutorMap> Executors as a result of compilation
    */
-  void compile(void);
-  /**
-   * @brief       Pass plan reference
-   * @param[out]  plan  Plan reference to return\n
-   *                    Set nullptr if compile is not run yet
-   */
-  void release(std::shared_ptr<exec::ExecutorMap> &executors) { executors = _executors; }
+  std::shared_ptr<exec::ExecutorMap> compile(void);
 
-  void state(State state) { _state = state; }
   State state(void) const { return _state; }
 
   /**
@@ -115,7 +110,6 @@ private:
   // be updated by child executor. If you want to support subgraphs being called recursively, you
   // have to add allocate non-constant tensor memory of executors in execution time when each
   // subgraph is called.
-  std::shared_ptr<exec::ExecutorMap> _executors;
   State _state;
   CompilerOptions _options;
 };

--- a/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksCompilation.cc
+++ b/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksCompilation.cc
@@ -32,7 +32,7 @@ bool ANeuralNetworksCompilation::finish() noexcept
 {
   try
   {
-    _compiler->compile();
+    _executors = _compiler->compile();
   }
   catch (const std::exception &e)
   {

--- a/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksCompilation.h
+++ b/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksCompilation.h
@@ -35,12 +35,13 @@ public:
   onert::compiler::State state(void) noexcept { return _compiler->state(); }
   void publish(std::shared_ptr<onert::exec::ExecutorMap> &executors) noexcept
   {
-    _compiler->release(executors);
+    executors = _executors;
   }
 
 private:
   std::shared_ptr<onert::ir::Subgraphs> _subgraphs;
   std::shared_ptr<onert::compiler::Compiler> _compiler;
+  std::shared_ptr<onert::exec::ExecutorMap> _executors;
 };
 
 #endif

--- a/runtime/onert/test/core/exec/ExecInstance.cc
+++ b/runtime/onert/test/core/exec/ExecInstance.cc
@@ -74,8 +74,7 @@ public:
     auto subgs = std::make_shared<onert::ir::Subgraphs>();
     subgs->push(onert::ir::SubgraphIndex{0}, graph);
     auto compiler = new onert::compiler::Compiler{subgs};
-    compiler->compile();
-    compiler->release(executors);
+    executors = compiler->compile();
     delete compiler;
   }
 
@@ -138,9 +137,7 @@ TEST(ExecInstance, twoCompile)
   auto subgs = std::make_shared<onert::ir::Subgraphs>();
   subgs->push(onert::ir::SubgraphIndex{0}, graph);
   auto compiler = new onert::compiler::Compiler{subgs};
-  compiler->compile();
-  std::shared_ptr<onert::exec::ExecutorMap> executors2;
-  compiler->release(executors2);
+  std::shared_ptr<onert::exec::ExecutorMap> executors2 = compiler->compile();
   auto execution2 = new onert::exec::Execution(executors2);
 
   const float exe2_input1_buffer[4] = {2, 1, -2, 0};

--- a/tests/tools/tflite_loader/src/tflite_loader.cc
+++ b/tests/tools/tflite_loader/src/tflite_loader.cc
@@ -80,10 +80,11 @@ void executeGraph(const std::shared_ptr<onert::ir::Graph> &g,
   auto subgs = std::make_shared<onert::ir::Subgraphs>();
   subgs->push(onert::ir::SubgraphIndex{0}, g);
   auto compiler = new onert::compiler::Compiler(subgs);
+  std::shared_ptr<onert::exec::ExecutorMap> executors;
   // Compilation
   try
   {
-    compiler->compile();
+    executors = compiler->compile();
   }
   catch (const std::exception &e)
   {
@@ -94,8 +95,6 @@ void executeGraph(const std::shared_ptr<onert::ir::Graph> &g,
 
   std::cout << "[Execution] Graph compiled!" << std::endl;
 
-  std::shared_ptr<onert::exec::ExecutorMap> executors;
-  compiler->release(executors);
   auto execution = std::make_shared<onert::exec::Execution>(executors);
 
   // Setting IO


### PR DESCRIPTION
Make `compile` method return executors right away rather than getting it
with `release` method later.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>