### PR TITLE
[onert] Fix concat elimination bug

### DIFF
--- a/runtime/onert/backend/acl_cl/Optimizer.cc
+++ b/runtime/onert/backend/acl_cl/Optimizer.cc
@@ -42,6 +42,7 @@ void Optimizer::optimize()
   // Concat elimination (build subtensor info)
   {
     acl_common::AclSubTensorAnalyzer sa{*_context->graph()};
+    sa.setUsePadding();
     for (auto op_info : _context->operation_list())
     {
       auto &op = _context->graph()->operations().at(op_info.index);


### PR DESCRIPTION
Don't use concat elimination if axis is last dimension and backend tensor uses padding (acl-cl backend)

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: #4407