### PR TITLE
[onert] Fix a bug with consecutive calls of nnfw_run()

### DIFF
--- a/runtime/onert/core/include/exec/FunctionSequence.h
+++ b/runtime/onert/core/include/exec/FunctionSequence.h
@@ -114,6 +114,7 @@ public: // methods related to dynamic tensor
    *       Once _enable_dynamic_shape_inferer is set to @c false it cannot be changed to @c true
    *       only with calling enableDynamicShapeInferer(). So initializing it to @c true is
    *       necessary.
+   * @todo This is a quick fix. Adding this will increase time for run(). Find way to optimize.
    */
   void initRunning() { _enable_dynamic_shape_inferer = true; }
 

--- a/runtime/onert/core/include/exec/FunctionSequence.h
+++ b/runtime/onert/core/include/exec/FunctionSequence.h
@@ -107,6 +107,16 @@ public: // methods related to dynamic tensor
     _enable_dynamic_shape_inferer = _enable_dynamic_shape_inferer && enable;
   }
 
+  /**
+   * @brief Call this function to initialize vars before running
+   * @note When we run a model with static tensor input and then run with dynamic tensor input,
+   *       _enable_dynamic_shape_inferer is set to @c false at first run.
+   *       Once _enable_dynamic_shape_inferer is set to @c false it cannot be changed to @c true
+   *       only with calling enableDynamicShapeInferer(). So initializing it to @c true is
+   *       necessary.
+   */
+  void initRunning() { _enable_dynamic_shape_inferer = true; }
+
 protected:
   std::vector<std::unique_ptr<IFunction>> _functions;
 

--- a/runtime/onert/core/src/exec/DataflowExecutor.cc
+++ b/runtime/onert/core/src/exec/DataflowExecutor.cc
@@ -159,6 +159,8 @@ void DataflowExecutor::executeImpl()
 
     _subject.notifyJobBegin(this, op_seq, backend);
 
+    job->fn_seq()->initRunning();
+
     // check if FunctionSequence needs to handle dynamic tensor
     bool handle_dynamic_tensor = op_seq->has_dynamic_tensor() || dynamic_input_exists;
     job->fn_seq()->enableDynamicShapeInferer(handle_dynamic_tensor);

--- a/runtime/onert/core/src/exec/LinearExecutor.cc
+++ b/runtime/onert/core/src/exec/LinearExecutor.cc
@@ -51,8 +51,10 @@ void LinearExecutor::executeImpl()
     _subject.notifyJobBegin(this, op_seq, backend);
 
     auto &fn_seq = code.fn_seq;
-    bool handle_dynamic_tensor = op_seq->has_dynamic_tensor() || hasDynamicInput();
 
+    fn_seq->initRunning();
+
+    bool handle_dynamic_tensor = op_seq->has_dynamic_tensor() || hasDynamicInput();
     fn_seq->enableDynamicShapeInferer(handle_dynamic_tensor);
     fn_seq->run();
 

--- a/runtime/onert/core/src/exec/ParallelExecutor.cc
+++ b/runtime/onert/core/src/exec/ParallelExecutor.cc
@@ -132,6 +132,8 @@ void ParallelExecutor::executeImpl()
       notify(job_index);
     };
 
+    job->fn_seq()->initRunning();
+
     // dynamic tensor setting
     bool handle_dynamic_tensor = op_seq->has_dynamic_tensor() || dynamic_input_exists;
     job->fn_seq()->enableDynamicShapeInferer(handle_dynamic_tensor);

--- a/tests/nnfw_api/src/RegressionTests.cc
+++ b/tests/nnfw_api/src/RegressionTests.cc
@@ -62,3 +62,83 @@ TEST_F(RegressionTest, neg_github_3826)
   ASSERT_EQ(nnfw_prepare(session), NNFW_STATUS_ERROR);
   NNFW_ENSURE_SUCCESS(nnfw_close_session(session));
 }
+
+TEST_F(RegressionTest, github_11748)
+{
+  // At the 1st call, input tensor is static. From the 2nd call, input tensor becomes dynamic.
+  // the following model and calling sequence were what nnstreamer people used for their test case.
+  CircleGen cgen;
+  int lhs = cgen.addTensor({{1}, circle::TensorType::TensorType_FLOAT32});
+
+  std::vector<float> rhs_data{2};
+  uint32_t rhs_buf = cgen.addBuffer(rhs_data);
+  int rhs = cgen.addTensor({{1}, circle::TensorType::TensorType_FLOAT32, rhs_buf});
+
+  int out = cgen.addTensor({{1}, circle::TensorType::TensorType_FLOAT32});
+  cgen.addOperatorAdd({{lhs, rhs}, {out}}, circle::ActivationFunctionType_NONE);
+  cgen.setInputsAndOutputs({lhs}, {out});
+  auto cbuf = cgen.finish();
+
+  nnfw_session *session = nullptr;
+  NNFW_ENSURE_SUCCESS(nnfw_create_session(&session));
+  NNFW_ENSURE_SUCCESS(nnfw_load_circle_from_buffer(session, cbuf.buffer(), cbuf.size()));
+  // To test when there is no backends loaded for the session
+  NNFW_ENSURE_SUCCESS(nnfw_set_available_backends(session, "cpu"));
+  NNFW_ENSURE_SUCCESS(nnfw_prepare(session));
+
+  uint32_t input_num = -1;
+  NNFW_ENSURE_SUCCESS(nnfw_input_size(session, &input_num));
+
+  nnfw_tensorinfo t_input;
+  NNFW_ENSURE_SUCCESS(nnfw_input_tensorinfo(session, 0, &t_input));
+
+  uint32_t output_num = -1;
+  NNFW_ENSURE_SUCCESS(nnfw_output_size(session, &output_num));
+
+  nnfw_tensorinfo t_output;
+  NNFW_ENSURE_SUCCESS(nnfw_output_tensorinfo(session, 0, &t_output));
+
+  // when new_dim == 1, input tensor is static. From 2, input tensor becomes dynamic.
+  for (int32_t new_dim = 1; new_dim <= 4; new_dim++)
+  {
+    nnfw_tensorinfo t_new_input;
+    t_new_input.dtype = t_input.dtype;
+    t_new_input.rank = 1;
+    t_new_input.dims[0] = new_dim;
+    NNFW_ENSURE_SUCCESS(nnfw_set_input_tensorinfo(session, 0, &t_new_input));
+
+    NNFW_ENSURE_SUCCESS(nnfw_input_size(session, &input_num));
+    NNFW_ENSURE_SUCCESS(nnfw_input_tensorinfo(session, 0, &t_input));
+
+    ASSERT_EQ(input_num, 1);
+    ASSERT_EQ(t_input.rank, t_new_input.rank);
+    ASSERT_EQ(t_input.dims[0], new_dim);
+
+    uint8_t input_buf[new_dim * sizeof(float)];
+    NNFW_ENSURE_SUCCESS(
+        nnfw_set_input(session, 0, t_input.dtype, &input_buf, new_dim * sizeof(float)));
+
+    uint8_t output_buf[new_dim * sizeof(float)];
+    NNFW_ENSURE_SUCCESS(
+        nnfw_set_output(session, 0, t_output.dtype, &output_buf, new_dim * sizeof(float)));
+
+    NNFW_ENSURE_SUCCESS(nnfw_run(session));
+
+    NNFW_ENSURE_SUCCESS(nnfw_output_size(session, &output_num));
+    NNFW_ENSURE_SUCCESS(nnfw_output_tensorinfo(session, 0, &t_output));
+
+    ASSERT_EQ(output_num, 1);
+    ASSERT_EQ(t_output.rank, t_new_input.rank);
+    ASSERT_EQ(t_output.dims[0], new_dim);
+
+    // seems weird calling but anyway nnstreamer people case calls this again.
+    // Anyways, runtime should work
+    NNFW_ENSURE_SUCCESS(
+        nnfw_set_input(session, 0, t_input.dtype, &input_buf, new_dim * sizeof(float)));
+    NNFW_ENSURE_SUCCESS(
+        nnfw_set_output(session, 0, t_output.dtype, &output_buf, new_dim * sizeof(float)));
+    NNFW_ENSURE_SUCCESS(nnfw_run(session));
+  }
+
+  NNFW_ENSURE_SUCCESS(nnfw_close_session(session));
+}


### PR DESCRIPTION
This fix a bug with consecutive calls of nnfw_run() when 1st call uses
static input tensor but dynamnic input tensor is used from the second call.

Related issue [here](https://github.sec.samsung.net/STAR/nnfw/issues/11748).

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>