### PR TITLE
[luci-interpreter] Allow LogSoftmax ops for KernelBuilder

### DIFF
--- a/compiler/luci-interpreter/src/loader/KernelBuilder.cpp
+++ b/compiler/luci-interpreter/src/loader/KernelBuilder.cpp
@@ -31,6 +31,7 @@
 #include "kernels/LeakyRelu.h"
 #include "kernels/LocalResponseNormalization.h"
 #include "kernels/Logistic.h"
+#include "kernels/LogSoftmax.h"
 #include "kernels/MaxPool2D.h"
 #include "kernels/Mean.h"
 #include "kernels/Mul.h"
@@ -347,6 +348,18 @@ std::unique_ptr<Kernel> KernelBuilder::visit(const luci::CircleLogistic *node)
   Tensor *output = getOutputTensor(node);
 
   return std::make_unique<kernels::Logistic>(input, output);
+}
+
+std::unique_ptr<Kernel> KernelBuilder::visit(const luci::CircleLogSoftmax *node)
+{
+  assert(node->arity() == 1);
+
+  const Tensor *input = getInputTensor(node->logits());
+  Tensor *output = getOutputTensor(node);
+
+  SoftmaxParams params{};
+
+  return std::make_unique<kernels::LogSoftmax>(input, output);
 }
 
 std::unique_ptr<Kernel> KernelBuilder::visit(const luci::CircleMaxPool2D *node)

--- a/compiler/luci-interpreter/src/loader/KernelBuilder.cpp
+++ b/compiler/luci-interpreter/src/loader/KernelBuilder.cpp
@@ -357,8 +357,6 @@ std::unique_ptr<Kernel> KernelBuilder::visit(const luci::CircleLogSoftmax *node)
   const Tensor *input = getInputTensor(node->logits());
   Tensor *output = getOutputTensor(node);
 
-  SoftmaxParams params{};
-
   return std::make_unique<kernels::LogSoftmax>(input, output);
 }
 

--- a/compiler/luci-interpreter/src/loader/KernelBuilder.h
+++ b/compiler/luci-interpreter/src/loader/KernelBuilder.h
@@ -55,6 +55,7 @@ public:
   std::unique_ptr<Kernel> visit(const luci::CircleLeakyRelu *node) override;
   std::unique_ptr<Kernel> visit(const luci::CircleLocalResponseNormalization *node) override;
   std::unique_ptr<Kernel> visit(const luci::CircleLogistic *node) override;
+  std::unique_ptr<Kernel> visit(const luci::CircleLogSoftmax *node) override;
   std::unique_ptr<Kernel> visit(const luci::CircleInput *node) override;
   std::unique_ptr<Kernel> visit(const luci::CircleMaxPool2D *node) override;
   std::unique_ptr<Kernel> visit(const luci::CircleMean *node) override;

--- a/compiler/luci-interpreter/src/loader/KernelBuilder.test.cpp
+++ b/compiler/luci-interpreter/src/loader/KernelBuilder.test.cpp
@@ -31,6 +31,7 @@
 #include <kernels/LeakyRelu.h>
 #include <kernels/LocalResponseNormalization.h>
 #include <kernels/Logistic.h>
+#include <kernels/LogSoftmax.h>
 #include <kernels/MaxPool2D.h>
 #include <kernels/Mean.h>
 #include <kernels/Mul.h>
@@ -409,6 +410,20 @@ TEST_F(KernelBuilderTest, Logistic)
   op->x(input);
 
   auto kernel = buildKernel<kernels::Logistic>(op);
+  ASSERT_THAT(kernel, NotNull());
+
+  checkTensor(kernel->input(), input);
+  checkTensor(kernel->output(), op);
+}
+
+TEST_F(KernelBuilderTest, LogSoftmax)
+{
+  auto *input = createInputNode();
+
+  auto *op = createNode<luci::CircleLogSoftmax>();
+  op->logits(input);
+
+  auto kernel = buildKernel<kernels::LogSoftmax>(op);
   ASSERT_THAT(kernel, NotNull());
 
   checkTensor(kernel->input(), input);


### PR DESCRIPTION
Related PR: #4018 
Fired Issue: #4097 

Added LogSoftmax kernel op for following source codes:
	- KernelBuilder.h
	- KernelBuilder.cpp
	- KernelBuilder.test.cpp

This commit have been tested on my PC.

Please review this PR, @seanshpark @jinevening .
I'll be happy to get feedback and change to make improvement.

Thank you.

(Derived from SOS Mine Project)

Signed-off-by: underflow101 <ikarus125@gmail.com>