### PR TITLE
[luci-interpreter] Remove CONST CircleOpcode

### DIFF
--- a/compiler/luci-interpreter/src/loader/GraphLoader.cpp
+++ b/compiler/luci-interpreter/src/loader/GraphLoader.cpp
@@ -69,7 +69,6 @@ bool isExecutableNode(const luci::CircleNode *node)
   switch (node->opcode())
   {
     // These nodes denote inputs / outputs of a graph.
-    case luci::CircleOpcode::CONST:
     case luci::CircleOpcode::CIRCLECONST:
     case luci::CircleOpcode::CIRCLEINPUT:
     case luci::CircleOpcode::CIRCLEOUTPUT:


### PR DESCRIPTION
This commit removes CONST CircleOpcode.

CONST CircleOpcode has been changed to CIRCLECONST.

Related : #3390 
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>