### PR TITLE
[DRAFT] [luci-interpreter, luci] Add Tanh sources to allow U8 ops

### DIFF
--- a/compiler/luci-interpreter/src/kernels/CMakeLists.txt
+++ b/compiler/luci-interpreter/src/kernels/CMakeLists.txt
@@ -56,6 +56,8 @@ set(SOURCES
     StridedSlice.cpp
     Squeeze.h
     Squeeze.cpp
+    Tanh.h
+    Tanh.cpp
     Transpose.h
     Transpose.cpp
     TransposeConv.h
@@ -105,6 +107,7 @@ set(TEST_SOURCES
     Split.test.cpp
     StridedSlice.test.cpp
     Squeeze.test.cpp
+    Tanh.test.cpp
     Transpose.test.cpp
     TransposeConv.test.cpp
     Unpack.test.cpp)

--- a/compiler/luci-interpreter/src/kernels/Tanh.cpp
+++ b/compiler/luci-interpreter/src/kernels/Tanh.cpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "kernels/Tanh.h"
+
+#include "kernels/Utils.h"
+
+#include <tensorflow/lite/kernels/internal/reference/reference_ops.h>
+
+namespace luci_interpreter
+{
+namespace kernels
+{
+
+Tanh::Tanh(const Tensor *input, Tensor *output) : Kernel({input}, {output}) {}
+
+void Tanh::configure()
+{
+    assert(input()->element_type() == output()->element_type());
+    if (input()->element_type() == DataType::U8)
+    {
+        assert(output()->scale() == 1. / 128);
+        populateLookupTable();
+    }
+    output()->resize(input()->shape());
+}
+
+void Tanh::execute() const
+{
+    switch (input()->element_type())
+    {
+        case DataType::FLOAT32:
+          evalFloat();
+          break;
+        case DataType::U8:
+          evalQuantized();
+          break;
+        default:
+          throw std::runtime_error("Unsupported type.");
+    }
+}
+
+void Tanh::evalFloat() const
+{
+    tflite::reference_ops::Tanh(getTensorShape(input()), getTensorData<float>(input()),
+                                getTensorShape(output()), getTensorData<float>(output()));
+}
+
+void Tanh::evalQuantized() const
+{
+    const int size = tflite::MatchingFlatSize(getTensorShape(input()), getTensorShape(output()));
+    uint8_t *output_data = getTensorData<uint8_t>(output());
+    const uint8_t *input_data = getTensorData<uint8_t>(input());
+    for (int i = 0; i < size; ++i)
+    {
+        output_data[i] = getTableValue(input_data[i]);
+    }
+}
+
+void Tanh::populateLookupTable()
+{
+    const auto input_scale = static_cast<double>(input()->scale());
+    const auto input_zero_point = static_cast<int32_t>(input()->zero_point());
+    const auto output_scale = static_cast<double>(output()->scale());
+    const auto output_zero_point = static_cast<int32_t>(output()->zero_point());
+    const float inverse_scale = 1 / output_scale;
+    int32_t maxval = std::numeric_limits<uint8_t>::max();
+    int32_t minval = std::numeric_limits<uint8_t>::min();
+    for (int32_t val = minval; val <= maxval; ++val)
+    {
+        const float dequantized = input_scale * (val - input_zero_point);
+        const float transformed = 1.0f / (1.0f + std::exp(-dequantized));
+        const float rescaled = std::round(transformed * inverse_scale);
+        const int32_t quantized = static_cast<int32_t>(rescaled + output_zero_point);
+        setTableValue(static_cast<uint8_t>(std::max(std::min(maxval, quantized), minval)),
+                    static_cast<uint8_t>(val));
+    }
+}
+
+} // namespace kernels
+} // namespace luci_interpreter

--- a/compiler/luci-interpreter/src/kernels/Tanh.cpp
+++ b/compiler/luci-interpreter/src/kernels/Tanh.cpp
@@ -29,65 +29,65 @@ Tanh::Tanh(const Tensor *input, Tensor *output) : Kernel({input}, {output}) {}
 
 void Tanh::configure()
 {
-    assert(input()->element_type() == output()->element_type());
-    if (input()->element_type() == DataType::U8)
-    {
-        assert(output()->scale() == 1. / 128);
-        populateLookupTable();
-    }
-    output()->resize(input()->shape());
+  assert(input()->element_type() == output()->element_type());
+  if (input()->element_type() == DataType::U8)
+  {
+    assert(output()->scale() == 1. / 128);
+    populateLookupTable();
+  }
+  output()->resize(input()->shape());
 }
 
 void Tanh::execute() const
 {
-    switch (input()->element_type())
-    {
-        case DataType::FLOAT32:
-          evalFloat();
-          break;
-        case DataType::U8:
-          evalQuantized();
-          break;
-        default:
-          throw std::runtime_error("Unsupported type.");
-    }
+  switch (input()->element_type())
+  {
+    case DataType::FLOAT32:
+      evalFloat();
+      break;
+    case DataType::U8:
+      evalQuantized();
+      break;
+    default:
+      throw std::runtime_error("Unsupported type.");
+  }
 }
 
 void Tanh::evalFloat() const
 {
-    tflite::reference_ops::Tanh(getTensorShape(input()), getTensorData<float>(input()),
-                                getTensorShape(output()), getTensorData<float>(output()));
+  tflite::reference_ops::Tanh(getTensorShape(input()), getTensorData<float>(input()),
+                              getTensorShape(output()), getTensorData<float>(output()));
 }
 
 void Tanh::evalQuantized() const
 {
-    const int size = tflite::MatchingFlatSize(getTensorShape(input()), getTensorShape(output()));
-    uint8_t *output_data = getTensorData<uint8_t>(output());
-    const uint8_t *input_data = getTensorData<uint8_t>(input());
-    for (int i = 0; i < size; ++i)
-    {
-        output_data[i] = getTableValue(input_data[i]);
-    }
+  const int size = tflite::MatchingFlatSize(getTensorShape(input()), getTensorShape(output()));
+  uint8_t *output_data = getTensorData<uint8_t>(output());
+  const uint8_t *input_data = getTensorData<uint8_t>(input());
+  for (int i = 0; i < size; ++i)
+  {
+    output_data[i] = getTableValue(input_data[i]);
+  }
 }
 
 void Tanh::populateLookupTable()
 {
-    const auto input_scale = static_cast<double>(input()->scale());
-    const auto input_zero_point = static_cast<int32_t>(input()->zero_point());
-    const auto output_scale = static_cast<double>(output()->scale());
-    const auto output_zero_point = static_cast<int32_t>(output()->zero_point());
-    const float inverse_scale = 1 / output_scale;
-    int32_t maxval = std::numeric_limits<uint8_t>::max();
-    int32_t minval = std::numeric_limits<uint8_t>::min();
-    for (int32_t val = minval; val <= maxval; ++val)
-    {
-        const float dequantized = input_scale * (val - input_zero_point);
-        const float transformed = 1.0f / (1.0f + std::exp(-dequantized));
-        const float rescaled = std::round(transformed * inverse_scale);
-        const int32_t quantized = static_cast<int32_t>(rescaled + output_zero_point);
-        setTableValue(static_cast<uint8_t>(std::max(std::min(maxval, quantized), minval)),
-                    static_cast<uint8_t>(val));
-    }
+  const auto input_scale = static_cast<double>(input()->scale());
+  const auto input_zero_point = static_cast<int32_t>(input()->zero_point());
+  const auto output_scale = static_cast<double>(output()->scale());
+  const auto output_zero_point = static_cast<int32_t>(output()->zero_point());
+  const float inverse_scale = 1 / output_scale;
+  int32_t maxval = std::numeric_limits<uint8_t>::max();
+  int32_t minval = std::numeric_limits<uint8_t>::min();
+  for (int32_t val = minval; val <= maxval; ++val)
+  {
+    const float dequantized = input_scale * (val - input_zero_point);
+    const float transformed = 1.0f / (1.0f + std::exp(-dequantized));
+    const float rescaled = std::round(transformed * inverse_scale);
+    const int32_t quantized = static_cast<int32_t>(rescaled + output_zero_point);
+    setTableValue(static_cast<uint8_t>(std::max(std::min(maxval, quantized), minval)),
+                  static_cast<uint8_t>(val));
+  }
 }
 
 } // namespace kernels

--- a/compiler/luci-interpreter/src/kernels/Tanh.h
+++ b/compiler/luci-interpreter/src/kernels/Tanh.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef LUCI_INTERPRETER_KERNELS_TANH_H
+#define LUCI_INTERPRETER_KERNELS_TANH_H
+
+#include "core/Kernel.h"
+
+namespace luci_interpreter
+{
+namespace kernels
+{
+
+class Tanh : public Kernel
+{
+public:
+    Tanh(const Tensor *input, Tensor *output);
+
+    const Tensor *input() const { return _inputs[0]; }
+    Tensor *output() const { return _outputs[0]; }
+
+    void configure() override;
+    void execute() const override;
+
+private:
+    void evalFloat() const;
+    void evalQuantized() const;
+    void populateLookupTable();
+    void setTableValue(uint8_t value, uint8_t idx) { _table[idx] = value; };
+    uint8_t getTableValue(uint8_t idx) const { return _table[idx]; };
+
+private:
+    uint8_t _table[256]{};
+};
+
+} // namespace kernels
+} // namespace luci_interpreter
+
+#endif // LUCI_INTERPRETER_KERNELS_LOGISTIC_H

--- a/compiler/luci-interpreter/src/kernels/Tanh.h
+++ b/compiler/luci-interpreter/src/kernels/Tanh.h
@@ -27,26 +27,26 @@ namespace kernels
 class Tanh : public Kernel
 {
 public:
-    Tanh(const Tensor *input, Tensor *output);
+  Tanh(const Tensor *input, Tensor *output);
 
-    const Tensor *input() const { return _inputs[0]; }
-    Tensor *output() const { return _outputs[0]; }
+  const Tensor *input() const { return _inputs[0]; }
+  Tensor *output() const { return _outputs[0]; }
 
-    void configure() override;
-    void execute() const override;
-
-private:
-    void evalFloat() const;
-    void evalQuantized() const;
-    void populateLookupTable();
-    void setTableValue(uint8_t value, uint8_t idx) { _table[idx] = value; };
-    uint8_t getTableValue(uint8_t idx) const { return _table[idx]; };
+  void configure() override;
+  void execute() const override;
 
 private:
-    uint8_t _table[256]{};
+  void evalFloat() const;
+  void evalQuantized() const;
+  void populateLookupTable();
+  void setTableValue(uint8_t value, uint8_t idx) { _table[idx] = value; };
+  uint8_t getTableValue(uint8_t idx) const { return _table[idx]; };
+
+private:
+  uint8_t _table[256]{};
 };
 
 } // namespace kernels
 } // namespace luci_interpreter
 
-#endif // LUCI_INTERPRETER_KERNELS_LOGISTIC_H
+#endif // LUCI_INTERPRETER_KERNELS_TANH_H

--- a/compiler/luci-interpreter/src/kernels/Tanh.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/Tanh.test.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "kernels/Tanh.h"
+#include "kernels/TestUtils.h"
+
+namespace luci_interpreter
+{
+namespace kernels
+{
+namespace
+{
+
+using namespace testing;
+
+TEST(TanhTest, Float)
+{
+    // TODO fix input & output ref data.
+
+    // TODO make a Shape checking of output_tensor.
+}
+
+// TODO Uint8
+// Need to Implement GetDequantizedOutput Function.
+
+} // namespace
+} // namespace kernels
+} // namespace luci_interpreter

--- a/compiler/luci-interpreter/src/kernels/Tanh.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/Tanh.test.cpp
@@ -28,9 +28,9 @@ using namespace testing;
 
 TEST(TanhTest, Float)
 {
-    // TODO fix input & output ref data.
+  // TODO fix input & output ref data.
 
-    // TODO make a Shape checking of output_tensor.
+  // TODO make a Shape checking of output_tensor.
 }
 
 // TODO Uint8

--- a/compiler/luci-interpreter/src/loader/KernelBuilder.cpp
+++ b/compiler/luci-interpreter/src/loader/KernelBuilder.cpp
@@ -43,6 +43,7 @@
 #include "kernels/Split.h"
 #include "kernels/StridedSlice.h"
 #include "kernels/Squeeze.h"
+#include "kernels/Tanh.h"
 #include "kernels/Unpack.h"
 #include "kernels/Transpose.h"
 #include "kernels/TransposeConv.h"
@@ -512,6 +513,16 @@ std::unique_ptr<Kernel> KernelBuilder::visit(const luci::CircleStridedSlice *nod
   params.shrink_axis_mask = node->shrink_axis_mask();
 
   return std::make_unique<kernels::StridedSlice>(input, begin, end, strides, output, params);
+}
+
+std::unique_ptr<Kernel> KernelBuilder::visit(const luci::CircleTanh *node)
+{
+  assert(node->arity() == 1);
+
+  const Tensor *input = getInputTensor(node->x());
+  Tensor *output = getOutputTensor(node);
+
+  return std::make_unique<kernels::Tanh>(input, output);
 }
 
 std::unique_ptr<Kernel> KernelBuilder::visit(const luci::CircleTranspose *node)

--- a/compiler/luci-interpreter/src/loader/KernelBuilder.h
+++ b/compiler/luci-interpreter/src/loader/KernelBuilder.h
@@ -69,6 +69,7 @@ public:
   std::unique_ptr<Kernel> visit(const luci::CircleSplit *node) override;
   std::unique_ptr<Kernel> visit(const luci::CircleStridedSlice *node) override;
   std::unique_ptr<Kernel> visit(const luci::CircleSqueeze *node) override;
+  std::unique_ptr<Kernel> visit(const luci::CircleTanh *node) override;
   std::unique_ptr<Kernel> visit(const luci::CircleTranspose *node) override;
   std::unique_ptr<Kernel> visit(const luci::CircleTransposeConv *node) override;
   std::unique_ptr<Kernel> visit(const luci::CircleUnpack *node) override;

--- a/compiler/luci-interpreter/src/loader/KernelBuilder.test.cpp
+++ b/compiler/luci-interpreter/src/loader/KernelBuilder.test.cpp
@@ -43,6 +43,7 @@
 #include <kernels/Split.h>
 #include <kernels/Squeeze.h>
 #include <kernels/StridedSlice.h>
+#include <kernels/Tanh.h>
 #include <kernels/Transpose.h>
 #include <kernels/TransposeConv.h>
 #include <kernels/Unpack.h>
@@ -654,6 +655,20 @@ TEST_F(KernelBuilderTest, StridedSlice)
   EXPECT_THAT(kernel->params().end_mask, Eq(op->end_mask()));
   EXPECT_THAT(kernel->params().new_axis_mask, Eq(op->new_axis_mask()));
   EXPECT_THAT(kernel->params().shrink_axis_mask, Eq(op->shrink_axis_mask()));
+}
+
+TEST_F(KernelBuilderTest, Tanh)
+{
+  auto *input = createInputNode();
+
+  auto *op = createNode<luci::CircleTanh>();
+  op->x(input);
+
+  auto kernel = buildKernel<kernels::Tanh>(op);
+  ASSERT_THAT(kernel, NotNull());
+
+  checkTensor(kernel->input(), input);
+  checkTensor(kernel->output(), op);
 }
 
 TEST_F(KernelBuilderTest, Transpose)

--- a/compiler/luci/import/src/Nodes/CircleTanh.cpp
+++ b/compiler/luci/import/src/Nodes/CircleTanh.cpp
@@ -28,21 +28,13 @@ bool CircleTanhGraphBuilder::validate(const ValidateArgs &args) const
   const auto &inputs = args.op.inputs;
   if (inputs.size() != 1)
     return false;
+  const auto &outputs = args.op.outputs;
+  if (outputs.size() != 1)
+    return false;
 
-  // Must be one of the following types
-  // bfloat16, half (float16), float32, float64, complex64, complex128
-  // Currently, circle supports float16, float32, complex64
   const auto &tensors = args.reader.tensors();
-  const auto &tensor = tensors.at(inputs[0]);
-  switch (tensor->type)
-  {
-    case circle::TensorType_FLOAT16:
-    case circle::TensorType_FLOAT32:
-    case circle::TensorType_COMPLEX64:
-      break;
-    default:
-      return false;
-  }
+  if (tensors.at(inputs[0])->type != tensors.at(outputs[0])->type)
+    return false;
 
   return true;
 }

--- a/compiler/luci/lang/src/Nodes/CircleTanh.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleTanh.test.cpp
@@ -33,22 +33,22 @@ TEST(CircleTanhTest, constructor)
 
 TEST(CircleTanhTest, input_NEG)
 {
-  luci::CircleTanh neg_node;
+  luci::CircleTanh tanh_node;
   luci::CircleTanh node;
 
-  neg_node.x(&node);
-  ASSERT_NE(nullptr, neg_node.x());
+  tanh_node.x(&node);
+  ASSERT_NE(nullptr, tanh_node.x());
 
-  neg_node.x(nullptr);
-  ASSERT_EQ(nullptr, neg_node.x());
+  tanh_node.x(nullptr);
+  ASSERT_EQ(nullptr, tanh_node.x());
 }
 
 TEST(CircleTanhTest, arity_NEG)
 {
-  luci::CircleTanh neg_node;
+  luci::CircleTanh tanh_node;
 
-  ASSERT_NO_THROW(neg_node.arg(0));
-  ASSERT_THROW(neg_node.arg(1), std::out_of_range);
+  ASSERT_NO_THROW(tanh_node.arg(0));
+  ASSERT_THROW(tanh_node.arg(1), std::out_of_range);
 }
 
 TEST(CircleTanhTest, visit_mutable_NEG)
@@ -57,10 +57,10 @@ TEST(CircleTanhTest, visit_mutable_NEG)
   {
   };
 
-  luci::CircleTanh neg_node;
+  luci::CircleTanh tanh_node;
 
   TestVisitor tv;
-  ASSERT_THROW(neg_node.accept(&tv), std::exception);
+  ASSERT_THROW(tanh_node.accept(&tv), std::exception);
 }
 
 TEST(CircleTanhTest, visit_NEG)
@@ -69,8 +69,8 @@ TEST(CircleTanhTest, visit_NEG)
   {
   };
 
-  luci::CircleTanh neg_node;
+  luci::CircleTanh tanh_node;
 
   TestVisitor tv;
-  ASSERT_THROW(neg_node.accept(&tv), std::exception);
+  ASSERT_THROW(tanh_node.accept(&tv), std::exception);
 }


### PR DESCRIPTION
Parent Issue: #3585 

This series of commits are for allowing importing quantized tanh.
These commits have been tested on my PC,
and worked well by passing `./nncc build` & `./nncc test`.

`compiler/luci-interpreter/src/kernels/Tanh.test.cpp` needs to add test inputs & outputs.
Written sources are based on Logistic sources.

Please review this Work in Progress codes, @seanshpark @jinevening @llFreetimell  .
I'll be happy to get feedback and change to make improvement.

Thank you.

(Derived from SOS Mine Project)

Signed-off-by: underflow101 <ikarus125@gmail.com>