### PR TITLE
[onert] Remove unused method in controlflow::TensorBuilder

### DIFF
--- a/runtime/onert/core/src/backend/controlflow/TensorBuilder.cc
+++ b/runtime/onert/core/src/backend/controlflow/TensorBuilder.cc
@@ -111,12 +111,6 @@ std::shared_ptr<cpu_common::Tensor> TensorBuilder::nativeOwnTensorAt(const ir::O
   return _tensor_reg->getNativeOwnTensor(ind);
 }
 
-void TensorBuilder::setNativeUserTensor(const ir::OperandIndex &ind,
-                                        const std::shared_ptr<UserTensor> &tensor)
-{
-  _tensor_reg->setNativeUserTensor(ind, tensor);
-}
-
 } // namespace controlflow
 } // namespace backend
 } // namespace onert

--- a/runtime/onert/core/src/backend/controlflow/TensorBuilder.h
+++ b/runtime/onert/core/src/backend/controlflow/TensorBuilder.h
@@ -68,7 +68,6 @@ public:
    * @return shared_ptr<operand::Tensor>
    */
   std::shared_ptr<cpu_common::Tensor> nativeOwnTensorAt(const ir::OperandIndex &ind);
-  void setNativeUserTensor(const ir::OperandIndex &ind, const std::shared_ptr<UserTensor> &tensor);
 
 private:
   const std::shared_ptr<TensorRegistry> _tensor_reg;


### PR DESCRIPTION
This removes unused method : `controlflow::TensorBuilder::setNativeUserTensor()`.

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>