### PR TITLE
[circle2circle-dredd-recipe-test] Add Net_TConv_BN_000 test

### DIFF
--- a/compiler/circle2circle-dredd-recipe-test/test.lst
+++ b/compiler/circle2circle-dredd-recipe-test/test.lst
@@ -10,6 +10,7 @@
 
 ## TFLITE RECIPE
 
+Add(Net_TConv_BN_000 PASS fuse_batchnorm_with_tconv)
 Add(Net_InstanceNorm_001 PASS fuse_instnorm)
 Add(Net_InstanceNorm_002 PASS fuse_instnorm)
 Add(BatchMatMulV2_000 PASS resolve_customop_batchmatmul)


### PR DESCRIPTION
This commit adds Net_TConv_BN_000 test to
circle2circle-dredd-recipe-test.

Draft : #3660
Related : #3565
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>