### PR TITLE
[infra/CI] Divide venv tar from compiler package

### DIFF
--- a/infra/scripts/docker_build_nncc.sh
+++ b/infra/scripts/docker_build_nncc.sh
@@ -65,6 +65,7 @@ mkdir -p ${NNCC_INSTALL_PREFIX}
   install tensorflow-cpu==2.3.0
 
 mkdir -p ${ARCHIVE_PATH}
-tar -zcf ${ARCHIVE_PATH}/nncc-package.tar.gz -C ${NNCC_INSTALL_PREFIX} ./
+tar -zcf ${ARCHIVE_PATH}/nncc-package.tar.gz -C ${NNCC_INSTALL_PREFIX} ./ --except "bin/venv"
+tar -zcf ${ARCHIVE_PATH}/nncc-venv-package.tar.gz -C ${NNCC_INSTALL_PREFIX} bin/venv
 
 popd > /dev/null


### PR DESCRIPTION
Remove venv from compiler package and make new venv tar pacakge for test
(compiler package is too large now: 200MB)

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>