### PR TITLE
[onert/test] Download server setting and help message

### DIFF
--- a/tests/nnfw_api/src/NNPackages.cc
+++ b/tests/nnfw_api/src/NNPackages.cc
@@ -71,7 +71,10 @@ void NNPackages::checkAll()
     DIR *dir = opendir(path.c_str());
     if (!dir)
     {
-      std::string msg = "missing nnpackage: " + package_name + ", path: " + path;
+      std::string msg =
+          "missing nnpackage: " + package_name + ", path: " + path +
+          "\nPlease run \'[install_dir]/test/onert-test prepare-model --nnpackage\' to "
+          "download nnpackage";
       throw std::runtime_error{msg};
     }
     closedir(dir);

--- a/tests/scripts/command/prepare-model
+++ b/tests/scripts/command/prepare-model
@@ -50,6 +50,12 @@ do
     shift
 done
 
+# Default download server url
+if [[ -z "$MODELFILE_SERVER" ]]; then
+    export MODELFILE_SERVER="http://npu.mooo.com/archive/tflite_test_model/"
+fi
+echo "Download from $MODELFILE_SERVER"
+
 if [[ $DOWNLOAD_MODEL == "all" ]] || [[ $DOWNLOAD_MODEL == "tflite" ]]; then
     # Download tflite models
     $INSTALL_DIR/test/models/run_test.sh --download=on --run=off --md5=$MD5_CHECK


### PR DESCRIPTION
Print message on nnfw_api_gtest howto download model file
Set default modelfile server url in prepare-model test command

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>