### PR TITLE
[Draft] [onert] Move wrong input params to inputs

### DIFF
--- a/runtime/onert/backend/acl_cl/KernelGenerator.cc
+++ b/runtime/onert/backend/acl_cl/KernelGenerator.cc
@@ -534,7 +534,7 @@ void KernelGenerator::visit(const ir::operation::Transpose &node)
 {
   const auto ofm_idx{node.getOutputs().at(0)};
   const auto ifm_idx{node.getInputs().at(ir::operation::Transpose::Input::INPUT)};
-  const auto &perm{node.param().perm};
+  const auto perm_idx{node.getInputs().at(ir::operation::Transpose::Input::PERMUTATION)};
 
   const auto rank = _ctx.at(ifm_idx).shape().rank();
 
@@ -543,7 +543,7 @@ void KernelGenerator::visit(const ir::operation::Transpose &node)
   const auto frontend_layout = _current_op_seq_layout;
   const auto backend_layout = ifm_tensor->layout();
 
-  std::vector<std::int32_t> pv(perm.cbegin(), perm.cend());
+  const auto pv = _ctx.at(perm_idx).asVector<int32_t>();
   // Reversed
   auto backend_pv = ::onert::backend::acl_common::getARMComputePermutationVector(
       rank, pv, frontend_layout, backend_layout);
@@ -1218,6 +1218,7 @@ void KernelGenerator::visit(const ir::operation::ArgMax &node)
 {
   const auto ofm_index{node.getOutputs().at(0)};
   const auto ifm_index{node.getInputs().at(ir::operation::ArgMax::Input::INPUT)};
+  const auto axis_index{node.getInputs().at(ir::operation::ArgMax::Input::AXIS)};
 
   auto ifm_shape = _ctx.at(ifm_index).shape();
   auto ofm_shape = _ctx.at(ofm_index).shape();
@@ -1230,7 +1231,7 @@ void KernelGenerator::visit(const ir::operation::ArgMax &node)
   auto frontend_layout = _current_op_seq_layout;
   auto backend_layout = ifm_tensor->layout();
 
-  int axis_value = node.param().axis;
+  int axis_value = _ctx.at(axis_index).asScalar<int32_t>();
   if (axis_value < 0)
   {
     axis_value += ifm_rank;
@@ -1289,6 +1290,7 @@ void KernelGenerator::visit(const ir::operation::DepthToSpace &node)
 void KernelGenerator::visit(const ir::operation::Split &node)
 {
   const auto ifm_index{node.getInputs().at(ir::operation::Split::Input::INPUT)};
+  const auto axis_index{node.getInputs().at(ir::operation::Split::Input::AXIS)};
 
   assert(node.param().num_splits == static_cast<int>(node.getOutputs().size()));
 
@@ -1304,7 +1306,7 @@ void KernelGenerator::visit(const ir::operation::Split &node)
 
   const auto frontend_layout = _current_op_seq_layout;
   const auto backend_layout = ifm_tensor->layout();
-  auto axis = node.param().axis;
+  auto axis = _ctx.at(axis_index).asScalar<int32_t>();
   if (axis < 0)
     axis += ifm_rank;
   axis = acl_common::ToARMComputeAxis(ifm_rank, axis, frontend_layout, backend_layout).value();

--- a/runtime/onert/backend/cpu/ops/ArgMinMaxLayer.h
+++ b/runtime/onert/backend/cpu/ops/ArgMinMaxLayer.h
@@ -33,18 +33,18 @@ namespace ops
 class ArgMinMaxLayer : public ::onert::exec::IFunction
 {
 public:
-  ArgMinMaxLayer() : _input(nullptr), _output(nullptr), _axis(-1), _is_arg_max(true) {}
+  ArgMinMaxLayer() : _input(nullptr), _output(nullptr), _axis(nullptr), _is_arg_max(true) {}
 
 public:
-  void configure(const IPortableTensor *indices, IPortableTensor *output, int32_t axis,
-                 bool is_arg_max);
+  void configure(const IPortableTensor *indices, IPortableTensor *output,
+                 const IPortableTensor *axis, bool is_arg_max);
 
   void run() override;
 
 private:
   const IPortableTensor *_input;
   IPortableTensor *_output;
-  int32_t _axis;
+  const IPortableTensor *_axis;
   bool _is_arg_max;
 };
 

--- a/runtime/onert/backend/cpu/ops/ResizeBilinearLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ResizeBilinearLayer.cc
@@ -28,16 +28,29 @@ namespace ops
 {
 
 ResizeBilinearLayer::ResizeBilinearLayer()
-    : _input(nullptr), _output(nullptr), _output_height(0), _output_width(0), _align_corners(false),
-      _half_pixel_centers(false)
+    : _input(nullptr), _output(nullptr), _size(nullptr), _output_height(0), _output_width(0),
+      _align_corners(false), _half_pixel_centers(false)
 {
   // DO NOTHING
+}
+
+void ResizeBilinearLayer::configure(const IPortableTensor *input, IPortableTensor *output,
+                                    const IPortableTensor *size, bool align_corners,
+                                    bool half_pixel_centers)
+{
+  assert(!size->is_constant());
+  _input = input;
+  _output = output;
+  _size = size;
+  _align_corners = align_corners;
+  _half_pixel_centers = half_pixel_centers;
 }
 
 void ResizeBilinearLayer::configure(const IPortableTensor *input, IPortableTensor *output,
                                     int32_t output_height, int32_t output_width, bool align_corners,
                                     bool half_pixel_centers)
 {
+  assert(_size == nullptr);
   _input = input;
   _output = output;
   _output_height = output_height;
@@ -49,11 +62,20 @@ void ResizeBilinearLayer::configure(const IPortableTensor *input, IPortableTenso
 void ResizeBilinearLayer::run()
 {
   nnfw::cker::ResizeBilinearParams params;
+  if (_size == nullptr)
+  {
+    params.output_height = _output_height;
+    params.output_width = _output_width;
+  }
+  else
+  {
+    const auto size_buf = reinterpret_cast<const int32_t *>(_size->buffer());
+    params.output_height = size_buf[0];
+    params.output_width = size_buf[1];
+  }
+
   params.align_corners = _align_corners;
   params.half_pixel_centers = _half_pixel_centers;
-  params.output_height = _output_height;
-  params.output_width = _output_width;
-
   switch (_input->data_type())
   {
     case OperandType::FLOAT32:

--- a/runtime/onert/backend/cpu/ops/ResizeBilinearLayer.h
+++ b/runtime/onert/backend/cpu/ops/ResizeBilinearLayer.h
@@ -36,7 +36,10 @@ public:
   ResizeBilinearLayer();
 
 public:
-  void configure(const IPortableTensor *input1, IPortableTensor *output, int32_t output_height,
+  void configure(const IPortableTensor *input1, IPortableTensor *output,
+                 const IPortableTensor *size, bool align_corners, bool half_pixel_centers);
+
+  void configure(const IPortableTensor *input, IPortableTensor *output, int32_t output_height,
                  int32_t output_width, bool align_corners, bool half_pixel_centers);
 
   void run() override;
@@ -44,6 +47,7 @@ public:
 private:
   const IPortableTensor *_input;
   IPortableTensor *_output;
+  const IPortableTensor *_size;
   int32_t _output_height;
   int32_t _output_width;
   bool _align_corners;

--- a/runtime/onert/backend/cpu/ops/SplitLayer.h
+++ b/runtime/onert/backend/cpu/ops/SplitLayer.h
@@ -38,15 +38,15 @@ public:
 public:
   template <typename T> void split(void);
 
-  void configure(const IPortableTensor *input, uint16_t num_splits, int16_t axis,
+  void configure(const IPortableTensor *input, const IPortableTensor *axis, uint16_t num_splits,
                  std::vector<IPortableTensor *> &outputs);
 
   void run() override;
 
 private:
   const IPortableTensor *_input;
+  const IPortableTensor *_axis;
   uint16_t _num_splits;
-  int16_t _axis;
   std::vector<IPortableTensor *> _outputs;
 };
 

--- a/runtime/onert/backend/cpu/ops/TransposeLayer.cc
+++ b/runtime/onert/backend/cpu/ops/TransposeLayer.cc
@@ -29,7 +29,7 @@ namespace cpu
 namespace ops
 {
 
-TransposeLayer::TransposeLayer() : _input(nullptr), _output(nullptr), _perm()
+TransposeLayer::TransposeLayer() : _input(nullptr), _output(nullptr), _perm(nullptr)
 {
   // DO NOTHING
 }
@@ -37,10 +37,11 @@ TransposeLayer::TransposeLayer() : _input(nullptr), _output(nullptr), _perm()
 template <typename T> void TransposeLayer::transpose()
 {
   nnfw::cker::TransposeParams param;
-  param.perm_count = _perm.size();
-  for (size_t i = 0; i < _perm.size(); i++)
+  assert(_perm->num_dimensions() == 1);
+  param.perm_count = _perm->dimension(0);
+  for (auto i = 0; i < param.perm_count; i++)
   {
-    param.perm[i] = _perm[i];
+    param.perm[i] = *(reinterpret_cast<const int32_t *>(_perm->buffer() + _perm->calcOffset({i})));
   }
 
   nnfw::cker::Transpose(param, getTensorShape(_input),
@@ -64,7 +65,7 @@ void TransposeLayer::transposeQuant8()
 }
 
 void TransposeLayer::configure(const IPortableTensor *input, IPortableTensor *output,
-                               const std::vector<int> &perm)
+                               const IPortableTensor *perm)
 {
   _input = input;
   _perm = perm;

--- a/runtime/onert/backend/cpu/ops/TransposeLayer.h
+++ b/runtime/onert/backend/cpu/ops/TransposeLayer.h
@@ -41,14 +41,14 @@ public:
   void transposeQuant8();
 
   void configure(const IPortableTensor *input, IPortableTensor *output,
-                 const std::vector<int> &perm);
+                 const IPortableTensor *perm);
 
   void run() override;
 
 private:
   const IPortableTensor *_input;
   IPortableTensor *_output;
-  std::vector<int> _perm;
+  const IPortableTensor *_perm;
 };
 
 } // namespace ops

--- a/runtime/onert/core/include/ir/operation/ArgMax.h
+++ b/runtime/onert/core/include/ir/operation/ArgMax.h
@@ -31,12 +31,12 @@ class ArgMax : public Operation
 public:
   enum Input
   {
-    INPUT
+    INPUT = 0,
+    AXIS = 1
   };
 
   struct Param
   {
-    int axis;
     DataType output_type;
   };
 

--- a/runtime/onert/core/include/ir/operation/ResizeBilinear.h
+++ b/runtime/onert/core/include/ir/operation/ResizeBilinear.h
@@ -34,10 +34,12 @@ public:
   enum Input
   {
     INPUT = 0,
+    SIZE = 1,
   };
 
   struct Param
   {
+    // If the input SIZE exists in inputs, height_out and width_out are not set. Ignore these params
     int32_t height_out;
     int32_t width_out;
     bool align_corners;

--- a/runtime/onert/core/include/ir/operation/ResizeNearestNeighbor.h
+++ b/runtime/onert/core/include/ir/operation/ResizeNearestNeighbor.h
@@ -34,10 +34,12 @@ public:
   enum Input
   {
     INPUT = 0,
+    SIZE = 1,
   };
 
   struct Param
   {
+    // If the input SIZE exists in inputs, height_out and width_out are not set. Ignore these params
     int32_t height_out;
     int32_t width_out;
     bool align_corners;

--- a/runtime/onert/core/include/ir/operation/Split.h
+++ b/runtime/onert/core/include/ir/operation/Split.h
@@ -29,12 +29,12 @@ class Split : public Operation
 public:
   enum Input
   {
-    INPUT = 0
+    INPUT = 0,
+    AXIS = 1,
   };
 
   struct Param
   {
-    int axis;
     int num_splits;
   };
 

--- a/runtime/onert/core/include/ir/operation/Transpose.h
+++ b/runtime/onert/core/include/ir/operation/Transpose.h
@@ -34,26 +34,15 @@ public:
   enum Input
   {
     INPUT = 0, // for an n-D tensor, specifying the tensor to be transposed.
-  };
-
-  struct Param
-  {
-    std::vector<int> perm;
+    PERMUTATION = 1,
   };
 
 public:
-  Transpose(const OperandIndexSequence &inputs, const OperandIndexSequence &outputs,
-            const Param &param);
+  Transpose(const OperandIndexSequence &inputs, const OperandIndexSequence &outputs);
 
 public:
   void accept(OperationVisitor &v) const override;
   OpCode opcode() const final { return OpCode::Transpose; }
-
-public:
-  const Param &param() const { return _param; }
-
-private:
-  Param _param;
 };
 
 } // namespace operation

--- a/runtime/onert/core/include/util/ShapeInference.h
+++ b/runtime/onert/core/include/util/ShapeInference.h
@@ -134,7 +134,7 @@ ir::Shape inferStridedSliceShape(const ir::Shape &input_shape, const StridedSlic
 
 ir::Shape inferTileShape(const ir::Shape &in_shape, const int32_t *multiplier);
 
-ir::Shape inferTransposeShape(const ir::Shape &in_shape, const std::vector<int> &perm);
+ir::Shape inferTransposeShape(const ir::Shape &in_shape, const int32_t *perm, const int32_t rank);
 
 ir::Shape inferUnpackShape(const ir::Shape &input_shape, int axis, int rank);
 

--- a/runtime/onert/core/src/compiler/OperationValidator.cc
+++ b/runtime/onert/core/src/compiler/OperationValidator.cc
@@ -233,12 +233,13 @@ void OperationValidator::visit(const ir::operation::Transpose &node)
     return;
 
   const auto input_index{node.getInputs().at(ir::operation::Transpose::Input::INPUT)};
-  const auto &perm{node.param().perm};
+  const auto perm_index{node.getInputs().at(ir::operation::Transpose::Input::PERMUTATION)};
+  OP_REQUIRES(_ctx.at(perm_index).isConstant());
 
   const auto &output_shape = _ctx.at(output_index).shape();
   const auto &input_shape = _ctx.at(input_index).shape();
 
-  OP_REQUIRES(input_shape.rank() == static_cast<int>(perm.size()));
+  OP_REQUIRES(input_shape.rank() == static_cast<int>(_ctx.at(perm_index).shape().num_elements()));
   OP_REQUIRES(input_shape.rank() == output_shape.rank());
 }
 
@@ -871,13 +872,17 @@ void OperationValidator::visit(const ir::operation::StridedSlice &node)
 void OperationValidator::visit(const ir::operation::Split &node)
 {
   const auto input_index{node.getInputs().at(ir::operation::Split::Input::INPUT)};
+  const auto axis_index{node.getInputs().at(ir::operation::Split::Input::AXIS)};
 
   if (_ctx.at(input_index).info().isDynamic())
     return;
 
+  OP_REQUIRES(_ctx.at(axis_index).isConstant());
+
   const auto num_splits = node.param().num_splits;
   const auto input_rank = _ctx.at(input_index).shape().rank();
-  const auto axis = node.param().axis < 0 ? node.param().axis + input_rank : node.param().axis;
+  auto axis = *reinterpret_cast<const int32_t *>(_ctx.at(axis_index).data()->base());
+  axis = axis < 0 ? axis + input_rank : axis;
 
   OP_REQUIRES(num_splits > 0 && num_splits <= 0xFFFF);
   OP_REQUIRES(axis >= 0 && axis < input_rank);

--- a/runtime/onert/core/src/exec/DynamicShapeInference.cc
+++ b/runtime/onert/core/src/exec/DynamicShapeInference.cc
@@ -104,20 +104,24 @@ void DynamicShapeInferer::visit(const ir::operation::ArgMax &op)
 {
   const auto input_idx{op.getInputs().at(ir::operation::ArgMax::Input::INPUT)};
   const auto &input = _tensor_registry->getITensor(input_idx);
-  auto input_shape = input->getShape();
 
-  if (!input->is_dynamic())
-    return;
-
-  const auto rank = input_shape.rank();
-  const auto axis = ((op.param().axis < 0) ? rank + op.param().axis : op.param().axis);
-
-  assert(0 <= axis && axis < rank);
+  const auto axis_idx{op.getInputs().at(ir::operation::ArgMax::Input::AXIS)};
+  const auto &axis = _tensor_registry->getITensor(axis_idx);
 
   auto output_ind = op.getOutputs().at(0);
   auto output = _tensor_registry->getITensor(output_ind);
 
-  ir::Shape new_shape = shape_inference::inferArgMaxShape(input_shape, axis, rank);
+  if (!input->is_dynamic() && !output->is_dynamic())
+    return;
+
+  auto input_shape = input->getShape();
+  auto axis_value = *reinterpret_cast<const int32_t *>(axis->buffer());
+  const auto rank = input_shape.rank();
+  axis_value = axis < 0 ? axis_value + rank : axis_value;
+
+  assert(0 <= axis_value && axis_value < rank);
+
+  ir::Shape new_shape = shape_inference::inferArgMaxShape(input_shape, axis_value, rank);
 
   dynamicTensorManagerOf(output)->applyShape(output_ind, new_shape);
   assert(output->buffer() != nullptr);
@@ -705,8 +709,29 @@ void DynamicShapeInferer::visit(const ir::operation::ResizeBilinear &op)
     return;
 
   // getting output shape from input shape and Params
-  auto output_shape = shape_inference::inferResizeBilinearShape(
-      input->getShape(), op.param().height_out, op.param().width_out);
+  int32_t height_out, width_out;
+  if (op.getInputs().size() == 2)
+  {
+    auto size_ind = op.getInputs().at(ir::operation::ResizeBilinear::Input::SIZE);
+    auto size = _tensor_registry->getITensor(size_ind);
+    if (size->data_type() == ir::DataType::INT32)
+    {
+      auto size_buf = reinterpret_cast<const int32_t *>(size->buffer());
+      height_out = size_buf[0];
+      width_out = size_buf[1];
+    }
+    else
+    {
+      throw std::runtime_error("DynamicShapeInferer ResizeBilinear : Unsupported data type");
+    }
+  }
+  else
+  {
+    height_out = op.param().height_out;
+    width_out = op.param().width_out;
+  }
+  auto output_shape =
+      shape_inference::inferResizeBilinearShape(input->getShape(), height_out, width_out);
 
   // if shape is changed, change output shape and reallocate output tensor memory
   if (output_shape != output->getShape() || output->buffer() == nullptr)
@@ -845,16 +870,31 @@ void DynamicShapeInferer::visit(const ir::operation::Split &op)
     return;
   }
 
+  assert(op.getOutputs().size() > 0);
+  bool is_dynamic = _tensor_registry->getITensor(op.getOutputs().at(0))->is_dynamic();
+  for (const auto output_idx : op.getOutputs())
+  {
+    auto output = _tensor_registry->getITensor(output_idx);
+    assert(is_dynamic == output->is_dynamic());
+  }
+  if (!is_dynamic)
+  {
+    return;
+  }
+
   auto input_shape = input->getShape();
 
-  const auto axis = op.param().axis;
+  const auto axis_idx{op.getInputs().at(ir::operation::Split::Input::AXIS)};
+  const auto &axis = _tensor_registry->getITensor(axis_idx);
+
+  auto axis_value = *reinterpret_cast<const int32_t *>(axis->buffer());
   const auto num_splits = op.param().num_splits;
   const auto rank = input_shape.rank();
-  auto axis_resolved = axis < 0 ? axis + rank : axis;
+  axis_value = axis < 0 ? axis_value + rank : axis_value;
 
-  assert(0 <= axis_resolved && axis_resolved < rank);
+  assert(0 <= axis_value && axis_value < rank);
 
-  ir::Shape new_shape = shape_inference::inferSplitShape(input_shape, axis_resolved, num_splits);
+  ir::Shape new_shape = shape_inference::inferSplitShape(input_shape, axis_value, num_splits);
   for (int out_tensor_idx = 0; out_tensor_idx < num_splits; out_tensor_idx++)
   {
     auto output_ind = op.getOutputs().at(out_tensor_idx);
@@ -967,15 +1007,26 @@ void DynamicShapeInferer::visit(const ir::operation::Transpose &op)
 
   // from op, access the buffer of second input to read new shape
   auto input_ind = op.getInputs().at(ir::operation::Transpose::Input::INPUT);
-  auto input_tensor = _tensor_registry->getITensor(input_ind);
-  auto input_shape = input_tensor->getShape();
+  auto input = _tensor_registry->getITensor(input_ind);
+  auto input_shape = input->getShape();
 
-  if (!input_tensor->is_dynamic())
+  if ((!input->is_dynamic()) && (!output->is_dynamic()))
     return;
 
-  const auto perm{op.param().perm};
+  auto perm_ind = op.getInputs().at(ir::operation::Transpose::Input::PERMUTATION);
+  auto perm = _tensor_registry->getITensor(perm_ind);
+
+  // Check rank
+  if (input->num_dimensions() != perm->getShape().num_elements())
+  {
+    throw std::runtime_error("DynamicShapeInferer failed, bad rank size: " +
+                             std::to_string(perm->getShape().num_elements()));
+  }
+
   // set output shape, based on input and params
-  ir::Shape new_shape = shape_inference::inferTransposeShape(input_shape, perm);
+  const auto perm_buffer = reinterpret_cast<const int32_t *>(perm->buffer());
+  ir::Shape new_shape =
+      shape_inference::inferTransposeShape(input_shape, perm_buffer, perm->dimension(0));
 
   dynamicTensorManagerOf(output)->applyShape(output_ind, new_shape);
   assert(output->buffer() != nullptr);

--- a/runtime/onert/core/src/ir/OperationDumper.cc
+++ b/runtime/onert/core/src/ir/OperationDumper.cc
@@ -72,7 +72,7 @@ OperationDumper::OperationDumper(const std::string &start_msg)
   VERBOSE(LIR) << start_msg << std::endl;
 }
 
-void OperationDumper::visit(const ArgMax &node) { dumpUnaryInputOp(node); }
+void OperationDumper::visit(const ArgMax &node) { dumpBinaryInputOp(node); }
 
 void OperationDumper::visit(const BatchToSpaceND &node)
 {
@@ -279,7 +279,21 @@ void OperationDumper::visit(const Reshape &node)
   dumpUnaryInputOp(node, shape);
 }
 
-void OperationDumper::visit(const ResizeBilinear &node) { dumpUnaryInputOp(node); }
+void OperationDumper::visit(const ResizeBilinear &node)
+{
+  if (node.getInputs().size() == 1)
+  {
+    dumpUnaryInputOp(node);
+  }
+  else if (node.getInputs().size() == 2)
+  {
+    dumpBinaryInputOp(node);
+  }
+  else
+  {
+    VERBOSE(LIR) << "* " << node.name() << " is set wrong" << std::endl;
+  }
+}
 
 void OperationDumper::visit(const Reverse &node)
 {
@@ -336,7 +350,7 @@ void OperationDumper::visit(const SpaceToBatchND &node)
 
 void OperationDumper::visit(const SpaceToDepth &node) { dumpUnaryInputOp(node); }
 
-void OperationDumper::visit(const Split &node) { dumpUnaryInputOp(node); }
+void OperationDumper::visit(const Split &node) { dumpBinaryInputOp(node); }
 
 void OperationDumper::visit(const SquaredDifference &node) { dumpBinaryInputOp(node); }
 

--- a/runtime/onert/core/src/ir/operation/ArgMax.cc
+++ b/runtime/onert/core/src/ir/operation/ArgMax.cc
@@ -31,7 +31,7 @@ void ArgMax::accept(OperationVisitor &v) const { v.visit(*this); }
 
 ArgMax::ArgMax(const OperandIndexSequence &inputs, const OperandIndexSequence &outputs,
                const Param &param)
-    : Operation{OperandConstraint::createExact(1u), inputs, outputs}, _param{param}
+    : Operation{OperandConstraint::createExact(2u), inputs, outputs}, _param{param}
 {
 }
 

--- a/runtime/onert/core/src/ir/operation/ResizeBilinear.cc
+++ b/runtime/onert/core/src/ir/operation/ResizeBilinear.cc
@@ -31,7 +31,7 @@ void ResizeBilinear::accept(OperationVisitor &v) const { v.visit(*this); }
 
 ResizeBilinear::ResizeBilinear(const OperandIndexSequence &inputs,
                                const OperandIndexSequence &outputs, const Param &param)
-    : Operation{OperandConstraint::createExact(1u), inputs, outputs}, _param{param}
+    : Operation{OperandConstraint::createInRange(1u, 2u), inputs, outputs}, _param{param}
 {
 }
 

--- a/runtime/onert/core/src/ir/operation/ResizeNearestNeighbor.cc
+++ b/runtime/onert/core/src/ir/operation/ResizeNearestNeighbor.cc
@@ -32,7 +32,7 @@ void ResizeNearestNeighbor::accept(OperationVisitor &v) const { v.visit(*this); 
 ResizeNearestNeighbor::ResizeNearestNeighbor(const OperandIndexSequence &inputs,
                                              const OperandIndexSequence &outputs,
                                              const Param &param)
-    : Operation{OperandConstraint::createExact(1u), inputs, outputs}, _param{param}
+    : Operation{OperandConstraint::createInRange(1u, 2u), inputs, outputs}, _param{param}
 {
 }
 

--- a/runtime/onert/core/src/ir/operation/Transpose.cc
+++ b/runtime/onert/core/src/ir/operation/Transpose.cc
@@ -29,9 +29,8 @@ namespace operation
 
 void Transpose::accept(OperationVisitor &v) const { v.visit(*this); }
 
-Transpose::Transpose(const OperandIndexSequence &inputs, const OperandIndexSequence &outputs,
-                     const Param &param)
-    : Operation{OperandConstraint::createExact(2u), inputs, outputs}, _param{param}
+Transpose::Transpose(const OperandIndexSequence &inputs, const OperandIndexSequence &outputs)
+    : Operation{OperandConstraint::createExact(2u), inputs, outputs}
 {
 }
 

--- a/runtime/onert/core/src/util/ShapeInference.cc
+++ b/runtime/onert/core/src/util/ShapeInference.cc
@@ -961,17 +961,16 @@ ir::Shape inferTileShape(const ir::Shape &in_shape, const int32_t *multiplier)
   return new_Shape;
 }
 
-ir::Shape inferTransposeShape(const ir::Shape &in_shape, const std::vector<int> &perm)
+ir::Shape inferTransposeShape(const ir::Shape &in_shape, const int32_t *perm, const int32_t rank)
 {
-  if (static_cast<int>(perm.size()) > in_shape.rank())
+  if (rank > in_shape.rank())
   {
-    throw std::runtime_error("inferTransposeShape failed, bad rank size: " +
-                             std::to_string(static_cast<int>(perm.size())));
+    throw std::runtime_error("inferTransposeShape failed, bad rank size: " + std::to_string(rank));
   }
-  ir::Shape out_shape(static_cast<int>(perm.size()));
-  for (int idx = 0; idx < static_cast<int>(perm.size()); idx++)
+  ir::Shape out_shape(rank);
+  for (int idx = 0; idx < rank; idx++)
   {
-    if (perm[idx] < 0 || perm[idx] >= static_cast<int>(perm.size()))
+    if (perm[idx] < 0 || perm[idx] >= rank)
     {
       throw std::runtime_error("inferTransposeShape failed, bad perm value: " +
                                std::to_string(perm[idx]));

--- a/runtime/onert/frontend/nnapi/wrapper/OperationFactory.cc
+++ b/runtime/onert/frontend/nnapi/wrapper/OperationFactory.cc
@@ -708,8 +708,7 @@ OperationFactory::OperationFactory()
     return new operation::StridedSlice{inputs, outputs, param};
   };
 
-  _map[ANEURALNETWORKS_TRANSPOSE] = [](const OperationFactory::Param &init_param,
-                                       Operands &operands) {
+  _map[ANEURALNETWORKS_TRANSPOSE] = [](const OperationFactory::Param &init_param, Operands &) {
     // TODO make this work with init_param.input_count == 1 (when permutation vector is optional)
 
     // Inputs
@@ -723,15 +722,10 @@ OperationFactory::OperationFactory()
     assert(init_param.input_count == 2);
     assert(init_param.output_count == 1);
 
-    OperandIndexSequence inputs{init_param.inputs[0]};
+    OperandIndexSequence inputs{init_param.inputs[0], init_param.inputs[1]};
     OperandIndexSequence outputs{init_param.outputs[0]};
-    std::vector<std::int32_t> perm =
-        operands.at(OperandIndex{init_param.inputs[1]}).asVector<std::int32_t>();
 
-    operation::Transpose::Param param;
-    param.perm.assign(perm.cbegin(), perm.cend());
-
-    return new operation::Transpose{inputs, outputs, param};
+    return new operation::Transpose{inputs, outputs};
   };
 
   _map[ANEURALNETWORKS_MUL] =
@@ -1406,7 +1400,7 @@ OperationFactory::OperationFactory()
   // TODO Remove ANEURALNETWORKS_ABS_EX
   _map[ANEURALNETWORKS_ABS_EX] = _map[ANEURALNETWORKS_ABS];
 
-  _map[ANEURALNETWORKS_ARGMAX] = [](const OperationFactory::Param &init_param, Operands &operands) {
+  _map[ANEURALNETWORKS_ARGMAX] = [](const OperationFactory::Param &init_param, Operands &) {
     assert(init_param.input_count == 2 && init_param.output_count == 1);
 
     OperandIndexSequence outputs{init_param.outputs[0]};
@@ -1415,10 +1409,9 @@ OperationFactory::OperationFactory()
     //
     //  0 -> Input Tensor Index
     //  1 -> Axis Tensor Index
-    OperandIndexSequence inputs{init_param.inputs[0]};
+    OperandIndexSequence inputs{init_param.inputs[0], init_param.inputs[1]};
 
     operation::ArgMax::Param param;
-    param.axis = operands.at(OperandIndex{init_param.inputs[1]}).asScalar<std::int32_t>();
     // NNAPI ARGMAX output type is always int32
     param.output_type = DataType::INT32;
 
@@ -1517,7 +1510,7 @@ OperationFactory::OperationFactory()
     assert(init_param.input_count == 3);
     assert(init_param.output_count >= 1); // At least one output tensor and axis
 
-    OperandIndexSequence inputs{init_param.inputs[0]};
+    OperandIndexSequence inputs{init_param.inputs[0], init_param.inputs[1]};
     OperandIndexSequence outputs;
     for (uint32_t n = 0; n < init_param.output_count; ++n)
     {
@@ -1525,7 +1518,6 @@ OperationFactory::OperationFactory()
     }
 
     operation::Split::Param param;
-    param.axis = operands.at(OperandIndex{init_param.inputs[1]}).asScalar<std::int32_t>();
     param.num_splits = operands.at(OperandIndex{init_param.inputs[2]}).asScalar<std::int32_t>();
 
     return new operation::Split{inputs, outputs, param};

--- a/runtime/onert/test/util/ShapeInference.cc
+++ b/runtime/onert/test/util/ShapeInference.cc
@@ -328,7 +328,8 @@ TEST(ShapeInference, Transpose)
     // pre-conditions
     ASSERT_EQ(in_shape.rank(), perm.size());
     ASSERT_EQ(expected.rank(), perm.size());
-    auto inferred_out_shape = onert::shape_inference::inferTransposeShape(in_shape, perm);
+    auto inferred_out_shape =
+        onert::shape_inference::inferTransposeShape(in_shape, perm.data(), perm.size());
     // post-conditions
     ASSERT_EQ(inferred_out_shape.rank(), perm.size());
     for (int32_t dim = 0; dim < expected.rank(); dim++)
@@ -369,12 +370,14 @@ TEST(ShapeInference, neg_Transpose)
   {
     std::vector<int> perm = {2, 0, 1, 0};
     // int32_t rank = 3;
-    ASSERT_THROW(onert::shape_inference::inferTransposeShape(in_shape, perm), std::runtime_error);
+    ASSERT_THROW(onert::shape_inference::inferTransposeShape(in_shape, perm.data(), perm.size()),
+                 std::runtime_error);
   }
   // Invalid parameter value
   {
     std::vector<int> perm = {2, 0, 3};
     // int32_t rank = 3;
-    ASSERT_THROW(onert::shape_inference::inferTransposeShape(in_shape, perm), std::runtime_error);
+    ASSERT_THROW(onert::shape_inference::inferTransposeShape(in_shape, perm.data(), perm.size()),
+                 std::runtime_error);
   }
 }


### PR DESCRIPTION
For issue #4053

This commit moves wrong mismatched input params between model schema and IR to inputs
  - ArgMax : remove param "axis" and add it as an input
  - ResizeNearestNeighbor : keep params and add input "size"
  - ResizeBilnear : keep params and add input "size"
  - Split : remove param "axis" and add it as an input
  - Tile : remove param "multiplies" and add it as an input
  - Transpose : remove param "perm" and add it as an input
    
Signed-off-by: ragmani <ragmani0216@gmail.com>