### PR TITLE
[onert] Introduce int8 and int16 type

### DIFF
--- a/runtime/onert/core/include/ir/DataType.h
+++ b/runtime/onert/core/include/ir/DataType.h
@@ -35,6 +35,8 @@ enum class DataType
   QUANT_INT8_SYMM = 6,
   FLOAT16 = 7,
   INT64 = 8,
+  QUANT_INT8_ASYMM = 9,
+  QUANT_INT16_ASYMM = 10,
 };
 
 size_t sizeOfDataType(DataType data_type);

--- a/runtime/onert/core/src/ir/DataType.cc
+++ b/runtime/onert/core/src/ir/DataType.cc
@@ -41,11 +41,14 @@ size_t sizeOfDataType(DataType data_type)
     case DataType::UINT8:
       return sizeof(uint8_t);
     case DataType::QUANT_INT8_SYMM:
+    case DataType::QUANT_INT8_ASYMM:
       return sizeof(int8_t);
     case DataType::FLOAT16:
       return sizeof(float16);
     case DataType::INT64:
       return sizeof(int64_t);
+    case DataType::QUANT_INT16_ASYMM:
+      return sizeof(int16_t);
     default:
       throw std::runtime_error{"Unsupported type size"};
   }


### PR DESCRIPTION
Introduce data type
- QUANT_INT8_ASYMM: int8 quantization operation input/output tensor data type (int8 weight tensor uses QUANT_INT8_SYMM)
- QUANT_INT16_ASYMM: int16 quantization operation input/output tensor data type

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

--- 

Related issue: #4664