### PR TITLE
[luci-interpreter] Add Exp Kernel

### DIFF
--- a/compiler/luci-interpreter/src/kernels/CMakeLists.txt
+++ b/compiler/luci-interpreter/src/kernels/CMakeLists.txt
@@ -20,6 +20,8 @@ set(SOURCES
     Div.cpp
     Elu.h
     Elu.cpp
+    Exp.h
+    Exp.cpp
     Floor.h
     Floor.cpp
     FloorDiv.h
@@ -136,6 +138,7 @@ set(TEST_SOURCES
     DepthwiseConv2D.test.cpp
     Div.test.cpp
     Elu.test.cpp
+    Exp.test.cpp
     Floor.test.cpp
     FloorDiv.test.cpp
     Equal.test.cpp

--- a/compiler/luci-interpreter/src/kernels/Exp.cpp
+++ b/compiler/luci-interpreter/src/kernels/Exp.cpp
@@ -31,6 +31,7 @@ Exp::Exp(const Tensor *input, Tensor *output) : Kernel({input}, {output}) {}
 void Exp::configure()
 {
   LUCI_INTERPRETER_CHECK(input()->element_type() == output()->element_type());
+  output()->resize(input()->shape());
 }
 
 void Exp::execute() const

--- a/compiler/luci-interpreter/src/kernels/Exp.cpp
+++ b/compiler/luci-interpreter/src/kernels/Exp.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "kernels/Exp.h"
+
+#include "kernels/Utils.h"
+
+#include <tensorflow/lite/kernels/internal/reference/reference_ops.h>
+
+namespace luci_interpreter
+{
+namespace kernels
+{
+
+Exp::Exp(const Tensor *input, Tensor *output) : Kernel({input}, {output}) {}
+
+void Exp::configure()
+{
+  LUCI_INTERPRETER_CHECK(input()->element_type() == output()->element_type());
+}
+
+void Exp::execute() const
+{
+  switch (input()->element_type())
+  {
+    case DataType::FLOAT32:
+      evalFloat();
+      break;
+    default:
+      throw std::runtime_error("Unsupported type.");
+  }
+}
+
+void Exp::evalFloat() const
+{
+  const int size = tflite::MatchingFlatSize(getTensorShape(input()), getTensorShape(output()));
+  tflite::reference_ops::Exp(getTensorData<float>(input()), size, getTensorData<float>(output()));
+}
+
+} // namespace kernels
+} // namespace luci_interpreter

--- a/compiler/luci-interpreter/src/kernels/Exp.h
+++ b/compiler/luci-interpreter/src/kernels/Exp.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef LUCI_INTERPRETER_KERNELS_EXP_H
+#define LUCI_INTERPRETER_KERNELS_EXP_H
+
+#include "core/Kernel.h"
+#include "core/KernelParams.h"
+
+namespace luci_interpreter
+{
+namespace kernels
+{
+
+class Exp : public Kernel
+{
+public:
+  Exp(const Tensor *input, Tensor *output);
+
+  const Tensor *input() const { return _inputs[0]; }
+  Tensor *output() const { return _outputs[0]; }
+
+  void configure() override;
+  void execute() const override;
+
+private:
+  void evalFloat() const;
+};
+
+} // namespace kernels
+} // namespace luci_interpreter
+
+#endif // LUCI_INTERPRETER_KERNELS_EXP_H

--- a/compiler/luci-interpreter/src/kernels/Exp.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/Exp.test.cpp
@@ -38,10 +38,12 @@ TEST(ExpTest, Float)
   kernel.configure();
   kernel.execute();
 
+  std::vector<int32_t> ref_output_shape{1, 1, 7};
   std::vector<float> ref_output_data{std::exp(0.0f),   std::exp(1.0f),    std::exp(-1.0f),
                                      std::exp(100.0f), std::exp(-100.0f), std::exp(0.01f),
                                      std::exp(-0.01f)};
   EXPECT_THAT(extractTensorData<float>(output_tensor), FloatArrayNear(ref_output_data));
+  EXPECT_THAT(extractTensorShape(output_tensor), ::testing::ElementsAreArray(ref_output_shape));
 }
 
 } // namespace

--- a/compiler/luci-interpreter/src/kernels/Exp.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/Exp.test.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "kernels/Exp.h"
+#include "kernels/TestUtils.h"
+
+namespace luci_interpreter
+{
+namespace kernels
+{
+namespace
+{
+
+using namespace testing;
+
+TEST(ExpTest, Float)
+{
+  Shape input_shape{1, 1, 7};
+  std::vector<float> input_data{0.0f, 1.0f, -1.0f, 100.0f, -100.0f, 0.01f, -0.01f};
+  Tensor input_tensor = makeInputTensor<DataType::FLOAT32>(input_shape, input_data);
+  Tensor output_tensor = makeOutputTensor(DataType::FLOAT32);
+
+  Exp kernel(&input_tensor, &output_tensor);
+  kernel.configure();
+  kernel.execute();
+
+  std::vector<float> ref_output_data{std::exp(0.0f),   std::exp(1.0f),    std::exp(-1.0f),
+                                     std::exp(100.0f), std::exp(-100.0f), std::exp(0.01f),
+                                     std::exp(-0.01f)};
+  EXPECT_THAT(extractTensorData<float>(output_tensor), FloatArrayNear(ref_output_data));
+}
+
+} // namespace
+} // namespace kernels
+} // namespace luci_interpreter

--- a/compiler/luci-interpreter/src/loader/KernelBuilder.cpp
+++ b/compiler/luci-interpreter/src/loader/KernelBuilder.cpp
@@ -25,6 +25,7 @@
 #include "kernels/DepthwiseConv2D.h"
 #include "kernels/Div.h"
 #include "kernels/Elu.h"
+#include "kernels/Exp.h"
 #include "kernels/Floor.h"
 #include "kernels/FloorDiv.h"
 #include "kernels/Equal.h"
@@ -269,6 +270,16 @@ std::unique_ptr<Kernel> KernelBuilder::visit(const luci::CircleElu *node)
   Tensor *output = getOutputTensor(node);
 
   return std::make_unique<kernels::Elu>(input, output);
+}
+
+std::unique_ptr<Kernel> KernelBuilder::visit(const luci::CircleExp *node)
+{
+  assert(node->arity() == 1);
+
+  const Tensor *input = getInputTensor(node->x());
+  Tensor *output = getOutputTensor(node);
+
+  return std::make_unique<kernels::Exp>(input, output);
 }
 
 std::unique_ptr<Kernel> KernelBuilder::visit(const luci::CircleFloor *node)

--- a/compiler/luci-interpreter/src/loader/KernelBuilder.h
+++ b/compiler/luci-interpreter/src/loader/KernelBuilder.h
@@ -52,6 +52,7 @@ public:
   std::unique_ptr<Kernel> visit(const luci::CircleFloor *node) override;
   std::unique_ptr<Kernel> visit(const luci::CircleFloorDiv *node) override;
   std::unique_ptr<Kernel> visit(const luci::CircleEqual *node) override;
+  std::unique_ptr<Kernel> visit(const luci::CircleExp *node) override;
   std::unique_ptr<Kernel> visit(const luci::CircleFullyConnected *node) override;
   std::unique_ptr<Kernel> visit(const luci::CircleGreater *node) override;
   std::unique_ptr<Kernel> visit(const luci::CircleGreaterEqual *node) override;

--- a/compiler/luci-interpreter/src/loader/KernelBuilder.test.cpp
+++ b/compiler/luci-interpreter/src/loader/KernelBuilder.test.cpp
@@ -29,6 +29,7 @@
 #include <kernels/Floor.h>
 #include <kernels/FloorDiv.h>
 #include <kernels/Equal.h>
+#include <kernels/Exp.h>
 #include <kernels/FullyConnected.h>
 #include <kernels/Greater.h>
 #include <kernels/GreaterEqual.h>
@@ -377,6 +378,20 @@ TEST_F(KernelBuilderTest, Equal)
 
   checkTensor(kernel->x(), x_input);
   checkTensor(kernel->y(), y_input);
+  checkTensor(kernel->output(), op);
+}
+
+TEST_F(KernelBuilderTest, Exp)
+{
+  auto *input = createInputNode();
+
+  auto *op = createNode<luci::CircleExp>();
+  op->x(input);
+
+  auto kernel = buildKernel<kernels::Exp>(op);
+  ASSERT_THAT(kernel, NotNull());
+
+  checkTensor(kernel->input(), input);
   checkTensor(kernel->output(), op);
 }
 


### PR DESCRIPTION
Fired Issue: #4661 

This commit adds `Exp` kernel.
I have only added Float kernel due to absence of U8 testing lists in Tensorflow reference.

This commit have been tested on my PC.

Please review this PR, @seanshpark @jinevening @s-barannikov  .
I'll be happy to get feedback and change to make improvement.

Thank you.

(Derived from SOS Mine Project)

Signed-off-by: underflow101 <ikarus125@gmail.com>