### PR TITLE
[one-cmds] Fix invalid input arguments

### DIFF
--- a/compiler/one-cmds/one-import-tf
+++ b/compiler/one-cmds/one-import-tf
@@ -145,7 +145,7 @@ if [ -z ${INPUT_PATH} ] || [ ! -e ${INPUT_PATH} ]; then
 fi
 
 if [ -z ${INPUT_ARRAYS} ]; then
-  output_arrays_not_set
+  input_arrays_not_set
 fi
 
 # INPUT_SHAPES is optional

--- a/compiler/one-cmds/one-import-tf
+++ b/compiler/one-cmds/one-import-tf
@@ -38,6 +38,41 @@ version()
   exit 255
 }
 
+input_not_set()
+{
+  echo "Error: input_path not set"
+  echo ""
+  usage
+}
+
+output_not_set()
+{
+  echo "Error: output_path not set"
+  echo ""
+  usage
+}
+
+input_arrays_not_set()
+{
+  echo "Error: input_arrays not set"
+  echo ""
+  usage
+}
+
+input_shapes_not_set()
+{
+  echo "Error: input_shapes not set"
+  echo ""
+  usage
+}
+
+output_arrays_not_set()
+{
+  echo "Error: output_arrays not set"
+  echo ""
+  usage
+}
+
 TF_INTERFACE="--v1"
 
 # Parse command-line arguments
@@ -54,22 +89,37 @@ while [ "$#" -ne 0 ]; do
       ;;
     '--input_path')
       export INPUT_PATH="$2"
+      if [ $# -lt 2 ]; then
+        input_not_set
+      fi
       shift 2
       ;;
     '--output_path')
       export OUTPUT_PATH="$2"
+      if [ $# -lt 2 ]; then
+        output_not_set
+      fi
       shift 2
       ;;
     '--input_arrays')
       export INPUT_ARRAYS="$2"
+      if [ $# -lt 2 ]; then
+        input_arrays_not_set
+      fi
       shift 2
       ;;
     '--input_shapes')
       export INPUT_SHAPES="$2"
+      if [ $# -lt 2 ]; then
+        input_shapes_not_set
+      fi
       shift 2
       ;;
     '--output_arrays')
       export OUTPUT_ARRAYS="$2"
+      if [ $# -lt 2 ]; then
+        output_arrays_not_set
+      fi
       shift 2
       ;;
     '--v2')
@@ -92,6 +142,20 @@ if [ -z ${INPUT_PATH} ] || [ ! -e ${INPUT_PATH} ]; then
   echo ""
   usage
   exit 2
+fi
+
+if [ -z ${INPUT_ARRAYS} ]; then
+  output_arrays_not_set
+fi
+
+# INPUT_SHAPES is optional
+
+if [ -z ${OUTPUT_PATH} ]; then
+  output_not_set
+fi
+
+if [ -z ${OUTPUT_ARRAYS} ]; then
+  output_arrays_not_set
 fi
 
 FILE_BASE=$(basename ${OUTPUT_PATH})

--- a/compiler/one-cmds/one-import-tflite
+++ b/compiler/one-cmds/one-import-tflite
@@ -34,6 +34,20 @@ version()
   exit 255
 }
 
+input_not_set()
+{
+  echo "Error: input_path not set"
+  echo ""
+  usage
+}
+
+output_not_set()
+{
+  echo "Error: output_path not set"
+  echo ""
+  usage
+}
+
 # Parse command-line arguments
 #
 while [ "$#" -ne 0 ]; do
@@ -48,10 +62,16 @@ while [ "$#" -ne 0 ]; do
       ;;
     '--input_path')
       export INPUT_PATH="$2"
+      if [ $# -lt 2 ]; then
+        input_not_set
+      fi
       shift 2
       ;;
     '--output_path')
       export OUTPUT_PATH="$2"
+      if [ $# -lt 2 ]; then
+        output_not_set
+      fi
       shift 2
       ;;
     *)
@@ -65,6 +85,10 @@ if [ -z ${INPUT_PATH} ] || [ ! -e ${INPUT_PATH} ]; then
   echo "Error: input model not found"
   echo ""
   usage
+fi
+
+if [ -z ${OUTPUT_PATH} ]; then
+  output_not_set
 fi
 
 # remove previous log

--- a/compiler/one-cmds/one-pack
+++ b/compiler/one-cmds/one-pack
@@ -34,6 +34,20 @@ version()
   exit 255
 }
 
+input_not_set()
+{
+  echo "Error: input path not set"
+  echo ""
+  usage
+}
+
+output_not_set()
+{
+  echo "Error: output path not set"
+  echo ""
+  usage
+}
+
 # Parse command-line arguments
 #
 while [ "$#" -ne 0 ]; do
@@ -51,10 +65,16 @@ while [ "$#" -ne 0 ]; do
       ;;
     '-i')
       export INPUT_PATH="$2"
+      if [ $# -lt 2 ]; then
+        input_not_set
+      fi
       shift 2
       ;;
     '-o')
       export OUTPUT_PATH="$2"
+      if [ $# -lt 2 ]; then
+        output_not_set
+      fi
       shift 2
       ;;
     *)
@@ -68,6 +88,10 @@ if [ -z ${INPUT_PATH} ] || [ ! -e ${INPUT_PATH} ]; then
   echo "Error: input model not found"
   echo ""
   usage
+fi
+
+if [ -z ${OUTPUT_PATH} ]; then
+  output_not_set
 fi
 
 INPUT_FILE=$(basename "${INPUT_PATH}")


### PR DESCRIPTION
This will fix error handling of invalid input arguments for import-tf, import-tflite and pack

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@samsung.com>