### PR TITLE
[onert/tool] Rootfs generator for ubuntu 20.04

### DIFF
--- a/docs/howto/how-to-cross-build-runtime-for-arm.md
+++ b/docs/howto/how-to-cross-build-runtime-for-arm.md
@@ -14,7 +14,7 @@ Use `install_rootfs.sh` script to prepare Root File System. You should have `sud
 $ sudo ./tools/cross/install_rootfs.sh arm
 ```
 - supports `arm`(default) and `aarch` architecutre for now
-- supports `xenial`(default) `trusty`, and `bionic` release
+- supports `xenial`(default) `trusty`, `bionic`, and `focal` release
 
 To see the options,
 ```
@@ -73,10 +73,10 @@ $ echo 'export PATH=~/your/path/gcc-linaro-7.2.1-2017.11-x86_64_arm-linux-gnueab
 ```
 
 - On Ubuntu 18.04 LTS, you can install using `apt-get`.
-Choose g++ version whatever you prefer: 6, 7 or 8.
+Choose g++ version whatever you prefer: 6, 7, 8 or 9.
 
 ```
-$ sudo apt-get install g++-{6,7,8}-arm-linux-gnueabihf
+$ sudo apt-get install g++-{6,7,8,9}-arm-linux-gnueabihf
 ```
 
 Make sure you get `libstdc++.so` updated on your target with your new toolchain's corresponding one.

--- a/tools/cross/aarch64/sources.list.focal
+++ b/tools/cross/aarch64/sources.list.focal
@@ -1,0 +1,11 @@
+deb http://ports.ubuntu.com/ubuntu-ports/ focal main restricted universe
+deb-src http://ports.ubuntu.com/ubuntu-ports/ focal main restricted universe
+
+deb http://ports.ubuntu.com/ubuntu-ports/ focal-updates main restricted universe
+deb-src http://ports.ubuntu.com/ubuntu-ports/ focal-updates main restricted universe
+
+deb http://ports.ubuntu.com/ubuntu-ports/ focal-backports main restricted
+deb-src http://ports.ubuntu.com/ubuntu-ports/ focal-backports main restricted
+
+deb http://ports.ubuntu.com/ubuntu-ports/ focal-security main restricted universe multiverse
+deb-src http://ports.ubuntu.com/ubuntu-ports/ focal-security main restricted universe multiverse

--- a/tools/cross/arm/sources.list.focal
+++ b/tools/cross/arm/sources.list.focal
@@ -1,0 +1,11 @@
+deb http://ports.ubuntu.com/ubuntu-ports/ focal main restricted universe
+deb-src http://ports.ubuntu.com/ubuntu-ports/ focal main restricted universe
+
+deb http://ports.ubuntu.com/ubuntu-ports/ focal-updates main restricted universe
+deb-src http://ports.ubuntu.com/ubuntu-ports/ focal-updates main restricted universe
+
+deb http://ports.ubuntu.com/ubuntu-ports/ focal-backports main restricted
+deb-src http://ports.ubuntu.com/ubuntu-ports/ focal-backports main restricted
+
+deb http://ports.ubuntu.com/ubuntu-ports/ focal-security main restricted universe multiverse
+deb-src http://ports.ubuntu.com/ubuntu-ports/ focal-security main restricted universe multiverse

--- a/tools/cross/install_rootfs.sh
+++ b/tools/cross/install_rootfs.sh
@@ -27,8 +27,9 @@ __Apt=""
 __UbuntuPackages="build-essential"
 
 # other development supports
-__UbuntuPackages+=" libboost-all-dev ocl-icd-opencl-dev"
+__UbuntuPackages+=" ocl-icd-opencl-dev"
 __UbuntuPackages+=" libhdf5-dev"
+__UbuntuBoostPackages=" llibboost-all-dev"
 
 # symlinks fixer
 __UbuntuPackages+=" symlinks"
@@ -77,6 +78,10 @@ for i in "$@" ; do
         bionic)
             __LinuxCodeName=bionic
             ;;
+        focal)
+            __LinuxCodeName=focal
+            __UbuntuBoostPackages=" libboost1.67-all-dev"
+            ;;
         --setproxy*)
             proxyip="${i#*=}"
             __Apt="Acquire::http::proxy \"http://$proxyip/\";\n"
@@ -92,6 +97,9 @@ for i in "$@" ; do
             ;;
     esac
 done
+
+# Current runtime build system supports boost version under 1.70
+__UbuntuPackages+="$__UbuntuBoostPackages"
 
 __RootfsDir="$__CrossDir/rootfs/$__BuildArch"
 


### PR DESCRIPTION
install_rootfs.sh supports ubuntu 20.04 host/target (ex. odroid-xu4)

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>