### PR TITLE
[tfl-verify] Use arser

### DIFF
--- a/compiler/tfl-verify/CMakeLists.txt
+++ b/compiler/tfl-verify/CMakeLists.txt
@@ -6,6 +6,7 @@ file(GLOB_RECURSE SOURCES "src/*.cpp")
 
 add_executable(tfl-verify ${SOURCES})
 target_include_directories(tfl-verify PRIVATE src)
+target_link_libraries(tfl-verify arser)
 target_link_libraries(tfl-verify foder)
 target_link_libraries(tfl-verify mio_tflite)
 target_link_libraries(tfl-verify safemain)

--- a/compiler/tfl-verify/requires.cmake
+++ b/compiler/tfl-verify/requires.cmake
@@ -1,3 +1,4 @@
+require("arser")
 require("foder")
 require("mio-tflite")
 require("safemain")

--- a/compiler/tfl-verify/src/Driver.cpp
+++ b/compiler/tfl-verify/src/Driver.cpp
@@ -35,7 +35,7 @@ int entry(int argc, char **argv)
   {
     std::cout << err.what() << std::endl;
     std::cout << arser;
-    return 0;
+    return 255;
   }
 
   auto verifier = std::make_unique<VerifyFlatbuffers>();

--- a/compiler/tfl-verify/src/Driver.cpp
+++ b/compiler/tfl-verify/src/Driver.cpp
@@ -16,22 +16,31 @@
 
 #include "VerifyFlatBuffers.h"
 
+#include <arser/arser.h>
+
 #include <iostream>
 #include <memory>
 #include <string>
 
 int entry(int argc, char **argv)
 {
-  if (argc != 2)
+  arser::Arser arser;
+  arser.add_argument("tflite").type(arser::DataType::STR).help("TFLite file path to verify");
+
+  try
   {
-    std::cerr << "ERROR: Failed to parse arguments" << std::endl;
-    std::cerr << std::endl;
-    std::cerr << "USAGE: " << argv[0] << " [tflite]" << std::endl;
-    return 255;
+    arser.parse(argc, argv);
   }
+  catch (const std::runtime_error &err)
+  {
+    std::cout << err.what() << std::endl;
+    std::cout << arser;
+    return 0;
+  }
+
   auto verifier = std::make_unique<VerifyFlatbuffers>();
 
-  std::string model_file = argv[argc - 1];
+  std::string model_file = arser.get<std::string>("tflite");
 
   std::cout << "[ RUN       ] Check " << model_file << std::endl;
 


### PR DESCRIPTION
This commit makes tfl-verify use arser

Related : #3001 
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>