### PR TITLE
[onert] Add a function to check if any graph input is dynamic

### DIFF
--- a/runtime/onert/core/src/exec/ExecutorBase.cc
+++ b/runtime/onert/core/src/exec/ExecutorBase.cc
@@ -321,7 +321,7 @@ void ExecutorBase::handleDynamicInputTensor(ir::IOIndex io_ind, const IODescript
   }
 }
 
-bool has_dynamic_input(const std::vector<std::shared_ptr<onert::backend::ITensor>> &input_tensors)
+bool hasDynamicTensor(const std::vector<std::shared_ptr<onert::backend::ITensor>> &input_tensors)
 {
   for (auto &tensor : input_tensors)
   {

--- a/runtime/onert/core/src/exec/ExecutorBase.cc
+++ b/runtime/onert/core/src/exec/ExecutorBase.cc
@@ -321,5 +321,15 @@ void ExecutorBase::handleDynamicInputTensor(ir::IOIndex io_ind, const IODescript
   }
 }
 
+bool has_dynamic_input(const std::vector<std::shared_ptr<onert::backend::ITensor>> &input_tensors)
+{
+  for (auto &tensor : input_tensors)
+  {
+    if (tensor->is_dynamic())
+      return true;
+  }
+  return false;
+}
+
 } // namespace exec
 } // namespace onert

--- a/runtime/onert/core/src/exec/ExecutorBase.cc
+++ b/runtime/onert/core/src/exec/ExecutorBase.cc
@@ -321,9 +321,9 @@ void ExecutorBase::handleDynamicInputTensor(ir::IOIndex io_ind, const IODescript
   }
 }
 
-bool hasDynamicTensor(const std::vector<std::shared_ptr<onert::backend::ITensor>> &input_tensors)
+bool ExecutorBase::hasDynamicInput()
 {
-  for (auto &tensor : input_tensors)
+  for (auto &tensor : _input_tensors)
   {
     if (tensor->is_dynamic())
       return true;

--- a/runtime/onert/core/src/exec/ExecutorBase.h
+++ b/runtime/onert/core/src/exec/ExecutorBase.h
@@ -143,6 +143,12 @@ private:
   }
 
 protected:
+  /**
+   * @brief Returns @c true if any input tensor is dynamic; @c false if all are static tensors
+   */
+  bool hasDynamicInput();
+
+protected:
   ExecutionObservee _subject;
   std::shared_ptr<ir::OperationIndexMap<int64_t>> _indexed_ranks;
   std::unique_ptr<ir::LoweredGraph> _lowered_graph;
@@ -157,11 +163,6 @@ protected:
 private:
   void handleDynamicInputTensor(ir::IOIndex input_index, const IODescription &desc);
 };
-
-/**
- * @brief Returns @c true if any input tensor is dynamic; @c false if all are static tensors
- */
-bool hasDynamicTensor(const std::vector<std::shared_ptr<onert::backend::ITensor>> &input_tensors);
 
 } // namespace exec
 } // namespace onert

--- a/runtime/onert/core/src/exec/ExecutorBase.h
+++ b/runtime/onert/core/src/exec/ExecutorBase.h
@@ -161,7 +161,7 @@ private:
 /**
  * @brief Returns @c true if any input tensor is dynamic; @c false if all are static tensors
  */
-bool has_dynamic_input(const std::vector<std::shared_ptr<onert::backend::ITensor>> &input_tensors);
+bool hasDynamicTensor(const std::vector<std::shared_ptr<onert::backend::ITensor>> &input_tensors);
 
 } // namespace exec
 } // namespace onert

--- a/runtime/onert/core/src/exec/ExecutorBase.h
+++ b/runtime/onert/core/src/exec/ExecutorBase.h
@@ -158,6 +158,11 @@ private:
   void handleDynamicInputTensor(ir::IOIndex input_index, const IODescription &desc);
 };
 
+/**
+ * @brief Returns @c true if any input tensor is dynamic; @c false if all are static tensors
+ */
+bool has_dynamic_input(const std::vector<std::shared_ptr<onert::backend::ITensor>> &input_tensors);
+
 } // namespace exec
 } // namespace onert
 


### PR DESCRIPTION
For #2943
Related PR: #3044
draft: #2957

This adds a helper function to check if any graph input is dynamic.

FYI, To decide to run `DynamicShapeInferer`, the following is considered:

1. Are all tensors are static at compilation time?
2. Are all input tensors are static?

If both are true, `DynamicShapeInferer` will _not_ be run.

This function is to check the second case.

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>