### PR TITLE
[release_tool] fix minor bug

### DIFF
--- a/tools/release_tool/git_release.sh
+++ b/tools/release_tool/git_release.sh
@@ -5,7 +5,7 @@
 getopt --test > /dev/null
 if [ $? -ne 4 ]; then
   echo "[ERROR] Your system doesn't have enhanced getopt"
-  echo 2
+  exit 2
 fi
 
 function Usage()


### PR DESCRIPTION
This commit makes `git_release.sh` occur an error when its system
doesn't have enhanced getopt instead of echo.

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>