### PR TITLE
[onert] Deallocate memory used by CustomKernel

### DIFF
--- a/runtime/onert/api/src/CustomKernel.cc
+++ b/runtime/onert/api/src/CustomKernel.cc
@@ -67,6 +67,15 @@ public:
 Kernel::Kernel(const nnfw_custom_eval evalFunction)
     : _params(), _userdata(nullptr), _userdata_size(0), _evalFunction(evalFunction)
 {
+  _params.inputs = _params.outputs = nullptr;
+}
+
+Kernel::~Kernel()
+{
+  if (_params.inputs)
+    delete[] _params.inputs;
+  if (_params.outputs)
+    delete[] _params.outputs;
 }
 
 void Kernel::configure(CustomKernelConfigParams &&inParams)

--- a/runtime/onert/api/src/CustomKernel.h
+++ b/runtime/onert/api/src/CustomKernel.h
@@ -35,6 +35,7 @@ class Kernel : public ::onert::exec::IFunction
 {
 public:
   explicit Kernel(nnfw_custom_eval evalFunction);
+  ~Kernel();
 
   nnfw_custom_kernel_params _params;
   char *_userdata;


### PR DESCRIPTION
This deallocates memory allocated for `_param.inputs` and `_param.outputs`.

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>