### PR TITLE
[cker] Fix wrong calculation code in MatrixBandPart

### DIFF
--- a/compute/cker/include/cker/operation/MatrixBandPart.h
+++ b/compute/cker/include/cker/operation/MatrixBandPart.h
@@ -33,7 +33,7 @@ void MatrixBandPart(const T num_lower_diags, const T num_upper_diags, const Shap
   auto last_dim = input_shape.DimensionsCount() - 1;
 
   T batch_num = 1;
-  for (int dim = 0; dim < last_dim - 2; dim++)
+  for (int dim = 0; dim < input_shape.DimensionsCount() - 2; dim++)
   {
     batch_num *= input_shape.Dims(dim);
   }

--- a/compute/cker/include/cker/operation/MatrixBandPart.h
+++ b/compute/cker/include/cker/operation/MatrixBandPart.h
@@ -32,10 +32,10 @@ void MatrixBandPart(const T num_lower_diags, const T num_upper_diags, const Shap
 {
   auto last_dim = input_shape.DimensionsCount() - 1;
 
-  T batch_num = 0;
+  T batch_num = 1;
   for (int dim = 0; dim < last_dim - 2; dim++)
   {
-    batch_num += input_shape.Dims(dim);
+    batch_num *= input_shape.Dims(dim);
   }
 
   const T row_num = input_shape.Dims(last_dim - 1);


### PR DESCRIPTION
When `input_shape` is 2-rank shape, `batch_num` is calculated as 0.
This commit will fix it.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>