### PR TITLE
[one-cmds] revise one-pack with log filename

### DIFF
--- a/compiler/one-cmds/one-pack
+++ b/compiler/one-cmds/one-pack
@@ -70,17 +70,20 @@ if [ -z ${INPUT_PATH} ] || [ ! -e ${INPUT_PATH} ]; then
   usage
 fi
 
+INPUT_FILE=$(basename "${INPUT_PATH}")
+LOG_FILE="${INPUT_FILE%.*}.pack.log"
+
 # remove previous log
-rm -rf "${OUTPUT_PATH}.log"
+rm -rf "${LOG_FILE}"
 
 show_err_onexit()
 {
-  cat "${OUTPUT_PATH}.log"
+  cat "${LOG_FILE}"
 }
 
 trap show_err_onexit ERR
 
 # Package circle model file to nnpkg
-echo "${DRIVER_PATH}/model2nnpkg.sh" -o "${OUTPUT_PATH}" "${INPUT_PATH}" > "${OUTPUT_PATH}.log"
+echo "${DRIVER_PATH}/model2nnpkg.sh" -o "${OUTPUT_PATH}" "${INPUT_PATH}" > "${LOG_FILE}"
 
-"${DRIVER_PATH}/model2nnpkg.sh" -o "${OUTPUT_PATH}" "${INPUT_PATH}" >> "${OUTPUT_PATH}.log" 2>&1
+"${DRIVER_PATH}/model2nnpkg.sh" -o "${OUTPUT_PATH}" "${INPUT_PATH}" >> "${LOG_FILE}" 2>&1


### PR DESCRIPTION
This will revise one-pack with log filename with output is current path "."
- this will drop log file with "..log" which is not good
- use input circle file name as base for log file

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>