### PR TITLE
[onert/test] Introduce model download command

### DIFF
--- a/infra/scripts/test_ubuntu_runtime_mixed.sh
+++ b/infra/scripts/test_ubuntu_runtime_mixed.sh
@@ -14,16 +14,14 @@ TEST_OS="linux"
 
 # This test requires test model installation
 pushd ${ROOT_PATH} > /dev/null
-echo
-echo "==== Run nnfw_api_gtest begin ===="
-echo
-NNFW_API_TEST_MODEL_INSTALLER=tests/scripts/nnfw_api_gtest/install_nnfw_api_gtest_nnpackages.sh
-TEST_BIN=Product/out/unittest_standalone/nnfw_api_gtest
-$NNFW_API_TEST_MODEL_INSTALLER --install-dir ${TEST_BIN}_models
-echo
-echo "==== Run nnfw_api_gtest end ===="
-echo
+echo ""
+echo "==== Run standalone unittest begin ===="
+echo ""
+Product/out/test/onert-test prepare-model --model=nnpackage
 Product/out/test/onert-test unittest --unittestdir=Product/out/unittest_standalone
+echo ""
+echo "==== Run standalone unittest end ===="
+echo ""
 
 # NOTE Fixed backend assignment by type of operation
 # TODO Enhance this with randomized test

--- a/tests/scripts/CMakeLists.txt
+++ b/tests/scripts/CMakeLists.txt
@@ -9,6 +9,14 @@ install(PROGRAMS ${TEST_DRIVER_SCRIPT} DESTINATION test)
 # Commands don't have execute permission itself
 install(DIRECTORY command DESTINATION test)
 
+# Install models test script
+file(GLOB MODEL_TEST_SCRIPT "models/run_test.sh")
+install(PROGRAMS ${MODEL_TEST_SCRIPT} DESTINATION test/models)
+
+# Install nnpackage test config
+file(GLOB MODEL_TEST_DIR LIST_DIRECTORIES true nnfw_api_gtest/models/*)
+install(DIRECTORY ${MODEL_TEST_DIR} DESTINATION test/models/nnpackage)
+
 # TODO Below install to tests/ will be deprecated
 
 # Install test scripts

--- a/tests/scripts/command/prepare-model
+++ b/tests/scripts/command/prepare-model
@@ -1,0 +1,64 @@
+#!/bin/bash
+#
+# Copyright (c) 2018 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+COMMAND_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALL_DIR="$(dirname $(dirname $COMMAND_DIR))"
+
+MD5_CHECK="on"
+DOWNLOAD_MODEL="all"
+
+function Usage()
+{
+    echo "Usage: $0 $(basename ${BASH_SOURCE[0]}) [OPTIONS]"
+    echo ""
+    echo "Options:"
+    echo "      --ignoremd5                         Ignore MD5 check when download model files"
+    echo "      --model=(all|nnpackage|tflite)      Download test model (default=all)"
+}
+
+for i in "$@"
+do
+    case $i in
+        -h|--help|help)
+            Usage
+            exit 1
+            ;;
+        --ignoremd5)
+            MD5_CHECK="off"
+            ;;
+        --model=*)
+            DOWNLOAD_MODEL=${i#*=}
+            ;;
+        *)
+            echo "Unknown option: $i"
+            exit 1
+        ;;
+    esac
+    shift
+done
+
+if [[ $DOWNLOAD_MODEL == "all" ]] || [[ $DOWNLOAD_MODEL == "tflite" ]]; then
+    # Download tflite models
+    $INSTALL_DIR/tests/scripts/models/run_test.sh --download=on --run=off --md5=$MD5_CHECK
+fi
+
+if [[ $DOWNLOAD_MODEL == "all" ]] || [[ $DOWNLOAD_MODEL == "nnpackage" ]]; then
+    # Download nnpackage model
+    NNPACKAGE_CONFIG_DIR=$INSTALL_DIR/test/models/nnpackage/
+    NNPACKAGE_CACHE_DIR=$INSTALL_DIR/unittest_standalone/nnfw_api_gtest_models/
+    $INSTALL_DIR/tests/scripts/models/run_test.sh --download=on --run=off --md5=$MD5_CHECK \
+        --configdir=$NNPACKAGE_CONFIG_DIR --cachedir=$NNPACKAGE_CACHE_DIR
+fi


### PR DESCRIPTION
Introduce model download command to merge nnpacakge and tflite model download

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Howto: (on target)
```
$ [install_dir]/test/onert-test prepare-model --model=nnpackage
$ [install_dir]/test/onert-test unittest --unittestdir=[install_dir]/unittest_standalone
```
