### PR TITLE
[luci-interpreter] Add accessors to individual kernel inputs / outputs

### DIFF
--- a/compiler/luci-interpreter/src/core/Kernel.h
+++ b/compiler/luci-interpreter/src/core/Kernel.h
@@ -27,11 +27,17 @@ namespace luci_interpreter
 // Base class for all kernels.
 class Kernel
 {
+protected:
+  Kernel(std::vector<const Tensor *> inputs, std::vector<Tensor *> outputs)
+      : _inputs(std::move(inputs)), _outputs(std::move(outputs))
+  {
+  }
+
 public:
   virtual ~Kernel() = default;
 
-  virtual std::vector<const Tensor *> getInputTensors() const = 0;
-  virtual std::vector<Tensor *> getOutputTensors() const = 0;
+  std::vector<const Tensor *> getInputTensors() const { return _inputs; }
+  std::vector<Tensor *> getOutputTensors() const { return _outputs; }
 
   // Configures the kernel.
   // This function is currently called once for each kernel during interpreter construction,
@@ -40,14 +46,24 @@ public:
 
   // Executes the kernel.
   virtual void execute() const = 0;
+
+protected:
+  // NOTE Prefer not to use these in derived classes.
+  const std::vector<const Tensor *> _inputs;
+  const std::vector<Tensor *> _outputs;
 };
 
 // Base class for kernels with parameters.
 template <typename Params> class KernelWithParams : public Kernel
 {
-public:
-  explicit KernelWithParams(const Params &params) : _params(params) {}
+protected:
+  KernelWithParams(std::vector<const Tensor *> inputs, std::vector<Tensor *> outputs,
+                   const Params &params)
+      : Kernel(std::move(inputs), std::move(outputs)), _params(params)
+  {
+  }
 
+public:
   const Params &params() const { return _params; }
 
 protected:

--- a/compiler/luci-interpreter/src/kernels/Add.h
+++ b/compiler/luci-interpreter/src/kernels/Add.h
@@ -30,8 +30,9 @@ class Add : public KernelWithParams<AddParams>
 public:
   Add(const Tensor *input1, const Tensor *input2, Tensor *output, const AddParams &params);
 
-  std::vector<const Tensor *> getInputTensors() const override { return {_input1, _input2}; }
-  std::vector<Tensor *> getOutputTensors() const override { return {_output}; }
+  const Tensor *input1() const { return _inputs[0]; }
+  const Tensor *input2() const { return _inputs[1]; }
+  Tensor *output() const { return _outputs[0]; }
 
   void configure() override;
   void execute() const override;
@@ -39,11 +40,6 @@ public:
 private:
   void evalFloat() const;
   void evalQuantized() const;
-
-private:
-  const Tensor *const _input1;
-  const Tensor *const _input2;
-  Tensor *const _output;
 };
 
 } // namespace kernels

--- a/compiler/luci-interpreter/src/kernels/ArgMax.h
+++ b/compiler/luci-interpreter/src/kernels/ArgMax.h
@@ -30,16 +30,12 @@ class ArgMax : public KernelWithParams<ArgMaxParams>
 public:
   ArgMax(const Tensor *input, const Tensor *axis, Tensor *output, const ArgMaxParams &params);
 
-  std::vector<const Tensor *> getInputTensors() const override { return {_input, _axis}; }
-  std::vector<Tensor *> getOutputTensors() const override { return {_output}; }
+  const Tensor *input() const { return _inputs[0]; }
+  const Tensor *axis() const { return _inputs[1]; }
+  Tensor *output() const { return _outputs[0]; }
 
   void configure() override;
   void execute() const override;
-
-private:
-  const Tensor *const _input;
-  const Tensor *const _axis;
-  Tensor *const _output;
 };
 
 } // namespace kernels

--- a/compiler/luci-interpreter/src/kernels/AveragePool2D.cpp
+++ b/compiler/luci-interpreter/src/kernels/AveragePool2D.cpp
@@ -29,13 +29,13 @@ namespace kernels
 {
 
 AveragePool2D::AveragePool2D(const Tensor *input, Tensor *output, const Pool2DParams &params)
-    : KernelWithParams<Pool2DParams>(params), _input(input), _output(output)
+    : KernelWithParams<Pool2DParams>({input}, {output}, params)
 {
 }
 
 void AveragePool2D::configure()
 {
-  const Shape &input_shape = _input->shape();
+  const Shape &input_shape = input()->shape();
 
   const int32_t batches = input_shape.dim(0);
   const int32_t input_height = input_shape.dim(1);
@@ -52,12 +52,12 @@ void AveragePool2D::configure()
   _padding_width =
       computePadding(_params.stride_width, 1, input_width, _params.filter_width, output_width);
 
-  _output->resize({batches, output_height, output_width, depth});
+  output()->resize({batches, output_height, output_width, depth});
 }
 
 void AveragePool2D::execute() const
 {
-  switch (_input->element_type())
+  switch (input()->element_type())
   {
     case DataType::FLOAT32:
       evalFloat();
@@ -86,15 +86,15 @@ void AveragePool2D::evalFloat() const
   params.float_activation_min = activation_min;
   params.float_activation_max = activation_max;
 
-  tflite::reference_ops::AveragePool(params, getTensorShape(_input), getTensorData<float>(_input),
-                                     getTensorShape(_output), getTensorData<float>(_output));
+  tflite::reference_ops::AveragePool(params, getTensorShape(input()), getTensorData<float>(input()),
+                                     getTensorShape(output()), getTensorData<float>(output()));
 }
 
 void AveragePool2D::evalQuantized() const
 {
   int32_t activation_min{};
   int32_t activation_max{};
-  calculateActivationRangeQuantized(_params.activation, _output, &activation_min, &activation_max);
+  calculateActivationRangeQuantized(_params.activation, output(), &activation_min, &activation_max);
 
   tflite::PoolParams params{};
   params.padding_values.height = _padding_height;
@@ -106,8 +106,9 @@ void AveragePool2D::evalQuantized() const
   params.quantized_activation_min = activation_min;
   params.quantized_activation_max = activation_max;
 
-  tflite::reference_ops::AveragePool(params, getTensorShape(_input), getTensorData<uint8_t>(_input),
-                                     getTensorShape(_output), getTensorData<uint8_t>(_output));
+  tflite::reference_ops::AveragePool(params, getTensorShape(input()),
+                                     getTensorData<uint8_t>(input()), getTensorShape(output()),
+                                     getTensorData<uint8_t>(output()));
 }
 
 } // namespace kernels

--- a/compiler/luci-interpreter/src/kernels/AveragePool2D.h
+++ b/compiler/luci-interpreter/src/kernels/AveragePool2D.h
@@ -30,8 +30,8 @@ class AveragePool2D : public KernelWithParams<Pool2DParams>
 public:
   AveragePool2D(const Tensor *input, Tensor *output, const Pool2DParams &params);
 
-  std::vector<const Tensor *> getInputTensors() const override { return {_input}; }
-  std::vector<Tensor *> getOutputTensors() const override { return {_output}; }
+  const Tensor *input() const { return _inputs[0]; }
+  Tensor *output() const { return _outputs[0]; }
 
   void configure() override;
   void execute() const override;
@@ -41,8 +41,6 @@ private:
   void evalQuantized() const;
 
 private:
-  const Tensor *const _input;
-  Tensor *const _output;
   int32_t _padding_height{};
   int32_t _padding_width{};
 };

--- a/compiler/luci-interpreter/src/kernels/Concatenation.cpp
+++ b/compiler/luci-interpreter/src/kernels/Concatenation.cpp
@@ -29,7 +29,7 @@ namespace kernels
 
 Concatenation::Concatenation(std::vector<const Tensor *> inputs, Tensor *output,
                              const ConcatenationParams &params)
-    : KernelWithParams<ConcatenationParams>(params), _inputs(std::move(inputs)), _output(output)
+    : KernelWithParams<ConcatenationParams>(std::move(inputs), {output}, params)
 {
 }
 
@@ -71,7 +71,7 @@ void Concatenation::configure()
   if (t0->element_type() == DataType::S8)
     throw std::runtime_error("Unsupported type.");
 
-  _output->resize(output_shape);
+  output()->resize(output_shape);
 }
 
 void Concatenation::execute() const
@@ -102,21 +102,21 @@ template <typename T> void Concatenation::evalGeneric() const
 {
   int axis = _params.axis;
   if (axis < 0)
-    axis += _output->shape().num_dims();
+    axis += output()->shape().num_dims();
 
   VectorOfTensors<T, true> inputs(_inputs);
   tflite::ConcatenationParams params{};
   params.axis = axis;
   params.inputs_count = _inputs.size();
   tflite::reference_ops::Concatenation(params, inputs.shapes(), inputs.data(),
-                                       getTensorShape(_output), getTensorData<T>(_output));
+                                       getTensorShape(output()), getTensorData<T>(output()));
 }
 
 void Concatenation::evalQuantized() const
 {
   int axis = _params.axis;
   if (axis < 0)
-    axis += _output->shape().num_dims();
+    axis += output()->shape().num_dims();
 
   VectorOfQuantizedTensors<true> inputs(_inputs);
   tflite::ConcatenationParams params{};
@@ -124,12 +124,12 @@ void Concatenation::evalQuantized() const
   params.input_zeropoint = inputs.zero_point();
   params.input_scale = inputs.scale();
   params.inputs_count = _inputs.size();
-  params.output_zeropoint = _output->zero_point();
-  params.output_scale = _output->scale();
+  params.output_zeropoint = output()->zero_point();
+  params.output_scale = output()->scale();
 
   tflite::reference_ops::ConcatenationWithScaling(params, inputs.shapes(), inputs.data(),
-                                                  getTensorShape(_output),
-                                                  getTensorData<uint8_t>(_output));
+                                                  getTensorShape(output()),
+                                                  getTensorData<uint8_t>(output()));
 }
 
 } // namespace kernels

--- a/compiler/luci-interpreter/src/kernels/Concatenation.h
+++ b/compiler/luci-interpreter/src/kernels/Concatenation.h
@@ -31,8 +31,8 @@ public:
   Concatenation(std::vector<const Tensor *> inputs, Tensor *output,
                 const ConcatenationParams &params);
 
-  std::vector<const Tensor *> getInputTensors() const override { return _inputs; }
-  std::vector<Tensor *> getOutputTensors() const override { return {_output}; }
+  const Tensor *input(int index) const { return _inputs[index]; }
+  Tensor *output() const { return _outputs[0]; }
 
   void configure() override;
   void execute() const override;
@@ -40,10 +40,6 @@ public:
 private:
   template <typename T> void evalGeneric() const;
   void evalQuantized() const;
-
-private:
-  const std::vector<const Tensor *> _inputs;
-  Tensor *const _output;
 };
 
 } // namespace kernels

--- a/compiler/luci-interpreter/src/kernels/Conv2D.cpp
+++ b/compiler/luci-interpreter/src/kernels/Conv2D.cpp
@@ -30,8 +30,7 @@ namespace kernels
 
 Conv2D::Conv2D(const Tensor *input, const Tensor *filter, const Tensor *bias, Tensor *output,
                const Conv2DParams &params)
-    : KernelWithParams<Conv2DParams>(params), _input(input), _filter(filter), _bias(bias),
-      _output(output)
+    : KernelWithParams<Conv2DParams>({input, filter, bias}, {output}, params)
 {
 }
 
@@ -46,22 +45,22 @@ void Conv2D::configure()
   // (4) | int8  int8   int32 int8   | quantized per channel
   //
   // We only support (1) and (3) for now.
-  if (_input->element_type() == DataType::FLOAT32 && _filter->element_type() == DataType::FLOAT32)
+  if (input()->element_type() == DataType::FLOAT32 && filter()->element_type() == DataType::FLOAT32)
   {
-    assert(_bias == nullptr || _bias->element_type() == DataType::FLOAT32);
+    assert(bias() == nullptr || bias()->element_type() == DataType::FLOAT32);
   }
-  else if (_input->element_type() == DataType::U8 && _filter->element_type() == DataType::U8)
+  else if (input()->element_type() == DataType::U8 && filter()->element_type() == DataType::U8)
   {
-    assert(_bias == nullptr || _bias->element_type() == DataType::S32);
+    assert(bias() == nullptr || bias()->element_type() == DataType::S32);
   }
   else
   {
     throw std::runtime_error("Unsupported type.");
   }
-  assert(_output->element_type() == _input->element_type());
+  assert(output()->element_type() == input()->element_type());
 
-  const Shape &input_shape = _input->shape();
-  const Shape &filter_shape = _filter->shape();
+  const Shape &input_shape = input()->shape();
+  const Shape &filter_shape = filter()->shape();
   assert(input_shape.num_dims() == 4 && filter_shape.num_dims() == 4);
 
   const int32_t batches = input_shape.dim(0);
@@ -72,8 +71,8 @@ void Conv2D::configure()
   const int32_t filter_width = filter_shape.dim(2);
   assert(filter_shape.dim(3) == input_shape.dim(3));
 
-  assert(_bias == nullptr ||
-         (_bias->shape().num_dims() == 1 && _bias->shape().dim(0) == output_depth));
+  assert(bias() == nullptr ||
+         (bias()->shape().num_dims() == 1 && bias()->shape().dim(0) == output_depth));
 
   const int32_t output_height =
       computeOutputSize(_params.padding, input_height, filter_height, _params.stride_height,
@@ -87,7 +86,7 @@ void Conv2D::configure()
   _padding_width = computePadding(_params.stride_width, _params.dilation_width_factor, input_width,
                                   filter_width, output_width);
 
-  _output->resize({batches, output_height, output_width, output_depth});
+  output()->resize({batches, output_height, output_width, output_depth});
 
   // Allocate tensor for Im2Col, if needed.
   // The checks here should be aligned with the actual implementation.
@@ -102,16 +101,16 @@ void Conv2D::configure()
     Shape im2col_shape{batches, output_height, output_width,
                        input_depth * filter_height * filter_width};
     _im2col =
-        std::make_unique<Tensor>(_input->element_type(), im2col_shape, AffineQuantization{}, "");
+        std::make_unique<Tensor>(input()->element_type(), im2col_shape, AffineQuantization{}, "");
   }
 }
 
 void Conv2D::execute() const
 {
-  switch (_input->element_type())
+  switch (input()->element_type())
   {
     case DataType::FLOAT32:
-      if (_filter->element_type() == DataType::FLOAT32)
+      if (filter()->element_type() == DataType::FLOAT32)
       {
         evalFloat();
         break;
@@ -141,18 +140,18 @@ void Conv2D::evalFloat() const
   params.float_activation_min = activation_min;
   params.float_activation_max = activation_max;
 
-  tflite::optimized_ops::Conv(params, getTensorShape(_input), getTensorData<float>(_input),
-                              getTensorShape(_filter), getTensorData<float>(_filter),
-                              getTensorShape(_bias), getTensorData<float>(_bias),
-                              getTensorShape(_output), getTensorData<float>(_output),
+  tflite::optimized_ops::Conv(params, getTensorShape(input()), getTensorData<float>(input()),
+                              getTensorShape(filter()), getTensorData<float>(filter()),
+                              getTensorShape(bias()), getTensorData<float>(bias()),
+                              getTensorShape(output()), getTensorData<float>(output()),
                               getTensorShape(_im2col.get()), getTensorData<float>(_im2col.get()));
 }
 
 void Conv2D::evalQuantized() const
 {
-  const auto input_scale = static_cast<double>(_input->scale());
-  const auto filter_scale = static_cast<double>(_filter->scale());
-  const auto output_scale = static_cast<double>(_output->scale());
+  const auto input_scale = static_cast<double>(input()->scale());
+  const auto filter_scale = static_cast<double>(filter()->scale());
+  const auto output_scale = static_cast<double>(output()->scale());
 
   const double real_multiplier = input_scale * filter_scale / output_scale;
   int32_t output_multiplier{};
@@ -161,7 +160,7 @@ void Conv2D::evalQuantized() const
 
   int32_t activation_min{};
   int32_t activation_max{};
-  calculateActivationRangeQuantized(_params.activation, _output, &activation_min, &activation_max);
+  calculateActivationRangeQuantized(_params.activation, output(), &activation_min, &activation_max);
 
   tflite::ConvParams params{};
   params.padding_values.height = _padding_height;
@@ -171,9 +170,9 @@ void Conv2D::evalQuantized() const
   params.dilation_height_factor = _params.dilation_height_factor;
   params.dilation_width_factor = _params.dilation_width_factor;
   // The kernel expects input and filter zero points to be negated.
-  params.input_offset = -_input->zero_point();    // Note the '-'.
-  params.weights_offset = -_filter->zero_point(); // Note the '-'.
-  params.output_offset = _output->zero_point();
+  params.input_offset = -input()->zero_point();    // Note the '-'.
+  params.weights_offset = -filter()->zero_point(); // Note the '-'.
+  params.output_offset = output()->zero_point();
   params.output_multiplier = output_multiplier;
   params.output_shift = output_shift;
   params.quantized_activation_min = activation_min;
@@ -185,9 +184,9 @@ void Conv2D::evalQuantized() const
   gemmlowp_context->set_max_num_threads(static_cast<int>(std::thread::hardware_concurrency()));
 
   tflite::optimized_ops::Conv(
-      params, getTensorShape(_input), getTensorData<uint8_t>(_input), getTensorShape(_filter),
-      getTensorData<uint8_t>(_filter), getTensorShape(_bias), getTensorData<int32_t>(_bias),
-      getTensorShape(_output), getTensorData<uint8_t>(_output), getTensorShape(_im2col.get()),
+      params, getTensorShape(input()), getTensorData<uint8_t>(input()), getTensorShape(filter()),
+      getTensorData<uint8_t>(filter()), getTensorShape(bias()), getTensorData<int32_t>(bias()),
+      getTensorShape(output()), getTensorData<uint8_t>(output()), getTensorShape(_im2col.get()),
       getTensorData<uint8_t>(_im2col.get()), gemmlowp_context.get());
 }
 

--- a/compiler/luci-interpreter/src/kernels/Conv2D.h
+++ b/compiler/luci-interpreter/src/kernels/Conv2D.h
@@ -33,8 +33,10 @@ public:
   Conv2D(const Tensor *input, const Tensor *filter, const Tensor *bias, Tensor *output,
          const Conv2DParams &params);
 
-  std::vector<const Tensor *> getInputTensors() const override { return {_input, _filter, _bias}; }
-  std::vector<Tensor *> getOutputTensors() const override { return {_output}; }
+  const Tensor *input() const { return _inputs[0]; }
+  const Tensor *filter() const { return _inputs[1]; }
+  const Tensor *bias() const { return _inputs[2]; }
+  Tensor *output() const { return _outputs[0]; }
 
   void configure() override;
   void execute() const override;
@@ -44,10 +46,6 @@ private:
   void evalQuantized() const;
 
 private:
-  const Tensor *const _input;
-  const Tensor *const _filter;
-  const Tensor *const _bias;
-  Tensor *const _output;
   std::unique_ptr<Tensor> _im2col;
   int32_t _padding_height{};
   int32_t _padding_width{};

--- a/compiler/luci-interpreter/src/kernels/DepthwiseConv2D.h
+++ b/compiler/luci-interpreter/src/kernels/DepthwiseConv2D.h
@@ -31,8 +31,10 @@ public:
   DepthwiseConv2D(const Tensor *input, const Tensor *filter, const Tensor *bias, Tensor *output,
                   const DepthwiseConv2DParams &params);
 
-  std::vector<const Tensor *> getInputTensors() const override { return {_input, _filter, _bias}; }
-  std::vector<Tensor *> getOutputTensors() const override { return {_output}; }
+  const Tensor *input() const { return _inputs[0]; }
+  const Tensor *filter() const { return _inputs[1]; }
+  const Tensor *bias() const { return _inputs[2]; }
+  Tensor *output() const { return _outputs[0]; }
 
   void configure() override;
   void execute() const override;
@@ -42,10 +44,6 @@ private:
   void evalQuantized() const;
 
 private:
-  const Tensor *const _input;
-  const Tensor *const _filter;
-  const Tensor *const _bias;
-  Tensor *const _output;
   int32_t _padding_height{};
   int32_t _padding_width{};
 };

--- a/compiler/luci-interpreter/src/kernels/Elu.cpp
+++ b/compiler/luci-interpreter/src/kernels/Elu.cpp
@@ -27,21 +27,21 @@ namespace luci_interpreter
 namespace kernels
 {
 
-Elu::Elu(const Tensor *input, Tensor *output) : _input(input), _output(output) {}
+Elu::Elu(const Tensor *input, Tensor *output) : Kernel({input}, {output}) {}
 
 void Elu::configure()
 {
-  assert(_input->element_type() == _output->element_type());
-  _output->resize(_input->shape());
+  assert(input()->element_type() == output()->element_type());
+  output()->resize(input()->shape());
 }
 
 void Elu::execute() const
 {
-  switch (_input->element_type())
+  switch (input()->element_type())
   {
     case DataType::FLOAT32:
-      tflite::optimized_ops::Elu(getTensorShape(_input), getTensorData<float>(_input),
-                                 getTensorShape(_output), getTensorData<float>(_output));
+      tflite::optimized_ops::Elu(getTensorShape(input()), getTensorData<float>(input()),
+                                 getTensorShape(output()), getTensorData<float>(output()));
       break;
     default:
       throw std::runtime_error("Unsupported type.");

--- a/compiler/luci-interpreter/src/kernels/Elu.h
+++ b/compiler/luci-interpreter/src/kernels/Elu.h
@@ -30,15 +30,11 @@ class Elu : public Kernel
 public:
   Elu(const Tensor *input, Tensor *output);
 
-  std::vector<const Tensor *> getInputTensors() const override { return {_input}; }
-  std::vector<Tensor *> getOutputTensors() const override { return {_output}; }
+  const Tensor *input() const { return _inputs[0]; }
+  Tensor *output() const { return _outputs[0]; }
 
   void configure() override;
   void execute() const override;
-
-private:
-  const Tensor *const _input;
-  Tensor *const _output;
 };
 
 } // namespace kernels

--- a/compiler/luci-interpreter/src/kernels/FullyConnected.h
+++ b/compiler/luci-interpreter/src/kernels/FullyConnected.h
@@ -31,20 +31,16 @@ public:
   FullyConnected(const Tensor *input, const Tensor *weights, const Tensor *bias, Tensor *output,
                  const FullyConnectedParams &params);
 
-  std::vector<const Tensor *> getInputTensors() const override { return {_input, _weights, _bias}; }
-  std::vector<Tensor *> getOutputTensors() const override { return {_output}; }
+  const Tensor *input() const { return _inputs[0]; }
+  const Tensor *weights() const { return _inputs[1]; }
+  const Tensor *bias() const { return _inputs[2]; }
+  Tensor *output() const { return _outputs[0]; }
 
   void configure() override;
   void execute() const override;
 
 private:
   void evalFloat() const;
-
-private:
-  const Tensor *const _input;
-  const Tensor *const _weights;
-  const Tensor *const _bias;
-  Tensor *const _output;
 };
 
 } // namespace kernels

--- a/compiler/luci-interpreter/src/kernels/If.h
+++ b/compiler/luci-interpreter/src/kernels/If.h
@@ -28,25 +28,17 @@ namespace kernels
 class If : public Kernel
 {
 public:
-  If(const Tensor *cond, std::vector<const Tensor *> inputs, std::vector<Tensor *> outputs,
+  If(const Tensor *cond, const std::vector<const Tensor *> &inputs, std::vector<Tensor *> outputs,
      RuntimeGraph *then_graph, RuntimeGraph *else_graph);
 
-  std::vector<const Tensor *> getInputTensors() const override
-  {
-    std::vector<const Tensor *> input_tensors{_cond};
-    input_tensors.insert(input_tensors.cend(), _inputs.cbegin(), _inputs.cend());
-    return input_tensors;
-  }
-
-  std::vector<Tensor *> getOutputTensors() const override { return _outputs; }
+  const Tensor *cond() const { return _inputs[0]; }
+  const Tensor *input(int index) const { return _inputs[1 + index]; }
+  Tensor *output(int index) const { return _outputs[index]; }
 
   void configure() override;
   void execute() const override;
 
 private:
-  const Tensor *const _cond;
-  const std::vector<const Tensor *> _inputs;
-  const std::vector<Tensor *> _outputs;
   RuntimeGraph *const _then_graph;
   RuntimeGraph *const _else_graph;
 };

--- a/compiler/luci-interpreter/src/kernels/L2Normalize.h
+++ b/compiler/luci-interpreter/src/kernels/L2Normalize.h
@@ -30,18 +30,14 @@ class L2Normalize : public KernelWithParams<L2NormParams>
 public:
   L2Normalize(const Tensor *input, Tensor *output, const L2NormParams &params);
 
-  std::vector<const Tensor *> getInputTensors() const override { return {_input}; }
-  std::vector<Tensor *> getOutputTensors() const override { return {_output}; }
+  const Tensor *input() const { return _inputs[0]; }
+  Tensor *output() const { return _outputs[0]; }
 
   void configure() override;
   void execute() const override;
 
 private:
   template <typename T> void eval(int32_t zero_point) const;
-
-private:
-  const Tensor *const _input;
-  Tensor *const _output;
 };
 
 } // namespace kernels

--- a/compiler/luci-interpreter/src/kernels/L2Pool2D.cpp
+++ b/compiler/luci-interpreter/src/kernels/L2Pool2D.cpp
@@ -30,19 +30,19 @@ namespace kernels
 {
 
 L2Pool2D::L2Pool2D(const Tensor *input, Tensor *output, const Pool2DParams &params)
-    : KernelWithParams<Pool2DParams>(params), _input(input), _output(output)
+    : KernelWithParams<Pool2DParams>({input}, {output}, params)
 {
 }
 
 void L2Pool2D::configure()
 {
-  assert(_input->shape().num_dims() == 4);
-  assert(_input->element_type() == _output->element_type());
+  assert(input()->shape().num_dims() == 4);
+  assert(input()->element_type() == output()->element_type());
 
-  int batches = _input->shape().dim(0);
-  int height = _input->shape().dim(1);
-  int width = _input->shape().dim(2);
-  int channels_out = _input->shape().dim(3);
+  int batches = input()->shape().dim(0);
+  int height = input()->shape().dim(1);
+  int width = input()->shape().dim(2);
+  int channels_out = input()->shape().dim(3);
 
   // Matching GetWindowedOutputSize in TensorFlow.
   auto padding = params().padding;
@@ -55,13 +55,13 @@ void L2Pool2D::configure()
   _padding_height =
       computePadding(params().stride_height, 1, height, params().filter_height, out_height);
 
-  assert(_input->element_type() == DataType::FLOAT32);
-  _output->resize({batches, out_height, out_width, channels_out});
+  assert(input()->element_type() == DataType::FLOAT32);
+  output()->resize({batches, out_height, out_width, channels_out});
 }
 
 void L2Pool2D::execute() const
 {
-  switch (_input->element_type())
+  switch (input()->element_type())
   {
     case DataType::FLOAT32:
       float activation_min, activation_max;
@@ -75,8 +75,9 @@ void L2Pool2D::execute() const
       op_params.padding_values.width = _padding_width;
       op_params.float_activation_min = activation_min;
       op_params.float_activation_max = activation_max;
-      tflite::optimized_ops::L2Pool(op_params, getTensorShape(_input), getTensorData<float>(_input),
-                                    getTensorShape(_output), getTensorData<float>(_output));
+      tflite::optimized_ops::L2Pool(op_params, getTensorShape(input()),
+                                    getTensorData<float>(input()), getTensorShape(output()),
+                                    getTensorData<float>(output()));
       break;
     default:
       throw std::runtime_error("Unsupported type.");

--- a/compiler/luci-interpreter/src/kernels/L2Pool2D.h
+++ b/compiler/luci-interpreter/src/kernels/L2Pool2D.h
@@ -32,18 +32,15 @@ class L2Pool2D : public KernelWithParams<Pool2DParams>
 public:
   L2Pool2D(const Tensor *input, Tensor *output, const Pool2DParams &params);
 
-  std::vector<const Tensor *> getInputTensors() const override { return {_input}; }
-  std::vector<Tensor *> getOutputTensors() const override { return {_output}; }
+  const Tensor *input() const { return _inputs[0]; }
+  Tensor *output() const { return _outputs[0]; }
 
   void configure() override;
   void execute() const override;
 
 private:
-  const Tensor *const _input;
-  Tensor *const _output;
-
-  int _padding_height = 0;
-  int _padding_width = 0;
+  int32_t _padding_height = 0;
+  int32_t _padding_width = 0;
 };
 
 } // namespace kernels

--- a/compiler/luci-interpreter/src/kernels/LeakyRelu.cpp
+++ b/compiler/luci-interpreter/src/kernels/LeakyRelu.cpp
@@ -30,28 +30,28 @@ namespace kernels
 {
 
 LeakyRelu::LeakyRelu(const Tensor *input, Tensor *output, const LeakyReluParams &params)
-    : KernelWithParams<LeakyReluParams>(params), _input(input), _output(output)
+    : KernelWithParams<LeakyReluParams>({input}, {output}, params)
 {
 }
 
 void LeakyRelu::configure()
 {
-  assert(_input->element_type() == _output->element_type());
-  if (_input->element_type() == DataType::U8)
+  assert(input()->element_type() == output()->element_type());
+  if (input()->element_type() == DataType::U8)
   {
     _q_alpha = static_cast<uint8_t>(std::max<float>(
         std::numeric_limits<uint8_t>::min(),
         std::min<float>(std::numeric_limits<uint8_t>::max(),
-                        std::round(_input->zero_point() + (params().alpha / _input->scale())))));
-    double real_multiplier = _input->scale() * _input->scale() / _output->scale();
+                        std::round(input()->zero_point() + (params().alpha / input()->scale())))));
+    double real_multiplier = input()->scale() * input()->scale() / output()->scale();
     quantizeMultiplierSmallerThanOneExp(real_multiplier, &_output_multiplier, &_output_shift);
   }
-  _output->resize(_input->shape());
+  output()->resize(input()->shape());
 }
 
 void LeakyRelu::execute() const
 {
-  switch (_input->element_type())
+  switch (input()->element_type())
   {
     case DataType::FLOAT32:
       evalFloat();
@@ -68,23 +68,24 @@ void LeakyRelu::evalFloat() const
 {
   tflite::LeakyReluParams op_params{};
   op_params.alpha = params().alpha;
-  tflite::optimized_ops::LeakyRelu(op_params, getTensorShape(_input), getTensorData<float>(_input),
-                                   getTensorShape(_output), getTensorData<float>(_output));
+  tflite::optimized_ops::LeakyRelu(op_params, getTensorShape(input()),
+                                   getTensorData<float>(input()), getTensorShape(output()),
+                                   getTensorData<float>(output()));
 }
 
 void LeakyRelu::evalQuantized() const
 {
   tflite::LeakyReluParams op_params{};
-  op_params.input_offset = _input->zero_point();
-  op_params.alpha_offset = _input->zero_point();
-  op_params.output_offset = _output->zero_point();
+  op_params.input_offset = input()->zero_point();
+  op_params.alpha_offset = input()->zero_point();
+  op_params.output_offset = output()->zero_point();
 
   op_params.output_multiplier = _output_multiplier;
   op_params.output_shift = _output_shift;
 
-  tflite::reference_ops::QuantizeLeakyRelu(op_params, _q_alpha, getTensorShape(_input),
-                                           getTensorData<uint8_t>(_input), getTensorShape(_output),
-                                           getTensorData<uint8_t>(_output));
+  tflite::reference_ops::QuantizeLeakyRelu(
+      op_params, _q_alpha, getTensorShape(input()), getTensorData<uint8_t>(input()),
+      getTensorShape(output()), getTensorData<uint8_t>(output()));
 }
 
 } // namespace kernels

--- a/compiler/luci-interpreter/src/kernels/LeakyRelu.h
+++ b/compiler/luci-interpreter/src/kernels/LeakyRelu.h
@@ -30,8 +30,8 @@ class LeakyRelu : public KernelWithParams<LeakyReluParams>
 public:
   LeakyRelu(const Tensor *input, Tensor *output, const LeakyReluParams &params);
 
-  std::vector<const Tensor *> getInputTensors() const override { return {_input}; }
-  std::vector<Tensor *> getOutputTensors() const override { return {_output}; }
+  const Tensor *input() const { return _inputs[0]; }
+  Tensor *output() const { return _outputs[0]; }
 
   void configure() override;
   void execute() const override;
@@ -39,10 +39,6 @@ public:
 private:
   void evalFloat() const;
   void evalQuantized() const;
-
-private:
-  const Tensor *const _input;
-  Tensor *const _output;
 
 private:
   uint8_t _q_alpha = 0;

--- a/compiler/luci-interpreter/src/kernels/LocalResponseNormalization.cpp
+++ b/compiler/luci-interpreter/src/kernels/LocalResponseNormalization.cpp
@@ -30,21 +30,21 @@ namespace kernels
 
 LocalResponseNormalization::LocalResponseNormalization(
     const Tensor *input, Tensor *output, const LocalResponseNormalizationParams &params)
-    : KernelWithParams<LocalResponseNormalizationParams>(params), _input(input), _output(output)
+    : KernelWithParams<LocalResponseNormalizationParams>({input}, {output}, params)
 {
 }
 
 void LocalResponseNormalization::configure()
 {
-  assert(_input->shape().num_dims() == 4);
-  assert(_output->element_type() == DataType::FLOAT32);
-  assert(_input->element_type() == _output->element_type());
-  _output->resize(_input->shape());
+  assert(input()->shape().num_dims() == 4);
+  assert(output()->element_type() == DataType::FLOAT32);
+  assert(input()->element_type() == output()->element_type());
+  output()->resize(input()->shape());
 }
 
 void LocalResponseNormalization::execute() const
 {
-  switch (_output->element_type())
+  switch (output()->element_type())
   {
     case DataType::FLOAT32:
       tflite::LocalResponseNormalizationParams op_params;
@@ -53,8 +53,8 @@ void LocalResponseNormalization::execute() const
       op_params.alpha = params().alpha;
       op_params.beta = params().beta;
       tflite::optimized_ops::LocalResponseNormalization(
-          op_params, getTensorShape(_input), getTensorData<float>(_input), getTensorShape(_output),
-          getTensorData<float>(_output));
+          op_params, getTensorShape(input()), getTensorData<float>(input()),
+          getTensorShape(output()), getTensorData<float>(output()));
       break;
     default:
       throw std::runtime_error("Unsupported type.");

--- a/compiler/luci-interpreter/src/kernels/LocalResponseNormalization.h
+++ b/compiler/luci-interpreter/src/kernels/LocalResponseNormalization.h
@@ -31,15 +31,11 @@ public:
   LocalResponseNormalization(const Tensor *input, Tensor *output,
                              const LocalResponseNormalizationParams &params);
 
-  std::vector<const Tensor *> getInputTensors() const override { return {_input}; }
-  std::vector<Tensor *> getOutputTensors() const override { return {_output}; }
+  const Tensor *input() const { return _inputs[0]; }
+  Tensor *output() const { return _outputs[0]; }
 
   void configure() override;
   void execute() const override;
-
-private:
-  const Tensor *const _input;
-  Tensor *const _output;
 };
 
 } // namespace kernels

--- a/compiler/luci-interpreter/src/kernels/Logistic.cpp
+++ b/compiler/luci-interpreter/src/kernels/Logistic.cpp
@@ -25,24 +25,22 @@ namespace luci_interpreter
 namespace kernels
 {
 
-Logistic::Logistic(const Tensor *input, Tensor *output) : _input(input), _output(output), _table{0}
-{
-}
+Logistic::Logistic(const Tensor *input, Tensor *output) : Kernel({input}, {output}) {}
 
 void Logistic::configure()
 {
-  assert(_input->element_type() == _output->element_type());
-  if (_input->element_type() == DataType::U8)
+  assert(input()->element_type() == output()->element_type());
+  if (input()->element_type() == DataType::U8)
   {
-    assert(_output->scale() == 1. / 256);
+    assert(output()->scale() == 1. / 256);
     populateLookupTable();
   }
-  _output->resize(_input->shape());
+  output()->resize(input()->shape());
 }
 
 void Logistic::execute() const
 {
-  switch (_input->element_type())
+  switch (input()->element_type())
   {
     case DataType::FLOAT32:
       evalFloat();
@@ -57,15 +55,15 @@ void Logistic::execute() const
 
 void Logistic::evalFloat() const
 {
-  tflite::reference_ops::Logistic(getTensorShape(_input), getTensorData<float>(_input),
-                                  getTensorShape(_output), getTensorData<float>(_output));
+  tflite::reference_ops::Logistic(getTensorShape(input()), getTensorData<float>(input()),
+                                  getTensorShape(output()), getTensorData<float>(output()));
 }
 
 void Logistic::evalQuantized() const
 {
-  const int size = tflite::MatchingFlatSize(getTensorShape(_input), getTensorShape(_output));
-  uint8_t *output_data = getTensorData<uint8_t>(_output);
-  const uint8_t *input_data = getTensorData<uint8_t>(_input);
+  const int size = tflite::MatchingFlatSize(getTensorShape(input()), getTensorShape(output()));
+  uint8_t *output_data = getTensorData<uint8_t>(output());
+  const uint8_t *input_data = getTensorData<uint8_t>(input());
   for (int i = 0; i < size; ++i)
   {
     output_data[i] = getTableValue(input_data[i]);
@@ -74,10 +72,10 @@ void Logistic::evalQuantized() const
 
 void Logistic::populateLookupTable()
 {
-  const auto input_scale = static_cast<double>(_input->scale());
-  const auto input_zero_point = static_cast<int32_t>(_input->zero_point());
-  const auto output_scale = static_cast<double>(_output->scale());
-  const auto output_zero_point = static_cast<int32_t>(_output->zero_point());
+  const auto input_scale = static_cast<double>(input()->scale());
+  const auto input_zero_point = static_cast<int32_t>(input()->zero_point());
+  const auto output_scale = static_cast<double>(output()->scale());
+  const auto output_zero_point = static_cast<int32_t>(output()->zero_point());
   const float inverse_scale = 1 / output_scale;
   int32_t maxval = std::numeric_limits<uint8_t>::max();
   int32_t minval = std::numeric_limits<uint8_t>::min();

--- a/compiler/luci-interpreter/src/kernels/Logistic.h
+++ b/compiler/luci-interpreter/src/kernels/Logistic.h
@@ -29,8 +29,8 @@ class Logistic : public Kernel
 public:
   Logistic(const Tensor *input, Tensor *output);
 
-  std::vector<const Tensor *> getInputTensors() const override { return {_input}; }
-  std::vector<Tensor *> getOutputTensors() const override { return {_output}; }
+  const Tensor *input() const { return _inputs[0]; }
+  Tensor *output() const { return _outputs[0]; }
 
   void configure() override;
   void execute() const override;
@@ -43,9 +43,7 @@ private:
   uint8_t getTableValue(uint8_t idx) const { return _table[idx]; };
 
 private:
-  const Tensor *const _input;
-  Tensor *const _output;
-  uint8_t _table[256];
+  uint8_t _table[256]{};
 };
 
 } // namespace kernels

--- a/compiler/luci-interpreter/src/kernels/MaxPool2D.h
+++ b/compiler/luci-interpreter/src/kernels/MaxPool2D.h
@@ -30,8 +30,8 @@ class MaxPool2D : public KernelWithParams<Pool2DParams>
 public:
   MaxPool2D(const Tensor *input, Tensor *output, const Pool2DParams &params);
 
-  std::vector<const Tensor *> getInputTensors() const override { return {_input}; }
-  std::vector<Tensor *> getOutputTensors() const override { return {_output}; }
+  const Tensor *input() const { return _inputs[0]; }
+  Tensor *output() const { return _outputs[0]; }
 
   void configure() override;
   void execute() const override;
@@ -41,8 +41,6 @@ private:
   void evalQuantized() const;
 
 private:
-  const Tensor *const _input;
-  Tensor *const _output;
   int32_t _padding_height{};
   int32_t _padding_width{};
 };

--- a/compiler/luci-interpreter/src/kernels/Mean.h
+++ b/compiler/luci-interpreter/src/kernels/Mean.h
@@ -32,8 +32,9 @@ class Mean : public KernelWithParams<ReducerParams>
 public:
   Mean(const Tensor *input, const Tensor *axes, Tensor *output, const ReducerParams &params);
 
-  std::vector<const Tensor *> getInputTensors() const override { return {_input, _axes}; }
-  std::vector<Tensor *> getOutputTensors() const override { return {_output}; }
+  const Tensor *input() const { return _inputs[0]; }
+  const Tensor *axes() const { return _inputs[1]; }
+  Tensor *output() const { return _outputs[0]; }
 
   void configure() override;
   void execute() const override;
@@ -43,9 +44,6 @@ private:
   void evalQuantized() const;
 
 private:
-  const Tensor *const _input;
-  const Tensor *const _axes;
-  Tensor *const _output;
   std::unique_ptr<Tensor> _temp_index;
   std::unique_ptr<Tensor> _resolved_axes;
   std::unique_ptr<Tensor> _temp_sum;

--- a/compiler/luci-interpreter/src/kernels/Mul.cpp
+++ b/compiler/luci-interpreter/src/kernels/Mul.cpp
@@ -29,19 +29,19 @@ namespace kernels
 {
 
 Mul::Mul(const Tensor *input1, const Tensor *input2, Tensor *output, const MulParams &params)
-    : KernelWithParams<MulParams>(params), _input1(input1), _input2(input2), _output(output)
+    : KernelWithParams<MulParams>({input1, input2}, {output}, params)
 {
 }
 
 void Mul::configure()
 {
-  assert(_input1->element_type() == _input2->element_type());
-  _output->resize(calculateShapeForBroadcast(_input1->shape(), _input2->shape()));
+  assert(input1()->element_type() == input2()->element_type());
+  output()->resize(calculateShapeForBroadcast(input1()->shape(), input2()->shape()));
 }
 
 void Mul::execute() const
 {
-  switch (_input1->element_type())
+  switch (input1()->element_type())
   {
     case DataType::FLOAT32:
       evalFloat();
@@ -62,19 +62,19 @@ void Mul::evalFloat() const
   params.float_activation_max = activation_max;
 
   const bool need_broadcast = tflite::reference_ops::ProcessBroadcastShapes(
-      getTensorShape(_input1), getTensorShape(_input2), &params);
+      getTensorShape(input1()), getTensorShape(input2()), &params);
 
   if (need_broadcast)
   {
     tflite::reference_ops::BroadcastMul4DSlow(
-        params, getTensorShape(_input1), getTensorData<float>(_input1), getTensorShape(_input2),
-        getTensorData<float>(_input2), getTensorShape(_output), getTensorData<float>(_output));
+        params, getTensorShape(input1()), getTensorData<float>(input1()), getTensorShape(input2()),
+        getTensorData<float>(input2()), getTensorShape(output()), getTensorData<float>(output()));
   }
   else
   {
-    tflite::reference_ops::Mul(params, getTensorShape(_input1), getTensorData<float>(_input1),
-                               getTensorShape(_input2), getTensorData<float>(_input2),
-                               getTensorShape(_output), getTensorData<float>(_output));
+    tflite::reference_ops::Mul(params, getTensorShape(input1()), getTensorData<float>(input1()),
+                               getTensorShape(input2()), getTensorData<float>(input2()),
+                               getTensorShape(output()), getTensorData<float>(output()));
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/Mul.h
+++ b/compiler/luci-interpreter/src/kernels/Mul.h
@@ -33,19 +33,15 @@ class Mul : public KernelWithParams<MulParams>
 public:
   Mul(const Tensor *input1, const Tensor *input2, Tensor *output, const MulParams &params);
 
-  std::vector<const Tensor *> getInputTensors() const override { return {_input1, _input2}; }
-  std::vector<Tensor *> getOutputTensors() const override { return {_output}; }
+  const Tensor *input1() const { return _inputs[0]; }
+  const Tensor *input2() const { return _inputs[1]; }
+  Tensor *output() const { return _outputs[0]; }
 
   void configure() override;
   void execute() const override;
 
 private:
   void evalFloat() const;
-
-private:
-  const Tensor *const _input1;
-  const Tensor *const _input2;
-  Tensor *const _output;
 };
 
 } // namespace kernels

--- a/compiler/luci-interpreter/src/kernels/Pad.cpp
+++ b/compiler/luci-interpreter/src/kernels/Pad.cpp
@@ -26,27 +26,27 @@ namespace kernels
 {
 
 Pad::Pad(const Tensor *input, const Tensor *paddings, Tensor *output)
-    : _input(input), _paddings(paddings), _output(output)
+    : Kernel({input, paddings}, {output})
 {
 }
 
 void Pad::configure()
 {
-  const Shape &input_shape = _input->shape();
+  const Shape &input_shape = input()->shape();
   const int num_dims = input_shape.num_dims();
 
   if (num_dims > 4)
     throw std::runtime_error("Unsupported number of dimensions.");
 
-  assert(_output->element_type() == _input->element_type());
-  assert(_paddings->element_type() == DataType::S32);
+  assert(output()->element_type() == input()->element_type());
+  assert(paddings()->element_type() == DataType::S32);
   // Paddings shape should be [N, 2].
-  assert(_paddings->shape().num_dims() == 2);
-  assert(_paddings->shape().dim(0) == num_dims);
-  assert(_paddings->shape().dim(1) == 2);
+  assert(paddings()->shape().num_dims() == 2);
+  assert(paddings()->shape().dim(0) == num_dims);
+  assert(paddings()->shape().dim(1) == 2);
 
   Shape output_shape(num_dims);
-  const auto *paddings_data = getTensorData<int32_t>(_paddings);
+  const auto *paddings_data = getTensorData<int32_t>(paddings());
   for (int i = 0; i < num_dims; ++i)
   {
     const int32_t padding_before = paddings_data[i * 2];
@@ -55,42 +55,42 @@ void Pad::configure()
     output_shape.dim(i) = input_shape.dim(i) + padding_before + padding_after;
   }
 
-  _output->resize(output_shape);
+  output()->resize(output_shape);
 }
 
 void Pad::execute() const
 {
-  const int num_dims = _input->shape().num_dims();
+  const int num_dims = input()->shape().num_dims();
 
   tflite::PadParams params{};
   params.left_padding_count = num_dims;
   params.right_padding_count = num_dims;
 
-  const auto *paddings_data = getTensorData<int32_t>(_paddings);
+  const auto *paddings_data = getTensorData<int32_t>(paddings());
   for (int i = num_dims - 1; i >= 0; --i)
   {
     params.left_padding[i] = paddings_data[i * 2];
     params.right_padding[i] = paddings_data[i * 2 + 1];
   }
 
-  switch (_input->element_type())
+  switch (input()->element_type())
   {
     case DataType::FLOAT32:
     {
       const float pad_value = 0.0f;
-      tflite::reference_ops::Pad(params, getTensorShape(_input), getTensorData<float>(_input),
-                                 &pad_value, getTensorShape(_output),
-                                 getTensorData<float>(_output));
+      tflite::reference_ops::Pad(params, getTensorShape(input()), getTensorData<float>(input()),
+                                 &pad_value, getTensorShape(output()),
+                                 getTensorData<float>(output()));
       break;
     }
     case DataType::U8:
     {
-      assert(_output->zero_point() >= std::numeric_limits<uint8_t>::min());
-      assert(_output->zero_point() <= std::numeric_limits<uint8_t>::max());
-      const auto pad_value = static_cast<uint8_t>(_output->zero_point());
-      tflite::reference_ops::Pad(params, getTensorShape(_input), getTensorData<uint8_t>(_input),
-                                 &pad_value, getTensorShape(_output),
-                                 getTensorData<uint8_t>(_output));
+      assert(output()->zero_point() >= std::numeric_limits<uint8_t>::min());
+      assert(output()->zero_point() <= std::numeric_limits<uint8_t>::max());
+      const auto pad_value = static_cast<uint8_t>(output()->zero_point());
+      tflite::reference_ops::Pad(params, getTensorShape(input()), getTensorData<uint8_t>(input()),
+                                 &pad_value, getTensorShape(output()),
+                                 getTensorData<uint8_t>(output()));
       break;
     }
     default:

--- a/compiler/luci-interpreter/src/kernels/Pad.h
+++ b/compiler/luci-interpreter/src/kernels/Pad.h
@@ -29,16 +29,12 @@ class Pad : public Kernel
 public:
   Pad(const Tensor *input, const Tensor *paddings, Tensor *output);
 
-  std::vector<const Tensor *> getInputTensors() const override { return {_input, _paddings}; }
-  std::vector<Tensor *> getOutputTensors() const override { return {_output}; }
+  const Tensor *input() const { return _inputs[0]; }
+  const Tensor *paddings() const { return _inputs[1]; }
+  Tensor *output() const { return _outputs[0]; }
 
   void configure() override;
   void execute() const override;
-
-private:
-  const Tensor *const _input;
-  const Tensor *const _paddings;
-  Tensor *const _output;
 };
 
 } // namespace kernels

--- a/compiler/luci-interpreter/src/kernels/Reshape.cpp
+++ b/compiler/luci-interpreter/src/kernels/Reshape.cpp
@@ -65,24 +65,24 @@ static void resolveUnknownDimension(const Shape &input_shape, Shape *output_shap
 }
 
 Reshape::Reshape(const Tensor *input, const Tensor *shape, Tensor *output)
-    : _input(input), _shape(shape), _output(output)
+    : Kernel({input, shape}, {output})
 {
 }
 
 void Reshape::configure()
 {
-  Shape output_shape = extractShapeFromTensor(_shape);
-  resolveUnknownDimension(_input->shape(), &output_shape);
-  _output->resize(output_shape);
+  Shape output_shape = extractShapeFromTensor(shape());
+  resolveUnknownDimension(input()->shape(), &output_shape);
+  output()->resize(output_shape);
 }
 
 void Reshape::execute() const
 {
-  const auto *input_data = _input->data<void>();
-  auto *output_data = _output->data<void>();
+  const auto *input_data = input()->data<void>();
+  auto *output_data = output()->data<void>();
 
-  const size_t element_size = getDataTypeSize(_input->element_type());
-  const int32_t num_elements = _input->shape().num_elements();
+  const size_t element_size = getDataTypeSize(input()->element_type());
+  const int32_t num_elements = input()->shape().num_elements();
   std::memcpy(output_data, input_data, num_elements * element_size);
 }
 

--- a/compiler/luci-interpreter/src/kernels/Reshape.h
+++ b/compiler/luci-interpreter/src/kernels/Reshape.h
@@ -29,16 +29,12 @@ class Reshape : public Kernel
 public:
   Reshape(const Tensor *input, const Tensor *shape, Tensor *output);
 
-  std::vector<const Tensor *> getInputTensors() const override { return {_input, _shape}; }
-  std::vector<Tensor *> getOutputTensors() const override { return {_output}; }
+  const Tensor *input() const { return _inputs[0]; }
+  const Tensor *shape() const { return _inputs[1]; }
+  Tensor *output() const { return _outputs[0]; }
 
   void configure() override;
   void execute() const override;
-
-private:
-  const Tensor *const _input;
-  const Tensor *const _shape;
-  Tensor *const _output;
 };
 
 } // namespace kernels

--- a/compiler/luci-interpreter/src/kernels/Softmax.cpp
+++ b/compiler/luci-interpreter/src/kernels/Softmax.cpp
@@ -29,19 +29,19 @@ namespace kernels
 {
 
 Softmax::Softmax(const Tensor *input, Tensor *output, const SoftmaxParams &params)
-    : KernelWithParams<SoftmaxParams>(params), _input(input), _output(output)
+    : KernelWithParams<SoftmaxParams>({input}, {output}, params)
 {
 }
 
 void Softmax::configure()
 {
-  assert(_input->element_type() == _output->element_type());
-  _output->resize(_input->shape());
+  assert(input()->element_type() == output()->element_type());
+  output()->resize(input()->shape());
 }
 
 void Softmax::execute() const
 {
-  switch (_input->element_type())
+  switch (input()->element_type())
   {
     case DataType::FLOAT32:
       evalFloat();
@@ -56,8 +56,8 @@ void Softmax::evalFloat() const
   tflite::SoftmaxParams params{};
   params.beta = _params.beta;
 
-  tflite::reference_ops::Softmax(params, getTensorShape(_input), getTensorData<float>(_input),
-                                 getTensorShape(_output), getTensorData<float>(_output));
+  tflite::reference_ops::Softmax(params, getTensorShape(input()), getTensorData<float>(input()),
+                                 getTensorShape(output()), getTensorData<float>(output()));
 }
 
 } // namespace kernels

--- a/compiler/luci-interpreter/src/kernels/Softmax.h
+++ b/compiler/luci-interpreter/src/kernels/Softmax.h
@@ -30,18 +30,14 @@ class Softmax : public KernelWithParams<SoftmaxParams>
 public:
   Softmax(const Tensor *input, Tensor *output, const SoftmaxParams &params);
 
-  std::vector<const Tensor *> getInputTensors() const override { return {_input}; }
-  std::vector<Tensor *> getOutputTensors() const override { return {_output}; }
+  const Tensor *input() const { return _inputs[0]; }
+  Tensor *output() const { return _outputs[0]; }
 
   void configure() override;
   void execute() const override;
 
 private:
   void evalFloat() const;
-
-private:
-  const Tensor *const _input;
-  Tensor *const _output;
 };
 
 } // namespace kernels

--- a/compiler/luci-interpreter/src/kernels/SpaceToDepth.cpp
+++ b/compiler/luci-interpreter/src/kernels/SpaceToDepth.cpp
@@ -24,21 +24,21 @@ namespace kernels
 {
 
 SpaceToDepth::SpaceToDepth(const Tensor *input, Tensor *output, const SpaceToDepthParams &params)
-    : KernelWithParams<SpaceToDepthParams>(params), _input(input), _output(output)
+    : KernelWithParams<SpaceToDepthParams>({input}, {output}, params)
 {
 }
 
 void SpaceToDepth::configure()
 {
-  assert(_input->shape().num_dims() == 4);
-  assert(_output->element_type() == DataType::FLOAT32 || _output->element_type() == DataType::U8 ||
-         _output->element_type() == DataType::S8 || _output->element_type() == DataType::S32 ||
-         _output->element_type() == DataType::S64);
-  assert(_input->element_type() == _output->element_type());
+  assert(input()->shape().num_dims() == 4);
+  assert(output()->element_type() == DataType::FLOAT32 ||
+         output()->element_type() == DataType::U8 || output()->element_type() == DataType::S8 ||
+         output()->element_type() == DataType::S32 || output()->element_type() == DataType::S64);
+  assert(input()->element_type() == output()->element_type());
 
   const int block_size = params().block_size;
-  const int32_t input_height = _input->shape().dim(1);
-  const int32_t input_width = _input->shape().dim(2);
+  const int32_t input_height = input()->shape().dim(1);
+  const int32_t input_width = input()->shape().dim(2);
   int32_t output_height = input_height / block_size;
   int32_t output_width = input_width / block_size;
 
@@ -46,29 +46,29 @@ void SpaceToDepth::configure()
   assert(input_width == output_width * block_size);
 
   Shape output_shape(4);
-  output_shape.dim(0) = _input->shape().dim(0);
+  output_shape.dim(0) = input()->shape().dim(0);
   output_shape.dim(1) = output_height;
   output_shape.dim(2) = output_width;
-  output_shape.dim(3) = _input->shape().dim(3) * block_size * block_size;
+  output_shape.dim(3) = input()->shape().dim(3) * block_size * block_size;
 
-  _output->resize(output_shape);
+  output()->resize(output_shape);
 }
 
 void SpaceToDepth::execute() const
 {
   tflite::SpaceToDepthParams op_params{};
   op_params.block_size = params().block_size;
-  switch (_input->element_type())
+  switch (input()->element_type())
   {
     case DataType::FLOAT32:
-      tflite::optimized_ops::SpaceToDepth(op_params, getTensorShape(_input),
-                                          getTensorData<float>(_input), getTensorShape(_output),
-                                          getTensorData<float>(_output));
+      tflite::optimized_ops::SpaceToDepth(op_params, getTensorShape(input()),
+                                          getTensorData<float>(input()), getTensorShape(output()),
+                                          getTensorData<float>(output()));
       break;
     case DataType::U8:
-      tflite::optimized_ops::SpaceToDepth(op_params, getTensorShape(_input),
-                                          getTensorData<uint8_t>(_input), getTensorShape(_output),
-                                          getTensorData<uint8_t>(_output));
+      tflite::optimized_ops::SpaceToDepth(op_params, getTensorShape(input()),
+                                          getTensorData<uint8_t>(input()), getTensorShape(output()),
+                                          getTensorData<uint8_t>(output()));
       break;
     default:
       throw std::runtime_error("Unsupported type.");

--- a/compiler/luci-interpreter/src/kernels/SpaceToDepth.h
+++ b/compiler/luci-interpreter/src/kernels/SpaceToDepth.h
@@ -32,15 +32,11 @@ class SpaceToDepth : public KernelWithParams<SpaceToDepthParams>
 public:
   SpaceToDepth(const Tensor *input, Tensor *output, const SpaceToDepthParams &params);
 
-  std::vector<const Tensor *> getInputTensors() const override { return {_input}; }
-  std::vector<Tensor *> getOutputTensors() const override { return {_output}; }
+  const Tensor *input() const { return _inputs[0]; }
+  Tensor *output() const { return _outputs[0]; }
 
   void configure() override;
   void execute() const override;
-
-private:
-  const Tensor *const _input;
-  Tensor *const _output;
 };
 
 } // namespace kernels

--- a/compiler/luci-interpreter/src/kernels/Split.h
+++ b/compiler/luci-interpreter/src/kernels/Split.h
@@ -30,16 +30,14 @@ class Split : public Kernel
 public:
   Split(const Tensor *axis, const Tensor *input, std::vector<Tensor *> outputs);
 
-  std::vector<const Tensor *> getInputTensors() const override { return {_axis, _input}; }
-  std::vector<Tensor *> getOutputTensors() const override { return _outputs; }
+  const Tensor *axis() const { return _inputs[0]; }
+  const Tensor *input() const { return _inputs[1]; }
+  Tensor *output(int index) const { return _outputs[index]; }
 
   void configure() override;
   void execute() const override;
 
 private:
-  const Tensor *const _axis;
-  const Tensor *const _input;
-  const std::vector<Tensor *> _outputs;
   int32_t _axis_value{};
 };
 

--- a/compiler/luci-interpreter/src/kernels/Squeeze.h
+++ b/compiler/luci-interpreter/src/kernels/Squeeze.h
@@ -31,15 +31,11 @@ class Squeeze : public KernelWithParams<SqueezeParams>
 public:
   Squeeze(const Tensor *input, Tensor *output, const SqueezeParams &params);
 
-  std::vector<const Tensor *> getInputTensors() const override { return {_input}; }
-  std::vector<Tensor *> getOutputTensors() const override { return {_output}; }
+  const Tensor *input() const { return _inputs[0]; }
+  Tensor *output() const { return _outputs[0]; }
 
   void configure() override;
   void execute() const override;
-
-private:
-  const Tensor *const _input;
-  Tensor *const _output;
 };
 
 } // namespace kernels

--- a/compiler/luci-interpreter/src/kernels/StridedSlice.h
+++ b/compiler/luci-interpreter/src/kernels/StridedSlice.h
@@ -31,21 +31,14 @@ public:
   StridedSlice(const Tensor *input, const Tensor *begin, const Tensor *end, const Tensor *strides,
                Tensor *output, const StridedSliceParams &params);
 
-  std::vector<const Tensor *> getInputTensors() const override
-  {
-    return {_input, _begin, _end, _strides};
-  }
-  std::vector<Tensor *> getOutputTensors() const override { return {_output}; }
+  const Tensor *input() const { return _inputs[0]; }
+  const Tensor *begin() const { return _inputs[1]; }
+  const Tensor *end() const { return _inputs[2]; }
+  const Tensor *strides() const { return _inputs[3]; }
+  Tensor *output() const { return _outputs[0]; }
 
   void configure() override;
   void execute() const override;
-
-private:
-  const Tensor *const _input;
-  const Tensor *const _begin;
-  const Tensor *const _end;
-  const Tensor *const _strides;
-  Tensor *const _output;
 };
 
 } // namespace kernels

--- a/compiler/luci-interpreter/src/kernels/Transpose.h
+++ b/compiler/luci-interpreter/src/kernels/Transpose.h
@@ -30,16 +30,12 @@ class Transpose : public Kernel
 public:
   Transpose(const Tensor *input, const Tensor *perm, Tensor *output);
 
-  std::vector<const Tensor *> getInputTensors() const override { return {_input, _perm}; }
-  std::vector<Tensor *> getOutputTensors() const override { return {_output}; }
+  const Tensor *input() const { return _inputs[0]; }
+  const Tensor *perm() const { return _inputs[1]; }
+  Tensor *output() const { return _outputs[0]; }
 
   void configure() override;
   void execute() const override;
-
-private:
-  const Tensor *const _input;
-  const Tensor *const _perm;
-  Tensor *const _output;
 };
 
 } // namespace kernels

--- a/compiler/luci-interpreter/src/kernels/TransposeConv.cpp
+++ b/compiler/luci-interpreter/src/kernels/TransposeConv.cpp
@@ -31,43 +31,42 @@ namespace kernels
 
 TransposeConv::TransposeConv(const Tensor *output_shape, const Tensor *filter, const Tensor *input,
                              Tensor *output, const TransposeConvParams &params)
-    : KernelWithParams<TransposeConvParams>(params), _output_shape(output_shape), _filter(filter),
-      _input(input), _output(output)
+    : KernelWithParams<TransposeConvParams>({output_shape, filter, input}, {output}, params)
 {
 }
 
 void TransposeConv::configure()
 {
-  assert(_output_shape->shape().num_dims() == 1);
-  assert(_input->shape().num_dims() == 4);
-  assert(_filter->shape().num_dims() == 4);
-  assert(_input->element_type() == DataType::FLOAT32 || _input->element_type() == DataType::U8);
-  assert(_input->element_type() == _output->element_type());
-  assert(_input->shape().dim(3) == _filter->shape().dim(3));
-  if (_input->element_type() == DataType::U8)
+  assert(output_shape()->shape().num_dims() == 1);
+  assert(input()->shape().num_dims() == 4);
+  assert(filter()->shape().num_dims() == 4);
+  assert(input()->element_type() == DataType::FLOAT32 || input()->element_type() == DataType::U8);
+  assert(input()->element_type() == output()->element_type());
+  assert(input()->shape().dim(3) == filter()->shape().dim(3));
+  if (input()->element_type() == DataType::U8)
   {
     _scratch_tensor =
-        std::make_unique<Tensor>(DataType::S32, _output->shape(), AffineQuantization{}, "");
+        std::make_unique<Tensor>(DataType::S32, output()->shape(), AffineQuantization{}, "");
     double real_multiplier = 0.0;
-    const double input_product_scale = _input->scale() * _filter->scale();
+    const double input_product_scale = input()->scale() * filter()->scale();
     assert(input_product_scale >= 0);
-    real_multiplier = input_product_scale / _output->scale();
+    real_multiplier = input_product_scale / output()->scale();
     int exponent;
     quantizeMultiplier(real_multiplier, &_output_multiplier, &exponent);
     _output_shift = -exponent;
   }
 
-  int dims = _output_shape->shape().dim(0);
-  Shape output_shape(dims);
-  const int32_t *shape_data = getTensorData<int32_t>(_output_shape);
-  for (int i = 0; i < dims; i++)
-    output_shape.dim(i) = shape_data[i];
-  _output->resize(output_shape);
+  const int num_dims = output_shape()->shape().dim(0);
+  Shape out_shape(num_dims);
+  const auto *shape_data = getTensorData<int32_t>(output_shape());
+  for (int i = 0; i < num_dims; i++)
+    out_shape.dim(i) = shape_data[i];
+  output()->resize(out_shape);
 }
 
 void TransposeConv::execute() const
 {
-  switch (_input->element_type())
+  switch (input()->element_type())
   {
     case DataType::FLOAT32:
       evalFloat();
@@ -82,11 +81,11 @@ void TransposeConv::execute() const
 
 void TransposeConv::evalFloat() const
 {
-  const int width = _output->shape().dim(2);
-  const int height = _output->shape().dim(1);
+  const int width = output()->shape().dim(2);
+  const int height = output()->shape().dim(1);
 
-  const int filter_width = _filter->shape().dim(2);
-  const int filter_height = _filter->shape().dim(1);
+  const int filter_width = filter()->shape().dim(2);
+  const int filter_height = filter()->shape().dim(1);
 
   int unused_output_height, unused_output_width;
   unused_output_width =
@@ -94,7 +93,7 @@ void TransposeConv::evalFloat() const
   unused_output_height =
       computeOutputSize(params().padding, height, filter_height, params().stride_height, 1);
   int32_t offset = 0;
-  tflite::ConvParams op_params;
+  tflite::ConvParams op_params{};
   op_params.padding_type = tflite::PaddingType::kSame;
   op_params.padding_values.height = computePaddingWithOffset(
       params().stride_height, 1, height, filter_height, unused_output_height, &offset);
@@ -106,21 +105,21 @@ void TransposeConv::evalFloat() const
   op_params.stride_width = params().stride_width;
   op_params.output_multiplier = _output_multiplier;
   tflite::reference_ops::TransposeConv(
-      op_params, getTensorShape(_input), getTensorData<float>(_input), getTensorShape(_filter),
-      getTensorData<float>(_filter), getTensorShape(_output), getTensorData<float>(_output),
+      op_params, getTensorShape(input()), getTensorData<float>(input()), getTensorShape(filter()),
+      getTensorData<float>(filter()), getTensorShape(output()), getTensorData<float>(output()),
       tflite::RuntimeShape(), (float *)nullptr);
 }
 
 void TransposeConv::evalQuantized() const
 {
-  int32_t input_offset = -_input->zero_point();
-  int32_t filter_offset = -_filter->zero_point();
-  int32_t output_offset = _filter->zero_point();
-  const int width = _output->shape().dim(2);
-  const int height = _output->shape().dim(1);
+  int32_t input_offset = -input()->zero_point();
+  int32_t filter_offset = -filter()->zero_point();
+  int32_t output_offset = filter()->zero_point();
+  const int width = output()->shape().dim(2);
+  const int height = output()->shape().dim(1);
 
-  const int filter_width = _filter->shape().dim(2);
-  const int filter_height = _filter->shape().dim(1);
+  const int filter_width = filter()->shape().dim(2);
+  const int filter_height = filter()->shape().dim(1);
 
   int unused_output_height, unused_output_width;
   unused_output_width =
@@ -128,7 +127,7 @@ void TransposeConv::evalQuantized() const
   unused_output_height =
       computeOutputSize(params().padding, height, filter_height, params().stride_height, 1);
   int32_t offset = 0;
-  tflite::ConvParams op_params;
+  tflite::ConvParams op_params{};
   op_params.padding_type = tflite::PaddingType::kSame;
   op_params.padding_values.height = computePaddingWithOffset(
       params().stride_height, 1, height, filter_height, unused_output_height, &offset);
@@ -145,8 +144,8 @@ void TransposeConv::evalQuantized() const
   op_params.quantized_activation_max = std::numeric_limits<uint8_t>::max();
 
   tflite::reference_ops::TransposeConv(
-      op_params, getTensorShape(_input), getTensorData<uint8>(_input), getTensorShape(_filter),
-      getTensorData<uint8>(_filter), getTensorShape(_output), getTensorData<uint8>(_output),
+      op_params, getTensorShape(input()), getTensorData<uint8>(input()), getTensorShape(filter()),
+      getTensorData<uint8>(filter()), getTensorShape(output()), getTensorData<uint8>(output()),
       tflite::RuntimeShape(), (uint8 *)nullptr, getTensorData<int32_t>(_scratch_tensor.get()));
 }
 

--- a/compiler/luci-interpreter/src/kernels/TransposeConv.h
+++ b/compiler/luci-interpreter/src/kernels/TransposeConv.h
@@ -31,11 +31,10 @@ public:
   TransposeConv(const Tensor *output_shape, const Tensor *filter, const Tensor *input,
                 Tensor *output, const TransposeConvParams &params);
 
-  std::vector<const Tensor *> getInputTensors() const override
-  {
-    return {_output_shape, _filter, _input};
-  }
-  std::vector<Tensor *> getOutputTensors() const override { return {_output}; }
+  const Tensor *output_shape() const { return _inputs[0]; }
+  const Tensor *filter() const { return _inputs[1]; }
+  const Tensor *input() const { return _inputs[2]; }
+  Tensor *output() const { return _outputs[0]; }
 
   void configure() override;
   void execute() const override;
@@ -45,11 +44,6 @@ private:
   void evalQuantized() const;
 
 private:
-  const Tensor *const _output_shape;
-  const Tensor *const _filter;
-  const Tensor *const _input;
-  Tensor *const _output;
-
   std::unique_ptr<Tensor> _scratch_tensor;
 
   // The scaling factor from input to output (aka the 'real multiplier') can

--- a/compiler/luci-interpreter/src/kernels/Unpack.h
+++ b/compiler/luci-interpreter/src/kernels/Unpack.h
@@ -30,17 +30,14 @@ class Unpack : public KernelWithParams<UnpackParams>
 public:
   Unpack(const Tensor *input, std::vector<Tensor *> outputs, const UnpackParams &params);
 
-  std::vector<const Tensor *> getInputTensors() const override { return {_input}; }
-  std::vector<Tensor *> getOutputTensors() const override { return {_outputs}; }
+  const Tensor *input() const { return _inputs[0]; }
+  Tensor *output(int index) const { return _outputs[index]; }
 
   void configure() override;
   void execute() const override;
 
 private:
   template <typename T> void executeImpl() const;
-
-  const Tensor *const _input;
-  const std::vector<Tensor *> _outputs;
 };
 
 } // namespace kernels


### PR DESCRIPTION
This is an updated clone of #3291.

* Add getters for kernel input / output tensors.
* Remove boilerplate code.

ONE-DCO-1.0-Signed-off-by: Sergei Barannikov <s.barannikov@samsung.com>