### PR TITLE
[onert] Adds some nnfw api testcases for Cast operation

### DIFF
--- a/runtime/onert/core/include/ir/Operation.h
+++ b/runtime/onert/core/include/ir/Operation.h
@@ -34,9 +34,12 @@ struct OperationVisitor;
 class Operation
 {
 public:
+  // TODO Remove default parameter
   Operation(OperandConstraint input_constr, const OperandIndexSequence &inputs,
-            const OperandIndexSequence &outputs);
-  explicit Operation(OperandConstraint input_constr);
+            const OperandIndexSequence &outputs,
+            OperandConstraint output_constr = OperandConstraint::createAny());
+  explicit Operation(OperandConstraint input_constr,
+                     OperandConstraint output_constr = OperandConstraint::createAny());
 
   Operation(const Operation &) = default;
   Operation(Operation &&) = default;
@@ -62,6 +65,7 @@ public:
 
 private:
   OperandConstraint _input_constr;
+  OperandConstraint _output_constr;
   OperandIndexSequence _inputs;
   OperandIndexSequence _outputs;
 };

--- a/runtime/onert/core/src/ir/Operation.cc
+++ b/runtime/onert/core/src/ir/Operation.cc
@@ -24,14 +24,17 @@ namespace ir
 {
 
 Operation::Operation(OperandConstraint input_constr, const OperandIndexSequence &inputs,
-                     const OperandIndexSequence &outputs)
-    : _input_constr{input_constr}
+                     const OperandIndexSequence &outputs, OperandConstraint output_constr)
+    : _input_constr{input_constr}, _output_constr{output_constr}
 {
   setInputs(inputs);
   setOutputs(outputs);
 }
 
-Operation::Operation(OperandConstraint input_constr) : _input_constr{input_constr} {}
+Operation::Operation(OperandConstraint input_constr, OperandConstraint output_constr)
+    : _input_constr{input_constr}, _output_constr{output_constr}
+{
+}
 
 Operation::~Operation() = default;
 
@@ -42,7 +45,12 @@ void Operation::setInputs(const OperandIndexSequence &indexes)
   _inputs = indexes;
 }
 
-void Operation::setOutputs(const OperandIndexSequence &indexes) { _outputs = indexes; }
+void Operation::setOutputs(const OperandIndexSequence &indexes)
+{
+  if (!_output_constr.check(indexes.size()))
+    throw std::runtime_error{"Invalid number of output tensors for this operation."};
+  _outputs = indexes;
+}
 
 void Operation::replaceInputs(const OperandIndex &from, const OperandIndex &to)
 {

--- a/runtime/onert/core/src/ir/operation/ElementwiseUnary.cc
+++ b/runtime/onert/core/src/ir/operation/ElementwiseUnary.cc
@@ -32,7 +32,9 @@ void ElementwiseUnary::accept(OperationVisitor &v) const { v.visit(*this); }
 
 ElementwiseUnary::ElementwiseUnary(const OperandIndexSequence &inputs,
                                    const OperandIndexSequence &outputs, const Param &param)
-    : Operation{OperandConstraint::createExact(1u), inputs, outputs}, _param{param}
+    : Operation{OperandConstraint::createExact(1u), inputs, outputs,
+                OperandConstraint::createExact(1u)},
+      _param{param}
 {
 }
 


### PR DESCRIPTION
This commit adds some nnfw api testcases for Cast operation.
  - Applies ir::OperandConstraint for outputs of operations
  - Adds some testcases

Signed-off-by: ragmani <ragmani0216@gmail.com>