### PR TITLE
[onert/test] Move unittest.sh

### DIFF
--- a/tests/scripts/CMakeLists.txt
+++ b/tests/scripts/CMakeLists.txt
@@ -6,6 +6,9 @@ endif(NOT INSTALL_TEST_SCRIPTS)
 file(GLOB TEST_DRIVER_SCRIPT onert-test)
 install(PROGRAMS ${TEST_DRIVER_SCRIPT} DESTINATION test)
 
+# Commands don't have execute permission itself
+install(DIRECTORY command DESTINATION test)
+
 # TODO Below install to tests/ will be deprecated
 
 # Install test scripts

--- a/tests/scripts/command/unittest
+++ b/tests/scripts/command/unittest
@@ -14,22 +14,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+COMMAND_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALL_DIR="$(dirname $(dirname $COMMAND_DIR))"
 UNITTEST_REPORT_DIR=
-UNITTEST_TEST_DIR=
+UNITTEST_TEST_DIR=$INSTALL_DIR/unittest
 UNITTEST_RESULT=0
 UNITTEST_RUN_ALL=""
 
 function Usage()
 {
     # TODO: Fill this
-    echo "Usage: LD_LIBRARY_PATH=Product/out/lib ./$0 --reportdir=report --unittestdir=Product/out/unittest"
+    echo "Usage: $0 $(basename ${BASH_SOURCE[0]}) [OPTIONS]"
+    echo ""
+    echo "Options:"
+    echo "      --reportdir=PATH        Path to write unittest report"
+    echo "      --unittestdir=PATH      Path to run unittest (default: $UNITTEST_TEST_DIR"
 }
 
-get_gtest_option()
+function get_gtest_option()
 {
     local UNITTEST_REPORT_FILE=$(basename $TEST_BIN)
-    local output_option="--gtest_output=xml:$UNITTEST_REPORT_DIR/$UNITTEST_REPORT_FILE.xml"
+    local output_option
     local filter_option
+    if [ -n "$UNITTEST_REPORT_DIR" ]; then
+        output_option="--gtest_output=xml:$UNITTEST_REPORT_DIR/$UNITTEST_REPORT_FILE.xml"
+    fi
     if [ -r "$TEST_BIN.skip" ]; then
       filter_option="--gtest_filter=-$(grep -v '#' "$TEST_BIN.skip" | tr '\n' ':')"
     fi
@@ -49,15 +58,15 @@ do
         --unittestdir=*)
             UNITTEST_TEST_DIR=${i#*=}
             ;;
-        --runall)
-            UNITTEST_RUN_ALL="true"
+        *)
+            echo "Unknown option: $i"
+            exit 1
+        ;;
     esac
     shift
 done
 
-# TODO: handle exceptions for params
-
-if [ ! -e "$UNITTEST_REPORT_DIR" ]; then
+if [ -n "$UNITTEST_REPORT_DIR" ] && [ ! -e "$UNITTEST_REPORT_DIR" ]; then
     mkdir -p $UNITTEST_REPORT_DIR
 fi
 
@@ -73,21 +82,9 @@ for TEST_BIN in `find $UNITTEST_TEST_DIR -maxdepth 1 -type f -executable`; do
     echo "============================================"
     echo "Starting set $num_unittest: $TEST_BIN..."
     echo "============================================"
-    TEMP_UNITTEST_RESULT=0
 
-    if [ "$UNITTEST_RUN_ALL" == "true" ]; then
-        for TEST_LIST_VERBOSE_LINE in $($TEST_BIN --gtest_list_tests); do
-            if [[ $TEST_LIST_VERBOSE_LINE == *\. ]]; then
-                TEST_LIST_CATEGORY=$TEST_LIST_VERBOSE_LINE
-            else
-                TEST_LIST_ITEM="$TEST_LIST_CATEGORY""$TEST_LIST_VERBOSE_LINE"
-                $TEST_BIN --gtest_filter=$TEST_LIST_ITEM --gtest_output="xml:$UNITTEST_REPORT_DIR/$TEST_LIST_ITEM.xml"
-            fi
-        done
-    else
-        $TEST_BIN $(get_gtest_option)
-        TEMP_UNITTEST_RESULT=$?
-    fi
+    $TEST_BIN $(get_gtest_option)
+    TEMP_UNITTEST_RESULT=$?
 
     if [[ $TEMP_UNITTEST_RESULT -ne 0 ]]; then
         UNITTEST_RESULT=$TEMP_UNITTEST_RESULT

--- a/tests/scripts/onert-test
+++ b/tests/scripts/onert-test
@@ -17,8 +17,8 @@
 [[ "${BASH_SOURCE[0]}" != "${0}" ]] && echo "Please don't source ${BASH_SOURCE[0]}, execute it" && return
 
 DRIVER_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-INSTALL_PATH=$(readlink -e $DRIVER_PATH/../)
-COMMAND_PATH=$INSTALL_PATH/tests/command
+INSTALL_PATH="$(dirname $DRIVER_PATH)"
+COMMAND_PATH=$INSTALL_PATH/test/command
 BIN_PATH=$INSTALL_PATH/bin
 
 export PATH=$BIN_PATH:$PATH

--- a/tests/scripts/test-driver.sh
+++ b/tests/scripts/test-driver.sh
@@ -123,7 +123,7 @@ source $TEST_DRIVER_DIR/common.sh
 
 # Run unittest in each part such as Runtime
 if [ "$ALLTEST_ON" == "true" ] || [ "$UNITTEST_ON" == "true" ]; then
-    $TEST_DRIVER_DIR/unittest.sh \
+    source $TEST_DRIVER_DIR/command/unittest \
         --reportdir=$REPORT_DIR \
         --unittestdir=$UNIT_TEST_DIR
 fi


### PR DESCRIPTION
- Rename unittest.sh to unittest
- Remove execution permission
- Move into tests/scripts/command
- Revise unittest command
  - Remove runall option: not used
  - Don't generate xml when reportdir option is not set
  - Default unittest directory: [installed_dir]/unittest/

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

part of #3514