### PR TITLE
[onert] Skip data copy to itself in FullyConnected

### DIFF
--- a/compute/cker/include/cker/operation/FullyConnected.h
+++ b/compute/cker/include/cker/operation/FullyConnected.h
@@ -78,8 +78,11 @@ inline void FullyConnected(const FullyConnectedParams &params, const Shape &inpu
   MatrixBatchVectorMultiplyAccumulate(weights_data, num_units, input_size, input_data, batch_size,
                                       output_data, /*result_stride=*/1);
 
-  // Apply activation function
-  ApplyActivationToVector(output_data, batch_size * num_units, params.activation, output_data);
+  if (params.activation != FusedActivationFunctionType::kNone)
+  {
+    // Apply activation function
+    ApplyActivationToVector(output_data, batch_size * num_units, params.activation, output_data);
+  }
 }
 
 inline void FullyConnected(const FullyConnectedParams &params, const Shape &input_shape,


### PR DESCRIPTION
As source and target have the same address.
ApplyActivationToVector with FusedActivationFunctionType:kNone
will do nothing but copy to itself unless there's further modification
in ApplyActiviationToVector

ONE-DCO-1.0-Signed-off-by: Juitem JoonWoo Kim <jw1772.kim@samsung.com>