### PR TITLE
[res/TensorFlowLiteRecipes] Add Logistic_U8_000

### DIFF
--- a/res/TensorFlowLiteRecipes/Logistic_U8_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/Logistic_U8_000/test.recipe
@@ -1,0 +1,19 @@
+operand {
+  name: "ifm"
+  type: UINT8
+  shape { dim: 1 dim: 3 dim: 3 dim: 2 }
+  quant { min: 0 max: 1 scale: 0.00390625 zero_point: -128 }
+}
+operand {
+  name: "ofm"
+  type: UINT8
+  shape { dim: 1 dim: 3 dim: 3 dim: 2 }
+  quant { min: 0 max: 1 scale: 0.00390625 zero_point: -128 }
+}
+operation {
+  type: "Logistic"
+  input: "ifm"
+  output: "ofm"
+}
+input: "ifm"
+output: "ofm"


### PR DESCRIPTION
Parent Issue: #1880
Fired Issue: #3461 

This commit adds recipes for Logistic_U8_000. (Derived from SOS Mine Project)

Scale & Zero point is set according to [Tensorflow Guide](https://www.tensorflow.org/lite/performance/quantization_spec)
> logistic: {1 / 256.0, -128}

> But it seems my `./nncc build` fails with this recipe. (from #3496)
- This has been fixed. Now it works fine and successfully passes build and test.

Please review this Work in Progress codes @seanshpark , @jinevening
I'll be happy to get feedback and change to make improvement.

Thank you.

P.S. #3496 has been closed and a new PR has been opened due to my mistake. I wrongly made rebase and somehow the whole commits (even commits that are NOT mine) has been updated on that PR. So I made this PR more carefully. Thank you.

Signed-off-by: underflow101 <ikarus125@gmail.com>