### PR TITLE
[onert] Ignore bias tensor with all zero values in fully connected layer

### DIFF
--- a/runtime/onert/backend/cpu/ops/FullyConnectedLayer.cc
+++ b/runtime/onert/backend/cpu/ops/FullyConnectedLayer.cc
@@ -18,6 +18,7 @@
 
 #include "../Tensor.h"
 #include <cker/operation/FullyConnected.h>
+#include <cker/TensorUtils.h>
 
 namespace onert
 {
@@ -167,6 +168,15 @@ void FullyConnectedLayer::run()
 
 void FullyConnectedLayer::prepare()
 {
+  if (_bias && _bias->is_constant())
+  {
+    const int bias_size = getTensorShape(_bias).FlatSize();
+    if (nnfw::cker::IsZeroVector(reinterpret_cast<float *>(_bias->buffer()), bias_size))
+    {
+      _bias = nullptr;
+    }
+  }
+
 #ifdef USE_RUY_GEMV
   // TODO This is workaround
   // The only fc hybrid will use ruy kernel


### PR DESCRIPTION
- This commit ignores bias tensor with all zero values in fully connected layer
  - For bias tensor with values, fully connected copies its value into output tensor
  - If bias tensor has all zero values, we can ignore that bias tensor to remove memcpy
  - Finds bias tensor with all zero values in prepare phase and mark it as optional tensor

ONE-DCO-1.0-Signed-off-by: JiHwan Yeo <jihwan.yeo@samsung.com>