### PR TITLE
[one-cmds] Show error if venv not prepared

### DIFF
--- a/compiler/one-cmds/one-import-bcq
+++ b/compiler/one-cmds/one-import-bcq
@@ -168,6 +168,10 @@ if [ -e ${VIRTUALENV_LINUX} ]; then
   source ${VIRTUALENV_LINUX}
 elif [ -e ${VIRTUALENV_WINDOWS} ]; then
   source ${VIRTUALENV_WINDOWS}
+else
+  echo "Error: Virtual environment not found. Please run 'one-prepare-venv' command."
+  echo "If encounter any problems, please follow provided document in 'doc' folder."
+  exit 255
 fi
 
 # remove previous log

--- a/compiler/one-cmds/one-import-tf
+++ b/compiler/one-cmds/one-import-tf
@@ -172,6 +172,10 @@ if [ -e ${VIRTUALENV_LINUX} ]; then
   source ${VIRTUALENV_LINUX}
 elif [ -e ${VIRTUALENV_WINDOWS} ]; then
   source ${VIRTUALENV_WINDOWS}
+else
+  echo "Error: Virtual environment not found. Please run 'one-prepare-venv' command."
+  echo "If encounter any problems, please follow provided document in 'doc' folder."
+  exit 255
 fi
 
 # remove previous log


### PR DESCRIPTION
This will revise commands that require venv to show error message and a guide if not prepared

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@samsung.com>