### PR TITLE
[circle_schema] Add SHUFFLED16x1FLOAT32 weight format

### DIFF
--- a/nnpackage/schema/circle_schema.fbs
+++ b/nnpackage/schema/circle_schema.fbs
@@ -27,6 +27,7 @@
 //              `BATCH_MATMUL` operator, `FLOAT64` tensor type,
 //              `asymmetric_quantize_inputs` for several operator options
 // Version 0.2: BCQ_GATHER and BCQ_FULLY_CONNECTED are added.
+// Version 0.3: SHUFFLED16x1FLOAT32 is added.
 
 namespace circle;
 
@@ -564,6 +565,7 @@ table BidirectionalSequenceRNNOptions {
 enum FullyConnectedOptionsWeightsFormat: byte {
   DEFAULT = 0,
   SHUFFLED4x16INT8 = 1,
+  SHUFFLED16x1FLOAT32 = 127
 }
 
 // An implementation of TensorFlow fully_connected (a.k.a Dense) layer.


### PR DESCRIPTION
It adds SHUFFLED16x1FLOAT32 in FullyConnectedOptionsWeightsFormat enum.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>