### PR TITLE
[release/1.9.0][bcq-tools] Modify unique value generator

### DIFF
--- a/compiler/bcq-tools/preserve_bcq_info
+++ b/compiler/bcq-tools/preserve_bcq_info
@@ -45,15 +45,19 @@ def load_graph(frozen_graph_filename):
 
 def preserve_bcq_info(flags):
     """
-    Generate unique dummy value from -1 to -N.
+    Generate unique dummy value from -1500000001 to -1500000002,
+    -1500000003, ..., etc.
 
     We use negative values to preserve BCQ information because
     positive values may cause some confusion with real BCQ information values.
+    In addition, the unique value is started from -1500000001 to
+    prevent another duplication. For example, if we start from -1 and if
+    new_shape attribute of Reshape operation is [1, -1], it can be duplicated.
     """
 
     class UniqueValueGen:
         def __init__(self):
-            self.unique_value = -1
+            self.unique_value = -1500000001
 
         def gen(self):
             val = self.unique_value


### PR DESCRIPTION
If `new_shape` attribute of `Reshape` operation is `[1, -1]`, preserved `do_w_x` can be duplicated with it and it can cause
unintended conversion.
This commit will fix it by modifying the starting value to -1500000001, which is prime number.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>