### PR TITLE
[onert] Replace dyn_cast with polymorphic_downcast

### DIFF
--- a/runtime/onert/core/src/backend/controlflow/DynamicTensorManager.cc
+++ b/runtime/onert/core/src/backend/controlflow/DynamicTensorManager.cc
@@ -17,6 +17,7 @@
 #include "DynamicTensorManager.h"
 
 #include "util/logging.h"
+#include "misc/polymorphic_downcast.h"
 
 namespace onert
 {
@@ -59,8 +60,7 @@ void DynamicTensorManager::deallocInput(ir::OperationIndex op_ind)
 
     _dynamic_mem_mgr->deallocate(tensor);
 
-    auto *cpu_tensor = dynamic_cast<cpu_common::Tensor *>(tensor);
-    assert(cpu_tensor);
+    auto *cpu_tensor = nnfw::misc::polymorphic_downcast<cpu_common::Tensor *>(tensor);
     cpu_tensor->resetBuffer();
 
     VERBOSE(DynamicTensorManager) << "Deallocating a tensor " << (void *)tensor

--- a/runtime/onert/core/src/backend/cpu_common/DynamicTensorManager.cc
+++ b/runtime/onert/core/src/backend/cpu_common/DynamicTensorManager.cc
@@ -17,6 +17,7 @@
 #include "backend/cpu_common/DynamicTensorManager.h"
 
 #include "util/logging.h"
+#include "misc/polymorphic_downcast.h"
 
 namespace onert
 {
@@ -59,8 +60,7 @@ void DynamicTensorManager::deallocInput(ir::OperationIndex op_ind)
 
     _dynamic_mem_mgr->deallocate(tensor);
 
-    auto *cpu_tensor = dynamic_cast<cpu_common::Tensor *>(tensor);
-    assert(cpu_tensor);
+    auto *cpu_tensor = nnfw::misc::polymorphic_downcast<cpu_common::Tensor *>(tensor);
     cpu_tensor->resetBuffer();
 
     VERBOSE(DynamicTensorManager) << "Deallocating tensor " << (void *)cpu_tensor


### PR DESCRIPTION
Replace dyn_cast with polymorphic_downcast in DynamicTensorManager as
this code always assumes that the downcast is successful. And for some
models this part could be performance-critical as it is run during
inference execution.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>