### PR TITLE
[onert] remove w0_size param from fullyconnected sparse weight kernel

### DIFF
--- a/compute/cker/include/cker/operation/FullyConnected.h
+++ b/compute/cker/include/cker/operation/FullyConnected.h
@@ -208,12 +208,13 @@ inline void FullyConnectedHybrid(const FullyConnectedParams &params, const Shape
   return;
 }
 
-inline void FullyConnectedSparseWeight(const FullyConnectedParams &params, const Shape &input_shape,
-                                       const float *input_data, const Shape &weights_shape,
-                                       const float *weights_data, const Shape &bias_shape,
-                                       const float *bias_data, const Shape &output_shape,
-                                       float *output_data, int w0_size, const uint16_t *w1_segments,
-                                       const uint16_t *w1_indices)
+inline void FullyConnectedSparseWeightRandom(const FullyConnectedParams &params,
+                                             const Shape &input_shape, const float *input_data,
+                                             const Shape &weights_shape, const float *weights_data,
+                                             const Shape &bias_shape, const float *bias_data,
+                                             const Shape &output_shape, float *output_data,
+                                             const uint16_t *w1_segments,
+                                             const uint16_t *w1_indices)
 {
   UNUSED_RELEASE(params);
   UNUSED_RELEASE(input_shape);
@@ -239,7 +240,7 @@ inline void FullyConnectedSparseWeight(const FullyConnectedParams &params, const
   }
   for (int b = 0; b < batches; ++b)
   {
-    for (int idx_0 = 0; idx_0 < w0_size; ++idx_0)
+    for (int idx_0 = 0; idx_0 < output_depth; ++idx_0)
     {
       for (int pw1 = w1_segments[idx_0]; pw1 < w1_segments[idx_0 + 1]; ++pw1)
       {

--- a/runtime/onert/backend/cpu/ops/FullyConnectedLayer.cc
+++ b/runtime/onert/backend/cpu/ops/FullyConnectedLayer.cc
@@ -158,15 +158,14 @@ void FullyConnectedLayer::fullyConnectedSparseWeight()
   op_params.float_activation_max = output_activation_max;
   op_params.activation = convertActivationType(_activation);
 
-  int w0_size = getTensorShape(_weights).Dims(0);
   const uint16_t *w1_segments = _weights->sparsity()->w1_segments();
   const uint16_t *w1_indices = _weights->sparsity()->w1_indices();
 
-  nnfw::cker::FullyConnectedSparseWeight(
+  nnfw::cker::FullyConnectedSparseWeightRandom(
       op_params, getTensorShape(_input), reinterpret_cast<const float *>(_input->buffer()),
       getTensorShape(_weights), reinterpret_cast<const float *>(_weights->buffer()),
       getTensorShape(_bias), reinterpret_cast<const float *>(_bias ? _bias->buffer() : nullptr),
-      getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()), w0_size, w1_segments,
+      getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()), w1_segments,
       w1_indices);
 }
 


### PR DESCRIPTION
It removes w0_size since it is same to weight.shape[0] (=output_depth).

Also, it renamed FullyConnectedSparseWeight to FullyConnectedSparseWeightRandom
to distinguish it with other FullyConnectedSparseWeight kernels. (For instance,
FullyConnectedSparseWeight16x1 will be introduced soon.)

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>