### PR TITLE
[onert] Reduce memory usage in Conv qasymm uint8 operation

### DIFF
--- a/compute/cker/include/cker/operation/Conv.h
+++ b/compute/cker/include/cker/operation/Conv.h
@@ -54,11 +54,7 @@ inline void TransposeFloatTensor(const float *input_data, const nnfw::cker::Shap
 class Conv
 {
 public:
-  Conv()
-      : _modified_filter_data(), _im2col_data(), _im2col_shape(4), _need_im2col(false),
-        _prepared(false)
-  {
-  }
+  Conv() : _modified_filter_data(), _im2col_shape(4), _need_im2col(false), _prepared(false) {}
 
   void prepare(const Shape &filter_shape, const float *filter_data, PaddingType padding_type,
                bool &is_replaced_weights, uint32_t dilationWidthFactor,
@@ -121,9 +117,10 @@ public:
                        params.stride_height);
     }
 
-    uint8_t *im2col_raw_data = _im2col_data.data();
+    int im2col_size = _need_im2col ? _im2col_shape.FlatSize() : 1;
+    uint8_t im2col_data[im2col_size];
     optimized::Conv(params, input_shape, input_data, filter_shape, filter_data, bias_shape,
-                    bias_data, output_shape, output_data, _im2col_shape, im2col_raw_data);
+                    bias_data, output_shape, output_data, _im2col_shape, im2col_data);
   }
 
 private:
@@ -155,13 +152,11 @@ private:
       _im2col_shape.SetDim(1, output_shape.Dims(1));
       _im2col_shape.SetDim(2, output_shape.Dims(2));
       _im2col_shape.SetDim(3, input_shape.Dims(3) * kernel_shape.Dims(1) * kernel_shape.Dims(2));
-      _im2col_data.resize(_im2col_shape.FlatSize());
     }
   }
 
 private:
   std::vector<float> _modified_filter_data;
-  std::vector<uint8_t> _im2col_data;
   Shape _im2col_shape;
   bool _need_im2col;
   bool _prepared;


### PR DESCRIPTION
Move allocate for im2col space from configure to run  because im2col data cannot reuse

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>