### PR TITLE
[onert] Remove method `TensorBuilder::iterate`

### DIFF
--- a/runtime/onert/backend/acl_common/AclTensorBuilder.h
+++ b/runtime/onert/backend/acl_common/AclTensorBuilder.h
@@ -70,7 +70,6 @@ public:
   void postFunctionPrepare() override;
 
   std::shared_ptr<ITensor> tensorAt(const ir::OperandIndex &ind) override;
-  void iterate(const IterateFunction &fn) override;
 
   std::unique_ptr<ITensorManager> releaseStaticTensorManager(void) override;
 
@@ -314,12 +313,6 @@ std::shared_ptr<ITensor>
 AclTensorBuilder<T_ITensor, T_Tensor, T_SubTensor>::tensorAt(const ir::OperandIndex &ind)
 {
   return _tensor_mgr->at(ind);
-}
-
-template <typename T_ITensor, typename T_Tensor, typename T_SubTensor>
-void AclTensorBuilder<T_ITensor, T_Tensor, T_SubTensor>::iterate(const IterateFunction &fn)
-{
-  _tensor_mgr->iterate(fn);
 }
 
 template <typename T_ITensor, typename T_Tensor, typename T_SubTensor>

--- a/runtime/onert/backend/cpu/TensorBuilder.cc
+++ b/runtime/onert/backend/cpu/TensorBuilder.cc
@@ -101,8 +101,6 @@ bool TensorBuilder::setMigrantTensor(const ir::OperandIndex &ind,
   return _tensor_reg->setMigrantTensor(ind, tensor);
 }
 
-void TensorBuilder::iterate(const IterateFunction &fn) { _static_tensor_mgr->iterate(fn); }
-
 std::shared_ptr<Tensor> TensorBuilder::at(const ir::OperandIndex &ind)
 {
   return _tensor_reg->getNativeTensor(ind);

--- a/runtime/onert/backend/cpu/TensorBuilder.h
+++ b/runtime/onert/backend/cpu/TensorBuilder.h
@@ -67,8 +67,6 @@ public:
    */
   std::shared_ptr<ITensor> tensorAt(const ir::OperandIndex &ind) override;
 
-  void iterate(const IterateFunction &fn) override;
-
   std::unique_ptr<ITensorManager> releaseStaticTensorManager(void) override;
 
   IDynamicTensorManager *dynamicTensorManager(void) override { return _dynamic_tensor_mgr.get(); }

--- a/runtime/onert/core/include/backend/ITensorBuilder.h
+++ b/runtime/onert/core/include/backend/ITensorBuilder.h
@@ -123,13 +123,6 @@ public: // methods for static tensor allocation
   }
 
   /**
-   * @brief Iterate over tensors
-   *
-   * @param fn The function to be run
-   */
-  virtual void iterate(const IterateFunction &fn) = 0;
-
-  /**
    * @brief Release static @c ITensorManger object which was built
    *        Before calling this, @c allocate must have been called
    *

--- a/runtime/onert/core/src/backend/controlflow/TensorBuilder.cc
+++ b/runtime/onert/core/src/backend/controlflow/TensorBuilder.cc
@@ -106,8 +106,6 @@ std::shared_ptr<ITensor> TensorBuilder::tensorAt(const ir::OperandIndex &ind)
   return _tensor_reg->getITensor(ind);
 }
 
-void TensorBuilder::iterate(const IterateFunction &fn) { _static_tensor_mgr->iterate(fn); }
-
 std::shared_ptr<cpu_common::Tensor> TensorBuilder::nativeOwnTensorAt(const ir::OperandIndex &ind)
 {
   return _tensor_reg->getNativeOwnTensor(ind);

--- a/runtime/onert/core/src/backend/controlflow/TensorBuilder.h
+++ b/runtime/onert/core/src/backend/controlflow/TensorBuilder.h
@@ -68,8 +68,6 @@ public:
    */
   std::shared_ptr<ITensor> tensorAt(const ir::OperandIndex &ind) override;
 
-  void iterate(const IterateFunction &fn) override;
-
   std::unique_ptr<ITensorManager> releaseStaticTensorManager(void) override;
 
   IDynamicTensorManager *dynamicTensorManager(void) override { return _dynamic_tensor_mgr.get(); }


### PR DESCRIPTION
Remove method `TensorBuilder::iterate` which is never used.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>