### PR TITLE
[compiler/common-artifacts] Add Unique testcases for exclusion

### DIFF
--- a/compiler/common-artifacts/exclude.lst
+++ b/compiler/common-artifacts/exclude.lst
@@ -166,6 +166,12 @@ tcgenerate(Tile_U8_000)
 tcgenerate(TopKV2_000) # fix luci
 tcgenerate(TopKV2_001) # fix luci
 tcgenerate(TransposeConv_000) # fix interpreter
+tcgenerate(Unique_000)
+tcgenerate(Unique_001)
+tcgenerate(Unique_002)
+tcgenerate(Unique_003)
+tcgenerate(Unique_U8_000)
+tcgenerate(Unique_U8_001)
 tcgenerate(Where_000) # luci NYI
 tcgenerate(Where_001) # luci NYI
 tcgenerate(While_000) # fix luci


### PR DESCRIPTION
Parent Issue : #2568
Draft PR : #2829

Add Unique testcases for exclusion under common-artifacts.

ONE-DCO-1.0-Signed-off-by: venkat.iyer <venkat.iyer@samsung.com>