### PR TITLE
[one-cmds] Revise one-import-tf

### DIFF
--- a/compiler/one-cmds/one-import-tf
+++ b/compiler/one-cmds/one-import-tf
@@ -84,10 +84,7 @@ while [ "$#" -ne 0 ]; do
 done
 
 if [ -n ${INPUT_SHAPES} ] && [ ${TF_INTERFACE} = "--v2" ]; then
-  echo "Error: shape cannot be assigned to dynamic shape in v2 version."
-  echo ""
-  usage
-  exit 2
+  echo "Warning: if --v2 option is used, shape will be ignored"
 fi
 
 if [ -z ${INPUT_PATH} ] || [ ! -e ${INPUT_PATH} ]; then

--- a/compiler/one-cmds/one-import-tf
+++ b/compiler/one-cmds/one-import-tf
@@ -83,6 +83,13 @@ while [ "$#" -ne 0 ]; do
   esac
 done
 
+if [ -n ${INPUT_SHAPES} ] && [ ${TF_INTERFACE} = "--v2" ]; then
+  echo "Error: shape cannot be assigned to dynamic shape in v2 version."
+  echo ""
+  usage
+  exit 2
+fi
+
 if [ -z ${INPUT_PATH} ] || [ ! -e ${INPUT_PATH} ]; then
   echo "Error: input model not found"
   echo ""
@@ -117,16 +124,18 @@ show_err_onexit()
 trap show_err_onexit ERR
 
 # generate temporary tflite file
-echo "python" "${DRIVER_PATH}/tf2tfliteV2.py" ${TF_INTERFACE} --input_path ${INPUT_PATH} \
---input_arrays ${INPUT_ARRAYS} --input_shapes ${INPUT_SHAPES} \
---output_path "${TMPDIR}/${MODEL_NAME}.tflite" \
---output_arrays ${OUTPUT_ARRAYS} > "${OUTPUT_PATH}.log"
-echo " " >> "${OUTPUT_PATH}.log"
+CONVERT_SCRIPT="python ${DRIVER_PATH}/tf2tfliteV2.py ${TF_INTERFACE} "
+CONVERT_SCRIPT+="--input_path ${INPUT_PATH} "
+CONVERT_SCRIPT+="--input_arrays ${INPUT_ARRAYS} "
+CONVERT_SCRIPT+="--output_path ${TMPDIR}/${MODEL_NAME}.tflite "
+CONVERT_SCRIPT+="--output_arrays ${OUTPUT_ARRAYS} "
+if [ ! -z ${INPUT_SHAPES} ]; then
+  CONVERT_SCRIPT+="--input_shapes ${INPUT_SHAPES} "
+fi
 
-python "${DRIVER_PATH}/tf2tfliteV2.py" ${TF_INTERFACE} --input_path ${INPUT_PATH} \
---input_arrays ${INPUT_ARRAYS} --input_shapes ${INPUT_SHAPES} \
---output_path "${TMPDIR}/${MODEL_NAME}.tflite" \
---output_arrays ${OUTPUT_ARRAYS} >> "${OUTPUT_PATH}.log" 2>&1
+echo ${CONVERT_SCRIPT} > "${OUTPUT_PATH}.log"
+echo "" >> "${OUTPUT_PATH}.log"
+$CONVERT_SCRIPT >> "${OUTPUT_PATH}.log" 2>&1
 
 # convert .tflite to .circle
 echo " " >> "${OUTPUT_PATH}.log"


### PR DESCRIPTION
This commit revises one-import-tf.

- `--input_shapes` and `--v2` becomes exclusive
- `--input_shapes` becomes optional

Related : #3831
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>