### PR TITLE
[luci-interpreter] Add NEG tc for Pow kernel

### DIFF
--- a/compiler/luci-interpreter/src/kernels/Pow.cpp
+++ b/compiler/luci-interpreter/src/kernels/Pow.cpp
@@ -34,6 +34,7 @@ Pow::Pow(const Tensor *input1, const Tensor *input2, Tensor *output)
 void Pow::configure()
 {
   LUCI_INTERPRETER_CHECK(input1()->element_type() == input2()->element_type());
+  LUCI_INTERPRETER_CHECK(input1()->element_type() == output()->element_type());
 
   output()->resize(calculateShapeForBroadcast(input1()->shape(), input2()->shape()));
 }

--- a/compiler/luci-interpreter/src/kernels/Pow.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/Pow.test.cpp
@@ -86,21 +86,21 @@ TEST(PowTest, IntPow)
   EXPECT_THAT(extractTensorShape(output_tensor), ::testing::ElementsAreArray(base_shape));
 }
 
-TEST(PowTest, Input_Type_Mismatch_NEG)
-{
-  Tensor input1_tensor = makeInputTensor<DataType::FLOAT32>({1}, {1.0f});
-  Tensor input2_tensor = makeInputTensor<DataType::S32>({1}, {4});
-  Tensor output_tensor = makeOutputTensor(DataType::FLOAT32);
-
-  Pow kernel(&input1_tensor, &input2_tensor, &output_tensor);
-  EXPECT_ANY_THROW(kernel.configure());
-}
-
 TEST(PowTest, Input_Output_Type_NEG)
 {
   Tensor input1_tensor = makeInputTensor<DataType::FLOAT32>({1}, {1.0f});
   Tensor input2_tensor = makeInputTensor<DataType::FLOAT32>({1}, {1.0f});
   Tensor output_tensor = makeOutputTensor(DataType::BOOL);
+
+  Pow kernel(&input1_tensor, &input2_tensor, &output_tensor);
+  EXPECT_ANY_THROW(kernel.configure());
+}
+
+TEST(PowTest, Input_Type_Mismatch_NEG)
+{
+  Tensor input1_tensor = makeInputTensor<DataType::FLOAT32>({1}, {1.0f});
+  Tensor input2_tensor = makeInputTensor<DataType::S32>({1}, {4});
+  Tensor output_tensor = makeOutputTensor(DataType::FLOAT32);
 
   Pow kernel(&input1_tensor, &input2_tensor, &output_tensor);
   EXPECT_ANY_THROW(kernel.configure());

--- a/compiler/luci-interpreter/src/kernels/Pow.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/Pow.test.cpp
@@ -106,7 +106,6 @@ TEST(PowTest, Input_Output_Type_NEG)
   EXPECT_ANY_THROW(kernel.configure());
 }
 
-
 TEST(PowTest, Invalid_Input_Type_NEG)
 {
   Tensor input1_tensor = makeInputTensor<DataType::S64>({1}, {1});

--- a/compiler/luci-interpreter/src/kernels/Pow.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/Pow.test.cpp
@@ -86,7 +86,7 @@ TEST(PowTest, IntPow)
   EXPECT_THAT(extractTensorShape(output_tensor), ::testing::ElementsAreArray(base_shape));
 }
 
-TEST(PowTest, Input_Output_Type_NEG)
+TEST(PowTest, Input_Type_Mismatch_NEG)
 {
   Tensor input1_tensor = makeInputTensor<DataType::FLOAT32>({1}, {1.0f});
   Tensor input2_tensor = makeInputTensor<DataType::S32>({1}, {4});
@@ -94,6 +94,28 @@ TEST(PowTest, Input_Output_Type_NEG)
 
   Pow kernel(&input1_tensor, &input2_tensor, &output_tensor);
   EXPECT_ANY_THROW(kernel.configure());
+}
+
+TEST(PowTest, Input_Output_Type_NEG)
+{
+  Tensor input1_tensor = makeInputTensor<DataType::FLOAT32>({1}, {1.0f});
+  Tensor input2_tensor = makeInputTensor<DataType::FLOAT32>({1}, {1.0f});
+  Tensor output_tensor = makeOutputTensor(DataType::BOOL);
+
+  Pow kernel(&input1_tensor, &input2_tensor, &output_tensor);
+  EXPECT_ANY_THROW(kernel.configure());
+}
+
+
+TEST(PowTest, Invalid_Input_Type_NEG)
+{
+  Tensor input1_tensor = makeInputTensor<DataType::S64>({1}, {1});
+  Tensor input2_tensor = makeInputTensor<DataType::S64>({1}, {1});
+  Tensor output_tensor = makeOutputTensor(DataType::S64);
+
+  Pow kernel(&input1_tensor, &input2_tensor, &output_tensor);
+  kernel.configure();
+  EXPECT_ANY_THROW(kernel.execute());
 }
 
 } // namespace


### PR DESCRIPTION
Parent Issue: #1623
Fired Issue: #4762 

This commit adds negative test cases for `Pow` kernel.
Also added `LUCI_INTERPRETER_CHECK` for output type.

This commit have been tested on my PC,
and worked well by passing `./nncc build` & `./nncc test`.

Please review this PR, @seanshpark @jinevening @llFreetimell .
I'll be happy to get feedback and change to make improvement.

Thank you.

(Derived from SOS Mine Project)

Signed-off-by: underflow101 <ikarus125@gmail.com>