### PR TITLE
[luci/export] Support NonMaxSuppressionV5 op

### DIFF
--- a/compiler/luci/export/src/CircleOperationExporter.cpp
+++ b/compiler/luci/export/src/CircleOperationExporter.cpp
@@ -103,6 +103,7 @@ public:
   void visit(luci::CircleMul *) final;
   void visit(luci::CircleNeg *) final;
   void visit(luci::CircleNonMaxSuppressionV4 *) final;
+  void visit(luci::CircleNonMaxSuppressionV5 *) final;
   void visit(luci::CircleNotEqual *) final;
   void visit(luci::CircleOneHot *) final;
   void visit(luci::CirclePack *) final;
@@ -169,6 +170,7 @@ public:
   void visit(luci::CircleCustomOut *) final {}
   void visit(luci::CircleIfOut *) final {}
   void visit(luci::CircleNonMaxSuppressionV4Out *) final {}
+  void visit(luci::CircleNonMaxSuppressionV5Out *) final {}
   void visit(luci::CircleSplitOut *) final {}
   void visit(luci::CircleSplitVOut *) final {}
   void visit(luci::CircleTopKV2Out *) final {}
@@ -738,6 +740,49 @@ void OperationExporter::visit(luci::CircleNonMaxSuppressionV4 *node)
   auto op_offset =
       CreateOperator(builder, op_idx, inputs, outputs,
                      circle::BuiltinOptions_NonMaxSuppressionV4Options, options.Union());
+  gd._operators.push_back(op_offset);
+}
+
+void OperationExporter::visit(luci::CircleNonMaxSuppressionV5 *node)
+{
+  auto nms_outs = loco::succs(node);
+  assert(nms_outs.size() == 3);
+
+  uint32_t op_idx =
+      md.registerBuiltinOpcode(circle::BuiltinOperator_NON_MAX_SUPPRESSION_V5, node->op_version());
+  std::vector<int32_t> inputs_vec{
+      get_tensor_index(node->boxes()),           get_tensor_index(node->scores()),
+      get_tensor_index(node->max_output_size()), get_tensor_index(node->iou_threshold()),
+      get_tensor_index(node->score_threshold()), get_tensor_index(node->soft_nms_sigma()),
+  };
+  std::vector<int32_t> outputs_vec;
+
+  for (uint32_t idx = 0; idx < nms_outs.size(); ++idx)
+  {
+    // store in order of index
+    bool found = false;
+    for (auto out : nms_outs)
+    {
+      auto nms_out = loco::must_cast<luci::CircleNonMaxSuppressionV5Out *>(out);
+      if (nms_out->index() == static_cast<int32_t>(idx))
+      {
+        outputs_vec.push_back(get_tensor_index(nms_out));
+        found = true;
+        break;
+      }
+    }
+    if (!found)
+    {
+      INTERNAL_EXN("Invalid NonMaxSuppressionV5 output");
+    }
+  }
+
+  auto inputs = builder.CreateVector(inputs_vec);
+  auto outputs = builder.CreateVector(outputs_vec);
+  auto options = CreateNonMaxSuppressionV5Options(builder);
+  auto op_offset =
+      CreateOperator(builder, op_idx, inputs, outputs,
+                     circle::BuiltinOptions_NonMaxSuppressionV5Options, options.Union());
   gd._operators.push_back(op_offset);
 }
 


### PR DESCRIPTION
Add support for NonMaxSuppressionV5 op in luci exporter.

ONE-DCO-1.0-Signed-off-by: Alexander Moiseev <a.moiseev@samsung.com>