### PR TITLE
[luci] Add support U8 ops for validate_minmax()

### DIFF
--- a/compiler/luci/import/src/ValidateHelpers.cpp
+++ b/compiler/luci/import/src/ValidateHelpers.cpp
@@ -78,6 +78,7 @@ bool validate_minmax(const GraphBuilderBase::ValidateArgs &args)
     case circle::TensorType_FLOAT64:
     case circle::TensorType_INT32:
     case circle::TensorType_INT64:
+    case circle::TensorType_UINT8:
       break;
     default:
       return false;


### PR DESCRIPTION
Parent Issue: #1880
Fired Issue: #4694 

Added support for U8 ops for validate_minmax() function.
This will allow `Maximum_U8` & `Minimum_U8` ops as well as any other kernel ops that use `validate_minmax()` function to validate in `CircleOps`.

Please review this PR, @seanshpark, @jinevening  .
I'll be happy to get feedback and change to make improvement.

Thank you.

(Derived from SOS Mine Project)

Signed-off-by: underflow101 <ikarus125@gmail.com>