### PR TITLE
[res/TensorFlowLiteRecipes] Add Tanh_U8_000

### DIFF
--- a/res/TensorFlowLiteRecipes/Tanh_U8_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/Tanh_U8_000/test.recipe
@@ -1,0 +1,19 @@
+operand {
+  name: "ifm"
+  type: UINT8
+  shape { dim: 1 dim: 3 dim: 3 dim: 2 }
+  quant { min: 0 max: 2 scale: 0.0078125 zero_point: 0 }
+}
+operand {
+  name: "ofm"
+  type: UINT8
+  shape { dim: 1 dim: 3 dim: 3 dim: 2 }
+  quant { min: 0 max: 2 scale: 0.0078125 zero_point: 0 }
+}
+operation {
+  type: "Tanh"
+  input: "ifm"
+  output: "ofm"
+}
+input: "ifm"
+output: "ofm"


### PR DESCRIPTION
Parent Issue: #1880 
Fired Issue: #3592 

This series of commits are for allowing importing quantized tanh.
These commits have been tested on my PC,
and worked well by passing ./nncc build & ./nncc test.

Added `Tanh_U8_000` recipe under directory `res/TensorFlowLiteRecipe`.

PR will be separated in 4 pieces:
- [luci] changes (#3614) (DONE)
- [luci-interpreter] changes (#3622) (DONE)
- [res/TensorFlowLiteRecipe] Tanh U8 recipe (#3780) (Current)
- [luci/tests] Add read & write ops for tanh u8 testing.

This is the second part of those separated PRs.

Please review this PR, @seanshpark  .
I'll be happy to get feedback and change to make improvement.

Thank you.

(Derived from SOS Mine Project)

Signed-off-by: underflow101 <ikarus125@gmail.com>