### PR TITLE
[one-cmds] add mode option to one-quantize

### DIFF
--- a/compiler/one-cmds/one-quantize
+++ b/compiler/one-cmds/one-quantize
@@ -27,6 +27,7 @@ usage()
   echo "    --granularity     Quantize granularity (supported: layer, default=layer)"
   echo "    --min_percentile  Minimum percentile (0.0~100.0, default=1.0)"
   echo "    --max_percentile  Maximum percentile (0.0~100.0, default=99.0)"
+  echo "    --mode            Record mode (supported: percentile/moving_average, default=percentile)"
   echo "    --input_path <path/to/input/circle>"
   echo "    --input_data <path/to/input/data>"
   echo "    --output_path <path/to/output/circle>"
@@ -38,6 +39,7 @@ QUANTIZED_DTYPE=uint8
 GRANULARITY=layer
 MIN_PERCENTILE=1
 MAX_PERCENTILE=99
+MODE=percentile
 
 # Parse command-line arguments
 #
@@ -67,6 +69,10 @@ while [ "$#" -ne 0 ]; do
       ;;
     '--max_percentile')
       MAX_PERCENTILE="$2"
+      shift 2
+      ;;
+    '--mode')
+      MODE="$2"
       shift 2
       ;;
 
@@ -127,6 +133,7 @@ echo "${DRIVER_PATH}/record-minmax" \
 --input_model "${TMPDIR}/${MODEL_NAME}.1.circle" \
 --input_data "${INPUT_DATA}" \
 --min_percentile ${MIN_PERCENTILE} --max_percentile ${MAX_PERCENTILE} \
+--mode "${MODE}" \
 --output_model "${TMPDIR}/${MODEL_NAME}.2.circle" >> "${OUTPUT_PATH}.log" 2>&1
 echo " " >> "${OUTPUT_PATH}.log"
 
@@ -134,6 +141,7 @@ echo " " >> "${OUTPUT_PATH}.log"
 --input_model "${TMPDIR}/${MODEL_NAME}.1.circle" \
 --input_data "${INPUT_DATA}" \
 --min_percentile ${MIN_PERCENTILE} --max_percentile ${MAX_PERCENTILE} \
+--mode "${MODE}" \
 --output_model "${TMPDIR}/${MODEL_NAME}.2.circle" >> "${OUTPUT_PATH}.log" 2>&1
 
 echo " " >> "${OUTPUT_PATH}.log"


### PR DESCRIPTION
This will add --mode option to one-quantize for record-minmax tool

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>