### PR TITLE
[onert] Fix CustomKernel to access non const tensor memory at runtime

### DIFF
--- a/runtime/onert/api/src/CustomKernel.cc
+++ b/runtime/onert/api/src/CustomKernel.cc
@@ -65,17 +65,8 @@ public:
 };
 
 Kernel::Kernel(const nnfw_custom_eval evalFunction)
-    : _params(), _userdata(nullptr), _userdata_size(0), _evalFunction(evalFunction)
+    : _in_params(), _userdata(nullptr), _userdata_size(0), _evalFunction(evalFunction)
 {
-  _params.inputs = _params.outputs = nullptr;
-}
-
-Kernel::~Kernel()
-{
-  if (_params.inputs)
-    delete[] _params.inputs;
-  if (_params.outputs)
-    delete[] _params.outputs;
 }
 
 void Kernel::configure(CustomKernelConfigParams &&inParams)
@@ -83,24 +74,40 @@ void Kernel::configure(CustomKernelConfigParams &&inParams)
   _userdata = inParams.userdata;
   _userdata_size = inParams.userdata_size;
 
-  _params.ninputs = inParams.input_allocations.size();
-  _params.inputs = new nnfw_operand[_params.ninputs];
-  for (size_t i = 0; i < _params.ninputs; ++i)
-  {
-    _params.inputs[i] =
-        APIConverter::convertOperand(inParams.input_allocations[i], inParams.input_types[i]);
-  }
-
-  _params.noutputs = inParams.output_allocations.size();
-  _params.outputs = new nnfw_operand[_params.noutputs];
-  for (size_t i = 0; i < _params.noutputs; ++i)
-  {
-    _params.outputs[i] =
-        APIConverter::convertOperand(inParams.output_allocations[i], inParams.output_types[i]);
-  }
+  _in_params = std::move(inParams);
 }
 
-void Kernel::run() { _evalFunction(&_params, _userdata, _userdata_size); }
+void Kernel::run()
+{
+  nnfw_custom_kernel_params params;
+
+  // set input tensor buffer and types
+  params.ninputs = _in_params.input_tensors.size();
+  params.inputs = new nnfw_operand[params.ninputs];
+
+  for (size_t i = 0; i < params.ninputs; ++i)
+  {
+    auto *buf = _in_params.input_tensors[i]->buffer();
+    assert(buf);
+    params.inputs[i] = APIConverter::convertOperand(buf, _in_params.input_types[i]);
+  }
+
+  // set output tensor buffer and types
+  params.noutputs = _in_params.output_tensors.size();
+  params.outputs = new nnfw_operand[params.noutputs];
+
+  for (size_t i = 0; i < params.noutputs; ++i)
+  {
+    auto *buf = _in_params.output_tensors[i]->buffer();
+    assert(buf);
+    params.outputs[i] = APIConverter::convertOperand(buf, _in_params.output_types[i]);
+  }
+
+  _evalFunction(&params, _userdata, _userdata_size);
+
+  delete[] params.inputs;
+  delete[] params.outputs;
+}
 
 } // namespace custom
 } // namespace frontend

--- a/runtime/onert/api/src/CustomKernel.h
+++ b/runtime/onert/api/src/CustomKernel.h
@@ -35,9 +35,9 @@ class Kernel : public ::onert::exec::IFunction
 {
 public:
   explicit Kernel(nnfw_custom_eval evalFunction);
-  ~Kernel();
 
-  nnfw_custom_kernel_params _params;
+  backend::custom::CustomKernelConfigParams _in_params;
+
   char *_userdata;
   size_t _userdata_size;
 

--- a/runtime/onert/backend/cpu/KernelGenerator.cc
+++ b/runtime/onert/backend/cpu/KernelGenerator.cc
@@ -603,21 +603,22 @@ void KernelGenerator::visit(const ir::operation::Custom &node)
   };
 
   auto fill_op_info = [&](const ir::OperandIndexSequence &opSeq,
-                          std::vector<custom::TypeInfo> &types, std::vector<void *> &allocs) {
+                          std::vector<custom::TypeInfo> &types,
+                          std::vector<std::shared_ptr<IPortableTensor>> &allocs) {
     for (auto &idx : opSeq)
     {
       const auto &operand = _ctx.at(idx);
       // TODO make sure using `_current_op_seq_layout` is correct for custom operations
       types.emplace_back(get_type_info(operand));
-      auto in_alloc = _tensor_builder->portableAt(idx)->buffer();
+      auto in_alloc = _tensor_builder->portableAt(idx);
       allocs.emplace_back(in_alloc);
     }
   };
 
   backend::custom::CustomKernelConfigParams params{};
 
-  fill_op_info(node.getInputs(), params.input_types, params.input_allocations);
-  fill_op_info(node.getOutputs(), params.output_types, params.output_allocations);
+  fill_op_info(node.getInputs(), params.input_types, params.input_tensors);
+  fill_op_info(node.getOutputs(), params.output_types, params.output_tensors);
 
   params.userdata = node.userdata().data;
   params.userdata_size = node.userdata().size;

--- a/runtime/onert/core/include/backend/CustomKernelBuilder.h
+++ b/runtime/onert/core/include/backend/CustomKernelBuilder.h
@@ -17,6 +17,7 @@
 #ifndef __ONERT_BACKEND_CUSTOM_KERNEL_BUILDER_H__
 #define __ONERT_BACKEND_CUSTOM_KERNEL_BUILDER_H__
 
+#include "backend/IPortableTensor.h"
 #include "misc/tensor/Shape.h"
 #include "ir/DataType.h"
 
@@ -50,10 +51,10 @@ struct TypeInfo
 
 struct CustomKernelConfigParams
 {
-  std::vector<void *> input_allocations;
+  std::vector<std::shared_ptr<backend::IPortableTensor>> input_tensors;
   std::vector<TypeInfo> input_types;
 
-  std::vector<void *> output_allocations;
+  std::vector<std::shared_ptr<backend::IPortableTensor>> output_tensors;
   std::vector<TypeInfo> output_types;
 
   char *userdata;


### PR DESCRIPTION
This fixes `CustomKernel` to access non const tensor memory not at compile time but at runtime.

Previously `CustomKernel` stores the address of tensor memory at _compile_ time (in `configure()`), which is not quite right in case of dynamic tensor since the real address of dynamic tensor _cannot be know at compile time_.

So, this change stores `IPortableTensor` and access the memory at `run()` (_run-time_).

Related to #2525 
    - when static tensor allocation is delayed at the beginning of nnfw_run(), `CustomKernel` fails because it access address at compile time.

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>