### PR TITLE
[onnxkit] Use ONNX 1.6.0

### DIFF
--- a/compiler/onnxkit/CMakeLists.txt
+++ b/compiler/onnxkit/CMakeLists.txt
@@ -1,5 +1,5 @@
 nnas_find_package(Protobuf QUIET)
-nnas_find_package(ONNXSource EXACT 1.4.1 QUIET)
+nnas_find_package(ONNXSource EXACT 1.6.0 QUIET)
 
 if(NOT Protobuf_FOUND)
   return()


### PR DESCRIPTION
This will revise onnxkit to use ONNX version 1.6.0

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>