### PR TITLE
[luci] Reorder the sequence of optimizations

### DIFF
--- a/compiler/luci/pass/src/CircleOptimizer.cpp
+++ b/compiler/luci/pass/src/CircleOptimizer.cpp
@@ -109,7 +109,7 @@ void CircleOptimizer::optimize(loco::Graph *g) const
   logo::Phase phase;
 
   /* TRANSFORM DECLARATION BEGIN */
-  
+
   // Shape inference is needed for added nodes doing below transformations
   phase.emplace_back(std::make_unique<luci::ShapeInferencePass>());
   phase.emplace_back(std::make_unique<luci::TypeInferencePass>());

--- a/compiler/luci/pass/src/CircleOptimizer.cpp
+++ b/compiler/luci/pass/src/CircleOptimizer.cpp
@@ -109,6 +109,12 @@ void CircleOptimizer::optimize(loco::Graph *g) const
   logo::Phase phase;
 
   /* TRANSFORM DECLARATION BEGIN */
+  
+  // Shape inference is needed for added nodes doing below transformations
+  phase.emplace_back(std::make_unique<luci::ShapeInferencePass>());
+  phase.emplace_back(std::make_unique<luci::TypeInferencePass>());
+  phase.emplace_back(std::make_unique<logo::RemoveDeadNodeWithQueryPass>());
+
   if (_options->query(Options::Algorithm::ResolveCustomOpAdd))
   {
     phase.emplace_back(std::make_unique<luci::ResolveCustomOpAddPass>());
@@ -138,10 +144,6 @@ void CircleOptimizer::optimize(loco::Graph *g) const
     phase.emplace_back(std::make_unique<FuseAddWithTConvPass>());
   }
 
-  // Shape inference is needed for added nodes doing above transformations
-  phase.emplace_back(std::make_unique<luci::ShapeInferencePass>());
-  phase.emplace_back(std::make_unique<luci::TypeInferencePass>());
-  phase.emplace_back(std::make_unique<logo::RemoveDeadNodeWithQueryPass>());
   /* TRANSFORM DECLARATION END */
 
   ProgressReporter prog(g, logo::PhaseStrategy::Saturate);

--- a/compiler/luci/pass/src/CircleOptimizer.cpp
+++ b/compiler/luci/pass/src/CircleOptimizer.cpp
@@ -110,10 +110,9 @@ void CircleOptimizer::optimize(loco::Graph *g) const
 
   /* TRANSFORM DECLARATION BEGIN */
 
-  // Shape inference is needed for added nodes doing below transformations
+  // Shape and type inference is needed for doing below transformations
   phase.emplace_back(std::make_unique<luci::ShapeInferencePass>());
   phase.emplace_back(std::make_unique<luci::TypeInferencePass>());
-  phase.emplace_back(std::make_unique<logo::RemoveDeadNodeWithQueryPass>());
 
   if (_options->query(Options::Algorithm::ResolveCustomOpAdd))
   {
@@ -143,6 +142,8 @@ void CircleOptimizer::optimize(loco::Graph *g) const
   {
     phase.emplace_back(std::make_unique<FuseAddWithTConvPass>());
   }
+
+  phase.emplace_back(std::make_unique<logo::RemoveDeadNodeWithQueryPass>());
 
   /* TRANSFORM DECLARATION END */
 


### PR DESCRIPTION
Parent Issue : #4373
Draft : #4374

Sometimes, some optimization passes need inferenced shape or dtype.
However for now, shape inference and type inference are done at last.
This commit will reorder the sequence of optimizations
and thus another optimization passes can use inferenced shape or dtype.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>