### PR TITLE
[onert] DotDumper : Always show In/Out tensors

### DIFF
--- a/runtime/onert/core/src/dumper/dot/DotDumper.cc
+++ b/runtime/onert/core/src/dumper/dot/DotDumper.cc
@@ -81,11 +81,8 @@ void DotDumper::dump(const std::string &tag)
     }
     else
     {
-      showing_cond = !object.isConstant();
-    }
-    if (object.isConstant() || _graph.getInputs().contains(index))
-    {
-      showing_cond = showing_cond && (object.getUses().size() > 0);
+      showing_cond =
+          !object.isConstant() || (_graph.getInputs() + _graph.getOutputs()).contains(index);
     }
     if (showing_cond)
     {


### PR DESCRIPTION
Always show In/Out tensors, especially when a output tensor is const.

Fix #4094

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>