### PR TITLE
[luci] Add to protect overflow about asymmetric quantization

### DIFF
--- a/compiler/luci/pass/src/QuantizationUtils.cpp
+++ b/compiler/luci/pass/src/QuantizationUtils.cpp
@@ -62,8 +62,8 @@ void compute_asym_scale_zp(float min, float max, float &scaling_factor, int64_t 
   const int32_t kMaxScale = 255;
   const double qmin_double = kMinScale;
   const double qmax_double = kMaxScale;
-  double rmin = std::fmin(0, min);
-  double rmax = std::fmax(0, max);
+  const double rmin = std::fmin(0, min);
+  const double rmax = std::fmax(0, max);
 
   double scale = (rmax - rmin) / (qmax_double - qmin_double);
   double zero_point_double = 0;
@@ -83,7 +83,6 @@ void compute_asym_scale_zp(float min, float max, float &scaling_factor, int64_t 
     assert(min >= 0 && max >= 0);
     nudged_zero_point = kMinScale;
     scale = max / (qmax_double - qmin_double);
-    rmin = 0;
     if (min > 0 && max > 0)
       WARN(l) << "The minimum and maximum values are all positive." << std::endl;
   }


### PR DESCRIPTION
### [luci] Add to protect overflow about asymmetric quantization
- It can be occured to overflow when you computed fixed bias value.
```
int32 fixed_bias = float_bias / (input scale * weight scale(too small));
```

ONE-DCO-1.0-Signed-off-by: mia park <mia.park@samsung.com>