### PR TITLE
[nnpkg_run] use same format for dumping boolean

### DIFF
--- a/tests/tools/nnpackage_run/src/h5formatter.cc
+++ b/tests/tools/nnpackage_run/src/h5formatter.cc
@@ -156,7 +156,7 @@ void H5Formatter::dumpOutputs(const std::string &filename, std::vector<Allocatio
         case NNFW_TYPE_TENSOR_BOOL:
         {
           H5::DataSet data_set =
-              value_group.createDataSet(std::to_string(i), H5::PredType::STD_I8LE, data_space);
+              value_group.createDataSet(std::to_string(i), H5::PredType::STD_U8LE, data_space);
           data_set.write(outputs[i].data(), H5::PredType::NATIVE_INT8);
           break;
         }


### PR DESCRIPTION
nnpackage_run has stored bool as I8.
It should be same format (=U8) of python and nnpackage_run load.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>