### PR TITLE
[nnfwapi] Test : support other tensor types

### DIFF
--- a/tests/nnfw_api/src/GenModelTest.h
+++ b/tests/nnfw_api/src/GenModelTest.h
@@ -23,22 +23,96 @@
 #include "CircleGen.h"
 #include "fixtures.h"
 
+inline size_t sizeOfNnfwType(NNFW_TYPE type)
+{
+  switch (type)
+  {
+    case NNFW_TYPE_TENSOR_BOOL:
+    case NNFW_TYPE_TENSOR_UINT8:
+    case NNFW_TYPE_TENSOR_QUANT8_ASYMM:
+      return 1;
+    case NNFW_TYPE_TENSOR_FLOAT32:
+    case NNFW_TYPE_TENSOR_INT32:
+      return 4;
+    case NNFW_TYPE_TENSOR_INT64:
+      return 8;
+    default:
+      throw std::runtime_error{"Invalid tensor type"};
+  }
+}
+
+// TODO Unify this with `SessionObject` in `fixtures.h`
+struct SessionObjectGeneric
+{
+  nnfw_session *session = nullptr;
+  std::vector<std::vector<uint8_t>> inputs;
+  std::vector<std::vector<uint8_t>> outputs;
+};
+
 struct TestCaseData
 {
   /**
    * @brief A vector of input buffers
-   *
-   * @todo support other types as well as float
    */
-  std::vector<std::vector<float>> inputs;
+  std::vector<std::vector<uint8_t>> inputs;
+
   /**
    * @brief A vector of output buffers
-   *
-   * @todo support other types as well as float
    */
-  std::vector<std::vector<float>> outputs;
+  std::vector<std::vector<uint8_t>> outputs;
+
+  /**
+   * @brief Append vector data to inputs
+   *
+   * @tparam T Data type
+   * @param data vector data array
+   */
+  template <typename T> void addInput(const std::vector<T> &data) { addData(inputs, data); }
+
+  /**
+   * @brief Append vector data to inputs
+   *
+   * @tparam T Data type
+   * @param data vector data array
+   */
+  template <typename T> void addOutput(const std::vector<T> &data) { addData(outputs, data); }
+
+private:
+  template <typename T>
+  static void addData(std::vector<std::vector<uint8_t>> &dest, const std::vector<T> &data)
+  {
+    size_t size = data.size() * sizeof(T);
+    dest.emplace_back();
+    dest.back().resize(size);
+    std::memcpy(dest.back().data(), data.data(), size);
+  }
 };
 
+/**
+ * @brief Create a TestCaseData with a uniform type
+ *
+ * A helper function for generating test cases that has the same data type for model inputs/outputs.
+ *
+ * @tparam T Uniform tensor type
+ * @param inputs Inputs tensor buffers
+ * @param outputs Output tensor buffers
+ * @return TestCaseData Generated test case data
+ */
+template <typename T>
+static TestCaseData uniformTCD(const std::vector<std::vector<T>> &inputs,
+                               const std::vector<std::vector<T>> &outputs)
+{
+  TestCaseData ret;
+  for (const auto &data : inputs)
+    ret.addInput(data);
+  for (const auto &data : outputs)
+    ret.addOutput(data);
+  return ret;
+}
+
+/**
+ * @brief A test configuration class
+ */
 class GenModelTestContext
 {
 public:
@@ -162,10 +236,9 @@ protected:
         nnfw_tensorinfo ti;
         NNFW_ENSURE_SUCCESS(nnfw_input_tensorinfo(_so.session, ind, &ti));
         uint64_t input_elements = num_elems(&ti);
-        _so.inputs[ind].resize(input_elements);
-
+        _so.inputs[ind].resize(input_elements * sizeOfNnfwType(ti.dtype));
         ASSERT_EQ(nnfw_set_input(_so.session, ind, ti.dtype, _so.inputs[ind].data(),
-                                 sizeof(float) * input_elements),
+                                 _so.inputs[ind].size()),
                   NNFW_STATUS_NO_ERROR);
       }
 
@@ -177,9 +250,9 @@ protected:
         nnfw_tensorinfo ti;
         NNFW_ENSURE_SUCCESS(nnfw_output_tensorinfo(_so.session, ind, &ti));
         uint64_t output_elements = num_elems(&ti);
-        _so.outputs[ind].resize(output_elements);
+        _so.outputs[ind].resize(output_elements * sizeOfNnfwType(ti.dtype));
         ASSERT_EQ(nnfw_set_output(_so.session, ind, ti.dtype, _so.outputs[ind].data(),
-                                  sizeof(float) * output_elements),
+                                  _so.outputs[ind].size()),
                   NNFW_STATUS_NO_ERROR);
       }
 
@@ -193,7 +266,7 @@ protected:
         {
           // Fill the values
           ASSERT_EQ(_so.inputs[i].size(), ref_inputs[i].size());
-          memcpy(_so.inputs[i].data(), ref_inputs[i].data(), _so.inputs[i].size() * sizeof(float));
+          memcpy(_so.inputs[i].data(), ref_inputs[i].data(), ref_inputs[i].size());
         }
 
         NNFW_ENSURE_SUCCESS(nnfw_run(_so.session));
@@ -201,12 +274,43 @@ protected:
         ASSERT_EQ(_so.outputs.size(), ref_outputs.size());
         for (uint32_t i = 0; i < _so.outputs.size(); i++)
         {
+          nnfw_tensorinfo ti;
+          NNFW_ENSURE_SUCCESS(nnfw_output_tensorinfo(_so.session, i, &ti));
+
           // Check output tensor values
           auto &ref_output = ref_outputs[i];
           auto &output = _so.outputs[i];
           ASSERT_EQ(output.size(), ref_output.size());
-          for (uint32_t e = 0; e < ref_output.size(); e++)
-            EXPECT_NEAR(ref_output[e], output[e], 0.001); // TODO better way for handling FP error?
+
+          switch (ti.dtype)
+          {
+            case NNFW_TYPE_TENSOR_BOOL:
+              // TODO Check if this comparison is correct
+              compareBuffersExact<bool>(ref_output, output);
+              break;
+            case NNFW_TYPE_TENSOR_UINT8:
+              compareBuffersExact<uint8_t>(ref_output, output);
+              break;
+            case NNFW_TYPE_TENSOR_INT32:
+              compareBuffersExact<int32_t>(ref_output, output);
+              break;
+            case NNFW_TYPE_TENSOR_FLOAT32:
+              // TODO better way for handling FP error?
+              for (uint32_t e = 0; e < ref_output.size() / sizeof(float); e++)
+              {
+                float refval = reinterpret_cast<const float *>(ref_output.data())[e];
+                float val = reinterpret_cast<const float *>(output.data())[e];
+                EXPECT_NEAR(refval, val, 0.001) << "e == " << e;
+              }
+              break;
+            case NNFW_TYPE_TENSOR_INT64:
+              compareBuffersExact<int64_t>(ref_output, output);
+              break;
+            case NNFW_TYPE_TENSOR_QUANT8_ASYMM:
+              throw std::runtime_error{"NYI : comparison of tensors of QUANT8_ASYMM"};
+            default:
+              throw std::runtime_error{"Invalid tensor type"};
+          }
         }
       }
 
@@ -214,7 +318,19 @@ protected:
     }
   }
 
+private:
+  template <typename T>
+  void compareBuffersExact(const std::vector<uint8_t> &ref_buf, const std::vector<uint8_t> &act_buf)
+  {
+    for (uint32_t e = 0; e < ref_buf.size() / sizeof(T); e++)
+    {
+      float ref = reinterpret_cast<const T *>(ref_buf.data())[e];
+      float act = reinterpret_cast<const T *>(act_buf.data())[e];
+      EXPECT_EQ(ref, act) << "index == " << e;
+    }
+  }
+
 protected:
-  SessionObject _so;
+  SessionObjectGeneric _so;
   std::unique_ptr<GenModelTestContext> _context;
 };

--- a/tests/nnfw_api/src/GenModelTest.h
+++ b/tests/nnfw_api/src/GenModelTest.h
@@ -237,6 +237,9 @@ protected:
         NNFW_ENSURE_SUCCESS(nnfw_input_tensorinfo(_so.session, ind, &ti));
         uint64_t input_elements = num_elems(&ti);
         _so.inputs[ind].resize(input_elements * sizeOfNnfwType(ti.dtype));
+        // TODO : Support optional inputs
+        ASSERT_GT(_so.inputs[ind].size(), 0)
+            << "Please make sure TC input is non-empty. Optional input is not supported yet.";
         ASSERT_EQ(nnfw_set_input(_so.session, ind, ti.dtype, _so.inputs[ind].data(),
                                  _so.inputs[ind].size()),
                   NNFW_STATUS_NO_ERROR);
@@ -251,6 +254,7 @@ protected:
         NNFW_ENSURE_SUCCESS(nnfw_output_tensorinfo(_so.session, ind, &ti));
         uint64_t output_elements = num_elems(&ti);
         _so.outputs[ind].resize(output_elements * sizeOfNnfwType(ti.dtype));
+        ASSERT_GT(_so.outputs[ind].size(), 0) << "Please make sure TC output is non-empty.";
         ASSERT_EQ(nnfw_set_output(_so.session, ind, ti.dtype, _so.outputs[ind].data(),
                                   _so.outputs[ind].size()),
                   NNFW_STATUS_NO_ERROR);

--- a/tests/nnfw_api/src/one_op_tests/Add.cc
+++ b/tests/nnfw_api/src/one_op_tests/Add.cc
@@ -30,8 +30,8 @@ TEST_F(GenModelTest, OneOp_Add_VarToConst)
   cgen.setInputsAndOutputs({lhs}, {out});
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
-  _context->addTestCase({{{1, 3, 2, 4}}, {{6, 7, 9, 8}}});
-  _context->addTestCase({{{0, 1, 2, 3}}, {{5, 5, 9, 7}}});
+  _context->addTestCase(uniformTCD<float>({{1, 3, 2, 4}}, {{6, 7, 9, 8}}));
+  _context->addTestCase(uniformTCD<float>({{0, 1, 2, 3}}, {{5, 5, 9, 7}}));
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
 
   SUCCEED();
@@ -47,7 +47,7 @@ TEST_F(GenModelTest, OneOp_Add_VarToVar)
   cgen.setInputsAndOutputs({lhs, rhs}, {out});
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
-  _context->addTestCase({{{1, 3, 2, 4}, {5, 4, 7, 4}}, {{6, 7, 9, 8}}});
+  _context->addTestCase(uniformTCD<float>({{1, 3, 2, 4}, {5, 4, 7, 4}}, {{6, 7, 9, 8}}));
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
 
   SUCCEED();

--- a/tests/nnfw_api/src/one_op_tests/AveragePool2D.cc
+++ b/tests/nnfw_api/src/one_op_tests/AveragePool2D.cc
@@ -26,7 +26,7 @@ TEST_F(GenModelTest, OneOp_AvgPool2D)
   cgen.setInputsAndOutputs({in}, {out});
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
-  _context->addTestCase({{{1, 3, 2, 4}}, {{2.5}}});
+  _context->addTestCase(uniformTCD<float>({{1, 3, 2, 4}}, {{2.5}}));
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
 
   SUCCEED();

--- a/tests/nnfw_api/src/one_op_tests/Cos.cc
+++ b/tests/nnfw_api/src/one_op_tests/Cos.cc
@@ -26,7 +26,7 @@ TEST_F(GenModelTest, OneOp_Cos)
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
   const float pi = 3.141592653589793;
-  _context->addTestCase({{{0, pi / 2, pi, 7}}, {{1, 0, -1, 0.75390225434}}});
+  _context->addTestCase(uniformTCD<float>({{0, pi / 2, pi, 7}}, {{1, 0, -1, 0.75390225434}}));
   _context->setBackends({"cpu"});
 
   SUCCEED();

--- a/tests/nnfw_api/src/one_op_tests/If.cc
+++ b/tests/nnfw_api/src/one_op_tests/If.cc
@@ -68,8 +68,8 @@ TEST_F(GenModelTest, OneOp_If)
   }
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
-  _context->addTestCase({{{-1.0}}, {{-100.0}}});
-  _context->addTestCase({{{1.0}}, {{100.0}}});
+  _context->addTestCase(uniformTCD<float>({{-1.0}}, {{-100.0}}));
+  _context->addTestCase(uniformTCD<float>({{1.0}}, {{100.0}}));
   _context->setBackends({"cpu"});
 
   SUCCEED();

--- a/tests/nnfw_api/src/one_op_tests/L2Normalization.cc
+++ b/tests/nnfw_api/src/one_op_tests/L2Normalization.cc
@@ -26,9 +26,10 @@ TEST_F(GenModelTest, OneOp_L2Normalization)
   cgen.setInputsAndOutputs({in}, {out});
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
-  _context->addTestCase({{{0, 3, 4, 0, 5, 12, 0, 8, 15, 0, 7, 24}},
-                         {{0, 0.6, 0.8, 0, 0.38461539149284363, 0.92307698726654053, 0,
-                           0.47058823704719543, 0.88235294818878174, 0, 0.28, 0.96}}});
+  _context->addTestCase(
+      uniformTCD<float>({{0, 3, 4, 0, 5, 12, 0, 8, 15, 0, 7, 24}},
+                        {{0, 0.6, 0.8, 0, 0.38461539149284363, 0.92307698726654053, 0,
+                          0.47058823704719543, 0.88235294818878174, 0, 0.28, 0.96}}));
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
 
   SUCCEED();

--- a/tests/nnfw_api/src/one_op_tests/LeakyRelu.cc
+++ b/tests/nnfw_api/src/one_op_tests/LeakyRelu.cc
@@ -25,7 +25,8 @@ TEST_F(GenModelTest, OneOp_LeakyRelu)
   cgen.setInputsAndOutputs({in}, {out});
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
-  _context->addTestCase({{{0, 1.0, 3.0, 1.0, -1.0, -2.0f}}, {{0, 1.0, 3.0, 1.0, -0.5, -1.0}}});
+  _context->addTestCase(
+      uniformTCD<float>({{0, 1.0, 3.0, 1.0, -1.0, -2.0f}}, {{0, 1.0, 3.0, 1.0, -0.5, -1.0}}));
   _context->setBackends({"acl_cl", "acl_neon"});
 
   SUCCEED();

--- a/tests/nnfw_api/src/one_op_tests/Pad.cc
+++ b/tests/nnfw_api/src/one_op_tests/Pad.cc
@@ -28,7 +28,8 @@ TEST_F(GenModelTest, OneOp_Pad)
   cgen.addOperatorPad({{in, padding}, {out}});
   cgen.setInputsAndOutputs({in}, {out});
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
-  _context->addTestCase({{{1, 2, 3, 4}}, {{0, 0, 0, 0, 0, 1, 2, 0, 0, 3, 4, 0, 0, 0, 0, 0}}});
+  _context->addTestCase(
+      uniformTCD<float>({{1, 2, 3, 4}}, {{0, 0, 0, 0, 0, 1, 2, 0, 0, 3, 4, 0, 0, 0, 0, 0}}));
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
 
   SUCCEED();

--- a/tests/nnfw_api/src/one_op_tests/PadV2.cc
+++ b/tests/nnfw_api/src/one_op_tests/PadV2.cc
@@ -34,7 +34,8 @@ TEST_F(GenModelTest, OneOp_PadV2)
   cgen.setInputsAndOutputs({in}, {out});
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
-  _context->addTestCase({{{1, 2, 3, 4}}, {{3, 3, 3, 3, 3, 1, 2, 3, 3, 3, 4, 3, 3, 3, 3, 3}}});
+  _context->addTestCase(
+      uniformTCD<float>({{1, 2, 3, 4}}, {{3, 3, 3, 3, 3, 1, 2, 3, 3, 3, 4, 3, 3, 3, 3, 3}}));
   _context->setBackends({"cpu"});
 
   SUCCEED();

--- a/tests/nnfw_api/src/one_op_tests/Rank.cc
+++ b/tests/nnfw_api/src/one_op_tests/Rank.cc
@@ -17,26 +17,19 @@
 #include "GenModelTest.h"
 
 // WORKAROUND Handle int32_t type input/output
-union float_int {
-  int32_t i;
-  float f;
-};
-
 TEST_F(GenModelTest, OneOp_Rank)
 {
   CircleGen cgen;
   int in = cgen.addTensor({{1, 3, 3, 2}, circle::TensorType::TensorType_FLOAT32});
   int out = cgen.addTensor({{1}, circle::TensorType::TensorType_INT32});
 
-  // TODO handle many type in addTestCase
-  float_int output_data;
-  output_data.i = 4;
-
   cgen.addOperatorRank({{in}, {out}});
   cgen.setInputsAndOutputs({in}, {out});
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
-  _context->addTestCase(
-      {{{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18}}, {{output_data.f}}});
+  TestCaseData tcd;
+  tcd.addInput(std::vector<float>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18});
+  tcd.addOutput(std::vector<int32_t>{4});
+  _context->addTestCase(tcd);
   _context->setBackends({"cpu"});
 
   SUCCEED();
@@ -49,14 +42,11 @@ TEST_F(GenModelTest, OneOp_Rank_Int32)
   int out = cgen.addTensor({{1}, circle::TensorType::TensorType_INT32});
 
   // TODO handle many type in addTestCase
-  float_int output_data;
-  output_data.i = 4;
-
   cgen.addOperatorRank({{in}, {out}});
   cgen.setInputsAndOutputs({in}, {out});
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
-  _context->addTestCase(
-      {{{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18}}, {{output_data.f}}});
+  _context->addTestCase(uniformTCD<int32_t>(
+      {{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18}}, {{4}}));
   _context->setBackends({"cpu"});
 
   SUCCEED();

--- a/tests/nnfw_api/src/one_op_tests/ResizeNearestNeighbor.cc
+++ b/tests/nnfw_api/src/one_op_tests/ResizeNearestNeighbor.cc
@@ -30,8 +30,9 @@ TEST_F(GenModelTest, OneOp_ResizeNearestNeighbor)
   cgen.setInputsAndOutputs({in}, {out});
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
-  _context->addTestCase({{{3, 4, 6, 10, 9, 10, 12, 16}},
-                         {{3, 4, 3, 4, 6, 10, 3, 4, 3, 4, 6, 10, 9, 10, 9, 10, 12, 16}}});
+  _context->addTestCase(
+      uniformTCD<float>({{3, 4, 6, 10, 9, 10, 12, 16}},
+                        {{3, 4, 3, 4, 6, 10, 3, 4, 3, 4, 6, 10, 9, 10, 9, 10, 12, 16}}));
   _context->setBackends({"acl_cl"});
 
   SUCCEED();

--- a/tests/nnfw_api/src/one_op_tests/While.cc
+++ b/tests/nnfw_api/src/one_op_tests/While.cc
@@ -66,9 +66,9 @@ TEST_F(GenModelTest, OneOp_While)
   }
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
-  _context->addTestCase({{{0}}, {{100}}});
-  _context->addTestCase({{{2}}, {{102}}});
-  _context->addTestCase({{{22}}, {{102}}});
+  _context->addTestCase(uniformTCD<float>({{0}}, {{100}}));
+  _context->addTestCase(uniformTCD<float>({{2}}, {{102}}));
+  _context->addTestCase(uniformTCD<float>({{22}}, {{102}}));
   _context->setBackends({"cpu"});
 
   SUCCEED();


### PR DESCRIPTION
Support more tensor types in GenModelTest.

- Introduce helper `uniformTCD` for generating test cases with all same
  data types of model inputs/outputs
- Now `TestCaseData` has buffers with `uint8_t` which indicates that
  those are byte buffers(it does not mean uint8)
- Fix the workarounds in Rank tests

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>