### PR TITLE
DRAFT revise nncc-tc-to-nnpkg-tc

### DIFF
--- a/infra/packaging/res/tf2nnpkg.20200630
+++ b/infra/packaging/res/tf2nnpkg.20200630
@@ -14,9 +14,15 @@ command_exists() {
 usage()
 {
   echo "Convert TensorFlow model to nnpackage."
-  echo "Usage: tf2nnpkg --info <path/to/info> --graphdef <path/to/pb> [OPTION] -o <path/to/nnpkg/directory>"
-  exit 0
+  echo "Usage: tf2nnpkg"
+  echo "    --info <path/to/info>"
+  echo "    --graphdef <path/to/pb>"
+  echo "    -o <path/to/nnpkg/directory>"
+  echo "    --v2 (optional) Use TF 2.x interface"
+  exit 255
 }
+
+TF_INTERFACE="--v1"
 
 # Parse command-line arguments
 #
@@ -38,6 +44,10 @@ while [ "$#" -ne 0 ]; do
     '-o')
       export OUTPUT_DIR="$2"
       shift 2
+      ;;
+    '--v2')
+      TF_INTERFACE="--v2"
+      shift
       ;;
     *)
       echo "${CUR}"
@@ -83,10 +93,7 @@ OUTPUT=$(awk -F, '/^output/ { print $2 }' ${INFO_FILE} | cut -d: -f1 | tr -d ' '
 INPUT_SHAPES=$(grep ^input ${INFO_FILE} | cut -d "[" -f2 | cut -d "]" -f1 | tr -d ' ' | xargs | tr ' ' ':')
 
 # generate tflite file
-python "${ROOT}/bin/tf2tfliteV2.py" --v2 --input_path ${GRAPHDEF_FILE} \
---output_path "${TMPDIR}/${MODEL_NAME}.tflite" \
---input_arrays ${INPUT} --output_arrays ${OUTPUT} || \
-python "${ROOT}/bin/tf2tfliteV2.py" --v1 --input_path ${GRAPHDEF_FILE} \
+python "${ROOT}/bin/tf2tfliteV2.py" ${TF_INTERFACE} --input_path ${GRAPHDEF_FILE} \
 --output_path "${TMPDIR}/${MODEL_NAME}.tflite" \
 --input_arrays ${INPUT} --input_shapes ${INPUT_SHAPES} \
 --output_arrays ${OUTPUT}

--- a/tools/nnpackage_tool/nncc-tc-to-nnpkg-tc/nncc-tc-to-nnpkg-tc.sh
+++ b/tools/nnpackage_tool/nncc-tc-to-nnpkg-tc/nncc-tc-to-nnpkg-tc.sh
@@ -62,6 +62,7 @@ tflite
 "
 
 model_type=""
+tf_intf_version=""
 
 for ext in $supported_model_types; do
   [ -e "$indir/$tcname"."$ext" ] && model_type=$ext
@@ -73,7 +74,9 @@ if [[ "$model_type" == "" ]]; then
 fi
 
 if [[ "$model_type" == "pb" ]]; then
-  $tf2nnpkg --info "$indir/$tcname".info --graphdef "$indir/$tcname"."$model_type" -o "$outdir"
+  [ -f "$indir/$tcname"."v2" ] && tf_intf_version="--v2"
+  $tf2nnpkg --info "$indir/$tcname".info --graphdef "$indir/$tcname"."$model_type" \
+  "$tf_intf_version" -o "$outdir"
 else
   $model2nnpkg -o "$outdir" "$indir/$tcname"."$model_type"
 fi


### PR DESCRIPTION
This will add --v2 option to use TF 2.x interface in tf2nnpkg and revise nncc-tc-to-nnpkg-tc
- current tc models will correctly convert with TF 1.x interface
- there is no .v2 file so it will be TF 1.x

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@samsung.com>