### PR TITLE
[onert] Move constant input checking

### DIFF
--- a/runtime/onert/backend/acl_cl/KernelGenerator.cc
+++ b/runtime/onert/backend/acl_cl/KernelGenerator.cc
@@ -1381,6 +1381,10 @@ void KernelGenerator::visit(const ir::operation::Split &node)
   const auto axis_index{node.getInputs().at(ir::operation::Split::Input::AXIS)};
 
   assert(node.param().num_splits == static_cast<int>(node.getOutputs().size()));
+  if (!_ctx.at(axis_index).isConstant())
+  {
+    throw std::runtime_error("Non-constant axis_index NYI for acl_cl backend");
+  }
 
   const auto ifm_rank = _ctx.at(ifm_index).shape().rank();
   std::vector<ir::OperandIndex> output_indexes;

--- a/runtime/onert/backend/acl_neon/KernelGenerator.cc
+++ b/runtime/onert/backend/acl_neon/KernelGenerator.cc
@@ -1040,6 +1040,10 @@ void KernelGenerator::visit(const ir::operation::Split &node)
   const auto axis_index{node.getInputs().at(ir::operation::Split::Input::AXIS)};
 
   assert(node.param().num_splits == static_cast<int>(node.getOutputs().size()));
+  if (!_ctx.at(axis_index).isConstant())
+  {
+    throw std::runtime_error("Non-constant axis_index NYI for acl_cl backend");
+  }
 
   const auto ifm_rank = _ctx.at(ifm_index).shape().rank();
   std::vector<ir::OperandIndex> output_indexes;

--- a/runtime/onert/backend/acl_neon/KernelGenerator.cc
+++ b/runtime/onert/backend/acl_neon/KernelGenerator.cc
@@ -1042,7 +1042,7 @@ void KernelGenerator::visit(const ir::operation::Split &node)
   assert(node.param().num_splits == static_cast<int>(node.getOutputs().size()));
   if (!_ctx.at(axis_index).isConstant())
   {
-    throw std::runtime_error("Non-constant axis_index NYI for acl_cl backend");
+    throw std::runtime_error("Non-constant axis_index NYI for acl_neon backend");
   }
 
   const auto ifm_rank = _ctx.at(ifm_index).shape().rank();

--- a/runtime/onert/core/src/compiler/OperationValidator.cc
+++ b/runtime/onert/core/src/compiler/OperationValidator.cc
@@ -43,6 +43,24 @@ void OperationValidator::operator()()
       [&](const ir::OperationIndex &, const ir::Operation &node) { node.accept(*this); });
 }
 
+void OperationValidator::visit(const ir::operation::BatchMatMul &node)
+{
+  const auto lhs_index(node.getInputs().at(ir::operation::BatchMatMul::Input::LHS));
+  const auto rhs_index(node.getInputs().at(ir::operation::BatchMatMul::Input::RHS));
+
+  // Constant lhs and rhs is not implemented yet
+  OP_REQUIRES(!_ctx.at(lhs_index).isConstant() && !_ctx.at(rhs_index).isConstant());
+}
+
+void OperationValidator::visit(const ir::operation::BatchToSpaceND &node)
+{
+  const auto block_size_index{
+      node.getInputs().at(ir::operation::BatchToSpaceND::Input::BLOCK_SIZE)};
+
+  // Non-constant block_size is not implemented yet
+  OP_REQUIRES(_ctx.at(block_size_index).isConstant());
+}
+
 void OperationValidator::visit(const ir::operation::Comparison &node)
 {
   const auto output_index{node.getOutputs().at(0)};
@@ -61,6 +79,17 @@ void OperationValidator::visit(const ir::operation::ElementwiseActivation &node)
 
   // Check if I/O types match
   OP_REQUIRES(_ctx.at(output_index).typeInfo().type() == _ctx.at(input_index).typeInfo().type());
+}
+
+void OperationValidator::visit(const ir::operation::SpaceToBatchND &node)
+{
+  const auto block_size_index{
+      node.getInputs().at(ir::operation::SpaceToBatchND::Input::BLOCK_SIZE)};
+  const auto paddings_index{node.getInputs().at(ir::operation::SpaceToBatchND::Input::PADDINGS)};
+
+  // Non-constant block_size and padding is not implemented yet
+  OP_REQUIRES(_ctx.at(block_size_index).isConstant());
+  OP_REQUIRES(_ctx.at(paddings_index).isConstant());
 }
 
 } // namespace compiler

--- a/runtime/onert/core/src/compiler/OperationValidator.h
+++ b/runtime/onert/core/src/compiler/OperationValidator.h
@@ -43,8 +43,11 @@ public:
   void operator()();
 
 public:
+  void visit(const ir::operation::BatchMatMul &node) override;
+  void visit(const ir::operation::BatchToSpaceND &node) override;
   void visit(const ir::operation::Comparison &node) override;
   void visit(const ir::operation::ElementwiseActivation &node) override;
+  void visit(const ir::operation::SpaceToBatchND &node) override;
 
 private:
   // TODO Remove _ctx field

--- a/runtime/onert/core/src/compiler/ShapeValidator.cc
+++ b/runtime/onert/core/src/compiler/ShapeValidator.cc
@@ -71,9 +71,6 @@ void ShapeValidator::visit(const ir::operation::BatchMatMul &node)
   const auto rhs_index(node.getInputs().at(ir::operation::BatchMatMul::Input::RHS));
   const auto out_index{node.getOutputs().at(0)};
 
-  // Constant lhs and rhs is not implemented yet
-  OP_REQUIRES(!_ctx.at(lhs_index).isConstant() && !_ctx.at(rhs_index).isConstant());
-
   if (_ctx.at(out_index).info().isDynamic())
     return;
 
@@ -103,8 +100,6 @@ void ShapeValidator::visit(const ir::operation::BatchToSpaceND &node)
   OP_REQUIRES(_ctx.at(block_size_index).shape().rank() == 1);
 
   OP_REQUIRES(_ctx.at(block_size_index).shape().dim(0) == 2);
-
-  OP_REQUIRES(_ctx.at(block_size_index).isConstant());
 
   OP_REQUIRES(input_shape.C == output_shape.C);
 }
@@ -300,9 +295,6 @@ void ShapeValidator::visit(const ir::operation::SpaceToBatchND &node)
   OP_REQUIRES(_ctx.at(block_size_index).shape().dim(0) == 2);
   OP_REQUIRES(_ctx.at(paddings_index).shape().dim(0) == 2);
   OP_REQUIRES(_ctx.at(paddings_index).shape().dim(1) == 2);
-
-  OP_REQUIRES(_ctx.at(block_size_index).isConstant());
-  OP_REQUIRES(_ctx.at(paddings_index).isConstant());
 
   OP_REQUIRES(input_shape.C == output_shape.C);
 }
@@ -864,8 +856,6 @@ void ShapeValidator::visit(const ir::operation::Split &node)
 
   const auto input_index{node.getInputs().at(ir::operation::Split::Input::INPUT)};
   const auto axis_index{node.getInputs().at(ir::operation::Split::Input::AXIS)};
-
-  OP_REQUIRES(_ctx.at(axis_index).isConstant());
 
   const auto num_splits = node.param().num_splits;
   const auto input_rank = _ctx.at(input_index).shape().rank();


### PR DESCRIPTION
Move constant input checking from ShapeValidator to OperationValidator
Move constant input checking for acl backend to acl kernel generator

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>