### PR TITLE
[nnpkgrun] Remove unnessary dependency

### DIFF
--- a/tests/tools/nnpackage_run/CMakeLists.txt
+++ b/tests/tools/nnpackage_run/CMakeLists.txt
@@ -32,7 +32,6 @@ endif(HDF5_FOUND)
 target_include_directories(nnpackage_run PRIVATE src)
 target_include_directories(nnpackage_run PRIVATE ${Boost_INCLUDE_DIRS})
 
-target_link_libraries(nnpackage_run tflite_loader)
 target_link_libraries(nnpackage_run nnfw_lib_tflite jsoncpp)
 target_link_libraries(nnpackage_run nnfw-dev)
 target_link_libraries(nnpackage_run ${Boost_PROGRAM_OPTIONS_LIBRARY})


### PR DESCRIPTION
CMake: Remove unnessary dependency `tflite_loader`.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>