### PR TITLE
[benchmark] fix floating point exception during memory benchmark

### DIFF
--- a/runtime/libs/benchmark/src/Result.cpp
+++ b/runtime/libs/benchmark/src/Result.cpp
@@ -166,7 +166,7 @@ Result::Result(const Phases &phases)
   if (option.memory)
   {
     print_memory = true;
-    for (int i = PhaseEnum::MODEL_LOAD; i <= PhaseEnum::EXECUTE; ++i)
+    for (int i = PhaseEnum::MODEL_LOAD; i < PhaseEnum::EXECUTE; ++i)
     {
       auto phase = phases.at(gPhaseStrings[i]);
       for (int j = MemoryType::RSS; j <= MemoryType::PSS; ++j)


### PR DESCRIPTION
It fixes floating point exception during running memory profiling on x86_64
with nnpackage_run. Benchmark does not polling memory usage for "Execute" phase,
however, Result try to get average  for all phases, which leads to divide by zero
for 'Execute' phase.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>