### PR TITLE
[TensorFlowLiteRecipes] fix unique op recipe

### DIFF
--- a/res/TensorFlowLiteRecipes/Unique_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/Unique_000/test.recipe
@@ -6,7 +6,7 @@ operand {
 operand {
   name: "ofm"
   type: FLOAT32
-  shape { dim: 0 }
+  shape { }
 }
 operand {
   name: "ofm_idx"

--- a/res/TensorFlowLiteRecipes/Unique_001/test.recipe
+++ b/res/TensorFlowLiteRecipes/Unique_001/test.recipe
@@ -6,7 +6,7 @@ operand {
 operand {
   name: "ofm"
   type: FLOAT32
-  shape { dim: 0 }
+  shape { }
 }
 operand {
   name: "ofm_idx"

--- a/res/TensorFlowLiteRecipes/Unique_002/test.recipe
+++ b/res/TensorFlowLiteRecipes/Unique_002/test.recipe
@@ -6,7 +6,7 @@ operand {
 operand {
   name: "ofm"
   type: INT32
-  shape { dim: 0 }
+  shape { }
 }
 operand {
   name: "ofm_idx"

--- a/res/TensorFlowLiteRecipes/Unique_003/test.recipe
+++ b/res/TensorFlowLiteRecipes/Unique_003/test.recipe
@@ -6,7 +6,7 @@ operand {
 operand {
   name: "ofm"
   type: INT32
-  shape { dim: 0 }
+  shape { }
 }
 operand {
   name: "ofm_idx"

--- a/res/TensorFlowLiteRecipes/Unique_U8_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/Unique_U8_000/test.recipe
@@ -7,7 +7,7 @@ operand {
 operand {
   name: "ofm"
   type: UINT8
-  shape { dim: 0 }
+  shape { }
 }
 operand {
   name: "ofm_idx"

--- a/res/TensorFlowLiteRecipes/Unique_U8_001/test.recipe
+++ b/res/TensorFlowLiteRecipes/Unique_U8_001/test.recipe
@@ -7,7 +7,7 @@ operand {
 operand {
   name: "ofm"
   type: UINT8
-  shape { dim: 0 }
+  shape { }
 }
 operand {
   name: "ofm_idx"


### PR DESCRIPTION
This commit fixes unique op recipe.

When I compare it with tfilte file generated from `res/TensorFlowPythonExamples`, there's no shape rather than zero dim.

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>