### PR TITLE
[onert] Throw an exception when tensor_registry is nullptr

### DIFF
--- a/runtime/onert/core/src/exec/ExecutorBase.cc
+++ b/runtime/onert/core/src/exec/ExecutorBase.cc
@@ -45,7 +45,12 @@ ExecutorBase::ExecutorBase(std::unique_ptr<ir::LoweredGraph> &&lowered_graph,
         for (auto &tensor_builder : tensor_builders)
         {
           auto tensor_registry = tensor_builder->tensorRegistry();
-          assert(tensor_registry);
+          if (!tensor_registry)
+            throw std::runtime_error(
+                "tensor registry doesn't exist. "
+                "Possible reason: you may use backend only with tensor registry (e.g., cpu) "
+                "but you probably didn't provide BACKENDS option");
+
           tensor = tensor_registry->getNativeITensor(ind);
           if (tensor != nullptr)
           {


### PR DESCRIPTION
This changes `assert` to `throw` when `tensor_register == nullptr`.

When we run some model with several subgraphs with cpu backend, 
if `BACKEND=cpu` _is not provided by mistake_, assert checks nullptr. However, with _release_ build, onert keeps running and dies with segmentation fault. 

So changing `assert` to `throw` seems better to prevent this mistake.

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>
