### PR TITLE
[onert] Introduce `nnfw_{in|out}put_tensorindex`

### DIFF
--- a/runtime/onert/api/include/nnfw_experimental.h
+++ b/runtime/onert/api/include/nnfw_experimental.h
@@ -62,4 +62,38 @@ typedef struct
 NNFW_STATUS nnfw_register_custom_op_info(nnfw_session *session, const char *id,
                                          custom_kernel_registration_info *info);
 
+/**
+ * @brief Get the input tensor index by name
+ *
+ * This function finds an input tensor of the given name.
+ * If found, the index value is set to the address that @c index points to, and returns
+ * @c NNFW_STATUS_NO_ERROR. Otherwise, @c index is unchanged and returns @c NNFW_STATUS_ERROR .
+ *
+ * @note If two or more input tensors are of the same name, the one with the lowest index is always
+ *       returned.
+ *
+ * @param[in]  session    the session object
+ * @param[in]  tensorname the name of the tensor to find, a null terminated char pointer string
+ * @param[out] index      the index to be ret
+ * @return     @c NNFW_STATUS_NO_ERROR if successful
+ */
+NNFW_STATUS nnfw_input_tensorindex(nnfw_session *session, const char *tensorname, uint32_t *index);
+
+/**
+ * @brief Get the input tensor index by name
+ *
+ * This function finds an input tensor of the given name.
+ * If found, the index value is set to the address that @c index points to, and returns
+ * @c NNFW_STATUS_NO_ERROR. Otherwise, @c index is unchanged and returns @c NNFW_STATUS_ERROR .
+ *
+ * @note If two or more input tensors are of the same name, the one with the lowest index is always
+ *       returned.
+ *
+ * @param[in]  session    the session object
+ * @param[in]  tensorname the name of the tensor to find, a null terminated char pointer string
+ * @param[out] index      the index to be ret
+ * @return     @c NNFW_STATUS_NO_ERROR if successful
+ */
+NNFW_STATUS nnfw_output_tensorindex(nnfw_session *session, const char *tensorname, uint32_t *index);
+
 #endif // __NNFW_EXPERIMENTAL_H__

--- a/runtime/onert/api/src/nnfw_api.cc
+++ b/runtime/onert/api/src/nnfw_api.cc
@@ -347,3 +347,15 @@ NNFW_STATUS nnfw_load_circle_from_buffer(nnfw_session *session, uint8_t *buffer,
   NNFW_RETURN_ERROR_IF_NULL(session);
   return session->load_circle_from_buffer(buffer, size);
 }
+
+NNFW_STATUS nnfw_input_tensorindex(nnfw_session *session, const char *tensorname, uint32_t *index)
+{
+  NNFW_RETURN_ERROR_IF_NULL(session);
+  return session->input_tensorindex(tensorname, index);
+}
+
+NNFW_STATUS nnfw_output_tensorindex(nnfw_session *session, const char *tensorname, uint32_t *index)
+{
+  NNFW_RETURN_ERROR_IF_NULL(session);
+  return session->output_tensorindex(tensorname, index);
+}

--- a/runtime/onert/api/src/nnfw_api_internal.h
+++ b/runtime/onert/api/src/nnfw_api_internal.h
@@ -122,8 +122,6 @@ public:
   NNFW_STATUS input_tensorinfo(uint32_t index, nnfw_tensorinfo *ti);
   NNFW_STATUS output_tensorinfo(uint32_t index, nnfw_tensorinfo *ti);
 
-  NNFW_STATUS register_custom_operation(const std::string &id, nnfw_custom_eval eval_func);
-
   NNFW_STATUS set_available_backends(const char *backends);
   NNFW_STATUS set_op_backend(const char *op, const char *backend);
 
@@ -133,8 +131,15 @@ public:
 
   NNFW_STATUS set_config(const char *key, const char *value);
   NNFW_STATUS get_config(const char *key, char *value, size_t value_size);
-
   NNFW_STATUS load_circle_from_buffer(uint8_t *buffer, size_t size);
+
+  //
+  // Experimental API
+  //
+
+  NNFW_STATUS register_custom_operation(const std::string &id, nnfw_custom_eval eval_func);
+  NNFW_STATUS input_tensorindex(const char *tensorname, uint32_t *index);
+  NNFW_STATUS output_tensorindex(const char *tensorname, uint32_t *index);
 
 private:
   onert::ir::Graph *primary_subgraph();

--- a/runtime/onert/core/include/ir/Graph.h
+++ b/runtime/onert/core/include/ir/Graph.h
@@ -60,8 +60,8 @@ public:
   OperandIndex addOperand(const Shape &shape, const TypeInfo &type);
   OperationIndex addOperation(std::unique_ptr<Operation> &&node);
   void setOperandValue(const OperandIndex &ind, std::shared_ptr<Data> data);
-  void addInput(const OperandIndex &ind);
-  void addOutput(const OperandIndex &ind);
+  void addInput(const OperandIndex &ind, const std::string &name = "");
+  void addOutput(const OperandIndex &ind, const std::string &name = "");
   void finishBuilding(void);
   void removeOperand(const OperandIndex &ind) { _operands.remove(ind); }
   bool isBuildingPhase(void) const { return _phase == Phase::BUILDING; }
@@ -94,6 +94,8 @@ public:
   OperandIndexSequence &getInputs() { return _inputs; }
   const OperandIndexSequence &getOutputs() const { return _outputs; }
   OperandIndexSequence &getOutputs() { return _outputs; }
+  IOIndex getInputIndex(const std::string &name) const;
+  IOIndex getOutputIndex(const std::string &name) const;
   const Operands &operands() const { return _operands; }
   Operands &operands() { return _operands; } // TODO Remove this non-const accessor
   const Operations &operations() const { return _operations; }
@@ -108,6 +110,8 @@ private:
   Operands _operands;
   OperandIndexSequence _inputs;
   OperandIndexSequence _outputs;
+  std::unordered_map<std::string, IOIndex> _name_to_input;
+  std::unordered_map<std::string, IOIndex> _name_to_output;
   // Child subgraphs
   std::shared_ptr<Subgraphs> _subgraphs;
   // TFLite and circle's default layout is NHWC;

--- a/runtime/onert/core/src/ir/Graph.cc
+++ b/runtime/onert/core/src/ir/Graph.cc
@@ -56,16 +56,32 @@ void Graph::setOperandValue(const OperandIndex &ind, std::shared_ptr<Data> data)
   _operands.at(ind).data(std::move(data));
 }
 
-void Graph::addInput(const OperandIndex &ind)
+void Graph::addInput(const OperandIndex &ind, const std::string &name)
 {
   assert(isBuildingPhase());
+  if (!name.empty())
+    _name_to_input.emplace(name, IOIndex{_inputs.size()});
   _inputs.append(ind);
 }
 
-void Graph::addOutput(const OperandIndex &ind)
+void Graph::addOutput(const OperandIndex &ind, const std::string &name)
 {
   assert(isBuildingPhase());
+  if (!name.empty())
+    _name_to_output.emplace(name, IOIndex{_outputs.size()});
   _outputs.append(ind);
+}
+
+IOIndex Graph::getInputIndex(const std::string &name) const
+{
+  auto itr = _name_to_input.find(name);
+  return (itr == _name_to_input.end()) ? IOIndex{} : itr->second;
+}
+
+IOIndex Graph::getOutputIndex(const std::string &name) const
+{
+  auto itr = _name_to_output.find(name);
+  return (itr == _name_to_output.end()) ? IOIndex{} : itr->second;
 }
 
 void Graph::finishBuilding(void)

--- a/runtime/onert/frontend/base_loader/include/base_loader.h
+++ b/runtime/onert/frontend/base_loader/include/base_loader.h
@@ -193,6 +193,7 @@ protected:
   const Model *_model;
   // Maps Tensor indices to onert Operands.
   std::vector<ir::OperandIndex> _tensor_to_operand;
+  std::unordered_map<ir::OperandIndex, std::string> _tensor_names;
   // Verifier
   std::unique_ptr<Verifier> _verifier;
 };
@@ -450,8 +451,8 @@ ir::OperandIndex BaseLoader<LoaderDomain, SpecificLoader>::loadOperand(const Ten
     subg.setOperandValue(operand_index, std::move(data_obj));
   }
 
-  // Name unused
-  // auto name = tensor->name();
+  _tensor_names.emplace(operand_index, tensor->name()->str());
+
   // Variablie
   if (tensor->is_variable())
     throw std::runtime_error("Variable tensor not supported!");

--- a/runtime/onert/frontend/circle/src/circle_loader.cc
+++ b/runtime/onert/frontend/circle/src/circle_loader.cc
@@ -103,12 +103,14 @@ public:
     // Set inputs
     for (const std::int32_t input_ind : *circle_subg->inputs())
     {
-      subg->addInput(tensorIdxToOperandIdx(input_ind));
+      subg->addInput(tensorIdxToOperandIdx(input_ind),
+                     _tensor_names.at(_tensor_to_operand[input_ind]));
     }
     // Set outputs
     for (const std::int32_t output_ind : *circle_subg->outputs())
     {
-      subg->addOutput(tensorIdxToOperandIdx(output_ind));
+      subg->addOutput(tensorIdxToOperandIdx(output_ind),
+                      _tensor_names.at(_tensor_to_operand[output_ind]));
     }
     // Create operations
     for (const auto *op : *circle_subg->operators())

--- a/runtime/onert/frontend/tflite/src/tflite_loader.cc
+++ b/runtime/onert/frontend/tflite/src/tflite_loader.cc
@@ -90,12 +90,14 @@ public:
     // Set inputs
     for (const std::int32_t input_ind : *tflite_subg->inputs())
     {
-      subg->addInput(tensorIdxToOperandIdx(input_ind));
+      subg->addInput(tensorIdxToOperandIdx(input_ind),
+                     _tensor_names.at(_tensor_to_operand[input_ind]));
     }
     // Set outputs
     for (const std::int32_t output_ind : *tflite_subg->outputs())
     {
-      subg->addOutput(tensorIdxToOperandIdx(output_ind));
+      subg->addOutput(tensorIdxToOperandIdx(output_ind),
+                      _tensor_names.at(_tensor_to_operand[output_ind]));
     }
     // Create operations
     for (const auto *op : *tflite_subg->operators())

--- a/tests/nnfw_api/src/ValidationTestAddModelLoaded.cc
+++ b/tests/nnfw_api/src/ValidationTestAddModelLoaded.cc
@@ -48,6 +48,17 @@ TEST_F(ValidationTestAddModelLoaded, output_tensorinfo)
   ASSERT_EQ(tensor_info.dims[0], 1);
 }
 
+TEST_F(ValidationTestAddModelLoaded, input_output_tensorindex)
+{
+  uint32_t in_ind = 100;
+  NNFW_ENSURE_SUCCESS(nnfw_input_tensorindex(_session, "X_input", &in_ind));
+  ASSERT_EQ(in_ind, 0);
+
+  uint32_t out_ind = 100;
+  NNFW_ENSURE_SUCCESS(nnfw_output_tensorindex(_session, "ADD_TOP", &out_ind));
+  ASSERT_EQ(out_ind, 0);
+}
+
 TEST_F(ValidationTestAddModelLoaded, neg_run)
 {
   // nnfw_prepare is not called
@@ -90,4 +101,17 @@ TEST_F(ValidationTestAddModelLoaded, neg_output_tensorinfo)
 {
   // tensor_info is null
   ASSERT_EQ(nnfw_output_tensorinfo(_session, 0, nullptr), NNFW_STATUS_UNEXPECTED_NULL);
+}
+
+TEST_F(ValidationTestAddModelLoaded, neg_input_output_tensorindex)
+{
+  uint32_t in_ind = 100;
+  ASSERT_EQ(nnfw_input_tensorindex(_session, "ADD_TOP", &in_ind), NNFW_STATUS_ERROR);
+  ASSERT_EQ(in_ind, 100);
+  ASSERT_EQ(nnfw_input_tensorindex(_session, "y_var", &in_ind), NNFW_STATUS_ERROR);
+  ASSERT_EQ(in_ind, 100);
+
+  uint32_t out_ind = 100;
+  ASSERT_EQ(nnfw_output_tensorindex(_session, "X_input", &out_ind), NNFW_STATUS_ERROR);
+  ASSERT_EQ(out_ind, 100);
 }

--- a/tests/nnfw_api/src/fixtures.h
+++ b/tests/nnfw_api/src/fixtures.h
@@ -19,7 +19,7 @@
 
 #include <array>
 #include <gtest/gtest.h>
-#include <nnfw.h>
+#include <nnfw_experimental.h>
 
 #include "NNPackages.h"
 


### PR DESCRIPTION
Introduce and implement getting input/output tensor number with name.

- Introduce two functions to `nnfw_experimental.h`
    - `nnfw_input_tensorindex`
    - `nnfw_output_tensorindex`
- base_loader loads tensor names
- Store I/O operand names in Graph

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>