### PR TITLE
[luci/export]Add UnidirectionalSequenceLSTM on luci/export

### DIFF
--- a/compiler/luci/export/src/CircleOperationExporter.cpp
+++ b/compiler/luci/export/src/CircleOperationExporter.cpp
@@ -719,6 +719,7 @@ public:
   void visit(luci::CircleTopKV2 *) final;
   void visit(luci::CircleTranspose *) final;
   void visit(luci::CircleTransposeConv *) final;
+  void visit(luci::CircleUnidirectionalSequenceLSTM *) final;
   void visit(luci::CircleUnique *) final;
   void visit(luci::CircleUnpack *) final;
   void visit(luci::CircleWhere *) final;
@@ -1374,6 +1375,17 @@ void OperationExporter::visit(luci::CircleTransposeConv *node)
                 circle::BuiltinOptions_TransposeConvOptions,
                 CreateTransposeConvOptions(_ctx.builder, getOpPadding(node->padding()),
                                            node->stride()->w(), node->stride()->h())
+                    .Union());
+}
+
+void OperationExporter::visit(luci::CircleUnidirectionalSequenceLSTM *node)
+{
+  export_simple(node, circle::BuiltinOperator_UNIDIRECTIONAL_SEQUENCE_LSTM,
+                circle::BuiltinOptions_UnidirectionalSequenceLSTMOptions,
+                CreateUnidirectionalSequenceLSTMOptions(
+                    _ctx.builder, to_circle_actfunc(node->fusedActivationFunction()),
+                    node->cell_clip(), node->proj_clip(), node->time_major(),
+                    node->asymmetric_quantize_inputs())
                     .Union());
 }
 


### PR DESCRIPTION
Parent Issue : #4151
Draft PR : #4260

This commit add `UnidirectionalSequenceLSTM` on luci/export.

ONE-DCO-1.0-Signed-off-by: KiDeuk Bang <rrstrous@nate.com>