### PR TITLE
[record-minmax] Use batch to compute moving avg

### DIFF
--- a/compiler/record-minmax/src/RecordMinMax.cpp
+++ b/compiler/record-minmax/src/RecordMinMax.cpp
@@ -153,8 +153,8 @@ void RecordMinMax::profileData(const std::string &mode, const std::string &input
     }
     else if (mode == "moving_average")
     {
-      min = getMovingAverage(minmax.min_vector, 0.9);
-      max = getMovingAverage(minmax.max_vector, 0.9);
+      min = getMovingAverage(minmax.min_vector, 0.9, 16, true);
+      max = getMovingAverage(minmax.max_vector, 0.9, 16, false);
     }
     assert(mode == "percentile" || mode == "moving_average");
     auto quantparam = std::make_unique<luci::CircleQuantParam>();


### PR DESCRIPTION
This uses batch to compute moving avg

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>