### PR TITLE
[Res/TFPythonExamples]Add UnidirectionalLSTM operation case

### DIFF
--- a/res/TensorFlowPythonExamples/examples/unidirectional_sequence_LSTM/__init__.py
+++ b/res/TensorFlowPythonExamples/examples/unidirectional_sequence_LSTM/__init__.py
@@ -1,0 +1,4 @@
+import tensorflow as tf
+
+in_ = tf.compat.v1.placeholder(dtype=tf.float32, shape=[28, 28, 3], name="Hole")
+op_ = tf.compat.v1.keras.layers.LSTM(1, time_major=False, return_sequences=True)(in_)


### PR DESCRIPTION
Parent Issue : #4151 
Draft PR : #4260 

This commit add `UnidirectionalLSTM` operation related case.

according to [this](https://colab.research.google.com/github/tensorflow/tensorflow/blob/master/tensorflow/lite/examples/experimental_new_converter/Keras_LSTM_fusion_Codelab.ipynb), `UnidirectionalSequenceLSTM` is created from `tf.keras.layers.LSTM`.

ONE-DCO-1.0-Signed-off-by: KiDeuk Bang <rrstrous@nate.com>