### PR TITLE
[onert/cpu] Support rank/shape for all type

### DIFF
--- a/runtime/onert/backend/cpu/ops/RankLayer.cc
+++ b/runtime/onert/backend/cpu/ops/RankLayer.cc
@@ -40,15 +40,8 @@ void RankLayer::configure(const IPortableTensor *input, IPortableTensor *output)
 
 void RankLayer::run()
 {
-  if (_input->data_type() == OperandType::FLOAT32 || _input->data_type() == OperandType::INT32)
-  {
-    int32_t *output_data = reinterpret_cast<int32_t *>(_output->buffer());
-    output_data[0] = _input->num_dimensions();
-  }
-  else
-  {
-    throw std::runtime_error{"Rank : unsupported data type"};
-  }
+  int32_t *output_data = reinterpret_cast<int32_t *>(_output->buffer());
+  output_data[0] = _input->num_dimensions();
 }
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/ShapeLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ShapeLayer.cc
@@ -40,7 +40,13 @@ template <typename T> void GetRawShape(const IPortableTensor *input, T *output_d
   }
 }
 
-void ShapeLayer::shape()
+void ShapeLayer::configure(const IPortableTensor *input, IPortableTensor *output)
+{
+  _input = input;
+  _output = output;
+}
+
+void ShapeLayer::run()
 {
   if (_output->data_type() == OperandType::UINT32)
   {
@@ -50,28 +56,13 @@ void ShapeLayer::shape()
   {
     GetRawShape(_input, reinterpret_cast<int32_t *>(_output->buffer()));
   }
+  else if (_output->data_type() == OperandType::INT64)
+  {
+    GetRawShape(_input, reinterpret_cast<int64_t *>(_output->buffer()));
+  }
   else
   {
     throw std::runtime_error{"NYI : not supported output type for ShapeLayer"};
-  }
-}
-
-void ShapeLayer::configure(const IPortableTensor *input, IPortableTensor *output)
-{
-  _input = input;
-  _output = output;
-}
-
-void ShapeLayer::run()
-{
-  if (_input->data_type() == OperandType::FLOAT32 || _input->data_type() == OperandType::INT32 ||
-      _input->data_type() == OperandType::QUANT_UINT8_ASYMM)
-  {
-    shape();
-  }
-  else
-  {
-    throw std::runtime_error{"Shape : unsupported data type"};
   }
 }
 

--- a/runtime/onert/backend/cpu/ops/ShapeLayer.h
+++ b/runtime/onert/backend/cpu/ops/ShapeLayer.h
@@ -36,8 +36,6 @@ public:
   ShapeLayer();
 
 public:
-  void shape();
-
   void configure(const IPortableTensor *input, IPortableTensor *output);
 
   void run() override;

--- a/runtime/onert/core/src/ir/OperationValidator.cc
+++ b/runtime/onert/core/src/ir/OperationValidator.cc
@@ -175,6 +175,13 @@ void OperationValidator::visit(const ir::operation::Pad &node)
   OP_REQUIRES(_ctx.at(pad_index).typeInfo().type() == ir::DataType::INT32);
 }
 
+void OperationValidator::visit(const ir::operation::Rank &node)
+{
+  const auto output_index{node.getOutputs().at(0)};
+
+  OP_REQUIRES(_ctx.at(output_index).typeInfo().type() == ir::DataType::INT32);
+}
+
 void OperationValidator::visit(const ir::operation::ResizeBilinear &node)
 {
   auto align_corners = node.param().align_corners;
@@ -191,6 +198,15 @@ void OperationValidator::visit(const ir::operation::Reverse &node)
 
   OP_REQUIRES(_ctx.at(axis_index).typeInfo().type() == ir::DataType::INT32);
   OP_REQUIRES(_ctx.at(output_index).typeInfo().type() == _ctx.at(input_index).typeInfo().type());
+}
+
+void OperationValidator::visit(const ir::operation::Shape &node)
+{
+  const auto output_index{node.getOutputs().at(0)};
+
+  OP_REQUIRES((_ctx.at(output_index).typeInfo().type() == ir::DataType::UINT32) ||
+              (_ctx.at(output_index).typeInfo().type() == ir::DataType::INT32) ||
+              (_ctx.at(output_index).typeInfo().type() == ir::DataType::INT64));
 }
 
 void OperationValidator::visit(const ir::operation::SpaceToBatchND &node)

--- a/runtime/onert/core/src/ir/OperationValidator.h
+++ b/runtime/onert/core/src/ir/OperationValidator.h
@@ -58,12 +58,14 @@ public:
   void visit(const ir::operation::Pad &node) override;
   void visit(const ir::operation::ResizeBilinear &node) override;
   void visit(const ir::operation::Reverse &node) override;
+  void visit(const ir::operation::Shape &node) override;
   void visit(const ir::operation::Select &node) override;
   void visit(const ir::operation::SpaceToBatchND &node) override;
   void visit(const ir::operation::SpaceToDepth &node) override;
   void visit(const ir::operation::Split &node) override;
   void visit(const ir::operation::SquaredDifference &node) override;
   void visit(const ir::operation::StridedSlice &node) override;
+  void visit(const ir::operation::Rank &node) override;
   void visit(const ir::operation::TransposeConv &node) override;
   void visit(const ir::operation::Unpack &node) override;
   void visit(const ir::operation::While &node) override;

--- a/tests/nnfw_api/src/CircleGen.cc
+++ b/tests/nnfw_api/src/CircleGen.cc
@@ -258,6 +258,13 @@ uint32_t CircleGen::addOperatorReverseV2(const OperatorParams &params)
                                 circle::BuiltinOptions_ReverseV2Options, options);
 }
 
+uint32_t CircleGen::addOperatorShape(const OperatorParams &params, circle::TensorType type)
+{
+  auto options = circle::CreateShapeOptions(_fbb, type).Union();
+  return addOperatorWithOptions(params, circle::BuiltinOperator_SHAPE,
+                                circle::BuiltinOptions_RankOptions, options);
+}
+
 uint32_t CircleGen::addOperatorSelect(const OperatorParams &params)
 {
   auto options = circle::CreateSelectOptions(_fbb).Union();

--- a/tests/nnfw_api/src/CircleGen.h
+++ b/tests/nnfw_api/src/CircleGen.h
@@ -171,6 +171,8 @@ public:
                                      bool half_pixel_centers = false);
   uint32_t addOperatorResizeNearestNeighbor(const OperatorParams &params);
   uint32_t addOperatorReverseV2(const OperatorParams &params);
+  uint32_t addOperatorShape(const OperatorParams &params,
+                            circle::TensorType type = circle::TensorType::TensorType_INT32);
   uint32_t addOperatorSelect(const OperatorParams &params);
   uint32_t addOperatorSelectV2(const OperatorParams &params);
   uint32_t addOperatorSplit(const OperatorParams &params, int32_t num_split);

--- a/tests/nnfw_api/src/one_op_tests/Shape.cc
+++ b/tests/nnfw_api/src/one_op_tests/Shape.cc
@@ -17,49 +17,51 @@
 #include "GenModelTest.h"
 
 // WORKAROUND Handle int32_t type input/output
-TEST_F(GenModelTest, OneOp_Rank)
+TEST_F(GenModelTest, OneOp_Shape)
 {
   CircleGen cgen;
   int in = cgen.addTensor({{1, 3, 3, 2}, circle::TensorType::TensorType_FLOAT32});
-  int out = cgen.addTensor({{1}, circle::TensorType::TensorType_INT32});
+  int out = cgen.addTensor({{4}, circle::TensorType::TensorType_INT32});
 
-  cgen.addOperatorRank({{in}, {out}});
+  cgen.addOperatorShape({{in}, {out}}, circle::TensorType::TensorType_INT32);
   cgen.setInputsAndOutputs({in}, {out});
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
   TestCaseData tcd;
   tcd.addInput(std::vector<float>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18});
-  tcd.addOutput(std::vector<int32_t>{4});
+  tcd.addOutput(std::vector<int32_t>{1, 3, 3, 2});
   _context->addTestCase(tcd);
   _context->setBackends({"cpu"});
 
   SUCCEED();
 }
 
-TEST_F(GenModelTest, OneOp_Rank_Int32)
+TEST_F(GenModelTest, OneOp_Shape_Int64)
 {
   CircleGen cgen;
-  int in = cgen.addTensor({{1, 3, 3, 2}, circle::TensorType::TensorType_INT32});
-  int out = cgen.addTensor({{1}, circle::TensorType::TensorType_INT32});
+  int in = cgen.addTensor({{1, 3, 3, 2}, circle::TensorType::TensorType_FLOAT32});
+  int out = cgen.addTensor({{1}, circle::TensorType::TensorType_INT64});
 
   // TODO handle many type in addTestCase
-  cgen.addOperatorRank({{in}, {out}});
+  cgen.addOperatorShape({{in}, {out}}, circle::TensorType::TensorType_INT64);
   cgen.setInputsAndOutputs({in}, {out});
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
-  _context->addTestCase(uniformTCD<int32_t>(
-      {{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18}}, {{4}}));
+  TestCaseData tcd;
+  tcd.addInput(std::vector<float>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18});
+  tcd.addOutput(std::vector<int64_t>{1, 3, 3, 2});
+  _context->addTestCase(tcd);
   _context->setBackends({"cpu"});
 
   SUCCEED();
 }
 
-TEST_F(GenModelTest, neg_OneOp_Rank_OutType)
+TEST_F(GenModelTest, neg_OneOp_Shape_OutType)
 {
   CircleGen cgen;
   int in = cgen.addTensor({{1, 3, 3, 2}, circle::TensorType::TensorType_INT32});
   int out = cgen.addTensor({{1}, circle::TensorType::TensorType_UINT8});
 
   // TODO handle many type in addTestCase
-  cgen.addOperatorRank({{in}, {out}});
+  cgen.addOperatorShape({{in}, {out}});
   cgen.setInputsAndOutputs({in}, {out});
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
   _context->expectFailModelLoad();


### PR DESCRIPTION
- Support rank/shape for all input type
- Check output type in OperationValidator
- Add 2 positive / 2 negative test

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>