### PR TITLE
[onert] Remove DynAllocInfo and related

### DIFF
--- a/runtime/onert/core/include/exec/IExecutor.h
+++ b/runtime/onert/core/include/exec/IExecutor.h
@@ -69,21 +69,6 @@ struct IExecutor
 
 using ExecutorMap = std::unordered_map<ir::SubgraphIndex, std::unique_ptr<IExecutor>>;
 
-// TODO Move this structure to suitable place
-/**
- * @brief Dynamic allocation info for input tensors
- *        When user sets shape of input having unknown dims after compilation, memory for the input
- * should be allocated before executing kernels. This struct contains information to allocate
- * memory.
- */
-struct DynAllocInfo
-{
-  /// @brief index of input tensor whose memory needs to be allocated at execution time
-  ir::OperandIndex ind;
-};
-
-using DynAllocInfoMap = std::unordered_map<std::shared_ptr<backend::ITensor>, DynAllocInfo>;
-
 } // namespace exec
 } // namespace onert
 

--- a/runtime/onert/core/src/backend/controlflow/kernel/IfLayer.cc
+++ b/runtime/onert/core/src/backend/controlflow/kernel/IfLayer.cc
@@ -34,12 +34,10 @@ IfLayer::IfLayer(const std::shared_ptr<backend::ITensor> &cond_tensor,
                  const std::vector<std::shared_ptr<backend::ITensor>> input_tensors,
                  const std::vector<std::shared_ptr<backend::ITensor>> output_tensors,
                  const ir::OperandIndexSequence &output_indices, const ir::Graph &graph,
-                 const exec::DynAllocInfoMap &outputs_dyn_alloc_info,
                  const ir::SubgraphIndex &then_subg_index, const ir::SubgraphIndex &else_subg_index,
                  exec::ExecutorMap *executor_map)
     : _cond_tensor{cond_tensor}, _input_tensors{input_tensors}, _output_tensors{output_tensors},
-      _output_indices{output_indices}, _graph{graph},
-      _outputs_dyn_alloc_info{outputs_dyn_alloc_info}, _then_subg_index{then_subg_index},
+      _output_indices{output_indices}, _graph{graph}, _then_subg_index{then_subg_index},
       _else_subg_index{else_subg_index}, _executor_map{executor_map}
 {
   // At this point, executor_map may not have executors of then subg and else subg
@@ -94,9 +92,8 @@ void IfLayer::run()
       dst_tensors.emplace_back(subg_exec->getInputTensors().at(i));
     }
   }
-  const auto &subg_inputs_dyn_alloc_info = subg_exec->getInputsDynamicAllocInfo();
   const auto permute_op_input_to_subg_input =
-      std::make_shared<PermuteLayer>(src_tensors, dst_tensors, subg_inputs_dyn_alloc_info);
+      std::make_shared<PermuteLayer>(src_tensors, dst_tensors);
 
   // Add tensors used as output of operation or contained in outputs of operation
   src_tensors.clear();
@@ -114,7 +111,7 @@ void IfLayer::run()
     }
   }
   const auto permute_subg_output_to_op_output =
-      std::make_shared<PermuteLayer>(src_tensors, dst_tensors, _outputs_dyn_alloc_info);
+      std::make_shared<PermuteLayer>(src_tensors, dst_tensors);
 
   // Remove copying of unused tensor
   permute_op_input_to_subg_input->prepare();

--- a/runtime/onert/core/src/backend/controlflow/kernel/IfLayer.h
+++ b/runtime/onert/core/src/backend/controlflow/kernel/IfLayer.h
@@ -36,7 +36,6 @@ public:
           const std::vector<std::shared_ptr<backend::ITensor>> input_tensors,
           const std::vector<std::shared_ptr<backend::ITensor>> output_tensors,
           const ir::OperandIndexSequence &output_indices, const ir::Graph &graph,
-          const exec::DynAllocInfoMap &outputs_dyn_alloc_info,
           const ir::SubgraphIndex &then_subg_index, const ir::SubgraphIndex &else_subg_index,
           exec::ExecutorMap *executor_map);
 
@@ -49,7 +48,6 @@ private:
   const std::vector<std::shared_ptr<backend::ITensor>> _output_tensors;
   const ir::OperandIndexSequence &_output_indices;
   const ir::Graph &_graph;
-  const exec::DynAllocInfoMap _outputs_dyn_alloc_info;
   const ir::SubgraphIndex _then_subg_index;
   const ir::SubgraphIndex _else_subg_index;
   exec::ExecutorMap *_executor_map;

--- a/runtime/onert/core/src/backend/controlflow/kernel/PermuteLayer.h
+++ b/runtime/onert/core/src/backend/controlflow/kernel/PermuteLayer.h
@@ -34,9 +34,7 @@ class PermuteLayer : public onert::exec::IPermuteFunction
 {
 public:
   PermuteLayer(const std::vector<std::shared_ptr<ITensor>> &src_tensors,
-               const std::vector<std::shared_ptr<ITensor>> &dst_tensors,
-               const exec::DynAllocInfoMap &dst_dyn_alloc_info_map)
-      : _dst_dyn_alloc_info_map{dst_dyn_alloc_info_map}
+               const std::vector<std::shared_ptr<ITensor>> &dst_tensors)
   {
     assert(src_tensors.size() == dst_tensors.size());
     _src_tensors = src_tensors;
@@ -64,9 +62,6 @@ public:
   }
 
   void run() override;
-
-private:
-  const exec::DynAllocInfoMap _dst_dyn_alloc_info_map;
 };
 
 } // namespace kernel

--- a/runtime/onert/core/src/backend/controlflow/kernel/WhileLayer.cc
+++ b/runtime/onert/core/src/backend/controlflow/kernel/WhileLayer.cc
@@ -33,13 +33,11 @@ namespace kernel
 WhileLayer::WhileLayer(const std::vector<std::shared_ptr<backend::ITensor>> &input_tensors,
                        const std::vector<std::shared_ptr<backend::ITensor>> &output_tensors,
                        const ir::OperandIndexSequence &output_indices, const ir::Graph &graph,
-                       const exec::DynAllocInfoMap &outputs_dyn_alloc_info,
                        const ir::SubgraphIndex &cond_subg_index,
                        const ir::SubgraphIndex &body_subg_index, exec::ExecutorMap *executor_map)
     : _cond_subg_index{cond_subg_index}, _body_subg_index{body_subg_index},
       _output_indices{output_indices}, _graph{graph}, _input_tensors{input_tensors},
-      _output_tensors{output_tensors}, _outputs_dyn_alloc_info{outputs_dyn_alloc_info},
-      _executor_map{executor_map}
+      _output_tensors{output_tensors}, _executor_map{executor_map}
 {
   // At this point, executor_map may not have executors of cond subg and body subg
 }
@@ -62,9 +60,7 @@ void WhileLayer::run()
       _executor_map->at(_body_subg_index).get());
 
   const auto &cond_graph = cond_exec->graph();
-  const auto &cond_inputs_dyn_alloc = cond_exec->getInputsDynamicAllocInfo();
   const auto &body_graph = body_exec->graph();
-  const auto &body_inputs_dyn_alloc = body_exec->getInputsDynamicAllocInfo();
 
   std::vector<std::shared_ptr<backend::ITensor>> input_tensors;
   std::vector<std::shared_ptr<backend::ITensor>> cond_input_tensors;
@@ -85,7 +81,7 @@ void WhileLayer::run()
     }
   }
   const auto permute_op_input_to_cond_input =
-      std::make_shared<PermuteLayer>(input_tensors, cond_input_tensors, cond_inputs_dyn_alloc);
+      std::make_shared<PermuteLayer>(input_tensors, cond_input_tensors);
 
   // Add only used tensors among outputs of while operation
   assert(_output_indices.size() == _input_tensors.size());
@@ -103,7 +99,7 @@ void WhileLayer::run()
     }
   }
   const auto permute_op_input_to_op_output =
-      std::make_shared<PermuteLayer>(input_tensors, output_tensors, _outputs_dyn_alloc_info);
+      std::make_shared<PermuteLayer>(input_tensors, output_tensors);
 
   // Add all tensors with unused tensors in body subgraph because unused input tensors will be
   // copied output tensors in body subgraph
@@ -111,7 +107,7 @@ void WhileLayer::run()
   input_tensors = _input_tensors;
   body_input_tensors = body_exec->getInputTensors();
   const auto permute_op_input_to_body_input =
-      std::make_shared<PermuteLayer>(input_tensors, body_input_tensors, body_inputs_dyn_alloc);
+      std::make_shared<PermuteLayer>(input_tensors, body_input_tensors);
 
   // Add only used tensors in cond subgraph
   assert(cond_graph.getInputs().size() == body_exec->getOutputTensors().size());
@@ -127,8 +123,8 @@ void WhileLayer::run()
       cond_input_tensors.emplace_back(cond_exec->getInputTensors().at(i));
     }
   }
-  const auto permute_body_output_to_cond_input = std::make_shared<PermuteLayer>(
-      body_output_tensors, cond_input_tensors, cond_inputs_dyn_alloc);
+  const auto permute_body_output_to_cond_input =
+      std::make_shared<PermuteLayer>(body_output_tensors, cond_input_tensors);
 
   // Add only used tensors in body subgraph
   assert(body_graph.getInputs().size() == body_exec->getOutputTensors().size());
@@ -146,8 +142,8 @@ void WhileLayer::run()
       body_input_tensors.emplace_back(body_exec->getInputTensors().at(i));
     }
   }
-  const auto permute_body_output_to_body_input = std::make_shared<PermuteLayer>(
-      body_output_tensors, body_input_tensors, body_inputs_dyn_alloc);
+  const auto permute_body_output_to_body_input =
+      std::make_shared<PermuteLayer>(body_output_tensors, body_input_tensors);
 
   // Add only used tensors among outputs of while operation
   assert(_output_indices.size() == body_exec->getOutputTensors().size());
@@ -165,7 +161,7 @@ void WhileLayer::run()
     }
   }
   const auto permute_body_output_to_op_output =
-      std::make_shared<PermuteLayer>(body_output_tensors, output_tensors, _outputs_dyn_alloc_info);
+      std::make_shared<PermuteLayer>(body_output_tensors, output_tensors);
 
   // Remove copying of unused tensor
   permute_op_input_to_cond_input->prepare();

--- a/runtime/onert/core/src/backend/controlflow/kernel/WhileLayer.h
+++ b/runtime/onert/core/src/backend/controlflow/kernel/WhileLayer.h
@@ -38,7 +38,6 @@ public:
   WhileLayer(const std::vector<std::shared_ptr<backend::ITensor>> &input_tensors,
              const std::vector<std::shared_ptr<backend::ITensor>> &output_tensors,
              const ir::OperandIndexSequence &output_indices, const ir::Graph &graph,
-             const exec::DynAllocInfoMap &outputs_dyn_alloc_info,
              const ir::SubgraphIndex &cond_subg_index, const ir::SubgraphIndex &body_subg_index,
              exec::ExecutorMap *executor_map);
 
@@ -52,7 +51,6 @@ private:
   const ir::Graph &_graph;
   const std::vector<std::shared_ptr<backend::ITensor>> _input_tensors;
   const std::vector<std::shared_ptr<backend::ITensor>> _output_tensors;
-  const exec::DynAllocInfoMap _outputs_dyn_alloc_info;
   exec::ExecutorMap *_executor_map;
 };
 

--- a/runtime/onert/core/src/exec/ExecutorBase.cc
+++ b/runtime/onert/core/src/exec/ExecutorBase.cc
@@ -43,8 +43,6 @@ ExecutorBase::ExecutorBase(std::unique_ptr<compiler::LoweredGraph> &&lowered_gra
       {
         std::shared_ptr<backend::ITensor> tensor = tensor_regs.getITensor(ind);
         assert(tensor != nullptr);
-        DynAllocInfo dyn_alloc_info{ind};
-        _input_to_dyn_alloc_info.emplace(tensor, dyn_alloc_info);
         list.push_back(tensor);
       }
       return list;
@@ -55,33 +53,12 @@ ExecutorBase::ExecutorBase(std::unique_ptr<compiler::LoweredGraph> &&lowered_gra
       {
         std::shared_ptr<backend::ITensor> tensor = tensor_regs.getITensor(ind);
         assert(tensor != nullptr);
-        DynAllocInfo dyn_alloc_info{ind};
-        _output_to_dyn_alloc_info.emplace(tensor, dyn_alloc_info);
         list.push_back(tensor);
       }
       return list;
     };
     _input_tensors = build_input_tensor_list(_graph.getInputs());
     _output_tensors = build_output_tensor_list(_graph.getOutputs());
-  }
-  else
-  {
-    assert(input_tensors.size() == _graph.getInputs().size());
-    assert(output_tensors.size() == _graph.getOutputs().size());
-    for (uint32_t i = 0; i < input_tensors.size(); i++)
-    {
-      auto tensor = input_tensors[i];
-      auto ind = _graph.getInputs().at(i);
-      DynAllocInfo dyn_alloc_info{ind};
-      _input_to_dyn_alloc_info.emplace(tensor, dyn_alloc_info);
-    }
-    for (uint32_t i = 0; i < output_tensors.size(); i++)
-    {
-      auto tensor = output_tensors[i];
-      auto ind = _graph.getOutputs().at(i);
-      DynAllocInfo dyn_alloc_info{ind};
-      _output_to_dyn_alloc_info.emplace(tensor, dyn_alloc_info);
-    }
   }
 }
 
@@ -106,22 +83,12 @@ void ExecutorBase::execute(const std::vector<std::shared_ptr<backend::ITensor>> 
     // If src_tensor or input_tensor is nullptr, pre_fn does not copy the tensors
     if (src_tensor != nullptr && input_tensor != nullptr)
     {
-      auto dyn_alloc_info = _input_to_dyn_alloc_info.find(_input_tensors[n]);
       const auto orig_input_shape = input_tensor->getShape();
       const auto changed_input_shape =
           convertShape(src_tensor->getShape(), src_tensor->layout(), input_tensor->layout());
       if (orig_input_shape != changed_input_shape)
       {
-        if (dyn_alloc_info == _input_to_dyn_alloc_info.end())
-        {
-          // The input_tensor is a dynamic tensor of backend that doesn't support dynamic tensor
-          throw std::runtime_error("Unknown dim is found at execution time for a backend that "
-                                   "does not support dynamic tensor");
-        }
-        else
-        {
-          input_tensor->set_dynamic();
-        }
+        input_tensor->set_dynamic();
       }
     }
   }
@@ -216,11 +183,6 @@ void ExecutorBase::handleDynamicInputTensor(ir::IOIndex io_ind, const IODescript
   auto shape_sig_found = desc.dynamic_input_shapes.find(io_ind);
   if (shape_sig_found != desc.dynamic_input_shapes.end())
   {
-    auto dyn_alloc_info = _input_to_dyn_alloc_info.find(_input_tensors[io_ind.value()]);
-    if (dyn_alloc_info == _input_to_dyn_alloc_info.end())
-      throw std::runtime_error("Unknown dim is found at execution time for a backend that "
-                               "does not support dynamic tensor");
-
     auto changed_input_shape = shape_sig_found->second;
     _input_tensors[io_ind.value()]->applyShape(changed_input_shape);
   }

--- a/runtime/onert/core/src/exec/ExecutorBase.h
+++ b/runtime/onert/core/src/exec/ExecutorBase.h
@@ -90,8 +90,6 @@ public:
     return _output_tensors;
   }
 
-  const DynAllocInfoMap &getInputsDynamicAllocInfo() const { return _input_to_dyn_alloc_info; }
-
 protected:
   /**
    * @brief Returns @c true if any input tensor is dynamic; @c false if all are static tensors
@@ -105,8 +103,6 @@ protected:
   const ir::Graph &_graph;
   std::vector<std::shared_ptr<backend::ITensor>> _input_tensors;
   std::vector<std::shared_ptr<backend::ITensor>> _output_tensors;
-  DynAllocInfoMap _input_to_dyn_alloc_info;
-  DynAllocInfoMap _output_to_dyn_alloc_info;
   std::mutex _mutex;
 
 private:


### PR DESCRIPTION
Now that we do not need to keep indices for dynamic tensor allocation,
we can remove DynAllocInfo and related stuff.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>