### PR TITLE
[record-minmax-conversion-test] Use overlay venv

### DIFF
--- a/compiler/record-minmax-conversion-test/CMakeLists.txt
+++ b/compiler/record-minmax-conversion-test/CMakeLists.txt
@@ -37,5 +37,6 @@ add_test(
   COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/testall.sh"
           "${TEST_CONFIG}"
           "${ARTIFACTS_BIN_PATH}"
+          "${NNCC_OVERLAY_DIR}/venv_1_13_2"
           ${RECORD_MINMAX_CONVERSION_TEST}
 )

--- a/compiler/record-minmax-conversion-test/testall.sh
+++ b/compiler/record-minmax-conversion-test/testall.sh
@@ -13,7 +13,7 @@ GEN_SCRIPT_PATH="${GEN_SOURCE_PATH}/gen_h5_random_inputs.py"
 CONFIG_PATH="$1"; shift
 BIN_PATH=$(dirname "$CONFIG_PATH")
 WORKDIR="$1"; shift
-VIRTUALENV="${WORKDIR}/venv_1_13_2"
+VIRTUALENV="$1"; shift
 
 source "${CONFIG_PATH}"
 


### PR DESCRIPTION
This commit makes this module use overlay venv

Related: #2359 
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>