### PR TITLE
[luci-interpreter] Restrict quantization helpers to integer types

### DIFF
--- a/compiler/luci-interpreter/src/kernels/TestUtils.h
+++ b/compiler/luci-interpreter/src/kernels/TestUtils.h
@@ -85,7 +85,7 @@ std::vector<::testing::Matcher<float>> ArrayFloatNear(const std::vector<float> &
 template <typename T>
 std::vector<T> quantize(const std::vector<float> &data, float scale, int32_t zero_point)
 {
-  assert(!std::is_floating_point<T>::value);
+  static_assert(std::is_integral<T>::value, "Integral type expected.");
   std::vector<T> q;
   for (const auto &f : data)
   {
@@ -99,7 +99,7 @@ std::vector<T> quantize(const std::vector<float> &data, float scale, int32_t zer
 template <typename T>
 std::vector<float> dequantize(const std::vector<T> &data, float scale, int32_t zero_point)
 {
-  assert(!std::is_floating_point<T>::value);
+  static_assert(std::is_integral<T>::value, "Integral type expected.");
   std::vector<float> f;
   for (const T &q : data)
   {
@@ -110,10 +110,7 @@ std::vector<float> dequantize(const std::vector<T> &data, float scale, int32_t z
 
 template <typename T> std::pair<float, int32_t> quantizationParams(float f_min, float f_max)
 {
-  if (std::is_floating_point<T>::value)
-  {
-    return {1.0f, 0};
-  }
+  static_assert(std::is_integral<T>::value, "Integral type expected.");
   int32_t zero_point = 0;
   float scale = 0;
   const T qmin = std::numeric_limits<T>::lowest();


### PR DESCRIPTION
Restrict `quantize`, `dequantize`, `quantizationParams` helper functions to work with integral types only.

ONE-DCO-1.0-Signed-off-by: Sergei Barannikov <s.barannikov@samsung.com>