### PR TITLE
[luci/service] Support NonMaxSuppressionV4 op

### DIFF
--- a/compiler/luci/service/src/CircleTypeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleTypeInferenceRule.cpp
@@ -252,6 +252,11 @@ struct TypeInferenceAlgorithm final : public luci::CircleNodeVisitor<loco::DataT
 
   loco::DataType visit(const luci::CircleNeg *node) final { return loco::dtype_get(node->x()); }
 
+  loco::DataType visit(const luci::CircleNonMaxSuppressionV4 *node) final
+  {
+    return loco::dtype_get(node->boxes());
+  }
+
   loco::DataType visit(const luci::CircleNotEqual *) final { return loco::DataType::BOOL; }
 
   loco::DataType visit(const luci::CirclePack *node) final
@@ -575,6 +580,13 @@ struct TypeInferenceAlgorithm final : public luci::CircleNodeVisitor<loco::DataT
     assert(then_graph_output->dtype() == else_graph_output->dtype());
 
     return then_graph_output->dtype();
+  }
+
+  loco::DataType visit(const luci::CircleNonMaxSuppressionV4Out *node) final
+  {
+    (void)node;
+    assert(node->index() == 0 || node->index() == 1);
+    return loco::DataType::S32;
   }
 
   loco::DataType visit(const luci::CircleSplitOut *node) final


### PR DESCRIPTION
Add shape and type inference for NonMaxSuppressionV4 in luci service.

ONE-DCO-1.0-Signed-off-by: Alexander Moiseev <a.moiseev@samsung.com>