### PR TITLE
[luci] add condition that builds CircleSparseToDense node

### DIFF
--- a/compiler/luci/import/src/Nodes/CircleSparseToDense.cpp
+++ b/compiler/luci/import/src/Nodes/CircleSparseToDense.cpp
@@ -42,7 +42,8 @@ CircleNode *CircleSparseToDenseGraphBuilder::build_node(const circle::OperatorT 
   node->default_value(inputs.at(3));
 
   const auto *options = op.builtin_options.AsSparseToDenseOptions();
-  node->validate_indices(options->validate_indices);
+  if (options)
+    node->validate_indices(options->validate_indices);
 
   return node;
 }


### PR DESCRIPTION
This commit adds condition that builds CircleSparseToDense node.

Somethimes there is no builtin option.

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>