### PR TITLE
[tests] exclude TransposeConv test from nnpkg test of acl_cl, acl_neon

### DIFF
--- a/tests/scripts/list/nnpkg_test_list.armv7l-linux.acl_cl
+++ b/tests/scripts/list/nnpkg_test_list.armv7l-linux.acl_cl
@@ -22,7 +22,7 @@ MaxPool2D_000.opt
 Mean_000.opt
 Mean_001.opt
 Mul_000.opt
-Net_TConv_BN_000.opt
+#Net_TConv_BN_000.opt
 Net_UnpackAdd_001.opt
 Pad_000.opt
 Quantization_000.opt
@@ -33,8 +33,8 @@ Softmax_000.opt
 SpaceToDepth_U8_000.opt
 Split_000.opt
 #Tanh_U8_000.opt
-TransposeConv_000.opt
-TransposeConv_001.opt
+#TransposeConv_000.opt
+#TransposeConv_001.opt
 Transpose_000.opt
 Unpack_000.opt
 Unpack_001.opt

--- a/tests/scripts/list/nnpkg_test_list.armv7l-linux.acl_neon
+++ b/tests/scripts/list/nnpkg_test_list.armv7l-linux.acl_neon
@@ -22,7 +22,7 @@ MaxPool2D_000.opt
 Mean_000.opt
 Mean_001.opt
 Mul_000.opt
-Net_TConv_BN_000.opt
+#Net_TConv_BN_000.opt
 Net_UnpackAdd_001.opt
 Pad_000.opt
 Quantization_000.opt
@@ -33,8 +33,8 @@ Reshape_002.opt
 SpaceToDepth_U8_000.opt
 Split_000.opt
 #Tanh_U8_000.opt
-TransposeConv_000.opt
-TransposeConv_001.opt
+#TransposeConv_000.opt
+#TransposeConv_001.opt
 Transpose_000.opt
 Unpack_000.opt
 Unpack_001.opt


### PR DESCRIPTION
This commit excludes TransposeConv test from nnpkg test of ac_cl,
acl_neon.

Since runtime doesn't support optional input, it will be excluded until
runtime support it.

Related : #3870 
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>