### PR TITLE
[onert] Find package to link flatbuffers to circle_schema

### DIFF
--- a/runtime/onert/frontend/circle_schema/CMakeLists.txt
+++ b/runtime/onert/frontend/circle_schema/CMakeLists.txt
@@ -1,5 +1,7 @@
 add_library(circle_schema INTERFACE)
 
+nnfw_find_package(FlatBuffers REQUIRED)
+
 target_link_libraries(circle_schema INTERFACE flatbuffers::flatbuffers)
 
 target_include_directories(circle_schema INTERFACE include)


### PR DESCRIPTION
Fix build fail by adding find_package to link flatbuffers to circle_schema

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

For #3720