### PR TITLE
[oenrt] Fix batch_to_space op

### DIFF
--- a/compute/cker/include/cker/operation/BatchToSpaceND.h
+++ b/compute/cker/include/cker/operation/BatchToSpaceND.h
@@ -87,8 +87,8 @@ inline void BatchToSpaceND(const Shape &unextended_input1_shape, const T *input1
   const int32_t block_shape_height = block_shape_data[0];
   const int32_t block_shape_width = block_shape_data[1];
 
-  const int crops_top = crops_data[0];
-  const int crops_left = crops_data[2];
+  const int32_t crops_top = crops_data[0];
+  const int32_t crops_left = crops_data[2];
 
   for (int in_batch = 0; in_batch < input_batch_size; ++in_batch)
   {

--- a/runtime/onert/backend/cpu/ops/BatchToSpaceNDLayer.cc
+++ b/runtime/onert/backend/cpu/ops/BatchToSpaceNDLayer.cc
@@ -44,12 +44,12 @@ void BatchToSpaceNDLayer::batchToSpaceNDFloat32()
   }
   else
   {
-    _crops_buffer = reinterpret_cast<const int *>(_crops);
+    _crops_buffer = reinterpret_cast<const int32_t *>(_crops->buffer());
   }
-  nnfw::cker::BatchToSpaceND(getTensorShape(_input),
-                             reinterpret_cast<const float *>(_input->buffer()),
-                             reinterpret_cast<const int *>(_block_shape->buffer()), _crops_buffer,
-                             getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()));
+  nnfw::cker::BatchToSpaceND(
+      getTensorShape(_input), reinterpret_cast<const float *>(_input->buffer()),
+      reinterpret_cast<const int32_t *>(_block_shape->buffer()), _crops_buffer,
+      getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()));
 }
 
 void BatchToSpaceNDLayer::configure(const IPortableTensor *input, IPortableTensor *output,

--- a/runtime/onert/frontend/base_loader/include/base_loader.h
+++ b/runtime/onert/frontend/base_loader/include/base_loader.h
@@ -1112,12 +1112,8 @@ void BaseLoader<LoaderDomain, SpecificLoader>::loadBatchToSpaceND(const Operator
   ir::OperandIndexSequence outputs;
 
   loadOperationIO(op, inputs, outputs);
-  auto input = inputs.at(0);
-  auto block_shape = inputs.at(1);
-  auto crops = inputs.at(2);
 
-  std::unique_ptr<ir::Operation> new_op{
-      new ir::operation::BatchToSpaceND{{input, block_shape, crops}, outputs}};
+  std::unique_ptr<ir::Operation> new_op{new ir::operation::BatchToSpaceND{inputs, outputs}};
   subg.addOperation(std::move(new_op));
 }
 


### PR DESCRIPTION
reinterpret_cast<const int32_t *>(_crops); -> reinterpret_cast<const int32_t *>(_crops->buffer());
_crops->buffer() should put in the crops buffer.
Not a pointer to IPortableTensor.

Change data type. int -> int32_t

Signed-off-by: YiHyunjin <hj0412.yi@samsung.com>