### PR TITLE
[onert] Use explicit copy constructor for Operand

### DIFF
--- a/runtime/onert/backend/acl_cl/KernelGenerator.cc
+++ b/runtime/onert/backend/acl_cl/KernelGenerator.cc
@@ -556,7 +556,7 @@ void KernelGenerator::visit(const ir::operation::Transpose &node)
   const auto frontend_layout = _current_op_seq_layout;
   const auto backend_layout = ifm_tensor->layout();
 
-  const auto perms = _ctx.at(perm_idx);
+  const auto &perms = _ctx.at(perm_idx);
   std::vector<int32_t> pv;
   if (perms.shape() == ir::Shape{0})
   {
@@ -844,7 +844,7 @@ void KernelGenerator::visit(const ir::operation::OneHot &node)
   }
 
   std::unique_ptr<::arm_compute::IFunction> fn;
-  const auto offvalue = _ctx.at(offvalue_idx);
+  const auto &offvalue = _ctx.at(offvalue_idx);
   if (offvalue.isConstant())
   {
     fn = acl_common::generateLayer<arm_compute::CLOneHot>(
@@ -1426,7 +1426,7 @@ void KernelGenerator::visit(const ir::operation::SplitV &node)
     output_tensors.emplace_back(_tensor_reg->getAclTensor(ofm_ind)->handle());
 
   auto fn = std::make_unique<arm_compute::CLSplitVEx>();
-  const auto split_dim_op = _ctx.at(split_dim_index);
+  const auto &split_dim_op = _ctx.at(split_dim_index);
   if (split_dim_op.isConstant())
   {
     int32_t split_dim = split_dim_op.asScalar<int32_t>();

--- a/runtime/onert/backend/acl_neon/KernelGenerator.cc
+++ b/runtime/onert/backend/acl_neon/KernelGenerator.cc
@@ -1294,7 +1294,7 @@ void KernelGenerator::visit(const ir::operation::Transpose &node)
   const auto backend_layout = ifm_tensor->layout();
   const auto rank = _ctx.at(ifm_idx).shape().rank();
 
-  const auto perms = _ctx.at(perm_idx);
+  const auto &perms = _ctx.at(perm_idx);
   std::vector<int32_t> pv;
   if (perms.shape() == ir::Shape{0})
   {

--- a/runtime/onert/core/include/ir/Operand.h
+++ b/runtime/onert/core/include/ir/Operand.h
@@ -40,6 +40,7 @@ public:
   {
     // DO NOTHING
   }
+  explicit Operand(const Operand &) = default;
 
 public:
   const Shape &shape(void) const { return _info.shape(); }

--- a/runtime/onert/core/src/compiler/StaticShapeInference.cc
+++ b/runtime/onert/core/src/compiler/StaticShapeInference.cc
@@ -175,8 +175,8 @@ void StaticShapeInferer::visit(const ir::operation::BatchMatMul &op)
   const auto lhs_index = op.getInputs().at(ir::operation::BatchMatMul::Input::LHS);
   const auto rhs_index = op.getInputs().at(ir::operation::BatchMatMul::Input::RHS);
   const auto output_index = op.getOutputs().at(0);
-  const auto lhs = _operands.at(lhs_index);
-  const auto rhs = _operands.at(rhs_index);
+  const auto &lhs = _operands.at(lhs_index);
+  const auto &rhs = _operands.at(rhs_index);
   auto &output = _operands.at(output_index);
   auto new_shape = shape_inference::inferBatchMatMulShape(lhs.shape(), rhs.shape(), op.param());
   output.info().shape(new_shape);
@@ -696,7 +696,7 @@ void StaticShapeInferer::visit(const ir::operation::ResizeBilinear &op)
   int32_t height_out, width_out;
   if (op.getInputs().size() == 2)
   {
-    auto size = _operands.at(op.getInputs().at(ir::operation::ResizeBilinear::Input::SIZE));
+    auto &size = _operands.at(op.getInputs().at(ir::operation::ResizeBilinear::Input::SIZE));
     if (!size.isConstant())
     {
       output.info().setDynamic();

--- a/runtime/onert/core/src/compiler/pass/ConstantInsertionPass.cc
+++ b/runtime/onert/core/src/compiler/pass/ConstantInsertionPass.cc
@@ -44,7 +44,7 @@ void ConstantInsertionPass::callback(const ir::OperationIndex &node_index, ir::O
       const auto key = ReplaceKey{input, factor};
       if (_replace_operands_map.count(key) == 0)
       {
-        auto new_object = object;
+        ir::Operand new_object(object);
         new_object.unsetDef();
         // TODO Remove const_case
         const_cast<ir::OperationIndexSet &>(new_object.getUses()).clear();

--- a/runtime/onert/frontend/base_loader/include/base_loader.h
+++ b/runtime/onert/frontend/base_loader/include/base_loader.h
@@ -1214,7 +1214,7 @@ void BaseLoader<LoaderDomain>::loadArgMax(const Operator *op, ir::Graph &subg)
   }
   auto am = loadOperationTo<ir::operation::ArgMax>(op, subg, param);
 
-  auto axisOperand = subg.operands().at(am->getInputs().at(ir::operation::ArgMax::Input::AXIS));
+  auto &axisOperand = subg.operands().at(am->getInputs().at(ir::operation::ArgMax::Input::AXIS));
   if (!(axisOperand.operandSize() == 4 && (axisOperand.typeInfo().type() == ir::DataType::INT32 ||
                                            axisOperand.typeInfo().type() == ir::DataType::INT64)))
     throw std::runtime_error("ArgMax: `axis` with an int32 or int64 element is only supported.");


### PR DESCRIPTION
Define ir::Operand copy contructor explicitly
Fix to reference operand if copy is needless

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>