### PR TITLE
[luci] Fix test warnings

### DIFF
--- a/compiler/luci/lang/src/Nodes/CircleSparseToDense.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleSparseToDense.test.cpp
@@ -33,7 +33,7 @@ TEST(CircleSparseToDenseTest, constructor)
   ASSERT_EQ(nullptr, stb_node.values());
   ASSERT_EQ(nullptr, stb_node.default_value());
 
-  ASSERT_EQ(false, stb_node.validate_indices());
+  ASSERT_FALSE(stb_node.validate_indices());
 }
 
 TEST(CircleSparseToDenseTest, input_NEG)

--- a/compiler/luci/lang/src/Nodes/CircleSum.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleSum.test.cpp
@@ -30,7 +30,7 @@ TEST(CircleSumTest, constructor_P)
 
   ASSERT_EQ(nullptr, sum_node.input());
   ASSERT_EQ(nullptr, sum_node.reduction_indices());
-  ASSERT_EQ(false, sum_node.keep_dims());
+  ASSERT_FALSE(sum_node.keep_dims());
 }
 
 TEST(CircleSumTest, input_NEG)


### PR DESCRIPTION
This will fix 'gtest-internal.h:133:55: warning: converting ‘false’ to pointer type for argument 1' warnings

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>