### PR TITLE
[onert] Introduces a function `exist` into TensorRegistry

### DIFF
--- a/runtime/onert/backend/acl_common/AclTensorRegistry.h
+++ b/runtime/onert/backend/acl_common/AclTensorRegistry.h
@@ -40,6 +40,8 @@ public:
 
   ITensor *getNativeITensor(const ir::OperandIndex &ind) override { return getITensor(ind); }
 
+  bool exist(const ir::OperandIndex &ind) const override { return _tensor_mgr->at(ind) != nullptr; }
+
   auto getAclTensor(const ir::OperandIndex &ind) { return _tensor_mgr->at(ind).get(); }
 
 private:

--- a/runtime/onert/core/include/backend/ITensorRegistry.h
+++ b/runtime/onert/core/include/backend/ITensorRegistry.h
@@ -59,6 +59,13 @@ struct ITensorRegistry
    * @return false if not supported
    */
   virtual bool setMigrantTensor(const ir::OperandIndex &, IPortableTensor *) { return false; }
+  /**
+   * @brief Check if a tensor with the given index exists
+   *
+   * @param[in] index Index of the tensor to be returned
+   * @return true if such entry exists otherwise false
+   */
+  virtual bool exist(const ir::OperandIndex &) const = 0;
 };
 
 } // namespace backend
@@ -129,6 +136,11 @@ public:
     if (itr != _migrant.end())
       throw std::runtime_error{"Tried to set a native tensor but a migrant tensor already exists."};
     _native[ind] = std::move(tensor);
+  }
+
+  bool exist(const ir::OperandIndex &index) const override
+  {
+    return _native.find(index) != _native.end() || _migrant.find(index) != _migrant.end();
   }
 
   const ir::OperandIndexMap<std::unique_ptr<T_Tensor>> &native_tensors() { return _native; }

--- a/runtime/onert/core/src/backend/controlflow/TensorRegistry.h
+++ b/runtime/onert/core/src/backend/controlflow/TensorRegistry.h
@@ -115,6 +115,8 @@ public:
     _native_user_tensors[ind] = std::move(tensor);
   }
 
+  bool exist(const ir::OperandIndex &ind) const override { return _base_reg->exist(ind); }
+
   const ir::OperandIndexMap<std::unique_ptr<UserTensor>> &native_user_tensors()
   {
     return _native_user_tensors;


### PR DESCRIPTION
For issue #3851
Draft PR #4519

This commit introduces a function `exist` that checks an operand exists in TensorRegistry as a tensor.

Signed-off-by: ragmani <ragmani0216@gmail.com>