### PR TITLE
[benchmark] allocate time vector in constructor and cleanup header

### DIFF
--- a/runtime/libs/benchmark/include/benchmark/Phase.h
+++ b/runtime/libs/benchmark/include/benchmark/Phase.h
@@ -27,10 +27,7 @@ namespace benchmark
 
 struct Phase
 {
-  Phase(const std::string &t, uint32_t c) : tag(t), count(c)
-  {
-    // DO NOTHING
-  }
+  Phase(const std::string &t, uint32_t c) : tag(t), count(c) { time.reserve(count); }
 
   const std::string tag;
   uint32_t count;

--- a/runtime/libs/benchmark/src/Phases.cpp
+++ b/runtime/libs/benchmark/src/Phases.cpp
@@ -18,9 +18,8 @@
 #include "benchmark/Phases.h"
 #include "benchmark/Types.h"
 
-#include <thread>
-#include <chrono>
 #include <cassert>
+#include <chrono>
 #include <iostream>
 #include <sys/time.h>
 


### PR DESCRIPTION
- allocate time vector in constructor to avoid several allocation
- remove unused header and sort in alphabetical order

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>