### PR TITLE
[one-cmds] use command name

### DIFF
--- a/compiler/one-cmds/one-codegen
+++ b/compiler/one-cmds/one-codegen
@@ -18,7 +18,7 @@ DRIVER_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 function Usage()
 {
-  echo "Usage: $0 [BACKEND] ..."
+  echo "Usage: one-codegen [BACKEND] ..."
   echo "Available BACKEND drivers:"
   backend_exist=0
   for file in `find $DRIVER_PATH -name *-compile -type f`;

--- a/compiler/one-cmds/one-import
+++ b/compiler/one-cmds/one-import
@@ -18,7 +18,7 @@ DRIVER_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 function Usage()
 {
-  echo "Usage: $0 [FRAMEWORK] ..."
+  echo "Usage: one-import [FRAMEWORK] ..."
   echo "Available FRAMEWORK drivers:"
   framework_exist=0
   for file in "$DRIVER_PATH"/one-import-*;


### PR DESCRIPTION
This will revise one-codegen and one-import to show it's explicit name
- before will show full path which is unnecessary to show the path

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>