### PR TITLE
[one-cmds] Add fuse_add_with_tconv option to one-optimize

### DIFF
--- a/compiler/one-cmds/how-to-use-one-commands.txt
+++ b/compiler/one-cmds/how-to-use-one-commands.txt
@@ -82,6 +82,7 @@ one-optimize provides network or operator transformation shown below.
 
 Current transformation options are
 - fold_dequantize : This removes Dequantize operation which can be folded
+- fuse_add_with_tconv: This fuses Add operator with the preceding TConv operator if possible
 - fuse_bcq: This enables Binary-Coded-bases Quantized DNNs
    - read https://arxiv.org/abs/2005.09904 for detailed information
 - fuse_instnorm: This will convert instance normalization related operators to

--- a/compiler/one-cmds/one-optimize
+++ b/compiler/one-cmds/one-optimize
@@ -26,6 +26,8 @@ usage()
   echo "    --all           Enable all optimization algorithms"
   echo "    --fold_dequantize"
   echo "                    Enable FoldDequantize Pass"
+  echo "    --fuse_add_with_tconv"
+  echo "                    Enable FuseAddWithTConv Pass"
   echo "    --fuse_bcq      Enable FuseBCQ Pass"
   echo "    --fuse_instnorm Enable FuseInstanceNormalization Pass"
   echo "    --resolve_customop_add"
@@ -71,6 +73,10 @@ while [ "$#" -ne 0 ]; do
       ;;
     '--fold_dequantize')
       OPTIMIZE_fold_dequantize=1
+      shift
+      ;;
+    '--fuse_add_with_tconv')
+      OPTIMIZE_fuse_add_with_tconv=1
       shift
       ;;
     '--fuse_bcq')
@@ -122,6 +128,9 @@ if [ $OPTIMIZE_all == 1 ]; then
 fi
 if [ $OPTIMIZE_fold_dequantize == 1 ]; then
   OPTIMIZE_OPTIONS+="--fold_dequantize "
+fi
+if [ $OPTIMIZE_fuse_add_with_tconv == 1 ]; then
+  OPTIMIZE_OPTIONS+="--fuse_add_with_tconv "
 fi
 if [ $OPTIMIZE_fuse_bcq == 1 ]; then
   OPTIMIZE_OPTIONS+="--fuse_bcq "


### PR DESCRIPTION
This adds fuse_add_with_tconv option to one-optimize

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/pull/4375