### PR TITLE
[onert] Rename ShapeInference files

### DIFF
--- a/docs/howto/how-to-introduce-a-new-operation-into-runtime.md
+++ b/docs/howto/how-to-introduce-a-new-operation-into-runtime.md
@@ -179,12 +179,12 @@ void Dumper::visit(const Select &node)
 5. Add code for shape inference
 - ONE runtime tries to calculate shapes and allocate memory during compilation time. For some calculations of output shapes that cannot be done during compilation time, ONE runtime will calculate shapes and allocate memory during execution time.
 - Calculation of shapes during compilation time is called _static shape inference_ and calculation of shapes during execution time is called _dynamic shape inference_.
-- [`StaticShapeInference.h`](`/runtime/onert/compiler/StaticShapeInference.h`)
+- [`StaticShapeInferer.h`](`/runtime/onert/compiler/StaticShapeInferer.h`)
 
 ```CPP
   void visit(const ir::operation::Select &op) override;
 ```
-- [`StaticShapeInference.cc`](/runtime/onert/core/src/compiler/StaticShapeInference.cc)
+- [`StaticShapeInferer.cc`](/runtime/onert/core/src/compiler/StaticShapeInferer.cc)
 ```CPP
 void StaticShapeInferer::visit(const ir::operation::Select &op)
 {

--- a/runtime/onert/backend/cpu/KernelGenerator.cc
+++ b/runtime/onert/backend/cpu/KernelGenerator.cc
@@ -71,7 +71,7 @@
 #include <memory>
 #include <util/Utils.h>
 #include <util/logging.h>
-#include <exec/DynamicShapeInference.h>
+#include <exec/DynamicShapeInferer.h>
 
 #include <stdexcept>
 

--- a/runtime/onert/core/include/exec/DynamicShapeInferer.h
+++ b/runtime/onert/core/include/exec/DynamicShapeInferer.h
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,60 +14,41 @@
  * limitations under the License.
  */
 
-#ifndef __ONERT_COMPILER_STATIC_SHAPE_INFERENCE_H__
-#define __ONERT_COMPILER_STATIC_SHAPE_INFERENCE_H__
+#ifndef __ONERT_EXEC_DYNAMIC_SHAPE_INFERER_H__
+#define __ONERT_EXEC_DYNAMIC_SHAPE_INFERER_H__
 
+#include "ir/Operands.h"
 #include "ir/OperationVisitor.h"
-#include "ir/OpSequence.h"
-#include "compiler/LoweredGraph.h"
 #include "ir/Index.h"
+#include "backend/IDynamicTensorManager.h"
+#include "backend/ITensorManager.h"
+#include "backend/ITensorRegistry.h"
 
-#include <memory>
-#include <unordered_map>
+#include <map>
 
 namespace onert
 {
-namespace compiler
+namespace exec
 {
 
 /**
- * @brief Class to infer shape before running kernels. It does the following:
- *        - re-calculate and set output shape at compile time (before running kernels)
- *        - if calculation cannot be done at compile time, mark the outputs to be dynamic, meaning
- *          shapes of outputs will be calculated during running kernels
+ * @brief Class to infer shape of output tensor at execution time and
+ *        allocate memory fo output tensor if needed
  */
-class StaticShapeInferer : public ir::OperationVisitor
+class DynamicShapeInferer : public ir::OperationVisitor
 {
 public:
-  StaticShapeInferer(
-      const ir::SubgraphIndex &subg_idx,
-      const std::unordered_map<ir::SubgraphIndex, std::unique_ptr<compiler::LoweredGraph>>
-          &lowered_subgs)
-      : _lowered_subgs(lowered_subgs), _operands(lowered_subgs.at(subg_idx)->graph().operands()),
-        _operations(lowered_subgs.at(subg_idx)->graph().operations()),
-        _return_has_dynamic_tensor(false)
-  { /* empty */
+  DynamicShapeInferer(const ir::Operands &operands,
+                      const std::shared_ptr<backend::ITensorRegistry> &tensor_registry)
+      : _operands(operands), _tensor_registry(tensor_registry)
+  {
+    UNUSED_RELEASE(_operands);
+    UNUSED_RELEASE(_tensor_registry);
   }
-  virtual ~StaticShapeInferer() = default;
 
 public:
-  /**
-   * @brief Infer shape of operands beloning to ops and set the output shape.
-   *        If output shape cannot be known without running op, mark it so that it can be allocated
-   *        when running kernel.
-   * @param op_seq sequence of operations
-   * @return @c true if op_seq's input or output has any dynamic tensor; @c false otherwise.
-   */
-  bool infer(const ir::OpSequence &op_seq);
-
-  void dump();
-
-private:
-  bool checkDynamicInput(const ir::Operation &op);
-  void setDynamicOutput(const ir::Operation &op);
-
-private:
   // TODO Define visitors for operations. List them in alphabetic order.
+  // Remove TODO when any op starting from the alphabet is added
   void visit(const ir::operation::ArgMax &op) override;
   void visit(const ir::operation::BatchMatMul &op) override;
   void visit(const ir::operation::BCQFullyConnected &op) override;
@@ -85,7 +66,6 @@ private:
   void visit(const ir::operation::FullyConnected &op) override;
   void visit(const ir::operation::FusedBatchNorm &op) override;
   void visit(const ir::operation::Gather &op) override;
-  void visit(const ir::operation::If &op) override;
   void visit(const ir::operation::L2Normalization &op) override;
   void visit(const ir::operation::LSTM &op) override;
   void visit(const ir::operation::MatrixBandPart &op) override;
@@ -94,6 +74,7 @@ private:
   void visit(const ir::operation::Pad &op) override;
   void visit(const ir::operation::Permute &op) override;
   void visit(const ir::operation::Pow &op) override;
+  // TODO write op starting from Q
   void visit(const ir::operation::Range &op) override;
   void visit(const ir::operation::Reduce &op) override;
   void visit(const ir::operation::Reshape &op) override;
@@ -111,31 +92,32 @@ private:
   void visit(const ir::operation::Tile &op) override;
   void visit(const ir::operation::Transpose &op) override;
   void visit(const ir::operation::Unpack &op) override;
-  void visit(const ir::operation::While &op) override;
+  // TODO write op starting from V
 
 private:
   /**
-   * @brief Performs shape inference for arithmetic operation
+   * @brief Performs shape inference and memory allocation for arithmetic operation
    */
   void handleBinaryArithmeticOp(const ir::Operation &op, const ir::OperandIndex lhs_idx,
                                 const ir::OperandIndex rhs_idx);
-
   /**
-   * @brief Performs shape inference for unary op whose output shape is
+   * @brief Performs shape inference and memory allocation for unary op whose output shape is
    *        always same with input shape
    */
   void handleSimpleUnaryOp(const ir::Operation &op, const ir::OperandIndex input_idx);
 
 private:
-  const std::unordered_map<ir::SubgraphIndex, std::unique_ptr<compiler::LoweredGraph>>
-      &_lowered_subgs;
-  // _operands and _operations can be changed by controlflow operation
-  ir::Operands &_operands;     // operands of current subgraph
-  ir::Operations &_operations; // operations of current subgraph
-  bool _return_has_dynamic_tensor;
+  /**
+   * @brief To get operand-level info, e.g., ir::Operand::isConstant()
+   */
+  const ir::Operands &_operands;
+  /**
+   * @brief To get tensor object and access tensor-level info, e.g., ITensor::buffer()
+   */
+  std::shared_ptr<backend::ITensorRegistry> _tensor_registry;
 };
 
-} // namespace compiler
+} // namespace exec
 } // namespace onert
 
-#endif // __ONERT_COMPILER_STATIC_SHAPE_INFERENCE_H__
+#endif // __ONERT_EXEC_DYNAMIC_SHAPE_INFERER_H__

--- a/runtime/onert/core/include/exec/FunctionSequence.h
+++ b/runtime/onert/core/include/exec/FunctionSequence.h
@@ -23,7 +23,7 @@
 #include <functional>
 
 #include "exec/IFunction.h"
-#include "exec/DynamicShapeInference.h"
+#include "exec/DynamicShapeInferer.h"
 #include "ir/Operations.h"
 #include "backend/ITensorRegistry.h"
 #include "backend/IDynamicTensorManager.h"

--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -27,7 +27,7 @@
 #include "compiler/IScheduler.h"
 #include "compiler/ManualScheduler.h"
 #include "compiler/HEScheduler.h"
-#include "compiler/StaticShapeInference.h"
+#include "compiler/StaticShapeInferer.h"
 #include "compiler/pass/ConstantOutputPass.h"
 #include "compiler/pass/OddOutputPass.h"
 #include "compiler/pass/PassRunner.h"

--- a/runtime/onert/core/src/compiler/StaticShapeInferer.cc
+++ b/runtime/onert/core/src/compiler/StaticShapeInferer.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "compiler/StaticShapeInference.h"
+#include "compiler/StaticShapeInferer.h"
 #include "util/ShapeInference.h"
 #include "util/logging.h"
 

--- a/runtime/onert/core/src/exec/DynamicShapeInferer.cc
+++ b/runtime/onert/core/src/exec/DynamicShapeInferer.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "exec/DynamicShapeInference.h"
+#include "exec/DynamicShapeInferer.h"
 #include "util/ShapeInference.h"
 #include <assert.h>
 


### PR DESCRIPTION
Rename `{Static/Dynamic}ShapeInference.{h/cc}` to ShapeInferer to match
them with their class names.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>