### PR TITLE
[souschef] common as_vector as_dataset

### DIFF
--- a/compiler/souschef/CMakeLists.txt
+++ b/compiler/souschef/CMakeLists.txt
@@ -1,5 +1,13 @@
+nnas_find_package(Protobuf QUIET)
+
+if(NOT Protobuf_FOUND)
+  message(STATUS "Build souschef: FAILED (missing Protobuf")
+  return()
+endif(NOT Protobuf_FOUND)
+
 file(GLOB_RECURSE SOURCES "src/*.cpp")
 
 add_library(souschef STATIC ${SOURCES})
 set_target_properties(souschef PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_include_directories(souschef PUBLIC include)
+target_link_libraries(souschef PUBLIC libprotobuf)

--- a/compiler/souschef/include/souschef/Dataset.h
+++ b/compiler/souschef/include/souschef/Dataset.h
@@ -19,6 +19,8 @@
 
 #include <vector>
 
+#include <google/protobuf/repeated_field.h>
+
 namespace souschef
 {
 
@@ -56,6 +58,21 @@ public:
 private:
   std::vector<T> _vec;
 };
+
+template <typename T> std::vector<T> as_vector(const ::google::protobuf::RepeatedPtrField<T> &field)
+{
+  std::vector<T> res;
+  for (const auto &elem : field)
+  {
+    res.emplace_back(elem);
+  }
+  return res;
+}
+
+template <typename T> Dataset<T> as_dataset(const ::google::protobuf::RepeatedPtrField<T> &field)
+{
+  return Dataset<T>(as_vector<T>(field));
+}
 
 } // namespace souschef
 


### PR DESCRIPTION
This will introduce common as_vector as_dataset methods from circlechef and tflchef

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>