### PR TITLE
[circle-inspect] Fix wrong argument in arser

### DIFF
--- a/compiler/circle-inspect/driver/Driver.cpp
+++ b/compiler/circle-inspect/driver/Driver.cpp
@@ -34,9 +34,7 @@ int entry(int argc, char **argv)
   arser.add_argument("--conv2d_weight")
       .nargs(0)
       .help("Dump Conv2D series weight operators in circle file");
-  arser.add_argument("--op_version")
-      .nargs(0)
-      .help("Dump versions of the operators in circle file");
+  arser.add_argument("--op_version").nargs(0).help("Dump versions of the operators in circle file");
   arser.add_argument("circle").type(arser::DataType::STR).help("Circle file to inspect");
 
   try

--- a/compiler/circle-inspect/driver/Driver.cpp
+++ b/compiler/circle-inspect/driver/Driver.cpp
@@ -35,9 +35,8 @@ int entry(int argc, char **argv)
       .nargs(0)
       .help("Dump Conv2D series weight operators in circle file");
   arser.add_argument("--op_version")
-      .nargs(1)
-      .type(arser::DataType::STR)
-      .help("Dump circle operator version");
+      .nargs(0)
+      .help("Dump versions of the operators in circle file");
   arser.add_argument("circle").type(arser::DataType::STR).help("Circle file to inspect");
 
   try


### PR DESCRIPTION
Parent Issue : #3174
Draft : #3216

`circle` file is already passed by `circle` argument.
This commit will fix wrong argument for op_version.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>