### PR TITLE
Use SNPE as default

### DIFF
--- a/runtime/onert/core/src/util/EventRecorder.h
+++ b/runtime/onert/core/src/util/EventRecorder.h
@@ -74,7 +74,8 @@ private:
 
 private:
   std::mutex _mu;
-  WriteFormat _write_format{WriteFormat::CHROME_TRACING};
+  // TODO: Allow user to control write_format
+  WriteFormat _write_format{WriteFormat::SNPE_BENCHMARK};
   std::vector<DurationEvent> _duration_events;
   std::vector<CounterEvent> _counter_events;
 };


### PR DESCRIPTION
From now onw, Use SNPE_BENCHMARK format as default

ONE-DCO-1.0-Signed-off-by: Chunseok Lee <chunseok.lee@samsung.com>