### PR TITLE
[record-minmax] Handling error when data file is not HDF5

### DIFF
--- a/compiler/record-minmax/src/HDF5Importer.h
+++ b/compiler/record-minmax/src/HDF5Importer.h
@@ -39,9 +39,12 @@ namespace record_minmax
 class HDF5Importer
 {
 public:
-  explicit HDF5Importer(const std::string &path) : _file{path, H5F_ACC_RDONLY}
+  explicit HDF5Importer(const std::string &path)
   {
-    // Do nothing
+    if (_file.isHdf5(path) == false)
+      throw std::runtime_error("Given data file is not HDF5");
+
+    _file = H5::H5File(path, H5F_ACC_RDONLY);
   }
 
 public:


### PR DESCRIPTION
This commit will add error handling code when data file is not HDF5.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>