### PR TITLE
[onert] Reduce namespace in OperationValidator

### DIFF
--- a/runtime/onert/core/src/ir/OperationValidator.cc
+++ b/runtime/onert/core/src/ir/OperationValidator.cc
@@ -30,8 +30,7 @@ namespace onert
 namespace ir
 {
 
-OperationValidator::OperationValidator(const ir::Graph &graph)
-    : _graph{graph}, _ctx{graph.operands()}
+OperationValidator::OperationValidator(const Graph &graph) : _graph{graph}, _ctx{graph.operands()}
 {
 }
 
@@ -40,31 +39,31 @@ void OperationValidator::operator()()
   assert(_graph.subgraphs() == nullptr);
 
   _graph.operations().iterate(
-      [&](const ir::OperationIndex &, const ir::Operation &node) { node.accept(*this); });
+      [&](const OperationIndex &, const Operation &node) { node.accept(*this); });
 }
 
-ir::DataType OperationValidator::operandType(const ir::OperandIndex &idx)
+DataType OperationValidator::operandType(const OperandIndex &idx)
 {
   return _graph.operands().at(idx).typeInfo().type();
 }
 
-bool OperationValidator::isConstant(const ir::OperandIndex &idx)
+bool OperationValidator::isConstant(const OperandIndex &idx)
 {
   return _graph.operands().at(idx).isConstant();
 }
 
-bool OperationValidator::isSameType(const ir::OperandIndex &idx1, const ir::OperandIndex &idx2)
+bool OperationValidator::isSameType(const OperandIndex &idx1, const OperandIndex &idx2)
 {
   return operandType(idx1) == operandType(idx2);
 }
 
-bool OperationValidator::isValidType(const ir::OperandIndex &idx, const ir::DataType &type)
+bool OperationValidator::isValidType(const OperandIndex &idx, const DataType &type)
 {
   return operandType(idx) == type;
 }
 
-bool OperationValidator::isValidType(const ir::OperandIndex &idx,
-                                     std::initializer_list<ir::DataType> valid_types)
+bool OperationValidator::isValidType(const OperandIndex &idx,
+                                     std::initializer_list<DataType> valid_types)
 {
   for (auto type_to_check : valid_types)
   {
@@ -77,63 +76,62 @@ bool OperationValidator::isValidType(const ir::OperandIndex &idx,
   return false;
 }
 
-void OperationValidator::visit(const ir::operation::AddN &node)
+void OperationValidator::visit(const operation::AddN &node)
 {
   int size = node.getInputs().size();
   for (int i = 0; i < size; i++)
   {
     const auto input_index(node.getInputs().at(i));
-    OP_REQUIRES(isValidType(input_index, {ir::DataType::FLOAT32, ir::DataType::INT32}));
+    OP_REQUIRES(isValidType(input_index, {DataType::FLOAT32, DataType::INT32}));
   }
 }
 
-void OperationValidator::visit(const ir::operation::BatchMatMul &node)
+void OperationValidator::visit(const operation::BatchMatMul &node)
 {
-  const auto lhs_index(node.getInputs().at(ir::operation::BatchMatMul::Input::LHS));
-  const auto rhs_index(node.getInputs().at(ir::operation::BatchMatMul::Input::RHS));
+  const auto lhs_index(node.getInputs().at(operation::BatchMatMul::Input::LHS));
+  const auto rhs_index(node.getInputs().at(operation::BatchMatMul::Input::RHS));
 
   // Constant lhs and rhs is not implemented yet
   OP_REQUIRES(!isConstant(lhs_index) && !isConstant(rhs_index));
 }
 
-void OperationValidator::visit(const ir::operation::BatchToSpaceND &node)
+void OperationValidator::visit(const operation::BatchToSpaceND &node)
 {
-  const auto block_size_index{
-      node.getInputs().at(ir::operation::BatchToSpaceND::Input::BLOCK_SIZE)};
+  const auto block_size_index{node.getInputs().at(operation::BatchToSpaceND::Input::BLOCK_SIZE)};
 
   // Non-constant block_size is not implemented yet
   OP_REQUIRES(isConstant(block_size_index));
 }
 
-void OperationValidator::visit(const ir::operation::BinaryArithmetic &node)
+void OperationValidator::visit(const operation::BinaryArithmetic &node)
 {
   const auto output_index{node.getOutputs().at(0)};
-  const auto lhs_index{node.getInputs().at(ir::operation::BinaryArithmetic::Input::LHS)};
-  const auto rhs_index{node.getInputs().at(ir::operation::BinaryArithmetic::Input::RHS)};
+  const auto lhs_index{node.getInputs().at(operation::BinaryArithmetic::Input::LHS)};
+  const auto rhs_index{node.getInputs().at(operation::BinaryArithmetic::Input::RHS)};
 
   OP_REQUIRES(isSameType(lhs_index, rhs_index));
   OP_REQUIRES(isSameType(lhs_index, output_index));
 }
 
-void OperationValidator::visit(const ir::operation::Comparison &node)
+void OperationValidator::visit(const operation::Comparison &node)
 {
   const auto output_index{node.getOutputs().at(0)};
 
-  const auto lhs_index{node.getInputs().at(ir::operation::Comparison::Input::INPUT0)};
-  const auto rhs_index{node.getInputs().at(ir::operation::Comparison::Input::INPUT1)};
+  const auto lhs_index{node.getInputs().at(operation::Comparison::Input::INPUT0)};
+  const auto rhs_index{node.getInputs().at(operation::Comparison::Input::INPUT1)};
 
   OP_REQUIRES(isSameType(lhs_index, rhs_index));
-  OP_REQUIRES(isValidType(output_index, ir::DataType::BOOL8));
+  OP_REQUIRES(isValidType(output_index, DataType::BOOL8));
 }
 
-void OperationValidator::visit(const ir::operation::DepthToSpace &node)
+void OperationValidator::visit(const operation::DepthToSpace &node)
 {
   int32_t block_size = node.param().block_size;
 
   OP_REQUIRES(block_size > 0);
 }
 
-void OperationValidator::visit(const ir::operation::ElementwiseActivation &node)
+void OperationValidator::visit(const operation::ElementwiseActivation &node)
 {
   const auto output_index{node.getOutputs().at(0)};
   const auto input_index{node.getInputs().at(0)};
@@ -142,91 +140,90 @@ void OperationValidator::visit(const ir::operation::ElementwiseActivation &node)
   OP_REQUIRES(isSameType(output_index, input_index));
 }
 
-void OperationValidator::visit(const ir::operation::ElementwiseBinary &node)
+void OperationValidator::visit(const operation::ElementwiseBinary &node)
 {
   const auto output_index{node.getOutputs().at(0)};
-  const auto lhs_index{node.getInputs().at(ir::operation::ElementwiseBinary::Input::LHS)};
-  const auto rhs_index{node.getInputs().at(ir::operation::ElementwiseBinary::Input::RHS)};
+  const auto lhs_index{node.getInputs().at(operation::ElementwiseBinary::Input::LHS)};
+  const auto rhs_index{node.getInputs().at(operation::ElementwiseBinary::Input::RHS)};
 
   OP_REQUIRES(isSameType(lhs_index, rhs_index));
   OP_REQUIRES(isSameType(lhs_index, output_index));
 }
 
-void OperationValidator::visit(const ir::operation::ElementwiseUnary &node)
+void OperationValidator::visit(const operation::ElementwiseUnary &node)
 {
   const auto output_index{node.getOutputs().at(0)};
-  const auto input_index{node.getInputs().at(ir::operation::ElementwiseUnary::Input::INPUT)};
+  const auto input_index{node.getInputs().at(operation::ElementwiseUnary::Input::INPUT)};
 
   // Check if I/O types match
-  if (node.param().op_type == ir::operation::ElementwiseUnary::Type::DEQUANTIZE)
+  if (node.param().op_type == operation::ElementwiseUnary::Type::DEQUANTIZE)
   {
     // NNAPI allow QUANT_INT8_SYMM type input
-    OP_REQUIRES(
-        isValidType(input_index, {ir::DataType::QUANT_UINT8_ASYMM, ir::DataType::QUANT_INT8_SYMM,
-                                  ir::DataType::QUANT_INT8_ASYMM}));
-    OP_REQUIRES(isValidType(output_index, ir::DataType::FLOAT32));
+    OP_REQUIRES(isValidType(input_index, {DataType::QUANT_UINT8_ASYMM, DataType::QUANT_INT8_SYMM,
+                                          DataType::QUANT_INT8_ASYMM}));
+    OP_REQUIRES(isValidType(output_index, DataType::FLOAT32));
   }
-  else if (node.param().op_type == ir::operation::ElementwiseUnary::Type::QUANTIZE)
+  else if (node.param().op_type == operation::ElementwiseUnary::Type::QUANTIZE)
   {
-    OP_REQUIRES(isValidType(input_index, ir::DataType::FLOAT32));
-    OP_REQUIRES(isValidType(output_index, ir::DataType::QUANT_UINT8_ASYMM));
+    OP_REQUIRES(isValidType(input_index, DataType::FLOAT32));
+    OP_REQUIRES(isValidType(output_index, DataType::QUANT_UINT8_ASYMM));
   }
-  else if (node.param().op_type != ir::operation::ElementwiseUnary::Type::CAST)
+  else if (node.param().op_type != operation::ElementwiseUnary::Type::CAST)
   {
     OP_REQUIRES(isSameType(output_index, input_index));
   }
 }
 
-void OperationValidator::visit(const ir::operation::EmbeddingLookup &node)
+void OperationValidator::visit(const operation::EmbeddingLookup &node)
 {
-  const auto lookups_index{node.getInputs().at(ir::operation::EmbeddingLookup::Input::LOOKUPS)};
+  const auto lookups_index{node.getInputs().at(operation::EmbeddingLookup::Input::LOOKUPS)};
 
-  OP_REQUIRES(isValidType(lookups_index, ir::DataType::INT32));
+  OP_REQUIRES(isValidType(lookups_index, DataType::INT32));
 }
 
-void OperationValidator::visit(const ir::operation::ExpandDims &node)
+void OperationValidator::visit(const operation::ExpandDims &node)
 {
   const auto output_index{node.getOutputs().at(0)};
-  const auto input_index{node.getInputs().at(ir::operation::ExpandDims::Input::INPUT)};
-  const auto axis_index{node.getInputs().at(ir::operation::ExpandDims::Input::AXIS)};
+  const auto input_index{node.getInputs().at(operation::ExpandDims::Input::INPUT)};
+  const auto axis_index{node.getInputs().at(operation::ExpandDims::Input::AXIS)};
 
   OP_REQUIRES(isSameType(output_index, input_index));
-  OP_REQUIRES(isValidType(axis_index, ir::DataType::INT32));
+  OP_REQUIRES(isValidType(axis_index, DataType::INT32));
 }
 
-void OperationValidator::visit(const ir::operation::HashtableLookup &node)
+void OperationValidator::visit(const operation::HashtableLookup &node)
 {
-  const auto hits_index{node.getOutputs().at(ir::operation::HashtableLookup::Output::HITS)};
-  const auto lookups_index{node.getInputs().at(ir::operation::HashtableLookup::Input::LOOKUPS)};
-  const auto keys_index{node.getInputs().at(ir::operation::HashtableLookup::Input::KEYS)};
+  const auto hits_index{node.getOutputs().at(operation::HashtableLookup::Output::HITS)};
+  const auto lookups_index{node.getInputs().at(operation::HashtableLookup::Input::LOOKUPS)};
+  const auto keys_index{node.getInputs().at(operation::HashtableLookup::Input::KEYS)};
 
-  OP_REQUIRES(isValidType(lookups_index, ir::DataType::INT32));
-  OP_REQUIRES(isValidType(keys_index, ir::DataType::INT32));
-  OP_REQUIRES(isValidType(hits_index, ir::DataType::QUANT_UINT8_ASYMM));
+  OP_REQUIRES(isValidType(lookups_index, DataType::INT32));
+  OP_REQUIRES(isValidType(keys_index, DataType::INT32));
+  OP_REQUIRES(isValidType(hits_index, DataType::QUANT_UINT8_ASYMM));
 }
 
-void OperationValidator::visit(const ir::operation::Pack &node)
+void OperationValidator::visit(const operation::Pack &node)
 {
   const auto num{node.param().num};
 
   OP_REQUIRES(num == static_cast<int32_t>(node.getInputs().size()));
 }
 
-void OperationValidator::visit(const ir::operation::Pad &node)
+void OperationValidator::visit(const operation::Pad &node)
 {
-  const auto pad_index{node.getInputs().at(ir::operation::Pad::Input::PAD)};
+  const auto pad_index{node.getInputs().at(operation::Pad::Input::PAD)};
 
-  OP_REQUIRES(isValidType(pad_index, ir::DataType::INT32));
+  OP_REQUIRES(isValidType(pad_index, DataType::INT32));
 }
 
-void OperationValidator::visit(const ir::operation::Rank &node)
+void OperationValidator::visit(const operation::Rank &node)
 {
   const auto output_index{node.getOutputs().at(0)};
 
-  OP_REQUIRES(_ctx.at(output_index).typeInfo().type() == ir::DataType::INT32);
+  OP_REQUIRES(isValidType(output_index, DataType::INT32));
 }
 
-void OperationValidator::visit(const ir::operation::ResizeBilinear &node)
+void OperationValidator::visit(const operation::ResizeBilinear &node)
 {
   auto align_corners = node.param().align_corners;
   auto half_pixel_centers = node.param().half_pixel_centers;
@@ -234,53 +231,50 @@ void OperationValidator::visit(const ir::operation::ResizeBilinear &node)
   OP_REQUIRES(!align_corners || !half_pixel_centers);
 }
 
-void OperationValidator::visit(const ir::operation::Reverse &node)
+void OperationValidator::visit(const operation::Reverse &node)
 {
   const auto output_index{node.getOutputs().at(0)};
-  const auto input_index{node.getInputs().at(ir::operation::Reverse::Input::INPUT)};
-  const auto axis_index{node.getInputs().at(ir::operation::Reverse::Input::AXIS)};
+  const auto input_index{node.getInputs().at(operation::Reverse::Input::INPUT)};
+  const auto axis_index{node.getInputs().at(operation::Reverse::Input::AXIS)};
 
-  OP_REQUIRES(isValidType(axis_index, ir::DataType::INT32));
+  OP_REQUIRES(isValidType(axis_index, DataType::INT32));
   OP_REQUIRES(isSameType(output_index, input_index));
 }
 
-void OperationValidator::visit(const ir::operation::Shape &node)
+void OperationValidator::visit(const operation::Select &node)
+{
+  const auto condition_index{node.getInputs().at(operation::Select::Input::CONDITION)};
+  const auto input_true_index{node.getInputs().at(operation::Select::Input::INPUT_TRUE)};
+  const auto input_false_index{node.getInputs().at(operation::Select::Input::INPUT_FALSE)};
+
+  OP_REQUIRES(isValidType(condition_index, DataType::BOOL8));
+  OP_REQUIRES(isSameType(input_true_index, input_false_index));
+}
+
+void OperationValidator::visit(const operation::Shape &node)
 {
   const auto output_index{node.getOutputs().at(0)};
 
-  OP_REQUIRES((_ctx.at(output_index).typeInfo().type() == ir::DataType::UINT32) ||
-              (_ctx.at(output_index).typeInfo().type() == ir::DataType::INT32) ||
-              (_ctx.at(output_index).typeInfo().type() == ir::DataType::INT64));
+  OP_REQUIRES(isValidType(output_index, {DataType::UINT32, DataType::INT32, DataType::INT64}));
 }
 
-void OperationValidator::visit(const ir::operation::SpaceToBatchND &node)
+void OperationValidator::visit(const operation::SpaceToBatchND &node)
 {
-  const auto block_size_index{
-      node.getInputs().at(ir::operation::SpaceToBatchND::Input::BLOCK_SIZE)};
-  const auto paddings_index{node.getInputs().at(ir::operation::SpaceToBatchND::Input::PADDINGS)};
+  const auto block_size_index{node.getInputs().at(operation::SpaceToBatchND::Input::BLOCK_SIZE)};
+  const auto paddings_index{node.getInputs().at(operation::SpaceToBatchND::Input::PADDINGS)};
 
   // Non-constant block_size and padding is not implemented yet
   OP_REQUIRES(isConstant(block_size_index));
   OP_REQUIRES(isConstant(paddings_index));
 }
 
-void OperationValidator::visit(const ir::operation::SpaceToDepth &node)
+void OperationValidator::visit(const operation::SpaceToDepth &node)
 {
   const auto block_size = node.param().block_size;
   OP_REQUIRES(block_size >= 1);
 }
 
-void OperationValidator::visit(const ir::operation::Select &node)
-{
-  const auto condition_index{node.getInputs().at(ir::operation::Select::Input::CONDITION)};
-  const auto input_true_index{node.getInputs().at(ir::operation::Select::Input::INPUT_TRUE)};
-  const auto input_false_index{node.getInputs().at(ir::operation::Select::Input::INPUT_FALSE)};
-
-  OP_REQUIRES(isValidType(condition_index, ir::DataType::BOOL8));
-  OP_REQUIRES(isSameType(input_true_index, input_false_index));
-}
-
-void OperationValidator::visit(const ir::operation::Split &node)
+void OperationValidator::visit(const operation::Split &node)
 {
   const auto num_splits = node.param().num_splits;
 
@@ -288,37 +282,37 @@ void OperationValidator::visit(const ir::operation::Split &node)
   OP_REQUIRES(node.getOutputs().size() == static_cast<uint32_t>(num_splits));
 }
 
-void OperationValidator::visit(const ir::operation::SquaredDifference &node)
+void OperationValidator::visit(const operation::SquaredDifference &node)
 {
   const auto output_index{node.getOutputs().at(0)};
-  const auto lhs_index{node.getInputs().at(ir::operation::SquaredDifference::Input::LHS)};
-  const auto rhs_index{node.getInputs().at(ir::operation::SquaredDifference::Input::RHS)};
+  const auto lhs_index{node.getInputs().at(operation::SquaredDifference::Input::LHS)};
+  const auto rhs_index{node.getInputs().at(operation::SquaredDifference::Input::RHS)};
 
   OP_REQUIRES(isSameType(output_index, lhs_index));
   OP_REQUIRES(isSameType(lhs_index, rhs_index));
 }
 
-void OperationValidator::visit(const ir::operation::StridedSlice &node)
+void OperationValidator::visit(const operation::StridedSlice &node)
 {
   const auto output_index{node.getOutputs().at(0)};
-  const auto input_index{node.getInputs().at(ir::operation::StridedSlice::Input::INPUT)};
+  const auto input_index{node.getInputs().at(operation::StridedSlice::Input::INPUT)};
 
   OP_REQUIRES(isSameType(output_index, input_index));
 }
 
-void OperationValidator::visit(const ir::operation::TransposeConv &node)
+void OperationValidator::visit(const operation::TransposeConv &node)
 {
-  OP_REQUIRES((node.param().padding.type == ir::PaddingType::SAME) ||
-              (node.param().padding.type == ir::PaddingType::VALID));
+  OP_REQUIRES((node.param().padding.type == PaddingType::SAME) ||
+              (node.param().padding.type == PaddingType::VALID));
 }
 
-void OperationValidator::visit(const ir::operation::Unpack &node)
+void OperationValidator::visit(const operation::Unpack &node)
 {
   const auto num{node.param().num};
   OP_REQUIRES(num == static_cast<int32_t>(node.getOutputs().size()));
 }
 
-void OperationValidator::visit(const ir::operation::While &node)
+void OperationValidator::visit(const operation::While &node)
 {
   OP_REQUIRES(node.getInputs().size() == node.getOutputs().size());
 }

--- a/runtime/onert/core/src/ir/OperationValidator.h
+++ b/runtime/onert/core/src/ir/OperationValidator.h
@@ -33,55 +33,55 @@ namespace onert
 namespace ir
 {
 
-class OperationValidator : public ir::OperationVisitor
+class OperationValidator : public OperationVisitor
 {
 public:
   OperationValidator(void) = delete;
-  OperationValidator(const ir::Graph &graph);
+  OperationValidator(const Graph &graph);
 
 public:
   void operator()();
 
 public:
-  void visit(const ir::operation::AddN &node) override;
-  void visit(const ir::operation::BatchMatMul &node) override;
-  void visit(const ir::operation::BatchToSpaceND &node) override;
-  void visit(const ir::operation::BinaryArithmetic &node) override;
-  void visit(const ir::operation::Comparison &node) override;
-  void visit(const ir::operation::DepthToSpace &node) override;
-  void visit(const ir::operation::ElementwiseActivation &node) override;
-  void visit(const ir::operation::ElementwiseBinary &node) override;
-  void visit(const ir::operation::ElementwiseUnary &node) override;
-  void visit(const ir::operation::EmbeddingLookup &node) override;
-  void visit(const ir::operation::ExpandDims &node) override;
-  void visit(const ir::operation::HashtableLookup &node) override;
-  void visit(const ir::operation::Pack &node) override;
-  void visit(const ir::operation::Pad &node) override;
-  void visit(const ir::operation::ResizeBilinear &node) override;
-  void visit(const ir::operation::Reverse &node) override;
-  void visit(const ir::operation::Shape &node) override;
-  void visit(const ir::operation::Select &node) override;
-  void visit(const ir::operation::SpaceToBatchND &node) override;
-  void visit(const ir::operation::SpaceToDepth &node) override;
-  void visit(const ir::operation::Split &node) override;
-  void visit(const ir::operation::SquaredDifference &node) override;
-  void visit(const ir::operation::StridedSlice &node) override;
-  void visit(const ir::operation::Rank &node) override;
-  void visit(const ir::operation::TransposeConv &node) override;
-  void visit(const ir::operation::Unpack &node) override;
-  void visit(const ir::operation::While &node) override;
+  void visit(const operation::AddN &node) override;
+  void visit(const operation::BatchMatMul &node) override;
+  void visit(const operation::BatchToSpaceND &node) override;
+  void visit(const operation::BinaryArithmetic &node) override;
+  void visit(const operation::Comparison &node) override;
+  void visit(const operation::DepthToSpace &node) override;
+  void visit(const operation::ElementwiseActivation &node) override;
+  void visit(const operation::ElementwiseBinary &node) override;
+  void visit(const operation::ElementwiseUnary &node) override;
+  void visit(const operation::EmbeddingLookup &node) override;
+  void visit(const operation::ExpandDims &node) override;
+  void visit(const operation::HashtableLookup &node) override;
+  void visit(const operation::Pack &node) override;
+  void visit(const operation::Pad &node) override;
+  void visit(const operation::Rank &node) override;
+  void visit(const operation::ResizeBilinear &node) override;
+  void visit(const operation::Reverse &node) override;
+  void visit(const operation::Select &node) override;
+  void visit(const operation::Shape &node) override;
+  void visit(const operation::SpaceToBatchND &node) override;
+  void visit(const operation::SpaceToDepth &node) override;
+  void visit(const operation::Split &node) override;
+  void visit(const operation::SquaredDifference &node) override;
+  void visit(const operation::StridedSlice &node) override;
+  void visit(const operation::TransposeConv &node) override;
+  void visit(const operation::Unpack &node) override;
+  void visit(const operation::While &node) override;
 
 private:
-  ir::DataType operandType(const ir::OperandIndex &idx);
-  bool isConstant(const ir::OperandIndex &idx);
-  bool isSameType(const ir::OperandIndex &idx1, const ir::OperandIndex &idx2);
-  bool isValidType(const ir::OperandIndex &idx, const ir::DataType &type);
-  bool isValidType(const ir::OperandIndex &idx, std::initializer_list<ir::DataType> valid_types);
+  DataType operandType(const OperandIndex &idx);
+  bool isConstant(const OperandIndex &idx);
+  bool isSameType(const OperandIndex &idx1, const OperandIndex &idx2);
+  bool isValidType(const OperandIndex &idx, const DataType &type);
+  bool isValidType(const OperandIndex &idx, std::initializer_list<DataType> valid_types);
 
 private:
   // TODO Remove _ctx field
-  const ir::Graph &_graph;
-  const ir::Operands &_ctx;
+  const Graph &_graph;
+  const Operands &_ctx;
 };
 
 } // namespace ir


### PR DESCRIPTION
OperationValidator is moved from onert::compiler to onert::ir

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>