### PR TITLE
[tf2nnpackage-value-remote-test] Use installed nnpkg test command

### DIFF
--- a/compiler/tf2nnpackage-value-remote-test/CMakeLists.txt
+++ b/compiler/tf2nnpackage-value-remote-test/CMakeLists.txt
@@ -33,12 +33,12 @@ endforeach()
 
 get_target_property(ARTIFACTS_SRC_PATH testDataGenerator SOURCE_DIR)
 
-# In this test, only the runtime test is performed because the test from tf to 
-# nnpackage is done in common-artifacts, and for this runtime test, generation of 
+# In this test, only the runtime test is performed because the test from tf to
+# nnpackage is done in common-artifacts, and for this runtime test, generation of
 # test data is required. And, tcgenerate in ${ARTIFACTS_SRC_PATH}/exclude.lst
 # means it won't generate test data, which is why below "tcgenerate" macro excludes
-# specific opearators from runtime test. 
-# Also, since circlize and optimize macro included in `exclude.lst` file is only 
+# specific opearators from runtime test.
+# Also, since circlize and optimize macro included in `exclude.lst` file is only
 # needed in common-artifacts, it has no function here.
 macro(circlize)
 endmacro()
@@ -72,7 +72,6 @@ set(TEST_CONFIG "${CMAKE_CURRENT_BINARY_DIR}/test.config")
 add_custom_command(
   OUTPUT ${TEST_CONFIG}
   COMMAND ${CMAKE_COMMAND} -E remove -f ${TEST_CONFIG}
-  COMMAND ${CMAKE_COMMAND} -E echo 'NNPKG_TEST_PATH=\"${NNAS_PROJECT_SOURCE_DIR}/tests/scripts/nnpkg_test.sh\"' >> ${TEST_CONFIG}
   COMMAND ${CMAKE_COMMAND} -E echo 'RUNTIME_LIBRARY_PATH=\"${NNAS_PROJECT_SOURCE_DIR}/Product/out/\"' >> ${TEST_CONFIG}
   COMMENT "Generate test configuration"
 )

--- a/compiler/tf2nnpackage-value-remote-test/README.md
+++ b/compiler/tf2nnpackage-value-remote-test/README.md
@@ -15,7 +15,7 @@
         set(REMOTE_IP "xxx.xxx.xxx.xxx")
         set(REMOTE_USER "remote_username")
         ```
-    - If any recipe is added, or if `REMOTE_IP` and `REMOTE_USER` is not given, `tf2nnpackage-value-remote-test` will not be created. 
+    - If any recipe is added, or if `REMOTE_IP` and `REMOTE_USER` is not given, `tf2nnpackage-value-remote-test` will not be created.
 1. (Optional) ssh authentication
     - This test uses `ssh` and `scp` commands, and those commands require a password of remote machine whenever they are called. This means that you should enter the password everytime when `ssh` and `scp` require.
     - This test resolves the problem by using `ssh-copy-id`, which copies the public key of host machine to `authorized_keys` of remote machine. Because of that, this test will ask the password of remote machine only once, at the first time. This is the only user interaction while running this test.
@@ -39,7 +39,7 @@
 ### Generated Files While Running
 
 - All related files(`pb`, `circle`, `h5` ... etc.) are taken from `build/compiler/common-artifacts` folder.
-- `nnpkg_test.sh`, runtime products and each nnpackage are sent to `REMOTE_WORKDIR` in remote machine.
+- Runtime products and each nnpackage are sent to `REMOTE_WORKDIR` in remote machine.
 - Each test result is generated in `build/compiler/common-artifacts` with the name `${RECIPE}.log`
 
 ### Check Test Result

--- a/compiler/tf2nnpackage-value-remote-test/testall.sh
+++ b/compiler/tf2nnpackage-value-remote-test/testall.sh
@@ -27,14 +27,8 @@ RESULT_CSV="${BINDIR}/Result_${CURRENT_DATETIME}.csv"
 
 source "${CONFIG_PATH}"
 
-echo "-- Found nnpkg_test: ${NNPKG_TEST_PATH}"
 echo "-- Found Runtime library: ${RUNTIME_LIBRARY_PATH}"
 echo "-- Found workdir: ${WORKDIR}"
-
-if [ -z ${NNPKG_TEST_PATH} ] || [ ! -f ${NNPKG_TEST_PATH} ]; then
-  echo "nnpkg_test is not found"
-  exit 4
-fi
 
 # Register remote machine ssh information
 cat /dev/zero | ssh-keygen -q -N ""
@@ -49,9 +43,6 @@ fi
 # Send runtime library files
 ssh "${REMOTE_USER}@${REMOTE_IP}" "mkdir -p ${REMOTE_WORKDIR}/Product/"
 scp -r "${RUNTIME_LIBRARY_PATH}" "${REMOTE_USER}@${REMOTE_IP}:${REMOTE_WORKDIR}/Product/"
-
-# Send nnpkg_test.sh
-scp "${NNPKG_TEST_PATH}" "${REMOTE_USER}@${REMOTE_IP}:${REMOTE_WORKDIR}/"
 
 TESTED=()
 PASSED=()
@@ -84,8 +75,8 @@ while [[ $# -ne 0 ]]; do
     PREFIX=${PREFIX}.opt ;
     fi
     scp -r "${PREFIX}/" "${REMOTE_USER}@${REMOTE_IP}:${REMOTE_WORKDIR}/${PREFIX}/"
-    ssh "${REMOTE_USER}@${REMOTE_IP}" "cd ${REMOTE_WORKDIR}; ./nnpkg_test.sh ${PREFIX}"
-    
+    ssh "${REMOTE_USER}@${REMOTE_IP}" "cd ${REMOTE_WORKDIR}; ./Product/out/test/onert-test nnpkg-test ${PREFIX}"
+
     if [[ $? -eq 0 ]]; then
       touch "${BINDIR}/${PASSED_TAG}"
     fi


### PR DESCRIPTION
Instead of push test script, use installed package test command "onert-test nnpkg-test"

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>