### PR TITLE
[record-minmax] Fix static analysis warning

### DIFF
--- a/compiler/record-minmax/src/RecordMinMax.cpp
+++ b/compiler/record-minmax/src/RecordMinMax.cpp
@@ -158,7 +158,7 @@ void RecordMinMax::profileData(const std::string &mode, const std::string &input
     auto node = iter->first;
     auto minmax = iter->second;
 
-    float min, max;
+    float min{0.0f}, max{0.0f};
     if (mode == "percentile")
     {
       min = getNthPercentile(minmax.min_vector, min_percentile);


### PR DESCRIPTION
This commit fixes static analysis warning in record-minmax.

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>