### PR TITLE
[onert] Removed excess getTensorShape calls

### DIFF
--- a/runtime/onert/backend/cpu/ops/BinaryArithmeticLayer.cc
+++ b/runtime/onert/backend/cpu/ops/BinaryArithmeticLayer.cc
@@ -34,20 +34,21 @@ template <nnfw::cker::BinaryArithmeticOpType arithmetic_type, typename T>
 void eval(const IPortableTensor *lhs, const IPortableTensor *rhs, IPortableTensor *output,
           nnfw::cker::BinaryArithmeticOpParam op_params)
 {
-  const bool need_broadcast =
-      nnfw::cker::ProcessBroadcastShapes(getTensorShape(lhs), getTensorShape(rhs), &op_params);
+  const auto lhsShape = getTensorShape(lhs);
+  const auto rhsShape = getTensorShape(rhs);
+  const bool need_broadcast = nnfw::cker::ProcessBroadcastShapes(lhsShape, rhsShape, &op_params);
   if (need_broadcast)
   {
     nnfw::cker::BroadcastBinaryArithmeticOp<arithmetic_type>(
-        op_params, getTensorShape(lhs), reinterpret_cast<const T *>(lhs->buffer()),
-        getTensorShape(rhs), reinterpret_cast<const T *>(rhs->buffer()), getTensorShape(output),
+        op_params, lhsShape, reinterpret_cast<const T *>(lhs->buffer()), rhsShape,
+        reinterpret_cast<const T *>(rhs->buffer()), getTensorShape(output),
         reinterpret_cast<T *>(output->buffer()));
     return;
   }
 
   nnfw::cker::BinaryArithmeticOp<arithmetic_type>(
-      op_params, getTensorShape(lhs), reinterpret_cast<const T *>(lhs->buffer()),
-      getTensorShape(rhs), reinterpret_cast<const T *>(rhs->buffer()), getTensorShape(output),
+      op_params, lhsShape, reinterpret_cast<const T *>(lhs->buffer()), rhsShape,
+      reinterpret_cast<const T *>(rhs->buffer()), getTensorShape(output),
       reinterpret_cast<T *>(output->buffer()));
 }
 

--- a/runtime/onert/backend/cpu/ops/StridedSliceLayer.cc
+++ b/runtime/onert/backend/cpu/ops/StridedSliceLayer.cc
@@ -37,17 +37,17 @@ StridedSliceLayer::StridedSliceLayer()
 
 template <typename T> void StridedSliceLayer::stridedSliceImpl()
 {
+  const auto inputShape = getTensorShape(_input);
+  const auto outputShape = getTensorShape(_output);
   auto op_params = nnfw::cker::buildStridedSliceParams(
       reinterpret_cast<uint32_t *>(_begin->buffer()), reinterpret_cast<uint32_t *>(_end->buffer()),
       reinterpret_cast<uint32_t *>(_strides->buffer()), _begin_mask, _end_mask, _shrink_axis_mask,
-      getTensorShape(_input).DimensionsCount());
+      inputShape.DimensionsCount());
 
-  nnfw::cker::checkOutputSize(op_params, getTensorShape(_input), getTensorShape(_output),
-                              getTensorShape(_input).DimensionsCount());
+  nnfw::cker::checkOutputSize(op_params, inputShape, outputShape, inputShape.DimensionsCount());
 
-  nnfw::cker::StridedSlice(op_params, getTensorShape(_input),
-                           reinterpret_cast<const T *>(_input->buffer()), getTensorShape(_output),
-                           reinterpret_cast<T *>(_output->buffer()));
+  nnfw::cker::StridedSlice(op_params, inputShape, reinterpret_cast<const T *>(_input->buffer()),
+                           outputShape, reinterpret_cast<T *>(_output->buffer()));
 }
 
 void StridedSliceLayer::configure(const IPortableTensor *input, const IPortableTensor *begin,


### PR DESCRIPTION
Affected layers are BinaryArithmeticLayer and StridedSliceLayer

getTensorShape is slow as it does many virtual calls, which slow down networks with many lightweight nodes. 
