### PR TITLE
[bcq-tools] Enable installing bcq-tools

### DIFF
--- a/compiler/bcq-tools/CMakeLists.txt
+++ b/compiler/bcq-tools/CMakeLists.txt
@@ -1,0 +1,27 @@
+set(BCQ_TOOLS_FILES
+    generate_bcq_output_arrays
+    preserve_bcq_info
+)
+
+foreach(BCQ_TOOLS IN ITEMS ${BCQ_TOOLS_FILES})
+
+  set(BCQ_TOOLS_FILE ${BCQ_TOOLS})
+  set(BCQ_TOOLS_SRC "${CMAKE_CURRENT_SOURCE_DIR}/${BCQ_TOOLS_FILE}")
+  set(BCQ_TOOLS_BIN "${CMAKE_CURRENT_BINARY_DIR}/${BCQ_TOOLS_FILE}")
+  set(BCQ_TOOLS_TARGET "${BCQ_TOOLS}_target")
+
+  add_custom_command(OUTPUT ${BCQ_TOOLS_BIN}
+    COMMAND ${CMAKE_COMMAND} -E copy "${BCQ_TOOLS_SRC}" "${BCQ_TOOLS_BIN}"
+    DEPENDS ${BCQ_TOOLS_SRC}
+    COMMENT "Generate ${BCQ_TOOLS_BIN}"
+  )
+
+  add_custom_target(${BCQ_TOOLS_TARGET} ALL DEPENDS ${BCQ_TOOLS_BIN})
+
+  install(FILES ${BCQ_TOOLS_BIN}
+          PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE
+                      GROUP_READ GROUP_WRITE GROUP_EXECUTE
+                      WORLD_READ WORLD_EXECUTE
+          DESTINATION bin)
+
+endforeach(BCQ_TOOLS)


### PR DESCRIPTION
Parent Issue : #3471
Draft : #3476

This commit will add `CMakeLists.txt` file to enable installing `bcq-tools`.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>