### PR TITLE
[oenrt] Test : Refine unit tests

### DIFF
--- a/runtime/onert/test/core/interp/ExecManager.cc
+++ b/runtime/onert/test/core/interp/ExecManager.cc
@@ -226,7 +226,7 @@ TEST_F(InterpExecutorTest, create_simple)
   ASSERT_NE(_executors->at(onert::ir::SubgraphIndex{0}), nullptr);
 }
 
-TEST_F(InterpExecutorTest, setInput)
+TEST_F(InterpExecutorTest, neg_setInput)
 {
   CreateSimpleModel();
   createExecution();
@@ -241,7 +241,7 @@ TEST_F(InterpExecutorTest, setInput)
   EXPECT_NO_THROW(_execution->setInput(input1, reinterpret_cast<const void *>(input1_buffer), 16));
 }
 
-TEST_F(InterpExecutorTest, setOutput)
+TEST_F(InterpExecutorTest, neg_setOutput)
 {
   CreateSimpleModel();
   createExecution();
@@ -258,7 +258,7 @@ TEST_F(InterpExecutorTest, setOutput)
   EXPECT_NO_THROW(_execution->setOutput(output, reinterpret_cast<void *>(output_buffer), 16));
 }
 
-TEST_F(InterpExecutorTest, setInputForUnspecifiedDimensions)
+TEST_F(InterpExecutorTest, neg_setInputForUnspecifiedDimensions)
 {
   CreateUnspecifiedDimensionsModel();
   createExecution();
@@ -279,7 +279,7 @@ TEST_F(InterpExecutorTest, setInputForUnspecifiedDimensions)
                                        reinterpret_cast<const void *>(input1_buffer), 16));
 }
 
-TEST_F(InterpExecutorTest, setOutputForUnspecifiedDimensions)
+TEST_F(InterpExecutorTest, neg_setOutputForUnspecifiedDimensions)
 {
   CreateUnspecifiedDimensionsModel();
   createExecution();

--- a/runtime/onert/test/graph/Graph.cc
+++ b/runtime/onert/test/graph/Graph.cc
@@ -18,7 +18,7 @@
 
 #include "ir/Graph.h"
 
-TEST(Graph, inputs_and_outputs)
+TEST(Graph, neg_inputs_and_outputs)
 {
   onert::ir::Graph graph;
 
@@ -49,4 +49,6 @@ TEST(Graph, inputs_and_outputs)
   ASSERT_EQ(graph.getOutputs().at(io_index0), 10);
   ASSERT_EQ(graph.getOutputs().at(io_index1), 11);
   ASSERT_EQ(graph.getOutputs().at(io_index2), 12);
+
+  EXPECT_THROW(graph.getOutputs().at(onert::ir::IOIndex{3}), std::out_of_range);
 }

--- a/runtime/onert/test/graph/operand/IndexSet.cc
+++ b/runtime/onert/test/graph/operand/IndexSet.cc
@@ -21,7 +21,7 @@
 using onert::ir::OperandIndex;
 using onert::ir::OperandIndexSequence;
 
-TEST(graph_OperandIndexSequence, neg_append)
+TEST(ir_OperandIndexSequence, neg_append)
 {
   OperandIndexSequence iset{0, 2, 4, 8};
 

--- a/runtime/onert/test/graph/operand/LayoutSet.cc
+++ b/runtime/onert/test/graph/operand/LayoutSet.cc
@@ -21,7 +21,7 @@
 using onert::ir::Layout;
 using onert::ir::LayoutSet;
 
-TEST(graph_operand_LayoutSet, neg_add_remove)
+TEST(ir_LayoutSet, neg_add_remove)
 {
   LayoutSet set{Layout::NCHW};
   set.remove(Layout::NHWC);
@@ -36,7 +36,7 @@ TEST(graph_operand_LayoutSet, neg_add_remove)
   ASSERT_EQ(set.size(), 0);
 }
 
-TEST(graph_operand_LayoutSet, set_operators)
+TEST(ir_LayoutSet, set_operators)
 {
   LayoutSet set1{Layout::NCHW};
   LayoutSet set2{Layout::NHWC};

--- a/runtime/onert/test/graph/operand/Set.cc
+++ b/runtime/onert/test/graph/operand/Set.cc
@@ -18,7 +18,7 @@
 
 #include "ir/Operands.h"
 
-TEST(graph_operand_Set, neg_set_test)
+TEST(ir_Operands, neg_set_test)
 {
   onert::ir::Operands set;
 

--- a/runtime/onert/test/graph/operand/UseDef.cc
+++ b/runtime/onert/test/graph/operand/UseDef.cc
@@ -31,7 +31,7 @@ using Mock = onert_test::ir::SimpleMock;
 
 } // namespace
 
-TEST(graph_operand_usedef, neg_usedef_test)
+TEST(ir_Operand, neg_usedef)
 {
   onert::ir::Graph graph;
   onert::ir::verifier::DAGChecker verifier;

--- a/runtime/onert/test/graph/operation/Set.cc
+++ b/runtime/onert/test/graph/operation/Set.cc
@@ -23,11 +23,19 @@ using onert::ir::Operation;
 using onert::ir::OperationIndex;
 using onert::ir::Operations;
 
-TEST(graph_operation_Set, operation_test)
+TEST(ir_Operations, basic)
 {
   Operations ops;
   ops.push(std::unique_ptr<Operation>(new onert_test::ir::SimpleMock({1, 2, 3, 4}, {5, 6, 7})));
   OperationIndex idx{0u};
   ASSERT_EQ(ops.at(idx).getInputs().size(), 4);
   ASSERT_EQ(ops.at(idx).getOutputs().size(), 3);
+}
+
+TEST(ir_Operations, neg_at)
+{
+  Operations ops;
+  ops.push(std::unique_ptr<Operation>(new onert_test::ir::SimpleMock({1, 2, 3, 4}, {5, 6, 7})));
+  OperationIndex idx{99u};
+  EXPECT_THROW(ops.at(idx), std::out_of_range);
 }

--- a/runtime/onert/test/graph/operation/SetIO.cc
+++ b/runtime/onert/test/graph/operation/SetIO.cc
@@ -29,7 +29,7 @@
 using Index = onert::ir::IOIndex;
 using IndexSet = onert::ir::OperandIndexSequence;
 
-TEST(graph_operation_setIO, operation_setIO_conv)
+TEST(ir_Operation_setIO, operation_setIO_conv)
 {
   onert::ir::Graph graph;
 
@@ -62,7 +62,7 @@ TEST(graph_operation_setIO, operation_setIO_conv)
   ASSERT_EQ(conv->getInputs().at(Index{0}).value(), 8);
 }
 
-TEST(graph_operation_setIO, neg_operation_setIO_concat)
+TEST(ir_Operation_setIO, neg_operation_setIO_concat)
 {
   onert::ir::Graph graph;
 

--- a/runtime/onert/test/util/ObjectManager.cc
+++ b/runtime/onert/test/util/ObjectManager.cc
@@ -32,7 +32,7 @@ TEST(ObjectManager, emplace)
   ASSERT_EQ(man.at(index), 100);
 }
 
-TEST(ObjectManager, remove_1)
+TEST(ObjectManager, neg_remove_1)
 {
   util::ObjectManager<Index, int> man;
 
@@ -44,7 +44,7 @@ TEST(ObjectManager, remove_1)
   ASSERT_FALSE(man.exist(index));
 }
 
-TEST(ObjectManager, remove_2)
+TEST(ObjectManager, neg_remove_2)
 {
   util::ObjectManager<Index, int> man;
 


### PR DESCRIPTION
- Turn some tests into negative tests
    - e.g.) Tests that contains `EXPECT_THROW` should be a negative
      case
- Rename some old test cases that were misleading

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>