### PR TITLE
[onert] Support Int32,Int64 for Neg operation

### DIFF
--- a/compute/cker/include/cker/operation/Elementwise.h
+++ b/compute/cker/include/cker/operation/Elementwise.h
@@ -66,8 +66,9 @@ inline void Rsqrt(const Shape &input_shape, const float *input_data, const Shape
   }
 }
 
-inline void Neg(const Shape &input_shape, const float *input_data, const Shape &output_shape,
-                float *output_data)
+template <typename T>
+inline void Neg(const Shape &input_shape, const T *input_data, const Shape &output_shape,
+                T *output_data)
 {
   const int size = MatchingFlatSize(input_shape, output_shape);
   for (int i = 0; i < size; i++)

--- a/runtime/onert/backend/cpu/ops/ElementwiseUnaryLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ElementwiseUnaryLayer.cc
@@ -157,10 +157,10 @@ void logicalNot(const IPortableTensor *input, IPortableTensor *output)
                          getTensorShape(output), reinterpret_cast<bool *>(output->buffer()));
 }
 
-void negFloat32(const IPortableTensor *input, IPortableTensor *output)
+template <typename T> void neg(const IPortableTensor *input, IPortableTensor *output)
 {
-  nnfw::cker::Neg(getTensorShape(input), reinterpret_cast<const float *>(input->buffer()),
-                  getTensorShape(output), reinterpret_cast<float *>(output->buffer()));
+  nnfw::cker::Neg<T>(getTensorShape(input), reinterpret_cast<const T *>(input->buffer()),
+                     getTensorShape(output), reinterpret_cast<T *>(output->buffer()));
 }
 
 template <typename InputT, typename OutputT>
@@ -292,7 +292,15 @@ void ElementwiseUnaryLayer::configure(const IPortableTensor *input, IPortableTen
     case ElementwiseUnaryType::kNeg:
       if ((input->data_type() == OperandType::FLOAT32))
       {
-        _kernel = negFloat32;
+        _kernel = neg<float>;
+      }
+      else if ((input->data_type() == OperandType::INT64))
+      {
+        _kernel = neg<int64_t>;
+      }
+      else if ((input->data_type() == OperandType::INT32))
+      {
+        _kernel = neg<int32_t>;
       }
       else
       {

--- a/tests/nnfw_api/src/one_op_tests/Neg.cc
+++ b/tests/nnfw_api/src/one_op_tests/Neg.cc
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "GenModelTest.h"
+
+TEST_F(GenModelTest, OneOp_Neg_Float32)
+{
+  CircleGen cgen;
+  int in = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_FLOAT32});
+  int out = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_FLOAT32});
+  cgen.addOperatorNeg({{in}, {out}});
+  cgen.setInputsAndOutputs({in}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->addTestCase(uniformTCD<float>({{1.1, -2.2, 3.3, -4.4}}, {{-1.1, 2.2, -3.3, 4.4}}));
+  _context->setBackends({"cpu"});
+
+  SUCCEED();
+}
+
+TEST_F(GenModelTest, OneOp_Neg_Int32)
+{
+  CircleGen cgen;
+  int in = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_INT32});
+  int out = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_INT32});
+  cgen.addOperatorNeg({{in}, {out}});
+  cgen.setInputsAndOutputs({in}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->addTestCase(uniformTCD<int32_t>({{1, -2, 3, -4}}, {{-1, 2, -3, 4}}));
+  _context->setBackends({"cpu"});
+
+  SUCCEED();
+}
+
+TEST_F(GenModelTest, OneOp_Neg_Int64)
+{
+  CircleGen cgen;
+  int in = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_INT64});
+  int out = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_INT64});
+  cgen.addOperatorNeg({{in}, {out}});
+  cgen.setInputsAndOutputs({in}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->addTestCase(uniformTCD<int64_t>({{1, -2, 3, -4}}, {{-1, 2, -3, 4}}));
+  _context->setBackends({"cpu"});
+
+  SUCCEED();
+}
+
+TEST_F(GenModelTest, neg_OneOp_Neg_Float32_TwoOperand)
+{
+  CircleGen cgen;
+  int in1 = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_FLOAT32});
+  int in2 = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_FLOAT32});
+  int out1 = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_FLOAT32});
+  int out2 = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_FLOAT32});
+  cgen.addOperatorCos({{in1, in2}, {out1, out2}});
+  cgen.setInputsAndOutputs({in1, in2}, {out1, out2});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->setBackends({"cpu"});
+  _context->expectFailModelLoad();
+
+  SUCCEED();
+}
+
+TEST_F(GenModelTest, neg_OneOp_Neg_Int32_TwoOperand)
+{
+  CircleGen cgen;
+  int in1 = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_INT32});
+  int in2 = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_INT32});
+  int out1 = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_INT32});
+  int out2 = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_INT32});
+  cgen.addOperatorCos({{in1, in2}, {out1, out2}});
+  cgen.setInputsAndOutputs({in1, in2}, {out1, out2});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->setBackends({"cpu"});
+  _context->expectFailModelLoad();
+
+  SUCCEED();
+}
+
+TEST_F(GenModelTest, neg_OneOp_Neg_Int64_TwoOperand)
+{
+  CircleGen cgen;
+  int in1 = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_INT64});
+  int in2 = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_INT64});
+  int out1 = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_INT64});
+  int out2 = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_INT64});
+  cgen.addOperatorCos({{in1, in2}, {out1, out2}});
+  cgen.setInputsAndOutputs({in1, in2}, {out1, out2});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->setBackends({"cpu"});
+  _context->expectFailModelLoad();
+
+  SUCCEED();
+}


### PR DESCRIPTION
This commit will enable supporting `Int32`, `Int64` for `Neg` operation
and add related testcases.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>