### PR TITLE
[onert] Log subgraph calls during execution

### DIFF
--- a/runtime/onert/core/src/backend/controlflow/kernel/IfLayer.cc
+++ b/runtime/onert/core/src/backend/controlflow/kernel/IfLayer.cc
@@ -63,13 +63,16 @@ void IfLayer::run()
   };
 
   exec::ExecutorBase *subg_exec = nullptr;
-  if (getResultCond(_cond_tensor.get()))
+  bool cond_result = getResultCond(_cond_tensor.get());
+  if (cond_result)
   {
+    VERBOSE(If) << "Call to $" << _then_subg_index << " (then)" << std::endl;
     subg_exec = nnfw::misc::polymorphic_downcast<exec::ExecutorBase *>(
         _executor_map->at(_then_subg_index).get());
   }
   else
   {
+    VERBOSE(If) << "Call to $" << _else_subg_index << " (else)" << std::endl;
     subg_exec = nnfw::misc::polymorphic_downcast<exec::ExecutorBase *>(
         _executor_map->at(_else_subg_index).get());
   }
@@ -120,6 +123,8 @@ void IfLayer::run()
   // Copy & run
   subg_exec->execute(_input_tensors, permute_op_input_to_subg_input);
   permute_subg_output_to_op_output->run();
+  VERBOSE(If) << "Return from $" << (cond_result ? _then_subg_index : _else_subg_index)
+              << std::endl;
 }
 
 } // namespace kernel

--- a/runtime/onert/core/src/backend/controlflow/kernel/WhileLayer.cc
+++ b/runtime/onert/core/src/backend/controlflow/kernel/WhileLayer.cc
@@ -186,16 +186,22 @@ void WhileLayer::run()
   };
 
   const auto body_execute_with_op_inputs = [&]() {
+    VERBOSE(While) << "Call to $" << _body_subg_index << " (body)" << std::endl;
     body_exec->execute(_input_tensors, permute_op_input_to_body_input);
+    VERBOSE(While) << "Return from $" << _body_subg_index << std::endl;
   };
 
   const auto body_execute_with_body_outputs = [&]() {
+    VERBOSE(While) << "Call to $" << _body_subg_index << " (body)" << std::endl;
     body_exec->execute(body_exec->getOutputTensors(), permute_body_output_to_body_input);
+    VERBOSE(While) << "Return from $" << _body_subg_index << std::endl;
   };
 
   std::function<void()> body_execute = body_execute_with_op_inputs;
   const auto cond_execute = [&]() {
+    VERBOSE(While) << "Call to $" << _cond_subg_index << " (cond)" << std::endl;
     cond_exec->execute(body_exec->getOutputTensors(), permute_body_output_to_cond_input);
+    VERBOSE(While) << "Return from $" << _cond_subg_index << std::endl;
   };
   auto permute_to_outputs_fn = permute_op_input_to_op_output;
 


### PR DESCRIPTION
Log subgraph calls during execution so we can trace the execution stack.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>