### PR TITLE
[onert] DRAFT: Optimize DynamicTensorManager::deallocInput()

### DIFF
--- a/runtime/onert/core/include/backend/IDynamicTensorManager.h
+++ b/runtime/onert/core/include/backend/IDynamicTensorManager.h
@@ -41,10 +41,10 @@ public:
   /**
    * @brief Plan when to delete a tensor. Note this planning is done at compilation time.
    * @param op_ind        operation index
-   * @param operand_ind   operand index of input operand of first param op. Operand can be static
-   *                      or dynamic since tensor type may not be clearly known at compilation time.
+   // TODO write this
+   * @param tensor
    */
-  virtual void planDealloc(ir::OperationIndex op_ind, ir::OperandIndex operand_ind) = 0;
+  virtual void planDealloc(ir::OperationIndex op_ind, backend::ITensor *tensor) = 0;
 
   /**
    * @brief Deallocate input tensors of op if an input tensor is a dynamic tensor and it won't

--- a/runtime/onert/core/include/backend/cpu_common/DynamicTensorManager.h
+++ b/runtime/onert/core/include/backend/cpu_common/DynamicTensorManager.h
@@ -47,7 +47,7 @@ public:
   void buildTensor(const ir::OperandIndex &ind, const ir::OperandInfo &tensor_info,
                    ir::Layout backend_layout);
 
-  void planDealloc(ir::OperationIndex op_ind, ir::OperandIndex operand_ind) override;
+  void planDealloc(ir::OperationIndex op_ind, backend::ITensor *tensor) override;
   void deallocInput(ir::OperationIndex op_ind) override;
   void deallocSubgraphOutput(ir::OperandIndex ind) override;
 
@@ -66,7 +66,8 @@ private:
 
   // contains list of dynamic tensor index, which can be deallocated after running operation
   // note: this map could contain static tensor index too. Careful use is required.
-  std::unordered_map<ir::OperationIndex, std::unordered_set<ir::OperandIndex>> _dealloc_tensor_map;
+  std::unordered_map<ir::OperationIndex, std::unordered_set<backend::ITensor *>>
+      _dealloc_tensor_map;
 };
 
 } // namespace cpu_common

--- a/runtime/onert/core/src/backend/controlflow/DynamicTensorManager.cc
+++ b/runtime/onert/core/src/backend/controlflow/DynamicTensorManager.cc
@@ -40,9 +40,9 @@ void DynamicTensorManager::buildTensor(const ir::OperandIndex &ind,
   _tensors->setNativeOwnTensor(ind, std::move(tensor));
 }
 
-void DynamicTensorManager::planDealloc(ir::OperationIndex op_ind, ir::OperandIndex operand_ind)
+void DynamicTensorManager::planDealloc(ir::OperationIndex op_ind, backend::ITensor *tensor)
 {
-  _dealloc_tensor_map[op_ind].emplace(operand_ind);
+  _dealloc_tensor_map[op_ind].emplace(tensor);
 }
 
 void DynamicTensorManager::deallocInput(ir::OperationIndex op_ind)
@@ -52,13 +52,13 @@ void DynamicTensorManager::deallocInput(ir::OperationIndex op_ind)
     return;
 
   auto &input_set = find->second;
-  for (auto input_ind : input_set)
+  for (auto *tensor : input_set)
   {
-    if (!_tensors->getNativeTensor(input_ind)->is_dynamic())
+    if (!tensor->is_dynamic())
       continue;
 
-    _dynamic_mem_mgr->deallocate(getRawITensor(input_ind));
-    VERBOSE(DynamicTensorManager) << "Deallocating #" << input_ind.value()
+    _dynamic_mem_mgr->deallocate(tensor);
+    VERBOSE(DynamicTensorManager) << "Deallocating a tensor " << (void *)tensor
                                   << " (input of op_ind: " << op_ind.value() << ")" << std::endl;
   }
 }

--- a/runtime/onert/core/src/backend/controlflow/DynamicTensorManager.h
+++ b/runtime/onert/core/src/backend/controlflow/DynamicTensorManager.h
@@ -46,7 +46,7 @@ public:
   void buildTensor(const ir::OperandIndex &ind, const ir::OperandInfo &tensor_info,
                    ir::Layout backend_layout);
 
-  void planDealloc(ir::OperationIndex op_ind, ir::OperandIndex operand_ind) override;
+  void planDealloc(ir::OperationIndex op_ind, backend::ITensor *tensor) override;
   void deallocInput(ir::OperationIndex op_ind) override;
   void deallocSubgraphOutput(ir::OperandIndex ind) override;
 
@@ -63,9 +63,10 @@ private:
   std::shared_ptr<cpu_common::DynamicMemoryManager> _dynamic_mem_mgr;
   const std::shared_ptr<TensorRegistry> _tensors;
 
-  // contains list of dynamic tensor index, which can be deallocated after running operation
-  // note: this map could contain static tensor index too. Careful use is required.
-  std::unordered_map<ir::OperationIndex, std::unordered_set<ir::OperandIndex>> _dealloc_tensor_map;
+  // contains list of dynamic tensor, which can be deallocated after running operation
+  // note: this map could contain static tensor too. Careful use is required.
+  std::unordered_map<ir::OperationIndex, std::unordered_set<backend::ITensor *>>
+      _dealloc_tensor_map;
 };
 
 } // namespace controlflow

--- a/runtime/onert/core/src/backend/cpu_common/DynamicTensorManager.cc
+++ b/runtime/onert/core/src/backend/cpu_common/DynamicTensorManager.cc
@@ -28,6 +28,7 @@ namespace cpu_common
 DynamicTensorManager::DynamicTensorManager(const std::shared_ptr<TensorRegistry> &reg)
     : _dynamic_mem_mgr{new DynamicMemoryManager()}, _tensors{reg}
 {
+  VERBOSE(DynamicTensorManager) << "=" << this << ": tensor registry=" << _tensors << std::endl;
   // DO NOTHING
 }
 
@@ -40,9 +41,9 @@ void DynamicTensorManager::buildTensor(const ir::OperandIndex &ind,
   _tensors->setNativeTensor(ind, std::move(tensor));
 }
 
-void DynamicTensorManager::planDealloc(ir::OperationIndex op_ind, ir::OperandIndex operand_ind)
+void DynamicTensorManager::planDealloc(ir::OperationIndex op_ind, backend::ITensor *tensor)
 {
-  _dealloc_tensor_map[op_ind].emplace(operand_ind);
+  _dealloc_tensor_map[op_ind].emplace(tensor);
 }
 
 void DynamicTensorManager::deallocInput(ir::OperationIndex op_ind)
@@ -52,16 +53,18 @@ void DynamicTensorManager::deallocInput(ir::OperationIndex op_ind)
     return;
 
   auto &input_set = find->second;
-  for (auto input_ind : input_set)
+  for (auto *tensor : input_set)
   {
-    auto *tensor = _tensors->getNativeTensor(input_ind);
     if (!tensor->is_dynamic())
       continue;
 
-    _dynamic_mem_mgr->deallocate(getRawITensor(input_ind));
-    tensor->resetBuffer();
+    _dynamic_mem_mgr->deallocate(tensor);
 
-    VERBOSE(DynamicTensorManager) << "Deallocating #" << input_ind.value()
+    auto *cpu_tensor = dynamic_cast<cpu_common::Tensor *>(tensor);
+    assert(cpu_tensor);
+    cpu_tensor->resetBuffer();
+
+    VERBOSE(DynamicTensorManager) << "Deallocating tensor " << (void *)cpu_tensor
                                   << " (input of op_ind: " << op_ind.value() << ")" << std::endl;
   }
 }

--- a/runtime/onert/core/src/compiler/Linear.cc
+++ b/runtime/onert/core/src/compiler/Linear.cc
@@ -182,7 +182,14 @@ void Linear::planTensors(const compiler::LoweredGraph &lowered_graph,
           // plan for deallocation of dynamic tensor
           auto dyn_tensor_manager = tensor_builder_map[ind]->dynamicTensorManager();
           if (dyn_tensor_manager)
-            dyn_tensor_manager->planDealloc(op_idx, ind);
+          {
+            const auto *backend =
+                lowered_graph.getLowerInfo(ind)->def_factors().getOnlyElement().backend();
+            auto &tensor_registry = lowered_graph.backend_contexts().at(backend)->tensor_registry;
+            auto *tensor = tensor_registry->getITensor(ind);
+            assert(tensor);
+            dyn_tensor_manager->planDealloc(op_idx, tensor);
+          }
         }
       }
     }


### PR DESCRIPTION
**_DRAFT/WIP_**

This is a draft to optimize `DynamicTensorManager::deallocInput()`.

When handling a model with dynamic tensors, `deallocInput()` is called after running a kernel of op.

If a kernel is small, total overhead of [ `deallocInput()` * number of ops ] could be relatively big.

For this reason, optimization of `deallocInput()` is necessary.

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>
