### PR TITLE
[locomotiv] Reduce class codes D

### DIFF
--- a/compiler/locomotiv/src/Node/DepthwiseFilterEncode.cpp
+++ b/compiler/locomotiv/src/Node/DepthwiseFilterEncode.cpp
@@ -79,10 +79,12 @@ std::unique_ptr<locomotiv::NodeData> dw_filter_encode(const loco::DepthwiseFilte
 
 } // namespace
 
-namespace locomotiv
+namespace
 {
 
-void NodeExecution::execute(loco::DepthwiseFilterEncode *enc)
+using namespace locomotiv;
+
+void execute_node(loco::DepthwiseFilterEncode *enc)
 {
   auto input_data = annot_data(enc->input());
 
@@ -109,5 +111,12 @@ void NodeExecution::execute(loco::DepthwiseFilterEncode *enc)
   annot_data(enc, std::move(enc_data));
   annot_domain(enc, loco::Domain::DepthwiseFilter);
 }
+
+} // namespace
+
+namespace locomotiv
+{
+
+void NodeExecution::execute(loco::DepthwiseFilterEncode *enc) { execute_node(enc); }
 
 } // namespace locomotiv


### PR DESCRIPTION
This will rename methods to reduce class lines of codes of NodeExecution

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>