### PR TITLE
[release_tool] fix minor bug

### DIFF
--- a/tools/release_tool/git_release.sh
+++ b/tools/release_tool/git_release.sh
@@ -199,8 +199,9 @@ UPLOAD_URL=$(echo ${UPLOAD_URL} | cut -d "{" -f 1)?name=
 
 # Upload the assets
 for ASSET_PATH in "${ASSET_PATHS[@]}"; do
+  ASSET_BASENAME=$(basename ${ASSET_PATH})
   curl -s --request POST --header "Authorization: token ${USER_TOKEN}" \
   --header "Content-Type: $(file -b --mime-type ${ASSET_PATH})" \
   --data-binary @${ASSET_PATH} \
-  ${UPLOAD_URL}${ASSET_PATH} > /dev/null
+  ${UPLOAD_URL}${ASSET_BASENAME} > /dev/null
 done


### PR DESCRIPTION
This commit fixes minor bug of git_release script.

When we upload an asset, the name of the uploaded asset should be a
basename.

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>