### PR TITLE
[onert] Add an optimized cl kernel for OneHot

### DIFF
--- a/compute/ARMComputeEx/arm_compute/core/CL/kernels/CLOneHotKernel.h
+++ b/compute/ARMComputeEx/arm_compute/core/CL/kernels/CLOneHotKernel.h
@@ -60,7 +60,7 @@ public:
   CLOneHotKernel &operator=(CLOneHotKernel &&) = default;
   /** Default destructor */
   ~CLOneHotKernel() = default;
-  /** Initialise the kernel's inputs and outputs
+  /** Initialise the kernel's inputs and output
    *
    * @param[in]  indices   Indices tensor. Supported tensor rank: up to 3. Must be one of the
    * following types: U32/S32
@@ -75,6 +75,19 @@ public:
    */
   void configure(const ICLTensor *indices, const ICLTensor *on_value, const ICLTensor *off_value,
                  ICLTensor *output, int depth, int axis = -1);
+  /** Initialise the kernel's inputs and output already initialized to off_value
+   *
+   * @param[in]  indices   Indices tensor. Supported tensor rank: up to 3. Must be one of the
+   * following types: U32/S32
+   * @param[in]  on_value  On value tensor. Supported tensor rank: only 1. Data type supported:
+   * U8/S8/U16/S16/F16/U32/S32/F32
+   * @param[out] output    Destination tensor. Data type supported: Same as @p on_value
+   * @param[in]  depth     The depth of the one hot dimension.
+   * @param[in]  axis      (Optional) The axis to fill. Negative values wrap around. Defaults to -1.
+   * value must be in range [-indices.rank , indices.rank)
+   */
+  void configure(const ICLTensor *indices, const ICLTensor *on_value, ICLTensor *output, int depth,
+                 int axis = -1);
   /** Static function to check if given info will lead to a valid configuration of @ref
    * CLOneHotKernel
    *
@@ -94,14 +107,46 @@ public:
   static Status validate(const ITensorInfo *indices, const ITensorInfo *on_value,
                          const ITensorInfo *off_value, const ITensorInfo *output, int depth,
                          int axis = -1);
+  /** Static function to check if given info will lead to a valid configuration of @ref
+   * CLOneHotKernel without off_value
+   *
+   * @param[in]  indices   Indices tensor. Supported tensor rank: up to 3. Must be one of the
+   * following types: U32/S32
+   * @param[in]  on_value  On value tensor. Supported tensor rank: only 1. Data type supported:
+   * U8/S8/U16/S16/F16/U32/S32/F32
+   * @param[in]  output    Destination tensor. Data type supported: Same as @p on_value
+   * @param[in]  depth     The depth of the one hot dimension.
+   * @param[in]  axis      (Optional) The axis to fill. Negative values wrap around. Defaults to -1.
+   * value must be in range [-indices.rank , indices.rank)
+   *
+   * @return a status
+   */
+  static Status validate(const ITensorInfo *indices, const ITensorInfo *on_value,
+                         const ITensorInfo *output, int depth, int axis = -1);
   // Inherited methods overridden:
   void run(const Window &window, cl::CommandQueue &queue) override;
+
+private:
+  /** Initialise the kernel's inputs and outputs internally
+   *
+   * @param[in]  indices   Indices tensor. Supported tensor rank: up to 3. Must be one of the
+   * following types: U32/S32
+   * @param[in]  on_value  On value tensor. Supported tensor rank: only 1. Data type supported:
+   * U8/S8/U16/S16/F16/U32/S32/F32
+   * @param[out] output    Destination tensor. Data type supported: Same as @p on_value
+   * @param[in]  depth     The depth of the one hot dimension.
+   * @param[in]  axis      (Optional) The axis to fill. Negative values wrap around. Defaults to -1.
+   * value must be in range [-indices.rank , indices.rank)
+   */
+  void configure_common(const ICLTensor *indices, const ICLTensor *on_value, ICLTensor *output,
+                        int depth, int axis);
 
 private:
   const ICLTensor *_indices;   /**< Indices tensor */
   const ICLTensor *_on_value;  /**< On value tensor */
   const ICLTensor *_off_value; /**< Off value tensor */
   ICLTensor *_output;          /**< Destination tensor */
+  bool _is_off_value_memset;   /**< Whether off_value is zero */
 };
 } // namespace arm_compute
 #endif /*__ARM_COMPUTE_CLONEHOTKERNEL_H__ */

--- a/compute/ARMComputeEx/src/core/CL/CLKernelLibrary.cpp
+++ b/compute/ARMComputeEx/src/core/CL/CLKernelLibrary.cpp
@@ -66,6 +66,7 @@ const std::map<std::string, std::string> CLKernelLibraryEx::_kernel_program_map 
     {"multiply_scale_factor", "multiply_scale_factor.cl"},
     {"neg_tensor", "neg_tensor.cl"},
     {"one_hot", "one_hot.cl"},
+    {"one_hot_only_on_value", "one_hot.cl"},
     {"quantization_symm8", "quantization_symm8.cl"},
     {"reduce_min_max", "reduce_operation.cl"},
     {"reduce_sum_mean", "reduce_operation.cl"},

--- a/compute/ARMComputeEx/src/core/CL/cl_kernels/one_hot.cl
+++ b/compute/ARMComputeEx/src/core/CL/cl_kernels/one_hot.cl
@@ -41,7 +41,7 @@
 
 #if defined(DATA_TYPE) && defined(AXIS) && defined(OUTPUT_DIM_Z)
 
-/** Performs the Gather operation along the chosen axis
+/** Performs the OneHot operation along the chosen axis
  * @note Datatype should be given as a preprocessor argument using -DDATA_TYPE=type. e.g.
  * -DDATA_TYPE=short
  * @note Axis should be given as a preprocessor argument using -DAXIS=axis. e.g. -DAXIS=1
@@ -131,6 +131,88 @@ __kernel void one_hot(TENSOR3D_DECLARATION(indices), VECTOR_DECLARATION(on_value
   const uint index = *(__global const uint *)tensor3D_offset(&indices, px, py, pz);
   *(__global DATA_TYPE *)output.ptr = index == pw ? *((__global const DATA_TYPE *)on_value_ptr)
                                                   : *((__global const DATA_TYPE *)off_value_ptr);
+#endif // AXIS
+}
+
+/** Performs the OneHot operation along the chosen axis as off_value being zero
+ * @note Datatype should be given as a preprocessor argument using -DDATA_TYPE=type. e.g.
+ * -DDATA_TYPE=short
+ * @note Axis should be given as a preprocessor argument using -DAXIS=axis. e.g. -DAXIS=1
+ * @attention Output tensor depth should be given as a preprocessor argument using
+ * -DOUTPUT_DIM_Z=size. e.g. -DOUTPUT_DIM_Z=16
+ * @attention Input tensor depth should be given as a preprocessor argument using
+ * -DINPUT_DIM_Z=size. e.g. -DINPUT_DIM_Z=16
+ *
+ *
+ * @param[in]  indices_ptr                              Pointer to the source tensor. Supported data
+ * types: S32
+ * @param[in]  indices_stride_x                         Stride of the source tensor in X dimension
+ * (in bytes)
+ * @param[in]  indices_step_x                           indices_stride_x * number of elements along
+ * X processed per work item (in bytes)
+ * @param[in]  indices_stride_y                         Stride of the source tensor in Y dimension
+ * (in bytes)
+ * @param[in]  indices_step_y                           indices_stride_y * number of elements along
+ * Y processed per work item (in bytes)
+ * @param[in]  indices_stride_z                         Stride of the source tensor in Y dimension
+ * (in bytes)
+ * @param[in]  indices_step_z                           indices_stride_z * number of elements along
+ * Z processed per work item (in bytes)
+ * @param[in]  indices_offset_first_element_in_bytes    Offset of the first element in the source
+ * tensor
+ * @param[in]  on_value_ptr                             Pointer to the on_value vector. Supported
+ * data types: U8/S8/U16/S16/F16/U32/S32/F32.
+ * @param[in]  on_value_stride_x                        Stride of the on_value vector in X dimension
+ * (in bytes)
+ * @param[in]  on_value_step_x                          on_value_stride_x * number of elements along
+ * X processed per work item (in bytes)
+ * @param[in]  on_value_offset_first_element_in_bytes   Offset of the first element in the on_value
+ * vector
+ * @param[out] output_ptr                               Pointer to the destination tensor. Supported
+ * data types: same as @p on_value
+ * @param[in]  output_stride_x                          Stride of the destination tensor in X
+ * dimension (in bytes)
+ * @param[in]  output_step_x                            output_stride_x * number of elements along X
+ * processed per work item (in bytes)
+ * @param[in]  output_stride_y                          Stride of the destination tensor in Y
+ * dimension (in bytes)
+ * @param[in]  output_step_y                            output_stride_y * number of elements along Y
+ * processed per work item (in bytes)
+ * @param[in]  output_stride_z                          Stride of the destination tensor in Z
+ * dimension (in bytes)
+ * @param[in]  output_step_z                            output_stride_z * number of elements along Z
+ * processed per work item (in bytes)
+ * @param[in]  output_stride_w                          Stride of the destination tensor in W
+ * dimension (in bytes)
+ * @param[in]  output_step_w                            output_stride_w * number of elements along W
+ * processed per work item (in bytes)
+ * @param[in]  output_offset_first_element_in_bytes     Offset of the first element in the
+ * destination tensor
+ */
+__kernel void one_hot_only_on_value(TENSOR3D_DECLARATION(indices), VECTOR_DECLARATION(on_value),
+                                    TENSOR4D_DECLARATION(output))
+{
+  const int px = get_global_id(0);
+  const int py = get_global_id(1);
+  const int pz = get_global_id(2);
+
+  const Tensor3D indices = CONVERT_TO_TENSOR3D_STRUCT_NO_STEP(indices);
+  const Tensor4D output = CONVERT_TO_TENSOR4D_STRUCT_NO_STEP(output, OUTPUT_DIM_Z);
+
+  const int index = *(__global const int *)tensor3D_offset(&indices, px, py, pz);
+
+#if AXIS == 0
+  *(__global DATA_TYPE *)tensor4D_offset(&output, index, px, py, pz) =
+      *((__global const DATA_TYPE *)on_value_ptr);
+#elif AXIS == 1
+  *(__global DATA_TYPE *)tensor4D_offset(&output, px, index, py, pz) =
+      *((__global const DATA_TYPE *)on_value_ptr);
+#elif AXIS == 2
+  *(__global DATA_TYPE *)tensor4D_offset(&output, px, py, index, pz) =
+      *((__global const DATA_TYPE *)on_value_ptr);
+#elif AXIS == 3
+  *(__global DATA_TYPE *)tensor4D_offset(&output, px, py, pz, index) =
+      *((__global const DATA_TYPE *)on_value_ptr);
 #endif // AXIS
 }
 

--- a/runtime/onert/backend/acl_common/Convert.cc
+++ b/runtime/onert/backend/acl_common/Convert.cc
@@ -335,6 +335,27 @@ arm_compute::ReduceOperation convertReduceType(ir::operation::Reduce::ReduceType
   }
 }
 
+arm_compute::PixelValue asPixelValue(const ir::Operand &operand)
+{
+  assert(operand.isConstant());
+  assert(operand.shape().num_elements() == 1);
+  switch (operand.typeInfo().type())
+  {
+    case ir::DataType::INT32:
+      return arm_compute::PixelValue(operand.asScalar<int32_t>());
+    case ir::DataType::INT64:
+      return arm_compute::PixelValue(operand.asScalar<int64_t>());
+    case ir::DataType::UINT32:
+      return arm_compute::PixelValue(operand.asScalar<uint64_t>());
+    case ir::DataType::UINT8:
+      return arm_compute::PixelValue(operand.asScalar<uint8_t>());
+    case ir::DataType::FLOAT32:
+      return arm_compute::PixelValue(operand.asScalar<float>());
+    default:
+      throw std::runtime_error("asPixelValue : Not supported datatype yet");
+  }
+}
+
 } // namespace acl_common
 } // namespace backend
 } // namespace onert

--- a/runtime/onert/backend/acl_common/Convert.h
+++ b/runtime/onert/backend/acl_common/Convert.h
@@ -17,6 +17,7 @@
 #ifndef __ONERT_BACKEND_ACL_COMMON_CONVERT_H__
 #define __ONERT_BACKEND_ACL_COMMON_CONVERT_H__
 
+#include <arm_compute/core/PixelValue.h>
 #include <arm_compute/core/TensorInfo.h>
 #include <arm_compute/core/SubTensorInfo.h>
 #include <arm_compute/core/TensorShape.h>
@@ -84,6 +85,8 @@ ir::DataType asRuntimeDataType(::arm_compute::DataType data_type);
 
 arm_compute::PoolingType convertPoolType(ir::operation::Pool2D::PoolType pool_type_ir);
 arm_compute::ReduceOperation convertReduceType(ir::operation::Reduce::ReduceType reduce_type_ir);
+
+arm_compute::PixelValue asPixelValue(const ir::Operand &operand);
 
 } // namespace acl_common
 } // namespace backend

--- a/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_neon
+++ b/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_neon
@@ -122,6 +122,7 @@ GeneratedTests.not_equal_dynamic_float_nnfw
 GeneratedTests.one_hot_ex_dynamic_nnfw
 GeneratedTests.one_hot_ex_float_1_nnfw
 GeneratedTests.one_hot_ex_float_2_nnfw
+GeneratedTests.one_hot_ex_float_off_value_constant_zero_nnfw
 GeneratedTests.pack_ex_dynamic_nnfw
 GeneratedTests.pad_dynamic_nnfw
 GeneratedTests.pad_v2_1_float

--- a/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_neon
+++ b/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_neon
@@ -121,6 +121,7 @@ GeneratedTests.not_equal_dynamic_float_nnfw
 GeneratedTests.one_hot_ex_dynamic_nnfw
 GeneratedTests.one_hot_ex_float_1_nnfw
 GeneratedTests.one_hot_ex_float_2_nnfw
+GeneratedTests.one_hot_ex_float_off_value_constant_zero_nnfw
 GeneratedTests.pack_ex_dynamic_nnfw
 GeneratedTests.pad_dynamic_nnfw
 GeneratedTests.pad_v2_1_float

--- a/tests/nnapi/nnapi_gtest.skip.noarch.interp
+++ b/tests/nnapi/nnapi_gtest.skip.noarch.interp
@@ -321,6 +321,7 @@ GeneratedTests.not_equal_simple
 GeneratedTests.one_hot_ex_dynamic_nnfw
 GeneratedTests.one_hot_ex_float_1_nnfw
 GeneratedTests.one_hot_ex_float_2_nnfw
+GeneratedTests.one_hot_ex_float_off_value_constant_zero_nnfw
 GeneratedTests.pack_ex_2D_float_1
 GeneratedTests.pack_ex_2D_float_2
 GeneratedTests.pack_ex_2D_int_1

--- a/tests/nnapi/specs/Ex/one_hot_ex_float_off_value_constant_zero_nnfw.mod.py
+++ b/tests/nnapi/specs/Ex/one_hot_ex_float_off_value_constant_zero_nnfw.mod.py
@@ -1,0 +1,45 @@
+#
+# Copyright (C) 2018 The Android Open Source Project
+# Copyright (C) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+model = Model()
+
+
+indices = Input("indices", "TENSOR_INT32", "{1, 2, 2}")
+depth = Parameter("depth", "TENSOR_INT32", "{1}", [3])
+onvalue = Input("onvalue", "TENSOR_FLOAT32", "{1}")
+offvalue = Parameter("offvalue", "TENSOR_FLOAT32", "{1}", [0.])
+
+axis0 = Int32Scalar("axis", 2) # default value is -1.
+model_output0 = Output("output", "TENSOR_FLOAT32", "{1, 2, 3, 2}")
+
+model0 = model.Operation("ONE_HOT_EX", indices, depth, onvalue, offvalue, axis0).To(model_output0)
+
+model_output_data = ([0., 0., 1., 0., 0., 1.,
+                      1., 0., 0., 0., 0., 1.,])
+
+
+indices_data = [1, 2, 0, 2]
+onvalue_data = [1.]
+
+Example(
+  {
+    indices : indices_data,
+    onvalue : onvalue_data,
+
+    model_output0 : model_output_data,
+  })
+


### PR DESCRIPTION
For issue #4172 

This commit adds an optimaized cl kernel for OneHot with off_value being costant and zero.

Signed-off-by: ragmani <ragmani0216@gmail.com>