### PR TITLE
[onert] Apply ExternalTensor to cpu backend

### DIFF
--- a/runtime/onert/backend/cpu/ConstantInitializer.cc
+++ b/runtime/onert/backend/cpu/ConstantInitializer.cc
@@ -48,7 +48,7 @@ void ConstantInitializer::registerExternalInitializer(const ir::OperandIndex &in
   _init_map[index] = [](const onert::ir::Operand &model_obj, onert::backend::ITensor &itensor) {
     auto data = model_obj.shareData();
     assert(data && data->base());
-    ExternalTensor &tensor = reinterpret_cast<ExternalTensor &>(itensor);
+    ExternalTensor &tensor = dynamic_cast<ExternalTensor &>(itensor);
     tensor.setData(data);
   };
 }

--- a/runtime/onert/backend/cpu/ConstantInitializer.h
+++ b/runtime/onert/backend/cpu/ConstantInitializer.h
@@ -36,6 +36,15 @@ public:
                       const std::shared_ptr<TensorBuilder> &tensor_builder);
 
 public:
+  void registerDefaultInitializer(const ir::OperandIndex &index, const ir::Operand &obj) override;
+
+  // TODO: For now the only cpu backend supports constant tensor to use data from external
+  // If the other backend supports (to do this,
+  // ExternalTensor should be abstract such as IExternal, maybe),
+  // this can be an interface of IConstantInitializer
+  void registerExternalInitializer(const ir::OperandIndex &, const ir::Operand &);
+
+public:
   void visit(const ir::operation::Conv2D &) override;
   void visit(const ir::operation::DepthwiseConv2D &) override;
   void visit(const ir::operation::FullyConnected &) override;

--- a/runtime/onert/backend/cpu/TensorBuilder.cc
+++ b/runtime/onert/backend/cpu/TensorBuilder.cc
@@ -29,7 +29,7 @@ namespace cpu
 
 TensorBuilder::TensorBuilder()
     : _tensor_reg{new cpu_common::TensorRegistry()},
-      _static_tensor_mgr{new cpu_common::StaticTensorManager(_tensor_reg)},
+      _static_tensor_mgr{new StaticTensorManager(_tensor_reg)},
       _dynamic_tensor_mgr{new cpu_common::DynamicTensorManager(_tensor_reg)}
 {
   /* empty */
@@ -77,11 +77,7 @@ bool TensorBuilder::isRegistered(const ir::OperandIndex &ind) const
   return _tensor_info_map.find(ind) != _tensor_info_map.end();
 }
 
-void TensorBuilder::prepare(void)
-{
-  _static_tensor_mgr->allocateConsts();
-  _static_tensor_mgr->allocateNonconsts();
-}
+void TensorBuilder::prepare(void) { _static_tensor_mgr->allocateNonconsts(); }
 
 void TensorBuilder::allocate()
 {
@@ -107,7 +103,7 @@ bool TensorBuilder::setMigrantTensor(const ir::OperandIndex &ind,
 
 void TensorBuilder::iterate(const IterateFunction &fn) { _static_tensor_mgr->iterate(fn); }
 
-std::shared_ptr<cpu_common::Tensor> TensorBuilder::at(const ir::OperandIndex &ind)
+std::shared_ptr<Tensor> TensorBuilder::at(const ir::OperandIndex &ind)
 {
   return _tensor_reg->getNativeTensor(ind);
 }

--- a/runtime/onert/backend/cpu/TensorBuilder.h
+++ b/runtime/onert/backend/cpu/TensorBuilder.h
@@ -18,12 +18,13 @@
 #define __ONERT_BACKEND_CPU_TENSOR_BUILDER_H__
 
 #include <backend/cpu_common/DynamicTensorManager.h>
-#include <backend/cpu_common/StaticTensorManager.h>
 #include <backend/cpu_common/TensorRegistry.h>
-#include <backend/cpu_common/Tensor.h>
 
 #include <backend/ITensorBuilder.h>
 #include <ir/OperandIndexMap.h>
+
+#include "StaticTensorManager.h"
+#include "Tensor.h"
 
 #include <unordered_map>
 
@@ -80,7 +81,7 @@ public:
    *        If not, program will crash with assert or exception.
    * @return shared_ptr<Tensor>
    */
-  std::shared_ptr<cpu_common::Tensor> at(const ir::OperandIndex &ind);
+  std::shared_ptr<Tensor> at(const ir::OperandIndex &ind);
   std::shared_ptr<IPortableTensor> portableAt(const ir::OperandIndex &ind);
   bool setMigrantTensor(const ir::OperandIndex &ind,
                         const std::shared_ptr<IPortableTensor> &tensor) override;
@@ -89,7 +90,7 @@ public:
 
 private:
   const std::shared_ptr<cpu_common::TensorRegistry> _tensor_reg;
-  std::unique_ptr<cpu_common::StaticTensorManager> _static_tensor_mgr;
+  std::unique_ptr<StaticTensorManager> _static_tensor_mgr;
   std::unique_ptr<cpu_common::DynamicTensorManager> _dynamic_tensor_mgr;
   ir::OperandIndexMap<ir::OperandInfo> _tensor_info_map;
 };


### PR DESCRIPTION
Apply ExternalTensor to cpu backend. Now cpu backend's const tensors are
ExternalTensor so that are not memory-allocated.

ONE-DCO-1.0-Signed-off-by: Yongseop Kim <yons.kim@samsung.com>