### PR TITLE
[onert] Remove ITensorBuilder::supportDynamicTensor

### DIFF
--- a/runtime/onert/backend/acl_common/AclTensorBuilder.h
+++ b/runtime/onert/backend/acl_common/AclTensorBuilder.h
@@ -96,8 +96,6 @@ public:
    */
   bool isSubTensorOf(const ir::OperandIndex &parent, const ir::OperandIndex &child);
 
-  bool supportDynamicTensor() override { return false; }
-
 private:
   void buildTensors(void);
   ir::OperandIndex findRootParent(ir::OperandIndex index);

--- a/runtime/onert/backend/cpu/TensorBuilder.h
+++ b/runtime/onert/backend/cpu/TensorBuilder.h
@@ -40,8 +40,6 @@ class TensorBuilder : public ITensorBuilder
 public:
   TensorBuilder();
 
-  bool supportDynamicTensor() override { return true; }
-
   /**
    * @brief     Register tensor information to allocate on CPU backend
    * @param[in] ind    Operand index

--- a/runtime/onert/core/include/backend/ITensorBuilder.h
+++ b/runtime/onert/core/include/backend/ITensorBuilder.h
@@ -40,11 +40,6 @@ struct ITensorBuilder
   virtual ~ITensorBuilder(void) = default;
 
   /**
-   * @brief Returns true if this TensorBuilder support dynamic tensor
-   */
-  virtual bool supportDynamicTensor() = 0;
-
-  /**
    * @brief Register tensor information to allocate on backend
    *
    * @param ind Index
@@ -131,10 +126,7 @@ public: // methods for dynamic tensor allocation
    * @note   Since it is a pointer, its life time is from the cration of TensorBuilder
    *         to the end of execution
    */
-  virtual IDynamicTensorManager *dynamicTensorManager(void)
-  {
-    throw std::runtime_error("dynamicTensorManager(): NYI");
-  }
+  virtual IDynamicTensorManager *dynamicTensorManager(void) { return nullptr; }
 
   /**
    * @brief Release dynamic @c ITensorManger object which was built
@@ -142,10 +134,7 @@ public: // methods for dynamic tensor allocation
    *
    * @return std::unique_ptr<ITensorManager> Tensor Manager object
    */
-  virtual std::unique_ptr<ITensorManager> releaseDynamicTensorManager(void)
-  {
-    throw std::runtime_error("releaseDynamicTensorManager() for this backend is not supported");
-  }
+  virtual std::unique_ptr<ITensorManager> releaseDynamicTensorManager(void) { return nullptr; }
 };
 
 } // namespace backend

--- a/runtime/onert/core/src/backend/controlflow/KernelGenerator.cc
+++ b/runtime/onert/core/src/backend/controlflow/KernelGenerator.cc
@@ -96,10 +96,7 @@ void KernelGenerator::visit(const ir::operation::If &node)
 
     output_tensors.emplace_back(output_tensor);
     const auto output_tensor_builder = getTensorBuilder(output_index);
-    if (output_tensor_builder->supportDynamicTensor())
-    {
-      outputs_dyn_alloc_info[output_tensor] = exec::DynAllocInfo{output_index};
-    }
+    outputs_dyn_alloc_info[output_tensor] = exec::DynAllocInfo{output_index};
   }
 
   // IfLayer just set ExecutorMap instead of then and else executor to avoid complexity of
@@ -125,10 +122,7 @@ void KernelGenerator::visit(const ir::operation::Permute &node)
   const auto output_tensor_builder = getTensorBuilder(output_index);
   VERBOSE(PERMUTE_FIND_TB) << output_index << " -> " << output_tensor_builder.get() << std::endl;
   assert(output_tensor_builder != nullptr);
-  if (output_tensor_builder->supportDynamicTensor())
-  {
-    outputs_dyn_alloc_info[output_tensors.at(0)] = exec::DynAllocInfo{output_index};
-  }
+  outputs_dyn_alloc_info[output_tensors.at(0)] = exec::DynAllocInfo{output_index};
 
   auto fn =
       std::make_unique<kernel::PermuteLayer>(input_tensors, output_tensors, outputs_dyn_alloc_info);
@@ -160,10 +154,7 @@ void KernelGenerator::visit(const ir::operation::While &node)
     output_tensors.emplace_back(output_tensor);
 
     const auto output_tensor_builder = getTensorBuilder(output_index);
-    if (output_tensor_builder->supportDynamicTensor())
-    {
-      outputs_dyn_alloc_info[output_tensor] = exec::DynAllocInfo{output_index};
-    }
+    outputs_dyn_alloc_info[output_tensor] = exec::DynAllocInfo{output_index};
   }
 
   // WhileLayer just set ExecutorMap instead of cond and body executor to avoid complexity of

--- a/runtime/onert/core/src/backend/controlflow/TensorBuilder.h
+++ b/runtime/onert/core/src/backend/controlflow/TensorBuilder.h
@@ -41,8 +41,6 @@ class TensorBuilder : public ITensorBuilder
 public:
   TensorBuilder();
 
-  bool supportDynamicTensor() override { return true; }
-
   /**
    * @brief     Register tensor information to allocate on CPU backend
    * @param[in] ind    Operand index

--- a/runtime/onert/core/src/compiler/Linear.cc
+++ b/runtime/onert/core/src/compiler/Linear.cc
@@ -180,11 +180,9 @@ void Linear::planTensors(const ir::LoweredGraph &lowered_graph,
           tensor_builder_map[ind]->notifyLastUse(ind);
 
           // plan for deallocation of dynamic tensor
-          if (tensor_builder_map[ind]->supportDynamicTensor())
-          {
-            assert(tensor_builder_map[ind]->dynamicTensorManager());
-            tensor_builder_map[ind]->dynamicTensorManager()->planDealloc(op_idx, ind);
-          }
+          auto dyn_tensor_manager = tensor_builder_map[ind]->dynamicTensorManager();
+          if (dyn_tensor_manager)
+            dyn_tensor_manager->planDealloc(op_idx, ind);
         }
       }
     }

--- a/runtime/onert/core/src/exec/ExecutorBase.cc
+++ b/runtime/onert/core/src/exec/ExecutorBase.cc
@@ -49,11 +49,8 @@ ExecutorBase::ExecutorBase(std::unique_ptr<ir::LoweredGraph> &&lowered_graph,
           tensor = tensor_registry->getNativeITensor(ind);
           if (tensor != nullptr)
           {
-            if (tensor_builder->supportDynamicTensor())
-            {
-              DynAllocInfo dyn_alloc_info{ind};
-              _input_to_dyn_alloc_info.emplace(tensor, dyn_alloc_info);
-            }
+            DynAllocInfo dyn_alloc_info{ind};
+            _input_to_dyn_alloc_info.emplace(tensor, dyn_alloc_info);
             break;
           }
         }
@@ -74,11 +71,8 @@ ExecutorBase::ExecutorBase(std::unique_ptr<ir::LoweredGraph> &&lowered_graph,
           tensor = tensor_registry->getNativeITensor(ind);
           if (tensor != nullptr)
           {
-            if (tensor_builder->supportDynamicTensor())
-            {
-              DynAllocInfo dyn_alloc_info{ind};
-              _output_to_dyn_alloc_info.emplace(tensor, dyn_alloc_info);
-            }
+            DynAllocInfo dyn_alloc_info{ind};
+            _output_to_dyn_alloc_info.emplace(tensor, dyn_alloc_info);
             break;
           }
         }
@@ -121,12 +115,9 @@ ExecutorBase::ExecutorBase(std::unique_ptr<ir::LoweredGraph> &&lowered_graph,
     if (s_tensor_manager != nullptr)
       _tensor_mgrs.insert(std::move(s_tensor_manager));
 
-    if (tensor_builder->supportDynamicTensor())
-    {
-      auto d_tensor_manager = tensor_builder->releaseDynamicTensorManager();
-      if (d_tensor_manager != nullptr)
-        _tensor_mgrs.insert(std::move(d_tensor_manager));
-    }
+    auto d_tensor_manager = tensor_builder->releaseDynamicTensorManager();
+    if (d_tensor_manager != nullptr)
+      _tensor_mgrs.insert(std::move(d_tensor_manager));
   }
 }
 


### PR DESCRIPTION
Remove `ITensorBuilder::supportDynamicTensor`.
This is as adding dynamic alloc info for all has no harm, and eventually
adding dynamic alloc info will be removed.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>