### PR TITLE
[infra] Use user defined value by default

### DIFF
--- a/infra/packaging/build
+++ b/infra/packaging/build
@@ -85,7 +85,7 @@ function join_by
 # Invoke "preset_configure" function that the preset provides
 preset_configure
 
-NPROC=$(cat /proc/cpuinfo | grep -c processor)
+NPROC=${NPROC:-$(cat /proc/cpuinfo | grep -c processor)}
 cmake --build . -- -j$((NPROC/2)) all
 cmake --build . -- install
 # Install NN Package tools

--- a/infra/packaging/build
+++ b/infra/packaging/build
@@ -86,6 +86,7 @@ function join_by
 preset_configure
 
 NPROC=${NPROC:-$(cat /proc/cpuinfo | grep -c processor)}
+echo "[BUILD] \"make\" with -j${NPROC} option. You can specify the number of jobs by defining NPROC"
 cmake --build . -- -j$((NPROC/2)) all
 cmake --build . -- install
 # Install NN Package tools


### PR DESCRIPTION
This commit enables create-package to get NPROC var from user as well as
from system.

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>