### PR TITLE
[onert] Fix when a const output is used

### DIFF
--- a/runtime/onert/core/src/compiler/pass/ConstantOutputPass.cc
+++ b/runtime/onert/core/src/compiler/pass/ConstantOutputPass.cc
@@ -47,6 +47,15 @@ void ConstantOutputPass::callback(const ir::OperandIndex &ind, ir::Operand &obj)
   permute_input_obj.insertUse(permute_ind);
   obj.setDef(permute_ind);
 
+  // Make the operations that uses this operand to use the generated operand
+  auto orig_uses = obj.getUses();
+  for (auto use : orig_uses)
+  {
+    permute_input_obj.insertUse(use);
+    obj.removeUse(use);
+    _graph.operations().at(use).replaceInputs(ind, permute_input_ind);
+  }
+
   VERBOSE(ConstantOutputPass) << "Permute Op inserted for a constant ouput, node index : "
                               << permute_ind << std::endl;
   VERBOSE(ConstantOutputPass) << "  - Input (inserted) Operand : " << permute_input_ind

--- a/tests/nnfw_api/src/GenModelTests.cc
+++ b/tests/nnfw_api/src/GenModelTests.cc
@@ -80,7 +80,7 @@ TEST_F(GenModelTest, UsedConstOutput)
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
   _context->addTestCase(uniformTCD<float>({{1, 1, 1, 1}, {-1, -1, -1, -1}},
                                           {{7, 5, 9, 2}, {5, 3, 7, 0}, {6, 4, 8, 1}}));
-  _context->setBackends({"cpu"});
+  _context->setBackends({"acl_cl", "acl_neon", "cpu"});
 
   SUCCEED();
 }


### PR DESCRIPTION
Update the uses of the tensor to be the generated one so it can still
be considered as const.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>