### PR TITLE
[one-cmds] Print error msg when error occurs

### DIFF
--- a/compiler/one-cmds/one-import-bcq
+++ b/compiler/one-cmds/one-import-bcq
@@ -109,6 +109,13 @@ fi
 # remove previous log
 rm -rf "${OUTPUT_PATH}.log"
 
+show_err_onexit()
+{
+  cat "${OUTPUT_PATH}.log"
+}
+
+trap show_err_onexit ERR
+
 # generate temporary preserved pb file
 echo "${DRIVER_PATH}/preserve_bcq_info" --input_path ${INPUT_PATH} \
 --output_path "${TMPDIR}/${MODEL_NAME}_preserved.pb"  > "${OUTPUT_PATH}.log"


### PR DESCRIPTION
This commit will enable printing error message when error occurs

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>