### PR TITLE
[compiler/common-artifacts] exclude unique from circle optimization

### DIFF
--- a/compiler/common-artifacts/exclude.lst
+++ b/compiler/common-artifacts/exclude.lst
@@ -5,6 +5,12 @@
 
 #[[ optimize : Exclude from circle optimization(circle2circle) ]]
 ## TensorFlowLiteRecipes
+optimize(Unique_000)
+optimize(Unique_001)
+optimize(Unique_002)
+optimize(Unique_003)
+optimize(Unique_U8_000)
+optimize(Unique_U8_001)
 
 ## CircleRecipes
 


### PR DESCRIPTION
Parent Issue : #2568
Draft PR : #2829

Exclude Unique from circle optimization under common-artifacts.

ONE-DCO-1.0-Signed-off-by: venkat.iyer <venkat.iyer@samsung.com>