### PR TITLE
[onert] CF KernelGen use IDynamicTensorManager

### DIFF
--- a/runtime/onert/core/src/backend/controlflow/Backend.h
+++ b/runtime/onert/core/src/backend/controlflow/Backend.h
@@ -69,7 +69,7 @@ public:
     auto tr = std::dynamic_pointer_cast<TensorRegistry>(tb->tensorRegistry());
     context->tensor_builder = tb;
     context->constant_initializer = std::make_shared<ConstantInitializer>(operands, tr);
-    context->kernel_gen = std::make_shared<KernelGenerator>(graph, tb, tr);
+    context->kernel_gen = std::make_shared<KernelGenerator>(graph, tb->dynamicTensorManager(), tr);
     context->tensor_register = nullptr;
     context->optimizer = nullptr;
     return context;

--- a/runtime/onert/core/src/backend/controlflow/KernelGenerator.cc
+++ b/runtime/onert/core/src/backend/controlflow/KernelGenerator.cc
@@ -31,10 +31,9 @@ namespace backend
 namespace controlflow
 {
 
-KernelGenerator::KernelGenerator(const ir::Graph &graph,
-                                 const std::shared_ptr<TensorBuilder> &tensor_builder,
+KernelGenerator::KernelGenerator(const ir::Graph &graph, IDynamicTensorManager *dyn_tensor_manager,
                                  const std::shared_ptr<TensorRegistry> &tensor_reg)
-    : _graph{graph}, _tensor_builder{tensor_builder}, _tensor_reg{tensor_reg},
+    : _graph{graph}, _dyn_tensor_manager{dyn_tensor_manager}, _tensor_reg{tensor_reg},
       _tensor_builder_set{}, _executor_map{nullptr}
 {
   UNUSED_RELEASE(_graph);
@@ -45,7 +44,7 @@ KernelGenerator::KernelGenerator(const ir::Graph &graph,
 void KernelGenerator::visit(const ir::OpSequence &op_seq)
 {
   assert(!_return_fn_seq);
-  assert(_tensor_builder->dynamicTensorManager());
+  assert(_dyn_tensor_manager);
   assert(_tensor_reg);
 
   auto dyn_shape_inferer =
@@ -60,7 +59,7 @@ void KernelGenerator::visit(const ir::OpSequence &op_seq)
     dyn_ctx->operations = &_graph.operations();
     dyn_ctx->dynamic_shape_inferer = std::move(dyn_shape_inferer);
     dyn_ctx->tensor_registry = _tensor_reg;
-    dyn_ctx->dynamic_tensor_manager = _tensor_builder->dynamicTensorManager();
+    dyn_ctx->dynamic_tensor_manager = _dyn_tensor_manager;
 
     _return_fn_seq->dynamic_tensor_ctx(dyn_ctx);
   }

--- a/runtime/onert/core/src/backend/controlflow/KernelGenerator.h
+++ b/runtime/onert/core/src/backend/controlflow/KernelGenerator.h
@@ -35,7 +35,7 @@ namespace controlflow
 class KernelGenerator : public IKernelGenerator
 {
 public:
-  KernelGenerator(const ir::Graph &graph, const std::shared_ptr<TensorBuilder> &tensor_builder,
+  KernelGenerator(const ir::Graph &graph, IDynamicTensorManager *dyn_tensor_manager,
                   const std::shared_ptr<TensorRegistry> &tensor_reg);
 
   void setTensorBuilderSet(const compiler::TensorBuilders &tensor_builder_set)
@@ -60,7 +60,7 @@ private:
 
 private:
   const ir::Graph &_graph;
-  std::shared_ptr<TensorBuilder> _tensor_builder;
+  IDynamicTensorManager *_dyn_tensor_manager;
   std::shared_ptr<TensorRegistry> _tensor_reg;
   compiler::TensorBuilders _tensor_builder_set;
   exec::ExecutorMap *_executor_map;


### PR DESCRIPTION
Make controlfow KernelGen use `IDynamicTensorManager` rather than
`TensorBuilder`, as Dynamic Tensor Manager is what it really needs.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>