### PR TITLE
[onert] optimize getTensorShape(IPortableTensor*)

### DIFF
--- a/runtime/onert/backend/cpu/ops/OperationUtils.h
+++ b/runtime/onert/backend/cpu/ops/OperationUtils.h
@@ -96,26 +96,14 @@ inline nnfw::cker::Shape getTensorShape(const IPortableTensor *tensor)
     return nnfw::cker::Shape();
 
   assert(tensor->layout() == ir::Layout::NHWC);
-  constexpr int kMaxSmallSize = 8;
-  int32_t raw_shape_small[kMaxSmallSize];
-  std::vector<int32_t> raw_shape_vec;
   auto rank = tensor->num_dimensions();
-  int32_t *data = nullptr;
-  if (rank > kMaxSmallSize)
-  {
-    raw_shape_vec.resize(rank);
-    data = raw_shape_vec.data();
-  }
-  else
-  {
-    data = raw_shape_small;
-  }
-
+  nnfw::cker::Shape ret(rank);
+  auto data = ret.DimsData();
   for (uint32_t i = 0; i < rank; ++i)
   {
     data[i] = tensor->dimension(i);
   }
-  return nnfw::cker::Shape(rank, data);
+  return ret;
 }
 
 inline nnfw::cker::FusedActivationFunctionType

--- a/runtime/onert/core/include/backend/cpu_common/Tensor.h
+++ b/runtime/onert/core/include/backend/cpu_common/Tensor.h
@@ -97,7 +97,7 @@ public:
    *       W : dimension(2)
    *       C : dimension(3)
    */
-  size_t dimension(size_t index) const override { return _info.shape().dim(index); }
+  size_t dimension(size_t index) const final override { return _info.shape().dim(index); }
   size_t num_dimensions() const override { return _info.shape().rank(); }
   size_t total_size() const override { return _info.total_size(); }
   size_t calcOffset(const ir::Coordinates &coords) const override;


### PR DESCRIPTION
getTensorShape make a temporary copy for shape.
Then, it is copied again in nnfw::shape::cker::Shape constructor.
It will remove unnecessary copy and allocation.

In addition, it adds final to cpu backend's dimension().
With final keyword, it gives better performance.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>