### PR TITLE
[common-artifacts] modify cmake HDF5 missing message

### DIFF
--- a/compiler/common-artifacts/CMakeLists.txt
+++ b/compiler/common-artifacts/CMakeLists.txt
@@ -43,7 +43,7 @@ add_custom_target(common_artifacts_python_deps ALL
 nnas_find_package(HDF5 QUIET)
 
 if(NOT HDF5_FOUND)
-  message("Couldn't find a package HDF5")
+  message(STATUS "Build common-artifacts: FAILED (missing HDF5)")
   return()
 endif(NOT HDF5_FOUND)
 


### PR DESCRIPTION
This commit modifies cmake message to clarify it

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>