### PR TITLE
[onert] Make nnpackage_run read shape info from input h5 file

### DIFF
--- a/tests/tools/nnpackage_run/src/args.h
+++ b/tests/tools/nnpackage_run/src/args.h
@@ -22,12 +22,23 @@
 #include <vector>
 #include <boost/program_options.hpp>
 
+#include "types.h"
+
 namespace po = boost::program_options;
 
 namespace nnpkg_run
 {
 
-using TensorShapeMap = std::unordered_map<uint32_t, std::vector<int>>;
+using TensorShapeMap = std::unordered_map<uint32_t, TensorShape>;
+
+#if defined(ONERT_HAVE_HDF5) && ONERT_HAVE_HDF5 == 1
+enum class WhenToUseH5Shape
+{
+  DO_NOT_USE, // don't use shapes in h5 file
+  PREPARE,    // read shapes in h5 file and set them as inputs' shape before calling nnfw_prepare()
+  RUN,        // read shapes in h5 file and set them as inputs' shape before calling nnfw_run()
+};
+#endif
 
 class Args
 {
@@ -39,6 +50,7 @@ public:
 #if defined(ONERT_HAVE_HDF5) && ONERT_HAVE_HDF5 == 1
   const std::string &getDumpFilename(void) const { return _dump_filename; }
   const std::string &getLoadFilename(void) const { return _load_filename; }
+  WhenToUseH5Shape getWhenToUseH5Shape(void) const { return _when_to_use_h5_shape; }
 #endif
   const int getNumRuns(void) const { return _num_runs; }
   const int getWarmupRuns(void) const { return _warmup_runs; }
@@ -48,8 +60,8 @@ public:
   const bool getMemoryPoll(void) const { return _mem_poll; }
   const bool getWriteReport(void) const { return _write_report; }
   const bool printVersion(void) const { return _print_version; }
-  const TensorShapeMap &getShapeMapForPrepare() { return _shape_prepare; }
-  const TensorShapeMap &getShapeMapForRun() { return _shape_run; }
+  TensorShapeMap &getShapeMapForPrepare() { return _shape_prepare; }
+  TensorShapeMap &getShapeMapForRun() { return _shape_run; }
   const int getVerboseLevel(void) const { return _verbose_level; }
 
 private:
@@ -64,6 +76,7 @@ private:
 #if defined(ONERT_HAVE_HDF5) && ONERT_HAVE_HDF5 == 1
   std::string _dump_filename;
   std::string _load_filename;
+  WhenToUseH5Shape _when_to_use_h5_shape = WhenToUseH5Shape::DO_NOT_USE;
 #endif
   TensorShapeMap _shape_prepare;
   TensorShapeMap _shape_run;

--- a/tests/tools/nnpackage_run/src/h5formatter.h
+++ b/tests/tools/nnpackage_run/src/h5formatter.h
@@ -20,6 +20,7 @@
 #include <string>
 #include <vector>
 
+#include "types.h"
 #include "allocation.h"
 
 struct nnfw_session;
@@ -30,6 +31,7 @@ class H5Formatter
 {
 public:
   H5Formatter(nnfw_session *sess) : session_(sess) {}
+  std::vector<TensorShape> readTensorShapes(const std::string &filename);
   void loadInputs(const std::string &filename, std::vector<Allocation> &inputs);
   void dumpOutputs(const std::string &filename, std::vector<Allocation> &outputs);
 

--- a/tests/tools/nnpackage_run/src/types.h
+++ b/tests/tools/nnpackage_run/src/types.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __NNPACKAGE_RUN_TYPES_H__
+#define __NNPACKAGE_RUN_TYPES_H__
+
+namespace nnpkg_run
+{
+
+using TensorShape = std::vector<int>;
+
+} // end of namespace nnpkg_run
+
+#endif // __NNPACKAGE_RUN_TYPES_H__


### PR DESCRIPTION
Parent issue: #3840

This adds `h5` into `--shape_prepare` and `--shape_run` param, which reads shape from h5 file.

For example,
```
$ ./Product/out/bin/nnpackage_run --nnpackage ${NNPACKAGE} --load ${H5_INPUT_FILE} \
  --shape_run h5 ...
```

Of course, explicit shape also work:

```
$ ./Product/out/bin/nnpackage_run --nnpackage ${NNPACKAGE} --load ${H5_INPUT_FILE} \
  --shape_run "[0,[10,1]]" ...
```

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>
