### PR TITLE
[onert] Rename OperationValidator to ShapeValidator

### DIFF
--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -18,7 +18,7 @@
 
 #include "ParamChecker.h"
 #include "ExecutorFactory.h"
-#include "OperationValidator.h"
+#include "ShapeValidator.h"
 #include "Fp32ToFp16Converter.h"
 
 #include <backend/controlflow/Config.h>
@@ -229,16 +229,24 @@ std::shared_ptr<exec::ExecutorMap> Compiler::compile(void)
     inferer.dump();
   }
 
-  /*************************************************************
-   *  Backend independent analysis & optimization phase finished
-   *************************************************************/
-
-  // operation validation
+  // Shape validation
+  // TODO Introduce operation validator to check shape independent operation feature
+  //      - Check shape independent operation feature as first compilation phase
+  //      - Move shape independent feature check from ShapeValidator to OperationValidator
+  // TODO Move ShapeValidator into shape inference
+  //      - Check input tensor shape validation
+  //      - Check parameter value validation which valid value is depend on input tensor shape
+  //      - Output tensor shape validation check is needless because
+  //        static/dynamic shape inferer will make valid output shape
   for (auto &pair : lowered_subgs)
   {
     auto &lowered_subg = pair.second;
-    compiler::OperationValidator{lowered_subg->graph()}();
+    compiler::ShapeValidator{lowered_subg->graph()}();
   }
+
+  /*************************************************************
+   *  Backend independent analysis & optimization phase finished
+   *************************************************************/
 
   executors = std::make_shared<exec::ExecutorMap>();
   for (auto &pair : lowered_subgs)

--- a/runtime/onert/core/src/compiler/ShapeValidator.h
+++ b/runtime/onert/core/src/compiler/ShapeValidator.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef __ONERT_COMPILER_OPERATION_VALIDATOR_H__
-#define __ONERT_COMPILER_OPERATION_VALIDATOR_H__
+#ifndef __ONERT_COMPILER_SHAPE_VALIDATOR_H__
+#define __ONERT_COMPILER_SHAPE_VALIDATOR_H__
 
 #include "ir/Layout.h"
 #include "ir/OperationVisitor.h"
@@ -34,11 +34,11 @@ namespace onert
 namespace compiler
 {
 
-class OperationValidator : public ir::OperationVisitor
+class ShapeValidator : public ir::OperationVisitor
 {
 public:
-  OperationValidator(void) = delete;
-  OperationValidator(const ir::Graph &graph);
+  ShapeValidator(void) = delete;
+  ShapeValidator(const ir::Graph &graph);
 
 public:
   void operator()();
@@ -97,4 +97,4 @@ private:
 } // namespace compiler
 } // namespace onert
 
-#endif // __ONERT_COMPILER_OPERATION_VALIDATOR_H__
+#endif // __ONERT_COMPILER_SHAPE_VALIDATOR_H__


### PR DESCRIPTION
Rename OperationValidator to ShapeValidator
Prepare introducing OperationValidator to check shape independent operation feature

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Part of #4348