### PR TITLE
[onert] Do nothing when 'passed shape of nnfw_set_tensorinfo() == model shape' 

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -481,26 +481,27 @@ NNFW_STATUS nnfw_session::apply_tensorinfo(uint32_t index, nnfw_tensorinfo ti)
     }
   }
 
+  auto ind = primary_subgraph()->getInputs().at(index);
+  auto &input = primary_subgraph()->operands().at(ind);
+
+  onert::ir::Shape new_shape(ti.rank);
+  for (int32_t i = 0; i < ti.rank; i++)
+    new_shape.dim(i) = ti.dims[i];
+
+  // if passed shape is same with the shape of model, do nothing
+  if (input.info().shape() == new_shape)
+    return NNFW_STATUS_NO_ERROR;
+
   if (!isStatePreparedOrFinishedRun())
   {
     // In this case, if we apply input shape in primary_subgraph, it will propagate after
     // compilation and excution
-    auto ind = primary_subgraph()->getInputs().at(index);
-    auto &input = primary_subgraph()->operands().at(ind);
-
-    onert::ir::Shape new_shape(ti.rank);
-    for (int32_t i = 0; i < ti.rank; i++)
-      new_shape.dim(i) = ti.dims[i];
 
     // overwrite input shape with the shape from ti
     input.info().shape(new_shape);
   }
   else // when called after nnfw_session::prepare()
   {
-    onert::ir::Shape new_shape(ti.rank);
-    for (int32_t i = 0; i < ti.rank; i++)
-      new_shape.dim(i) = ti.dims[i];
-
     _execution->changeInputShape(onert::ir::IOIndex(index), new_shape);
   }
 


### PR DESCRIPTION
This makes `nnfw_set_input_tensorinfo()` do nothing when 'passed shape == model shape'.

related: https://github.com/Samsung/ONE/pull/3965#issuecomment-679777002

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>