### PR TITLE
[luci-interpreter]Negative Tests for Elu kernel

### DIFF
--- a/compiler/luci-interpreter/src/kernels/Elu.cpp
+++ b/compiler/luci-interpreter/src/kernels/Elu.cpp
@@ -31,7 +31,7 @@ Elu::Elu(const Tensor *input, Tensor *output) : Kernel({input}, {output}) {}
 
 void Elu::configure()
 {
-  assert(input()->element_type() == output()->element_type());
+  LUCI_INTERPRETER_CHECK(input()->element_type() == output()->element_type());
   output()->resize(input()->shape());
 }
 

--- a/compiler/luci-interpreter/src/kernels/Elu.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/Elu.test.cpp
@@ -73,21 +73,6 @@ TEST(EluTest, InOutTypeMismatch_NEG)
   EXPECT_ANY_THROW(kernel.configure());
 }
 
-TEST(EluTest, InvalidType_NEG)
-{
-  Shape input_shape{1, 2, 4, 1};
-  std::vector<uint8_t> input_data{
-      0, 6, 2,  4, //
-      3, 2, 10, 1, //
-  };
-  Tensor input_tensor = makeInputTensor<DataType::U8>(input_shape, input_data);
-  Tensor output_tensor = makeOutputTensor(DataType::U8);
-
-  Elu kernel(&input_tensor, &output_tensor);
-  kernel.configure();
-  EXPECT_ANY_THROW(kernel.execute());
-}
-
 } // namespace
 } // namespace kernels
 } // namespace luci_interpreter

--- a/compiler/luci-interpreter/src/kernels/Elu.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/Elu.test.cpp
@@ -59,6 +59,35 @@ TEST(EluTest, SimpleElu)
       });
 }
 
+TEST(EluTest, InOutTypeMismatch_NEG)
+{
+  Shape input_shape{1, 2, 4, 1};
+  std::vector<float> input_data{
+      0, -6, 2,  -4,   //
+      3, -2, 10, -0.1, //
+  };
+  Tensor input_tensor = makeInputTensor<DataType::FLOAT32>(input_shape, input_data);
+  Tensor output_tensor = makeOutputTensor(DataType::U8);
+
+  Elu kernel(&input_tensor, &output_tensor);
+  EXPECT_ANY_THROW(kernel.configure());
+}
+
+TEST(EluTest, InvalidType_NEG)
+{
+  Shape input_shape{1, 2, 4, 1};
+  std::vector<uint8_t> input_data{
+      0, 6, 2,  4, //
+      3, 2, 10, 1, //
+  };
+  Tensor input_tensor = makeInputTensor<DataType::U8>(input_shape, input_data);
+  Tensor output_tensor = makeOutputTensor(DataType::U8);
+
+  Elu kernel(&input_tensor, &output_tensor);
+  kernel.configure();
+  EXPECT_ANY_THROW(kernel.execute());
+}
+
 } // namespace
 } // namespace kernels
 } // namespace luci_interpreter


### PR DESCRIPTION
For #1623 

This commit add negative tests on `Elu` kernel on luci-interpreter.

ONE-DCO-1.0-Signed-off-by: KiDeuk Bang <rrstrous@nate.com>