### PR TITLE
[onert] Make `--shape_run h5` as default option of nnpackage_run when '--load' is provided

### DIFF
--- a/runtime/onert/core/src/exec/Execution.cc
+++ b/runtime/onert/core/src/exec/Execution.cc
@@ -42,6 +42,9 @@ void Execution::changeInputShape(const ir::IOIndex &index, const ir::Shape &new_
   // Note that 'compiled' model will not be updated with new_shape
   // but new_shape will change model input shape while 'running' the model
   _io_desc.dynamic_input_shapes[index] = new_shape;
+
+  VERBOSE(Execution) << "Model input shape will be changed at the start of execute()"
+                     << "(index: " << index.value() << ")" << std::endl;
 }
 
 // TODO Remove default parameter

--- a/tests/tools/nnpackage_run/src/args.cc
+++ b/tests/tools/nnpackage_run/src/args.cc
@@ -216,13 +216,18 @@ void Args::Initialize(void)
          "e.g. nnpackage_run-UNIT_Add_000-acl_cl.csv.\n"
          "{nnpkg} name may be changed to realpath if you use symbolic-link.")
     ("shape_prepare", po::value<std::string>()->default_value("[]")->notifier(process_shape_prepare),
-         "set shape of specified tensor before compilation (before calling nnfw_prepare()).\n"
-         "'h5': read shape(s) from H5 input file. '--load' should also be provided.\n"
-         "'[0, [1, 2], 2, []]': set 0th tensor to [1, 2] and 2nd tensor to [].")
+         "Please refer to the description of 'shape_run'")
     ("shape_run", po::value<std::string>()->default_value("[]")->notifier(process_shape_run),
-         "set shape of specified tensor before running (before calling nnfw_run()).\n"
+         "'--shape_prepare: set shape of tensors before compilation (before calling nnfw_prepare()).\n"
+         "'--shape_run: set shape of tensors before running (before calling nnfw_run()).\n"
+         "Allowed value:.\n"
+         "'[0, [1, 2], 2, []]': set 0th tensor to [1, 2] and 2nd tensor to [] (scalar).\n"
+#if defined(ONERT_HAVE_HDF5) && ONERT_HAVE_HDF5 == 1
          "'h5': read shape(s) from H5 input file. '--load' should also be provided.\n"
-         "'[0, [1, 2], 2, []]': set 0th tensor to [1, 2] and 2nd tensor to [].")
+         "if '--load' option is provided but '--shape_prepare' or '--shape_run' is not provided,\n"
+         "'--shape_run h5' will be used by default.\n"
+#endif
+         )
     ("verbose_level,v", po::value<int>()->default_value(0)->notifier([&](const auto &v) { _verbose_level = v; }),
          "Verbose level\n"
          "0: prints the only result. Messages btw run don't print\n"
@@ -286,6 +291,20 @@ void Args::Parse(const int argc, char **argv)
       _warmup_runs = 1;
     }
   }
+}
+
+bool Args::shapeParamProvided()
+{
+  bool provided = false;
+#if defined(ONERT_HAVE_HDF5) && ONERT_HAVE_HDF5 == 1
+  // "--shape_run h5" or "--shape_prepare h5" was provided
+  provided = (getWhenToUseH5Shape() != WhenToUseH5Shape::NOT_PROVIDED);
+#endif
+  // specific shape was provided
+  // e.g., "--shape_run '[0, [10, 1]]'" or "--shape_prepare '[0, [10, 1]]'"
+  provided |= (!getShapeMapForPrepare().empty()) || (!getShapeMapForRun().empty());
+
+  return provided;
 }
 
 } // end of namespace nnpkg_run

--- a/tests/tools/nnpackage_run/src/args.cc
+++ b/tests/tools/nnpackage_run/src/args.cc
@@ -227,6 +227,7 @@ void Args::Initialize(void)
          "if '--load' option is provided but '--shape_prepare' or '--shape_run' is not provided,\n"
          "'--shape_run h5' will be used by default.\n"
 #endif
+         "For detailed description, please consutl the description of nnfw_set_input_tensorinfo()\n"
          )
     ("verbose_level,v", po::value<int>()->default_value(0)->notifier([&](const auto &v) { _verbose_level = v; }),
          "Verbose level\n"

--- a/tests/tools/nnpackage_run/src/args.h
+++ b/tests/tools/nnpackage_run/src/args.h
@@ -34,9 +34,9 @@ using TensorShapeMap = std::unordered_map<uint32_t, TensorShape>;
 #if defined(ONERT_HAVE_HDF5) && ONERT_HAVE_HDF5 == 1
 enum class WhenToUseH5Shape
 {
-  DO_NOT_USE, // don't use shapes in h5 file
-  PREPARE,    // read shapes in h5 file and set them as inputs' shape before calling nnfw_prepare()
-  RUN,        // read shapes in h5 file and set them as inputs' shape before calling nnfw_run()
+  NOT_PROVIDED, // Param not provided
+  PREPARE, // read shapes in h5 file and set them as inputs' shape before calling nnfw_prepare()
+  RUN,     // read shapes in h5 file and set them as inputs' shape before calling nnfw_run()
 };
 #endif
 
@@ -62,6 +62,8 @@ public:
   const bool printVersion(void) const { return _print_version; }
   TensorShapeMap &getShapeMapForPrepare() { return _shape_prepare; }
   TensorShapeMap &getShapeMapForRun() { return _shape_run; }
+  /// @brief Return true if "--shape_run" or "--shape_prepare" is provided
+  bool shapeParamProvided();
   const int getVerboseLevel(void) const { return _verbose_level; }
 
 private:
@@ -76,7 +78,7 @@ private:
 #if defined(ONERT_HAVE_HDF5) && ONERT_HAVE_HDF5 == 1
   std::string _dump_filename;
   std::string _load_filename;
-  WhenToUseH5Shape _when_to_use_h5_shape = WhenToUseH5Shape::DO_NOT_USE;
+  WhenToUseH5Shape _when_to_use_h5_shape = WhenToUseH5Shape::NOT_PROVIDED;
 #endif
   TensorShapeMap _shape_prepare;
   TensorShapeMap _shape_run;

--- a/tests/tools/nnpackage_run/src/nnpackage_run.cc
+++ b/tests/tools/nnpackage_run/src/nnpackage_run.cc
@@ -166,11 +166,15 @@ int main(const int argc, char **argv)
 
 // set input shape before compilation
 #if defined(ONERT_HAVE_HDF5) && ONERT_HAVE_HDF5 == 1
+
+    auto fill_shape_from_h5 = [&session](const std::string &h5_file, TensorShapeMap &shape_map) {
+      assert(!h5_file.empty());
+      auto shapes = H5Formatter(session).readTensorShapes(h5_file);
+      overwriteShapeMap(shape_map, shapes);
+    };
+
     if (args.getWhenToUseH5Shape() == WhenToUseH5Shape::PREPARE)
-    {
-      auto shapes = H5Formatter(session).readTensorShapes(args.getLoadFilename());
-      overwriteShapeMap(args.getShapeMapForPrepare(), shapes);
-    }
+      fill_shape_from_h5(args.getLoadFilename(), args.getShapeMapForPrepare());
 #endif
     setTensorInfo(args.getShapeMapForPrepare());
 
@@ -183,11 +187,9 @@ int main(const int argc, char **argv)
 
 // set input shape after compilation and before execution
 #if defined(ONERT_HAVE_HDF5) && ONERT_HAVE_HDF5 == 1
-    if (args.getWhenToUseH5Shape() == WhenToUseH5Shape::RUN)
-    {
-      auto shapes = H5Formatter(session).readTensorShapes(args.getLoadFilename());
-      overwriteShapeMap(args.getShapeMapForRun(), shapes);
-    }
+    if (args.getWhenToUseH5Shape() == WhenToUseH5Shape::RUN ||
+        (!args.getLoadFilename().empty() && !args.shapeParamProvided()))
+      fill_shape_from_h5(args.getLoadFilename(), args.getShapeMapForRun());
 #endif
     setTensorInfo(args.getShapeMapForRun());
 


### PR DESCRIPTION
This make `nnpackage_run` work the following case:
- `--load` is privided
- _no_ `--shape_run` or `--shape_prepare` is provided
- when input shape in h5 and input shape in model are _different_

In such case, 
**shapes in h5 file** is used to set the shape before `nnfw_run()`, which is same with `--shape_run h5` option.

When the input shape in h5 and input shape in model is **same**,
`nnfw_set_input_tensorinfo()` returns without doing anything: https://github.com/Samsung/ONE/blob/master/runtime/onert/api/src/nnfw_api_internal.cc#L492

related to https://github.com/Samsung/ONE/pull/3965#issuecomment-679777002

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>
