### PR TITLE
[res/TensorFlowLiteRecipes] Add Logistic_U8_000

### DIFF
--- a/res/TensorFlowLiteRecipes/Logistic_U8_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/Logistic_U8_000/test.recipe
@@ -1,0 +1,19 @@
+operand {
+  name: "ifm"
+  type: UINT8
+  shape { dim: 1 dim: 3 dim: 3 dim: 2 }
+  quant { min: 0 max: 1 scale: 0.00390625 zero_point: -128 }
+}
+operand {
+  name: "ofm"
+  type: UINT8
+  shape { dim: 1 dim: 3 dim: 3 dim: 2 }
+  quant { min: 0 max: 1 scale: 0.00390625 zero_point: -128 }
+}
+operation {
+  type: "Logistic"
+  input: "ifm"
+  output: "ofm"
+}
+input: "ifm"
+output: "ofm"


### PR DESCRIPTION
Parent Issue: #1880
Fired Issue: #3461 

This commit adds recipes for Logistic_U8_000. (Derived from SOS Mine Project)

Scale & Zero point is set according to [Tensorflow Guide](https://www.tensorflow.org/lite/performance/quantization_spec)
> logistic: {1 / 256.0, -128}

Tried my git to fetch & merge from `upstream/master`, so hopes to work well this time.

Logistic_U8_000 part of `./nncc build` result:
`[ 80%] Generate Logistic_U8_000.recipe`
`[ 80%] Generate Logistic_U8_000.tflite`
`[ 80%] Generate Logistic_U8_000.circle`
`[ 80%] Generate Logistic_U8_000.opt.circle`
`[ 80%] Generate Logistic_U8_000 nnpackage`
`Generating nnpackage Logistic_U8_000.opt in .`
`[ 80%] Generate /home/bearpaek/data/git/opensource/ONE/build/compiler/common-artifacts/Logistic_U8_000.opt.input.h5 and /home/bearpaek/data/git/opensource/ONE/build/compiler/common-artifacts/Logistic_U8_000.opt.expected.h5`
`[ 80%] Move Logistic_U8_000.opt.input.h5 to nnpackage`
`[ 80%] Move Logistic_U8_000.opt.expected.h5 to nnpackage`

luci read&write test part of `./nncc test` result:
`      Start 64: luci_unit_readtest`
`64/77 Test #64: luci_unit_readtest .........................   Passed    2.53 sec`
`      Start 65: luci_unit_writetest`
`65/77 Test #65: luci_unit_writetest ........................   Passed    2.49 sec`

Please review this Work in Progress codes, @seanshpark @jinevening .
I'll be happy to get feedback and change to make improvement.

Thank you.

P.S. All 5 checks passed! Now it seems there's no more problem with my git!

Signed-off-by: underflow101 <ikarus125@gmail.com>