### PR TITLE
[onert] introduce BSR sparsity (loader and layer)

### DIFF
--- a/runtime/onert/backend/cpu/ops/FullyConnectedLayer.cc
+++ b/runtime/onert/backend/cpu/ops/FullyConnectedLayer.cc
@@ -161,12 +161,22 @@ void FullyConnectedLayer::fullyConnectedSparseWeight()
   const uint16_t *w1_segments = _weights->sparsity()->w1_segments();
   const uint16_t *w1_indices = _weights->sparsity()->w1_indices();
 
-  nnfw::cker::FullyConnectedSparseWeightRandom(
-      op_params, getTensorShape(_input), reinterpret_cast<const float *>(_input->buffer()),
-      getTensorShape(_weights), reinterpret_cast<const float *>(_weights->buffer()),
-      getTensorShape(_bias), reinterpret_cast<const float *>(_bias ? _bias->buffer() : nullptr),
-      getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()), w1_segments,
-      w1_indices);
+  auto block_size = _weights->sparsity()->block_size();
+  if (block_size.size() == 0)
+  {
+    nnfw::cker::FullyConnectedSparseWeightRandom(
+        op_params, getTensorShape(_input), reinterpret_cast<const float *>(_input->buffer()),
+        getTensorShape(_weights), reinterpret_cast<const float *>(_weights->buffer()),
+        getTensorShape(_bias), reinterpret_cast<const float *>(_bias ? _bias->buffer() : nullptr),
+        getTensorShape(_output), reinterpret_cast<float *>(_output->buffer()), w1_segments,
+        w1_indices);
+  }
+  else if (block_size.size() == 2 && block_size[0] == 16 && block_size[1] == 1)
+  {
+    throw std::runtime_error{"FullyConnectedSparseWeight16x1 is not supported yet"};
+  }
+  else
+    throw std::runtime_error{"FullyConnected: unsupported sparsity"};
 }
 
 void FullyConnectedLayer::configure(const IPortableTensor *input, const IPortableTensor *weights,

--- a/runtime/onert/core/include/ir/Sparsity.h
+++ b/runtime/onert/core/include/ir/Sparsity.h
@@ -33,8 +33,9 @@ struct Sparsity
 {
 public:
   Sparsity() = default;
-  Sparsity(std::vector<uint16_t> &&w1_segments, std::vector<uint16_t> &&w1_indices)
-      : _w1_segments(w1_segments), _w1_indices(w1_indices)
+  Sparsity(std::vector<uint16_t> &&w1_segments, std::vector<uint16_t> &&w1_indices,
+           std::vector<int32_t> &&block_size)
+      : _w1_segments(w1_segments), _w1_indices(w1_indices), _block_size(block_size)
   {
   }
 
@@ -46,10 +47,15 @@ public:
    * @brief Returns indices array. See compressed sparse row format.
    */
   const uint16_t *w1_indices() const { return _w1_indices.data(); }
+  /**
+   * @brief Returns block size which is used for block sparsity
+   */
+  const std::vector<int32_t> &block_size() const { return _block_size; }
 
 private:
   std::vector<uint16_t> _w1_segments;
   std::vector<uint16_t> _w1_indices;
+  std::vector<int32_t> _block_size;
 };
 
 } // namespace ir


### PR DESCRIPTION
- loader will load block_map and block size.
- cpu backend will dispatch 16x1 kernel for that case.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>