### PR TITLE
[tflitefile_tool] use env's python instead of /usr/bin/python

### DIFF
--- a/tools/tflitefile_tool/select_operator.py
+++ b/tools/tflitefile_tool/select_operator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # Copyright (c) 2018 Samsung Electronics Co., Ltd. All Rights Reserved
 #


### PR DESCRIPTION
Some python environment like virtualenv uses its own python,
instead of /usr/bin/python. This will enable to use env's.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>