### PR TITLE
[onert] Remove deallocSubgraphOutput method

### DIFF
--- a/runtime/onert/core/include/backend/IDynamicTensorManager.h
+++ b/runtime/onert/core/include/backend/IDynamicTensorManager.h
@@ -52,12 +52,6 @@ public:
    * @note  This will work after calling planDealloc
    */
   virtual void deallocInput(ir::OperationIndex op_ind) = 0;
-
-  /**
-   * @brief Deallocate an output tensor if the tensor is a dynamic tensor
-   * @note  This will work after calling planDealloc
-   */
-  virtual void deallocSubgraphOutput(ir::OperandIndex ind) = 0;
 };
 
 } // namespace backend

--- a/runtime/onert/core/include/backend/cpu_common/DynamicTensorManager.h
+++ b/runtime/onert/core/include/backend/cpu_common/DynamicTensorManager.h
@@ -49,7 +49,6 @@ public:
 
   void planDealloc(ir::OperationIndex op_ind, backend::ITensor *tensor) override;
   void deallocInput(ir::OperationIndex op_ind) override;
-  void deallocSubgraphOutput(ir::OperandIndex ind) override;
 
   std::shared_ptr<DynamicMemoryManager> dynamic_mem_mgr() { return _dynamic_mem_mgr; }
 

--- a/runtime/onert/core/src/backend/controlflow/DynamicTensorManager.cc
+++ b/runtime/onert/core/src/backend/controlflow/DynamicTensorManager.cc
@@ -63,16 +63,6 @@ void DynamicTensorManager::deallocInput(ir::OperationIndex op_ind)
   }
 }
 
-void DynamicTensorManager::deallocSubgraphOutput(ir::OperandIndex output_ind)
-{
-  if (!_tensors->getNativeTensor(output_ind)->is_dynamic())
-    return;
-
-  _dynamic_mem_mgr->deallocate(getRawITensor(output_ind));
-  VERBOSE(DynamicTensorManager) << "Deallocating #" << output_ind.value()
-                                << " (output of a subgraph)" << std::endl;
-}
-
 const ITensor *DynamicTensorManager::getRawITensor(ir::OperandIndex ind)
 {
   auto ptr = _tensors->getITensor(ind);

--- a/runtime/onert/core/src/backend/controlflow/DynamicTensorManager.h
+++ b/runtime/onert/core/src/backend/controlflow/DynamicTensorManager.h
@@ -48,7 +48,6 @@ public:
 
   void planDealloc(ir::OperationIndex op_ind, backend::ITensor *tensor) override;
   void deallocInput(ir::OperationIndex op_ind) override;
-  void deallocSubgraphOutput(ir::OperandIndex ind) override;
 
   std::shared_ptr<cpu_common::DynamicMemoryManager> dynamic_mem_mgr() { return _dynamic_mem_mgr; }
 

--- a/runtime/onert/core/src/backend/cpu_common/DynamicTensorManager.cc
+++ b/runtime/onert/core/src/backend/cpu_common/DynamicTensorManager.cc
@@ -68,19 +68,6 @@ void DynamicTensorManager::deallocInput(ir::OperationIndex op_ind)
   }
 }
 
-void DynamicTensorManager::deallocSubgraphOutput(ir::OperandIndex output_ind)
-{
-  auto *tensor = _tensors->getNativeTensor(output_ind);
-  if (!tensor->is_dynamic())
-    return;
-
-  _dynamic_mem_mgr->deallocate(getRawITensor(output_ind));
-  tensor->resetBuffer();
-
-  VERBOSE(DynamicTensorManager) << "Deallocating #" << output_ind.value()
-                                << " (output of a subgraph)" << std::endl;
-}
-
 const ITensor *DynamicTensorManager::getRawITensor(ir::OperandIndex ind)
 {
   auto ptr = _tensors->getITensor(ind);


### PR DESCRIPTION
Remove deallocSubgraphOutput in TensorManager class. Now all subgraph
outputs are all user-given buffers, we do not need this method. (already
never used.)

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>