### PR TITLE
[onert] Fix dynamic shape inference of ArgMax

### DIFF
--- a/runtime/onert/core/src/exec/DynamicShapeInferer.cc
+++ b/runtime/onert/core/src/exec/DynamicShapeInferer.cc
@@ -103,7 +103,7 @@ void DynamicShapeInferer::visit(const ir::operation::ArgMax &op)
   auto output_ind = op.getOutputs().at(0);
   auto output = _tensor_registry->getITensor(output_ind);
 
-  if (!input->is_dynamic())
+  if (!input->is_dynamic() && !output->is_dynamic())
     return;
 
   auto input_shape = input->getShape();


### PR DESCRIPTION
Fix dynamic shape inference of ArgMax. The shape could change depending
on the value of axis. So if output is dynamic we should do shape
inference again.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>