### PR TITLE
[circlechef] Add tests directory only when enabled

### DIFF
--- a/compiler/circlechef/CMakeLists.txt
+++ b/compiler/circlechef/CMakeLists.txt
@@ -18,4 +18,6 @@ add_subdirectory(core)
 add_subdirectory(circle)
 # Tools
 add_subdirectory(tools)
-add_subdirectory(tests)
+if(ENABLE_TEST)
+  add_subdirectory(tests)
+endif(ENABLE_TEST)


### PR DESCRIPTION
This commit let circlechef tests directory be added only when test
enabled.

ONE-DCO-1.0-Signed-off-by: Cheongyo Bahk <cg.bahk@gmail.com>

---

This is to make it easy to build circlechef from external