### PR TITLE
[scripts] create python virtual env

### DIFF
--- a/infra/scripts/docker_build_nncc.sh
+++ b/infra/scripts/docker_build_nncc.sh
@@ -54,6 +54,15 @@ pushd $ROOT_PATH > /dev/null
 mkdir -p ${NNCC_INSTALL_PREFIX}
 ./nncc docker-run ./nnas create-package --prefix "${PWD}/${NNCC_INSTALL_PREFIX}" -- "${CONFIG_OPTIONS}"
 
+# create python virtual environment
+python3 -m venv "${NNCC_INSTALL_PREFIX}/bin/venv"
+
+source "${NNCC_INSTALL_PREFIX}/bin/venv/bin/activate"
+python -m pip --default-timeout=1000 --trusted-host pypi.org --trusted-host files.pythonhost.org \
+  install -U pip setuptools
+python -m pip --default-timeout=1000 --trusted-host pypi.org --trusted-host files.pythonhost.org \
+  install tensorflow-cpu==2.3.0rc0
+
 mkdir -p ${ARCHIVE_PATH}
 tar -zcf ${ARCHIVE_PATH}/nncc-package.tar.gz -C ${NNCC_INSTALL_PREFIX} ./
 


### PR DESCRIPTION
This commit adds python virtual env creation step to docker_build_nncc.

We originally install Python with `./nnas create-package` command, but I split the process in two for convenience. There is no need to change CI script.

Related : #3355 
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>