### PR TITLE
[arser] Fix build fail by ignored-qualifiers warning

### DIFF
--- a/compiler/arser/include/arser/arser.h
+++ b/compiler/arser/include/arser/arser.h
@@ -427,7 +427,7 @@ std::ostream &operator<<(std::ostream &stream, const Arser &parser)
     stream << arg._name << " ";
     std::string arg_name = arg._name.substr(2);
     std::for_each(arg_name.begin(), arg_name.end(),
-                  [&stream](const char &c) { stream << static_cast<const char>(::toupper(c)); });
+                  [&stream](const char &c) { stream << static_cast<char>(::toupper(c)); });
     stream << " ";
   }
   // rest of the optional argument
@@ -441,7 +441,7 @@ std::ostream &operator<<(std::ostream &stream, const Arser &parser)
       stream << " ";
       std::string arg_name = arg._name.substr(2);
       std::for_each(arg_name.begin(), arg_name.end(),
-                    [&stream](const char &c) { stream << static_cast<const char>(::toupper(c)); });
+                    [&stream](const char &c) { stream << static_cast<char>(::toupper(c)); });
     }
     stream << "]"
            << " ";


### PR DESCRIPTION
Fix build fail on gcc 9.3.0 by ignored-qualifiers warning
(message: type qualifiers ignored on cast result type)

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>