### PR TITLE
[onert] Introduce USE_MMAPED_DATA option

### DIFF
--- a/runtime/onert/core/include/util/Config.lst
+++ b/runtime/onert/core/include/util/Config.lst
@@ -35,6 +35,7 @@ CONFIG(OP_SEQ_MAX_NODE         , int          , "0")
 CONFIG(TRACE_FILEPATH          , std::string  , "")
 CONFIG(FP16_ENABLE             , bool         , "0")
 CONFIG(RUY_THREADS             , int          , "-1")
+CONFIG(USE_MMAPED_DATA         , bool         , "0")
 
 // Auto-generate all operations
 


### PR DESCRIPTION
- This commit introduces USE_MMAPED_DATA option to use MMAPED_DATA
- base_loader uses CACHED_DATA for values of constant tensors by default
- When USE_MMAPED_DATA is turned on, MMPAED_DATA is used

ONE-DCO-1.0-Signed-off-by: JiHwan Yeo <jihwan.yeo@samsung.com>

---

For issue #3961