### PR TITLE
[onert] Devirtualize calls in getTensorShape

### DIFF
--- a/runtime/onert/backend/cpu/ops/OperationUtils.h
+++ b/runtime/onert/backend/cpu/ops/OperationUtils.h
@@ -95,13 +95,16 @@ inline nnfw::cker::Shape getTensorShape(const IPortableTensor *tensor)
   if (tensor == nullptr)
     return nnfw::cker::Shape();
 
+  const ir::Shape &shape = tensor->get_info().shape();
+
   assert(tensor->layout() == ir::Layout::NHWC);
-  auto rank = tensor->num_dimensions();
+
+  auto rank = shape.rank();
   nnfw::cker::Shape ret(rank);
   auto data = ret.DimsData();
-  for (uint32_t i = 0; i < rank; ++i)
+  for (int i = 0; i < rank; ++i)
   {
-    data[i] = tensor->dimension(i);
+    data[i] = shape.dim(i);
   }
   return ret;
 }

--- a/runtime/onert/core/include/backend/IPortableTensor.h
+++ b/runtime/onert/core/include/backend/IPortableTensor.h
@@ -18,6 +18,7 @@
 #define __ONERT_BACKEND_I_PORTABLE_TENSOR_H__
 
 #include "backend/ITensor.h"
+#include "ir/OperandInfo.h"
 #include "ir/Sparsity.h"
 
 namespace onert
@@ -37,12 +38,18 @@ namespace backend
 class IPortableTensor : public ITensor
 {
 public:
+  IPortableTensor(const ir::OperandInfo &info) : _info(info) {}
+
   virtual ~IPortableTensor();
   virtual const ir::Sparsity *sparsity() const { return nullptr; }
+  const ir::OperandInfo &get_info() const { return _info; }
 
 public:
   bool has_padding() const final { return false; }
   void access(const std::function<void(ITensor &tensor)> &fn) final { fn(*this); }
+
+protected:
+  ir::OperandInfo _info;
 };
 
 } // namespace backend

--- a/runtime/onert/core/include/backend/cpu_common/Tensor.h
+++ b/runtime/onert/core/include/backend/cpu_common/Tensor.h
@@ -40,7 +40,7 @@ public:
 public:
   Tensor(const ir::OperandInfo &info, const ir::Layout layout,
          DynamicMemoryManager *dynamic_mem_mgr)
-      : _info(info), _layout(layout), _buffer(nullptr), _num_references(0),
+      : IPortableTensor(info), _layout(layout), _buffer(nullptr), _num_references(0),
         _dynamic_mem_mgr(dynamic_mem_mgr), _allocator(nullptr)
   {
     // DO NOTHING
@@ -162,7 +162,6 @@ public:
   void setShape(const ir::Shape &new_shape) override;
 
 protected:
-  ir::OperandInfo _info;
   ir::Layout _layout;
   uint8_t *_buffer;
   int32_t _num_references;

--- a/runtime/onert/core/src/backend/controlflow/UserTensor.h
+++ b/runtime/onert/core/src/backend/controlflow/UserTensor.h
@@ -39,7 +39,7 @@ class UserTensor : public IPortableTensor
 {
 public:
   UserTensor(const ir::OperandInfo &info, ir::Layout layout, uint8_t *buffer, size_t size)
-      : _info{info}, _layout{layout}, _buffer{buffer}, _size{size}, _dynamic{false}
+      : IPortableTensor{info}, _layout{layout}, _buffer{buffer}, _size{size}, _dynamic{false}
   {
   }
 
@@ -72,7 +72,6 @@ public:
   bool applyShape(const ir::Shape &) override;
 
 private:
-  ir::OperandInfo _info;
   ir::Layout _layout;
   uint8_t *_buffer;
   size_t _size;


### PR DESCRIPTION
Added non virtual get_info method to IPortableTensor class that helped to remove redundant virtual method calls.

ONE-DCO-1.0-Signed-off-by: Alexander Efimov <a.efimov@samsung.com>