### PR TITLE
[circlechef] Add version parameter to Operation

### DIFF
--- a/compiler/circlechef/proto/circlechef.proto
+++ b/compiler/circlechef/proto/circlechef.proto
@@ -82,6 +82,7 @@ message Operation {
   optional string type = 1;
   repeated string input = 2;
   repeated string output = 3;
+  optional int32 version = 4 [default = 1];
 
   optional BatchMatMulOptions batch_matmul_options = 100;
   optional InstanceNormOptions instance_norm_options = 101;


### PR DESCRIPTION
Parent Issue : #3174
Draft : #3216

Until now, there was no way to express operation version in `circlechef`.
This commit will add `version` parameter in Operation.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>