### PR TITLE
[onert] Change nnfw_lib_benchmark to static library

### DIFF
--- a/runtime/libs/benchmark/CMakeLists.txt
+++ b/runtime/libs/benchmark/CMakeLists.txt
@@ -1,6 +1,5 @@
 file(GLOB_RECURSE SOURCES "src/*.cpp")
 
-add_library(nnfw_lib_benchmark SHARED ${SOURCES})
+add_library(nnfw_lib_benchmark STATIC ${SOURCES})
 target_include_directories(nnfw_lib_benchmark PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_link_libraries(nnfw_lib_benchmark PRIVATE ${LIB_PTHREAD})
-install(TARGETS nnfw_lib_benchmark DESTINATION lib)


### PR DESCRIPTION
Change nnfw_lib_benchmark to static library and don't install
nnfw_lib_benchmark is used for test binary

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>