### PR TITLE
[onert] Fix when duplicated output tensors used

### DIFF
--- a/runtime/onert/core/include/ir/OperandIndexSequence.h
+++ b/runtime/onert/core/include/ir/OperandIndexSequence.h
@@ -82,6 +82,8 @@ public:
 public:
   std::vector<OperandIndex>::const_iterator begin(void) const { return _vec.begin(); }
   std::vector<OperandIndex>::const_iterator end(void) const { return _vec.end(); }
+  std::vector<OperandIndex>::iterator begin(void) { return _vec.begin(); }
+  std::vector<OperandIndex>::iterator end(void) { return _vec.end(); }
 
 private:
   std::vector<OperandIndex> _vec;

--- a/runtime/onert/core/src/compiler/pass/OddOutputPass.cc
+++ b/runtime/onert/core/src/compiler/pass/OddOutputPass.cc
@@ -19,6 +19,7 @@
 #include "ir/Graph.h"
 #include "ir/operation/Permute.h"
 #include "util/logging.h"
+#include "util/Utils.h"
 
 namespace onert
 {
@@ -31,7 +32,8 @@ void OddOutputPass::run()
 {
   auto &outputs = _graph.getOutputs();
 
-  // Case 1 : An operand which is a model output and a model input
+  VERBOSE(OddOutputPass) << "Case 1 : An operand which is a model output and a model input"
+                         << std::endl;
   for (auto &ind : outputs)
   {
     if (_graph.getInputs().contains(ind))
@@ -58,6 +60,46 @@ void OddOutputPass::run()
       _graph.getOutputs().replace(ind, permute_output_ind);
     }
   }
+
+  VERBOSE(OddOutputPass) << "Case 2 : Two or more duplicated outputs" << std::endl;
+  std::unordered_set<ir::OperandIndex> occurence;
+  for (auto &ind : outputs)
+  {
+    auto &obj = _graph.operands().at(ind);
+    if (occurence.count(ind) == 0)
+    {
+      occurence.insert(ind);
+      continue;
+    }
+
+    // Panic when it is const, it must have been handled earlier in another pass
+    UNUSED_RELEASE(obj);
+    assert(!obj.isConstant());
+
+    auto permute_output_ind = insertPermute(ind);
+    ind = permute_output_ind; // Replace output index to fix output duplication
+  }
+}
+
+ir::OperandIndex OddOutputPass::insertPermute(ir::OperandIndex ind)
+{
+  auto &obj = _graph.operands().at(ind);
+  auto output_ind = _graph.addOperand(obj.shape(), obj.typeInfo());
+  auto &output_obj = _graph.operands().at(output_ind);
+
+  using ir::operation::Permute;
+  auto permute_obj = std::make_unique<Permute>(ind, output_ind, Permute::Type::COPY);
+  auto permute_ind = _graph.operations().push(std::move(permute_obj));
+
+  output_obj.setDef(permute_ind);
+  obj.insertUse(permute_ind);
+
+  VERBOSE(OddOutputPass) << "Permute Op inserted for a constant output, node index : "
+                         << permute_ind << std::endl;
+  VERBOSE(OddOutputPass) << "  - Input (original) Operand : " << ind << std::endl;
+  VERBOSE(OddOutputPass) << "  - Output(inserted) Operand : " << output_ind << std::endl;
+
+  return output_ind;
 }
 
 } // namespace pass

--- a/runtime/onert/core/src/compiler/pass/OddOutputPass.h
+++ b/runtime/onert/core/src/compiler/pass/OddOutputPass.h
@@ -54,9 +54,17 @@ namespace pass
  * ((#0 Input0)) -> [#0 Permute] -> ((#1 Output0))
  * ```
  *
- * Case 2 : Two or more same outputs
+ * Case 2 : Two or more duplicated outputs
  *
- * This case is not yet implemented.
+ * Do the same with Case 1, but between two outputs of the same tensor index.
+ *
+ * e.g.)
+ *
+ * ```
+ * ((#0 Input0)) -> [#0 Some Operation] -> ((#1 Output0 and also Output1))
+ * becomes
+ * ((#0 Input0)) -> [#0 Some Operation] -> ((#1 Output0)) [#1 Permute] -> ((#2 Output1))
+ * ```
  *
  */
 class OddOutputPass : public Pass
@@ -69,6 +77,9 @@ public:
 
 public:
   void run() override;
+
+private:
+  ir::OperandIndex insertPermute(ir::OperandIndex input);
 };
 
 } // namespace pass

--- a/runtime/onert/core/src/compiler/pass/PermutationEliminationPass.cc
+++ b/runtime/onert/core/src/compiler/pass/PermutationEliminationPass.cc
@@ -63,6 +63,9 @@ void PermutationEliminationPass::visit(const ir::operation::Permute &node)
     auto permute_output = node.getOutputs().at(0);
     if (_graph.getInputs().contains(permute_input) && _graph.getOutputs().contains(permute_output))
       return;
+    // Likewise, if copying between outputs to outputs, keep it.
+    if (_graph.getOutputs().contains(permute_input) && _graph.getOutputs().contains(permute_output))
+      return;
 
     // Exceptional case : When the output operand is a model output
     // In this case we keep the output and remove the input


### PR DESCRIPTION
just like the case when "an operand that is input & output", do the
same for an operand which is referred as a model output two or more
times.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>