### PR TITLE
[onert] Support Tile operation's multiplies as input on loader

### DIFF
--- a/runtime/onert/core/include/util/ShapeInference.h
+++ b/runtime/onert/core/include/util/ShapeInference.h
@@ -132,7 +132,8 @@ StridedSliceParams buildStridedSliceParams(const T *begin, const T *end, const T
 ir::Shape inferStridedSliceShape(const ir::Shape &input_shape, const StridedSliceParams &op_params,
                                  uint32_t rank);
 
-ir::Shape inferTileShape(const ir::Shape &in_shape, const int32_t *multiplier);
+ir::Shape inferTileShape(const ir::Shape &in_shape, const int32_t *multiplier,
+                         const int32_t multiplier_size);
 
 ir::Shape inferTransposeShape(const ir::Shape &in_shape, const int32_t *perm, const int32_t rank);
 

--- a/runtime/onert/core/src/compiler/StaticShapeInference.cc
+++ b/runtime/onert/core/src/compiler/StaticShapeInference.cc
@@ -953,7 +953,8 @@ void StaticShapeInferer::visit(const ir::operation::Tile &op)
   assert(multiplier_buffer);
 
   // re-sizing output shape
-  auto new_shape = shape_inference::inferTileShape(input.info().shape(), multiplier_buffer);
+  auto new_shape = shape_inference::inferTileShape(input.info().shape(), multiplier_buffer,
+                                                   multiplier.shape().num_elements());
   output.info().shape(new_shape);
 }
 

--- a/runtime/onert/core/src/exec/DynamicShapeInference.cc
+++ b/runtime/onert/core/src/exec/DynamicShapeInference.cc
@@ -977,7 +977,8 @@ void DynamicShapeInferer::visit(const ir::operation::Tile &op)
   auto multiplier_buffer = reinterpret_cast<const int32_t *>(multiplier->buffer());
   assert(multiplier_buffer);
 
-  auto output_shape = shape_inference::inferTileShape(input_shape, multiplier_buffer);
+  auto output_shape =
+      shape_inference::inferTileShape(input_shape, multiplier_buffer, multiplier->dimension(0));
 
   // set output shape and output buffer
   output->applyShape(output_shape);

--- a/runtime/onert/core/src/util/ShapeInference.cc
+++ b/runtime/onert/core/src/util/ShapeInference.cc
@@ -965,9 +965,15 @@ ir::Shape inferStridedSliceShape(const ir::Shape &input_shape, const StridedSlic
   return out_shape;
 }
 
-ir::Shape inferTileShape(const ir::Shape &in_shape, const int32_t *multiplier)
+ir::Shape inferTileShape(const ir::Shape &in_shape, const int32_t *multiplier,
+                         const int32_t multiplier_size)
 {
-  // assert(in_shape.rank() == multiplier.rank());
+  if (multiplier_size != in_shape.rank())
+  {
+    throw std::runtime_error("inferTileShape failed, input rank: " +
+                             std::to_string(in_shape.rank()) + ", bad multipliers size: " +
+                             std::to_string(multiplier_size) + "");
+  }
   ir::Shape new_Shape(in_shape.rank());
 
   for (int i = 0; i < in_shape.rank(); ++i)

--- a/tests/nnfw_api/src/one_op_tests/Tile.cc
+++ b/tests/nnfw_api/src/one_op_tests/Tile.cc
@@ -35,13 +35,55 @@ TEST_F(GenModelTest, OneOp_Tile_ConstMul)
   SUCCEED();
 }
 
-// Variable mul input is not supported yet
-TEST_F(GenModelTest, DISABLED_OneOp_Tile_VarMul)
+TEST_F(GenModelTest, OneOp_Tile_MulToConst)
 {
   CircleGen cgen;
-  int in = cgen.addTensor({{2, 3}, circle::TensorType::TensorType_INT32});
+  std::vector<int32_t> multiplies_data{2, 3, 1};
+  uint32_t multiplies_buf = cgen.addBuffer(multiplies_data);
+  int multiplies = cgen.addTensor({{3}, circle::TensorType::TensorType_INT32, multiplies_buf});
+  int in = cgen.addTensor({{1, 2, 3}, circle::TensorType::TensorType_FLOAT32});
+  int out = cgen.addTensor({{2, 6, 3}, circle::TensorType::TensorType_FLOAT32});
+  cgen.addOperatorTile({{in, multiplies}, {out}});
+  cgen.setInputsAndOutputs({in}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->addTestCase(uniformTCD<float>(
+      {{11, 12, 13, 21, 22, 23}},
+      {{11, 12, 13, 21, 22, 23, 11, 12, 13, 21, 22, 23, 11, 12, 13, 21, 22, 23,
+        11, 12, 13, 21, 22, 23, 11, 12, 13, 21, 22, 23, 11, 12, 13, 21, 22, 23}}));
+  _context->setBackends({"cpu"});
+
+  SUCCEED();
+}
+
+TEST_F(GenModelTest, OneOp_Tile_MulToVar)
+{
+  CircleGen cgen;
+  int multiplies = cgen.addTensor({{3}, circle::TensorType::TensorType_INT32});
+  int in = cgen.addTensor({{1, 2, 3}, circle::TensorType::TensorType_FLOAT32});
+  int out = cgen.addTensor({{2, 6, 3}, circle::TensorType::TensorType_FLOAT32});
+  cgen.addOperatorTile({{in, multiplies}, {out}});
+  cgen.setInputsAndOutputs({in, multiplies}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  TestCaseData tcd;
+  tcd.addInput(std::vector<float>{11, 12, 13, 21, 22, 23});
+  tcd.addInput(std::vector<int32_t>{2, 3, 1});
+  tcd.addOutput(std::vector<float>{11, 12, 13, 21, 22, 23, 11, 12, 13, 21, 22, 23,
+                                   11, 12, 13, 21, 22, 23, 11, 12, 13, 21, 22, 23,
+                                   11, 12, 13, 21, 22, 23, 11, 12, 13, 21, 22, 23});
+  _context->addTestCase(tcd);
+  _context->setBackends({"cpu"});
+
+  SUCCEED();
+}
+
+TEST_F(GenModelTest, OneOp_Tile_VarMul)
+{
+  CircleGen cgen;
+  int in = cgen.addTensor({{2, 3}, circle::TensorType::TensorType_FLOAT32});
   int mul = cgen.addTensor({{2}, circle::TensorType::TensorType_INT32});
-  int out = cgen.addTensor({{2, 6}, circle::TensorType::TensorType_INT32});
+  int out = cgen.addTensor({{2, 6}, circle::TensorType::TensorType_FLOAT32});
   cgen.addOperatorTile({{in, mul}, {out}});
   cgen.setInputsAndOutputs({in, mul}, {out});
 
@@ -66,6 +108,24 @@ TEST_F(GenModelTest, neg_OneOp_Tile)
   int mul = cgen.addTensor({{2, 2}, circle::TensorType::TensorType_INT32, mul_buf});
   int out = cgen.addTensor({{2, 6}, circle::TensorType::TensorType_FLOAT32});
   cgen.addOperatorTile({{in, mul}, {out}});
+  cgen.setInputsAndOutputs({in}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->setBackends({"cpu"});
+  _context->setCompileFail();
+
+  SUCCEED();
+}
+
+TEST_F(GenModelTest, neg_OneOp_Tile_InvalidMulSize)
+{
+  CircleGen cgen;
+  std::vector<int32_t> multiplies_data{2, 6};
+  uint32_t multiplies_buf = cgen.addBuffer(multiplies_data);
+  int multiplies = cgen.addTensor({{2}, circle::TensorType::TensorType_INT32, multiplies_buf});
+  int in = cgen.addTensor({{1, 2, 3}, circle::TensorType::TensorType_FLOAT32});
+  int out = cgen.addTensor({{2, 6, 3}, circle::TensorType::TensorType_FLOAT32});
+  cgen.addOperatorTile({{in, multiplies}, {out}});
   cgen.setInputsAndOutputs({in}, {out});
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());


### PR DESCRIPTION
For issue #4053

This commit makes loader supports Tile operation's axis as input.

Signed-off-by: ragmani <ragmani0216@gmail.com>