### PR TITLE
[tfl-inspect] Introduce DumpOperatorVersion

### DIFF
--- a/compiler/tfl-inspect/driver/Driver.cpp
+++ b/compiler/tfl-inspect/driver/Driver.cpp
@@ -35,9 +35,9 @@ int entry(int argc, char **argv)
       .nargs(0)
       .help("Dump Conv2D series weight operators in tflite file");
   arser.add_argument("--op_version")
-    .nargs(1)
-    .type(arser::DataType::STR)
-    .help("Dump tflite operator version");
+      .nargs(1)
+      .type(arser::DataType::STR)
+      .help("Dump tflite operator version");
   arser.add_argument("tflite").type(arser::DataType::STR).help("TFLite file to inspect");
 
   try

--- a/compiler/tfl-inspect/driver/Driver.cpp
+++ b/compiler/tfl-inspect/driver/Driver.cpp
@@ -34,6 +34,10 @@ int entry(int argc, char **argv)
   arser.add_argument("--conv2d_weight")
       .nargs(0)
       .help("Dump Conv2D series weight operators in tflite file");
+  arser.add_argument("--op_version")
+    .nargs(1)
+    .type(arser::DataType::STR)
+    .help("Dump tflite operator version");
   arser.add_argument("tflite").type(arser::DataType::STR).help("TFLite file to inspect");
 
   try
@@ -47,7 +51,7 @@ int entry(int argc, char **argv)
     return 255;
   }
 
-  if (!arser["--operators"] && !arser["--conv2d_weight"])
+  if (!arser["--operators"] && !arser["--conv2d_weight"] && !arser["--op_version"])
   {
     std::cout << "At least one option must be specified" << std::endl;
     std::cout << arser;
@@ -60,6 +64,8 @@ int entry(int argc, char **argv)
     dumps.push_back(stdex::make_unique<tflinspect::DumpOperators>());
   if (arser["--conv2d_weight"])
     dumps.push_back(stdex::make_unique<tflinspect::DumpConv2DWeight>());
+  if (arser["--op_version"])
+    dumps.push_back(stdex::make_unique<tflinspect::DumpOperatorVersion>());
 
   std::string model_file = arser.get<std::string>("tflite");
 

--- a/compiler/tfl-inspect/src/Dump.cpp
+++ b/compiler/tfl-inspect/src/Dump.cpp
@@ -141,3 +141,39 @@ void DumpConv2DWeight::run(std::ostream &os, const tflite::Model *model)
 }
 
 } // namespace tflinspect
+
+namespace tflinspect
+{
+
+void DumpOperatorVersion::run(std::ostream &os, const tflite::Model *model)
+{
+  std::map<std::string, int32_t> op_version_map;
+
+  tflinspect::Reader reader(model);
+
+  // This assert is subject to be changed later
+  assert(reader.num_subgraph() == 1);
+  reader.select_subgraph(0);
+
+  auto ops = reader.operators();
+
+  // Dump operators' version
+  for (uint32_t i = 0; i < ops->Length(); ++i)
+  {
+    const auto op = ops->Get(i);
+
+    auto op_name = reader.opcode_name(op);
+    auto op_version = reader.opcodes().at(op->opcode_index())->version();
+
+    if (op_version_map.find(op_name) == op_version_map.end() ||
+        op_version_map[op_name] < op_version)
+      op_version_map[op_name] = op_version;
+  }
+
+  for (auto op : op_version_map)
+  {
+    os << op.first << "," << op.second << std::endl;
+  }
+}
+
+} // namespace tflinspect

--- a/compiler/tfl-inspect/src/Dump.h
+++ b/compiler/tfl-inspect/src/Dump.h
@@ -51,6 +51,15 @@ public:
   void run(std::ostream &os, const tflite::Model *model);
 };
 
+class DumpOperatorVersion final : public DumpInterface
+{
+public:
+  DumpOperatorVersion() = default;
+
+public:
+  void run(std::ostream &os, const tflite::Model *model);
+};
+
 } // namespace tflinspect
 
 #endif // __DUMP_H__


### PR DESCRIPTION
Parent Issue : #3174
Draft : #3216

This commit will introduce `DumpOperatorVersion`, which dumps
the version of tflite operator.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>