### PR TITLE
[onert] Adds to initialize time_major param of LSTM operation

### DIFF
--- a/runtime/onert/frontend/nnapi/wrapper/OperationFactory.cc
+++ b/runtime/onert/frontend/nnapi/wrapper/OperationFactory.cc
@@ -1302,6 +1302,9 @@ OperationFactory::OperationFactory()
     }
     param.cell_threshold = operands.at(OperandIndex{init_param.inputs[21]}).asScalar<float>();
     param.projection_threshold = operands.at(OperandIndex{init_param.inputs[22]}).asScalar<float>();
+    // This is initialization to prevent warning or error by static code analyzer. LSTM operation
+    // does not need time_major
+    param.time_major = false;
 
     return new operation::LSTM{inputs, outputs, param};
   };


### PR DESCRIPTION
For issue #4620

This commit adds to initialize time_major param of LSTM operation to avoid warning by static code analyzer.

Signed-off-by: ragmani <ragmani0216@gmail.com>