### PR TITLE
[nnfwapi] Add experimental API TCs

### DIFF
--- a/tests/nnfw_api/src/ValidationTestAddModelLoaded.cc
+++ b/tests/nnfw_api/src/ValidationTestAddModelLoaded.cc
@@ -122,3 +122,71 @@ TEST_F(ValidationTestAddModelLoaded, neg_input_output_tensorindex)
   ASSERT_EQ(nnfw_output_tensorindex(_session, "X_input", &out_ind), NNFW_STATUS_ERROR);
   ASSERT_EQ(out_ind, 100);
 }
+
+TEST_F(ValidationTestAddModelLoaded, experimental_input_tensorindex)
+{
+  uint32_t ind = 999;
+  NNFW_ENSURE_SUCCESS(nnfw_input_tensorindex(_session, "X_input", &ind));
+  ASSERT_EQ(ind, 0);
+}
+
+TEST_F(ValidationTestAddModelLoaded, neg_experimental_input_tensorindex_name_null)
+{
+  uint32_t ind = 999;
+  ASSERT_EQ(nnfw_input_tensorindex(_session, nullptr, &ind), NNFW_STATUS_UNEXPECTED_NULL);
+  ASSERT_EQ(ind, 999);
+}
+
+TEST_F(ValidationTestAddModelLoaded, neg_experimental_input_tensorindex_index_null)
+{
+  ASSERT_EQ(nnfw_input_tensorindex(_session, "X_input", nullptr), NNFW_STATUS_UNEXPECTED_NULL);
+}
+
+TEST_F(ValidationTestAddModelLoaded, neg_experimental_input_name_too_long)
+{
+  std::string long_name(1024, 'x'); // Too long
+  uint32_t ind = 999;
+  ASSERT_EQ(nnfw_output_tensorindex(_session, long_name.c_str(), &ind), NNFW_STATUS_ERROR);
+  ASSERT_EQ(ind, 999);
+}
+
+TEST_F(ValidationTestAddModelLoaded, neg_experimental_input_no_such_name)
+{
+  uint32_t ind = 999;
+  ASSERT_EQ(nnfw_output_tensorindex(_session, "NO_SUCH_TENSOR_NAME", &ind), NNFW_STATUS_ERROR);
+  ASSERT_EQ(ind, 999);
+}
+
+TEST_F(ValidationTestAddModelLoaded, experimental_output_tensorindex)
+{
+  uint32_t ind = 999;
+  NNFW_ENSURE_SUCCESS(nnfw_output_tensorindex(_session, "ADD_TOP", &ind));
+  ASSERT_EQ(ind, 0);
+}
+
+TEST_F(ValidationTestAddModelLoaded, neg_experimental_output_tensorindex_name_null)
+{
+  uint32_t ind = 999;
+  ASSERT_EQ(nnfw_output_tensorindex(_session, nullptr, &ind), NNFW_STATUS_UNEXPECTED_NULL);
+  ASSERT_EQ(ind, 999);
+}
+
+TEST_F(ValidationTestAddModelLoaded, neg_experimental_output_tensorindex_index_null)
+{
+  ASSERT_EQ(nnfw_output_tensorindex(_session, "ADD_TOP", nullptr), NNFW_STATUS_UNEXPECTED_NULL);
+}
+
+TEST_F(ValidationTestAddModelLoaded, neg_experimental_output_name_too_long)
+{
+  std::string long_name(1024, 'x'); // Too long
+  uint32_t ind = 999;
+  ASSERT_EQ(nnfw_output_tensorindex(_session, long_name.c_str(), &ind), NNFW_STATUS_ERROR);
+  ASSERT_EQ(ind, 999);
+}
+
+TEST_F(ValidationTestAddModelLoaded, neg_experimental_output_no_such_name)
+{
+  uint32_t ind = 999;
+  ASSERT_EQ(nnfw_output_tensorindex(_session, "NO_SUCH_TENSOR_NAME", &ind), NNFW_STATUS_ERROR);
+  ASSERT_EQ(ind, 999);
+}

--- a/tests/nnfw_api/src/ValidationTestSingleSession.cc
+++ b/tests/nnfw_api/src/ValidationTestSingleSession.cc
@@ -109,3 +109,17 @@ TEST_F(ValidationTestSingleSession, neg_output_tensorinfo)
   ASSERT_EQ(nnfw_output_tensorinfo(nullptr, 0, &tensor_info), NNFW_STATUS_UNEXPECTED_NULL);
   ASSERT_EQ(nnfw_output_tensorinfo(nullptr, 0, nullptr), NNFW_STATUS_UNEXPECTED_NULL);
 }
+
+TEST_F(ValidationTestSingleSession, neg_experimental_input_tensorindex_session_null)
+{
+  uint32_t ind = 999;
+  ASSERT_EQ(nnfw_input_tensorindex(nullptr, "X_input", &ind), NNFW_STATUS_UNEXPECTED_NULL);
+  ASSERT_EQ(ind, 999);
+}
+
+TEST_F(ValidationTestSingleSession, neg_experimental_output_tensorindex_session_null)
+{
+  uint32_t ind = 999;
+  ASSERT_EQ(nnfw_output_tensorindex(nullptr, "ADD_TOP", &ind), NNFW_STATUS_UNEXPECTED_NULL);
+  ASSERT_EQ(ind, 999);
+}


### PR DESCRIPTION
TCs for `nnfw_input_tensorindex` and `nnfw_output_tensorindex`.

- 2 positive tests
- 10 negative tests

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>