### PR TITLE
[circle-tensordump] Check whether option is provided or not

### DIFF
--- a/compiler/circle-tensordump/driver/Driver.cpp
+++ b/compiler/circle-tensordump/driver/Driver.cpp
@@ -49,6 +49,13 @@ int entry(int argc, char **argv)
     return 255;
   }
 
+  if (arser["--tensors_to_hdf5"] == arser["--tensors"])
+  {
+    std::cout << "[Error] You must specify one option for how to print." << std::endl;
+    std::cout << arser;
+    return 255;
+  }
+
   std::unique_ptr<circletensordump::DumpInterface> dump;
 
   std::string model_file = arser.get<std::string>("circle");


### PR DESCRIPTION
This commit add condition that checks whether one option is provided or
not.

circle-tensordump needs one option for how to print but arser doesn't
support required exclusive option yet.

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>