### PR TITLE
[luci-interpreter] Loosen dependencies between loader classes

### DIFF
--- a/compiler/luci-interpreter/src/loader/GraphLoader.cpp
+++ b/compiler/luci-interpreter/src/loader/GraphLoader.cpp
@@ -16,7 +16,6 @@
 
 #include "loader/GraphLoader.h"
 
-#include "loader/ModuleLoader.h"
 #include "loader/KernelBuilder.h"
 
 #include <loco/IR/Algorithm.h>
@@ -102,11 +101,12 @@ bool isTensorProducingNode(const luci::CircleNode *node)
 
 } // namespace
 
-GraphLoader::GraphLoader(const ModuleLoader &module_loader, const loco::Graph *graph,
-                         RuntimeGraph *runtime_graph, RuntimeToIR &runtime_to_ir,
-                         std::unordered_map<const loco::Node *, Tensor *> &node_to_tensor)
-    : _module_loader(module_loader), _graph(graph), _runtime_graph(runtime_graph),
-      _runtime_to_ir(runtime_to_ir), _node_to_tensor(node_to_tensor)
+GraphLoader::GraphLoader(
+    const loco::Graph *graph, RuntimeGraph *runtime_graph, RuntimeToIR &runtime_to_ir,
+    const std::unordered_map<const loco::Graph *, RuntimeGraph *> &graph_to_runtime_graph,
+    std::unordered_map<const loco::Node *, Tensor *> &node_to_tensor)
+    : _graph(graph), _runtime_graph(runtime_graph), _runtime_to_ir(runtime_to_ir),
+      _graph_to_runtime_graph(graph_to_runtime_graph), _node_to_tensor(node_to_tensor)
 {
 }
 
@@ -178,7 +178,7 @@ void GraphLoader::initInputOutputTensors() const
 
 void GraphLoader::loadOperators()
 {
-  KernelBuilder kernel_builder(_module_loader, *this);
+  KernelBuilder kernel_builder(_graph_to_runtime_graph, _node_to_tensor);
 
   // Create kernels for executable nodes. This has to be done in execution order.
   for (const loco::Node *loco_node :

--- a/compiler/luci-interpreter/src/loader/GraphLoader.h
+++ b/compiler/luci-interpreter/src/loader/GraphLoader.h
@@ -27,29 +27,25 @@
 namespace luci_interpreter
 {
 
-class ModuleLoader;
-
 class GraphLoader
 {
 public:
-  GraphLoader(const ModuleLoader &module_loader, const loco::Graph *graph,
-              RuntimeGraph *runtime_graph, RuntimeToIR &runtime_to_ir,
+  GraphLoader(const loco::Graph *graph, RuntimeGraph *runtime_graph, RuntimeToIR &runtime_to_ir,
+              const std::unordered_map<const loco::Graph *, RuntimeGraph *> &graph_to_runtime_graph,
               std::unordered_map<const loco::Node *, Tensor *> &node_to_tensor);
 
   void load();
-
-  Tensor *getTensorForNode(const loco::Node *node) const { return _node_to_tensor.at(node); }
 
 private:
   void loadOperators();
   void initInputOutputTensors() const;
   void loadTensors();
 
-  const ModuleLoader &_module_loader;
   const loco::Graph *_graph;
   RuntimeGraph *_runtime_graph;
   RuntimeToIR &_runtime_to_ir;
 
+  const std::unordered_map<const loco::Graph *, RuntimeGraph *> &_graph_to_runtime_graph;
   std::unordered_map<const loco::Node *, Tensor *> &_node_to_tensor;
 };
 

--- a/compiler/luci-interpreter/src/loader/KernelBuilder.cpp
+++ b/compiler/luci-interpreter/src/loader/KernelBuilder.cpp
@@ -43,8 +43,6 @@
 #include "kernels/Unpack.h"
 #include "kernels/Transpose.h"
 #include "kernels/TransposeConv.h"
-#include "loader/GraphLoader.h"
-#include "loader/ModuleLoader.h"
 
 #include <stdexcept>
 
@@ -68,7 +66,7 @@ static std::vector<const loco::Node *> collectOutputNodes(const luci::CircleNode
 
 const Tensor *KernelBuilder::getInputTensor(const loco::Node *node) const
 {
-  const Tensor *tensor = _graph_loader.getTensorForNode(node);
+  const Tensor *tensor = _node_to_tensor.at(node);
   assert(tensor != nullptr);
   return tensor;
 }
@@ -81,7 +79,7 @@ const Tensor *KernelBuilder::getOptionalInputTensor(const loco::Node *node) cons
 
 Tensor *KernelBuilder::getOutputTensor(const loco::Node *node) const
 {
-  Tensor *tensor = _graph_loader.getTensorForNode(node);
+  Tensor *tensor = _node_to_tensor.at(node);
   assert(tensor != nullptr);
   return tensor;
 }
@@ -98,7 +96,7 @@ KernelBuilder::getOutputTensors(const std::vector<const loco::Node *> &nodes) co
 
 RuntimeGraph *KernelBuilder::getRuntimeGraph(const loco::Graph *graph) const
 {
-  RuntimeGraph *runtime_graph = _module_loader.getRuntimeGraph(graph);
+  RuntimeGraph *runtime_graph = _graph_to_runtime_graph.at(graph);
   assert(runtime_graph != nullptr);
   return runtime_graph;
 }

--- a/compiler/luci-interpreter/src/loader/KernelBuilder.h
+++ b/compiler/luci-interpreter/src/loader/KernelBuilder.h
@@ -24,18 +24,18 @@
 
 #include <memory>
 #include <vector>
+#include <unordered_map>
 
 namespace luci_interpreter
 {
 
-class GraphLoader;
-class ModuleLoader;
-
 class KernelBuilder : public luci::CircleNodeVisitor<std::unique_ptr<Kernel>>
 {
 public:
-  KernelBuilder(const ModuleLoader &module_loader, const GraphLoader &graph_loader)
-      : _module_loader(module_loader), _graph_loader(graph_loader)
+  KernelBuilder(
+      const std::unordered_map<const loco::Graph *, RuntimeGraph *> &graph_to_runtime_graph,
+      const std::unordered_map<const loco::Node *, Tensor *> &node_to_tensor)
+      : _graph_to_runtime_graph(graph_to_runtime_graph), _node_to_tensor(node_to_tensor)
   {
   }
 
@@ -82,8 +82,8 @@ private:
   RuntimeGraph *getRuntimeGraph(const loco::Graph *graph) const;
 
 private:
-  const ModuleLoader &_module_loader;
-  const GraphLoader &_graph_loader;
+  const std::unordered_map<const loco::Graph *, RuntimeGraph *> &_graph_to_runtime_graph;
+  const std::unordered_map<const loco::Node *, Tensor *> &_node_to_tensor;
 };
 
 } // namespace luci_interpreter

--- a/compiler/luci-interpreter/src/loader/ModuleLoader.cpp
+++ b/compiler/luci-interpreter/src/loader/ModuleLoader.cpp
@@ -41,7 +41,8 @@ void ModuleLoader::load()
   {
     const loco::Graph *graph = _module->graph(i);
     RuntimeGraph *runtime_graph = _graph_to_runtime_graph.at(graph);
-    GraphLoader loader(*this, graph, runtime_graph, _runtime_to_ir, _node_to_tensor);
+    GraphLoader loader(graph, runtime_graph, _runtime_to_ir, _graph_to_runtime_graph,
+                       _node_to_tensor);
     loader.load();
   }
 }

--- a/compiler/luci-interpreter/src/loader/ModuleLoader.h
+++ b/compiler/luci-interpreter/src/loader/ModuleLoader.h
@@ -36,11 +36,6 @@ public:
 
   void load();
 
-  RuntimeGraph *getRuntimeGraph(const loco::Graph *graph) const
-  {
-    return _graph_to_runtime_graph.at(graph);
-  }
-
 private:
   const luci::Module *_module;
   RuntimeModule *_runtime_module;


### PR DESCRIPTION
This is to make testing of `KernelBuilder` easier.

ONE-DCO-1.0-Signed-off-by: Sergei Barannikov <s.barannikov@samsung.com>