### PR TITLE
[ndarray] Do not link coverage lib

### DIFF
--- a/runtime/libs/ndarray/CMakeLists.txt
+++ b/runtime/libs/ndarray/CMakeLists.txt
@@ -13,7 +13,6 @@ if(${NDARRAY_INLINE_TEMPLATES})
 endif()
 
 target_link_libraries(ndarray PRIVATE nnfw_common)
-target_link_libraries(ndarray PRIVATE nnfw_coverage)
 
 add_subdirectory(test)
 add_subdirectory(example)


### PR DESCRIPTION
Do not link coverage lib since it is not used by onert.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>