### PR TITLE
[luci-interpreter]Negative Tests for ArgMax kernel

### DIFF
--- a/compiler/luci-interpreter/src/kernels/ArgMax.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/ArgMax.test.cpp
@@ -93,6 +93,21 @@ TYPED_TEST(ArgMaxTest, MultiDimensions)
                             /*dimension_data=*/{3}, /*output_data=*/{3, 1});
 }
 
+TEST(ArgMaxTest, UnsupportedType)
+{
+  Tensor input_tensor = makeInputTensor<DataType::FLOAT32>({1, 1, 2, 4}, {
+                                                                             1, 2, 7, 8, 1, 9, 7, 3,
+                                                                         });
+  Tensor dimension_tensor = makeInputTensor<DataType::S32>({}, {3});
+  Tensor output_tensor = makeOutputTensor(DataType::U8);
+
+  ArgMaxParams params{};
+  params.output_type = DataType::U8;
+  ArgMax kernel(&input_tensor, &dimension_tensor, &output_tensor, params);
+  kernel.configure();
+  EXPECT_ANY_THROW(kernel.execute());
+}
+
 } // namespace
 } // namespace kernels
 } // namespace luci_interpreter

--- a/compiler/luci-interpreter/src/kernels/ArgMax.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/ArgMax.test.cpp
@@ -93,7 +93,7 @@ TYPED_TEST(ArgMaxTest, MultiDimensions)
                             /*dimension_data=*/{3}, /*output_data=*/{3, 1});
 }
 
-TEST(ArgMaxTest, UnsupportedType)
+TEST(ArgMaxTest, UnsupportedType_NEG)
 {
   Tensor input_tensor = makeInputTensor<DataType::FLOAT32>({1, 1, 2, 4}, {
                                                                              1, 2, 7, 8, 1, 9, 7, 3,


### PR DESCRIPTION
For #1623

This commit add negative tests on `ArgMax` kernel on luci-interpreter.

ONE-DCO-1.0-Signed-off-by: KiDeuk Bang <rrstrous@nate.com>