### PR TITLE
[onert] Fix conv2d op for dilation

### DIFF
--- a/compute/cker/include/cker/operation/Conv.h
+++ b/compute/cker/include/cker/operation/Conv.h
@@ -61,11 +61,13 @@ public:
   }
 
   void prepare(const Shape &filter_shape, const float *filter_data, PaddingType padding_type,
-               bool &is_replaced_weights)
+               bool &is_replaced_weights, uint32_t dilationWidthFactor,
+               uint32_t dilationHeightFactor)
   {
     if (!_prepared)
     {
-      if (usableMultiThreaded(padding_type))
+      if (usableMultiThreaded(padding_type) && dilationWidthFactor == 1 &&
+          dilationHeightFactor == 1)
       {
         transposeFilter(filter_shape, filter_data, is_replaced_weights);
       }
@@ -87,7 +89,8 @@ public:
                   const Shape &filter_shape, const float *filter_data, const Shape &bias_shape,
                   const float *bias_data, const Shape &output_shape, float *output_data)
   {
-    if (usableMultiThreaded(params.padding_type))
+    if (usableMultiThreaded(params.padding_type) && params.dilation_width_factor == 1 &&
+        params.dilation_height_factor == 1)
     {
       bool transposed_in_execution = false;
       if (!_prepared)

--- a/compute/cker/include/cker/operation/Conv.h
+++ b/compute/cker/include/cker/operation/Conv.h
@@ -66,8 +66,7 @@ public:
   {
     if (!_prepared)
     {
-      if (usableMultiThreaded(padding_type) && dilationWidthFactor == 1 &&
-          dilationHeightFactor == 1)
+      if (usableMultiThreaded(padding_type, dilationWidthFactor, dilationHeightFactor))
       {
         transposeFilter(filter_shape, filter_data, is_replaced_weights);
       }
@@ -89,8 +88,8 @@ public:
                   const Shape &filter_shape, const float *filter_data, const Shape &bias_shape,
                   const float *bias_data, const Shape &output_shape, float *output_data)
   {
-    if (usableMultiThreaded(params.padding_type) && params.dilation_width_factor == 1 &&
-        params.dilation_height_factor == 1)
+    if (usableMultiThreaded(params.padding_type, params.dilation_width_factor,
+                            params.dilation_height_factor))
     {
       bool transposed_in_execution = false;
       if (!_prepared)
@@ -128,9 +127,11 @@ public:
   }
 
 private:
-  bool usableMultiThreaded(PaddingType padding_type)
+  bool usableMultiThreaded(PaddingType padding_type, uint32_t dilation_width_factor,
+                           int32_t dilation_height_factor)
   {
-    return padding_type != PaddingType::kNone && std::thread::hardware_concurrency() > 1;
+    return padding_type != PaddingType::kNone && std::thread::hardware_concurrency() > 1 &&
+           dilation_width_factor == 1 && dilation_height_factor == 1;
   }
 
   void transposeFilter(const Shape &filter_shape, const float *filter_data,

--- a/runtime/onert/backend/cpu/KernelGenerator.cc
+++ b/runtime/onert/backend/cpu/KernelGenerator.cc
@@ -278,7 +278,8 @@ void KernelGenerator::visit(const ir::operation::Conv2D &node)
   const auto ker_width = ker_shape.dim(2);
 
   const auto padding =
-      ir::calculatePadding(param_padding, ifm_shape, ofm_shape, stride, ker_width, ker_height);
+      ir::calculatePadding(param_padding, ifm_shape, ofm_shape, stride, ker_width, ker_height,
+                           dilation.width_factor, dilation.height_factor);
 
   fn->configure(ifm_tensor, ker_tensor, bias_tensor, param_padding.type, padding.left,
                 padding.right, padding.top, padding.bottom, stride.horizontal, stride.vertical,

--- a/runtime/onert/backend/cpu/ops/ConvolutionLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ConvolutionLayer.cc
@@ -150,7 +150,8 @@ void ConvolutionLayer::run()
     param_padding.param.bottom = _paddingBottom;
 
     const auto padding =
-        ir::calculatePadding(param_padding, ifm_shape, ofm_shape, stride, ker_width, ker_height);
+        ir::calculatePadding(param_padding, ifm_shape, ofm_shape, stride, ker_width, ker_height,
+                             _dilationWidthFactor, _dilationHeightFactor);
 
     _paddingLeft = padding.left;
     _paddingRight = padding.right;
@@ -181,7 +182,8 @@ void ConvolutionLayer::prepare()
   {
     bool is_transposed = false;
     kernel.prepare(getTensorShape(_kernel), reinterpret_cast<const float *>(_kernel->buffer()),
-                   getPaddingType(_paddingType), is_transposed);
+                   getPaddingType(_paddingType), is_transposed, _dilationWidthFactor,
+                   _dilationHeightFactor);
 
     // Decrease reference of _kernel(weights) only when _kernel is constant
     if (is_transposed)

--- a/runtime/onert/core/include/ir/Padding.h
+++ b/runtime/onert/core/include/ir/Padding.h
@@ -65,7 +65,8 @@ struct Padding
 // TODO Change to Padding struct's method
 const ExplicitPadding calculatePadding(const Padding &padding, const FeatureShape &ifm_shape,
                                        const FeatureShape &ofm_shape, const Stride &stride,
-                                       uint32_t kw, uint32_t kh);
+                                       uint32_t kw, uint32_t kh, uint32_t dwf = 1,
+                                       uint32_t dhf = 1);
 
 } // namespace ir
 } // namespace onert

--- a/runtime/onert/core/src/util/ShapeInference.cc
+++ b/runtime/onert/core/src/util/ShapeInference.cc
@@ -79,34 +79,8 @@ ir::Shape broadcastShapes(const ir::Shape &lhs_shape, const ir::Shape &rhs_shape
 // Calculate output height and width of convolution-like operation
 std::pair<int, int> calcConvLikeHeightAndWidth(const int in_h, const int in_w, const int ker_h,
                                                const int ker_w, const ir::Padding pad,
-                                               const ir::Stride stride)
-{
-  int32_t out_h = 0, out_w = 0;
-
-  switch (pad.type)
-  {
-    case ir::PaddingType::SAME:
-      out_h = ceil_div(in_h, stride.vertical);
-      out_w = ceil_div(in_w, stride.horizontal);
-      break;
-    case ir::PaddingType::VALID:
-      out_h = ceil_div(in_h - ker_h + 1, stride.vertical);
-      out_w = ceil_div(in_w - ker_w + 1, stride.horizontal);
-      break;
-    case ir::PaddingType::EXPLICIT:
-      out_h = (in_h + pad.param.top + pad.param.bottom - ker_h) / stride.vertical + 1;
-      out_w = (in_w + pad.param.left + pad.param.right - ker_w) / stride.horizontal + 1;
-      break;
-    default:
-      assert(false);
-  }
-
-  return {out_h, out_w};
-}
-
-std::pair<int, int> calcConvLikeHeightAndWidth(const int in_h, const int in_w, const int ker_h,
-                                               const int ker_w, const ir::Padding pad,
-                                               const ir::Stride stride, const ir::Dilation dilation)
+                                               const ir::Stride stride,
+                                               const ir::Dilation dilation = {1, 1})
 {
   int32_t out_h = 0, out_w = 0;
   int32_t effective_filter_w_size = (ker_w - 1) * dilation.width_factor + 1;


### PR DESCRIPTION
When using MultiThread, both dilation data must be 1.
When obtaining padding data, dilation data is used.

Signed-off-by: YiHyunjin <hj0412.yi@samsung.com>