### PR TITLE
[tflitefile_tool] fix select_operator in quantization

### DIFF
--- a/tools/tflitefile_tool/select_operator.py
+++ b/tools/tflitefile_tool/select_operator.py
@@ -175,7 +175,7 @@ def GenerateQuantization(new_builder, selected_quantization):
     # Create zero_point vector
     zeropoint_num = selected_quantization.ZeroPointLength()
     if zeropoint_num != 0:
-        tflite.QuantizationParameters.QuantizationParametersStartScaleVector(
+        tflite.QuantizationParameters.QuantizationParametersStartZeroPointVector(
             new_builder, zeropoint_num)
         for zeropoint_idx in reversed(range(zeropoint_num)):
             new_builder.PrependInt64(selected_quantization.ZeroPoint(zeropoint_idx))


### PR DESCRIPTION
It fixes the bug occasionally generates model with incorrect operator and
quantization parameters.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>