### PR TITLE
[tflitefile_tool] select_operator will show unsupported op info

### DIFF
--- a/tools/tflitefile_tool/select_operator.py
+++ b/tools/tflitefile_tool/select_operator.py
@@ -909,7 +909,8 @@ def GenerateBuiltinOption(new_builder, selected_builtin_option, builtin_option_t
         return tflite.WhileOptions.WhileOptionsEnd(new_builder)
 
     # Cannot handle builtin option type yet
-    print("Cannot handle this option yet")
+    print("Cannot handle BuiltinOptions {} yet. See BuiltinOptions.py for op name".format(
+        builtin_option_type))
     exit(1)
 
 


### PR DESCRIPTION
Currently select_operator does not show any information about
what operator is not supported.
It will print BuiltinOptions index to find out easily what operator is
not supported.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>