### PR TITLE
[preset] Remove deprecated command

### DIFF
--- a/infra/packaging/preset/20200731_windows
+++ b/infra/packaging/preset/20200731_windows
@@ -29,7 +29,6 @@ function preset_configure()
   # TODO Use "nncc configure" and "nncc build"
   cmake \
     -G "MSYS Makefiles" \
-    -DTF2NNPKG_FOR_WINDOWS=ON \
     -DUSE_PROTOBUF_LEGACY_IMPORT=ON \
     -DCMAKE_EXE_LINKER_FLAGS="-Wl,--allow-multiple-definition" \
     -DCMAKE_SHARED_LINKER_FLAGS="-Wl,--allow-multiple-definition" \


### PR DESCRIPTION
This commit removes deprecated command TF2NNPKG_FOR_WINDOWS.

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>