### PR TITLE
[pota-quantization-value-test] Use overlay venv

### DIFF
--- a/compiler/pota-quantization-value-test/CMakeLists.txt
+++ b/compiler/pota-quantization-value-test/CMakeLists.txt
@@ -15,6 +15,8 @@ unset(TEST_DEPS)
 
 get_target_property(ARTIFACTS_BIN_PATH testDataGenerator BINARY_DIR)
 
+set(VIRTUALENV "${NNCC_OVERLAY_DIR}/venv_1_13_2")
+
 ###
 ### Generate test.config
 ###
@@ -26,6 +28,7 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E echo 'RECORD_MINMAX_PATH=\"$<TARGET_FILE:record-minmax>\"' >> ${TEST_CONFIG}
   COMMAND ${CMAKE_COMMAND} -E echo 'CIRCLE_QUANTIZER_PATH=\"$<TARGET_FILE:circle-quantizer>\"' >> ${TEST_CONFIG}
   COMMAND ${CMAKE_COMMAND} -E echo 'CIRCLE_TENSORDUMP_PATH=\"$<TARGET_FILE:circle-tensordump>\"' >> ${TEST_CONFIG}
+  COMMAND ${CMAKE_COMMAND} -E echo 'VIRTUALENV=\"${VIRTUALENV}\"' >> ${TEST_CONFIG}
   DEPENDS record-minmax
   DEPENDS circle-quantizer
   DEPENDS circle-tensordump

--- a/compiler/pota-quantization-value-test/test_fake_wquant.sh
+++ b/compiler/pota-quantization-value-test/test_fake_wquant.sh
@@ -14,7 +14,6 @@ CONFIG_PATH="$1"; shift
 BIN_PATH=$(dirname "${CONFIG_PATH}")
 TEST_INPUT_PATH="${SOURCE_PATH}/test_inputs"
 WORKDIR="$1"; shift
-VIRTUALENV="${WORKDIR}/venv_1_13_2"
 
 source "${CONFIG_PATH}"
 

--- a/compiler/pota-quantization-value-test/test_quantization.sh
+++ b/compiler/pota-quantization-value-test/test_quantization.sh
@@ -14,7 +14,6 @@ CONFIG_PATH="$1"; shift
 BIN_PATH=$(dirname "${CONFIG_PATH}")
 TEST_INPUT_PATH="${SOURCE_PATH}/test_inputs"
 WORKDIR="$1"; shift
-VIRTUALENV="${WORKDIR}/venv_1_13_2"
 
 source "${CONFIG_PATH}"
 

--- a/compiler/pota-quantization-value-test/test_record_minmax.sh
+++ b/compiler/pota-quantization-value-test/test_record_minmax.sh
@@ -15,7 +15,6 @@ CONFIG_PATH="$1"; shift
 BIN_PATH=$(dirname "${CONFIG_PATH}")
 TEST_INPUT_PATH="${SOURCE_PATH}/test_inputs"
 WORKDIR="$1"; shift
-VIRTUALENV="${WORKDIR}/venv_1_13_2"
 
 source "${CONFIG_PATH}"
 


### PR DESCRIPTION
This commit makes this module use overlay venv

Related : #2359 
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>