### PR TITLE
[infra/cmake] Remove unused setting SOURCE_GET

### DIFF
--- a/infra/cmake/packages/ARMComputeSourceConfig.cmake
+++ b/infra/cmake/packages/ARMComputeSourceConfig.cmake
@@ -12,7 +12,7 @@ function(_ARMComputeSource_import)
   ExternalSource_Download(ARMCOMPUTE ${ARMCOMPUTE_URL})
 
   set(ARMComputeSource_DIR ${ARMCOMPUTE_SOURCE_DIR} PARENT_SCOPE)
-  set(ARMComputeSource_FOUND ${ARMCOMPUTE_SOURCE_GET} PARENT_SCOPE)
+  set(ARMComputeSource_FOUND TRUE PARENT_SCOPE)
 endfunction(_ARMComputeSource_import)
 
 _ARMComputeSource_import()

--- a/infra/cmake/packages/BoostSourceConfig.cmake
+++ b/infra/cmake/packages/BoostSourceConfig.cmake
@@ -13,7 +13,7 @@ function(_BoostSource_import)
   ExternalSource_Download(BOOST ${BOOST_URL})
 
   set(BoostSource_DIR ${BOOST_SOURCE_DIR} PARENT_SCOPE)
-  set(BoostSource_FOUND ${BOOST_SOURCE_GET} PARENT_SCOPE)
+  set(BoostSource_FOUND TRUE PARENT_SCOPE)
 endfunction(_BoostSource_import)
 
 _BoostSource_import()

--- a/infra/cmake/packages/NoniusSourceConfig.cmake
+++ b/infra/cmake/packages/NoniusSourceConfig.cmake
@@ -20,7 +20,7 @@ function(_NoniusSource_import)
   endif(BUILD_KBENCHMARK)
 
   set(NoniusSource_DIR ${NONIUS_SOURCE_DIR} PARENT_SCOPE)
-  set(NoniusSource_FOUND ${NONIUS_SOURCE_GET} PARENT_SCOPE)
+  set(NoniusSource_FOUND TRUE PARENT_SCOPE)
 endfunction(_NoniusSource_import)
 
 _NoniusSource_import()

--- a/infra/nnfw/cmake/packages/FarmhashSourceConfig.cmake
+++ b/infra/nnfw/cmake/packages/FarmhashSourceConfig.cmake
@@ -13,7 +13,7 @@ function(_FarmhashSource_import)
   ExternalSource_Download("farmhash" ${FARMHASH_URL})
 
   set(FarmhashSource_DIR ${farmhash_SOURCE_DIR} PARENT_SCOPE)
-  set(FarmhashSource_FOUND ${farmhash_SOURCE_GET} PARENT_SCOPE)
+  set(FarmhashSource_FOUND TRUE PARENT_SCOPE)
 endfunction(_FarmhashSource_import)
 
 _FarmhashSource_import()

--- a/infra/nnfw/cmake/packages/GEMMLowpSourceConfig.cmake
+++ b/infra/nnfw/cmake/packages/GEMMLowpSourceConfig.cmake
@@ -13,7 +13,7 @@ function(_GEMMLowpSource_import)
   ExternalSource_Download("gemmlowp" ${GEMMLOWP_URL})
 
   set(GEMMLowpSource_DIR ${gemmlowp_SOURCE_DIR} PARENT_SCOPE)
-  set(GEMMLowpSource_FOUND ${gemmlowp_SOURCE_GET} PARENT_SCOPE)
+  set(GEMMLowpSource_FOUND TRUE PARENT_SCOPE)
 endfunction(_GEMMLowpSource_import)
 
 _GEMMLowpSource_import()

--- a/infra/nnfw/cmake/packages/NEON2SSESourceConfig.cmake
+++ b/infra/nnfw/cmake/packages/NEON2SSESourceConfig.cmake
@@ -13,7 +13,7 @@ function(_NEON2SSESource_import)
   ExternalSource_Download("neon_2_sse" ${NEON2SSE_URL})
 
   set(NEON2SSESource_DIR ${neon_2_sse_SOURCE_DIR} PARENT_SCOPE)
-  set(NEON2SSESource_FOUND ${neon_2_sse_SOURCE_GET} PARENT_SCOPE)
+  set(NEON2SSESource_FOUND TRUE PARENT_SCOPE)
 endfunction(_NEON2SSESource_import)
 
 _NEON2SSESource_import()


### PR DESCRIPTION
Remove deprecated variable using ${PREFIX}_SOURCE_GET

Setting ${PREFIX}_SOURCE_GET was deprecated.
ExternalSource_Download() macro stop if download fail without setting ${PREFIX}_SOURCE_GET

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>