### PR TITLE
[onert] Fix ResizeBilinear invalid output shape condition

### DIFF
--- a/runtime/onert/core/src/util/ShapeInference.cc
+++ b/runtime/onert/core/src/util/ShapeInference.cc
@@ -569,7 +569,7 @@ ir::Shape inferResizeBilinearShape(const ir::Shape &in_shape, const int32_t outp
     throw std::runtime_error{"ResizeBilinear: size value must be positive value, output_height = " +
                              std::to_string(output_height)};
   }
-  if (output_height < 0)
+  if (output_width < 0)
   {
     throw std::runtime_error{"ResizeBilinear: size value must be positive value, output_width = " +
                              std::to_string(output_height)};


### PR DESCRIPTION
Fix typo: output_height -> output_width

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: https://github.com/Samsung/ONE/issues/1635#issuecomment-708121712