### PR TITLE
[luci-interpreter] Add UINT8 for LogSoftmax kernel 

### DIFF
--- a/compiler/luci-interpreter/src/kernels/CMakeLists.txt
+++ b/compiler/luci-interpreter/src/kernels/CMakeLists.txt
@@ -32,6 +32,8 @@ set(SOURCES
     LocalResponseNormalization.cpp
     Logistic.h
     Logistic.cpp
+    LogSoftmax.h
+    LogSoftmax.cpp
     MaxPool2D.h
     MaxPool2D.cpp
     Mean.h
@@ -100,6 +102,7 @@ set(TEST_SOURCES
     LeakyRelu.test.cpp
     LocalResponseNormalization.test.cpp
     Logistic.test.cpp
+    LogSoftmax.test.cpp
     MaxPool2D.test.cpp
     Mean.test.cpp
     Mul.test.cpp

--- a/compiler/luci-interpreter/src/kernels/LogSoftmax.cpp
+++ b/compiler/luci-interpreter/src/kernels/LogSoftmax.cpp
@@ -32,6 +32,11 @@ LogSoftmax::LogSoftmax(const Tensor *input, Tensor *output) : Kernel({input}, {o
 void LogSoftmax::configure()
 {
   LUCI_INTERPRETER_CHECK(input()->element_type() == output()->element_type());
+  if(input()->element_type() == DataType::U8)
+  {
+    LUCI_INTERPRETER_CHECK(output()->scale() == 16. / 256);
+    LUCI_INTERPRETER_CHECK(output()->zero_point() == 255);
+  }
   output()->resize(input()->shape());
 }
 

--- a/compiler/luci-interpreter/src/kernels/LogSoftmax.cpp
+++ b/compiler/luci-interpreter/src/kernels/LogSoftmax.cpp
@@ -82,7 +82,6 @@ void LogSoftmax::evalQuantized() const
   params.table = const_cast<float *>(_table);
   params.zero_point = output()->zero_point();
   params.scale = output()->scale();
-  params.beta = 1.0;
 
   tflite::optimized_ops::LogSoftmax(params, input_scale, input_shape, input_data, output_shape,
                                     output_data);

--- a/compiler/luci-interpreter/src/kernels/LogSoftmax.cpp
+++ b/compiler/luci-interpreter/src/kernels/LogSoftmax.cpp
@@ -62,7 +62,6 @@ void LogSoftmax::evalQuantized() const
   const auto input_shape = getTensorShape(input());
   const auto output_shape = getTensorShape(output());
   const auto input_scale = input()->scale();
-  const int size = tflite::MatchingFlatSize(getTensorShape(input()), getTensorShape(output()));
   uint8_t *output_data = getTensorData<uint8_t>(output());
   const uint8_t *input_data = getTensorData<uint8_t>(input());
 

--- a/compiler/luci-interpreter/src/kernels/LogSoftmax.cpp
+++ b/compiler/luci-interpreter/src/kernels/LogSoftmax.cpp
@@ -74,7 +74,8 @@ void LogSoftmax::evalQuantized() const
   params.beta = 1.0;
 
   tflite::optimized_ops::PopulateSoftmaxLookupTable(&params, input()->scale(), params.beta);
-  tflite::optimized_ops::LogSoftmax(params, input_scale, input_shape, input_data, output_shape, output_data);
+  tflite::optimized_ops::LogSoftmax(params, input_scale, input_shape, input_data, output_shape,
+                                    output_data);
 }
 
 } // namespace kernels

--- a/compiler/luci-interpreter/src/kernels/LogSoftmax.cpp
+++ b/compiler/luci-interpreter/src/kernels/LogSoftmax.cpp
@@ -32,7 +32,7 @@ LogSoftmax::LogSoftmax(const Tensor *input, Tensor *output) : Kernel({input}, {o
 void LogSoftmax::configure()
 {
   LUCI_INTERPRETER_CHECK(input()->element_type() == output()->element_type());
-  if(input()->element_type() == DataType::U8)
+  if (input()->element_type() == DataType::U8)
   {
     LUCI_INTERPRETER_CHECK(output()->scale() == 16. / 256);
     LUCI_INTERPRETER_CHECK(output()->zero_point() == 255);

--- a/compiler/luci-interpreter/src/kernels/LogSoftmax.cpp
+++ b/compiler/luci-interpreter/src/kernels/LogSoftmax.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "kernels/LogSoftmax.h"
+
+#include "kernels/Utils.h"
+
+#include <tensorflow/lite/kernels/internal/reference/reference_ops.h>
+
+#include <tensorflow/lite/kernels/internal/optimized/optimized_ops.h>
+
+namespace luci_interpreter
+{
+namespace kernels
+{
+
+LogSoftmax::LogSoftmax(const Tensor *input, Tensor *output) : Kernel({input}, {output}) {}
+
+void LogSoftmax::configure()
+{
+  assert(input()->element_type() == output()->element_type());
+  output()->resize(input()->shape());
+}
+
+void LogSoftmax::execute() const
+{
+  switch (input()->element_type())
+  {
+    case DataType::FLOAT32:
+      evalFloat();
+      break;
+    case DataType::U8:
+      evalQuantized();
+      break;
+    default:
+      throw std::runtime_error("Unsupported type.");
+  }
+}
+
+void LogSoftmax::evalFloat() const
+{
+  tflite::SoftmaxParams params{};
+  tflite::reference_ops::LogSoftmax(params, getTensorShape(input()), getTensorData<float>(input()),
+                                    getTensorShape(output()), getTensorData<float>(output()));
+}
+
+void LogSoftmax::evalQuantized() const
+{
+  const auto input_shape = getTensorShape(input());
+  const auto output_shape = getTensorShape(output());
+  const auto input_scale = input()->scale();
+  const int size = tflite::MatchingFlatSize(getTensorShape(input()), getTensorShape(output()));
+  uint8_t *output_data = getTensorData<uint8_t>(output());
+  const uint8_t *input_data = getTensorData<uint8_t>(input());
+
+  tflite::SoftmaxParams params{};
+
+  params.table = new float[256];
+  params.zero_point = output()->zero_point();
+  params.scale = output()->scale();
+  params.beta = 1.0;
+
+  tflite::optimized_ops::PopulateSoftmaxLookupTable(&params, input()->scale(), params.beta);
+  tflite::optimized_ops::LogSoftmax(params, input_scale, input_shape, input_data, output_shape, output_data);
+}
+
+} // namespace kernels
+} // namespace luci_interpreter

--- a/compiler/luci-interpreter/src/kernels/LogSoftmax.cpp
+++ b/compiler/luci-interpreter/src/kernels/LogSoftmax.cpp
@@ -31,7 +31,7 @@ LogSoftmax::LogSoftmax(const Tensor *input, Tensor *output) : Kernel({input}, {o
 
 void LogSoftmax::configure()
 {
-  assert(input()->element_type() == output()->element_type());
+  LUCI_INTERPRETER_CHECK(input()->element_type() == output()->element_type());
   output()->resize(input()->shape());
 }
 
@@ -67,7 +67,8 @@ void LogSoftmax::evalQuantized() const
 
   tflite::SoftmaxParams params{};
 
-  params.table = new float[256];
+  float intermediate[256];
+  params.table = intermediate;
   params.zero_point = output()->zero_point();
   params.scale = output()->scale();
   params.beta = 1.0;

--- a/compiler/luci-interpreter/src/kernels/LogSoftmax.h
+++ b/compiler/luci-interpreter/src/kernels/LogSoftmax.h
@@ -38,9 +38,6 @@ public:
 private:
   void evalFloat() const;
   void evalQuantized() const;
-
-private:
-  uint8_t _table[256]{};
 };
 
 } // namespace kernels

--- a/compiler/luci-interpreter/src/kernels/LogSoftmax.h
+++ b/compiler/luci-interpreter/src/kernels/LogSoftmax.h
@@ -38,6 +38,8 @@ public:
 private:
   void evalFloat() const;
   void evalQuantized() const;
+
+  float _table[256];
 };
 
 } // namespace kernels

--- a/compiler/luci-interpreter/src/kernels/LogSoftmax.h
+++ b/compiler/luci-interpreter/src/kernels/LogSoftmax.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef LUCI_INTERPRETER_KERNELS_LOGSOFTMAX_H
+#define LUCI_INTERPRETER_KERNELS_LOGSOFTMAX_H
+
+#include "core/Kernel.h"
+
+namespace luci_interpreter
+{
+namespace kernels
+{
+
+class LogSoftmax : public Kernel
+{
+public:
+  LogSoftmax(const Tensor *input, Tensor *output);
+
+  const Tensor *input() const { return _inputs[0]; }
+  Tensor *output() const { return _outputs[0]; }
+
+  void configure() override;
+  void execute() const override;
+
+private:
+  void evalFloat() const;
+  void evalQuantized() const;
+
+private:
+  uint8_t _table[256]{};
+};
+
+} // namespace kernels
+} // namespace luci_interpreter
+
+#endif // LUCI_INTERPRETER_KERNELS_LOGSOFTMAX_H

--- a/compiler/luci-interpreter/src/kernels/LogSoftmax.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/LogSoftmax.test.cpp
@@ -31,8 +31,8 @@ TEST(LogSoftmaxTest, Float)
 {
   Shape input_shape{2, 4};
   std::vector<float> input_data{
-      0, -6, 2, 4,   //
-      3, -2, 10, 1,  //
+      0, -6, 2,  4, //
+      3, -2, 10, 1, //
   };
   Tensor input_tensor = makeInputTensor<DataType::FLOAT32>(input_shape, input_data);
   Tensor output_tensor = makeOutputTensor(DataType::FLOAT32);
@@ -42,8 +42,8 @@ TEST(LogSoftmaxTest, Float)
   kernel.execute();
 
   std::vector<float> ref_output_data{
-      -4.14297, -10.14297, -2.14297, -.142971,    //
-      -7.00104, -12.00104, -.00104087, -9.00104,  //
+      -4.14297, -10.14297, -2.14297,   -.142971, //
+      -7.00104, -12.00104, -.00104087, -9.00104, //
   };
   EXPECT_THAT(extractTensorData<float>(output_tensor),
               ElementsAreArray(ArrayFloatNear(ref_output_data)));
@@ -53,16 +53,14 @@ TEST(LogSoftmaxTest, Uint8)
 {
   float kMin = -10;
   float kMax = 10;
-  float kLogSoftmaxQuantizedTolerance = (kMax - kMin) / 255.0;;
+  float kLogSoftmaxQuantizedTolerance = (kMax - kMin) / 255.0;
   std::pair<float, int32_t> quant_param = quantizationParams<uint8_t>(kMin, kMax);
   std::vector<float> input_data{
-      0, -6, 2, 4,   //
-      3, -2, 10, 1,  //
+      0, -6, 2,  4, //
+      3, -2, 10, 1, //
   };
-  Tensor input_tensor{
-      DataType::U8, {2, 4}, {{quant_param.first}, {quant_param.second}}, ""};
-  Tensor output_tensor =
-      makeOutputTensor(DataType::U8, 16. / 256, 255);
+  Tensor input_tensor{DataType::U8, {2, 4}, {{quant_param.first}, {quant_param.second}}, ""};
+  Tensor output_tensor = makeOutputTensor(DataType::U8, 16. / 256, 255);
   std::vector<uint8_t> quantize_input =
       quantize<uint8_t>(input_data, quant_param.first, quant_param.second);
   input_tensor.writeData(quantize_input.data(), quantize_input.size() * sizeof(uint8_t));
@@ -72,8 +70,8 @@ TEST(LogSoftmaxTest, Uint8)
   kernel.execute();
 
   std::vector<float> ref_output_data{
-      -4.14297, -10.14297, -2.14297, -.142971,    //
-      -7.00104, -12.00104, -.00104087, -9.00104,  //
+      -4.14297, -10.14297, -2.14297,   -.142971, //
+      -7.00104, -12.00104, -.00104087, -9.00104, //
   };
   std::vector<int32_t> ref_output_shape{2, 4};
   EXPECT_THAT(dequantize<uint8_t>(extractTensorData<uint8_t>(output_tensor), output_tensor.scale(),

--- a/compiler/luci-interpreter/src/kernels/LogSoftmax.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/LogSoftmax.test.cpp
@@ -53,7 +53,7 @@ TEST(LogSoftmaxTest, Uint8)
 {
   float kMin = -10;
   float kMax = 10;
-  float kLogSoftmaxQuantizedTolerance = (kMax - kMin) / 255.0;
+  float kLogSoftmaxQuantizedTolerance = 16. / 256;
   std::pair<float, int32_t> quant_param = quantizationParams<uint8_t>(kMin, kMax);
   std::vector<float> input_data{
       0, -6, 2,  4, //
@@ -78,6 +78,8 @@ TEST(LogSoftmaxTest, Uint8)
                                   output_tensor.zero_point()),
               ElementsAreArray(ArrayFloatNear(ref_output_data, kLogSoftmaxQuantizedTolerance)));
   EXPECT_THAT(extractTensorShape(output_tensor), ::testing::ElementsAreArray(ref_output_shape));
+  EXPECT_THAT(extractTensorData<uint8_t>(output_tensor),
+              ::testing::ElementsAreArray({189, 93, 221, 253, 142, 63, 255, 111}));
 }
 
 } // namespace

--- a/compiler/luci-interpreter/src/kernels/LogSoftmax.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/LogSoftmax.test.cpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "kernels/LogSoftmax.h"
+#include "kernels/TestUtils.h"
+
+namespace luci_interpreter
+{
+namespace kernels
+{
+namespace
+{
+
+using namespace testing;
+
+TEST(LogSoftmaxTest, Float)
+{
+  Shape input_shape{2, 4};
+  std::vector<float> input_data{
+      0, -6, 2, 4,   //
+      3, -2, 10, 1,  //
+  };
+  Tensor input_tensor = makeInputTensor<DataType::FLOAT32>(input_shape, input_data);
+  Tensor output_tensor = makeOutputTensor(DataType::FLOAT32);
+
+  LogSoftmax kernel(&input_tensor, &output_tensor);
+  kernel.configure();
+  kernel.execute();
+
+  std::vector<float> ref_output_data{
+      -4.14297, -10.14297, -2.14297, -.142971,    //
+      -7.00104, -12.00104, -.00104087, -9.00104,  //
+  };
+  EXPECT_THAT(extractTensorData<float>(output_tensor),
+              ElementsAreArray(ArrayFloatNear(ref_output_data)));
+}
+
+TEST(LogSoftmaxTest, Uint8)
+{
+  float kMin = -10;
+  float kMax = 10;
+  float kLogSoftmaxQuantizedTolerance = (kMax - kMin) / 255.0;;
+  std::pair<float, int32_t> quant_param = quantizationParams<uint8_t>(kMin, kMax);
+  std::vector<float> input_data{
+      0, -6, 2, 4,   //
+      3, -2, 10, 1,  //
+  };
+  Tensor input_tensor{
+      DataType::U8, {2, 4}, {{quant_param.first}, {quant_param.second}}, ""};
+  Tensor output_tensor =
+      makeOutputTensor(DataType::U8, 16. / 256, 255);
+  std::vector<uint8_t> quantize_input =
+      quantize<uint8_t>(input_data, quant_param.first, quant_param.second);
+  input_tensor.writeData(quantize_input.data(), quantize_input.size() * sizeof(uint8_t));
+
+  LogSoftmax kernel(&input_tensor, &output_tensor);
+  kernel.configure();
+  kernel.execute();
+
+  std::vector<float> ref_output_data{
+      -4.14297, -10.14297, -2.14297, -.142971,    //
+      -7.00104, -12.00104, -.00104087, -9.00104,  //
+  };
+  std::vector<int32_t> ref_output_shape{2, 4};
+  EXPECT_THAT(dequantize<uint8_t>(extractTensorData<uint8_t>(output_tensor), output_tensor.scale(),
+                                  output_tensor.zero_point()),
+              ElementsAreArray(ArrayFloatNear(ref_output_data, kLogSoftmaxQuantizedTolerance)));
+  EXPECT_THAT(extractTensorShape(output_tensor), ::testing::ElementsAreArray(ref_output_shape));
+}
+
+} // namespace
+} // namespace kernels
+} // namespace luci_interpreter


### PR DESCRIPTION
Parent Issue: #3458 
Fired Issue: #3833 

This commit adds UINT8 handling on `LogSoftmax` kernel.

This commit have been tested on my PC,
and worked well by passing `./nncc build` & `./nncc test`.

Please review this PR, @seanshpark @jinevening @s-barannikov  .
I'll be happy to get feedback and change to make improvement.

Thank you.

(Derived from SOS Mine Project)

Signed-off-by: underflow101 <ikarus125@gmail.com>