### PR TITLE
[nnfwapi] Introduce `nnfw_load_circle_from_buffer`

### DIFF
--- a/runtime/onert/api/include/nnfw_internal.h
+++ b/runtime/onert/api/include/nnfw_internal.h
@@ -23,4 +23,16 @@ NNFW_STATUS nnfw_set_config(nnfw_session *session, const char *key, const char *
 
 NNFW_STATUS nnfw_get_config(nnfw_session *session, const char *key, char *value, size_t value_size);
 
+/**
+ * @brief Load a circle model from buffer.
+ *
+ * The buffer must outlive the session.
+ *
+ * @param[in] session session
+ * @param[in] buffer  Pointer to the buffer
+ * @param[in] size    Buffer size
+ * @return NNFW_STATUS
+ */
+NNFW_STATUS nnfw_load_circle_from_buffer(nnfw_session *session, uint8_t *buffer, size_t size);
+
 #endif // __NNFW_INTERNAL_H__

--- a/runtime/onert/api/src/nnfw_api.cc
+++ b/runtime/onert/api/src/nnfw_api.cc
@@ -341,3 +341,9 @@ NNFW_STATUS nnfw_query_info_u32(nnfw_session *session, NNFW_INFO_ID id, uint32_t
   // It should not be reached.
   return NNFW_STATUS_ERROR;
 }
+
+NNFW_STATUS nnfw_load_circle_from_buffer(nnfw_session *session, uint8_t *buffer, size_t size)
+{
+  NNFW_RETURN_ERROR_IF_NULL(session);
+  return session->load_circle_from_buffer(buffer, size);
+}

--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -73,6 +73,24 @@ nnfw_session::nnfw_session()
 
 nnfw_session::~nnfw_session() = default;
 
+NNFW_STATUS nnfw_session::load_circle_from_buffer(uint8_t *buffer, size_t size)
+{
+  if (!isStateInitialized())
+    return NNFW_STATUS_INVALID_STATE;
+
+  if (!buffer)
+    return NNFW_STATUS_UNEXPECTED_NULL;
+
+  if (size == 0)
+    return NNFW_STATUS_ERROR;
+
+  _subgraphs = onert::circle_loader::loadModel(buffer, size);
+  _compiler = std::make_unique<onert::compiler::Compiler>(_subgraphs);
+
+  _state = State::MODEL_LOADED;
+  return NNFW_STATUS_NO_ERROR;
+}
+
 NNFW_STATUS nnfw_session::load_model_from_file(const char *package_dir)
 {
   if (!isStateInitialized())

--- a/runtime/onert/api/src/nnfw_api_internal.h
+++ b/runtime/onert/api/src/nnfw_api_internal.h
@@ -127,8 +127,14 @@ public:
   NNFW_STATUS set_available_backends(const char *backends);
   NNFW_STATUS set_op_backend(const char *op, const char *backend);
 
+  //
+  // Internal-only API
+  //
+
   NNFW_STATUS set_config(const char *key, const char *value);
   NNFW_STATUS get_config(const char *key, char *value, size_t value_size);
+
+  NNFW_STATUS load_circle_from_buffer(uint8_t *buffer, size_t size);
 
 private:
   onert::ir::Graph *primary_subgraph();

--- a/runtime/onert/frontend/base_loader/include/base_loader.h
+++ b/runtime/onert/frontend/base_loader/include/base_loader.h
@@ -77,6 +77,13 @@ public:
    * @param file_path
    */
   void loadFromFile(const char *file_path);
+  /**
+   * @brief Load a model from a buffer
+   *
+   * @param buffer buffer pointer
+   * @param size buffer size
+   */
+  void loadFromBuffer(uint8_t *buffer, size_t size);
 
 protected:
   ~BaseLoader() = default;
@@ -222,6 +229,15 @@ void BaseLoader<LoaderDomain, SpecificLoader>::BaseLoader::loadFromFile(const ch
   munmap(_base, size);
 
   close(_fd);
+}
+
+template <typename LoaderDomain, typename SpecificLoader>
+void BaseLoader<LoaderDomain, SpecificLoader>::BaseLoader::loadFromBuffer(uint8_t *buffer,
+                                                                          size_t size)
+{
+  _base = buffer;
+  _verifier = std::make_unique<Verifier>(reinterpret_cast<const std::uint8_t *>(_base), size);
+  loadModel();
 }
 
 template <typename LoaderDomain, typename SpecificLoader>

--- a/runtime/onert/frontend/circle/include/circle_loader.h
+++ b/runtime/onert/frontend/circle/include/circle_loader.h
@@ -26,6 +26,7 @@ namespace onert
 namespace circle_loader
 {
 std::unique_ptr<ir::Subgraphs> loadModel(const char *filename);
+std::unique_ptr<ir::Subgraphs> loadModel(uint8_t *buffer, size_t size);
 } // namespace circle_loader
 } // namespace onert
 

--- a/runtime/onert/frontend/circle/src/circle_loader.cc
+++ b/runtime/onert/frontend/circle/src/circle_loader.cc
@@ -206,5 +206,13 @@ std::unique_ptr<ir::Subgraphs> loadModel(const char *filename)
   return subgraphs;
 }
 
+std::unique_ptr<ir::Subgraphs> loadModel(uint8_t *buffer, size_t size)
+{
+  auto subgraphs = std::make_unique<ir::Subgraphs>();
+  CircleLoader loader(subgraphs);
+  loader.loadFromBuffer(buffer, size);
+  return subgraphs;
+}
+
 } // namespace circle_loader
 } // namespace onert


### PR DESCRIPTION
Introduce `nnfw_load_circle_from_buffer` to `nnfw_internal.h`.
This is a debugging API to load CIRCLE from an in-memory buffer.

Draft : #3706

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>