### PR TITLE
[onert/lib_benchmark] Support overall memory measurement

### DIFF
--- a/runtime/libs/benchmark/include/benchmark/MemoryInfo.h
+++ b/runtime/libs/benchmark/include/benchmark/MemoryInfo.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __NNFW_BENCHMARK_MEMORY_INFO_H__
+#define __NNFW_BENCHMARK_MEMORY_INFO_H__
+
+#include <cstdint>
+#include <string>
+
+namespace benchmark
+{
+
+bool prepareVmRSS();
+bool prepareVmHWM();
+bool prepareGpuMemory();
+bool preparePssSum();
+
+uint32_t getVmRSS();
+uint32_t getVmHWM();
+uint32_t getGpuMemory(const std::string &process_name);
+uint32_t getPssSum();
+
+std::string getProcessName();
+
+} // namespace benchmark
+
+#endif // __NNFW_BENCHMARK_MEMORY_INFO_H__

--- a/runtime/libs/benchmark/include/benchmark/MemoryPoller.h
+++ b/runtime/libs/benchmark/include/benchmark/MemoryPoller.h
@@ -57,10 +57,6 @@ public:
 private:
   void process();
   bool prepareMemoryPolling();
-  uint32_t getVmRSS();
-  uint32_t getVmHWM();
-  uint32_t getGpuMemory();
-  uint32_t getPssSum();
 
 private:
   std::chrono::milliseconds _duration;

--- a/runtime/libs/benchmark/include/benchmark/Phases.h
+++ b/runtime/libs/benchmark/include/benchmark/Phases.h
@@ -50,7 +50,8 @@ public:
   const MemoryPoller &mem_poll() const { return *_mem_poll; }
   const Phase &at(const std::string &tag) const { return _phases.at(tag); }
 
-  uint32_t overall_memory() const { return _mem_after_run - _mem_before_init; }
+  uint32_t mem_before_init() const { return _mem_before_init; }
+  uint32_t mem_after_run() const { return _mem_after_run; }
 
 private:
   void run(const std::string &tag, const PhaseFunc &exec, const PhaseFunc *post, uint32_t loop_num,

--- a/runtime/libs/benchmark/include/benchmark/Phases.h
+++ b/runtime/libs/benchmark/include/benchmark/Phases.h
@@ -50,6 +50,8 @@ public:
   const MemoryPoller &mem_poll() const { return *_mem_poll; }
   const Phase &at(const std::string &tag) const { return _phases.at(tag); }
 
+  uint32_t overall_memory() const { return _mem_after_run - _mem_before_init; }
+
 private:
   void run(const std::string &tag, const PhaseFunc &exec, const PhaseFunc *post, uint32_t loop_num,
            bool option_disable);
@@ -58,6 +60,8 @@ private:
   const PhaseOption _option;
   std::unordered_map<std::string, Phase> _phases;
   std::unique_ptr<MemoryPoller> _mem_poll;
+  uint32_t _mem_before_init;
+  uint32_t _mem_after_run;
 };
 
 } // namespace benchmark

--- a/runtime/libs/benchmark/include/benchmark/Result.h
+++ b/runtime/libs/benchmark/include/benchmark/Result.h
@@ -34,7 +34,8 @@ public:
   double time[PhaseEnum::END_OF_PHASE][FigureType::END_OF_FIG_TYPE];
   uint32_t memory[PhaseEnum::END_OF_PHASE][MemoryType::END_OF_MEM_TYPE];
   bool print_memory = false;
-  uint32_t overall_memory = 0;
+  uint32_t init_memory = 0;
+  uint32_t peak_memory = 0;
 };
 
 // TODO Support not only stdout but also ostream

--- a/runtime/libs/benchmark/include/benchmark/Result.h
+++ b/runtime/libs/benchmark/include/benchmark/Result.h
@@ -34,6 +34,7 @@ public:
   double time[PhaseEnum::END_OF_PHASE][FigureType::END_OF_FIG_TYPE];
   uint32_t memory[PhaseEnum::END_OF_PHASE][MemoryType::END_OF_MEM_TYPE];
   bool print_memory = false;
+  uint32_t overall_memory = 0;
 };
 
 // TODO Support not only stdout but also ostream

--- a/runtime/libs/benchmark/src/MemoryInfo.cpp
+++ b/runtime/libs/benchmark/src/MemoryInfo.cpp
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "benchmark/MemoryInfo.h"
+
+#include <vector>
+#include <algorithm>
+#include <fstream>
+#include <sstream>
+#include <cassert>
+#include <sys/time.h>
+#include <sys/resource.h>
+
+namespace
+{
+
+const std::string proc_status_path("/proc/self/status");
+const std::string gpu_memory_path("/sys/kernel/debug/mali0/gpu_memory");
+const std::string proc_smaps_path("/proc/self/smaps");
+
+bool isStrNumber(const std::string &s)
+{
+  return !s.empty() &&
+         std::find_if(s.begin(), s.end(), [](char c) { return !std::isdigit(c); }) == s.end();
+}
+
+std::vector<std::string> splitLine(std::string line, std::string delimiters = " \n\t")
+{
+  std::vector<std::string> words;
+  size_t prev = 0, pos;
+
+  while ((pos = line.find_first_of(delimiters, prev)) != std::string::npos)
+  {
+    if (pos > prev)
+      words.emplace_back(line.substr(prev, pos - prev));
+    prev = pos + 1;
+  }
+
+  if (prev < line.length())
+    words.emplace_back(line.substr(prev, std::string::npos));
+
+  return words;
+}
+
+std::vector<std::string> getValueFromFileStatus(const std::string &file, const std::string &key)
+{
+  std::ifstream ifs(file);
+  assert(ifs.is_open());
+
+  std::string line;
+  std::vector<std::string> val;
+
+  bool found = false;
+  while (std::getline(ifs, line))
+  {
+    if (line.find(key) != std::string::npos)
+    {
+      found = true;
+      break;
+    }
+  }
+  ifs.close();
+
+  if (!found)
+  {
+    // NOTE. the process which uses gpu resources cannot be there yet at the model-load phase.
+    // At that time, just return empty.
+    return val;
+  }
+
+  val = splitLine(line);
+  return val;
+}
+
+// Because of smaps' structure, returns sum value as uint32_t
+uint32_t getSumValueFromFileSmaps(const std::string &file, const std::string &key)
+{
+  std::ifstream ifs(file);
+  assert(ifs.is_open());
+
+  std::string line;
+  uint32_t sum = 0;
+  while (std::getline(ifs, line))
+  {
+    if (line.find(key) != std::string::npos)
+    {
+      // an example by splitLine()
+      // `Pss:                   0 kB`
+      // val[0]: "Pss:", val[1]: "0" val[2]: "kB"
+      auto val = splitLine(line);
+      assert(val.size() != 0);
+      // SwapPss could show so that check where Pss is at the beginning
+      if (val[0].find("Pss") != 0)
+      {
+        continue;
+      }
+      sum += std::stoul(val[1]);
+    }
+  }
+
+  return sum;
+}
+
+} // namespace
+
+namespace benchmark
+{
+
+bool prepareVmRSS() { return std::ifstream(proc_status_path).is_open(); }
+
+bool prepareVmHWM() { return std::ifstream(proc_status_path).is_open(); }
+
+bool prepareGpuMemory() { return std::ifstream(gpu_memory_path).is_open(); }
+
+bool preparePssSum() { return std::ifstream(proc_smaps_path).is_open(); }
+
+uint32_t getVmRSS()
+{
+  auto val = getValueFromFileStatus(proc_status_path, "VmRSS");
+  if (val.size() == 0)
+    return 0;
+  assert(isStrNumber(val[1]));
+  return std::stoul(val[1]);
+}
+
+uint32_t getVmHWM()
+{
+  auto val = getValueFromFileStatus(proc_status_path, "VmHWM");
+  if (val.size() == 0)
+    return 0;
+  // key: value
+  assert(isStrNumber(val[1]));
+  return std::stoul(val[1]);
+}
+
+uint32_t getGpuMemory(const std::string &process_name)
+{
+  assert(!process_name.empty());
+  auto val = getValueFromFileStatus(gpu_memory_path, process_name);
+  if (val.size() == 0)
+    return 0;
+  // process_name -> pid -> gpu_mem -> max_gpu_mem
+  assert(isStrNumber(val[2]));
+  return std::stoul(val[2]);
+}
+
+uint32_t getPssSum() { return getSumValueFromFileSmaps(proc_smaps_path, "Pss"); }
+
+std::string getProcessName()
+{
+  auto val = getValueFromFileStatus(proc_status_path, "Name");
+  assert(val.size() >= 2);
+  return val[1];
+}
+
+} // namespace benchmark

--- a/runtime/libs/benchmark/src/Phases.cpp
+++ b/runtime/libs/benchmark/src/Phases.cpp
@@ -17,6 +17,7 @@
 
 #include "benchmark/Phases.h"
 #include "benchmark/Types.h"
+#include "benchmark/MemoryInfo.h"
 
 #include <cassert>
 #include <chrono>
@@ -46,8 +47,11 @@ void SleepForMicros(uint64_t micros)
 namespace benchmark
 {
 
-Phases::Phases(const PhaseOption &option) : _option(option)
+Phases::Phases(const PhaseOption &option) : _option(option), _mem_before_init(0), _mem_after_run(0)
 {
+  assert(prepareVmRSS());
+  _mem_before_init = getVmHWM();
+
   if (_option.memory)
   {
     _mem_poll = std::make_unique<MemoryPoller>(std::chrono::milliseconds(option.memory_interval),
@@ -92,6 +96,8 @@ void Phases::run(const std::string &tag, const PhaseFunc &exec, const PhaseFunc 
       SleepForMicros(_option.run_delay);
     }
   }
+
+  _mem_after_run = getVmHWM();
 
   if (p == PhaseEnum::END_OF_PHASE)
   {

--- a/runtime/libs/benchmark/src/Result.cpp
+++ b/runtime/libs/benchmark/src/Result.cpp
@@ -141,6 +141,12 @@ void printResultMemory(const uint32_t memory[benchmark::PhaseEnum::END_OF_PHASE]
   }
 }
 
+void printOverallMemory(uint32_t overall_memory)
+{
+  std::cout << "Overall Memory: " << overall_memory << " kb" << std::endl;
+  std::cout << "===================================" << std::endl;
+}
+
 } // namespace
 
 namespace benchmark
@@ -175,11 +181,14 @@ Result::Result(const Phases &phases)
       }
     }
   }
+  overall_memory = phases.overall_memory();
 }
 
 void printResult(const Result &result)
 {
   printResultTime(result.time);
+
+  printOverallMemory(result.overall_memory);
 
   if (result.print_memory == false)
     return;

--- a/runtime/libs/benchmark/src/Result.cpp
+++ b/runtime/libs/benchmark/src/Result.cpp
@@ -141,9 +141,12 @@ void printResultMemory(const uint32_t memory[benchmark::PhaseEnum::END_OF_PHASE]
   }
 }
 
-void printOverallMemory(uint32_t overall_memory)
+void printUsedPeakMemory(uint32_t init_memory, uint32_t peak_memory)
 {
-  std::cout << "Overall Memory: " << overall_memory << " kb" << std::endl;
+  uint32_t used_peak_memory = peak_memory - init_memory;
+  std::cout << "Used Peak Memory : " << used_peak_memory << " kb" << std::endl;
+  std::cout << "- HWM after run  : " << peak_memory << " kb" << std::endl;
+  std::cout << "- HWM before init: " << init_memory << " kb" << std::endl;
   std::cout << "===================================" << std::endl;
 }
 
@@ -181,19 +184,19 @@ Result::Result(const Phases &phases)
       }
     }
   }
-  overall_memory = phases.overall_memory();
+  init_memory = phases.mem_before_init();
+  peak_memory = phases.mem_after_run();
 }
 
 void printResult(const Result &result)
 {
   printResultTime(result.time);
 
-  printOverallMemory(result.overall_memory);
-
   if (result.print_memory == false)
     return;
 
   printResultMemory(result.memory);
+  printUsedPeakMemory(result.init_memory, result.peak_memory);
 }
 
 // TODO There are necessary for a kind of output data file so that it doesn't have to be csv file


### PR DESCRIPTION
Overall memory = memory after running - memory before initing
- To do this, extract some memory measurement functions from
MemoryPoller into MemoryInfo file

ONE-DCO-1.0-Signed-off-by: Yongseop Kim <yons.kim@samsung.com>