### PR TITLE
[circle-inspect] Introduce DumpOperatorVersion

### DIFF
--- a/compiler/circle-inspect/driver/Driver.cpp
+++ b/compiler/circle-inspect/driver/Driver.cpp
@@ -34,6 +34,10 @@ int entry(int argc, char **argv)
   arser.add_argument("--conv2d_weight")
       .nargs(0)
       .help("Dump Conv2D series weight operators in circle file");
+  arser.add_argument("--op_version")
+      .nargs(1)
+      .type(arser::DataType::STR)
+      .help("Dump circle operator version");
   arser.add_argument("circle").type(arser::DataType::STR).help("Circle file to inspect");
 
   try
@@ -47,12 +51,17 @@ int entry(int argc, char **argv)
     return 255;
   }
 
-  if (!arser["--operators"] && !arser["--conv2d_weight"])
+  if (!arser["--operators"] && !arser["--conv2d_weight"] && !arser["--op_version"])
   {
     std::cout << "At least one option must be specified" << std::endl;
     std::cout << arser;
     return 255;
   }
+
+  argparse["--op_version"] = [&](void) {
+    // dump circle operator version
+    return std::move(stdex::make_unique<circleinspect::DumpOperatorVersion>());
+  };
 
   std::vector<std::unique_ptr<circleinspect::DumpInterface>> dumps;
 
@@ -60,6 +69,8 @@ int entry(int argc, char **argv)
     dumps.push_back(std::make_unique<circleinspect::DumpOperators>());
   if (arser["--conv2d_weight"])
     dumps.push_back(std::make_unique<circleinspect::DumpConv2DWeight>());
+  if (arser["--conv2d_weight"])
+    dumps.push_back(std::make_unique<circleinspect::DumpOperatorVersion>());
 
   std::string model_file = arser.get<std::string>("circle");
 

--- a/compiler/circle-inspect/driver/Driver.cpp
+++ b/compiler/circle-inspect/driver/Driver.cpp
@@ -58,11 +58,6 @@ int entry(int argc, char **argv)
     return 255;
   }
 
-  argparse["--op_version"] = [&](void) {
-    // dump circle operator version
-    return std::move(stdex::make_unique<circleinspect::DumpOperatorVersion>());
-  };
-
   std::vector<std::unique_ptr<circleinspect::DumpInterface>> dumps;
 
   if (arser["--operators"])

--- a/compiler/circle-inspect/driver/Driver.cpp
+++ b/compiler/circle-inspect/driver/Driver.cpp
@@ -64,7 +64,7 @@ int entry(int argc, char **argv)
     dumps.push_back(std::make_unique<circleinspect::DumpOperators>());
   if (arser["--conv2d_weight"])
     dumps.push_back(std::make_unique<circleinspect::DumpConv2DWeight>());
-  if (arser["--conv2d_weight"])
+  if (arser["--op_version"])
     dumps.push_back(std::make_unique<circleinspect::DumpOperatorVersion>());
 
   std::string model_file = arser.get<std::string>("circle");

--- a/compiler/circle-inspect/src/Dump.cpp
+++ b/compiler/circle-inspect/src/Dump.cpp
@@ -139,3 +139,39 @@ void DumpConv2DWeight::run(std::ostream &os, const circle::Model *model)
 }
 
 } // namespace circleinspect
+
+namespace circleinspect
+{
+
+void DumpOperatorVersion::run(std::ostream &os, const circle::Model *model)
+{
+  std::map<std::string, int32_t> op_version_map;
+
+  circleinspect::Reader reader(model);
+
+  // This assert is subject to be changed later
+  assert(reader.num_subgraph() == 1);
+  reader.select_subgraph(0);
+
+  auto ops = reader.operators();
+
+  // Dump operators' version
+  for (uint32_t i = 0; i < ops->Length(); ++i)
+  {
+    const auto op = ops->Get(i);
+
+    auto op_name = reader.opcode_name(op);
+    auto op_version = reader.opcodes().at(op->opcode_index())->version();
+
+    if (op_version_map.find(op_name) == op_version_map.end() ||
+        op_version_map[op_name] < op_version)
+      op_version_map[op_name] = op_version;
+  }
+
+  for (auto op : op_version_map)
+  {
+    os << op.first << "," << op.second << std::endl;
+  }
+}
+
+} // namespace circleinspect

--- a/compiler/circle-inspect/src/Dump.h
+++ b/compiler/circle-inspect/src/Dump.h
@@ -51,6 +51,15 @@ public:
   void run(std::ostream &os, const circle::Model *model);
 };
 
+class DumpOperatorVersion final : public DumpInterface
+{
+public:
+  DumpOperatorVersion() = default;
+
+public:
+  void run(std::ostream &os, const circle::Model *model);
+};
+
 } // namespace circleinspect
 
 #endif // __DUMP_H__


### PR DESCRIPTION
Parent Issue : #3174
Draft : #3216

This commit will introduce DumpOperatorVersion, which dumps
the version of circle operator.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>