### PR TITLE
[infra] Fix bug in docker_build_nncc

### DIFF
--- a/infra/scripts/docker_build_nncc.sh
+++ b/infra/scripts/docker_build_nncc.sh
@@ -55,12 +55,13 @@ mkdir -p ${NNCC_INSTALL_PREFIX}
 ./nncc docker-run ./nnas create-package --prefix "${PWD}/${NNCC_INSTALL_PREFIX}" -- "${CONFIG_OPTIONS}"
 
 # create python virtual environment
-python3 -m venv "${NNCC_INSTALL_PREFIX}/bin/venv"
+./nncc docker-run python3 -m venv "${NNCC_INSTALL_PREFIX}/bin/venv"
 
-source "${NNCC_INSTALL_PREFIX}/bin/venv/bin/activate"
-python -m pip --default-timeout=1000 --trusted-host pypi.org --trusted-host files.pythonhost.org \
+./nncc docker-run "${NNCC_INSTALL_PREFIX}/bin/venv/bin/python" \
+  -m pip --default-timeout=1000 --trusted-host pypi.org --trusted-host files.pythonhost.org \
   install -U pip setuptools
-python -m pip --default-timeout=1000 --trusted-host pypi.org --trusted-host files.pythonhost.org \
+./nncc docker-run "${NNCC_INSTALL_PREFIX}/bin/venv/bin/python" \
+  -m pip --default-timeout=1000 --trusted-host pypi.org --trusted-host files.pythonhost.org \
   install tensorflow-cpu==2.3.0rc0
 
 mkdir -p ${ARCHIVE_PATH}


### PR DESCRIPTION
This commit fixes bug in docker_build_nncc.

It makes script use docker's python when making virtual env.

Test result : http://npuci.mooo.com:8080/job/nnfw/job/test/job/swchae/job/daily-publish-package/9/
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>