### PR TITLE
[onert] Change shared_ptr for tensors to unique_ptr

### DIFF
--- a/runtime/onert/backend/acl_cl/KernelGenerator.cc
+++ b/runtime/onert/backend/acl_cl/KernelGenerator.cc
@@ -78,9 +78,9 @@ void KernelGenerator::visit(const ir::operation::BatchToSpaceND &node)
   const auto block_size_index{
       node.getInputs().at(ir::operation::BatchToSpaceND::Input::BLOCK_SIZE)};
 
-  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index).get();
-  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index).get();
-  auto block_size_tensor = _tensor_reg->getAclTensor(block_size_index).get();
+  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index);
+  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index);
+  auto block_size_tensor = _tensor_reg->getAclTensor(block_size_index);
 
   assert(_ctx.at(block_size_index).data());
 
@@ -98,9 +98,9 @@ void KernelGenerator::visit(const ir::operation::BinaryArithmetic &node)
 
   const auto activation = node.param().activation;
 
-  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index).get();
-  auto lhs_tensor = _tensor_reg->getAclTensor(lhs_index).get();
-  auto rhs_tensor = _tensor_reg->getAclTensor(rhs_index).get();
+  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index);
+  auto lhs_tensor = _tensor_reg->getAclTensor(lhs_index);
+  auto rhs_tensor = _tensor_reg->getAclTensor(rhs_index);
 
   const auto act_info = acl_common::asActivationLayerInfo(activation);
 
@@ -164,10 +164,10 @@ void KernelGenerator::visit(const ir::operation::Conv2D &node)
                                             ker_width, ker_height);
   const auto activation = node.param().activation;
 
-  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index).get();
-  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index).get();
-  auto ker_tensor = _tensor_reg->getAclTensor(ker_index).get();
-  auto bias_tensor = _tensor_reg->getAclTensor(bias_index).get();
+  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index);
+  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index);
+  auto ker_tensor = _tensor_reg->getAclTensor(ker_index);
+  auto bias_tensor = _tensor_reg->getAclTensor(bias_index);
 
   const auto conv_info = acl_common::asPadStrideInfo(padding, stride);
   const auto act_info = acl_common::asActivationLayerInfo(activation);
@@ -202,10 +202,10 @@ void KernelGenerator::visit(const ir::operation::DepthwiseConv2D &node)
   const auto multiplier = node.param().multiplier;
   const auto activation = node.param().activation;
 
-  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index).get();
-  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index).get();
-  auto ker_tensor = _tensor_reg->getAclTensor(ker_index).get();
-  auto bias_tensor = _tensor_reg->getAclTensor(bias_index).get();
+  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index);
+  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index);
+  auto ker_tensor = _tensor_reg->getAclTensor(ker_index);
+  auto bias_tensor = _tensor_reg->getAclTensor(bias_index);
 
   const auto conv_info = acl_common::asPadStrideInfo(padding, stride);
   const auto act_info = acl_common::asActivationLayerInfo(activation);
@@ -240,7 +240,7 @@ void KernelGenerator::visit(const ir::operation::Concat &node)
     return;
   }
 
-  auto output_tensor = _tensor_reg->getAclTensor(ofm_index).get();
+  auto output_tensor = _tensor_reg->getAclTensor(ofm_index);
   std::vector<::arm_compute::ICLTensor *> input_tensors;
   for (auto &ifm_ind : input_indexes)
     input_tensors.emplace_back(_tensor_reg->getAclTensor(ifm_ind)->handle());
@@ -268,7 +268,7 @@ void KernelGenerator::visit(const ir::operation::Concat &node)
 void KernelGenerator::visit(const ir::operation::FullyConnected &node)
 {
   const auto output_index{node.getOutputs().at(0)};
-  auto output_tensor = _tensor_reg->getAclTensor(output_index).get();
+  auto output_tensor = _tensor_reg->getAclTensor(output_index);
   const auto activation = node.param().activation;
 
   auto fn = acl_common::kernelGenFullyConnected<acl_common::AclFunction, ::arm_compute::ICLTensor,
@@ -286,8 +286,8 @@ void KernelGenerator::visit(const ir::operation::Reduce &node)
   const auto keep_dims{node.param().keep_dims};
   const auto reduce_type = node.param().reduce_type;
 
-  auto output_tensor = _tensor_reg->getAclTensor(output_index).get();
-  auto input_tensor = _tensor_reg->getAclTensor(input_index).get();
+  auto output_tensor = _tensor_reg->getAclTensor(output_index);
+  auto input_tensor = _tensor_reg->getAclTensor(input_index);
 
   // Convert to ACL axes taking into account negative values and possible duplicates.
   const auto &axes = _ctx.at(axes_index);
@@ -320,8 +320,8 @@ void KernelGenerator::visit(const ir::operation::Reshape &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(ir::operation::Reshape::Input::INPUT)};
 
-  auto output_tensor = _tensor_reg->getAclTensor(output_index).get();
-  auto input_tensor = _tensor_reg->getAclTensor(input_index).get();
+  auto output_tensor = _tensor_reg->getAclTensor(output_index);
+  auto input_tensor = _tensor_reg->getAclTensor(input_index);
 
   // NOTE This operation must not be changed the layout from frontend to backend
   //      So, PermutationOperationPass makes layouts of frontend and backend the same.
@@ -351,8 +351,8 @@ void KernelGenerator::visit(const ir::operation::Squeeze &node)
   (void)dims;
   (void)ndim;
 
-  auto output_tensor = _tensor_reg->getAclTensor(output_index).get();
-  auto input_tensor = _tensor_reg->getAclTensor(input_index).get();
+  auto output_tensor = _tensor_reg->getAclTensor(output_index);
+  auto input_tensor = _tensor_reg->getAclTensor(input_index);
   auto fn = acl_common::generateLayer<arm_compute::CLReshapeLayer>(input_tensor->handle(),
                                                                    output_tensor->handle());
   _return_fn = asAclFunction(std::move(fn));
@@ -365,8 +365,8 @@ void KernelGenerator::visit(const ir::operation::Softmax &node)
 
   const auto beta = node.param().beta;
 
-  auto output_tensor = _tensor_reg->getAclTensor(output_index).get();
-  auto input_tensor = _tensor_reg->getAclTensor(input_index).get();
+  auto output_tensor = _tensor_reg->getAclTensor(output_index);
+  auto input_tensor = _tensor_reg->getAclTensor(input_index);
 
   auto fn = acl_common::generateLayer<arm_compute::CLSoftmaxLayer>(
       _tensor_builder->acl_tensor_manager()->internal_buffer_manager(), input_tensor->handle(),
@@ -382,8 +382,8 @@ void KernelGenerator::visit(const ir::operation::Slice &node)
   const auto begins_index{node.getInputs().at(ir::operation::Slice::Input::BEGINS)};
   const auto sizes_index{node.getInputs().at(ir::operation::Slice::Input::SIZES)};
 
-  auto outputData_tensor = _tensor_reg->getAclTensor(output_index).get();
-  auto inputData_tensor = _tensor_reg->getAclTensor(input_index).get();
+  auto outputData_tensor = _tensor_reg->getAclTensor(output_index);
+  auto inputData_tensor = _tensor_reg->getAclTensor(input_index);
   const auto frontend_layout = _current_op_seq_layout;
   const auto backend_layout = inputData_tensor->layout();
 
@@ -449,8 +449,8 @@ void KernelGenerator::visit(const ir::operation::StridedSlice &node)
   const auto ends_index{node.getInputs().at(ir::operation::StridedSlice::Input::ENDS)};
   const auto strides_index{node.getInputs().at(ir::operation::StridedSlice::Input::STRIDES)};
 
-  auto outputData_tensor = _tensor_reg->getAclTensor(output_index).get();
-  auto inputData_tensor = _tensor_reg->getAclTensor(input_index).get();
+  auto outputData_tensor = _tensor_reg->getAclTensor(output_index);
+  auto inputData_tensor = _tensor_reg->getAclTensor(input_index);
   const auto frontend_layout = _current_op_seq_layout;
   const auto backend_layout = inputData_tensor->layout();
 
@@ -551,8 +551,8 @@ void KernelGenerator::visit(const ir::operation::Transpose &node)
 
   const auto rank = _ctx.at(ifm_idx).shape().rank();
 
-  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_idx).get();
-  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_idx).get();
+  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_idx);
+  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_idx);
   const auto frontend_layout = _current_op_seq_layout;
   const auto backend_layout = ifm_tensor->layout();
 
@@ -597,8 +597,8 @@ void KernelGenerator::visit(const ir::operation::ElementwiseActivation &node)
   const auto ofm_index{node.getOutputs().at(0)};
   const auto ifm_index{node.getInputs().at(ir::operation::ElementwiseActivation::Input::INPUT)};
 
-  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index).get();
-  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index).get();
+  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index);
+  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index);
 
   const ::arm_compute::ActivationLayerInfo act_info = acl_common::asActivationLayerInfo(
       node.param().op_type, node.param().alpha, node.param().beta);
@@ -615,9 +615,9 @@ void KernelGenerator::visit(const ir::operation::ElementwiseBinary &node)
   const auto lhs_index{node.getInputs().at(ir::operation::ElementwiseBinary::Input::LHS)};
   const auto rhs_index{node.getInputs().at(ir::operation::ElementwiseBinary::Input::RHS)};
 
-  auto output_tensor = _tensor_reg->getAclTensor(output_index).get();
-  auto lhs_tensor = _tensor_reg->getAclTensor(lhs_index).get();
-  auto rhs_tensor = _tensor_reg->getAclTensor(rhs_index).get();
+  auto output_tensor = _tensor_reg->getAclTensor(output_index);
+  auto lhs_tensor = _tensor_reg->getAclTensor(lhs_index);
+  auto rhs_tensor = _tensor_reg->getAclTensor(rhs_index);
 
   std::unique_ptr<arm_compute::IFunction> fn;
   switch (node.param().op_type)
@@ -664,8 +664,8 @@ void KernelGenerator::visit(const ir::operation::ElementwiseUnary &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(ir::operation::ElementwiseUnary::Input::INPUT)};
 
-  auto output_tensor = _tensor_reg->getAclTensor(output_index).get();
-  auto input_tensor = _tensor_reg->getAclTensor(input_index).get();
+  auto output_tensor = _tensor_reg->getAclTensor(output_index);
+  auto input_tensor = _tensor_reg->getAclTensor(input_index);
 
   std::unique_ptr<arm_compute::IFunction> fn;
   switch (node.param().op_type)
@@ -757,8 +757,8 @@ void KernelGenerator::visit(const ir::operation::ExpandDims &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(ir::operation::ExpandDims::Input::INPUT)};
 
-  auto output_tensor = _tensor_reg->getAclTensor(output_index).get();
-  auto input_tensor = _tensor_reg->getAclTensor(input_index).get();
+  auto output_tensor = _tensor_reg->getAclTensor(output_index);
+  auto input_tensor = _tensor_reg->getAclTensor(input_index);
 
   auto fn = acl_common::generateLayer<arm_compute::CLReshapeLayer>(input_tensor->handle(),
                                                                    output_tensor->handle());
@@ -773,10 +773,10 @@ void KernelGenerator::visit(const ir::operation::InstanceNorm &node)
   const auto gamma_index{node.getInputs().at(ir::operation::InstanceNorm::Input::GAMMA)};
   const auto beta_index{node.getInputs().at(ir::operation::InstanceNorm::Input::BETA)};
 
-  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index).get();
-  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index).get();
-  auto gamma_tensor = _tensor_reg->getAclTensor(gamma_index).get();
-  auto beta_tensor = _tensor_reg->getAclTensor(beta_index).get();
+  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index);
+  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index);
+  auto gamma_tensor = _tensor_reg->getAclTensor(gamma_index);
+  auto beta_tensor = _tensor_reg->getAclTensor(beta_index);
   auto epsilon = node.param().epsilon;
   auto activation = node.param().activation;
 
@@ -802,9 +802,9 @@ void KernelGenerator::visit(const ir::operation::Comparison &node)
 
   const auto comparison_type = node.param().comparison_type;
 
-  auto output_tensor = _tensor_reg->getAclTensor(output_index).get();
-  auto input0_tensor = _tensor_reg->getAclTensor(input0_index).get();
-  auto input1_tensor = _tensor_reg->getAclTensor(input1_index).get();
+  auto output_tensor = _tensor_reg->getAclTensor(output_index);
+  auto input0_tensor = _tensor_reg->getAclTensor(input0_index);
+  auto input1_tensor = _tensor_reg->getAclTensor(input1_index);
 
   auto fn = acl_common::generateLayer<arm_compute::CLComparison>(
       input0_tensor->handle(), input1_tensor->handle(), output_tensor->handle(),
@@ -823,9 +823,9 @@ void KernelGenerator::visit(const ir::operation::OneHot &node)
   const auto depth = _ctx.at(depth_idx).asScalar<int32_t>();
   assert(depth > 0);
 
-  auto output_tensor = _tensor_reg->getAclTensor(output_idx).get();
-  auto indices_tensor = _tensor_reg->getAclTensor(indices_idx).get();
-  auto onvalue_tensor = _tensor_reg->getAclTensor(onvalue_idx).get();
+  auto output_tensor = _tensor_reg->getAclTensor(output_idx);
+  auto indices_tensor = _tensor_reg->getAclTensor(indices_idx);
+  auto onvalue_tensor = _tensor_reg->getAclTensor(onvalue_idx);
 
   const size_t output_rank = _ctx.at(output_idx).shape().rank();
   const auto frontend_layout = _current_op_seq_layout;
@@ -851,7 +851,7 @@ void KernelGenerator::visit(const ir::operation::OneHot &node)
   }
   else
   {
-    auto offvalue_tensor = _tensor_reg->getAclTensor(offvalue_idx).get();
+    auto offvalue_tensor = _tensor_reg->getAclTensor(offvalue_idx);
     fn = acl_common::generateLayer<arm_compute::CLOneHot>(
         indices_tensor->handle(), onvalue_tensor->handle(), offvalue_tensor->handle(),
         output_tensor->handle(), static_cast<uint32_t>(depth), axis);
@@ -873,13 +873,13 @@ void KernelGenerator::visit(const ir::operation::Pack &node)
   for (const auto &input_index : node.getInputs())
     input_indexes.emplace_back(input_index);
 
-  auto output = _tensor_reg->getAclTensor(output_index).get()->handle();
+  auto output = _tensor_reg->getAclTensor(output_index)->handle();
   std::vector<arm_compute::ICLTensor *> inputs;
   for (const auto &input_index : input_indexes)
     inputs.emplace_back(_tensor_reg->getAclTensor(input_index)->handle());
 
   const auto frontend_layout = _current_op_seq_layout;
-  const auto backend_layout = _tensor_reg->getAclTensor(output_index).get()->layout();
+  const auto backend_layout = _tensor_reg->getAclTensor(output_index)->layout();
 
   if (axis < 0)
     axis += output_rank;
@@ -920,7 +920,7 @@ void KernelGenerator::visit(const ir::operation::Pool2D &node)
       acl_common::convertPoolType(node.param().op_type));
 
   const auto ofm_index{node.getOutputs().at(0)};
-  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index).get();
+  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index);
   const auto activation = node.param().activation;
   _return_fn = std::make_unique<exec::FunctionSequence>(
       asAclFunction(std::move(raw_fn)),
@@ -932,8 +932,8 @@ void KernelGenerator::visit(const ir::operation::Permute &node)
   const auto ofm_idx{node.getOutputs().at(0)};
   const auto ifm_idx{node.getInputs().at(0)};
   const auto permute_type = node.getPermuteType();
-  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_idx).get();
-  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_idx).get();
+  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_idx);
+  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_idx);
   const auto rank = _ctx.at(ofm_idx).shape().rank();
   assert(_ctx.at(ifm_idx).shape().rank() == _ctx.at(ofm_idx).shape().rank());
 
@@ -968,8 +968,8 @@ void KernelGenerator::visit(const ir::operation::ResizeBilinear &node)
   const auto ofm_index{node.getOutputs().at(0)};
   const auto ifm_index{node.getInputs().at(ir::operation::ResizeBilinear::Input::INPUT)};
 
-  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index).get();
-  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index).get();
+  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index);
+  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index);
 
   auto fn = acl_common::generateLayer<arm_compute::CLScale>(
       ifm_tensor->handle(), ofm_tensor->handle(), ::arm_compute::InterpolationPolicy::BILINEAR,
@@ -984,8 +984,8 @@ void KernelGenerator::visit(const ir::operation::ResizeNearestNeighbor &node)
   const auto ofm_index{node.getOutputs().at(0)};
   const auto ifm_index{node.getInputs().at(ir::operation::ResizeNearestNeighbor::Input::INPUT)};
 
-  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index).get();
-  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index).get();
+  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index);
+  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index);
 
   auto fn = acl_common::generateLayer<arm_compute::CLScale>(
       ifm_tensor->handle(), ofm_tensor->handle(),
@@ -1010,14 +1010,14 @@ void KernelGenerator::visit(const ir::operation::RNN &node)
 
   const auto activation = node.param().activation;
 
-  auto output_tensor = _tensor_reg->getAclTensor(output_index).get();
-  auto hidden_state_out_tensor = _tensor_reg->getAclTensor(hidden_state_out_index).get();
+  auto output_tensor = _tensor_reg->getAclTensor(output_index);
+  auto hidden_state_out_tensor = _tensor_reg->getAclTensor(hidden_state_out_index);
 
-  auto input_tensor = _tensor_reg->getAclTensor(input_index).get();
-  auto weights_tensor = _tensor_reg->getAclTensor(weights_index).get();
-  auto recurrent_weights_tensor = _tensor_reg->getAclTensor(recurrent_weights_index).get();
-  auto bias_tensor = _tensor_reg->getAclTensor(bias_index).get();
-  auto hidden_state_in_tensor = _tensor_reg->getAclTensor(hidden_state_in_index).get();
+  auto input_tensor = _tensor_reg->getAclTensor(input_index);
+  auto weights_tensor = _tensor_reg->getAclTensor(weights_index);
+  auto recurrent_weights_tensor = _tensor_reg->getAclTensor(recurrent_weights_index);
+  auto bias_tensor = _tensor_reg->getAclTensor(bias_index);
+  auto hidden_state_in_tensor = _tensor_reg->getAclTensor(hidden_state_in_index);
   auto act_info = ::onert::backend::acl_common::asActivationLayerInfo(activation);
 
   auto copy_layer = acl_common::generateLayer<arm_compute::CLCopy>(
@@ -1039,10 +1039,10 @@ void KernelGenerator::visit(const ir::operation::SpaceToBatchND &node)
       node.getInputs().at(ir::operation::SpaceToBatchND::Input::BLOCK_SIZE)};
   const auto paddings_index{node.getInputs().at(ir::operation::SpaceToBatchND::Input::PADDINGS)};
 
-  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index).get();
-  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index).get();
-  auto block_size_tensor = _tensor_reg->getAclTensor(block_size_index).get();
-  auto paddings_tensor = _tensor_reg->getAclTensor(paddings_index).get();
+  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index);
+  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index);
+  auto block_size_tensor = _tensor_reg->getAclTensor(block_size_index);
+  auto paddings_tensor = _tensor_reg->getAclTensor(paddings_index);
 
   assert(_ctx.at(block_size_index).data());
   assert(_ctx.at(paddings_index).data());
@@ -1061,8 +1061,8 @@ void KernelGenerator::visit(const ir::operation::SpaceToDepth &node)
 
   auto block_size = node.param().block_size;
 
-  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index).get();
-  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index).get();
+  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index);
+  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index);
 
   auto fn = acl_common::generateLayer<arm_compute::CLSpaceToDepthLayer>(
       ifm_tensor->handle(), ofm_tensor->handle(), block_size);
@@ -1076,9 +1076,9 @@ void KernelGenerator::visit(const ir::operation::EmbeddingLookup &node)
   const auto lookups_index{node.getInputs().at(ir::operation::EmbeddingLookup::Input::LOOKUPS)};
   const auto values_index{node.getInputs().at(ir::operation::EmbeddingLookup::Input::VALUES)};
 
-  auto output_tensor = _tensor_reg->getAclTensor(output_index).get();
-  auto lookups_tensor = _tensor_reg->getAclTensor(lookups_index).get();
-  auto values_tensor = _tensor_reg->getAclTensor(values_index).get();
+  auto output_tensor = _tensor_reg->getAclTensor(output_index);
+  auto lookups_tensor = _tensor_reg->getAclTensor(lookups_index);
+  auto values_tensor = _tensor_reg->getAclTensor(values_index);
 
   auto fn = acl_common::generateLayer<arm_compute::CLEmbeddingLookup>(
       values_tensor->handle(), output_tensor->handle(), lookups_tensor->handle());
@@ -1105,8 +1105,8 @@ void KernelGenerator::visit(const ir::operation::L2Normalization &node)
   float beta = 0.5f;                             // pow(reduction, -0.5) = 1 / sqrt(reduction)
   float bias = 0.0f;                             // Don't offset the reduction.
 
-  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index).get();
-  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index).get();
+  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index);
+  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index);
 
   const auto norm_info = ::arm_compute::NormalizationLayerInfo(::arm_compute::NormType::CROSS_MAP,
                                                                radius, alpha, beta, bias, false);
@@ -1126,12 +1126,12 @@ void KernelGenerator::visit(const ir::operation::HashtableLookup &node)
   const auto keys_index{node.getInputs().at(ir::operation::HashtableLookup::Input::KEYS)};
   const auto values_index{node.getInputs().at(ir::operation::HashtableLookup::Input::VALUES)};
 
-  auto output_tensor = _tensor_reg->getAclTensor(output_index).get();
-  auto hits_tensor = _tensor_reg->getAclTensor(hits_index).get();
+  auto output_tensor = _tensor_reg->getAclTensor(output_index);
+  auto hits_tensor = _tensor_reg->getAclTensor(hits_index);
 
-  auto lookups_tensor = _tensor_reg->getAclTensor(lookups_index).get();
-  auto keys_tensor = _tensor_reg->getAclTensor(keys_index).get();
-  auto values_tensor = _tensor_reg->getAclTensor(values_index).get();
+  auto lookups_tensor = _tensor_reg->getAclTensor(lookups_index);
+  auto keys_tensor = _tensor_reg->getAclTensor(keys_index);
+  auto values_tensor = _tensor_reg->getAclTensor(values_index);
 
   auto fn = acl_common::generateLayer<arm_compute::CLHashtableLookup>(
       lookups_tensor->handle(), keys_tensor->handle(), values_tensor->handle(),
@@ -1146,9 +1146,9 @@ void KernelGenerator::visit(const ir::operation::PReLU &node)
   const auto ifm_index{node.getInputs().at(ir::operation::PReLU::Input::INPUT)};
   const auto alpha_index{node.getInputs().at(ir::operation::PReLU::Input::ALPHA)};
 
-  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index).get();
-  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index).get();
-  auto alpha_tensor = _tensor_reg->getAclTensor(alpha_index).get();
+  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index);
+  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index);
+  auto alpha_tensor = _tensor_reg->getAclTensor(alpha_index);
 
   auto fn = acl_common::generateLayer<arm_compute::CLPReluLayer>(
       ifm_tensor->handle(), alpha_tensor->handle(), ofm_tensor->handle());
@@ -1181,9 +1181,9 @@ void KernelGenerator::visit(const ir::operation::TransposeConv &node)
     invalid_vertical = ofm_shape.H - (1 + (ifm_shape.H - 1) * stride.vertical) - (ker_shape.H - 1);
   }
 
-  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index).get();
-  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index).get();
-  auto ker_tensor = _tensor_reg->getAclTensor(ker_index).get();
+  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index);
+  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index);
+  auto ker_tensor = _tensor_reg->getAclTensor(ker_index);
 
   const auto tconv_info = acl_common::asPadStrideInfo(padding, stride);
 
@@ -1201,9 +1201,9 @@ void KernelGenerator::visit(const ir::operation::SquaredDifference &node)
   const auto lhs_index{node.getInputs().at(ir::operation::SquaredDifference::Input::LHS)};
   const auto rhs_index{node.getInputs().at(ir::operation::SquaredDifference::Input::RHS)};
 
-  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index).get();
-  auto lhs_tensor = _tensor_reg->getAclTensor(lhs_index).get();
-  auto rhs_tensor = _tensor_reg->getAclTensor(rhs_index).get();
+  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index);
+  auto lhs_tensor = _tensor_reg->getAclTensor(lhs_index);
+  auto rhs_tensor = _tensor_reg->getAclTensor(rhs_index);
 
   auto fn = acl_common::generateLayer<arm_compute::CLElementwiseSquaredDiff>(
       lhs_tensor->handle(), rhs_tensor->handle(), ofm_tensor->handle());
@@ -1225,9 +1225,9 @@ void KernelGenerator::visit(const ir::operation::TopKV2 &node)
 
   const auto k = node.param().k;
 
-  auto values_tensor = _tensor_reg->getAclTensor(outputValues_index).get();
-  auto indices_tensor = _tensor_reg->getAclTensor(outputIndices_index).get();
-  auto input_tensor = _tensor_reg->getAclTensor(inputData_index).get();
+  auto values_tensor = _tensor_reg->getAclTensor(outputValues_index);
+  auto indices_tensor = _tensor_reg->getAclTensor(outputIndices_index);
+  auto input_tensor = _tensor_reg->getAclTensor(inputData_index);
 
   auto fn = acl_common::generateLayer<arm_compute::CLTopKV2>(
       input_tensor->handle(), k, values_tensor->handle(), indices_tensor->handle());
@@ -1247,9 +1247,9 @@ void KernelGenerator::visit(const ir::operation::Gather &node)
   const auto axis_value = (axis_raw < 0 ? (ifm_rank + axis_raw) : axis_raw);
   const int axis = ::onert::backend::acl_common::ToARMComputeAxis(ifm_rank, axis_value).value();
 
-  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index).get();
-  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index).get();
-  auto indices_tensor = _tensor_reg->getAclTensor(indices_index).get();
+  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index);
+  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index);
+  auto indices_tensor = _tensor_reg->getAclTensor(indices_index);
 
   // NOTE The frontend layout and backend layout must be the same for this operation.
   //      If not the same, we have to add a stage(?) to perform permutation of output tensor. It
@@ -1310,8 +1310,8 @@ void KernelGenerator::visit(const ir::operation::ArgMax &node)
 
   assert((ifm_shape.rank() - 1) == ofm_shape.rank());
 
-  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index).get();
-  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index).get();
+  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index);
+  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index);
   const auto ifm_rank = _ctx.at(ifm_index).shape().rank();
   auto frontend_layout = _current_op_seq_layout;
   auto backend_layout = ifm_tensor->layout();
@@ -1343,8 +1343,8 @@ void KernelGenerator::visit(const ir::operation::LocalResponseNormalization &nod
   auto beta = node.param().beta;
   auto bias = node.param().bias;
 
-  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index).get();
-  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index).get();
+  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index);
+  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index);
 
   const auto norm_info = ::arm_compute::NormalizationLayerInfo(
       ::arm_compute::NormType::CROSS_MAP, radius * 2 + 1, alpha, beta, bias, false);
@@ -1363,8 +1363,8 @@ void KernelGenerator::visit(const ir::operation::DepthToSpace &node)
   auto block_size = node.param().block_size;
   assert(block_size > 0);
 
-  auto output_tensor = _tensor_reg->getAclTensor(output_index).get();
-  auto input_tensor = _tensor_reg->getAclTensor(input_index).get();
+  auto output_tensor = _tensor_reg->getAclTensor(output_index);
+  auto input_tensor = _tensor_reg->getAclTensor(input_index);
 
   auto fn = acl_common::generateLayer<arm_compute::CLDepthToSpaceLayer>(
       input_tensor->handle(), output_tensor->handle(), block_size);
@@ -1384,10 +1384,10 @@ void KernelGenerator::visit(const ir::operation::Split &node)
   for (const auto &output : node.getOutputs())
     output_indexes.emplace_back(output);
 
-  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index).get();
+  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index);
   std::vector<arm_compute::ICLTensor *> output_tensors;
   for (const auto &ofm_ind : output_indexes)
-    output_tensors.emplace_back(_tensor_reg->getAclTensor(ofm_ind).get()->handle());
+    output_tensors.emplace_back(_tensor_reg->getAclTensor(ofm_ind)->handle());
 
   const auto frontend_layout = _current_op_seq_layout;
   const auto backend_layout = ifm_tensor->layout();
@@ -1415,12 +1415,12 @@ void KernelGenerator::visit(const ir::operation::SplitV &node)
   for (const auto &output : node.getOutputs())
     output_indexes.emplace_back(output);
 
-  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index).get();
-  auto size_split_tensor = _tensor_reg->getAclTensor(size_split_index).get();
+  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index);
+  auto size_split_tensor = _tensor_reg->getAclTensor(size_split_index);
 
   std::vector<arm_compute::ICLTensor *> output_tensors;
   for (const auto &ofm_ind : output_indexes)
-    output_tensors.emplace_back(_tensor_reg->getAclTensor(ofm_ind).get()->handle());
+    output_tensors.emplace_back(_tensor_reg->getAclTensor(ofm_ind)->handle());
 
   auto fn = std::make_unique<arm_compute::CLSplitVEx>();
   const auto split_dim_op = _ctx.at(split_dim_index);
@@ -1463,13 +1463,13 @@ void KernelGenerator::visit(const ir::operation::Unpack &node)
   for (const auto &output_index : node.getOutputs())
     output_indexes.emplace_back(output_index);
 
-  auto input = _tensor_reg->getAclTensor(input_index).get()->handle();
+  auto input = _tensor_reg->getAclTensor(input_index)->handle();
   std::vector<arm_compute::ICLTensor *> outputs;
   for (const auto &output_index : output_indexes)
     outputs.emplace_back(_tensor_reg->getAclTensor(output_index)->handle());
 
   const auto frontend_layout = _current_op_seq_layout;
-  const auto backend_layout = _tensor_reg->getAclTensor(input_index).get()->layout();
+  const auto backend_layout = _tensor_reg->getAclTensor(input_index)->layout();
   if (axis < 0)
     axis += input_rank;
   axis = acl_common::ToARMComputeAxis(input_rank, axis, frontend_layout, backend_layout).value();
@@ -1510,11 +1510,11 @@ void KernelGenerator::visit(const ir::operation::Pad &node)
   auto quant_info = ::arm_compute::QuantizationInfo(input_type.scale(), input_type.offset());
   const auto pixel_value = ::arm_compute::PixelValue(0, data_type, quant_info);
 
-  auto input = _tensor_reg->getAclTensor(input_index).get()->handle();
-  auto output = _tensor_reg->getAclTensor(output_index).get()->handle();
+  auto input = _tensor_reg->getAclTensor(input_index)->handle();
+  auto output = _tensor_reg->getAclTensor(output_index)->handle();
 
   const auto frontend_layout = _current_op_seq_layout;
-  const auto backend_layout = _tensor_reg->getAclTensor(input_index).get()->layout();
+  const auto backend_layout = _tensor_reg->getAclTensor(input_index)->layout();
 
   ::arm_compute::PaddingList padding_list;
   padding_list.resize(rank);
@@ -1552,8 +1552,8 @@ void KernelGenerator::visit(const ir::operation::ConvertFp32ToFp16 &node)
   const auto ofm_index{node.getOutputs().at(0)};
   const auto ifm_index{node.getInputs().at(ir::operation::ConvertFp32ToFp16::Input::INPUT)};
 
-  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index).get();
-  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index).get();
+  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index);
+  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index);
 
   auto fn = acl_common::generateLayer<arm_compute::CLDepthConvertLayer>(
       ifm_tensor->handle(), ofm_tensor->handle(), ::arm_compute::ConvertPolicy::SATURATE, 0);
@@ -1566,8 +1566,8 @@ void KernelGenerator::visit(const ir::operation::ConvertFp16ToFp32 &node)
   const auto ofm_index{node.getOutputs().at(0)};
   const auto ifm_index{node.getInputs().at(ir::operation::ConvertFp16ToFp32::Input::INPUT)};
 
-  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index).get();
-  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index).get();
+  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index);
+  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index);
 
   auto fn = acl_common::generateLayer<arm_compute::CLDepthConvertLayer>(
       ifm_tensor->handle(), ofm_tensor->handle(), ::arm_compute::ConvertPolicy::SATURATE, 0);

--- a/runtime/onert/backend/acl_common/AclKernelGen.h
+++ b/runtime/onert/backend/acl_common/AclKernelGen.h
@@ -138,30 +138,27 @@ std::unique_ptr<exec::IFunction> kernelGenLSTM(const ir::operation::LSTM &node,
   const auto projection_clip = projection_threshold;
   assert(cell_clip >= 0.f && projection_clip >= 0.f);
 
-  auto scratch_buffer_tensor = tensor_reg->getAclTensor(scratch_buffer_index).get();
-  auto output_state_out_tensor = tensor_reg->getAclTensor(output_state_out_index).get();
-  auto cell_state_out_tensor = tensor_reg->getAclTensor(cell_state_out_index).get();
-  auto output_tensor = tensor_reg->getAclTensor(output_index).get();
+  auto scratch_buffer_tensor = tensor_reg->getAclTensor(scratch_buffer_index);
+  auto output_state_out_tensor = tensor_reg->getAclTensor(output_state_out_index);
+  auto cell_state_out_tensor = tensor_reg->getAclTensor(cell_state_out_index);
+  auto output_tensor = tensor_reg->getAclTensor(output_index);
 
-  auto input_tensor = tensor_reg->getAclTensor(input_index).get();
+  auto input_tensor = tensor_reg->getAclTensor(input_index);
 
-  auto input_to_forget_weights_tensor =
-      tensor_reg->getAclTensor(input_to_forget_weights_index).get();
-  auto input_to_cell_weights_tensor = tensor_reg->getAclTensor(input_to_cell_weights_index).get();
-  auto input_to_output_weights_tensor =
-      tensor_reg->getAclTensor(input_to_output_weights_index).get();
+  auto input_to_forget_weights_tensor = tensor_reg->getAclTensor(input_to_forget_weights_index);
+  auto input_to_cell_weights_tensor = tensor_reg->getAclTensor(input_to_cell_weights_index);
+  auto input_to_output_weights_tensor = tensor_reg->getAclTensor(input_to_output_weights_index);
   auto recurrent_to_forget_weights_tensor =
-      tensor_reg->getAclTensor(recurrent_to_forget_weights_index).get();
-  auto recurrent_to_cell_weights_tensor =
-      tensor_reg->getAclTensor(recurrent_to_cell_weights_index).get();
+      tensor_reg->getAclTensor(recurrent_to_forget_weights_index);
+  auto recurrent_to_cell_weights_tensor = tensor_reg->getAclTensor(recurrent_to_cell_weights_index);
   auto recurrent_to_output_weights_tensor =
-      tensor_reg->getAclTensor(recurrent_to_output_weights_index).get();
+      tensor_reg->getAclTensor(recurrent_to_output_weights_index);
 
-  auto forget_gate_bias_tensor = tensor_reg->getAclTensor(forget_gate_bias_index).get();
-  auto cell_bias_tensor = tensor_reg->getAclTensor(cell_bias_index).get();
-  auto output_gate_bias_tensor = tensor_reg->getAclTensor(output_gate_bias_index).get();
-  auto output_state_in_tensor = tensor_reg->getAclTensor(output_state_in_index).get();
-  auto cell_state_in_tensor = tensor_reg->getAclTensor(cell_state_in_index).get();
+  auto forget_gate_bias_tensor = tensor_reg->getAclTensor(forget_gate_bias_index);
+  auto cell_bias_tensor = tensor_reg->getAclTensor(cell_bias_index);
+  auto output_gate_bias_tensor = tensor_reg->getAclTensor(output_gate_bias_index);
+  auto output_state_in_tensor = tensor_reg->getAclTensor(output_state_in_index);
+  auto cell_state_in_tensor = tensor_reg->getAclTensor(cell_state_in_index);
 
   auto act_info = asActivationLayerInfo(activation);
 
@@ -169,13 +166,13 @@ std::unique_ptr<exec::IFunction> kernelGenLSTM(const ir::operation::LSTM &node,
   if (has_cifg_param)
   {
     auto input_to_input_weights_tensor =
-        tensor_reg->getAclTensor(input_to_input_weights_index).get(); // optional
+        tensor_reg->getAclTensor(input_to_input_weights_index); // optional
     auto recurrent_to_input_weights_tensor =
-        tensor_reg->getAclTensor(recurrent_to_input_weights_index).get(); // optional
+        tensor_reg->getAclTensor(recurrent_to_input_weights_index); // optional
     auto cell_to_input_weights_handle =
-        has_peephole_param ? tensor_reg->getAclTensor(cell_to_input_weights_index).get()->handle()
+        has_peephole_param ? tensor_reg->getAclTensor(cell_to_input_weights_index)->handle()
                            : nullptr; // optional (non-cifg && peephole)
-    auto input_gate_bias_tensor = tensor_reg->getAclTensor(input_gate_bias_index).get(); // optional
+    auto input_gate_bias_tensor = tensor_reg->getAclTensor(input_gate_bias_index); // optional
     lstm_params.set_cifg_params(input_to_input_weights_tensor->handle(),
                                 recurrent_to_input_weights_tensor->handle(),
                                 cell_to_input_weights_handle, input_gate_bias_tensor->handle());
@@ -183,19 +180,18 @@ std::unique_ptr<exec::IFunction> kernelGenLSTM(const ir::operation::LSTM &node,
   if (has_peephole_param)
   {
     auto cell_to_forget_weights_tensor =
-        tensor_reg->getAclTensor(cell_to_forget_weights_index).get(); // optional
+        tensor_reg->getAclTensor(cell_to_forget_weights_index); // optional
     auto cell_to_output_weights_tensor =
-        tensor_reg->getAclTensor(cell_to_output_weights_index).get(); // optional
+        tensor_reg->getAclTensor(cell_to_output_weights_index); // optional
     lstm_params.set_peephole_params(cell_to_forget_weights_tensor->handle(),
                                     cell_to_output_weights_tensor->handle());
   }
   if (has_projection_param)
   {
-    auto projection_weights_tensor =
-        tensor_reg->getAclTensor(projection_weights_index).get(); // optional
-    auto projection_bias_handle =
-        has_projection_bias ? tensor_reg->getAclTensor(projection_bias_index).get()->handle()
-                            : nullptr; // optional
+    auto projection_weights_tensor = tensor_reg->getAclTensor(projection_weights_index); // optional
+    auto projection_bias_handle = has_projection_bias
+                                      ? tensor_reg->getAclTensor(projection_bias_index)->handle()
+                                      : nullptr; // optional
     lstm_params.set_projection_params(projection_weights_tensor->handle(), projection_bias_handle);
   }
 
@@ -260,10 +256,10 @@ kernelGenFullyConnected(const ir::operation::FullyConnected &node, const ir::Ope
     reshape.dim(1) = input_size; /* W */
   }
 
-  auto output_tensor = tensor_reg->getAclTensor(output_index).get();
-  const auto input_tensor = tensor_reg->getAclTensor(input_index).get();
-  const auto weight_tensor = tensor_reg->getAclTensor(weight_index).get();
-  const auto bias_tensor = tensor_reg->getAclTensor(bias_index).get();
+  auto output_tensor = tensor_reg->getAclTensor(output_index);
+  const auto input_tensor = tensor_reg->getAclTensor(input_index);
+  const auto weight_tensor = tensor_reg->getAclTensor(weight_index);
+  const auto bias_tensor = tensor_reg->getAclTensor(bias_index);
   const auto frontend_layout = layout;
   const auto acl_layout = output_tensor->handle()->info()->data_layout();
 
@@ -313,8 +309,8 @@ kernelGenPool2D(const T_PoolOp &node, const ir::Operands &operands,
   VERBOSE(Pool2DParam) << "PAD(L): " << padding.left << std::endl;
   VERBOSE(Pool2DParam) << "PAD(R): " << padding.right << std::endl;
 
-  auto ofm_tensor = tensor_reg->getAclTensor(ofm_index).get();
-  auto ifm_tensor = tensor_reg->getAclTensor(ifm_index).get();
+  auto ofm_tensor = tensor_reg->getAclTensor(ofm_index);
+  auto ifm_tensor = tensor_reg->getAclTensor(ifm_index);
 
   ::arm_compute::PoolingLayerInfo info{
       pooling_type, ::arm_compute::Size2D{kw, kh}, ifm_tensor->info()->data_layout(),

--- a/runtime/onert/backend/acl_common/AclTensorRegistry.h
+++ b/runtime/onert/backend/acl_common/AclTensorRegistry.h
@@ -36,17 +36,11 @@ template <typename T_AclTensorManager> class AclTensorRegistry : public ITensorR
 public:
   AclTensorRegistry(T_AclTensorManager *tensor_mgr) : _tensor_mgr{tensor_mgr} {}
 
-  std::shared_ptr<ITensor> getITensor(const ir::OperandIndex &ind) override
-  {
-    return _tensor_mgr->at(ind);
-  }
+  ITensor *getITensor(const ir::OperandIndex &ind) override { return _tensor_mgr->at(ind).get(); }
 
-  std::shared_ptr<ITensor> getNativeITensor(const ir::OperandIndex &ind) override
-  {
-    return getITensor(ind);
-  }
+  ITensor *getNativeITensor(const ir::OperandIndex &ind) override { return getITensor(ind); }
 
-  auto getAclTensor(const ir::OperandIndex &ind) { return _tensor_mgr->at(ind); }
+  auto getAclTensor(const ir::OperandIndex &ind) { return _tensor_mgr->at(ind).get(); }
 
 private:
   T_AclTensorManager *_tensor_mgr;

--- a/runtime/onert/backend/acl_neon/KernelGenerator.cc
+++ b/runtime/onert/backend/acl_neon/KernelGenerator.cc
@@ -79,8 +79,8 @@ void KernelGenerator::visit(const ir::operation::ArgMax &node)
 
   const auto ifm_rank = _ctx.at(ifm_index).shape().rank();
 
-  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index).get();
-  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index).get();
+  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index);
+  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index);
   auto frontend_layout = _current_op_seq_layout;
   auto backend_layout = ifm_tensor->layout();
 
@@ -107,9 +107,9 @@ void KernelGenerator::visit(const ir::operation::BatchToSpaceND &node)
   const auto block_size_index{
       node.getInputs().at(ir::operation::BatchToSpaceND::Input::BLOCK_SIZE)};
 
-  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index).get();
-  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index).get();
-  auto block_size_tensor = _tensor_reg->getAclTensor(block_size_index).get();
+  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index);
+  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index);
+  auto block_size_tensor = _tensor_reg->getAclTensor(block_size_index);
 
   assert(_ctx.at(block_size_index).data());
 
@@ -127,9 +127,9 @@ void KernelGenerator::visit(const ir::operation::BinaryArithmetic &node)
 
   const auto activation = node.param().activation;
 
-  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index).get();
-  auto lhs_tensor = _tensor_reg->getAclTensor(lhs_index).get();
-  auto rhs_tensor = _tensor_reg->getAclTensor(rhs_index).get();
+  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index);
+  auto lhs_tensor = _tensor_reg->getAclTensor(lhs_index);
+  auto rhs_tensor = _tensor_reg->getAclTensor(rhs_index);
 
   std::unique_ptr<arm_compute::IFunction> fn;
   switch (node.param().arithmetic_type)
@@ -191,10 +191,10 @@ void KernelGenerator::visit(const ir::operation::Conv2D &node)
                                             ker_width, ker_height);
   const auto activation = node.param().activation;
 
-  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index).get();
-  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index).get();
-  auto ker_tensor = _tensor_reg->getAclTensor(ker_index).get();
-  auto bias_tensor = _tensor_reg->getAclTensor(bias_index).get();
+  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index);
+  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index);
+  auto ker_tensor = _tensor_reg->getAclTensor(ker_index);
+  auto bias_tensor = _tensor_reg->getAclTensor(bias_index);
 
   const auto conv_info = acl_common::asPadStrideInfo(padding, stride);
   const auto act_info = acl_common::asActivationLayerInfo(activation);
@@ -215,8 +215,8 @@ void KernelGenerator::visit(const ir::operation::DepthToSpace &node)
   auto block_size = node.param().block_size;
   assert(block_size > 0);
 
-  auto output_tensor = _tensor_reg->getAclTensor(output_index).get();
-  auto input_tensor = _tensor_reg->getAclTensor(input_index).get();
+  auto output_tensor = _tensor_reg->getAclTensor(output_index);
+  auto input_tensor = _tensor_reg->getAclTensor(input_index);
 
   auto fn = acl_common::generateLayer<arm_compute::NEDepthToSpaceLayer>(
       input_tensor->handle(), output_tensor->handle(), block_size);
@@ -246,10 +246,10 @@ void KernelGenerator::visit(const ir::operation::DepthwiseConv2D &node)
   const auto multiplier = node.param().multiplier;
   const auto activation = node.param().activation;
 
-  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index).get();
-  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index).get();
-  auto ker_tensor = _tensor_reg->getAclTensor(ker_index).get();
-  auto bias_tensor = _tensor_reg->getAclTensor(bias_index).get();
+  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index);
+  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index);
+  auto ker_tensor = _tensor_reg->getAclTensor(ker_index);
+  auto bias_tensor = _tensor_reg->getAclTensor(bias_index);
 
   const auto conv_info = acl_common::asPadStrideInfo(padding, stride);
   const auto act_info = acl_common::asActivationLayerInfo(activation);
@@ -283,7 +283,7 @@ void KernelGenerator::visit(const ir::operation::Concat &node)
     return;
   }
 
-  auto output_tensor = _tensor_reg->getAclTensor(ofm_index).get();
+  auto output_tensor = _tensor_reg->getAclTensor(ofm_index);
   std::vector<::arm_compute::ITensor *> input_tensors;
   for (const auto &ifm_ind : input_indexes)
     input_tensors.emplace_back(_tensor_reg->getAclTensor(ifm_ind)->handle());
@@ -313,8 +313,8 @@ void KernelGenerator::visit(const ir::operation::ElementwiseActivation &node)
   const auto ofm_index{node.getOutputs().at(0)};
   const auto ifm_index{node.getInputs().at(ir::operation::ElementwiseActivation::Input::INPUT)};
 
-  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index).get();
-  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index).get();
+  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index);
+  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index);
 
   const ::arm_compute::ActivationLayerInfo act_info = acl_common::asActivationLayerInfo(
       node.param().op_type, node.param().alpha, node.param().beta);
@@ -344,9 +344,9 @@ void KernelGenerator::visit(const ir::operation::ElementwiseBinary &node)
   const auto lhs_index{node.getInputs().at(ir::operation::ElementwiseBinary::Input::LHS)};
   const auto rhs_index{node.getInputs().at(ir::operation::ElementwiseBinary::Input::RHS)};
 
-  auto output_tensor = _tensor_reg->getAclTensor(output_index).get();
-  auto lhs_tensor = _tensor_reg->getAclTensor(lhs_index).get();
-  auto rhs_tensor = _tensor_reg->getAclTensor(rhs_index).get();
+  auto output_tensor = _tensor_reg->getAclTensor(output_index);
+  auto lhs_tensor = _tensor_reg->getAclTensor(lhs_index);
+  auto rhs_tensor = _tensor_reg->getAclTensor(rhs_index);
 
   std::unique_ptr<arm_compute::IFunction> fn;
   switch (node.param().op_type)
@@ -391,8 +391,8 @@ void KernelGenerator::visit(const ir::operation::ElementwiseUnary &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(ir::operation::ElementwiseUnary::Input::INPUT)};
 
-  auto output_tensor = _tensor_reg->getAclTensor(output_index).get();
-  auto input_tensor = _tensor_reg->getAclTensor(input_index).get();
+  auto output_tensor = _tensor_reg->getAclTensor(output_index);
+  auto input_tensor = _tensor_reg->getAclTensor(input_index);
 
   std::unique_ptr<arm_compute::IFunction> fn;
   switch (node.param().op_type)
@@ -481,9 +481,9 @@ void KernelGenerator::visit(const ir::operation::EmbeddingLookup &node)
   const auto lookups_index{node.getInputs().at(ir::operation::EmbeddingLookup::Input::LOOKUPS)};
   const auto values_index{node.getInputs().at(ir::operation::EmbeddingLookup::Input::VALUES)};
 
-  auto output_tensor = _tensor_reg->getAclTensor(output_index).get();
-  auto lookups_tensor = _tensor_reg->getAclTensor(lookups_index).get();
-  auto values_tensor = _tensor_reg->getAclTensor(values_index).get();
+  auto output_tensor = _tensor_reg->getAclTensor(output_index);
+  auto lookups_tensor = _tensor_reg->getAclTensor(lookups_index);
+  auto values_tensor = _tensor_reg->getAclTensor(values_index);
 
   auto fn = acl_common::generateLayer<arm_compute::NEEmbeddingLookup>(
       values_tensor->handle(), output_tensor->handle(), lookups_tensor->handle());
@@ -494,7 +494,7 @@ void KernelGenerator::visit(const ir::operation::EmbeddingLookup &node)
 void KernelGenerator::visit(const ir::operation::FullyConnected &node)
 {
   const auto output_index{node.getOutputs().at(0)};
-  auto output_tensor = _tensor_reg->getAclTensor(output_index).get();
+  auto output_tensor = _tensor_reg->getAclTensor(output_index);
   const auto activation = node.param().activation;
 
   auto fn = acl_common::kernelGenFullyConnected<acl_common::AclFunction, ::arm_compute::ITensor,
@@ -513,12 +513,12 @@ void KernelGenerator::visit(const ir::operation::HashtableLookup &node)
   const auto keys_index{node.getInputs().at(ir::operation::HashtableLookup::Input::KEYS)};
   const auto values_index{node.getInputs().at(ir::operation::HashtableLookup::Input::VALUES)};
 
-  auto output_tensor = _tensor_reg->getAclTensor(output_index).get();
-  auto hits_tensor = _tensor_reg->getAclTensor(hits_index).get();
+  auto output_tensor = _tensor_reg->getAclTensor(output_index);
+  auto hits_tensor = _tensor_reg->getAclTensor(hits_index);
 
-  auto lookups_tensor = _tensor_reg->getAclTensor(lookups_index).get();
-  auto keys_tensor = _tensor_reg->getAclTensor(keys_index).get();
-  auto values_tensor = _tensor_reg->getAclTensor(values_index).get();
+  auto lookups_tensor = _tensor_reg->getAclTensor(lookups_index);
+  auto keys_tensor = _tensor_reg->getAclTensor(keys_index);
+  auto values_tensor = _tensor_reg->getAclTensor(values_index);
 
   auto fn = acl_common::generateLayer<arm_compute::NEHashtableLookup>(
       lookups_tensor->handle(), keys_tensor->handle(), values_tensor->handle(),
@@ -540,9 +540,9 @@ void KernelGenerator::visit(const ir::operation::Gather &node)
   // Converting in reverse order
   const int axis = ::onert::backend::acl_common::ToARMComputeAxis(ifm_rank, axis_value).value();
 
-  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index).get();
-  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index).get();
-  auto indices_tensor = _tensor_reg->getAclTensor(indices_index).get();
+  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index);
+  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index);
+  auto indices_tensor = _tensor_reg->getAclTensor(indices_index);
   const auto backend_layout = ofm_tensor->layout();
   UNUSED_RELEASE(backend_layout);
 
@@ -597,10 +597,10 @@ void KernelGenerator::visit(const ir::operation::InstanceNorm &node)
   const auto gamma_index{node.getInputs().at(ir::operation::InstanceNorm::Input::GAMMA)};
   const auto beta_index{node.getInputs().at(ir::operation::InstanceNorm::Input::BETA)};
 
-  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index).get();
-  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index).get();
-  auto gamma_tensor = _tensor_reg->getAclTensor(gamma_index).get();
-  auto beta_tensor = _tensor_reg->getAclTensor(beta_index).get();
+  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index);
+  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index);
+  auto gamma_tensor = _tensor_reg->getAclTensor(gamma_index);
+  auto beta_tensor = _tensor_reg->getAclTensor(beta_index);
   auto epsilon = node.param().epsilon;
   auto activation = node.param().activation;
 
@@ -631,8 +631,8 @@ void KernelGenerator::visit(const ir::operation::L2Normalization &node)
   float beta = 0.5f;                             // pow(reduction, -0.5) = 1 / sqrt(reduction)
   float bias = 0.0f;                             // Don't offset the reduction.
 
-  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index).get();
-  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index).get();
+  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index);
+  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index);
 
   const auto norm_info = ::arm_compute::NormalizationLayerInfo(::arm_compute::NormType::CROSS_MAP,
                                                                radius, alpha, beta, bias, false);
@@ -654,8 +654,8 @@ void KernelGenerator::visit(const ir::operation::LocalResponseNormalization &nod
   auto beta = node.param().beta;
   auto bias = node.param().bias;
 
-  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index).get();
-  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index).get();
+  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index);
+  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index);
 
   const auto norm_info = ::arm_compute::NormalizationLayerInfo(
       ::arm_compute::NormType::CROSS_MAP, radius * 2 + 1, alpha, beta, bias, false);
@@ -683,13 +683,13 @@ void KernelGenerator::visit(const ir::operation::Pack &node)
   for (const auto &input_index : node.getInputs())
     input_indexes.emplace_back(input_index);
 
-  auto output = _tensor_reg->getAclTensor(output_index).get()->handle();
+  auto output = _tensor_reg->getAclTensor(output_index)->handle();
   std::vector<arm_compute::ITensor *> inputs;
   for (const auto &input_index : input_indexes)
     inputs.emplace_back(_tensor_reg->getAclTensor(input_index)->handle());
 
   const auto frontend_layout = _current_op_seq_layout;
-  const auto backend_layout = _tensor_reg->getAclTensor(output_index).get()->layout();
+  const auto backend_layout = _tensor_reg->getAclTensor(output_index)->layout();
 
   if (axis < 0)
     axis += output_rank;
@@ -728,8 +728,8 @@ void KernelGenerator::visit(const ir::operation::Pad &node)
   auto rank = _ctx.at(input_index).shape().rank();
   auto pad_base = _ctx.at(pad_index).data()->base();
 
-  auto input = _tensor_reg->getAclTensor(input_index).get()->handle();
-  auto output = _tensor_reg->getAclTensor(output_index).get()->handle();
+  auto input = _tensor_reg->getAclTensor(input_index)->handle();
+  auto output = _tensor_reg->getAclTensor(output_index)->handle();
 
   ::arm_compute::PaddingList padding_list;
   padding_list.resize(rank);
@@ -738,7 +738,7 @@ void KernelGenerator::visit(const ir::operation::Pad &node)
     const int32_t *from = reinterpret_cast<const int32_t *>(pad_base) + (n * 2);
 
     const auto frontend_layout = _current_op_seq_layout;
-    const auto backend_layout = _tensor_reg->getAclTensor(input_index).get()->layout();
+    const auto backend_layout = _tensor_reg->getAclTensor(input_index)->layout();
     const auto axis =
         acl_common::ToARMComputeAxis(rank, n, frontend_layout, backend_layout).value();
     padding_list[axis] = ::arm_compute::PaddingInfo{from[0], from[1]};
@@ -765,7 +765,7 @@ void KernelGenerator::visit(const ir::operation::Pool2D &node)
       acl_common::convertPoolType(node.param().op_type));
 
   const auto ofm_index{node.getOutputs().at(0)};
-  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index).get();
+  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index);
   const auto activation = node.param().activation;
   _return_fn = std::make_unique<exec::FunctionSequence>(
       asAclFunction(std::move(raw_fn)),
@@ -777,8 +777,8 @@ void KernelGenerator::visit(const ir::operation::Permute &node)
   const auto ofm_idx{node.getOutputs().at(0)};
   const auto ifm_idx{node.getInputs().at(0)};
   const auto permute_type = node.getPermuteType();
-  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_idx).get();
-  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_idx).get();
+  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_idx);
+  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_idx);
   const auto rank = _ctx.at(ofm_idx).shape().rank();
   assert(_ctx.at(ifm_idx).shape().rank() == _ctx.at(ofm_idx).shape().rank());
 
@@ -813,9 +813,9 @@ void KernelGenerator::visit(const ir::operation::PReLU &node)
   const auto ifm_index{node.getInputs().at(ir::operation::PReLU::Input::INPUT)};
   const auto alpha_index{node.getInputs().at(ir::operation::PReLU::Input::ALPHA)};
 
-  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index).get();
-  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index).get();
-  auto alpha_tensor = _tensor_reg->getAclTensor(alpha_index).get();
+  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index);
+  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index);
+  auto alpha_tensor = _tensor_reg->getAclTensor(alpha_index);
 
   auto fn = acl_common::generateLayer<arm_compute::NEPReluLayer>(
       ifm_tensor->handle(), alpha_tensor->handle(), ofm_tensor->handle());
@@ -829,8 +829,8 @@ void KernelGenerator::visit(const ir::operation::Reduce &node)
   const auto input_index{node.getInputs().at(ir::operation::Reduce::Input::INPUT)};
   const auto axes_index{node.getInputs().at(ir::operation::Reduce::Input::AXES)};
 
-  auto output_tensor = _tensor_reg->getAclTensor(output_index).get();
-  auto input_tensor = _tensor_reg->getAclTensor(input_index).get();
+  auto output_tensor = _tensor_reg->getAclTensor(output_index);
+  auto input_tensor = _tensor_reg->getAclTensor(input_index);
 
   // Convert to ACL axes taking into account negative values and possible duplicates.
   const auto &axes = _ctx.at(axes_index);
@@ -867,8 +867,8 @@ void KernelGenerator::visit(const ir::operation::Reshape &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(ir::operation::Reshape::Input::INPUT)};
 
-  auto output_tensor = _tensor_reg->getAclTensor(output_index).get();
-  auto input_tensor = _tensor_reg->getAclTensor(input_index).get();
+  auto output_tensor = _tensor_reg->getAclTensor(output_index);
+  auto input_tensor = _tensor_reg->getAclTensor(input_index);
 
   // NOTE This operation must not be changed the layout from frontend to backend
   //      So, PermutationOperationPass makes layouts of frontend and backend the same.
@@ -890,8 +890,8 @@ void KernelGenerator::visit(const ir::operation::ResizeBilinear &node)
   const auto ofm_index{node.getOutputs().at(0)};
   const auto ifm_index{node.getInputs().at(ir::operation::ResizeBilinear::Input::INPUT)};
 
-  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index).get();
-  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index).get();
+  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index);
+  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index);
 
   auto fn = acl_common::generateLayer<arm_compute::NEScale>(
       ifm_tensor->handle(), ofm_tensor->handle(), ::arm_compute::InterpolationPolicy::BILINEAR,
@@ -916,14 +916,14 @@ void KernelGenerator::visit(const ir::operation::RNN &node)
 
   const auto activation = node.param().activation;
 
-  auto output_tensor = _tensor_reg->getAclTensor(output_index).get();
-  auto hidden_state_out_tensor = _tensor_reg->getAclTensor(hidden_state_out_index).get();
+  auto output_tensor = _tensor_reg->getAclTensor(output_index);
+  auto hidden_state_out_tensor = _tensor_reg->getAclTensor(hidden_state_out_index);
 
-  auto input_tensor = _tensor_reg->getAclTensor(input_index).get();
-  auto weights_tensor = _tensor_reg->getAclTensor(weights_index).get();
-  auto recurrent_weights_tensor = _tensor_reg->getAclTensor(recurrent_weights_index).get();
-  auto bias_tensor = _tensor_reg->getAclTensor(bias_index).get();
-  auto hidden_state_in_tensor = _tensor_reg->getAclTensor(hidden_state_in_index).get();
+  auto input_tensor = _tensor_reg->getAclTensor(input_index);
+  auto weights_tensor = _tensor_reg->getAclTensor(weights_index);
+  auto recurrent_weights_tensor = _tensor_reg->getAclTensor(recurrent_weights_index);
+  auto bias_tensor = _tensor_reg->getAclTensor(bias_index);
+  auto hidden_state_in_tensor = _tensor_reg->getAclTensor(hidden_state_in_index);
   auto act_info = ::onert::backend::acl_common::asActivationLayerInfo(activation);
 
   auto copy_layer = acl_common::generateLayer<arm_compute::NECopy>(
@@ -949,8 +949,8 @@ void KernelGenerator::visit(const ir::operation::Squeeze &node)
   (void)dims;
   (void)ndim;
 
-  auto output_tensor = _tensor_reg->getAclTensor(output_index).get();
-  auto input_tensor = _tensor_reg->getAclTensor(input_index).get();
+  auto output_tensor = _tensor_reg->getAclTensor(output_index);
+  auto input_tensor = _tensor_reg->getAclTensor(input_index);
   auto fn = acl_common::generateLayer<arm_compute::NEReshapeLayer>(input_tensor->handle(),
                                                                    output_tensor->handle());
   _return_fn = asAclFunction(std::move(fn));
@@ -962,8 +962,8 @@ void KernelGenerator::visit(const ir::operation::Softmax &node)
   const auto input_index{node.getInputs().at(ir::operation::Softmax::Input::INPUT)};
   const auto beta = node.param().beta;
 
-  auto output_tensor = _tensor_reg->getAclTensor(output_index).get();
-  auto input_tensor = _tensor_reg->getAclTensor(input_index).get();
+  auto output_tensor = _tensor_reg->getAclTensor(output_index);
+  auto input_tensor = _tensor_reg->getAclTensor(input_index);
   const auto frontend_layout = _current_op_seq_layout;
   const auto backend_layout = input_tensor->layout();
 
@@ -992,10 +992,10 @@ void KernelGenerator::visit(const ir::operation::SpaceToBatchND &node)
       node.getInputs().at(ir::operation::SpaceToBatchND::Input::BLOCK_SIZE)};
   const auto paddings_index{node.getInputs().at(ir::operation::SpaceToBatchND::Input::PADDINGS)};
 
-  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index).get();
-  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index).get();
-  auto block_size_tensor = _tensor_reg->getAclTensor(block_size_index).get();
-  auto paddings_tensor = _tensor_reg->getAclTensor(paddings_index).get();
+  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index);
+  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index);
+  auto block_size_tensor = _tensor_reg->getAclTensor(block_size_index);
+  auto paddings_tensor = _tensor_reg->getAclTensor(paddings_index);
 
   assert(_ctx.at(block_size_index).data());
   assert(_ctx.at(paddings_index).data());
@@ -1014,8 +1014,8 @@ void KernelGenerator::visit(const ir::operation::SpaceToDepth &node)
 
   auto block_size = node.param().block_size;
 
-  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index).get();
-  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index).get();
+  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index);
+  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index);
 
   auto fn = acl_common::generateLayer<arm_compute::NESpaceToDepthLayer>(
       ifm_tensor->handle(), ofm_tensor->handle(), block_size);
@@ -1036,10 +1036,10 @@ void KernelGenerator::visit(const ir::operation::Split &node)
   for (const auto &output : node.getOutputs())
     output_indexes.emplace_back(output);
 
-  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index).get();
+  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index);
   std::vector<arm_compute::ITensor *> output_tensors;
   for (const auto &ofm_ind : output_indexes)
-    output_tensors.emplace_back(_tensor_reg->getAclTensor(ofm_ind).get()->handle());
+    output_tensors.emplace_back(_tensor_reg->getAclTensor(ofm_ind)->handle());
 
   const auto frontend_layout = _current_op_seq_layout;
   const auto backend_layout = ifm_tensor->layout();
@@ -1060,9 +1060,9 @@ void KernelGenerator::visit(const ir::operation::SquaredDifference &node)
   const auto lhs_index{node.getInputs().at(ir::operation::SquaredDifference::Input::LHS)};
   const auto rhs_index{node.getInputs().at(ir::operation::SquaredDifference::Input::RHS)};
 
-  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index).get();
-  auto lhs_tensor = _tensor_reg->getAclTensor(lhs_index).get();
-  auto rhs_tensor = _tensor_reg->getAclTensor(rhs_index).get();
+  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index);
+  auto lhs_tensor = _tensor_reg->getAclTensor(lhs_index);
+  auto rhs_tensor = _tensor_reg->getAclTensor(rhs_index);
 
   auto fn = acl_common::generateLayer<arm_compute::NEElementwiseSquaredDiff>(
       lhs_tensor->handle(), rhs_tensor->handle(), ofm_tensor->handle());
@@ -1077,8 +1077,8 @@ void KernelGenerator::visit(const ir::operation::Slice &node)
   const auto begins_index{node.getInputs().at(ir::operation::Slice::Input::BEGINS)};
   const auto sizes_index{node.getInputs().at(ir::operation::Slice::Input::SIZES)};
 
-  auto outputData_tensor = _tensor_reg->getAclTensor(output_index).get();
-  auto inputData_tensor = _tensor_reg->getAclTensor(input_index).get();
+  auto outputData_tensor = _tensor_reg->getAclTensor(output_index);
+  auto inputData_tensor = _tensor_reg->getAclTensor(input_index);
   const auto frontend_layout = _current_op_seq_layout;
   const auto backend_layout = inputData_tensor->layout();
 
@@ -1142,8 +1142,8 @@ void KernelGenerator::visit(const ir::operation::StridedSlice &node)
   const auto ends_index{node.getInputs().at(ir::operation::StridedSlice::Input::ENDS)};
   const auto strides_index{node.getInputs().at(ir::operation::StridedSlice::Input::STRIDES)};
 
-  auto outputData_tensor = _tensor_reg->getAclTensor(output_index).get();
-  auto inputData_tensor = _tensor_reg->getAclTensor(input_index).get();
+  auto outputData_tensor = _tensor_reg->getAclTensor(output_index);
+  auto inputData_tensor = _tensor_reg->getAclTensor(input_index);
   const auto frontend_layout = _current_op_seq_layout;
   const auto backend_layout = inputData_tensor->layout();
 
@@ -1258,9 +1258,9 @@ void KernelGenerator::visit(const ir::operation::TransposeConv &node)
     invalid_vertical = ofm_shape.H - (1 + (ifm_shape.H - 1) * stride.vertical) - (ker_shape.H - 1);
   }
 
-  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index).get();
-  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index).get();
-  auto ker_tensor = _tensor_reg->getAclTensor(ker_index).get();
+  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index);
+  auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index);
+  auto ker_tensor = _tensor_reg->getAclTensor(ker_index);
 
   const auto tconv_info = acl_common::asPadStrideInfo(padding, stride);
 
@@ -1277,8 +1277,8 @@ void KernelGenerator::visit(const ir::operation::Transpose &node)
   const auto ifm_idx{node.getInputs().at(ir::operation::Transpose::Input::INPUT)};
   const auto perm_idx{node.getInputs().at(ir::operation::Transpose::Input::PERMUTATION)};
 
-  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_idx).get();
-  const auto ifm_tensor = _tensor_reg->getAclTensor(ifm_idx).get();
+  auto ofm_tensor = _tensor_reg->getAclTensor(ofm_idx);
+  const auto ifm_tensor = _tensor_reg->getAclTensor(ifm_idx);
   const auto frontend_layout = _current_op_seq_layout;
   const auto backend_layout = ifm_tensor->layout();
   const auto rank = _ctx.at(ifm_idx).shape().rank();
@@ -1329,13 +1329,13 @@ void KernelGenerator::visit(const ir::operation::Unpack &node)
   for (const auto &output_index : node.getOutputs())
     output_indexes.emplace_back(output_index);
 
-  auto input = _tensor_reg->getAclTensor(input_index).get()->handle();
+  auto input = _tensor_reg->getAclTensor(input_index)->handle();
   std::vector<arm_compute::ITensor *> outputs;
   for (const auto &output_index : output_indexes)
     outputs.emplace_back(_tensor_reg->getAclTensor(output_index)->handle());
 
   const auto frontend_layout = _current_op_seq_layout;
-  const auto backend_layout = _tensor_reg->getAclTensor(input_index).get()->layout();
+  const auto backend_layout = _tensor_reg->getAclTensor(input_index)->layout();
   if (axis < 0)
     axis += input_rank;
   axis = acl_common::ToARMComputeAxis(input_rank, axis, frontend_layout, backend_layout).value();
@@ -1366,8 +1366,8 @@ void KernelGenerator::visit(const ir::operation::ExpandDims &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(ir::operation::ExpandDims::Input::INPUT)};
 
-  auto output_tensor = _tensor_reg->getAclTensor(output_index).get();
-  auto input_tensor = _tensor_reg->getAclTensor(input_index).get();
+  auto output_tensor = _tensor_reg->getAclTensor(output_index);
+  auto input_tensor = _tensor_reg->getAclTensor(input_index);
 
   auto fn = acl_common::generateLayer<arm_compute::NEReshapeLayer>(input_tensor->handle(),
                                                                    output_tensor->handle());
@@ -1383,9 +1383,9 @@ void KernelGenerator::visit(const ir::operation::Comparison &node)
 
   const auto comparison_type = node.param().comparison_type;
 
-  auto output_tensor = _tensor_reg->getAclTensor(output_index).get();
-  auto input0_tensor = _tensor_reg->getAclTensor(input0_index).get();
-  auto input1_tensor = _tensor_reg->getAclTensor(input1_index).get();
+  auto output_tensor = _tensor_reg->getAclTensor(output_index);
+  auto input0_tensor = _tensor_reg->getAclTensor(input0_index);
+  auto input1_tensor = _tensor_reg->getAclTensor(input1_index);
 
   auto fn = acl_common::generateLayer<arm_compute::NEElementwiseComparison>(
       input0_tensor->handle(), input1_tensor->handle(), output_tensor->handle(),
@@ -1403,11 +1403,11 @@ void KernelGenerator::visit(const ir::operation::OneHot &node)
   const auto offvalue_idx{node.getInputs().at(ir::operation::OneHot::Input::OFF_VALUE)};
   const auto axis = node.param().axis;
 
-  auto output_tensor = _tensor_reg->getAclTensor(out_idx).get();
-  auto indices_tensor = _tensor_reg->getAclTensor(indices_idx).get();
-  auto depth_tensor = _tensor_reg->getAclTensor(depth_idx).get();
-  auto onvalue_tensor = _tensor_reg->getAclTensor(onvalue_idx).get();
-  auto offvalue_tensor = _tensor_reg->getAclTensor(offvalue_idx).get();
+  auto output_tensor = _tensor_reg->getAclTensor(out_idx);
+  auto indices_tensor = _tensor_reg->getAclTensor(indices_idx);
+  auto depth_tensor = _tensor_reg->getAclTensor(depth_idx);
+  auto onvalue_tensor = _tensor_reg->getAclTensor(onvalue_idx);
+  auto offvalue_tensor = _tensor_reg->getAclTensor(offvalue_idx);
 
   auto fn = acl_common::generateLayer<arm_compute::CPPOneHotEx>(
       indices_tensor->handle(), depth_tensor->handle(), onvalue_tensor->handle(),

--- a/runtime/onert/backend/cpu/KernelGenerator.cc
+++ b/runtime/onert/backend/cpu/KernelGenerator.cc
@@ -272,10 +272,10 @@ void KernelGenerator::visit(const ir::operation::Conv2D &node)
   const auto ker_index{node.getInputs().at(Conv2D::Input::KERNEL)};
   const auto bias_index{node.getInputs().at(Conv2D::Input::BIAS)};
 
-  auto ofm_tensor = _tensor_reg->getPortableTensor(ofm_index).get();
-  auto ifm_tensor = _tensor_reg->getPortableTensor(ifm_index).get();
-  auto ker_tensor = _tensor_reg->getPortableTensor(ker_index).get();
-  auto bias_tensor = _tensor_reg->getPortableTensor(bias_index).get();
+  auto ofm_tensor = _tensor_reg->getPortableTensor(ofm_index);
+  auto ifm_tensor = _tensor_reg->getPortableTensor(ifm_index);
+  auto ker_tensor = _tensor_reg->getPortableTensor(ker_index);
+  auto bias_tensor = _tensor_reg->getPortableTensor(bias_index);
 
   const auto stride = node.param().stride;
   const auto activation = node.param().activation;
@@ -332,10 +332,10 @@ void KernelGenerator::visit(const ir::operation::DepthwiseConv2D &node)
   const auto multiplier = node.param().multiplier;
   const auto activation = node.param().activation;
 
-  auto ofm_tensor = _tensor_reg->getPortableTensor(ofm_index).get();
-  auto ifm_tensor = _tensor_reg->getPortableTensor(ifm_index).get();
-  auto ker_tensor = _tensor_reg->getPortableTensor(ker_index).get();
-  auto bias_tensor = _tensor_reg->getPortableTensor(bias_index).get();
+  auto ofm_tensor = _tensor_reg->getPortableTensor(ofm_index);
+  auto ifm_tensor = _tensor_reg->getPortableTensor(ifm_index);
+  auto ker_tensor = _tensor_reg->getPortableTensor(ker_index);
+  auto bias_tensor = _tensor_reg->getPortableTensor(bias_index);
 
   auto fn = std::make_unique<ops::DepthwiseConvolutionLayer>();
 
@@ -353,11 +353,11 @@ void KernelGenerator::visit(const ir::operation::Concat &node)
   const auto rank = _ctx.at(ofm_index).shape().rank();
   const auto axis = ops::getAxis(rank, node.param().axis, _current_op_seq_layout);
 
-  auto output_tensor = _tensor_reg->getPortableTensor(ofm_index).get();
+  auto output_tensor = _tensor_reg->getPortableTensor(ofm_index);
 
   std::vector<const IPortableTensor *> input_tensors;
   for (auto &ifm_idx : node.getInputs())
-    input_tensors.emplace_back(_tensor_reg->getPortableTensor(ifm_idx).get());
+    input_tensors.emplace_back(_tensor_reg->getPortableTensor(ifm_idx));
 
   auto fn = std::make_unique<ops::ConcatLayer>();
 
@@ -372,9 +372,9 @@ void KernelGenerator::visit(const ir::operation::BatchToSpaceND &node)
   const auto input_index{node.getInputs().at(ir::operation::BatchToSpaceND::INPUT)};
   const auto block_size_index{node.getInputs().at(ir::operation::BatchToSpaceND::BLOCK_SIZE)};
 
-  auto output_alloc = _tensor_reg->getPortableTensor(output_index).get();
-  auto input_alloc = _tensor_reg->getPortableTensor(input_index).get();
-  auto block_size_alloc = _tensor_reg->getPortableTensor(block_size_index).get();
+  auto output_alloc = _tensor_reg->getPortableTensor(output_index);
+  auto input_alloc = _tensor_reg->getPortableTensor(input_index);
+  auto block_size_alloc = _tensor_reg->getPortableTensor(block_size_index);
 
   auto fn = std::make_unique<ops::BatchToSpaceNDLayer>();
 
@@ -384,7 +384,7 @@ void KernelGenerator::visit(const ir::operation::BatchToSpaceND &node)
   if (node.getInputs().size() != NNApiInputs)
   {
     const auto crops_data_index{node.getInputs().at(ir::operation::BatchToSpaceND::CROPS_DATA)};
-    crops_alloc = _tensor_reg->getPortableTensor(crops_data_index).get();
+    crops_alloc = _tensor_reg->getPortableTensor(crops_data_index);
   }
 
   fn->configure(input_alloc, output_alloc, block_size_alloc, crops_alloc);
@@ -398,9 +398,9 @@ void KernelGenerator::visit(const ir::operation::Fill &node)
   const auto input_index{node.getInputs().at(ir::operation::Fill::Input::INPUT)};
   const auto value_index{node.getInputs().at(ir::operation::Fill::Input::VALUE)};
 
-  auto output_tensor = _tensor_reg->getPortableTensor(output_index).get();
-  auto input_tensor = _tensor_reg->getPortableTensor(input_index).get();
-  auto value_tensor = _tensor_reg->getPortableTensor(value_index).get();
+  auto output_tensor = _tensor_reg->getPortableTensor(output_index);
+  auto input_tensor = _tensor_reg->getPortableTensor(input_index);
+  auto value_tensor = _tensor_reg->getPortableTensor(value_index);
 
   auto fn = std::make_unique<ops::FillLayer>();
 
@@ -419,11 +419,10 @@ void KernelGenerator::visit(const ir::operation::FullyConnected &node)
   const auto bias_index{node.getInputs().at(FullyConnected::Input::BIAS)};
   const auto activation = node.param().activation;
 
-  auto output_tensor = _tensor_reg->getPortableTensor(output_index).get();
-  auto input_tensor = _tensor_reg->getPortableTensor(input_index).get();
-  auto weight_tensor = _tensor_reg->getPortableTensor(weight_index).get();
-  auto bias_tensor =
-      bias_index.undefined() ? nullptr : _tensor_reg->getPortableTensor(bias_index).get();
+  auto output_tensor = _tensor_reg->getPortableTensor(output_index);
+  auto input_tensor = _tensor_reg->getPortableTensor(input_index);
+  auto weight_tensor = _tensor_reg->getPortableTensor(weight_index);
+  auto bias_tensor = bias_index.undefined() ? nullptr : _tensor_reg->getPortableTensor(bias_index);
 
   auto fn = std::make_unique<ops::FullyConnectedLayer>();
 
@@ -438,8 +437,8 @@ void KernelGenerator::visit(const ir::operation::Reshape &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(ir::operation::Reshape::Input::INPUT)};
 
-  auto output_tensor = _tensor_reg->getPortableTensor(output_index).get();
-  auto input_tensor = _tensor_reg->getPortableTensor(input_index).get();
+  auto output_tensor = _tensor_reg->getPortableTensor(output_index);
+  auto input_tensor = _tensor_reg->getPortableTensor(input_index);
 
   // optional 2nd input
   IPortableTensor *shape_tensor = nullptr;
@@ -447,7 +446,7 @@ void KernelGenerator::visit(const ir::operation::Reshape &node)
   if (node.getInputs().size() == 2)
   {
     const auto shape_index{node.getInputs().at(ir::operation::Reshape::Input::SHAPE)};
-    shape_tensor = _tensor_reg->getPortableTensor(shape_index).get();
+    shape_tensor = _tensor_reg->getPortableTensor(shape_index);
   }
 
   auto fn = std::make_unique<ops::ReshapeLayer>();
@@ -461,8 +460,8 @@ void KernelGenerator::visit(const ir::operation::Squeeze &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(ir::operation::Squeeze::Input::INPUT)};
 
-  auto output_tensor = _tensor_reg->getPortableTensor(output_index).get();
-  auto input_tensor = _tensor_reg->getPortableTensor(input_index).get();
+  auto output_tensor = _tensor_reg->getPortableTensor(output_index);
+  auto input_tensor = _tensor_reg->getPortableTensor(input_index);
 
   // Squeeze can share same kernel with reshape
   auto fn = std::make_unique<ops::ReshapeLayer>();
@@ -479,8 +478,8 @@ void KernelGenerator::visit(const ir::operation::Softmax &node)
 
   const auto beta = node.param().beta;
 
-  auto output_tensor = _tensor_reg->getPortableTensor(output_index).get();
-  auto input_tensor = _tensor_reg->getPortableTensor(input_index).get();
+  auto output_tensor = _tensor_reg->getPortableTensor(output_index);
+  auto input_tensor = _tensor_reg->getPortableTensor(input_index);
 
   auto fn = std::make_unique<ops::SoftMaxLayer>();
 
@@ -497,9 +496,9 @@ void KernelGenerator::visit(const ir::operation::BinaryArithmetic &node)
 
   const auto activation = node.param().activation;
 
-  auto ofm_tensor = _tensor_reg->getPortableTensor(ofm_index).get();
-  auto lhs_tensor = _tensor_reg->getPortableTensor(lhs_index).get();
-  auto rhs_tensor = _tensor_reg->getPortableTensor(rhs_index).get();
+  auto ofm_tensor = _tensor_reg->getPortableTensor(ofm_index);
+  auto lhs_tensor = _tensor_reg->getPortableTensor(lhs_index);
+  auto rhs_tensor = _tensor_reg->getPortableTensor(rhs_index);
 
   auto fn = std::make_unique<ops::BinaryArithmeticLayer>();
 
@@ -515,9 +514,9 @@ void KernelGenerator::visit(const ir::operation::Comparison &node)
   const auto lhs_index{node.getInputs().at(ir::operation::Comparison::Input::INPUT0)};
   const auto rhs_index{node.getInputs().at(ir::operation::Comparison::Input::INPUT1)};
 
-  auto ofm_tensor = _tensor_reg->getPortableTensor(ofm_index).get();
-  auto lhs_tensor = _tensor_reg->getPortableTensor(lhs_index).get();
-  auto rhs_tensor = _tensor_reg->getPortableTensor(rhs_index).get();
+  auto ofm_tensor = _tensor_reg->getPortableTensor(ofm_index);
+  auto lhs_tensor = _tensor_reg->getPortableTensor(lhs_index);
+  auto rhs_tensor = _tensor_reg->getPortableTensor(rhs_index);
 
   auto comparison_type = node.param().comparison_type;
 
@@ -534,9 +533,9 @@ void KernelGenerator::visit(const ir::operation::Gather &node)
   const auto input_index{node.getInputs().at(ir::operation::Gather::Input::INPUT)};
   const auto indices_index{node.getInputs().at(ir::operation::Gather::Input::INDICES)};
 
-  auto output_tensor = _tensor_reg->getPortableTensor(output_index).get();
-  auto input_tensor = _tensor_reg->getPortableTensor(input_index).get();
-  auto indices_tensor = _tensor_reg->getPortableTensor(indices_index).get();
+  auto output_tensor = _tensor_reg->getPortableTensor(output_index);
+  auto input_tensor = _tensor_reg->getPortableTensor(input_index);
+  auto indices_tensor = _tensor_reg->getPortableTensor(indices_index);
 
   const auto backend_layout = output_tensor->layout();
   UNUSED_RELEASE(backend_layout);
@@ -575,11 +574,11 @@ void KernelGenerator::visit(const ir::operation::OneHot &node)
 
   const auto axis = node.param().axis;
 
-  auto output_tensor = _tensor_reg->getPortableTensor(output_index).get();
-  auto indices_tensor = _tensor_reg->getPortableTensor(indices_index).get();
-  auto depth_tensor = _tensor_reg->getPortableTensor(depth_index).get();
-  auto onvalue_tensor = _tensor_reg->getPortableTensor(onvalue_index).get();
-  auto offvalue_tensor = _tensor_reg->getPortableTensor(offvalue_index).get();
+  auto output_tensor = _tensor_reg->getPortableTensor(output_index);
+  auto indices_tensor = _tensor_reg->getPortableTensor(indices_index);
+  auto depth_tensor = _tensor_reg->getPortableTensor(depth_index);
+  auto onvalue_tensor = _tensor_reg->getPortableTensor(onvalue_index);
+  auto offvalue_tensor = _tensor_reg->getPortableTensor(offvalue_index);
 
   assert(indices_tensor->data_type() == OperandType::INT32);
   assert(axis <= static_cast<int>(indices_tensor->num_dimensions()));
@@ -595,10 +594,10 @@ void KernelGenerator::visit(const ir::operation::Einsum &node)
 {
   const auto ofm_index{node.getOutputs().at(0)};
 
-  auto output_tensor = _tensor_reg->getPortableTensor(ofm_index).get();
+  auto output_tensor = _tensor_reg->getPortableTensor(ofm_index);
   std::vector<const IPortableTensor *> input_tensors;
   for (auto &ifm_idx : node.getInputs())
-    input_tensors.emplace_back(_tensor_reg->getPortableTensor(ifm_idx).get());
+    input_tensors.emplace_back(_tensor_reg->getPortableTensor(ifm_idx));
 
   const auto equation = node.param().equation;
 
@@ -613,7 +612,7 @@ void KernelGenerator::visit(const ir::operation::Custom &node)
 {
   auto fill_op_info = [&](const ir::OperandIndexSequence &opSeq,
                           std::vector<custom::TypeInfo> &types,
-                          std::vector<std::shared_ptr<IPortableTensor>> &tensors) {
+                          std::vector<IPortableTensor *> &tensors) {
     for (auto &idx : opSeq)
     {
       const auto &operand = _ctx.at(idx);
@@ -642,8 +641,8 @@ void KernelGenerator::visit(const ir::operation::ElementwiseActivation &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(ir::operation::ElementwiseActivation::Input::INPUT)};
 
-  auto output_tensor = _tensor_reg->getPortableTensor(output_index).get();
-  auto input_tensor = _tensor_reg->getPortableTensor(input_index).get();
+  auto output_tensor = _tensor_reg->getPortableTensor(output_index);
+  auto input_tensor = _tensor_reg->getPortableTensor(input_index);
 
   auto fn = std::make_unique<ops::ElementwiseActivationLayer>();
 
@@ -659,9 +658,9 @@ void KernelGenerator::visit(const ir::operation::ElementwiseBinary &node)
   const auto lhs_index{node.getInputs().at(ir::operation::ElementwiseBinary::Input::LHS)};
   const auto rhs_index{node.getInputs().at(ir::operation::ElementwiseBinary::Input::RHS)};
 
-  auto output_tensor = _tensor_reg->getPortableTensor(output_index).get();
-  auto lhs_tensor = _tensor_reg->getPortableTensor(lhs_index).get();
-  auto rhs_tensor = _tensor_reg->getPortableTensor(rhs_index).get();
+  auto output_tensor = _tensor_reg->getPortableTensor(output_index);
+  auto lhs_tensor = _tensor_reg->getPortableTensor(lhs_index);
+  auto rhs_tensor = _tensor_reg->getPortableTensor(rhs_index);
 
   auto fn = std::make_unique<ops::ElementwiseBinaryLayer>();
 
@@ -676,8 +675,8 @@ void KernelGenerator::visit(const ir::operation::ElementwiseUnary &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(ir::operation::ElementwiseUnary::Input::INPUT)};
 
-  auto output_tensor = _tensor_reg->getPortableTensor(output_index).get();
-  auto input_tensor = _tensor_reg->getPortableTensor(input_index).get();
+  auto output_tensor = _tensor_reg->getPortableTensor(output_index);
+  auto input_tensor = _tensor_reg->getPortableTensor(input_index);
 
   auto fn = std::make_unique<ops::ElementwiseUnaryLayer>();
 
@@ -692,9 +691,9 @@ void KernelGenerator::visit(const ir::operation::ExpandDims &node)
   const auto input_index{node.getInputs().at(ir::operation::ExpandDims::Input::INPUT)};
   const auto axis_index{node.getInputs().at(ir::operation::ExpandDims::Input::AXIS)};
 
-  auto output_tensor = _tensor_reg->getPortableTensor(output_index).get();
-  auto input_tensor = _tensor_reg->getPortableTensor(input_index).get();
-  auto axis_tensor = _tensor_reg->getPortableTensor(axis_index).get();
+  auto output_tensor = _tensor_reg->getPortableTensor(output_index);
+  auto input_tensor = _tensor_reg->getPortableTensor(input_index);
+  auto axis_tensor = _tensor_reg->getPortableTensor(axis_index);
 
   auto fn = std::make_unique<ops::ExpandDimsLayer>();
 
@@ -712,11 +711,11 @@ void KernelGenerator::visit(const ir::operation::Pack &node)
 
   assert(-rank <= axis && axis < rank);
 
-  auto output_tensor = _tensor_reg->getPortableTensor(ofm_index).get();
+  auto output_tensor = _tensor_reg->getPortableTensor(ofm_index);
 
   std::vector<const IPortableTensor *> input_tensors;
   for (auto &ifm_idx : node.getInputs())
-    input_tensors.emplace_back(_tensor_reg->getPortableTensor(ifm_idx).get());
+    input_tensors.emplace_back(_tensor_reg->getPortableTensor(ifm_idx));
 
   auto fn = std::make_unique<ops::PackLayer>();
 
@@ -734,11 +733,11 @@ void KernelGenerator::visit(const ir::operation::Unpack &node)
 
   assert(rank == 0 || (-rank <= axis && axis < rank));
 
-  auto input_tensor = _tensor_reg->getPortableTensor(input_index).get();
+  auto input_tensor = _tensor_reg->getPortableTensor(input_index);
 
   std::vector<IPortableTensor *> output_tensors;
   for (auto &output_idx : node.getOutputs())
-    output_tensors.emplace_back(_tensor_reg->getPortableTensor(output_idx).get());
+    output_tensors.emplace_back(_tensor_reg->getPortableTensor(output_idx));
 
   auto fn = std::make_unique<ops::UnpackLayer>();
 
@@ -756,8 +755,8 @@ void KernelGenerator::visit(const ir::operation::Pad &node)
   const auto output_index{node.getOutputs().at(0)};
   assert(_ctx.at(pad_index).data());
 
-  auto input = _tensor_reg->getPortableTensor(input_index).get();
-  auto output = _tensor_reg->getPortableTensor(output_index).get();
+  auto input = _tensor_reg->getPortableTensor(input_index);
+  auto output = _tensor_reg->getPortableTensor(output_index);
   auto pad_rank = _ctx.at(pad_index).shape().dim(0);
   auto pad_base = reinterpret_cast<const int32_t *>(_ctx.at(pad_index).data()->base());
 
@@ -782,9 +781,9 @@ void KernelGenerator::visit(const ir::operation::Transpose &node)
   const auto input_index{node.getInputs().at(ir::operation::Transpose::Input::INPUT)};
   const auto perm_index{node.getInputs().at(ir::operation::Transpose::Input::PERMUTATION)};
 
-  auto output_tensor = _tensor_reg->getPortableTensor(output_index).get();
-  auto input_tensor = _tensor_reg->getPortableTensor(input_index).get();
-  auto perm_tensor = _tensor_reg->getPortableTensor(perm_index).get();
+  auto output_tensor = _tensor_reg->getPortableTensor(output_index);
+  auto input_tensor = _tensor_reg->getPortableTensor(input_index);
+  auto perm_tensor = _tensor_reg->getPortableTensor(perm_index);
 
   auto fn = std::make_unique<ops::TransposeLayer>();
 
@@ -800,9 +799,9 @@ void KernelGenerator::visit(const ir::operation::Reduce &node)
   const auto axes_index{node.getInputs().at(ir::operation::Reduce::Input::AXES)};
 
   const auto keep_dims = node.param().keep_dims;
-  auto output_tensor = _tensor_reg->getPortableTensor(output_index).get();
-  auto input_tensor = _tensor_reg->getPortableTensor(input_index).get();
-  auto axes_tensor = _tensor_reg->getPortableTensor(axes_index).get();
+  auto output_tensor = _tensor_reg->getPortableTensor(output_index);
+  auto input_tensor = _tensor_reg->getPortableTensor(input_index);
+  auto axes_tensor = _tensor_reg->getPortableTensor(axes_index);
 
   if (node.param().reduce_type == ir::operation::Reduce::ReduceType::MEAN)
   {
@@ -830,10 +829,10 @@ void KernelGenerator::visit(const ir::operation::Select &node)
   const auto true_index{node.getInputs().at(ir::operation::Select::Input::INPUT_TRUE)};
   const auto false_index{node.getInputs().at(ir::operation::Select::Input::INPUT_FALSE)};
 
-  auto output_tensor = _tensor_reg->getPortableTensor(output_index).get();
-  auto condition_tensor = _tensor_reg->getPortableTensor(condition_index).get();
-  auto true_tensor = _tensor_reg->getPortableTensor(true_index).get();
-  auto false_tensor = _tensor_reg->getPortableTensor(false_index).get();
+  auto output_tensor = _tensor_reg->getPortableTensor(output_index);
+  auto condition_tensor = _tensor_reg->getPortableTensor(condition_index);
+  auto true_tensor = _tensor_reg->getPortableTensor(true_index);
+  auto false_tensor = _tensor_reg->getPortableTensor(false_index);
 
   auto fn = std::make_unique<ops::SelectLayer>();
 
@@ -849,10 +848,10 @@ void KernelGenerator::visit(const ir::operation::Slice &node)
   const auto begins_index{node.getInputs().at(ir::operation::Slice::Input::BEGINS)};
   const auto sizes_index{node.getInputs().at(ir::operation::Slice::Input::SIZES)};
 
-  auto output_tensor = _tensor_reg->getPortableTensor(output_index).get();
-  auto input_tensor = _tensor_reg->getPortableTensor(input_index).get();
-  auto begins_tensor = _tensor_reg->getPortableTensor(begins_index).get();
-  auto sizes_tensor = _tensor_reg->getPortableTensor(sizes_index).get();
+  auto output_tensor = _tensor_reg->getPortableTensor(output_index);
+  auto input_tensor = _tensor_reg->getPortableTensor(input_index);
+  auto begins_tensor = _tensor_reg->getPortableTensor(begins_index);
+  auto sizes_tensor = _tensor_reg->getPortableTensor(sizes_index);
 
   auto fn = std::make_unique<ops::SliceLayer>();
 
@@ -869,11 +868,11 @@ void KernelGenerator::visit(const ir::operation::StridedSlice &node)
   const auto ends_index{node.getInputs().at(ir::operation::StridedSlice::Input::ENDS)};
   const auto strides_index{node.getInputs().at(ir::operation::StridedSlice::Input::STRIDES)};
 
-  auto output_tensor = _tensor_reg->getPortableTensor(output_index).get();
-  auto input_tensor = _tensor_reg->getPortableTensor(input_index).get();
-  auto starts_tensor = _tensor_reg->getPortableTensor(starts_index).get();
-  auto ends_tensor = _tensor_reg->getPortableTensor(ends_index).get();
-  auto strides_tensor = _tensor_reg->getPortableTensor(strides_index).get();
+  auto output_tensor = _tensor_reg->getPortableTensor(output_index);
+  auto input_tensor = _tensor_reg->getPortableTensor(input_index);
+  auto starts_tensor = _tensor_reg->getPortableTensor(starts_index);
+  auto ends_tensor = _tensor_reg->getPortableTensor(ends_index);
+  auto strides_tensor = _tensor_reg->getPortableTensor(strides_index);
 
   auto begin_mask = node.param().begin_mask;
   auto end_mask = node.param().end_mask;
@@ -895,12 +894,12 @@ void KernelGenerator::visit(const ir::operation::Split &node)
   const auto input_idx{node.getInputs().at(ir::operation::Split::Input::INPUT)};
   const auto axis_idx{node.getInputs().at(ir::operation::Split::Input::AXIS)};
 
-  auto in_tensor = _tensor_reg->getPortableTensor(input_idx).get();
-  auto axis_tensor = _tensor_reg->getPortableTensor(axis_idx).get();
+  auto in_tensor = _tensor_reg->getPortableTensor(input_idx);
+  auto axis_tensor = _tensor_reg->getPortableTensor(axis_idx);
 
   std::vector<IPortableTensor *> out_tensors;
   for (auto &output_idx : node.getOutputs())
-    out_tensors.emplace_back(_tensor_reg->getPortableTensor(output_idx).get());
+    out_tensors.emplace_back(_tensor_reg->getPortableTensor(output_idx));
 
   auto fn = std::make_unique<ops::SplitLayer>();
 
@@ -914,8 +913,8 @@ void KernelGenerator::visit(const ir::operation::Shape &node)
   const auto ofm_index{node.getOutputs().at(0)};
   const auto ifm_index{node.getInputs().at(ir::operation::Shape::Input::INPUT)};
 
-  auto ofm_tensor = _tensor_reg->getPortableTensor(ofm_index).get();
-  auto ifm_tensor = _tensor_reg->getPortableTensor(ifm_index).get();
+  auto ofm_tensor = _tensor_reg->getPortableTensor(ofm_index);
+  auto ifm_tensor = _tensor_reg->getPortableTensor(ifm_index);
 
   auto fn = std::make_unique<ops::ShapeLayer>();
 
@@ -932,8 +931,8 @@ void KernelGenerator::visit(const ir::operation::ResizeBilinear &node)
   auto align_corners = node.param().align_corners;
   auto half_pixel_centers = node.param().half_pixel_centers;
 
-  auto output_tensor = _tensor_reg->getPortableTensor(output_index).get();
-  auto input_tensor = _tensor_reg->getPortableTensor(input_index).get();
+  auto output_tensor = _tensor_reg->getPortableTensor(output_index);
+  auto input_tensor = _tensor_reg->getPortableTensor(input_index);
 
   auto fn = std::make_unique<ops::ResizeBilinearLayer>();
 
@@ -946,7 +945,7 @@ void KernelGenerator::visit(const ir::operation::ResizeBilinear &node)
   {
     assert(node.getInputs().size() == 2);
     const auto size_index{node.getInputs().at(ir::operation::ResizeBilinear::SIZE)};
-    auto size_tensor = _tensor_reg->getPortableTensor(size_index).get();
+    auto size_tensor = _tensor_reg->getPortableTensor(size_index);
     if (size_tensor->is_constant())
     {
       auto size_vec = _ctx.at(size_index).asVector<int32_t>();
@@ -970,9 +969,9 @@ void KernelGenerator::visit(const ir::operation::Reverse &node)
   const auto input_index{node.getInputs().at(ir::operation::Reverse::INPUT)};
   const auto axis_index{node.getInputs().at(ir::operation::Reverse::AXIS)};
 
-  auto output_tensor = _tensor_reg->getPortableTensor(output_index).get();
-  auto input_tensor = _tensor_reg->getPortableTensor(input_index).get();
-  auto axis_tensor = _tensor_reg->getPortableTensor(axis_index).get();
+  auto output_tensor = _tensor_reg->getPortableTensor(output_index);
+  auto input_tensor = _tensor_reg->getPortableTensor(input_index);
+  auto axis_tensor = _tensor_reg->getPortableTensor(axis_index);
 
   auto fn = std::make_unique<ops::ReverseLayer>();
 
@@ -987,9 +986,9 @@ void KernelGenerator::visit(const ir::operation::ArgMax &node)
   const auto input_index{node.getInputs().at(ir::operation::ArgMax::INPUT)};
   const auto axis_index{node.getInputs().at(ir::operation::ArgMax::AXIS)};
 
-  auto output_tensor = _tensor_reg->getPortableTensor(output_index).get();
-  auto input_tensor = _tensor_reg->getPortableTensor(input_index).get();
-  auto axis_tensor = _tensor_reg->getPortableTensor(axis_index).get();
+  auto output_tensor = _tensor_reg->getPortableTensor(output_index);
+  auto input_tensor = _tensor_reg->getPortableTensor(input_index);
+  auto axis_tensor = _tensor_reg->getPortableTensor(axis_index);
 
   auto fn = std::make_unique<ops::ArgMinMaxLayer>();
 
@@ -1012,8 +1011,8 @@ void KernelGenerator::visit(const ir::operation::Pool2D &node)
       ir::calculatePadding(node.param().padding, ifm_shape, ofm_shape, stride, kw, kh);
   const auto activation = node.param().activation;
 
-  auto ofm_tensor = _tensor_reg->getPortableTensor(ofm_index).get();
-  auto ifm_tensor = _tensor_reg->getPortableTensor(ifm_index).get();
+  auto ofm_tensor = _tensor_reg->getPortableTensor(ofm_index);
+  auto ifm_tensor = _tensor_reg->getPortableTensor(ifm_index);
 
   auto fn = std::make_unique<ops::PoolLayer>();
 
@@ -1030,9 +1029,9 @@ void KernelGenerator::visit(const ir::operation::Pow &node)
   const auto lhs_index{node.getInputs().at(ir::operation::Pow::LHS)};
   const auto rhs_index{node.getInputs().at(ir::operation::Pow::RHS)};
 
-  auto output_tensor = _tensor_reg->getPortableTensor(output_index).get();
-  auto lhs_tensor = _tensor_reg->getPortableTensor(lhs_index).get();
-  auto rhs_tensor = _tensor_reg->getPortableTensor(rhs_index).get();
+  auto output_tensor = _tensor_reg->getPortableTensor(output_index);
+  auto lhs_tensor = _tensor_reg->getPortableTensor(lhs_index);
+  auto rhs_tensor = _tensor_reg->getPortableTensor(rhs_index);
 
   auto fn = std::make_unique<ops::PowLayer>();
 
@@ -1046,8 +1045,8 @@ void KernelGenerator::visit(const ir::operation::L2Normalization &node)
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(0)};
 
-  auto output_alloc = _tensor_reg->getPortableTensor(output_index).get();
-  auto input_alloc = _tensor_reg->getPortableTensor(input_index).get();
+  auto output_alloc = _tensor_reg->getPortableTensor(output_index);
+  auto input_alloc = _tensor_reg->getPortableTensor(input_index);
 
   auto fn = std::make_unique<ops::L2NormLayer>();
 
@@ -1063,10 +1062,10 @@ void KernelGenerator::visit(const ir::operation::Range &node)
   const auto limit_index{node.getInputs().at(ir::operation::Range::LIMIT)};
   const auto delta_index{node.getInputs().at(ir::operation::Range::DELTA)};
 
-  auto output_tensor = _tensor_reg->getPortableTensor(output_index).get();
-  auto start_tensor = _tensor_reg->getPortableTensor(start_index).get();
-  auto limit_tensor = _tensor_reg->getPortableTensor(limit_index).get();
-  auto delta_tensor = _tensor_reg->getPortableTensor(delta_index).get();
+  auto output_tensor = _tensor_reg->getPortableTensor(output_index);
+  auto start_tensor = _tensor_reg->getPortableTensor(start_index);
+  auto limit_tensor = _tensor_reg->getPortableTensor(limit_index);
+  auto delta_tensor = _tensor_reg->getPortableTensor(delta_index);
 
   auto fn = std::make_unique<ops::RangeLayer>();
 
@@ -1079,8 +1078,8 @@ void KernelGenerator::visit(const ir::operation::Rank &node)
   const auto ofm_index{node.getOutputs().at(0)};
   const auto ifm_index{node.getInputs().at(ir::operation::Shape::Input::INPUT)};
 
-  auto ofm_tensor = _tensor_reg->getPortableTensor(ofm_index).get();
-  auto ifm_tensor = _tensor_reg->getPortableTensor(ifm_index).get();
+  auto ofm_tensor = _tensor_reg->getPortableTensor(ofm_index);
+  auto ifm_tensor = _tensor_reg->getPortableTensor(ifm_index);
 
   auto fn = std::make_unique<ops::RankLayer>();
 
@@ -1095,9 +1094,9 @@ void KernelGenerator::visit(const ir::operation::SquaredDifference &node)
   const auto lhs_index{node.getInputs().at(ir::operation::SquaredDifference::Input::LHS)};
   const auto rhs_index{node.getInputs().at(ir::operation::SquaredDifference::Input::RHS)};
 
-  auto ofm_tensor = _tensor_reg->getPortableTensor(ofm_index).get();
-  auto lhs_tensor = _tensor_reg->getPortableTensor(lhs_index).get();
-  auto rhs_tensor = _tensor_reg->getPortableTensor(rhs_index).get();
+  auto ofm_tensor = _tensor_reg->getPortableTensor(ofm_index);
+  auto lhs_tensor = _tensor_reg->getPortableTensor(lhs_index);
+  auto rhs_tensor = _tensor_reg->getPortableTensor(rhs_index);
 
   auto fn = std::make_unique<ops::SqDiffLayer>();
 
@@ -1111,9 +1110,9 @@ void KernelGenerator::visit(const ir::operation::Tile &node)
   const auto input_index{node.getInputs().at(ir::operation::Tile::INPUT)};
   const auto multiples_index{node.getInputs().at(ir::operation::Tile::MULTIPLES)};
 
-  auto output_tensor = _tensor_reg->getPortableTensor(output_index).get();
-  auto input_tensor = _tensor_reg->getPortableTensor(input_index).get();
-  auto multiples_tensor = _tensor_reg->getPortableTensor(multiples_index).get();
+  auto output_tensor = _tensor_reg->getPortableTensor(output_index);
+  auto input_tensor = _tensor_reg->getPortableTensor(input_index);
+  auto multiples_tensor = _tensor_reg->getPortableTensor(multiples_index);
 
   auto fn = std::make_unique<ops::TileLayer>();
 
@@ -1128,10 +1127,10 @@ void KernelGenerator::visit(const ir::operation::MatrixBandPart &node)
   const auto num_lower_index{node.getInputs().at(ir::operation::MatrixBandPart::NUM_LOWER_DIAG)};
   const auto num_upper_index{node.getInputs().at(ir::operation::MatrixBandPart::NUM_UPPER_DIAG)};
 
-  auto output_tensor = _tensor_reg->getPortableTensor(output_index).get();
-  auto input_tensor = _tensor_reg->getPortableTensor(input_index).get();
-  auto num_lower_tensor = _tensor_reg->getPortableTensor(num_lower_index).get();
-  auto num_upper_tensor = _tensor_reg->getPortableTensor(num_upper_index).get();
+  auto output_tensor = _tensor_reg->getPortableTensor(output_index);
+  auto input_tensor = _tensor_reg->getPortableTensor(input_index);
+  auto num_lower_tensor = _tensor_reg->getPortableTensor(num_lower_index);
+  auto num_upper_tensor = _tensor_reg->getPortableTensor(num_upper_index);
 
   auto fn = std::make_unique<ops::MatrixBandPartLayer>();
 
@@ -1145,9 +1144,9 @@ void KernelGenerator::visit(const ir::operation::BatchMatMul &node)
   const auto lhs_index{node.getInputs().at(ir::operation::BatchMatMul::LHS)};
   const auto rhs_index{node.getInputs().at(ir::operation::BatchMatMul::RHS)};
 
-  auto output_tensor = _tensor_reg->getPortableTensor(output_index).get();
-  auto lhs_tensor = _tensor_reg->getPortableTensor(lhs_index).get();
-  auto rhs_tensor = _tensor_reg->getPortableTensor(rhs_index).get();
+  auto output_tensor = _tensor_reg->getPortableTensor(output_index);
+  auto lhs_tensor = _tensor_reg->getPortableTensor(lhs_index);
+  auto rhs_tensor = _tensor_reg->getPortableTensor(rhs_index);
 
   const auto adj_x = node.param().adj_x;
   const auto adj_y = node.param().adj_y;
@@ -1164,9 +1163,9 @@ void KernelGenerator::visit(const ir::operation::BroadcastTo &node)
   const auto input_index{node.getInputs().at(ir::operation::BroadcastTo::INPUT)};
   const auto shape_index{node.getInputs().at(ir::operation::BroadcastTo::SHAPE)};
 
-  auto output_tensor = _tensor_reg->getPortableTensor(output_index).get();
-  auto input_tensor = _tensor_reg->getPortableTensor(input_index).get();
-  auto shape_tensor = _tensor_reg->getPortableTensor(shape_index).get();
+  auto output_tensor = _tensor_reg->getPortableTensor(output_index);
+  auto input_tensor = _tensor_reg->getPortableTensor(input_index);
+  auto shape_tensor = _tensor_reg->getPortableTensor(shape_index);
 
   auto fn = std::make_unique<ops::BroadcastToLayer>();
 
@@ -1179,10 +1178,10 @@ void KernelGenerator::visit(const ir::operation::FusedBatchNorm &node)
 {
   const auto ofm_index{node.getOutputs().at(0)};
 
-  auto output_tensor = _tensor_reg->getPortableTensor(ofm_index).get();
+  auto output_tensor = _tensor_reg->getPortableTensor(ofm_index);
   std::vector<const IPortableTensor *> input_tensors;
   for (auto &ifm_idx : node.getInputs())
-    input_tensors.emplace_back(_tensor_reg->getPortableTensor(ifm_idx).get());
+    input_tensors.emplace_back(_tensor_reg->getPortableTensor(ifm_idx));
 
   const auto epsilon = node.param().epsilon;
   const auto is_training = node.param().is_training;
@@ -1203,8 +1202,8 @@ void KernelGenerator::visit(const ir::operation::LogSoftmax &node)
   const auto beta = node.param().beta;
   const auto axis = node.param().axis;
 
-  auto output_tensor = _tensor_reg->getPortableTensor(output_index).get();
-  auto input_tensor = _tensor_reg->getPortableTensor(input_index).get();
+  auto output_tensor = _tensor_reg->getPortableTensor(output_index);
+  auto input_tensor = _tensor_reg->getPortableTensor(input_index);
 
   auto fn = std::make_unique<ops::LogSoftMaxLayer>();
 
@@ -1220,10 +1219,10 @@ void KernelGenerator::visit(const ir::operation::SpaceToBatchND &node)
   const auto block_shape_index{node.getInputs().at(ir::operation::SpaceToBatchND::BLOCK_SIZE)};
   const auto padding_index{node.getInputs().at(ir::operation::SpaceToBatchND::PADDINGS)};
 
-  auto output_tensor = _tensor_reg->getPortableTensor(output_index).get();
-  auto input_tensor = _tensor_reg->getPortableTensor(input_index).get();
-  auto block_shape_tensor = _tensor_reg->getPortableTensor(block_shape_index).get();
-  auto padding_tensor = _tensor_reg->getPortableTensor(padding_index).get();
+  auto output_tensor = _tensor_reg->getPortableTensor(output_index);
+  auto input_tensor = _tensor_reg->getPortableTensor(input_index);
+  auto block_shape_tensor = _tensor_reg->getPortableTensor(block_shape_index);
+  auto padding_tensor = _tensor_reg->getPortableTensor(padding_index);
 
   auto fn = std::make_unique<ops::SpaceToBatchNDLayer>();
 
@@ -1238,8 +1237,8 @@ void KernelGenerator::visit(const ir::operation::SpaceToDepth &node)
   const auto output_index{node.getOutputs().at(0)};
   auto block_size = node.param().block_size;
 
-  auto input_tensor = _tensor_reg->getPortableTensor(input_index).get();
-  auto output_tensor = _tensor_reg->getPortableTensor(output_index).get();
+  auto input_tensor = _tensor_reg->getPortableTensor(input_index);
+  auto output_tensor = _tensor_reg->getPortableTensor(output_index);
 
   auto fn = std::make_unique<ops::SpaceToDepthLayer>();
 
@@ -1253,9 +1252,9 @@ void KernelGenerator::visit(const ir::operation::StatelessRandomUniform &node)
   const auto shape_index{node.getInputs().at(ir::operation::StatelessRandomUniform::SHAPE)};
   const auto seed_index{node.getInputs().at(ir::operation::StatelessRandomUniform::SEED)};
 
-  auto output_alloc = _tensor_reg->getPortableTensor(output_index).get();
-  auto shape_alloc = _tensor_reg->getPortableTensor(shape_index).get();
-  auto seed_alloc = _tensor_reg->getPortableTensor(seed_index).get();
+  auto output_alloc = _tensor_reg->getPortableTensor(output_index);
+  auto shape_alloc = _tensor_reg->getPortableTensor(shape_index);
+  auto seed_alloc = _tensor_reg->getPortableTensor(seed_index);
 
   auto fn = std::make_unique<ops::StatelessRandomUniformLayer>();
 
@@ -1272,13 +1271,13 @@ void KernelGenerator::visit(const ir::operation::SplitV &node)
   const auto size_splits{node.getInputs().at(ir::operation::SplitV::Input::SIZE_SPLITS)};
   const auto split_dim{node.getInputs().at(ir::operation::SplitV::Input::SPLIT_DIM)};
 
-  auto in_tensor = _tensor_reg->getPortableTensor(input_idx).get();
-  auto in_size_splits = _tensor_reg->getPortableTensor(size_splits).get();
-  auto in_split_dim = _tensor_reg->getPortableTensor(split_dim).get();
+  auto in_tensor = _tensor_reg->getPortableTensor(input_idx);
+  auto in_size_splits = _tensor_reg->getPortableTensor(size_splits);
+  auto in_split_dim = _tensor_reg->getPortableTensor(split_dim);
 
   std::vector<IPortableTensor *> out_tensors;
   for (auto &output_idx : node.getOutputs())
-    out_tensors.emplace_back(_tensor_reg->getPortableTensor(output_idx).get());
+    out_tensors.emplace_back(_tensor_reg->getPortableTensor(output_idx));
 
   auto fn = std::make_unique<ops::SplitVLayer>();
 

--- a/runtime/onert/backend/cpu/StaticTensorManager.cc
+++ b/runtime/onert/backend/cpu/StaticTensorManager.cc
@@ -41,7 +41,7 @@ void StaticTensorManager::allocateNonconsts(void)
   for (auto &pair : _tensors->native_tensors())
   {
     const auto &ind = pair.first;
-    auto tensor = pair.second;
+    auto tensor = pair.second.get();
     if (!_as_constants[ind] && !tensor->is_dynamic())
     {
       auto *buffer = _nonconst_mgr->getBuffer(ind);
@@ -62,14 +62,14 @@ void StaticTensorManager::buildTensor(const ir::OperandIndex &ind,
   assert(!_tensors->getITensor(ind));
   if (as_const)
   {
-    auto tensor = std::make_shared<ExternalTensor>(tensor_info, backend_layout);
-    _tensors->setNativeTensor(ind, tensor);
+    auto tensor = std::make_unique<ExternalTensor>(tensor_info, backend_layout);
+    _tensors->setNativeTensor(ind, std::move(tensor));
   }
   else
   {
-    auto tensor = std::make_shared<Tensor>(tensor_info, backend_layout,
+    auto tensor = std::make_unique<Tensor>(tensor_info, backend_layout,
                                            _dynamic_tensor_manager->dynamic_mem_mgr().get());
-    _tensors->setNativeTensor(ind, tensor);
+    _tensors->setNativeTensor(ind, std::move(tensor));
   }
   _as_constants[ind] = as_const;
 }

--- a/runtime/onert/core/include/backend/CustomKernelBuilder.h
+++ b/runtime/onert/core/include/backend/CustomKernelBuilder.h
@@ -49,10 +49,10 @@ struct TypeInfo
 
 struct CustomKernelConfigParams
 {
-  std::vector<std::shared_ptr<backend::IPortableTensor>> input_tensors;
+  std::vector<backend::IPortableTensor *> input_tensors;
   std::vector<TypeInfo> input_types;
 
-  std::vector<std::shared_ptr<backend::IPortableTensor>> output_tensors;
+  std::vector<backend::IPortableTensor *> output_tensors;
   std::vector<TypeInfo> output_types;
 
   char *userdata;

--- a/runtime/onert/core/include/backend/ITensorRegistry.h
+++ b/runtime/onert/core/include/backend/ITensorRegistry.h
@@ -43,7 +43,7 @@ struct ITensorRegistry
    *
    * @note  Return tensor cannot be used longer than dynamic tensor manager
    */
-  virtual std::shared_ptr<ITensor> getITensor(const ir::OperandIndex &) = 0;
+  virtual ITensor *getITensor(const ir::OperandIndex &) = 0;
   /**
    * @brief Returns pointer of ITensor among native tensors
    *
@@ -51,17 +51,14 @@ struct ITensorRegistry
    *
    * @note  Returned tensor cannot be used longer than dynamic tensor manager
    */
-  virtual std::shared_ptr<ITensor> getNativeITensor(const ir::OperandIndex &) = 0;
+  virtual ITensor *getNativeITensor(const ir::OperandIndex &) = 0;
   /**
    * @brief Set the Migrant Tensor which are from other backends
    *
    * @return true if supported
    * @return false if not supported
    */
-  virtual bool setMigrantTensor(const ir::OperandIndex &, const std::shared_ptr<IPortableTensor> &)
-  {
-    return false;
-  }
+  virtual bool setMigrantTensor(const ir::OperandIndex &, IPortableTensor *) { return false; }
 };
 
 } // namespace backend
@@ -85,7 +82,7 @@ namespace backend
 template <typename T_Tensor> class PortableTensorRegistryTemplate : public ITensorRegistry
 {
 public:
-  std::shared_ptr<ITensor> getITensor(const ir::OperandIndex &ind) override
+  ITensor *getITensor(const ir::OperandIndex &ind) override
   {
     static_assert(std::is_base_of<ITensor, T_Tensor>::value, "T_Tensor must derive from ITensor.");
     auto external_tensor = _migrant.find(ind);
@@ -94,12 +91,9 @@ public:
     return getNativeTensor(ind);
   }
 
-  std::shared_ptr<ITensor> getNativeITensor(const ir::OperandIndex &ind) override
-  {
-    return getNativeTensor(ind);
-  }
+  ITensor *getNativeITensor(const ir::OperandIndex &ind) override { return getNativeTensor(ind); }
 
-  std::shared_ptr<IPortableTensor> getPortableTensor(const ir::OperandIndex &ind)
+  IPortableTensor *getPortableTensor(const ir::OperandIndex &ind)
   {
     auto external_tensor = _migrant.find(ind);
     if (external_tensor != _migrant.end())
@@ -110,16 +104,15 @@ public:
     return getNativeTensor(ind);
   }
 
-  std::shared_ptr<T_Tensor> getNativeTensor(const ir::OperandIndex &ind)
+  T_Tensor *getNativeTensor(const ir::OperandIndex &ind)
   {
     auto tensor = _native.find(ind);
     if (tensor != _native.end())
-      return tensor->second;
+      return tensor->second.get();
     return nullptr;
   }
 
-  bool setMigrantTensor(const ir::OperandIndex &ind,
-                        const std::shared_ptr<IPortableTensor> &tensor) override
+  bool setMigrantTensor(const ir::OperandIndex &ind, IPortableTensor *tensor) override
   {
     assert(tensor != nullptr);
     auto itr = _native.find(ind);
@@ -129,25 +122,22 @@ public:
     return true;
   }
 
-  void setNativeTensor(const ir::OperandIndex &ind, const std::shared_ptr<T_Tensor> &tensor)
+  void setNativeTensor(const ir::OperandIndex &ind, std::unique_ptr<T_Tensor> &&tensor)
   {
     assert(tensor != nullptr);
     auto itr = _migrant.find(ind);
     if (itr != _migrant.end())
       throw std::runtime_error{"Tried to set a native tensor but a migrant tensor already exists."};
-    _native[ind] = tensor;
+    _native[ind] = std::move(tensor);
   }
 
-  const ir::OperandIndexMap<std::shared_ptr<T_Tensor>> &native_tensors() { return _native; }
+  const ir::OperandIndexMap<std::unique_ptr<T_Tensor>> &native_tensors() { return _native; }
 
-  const ir::OperandIndexMap<std::shared_ptr<IPortableTensor>> &migrant_tensors()
-  {
-    return _migrant;
-  }
+  const ir::OperandIndexMap<IPortableTensor *> &migrant_tensors() { return _migrant; }
 
 private:
-  ir::OperandIndexMap<std::shared_ptr<IPortableTensor>> _migrant;
-  ir::OperandIndexMap<std::shared_ptr<T_Tensor>> _native;
+  ir::OperandIndexMap<IPortableTensor *> _migrant;
+  ir::OperandIndexMap<std::unique_ptr<T_Tensor>> _native;
 };
 
 } // namespace backend

--- a/runtime/onert/core/src/backend/controlflow/DynamicTensorManager.cc
+++ b/runtime/onert/core/src/backend/controlflow/DynamicTensorManager.cc
@@ -36,8 +36,8 @@ void DynamicTensorManager::buildTensor(const ir::OperandIndex &ind,
                                        ir::Layout backend_layout)
 {
   auto tensor =
-      std::make_shared<cpu_common::Tensor>(tensor_info, backend_layout, _dynamic_mem_mgr.get());
-  _tensors->setNativeOwnTensor(ind, tensor);
+      std::make_unique<cpu_common::Tensor>(tensor_info, backend_layout, _dynamic_mem_mgr.get());
+  _tensors->setNativeOwnTensor(ind, std::move(tensor));
 }
 
 void DynamicTensorManager::planDealloc(ir::OperationIndex op_ind, ir::OperandIndex operand_ind)
@@ -75,7 +75,7 @@ void DynamicTensorManager::deallocSubgraphOutput(ir::OperandIndex output_ind)
 
 const ITensor *DynamicTensorManager::getRawITensor(ir::OperandIndex ind)
 {
-  auto ptr = _tensors->getITensor(ind).get();
+  auto ptr = _tensors->getITensor(ind);
   assert(ptr);
   return ptr;
 }

--- a/runtime/onert/core/src/backend/controlflow/KernelGenerator.cc
+++ b/runtime/onert/core/src/backend/controlflow/KernelGenerator.cc
@@ -78,7 +78,7 @@ void KernelGenerator::visit(const ir::operation::If &node)
   const auto then_subg_index = node.param().then_subg_index;
   const auto else_subg_index = node.param().else_subg_index;
 
-  std::vector<std::shared_ptr<backend::ITensor>> input_tensors;
+  std::vector<backend::ITensor *> input_tensors;
   for (const auto input_index : node.getInputs())
   {
     auto input_tensor = getTensor(input_index);
@@ -86,7 +86,7 @@ void KernelGenerator::visit(const ir::operation::If &node)
     input_tensors.emplace_back(input_tensor);
   }
 
-  std::vector<std::shared_ptr<backend::ITensor>> output_tensors;
+  std::vector<backend::ITensor *> output_tensors;
   for (const auto output_index : node.getOutputs())
   {
     auto output_tensor = getTensor(output_index);
@@ -110,8 +110,8 @@ void KernelGenerator::visit(const ir::operation::Permute &node)
   const auto input_index{node.getInputs().at(0)};
 
   // Add PermuteLayer
-  std::vector<std::shared_ptr<ITensor>> output_tensors{getTensor(output_index)};
-  std::vector<std::shared_ptr<ITensor>> input_tensors{getTensor(input_index)};
+  std::vector<ITensor *> output_tensors{getTensor(output_index)};
+  std::vector<ITensor *> input_tensors{getTensor(input_index)};
 
   auto fn = std::make_unique<kernel::PermuteLayer>(input_tensors, output_tensors);
   _return_fn = std::move(fn);
@@ -124,7 +124,7 @@ void KernelGenerator::visit(const ir::operation::While &node)
 
   // This op does not support input as a constant, because controlflow backend does not have
   // TensorBuilder
-  std::vector<std::shared_ptr<backend::ITensor>> input_tensors;
+  std::vector<backend::ITensor *> input_tensors;
   for (const auto input_index : node.getInputs())
   {
     auto input_tensor = getTensor(input_index);
@@ -132,7 +132,7 @@ void KernelGenerator::visit(const ir::operation::While &node)
     input_tensors.emplace_back(input_tensor);
   }
 
-  std::vector<std::shared_ptr<backend::ITensor>> output_tensors;
+  std::vector<backend::ITensor *> output_tensors;
   for (const auto output_index : node.getOutputs())
   {
     auto output_tensor = getTensor(output_index);
@@ -148,9 +148,9 @@ void KernelGenerator::visit(const ir::operation::While &node)
   _return_fn = std::move(fn);
 }
 
-std::shared_ptr<backend::ITensor> KernelGenerator::getTensor(const ir::OperandIndex &index)
+backend::ITensor *KernelGenerator::getTensor(const ir::OperandIndex &index)
 {
-  std::shared_ptr<backend::ITensor> ret = _tensor_registries.getITensor(index);
+  backend::ITensor *ret = _tensor_registries.getITensor(index);
   assert(ret != nullptr);
   return ret;
 }

--- a/runtime/onert/core/src/backend/controlflow/KernelGenerator.h
+++ b/runtime/onert/core/src/backend/controlflow/KernelGenerator.h
@@ -56,7 +56,7 @@ public:
   void visit(const ir::operation::While &) override;
 
 private:
-  std::shared_ptr<backend::ITensor> getTensor(const ir::OperandIndex &index);
+  backend::ITensor *getTensor(const ir::OperandIndex &index);
 
 private:
   const ir::Graph &_graph;

--- a/runtime/onert/core/src/backend/controlflow/TensorBuilder.cc
+++ b/runtime/onert/core/src/backend/controlflow/TensorBuilder.cc
@@ -106,7 +106,7 @@ IDynamicTensorManager *TensorBuilder::dynamicTensorManager(void)
   return _dynamic_tensor_mgr.get();
 }
 
-std::shared_ptr<cpu_common::Tensor> TensorBuilder::nativeOwnTensorAt(const ir::OperandIndex &ind)
+cpu_common::Tensor *TensorBuilder::nativeOwnTensorAt(const ir::OperandIndex &ind)
 {
   return _tensor_reg->getNativeOwnTensor(ind);
 }

--- a/runtime/onert/core/src/backend/controlflow/TensorBuilder.h
+++ b/runtime/onert/core/src/backend/controlflow/TensorBuilder.h
@@ -65,9 +65,9 @@ public:
    * @brief Get tensor with a specific OperandIndex.
    * @param ind OperandIndex for the tensor. There must exist a tensor with this ind.
    *        If not, program will crash with assert or exception.
-   * @return shared_ptr<operand::Tensor>
+   * @return operand::Tensor *
    */
-  std::shared_ptr<cpu_common::Tensor> nativeOwnTensorAt(const ir::OperandIndex &ind);
+  cpu_common::Tensor *nativeOwnTensorAt(const ir::OperandIndex &ind);
 
 private:
   const std::shared_ptr<TensorRegistry> _tensor_reg;

--- a/runtime/onert/core/src/backend/controlflow/kernel/IfLayer.cc
+++ b/runtime/onert/core/src/backend/controlflow/kernel/IfLayer.cc
@@ -30,9 +30,8 @@ namespace controlflow
 namespace kernel
 {
 
-IfLayer::IfLayer(const std::shared_ptr<backend::ITensor> &cond_tensor,
-                 const std::vector<std::shared_ptr<backend::ITensor>> input_tensors,
-                 const std::vector<std::shared_ptr<backend::ITensor>> output_tensors,
+IfLayer::IfLayer(backend::ITensor *cond_tensor, const std::vector<backend::ITensor *> input_tensors,
+                 const std::vector<backend::ITensor *> output_tensors,
                  const ir::OperandIndexSequence &output_indices, const ir::Graph &graph,
                  const ir::SubgraphIndex &then_subg_index, const ir::SubgraphIndex &else_subg_index,
                  exec::ExecutorMap *executor_map)
@@ -61,7 +60,7 @@ void IfLayer::run()
   };
 
   exec::ExecutorBase *subg_exec = nullptr;
-  bool cond_result = getResultCond(_cond_tensor.get());
+  bool cond_result = getResultCond(_cond_tensor);
   if (cond_result)
   {
     VERBOSE(If) << "Call to $" << _then_subg_index << " (then)" << std::endl;
@@ -77,8 +76,8 @@ void IfLayer::run()
 
   const auto &subg_graph = subg_exec->graph();
 
-  std::vector<std::shared_ptr<backend::ITensor>> src_tensors;
-  std::vector<std::shared_ptr<backend::ITensor>> dst_tensors;
+  std::vector<backend::ITensor *> src_tensors;
+  std::vector<backend::ITensor *> dst_tensors;
   // Add tensors used in subgraph or contained in outputs of subgraph
   assert(subg_graph.getInputs().size() == _input_tensors.size());
   assert(subg_graph.getInputs().size() == subg_exec->getInputTensors().size());

--- a/runtime/onert/core/src/backend/controlflow/kernel/IfLayer.h
+++ b/runtime/onert/core/src/backend/controlflow/kernel/IfLayer.h
@@ -32,9 +32,8 @@ namespace kernel
 class IfLayer : public ::onert::exec::IFunction
 {
 public:
-  IfLayer(const std::shared_ptr<backend::ITensor> &cond_tensor,
-          const std::vector<std::shared_ptr<backend::ITensor>> input_tensors,
-          const std::vector<std::shared_ptr<backend::ITensor>> output_tensors,
+  IfLayer(backend::ITensor *cond_tensor, const std::vector<backend::ITensor *> input_tensors,
+          const std::vector<backend::ITensor *> output_tensors,
           const ir::OperandIndexSequence &output_indices, const ir::Graph &graph,
           const ir::SubgraphIndex &then_subg_index, const ir::SubgraphIndex &else_subg_index,
           exec::ExecutorMap *executor_map);
@@ -43,9 +42,9 @@ public:
   void run() override;
 
 private:
-  const std::shared_ptr<backend::ITensor> _cond_tensor;
-  const std::vector<std::shared_ptr<backend::ITensor>> _input_tensors;
-  const std::vector<std::shared_ptr<backend::ITensor>> _output_tensors;
+  backend::ITensor *_cond_tensor;
+  const std::vector<backend::ITensor *> _input_tensors;
+  const std::vector<backend::ITensor *> _output_tensors;
   const ir::OperandIndexSequence &_output_indices;
   const ir::Graph &_graph;
   const ir::SubgraphIndex _then_subg_index;

--- a/runtime/onert/core/src/backend/controlflow/kernel/PermuteLayer.h
+++ b/runtime/onert/core/src/backend/controlflow/kernel/PermuteLayer.h
@@ -33,8 +33,7 @@ namespace kernel
 class PermuteLayer : public onert::exec::IPermuteFunction
 {
 public:
-  PermuteLayer(const std::vector<std::shared_ptr<ITensor>> &src_tensors,
-               const std::vector<std::shared_ptr<ITensor>> &dst_tensors)
+  PermuteLayer(const std::vector<ITensor *> &src_tensors, const std::vector<ITensor *> &dst_tensors)
   {
     assert(src_tensors.size() == dst_tensors.size());
     _src_tensors = src_tensors;

--- a/runtime/onert/core/src/backend/controlflow/kernel/WhileLayer.cc
+++ b/runtime/onert/core/src/backend/controlflow/kernel/WhileLayer.cc
@@ -30,8 +30,8 @@ namespace controlflow
 namespace kernel
 {
 
-WhileLayer::WhileLayer(const std::vector<std::shared_ptr<backend::ITensor>> &input_tensors,
-                       const std::vector<std::shared_ptr<backend::ITensor>> &output_tensors,
+WhileLayer::WhileLayer(const std::vector<backend::ITensor *> input_tensors,
+                       const std::vector<backend::ITensor *> output_tensors,
                        const ir::OperandIndexSequence &output_indices, const ir::Graph &graph,
                        const ir::SubgraphIndex &cond_subg_index,
                        const ir::SubgraphIndex &body_subg_index, exec::ExecutorMap *executor_map)
@@ -62,11 +62,11 @@ void WhileLayer::run()
   const auto &cond_graph = cond_exec->graph();
   const auto &body_graph = body_exec->graph();
 
-  std::vector<std::shared_ptr<backend::ITensor>> input_tensors;
-  std::vector<std::shared_ptr<backend::ITensor>> cond_input_tensors;
-  std::vector<std::shared_ptr<backend::ITensor>> body_input_tensors;
-  std::vector<std::shared_ptr<backend::ITensor>> body_output_tensors;
-  std::vector<std::shared_ptr<backend::ITensor>> output_tensors;
+  std::vector<backend::ITensor *> input_tensors;
+  std::vector<backend::ITensor *> cond_input_tensors;
+  std::vector<backend::ITensor *> body_input_tensors;
+  std::vector<backend::ITensor *> body_output_tensors;
+  std::vector<backend::ITensor *> output_tensors;
 
   // Add only used tensors in cond subgraph
   assert(cond_graph.getInputs().size() == _input_tensors.size());
@@ -204,7 +204,7 @@ void WhileLayer::run()
   auto permute_to_outputs_fn = permute_op_input_to_op_output;
 
   // Loop while Cond subgraph's output is true
-  while (getResultCond(cond_output_tensor.get()))
+  while (getResultCond(cond_output_tensor))
   {
     body_execute();
     cond_execute();

--- a/runtime/onert/core/src/backend/controlflow/kernel/WhileLayer.h
+++ b/runtime/onert/core/src/backend/controlflow/kernel/WhileLayer.h
@@ -35,8 +35,8 @@ namespace kernel
 class WhileLayer : public ::onert::exec::IFunction
 {
 public:
-  WhileLayer(const std::vector<std::shared_ptr<backend::ITensor>> &input_tensors,
-             const std::vector<std::shared_ptr<backend::ITensor>> &output_tensors,
+  WhileLayer(const std::vector<backend::ITensor *> input_tensors,
+             const std::vector<backend::ITensor *> output_tensors,
              const ir::OperandIndexSequence &output_indices, const ir::Graph &graph,
              const ir::SubgraphIndex &cond_subg_index, const ir::SubgraphIndex &body_subg_index,
              exec::ExecutorMap *executor_map);
@@ -49,8 +49,8 @@ private:
   const ir::SubgraphIndex _body_subg_index;
   const ir::OperandIndexSequence &_output_indices;
   const ir::Graph &_graph;
-  const std::vector<std::shared_ptr<backend::ITensor>> _input_tensors;
-  const std::vector<std::shared_ptr<backend::ITensor>> _output_tensors;
+  const std::vector<backend::ITensor *> _input_tensors;
+  const std::vector<backend::ITensor *> _output_tensors;
   exec::ExecutorMap *_executor_map;
 };
 

--- a/runtime/onert/core/src/backend/cpu_common/DynamicTensorManager.cc
+++ b/runtime/onert/core/src/backend/cpu_common/DynamicTensorManager.cc
@@ -36,8 +36,8 @@ void DynamicTensorManager::buildTensor(const ir::OperandIndex &ind,
                                        ir::Layout backend_layout)
 {
   assert(_tensors->getNativeTensor(ind) == nullptr);
-  auto tensor = std::make_shared<Tensor>(tensor_info, backend_layout, _dynamic_mem_mgr.get());
-  _tensors->setNativeTensor(ind, tensor);
+  auto tensor = std::make_unique<Tensor>(tensor_info, backend_layout, _dynamic_mem_mgr.get());
+  _tensors->setNativeTensor(ind, std::move(tensor));
 }
 
 void DynamicTensorManager::planDealloc(ir::OperationIndex op_ind, ir::OperandIndex operand_ind)
@@ -54,7 +54,7 @@ void DynamicTensorManager::deallocInput(ir::OperationIndex op_ind)
   auto &input_set = find->second;
   for (auto input_ind : input_set)
   {
-    auto *tensor = _tensors->getNativeTensor(input_ind).get();
+    auto *tensor = _tensors->getNativeTensor(input_ind);
     if (!tensor->is_dynamic())
       continue;
 
@@ -68,7 +68,7 @@ void DynamicTensorManager::deallocInput(ir::OperationIndex op_ind)
 
 void DynamicTensorManager::deallocSubgraphOutput(ir::OperandIndex output_ind)
 {
-  auto *tensor = _tensors->getNativeTensor(output_ind).get();
+  auto *tensor = _tensors->getNativeTensor(output_ind);
   if (!tensor->is_dynamic())
     return;
 
@@ -81,7 +81,7 @@ void DynamicTensorManager::deallocSubgraphOutput(ir::OperandIndex output_ind)
 
 const ITensor *DynamicTensorManager::getRawITensor(ir::OperandIndex ind)
 {
-  auto ptr = _tensors->getITensor(ind).get();
+  auto ptr = _tensors->getITensor(ind);
   assert(ptr);
   return ptr;
 }

--- a/runtime/onert/core/src/backend/cpu_common/StaticTensorManager.cc
+++ b/runtime/onert/core/src/backend/cpu_common/StaticTensorManager.cc
@@ -39,10 +39,10 @@ void StaticTensorManager::allocateConsts(void)
   for (auto &pair : _tensors->native_tensors())
   {
     const auto &ind = pair.first;
-    auto tensor = pair.second;
+    auto tensor = pair.second.get();
     if (_as_constants[ind])
     {
-      auto mem_alloc = _const_mgr->allocate(_tensors->getITensor(ind).get(), tensor->total_size());
+      auto mem_alloc = _const_mgr->allocate(_tensors->getITensor(ind), tensor->total_size());
       tensor->setBuffer(mem_alloc);
       auto buffer = mem_alloc->base();
       VERBOSE(CPU_COMMON_StaticTensorManager) << "CONSTANT TENSOR(#" << ind.value()
@@ -59,7 +59,7 @@ void StaticTensorManager::allocateNonconsts(void)
   for (auto &pair : _tensors->native_tensors())
   {
     const auto &ind = pair.first;
-    auto tensor = pair.second;
+    auto tensor = pair.second.get();
     if (!_as_constants[ind] && !tensor->is_dynamic())
     {
       auto *buffer = _nonconst_mgr->getBuffer(ind);
@@ -80,8 +80,8 @@ void StaticTensorManager::buildTensor(const ir::OperandIndex &ind,
                                       bool as_const)
 {
   assert(!_tensors->getNativeTensor(ind));
-  auto tensor = std::make_shared<Tensor>(tensor_info, backend_layout, _dynamic_mem_mgr);
-  _tensors->setNativeTensor(ind, tensor);
+  auto tensor = std::make_unique<Tensor>(tensor_info, backend_layout, _dynamic_mem_mgr);
+  _tensors->setNativeTensor(ind, std::move(tensor));
   _as_constants[ind] = as_const;
 }
 

--- a/runtime/onert/core/src/compiler/ExecutorFactory.h
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.h
@@ -46,7 +46,7 @@ private:
   static void initializeBackendContext(compiler::LoweredGraph *lowered_graph);
   static void runTensorRegistration(compiler::LoweredGraph *lowered_graph,
                                     const std::vector<ir::OpSequenceIndex> &order);
-  static std::vector<std::shared_ptr<backend::ITensor>>
+  static std::vector<backend::ITensor *>
   initializeModelIOTensors(compiler::LoweredGraph &lowered_graph,
                            const ir::OperandIndexSequence &indices);
   static void prepareExternalTensors(compiler::LoweredGraph &lowered_graph);

--- a/runtime/onert/core/src/compiler/TensorRegistries.h
+++ b/runtime/onert/core/src/compiler/TensorRegistries.h
@@ -69,7 +69,7 @@ public:
     return _cf_tensor_reg;
   }
 
-  std::shared_ptr<backend::ITensor> getITensor(ir::OperandIndex ind) const
+  backend::ITensor *getITensor(ir::OperandIndex ind) const
   {
     for (auto &tensor_reg : _tensor_regs)
     {

--- a/runtime/onert/core/src/exec/DataflowExecutor.cc
+++ b/runtime/onert/core/src/exec/DataflowExecutor.cc
@@ -77,11 +77,11 @@ bool DataflowExecutor::noWaitingJobs()
                      [](const std::unique_ptr<Job> &job) { return job == nullptr; });
 }
 
-DataflowExecutor::DataflowExecutor(
-    std::unique_ptr<compiler::LoweredGraph> lowered_graph,
-    const std::vector<std::shared_ptr<backend::ITensor>> &input_tensors,
-    const std::vector<std::shared_ptr<backend::ITensor>> &output_tensors,
-    const compiler::TensorRegistries &tensor_regs, compiler::CodeMap &&code_map)
+DataflowExecutor::DataflowExecutor(std::unique_ptr<compiler::LoweredGraph> lowered_graph,
+                                   const std::vector<backend::ITensor *> &input_tensors,
+                                   const std::vector<backend::ITensor *> &output_tensors,
+                                   const compiler::TensorRegistries &tensor_regs,
+                                   compiler::CodeMap &&code_map)
     : ExecutorBase{std::move(lowered_graph), input_tensors, output_tensors, tensor_regs},
       _code_map{std::move(code_map)}
 {

--- a/runtime/onert/core/src/exec/DataflowExecutor.h
+++ b/runtime/onert/core/src/exec/DataflowExecutor.h
@@ -50,8 +50,8 @@ public:
    * @param code_map OpSequence and its code map
    */
   DataflowExecutor(std::unique_ptr<compiler::LoweredGraph> lowered_graph,
-                   const std::vector<std::shared_ptr<backend::ITensor>> &input_tensors,
-                   const std::vector<std::shared_ptr<backend::ITensor>> &output_tensors,
+                   const std::vector<backend::ITensor *> &input_tensors,
+                   const std::vector<backend::ITensor *> &output_tensors,
                    const compiler::TensorRegistries &tensor_regs, compiler::CodeMap &&code_map);
 
   void executeImpl() override;

--- a/runtime/onert/core/src/exec/DynamicShapeInference.cc
+++ b/runtime/onert/core/src/exec/DynamicShapeInference.cc
@@ -95,10 +95,10 @@ void DynamicShapeInferer::handleSimpleUnaryOp(const ir::Operation &op,
 void DynamicShapeInferer::visit(const ir::operation::ArgMax &op)
 {
   const auto input_idx{op.getInputs().at(ir::operation::ArgMax::Input::INPUT)};
-  const auto &input = _tensor_registry->getITensor(input_idx);
+  const auto input = _tensor_registry->getITensor(input_idx);
 
   const auto axis_idx{op.getInputs().at(ir::operation::ArgMax::Input::AXIS)};
-  const auto &axis = _tensor_registry->getITensor(axis_idx);
+  const auto axis = _tensor_registry->getITensor(axis_idx);
 
   auto output_ind = op.getOutputs().at(0);
   auto output = _tensor_registry->getITensor(output_ind);
@@ -230,7 +230,7 @@ void DynamicShapeInferer::visit(const ir::operation::Concat &op)
     for (auto input_ind : op.getInputs())
     {
       auto input = _tensor_registry->getITensor(input_ind);
-      if (input != first_input && !isConcatible(first_input.get(), input.get(), op.param().axis))
+      if (input != first_input && !isConcatible(first_input, input, op.param().axis))
         throw std::runtime_error("input shapes does not matched for concat");
     }
   }
@@ -348,7 +348,7 @@ void DynamicShapeInferer::visit(const ir::operation::Fill &op)
   if ((!input->is_dynamic()) && (!output->is_dynamic()))
     return;
 
-  assert(input.get()->data_type() == ir::DataType::INT32);
+  assert(input->data_type() == ir::DataType::INT32);
 
   auto input_buf = reinterpret_cast<const int32_t *>(input->buffer());
   assert(input_buf);

--- a/runtime/onert/core/src/exec/ExecutorBase.h
+++ b/runtime/onert/core/src/exec/ExecutorBase.h
@@ -51,8 +51,8 @@ public:
    * @param tensor_builders Tensor builders that are currently used
    */
   ExecutorBase(std::unique_ptr<compiler::LoweredGraph> &&lowered_graph,
-               const std::vector<std::shared_ptr<backend::ITensor>> &input_tensors,
-               const std::vector<std::shared_ptr<backend::ITensor>> &output_tensors,
+               const std::vector<backend::ITensor *> &input_tensors,
+               const std::vector<backend::ITensor *> &output_tensors,
                const compiler::TensorRegistries &tensor_regs);
 
   virtual ~ExecutorBase() = default;
@@ -65,7 +65,7 @@ public:
    * @param src_tensor Tensor list that will be copied to input tensors of this
    * @param pre_fn The permutation function that copy from src_tensor to input tensors of this
    */
-  void execute(const std::vector<std::shared_ptr<backend::ITensor>> &src_tensors,
+  void execute(const std::vector<backend::ITensor *> &src_tensors,
                const std::shared_ptr<IPermuteFunction> &pre_fn);
 
   void execute(const IODescription &desc) final;
@@ -80,15 +80,9 @@ public:
 
   void addObserver(std::unique_ptr<IExecutionObserver> ref) { _subject.add(std::move(ref)); };
 
-  const std::vector<std::shared_ptr<backend::ITensor>> &getInputTensors() const
-  {
-    return _input_tensors;
-  }
+  const std::vector<backend::ITensor *> &getInputTensors() const { return _input_tensors; }
 
-  const std::vector<std::shared_ptr<backend::ITensor>> &getOutputTensors() const
-  {
-    return _output_tensors;
-  }
+  const std::vector<backend::ITensor *> &getOutputTensors() const { return _output_tensors; }
 
 protected:
   /**
@@ -101,8 +95,8 @@ protected:
   std::shared_ptr<ir::OperationIndexMap<int64_t>> _indexed_ranks;
   std::unique_ptr<compiler::LoweredGraph> _lowered_graph;
   const ir::Graph &_graph;
-  std::vector<std::shared_ptr<backend::ITensor>> _input_tensors;
-  std::vector<std::shared_ptr<backend::ITensor>> _output_tensors;
+  std::vector<backend::ITensor *> _input_tensors;
+  std::vector<backend::ITensor *> _output_tensors;
   std::mutex _mutex;
 
 private:

--- a/runtime/onert/core/src/exec/IPermuteFunction.h
+++ b/runtime/onert/core/src/exec/IPermuteFunction.h
@@ -56,7 +56,7 @@ public:
     auto dst_it = _dst_tensors.begin();
     while (src_it != _src_tensors.end())
     {
-      const auto src_tensor = *src_it;
+      auto src_tensor = *src_it;
       auto dst_tensor = *dst_it;
       if (src_tensor != dst_tensor)
       {
@@ -101,9 +101,8 @@ public:
   virtual void optimize() = 0;
 
 private:
-  template <class T>
-  void permute(const std::shared_ptr<backend::ITensor> &src, std::shared_ptr<backend::ITensor> &dst,
-               size_t rank)
+  // TODO make src const by proving const access()
+  template <class T> void permute(backend::ITensor *src, backend::ITensor *dst, size_t rank)
   {
     const auto permute_type = [&]() -> PermuteType {
       if (src->layout() == ir::Layout::NHWC && dst->layout() == ir::Layout::NCHW)
@@ -275,8 +274,8 @@ private:
   }
 
 protected:
-  std::vector<std::shared_ptr<backend::ITensor>> _src_tensors;
-  std::vector<std::shared_ptr<backend::ITensor>> _dst_tensors;
+  std::vector<backend::ITensor *> _src_tensors;
+  std::vector<backend::ITensor *> _dst_tensors;
   // TODO Remove this member if it is possible
   std::vector<size_t> _ranks;
 };

--- a/runtime/onert/core/src/exec/LinearExecutor.h
+++ b/runtime/onert/core/src/exec/LinearExecutor.h
@@ -47,8 +47,8 @@ public:
    * @param code_map OpSequence and its code map
    */
   LinearExecutor(std::unique_ptr<compiler::LoweredGraph> lowered_graph,
-                 const std::vector<std::shared_ptr<backend::ITensor>> &input_tensors,
-                 const std::vector<std::shared_ptr<backend::ITensor>> &output_tensors,
+                 const std::vector<backend::ITensor *> &input_tensors,
+                 const std::vector<backend::ITensor *> &output_tensors,
                  const compiler::TensorRegistries &tensor_regs, compiler::CodeMap &&code_map,
                  const std::vector<ir::OpSequenceIndex> &order)
       : ExecutorBase{std::move(lowered_graph), input_tensors, output_tensors, tensor_regs}

--- a/runtime/onert/core/src/exec/ParallelExecutor.cc
+++ b/runtime/onert/core/src/exec/ParallelExecutor.cc
@@ -59,11 +59,11 @@ void ParallelExecutor::notify(uint32_t finished_job_id)
   _cv_jobs.notify_all();
 }
 
-ParallelExecutor::ParallelExecutor(
-    std::unique_ptr<compiler::LoweredGraph> lowered_graph,
-    const std::vector<std::shared_ptr<backend::ITensor>> &input_tensors,
-    const std::vector<std::shared_ptr<backend::ITensor>> &output_tensors,
-    const compiler::TensorRegistries &tensor_regs, compiler::CodeMap &&code_map)
+ParallelExecutor::ParallelExecutor(std::unique_ptr<compiler::LoweredGraph> lowered_graph,
+                                   const std::vector<backend::ITensor *> &input_tensors,
+                                   const std::vector<backend::ITensor *> &output_tensors,
+                                   const compiler::TensorRegistries &tensor_regs,
+                                   compiler::CodeMap &&code_map)
     : DataflowExecutor{std::move(lowered_graph), input_tensors, output_tensors, tensor_regs,
                        std::move(code_map)}
 {

--- a/runtime/onert/core/src/exec/ParallelExecutor.h
+++ b/runtime/onert/core/src/exec/ParallelExecutor.h
@@ -51,8 +51,8 @@ public:
    * @param code_map OpSequence and its code map
    */
   ParallelExecutor(std::unique_ptr<compiler::LoweredGraph> lowered_graph,
-                   const std::vector<std::shared_ptr<backend::ITensor>> &input_tensors,
-                   const std::vector<std::shared_ptr<backend::ITensor>> &output_tensors,
+                   const std::vector<backend::ITensor *> &input_tensors,
+                   const std::vector<backend::ITensor *> &output_tensors,
                    const compiler::TensorRegistries &tensor_regs, compiler::CodeMap &&code_map);
 
   void executeImpl() override;


### PR DESCRIPTION
This commit enables the following:
- replace things like `shared_ptr<ITensor>` to `unique_ptr`, making `TensorRegistry` have ownership
- methods like `getITensor()` do not return `shared_ptr` but return _raw pointer_ to increase performance.

Please refer to [parent discussion](https://github.sec.samsung.net/STAR/nnfw/issues/11743) and [performance note showing that now `getITensor() is x2 faster](https://github.sec.samsung.net/STAR/nnfw/issues/11743#issuecomment-831227).

I check this commit with valgrind and there's no leak or invalid access due to this commit.

Note:
- I changed `shared_ptr` to `unique_ptr` in CPU code, However, for acl source code, I left `shared_ptr` in the internals acl code.

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>