### PR TITLE
[onert] Remove the calls of CalculateActivationRange in FullyConnected

### DIFF
--- a/compute/cker/include/cker/Types.h
+++ b/compute/cker/include/cker/Types.h
@@ -258,9 +258,9 @@ struct FullyConnectedParams
   // uint8, etc, activation params.
   int32_t quantized_activation_min;
   int32_t quantized_activation_max;
-  // float activation params.
-  float float_activation_min;
-  float float_activation_max;
+  // float activation params - no one use this params, but ruy might use them later.
+  // float float_activation_min;
+  // float float_activation_max;
   // FullyConnectedWeightsFormat weights_format;
 };
 

--- a/runtime/onert/backend/cpu/ops/FullyConnectedLayer.cc
+++ b/runtime/onert/backend/cpu/ops/FullyConnectedLayer.cc
@@ -42,12 +42,7 @@ FullyConnectedLayer::~FullyConnectedLayer() = default;
 
 void FullyConnectedLayer::fullyConnectedFloat32()
 {
-  float output_activation_min = 0, output_activation_max = 0;
-  CalculateActivationRange(_activation, &output_activation_min, &output_activation_max);
-
   nnfw::cker::FullyConnectedParams op_params;
-  op_params.float_activation_min = output_activation_min;
-  op_params.float_activation_max = output_activation_max;
   op_params.activation = convertActivationType(_activation);
 
   nnfw::cker::FullyConnected(
@@ -150,12 +145,7 @@ void FullyConnectedLayer::fullyConnectedHybrid()
 
 void FullyConnectedLayer::fullyConnectedSparseWeight()
 {
-  float output_activation_min = 0, output_activation_max = 0;
-  CalculateActivationRange(_activation, &output_activation_min, &output_activation_max);
-
   nnfw::cker::FullyConnectedParams op_params;
-  op_params.float_activation_min = output_activation_min;
-  op_params.float_activation_max = output_activation_max;
   op_params.activation = convertActivationType(_activation);
 
   const uint16_t *w1_segments = _weights->sparsity()->w1_segments();

--- a/runtime/onert/core/src/interp/operations/FullyConnected.cc
+++ b/runtime/onert/core/src/interp/operations/FullyConnected.cc
@@ -84,8 +84,6 @@ void invoke(const ITensor *ifm_tensor, const ITensor *ker_tensor, const ITensor 
   // Calculate
   nnfw::cker::FullyConnectedParams cker_param;
   cker_param.activation = convertActivationType(param.activation);
-  calculateActivationRange(param.activation, &cker_param.float_activation_min,
-                           &cker_param.float_activation_max);
   const auto cker_ifm_shape = convertShape(ifm_tensor->tensorInfo().shape());
   const auto cker_ker_shape = convertShape(ker_tensor->tensorInfo().shape());
   const auto cker_bias_shape = convertShape(bias_tensor->tensorInfo().shape());


### PR DESCRIPTION
It removes the calls of CalculateActivationRange in FullyConnected.
Because the calculated float_activation_{min,max} are not used any longer.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>