### PR TITLE
[onert] static tensor info caching in BinaryArithmeticLayer

### DIFF
--- a/compute/cker/include/cker/Shape.h
+++ b/compute/cker/include/cker/Shape.h
@@ -136,6 +136,21 @@ public:
     std::memcpy(dst_dims, dims_data, dimensions_count * sizeof(int32_t));
   }
 
+  inline void ReplaceWith(const Shape &other)
+  {
+    ReplaceWith(other.DimensionsCount(), other.DimsData());
+  }
+
+  inline void ReplaceWith(Shape &&other)
+  {
+    Resize(0);
+    std::swap(_size, other._size);
+    if (_size <= kMaxSmallSize)
+      std::copy(other._dims, other._dims + kMaxSmallSize, _dims);
+    else
+      _dims_pointer = other._dims_pointer;
+  }
+
   template <typename T> inline void BuildFrom(const T &src_iterable)
   {
     const int dimensions_count = std::distance(src_iterable.begin(), src_iterable.end());

--- a/runtime/onert/backend/cpu/ops/BinaryArithmeticLayer.cc
+++ b/runtime/onert/backend/cpu/ops/BinaryArithmeticLayer.cc
@@ -56,8 +56,13 @@ template <nnfw::cker::BinaryArithmeticOpType arithmetic_type, typename T> struct
 
   void operator()(const IPortableTensor *lhs, const IPortableTensor *rhs, IPortableTensor *output)
   {
+    // Assume dynamic tensors never become static and static ones never change shape since
+    // configure()
     if (output->is_dynamic())
       updateCache(lhs, rhs, output);
+    else
+      assert(_lhs_shape == getTensorShape(lhs) && _rhs_shape == getTensorShape(rhs) &&
+             _output_shape == getTensorShape(output));
     auto lhs_buffer = reinterpret_cast<const T *>(lhs->buffer());
     auto rhs_buffer = reinterpret_cast<const T *>(rhs->buffer());
     auto output_buffer = reinterpret_cast<T *>(output->buffer());

--- a/runtime/onert/backend/cpu/ops/BinaryArithmeticLayer.cc
+++ b/runtime/onert/backend/cpu/ops/BinaryArithmeticLayer.cc
@@ -30,31 +30,54 @@ namespace ops
 namespace
 {
 
-template <nnfw::cker::BinaryArithmeticOpType arithmetic_type, typename T>
-void eval(const IPortableTensor *lhs, const IPortableTensor *rhs, IPortableTensor *output,
-          nnfw::cker::BinaryArithmeticOpParam op_params)
+template <nnfw::cker::BinaryArithmeticOpType arithmetic_type, typename T> struct Eval
 {
-  const auto lhs_shape = getTensorShape(lhs);
-  const auto rhs_shape = getTensorShape(rhs);
-  const bool need_broadcast = nnfw::cker::ProcessBroadcastShapes(lhs_shape, rhs_shape, &op_params);
-  if (need_broadcast)
+  nnfw::cker::Shape _lhs_shape;
+  nnfw::cker::Shape _rhs_shape;
+  nnfw::cker::Shape _output_shape;
+  nnfw::cker::BinaryArithmeticOpParam _op_params;
+  bool _need_broadcast;
+
+  Eval(const IPortableTensor *lhs, const IPortableTensor *rhs, IPortableTensor *output,
+       nnfw::cker::BinaryArithmeticOpParam op_params)
+      : _op_params(std::move(op_params))
   {
-    nnfw::cker::BroadcastBinaryArithmeticOp<arithmetic_type>(
-        op_params, lhs_shape, reinterpret_cast<const T *>(lhs->buffer()), rhs_shape,
-        reinterpret_cast<const T *>(rhs->buffer()), getTensorShape(output),
-        reinterpret_cast<T *>(output->buffer()));
-    return;
+    if (!output->is_dynamic())
+      updateCache(lhs, rhs, output);
   }
 
-  nnfw::cker::BinaryArithmeticOp<arithmetic_type>(
-      op_params, lhs_shape, reinterpret_cast<const T *>(lhs->buffer()), rhs_shape,
-      reinterpret_cast<const T *>(rhs->buffer()), getTensorShape(output),
-      reinterpret_cast<T *>(output->buffer()));
-}
+  void updateCache(const IPortableTensor *lhs, const IPortableTensor *rhs, IPortableTensor *output)
+  {
+    _lhs_shape.ReplaceWith(getTensorShape(lhs));
+    _rhs_shape.ReplaceWith(getTensorShape(rhs));
+    _output_shape.ReplaceWith(getTensorShape(output));
+    _need_broadcast = nnfw::cker::ProcessBroadcastShapes(_lhs_shape, _rhs_shape, &_op_params);
+  }
+
+  void operator()(const IPortableTensor *lhs, const IPortableTensor *rhs, IPortableTensor *output)
+  {
+    if (output->is_dynamic())
+      updateCache(lhs, rhs, output);
+    auto lhs_buffer = reinterpret_cast<const T *>(lhs->buffer());
+    auto rhs_buffer = reinterpret_cast<const T *>(rhs->buffer());
+    auto output_buffer = reinterpret_cast<T *>(output->buffer());
+    if (_need_broadcast)
+    {
+      nnfw::cker::BroadcastBinaryArithmeticOp<arithmetic_type>(
+          _op_params, _lhs_shape, lhs_buffer, _rhs_shape, rhs_buffer, _output_shape, output_buffer);
+    }
+    else
+    {
+      nnfw::cker::BinaryArithmeticOp<arithmetic_type>(
+          _op_params, _lhs_shape, lhs_buffer, _rhs_shape, rhs_buffer, _output_shape, output_buffer);
+    }
+  }
+};
 
 template <nnfw::cker::BinaryArithmeticOpType arithmetic_type>
 std::function<void(const IPortableTensor *, const IPortableTensor *, IPortableTensor *)>
-generateKernelGeneric(const IPortableTensor *lhs, const ir::Activation activation,
+generateKernelGeneric(const IPortableTensor *lhs, const IPortableTensor *rhs,
+                      IPortableTensor *output, const ir::Activation activation,
                       nnfw::cker::BinaryArithmeticOpParam op_params)
 {
   switch (lhs->data_type())
@@ -65,8 +88,7 @@ generateKernelGeneric(const IPortableTensor *lhs, const ir::Activation activatio
       CalculateActivationRange(activation, &output_activation_min, &output_activation_max);
       op_params.float_activation_max = output_activation_max;
       op_params.float_activation_min = output_activation_min;
-      return std::bind(&eval<arithmetic_type, float>, std::placeholders::_1, std::placeholders::_2,
-                       std::placeholders::_3, op_params);
+      return Eval<arithmetic_type, float>(lhs, rhs, output, op_params);
       break;
     }
     case OperandType::INT32:
@@ -75,8 +97,7 @@ generateKernelGeneric(const IPortableTensor *lhs, const ir::Activation activatio
       CalculateActivationRange(activation, &output_activation_min, &output_activation_max);
       op_params.quantized_activation_max = output_activation_max;
       op_params.quantized_activation_min = output_activation_min;
-      return std::bind(eval<arithmetic_type, int32_t>, std::placeholders::_1, std::placeholders::_2,
-                       std::placeholders::_3, op_params);
+      return Eval<arithmetic_type, int32_t>(lhs, rhs, output, op_params);
       break;
     }
     default:
@@ -157,14 +178,13 @@ void BinaryArithmeticLayer::configure(const IPortableTensor *lhs, const IPortabl
       if (_lhs->data_type() == OperandType::QUANT_UINT8_ASYMM)
       {
         setAddOrSubQuant8Params(_lhs, _rhs, _output, activation, &op_params);
-        _kernel = std::bind(&eval<nnfw::cker::BinaryArithmeticOpType::ADD, uint8_t>,
-                            std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
-                            op_params);
+        _kernel =
+            Eval<nnfw::cker::BinaryArithmeticOpType::ADD, uint8_t>(_lhs, _rhs, _output, op_params);
       }
       else
       {
-        _kernel = generateKernelGeneric<nnfw::cker::BinaryArithmeticOpType::ADD>(_lhs, activation,
-                                                                                 op_params);
+        _kernel = generateKernelGeneric<nnfw::cker::BinaryArithmeticOpType::ADD>(
+            _lhs, _rhs, _output, activation, op_params);
       }
       break;
     case ArithmeticType::kSub:
@@ -172,14 +192,13 @@ void BinaryArithmeticLayer::configure(const IPortableTensor *lhs, const IPortabl
       {
         setAddOrSubQuant8Params(_lhs, _rhs, _output, activation, &op_params);
         op_params.input2_multiplier *= -1;
-        _kernel = std::bind(&eval<nnfw::cker::BinaryArithmeticOpType::SUB, uint8_t>,
-                            std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
-                            op_params);
+        _kernel =
+            Eval<nnfw::cker::BinaryArithmeticOpType::SUB, uint8_t>(_lhs, _rhs, _output, op_params);
       }
       else
       {
-        _kernel = generateKernelGeneric<nnfw::cker::BinaryArithmeticOpType::SUB>(_lhs, activation,
-                                                                                 op_params);
+        _kernel = generateKernelGeneric<nnfw::cker::BinaryArithmeticOpType::SUB>(
+            _lhs, _rhs, _output, activation, op_params);
       }
       break;
     case ArithmeticType::kMul:
@@ -187,14 +206,13 @@ void BinaryArithmeticLayer::configure(const IPortableTensor *lhs, const IPortabl
       {
         nnfw::cker::BinaryArithmeticOpParam op_params;
         setMulQuant8Params(_lhs, _rhs, _output, activation, &op_params);
-        _kernel = std::bind(&eval<nnfw::cker::BinaryArithmeticOpType::MUL, uint8_t>,
-                            std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
-                            op_params);
+        _kernel =
+            Eval<nnfw::cker::BinaryArithmeticOpType::MUL, uint8_t>(_lhs, _rhs, _output, op_params);
       }
       else
       {
-        _kernel = generateKernelGeneric<nnfw::cker::BinaryArithmeticOpType::MUL>(_lhs, activation,
-                                                                                 op_params);
+        _kernel = generateKernelGeneric<nnfw::cker::BinaryArithmeticOpType::MUL>(
+            _lhs, _rhs, _output, activation, op_params);
       }
       break;
     case ArithmeticType::kDiv:
@@ -209,8 +227,8 @@ void BinaryArithmeticLayer::configure(const IPortableTensor *lhs, const IPortabl
       }
       else
       {
-        _kernel = generateKernelGeneric<nnfw::cker::BinaryArithmeticOpType::DIV>(_lhs, activation,
-                                                                                 op_params);
+        _kernel = generateKernelGeneric<nnfw::cker::BinaryArithmeticOpType::DIV>(
+            _lhs, _rhs, _output, activation, op_params);
       }
       break;
     default:


### PR DESCRIPTION
Keep tensor shapes and derived broadcast parameters in binary arithmetic CPU ops implementation, and reuse them when all tensors turned out to be static tensors.

This change brings 5%+ improvement on you-know-what oversized-graph network.

It relies on shape inference logic always marking output tensor of an op as dynamic once any of its input tensors is dynamic. **Please verify if it is correct before merging.**