### PR TITLE
[onert] Move `applyShape` to `ITensor`

### DIFF
--- a/docs/howto/how-to-introduce-a-new-operation-into-runtime.md
+++ b/docs/howto/how-to-introduce-a-new-operation-into-runtime.md
@@ -229,7 +229,7 @@ void DynamicShapeInferer::visit(const ir::operation::Select &op)
   ir::Shape new_shape =
       shape_inference::inferSelectShape(input_cond_shape, input_true_shape, input_false_shape);
 
-  dynamicTensorManagerOf(output)->applyShape(output_ind, new_shape);
+  output->applyShape(new_shape);
 }
 ```
 

--- a/runtime/onert/backend/cpu/StaticTensorManager.cc
+++ b/runtime/onert/backend/cpu/StaticTensorManager.cc
@@ -67,7 +67,8 @@ void StaticTensorManager::buildTensor(const ir::OperandIndex &ind,
   }
   else
   {
-    auto tensor = std::make_shared<Tensor>(tensor_info, backend_layout, _dynamic_tensor_manager);
+    auto tensor = std::make_shared<Tensor>(tensor_info, backend_layout,
+                                           _dynamic_tensor_manager->dynamic_mem_mgr().get());
     _tensors->setNativeTensor(ind, tensor);
   }
   _as_constants[ind] = as_const;

--- a/runtime/onert/core/include/backend/IDynamicTensorManager.h
+++ b/runtime/onert/core/include/backend/IDynamicTensorManager.h
@@ -39,18 +39,6 @@ struct IDynamicTensorManager : public ITensorManager
 
 public:
   /**
-   * @brief Set new shape and allocate memory for dynamic tensor.
-   *        If a tensor is dynamic tensor and previously allocated memory exists,
-   *        it will be deallocated.
-   *        If a tensor is static tensor (with previously allocated memory by StaticTensorManager),
-   *        tensor->buffer() will be overwrite to the dynamically allocated memory
-   * @param ind             operand index of a tensor
-   * @param new_shape       tensor's new shape. While allocating memory for this new_shape,
-   *                        tensor's shape is set to new_shape
-   */
-  virtual void applyShape(const ir::OperandIndex &ind, const ir::Shape &new_shape) = 0;
-
-  /**
    * @brief Plan when to delete a tensor. Note this planning is done at compilation time.
    * @param op_ind        operation index
    * @param operand_ind   operand index of input operand of first param op. Operand can be static

--- a/runtime/onert/core/include/backend/ITensor.h
+++ b/runtime/onert/core/include/backend/ITensor.h
@@ -53,13 +53,19 @@ public:
   virtual void access(const std::function<void(ITensor &tensor)> &fn) = 0;
 
   /**
-   * @brief Return the dynamic tensor manager
+   * @brief Set the shape to @c shape and possibly re-allocate the buffer
    *
-   * If dynamic tensors are not supported, it returns @c nullptr .
+   * If a tensor is dynamic tensor and previously allocated memory exists,
+   * it will be deallocated.
+   * If a tensor is static tensor (with previously allocated memory by StaticTensorManager),
+   * @c buffer() will be overwriten
    *
-   * @return IDynamicTensorManager* DynamicTensorManager
+   * @param shape tensor's new shape. While allocating memory for this new_shape,
+   *              tensor's shape is set to new_shape
+   * @return true If applying shape is successful
+   * @return false If not applying shape is not supported (it throws for other errors)
    */
-  virtual IDynamicTensorManager *dynamic_tensor_manager() { return nullptr; }
+  virtual bool applyShape(const ir::Shape &) { return false; }
 
   /**
    * @brief Return true if the tensor is constant

--- a/runtime/onert/core/include/backend/cpu_common/DynamicTensorManager.h
+++ b/runtime/onert/core/include/backend/cpu_common/DynamicTensorManager.h
@@ -44,14 +44,14 @@ public:
 
   virtual ~DynamicTensorManager() = default;
 
-  void applyShape(const ir::OperandIndex &ind, const ir::Shape &new_shape) override;
-
   void buildTensor(const ir::OperandIndex &ind, const ir::OperandInfo &tensor_info,
                    ir::Layout backend_layout);
 
   void planDealloc(ir::OperationIndex op_ind, ir::OperandIndex operand_ind) override;
   void deallocInput(ir::OperationIndex op_ind) override;
   void deallocSubgraphOutput(ir::OperandIndex ind) override;
+
+  std::shared_ptr<DynamicMemoryManager> dynamic_mem_mgr() { return _dynamic_mem_mgr; }
 
 private:
   const ITensor *getRawITensor(ir::OperandIndex ind);

--- a/runtime/onert/core/include/backend/cpu_common/MemoryManager.h
+++ b/runtime/onert/core/include/backend/cpu_common/MemoryManager.h
@@ -20,7 +20,6 @@
 #include "Allocator.h"
 #include "backend/IMemoryManager.h"
 #include "IMemoryPlanner.h"
-#include "ir/OperandIndexMap.h"
 
 namespace onert
 {

--- a/runtime/onert/core/include/backend/cpu_common/StaticTensorManager.h
+++ b/runtime/onert/core/include/backend/cpu_common/StaticTensorManager.h
@@ -20,7 +20,6 @@
 #include "MemoryManager.h"
 
 #include "backend/IStaticTensorManager.h"
-#include "backend/IDynamicTensorManager.h"
 #include "ir/OperandIndexMap.h"
 #include "ir/OperandInfo.h"
 #include "TensorRegistry.h"
@@ -32,11 +31,13 @@ namespace backend
 namespace cpu_common
 {
 
+class DynamicTensorManager;
+
 class StaticTensorManager : public backend::IStaticTensorManager
 {
 public:
   StaticTensorManager(const std::shared_ptr<TensorRegistry> &reg,
-                      IDynamicTensorManager *dynamic_tensor_manager);
+                      DynamicMemoryManager *dynamic_mem_mgr);
   virtual ~StaticTensorManager() = default;
 
   void allocateConsts(void);
@@ -57,7 +58,7 @@ private:
   std::unique_ptr<MemoryManager> _nonconst_mgr;
   const std::shared_ptr<TensorRegistry> _tensors;
   ir::OperandIndexMap<bool> _as_constants;
-  IDynamicTensorManager *_dynamic_tensor_manager;
+  DynamicMemoryManager *_dynamic_mem_mgr;
 };
 
 } // namespace cpu_common

--- a/runtime/onert/core/include/backend/cpu_common/Tensor.h
+++ b/runtime/onert/core/include/backend/cpu_common/Tensor.h
@@ -29,6 +29,8 @@ namespace backend
 namespace cpu_common
 {
 
+class DynamicMemoryManager;
+
 class Tensor : public IPortableTensor
 {
 public:
@@ -37,9 +39,9 @@ public:
 
 public:
   Tensor(const ir::OperandInfo &info, const ir::Layout layout,
-         IDynamicTensorManager *dynamic_tensor_manager)
+         DynamicMemoryManager *dynamic_mem_mgr)
       : _info(info), _layout(layout), _buffer(nullptr), _num_references(0),
-        _dynamic_tensor_manager(dynamic_tensor_manager), _allocator(nullptr)
+        _dynamic_mem_mgr(dynamic_mem_mgr), _allocator(nullptr)
   {
     // DO NOTHING
   }
@@ -106,7 +108,7 @@ public:
   bool is_constant() const override { return _info.isConstant(); }
   bool is_dynamic() const override { return _info.isDynamic(); }
   void set_dynamic() override { _info.setDynamic(); }
-  IDynamicTensorManager *dynamic_tensor_manager() override { return _dynamic_tensor_manager; }
+  bool applyShape(const ir::Shape &new_shape) override;
   const ir::Sparsity *sparsity() const override { return _info.typeInfo().sparsity(); }
 
   virtual void increase_ref()
@@ -142,7 +144,7 @@ protected:
   ir::Layout _layout;
   uint8_t *_buffer;
   int32_t _num_references;
-  IDynamicTensorManager *_dynamic_tensor_manager;
+  DynamicMemoryManager *_dynamic_mem_mgr;
 
 private:
   /**

--- a/runtime/onert/core/src/backend/controlflow/DynamicTensorManager.h
+++ b/runtime/onert/core/src/backend/controlflow/DynamicTensorManager.h
@@ -43,14 +43,14 @@ public:
 
   virtual ~DynamicTensorManager() = default;
 
-  void applyShape(const ir::OperandIndex &ind, const ir::Shape &new_shape) override;
-
   void buildTensor(const ir::OperandIndex &ind, const ir::OperandInfo &tensor_info,
                    ir::Layout backend_layout);
 
   void planDealloc(ir::OperationIndex op_ind, ir::OperandIndex operand_ind) override;
   void deallocInput(ir::OperationIndex op_ind) override;
   void deallocSubgraphOutput(ir::OperandIndex ind) override;
+
+  std::shared_ptr<cpu_common::DynamicMemoryManager> dynamic_mem_mgr() { return _dynamic_mem_mgr; }
 
 private:
   const ITensor *getRawITensor(ir::OperandIndex ind);

--- a/runtime/onert/core/src/backend/controlflow/TensorBuilder.cc
+++ b/runtime/onert/core/src/backend/controlflow/TensorBuilder.cc
@@ -29,8 +29,8 @@ namespace controlflow
 
 TensorBuilder::TensorBuilder(const std::shared_ptr<TensorRegistry> &tensor_reg)
     : _tensor_reg{tensor_reg}, _dynamic_tensor_mgr{new DynamicTensorManager(_tensor_reg)},
-      _static_tensor_mgr{
-          new cpu_common::StaticTensorManager(_tensor_reg->base_reg(), _dynamic_tensor_mgr.get())}
+      _static_tensor_mgr{new cpu_common::StaticTensorManager(
+          _tensor_reg->base_reg(), _dynamic_tensor_mgr->dynamic_mem_mgr().get())}
 {
   /* empty */
 }
@@ -99,6 +99,11 @@ void TensorBuilder::allocate()
 {
   // NOTE For now nothing to do. Allocation is done in prepare stage, which is not appropriate
   //      This is because CPU kernels require `ITensor`s to be allocated before Kernel Generation.
+}
+
+IDynamicTensorManager *TensorBuilder::dynamicTensorManager(void)
+{
+  return _dynamic_tensor_mgr.get();
 }
 
 std::shared_ptr<cpu_common::Tensor> TensorBuilder::nativeOwnTensorAt(const ir::OperandIndex &ind)

--- a/runtime/onert/core/src/backend/controlflow/TensorBuilder.h
+++ b/runtime/onert/core/src/backend/controlflow/TensorBuilder.h
@@ -59,7 +59,7 @@ public:
   void allocate() override;
   void postFunctionPrepare() override { /* DO NOTHING */}
 
-  IDynamicTensorManager *dynamicTensorManager(void) override { return _dynamic_tensor_mgr.get(); }
+  IDynamicTensorManager *dynamicTensorManager(void) override;
 
   /**
    * @brief Get tensor with a specific OperandIndex.

--- a/runtime/onert/core/src/backend/controlflow/UserTensor.cc
+++ b/runtime/onert/core/src/backend/controlflow/UserTensor.cc
@@ -16,6 +16,9 @@
 
 #include "UserTensor.h"
 
+#include "util/Exceptions.h"
+#include "ir/DataType.h"
+
 namespace onert
 {
 namespace backend
@@ -33,6 +36,16 @@ size_t UserTensor::calcOffset(const ir::Coordinates &coords) const
   }
   offset *= sizeOfDataType(data_type());
   return offset;
+}
+
+bool UserTensor::applyShape(const ir::Shape &new_shape)
+{
+  // User tensors cannot be reallocated.
+  auto new_size = new_shape.num_elements() * ir::sizeOfDataType(data_type());
+  if (total_size() < new_size)
+    throw InsufficientBufferSizeException{"User given buffer size is too small."};
+  setShape(new_shape);
+  return true;
 }
 
 } // namespace controlflow

--- a/runtime/onert/core/src/backend/controlflow/UserTensor.h
+++ b/runtime/onert/core/src/backend/controlflow/UserTensor.h
@@ -38,16 +38,12 @@ namespace controlflow
 class UserTensor : public IPortableTensor
 {
 public:
-  UserTensor(const ir::OperandInfo &info, ir::Layout layout, uint8_t *buffer, size_t size,
-             IDynamicTensorManager *dynamic_tensor_manager)
-      : _info{info}, _layout{layout}, _buffer{buffer}, _size{size}, _dynamic{false},
-        _dynamic_tensor_manager{dynamic_tensor_manager}
+  UserTensor(const ir::OperandInfo &info, ir::Layout layout, uint8_t *buffer, size_t size)
+      : _info{info}, _layout{layout}, _buffer{buffer}, _size{size}, _dynamic{false}
   {
   }
 
-  UserTensor(const ir::OperandInfo &info, ir::Layout layout,
-             IDynamicTensorManager *dynamic_tensor_manager)
-      : UserTensor{info, layout, nullptr, 0, dynamic_tensor_manager}
+  UserTensor(const ir::OperandInfo &info, ir::Layout layout) : UserTensor{info, layout, nullptr, 0}
   {
   }
 
@@ -73,7 +69,7 @@ public:
   ir::Shape getShape() const override { return _info.shape(); }
   void setShape(const ir::Shape &new_shape) override { _info.shape(new_shape); }
   bool is_constant() const override { return false; }
-  IDynamicTensorManager *dynamic_tensor_manager() override { return _dynamic_tensor_manager; }
+  bool applyShape(const ir::Shape &) override;
 
 private:
   ir::OperandInfo _info;
@@ -81,7 +77,6 @@ private:
   uint8_t *_buffer;
   size_t _size;
   bool _dynamic;
-  IDynamicTensorManager *_dynamic_tensor_manager;
 };
 
 } // namespace controlflow

--- a/runtime/onert/core/src/backend/controlflow/kernel/PermuteLayer.cc
+++ b/runtime/onert/core/src/backend/controlflow/kernel/PermuteLayer.cc
@@ -54,12 +54,9 @@ void PermuteLayer::run()
 
       try
       {
-        const auto dst_index = _dst_dyn_alloc_info_map.at(dst_tensor).ind;
-        auto dyn_tensor_manager = dst_tensor->dynamic_tensor_manager();
-        if (!dyn_tensor_manager)
+        if (!dst_tensor->applyShape(new_shape))
           throw std::runtime_error{
               "Error: PermuteLayer: output's TensorManager does not support dynamic tensor"};
-        dyn_tensor_manager->applyShape(dst_index, new_shape);
         assert(dst_tensor->buffer() != nullptr);
       }
       catch (const std::out_of_range &e)

--- a/runtime/onert/core/src/backend/cpu_common/StaticTensorManager.cc
+++ b/runtime/onert/core/src/backend/cpu_common/StaticTensorManager.cc
@@ -27,9 +27,9 @@ namespace cpu_common
 {
 
 StaticTensorManager::StaticTensorManager(const std::shared_ptr<TensorRegistry> &reg,
-                                         IDynamicTensorManager *dynamic_tensor_manager)
+                                         DynamicMemoryManager *dynamic_mem_mgr)
     : _const_mgr{new DynamicMemoryManager()}, _nonconst_mgr{new MemoryManager()}, _tensors{reg},
-      _dynamic_tensor_manager{dynamic_tensor_manager}
+      _dynamic_mem_mgr{dynamic_mem_mgr}
 {
   // DO NOTHING
 }
@@ -42,7 +42,7 @@ void StaticTensorManager::allocateConsts(void)
     auto tensor = pair.second;
     if (_as_constants[ind])
     {
-      auto mem_alloc = _const_mgr->allocate(tensor.get(), tensor->total_size());
+      auto mem_alloc = _const_mgr->allocate(_tensors->getITensor(ind).get(), tensor->total_size());
       tensor->setBuffer(mem_alloc);
       auto buffer = mem_alloc->base();
       VERBOSE(CPU_COMMON_StaticTensorManager) << "CONSTANT TENSOR(#" << ind.value()
@@ -80,7 +80,7 @@ void StaticTensorManager::buildTensor(const ir::OperandIndex &ind,
                                       bool as_const)
 {
   assert(!_tensors->getNativeTensor(ind));
-  auto tensor = std::make_shared<Tensor>(tensor_info, backend_layout, _dynamic_tensor_manager);
+  auto tensor = std::make_shared<Tensor>(tensor_info, backend_layout, _dynamic_mem_mgr);
   _tensors->setNativeTensor(ind, tensor);
   _as_constants[ind] = as_const;
 }

--- a/runtime/onert/core/src/backend/cpu_common/Tensor.cc
+++ b/runtime/onert/core/src/backend/cpu_common/Tensor.cc
@@ -16,6 +16,9 @@
 
 #include "backend/cpu_common/Tensor.h"
 
+#include "ir/DataType.h"
+#include "backend/cpu_common/MemoryManager.h"
+
 namespace onert
 {
 namespace backend
@@ -39,6 +42,55 @@ size_t Tensor::calcOffset(const ir::Coordinates &coords) const
 }
 
 void Tensor::setShape(const ir::Shape &new_shape) { _info.shape(new_shape); }
+
+bool Tensor::applyShape(const ir::Shape &new_shape)
+{
+  bool previously_dynamic = is_dynamic();
+
+  auto allocTensorMem = [&](bool overwrite = false) {
+    auto capacity = total_size();
+    auto alloc = _dynamic_mem_mgr->allocate(this, capacity);
+
+    if (overwrite)
+      overwriteBuffer(alloc);
+    else
+      setBuffer(alloc);
+  };
+
+  if (!previously_dynamic)
+  {
+    // TODO deallocate tensor->buffer()
+    // issue is that staticTensorManager might have allocate this memory
+    setShape(new_shape);
+    set_dynamic();
+    allocTensorMem(true);
+  }
+  else if (buffer() == nullptr)
+  {
+    setShape(new_shape);
+    set_dynamic();
+    allocTensorMem();
+  }
+  // when buffer was already allocated and new_shape requires different size
+  else
+  {
+    auto previous_size = total_size();
+    auto new_size = new_shape.num_elements() * ir::sizeOfDataType(data_type());
+    if (previous_size != new_size)
+    {
+      _dynamic_mem_mgr->deallocate(this);
+
+      setShape(new_shape);
+      set_dynamic();
+      allocTensorMem(true);
+    }
+    else
+    { // when buffer with same size was already allocated, shape could differ
+      setShape(new_shape);
+    }
+  }
+  return true;
+}
 
 } // namespace cpu_common
 } // namespace backend

--- a/runtime/onert/core/src/compiler/ExecutorFactory.cc
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.cc
@@ -212,8 +212,8 @@ ExecutorFactory::initializeModelIOTensors(compiler::LoweredGraph &lowered_graph,
     const auto &operand = lowered_graph.graph().operands().at(ind);
     auto tensor = std::make_shared<backend::controlflow::UserTensor>(
         operand.info(),
-        ir::Layout::NHWC, /* FIXME find op_seq for this operand and use frontend_layout */
-        cf_tensor_builder->dynamicTensorManager());
+        ir::Layout::NHWC /* FIXME find op_seq for this operand and use frontend_layout */
+        );
 
     // Add tensor to controlflow TensorRegistry.
     cf_tensor_reg->setNativeUserTensor(ind, tensor);

--- a/runtime/onert/core/src/exec/DynamicShapeInference.cc
+++ b/runtime/onert/core/src/exec/DynamicShapeInference.cc
@@ -23,14 +23,6 @@ namespace onert
 namespace exec
 {
 
-inline backend::IDynamicTensorManager *
-dynamicTensorManagerOf(const std::shared_ptr<backend::ITensor> &tensor)
-{
-  if (!tensor->dynamic_tensor_manager())
-    throw std::runtime_error{"Dynamic Tensor Manager is not available for this tensor."};
-  return tensor->dynamic_tensor_manager();
-}
-
 void DynamicShapeInferer::handleBinaryArithmeticOp(const ir::Operation &op,
                                                    const ir::OperandIndex lhs_idx,
                                                    const ir::OperandIndex rhs_idx)
@@ -64,7 +56,7 @@ void DynamicShapeInferer::handleBinaryArithmeticOp(const ir::Operation &op,
 
   ir::Shape new_shape = shape_inference::inferEltwiseShape(lhs_shape, rhs_shape);
 
-  dynamicTensorManagerOf(output)->applyShape(output_idx, new_shape);
+  output->applyShape(new_shape);
   assert(output->buffer() != nullptr);
 }
 
@@ -96,7 +88,7 @@ void DynamicShapeInferer::handleSimpleUnaryOp(const ir::Operation &op,
   auto output_ind = op.getOutputs().at(0);
   auto output = _tensor_registry->getITensor(output_ind);
 
-  dynamicTensorManagerOf(output)->applyShape(output_ind, output_shape);
+  output->applyShape(output_shape);
   assert(output->buffer() != nullptr);
 }
 
@@ -122,7 +114,7 @@ void DynamicShapeInferer::visit(const ir::operation::ArgMax &op)
 
   ir::Shape new_shape = shape_inference::inferArgMaxShape(input_shape, axis_value, rank);
 
-  dynamicTensorManagerOf(output)->applyShape(output_ind, new_shape);
+  output->applyShape(new_shape);
   assert(output->buffer() != nullptr);
 }
 
@@ -144,7 +136,7 @@ void DynamicShapeInferer::visit(const ir::operation::BatchMatMul &op)
   // TODO
 
   auto new_shape = shape_inference::inferBatchMatMulShape(lhs_shape, rhs_shape, op.param());
-  dynamicTensorManagerOf(output)->applyShape(output_index, new_shape);
+  output->applyShape(new_shape);
 }
 
 void DynamicShapeInferer::visit(const ir::operation::BinaryArithmetic &op)
@@ -173,7 +165,7 @@ void DynamicShapeInferer::visit(const ir::operation::BroadcastTo &op)
       shape->getShape(), reinterpret_cast<const int32_t *>(shape->buffer()));
 
   // set output shape and output buffer
-  dynamicTensorManagerOf(output)->applyShape(output_ind, output_shape);
+  output->applyShape(output_shape);
   assert(output->buffer() != nullptr);
 }
 
@@ -258,7 +250,7 @@ void DynamicShapeInferer::visit(const ir::operation::Concat &op)
   auto output = _tensor_registry->getITensor(output_ind);
   auto output_shape = shape_inference::inferConcatShape(in_shapes, op.param());
 
-  dynamicTensorManagerOf(output)->applyShape(output_ind, output_shape);
+  output->applyShape(output_shape);
 }
 
 void DynamicShapeInferer::visit(const ir::operation::Conv2D &op)
@@ -281,7 +273,7 @@ void DynamicShapeInferer::visit(const ir::operation::Conv2D &op)
 
   ir::Shape output_shape = shape_inference::inferConv2DShape(input_shape, ker_shape, op.param());
 
-  dynamicTensorManagerOf(output)->applyShape(output_ind, output_shape);
+  output->applyShape(output_shape);
   assert(output->buffer() != nullptr);
 }
 
@@ -341,7 +333,7 @@ void DynamicShapeInferer::visit(const ir::operation::ExpandDims &op)
 
   auto output_shape = shape_inference::inferExpandDimsShape(input_shape, axis_buf[0]);
 
-  dynamicTensorManagerOf(output)->applyShape(output_ind, output_shape);
+  output->applyShape(output_shape);
   assert(output->buffer() != nullptr);
 }
 
@@ -364,7 +356,7 @@ void DynamicShapeInferer::visit(const ir::operation::Fill &op)
 
   auto output_shape = shape_inference::inferFillShape(input_shape, input_buf);
 
-  dynamicTensorManagerOf(output)->applyShape(output_ind, output_shape);
+  output->applyShape(output_shape);
   assert(output->buffer() != nullptr);
 }
 
@@ -387,7 +379,7 @@ void DynamicShapeInferer::visit(const ir::operation::FullyConnected &op)
   auto output_ind = op.getOutputs().at(0);
   auto output = _tensor_registry->getITensor(output_ind);
 
-  dynamicTensorManagerOf(output)->applyShape(output_ind, new_shape);
+  output->applyShape(new_shape);
   assert(output->buffer() != nullptr);
 }
 
@@ -419,7 +411,7 @@ void DynamicShapeInferer::visit(const ir::operation::Gather &op)
   auto output_ind = op.getOutputs().at(0);
   auto output = _tensor_registry->getITensor(output_ind);
 
-  dynamicTensorManagerOf(output)->applyShape(output_ind, new_shape);
+  output->applyShape(new_shape);
   assert(output->buffer() != nullptr);
 }
 
@@ -455,7 +447,7 @@ void DynamicShapeInferer::visit(const ir::operation::OneHot &op)
   const auto axis_val = op.param().axis;
 
   ir::Shape new_shape = shape_inference::inferOnehotShape(indices_shape, *depth_buf, axis_val);
-  dynamicTensorManagerOf(output)->applyShape(output_ind, new_shape);
+  output->applyShape(new_shape);
   assert(output->buffer() != nullptr);
 }
 
@@ -491,7 +483,7 @@ void DynamicShapeInferer::visit(const ir::operation::Pack &op)
 
   ir::Shape new_shape = shape_inference::inferPackShape(input_shape, axis, rank, num);
 
-  dynamicTensorManagerOf(output)->applyShape(output_ind, new_shape);
+  output->applyShape(new_shape);
   assert(output->buffer() != nullptr);
 }
 
@@ -518,7 +510,7 @@ void DynamicShapeInferer::visit(const ir::operation::Pad &op)
       shape_inference::inferPadShape(input->getShape(), pad_buf, pad->getShape().num_elements());
 
   // change output shape and reallocate output tensor memory
-  dynamicTensorManagerOf(output)->applyShape(output_ind, output_shape);
+  output->applyShape(output_shape);
   assert(output->buffer() != nullptr);
 }
 
@@ -570,7 +562,7 @@ void DynamicShapeInferer::visit(const ir::operation::Range &op)
         *reinterpret_cast<int32_t *>(limit_tensor->buffer()),
         *reinterpret_cast<int32_t *>(delta_tensor->buffer()));
   }
-  dynamicTensorManagerOf(output)->applyShape(output_ind, new_shape);
+  output->applyShape(new_shape);
   assert(output->buffer() != nullptr);
 }
 
@@ -614,7 +606,7 @@ void DynamicShapeInferer::visit(const ir::operation::Reduce &op)
 
   ir::Shape new_shape = shape_inference::inferReduceShape(input_shape, axes_vec, keep_dims);
 
-  dynamicTensorManagerOf(output)->applyShape(output_ind, new_shape);
+  output->applyShape(new_shape);
   assert(output->buffer() != nullptr);
 }
 
@@ -668,7 +660,7 @@ void DynamicShapeInferer::visit(const ir::operation::Reshape &op)
     if (output_shape != output->getShape() || output->buffer() == nullptr)
     {
       // change on output shape
-      dynamicTensorManagerOf(output)->applyShape(output_ind, output_shape);
+      output->applyShape(output_shape);
     }
     assert(output->buffer() != nullptr);
   }
@@ -684,7 +676,7 @@ void DynamicShapeInferer::visit(const ir::operation::Reshape &op)
     if (output_shape != output->getShape() || output->buffer() == nullptr)
     {
       // change on output shape
-      dynamicTensorManagerOf(output)->applyShape(output_ind, output_shape);
+      output->applyShape(output_shape);
     }
     assert(output->buffer() != nullptr);
   }
@@ -736,7 +728,7 @@ void DynamicShapeInferer::visit(const ir::operation::ResizeBilinear &op)
   if (output_shape != output->getShape() || output->buffer() == nullptr)
   {
     // change on output shape
-    dynamicTensorManagerOf(output)->applyShape(output_ind, output_shape);
+    output->applyShape(output_shape);
   }
   assert(output->buffer() != nullptr);
 }
@@ -773,7 +765,7 @@ void DynamicShapeInferer::visit(const ir::operation::Select &op)
   auto output_ind = op.getOutputs().at(0);
   auto output = _tensor_registry->getITensor(output_ind);
 
-  dynamicTensorManagerOf(output)->applyShape(output_ind, new_shape);
+  output->applyShape(new_shape);
   assert(output->buffer() != nullptr);
 }
 
@@ -792,7 +784,7 @@ void DynamicShapeInferer::visit(const ir::operation::Shape &op)
   ir::Shape output_shape;
   output_shape.append(input_shape.rank());
 
-  dynamicTensorManagerOf(output)->applyShape(output_ind, output_shape);
+  output->applyShape(output_shape);
   assert(output->buffer() != nullptr);
 }
 
@@ -818,7 +810,7 @@ void DynamicShapeInferer::visit(const ir::operation::Slice &op)
 
   ir::Shape new_shape = shape_inference::inferSliceShape(input_shape, begins_buf, sizes_buf);
 
-  dynamicTensorManagerOf(output)->applyShape(output_index, new_shape);
+  output->applyShape(new_shape);
   assert(output->buffer() != nullptr);
 }
 
@@ -855,7 +847,7 @@ void DynamicShapeInferer::visit(const ir::operation::SpaceToBatchND &op)
   ir::Shape new_shape = shape_inference::inferSpaceToBatchNDShape(
       input_shape, block_shape_shape, padding_shape, block_shape_data, padding_data);
 
-  dynamicTensorManagerOf(output)->applyShape(output_idx, new_shape);
+  output->applyShape(new_shape);
   assert(output->buffer() != nullptr);
 }
 
@@ -894,7 +886,7 @@ void DynamicShapeInferer::visit(const ir::operation::Split &op)
     auto output_ind = op.getOutputs().at(out_tensor_idx);
     auto output = _tensor_registry->getITensor(output_ind);
 
-    dynamicTensorManagerOf(output)->applyShape(output_ind, new_shape);
+    output->applyShape(new_shape);
     assert(output->buffer() != nullptr);
   }
 }
@@ -923,7 +915,7 @@ void DynamicShapeInferer::visit(const ir::operation::Squeeze &op)
   auto output_ind = op.getOutputs().at(0);
   auto output = _tensor_registry->getITensor(output_ind);
 
-  dynamicTensorManagerOf(output)->applyShape(output_ind, new_shape);
+  output->applyShape(new_shape);
   assert(output->buffer() != nullptr);
 }
 
@@ -964,7 +956,7 @@ void DynamicShapeInferer::visit(const ir::operation::StridedSlice &op)
   ir::Shape output_shape =
       onert::shape_inference::inferStridedSliceShape(input_shape, op_params, rank);
 
-  dynamicTensorManagerOf(output)->applyShape(output_index, output_shape);
+  output->applyShape(output_shape);
   assert(output->buffer() != nullptr);
 }
 
@@ -989,7 +981,7 @@ void DynamicShapeInferer::visit(const ir::operation::Tile &op)
   auto output_shape = shape_inference::inferTileShape(input_shape, multiplier_buffer);
 
   // set output shape and output buffer
-  dynamicTensorManagerOf(output)->applyShape(output_ind, output_shape);
+  output->applyShape(output_shape);
   assert(output->buffer() != nullptr);
 }
 
@@ -1042,7 +1034,7 @@ void DynamicShapeInferer::visit(const ir::operation::Transpose &op)
     const auto perm_buffer = reinterpret_cast<const int32_t *>(perm->buffer());
     new_shape = shape_inference::inferTransposeShape(input_shape, perm_buffer, perm->dimension(0));
   }
-  dynamicTensorManagerOf(output)->applyShape(output_ind, new_shape);
+  output->applyShape(new_shape);
   assert(output->buffer() != nullptr);
 }
 
@@ -1070,7 +1062,7 @@ void DynamicShapeInferer::visit(const ir::operation::Unpack &op)
     auto output_ind = op.getOutputs().at(out_tensor_idx);
     auto output = _tensor_registry->getITensor(output_ind);
 
-    dynamicTensorManagerOf(output)->applyShape(output_ind, new_shape);
+    output->applyShape(new_shape);
 
     assert(output->buffer() != nullptr);
   }

--- a/runtime/onert/core/src/exec/ExecutorBase.cc
+++ b/runtime/onert/core/src/exec/ExecutorBase.cc
@@ -222,11 +222,7 @@ void ExecutorBase::handleDynamicInputTensor(ir::IOIndex io_ind, const IODescript
                                "does not support dynamic tensor");
 
     auto changed_input_shape = shape_sig_found->second;
-    auto operand_ind = dyn_alloc_info->second.ind;
-
-    auto dyn_tensor_manager = _input_tensors[io_ind.value()]->dynamic_tensor_manager();
-    assert(dyn_tensor_manager);
-    dyn_tensor_manager->applyShape(operand_ind, changed_input_shape);
+    _input_tensors[io_ind.value()]->applyShape(changed_input_shape);
   }
 }
 

--- a/runtime/onert/core/src/interp/Tensor.h
+++ b/runtime/onert/core/src/interp/Tensor.h
@@ -171,7 +171,6 @@ public:
   int32_t data_offset() const override { return _info.typeInfo().offset(); }
   const ir::OperandInfo &tensorInfo() const override { return _info; }
   uint64_t num_elements() const override { return _info.shape().num_elements(); };
-  backend::IDynamicTensorManager *dynamic_tensor_manager() override { return nullptr; }
 
 private:
   const ir::OperandInfo _info;


### PR DESCRIPTION
Move `applyShape` to `ITensor`.

- Replace `DynamicTensorManager::applyShape` with `ITensor::applyShape`
- `cpu_common::Tensor` now has `DynamicMemoryManager` rather than
  `DynamicTensorManager`
- Remove unused DynamicTensorManager in `controlflow::UserTensor`

After this, we can finally remove `DynAllocInfo` stuff.

Draft : #4175

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>