### PR TITLE
[onert] Enable constant tensor deallocation if tensor is cached

### DIFF
--- a/runtime/onert/backend/cpu/ops/FullyConnectedLayer.cc
+++ b/runtime/onert/backend/cpu/ops/FullyConnectedLayer.cc
@@ -115,8 +115,6 @@ void FullyConnectedLayer::fullyConnectedHybrid()
       getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()), temp_arena,
       _external_context->ruy_context());
 
-// TODO Remove this ifdef
-#ifdef EXPERIMENTAL_RUY_FEATURE
   if (_cached_weights == nullptr || _is_weights_freed)
     return;
 
@@ -148,7 +146,6 @@ void FullyConnectedLayer::fullyConnectedHybrid()
       _is_weights_freed = true;
     }
   }
-#endif
 #endif
 }
 
@@ -198,8 +195,7 @@ void FullyConnectedLayer::prepare()
     }
   }
 
-#ifdef USE_RUY_GEMV
-#ifdef EXPERIMENTAL_RUY_FEATURE
+#if defined(__ARM_NEON__) && defined(USE_RUY_GEMV)
   // TODO This is workaround
   // The only fc hybrid will use ruy kernel
   if (_input->data_type() != OperandType::FLOAT32 ||
@@ -230,7 +226,6 @@ void FullyConnectedLayer::prepare()
       _cached_weights = _weights->buffer();
     }
   }
-#endif
 #endif
 }
 

--- a/runtime/onert/backend/cpu/ops/FullyConnectedLayer.h
+++ b/runtime/onert/backend/cpu/ops/FullyConnectedLayer.h
@@ -76,9 +76,7 @@ private:
 
 #ifdef USE_RUY_GEMV
   uint8_t *_cached_weights = nullptr; // weights to be cached and a key
-#ifdef EXPERIMENTAL_RUY_FEATURE
-  bool _is_weights_freed = false; // is weights freed?
-#endif
+  bool _is_weights_freed = false;     // is weights freed?
 #endif
 };
 


### PR DESCRIPTION
- Constant tensor deallocation is introduced at #2748 but it is disabled since it produces error with multi-thread execution #2929
- Multi-thread issue is now fixed by #3559
- Remove temporal macro `EXPERIMENTAL_RUY_FEATURE` to enable deallocation feature
  - Deallocation is only enabled on ARM architecture
  - Ruy library is not used on x86

ONE-DCO-1.0-Signed-off-by: JiHwan Yeo <jihwan.yeo@samsung.com>