### PR TITLE
[onert] Revise OpSequences dump method

### DIFF
--- a/runtime/onert/core/include/ir/OpSequences.h
+++ b/runtime/onert/core/include/ir/OpSequences.h
@@ -63,13 +63,6 @@ public:
    */
   OpSequenceIndex getOperation(const OperationIndex &operation_index) const;
   /**
-   * @brief Dump OpSequences
-   *
-   * @param msg Message that will be displayed
-   * @param graph Graph that has information used for dump
-   */
-  void dump(const std::string &msg, const Operations &operations) const;
-  /**
    * @brief Remove an operation from OpSequence
    *
    * @param operation_index Operation index to be removed
@@ -83,6 +76,14 @@ private:
   OpSequenceIndex findOperation(const OperationIndex &operation_index) const;
   mutable std::unordered_map<OperationIndex, OpSequenceIndex> _seq_indexes;
 };
+
+/**
+ * @brief Dump OpSequences
+ *
+ * @param op_seqs Operation Sequences
+ * @param operations Operation context
+ */
+void dumpOpSequences(const OpSequences &op_seqs, const Operations &operations);
 
 } // namespace ir
 } // namespace onert

--- a/runtime/onert/core/src/ir/LoweredGraph.cc
+++ b/runtime/onert/core/src/ir/LoweredGraph.cc
@@ -102,7 +102,8 @@ LoweredGraph::LoweredGraph(const Graph &graph, const compiler::CompilerOptions &
       std::reverse(std::begin(op_seq.operations()), std::end(op_seq.operations()));
     });
 
-    _op_seqs.dump("merged and sorted operations without permutation", _graph.operations());
+    VERBOSE(OpSequences) << "dump without permutation" << std::endl;
+    dumpOpSequences(_op_seqs, _graph.operations());
 
     pass::ConstantInsertionPass ci_pass(*this);
     ci_pass.run();
@@ -127,7 +128,8 @@ LoweredGraph::LoweredGraph(const Graph &graph, const compiler::CompilerOptions &
     pass::PermutationEliminationPass pe_pass(*this);
     pe_pass.run();
 
-    _op_seqs.dump("merged and sorted operations with permutation", _graph.operations());
+    VERBOSE(OpSequences) << "dump with permutation" << std::endl;
+    dumpOpSequences(_op_seqs, _graph.operations());
   }
 
   // Graph verifications

--- a/runtime/onert/core/src/ir/OpSequences.cc
+++ b/runtime/onert/core/src/ir/OpSequences.cc
@@ -83,15 +83,6 @@ OpSequenceIndex OpSequences::getOperation(const OperationIndex &operation_index)
   return ret;
 }
 
-// TODO: Extract this into external helper function
-void OpSequences::dump(const std::string &msg, const Operations &operations) const
-{
-  VERBOSE(OpSequences) << "OpSequences(" << msg << ")" << std::endl;
-  iterate([&](const OpSequenceIndex &idx, const OpSequence &op_seq) {
-    VERBOSE(OpSequences) << idx.value() << "] " << getStrFromOpSeq(op_seq, operations) << std::endl;
-  });
-}
-
 void OpSequences::removeFromOpSequence(const OperationIndex &operation_index)
 {
   const auto op_seq_index = findOperation(operation_index);
@@ -120,6 +111,13 @@ OpSequenceIndex OpSequences::findOperation(const OperationIndex &operation_index
     }
   }
   throw std::runtime_error("Operation not found");
+}
+
+void dumpOpSequences(const OpSequences &op_seqs, const Operations &operations)
+{
+  op_seqs.iterate([&](const OpSequenceIndex &idx, const OpSequence &op_seq) {
+    VERBOSE(OpSequences) << idx.value() << "] " << getStrFromOpSeq(op_seq, operations) << std::endl;
+  });
 }
 
 } // namespace ir


### PR DESCRIPTION
- Make the method to be outside of the class
- Remove message parameter

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>