### PR TITLE
[circledump] Support quantized_dimension

### DIFF
--- a/compiler/circledump/src/Dump.cpp
+++ b/compiler/circledump/src/Dump.cpp
@@ -172,7 +172,12 @@ void dump_sub_graph(std::ostream &os, circleread::Reader &reader)
             os << std::endl << strqindent;
         }
         if (q_params->zero_point())
+        {
           os << "zeropt(" << q_params->zero_point() << ") ";
+          if (q_params->zero_point()->size() > 1)
+            os << std::endl << strqindent;
+        }
+        os << "quantized_dimension(" << q_params->quantized_dimension() << ")";
 
         os << std::endl;
       }


### PR DESCRIPTION
This commit makes circledump support quantized_dimension

Related : #3218
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>