### PR TITLE
[common-artifacts] Exclude CWQ depthwise conv model

### DIFF
--- a/compiler/common-artifacts/exclude.lst
+++ b/compiler/common-artifacts/exclude.lst
@@ -45,6 +45,7 @@ tcgenerate(Cos_000)
 tcgenerate(DepthToSpace_000)
 tcgenerate(DepthwiseConv2D_001) # runtime doesn't support dilation
 tcgenerate(DepthwiseConv2D_U8_000)
+tcgenerate(DepthwiseConv2D_U8_001)  # luci-interpreter doesn't support channel-wise quantization yet
 tcgenerate(Div_000)
 tcgenerate(ELU_000)
 tcgenerate(Equal_000)


### PR DESCRIPTION
This excludes CWQ depthwise conv model

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to #3218 Draft PR #3320