### PR TITLE
[nnfwapi-internal] Add negative tests for config

### DIFF
--- a/runtime/onert/api/src/nnfw_debug.cc
+++ b/runtime/onert/api/src/nnfw_debug.cc
@@ -18,12 +18,21 @@
 
 #include <util/ConfigSource.h>
 
+#define NNFW_RETURN_ERROR_IF_NULL(p)      \
+  do                                      \
+  {                                       \
+    if ((p) == NULL)                      \
+      return NNFW_STATUS_UNEXPECTED_NULL; \
+  } while (0)
+
 NNFW_STATUS nnfw_set_config(nnfw_session *session, const char *key, const char *value)
 {
+  NNFW_RETURN_ERROR_IF_NULL(session);
   return session->set_config(key, value);
 }
 
 NNFW_STATUS nnfw_get_config(nnfw_session *session, const char *key, char *value, size_t value_size)
 {
+  NNFW_RETURN_ERROR_IF_NULL(session);
   return session->get_config(key, value, value_size);
 }

--- a/tests/nnfw_api/src/ValidationTestAddSessionPrepared.cc
+++ b/tests/nnfw_api/src/ValidationTestAddSessionPrepared.cc
@@ -191,4 +191,11 @@ TEST_F(ValidationTestAddSessionPrepared, neg_run_without_set_output)
   ASSERT_EQ(nnfw_run(_session), NNFW_STATUS_ERROR);
 }
 
+TEST_F(ValidationTestAddSessionPrepared, neg_internal_set_config)
+{
+  // All arguments are valid, but the session state is wrong
+  ASSERT_EQ(nnfw_set_config(_session, "TRACE_FILEPATH", ""), NNFW_STATUS_INVALID_STATE);
+  ASSERT_EQ(nnfw_set_config(_session, "GRAPH_DOT_DUMP", "0"), NNFW_STATUS_INVALID_STATE);
+}
+
 // TODO Validation check when "nnfw_run" is called without input & output tensor setting

--- a/tests/nnfw_api/src/ValidationTestSessionCreated.cc
+++ b/tests/nnfw_api/src/ValidationTestSessionCreated.cc
@@ -118,3 +118,10 @@ TEST_F(ValidationTestSessionCreated, neg_output_tensorinfo)
   // model is not loaded and tensor_info is null
   ASSERT_EQ(nnfw_output_tensorinfo(_session, 0, nullptr), NNFW_STATUS_INVALID_STATE);
 }
+
+TEST_F(ValidationTestSessionCreated, neg_internal_set_config)
+{
+  // All arguments are valid, but the session state is wrong
+  ASSERT_EQ(nnfw_set_config(_session, "TRACE_FILEPATH", ""), NNFW_STATUS_INVALID_STATE);
+  ASSERT_EQ(nnfw_set_config(_session, "GRAPH_DOT_DUMP", "0"), NNFW_STATUS_INVALID_STATE);
+}

--- a/tests/nnfw_api/src/ValidationTestSingleSession.cc
+++ b/tests/nnfw_api/src/ValidationTestSingleSession.cc
@@ -123,3 +123,9 @@ TEST_F(ValidationTestSingleSession, neg_experimental_output_tensorindex_session_
   ASSERT_EQ(nnfw_output_tensorindex(nullptr, "ADD_TOP", &ind), NNFW_STATUS_UNEXPECTED_NULL);
   ASSERT_EQ(ind, 999);
 }
+
+TEST_F(ValidationTestSingleSession, neg_internal_set_config)
+{
+  ASSERT_EQ(nnfw_set_config(nullptr, "TRACE_FILEPATH", ""), NNFW_STATUS_UNEXPECTED_NULL);
+  ASSERT_EQ(nnfw_set_config(nullptr, "GRAPH_DOT_DUMP", "0"), NNFW_STATUS_UNEXPECTED_NULL);
+}

--- a/tests/nnfw_api/src/fixtures.h
+++ b/tests/nnfw_api/src/fixtures.h
@@ -20,6 +20,7 @@
 #include <array>
 #include <gtest/gtest.h>
 #include <nnfw_experimental.h>
+#include <nnfw_internal.h>
 
 #include "NNPackages.h"
 


### PR DESCRIPTION
- Add negative tests for config
- Handle error correctly when session is null

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>