### PR TITLE
[luci-value-test] Use overlay venv

### DIFF
--- a/compiler/luci-value-test/CMakeLists.txt
+++ b/compiler/luci-value-test/CMakeLists.txt
@@ -20,5 +20,6 @@ add_test(NAME luci_value_test
   COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/evalverify.sh"
           "${CMAKE_CURRENT_BINARY_DIR}"
           "${ARTIFACTS_BIN_PATH}"
+          "${NNCC_OVERLAY_DIR}/venv_1_13_2"
           ${LUCI_VALUE_TESTS}
 )

--- a/compiler/luci-value-test/evalverify.sh
+++ b/compiler/luci-value-test/evalverify.sh
@@ -11,8 +11,8 @@ VERIFY_SOURCE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 VERIFY_SCRIPT_PATH="${VERIFY_SOURCE_PATH}/luci_eval_verifier.py"
 BINDIR="$1"; shift
 WORKDIR="$1"; shift
+VIRTUALENV="$1"; shift
 INTERPRETER_DRIVER_PATH="${BINDIR}/tester/luci_eval_tester"
-VIRTUALENV="${WORKDIR}/venv_1_13_2"
 
 TESTED=()
 PASSED=()


### PR DESCRIPTION
This commit makes this module use overlay venv

Related: #2359 
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>