### PR TITLE
[onert] filter optional tensor during checkDynamicInput

### DIFF
--- a/runtime/onert/core/src/compiler/StaticShapeInference.cc
+++ b/runtime/onert/core/src/compiler/StaticShapeInference.cc
@@ -64,7 +64,7 @@ bool StaticShapeInferer::infer(const ir::OpSequence &op_seq)
 
 bool StaticShapeInferer::checkDynamicInput(const ir::Operation &op)
 {
-  for (auto input_idx : op.getInputs())
+  for (auto input_idx : op.getInputs() | ir::Remove::UNDEFINED | ir::Remove::DUPLICATED)
   {
     if (_operands.at(input_idx).info().isDynamic())
     {


### PR DESCRIPTION
Operator may have index -1 for input tensor index (optional tensor).
It filters out -1 index to avoid `_Map_base::at`.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>