### PR TITLE
[luci-interpreter] Add Maximum kernel

### DIFF
--- a/compiler/luci-interpreter/src/kernels/CMakeLists.txt
+++ b/compiler/luci-interpreter/src/kernels/CMakeLists.txt
@@ -50,6 +50,8 @@ set(SOURCES
     Logistic.cpp
     LogSoftmax.h
     LogSoftmax.cpp
+    Maximum.h
+    Maximum.cpp
     MaxPool2D.h
     MaxPool2D.cpp
     Mean.h
@@ -147,6 +149,7 @@ set(TEST_SOURCES
     LocalResponseNormalization.test.cpp
     Logistic.test.cpp
     LogSoftmax.test.cpp
+    Maximum.test.cpp
     MaxPool2D.test.cpp
     Mean.test.cpp
     Mul.test.cpp

--- a/compiler/luci-interpreter/src/kernels/Maximum.cpp
+++ b/compiler/luci-interpreter/src/kernels/Maximum.cpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "kernels/Maximum.h"
+
+#include "kernels/Utils.h"
+
+namespace luci_interpreter
+{
+namespace kernels
+{
+
+Maximum::Maximum(const Tensor *input1, const Tensor *input2, Tensor *output)
+    : Kernel({input1, input2}, {output})
+{
+}
+
+void Maximum::configure()
+{
+  LUCI_INTERPRETER_CHECK(input1()->element_type() == input2()->element_type())
+  LUCI_INTERPRETER_CHECK(input1()->element_type() == output()->element_type())
+  output()->resize(input1()->shape());
+}
+
+void Maximum::execute() const
+{
+  switch (input1()->element_type())
+  {
+    case DataType::FLOAT32:
+      evalFloat();
+      break;
+    case DataType::U8:
+      evalQuantized();
+      break;
+    default:
+      throw std::runtime_error("Unsupported type.");
+  }
+}
+
+void Maximum::evalFloat() const
+{
+  const int size = tflite::MatchingFlatSize(getTensorShape(input1()), getTensorShape(output()));
+  float *output_data = getTensorData<float>(output());
+  const float *input_data1 = getTensorData<float>(input1());
+  const float *input_data2 = getTensorData<float>(input2());
+  for (int i = 0; i < size; ++i)
+  {
+    output_data[i] = std::max(input_data1[i], input_data2[i]);
+  }
+}
+
+void Maximum::evalQuantized() const
+{
+  const int size = tflite::MatchingFlatSize(getTensorShape(input1()), getTensorShape(output()));
+  uint8_t *output_data = getTensorData<uint8_t>(output());
+  const uint8_t *input_data1 = getTensorData<uint8_t>(input1());
+  const uint8_t *input_data2 = getTensorData<uint8_t>(input2());
+  for (int i = 0; i < size; ++i)
+  {
+    output_data[i] = std::max(input_data1[i], input_data2[i]);
+  }
+}
+
+} // namespace kernels
+} // namespace luci_interpreter

--- a/compiler/luci-interpreter/src/kernels/Maximum.cpp
+++ b/compiler/luci-interpreter/src/kernels/Maximum.cpp
@@ -43,30 +43,22 @@ void Maximum::execute() const
   switch (input1()->element_type())
   {
     case DataType::FLOAT32:
-      evalFloat();
+      evalMaximum<float>();
       break;
     case DataType::U8:
-      evalQuantized();
+      evalMaximum<uint8_t>();
       break;
     default:
       throw std::runtime_error("Unsupported type.");
   }
 }
 
-void Maximum::evalFloat() const
+template <typename T> inline void Maximum::evalMaximum() const
 {
-  BinaryOpBroadcastSlow(getTensorShape(input1()), getTensorData<float>(input1()),
-                        getTensorShape(input2()), getTensorData<float>(input2()),
-                        getTensorShape(output()), getTensorData<float>(output()),
-                        [](float x, float y) { return std::max(x, y); });
-}
-
-void Maximum::evalQuantized() const
-{
-  BinaryOpBroadcastSlow(getTensorShape(input1()), getTensorData<uint8_t>(input1()),
-                        getTensorShape(input2()), getTensorData<uint8_t>(input2()),
-                        getTensorShape(output()), getTensorData<uint8_t>(output()),
-                        [](uint8_t x, uint8_t y) { return std::max(x, y); });
+  BinaryOpBroadcastSlow(getTensorShape(input1()), getTensorData<T>(input1()),
+                        getTensorShape(input2()), getTensorData<T>(input2()),
+                        getTensorShape(output()), getTensorData<T>(output()),
+                        [](T x, T y) { return std::max(x, y); });
 }
 
 } // namespace kernels

--- a/compiler/luci-interpreter/src/kernels/Maximum.h
+++ b/compiler/luci-interpreter/src/kernels/Maximum.h
@@ -38,8 +38,7 @@ public:
   void execute() const override;
 
 private:
-  void evalFloat() const;
-  void evalQuantized() const;
+  template <typename T> inline void evalMaximum() const;
 };
 
 } // namespace kernels

--- a/compiler/luci-interpreter/src/kernels/Maximum.h
+++ b/compiler/luci-interpreter/src/kernels/Maximum.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef LUCI_INTERPRETER_KERNELS_MAXIMUM_H
+#define LUCI_INTERPRETER_KERNELS_MAXIMUM_H
+
+#include "core/Kernel.h"
+#include "core/KernelParams.h"
+
+namespace luci_interpreter
+{
+namespace kernels
+{
+
+class Maximum : public Kernel
+{
+public:
+  Maximum(const Tensor *input1, const Tensor *input2, Tensor *output);
+
+  const Tensor *input1() const { return _inputs[0]; }
+  const Tensor *input2() const { return _inputs[1]; }
+  Tensor *output() const { return _outputs[0]; }
+
+  void configure() override;
+  void execute() const override;
+
+private:
+  void evalFloat() const;
+  void evalQuantized() const;
+};
+
+} // namespace kernels
+} // namespace luci_interpreter
+
+#endif // LUCI_INTERPRETER_KERNELS_MAXIMUM_H

--- a/compiler/luci-interpreter/src/kernels/Maximum.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/Maximum.test.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "kernels/Maximum.h"
+#include "kernels/TestUtils.h"
+
+namespace luci_interpreter
+{
+namespace kernels
+{
+namespace
+{
+
+using namespace testing;
+
+float GetTolerance(float min, float max)
+{
+  float kQuantizedStep = (max - min) / 255.0;
+  return kQuantizedStep;
+}
+
+TEST(MaximumTest, Float)
+{
+  Shape input_shape{3, 1, 2};
+  std::vector<float> input_data1{1.0, 0.0, -1.0, 11.0, -2.0, -1.44};
+  std::vector<float> input_data2{-1.0, 0.0, 1.0, 12.0, -3.0, -1.43};
+  Tensor input_tensor1 = makeInputTensor<DataType::FLOAT32>(input_shape, input_data1);
+  Tensor input_tensor2 = makeInputTensor<DataType::FLOAT32>(input_shape, input_data2);
+  Tensor output_tensor = makeOutputTensor(DataType::FLOAT32);
+
+  Maximum kernel(&input_tensor1, &input_tensor2, &output_tensor);
+  kernel.configure();
+  kernel.execute();
+
+  std::vector<float> ref_output_data{1.0, 0.0, 1.0, 12.0, -2.0, -1.43};
+  EXPECT_THAT(extractTensorData<float>(output_tensor),
+              ElementsAreArray(ArrayFloatNear(ref_output_data)));
+}
+
+TEST(MaximumTest, Uint8)
+{
+  Shape input_shape{3, 1, 2};
+  std::vector<uint8_t> input_data1{1, 0, 2, 11, 2, 23};
+  std::vector<uint8_t> input_data2{0, 0, 1, 12, 255, 1};
+  Tensor input_tensor1 = makeInputTensor<DataType::U8>(input_shape, input_data1);
+  Tensor input_tensor2 = makeInputTensor<DataType::U8>(input_shape, input_data2);
+  Tensor output_tensor = makeOutputTensor(DataType::U8);
+
+  Maximum kernel(&input_tensor1, &input_tensor2, &output_tensor);
+  kernel.configure();
+  kernel.execute();
+
+  std::vector<int32_t> ref_output_shape{2, 4};
+  EXPECT_THAT(extractTensorData<uint8_t>(output_tensor),
+              ::testing::ElementsAreArray({1, 0, 2, 12, 255, 23}));
+}
+
+} // namespace
+} // namespace kernels
+} // namespace luci_interpreter

--- a/compiler/luci-interpreter/src/kernels/Maximum.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/Maximum.test.cpp
@@ -27,8 +27,6 @@ namespace
 
 using namespace testing;
 
-float GetTolerance(float min, float max) { return (max - min) / 255.0; }
-
 TEST(MaximumTest, Float)
 {
   Shape input_shape{3, 1, 2};

--- a/compiler/luci-interpreter/src/kernels/Maximum.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/Maximum.test.cpp
@@ -27,11 +27,7 @@ namespace
 
 using namespace testing;
 
-float GetTolerance(float min, float max)
-{
-  float kQuantizedStep = (max - min) / 255.0;
-  return kQuantizedStep;
-}
+float GetTolerance(float min, float max) { return (max - min) / 255.0; }
 
 TEST(MaximumTest, Float)
 {
@@ -47,8 +43,7 @@ TEST(MaximumTest, Float)
   kernel.execute();
 
   std::vector<float> ref_output_data{1.0, 0.0, 1.0, 12.0, -2.0, -1.43};
-  EXPECT_THAT(extractTensorData<float>(output_tensor),
-              ElementsAreArray(ArrayFloatNear(ref_output_data)));
+  EXPECT_THAT(extractTensorData<float>(output_tensor), FloatArrayNear(ref_output_data));
 }
 
 TEST(MaximumTest, Uint8)

--- a/compiler/luci-interpreter/src/loader/KernelBuilder.cpp
+++ b/compiler/luci-interpreter/src/loader/KernelBuilder.cpp
@@ -40,6 +40,7 @@
 #include "kernels/LocalResponseNormalization.h"
 #include "kernels/Logistic.h"
 #include "kernels/LogSoftmax.h"
+#include "kernels/Maximum.h"
 #include "kernels/MaxPool2D.h"
 #include "kernels/Mean.h"
 #include "kernels/Mul.h"
@@ -462,6 +463,17 @@ std::unique_ptr<Kernel> KernelBuilder::visit(const luci::CircleLogSoftmax *node)
   Tensor *output = getOutputTensor(node);
 
   return std::make_unique<kernels::LogSoftmax>(input, output);
+}
+
+std::unique_ptr<Kernel> KernelBuilder::visit(const luci::CircleMaximum *node)
+{
+  assert(node->arity() == 2);
+
+  const Tensor *input1 = getInputTensor(node->x());
+  const Tensor *input2 = getInputTensor(node->y());
+  Tensor *output = getOutputTensor(node);
+
+  return std::make_unique<kernels::Maximum>(input1, input2, output);
 }
 
 std::unique_ptr<Kernel> KernelBuilder::visit(const luci::CircleMaxPool2D *node)

--- a/compiler/luci-interpreter/src/loader/KernelBuilder.h
+++ b/compiler/luci-interpreter/src/loader/KernelBuilder.h
@@ -65,6 +65,7 @@ public:
   std::unique_ptr<Kernel> visit(const luci::CircleLogistic *node) override;
   std::unique_ptr<Kernel> visit(const luci::CircleLogSoftmax *node) override;
   std::unique_ptr<Kernel> visit(const luci::CircleInput *node) override;
+  std::unique_ptr<Kernel> visit(const luci::CircleMaximum *node) override;
   std::unique_ptr<Kernel> visit(const luci::CircleMaxPool2D *node) override;
   std::unique_ptr<Kernel> visit(const luci::CircleMean *node) override;
   std::unique_ptr<Kernel> visit(const luci::CircleMul *node) override;

--- a/compiler/luci-interpreter/src/loader/KernelBuilder.test.cpp
+++ b/compiler/luci-interpreter/src/loader/KernelBuilder.test.cpp
@@ -40,6 +40,7 @@
 #include <kernels/LocalResponseNormalization.h>
 #include <kernels/Logistic.h>
 #include <kernels/LogSoftmax.h>
+#include <kernels/Maximum.h>
 #include <kernels/MaxPool2D.h>
 #include <kernels/Mean.h>
 #include <kernels/Mul.h>
@@ -578,6 +579,23 @@ TEST_F(KernelBuilderTest, LogSoftmax)
   ASSERT_THAT(kernel, NotNull());
 
   checkTensor(kernel->input(), input);
+  checkTensor(kernel->output(), op);
+}
+
+TEST_F(KernelBuilderTest, Maximum)
+{
+  auto *input1 = createInputNode();
+  auto *input2 = createInputNode();
+
+  auto *op = createNode<luci::CircleMaximum>();
+  op->x(input1);
+  op->y(input2);
+
+  auto kernel = buildKernel<kernels::Maximum>(op);
+  ASSERT_THAT(kernel, NotNull());
+
+  checkTensor(kernel->input1(), input1);
+  checkTensor(kernel->input2(), input2);
   checkTensor(kernel->output(), op);
 }
 


### PR DESCRIPTION
Parent Issue: #3458
Fired Issue: #4135 

This commit adds `Maximum` kernel.

This commit have been tested on my PC,
and worked well by passing `./nncc build` & `./nncc test`.

<pre><code>
void Maximum(const RuntimeShape& input1_shape, const T* input1_data,
             const T* input2_data, const RuntimeShape& output_shape,
             T* output_data)</code></pre>
`reference_op` above didn't work well giving the error below:
<details><summary><b>Error when using reference_op</b></summary>
<pre><code>
ONE/compiler/luci-interpreter/src/kernels/Maximum.test.cpp:51: Failure
Value of: extractTensorData<float>(output_tensor)
Expected: has 6 elements where
element #0 is approximately 1 (absolute error <= 9.9999997e-06),
element #1 is approximately 0 (absolute error <= 9.9999997e-06),
element #2 is approximately 1 (absolute error <= 9.9999997e-06),
element #3 is approximately 12 (absolute error <= 9.9999997e-06),
element #4 is approximately -2 (absolute error <= 9.9999997e-06),
element #5 is approximately -1.4299999 (absolute error <= 9.9999997e-06)
  Actual: { 1, 0, -1, 11, -1, -1 }, whose element #2 doesn't match, which is -2 from 1
</code></pre></details>

So I decided to use `std::max()` function to write this code.

Please review this PR, @seanshpark @jinevening @s-barannikov  .
I'll be happy to get feedback and change to make improvement.

Thank you.

(Derived from SOS Mine Project)

Signed-off-by: underflow101 <ikarus125@gmail.com>