### PR TITLE
[onert] Renaming member var name of IODescription

### DIFF
--- a/runtime/onert/core/include/exec/IODescription.h
+++ b/runtime/onert/core/include/exec/IODescription.h
@@ -62,8 +62,8 @@ struct IODescription
 {
   std::vector<std::unique_ptr<InputDesc>> inputs;
   std::vector<std::unique_ptr<OutputDesc>> outputs;
-  // Contains shape of input set by set_input_tensorinfo
-  std::unordered_map<ir::IOIndex, ir::Shape> input_shape_signature;
+  // Contains shape of input set by nnfw_set_input_tensorinfo(..)
+  std::unordered_map<ir::IOIndex, ir::Shape> dynamic_input_shapes;
 };
 
 } // namespace exec

--- a/runtime/onert/core/src/exec/Execution.cc
+++ b/runtime/onert/core/src/exec/Execution.cc
@@ -38,7 +38,10 @@ void Execution::changeInputShape(const ir::IOIndex &index, const ir::Shape &new_
   if (_io_desc.inputs.at(index.value()) != 0)
     throw std::runtime_error("Error in calling order");
 
-  _io_desc.input_shape_signature[index] = new_shape;
+  // This will be used later to set input tensor dynamic
+  // Note that 'compiled' model will not be updated with new_shape
+  // but new_shape will change model input shape while 'running' the model
+  _io_desc.dynamic_input_shapes[index] = new_shape;
 }
 
 // TODO Remove default parameter
@@ -54,8 +57,8 @@ void Execution::setInput(const ir::IOIndex &index, const void *buffer, size_t le
   // if input_shape_sig is set, input_shape_sig overrides shape in info
   // note: input_shape_sig contains shape passed by nnfw_set_input_tensorinfo()
   {
-    auto input_shape_sig = _io_desc.input_shape_signature.find(index);
-    auto size_required = (input_shape_sig != _io_desc.input_shape_signature.end())
+    auto input_shape_sig = _io_desc.dynamic_input_shapes.find(index);
+    auto size_required = (input_shape_sig != _io_desc.dynamic_input_shapes.end())
                              ? input_shape_sig->second.num_elements() *
                                    onert::ir::sizeOfDataType(info.typeInfo().type())
                              : info.total_size();
@@ -154,8 +157,8 @@ bool Execution::isFinished(void) const { return finished; }
 
 ir::Shape Execution::getInputShape(ir::IOIndex ind) const
 {
-  auto itr = _io_desc.input_shape_signature.find(ind);
-  if (itr == _io_desc.input_shape_signature.end())
+  auto itr = _io_desc.dynamic_input_shapes.find(ind);
+  if (itr == _io_desc.dynamic_input_shapes.end())
   {
     auto operand_idx = primary_subgraph().getInputs().at(ind.value());
     return primary_subgraph().operands().at(operand_idx).shape();

--- a/runtime/onert/core/src/exec/ExecutorBase.cc
+++ b/runtime/onert/core/src/exec/ExecutorBase.cc
@@ -183,8 +183,8 @@ void ExecutorBase::execute(const IODescription &desc)
     // TODO Remove dynamic_cast
     auto tensor = std::dynamic_pointer_cast<backend::controlflow::UserTensor>(_input_tensors[i]);
     assert(tensor);
-    auto input_shape = desc.input_shape_signature.find(ir::IOIndex{i});
-    if (input_shape != desc.input_shape_signature.end())
+    auto input_shape = desc.dynamic_input_shapes.find(ir::IOIndex{i});
+    if (input_shape != desc.dynamic_input_shapes.end())
     {
       tensor->set_dynamic();
       tensor->setShape(input_shape->second);
@@ -249,8 +249,8 @@ void ExecutorBase::execute(const IODescription &desc)
  */
 void ExecutorBase::handleDynamicInputTensor(ir::IOIndex io_ind, const IODescription &desc)
 {
-  auto shape_sig_found = desc.input_shape_signature.find(io_ind);
-  if (shape_sig_found != desc.input_shape_signature.end())
+  auto shape_sig_found = desc.dynamic_input_shapes.find(io_ind);
+  if (shape_sig_found != desc.dynamic_input_shapes.end())
   {
     auto dyn_alloc_info = _input_to_dyn_alloc_info.find(_input_tensors[io_ind.value()]);
     if (dyn_alloc_info == _input_to_dyn_alloc_info.end())


### PR DESCRIPTION
Related https://github.com/Samsung/ONE/pull/3998#issuecomment-681204641

This renames member var name for better readability and adds more comment:
- from `IODescription::input_shape_signature`
- to `IODescription::dynamic_input_shapes`

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>
