### PR TITLE
[dalgona] Introduce python interface to analyze DNN

### DIFF
--- a/compiler/dalgona/README.md
+++ b/compiler/dalgona/README.md
@@ -1,0 +1,72 @@
+# dalgona
+
+## What is dalgona?
+
+_dalgona_ is a tool for dynamic analysis of deep neural network.
+
+## How it works?
+
+_dalgona_ runs a user's custom analysis code (written in "Python") while performing inference. The analysis code has the form of hooks, called before/after each operator is executed. Intermediate execution results (values of activations) are passed to the hooks, so users can analyze the distribution of activations inside the hooks. The analysis result can be exported as files, log messages or any other forms, used for various purposes (model compression, optimization, etc.).
+
+## Possible applications
+- Finding quantization parameters based on the distribution of activations
+- Finding sparse activations by observing the portion of zero values
+- Finding the distribution of conditional variables in If-statement and While-statement
+- Visualization of activation data with Python libraries
+
+## Prerequisite
+- Python (apt install python-dev python3-dev)
+- Circle model (target to analyze)
+- Input data of the model (hdf5 format. See imgdata2hdf5 or gen_h5_explicit_inputs.py for more details.)
+- Analysis code (Python code)
+
+## Example
+```
+dalgona \
+ --input_model model.circle
+ --input_data data.hdf5
+ --analysis analysis/AnalysisTemplate.py
+```
+
+## Arguments
+```
+  --help            Show help message and exit
+  --input_model     Input model filepath (.circle)
+  --input_data      Input data filepath (.h5)
+  --analysis        Analysis code filepath (.py)
+  --analysis_args   (optional) String argument passed to the analysis code
+```
+
+## How to write analysis code?
+
+_dalgona_ provides hooks which are called before/after an operator is executed.
+Users can access tensors relevant to the corresponding operator inside the hooks.
+The information of each operator is passed as the arguments of the hook.
+For example, for a Conv2D operator, _dalgona_ provides following hooks.
+
+```
+  def Conv2DPre(self, name, input, filter, bias, padding, stride, dilation, fused_act)
+  def Conv2DPost(self, name, input, filter, bias, padding, stride, dilation, output, fused_act)
+```
+
+`Conv2DPre`/`Conv2DPost` are called before/after Conv2D is executed, respectively. Users can write codes to analyze the distribution of intermediate tensors using the provided arguments.
+
+(Note that Conv2DPost has one more argument "output", which is the execution result of the operator)
+
+The tensor (e.g., input, filter, bias, output) is expressed as a Python dictionary as below.
+
+```
+{'name': string, 'data': numpy array, 'quantparam': {'scale': list, 'zero_point': list, 'quantized_dimension': int}}
+```
+
+We proivde a template for the analysis code in `analysis/AnalysisTemplate.py`. Users can copy the template file and modify it to write their custom analysis codes.
+
+| List of hooks | Explanation |
+| --------------|------------ |
+| StartAnalysis(self) | Called when the analysis starts |
+| EndAnalysis(self) | Called when the analysis ends |
+| StartNetworkExecution(self, inputs) | Called when the execution of a network starts |
+| EndNetworkExecution(self, outputs) | Called when the execution of a network ends |
+| DefaultOpPre(self, name, opcode, inputs) | Default hook called before an operator is executed |
+| DefaultOpPost(self, name, opcode, inputs, output) | Default hook called after an operator is executed |
+| \<OPCODE\>Pre/Post | Hooks called before/after the corresponding operator is executed. |

--- a/compiler/dalgona/driver/Driver.cpp
+++ b/compiler/dalgona/driver/Driver.cpp
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Dalgona.h"
+
+#include <arser/arser.h>
+#include <pybind11/embed.h>
+
+namespace py = pybind11;
+
+int entry(const int argc, char **argv)
+{
+  using namespace dalgona;
+
+  arser::Arser arser("Dalgona: Dynamic analysis tool for DNN");
+
+  arser.add_argument("--input_model")
+      .nargs(1)
+      .type(arser::DataType::STR)
+      .required(true)
+      .help("Input model filepath (.circle)");
+
+  arser.add_argument("--input_data")
+      .nargs(1)
+      .type(arser::DataType::STR)
+      .required(true)
+      .help("Input data filepath (.h5)");
+
+  arser.add_argument("--analysis")
+      .nargs(1)
+      .type(arser::DataType::STR)
+      .required(true)
+      .help("Analysis code filepath (.py)");
+
+  arser.add_argument("--analysis_args")
+      .nargs(1)
+      .type(arser::DataType::STR)
+      .help("String argument passed to the analysis code");
+
+  try
+  {
+    arser.parse(argc, argv);
+  }
+  catch (const std::runtime_error &err)
+  {
+    std::cout << err.what() << std::endl;
+    std::cout << arser;
+    return EXIT_FAILURE;
+  }
+
+  auto input_model_path = arser.get<std::string>("--input_model");
+  auto input_data_path = arser.get<std::string>("--input_data");
+  auto analysis_path = arser.get<std::string>("--analysis");
+  std::string analysis_args = "";
+  if (arser["--analysis_args"])
+    analysis_args = arser.get<std::string>("--analysis_args");
+
+  // Initialize python interpreter
+  py::scoped_interpreter guard{};
+
+  Dalgona dalgona;
+
+  // Initialize interpreter and operator hooks
+  dalgona.initialize(input_model_path);
+
+  // Run analysis
+  dalgona.runAnalysis(input_data_path, analysis_path, analysis_args);
+
+  return EXIT_SUCCESS;
+}

--- a/compiler/dalgona/include/Dalgona.h
+++ b/compiler/dalgona/include/Dalgona.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __DALGONA_H__
+#define __DALGONA_H__
+
+#include "OperatorObserver.h"
+
+#include <luci/IR/Module.h>
+#include <luci_interpreter/Interpreter.h>
+
+#include <memory>
+
+namespace dalgona
+{
+
+class Dalgona
+{
+public:
+  explicit Dalgona() = default;
+
+  ~Dalgona() = default;
+
+  void initialize(const std::string &input_model_path);
+
+  void runAnalysis(const std::string &input_data_path, const std::string &analysis_path,
+                   const std::string &analysis_args);
+
+private:
+  std::unique_ptr<luci::Module> _module{nullptr};
+  std::unique_ptr<luci_interpreter::Interpreter> _interpreter{nullptr};
+  std::unique_ptr<OperatorObserver> _observer{nullptr};
+};
+
+} // namespace dalgona
+
+#endif // __DALGONA_H__

--- a/compiler/dalgona/include/OperatorObserver.h
+++ b/compiler/dalgona/include/OperatorObserver.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __DALGONA_OPERATOR_OBSERVER_H__
+#define __DALGONA_OPERATOR_OBSERVER_H__
+
+#include <loco/IR/Graph.h>
+#include <luci_interpreter/Interpreter.h>
+#include <luci_interpreter/core/Tensor.h>
+
+#include <pybind11/embed.h>
+
+#include <vector>
+#include <unordered_map>
+
+namespace py = pybind11;
+
+namespace dalgona
+{
+
+class OperatorObserver : public luci_interpreter::ExecutionObserver
+{
+public:
+  OperatorObserver(luci_interpreter::Interpreter *interpreter) : _interpreter(interpreter)
+  {
+    // Do nothing
+  }
+
+  // Called when the analysis starts
+  void importAnalysis(const std::string &analysis_path, py::object &globals,
+                      const std::string &analysis_args);
+
+  // Called after the analysis is done
+  void endAnalysis();
+
+  // Called before a network is started to be executed
+  void startNetworkExecution(loco::Graph *graph);
+
+  // Called after a network is executed
+  void endNetworkExecution(loco::Graph *graph);
+
+  // Called before an operator is executed
+  void preOperatorExecute(const luci::CircleNode *node) override {}
+
+  // Called after an operator is executed
+  void postOperatorExecute(const luci::CircleNode *node) override {}
+
+private:
+  luci_interpreter::Interpreter *_interpreter{nullptr};
+  py::object _analysis;
+};
+
+} // namespace dalgona
+
+#endif // __DALGONA_OPERATOR_OBSERVER_H__

--- a/compiler/dalgona/src/Dalgona.cpp
+++ b/compiler/dalgona/src/Dalgona.cpp
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Dalgona.h"
+#include "OperatorObserver.h"
+#include "HDF5Importer.h"
+
+#include <luci/Importer.h>
+
+#include <pybind11/embed.h>
+
+#include <fstream>
+#include <iostream>
+
+using Shape = luci_interpreter::Shape;
+using DataType = luci_interpreter::DataType;
+
+namespace py = pybind11;
+
+namespace
+{
+
+/**
+ * @brief  getTensorSize will return size in bytes
+ */
+template <typename NodeT> size_t getTensorSize(const NodeT *node)
+{
+  uint32_t tensor_size = loco::size(node->dtype());
+  for (uint32_t i = 0; i < node->rank(); ++i)
+    tensor_size *= node->dim(i).value();
+  return tensor_size;
+}
+
+/**
+ * @brief  verifyTypeShape checks the type and the shape of CircleInput
+ *         This throws an exception if type or shape does not match
+ */
+bool verifyTypeShape(const luci::CircleInput *input_node, const DataType &dtype, const Shape &shape)
+{
+  // Type check
+  if (dtype != input_node->dtype())
+    throw std::runtime_error("Wrong input type.");
+
+  if (shape.num_dims() != input_node->rank())
+    throw std::runtime_error("Input rank mismatch.");
+
+  for (uint32_t i = 0; i < shape.num_dims(); i++)
+  {
+    if (shape.dim(i) != input_node->dim(i).value())
+      throw std::runtime_error("Input shape mismatch.");
+  }
+}
+
+} // namespace
+
+namespace dalgona
+{
+
+void Dalgona::initialize(const std::string &input_model_path)
+{
+  // Load model from the file
+  std::ifstream fs(input_model_path, std::ifstream::binary);
+  if (fs.fail())
+  {
+    throw std::runtime_error("Cannot open model file \"" + input_model_path + "\".\n");
+  }
+  std::vector<char> model_data((std::istreambuf_iterator<char>(fs)),
+                               std::istreambuf_iterator<char>());
+  _module = luci::Importer().importModule(circle::GetModel(model_data.data()));
+
+  if (_module == nullptr)
+  {
+    throw std::runtime_error("ERROR: Failed to load '" + input_model_path + "'");
+  }
+
+  // Initialize interpreter
+  _interpreter = std::make_unique<luci_interpreter::Interpreter>(_module.get());
+
+  _observer = std::make_unique<OperatorObserver>(_interpreter.get());
+
+  _interpreter->attachObserver(_observer.get());
+}
+
+void Dalgona::runAnalysis(const std::string &input_data_path, const std::string &analysis_path,
+                          const std::string &analysis_args)
+{
+  py::object scope = py::module::import("__main__").attr("__dict__");
+  _observer->importAnalysis(analysis_path, scope, analysis_args);
+
+  HDF5Importer importer(input_data_path);
+
+  bool is_raw_data = importer.isRawData();
+
+  const auto num_records = importer.numRecords();
+  if (num_records == 0)
+    throw std::runtime_error("The input data file does not contain any record.");
+
+  const auto input_nodes = loco::input_nodes(_module->graph());
+  const auto num_inputs = input_nodes.size();
+
+  for (int32_t record_idx = 0; record_idx < num_records; record_idx++)
+  {
+    if (num_inputs != importer.numInputs(record_idx))
+      throw std::runtime_error("Wrong number of inputs.");
+
+    if (record_idx % 100 == 0)
+      std::cout << "Running " << record_idx << "'th data" << std::endl;
+
+    for (int32_t input_idx = 0; input_idx < num_inputs; input_idx++)
+    {
+      const auto *input_node = loco::must_cast<const luci::CircleInput *>(input_nodes[input_idx]);
+      assert(input_node->index() == input_idx);
+      std::vector<char> input_data(getTensorSize(input_node));
+
+      if (!is_raw_data)
+      {
+        DataType dtype;
+        Shape shape(input_node->rank());
+        importer.readTensor(record_idx, input_idx, &dtype, &shape, input_data.data());
+
+        // Check the type and the shape of the input data is valid
+        verifyTypeShape(input_node, dtype, shape);
+      }
+      else
+      {
+        // Skip type/shape check for raw data
+        importer.readTensor(record_idx, input_idx, input_data.data());
+      }
+
+      _interpreter->writeInputTensor(input_node, input_data.data(), input_data.size());
+    }
+
+    _observer->startNetworkExecution(_module->graph());
+    _interpreter->interpret();
+    _observer->endNetworkExecution(_module->graph());
+  }
+
+  std::cout << "Finished executing " << num_records << "'th data" << std::endl;
+  _observer->endAnalysis();
+}
+
+} // namespace dalgona

--- a/compiler/dalgona/src/HDF5Importer.cpp
+++ b/compiler/dalgona/src/HDF5Importer.cpp
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "HDF5Importer.h"
+
+#include <H5Cpp.h>
+
+#include <string>
+#include <cassert>
+#include <stdexcept>
+
+using Shape = luci_interpreter::Shape;
+using DataType = luci_interpreter::DataType;
+
+namespace
+{
+
+Shape toInternalShape(const H5::DataSpace &dataspace)
+{
+  int rank = dataspace.getSimpleExtentNdims();
+
+  std::vector<hsize_t> dims;
+  dims.resize(rank, 0);
+  dataspace.getSimpleExtentDims(dims.data());
+
+  Shape res(rank);
+  for (int axis = 0; axis < rank; ++axis)
+  {
+    res.dim(axis) = dims[axis];
+  }
+
+  return res;
+}
+
+DataType toInternalDtype(const H5::DataType &h5_type)
+{
+  if (h5_type == H5::PredType::IEEE_F32BE || h5_type == H5::PredType::IEEE_F32LE)
+  {
+    return DataType::FLOAT32;
+  }
+  if (h5_type == H5::PredType::STD_I32BE || h5_type == H5::PredType::STD_I32LE)
+  {
+    return DataType::S32;
+  }
+  if (h5_type == H5::PredType::STD_I64BE || h5_type == H5::PredType::STD_I64LE)
+  {
+    return DataType::S64;
+  }
+  if (h5_type == H5::PredType::STD_U8BE || h5_type == H5::PredType::STD_U8LE)
+  {
+    return DataType::U8;
+  }
+  // Only support three datatypes for now
+  return DataType::Unknown;
+}
+
+void readTensorData(H5::DataSet &tensor, uint8_t *buffer)
+{
+  tensor.read(buffer, H5::PredType::NATIVE_UINT8);
+}
+
+void readTensorData(H5::DataSet &tensor, float *buffer)
+{
+  tensor.read(buffer, H5::PredType::NATIVE_FLOAT);
+}
+void readTensorData(H5::DataSet &tensor, int32_t *buffer)
+{
+  tensor.read(buffer, H5::PredType::NATIVE_INT);
+}
+void readTensorData(H5::DataSet &tensor, int64_t *buffer)
+{
+  tensor.read(buffer, H5::PredType::NATIVE_LONG);
+}
+
+} // namespace
+
+namespace dalgona
+{
+
+void HDF5Importer::readTensor(int32_t record_idx, int32_t input_idx, void *buffer)
+{
+  auto tensor =
+      _file.openDataSet("value/" + std::to_string(record_idx) + "/" + std::to_string(input_idx));
+
+  readTensorData(tensor, static_cast<uint8_t *>(buffer));
+}
+
+void HDF5Importer::readTensor(int32_t record_idx, int32_t input_idx, DataType *dtype, Shape *shape,
+                              void *buffer)
+{
+  auto tensor =
+      _file.openDataSet("value/" + std::to_string(record_idx) + "/" + std::to_string(input_idx));
+
+  auto tensor_dtype = tensor.getDataType();
+  *dtype = toInternalDtype(tensor_dtype);
+
+  auto tensor_shape = tensor.getSpace();
+  *shape = toInternalShape(tensor_shape);
+
+  switch (*dtype)
+  {
+    case DataType::FLOAT32:
+      readTensorData(tensor, static_cast<float *>(buffer));
+      break;
+    case DataType::S32:
+      readTensorData(tensor, static_cast<int32_t *>(buffer));
+      break;
+    case DataType::S64:
+      readTensorData(tensor, static_cast<int64_t *>(buffer));
+      break;
+    case DataType::U8:
+      readTensorData(tensor, static_cast<uint8_t *>(buffer));
+      break;
+    default:
+      throw std::runtime_error{"Unsupported data type for input data (.h5)"};
+  }
+}
+
+} // namespace dalgona

--- a/compiler/dalgona/src/HDF5Importer.h
+++ b/compiler/dalgona/src/HDF5Importer.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __DALGONA_HDF5IMPORTER_H__
+#define __DALGONA_HDF5IMPORTER_H__
+
+#include <luci_interpreter/core/Tensor.h>
+
+#include <H5Cpp.h>
+
+using Shape = luci_interpreter::Shape;
+using DataType = luci_interpreter::DataType;
+
+namespace dalgona
+{
+
+// HDF5Importer reads an input data saved in the hdf5 file in the given path
+// The hierarchy of the hdf5 file is as follows.
+// Group "/"
+//  > Group "value"
+//    > Group <record_idx>
+//      > Dataset <input_idx>
+// record_idx : index of the record (dataset file can contain multiple records)
+// input_idx : index of the input (DNN model can have multiple inputs)
+// Ex: the j'th input of the i'th record can be accessed by "/value/i/j"
+class HDF5Importer
+{
+public:
+  explicit HDF5Importer(const std::string &path) : _file{path, H5F_ACC_RDONLY}
+  {
+    // Do nothing
+  }
+
+public:
+  /**
+   * @brief Read tensor data from file and store it into buffer
+   * @details A tensor in the file can be retrieved with (record_idx, input_idx)
+   * @param record_idx : index of the record
+   * @param input_idx : index of the input
+   * @param dtype : pointer to write the tensor's data type
+   * @param shape : pointer to write the tensor's shape
+   * @param buffer : pointer to write the tensor's data
+   */
+  void readTensor(int32_t record_idx, int32_t input_idx, DataType *dtype, Shape *shape,
+                  void *buffer);
+
+  // Read a raw tensor (no type/shape is specified)
+  void readTensor(int32_t record_idx, int32_t input_idx, void *buffer);
+
+  bool isRawData() { return _file.openGroup("value").attrExists("rawData"); }
+
+  int32_t numRecords() { return _file.openGroup("value").getNumObjs(); }
+
+  int32_t numInputs(int32_t record_idx)
+  {
+    return _file.openGroup("value/" + std::to_string(record_idx)).getNumObjs();
+  }
+
+private:
+  H5::H5File _file;
+};
+
+} // namespace dalgona
+
+#endif // __DALGONA_HDF5IMPORTER_H__

--- a/compiler/dalgona/src/OperatorObserver.cpp
+++ b/compiler/dalgona/src/OperatorObserver.cpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "OperatorObserver.h"
+#include "Utils.h"
+
+#include <loco/IR/Graph.h>
+
+namespace dalgona
+{
+
+void OperatorObserver::importAnalysis(const std::string &analysis_path, py::object &globals,
+                                      const std::string &analysis_args)
+{
+  auto base_filename = analysis_path.substr(analysis_path.find_last_of("/\\") + 1);
+  // module name must be the same with the python code
+  // ex: MyAnalysis.py -> module name = MyAnalysis
+  auto module_name = base_filename.substr(0, base_filename.find_last_of('.'));
+
+  py::dict locals;
+  locals["path"] = py::cast(analysis_path);
+
+  py::eval<py::eval_statements>("import sys\n"
+                                "import os\n"
+                                "sys.path.append(os.path.dirname(path))\n"
+                                "import " +
+                                    module_name + "\n"
+                                                  "analysis = " +
+                                    module_name + "." + module_name + "()",
+                                globals, locals);
+
+  _analysis = locals["analysis"];
+
+  if (py::hasattr(_analysis, "StartAnalysis"))
+    pySafeCall(_analysis.attr("StartAnalysis"), analysis_args);
+}
+
+void OperatorObserver::startNetworkExecution(loco::Graph *graph)
+{
+  if (!py::hasattr(_analysis, "StartNetworkExecution"))
+    return;
+
+  const auto input_nodes = loco::input_nodes(graph);
+  py::list inputs;
+  // Assumption: input_nodes is iterated in the same order of model inputs
+  for (const auto input_node : input_nodes)
+  {
+    auto circle_node = loco::must_cast<luci::CircleInput *>(input_node);
+    inputs.append(outputPyArray(circle_node, _interpreter));
+  }
+  pySafeCall(_analysis.attr("StartNetworkExecution"), inputs);
+}
+
+void OperatorObserver::endNetworkExecution(loco::Graph *graph)
+{
+  if (!py::hasattr(_analysis, "EndNetworkExecution"))
+    return;
+
+  const auto output_nodes = loco::output_nodes(graph);
+  py::list outputs;
+  // Assumption: output_nodes is iterated in the same order of model outputs
+  for (const auto output_node : output_nodes)
+  {
+    auto circle_node = loco::must_cast<luci::CircleOutput *>(output_node);
+    outputs.append(
+        outputPyArray(loco::must_cast<luci::CircleNode *>(circle_node->from()), _interpreter));
+  }
+  pySafeCall(_analysis.attr("EndNetworkExecution"), outputs);
+}
+
+void OperatorObserver::endAnalysis()
+{
+  if (py::hasattr(_analysis, "EndAnalysis"))
+    pySafeCall(_analysis.attr("EndAnalysis"));
+}
+
+} // namespace dalgona

--- a/compiler/dalgona/src/Utils.cpp
+++ b/compiler/dalgona/src/Utils.cpp
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Utils.h"
+
+#include <pybind11/numpy.h>
+#include <stdexcept>
+
+using Tensor = luci_interpreter::Tensor;
+
+namespace py = pybind11;
+using namespace py::literals;
+
+namespace
+{
+
+py::array numpyArray(const Tensor *tensor)
+{
+  std::vector<ptrdiff_t> shape(tensor->shape().num_dims());
+  for (int i = 0; i < tensor->shape().num_dims(); i++)
+  {
+    shape[i] = tensor->shape().dim(i);
+  }
+
+  switch (tensor->element_type())
+  {
+    case loco::DataType::FLOAT32:
+      return py::array_t<float, py::array::c_style>(shape, tensor->data<float>());
+    case loco::DataType::S32:
+      return py::array_t<int32_t, py::array::c_style>(shape, tensor->data<int32_t>());
+    case loco::DataType::S64:
+      return py::array_t<int64_t, py::array::c_style>(shape, tensor->data<int64_t>());
+    case loco::DataType::U8:
+      return py::array_t<uint8_t, py::array::c_style>(shape, tensor->data<uint8_t>());
+    default:
+      throw std::runtime_error("Unsupported data type");
+  }
+}
+
+py::dict quantizationParameters(const Tensor *tensor)
+{
+  auto scale = tensor->scales();
+  auto zp = tensor->zero_points();
+
+  py::list py_scale;
+  for (auto s : scale)
+  {
+    py_scale.append(s);
+  }
+
+  py::list py_zp;
+  for (auto z : zp)
+  {
+    py_zp.append(z);
+  }
+
+  auto quantparam = py::dict("scale"_a = py_scale, "zero_point"_a = py_zp,
+                             "quantized_dimension"_a = tensor->quantized_dimension());
+  return quantparam;
+}
+
+} // namespace
+
+namespace dalgona
+{
+
+std::vector<py::dict> inputsPyArray(const luci::CircleNode *node,
+                                    luci_interpreter::Interpreter *interpreter)
+{
+  std::vector<py::dict> inputs;
+  for (uint32_t i = 0; i < node->arity(); ++i)
+  {
+    const auto input_tensor = interpreter->getTensor(node->arg(i));
+    auto circle_node = static_cast<luci::CircleNode *>(node->arg(i));
+    auto py_input = py::dict("name"_a = circle_node->name(), "data"_a = numpyArray(input_tensor),
+                             "quantparam"_a = quantizationParameters(input_tensor));
+    inputs.push_back(py_input);
+  }
+  return inputs;
+}
+
+// Note: Only returns 1 output
+py::dict outputPyArray(const luci::CircleNode *node, luci_interpreter::Interpreter *interpreter)
+{
+  const auto output_tensor = interpreter->getTensor(node);
+  auto py_output = py::dict("name"_a = node->name(), "data"_a = numpyArray(output_tensor),
+                            "quantparam"_a = quantizationParameters(output_tensor));
+  return py_output;
+}
+
+} // namespace dalgona

--- a/compiler/dalgona/src/Utils.h
+++ b/compiler/dalgona/src/Utils.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __DALGONA_UTILS_H__
+#define __DALGONA_UTILS_H__
+
+#include <luci_interpreter/Interpreter.h>
+#include <luci_interpreter/core/Tensor.h>
+#include <luci/IR/CircleOpcode.h>
+#include <luci/IR/CircleNodeDecl.h>
+#include <luci/IR/LuciNodeMixins.h>
+
+#include <pybind11/numpy.h>
+
+namespace py = pybind11;
+
+namespace dalgona
+{
+
+template <typename... Args> void pySafeCall(py::object func, Args... args)
+{
+  try
+  {
+    func(args...);
+  }
+  catch (py::error_already_set &e)
+  {
+    throw std::runtime_error(e.what());
+  }
+}
+
+std::vector<py::dict> inputsPyArray(const luci::CircleNode *node,
+                                    luci_interpreter::Interpreter *interpreter);
+
+py::dict outputPyArray(const luci::CircleNode *node, luci_interpreter::Interpreter *interpreter);
+
+} // namespace dalgona
+
+#endif // __DALGONA_UTILS_H__


### PR DESCRIPTION
This introduces dalgona, python interface to analyze DNN during inference

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Draft PR: #3501