### PR TITLE
[onert] Refines disabling applied dimension correction

### DIFF
--- a/compute/ARMComputeEx/arm_compute/core/NEON/kernels/NEGatherKernelEx.h
+++ b/compute/ARMComputeEx/arm_compute/core/NEON/kernels/NEGatherKernelEx.h
@@ -126,6 +126,7 @@ private:
   const ITensor *_input;
   const ITensor *_indices;
   int _axis;
+  size_t _indices_rank;
   ITensor *_output;
   kernel_ptr _func;
 };

--- a/runtime/onert/backend/acl_cl/KernelGenerator.cc
+++ b/runtime/onert/backend/acl_cl/KernelGenerator.cc
@@ -524,13 +524,10 @@ void KernelGenerator::visit(const ir::operation::StridedSlice &node)
   }
 
   // Disable applied dim_correction
-  const auto orig_input_shape = inputData_tensor->info()->tensor_shape();
-  if (starts_set.num_dimensions() != inputData_tensor->info()->num_dimensions())
+  if (inputData_tensor->num_dimensions() != inputData_tensor->info()->num_dimensions())
   {
     // This means that high dimension's value is 1 and input tensor is applied dim_correction
-    const auto input = _ctx.at(input_index);
-    inputData_tensor->info()->set_tensor_shape(
-        acl_common::asTensorShape(input.shape(), _current_op_seq_layout, backend_layout, false));
+    acl_common::disableDimCorrection(inputData_tensor);
   }
 
   auto fn = acl_common::generateLayer<arm_compute::CLStridedSlice>(
@@ -538,7 +535,10 @@ void KernelGenerator::visit(const ir::operation::StridedSlice &node)
       begin_mask, end_mask, shrink_axis_mask);
 
   // Revert disabling applied dim_correction
-  inputData_tensor->info()->set_tensor_shape(orig_input_shape);
+  if (inputData_tensor->dimension(0) == 1)
+  {
+    acl_common::enableDimCorrection(inputData_tensor);
+  }
 
   _return_fn = asAclFunction(std::move(fn));
 }
@@ -833,12 +833,10 @@ void KernelGenerator::visit(const ir::operation::OneHot &node)
   int32_t axis = node.param().axis == -1 ? output_rank - 1 : node.param().axis;
   axis = acl_common::ToARMComputeAxis(output_rank, axis, frontend_layout, backend_layout).value();
 
-  const auto orig_output_acl_tensor_shape = output_tensor->info()->tensor_shape();
-  if (output_rank != output_tensor->info()->num_dimensions())
+  if (output_tensor->num_dimensions() != output_tensor->info()->num_dimensions())
   {
-    // This means that high dimension's value is 1 and ifm tensor is applied dim_correction
-    output_tensor->info()->set_tensor_shape(acl_common::asTensorShape(
-        _ctx.at(output_idx).shape(), _current_op_seq_layout, backend_layout, false));
+    // This means that high dimension's value is 1 and output_tensor is applied dim_correction
+    acl_common::disableDimCorrection(output_tensor);
   }
 
   std::unique_ptr<::arm_compute::IFunction> fn;
@@ -857,7 +855,10 @@ void KernelGenerator::visit(const ir::operation::OneHot &node)
         output_tensor->handle(), static_cast<uint32_t>(depth), axis);
   }
 
-  output_tensor->info()->set_tensor_shape(orig_output_acl_tensor_shape);
+  if (output_tensor->dimension(0) == 1)
+  {
+    acl_common::enableDimCorrection(output_tensor);
+  }
 
   _return_fn = asAclFunction(std::move(fn));
 }
@@ -886,28 +887,26 @@ void KernelGenerator::visit(const ir::operation::Pack &node)
   axis = acl_common::ToARMComputeAxis(output_rank, axis, frontend_layout, backend_layout).value();
 
   // Disable applied dim_correction
-  std::vector<arm_compute::TensorShape> orig_inputs_acl_tensor_shapes;
   for (const auto &input_index : input_indexes)
   {
-    size_t input_rank = _ctx.at(input_index).shape().rank();
     const auto &input_tensor = _tensor_reg->getAclTensor(input_index);
-    orig_inputs_acl_tensor_shapes.emplace_back(input_tensor->info()->tensor_shape());
-    assert(input_rank == input_tensor->num_dimensions());
-    if (input_rank != input_tensor->info()->num_dimensions())
+    if (input_tensor->num_dimensions() != input_tensor->info()->num_dimensions())
     {
-      // This means that high dimension's value is 1 and ifm tensor is applied dim_correction
-      input_tensor->info()->set_tensor_shape(acl_common::asTensorShape(
-          _ctx.at(input_index).shape(), _current_op_seq_layout, backend_layout, false));
+      // This means that high dimension's value is 1 and input tensor is applied dim_correction
+      acl_common::disableDimCorrection(input_tensor);
     }
   }
 
   auto fn = acl_common::generateLayer<arm_compute::CLStackLayer>(inputs, axis, output);
 
   // Revert disabling applied dim_correction
-  assert(inputs.size() == orig_inputs_acl_tensor_shapes.size());
-  for (size_t i = 0; i < inputs.size(); ++i)
+  for (const auto &input_index : input_indexes)
   {
-    inputs.at(i)->info()->set_tensor_shape(orig_inputs_acl_tensor_shapes.at(i));
+    const auto &input_tensor = _tensor_reg->getAclTensor(input_index);
+    if (input_tensor->dimension(0) == 1)
+    {
+      acl_common::enableDimCorrection(input_tensor);
+    }
   }
 
   _return_fn = asAclFunction(std::move(fn));
@@ -1272,29 +1271,29 @@ void KernelGenerator::visit(const ir::operation::Gather &node)
   assert(k == indices_tensor->num_dimensions());
 
   // Disable applied dim_correction
-  const auto orig_ifm_acl_tensor_shape = ifm_tensor->info()->tensor_shape();
   if (n != ifm_tensor->info()->num_dimensions())
   {
     // This means that high dimension's value is 1 and ifm tensor is applied dim_correction
-    const auto ifm = _ctx.at(ifm_index);
-    ifm_tensor->info()->set_tensor_shape(
-        acl_common::asTensorShape(ifm.shape(), _current_op_seq_layout, backend_layout, false));
+    acl_common::disableDimCorrection(ifm_tensor);
   }
-  const auto orig_indice_acl_tensor_shape = indices_tensor->info()->tensor_shape();
   if (k != indices_tensor->info()->num_dimensions())
   {
     // This means that high dimension's value is 1 and indices tensor is applied dim_correction
-    const auto indices = _ctx.at(indices_index);
-    indices_tensor->info()->set_tensor_shape(
-        acl_common::asTensorShape(indices.shape(), _current_op_seq_layout, backend_layout, false));
+    acl_common::disableDimCorrection(indices_tensor);
   }
 
   auto fn = acl_common::generateLayer<arm_compute::CLGatherEx>(
       ifm_tensor->handle(), indices_tensor->handle(), ofm_tensor->handle(), axis);
 
   // Revert disabling applied dim_correction
-  ifm_tensor->info()->set_tensor_shape(orig_ifm_acl_tensor_shape);
-  indices_tensor->info()->set_tensor_shape(orig_indice_acl_tensor_shape);
+  if (ifm_tensor->dimension(0) == 1)
+  {
+    acl_common::enableDimCorrection(ifm_tensor);
+  }
+  if (indices_tensor->dimension(0) == 1)
+  {
+    acl_common::enableDimCorrection(indices_tensor);
+  }
 
   _return_fn = asAclFunction(std::move(fn));
 }
@@ -1431,11 +1430,10 @@ void KernelGenerator::visit(const ir::operation::SplitV &node)
     const auto frontend_layout = _current_op_seq_layout;
     const auto backend_layout = ifm_tensor->layout();
 
-    if (ifm_rank != ifm_tensor->info()->num_dimensions())
+    if (ifm_tensor->num_dimensions() != ifm_tensor->info()->num_dimensions())
     {
       // This means that high dimension's value is 1 and ifm tensor is applied dim_correction
-      ifm_tensor->info()->set_tensor_shape(acl_common::asTensorShape(
-          _ctx.at(ifm_index).shape(), _current_op_seq_layout, backend_layout, false));
+      acl_common::disableDimCorrection(ifm_tensor);
     }
 
     split_dim_revised =
@@ -1443,6 +1441,11 @@ void KernelGenerator::visit(const ir::operation::SplitV &node)
             .value();
     fn->configure(ifm_tensor->handle(), size_split_tensor->handle(), split_dim_revised,
                   output_tensors, node.param().num_splits);
+
+    if (ifm_tensor->dimension(0) == 1)
+    {
+      acl_common::enableDimCorrection(ifm_tensor);
+    }
   }
   else
   {
@@ -1475,22 +1478,27 @@ void KernelGenerator::visit(const ir::operation::Unpack &node)
   axis = acl_common::ToARMComputeAxis(input_rank, axis, frontend_layout, backend_layout).value();
 
   // Disable applied dim_correction
-  std::vector<arm_compute::TensorShape> orig_outputs_acl_tensor_shapes;
   for (const auto &output_index : output_indexes)
   {
-    size_t output_rank = _ctx.at(output_index).shape().rank();
     const auto &output_tensor = _tensor_reg->getAclTensor(output_index);
-    orig_outputs_acl_tensor_shapes.emplace_back(output_tensor->info()->tensor_shape());
-    assert(output_rank == output_tensor->num_dimensions());
-    if (output_rank != output_tensor->info()->num_dimensions())
+    if (output_tensor->num_dimensions() != output_tensor->info()->num_dimensions())
     {
-      // This means that high dimension's value is 1 and ifm tensor is applied dim_correction
-      output_tensor->info()->set_tensor_shape(acl_common::asTensorShape(
-          _ctx.at(output_index).shape(), _current_op_seq_layout, backend_layout, false));
+      // This means that high dimension's value is 1 and output tensor is applied dim_correction
+      acl_common::disableDimCorrection(output_tensor);
     }
   }
 
   auto fn = acl_common::generateLayer<arm_compute::CLUnstack>(input, outputs, axis);
+
+  // Revert disabling applied dim_correction
+  for (const auto &output_index : output_indexes)
+  {
+    const auto &output_tensor = _tensor_reg->getAclTensor(output_index);
+    if (output_tensor->dimension(0) == 1)
+    {
+      acl_common::enableDimCorrection(output_tensor);
+    }
+  }
 
   _return_fn = asAclFunction(std::move(fn));
 }
@@ -1528,21 +1536,26 @@ void KernelGenerator::visit(const ir::operation::Pad &node)
   }
 
   // Disable applied dim_correction
-  size_t input_rank = _ctx.at(input_index).shape().rank();
   const auto &input_tensor = _tensor_reg->getAclTensor(input_index);
-  assert(input_rank == input_tensor->num_dimensions());
-  if (input_rank != input_tensor->info()->num_dimensions())
+  if (input_tensor->num_dimensions() != input_tensor->info()->num_dimensions())
   {
-    // This means that high dimension's value is 1 and ifm tensor is applied dim_correction
-    input_tensor->info()->set_tensor_shape(acl_common::asTensorShape(
-        _ctx.at(input_index).shape(), frontend_layout, backend_layout, false));
+    // This means that high dimension's value is 1 and input tensor is applied dim_correction
+    acl_common::disableDimCorrection(input_tensor);
   }
 
   auto fn =
       acl_common::generateLayer<arm_compute::CLPadLayer>(input, output, padding_list, pixel_value);
 
-  // Do not revert disabling applied dim_correction CLPadKernel has cl kernel for 4-dimension
-  // It would produce a mistach of result
+  // NOTE Do not revert disabling applied dim_correction for 4D.
+  // It would produce a mistach of result by incorrect offset_first_element in
+  // ICLKernel::add_tensor_argument<3>().
+  // We have to disable applied dim_correction and not to revert enabling for the kernel that slices
+  // 4D to 3D because slicing arm_compute::Window can causes incorrect offset_first_element if the
+  // used tensor is 4D and the tensor's high dimention is 1
+  if (input_tensor->num_dimensions() < 4 && input_tensor->dimension(0) == 1)
+  {
+    acl_common::enableDimCorrection(input_tensor);
+  }
 
   _return_fn = asAclFunction(std::move(fn));
 }

--- a/runtime/onert/backend/acl_common/AclKernelGen.h
+++ b/runtime/onert/backend/acl_common/AclKernelGen.h
@@ -30,6 +30,20 @@ namespace backend
 namespace acl_common
 {
 
+void enableDimCorrection(IACLTensor *tensor)
+{
+  size_t input_rank = tensor->num_dimensions();
+  const_cast<arm_compute::TensorShape &>(tensor->info()->tensor_shape())
+      .set(input_rank - 1, tensor->info()->dimension(input_rank - 1), true);
+}
+
+void disableDimCorrection(IACLTensor *tensor)
+{
+  size_t input_rank = tensor->num_dimensions();
+  const_cast<arm_compute::TensorShape &>(tensor->info()->tensor_shape())
+      .set(input_rank - 1, tensor->info()->dimension(input_rank - 1), false);
+}
+
 template <typename Layer, typename... Args>
 std::unique_ptr<arm_compute::IFunction> generateLayer(Args &&... args)
 {

--- a/runtime/onert/backend/acl_common/AclTensorBuilder.h
+++ b/runtime/onert/backend/acl_common/AclTensorBuilder.h
@@ -159,7 +159,6 @@ void AclTensorBuilder<T_ITensor, T_Tensor, T_SubTensor>::registerTensorInfo(
   else
   {
     // SubTensors
-
     assert(!info.isConstant() && "Subtensors of constants are not supported yet.");
 
     // Update offset info and emplace

--- a/tests/nnfw_api/src/one_op_tests/Concat.cc
+++ b/tests/nnfw_api/src/one_op_tests/Concat.cc
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "GenModelTest.h"
+
+#include <memory>
+
+TEST_F(GenModelTest, OneOp_Concat_ShareSubTensor)
+{
+  CircleGen cgen;
+  int lhs = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_FLOAT32});
+  int rhs = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_FLOAT32});
+  int shared_subtensor = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_FLOAT32});
+  int concat_out = cgen.addTensor({{1, 2, 2, 2}, circle::TensorType::TensorType_FLOAT32});
+  std::vector<int32_t> padding_data{0, 0, 1, 1, 1, 1, 0, 0};
+  uint32_t padding_buf = cgen.addBuffer(padding_data);
+  int padding = cgen.addTensor({{4, 2}, circle::TensorType::TensorType_INT32, padding_buf});
+  int pad_out = cgen.addTensor({{1, 4, 4, 1}, circle::TensorType::TensorType_FLOAT32});
+  cgen.addOperatorAdd({{lhs, rhs}, {shared_subtensor}}, circle::ActivationFunctionType_NONE);
+  cgen.addOperatorConcatenation({{rhs, shared_subtensor}, {concat_out}}, 3,
+                                circle::ActivationFunctionType_NONE);
+  cgen.addOperatorPad({{shared_subtensor, padding}, {pad_out}});
+  cgen.setInputsAndOutputs({lhs, rhs}, {pad_out, concat_out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->addTestCase(uniformTCD<float>(
+      {{1, 3, 2, 4}, {5, 4, 7, 4}},
+      {{0, 0, 0, 0, 0, 6, 7, 0, 0, 9, 8, 0, 0, 0, 0, 0}, {5, 6, 4, 7, 7, 9, 4, 8}}));
+  _context->setBackends({"acl_cl", "acl_neon"});
+
+  SUCCEED();
+}


### PR DESCRIPTION
For issue #4244

This commit refines disabling applied dimension correction to prevent bugs by calling set_tensor_shape() of arm_compute::ITensorInfo.
  - Changes the way that disables applied dimension correction from calling set_tensor_shape() to calling set() of arm_compute::TensorShape
  - Unify disabling and enabling applied dimension correction

Signed-off-by: ragmani <ragmani0216@gmail.com>