### PR TITLE
[onert] Optimization for model input copies

### DIFF
--- a/runtime/onert/core/src/compiler/ExecutorFactory.cc
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.cc
@@ -201,16 +201,33 @@ ExecutorFactory::initializeModelIOTensors(ir::LoweredGraph &lowered_graph,
     // Add tensor to controlflow TensorRegistry.
     cf_tensor_builder->setUserTensor(ind, tensor);
     ret.push_back(tensor);
-
-    // Set other tensors as external tensors
-    for (auto &tensor_builder : tensor_builders)
-    {
-      // FIXME This is a workaround registering all user tensors to all backends
-      // FIXME Handle when it is failed
-      tensor_builder->setExternalTensor(ind, tensor);
-    }
   }
   return ret;
+}
+
+void ExecutorFactory::prepareExternalTensors(ir::LoweredGraph &lowered_graph,
+                                             TensorBuilders &tensor_builders)
+{
+  lowered_graph.op_seqs().iterate(
+      [&](const ir::OpSequenceIndex &op_seq_index, const ir::OpSequence &op_seq) {
+        auto lower_info = lowered_graph.getLowerInfo(op_seq_index);
+        auto &backend_ctx = lowered_graph.backend_contexts().at(lower_info->backend());
+        for (auto ind : (op_seq.getInputs() + op_seq.getOutputs()) | ir::Remove::DUPLICATED |
+                            ir::Remove::UNDEFINED)
+        {
+          // If an OpSequence input/output tensor does not have a own tensor object,
+          // it must be using external tensors, so find the tensor from other tensor builders and
+          // set the tensor to this tensor builder if portable
+          if (!backend_ctx->tensor_builder->tensorAt(ind))
+          {
+            auto tensor = tensor_builders.getITensor(ind);
+            assert(tensor); // The tensor must have been created in one of TensorBuilders
+            auto ptensor = std::dynamic_pointer_cast<backend::IPortableTensor>(tensor);
+            if (ptensor)
+              backend_ctx->tensor_builder->setExternalTensor(ind, ptensor);
+          }
+        }
+      });
 }
 
 exec::IExecutor *
@@ -264,6 +281,8 @@ ExecutorFactory::createLinearExecutor(std::unique_ptr<ir::LoweredGraph> lowered_
   {
     tensor_builder->prepare();
   }
+
+  prepareExternalTensors(*lowered_graph, tensor_builders);
 
   ExecutionBuilder builder;
 
@@ -366,6 +385,8 @@ exec::IExecutor *ExecutorFactory::createDataflowExecutor(
   {
     tensor_builder->prepare();
   }
+
+  prepareExternalTensors(*lowered_graph, tensor_builders);
 
   ExecutionBuilder builder;
 

--- a/runtime/onert/core/src/compiler/ExecutorFactory.h
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.h
@@ -22,6 +22,7 @@
 #include "backend/ITensor.h"
 #include "exec/IExecutor.h"
 #include "ir/LoweredGraph.h"
+#include "TensorBuilders.h"
 
 namespace onert
 {
@@ -48,6 +49,8 @@ private:
   static std::vector<std::shared_ptr<backend::ITensor>>
   initializeModelIOTensors(ir::LoweredGraph &lowered_graph,
                            const ir::OperandIndexSequence &indices);
+  static void prepareExternalTensors(ir::LoweredGraph &lowered_graph,
+                                     TensorBuilders &tensor_builders);
   static exec::IExecutor *
   createLinearExecutor(std::unique_ptr<ir::LoweredGraph> lowered_graph,
                        const compiler::CompilerOptions &options,

--- a/runtime/onert/core/src/compiler/TensorBuilders.h
+++ b/runtime/onert/core/src/compiler/TensorBuilders.h
@@ -23,6 +23,7 @@
 #include "backend/Backend.h"
 #include "backend/controlflow/Config.h"
 #include "backend/controlflow/TensorBuilder.h"
+#include "util/logging.h"
 
 namespace onert
 {
@@ -64,6 +65,17 @@ public:
   std::shared_ptr<backend::controlflow::TensorBuilder> getControlflowTensorBuilder() const
   {
     return _cf_tensor_builder;
+  }
+
+  std::shared_ptr<backend::ITensor> getITensor(ir::OperandIndex ind)
+  {
+    for (auto &tensor_builder : _tensor_builders)
+    {
+      auto tensor = tensor_builder->tensorAt(ind);
+      if (tensor)
+        return tensor;
+    }
+    return nullptr;
   }
 
 private:


### PR DESCRIPTION
Do not insert Permute operation when tensors are copied from controlflow
to cpu(model input cases).

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>