### PR TITLE
[luci] Fix type inference for ResizeBilinear

### DIFF
--- a/compiler/luci/service/src/CircleTypeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleTypeInferenceRule.cpp
@@ -345,7 +345,10 @@ struct TypeInferenceAlgorithm final : public luci::CircleNodeVisitor<loco::DataT
     return loco::dtype_get(node->tensor());
   }
 
-  loco::DataType visit(const luci::CircleResizeBilinear *) final { return loco::DataType::FLOAT32; }
+  loco::DataType visit(const luci::CircleResizeBilinear *node) final
+  {
+    return loco::dtype_get(node->input());
+  }
 
   loco::DataType visit(const luci::CircleResizeNearestNeighbor *node) final
   {


### PR DESCRIPTION
This will fix type infererence for ResizeBilinear Op

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>