### PR TITLE
[onert] Support UnidirectionalSequenceLSTM operation on cpu backend

### DIFF
--- a/compute/cker/include/cker/TensorUtils.h
+++ b/compute/cker/include/cker/TensorUtils.h
@@ -31,55 +31,133 @@ namespace nnfw
 namespace cker
 {
 
-void VectorBatchVectorAssign(const float *vector, int v_size, int n_batch, float *batch_vector)
+inline void CwiseClipping(float *vector, const int v_size, const float clipping_value)
+{
+  NEON_OR_PORTABLE(CwiseClipping, vector, v_size, clipping_value);
+}
+
+inline void VectorBatchVectorAdd(const float *vector, int v_size, int n_batch, float *batch_vector)
+{
+  PortableVectorBatchVectorAdd(vector, v_size, n_batch, batch_vector);
+}
+
+inline void VectorBatchVectorAssign(const float *vector, int v_size, int n_batch,
+                                    float *batch_vector)
 {
   PortableVectorBatchVectorAssign(vector, v_size, n_batch, batch_vector);
 }
 
-bool IsZeroVector(const float *vector, int v_size)
+// Cwise product of two vectors.
+template <typename T>
+inline void VectorVectorCwiseProduct(const T *__restrict__ vector1, const T *__restrict__ vector2,
+                                     int v_size, T *__restrict__ result)
+{
+  for (int v = 0; v < v_size; v++)
+  {
+    *result++ = *vector1++ * *vector2++;
+  }
+}
+
+// Cwise product and accumulate of two vectors. Since it's a MAC operation, the
+// assumption here is that result array is initialized to valid values.
+template <typename T>
+inline void VectorVectorCwiseProductAccumulate(const T *__restrict__ vector1,
+                                               const T *__restrict__ vector2, int v_size,
+                                               T *__restrict__ result)
+{
+  for (int v = 0; v < v_size; v++)
+  {
+    *result++ += *vector1++ * *vector2++;
+  }
+}
+
+// Cwise product of a vector and a batch-vector.
+template <typename T>
+inline void VectorBatchVectorCwiseProduct(const T *vector, int v_size, const T *batch_vector,
+                                          int n_batch, T *result)
+{
+  for (int b = 0; b < n_batch; b++)
+  {
+    VectorVectorCwiseProduct(vector, batch_vector, v_size, result);
+    // Update the pointers.
+    result += v_size;
+    batch_vector += v_size;
+  }
+}
+
+// Cwise product and accumulate of a vector and a batch-vector. Since it's a MAC
+// operation, the assumption here is that result array is initialized to valid
+// values.
+template <typename T>
+inline void VectorBatchVectorCwiseProductAccumulate(const T *vector, int v_size,
+                                                    const T *batch_vector, int n_batch, T *result)
+{
+  for (int b = 0; b < n_batch; b++)
+  {
+    VectorVectorCwiseProductAccumulate(vector, batch_vector, v_size, result);
+    // Update the pointers.
+    result += v_size;
+    batch_vector += v_size;
+  }
+}
+
+inline bool IsZeroVector(const float *vector, int v_size)
 {
   return NEON_OR_PORTABLE(IsZeroVector, vector, v_size);
 }
 
-void ApplyActivationToVector(const float *vector, int v_size,
-                             FusedActivationFunctionType activation, float *result)
+inline void ApplyActivationToVector(const float *vector, int v_size,
+                                    FusedActivationFunctionType activation, float *result)
 {
   PortableApplyActivationToVector(vector, v_size, activation, result);
 }
 
-void SymmetricQuantizeFloats(const float *values, const int size, int8_t *quantized_values,
-                             float *min, float *max, float *scaling_factor)
+inline void Sub1Vector(const float *vector, int v_size, float *result)
+{
+  NEON_OR_PORTABLE(Sub1Vector, vector, v_size, result);
+}
+
+inline void SymmetricQuantizeFloats(const float *values, const int size, int8_t *quantized_values,
+                                    float *min, float *max, float *scaling_factor)
 {
   return NEON_OR_PORTABLE(SymmetricQuantizeFloats, values, size, quantized_values, min, max,
                           scaling_factor);
 }
 
-void MatrixBatchVectorMultiplyAccumulate(const int8_t *matrix, const int m_rows, const int m_cols,
-                                         const int8_t *vector, const float *scaling_factors,
-                                         int n_batch, float *result, int result_stride)
+inline void MatrixBatchVectorMultiplyAccumulate(const int8_t *matrix, const int m_rows,
+                                                const int m_cols, const int8_t *vector,
+                                                const float *scaling_factors, int n_batch,
+                                                float *result, int result_stride)
 {
   NEON_OR_PORTABLE(MatrixBatchVectorMultiplyAccumulate, matrix, m_rows, m_cols, vector,
                    scaling_factors, n_batch, result, result_stride);
 }
 
-void MatrixBatchVectorMultiplyAccumulate(const float *matrix, int m_rows, int m_cols,
-                                         const float *vector, int n_batch, float *result,
-                                         int result_stride)
+inline void MatrixBatchVectorMultiplyAccumulate(const float *matrix, int m_rows, int m_cols,
+                                                const float *vector, int n_batch, float *result,
+                                                int result_stride)
 {
   NEON_OR_PORTABLE(MatrixBatchVectorMultiplyAccumulate, matrix, m_rows, m_cols, vector, n_batch,
                    result, result_stride);
 }
 
-void MatrixBatchVectorMultiplyAccumulate(const int8_t *matrix, const int m_rows, const int m_cols,
-                                         const int8_t *vectors, const float *scaling_factors,
-                                         int n_batch, int32_t *scratch, float *result,
-                                         int result_stride, ruy::Context *ruy_context)
+inline void MatrixBatchVectorMultiplyAccumulate(const int8_t *matrix, const int m_rows,
+                                                const int m_cols, const int8_t *vectors,
+                                                const float *scaling_factors, int n_batch,
+                                                int32_t *scratch, float *result, int result_stride,
+                                                ruy::Context *ruy_context)
 {
   NEON_OR_PORTABLE(MatrixBatchVectorMultiplyAccumulate, matrix, m_rows, m_cols, vectors,
                    scaling_factors, n_batch, scratch, result, result_stride, ruy_context);
 }
 
-void ZeroVector(float *vector, int v_size) { PortableZeroVector(vector, v_size); }
+inline void MeanStddevNormalization(const float *input_vector, float *output_vector, int v_size,
+                                    int n_batch)
+{
+  PortableMeanStddevNormalization(input_vector, output_vector, v_size, n_batch);
+}
+
+inline void ZeroVector(float *vector, int v_size) { PortableZeroVector(vector, v_size); }
 
 } // namespace cker
 } // namespace nnfw

--- a/compute/cker/include/cker/Types.h
+++ b/compute/cker/include/cker/Types.h
@@ -34,6 +34,8 @@ enum class FusedActivationFunctionType
   kRelu6 = 1,
   kRelu1 = 2,
   kRelu = 3,
+  kTanh = 4,
+  kSigmoid = 6,
 };
 enum class PaddingType
 {
@@ -266,6 +268,27 @@ struct L2NormParams
 {
   // uint8 inference params.
   int32_t input_zero_point;
+};
+
+enum LSTMKernelType
+{
+  kTfLiteLSTMFullKernel = 0,
+  kTfLiteLSTMBasicKernel
+};
+
+struct LSTMParams
+{
+  // Parameters for LSTM version 1.
+  FusedActivationFunctionType activation{FusedActivationFunctionType::kNone};
+  float cell_clip;
+  float proj_clip;
+
+  // Parameters for LSTM version 2.
+  // kTfLiteLSTMBasicKernel is only supported in version 2 or above.
+  LSTMKernelType kernel_type;
+
+  // Parameters for LSTM version 4.
+  bool asymmetric_quantize_inputs;
 };
 
 struct GatherParams

--- a/compute/cker/include/cker/operation/LSTM.h
+++ b/compute/cker/include/cker/operation/LSTM.h
@@ -1,0 +1,364 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __NNFW_CKER_UNIDIRECTIONALSEQUENCELSTM_H__
+#define __NNFW_CKER_UNIDIRECTIONALSEQUENCELSTM_H__
+
+#include "cker/TensorUtils.h"
+#include "cker/Types.h"
+
+namespace nnfw
+{
+namespace cker
+{
+
+// LINT.IfChange
+// Calculates a single LSTM gate.
+//
+// Implements the following formula: (* is matrix multiply)
+//   gate = activate(W_input    * input + W_aux       * aux_input   +
+//                   W_peephole * cell  + W_recurrent * prev_output + bias)
+// with layer norm:
+//   gate = activate(W_norm * normalize(...) + bias) // not adding bias inside
+//
+// Activation is sigmoid except for the "cell" gate (configurable, usually tanh)
+//
+// Parameters:
+// Input vectors (to LSTM):    | Size:                | Optional?
+//   input                     | n_input              |
+//   aux_input                 | n_aux_input          | y (bidir LSTM)
+// Input vectors (persistent states):
+//   output_state              | n_output             |
+//   cell_state                | n_cell               |
+// 'Constant' inputs:
+//   input_to_gate_weights     | n_cell * n_input     |
+//   aux_input_to_gate_weights | n_cell * n_aux_input | y (bidir LSTM)
+//   recurrent_to_gate_weights | n_cell * n_output    |
+//   cell_to_gate_weights      | n_cell               | y (peephole)
+//   gate_bias                 | n_cell               |
+//   layer_norm_coefficients   | n_cell               | y (layer norm)
+// Output vector:
+//   gate                      | n_cell               |
+// Scalar parameters:
+//   n_batch                                    - batch size / number of vectors
+//   n_input, n_aux_input, n_output, n_cell     - size of vectors.
+//   activation                                 - activation to use.
+//   is_input_all_zeros, is_aux_input_all_zeros - if input vectors are all zero.
+//   use_layer_norm                             - if doing layer norm LSTM.
+inline void CalculateLstmGateFloat(const float *input, const float *input_to_gate_weights,
+                                   const float *aux_input, const float *aux_input_to_gate_weights,
+                                   const float *output_state,
+                                   const float *recurrent_to_gate_weights, const float *cell_state,
+                                   const float *cell_to_gate_weights,
+                                   const float *layer_norm_coefficients, const float *gate_bias,
+                                   const int n_batch, const int n_input, const int n_aux_input,
+                                   const int n_output, const int n_cell,
+                                   const FusedActivationFunctionType activation, float *gate,
+                                   const bool is_input_all_zeros, const bool is_aux_input_all_zeros)
+{
+  const bool use_peephole = (cell_to_gate_weights != nullptr);
+  const bool use_layer_norm = (layer_norm_coefficients != nullptr);
+
+  // Initialize scratch buffers with bias for regular lstm or initialize with
+  // zero for layer norm lstm.
+  if (use_layer_norm)
+  {
+    std::fill_n(gate, n_cell * n_batch, 0.0f);
+  }
+  else
+  {
+    VectorBatchVectorAssign(gate_bias, n_cell, n_batch, gate);
+  }
+  // For each batch and cell: compute input_weight * input.
+  // Skip if input is all zeros.
+  if (!is_input_all_zeros)
+  {
+    MatrixBatchVectorMultiplyAccumulate(input_to_gate_weights, n_cell, n_input, input, n_batch,
+                                        gate, /*result_stride=*/1);
+  }
+  // For each batch and cell: compute aux_input_weight * aux_input.
+  // Skip if auxiliary input is not available or all zeros.
+  if (!is_aux_input_all_zeros)
+  {
+    MatrixBatchVectorMultiplyAccumulate(aux_input_to_gate_weights, n_cell, n_aux_input, aux_input,
+                                        n_batch, gate, /*result_stride=*/1);
+  }
+  // For each batch and cell: compute recurrent_weight * output_state.
+  MatrixBatchVectorMultiplyAccumulate(recurrent_to_gate_weights, n_cell, n_output, output_state,
+                                      n_batch, gate, /*result_stride=*/1);
+  // For each batch and cell: compute cell_weight .* cell_state (peephole LSTM)
+  if (use_peephole)
+  {
+    VectorBatchVectorCwiseProductAccumulate(cell_to_gate_weights, n_cell, cell_state, n_batch,
+                                            gate);
+  }
+  // Do layer normalization (if layer norm LSTM)
+  if (use_layer_norm)
+  {
+    MeanStddevNormalization(gate, gate, n_cell, n_batch);
+    VectorBatchVectorCwiseProduct(layer_norm_coefficients, n_cell, gate, n_batch, gate);
+    VectorBatchVectorAdd(gate_bias, n_cell, n_batch, gate);
+  }
+  // Apply activation
+  ApplyActivationToVector(gate, n_batch * n_cell, activation, gate);
+}
+
+// Updates the LSTM cell state, used by both float and hybrid LSTM versions.
+//
+// Implements the following formula:
+//   cell_state_new = clip(forget_gate * cell_state + input_gate * cell_gate)
+//
+// With CIFG LSTM, input gate is replaced by (1-forget_gate).
+//
+// Parameters:
+//  - n_batch, n_cell: sizes of vectors
+//  - cell_state: input/output vector, size n_batch*n_cell
+//  - input_gate: input vector, size n_batch*n_cell.
+//  - forget_gate: input/scratch vector, size n_batch*n_cell, modified with CIFG
+//  - cell_gate: input vector, size n_batch*n_cell.
+//  - use_cifg: use 1-forget_gate instead of input_gate.
+//  - clip: if > 0, clip the resulting cell state to [-clip, +clip].
+void UpdateLstmCellFloat(int n_batch, int n_cell, float *cell_state, const float *input_gate,
+                         float *forget_gate, const float *cell_gate, bool use_cifg, float clip)
+{
+  VectorVectorCwiseProduct(forget_gate, cell_state, n_batch * n_cell, cell_state);
+
+  if (use_cifg)
+  {
+    // With CIFG, input_gate = 1-forget_gate. Use the forget_gate array as
+    // scratch, as input_gate array is not allocated in this case. (Be careful
+    // not to write to the scratch before reading the forget gate data.)
+    float *scratch = forget_gate;
+    Sub1Vector(forget_gate, n_batch * n_cell, scratch);
+    VectorVectorCwiseProductAccumulate(cell_gate, scratch, n_batch * n_cell, cell_state);
+  }
+  else
+  {
+    VectorVectorCwiseProductAccumulate(cell_gate, input_gate, n_batch * n_cell, cell_state);
+  }
+  if (clip > 0.0f)
+  {
+    CwiseClipping(cell_state, n_batch * n_cell, clip);
+  }
+}
+
+// Calculates the output state tensor of an LSTM step.
+//
+// Implements the following formula:
+//   output_no_projection = output_gate .* activate(cell_state)
+//     (elementwise vector product)
+// If no projection is used:
+//   output = output_state = output_no_projection
+// With projection:
+//   output = output_state = clip(W*output_no_projection + bias)
+//
+// Output might not have a different 'stride' than n_batch, so we need to copy.
+//
+// Parameters:
+//  - n_batch: batches: the number of distinct vectors in each array.
+//  - n_cell, n_output: sizes of vectors.
+//  - cell_state, output_gate: input vectors, size n_batch*n_cell.
+//  - projection_weights, projection_weights_scale, projection_bias:
+//      constant inputs, describing projection matrix and bias.
+//  - proj_clip: if > 0, clip the output of the projection.
+//  - output_state: output vector, size n_batch*n_output. Must be contigous.
+//  - scratch: scratch area, size n_batch*n_cell.
+void CalculateLstmOutputFloat(int n_batch, int n_cell, int n_output, const float *cell_state,
+                              const float *output_gate, FusedActivationFunctionType activation,
+                              const float *projection_weights, const float *projection_bias,
+                              const float proj_clip, float *output_state, float *scratch)
+{
+  ApplyActivationToVector(cell_state, n_batch * n_cell, activation, scratch);
+  VectorVectorCwiseProduct(output_gate, scratch, n_batch * n_cell, scratch);
+
+  const bool use_projection = (projection_weights != nullptr);
+  const bool use_projection_bias = (projection_bias != nullptr);
+
+  if (use_projection)
+  {
+    if (use_projection_bias)
+    {
+      VectorBatchVectorAssign(projection_bias, n_output, n_batch, output_state);
+    }
+    else
+    {
+      std::fill_n(output_state, n_batch * n_output, 0.0f);
+    }
+    MatrixBatchVectorMultiplyAccumulate(projection_weights, n_output, n_cell, scratch, n_batch,
+                                        output_state, /*result_stride=*/1);
+    if (proj_clip > 0.0f)
+    {
+      CwiseClipping(output_state, n_batch * n_output, proj_clip);
+    }
+  }
+  else
+  {
+    std::copy_n(scratch, n_batch * n_output, output_state);
+  }
+}
+
+// Performs an LSTM batch inference step for input specified by input_ptr.
+// The LSTM cell is specified by the pointers to its weights (*_weights_ptr) and
+// biases (*_bias_ptr), and buffers (*_scratch), along with additional
+// parameters:
+//  - params: various LSTM params including activation, clipping, etc.,
+//  - n_batch: size of batch,
+//  - n_cell: number of cells (or units),
+//  - n_input: the input size,
+//  - n_aux_input: the auxiliary input size.
+//  - n_output: the output size.
+//  - output_batch_leading_dim: the leading dimension of the output buffer.
+//
+// Input of size 'n_batch * n_input':
+//   input_ptr
+// Input of size 'n_batch * n_aux_input':
+//   aux_input_ptr                     - optional (can be nullptr)
+//
+// LSTM weights:
+// Input weights of size 'n_cell * n_input':
+//   input_to_input_weights            - optional
+//   input_to_forget_weights
+//   input_to_cell_weights
+//   input_to_output_weights
+// Auxiliary input weights of size 'n_cell * n_aux_input':
+//   aux_input_to_input_weights        - optional
+//   aux_input_to_forget_weights       - optional
+//   aux_input_to_cell_weights         - optional
+//   aux_input_to_output_weights       - optional
+// Recurrent weights of size 'n_cell * n_output':
+//   recurrent_to_input_weights        - optional
+//   recurrent_to_forget_weights
+//   recurrent_to_cell_weights
+//   recurrent_to_input_weights
+// Peephole weights of size 'n_cell', representing diagonal matrices.
+//   cell_to_input_weights             - optional
+//   cell_to_cell_weights              - optional
+//   cell_to_output_weights            - optional
+// Projection weights of size 'n_output * n_cell'
+//   projection_weights_ptr            - optional
+// Gate biases of size 'n_cell':
+//   input_gate_bias_ptr               - optional
+//   forget_gate_bias_ptr
+//   cell_gate_bias_ptr
+//   output_gate_bias_ptr
+//
+// Layer norm coefficients of size 'n_cell', representing diagonal matrices.
+//   input_layer_norm_coefficients_ptr  - optional
+//   forget_layer_norm_coefficients_ptr - optional
+//   cell_layer_norm_coefficients_ptr   - optional
+//   output_layer_norm_coefficients_ptr - optional
+//
+// The pointers to the cell and output state and the output are updated.
+//
+// The pointers input_ptr, aux_input_ptr, and output_ptr point to data aligned
+// in batch_major order, and each step processes batch_size many inputs from
+// input_ptr, and updates batch_size many cell and output states.
+//
+// The output_batch_dim is output.shape[-1], i.e. the outermost dimension of the
+// output tensor, and in most cases will be equal to n_output. It is usually not
+// when we want to store the LSTM output into a slice of the output tensor, e.g.
+// for bidirectional LSTMs with merge_outputs. In this case, the batched
+// operations cannot be used since they assume that the batched outputs are
+// contiguous, and we manually loop over the batched outputs.
+// LINT.IfChange
+inline void LstmStepFloat(
+    const float *input_ptr, const float *input_to_input_weights_ptr,
+    const float *input_to_forget_weights_ptr, const float *input_to_cell_weights_ptr,
+    const float *input_to_output_weights_ptr, const float *aux_input_ptr,
+    const float *aux_input_to_input_weights_ptr, const float *aux_input_to_forget_weights_ptr,
+    const float *aux_input_to_cell_weights_ptr, const float *aux_input_to_output_weights_ptr,
+    const float *recurrent_to_input_weights_ptr, const float *recurrent_to_forget_weights_ptr,
+    const float *recurrent_to_cell_weights_ptr, const float *recurrent_to_output_weights_ptr,
+    const float *cell_to_input_weights_ptr, const float *cell_to_forget_weights_ptr,
+    const float *cell_to_output_weights_ptr, const float *input_layer_norm_coefficients_ptr,
+    const float *forget_layer_norm_coefficients_ptr, const float *cell_layer_norm_coefficients_ptr,
+    const float *output_layer_norm_coefficients_ptr, const float *input_gate_bias_ptr,
+    const float *forget_gate_bias_ptr, const float *cell_gate_bias_ptr,
+    const float *output_gate_bias_ptr, const float *projection_weights_ptr,
+    const float *projection_bias_ptr, const LSTMParams *params, int n_batch, int n_cell,
+    int n_input, int n_aux_input, int n_output, int output_batch_leading_dim,
+    float *output_state_ptr, float *cell_state_ptr, float *scratch0, float *scratch1,
+    float *scratch2, float *scratch3, float *output_ptr)
+{
+  // Since we have already checked that weights are all there or none, we can
+  // check the existence of only one to the get the condition.
+  const bool use_cifg = (input_to_input_weights_ptr == nullptr);
+
+  // Make named scratch buffers.
+  float *input_gate_scratch = scratch0;
+  float *forget_gate_scratch = scratch1;
+  float *cell_gate_scratch = scratch2;
+  float *output_gate_scratch = scratch3;
+
+  // Check if inputs are all zeros so we can skip some computations.
+  const bool is_input_all_zeros = IsZeroVector(input_ptr, n_batch * n_input);
+  const bool is_aux_input_all_zeros =
+      (aux_input_ptr == nullptr || IsZeroVector(aux_input_ptr, n_batch * n_aux_input));
+  if (!use_cifg)
+  {
+    // Calculate the input gate. (If not CIFG.)
+    CalculateLstmGateFloat(input_ptr, input_to_input_weights_ptr, aux_input_ptr,
+                           aux_input_to_input_weights_ptr, output_state_ptr,
+                           recurrent_to_input_weights_ptr, cell_state_ptr,
+                           cell_to_input_weights_ptr, input_layer_norm_coefficients_ptr,
+                           input_gate_bias_ptr, n_batch, n_input, n_aux_input, n_output, n_cell,
+                           /*activation=kTfLiteActSigmoid*/ FusedActivationFunctionType::kSigmoid,
+                           input_gate_scratch, is_input_all_zeros, is_aux_input_all_zeros);
+  }
+  // Calculate the forget gate.
+  CalculateLstmGateFloat(input_ptr, input_to_forget_weights_ptr, aux_input_ptr,
+                         aux_input_to_forget_weights_ptr, output_state_ptr,
+                         recurrent_to_forget_weights_ptr, cell_state_ptr,
+                         cell_to_forget_weights_ptr, forget_layer_norm_coefficients_ptr,
+                         forget_gate_bias_ptr, n_batch, n_input, n_aux_input, n_output, n_cell,
+                         /*activation=kTfLiteActSigmoid*/ FusedActivationFunctionType::kSigmoid,
+                         forget_gate_scratch, is_input_all_zeros, is_aux_input_all_zeros);
+  // Calculate the cell update gate.
+  CalculateLstmGateFloat(
+      input_ptr, input_to_cell_weights_ptr, aux_input_ptr, aux_input_to_cell_weights_ptr,
+      output_state_ptr, recurrent_to_cell_weights_ptr, /*cell_state=*/nullptr,
+      /*cell_to_gate_weights=*/nullptr, cell_layer_norm_coefficients_ptr, cell_gate_bias_ptr,
+      n_batch, n_input, n_aux_input, n_output, n_cell, params->activation, cell_gate_scratch,
+      is_input_all_zeros, is_aux_input_all_zeros);
+  // Update the cell state.
+  UpdateLstmCellFloat(n_batch, n_cell, cell_state_ptr, input_gate_scratch, forget_gate_scratch,
+                      cell_gate_scratch, use_cifg, params->cell_clip);
+  // Calculate output gate.
+  CalculateLstmGateFloat(input_ptr, input_to_output_weights_ptr, aux_input_ptr,
+                         aux_input_to_output_weights_ptr, output_state_ptr,
+                         recurrent_to_output_weights_ptr, cell_state_ptr,
+                         cell_to_output_weights_ptr, output_layer_norm_coefficients_ptr,
+                         output_gate_bias_ptr, n_batch, n_input, n_aux_input, n_output, n_cell,
+                         /*activation=kTfLiteActSigmoid*/ FusedActivationFunctionType::kSigmoid,
+                         output_gate_scratch, is_input_all_zeros, is_aux_input_all_zeros);
+  // Update the output state.
+  CalculateLstmOutputFloat(n_batch, n_cell, n_output, cell_state_ptr, output_gate_scratch,
+                           params->activation, projection_weights_ptr, projection_bias_ptr,
+                           params->proj_clip, output_state_ptr, scratch2);
+  // Copy output state to the output. Note that the output's rows may not be
+  // contiguous (output_batch_leading_dim != n_output).
+  for (int b = 0; b < n_batch; b++)
+  {
+    std::copy_n(output_state_ptr + b * n_output, n_output,
+                output_ptr + b * output_batch_leading_dim);
+  }
+}
+
+} // namespace cker
+} // namespace nnfw
+
+#endif // __NNFW_CKER_UNIDIRECTIONALSEQUENCELSTM_H__

--- a/runtime/onert/backend/cpu/KernelGenerator.cc
+++ b/runtime/onert/backend/cpu/KernelGenerator.cc
@@ -31,6 +31,7 @@
 #include "ops/FillLayer.h"
 #include "ops/FullyConnectedLayer.h"
 #include "ops/GatherLayer.h"
+#include "ops/LSTMLayer.h"
 #include "ops/MeanLayer.h"
 #include "ops/OneHotLayer.h"
 #include "ops/OperationUtils.h"
@@ -1280,6 +1281,177 @@ void KernelGenerator::visit(const ir::operation::SplitV &node)
   auto fn = std::make_unique<ops::SplitVLayer>();
 
   fn->configure(in_tensor, in_size_splits, in_split_dim, num_splits, out_tensors);
+
+  _return_fn = std::move(fn);
+}
+
+void KernelGenerator::visit(const ir::operation::LSTM &node)
+{
+  const auto scratch_buffer_index{
+      node.getOutputs().at(ir::operation::LSTM::Output::SCRATCH_BUFFER)};
+  const auto output_state_out_index{
+      node.getOutputs().at(ir::operation::LSTM::Output::OUTPUT_STATE_OUT)};
+  const auto cell_state_out_index{
+      node.getOutputs().at(ir::operation::LSTM::Output::CELL_STATE_OUT)};
+  const auto output_index{node.getOutputs().at(ir::operation::LSTM::Output::OUTPUT)};
+
+  const auto input_index{node.getInputs().at(ir::operation::LSTM::Input::INPUT)};
+  const auto input_to_input_weights_index{
+      node.getInputs().at(ir::operation::LSTM::Input::INPUT_TO_INPUT_WEIGHTS)}; // optional
+  const auto input_to_forget_weights_index{
+      node.getInputs().at(ir::operation::LSTM::Input::INPUT_TO_FORGET_WEIGHTS)};
+  const auto input_to_cell_weights_index{
+      node.getInputs().at(ir::operation::LSTM::Input::INPUT_TO_CELL_WEIGHTS)};
+  const auto input_to_output_weights_index{
+      node.getInputs().at(ir::operation::LSTM::Input::INPUT_TO_OUTPUT_WEIGHTS)};
+  const auto recurrent_to_input_weights_index{
+      node.getInputs().at(ir::operation::LSTM::Input::RECURRENT_TO_INPUT_WEIGHTS)}; // optional
+  const auto recurrent_to_forget_weights_index{
+      node.getInputs().at(ir::operation::LSTM::Input::RECURRENT_TO_FORGET_WEIGHTS)};
+  const auto recurrent_to_cell_weights_index{
+      node.getInputs().at(ir::operation::LSTM::Input::RECURRENT_TO_CELL_WEIGHTS)};
+  const auto recurrent_to_output_weights_index{
+      node.getInputs().at(ir::operation::LSTM::Input::RECURRENT_TO_OUTPUT_WEIGHTS)};
+  const auto cell_to_input_weights_index{
+      node.getInputs().at(ir::operation::LSTM::Input::CELL_TO_INPUT_WEIGHTS)}; // optional
+  const auto cell_to_forget_weights_index{
+      node.getInputs().at(ir::operation::LSTM::Input::CELL_TO_FORGET_WEIGHTS)}; // optional
+  const auto cell_to_output_weights_index{
+      node.getInputs().at(ir::operation::LSTM::Input::CELL_TO_OUTPUT_WEIGHTS)}; // optional
+  const auto input_gate_bias_index{
+      node.getInputs().at(ir::operation::LSTM::Input::INPUT_GATE_BIAS)};
+  const auto forget_gate_bias_index{
+      node.getInputs().at(ir::operation::LSTM::Input::FORGET_GATE_BIAS)};
+  const auto cell_gate_bias_index{node.getInputs().at(ir::operation::LSTM::Input::CELL_BIAS)};
+  const auto output_gate_bias_index{
+      node.getInputs().at(ir::operation::LSTM::Input::OUTPUT_GATE_BIAS)};
+  const auto projection_weights_index{
+      node.getInputs().at(ir::operation::LSTM::Input::PROJECTION_WEIGHTS)}; // optional
+  const auto projection_bias_index{
+      node.getInputs().at(ir::operation::LSTM::Input::PROJECTION_BIAS)}; // optional
+  const auto output_state_in_index{
+      node.getInputs().at(ir::operation::LSTM::Input::OUTPUT_STATE_IN)};
+  const auto cell_state_in_index{node.getInputs().at(ir::operation::LSTM::Input::CELL_STATE_IN)};
+  const auto time_major = node.param().time_major;
+
+  // NOTE The input_to_input_weights and the recurrent_to_input_weights do not exist in CIFG.
+  // has_input_to_input_weights && has_recurrent_to_input_weights: no CIFG
+  // !(has_input_to_input_weights && has_recurrent_to_input_weights): CIFG
+  // NOTE The cell_to_input_weights does not exist in non-peephole although regular LSTM(non-CIFG).
+  bool has_input_to_input_weights = _ctx.at(input_to_input_weights_index).shape().dim(0) != 0 &&
+                                    _ctx.at(input_to_input_weights_index).shape().dim(1) != 0;
+  bool has_recurrent_to_input_weights =
+      _ctx.at(recurrent_to_input_weights_index).shape().dim(0) != 0 &&
+      _ctx.at(recurrent_to_input_weights_index).shape().dim(1) != 0;
+
+  // NOTE The cell_to_forget_weights and the cell_to_output_weights exist in peephole.
+  // But the cell_to_input_weights does not exist in regular CIFG although peephole.
+  // has_cell_to_forget_weights && has_cell_to_output_weights: peephole
+  // !(has_cell_to_forget_weights && has_cell_to_output_weights): no peephole
+  bool has_cell_to_forget_weights = _ctx.at(cell_to_forget_weights_index).shape().dim(0) != 0;
+  bool has_cell_to_output_weights = _ctx.at(cell_to_output_weights_index).shape().dim(0) != 0;
+
+  bool has_input_gate_bias = _ctx.at(input_gate_bias_index).shape().dim(0);
+
+  bool has_projection_weights = _ctx.at(projection_weights_index).shape().dim(0) != 0 &&
+                                _ctx.at(projection_weights_index).shape().dim(1) != 0;
+  bool has_projection_bias = _ctx.at(projection_bias_index).shape().dim(0);
+
+  auto scratch_buffer_tensor = _ctx.exist(scratch_buffer_index)
+                                   ? _tensor_reg->getPortableTensor(scratch_buffer_index)
+                                   : nullptr; // optional
+  auto output_state_out_tensor = _tensor_reg->getPortableTensor(output_state_out_index);
+  auto cell_state_out_tensor = _tensor_reg->getPortableTensor(cell_state_out_index);
+  auto output_tensor = _tensor_reg->getPortableTensor(output_index);
+
+  auto input_tensor = _tensor_reg->getPortableTensor(input_index);
+
+  auto input_to_input_weights_tensor =
+      has_input_to_input_weights ? _tensor_reg->getPortableTensor(input_to_input_weights_index)
+                                 : nullptr; // optional
+  auto input_to_forget_weights_tensor =
+      _tensor_reg->getPortableTensor(input_to_forget_weights_index);
+  auto input_to_cell_weights_tensor = _tensor_reg->getPortableTensor(input_to_cell_weights_index);
+  auto input_to_output_weights_tensor =
+      _tensor_reg->getPortableTensor(input_to_output_weights_index);
+  auto recurrent_to_input_weights_tensor =
+      has_recurrent_to_input_weights
+          ? _tensor_reg->getPortableTensor(recurrent_to_input_weights_index)
+          : nullptr; // optional
+  auto recurrent_to_forget_weights_tensor =
+      _tensor_reg->getPortableTensor(recurrent_to_forget_weights_index);
+  auto recurrent_to_cell_weights_tensor =
+      _tensor_reg->getPortableTensor(recurrent_to_cell_weights_index);
+  auto recurrent_to_output_weights_tensor =
+      _tensor_reg->getPortableTensor(recurrent_to_output_weights_index);
+
+  auto cell_to_input_weights_tensor = _tensor_reg->getPortableTensor(cell_to_input_weights_index);
+  auto cell_to_forget_weights_tensor =
+      has_cell_to_forget_weights ? _tensor_reg->getPortableTensor(cell_to_forget_weights_index)
+                                 : nullptr; // optional
+  auto cell_to_output_weights_tensor =
+      has_cell_to_output_weights ? _tensor_reg->getPortableTensor(cell_to_output_weights_index)
+                                 : nullptr; // optional
+
+  auto input_gate_bias_tensor =
+      has_input_gate_bias ? _tensor_reg->getPortableTensor(input_gate_bias_index) : nullptr;
+  auto forget_gate_bias_tensor = _tensor_reg->getPortableTensor(forget_gate_bias_index);
+  auto cell_gate_bias_tensor = _tensor_reg->getPortableTensor(cell_gate_bias_index);
+  auto output_gate_bias_tensor = _tensor_reg->getPortableTensor(output_gate_bias_index);
+  auto output_state_in_tensor = _tensor_reg->getPortableTensor(output_state_in_index);
+  auto cell_state_in_tensor = _tensor_reg->getPortableTensor(cell_state_in_index);
+
+  auto projection_weights_tensor = has_projection_weights
+                                       ? _tensor_reg->getPortableTensor(projection_weights_index)
+                                       : nullptr; // optional
+  auto projection_bias_tensor = has_projection_bias
+                                    ? _tensor_reg->getPortableTensor(projection_bias_index)
+                                    : nullptr; // optional
+
+  IPortableTensor *input_layer_norm_weights_tensor = nullptr;
+  IPortableTensor *forget_layer_norm_weights_tensor = nullptr;
+  IPortableTensor *cell_layer_norm_weights_tensor = nullptr;
+  IPortableTensor *output_layer_norm_weights_tensor = nullptr;
+  if (node.getInputs().size() == 24)
+  {
+    const auto input_layer_norm_weights_index{
+        node.getInputs().at(ir::operation::LSTM::Input::INPUT_LAYER_NORMALIZATION_WEIGHTS)};
+    const auto forget_layer_norm_weights_index{
+        node.getInputs().at(ir::operation::LSTM::Input::FORGET_LAYER_NORMALIZATION_WEIGHTS)};
+    const auto cell_layer_norm_weights_index{
+        node.getInputs().at(ir::operation::LSTM::Input::CELL_LAYER_NORMALIZATION_WEIGHTS)};
+    const auto output_layer_norm_weights_index{
+        node.getInputs().at(ir::operation::LSTM::Input::OUTPUT_LAYER_NORMALIZATION_WEIGHTS)};
+
+    input_layer_norm_weights_tensor =
+        _tensor_reg->getPortableTensor(input_layer_norm_weights_index);
+    forget_layer_norm_weights_tensor =
+        _tensor_reg->getPortableTensor(forget_layer_norm_weights_index);
+    cell_layer_norm_weights_tensor = _tensor_reg->getPortableTensor(cell_layer_norm_weights_index);
+    output_layer_norm_weights_tensor =
+        _tensor_reg->getPortableTensor(output_layer_norm_weights_index);
+  }
+
+  auto fn = std::make_unique<ops::LSTMLayer>();
+
+  fn->configure(
+      input_tensor, input_to_input_weights_tensor, input_to_forget_weights_tensor,
+      input_to_cell_weights_tensor, input_to_output_weights_tensor,
+      recurrent_to_input_weights_tensor, recurrent_to_forget_weights_tensor,
+      recurrent_to_cell_weights_tensor, recurrent_to_output_weights_tensor,
+      cell_to_input_weights_tensor, cell_to_forget_weights_tensor, cell_to_output_weights_tensor,
+      input_layer_norm_weights_tensor, forget_layer_norm_weights_tensor,
+      cell_layer_norm_weights_tensor, output_layer_norm_weights_tensor,
+      /*aux_input=*/nullptr,
+      /*aux_input_to_input_weights=*/nullptr,
+      /*aux_input_to_forget_weights=*/nullptr,
+      /*aux_input_to_cell_weights=*/nullptr,
+      /*aux_input_to_output_weights=*/nullptr, input_gate_bias_tensor, forget_gate_bias_tensor,
+      cell_gate_bias_tensor, output_gate_bias_tensor, projection_weights_tensor,
+      projection_bias_tensor, output_state_in_tensor, cell_state_in_tensor, node.param(),
+      /*forward_sequence=*/true, time_major,
+      /*output_offset=*/0, scratch_buffer_tensor, output_state_out_tensor, cell_state_out_tensor,
+      output_tensor);
 
   _return_fn = std::move(fn);
 }

--- a/runtime/onert/backend/cpu/KernelGenerator.h
+++ b/runtime/onert/backend/cpu/KernelGenerator.h
@@ -63,6 +63,7 @@ public:
   void visit(const ir::operation::ElementwiseBinary &) override;
   void visit(const ir::operation::ElementwiseUnary &) override;
   void visit(const ir::operation::ExpandDims &) override;
+  void visit(const ir::operation::LSTM &) override;
   void visit(const ir::operation::Pad &) override;
   void visit(const ir::operation::Pack &) override;
   void visit(const ir::operation::Unpack &) override;

--- a/runtime/onert/backend/cpu/ops/LSTMLayer.cc
+++ b/runtime/onert/backend/cpu/ops/LSTMLayer.cc
@@ -1,0 +1,347 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "LSTMLayer.h"
+
+#include "OperationUtils.h"
+
+#include <cker/operation/LSTM.h>
+
+namespace onert
+{
+namespace backend
+{
+namespace cpu
+{
+namespace ops
+{
+
+namespace
+{
+template <typename T>
+T *getOptionalOutputBuffer(onert::backend::IPortableTensor *tensor, std::vector<uint8_t> *temp_vec,
+                           int total_size)
+{
+  if (tensor == nullptr)
+  {
+    temp_vec->reserve(total_size);
+    return reinterpret_cast<T *>(temp_vec->data());
+  }
+
+  return reinterpret_cast<T *>(tensor->buffer());
+}
+}
+
+LSTMLayer::LSTMLayer()
+    : _input(nullptr), _input_to_input_weights(nullptr), _input_to_forget_weights(nullptr),
+      _input_to_cell_weights(nullptr), _input_to_output_weights(nullptr),
+      _recurrent_to_input_weights(nullptr), _recurrent_to_forget_weights(nullptr),
+      _recurrent_to_cell_weights(nullptr), _recurrent_to_output_weights(nullptr),
+      _cell_to_input_weights(nullptr), _cell_to_forget_weights(nullptr),
+      _cell_to_output_weights(nullptr), _input_layer_norm_coefficients(nullptr),
+      _forget_layer_norm_coefficients(nullptr), _cell_layer_norm_coefficients(nullptr),
+      _output_layer_norm_coefficients(nullptr), _input_gate_bias(nullptr),
+      _forget_gate_bias(nullptr), _cell_gate_bias(nullptr), _output_gate_bias(nullptr),
+      _projection_weights(nullptr), _projection_bias(nullptr), _output_state_in(nullptr),
+      _cell_state_in(nullptr), _scratch_buffer(nullptr), _output_state(nullptr),
+      _cell_state(nullptr), _output(nullptr), _scratch_vec(), _output_state_vec(),
+      _cell_state_vec(), _params(), _forward_sequence(true), _time_major(true), _output_offset(0)
+{
+  // DO NOTHING
+}
+
+void LSTMLayer::LSTMFloat()
+{
+  assert(_input->num_dimensions() >= 2 && _input->num_dimensions() <= 3);
+  int max_time, n_batch;
+  if (_input->num_dimensions() == 3)
+  {
+    max_time = (_time_major) ? _input->dimension(0) : _input->dimension(1);
+    n_batch = (_time_major) ? _input->dimension(1) : _input->dimension(0);
+  }
+  else
+  {
+    max_time = 1;
+    n_batch = _input->dimension(0);
+  }
+  const int n_input = _input->dimension(_input->num_dimensions() - 1);
+  const int aux_input_size = 0;
+  ;
+
+  // n_cell and n_output will be the same size when there is no projection.
+  const int n_cell = _input_to_output_weights->dimension(0);
+  const int n_output = _recurrent_to_output_weights->dimension(1);
+
+  // Since we have already checked that weights are all there or none, we can
+  // check the existence of only one to the get the condition.
+  const bool use_cifg = (_input_to_input_weights == nullptr);
+
+  // Optional outputs
+  float *output_state_buf = getOptionalOutputBuffer<float>(_output_state, &_output_state_vec,
+                                                           n_batch * n_output * sizeof(float));
+  float *cell_state_buf = getOptionalOutputBuffer<float>(_cell_state, &_cell_state_vec,
+                                                         n_batch * n_cell * sizeof(float));
+  memcpy(output_state_buf, _output_state_in->buffer(), _output_state_in->total_size());
+  memcpy(cell_state_buf, _cell_state_in->buffer(), _cell_state_in->total_size());
+
+  // Index the scratch buffers pointers to the global scratch buffer.
+  float *scratch_buffer_buf = getOptionalOutputBuffer<float>(
+      _scratch_buffer, &_scratch_vec, n_batch * n_cell * (use_cifg ? 3 : 4) * sizeof(float));
+  float *input_gate_scratch = nullptr;
+  float *cell_gate_scratch = nullptr;
+  float *forget_gate_scratch = nullptr;
+  float *output_gate_scratch = nullptr;
+  if (use_cifg)
+  {
+    cell_gate_scratch = scratch_buffer_buf;
+    forget_gate_scratch = scratch_buffer_buf + n_cell * n_batch;
+    output_gate_scratch = scratch_buffer_buf + 2 * n_cell * n_batch;
+  }
+  else
+  {
+    input_gate_scratch = scratch_buffer_buf;
+    cell_gate_scratch = scratch_buffer_buf + n_cell * n_batch;
+    forget_gate_scratch = scratch_buffer_buf + 2 * n_cell * n_batch;
+    output_gate_scratch = scratch_buffer_buf + 3 * n_cell * n_batch;
+  }
+
+  // Optional inputs
+  float *input_to_input_weights_ptr =
+      _input_to_input_weights ? reinterpret_cast<float *>(_input_to_input_weights->buffer())
+                              : nullptr;
+  float *recurrent_to_input_weights_ptr =
+      _recurrent_to_input_weights ? reinterpret_cast<float *>(_recurrent_to_input_weights->buffer())
+                                  : nullptr;
+  float *cell_to_input_weights_ptr =
+      _cell_to_input_weights ? reinterpret_cast<float *>(_cell_to_input_weights->buffer())
+                             : nullptr;
+  float *cell_to_forget_weights_ptr =
+      _cell_to_forget_weights ? reinterpret_cast<float *>(_cell_to_forget_weights->buffer())
+                              : nullptr;
+  float *cell_to_output_weights_ptr =
+      _cell_to_output_weights ? reinterpret_cast<float *>(_cell_to_output_weights->buffer())
+                              : nullptr;
+  float *input_gate_bias_ptr =
+      _input_gate_bias ? reinterpret_cast<float *>(_input_gate_bias->buffer()) : nullptr;
+  float *projection_weights_ptr =
+      _projection_weights ? reinterpret_cast<float *>(_projection_weights->buffer()) : nullptr;
+  float *projection_bias_ptr =
+      _projection_bias ? reinterpret_cast<float *>(_projection_bias->buffer()) : nullptr;
+  float *input_layer_norm_coefficients_ptr =
+      _input_layer_norm_coefficients
+          ? reinterpret_cast<float *>(_input_layer_norm_coefficients->buffer())
+          : nullptr;
+  float *forget_layer_norm_coefficients_ptr =
+      _forget_layer_norm_coefficients
+          ? reinterpret_cast<float *>(_forget_layer_norm_coefficients->buffer())
+          : nullptr;
+  float *cell_layer_norm_coefficients_ptr =
+      _cell_layer_norm_coefficients
+          ? reinterpret_cast<float *>(_cell_layer_norm_coefficients->buffer())
+          : nullptr;
+  float *output_layer_norm_coefficients_ptr =
+      _output_layer_norm_coefficients
+          ? reinterpret_cast<float *>(_output_layer_norm_coefficients->buffer())
+          : nullptr;
+
+  // Copy out the LSTM specific params so they can be passed in the function.
+  nnfw::cker::LSTMParams lstm_params;
+  lstm_params.activation = convertActivationType(_params.activation);
+  lstm_params.cell_clip = _params.cell_threshold;
+  lstm_params.proj_clip = _params.projection_threshold;
+
+  const int output_batch_leading_dim = _output->dimension(_output->num_dimensions() - 1);
+  if (_time_major)
+  {
+    // Loop through the sequence.
+    const int input_step = n_batch * n_input;
+    const int output_step = n_batch * output_batch_leading_dim;
+    for (int t = 0; t < max_time; t++)
+    {
+      // If this is the forward_sequence, step forward, otherwise step
+      // backwards.
+      const int t_rel = _forward_sequence ? t : max_time - t - 1;
+      const float *input_ptr = reinterpret_cast<float *>(_input->buffer()) + t_rel * input_step;
+      const float *aux_input_ptr = nullptr;
+      if (_aux_input)
+      {
+        aux_input_ptr = reinterpret_cast<float *>(_aux_input->buffer()) + t_rel * input_step;
+      }
+      float *output_ptr =
+          reinterpret_cast<float *>(_output->buffer()) + t_rel * output_step + _output_offset;
+
+      LstmStepFloat(
+          input_ptr, input_to_input_weights_ptr,
+          reinterpret_cast<float *>(_input_to_forget_weights->buffer()),
+          reinterpret_cast<float *>(_input_to_cell_weights->buffer()),
+          reinterpret_cast<float *>(_input_to_output_weights->buffer()), aux_input_ptr,
+          /*aux_input_to_input_weights=*/nullptr,
+          /*aux_input_to_forget_weights=*/nullptr,
+          /*aux_input_to_cell_weights=*/nullptr,
+          /*aux_input_to_output_weights=*/nullptr, recurrent_to_input_weights_ptr,
+          reinterpret_cast<float *>(_recurrent_to_forget_weights->buffer()),
+          reinterpret_cast<float *>(_recurrent_to_cell_weights->buffer()),
+          reinterpret_cast<float *>(_recurrent_to_output_weights->buffer()),
+          cell_to_input_weights_ptr, cell_to_forget_weights_ptr, cell_to_output_weights_ptr,
+          input_layer_norm_coefficients_ptr, forget_layer_norm_coefficients_ptr,
+          cell_layer_norm_coefficients_ptr, output_layer_norm_coefficients_ptr, input_gate_bias_ptr,
+          reinterpret_cast<float *>(_forget_gate_bias->buffer()),
+          reinterpret_cast<float *>(_cell_gate_bias->buffer()),
+          reinterpret_cast<float *>(_output_gate_bias->buffer()), projection_weights_ptr,
+          projection_bias_ptr, &lstm_params, n_batch, n_cell, n_input, aux_input_size, n_output,
+          output_batch_leading_dim, output_state_buf, cell_state_buf, input_gate_scratch,
+          forget_gate_scratch, cell_gate_scratch, output_gate_scratch, output_ptr);
+    }
+  }
+  else
+  {
+    for (int b = 0; b < n_batch; b++)
+    {
+      const int input_step = n_input;
+      const int output_step = output_batch_leading_dim;
+      for (int t = 0; t < max_time; t++)
+      {
+        // If this is the forward_sequence, step forward, otherwise step
+        // backwards.
+        const int t_rel = _forward_sequence ? t : max_time - t - 1;
+        const int time_offset = b * max_time + t_rel;
+        const float *input_ptr =
+            reinterpret_cast<float *>(_input->buffer()) + time_offset * input_step;
+        const float *aux_input_ptr = nullptr;
+        if (_aux_input)
+        {
+          aux_input_ptr =
+              reinterpret_cast<float *>(_aux_input->buffer()) + time_offset * input_step;
+        }
+        float *output_ptr = reinterpret_cast<float *>(_output->buffer()) +
+                            time_offset * output_step + _output_offset;
+
+        // Offset the {output,cell}_state pointers to the right batch.
+        float *output_state_ptr = output_state_buf + b * output_batch_leading_dim;
+        float *cell_state_ptr = cell_state_buf + b * n_cell;
+        // Offset the scratch pointers to the right batch.
+        float *input_gate_scratch_ptr =
+            input_gate_scratch ? input_gate_scratch + b * n_cell : nullptr;
+        float *forget_gate_scratch_ptr = forget_gate_scratch + b * n_cell;
+        float *cell_gate_scratch_ptr = cell_gate_scratch + b * n_cell;
+        float *output_gate_scratch_ptr = output_gate_scratch + b * n_cell;
+
+        LstmStepFloat(
+            input_ptr, reinterpret_cast<float *>(_input_to_input_weights->buffer()),
+            reinterpret_cast<float *>(_input_to_forget_weights->buffer()),
+            reinterpret_cast<float *>(_input_to_cell_weights->buffer()),
+            reinterpret_cast<float *>(_input_to_output_weights->buffer()), aux_input_ptr,
+            /*aux_input_to_input_weights=*/nullptr,
+            /*aux_input_to_forget_weights=*/nullptr,
+            /*aux_input_to_cell_weights=*/nullptr,
+            /*aux_input_to_output_weights=*/nullptr, recurrent_to_input_weights_ptr,
+            reinterpret_cast<float *>(_recurrent_to_forget_weights->buffer()),
+            reinterpret_cast<float *>(_recurrent_to_cell_weights->buffer()),
+            reinterpret_cast<float *>(_recurrent_to_output_weights->buffer()),
+            cell_to_input_weights_ptr, cell_to_forget_weights_ptr, cell_to_output_weights_ptr,
+            input_layer_norm_coefficients_ptr, forget_layer_norm_coefficients_ptr,
+            cell_layer_norm_coefficients_ptr, output_layer_norm_coefficients_ptr,
+            input_gate_bias_ptr, reinterpret_cast<float *>(_forget_gate_bias->buffer()),
+            reinterpret_cast<float *>(_cell_gate_bias->buffer()),
+            reinterpret_cast<float *>(_output_gate_bias->buffer()), projection_weights_ptr,
+            projection_bias_ptr, &lstm_params, /*n_batch=*/1, n_cell, n_input, aux_input_size,
+            n_output, output_batch_leading_dim, output_state_ptr, cell_state_ptr,
+            input_gate_scratch_ptr, forget_gate_scratch_ptr, cell_gate_scratch_ptr,
+            output_gate_scratch_ptr, output_ptr);
+      }
+    }
+  }
+}
+
+void LSTMLayer::configure(
+    const IPortableTensor *input, const IPortableTensor *input_to_input_weights,
+    const IPortableTensor *input_to_forget_weights, const IPortableTensor *input_to_cell_weights,
+    const IPortableTensor *input_to_output_weights,
+    const IPortableTensor *recurrent_to_input_weights,
+    const IPortableTensor *recurrent_to_forget_weights,
+    const IPortableTensor *recurrent_to_cell_weights,
+    const IPortableTensor *recurrent_to_output_weights,
+    const IPortableTensor *cell_to_input_weights, const IPortableTensor *cell_to_forget_weights,
+    const IPortableTensor *cell_to_output_weights, const IPortableTensor *input_layer_norm_weights,
+    const IPortableTensor *forget_layer_norm_weights,
+    const IPortableTensor *cell_layer_norm_weights,
+    const IPortableTensor *output_layer_norm_weights, const IPortableTensor *aux_input,
+    const IPortableTensor *aux_input_to_input_weights,
+    const IPortableTensor *aux_input_to_forget_weights,
+    const IPortableTensor *aux_input_to_cell_weights,
+    const IPortableTensor *aux_input_to_output_weights, const IPortableTensor *input_gate_bias,
+    const IPortableTensor *forget_gate_bias, const IPortableTensor *cell_gate_bias,
+    const IPortableTensor *output_gate_bias, const IPortableTensor *projection_weights,
+    const IPortableTensor *projection_bias, const IPortableTensor *output_state_in,
+    const IPortableTensor *cell_state_in, const ir::operation::LSTM::Param &params,
+    bool forward_sequence, bool time_major, int output_offset, IPortableTensor *scratch_buffer,
+    IPortableTensor *output_state, IPortableTensor *cell_state, IPortableTensor *output)
+{
+  _input = input;
+  _input_to_input_weights = input_to_input_weights;
+  _input_to_forget_weights = input_to_forget_weights;
+  _input_to_cell_weights = input_to_cell_weights;
+  _input_to_output_weights = input_to_output_weights;
+  _recurrent_to_input_weights = recurrent_to_input_weights;
+  _recurrent_to_forget_weights = recurrent_to_forget_weights;
+  _recurrent_to_cell_weights = recurrent_to_cell_weights;
+  _recurrent_to_output_weights = recurrent_to_output_weights;
+  _cell_to_input_weights = cell_to_input_weights;
+  _cell_to_forget_weights = cell_to_forget_weights;
+  _cell_to_output_weights = cell_to_output_weights;
+  _input_layer_norm_coefficients = input_layer_norm_weights;
+  _forget_layer_norm_coefficients = forget_layer_norm_weights;
+  _cell_layer_norm_coefficients = cell_layer_norm_weights;
+  _output_layer_norm_coefficients = output_layer_norm_weights;
+  _aux_input = aux_input, _aux_input_to_input_weights = aux_input_to_input_weights,
+  _aux_input_to_forget_weights = aux_input_to_forget_weights,
+  _aux_input_to_cell_weights = aux_input_to_cell_weights,
+  _aux_input_to_output_weights = aux_input_to_output_weights, _input_gate_bias = input_gate_bias;
+  _forget_gate_bias = forget_gate_bias;
+  _cell_gate_bias = cell_gate_bias;
+  _output_gate_bias = output_gate_bias;
+  _projection_weights = projection_weights;
+  _projection_bias = projection_bias;
+  _output_state_in = output_state_in;
+  _cell_state_in = cell_state_in;
+  _params = params;
+  _forward_sequence = forward_sequence;
+  _time_major = time_major;
+  _output_offset = output_offset;
+  _scratch_buffer = scratch_buffer;
+  _output_state = output_state;
+  _cell_state = cell_state;
+  _output = output;
+}
+
+void LSTMLayer::run()
+{
+
+  if (_input->data_type() == OperandType::FLOAT32)
+  {
+    LSTMFloat();
+  }
+  else
+  {
+    throw std::runtime_error{"LSTMLayer: unsupported data type"};
+  }
+}
+
+} // namespace ops
+} // namespace cpu
+} // namespace backend
+} // namespace onert

--- a/runtime/onert/backend/cpu/ops/LSTMLayer.h
+++ b/runtime/onert/backend/cpu/ops/LSTMLayer.h
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_BACKEND_CPU_OPS_LSTMLAYER_H__
+#define __ONERT_BACKEND_CPU_OPS_LSTMLAYER_H__
+
+#include <backend/IPortableTensor.h>
+#include "OperationUtils.h"
+#include <ir/InternalType.h>
+#include <ir/operation/LSTM.h>
+#include <exec/IFunction.h>
+
+namespace nnfw
+{
+namespace cker
+{
+class FCTempArena;
+}
+} // namespace nnfw
+
+namespace onert
+{
+namespace backend
+{
+namespace cpu
+{
+namespace ops
+{
+
+// TODO Support LSTM, BiDirectionalSequenceLSTM
+class LSTMLayer : public ::onert::exec::IFunction
+{
+public:
+  LSTMLayer();
+
+public:
+  void LSTMFloat();
+
+  void configure(const IPortableTensor *input, const IPortableTensor *input_to_input_weights,
+                 const IPortableTensor *input_to_forget_weights,
+                 const IPortableTensor *input_to_cell_weights,
+                 const IPortableTensor *input_to_output_weights,
+                 const IPortableTensor *recurrent_to_input_weights,
+                 const IPortableTensor *recurrent_to_forget_weights,
+                 const IPortableTensor *recurrent_to_cell_weights,
+                 const IPortableTensor *recurrent_to_output_weights,
+                 const IPortableTensor *cell_to_input_weights,
+                 const IPortableTensor *cell_to_forget_weights,
+                 const IPortableTensor *cell_to_output_weights,
+                 const IPortableTensor *input_layer_norm_weights,
+                 const IPortableTensor *forget_layer_norm_weights,
+                 const IPortableTensor *cell_layer_norm_weights,
+                 const IPortableTensor *output_layer_norm_weights, const IPortableTensor *aux_input,
+                 const IPortableTensor *aux_input_to_input_weights,
+                 const IPortableTensor *aux_input_to_forget_weights,
+                 const IPortableTensor *aux_input_to_cell_weights,
+                 const IPortableTensor *aux_input_to_output_weights,
+                 const IPortableTensor *input_gate_bias, const IPortableTensor *forget_gate_bias,
+                 const IPortableTensor *cell_gate_bias, const IPortableTensor *output_gate_bias,
+                 const IPortableTensor *projection_weights, const IPortableTensor *projection_bias,
+                 const IPortableTensor *output_state_in, const IPortableTensor *cell_state_in,
+                 const ir::operation::LSTM::Param &params, bool forward_sequence, bool time_major,
+                 int32_t output_offset, IPortableTensor *scratch_buffer,
+                 IPortableTensor *output_state, IPortableTensor *cell_state,
+                 IPortableTensor *output);
+
+  void run() override;
+
+private:
+  const IPortableTensor *_input;
+  const IPortableTensor *_input_to_input_weights;
+  const IPortableTensor *_input_to_forget_weights;
+  const IPortableTensor *_input_to_cell_weights;
+  const IPortableTensor *_input_to_output_weights;
+  const IPortableTensor *_recurrent_to_input_weights;
+  const IPortableTensor *_recurrent_to_forget_weights;
+  const IPortableTensor *_recurrent_to_cell_weights;
+  const IPortableTensor *_recurrent_to_output_weights;
+  const IPortableTensor *_cell_to_input_weights;
+  const IPortableTensor *_cell_to_forget_weights;
+  const IPortableTensor *_cell_to_output_weights;
+  const IPortableTensor *_input_layer_norm_coefficients;
+  const IPortableTensor *_forget_layer_norm_coefficients;
+  const IPortableTensor *_cell_layer_norm_coefficients;
+  const IPortableTensor *_output_layer_norm_coefficients;
+  const IPortableTensor *_aux_input;
+  const IPortableTensor *_aux_input_to_input_weights;
+  const IPortableTensor *_aux_input_to_forget_weights;
+  const IPortableTensor *_aux_input_to_cell_weights;
+  const IPortableTensor *_aux_input_to_output_weights;
+  const IPortableTensor *_input_gate_bias;
+  const IPortableTensor *_forget_gate_bias;
+  const IPortableTensor *_cell_gate_bias;
+  const IPortableTensor *_output_gate_bias;
+  const IPortableTensor *_projection_weights;
+  const IPortableTensor *_projection_bias;
+  const IPortableTensor *_output_state_in;
+  const IPortableTensor *_cell_state_in;
+  IPortableTensor *_scratch_buffer;
+  IPortableTensor *_output_state;
+  IPortableTensor *_cell_state;
+  IPortableTensor *_output;
+  std::vector<uint8_t> _scratch_vec;
+  std::vector<uint8_t> _output_state_vec;
+  std::vector<uint8_t> _cell_state_vec;
+  ir::operation::LSTM::Param _params;
+  bool _forward_sequence;
+  bool _time_major;
+  int32_t _output_offset;
+};
+
+} // namespace ops
+} // namespace cpu
+} // namespace backend
+} // namespace onert
+
+#endif // __ONERT_BACKEND_CPU_OPS_LSTMLAYER_H__

--- a/runtime/onert/backend/cpu/ops/OperationUtils.h
+++ b/runtime/onert/backend/cpu/ops/OperationUtils.h
@@ -119,6 +119,10 @@ convertActivationType(const ir::Activation activation)
       return nnfw::cker::FusedActivationFunctionType::kRelu1;
     case ir::Activation::RELU6:
       return nnfw::cker::FusedActivationFunctionType::kRelu6;
+    case ir::Activation::TANH:
+      return nnfw::cker::FusedActivationFunctionType::kTanh;
+    case ir::Activation::SIGMOID:
+      return nnfw::cker::FusedActivationFunctionType::kSigmoid;
     default:
       throw std::runtime_error{"CPU backend: Cannot convert activation type"};
   }


### PR DESCRIPTION
For issue #3851
Draft PR #4519

This commit make cpu backend supports UnidirectionalSequenceLSTM operation for float.
  - Add LSTMLayer on cpu backend
  - Introduce LstmStepFloat() into cker

Signed-off-by: ragmani <ragmani0216@gmail.com>