### PR TITLE
[onert] Remove DynamicTensorMan from DynAllocInfo

### DIFF
--- a/runtime/onert/core/include/exec/IExecutor.h
+++ b/runtime/onert/core/include/exec/IExecutor.h
@@ -80,8 +80,6 @@ struct DynAllocInfo
 {
   /// @brief index of input tensor whose memory needs to be allocated at execution time
   ir::OperandIndex ind;
-  /// @brief dynamic tensor manager that can allocate memory when input tensor is dynamic
-  backend::IDynamicTensorManager *dyn_tensor_manager;
 };
 
 using DynAllocInfoMap = std::unordered_map<std::shared_ptr<backend::ITensor>, DynAllocInfo>;

--- a/runtime/onert/core/src/backend/controlflow/KernelGenerator.cc
+++ b/runtime/onert/core/src/backend/controlflow/KernelGenerator.cc
@@ -98,8 +98,7 @@ void KernelGenerator::visit(const ir::operation::If &node)
     const auto output_tensor_builder = getTensorBuilder(output_index);
     if (output_tensor_builder->supportDynamicTensor())
     {
-      auto output_dyn_manager = output_tensor_builder->dynamicTensorManager();
-      outputs_dyn_alloc_info[output_tensor] = exec::DynAllocInfo{output_index, output_dyn_manager};
+      outputs_dyn_alloc_info[output_tensor] = exec::DynAllocInfo{output_index};
     }
   }
 
@@ -128,8 +127,7 @@ void KernelGenerator::visit(const ir::operation::Permute &node)
   assert(output_tensor_builder != nullptr);
   if (output_tensor_builder->supportDynamicTensor())
   {
-    outputs_dyn_alloc_info[output_tensors.at(0)] =
-        exec::DynAllocInfo{output_index, output_tensor_builder->dynamicTensorManager()};
+    outputs_dyn_alloc_info[output_tensors.at(0)] = exec::DynAllocInfo{output_index};
   }
 
   auto fn =
@@ -164,8 +162,7 @@ void KernelGenerator::visit(const ir::operation::While &node)
     const auto output_tensor_builder = getTensorBuilder(output_index);
     if (output_tensor_builder->supportDynamicTensor())
     {
-      auto output_dyn_manager = output_tensor_builder->dynamicTensorManager();
-      outputs_dyn_alloc_info[output_tensor] = exec::DynAllocInfo{output_index, output_dyn_manager};
+      outputs_dyn_alloc_info[output_tensor] = exec::DynAllocInfo{output_index};
     }
   }
 

--- a/runtime/onert/core/src/backend/controlflow/kernel/PermuteLayer.cc
+++ b/runtime/onert/core/src/backend/controlflow/kernel/PermuteLayer.cc
@@ -55,7 +55,11 @@ void PermuteLayer::run()
       try
       {
         const auto dst_index = _dst_dyn_alloc_info_map.at(dst_tensor).ind;
-        _dst_dyn_alloc_info_map.at(dst_tensor).dyn_tensor_manager->applyShape(dst_index, new_shape);
+        auto dyn_tensor_manager = dst_tensor->dynamic_tensor_manager();
+        if (!dyn_tensor_manager)
+          throw std::runtime_error{
+              "Error: PermuteLayer: output's TensorManager does not support dynamic tensor"};
+        dyn_tensor_manager->applyShape(dst_index, new_shape);
         assert(dst_tensor->buffer() != nullptr);
       }
       catch (const std::out_of_range &e)

--- a/runtime/onert/core/src/exec/ExecutorBase.cc
+++ b/runtime/onert/core/src/exec/ExecutorBase.cc
@@ -51,7 +51,7 @@ ExecutorBase::ExecutorBase(std::unique_ptr<ir::LoweredGraph> &&lowered_graph,
           {
             if (tensor_builder->supportDynamicTensor())
             {
-              DynAllocInfo dyn_alloc_info{ind, tensor_builder->dynamicTensorManager()};
+              DynAllocInfo dyn_alloc_info{ind};
               _input_to_dyn_alloc_info.emplace(tensor, dyn_alloc_info);
             }
             break;
@@ -76,7 +76,7 @@ ExecutorBase::ExecutorBase(std::unique_ptr<ir::LoweredGraph> &&lowered_graph,
           {
             if (tensor_builder->supportDynamicTensor())
             {
-              DynAllocInfo dyn_alloc_info{ind, tensor_builder->dynamicTensorManager()};
+              DynAllocInfo dyn_alloc_info{ind};
               _output_to_dyn_alloc_info.emplace(tensor, dyn_alloc_info);
             }
             break;
@@ -102,14 +102,14 @@ ExecutorBase::ExecutorBase(std::unique_ptr<ir::LoweredGraph> &&lowered_graph,
     {
       auto tensor = input_tensors[i];
       auto ind = _graph.getInputs().at(i);
-      DynAllocInfo dyn_alloc_info{ind, cf_dyn_tensor_builder->dynamicTensorManager()};
+      DynAllocInfo dyn_alloc_info{ind};
       _input_to_dyn_alloc_info.emplace(tensor, dyn_alloc_info);
     }
     for (uint32_t i = 0; i < output_tensors.size(); i++)
     {
       auto tensor = output_tensors[i];
       auto ind = _graph.getOutputs().at(i);
-      DynAllocInfo dyn_alloc_info{ind, cf_dyn_tensor_builder->dynamicTensorManager()};
+      DynAllocInfo dyn_alloc_info{ind};
       _output_to_dyn_alloc_info.emplace(tensor, dyn_alloc_info);
     }
   }
@@ -269,7 +269,9 @@ void ExecutorBase::handleDynamicInputTensor(ir::IOIndex io_ind, const IODescript
     auto changed_input_shape = shape_sig_found->second;
     auto operand_ind = dyn_alloc_info->second.ind;
 
-    dyn_alloc_info->second.dyn_tensor_manager->applyShape(operand_ind, changed_input_shape);
+    auto dyn_tensor_manager = _input_tensors[io_ind.value()]->dynamic_tensor_manager();
+    assert(dyn_tensor_manager);
+    dyn_tensor_manager->applyShape(operand_ind, changed_input_shape);
   }
 }
 


### PR DESCRIPTION
Now that there is this method `ITensor::dynamic_tensor_manager`, no need
to have `DynamicTensorManager` in `DynAllocInfo`.

% Eventually `DynAllocInfo` will be removed.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>