### PR TITLE
[Luci] Fix CircleTanh to allow Tanh U8 ops

### DIFF
--- a/compiler/luci/import/src/Nodes/CircleTanh.cpp
+++ b/compiler/luci/import/src/Nodes/CircleTanh.cpp
@@ -28,21 +28,13 @@ bool CircleTanhGraphBuilder::validate(const ValidateArgs &args) const
   const auto &inputs = args.op.inputs;
   if (inputs.size() != 1)
     return false;
+  const auto &outputs = args.op.outputs;
+  if (outputs.size() != 1)
+    return false;
 
-  // Must be one of the following types
-  // bfloat16, half (float16), float32, float64, complex64, complex128
-  // Currently, circle supports float16, float32, complex64
   const auto &tensors = args.reader.tensors();
-  const auto &tensor = tensors.at(inputs[0]);
-  switch (tensor->type)
-  {
-    case circle::TensorType_FLOAT16:
-    case circle::TensorType_FLOAT32:
-    case circle::TensorType_COMPLEX64:
-      break;
-    default:
-      return false;
-  }
+  if (tensors.at(inputs[0])->type != tensors.at(outputs[0])->type)
+    return false;
 
   return true;
 }


### PR DESCRIPTION
Parent Issue: #3585 
DRAFT PR: #3594 

This series of commits are for allowing importing quantized tanh.
These commits have been tested on my PC,
and worked well by passing ./nncc build & ./nncc test.

Written sources are modified based on CircleLogistic sources.

PR will be separated in 4 pieces:
- [luci] changes
- [luci-interpreter] changes
- [res/TensorFlowLiteRecipe] Tanh U8 recipe
- [luci/tests] Add read & write ops for tanh u8 testing.

This is the first part of those separated PRs.

Please review this PR, @seanshpark @llFreetimell  @struss .
I'll be happy to get feedback and change to make improvement.

Thank you.

(Derived from SOS Mine Project)

Signed-off-by: underflow101 <ikarus125@gmail.com>