### PR TITLE
[onert] Fix Split operation input index

### DIFF
--- a/runtime/onert/core/include/ir/operation/Split.h
+++ b/runtime/onert/core/include/ir/operation/Split.h
@@ -29,8 +29,8 @@ class Split : public Operation
 public:
   enum Input
   {
-    INPUT = 0,
-    AXIS = 1
+    AXIS = 0,
+    INPUT = 1,
   };
 
   struct Param

--- a/runtime/onert/frontend/nnapi/wrapper/OperationFactory.cc
+++ b/runtime/onert/frontend/nnapi/wrapper/OperationFactory.cc
@@ -1538,7 +1538,7 @@ OperationFactory::OperationFactory()
     assert(init_param.input_count == 3);
     assert(init_param.output_count >= 1); // At least one output tensor and axis
 
-    OperandIndexSequence inputs{init_param.inputs[0], init_param.inputs[1]};
+    OperandIndexSequence inputs{init_param.inputs[1], init_param.inputs[0]};
     OperandIndexSequence outputs;
     for (uint32_t n = 0; n < init_param.output_count; ++n)
     {


### PR DESCRIPTION
Split operation's 1st operand is axis, and 2nd operand is input tensor

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: #4116 