### PR TITLE
[luci-interpreter]Add ResizeNearestNeighbor kernel.

### DIFF
--- a/compiler/luci-interpreter/src/core/KernelParams.h
+++ b/compiler/luci-interpreter/src/core/KernelParams.h
@@ -115,6 +115,12 @@ struct ReducerParams
   bool keep_dims;
 };
 
+struct ResizeNearestNeighborParams
+{
+  bool align_corners;
+  bool half_pixel_centers;
+};
+
 struct SpaceToDepthParams
 {
   int block_size;

--- a/compiler/luci-interpreter/src/kernels/CMakeLists.txt
+++ b/compiler/luci-interpreter/src/kernels/CMakeLists.txt
@@ -46,6 +46,8 @@ set(SOURCES
     Prelu.cpp
     Reshape.h
     Reshape.cpp
+    ResizeNearestNeighbor.h
+    ResizeNearestNeighbor.cpp
     Reverse.h
     Reverse.cpp
     Rsqrt.h
@@ -111,6 +113,7 @@ set(TEST_SOURCES
     Pad.test.cpp
     Prelu.test.cpp
     Reshape.test.cpp
+    ResizeNearestNeighbor.test.cpp
     Reverse.test.cpp
     Rsqrt.test.cpp
     Slice.test.cpp

--- a/compiler/luci-interpreter/src/kernels/ResizeNearestNeighbor.cpp
+++ b/compiler/luci-interpreter/src/kernels/ResizeNearestNeighbor.cpp
@@ -57,13 +57,14 @@ void ResizeNearestNeighbor::execute() const
   {
     case DataType::FLOAT32:
       tflite::reference_ops::ResizeNearestNeighbor(
-          op_params, getTensorShape(input()), getTensorData<int32>(input()), getTensorShape(size()),
-          getTensorData<int32>(size()), getTensorShape(output()), getTensorData<int32>(output()));
+          op_params, getTensorShape(input()), getTensorData<int32_t>(input()),
+          getTensorShape(size()), getTensorData<int32_t>(size()), getTensorShape(output()),
+          getTensorData<int32_t>(output()));
       break;
     case DataType::U8:
       tflite::optimized_ops::ResizeNearestNeighbor(
           op_params, getTensorShape(input()), getTensorData<uint8_t>(input()),
-          getTensorShape(size()), getTensorData<int32>(size()), getTensorShape(output()),
+          getTensorShape(size()), getTensorData<int32_t>(size()), getTensorShape(output()),
           getTensorData<uint8_t>(output()));
       break;
     default:

--- a/compiler/luci-interpreter/src/kernels/ResizeNearestNeighbor.cpp
+++ b/compiler/luci-interpreter/src/kernels/ResizeNearestNeighbor.cpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "kernels/ResizeNearestNeighbor.h"
+
+#include "kernels/Utils.h"
+
+#include <tensorflow/lite/kernels/internal/reference/reference_ops.h>
+#include <tensorflow/lite/kernels/internal/optimized/optimized_ops.h>
+
+namespace luci_interpreter
+{
+namespace kernels
+{
+
+ResizeNearestNeighbor::ResizeNearestNeighbor(const Tensor *input, const Tensor *size,
+                                             Tensor *output,
+                                             const ResizeNearestNeighborParams &params)
+    : KernelWithParams<ResizeNearestNeighborParams>({input, size}, {output}, params)
+{
+}
+
+void ResizeNearestNeighbor::configure()
+{
+  LUCI_INTERPRETER_CHECK(input()->shape().num_dims() == 4);
+  LUCI_INTERPRETER_CHECK(size()->shape().num_dims() == 1);
+  LUCI_INTERPRETER_CHECK(size()->element_type() == DataType::S32);
+  LUCI_INTERPRETER_CHECK(size()->shape().dim(0) == 2);
+  Shape output_shape(4);
+  output_shape.dim(0) = input()->shape().dim(0);
+  output_shape.dim(1) = getTensorData<int32_t>(size())[0];
+  output_shape.dim(2) = getTensorData<int32_t>(size())[1];
+  output_shape.dim(3) = input()->shape().dim(3);
+  output()->resize(output_shape);
+}
+
+void ResizeNearestNeighbor::execute() const
+{
+  tflite::ResizeNearestNeighborParams op_params{};
+  op_params.align_corners = params().align_corners;
+  op_params.half_pixel_centers = params().half_pixel_centers;
+  switch (output()->element_type())
+  {
+    case DataType::FLOAT32:
+      tflite::reference_ops::ResizeNearestNeighbor(
+          op_params, getTensorShape(input()), getTensorData<int32>(input()), getTensorShape(size()),
+          getTensorData<int32>(size()), getTensorShape(output()), getTensorData<int32>(output()));
+      break;
+    case DataType::U8:
+      tflite::optimized_ops::ResizeNearestNeighbor(
+          op_params, getTensorShape(input()), getTensorData<uint8_t>(input()),
+          getTensorShape(size()), getTensorData<int32>(size()), getTensorShape(output()),
+          getTensorData<uint8_t>(output()));
+      break;
+    default:
+      throw std::runtime_error("Unsupported type.");
+  }
+}
+
+} // namespace kernels
+} // namespace luci_interpreter

--- a/compiler/luci-interpreter/src/kernels/ResizeNearestNeighbor.h
+++ b/compiler/luci-interpreter/src/kernels/ResizeNearestNeighbor.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef LUCI_INTERPRETER_KERNELS_RESIZENEARESTNEIGHBOR_H
+#define LUCI_INTERPRETER_KERNELS_RESIZENEARESTNEIGHBOR_H
+
+#include "core/Kernel.h"
+#include "core/KernelParams.h"
+
+namespace luci_interpreter
+{
+namespace kernels
+{
+
+class ResizeNearestNeighbor : public KernelWithParams<ResizeNearestNeighborParams>
+{
+public:
+  ResizeNearestNeighbor(const Tensor *input, const Tensor *shape, Tensor *output,
+                        const ResizeNearestNeighborParams &params);
+
+  const Tensor *input() const { return _inputs[0]; }
+  const Tensor *size() const { return _inputs[1]; }
+  Tensor *output() const { return _outputs[0]; }
+
+  void configure() override;
+  void execute() const override;
+};
+
+} // namespace kernels
+} // namespace luci_interpreter
+
+#endif // LUCI_INTERPRETER_KERNELS_RESIZENEARESTNEIGHBOR_H

--- a/compiler/luci-interpreter/src/kernels/ResizeNearestNeighbor.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/ResizeNearestNeighbor.test.cpp
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "kernels/ResizeNearestNeighbor.h"
+#include "kernels/TestUtils.h"
+
+namespace luci_interpreter
+{
+namespace kernels
+{
+namespace
+{
+
+using namespace testing;
+
+template <typename T>
+void Check(std::initializer_list<int32_t> input_shape, std::initializer_list<int32_t> size_shape,
+           std::initializer_list<int32_t> output_shape, std::initializer_list<float> input_data,
+           std::initializer_list<int32_t> size_data, std::initializer_list<float> output_data,
+           bool align_corners, bool half_pixel_centers)
+{
+  std::pair<float, int32_t> quant_param =
+      quantizationParams<T>(std::min(input_data) < 0 ? std::min(input_data) : 0.f,
+                            std::max(input_data) > 0 ? std::max(input_data) : 0.f);
+  Tensor input_tensor{
+      getElementType<T>(), input_shape, {{quant_param.first}, {quant_param.second}}, ""};
+  Tensor size_tensor{DataType::S32, size_shape, {}, ""};
+
+  if (std::is_floating_point<T>::value)
+  {
+    input_tensor.writeData(input_data.begin(), input_data.size() * sizeof(T));
+  }
+  else
+  {
+    std::vector<T> quantized_input_value =
+        quantize<T>(input_data, quant_param.first, quant_param.second);
+    input_tensor.writeData(quantized_input_value.data(), quantized_input_value.size() * sizeof(T));
+  }
+  size_tensor.writeData(size_data.begin(), size_data.size() * sizeof(int32_t));
+
+  Tensor output_tensor =
+      makeOutputTensor(getElementType<T>(), quant_param.first, quant_param.first);
+
+  ResizeNearestNeighborParams params{};
+  params.align_corners = align_corners;
+  params.half_pixel_centers = half_pixel_centers;
+
+  ResizeNearestNeighbor kernel(&input_tensor, &size_tensor, &output_tensor, params);
+  kernel.configure();
+  kernel.execute();
+
+  if (std::is_floating_point<T>::value)
+  {
+    EXPECT_THAT(extractTensorData<T>(output_tensor), ElementsAreArray(ArrayFloatNear(output_data)));
+  }
+  else
+  {
+    EXPECT_THAT(dequantize<T>(extractTensorData<T>(output_tensor), output_tensor.scale(),
+                              output_tensor.zero_point()),
+                ElementsAreArray(ArrayFloatNear(output_data, output_tensor.scale())));
+  }
+  EXPECT_THAT(extractTensorShape(output_tensor), output_shape);
+}
+
+template <typename T> class ResizeNearestNeighborTest : public ::testing::Test
+{
+};
+
+using DataTypes = ::testing::Types<float, uint8_t>;
+TYPED_TEST_CASE(ResizeNearestNeighborTest, DataTypes);
+
+TYPED_TEST(ResizeNearestNeighborTest, SimpleTest)
+{
+  Check<TypeParam>({2, 2, 2, 1}, {2}, {2, 3, 3, 1},
+                   {
+                       3, 6,  //
+                       9, 12, //
+                       4, 10, //
+                       10, 16 //
+                   },
+                   {3, 3},
+                   {
+                       3, 3, 6,    //
+                       3, 3, 6,    //
+                       9, 9, 12,   //
+                       4, 4, 10,   //
+                       4, 4, 10,   //
+                       10, 10, 16, //
+                   },
+                   false, false);
+}
+
+TEST(ResizeNearestNeighborTest, InputShapeInvalid_NEG)
+{
+  Tensor input_tensor = makeInputTensor<DataType::FLOAT32>({2, 2, 2}, {
+                                                                          3, 6,  //
+                                                                          9, 12, //
+                                                                          4, 10, //
+                                                                          10, 16 //
+                                                                      });
+  Tensor size_tensor = makeInputTensor<DataType::S32>({2}, {3, 3});
+  Tensor output_tensor = makeOutputTensor(DataType::FLOAT32);
+
+  ResizeNearestNeighborParams params{};
+  params.align_corners = false;
+  params.half_pixel_centers = false;
+
+  ResizeNearestNeighbor kernel(&input_tensor, &size_tensor, &output_tensor, params);
+  EXPECT_ANY_THROW(kernel.configure());
+}
+
+TEST(ResizeNearestNeighborTest, SizeShapeInvalid_NEG)
+{
+  Tensor input_tensor = makeInputTensor<DataType::FLOAT32>({2, 2, 2, 1}, {
+                                                                             3, 6,  //
+                                                                             9, 12, //
+                                                                             4, 10, //
+                                                                             10, 16 //
+                                                                         });
+  Tensor size_tensor = makeInputTensor<DataType::S32>({2, 1}, {3, 3});
+  Tensor output_tensor = makeOutputTensor(DataType::FLOAT32);
+
+  ResizeNearestNeighborParams params{};
+  params.align_corners = false;
+  params.half_pixel_centers = false;
+
+  ResizeNearestNeighbor kernel(&input_tensor, &size_tensor, &output_tensor, params);
+  EXPECT_ANY_THROW(kernel.configure());
+}
+
+TEST(ResizeNearestNeighborTest, SizeDimInvalid_NEG)
+{
+  Tensor input_tensor = makeInputTensor<DataType::FLOAT32>({2, 2, 2, 1}, {
+                                                                             3, 6,  //
+                                                                             9, 12, //
+                                                                             4, 10, //
+                                                                             10, 16 //
+                                                                         });
+  Tensor size_tensor = makeInputTensor<DataType::S32>({3}, {3, 3, 1});
+  Tensor output_tensor = makeOutputTensor(DataType::FLOAT32);
+
+  ResizeNearestNeighborParams params{};
+  params.align_corners = false;
+  params.half_pixel_centers = false;
+
+  ResizeNearestNeighbor kernel(&input_tensor, &size_tensor, &output_tensor, params);
+  EXPECT_ANY_THROW(kernel.configure());
+}
+
+} // namespace
+} // namespace kernels
+} // namespace luci_interpreter

--- a/compiler/luci-interpreter/src/kernels/ResizeNearestNeighbor.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/ResizeNearestNeighbor.test.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2017 The TensorFlow Authors. All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -101,6 +102,48 @@ TYPED_TEST(ResizeNearestNeighborTest, SimpleTest)
                        10, 10, 16, //
                    },
                    false, false);
+}
+
+TYPED_TEST(ResizeNearestNeighborTest, AlignCenterTest)
+{
+  Check<TypeParam>({2, 2, 2, 1}, {2}, {2, 3, 3, 1},
+                   {
+                       3, 6,  //
+                       9, 12, //
+                       4, 10, //
+                       10, 16 //
+                   },
+                   {3, 3},
+                   {
+                       3, 6, 6,    //
+                       9, 12, 12,  //
+                       9, 12, 12,  //
+                       4, 10, 10,  //
+                       10, 16, 16, //
+                       10, 16, 16, //
+                   },
+                   true, false);
+}
+
+TYPED_TEST(ResizeNearestNeighborTest, HalfPixelCenterTest)
+{
+  Check<TypeParam>({2, 2, 2, 1}, {2}, {2, 3, 3, 1},
+                   {
+                       3, 6,  //
+                       9, 12, //
+                       4, 10, //
+                       10, 16 //
+                   },
+                   {3, 3},
+                   {
+                       3, 6, 6,    //
+                       9, 12, 12,  //
+                       9, 12, 12,  //
+                       4, 10, 10,  //
+                       10, 16, 16, //
+                       10, 16, 16, //
+                   },
+                   false, true);
 }
 
 TEST(ResizeNearestNeighborTest, InputShapeInvalid_NEG)

--- a/compiler/luci-interpreter/src/loader/KernelBuilder.cpp
+++ b/compiler/luci-interpreter/src/loader/KernelBuilder.cpp
@@ -37,6 +37,7 @@
 #include "kernels/Pad.h"
 #include "kernels/Prelu.h"
 #include "kernels/Reshape.h"
+#include "kernels/ResizeNearestNeighbor.h"
 #include "kernels/Reverse.h"
 #include "kernels/Rsqrt.h"
 #include "kernels/Slice.h"
@@ -432,6 +433,25 @@ std::unique_ptr<Kernel> KernelBuilder::visit(const luci::CircleReshape *node)
 
   // NOTE 'newShape' attribute is ignored.
   return std::make_unique<kernels::Reshape>(input, shape, output);
+}
+
+std::unique_ptr<Kernel> KernelBuilder::visit(const luci::CircleResizeNearestNeighbor *node)
+{
+  assert(node->arity() == 2);
+
+  const Tensor *input = getInputTensor(node->input());
+  const Tensor *size = getInputTensor(node->size());
+  Tensor *output = getOutputTensor(node);
+
+  ResizeNearestNeighborParams params{};
+  params.align_corners = node->align_corners();
+  // TODO update half_pixel_centers after CircleResizeNearestNeighbor updated
+  // Current CircleResizeNearestNeighbor don't have half_pixel_centers.
+  // default value on current is false.
+  // it need to be updated when CircleResizeNearestNeighbor updated.
+  params.half_pixel_centers = false;
+
+  return std::make_unique<kernels::ResizeNearestNeighbor>(input, size, output, params);
 }
 
 std::unique_ptr<Kernel> KernelBuilder::visit(const luci::CircleReverseV2 *node)

--- a/compiler/luci-interpreter/src/loader/KernelBuilder.h
+++ b/compiler/luci-interpreter/src/loader/KernelBuilder.h
@@ -63,6 +63,7 @@ public:
   std::unique_ptr<Kernel> visit(const luci::CirclePad *node) override;
   std::unique_ptr<Kernel> visit(const luci::CirclePRelu *node) override;
   std::unique_ptr<Kernel> visit(const luci::CircleReshape *node) override;
+  std::unique_ptr<Kernel> visit(const luci::CircleResizeNearestNeighbor *node) override;
   std::unique_ptr<Kernel> visit(const luci::CircleReverseV2 *node) override;
   std::unique_ptr<Kernel> visit(const luci::CircleRsqrt *node) override;
   std::unique_ptr<Kernel> visit(const luci::CircleSlice *node) override;

--- a/compiler/luci-interpreter/src/loader/KernelBuilder.test.cpp
+++ b/compiler/luci-interpreter/src/loader/KernelBuilder.test.cpp
@@ -37,6 +37,7 @@
 #include <kernels/Pad.h>
 #include <kernels/Prelu.h>
 #include <kernels/Reshape.h>
+#include <kernels/ResizeNearestNeighbor.h>
 #include <kernels/Reverse.h>
 #include <kernels/Rsqrt.h>
 #include <kernels/Slice.h>
@@ -514,6 +515,27 @@ TEST_F(KernelBuilderTest, Prelu)
   checkTensor(kernel->input(), input);
   checkTensor(kernel->alpha(), alpha);
   checkTensor(kernel->output(), op);
+}
+
+TEST_F(KernelBuilderTest, ResizeNearestNeighbor)
+{
+  auto *input = createInputNode();
+  auto *size = createInputNode();
+
+  auto *op = createNode<luci::CircleResizeNearestNeighbor>();
+  op->input(input);
+  op->size(size);
+  op->align_corners(true);
+
+  auto kernel = buildKernel<kernels::ResizeNearestNeighbor>(op);
+  ASSERT_THAT(kernel, NotNull());
+
+  checkTensor(kernel->input(), input);
+  checkTensor(kernel->size(), size);
+  checkTensor(kernel->output(), op);
+  EXPECT_THAT(kernel->params().align_corners, Eq(op->align_corners()));
+  // TODO currently half_pixel_centers are not implemented on CircleResizeNearestNeighbor
+  // after adding, need to be updated.
 }
 
 TEST_F(KernelBuilderTest, Reshape)


### PR DESCRIPTION
This commit Add `ResizeNearestNeighbor` kernel on luci-interpreter for Float and Uint8

ONE-DCO-1.0-Signed-off-by: KiDeuk Bang <rrstrous@nate.com>