### PR TITLE
[one-cmds] Add missing declaration

### DIFF
--- a/compiler/one-cmds/one-optimize
+++ b/compiler/one-cmds/one-optimize
@@ -49,6 +49,7 @@ version()
 
 OPTIMIZE_all=0
 OPTIMIZE_fold_dequantize=0
+OPTIMIZE_fuse_add_with_tconv=0
 OPTIMIZE_fuse_bcq=0
 OPTIMIZE_fuse_instnorm=0
 OPTIMIZE_resolve_customop_add=0


### PR DESCRIPTION
Missing declaration causes `unary operator expected` error.
This commit will fix it.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>