### PR TITLE
[onert] Throw when odd OperationConstraint

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -112,7 +112,16 @@ NNFW_STATUS nnfw_session::load_circle_from_buffer(uint8_t *buffer, size_t size)
   if (size == 0)
     return NNFW_STATUS_ERROR;
 
-  _subgraphs = onert::circle_loader::loadModel(buffer, size);
+  try
+  {
+    _subgraphs = onert::circle_loader::loadModel(buffer, size);
+  }
+  catch (const std::exception &e)
+  {
+    std::cerr << "Error during model loading : " << e.what() << std::endl;
+    return NNFW_STATUS_ERROR;
+  }
+
   _compiler = std::make_unique<onert::compiler::Compiler>(_subgraphs);
 
   _state = State::MODEL_LOADED;

--- a/runtime/onert/core/src/ir/Operation.cc
+++ b/runtime/onert/core/src/ir/Operation.cc
@@ -25,8 +25,10 @@ namespace ir
 
 Operation::Operation(OperandConstraint input_constr, const OperandIndexSequence &inputs,
                      const OperandIndexSequence &outputs)
-    : _input_constr{input_constr}, _inputs{inputs}, _outputs{outputs}
+    : _input_constr{input_constr}
 {
+  setInputs(inputs);
+  setOutputs(outputs);
 }
 
 Operation::Operation(OperandConstraint input_constr) : _input_constr{input_constr} {}
@@ -35,7 +37,8 @@ Operation::~Operation() = default;
 
 void Operation::setInputs(const OperandIndexSequence &indexes)
 {
-  assert(_input_constr.check(indexes.size()));
+  if (!_input_constr.check(indexes.size()))
+    throw std::runtime_error{"Invalid number of input tensors for this operation."};
   _inputs = indexes;
 }
 

--- a/runtime/onert/core/src/ir/operation/BatchToSpaceND.cc
+++ b/runtime/onert/core/src/ir/operation/BatchToSpaceND.cc
@@ -31,7 +31,7 @@ void BatchToSpaceND::accept(OperationVisitor &v) const { v.visit(*this); }
 
 BatchToSpaceND::BatchToSpaceND(const OperandIndexSequence &inputs,
                                const OperandIndexSequence &outputs)
-    : Operation{OperandConstraint::createExact(3u), inputs, outputs}
+    : Operation{OperandConstraint::createInRange(2u, 3u), inputs, outputs}
 {
 }
 

--- a/runtime/onert/core/src/ir/operation/Fill.cc
+++ b/runtime/onert/core/src/ir/operation/Fill.cc
@@ -30,7 +30,7 @@ namespace operation
 void Fill::accept(OperationVisitor &v) const { v.visit(*this); }
 
 Fill::Fill(const OperandIndexSequence &inputs, const OperandIndexSequence &outputs)
-    : Operation{OperandConstraint::createExact(1u), inputs, outputs}
+    : Operation{OperandConstraint::createExact(2u), inputs, outputs}
 {
 }
 

--- a/runtime/onert/core/src/ir/operation/FullyConnected.cc
+++ b/runtime/onert/core/src/ir/operation/FullyConnected.cc
@@ -31,7 +31,7 @@ void FullyConnected::accept(OperationVisitor &v) const { v.visit(*this); }
 
 FullyConnected::FullyConnected(const OperandIndexSequence &inputs,
                                const OperandIndexSequence &outputs, const Param &param)
-    : Operation{OperandConstraint::createExact(3u), inputs, outputs}, _param{param}
+    : Operation{OperandConstraint::createInRange(2u, 3u), inputs, outputs}, _param{param}
 {
 }
 

--- a/runtime/onert/core/src/ir/operation/Pack.cc
+++ b/runtime/onert/core/src/ir/operation/Pack.cc
@@ -25,7 +25,7 @@ namespace operation
 void Pack::accept(OperationVisitor &v) const { v.visit(*this); }
 Pack::Pack(const OperandIndexSequence &inputs, const OperandIndexSequence &outputs,
            const Param &param)
-    : Operation{OperandConstraint::createAtLeast(3u), inputs, outputs}, _param{param}
+    : Operation{OperandConstraint::createAtLeast(2u), inputs, outputs}, _param{param}
 {
 }
 } // namespace operation

--- a/tests/nnfw_api/src/GenModelTest.h
+++ b/tests/nnfw_api/src/GenModelTest.h
@@ -152,11 +152,18 @@ public:
   const std::vector<std::string> &backends() const { return _backends; }
 
   /**
+   * @brief Return test is defined to fail on model load
+   *
+   * @return bool test is defined to fail on model load
+   */
+  bool expected_expected_fail_model_load() const { return _expected_fail_model_load; }
+
+  /**
    * @brief Return test is defined to fail on compile
    *
    * @return bool test is defined to fail on compile
    */
-  const bool fail_compile() const { return _fail_compile; }
+  bool expected_expected_fail_compile() const { return _expected_fail_compile; }
 
   /**
    * @brief Set the output buffer size of specified output tensor
@@ -204,16 +211,22 @@ public:
   }
 
   /**
-   * @brief Set the Test Fail while compiling
+   * @brief Expect failure while model load
    */
-  void setCompileFail() { _fail_compile = true; }
+  void expectFailModelLoad() { _expected_fail_model_load = true; }
+
+  /**
+   * @brief Expect failure while compiling
+   */
+  void expectFailCompile() { _expected_fail_compile = true; }
 
 private:
   CircleBuffer _cbuf;
   std::vector<TestCaseData> _test_cases;
   std::vector<std::string> _backends;
   std::unordered_map<uint32_t, size_t> _output_sizes;
-  bool _fail_compile{false};
+  bool _expected_fail_model_load{false};
+  bool _expected_fail_compile{false};
 };
 
 /**
@@ -242,10 +255,19 @@ protected:
       //      nnfw_load_circle_from_buffer to outside forloop
       NNFW_ENSURE_SUCCESS(nnfw_create_session(&_so.session));
       auto &cbuf = _context->cbuf();
-      NNFW_ENSURE_SUCCESS(nnfw_load_circle_from_buffer(_so.session, cbuf.buffer(), cbuf.size()));
+      auto model_load_result =
+          nnfw_load_circle_from_buffer(_so.session, cbuf.buffer(), cbuf.size());
+      if (_context->expected_expected_fail_model_load())
+      {
+        ASSERT_NE(model_load_result, NNFW_STATUS_NO_ERROR);
+        std::cerr << "Failed model loading as expected." << std::endl;
+        NNFW_ENSURE_SUCCESS(nnfw_close_session(_so.session));
+        continue;
+      }
+      NNFW_ENSURE_SUCCESS(model_load_result);
       NNFW_ENSURE_SUCCESS(nnfw_set_available_backends(_so.session, backend.data()));
 
-      if (_context->fail_compile())
+      if (_context->expected_expected_fail_compile())
       {
         ASSERT_EQ(nnfw_prepare(_so.session), NNFW_STATUS_ERROR);
 

--- a/tests/nnfw_api/src/one_op_tests/Add.cc
+++ b/tests/nnfw_api/src/one_op_tests/Add.cc
@@ -64,7 +64,7 @@ TEST_F(GenModelTest, neg_OneOp_Add_InvalidShape)
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
-  _context->setCompileFail();
+  _context->expectFailCompile();
 
   SUCCEED();
 }
@@ -82,7 +82,7 @@ TEST_F(GenModelTest, neg_OneOp_Add_InvalidShapeConst)
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
-  _context->setCompileFail();
+  _context->expectFailCompile();
 
   SUCCEED();
 }
@@ -97,7 +97,7 @@ TEST_F(GenModelTest, neg_OneOp_Add_OneOperand)
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
-  _context->setCompileFail();
+  _context->expectFailModelLoad();
 
   SUCCEED();
 }

--- a/tests/nnfw_api/src/one_op_tests/ArgMax.cc
+++ b/tests/nnfw_api/src/one_op_tests/ArgMax.cc
@@ -75,7 +75,7 @@ TEST_F(GenModelTest, neg_OneOp_ArgMax_InvalidAxis0)
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
-  _context->setCompileFail();
+  _context->expectFailCompile();
 
   SUCCEED();
 }
@@ -94,7 +94,7 @@ TEST_F(GenModelTest, neg_OneOp_ArgMax_InvalidAxis1)
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
-  _context->setCompileFail();
+  _context->expectFailCompile();
 
   SUCCEED();
 }

--- a/tests/nnfw_api/src/one_op_tests/AveragePool2D.cc
+++ b/tests/nnfw_api/src/one_op_tests/AveragePool2D.cc
@@ -43,7 +43,7 @@ TEST_F(GenModelTest, neg_OneOp_AvgPool2D)
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
-  _context->setCompileFail();
+  _context->expectFailCompile();
 
   SUCCEED();
 }

--- a/tests/nnfw_api/src/one_op_tests/Cos.cc
+++ b/tests/nnfw_api/src/one_op_tests/Cos.cc
@@ -44,7 +44,7 @@ TEST_F(GenModelTest, neg_OneOp_Cos_TwoOperand)
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
   _context->setBackends({"cpu"});
-  _context->setCompileFail();
+  _context->expectFailModelLoad();
 
   SUCCEED();
 }

--- a/tests/nnfw_api/src/one_op_tests/Pad.cc
+++ b/tests/nnfw_api/src/one_op_tests/Pad.cc
@@ -49,7 +49,7 @@ TEST_F(GenModelTest, neg_OneOp_Pad_InvalidPadRank)
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
-  _context->setCompileFail();
+  _context->expectFailCompile();
 
   SUCCEED();
 }
@@ -68,7 +68,7 @@ TEST_F(GenModelTest, neg_OneOp_Pad_InvalidPadDim0)
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
-  _context->setCompileFail();
+  _context->expectFailCompile();
 
   SUCCEED();
 }
@@ -87,7 +87,7 @@ TEST_F(GenModelTest, neg_OneOp_Pad_InvalidPadDim1)
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
-  _context->setCompileFail();
+  _context->expectFailCompile();
 
   SUCCEED();
 }

--- a/tests/nnfw_api/src/one_op_tests/PadV2.cc
+++ b/tests/nnfw_api/src/one_op_tests/PadV2.cc
@@ -60,7 +60,7 @@ TEST_F(GenModelTest, neg_OneOp_PadV2_InvalidPadRank)
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
-  _context->setCompileFail();
+  _context->expectFailCompile();
 
   SUCCEED();
 }
@@ -84,7 +84,7 @@ TEST_F(GenModelTest, neg_OneOp_PadV2_InvalidPadDim0)
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
-  _context->setCompileFail();
+  _context->expectFailCompile();
 
   SUCCEED();
 }
@@ -108,7 +108,7 @@ TEST_F(GenModelTest, neg_OneOp_PadV2_InvalidPadDim1)
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
-  _context->setCompileFail();
+  _context->expectFailCompile();
 
   SUCCEED();
 }

--- a/tests/nnfw_api/src/one_op_tests/ResizeBilinear.cc
+++ b/tests/nnfw_api/src/one_op_tests/ResizeBilinear.cc
@@ -69,7 +69,7 @@ TEST_F(GenModelTest, neg_OneOp_ResizeBilinear_InvalidSizeVal)
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
   _context->setBackends({"cpu"});
-  _context->setCompileFail();
+  _context->expectFailCompile();
 
   SUCCEED();
 }

--- a/tests/nnfw_api/src/one_op_tests/Tile.cc
+++ b/tests/nnfw_api/src/one_op_tests/Tile.cc
@@ -70,7 +70,7 @@ TEST_F(GenModelTest, neg_OneOp_Tile)
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
   _context->setBackends({"cpu"});
-  _context->setCompileFail();
+  _context->expectFailCompile();
 
   SUCCEED();
 }

--- a/tests/nnfw_api/src/one_op_tests/Transpose.cc
+++ b/tests/nnfw_api/src/one_op_tests/Transpose.cc
@@ -103,7 +103,7 @@ TEST_F(GenModelTest, neg_OneOp_Transpose_InvalidPermsSize)
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
-  _context->setCompileFail();
+  _context->expectFailCompile();
 
   SUCCEED();
 }
@@ -121,7 +121,7 @@ TEST_F(GenModelTest, neg_OneOp_Transpose_InvalidPermsVal)
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
-  _context->setCompileFail();
+  _context->expectFailCompile();
 
   SUCCEED();
 }
@@ -139,7 +139,7 @@ TEST_F(GenModelTest, neg_OneOp_Transpose_DuplicatedPermsVal)
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
-  _context->setCompileFail();
+  _context->expectFailCompile();
 
   SUCCEED();
 }


### PR DESCRIPTION
Throw when the number of inputs is odd for an operation.

- Introduce expected model-loading failure to GenModelTest
- Fix some operations' constraint that were wrong

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>