### PR TITLE
[cmake] flatbuffer build test off

### DIFF
--- a/infra/cmake/packages/FlatBuffersConfig.cmake
+++ b/infra/cmake/packages/FlatBuffersConfig.cmake
@@ -25,7 +25,7 @@ function(_FlatBuffers_build)
                       BUILD_DIR   ${CMAKE_BINARY_DIR}/externals/FLATBUFFERS/build
                       INSTALL_DIR ${EXT_OVERLAY_DIR}
                       BUILD_FLAGS ${ADDITIONAL_CXX_FLAGS}
-                      IDENTIFIER  "1.10-fix1"
+                      IDENTIFIER  "1.10-fix2"
                       EXTRA_OPTS "-DFLATBUFFERS_BUILD_TESTS:BOOL=OFF"
                       PKG_NAME    "FLATBUFFERS")
 

--- a/infra/cmake/packages/FlatBuffersConfig.cmake
+++ b/infra/cmake/packages/FlatBuffersConfig.cmake
@@ -26,6 +26,7 @@ function(_FlatBuffers_build)
                       INSTALL_DIR ${EXT_OVERLAY_DIR}
                       BUILD_FLAGS ${ADDITIONAL_CXX_FLAGS}
                       IDENTIFIER  "1.10-fix1"
+                      EXTRA_OPTS "-DFLATBUFFERS_BUILD_TESTS:BOOL=OFF"
                       PKG_NAME    "FLATBUFFERS")
 
 endfunction(_FlatBuffers_build)


### PR DESCRIPTION
This commit adds EXTRA_OPTS to Flatbuffers build for resolving gcc bugs

Related : #3390 
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>