### PR TITLE
[luci/service] Add SelectV2 operation

### DIFF
--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -1467,6 +1467,17 @@ public:
     return loco::NodeShape{t_shape};
   }
 
+  loco::NodeShape visit(const luci::CircleSelectV2 *node) final
+  {
+    auto c_shape = loco::shape_get(node->condition()).as<loco::TensorShape>();
+    auto t_shape = loco::shape_get(node->t()).as<loco::TensorShape>();
+    auto e_shape = loco::shape_get(node->e()).as<loco::TensorShape>();
+
+    // validate ability to broadcast shapes to each other
+    auto b_shape = broadcast_shape(broadcast_shape(c_shape, t_shape), e_shape);
+    return loco::NodeShape{b_shape};
+  }
+
   loco::NodeShape visit(const luci::CircleShape *node) final
   {
     auto input_shape = loco::shape_get(node->input()).as<loco::TensorShape>();

--- a/compiler/luci/service/src/CircleTypeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleTypeInferenceRule.cpp
@@ -382,6 +382,12 @@ struct TypeInferenceAlgorithm final : public luci::CircleNodeVisitor<loco::DataT
     return loco::dtype_get(node->t());
   }
 
+  loco::DataType visit(const luci::CircleSelectV2 *node) final
+  {
+    assert(loco::dtype_get(node->t()) == loco::dtype_get(node->e()));
+    return loco::dtype_get(node->t());
+  }
+
   loco::DataType visit(const luci::CircleShape *node) final { return node->out_type(); }
 
   loco::DataType visit(const luci::CircleSin *node) final { return loco::dtype_get(node->x()); }


### PR DESCRIPTION
Support for SelectV2 operation in Luci service.

ONE-DCO-1.0-Signed-off-by: Alexander Moiseev <a.moiseev@samsung.com>