### PR TITLE
[onert] Enable L2Norm and PadV2 operation loading

### DIFF
--- a/runtime/onert/core/src/ir/operation/Pad.cc
+++ b/runtime/onert/core/src/ir/operation/Pad.cc
@@ -27,8 +27,10 @@ namespace operation
 
 void Pad::accept(OperationVisitor &v) const { v.visit(*this); }
 
+// PAD: 2 inputs
+// PADV2: 3 inputs
 Pad::Pad(const OperandIndexSequence &inputs, const OperandIndexSequence &outputs)
-    : Operation{OperandConstraint::createExact(2u), inputs, outputs}
+    : Operation{OperandConstraint::createInRange(2u, 3u), inputs, outputs}
 {
 }
 

--- a/runtime/onert/frontend/base_loader/include/base_loader.h
+++ b/runtime/onert/frontend/base_loader/include/base_loader.h
@@ -177,6 +177,7 @@ protected:
   void loadQuantize(const Operator *op, ir::Graph &subg);
   void loadSpaceToDepth(const Operator *op, ir::Graph &subg);
   void loadStatelessRandomUniform(const Operator *op, ir::Graph &subg);
+  void loadL2Normalization(const Operator *op, ir::Graph &subg);
 
 protected:
   // Base address for mapped region for loading (if needed)
@@ -1793,6 +1794,19 @@ void BaseLoader<LoaderDomain, SpecificLoader>::loadQuantize(const Operator *op, 
 }
 
 template <typename LoaderDomain, typename SpecificLoader>
+void BaseLoader<LoaderDomain, SpecificLoader>::loadL2Normalization(const Operator *op,
+                                                                   ir::Graph &subg)
+{
+  ir::OperandIndexSequence inputs;
+  ir::OperandIndexSequence outputs;
+
+  loadOperationIO(op, inputs, outputs);
+
+  std::unique_ptr<ir::Operation> new_op(new ir::operation::L2Normalization(inputs, outputs));
+  subg.addOperation(std::move(new_op));
+}
+
+template <typename LoaderDomain, typename SpecificLoader>
 void BaseLoader<LoaderDomain, SpecificLoader>::loadOperation(const Operator *op, ir::Graph &subg)
 {
   const auto builtin_op = _model->operator_codes()->Get(op->opcode_index())->builtin_code();
@@ -1885,6 +1899,7 @@ void BaseLoader<LoaderDomain, SpecificLoader>::loadOperation(const Operator *op,
       loadReverseV2(op, subg);
       return;
     case BuiltinOperator::BuiltinOperator_PAD:
+    case BuiltinOperator::BuiltinOperator_PADV2:
       loadPad(op, subg);
       return;
     case BuiltinOperator::BuiltinOperator_LOGISTIC:
@@ -2018,6 +2033,9 @@ void BaseLoader<LoaderDomain, SpecificLoader>::loadOperation(const Operator *op,
       return;
     case BuiltinOperator::BuiltinOperator_SPACE_TO_DEPTH:
       loadSpaceToDepth(op, subg);
+      return;
+    case BuiltinOperator::BuiltinOperator_L2_NORMALIZATION:
+      loadL2Normalization(op, subg);
       return;
     default:
       throw std::runtime_error(

--- a/tests/nnfw_api/src/CircleGen.cc
+++ b/tests/nnfw_api/src/CircleGen.cc
@@ -103,6 +103,27 @@ uint32_t CircleGen::addOperatorCos(const OperatorParams &params)
                                 circle::BuiltinOptions_CosOptions, options);
 }
 
+uint32_t CircleGen::addOperatorL2Normalization(const OperatorParams &params)
+{
+  auto options = circle::CreateL2NormOptions(_fbb).Union();
+  return addOperatorWithOptions(params, circle::BuiltinOperator_L2_NORMALIZATION,
+                                circle::BuiltinOptions_L2NormOptions, options);
+}
+
+uint32_t CircleGen::addOperatorPad(const OperatorParams &params)
+{
+  auto options = circle::CreatePadOptions(_fbb).Union();
+  return addOperatorWithOptions(params, circle::BuiltinOperator_PAD,
+                                circle::BuiltinOptions_PadOptions, options);
+}
+
+uint32_t CircleGen::addOperatorPadV2(const OperatorParams &params)
+{
+  auto options = circle::CreatePadOptions(_fbb).Union();
+  return addOperatorWithOptions(params, circle::BuiltinOperator_PADV2,
+                                circle::BuiltinOptions_PadV2Options, options);
+}
+
 // NOTE Please add addOperator functions ABOVE this lie
 //
 // %  How to add a new addOperatorXXX fuction

--- a/tests/nnfw_api/src/CircleGen.h
+++ b/tests/nnfw_api/src/CircleGen.h
@@ -88,6 +88,9 @@ public:
                                     int stride_w, int stride_h, int filter_w, int filter_h,
                                     circle::ActivationFunctionType actfn);
   uint32_t addOperatorCos(const OperatorParams &params);
+  uint32_t addOperatorL2Normalization(const OperatorParams &params);
+  uint32_t addOperatorPad(const OperatorParams &params);
+  uint32_t addOperatorPadV2(const OperatorParams &params);
 
   // NOTE Please add addOperator functions ABOVE this lie
   // ===== Add Operator methods end =====

--- a/tests/nnfw_api/src/GenModelTests.cc
+++ b/tests/nnfw_api/src/GenModelTests.cc
@@ -164,3 +164,57 @@ TEST_F(GenModelTest, OneOp_Cos)
   _ref_inputs = {{0, pi / 2, pi, 7}};
   _ref_outputs = {{1, 0, -1, 0.75390225434}};
 }
+
+TEST_F(GenModelTest, OneOp_Pad)
+{
+  CircleGen cgen;
+  int in = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_FLOAT32});
+  std::vector<int32_t> padding_data{0, 0, 1, 1, 1, 1, 0, 0};
+  uint32_t padding_buf = cgen.addBuffer(padding_data);
+  int padding = cgen.addTensor({{4, 2}, circle::TensorType::TensorType_INT32, padding_buf});
+  int out = cgen.addTensor({{1, 4, 4, 1}, circle::TensorType::TensorType_FLOAT32});
+
+  cgen.addOperatorPad({{in, padding}, {out}});
+  cgen.setInputsAndOutputs({in}, {out});
+  _cbuf = cgen.finish();
+
+  _ref_inputs = {{1, 2, 3, 4}};
+  _ref_outputs = {{0, 0, 0, 0, 0, 1, 2, 0, 0, 3, 4, 0, 0, 0, 0, 0}};
+}
+
+TEST_F(GenModelTest, OneOp_PadV2)
+{
+  CircleGen cgen;
+  int in = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_FLOAT32});
+  std::vector<int32_t> padding_data{0, 0, 1, 1, 1, 1, 0, 0};
+  uint32_t padding_buf = cgen.addBuffer(padding_data);
+  int padding = cgen.addTensor({{4, 2}, circle::TensorType::TensorType_INT32, padding_buf});
+  std::vector<float> padding_value_data{3.0};
+  uint32_t padding_value_buf = cgen.addBuffer(padding_value_data);
+  int padding_value =
+      cgen.addTensor({{1}, circle::TensorType::TensorType_FLOAT32, padding_value_buf});
+
+  int out = cgen.addTensor({{1, 4, 4, 1}, circle::TensorType::TensorType_FLOAT32});
+
+  cgen.addOperatorPadV2({{in, padding, padding_value}, {out}});
+  cgen.setInputsAndOutputs({in}, {out});
+  _cbuf = cgen.finish();
+
+  _ref_inputs = {{1, 2, 3, 4}};
+  _ref_outputs = {{3, 3, 3, 3, 3, 1, 2, 3, 3, 3, 4, 3, 3, 3, 3, 3}};
+}
+
+TEST_F(GenModelTest, OneOp_L2Normalization)
+{
+  CircleGen cgen;
+  int in = cgen.addTensor({{1, 2, 2, 3}, circle::TensorType::TensorType_FLOAT32});
+  int out = cgen.addTensor({{1, 2, 2, 3}, circle::TensorType::TensorType_FLOAT32});
+
+  cgen.addOperatorL2Normalization({{in}, {out}});
+  cgen.setInputsAndOutputs({in}, {out});
+  _cbuf = cgen.finish();
+
+  _ref_inputs = {{0, 3, 4, 0, 5, 12, 0, 8, 15, 0, 7, 24}};
+  _ref_outputs = {{0, 0.6, 0.8, 0, 0.38461539149284363, 0.92307698726654053, 0, 0.47058823704719543,
+                   0.88235294818878174, 0, 0.28, 0.96}};
+}


### PR DESCRIPTION
- Enable L2Normalization and PadV2 operation in base_loader.h
- Add model generation test

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>