### PR TITLE
[luci] Model size optimization when exporting model

### DIFF
--- a/compiler/luci/export/src/CircleTensorExporter.cpp
+++ b/compiler/luci/export/src/CircleTensorExporter.cpp
@@ -388,8 +388,7 @@ bool has_same_values(luci::CircleConst *lhs, luci::CircleConst *rhs)
   return true;
 }
 
-uint32_t get_buffer_id(FlatBufferBuilder &builder, SerializedModelData &md,
-                             luci::CircleConst *node)
+uint32_t get_buffer_id(FlatBufferBuilder &builder, SerializedModelData &md, luci::CircleConst *node)
 {
   if (node != nullptr)
   {

--- a/compiler/luci/export/src/CircleTensorExporter.cpp
+++ b/compiler/luci/export/src/CircleTensorExporter.cpp
@@ -388,7 +388,7 @@ bool has_same_values(luci::CircleConst *lhs, luci::CircleConst *rhs)
   return true;
 }
 
-uint32_t optimized_buffer_id(FlatBufferBuilder &builder, SerializedModelData &md,
+uint32_t get_buffer_id(FlatBufferBuilder &builder, SerializedModelData &md,
                              luci::CircleConst *node)
 {
   if (node != nullptr)
@@ -431,7 +431,7 @@ void exportOpDefinedTensor(const CircleTensoInfo &info, FlatBufferBuilder &build
 
   auto sparsityparam = encodeSparsityParameters(builder, info.sparsityparam());
 
-  auto buffer_id = optimized_buffer_id(builder, md, info.content());
+  auto buffer_id = get_buffer_id(builder, md, info.content());
 
   auto name_offset = builder.CreateString(info.name());
   auto tensor_offset = CreateTensor(builder, shape_offset, info.dtype(), buffer_id, name_offset,

--- a/compiler/luci/export/src/SerializedData.h
+++ b/compiler/luci/export/src/SerializedData.h
@@ -19,9 +19,12 @@
 
 #include <mio/circle/schema_generated.h>
 
+#include <luci/IR/CircleNodes.h>
+
 #include <vector>
 
 #include <unordered_map>
+#include <map>
 
 namespace luci
 {
@@ -83,6 +86,9 @@ struct SerializedModelData final
 
   std::unordered_map<OpCode, uint32_t> _operator_codes;
   std::vector<flatbuffers::Offset<circle::Buffer>> _buffers;
+
+  // This is used for removing buffers with same values
+  std::map<luci::CircleConst *, uint32_t> _cached_buffer_id;
 
   /**
    * @brief if opcode is not registered in table of opcodes add it


### PR DESCRIPTION
This commit will decrease model size by following optimizations
- Remove redundant empty buffers
- Remove redundant buffers with same values

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>