### PR TITLE
[cker/ruy] Use polymorphic_downcast to fix dynamic_cast error on android

### DIFF
--- a/runtime/libs/misc/include/misc/polymorphic_downcast.h
+++ b/runtime/libs/misc/include/misc/polymorphic_downcast.h
@@ -27,7 +27,9 @@ namespace misc
 
 template <typename DstType, typename SrcType> inline DstType polymorphic_downcast(SrcType *x)
 {
+#ifndef __ANDROID__
   assert(dynamic_cast<DstType>(x) == x);
+#endif
   return static_cast<DstType>(x);
 }
 


### PR DESCRIPTION
- `dynamic_cast` is not working across shared library boundaries (Android NDK limitation)
- `EXPERIMENTAL_RUY_FEATURE` flag uses `dynamic_cast` and it is not working on android
- Use polymorphic_downcast instead of dynamic_cast to fix this issue

ONE-DCO-1.0-Signed-off-by: JiHwan Yeo <jihwan.yeo@samsung.com>

---

For issue : #3632