### PR TITLE
[cmake] add one more path to path_suffix

### DIFF
--- a/infra/cmake/packages/HDF5Config.cmake
+++ b/infra/cmake/packages/HDF5Config.cmake
@@ -27,6 +27,7 @@ _HDF5_build()
 find_path(HDF5_CONFIG_DIR "hdf5-config.cmake"
           PATHS ${EXT_OVERLAY_DIR}
           PATH_SUFFIXES
+            cmake
             share/cmake
             share/cmake/hdf5
             cmake/hdf5


### PR DESCRIPTION
This commit adds a path to path_suffix of find_path in HDF5Config.cmake

Related : #3390 
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>