### PR TITLE
[tf2circle-value-pbtxt-remote-test] Use installed nnpkg test command

### DIFF
--- a/compiler/tf2circle-value-pbtxt-remote-test/CMakeLists.txt
+++ b/compiler/tf2circle-value-pbtxt-remote-test/CMakeLists.txt
@@ -141,7 +141,6 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E echo 'HDF5_EXPORT_ACTION_PATH=\"$<TARGET_FILE:nnkit_HDF5_export_action>\"' >> ${TEST_CONFIG}
   COMMAND ${CMAKE_COMMAND} -E echo 'HDF5_IMPORT_ACTION_PATH=\"$<TARGET_FILE:nnkit_HDF5_import_action>\"' >> ${TEST_CONFIG}
   COMMAND ${CMAKE_COMMAND} -E echo 'MODEL2NNPKG_PATH=\"${NNAS_PROJECT_SOURCE_DIR}/tools/nnpackage_tool/model2nnpkg/model2nnpkg.sh\"' >> ${TEST_CONFIG}
-  COMMAND ${CMAKE_COMMAND} -E echo 'NNPKG_TEST_PATH=\"${NNAS_PROJECT_SOURCE_DIR}/tests/scripts/nnpkg_test.sh\"' >> ${TEST_CONFIG}
   COMMAND ${CMAKE_COMMAND} -E echo 'RUNTIME_LIBRARY_PATH=\"${NNAS_PROJECT_SOURCE_DIR}/Product/out/\"' >> ${TEST_CONFIG}
   DEPENDS
     nnkit-run

--- a/compiler/tf2circle-value-pbtxt-remote-test/README.md
+++ b/compiler/tf2circle-value-pbtxt-remote-test/README.md
@@ -36,13 +36,13 @@
         #--------------- Remote Machine Setting ---------------#
         set(REMOTE_IP "xxx.xxx.xxx.xxx")
         set(REMOTE_USER "remote_username")
-        
+
         #--------------------- Tests list ---------------------#
         add(UNIT_Add_000)
         add(UNIT_Add_001)
         ...
         ```
-    - If any Tensorflow model is added, or if `REMOTE_IP` and `REMOTE_USER` is not given, `tf2circle-value-pbtxt-remote-test` will not be created. 
+    - If any Tensorflow model is added, or if `REMOTE_IP` and `REMOTE_USER` is not given, `tf2circle-value-pbtxt-remote-test` will not be created.
 1. (Optional) ssh authentication
     - This test uses `ssh` and `scp` commands, and those commands require a password of remote machine whenever they are called. This means that you should enter the password everytime when `ssh` and `scp` require.
     - This test resolves the problem by using `ssh-copy-id`, which copies the public key of host machine to `authorized_keys` of remote machine. Because of that, this test will ask the password of remote machine only once, at the first time. This is the only user interaction while running this test.
@@ -71,7 +71,7 @@
         ├ Result_latest -> Result_YYMMDD_hhmmss.csv
         ├ Result_YYMMDD_hhmmss.csv
         ├ ...
-        | 
+        |
         ├ UNIT_Add_000
         |     ├ metadata
         |     |     ├ MANIFEST
@@ -91,16 +91,16 @@
         |
         ├ ...
     ```
-- `nnpkg_test.sh`, runtime products and each nnpackage are sent to `REMOTE_WORKDIR` in remote machine.
+- Runtime products and each nnpackage are sent to `REMOTE_WORKDIR` in remote machine.
 - (TBD) Modify script not to remove obtained h5 file.
     ```
     REMOTE_WORKDIR
-        ├ nnpkg_test.sh
         |
         ├ Product
         |     └ out
         |        ├ bin
         |        ├ lib
+        |        ├ test
         |        ├ ...
         |
         ├ UNIT_Add_000

--- a/compiler/tf2circle-value-pbtxt-remote-test/testall.sh
+++ b/compiler/tf2circle-value-pbtxt-remote-test/testall.sh
@@ -30,7 +30,6 @@ echo "-- Found nnkit-run: ${NNKIT_RUN_PATH}"
 echo "-- Found TF backend: ${TF_BACKEND_PATH}"
 echo "-- Found TF2CIRCLE: ${TF2CIRCLE_PATH}"
 echo "-- Found MODEL2NNPKG: ${MODEL2NNPKG_PATH}"
-echo "-- Found nnpkg_test: ${NNPKG_TEST_PATH}"
 echo "-- Found Runtime library: ${RUNTIME_LIBRARY_PATH}"
 echo "-- Found randomize action: ${RANDOMIZE_ACTION_PATH}"
 echo "-- Found HDF5 export action: ${HDF5_EXPORT_ACTION_PATH}"
@@ -40,11 +39,6 @@ echo "-- Found workdir: ${WORKDIR}"
 if [ -z ${MODEL2NNPKG_PATH} ] || [ ! -f ${MODEL2NNPKG_PATH} ]; then
   echo "MODEL2NNPKG is not found"
   exit 3
-fi
-
-if [ -z ${NNPKG_TEST_PATH} ] || [ ! -f ${NNPKG_TEST_PATH} ]; then
-  echo "nnpkg_test is not found"
-  exit 4
 fi
 
 # Register remote machine ssh information
@@ -60,9 +54,6 @@ fi
 # Send runtime library files
 ssh "${REMOTE_USER}@${REMOTE_IP}" "mkdir -p ${REMOTE_WORKDIR}/Product/"
 scp -r "${RUNTIME_LIBRARY_PATH}" "${REMOTE_USER}@${REMOTE_IP}:${REMOTE_WORKDIR}/Product/"
-
-# Send nnpkg_test.sh
-scp "${NNPKG_TEST_PATH}" "${REMOTE_USER}@${REMOTE_IP}:${REMOTE_WORKDIR}/"
 
 TESTED=()
 PASSED=()
@@ -120,8 +111,8 @@ while [[ $# -ne 0 ]]; do
 
     # Run test_arm_nnpkg in remote machine
     scp -r "${WORKDIR}/${PREFIX}/" "${REMOTE_USER}@${REMOTE_IP}:${REMOTE_WORKDIR}/${PREFIX}/"
-    ssh "${REMOTE_USER}@${REMOTE_IP}" "cd ${REMOTE_WORKDIR}; ./nnpkg_test.sh -i . -o  ${PREFIX}/metadata/tc ${PREFIX}"
-    
+    ssh "${REMOTE_USER}@${REMOTE_IP}" "cd ${REMOTE_WORKDIR}; ./Product/out/test/onert-test nnpkg-test -i . -o  ${PREFIX}/metadata/tc ${PREFIX}"
+
     if [[ $? -eq 0 ]]; then
       touch "${PASSED_TAG}"
     fi


### PR DESCRIPTION
Instead of push test script, use installed package test command "onert-test nnpkg-test"

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>