### PR TITLE
[onert] Fix wrong parent of StaticTensorManager

### DIFF
--- a/runtime/onert/backend/cpu/StaticTensorManager.h
+++ b/runtime/onert/backend/cpu/StaticTensorManager.h
@@ -17,6 +17,7 @@
 #ifndef __ONERT_BACKEND_CPU_STATICTENSOR_MANAGER_H__
 #define __ONERT_BACKEND_CPU_STATICTENSOR_MANAGER_H__
 
+#include "backend/IStaticTensorManager.h"
 #include "backend/cpu_common/MemoryManager.h"
 #include "backend/cpu_common/TensorRegistry.h"
 #include "backend/ITensorManager.h"
@@ -30,7 +31,7 @@ namespace backend
 namespace cpu
 {
 
-class StaticTensorManager : public backend::ITensorManager
+class StaticTensorManager : public backend::IStaticTensorManager
 {
 public:
   StaticTensorManager(const std::shared_ptr<cpu_common::TensorRegistry> &reg);

--- a/runtime/onert/core/include/backend/cpu_common/StaticTensorManager.h
+++ b/runtime/onert/core/include/backend/cpu_common/StaticTensorManager.h
@@ -19,7 +19,7 @@
 
 #include "MemoryManager.h"
 
-#include "backend/ITensorManager.h"
+#include "backend/IStaticTensorManager.h"
 #include "ir/OperandIndexMap.h"
 #include "ir/OperandInfo.h"
 #include "TensorRegistry.h"
@@ -31,7 +31,7 @@ namespace backend
 namespace cpu_common
 {
 
-class StaticTensorManager : public backend::ITensorManager
+class StaticTensorManager : public backend::IStaticTensorManager
 {
 public:
   StaticTensorManager(const std::shared_ptr<TensorRegistry> &reg);


### PR DESCRIPTION
This fixes the parent of `StaticTensorManager` from `ITensorManager` to `IStaticTensorManager`.

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>