### PR TITLE
[luci-interpreter]Negative Tests for Concatenation kernel

### DIFF
--- a/compiler/luci-interpreter/src/kernels/Concatenation.cpp
+++ b/compiler/luci-interpreter/src/kernels/Concatenation.cpp
@@ -36,23 +36,20 @@ Concatenation::Concatenation(std::vector<const Tensor *> inputs, Tensor *output,
 void Concatenation::configure()
 {
   const int num_inputs = _inputs.size();
-  assert(num_inputs > 0);
+  LUCI_INTERPRETER_CHECK(num_inputs > 0);
   const Tensor *t0 = _inputs[0];
 
   int axis = _params.axis;
   if (axis < 0)
     axis += t0->shape().num_dims();
-  if (axis < 0 || axis >= t0->shape().num_dims())
-  {
-    throw std::runtime_error("Axis value must be in range -(num_dims)<= axis < num_dims");
-  }
+  LUCI_INTERPRETER_CHECK(axis >= 0 && axis < t0->shape().num_dims());
 
   int32_t sum_axis = t0->shape().dim(axis);
   for (int i = 1; i < num_inputs; ++i)
   {
     const Tensor *tensor = _inputs[i];
-    assert(tensor->element_type() == t0->element_type());
-    assert(tensor->shape().num_dims() == t0->shape().num_dims());
+    LUCI_INTERPRETER_CHECK(tensor->element_type() == t0->element_type());
+    LUCI_INTERPRETER_CHECK(tensor->shape().num_dims() == t0->shape().num_dims());
     for (int d = 0; d < t0->shape().num_dims(); ++d)
     {
       if (d == axis)
@@ -61,7 +58,7 @@ void Concatenation::configure()
       }
       else
       {
-        assert(tensor->shape().dim(d) == t0->shape().dim(d));
+        LUCI_INTERPRETER_CHECK(tensor->shape().dim(d) == t0->shape().dim(d));
       }
     }
   }

--- a/compiler/luci-interpreter/src/kernels/Concatenation.cpp
+++ b/compiler/luci-interpreter/src/kernels/Concatenation.cpp
@@ -42,7 +42,10 @@ void Concatenation::configure()
   int axis = _params.axis;
   if (axis < 0)
     axis += t0->shape().num_dims();
-  assert(axis >= 0 && axis < t0->shape().num_dims());
+  if (axis < 0 || axis >= t0->shape().num_dims())
+  {
+    throw std::runtime_error("Axis value must be in range -(num_dims)<= axis < num_dims");
+  }
 
   int32_t sum_axis = t0->shape().dim(axis);
   for (int i = 1; i < num_inputs; ++i)

--- a/compiler/luci-interpreter/src/kernels/Concatenation.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/Concatenation.test.cpp
@@ -87,13 +87,10 @@ TEST(ConcatenationTest, Unsupported_Configure_Type_NEG)
   Tensor output_tensor = makeOutputTensor(DataType::S8);
   ConcatenationParams params{};
 
-  // Try different 'axis' and expect different results.
-  {
-    params.axis = -1;
+  params.axis = -1;
 
-    Concatenation kernel({&input1_tensor, &input2_tensor}, &output_tensor, params);
-    EXPECT_ANY_THROW(kernel.configure());
-  }
+  Concatenation kernel({&input1_tensor, &input2_tensor}, &output_tensor, params);
+  EXPECT_ANY_THROW(kernel.configure());
 }
 
 TEST(ConcatenationTest, Invalid_Axis_NEG)
@@ -105,13 +102,10 @@ TEST(ConcatenationTest, Invalid_Axis_NEG)
   Tensor output_tensor = makeOutputTensor(DataType::FLOAT32);
   ConcatenationParams params{};
 
-  // Try different 'axis' and expect different results.
-  {
-    params.axis = -3;
+  params.axis = -3;
 
-    Concatenation kernel({&input1_tensor, &input2_tensor}, &output_tensor, params);
-    EXPECT_ANY_THROW(kernel.configure());
-  }
+  Concatenation kernel({&input1_tensor, &input2_tensor}, &output_tensor, params);
+  EXPECT_ANY_THROW(kernel.configure());
 }
 
 } // namespace

--- a/compiler/luci-interpreter/src/kernels/Concatenation.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/Concatenation.test.cpp
@@ -96,22 +96,21 @@ TEST(ConcatenationTest, Unsupported_Configure_Type_NEG)
   }
 }
 
-TEST(ConcatenationTest, Unsupported_Execute_Type_NEG)
+TEST(ConcatenationTest, Invalid_Axis_NEG)
 {
-  std::vector<int16_t> input1_data{1, 2, 3, 4, 5, 6};
-  std::vector<int16_t> input2_data{7, 8, 9, 10, 11, 12};
-  Tensor input1_tensor = makeInputTensor<DataType::S16>({2, 3}, input1_data);
-  Tensor input2_tensor = makeInputTensor<DataType::S16>({2, 3}, input2_data);
-  Tensor output_tensor = makeOutputTensor(DataType::S16);
+  std::vector<float> input1_data{1, 2, 3, 4, 5, 6};
+  std::vector<float> input2_data{7, 8, 9, 10, 11, 12};
+  Tensor input1_tensor = makeInputTensor<DataType::FLOAT32>({2, 3}, input1_data);
+  Tensor input2_tensor = makeInputTensor<DataType::FLOAT32>({2, 3}, input2_data);
+  Tensor output_tensor = makeOutputTensor(DataType::FLOAT32);
   ConcatenationParams params{};
 
   // Try different 'axis' and expect different results.
   {
-    params.axis = -1;
+    params.axis = -3;
 
     Concatenation kernel({&input1_tensor, &input2_tensor}, &output_tensor, params);
-    kernel.configure();
-    EXPECT_ANY_THROW(kernel.execute());
+    EXPECT_ANY_THROW(kernel.configure());
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/Concatenation.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/Concatenation.test.cpp
@@ -78,6 +78,43 @@ TEST(ConcatenationTest, Float)
   }
 }
 
+TEST(ConcatenationTest, Unsupported_Configure_Type_NEG)
+{
+  std::vector<int8_t> input1_data{1, 2, 3, 4, 5, 6};
+  std::vector<int8_t> input2_data{7, 8, 9, 10, 11, 12};
+  Tensor input1_tensor = makeInputTensor<DataType::S8>({2, 3}, input1_data);
+  Tensor input2_tensor = makeInputTensor<DataType::S8>({2, 3}, input2_data);
+  Tensor output_tensor = makeOutputTensor(DataType::S8);
+  ConcatenationParams params{};
+
+  // Try different 'axis' and expect different results.
+  {
+    params.axis = -1;
+
+    Concatenation kernel({&input1_tensor, &input2_tensor}, &output_tensor, params);
+    EXPECT_ANY_THROW(kernel.configure());
+  }
+}
+
+TEST(ConcatenationTest, Unsupported_Execute_Type_NEG)
+{
+  std::vector<int16_t> input1_data{1, 2, 3, 4, 5, 6};
+  std::vector<int16_t> input2_data{7, 8, 9, 10, 11, 12};
+  Tensor input1_tensor = makeInputTensor<DataType::S16>({2, 3}, input1_data);
+  Tensor input2_tensor = makeInputTensor<DataType::S16>({2, 3}, input2_data);
+  Tensor output_tensor = makeOutputTensor(DataType::S16);
+  ConcatenationParams params{};
+
+  // Try different 'axis' and expect different results.
+  {
+    params.axis = -1;
+
+    Concatenation kernel({&input1_tensor, &input2_tensor}, &output_tensor, params);
+    kernel.configure();
+    EXPECT_ANY_THROW(kernel.execute());
+  }
+}
+
 } // namespace
 } // namespace kernels
 } // namespace luci_interpreter

--- a/compiler/luci-interpreter/src/kernels/Concatenation.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/Concatenation.test.cpp
@@ -78,18 +78,14 @@ TEST(ConcatenationTest, Float)
   }
 }
 
-TEST(ConcatenationTest, Unsupported_Configure_Type_NEG)
+TEST(ConcatenationTest, Input_Number_Check_NEG)
 {
-  std::vector<int8_t> input1_data{1, 2, 3, 4, 5, 6};
-  std::vector<int8_t> input2_data{7, 8, 9, 10, 11, 12};
-  Tensor input1_tensor = makeInputTensor<DataType::S8>({2, 3}, input1_data);
-  Tensor input2_tensor = makeInputTensor<DataType::S8>({2, 3}, input2_data);
-  Tensor output_tensor = makeOutputTensor(DataType::S8);
+  Tensor output_tensor = makeOutputTensor(DataType::FLOAT32);
   ConcatenationParams params{};
 
   params.axis = -1;
 
-  Concatenation kernel({&input1_tensor, &input2_tensor}, &output_tensor, params);
+  Concatenation kernel({}, &output_tensor, params);
   EXPECT_ANY_THROW(kernel.configure());
 }
 
@@ -103,6 +99,66 @@ TEST(ConcatenationTest, Invalid_Axis_NEG)
   ConcatenationParams params{};
 
   params.axis = -3;
+
+  Concatenation kernel({&input1_tensor, &input2_tensor}, &output_tensor, params);
+  EXPECT_ANY_THROW(kernel.configure());
+}
+
+TEST(ConcatenationTest, Mismatching_Input_Type_NEG)
+{
+  std::vector<float> input1_data{1, 2, 3, 4, 5, 6};
+  std::vector<uint8_t> input2_data{7, 8, 9, 10, 11, 12};
+  Tensor input1_tensor = makeInputTensor<DataType::FLOAT32>({2, 3}, input1_data);
+  Tensor input2_tensor = makeInputTensor<DataType::U8>({2, 3}, input2_data);
+  Tensor output_tensor = makeOutputTensor(DataType::FLOAT32);
+  ConcatenationParams params{};
+
+  params.axis = -1;
+
+  Concatenation kernel({&input1_tensor, &input2_tensor}, &output_tensor, params);
+  EXPECT_ANY_THROW(kernel.configure());
+}
+
+TEST(ConcatenationTest, Mismatching_Input_Dimension_Num_NEG)
+{
+  std::vector<float> input1_data{1, 2, 3, 4, 5, 6};
+  std::vector<float> input2_data{7, 8, 9, 10, 11, 12};
+  Tensor input1_tensor = makeInputTensor<DataType::FLOAT32>({2, 3}, input1_data);
+  Tensor input2_tensor = makeInputTensor<DataType::FLOAT32>({1, 2, 3}, input2_data);
+  Tensor output_tensor = makeOutputTensor(DataType::FLOAT32);
+  ConcatenationParams params{};
+
+  params.axis = -1;
+
+  Concatenation kernel({&input1_tensor, &input2_tensor}, &output_tensor, params);
+  EXPECT_ANY_THROW(kernel.configure());
+}
+
+TEST(ConcatenationTest, Mismatching_Input_Dimension_NEG)
+{
+  std::vector<float> input1_data{1, 2, 3, 4, 5, 6};
+  std::vector<float> input2_data{7, 8, 9, 10, 11, 12, 13, 14, 15};
+  Tensor input1_tensor = makeInputTensor<DataType::FLOAT32>({2, 3}, input1_data);
+  Tensor input2_tensor = makeInputTensor<DataType::FLOAT32>({3, 3}, input2_data);
+  Tensor output_tensor = makeOutputTensor(DataType::FLOAT32);
+  ConcatenationParams params{};
+
+  params.axis = -1;
+
+  Concatenation kernel({&input1_tensor, &input2_tensor}, &output_tensor, params);
+  EXPECT_ANY_THROW(kernel.configure());
+}
+
+TEST(ConcatenationTest, Unsupported_Configure_Type_NEG)
+{
+  std::vector<int8_t> input1_data{1, 2, 3, 4, 5, 6};
+  std::vector<int8_t> input2_data{7, 8, 9, 10, 11, 12};
+  Tensor input1_tensor = makeInputTensor<DataType::S8>({2, 3}, input1_data);
+  Tensor input2_tensor = makeInputTensor<DataType::S8>({2, 3}, input2_data);
+  Tensor output_tensor = makeOutputTensor(DataType::S8);
+  ConcatenationParams params{};
+
+  params.axis = -1;
 
   Concatenation kernel({&input1_tensor, &input2_tensor}, &output_tensor, params);
   EXPECT_ANY_THROW(kernel.configure());


### PR DESCRIPTION
For #1623 

This commit add negative tests on `Concatenation` kernel on luci-interpreter.

ONE-DCO-1.0-Signed-off-by: KiDeuk Bang <rrstrous@nate.com>