### PR TITLE
[circlechef] Revise set of BuiltinCode of circle

### DIFF
--- a/compiler/circlechef/core/src/ModelChef.cpp
+++ b/compiler/circlechef/core/src/ModelChef.cpp
@@ -556,7 +556,8 @@ GeneratedModel cook(const ::circlechef::ModelRecipe &model_recipe)
 
   // Create OperatorCode with Custom Operator
   std::set<std::string> custom_code_set = gather_customcode_set(model_recipe);
-  if (custom_code_set.size())
+  if (custom_code_set.size() &&
+      builtin_code_map.find(circle::BuiltinOperator_CUSTOM) == builtin_code_map.end())
     builtin_code_map[circle::BuiltinOperator_CUSTOM] = 1;
 
   for (auto opcode : custom_code_set)


### PR DESCRIPTION
Parent Issue : #3174
Draft : #3216

Until now, `builtin_code_set` did not include operator version.
This commit will revise it to include the version information by
changing it from `std::set` to `std::map`.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>