### PR TITLE
[res/TensorFlowLiteRecipes] Add NotEqual_U8_000

### DIFF
--- a/res/TensorFlowLiteRecipes/NotEqual_U8_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/NotEqual_U8_000/test.recipe
@@ -1,0 +1,28 @@
+operand {
+  name: "ifm1"
+  type: UINT8
+  shape { dim: 1 dim: 4 dim: 4 dim: 3 }
+  quant { min: -1 max: 1 scale: 0.0078431373 zero_point: 128 }
+}
+operand {
+  name: "ifm2"
+  type: UINT8
+  shape { dim: 1 dim: 4 dim: 4 dim: 3 }
+  quant { min: -1 max: 1 scale: 0.0078431373 zero_point: 128 }
+}
+operand {
+  name: "ofm"
+  type: BOOL
+  shape { dim: 1 dim: 4 dim: 4 dim: 3 }
+}
+operation {
+  type: "NotEqual"
+  notequal_options {
+  }
+  input: "ifm1"
+  input: "ifm2"
+  output: "ofm"
+}
+input: "ifm1"
+input: "ifm2"
+output: "ofm"


### PR DESCRIPTION
Parent Issue: #1880
Fired Issue: #4731 

This commit enable U8 recipe for NotEqual_000 Op.

Please review this PR, @seanshpark @jinevening .
I'll be happy to get feedback and change to make improvement.

Thank you.

(Derived from SOS Mine Project)

Signed-off-by: underflow101 <ikarus125@gmail.com>