### PR TITLE
[onert] Do not use TensorBuilder in Executors

### DIFF
--- a/runtime/onert/core/src/compiler/ExecutorFactory.cc
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.cc
@@ -25,6 +25,7 @@
 #include "compiler/ExecutionBuilder.h"
 #include "exec/ExecTime.h"
 #include "compiler/Linear.h"
+#include "compiler/TensorBuilders.h"
 #include "backend/IConstantInitializer.h"
 #include "backend/IKernelGenerator.h"
 #include "backend/IOptimizer.h"
@@ -63,6 +64,23 @@ private:
   std::unique_ptr<exec::IFunction> _fn;
   std::shared_ptr<backend::IConfig> _config;
 };
+
+// TODO Think of a better way to manage TensorManagers
+backend::TensorManagerSet createTensorManagerSet(const compiler::TensorBuilders &tensor_builders)
+{
+  backend::TensorManagerSet tensor_mgrs;
+  for (auto &tensor_builder : tensor_builders)
+  {
+    auto s_tensor_manager = tensor_builder->releaseStaticTensorManager();
+    if (s_tensor_manager != nullptr)
+      tensor_mgrs.insert(std::move(s_tensor_manager));
+
+    auto d_tensor_manager = tensor_builder->releaseDynamicTensorManager();
+    if (d_tensor_manager != nullptr)
+      tensor_mgrs.insert(std::move(d_tensor_manager));
+  }
+  return tensor_mgrs;
+}
 
 } // namespace
 } // namespace onert
@@ -352,9 +370,11 @@ ExecutorFactory::createLinearExecutor(std::unique_ptr<compiler::LoweredGraph> lo
     });
   }
 
-  auto exec =
-      new exec::LinearExecutor{std::move(lowered_graph), input_tensors,       output_tensors,
-                               tensor_builders,          std::move(code_map), order};
+  TensorRegistries tensor_regs{lowered_graph->backend_contexts(), true};
+  backend::TensorManagerSet tensor_mgrs = createTensorManagerSet(tensor_builders);
+  auto exec = new exec::LinearExecutor{
+      std::move(lowered_graph), input_tensors,       output_tensors, tensor_regs,
+      std::move(tensor_mgrs),   std::move(code_map), order};
 
   if (!options.trace_filepath.empty())
   {
@@ -457,17 +477,21 @@ exec::IExecutor *ExecutorFactory::createDataflowExecutor(
     });
   }
 
+  TensorRegistries tensor_regs{lowered_graph->backend_contexts(), true};
+  backend::TensorManagerSet tensor_mgrs = createTensorManagerSet(tensor_builders);
+
   exec::ExecutorBase *exec = nullptr;
   if (parallel)
   {
-    exec = new exec::ParallelExecutor{std::move(lowered_graph), input_tensors, output_tensors,
-                                      tensor_builders, std::move(code_map)};
+    exec = new exec::ParallelExecutor{std::move(lowered_graph), input_tensors,
+                                      output_tensors,           tensor_regs,
+                                      std::move(tensor_mgrs),   std::move(code_map)};
   }
   else
   {
-    auto dataflow_exec =
-        new exec::DataflowExecutor{std::move(lowered_graph), input_tensors, output_tensors,
-                                   tensor_builders, std::move(code_map)};
+    auto dataflow_exec = new exec::DataflowExecutor{std::move(lowered_graph), input_tensors,
+                                                    output_tensors,           tensor_regs,
+                                                    std::move(tensor_mgrs),   std::move(code_map)};
     if (options.he_profiling_mode)
     {
       std::vector<const backend::Backend *> backends;

--- a/runtime/onert/core/src/compiler/ExecutorFactory.h
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.h
@@ -22,7 +22,6 @@
 #include "backend/ITensor.h"
 #include "exec/IExecutor.h"
 #include "compiler/LoweredGraph.h"
-#include "TensorBuilders.h"
 #include "TensorRegistries.h"
 
 namespace onert

--- a/runtime/onert/core/src/compiler/TensorRegistries.h
+++ b/runtime/onert/core/src/compiler/TensorRegistries.h
@@ -69,7 +69,7 @@ public:
     return _cf_tensor_reg;
   }
 
-  std::shared_ptr<backend::ITensor> getITensor(ir::OperandIndex ind)
+  std::shared_ptr<backend::ITensor> getITensor(ir::OperandIndex ind) const
   {
     for (auto &tensor_reg : _tensor_regs)
     {

--- a/runtime/onert/core/src/exec/DataflowExecutor.cc
+++ b/runtime/onert/core/src/exec/DataflowExecutor.cc
@@ -81,8 +81,10 @@ DataflowExecutor::DataflowExecutor(
     std::unique_ptr<compiler::LoweredGraph> lowered_graph,
     const std::vector<std::shared_ptr<backend::ITensor>> &input_tensors,
     const std::vector<std::shared_ptr<backend::ITensor>> &output_tensors,
-    const compiler::TensorBuilders &tensor_builders, compiler::CodeMap &&code_map)
-    : ExecutorBase{std::move(lowered_graph), input_tensors, output_tensors, tensor_builders},
+    const compiler::TensorRegistries &tensor_regs, backend::TensorManagerSet &&tensor_mgrs,
+    compiler::CodeMap &&code_map)
+    : ExecutorBase{std::move(lowered_graph), input_tensors, output_tensors, tensor_regs,
+                   std::move(tensor_mgrs)},
       _code_map{std::move(code_map)}
 {
   VERBOSE(DataflowExecutor) << "Constructing Dataflow Executor" << std::endl;

--- a/runtime/onert/core/src/exec/DataflowExecutor.h
+++ b/runtime/onert/core/src/exec/DataflowExecutor.h
@@ -52,7 +52,8 @@ public:
   DataflowExecutor(std::unique_ptr<compiler::LoweredGraph> lowered_graph,
                    const std::vector<std::shared_ptr<backend::ITensor>> &input_tensors,
                    const std::vector<std::shared_ptr<backend::ITensor>> &output_tensors,
-                   const compiler::TensorBuilders &tensor_builders, compiler::CodeMap &&code_map);
+                   const compiler::TensorRegistries &tensor_regs,
+                   backend::TensorManagerSet &&tensor_mgrs, compiler::CodeMap &&code_map);
 
   void executeImpl() override;
 

--- a/runtime/onert/core/src/exec/ExecutorBase.h
+++ b/runtime/onert/core/src/exec/ExecutorBase.h
@@ -33,9 +33,8 @@
 #include "exec/IFunction.h"
 #include "backend/IDynamicTensorManager.h"
 #include "backend/ITensorManager.h"
-#include "backend/ITensorBuilder.h"
 #include "exec/ExecutionObservee.h"
-#include "compiler/TensorBuilders.h"
+#include "compiler/TensorRegistries.h"
 #include <list>
 
 namespace onert
@@ -54,7 +53,8 @@ public:
   ExecutorBase(std::unique_ptr<compiler::LoweredGraph> &&lowered_graph,
                const std::vector<std::shared_ptr<backend::ITensor>> &input_tensors,
                const std::vector<std::shared_ptr<backend::ITensor>> &output_tensors,
-               const compiler::TensorBuilders &tensor_builders);
+               const compiler::TensorRegistries &tensor_regs,
+               backend::TensorManagerSet &&tensor_mgrs);
 
   virtual ~ExecutorBase() = default;
 

--- a/runtime/onert/core/src/exec/LinearExecutor.h
+++ b/runtime/onert/core/src/exec/LinearExecutor.h
@@ -49,9 +49,11 @@ public:
   LinearExecutor(std::unique_ptr<compiler::LoweredGraph> lowered_graph,
                  const std::vector<std::shared_ptr<backend::ITensor>> &input_tensors,
                  const std::vector<std::shared_ptr<backend::ITensor>> &output_tensors,
-                 const compiler::TensorBuilders &tensor_builders, compiler::CodeMap &&code_map,
+                 const compiler::TensorRegistries &tensor_regs,
+                 backend::TensorManagerSet &&tensor_mgrs, compiler::CodeMap &&code_map,
                  const std::vector<ir::OpSequenceIndex> &order)
-      : ExecutorBase{std::move(lowered_graph), input_tensors, output_tensors, tensor_builders}
+      : ExecutorBase{std::move(lowered_graph), input_tensors, output_tensors, tensor_regs,
+                     std::move(tensor_mgrs)}
   {
     for (auto index : order)
     {

--- a/runtime/onert/core/src/exec/ParallelExecutor.cc
+++ b/runtime/onert/core/src/exec/ParallelExecutor.cc
@@ -63,9 +63,10 @@ ParallelExecutor::ParallelExecutor(
     std::unique_ptr<compiler::LoweredGraph> lowered_graph,
     const std::vector<std::shared_ptr<backend::ITensor>> &input_tensors,
     const std::vector<std::shared_ptr<backend::ITensor>> &output_tensors,
-    const compiler::TensorBuilders &tensor_builders, compiler::CodeMap &&code_map)
-    : DataflowExecutor{std::move(lowered_graph), input_tensors, output_tensors, tensor_builders,
-                       std::move(code_map)}
+    const compiler::TensorRegistries &tensor_regs, backend::TensorManagerSet &&tensor_mgrs,
+    compiler::CodeMap &&code_map)
+    : DataflowExecutor{std::move(lowered_graph), input_tensors,      output_tensors, tensor_regs,
+                       std::move(tensor_mgrs),   std::move(code_map)}
 {
   VERBOSE(ParallelExecutor) << "Constructing Parallel Executor" << std::endl;
 }

--- a/runtime/onert/core/src/exec/ParallelExecutor.h
+++ b/runtime/onert/core/src/exec/ParallelExecutor.h
@@ -53,7 +53,8 @@ public:
   ParallelExecutor(std::unique_ptr<compiler::LoweredGraph> lowered_graph,
                    const std::vector<std::shared_ptr<backend::ITensor>> &input_tensors,
                    const std::vector<std::shared_ptr<backend::ITensor>> &output_tensors,
-                   const compiler::TensorBuilders &tensor_builders, compiler::CodeMap &&code_map);
+                   const compiler::TensorRegistries &tensor_regs,
+                   backend::TensorManagerSet &&tensor_mgrs, compiler::CodeMap &&code_map);
 
   void executeImpl() override;
 


### PR DESCRIPTION
Do not use TensorBuilder in Executors as what executors need are just
TensorRegistries and TensorManagers.

% This is part of refactoring(distinguishing TensorBuilder and
TensorRegistry).

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>