### PR TITLE
[onert] Fix when an operand that is input & output

### DIFF
--- a/runtime/onert/core/src/backend/controlflow/DynamicTensorManager.cc
+++ b/runtime/onert/core/src/backend/controlflow/DynamicTensorManager.cc
@@ -58,6 +58,11 @@ void DynamicTensorManager::deallocInput(ir::OperationIndex op_ind)
       continue;
 
     _dynamic_mem_mgr->deallocate(tensor);
+
+    auto *cpu_tensor = dynamic_cast<cpu_common::Tensor *>(tensor);
+    assert(cpu_tensor);
+    cpu_tensor->resetBuffer();
+
     VERBOSE(DynamicTensorManager) << "Deallocating a tensor " << (void *)tensor
                                   << " (input of op_ind: " << op_ind.value() << ")" << std::endl;
   }

--- a/runtime/onert/core/src/backend/cpu_common/MemoryManager.cc
+++ b/runtime/onert/core/src/backend/cpu_common/MemoryManager.cc
@@ -20,6 +20,7 @@
 
 #include "MemoryPlannerFactory.h"
 #include "util/ConfigSource.h"
+#include "util/logging.h"
 
 namespace onert
 {

--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -29,6 +29,7 @@
 #include "compiler/HEScheduler.h"
 #include "compiler/StaticShapeInference.h"
 #include "compiler/pass/ConstantOutputPass.h"
+#include "compiler/pass/OddOutputPass.h"
 #include "compiler/pass/PassRunner.h"
 #include "exec/ExecTime.h"
 #include "ir/operation/LowerInfo.h"
@@ -167,7 +168,10 @@ std::shared_ptr<exec::ExecutorMap> Compiler::compile(void)
 
   _subgraphs->iterate([&](const ir::SubgraphIndex &, ir::Graph &subg) {
     // Mandatory passes
-    pass::PassRunner{}.append(std::make_unique<pass::ConstantOutputPass>(subg)).run();
+    pass::PassRunner{}
+        .append(std::make_unique<pass::ConstantOutputPass>(subg))
+        .append(std::make_unique<pass::OddOutputPass>(subg))
+        .run();
   });
 
   /***************************************************

--- a/runtime/onert/core/src/compiler/pass/OddOutputPass.cc
+++ b/runtime/onert/core/src/compiler/pass/OddOutputPass.cc
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "OddOutputPass.h"
+
+#include "ir/Graph.h"
+#include "ir/operation/Permute.h"
+#include "util/logging.h"
+
+namespace onert
+{
+namespace compiler
+{
+namespace pass
+{
+
+void OddOutputPass::run()
+{
+  auto &outputs = _graph.getOutputs();
+
+  // Case 1 : An operand which is a model output and a model input
+  for (auto &ind : outputs)
+  {
+    if (_graph.getInputs().contains(ind))
+    {
+      auto &obj = _graph.operands().at(ind);
+
+      auto permute_output_ind = _graph.addOperand(obj.shape(), obj.typeInfo());
+      auto &permute_output_obj = _graph.operands().at(permute_output_ind);
+
+      using ir::operation::Permute;
+      auto permute_obj = std::make_unique<Permute>(ind, permute_output_ind, Permute::Type::COPY);
+      auto permute_ind = _graph.operations().push(std::move(permute_obj));
+
+      permute_output_obj.setDef(permute_ind);
+      obj.insertUse(permute_ind);
+
+      VERBOSE(OddOutputPass) << "Permute Op inserted for a constant output, node index : "
+                             << permute_ind << std::endl;
+      VERBOSE(OddOutputPass) << "  - Input (original) Operand : " << ind << std::endl;
+      VERBOSE(OddOutputPass) << "  - Output(inserted) Operand : " << permute_output_ind
+                             << std::endl;
+
+      // Update the output to be newly added operand
+      _graph.getOutputs().replace(ind, permute_output_ind);
+    }
+  }
+}
+
+} // namespace pass
+} // namespace compiler
+} // namespace onert

--- a/runtime/onert/core/src/compiler/pass/OddOutputPass.h
+++ b/runtime/onert/core/src/compiler/pass/OddOutputPass.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_COMPILER_PASS_ODD_OUTPUT_PASS_H__
+#define __ONERT_COMPILER_PASS_ODD_OUTPUT_PASS_H__
+
+#include <unordered_set>
+
+#include "Pass.h"
+#include "ir/Index.h"
+
+namespace onert
+{
+namespace compiler
+{
+namespace pass
+{
+
+/**
+ * @brief Pass to specially handle odd outputs in a subgraph
+ *
+ * Runtime Graph IR requires every input or output must have distinct tensor index, this is onert's
+ * restriction. However we allow duplication of indices in the models(or API). So we should
+ * transform the graph after model-loading.
+ *
+ * This is necessary since our API lets users to set different buffers for each input and output so
+ * it is unavoidable that we must copy the value at runtime.
+ *
+ * Note that this is a mandatory pass for Graph.
+ *
+ * Case 1 : An operand which is a model output and a model input
+ *
+ * Create an operand and insert a Permute(copy) op between them. And change the output to be the
+ * newly generated operand.
+ *
+ * e.g.)
+ *
+ * ```
+ * ((#0 Input0 and also Output0))
+ * becomes
+ * ((#0 Input0)) -> [#0 Permute] -> ((#1 Output0))
+ * ```
+ *
+ * Case 2 : Two or more same outputs
+ *
+ * This case is not yet implemented.
+ *
+ */
+class OddOutputPass : public Pass
+{
+public:
+  using Pass::Pass;
+
+public:
+  std::string id() final { return "OddOutputPass"; }
+
+public:
+  void run() override;
+};
+
+} // namespace pass
+} // namespace compiler
+} // namespace onert
+
+#endif // __ONERT_COMPILER_PASS_ODD_OUTPUT_PASS_H__

--- a/runtime/onert/core/src/compiler/pass/PermutationEliminationPass.cc
+++ b/runtime/onert/core/src/compiler/pass/PermutationEliminationPass.cc
@@ -58,6 +58,11 @@ void PermutationEliminationPass::visit(const ir::operation::Permute &node)
     auto permute_input = node.getInputs().at(0);
     if (_graph.operands().at(permute_input).isConstant())
       return;
+    // If the input is a model input, we cannot remove it since our API lets users to set different
+    // buffers for inputs and outputs even though one tensor is both at the same time.
+    auto permute_output = node.getOutputs().at(0);
+    if (_graph.getInputs().contains(permute_input) && _graph.getOutputs().contains(permute_output))
+      return;
 
     // Exceptional case : When the output operand is a model output
     // In this case we keep the output and remove the input

--- a/tests/nnfw_api/src/GenModelTests.cc
+++ b/tests/nnfw_api/src/GenModelTests.cc
@@ -84,3 +84,35 @@ TEST_F(GenModelTest, UsedConstOutput)
 
   SUCCEED();
 }
+
+TEST_F(GenModelTest, TensorBothInputOutput)
+{
+  // A single tensor which is an input and an output at the same time
+  CircleGen cgen;
+  int t = cgen.addTensor({{2, 2}, circle::TensorType::TensorType_FLOAT32});
+  cgen.setInputsAndOutputs({t}, {t});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->addTestCase(uniformTCD<float>({{1, 3, 2, 4}}, {{1, 3, 2, 4}}));
+  _context->addTestCase(uniformTCD<float>({{100, 300, 200, 400}}, {{100, 300, 200, 400}}));
+  _context->setBackends({"acl_cl", "acl_neon", "cpu"});
+
+  SUCCEED();
+}
+
+TEST_F(GenModelTest, TensorBothInputOutputCrossed)
+{
+  // Two tensors which are an input and an output at the same time
+  // But the order of inputs and outputs is changed.
+  CircleGen cgen;
+  int t1 = cgen.addTensor({{1}, circle::TensorType::TensorType_FLOAT32});
+  int t2 = cgen.addTensor({{1}, circle::TensorType::TensorType_FLOAT32});
+  cgen.setInputsAndOutputs({t1, t2}, {t2, t1});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->addTestCase(uniformTCD<float>({{1}, {2}}, {{2}, {1}}));
+  _context->addTestCase(uniformTCD<float>({{100}, {200}}, {{200}, {100}}));
+  _context->setBackends({"acl_cl", "acl_neon", "cpu"});
+
+  SUCCEED();
+}


### PR DESCRIPTION
Insert a Permute operation and an operand to make an input can be copied
to an output. This is necessary since our API lets users give different
buffer pointers even though a tensor is an input and an output at the
same time.

- Introduce OddOutputPass to handle when an output is also an input
- Fix controlflow::DynamicTensorManager bug
- Add restriction to `PermutationInsertionPass` so the inserted Permute
  op can never be gone
- Add two tests

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>