### PR TITLE
[pota-quantization-value-test] Enable tests with updated params of record-minmax

### DIFF
--- a/compiler/pota-quantization-value-test/CMakeLists.txt
+++ b/compiler/pota-quantization-value-test/CMakeLists.txt
@@ -46,21 +46,21 @@ add_test(
           ${QUANTIZATION_VALUE_TEST_WITH_PARAM}
 )
 
-#add_test(
-#  NAME pota_record_minmax_test
-#  COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/test_record_minmax.sh"
-#          "${TEST_CONFIG}"
-#          "${ARTIFACTS_BIN_PATH}"
-#          ${QUANTIZATION_VALUE_TEST_WITH_PARAM}
-#)
+add_test(
+  NAME pota_record_minmax_test
+  COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/test_record_minmax.sh"
+          "${TEST_CONFIG}"
+          "${ARTIFACTS_BIN_PATH}"
+          ${QUANTIZATION_VALUE_TEST_WITH_PARAM}
+)
 
-#add_test(
-#  NAME pota_quantization_test
-#  COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/test_quantization.sh"
-#          "${TEST_CONFIG}"
-#          "${ARTIFACTS_BIN_PATH}"
-#          ${QUANTIZATION_VALUE_TEST_WITH_PARAM}
-#)
+add_test(
+  NAME pota_quantization_test
+  COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/test_quantization.sh"
+          "${TEST_CONFIG}"
+          "${ARTIFACTS_BIN_PATH}"
+          ${QUANTIZATION_VALUE_TEST_WITH_PARAM}
+)
 
-#set_tests_properties(pota_record_minmax_test PROPERTIES DEPENDS pota_fake_wquant_test)
-#set_tests_properties(pota_quantization_test PROPERTIES DEPENDS pota_record_minmax_test)
+set_tests_properties(pota_record_minmax_test PROPERTIES DEPENDS pota_fake_wquant_test)
+set_tests_properties(pota_quantization_test PROPERTIES DEPENDS pota_record_minmax_test)

--- a/compiler/pota-quantization-value-test/test_record_minmax.sh
+++ b/compiler/pota-quantization-value-test/test_record_minmax.sh
@@ -60,9 +60,9 @@ while [ "$1" != "" ]; do
 
     # Run record-minmax
     "${RECORD_MINMAX_PATH}" \
-      "${TEST_RESULT_FILE}.fake_quantized.circle" \
-      "${TEST_RESULT_FILE}.input.h5" \
-      "${TEST_RESULT_FILE}.minmax_recorded.circle" 
+      --input_model "${TEST_RESULT_FILE}.fake_quantized.circle" \
+      --input_data "${TEST_RESULT_FILE}.input.h5" \
+      --output_model "${TEST_RESULT_FILE}.minmax_recorded.circle" 
 
     # Dump min/max values (circle-tensordump)
     "${CIRCLE_TENSORDUMP_PATH}" \


### PR DESCRIPTION
This enables tests with updated parameters of record-minmax

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to #2809 , Draft PR #3012