### PR TITLE
[onert] Use std::vector for _interference_graph in WICPlanner

### DIFF
--- a/runtime/onert/core/src/backend/cpu_common/MemoryPlanner.cc
+++ b/runtime/onert/core/src/backend/cpu_common/MemoryPlanner.cc
@@ -121,13 +121,14 @@ void WICPlanner::claim(const ir::OperandIndex &ind, size_t size)
 {
   assert(size != 0);
 
-  _operands.insert({size, ind});
-  for (auto &live_operand : _live_operands)
+  _operands.emplace(size, ind);
+  _interference_graph[ind].insert(_interference_graph[ind].end(), _live_operands.cbegin(),
+                                  _live_operands.cend());
+  for (const auto &live_operand : _live_operands)
   {
-    _interference_graph[live_operand].insert(ind);
-    _interference_graph[ind].insert(live_operand);
+    _interference_graph[live_operand].emplace_back(ind);
   }
-  _live_operands.insert(ind);
+  _live_operands.emplace(ind);
 
   VERBOSE(WIC_PLANNER) << "claim(#" << ind.value() << "): [" << size << "sz]" << std::endl;
 }

--- a/runtime/onert/core/src/backend/cpu_common/MemoryPlanner.h
+++ b/runtime/onert/core/src/backend/cpu_common/MemoryPlanner.h
@@ -23,6 +23,7 @@
 #define __ONERT_BACKEND_CPU_COMMON_MEMORY_PLANNER_H__
 
 #include <map>
+#include <vector>
 #include <unordered_set>
 #include <memory>
 
@@ -147,7 +148,7 @@ private:
   uint32_t _capacity;
   MemoryPlans _mem_plans;
   std::unordered_set<ir::OperandIndex> _live_operands;
-  ir::OperandIndexMap<std::unordered_set<ir::OperandIndex>> _interference_graph;
+  ir::OperandIndexMap<std::vector<ir::OperandIndex>> _interference_graph;
   // Sort operands by descending order of size
   std::multimap<uint32_t, ir::OperandIndex, std::greater<uint32_t>> _operands;
 };


### PR DESCRIPTION
- This commit changes type of `_interference_graph` to `std::vector`
  - `std::vector` is more efficient and consumes less memory than `std::unordered_set`

ONE-DCO-1.0-Signed-off-by: JiHwan Yeo <jihwan.yeo@samsung.com>

---

Related : https://github.com/Samsung/ONE/issues/2994#issuecomment-656484128
From draft #3003