### PR TITLE
[onert] Fixes missing out printing name of LSTM

### DIFF
--- a/runtime/onert/core/include/ir/operation/LSTM.h
+++ b/runtime/onert/core/include/ir/operation/LSTM.h
@@ -73,6 +73,7 @@ public:
 
 public:
   void accept(OperationVisitor &v) const override;
+  std::string name() const override;
   OpCode opcode() const final { return OpCode::LSTM; }
 
 public:

--- a/runtime/onert/core/src/ir/OperationDumper.cc
+++ b/runtime/onert/core/src/ir/OperationDumper.cc
@@ -199,6 +199,7 @@ void OperationDumper::visit(const LocalResponseNormalization &node) { dumpUnaryI
 
 void OperationDumper::visit(const LSTM &node)
 {
+  VERBOSE(LIR) << "* " << node.name() << std::endl;
   VERBOSE(LIR)
       << "  - Inputs : Input(" << node.getInputs().at(LSTM::Input::INPUT)
       << ") Input To Input Weights(" << node.getInputs().at(LSTM::Input::INPUT_TO_INPUT_WEIGHTS)

--- a/runtime/onert/core/src/ir/operation/LSTM.cc
+++ b/runtime/onert/core/src/ir/operation/LSTM.cc
@@ -35,6 +35,14 @@ LSTM::LSTM(const OperandIndexSequence &inputs, const OperandIndexSequence &outpu
 {
 }
 
+std::string LSTM::name() const
+{
+  if (getOutputs().at(Output::SCRATCH_BUFFER).undefined())
+    return std::string{"UnidirectionalSequenceLSTM"};
+  else
+    return Operation::name();
+}
+
 } // namespace operation
 } // namespace ir
 } // namespace onert


### PR DESCRIPTION
This commit fixes missing out printing name of LSTM.

Signed-off-by: ragmani <ragmani0216@gmail.com>