### PR TITLE
[luci-interpreter] Add a helper to dequantize tensor data

### DIFF
--- a/compiler/luci-interpreter/src/kernels/Add.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/Add.test.cpp
@@ -71,8 +71,7 @@ TEST(AddTest, Uint8)
     kernel.configure();
     kernel.execute();
 
-    EXPECT_THAT(dequantize<uint8_t>(extractTensorData<uint8_t>(output_tensor),
-                                    output_tensor.scale(), output_tensor.zero_point()),
+    EXPECT_THAT(dequantizeTensorData(output_tensor),
                 ElementsAreArray(ArrayFloatNear(output_data[i], kQuantizedTolerance)));
     EXPECT_THAT(extractTensorShape(output_tensor), ::testing::ElementsAreArray(output_shapes[i]));
   }
@@ -93,8 +92,7 @@ TEST(AddTest, Uint8)
     kernel.configure();
     kernel.execute();
 
-    EXPECT_THAT(dequantize<uint8_t>(extractTensorData<uint8_t>(output_tensor),
-                                    output_tensor.scale(), output_tensor.zero_point()),
+    EXPECT_THAT(dequantizeTensorData(output_tensor),
                 ElementsAreArray(ArrayFloatNear(output_data[i], kQuantizedTolerance)));
     EXPECT_THAT(extractTensorShape(output_tensor), ::testing::ElementsAreArray(output_shapes[i]));
   }

--- a/compiler/luci-interpreter/src/kernels/AveragePool2D.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/AveragePool2D.test.cpp
@@ -81,9 +81,7 @@ TEST(AveragePool2DTest, Uint8_0)
   kernel.configure();
   kernel.execute();
 
-  EXPECT_THAT(dequantize(extractTensorData<uint8_t>(output_tensor), output_tensor.scale(),
-                         output_tensor.zero_point()),
-              ElementsAreArray(ArrayFloatNear({0.0, 6.0})));
+  EXPECT_THAT(dequantizeTensorData(output_tensor), ElementsAreArray(ArrayFloatNear({0.0, 6.0})));
   EXPECT_THAT(extractTensorShape(output_tensor), ::testing::ElementsAreArray({1, 1, 2, 1}));
 }
 
@@ -111,9 +109,7 @@ TEST(AveragePool2DTest, Uint8_1)
   kernel.configure();
   kernel.execute();
 
-  EXPECT_THAT(dequantize(extractTensorData<uint8_t>(output_tensor), output_tensor.scale(),
-                         output_tensor.zero_point()),
-              ElementsAreArray(ArrayFloatNear({2.75, 6.0})));
+  EXPECT_THAT(dequantizeTensorData(output_tensor), ElementsAreArray(ArrayFloatNear({2.75, 6.0})));
   EXPECT_THAT(extractTensorShape(output_tensor), ::testing::ElementsAreArray({1, 1, 2, 1}));
 }
 

--- a/compiler/luci-interpreter/src/kernels/Conv2D.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/Conv2D.test.cpp
@@ -167,8 +167,7 @@ TEST(Conv2DTest, Uint8)
       37, 4, 3, // second batch, right
   };
   std::vector<int32_t> ref_output_shape{2, 1, 2, 3};
-  EXPECT_THAT(dequantize<uint8_t>(extractTensorData<uint8_t>(output_tensor),
-                                  output_quant_param.first, output_quant_param.second),
+  EXPECT_THAT(dequantizeTensorData(output_tensor),
               ElementsAreArray(ArrayFloatNear(ref_output_data)));
   EXPECT_THAT(extractTensorShape(output_tensor), ::testing::ElementsAreArray(ref_output_shape));
 }

--- a/compiler/luci-interpreter/src/kernels/DepthwiseConv2D.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/DepthwiseConv2D.test.cpp
@@ -115,8 +115,7 @@ TEST(DepthwiseConv2DTest, Uint8)
       71, -34, 99,  -20, //
       91, -26, 127, -4,  //
   };
-  EXPECT_THAT(dequantize(extractTensorData<uint8_t>(output_tensor), output_tensor.scale(),
-                         output_tensor.zero_point()),
+  EXPECT_THAT(dequantizeTensorData(output_tensor),
               ElementsAreArray(ArrayFloatNear(ref_output_data)));
   EXPECT_THAT(extractTensorShape(output_tensor), ::testing::ElementsAreArray({1, 2, 1, 4}));
 }

--- a/compiler/luci-interpreter/src/kernels/FullyConnected.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/FullyConnected.test.cpp
@@ -75,8 +75,7 @@ void Check<uint8_t>(
   kernel.execute();
 
   EXPECT_THAT(extractTensorShape(output_tensor), ::testing::ElementsAreArray(output_shape));
-  EXPECT_THAT(dequantize(extractTensorData<uint8_t>(output_tensor), output_tensor.scale(),
-                         output_tensor.zero_point()),
+  EXPECT_THAT(dequantizeTensorData(output_tensor),
               ElementsAreArray(ArrayFloatNear(output_data, quantized_tolerance)));
 }
 

--- a/compiler/luci-interpreter/src/kernels/LogSoftmax.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/LogSoftmax.test.cpp
@@ -72,8 +72,7 @@ TEST(LogSoftmaxTest, Uint8)
       -7.00104, -12.00104, -.00104087, -9.00104, //
   };
   std::vector<int32_t> ref_output_shape{2, 4};
-  EXPECT_THAT(dequantize<uint8_t>(extractTensorData<uint8_t>(output_tensor), output_tensor.scale(),
-                                  output_tensor.zero_point()),
+  EXPECT_THAT(dequantizeTensorData(output_tensor),
               ElementsAreArray(ArrayFloatNear(ref_output_data, kLogSoftmaxQuantizedTolerance)));
   EXPECT_THAT(extractTensorShape(output_tensor), ::testing::ElementsAreArray(ref_output_shape));
   EXPECT_THAT(extractTensorData<uint8_t>(output_tensor),

--- a/compiler/luci-interpreter/src/kernels/MaxPool2D.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/MaxPool2D.test.cpp
@@ -84,8 +84,7 @@ TEST(MaxPool2DTest, Uint8)
 
   std::vector<float> ref_output_data{0.0, 6.0};
   std::initializer_list<int32_t> ref_output_shape{1, 1, 2, 1};
-  EXPECT_THAT(dequantize<uint8_t>(extractTensorData<uint8_t>(output_tensor), output_tensor.scale(),
-                                  output_tensor.zero_point()),
+  EXPECT_THAT(dequantizeTensorData(output_tensor),
               ElementsAreArray(ArrayFloatNear(ref_output_data)));
   EXPECT_THAT(extractTensorShape(output_tensor), ::testing::ElementsAreArray(ref_output_shape));
 }

--- a/compiler/luci-interpreter/src/kernels/Mean.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/Mean.test.cpp
@@ -123,8 +123,7 @@ TEST(MeanTest, Uint8KeepDims)
 
   std::vector<float> ref_output_data{0.3, 0.35, 0.55};
   std::initializer_list<int32_t> ref_output_shape{3, 1};
-  EXPECT_THAT(dequantize<uint8_t>(extractTensorData<uint8_t>(output_tensor), output_tensor.scale(),
-                                  output_tensor.zero_point()),
+  EXPECT_THAT(dequantizeTensorData(output_tensor),
               ElementsAreArray(ArrayFloatNear(ref_output_data, kQuantizedTolerance)));
   EXPECT_THAT(extractTensorShape(output_tensor), ::testing::ElementsAreArray(ref_output_shape));
 }
@@ -150,8 +149,7 @@ TEST(MeanTest, Uint8NotKeepDims)
 
   std::vector<float> ref_output_data{0.4, 0.4};
   std::initializer_list<int32_t> ref_output_shape{1, 2};
-  EXPECT_THAT(dequantize<uint8_t>(extractTensorData<uint8_t>(output_tensor), output_tensor.scale(),
-                                  output_tensor.zero_point()),
+  EXPECT_THAT(dequantizeTensorData(output_tensor),
               ElementsAreArray(ArrayFloatNear(ref_output_data, kQuantizedTolerance)));
   EXPECT_THAT(extractTensorShape(output_tensor), ::testing::ElementsAreArray(ref_output_shape));
 }

--- a/compiler/luci-interpreter/src/kernels/Pad.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/Pad.test.cpp
@@ -45,8 +45,7 @@ TEST(Pad, Uint8)
 
   std::vector<float> ref_output_data{0, -0.8, 0.2, 0.9, 0, 0, 0, 0, 0.7, 0.1, -0.3, 0, 0, 0,
                                      0, 0,    0,   0,   0, 0, 0, 0, 0,   0,   0,    0, 0, 0};
-  EXPECT_THAT(dequantize(extractTensorData<uint8_t>(output_tensor), output_tensor.scale(),
-                         output_tensor.zero_point()),
+  EXPECT_THAT(dequantizeTensorData(output_tensor),
               ElementsAreArray(ArrayFloatNear(ref_output_data, kQuantizedTolerance)));
   EXPECT_THAT(extractTensorShape(output_tensor), ::testing::ElementsAreArray({1, 4, 7, 1}));
 }

--- a/compiler/luci-interpreter/src/kernels/Prelu.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/Prelu.test.cpp
@@ -114,8 +114,7 @@ TEST(PreluTest, Uint8Simple)
   kernel.configure();
   kernel.execute();
 
-  EXPECT_THAT(dequantize(extractTensorData<uint8_t>(output_tensor), output_tensor.scale(),
-                         output_tensor.zero_point()),
+  EXPECT_THAT(dequantizeTensorData(output_tensor),
               ElementsAreArray(ArrayFloatNear(ref_output_data, kQuantizedTolerance)));
   EXPECT_THAT(extractTensorShape(output_tensor), ::testing::ElementsAreArray({1, 2, 3, 1}));
 
@@ -158,8 +157,7 @@ TEST(PreluTest, Uint8Broadcast)
   kernel.configure();
   kernel.execute();
 
-  EXPECT_THAT(dequantize(extractTensorData<uint8_t>(output_tensor), output_tensor.scale(),
-                         output_tensor.zero_point()),
+  EXPECT_THAT(dequantizeTensorData(output_tensor),
               ElementsAreArray(ArrayFloatNear(ref_output_data, kQuantizedTolerance)));
   EXPECT_THAT(extractTensorShape(output_tensor), ::testing::ElementsAreArray({1, 2, 2, 3}));
   EXPECT_THAT(extractTensorData<uint8_t>(output_tensor),

--- a/compiler/luci-interpreter/src/kernels/Relu.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/Relu.test.cpp
@@ -73,9 +73,8 @@ TEST(ReluTest, Uint8Quantized)
   EXPECT_THAT(extractTensorShape(output_tensor), ::testing::ElementsAreArray({1, 2, 4, 1}));
   EXPECT_THAT(extractTensorData<uint8_t>(output_tensor),
               ::testing::ElementsAreArray({128, 128, 160, 192, 176, 128, 240, 144}));
-  EXPECT_THAT(
-      dequantize(extractTensorData<uint8_t>(output_tensor), quant_param.first, quant_param.second),
-      ElementsAreArray(ArrayFloatNear({0, 0, 2, 4, 3, 0, 7, 1})));
+  EXPECT_THAT(dequantizeTensorData(output_tensor),
+              ElementsAreArray(ArrayFloatNear({0, 0, 2, 4, 3, 0, 7, 1})));
 }
 
 TEST(ReluTest, Uint8Requantized)
@@ -105,8 +104,7 @@ TEST(ReluTest, Uint8Requantized)
   EXPECT_THAT(extractTensorShape(output_tensor), ::testing::ElementsAreArray({1, 2, 4, 1}));
   EXPECT_THAT(extractTensorData<uint8_t>(output_tensor),
               ::testing::ElementsAreArray({0, 0, 64, 128, 96, 0, 224, 32}));
-  EXPECT_THAT(dequantize(extractTensorData<uint8_t>(output_tensor), quant_output.first,
-                         quant_output.second),
+  EXPECT_THAT(dequantizeTensorData(output_tensor),
               ElementsAreArray(ArrayFloatNear({0, 0, 2, 4, 3, 0, 7, 1})));
 }
 

--- a/compiler/luci-interpreter/src/kernels/Relu6.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/Relu6.test.cpp
@@ -75,9 +75,8 @@ TEST(Relu6Test, Uint8Quantized)
   EXPECT_THAT(extractTensorShape(output_tensor), ::testing::ElementsAreArray({1, 2, 4, 1}));
   EXPECT_THAT(extractTensorData<uint8_t>(output_tensor),
               ::testing::ElementsAreArray({128, 128, 154, 205, 128, 166, 205, 141}));
-  EXPECT_THAT(
-      dequantize(extractTensorData<uint8_t>(output_tensor), quant_param.first, quant_param.second),
-      ElementsAreArray(ArrayFloatNear({0, 0, 2, 6, 0, 3, 6, 1}, tolerance)));
+  EXPECT_THAT(dequantizeTensorData(output_tensor),
+              ElementsAreArray(ArrayFloatNear({0, 0, 2, 6, 0, 3, 6, 1}, tolerance)));
 }
 
 TEST(Relu6Test, Uint8Requantized)
@@ -108,8 +107,7 @@ TEST(Relu6Test, Uint8Requantized)
   EXPECT_THAT(extractTensorShape(output_tensor), ::testing::ElementsAreArray({1, 2, 4, 1}));
   EXPECT_THAT(extractTensorData<uint8_t>(output_tensor),
               ::testing::ElementsAreArray({0, 0, 87, 255, 0, 127, 255, 43}));
-  EXPECT_THAT(dequantize(extractTensorData<uint8_t>(output_tensor), quant_output.first,
-                         quant_output.second),
+  EXPECT_THAT(dequantizeTensorData(output_tensor),
               ElementsAreArray(ArrayFloatNear({0, 0, 2, 6, 0, 3, 6, 1}, tolerance)));
 }
 

--- a/compiler/luci-interpreter/src/kernels/ResizeBilinear.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/ResizeBilinear.test.cpp
@@ -73,8 +73,7 @@ void Check<uint8_t>(std::initializer_list<int32_t> input_shape,
   kernel.execute();
 
   EXPECT_THAT(extractTensorShape(output_tensor), ::testing::ElementsAreArray(output_shape));
-  EXPECT_THAT(dequantize(extractTensorData<uint8_t>(output_tensor), output_tensor.scale(),
-                         output_tensor.zero_point()),
+  EXPECT_THAT(dequantizeTensorData(output_tensor),
               ElementsAreArray(ArrayFloatNear(output_data, output_tensor.scale())));
 }
 

--- a/compiler/luci-interpreter/src/kernels/ResizeNearestNeighbor.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/ResizeNearestNeighbor.test.cpp
@@ -75,8 +75,7 @@ void Check<uint8_t>(std::initializer_list<int32_t> input_shape,
   kernel.execute();
 
   EXPECT_THAT(extractTensorShape(output_tensor), ::testing::ElementsAreArray(output_shape));
-  EXPECT_THAT(dequantize<uint8_t>(extractTensorData<uint8_t>(output_tensor), output_tensor.scale(),
-                                  output_tensor.zero_point()),
+  EXPECT_THAT(dequantizeTensorData(output_tensor),
               ElementsAreArray(ArrayFloatNear(output_data, output_tensor.scale())));
 }
 

--- a/compiler/luci-interpreter/src/kernels/StridedSlice.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/StridedSlice.test.cpp
@@ -91,9 +91,7 @@ TEST(StridedSliceTest, Uint8)
 
   std::vector<int32_t> output_shape{3, 2};
   std::vector<float> output_data{1, 2, 3, 4, 5, 6};
-  EXPECT_THAT(dequantize(extractTensorData<uint8_t>(output_tensor), output_tensor.scale(),
-                         output_tensor.zero_point()),
-              ElementsAreArray(ArrayFloatNear(output_data)));
+  EXPECT_THAT(dequantizeTensorData(output_tensor), ElementsAreArray(ArrayFloatNear(output_data)));
   EXPECT_THAT(extractTensorShape(output_tensor), ::testing::ElementsAreArray(output_shape));
 }
 

--- a/compiler/luci-interpreter/src/kernels/Tanh.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/Tanh.test.cpp
@@ -94,8 +94,7 @@ TEST(TanhTest, Uint8)
       -0.999329, -0.96402,  0.99999,  0.76159,  //
   };
   std::vector<int32_t> ref_output_shape{2, 6, 4, 1};
-  EXPECT_THAT(dequantize<uint8_t>(extractTensorData<uint8_t>(output_tensor), output_tensor.scale(),
-                                  output_tensor.zero_point()),
+  EXPECT_THAT(dequantizeTensorData(output_tensor),
               ElementsAreArray(ArrayFloatNear(ref_output_data, kTanhTolerance)));
   EXPECT_THAT(extractTensorShape(output_tensor), ::testing::ElementsAreArray(ref_output_shape));
 }

--- a/compiler/luci-interpreter/src/kernels/TestUtils.cpp
+++ b/compiler/luci-interpreter/src/kernels/TestUtils.cpp
@@ -34,6 +34,12 @@ Tensor makeOutputTensor(DataType element_type, float scale, int32_t zero_point)
   return Tensor(element_type, {}, {{scale}, {zero_point}}, "");
 }
 
+std::vector<float> dequantizeTensorData(const Tensor &tensor)
+{
+  assert(tensor.element_type() == DataType::U8);
+  return dequantize(extractTensorData<uint8_t>(tensor), tensor.scale(), tensor.zero_point());
+}
+
 std::vector<Matcher<float>> ArrayFloatNear(const std::vector<float> &values, float max_abs_error)
 {
   std::vector<Matcher<float>> matchers;

--- a/compiler/luci-interpreter/src/kernels/TestUtils.h
+++ b/compiler/luci-interpreter/src/kernels/TestUtils.h
@@ -79,6 +79,8 @@ template <typename T> std::vector<T> extractTensorData(const Tensor &tensor)
   return std::vector<T>(data_ptr, data_ptr + tensor.shape().num_elements());
 }
 
+std::vector<float> dequantizeTensorData(const Tensor &tensor);
+
 std::vector<::testing::Matcher<float>> ArrayFloatNear(const std::vector<float> &values,
                                                       float max_abs_error = 1.0e-5f);
 


### PR DESCRIPTION
Add `dequantizeTensorData` helper to use in tests.

ONE-DCO-1.0-Signed-off-by: Sergei Barannikov <s.barannikov@samsung.com>