### PR TITLE
[luci] Fix static warnings in QuantizeWithMinMax

### DIFF
--- a/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
+++ b/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
@@ -759,7 +759,7 @@ void propagate_concat_quantparam(luci::CircleConcatenation *concat, loco::DataTy
         throw std::runtime_error("Unsupported data type for constant input of concatenation Op");
 
       const auto concat_qparam = concat->quantparam();
-      if(concat_qparam == nullptr)
+      if (concat_qparam == nullptr)
         throw std::runtime_error("quantparam of concat is not found during propagation");
 
       assert(concat_qparam->scale.size() == 1);

--- a/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
+++ b/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
@@ -35,7 +35,8 @@ namespace
 void overwrite_quantparam(luci::CircleConcatenation *concat, luci::CircleNode *target)
 {
   auto concat_qparam = concat->quantparam();
-  assert(concat_qparam != nullptr);
+  if (concat_qparam == nullptr)
+    throw std::runtime_error("quantparam of concat is not found during overwrite");
 
   auto target_qparam = target->quantparam();
   if (target_qparam == nullptr)
@@ -758,6 +759,9 @@ void propagate_concat_quantparam(luci::CircleConcatenation *concat, loco::DataTy
         throw std::runtime_error("Unsupported data type for constant input of concatenation Op");
 
       const auto concat_qparam = concat->quantparam();
+      if(concat_qparam == nullptr)
+        throw std::runtime_error("quantparam of concat is not found during propagation");
+
       assert(concat_qparam->scale.size() == 1);
       const auto scaling_factor = concat_qparam->scale[0];
       const auto zerop = concat_qparam->zerop[0];


### PR DESCRIPTION
This commit will fix static warnings in `QuantizeWithMinMaxPass`

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>