### PR TITLE
[luci-interpreter] Add CIRCLECONST CircleOpCode case

### DIFF
--- a/compiler/luci-interpreter/src/loader/GraphLoader.cpp
+++ b/compiler/luci-interpreter/src/loader/GraphLoader.cpp
@@ -70,6 +70,7 @@ bool isExecutableNode(const luci::CircleNode *node)
   {
     // These nodes denote inputs / outputs of a graph.
     case luci::CircleOpcode::CONST:
+    case luci::CircleOpcode::CIRCLECONST:
     case luci::CircleOpcode::CIRCLEINPUT:
     case luci::CircleOpcode::CIRCLEOUTPUT:
     // The following nodes denote outputs of multiple-output nodes.


### PR DESCRIPTION
This commit adds CONSTANT CircleOpCode case.

`CONST` will be deprecated soon.
Related : #3390 
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>