### PR TITLE
[circle-tensordump] Support int16 data type

### DIFF
--- a/compiler/circle-tensordump/src/Dump.cpp
+++ b/compiler/circle-tensordump/src/Dump.cpp
@@ -182,6 +182,10 @@ H5::PredType hdf5_dtype_cast(const circle::TensorType &circle_type)
     {
       return H5::PredType::NATIVE_UINT8;
     }
+    case circle::TensorType_INT16:
+    {
+      return H5::PredType::NATIVE_INT16;
+    }
     case circle::TensorType_INT32:
     {
       return H5::PredType::NATIVE_INT32;


### PR DESCRIPTION
This supports int16 data type

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: #4444 
Draft PR: #4445