### PR TITLE
Fix coverity1148326

### DIFF
--- a/compute/ARMComputeEx/src/runtime/CL/functions/CLReduceOperation.cpp
+++ b/compute/ARMComputeEx/src/runtime/CL/functions/CLReduceOperation.cpp
@@ -120,6 +120,8 @@ void CLReduceOperation::configure(ICLTensor *input, ICLTensor *output,
   const size_t num_of_kernels = axis.size();
   const size_t num_of_interm_tensors = num_of_kernels - (keep_dims ? 1 : 0);
 
+  ARM_COMPUTE_ERROR_ON(num_of_kernels < 1);
+
   _interm_tensors = support::cpp14::make_unique<CLTensor[]>(num_of_interm_tensors);
   _reduce_kernels = support::cpp14::make_unique<CLReduceOperationKernel[]>(num_of_kernels);
 


### PR DESCRIPTION
Fix coverity defect : Integer overflowed argument

```
6. overflow_sink: Overflowed or truncated value (or a value computed from an overflowed or truncated value) num_of_interm_tensors - 1U used as critical argument to function. [show details]
    _interm_tensors[num_of_interm_tensors - 1].allocator()->allocate();
```

ONE-DCO-1.0-Signed-off-by: Chunseok Lee <chunseok.lee@samsung.com>