### PR TITLE
Revert "[onert] Load boost backend (#3269)"

### DIFF
--- a/runtime/onert/core/src/compiler/BackendManager.cc
+++ b/runtime/onert/core/src/compiler/BackendManager.cc
@@ -70,30 +70,17 @@ void BackendManager::loadBackend(const std::string &backend)
   }
 
   // TODO Remove indentation
-  // Workaround If backend have dynamic library with "-boost" suffix naming,
-  //            BackendManager load library with "-boost" suffix instead of library without suffix
-  //            This feature is used for custom backend extension to support additional operations
   {
-    const std::string backend_boost_so = "libbackend_" + backend + "-boost" + SHARED_LIB_EXT;
     const std::string backend_so = "libbackend_" + backend + SHARED_LIB_EXT;
+    void *handle = dlopen(backend_so.c_str(), RTLD_LAZY | RTLD_LOCAL);
 
-    void *handle = dlopen(backend_boost_so.c_str(), RTLD_LAZY | RTLD_LOCAL);
     if (handle == nullptr)
     {
-      handle = dlopen(backend_so.c_str(), RTLD_LAZY | RTLD_LOCAL);
-
-      if (handle == nullptr)
-      {
-        VERBOSE_F() << "Failed to load backend '" << backend << "' - " << dlerror() << std::endl;
-        return;
-      }
-
-      VERBOSE_F() << "Successfully loaded '" << backend << "' - " << backend_so << "\n";
+      VERBOSE_F() << "Failed to load backend '" << backend << "' - " << dlerror() << std::endl;
+      return;
     }
-    else
-    {
-      VERBOSE_F() << "Successfully loaded '" << backend << "' - " << backend_boost_so << "\n";
-    }
+
+    VERBOSE_F() << "Successfully loaded '" << backend << "' - " << backend_so << "\n";
 
     {
       // load object creator function


### PR DESCRIPTION
This reverts commit 3d7ab141d26bcd09f0a358ebaef17a3bac69040e.

Now we do not need the workaround.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>