### PR TITLE
[onert/cpu] Initialize ReduceLayer reduce type field

### DIFF
--- a/runtime/onert/backend/cpu/ops/ReduceLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ReduceLayer.cc
@@ -159,7 +159,7 @@ void evalSumQuantized(const IPortableTensor *input, IPortableTensor *output,
 
 ReduceLayer::ReduceLayer()
     : _input(nullptr), _axes(nullptr), _output(nullptr), _reduce_kernel(new nnfw::cker::Reduce()),
-      _kernel()
+      _kernel(), _reduceType(ReduceType::kInvalid)
 {
   // DO NOTHING
 }
@@ -172,10 +172,9 @@ void ReduceLayer::configure(const IPortableTensor *input, const IPortableTensor 
   _input = input;
   _axes = axes;
   _output = output;
-#ifdef USE_NEON
   _reduceType = reduceType;
-#endif // NEON
-  switch (reduceType)
+
+  switch (_reduceType)
   {
     case ReduceType::kSum:
       if (_input->data_type() == OperandType::QUANT_UINT8_ASYMM)
@@ -202,7 +201,7 @@ void ReduceLayer::configure(const IPortableTensor *input, const IPortableTensor 
       _kernel = generateKernelGeneric(_input, keep_dims, *_reduce_kernel, ReduceType::kAll);
       break;
     default:
-      throw std::runtime_error{"ReduceSum: Unsupported reduce type"};
+      throw std::runtime_error{"Reduce: Unsupported reduce type"};
   }
 }
 

--- a/runtime/onert/backend/cpu/ops/ReduceLayer.h
+++ b/runtime/onert/backend/cpu/ops/ReduceLayer.h
@@ -49,6 +49,7 @@ enum class ReduceType
   kMin,
   kAny,
   kAll,
+  kInvalid // For debug and initialize
 };
 
 class ReduceLayer : public ::onert::exec::IFunction
@@ -67,14 +68,13 @@ private:
   const IPortableTensor *_input;
   const IPortableTensor *_axes;
   IPortableTensor *_output;
-#ifdef USE_NEON
-  ReduceType _reduceType;
-#endif // NEON
 
   std::unique_ptr<nnfw::cker::Reduce> _reduce_kernel;
   std::function<void(const IPortableTensor *input, IPortableTensor *output,
                      const std::vector<int> &axes)>
       _kernel;
+
+  ReduceType _reduceType;
 };
 
 } // namespace ops


### PR DESCRIPTION
Initialize _reduceType field and use all target
New reduce type for initialize and debug: kInvliad
Fix exception log

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: https://github.com/Samsung/ONE/issues/1635#issuecomment-708121712