### PR TITLE
[onert] Remove unused object in DynamicShapeInferer

### DIFF
--- a/runtime/onert/backend/cpu/KernelGenerator.cc
+++ b/runtime/onert/backend/cpu/KernelGenerator.cc
@@ -219,9 +219,7 @@ void KernelGenerator::visit(const ir::OpSequence &op_seq)
   assert(_tensor_builder->dynamicTensorManager());
   assert(_tensor_reg);
 
-  auto dyn_tensor_manager = _tensor_builder->dynamicTensorManager();
-  auto dyn_shape_inferer =
-      std::make_shared<exec::DynamicShapeInferer>(_ctx, dyn_tensor_manager, _tensor_reg);
+  auto dyn_shape_inferer = std::make_shared<exec::DynamicShapeInferer>(_ctx, _tensor_reg);
 
   _return_fn_seq = std::make_unique<exec::FunctionSequence>();
 

--- a/runtime/onert/core/include/exec/DynamicShapeInference.h
+++ b/runtime/onert/core/include/exec/DynamicShapeInference.h
@@ -38,13 +38,11 @@ namespace exec
 class DynamicShapeInferer : public ir::OperationVisitor
 {
 public:
-  DynamicShapeInferer(const ir::Operands &operands, backend::IDynamicTensorManager *tensor_manager,
+  DynamicShapeInferer(const ir::Operands &operands,
                       const std::shared_ptr<backend::ITensorRegistry> &tensor_registry)
-      : _operands(operands), _dynamic_tensor_manager(tensor_manager),
-        _tensor_registry(tensor_registry)
+      : _operands(operands), _tensor_registry(tensor_registry)
   {
     UNUSED_RELEASE(_operands);
-    UNUSED_RELEASE(_dynamic_tensor_manager);
     UNUSED_RELEASE(_tensor_registry);
   }
 
@@ -110,11 +108,6 @@ private:
    * @brief To get operand-level info, e.g., ir::Operand::isConstant()
    */
   const ir::Operands &_operands;
-  /**
-   * @brief To allocate memory for output tensor if needed
-   */
-  // TODO Remove this, as it is no longer used
-  backend::IDynamicTensorManager *_dynamic_tensor_manager;
   /**
    * @brief To get tensor object and access tensor-level info, e.g., ITensor::buffer()
    */

--- a/runtime/onert/core/src/backend/controlflow/KernelGenerator.cc
+++ b/runtime/onert/core/src/backend/controlflow/KernelGenerator.cc
@@ -48,9 +48,8 @@ void KernelGenerator::visit(const ir::OpSequence &op_seq)
   assert(_tensor_builder->dynamicTensorManager());
   assert(_tensor_reg);
 
-  auto dyn_tensor_manager = _tensor_builder->dynamicTensorManager();
-  auto dyn_shape_inferer = std::make_unique<exec::DynamicShapeInferer>(
-      _graph.operands(), dyn_tensor_manager, _tensor_reg);
+  auto dyn_shape_inferer =
+      std::make_unique<exec::DynamicShapeInferer>(_graph.operands(), _tensor_reg);
 
   _return_fn_seq = std::make_unique<exec::FunctionSequence>();
 

--- a/runtime/onert/core/src/exec/DynamicShapeInference.cc
+++ b/runtime/onert/core/src/exec/DynamicShapeInference.cc
@@ -712,7 +712,7 @@ void DynamicShapeInferer::visit(const ir::operation::ResizeBilinear &op)
   if (output_shape != output->getShape() || output->buffer() == nullptr)
   {
     // change on output shape
-    _dynamic_tensor_manager->applyShape(output_ind, output_shape);
+    dynamicTensorManagerOf(output)->applyShape(output_ind, output_shape);
   }
   assert(output->buffer() != nullptr);
 }


### PR DESCRIPTION
Remove unused object `_dynamic_tensor_manager` since now we use
individual `ITensor`'s dynamic tensor manager object.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>