### PR TITLE
[onert] Support optional bias tensor for FullyConnected in ACL backend

### DIFF
--- a/runtime/onert/backend/acl_common/AclConstantInitializer.cc
+++ b/runtime/onert/backend/acl_common/AclConstantInitializer.cc
@@ -35,8 +35,11 @@ void AclConstantInitializer::copyInputInitialize(const ir::Operation &node, uint
   assert(node.getInputs().size() > index);
 
   const auto &input_index = node.getInputs().at(index);
-  const auto &input_obj = _operands.at(input_index);
-  registerCopyInitializer(input_index, input_obj);
+  if (input_index.valid())
+  {
+    const auto &input_obj = _operands.at(input_index);
+    registerCopyInitializer(input_index, input_obj);
+  }
 }
 
 void AclConstantInitializer::permuteInputInitialize(const ir::Operation &node, uint32_t index)


### PR DESCRIPTION
This commit supports optional bias tensor for FullyConnected in ACL backend

ONE-DCO-1.0-Signed-off-by: JiHwan Yeo <jihwan.yeo@samsung.com>