### PR TITLE
[onert] Introduce new PermutationEliminationPass

### DIFF
--- a/runtime/onert/core/src/ir/LoweredGraph.cc
+++ b/runtime/onert/core/src/ir/LoweredGraph.cc
@@ -23,6 +23,7 @@
 #include "pass/ConstantLoweringPass.h"
 #include "pass/PermutationOperationPass.h"
 #include "pass/PermutationInsertionPass.h"
+#include "pass/PermutationEliminationPass.h"
 #include "ir/GraphIterator.h"
 #include "verifier/Verifier.h"
 #include "backend/Backend.h"
@@ -122,6 +123,9 @@ LoweredGraph::LoweredGraph(const Graph &graph, const compiler::CompilerOptions &
 
     pass::PermutationInsertionPass pi_pass(*this);
     pi_pass.run();
+
+    pass::PermutationEliminationPass pe_pass(*this);
+    pe_pass.run();
 
     _op_seqs.dump("merged and sorted operations with permutation", _graph.operations());
   }

--- a/runtime/onert/core/src/ir/pass/PermutationEliminationPass.cc
+++ b/runtime/onert/core/src/ir/pass/PermutationEliminationPass.cc
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "PermutationEliminationPass.h"
+#include "backend/controlflow/Config.h"
+
+#include "util/logging.h"
+
+namespace onert
+{
+namespace ir
+{
+namespace pass
+{
+
+void PermutationEliminationPass::callback(const OperationIndex &ind, Operation &node)
+{
+  _op_ind = ind;
+  node.accept(*this);
+};
+
+void PermutationEliminationPass::visit(const operation::Permute &node)
+{
+  auto in_operand = node.getInputs().at(0);
+  auto out_operand = node.getOutputs().at(0);
+
+  // Check if two tensors are both portable
+  // TODO Make this general, this is just a workaround to check two tensors are portable
+  {
+    auto in_def_factor = _lowered_graph.getLowerInfo(in_operand)->def_factors().getOnlyElement();
+    auto out_def_factor = _lowered_graph.getLowerInfo(out_operand)->def_factors().getOnlyElement();
+
+    auto in_backend_id = in_def_factor.backend()->config()->id();
+    auto out_backend_id = out_def_factor.backend()->config()->id();
+
+    // NOTE This is to skip Permute insertion for model inputs(controlflow -> cpu), but not
+    // outputs. This function currently assumes that backend1 is Def and backend2 is Use. However
+    // it is going to be fixed soon.
+    // TODO make both ways work
+    if (!(in_backend_id == backend::controlflow::Config::ID && out_backend_id == "cpu"))
+      return;
+  }
+
+  // Make OpSequences(that use the output) use the input
+  {
+    auto &in_operand_obj = _graph.operands().at(in_operand);
+    in_operand_obj.removeUse(_op_ind);
+
+    _lowered_graph.op_seqs().iterate([&](const ir::OpSequenceIndex &, ir::OpSequence &op_seq) {
+      if (!op_seq.getInputs().contains(out_operand))
+        return;
+
+      // Update OpSequence/Operation edges and Operand edges
+      if (op_seq.getInputs().contains(out_operand))
+      {
+        op_seq.replaceInputs(out_operand, in_operand);
+        for (auto op : op_seq.operations())
+        {
+          auto &operation_obj = _graph.operations().at(op);
+          if (operation_obj.getInputs().contains(out_operand))
+          {
+            operation_obj.replaceInputs(out_operand, in_operand);
+            in_operand_obj.insertUse(op);
+          }
+        }
+      }
+    });
+  }
+
+  // Remove Permute operation, enclosing OpSequence and the operand
+  {
+    _graph.removeOperand(out_operand);
+
+    auto op_seq_ind = _lowered_graph.op_seqs().getOperation(_op_ind);
+    // Assumes enclosing OpSequence contatins just this Permute operation
+    assert(_lowered_graph.op_seqs().at(op_seq_ind).size() == 1);
+    _lowered_graph.op_seqs().remove(op_seq_ind);
+    _graph.operations().remove(_op_ind);
+  }
+
+  VERBOSE(removePermute) << "Permute Op removed, node index : " << _op_ind << std::endl;
+  VERBOSE(removePermute) << "  - Input (kept)    Operand : " << in_operand << std::endl;
+  VERBOSE(removePermute) << "  - Output(removed) Operand : " << out_operand << std::endl;
+}
+
+} // namespace pass
+} // namespace ir
+} // namespace onert

--- a/runtime/onert/core/src/ir/pass/PermutationEliminationPass.h
+++ b/runtime/onert/core/src/ir/pass/PermutationEliminationPass.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_GRAPH_PASS_PERMUTATION_ELIMINATION_PASS_H__
+#define __ONERT_GRAPH_PASS_PERMUTATION_ELIMINATION_PASS_H__
+
+#include "ir/OperationVisitor.h"
+#include "LoweredOperationPass.h"
+
+namespace onert
+{
+namespace ir
+{
+namespace pass
+{
+
+/**
+ * @brief An optimization pass that removes Permute operations if possible
+ *
+ * There may be some Permute operations that are inserted by PermutationInsertionPass or other
+ * passes. This pass checks all Permute operations and eliminates them if Permute in/out tensors
+ * are compatible and layouts match.
+ *
+ * Permute input tensor is kept and the output is removed for all the cases, except model outputs.
+ * As all output tensors have to be controlflow backend, so the output is kept.
+ *
+ * @note This is an optimization pass which means that everything should work fine even if this pass
+ *       was skipped.
+ */
+class PermutationEliminationPass : public LoweredOperationPass, public OperationVisitor
+{
+public:
+  using LoweredOperationPass::LoweredOperationPass;
+
+public:
+  std::string id() final { return "PermutationEliminationPass"; }
+
+public:
+  void callback(const OperationIndex &i, Operation &n) final;
+
+private:
+  void visit(const operation::Permute &) final;
+
+private:
+  ir::OperationIndex _op_ind;
+};
+
+} // namespace pass
+} // namespace ir
+} // namespace onert
+
+#endif // __ONERT_GRAPH_PASS_PERMUTATION_ELIMINATION_PASS_H__

--- a/runtime/onert/core/src/ir/pass/PermutationInsertionPass.cc
+++ b/runtime/onert/core/src/ir/pass/PermutationInsertionPass.cc
@@ -60,35 +60,8 @@ void PermutationInsertionPass::callback(const OperandIndex &index, Operand &obje
     }
 
     auto insert_set = operand_li->use_factors() - operand_li->def_factors();
-    auto def_factor = operand_li->def_factors().getOnlyElement();
-
-    auto compatible_backends = [](auto backend1, auto backend2) {
-      // TODO This is a workaround for not inserting Permute between cpu and controlflow.
-      //      To be general, we need another way of checking they are compatible.
-      const auto cf = backend::controlflow::Config::ID;
-      const auto cpu = "cpu";
-      const auto id1 = backend1->config()->id();
-      const auto id2 = backend2->config()->id();
-      // NOTE This is to skip Permute insertion for model inputs(controlflow -> cpu), but not
-      // outputs. This function currently assumes that backend1 is Def and backend2 is Use. However
-      // it is going to be fixed soon.
-      // TODO make both ways work
-      return (id1 == cpu && id2 == cf);
-    };
-
     for (auto factor : insert_set)
     {
-      // Check exceptional cases that Permute ops are not inserted
-      if (factor.layout() == def_factor.layout() &&
-          compatible_backends(factor.backend(), def_factor.backend()))
-      {
-        VERBOSE(PermutationInsertionPass) << "Permutation Insertion is skipped for operand "
-                                          << index << " / as the tensor is compatible with backend "
-                                          << factor.backend()->config()->id() << std::endl;
-        factor_to_index.emplace(factor, index);
-        continue;
-      }
-
       const auto permute_operation_index = insertPermute(index, factor);
       permute_indexes.push_back(permute_operation_index);
       const auto &permute_operation = _graph.operations().at(permute_operation_index);


### PR DESCRIPTION
- Introduce new PermutationEliminationPass
- Change approach for Permute insertion
    - Insert all Permute operations needed
    - Then remove unnecessary Permute (Check if the tensor is portable)

Part of #8533

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>