### PR TITLE
[onert] Use TensorRegistry directly in controlflow

### DIFF
--- a/runtime/onert/core/src/backend/controlflow/Backend.h
+++ b/runtime/onert/core/src/backend/controlflow/Backend.h
@@ -21,6 +21,7 @@
 #include "ConstantInitializer.h"
 #include "KernelGenerator.h"
 #include "TensorBuilder.h"
+#include "Tensor.h"
 
 #include <backend/Backend.h>
 
@@ -64,10 +65,11 @@ public:
     // TODO Remove TensorBuilder and ConstantInitializer
     // TODO Support Consecutive controflow operation's intermediate tensor
     auto tb = std::make_shared<TensorBuilder>();
-    auto tr = tb->tensorRegistry();
+    // TODO TensorRegistry will be generated here, not relying on TensorBuilder.
+    auto tr = std::dynamic_pointer_cast<TensorRegistry>(tb->tensorRegistry());
     context->tensor_builder = tb;
     context->constant_initializer = std::make_shared<ConstantInitializer>(operands, tr);
-    context->kernel_gen = std::make_shared<KernelGenerator>(graph, tb);
+    context->kernel_gen = std::make_shared<KernelGenerator>(graph, tb, tr);
     context->tensor_register = nullptr;
     context->optimizer = nullptr;
     return context;

--- a/runtime/onert/core/src/backend/controlflow/KernelGenerator.h
+++ b/runtime/onert/core/src/backend/controlflow/KernelGenerator.h
@@ -23,8 +23,7 @@
 #include <ir/Graph.h>
 #include "TensorBuilder.h"
 #include "compiler/TensorBuilders.h"
-
-#include "compiler/TensorBuilders.h"
+#include "TensorRegistry.h"
 
 namespace onert
 {
@@ -36,7 +35,8 @@ namespace controlflow
 class KernelGenerator : public IKernelGenerator
 {
 public:
-  KernelGenerator(const ir::Graph &graph, const std::shared_ptr<TensorBuilder> &tensor_builder);
+  KernelGenerator(const ir::Graph &graph, const std::shared_ptr<TensorBuilder> &tensor_builder,
+                  const std::shared_ptr<TensorRegistry> &tensor_reg);
 
   void setTensorBuilderSet(const compiler::TensorBuilders &tensor_builder_set)
   {
@@ -62,6 +62,7 @@ private:
 private:
   const ir::Graph &_graph;
   std::shared_ptr<TensorBuilder> _tensor_builder;
+  std::shared_ptr<TensorRegistry> _tensor_reg;
   compiler::TensorBuilders _tensor_builder_set;
   exec::ExecutorMap *_executor_map;
 };


### PR DESCRIPTION
Use TensorRegistry directly in controlflow KernelGenerator.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>