### PR TITLE
[TensorFlowLiteRecipes] Add test.rule to Net_TConv_BN_000

### DIFF
--- a/res/TensorFlowLiteRecipes/Net_TConv_BN_000/test.rule
+++ b/res/TensorFlowLiteRecipes/Net_TConv_BN_000/test.rule
@@ -1,0 +1,7 @@
+# To check if BatchNorm op(mul + add) is fused to Transposed Convolution op
+
+RULE    "VERIFY_FILE_FORMAT"      $(verify_file_format) '=' 1
+
+RULE    "TCONV_EXIST"             $(op_count TRANSPOSE_CONV) '=' 1
+RULE    "NO_MUL"                  $(op_count MUL) '=' 0
+RULE    "NO_ADD"                  $(op_count ADD) '=' 0


### PR DESCRIPTION
This commit adds test.rule to Net_TConv_BN_000.

Draft : #3660 
Related : #3565 
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>