### PR TITLE
[onert] Fix wrong input size constraint of Pack op

### DIFF
--- a/runtime/onert/core/src/ir/operation/Pack.cc
+++ b/runtime/onert/core/src/ir/operation/Pack.cc
@@ -25,7 +25,7 @@ namespace operation
 void Pack::accept(OperationVisitor &v) const { v.visit(*this); }
 Pack::Pack(const OperandIndexSequence &inputs, const OperandIndexSequence &outputs,
            const Param &param)
-    : Operation{OperandConstraint::createAtLeast(2u), inputs, outputs}, _param{param}
+    : Operation{OperandConstraint::createAtLeast(1u), inputs, outputs}, _param{param}
 {
 }
 } // namespace operation


### PR DESCRIPTION
This fixes wrong input size constraint of Pack.

Situation:

- In a model I am working on, there is a `Pack` op like the following and it has only one input. :open_mouth: 

```
PACK
    ValuesCount(1) Axis(0)
    I  strided_slice_7
    O  Reshape_2/shape
```

- I checked with Tensorflow doc, and there is no constraints on the size of inputs.
- I checked with code of TFLite kernel, and only constraint I've seen was
  number of input tensors >= 1.

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>