### PR TITLE
[onert] Do not copy in/outputs on start Execution

### DIFF
--- a/runtime/onert/backend/acl_common/AclTensorBuilder.h
+++ b/runtime/onert/backend/acl_common/AclTensorBuilder.h
@@ -63,6 +63,7 @@ public:
   void notifyLastUse(const ir::OperandIndex &) override;
 
   bool isRegistered(const ir::OperandIndex &) const override;
+  std::shared_ptr<backend::ITensorRegistry> tensorRegistry() override { return nullptr; }
 
   void prepare(void) override;
   void allocate() override;

--- a/runtime/onert/backend/cpu/TensorBuilder.cc
+++ b/runtime/onert/backend/cpu/TensorBuilder.cc
@@ -99,6 +99,12 @@ std::shared_ptr<IPortableTensor> TensorBuilder::portableAt(const ir::OperandInde
   return _tensor_reg->getPortableTensor(ind);
 }
 
+bool TensorBuilder::setExternalTensor(const ir::OperandIndex &ind,
+                                      const std::shared_ptr<IPortableTensor> &tensor)
+{
+  return _tensor_reg->setExternalTensor(ind, tensor);
+}
+
 void TensorBuilder::iterate(const IterateFunction &fn) { _static_tensor_mgr->iterate(fn); }
 
 std::shared_ptr<cpu_common::Tensor> TensorBuilder::at(const ir::OperandIndex &ind)

--- a/runtime/onert/backend/cpu/TensorBuilder.h
+++ b/runtime/onert/backend/cpu/TensorBuilder.h
@@ -82,6 +82,8 @@ public:
    */
   std::shared_ptr<cpu_common::Tensor> at(const ir::OperandIndex &ind);
   std::shared_ptr<IPortableTensor> portableAt(const ir::OperandIndex &ind);
+  bool setExternalTensor(const ir::OperandIndex &ind,
+                         const std::shared_ptr<IPortableTensor> &tensor) override;
 
   std::shared_ptr<ITensorRegistry> tensorRegistry() override { return _tensor_reg; }
 

--- a/runtime/onert/core/include/backend/ITensorBuilder.h
+++ b/runtime/onert/core/include/backend/ITensorBuilder.h
@@ -70,10 +70,7 @@ struct ITensorBuilder
    *
    * @note   Backend should implement this when it has StaticTensorManager and DynamicTensorManager
    */
-  virtual std::shared_ptr<backend::ITensorRegistry> tensorRegistry()
-  {
-    throw std::runtime_error("tensorRegistry(): NYI");
-  }
+  virtual std::shared_ptr<backend::ITensorRegistry> tensorRegistry() = 0;
 
 public: // methods for static tensor allocation
   /**
@@ -113,6 +110,18 @@ public: // methods for static tensor allocation
    * @return std::shared_ptr<ITensor> The tensor object
    */
   virtual std::shared_ptr<ITensor> tensorAt(const ir::OperandIndex &ind) = 0;
+
+  /**
+   * @brief Set the External Tensor object
+   *
+   * @return true if succeeded
+   * @return false if failed or unsupported
+   */
+  virtual bool setExternalTensor(const ir::OperandIndex &, const std::shared_ptr<IPortableTensor> &)
+  {
+    return false;
+  }
+
   /**
    * @brief Iterate over tensors
    *

--- a/runtime/onert/core/include/backend/ITensorRegistry.h
+++ b/runtime/onert/core/include/backend/ITensorRegistry.h
@@ -103,14 +103,17 @@ public:
     return nullptr;
   }
 
-  void setExternalTensor(const ir::OperandIndex &ind,
+  bool setExternalTensor(const ir::OperandIndex &ind,
                          const std::shared_ptr<IPortableTensor> &tensor)
   {
-    auto itr = _managed.find(ind);
-    if (itr != _managed.end() && itr->second != nullptr && tensor != nullptr)
-      throw std::runtime_error{
-          "Tried to set an external tensor but an managed tensor already exists."};
+    // TODO Uncomment this as two tensors for an index is not allowed.
+    //      But now it is temporarily allowed as a workaround. External one hides Managed one.
+    // auto itr = _managed.find(ind);
+    // if (itr != _managed.end() && itr->second != nullptr && tensor != nullptr)
+    //  throw std::runtime_error{
+    //      "Tried to set an external tensor but an managed tensor already exists."};
     _external[ind] = tensor;
+    return true;
   }
 
   void setManagedTensor(const ir::OperandIndex &ind, const std::shared_ptr<T_Tensor> &tensor)

--- a/runtime/onert/core/include/compiler/Compiler.h
+++ b/runtime/onert/core/include/compiler/Compiler.h
@@ -48,6 +48,7 @@ struct CompilerOptions
 {
   // GENERAL OPTIONS
   std::vector<std::string> backend_list;
+  bool is_primary_subgraph;
 
   // OPTIONS ONLY FOR DEBUGGING/PROFILING
   std::string trace_filepath; //< File path to save trace records

--- a/runtime/onert/core/include/compiler/Compiler.h
+++ b/runtime/onert/core/include/compiler/Compiler.h
@@ -48,7 +48,7 @@ struct CompilerOptions
 {
   // GENERAL OPTIONS
   std::vector<std::string> backend_list;
-  bool is_primary_subgraph;
+  bool is_primary_subgraph; // TODO Remove this out of this struct as it is not user-given option
 
   // OPTIONS ONLY FOR DEBUGGING/PROFILING
   std::string trace_filepath; //< File path to save trace records

--- a/runtime/onert/core/include/ir/LoweredGraph.h
+++ b/runtime/onert/core/include/ir/LoweredGraph.h
@@ -64,7 +64,8 @@ private:
                        const compiler::BackendResolver &backend_resolver);
 
   void
-  manipulateLowerInfo(OperandIndexMap<std::unique_ptr<operand::LowerInfo>> &operands_lower_info);
+  manipulateLowerInfo(OperandIndexMap<std::unique_ptr<operand::LowerInfo>> &operands_lower_info,
+                      bool is_primary);
   void dumpLowerInfo();
   bool mergeable(const OpSequenceIndex &op_seq_index, const OperationIndex &node_index,
                  Layout layout, const compiler::BackendResolver &backend_resolver);

--- a/runtime/onert/core/src/backend/controlflow/Config.h
+++ b/runtime/onert/core/src/backend/controlflow/Config.h
@@ -39,7 +39,7 @@ public:
   bool supportDynamicTensor() override
   {
     // TODO Make this backend to support dynamic tensor or not to build non-constant tensor
-    return false;
+    return true;
   }
   bool supportFP16() override { return false; }
 

--- a/runtime/onert/core/src/backend/controlflow/KernelGenerator.cc
+++ b/runtime/onert/core/src/backend/controlflow/KernelGenerator.cc
@@ -122,6 +122,7 @@ void KernelGenerator::visit(const ir::operation::Permute &node)
   std::vector<std::shared_ptr<ITensor>> input_tensors{getTensor(input_index)};
   std::unordered_map<std::shared_ptr<ITensor>, exec::DynAllocInfo> outputs_dyn_alloc_info;
   const auto output_tensor_builder = getTensorBuilder(output_index);
+  VERBOSE(PERMUTE_FIND_TB) << output_index << " -> " << output_tensor_builder.get() << std::endl;
   assert(output_tensor_builder != nullptr);
   if (output_tensor_builder->supportDynamicTensor())
   {
@@ -197,7 +198,8 @@ KernelGenerator::getTensorBuilder(const ir::OperandIndex &index)
   std::shared_ptr<backend::ITensorBuilder> ret;
   for (auto tensor_builder : _tensor_builder_set)
   {
-    auto tensor = tensor_builder->tensorAt(index);
+    auto reg = tensor_builder->tensorRegistry();
+    auto tensor = reg ? reg->getManagedITensor(index) : tensor_builder->tensorAt(index);
     if (tensor)
     {
       ret = tensor_builder;

--- a/runtime/onert/core/src/backend/controlflow/UserTensor.h
+++ b/runtime/onert/core/src/backend/controlflow/UserTensor.h
@@ -39,7 +39,7 @@ class UserTensor : public IPortableTensor
 {
 public:
   UserTensor(const ir::OperandInfo &info, ir::Layout layout, uint8_t *buffer, size_t size)
-      : _info{info}, _layout{layout}, _buffer{buffer}, _size{size}
+      : _info{info}, _layout{layout}, _buffer{buffer}, _size{size}, _dynamic{false}
   {
   }
 
@@ -64,7 +64,8 @@ public:
   ir::DataType data_type() const override { return _info.typeInfo().type(); }
   float data_scale() const override { return _info.typeInfo().scale(); }
   int32_t data_offset() const override { return _info.typeInfo().offset(); }
-  bool is_dynamic() const override { return false; }
+  bool is_dynamic() const override { return _dynamic; }
+  void set_dynamic() override { _dynamic = true; }
   ir::Shape getShape() const override { return _info.shape(); }
   void setShape(const ir::Shape &new_shape) override { _info.shape(new_shape); }
 
@@ -73,6 +74,7 @@ private:
   ir::Layout _layout;
   uint8_t *_buffer;
   size_t _size;
+  bool _dynamic;
 };
 
 } // namespace controlflow

--- a/runtime/onert/core/src/backend/cpu_common/DynamicTensorManager.cc
+++ b/runtime/onert/core/src/backend/cpu_common/DynamicTensorManager.cc
@@ -33,6 +33,8 @@ DynamicTensorManager::DynamicTensorManager(const std::shared_ptr<TensorRegistry>
 
 void DynamicTensorManager::applyShape(const ir::OperandIndex &ind, const ir::Shape &new_shape)
 {
+  VERBOSE_F() << ind << std::endl;
+
   auto tensor = _tensors->getManagedTensor(ind);
   assert(tensor);
 

--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -182,6 +182,7 @@ std::shared_ptr<exec::ExecutorMap> Compiler::compile(void)
   // Lower: Assign backend
   std::unordered_map<ir::SubgraphIndex, std::unique_ptr<ir::LoweredGraph>> lowered_subgs;
   _subgraphs->iterate([&](const ir::SubgraphIndex &index, ir::Graph &subg) {
+    _options.is_primary_subgraph = (index == ir::SubgraphIndex{0});
     onert::dumper::dot::DotDumper dot_dumper(subg, dump_level);
     dot_dumper.dump(nnfw::misc::str("before_lower_subg-", index.value()));
 
@@ -238,6 +239,8 @@ std::shared_ptr<exec::ExecutorMap> Compiler::compile(void)
     const auto &subg_index = pair.first;
     auto &lowered_subg = pair.second;
     auto indexed_ranks = lowered_subg->indexed_ranks();
+
+    _options.is_primary_subgraph = (subg_index == ir::SubgraphIndex{0});
 
     onert::dumper::dot::DotDumper dot_dumper_lowered(lowered_subg.get(), dump_level);
     dot_dumper_lowered.dump("after_lower_subg-" + std::to_string(subg_index.value()));

--- a/runtime/onert/core/src/compiler/ExecutorFactory.cc
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.cc
@@ -198,8 +198,6 @@ ExecutorFactory::initializeModelIOTensors(ir::LoweredGraph &lowered_graph,
         operand.info(),
         ir::Layout::NHWC /* FIXME find op_seq for this operand and use frontend_layout */);
 
-    VERBOSE_F() << "XXXXXXX " << ind.value() << std::endl;
-
     // Add tensor to controlflow TensorRegistry.
     cf_tensor_builder->setUserTensor(ind, tensor);
     ret.push_back(tensor);
@@ -209,7 +207,6 @@ ExecutorFactory::initializeModelIOTensors(ir::LoweredGraph &lowered_graph,
     {
       // FIXME This is a workaround registering all user tensors to all backends
       // FIXME Handle when it is failed
-      VERBOSE_F() << "EXTERNAL TENSOR : " << ind << (tensor ? " GOOD" : " NULL") << std::endl;
       tensor_builder->setExternalTensor(ind, tensor);
     }
   }

--- a/runtime/onert/core/src/compiler/ExecutorFactory.h
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.h
@@ -19,6 +19,7 @@
 
 #include <unordered_map>
 
+#include "backend/ITensor.h"
 #include "exec/IExecutor.h"
 #include "ir/LoweredGraph.h"
 
@@ -44,6 +45,9 @@ private:
   static void initializeBackendContext(ir::LoweredGraph *lowered_graph);
   static void runTensorRegistration(ir::LoweredGraph *lowered_graph,
                                     const std::vector<ir::OpSequenceIndex> &order);
+  static std::vector<std::shared_ptr<backend::ITensor>>
+  initializeModelIOTensors(ir::LoweredGraph &lowered_graph,
+                           const ir::OperandIndexSequence &indices);
   static exec::IExecutor *
   createLinearExecutor(std::unique_ptr<ir::LoweredGraph> lowered_graph,
                        const compiler::CompilerOptions &options,

--- a/runtime/onert/core/src/exec/DataflowExecutor.cc
+++ b/runtime/onert/core/src/exec/DataflowExecutor.cc
@@ -77,10 +77,13 @@ bool DataflowExecutor::noWaitingJobs()
                      [](const std::unique_ptr<Job> &job) { return job == nullptr; });
 }
 
-DataflowExecutor::DataflowExecutor(std::unique_ptr<ir::LoweredGraph> lowered_graph,
-                                   const compiler::TensorBuilders &tensor_builders,
-                                   compiler::CodeMap &&code_map)
-    : ExecutorBase{std::move(lowered_graph), tensor_builders}, _code_map{std::move(code_map)}
+DataflowExecutor::DataflowExecutor(
+    std::unique_ptr<ir::LoweredGraph> lowered_graph,
+    const std::vector<std::shared_ptr<backend::ITensor>> &input_tensors,
+    const std::vector<std::shared_ptr<backend::ITensor>> &output_tensors,
+    const compiler::TensorBuilders &tensor_builders, compiler::CodeMap &&code_map)
+    : ExecutorBase{std::move(lowered_graph), input_tensors, output_tensors, tensor_builders},
+      _code_map{std::move(code_map)}
 {
   VERBOSE(DataflowExecutor) << "Constructing Dataflow Executor" << std::endl;
 

--- a/runtime/onert/core/src/exec/DataflowExecutor.h
+++ b/runtime/onert/core/src/exec/DataflowExecutor.h
@@ -50,6 +50,8 @@ public:
    * @param code_map OpSequence and its code map
    */
   DataflowExecutor(std::unique_ptr<ir::LoweredGraph> lowered_graph,
+                   const std::vector<std::shared_ptr<backend::ITensor>> &input_tensors,
+                   const std::vector<std::shared_ptr<backend::ITensor>> &output_tensors,
                    const compiler::TensorBuilders &tensor_builders, compiler::CodeMap &&code_map);
 
   void executeImpl() override;

--- a/runtime/onert/core/src/exec/ExecutorBase.cc
+++ b/runtime/onert/core/src/exec/ExecutorBase.cc
@@ -44,7 +44,9 @@ ExecutorBase::ExecutorBase(std::unique_ptr<ir::LoweredGraph> &&lowered_graph,
         std::shared_ptr<backend::ITensor> tensor;
         for (auto &tensor_builder : tensor_builders)
         {
-          tensor = tensor_builder->tensorRegistry()->getManagedITensor(ind);
+          auto tensor_registry = tensor_builder->tensorRegistry();
+          assert(tensor_registry);
+          tensor = tensor_registry->getManagedITensor(ind);
           if (tensor != nullptr)
           {
             if (tensor_builder->supportDynamicTensor())
@@ -67,7 +69,9 @@ ExecutorBase::ExecutorBase(std::unique_ptr<ir::LoweredGraph> &&lowered_graph,
         std::shared_ptr<backend::ITensor> tensor;
         for (auto &tensor_builder : tensor_builders)
         {
-          tensor = tensor_builder->tensorRegistry()->getManagedITensor(ind);
+          auto tensor_registry = tensor_builder->tensorRegistry();
+          assert(tensor_registry);
+          tensor = tensor_registry->getManagedITensor(ind);
           if (tensor != nullptr)
           {
             if (tensor_builder->supportDynamicTensor())
@@ -180,9 +184,6 @@ void ExecutorBase::execute(const IODescription &desc)
   // TODO: if all used backends on this executor are thread-safe,
   //       do not need to use mutex (otherwise, use mutex)
   std::lock_guard<std::mutex> lock(_mutex);
-
-  std::vector<std::unique_ptr<ISource>> sources{_graph.getInputs().size()};
-  std::vector<std::unique_ptr<ISink>> sinks{_graph.getOutputs().size()};
 
   // Set input(s)
   assert(_input_tensors.size() == desc.inputs.size());

--- a/runtime/onert/core/src/exec/IPermuteFunction.h
+++ b/runtime/onert/core/src/exec/IPermuteFunction.h
@@ -129,7 +129,7 @@ private:
           assert(src_tensor.layout() == dst_tensor.layout());
           if (!src_tensor.has_padding() && !dst_tensor.has_padding())
           {
-            assert(src_size == dst_tensor.total_size());
+            assert(src_size <= dst_tensor.total_size());
             memcpy(dst_buffer, src_buffer, src_size);
             return;
           }

--- a/runtime/onert/core/src/exec/LinearExecutor.h
+++ b/runtime/onert/core/src/exec/LinearExecutor.h
@@ -47,9 +47,11 @@ public:
    * @param code_map OpSequence and its code map
    */
   LinearExecutor(std::unique_ptr<ir::LoweredGraph> lowered_graph,
+                 const std::vector<std::shared_ptr<backend::ITensor>> &input_tensors,
+                 const std::vector<std::shared_ptr<backend::ITensor>> &output_tensors,
                  const compiler::TensorBuilders &tensor_builders, compiler::CodeMap &&code_map,
                  const std::vector<ir::OpSequenceIndex> &order)
-      : ExecutorBase{std::move(lowered_graph), tensor_builders}
+      : ExecutorBase{std::move(lowered_graph), input_tensors, output_tensors, tensor_builders}
   {
     for (auto index : order)
     {

--- a/runtime/onert/core/src/exec/ParallelExecutor.cc
+++ b/runtime/onert/core/src/exec/ParallelExecutor.cc
@@ -59,10 +59,13 @@ void ParallelExecutor::notify(uint32_t finished_job_id)
   _cv_jobs.notify_all();
 }
 
-ParallelExecutor::ParallelExecutor(std::unique_ptr<ir::LoweredGraph> lowered_graph,
-                                   const compiler::TensorBuilders &tensor_builders,
-                                   compiler::CodeMap &&code_map)
-    : DataflowExecutor{std::move(lowered_graph), tensor_builders, std::move(code_map)}
+ParallelExecutor::ParallelExecutor(
+    std::unique_ptr<ir::LoweredGraph> lowered_graph,
+    const std::vector<std::shared_ptr<backend::ITensor>> &input_tensors,
+    const std::vector<std::shared_ptr<backend::ITensor>> &output_tensors,
+    const compiler::TensorBuilders &tensor_builders, compiler::CodeMap &&code_map)
+    : DataflowExecutor{std::move(lowered_graph), input_tensors, output_tensors, tensor_builders,
+                       std::move(code_map)}
 {
   VERBOSE(ParallelExecutor) << "Constructing Parallel Executor" << std::endl;
 }

--- a/runtime/onert/core/src/exec/ParallelExecutor.h
+++ b/runtime/onert/core/src/exec/ParallelExecutor.h
@@ -51,6 +51,8 @@ public:
    * @param code_map OpSequence and its code map
    */
   ParallelExecutor(std::unique_ptr<ir::LoweredGraph> lowered_graph,
+                   const std::vector<std::shared_ptr<backend::ITensor>> &input_tensors,
+                   const std::vector<std::shared_ptr<backend::ITensor>> &output_tensors,
                    const compiler::TensorBuilders &tensor_builders, compiler::CodeMap &&code_map);
 
   void executeImpl() override;

--- a/runtime/onert/core/src/ir/pass/PermutationInsertionPass.cc
+++ b/runtime/onert/core/src/ir/pass/PermutationInsertionPass.cc
@@ -60,8 +60,36 @@ void PermutationInsertionPass::callback(const OperandIndex &index, Operand &obje
     }
 
     auto insert_set = operand_li->use_factors() - operand_li->def_factors();
+    auto def_factor = operand_li->def_factors().getOnlyElement();
+
+    auto compatible_backends = [](auto /* backend1 */, auto /* backend2 */) {
+      // TODO If other issues for Permute elimination are resolved, enable this
+      return false;
+      /*
+      // TODO This is a workaround for not inserting Permute between cpu and controlflow.
+      //      To be general, we need another way of checking they are compatible.
+      const auto cf = backend::controlflow::Config::ID;
+      const auto cpu = "cpu";
+      const auto id1 = backend1->config()->id();
+      const auto id2 = backend2->config()->id();
+      return (id1 == cpu && id2 == cf) // Allows no-Permute for Model inputs
+          || (id1 == cf && id2 == cpu); // Allows no-Permute for Model outputs
+          */
+    };
+
     for (auto factor : insert_set)
     {
+      if (factor.layout() == def_factor.layout() &&
+          compatible_backends(factor.backend(), def_factor.backend()))
+      {
+        // For this factor we can just reuse existing operand - Permute is not added.
+        VERBOSE(PermutationInsertionPass) << "Permutation Insertion is skipped for operand "
+                                          << index << " / as the tensor is compatible with backend "
+                                          << factor.backend()->config()->id() << std::endl;
+        factor_to_index.emplace(factor, index);
+        continue;
+      }
+
       const auto permute_operation_index = insertPermute(index, factor);
       permute_indexes.push_back(permute_operation_index);
       const auto &permute_operation = _graph.operations().at(permute_operation_index);

--- a/runtime/onert/core/src/ir/pass/PermutationOperationPass.cc
+++ b/runtime/onert/core/src/ir/pass/PermutationOperationPass.cc
@@ -19,6 +19,7 @@
 #include "backend/Backend.h"
 #include "backend/IConfig.h"
 #include "ir/Graph.h"
+#include "util/logging.h"
 
 namespace onert
 {
@@ -199,7 +200,9 @@ void PermutationOperationPass::changeToKeepLayout(const Operation &node)
       lower_info->addUsePermuteFactor(new_factor);
 
       // Whether if node's input is an input of model or a constant
-      if (_graph.operands().at(input).getDef().size() == 0)
+      if (_graph.operands().at(input).getDef().size() == 0 &&
+          (lower_info->def_factors().size() == 1 &&
+           lower_info->def_factors().getOnlyElement() == removed_factor))
       {
         assert(_graph.getInputs().contains(input) || _graph.operands().at(input).isConstant());
         lower_info->removeDefPermuteFactor(removed_factor);


### PR DESCRIPTION
- Wrap input/output buffers be `controlflow::UserTensor` so now I/O
  tensors are represented in IR
- `PermutationInsertionPass` now creates Permute operation for
  input/outputs
- Remove Source on start and Sink on end in executors

If some conditions are met `PermutationInsertionPass` can skip Permute
insertion and reuse tensors from other backends. It will be implemented
soon.

Draft PR : #2835

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>