### PR TITLE
[nnfwapi] Return UNEXPECTED_NULL rather than ERROR

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -81,7 +81,7 @@ NNFW_STATUS nnfw_session::load_model_from_file(const char *package_dir)
   if (!package_dir)
   {
     std::cerr << "package_dir is null." << std::endl;
-    return NNFW_STATUS_ERROR;
+    return NNFW_STATUS_UNEXPECTED_NULL;
   }
 
   if (!null_terminating(package_dir, MAX_PATH_LENGTH))
@@ -303,7 +303,7 @@ NNFW_STATUS nnfw_session::input_size(uint32_t *number)
     if (number == nullptr)
     {
       std::cerr << "Error during nnfw_session::input_size, number is null pointer." << std::endl;
-      return NNFW_STATUS_ERROR;
+      return NNFW_STATUS_UNEXPECTED_NULL;
     }
     *number = primary_subgraph()->getInputs().size();
   }
@@ -325,7 +325,7 @@ NNFW_STATUS nnfw_session::output_size(uint32_t *number)
     if (number == nullptr)
     {
       std::cerr << "Error during nnfw_session::output_size, number is null pointer." << std::endl;
-      return NNFW_STATUS_ERROR;
+      return NNFW_STATUS_UNEXPECTED_NULL;
     }
     *number = primary_subgraph()->getOutputs().size();
   }
@@ -472,7 +472,7 @@ NNFW_STATUS nnfw_session::input_tensorinfo(uint32_t index, nnfw_tensorinfo *ti)
     {
       std::cerr << "Error during nnfw_session::input_tensorinfo, tensorinfo is null pointer."
                 << std::endl;
-      return NNFW_STATUS_ERROR;
+      return NNFW_STATUS_UNEXPECTED_NULL;
     }
     if (index >= primary_subgraph()->getInputs().size())
     {
@@ -508,7 +508,7 @@ NNFW_STATUS nnfw_session::output_tensorinfo(uint32_t index, nnfw_tensorinfo *ti)
   {
     std::cerr << "Error during nnfw_session::output_tensorinfo, tensorinfo is null pointer."
               << std::endl;
-    return NNFW_STATUS_ERROR;
+    return NNFW_STATUS_UNEXPECTED_NULL;
   }
 
   if (index >= primary_subgraph()->getOutputs().size())
@@ -577,10 +577,10 @@ NNFW_STATUS nnfw_session::set_available_backends(const char *backends)
 
   try
   {
-    if (!backends || null_terminating(backends, MAX_BACKEND_NAME_LENGTH) == false)
-    {
+    if (!backends)
+      return NNFW_STATUS_UNEXPECTED_NULL;
+    if (null_terminating(backends, MAX_BACKEND_NAME_LENGTH) == false)
       return NNFW_STATUS_ERROR;
-    }
 
     auto &options = _compiler->options();
 
@@ -603,11 +603,11 @@ NNFW_STATUS nnfw_session::set_op_backend(const char *op, const char *backend)
 
   try
   {
-    if (!op || !null_terminating(op, MAX_OP_NAME_LENGTH) || !backend ||
+    if (!op || !backend)
+      return NNFW_STATUS_UNEXPECTED_NULL;
+    if (!null_terminating(op, MAX_OP_NAME_LENGTH) ||
         !null_terminating(backend, MAX_BACKEND_NAME_LENGTH))
-    {
       return NNFW_STATUS_ERROR;
-    }
 
     auto key = get_op_backend_string(op);
 
@@ -631,6 +631,9 @@ NNFW_STATUS nnfw_session::set_config(const char *key, const char *value)
 {
   if (!isStateModelLoaded())
     return NNFW_STATUS_INVALID_STATE;
+
+  if (!key || !value)
+    return NNFW_STATUS_UNEXPECTED_NULL;
 
   auto &options = _compiler->options();
 
@@ -697,6 +700,9 @@ NNFW_STATUS nnfw_session::get_config(const char *key, char *value, size_t value_
 {
   if (!isStateModelLoaded())
     return NNFW_STATUS_INVALID_STATE;
+
+  if (!key || !value)
+    return NNFW_STATUS_UNEXPECTED_NULL;
 
   auto &options = _compiler->options();
 

--- a/tests/nnfw_api/src/ValidationTestAddModelLoaded.cc
+++ b/tests/nnfw_api/src/ValidationTestAddModelLoaded.cc
@@ -73,12 +73,12 @@ TEST_F(ValidationTestAddModelLoaded, neg_set_output)
 
 TEST_F(ValidationTestAddModelLoaded, neg_get_input_size)
 {
-  ASSERT_EQ(nnfw_input_size(_session, nullptr), NNFW_STATUS_ERROR);
+  ASSERT_EQ(nnfw_input_size(_session, nullptr), NNFW_STATUS_UNEXPECTED_NULL);
 }
 
 TEST_F(ValidationTestAddModelLoaded, neg_get_output_size)
 {
-  ASSERT_EQ(nnfw_output_size(_session, nullptr), NNFW_STATUS_ERROR);
+  ASSERT_EQ(nnfw_output_size(_session, nullptr), NNFW_STATUS_UNEXPECTED_NULL);
 }
 
 TEST_F(ValidationTestAddModelLoaded, neg_load_model)
@@ -92,5 +92,5 @@ TEST_F(ValidationTestAddModelLoaded, neg_load_model)
 TEST_F(ValidationTestAddModelLoaded, neg_output_tensorinfo)
 {
   // tensor_info is null
-  ASSERT_EQ(nnfw_output_tensorinfo(_session, 0, nullptr), NNFW_STATUS_ERROR);
+  ASSERT_EQ(nnfw_output_tensorinfo(_session, 0, nullptr), NNFW_STATUS_UNEXPECTED_NULL);
 }

--- a/tests/nnfw_api/src/ValidationTestAddSessionPrepared.cc
+++ b/tests/nnfw_api/src/ValidationTestAddSessionPrepared.cc
@@ -139,12 +139,12 @@ TEST_F(ValidationTestAddSessionPrepared, neg_set_output_002)
 
 TEST_F(ValidationTestAddSessionPrepared, neg_get_input_size)
 {
-  ASSERT_EQ(nnfw_input_size(_session, nullptr), NNFW_STATUS_ERROR);
+  ASSERT_EQ(nnfw_input_size(_session, nullptr), NNFW_STATUS_UNEXPECTED_NULL);
 }
 
 TEST_F(ValidationTestAddSessionPrepared, neg_get_output_size)
 {
-  ASSERT_EQ(nnfw_output_size(_session, nullptr), NNFW_STATUS_ERROR);
+  ASSERT_EQ(nnfw_output_size(_session, nullptr), NNFW_STATUS_UNEXPECTED_NULL);
 }
 
 TEST_F(ValidationTestAddSessionPrepared, neg_load_model)

--- a/tests/nnfw_api/src/ValidationTestSessionCreated.cc
+++ b/tests/nnfw_api/src/ValidationTestSessionCreated.cc
@@ -40,7 +40,7 @@ TEST_F(ValidationTestSessionCreated, neg_load_session_1)
 
 TEST_F(ValidationTestSessionCreated, neg_load_session_2)
 {
-  ASSERT_EQ(nnfw_load_model_from_file(_session, nullptr), NNFW_STATUS_ERROR);
+  ASSERT_EQ(nnfw_load_model_from_file(_session, nullptr), NNFW_STATUS_UNEXPECTED_NULL);
 }
 
 TEST_F(ValidationTestSessionCreated, neg_load_session_3)


### PR DESCRIPTION
API returned `NNFW_STATUS_UNEXPECTED_NULL` when the session pointer is
null. This commit makes it return `NNFW_STATUS_UNEXPECTED_NULL`,
when other arguments are null as well.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>