### PR TITLE
[res] Add DepthwiseConv2D testcase which has version 2

### DIFF
--- a/res/TensorFlowLiteRecipes/DepthwiseConv2D_003/test.recipe
+++ b/res/TensorFlowLiteRecipes/DepthwiseConv2D_003/test.recipe
@@ -1,0 +1,44 @@
+operand {
+  name: "ifm"
+  type: FLOAT32
+  shape { dim: 1 dim: 4 dim: 5 dim: 5 }
+}
+operand {
+  name: "ker"
+  type: FLOAT32
+  shape { dim: 1 dim: 1 dim: 2 dim: 25 }
+}
+operand {
+  name: "bias"
+  type: FLOAT32
+  shape { dim: 25 }
+  filler {
+    tag: "constant"
+    arg: "1.1"
+  }
+}
+operand {
+  name: "ofm"
+  type: FLOAT32
+  shape { dim: 1 dim: 2 dim: 2 dim: 25 }
+}
+operation {
+  type: "DepthwiseConv2D"
+  version: 2
+  depthwiseconv2d_options {
+    padding: VALID
+    stride_w: 2
+    stride_h: 2
+    dilation_w_factor: 2
+    dilation_h_factor: 1
+    depth_multiplier: 5
+    activation : RELU6
+  }
+  input: "ifm"
+  input: "ker"
+  input: "bias"
+  output: "ofm"
+}
+input: "ifm"
+input: "ker"
+output: "ofm"

--- a/res/TensorFlowLiteRecipes/DepthwiseConv2D_003/test.rule
+++ b/res/TensorFlowLiteRecipes/DepthwiseConv2D_003/test.rule
@@ -1,0 +1,3 @@
+# To check if DEPTHWISE_CONV_2D version is 2
+
+RULE    "OP_VERSION_CHECK"        $(op_version DEPTHWISE_CONV_2D) '=' 2


### PR DESCRIPTION
Parent Issue : #3174
Draft : #3216

This commit will add `DepthwiseConv2D` test case which version 2 is included.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>