### PR TITLE
[onert] Fix bug that doesn't round indices values in acl kernels

### DIFF
--- a/compute/ARMComputeEx/src/core/CL/cl_kernels/one_hot.cl
+++ b/compute/ARMComputeEx/src/core/CL/cl_kernels/one_hot.cl
@@ -39,7 +39,7 @@
  */
 #include "helpers.h"
 
-#if defined(DATA_TYPE) && defined(AXIS) && defined(OUTPUT_DIM_Z)
+#if defined(DATA_TYPE) && defined(AXIS) && defined(DEPTH) && defined(OUTPUT_DIM_Z)
 
 /** Performs the OneHot operation along the chosen axis
  * @note Datatype should be given as a preprocessor argument using -DDATA_TYPE=type. e.g.
@@ -201,6 +201,9 @@ __kernel void one_hot_only_on_value(TENSOR3D_DECLARATION(indices), VECTOR_DECLAR
 
   const int index = *(__global const int *)tensor3D_offset(&indices, px, py, pz);
 
+  if (index < 0 || index >= DEPTH)
+    return;
+
 #if AXIS == 0
   *(__global DATA_TYPE *)tensor4D_offset(&output, index, px, py, pz) =
       *((__global const DATA_TYPE *)on_value_ptr);
@@ -216,4 +219,4 @@ __kernel void one_hot_only_on_value(TENSOR3D_DECLARATION(indices), VECTOR_DECLAR
 #endif // AXIS
 }
 
-#endif // defined(DATA_TYPE) && defined(AXIS) && defined(OUTPUT_DIM_Z)
+#endif // defined(DATA_TYPE) && defined(AXIS) && defined(DEPTH) && defined(OUTPUT_DIM_Z)

--- a/compute/ARMComputeEx/src/core/CL/kernels/CLOneHotKernel.cpp
+++ b/compute/ARMComputeEx/src/core/CL/kernels/CLOneHotKernel.cpp
@@ -133,6 +133,7 @@ void CLOneHotKernel::configure_common(const ICLTensor *indices, const ICLTensor 
   build_opts.add_option("-DDATA_TYPE=" + get_cl_unsigned_type_from_element_size(
                                              data_size_from_type(on_value->info()->data_type())));
   build_opts.add_option("-DAXIS=" + support::cpp11::to_string(actual_axis));
+  build_opts.add_option("-DDEPTH=" + support::cpp11::to_string(depth));
   build_opts.add_option("-DOUTPUT_DIM_Z=" +
                         support::cpp11::to_string(output->info()->dimension(2)));
   // Create kernel

--- a/tests/nnfw_api/src/CircleGen.cc
+++ b/tests/nnfw_api/src/CircleGen.cc
@@ -174,6 +174,13 @@ uint32_t CircleGen::addOperatorNeg(const OperatorParams &params)
                                 circle::BuiltinOptions_NegOptions, options);
 }
 
+uint32_t CircleGen::addOperatorOneHot(const OperatorParams &params, int32_t axis)
+{
+  auto options = circle::CreateOneHotOptions(_fbb, axis).Union();
+  return addOperatorWithOptions(params, circle::BuiltinOperator_ONE_HOT,
+                                circle::BuiltinOptions_OneHotOptions, options);
+}
+
 uint32_t CircleGen::addOperatorPad(const OperatorParams &params)
 {
   auto options = circle::CreatePadOptions(_fbb).Union();

--- a/tests/nnfw_api/src/CircleGen.h
+++ b/tests/nnfw_api/src/CircleGen.h
@@ -153,6 +153,7 @@ public:
   uint32_t addOperatorLess(const OperatorParams &params);
   uint32_t addOperatorLogSoftmax(const OperatorParams &params);
   uint32_t addOperatorNeg(const OperatorParams &params);
+  uint32_t addOperatorOneHot(const OperatorParams &params, int32_t axis);
   uint32_t addOperatorPad(const OperatorParams &params);
   uint32_t addOperatorPadV2(const OperatorParams &params);
   uint32_t addOperatorRank(const OperatorParams &params);

--- a/tests/nnfw_api/src/one_op_tests/OneHot.cc
+++ b/tests/nnfw_api/src/one_op_tests/OneHot.cc
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "GenModelTest.h"
+
+#include <memory>
+
+TEST_F(GenModelTest, OneOp_OneHot_OffValueToConst)
+{
+  CircleGen cgen;
+  std::vector<int32_t> depth_data{3};
+  uint32_t depth_buf = cgen.addBuffer(depth_data);
+  std::vector<float> off_value_data{0};
+  uint32_t off_value_buf = cgen.addBuffer(off_value_data);
+  int indices = cgen.addTensor({{1, 2, 2}, circle::TensorType::TensorType_INT32});
+  int depth = cgen.addTensor({{1}, circle::TensorType::TensorType_INT32, depth_buf});
+  int on_value = cgen.addTensor({{1}, circle::TensorType::TensorType_FLOAT32});
+  int off_value = cgen.addTensor({{1}, circle::TensorType::TensorType_FLOAT32, off_value_buf});
+  int axis = 2;
+  int out = cgen.addTensor({{1, 2, 3, 2}, circle::TensorType::TensorType_FLOAT32});
+  cgen.addOperatorOneHot({{indices, depth, on_value, off_value}, {out}}, axis);
+  cgen.setInputsAndOutputs({indices, on_value}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  TestCaseData tcd;
+  tcd.addInput(std::vector<int32_t>{1, 2, 0, 2});
+  tcd.addInput(std::vector<float>{1});
+  tcd.addOutput(std::vector<float>{0, 0, 1, 0, 0, 1, 1, 0, 0, 0, 0, 1});
+  _context->addTestCase(tcd);
+  _context->setBackends({"acl_cl", "acl_neon", "cpu"});
+
+  SUCCEED();
+}
+
+TEST_F(GenModelTest, OneOp_OneHot_OffValueToNotZero)
+{
+  CircleGen cgen;
+  std::vector<int32_t> depth_data{3};
+  uint32_t depth_buf = cgen.addBuffer(depth_data);
+  int indices = cgen.addTensor({{1, 2, 2}, circle::TensorType::TensorType_INT32});
+  int depth = cgen.addTensor({{1}, circle::TensorType::TensorType_INT32, depth_buf});
+  int on_value = cgen.addTensor({{1}, circle::TensorType::TensorType_FLOAT32});
+  int off_value = cgen.addTensor({{1}, circle::TensorType::TensorType_FLOAT32});
+  int axis = 2;
+  int out = cgen.addTensor({{1, 2, 3, 2}, circle::TensorType::TensorType_FLOAT32});
+  cgen.addOperatorOneHot({{indices, depth, on_value, off_value}, {out}}, axis);
+  cgen.setInputsAndOutputs({indices, on_value, off_value}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  TestCaseData tcd;
+  tcd.addInput(std::vector<int32_t>{1, 2, 0, 2});
+  tcd.addInput(std::vector<float>{1});
+  tcd.addInput(std::vector<float>{-1});
+  tcd.addOutput(std::vector<float>{-1, -1, 1, -1, -1, 1, 1, -1, -1, -1, -1, 1});
+  _context->addTestCase(tcd);
+  _context->setBackends({"acl_cl", "acl_neon", "cpu"});
+
+  SUCCEED();
+}
+
+TEST_F(GenModelTest, OneOp_OneHot_IndicesValueToNeg_OffValueToConst)
+{
+  CircleGen cgen;
+  std::vector<int32_t> depth_data{3};
+  uint32_t depth_buf = cgen.addBuffer(depth_data);
+  std::vector<float> off_value_data{0};
+  uint32_t off_value_buf = cgen.addBuffer(off_value_data);
+  int indices = cgen.addTensor({{2, 2}, circle::TensorType::TensorType_INT32});
+  int depth = cgen.addTensor({{1}, circle::TensorType::TensorType_INT32, depth_buf});
+  int on_value = cgen.addTensor({{1}, circle::TensorType::TensorType_FLOAT32});
+  int off_value = cgen.addTensor({{1}, circle::TensorType::TensorType_FLOAT32, off_value_buf});
+  int axis = 2;
+  int out = cgen.addTensor({{2, 2, 3}, circle::TensorType::TensorType_FLOAT32});
+  cgen.addOperatorOneHot({{indices, depth, on_value, off_value}, {out}}, axis);
+  cgen.setInputsAndOutputs({indices, on_value}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  TestCaseData tcd;
+  tcd.addInput(std::vector<int32_t>{1, 2, 0, -1});
+  tcd.addInput(std::vector<float>{1});
+  tcd.addOutput(std::vector<float>{0, 1, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0});
+  _context->addTestCase(tcd);
+  _context->setBackends({"acl_cl", "acl_neon", "cpu"});
+
+  SUCCEED();
+}
+
+TEST_F(GenModelTest, OneOp_OneHot_IndicesValueToNeg_OffValueToVar)
+{
+  CircleGen cgen;
+  std::vector<int32_t> depth_data{3};
+  uint32_t depth_buf = cgen.addBuffer(depth_data);
+  int indices = cgen.addTensor({{2, 2}, circle::TensorType::TensorType_INT32});
+  int depth = cgen.addTensor({{1}, circle::TensorType::TensorType_INT32, depth_buf});
+  int on_value = cgen.addTensor({{1}, circle::TensorType::TensorType_FLOAT32});
+  int off_value = cgen.addTensor({{1}, circle::TensorType::TensorType_FLOAT32});
+  int axis = 2;
+  int out = cgen.addTensor({{2, 2, 3}, circle::TensorType::TensorType_FLOAT32});
+  cgen.addOperatorOneHot({{indices, depth, on_value, off_value}, {out}}, axis);
+  cgen.setInputsAndOutputs({indices, on_value, off_value}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  TestCaseData tcd;
+  tcd.addInput(std::vector<int32_t>{1, 2, 0, -1});
+  tcd.addInput(std::vector<float>{1});
+  tcd.addInput(std::vector<float>{0});
+  tcd.addOutput(std::vector<float>{0, 1, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0});
+  _context->addTestCase(tcd);
+  _context->setBackends({"acl_cl", "acl_neon", "cpu"});
+
+  SUCCEED();
+}
+
+TEST_F(GenModelTest, neg_OneOp_OneHot_OneOperand)
+{
+  CircleGen cgen;
+  int indices = cgen.addTensor({{1, 2, 2}, circle::TensorType::TensorType_INT32});
+  int axis = 2;
+  int out = cgen.addTensor({{1, 2, 3, 2}, circle::TensorType::TensorType_FLOAT32});
+  cgen.addOperatorOneHot({{indices}, {out}}, axis);
+  cgen.setInputsAndOutputs({indices}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->setBackends({"acl_cl", "acl_neon", "cpu"});
+  _context->expectFailModelLoad();
+
+  SUCCEED();
+}
+
+TEST_F(GenModelTest, neg_OneOp_OneHot_TwoOperands)
+{
+  CircleGen cgen;
+  std::vector<int> depth_data{3};
+  uint32_t depth_buf = cgen.addBuffer(depth_data);
+  int indices = cgen.addTensor({{1, 2, 2}, circle::TensorType::TensorType_INT32});
+  int depth = cgen.addTensor({{1}, circle::TensorType::TensorType_INT32, depth_buf});
+  int axis = 2;
+  int out = cgen.addTensor({{1, 2, 3, 2}, circle::TensorType::TensorType_FLOAT32});
+  cgen.addOperatorOneHot({{indices, depth}, {out}}, axis);
+  cgen.setInputsAndOutputs({indices}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->setBackends({"acl_cl", "acl_neon", "cpu"});
+  _context->expectFailModelLoad();
+
+  SUCCEED();
+}
+
+TEST_F(GenModelTest, neg_OneOp_OneHot_ThreeOperands)
+{
+  CircleGen cgen;
+  std::vector<int> depth_data{3};
+  uint32_t depth_buf = cgen.addBuffer(depth_data);
+  int indices = cgen.addTensor({{1, 2, 2}, circle::TensorType::TensorType_INT32});
+  int depth = cgen.addTensor({{1}, circle::TensorType::TensorType_INT32, depth_buf});
+  int on_value = cgen.addTensor({{1}, circle::TensorType::TensorType_FLOAT32});
+  int axis = 2;
+  int out = cgen.addTensor({{1, 2, 3, 2}, circle::TensorType::TensorType_FLOAT32});
+  cgen.addOperatorOneHot({{indices, depth, on_value}, {out}}, axis);
+  cgen.setInputsAndOutputs({indices, on_value}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->setBackends({"acl_cl", "acl_neon", "cpu"});
+  _context->expectFailModelLoad();
+
+  SUCCEED();
+}
+
+TEST_F(GenModelTest, neg_OneOp_OneHot_InvalidAxis)
+{
+  CircleGen cgen;
+  std::vector<int> depth_data{3};
+  uint32_t depth_buf = cgen.addBuffer(depth_data);
+  int indices = cgen.addTensor({{1, 2, 2}, circle::TensorType::TensorType_INT32});
+  int depth = cgen.addTensor({{1}, circle::TensorType::TensorType_INT32, depth_buf});
+  int on_value = cgen.addTensor({{1}, circle::TensorType::TensorType_FLOAT32});
+  int off_value = cgen.addTensor({{1}, circle::TensorType::TensorType_FLOAT32});
+  int axis = 4;
+  int out = cgen.addTensor({{1, 2, 3, 2}, circle::TensorType::TensorType_FLOAT32});
+  cgen.addOperatorOneHot({{indices, depth, on_value, off_value}, {out}}, axis);
+  cgen.setInputsAndOutputs({indices, on_value, off_value}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->setBackends({"acl_cl", "acl_neon", "cpu"});
+  _context->expectFailCompile();
+
+  SUCCEED();
+}


### PR DESCRIPTION
From https://github.com/Samsung/ONE/pull/4331#discussion_r493974899

This commit fixes bug that doesn't round indices values in acl kernels
  - Fix bug
  - Add some nnfw api tests for OneHot