### PR TITLE
[onert] Remove redundant std::move in return statement of KernelGen

### DIFF
--- a/runtime/onert/backend/acl_common/AclKernelGen.h
+++ b/runtime/onert/backend/acl_common/AclKernelGen.h
@@ -305,7 +305,7 @@ kernelGenPool2D(const T_PoolOp &node, const ir::Operands &operands,
 
   fn->configure(ifm_tensor->handle(), ofm_tensor->handle(), info);
 
-  return std::move(fn);
+  return fn;
 }
 
 } // namespace acl_common


### PR DESCRIPTION
Fix https://github.com/Samsung/ONE/issues/3558#issue-668571673

This commit removes redundant std::move in return statement of KernelGen

Signed-off-by: ragmani <ragmani0216@gmail.com>