### PR TITLE
[one-cmds] Update how-to-prepare-virtualenv.txt

### DIFF
--- a/compiler/one-cmds/how-to-prepare-virtualenv.txt
+++ b/compiler/one-cmds/how-to-prepare-virtualenv.txt
@@ -1,7 +1,7 @@
 About
 -----
 
-Last update: 2020-08-03
+Last update: 2020-09-15
 
 This document explains about 'one-prepare-venv' command.
 
@@ -20,14 +20,31 @@ $ sudo apt-get upgrade
 $ sudo apt-get install python3-pip python3-venv
 
 
-How to run
-----------
+How to run for Ubuntu
+---------------------
 
 Just run 'one-prepare-venv' command
 
 $ one-prepare-venv
 
 There will be venv folder as of result.
+
+
+How to run for Windows
+----------------------
+
+1. First, please prepare Python 3.5-3.7
+2. Open the Command Prompt as an administrator
+3. cd(change directory) to the directory where one-compiler is installed
+4. run below command
+```
+$ ONE\install\bin> python -m venv venv
+$ ONE\install\bin> cd venv/Scripts
+$ ONE\install\bin\venv/Scripts> pip.exe install -U pip
+$ ONE\install\bin\venv/Scripts> pip.exe install -U tensorflow-cpu==2.3.0
+```
+
+After running the above command, go back to MinGW and run one-compiler.
 
 
 Trouble shooting


### PR DESCRIPTION
This commit updates how-to-prepare-virtualenv.txt.

`How to run for Windows` section is added.

Related : #4122 
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>