### PR TITLE
[onert] Add destructor to cpu_common::Tensor

### DIFF
--- a/runtime/onert/core/include/backend/cpu_common/Tensor.h
+++ b/runtime/onert/core/include/backend/cpu_common/Tensor.h
@@ -33,6 +33,7 @@ class Tensor : public IPortableTensor
 {
 public:
   Tensor() = delete;
+  virtual ~Tensor();
 
 public:
   Tensor(const ir::OperandInfo &info, const ir::Layout layout,

--- a/runtime/onert/core/src/backend/cpu_common/Tensor.cc
+++ b/runtime/onert/core/src/backend/cpu_common/Tensor.cc
@@ -23,6 +23,8 @@ namespace backend
 namespace cpu_common
 {
 
+Tensor::~Tensor() = default;
+
 size_t Tensor::calcOffset(const ir::Coordinates &coords) const
 {
   size_t rank = num_dimensions();


### PR DESCRIPTION
As it is used as a base class, having a virtual destructor makes it
safer.

It also resolves the issue on Android, as it creates a key function by
defining it as non-inline.

Related : #4157

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>