### PR TITLE
[onert] Introduce ITensor::dynamic_tensor_manager

### DIFF
--- a/runtime/onert/backend/cpu/StaticTensorManager.cc
+++ b/runtime/onert/backend/cpu/StaticTensorManager.cc
@@ -26,8 +26,10 @@ namespace backend
 namespace cpu
 {
 
-StaticTensorManager::StaticTensorManager(const std::shared_ptr<cpu_common::TensorRegistry> &reg)
-    : _nonconst_mgr{new cpu_common::MemoryManager()}, _tensors{reg}
+StaticTensorManager::StaticTensorManager(const std::shared_ptr<cpu_common::TensorRegistry> &reg,
+                                         cpu_common::DynamicTensorManager *dynamic_tensor_manager)
+    : _nonconst_mgr{new cpu_common::MemoryManager()}, _tensors{reg},
+      _dynamic_tensor_manager{dynamic_tensor_manager}
 {
   // DO NOTHING
 }
@@ -65,7 +67,7 @@ void StaticTensorManager::buildTensor(const ir::OperandIndex &ind,
   }
   else
   {
-    auto tensor = std::make_shared<Tensor>(tensor_info, backend_layout);
+    auto tensor = std::make_shared<Tensor>(tensor_info, backend_layout, _dynamic_tensor_manager);
     _tensors->setNativeTensor(ind, tensor);
   }
   _as_constants[ind] = as_const;

--- a/runtime/onert/backend/cpu/StaticTensorManager.h
+++ b/runtime/onert/backend/cpu/StaticTensorManager.h
@@ -18,6 +18,7 @@
 #define __ONERT_BACKEND_CPU_STATICTENSOR_MANAGER_H__
 
 #include "backend/IStaticTensorManager.h"
+#include "backend/cpu_common/DynamicTensorManager.h"
 #include "backend/cpu_common/MemoryManager.h"
 #include "backend/cpu_common/TensorRegistry.h"
 #include "backend/ITensorManager.h"
@@ -34,7 +35,8 @@ namespace cpu
 class StaticTensorManager : public backend::IStaticTensorManager
 {
 public:
-  StaticTensorManager(const std::shared_ptr<cpu_common::TensorRegistry> &reg);
+  StaticTensorManager(const std::shared_ptr<cpu_common::TensorRegistry> &reg,
+                      cpu_common::DynamicTensorManager *dynamic_tensor_manager);
   virtual ~StaticTensorManager() = default;
 
   void allocateNonconsts(void);
@@ -52,6 +54,7 @@ private:
   std::unique_ptr<cpu_common::MemoryManager> _nonconst_mgr;
   const std::shared_ptr<cpu_common::TensorRegistry> _tensors;
   ir::OperandIndexMap<bool> _as_constants;
+  cpu_common::DynamicTensorManager *_dynamic_tensor_manager;
 };
 
 } // namespace cpu

--- a/runtime/onert/backend/cpu/Tensor.h
+++ b/runtime/onert/backend/cpu/Tensor.h
@@ -37,7 +37,8 @@ public:
   ExternalTensor() = delete;
 
 public:
-  ExternalTensor(const ir::OperandInfo &info, const ir::Layout layout) : Tensor(info, layout)
+  ExternalTensor(const ir::OperandInfo &info, const ir::Layout layout)
+      : Tensor(info, layout, nullptr)
   {
     assert(_layout == ir::Layout::NHWC);
     assert(_info.isConstant());

--- a/runtime/onert/backend/cpu/TensorBuilder.cc
+++ b/runtime/onert/backend/cpu/TensorBuilder.cc
@@ -29,8 +29,8 @@ namespace cpu
 
 TensorBuilder::TensorBuilder()
     : _tensor_reg{new cpu_common::TensorRegistry()},
-      _static_tensor_mgr{new StaticTensorManager(_tensor_reg)},
-      _dynamic_tensor_mgr{new cpu_common::DynamicTensorManager(_tensor_reg)}
+      _dynamic_tensor_mgr{new cpu_common::DynamicTensorManager(_tensor_reg)},
+      _static_tensor_mgr{new StaticTensorManager(_tensor_reg, _dynamic_tensor_mgr.get())}
 {
   /* empty */
 }

--- a/runtime/onert/backend/cpu/TensorBuilder.h
+++ b/runtime/onert/backend/cpu/TensorBuilder.h
@@ -90,8 +90,8 @@ public:
 
 private:
   const std::shared_ptr<cpu_common::TensorRegistry> _tensor_reg;
-  std::unique_ptr<StaticTensorManager> _static_tensor_mgr;
   std::unique_ptr<cpu_common::DynamicTensorManager> _dynamic_tensor_mgr;
+  std::unique_ptr<StaticTensorManager> _static_tensor_mgr;
   ir::OperandIndexMap<ir::OperandInfo> _tensor_info_map;
 };
 

--- a/runtime/onert/core/include/backend/ITensor.h
+++ b/runtime/onert/core/include/backend/ITensor.h
@@ -32,6 +32,8 @@ namespace onert
 namespace backend
 {
 
+struct IDynamicTensorManager;
+
 class ITensor
 {
 public:
@@ -49,6 +51,15 @@ public:
   virtual int32_t data_offset() const = 0;
   virtual bool has_padding() const = 0;
   virtual void access(const std::function<void(ITensor &tensor)> &fn) = 0;
+
+  /**
+   * @brief Return the dynamic tensor manager
+   *
+   * If dynamic tensors are not supported, it returns @c nullptr .
+   *
+   * @return IDynamicTensorManager* DynamicTensorManager
+   */
+  virtual IDynamicTensorManager *dynamic_tensor_manager() { return nullptr; }
 
   /**
    * @brief Return true if the tensor is constant

--- a/runtime/onert/core/include/backend/cpu_common/Tensor.h
+++ b/runtime/onert/core/include/backend/cpu_common/Tensor.h
@@ -35,8 +35,10 @@ public:
   Tensor() = delete;
 
 public:
-  Tensor(const ir::OperandInfo &info, const ir::Layout layout)
-      : _info(info), _layout(layout), _buffer(nullptr), _num_references(0), _allocator(nullptr)
+  Tensor(const ir::OperandInfo &info, const ir::Layout layout,
+         IDynamicTensorManager *dynamic_tensor_manager)
+      : _info(info), _layout(layout), _buffer(nullptr), _num_references(0),
+        _dynamic_tensor_manager(dynamic_tensor_manager), _allocator(nullptr)
   {
     // DO NOTHING
   }
@@ -96,6 +98,7 @@ public:
   bool is_constant() const override { return _info.isConstant(); }
   bool is_dynamic() const override { return _info.isDynamic(); }
   void set_dynamic() override { _info.setDynamic(); }
+  IDynamicTensorManager *dynamic_tensor_manager() override { return _dynamic_tensor_manager; }
 
   virtual void increase_ref()
   {
@@ -130,6 +133,7 @@ protected:
   ir::Layout _layout;
   uint8_t *_buffer;
   int32_t _num_references;
+  IDynamicTensorManager *_dynamic_tensor_manager;
 
 private:
   std::shared_ptr<Allocator> _allocator;

--- a/runtime/onert/core/include/exec/DynamicShapeInference.h
+++ b/runtime/onert/core/include/exec/DynamicShapeInference.h
@@ -128,6 +128,7 @@ private:
   /**
    * @brief To allocate memory for output tensor if needed
    */
+  // TODO Remove this, as it is no longer used
   backend::IDynamicTensorManager *_dynamic_tensor_manager;
   /**
    * @brief To get tensor object and access tensor-level info, e.g., ITensor::buffer()

--- a/runtime/onert/core/src/backend/controlflow/DynamicTensorManager.cc
+++ b/runtime/onert/core/src/backend/controlflow/DynamicTensorManager.cc
@@ -45,6 +45,7 @@ void DynamicTensorManager::applyShape(const ir::OperandIndex &ind, const ir::Sha
     if (buffer_size < new_size)
       throw std::runtime_error{"ExecutorBase: output buffer size is less than output tensor size"};
     user_tensor->setShape(new_shape);
+    return;
   }
 
   // NOTE Then handle native tensors
@@ -102,7 +103,7 @@ void DynamicTensorManager::buildTensor(const ir::OperandIndex &ind,
                                        ir::Layout backend_layout)
 {
   assert(_tensors->getNativeTensor(ind) == nullptr);
-  auto tensor = std::make_shared<cpu_common::Tensor>(tensor_info, backend_layout);
+  auto tensor = std::make_shared<cpu_common::Tensor>(tensor_info, backend_layout, this);
   _tensors->setNativeTensor(ind, tensor);
 }
 

--- a/runtime/onert/core/src/backend/controlflow/DynamicTensorManager.h
+++ b/runtime/onert/core/src/backend/controlflow/DynamicTensorManager.h
@@ -61,6 +61,7 @@ private:
    * @todo  DynamicMemoryManager is not optimized. Optimized one is needed
    */
   std::shared_ptr<cpu_common::DynamicMemoryManager> _dynamic_mem_mgr;
+  // TODO Refactoring : Merge two TensorRegistries into one
   const std::shared_ptr<cpu_common::TensorRegistry> _tensors;
   const std::shared_ptr<UserTensorRegistry> _user_tensors;
 

--- a/runtime/onert/core/src/backend/controlflow/UserTensor.h
+++ b/runtime/onert/core/src/backend/controlflow/UserTensor.h
@@ -38,12 +38,16 @@ namespace controlflow
 class UserTensor : public IPortableTensor
 {
 public:
-  UserTensor(const ir::OperandInfo &info, ir::Layout layout, uint8_t *buffer, size_t size)
-      : _info{info}, _layout{layout}, _buffer{buffer}, _size{size}, _dynamic{false}
+  UserTensor(const ir::OperandInfo &info, ir::Layout layout, uint8_t *buffer, size_t size,
+             IDynamicTensorManager *dynamic_tensor_manager)
+      : _info{info}, _layout{layout}, _buffer{buffer}, _size{size}, _dynamic{false},
+        _dynamic_tensor_manager{dynamic_tensor_manager}
   {
   }
 
-  UserTensor(const ir::OperandInfo &info, ir::Layout layout) : UserTensor{info, layout, nullptr, 0}
+  UserTensor(const ir::OperandInfo &info, ir::Layout layout,
+             IDynamicTensorManager *dynamic_tensor_manager)
+      : UserTensor{info, layout, nullptr, 0, dynamic_tensor_manager}
   {
   }
 
@@ -69,6 +73,7 @@ public:
   ir::Shape getShape() const override { return _info.shape(); }
   void setShape(const ir::Shape &new_shape) override { _info.shape(new_shape); }
   bool is_constant() const override { return false; }
+  IDynamicTensorManager *dynamic_tensor_manager() override { return _dynamic_tensor_manager; }
 
 private:
   ir::OperandInfo _info;
@@ -76,6 +81,7 @@ private:
   uint8_t *_buffer;
   size_t _size;
   bool _dynamic;
+  IDynamicTensorManager *_dynamic_tensor_manager;
 };
 
 } // namespace controlflow

--- a/runtime/onert/core/src/backend/cpu_common/DynamicTensorManager.cc
+++ b/runtime/onert/core/src/backend/cpu_common/DynamicTensorManager.cc
@@ -89,7 +89,7 @@ void DynamicTensorManager::buildTensor(const ir::OperandIndex &ind,
                                        ir::Layout backend_layout)
 {
   assert(_tensors->getNativeTensor(ind) == nullptr);
-  auto tensor = std::make_shared<Tensor>(tensor_info, backend_layout);
+  auto tensor = std::make_shared<Tensor>(tensor_info, backend_layout, this);
   _tensors->setNativeTensor(ind, tensor);
 }
 

--- a/runtime/onert/core/src/backend/cpu_common/StaticTensorManager.cc
+++ b/runtime/onert/core/src/backend/cpu_common/StaticTensorManager.cc
@@ -16,6 +16,7 @@
 
 #include "backend/cpu_common/StaticTensorManager.h"
 
+#include "backend/cpu_common/DynamicTensorManager.h"
 #include <util/logging.h>
 
 namespace onert
@@ -77,7 +78,7 @@ void StaticTensorManager::buildTensor(const ir::OperandIndex &ind,
                                       bool as_const)
 {
   assert(!_tensors->getNativeTensor(ind));
-  auto tensor = std::make_shared<Tensor>(tensor_info, backend_layout);
+  auto tensor = std::make_shared<Tensor>(tensor_info, backend_layout, nullptr);
   _tensors->setNativeTensor(ind, tensor);
   _as_constants[ind] = as_const;
 }

--- a/runtime/onert/core/src/compiler/ExecutorFactory.cc
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.cc
@@ -196,7 +196,8 @@ ExecutorFactory::initializeModelIOTensors(ir::LoweredGraph &lowered_graph,
     const auto &operand = lowered_graph.graph().operands().at(ind);
     auto tensor = std::make_shared<backend::controlflow::UserTensor>(
         operand.info(),
-        ir::Layout::NHWC /* FIXME find op_seq for this operand and use frontend_layout */);
+        ir::Layout::NHWC, /* FIXME find op_seq for this operand and use frontend_layout */
+        cf_tensor_builder->dynamicTensorManager());
 
     // Add tensor to controlflow TensorRegistry.
     cf_tensor_builder->setUserTensor(ind, tensor);

--- a/runtime/onert/core/src/exec/DynamicShapeInference.cc
+++ b/runtime/onert/core/src/exec/DynamicShapeInference.cc
@@ -16,11 +16,20 @@
 
 #include "exec/DynamicShapeInference.h"
 #include "util/ShapeInference.h"
+#include <assert.h>
 
 namespace onert
 {
 namespace exec
 {
+
+inline backend::IDynamicTensorManager *
+dynamicTensorManagerOf(const std::shared_ptr<backend::ITensor> &tensor)
+{
+  if (!tensor->dynamic_tensor_manager())
+    throw std::runtime_error{"Dynamic Tensor Manager is not available for this tensor."};
+  return tensor->dynamic_tensor_manager();
+}
 
 void DynamicShapeInferer::handleBinaryArithmeticOp(const ir::Operation &op,
                                                    const ir::OperandIndex lhs_idx,
@@ -55,7 +64,7 @@ void DynamicShapeInferer::handleBinaryArithmeticOp(const ir::Operation &op,
 
   ir::Shape new_shape = shape_inference::inferEltwiseShape(lhs_shape, rhs_shape);
 
-  _dynamic_tensor_manager->applyShape(output_idx, new_shape);
+  dynamicTensorManagerOf(output)->applyShape(output_idx, new_shape);
   assert(output->buffer() != nullptr);
 }
 
@@ -87,7 +96,7 @@ void DynamicShapeInferer::handleSimpleUnaryOp(const ir::Operation &op,
   auto output_ind = op.getOutputs().at(0);
   auto output = _tensor_registry->getITensor(output_ind);
 
-  _dynamic_tensor_manager->applyShape(output_ind, output_shape);
+  dynamicTensorManagerOf(output)->applyShape(output_ind, output_shape);
   assert(output->buffer() != nullptr);
 }
 
@@ -121,7 +130,7 @@ void DynamicShapeInferer::visit(const ir::operation::ArgMax &op)
 
   ir::Shape new_shape = shape_inference::inferArgMaxShape(input_shape, axis, rank);
 
-  _dynamic_tensor_manager->applyShape(output_ind, new_shape);
+  dynamicTensorManagerOf(output)->applyShape(output_ind, new_shape);
   assert(output->buffer() != nullptr);
 }
 
@@ -143,7 +152,7 @@ void DynamicShapeInferer::visit(const ir::operation::BatchMatMul &op)
   // TODO
 
   auto new_shape = shape_inference::inferBatchMatMulShape(lhs_shape, rhs_shape, op.param());
-  _dynamic_tensor_manager->applyShape(output_index, new_shape);
+  dynamicTensorManagerOf(output)->applyShape(output_index, new_shape);
 }
 
 void DynamicShapeInferer::visit(const ir::operation::BroadcastTo &op)
@@ -166,7 +175,7 @@ void DynamicShapeInferer::visit(const ir::operation::BroadcastTo &op)
       shape->getShape(), reinterpret_cast<const int32_t *>(shape->buffer()));
 
   // set output shape and output buffer
-  _dynamic_tensor_manager->applyShape(output_ind, output_shape);
+  dynamicTensorManagerOf(output)->applyShape(output_ind, output_shape);
   assert(output->buffer() != nullptr);
 }
 
@@ -256,7 +265,7 @@ void DynamicShapeInferer::visit(const ir::operation::Concat &op)
   auto output = _tensor_registry->getITensor(output_ind);
   auto output_shape = shape_inference::inferConcatShape(in_shapes, op.param());
 
-  _dynamic_tensor_manager->applyShape(output_ind, output_shape);
+  dynamicTensorManagerOf(output)->applyShape(output_ind, output_shape);
 }
 
 void DynamicShapeInferer::visit(const ir::operation::Conv2D &op)
@@ -279,7 +288,7 @@ void DynamicShapeInferer::visit(const ir::operation::Conv2D &op)
 
   ir::Shape output_shape = shape_inference::inferConv2DShape(input_shape, ker_shape, op.param());
 
-  _dynamic_tensor_manager->applyShape(output_ind, output_shape);
+  dynamicTensorManagerOf(output)->applyShape(output_ind, output_shape);
   assert(output->buffer() != nullptr);
 }
 
@@ -339,7 +348,7 @@ void DynamicShapeInferer::visit(const ir::operation::ExpandDims &op)
 
   auto output_shape = shape_inference::inferExpandDimsShape(input_shape, axis_buf[0]);
 
-  _dynamic_tensor_manager->applyShape(output_ind, output_shape);
+  dynamicTensorManagerOf(output)->applyShape(output_ind, output_shape);
   assert(output->buffer() != nullptr);
 }
 
@@ -362,7 +371,7 @@ void DynamicShapeInferer::visit(const ir::operation::Fill &op)
 
   auto output_shape = shape_inference::inferFillShape(input_shape, input_buf);
 
-  _dynamic_tensor_manager->applyShape(output_ind, output_shape);
+  dynamicTensorManagerOf(output)->applyShape(output_ind, output_shape);
   assert(output->buffer() != nullptr);
 }
 
@@ -385,7 +394,7 @@ void DynamicShapeInferer::visit(const ir::operation::FullyConnected &op)
   auto output_ind = op.getOutputs().at(0);
   auto output = _tensor_registry->getITensor(output_ind);
 
-  _dynamic_tensor_manager->applyShape(output_ind, new_shape);
+  dynamicTensorManagerOf(output)->applyShape(output_ind, new_shape);
   assert(output->buffer() != nullptr);
 }
 
@@ -417,7 +426,7 @@ void DynamicShapeInferer::visit(const ir::operation::Gather &op)
   auto output_ind = op.getOutputs().at(0);
   auto output = _tensor_registry->getITensor(output_ind);
 
-  _dynamic_tensor_manager->applyShape(output_ind, new_shape);
+  dynamicTensorManagerOf(output)->applyShape(output_ind, new_shape);
   assert(output->buffer() != nullptr);
 }
 
@@ -497,7 +506,7 @@ void DynamicShapeInferer::visit(const ir::operation::OneHot &op)
   const auto axis_val = op.param().axis;
 
   ir::Shape new_shape = shape_inference::inferOnehotShape(indices_shape, *depth_buf, axis_val);
-  _dynamic_tensor_manager->applyShape(output_ind, new_shape);
+  dynamicTensorManagerOf(output)->applyShape(output_ind, new_shape);
   assert(output->buffer() != nullptr);
 }
 
@@ -533,7 +542,7 @@ void DynamicShapeInferer::visit(const ir::operation::Pack &op)
 
   ir::Shape new_shape = shape_inference::inferPackShape(input_shape, axis, rank, num);
 
-  _dynamic_tensor_manager->applyShape(output_ind, new_shape);
+  dynamicTensorManagerOf(output)->applyShape(output_ind, new_shape);
   assert(output->buffer() != nullptr);
 }
 
@@ -560,7 +569,7 @@ void DynamicShapeInferer::visit(const ir::operation::Pad &op)
       shape_inference::inferPadShape(input->getShape(), pad_buf, pad->getShape().num_elements());
 
   // change output shape and reallocate output tensor memory
-  _dynamic_tensor_manager->applyShape(output_ind, output_shape);
+  dynamicTensorManagerOf(output)->applyShape(output_ind, output_shape);
   assert(output->buffer() != nullptr);
 }
 
@@ -612,7 +621,7 @@ void DynamicShapeInferer::visit(const ir::operation::Range &op)
         *reinterpret_cast<int32_t *>(limit_tensor->buffer()),
         *reinterpret_cast<int32_t *>(delta_tensor->buffer()));
   }
-  _dynamic_tensor_manager->applyShape(output_ind, new_shape);
+  dynamicTensorManagerOf(output)->applyShape(output_ind, new_shape);
   assert(output->buffer() != nullptr);
 }
 
@@ -656,7 +665,7 @@ void DynamicShapeInferer::visit(const ir::operation::Reduce &op)
 
   ir::Shape new_shape = shape_inference::inferReduceShape(input_shape, axes_vec, keep_dims);
 
-  _dynamic_tensor_manager->applyShape(output_ind, new_shape);
+  dynamicTensorManagerOf(output)->applyShape(output_ind, new_shape);
   assert(output->buffer() != nullptr);
 }
 
@@ -710,7 +719,7 @@ void DynamicShapeInferer::visit(const ir::operation::Reshape &op)
     if (output_shape != output->getShape() || output->buffer() == nullptr)
     {
       // change on output shape
-      _dynamic_tensor_manager->applyShape(output_ind, output_shape);
+      dynamicTensorManagerOf(output)->applyShape(output_ind, output_shape);
     }
     assert(output->buffer() != nullptr);
   }
@@ -726,7 +735,7 @@ void DynamicShapeInferer::visit(const ir::operation::Reshape &op)
     if (output_shape != output->getShape() || output->buffer() == nullptr)
     {
       // change on output shape
-      _dynamic_tensor_manager->applyShape(output_ind, output_shape);
+      dynamicTensorManagerOf(output)->applyShape(output_ind, output_shape);
     }
     assert(output->buffer() != nullptr);
   }
@@ -779,7 +788,7 @@ void DynamicShapeInferer::visit(const ir::operation::Select &op)
   auto output_ind = op.getOutputs().at(0);
   auto output = _tensor_registry->getITensor(output_ind);
 
-  _dynamic_tensor_manager->applyShape(output_ind, new_shape);
+  dynamicTensorManagerOf(output)->applyShape(output_ind, new_shape);
   assert(output->buffer() != nullptr);
 }
 
@@ -798,7 +807,7 @@ void DynamicShapeInferer::visit(const ir::operation::Shape &op)
   ir::Shape output_shape;
   output_shape.append(input_shape.rank());
 
-  _dynamic_tensor_manager->applyShape(output_ind, output_shape);
+  dynamicTensorManagerOf(output)->applyShape(output_ind, output_shape);
   assert(output->buffer() != nullptr);
 }
 
@@ -829,7 +838,7 @@ void DynamicShapeInferer::visit(const ir::operation::Slice &op)
 
   ir::Shape new_shape = shape_inference::inferSliceShape(input_shape, begins_buf, sizes_buf);
 
-  _dynamic_tensor_manager->applyShape(output_index, new_shape);
+  dynamicTensorManagerOf(output)->applyShape(output_index, new_shape);
   assert(output->buffer() != nullptr);
 }
 
@@ -866,7 +875,7 @@ void DynamicShapeInferer::visit(const ir::operation::SpaceToBatchND &op)
   ir::Shape new_shape = shape_inference::inferSpaceToBatchNDShape(
       input_shape, block_shape_shape, padding_shape, block_shape_data, padding_data);
 
-  _dynamic_tensor_manager->applyShape(output_idx, new_shape);
+  dynamicTensorManagerOf(output)->applyShape(output_idx, new_shape);
   assert(output->buffer() != nullptr);
 }
 
@@ -895,7 +904,7 @@ void DynamicShapeInferer::visit(const ir::operation::Split &op)
     auto output_ind = op.getOutputs().at(out_tensor_idx);
     auto output = _tensor_registry->getITensor(output_ind);
 
-    _dynamic_tensor_manager->applyShape(output_ind, new_shape);
+    dynamicTensorManagerOf(output)->applyShape(output_ind, new_shape);
     assert(output->buffer() != nullptr);
   }
 }
@@ -924,7 +933,7 @@ void DynamicShapeInferer::visit(const ir::operation::Squeeze &op)
   auto output_ind = op.getOutputs().at(0);
   auto output = _tensor_registry->getITensor(output_ind);
 
-  _dynamic_tensor_manager->applyShape(output_ind, new_shape);
+  dynamicTensorManagerOf(output)->applyShape(output_ind, new_shape);
   assert(output->buffer() != nullptr);
 }
 
@@ -965,7 +974,7 @@ void DynamicShapeInferer::visit(const ir::operation::StridedSlice &op)
   ir::Shape output_shape =
       onert::shape_inference::inferStridedSliceShape(input_shape, op_params, rank);
 
-  _dynamic_tensor_manager->applyShape(output_index, output_shape);
+  dynamicTensorManagerOf(output)->applyShape(output_index, output_shape);
   assert(output->buffer() != nullptr);
 }
 
@@ -1001,7 +1010,7 @@ void DynamicShapeInferer::visit(const ir::operation::Tile &op)
   auto output_shape = shape_inference::inferTileShape(input_shape, multiplier_buffer);
 
   // set output shape and output buffer
-  _dynamic_tensor_manager->applyShape(output_ind, output_shape);
+  dynamicTensorManagerOf(output)->applyShape(output_ind, output_shape);
   assert(output->buffer() != nullptr);
 }
 
@@ -1023,7 +1032,7 @@ void DynamicShapeInferer::visit(const ir::operation::Transpose &op)
   // set output shape, based on input and params
   ir::Shape new_shape = shape_inference::inferTransposeShape(input_shape, perm);
 
-  _dynamic_tensor_manager->applyShape(output_ind, new_shape);
+  dynamicTensorManagerOf(output)->applyShape(output_ind, new_shape);
   assert(output->buffer() != nullptr);
 }
 
@@ -1051,7 +1060,7 @@ void DynamicShapeInferer::visit(const ir::operation::Unpack &op)
     auto output_ind = op.getOutputs().at(out_tensor_idx);
     auto output = _tensor_registry->getITensor(output_ind);
 
-    _dynamic_tensor_manager->applyShape(output_ind, new_shape);
+    dynamicTensorManagerOf(output)->applyShape(output_ind, new_shape);
 
     assert(output->buffer() != nullptr);
   }

--- a/runtime/onert/core/src/interp/Tensor.h
+++ b/runtime/onert/core/src/interp/Tensor.h
@@ -171,6 +171,7 @@ public:
   int32_t data_offset() const override { return _info.typeInfo().offset(); }
   const ir::OperandInfo &tensorInfo() const override { return _info; }
   uint64_t num_elements() const override { return _info.shape().num_elements(); };
+  backend::IDynamicTensorManager *dynamic_tensor_manager() override { return nullptr; }
 
 private:
   const ir::OperandInfo _info;


### PR DESCRIPTION
Introduce `ITensor::dynamic_tensor_manager`. Now portable tensors are
used between backends, dynamic tensor shape application can be done
for a tensor of another backend. In case of that, it is much useful
to have this method in tensor.

Part of #3533

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>