### PR TITLE
[onert] Support Int64 for Fill operation

### DIFF
--- a/runtime/onert/backend/cpu/ops/FillLayer.cc
+++ b/runtime/onert/backend/cpu/ops/FillLayer.cc
@@ -58,6 +58,12 @@ void FillLayer::run()
                                   getTensorShape(_output),
                                   reinterpret_cast<int32_t *>(_output->buffer()));
       break;
+    case OperandType::INT64:
+      nnfw::cker::Fill<int64_t *>(getTensorShape(_input), reinterpret_cast<int *>(_input->buffer()),
+                                  reinterpret_cast<int64_t *>(_value->buffer()),
+                                  getTensorShape(_output),
+                                  reinterpret_cast<int64_t *>(_output->buffer()));
+      break;
     case OperandType::UINT32:
       nnfw::cker::Fill<uint32_t *>(
           getTensorShape(_input), reinterpret_cast<int *>(_input->buffer()),

--- a/tests/nnfw_api/src/CircleGen.cc
+++ b/tests/nnfw_api/src/CircleGen.cc
@@ -155,6 +155,13 @@ uint32_t CircleGen::addOperatorFullyConnected(const OperatorParams &params)
                                 circle::BuiltinOptions_FullyConnectedOptions, options);
 }
 
+uint32_t CircleGen::addOperatorFill(const OperatorParams &params)
+{
+  auto options = circle::CreateFillOptions(_fbb).Union();
+  return addOperatorWithOptions(params, circle::BuiltinOperator_FILL,
+                                circle::BuiltinOptions_FillOptions, options);
+}
+
 uint32_t CircleGen::addOperatorL2Normalization(const OperatorParams &params)
 {
   auto options = circle::CreateL2NormOptions(_fbb).Union();

--- a/tests/nnfw_api/src/CircleGen.h
+++ b/tests/nnfw_api/src/CircleGen.h
@@ -149,6 +149,7 @@ public:
   uint32_t addOperatorCos(const OperatorParams &params);
   uint32_t addOperatorEqual(const OperatorParams &params);
   uint32_t addOperatorFullyConnected(const OperatorParams &params);
+  uint32_t addOperatorFill(const OperatorParams &params);
   uint32_t addOperatorIf(const OperatorParams &params, uint32_t then_subg, uint32_t else_subg);
   uint32_t addOperatorInstanceNorm(const OperatorParams &params, float epsilon,
                                    circle::ActivationFunctionType actfn);

--- a/tests/nnfw_api/src/CircleGen.h
+++ b/tests/nnfw_api/src/CircleGen.h
@@ -148,8 +148,8 @@ public:
                                     circle::ActivationFunctionType actfn);
   uint32_t addOperatorCos(const OperatorParams &params);
   uint32_t addOperatorEqual(const OperatorParams &params);
-  uint32_t addOperatorFullyConnected(const OperatorParams &params);
   uint32_t addOperatorFill(const OperatorParams &params);
+  uint32_t addOperatorFullyConnected(const OperatorParams &params);
   uint32_t addOperatorIf(const OperatorParams &params, uint32_t then_subg, uint32_t else_subg);
   uint32_t addOperatorInstanceNorm(const OperatorParams &params, float epsilon,
                                    circle::ActivationFunctionType actfn);

--- a/tests/nnfw_api/src/one_op_tests/Fill.cc
+++ b/tests/nnfw_api/src/one_op_tests/Fill.cc
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "GenModelTest.h"
+
+TEST_F(GenModelTest, OneOp_Fill_Int32)
+{
+  CircleGen cgen;
+  std::vector<int32_t> value_data{13};
+  uint32_t value_buf = cgen.addBuffer(value_data);
+
+  int in = cgen.addTensor({{2}, circle::TensorType::TensorType_INT32});
+  int value = cgen.addTensor({{1}, circle::TensorType::TensorType_INT32, value_buf});
+  int out = cgen.addTensor({{2, 3}, circle::TensorType::TensorType_INT32});
+  cgen.addOperatorFill({{in, value}, {out}});
+  cgen.setInputsAndOutputs({in}, {out});
+
+  TestCaseData tcd;
+  tcd.addInput(std::vector<int32_t>{2, 3});
+  tcd.addOutput(std::vector<int32_t>{13, 13, 13, 13, 13, 13});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->addTestCase(tcd);
+  _context->setBackends({"cpu"});
+
+  SUCCEED();
+}
+
+TEST_F(GenModelTest, OneOp_Fill_Int64)
+{
+  CircleGen cgen;
+  std::vector<int64_t> value_data{13};
+  uint32_t value_buf = cgen.addBuffer(value_data);
+
+  int in = cgen.addTensor({{2}, circle::TensorType::TensorType_INT32});
+  int value = cgen.addTensor({{1}, circle::TensorType::TensorType_INT64, value_buf});
+  int out = cgen.addTensor({{2, 3}, circle::TensorType::TensorType_INT64});
+  cgen.addOperatorFill({{in, value}, {out}});
+  cgen.setInputsAndOutputs({in}, {out});
+
+  TestCaseData tcd;
+  tcd.addInput(std::vector<int32_t>{2, 3});
+  tcd.addOutput(std::vector<int64_t>{13, 13, 13, 13, 13, 13});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->addTestCase(tcd);
+  _context->setBackends({"cpu"});
+
+  SUCCEED();
+}
+
+TEST_F(GenModelTest, OneOp_Fill_Float32)
+{
+  CircleGen cgen;
+  std::vector<float> value_data{1.3};
+  uint32_t value_buf = cgen.addBuffer(value_data);
+
+  int in = cgen.addTensor({{2}, circle::TensorType::TensorType_INT32});
+  int value = cgen.addTensor({{1}, circle::TensorType::TensorType_FLOAT32, value_buf});
+  int out = cgen.addTensor({{2, 3}, circle::TensorType::TensorType_FLOAT32});
+  cgen.addOperatorFill({{in, value}, {out}});
+  cgen.setInputsAndOutputs({in}, {out});
+
+  TestCaseData tcd;
+  tcd.addInput(std::vector<int32_t>{2, 3});
+  tcd.addOutput(std::vector<float>{1.3, 1.3, 1.3, 1.3, 1.3, 1.3});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->addTestCase(tcd);
+  _context->setBackends({"cpu"});
+
+  SUCCEED();
+}
+
+TEST_F(GenModelTest, neg_OneOp_Fill_Int32_oneoperand)
+{
+  CircleGen cgen;
+
+  int in = cgen.addTensor({{2}, circle::TensorType::TensorType_INT32});
+  int out = cgen.addTensor({{2, 3}, circle::TensorType::TensorType_INT32});
+  cgen.addOperatorFill({{in}, {out}});
+  cgen.setInputsAndOutputs({in}, {out});
+
+  TestCaseData tcd;
+  tcd.addInput(std::vector<int32_t>{2, 3});
+  tcd.addOutput(std::vector<int32_t>{13, 13, 13, 13, 13, 13});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->addTestCase(tcd);
+  _context->setBackends({"cpu"});
+  _context->expectFailModelLoad();
+
+  SUCCEED();
+}
+
+TEST_F(GenModelTest, neg_OneOp_Fill_Int64_oneoperand)
+{
+  CircleGen cgen;
+
+  int in = cgen.addTensor({{2}, circle::TensorType::TensorType_INT32});
+  int out = cgen.addTensor({{2, 3}, circle::TensorType::TensorType_INT64});
+  cgen.addOperatorFill({{in}, {out}});
+  cgen.setInputsAndOutputs({in}, {out});
+
+  TestCaseData tcd;
+  tcd.addInput(std::vector<int32_t>{2, 3});
+  tcd.addOutput(std::vector<int64_t>{13, 13, 13, 13, 13, 13});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->addTestCase(tcd);
+  _context->setBackends({"cpu"});
+  _context->expectFailModelLoad();
+
+  SUCCEED();
+}
+
+TEST_F(GenModelTest, neg_OneOp_Fill_Float32_oneoperand)
+{
+  CircleGen cgen;
+
+  int in = cgen.addTensor({{2}, circle::TensorType::TensorType_INT32});
+  int out = cgen.addTensor({{2, 3}, circle::TensorType::TensorType_FLOAT32});
+  cgen.addOperatorFill({{in}, {out}});
+  cgen.setInputsAndOutputs({in}, {out});
+
+  TestCaseData tcd;
+  tcd.addInput(std::vector<int32_t>{2, 3});
+  tcd.addOutput(std::vector<float>{1.3, 1.3, 1.3, 1.3, 1.3, 1.3});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->addTestCase(tcd);
+  _context->setBackends({"cpu"});
+  _context->expectFailModelLoad();
+
+  SUCCEED();
+}


### PR DESCRIPTION
This commit will enable supporting `Int64` for `Fill` operation
and add related test cases

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>