### PR TITLE
[luci] Mark operator version during import step

### DIFF
--- a/compiler/luci/import/src/GraphBuilder.cpp
+++ b/compiler/luci/import/src/GraphBuilder.cpp
@@ -30,6 +30,7 @@ void GraphBuilder::build(const circle::OperatorT &op, GraphBuilderContext *conte
   const std::vector<int32_t> &inputs = op.inputs;
   const std::vector<int32_t> &outputs = op.outputs;
   const auto &tensors = context->reader()->tensors();
+  const auto &opcodes = context->reader()->opcodes();
   auto tensors_ptr = context->reader()->tensors_ptr();
   assert(tensors_ptr != nullptr);
 
@@ -62,6 +63,9 @@ void GraphBuilder::build(const circle::OperatorT &op, GraphBuilderContext *conte
       node->shape_status(ShapeStatus::NOSHAPE);
     else
       node->shape_status(ShapeStatus::VALID);
+
+    // mark operator version
+    node->op_version(opcodes[op.opcode_index].get()->version);
   }
 
   // Register node's only output.

--- a/compiler/luci/import/src/Nodes/CircleCustom.cpp
+++ b/compiler/luci/import/src/Nodes/CircleCustom.cpp
@@ -53,6 +53,7 @@ void CircleCustomGraphBuilder::build(const circle::OperatorT &op,
   }
   node->custom_options(std::vector<uint8_t>{op.custom_options.begin(), op.custom_options.end()});
   node->custom_code(opcode.custom_code);
+  // Operator version of custom is always 1, so do nothing
 
   uint32_t output_count = outputs.size();
 

--- a/compiler/luci/import/src/Nodes/CircleIf.cpp
+++ b/compiler/luci/import/src/Nodes/CircleIf.cpp
@@ -79,6 +79,7 @@ void CircleIfGraphBuilder::build(const circle::OperatorT &op, GraphBuilderContex
   const std::vector<int32_t> &inputs = op.inputs;
   const std::vector<int32_t> &outputs = op.outputs;
   const auto &tensors = context->reader()->tensors();
+  const auto &opcodes = context->reader()->opcodes();
   auto tensors_ptr = context->reader()->tensors_ptr();
   assert(tensors_ptr != nullptr);
 
@@ -109,6 +110,7 @@ void CircleIfGraphBuilder::build(const circle::OperatorT &op, GraphBuilderContex
     // Lets use name of output 0 as If name
     const circle::TensorT &output_tensor = *tensors[outputs[0]];
     node->name(tensor_name(output_tensor));
+    node->op_version(opcodes[op.opcode_index].get()->version);
 
     // NOTE We don't set quantization for If itself but to virtual outputs
   }

--- a/compiler/luci/import/src/Nodes/CircleSplit.cpp
+++ b/compiler/luci/import/src/Nodes/CircleSplit.cpp
@@ -67,6 +67,7 @@ void CircleSplitGraphBuilder::build(const circle::OperatorT &op, GraphBuilderCon
   const std::vector<int32_t> &inputs = op.inputs;
   const std::vector<int32_t> &outputs = op.outputs;
   const auto &tensors = context->reader()->tensors();
+  const auto &opcodes = context->reader()->opcodes();
   auto tensors_ptr = context->reader()->tensors_ptr();
   assert(tensors_ptr != nullptr);
 
@@ -90,6 +91,7 @@ void CircleSplitGraphBuilder::build(const circle::OperatorT &op, GraphBuilderCon
     // Let's use name of output 0 as Split name
     const circle::TensorT &output_tensor = *tensors[outputs[0]];
     node->name(tensor_name(output_tensor));
+    node->op_version(opcodes[op.opcode_index].get()->version);
 
     // NOTE We don't set quantization for Split itself but to virtual outputs
   }

--- a/compiler/luci/import/src/Nodes/CircleSplitV.cpp
+++ b/compiler/luci/import/src/Nodes/CircleSplitV.cpp
@@ -68,6 +68,7 @@ void CircleSplitVGraphBuilder::build(const circle::OperatorT &op,
   const std::vector<int32_t> &inputs = op.inputs;
   const std::vector<int32_t> &outputs = op.outputs;
   const auto &tensors = context->reader()->tensors();
+  const auto &opcodes = context->reader()->opcodes();
   auto tensors_ptr = context->reader()->tensors_ptr();
   assert(tensors_ptr != nullptr);
 
@@ -92,6 +93,7 @@ void CircleSplitVGraphBuilder::build(const circle::OperatorT &op,
     // Let's use name of output 0 as Split name
     const circle::TensorT &output_tensor = *tensors[outputs[0]];
     node->name(tensor_name(output_tensor));
+    node->op_version(opcodes[op.opcode_index].get()->version);
 
     // NOTE We don't set quantization for Split itself but to virtual outputs
   }

--- a/compiler/luci/import/src/Nodes/CircleTopKV2.cpp
+++ b/compiler/luci/import/src/Nodes/CircleTopKV2.cpp
@@ -69,6 +69,7 @@ void CircleTopKV2GraphBuilder::build(const circle::OperatorT &op,
   const std::vector<int32_t> &inputs = op.inputs;
   const std::vector<int32_t> &outputs = op.outputs;
   const auto &tensors = context->reader()->tensors();
+  const auto &opcodes = context->reader()->opcodes();
   auto tensors_ptr = context->reader()->tensors_ptr();
   assert(tensors_ptr != nullptr);
 
@@ -88,6 +89,7 @@ void CircleTopKV2GraphBuilder::build(const circle::OperatorT &op,
     // Let's use name of output 0 as TopKV2 name
     const circle::TensorT &output_tensor = *tensors[outputs[0]];
     node->name(tensor_name(output_tensor));
+    node->op_version(opcodes[op.opcode_index].get()->version);
 
     // NOTE We don't set quantization for TopKV2 itself but to virtual outputs
   }

--- a/compiler/luci/import/src/Nodes/CircleUnpack.cpp
+++ b/compiler/luci/import/src/Nodes/CircleUnpack.cpp
@@ -98,6 +98,7 @@ void CircleUnpackGraphBuilder::build(const circle::OperatorT &op,
   const std::vector<int32_t> &inputs = op.inputs;
   const std::vector<int32_t> &outputs = op.outputs;
   const auto &tensors = context->reader()->tensors();
+  const auto &opcodes = context->reader()->opcodes();
   auto tensors_ptr = context->reader()->tensors_ptr();
   assert(tensors_ptr != nullptr);
 
@@ -122,6 +123,7 @@ void CircleUnpackGraphBuilder::build(const circle::OperatorT &op,
     // Let's use name of output 0 as Unpack name
     const circle::TensorT &output_tensor = *tensors[outputs[0]];
     node->name(tensor_name(output_tensor));
+    node->op_version(opcodes[op.opcode_index].get()->version);
 
     // NOTE We don't set quantization for Unpack itself but to virtual outputs
   }

--- a/compiler/luci/import/src/Nodes/CircleWhile.cpp
+++ b/compiler/luci/import/src/Nodes/CircleWhile.cpp
@@ -67,6 +67,7 @@ void CircleWhileGraphBuilder::build(const circle::OperatorT &op, GraphBuilderCon
   const std::vector<int32_t> &inputs = op.inputs;
   const std::vector<int32_t> &outputs = op.outputs;
   const auto &tensors = context->reader()->tensors();
+  const auto &opcodes = context->reader()->opcodes();
 
   std::vector<CircleNode *> input_nodes;
   for (const int32_t input_tensor_index : inputs)
@@ -96,6 +97,7 @@ void CircleWhileGraphBuilder::build(const circle::OperatorT &op, GraphBuilderCon
     // Lets use name of output 0 as While name
     const circle::TensorT &output_tensor = *tensors[outputs[0]];
     node->name(tensor_name(output_tensor));
+    node->op_version(opcodes[op.opcode_index].get()->version);
 
     // NOTE We don't set quantization for While itself but to virtual outputs
   }


### PR DESCRIPTION
Parent Issue : #3174
Draft : #3216

This commit will add marking operator version when `luci` imports
circle operators.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>