### PR TITLE
[nnfwapi] Test: add internal API test

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -779,7 +779,9 @@ NNFW_STATUS nnfw_session::get_config(const char *key, char *value, size_t value_
     return true;
   };
 
-  if (key == onert::util::config::BACKENDS)
+  const std::string skey = key;
+
+  if (skey == onert::util::config::BACKENDS)
   {
     if (options.backend_list.size() == 0)
       return NNFW_STATUS_NO_ERROR; // no setting backend is not an error of get_config_str()
@@ -791,7 +793,7 @@ NNFW_STATUS nnfw_session::get_config(const char *key, char *value, size_t value_
 
     strncpy(value, str.c_str(), value_size);
   }
-  else if (key == onert::util::config::EXECUTOR)
+  else if (skey == onert::util::config::EXECUTOR)
   {
     if (!check_boundary(value_size, options.executor))
       return NNFW_STATUS_ERROR;

--- a/tests/nnfw_api/src/ValidationTestAddModelLoaded.cc
+++ b/tests/nnfw_api/src/ValidationTestAddModelLoaded.cc
@@ -17,6 +17,8 @@
 #include "fixtures.h"
 #include "NNPackages.h"
 
+#include "nnfw_internal.h"
+
 using ValidationTestAddModelLoaded = ValidationTestModelLoaded<NNPackages::ADD>;
 
 TEST_F(ValidationTestAddModelLoaded, prepare_001)
@@ -189,4 +191,60 @@ TEST_F(ValidationTestAddModelLoaded, neg_experimental_output_no_such_name)
   uint32_t ind = 999;
   ASSERT_EQ(nnfw_output_tensorindex(_session, "NO_SUCH_TENSOR_NAME", &ind), NNFW_STATUS_ERROR);
   ASSERT_EQ(ind, 999);
+}
+
+TEST_F(ValidationTestAddModelLoaded, debug_set_config)
+{
+  // At least one test for all valid keys
+  NNFW_ENSURE_SUCCESS(nnfw_set_config(_session, "TRACE_FILEPATH", ""));
+  NNFW_ENSURE_SUCCESS(nnfw_set_config(_session, "GRAPH_DOT_DUMP", "0"));
+  NNFW_ENSURE_SUCCESS(nnfw_set_config(_session, "GRAPH_DOT_DUMP", "1"));
+  NNFW_ENSURE_SUCCESS(nnfw_set_config(_session, "GRAPH_DOT_DUMP", "2"));
+  NNFW_ENSURE_SUCCESS(nnfw_set_config(_session, "OP_SEQ_MAX_NODE", "0"));
+  NNFW_ENSURE_SUCCESS(nnfw_set_config(_session, "OP_SEQ_MAX_NODE", "1"));
+  NNFW_ENSURE_SUCCESS(nnfw_set_config(_session, "EXECUTOR", "Linear"));
+  NNFW_ENSURE_SUCCESS(nnfw_set_config(_session, "OP_BACKEND_ALLOPS", "cpu"));
+  NNFW_ENSURE_SUCCESS(nnfw_set_config(_session, "USE_SCHEDULER", "0"));
+  NNFW_ENSURE_SUCCESS(nnfw_set_config(_session, "USE_SCHEDULER", "1"));
+  NNFW_ENSURE_SUCCESS(nnfw_set_config(_session, "PROFILING_MODE", "0"));
+  NNFW_ENSURE_SUCCESS(nnfw_set_config(_session, "PROFILING_MODE", "1"));
+  NNFW_ENSURE_SUCCESS(nnfw_set_config(_session, "DISABLE_COMPILE", "0"));
+  NNFW_ENSURE_SUCCESS(nnfw_set_config(_session, "DISABLE_COMPILE", "1"));
+  SUCCEED();
+}
+
+TEST_F(ValidationTestAddModelLoaded, neg_debug_set_config)
+{
+  // unexpected null args
+  ASSERT_EQ(nnfw_set_config(_session, nullptr, "1"), NNFW_STATUS_UNEXPECTED_NULL);
+  ASSERT_EQ(nnfw_set_config(_session, "EXECUTOR", nullptr), NNFW_STATUS_UNEXPECTED_NULL);
+
+  // wrong keys
+  ASSERT_EQ(nnfw_set_config(_session, "", "1"), NNFW_STATUS_ERROR);
+  ASSERT_EQ(nnfw_set_config(_session, "BAD_KEY", "1"), NNFW_STATUS_ERROR);
+}
+
+TEST_F(ValidationTestAddModelLoaded, debug_get_config)
+{
+  // At least one test for all valid keys
+  char buf[1024];
+  NNFW_ENSURE_SUCCESS(nnfw_get_config(_session, "EXECUTOR", buf, sizeof(buf)));
+  NNFW_ENSURE_SUCCESS(nnfw_get_config(_session, "BACKENDS", buf, sizeof(buf)));
+  SUCCEED();
+}
+
+TEST_F(ValidationTestAddModelLoaded, neg_debug_get_config)
+{
+  // unexpected null args
+  char buf[1024];
+  ASSERT_EQ(nnfw_get_config(_session, nullptr, buf, sizeof(buf)), NNFW_STATUS_UNEXPECTED_NULL);
+  ASSERT_EQ(nnfw_get_config(_session, "EXECUTOR", nullptr, 0), NNFW_STATUS_UNEXPECTED_NULL);
+
+  // buffer is too small
+  ASSERT_EQ(nnfw_get_config(_session, "EXECUTOR", buf, 1), NNFW_STATUS_ERROR);
+  ASSERT_EQ(nnfw_get_config(_session, "BACKENDS", buf, 1), NNFW_STATUS_ERROR);
+
+  // wrong keys
+  ASSERT_EQ(nnfw_get_config(_session, "", buf, sizeof(buf)), NNFW_STATUS_ERROR);
+  ASSERT_EQ(nnfw_get_config(_session, "BAD_KEY", buf, sizeof(buf)), NNFW_STATUS_ERROR);
 }


### PR DESCRIPTION
- Fix bug in `nnfw_get_config`
    - Compared two char ptrs, not the values
- Add tests for `nnfw_get_config`
- Add tests for `nnfw_set_config`

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>