### PR TITLE
[onert/nnpackage_run] Disallow two shape-related options together to be given from cmd

### DIFF
--- a/tests/tools/nnpackage_run/src/args.cc
+++ b/tests/tools/nnpackage_run/src/args.cc
@@ -255,6 +255,11 @@ void Args::Parse(const int argc, char **argv)
                                             "' cannot be given at once.");
       }
     };
+
+    // calling, e.g., "nnpackage_run .. -- shape_prepare .. --shape_run .." should theoretically
+    // work but allowing both options together on command line makes the usage and implemenation
+    // of nnpackage_run too complicated. Therefore let's not allow those option together.
+    conflicting_options("shape_prepare", "shape_run");
   }
 
   if (vm.count("help"))


### PR DESCRIPTION
This disallows both "shape_prepare" and "shape_run" together to be given at the same time.
For example,

`$ nnpackage_run .. -- shape_prepare .. --shape_run .. `

will prints an error.

```
$ ./Product/out/bin/nnpackage_run --nnpackage some_model --shape_run some_val --shape_prepare some_val
terminate called after throwing an instance of 'boost::program_options::error'
  what():  Two options 'shape_prepare' and 'shape_run' cannot be given at once.
```

This is to simplify parameter usage of nnpackage_run.

Related to https://github.com/Samsung/ONE/pull/4028#issuecomment-687009944

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>