### PR TITLE
[circle2circle] Add FuseBatchNormWithTConv option

### DIFF
--- a/compiler/circle2circle/src/Circle2Circle.cpp
+++ b/compiler/circle2circle/src/Circle2Circle.cpp
@@ -60,6 +60,12 @@ int entry(int argc, char **argv)
   arser.add_argument("--all").nargs(0).required(false).default_value(false).help(
       "Enable all optimize options");
 
+  arser.add_argument("--fuse_batchnorm_with_tconv")
+      .nargs(0)
+      .required(false)
+      .default_value(false)
+      .help("This will fuse BatchNorm operators to Transposed Convolution operator");
+
   arser.add_argument("--fuse_bcq")
       .nargs(0)
       .required(false)
@@ -124,6 +130,8 @@ int entry(int argc, char **argv)
     options->enable(Algorithms::ResolveCustomOpBatchMatMul);
     options->enable(Algorithms::ResolveCustomOpMatMul);
   }
+  if (arser.get<bool>("--fuse_batchnorm_with_tconv"))
+    options->enable(Algorithms::FuseBatchNormWithTConv);
   if (arser.get<bool>("--fuse_bcq"))
     options->enable(Algorithms::FuseBCQ);
   if (arser.get<bool>("--fuse_instnorm"))


### PR DESCRIPTION
This commit adds FuseBatchNormWithTConv option to circle2circle.

Draft : #3660
Related : #3565
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>