### PR TITLE
[onert/test] Add negative tests for GenModelTest

### DIFF
--- a/tests/nnfw_api/src/RegressionTests.cc
+++ b/tests/nnfw_api/src/RegressionTests.cc
@@ -39,6 +39,8 @@ TEST_F(RegressionTest, github_1535)
 
   NNFW_ENSURE_SUCCESS(nnfw_close_session(session1));
   NNFW_ENSURE_SUCCESS(nnfw_close_session(session2));
+
+  SUCCEED();
 }
 
 TEST_F(RegressionTest, neg_github_3826)

--- a/tests/nnfw_api/src/ValidationTestAddModelLoaded.cc
+++ b/tests/nnfw_api/src/ValidationTestAddModelLoaded.cc
@@ -19,11 +19,18 @@
 
 using ValidationTestAddModelLoaded = ValidationTestModelLoaded<NNPackages::ADD>;
 
-TEST_F(ValidationTestAddModelLoaded, prepare_001) { NNFW_ENSURE_SUCCESS(nnfw_prepare(_session)); }
+TEST_F(ValidationTestAddModelLoaded, prepare_001)
+{
+  NNFW_ENSURE_SUCCESS(nnfw_prepare(_session));
+
+  SUCCEED();
+}
 
 TEST_F(ValidationTestAddModelLoaded, set_available_backends_001)
 {
   NNFW_ENSURE_SUCCESS(nnfw_set_available_backends(_session, "cpu"));
+
+  SUCCEED();
 }
 
 TEST_F(ValidationTestAddModelLoaded, get_input_size)

--- a/tests/nnfw_api/src/ValidationTestFourAddModelsSetInput.cc
+++ b/tests/nnfw_api/src/ValidationTestFourAddModelsSetInput.cc
@@ -23,6 +23,8 @@ TEST_F(ValidationTestFourAddModelsSetInput, run_001)
 {
   NNFW_ENSURE_SUCCESS(nnfw_run(_objects[0].session));
   NNFW_ENSURE_SUCCESS(nnfw_run(_objects[1].session));
+
+  SUCCEED();
 }
 
 TEST_F(ValidationTestFourAddModelsSetInput, run_002)
@@ -33,6 +35,8 @@ TEST_F(ValidationTestFourAddModelsSetInput, run_002)
     for (auto obj : _objects)
       NNFW_ENSURE_SUCCESS(nnfw_run(obj.session));
   }
+
+  SUCCEED();
 }
 
 TEST_F(ValidationTestFourAddModelsSetInput, run_async)
@@ -41,4 +45,6 @@ TEST_F(ValidationTestFourAddModelsSetInput, run_async)
     NNFW_ENSURE_SUCCESS(nnfw_run_async(obj.session));
   for (auto obj : _objects)
     NNFW_ENSURE_SUCCESS(nnfw_await(obj.session));
+
+  SUCCEED();
 }

--- a/tests/nnfw_api/src/ValidationTestSessionCreated.cc
+++ b/tests/nnfw_api/src/ValidationTestSessionCreated.cc
@@ -29,6 +29,8 @@ TEST_F(ValidationTestSessionCreated, close_and_create_again)
 {
   NNFW_ENSURE_SUCCESS(nnfw_close_session(_session));
   NNFW_ENSURE_SUCCESS(nnfw_create_session(&_session));
+
+  SUCCEED();
 }
 
 TEST_F(ValidationTestSessionCreated, neg_load_session_1)

--- a/tests/nnfw_api/src/ValidationTestSingleSession.cc
+++ b/tests/nnfw_api/src/ValidationTestSingleSession.cc
@@ -21,12 +21,16 @@ TEST_F(ValidationTestSingleSession, create_001)
 {
   NNFW_ENSURE_SUCCESS(nnfw_create_session(&_session));
   NNFW_ENSURE_SUCCESS(nnfw_close_session(_session));
+
+  SUCCEED();
 }
 
 TEST_F(ValidationTestSingleSession, query_info_u32)
 {
   uint32_t val = 0;
   NNFW_ENSURE_SUCCESS(nnfw_query_info_u32(nullptr, NNFW_INFO_ID_VERSION, &val));
+
+  SUCCEED();
 }
 
 TEST_F(ValidationTestSingleSession, neg_create_001)

--- a/tests/nnfw_api/src/one_op_tests/Add.cc
+++ b/tests/nnfw_api/src/one_op_tests/Add.cc
@@ -33,6 +33,8 @@ TEST_F(GenModelTest, OneOp_Add_VarToConst)
   _context->addTestCase({{{1, 3, 2, 4}}, {{6, 7, 9, 8}}});
   _context->addTestCase({{{0, 1, 2, 3}}, {{5, 5, 9, 7}}});
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
+
+  SUCCEED();
 }
 
 TEST_F(GenModelTest, OneOp_Add_VarToVar)
@@ -61,6 +63,8 @@ TEST_F(GenModelTest, neg_OneOp_Add_InvalidShape)
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
   _context->setCompileFail();
+
+  SUCCEED();
 }
 
 TEST_F(GenModelTest, neg_OneOp_Add_InvalidShapeConst)
@@ -77,6 +81,8 @@ TEST_F(GenModelTest, neg_OneOp_Add_InvalidShapeConst)
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
   _context->setCompileFail();
+
+  SUCCEED();
 }
 
 TEST_F(GenModelTest, neg_OneOp_Add_OneOperand)
@@ -90,4 +96,6 @@ TEST_F(GenModelTest, neg_OneOp_Add_OneOperand)
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
   _context->setCompileFail();
+
+  SUCCEED();
 }

--- a/tests/nnfw_api/src/one_op_tests/Add.cc
+++ b/tests/nnfw_api/src/one_op_tests/Add.cc
@@ -48,3 +48,46 @@ TEST_F(GenModelTest, OneOp_Add_VarToVar)
   _context->addTestCase({{{1, 3, 2, 4}, {5, 4, 7, 4}}, {{6, 7, 9, 8}}});
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
 }
+
+TEST_F(GenModelTest, neg_OneOp_Add_InvalidShape)
+{
+  CircleGen cgen;
+  int lhs = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_FLOAT32});
+  int rhs = cgen.addTensor({{1, 2, 3, 1}, circle::TensorType::TensorType_FLOAT32});
+  int out = cgen.addTensor({{1, 2, 3, 1}, circle::TensorType::TensorType_FLOAT32});
+  cgen.addOperatorAdd({{lhs, rhs}, {out}}, circle::ActivationFunctionType_NONE);
+  cgen.setInputsAndOutputs({lhs, rhs}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->setBackends({"acl_cl", "acl_neon", "cpu"});
+  _context->setCompileFail();
+}
+
+TEST_F(GenModelTest, neg_OneOp_Add_InvalidShapeConst)
+{
+  CircleGen cgen;
+  std::vector<float> rhs_data{5, 4, 0, 7, 4, 0};
+  uint32_t rhs_buf = cgen.addBuffer(rhs_data);
+  int lhs = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_FLOAT32});
+  int rhs = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_FLOAT32, rhs_buf});
+  int out = cgen.addTensor({{1, 2, 3, 1}, circle::TensorType::TensorType_FLOAT32});
+  cgen.addOperatorAdd({{lhs, rhs}, {out}}, circle::ActivationFunctionType_NONE);
+  cgen.setInputsAndOutputs({lhs, rhs}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->setBackends({"acl_cl", "acl_neon", "cpu"});
+  _context->setCompileFail();
+}
+
+TEST_F(GenModelTest, neg_OneOp_Add_OneOperand)
+{
+  CircleGen cgen;
+  int in = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_FLOAT32});
+  int out = cgen.addTensor({{1, 2, 3, 1}, circle::TensorType::TensorType_FLOAT32});
+  cgen.addOperatorAdd({{in}, {out}}, circle::ActivationFunctionType_NONE);
+  cgen.setInputsAndOutputs({in}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->setBackends({"acl_cl", "acl_neon", "cpu"});
+  _context->setCompileFail();
+}

--- a/tests/nnfw_api/src/one_op_tests/AveragePool2D.cc
+++ b/tests/nnfw_api/src/one_op_tests/AveragePool2D.cc
@@ -28,6 +28,8 @@ TEST_F(GenModelTest, OneOp_AvgPool2D)
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
   _context->addTestCase({{{1, 3, 2, 4}}, {{2.5}}});
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
+
+  SUCCEED();
 }
 
 TEST_F(GenModelTest, neg_OneOp_AvgPool2D)
@@ -42,4 +44,6 @@ TEST_F(GenModelTest, neg_OneOp_AvgPool2D)
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
   _context->setCompileFail();
+
+  SUCCEED();
 }

--- a/tests/nnfw_api/src/one_op_tests/AveragePool2D.cc
+++ b/tests/nnfw_api/src/one_op_tests/AveragePool2D.cc
@@ -29,3 +29,17 @@ TEST_F(GenModelTest, OneOp_AvgPool2D)
   _context->addTestCase({{{1, 3, 2, 4}}, {{2.5}}});
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
 }
+
+TEST_F(GenModelTest, neg_OneOp_AvgPool2D)
+{
+  CircleGen cgen;
+  int in = cgen.addTensor({{2, 2, 1}, circle::TensorType::TensorType_FLOAT32});
+  int out = cgen.addTensor({{1, 1, 1}, circle::TensorType::TensorType_FLOAT32});
+  cgen.addOperatorAveragePool2D({{in}, {out}}, circle::Padding_SAME, 2, 2, 2, 2,
+                                circle::ActivationFunctionType_NONE);
+  cgen.setInputsAndOutputs({in}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->setBackends({"acl_cl", "acl_neon", "cpu"});
+  _context->setCompileFail();
+}

--- a/tests/nnfw_api/src/one_op_tests/Cos.cc
+++ b/tests/nnfw_api/src/one_op_tests/Cos.cc
@@ -28,6 +28,8 @@ TEST_F(GenModelTest, OneOp_Cos)
   const float pi = 3.141592653589793;
   _context->addTestCase({{{0, pi / 2, pi, 7}}, {{1, 0, -1, 0.75390225434}}});
   _context->setBackends({"cpu"});
+
+  SUCCEED();
 }
 
 TEST_F(GenModelTest, neg_OneOp_Cos_TwoOperand)
@@ -43,4 +45,6 @@ TEST_F(GenModelTest, neg_OneOp_Cos_TwoOperand)
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
   _context->setBackends({"cpu"});
   _context->setCompileFail();
+
+  SUCCEED();
 }

--- a/tests/nnfw_api/src/one_op_tests/Cos.cc
+++ b/tests/nnfw_api/src/one_op_tests/Cos.cc
@@ -29,3 +29,18 @@ TEST_F(GenModelTest, OneOp_Cos)
   _context->addTestCase({{{0, pi / 2, pi, 7}}, {{1, 0, -1, 0.75390225434}}});
   _context->setBackends({"cpu"});
 }
+
+TEST_F(GenModelTest, neg_OneOp_Cos_TwoOperand)
+{
+  CircleGen cgen;
+  int lhs = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_FLOAT32});
+  int rhs = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_FLOAT32});
+  int out1 = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_FLOAT32});
+  int out2 = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_FLOAT32});
+  cgen.addOperatorCos({{lhs, rhs}, {out1, out2}});
+  cgen.setInputsAndOutputs({lhs, rhs}, {out1, out2});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->setBackends({"cpu"});
+  _context->setCompileFail();
+}

--- a/tests/nnfw_api/src/one_op_tests/L2Normalization.cc
+++ b/tests/nnfw_api/src/one_op_tests/L2Normalization.cc
@@ -30,4 +30,6 @@ TEST_F(GenModelTest, OneOp_L2Normalization)
                          {{0, 0.6, 0.8, 0, 0.38461539149284363, 0.92307698726654053, 0,
                            0.47058823704719543, 0.88235294818878174, 0, 0.28, 0.96}}});
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
+
+  SUCCEED();
 }

--- a/tests/nnfw_api/src/one_op_tests/LeakyRelu.cc
+++ b/tests/nnfw_api/src/one_op_tests/LeakyRelu.cc
@@ -27,4 +27,6 @@ TEST_F(GenModelTest, OneOp_LeakyRelu)
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
   _context->addTestCase({{{0, 1.0, 3.0, 1.0, -1.0, -2.0f}}, {{0, 1.0, 3.0, 1.0, -0.5, -1.0}}});
   _context->setBackends({"acl_cl", "acl_neon"});
+
+  SUCCEED();
 }

--- a/tests/nnfw_api/src/one_op_tests/Pad.cc
+++ b/tests/nnfw_api/src/one_op_tests/Pad.cc
@@ -30,6 +30,8 @@ TEST_F(GenModelTest, OneOp_Pad)
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
   _context->addTestCase({{{1, 2, 3, 4}}, {{0, 0, 0, 0, 0, 1, 2, 0, 0, 3, 4, 0, 0, 0, 0, 0}}});
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
+
+  SUCCEED();
 }
 
 TEST_F(GenModelTest, neg_OneOp_Pad_InvalidPadRank)
@@ -47,6 +49,8 @@ TEST_F(GenModelTest, neg_OneOp_Pad_InvalidPadRank)
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
   _context->setCompileFail();
+
+  SUCCEED();
 }
 
 TEST_F(GenModelTest, neg_OneOp_Pad_InvalidPadDim0)
@@ -64,6 +68,8 @@ TEST_F(GenModelTest, neg_OneOp_Pad_InvalidPadDim0)
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
   _context->setCompileFail();
+
+  SUCCEED();
 }
 
 TEST_F(GenModelTest, neg_OneOp_Pad_InvalidPadDim1)
@@ -81,4 +87,6 @@ TEST_F(GenModelTest, neg_OneOp_Pad_InvalidPadDim1)
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
   _context->setCompileFail();
+
+  SUCCEED();
 }

--- a/tests/nnfw_api/src/one_op_tests/Pad.cc
+++ b/tests/nnfw_api/src/one_op_tests/Pad.cc
@@ -31,3 +31,54 @@ TEST_F(GenModelTest, OneOp_Pad)
   _context->addTestCase({{{1, 2, 3, 4}}, {{0, 0, 0, 0, 0, 1, 2, 0, 0, 3, 4, 0, 0, 0, 0, 0}}});
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
 }
+
+TEST_F(GenModelTest, neg_OneOp_Pad_InvalidPadRank)
+{
+  CircleGen cgen;
+  int in = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_FLOAT32});
+  std::vector<int32_t> padding_data{1, 1, 1, 1};
+  uint32_t padding_buf = cgen.addBuffer(padding_data);
+  int padding = cgen.addTensor({{4}, circle::TensorType::TensorType_INT32, padding_buf});
+  int out = cgen.addTensor({{1, 4, 4, 1}, circle::TensorType::TensorType_FLOAT32});
+
+  cgen.addOperatorPad({{in, padding}, {out}});
+  cgen.setInputsAndOutputs({in}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->setBackends({"acl_cl", "acl_neon", "cpu"});
+  _context->setCompileFail();
+}
+
+TEST_F(GenModelTest, neg_OneOp_Pad_InvalidPadDim0)
+{
+  CircleGen cgen;
+  int in = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_FLOAT32});
+  std::vector<int32_t> padding_data{1, 1, 1, 1};
+  uint32_t padding_buf = cgen.addBuffer(padding_data);
+  int padding = cgen.addTensor({{2, 2}, circle::TensorType::TensorType_INT32, padding_buf});
+  int out = cgen.addTensor({{1, 4, 4, 1}, circle::TensorType::TensorType_FLOAT32});
+
+  cgen.addOperatorPad({{in, padding}, {out}});
+  cgen.setInputsAndOutputs({in}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->setBackends({"acl_cl", "acl_neon", "cpu"});
+  _context->setCompileFail();
+}
+
+TEST_F(GenModelTest, neg_OneOp_Pad_InvalidPadDim1)
+{
+  CircleGen cgen;
+  int in = cgen.addTensor({{1, 1, 1, 1}, circle::TensorType::TensorType_FLOAT32});
+  std::vector<int32_t> padding_data{1, 1, 1, 1};
+  uint32_t padding_buf = cgen.addBuffer(padding_data);
+  int padding = cgen.addTensor({{4, 1}, circle::TensorType::TensorType_INT32, padding_buf});
+  int out = cgen.addTensor({{2, 2, 2, 2}, circle::TensorType::TensorType_FLOAT32});
+
+  cgen.addOperatorPad({{in, padding}, {out}});
+  cgen.setInputsAndOutputs({in}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->setBackends({"acl_cl", "acl_neon", "cpu"});
+  _context->setCompileFail();
+}

--- a/tests/nnfw_api/src/one_op_tests/PadV2.cc
+++ b/tests/nnfw_api/src/one_op_tests/PadV2.cc
@@ -37,3 +37,69 @@ TEST_F(GenModelTest, OneOp_PadV2)
   _context->addTestCase({{{1, 2, 3, 4}}, {{3, 3, 3, 3, 3, 1, 2, 3, 3, 3, 4, 3, 3, 3, 3, 3}}});
   _context->setBackends({"cpu"});
 }
+
+TEST_F(GenModelTest, neg_OneOp_PadV2_InvalidPadRank)
+{
+  CircleGen cgen;
+  int in = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_FLOAT32});
+  std::vector<int32_t> padding_data{1, 1, 1, 1};
+  uint32_t padding_buf = cgen.addBuffer(padding_data);
+  int padding = cgen.addTensor({{4}, circle::TensorType::TensorType_INT32, padding_buf});
+  std::vector<float> padding_value_data{3.0};
+  uint32_t padding_value_buf = cgen.addBuffer(padding_value_data);
+  int padding_value =
+      cgen.addTensor({{1}, circle::TensorType::TensorType_FLOAT32, padding_value_buf});
+
+  int out = cgen.addTensor({{1, 4, 4, 1}, circle::TensorType::TensorType_FLOAT32});
+
+  cgen.addOperatorPad({{in, padding, padding_value}, {out}});
+  cgen.setInputsAndOutputs({in}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->setBackends({"acl_cl", "acl_neon", "cpu"});
+  _context->setCompileFail();
+}
+
+TEST_F(GenModelTest, neg_OneOp_PadV2_InvalidPadDim0)
+{
+  CircleGen cgen;
+  int in = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_FLOAT32});
+  std::vector<int32_t> padding_data{1, 1, 1, 1};
+  uint32_t padding_buf = cgen.addBuffer(padding_data);
+  int padding = cgen.addTensor({{2, 2}, circle::TensorType::TensorType_INT32, padding_buf});
+  std::vector<float> padding_value_data{3.0};
+  uint32_t padding_value_buf = cgen.addBuffer(padding_value_data);
+  int padding_value =
+      cgen.addTensor({{1}, circle::TensorType::TensorType_FLOAT32, padding_value_buf});
+
+  int out = cgen.addTensor({{1, 4, 4, 1}, circle::TensorType::TensorType_FLOAT32});
+
+  cgen.addOperatorPad({{in, padding, padding_value}, {out}});
+  cgen.setInputsAndOutputs({in}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->setBackends({"acl_cl", "acl_neon", "cpu"});
+  _context->setCompileFail();
+}
+
+TEST_F(GenModelTest, neg_OneOp_PadV2_InvalidPadDim1)
+{
+  CircleGen cgen;
+  int in = cgen.addTensor({{1, 1, 1, 1}, circle::TensorType::TensorType_FLOAT32});
+  std::vector<int32_t> padding_data{1, 1, 1, 1};
+  uint32_t padding_buf = cgen.addBuffer(padding_data);
+  int padding = cgen.addTensor({{4, 1}, circle::TensorType::TensorType_INT32, padding_buf});
+  std::vector<float> padding_value_data{3.0};
+  uint32_t padding_value_buf = cgen.addBuffer(padding_value_data);
+  int padding_value =
+      cgen.addTensor({{1}, circle::TensorType::TensorType_FLOAT32, padding_value_buf});
+
+  int out = cgen.addTensor({{2, 2, 2, 2}, circle::TensorType::TensorType_FLOAT32});
+
+  cgen.addOperatorPad({{in, padding, padding_value}, {out}});
+  cgen.setInputsAndOutputs({in}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->setBackends({"acl_cl", "acl_neon", "cpu"});
+  _context->setCompileFail();
+}

--- a/tests/nnfw_api/src/one_op_tests/PadV2.cc
+++ b/tests/nnfw_api/src/one_op_tests/PadV2.cc
@@ -36,6 +36,8 @@ TEST_F(GenModelTest, OneOp_PadV2)
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
   _context->addTestCase({{{1, 2, 3, 4}}, {{3, 3, 3, 3, 3, 1, 2, 3, 3, 3, 4, 3, 3, 3, 3, 3}}});
   _context->setBackends({"cpu"});
+
+  SUCCEED();
 }
 
 TEST_F(GenModelTest, neg_OneOp_PadV2_InvalidPadRank)
@@ -58,6 +60,8 @@ TEST_F(GenModelTest, neg_OneOp_PadV2_InvalidPadRank)
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
   _context->setCompileFail();
+
+  SUCCEED();
 }
 
 TEST_F(GenModelTest, neg_OneOp_PadV2_InvalidPadDim0)
@@ -80,6 +84,8 @@ TEST_F(GenModelTest, neg_OneOp_PadV2_InvalidPadDim0)
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
   _context->setCompileFail();
+
+  SUCCEED();
 }
 
 TEST_F(GenModelTest, neg_OneOp_PadV2_InvalidPadDim1)
@@ -102,4 +108,6 @@ TEST_F(GenModelTest, neg_OneOp_PadV2_InvalidPadDim1)
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
   _context->setCompileFail();
+
+  SUCCEED();
 }

--- a/tests/nnfw_api/src/one_op_tests/Rank.cc
+++ b/tests/nnfw_api/src/one_op_tests/Rank.cc
@@ -38,6 +38,8 @@ TEST_F(GenModelTest, OneOp_Rank)
   _context->addTestCase(
       {{{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18}}, {{output_data.f}}});
   _context->setBackends({"cpu"});
+
+  SUCCEED();
 }
 
 TEST_F(GenModelTest, OneOp_Rank_Int32)
@@ -56,4 +58,6 @@ TEST_F(GenModelTest, OneOp_Rank_Int32)
   _context->addTestCase(
       {{{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18}}, {{output_data.f}}});
   _context->setBackends({"cpu"});
+
+  SUCCEED();
 }

--- a/tests/nnfw_api/src/one_op_tests/ResizeNearestNeighbor.cc
+++ b/tests/nnfw_api/src/one_op_tests/ResizeNearestNeighbor.cc
@@ -33,4 +33,6 @@ TEST_F(GenModelTest, OneOp_ResizeNearestNeighbor)
   _context->addTestCase({{{3, 4, 6, 10, 9, 10, 12, 16}},
                          {{3, 4, 3, 4, 6, 10, 3, 4, 3, 4, 6, 10, 9, 10, 9, 10, 12, 16}}});
   _context->setBackends({"acl_cl"});
+
+  SUCCEED();
 }

--- a/tests/nnfw_api/src/one_op_tests/While.cc
+++ b/tests/nnfw_api/src/one_op_tests/While.cc
@@ -70,4 +70,6 @@ TEST_F(GenModelTest, OneOp_While)
   _context->addTestCase({{{2}}, {{102}}});
   _context->addTestCase({{{22}}, {{102}}});
   _context->setBackends({"cpu"});
+
+  SUCCEED();
 }


### PR DESCRIPTION
Add negative tests - operation validator
- Add
- AveragePool2D
- Cos
- Pad
- PadV2

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>