### PR TITLE
[onert] Put `private` to correct position

### DIFF
--- a/runtime/onert/core/src/ir/pass/PermutationInsertionPass.h
+++ b/runtime/onert/core/src/ir/pass/PermutationInsertionPass.h
@@ -38,6 +38,7 @@ public:
   std::string id() override { return "PermutationInsertionPass"; }
   void callback(const OperandIndex &index, Operand &object) override;
 
+private:
   /**
    * @brief Insert Permute operation that has given operand as input
    *
@@ -48,8 +49,6 @@ public:
    */
   OperationIndex insertPermute(const OperandIndex &operand_index,
                                const operand::PermuteFactor &factor);
-
-private:
 };
 
 } // namespace pass


### PR DESCRIPTION
This puts `private` to correct position of `PermutationInsertionPass`.

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>