### PR TITLE
[luci-interpreter] Add Tanh for CMakeLists

### DIFF
--- a/compiler/luci-interpreter/src/kernels/CMakeLists.txt
+++ b/compiler/luci-interpreter/src/kernels/CMakeLists.txt
@@ -56,6 +56,8 @@ set(SOURCES
     StridedSlice.cpp
     Squeeze.h
     Squeeze.cpp
+    Tanh.h
+    Tanh.cpp
     Transpose.h
     Transpose.cpp
     TransposeConv.h
@@ -105,6 +107,7 @@ set(TEST_SOURCES
     Split.test.cpp
     StridedSlice.test.cpp
     Squeeze.test.cpp
+    Tanh.test.cpp
     Transpose.test.cpp
     TransposeConv.test.cpp
     Unpack.test.cpp)


### PR DESCRIPTION
Parent Issue: #3585 
Fired Issue: #3588 

This series of commits are for allowing importing quantized tanh.
These commits have been tested on my PC,
and worked well by passing `./nncc build` & `./nncc test`.

First, I have put Tanh to CMakeLists.

- Added Tanh.cpp & Tanh.h for SOURCES
- Added Tanh.test.cpp for TEST SOURCES

Please review this Work in Progress codes, @seanshpark @jinevening .
I'll be happy to get feedback and change to make improvement.

Thank you.

(Derived from SOS Mine Project)

Signed-off-by: underflow101 <ikarus125@gmail.com>