### PR TITLE
[onert] Fix weight deallocation to work on android (1.8.0 release)

### DIFF
--- a/runtime/onert/backend/cpu/ops/FullyConnectedLayer.cc
+++ b/runtime/onert/backend/cpu/ops/FullyConnectedLayer.cc
@@ -220,7 +220,7 @@ void FullyConnectedLayer::prepare()
     }
   }
 
-#if defined(__ARM_NEON__) && defined(USE_RUY_GEMV)
+#if (defined(__ARM_NEON__) || defined(__ARM_NEON)) && defined(USE_RUY_GEMV)
   // TODO This is workaround
   // The only fc hybrid will use ruy kernel
   if (_input->data_type() != OperandType::FLOAT32 ||


### PR DESCRIPTION
- Weight deallocation is enabled when `__ARM_NEON__` flag is exist
  - This flag is legacy and not supported on android
  - It is replaced by `__ARM_NEON`
- Use both `__ARM_NEON` and `__ARM_NEON__` flags to enable weight deallocation on android

ONE-DCO-1.0-Signed-off-by: JiHwan Yeo <jihwan.yeo@samsung.com>