### PR TITLE
[Draft] Manage ruy_context on runtime

### DIFF
--- a/compute/cker/include/cker/NeonTensorUtils.h
+++ b/compute/cker/include/cker/NeonTensorUtils.h
@@ -546,7 +546,7 @@ bool NeonIsZeroVector(const float *vector, int v_size)
 
 void NeonCpuBackendGemm(const int8_t *input, const int32_t *bias,
                         const int8_t *input_to_gate_weights, int32_t n_batch, int32_t n_input,
-                        int32_t n_output, int32_t, int32_t *scratch)
+                        int32_t n_output, int32_t, int32_t *scratch, ruy::Context *ruy_context)
 {
   MatrixParams<int8_t> lhs_params;
   lhs_params.order = Order::kRowMajor;
@@ -571,8 +571,6 @@ void NeonCpuBackendGemm(const int8_t *input, const int32_t *bias,
   }
 
   // Below code is from tflite::cpu_backend_gemm::detail::GemmImplUsingRuy
-  ruy::Context *ruy_context = ruy_support::GetRuyContext();
-
   ruy::Matrix<int8_t> ruy_lhs;
   ruy::Matrix<int8_t> ruy_rhs;
   ruy::Matrix<int32_t> ruy_dst;
@@ -851,13 +849,13 @@ void NeonMatrixBatchVectorMultiplyAccumulate(const int8_t *__restrict__ matrix, 
                                              const int m_cols, const int8_t *__restrict__ vectors,
                                              const float *scaling_factors, int n_batch,
                                              int32_t *scratch, float *__restrict__ result,
-                                             int result_stride)
+                                             int result_stride, ruy::Context *ruy_context)
 {
   if (m_rows % 4 == 0 && result_stride == 1)
   {
     const int32_t *bias = static_cast<const int32_t *>(nullptr);
     NeonCpuBackendGemm(vectors, bias, matrix, n_batch, m_cols, m_rows,
-                       /*output_zp =*/0, scratch);
+                       /*output_zp =*/0, scratch, ruy_context);
 
     // Multiply by float scaling factors and write to result
     const int total_size = n_batch * m_rows;

--- a/compute/cker/include/cker/PortableTensorUtils.h
+++ b/compute/cker/include/cker/PortableTensorUtils.h
@@ -20,6 +20,7 @@
 
 #include "cker/Types.h"
 #include "cker/neon/neon_check.h"
+#include <ruy/context.h>
 
 #include <cstring>
 #include <cmath>
@@ -142,7 +143,7 @@ void PortableMatrixBatchVectorMultiplyAccumulate(const int8_t *__restrict__ matr
                                                  const int8_t *__restrict__ vector,
                                                  const float *scaling_factors, int n_batch,
                                                  int32_t *, float *__restrict__ result,
-                                                 int result_stride)
+                                                 int result_stride, ruy::Context *)
 {
   PortableMatrixBatchVectorMultiplyAccumulate(matrix, m_rows, m_cols, vector, scaling_factors,
                                               n_batch, result, result_stride);

--- a/compute/cker/include/cker/TensorUtils.h
+++ b/compute/cker/include/cker/TensorUtils.h
@@ -73,10 +73,10 @@ void MatrixBatchVectorMultiplyAccumulate(const float *matrix, int m_rows, int m_
 void MatrixBatchVectorMultiplyAccumulate(const int8_t *matrix, const int m_rows, const int m_cols,
                                          const int8_t *vectors, const float *scaling_factors,
                                          int n_batch, int32_t *scratch, float *result,
-                                         int result_stride)
+                                         int result_stride, ruy::Context *ruy_context)
 {
   NEON_OR_PORTABLE(MatrixBatchVectorMultiplyAccumulate, matrix, m_rows, m_cols, vectors,
-                   scaling_factors, n_batch, scratch, result, result_stride);
+                   scaling_factors, n_batch, scratch, result, result_stride, ruy_context);
 }
 
 void ZeroVector(float *vector, int v_size) { PortableZeroVector(vector, v_size); }

--- a/compute/cker/include/cker/operation/FullyConnected.h
+++ b/compute/cker/include/cker/operation/FullyConnected.h
@@ -18,6 +18,7 @@
 #ifndef __NNFW_CKER_FULLY_CONNECTED_H__
 #define __NNFW_CKER_FULLY_CONNECTED_H__
 
+#include <ruy/context.h>
 #include "cker/Shape.h"
 #include "cker/Types.h"
 #include "cker/Utils.h"
@@ -143,7 +144,7 @@ inline void FullyConnectedHybrid(const FullyConnectedParams &params, const Shape
                                  const float *input_data, const Shape &filter_shape,
                                  const int8_t *filter_data, const Shape &, const float *bias_data,
                                  const Shape &output_shape, float *output_data,
-                                 FCTempArena &temp_arena)
+                                 FCTempArena &temp_arena, ruy::Context *ruy_context)
 {
   int total_input_size = input_shape.FlatSize();
   const int input_size = filter_shape.Dims(1);
@@ -189,11 +190,11 @@ inline void FullyConnectedHybrid(const FullyConnectedParams &params, const Shape
   int32_t *scratch = temp_arena.accum_scratch.data();
   MatrixBatchVectorMultiplyAccumulate(filter_data, num_units, input_size, quant_data,
                                       scaling_factors_ptr, batch_size, scratch, output_data,
-                                      /*result_stride=*/1);
+                                      /*result_stride=*/1, ruy_context);
 #else
   MatrixBatchVectorMultiplyAccumulate(filter_data, num_units, input_size, quant_data,
                                       scaling_factors_ptr, batch_size, output_data,
-                                      /*result_stride=*/1);
+                                      /*result_stride=*/1, ruy_context);
   UNUSED_RELEASE(output_shape);
 #endif
 

--- a/compute/cker/include/cker/ruy/RuySupport.h
+++ b/compute/cker/include/cker/ruy/RuySupport.h
@@ -22,53 +22,12 @@
 #include <ruy/context.h>
 #include "cker/Types.h"
 
-namespace
-{
-const int kDefaultNumThreadpoolThreads = 1;
-}
-
 namespace nnfw
 {
 namespace cker
 {
 namespace ruy_support
 {
-
-struct RuyContext
-{
-public:
-  RuyContext() : ruy_context_(new ruy::Context)
-  {
-    SetMaxNumThreads(onert::util::getConfigInt(onert::util::config::RUY_THREADS));
-#ifdef USE_RUY_GEMV
-    ruy_context_->cache_policy = ruy::kCacheLHSOnNarrowMul;
-#endif
-  };
-
-  ruy::Context *ruy_context() const { return ruy_context_.get(); }
-
-  static inline RuyContext &GetRuyContext()
-  {
-    static thread_local RuyContext instance;
-    return instance;
-  }
-
-  void SetMaxNumThreads(int max_num_threads)
-  {
-    const int target_num_threads =
-        max_num_threads > -1 ? max_num_threads : kDefaultNumThreadpoolThreads;
-    ruy_context_->max_num_threads = target_num_threads;
-  }
-
-private:
-  const std::unique_ptr<ruy::Context> ruy_context_;
-};
-
-inline ruy::Context *GetRuyContext()
-{
-  auto &ctx = RuyContext::GetRuyContext();
-  return ctx.ruy_context();
-}
 
 template <typename Scalar, typename DataPointer>
 void MakeRuyMatrix(const MatrixParams<Scalar> &params, DataPointer data_ptr,

--- a/runtime/libs/benchmark/src/Phases.cpp
+++ b/runtime/libs/benchmark/src/Phases.cpp
@@ -67,7 +67,6 @@ void Phases::run(const std::string &tag, const PhaseFunc &exec, const PhaseFunc 
     t = nowMicros();
 
     std::thread th = std::thread(exec, phase, i);
-
     th.join();
 
     t = nowMicros() - t;

--- a/runtime/libs/benchmark/src/Phases.cpp
+++ b/runtime/libs/benchmark/src/Phases.cpp
@@ -66,7 +66,9 @@ void Phases::run(const std::string &tag, const PhaseFunc &exec, const PhaseFunc 
     uint64_t t = 0u;
     t = nowMicros();
 
-    exec(phase, i);
+    std::thread th = std::thread(exec, phase, i);
+
+    th.join();
 
     t = nowMicros() - t;
 

--- a/runtime/onert/backend/cpu/Backend.h
+++ b/runtime/onert/backend/cpu/Backend.h
@@ -19,6 +19,7 @@
 
 #include "Config.h"
 #include "ConstantInitializer.h"
+#include "ExternalContext.h"
 #include "KernelGenerator.h"
 
 #include <backend/Backend.h>
@@ -35,7 +36,7 @@ namespace cpu
 class Backend : public ::onert::backend::Backend
 {
 public:
-  Backend() : _config{std::make_shared<Config>()} {}
+  Backend() : _config{std::make_shared<Config>()}, _external_context(new ExternalContext) {}
 
   std::shared_ptr<IConfig> config() const override { return _config; }
 
@@ -49,7 +50,8 @@ public:
     auto tb = std::make_shared<TensorBuilder>();
     context->tensor_builder = tb;
     context->constant_initializer = std::make_shared<ConstantInitializer>(operands, tb);
-    context->kernel_gen = std::make_shared<KernelGenerator>(operands, operations, tb, kb);
+    context->kernel_gen =
+        std::make_shared<KernelGenerator>(operands, operations, tb, kb, _external_context);
     context->tensor_register = nullptr;
     context->optimizer = nullptr;
     return context;
@@ -57,6 +59,7 @@ public:
 
 private:
   std::shared_ptr<IConfig> _config;
+  std::shared_ptr<ExternalContext> _external_context;
 };
 
 } // namespace cpu

--- a/runtime/onert/backend/cpu/Backend.h
+++ b/runtime/onert/backend/cpu/Backend.h
@@ -17,9 +17,9 @@
 #ifndef __ONERT_BACKEND_CPU_BACKEND_H__
 #define __ONERT_BACKEND_CPU_BACKEND_H__
 
+#include "BackendContext.h"
 #include "Config.h"
 #include "ConstantInitializer.h"
-#include "ExternalContext.h"
 #include "KernelGenerator.h"
 
 #include <backend/Backend.h>
@@ -36,13 +36,13 @@ namespace cpu
 class Backend : public ::onert::backend::Backend
 {
 public:
-  Backend() : _config{std::make_shared<Config>()}, _external_context(new ExternalContext) {}
+  Backend() : _config{std::make_shared<Config>()} {}
 
   std::shared_ptr<IConfig> config() const override { return _config; }
 
-  std::unique_ptr<BackendContext> newContext(const ir::Graph &graph,
-                                             const std::shared_ptr<custom::IKernelBuilder> &kb,
-                                             bool) const override
+  std::unique_ptr<onert::backend::BackendContext>
+  newContext(const ir::Graph &graph, const std::shared_ptr<custom::IKernelBuilder> &kb,
+             bool) const override
   {
     const auto &operands = graph.operands();
     const auto &operations = graph.operations();
@@ -50,8 +50,8 @@ public:
     auto tb = std::make_shared<TensorBuilder>();
     context->tensor_builder = tb;
     context->constant_initializer = std::make_shared<ConstantInitializer>(operands, tb);
-    context->kernel_gen =
-        std::make_shared<KernelGenerator>(operands, operations, tb, kb, _external_context);
+    context->kernel_gen = std::make_shared<KernelGenerator>(operands, operations, tb, kb,
+                                                            context->external_context());
     context->tensor_register = nullptr;
     context->optimizer = nullptr;
     return context;
@@ -59,7 +59,6 @@ public:
 
 private:
   std::shared_ptr<IConfig> _config;
-  std::shared_ptr<ExternalContext> _external_context;
 };
 
 } // namespace cpu

--- a/runtime/onert/backend/cpu/BackendContext.h
+++ b/runtime/onert/backend/cpu/BackendContext.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_BACKEND_CPU_BACKEND_CONTEXT_H__
+#define __ONERT_BACKEND_CPU_BACKEND_CONTEXT_H__
+
+#include <backend/BackendContext.h>
+#include "ExternalContext.h"
+
+namespace onert
+{
+namespace backend
+{
+namespace cpu
+{
+
+class BackendContext : public onert::backend::BackendContext
+{
+public:
+  BackendContext(const Backend *backend, const ir::Graph *graph,
+                 std::shared_ptr<ITensorBuilder> tensor_builder = nullptr,
+                 std::shared_ptr<IConstantInitializer> constant_initializer = nullptr,
+                 std::shared_ptr<IKernelGenerator> kernel_gen = nullptr,
+                 std::shared_ptr<ITensorRegister> tensor_register = nullptr,
+                 std::shared_ptr<IOptimizer> optimizer = nullptr)
+      : onert::backend::BackendContext(backend, graph, tensor_builder, constant_initializer,
+                                       kernel_gen, tensor_register, optimizer),
+        _external_context(new ExternalContext)
+  {
+  }
+
+  std::shared_ptr<ExternalContext> external_context() { return _external_context; }
+
+private:
+  std::shared_ptr<ExternalContext> _external_context;
+};
+
+} // namespace cpu
+} // namespace backend
+} // namespace onert
+
+#endif // __ONERT_BACKEND_CPU_BACKEND_CONTEXT_H__

--- a/runtime/onert/backend/cpu/CMakeLists.txt
+++ b/runtime/onert/backend/cpu/CMakeLists.txt
@@ -1,5 +1,7 @@
 set(LIB_ONERT_BACKEND_CPU onert_backend_cpu)
 
+nnfw_find_package(Ruy REQUIRED)
+
 file(GLOB_RECURSE SOURCES "*.cc")
 
 add_library(${LIB_ONERT_BACKEND_CPU} SHARED ${SOURCES})
@@ -8,6 +10,12 @@ target_link_libraries(${LIB_ONERT_BACKEND_CPU} PRIVATE nnfw_lib_cker)
 target_link_libraries(${LIB_ONERT_BACKEND_CPU} PRIVATE onert_core)
 target_link_libraries(${LIB_ONERT_BACKEND_CPU} PRIVATE nnfw_common)
 target_link_libraries(${LIB_ONERT_BACKEND_CPU} PRIVATE nnfw_coverage)
+target_link_libraries(${LIB_ONERT_BACKEND_CPU} PRIVATE ruy)
+target_link_libraries(${LIB_ONERT_BACKEND_CPU} PRIVATE ruy_instrumentation)
+target_compile_definitions(${LIB_ONERT_BACKEND_CPU} PRIVATE USE_RUY_GEMV)
+if(PROFILE_RUY)
+  target_link_libraries(${LIB_ONERT_BACKEND_CPU} PRIVATE ruy_profiler)
+endif(PROFILE_RUY)
 
 set_target_properties(${LIB_ONERT_BACKEND_CPU} PROPERTIES OUTPUT_NAME backend_cpu)
 

--- a/runtime/onert/backend/cpu/ExternalContext.h
+++ b/runtime/onert/backend/cpu/ExternalContext.h
@@ -17,6 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_EXTERNAL_CONTEXT_H__
 #define __ONERT_BACKEND_CPU_EXTERNAL_CONTEXT_H__
 
+#include <backend/IExternalContext.h>
 #include <util/ConfigSource.h>
 #include <ruy/context.h>
 
@@ -32,7 +33,7 @@ namespace backend
 namespace cpu
 {
 
-class ExternalContext
+class ExternalContext : public IExternalContext
 {
 public:
   ExternalContext() : _ruy_context(new ruy::Context)

--- a/runtime/onert/backend/cpu/ExternalContext.h
+++ b/runtime/onert/backend/cpu/ExternalContext.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_BACKEND_CPU_EXTERNAL_CONTEXT_H__
+#define __ONERT_BACKEND_CPU_EXTERNAL_CONTEXT_H__
+
+#include <util/ConfigSource.h>
+#include <ruy/context.h>
+
+namespace
+{
+const int kDefaultNumThreadpoolThreads = 1;
+}
+
+namespace onert
+{
+namespace backend
+{
+namespace cpu
+{
+
+class ExternalContext
+{
+public:
+  ExternalContext() : _ruy_context(new ruy::Context)
+  {
+    SetMaxNumThreads(onert::util::getConfigInt(onert::util::config::RUY_THREADS));
+#ifdef USE_RUY_GEMV
+    _ruy_context->cache_policy = ruy::kCacheLHSOnNarrowMul;
+#endif
+  }
+
+  void SetMaxNumThreads(int max_num_threads)
+  {
+    const int target_num_threads =
+        max_num_threads > -1 ? max_num_threads : kDefaultNumThreadpoolThreads;
+    _ruy_context->max_num_threads = target_num_threads;
+  }
+
+  ruy::Context *ruy_context() const { return _ruy_context.get(); }
+
+private:
+  const std::unique_ptr<ruy::Context> _ruy_context;
+};
+
+} // namespace cpu
+} // namespace backend
+} // namespace onert
+
+#endif // __ONERT_BACKEND_CPU_EXTERNAL_CONTEXT_H__

--- a/runtime/onert/backend/cpu/KernelGenerator.cc
+++ b/runtime/onert/backend/cpu/KernelGenerator.cc
@@ -122,9 +122,11 @@ ops::ReduceType convertReduceType(ir::operation::Reduce::ReduceType reduce_type_
 KernelGenerator::KernelGenerator(
     const ir::Operands &operands_ctx, const ir::Operations &operations_ctx,
     const std::shared_ptr<TensorBuilder> &tensor_builder,
-    const std::shared_ptr<backend::custom::IKernelBuilder> &kernel_builder)
+    const std::shared_ptr<backend::custom::IKernelBuilder> &kernel_builder,
+    const std::shared_ptr<ExternalContext> &external_context)
     : _ctx(operands_ctx), _operations_ctx{operations_ctx}, _tensor_builder(tensor_builder),
-      _kernel_builder(kernel_builder), _current_op_seq_layout(ir::Layout::UNKNOWN)
+      _kernel_builder(kernel_builder), _current_op_seq_layout(ir::Layout::UNKNOWN),
+      _external_context(external_context)
 {
   // DO NOTHING
 }
@@ -364,7 +366,8 @@ void KernelGenerator::visit(const ir::operation::FullyConnected &node)
 
   auto fn = std::make_unique<ops::FullyConnectedLayer>();
 
-  fn->configure(input_tensor, weight_tensor, bias_tensor, activation, output_tensor);
+  fn->configure(input_tensor, weight_tensor, bias_tensor, activation, output_tensor,
+                _external_context);
 
   _return_fn = std::move(fn);
 }

--- a/runtime/onert/backend/cpu/KernelGenerator.h
+++ b/runtime/onert/backend/cpu/KernelGenerator.h
@@ -17,6 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_KERNEL_GENERATOR_H__
 #define __ONERT_BACKEND_CPU_KERNEL_GENERATOR_H__
 
+#include "ExternalContext.h"
 #include "TensorBuilder.h"
 #include "Tensor.h"
 
@@ -37,7 +38,8 @@ class KernelGenerator : public IKernelGenerator
 public:
   KernelGenerator(const ir::Operands &operands_ctx, const ir::Operations &operations_ctx,
                   const std::shared_ptr<TensorBuilder> &tensor_builder,
-                  const std::shared_ptr<custom::IKernelBuilder> &kernel_builder);
+                  const std::shared_ptr<custom::IKernelBuilder> &kernel_builder,
+                  const std::shared_ptr<ExternalContext> &external_context);
 
   using IKernelGenerator::visit;
 
@@ -111,6 +113,7 @@ private:
   std::shared_ptr<TensorBuilder> _tensor_builder;
   std::shared_ptr<backend::custom::IKernelBuilder> _kernel_builder;
   ir::Layout _current_op_seq_layout;
+  const std::shared_ptr<ExternalContext> _external_context;
 };
 
 } // namespace cpu

--- a/runtime/onert/backend/cpu/ops/FullyConnectedLayer.h
+++ b/runtime/onert/backend/cpu/ops/FullyConnectedLayer.h
@@ -18,6 +18,7 @@
 #define __ONERT_BACKEND_CPU_OPS_FULLYCONNECTEDLAYER_H__
 
 #include <backend/IPortableTensor.h>
+#include "../ExternalContext.h"
 #include "OperationUtils.h"
 
 #include <exec/IFunction.h>
@@ -53,7 +54,8 @@ public:
   void fullyConnectedHybrid();
 
   void configure(const IPortableTensor *input, const IPortableTensor *weights,
-                 const IPortableTensor *bias, ir::Activation activation, IPortableTensor *output);
+                 const IPortableTensor *bias, ir::Activation activation, IPortableTensor *output,
+                 const std::shared_ptr<ExternalContext> &external_context);
 
   void run() override;
 
@@ -67,6 +69,8 @@ private:
 
   ir::Activation _activation;
   std::unique_ptr<nnfw::cker::FCTempArena> _temp_arena;
+
+  std::shared_ptr<ExternalContext> _external_context;
 
   bool _is_hybrid;
 

--- a/runtime/onert/backend/cpu/ops/FullyConnectedLayer.h
+++ b/runtime/onert/backend/cpu/ops/FullyConnectedLayer.h
@@ -75,6 +75,7 @@ private:
   bool _is_hybrid;
 
 #ifdef USE_RUY_GEMV
+  bool _is_weights_freed = false;
   uint8_t *_cached_weights = nullptr; // weights to be cached and a key
 #ifdef EXPERIMENTAL_RUY_FEATURE
   bool _is_weights_freed = false; // is weights freed?

--- a/runtime/onert/backend/cpu/ops/FullyConnectedLayer.h
+++ b/runtime/onert/backend/cpu/ops/FullyConnectedLayer.h
@@ -75,7 +75,6 @@ private:
   bool _is_hybrid;
 
 #ifdef USE_RUY_GEMV
-  bool _is_weights_freed = false;
   uint8_t *_cached_weights = nullptr; // weights to be cached and a key
 #ifdef EXPERIMENTAL_RUY_FEATURE
   bool _is_weights_freed = false; // is weights freed?

--- a/runtime/onert/core/include/backend/BackendContext.h
+++ b/runtime/onert/core/include/backend/BackendContext.h
@@ -56,6 +56,8 @@ public:
   {
   }
 
+  virtual ~BackendContext() = default;
+
   void initialize(const std::vector<OperationInfo> &operation_list,
                   const std::vector<ir::OperandIndex> &operand_list);
   void initConsts();

--- a/runtime/onert/core/include/backend/IExternalContext.h
+++ b/runtime/onert/core/include/backend/IExternalContext.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_BACKEND_IEXTERNAL_CONTEXT_H__
+#define __ONERT_BACKEND_IEXTERNAL_CONTEXT_H__
+
+namespace onert
+{
+namespace backend
+{
+
+struct IExternalContext
+{
+  virtual ~IExternalContext() = default;
+  virtual void SetMaxNumThreads(int) = 0;
+};
+
+} // namespace backend
+} // namespace onert
+
+#endif // __ONERT_BACKEND_IEXTERNAL_CONTEXT__

--- a/tests/tools/nnpackage_run/src/args.cc
+++ b/tests/tools/nnpackage_run/src/args.cc
@@ -251,6 +251,8 @@ void Args::Parse(const int argc, char **argv)
     return;
   }
 
+    _executable_basename = basename(argv[0]);
+
   try
   {
     po::notify(vm);

--- a/tests/tools/nnpackage_run/src/args.h
+++ b/tests/tools/nnpackage_run/src/args.h
@@ -35,6 +35,7 @@ public:
   Args(const int argc, char **argv);
   void print(void);
 
+  std::string getExecutableBasename(void) const { return _executable_basename; }
   const std::string &getPackageFilename(void) const { return _package_filename; }
 #if defined(ONERT_HAVE_HDF5) && ONERT_HAVE_HDF5 == 1
   const std::string &getDumpFilename(void) const { return _dump_filename; }
@@ -60,6 +61,7 @@ private:
   po::positional_options_description _positional;
   po::options_description _options;
 
+  std::string _executable_basename;
   std::string _package_filename;
 #if defined(ONERT_HAVE_HDF5) && ONERT_HAVE_HDF5 == 1
   std::string _dump_filename;

--- a/tests/tools/nnpackage_run/src/nnpackage_run.cc
+++ b/tests/tools/nnpackage_run/src/nnpackage_run.cc
@@ -34,6 +34,7 @@
 #include <iostream>
 #include <libgen.h>
 #include <stdexcept>
+#include <thread>
 #include <unordered_map>
 #include <vector>
 
@@ -61,13 +62,12 @@ NNFW_STATUS resolve_op_backend(nnfw_session *session)
   return NNFW_STATUS_NO_ERROR;
 }
 
-int main(const int argc, char **argv)
+int run(nnpkg_run::Args args)
 {
   using namespace nnpkg_run;
 
   try
   {
-    Args args(argc, argv);
     auto nnpackage_path = args.getPackageFilename();
     if (args.printVersion())
     {
@@ -275,7 +275,7 @@ int main(const int argc, char **argv)
         std::cerr << "E: during getting realpath from nnpackage_path." << std::endl;
         exit(-1);
       }
-      exec_basename = basename(argv[0]);
+      exec_basename = args.getExecutableBasename();
     }
 
     benchmark::writeResult(result, exec_basename, nnpkg_basename, backend_name);
@@ -285,6 +285,35 @@ int main(const int argc, char **argv)
   catch (std::runtime_error &e)
   {
     std::cerr << "E: Fail to run by runtime error:" << e.what() << std::endl;
+    exit(-1);
+  }
+}
+
+int main(const int argc, char **argv)
+{
+  try
+  {
+    nnpkg_run::Args args(argc, argv);
+
+    int num_threads = 4;
+
+    if (num_threads > 1)
+    {
+      std::vector<std::thread> threads;
+      for (int i = 0; i < num_threads; i++)
+        threads.push_back(std::thread(run, args));
+
+      for (auto &th : threads)
+        th.join();
+    }
+    else
+    {
+      run(args);
+    }
+  }
+  catch (std::runtime_error &e)
+  {
+    std::cerr << "E: Fail to parse arguments:" << e.what() << std::endl;
     exit(-1);
   }
 }

--- a/tests/tools/nnpackage_run/src/nnpackage_run.cc
+++ b/tests/tools/nnpackage_run/src/nnpackage_run.cc
@@ -293,22 +293,25 @@ int main(const int argc, char **argv)
 {
   try
   {
-    nnpkg_run::Args args(argc, argv);
-
-    int num_threads = 4;
-
-    if (num_threads > 1)
+    for (int k = 0; k < 10; k++)
     {
-      std::vector<std::thread> threads;
-      for (int i = 0; i < num_threads; i++)
-        threads.push_back(std::thread(run, args));
+      nnpkg_run::Args args(argc, argv);
 
-      for (auto &th : threads)
-        th.join();
-    }
-    else
-    {
-      run(args);
+      int num_threads = 4;
+
+      if (num_threads > 1)
+      {
+        std::vector<std::thread> threads;
+        for (int i = 0; i < num_threads; i++)
+          threads.push_back(std::thread(run, args));
+
+        for (auto &th : threads)
+          th.join();
+      }
+      else
+      {
+        run(args);
+      }
     }
   }
   catch (std::runtime_error &e)


### PR DESCRIPTION
- Create ExternalContext class which has ruy context
  - CPU backend has ExternalContext
  - KernelGenerator and FullyConnectedLayer has ExternalContext
  - Pass ruy_context to cker::FullyConnectedHybrid
- Link ruy library to onert

ONE-DCO-1.0-Signed-off-by: JiHwan Yeo <jihwan.yeo@samsung.com>

---

For issue : #3318