### PR TITLE
[tflite2circle] Add shape signature during conversion

### DIFF
--- a/compiler/tflite2circle/src/CircleModel.cpp
+++ b/compiler/tflite2circle/src/CircleModel.cpp
@@ -119,6 +119,15 @@ Offset<SubGraphLink>::Offset(FlatBufBuilder &fb, const TFLFlatBufVec *tflite_fla
       // is_variable
       bool is_variable = it->is_variable();
 
+      // shape signature
+      flatbuffers::Offset<flatbuffers::Vector<int32_t>> shape_signature;
+      if (it->shape_signature())
+      {
+        auto shape_signature_vec =
+            std::vector<int32_t>({it->shape_signature()->begin(), it->shape_signature()->end()});
+        shape_signature = fb->CreateVector(shape_signature_vec);
+      }
+
       circle::TensorBuilder tensor_builder{*fb};
       tensor_builder.add_shape(shape);
       tensor_builder.add_type(get_circle_tensortype(it->type()));
@@ -126,6 +135,7 @@ Offset<SubGraphLink>::Offset(FlatBufBuilder &fb, const TFLFlatBufVec *tflite_fla
       tensor_builder.add_name(name);
       tensor_builder.add_quantization(quantization);
       tensor_builder.add_is_variable(is_variable);
+      tensor_builder.add_shape_signature(shape_signature);
       auto tensor = tensor_builder.Finish();
       tensor_vec.emplace_back(tensor);
     }


### PR DESCRIPTION
Until now, `tflite2circle` didn't add shape_signature of TFLite model.
This commit will add shape_signature to circle model.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>