### PR TITLE
[draft] [onert] introduce sparsity for sparse weight fully connected

### DIFF
--- a/runtime/onert/backend/cpu/ops/FullyConnectedLayer.h
+++ b/runtime/onert/backend/cpu/ops/FullyConnectedLayer.h
@@ -53,6 +53,8 @@ public:
 
   void fullyConnectedHybrid();
 
+  void fullyConnectedSparseWeight();
+
   void configure(const IPortableTensor *input, const IPortableTensor *weights,
                  const IPortableTensor *bias, ir::Activation activation, IPortableTensor *output,
                  const std::shared_ptr<ExternalContext> &external_context);

--- a/runtime/onert/core/include/backend/IPortableTensor.h
+++ b/runtime/onert/core/include/backend/IPortableTensor.h
@@ -37,6 +37,9 @@ class IPortableTensor : public ITensor
 {
 public:
   virtual ~IPortableTensor() = default;
+  virtual bool is_sparse() const { return false; }
+  virtual const uint16_t *w1_segments() const { return nullptr; }
+  virtual const uint16_t *w1_indices() const { return nullptr; }
 
 public:
   bool has_padding() const final { return false; }

--- a/runtime/onert/core/include/backend/cpu_common/Tensor.h
+++ b/runtime/onert/core/include/backend/cpu_common/Tensor.h
@@ -106,6 +106,9 @@ public:
   bool is_dynamic() const override { return _info.isDynamic(); }
   void set_dynamic() override { _info.setDynamic(); }
   IDynamicTensorManager *dynamic_tensor_manager() override { return _dynamic_tensor_manager; }
+  bool is_sparse() const override { return _info.typeInfo().sparse(); }
+  virtual const uint16_t *w1_segments() const override { return _info.typeInfo().w1_segments(); }
+  virtual const uint16_t *w1_indices() const override { return _info.typeInfo().w1_indices(); }
 
   virtual void increase_ref()
   {

--- a/runtime/onert/core/include/ir/TypeInfo.h
+++ b/runtime/onert/core/include/ir/TypeInfo.h
@@ -42,6 +42,8 @@ public:
   float scale() const { return _scale; }
   int32_t offset() const { return _offset; }
   bool sparse() const { return _sparse; }
+  const uint16_t *w1_segments() const { return _w1_segments.data(); }
+  const uint16_t *w1_indices() const { return _w1_indices.data(); }
 
 public:
   void type(const DataType type) { _type = type; }


### PR DESCRIPTION
Related: #3597 

It bring the code for sparse weight 2d fully connected.

- This PR is based on tensorflow lite's sparsed_op implementation.
- It uses `sparsity` field of `tflite`.
- It is composed of loader, ir, kernel.
  - Please focus on loader and ir part since I will replace kernel implementation to other which shows better performance.

#### To Do
- [x] Remove hard coded ConstantInitializer~ ←sparse weight has smaller size than normal weight tensor. It is okay.
- [x] Remove `w0_size`, which may be removed by using output's dimension.
- [x] Support `bias` (which is **necessary** for my target model).