### PR TITLE
[record-minmax] Add CIRCLECONST OpCode

### DIFF
--- a/compiler/record-minmax/src/MinMaxObserver.cpp
+++ b/compiler/record-minmax/src/MinMaxObserver.cpp
@@ -38,7 +38,8 @@ void MinMaxObserver::postTensorWrite(const luci::CircleNode *node,
   assert(node->opcode() != luci::CircleOpcode::UNPACK);
   assert(node->opcode() != luci::CircleOpcode::WHILE);
 
-  if (node->opcode() == luci::CircleOpcode::CONST)
+  if (node->opcode() == luci::CircleOpcode::CONST ||
+      node->opcode() == luci::CircleOpcode::CIRCLECONST)
   {
     // node is not activation. Do nothing.
     return;


### PR DESCRIPTION
This commit adds CIRCLECONST OpCode to if-condition.

This is an intermediate process to convert CONST to CIRCLECONST.

Related : #3390 
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>