### PR TITLE
[locomotiv] Reduce class codes B-D

### DIFF
--- a/compiler/locomotiv/src/Node/BiasAdd.cpp
+++ b/compiler/locomotiv/src/Node/BiasAdd.cpp
@@ -41,10 +41,12 @@ std::unique_ptr<NodeData> calc(const NodeData *input_data, const NodeData *bias_
 
 } // namespace
 
-namespace locomotiv
+namespace
 {
 
-void NodeExecution::execute(loco::BiasAdd<loco::Domain::Tensor> *bias_add)
+using namespace locomotiv;
+
+void execute_node(loco::BiasAdd<loco::Domain::Tensor> *bias_add)
 {
   validate(bias_add, "BiasAdd is nullptr");
 
@@ -63,7 +65,7 @@ void NodeExecution::execute(loco::BiasAdd<loco::Domain::Tensor> *bias_add)
   annot_domain(bias_add, annot_domain(bias_add->value()));
 }
 
-void NodeExecution::execute(loco::BiasAdd<loco::Domain::Feature> *bias_add)
+void execute_node(loco::BiasAdd<loco::Domain::Feature> *bias_add)
 {
   validate(bias_add, "BiasAdd is nullptr");
 
@@ -82,7 +84,7 @@ void NodeExecution::execute(loco::BiasAdd<loco::Domain::Feature> *bias_add)
   annot_domain(bias_add, loco::Domain::Feature);
 }
 
-} // namespace locomotiv
+} // namespace
 
 namespace
 {
@@ -123,3 +125,18 @@ std::unique_ptr<NodeData> calc(const NodeData *input_data, const NodeData *bias_
 }
 
 } // namespace
+
+namespace locomotiv
+{
+
+void NodeExecution::execute(loco::BiasAdd<loco::Domain::Tensor> *bias_add)
+{
+  execute_node(bias_add);
+}
+
+void NodeExecution::execute(loco::BiasAdd<loco::Domain::Feature> *bias_add)
+{
+  execute_node(bias_add);
+}
+
+} // namespace locomotiv

--- a/compiler/locomotiv/src/Node/BiasEncode.cpp
+++ b/compiler/locomotiv/src/Node/BiasEncode.cpp
@@ -23,10 +23,12 @@
 #include <stdexcept>
 #include <cassert>
 
-namespace locomotiv
+namespace
 {
 
-void NodeExecution::execute(loco::BiasEncode *bias_enc)
+using namespace locomotiv;
+
+void execute_node(loco::BiasEncode *bias_enc)
 {
   auto input_data = annot_data(bias_enc->input());
 
@@ -59,5 +61,12 @@ void NodeExecution::execute(loco::BiasEncode *bias_enc)
   annot_data(bias_enc, std::move(bias_enc_data));
   annot_domain(bias_enc, loco::Domain::Bias);
 }
+
+} // namespace
+
+namespace locomotiv
+{
+
+void NodeExecution::execute(loco::BiasEncode *bias_enc) { execute_node(bias_enc); }
 
 } // namespace locomotiv

--- a/compiler/locomotiv/src/Node/ConstGen.cpp
+++ b/compiler/locomotiv/src/Node/ConstGen.cpp
@@ -53,10 +53,12 @@ inline uint32_t offset_by_index(const Shape &shape, const Index &index)
 
 } // namespace
 
-namespace locomotiv
+namespace
 {
 
-void NodeExecution::execute(loco::ConstGen *constgen)
+using namespace locomotiv;
+
+void execute_node(loco::ConstGen *constgen)
 {
   uint32_t volume = 1;
 
@@ -112,5 +114,12 @@ void NodeExecution::execute(loco::ConstGen *constgen)
   annot_data(constgen, std::move(data));
   annot_domain(constgen, loco::Domain::Tensor);
 }
+
+} // namespace
+
+namespace locomotiv
+{
+
+void NodeExecution::execute(loco::ConstGen *constgen) { execute_node(constgen); }
 
 } // namespace locomotiv

--- a/compiler/locomotiv/src/Node/Conv2D.cpp
+++ b/compiler/locomotiv/src/Node/Conv2D.cpp
@@ -139,10 +139,12 @@ Buffer<RET_T> calc_conv2D(const loco::Conv2D *conv2d, const Buffer<IFM_T> *input
 
 } // namespace
 
-namespace locomotiv
+namespace
 {
 
-void NodeExecution::execute(loco::Conv2D *conv2d)
+using namespace locomotiv;
+
+void execute_node(loco::Conv2D *conv2d)
 {
   auto ifm_data = annot_data(conv2d->ifm());
   auto ker_data = annot_data(conv2d->ker());
@@ -175,5 +177,12 @@ void NodeExecution::execute(loco::Conv2D *conv2d)
   annot_data(conv2d, std::move(conv2d_result));
   annot_domain(conv2d, loco::Domain::Feature);
 }
+
+} // namespace
+
+namespace locomotiv
+{
+
+void NodeExecution::execute(loco::Conv2D *conv2d) { execute_node(conv2d); }
 
 } // namespace locomotiv

--- a/compiler/locomotiv/src/Node/DepthwiseConv2D.cpp
+++ b/compiler/locomotiv/src/Node/DepthwiseConv2D.cpp
@@ -143,10 +143,12 @@ Buffer<RET_T> calc_dw_conv2d(const loco::DepthwiseConv2D *dw_conv2d, const Buffe
 
 } // namespace
 
-namespace locomotiv
+namespace
 {
 
-void NodeExecution::execute(loco::DepthwiseConv2D *dw_conv2d)
+using namespace locomotiv;
+
+void execute_node(loco::DepthwiseConv2D *dw_conv2d)
 {
   auto ifm_data = annot_data(dw_conv2d->ifm());
   auto ker_data = annot_data(dw_conv2d->ker());
@@ -181,5 +183,12 @@ void NodeExecution::execute(loco::DepthwiseConv2D *dw_conv2d)
   annot_data(dw_conv2d, std::move(dw_conv2d_result));
   annot_domain(dw_conv2d, loco::Domain::Feature);
 }
+
+} // namespace
+
+namespace locomotiv
+{
+
+void NodeExecution::execute(loco::DepthwiseConv2D *dw_conv2d) { execute_node(dw_conv2d); }
 
 } // namespace locomotiv


### PR DESCRIPTION
This will rename methods to reduce class lines of codes of NodeExecution

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>