### PR TITLE
[onert] Add uint8 asymmetric quantization for SpaceToDepth

### DIFF
--- a/runtime/onert/backend/cpu/ops/SpaceToDepthLayer.cc
+++ b/runtime/onert/backend/cpu/ops/SpaceToDepthLayer.cc
@@ -40,8 +40,8 @@ template <typename T> void SpaceToDepthLayer::spaceToDepth()
   params.block_size = _block_size;
 
   nnfw::cker::SpaceToDepth(params, getTensorShape(_input),
-                           reinterpret_cast<const float *>(_input->buffer()),
-                           getTensorShape(_output), reinterpret_cast<T *>(_output->buffer()));
+                           reinterpret_cast<const T *>(_input->buffer()), getTensorShape(_output),
+                           reinterpret_cast<T *>(_output->buffer()));
 }
 
 void SpaceToDepthLayer::configure(const IPortableTensor *input, const int32_t block_size,
@@ -57,6 +57,10 @@ void SpaceToDepthLayer::run()
   if (_input->data_type() == OperandType::FLOAT32)
   {
     spaceToDepth<float>();
+  }
+  else if (_input->data_type() == OperandType::QUANT_UINT8_ASYMM)
+  {
+    spaceToDepth<uint8_t>();
   }
   else
   {

--- a/tests/nnapi/nnapi_gtest.skip.aarch64-linux.cpu
+++ b/tests/nnapi/nnapi_gtest.skip.aarch64-linux.cpu
@@ -129,8 +129,6 @@ GeneratedTests.slice_6
 GeneratedTests.slice_8
 GeneratedTests.slice_zero_sized
 GeneratedTests.slice_zero_sized_quant8
-GeneratedTests.space_to_depth_quant8_1
-GeneratedTests.space_to_depth_quant8_2
 GeneratedTests.sqrt_
 GeneratedTests.sqrt_1D_float_nnfw
 GeneratedTests.sqrt_2D_float_nnfw

--- a/tests/nnapi/nnapi_gtest.skip.armv7l-linux.cpu
+++ b/tests/nnapi/nnapi_gtest.skip.armv7l-linux.cpu
@@ -129,8 +129,6 @@ GeneratedTests.slice_6
 GeneratedTests.slice_8
 GeneratedTests.slice_zero_sized
 GeneratedTests.slice_zero_sized_quant8
-GeneratedTests.space_to_depth_quant8_1
-GeneratedTests.space_to_depth_quant8_2
 GeneratedTests.sqrt_
 GeneratedTests.sqrt_1D_float_nnfw
 GeneratedTests.sqrt_2D_float_nnfw

--- a/tests/nnapi/nnapi_gtest.skip.x86_64-linux.cpu
+++ b/tests/nnapi/nnapi_gtest.skip.x86_64-linux.cpu
@@ -129,8 +129,6 @@ GeneratedTests.slice_6
 GeneratedTests.slice_8
 GeneratedTests.slice_zero_sized
 GeneratedTests.slice_zero_sized_quant8
-GeneratedTests.space_to_depth_quant8_1
-GeneratedTests.space_to_depth_quant8_2
 GeneratedTests.sqrt_
 GeneratedTests.sqrt_1D_float_nnfw
 GeneratedTests.sqrt_2D_float_nnfw


### PR DESCRIPTION
parent issue : #3474 

Support uint8 asymmetric quantization for SpaceToDepth

ONE-DCO-1.0-Signed-off-by: sungho22.lee <sungho22.lee@samsung.com>