### PR TITLE
[onert] Introduce registerDefaultInitializer function

### DIFF
--- a/runtime/onert/core/include/backend/IConstantInitializer.h
+++ b/runtime/onert/core/include/backend/IConstantInitializer.h
@@ -195,6 +195,12 @@ protected:
   virtual std::shared_ptr<ITensorBuilder> tensor_builder() const = 0;
 
 public:
+  virtual void registerDefaultInitializer(const ir::OperandIndex &index, const ir::Operand &obj)
+  {
+    registerPermuteInitializer(index, obj); // as default
+  }
+
+public:
   void registerCopyInitializer(const ir::OperandIndex &index, const ir::Operand &obj);
   void registerPermuteInitializer(const ir::OperandIndex &index, const ir::Operand &obj);
 

--- a/runtime/onert/core/src/backend/BackendContext.cc
+++ b/runtime/onert/core/src/backend/BackendContext.cc
@@ -44,7 +44,7 @@ void BackendContext::initConsts()
     const auto &obj = _graph->operands().at(ind);
     if (obj.isConstant() && !constant_initializer->exist(ind))
     {
-      constant_initializer->registerPermuteInitializer(ind, obj);
+      constant_initializer->registerDefaultInitializer(ind, obj);
     }
   }
 


### PR DESCRIPTION
Introduce registerDefaultInitializer function. In the future, cpu
backend will use it with registerExternalInitializer.

ONE-DCO-1.0-Signed-off-by: Yongseop Kim <yons.kim@samsung.com>