### PR TITLE
[onert] Use atomic finished flag in the Execution

### DIFF
--- a/runtime/onert/core/include/exec/Execution.h
+++ b/runtime/onert/core/include/exec/Execution.h
@@ -25,6 +25,7 @@
 #include "exec/IExecutor.h"
 #include "IODescription.h"
 
+#include <atomic>
 #include <thread>
 
 namespace onert
@@ -45,6 +46,8 @@ public:
    * @param[in] executor  Model executor
    */
   Execution(const std::shared_ptr<ExecutorMap> &executors);
+
+  ~Execution();
 
 public:
   /**
@@ -137,12 +140,15 @@ public:
    * @brief   Check execution is finished
    * @return  @c true if execution is finished, otherwise @c false
    */
-  bool isFinished(void) const;
+  bool isFinished(void) const { return _finished; }
 
   ir::Shape getInputShape(ir::IOIndex ind) const;
   ir::Shape getOutputShape(ir::IOIndex ind) const;
 
 private:
+  void executeAsync();
+  void assertAsyncInactive();
+
   const std::unique_ptr<IExecutor> &primary_executor() const
   {
     return _executors->at(ir::SubgraphIndex{0});
@@ -153,7 +159,7 @@ private:
   const std::shared_ptr<ExecutorMap> _executors;
   IODescription _io_desc;
   std::unique_ptr<std::thread> _exec_thread;
-  bool finished{false};
+  std::atomic<bool> _finished{false};
 };
 
 } // namespace exec


### PR DESCRIPTION
Investigating the runtime code, I noticed that bool finished flag in Execution may be accessed from two unsynchronized threads at the same time. That should be safe in practice in this particular case, but not correct in theory.

I made the flag atomic, added flag reset in startAsync, and also added some async-related runtime checks.

What do you think?