### PR TITLE
[common-artifacts] Exclude ResizeBilinear_U8

### DIFF
--- a/compiler/common-artifacts/exclude.lst
+++ b/compiler/common-artifacts/exclude.lst
@@ -129,6 +129,7 @@ tcgenerate(ReLUN1To1_000)
 tcgenerate(Reshape_003) # luci-interpreter doesn't support reshape without built-in option
 tcgenerate(Reshape_U8_000)
 tcgenerate(ResizeBilinear_000)
+tcgenerate(ResizeBilinear_U8_000) # luci-interpreter
 tcgenerate(ResizeNearestNeighbor_000)
 tcgenerate(ReverseSequence_000)
 tcgenerate(ReverseV2_000)


### PR DESCRIPTION
This will exclude ResizeBilinear_U8_000 recipe as luci-interpreter needs implementation

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>