### PR TITLE
[onert] Throw when output buffer is unset

### DIFF
--- a/runtime/onert/core/src/exec/ExecutorBase.cc
+++ b/runtime/onert/core/src/exec/ExecutorBase.cc
@@ -120,6 +120,7 @@ void ExecutorBase::execute(const IODescription &desc)
       tensor->set_dynamic();
       tensor->setShape(input_shape->second);
     }
+    // TODO Check if (desc.inputs[i] == nullptr)
     // TODO Better design for ITensor? (we need const_cast as ITensor is writable)
     tensor->setBuffer(static_cast<uint8_t *>(const_cast<void *>(desc.inputs[i]->buffer)),
                       desc.inputs[i]->size);
@@ -134,9 +135,9 @@ void ExecutorBase::execute(const IODescription &desc)
     auto tensor = std::dynamic_pointer_cast<backend::controlflow::UserTensor>(_output_tensors[i]);
     assert(tensor);
     tensor->set_dynamic(); // It can't be resized but shape could change
-    // TODO Better design for ITensor? (we need const_cast as ITensor is writable)
-    tensor->setBuffer(static_cast<uint8_t *>(const_cast<void *>(desc.outputs[i]->buffer)),
-                      desc.outputs[i]->size);
+    if (desc.outputs[i] == nullptr)
+      throw std::runtime_error{"Output " + std::to_string(i) + "'s buffer is not set."};
+    tensor->setBuffer(static_cast<uint8_t *>(desc.outputs[i]->buffer), desc.outputs[i]->size);
   }
 
   executeImpl();

--- a/tests/nnfw_api/src/ValidationTestAddSessionPrepared.cc
+++ b/tests/nnfw_api/src/ValidationTestAddSessionPrepared.cc
@@ -161,4 +161,12 @@ TEST_F(ValidationTestAddSessionPrepared, neg_prepare)
   ASSERT_EQ(nnfw_prepare(_session), NNFW_STATUS_INVALID_STATE);
 }
 
+TEST_F(ValidationTestAddSessionPrepared, neg_run_without_set_output)
+{
+  uint8_t input[4];
+  NNFW_ENSURE_SUCCESS(nnfw_set_input(_session, 0, NNFW_TYPE_TENSOR_FLOAT32, input, sizeof(input)));
+  // `nnfw_set_output()` is not called
+  ASSERT_EQ(nnfw_run(_session), NNFW_STATUS_ERROR);
+}
+
 // TODO Validation check when "nnfw_run" is called without input & output tensor setting


### PR DESCRIPTION
Throw when output buffer is unset and this leads to returning error
when trying to `nnfw_run` but `nnfw_set_output` is not called for an
output.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>