### PR TITLE
[onert] Set dyn_tensor_manager for static tensors

### DIFF
--- a/runtime/onert/core/include/backend/cpu_common/StaticTensorManager.h
+++ b/runtime/onert/core/include/backend/cpu_common/StaticTensorManager.h
@@ -20,6 +20,7 @@
 #include "MemoryManager.h"
 
 #include "backend/IStaticTensorManager.h"
+#include "backend/IDynamicTensorManager.h"
 #include "ir/OperandIndexMap.h"
 #include "ir/OperandInfo.h"
 #include "TensorRegistry.h"
@@ -34,7 +35,8 @@ namespace cpu_common
 class StaticTensorManager : public backend::IStaticTensorManager
 {
 public:
-  StaticTensorManager(const std::shared_ptr<TensorRegistry> &reg);
+  StaticTensorManager(const std::shared_ptr<TensorRegistry> &reg,
+                      IDynamicTensorManager *dynamic_tensor_manager);
   virtual ~StaticTensorManager() = default;
 
   void allocateConsts(void);
@@ -55,6 +57,7 @@ private:
   std::unique_ptr<MemoryManager> _nonconst_mgr;
   const std::shared_ptr<TensorRegistry> _tensors;
   ir::OperandIndexMap<bool> _as_constants;
+  IDynamicTensorManager *_dynamic_tensor_manager;
 };
 
 } // namespace cpu_common

--- a/runtime/onert/core/src/backend/controlflow/TensorBuilder.cc
+++ b/runtime/onert/core/src/backend/controlflow/TensorBuilder.cc
@@ -28,9 +28,9 @@ namespace controlflow
 {
 
 TensorBuilder::TensorBuilder()
-    : _tensor_reg{new TensorRegistry()},
-      _static_tensor_mgr{new cpu_common::StaticTensorManager(_tensor_reg->base_reg())},
-      _dynamic_tensor_mgr{new DynamicTensorManager(_tensor_reg)}
+    : _tensor_reg{new TensorRegistry()}, _dynamic_tensor_mgr{new DynamicTensorManager(_tensor_reg)},
+      _static_tensor_mgr{
+          new cpu_common::StaticTensorManager(_tensor_reg->base_reg(), _dynamic_tensor_mgr.get())}
 {
   /* empty */
 }

--- a/runtime/onert/core/src/backend/controlflow/TensorBuilder.h
+++ b/runtime/onert/core/src/backend/controlflow/TensorBuilder.h
@@ -80,8 +80,8 @@ public:
 
 private:
   const std::shared_ptr<TensorRegistry> _tensor_reg;
-  std::unique_ptr<cpu_common::StaticTensorManager> _static_tensor_mgr;
   std::unique_ptr<DynamicTensorManager> _dynamic_tensor_mgr;
+  std::unique_ptr<cpu_common::StaticTensorManager> _static_tensor_mgr;
   ir::OperandIndexMap<ir::OperandInfo> _tensor_info_map;
   ir::OperandIndexMap<ir::Layout> _tensor_layout_map;
 };

--- a/runtime/onert/core/src/backend/cpu_common/StaticTensorManager.cc
+++ b/runtime/onert/core/src/backend/cpu_common/StaticTensorManager.cc
@@ -26,8 +26,10 @@ namespace backend
 namespace cpu_common
 {
 
-StaticTensorManager::StaticTensorManager(const std::shared_ptr<TensorRegistry> &reg)
-    : _const_mgr{new DynamicMemoryManager()}, _nonconst_mgr{new MemoryManager()}, _tensors{reg}
+StaticTensorManager::StaticTensorManager(const std::shared_ptr<TensorRegistry> &reg,
+                                         IDynamicTensorManager *dynamic_tensor_manager)
+    : _const_mgr{new DynamicMemoryManager()}, _nonconst_mgr{new MemoryManager()}, _tensors{reg},
+      _dynamic_tensor_manager{dynamic_tensor_manager}
 {
   // DO NOTHING
 }
@@ -78,7 +80,7 @@ void StaticTensorManager::buildTensor(const ir::OperandIndex &ind,
                                       bool as_const)
 {
   assert(!_tensors->getNativeTensor(ind));
-  auto tensor = std::make_shared<Tensor>(tensor_info, backend_layout, nullptr);
+  auto tensor = std::make_shared<Tensor>(tensor_info, backend_layout, _dynamic_tensor_manager);
   _tensors->setNativeTensor(ind, tensor);
   _as_constants[ind] = as_const;
 }


### PR DESCRIPTION
Set `dynamic_tensor_manager` for static tensors in controlflow backend.
This is needed as any static tensors could turn into dynamic.

% Same approach has been applied for cpu backend, but not for controflow
yet.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>