### PR TITLE
[luci-interpreter] Initialize member variables in luci-interpreters

### DIFF
--- a/compiler/luci-interpreter/src/kernels/Relu.h
+++ b/compiler/luci-interpreter/src/kernels/Relu.h
@@ -40,8 +40,8 @@ private:
   void evalQuantized() const;
 
 private:
-  int32_t _output_multiplier = 0;
-  int32_t _output_shift = 0;
+  int32_t _output_multiplier{0};
+  int32_t _output_shift{0};
 };
 
 } // namespace kernels

--- a/compiler/luci-interpreter/src/kernels/Relu.h
+++ b/compiler/luci-interpreter/src/kernels/Relu.h
@@ -40,8 +40,8 @@ private:
   void evalQuantized() const;
 
 private:
-  int32_t _output_multiplier;
-  int32_t _output_shift;
+  int32_t _output_multiplier = 0;
+  int32_t _output_shift = 0;
 };
 
 } // namespace kernels

--- a/compiler/luci-interpreter/src/kernels/Relu6.h
+++ b/compiler/luci-interpreter/src/kernels/Relu6.h
@@ -40,8 +40,8 @@ private:
   void evalQuantized() const;
 
 private:
-  int32_t _output_multiplier = 0;
-  int32_t _output_shift = 0;
+  int32_t _output_multiplier{0};
+  int32_t _output_shift{0};
 };
 
 } // namespace kernels

--- a/compiler/luci-interpreter/src/kernels/Relu6.h
+++ b/compiler/luci-interpreter/src/kernels/Relu6.h
@@ -40,8 +40,8 @@ private:
   void evalQuantized() const;
 
 private:
-  int32_t _output_multiplier;
-  int32_t _output_shift;
+  int32_t _output_multiplier = 0;
+  int32_t _output_shift = 0;
 };
 
 } // namespace kernels


### PR DESCRIPTION
This commit will initialize member variables in luci-interpreters to fix static warnings

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>