### PR TITLE
MIN supports INT32 type

### DIFF
--- a/runtime/onert/backend/cpu/ops/ElementwiseBinaryLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ElementwiseBinaryLayer.cc
@@ -125,6 +125,10 @@ void ElementwiseBinaryLayer::configure(const IPortableTensor *lhs, const IPortab
         }
         _kernel = minimumGeneric<uint8_t>;
       }
+      else if (_lhs->data_type() == OperandType::INT32)
+      {
+        _kernel = minimumGeneric<int32_t>;
+      }
       else if (_lhs->data_type() == OperandType::FLOAT32)
       {
         _kernel = minimumGeneric<float>;


### PR DESCRIPTION
Now, MIN Layer supports INT32 type

ONE-DCO-1.0-Signed-off-by: Chunseok Lee <chunseok.lee@samsung.com>