### PR TITLE
[acl-ex] Check reduce axis set size before use

### DIFF
--- a/compute/ARMComputeEx/src/runtime/CL/functions/CLReduceOperation.cpp
+++ b/compute/ARMComputeEx/src/runtime/CL/functions/CLReduceOperation.cpp
@@ -59,6 +59,8 @@ Status CLReduceOperation::validate(const ITensorInfo *input, const ITensorInfo *
   const size_t num_of_kernels = axis.size();
   const size_t num_of_interm_tensors = num_of_kernels - (keep_dims ? 1 : 0);
 
+  ARM_COMPUTE_RETURN_ERROR_ON(num_of_kernels < 1);
+
   // Create temporary tensor infos
   auto interm_tensors = support::cpp14::make_unique<TensorInfo[]>(num_of_interm_tensors);
 


### PR DESCRIPTION
Check reduced axis set has at least one element

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: https://github.com/Samsung/ONE/issues/1635#issuecomment-680395192