### PR TITLE
[luci-interpreter] Simple tensor memory management

### DIFF
--- a/compiler/luci-interpreter/include/luci_interpreter/core/Tensor.h
+++ b/compiler/luci-interpreter/include/luci_interpreter/core/Tensor.h
@@ -118,13 +118,13 @@ public:
 
   template <typename T> const T *data() const
   {
-    assert(!!_data);
+    assert(_data_allocated);
     return reinterpret_cast<const T *>(_data.get());
   }
 
   template <typename T> T *data()
   {
-    if (!_data)
+    if (!_data_allocated)
       allocate();
     return reinterpret_cast<T *>(_data.get());
   }
@@ -143,6 +143,7 @@ private:
   AffineQuantization _quantization;
   std::unique_ptr<uint8_t[]> _data;
   std::string _name;
+  bool _data_allocated;
 };
 
 } // namespace luci_interpreter

--- a/compiler/luci-interpreter/include/luci_interpreter/core/Tensor.h
+++ b/compiler/luci-interpreter/include/luci_interpreter/core/Tensor.h
@@ -107,15 +107,27 @@ public:
     return _quantization.zero_point[0];
   }
 
+  void allocate();
+  void deallocate();
+
   const std::vector<float> &scales() const { return _quantization.scale; }
 
   const std::vector<int32_t> &zero_points() const { return _quantization.zero_point; }
 
   int32_t quantized_dimension() const { return _quantization.quantized_dimension; }
 
-  template <typename T> const T *data() const { return reinterpret_cast<const T *>(_data.get()); }
+  template <typename T> const T *data() const
+  {
+    assert(!!_data);
+    return reinterpret_cast<const T *>(_data.get());
+  }
 
-  template <typename T> T *data() { return reinterpret_cast<T *>(_data.get()); }
+  template <typename T> T *data()
+  {
+    if (!_data)
+      allocate();
+    return reinterpret_cast<T *>(_data.get());
+  }
 
   const std::string &name() const { return _name; }
 

--- a/compiler/luci-interpreter/src/core/RuntimeGraph.cpp
+++ b/compiler/luci-interpreter/src/core/RuntimeGraph.cpp
@@ -155,6 +155,7 @@ void RuntimeGraph::execute() const
     // TODO The `configure` method should only be called if the outputs of an operator need to be
     //  resized.
     kernel->configure();
+// TODO decide where to allocate memory, and uncomment/remove this if
 #if 0
     _tensor_alloc_plan->allocate(
         index); // Preallocate outputs in advance instead of relying on automatic allocation

--- a/compiler/luci-interpreter/src/core/RuntimeGraph.cpp
+++ b/compiler/luci-interpreter/src/core/RuntimeGraph.cpp
@@ -24,6 +24,82 @@
 namespace luci_interpreter
 {
 
+class RuntimeGraph::TensorAllocPlan
+{
+  std::vector<std::vector<Tensor *>> _alloc_plan;
+  std::vector<std::vector<Tensor *>> _dealloc_plan;
+  bool _valid = false;
+
+public:
+  void invalidate() { _valid = false; }
+  bool isValid() const { return _valid; }
+  void build(const RuntimeGraph &graph);
+  void allocate(size_t kernel_index) const;
+  void deallocate(size_t kernel_index) const;
+};
+
+void RuntimeGraph::TensorAllocPlan::build(const RuntimeGraph &graph)
+{
+  invalidate();
+  using Lifetime = std::pair<size_t, size_t>;
+  std::unordered_map<Tensor *, Lifetime> lifetimes;
+  const size_t num_kernels = graph._kernels.size();
+  for (size_t index = 0; index < num_kernels; ++index)
+  {
+    const auto &kernel = graph._kernels[index];
+    for (const Tensor *tensor : kernel->getInputTensors())
+    {
+      auto nc_tensor = const_cast<Tensor *>(tensor);
+      if (lifetimes.count(nc_tensor) > 0)
+        lifetimes.at(nc_tensor).second = index;
+    }
+    for (Tensor *tensor : kernel->getOutputTensors())
+    {
+      assert(lifetimes.count(tensor) == 0);
+      lifetimes[tensor] = Lifetime(index, index);
+    }
+  }
+  for (const Tensor *tensor : graph.getOutputTensors())
+  {
+    auto nc_tensor = const_cast<Tensor *>(tensor);
+    if (lifetimes.count(nc_tensor) > 0)
+      lifetimes.at(nc_tensor).second = num_kernels;
+  }
+  _alloc_plan.assign(num_kernels, std::vector<Tensor *>());
+  _dealloc_plan.assign(num_kernels + 1, std::vector<Tensor *>());
+  for (const auto &item : lifetimes)
+  {
+    _alloc_plan[item.second.first].push_back(item.first);
+    _dealloc_plan[item.second.second].push_back(item.first);
+  }
+  _valid = true;
+}
+
+void RuntimeGraph::TensorAllocPlan::allocate(size_t kernel_index) const
+{
+  assert(_valid && kernel_index < _alloc_plan.size());
+  for (Tensor *tensor : _alloc_plan[kernel_index])
+  {
+    tensor->allocate();
+  }
+}
+
+void RuntimeGraph::TensorAllocPlan::deallocate(size_t kernel_index) const
+{
+  assert(_valid && kernel_index < _dealloc_plan.size());
+  for (Tensor *tensor : _dealloc_plan[kernel_index])
+  {
+    tensor->deallocate();
+  }
+}
+
+RuntimeGraph::RuntimeGraph(RuntimeModule *owning_module)
+    : _owning_module(owning_module), _tensor_alloc_plan(std::make_unique<TensorAllocPlan>())
+{
+}
+
+RuntimeGraph::~RuntimeGraph() {}
+
 Tensor *RuntimeGraph::addTensor(std::unique_ptr<Tensor> &&tensor)
 {
   assert(tensor != nullptr);
@@ -49,36 +125,13 @@ void RuntimeGraph::addKernel(std::unique_ptr<Kernel> &&kernel)
 {
   assert(kernel != nullptr);
   _kernels.push_back(std::move(kernel));
-  _tensor_dealloc_plan.clear();
-}
-
-void RuntimeGraph::prepareDeallocPlan() const
-{
-  // For every tensor which is an output of some kernel find the last kernel which uses it.
-  std::unordered_map<const Tensor *, size_t> dealloc_index;
-  for (size_t index = 0; index < _kernels.size(); ++index)
-  {
-    const auto &kernel = _kernels[index];
-    for (const Tensor *tensor : kernel->getOutputTensors())
-    {
-      assert(dealloc_index.count(tensor) == 0);
-      dealloc_index[tensor] = index;
-    }
-    for (const Tensor *tensor : kernel->getInputTensors())
-      if (dealloc_index.count(tensor) > 0)
-        dealloc_index[tensor] = index;
-  }
-  for (const Tensor *tensor : getOutputTensors())
-    dealloc_index.erase(tensor);
-  _tensor_dealloc_plan.assign(_kernels.size(), std::vector<Tensor *>());
-  for (const auto &item : dealloc_index)
-    _tensor_dealloc_plan[item.second].push_back(const_cast<Tensor *>(item.first));
+  _tensor_alloc_plan->invalidate();
 }
 
 void RuntimeGraph::execute() const
 {
-  if (_tensor_dealloc_plan.empty())
-    prepareDeallocPlan();
+  if (!_tensor_alloc_plan->isValid())
+    _tensor_alloc_plan->build(*this);
 
   EventNotifier *event_notifier = _owning_module->getEventNotifier();
 
@@ -102,6 +155,10 @@ void RuntimeGraph::execute() const
     // TODO The `configure` method should only be called if the outputs of an operator need to be
     //  resized.
     kernel->configure();
+#if 0
+    _tensor_alloc_plan->allocate(
+        index); // Preallocate outputs in advance instead of relying on automatic allocation
+#endif
     kernel->execute();
 
     if (event_notifier != nullptr)
@@ -116,10 +173,7 @@ void RuntimeGraph::execute() const
         event_notifier->postTensorWrite(tensor);
       }
     }
-
-    // Deallocate tensors which are not to be used any more in this run
-    for (Tensor *tensor : _tensor_dealloc_plan[index])
-      tensor->deallocate();
+    _tensor_alloc_plan->deallocate(index);
   }
 }
 

--- a/compiler/luci-interpreter/src/core/RuntimeGraph.h
+++ b/compiler/luci-interpreter/src/core/RuntimeGraph.h
@@ -30,8 +30,13 @@ class RuntimeModule;
 
 class RuntimeGraph
 {
+private:
+  class TensorAllocPlan;
+  friend class TensorAllocPlan;
+
 public:
-  explicit RuntimeGraph(RuntimeModule *owning_module) : _owning_module(owning_module) {}
+  explicit RuntimeGraph(RuntimeModule *owning_module);
+  ~RuntimeGraph();
 
   Tensor *addTensor(std::unique_ptr<Tensor> &&tensor);
 
@@ -46,9 +51,6 @@ public:
   void execute() const;
 
 private:
-  // Build tensor deallocation plan
-  void prepareDeallocPlan() const;
-
   RuntimeModule *_owning_module;
   std::vector<std::unique_ptr<Tensor>> _tensors;
   std::vector<Tensor *> _input_tensors;
@@ -57,7 +59,7 @@ private:
   // Kernels in execution order.
   std::vector<std::unique_ptr<Kernel>> _kernels;
   // Tensors that are not used anymore after given op
-  mutable std::vector<std::vector<Tensor *>> _tensor_dealloc_plan;
+  std::unique_ptr<TensorAllocPlan> _tensor_alloc_plan;
 };
 
 } // namespace luci_interpreter

--- a/compiler/luci-interpreter/src/core/RuntimeGraph.h
+++ b/compiler/luci-interpreter/src/core/RuntimeGraph.h
@@ -46,6 +46,9 @@ public:
   void execute() const;
 
 private:
+  // Build tensor deallocation plan
+  void prepareDeallocPlan() const;
+
   RuntimeModule *_owning_module;
   std::vector<std::unique_ptr<Tensor>> _tensors;
   std::vector<Tensor *> _input_tensors;
@@ -53,6 +56,8 @@ private:
 
   // Kernels in execution order.
   std::vector<std::unique_ptr<Kernel>> _kernels;
+  // Tensors that are not used anymore after given op
+  mutable std::vector<std::vector<Tensor *>> _tensor_dealloc_plan;
 };
 
 } // namespace luci_interpreter

--- a/compiler/luci-interpreter/src/core/Tensor.cpp
+++ b/compiler/luci-interpreter/src/core/Tensor.cpp
@@ -25,18 +25,24 @@ namespace luci_interpreter
 Tensor::Tensor(DataType element_type, Shape shape, AffineQuantization quantization,
                std::string name)
     : _element_type(element_type), _shape(std::move(shape)), _quantization(std::move(quantization)),
-      _name(std::move(name))
+      _name(std::move(name)), _data_allocated(false)
 {
 }
 
 void Tensor::allocate()
 {
+  deallocate();
   const size_t element_size = getDataTypeSize(_element_type);
   const int32_t num_elements = _shape.num_elements();
   _data = std::make_unique<uint8_t[]>(num_elements * element_size);
+  _data_allocated = true;
 }
 
-void Tensor::deallocate() { _data = nullptr; }
+void Tensor::deallocate()
+{
+  _data_allocated = false;
+  _data.reset();
+}
 
 void Tensor::readData(void *data_ptr, size_t data_size) const
 {

--- a/compiler/luci-interpreter/src/core/Tensor.cpp
+++ b/compiler/luci-interpreter/src/core/Tensor.cpp
@@ -27,10 +27,16 @@ Tensor::Tensor(DataType element_type, Shape shape, AffineQuantization quantizati
     : _element_type(element_type), _shape(std::move(shape)), _quantization(std::move(quantization)),
       _name(std::move(name))
 {
+}
+
+void Tensor::allocate()
+{
   const size_t element_size = getDataTypeSize(_element_type);
   const int32_t num_elements = _shape.num_elements();
   _data = std::make_unique<uint8_t[]>(num_elements * element_size);
 }
+
+void Tensor::deallocate() { _data = nullptr; }
 
 void Tensor::readData(void *data_ptr, size_t data_size) const
 {
@@ -58,11 +64,8 @@ void Tensor::writeData(const void *data_ptr, size_t data_size)
 
 void Tensor::resize(const Shape &new_shape)
 {
+  deallocate();
   _shape = new_shape;
-  const size_t element_size = getDataTypeSize(_element_type);
-  const int32_t num_elements = _shape.num_elements();
-  // NOTE: _data can be nullptr for empty tensors
-  _data = std::make_unique<uint8_t[]>(num_elements * element_size);
 }
 
 } // namespace luci_interpreter

--- a/compiler/luci-interpreter/src/kernels/Conv2D.cpp
+++ b/compiler/luci-interpreter/src/kernels/Conv2D.cpp
@@ -135,6 +135,8 @@ void Conv2D::execute() const
     default:
       throw std::runtime_error("Unsupported type.");
   }
+  if (!!_im2col)
+    _im2col->deallocate();
 }
 
 void Conv2D::evalFloat() const

--- a/compiler/luci-interpreter/src/kernels/Mean.cpp
+++ b/compiler/luci-interpreter/src/kernels/Mean.cpp
@@ -180,6 +180,12 @@ void Mean::execute() const
     default:
       throw std::runtime_error("Unsupported type.");
   }
+  if (!!_temp_index)
+    _temp_index->deallocate();
+  if (!!_resolved_axes)
+    _resolved_axes->deallocate();
+  if (!!_temp_sum)
+    _temp_sum->deallocate();
 }
 
 void Mean::evalFloat() const

--- a/compiler/luci-interpreter/src/kernels/TransposeConv.cpp
+++ b/compiler/luci-interpreter/src/kernels/TransposeConv.cpp
@@ -96,6 +96,8 @@ void TransposeConv::execute() const
     default:
       throw std::runtime_error("Unsupported type.");
   }
+  if (!!_scratch_tensor)
+    _scratch_tensor->deallocate();
 }
 
 void TransposeConv::evalFloat() const


### PR DESCRIPTION
Reduce tensor data memory usage. Allocate lazily on demand. Deallocate when not needed any more.

Theoretical tensor memory usage on inception V3: 90.9 MB (weights) + 200.6 MB (other) --> 90.9 MB + 8.8 MB

luci-value-tester peak usage: 501 MB --> 386 MB (same as preparing the interpreter and skipping inference)