### PR TITLE
[luci] Fix wrong code in FuseBCQPass

### DIFF
--- a/compiler/luci/pass/src/FuseBCQPass.cpp
+++ b/compiler/luci/pass/src/FuseBCQPass.cpp
@@ -56,7 +56,7 @@ const std::string node_name_prefix(luci::NodeName node_name)
   else if (prefix.find("/MatMul") != std::string::npos)
   {
     const auto index = prefix.find("/MatMul");
-    prefix = prefix.substr(0, index - 1);
+    prefix = prefix.substr(0, index);
   }
   else if (prefix.find("kernel/") != std::string::npos)
   {


### PR DESCRIPTION
This commit will fix wrong code in `FuseBCQPass`.

**I am sorry for bothering...**

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>