### PR TITLE
[locomotiv] Reduce class codes M-S

### DIFF
--- a/compiler/locomotiv/src/Node/MaxPool2D.cpp
+++ b/compiler/locomotiv/src/Node/MaxPool2D.cpp
@@ -129,10 +129,12 @@ nncc::core::ADT::tensor::Buffer<T> maxPool2D(const loco::MaxPool2D *maxpool2d,
 
 } // namespace
 
-namespace locomotiv
+namespace
 {
 
-void NodeExecution::execute(loco::MaxPool2D *maxpool2d)
+using namespace locomotiv;
+
+void execute_node(loco::MaxPool2D *maxpool2d)
 {
   auto ifm_data = annot_data(maxpool2d->ifm());
 
@@ -163,5 +165,12 @@ void NodeExecution::execute(loco::MaxPool2D *maxpool2d)
   annot_data(maxpool2d, std::move(maxpool2d_data));
   annot_domain(maxpool2d, loco::Domain::Feature);
 }
+
+} // namespace
+
+namespace locomotiv
+{
+
+void NodeExecution::execute(loco::MaxPool2D *maxpool2d) { execute_node(maxpool2d); }
 
 } // namespace locomotiv

--- a/compiler/locomotiv/src/Node/Pull.cpp
+++ b/compiler/locomotiv/src/Node/Pull.cpp
@@ -24,10 +24,12 @@
 #include <cassert>
 #include <stdexcept>
 
-namespace locomotiv
+namespace
 {
 
-void NodeExecution::execute(loco::Pull *pull)
+using namespace locomotiv;
+
+void execute_node(loco::Pull *pull)
 {
 // TODO Remove deprecated code
 #if 0
@@ -68,5 +70,12 @@ void NodeExecution::execute(loco::Pull *pull)
   annot_data(pull, std::move(pull_data));
   annot_domain(pull, loco::Domain::Tensor);
 }
+
+} // namespace
+
+namespace locomotiv
+{
+
+void NodeExecution::execute(loco::Pull *pull) { execute_node(pull); }
 
 } // namespace locomotiv

--- a/compiler/locomotiv/src/Node/Push.cpp
+++ b/compiler/locomotiv/src/Node/Push.cpp
@@ -23,10 +23,12 @@
 #include <stdexcept>
 #include <cassert>
 
-namespace locomotiv
+namespace
 {
 
-void NodeExecution::execute(loco::Push *push)
+using namespace locomotiv;
+
+void execute_node(loco::Push *push)
 {
   auto from_data = annot_data(push->from());
 
@@ -57,5 +59,12 @@ void NodeExecution::execute(loco::Push *push)
   annot_data(push, std::move(push_data));
   annot_domain(push, loco::Domain::Tensor);
 }
+
+} // namespace
+
+namespace locomotiv
+{
+
+void NodeExecution::execute(loco::Push *push) { execute_node(push); }
 
 } // namespace locomotiv

--- a/compiler/locomotiv/src/Node/Reshape.cpp
+++ b/compiler/locomotiv/src/Node/Reshape.cpp
@@ -36,10 +36,12 @@ using nncc::core::ADT::tensor::num_elements;
 #include <cstring>
 #include <vector>
 
-namespace locomotiv
+namespace
 {
 
-void NodeExecution::execute(loco::Reshape<loco::ReshapeType::Fixed> *reshape)
+using namespace locomotiv;
+
+void execute_node(loco::Reshape<loco::ReshapeType::Fixed> *reshape)
 {
   auto input_data = annot_data(reshape->input());
 
@@ -85,6 +87,16 @@ void NodeExecution::execute(loco::Reshape<loco::ReshapeType::Fixed> *reshape)
   assert(reshape_data != nullptr);
   annot_data(reshape, std::move(reshape_data));
   annot_domain(reshape, annot_domain(reshape->input()));
+}
+
+} // namespace
+
+namespace locomotiv
+{
+
+void NodeExecution::execute(loco::Reshape<loco::ReshapeType::Fixed> *reshape)
+{
+  execute_node(reshape);
 }
 
 } // namespace locomotiv

--- a/compiler/locomotiv/src/Node/Softmax.cpp
+++ b/compiler/locomotiv/src/Node/Softmax.cpp
@@ -65,10 +65,12 @@ Shape reduce_shape(const Shape &shape, uint32_t axis)
 
 } // namespace
 
-namespace locomotiv
+namespace
 {
 
-void NodeExecution::execute(loco::TensorSoftmax *softmax)
+using namespace locomotiv;
+
+void execute_node(loco::TensorSoftmax *softmax)
 {
   auto input_data = annot_data(softmax->input());
 
@@ -118,5 +120,12 @@ void NodeExecution::execute(loco::TensorSoftmax *softmax)
   annot_data(softmax, std::move(softmax_data));
   annot_domain(softmax, annot_domain(softmax->input()));
 }
+
+} // namespace
+
+namespace locomotiv
+{
+
+void NodeExecution::execute(loco::TensorSoftmax *softmax) { execute_node(softmax); }
 
 } // namespace locomotiv


### PR DESCRIPTION
This will rename methods to reduce class lines of codes of NodeExecution

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>