### PR TITLE
[onert] Remove `ITensorBuilder::setMigrantTensor`

### DIFF
--- a/runtime/onert/backend/cpu/TensorBuilder.cc
+++ b/runtime/onert/backend/cpu/TensorBuilder.cc
@@ -85,12 +85,6 @@ void TensorBuilder::allocate()
   //      This is because CPU kernels require `ITensor`s to be allocated before Kernel Generation.
 }
 
-bool TensorBuilder::setMigrantTensor(const ir::OperandIndex &ind,
-                                     const std::shared_ptr<IPortableTensor> &tensor)
-{
-  return _tensor_reg->setMigrantTensor(ind, tensor);
-}
-
 std::unique_ptr<ITensorManager> TensorBuilder::releaseStaticTensorManager(void)
 {
   return std::move(_static_tensor_mgr);

--- a/runtime/onert/backend/cpu/TensorBuilder.h
+++ b/runtime/onert/backend/cpu/TensorBuilder.h
@@ -64,9 +64,6 @@ public:
 
   std::unique_ptr<ITensorManager> releaseDynamicTensorManager(void) override;
 
-  bool setMigrantTensor(const ir::OperandIndex &ind,
-                        const std::shared_ptr<IPortableTensor> &tensor) override;
-
   std::shared_ptr<ITensorRegistry> tensorRegistry() override { return _tensor_reg; }
 
 private:

--- a/runtime/onert/core/include/backend/ITensorBuilder.h
+++ b/runtime/onert/core/include/backend/ITensorBuilder.h
@@ -97,16 +97,6 @@ public: // methods for static tensor allocation
    *        called.
    */
   virtual void postFunctionPrepare() = 0;
-  /**
-   * @brief Set the migrant tensor object
-   *
-   * @return true if succeeded
-   * @return false if failed or unsupported
-   */
-  virtual bool setMigrantTensor(const ir::OperandIndex &, const std::shared_ptr<IPortableTensor> &)
-  {
-    return false;
-  }
 
   /**
    * @brief Release static @c ITensorManger object which was built

--- a/runtime/onert/core/include/backend/ITensorRegistry.h
+++ b/runtime/onert/core/include/backend/ITensorRegistry.h
@@ -21,6 +21,7 @@
 
 #include "ir/Index.h"
 #include "backend/ITensor.h"
+#include "backend/IPortableTensor.h"
 
 namespace onert
 {
@@ -51,13 +52,22 @@ struct ITensorRegistry
    * @note  Returned tensor cannot be used longer than dynamic tensor manager
    */
   virtual std::shared_ptr<ITensor> getNativeITensor(const ir::OperandIndex &) = 0;
+  /**
+   * @brief Set the Migrant Tensor which are from other backends
+   *
+   * @return true if supported
+   * @return false if not supported
+   */
+  virtual bool setMigrantTensor(const ir::OperandIndex &, const std::shared_ptr<IPortableTensor> &)
+  {
+    return false;
+  }
 };
 
 } // namespace backend
 } // namespace onert
 
 #include "ir/OperandIndexMap.h"
-#include "backend/IPortableTensor.h"
 
 namespace onert
 {
@@ -108,7 +118,8 @@ public:
     return nullptr;
   }
 
-  bool setMigrantTensor(const ir::OperandIndex &ind, const std::shared_ptr<IPortableTensor> &tensor)
+  bool setMigrantTensor(const ir::OperandIndex &ind,
+                        const std::shared_ptr<IPortableTensor> &tensor) override
   {
     assert(tensor != nullptr);
     auto itr = _native.find(ind);

--- a/runtime/onert/core/src/backend/controlflow/TensorRegistry.h
+++ b/runtime/onert/core/src/backend/controlflow/TensorRegistry.h
@@ -93,7 +93,8 @@ public:
     return nullptr;
   }
 
-  bool setMigrantTensor(ir::OperandIndex ind, const std::shared_ptr<IPortableTensor> &tensor)
+  bool setMigrantTensor(const ir::OperandIndex &ind,
+                        const std::shared_ptr<IPortableTensor> &tensor) override
   {
     assert(tensor);
     assert(!getITensor(ind)); // For the ind, tensor is not registered yet

--- a/runtime/onert/core/src/compiler/ExecutorFactory.h
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.h
@@ -23,6 +23,7 @@
 #include "exec/IExecutor.h"
 #include "compiler/LoweredGraph.h"
 #include "TensorBuilders.h"
+#include "TensorRegistries.h"
 
 namespace onert
 {
@@ -49,8 +50,7 @@ private:
   static std::vector<std::shared_ptr<backend::ITensor>>
   initializeModelIOTensors(compiler::LoweredGraph &lowered_graph,
                            const ir::OperandIndexSequence &indices);
-  static void prepareExternalTensors(compiler::LoweredGraph &lowered_graph,
-                                     TensorBuilders &tensor_builders);
+  static void prepareExternalTensors(compiler::LoweredGraph &lowered_graph);
   static exec::IExecutor *
   createLinearExecutor(std::unique_ptr<compiler::LoweredGraph> lowered_graph,
                        const compiler::CompilerOptions &options,

--- a/runtime/onert/core/src/compiler/TensorRegistries.h
+++ b/runtime/onert/core/src/compiler/TensorRegistries.h
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_COMPILER_TENSOR_REGISTRIES_H__
+#define __ONERT_COMPILER_TENSOR_REGISTRIES_H__
+
+#include <unordered_set>
+#include <memory>
+#include "backend/BackendContext.h"
+#include "backend/Backend.h"
+#include "backend/controlflow/Config.h"
+#include "backend/controlflow/TensorBuilder.h"
+#include "backend/controlflow/TensorRegistry.h"
+
+namespace onert
+{
+namespace compiler
+{
+
+class TensorRegistries
+{
+public:
+  TensorRegistries() = default;
+
+  TensorRegistries(const onert::backend::BackendContexts &backend_contexts,
+                   bool include_controlflow)
+  {
+    for (const auto &e : backend_contexts)
+    {
+      auto tensor_reg = e.second->tensor_builder->tensorRegistry();
+      if (e.first->config()->id() == backend::controlflow::Config::ID)
+      {
+        _cf_tensor_reg =
+            std::dynamic_pointer_cast<backend::controlflow::TensorRegistry>(tensor_reg);
+        if (include_controlflow)
+          _tensor_regs.insert(tensor_reg);
+      }
+      else
+      {
+        _tensor_regs.insert(tensor_reg);
+      }
+    }
+  }
+
+  std::unordered_set<std::shared_ptr<onert::backend::ITensorRegistry>>::const_iterator begin() const
+  {
+    return _tensor_regs.cbegin();
+  }
+  std::unordered_set<std::shared_ptr<onert::backend::ITensorRegistry>>::const_iterator end() const
+  {
+    return _tensor_regs.cend();
+  }
+
+  std::shared_ptr<backend::controlflow::TensorRegistry> getControlflowTensorRegistry() const
+  {
+    return _cf_tensor_reg;
+  }
+
+  std::shared_ptr<backend::ITensor> getITensor(ir::OperandIndex ind)
+  {
+    for (auto &tensor_reg : _tensor_regs)
+    {
+      auto tensor = tensor_reg->getITensor(ind);
+      if (tensor)
+        return tensor;
+    }
+    return nullptr;
+  }
+
+private:
+  std::unordered_set<std::shared_ptr<backend::ITensorRegistry>> _tensor_regs;
+  std::shared_ptr<backend::controlflow::TensorRegistry> _cf_tensor_reg;
+};
+
+} // namespace compiler
+} // namespace onert
+
+#endif // __ONERT_COMPILER_TENSOR_REGISTRIES_H__


### PR DESCRIPTION
Replace TensorBuilder with TensorRegistry in ExecutorFactory.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>