### PR TITLE
[onert] Adding dynamic tests into skip file of acl and interp

### DIFF
--- a/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_cl
+++ b/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_cl
@@ -60,6 +60,8 @@ GeneratedTests.einsum_ex_float_matmul_4x4_4_2
 GeneratedTests.equal_dynamic_float_nnfw
 GeneratedTests.exp_
 GeneratedTests.exp_dynamic_nnfw
+GeneratedTests.expand_dims_dynamic_nnfw_1
+GeneratedTests.expand_dims_dynamic_nnfw_2
 GeneratedTests.fill_ex_1D_float
 GeneratedTests.fill_ex_4D_float
 GeneratedTests.fill_ex_dynamic_nnfw
@@ -94,6 +96,7 @@ GeneratedTests.logical_not_1D_nnfw
 GeneratedTests.logical_not_4D_nnfw
 GeneratedTests.logical_not_dynamic_nnfw
 GeneratedTests.logical_or_broadcast
+GeneratedTests.logical_or_dynamic_nnfw
 GeneratedTests.logistic_dynamic_nnfw
 GeneratedTests.lsh_projection
 GeneratedTests.lsh_projection_2

--- a/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_neon
+++ b/tests/nnapi/nnapi_gtest.skip.aarch64-linux.acl_neon
@@ -61,6 +61,8 @@ GeneratedTests.equal_dynamic_float_nnfw
 GeneratedTests.exp_
 GeneratedTests.exp_2D_float_nnfw
 GeneratedTests.exp_dynamic_nnfw
+GeneratedTests.expand_dims_dynamic_nnfw_1
+GeneratedTests.expand_dims_dynamic_nnfw_2
 GeneratedTests.fill_ex_1D_float
 GeneratedTests.fill_ex_4D_float
 GeneratedTests.fill_ex_dynamic_nnfw
@@ -96,6 +98,7 @@ GeneratedTests.logical_not
 GeneratedTests.logical_not_1D_nnfw
 GeneratedTests.logical_not_4D_nnfw
 GeneratedTests.logical_not_dynamic_nnfw
+GeneratedTests.logical_or_dynamic_nnfw
 GeneratedTests.logistic_dynamic_nnfw
 GeneratedTests.lsh_projection
 GeneratedTests.lsh_projection_2

--- a/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_cl
+++ b/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_cl
@@ -60,6 +60,8 @@ GeneratedTests.einsum_ex_float_matmul_4x4_4_2
 GeneratedTests.equal_dynamic_float_nnfw
 GeneratedTests.exp_
 GeneratedTests.exp_dynamic_nnfw
+GeneratedTests.expand_dims_dynamic_nnfw_1
+GeneratedTests.expand_dims_dynamic_nnfw_2
 GeneratedTests.fill_ex_1D_float
 GeneratedTests.fill_ex_4D_float
 GeneratedTests.fill_ex_dynamic_nnfw
@@ -94,6 +96,7 @@ GeneratedTests.logical_not_1D_nnfw
 GeneratedTests.logical_not_4D_nnfw
 GeneratedTests.logical_not_dynamic_nnfw
 GeneratedTests.logical_or_broadcast
+GeneratedTests.logical_or_dynamic_nnfw
 GeneratedTests.logistic_dynamic_nnfw
 GeneratedTests.lsh_projection
 GeneratedTests.lsh_projection_2

--- a/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_neon
+++ b/tests/nnapi/nnapi_gtest.skip.armv7l-linux.acl_neon
@@ -61,6 +61,8 @@ GeneratedTests.equal_dynamic_float_nnfw
 GeneratedTests.exp_
 GeneratedTests.exp_2D_float_nnfw
 GeneratedTests.exp_dynamic_nnfw
+GeneratedTests.expand_dims_dynamic_nnfw_1
+GeneratedTests.expand_dims_dynamic_nnfw_2
 GeneratedTests.fill_ex_1D_float
 GeneratedTests.fill_ex_4D_float
 GeneratedTests.fill_ex_dynamic_nnfw
@@ -95,6 +97,7 @@ GeneratedTests.logical_not
 GeneratedTests.logical_not_1D_nnfw
 GeneratedTests.logical_not_4D_nnfw
 GeneratedTests.logical_not_dynamic_nnfw
+GeneratedTests.logical_or_dynamic_nnfw
 GeneratedTests.logistic_dynamic_nnfw
 GeneratedTests.lsh_projection
 GeneratedTests.lsh_projection_2

--- a/tests/nnapi/nnapi_gtest.skip.noarch.interp
+++ b/tests/nnapi/nnapi_gtest.skip.noarch.interp
@@ -247,6 +247,7 @@ GeneratedTests.logical_or_4D_nnfw
 GeneratedTests.logical_or_broadcast
 GeneratedTests.logical_or_broadcast_4D_2D_nnfw
 GeneratedTests.logical_or_broadcast_nnfw
+GeneratedTests.logical_or_dynamic_nnfw
 GeneratedTests.logical_or_simple
 GeneratedTests.logistic_dynamic_nnfw
 GeneratedTests.logistic_quant8_1


### PR DESCRIPTION
This adds dynamic tests into skip file of acl and interp, which have been removed at c82b149daea09408daabb3e2996c9cbd0e1b1fb8.

acl_cl, acl_neon, and maybe interpreter do not support dynamic tensor yet.

Related to https://github.com/Samsung/ONE/pull/4549#issuecomment-705328755

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>