### PR TITLE
[tf2tfliteV2-conversion-test] Use overlay venv

### DIFF
--- a/compiler/tf2tfliteV2-conversion-test/CMakeLists.txt
+++ b/compiler/tf2tfliteV2-conversion-test/CMakeLists.txt
@@ -72,7 +72,7 @@ list(APPEND TEST_DEPS "${TEST_RUNNER}")
 
 get_target_property(ARTIFACTS_BIN_PATH testDataGenerator BINARY_DIR)
 
-set(VIRTUALENV "${ARTIFACTS_BIN_PATH}/venv_1_13_2")
+set(VIRTUALENV "${NNCC_OVERLAY_DIR}/venv_1_13_2")
 
 ###
 ### Generate test.config


### PR DESCRIPTION
This commit makes this module use overlay venv

Related: #2359 
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>