### PR TITLE
[infra] Add vconone to utcount

### DIFF
--- a/infra/nncc/command/utcount
+++ b/infra/nncc/command/utcount
@@ -13,7 +13,7 @@ BUILD_ITEMS="angkor cwrap pepper-str pepper-strcast pp stdex \
 oops pepper-assert \
 hermes hermes-std \
 loco locop locomotiv logo-core logo \
-foder souschef arser \
+foder souschef arser vconone \
 safemain mio-circle mio-tflite \
 tflite2circle \
 luci \


### PR DESCRIPTION
This will add vconone to utcount module list

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>