### PR TITLE
[luci] fix shape inference that infers CircleSparseToDense node shape

### DIFF
--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -1420,7 +1420,7 @@ loco::NodeShape infer_sparse_to_dense(const luci::CircleSparseToDense *node)
         INTERNAL_EXN_V("Only support rank 1 CircleConst",
                        oops::to_uint32(output_shape_node->rank()));
 
-      shape.rank(output_shape_node->dim(0).value());
+      shape.rank(output_shape_node->size<loco::DataType::S32>());
 
       for (uint32_t axis = 0; axis < shape.rank(); ++axis)
       {


### PR DESCRIPTION
This commit fixes shape inference that infers CircleSparseToDense node
shape.

output shape of this node should be inferred by `output_shape_node`
which is one of its inputs.

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>