### PR TITLE
[luci] Add BCQ node name prefix rule

### DIFF
--- a/compiler/luci/pass/src/FuseBCQPass.cpp
+++ b/compiler/luci/pass/src/FuseBCQPass.cpp
@@ -53,6 +53,11 @@ const std::string node_name_prefix(luci::NodeName node_name)
     const auto index = prefix.find("Tensordot/");
     prefix = prefix.substr(0, index - 1);
   }
+  else if (prefix.find("/MatMul") != std::string::npos)
+  {
+    const auto index = prefix.find("/MatMul");
+    prefix = prefix.substr(0, index - 1);
+  }
   else if (prefix.find("kernel/") != std::string::npos)
   {
     const auto index = prefix.find("kernel/");


### PR DESCRIPTION
This commit will add a new prefix rule for BCQ node names.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>