### PR TITLE
[doc] guide to use ln insteand of cp for Makefile.template

### DIFF
--- a/docs/howto/how-to-build-runtime.md
+++ b/docs/howto/how-to-build-runtime.md
@@ -13,7 +13,7 @@ In the Ubuntu, you can easily install it with the following command.
 
 ```
 $ sudo apt-get install cmake libboost-all-dev
-``` 
+```
 
 If your linux system does not have the basic development configuration, you will need to install more packages. A list of all packages needed to configure the development environment can be found in the https://github.com/Samsung/ONE/blob/master/infra/docker/Dockerfile.1804 file.
 
@@ -44,7 +44,7 @@ python3-venv \
 scons \
 software-properties-common \
 unzip \
-wget 
+wget
 
 $ mkdir /tmp/gtest
 $ cd /tmp/gtest
@@ -63,7 +63,7 @@ In a typical linux development environment, including Ubuntu, you can build the 
 ```
 $ git clone https://github.com/Samsung/ONE.git one
 $ cd one
-$ cp -n Makefile.template Makefile; make install
+$ make -f Makefile.template install
 ```
 
 Unfortunately, the debug build on the x86_64 architecture currently has an error. To solve the problem, you must use gcc version 9 or higher. Another workaround is to do a release build rather than a debug build. This is not a suitable method for debugging during development, but it is enough to check the function of the runtime. To release build the runtime, add the environment variable `BUILD_TYPE=release` to the build command as follows.

--- a/docs/nnfw/howto/CrossBuildForAndroid.md
+++ b/docs/nnfw/howto/CrossBuildForAndroid.md
@@ -44,11 +44,9 @@ Different from cross build for linux,
 Here is an example of using Makefile.
 
 ```bash
-cp -n Makefile.template Makefile
-
 TARGET_OS=android \
 CROSS_BUILD=1 \
 NDK_DIR=/path/android-tools/r20/ndk \
 EXT_ACL_FOLDER=/path/arm_compute-v19.11.1-bin-android/lib/android-arm64-v8a-neon-cl \
-make install
+make -f Makefile.template install
 ```


### PR DESCRIPTION
Currently build guide says use `cp -n ` for Makefile.
It will guide to use `ln -s` so that they don't need to
update Makefile continually.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>