### PR TITLE
[circle2circle] Make batchnorm gamma positive

### DIFF
--- a/compiler/circle2circle/src/Circle2Circle.cpp
+++ b/compiler/circle2circle/src/Circle2Circle.cpp
@@ -90,6 +90,14 @@ int entry(int argc, char **argv)
       .default_value(false)
       .help("This will fuse operators to InstanceNorm operator");
 
+  arser.add_argument("--make_batchnorm_gamma_positive")
+      .nargs(0)
+      .required(false)
+      .default_value(false)
+      .help("This will make negative gamma of BatchNorm into a small positive value (1e-10). Note "
+            "that this pass can change the execution result of the model. So, use it only when the "
+            "impact is known to be acceptable.");
+
   arser.add_argument("--resolve_customop_add")
       .nargs(0)
       .required(false)
@@ -187,6 +195,8 @@ int entry(int argc, char **argv)
     options->enable(Algorithms::FuseBCQ);
   if (arser.get<bool>("--fuse_instnorm"))
     options->enable(Algorithms::FuseInstanceNorm);
+  if (arser.get<bool>("--make_batchnorm_gamma_positive"))
+    options->enable(Algorithms::MakeBatchNormGammaPositive);
   if (arser.get<bool>("--resolve_customop_add"))
     options->enable(Algorithms::ResolveCustomOpAdd);
   if (arser.get<bool>("--resolve_customop_batchmatmul"))


### PR DESCRIPTION
This adds an option to make BN gamma positive

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: #4773
Draft PR: #4788