### PR TITLE
Resolve TCM

### DIFF
--- a/tests/nnfw_api/src/one_op_tests/Add.cc
+++ b/tests/nnfw_api/src/one_op_tests/Add.cc
@@ -49,6 +49,8 @@ TEST_F(GenModelTest, OneOp_Add_VarToVar)
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
   _context->addTestCase({{{1, 3, 2, 4}, {5, 4, 7, 4}}, {{6, 7, 9, 8}}});
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
+
+  SUCCEED();
 }
 
 TEST_F(GenModelTest, neg_OneOp_Add_InvalidShape)


### PR DESCRIPTION
* Add `SUCCEED();` to resolve `No Assertion` warning in TCM.

Signed-off-by: Sung-Jae Lee <sj925.lee@samsung.com>

https://github.com/Samsung/ONE/issues/4030#issuecomment-686559570