### PR TITLE
[onert] Rewrite ModelTestInputReshaping.cc test with CircleGen

### DIFF
--- a/tests/nnfw_api/src/NNPackages.cc
+++ b/tests/nnfw_api/src/NNPackages.cc
@@ -29,7 +29,7 @@ const char *TEST_PACKAGE_NAMES[] = {
     "add", "add_no_manifest", "add_invalid_manifest",
 
     // for dynamic tensor test
-    "input_reshaping_add", "dynamic_tensor_reshape", "while_dynamic", "if_dynamic",
+    "dynamic_tensor_reshape", "while_dynamic", "if_dynamic",
 };
 
 NNPackages &NNPackages::get()

--- a/tests/nnfw_api/src/NNPackages.h
+++ b/tests/nnfw_api/src/NNPackages.h
@@ -43,7 +43,6 @@ public:
     ADD_INVALID_MANIFEST, //< Contains "Add" model but the manifest file is broken JSON
 
     // for dynamic tensor test
-    INPUT_RESHAPING_ADD,
     DYNAMIC_TENSOR_RESHAPE,
     WHILE_DYNAMIC,
     IF_DYNAMIC,


### PR DESCRIPTION
This rewrites `ModelTestInputReshaping.cc` test with `CircleGen`.

Along with this, all nnfw API calls were enclosed with `NNFW_ENSURE_SUCCESS(...)` macro.

After #4038

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>