### PR TITLE
[onert] Remove FunctionSequenceForDynamicTensor

### DIFF
--- a/runtime/onert/backend/acl_cl/KernelGenerator.cc
+++ b/runtime/onert/backend/acl_cl/KernelGenerator.cc
@@ -58,6 +58,8 @@ void KernelGenerator::visit(const ir::OpSequence &op_seq)
   //      (all derivatives have the same implementation for this)
   assert(!_return_fn_seq);
   _return_fn_seq = std::make_unique<exec::FunctionSequence>();
+  _return_fn_seq->enableDynamicShapeInferer(false);
+
   _current_op_seq_layout = op_seq.getLayout();
   for (const auto &operation_idx : op_seq.operations())
   {

--- a/runtime/onert/backend/acl_neon/KernelGenerator.cc
+++ b/runtime/onert/backend/acl_neon/KernelGenerator.cc
@@ -58,6 +58,8 @@ void KernelGenerator::visit(const ir::OpSequence &op_seq)
   //      (all derivatives have the same implementation for this)
   assert(!_return_fn_seq);
   _return_fn_seq = std::make_unique<exec::FunctionSequence>();
+  _return_fn_seq->enableDynamicShapeInferer(false);
+
   _current_op_seq_layout = op_seq.getLayout();
   for (const auto &operation_idx : op_seq.operations())
   {

--- a/runtime/onert/core/include/exec/FunctionSequence.h
+++ b/runtime/onert/core/include/exec/FunctionSequence.h
@@ -18,6 +18,7 @@
 #define __ONERT_EXEC_FUNCTION_SEQUENCE_H__
 
 #include <memory>
+#include <cassert>
 #include <vector>
 #include <functional>
 
@@ -92,47 +93,27 @@ public: // methods related to dynamic tensor
     _dynamic_tensor_ctx = dynamic_tensor_ctx;
   }
 
+  std::shared_ptr<DynamicTensorCtx> &dynamic_tensor_ctx() { return _dynamic_tensor_ctx; }
+
   /**
-   * @brief Call this function if this FunctionSequence handles dynamic tensors.
-   * @note When dynamic tensors are handled, enableDynamicShapeInferer(true) must be called before
-   *       run(). If not called, run() assumes that all tensors are static.
+   * @brief Call this function by passing @c true if this FunctionSequence handles dynamic tensors
+   *        and should run DynamicShapeInferer. This function can be called multiple times and
+   *        if @c false is passed during multiple calls, DynamicShapeInfere will not be run.
+   * @note This must be called before run(). If not called, run() assumes that all tensors are
+   *       dynamic and DynamicShapeInferer will be run.
    */
-  void enableDynamicShapeInferer(bool enable) { _enable_dynamic_shape_inferer = enable; }
+  void enableDynamicShapeInferer(bool enable)
+  {
+    _enable_dynamic_shape_inferer = _enable_dynamic_shape_inferer && enable;
+  }
 
 protected:
   std::vector<std::unique_ptr<IFunction>> _functions;
 
-protected: // context to run this sequence when this sequence may handle dynamic tensors
-  bool _enable_dynamic_shape_inferer = false;
+protected:
+  bool _enable_dynamic_shape_inferer = true;
+
   std::shared_ptr<DynamicTensorCtx> _dynamic_tensor_ctx = nullptr;
-};
-
-//
-// TODO Deprecate this
-//
-/**
- * @brief Function sequence used for backend that supports dynamic tensor
- *        Such backend cannot use class FunctionSequence but use this class
- */
-class FunctionSequenceForDynamicBackend : public FunctionSequence
-{
-public:
-  FunctionSequenceForDynamicBackend(const ir::OpSequence &op_seq, const ir::Operations &operations,
-                                    std::unique_ptr<DynamicShapeInferer> dyn_shape_inferer,
-                                    backend::IDynamicTensorManager *dyn_tensor_manager)
-      : _op_seq(op_seq), _operations_ctx(operations),
-        _dyn_shape_inferer(std::move(dyn_shape_inferer)), _dyn_tensor_manager(dyn_tensor_manager)
-  { /* empty */
-  }
-
-  void run() override;
-
-private:
-  const ir::OpSequence &_op_seq;
-  const ir::Operations &_operations_ctx;
-  /// @brief shape inferer at execution time
-  std::unique_ptr<DynamicShapeInferer> _dyn_shape_inferer;
-  backend::IDynamicTensorManager *_dyn_tensor_manager;
 };
 
 } // namespace exec

--- a/runtime/onert/core/src/backend/controlflow/KernelGenerator.cc
+++ b/runtime/onert/core/src/backend/controlflow/KernelGenerator.cc
@@ -47,12 +47,23 @@ void KernelGenerator::visit(const ir::OpSequence &op_seq)
   assert(_tensor_builder->tensorRegistry());
 
   auto dyn_tensor_manager = _tensor_builder->dynamicTensorManager();
-  auto dyn_shape_inferer = std::make_unique<exec::DynamicInferer>(
+  auto dyn_shape_inferer = std::make_unique<exec::DynamicShapeInferer>(
       _graph.operands(), dyn_tensor_manager, _tensor_builder->tensorRegistry());
 
-  // TODO Always returning FunctionSequenceForDynamicBackend may cause performance issue
-  _return_fn_seq = std::make_unique<exec::FunctionSequenceForDynamicBackend>(
-      op_seq, _graph.operations(), std::move(dyn_shape_inferer), dyn_tensor_manager);
+  _return_fn_seq = std::make_unique<exec::FunctionSequence>();
+
+  // Prepare to handle dynamic tensors later
+  auto dyn_ctx = std::make_shared<exec::FunctionSequence::DynamicTensorCtx>();
+  {
+    dyn_ctx->op_seq = &op_seq;
+    dyn_ctx->operations = &_graph.operations();
+    dyn_ctx->dynamic_shape_inferer = std::move(dyn_shape_inferer);
+    dyn_ctx->tensor_registry = _tensor_builder->tensorRegistry();
+    dyn_ctx->dynamic_tensor_manager = _tensor_builder->dynamicTensorManager();
+
+    _return_fn_seq->dynamic_tensor_ctx(dyn_ctx);
+  }
+  _return_fn_seq->enableDynamicShapeInferer(true);
 
   for (const auto &op_idx : op_seq.operations())
   {

--- a/runtime/onert/core/src/exec/DataflowExecutor.cc
+++ b/runtime/onert/core/src/exec/DataflowExecutor.cc
@@ -126,6 +126,8 @@ void DataflowExecutor::executeImpl()
 {
   assert(noWaitingJobs());
 
+  bool dynamic_input_exists = hasDynamicInput();
+
   // Execution setup
   _waiting_jobs.swap(_finished_jobs); // Move finished jobs to waiting jobs
 
@@ -153,6 +155,10 @@ void DataflowExecutor::executeImpl()
         _lowered_graph->getLowerInfo()->op_seq.at(op_seq_index)->backend();
 
     _subject.notifyJobBegin(this, op_seq, backend);
+
+    // check if FunctionSequence needs to handle dynamic tensor
+    bool handle_dynamic_tensor = op_seq->has_dynamic_tensor() || dynamic_input_exists;
+    job->fn_seq()->enableDynamicShapeInferer(handle_dynamic_tensor);
 
     job->run();
 

--- a/runtime/onert/core/src/exec/LinearExecutor.cc
+++ b/runtime/onert/core/src/exec/LinearExecutor.cc
@@ -49,7 +49,13 @@ void LinearExecutor::executeImpl()
     ruy::profiler::ScopeLabel label(seq_to_label(op_seq, _graph.operations()));
 #endif
     _subject.notifyJobBegin(this, op_seq, backend);
-    code.fn_seq->run();
+
+    auto &fn_seq = code.fn_seq;
+    bool handle_dynamic_tensor = op_seq->has_dynamic_tensor() || hasDynamicInput();
+
+    fn_seq->enableDynamicShapeInferer(handle_dynamic_tensor);
+    fn_seq->run();
+
     _subject.notifyJobEnd(this, op_seq, backend);
   }
   _subject.notifyModelEnd(this);


### PR DESCRIPTION
This PR removes `FunctionSequenceForDynamicTensor` and make `FunctionSequence` run `DynamicShapeInferer` when needed.

For #2943
draft: #2957

What's been changed to remove it is:
1. `KernelGenerator` calls `FunctionSequence::enableDynamicShapeInferer(...)`
   - if backend support dynamic shape inferer, `enableDynamicShapeInferer(true)` is called
      - CPU, control flow backend
   - if backend does not support dynamic shape inferer, `enableDynamicShapeInferer(false)` is called
      - ACL backend
2. `FunctionSequence` has a vector of `IFunction` element and some of `IFunction` could be `FunctionSequence` objects. 
   - for example, in ACL, `AvgPool` IFunction is actually `FunctionSequence` object.
   - in this case, propagate `enableDynamicShapeInferer(...)` to its elements.
3. `Executor` checks two status
   - status
      - Was dynamic tensor found during compilation while running `StaticShapeInferer`?
      - Is graph input dynamic? (`nnfw_set_input_tensorinfo(..)` makes input tensor dynamic)
   - if so, call `enableDynamicShapeInferer(true)`
   - if not, call `enableDynamicShapeInferer(false)` 

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>
