### PR TITLE
[common-artifacts] Add BOOL DataType support for TestDataGenerator

### DIFF
--- a/compiler/common-artifacts/src/TestDataGenerator.cpp
+++ b/compiler/common-artifacts/src/TestDataGenerator.cpp
@@ -49,6 +49,8 @@ H5::PredType hdf5_dtype_cast(const loco::DataType loco_dtype)
       return H5::PredType::NATIVE_INT64;
     case loco::DataType::FLOAT32:
       return H5::PredType::NATIVE_FLOAT;
+    case loco::DataType::BOOL:
+      return H5::PredType::NATIVE_HBOOL;
     default:
       throw std::runtime_error("NYI data type.");
   }


### PR DESCRIPTION
Parent Issue: #1880
Fired Issue: #4696 

Added support for BOOL DataType for TestDataGenerator.
This will allow `Equal`, `Less`, `Greater`, `GreaterEqual`, etc. op's recipes that gives BOOL DataType output tensor.

Please review this PR, @seanshpark, @jinevening .
I'll be happy to get feedback and change to make improvement.

Thank you.

(Derived from SOS Mine Project)

Signed-off-by: underflow101 <ikarus125@gmail.com>