### PR TITLE
[luci-interpreter] Add quantized version of makeInputTensor

### DIFF
--- a/compiler/luci-interpreter/src/kernels/Add.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/Add.test.cpp
@@ -57,18 +57,10 @@ TEST(AddTest, Uint8)
   std::pair<float, int32_t> quant_param = quantizationParams<uint8_t>(-3.f, 3.f);
   for (int i = 0; i < output_data.size(); i++)
   {
-    Tensor input1_tensor{
-        getElementType<uint8_t>(), base_shape, {{quant_param.first}, {quant_param.second}}, ""};
-    Tensor input2_tensor{
-        getElementType<uint8_t>(), test_shapes[i], {{quant_param.first}, {quant_param.second}}, ""};
-    std::vector<uint8_t> quantized_input1_value =
-        quantize<uint8_t>(base_data, quant_param.first, quant_param.second);
-    std::vector<uint8_t> quantized_input2_value =
-        quantize<uint8_t>(test_data, quant_param.first, quant_param.second);
-    input1_tensor.writeData(quantized_input1_value.data(),
-                            quantized_input1_value.size() * sizeof(uint8_t));
-    input2_tensor.writeData(quantized_input2_value.data(),
-                            quantized_input2_value.size() * sizeof(uint8_t));
+    Tensor input1_tensor =
+        makeInputTensor<DataType::U8>(base_shape, quant_param.first, quant_param.second, base_data);
+    Tensor input2_tensor = makeInputTensor<DataType::U8>(test_shapes[i], quant_param.first,
+                                                         quant_param.second, test_data);
     Tensor output_tensor =
         makeOutputTensor(getElementType<uint8_t>(), quant_param.first, quant_param.second);
 
@@ -87,18 +79,10 @@ TEST(AddTest, Uint8)
   // Re-run with exchanged inputs.
   for (int i = 0; i < output_data.size(); i++)
   {
-    Tensor input1_tensor{
-        getElementType<uint8_t>(), test_shapes[i], {{quant_param.first}, {quant_param.second}}, ""};
-    Tensor input2_tensor{
-        getElementType<uint8_t>(), base_shape, {{quant_param.first}, {quant_param.second}}, ""};
-    std::vector<uint8_t> quantized_input1_value =
-        quantize<uint8_t>(test_data, quant_param.first, quant_param.second);
-    std::vector<uint8_t> quantized_input2_value =
-        quantize<uint8_t>(base_data, quant_param.first, quant_param.second);
-    input1_tensor.writeData(quantized_input1_value.data(),
-                            quantized_input1_value.size() * sizeof(uint8_t));
-    input2_tensor.writeData(quantized_input2_value.data(),
-                            quantized_input2_value.size() * sizeof(uint8_t));
+    Tensor input1_tensor = makeInputTensor<DataType::U8>(test_shapes[i], quant_param.first,
+                                                         quant_param.second, test_data);
+    Tensor input2_tensor =
+        makeInputTensor<DataType::U8>(base_shape, quant_param.first, quant_param.second, base_data);
     Tensor output_tensor =
         makeOutputTensor(getElementType<uint8_t>(), quant_param.first, quant_param.second);
 

--- a/compiler/luci-interpreter/src/kernels/ArgMax.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/ArgMax.test.cpp
@@ -32,12 +32,9 @@ void Check(std::initializer_list<int32_t> input_shape,
            std::initializer_list<int32_t> output_shape, std::initializer_list<T1> input_data,
            std::initializer_list<int32_t> dimension_data, std::initializer_list<T2> output_data)
 {
-
-  Tensor input_tensor{getElementType<T1>(), input_shape, {}, ""};
-  input_tensor.writeData(input_data.begin(), input_data.size() * sizeof(T1));
-  Tensor dimension_tensor{DataType::S32, dimension_shape, {}, ""};
-  dimension_tensor.writeData(dimension_data.begin(), dimension_data.size() * sizeof(int32_t));
-
+  constexpr DataType element_type = getElementType<T1>();
+  Tensor input_tensor = makeInputTensor<element_type>(input_shape, input_data);
+  Tensor dimension_tensor = makeInputTensor<DataType::S32>(dimension_shape, dimension_data);
   Tensor output_tensor = makeOutputTensor(getElementType<T2>());
 
   ArgMaxParams params{};

--- a/compiler/luci-interpreter/src/kernels/AveragePool2D.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/AveragePool2D.test.cpp
@@ -60,17 +60,14 @@ TEST(AveragePool2DTest, Float)
 
 TEST(AveragePool2DTest, Uint8_0)
 {
+  std::vector<float> input_data{
+      0,  -6, 12, 4, //
+      -3, -2, 10, 7, //
+  };
   std::pair<float, int32_t> quant_param = quantizationParams<uint8_t>(-15.9375f, 15.9375f);
-  Tensor input_tensor{DataType::U8, {1, 2, 4, 1}, {{quant_param.first}, {quant_param.second}}, ""};
+  Tensor input_tensor = makeInputTensor<DataType::U8>({1, 2, 4, 1}, quant_param.first,
+                                                      quant_param.second, input_data);
   Tensor output_tensor = makeOutputTensor(DataType::U8, quant_param.first, quant_param.second);
-
-  std::vector<uint8_t> quant_input = quantize<uint8_t>(
-      {
-          0, -6, 12, 4,  //
-          -3, -2, 10, 7, //
-      },
-      quant_param.first, quant_param.second);
-  input_tensor.writeData(quant_input.data(), quant_input.size() * sizeof(uint8_t));
 
   Pool2DParams params{};
   params.padding = Padding::VALID;
@@ -92,17 +89,15 @@ TEST(AveragePool2DTest, Uint8_0)
 
 TEST(AveragePool2DTest, Uint8_1)
 {
-  std::pair<float, int32_t> quant_param = quantizationParams<uint8_t>(-15.9375f, 15.9375f);
-  Tensor input_tensor{DataType::U8, {1, 2, 4, 1}, {{quant_param.first}, {quant_param.second}}, ""};
-  Tensor output_tensor = makeOutputTensor(DataType::U8, quant_param.first, quant_param.second);
+  std::vector<float> input_data{
+      0, 6, 12, 4, //
+      3, 2, 10, 7, //
+  };
 
-  std::vector<uint8_t> quant_input = quantize<uint8_t>(
-      {
-          0, 6, 12, 4, //
-          3, 2, 10, 7, //
-      },
-      quant_param.first, quant_param.second);
-  input_tensor.writeData(quant_input.data(), quant_input.size() * sizeof(uint8_t));
+  std::pair<float, int32_t> quant_param = quantizationParams<uint8_t>(-15.9375f, 15.9375f);
+  Tensor input_tensor = makeInputTensor<DataType::U8>({1, 2, 4, 1}, quant_param.first,
+                                                      quant_param.second, input_data);
+  Tensor output_tensor = makeOutputTensor(DataType::U8, quant_param.first, quant_param.second);
 
   Pool2DParams params{};
   params.padding = Padding::VALID;
@@ -170,19 +165,16 @@ TEST(AveragePool2DTest, In_Out_Type_NEG)
 
 TEST(AveragePool2DTest, Quant_Param_NEG)
 {
+  std::vector<float> input_data{
+      0,  -6, 12, 4, //
+      -3, -2, 10, 7, //
+  };
+
   std::pair<float, int32_t> quant_param1 = quantizationParams<uint8_t>(-15.9375f, 15.9375f);
   std::pair<float, int32_t> quant_param2 = quantizationParams<uint8_t>(-7.875f, 7.875f);
-  Tensor input_tensor{
-      DataType::U8, {1, 2, 4, 1}, {{quant_param1.first}, {quant_param1.second}}, ""};
+  Tensor input_tensor = makeInputTensor<DataType::U8>({1, 2, 4, 1}, quant_param1.first,
+                                                      quant_param1.second, input_data);
   Tensor output_tensor = makeOutputTensor(DataType::U8, quant_param2.first, quant_param2.second);
-
-  std::vector<uint8_t> quant_input = quantize<uint8_t>(
-      {
-          0, -6, 12, 4,  //
-          -3, -2, 10, 7, //
-      },
-      quant_param1.first, quant_param1.second);
-  input_tensor.writeData(quant_input.data(), quant_input.size() * sizeof(uint8_t));
 
   Pool2DParams params{};
   params.padding = Padding::VALID;

--- a/compiler/luci-interpreter/src/kernels/DepthwiseConv2D.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/DepthwiseConv2D.test.cpp
@@ -73,39 +73,30 @@ TEST(DepthwiseConv2DTest, Float)
 
 TEST(DepthwiseConv2DTest, Uint8)
 {
+  std::vector<float> input_data{
+      1, 2, 7,  8,  // column 1
+      3, 4, 9,  10, // column 2
+      5, 6, 11, 12, // column 3
+  };
+  std::vector<float> filter_data{
+      1,  2,   3,   4,   //
+      -9, 10,  -11, 12,  //
+      5,  6,   7,   8,   //
+      13, -14, 15,  -16, //
+  };
+  std::vector<float> bias_data{1, 2, 3, 4};
+
   std::pair<float, int32_t> input_quant_param = quantizationParams<uint8_t>(-63.5, 64);
   std::pair<float, int32_t> output_quant_param = quantizationParams<uint8_t>(-127, 128);
 
-  Tensor input_tensor{
-      DataType::U8, {1, 3, 2, 2}, {{input_quant_param.first}, {input_quant_param.second}}, ""};
-  Tensor filter_tensor{
-      DataType::U8, {1, 2, 2, 4}, {{input_quant_param.first}, {input_quant_param.second}}, ""};
-  Tensor bias_tensor{
-      DataType::S32, {4}, {{input_quant_param.first * input_quant_param.first}, {0}}, ""};
+  Tensor input_tensor = makeInputTensor<DataType::U8>({1, 3, 2, 2}, input_quant_param.first,
+                                                      input_quant_param.second, input_data);
+  Tensor filter_tensor = makeInputTensor<DataType::U8>({1, 2, 2, 4}, input_quant_param.first,
+                                                       input_quant_param.second, filter_data);
+  Tensor bias_tensor = makeInputTensor<DataType::S32>(
+      {4}, input_quant_param.first * input_quant_param.first, 0, bias_data);
   Tensor output_tensor =
       makeOutputTensor(DataType::U8, output_quant_param.first, output_quant_param.second);
-
-  std::vector<uint8_t> quant_input = quantize<uint8_t>(
-      {
-          1, 2, 7, 8,   // column 1
-          3, 4, 9, 10,  // column 2
-          5, 6, 11, 12, // column 3
-      },
-      input_quant_param.first, input_quant_param.second);
-  std::vector<uint8_t> quant_filter = quantize<uint8_t>(
-      {
-          1, 2, 3, 4,       //
-          -9, 10, -11, 12,  //
-          5, 6, 7, 8,       //
-          13, -14, 15, -16, //
-      },
-      input_quant_param.first, input_quant_param.second);
-  std::vector<int32_t> quant_bias =
-      quantize<int32_t>({1, 2, 3, 4}, input_quant_param.first * input_quant_param.first, 0);
-
-  input_tensor.writeData(quant_input.data(), quant_input.size() * sizeof(uint8_t));
-  filter_tensor.writeData(quant_filter.data(), quant_filter.size() * sizeof(uint8_t));
-  bias_tensor.writeData(quant_bias.data(), quant_bias.size() * sizeof(int32_t));
 
   DepthwiseConv2DParams params{};
   params.padding = Padding::VALID;

--- a/compiler/luci-interpreter/src/kernels/Elu.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/Elu.test.cpp
@@ -29,9 +29,7 @@ using namespace testing;
 void Check(std::initializer_list<int32_t> input_shape, std::initializer_list<int32_t> output_shape,
            std::initializer_list<float> input_data, std::initializer_list<float> output_data)
 {
-  Tensor input_tensor{DataType::FLOAT32, input_shape, {}, ""};
-  input_tensor.writeData(input_data.begin(), input_data.size() * sizeof(float));
-
+  Tensor input_tensor = makeInputTensor<DataType::FLOAT32>(input_shape, input_data);
   Tensor output_tensor = makeOutputTensor(DataType::FLOAT32);
 
   Elu kernel(&input_tensor, &output_tensor);

--- a/compiler/luci-interpreter/src/kernels/LeakyRelu.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/LeakyRelu.test.cpp
@@ -28,12 +28,10 @@ using namespace testing;
 
 template <typename T>
 void Check(std::initializer_list<int32_t> input_shape, std::initializer_list<int32_t> output_shape,
-           std::initializer_list<T> input_data, std::initializer_list<T> output_data, float alpha,
-           DataType element_type)
+           std::initializer_list<T> input_data, std::initializer_list<T> output_data, float alpha)
 {
-  Tensor input_tensor{element_type, input_shape, {}, ""};
-  input_tensor.writeData(input_data.begin(), input_data.size() * sizeof(T));
-
+  constexpr DataType element_type = getElementType<T>();
+  Tensor input_tensor = makeInputTensor<element_type>(input_shape, input_data);
   Tensor output_tensor = makeOutputTensor(element_type);
 
   LeakyReluParams params{};
@@ -50,7 +48,8 @@ void Check(std::initializer_list<int32_t> input_shape, std::initializer_list<int
 
 TEST(LeakReluTest, FloatSimple)
 {
-  Check<float>(/*input_shape=*/{2, 3}, /*output_shape=*/{2, 3}, /*input_data=*/
+  Check<float>(/*input_shape=*/{2, 3}, /*output_shape=*/{2, 3},
+               /*input_data=*/
                {
                    0.0f, 1.0f, 3.0f,   // Row 1
                    1.0f, -1.0f, -2.0f, // Row 2
@@ -60,7 +59,7 @@ TEST(LeakReluTest, FloatSimple)
                    0.0f, 1.0f, 3.0f,   // Row 1
                    1.0f, -0.5f, -1.0f, // Row 2
                },
-               /*alpha=*/0.5f, getElementType<float>());
+               /*alpha=*/0.5f);
 
   SUCCEED();
 }

--- a/compiler/luci-interpreter/src/kernels/LogSoftmax.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/LogSoftmax.test.cpp
@@ -59,11 +59,9 @@ TEST(LogSoftmaxTest, Uint8)
       0, -6, 2,  4, //
       3, -2, 10, 1, //
   };
-  Tensor input_tensor{DataType::U8, {2, 4}, {{quant_param.first}, {quant_param.second}}, ""};
+  Tensor input_tensor =
+      makeInputTensor<DataType::U8>({2, 4}, quant_param.first, quant_param.second, input_data);
   Tensor output_tensor = makeOutputTensor(DataType::U8, 16. / 256, 255);
-  std::vector<uint8_t> quantize_input =
-      quantize<uint8_t>(input_data, quant_param.first, quant_param.second);
-  input_tensor.writeData(quantize_input.data(), quantize_input.size() * sizeof(uint8_t));
 
   LogSoftmax kernel(&input_tensor, &output_tensor);
   kernel.configure();

--- a/compiler/luci-interpreter/src/kernels/MaxPool2D.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/MaxPool2D.test.cpp
@@ -66,11 +66,9 @@ TEST(MaxPool2DTest, Uint8)
       0,  -6, 12, 4, //
       -3, -2, 10, 7, //
   };
-  Tensor input_tensor{DataType::U8, {1, 2, 4, 1}, {{quant_param.first}, {quant_param.second}}, ""};
+  Tensor input_tensor = makeInputTensor<DataType::U8>({1, 2, 4, 1}, quant_param.first,
+                                                      quant_param.second, input_data);
   Tensor output_tensor = makeOutputTensor(DataType::U8, quant_param.first, quant_param.second);
-  std::vector<uint8_t> quantize_input =
-      quantize<uint8_t>(input_data, quant_param.first, quant_param.second);
-  input_tensor.writeData(quantize_input.data(), quantize_input.size() * sizeof(uint8_t));
 
   Pool2DParams params{};
   params.padding = Padding::VALID;

--- a/compiler/luci-interpreter/src/kernels/Mean.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/Mean.test.cpp
@@ -109,12 +109,10 @@ TEST(MeanTest, Uint8KeepDims)
   std::pair<float, int32_t> quant_param = quantizationParams<uint8_t>(-1.0f, 1.0f);
 
   std::vector<int32_t> axis_data{1};
-  Tensor input_tensor{DataType::U8, {3, 2}, {{quant_param.first}, {quant_param.second}}, ""};
+  Tensor input_tensor =
+      makeInputTensor<DataType::U8>({3, 2}, quant_param.first, quant_param.second, input_data);
   Tensor axis_tensor = makeInputTensor<DataType::S32>({1}, axis_data);
   Tensor output_tensor = makeOutputTensor(DataType::U8, quant_param.first, quant_param.second);
-  std::vector<uint8_t> quantize_input =
-      quantize<uint8_t>(input_data, quant_param.first, quant_param.second);
-  input_tensor.writeData(quantize_input.data(), quantize_input.size() * sizeof(uint8_t));
 
   ReducerParams params{};
   params.keep_dims = true;
@@ -138,12 +136,10 @@ TEST(MeanTest, Uint8NotKeepDims)
   std::pair<float, int32_t> quant_param = quantizationParams<uint8_t>(-1.0f, 1.0f);
 
   std::vector<int32_t> axis_data{1};
-  Tensor input_tensor{DataType::U8, {1, 3, 2}, {{quant_param.first}, {quant_param.second}}, ""};
+  Tensor input_tensor =
+      makeInputTensor<DataType::U8>({1, 3, 2}, quant_param.first, quant_param.second, input_data);
   Tensor axis_tensor = makeInputTensor<DataType::S32>({1}, axis_data);
   Tensor output_tensor = makeOutputTensor(DataType::U8, quant_param.first, quant_param.second);
-  std::vector<uint8_t> quantize_input =
-      quantize<uint8_t>(input_data, quant_param.first, quant_param.second);
-  input_tensor.writeData(quantize_input.data(), quantize_input.size() * sizeof(uint8_t));
 
   ReducerParams params{};
   params.keep_dims = false;

--- a/compiler/luci-interpreter/src/kernels/Pad.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/Pad.test.cpp
@@ -34,12 +34,10 @@ TEST(Pad, Uint8)
   std::pair<float, int32_t> quant_param = quantizationParams<uint8_t>(-1.0f, 1.0f);
   std::vector<float> input_data{-0.8, 0.2, 0.9, 0.7, 0.1, -0.3};
   std::vector<int32_t> paddings_data{0, 0, 0, 2, 1, 3, 0, 0};
-  Tensor input_tensor{DataType::U8, {1, 2, 3, 1}, {{quant_param.first}, {quant_param.second}}, ""};
+  Tensor input_tensor = makeInputTensor<DataType::U8>({1, 2, 3, 1}, quant_param.first,
+                                                      quant_param.second, input_data);
   Tensor paddings_tensor = makeInputTensor<DataType::S32>({4, 2}, paddings_data);
   Tensor output_tensor = makeOutputTensor(DataType::U8, quant_param.first, quant_param.second);
-  std::vector<uint8_t> quantize_input =
-      quantize<uint8_t>(input_data, quant_param.first, quant_param.second);
-  input_tensor.writeData(quantize_input.data(), quantize_input.size() * sizeof(uint8_t));
 
   Pad kernel(&input_tensor, &paddings_tensor, &output_tensor);
   kernel.configure();

--- a/compiler/luci-interpreter/src/kernels/Rsqrt.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/Rsqrt.test.cpp
@@ -29,9 +29,7 @@ using namespace testing;
 void Check(std::initializer_list<int32_t> input_shape, std::initializer_list<int32_t> output_shape,
            std::initializer_list<float> input_data, std::initializer_list<float> output_data)
 {
-  Tensor input_tensor{DataType::FLOAT32, input_shape, {}, ""};
-  input_tensor.writeData(input_data.begin(), input_data.size() * sizeof(float));
-
+  Tensor input_tensor = makeInputTensor<DataType::FLOAT32>(input_shape, input_data);
   Tensor output_tensor = makeOutputTensor(DataType::FLOAT32);
 
   Rsqrt kernel(&input_tensor, &output_tensor);

--- a/compiler/luci-interpreter/src/kernels/SpaceToDepth.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/SpaceToDepth.test.cpp
@@ -35,13 +35,13 @@ TYPED_TEST_CASE(SpaceToDepthTest, DataTypes);
 
 TYPED_TEST(SpaceToDepthTest, SimpleCase)
 {
+  constexpr DataType element_type = getElementType<TypeParam>();
   std::vector<TypeParam> input_data{1, 5, 6, 7, 2, 3, 4, 8};
   Shape input_shape{1, 2, 2, 2};
-  Tensor input_tensor{getElementType<TypeParam>(), input_shape, {{}, {}}, ""};
-  input_tensor.writeData(input_data.data(), input_data.size() * sizeof(TypeParam));
+  Tensor input_tensor = makeInputTensor<element_type>(input_shape, input_data);
   std::vector<TypeParam> output_data{1, 5, 6, 7, 2, 3, 4, 8};
   std::vector<int32_t> output_shape{1, 1, 1, 8};
-  Tensor output_tensor = makeOutputTensor(getElementType<TypeParam>());
+  Tensor output_tensor = makeOutputTensor(element_type);
 
   SpaceToDepthParams params{};
   params.block_size = 2;

--- a/compiler/luci-interpreter/src/kernels/Split.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/Split.test.cpp
@@ -30,11 +30,11 @@ using namespace testing;
 template <typename T>
 void Check(int axis, int num_splits, std::initializer_list<int32_t> input_shape,
            std::initializer_list<int32_t> output_shape, std::initializer_list<T> input_data,
-           std::vector<std::vector<T>> output_data, DataType element_type)
+           std::vector<std::vector<T>> output_data)
 {
+  constexpr DataType element_type = getElementType<T>();
   Tensor axis_tensor = makeInputTensor<DataType::S32>({}, {axis});
-  Tensor input_tensor{element_type, input_shape, {}, ""};
-  input_tensor.writeData(input_data.begin(), input_data.size() * sizeof(T));
+  Tensor input_tensor = makeInputTensor<element_type>(input_shape, input_data);
 
   std::vector<Tensor> output_tensors;
   output_tensors.reserve(num_splits);
@@ -74,51 +74,42 @@ TYPED_TEST(SplitTest, FourDimensional)
                    {
                        {1, 2, 3, 4, 5, 6, 7, 8},        //
                        {9, 10, 11, 12, 13, 14, 15, 16}, //
-                   },
-                   getElementType<TypeParam>());
+                   });
   Check<TypeParam>(
       /*axis=*/1, /*num_splits=*/2, {2, 2, 2, 2}, {2, 1, 2, 2},
-      {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
-      {
-          {1, 2, 3, 4, 9, 10, 11, 12},  //
-          {5, 6, 7, 8, 13, 14, 15, 16}, //
-      },
-      getElementType<TypeParam>());
+      {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}, {
+                                                                   {1, 2, 3, 4, 9, 10, 11, 12},  //
+                                                                   {5, 6, 7, 8, 13, 14, 15, 16}, //
+                                                               });
   Check<TypeParam>(
       /*axis=*/2, /*num_splits=*/2, {2, 2, 2, 2}, {2, 2, 1, 2},
-      {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
-      {
-          {1, 2, 5, 6, 9, 10, 13, 14},  //
-          {3, 4, 7, 8, 11, 12, 15, 16}, //
-      },
-      getElementType<TypeParam>());
+      {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}, {
+                                                                   {1, 2, 5, 6, 9, 10, 13, 14},  //
+                                                                   {3, 4, 7, 8, 11, 12, 15, 16}, //
+                                                               });
   Check<TypeParam>(
       /*axis=*/3, /*num_splits=*/2, {2, 2, 2, 2}, {2, 2, 2, 1},
-      {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
-      {
-          {1, 3, 5, 7, 9, 11, 13, 15},  //
-          {2, 4, 6, 8, 10, 12, 14, 16}, //
-      },
-      getElementType<TypeParam>());
+      {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}, {
+                                                                   {1, 3, 5, 7, 9, 11, 13, 15},  //
+                                                                   {2, 4, 6, 8, 10, 12, 14, 16}, //
+                                                               });
 }
 
 TYPED_TEST(SplitTest, OneDimensional)
 {
   Check<TypeParam>(
       /*axis=*/0, /*num_splits=*/8, {8}, {1}, {1, 2, 3, 4, 5, 6, 7, 8},
-      {{1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}}, getElementType<TypeParam>());
+      {{1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}});
 }
 
 TYPED_TEST(SplitTest, NegativeAxis)
 {
   Check<TypeParam>(
       /*axis=*/-4, /*num_splits=*/2, {2, 2, 2, 2}, {1, 2, 2, 2},
-      {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
-      {
-          {1, 2, 3, 4, 5, 6, 7, 8}, //
-          {9, 10, 11, 12, 13, 14, 15, 16},
-      },
-      getElementType<TypeParam>());
+      {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}, {
+                                                                   {1, 2, 3, 4, 5, 6, 7, 8}, //
+                                                                   {9, 10, 11, 12, 13, 14, 15, 16},
+                                                               });
 }
 
 } // namespace

--- a/compiler/luci-interpreter/src/kernels/Sqrt.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/Sqrt.test.cpp
@@ -29,9 +29,7 @@ using namespace testing;
 void Check(std::initializer_list<int32_t> input_shape, std::initializer_list<int32_t> output_shape,
            std::initializer_list<float> input_data, std::initializer_list<float> output_data)
 {
-  Tensor input_tensor{DataType::FLOAT32, input_shape, {}, ""};
-  input_tensor.writeData(input_data.begin(), input_data.size() * sizeof(float));
-
+  Tensor input_tensor = makeInputTensor<DataType::FLOAT32>(input_shape, input_data);
   Tensor output_tensor = makeOutputTensor(DataType::FLOAT32);
 
   Sqrt kernel(&input_tensor, &output_tensor);

--- a/compiler/luci-interpreter/src/kernels/Squeeze.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/Squeeze.test.cpp
@@ -29,17 +29,14 @@ using namespace testing;
 template <typename T>
 void Check(std::initializer_list<int32_t> input_shape, std::initializer_list<int32_t> output_shape,
            std::initializer_list<T> input_data, std::initializer_list<T> output_data,
-           DataType element_type, std::vector<int32_t> squeeze_dims)
+           std::initializer_list<int32_t> squeeze_dims)
 {
-  Tensor input_tensor{element_type, input_shape, {}, ""};
-  input_tensor.writeData(input_data.begin(), input_data.size() * sizeof(T));
+  constexpr DataType element_type = getElementType<T>();
+  Tensor input_tensor = makeInputTensor<element_type>(input_shape, input_data);
   Tensor output_tensor = makeOutputTensor(element_type);
 
   SqueezeParams params{};
-  for (size_t i = 0; i < squeeze_dims.size(); i++)
-  {
-    params.squeeze_dims.push_back(squeeze_dims.at(i));
-  }
+  params.squeeze_dims = squeeze_dims;
 
   Squeeze kernel(&input_tensor, &output_tensor, params);
   kernel.configure();
@@ -64,7 +61,7 @@ TYPED_TEST(SqueezeTest, TotalTest)
                       13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24},
       /*output_data=*/{1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12,
                        13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24},
-      getElementType<TypeParam>(), {-1, 0});
+      {-1, 0});
 }
 
 } // namespace

--- a/compiler/luci-interpreter/src/kernels/StridedSlice.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/StridedSlice.test.cpp
@@ -36,16 +36,11 @@ TEST(StridedSliceTest, Float)
   std::vector<int32_t> end_data{1, 3, 2};
   Shape strides_shape{3};
   std::vector<int32_t> strides_data{1, 1, 1};
-  Tensor input_tensor{DataType::FLOAT32, input_shape, {}, ""};
-  Tensor begin_tensor{DataType::S32, begin_shape, {}, ""};
-  Tensor end_tensor{DataType::S32, end_shape, {}, ""};
-  Tensor strides_tensor{DataType::S32, strides_shape, {}, ""};
+  Tensor input_tensor = makeInputTensor<DataType::FLOAT32>(input_shape, input_data);
+  Tensor begin_tensor = makeInputTensor<DataType::S32>(begin_shape, begin_data);
+  Tensor end_tensor = makeInputTensor<DataType::S32>(end_shape, end_data);
+  Tensor strides_tensor = makeInputTensor<DataType::S32>(strides_shape, strides_data);
   Tensor output_tensor = makeOutputTensor(DataType::FLOAT32);
-
-  input_tensor.writeData(input_data.data(), input_data.size() * sizeof(float));
-  begin_tensor.writeData(begin_data.data(), begin_data.size() * sizeof(int32_t));
-  end_tensor.writeData(end_data.data(), end_data.size() * sizeof(int32_t));
-  strides_tensor.writeData(strides_data.data(), strides_data.size() * sizeof(int32_t));
 
   StridedSliceParams params{};
   params.begin_mask = 0;
@@ -70,23 +65,17 @@ TEST(StridedSliceTest, Uint8)
 {
   Shape input_shape{2, 3, 2};
   std::vector<float> input_data{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
-  std::vector<uint8_t> quant_input_data = quantize<uint8_t>(input_data, 1.0f, 0);
   Shape begin_shape{3};
   std::vector<int32_t> begin_data{0, 0, 0};
   Shape end_shape{3};
   std::vector<int32_t> end_data{1, 3, 2};
   Shape strides_shape{3};
   std::vector<int32_t> strides_data{1, 1, 1};
-  Tensor input_tensor{DataType::U8, input_shape, {{1.0f}, {0}}, ""};
-  Tensor begin_tensor{DataType::S32, begin_shape, {}, ""};
-  Tensor end_tensor{DataType::S32, end_shape, {}, ""};
-  Tensor strides_tensor{DataType::S32, strides_shape, {}, ""};
+  Tensor input_tensor = makeInputTensor<DataType::U8>(input_shape, 1.0f, 0, input_data);
+  Tensor begin_tensor = makeInputTensor<DataType::S32>(begin_shape, begin_data);
+  Tensor end_tensor = makeInputTensor<DataType::S32>(end_shape, end_data);
+  Tensor strides_tensor = makeInputTensor<DataType::S32>(strides_shape, strides_data);
   Tensor output_tensor = makeOutputTensor(DataType::U8, 1.0f, 0);
-
-  input_tensor.writeData(quant_input_data.data(), quant_input_data.size() * sizeof(uint8_t));
-  begin_tensor.writeData(begin_data.data(), begin_data.size() * sizeof(int32_t));
-  end_tensor.writeData(end_data.data(), end_data.size() * sizeof(int32_t));
-  strides_tensor.writeData(strides_data.data(), strides_data.size() * sizeof(int32_t));
 
   StridedSliceParams params{};
   params.begin_mask = 0;

--- a/compiler/luci-interpreter/src/kernels/Tanh.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/Tanh.test.cpp
@@ -70,13 +70,10 @@ TEST(TanhTest, Uint8)
       0,  -6, 2, 4, //
       -4, -2, 8, 1, //
   };
-  Tensor input_tensor{
-      DataType::U8, {2, 6, 4, 1}, {{input_quant_param.first}, {input_quant_param.second}}, ""};
+  Tensor input_tensor = makeInputTensor<DataType::U8>({2, 6, 4, 1}, input_quant_param.first,
+                                                      input_quant_param.second, input_data);
   Tensor output_tensor =
       makeOutputTensor(DataType::U8, output_quant_param.first, output_quant_param.second);
-  std::vector<uint8_t> quantize_input =
-      quantize<uint8_t>(input_data, input_quant_param.first, input_quant_param.second);
-  input_tensor.writeData(quantize_input.data(), quantize_input.size() * sizeof(uint8_t));
 
   Tanh kernel(&input_tensor, &output_tensor);
   kernel.configure();

--- a/compiler/luci-interpreter/src/kernels/Transpose.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/Transpose.test.cpp
@@ -29,14 +29,11 @@ using namespace testing;
 template <typename T>
 void Check(std::initializer_list<int32_t> input_shape, std::initializer_list<int32_t> perm_shape,
            std::initializer_list<int32_t> output_shape, std::initializer_list<T> input_data,
-           std::initializer_list<int32_t> perm_data, std::initializer_list<T> output_data,
-           DataType element_type)
+           std::initializer_list<int32_t> perm_data, std::initializer_list<T> output_data)
 {
-  Tensor input_tensor{element_type, input_shape, {}, ""};
-  input_tensor.writeData(input_data.begin(), input_data.size() * sizeof(T));
-
-  Tensor perm_tensor{DataType::S32, perm_shape, {}, ""};
-  perm_tensor.writeData(perm_data.begin(), perm_data.size() * sizeof(int32_t));
+  constexpr DataType element_type = getElementType<T>();
+  Tensor input_tensor = makeInputTensor<element_type>(input_shape, input_data);
+  Tensor perm_tensor = makeInputTensor<DataType::S32>(perm_shape, perm_data);
   Tensor output_tensor = makeOutputTensor(element_type);
 
   Transpose kernel(&input_tensor, &perm_tensor, &output_tensor);
@@ -60,8 +57,7 @@ TYPED_TEST(TransposeTest, Small3D)
                                    12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23},
                    /*perm_data=*/{2, 0, 1},
                    /*output_data=*/{0, 4, 8,  12, 16, 20, 1, 5, 9,  13, 17, 21,
-                                    2, 6, 10, 14, 18, 22, 3, 7, 11, 15, 19, 23},
-                   getElementType<TypeParam>());
+                                    2, 6, 10, 14, 18, 22, 3, 7, 11, 15, 19, 23});
 }
 
 TYPED_TEST(TransposeTest, Large4D)
@@ -84,8 +80,7 @@ TYPED_TEST(TransposeTest, Large4D)
                        10, 11, 12, 13, 14, 30, 31, 32, 33, 34, 50,  51,  52,  53,  54,
                        70, 71, 72, 73, 74, 90, 91, 92, 93, 94, 110, 111, 112, 113, 114,
                        15, 16, 17, 18, 19, 35, 36, 37, 38, 39, 55,  56,  57,  58,  59,
-                       75, 76, 77, 78, 79, 95, 96, 97, 98, 99, 115, 116, 117, 118, 119},
-      getElementType<TypeParam>());
+                       75, 76, 77, 78, 79, 95, 96, 97, 98, 99, 115, 116, 117, 118, 119});
 }
 
 TYPED_TEST(TransposeTest, Large2D)
@@ -101,15 +96,13 @@ TYPED_TEST(TransposeTest, Large2D)
                       90,  91,  92,  93,  94,  95,  96,  97,  98,  99,  100, 101, 102, 103, 104,
                       105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119},
       /*perm_data=*/{1, 0},
-      /*output_data=*/{0,  12, 24, 36,  48,  60, 72, 84, 96,  108, 1,  13, 25, 37,  49,
-                       61, 73, 85, 97,  109, 2,  14, 26, 38,  50,  62, 74, 86, 98,  110,
-                       3,  15, 27, 39,  51,  63, 75, 87, 99,  111, 4,  16, 28, 40,  52,
-                       64, 76, 88, 100, 112, 5,  17, 29, 41,  53,  65, 77, 89, 101, 113,
-                       6,  18, 30, 42,  54,  66, 78, 90, 102, 114, 7,  19, 31, 43,  55,
-                       67, 79, 91, 103, 115, 8,  20, 32, 44,  56,  68, 80, 92, 104, 116,
-                       9,  21, 33, 45,  57,  69, 81, 93, 105, 117, 10, 22, 34, 46,  58,
-                       70, 82, 94, 106, 118, 11, 23, 35, 47,  59,  71, 83, 95, 107, 119},
-      getElementType<TypeParam>());
+      /*output_data=*/{
+          0,  12, 24, 36, 48, 60, 72, 84, 96,  108, 1,  13, 25, 37, 49, 61, 73, 85, 97,  109,
+          2,  14, 26, 38, 50, 62, 74, 86, 98,  110, 3,  15, 27, 39, 51, 63, 75, 87, 99,  111,
+          4,  16, 28, 40, 52, 64, 76, 88, 100, 112, 5,  17, 29, 41, 53, 65, 77, 89, 101, 113,
+          6,  18, 30, 42, 54, 66, 78, 90, 102, 114, 7,  19, 31, 43, 55, 67, 79, 91, 103, 115,
+          8,  20, 32, 44, 56, 68, 80, 92, 104, 116, 9,  21, 33, 45, 57, 69, 81, 93, 105, 117,
+          10, 22, 34, 46, 58, 70, 82, 94, 106, 118, 11, 23, 35, 47, 59, 71, 83, 95, 107, 119});
 }
 
 } // namespace

--- a/compiler/luci-interpreter/src/kernels/TransposeConv.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/TransposeConv.test.cpp
@@ -28,21 +28,18 @@ using namespace testing;
 
 template <typename T, typename B>
 void Check(std::initializer_list<int32_t> output_shape_shape,
-           std::initializer_list<int32_t> weight_shape,
-           std::initializer_list<int32_t> input_data_shape,
+           std::initializer_list<int32_t> weight_shape, std::initializer_list<int32_t> input_shape,
            std::initializer_list<int32_t> bias_shape, std::initializer_list<int32_t> output_shape,
            std::initializer_list<int32_t> output_shape_data, std::initializer_list<T> weight_data,
-           std::initializer_list<T> input_data_data, std::initializer_list<B> bias_data,
+           std::initializer_list<T> input_data, std::initializer_list<B> bias_data,
            std::initializer_list<T> output_data, luci::Padding padding, int32_t stride_height,
-           int32_t stride_width, DataType element_type)
+           int32_t stride_width)
 {
-  Tensor output_shape_tensor{element_type, output_shape_shape, {}, ""};
-  output_shape_tensor.writeData(output_shape_data.begin(), output_shape_data.size() * sizeof(T));
-  Tensor weight_tensor{element_type, weight_shape, {}, ""};
-  weight_tensor.writeData(weight_data.begin(), weight_data.size() * sizeof(T));
-  Tensor input_data_tensor{element_type, input_data_shape, {}, ""};
-  input_data_tensor.writeData(input_data_data.begin(), input_data_data.size() * sizeof(T));
-
+  constexpr DataType element_type = getElementType<T>();
+  Tensor output_shape_tensor =
+      makeInputTensor<DataType::S32>(output_shape_shape, output_shape_data);
+  Tensor weight_tensor = makeInputTensor<element_type>(weight_shape, weight_data);
+  Tensor input_data_tensor = makeInputTensor<element_type>(input_shape, input_data);
   Tensor output_tensor = makeOutputTensor(element_type);
 
   TransposeConvParams params{};
@@ -71,14 +68,13 @@ void Check(std::initializer_list<int32_t> output_shape_shape,
 TEST(TransposeConvTest, FloatSimple)
 {
   Check<float, float>(
-      /*outputShape_shape=*/{4}, /*weight_shape=*/{1, 3, 3, 1}, /*input_shape=*/{1, 4, 4, 1},
-      /*bias_shape=*/{}, /*output_shape=*/{1, 4, 4, 1}, /*outputShape_data=*/{1, 4, 4, 1},
+      /*output_shape_shape=*/{4}, /*weight_shape=*/{1, 3, 3, 1}, /*input_shape=*/{1, 4, 4, 1},
+      /*bias_shape=*/{}, /*output_shape=*/{1, 4, 4, 1}, /*output_shape_data=*/{1, 4, 4, 1},
       /*weight_data=*/{1, 2, 3, 4, 5, 6, 7, 8, 9},
       /*input_data=*/{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
       /*bias_data=*/{},
       /*output_data=*/{29, 62, 83, 75, 99, 192, 237, 198, 207, 372, 417, 330, 263, 446, 485, 365},
-      /*params.padding=*/luci::Padding::SAME, /*stride_height=*/1, /*stride_width=*/1,
-      getElementType<float>());
+      /*params.padding=*/luci::Padding::SAME, /*stride_height=*/1, /*stride_width=*/1);
 
   SUCCEED();
 }
@@ -86,16 +82,15 @@ TEST(TransposeConvTest, FloatSimple)
 TEST(TransposeConvTest, FloatTwoFiltersTest)
 {
   Check<float, float>(
-      /*outputShape_shape=*/{4}, /*weight_shape=*/{1, 3, 3, 2}, /*input_shape=*/{1, 4, 4, 2},
-      /*bias_shape=*/{}, /*output_shape=*/{1, 4, 4, 1}, /*outputShape_data=*/{1, 4, 4, 1},
+      /*output_shape_shape=*/{4}, /*weight_shape=*/{1, 3, 3, 2}, /*input_shape=*/{1, 4, 4, 2},
+      /*bias_shape=*/{}, /*output_shape=*/{1, 4, 4, 1}, /*output_shape_data=*/{1, 4, 4, 1},
       /*weight_data=*/{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18},
       /*input_data=*/{1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16,
                       17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32},
       /*bias_data=*/{},
-      /*output_data=*/{184, 412, 568, 528, 678, 1347, 1689, 1434, 1494, 2715, 3057, 2442, 1968,
-                       3352, 3652, 2760},
-      /*params.padding=*/luci::Padding::SAME, /*stride_height=*/1, /*stride_width=*/1,
-      getElementType<float>());
+      /*output_data=*/
+      {184, 412, 568, 528, 678, 1347, 1689, 1434, 1494, 2715, 3057, 2442, 1968, 3352, 3652, 2760},
+      /*params.padding=*/luci::Padding::SAME, /*stride_height=*/1, /*stride_width=*/1);
 
   SUCCEED();
 }
@@ -103,17 +98,16 @@ TEST(TransposeConvTest, FloatTwoFiltersTest)
 TEST(TransposeConvTest, SimpleBiasTest)
 {
   Check<float, float>(
-      /*outputShape_shape=*/{4}, /*weight_shape=*/{2, 3, 3, 1},
+      /*output_shape_shape=*/{4}, /*weight_shape=*/{2, 3, 3, 1},
       /*input_shape=*/{1, 2, 2, 1},
-      /*bias_shape=*/{2}, /*output_shape=*/{1, 4, 4, 1}, /*outputShape_data=*/{1, 5, 5, 2},
+      /*bias_shape=*/{2}, /*output_shape=*/{1, 4, 4, 1}, /*output_shape_data=*/{1, 5, 5, 2},
       /*weight_data=*/{1, 3, 5, 7, 9, 11, 13, 15, 17, 2, 4, 6, 8, 10, 12, 14, 16, 18},
       /*input_data=*/{1, 2, 3, 4},
       /*bias_data=*/{3, 4},
       /*output_data=*/{4,  6,  6,  8,  10, 14, 9,  12, 13, 16, 10,  12,  12, 14, 28, 32, 21,
                        24, 25, 28, 19, 24, 27, 32, 65, 76, 45, 52,  57,  64, 24, 28, 30, 34,
                        64, 72, 39, 44, 47, 52, 42, 46, 48, 52, 106, 114, 63, 68, 71, 76},
-      /*params.padding=*/luci::Padding::VALID, /*stride_height=*/2, /*stride_width=*/2,
-      getElementType<float>());
+      /*params.padding=*/luci::Padding::VALID, /*stride_height=*/2, /*stride_width=*/2);
 
   SUCCEED();
 }


### PR DESCRIPTION
* Add `makeInputTensor` overload which makes quantized tensor from `float` data.
* Use `makeInputTensor` in some tests.

ONE-DCO-1.0-Signed-off-by: Sergei Barannikov <s.barannikov@samsung.com>