### PR TITLE
[onert] Renaming expect_error_on_run() method

### DIFF
--- a/tests/nnfw_api/src/GenModelTest.h
+++ b/tests/nnfw_api/src/GenModelTest.h
@@ -80,11 +80,10 @@ struct TestCaseData
   template <typename T> void addOutput(const std::vector<T> &data) { addData(outputs, data); }
 
   /**
-   * @brief Set @c True if @c NNFW_STATUS_ERROR is expected after calling @c nnfw_run() with
-   *        this test case; set @c False otherwise.
+   * @brief Call this when @c nnfw_run() for this test case is expected to be failed
    */
-  void expect_error_on_run(bool expect_error_on_run) { _expect_error_on_run = expect_error_on_run; }
-  bool expect_error_on_run() const { return _expect_error_on_run; }
+  void expectFailRun() { _expected_fail_run = true; }
+  bool expected_fail_run() const { return _expected_fail_run; }
 
 private:
   template <typename T>
@@ -96,7 +95,7 @@ private:
     std::memcpy(dest.back().data(), data.data(), size);
   }
 
-  bool _expect_error_on_run = false;
+  bool _expected_fail_run = false;
 };
 
 template <>
@@ -350,7 +349,7 @@ protected:
           memcpy(_so.inputs[i].data(), ref_inputs[i].data(), ref_inputs[i].size());
         }
 
-        if (test_case.expect_error_on_run())
+        if (test_case.expected_fail_run())
         {
           ASSERT_EQ(nnfw_run(_so.session), NNFW_STATUS_ERROR);
           continue;

--- a/tests/nnfw_api/src/GenModelTests.cc
+++ b/tests/nnfw_api/src/GenModelTests.cc
@@ -283,7 +283,7 @@ TEST_F(GenModelTest, neg_Reshape_without_shape_param)
   CircleGen::Shape wrong_new_shape_val{2, 3};
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
   auto tc = uniformTCD<int32_t>({{1, 2, 3, 4}, wrong_new_shape_val}, {{1, 2, 3, 4}});
-  tc.expect_error_on_run(true);
+  tc.expectFailRun();
   _context->addTestCase(tc);
   _context->setBackends({"cpu" /* "acl_cl", "acl_neon" does not support dynamic tensor */});
 

--- a/tests/nnfw_api/src/ModelTestDynamicTensor.cc
+++ b/tests/nnfw_api/src/ModelTestDynamicTensor.cc
@@ -111,7 +111,7 @@ TEST_F(GenModelTest, neg_reshape_from_2x3_to_wrong_3x3)
     TestCaseData tcd;
     tcd.addInput(wrong_shape);
     tcd.addOutput(expected);
-    tcd.expect_error_on_run(true);
+    tcd.expectFailRun();
 
     _context->addTestCase(tcd);
     _context->setBackends({"cpu"}); // Currently, dynamic tensor runs on "cpu" only
@@ -151,21 +151,22 @@ TEST_F(GenModelTest, neg_reshape_multiple_executions)
   std::vector<int> new_shape;
   std::vector<float> expected = {-1.5, -1.0, -0.5, 0.5, 1.0, 1.5};
 
-  auto add_tcd = [&](const decltype(new_shape) &&new_shape, bool expect_error_on_run) {
+  auto add_tcd = [&](const decltype(new_shape) &&new_shape, bool expect_fail_on_run) {
     TestCaseData tcd;
     tcd.addInput(new_shape);
     tcd.addOutput(expected);
-    tcd.expect_error_on_run(expect_error_on_run);
+    if (expect_fail_on_run)
+      tcd.expectFailRun();
     _context->addTestCase(tcd);
   };
 
   _context = std::make_unique<GenModelTestContext>(build_dynamic_Reshape());
   {
-    bool EXPECT_ERROR_ON_RUN = true;
-    bool EXPECT_SUCCESS_ON_RUN = !EXPECT_ERROR_ON_RUN;
+    bool EXPECT_FAIL_ON_RUN = true;
+    bool EXPECT_SUCCESS_ON_RUN = !EXPECT_FAIL_ON_RUN;
 
     add_tcd({3, 2}, EXPECT_SUCCESS_ON_RUN);
-    add_tcd({1, 100}, EXPECT_ERROR_ON_RUN); // 1th tcd. wrong shape
+    add_tcd({1, 100}, EXPECT_FAIL_ON_RUN); // 1th tcd. wrong shape
     add_tcd({6, 1}, EXPECT_SUCCESS_ON_RUN);
 
     _context->setBackends({"cpu"}); // Currently, dynamic tensor runs on "cpu" only


### PR DESCRIPTION
Rename `expect_error_on_run()` method and related variables to sync
the names with `expectFailCompile()` and `expectFailModelLoading()`.

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>