### PR TITLE
[luci-interpreter]Update to use Tensorflow 2.3.0 on luci-interpreter.

### DIFF
--- a/compiler/luci-interpreter/src/CMakeLists.txt
+++ b/compiler/luci-interpreter/src/CMakeLists.txt
@@ -1,6 +1,7 @@
-nnas_find_package(TensorFlowSource EXACT 2.1.0 QUIET)
-nnas_find_package(TensorFlowGEMMLowpSource EXACT 2.1.0 QUIET)
-nnas_find_package(TensorFlowEigenSource EXACT 2.1.0 QUIET)
+nnas_find_package(TensorFlowSource EXACT 2.3.0 QUIET)
+nnas_find_package(TensorFlowGEMMLowpSource EXACT 2.3.0 QUIET)
+nnas_find_package(TensorFlowEigenSource EXACT 2.3.0 QUIET)
+nnas_find_package(TensorFlowRuySource EXACT 2.3.0 QUIET)
 
 if (NOT TensorFlowSource_FOUND)
   message(STATUS "Skipping luci-interpreter: TensorFlow not found")
@@ -14,6 +15,11 @@ endif ()
 
 if (NOT TensorFlowEigenSource_FOUND)
   message(STATUS "Skipping luci-interpreter: Eigen not found")
+  return()
+endif ()
+
+if (NOT TensorFlowRuySource_FOUND)
+  message(STATUS "Skipping luci-interpreter: Ruy not found")
   return()
 endif ()
 

--- a/compiler/luci-interpreter/src/kernels/CMakeLists.txt
+++ b/compiler/luci-interpreter/src/kernels/CMakeLists.txt
@@ -63,7 +63,8 @@ set(SOURCES
     TransposeConv.h
     TransposeConv.cpp
     Unpack.h
-    Unpack.cpp)
+    Unpack.cpp
+    ${TensorFlowSource_DIR}/tensorflow/lite/kernels/internal/quantization_util.cc)
 
 list(APPEND SOURCES Utils.h Utils.cpp)
 
@@ -71,6 +72,7 @@ add_library(luci_interpreter_kernels STATIC ${SOURCES})
 set_target_properties(luci_interpreter_kernels PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_include_directories(luci_interpreter_kernels PUBLIC ${LUCI_INTERPRETER_SOURCE_DIR})
 target_include_directories(luci_interpreter_kernels SYSTEM PRIVATE
+    "${TensorFlowRuySource_DIR}"
     "${TensorFlowGEMMLowpSource_DIR}"
     "${TensorFlowEigenSource_DIR}"
     "${TensorFlowSource_DIR}")

--- a/compiler/luci-interpreter/src/kernels/CMakeLists.txt
+++ b/compiler/luci-interpreter/src/kernels/CMakeLists.txt
@@ -63,10 +63,9 @@ set(SOURCES
     TransposeConv.h
     TransposeConv.cpp
     Unpack.h
-    Unpack.cpp
-    ${TensorFlowSource_DIR}/tensorflow/lite/kernels/internal/quantization_util.cc)
+    Unpack.cpp)
 
-list(APPEND SOURCES Utils.h Utils.cpp)
+list(APPEND SOURCES Utils.h Utils.cpp ${TensorFlowSource_DIR}/tensorflow/lite/kernels/internal/quantization_util.cc)
 
 add_library(luci_interpreter_kernels STATIC ${SOURCES})
 set_target_properties(luci_interpreter_kernels PROPERTIES POSITION_INDEPENDENT_CODE ON)

--- a/compiler/luci-interpreter/src/kernels/LeakyRelu.h
+++ b/compiler/luci-interpreter/src/kernels/LeakyRelu.h
@@ -41,9 +41,10 @@ private:
   void evalQuantized() const;
 
 private:
-  uint8_t _q_alpha = 0;
-  int32_t _output_multiplier = 0;
-  int _output_shift = 0;
+  int32_t _output_multiplier_alpha = 0;
+  int _output_shift_alpha = 0;
+  int32_t _output_multiplier_identity = 0;
+  int _output_shift_identity = 0;
 };
 
 } // namespace kernels

--- a/compiler/luci-interpreter/src/kernels/Mul.cpp
+++ b/compiler/luci-interpreter/src/kernels/Mul.cpp
@@ -19,7 +19,8 @@
 
 #include "kernels/Utils.h"
 
-#include <tensorflow/lite/kernels/internal/reference/reference_ops.h>
+#include <tensorflow/lite/kernels/internal/optimized/optimized_ops.h>
+#include <tensorflow/lite/kernels/internal/reference/process_broadcast_shapes.h>
 
 #include <stdexcept>
 
@@ -66,13 +67,13 @@ void Mul::evalFloat() const
 
   if (need_broadcast)
   {
-    tflite::reference_ops::BroadcastMul4DSlow(
+    tflite::optimized_ops::BroadcastMul4DSlow(
         params, getTensorShape(input1()), getTensorData<float>(input1()), getTensorShape(input2()),
         getTensorData<float>(input2()), getTensorShape(output()), getTensorData<float>(output()));
   }
   else
   {
-    tflite::reference_ops::Mul(params, getTensorShape(input1()), getTensorData<float>(input1()),
+    tflite::optimized_ops::Mul(params, getTensorShape(input1()), getTensorData<float>(input1()),
                                getTensorShape(input2()), getTensorData<float>(input2()),
                                getTensorShape(output()), getTensorData<float>(output()));
   }

--- a/compiler/luci-interpreter/src/kernels/TransposeConv.cpp
+++ b/compiler/luci-interpreter/src/kernels/TransposeConv.cpp
@@ -30,8 +30,8 @@ namespace kernels
 {
 
 TransposeConv::TransposeConv(const Tensor *output_shape, const Tensor *filter, const Tensor *input,
-                             Tensor *output, const TransposeConvParams &params)
-    : KernelWithParams<TransposeConvParams>({output_shape, filter, input}, {output}, params)
+                             const Tensor *bias, Tensor *output, const TransposeConvParams &params)
+    : KernelWithParams<TransposeConvParams>({output_shape, filter, input, bias}, {output}, params)
 {
 }
 
@@ -106,8 +106,9 @@ void TransposeConv::evalFloat() const
   op_params.output_multiplier = _output_multiplier;
   tflite::reference_ops::TransposeConv(
       op_params, getTensorShape(input()), getTensorData<float>(input()), getTensorShape(filter()),
-      getTensorData<float>(filter()), getTensorShape(output()), getTensorData<float>(output()),
-      tflite::RuntimeShape(), (float *)nullptr);
+      getTensorData<float>(filter()), getTensorShape(bias()), getTensorData<float>(bias()),
+      getTensorShape(output()), getTensorData<float>(output()), tflite::RuntimeShape(),
+      (float *)nullptr);
 }
 
 void TransposeConv::evalQuantized() const
@@ -145,8 +146,9 @@ void TransposeConv::evalQuantized() const
 
   tflite::reference_ops::TransposeConv(
       op_params, getTensorShape(input()), getTensorData<uint8>(input()), getTensorShape(filter()),
-      getTensorData<uint8>(filter()), getTensorShape(output()), getTensorData<uint8>(output()),
-      tflite::RuntimeShape(), (uint8 *)nullptr, getTensorData<int32_t>(_scratch_tensor.get()));
+      getTensorData<uint8>(filter()), getTensorShape(bias()), getTensorData<int32_t>(bias()),
+      getTensorShape(output()), getTensorData<uint8>(output()), tflite::RuntimeShape(),
+      (uint8 *)nullptr, getTensorData<int32_t>(_scratch_tensor.get()));
 }
 
 } // namespace kernels

--- a/compiler/luci-interpreter/src/kernels/TransposeConv.h
+++ b/compiler/luci-interpreter/src/kernels/TransposeConv.h
@@ -29,11 +29,12 @@ class TransposeConv : public KernelWithParams<TransposeConvParams>
 {
 public:
   TransposeConv(const Tensor *output_shape, const Tensor *filter, const Tensor *input,
-                Tensor *output, const TransposeConvParams &params);
+                const Tensor *bias, Tensor *output, const TransposeConvParams &params);
 
   const Tensor *output_shape() const { return _inputs[0]; }
   const Tensor *filter() const { return _inputs[1]; }
   const Tensor *input() const { return _inputs[2]; }
+  const Tensor *bias() const { return _inputs[3]; }
   Tensor *output() const { return _outputs[0]; }
 
   void configure() override;

--- a/compiler/luci-interpreter/src/kernels/TransposeConv.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/TransposeConv.test.cpp
@@ -50,8 +50,8 @@ void Check(std::initializer_list<int32_t> output_shape_shape,
   params.stride_height = stride_height;
   params.stride_width = stride_width;
 
-  TransposeConv kernel(&output_shape_tensor, &weight_tensor, &input_data_tensor, &output_tensor,
-                       params);
+  TransposeConv kernel(&output_shape_tensor, &weight_tensor, &input_data_tensor, nullptr,
+                       &output_tensor, params);
   kernel.configure();
   kernel.execute();
 

--- a/compiler/luci-interpreter/src/kernels/TransposeConv.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/TransposeConv.test.cpp
@@ -26,15 +26,15 @@ namespace
 
 using namespace testing;
 
-template <typename T>
+template <typename T, typename B>
 void Check(std::initializer_list<int32_t> output_shape_shape,
            std::initializer_list<int32_t> weight_shape,
            std::initializer_list<int32_t> input_data_shape,
-           std::initializer_list<int32_t> output_shape,
+           std::initializer_list<int32_t> bias_shape, std::initializer_list<int32_t> output_shape,
            std::initializer_list<int32_t> output_shape_data, std::initializer_list<T> weight_data,
-           std::initializer_list<T> input_data_data, std::initializer_list<T> output_data,
-           luci::Padding padding, int32_t stride_height, int32_t stride_width,
-           DataType element_type)
+           std::initializer_list<T> input_data_data, std::initializer_list<B> bias_data,
+           std::initializer_list<T> output_data, luci::Padding padding, int32_t stride_height,
+           int32_t stride_width, DataType element_type)
 {
   Tensor output_shape_tensor{element_type, output_shape_shape, {}, ""};
   output_shape_tensor.writeData(output_shape_data.begin(), output_shape_data.size() * sizeof(T));
@@ -50,21 +50,32 @@ void Check(std::initializer_list<int32_t> output_shape_shape,
   params.stride_height = stride_height;
   params.stride_width = stride_width;
 
-  TransposeConv kernel(&output_shape_tensor, &weight_tensor, &input_data_tensor, nullptr,
-                       &output_tensor, params);
-  kernel.configure();
-  kernel.execute();
-
+  if (bias_data.size() != 0)
+  {
+    Tensor bias_tensor = makeInputTensor<getElementType<B>()>(bias_shape, bias_data);
+    TransposeConv kernel(&output_shape_tensor, &weight_tensor, &input_data_tensor, &bias_tensor,
+                         &output_tensor, params);
+    kernel.configure();
+    kernel.execute();
+  }
+  else
+  {
+    TransposeConv kernel(&output_shape_tensor, &weight_tensor, &input_data_tensor, nullptr,
+                         &output_tensor, params);
+    kernel.configure();
+    kernel.execute();
+  }
   EXPECT_THAT(extractTensorData<T>(output_tensor), ::testing::ElementsAreArray(output_data));
 }
 
 TEST(TransposeConvTest, FloatSimple)
 {
-  Check<float>(
+  Check<float, float>(
       /*outputShape_shape=*/{4}, /*weight_shape=*/{1, 3, 3, 1}, /*input_shape=*/{1, 4, 4, 1},
-      /*output_shape=*/{1, 4, 4, 1}, /*outputShape_data=*/{1, 4, 4, 1},
+      /*bias_shape=*/{}, /*output_shape=*/{1, 4, 4, 1}, /*outputShape_data=*/{1, 4, 4, 1},
       /*weight_data=*/{1, 2, 3, 4, 5, 6, 7, 8, 9},
       /*input_data=*/{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
+      /*bias_data=*/{},
       /*output_data=*/{29, 62, 83, 75, 99, 192, 237, 198, 207, 372, 417, 330, 263, 446, 485, 365},
       /*params.padding=*/luci::Padding::SAME, /*stride_height=*/1, /*stride_width=*/1,
       getElementType<float>());
@@ -74,15 +85,34 @@ TEST(TransposeConvTest, FloatSimple)
 
 TEST(TransposeConvTest, FloatTwoFiltersTest)
 {
-  Check<float>(
+  Check<float, float>(
       /*outputShape_shape=*/{4}, /*weight_shape=*/{1, 3, 3, 2}, /*input_shape=*/{1, 4, 4, 2},
-      /*output_shape=*/{1, 4, 4, 1}, /*outputShape_data=*/{1, 4, 4, 1},
+      /*bias_shape=*/{}, /*output_shape=*/{1, 4, 4, 1}, /*outputShape_data=*/{1, 4, 4, 1},
       /*weight_data=*/{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18},
       /*input_data=*/{1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16,
                       17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32},
+      /*bias_data=*/{},
       /*output_data=*/{184, 412, 568, 528, 678, 1347, 1689, 1434, 1494, 2715, 3057, 2442, 1968,
                        3352, 3652, 2760},
       /*params.padding=*/luci::Padding::SAME, /*stride_height=*/1, /*stride_width=*/1,
+      getElementType<float>());
+
+  SUCCEED();
+}
+
+TEST(TransposeConvTest, SimpleBiasTest)
+{
+  Check<float, float>(
+      /*outputShape_shape=*/{4}, /*weight_shape=*/{2, 3, 3, 1},
+      /*input_shape=*/{1, 2, 2, 1},
+      /*bias_shape=*/{2}, /*output_shape=*/{1, 4, 4, 1}, /*outputShape_data=*/{1, 5, 5, 2},
+      /*weight_data=*/{1, 3, 5, 7, 9, 11, 13, 15, 17, 2, 4, 6, 8, 10, 12, 14, 16, 18},
+      /*input_data=*/{1, 2, 3, 4},
+      /*bias_data=*/{3, 4},
+      /*output_data=*/{4,  6,  6,  8,  10, 14, 9,  12, 13, 16, 10,  12,  12, 14, 28, 32, 21,
+                       24, 25, 28, 19, 24, 27, 32, 65, 76, 45, 52,  57,  64, 24, 28, 30, 34,
+                       64, 72, 39, 44, 47, 52, 42, 46, 48, 52, 106, 114, 63, 68, 71, 76},
+      /*params.padding=*/luci::Padding::VALID, /*stride_height=*/2, /*stride_width=*/2,
       getElementType<float>());
 
   SUCCEED();

--- a/compiler/luci-interpreter/src/loader/KernelBuilder.cpp
+++ b/compiler/luci-interpreter/src/loader/KernelBuilder.cpp
@@ -547,6 +547,8 @@ std::unique_ptr<Kernel> KernelBuilder::visit(const luci::CircleTransposeConv *no
   const Tensor *filter = getInputTensor(node->filter());
   const Tensor *out_backprop = getInputTensor(node->outBackprop());
   const Tensor *bias = nullptr;
+  // TODO Add Bias node and after luci updated as arity 4.
+  // const Tensor *bias = getInputTensor(node->bias());
 
   Tensor *output = getOutputTensor(node);
 

--- a/compiler/luci-interpreter/src/loader/KernelBuilder.cpp
+++ b/compiler/luci-interpreter/src/loader/KernelBuilder.cpp
@@ -546,6 +546,7 @@ std::unique_ptr<Kernel> KernelBuilder::visit(const luci::CircleTransposeConv *no
   const Tensor *input_sizes = getInputTensor(node->inputSizes());
   const Tensor *filter = getInputTensor(node->filter());
   const Tensor *out_backprop = getInputTensor(node->outBackprop());
+  const Tensor *bias = nullptr;
 
   Tensor *output = getOutputTensor(node);
 
@@ -554,7 +555,7 @@ std::unique_ptr<Kernel> KernelBuilder::visit(const luci::CircleTransposeConv *no
   params.stride_height = node->stride()->h();
   params.stride_width = node->stride()->w();
 
-  return std::make_unique<kernels::TransposeConv>(input_sizes, filter, out_backprop, output,
+  return std::make_unique<kernels::TransposeConv>(input_sizes, filter, out_backprop, bias, output,
                                                   params);
 }
 

--- a/compiler/luci-interpreter/src/loader/KernelBuilder.test.cpp
+++ b/compiler/luci-interpreter/src/loader/KernelBuilder.test.cpp
@@ -690,15 +690,17 @@ TEST_F(KernelBuilderTest, Transpose)
 
 TEST_F(KernelBuilderTest, TransposeConv)
 {
+  // TODO Add Bias node and after luci updated as arity 4.
   auto *output_shape = createInputNode();
   auto *filter = createInputNode();
   auto *input = createInputNode();
-  auto *bias = createInputNode();
+  // auto *bias = createInputNode();
 
   auto *op = createNode<luci::CircleTransposeConv>();
   op->inputSizes(output_shape);
   op->filter(filter);
   op->outBackprop(input);
+  // op->bias(bias);
 
   op->padding(luci::Padding::SAME);
   op->stride()->h(11);
@@ -711,6 +713,7 @@ TEST_F(KernelBuilderTest, TransposeConv)
   checkTensor(kernel->filter(), filter);
   checkTensor(kernel->input(), input);
   checkTensor(kernel->output(), op);
+  // checkTensor(kernel->bias(), bias);
   EXPECT_THAT(kernel->params().padding, Eq(op->padding()));
   EXPECT_THAT(kernel->params().stride_height, Eq(op->stride()->h()));
   EXPECT_THAT(kernel->params().stride_width, Eq(op->stride()->w()));

--- a/compiler/luci-interpreter/src/loader/KernelBuilder.test.cpp
+++ b/compiler/luci-interpreter/src/loader/KernelBuilder.test.cpp
@@ -693,6 +693,7 @@ TEST_F(KernelBuilderTest, TransposeConv)
   auto *output_shape = createInputNode();
   auto *filter = createInputNode();
   auto *input = createInputNode();
+  auto *bias = createInputNode();
 
   auto *op = createNode<luci::CircleTransposeConv>();
   op->inputSizes(output_shape);


### PR DESCRIPTION
This commit update to use Tensorflow 2.3.0 on luci-interpreter.

  1. Update cmake file in luci-interpreter kernel to include some file in Tensorflow(Mean kernel use this.)
  2. Update kernels for changed spec from 2.1.0 to 2.3.0.(`LeakyRelu`, `Mul`)
	`LeakyRelu` : Arguments are changed.
	`Mul` : kernel changed to reference to optimized.
  3. Update Kernel that accept more tensor.(handle 3~4 Tensor both).`TransposeConv`
	currently, accept nullptr on 4th Tensor. it will update later.

ONE-DCO-1.0-Signed-off-by: KiDeuk Bang <rrstrous@nate.com>