### PR TITLE
[one-cmds] import-tf provide tf version option

### DIFF
--- a/compiler/one-cmds/one-import-tf
+++ b/compiler/one-cmds/one-import-tf
@@ -28,6 +28,7 @@ usage()
   echo "    --input_arrays <names of the input arrays, comma-separated>"
   echo "    --input_shapes <input shapes, colon-separated>"
   echo "    --output_arrays <names of the output arrays, comma-separated>"
+  echo "    --v2 Use TensorFlow 2.x interface (default is 1.x interface)"
   exit 255
 }
 
@@ -36,6 +37,8 @@ version()
   $DRIVER_PATH/one-version one-import-tf
   exit 255
 }
+
+TF_INTERFACE="--v1"
 
 # Parse command-line arguments
 #
@@ -68,6 +71,10 @@ while [ "$#" -ne 0 ]; do
     '--output_arrays')
       export OUTPUT_ARRAYS="$2"
       shift 2
+      ;;
+    '--v2')
+      TF_INTERFACE="--v2"
+      shift
       ;;
     *)
       echo "Unknown parameter: ${CUR}"
@@ -103,13 +110,13 @@ fi
 rm -rf "${OUTPUT_PATH}.log"
 
 # generate temporary tflite file
-echo "python" "${DRIVER_PATH}/tf2tfliteV2.py" --v2 --input_path ${INPUT_PATH} \
+echo "python" "${DRIVER_PATH}/tf2tfliteV2.py" ${TF_INTERFACE} --input_path ${INPUT_PATH} \
 --input_arrays ${INPUT_ARRAYS} --input_shapes ${INPUT_SHAPES} \
 --output_path "${TMPDIR}/${MODEL_NAME}.tflite" \
 --output_arrays ${OUTPUT_ARRAYS} > "${OUTPUT_PATH}.log"
 echo " " >> "${OUTPUT_PATH}.log"
 
-python "${DRIVER_PATH}/tf2tfliteV2.py" --v2 --input_path ${INPUT_PATH} \
+python "${DRIVER_PATH}/tf2tfliteV2.py" ${TF_INTERFACE} --input_path ${INPUT_PATH} \
 --input_arrays ${INPUT_ARRAYS} --input_shapes ${INPUT_SHAPES} \
 --output_path "${TMPDIR}/${MODEL_NAME}.tflite" \
 --output_arrays ${OUTPUT_ARRAYS} >> "${OUTPUT_PATH}.log" 2>&1


### PR DESCRIPTION
This will enable to use TF version for import-tf with default 1.x interface and change with --v2 option

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>