### PR TITLE
[circle2circle-dredd-recipe-test] Enable second InstanceNorm fuse test

### DIFF
--- a/compiler/circle2circle-dredd-recipe-test/test.lst
+++ b/compiler/circle2circle-dredd-recipe-test/test.lst
@@ -11,7 +11,7 @@
 ## TFLITE RECIPE
 
 Add(Net_InstanceNorm_001 PASS fuse_instnorm)
-# Add(Net_InstanceNorm_002 PASS fuse_instnorm)
+Add(Net_InstanceNorm_002 PASS fuse_instnorm)
 Add(BatchMatMulV2_000 PASS resolve_customop_batchmatmul)
 Add(MatMul_000 PASS resolve_customop_matmul)
 


### PR DESCRIPTION
Enable Net_InstanceNorm_002 cirtce2circle test

ONE-DCO-1.0-Signed-off-by: Denis Krylov <krylovdenism@gmail.com>