### PR TITLE
[onert] Enable dynamic_cast assert for android in polymorphic_downcast

### DIFF
--- a/runtime/libs/misc/include/misc/polymorphic_downcast.h
+++ b/runtime/libs/misc/include/misc/polymorphic_downcast.h
@@ -27,9 +27,7 @@ namespace misc
 
 template <typename DstType, typename SrcType> inline DstType polymorphic_downcast(SrcType *x)
 {
-#ifndef __ANDROID__
   assert(dynamic_cast<DstType>(x) == x);
-#endif
   return static_cast<DstType>(x);
 }
 


### PR DESCRIPTION
- This commit enables dynamic_cast assert for android in polymorphic_downcast
  - Check for `__ANDROID__` macro is added to avoid assertion #3654
  - dynamic_cast now works well on android #4341

ONE-DCO-1.0-Signed-off-by: JiHwan Yeo <jihwan.yeo@samsung.com>