### PR TITLE
[onert] Change FunctionSequence::SetDynamicTensorContext() signature

### DIFF
--- a/runtime/onert/core/src/exec/FunctionSequence.cc
+++ b/runtime/onert/core/src/exec/FunctionSequence.cc
@@ -29,21 +29,21 @@ void FunctionSequence::run()
 {
   if (_enable_dynamic_shape_inferer)
   {
-    if (_op_seq->size() != _functions.size())
+    if (_dynamic_tensor_ctx->op_seq->size() != _functions.size())
       throw std::runtime_error("operation and functions should be mapped one by one");
 
-    auto op_seq_iter = _op_seq->begin();
+    auto op_seq_iter = _dynamic_tensor_ctx->op_seq->begin();
     for (const auto &function : _functions)
     {
       // set shape of output and allocate memory when needed
-      auto &op = _operations->at(*op_seq_iter);
-      op.accept(*_dynamic_shape_inferer);
+      auto &op = _dynamic_tensor_ctx->operations->at(*op_seq_iter);
+      op.accept(*_dynamic_tensor_ctx->dynamic_shape_inferer);
 
       // run kernel
       function->run();
 
       // deallocate input tensors which is no longer used
-      _dynamic_tensor_manager->deallocInput(*op_seq_iter);
+      _dynamic_tensor_ctx->dynamic_tensor_manager->deallocInput(*op_seq_iter);
 
       op_seq_iter++;
     }


### PR DESCRIPTION
Parameters were packed into struct and name was changed to shorter form.

For #2943
Related comment: https://github.com/Samsung/ONE/pull/3042#discussion_r453600747
draft: #2957

Regarding https://github.com/Samsung/ONE/pull/3042#discussion_r453600747, I will try to go with simple solution time time. :-)

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>