### PR TITLE
[nnfwapi] Test: Use NNFW_ENSURE_SUCCESS macro

### DIFF
--- a/tests/nnfw_api/src/GenModelTests.cc
+++ b/tests/nnfw_api/src/GenModelTests.cc
@@ -34,22 +34,22 @@
 class GenModelTest : public ::testing::Test
 {
 protected:
-  void SetUp() override { NNFW_ENSURE_CALL(nnfw_create_session(&_so.session)); }
+  void SetUp() override { NNFW_ENSURE_SUCCESS(nnfw_create_session(&_so.session)); }
 
   void TearDown() override
   {
-    NNFW_ENSURE_CALL(nnfw_load_circle_from_buffer(_so.session, _cbuf.buffer(), _cbuf.size()));
-    NNFW_ENSURE_CALL(nnfw_prepare(_so.session));
+    NNFW_ENSURE_SUCCESS(nnfw_load_circle_from_buffer(_so.session, _cbuf.buffer(), _cbuf.size()));
+    NNFW_ENSURE_SUCCESS(nnfw_prepare(_so.session));
 
     // In/Out buffer settings
     {
       uint32_t num_inputs;
-      NNFW_ENSURE_CALL(nnfw_input_size(_so.session, &num_inputs));
+      NNFW_ENSURE_SUCCESS(nnfw_input_size(_so.session, &num_inputs));
       _so.inputs.resize(num_inputs);
       for (uint32_t ind = 0; ind < _so.inputs.size(); ind++)
       {
         nnfw_tensorinfo ti;
-        NNFW_ENSURE_CALL(nnfw_input_tensorinfo(_so.session, ind, &ti));
+        NNFW_ENSURE_SUCCESS(nnfw_input_tensorinfo(_so.session, ind, &ti));
         uint64_t input_elements = num_elems(&ti);
         _so.inputs[ind].resize(input_elements);
 
@@ -59,12 +59,12 @@ protected:
       }
 
       uint32_t num_outputs;
-      NNFW_ENSURE_CALL(nnfw_output_size(_so.session, &num_outputs));
+      NNFW_ENSURE_SUCCESS(nnfw_output_size(_so.session, &num_outputs));
       _so.outputs.resize(num_outputs);
       for (uint32_t ind = 0; ind < _so.outputs.size(); ind++)
       {
         nnfw_tensorinfo ti;
-        NNFW_ENSURE_CALL(nnfw_output_tensorinfo(_so.session, ind, &ti));
+        NNFW_ENSURE_SUCCESS(nnfw_output_tensorinfo(_so.session, ind, &ti));
         uint64_t output_elements = num_elems(&ti);
         _so.outputs[ind].resize(output_elements);
         ASSERT_EQ(nnfw_set_output(_so.session, ind, ti.dtype, _so.outputs[ind].data(),
@@ -83,7 +83,7 @@ protected:
         memcpy(_so.inputs[i].data(), _ref_inputs[i].data(), _so.inputs[i].size() * sizeof(float));
       }
 
-      NNFW_ENSURE_CALL(nnfw_run(_so.session));
+      NNFW_ENSURE_SUCCESS(nnfw_run(_so.session));
 
       ASSERT_EQ(_so.outputs.size(), _ref_outputs.size());
       for (uint32_t i = 0; i < _so.outputs.size(); i++)
@@ -97,7 +97,7 @@ protected:
       }
     }
 
-    NNFW_ENSURE_CALL(nnfw_close_session(_so.session));
+    NNFW_ENSURE_SUCCESS(nnfw_close_session(_so.session));
   }
 
 protected:

--- a/tests/nnfw_api/src/ModelTestDynamicTensor.cc
+++ b/tests/nnfw_api/src/ModelTestDynamicTensor.cc
@@ -67,22 +67,22 @@ protected:
   {
     NNFW_STATUS res = nnfw_set_input(_session, 0, NNFW_TYPE_TENSOR_INT32, new_shape.data(),
                                      sizeof(int) * new_shape.size());
-    ASSERT_EQ(res, NNFW_STATUS_NO_ERROR);
+    NNFW_ENSURE_SUCCESS(res);
 
     res = nnfw_set_output(_session, 0, NNFW_TYPE_TENSOR_FLOAT32, actual_output->data(),
                           sizeof(float) * actual_output_size);
-    ASSERT_EQ(res, NNFW_STATUS_NO_ERROR);
+    NNFW_ENSURE_SUCCESS(res);
   }
 
   void prepare_and_set_input_output(const std::vector<int> &new_shape, int actual_output_size,
                                     std::vector<float> *actual_output)
   {
-    ASSERT_EQ(nnfw_set_available_backends(_session, "cpu"), NNFW_STATUS_NO_ERROR);
+    NNFW_ENSURE_SUCCESS(nnfw_set_available_backends(_session, "cpu"));
 
     NNFW_STATUS res = NNFW_STATUS_ERROR;
 
     res = nnfw_prepare(_session);
-    ASSERT_EQ(res, NNFW_STATUS_NO_ERROR);
+    NNFW_ENSURE_SUCCESS(res);
 
     set_input_output(new_shape, actual_output_size, actual_output);
     // real test case should start from calling nnfw_run()
@@ -102,11 +102,11 @@ protected:
 
     if (no_run_error)
     {
-      ASSERT_EQ(res, NNFW_STATUS_NO_ERROR);
+      NNFW_ENSURE_SUCCESS(res);
 
       // output shape check
       nnfw_tensorinfo info;
-      ASSERT_EQ(nnfw_output_tensorinfo(_session, 0, &info), NNFW_STATUS_NO_ERROR);
+      NNFW_ENSURE_SUCCESS(nnfw_output_tensorinfo(_session, 0, &info));
       ASSERT_EQ(info.rank, new_shape.size());
       for (uint32_t d = 0; d < info.rank; ++d)
         ASSERT_EQ(info.dims[d], new_shape[d]);
@@ -137,7 +137,7 @@ TEST_F(TestDynamicTensorReshapeModelLoaded, reshape_to_3x2)
 
   // Do inference
   NNFW_STATUS res = nnfw_run(_session);
-  ASSERT_EQ(res, NNFW_STATUS_NO_ERROR);
+  NNFW_ENSURE_SUCCESS(res);
 
   // output value check
   for (int i = 0; i < expected.size(); ++i)
@@ -163,10 +163,10 @@ TEST_F(TestDynamicTensorReshapeModelLoaded, neg_reshape_to_wrong_3x3)
 
 TEST_F(TestDynamicTensorReshapeModelLoaded, reshape_multiple_executions)
 {
-  ASSERT_EQ(nnfw_set_available_backends(_session, "cpu"), NNFW_STATUS_NO_ERROR);
+  NNFW_ENSURE_SUCCESS(nnfw_set_available_backends(_session, "cpu"));
 
   NNFW_STATUS res = nnfw_prepare(_session);
-  ASSERT_EQ(res, NNFW_STATUS_NO_ERROR);
+  NNFW_ENSURE_SUCCESS(res);
 
   std::vector<int> new_shape;
   std::vector<float> expected = {-1.5, -1.0, -0.5, 0.5, 1.0, 1.5};
@@ -184,10 +184,10 @@ TEST_F(TestDynamicTensorReshapeModelLoaded, reshape_multiple_executions)
 
 TEST_F(TestDynamicTensorReshapeModelLoaded, neg_reshape_multiple_executions)
 {
-  ASSERT_EQ(nnfw_set_available_backends(_session, "cpu"), NNFW_STATUS_NO_ERROR);
+  NNFW_ENSURE_SUCCESS(nnfw_set_available_backends(_session, "cpu"));
 
   NNFW_STATUS res = nnfw_prepare(_session);
-  ASSERT_EQ(res, NNFW_STATUS_NO_ERROR);
+  NNFW_ENSURE_SUCCESS(res);
 
   std::vector<int> new_shape;
   std::vector<float> expected = {-1.5, -1.0, -0.5, 0.5, 1.0, 1.5};
@@ -217,8 +217,8 @@ protected:
                                       const std::vector<float> &input1,
                                       std::vector<float> *actual_output, nnfw_tensorinfo input0_ti)
   {
-    ASSERT_EQ(nnfw_prepare(_session), NNFW_STATUS_NO_ERROR);
-    ASSERT_EQ(nnfw_set_input_tensorinfo(_session, 0, &input0_ti), NNFW_STATUS_NO_ERROR);
+    NNFW_ENSURE_SUCCESS(nnfw_prepare(_session));
+    NNFW_ENSURE_SUCCESS(nnfw_set_input_tensorinfo(_session, 0, &input0_ti));
 
     ASSERT_EQ(nnfw_set_input(_session, 0, NNFW_TYPE_TENSOR_FLOAT32, input0.data(),
                              sizeof(float) * input0.size()),
@@ -250,7 +250,7 @@ protected:
  */
 TEST_F(TestInputUnknownDimInputConcatModelLoaded, concat_input0_to_2x3)
 {
-  ASSERT_EQ(nnfw_set_available_backends(_session, "cpu"), NNFW_STATUS_NO_ERROR);
+  NNFW_ENSURE_SUCCESS(nnfw_set_available_backends(_session, "cpu"));
 
   const std::vector<float> input0 = {1, 2, 3};          // of shape [1, 3]
   const std::vector<float> input1 = {4, 5, 6, 7, 8, 9}; // of shape [2, 3]
@@ -260,14 +260,14 @@ TEST_F(TestInputUnknownDimInputConcatModelLoaded, concat_input0_to_2x3)
 
   // input reshaping to [1, 3]
   nnfw_tensorinfo ti = {NNFW_TYPE_TENSOR_FLOAT32, 2, {1, 3}};
-  ASSERT_EQ(nnfw_set_input_tensorinfo(_session, 0, &ti), NNFW_STATUS_NO_ERROR);
-  ASSERT_EQ(nnfw_prepare(_session), NNFW_STATUS_NO_ERROR);
+  NNFW_ENSURE_SUCCESS(nnfw_set_input_tensorinfo(_session, 0, &ti));
+  NNFW_ENSURE_SUCCESS(nnfw_prepare(_session));
 
   set_input_output(_session, input0, input1, actual_output);
 
   // Do inference
   NNFW_STATUS res = nnfw_run(_session);
-  ASSERT_EQ(res, NNFW_STATUS_NO_ERROR);
+  NNFW_ENSURE_SUCCESS(res);
 
   // output value check
   for (int i = 0; i < expected.size(); ++i)
@@ -291,7 +291,7 @@ TEST_F(TestInputUnknownDimInputConcatModelLoaded, concat_input0_to_2x3)
  */
 TEST_F(TestInputUnknownDimInputConcatModelLoaded, neg_concat_input0_to_wrong_shape)
 {
-  ASSERT_EQ(nnfw_set_available_backends(_session, "cpu"), NNFW_STATUS_NO_ERROR);
+  NNFW_ENSURE_SUCCESS(nnfw_set_available_backends(_session, "cpu"));
 
   const std::vector<float> input0 = {1, 2, 3};          // of shape [3, 1], wrong shape
   const std::vector<float> input1 = {4, 5, 6, 7, 8, 9}; // of shape [2, 3]
@@ -300,7 +300,7 @@ TEST_F(TestInputUnknownDimInputConcatModelLoaded, neg_concat_input0_to_wrong_sha
 
   // input reshaping to [3, 1]
   nnfw_tensorinfo ti = {NNFW_TYPE_TENSOR_FLOAT32, 2, {3, 1}};
-  ASSERT_EQ(nnfw_set_input_tensorinfo(_session, 0, &ti), NNFW_STATUS_NO_ERROR);
+  NNFW_ENSURE_SUCCESS(nnfw_set_input_tensorinfo(_session, 0, &ti));
 
   ASSERT_EQ(nnfw_prepare(_session), NNFW_STATUS_ERROR);
 }
@@ -330,7 +330,7 @@ using TestDynamicTensorApplyTensorInfoBinaryOp =
 
 TEST_F(TestDynamicTensorApplyTensorInfoBinaryOp, set_input_tensorinfo_after_compilation_add)
 {
-  ASSERT_EQ(nnfw_set_available_backends(_session, "cpu"), NNFW_STATUS_NO_ERROR);
+  NNFW_ENSURE_SUCCESS(nnfw_set_available_backends(_session, "cpu"));
 
   // input reshaping to [2, 2, 3]
   nnfw_tensorinfo input0_ti = {NNFW_TYPE_TENSOR_FLOAT32, 3, {2, 2, 3}};
@@ -341,15 +341,15 @@ TEST_F(TestDynamicTensorApplyTensorInfoBinaryOp, set_input_tensorinfo_after_comp
   std::vector<float> expected_output = {1.1 * 2, 2.1 * 2, 3.1 * 2, 4.1 * 2,  5.1 * 2,  6.1 * 2,
                                         7.1 * 2, 8.1 * 2, 9.1 * 2, 10.1 * 2, 11.1 * 2, 12.1 * 2};
 
-  ASSERT_EQ(nnfw_prepare(_session), NNFW_STATUS_NO_ERROR);
+  NNFW_ENSURE_SUCCESS(nnfw_prepare(_session));
 
-  ASSERT_EQ(nnfw_set_input_tensorinfo(_session, 0, &input0_ti), NNFW_STATUS_NO_ERROR);
+  NNFW_ENSURE_SUCCESS(nnfw_set_input_tensorinfo(_session, 0, &input0_ti));
 
   set_input_output(_session, input0, input1, actual_output);
 
   // Do inference
   NNFW_STATUS res = nnfw_run(_session);
-  ASSERT_EQ(res, NNFW_STATUS_NO_ERROR);
+  NNFW_ENSURE_SUCCESS(res);
 
   // output value check
   for (int i = 0; i < expected_output.size(); ++i)
@@ -374,7 +374,7 @@ using TestDynamicTensorApplyTensorInfoUnaryOp = ValidationTestModelLoaded<NNPack
 
 TEST_F(TestDynamicTensorApplyTensorInfoUnaryOp, set_input_tensorinfo_after_compilation_neg)
 {
-  ASSERT_EQ(nnfw_set_available_backends(_session, "cpu"), NNFW_STATUS_NO_ERROR);
+  NNFW_ENSURE_SUCCESS(nnfw_set_available_backends(_session, "cpu"));
 
   nnfw_tensorinfo input0_ti_original = {NNFW_TYPE_TENSOR_FLOAT32, 2, {4, 4}};
 
@@ -397,21 +397,21 @@ TEST_F(TestDynamicTensorApplyTensorInfoUnaryOp, set_input_tensorinfo_after_compi
     expected_output[i] = -1 * input0[i];
   }
 
-  ASSERT_EQ(nnfw_prepare(_session), NNFW_STATUS_NO_ERROR);
+  NNFW_ENSURE_SUCCESS(nnfw_prepare(_session));
 
   // input shape check
   {
     nnfw_tensorinfo ti = {};
-    ASSERT_EQ(nnfw_input_tensorinfo(_session, 0, &ti), NNFW_STATUS_NO_ERROR);
+    NNFW_ENSURE_SUCCESS(nnfw_input_tensorinfo(_session, 0, &ti));
     ASSERT_TRUE(tensorInfoEqual(input0_ti_original, ti));
   }
 
-  ASSERT_EQ(nnfw_set_input_tensorinfo(_session, 0, &input0_ti), NNFW_STATUS_NO_ERROR);
+  NNFW_ENSURE_SUCCESS(nnfw_set_input_tensorinfo(_session, 0, &input0_ti));
 
   // input shape check
   {
     nnfw_tensorinfo ti = {};
-    ASSERT_EQ(nnfw_input_tensorinfo(_session, 0, &ti), NNFW_STATUS_NO_ERROR);
+    NNFW_ENSURE_SUCCESS(nnfw_input_tensorinfo(_session, 0, &ti));
     ASSERT_TRUE(tensorInfoEqual(input0_ti, ti));
   }
 
@@ -419,7 +419,7 @@ TEST_F(TestDynamicTensorApplyTensorInfoUnaryOp, set_input_tensorinfo_after_compi
 
   // Do inference
   NNFW_STATUS res = nnfw_run(_session);
-  ASSERT_EQ(res, NNFW_STATUS_NO_ERROR);
+  NNFW_ENSURE_SUCCESS(res);
 
   // output value check
   for (int i = 0; i < expected_output.size(); ++i)
@@ -435,20 +435,20 @@ const static std::vector<float> while_dynamic_output0{ 0.0388205424, 0.042615629
 
 TEST_F(TestWhileDynamicModelLoaded, run_verify)
 {
-  ASSERT_EQ(nnfw_set_available_backends(_session, "cpu"), NNFW_STATUS_NO_ERROR);
-  ASSERT_EQ(nnfw_prepare(_session), NNFW_STATUS_NO_ERROR);
+  NNFW_ENSURE_SUCCESS(nnfw_set_available_backends(_session, "cpu"));
+  NNFW_ENSURE_SUCCESS(nnfw_prepare(_session));
 
   std::vector<float> actual_output0(10);
 
   nnfw_tensorinfo ti = {NNFW_TYPE_TENSOR_FLOAT32, 3, {1, 28, 28}};
-  ASSERT_EQ(nnfw_set_input_tensorinfo(_session, 0, &ti), NNFW_STATUS_NO_ERROR);
+  NNFW_ENSURE_SUCCESS(nnfw_set_input_tensorinfo(_session, 0, &ti));
 
   set_input_output(_session, while_dynamic_input0, actual_output0);
 
-  ASSERT_EQ(nnfw_run(_session), NNFW_STATUS_NO_ERROR);
+  NNFW_ENSURE_SUCCESS(nnfw_run(_session));
 
   nnfw_tensorinfo ti_output0_expected = {NNFW_TYPE_TENSOR_FLOAT32, 2, {1, 10}};
-  ASSERT_EQ(nnfw_output_tensorinfo(_session, 0, &ti), NNFW_STATUS_NO_ERROR);
+  NNFW_ENSURE_SUCCESS(nnfw_output_tensorinfo(_session, 0, &ti));
   ASSERT_TRUE(tensorInfoEqual(ti, ti_output0_expected));
 
   // output value check
@@ -458,11 +458,11 @@ TEST_F(TestWhileDynamicModelLoaded, run_verify)
 
 TEST_F(TestWhileDynamicModelLoaded, neg_run_verify)
 {
-  ASSERT_EQ(nnfw_set_available_backends(_session, "cpu"), NNFW_STATUS_NO_ERROR);
-  ASSERT_EQ(nnfw_prepare(_session), NNFW_STATUS_NO_ERROR);
+  NNFW_ENSURE_SUCCESS(nnfw_set_available_backends(_session, "cpu"));
+  NNFW_ENSURE_SUCCESS(nnfw_prepare(_session));
 
   nnfw_tensorinfo ti = {NNFW_TYPE_TENSOR_FLOAT32, 3, {1, 28, 28}};
-  ASSERT_EQ(nnfw_set_input_tensorinfo(_session, 0, &ti), NNFW_STATUS_NO_ERROR);
+  NNFW_ENSURE_SUCCESS(nnfw_set_input_tensorinfo(_session, 0, &ti));
 
   // Insufficient size of output (10 or more is sufficient)
   std::vector<float> actual_output0(9);
@@ -482,27 +482,27 @@ const static std::vector<float> if_dynamic_output0{ 0.0444660522, 0.0271649156, 
 
 TEST_F(TestIfDynamicModelLoaded, run_verify)
 {
-  ASSERT_EQ(nnfw_set_available_backends(_session, "cpu"), NNFW_STATUS_NO_ERROR);
-  ASSERT_EQ(nnfw_prepare(_session), NNFW_STATUS_NO_ERROR);
+  NNFW_ENSURE_SUCCESS(nnfw_set_available_backends(_session, "cpu"));
+  NNFW_ENSURE_SUCCESS(nnfw_prepare(_session));
 
   nnfw_tensorinfo ti_output0_expected = {NNFW_TYPE_TENSOR_FLOAT32, 2, {1, 10}};
 
   // Output tensor sizes are inferenced after `nnfw_prepare`
   {
     nnfw_tensorinfo ti;
-    ASSERT_EQ(nnfw_output_tensorinfo(_session, 0, &ti), NNFW_STATUS_NO_ERROR);
+    NNFW_ENSURE_SUCCESS(nnfw_output_tensorinfo(_session, 0, &ti));
     ASSERT_TRUE(tensorInfoEqual(ti, ti_output0_expected));
   }
 
   std::vector<float> actual_output0(10);
   set_input_output(_session, if_dynamic_input0, actual_output0);
 
-  ASSERT_EQ(nnfw_run(_session), NNFW_STATUS_NO_ERROR);
+  NNFW_ENSURE_SUCCESS(nnfw_run(_session));
 
   // Check output tensor sizes again
   {
     nnfw_tensorinfo ti;
-    ASSERT_EQ(nnfw_output_tensorinfo(_session, 0, &ti), NNFW_STATUS_NO_ERROR);
+    NNFW_ENSURE_SUCCESS(nnfw_output_tensorinfo(_session, 0, &ti));
     ASSERT_TRUE(tensorInfoEqual(ti, ti_output0_expected));
   }
 

--- a/tests/nnfw_api/src/ModelTestInputReshaping.cc
+++ b/tests/nnfw_api/src/ModelTestInputReshaping.cc
@@ -35,8 +35,8 @@ TEST_F(TestInputReshapingAddModelLoaded, reshaping_2x2_to_4x2)
 {
   NNFW_STATUS res = NNFW_STATUS_ERROR;
 
-  ASSERT_EQ(nnfw_set_available_backends(_session, "cpu"), NNFW_STATUS_NO_ERROR);
-  ASSERT_EQ(nnfw_set_config(_session, "EXECUTOR", "Linear"), NNFW_STATUS_NO_ERROR);
+  NNFW_ENSURE_SUCCESS(nnfw_set_available_backends(_session, "cpu"));
+  NNFW_ENSURE_SUCCESS(nnfw_set_config(_session, "EXECUTOR", "Linear"));
 
   // input and output values
   const std::vector<float> input1 = {0, 1, 2, 3, 4, 5, 6, 7}; // of changed shape [4, 2]
@@ -56,7 +56,7 @@ TEST_F(TestInputReshapingAddModelLoaded, reshaping_2x2_to_4x2)
   res = nnfw_set_input_tensorinfo(_session, 0, &ti);
 
   res = nnfw_prepare(_session);
-  ASSERT_EQ(res, NNFW_STATUS_NO_ERROR);
+  NNFW_ENSURE_SUCCESS(res);
 
   nnfw_tensorinfo ti_input = {}; // Static inference result will be stored
   nnfw_input_tensorinfo(_session, 0, &ti_input);
@@ -68,21 +68,21 @@ TEST_F(TestInputReshapingAddModelLoaded, reshaping_2x2_to_4x2)
 
   res = nnfw_set_input(_session, 0, NNFW_TYPE_TENSOR_FLOAT32, input1.data(),
                        sizeof(float) * input1.size());
-  ASSERT_EQ(res, NNFW_STATUS_NO_ERROR);
+  NNFW_ENSURE_SUCCESS(res);
   res = nnfw_set_input(_session, 1, NNFW_TYPE_TENSOR_FLOAT32, input2.data(),
                        sizeof(float) * input2.size());
-  ASSERT_EQ(res, NNFW_STATUS_NO_ERROR);
+  NNFW_ENSURE_SUCCESS(res);
 
   uint64_t output_num_elements = tensorInfoNumElements(ti_output);
   ASSERT_EQ(output_num_elements, expected.size());
   std::vector<float> actual_output(output_num_elements);
   res = nnfw_set_output(_session, 0, NNFW_TYPE_TENSOR_FLOAT32, actual_output.data(),
                         sizeof(float) * actual_output.size());
-  ASSERT_EQ(res, NNFW_STATUS_NO_ERROR);
+  NNFW_ENSURE_SUCCESS(res);
 
   // Do inference
   res = nnfw_run(_session);
-  ASSERT_EQ(res, NNFW_STATUS_NO_ERROR);
+  NNFW_ENSURE_SUCCESS(res);
 
   // compare
   for (int i = 0; i < expected.size(); ++i)

--- a/tests/nnfw_api/src/RegressionTests.cc
+++ b/tests/nnfw_api/src/RegressionTests.cc
@@ -22,17 +22,17 @@ TEST_F(RegressionTest, github_1535)
   auto package_path = NNPackages::get().getModelAbsolutePath(NNPackages::ADD);
 
   nnfw_session *session1 = nullptr;
-  ASSERT_EQ(nnfw_create_session(&session1), NNFW_STATUS_NO_ERROR);
-  ASSERT_EQ(nnfw_load_model_from_file(session1, package_path.c_str()), NNFW_STATUS_NO_ERROR);
-  ASSERT_EQ(nnfw_set_available_backends(session1, "cpu;acl_cl;acl_neon"), NNFW_STATUS_NO_ERROR);
-  ASSERT_EQ(nnfw_prepare(session1), NNFW_STATUS_NO_ERROR);
+  NNFW_ENSURE_SUCCESS(nnfw_create_session(&session1));
+  NNFW_ENSURE_SUCCESS(nnfw_load_model_from_file(session1, package_path.c_str()));
+  NNFW_ENSURE_SUCCESS(nnfw_set_available_backends(session1, "cpu;acl_cl;acl_neon"));
+  NNFW_ENSURE_SUCCESS(nnfw_prepare(session1));
 
   nnfw_session *session2 = nullptr;
-  ASSERT_EQ(nnfw_create_session(&session2), NNFW_STATUS_NO_ERROR);
-  ASSERT_EQ(nnfw_load_model_from_file(session2, package_path.c_str()), NNFW_STATUS_NO_ERROR);
-  ASSERT_EQ(nnfw_set_available_backends(session2, "cpu"), NNFW_STATUS_NO_ERROR);
-  ASSERT_EQ(nnfw_prepare(session2), NNFW_STATUS_NO_ERROR);
+  NNFW_ENSURE_SUCCESS(nnfw_create_session(&session2));
+  NNFW_ENSURE_SUCCESS(nnfw_load_model_from_file(session2, package_path.c_str()));
+  NNFW_ENSURE_SUCCESS(nnfw_set_available_backends(session2, "cpu"));
+  NNFW_ENSURE_SUCCESS(nnfw_prepare(session2));
 
-  ASSERT_EQ(nnfw_close_session(session1), NNFW_STATUS_NO_ERROR);
-  ASSERT_EQ(nnfw_close_session(session2), NNFW_STATUS_NO_ERROR);
+  NNFW_ENSURE_SUCCESS(nnfw_close_session(session1));
+  NNFW_ENSURE_SUCCESS(nnfw_close_session(session2));
 }

--- a/tests/nnfw_api/src/ValidationTestAddModelLoaded.cc
+++ b/tests/nnfw_api/src/ValidationTestAddModelLoaded.cc
@@ -19,34 +19,31 @@
 
 using ValidationTestAddModelLoaded = ValidationTestModelLoaded<NNPackages::ADD>;
 
-TEST_F(ValidationTestAddModelLoaded, prepare_001)
-{
-  ASSERT_EQ(nnfw_prepare(_session), NNFW_STATUS_NO_ERROR);
-}
+TEST_F(ValidationTestAddModelLoaded, prepare_001) { NNFW_ENSURE_SUCCESS(nnfw_prepare(_session)); }
 
 TEST_F(ValidationTestAddModelLoaded, set_available_backends_001)
 {
-  ASSERT_EQ(nnfw_set_available_backends(_session, "cpu"), NNFW_STATUS_NO_ERROR);
+  NNFW_ENSURE_SUCCESS(nnfw_set_available_backends(_session, "cpu"));
 }
 
 TEST_F(ValidationTestAddModelLoaded, get_input_size)
 {
   uint32_t size = 0;
-  ASSERT_EQ(nnfw_input_size(_session, &size), NNFW_STATUS_NO_ERROR);
+  NNFW_ENSURE_SUCCESS(nnfw_input_size(_session, &size));
   ASSERT_EQ(size, 1);
 }
 
 TEST_F(ValidationTestAddModelLoaded, get_output_size)
 {
   uint32_t size = 0;
-  ASSERT_EQ(nnfw_output_size(_session, &size), NNFW_STATUS_NO_ERROR);
+  NNFW_ENSURE_SUCCESS(nnfw_output_size(_session, &size));
   ASSERT_EQ(size, 1);
 }
 
 TEST_F(ValidationTestAddModelLoaded, output_tensorinfo)
 {
   nnfw_tensorinfo tensor_info;
-  ASSERT_EQ(nnfw_output_tensorinfo(_session, 0, &tensor_info), NNFW_STATUS_NO_ERROR);
+  NNFW_ENSURE_SUCCESS(nnfw_output_tensorinfo(_session, 0, &tensor_info));
   ASSERT_EQ(tensor_info.rank, 1);
   ASSERT_EQ(tensor_info.dims[0], 1);
 }

--- a/tests/nnfw_api/src/ValidationTestAddSessionPrepared.cc
+++ b/tests/nnfw_api/src/ValidationTestAddSessionPrepared.cc
@@ -23,7 +23,7 @@ TEST_F(ValidationTestAddSessionPrepared, run)
 {
   SetInOutBuffers();
   _input[0] = 3.0;
-  ASSERT_EQ(nnfw_run(_session), NNFW_STATUS_NO_ERROR);
+  NNFW_ENSURE_SUCCESS(nnfw_run(_session));
   ASSERT_FLOAT_EQ(_output[0], 5.0);
 }
 
@@ -31,11 +31,11 @@ TEST_F(ValidationTestAddSessionPrepared, run_twice)
 {
   SetInOutBuffers();
   _input[0] = 4.0;
-  ASSERT_EQ(nnfw_run(_session), NNFW_STATUS_NO_ERROR);
+  NNFW_ENSURE_SUCCESS(nnfw_run(_session));
   ASSERT_FLOAT_EQ(_output[0], 6.0);
 
   _input[0] = 5.0f;
-  ASSERT_EQ(nnfw_run(_session), NNFW_STATUS_NO_ERROR);
+  NNFW_ENSURE_SUCCESS(nnfw_run(_session));
   ASSERT_FLOAT_EQ(_output[0], 7.0);
 }
 
@@ -43,8 +43,8 @@ TEST_F(ValidationTestAddSessionPrepared, run_async)
 {
   SetInOutBuffers();
   _input[0] = 3.0;
-  ASSERT_EQ(nnfw_run_async(_session), NNFW_STATUS_NO_ERROR);
-  ASSERT_EQ(nnfw_await(_session), NNFW_STATUS_NO_ERROR);
+  NNFW_ENSURE_SUCCESS(nnfw_run_async(_session));
+  NNFW_ENSURE_SUCCESS(nnfw_await(_session));
   ASSERT_FLOAT_EQ(_output[0], 5.0);
 }
 
@@ -58,21 +58,21 @@ TEST_F(ValidationTestAddSessionPrepared, set_input_001)
 TEST_F(ValidationTestAddSessionPrepared, get_input_size)
 {
   uint32_t size = 0;
-  ASSERT_EQ(nnfw_input_size(_session, &size), NNFW_STATUS_NO_ERROR);
+  NNFW_ENSURE_SUCCESS(nnfw_input_size(_session, &size));
   ASSERT_EQ(size, 1);
 }
 
 TEST_F(ValidationTestAddSessionPrepared, get_output_size)
 {
   uint32_t size = 0;
-  ASSERT_EQ(nnfw_output_size(_session, &size), NNFW_STATUS_NO_ERROR);
+  NNFW_ENSURE_SUCCESS(nnfw_output_size(_session, &size));
   ASSERT_EQ(size, 1);
 }
 
 TEST_F(ValidationTestAddSessionPrepared, output_tensorinfo)
 {
   nnfw_tensorinfo tensor_info;
-  ASSERT_EQ(nnfw_output_tensorinfo(_session, 0, &tensor_info), NNFW_STATUS_NO_ERROR);
+  NNFW_ENSURE_SUCCESS(nnfw_output_tensorinfo(_session, 0, &tensor_info));
   ASSERT_EQ(tensor_info.rank, 1);
   ASSERT_EQ(tensor_info.dims[0], 1);
 }
@@ -86,24 +86,24 @@ TEST_F(ValidationTestAddSessionPrepared, neg_await_without_async_run)
 TEST_F(ValidationTestAddSessionPrepared, neg_await_after_sync_run)
 {
   SetInOutBuffers();
-  ASSERT_EQ(nnfw_run(_session), NNFW_STATUS_NO_ERROR);
+  NNFW_ENSURE_SUCCESS(nnfw_run(_session));
   ASSERT_EQ(nnfw_await(_session), NNFW_STATUS_ERROR);
 }
 
 TEST_F(ValidationTestAddSessionPrepared, neg_await_twice)
 {
   SetInOutBuffers();
-  ASSERT_EQ(nnfw_run_async(_session), NNFW_STATUS_NO_ERROR);
-  ASSERT_EQ(nnfw_await(_session), NNFW_STATUS_NO_ERROR);
+  NNFW_ENSURE_SUCCESS(nnfw_run_async(_session));
+  NNFW_ENSURE_SUCCESS(nnfw_await(_session));
   ASSERT_EQ(nnfw_await(_session), NNFW_STATUS_ERROR);
 }
 
 TEST_F(ValidationTestAddSessionPrepared, neg_run_during_async_run)
 {
   SetInOutBuffers();
-  ASSERT_EQ(nnfw_run_async(_session), NNFW_STATUS_NO_ERROR);
+  NNFW_ENSURE_SUCCESS(nnfw_run_async(_session));
   EXPECT_EQ(nnfw_run(_session), NNFW_STATUS_INVALID_STATE);
-  ASSERT_EQ(nnfw_await(_session), NNFW_STATUS_NO_ERROR);
+  NNFW_ENSURE_SUCCESS(nnfw_await(_session));
 }
 
 TEST_F(ValidationTestAddSessionPrepared, neg_set_input_001)

--- a/tests/nnfw_api/src/ValidationTestFourAddModelsSetInput.cc
+++ b/tests/nnfw_api/src/ValidationTestFourAddModelsSetInput.cc
@@ -21,8 +21,8 @@ using ValidationTestFourAddModelsSetInput = ValidationTestFourModelsSetInput<NNP
 
 TEST_F(ValidationTestFourAddModelsSetInput, run_001)
 {
-  ASSERT_EQ(nnfw_run(_objects[0].session), NNFW_STATUS_NO_ERROR);
-  ASSERT_EQ(nnfw_run(_objects[1].session), NNFW_STATUS_NO_ERROR);
+  NNFW_ENSURE_SUCCESS(nnfw_run(_objects[0].session));
+  NNFW_ENSURE_SUCCESS(nnfw_run(_objects[1].session));
 }
 
 TEST_F(ValidationTestFourAddModelsSetInput, run_002)
@@ -31,14 +31,14 @@ TEST_F(ValidationTestFourAddModelsSetInput, run_002)
   while (rep--)
   {
     for (auto obj : _objects)
-      ASSERT_EQ(nnfw_run(obj.session), NNFW_STATUS_NO_ERROR);
+      NNFW_ENSURE_SUCCESS(nnfw_run(obj.session));
   }
 }
 
 TEST_F(ValidationTestFourAddModelsSetInput, run_async)
 {
   for (auto obj : _objects)
-    ASSERT_EQ(nnfw_run_async(obj.session), NNFW_STATUS_NO_ERROR);
+    NNFW_ENSURE_SUCCESS(nnfw_run_async(obj.session));
   for (auto obj : _objects)
-    ASSERT_EQ(nnfw_await(obj.session), NNFW_STATUS_NO_ERROR);
+    NNFW_ENSURE_SUCCESS(nnfw_await(obj.session));
 }

--- a/tests/nnfw_api/src/ValidationTestSessionCreated.cc
+++ b/tests/nnfw_api/src/ValidationTestSessionCreated.cc
@@ -27,8 +27,8 @@ TEST_F(ValidationTestSessionCreated, load_session_001)
 
 TEST_F(ValidationTestSessionCreated, close_and_create_again)
 {
-  ASSERT_EQ(nnfw_close_session(_session), NNFW_STATUS_NO_ERROR);
-  ASSERT_EQ(nnfw_create_session(&_session), NNFW_STATUS_NO_ERROR);
+  NNFW_ENSURE_SUCCESS(nnfw_close_session(_session));
+  NNFW_ENSURE_SUCCESS(nnfw_create_session(&_session));
 }
 
 TEST_F(ValidationTestSessionCreated, neg_load_session_1)

--- a/tests/nnfw_api/src/ValidationTestSingleSession.cc
+++ b/tests/nnfw_api/src/ValidationTestSingleSession.cc
@@ -19,14 +19,14 @@
 
 TEST_F(ValidationTestSingleSession, create_001)
 {
-  ASSERT_EQ(nnfw_create_session(&_session), NNFW_STATUS_NO_ERROR);
-  ASSERT_EQ(nnfw_close_session(_session), NNFW_STATUS_NO_ERROR);
+  NNFW_ENSURE_SUCCESS(nnfw_create_session(&_session));
+  NNFW_ENSURE_SUCCESS(nnfw_close_session(_session));
 }
 
 TEST_F(ValidationTestSingleSession, query_info_u32)
 {
   uint32_t val = 0;
-  ASSERT_EQ(nnfw_query_info_u32(nullptr, NNFW_INFO_ID_VERSION, &val), NNFW_STATUS_NO_ERROR);
+  NNFW_ENSURE_SUCCESS(nnfw_query_info_u32(nullptr, NNFW_INFO_ID_VERSION, &val));
 }
 
 TEST_F(ValidationTestSingleSession, neg_create_001)

--- a/tests/nnfw_api/src/fixtures.h
+++ b/tests/nnfw_api/src/fixtures.h
@@ -23,7 +23,7 @@
 
 #include "NNPackages.h"
 
-#define NNFW_ENSURE_CALL(EXPR) ASSERT_EQ((EXPR), NNFW_STATUS_NO_ERROR)
+#define NNFW_ENSURE_SUCCESS(EXPR) ASSERT_EQ((EXPR), NNFW_STATUS_NO_ERROR)
 
 inline uint64_t num_elems(const nnfw_tensorinfo *ti)
 {


### PR DESCRIPTION
As the pattern `ASSERT_EQ(???, NNFW_STATUS_NO_ERROR)` is used often,
let's use a macro for that which is more readable and shorter.

- Rename NNFW_ENSURE_CALL to NNFW_ENSURE_SUCCESS
- Replace all `ASSERT_EQ(???, NNFW_STATUS_NO_ERROR)` to
  `NNFW_ENSURE_CALL(???)`

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>