### PR TITLE
[common-artifacts]Exclude from example creation.

### DIFF
--- a/compiler/common-artifacts/exclude.lst
+++ b/compiler/common-artifacts/exclude.lst
@@ -5,6 +5,8 @@
 
 #[[ optimize : Exclude from circle optimization(circle2circle) ]]
 ## TensorFlowLiteRecipes
+optimize(UnidirectionalSequenceLSTM_000)
+optimize(UnidirectionalSequenceLSTM_001)
 optimize(Unique_000)
 optimize(Unique_001)
 optimize(Unique_002)
@@ -160,6 +162,8 @@ tcgenerate(Tile_000)
 tcgenerate(Tile_U8_000)
 tcgenerate(TopKV2_000)
 tcgenerate(TopKV2_001)
+tcgenerate(UnidirectionalSequenceLSTM_000)
+tcgenerate(UnidirectionalSequenceLSTM_001)
 tcgenerate(Unique_000)
 tcgenerate(Unique_001)
 tcgenerate(Unique_002)


### PR DESCRIPTION
Parent Issue : #4151
Draft PR : #4260

This commit add `UnidirectionalSequenceLSTM` to exclusion list using TC generation.

ONE-DCO-1.0-Signed-off-by: KiDeuk Bang <rrstrous@nate.com>