### PR TITLE
[nnfw_api] change bias to 1D in fullyconnected test

### DIFF
--- a/tests/nnfw_api/src/one_op_tests/FullyConnected.cc
+++ b/tests/nnfw_api/src/one_op_tests/FullyConnected.cc
@@ -44,7 +44,7 @@ TEST_F(GenModelTest, OneOp_FullyConnected)
   uint32_t bias_buf = cgen.addBuffer(bias_data);
   int input = cgen.addTensor({{1, 4}, circle::TensorType::TensorType_FLOAT32});
   int weight = cgen.addTensor({{16, 4}, circle::TensorType::TensorType_FLOAT32, weight_buf});
-  int bias = cgen.addTensor({{16, 1}, circle::TensorType::TensorType_FLOAT32, bias_buf});
+  int bias = cgen.addTensor({{16}, circle::TensorType::TensorType_FLOAT32, bias_buf});
   int output = cgen.addTensor({{1, 16}, circle::TensorType::TensorType_FLOAT32});
   cgen.addOperatorFullyConnected({{input, weight, bias}, {output}});
   cgen.setInputsAndOutputs({input}, {output});
@@ -52,7 +52,7 @@ TEST_F(GenModelTest, OneOp_FullyConnected)
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
   _context->addTestCase(
       uniformTCD<float>({{1, 3, 2, 1}}, {{2, 1, 5, 5, 2, 1, 5, 5, 2, 1, 5, 5, 2, 1, 5, 6}}));
-  _context->setBackends({"cpu"});
+  _context->setBackends({"cpu", "acl_neon"});
 
   SUCCEED();
 }


### PR DESCRIPTION
- It will use 1D bias, instead of 2D bias.
- Enables acl-neon backend which works for 1D bias only.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>