### PR TITLE
[onert] Introduce StaticTensorManager for cpu backend

### DIFF
--- a/runtime/onert/backend/cpu/StaticTensorManager.cc
+++ b/runtime/onert/backend/cpu/StaticTensorManager.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-#include "backend/cpu_common/StaticTensorManager.h"
+#include "StaticTensorManager.h"
+#include "Tensor.h"
 
 #include <util/logging.h>
 
@@ -22,31 +23,13 @@ namespace onert
 {
 namespace backend
 {
-namespace cpu_common
+namespace cpu
 {
 
-StaticTensorManager::StaticTensorManager(const std::shared_ptr<TensorRegistry> &reg)
-    : _const_mgr{new DynamicMemoryManager()}, _nonconst_mgr{new MemoryManager()}, _tensors{reg}
+StaticTensorManager::StaticTensorManager(const std::shared_ptr<cpu_common::TensorRegistry> &reg)
+    : _nonconst_mgr{new cpu_common::MemoryManager()}, _tensors{reg}
 {
   // DO NOTHING
-}
-
-void StaticTensorManager::allocateConsts(void)
-{
-  for (auto &pair : _tensors->managed_tensors())
-  {
-    const auto &ind = pair.first;
-    auto tensor = pair.second;
-    if (_as_constants[ind])
-    {
-      auto mem_alloc = _const_mgr->allocate(ind, tensor->total_size());
-      tensor->setBuffer(mem_alloc);
-      auto buffer = mem_alloc->base();
-      VERBOSE(CPU_COMMON_StaticTensorManager) << "CONSTANT TENSOR(#" << ind.value()
-                                              << "): " << static_cast<void *>(buffer)
-                                              << "size : " << tensor->total_size() << std::endl;
-    }
-  }
 }
 
 void StaticTensorManager::allocateNonconsts(void)
@@ -62,13 +45,11 @@ void StaticTensorManager::allocateNonconsts(void)
       auto *buffer = _nonconst_mgr->getBuffer(ind);
       tensor->setBuffer(buffer);
 
-      VERBOSE(CPU_COMMON_StaticTensorManager) << "TENSOR(#" << ind.value()
-                                              << "): " << static_cast<void *>(buffer) << std::endl;
+      VERBOSE(CPU_StaticTensorManager) << "TENSOR(#" << ind.value()
+                                       << "): " << static_cast<void *>(buffer) << std::endl;
     }
   }
 }
-
-void StaticTensorManager::deallocateConsts(void) { _const_mgr->deallocate(); }
 
 void StaticTensorManager::deallocateNonconsts(void) { _nonconst_mgr->deallocate(); }
 
@@ -76,18 +57,26 @@ void StaticTensorManager::buildTensor(const ir::OperandIndex &ind,
                                       const ir::OperandInfo &tensor_info, ir::Layout backend_layout,
                                       bool as_const)
 {
-  assert(!_tensors->getManagedTensor(ind));
-  auto tensor = std::make_shared<Tensor>(tensor_info, backend_layout);
-  _tensors->setManagedTensor(ind, tensor);
+  assert(!_tensors->getITensor(ind));
+  if (as_const)
+  {
+    auto tensor = std::make_shared<ExternalTensor>(tensor_info, backend_layout);
+    _tensors->setExternalTensor(ind, tensor);
+  }
+  else
+  {
+    auto tensor = std::make_shared<Tensor>(tensor_info, backend_layout);
+    _tensors->setManagedTensor(ind, tensor);
+  }
   _as_constants[ind] = as_const;
 }
 
 void StaticTensorManager::claimPlan(const ir::OperandIndex &ind, uint32_t size)
 {
-  assert(_tensors->getManagedTensor(ind));
+  assert(_tensors->getITensor(ind));
 
   // This method is called only when a tensor has proper shape
-  assert(!_tensors->getManagedTensor(ind)->is_dynamic());
+  assert(!_tensors->getITensor(ind)->is_dynamic());
 
   if (!_as_constants[ind])
     _nonconst_mgr->claimPlan(ind, size);
@@ -95,10 +84,10 @@ void StaticTensorManager::claimPlan(const ir::OperandIndex &ind, uint32_t size)
 
 void StaticTensorManager::releasePlan(const ir::OperandIndex &ind)
 {
-  assert(_tensors->getManagedTensor(ind));
+  assert(_tensors->getITensor(ind));
 
   // This method is called only when a tensor has proper shape
-  assert(!_tensors->getManagedTensor(ind)->is_dynamic());
+  assert(!_tensors->getITensor(ind)->is_dynamic());
 
   if (!_as_constants[ind])
     _nonconst_mgr->releasePlan(ind);
@@ -108,8 +97,10 @@ void StaticTensorManager::iterate(const std::function<void(const ir::OperandInde
 {
   for (const auto &it : _tensors->managed_tensors())
     fn(it.first);
+  for (const auto &it : _tensors->external_tensors())
+    fn(it.first);
 }
 
-} // namespace cpu_common
+} // namespace cpu
 } // namespace backend
 } // namespace onert

--- a/runtime/onert/backend/cpu/StaticTensorManager.h
+++ b/runtime/onert/backend/cpu/StaticTensorManager.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_BACKEND_CPU_STATICTENSOR_MANAGER_H__
+#define __ONERT_BACKEND_CPU_STATICTENSOR_MANAGER_H__
+
+#include "backend/cpu_common/MemoryManager.h"
+#include "backend/cpu_common/TensorRegistry.h"
+#include "backend/ITensorManager.h"
+#include "ir/OperandIndexMap.h"
+#include "ir/OperandInfo.h"
+
+namespace onert
+{
+namespace backend
+{
+namespace cpu
+{
+
+class StaticTensorManager : public backend::ITensorManager
+{
+public:
+  StaticTensorManager(const std::shared_ptr<cpu_common::TensorRegistry> &reg);
+  virtual ~StaticTensorManager() = default;
+
+  void allocateNonconsts(void);
+  void deallocateNonconsts(void);
+
+  void buildTensor(const ir::OperandIndex &ind, const ir::OperandInfo &tensor_info,
+                   ir::Layout backend_layout, bool as_const);
+
+  void claimPlan(const ir::OperandIndex &ind, uint32_t size);
+  void releasePlan(const ir::OperandIndex &ind);
+
+  void iterate(const std::function<void(const ir::OperandIndex &)> &fn);
+
+private:
+  std::unique_ptr<cpu_common::MemoryManager> _nonconst_mgr;
+  const std::shared_ptr<cpu_common::TensorRegistry> _tensors;
+  ir::OperandIndexMap<bool> _as_constants;
+};
+
+} // namespace cpu
+} // namespace backend
+} // namespace onert
+
+#endif // __ONERT_BACKEND_CPU_STATICTENSOR_MANAGER_H__


### PR DESCRIPTION
Introduce StaticTensorManager for cpu backend. Compared to
cpu_common::StaticTensorManager, cpu::StaticTensorManager doesn't use
const tensor manager because it handles const tensors as ExternalTensor.
**For now, it is not used but will be soon.**

ONE-DCO-1.0-Signed-off-by: Yongseop Kim <yons.kim@samsung.com>