### PR TITLE
[onert] DRAFT: Enable combinations of nnfw_set_input_tensorinfo() and nnfw_run()

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -508,6 +508,10 @@ NNFW_STATUS nnfw_session::apply_tensorinfo(uint32_t index, nnfw_tensorinfo ti)
   }
   else // when called after nnfw_session::prepare()
   {
+    onert::ir::Shape new_shape(ti.rank);
+    for (int32_t i = 0; i < ti.rank; i++)
+      new_shape.dim(i) = ti.dims[i];
+
     _execution->changeInputShape(onert::ir::IOIndex(index), new_shape);
   }
 

--- a/runtime/onert/core/src/exec/FunctionSequence.cc
+++ b/runtime/onert/core/src/exec/FunctionSequence.cc
@@ -30,6 +30,7 @@ void FunctionSequence::run()
 {
   if (_enable_dynamic_shape_inferer && _dynamic_tensor_ctx)
   {
+    VERBOSE(FunctionSequence) << "run with DYNAMIC shape inferer" << std::endl;
     // acl_cl and acl_neon backend don't support dynamic shape.
     // _dynamic_tensor_ctx is always nullptr for acl_cl and acl_neon
     // Thus, those two bakends cannot reach here.
@@ -61,6 +62,7 @@ void FunctionSequence::run()
   }
   else
   {
+    VERBOSE(FunctionSequence) << "run with STATUC shape inferer" << std::endl;
     for (const auto &function : _functions)
     {
       function->run();


### PR DESCRIPTION
DRAFT/WIP

This is a draft to enable combinations of nnfw_set_input_tensorinfo() and nnfw_run().

parent issue: #4625

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>