### PR TITLE
[tizen] Add our rpm repo in gbs.conf

### DIFF
--- a/infra/nnfw/config/gbs.conf
+++ b/infra/nnfw/config/gbs.conf
@@ -5,7 +5,7 @@ profile = profile.tizen
 [profile.tizen]
 user=obs_viewer
 obs = obs.tizen
-repos = repo.tizen_base,repo.tizen_mobile
+repos = repo.tizen_one,repo.tizen_base,repo.tizen_mobile
 buildroot = /home/GBS-ROOT/
 
 [obs.tizen]
@@ -16,4 +16,7 @@ url = http://download.tizen.org/snapshots/tizen/unified/latest/repos/standard/pa
 
 [repo.tizen_base]
 url = http://download.tizen.org/snapshots/tizen/base/latest/repos/standard/packages/
+
+[repo.tizen_one]
+url = http://nnfw.mooo.com/archive/tizen/
 


### PR DESCRIPTION
For #3428

This commit adds our rpm repo in gbs.conf to support acl v20.05 on tizen

Signed-off-by: ragmani <ragmani0216@gmail.com>