### PR TITLE
[luci] Change default value of CircleSparseToDense's attribute

### DIFF
--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleSparseToDense.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleSparseToDense.h
@@ -49,7 +49,7 @@ public:
   void validate_indices(bool validate_indices) { _validate_indices = validate_indices; }
 
 private:
-  bool _validate_indices{true};
+  bool _validate_indices{false};
 };
 
 } // namespace luci

--- a/compiler/luci/lang/src/Nodes/CircleSparseToDense.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleSparseToDense.test.cpp
@@ -33,7 +33,7 @@ TEST(CircleSparseToDenseTest, constructor)
   ASSERT_EQ(nullptr, stb_node.values());
   ASSERT_EQ(nullptr, stb_node.default_value());
 
-  ASSERT_EQ(true, stb_node.validate_indices());
+  ASSERT_EQ(false, stb_node.validate_indices());
 }
 
 TEST(CircleSparseToDenseTest, input_NEG)


### PR DESCRIPTION
This commit changes default value of CircleSparseToDense's attribute.

All unspecified value in schema will be 0 or null or sth by default.
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>