### PR TITLE
[onert] Revert #3219 (Tensorbuilder::allocate() to allocateAtCompiltTime() and allocateAtRunTime())

### DIFF
--- a/runtime/onert/backend/acl_common/AclTensorBuilder.h
+++ b/runtime/onert/backend/acl_common/AclTensorBuilder.h
@@ -65,8 +65,7 @@ public:
   bool isRegistered(const ir::OperandIndex &) const override;
 
   void prepare(void) override;
-  void allocateAtCompileTime() override;
-  void allocateAtRunTime() override;
+  void allocate() override;
   void postFunctionPrepare() override;
 
   std::shared_ptr<ITensor> tensorAt(const ir::OperandIndex &ind) override;
@@ -227,7 +226,7 @@ void AclTensorBuilder<T_ITensor, T_Tensor, T_SubTensor>::prepare(void)
 }
 
 template <typename T_ITensor, typename T_Tensor, typename T_SubTensor>
-void AclTensorBuilder<T_ITensor, T_Tensor, T_SubTensor>::allocateAtCompileTime(void)
+void AclTensorBuilder<T_ITensor, T_Tensor, T_SubTensor>::allocate(void)
 {
   // Update lifetime sequence to apply subtensor optimization
 
@@ -301,12 +300,6 @@ void AclTensorBuilder<T_ITensor, T_Tensor, T_SubTensor>::allocateAtCompileTime(v
   _tensor_mgr->allocateNonconsts();
 
   _tensor_mgr->allocateInternalBufferManager();
-}
-
-template <typename T_ITensor, typename T_Tensor, typename T_SubTensor>
-void AclTensorBuilder<T_ITensor, T_Tensor, T_SubTensor>::allocateAtRunTime(void)
-{
-  // Everything is allocated at compile time
 }
 
 template <typename T_ITensor, typename T_Tensor, typename T_SubTensor>

--- a/runtime/onert/backend/cpu/TensorBuilder.cc
+++ b/runtime/onert/backend/cpu/TensorBuilder.cc
@@ -83,14 +83,10 @@ void TensorBuilder::prepare(void)
   _static_tensor_mgr->allocateNonconsts();
 }
 
-void TensorBuilder::allocateAtCompileTime()
+void TensorBuilder::allocate()
 {
-  // TODO Write code here
-}
-
-void TensorBuilder::allocateAtRunTime()
-{
-  // TODO Write code here
+  // NOTE For now nothing to do. Allocation is done in prepare stage, which is not appropriate
+  //      This is because CPU kernels require `ITensor`s to be allocated before Kernel Generation.
 }
 
 std::shared_ptr<ITensor> TensorBuilder::tensorAt(const ir::OperandIndex &ind)

--- a/runtime/onert/backend/cpu/TensorBuilder.h
+++ b/runtime/onert/backend/cpu/TensorBuilder.h
@@ -56,8 +56,7 @@ public:
   bool isRegistered(const ir::OperandIndex &) const override;
 
   void prepare(void) override;
-  void allocateAtCompileTime() override;
-  void allocateAtRunTime() override;
+  void allocate() override;
   void postFunctionPrepare() override { /* DO NOTHING */}
 
   /**

--- a/runtime/onert/core/include/backend/ITensorBuilder.h
+++ b/runtime/onert/core/include/backend/ITensorBuilder.h
@@ -98,9 +98,7 @@ public: // methods for static tensor allocation
    * @brief Allocate the tensors
    *        Before calling this, @c prepare must be called
    */
-  virtual void allocateAtCompileTime() = 0;
-
-  virtual void allocateAtRunTime() = 0;
+  virtual void allocate() = 0;
   /**
    * @brief Some actions after functions' @c IFunction::prepare method.
    *        This is called right after each function's @c IFunction::prepare function has been

--- a/runtime/onert/core/src/backend/controlflow/TensorBuilder.cc
+++ b/runtime/onert/core/src/backend/controlflow/TensorBuilder.cc
@@ -83,14 +83,10 @@ void TensorBuilder::prepare(void)
   _static_tensor_mgr->allocateNonconsts();
 }
 
-void TensorBuilder::allocateAtCompileTime()
+void TensorBuilder::allocate()
 {
-  // TODO Write code here
-}
-
-void TensorBuilder::allocateAtRunTime()
-{
-  // TODO Write code here
+  // NOTE For now nothing to do. Allocation is done in prepare stage, which is not appropriate
+  //      This is because CPU kernels require `ITensor`s to be allocated before Kernel Generation.
 }
 
 std::shared_ptr<ITensor> TensorBuilder::tensorAt(const ir::OperandIndex &ind)

--- a/runtime/onert/core/src/backend/controlflow/TensorBuilder.h
+++ b/runtime/onert/core/src/backend/controlflow/TensorBuilder.h
@@ -58,8 +58,7 @@ public:
   bool isRegistered(const ir::OperandIndex &) const override;
 
   void prepare(void) override;
-  void allocateAtCompileTime() override;
-  void allocateAtRunTime() override;
+  void allocate() override;
   void postFunctionPrepare() override { /* DO NOTHING */}
 
   /**

--- a/runtime/onert/core/src/compiler/ExecutorFactory.cc
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.cc
@@ -245,7 +245,7 @@ ExecutorFactory::createLinearExecutor(std::unique_ptr<ir::LoweredGraph> lowered_
 
   for (auto &tensor_builder : tensor_builders)
   {
-    tensor_builder->allocateAtCompileTime();
+    tensor_builder->allocate();
   }
 
   for (auto &pair : backend_contexts)
@@ -339,7 +339,7 @@ exec::IExecutor *ExecutorFactory::createDataflowExecutor(
 
   for (const auto &tensor_builder : tensor_builders)
   {
-    tensor_builder->allocateAtCompileTime();
+    tensor_builder->allocate();
   }
 
   for (auto &pair : backend_contexts)

--- a/runtime/onert/core/src/exec/ExecutorBase.cc
+++ b/runtime/onert/core/src/exec/ExecutorBase.cc
@@ -157,9 +157,6 @@ void ExecutorBase::execute(const std::vector<std::shared_ptr<backend::ITensor>> 
   // Deadlock occurs when an Executor is called recursively.
   std::lock_guard<std::mutex> lock(_mutex);
 
-  // TODO write code to allocate memory for static tensors by calling
-  //     tensor_builder.allocateAtRunTime()
-
   assert(src_tensors.size() == _graph.getInputs().size());
   assert(src_tensors.size() == _input_tensors.size());
   for (uint32_t n = 0; n < _graph.getInputs().size(); ++n)
@@ -205,9 +202,6 @@ void ExecutorBase::execute(const IODescription &desc)
   // TODO: if all used backends on this executor are thread-safe,
   //       do not need to use mutex (otherwise, use mutex)
   std::lock_guard<std::mutex> lock(_mutex);
-
-  // TODO write code to allocate memory for static tensors by calling
-  //     tensor_builder.allocateAtRunTime()
 
   std::vector<std::unique_ptr<ISource>> sources{_graph.getInputs().size()};
   std::vector<std::unique_ptr<ISink>> sinks{_graph.getOutputs().size()};


### PR DESCRIPTION
This reverts #3219 (Tensorbuilder::allocate() to allocateAtCompiltTime() and allocateAtRunTime()) 
(commit 9a288941dec54dd622625ac7981b3ce7d52574c3)

Reason:
- This commit cannot cover all cases and leaving this commit may cause future issue. 
- Need to consider memory planning should be done at the beginning of execution.
- Let me try modifying draft (#3122) and make following commits.

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>
