### PR TITLE
[tflitefile_tool] support dilation in select_operator.py

### DIFF
--- a/tools/tflitefile_tool/select_operator.py
+++ b/tools/tflitefile_tool/select_operator.py
@@ -272,6 +272,10 @@ def GenerateBuiltinOption(new_builder, selected_builtin_option, builtin_option_t
                                                      conv2d_options.StrideW())
         tflite.Conv2DOptions.Conv2DOptionsAddStrideH(new_builder,
                                                      conv2d_options.StrideH())
+        tflite.Conv2DOptions.Conv2DOptionsAddDilationWFactor(
+            new_builder, conv2d_options.DilationWFactor())
+        tflite.Conv2DOptions.Conv2DOptionsAddDilationHFactor(
+            new_builder, conv2d_options.DilationHFactor())
         tflite.Conv2DOptions.Conv2DOptionsAddFusedActivationFunction(
             new_builder, conv2d_options.FusedActivationFunction())
         return tflite.Conv2DOptions.Conv2DOptionsEnd(new_builder)


### PR DESCRIPTION
Currently select_operator ignores dilation factors.
Now, it will handle them.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>