### PR TITLE
Revert "[onert] Use optimized logistic cpu kernel for aarch64 only 

### DIFF
--- a/compute/cker/include/cker/operation/Logistic.h
+++ b/compute/cker/include/cker/operation/Logistic.h
@@ -32,18 +32,9 @@ namespace cker
 inline void Logistic(const Shape &input_shape, const float *input_data, const Shape &output_shape,
                      float *output_data)
 {
-#ifdef __aarch64__
   auto input_map = MapAsVector(input_data, input_shape);
   auto output_map = MapAsVector(output_data, output_shape);
   output_map.array() = input_map.array().unaryExpr(Eigen::internal::scalar_logistic_op<float>());
-#else
-  // Note, this can be done using TANH: (1/2) + (1/2) * TANH(x/2)
-  const int size = MatchingFlatSize(input_shape, output_shape);
-  for (int i = 0; i < size; i++)
-  {
-    output_data[i] = 1.f / (1.f + std::exp(-input_data[i]));
-  }
-#endif
 }
 
 } // namespace cker


### PR DESCRIPTION
This reverts commit 0b79eab4c982ef68ef842dcf2facd12f5684e8ae.
For performance issue, we will revert this PR. Note that this patch causes accuracy drop. 