### PR TITLE
[onert/test] Return void setInputsAndOutputs

### DIFF
--- a/tests/nnfw_api/src/CircleGen.cc
+++ b/tests/nnfw_api/src/CircleGen.cc
@@ -59,8 +59,7 @@ uint32_t CircleGen::addTensor(const TensorParams &params)
   return ind;
 }
 
-uint32_t CircleGen::setInputsAndOutputs(const std::vector<int> &inputs,
-                                        const std::vector<int> &outputs)
+void CircleGen::setInputsAndOutputs(const std::vector<int> &inputs, const std::vector<int> &outputs)
 {
   _inputs = inputs;
   _outputs = outputs;

--- a/tests/nnfw_api/src/CircleGen.h
+++ b/tests/nnfw_api/src/CircleGen.h
@@ -78,7 +78,7 @@ public:
   }
   uint32_t addBuffer(const uint8_t *buf, size_t size);
   uint32_t addTensor(const TensorParams &params);
-  uint32_t setInputsAndOutputs(const std::vector<int> &inputs, const std::vector<int> &outputs);
+  void setInputsAndOutputs(const std::vector<int> &inputs, const std::vector<int> &outputs);
   CircleBuffer finish();
 
   // ===== Add Operator methods begin =====


### PR DESCRIPTION
Fix CircleGen::setInputsAndOutputs() return type: return nothing

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>