### PR TITLE
[onert] Move unit tests to unittest_standalone

### DIFF
--- a/compute/test/CMakeLists.txt
+++ b/compute/test/CMakeLists.txt
@@ -10,4 +10,4 @@ target_link_libraries(${TEST_COMPUTE} gtest_main)
 target_link_libraries(${TEST_COMPUTE} ${LIB_PTHREAD} dl)
 add_test(${TEST_COMPUTE} ${TEST_COMPUTE})
 
-install(TARGETS ${TEST_COMPUTE} DESTINATION unittest)
+install(TARGETS ${TEST_COMPUTE} DESTINATION unittest_standalone)

--- a/infra/scripts/test_ubuntu_runtime_mixed.sh
+++ b/infra/scripts/test_ubuntu_runtime_mixed.sh
@@ -26,6 +26,11 @@ echo "==== Run nnfw_api_gtest end ===="
 echo
 popd > /dev/null
 
+Product/out/unittest_standalone/test_compute
+Product/out/unittest_standalone/test_onert
+Product/out/unittest_standalone/test_onert_backend_cpu_common
+Product/out/unittest_standalone/test_onert_frontend_nnapi
+Product/out/unittest_standalone/tflite_test
 
 pushd ${ROOT_PATH}
 

--- a/runtime/onert/core/CMakeLists.txt
+++ b/runtime/onert/core/CMakeLists.txt
@@ -37,4 +37,4 @@ target_link_libraries(${TEST_ONERT_BACKEND_CPU_COMMON} onert_core)
 target_link_libraries(${TEST_ONERT_BACKEND_CPU_COMMON} gtest gtest_main dl ${LIB_PTHREAD})
 
 add_test(${TEST_ONERT_BACKEND_CPU_COMMON} ${TEST_ONERT_BACKEND_CPU_COMMON})
-install(TARGETS ${TEST_ONERT_BACKEND_CPU_COMMON} DESTINATION unittest)
+install(TARGETS ${TEST_ONERT_BACKEND_CPU_COMMON} DESTINATION unittest_standalone)

--- a/runtime/onert/frontend/nnapi/CMakeLists.txt
+++ b/runtime/onert/frontend/nnapi/CMakeLists.txt
@@ -24,4 +24,4 @@ target_link_libraries(test_onert_frontend_nnapi PRIVATE ${LIB_ONERT} dl)
 target_link_libraries(test_onert_frontend_nnapi PRIVATE gtest)
 target_link_libraries(test_onert_frontend_nnapi PRIVATE gtest_main)
 
-install(TARGETS test_onert_frontend_nnapi DESTINATION unittest)
+install(TARGETS test_onert_frontend_nnapi DESTINATION unittest_standalone)

--- a/runtime/onert/test/CMakeLists.txt
+++ b/runtime/onert/test/CMakeLists.txt
@@ -12,4 +12,4 @@ target_link_libraries(${TEST_ONERT} gtest_main)
 target_link_libraries(${TEST_ONERT} ${LIB_PTHREAD} dl)
 add_test(${TEST_ONERT} ${TEST_ONERT})
 
-install(TARGETS ${TEST_ONERT} DESTINATION unittest)
+install(TARGETS ${TEST_ONERT} DESTINATION unittest_standalone)

--- a/tests/tools/tflite_run/CMakeLists.txt
+++ b/tests/tools/tflite_run/CMakeLists.txt
@@ -32,4 +32,4 @@ add_executable(tflite_test src/tflite_test.cc)
 ## Link test executable against gtest & gtest_main
 target_link_libraries(tflite_test gtest gtest_main ${LIB_PTHREAD})
 ## install test binary for packaging
-install(TARGETS tflite_test DESTINATION unittest)
+install(TARGETS tflite_test DESTINATION unittest_standalone)


### PR DESCRIPTION
Move unit tests to `unittest_standalone` directory to make sure those
tests are run just once.

Tests in `unittest` are executed multiple times with different
executors and backends. However, it is necessary for nnapi tests only.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>