### PR TITLE
[luci/service]Add UnidirectionalSequenceLSTM on luci/service

### DIFF
--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -2393,14 +2393,14 @@ public:
     return infer_transpose_conv(node);
   }
 
+  loco::NodeShape visit(const luci::CircleUnpack *node) final { return infer_unpack(node); }
+
   loco::NodeShape visit(const luci::CircleUnidirectionalSequenceLSTM *node) final
   {
     return infer_unidirectionalsequencelstm(node);
   }
 
   loco::NodeShape visit(const luci::CircleUnique *node) final { return infer_unique(node); }
-
-  loco::NodeShape visit(const luci::CircleUnpack *node) final { return infer_unpack(node); }
 
   loco::NodeShape visit(const luci::CircleWhere *node) final { return use_own(node); }
 

--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -1613,7 +1613,7 @@ loco::NodeShape infer_unidirectionalsequencelstm(const luci::CircleUnidirectiona
   auto input_shape = loco::shape_get(node->input()).as<loco::TensorShape>();
   auto recurrent_to_output_weights =
       loco::shape_get(node->recurrent_to_output_weights()).as<loco::TensorShape>();
-  auto rank = static_cast<int32_t>(input_shape.rank());
+  auto rank = input_shape.rank();
   loco::TensorShape output_shape;
   output_shape.rank(rank);
   for (int32_t i = 0; i < rank - 1; i++)

--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -1608,6 +1608,22 @@ loco::NodeShape infer_unpack(const luci::CircleUnpack *node)
   return loco::NodeShape{output_shape};
 }
 
+loco::NodeShape infer_unidirectionalsequencelstm(const luci::CircleUnidirectionalSequenceLSTM *node)
+{
+  auto input_shape = loco::shape_get(node->input()).as<loco::TensorShape>();
+  auto recurrent_to_output_weights =
+      loco::shape_get(node->recurrent_to_output_weights()).as<loco::TensorShape>();
+  auto rank = static_cast<int32_t>(input_shape.rank());
+  loco::TensorShape output_shape;
+  output_shape.rank(rank);
+  for (int32_t i = 0; i < rank - 1; i++)
+  {
+    output_shape.dim(i) = input_shape.dim(i);
+  }
+  output_shape.dim(rank - 1) = recurrent_to_output_weights.dim(1);
+  return loco::NodeShape{output_shape};
+}
+
 loco::NodeShape infer_unique(const luci::CircleUnique *node)
 {
   auto input_shape = loco::shape_get(node->input()).as<loco::TensorShape>();
@@ -2377,9 +2393,14 @@ public:
     return infer_transpose_conv(node);
   }
 
-  loco::NodeShape visit(const luci::CircleUnpack *node) final { return infer_unpack(node); }
+  loco::NodeShape visit(const luci::CircleUnidirectionalSequenceLSTM *node) final
+  {
+    return infer_unidirectionalsequencelstm(node);
+  }
 
   loco::NodeShape visit(const luci::CircleUnique *node) final { return infer_unique(node); }
+
+  loco::NodeShape visit(const luci::CircleUnpack *node) final { return infer_unpack(node); }
 
   loco::NodeShape visit(const luci::CircleWhere *node) final { return use_own(node); }
 

--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -1616,7 +1616,7 @@ loco::NodeShape infer_unidirectionalsequencelstm(const luci::CircleUnidirectiona
   auto rank = input_shape.rank();
   loco::TensorShape output_shape;
   output_shape.rank(rank);
-  for (int32_t i = 0; i < rank - 1; i++)
+  for (uint32_t i = 0; i < rank - 1; i++)
   {
     output_shape.dim(i) = input_shape.dim(i);
   }

--- a/compiler/luci/service/src/CircleTypeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleTypeInferenceRule.cpp
@@ -492,6 +492,11 @@ struct TypeInferenceAlgorithm final : public luci::CircleNodeVisitor<loco::DataT
     return loco::dtype_get(node->outBackprop());
   }
 
+  loco::DataType visit(const luci::CircleUnidirectionalSequenceLSTM *node) final
+  {
+    return loco::dtype_get(node->input());
+  }
+
   loco::DataType visit(const luci::CircleUnique *node) final
   {
     return loco::dtype_get(node->input());


### PR DESCRIPTION
Parent Issue : #4151
Draft PR : #4260

This commit add Type Inference/Shape Inference on luci.

ONE-DCO-1.0-Signed-off-by: KiDeuk Bang <rrstrous@nate.com>