### PR TITLE
[onert] Fix DotDumper undefined operands

### DIFF
--- a/runtime/onert/core/src/dumper/dot/DotDumper.cc
+++ b/runtime/onert/core/src/dumper/dot/DotDumper.cc
@@ -139,7 +139,7 @@ void DotDumper::dump(const std::string &tag)
       input_node->addOutEdge(node.get());
     }
 
-    for (auto output : op.getOutputs())
+    for (auto output : op.getOutputs() | ir::Remove::UNDEFINED)
     {
       using onert::dumper::dot::Operand;
       auto &output_node = operand_nodes.at(output);


### PR DESCRIPTION
Fix DotDumper when handling undefined operands - do not add undefined
operands to operand list.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>