### PR TITLE
[onert] Support DynamicShapeInference for BCQGather

### DIFF
--- a/runtime/onert/core/include/compiler/StaticShapeInference.h
+++ b/runtime/onert/core/include/compiler/StaticShapeInference.h
@@ -71,6 +71,7 @@ private:
   void visit(const ir::operation::ArgMax &op) override;
   void visit(const ir::operation::BatchMatMul &op) override;
   void visit(const ir::operation::BCQFullyConnected &op) override;
+  void visit(const ir::operation::BCQGather &op) override;
   void visit(const ir::operation::BinaryArithmetic &op) override;
   void visit(const ir::operation::BroadcastTo &op) override;
   void visit(const ir::operation::Comparison &op) override;

--- a/runtime/onert/core/include/exec/DynamicShapeInference.h
+++ b/runtime/onert/core/include/exec/DynamicShapeInference.h
@@ -52,6 +52,7 @@ public:
   void visit(const ir::operation::ArgMax &op) override;
   void visit(const ir::operation::BatchMatMul &op) override;
   void visit(const ir::operation::BCQFullyConnected &op) override;
+  void visit(const ir::operation::BCQGather &op) override;
   void visit(const ir::operation::BinaryArithmetic &op) override;
   void visit(const ir::operation::BroadcastTo &op) override;
   void visit(const ir::operation::Comparison &op) override;

--- a/runtime/onert/core/include/util/ShapeInference.h
+++ b/runtime/onert/core/include/util/ShapeInference.h
@@ -50,6 +50,10 @@ ir::Shape inferBatchMatMulShape(const ir::Shape &lhs_shape, const ir::Shape &rhs
 ir::Shape inferBCQFullyConnectedShape(const ir::Shape &in_shape, const ir::Shape &cluster_shape,
                                       const int32_t *cluster_buf);
 
+ir::Shape inferBCQGatherShape(const ir::Shape &indices_shape, const ir::Shape &cluster_shape,
+                              const int32_t *cluster_buf, int rank,
+                              const ir::operation::BCQGather::Param &param);
+
 ir::Shape inferBroadcastToShape(const ir::Shape shp_shape, const int32_t *shp_buf);
 
 ir::Shape inferConcatShape(const Shapes &in_shapes, const ir::operation::Concat::Param &param);


### PR DESCRIPTION
- Implement static/dynamic shape inference for BCQGather
- Add ShapeInference Test for Gather, BCQGather, BCQFullyConnected
- Related Issue : https://github.sec.samsung.net/STAR/nnfw/issues/11819