### PR TITLE
[bcq-tools] Introduce preserving BCQ information tool

### DIFF
--- a/compiler/bcq-tools/README.md
+++ b/compiler/bcq-tools/README.md
@@ -9,7 +9,9 @@ This directory includes some tools related with BCQ.
 `preserve_bcq_info` is for preserving constant nodes which include BCQ information.
 When `.pb` file is converted to `.tflite` file by TFlite converter, constant nodes whose values are exactly same are removed and then linked to only one representative node.
 This makes us impossible to know what constant node should be linked to a node which we want to apply BCQ.
-Therefore, we should preserve these BCQ information.
+One of the solutions is making all the same constant nodes different by inserting unique values and ignore the newly generated unique values when BCQ fusing is applied.
+`preserve_bcq_info` will generate and insert unique dummy values to the constant nodes whose values are same not to be removed by Tensorflow Lite converter.
+As a result, BCQ information will be preserved.
 
 ### How to use
 

--- a/compiler/bcq-tools/README.md
+++ b/compiler/bcq-tools/README.md
@@ -8,7 +8,7 @@ This directory includes some tools related with BCQ.
 
 `preserve_bcq_info` is for preserving constant nodes which include BCQ information.
 When `.pb` file is converted to `.tflite` file by TFlite converter, constant nodes whose values are exactly same are removed and then linked to only one representative node.
-It causes information missing problem because we don't know which constant nodes should be linked to even we still want to apply BCQ.
+This makes us impossible to know what constant node should be linked to a node which we want to apply BCQ.
 Therefore, we should preserve these BCQ information.
 
 ### How to use

--- a/compiler/bcq-tools/README.md
+++ b/compiler/bcq-tools/README.md
@@ -14,7 +14,7 @@ Therefore, we should preserve these BCQ information.
 ### How to use
 
 ```bash
-python preserve_bcq_info.py \
+preserve_bcq_info \
 --input_path /path/to/original_model.pb \
 --output_path /path/to/preserved_model.pb
 ```

--- a/compiler/bcq-tools/README.md
+++ b/compiler/bcq-tools/README.md
@@ -6,7 +6,7 @@ This directory includes some tools related with BCQ.
 
 ### Purpose
 
-`preserve_bcq_info` is for preserving constant nodes which are including BCQ information.
+`preserve_bcq_info` is for preserving constant nodes which include BCQ information.
 When `.pb` file is converted to `.tflite` file by TFlite converter, constant nodes whose values are exactly same are removed and then linked to only one representative node.
 It causes information missing problem because we don't know which constant nodes should be linked to even we still want to apply BCQ.
 Therefore, we should preserve these BCQ information.

--- a/compiler/bcq-tools/README.md
+++ b/compiler/bcq-tools/README.md
@@ -1,0 +1,44 @@
+# BCQ Tools
+
+This directory includes some tools related with BCQ.
+
+## preserve_bcq_info
+
+### Purpose
+
+`preserve_bcq_info` is for preserving constant nodes which are including BCQ information.
+When `.pb` file is converted to `.tflite` file by TFlite converter, constant nodes whose values are exactly same are removed and then linked to only one representative node.
+It causes information missing problem because we don't know which constant nodes should be linked to even we still want to apply BCQ.
+Therefore, we should preserve these BCQ information.
+
+### How to use
+
+```bash
+python preserve_bcq_info.py \
+--input_path /path/to/original_model.pb \
+--output_path /path/to/preserved_model.pb
+```
+
+### How it works
+
+If we add unique dummy value at the end of each constant nodes, all the constant nodes would be different. Following is an example.
+
+```
+[Original Constant Nodes]
+const(value=[1, 2, 3], name='const1')
+const(value=[1, 2, 3], name='const2')
+const(value=[1, 2, 3], name='const3')
+
+[After BCQ information preserved]
+const(value=[1, 2, 3, -1], name='const1')
+const(value=[1, 2, 3, -2], name='const2')
+const(value=[1, 2, 3, -3], name='const3')
+```
+
+For dummy values, negative values are used instead of positive values.
+This is because positive valus may be confused with original constant node values.
+For your information, unique dummy value starts from -1 and moves to -2, -3, ..., -N, where N is the number of preserved constant nodes.
+
+### Caution
+
+- Newly generated dummy values should be ignored when the constant nodes are used.

--- a/compiler/bcq-tools/preserve_bcq_info
+++ b/compiler/bcq-tools/preserve_bcq_info
@@ -79,9 +79,10 @@ def preserve_bcq_info(flags):
                 substitution_dict[node.name] = tf.make_tensor_proto(
                     [int(original_tensor[0]), unique_value.gen()], tf.int32)
 
-            if ("/bcqinfo_number_of_clusters" in node.name
-                    or "/bcqinfo_size_of_clusters" in node.name
-                    or "/bcqinfo_qbits_of_clusters" in node.name):
+            preserved_bcqinfo_list = ["/bcqinfo_number_of_clusters", "/bcqinfo_size_of_clusters", 
+                "/bcqinfo_qbits_of_clusters"]
+
+            if any(name in node.name for name in preserved_bcqinfo_list):
                 original_tensor = tf.make_ndarray(
                     node.attr["value"].tensor)  # variable name change
                 substitution_dict[node.name] = tf.make_tensor_proto(

--- a/compiler/bcq-tools/preserve_bcq_info
+++ b/compiler/bcq-tools/preserve_bcq_info
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+
+import tensorflow as tf
+import numpy as np
+
+import argparse
+import sys
+
+
+def _get_parser():
+    """
+    Returns an ArgumentParser for preserving BCQ information.
+    """
+    parser = argparse.ArgumentParser(
+        description=("Command line tool to preserve BCQ information"))
+
+    # Input and output path.
+    parser.add_argument(
+        "-i",
+        "--input_path",
+        type=str,
+        help="Full filepath of the input file.",
+        required=True)
+    parser.add_argument(
+        "-o",
+        "--output_path",
+        type=str,
+        help="Full filepath of the output file.",
+        required=True)
+
+    return parser
+
+
+def load_graph(frozen_graph_filename):
+    """
+    Load graph from frozen pb file
+    """
+    with tf.compat.v1.gfile.GFile(frozen_graph_filename, "rb") as f:
+        graph_def = tf.compat.v1.GraphDef()
+        graph_def.ParseFromString(f.read())
+    with tf.Graph().as_default() as graph:
+        tf.import_graph_def(graph_def, name='')
+    return graph
+
+
+def preserve_bcq_info(flags):
+    """
+    Generate unique dummy value from -1 to -N.
+
+    We use negative values to preserve BCQ information because
+    positive values may cause some confusion with real BCQ information values.
+    """
+
+    class UniqueValueGen:
+        def __init__(self):
+            self.unique_value = -1
+
+        def gen(self):
+            val = self.unique_value
+            self.unique_value = val - 1
+            return val
+
+    unique_value = UniqueValueGen()
+
+    original_graph_model = load_graph(flags.input_path)
+    original_graph_model_def = original_graph_model.as_graph_def()
+
+    new_graph = tf.compat.v1.GraphDef()
+    substitution_dict = {}
+
+    DT_INT32 = None  # Just for copying DT_INT32 attribute value
+
+    for node in original_graph_model_def.node:
+        if node.op == "Const":
+
+            # Because bcqinfo_do_w_x is BOOL type, we cannot add dummy value at the end.
+            # Therefore we should convert the type to INT32 type.
+            if "/bcqinfo_do_w_x" in node.name:
+                original_tensor = tf.make_ndarray(node.attr["value"].tensor)
+                substitution_dict[node.name] = tf.make_tensor_proto(
+                    [int(original_tensor[0]), unique_value.gen()], tf.int32)
+
+            if ("/bcqinfo_number_of_clusters" in node.name
+                    or "/bcqinfo_size_of_clusters" in node.name
+                    or "/bcqinfo_qbits_of_clusters" in node.name):
+                original_tensor = tf.make_ndarray(
+                    node.attr["value"].tensor)  # variable name change
+                substitution_dict[node.name] = tf.make_tensor_proto(
+                    np.append(original_tensor, unique_value.gen()), tf.int32)
+                DT_INT32 = node.attr["dtype"]
+
+    for node in original_graph_model_def.node:
+        if node.name in substitution_dict:
+            new_node = new_graph.node.add()
+            new_node.op = "Const"
+            new_node.name = node.name
+            new_node.attr["dtype"].CopyFrom(DT_INT32)
+            new_node.attr["value"].tensor.CopyFrom(substitution_dict[node.name])
+        else:
+            new_node = new_graph.node.add()
+            new_node.CopyFrom(node)
+
+    tf.io.write_graph(new_graph, '.', flags.output_path, False)
+
+
+def main():
+    # Parse argument.
+    parser = _get_parser()
+    flags = parser.parse_known_args(args=sys.argv[1:])
+
+    # Generate a new pb file, which BCQ information is preserved.
+    preserve_bcq_info(flags[0])
+
+
+if __name__ == "__main__":
+    main()

--- a/compiler/bcq-tools/preserve_bcq_info
+++ b/compiler/bcq-tools/preserve_bcq_info
@@ -72,7 +72,6 @@ def preserve_bcq_info(flags):
 
     for node in original_graph_model_def.node:
         if node.op == "Const":
-
             # Because bcqinfo_do_w_x is BOOL type, we cannot add dummy value at the end.
             # Therefore we should convert the type to INT32 type.
             if "/bcqinfo_do_w_x" in node.name:


### PR DESCRIPTION
Parent Issue : #3471 

This commit will introduce `preserve_bcq_info` tool, which is for preserving BCQ information.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>