### PR TITLE
[luci] Fix core algorithm in FuseBCQPass

### DIFF
--- a/compiler/luci/pass/src/FuseBCQPass.cpp
+++ b/compiler/luci/pass/src/FuseBCQPass.cpp
@@ -188,7 +188,6 @@ public:
           bcq_fc->fusedActivationFunction(fully_connected->fusedActivationFunction());
 
           loco::Node *bcq_input = fully_connected->input();
-          int32_t batch_rank = 0;
 
           // If input of BCQFullyConnected has more than rank 2, we should reshape it as rank 2
           const auto original_input = loco::must_cast<luci::CircleNode *>(fully_connected->input());
@@ -215,7 +214,6 @@ public:
             reshape->shape(new_shape);
 
             bcq_input = reshape;
-            batch_rank = original_input->rank() - 2;
           }
 
           // If x_w formation, we should insert Transpose in front and back of BCQFullyConnected


### PR DESCRIPTION
This commit will revise `FuseBCQPass` algorithm to handle following things.
- In case of input shape has unknown dimension, `input_hidden_size` and `weights_hidden_size` is set by constant tensor, not input.
- `Transpose` operation should be inserted only after `BCQGather` when `do_w_x` is false.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>