### PR TITLE
emit_rusage only on debug mode

### DIFF
--- a/runtime/onert/core/src/util/EventCollector.cc
+++ b/runtime/onert/core/src/util/EventCollector.cc
@@ -54,6 +54,7 @@ private:
   std::string _ts;
 };
 
+#ifdef DEBUG
 inline void emit_rusage(EventRecorder *rec, const std::string &ts)
 {
   struct rusage ru;
@@ -81,6 +82,7 @@ inline void emit_rusage(EventRecorder *rec, const std::string &ts)
     rec->emit(evt);
   }
 }
+#endif
 
 } // namespace
 

--- a/runtime/onert/core/src/util/EventCollector.cc
+++ b/runtime/onert/core/src/util/EventCollector.cc
@@ -99,8 +99,8 @@ void EventCollector::onEvent(const Event &event)
       break;
   }
 
-  // TODO: Add resurece measurement(e.g. RSS)
-  // when ready with low overhead in release build
+// TODO: Add resurece measurement(e.g. RSS)
+// when ready with low overhead in release build
 #ifdef DEBUG
   emit_rusage(_rec, ts);
 #endif

--- a/runtime/onert/core/src/util/EventCollector.cc
+++ b/runtime/onert/core/src/util/EventCollector.cc
@@ -54,7 +54,7 @@ private:
   std::string _ts;
 };
 
-void emit_rusage(EventRecorder *rec, const std::string &ts)
+inline void emit_rusage(EventRecorder *rec, const std::string &ts)
 {
   struct rusage ru;
 
@@ -99,6 +99,9 @@ void EventCollector::onEvent(const Event &event)
       break;
   }
 
-  // Trace resource usage per each event notification
+  // TODO: Add resurece measurement(e.g. RSS)
+  // when ready with low overhead in release build
+#ifdef DEBUG
   emit_rusage(_rec, ts);
+#endif
 }


### PR DESCRIPTION
`emit_rusage` causes severe overhead on measurement. Let's enable this on debug build

ONE-DCO-1.0-Signed-off-by: Chunseok Lee <chunseok.lee@samsung.com>