### PR TITLE
[onert] Refine onert/graph test cases

### DIFF
--- a/runtime/onert/test/graph/Index.cc
+++ b/runtime/onert/test/graph/Index.cc
@@ -20,7 +20,7 @@
 
 using Index = ::onert::util::Index<uint32_t, struct TestTag>;
 
-TEST(Index, index_test)
+TEST(Index, neg_index_test)
 {
   Index idx1{1u};
   Index idx2{2u};

--- a/runtime/onert/test/graph/operand/IndexSet.cc
+++ b/runtime/onert/test/graph/operand/IndexSet.cc
@@ -21,7 +21,7 @@
 using onert::ir::OperandIndex;
 using onert::ir::OperandIndexSequence;
 
-TEST(graph_OperandIndexSequence, append)
+TEST(graph_OperandIndexSequence, neg_append)
 {
   OperandIndexSequence iset{0, 2, 4, 8};
 
@@ -42,7 +42,7 @@ TEST(graph_OperandIndexSequence, append)
   ASSERT_FALSE(iset.contains(OperandIndex{11}));
 }
 
-TEST(graph_OperandIndexSequence, replace)
+TEST(graph_OperandIndexSequence, neg_replace)
 {
   OperandIndexSequence iset{0, 1, 2, 3};
 

--- a/runtime/onert/test/graph/operand/LayoutSet.cc
+++ b/runtime/onert/test/graph/operand/LayoutSet.cc
@@ -21,7 +21,22 @@
 using onert::ir::Layout;
 using onert::ir::LayoutSet;
 
-TEST(graph_operand_LayoutSet, layout_set_operators)
+TEST(graph_operand_LayoutSet, neg_add_remove)
+{
+  LayoutSet set{Layout::NCHW};
+  set.remove(Layout::NHWC);
+  ASSERT_EQ(set.size(), 1);
+  set.add(Layout::NHWC);
+  ASSERT_EQ(set.size(), 2);
+  set.remove(Layout::NHWC);
+  ASSERT_EQ(set.size(), 1);
+  set.remove(Layout::NCHW);
+  ASSERT_EQ(set.size(), 0);
+  set.remove(Layout::NCHW);
+  ASSERT_EQ(set.size(), 0);
+}
+
+TEST(graph_operand_LayoutSet, set_operators)
 {
   LayoutSet set1{Layout::NCHW};
   LayoutSet set2{Layout::NHWC};

--- a/runtime/onert/test/graph/operand/Set.cc
+++ b/runtime/onert/test/graph/operand/Set.cc
@@ -18,7 +18,7 @@
 
 #include "ir/Operands.h"
 
-TEST(graph_operand_Set, set_test)
+TEST(graph_operand_Set, neg_set_test)
 {
   onert::ir::Operands set;
 

--- a/runtime/onert/test/graph/operand/UseDef.cc
+++ b/runtime/onert/test/graph/operand/UseDef.cc
@@ -31,7 +31,7 @@ using Mock = onert_test::ir::SimpleMock;
 
 } // namespace
 
-TEST(graph_operand_usedef, usedef_test)
+TEST(graph_operand_usedef, neg_usedef_test)
 {
   onert::ir::Graph graph;
   onert::ir::verifier::DAGChecker verifier;
@@ -62,7 +62,7 @@ TEST(graph_operand_usedef, usedef_test)
 
   graph.finishBuilding();
 
-  ASSERT_EQ(verifier.verify(graph), true);
+  ASSERT_TRUE(verifier.verify(graph));
 
   // Check def
   ASSERT_EQ(graph.operands().at(operand_index1).getDef(), mocknode_index1);

--- a/runtime/onert/test/graph/operation/SetIO.cc
+++ b/runtime/onert/test/graph/operation/SetIO.cc
@@ -62,7 +62,7 @@ TEST(graph_operation_setIO, operation_setIO_conv)
   ASSERT_EQ(conv->getInputs().at(Index{0}).value(), 8);
 }
 
-TEST(graph_operation_setIO, operation_setIO_concat)
+TEST(graph_operation_setIO, neg_operation_setIO_concat)
 {
   onert::ir::Graph graph;
 


### PR DESCRIPTION
This commit refines onert/graph test cases.

- Rename some tests (to be negative tests)
    - According to the rule I made - "If a test contains both positive
      and negative tests, it is a negative test."
    - Some tests must be renamed to be negative tests
- Add new negative tests

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>