### PR TITLE
[onert] Fix when changing input shape many times

### DIFF
--- a/runtime/onert/core/src/exec/Execution.cc
+++ b/runtime/onert/core/src/exec/Execution.cc
@@ -34,10 +34,6 @@ Execution::Execution(const std::shared_ptr<ExecutorMap> &executors) : _executors
 
 void Execution::changeInputShape(const ir::IOIndex &index, const ir::Shape &new_shape)
 {
-  // This should be called BEFORE setInput.
-  if (_io_desc.inputs.at(index.value()) != 0)
-    throw std::runtime_error("Error in calling order");
-
   // This will be used later to set input tensor dynamic
   // Note that 'compiled' model will not be updated with new_shape
   // but new_shape will change model input shape while 'running' the model

--- a/tests/nnfw_api/src/ValidationTestAddSessionPrepared.cc
+++ b/tests/nnfw_api/src/ValidationTestAddSessionPrepared.cc
@@ -39,6 +39,28 @@ TEST_F(ValidationTestAddSessionPrepared, run_twice)
   ASSERT_FLOAT_EQ(_output[0], 7.0);
 }
 
+TEST_F(ValidationTestAddSessionPrepared, run_many_times_dynamic_input)
+{
+  for (int v = 1; v <= 5; v++) // 5 times with different shapes
+  {
+    nnfw_tensorinfo ti_input = {NNFW_TYPE_TENSOR_FLOAT32, 4, {1, 1, 1, v}};
+    SetInOutBuffersDynamic(&ti_input);
+
+    for (int i = 0; i < v; i++)
+      _input[i] = i * 10.0;
+
+    NNFW_ENSURE_SUCCESS(nnfw_run(_session));
+
+    // Check if the shape inference is correct
+    nnfw_tensorinfo ti_output;
+    ASSERT_EQ(nnfw_output_tensorinfo(_session, 0, &ti_output), NNFW_STATUS_NO_ERROR);
+    EXPECT_EQ(num_elems(&ti_input), num_elems(&ti_output));
+
+    for (int i = 0; i < v; i++)
+      ASSERT_FLOAT_EQ(_output[i], i * 10.0 + 2.0) << "i : " << i;
+  }
+}
+
 TEST_F(ValidationTestAddSessionPrepared, run_async)
 {
   SetInOutBuffers();

--- a/tests/nnfw_api/src/fixtures.h
+++ b/tests/nnfw_api/src/fixtures.h
@@ -126,6 +126,21 @@ protected:
               NNFW_STATUS_NO_ERROR);
   }
 
+  void SetInOutBuffersDynamic(const nnfw_tensorinfo *ti_input)
+  {
+    NNFW_ENSURE_SUCCESS(nnfw_set_input_tensorinfo(_session, 0, ti_input));
+    uint64_t input_elements = num_elems(ti_input);
+    _input.resize(input_elements);
+    ASSERT_EQ(
+        nnfw_set_input(_session, 0, ti_input->dtype, _input.data(), sizeof(float) * input_elements),
+        NNFW_STATUS_NO_ERROR);
+
+    _output.resize(40000); // Give sufficient size for the output
+    ASSERT_EQ(nnfw_set_output(_session, 0, ti_input->dtype, _output.data(),
+                              sizeof(float) * _output.size()),
+              NNFW_STATUS_NO_ERROR);
+  }
+
 protected:
   std::vector<float> _input;
   std::vector<float> _output;


### PR DESCRIPTION
When input shapes were changed more than twice for a session, an
exception is was thrown. This commit fixes it.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>