### PR TITLE
[onert] Add InputAndOutput GenModelTest

### DIFF
--- a/tests/nnfw_api/src/GenModelTests.cc
+++ b/tests/nnfw_api/src/GenModelTests.cc
@@ -165,6 +165,21 @@ TEST_F(GenModelTest, OneTensor_InputAndTwoOutputs)
   SUCCEED();
 }
 
+TEST_F(GenModelTest, OneTensor_InputAndTwoOutputsUsed)
+{
+  CircleGen cgen;
+  int t = cgen.addTensor({{2}, circle::TensorType::TensorType_FLOAT32});
+  int o = cgen.addTensor({{2}, circle::TensorType::TensorType_FLOAT32});
+  cgen.addOperatorNeg({{t}, {o}});
+  cgen.setInputsAndOutputs({t}, {t, t, o}); // Same tensor is an input and 2 outputs
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->addTestCase(uniformTCD<float>({{1, 1}}, {{1, 1}, {1, 1}, {-1, -1}}));
+  _context->setBackends({"acl_cl", "acl_neon", "cpu"});
+
+  SUCCEED();
+}
+
 TEST_F(GenModelTest, OneTensor_ConstAndThreeOutputs)
 {
   CircleGen cgen;


### PR DESCRIPTION
Add a TC for when an operand is both Input and Output and is used by an
operation.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>