### PR TITLE
[tfl-inspect] Remove redundant std::move

### DIFF
--- a/compiler/tfl-inspect/driver/Driver.cpp
+++ b/compiler/tfl-inspect/driver/Driver.cpp
@@ -57,9 +57,9 @@ int entry(int argc, char **argv)
   std::vector<std::unique_ptr<tflinspect::DumpInterface>> dumps;
 
   if (arser["--operators"])
-    dumps.push_back(std::move(stdex::make_unique<tflinspect::DumpOperators>()));
+    dumps.push_back(stdex::make_unique<tflinspect::DumpOperators>());
   if (arser["--conv2d_weight"])
-    dumps.push_back(std::move(stdex::make_unique<tflinspect::DumpConv2DWeight>()));
+    dumps.push_back(stdex::make_unique<tflinspect::DumpConv2DWeight>());
 
   std::string model_file = arser.get<std::string>("tflite");
 


### PR DESCRIPTION
This commit remoes redundant std::move

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>