### PR TITLE
[luci-interpreter] Add quantized_dimension to luci-interpreter

### DIFF
--- a/compiler/luci-interpreter/include/luci_interpreter/core/Tensor.h
+++ b/compiler/luci-interpreter/include/luci_interpreter/core/Tensor.h
@@ -79,12 +79,11 @@ private:
 //
 // Note that due to historical and performance reasons, per-tensor quantization uses unsigned
 // integer types, while per-channel uses signed types assuming 'zero_point' == 0.
-//
-// TODO Add 'quantized_dimension' field for per-channel case when IR provides it.
 struct AffineQuantization
 {
   std::vector<float> scale;
   std::vector<int32_t> zero_point;
+  int32_t quantized_dimension;
 };
 
 class Tensor
@@ -107,6 +106,12 @@ public:
     assert(_quantization.zero_point.size() == 1);
     return _quantization.zero_point[0];
   }
+
+  const std::vector<float> &scales() const { return _quantization.scale; }
+
+  const std::vector<int32_t> &zero_points() const { return _quantization.zero_point; }
+
+  int32_t quantized_dimension() const { return _quantization.quantized_dimension; }
 
   template <typename T> const T *data() const { return reinterpret_cast<const T *>(_data.get()); }
 

--- a/compiler/luci-interpreter/src/loader/GraphLoader.cpp
+++ b/compiler/luci-interpreter/src/loader/GraphLoader.cpp
@@ -136,6 +136,7 @@ void GraphLoader::loadTensors()
       const luci::CircleQuantParam *params = node->quantparam();
       quantization.scale.assign(params->scale.cbegin(), params->scale.cend());
       quantization.zero_point.assign(params->zerop.cbegin(), params->zerop.cend());
+      quantization.quantized_dimension = params->quantized_dimension;
     }
 
     auto tensor = std::make_unique<Tensor>(node->dtype(), std::move(shape), std::move(quantization),


### PR DESCRIPTION
This adds quantized_dimension to luci-interpreter

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to #3218