### PR TITLE
[luci] Support S8 in CiecleTensorExporter

### DIFF
--- a/compiler/luci/export/src/CircleTensorExporter.cpp
+++ b/compiler/luci/export/src/CircleTensorExporter.cpp
@@ -265,6 +265,8 @@ flatbuffers::Offset<circle::Buffer> encodeOpBuffer(FlatBufferBuilder &builder, l
   {
     case loco::DataType::FLOAT32:
       return encodeOpBufferByDType<loco::DataType::FLOAT32>(builder, c);
+    case loco::DataType::S8:
+      return encodeOpBufferByDType<loco::DataType::S8>(builder, c);
     case loco::DataType::S16:
       return encodeOpBufferByDType<loco::DataType::S16>(builder, c);
     case loco::DataType::S32:


### PR DESCRIPTION
Parent Issue : #4373
Draft : #4374

This commit will enable supporting `loco::DataType::S8`in CircleTensorExporter

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>