### PR TITLE
[one-cmds] Create python symbolic link

### DIFF
--- a/compiler/one-cmds/one-prepare-venv
+++ b/compiler/one-cmds/one-prepare-venv
@@ -52,3 +52,7 @@ python -m pip --default-timeout=1000 --trusted-host pypi.org --trusted-host file
   install -U pip==20.2.1 setuptools==49.3.0
 python -m pip --default-timeout=1000 --trusted-host pypi.org --trusted-host files.pythonhost.org \
   install tensorflow-cpu==2.3.0
+
+# Create python symoblic link
+rm -f ${DRIVER_PATH}/python
+ln -s venv/bin/python ${DRIVER_PATH}/python


### PR DESCRIPTION
one-prepare-venv create python symbolic link
Can use virtual environment python by setting PATH [install_dir]/bin only

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>