### PR TITLE
[nnfwapi] Log cond subgraph call of While op

### DIFF
--- a/runtime/onert/core/src/backend/controlflow/kernel/WhileLayer.cc
+++ b/runtime/onert/core/src/backend/controlflow/kernel/WhileLayer.cc
@@ -175,7 +175,9 @@ void WhileLayer::run()
   permute_body_output_to_body_input->prepare();
   permute_body_output_to_op_output->prepare();
 
+  VERBOSE(While) << "Call to $" << _cond_subg_index << " (cond)" << std::endl;
   cond_exec->execute(_input_tensors, permute_op_input_to_cond_input);
+  VERBOSE(While) << "Return from $" << _cond_subg_index << std::endl;
 
   assert(cond_exec->getOutputTensors().size() == 1);
   auto &cond_output_tensor = cond_exec->getOutputTensors().at(0);


### PR DESCRIPTION
cond subgraph call logging was missing.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>