### PR TITLE
[nnfwapi] Add ReduceMax tests

### DIFF
--- a/runtime/onert/core/src/util/ShapeInference.cc
+++ b/runtime/onert/core/src/util/ShapeInference.cc
@@ -190,11 +190,12 @@ ir::Shape inferReduceShape(const ir::Shape &input_shape, const std::vector<int> 
     for (int i = 0; i < num_axis; ++i)
     {
       int current = axes[i];
+      if (!(-input_num_dims <= current && current < input_num_dims))
+        throw std::runtime_error{"Invalid dim value " + std::to_string(current)};
       if (current < 0)
       {
         current += input_num_dims;
       }
-      assert(0 <= current && current < input_num_dims);
       for (int j = 0; j < i; ++j)
       {
         int previous = axes[j];

--- a/tests/nnfw_api/src/CircleGen.cc
+++ b/tests/nnfw_api/src/CircleGen.cc
@@ -202,6 +202,23 @@ uint32_t CircleGen::addOperatorRank(const OperatorParams &params)
                                 circle::BuiltinOptions_RankOptions, options);
 }
 
+uint32_t CircleGen::addOperatorReduce(const OperatorParams &params,
+                                      circle::BuiltinOperator reduce_op, bool keep_dims)
+{
+  switch (reduce_op)
+  {
+    case circle::BuiltinOperator_REDUCE_ANY:
+    case circle::BuiltinOperator_REDUCE_MIN:
+    case circle::BuiltinOperator_REDUCE_MAX:
+    case circle::BuiltinOperator_REDUCE_PROD:
+      break;
+    default:
+      throw std::runtime_error{"Wrong reduce op"};
+  }
+  auto options = circle::CreateReducerOptions(_fbb, keep_dims).Union();
+  return addOperatorWithOptions(params, reduce_op, circle::BuiltinOptions_ReducerOptions, options);
+}
+
 uint32_t CircleGen::addOperatorReshape(const OperatorParams &params, const Shape &new_shape)
 {
   auto options = circle::CreateReshapeOptionsDirect(_fbb, &new_shape).Union();

--- a/tests/nnfw_api/src/CircleGen.h
+++ b/tests/nnfw_api/src/CircleGen.h
@@ -159,6 +159,8 @@ public:
   uint32_t addOperatorPad(const OperatorParams &params);
   uint32_t addOperatorPadV2(const OperatorParams &params);
   uint32_t addOperatorRank(const OperatorParams &params);
+  uint32_t addOperatorReduce(const OperatorParams &params, circle::BuiltinOperator reduce_op,
+                             bool keep_dims);
   uint32_t addOperatorReshape(const OperatorParams &params, const Shape &new_shape);
   uint32_t addOperatorResizeBilinear(const OperatorParams &params, bool align_corners = false,
                                      bool half_pixel_centers = false);

--- a/tests/nnfw_api/src/one_op_tests/Reduce.cc
+++ b/tests/nnfw_api/src/one_op_tests/Reduce.cc
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "GenModelTest.h"
+
+#include <memory>
+
+CircleBuffer genSimpleReduceModel(circle::BuiltinOperator op, bool keep_dims)
+{
+  CircleGen cgen;
+  uint32_t axis_buf = cgen.addBuffer(std::vector<int32_t>{0, 1, 2, 3});
+  int in = cgen.addTensor({{2, 1, 1, 3}, circle::TensorType::TensorType_FLOAT32});
+  int axis = cgen.addTensor({{4}, circle::TensorType::TensorType_INT32, axis_buf});
+  int out = cgen.addTensor({{1}, circle::TensorType::TensorType_FLOAT32});
+  cgen.addOperatorReduce({{in, axis}, {out}}, op, keep_dims);
+  cgen.setInputsAndOutputs({in}, {out});
+  return cgen.finish();
+}
+
+TEST_F(GenModelTest, OneOp_ReduceMax)
+{
+  auto model = genSimpleReduceModel(circle::BuiltinOperator_REDUCE_MAX, false);
+  _context = std::make_unique<GenModelTestContext>(std::move(model));
+  _context->addTestCase(uniformTCD<float>({{1, 2, 3, 4, 5, 6}}, {{6}}));
+  _context->addTestCase(uniformTCD<float>({{100, 98, 55, 200, 3, 40}}, {{200}}));
+  _context->setBackends({"acl_cl", "acl_neon", "cpu"});
+
+  SUCCEED();
+}
+
+class ReduceMaxBadIndex : public GenModelTest,
+                          public ::testing::WithParamInterface<std::vector<int>>
+{
+};
+
+TEST_P(ReduceMaxBadIndex, neg_Test)
+{
+  CircleGen cgen;
+  // Axis cannot be equal or bigger than input's rank - 4
+  uint32_t axis_buf = cgen.addBuffer(GetParam());
+  int in = cgen.addTensor({{2, 1, 1, 3}, circle::TensorType::TensorType_FLOAT32});
+  int axis = cgen.addTensor({{4}, circle::TensorType::TensorType_INT32, axis_buf});
+  int out = cgen.addTensor({{1}, circle::TensorType::TensorType_FLOAT32});
+  cgen.addOperatorReduce({{in, axis}, {out}}, circle::BuiltinOperator_REDUCE_MAX, false);
+  cgen.setInputsAndOutputs({in}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->expectFailCompile();
+
+  SUCCEED();
+}
+
+INSTANTIATE_TEST_CASE_P(GenModelTest, ReduceMaxBadIndex,
+                        ::testing::Values(std::vector<int32_t>{0, 1, 2, 4},
+                                          std::vector<int32_t>{0, -5, 2, 3},
+                                          std::vector<int32_t>{-88, 1, 2, 3},
+                                          std::vector<int32_t>{0, 1, 88, 3}));


### PR DESCRIPTION
Make ShapeInferer to throw rather than `assert`.
Add ReduceMax GenModel tests - 1 positive / 4 negatives.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>