### PR TITLE
[infra/cmake] Boost config and Install path

### DIFF
--- a/infra/cmake/packages/BoostSourceConfig.cmake
+++ b/infra/cmake/packages/BoostSourceConfig.cmake
@@ -9,7 +9,7 @@ function(_BoostSource_import)
 
   # EXTERNAL_DOWNLOAD_SERVER will be overwritten by CI server to use mirror server.
   envoption(EXTERNAL_DOWNLOAD_SERVER "http://sourceforge.net")
-  set(BOOST_URL ${EXTERNAL_DOWNLOAD_SERVER}/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.gz)
+  envoption(BOOST_URL ${EXTERNAL_DOWNLOAD_SERVER}/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.gz)
   ExternalSource_Download(BOOST ${BOOST_URL})
 
   set(BoostSource_DIR ${BOOST_SOURCE_DIR} PARENT_SCOPE)

--- a/infra/nnfw/cmake/packages/BoostConfig.cmake
+++ b/infra/nnfw/cmake/packages/BoostConfig.cmake
@@ -13,7 +13,7 @@ function(_Boost_Build Boost_PREFIX)
                     RESULT_VARIABLE Boost_BUILD)
   endif()
 
-  set(BoostBuild_DIR ${BoostSource_DIR})
+  set(BoostBuild_DIR ${CMAKE_BINARY_DIR}/externals/boost)
   set(BoostInstall_DIR ${Boost_PREFIX})
 
   unset(Boost_Options)
@@ -55,18 +55,13 @@ if (NOT BUILD_BOOST)
   endif()
 endif()
 
-set(Boost_PREFIX ${CMAKE_INSTALL_PREFIX})
+set(Boost_PREFIX ${EXT_OVERLAY_DIR})
 
 if(BUILD_BOOST)
   _Boost_Build("${Boost_PREFIX}")
 
-  # Let's use locally built boost to system-wide one so sub modules
-  # needing Boost library and header files can search for them
-  # in ${Boost_PREFIX} directory
-  list(APPEND CMAKE_PREFIX_PATH "${Boost_PREFIX}")
-
   # Without Boost_INCLUDE_DIR, it complains the variable is missing during find_package.
-  set(Boost_INCLUDE_DIR ${CMAKE_INSTALL_PREFIX}/include)
+  set(Boost_INCLUDE_DIR ${Boost_PREFIX}/include)
 
   # 1) without static build, it will complain it cannot find libc++_shared.so.
   # 2) We uses static libraries for other libraries.


### PR DESCRIPTION
- Introduce boost source download mirror environment: BOOST_URL
- Change build path to intermediate workspace (obj/externals/boost)
- Change user-config.jam generation path to intermediate workspace (obj/externals/boost)
- Change built boost install path to overlay

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>