### PR TITLE
MIN supports INT32 type

### DIFF
--- a/runtime/onert/backend/cpu/ops/ElementwiseBinaryLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ElementwiseBinaryLayer.cc
@@ -125,6 +125,10 @@ void ElementwiseBinaryLayer::configure(const IPortableTensor *lhs, const IPortab
         }
         _kernel = minimumGeneric<uint8_t>;
       }
+      else if (_lhs->data_type() == OperandType::INT32)
+      {
+        _kernel = minimumGeneric<int32_t>;
+      }
       else if (_lhs->data_type() == OperandType::FLOAT32)
       {
         _kernel = minimumGeneric<float>;

--- a/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_cl
+++ b/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_cl
@@ -110,6 +110,7 @@ GeneratedTests.matrix_band_part_ex_4D_float
 GeneratedTests.matrix_band_part_ex_dynamic_nnfw
 GeneratedTests.maximum_dynamic_nnfw
 GeneratedTests.minimum_dynamic_nnfw
+GeneratedTests.minimum_int32
 GeneratedTests.mul_dynamic_nnfw
 GeneratedTests.neg
 GeneratedTests.neg_dynamic_nnfw

--- a/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_cl
+++ b/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_cl
@@ -110,6 +110,7 @@ GeneratedTests.matrix_band_part_ex_4D_float
 GeneratedTests.matrix_band_part_ex_dynamic_nnfw
 GeneratedTests.maximum_dynamic_nnfw
 GeneratedTests.minimum_dynamic_nnfw
+GeneratedTests.minimum_int32
 GeneratedTests.mul_dynamic_nnfw
 GeneratedTests.neg
 GeneratedTests.neg_dynamic_nnfw

--- a/tests/nnapi/nnapi_gtest.skip.noarch.interp
+++ b/tests/nnapi/nnapi_gtest.skip.noarch.interp
@@ -291,6 +291,7 @@ GeneratedTests.minimum_overflow
 GeneratedTests.minimum_quant8_nnfw
 GeneratedTests.minimum_simple
 GeneratedTests.minimum_simple_quant8
+GeneratedTests.minimum_int32
 GeneratedTests.mul_broadcast_quant8
 GeneratedTests.mul_dynamic_nnfw
 GeneratedTests.mul_quant8

--- a/tests/nnapi/nnapi_gtest.skip.x86_64-linux.cpu
+++ b/tests/nnapi/nnapi_gtest.skip.x86_64-linux.cpu
@@ -67,6 +67,7 @@ GeneratedTests.lstm_state2
 GeneratedTests.maximum_broadcast_quant8
 GeneratedTests.maximum_overflow
 GeneratedTests.maximum_simple_quant8
+GeneratedTests.minimum_int32
 GeneratedTests.minimum_broadcast_quant8
 GeneratedTests.minimum_overflow
 GeneratedTests.minimum_simple_quant8

--- a/tests/nnapi/specs/V1_2/minimum_int32.mod.py
+++ b/tests/nnapi/specs/V1_2/minimum_int32.mod.py
@@ -1,0 +1,32 @@
+#
+# Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+# Copyright (C) 2020 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+i1 = Input("input0", "TENSOR_INT32", "{3, 1, 2}")
+i2 = Input("input1", "TENSOR_INT32", "{3, 1, 2}")
+i3 = Output("output0", "TENSOR_INT32", "{3, 1, 2}")
+
+model = Model().Operation("MINIMUM", i1, i2).To(i3)
+
+input0 = {i1:
+          [129, 12, 15, 130, -77, 33],
+          i2:
+          [44, 127, -25, 5, 39, 27]}
+
+output0 = {i3:
+           [44, 12, -25, 5, -77, 27]}
+
+Example((input0, output0))


### PR DESCRIPTION
Now, MIN Layer supports INT32 type

ONE-DCO-1.0-Signed-off-by: Chunseok Lee <chunseok.lee@samsung.com>