### PR TITLE
[onert] Fix ResizeBilinear shape inference log

### DIFF
--- a/runtime/onert/core/src/util/ShapeInference.cc
+++ b/runtime/onert/core/src/util/ShapeInference.cc
@@ -572,7 +572,7 @@ ir::Shape inferResizeBilinearShape(const ir::Shape &in_shape, const int32_t outp
   if (output_width < 0)
   {
     throw std::runtime_error{"ResizeBilinear: size value must be positive value, output_width = " +
-                             std::to_string(output_height)};
+                             std::to_string(output_width)};
   }
 
   ir::Shape ret(in_shape.rank());


### PR DESCRIPTION
Fix shape inference log bug by typo: output_height -> output_width

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: https://github.com/Samsung/ONE/issues/1635#issuecomment-708121712