### PR TITLE
[onert] Make exec::Job work for FunctionSequence (not IFunction)

### DIFF
--- a/runtime/onert/core/src/exec/Job.cc
+++ b/runtime/onert/core/src/exec/Job.cc
@@ -25,9 +25,9 @@ namespace onert
 namespace exec
 {
 
-Job::Job(uint32_t index, IFunction *fn) : _index{index}, _fn{fn} {}
+Job::Job(uint32_t index, FunctionSequence *fn_seq) : _index{index}, _fn_seq{fn_seq} {}
 
-void Job::run() { _fn->run(); }
+void Job::run() { _fn_seq->run(); }
 
 } // namespace exec
 } // namespace onert

--- a/runtime/onert/core/src/exec/Job.h
+++ b/runtime/onert/core/src/exec/Job.h
@@ -19,7 +19,7 @@
 
 #include <unordered_set>
 
-#include "exec/IFunction.h"
+#include "exec/FunctionSequence.h"
 #include "ir/Index.h"
 #include "ir/OperandIndexSequence.h"
 #include "backend/Backend.h"
@@ -36,11 +36,11 @@ public:
    * @brief Constructs a Job object
    *
    * @param index Operation index for this job
-   * @param fn compiled code to run this job
+   * @param fn_seq compiled code to run this job
    * @param inputs Input operand list
    * @param outputs Output operand list
    */
-  Job(uint32_t index, IFunction *fn);
+  Job(uint32_t index, FunctionSequence *fn_seq);
   /**
    * @brief Execute the compiled code
    */
@@ -56,11 +56,11 @@ public:
    *
    * @return Pointer of the function
    */
-  IFunction *fn() { return _fn; }
+  FunctionSequence *fn_seq() { return _fn_seq; }
 
 private:
   uint32_t _index;
-  IFunction *_fn;
+  FunctionSequence *_fn_seq;
 };
 
 } // namespace exec

--- a/runtime/onert/core/src/exec/ParallelExecutor.cc
+++ b/runtime/onert/core/src/exec/ParallelExecutor.cc
@@ -127,7 +127,7 @@ void ParallelExecutor::executeImpl()
       notify(job_index);
     };
 
-    _scheduler->assign(std::make_unique<HookFunction>(job->fn(), setup, teardown), backend);
+    _scheduler->assign(std::make_unique<HookFunction>(job->fn_seq(), setup, teardown), backend);
     _finished_jobs[job_index] = std::move(job);
   }
 


### PR DESCRIPTION
For #2943
draft: #2957

This makes `exec::Job` work for `FunctionSequence` (previously, `IFunction`).
All jobs currently run `FunctionSequence.run()`, and runing `IFunction.run()` seems general.

This is needed to enable calls like the following later:
```
job->fn_seq()->enableDynamicShapeInferer(true);
```
(Related PR: https://github.com/Samsung/ONE/pull/3042/files#diff-a01ffbfbfc137438970dd03eb52ae14eR98)

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>