### PR TITLE
[luci-interpreter]Add SpaceToDepth kernels on luci-interpreter

### DIFF
--- a/compiler/luci-interpreter/src/core/KernelParams.h
+++ b/compiler/luci-interpreter/src/core/KernelParams.h
@@ -109,6 +109,11 @@ struct ReducerParams
   bool keep_dims;
 };
 
+struct SpaceToDepthParams
+{
+  int block_size;
+};
+
 struct SoftmaxParams
 {
   float beta;

--- a/compiler/luci-interpreter/src/kernels/CMakeLists.txt
+++ b/compiler/luci-interpreter/src/kernels/CMakeLists.txt
@@ -42,6 +42,8 @@ set(SOURCES
     Reshape.cpp
     Softmax.h
     Softmax.cpp
+    SpaceToDepth.h
+    SpaceToDepth.cpp
     Split.h
     Split.cpp
     StridedSlice.h
@@ -88,6 +90,7 @@ set(TEST_SOURCES
     Pad.test.cpp
     Reshape.test.cpp
     Softmax.test.cpp
+    SpaceToDepth.test.cpp
     Split.test.cpp
     StridedSlice.test.cpp
     Transpose.test.cpp

--- a/compiler/luci-interpreter/src/kernels/SpaceToDepth.cpp
+++ b/compiler/luci-interpreter/src/kernels/SpaceToDepth.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "SpaceToDepth.h"
+#include "Utils.h"
+#include <tensorflow/lite/kernels/internal/optimized/optimized_ops.h>
+
+namespace luci_interpreter
+{
+namespace kernels
+{
+
+SpaceToDepth::SpaceToDepth(const Tensor *input, Tensor *output, const SpaceToDepthParams &params)
+    : KernelWithParams<SpaceToDepthParams>(params), _input(input), _output(output)
+{
+}
+
+void SpaceToDepth::configure()
+{
+  assert(_input->shape().num_dims() == 4);
+  assert(_output->element_type() == DataType::FLOAT32 || _output->element_type() == DataType::U8 ||
+         _output->element_type() == DataType::S8 || _output->element_type() == DataType::S32 ||
+         _output->element_type() == DataType::S64);
+  assert(_input->element_type() == _output->element_type());
+
+  const int block_size = params().block_size;
+  const int input_height = _input->shape().dim(1);
+  const int input_width = _input->shape().dim(2);
+  int output_height = input_height / block_size;
+  int output_width = input_width / block_size;
+
+  assert(input_height == output_height * block_size);
+  assert(input_width == output_width * block_size);
+
+  Shape output_shape(4);
+  output_shape.dim(0) = _input->shape().dim(0);
+  output_shape.dim(1) = output_height;
+  output_shape.dim(2) = output_width;
+  output_shape.dim(3) = _input->shape().dim(3) * block_size * block_size;
+
+  _output->resize(output_shape);
+}
+
+void SpaceToDepth::execute() const
+{
+  tflite::SpaceToDepthParams op_params{};
+  op_params.block_size = params().block_size;
+  switch (_input->element_type())
+  {
+    case DataType::FLOAT32:
+      tflite::optimized_ops::SpaceToDepth(op_params, getTensorShape(_input),
+                                          getTensorData<float>(_input), getTensorShape(_output),
+                                          getTensorData<float>(_output));
+      break;
+    case DataType::U8:
+      tflite::optimized_ops::SpaceToDepth(op_params, getTensorShape(_input),
+                                          getTensorData<uint8_t>(_input), getTensorShape(_output),
+                                          getTensorData<uint8_t>(_output));
+      break;
+    default:
+      throw std::runtime_error("Unsupported type.");
+  }
+}
+
+} // namespace kernels
+} // namespace luci_interpreter

--- a/compiler/luci-interpreter/src/kernels/SpaceToDepth.cpp
+++ b/compiler/luci-interpreter/src/kernels/SpaceToDepth.cpp
@@ -37,10 +37,10 @@ void SpaceToDepth::configure()
   assert(_input->element_type() == _output->element_type());
 
   const int block_size = params().block_size;
-  const int input_height = _input->shape().dim(1);
-  const int input_width = _input->shape().dim(2);
-  int output_height = input_height / block_size;
-  int output_width = input_width / block_size;
+  const int32_t input_height = _input->shape().dim(1);
+  const int32_t input_width = _input->shape().dim(2);
+  int32_t output_height = input_height / block_size;
+  int32_t output_width = input_width / block_size;
 
   assert(input_height == output_height * block_size);
   assert(input_width == output_width * block_size);

--- a/compiler/luci-interpreter/src/kernels/SpaceToDepth.h
+++ b/compiler/luci-interpreter/src/kernels/SpaceToDepth.h
@@ -20,7 +20,6 @@
 #include "core/Kernel.h"
 #include "core/KernelParams.h"
 
-#include <cstdint>
 #include <vector>
 
 namespace luci_interpreter

--- a/compiler/luci-interpreter/src/kernels/SpaceToDepth.h
+++ b/compiler/luci-interpreter/src/kernels/SpaceToDepth.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef LUCI_INTERPRETER_KERNELS_SPACETODEPTH_H
+#define LUCI_INTERPRETER_KERNELS_SPACETODEPTH_H
+
+#include "core/Kernel.h"
+#include "core/KernelParams.h"
+
+#include <cstdint>
+#include <vector>
+
+namespace luci_interpreter
+{
+namespace kernels
+{
+
+class SpaceToDepth : public KernelWithParams<SpaceToDepthParams>
+{
+public:
+  SpaceToDepth(const Tensor *input, Tensor *output, const SpaceToDepthParams &params);
+
+  std::vector<const Tensor *> getInputTensors() const override { return {_input}; }
+  std::vector<Tensor *> getOutputTensors() const override { return {_output}; }
+
+  void configure() override;
+  void execute() const override;
+
+private:
+  const Tensor *const _input;
+  Tensor *const _output;
+};
+
+} // namespace kernels
+} // namespace luci_interpreter
+
+#endif // LUCI_INTERPRETER_KERNELS_SPACETODEPTH_H

--- a/compiler/luci-interpreter/src/kernels/SpaceToDepth.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/SpaceToDepth.test.cpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "kernels/SpaceToDepth.h"
+#include "kernels/TestUtils.h"
+
+namespace luci_interpreter
+{
+namespace kernels
+{
+namespace
+{
+
+using namespace testing;
+
+TEST(SpaceToDepthTest, Float)
+{
+  std::vector<float> input_data{1.4, 2.3, 3.2, 4.1, 5.4, 6.3, 7.2, 8.1};
+  Shape input_shape{1, 2, 2, 2};
+  Tensor input_tensor{DataType::FLOAT32, input_shape, {{}, {}}, ""};
+  input_tensor.writeData(input_data.data(), input_data.size() * sizeof(float));
+  std::vector<float> output_data{1.4, 2.3, 3.2, 4.1, 5.4, 6.3, 7.2, 8.1};
+  std::vector<int32_t> output_shape{1, 1, 1, 8};
+  Tensor output_tensor = makeOutputTensor(DataType::FLOAT32);
+
+  SpaceToDepthParams params{};
+  params.block_size = 2;
+
+  SpaceToDepth kernel(&input_tensor, &output_tensor, params);
+  kernel.configure();
+  kernel.execute();
+
+  EXPECT_THAT(extractTensorData<float>(output_tensor),
+              ElementsAreArray(ArrayFloatNear(output_data)));
+  EXPECT_THAT(extractTensorShape(output_tensor), ::testing::ElementsAreArray(output_shape));
+}
+
+TEST(SpaceToDepthTest, Uint8)
+{
+  std::pair<float, int32_t> quant_params = quantizationParams<uint8_t>(-12.7f, 12.8f);
+  std::vector<uint8_t> input_data = quantize<uint8_t>({1.4, 2.3, 3.2, 4.1, 5.4, 6.3, 7.2, 8.1},
+                                                      quant_params.first, quant_params.second);
+  Shape input_shape{1, 2, 2, 2};
+  Tensor input_tensor{DataType::U8, input_shape, {{quant_params.first}, {quant_params.second}}, ""};
+  input_tensor.writeData(input_data.data(), input_data.size() * sizeof(uint8_t));
+  std::vector<float> output_data{1.4, 2.3, 3.2, 4.1, 5.4, 6.3, 7.2, 8.1};
+  std::vector<int32_t> output_shape{1, 1, 1, 8};
+  Tensor output_tensor = makeOutputTensor(DataType::U8, quant_params.first, quant_params.second);
+
+  SpaceToDepthParams params{};
+  params.block_size = 2;
+
+  SpaceToDepth kernel(&input_tensor, &output_tensor, params);
+  kernel.configure();
+  kernel.execute();
+
+  EXPECT_THAT(dequantize(extractTensorData<uint8_t>(output_tensor), output_tensor.scale(),
+                         output_tensor.zero_point()),
+              ElementsAreArray(ArrayFloatNear(output_data)));
+  EXPECT_THAT(extractTensorShape(output_tensor), ::testing::ElementsAreArray(output_shape));
+}
+
+} // namespace
+} // namespace kernels
+} // namespace luci_interpreter

--- a/compiler/luci-interpreter/src/loader/KernelBuilder.cpp
+++ b/compiler/luci-interpreter/src/loader/KernelBuilder.cpp
@@ -36,6 +36,7 @@
 #include "kernels/Pad.h"
 #include "kernels/Reshape.h"
 #include "kernels/Softmax.h"
+#include "kernels/SpaceToDepth.h"
 #include "kernels/Split.h"
 #include "kernels/StridedSlice.h"
 #include "kernels/Unpack.h"
@@ -411,6 +412,19 @@ std::unique_ptr<Kernel> KernelBuilder::visit(const luci::CircleSoftmax *node)
   params.beta = node->beta();
 
   return std::make_unique<kernels::Softmax>(input, output, params);
+}
+
+std::unique_ptr<Kernel> KernelBuilder::visit(const luci::CircleSpaceToDepth *node)
+{
+  assert(node->arity() == 1);
+  const Tensor *input = getInputTensor(node->input());
+
+  Tensor *output = getOutputTensor(node);
+
+  SpaceToDepthParams params{};
+  params.block_size = node->block_size();
+
+  return std::make_unique<kernels::SpaceToDepth>(input, output, params);
 }
 
 std::unique_ptr<Kernel> KernelBuilder::visit(const luci::CircleSplit *node)

--- a/compiler/luci-interpreter/src/loader/KernelBuilder.h
+++ b/compiler/luci-interpreter/src/loader/KernelBuilder.h
@@ -62,6 +62,7 @@ public:
   std::unique_ptr<Kernel> visit(const luci::CirclePad *node) override;
   std::unique_ptr<Kernel> visit(const luci::CircleReshape *node) override;
   std::unique_ptr<Kernel> visit(const luci::CircleSoftmax *node) override;
+  std::unique_ptr<Kernel> visit(const luci::CircleSpaceToDepth *node) override;
   std::unique_ptr<Kernel> visit(const luci::CircleSplit *node) override;
   std::unique_ptr<Kernel> visit(const luci::CircleStridedSlice *node) override;
   std::unique_ptr<Kernel> visit(const luci::CircleTranspose *node) override;


### PR DESCRIPTION
This commit add `SpaceToDepth` operation kernels on luci-interpreter.

ONE-DCO-1.0-Signed-off-by: KiDeuk Bang <rrstrous@nate.com>