### PR TITLE
[onert] Create ExternalData if data is from memory

### DIFF
--- a/runtime/onert/frontend/base_loader/include/base_loader.h
+++ b/runtime/onert/frontend/base_loader/include/base_loader.h
@@ -441,18 +441,26 @@ ir::OperandIndex BaseLoader<LoaderDomain, SpecificLoader>::loadOperand(const Ten
   if (data != nullptr)
   {
     using std::ptrdiff_t;
-    size_t data_size = data->size();
-    ptrdiff_t unaligned_offset_start = data->data() - _base;
-    ptrdiff_t offset_end = unaligned_offset_start + data_size;
+    std::unique_ptr<ir::Data> data_obj;
+    if (_fd == -1) // Model is from memory
+    {
+      data_obj = std::make_unique<ir::ExternalData>(data->data(), data->size());
+    }
+    else // Model is loaded(mmap'd) from a file
+    {
+      size_t data_size = data->size();
+      ptrdiff_t unaligned_offset_start = data->data() - _base;
+      ptrdiff_t offset_end = unaligned_offset_start + data_size;
 
-    // Calculated aligned offset from base address of mapped region
-    // munmap accepts memory address which is a multiple of the pagesize
-    ptrdiff_t aligned_offset_start = (unaligned_offset_start / _pagesize) * _pagesize;
-    size_t mmap_size = offset_end - aligned_offset_start;
+      // Calculated aligned offset from base address of mapped region
+      // munmap accepts memory address which is a multiple of the pagesize
+      ptrdiff_t aligned_offset_start = (unaligned_offset_start / _pagesize) * _pagesize;
+      size_t mmap_size = offset_end - aligned_offset_start;
 
-    auto ptr = std::make_unique<ir::MMapedData>(_fd, aligned_offset_start, mmap_size,
-                                                unaligned_offset_start, data_size);
-    subg.setOperandValue(operand_index, std::move(ptr));
+      data_obj = std::make_unique<ir::MMapedData>(_fd, aligned_offset_start, mmap_size,
+                                                  unaligned_offset_start, data_size);
+    }
+    subg.setOperandValue(operand_index, std::move(data_obj));
   }
 
   // Name unused


### PR DESCRIPTION
Create ExternalData if the model is loaded to memory, not a file.
This will be used for in-memory loading API.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>