### PR TITLE
[onert] Update circle_schema_generated.h for shuffled16x1float32

### DIFF
--- a/runtime/onert/frontend/circle_schema/include/circle_schema_generated.h
+++ b/runtime/onert/frontend/circle_schema/include/circle_schema_generated.h
@@ -25,240 +25,358 @@ namespace circle
 {
 
 struct CustomQuantization;
+struct CustomQuantizationBuilder;
 
 struct QuantizationParameters;
+struct QuantizationParametersBuilder;
 
 struct Int32Vector;
+struct Int32VectorBuilder;
 
 struct Uint16Vector;
+struct Uint16VectorBuilder;
 
 struct Uint8Vector;
+struct Uint8VectorBuilder;
 
 struct DimensionMetadata;
+struct DimensionMetadataBuilder;
 
 struct SparsityParameters;
+struct SparsityParametersBuilder;
 
 struct Tensor;
+struct TensorBuilder;
 
 struct Conv2DOptions;
+struct Conv2DOptionsBuilder;
 
 struct Pool2DOptions;
+struct Pool2DOptionsBuilder;
 
 struct DepthwiseConv2DOptions;
+struct DepthwiseConv2DOptionsBuilder;
 
 struct ConcatEmbeddingsOptions;
+struct ConcatEmbeddingsOptionsBuilder;
 
 struct LSHProjectionOptions;
+struct LSHProjectionOptionsBuilder;
 
 struct SVDFOptions;
+struct SVDFOptionsBuilder;
 
 struct RNNOptions;
+struct RNNOptionsBuilder;
 
 struct SequenceRNNOptions;
+struct SequenceRNNOptionsBuilder;
 
 struct BidirectionalSequenceRNNOptions;
+struct BidirectionalSequenceRNNOptionsBuilder;
 
 struct FullyConnectedOptions;
+struct FullyConnectedOptionsBuilder;
 
 struct SoftmaxOptions;
+struct SoftmaxOptionsBuilder;
 
 struct ConcatenationOptions;
+struct ConcatenationOptionsBuilder;
 
 struct AddOptions;
+struct AddOptionsBuilder;
 
 struct MulOptions;
+struct MulOptionsBuilder;
 
 struct L2NormOptions;
+struct L2NormOptionsBuilder;
 
 struct LocalResponseNormalizationOptions;
+struct LocalResponseNormalizationOptionsBuilder;
 
 struct LSTMOptions;
+struct LSTMOptionsBuilder;
 
 struct UnidirectionalSequenceLSTMOptions;
+struct UnidirectionalSequenceLSTMOptionsBuilder;
 
 struct BidirectionalSequenceLSTMOptions;
+struct BidirectionalSequenceLSTMOptionsBuilder;
 
 struct ResizeBilinearOptions;
+struct ResizeBilinearOptionsBuilder;
 
 struct ResizeNearestNeighborOptions;
+struct ResizeNearestNeighborOptionsBuilder;
 
 struct CallOptions;
+struct CallOptionsBuilder;
 
 struct PadOptions;
+struct PadOptionsBuilder;
 
 struct PadV2Options;
+struct PadV2OptionsBuilder;
 
 struct ReshapeOptions;
+struct ReshapeOptionsBuilder;
 
 struct SpaceToBatchNDOptions;
+struct SpaceToBatchNDOptionsBuilder;
 
 struct BatchToSpaceNDOptions;
+struct BatchToSpaceNDOptionsBuilder;
 
 struct SkipGramOptions;
+struct SkipGramOptionsBuilder;
 
 struct SpaceToDepthOptions;
+struct SpaceToDepthOptionsBuilder;
 
 struct DepthToSpaceOptions;
+struct DepthToSpaceOptionsBuilder;
 
 struct SubOptions;
+struct SubOptionsBuilder;
 
 struct DivOptions;
+struct DivOptionsBuilder;
 
 struct TopKV2Options;
+struct TopKV2OptionsBuilder;
 
 struct EmbeddingLookupSparseOptions;
+struct EmbeddingLookupSparseOptionsBuilder;
 
 struct GatherOptions;
+struct GatherOptionsBuilder;
 
 struct TransposeOptions;
+struct TransposeOptionsBuilder;
 
 struct ExpOptions;
+struct ExpOptionsBuilder;
 
 struct CosOptions;
+struct CosOptionsBuilder;
 
 struct ReducerOptions;
+struct ReducerOptionsBuilder;
 
 struct SqueezeOptions;
+struct SqueezeOptionsBuilder;
 
 struct SplitOptions;
+struct SplitOptionsBuilder;
 
 struct SplitVOptions;
+struct SplitVOptionsBuilder;
 
 struct StridedSliceOptions;
+struct StridedSliceOptionsBuilder;
 
 struct LogSoftmaxOptions;
+struct LogSoftmaxOptionsBuilder;
 
 struct CastOptions;
+struct CastOptionsBuilder;
 
 struct DequantizeOptions;
+struct DequantizeOptionsBuilder;
 
 struct MaximumMinimumOptions;
+struct MaximumMinimumOptionsBuilder;
 
 struct TileOptions;
+struct TileOptionsBuilder;
 
 struct ArgMaxOptions;
+struct ArgMaxOptionsBuilder;
 
 struct ArgMinOptions;
+struct ArgMinOptionsBuilder;
 
 struct GreaterOptions;
+struct GreaterOptionsBuilder;
 
 struct GreaterEqualOptions;
+struct GreaterEqualOptionsBuilder;
 
 struct LessOptions;
+struct LessOptionsBuilder;
 
 struct LessEqualOptions;
+struct LessEqualOptionsBuilder;
 
 struct NegOptions;
+struct NegOptionsBuilder;
 
 struct SelectOptions;
+struct SelectOptionsBuilder;
 
 struct SliceOptions;
+struct SliceOptionsBuilder;
 
 struct TransposeConvOptions;
+struct TransposeConvOptionsBuilder;
 
 struct ExpandDimsOptions;
+struct ExpandDimsOptionsBuilder;
 
 struct SparseToDenseOptions;
+struct SparseToDenseOptionsBuilder;
 
 struct EqualOptions;
+struct EqualOptionsBuilder;
 
 struct NotEqualOptions;
+struct NotEqualOptionsBuilder;
 
 struct ShapeOptions;
+struct ShapeOptionsBuilder;
 
 struct RankOptions;
+struct RankOptionsBuilder;
 
 struct PowOptions;
+struct PowOptionsBuilder;
 
 struct FakeQuantOptions;
+struct FakeQuantOptionsBuilder;
 
 struct PackOptions;
+struct PackOptionsBuilder;
 
 struct LogicalOrOptions;
+struct LogicalOrOptionsBuilder;
 
 struct OneHotOptions;
+struct OneHotOptionsBuilder;
 
 struct AbsOptions;
+struct AbsOptionsBuilder;
 
 struct HardSwishOptions;
+struct HardSwishOptionsBuilder;
 
 struct LogicalAndOptions;
+struct LogicalAndOptionsBuilder;
 
 struct LogicalNotOptions;
+struct LogicalNotOptionsBuilder;
 
 struct UnpackOptions;
+struct UnpackOptionsBuilder;
 
 struct FloorDivOptions;
+struct FloorDivOptionsBuilder;
 
 struct SquareOptions;
+struct SquareOptionsBuilder;
 
 struct ZerosLikeOptions;
+struct ZerosLikeOptionsBuilder;
 
 struct FillOptions;
+struct FillOptionsBuilder;
 
 struct FloorModOptions;
+struct FloorModOptionsBuilder;
 
 struct RangeOptions;
+struct RangeOptionsBuilder;
 
 struct LeakyReluOptions;
+struct LeakyReluOptionsBuilder;
 
 struct SquaredDifferenceOptions;
+struct SquaredDifferenceOptionsBuilder;
 
 struct MirrorPadOptions;
+struct MirrorPadOptionsBuilder;
 
 struct UniqueOptions;
+struct UniqueOptionsBuilder;
 
 struct ReverseV2Options;
+struct ReverseV2OptionsBuilder;
 
 struct AddNOptions;
+struct AddNOptionsBuilder;
 
 struct GatherNdOptions;
+struct GatherNdOptionsBuilder;
 
 struct WhereOptions;
+struct WhereOptionsBuilder;
 
 struct ReverseSequenceOptions;
+struct ReverseSequenceOptionsBuilder;
 
 struct MatrixDiagOptions;
+struct MatrixDiagOptionsBuilder;
 
 struct QuantizeOptions;
+struct QuantizeOptionsBuilder;
 
 struct MatrixSetDiagOptions;
+struct MatrixSetDiagOptionsBuilder;
 
 struct IfOptions;
+struct IfOptionsBuilder;
 
 struct WhileOptions;
+struct WhileOptionsBuilder;
 
 struct NonMaxSuppressionV4Options;
+struct NonMaxSuppressionV4OptionsBuilder;
 
 struct NonMaxSuppressionV5Options;
+struct NonMaxSuppressionV5OptionsBuilder;
 
 struct ScatterNdOptions;
+struct ScatterNdOptionsBuilder;
 
 struct SelectV2Options;
+struct SelectV2OptionsBuilder;
 
 struct DensifyOptions;
+struct DensifyOptionsBuilder;
 
 struct SegmentSumOptions;
+struct SegmentSumOptionsBuilder;
 
 struct BatchMatMulOptions;
+struct BatchMatMulOptionsBuilder;
 
 struct BCQGatherOptions;
+struct BCQGatherOptionsBuilder;
 
 struct BCQFullyConnectedOptions;
+struct BCQFullyConnectedOptionsBuilder;
 
 struct InstanceNormOptions;
+struct InstanceNormOptionsBuilder;
 
 struct OperatorCode;
+struct OperatorCodeBuilder;
 
 struct Operator;
+struct OperatorBuilder;
 
 struct SubGraph;
+struct SubGraphBuilder;
 
 struct Buffer;
+struct BufferBuilder;
 
 struct Metadata;
+struct MetadataBuilder;
 
 struct Model;
+struct ModelBuilder;
 
 enum TensorType
 {
@@ -288,15 +406,17 @@ inline const TensorType (&EnumValuesTensorType())[11]
 
 inline const char *const *EnumNamesTensorType()
 {
-  static const char *const names[] = {"FLOAT32",   "FLOAT16", "INT32",   "UINT8",
-                                      "INT64",     "STRING",  "BOOL",    "INT16",
-                                      "COMPLEX64", "INT8",    "FLOAT64", nullptr};
+  static const char *const names[12] = {"FLOAT32",   "FLOAT16", "INT32",   "UINT8",
+                                        "INT64",     "STRING",  "BOOL",    "INT16",
+                                        "COMPLEX64", "INT8",    "FLOAT64", nullptr};
   return names;
 }
 
 inline const char *EnumNameTensorType(TensorType e)
 {
-  const size_t index = static_cast<int>(e);
+  if (flatbuffers::IsOutRange(e, TensorType_FLOAT32, TensorType_FLOAT64))
+    return "";
+  const size_t index = static_cast<size_t>(e);
   return EnumNamesTensorType()[index];
 }
 
@@ -317,13 +437,15 @@ inline const QuantizationDetails (&EnumValuesQuantizationDetails())[2]
 
 inline const char *const *EnumNamesQuantizationDetails()
 {
-  static const char *const names[] = {"NONE", "CustomQuantization", nullptr};
+  static const char *const names[3] = {"NONE", "CustomQuantization", nullptr};
   return names;
 }
 
 inline const char *EnumNameQuantizationDetails(QuantizationDetails e)
 {
-  const size_t index = static_cast<int>(e);
+  if (flatbuffers::IsOutRange(e, QuantizationDetails_NONE, QuantizationDetails_CustomQuantization))
+    return "";
+  const size_t index = static_cast<size_t>(e);
   return EnumNamesQuantizationDetails()[index];
 }
 
@@ -332,7 +454,7 @@ template <typename T> struct QuantizationDetailsTraits
   static const QuantizationDetails enum_value = QuantizationDetails_NONE;
 };
 
-template <> struct QuantizationDetailsTraits<CustomQuantization>
+template <> struct QuantizationDetailsTraits<circle::CustomQuantization>
 {
   static const QuantizationDetails enum_value = QuantizationDetails_CustomQuantization;
 };
@@ -359,13 +481,15 @@ inline const DimensionType (&EnumValuesDimensionType())[2]
 
 inline const char *const *EnumNamesDimensionType()
 {
-  static const char *const names[] = {"DENSE", "SPARSE_CSR", nullptr};
+  static const char *const names[3] = {"DENSE", "SPARSE_CSR", nullptr};
   return names;
 }
 
 inline const char *EnumNameDimensionType(DimensionType e)
 {
-  const size_t index = static_cast<int>(e);
+  if (flatbuffers::IsOutRange(e, DimensionType_DENSE, DimensionType_SPARSE_CSR))
+    return "";
+  const size_t index = static_cast<size_t>(e);
   return EnumNamesDimensionType()[index];
 }
 
@@ -389,14 +513,16 @@ inline const SparseIndexVector (&EnumValuesSparseIndexVector())[4]
 
 inline const char *const *EnumNamesSparseIndexVector()
 {
-  static const char *const names[] = {"NONE", "Int32Vector", "Uint16Vector", "Uint8Vector",
-                                      nullptr};
+  static const char *const names[5] = {"NONE", "Int32Vector", "Uint16Vector", "Uint8Vector",
+                                       nullptr};
   return names;
 }
 
 inline const char *EnumNameSparseIndexVector(SparseIndexVector e)
 {
-  const size_t index = static_cast<int>(e);
+  if (flatbuffers::IsOutRange(e, SparseIndexVector_NONE, SparseIndexVector_Uint8Vector))
+    return "";
+  const size_t index = static_cast<size_t>(e);
   return EnumNamesSparseIndexVector()[index];
 }
 
@@ -405,17 +531,17 @@ template <typename T> struct SparseIndexVectorTraits
   static const SparseIndexVector enum_value = SparseIndexVector_NONE;
 };
 
-template <> struct SparseIndexVectorTraits<Int32Vector>
+template <> struct SparseIndexVectorTraits<circle::Int32Vector>
 {
   static const SparseIndexVector enum_value = SparseIndexVector_Int32Vector;
 };
 
-template <> struct SparseIndexVectorTraits<Uint16Vector>
+template <> struct SparseIndexVectorTraits<circle::Uint16Vector>
 {
   static const SparseIndexVector enum_value = SparseIndexVector_Uint16Vector;
 };
 
-template <> struct SparseIndexVectorTraits<Uint8Vector>
+template <> struct SparseIndexVectorTraits<circle::Uint8Vector>
 {
   static const SparseIndexVector enum_value = SparseIndexVector_Uint8Vector;
 };
@@ -699,268 +825,270 @@ inline const BuiltinOperator (&EnumValuesBuiltinOperator())[130]
 
 inline const char *const *EnumNamesBuiltinOperator()
 {
-  static const char *const names[] = {"ADD",
-                                      "AVERAGE_POOL_2D",
-                                      "CONCATENATION",
-                                      "CONV_2D",
-                                      "DEPTHWISE_CONV_2D",
-                                      "DEPTH_TO_SPACE",
-                                      "DEQUANTIZE",
-                                      "EMBEDDING_LOOKUP",
-                                      "FLOOR",
-                                      "FULLY_CONNECTED",
-                                      "HASHTABLE_LOOKUP",
-                                      "L2_NORMALIZATION",
-                                      "L2_POOL_2D",
-                                      "LOCAL_RESPONSE_NORMALIZATION",
-                                      "LOGISTIC",
-                                      "LSH_PROJECTION",
-                                      "LSTM",
-                                      "MAX_POOL_2D",
-                                      "MUL",
-                                      "RELU",
-                                      "RELU_N1_TO_1",
-                                      "RELU6",
-                                      "RESHAPE",
-                                      "RESIZE_BILINEAR",
-                                      "RNN",
-                                      "SOFTMAX",
-                                      "SPACE_TO_DEPTH",
-                                      "SVDF",
-                                      "TANH",
-                                      "CONCAT_EMBEDDINGS",
-                                      "SKIP_GRAM",
-                                      "CALL",
-                                      "CUSTOM",
-                                      "EMBEDDING_LOOKUP_SPARSE",
-                                      "PAD",
-                                      "UNIDIRECTIONAL_SEQUENCE_RNN",
-                                      "GATHER",
-                                      "BATCH_TO_SPACE_ND",
-                                      "SPACE_TO_BATCH_ND",
-                                      "TRANSPOSE",
-                                      "MEAN",
-                                      "SUB",
-                                      "DIV",
-                                      "SQUEEZE",
-                                      "UNIDIRECTIONAL_SEQUENCE_LSTM",
-                                      "STRIDED_SLICE",
-                                      "BIDIRECTIONAL_SEQUENCE_RNN",
-                                      "EXP",
-                                      "TOPK_V2",
-                                      "SPLIT",
-                                      "LOG_SOFTMAX",
-                                      "DELEGATE",
-                                      "BIDIRECTIONAL_SEQUENCE_LSTM",
-                                      "CAST",
-                                      "PRELU",
-                                      "MAXIMUM",
-                                      "ARG_MAX",
-                                      "MINIMUM",
-                                      "LESS",
-                                      "NEG",
-                                      "PADV2",
-                                      "GREATER",
-                                      "GREATER_EQUAL",
-                                      "LESS_EQUAL",
-                                      "SELECT",
-                                      "SLICE",
-                                      "SIN",
-                                      "TRANSPOSE_CONV",
-                                      "SPARSE_TO_DENSE",
-                                      "TILE",
-                                      "EXPAND_DIMS",
-                                      "EQUAL",
-                                      "NOT_EQUAL",
-                                      "LOG",
-                                      "SUM",
-                                      "SQRT",
-                                      "RSQRT",
-                                      "SHAPE",
-                                      "POW",
-                                      "ARG_MIN",
-                                      "FAKE_QUANT",
-                                      "REDUCE_PROD",
-                                      "REDUCE_MAX",
-                                      "PACK",
-                                      "LOGICAL_OR",
-                                      "ONE_HOT",
-                                      "LOGICAL_AND",
-                                      "LOGICAL_NOT",
-                                      "UNPACK",
-                                      "REDUCE_MIN",
-                                      "FLOOR_DIV",
-                                      "REDUCE_ANY",
-                                      "SQUARE",
-                                      "ZEROS_LIKE",
-                                      "FILL",
-                                      "FLOOR_MOD",
-                                      "RANGE",
-                                      "RESIZE_NEAREST_NEIGHBOR",
-                                      "LEAKY_RELU",
-                                      "SQUARED_DIFFERENCE",
-                                      "MIRROR_PAD",
-                                      "ABS",
-                                      "SPLIT_V",
-                                      "UNIQUE",
-                                      "CEIL",
-                                      "REVERSE_V2",
-                                      "ADD_N",
-                                      "GATHER_ND",
-                                      "COS",
-                                      "WHERE",
-                                      "RANK",
-                                      "ELU",
-                                      "REVERSE_SEQUENCE",
-                                      "MATRIX_DIAG",
-                                      "QUANTIZE",
-                                      "MATRIX_SET_DIAG",
-                                      "ROUND",
-                                      "HARD_SWISH",
-                                      "IF",
-                                      "WHILE",
-                                      "NON_MAX_SUPPRESSION_V4",
-                                      "NON_MAX_SUPPRESSION_V5",
-                                      "SCATTER_ND",
-                                      "SELECT_V2",
-                                      "DENSIFY",
-                                      "SEGMENT_SUM",
-                                      "BATCH_MATMUL",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "BCQ_GATHER",
-                                      "BCQ_FULLY_CONNECTED",
-                                      "INSTANCE_NORM",
-                                      nullptr};
+  static const char *const names[256] = {"ADD",
+                                         "AVERAGE_POOL_2D",
+                                         "CONCATENATION",
+                                         "CONV_2D",
+                                         "DEPTHWISE_CONV_2D",
+                                         "DEPTH_TO_SPACE",
+                                         "DEQUANTIZE",
+                                         "EMBEDDING_LOOKUP",
+                                         "FLOOR",
+                                         "FULLY_CONNECTED",
+                                         "HASHTABLE_LOOKUP",
+                                         "L2_NORMALIZATION",
+                                         "L2_POOL_2D",
+                                         "LOCAL_RESPONSE_NORMALIZATION",
+                                         "LOGISTIC",
+                                         "LSH_PROJECTION",
+                                         "LSTM",
+                                         "MAX_POOL_2D",
+                                         "MUL",
+                                         "RELU",
+                                         "RELU_N1_TO_1",
+                                         "RELU6",
+                                         "RESHAPE",
+                                         "RESIZE_BILINEAR",
+                                         "RNN",
+                                         "SOFTMAX",
+                                         "SPACE_TO_DEPTH",
+                                         "SVDF",
+                                         "TANH",
+                                         "CONCAT_EMBEDDINGS",
+                                         "SKIP_GRAM",
+                                         "CALL",
+                                         "CUSTOM",
+                                         "EMBEDDING_LOOKUP_SPARSE",
+                                         "PAD",
+                                         "UNIDIRECTIONAL_SEQUENCE_RNN",
+                                         "GATHER",
+                                         "BATCH_TO_SPACE_ND",
+                                         "SPACE_TO_BATCH_ND",
+                                         "TRANSPOSE",
+                                         "MEAN",
+                                         "SUB",
+                                         "DIV",
+                                         "SQUEEZE",
+                                         "UNIDIRECTIONAL_SEQUENCE_LSTM",
+                                         "STRIDED_SLICE",
+                                         "BIDIRECTIONAL_SEQUENCE_RNN",
+                                         "EXP",
+                                         "TOPK_V2",
+                                         "SPLIT",
+                                         "LOG_SOFTMAX",
+                                         "DELEGATE",
+                                         "BIDIRECTIONAL_SEQUENCE_LSTM",
+                                         "CAST",
+                                         "PRELU",
+                                         "MAXIMUM",
+                                         "ARG_MAX",
+                                         "MINIMUM",
+                                         "LESS",
+                                         "NEG",
+                                         "PADV2",
+                                         "GREATER",
+                                         "GREATER_EQUAL",
+                                         "LESS_EQUAL",
+                                         "SELECT",
+                                         "SLICE",
+                                         "SIN",
+                                         "TRANSPOSE_CONV",
+                                         "SPARSE_TO_DENSE",
+                                         "TILE",
+                                         "EXPAND_DIMS",
+                                         "EQUAL",
+                                         "NOT_EQUAL",
+                                         "LOG",
+                                         "SUM",
+                                         "SQRT",
+                                         "RSQRT",
+                                         "SHAPE",
+                                         "POW",
+                                         "ARG_MIN",
+                                         "FAKE_QUANT",
+                                         "REDUCE_PROD",
+                                         "REDUCE_MAX",
+                                         "PACK",
+                                         "LOGICAL_OR",
+                                         "ONE_HOT",
+                                         "LOGICAL_AND",
+                                         "LOGICAL_NOT",
+                                         "UNPACK",
+                                         "REDUCE_MIN",
+                                         "FLOOR_DIV",
+                                         "REDUCE_ANY",
+                                         "SQUARE",
+                                         "ZEROS_LIKE",
+                                         "FILL",
+                                         "FLOOR_MOD",
+                                         "RANGE",
+                                         "RESIZE_NEAREST_NEIGHBOR",
+                                         "LEAKY_RELU",
+                                         "SQUARED_DIFFERENCE",
+                                         "MIRROR_PAD",
+                                         "ABS",
+                                         "SPLIT_V",
+                                         "UNIQUE",
+                                         "CEIL",
+                                         "REVERSE_V2",
+                                         "ADD_N",
+                                         "GATHER_ND",
+                                         "COS",
+                                         "WHERE",
+                                         "RANK",
+                                         "ELU",
+                                         "REVERSE_SEQUENCE",
+                                         "MATRIX_DIAG",
+                                         "QUANTIZE",
+                                         "MATRIX_SET_DIAG",
+                                         "ROUND",
+                                         "HARD_SWISH",
+                                         "IF",
+                                         "WHILE",
+                                         "NON_MAX_SUPPRESSION_V4",
+                                         "NON_MAX_SUPPRESSION_V5",
+                                         "SCATTER_ND",
+                                         "SELECT_V2",
+                                         "DENSIFY",
+                                         "SEGMENT_SUM",
+                                         "BATCH_MATMUL",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "BCQ_GATHER",
+                                         "BCQ_FULLY_CONNECTED",
+                                         "INSTANCE_NORM",
+                                         nullptr};
   return names;
 }
 
 inline const char *EnumNameBuiltinOperator(BuiltinOperator e)
 {
-  const size_t index = static_cast<int>(e);
+  if (flatbuffers::IsOutRange(e, BuiltinOperator_ADD, BuiltinOperator_INSTANCE_NORM))
+    return "";
+  const size_t index = static_cast<size_t>(e);
   return EnumNamesBuiltinOperator()[index];
 }
 
@@ -1187,268 +1315,270 @@ inline const BuiltinOptions (&EnumValuesBuiltinOptions())[105]
 
 inline const char *const *EnumNamesBuiltinOptions()
 {
-  static const char *const names[] = {"NONE",
-                                      "Conv2DOptions",
-                                      "DepthwiseConv2DOptions",
-                                      "ConcatEmbeddingsOptions",
-                                      "LSHProjectionOptions",
-                                      "Pool2DOptions",
-                                      "SVDFOptions",
-                                      "RNNOptions",
-                                      "FullyConnectedOptions",
-                                      "SoftmaxOptions",
-                                      "ConcatenationOptions",
-                                      "AddOptions",
-                                      "L2NormOptions",
-                                      "LocalResponseNormalizationOptions",
-                                      "LSTMOptions",
-                                      "ResizeBilinearOptions",
-                                      "CallOptions",
-                                      "ReshapeOptions",
-                                      "SkipGramOptions",
-                                      "SpaceToDepthOptions",
-                                      "EmbeddingLookupSparseOptions",
-                                      "MulOptions",
-                                      "PadOptions",
-                                      "GatherOptions",
-                                      "BatchToSpaceNDOptions",
-                                      "SpaceToBatchNDOptions",
-                                      "TransposeOptions",
-                                      "ReducerOptions",
-                                      "SubOptions",
-                                      "DivOptions",
-                                      "SqueezeOptions",
-                                      "SequenceRNNOptions",
-                                      "StridedSliceOptions",
-                                      "ExpOptions",
-                                      "TopKV2Options",
-                                      "SplitOptions",
-                                      "LogSoftmaxOptions",
-                                      "CastOptions",
-                                      "DequantizeOptions",
-                                      "MaximumMinimumOptions",
-                                      "ArgMaxOptions",
-                                      "LessOptions",
-                                      "NegOptions",
-                                      "PadV2Options",
-                                      "GreaterOptions",
-                                      "GreaterEqualOptions",
-                                      "LessEqualOptions",
-                                      "SelectOptions",
-                                      "SliceOptions",
-                                      "TransposeConvOptions",
-                                      "SparseToDenseOptions",
-                                      "TileOptions",
-                                      "ExpandDimsOptions",
-                                      "EqualOptions",
-                                      "NotEqualOptions",
-                                      "ShapeOptions",
-                                      "PowOptions",
-                                      "ArgMinOptions",
-                                      "FakeQuantOptions",
-                                      "PackOptions",
-                                      "LogicalOrOptions",
-                                      "OneHotOptions",
-                                      "LogicalAndOptions",
-                                      "LogicalNotOptions",
-                                      "UnpackOptions",
-                                      "FloorDivOptions",
-                                      "SquareOptions",
-                                      "ZerosLikeOptions",
-                                      "FillOptions",
-                                      "BidirectionalSequenceLSTMOptions",
-                                      "BidirectionalSequenceRNNOptions",
-                                      "UnidirectionalSequenceLSTMOptions",
-                                      "FloorModOptions",
-                                      "RangeOptions",
-                                      "ResizeNearestNeighborOptions",
-                                      "LeakyReluOptions",
-                                      "SquaredDifferenceOptions",
-                                      "MirrorPadOptions",
-                                      "AbsOptions",
-                                      "SplitVOptions",
-                                      "UniqueOptions",
-                                      "ReverseV2Options",
-                                      "AddNOptions",
-                                      "GatherNdOptions",
-                                      "CosOptions",
-                                      "WhereOptions",
-                                      "RankOptions",
-                                      "ReverseSequenceOptions",
-                                      "MatrixDiagOptions",
-                                      "QuantizeOptions",
-                                      "MatrixSetDiagOptions",
-                                      "HardSwishOptions",
-                                      "IfOptions",
-                                      "WhileOptions",
-                                      "DepthToSpaceOptions",
-                                      "NonMaxSuppressionV4Options",
-                                      "NonMaxSuppressionV5Options",
-                                      "ScatterNdOptions",
-                                      "SelectV2Options",
-                                      "DensifyOptions",
-                                      "SegmentSumOptions",
-                                      "BatchMatMulOptions",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "",
-                                      "BCQGatherOptions",
-                                      "BCQFullyConnectedOptions",
-                                      "InstanceNormOptions",
-                                      nullptr};
+  static const char *const names[256] = {"NONE",
+                                         "Conv2DOptions",
+                                         "DepthwiseConv2DOptions",
+                                         "ConcatEmbeddingsOptions",
+                                         "LSHProjectionOptions",
+                                         "Pool2DOptions",
+                                         "SVDFOptions",
+                                         "RNNOptions",
+                                         "FullyConnectedOptions",
+                                         "SoftmaxOptions",
+                                         "ConcatenationOptions",
+                                         "AddOptions",
+                                         "L2NormOptions",
+                                         "LocalResponseNormalizationOptions",
+                                         "LSTMOptions",
+                                         "ResizeBilinearOptions",
+                                         "CallOptions",
+                                         "ReshapeOptions",
+                                         "SkipGramOptions",
+                                         "SpaceToDepthOptions",
+                                         "EmbeddingLookupSparseOptions",
+                                         "MulOptions",
+                                         "PadOptions",
+                                         "GatherOptions",
+                                         "BatchToSpaceNDOptions",
+                                         "SpaceToBatchNDOptions",
+                                         "TransposeOptions",
+                                         "ReducerOptions",
+                                         "SubOptions",
+                                         "DivOptions",
+                                         "SqueezeOptions",
+                                         "SequenceRNNOptions",
+                                         "StridedSliceOptions",
+                                         "ExpOptions",
+                                         "TopKV2Options",
+                                         "SplitOptions",
+                                         "LogSoftmaxOptions",
+                                         "CastOptions",
+                                         "DequantizeOptions",
+                                         "MaximumMinimumOptions",
+                                         "ArgMaxOptions",
+                                         "LessOptions",
+                                         "NegOptions",
+                                         "PadV2Options",
+                                         "GreaterOptions",
+                                         "GreaterEqualOptions",
+                                         "LessEqualOptions",
+                                         "SelectOptions",
+                                         "SliceOptions",
+                                         "TransposeConvOptions",
+                                         "SparseToDenseOptions",
+                                         "TileOptions",
+                                         "ExpandDimsOptions",
+                                         "EqualOptions",
+                                         "NotEqualOptions",
+                                         "ShapeOptions",
+                                         "PowOptions",
+                                         "ArgMinOptions",
+                                         "FakeQuantOptions",
+                                         "PackOptions",
+                                         "LogicalOrOptions",
+                                         "OneHotOptions",
+                                         "LogicalAndOptions",
+                                         "LogicalNotOptions",
+                                         "UnpackOptions",
+                                         "FloorDivOptions",
+                                         "SquareOptions",
+                                         "ZerosLikeOptions",
+                                         "FillOptions",
+                                         "BidirectionalSequenceLSTMOptions",
+                                         "BidirectionalSequenceRNNOptions",
+                                         "UnidirectionalSequenceLSTMOptions",
+                                         "FloorModOptions",
+                                         "RangeOptions",
+                                         "ResizeNearestNeighborOptions",
+                                         "LeakyReluOptions",
+                                         "SquaredDifferenceOptions",
+                                         "MirrorPadOptions",
+                                         "AbsOptions",
+                                         "SplitVOptions",
+                                         "UniqueOptions",
+                                         "ReverseV2Options",
+                                         "AddNOptions",
+                                         "GatherNdOptions",
+                                         "CosOptions",
+                                         "WhereOptions",
+                                         "RankOptions",
+                                         "ReverseSequenceOptions",
+                                         "MatrixDiagOptions",
+                                         "QuantizeOptions",
+                                         "MatrixSetDiagOptions",
+                                         "HardSwishOptions",
+                                         "IfOptions",
+                                         "WhileOptions",
+                                         "DepthToSpaceOptions",
+                                         "NonMaxSuppressionV4Options",
+                                         "NonMaxSuppressionV5Options",
+                                         "ScatterNdOptions",
+                                         "SelectV2Options",
+                                         "DensifyOptions",
+                                         "SegmentSumOptions",
+                                         "BatchMatMulOptions",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "",
+                                         "BCQGatherOptions",
+                                         "BCQFullyConnectedOptions",
+                                         "InstanceNormOptions",
+                                         nullptr};
   return names;
 }
 
 inline const char *EnumNameBuiltinOptions(BuiltinOptions e)
 {
-  const size_t index = static_cast<int>(e);
+  if (flatbuffers::IsOutRange(e, BuiltinOptions_NONE, BuiltinOptions_InstanceNormOptions))
+    return "";
+  const size_t index = static_cast<size_t>(e);
   return EnumNamesBuiltinOptions()[index];
 }
 
@@ -1457,522 +1587,522 @@ template <typename T> struct BuiltinOptionsTraits
   static const BuiltinOptions enum_value = BuiltinOptions_NONE;
 };
 
-template <> struct BuiltinOptionsTraits<Conv2DOptions>
+template <> struct BuiltinOptionsTraits<circle::Conv2DOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_Conv2DOptions;
 };
 
-template <> struct BuiltinOptionsTraits<DepthwiseConv2DOptions>
+template <> struct BuiltinOptionsTraits<circle::DepthwiseConv2DOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_DepthwiseConv2DOptions;
 };
 
-template <> struct BuiltinOptionsTraits<ConcatEmbeddingsOptions>
+template <> struct BuiltinOptionsTraits<circle::ConcatEmbeddingsOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_ConcatEmbeddingsOptions;
 };
 
-template <> struct BuiltinOptionsTraits<LSHProjectionOptions>
+template <> struct BuiltinOptionsTraits<circle::LSHProjectionOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_LSHProjectionOptions;
 };
 
-template <> struct BuiltinOptionsTraits<Pool2DOptions>
+template <> struct BuiltinOptionsTraits<circle::Pool2DOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_Pool2DOptions;
 };
 
-template <> struct BuiltinOptionsTraits<SVDFOptions>
+template <> struct BuiltinOptionsTraits<circle::SVDFOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_SVDFOptions;
 };
 
-template <> struct BuiltinOptionsTraits<RNNOptions>
+template <> struct BuiltinOptionsTraits<circle::RNNOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_RNNOptions;
 };
 
-template <> struct BuiltinOptionsTraits<FullyConnectedOptions>
+template <> struct BuiltinOptionsTraits<circle::FullyConnectedOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_FullyConnectedOptions;
 };
 
-template <> struct BuiltinOptionsTraits<SoftmaxOptions>
+template <> struct BuiltinOptionsTraits<circle::SoftmaxOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_SoftmaxOptions;
 };
 
-template <> struct BuiltinOptionsTraits<ConcatenationOptions>
+template <> struct BuiltinOptionsTraits<circle::ConcatenationOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_ConcatenationOptions;
 };
 
-template <> struct BuiltinOptionsTraits<AddOptions>
+template <> struct BuiltinOptionsTraits<circle::AddOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_AddOptions;
 };
 
-template <> struct BuiltinOptionsTraits<L2NormOptions>
+template <> struct BuiltinOptionsTraits<circle::L2NormOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_L2NormOptions;
 };
 
-template <> struct BuiltinOptionsTraits<LocalResponseNormalizationOptions>
+template <> struct BuiltinOptionsTraits<circle::LocalResponseNormalizationOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_LocalResponseNormalizationOptions;
 };
 
-template <> struct BuiltinOptionsTraits<LSTMOptions>
+template <> struct BuiltinOptionsTraits<circle::LSTMOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_LSTMOptions;
 };
 
-template <> struct BuiltinOptionsTraits<ResizeBilinearOptions>
+template <> struct BuiltinOptionsTraits<circle::ResizeBilinearOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_ResizeBilinearOptions;
 };
 
-template <> struct BuiltinOptionsTraits<CallOptions>
+template <> struct BuiltinOptionsTraits<circle::CallOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_CallOptions;
 };
 
-template <> struct BuiltinOptionsTraits<ReshapeOptions>
+template <> struct BuiltinOptionsTraits<circle::ReshapeOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_ReshapeOptions;
 };
 
-template <> struct BuiltinOptionsTraits<SkipGramOptions>
+template <> struct BuiltinOptionsTraits<circle::SkipGramOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_SkipGramOptions;
 };
 
-template <> struct BuiltinOptionsTraits<SpaceToDepthOptions>
+template <> struct BuiltinOptionsTraits<circle::SpaceToDepthOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_SpaceToDepthOptions;
 };
 
-template <> struct BuiltinOptionsTraits<EmbeddingLookupSparseOptions>
+template <> struct BuiltinOptionsTraits<circle::EmbeddingLookupSparseOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_EmbeddingLookupSparseOptions;
 };
 
-template <> struct BuiltinOptionsTraits<MulOptions>
+template <> struct BuiltinOptionsTraits<circle::MulOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_MulOptions;
 };
 
-template <> struct BuiltinOptionsTraits<PadOptions>
+template <> struct BuiltinOptionsTraits<circle::PadOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_PadOptions;
 };
 
-template <> struct BuiltinOptionsTraits<GatherOptions>
+template <> struct BuiltinOptionsTraits<circle::GatherOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_GatherOptions;
 };
 
-template <> struct BuiltinOptionsTraits<BatchToSpaceNDOptions>
+template <> struct BuiltinOptionsTraits<circle::BatchToSpaceNDOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_BatchToSpaceNDOptions;
 };
 
-template <> struct BuiltinOptionsTraits<SpaceToBatchNDOptions>
+template <> struct BuiltinOptionsTraits<circle::SpaceToBatchNDOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_SpaceToBatchNDOptions;
 };
 
-template <> struct BuiltinOptionsTraits<TransposeOptions>
+template <> struct BuiltinOptionsTraits<circle::TransposeOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_TransposeOptions;
 };
 
-template <> struct BuiltinOptionsTraits<ReducerOptions>
+template <> struct BuiltinOptionsTraits<circle::ReducerOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_ReducerOptions;
 };
 
-template <> struct BuiltinOptionsTraits<SubOptions>
+template <> struct BuiltinOptionsTraits<circle::SubOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_SubOptions;
 };
 
-template <> struct BuiltinOptionsTraits<DivOptions>
+template <> struct BuiltinOptionsTraits<circle::DivOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_DivOptions;
 };
 
-template <> struct BuiltinOptionsTraits<SqueezeOptions>
+template <> struct BuiltinOptionsTraits<circle::SqueezeOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_SqueezeOptions;
 };
 
-template <> struct BuiltinOptionsTraits<SequenceRNNOptions>
+template <> struct BuiltinOptionsTraits<circle::SequenceRNNOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_SequenceRNNOptions;
 };
 
-template <> struct BuiltinOptionsTraits<StridedSliceOptions>
+template <> struct BuiltinOptionsTraits<circle::StridedSliceOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_StridedSliceOptions;
 };
 
-template <> struct BuiltinOptionsTraits<ExpOptions>
+template <> struct BuiltinOptionsTraits<circle::ExpOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_ExpOptions;
 };
 
-template <> struct BuiltinOptionsTraits<TopKV2Options>
+template <> struct BuiltinOptionsTraits<circle::TopKV2Options>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_TopKV2Options;
 };
 
-template <> struct BuiltinOptionsTraits<SplitOptions>
+template <> struct BuiltinOptionsTraits<circle::SplitOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_SplitOptions;
 };
 
-template <> struct BuiltinOptionsTraits<LogSoftmaxOptions>
+template <> struct BuiltinOptionsTraits<circle::LogSoftmaxOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_LogSoftmaxOptions;
 };
 
-template <> struct BuiltinOptionsTraits<CastOptions>
+template <> struct BuiltinOptionsTraits<circle::CastOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_CastOptions;
 };
 
-template <> struct BuiltinOptionsTraits<DequantizeOptions>
+template <> struct BuiltinOptionsTraits<circle::DequantizeOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_DequantizeOptions;
 };
 
-template <> struct BuiltinOptionsTraits<MaximumMinimumOptions>
+template <> struct BuiltinOptionsTraits<circle::MaximumMinimumOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_MaximumMinimumOptions;
 };
 
-template <> struct BuiltinOptionsTraits<ArgMaxOptions>
+template <> struct BuiltinOptionsTraits<circle::ArgMaxOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_ArgMaxOptions;
 };
 
-template <> struct BuiltinOptionsTraits<LessOptions>
+template <> struct BuiltinOptionsTraits<circle::LessOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_LessOptions;
 };
 
-template <> struct BuiltinOptionsTraits<NegOptions>
+template <> struct BuiltinOptionsTraits<circle::NegOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_NegOptions;
 };
 
-template <> struct BuiltinOptionsTraits<PadV2Options>
+template <> struct BuiltinOptionsTraits<circle::PadV2Options>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_PadV2Options;
 };
 
-template <> struct BuiltinOptionsTraits<GreaterOptions>
+template <> struct BuiltinOptionsTraits<circle::GreaterOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_GreaterOptions;
 };
 
-template <> struct BuiltinOptionsTraits<GreaterEqualOptions>
+template <> struct BuiltinOptionsTraits<circle::GreaterEqualOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_GreaterEqualOptions;
 };
 
-template <> struct BuiltinOptionsTraits<LessEqualOptions>
+template <> struct BuiltinOptionsTraits<circle::LessEqualOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_LessEqualOptions;
 };
 
-template <> struct BuiltinOptionsTraits<SelectOptions>
+template <> struct BuiltinOptionsTraits<circle::SelectOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_SelectOptions;
 };
 
-template <> struct BuiltinOptionsTraits<SliceOptions>
+template <> struct BuiltinOptionsTraits<circle::SliceOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_SliceOptions;
 };
 
-template <> struct BuiltinOptionsTraits<TransposeConvOptions>
+template <> struct BuiltinOptionsTraits<circle::TransposeConvOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_TransposeConvOptions;
 };
 
-template <> struct BuiltinOptionsTraits<SparseToDenseOptions>
+template <> struct BuiltinOptionsTraits<circle::SparseToDenseOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_SparseToDenseOptions;
 };
 
-template <> struct BuiltinOptionsTraits<TileOptions>
+template <> struct BuiltinOptionsTraits<circle::TileOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_TileOptions;
 };
 
-template <> struct BuiltinOptionsTraits<ExpandDimsOptions>
+template <> struct BuiltinOptionsTraits<circle::ExpandDimsOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_ExpandDimsOptions;
 };
 
-template <> struct BuiltinOptionsTraits<EqualOptions>
+template <> struct BuiltinOptionsTraits<circle::EqualOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_EqualOptions;
 };
 
-template <> struct BuiltinOptionsTraits<NotEqualOptions>
+template <> struct BuiltinOptionsTraits<circle::NotEqualOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_NotEqualOptions;
 };
 
-template <> struct BuiltinOptionsTraits<ShapeOptions>
+template <> struct BuiltinOptionsTraits<circle::ShapeOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_ShapeOptions;
 };
 
-template <> struct BuiltinOptionsTraits<PowOptions>
+template <> struct BuiltinOptionsTraits<circle::PowOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_PowOptions;
 };
 
-template <> struct BuiltinOptionsTraits<ArgMinOptions>
+template <> struct BuiltinOptionsTraits<circle::ArgMinOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_ArgMinOptions;
 };
 
-template <> struct BuiltinOptionsTraits<FakeQuantOptions>
+template <> struct BuiltinOptionsTraits<circle::FakeQuantOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_FakeQuantOptions;
 };
 
-template <> struct BuiltinOptionsTraits<PackOptions>
+template <> struct BuiltinOptionsTraits<circle::PackOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_PackOptions;
 };
 
-template <> struct BuiltinOptionsTraits<LogicalOrOptions>
+template <> struct BuiltinOptionsTraits<circle::LogicalOrOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_LogicalOrOptions;
 };
 
-template <> struct BuiltinOptionsTraits<OneHotOptions>
+template <> struct BuiltinOptionsTraits<circle::OneHotOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_OneHotOptions;
 };
 
-template <> struct BuiltinOptionsTraits<LogicalAndOptions>
+template <> struct BuiltinOptionsTraits<circle::LogicalAndOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_LogicalAndOptions;
 };
 
-template <> struct BuiltinOptionsTraits<LogicalNotOptions>
+template <> struct BuiltinOptionsTraits<circle::LogicalNotOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_LogicalNotOptions;
 };
 
-template <> struct BuiltinOptionsTraits<UnpackOptions>
+template <> struct BuiltinOptionsTraits<circle::UnpackOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_UnpackOptions;
 };
 
-template <> struct BuiltinOptionsTraits<FloorDivOptions>
+template <> struct BuiltinOptionsTraits<circle::FloorDivOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_FloorDivOptions;
 };
 
-template <> struct BuiltinOptionsTraits<SquareOptions>
+template <> struct BuiltinOptionsTraits<circle::SquareOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_SquareOptions;
 };
 
-template <> struct BuiltinOptionsTraits<ZerosLikeOptions>
+template <> struct BuiltinOptionsTraits<circle::ZerosLikeOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_ZerosLikeOptions;
 };
 
-template <> struct BuiltinOptionsTraits<FillOptions>
+template <> struct BuiltinOptionsTraits<circle::FillOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_FillOptions;
 };
 
-template <> struct BuiltinOptionsTraits<BidirectionalSequenceLSTMOptions>
+template <> struct BuiltinOptionsTraits<circle::BidirectionalSequenceLSTMOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_BidirectionalSequenceLSTMOptions;
 };
 
-template <> struct BuiltinOptionsTraits<BidirectionalSequenceRNNOptions>
+template <> struct BuiltinOptionsTraits<circle::BidirectionalSequenceRNNOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_BidirectionalSequenceRNNOptions;
 };
 
-template <> struct BuiltinOptionsTraits<UnidirectionalSequenceLSTMOptions>
+template <> struct BuiltinOptionsTraits<circle::UnidirectionalSequenceLSTMOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_UnidirectionalSequenceLSTMOptions;
 };
 
-template <> struct BuiltinOptionsTraits<FloorModOptions>
+template <> struct BuiltinOptionsTraits<circle::FloorModOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_FloorModOptions;
 };
 
-template <> struct BuiltinOptionsTraits<RangeOptions>
+template <> struct BuiltinOptionsTraits<circle::RangeOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_RangeOptions;
 };
 
-template <> struct BuiltinOptionsTraits<ResizeNearestNeighborOptions>
+template <> struct BuiltinOptionsTraits<circle::ResizeNearestNeighborOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_ResizeNearestNeighborOptions;
 };
 
-template <> struct BuiltinOptionsTraits<LeakyReluOptions>
+template <> struct BuiltinOptionsTraits<circle::LeakyReluOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_LeakyReluOptions;
 };
 
-template <> struct BuiltinOptionsTraits<SquaredDifferenceOptions>
+template <> struct BuiltinOptionsTraits<circle::SquaredDifferenceOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_SquaredDifferenceOptions;
 };
 
-template <> struct BuiltinOptionsTraits<MirrorPadOptions>
+template <> struct BuiltinOptionsTraits<circle::MirrorPadOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_MirrorPadOptions;
 };
 
-template <> struct BuiltinOptionsTraits<AbsOptions>
+template <> struct BuiltinOptionsTraits<circle::AbsOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_AbsOptions;
 };
 
-template <> struct BuiltinOptionsTraits<SplitVOptions>
+template <> struct BuiltinOptionsTraits<circle::SplitVOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_SplitVOptions;
 };
 
-template <> struct BuiltinOptionsTraits<UniqueOptions>
+template <> struct BuiltinOptionsTraits<circle::UniqueOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_UniqueOptions;
 };
 
-template <> struct BuiltinOptionsTraits<ReverseV2Options>
+template <> struct BuiltinOptionsTraits<circle::ReverseV2Options>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_ReverseV2Options;
 };
 
-template <> struct BuiltinOptionsTraits<AddNOptions>
+template <> struct BuiltinOptionsTraits<circle::AddNOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_AddNOptions;
 };
 
-template <> struct BuiltinOptionsTraits<GatherNdOptions>
+template <> struct BuiltinOptionsTraits<circle::GatherNdOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_GatherNdOptions;
 };
 
-template <> struct BuiltinOptionsTraits<CosOptions>
+template <> struct BuiltinOptionsTraits<circle::CosOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_CosOptions;
 };
 
-template <> struct BuiltinOptionsTraits<WhereOptions>
+template <> struct BuiltinOptionsTraits<circle::WhereOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_WhereOptions;
 };
 
-template <> struct BuiltinOptionsTraits<RankOptions>
+template <> struct BuiltinOptionsTraits<circle::RankOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_RankOptions;
 };
 
-template <> struct BuiltinOptionsTraits<ReverseSequenceOptions>
+template <> struct BuiltinOptionsTraits<circle::ReverseSequenceOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_ReverseSequenceOptions;
 };
 
-template <> struct BuiltinOptionsTraits<MatrixDiagOptions>
+template <> struct BuiltinOptionsTraits<circle::MatrixDiagOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_MatrixDiagOptions;
 };
 
-template <> struct BuiltinOptionsTraits<QuantizeOptions>
+template <> struct BuiltinOptionsTraits<circle::QuantizeOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_QuantizeOptions;
 };
 
-template <> struct BuiltinOptionsTraits<MatrixSetDiagOptions>
+template <> struct BuiltinOptionsTraits<circle::MatrixSetDiagOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_MatrixSetDiagOptions;
 };
 
-template <> struct BuiltinOptionsTraits<HardSwishOptions>
+template <> struct BuiltinOptionsTraits<circle::HardSwishOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_HardSwishOptions;
 };
 
-template <> struct BuiltinOptionsTraits<IfOptions>
+template <> struct BuiltinOptionsTraits<circle::IfOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_IfOptions;
 };
 
-template <> struct BuiltinOptionsTraits<WhileOptions>
+template <> struct BuiltinOptionsTraits<circle::WhileOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_WhileOptions;
 };
 
-template <> struct BuiltinOptionsTraits<DepthToSpaceOptions>
+template <> struct BuiltinOptionsTraits<circle::DepthToSpaceOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_DepthToSpaceOptions;
 };
 
-template <> struct BuiltinOptionsTraits<NonMaxSuppressionV4Options>
+template <> struct BuiltinOptionsTraits<circle::NonMaxSuppressionV4Options>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_NonMaxSuppressionV4Options;
 };
 
-template <> struct BuiltinOptionsTraits<NonMaxSuppressionV5Options>
+template <> struct BuiltinOptionsTraits<circle::NonMaxSuppressionV5Options>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_NonMaxSuppressionV5Options;
 };
 
-template <> struct BuiltinOptionsTraits<ScatterNdOptions>
+template <> struct BuiltinOptionsTraits<circle::ScatterNdOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_ScatterNdOptions;
 };
 
-template <> struct BuiltinOptionsTraits<SelectV2Options>
+template <> struct BuiltinOptionsTraits<circle::SelectV2Options>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_SelectV2Options;
 };
 
-template <> struct BuiltinOptionsTraits<DensifyOptions>
+template <> struct BuiltinOptionsTraits<circle::DensifyOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_DensifyOptions;
 };
 
-template <> struct BuiltinOptionsTraits<SegmentSumOptions>
+template <> struct BuiltinOptionsTraits<circle::SegmentSumOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_SegmentSumOptions;
 };
 
-template <> struct BuiltinOptionsTraits<BatchMatMulOptions>
+template <> struct BuiltinOptionsTraits<circle::BatchMatMulOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_BatchMatMulOptions;
 };
 
-template <> struct BuiltinOptionsTraits<BCQGatherOptions>
+template <> struct BuiltinOptionsTraits<circle::BCQGatherOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_BCQGatherOptions;
 };
 
-template <> struct BuiltinOptionsTraits<BCQFullyConnectedOptions>
+template <> struct BuiltinOptionsTraits<circle::BCQFullyConnectedOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_BCQFullyConnectedOptions;
 };
 
-template <> struct BuiltinOptionsTraits<InstanceNormOptions>
+template <> struct BuiltinOptionsTraits<circle::InstanceNormOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_InstanceNormOptions;
 };
@@ -1998,13 +2128,15 @@ inline const Padding (&EnumValuesPadding())[2]
 
 inline const char *const *EnumNamesPadding()
 {
-  static const char *const names[] = {"SAME", "VALID", nullptr};
+  static const char *const names[3] = {"SAME", "VALID", nullptr};
   return names;
 }
 
 inline const char *EnumNamePadding(Padding e)
 {
-  const size_t index = static_cast<int>(e);
+  if (flatbuffers::IsOutRange(e, Padding_SAME, Padding_VALID))
+    return "";
+  const size_t index = static_cast<size_t>(e);
   return EnumNamesPadding()[index];
 }
 
@@ -2031,14 +2163,16 @@ inline const ActivationFunctionType (&EnumValuesActivationFunctionType())[6]
 
 inline const char *const *EnumNamesActivationFunctionType()
 {
-  static const char *const names[] = {"NONE", "RELU",     "RELU_N1_TO_1", "RELU6",
-                                      "TANH", "SIGN_BIT", nullptr};
+  static const char *const names[7] = {"NONE", "RELU",     "RELU_N1_TO_1", "RELU6",
+                                       "TANH", "SIGN_BIT", nullptr};
   return names;
 }
 
 inline const char *EnumNameActivationFunctionType(ActivationFunctionType e)
 {
-  const size_t index = static_cast<int>(e);
+  if (flatbuffers::IsOutRange(e, ActivationFunctionType_NONE, ActivationFunctionType_SIGN_BIT))
+    return "";
+  const size_t index = static_cast<size_t>(e);
   return EnumNamesActivationFunctionType()[index];
 }
 
@@ -2060,13 +2194,15 @@ inline const LSHProjectionType (&EnumValuesLSHProjectionType())[3]
 
 inline const char *const *EnumNamesLSHProjectionType()
 {
-  static const char *const names[] = {"UNKNOWN", "SPARSE", "DENSE", nullptr};
+  static const char *const names[4] = {"UNKNOWN", "SPARSE", "DENSE", nullptr};
   return names;
 }
 
 inline const char *EnumNameLSHProjectionType(LSHProjectionType e)
 {
-  const size_t index = static_cast<int>(e);
+  if (flatbuffers::IsOutRange(e, LSHProjectionType_UNKNOWN, LSHProjectionType_DENSE))
+    return "";
+  const size_t index = static_cast<size_t>(e);
   return EnumNamesLSHProjectionType()[index];
 }
 
@@ -2074,28 +2210,33 @@ enum FullyConnectedOptionsWeightsFormat
 {
   FullyConnectedOptionsWeightsFormat_DEFAULT = 0,
   FullyConnectedOptionsWeightsFormat_SHUFFLED4x16INT8 = 1,
+  FullyConnectedOptionsWeightsFormat_SHUFFLED16x1FLOAT32 = 127,
   FullyConnectedOptionsWeightsFormat_MIN = FullyConnectedOptionsWeightsFormat_DEFAULT,
-  FullyConnectedOptionsWeightsFormat_MAX = FullyConnectedOptionsWeightsFormat_SHUFFLED4x16INT8
+  FullyConnectedOptionsWeightsFormat_MAX = FullyConnectedOptionsWeightsFormat_SHUFFLED16x1FLOAT32
 };
 
-inline const FullyConnectedOptionsWeightsFormat (&EnumValuesFullyConnectedOptionsWeightsFormat())[2]
+inline const FullyConnectedOptionsWeightsFormat (&EnumValuesFullyConnectedOptionsWeightsFormat())[3]
 {
   static const FullyConnectedOptionsWeightsFormat values[] = {
       FullyConnectedOptionsWeightsFormat_DEFAULT,
-      FullyConnectedOptionsWeightsFormat_SHUFFLED4x16INT8};
+      FullyConnectedOptionsWeightsFormat_SHUFFLED4x16INT8,
+      FullyConnectedOptionsWeightsFormat_SHUFFLED16x1FLOAT32};
   return values;
-}
-
-inline const char *const *EnumNamesFullyConnectedOptionsWeightsFormat()
-{
-  static const char *const names[] = {"DEFAULT", "SHUFFLED4x16INT8", nullptr};
-  return names;
 }
 
 inline const char *EnumNameFullyConnectedOptionsWeightsFormat(FullyConnectedOptionsWeightsFormat e)
 {
-  const size_t index = static_cast<int>(e);
-  return EnumNamesFullyConnectedOptionsWeightsFormat()[index];
+  switch (e)
+  {
+    case FullyConnectedOptionsWeightsFormat_DEFAULT:
+      return "DEFAULT";
+    case FullyConnectedOptionsWeightsFormat_SHUFFLED4x16INT8:
+      return "SHUFFLED4x16INT8";
+    case FullyConnectedOptionsWeightsFormat_SHUFFLED16x1FLOAT32:
+      return "SHUFFLED16x1FLOAT32";
+    default:
+      return "";
+  }
 }
 
 enum LSTMKernelType
@@ -2114,13 +2255,15 @@ inline const LSTMKernelType (&EnumValuesLSTMKernelType())[2]
 
 inline const char *const *EnumNamesLSTMKernelType()
 {
-  static const char *const names[] = {"FULL", "BASIC", nullptr};
+  static const char *const names[3] = {"FULL", "BASIC", nullptr};
   return names;
 }
 
 inline const char *EnumNameLSTMKernelType(LSTMKernelType e)
 {
-  const size_t index = static_cast<int>(e);
+  if (flatbuffers::IsOutRange(e, LSTMKernelType_FULL, LSTMKernelType_BASIC))
+    return "";
+  const size_t index = static_cast<size_t>(e);
   return EnumNamesLSTMKernelType()[index];
 }
 
@@ -2141,13 +2284,15 @@ inline const CombinerType (&EnumValuesCombinerType())[3]
 
 inline const char *const *EnumNamesCombinerType()
 {
-  static const char *const names[] = {"SUM", "MEAN", "SQRTN", nullptr};
+  static const char *const names[4] = {"SUM", "MEAN", "SQRTN", nullptr};
   return names;
 }
 
 inline const char *EnumNameCombinerType(CombinerType e)
 {
-  const size_t index = static_cast<int>(e);
+  if (flatbuffers::IsOutRange(e, CombinerType_SUM, CombinerType_SQRTN))
+    return "";
+  const size_t index = static_cast<size_t>(e);
   return EnumNamesCombinerType()[index];
 }
 
@@ -2167,13 +2312,15 @@ inline const MirrorPadMode (&EnumValuesMirrorPadMode())[2]
 
 inline const char *const *EnumNamesMirrorPadMode()
 {
-  static const char *const names[] = {"REFLECT", "SYMMETRIC", nullptr};
+  static const char *const names[3] = {"REFLECT", "SYMMETRIC", nullptr};
   return names;
 }
 
 inline const char *EnumNameMirrorPadMode(MirrorPadMode e)
 {
-  const size_t index = static_cast<int>(e);
+  if (flatbuffers::IsOutRange(e, MirrorPadMode_REFLECT, MirrorPadMode_SYMMETRIC))
+    return "";
+  const size_t index = static_cast<size_t>(e);
   return EnumNamesMirrorPadMode()[index];
 }
 
@@ -2192,13 +2339,15 @@ inline const CustomOptionsFormat (&EnumValuesCustomOptionsFormat())[1]
 
 inline const char *const *EnumNamesCustomOptionsFormat()
 {
-  static const char *const names[] = {"FLEXBUFFERS", nullptr};
+  static const char *const names[2] = {"FLEXBUFFERS", nullptr};
   return names;
 }
 
 inline const char *EnumNameCustomOptionsFormat(CustomOptionsFormat e)
 {
-  const size_t index = static_cast<int>(e);
+  if (flatbuffers::IsOutRange(e, CustomOptionsFormat_FLEXBUFFERS, CustomOptionsFormat_FLEXBUFFERS))
+    return "";
+  const size_t index = static_cast<size_t>(e);
   return EnumNamesCustomOptionsFormat()[index];
 }
 
@@ -2218,19 +2367,22 @@ inline const DataFormat (&EnumValuesDataFormat())[2]
 
 inline const char *const *EnumNamesDataFormat()
 {
-  static const char *const names[] = {"CHANNELS_LAST", "CHANNELS_FIRST", nullptr};
+  static const char *const names[3] = {"CHANNELS_LAST", "CHANNELS_FIRST", nullptr};
   return names;
 }
 
 inline const char *EnumNameDataFormat(DataFormat e)
 {
-  const size_t index = static_cast<int>(e);
+  if (flatbuffers::IsOutRange(e, DataFormat_CHANNELS_LAST, DataFormat_CHANNELS_FIRST))
+    return "";
+  const size_t index = static_cast<size_t>(e);
   return EnumNamesDataFormat()[index];
 }
 
 struct CustomQuantization FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef CustomQuantizationBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_CUSTOM = 4
   };
@@ -2247,6 +2399,7 @@ struct CustomQuantization FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct CustomQuantizationBuilder
 {
+  typedef CustomQuantization Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_custom(flatbuffers::Offset<flatbuffers::Vector<uint8_t>> custom)
@@ -2279,12 +2432,18 @@ inline flatbuffers::Offset<CustomQuantization>
 CreateCustomQuantizationDirect(flatbuffers::FlatBufferBuilder &_fbb,
                                const std::vector<uint8_t> *custom = nullptr)
 {
-  return circle::CreateCustomQuantization(_fbb, custom ? _fbb.CreateVector<uint8_t>(*custom) : 0);
+  if (custom)
+  {
+    _fbb.ForceVectorAlignment(custom->size(), sizeof(uint8_t), 16);
+  }
+  auto custom__ = custom ? _fbb.CreateVector<uint8_t>(*custom) : 0;
+  return circle::CreateCustomQuantization(_fbb, custom__);
 }
 
 struct QuantizationParameters FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef QuantizationParametersBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_MIN = 4,
     VT_MAX = 6,
@@ -2310,16 +2469,16 @@ struct QuantizationParameters FLATBUFFERS_FINAL_CLASS : private flatbuffers::Tab
   {
     return GetPointer<const flatbuffers::Vector<int64_t> *>(VT_ZERO_POINT);
   }
-  QuantizationDetails details_type() const
+  circle::QuantizationDetails details_type() const
   {
-    return static_cast<QuantizationDetails>(GetField<uint8_t>(VT_DETAILS_TYPE, 0));
+    return static_cast<circle::QuantizationDetails>(GetField<uint8_t>(VT_DETAILS_TYPE, 0));
   }
   const void *details() const { return GetPointer<const void *>(VT_DETAILS); }
   template <typename T> const T *details_as() const;
-  const CustomQuantization *details_as_CustomQuantization() const
+  const circle::CustomQuantization *details_as_CustomQuantization() const
   {
-    return details_type() == QuantizationDetails_CustomQuantization
-               ? static_cast<const CustomQuantization *>(details())
+    return details_type() == circle::QuantizationDetails_CustomQuantization
+               ? static_cast<const circle::CustomQuantization *>(details())
                : nullptr;
   }
   int32_t quantized_dimension() const { return GetField<int32_t>(VT_QUANTIZED_DIMENSION, 0); }
@@ -2337,13 +2496,15 @@ struct QuantizationParameters FLATBUFFERS_FINAL_CLASS : private flatbuffers::Tab
 };
 
 template <>
-inline const CustomQuantization *QuantizationParameters::details_as<CustomQuantization>() const
+inline const circle::CustomQuantization *
+QuantizationParameters::details_as<circle::CustomQuantization>() const
 {
   return details_as_CustomQuantization();
 }
 
 struct QuantizationParametersBuilder
 {
+  typedef QuantizationParameters Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_min(flatbuffers::Offset<flatbuffers::Vector<float>> min)
@@ -2362,7 +2523,7 @@ struct QuantizationParametersBuilder
   {
     fbb_.AddOffset(QuantizationParameters::VT_ZERO_POINT, zero_point);
   }
-  void add_details_type(QuantizationDetails details_type)
+  void add_details_type(circle::QuantizationDetails details_type)
   {
     fbb_.AddElement<uint8_t>(QuantizationParameters::VT_DETAILS_TYPE,
                              static_cast<uint8_t>(details_type), 0);
@@ -2389,14 +2550,13 @@ struct QuantizationParametersBuilder
   }
 };
 
-inline flatbuffers::Offset<QuantizationParameters>
-CreateQuantizationParameters(flatbuffers::FlatBufferBuilder &_fbb,
-                             flatbuffers::Offset<flatbuffers::Vector<float>> min = 0,
-                             flatbuffers::Offset<flatbuffers::Vector<float>> max = 0,
-                             flatbuffers::Offset<flatbuffers::Vector<float>> scale = 0,
-                             flatbuffers::Offset<flatbuffers::Vector<int64_t>> zero_point = 0,
-                             QuantizationDetails details_type = QuantizationDetails_NONE,
-                             flatbuffers::Offset<void> details = 0, int32_t quantized_dimension = 0)
+inline flatbuffers::Offset<QuantizationParameters> CreateQuantizationParameters(
+    flatbuffers::FlatBufferBuilder &_fbb, flatbuffers::Offset<flatbuffers::Vector<float>> min = 0,
+    flatbuffers::Offset<flatbuffers::Vector<float>> max = 0,
+    flatbuffers::Offset<flatbuffers::Vector<float>> scale = 0,
+    flatbuffers::Offset<flatbuffers::Vector<int64_t>> zero_point = 0,
+    circle::QuantizationDetails details_type = circle::QuantizationDetails_NONE,
+    flatbuffers::Offset<void> details = 0, int32_t quantized_dimension = 0)
 {
   QuantizationParametersBuilder builder_(_fbb);
   builder_.add_quantized_dimension(quantized_dimension);
@@ -2413,19 +2573,21 @@ inline flatbuffers::Offset<QuantizationParameters> CreateQuantizationParametersD
     flatbuffers::FlatBufferBuilder &_fbb, const std::vector<float> *min = nullptr,
     const std::vector<float> *max = nullptr, const std::vector<float> *scale = nullptr,
     const std::vector<int64_t> *zero_point = nullptr,
-    QuantizationDetails details_type = QuantizationDetails_NONE,
+    circle::QuantizationDetails details_type = circle::QuantizationDetails_NONE,
     flatbuffers::Offset<void> details = 0, int32_t quantized_dimension = 0)
 {
-  return circle::CreateQuantizationParameters(
-      _fbb, min ? _fbb.CreateVector<float>(*min) : 0, max ? _fbb.CreateVector<float>(*max) : 0,
-      scale ? _fbb.CreateVector<float>(*scale) : 0,
-      zero_point ? _fbb.CreateVector<int64_t>(*zero_point) : 0, details_type, details,
-      quantized_dimension);
+  auto min__ = min ? _fbb.CreateVector<float>(*min) : 0;
+  auto max__ = max ? _fbb.CreateVector<float>(*max) : 0;
+  auto scale__ = scale ? _fbb.CreateVector<float>(*scale) : 0;
+  auto zero_point__ = zero_point ? _fbb.CreateVector<int64_t>(*zero_point) : 0;
+  return circle::CreateQuantizationParameters(_fbb, min__, max__, scale__, zero_point__,
+                                              details_type, details, quantized_dimension);
 }
 
 struct Int32Vector FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef Int32VectorBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_VALUES = 4
   };
@@ -2442,6 +2604,7 @@ struct Int32Vector FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct Int32VectorBuilder
 {
+  typedef Int32Vector Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_values(flatbuffers::Offset<flatbuffers::Vector<int32_t>> values)
@@ -2474,12 +2637,14 @@ inline flatbuffers::Offset<Int32Vector>
 CreateInt32VectorDirect(flatbuffers::FlatBufferBuilder &_fbb,
                         const std::vector<int32_t> *values = nullptr)
 {
-  return circle::CreateInt32Vector(_fbb, values ? _fbb.CreateVector<int32_t>(*values) : 0);
+  auto values__ = values ? _fbb.CreateVector<int32_t>(*values) : 0;
+  return circle::CreateInt32Vector(_fbb, values__);
 }
 
 struct Uint16Vector FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef Uint16VectorBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_VALUES = 4
   };
@@ -2496,6 +2661,7 @@ struct Uint16Vector FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct Uint16VectorBuilder
 {
+  typedef Uint16Vector Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_values(flatbuffers::Offset<flatbuffers::Vector<uint16_t>> values)
@@ -2528,12 +2694,18 @@ inline flatbuffers::Offset<Uint16Vector>
 CreateUint16VectorDirect(flatbuffers::FlatBufferBuilder &_fbb,
                          const std::vector<uint16_t> *values = nullptr)
 {
-  return circle::CreateUint16Vector(_fbb, values ? _fbb.CreateVector<uint16_t>(*values) : 0);
+  if (values)
+  {
+    _fbb.ForceVectorAlignment(values->size(), sizeof(uint16_t), 4);
+  }
+  auto values__ = values ? _fbb.CreateVector<uint16_t>(*values) : 0;
+  return circle::CreateUint16Vector(_fbb, values__);
 }
 
 struct Uint8Vector FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef Uint8VectorBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_VALUES = 4
   };
@@ -2550,6 +2722,7 @@ struct Uint8Vector FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct Uint8VectorBuilder
 {
+  typedef Uint8Vector Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_values(flatbuffers::Offset<flatbuffers::Vector<uint8_t>> values)
@@ -2582,12 +2755,18 @@ inline flatbuffers::Offset<Uint8Vector>
 CreateUint8VectorDirect(flatbuffers::FlatBufferBuilder &_fbb,
                         const std::vector<uint8_t> *values = nullptr)
 {
-  return circle::CreateUint8Vector(_fbb, values ? _fbb.CreateVector<uint8_t>(*values) : 0);
+  if (values)
+  {
+    _fbb.ForceVectorAlignment(values->size(), sizeof(uint8_t), 4);
+  }
+  auto values__ = values ? _fbb.CreateVector<uint8_t>(*values) : 0;
+  return circle::CreateUint8Vector(_fbb, values__);
 }
 
 struct DimensionMetadata FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef DimensionMetadataBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_FORMAT = 4,
     VT_DENSE_SIZE = 6,
@@ -2596,57 +2775,57 @@ struct DimensionMetadata FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
     VT_ARRAY_INDICES_TYPE = 12,
     VT_ARRAY_INDICES = 14
   };
-  DimensionType format() const
+  circle::DimensionType format() const
   {
-    return static_cast<DimensionType>(GetField<int8_t>(VT_FORMAT, 0));
+    return static_cast<circle::DimensionType>(GetField<int8_t>(VT_FORMAT, 0));
   }
   int32_t dense_size() const { return GetField<int32_t>(VT_DENSE_SIZE, 0); }
-  SparseIndexVector array_segments_type() const
+  circle::SparseIndexVector array_segments_type() const
   {
-    return static_cast<SparseIndexVector>(GetField<uint8_t>(VT_ARRAY_SEGMENTS_TYPE, 0));
+    return static_cast<circle::SparseIndexVector>(GetField<uint8_t>(VT_ARRAY_SEGMENTS_TYPE, 0));
   }
   const void *array_segments() const { return GetPointer<const void *>(VT_ARRAY_SEGMENTS); }
   template <typename T> const T *array_segments_as() const;
-  const Int32Vector *array_segments_as_Int32Vector() const
+  const circle::Int32Vector *array_segments_as_Int32Vector() const
   {
-    return array_segments_type() == SparseIndexVector_Int32Vector
-               ? static_cast<const Int32Vector *>(array_segments())
+    return array_segments_type() == circle::SparseIndexVector_Int32Vector
+               ? static_cast<const circle::Int32Vector *>(array_segments())
                : nullptr;
   }
-  const Uint16Vector *array_segments_as_Uint16Vector() const
+  const circle::Uint16Vector *array_segments_as_Uint16Vector() const
   {
-    return array_segments_type() == SparseIndexVector_Uint16Vector
-               ? static_cast<const Uint16Vector *>(array_segments())
+    return array_segments_type() == circle::SparseIndexVector_Uint16Vector
+               ? static_cast<const circle::Uint16Vector *>(array_segments())
                : nullptr;
   }
-  const Uint8Vector *array_segments_as_Uint8Vector() const
+  const circle::Uint8Vector *array_segments_as_Uint8Vector() const
   {
-    return array_segments_type() == SparseIndexVector_Uint8Vector
-               ? static_cast<const Uint8Vector *>(array_segments())
+    return array_segments_type() == circle::SparseIndexVector_Uint8Vector
+               ? static_cast<const circle::Uint8Vector *>(array_segments())
                : nullptr;
   }
-  SparseIndexVector array_indices_type() const
+  circle::SparseIndexVector array_indices_type() const
   {
-    return static_cast<SparseIndexVector>(GetField<uint8_t>(VT_ARRAY_INDICES_TYPE, 0));
+    return static_cast<circle::SparseIndexVector>(GetField<uint8_t>(VT_ARRAY_INDICES_TYPE, 0));
   }
   const void *array_indices() const { return GetPointer<const void *>(VT_ARRAY_INDICES); }
   template <typename T> const T *array_indices_as() const;
-  const Int32Vector *array_indices_as_Int32Vector() const
+  const circle::Int32Vector *array_indices_as_Int32Vector() const
   {
-    return array_indices_type() == SparseIndexVector_Int32Vector
-               ? static_cast<const Int32Vector *>(array_indices())
+    return array_indices_type() == circle::SparseIndexVector_Int32Vector
+               ? static_cast<const circle::Int32Vector *>(array_indices())
                : nullptr;
   }
-  const Uint16Vector *array_indices_as_Uint16Vector() const
+  const circle::Uint16Vector *array_indices_as_Uint16Vector() const
   {
-    return array_indices_type() == SparseIndexVector_Uint16Vector
-               ? static_cast<const Uint16Vector *>(array_indices())
+    return array_indices_type() == circle::SparseIndexVector_Uint16Vector
+               ? static_cast<const circle::Uint16Vector *>(array_indices())
                : nullptr;
   }
-  const Uint8Vector *array_indices_as_Uint8Vector() const
+  const circle::Uint8Vector *array_indices_as_Uint8Vector() const
   {
-    return array_indices_type() == SparseIndexVector_Uint8Vector
-               ? static_cast<const Uint8Vector *>(array_indices())
+    return array_indices_type() == circle::SparseIndexVector_Uint8Vector
+               ? static_cast<const circle::Uint8Vector *>(array_indices())
                : nullptr;
   }
   bool Verify(flatbuffers::Verifier &verifier) const
@@ -2663,41 +2842,49 @@ struct DimensionMetadata FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
   }
 };
 
-template <> inline const Int32Vector *DimensionMetadata::array_segments_as<Int32Vector>() const
+template <>
+inline const circle::Int32Vector *DimensionMetadata::array_segments_as<circle::Int32Vector>() const
 {
   return array_segments_as_Int32Vector();
 }
 
-template <> inline const Uint16Vector *DimensionMetadata::array_segments_as<Uint16Vector>() const
+template <>
+inline const circle::Uint16Vector *
+DimensionMetadata::array_segments_as<circle::Uint16Vector>() const
 {
   return array_segments_as_Uint16Vector();
 }
 
-template <> inline const Uint8Vector *DimensionMetadata::array_segments_as<Uint8Vector>() const
+template <>
+inline const circle::Uint8Vector *DimensionMetadata::array_segments_as<circle::Uint8Vector>() const
 {
   return array_segments_as_Uint8Vector();
 }
 
-template <> inline const Int32Vector *DimensionMetadata::array_indices_as<Int32Vector>() const
+template <>
+inline const circle::Int32Vector *DimensionMetadata::array_indices_as<circle::Int32Vector>() const
 {
   return array_indices_as_Int32Vector();
 }
 
-template <> inline const Uint16Vector *DimensionMetadata::array_indices_as<Uint16Vector>() const
+template <>
+inline const circle::Uint16Vector *DimensionMetadata::array_indices_as<circle::Uint16Vector>() const
 {
   return array_indices_as_Uint16Vector();
 }
 
-template <> inline const Uint8Vector *DimensionMetadata::array_indices_as<Uint8Vector>() const
+template <>
+inline const circle::Uint8Vector *DimensionMetadata::array_indices_as<circle::Uint8Vector>() const
 {
   return array_indices_as_Uint8Vector();
 }
 
 struct DimensionMetadataBuilder
 {
+  typedef DimensionMetadata Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_format(DimensionType format)
+  void add_format(circle::DimensionType format)
   {
     fbb_.AddElement<int8_t>(DimensionMetadata::VT_FORMAT, static_cast<int8_t>(format), 0);
   }
@@ -2705,7 +2892,7 @@ struct DimensionMetadataBuilder
   {
     fbb_.AddElement<int32_t>(DimensionMetadata::VT_DENSE_SIZE, dense_size, 0);
   }
-  void add_array_segments_type(SparseIndexVector array_segments_type)
+  void add_array_segments_type(circle::SparseIndexVector array_segments_type)
   {
     fbb_.AddElement<uint8_t>(DimensionMetadata::VT_ARRAY_SEGMENTS_TYPE,
                              static_cast<uint8_t>(array_segments_type), 0);
@@ -2714,7 +2901,7 @@ struct DimensionMetadataBuilder
   {
     fbb_.AddOffset(DimensionMetadata::VT_ARRAY_SEGMENTS, array_segments);
   }
-  void add_array_indices_type(SparseIndexVector array_indices_type)
+  void add_array_indices_type(circle::SparseIndexVector array_indices_type)
   {
     fbb_.AddElement<uint8_t>(DimensionMetadata::VT_ARRAY_INDICES_TYPE,
                              static_cast<uint8_t>(array_indices_type), 0);
@@ -2736,13 +2923,13 @@ struct DimensionMetadataBuilder
   }
 };
 
-inline flatbuffers::Offset<DimensionMetadata>
-CreateDimensionMetadata(flatbuffers::FlatBufferBuilder &_fbb,
-                        DimensionType format = DimensionType_DENSE, int32_t dense_size = 0,
-                        SparseIndexVector array_segments_type = SparseIndexVector_NONE,
-                        flatbuffers::Offset<void> array_segments = 0,
-                        SparseIndexVector array_indices_type = SparseIndexVector_NONE,
-                        flatbuffers::Offset<void> array_indices = 0)
+inline flatbuffers::Offset<DimensionMetadata> CreateDimensionMetadata(
+    flatbuffers::FlatBufferBuilder &_fbb,
+    circle::DimensionType format = circle::DimensionType_DENSE, int32_t dense_size = 0,
+    circle::SparseIndexVector array_segments_type = circle::SparseIndexVector_NONE,
+    flatbuffers::Offset<void> array_segments = 0,
+    circle::SparseIndexVector array_indices_type = circle::SparseIndexVector_NONE,
+    flatbuffers::Offset<void> array_indices = 0)
 {
   DimensionMetadataBuilder builder_(_fbb);
   builder_.add_array_indices(array_indices);
@@ -2756,7 +2943,8 @@ CreateDimensionMetadata(flatbuffers::FlatBufferBuilder &_fbb,
 
 struct SparsityParameters FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef SparsityParametersBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_TRAVERSAL_ORDER = 4,
     VT_BLOCK_MAP = 6,
@@ -2770,9 +2958,9 @@ struct SparsityParameters FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
   {
     return GetPointer<const flatbuffers::Vector<int32_t> *>(VT_BLOCK_MAP);
   }
-  const flatbuffers::Vector<flatbuffers::Offset<DimensionMetadata>> *dim_metadata() const
+  const flatbuffers::Vector<flatbuffers::Offset<circle::DimensionMetadata>> *dim_metadata() const
   {
-    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<DimensionMetadata>> *>(
+    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<circle::DimensionMetadata>> *>(
         VT_DIM_METADATA);
   }
   bool Verify(flatbuffers::Verifier &verifier) const
@@ -2787,6 +2975,7 @@ struct SparsityParameters FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct SparsityParametersBuilder
 {
+  typedef SparsityParameters Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_traversal_order(flatbuffers::Offset<flatbuffers::Vector<int32_t>> traversal_order)
@@ -2798,7 +2987,8 @@ struct SparsityParametersBuilder
     fbb_.AddOffset(SparsityParameters::VT_BLOCK_MAP, block_map);
   }
   void add_dim_metadata(
-      flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<DimensionMetadata>>> dim_metadata)
+      flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<circle::DimensionMetadata>>>
+          dim_metadata)
   {
     fbb_.AddOffset(SparsityParameters::VT_DIM_METADATA, dim_metadata);
   }
@@ -2819,8 +3009,8 @@ inline flatbuffers::Offset<SparsityParameters> CreateSparsityParameters(
     flatbuffers::FlatBufferBuilder &_fbb,
     flatbuffers::Offset<flatbuffers::Vector<int32_t>> traversal_order = 0,
     flatbuffers::Offset<flatbuffers::Vector<int32_t>> block_map = 0,
-    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<DimensionMetadata>>> dim_metadata =
-        0)
+    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<circle::DimensionMetadata>>>
+        dim_metadata = 0)
 {
   SparsityParametersBuilder builder_(_fbb);
   builder_.add_dim_metadata(dim_metadata);
@@ -2832,17 +3022,21 @@ inline flatbuffers::Offset<SparsityParameters> CreateSparsityParameters(
 inline flatbuffers::Offset<SparsityParameters> CreateSparsityParametersDirect(
     flatbuffers::FlatBufferBuilder &_fbb, const std::vector<int32_t> *traversal_order = nullptr,
     const std::vector<int32_t> *block_map = nullptr,
-    const std::vector<flatbuffers::Offset<DimensionMetadata>> *dim_metadata = nullptr)
+    const std::vector<flatbuffers::Offset<circle::DimensionMetadata>> *dim_metadata = nullptr)
 {
-  return circle::CreateSparsityParameters(
-      _fbb, traversal_order ? _fbb.CreateVector<int32_t>(*traversal_order) : 0,
-      block_map ? _fbb.CreateVector<int32_t>(*block_map) : 0,
-      dim_metadata ? _fbb.CreateVector<flatbuffers::Offset<DimensionMetadata>>(*dim_metadata) : 0);
+  auto traversal_order__ = traversal_order ? _fbb.CreateVector<int32_t>(*traversal_order) : 0;
+  auto block_map__ = block_map ? _fbb.CreateVector<int32_t>(*block_map) : 0;
+  auto dim_metadata__ =
+      dim_metadata
+          ? _fbb.CreateVector<flatbuffers::Offset<circle::DimensionMetadata>>(*dim_metadata)
+          : 0;
+  return circle::CreateSparsityParameters(_fbb, traversal_order__, block_map__, dim_metadata__);
 }
 
 struct Tensor FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef TensorBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_SHAPE = 4,
     VT_TYPE = 6,
@@ -2857,20 +3051,23 @@ struct Tensor FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
   {
     return GetPointer<const flatbuffers::Vector<int32_t> *>(VT_SHAPE);
   }
-  TensorType type() const { return static_cast<TensorType>(GetField<int8_t>(VT_TYPE, 0)); }
+  circle::TensorType type() const
+  {
+    return static_cast<circle::TensorType>(GetField<int8_t>(VT_TYPE, 0));
+  }
   uint32_t buffer() const { return GetField<uint32_t>(VT_BUFFER, 0); }
   const flatbuffers::String *name() const
   {
     return GetPointer<const flatbuffers::String *>(VT_NAME);
   }
-  const QuantizationParameters *quantization() const
+  const circle::QuantizationParameters *quantization() const
   {
-    return GetPointer<const QuantizationParameters *>(VT_QUANTIZATION);
+    return GetPointer<const circle::QuantizationParameters *>(VT_QUANTIZATION);
   }
   bool is_variable() const { return GetField<uint8_t>(VT_IS_VARIABLE, 0) != 0; }
-  const SparsityParameters *sparsity() const
+  const circle::SparsityParameters *sparsity() const
   {
-    return GetPointer<const SparsityParameters *>(VT_SPARSITY);
+    return GetPointer<const circle::SparsityParameters *>(VT_SPARSITY);
   }
   const flatbuffers::Vector<int32_t> *shape_signature() const
   {
@@ -2891,13 +3088,14 @@ struct Tensor FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct TensorBuilder
 {
+  typedef Tensor Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_shape(flatbuffers::Offset<flatbuffers::Vector<int32_t>> shape)
   {
     fbb_.AddOffset(Tensor::VT_SHAPE, shape);
   }
-  void add_type(TensorType type)
+  void add_type(circle::TensorType type)
   {
     fbb_.AddElement<int8_t>(Tensor::VT_TYPE, static_cast<int8_t>(type), 0);
   }
@@ -2906,7 +3104,7 @@ struct TensorBuilder
   {
     fbb_.AddOffset(Tensor::VT_NAME, name);
   }
-  void add_quantization(flatbuffers::Offset<QuantizationParameters> quantization)
+  void add_quantization(flatbuffers::Offset<circle::QuantizationParameters> quantization)
   {
     fbb_.AddOffset(Tensor::VT_QUANTIZATION, quantization);
   }
@@ -2914,7 +3112,7 @@ struct TensorBuilder
   {
     fbb_.AddElement<uint8_t>(Tensor::VT_IS_VARIABLE, static_cast<uint8_t>(is_variable), 0);
   }
-  void add_sparsity(flatbuffers::Offset<SparsityParameters> sparsity)
+  void add_sparsity(flatbuffers::Offset<circle::SparsityParameters> sparsity)
   {
     fbb_.AddOffset(Tensor::VT_SPARSITY, sparsity);
   }
@@ -2938,10 +3136,10 @@ struct TensorBuilder
 inline flatbuffers::Offset<Tensor>
 CreateTensor(flatbuffers::FlatBufferBuilder &_fbb,
              flatbuffers::Offset<flatbuffers::Vector<int32_t>> shape = 0,
-             TensorType type = TensorType_FLOAT32, uint32_t buffer = 0,
+             circle::TensorType type = circle::TensorType_FLOAT32, uint32_t buffer = 0,
              flatbuffers::Offset<flatbuffers::String> name = 0,
-             flatbuffers::Offset<QuantizationParameters> quantization = 0, bool is_variable = false,
-             flatbuffers::Offset<SparsityParameters> sparsity = 0,
+             flatbuffers::Offset<circle::QuantizationParameters> quantization = 0,
+             bool is_variable = false, flatbuffers::Offset<circle::SparsityParameters> sparsity = 0,
              flatbuffers::Offset<flatbuffers::Vector<int32_t>> shape_signature = 0)
 {
   TensorBuilder builder_(_fbb);
@@ -2958,20 +3156,23 @@ CreateTensor(flatbuffers::FlatBufferBuilder &_fbb,
 
 inline flatbuffers::Offset<Tensor> CreateTensorDirect(
     flatbuffers::FlatBufferBuilder &_fbb, const std::vector<int32_t> *shape = nullptr,
-    TensorType type = TensorType_FLOAT32, uint32_t buffer = 0, const char *name = nullptr,
-    flatbuffers::Offset<QuantizationParameters> quantization = 0, bool is_variable = false,
-    flatbuffers::Offset<SparsityParameters> sparsity = 0,
+    circle::TensorType type = circle::TensorType_FLOAT32, uint32_t buffer = 0,
+    const char *name = nullptr,
+    flatbuffers::Offset<circle::QuantizationParameters> quantization = 0, bool is_variable = false,
+    flatbuffers::Offset<circle::SparsityParameters> sparsity = 0,
     const std::vector<int32_t> *shape_signature = nullptr)
 {
-  return circle::CreateTensor(_fbb, shape ? _fbb.CreateVector<int32_t>(*shape) : 0, type, buffer,
-                              name ? _fbb.CreateString(name) : 0, quantization, is_variable,
-                              sparsity,
-                              shape_signature ? _fbb.CreateVector<int32_t>(*shape_signature) : 0);
+  auto shape__ = shape ? _fbb.CreateVector<int32_t>(*shape) : 0;
+  auto name__ = name ? _fbb.CreateString(name) : 0;
+  auto shape_signature__ = shape_signature ? _fbb.CreateVector<int32_t>(*shape_signature) : 0;
+  return circle::CreateTensor(_fbb, shape__, type, buffer, name__, quantization, is_variable,
+                              sparsity, shape_signature__);
 }
 
 struct Conv2DOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef Conv2DOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_PADDING = 4,
     VT_STRIDE_W = 6,
@@ -2980,12 +3181,16 @@ struct Conv2DOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
     VT_DILATION_W_FACTOR = 12,
     VT_DILATION_H_FACTOR = 14
   };
-  Padding padding() const { return static_cast<Padding>(GetField<int8_t>(VT_PADDING, 0)); }
+  circle::Padding padding() const
+  {
+    return static_cast<circle::Padding>(GetField<int8_t>(VT_PADDING, 0));
+  }
   int32_t stride_w() const { return GetField<int32_t>(VT_STRIDE_W, 0); }
   int32_t stride_h() const { return GetField<int32_t>(VT_STRIDE_H, 0); }
-  ActivationFunctionType fused_activation_function() const
+  circle::ActivationFunctionType fused_activation_function() const
   {
-    return static_cast<ActivationFunctionType>(GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
+    return static_cast<circle::ActivationFunctionType>(
+        GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
   }
   int32_t dilation_w_factor() const { return GetField<int32_t>(VT_DILATION_W_FACTOR, 1); }
   int32_t dilation_h_factor() const { return GetField<int32_t>(VT_DILATION_H_FACTOR, 1); }
@@ -3002,9 +3207,10 @@ struct Conv2DOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct Conv2DOptionsBuilder
 {
+  typedef Conv2DOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_padding(Padding padding)
+  void add_padding(circle::Padding padding)
   {
     fbb_.AddElement<int8_t>(Conv2DOptions::VT_PADDING, static_cast<int8_t>(padding), 0);
   }
@@ -3016,7 +3222,7 @@ struct Conv2DOptionsBuilder
   {
     fbb_.AddElement<int32_t>(Conv2DOptions::VT_STRIDE_H, stride_h, 0);
   }
-  void add_fused_activation_function(ActivationFunctionType fused_activation_function)
+  void add_fused_activation_function(circle::ActivationFunctionType fused_activation_function)
   {
     fbb_.AddElement<int8_t>(Conv2DOptions::VT_FUSED_ACTIVATION_FUNCTION,
                             static_cast<int8_t>(fused_activation_function), 0);
@@ -3042,11 +3248,11 @@ struct Conv2DOptionsBuilder
   }
 };
 
-inline flatbuffers::Offset<Conv2DOptions>
-CreateConv2DOptions(flatbuffers::FlatBufferBuilder &_fbb, Padding padding = Padding_SAME,
-                    int32_t stride_w = 0, int32_t stride_h = 0,
-                    ActivationFunctionType fused_activation_function = ActivationFunctionType_NONE,
-                    int32_t dilation_w_factor = 1, int32_t dilation_h_factor = 1)
+inline flatbuffers::Offset<Conv2DOptions> CreateConv2DOptions(
+    flatbuffers::FlatBufferBuilder &_fbb, circle::Padding padding = circle::Padding_SAME,
+    int32_t stride_w = 0, int32_t stride_h = 0,
+    circle::ActivationFunctionType fused_activation_function = circle::ActivationFunctionType_NONE,
+    int32_t dilation_w_factor = 1, int32_t dilation_h_factor = 1)
 {
   Conv2DOptionsBuilder builder_(_fbb);
   builder_.add_dilation_h_factor(dilation_h_factor);
@@ -3060,7 +3266,8 @@ CreateConv2DOptions(flatbuffers::FlatBufferBuilder &_fbb, Padding padding = Padd
 
 struct Pool2DOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef Pool2DOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_PADDING = 4,
     VT_STRIDE_W = 6,
@@ -3069,14 +3276,18 @@ struct Pool2DOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
     VT_FILTER_HEIGHT = 12,
     VT_FUSED_ACTIVATION_FUNCTION = 14
   };
-  Padding padding() const { return static_cast<Padding>(GetField<int8_t>(VT_PADDING, 0)); }
+  circle::Padding padding() const
+  {
+    return static_cast<circle::Padding>(GetField<int8_t>(VT_PADDING, 0));
+  }
   int32_t stride_w() const { return GetField<int32_t>(VT_STRIDE_W, 0); }
   int32_t stride_h() const { return GetField<int32_t>(VT_STRIDE_H, 0); }
   int32_t filter_width() const { return GetField<int32_t>(VT_FILTER_WIDTH, 0); }
   int32_t filter_height() const { return GetField<int32_t>(VT_FILTER_HEIGHT, 0); }
-  ActivationFunctionType fused_activation_function() const
+  circle::ActivationFunctionType fused_activation_function() const
   {
-    return static_cast<ActivationFunctionType>(GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
+    return static_cast<circle::ActivationFunctionType>(
+        GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
   }
   bool Verify(flatbuffers::Verifier &verifier) const
   {
@@ -3091,9 +3302,10 @@ struct Pool2DOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct Pool2DOptionsBuilder
 {
+  typedef Pool2DOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_padding(Padding padding)
+  void add_padding(circle::Padding padding)
   {
     fbb_.AddElement<int8_t>(Pool2DOptions::VT_PADDING, static_cast<int8_t>(padding), 0);
   }
@@ -3113,7 +3325,7 @@ struct Pool2DOptionsBuilder
   {
     fbb_.AddElement<int32_t>(Pool2DOptions::VT_FILTER_HEIGHT, filter_height, 0);
   }
-  void add_fused_activation_function(ActivationFunctionType fused_activation_function)
+  void add_fused_activation_function(circle::ActivationFunctionType fused_activation_function)
   {
     fbb_.AddElement<int8_t>(Pool2DOptions::VT_FUSED_ACTIVATION_FUNCTION,
                             static_cast<int8_t>(fused_activation_function), 0);
@@ -3131,11 +3343,10 @@ struct Pool2DOptionsBuilder
   }
 };
 
-inline flatbuffers::Offset<Pool2DOptions>
-CreatePool2DOptions(flatbuffers::FlatBufferBuilder &_fbb, Padding padding = Padding_SAME,
-                    int32_t stride_w = 0, int32_t stride_h = 0, int32_t filter_width = 0,
-                    int32_t filter_height = 0,
-                    ActivationFunctionType fused_activation_function = ActivationFunctionType_NONE)
+inline flatbuffers::Offset<Pool2DOptions> CreatePool2DOptions(
+    flatbuffers::FlatBufferBuilder &_fbb, circle::Padding padding = circle::Padding_SAME,
+    int32_t stride_w = 0, int32_t stride_h = 0, int32_t filter_width = 0, int32_t filter_height = 0,
+    circle::ActivationFunctionType fused_activation_function = circle::ActivationFunctionType_NONE)
 {
   Pool2DOptionsBuilder builder_(_fbb);
   builder_.add_filter_height(filter_height);
@@ -3149,7 +3360,8 @@ CreatePool2DOptions(flatbuffers::FlatBufferBuilder &_fbb, Padding padding = Padd
 
 struct DepthwiseConv2DOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef DepthwiseConv2DOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_PADDING = 4,
     VT_STRIDE_W = 6,
@@ -3159,13 +3371,17 @@ struct DepthwiseConv2DOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Tab
     VT_DILATION_W_FACTOR = 14,
     VT_DILATION_H_FACTOR = 16
   };
-  Padding padding() const { return static_cast<Padding>(GetField<int8_t>(VT_PADDING, 0)); }
+  circle::Padding padding() const
+  {
+    return static_cast<circle::Padding>(GetField<int8_t>(VT_PADDING, 0));
+  }
   int32_t stride_w() const { return GetField<int32_t>(VT_STRIDE_W, 0); }
   int32_t stride_h() const { return GetField<int32_t>(VT_STRIDE_H, 0); }
   int32_t depth_multiplier() const { return GetField<int32_t>(VT_DEPTH_MULTIPLIER, 0); }
-  ActivationFunctionType fused_activation_function() const
+  circle::ActivationFunctionType fused_activation_function() const
   {
-    return static_cast<ActivationFunctionType>(GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
+    return static_cast<circle::ActivationFunctionType>(
+        GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
   }
   int32_t dilation_w_factor() const { return GetField<int32_t>(VT_DILATION_W_FACTOR, 1); }
   int32_t dilation_h_factor() const { return GetField<int32_t>(VT_DILATION_H_FACTOR, 1); }
@@ -3183,9 +3399,10 @@ struct DepthwiseConv2DOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Tab
 
 struct DepthwiseConv2DOptionsBuilder
 {
+  typedef DepthwiseConv2DOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_padding(Padding padding)
+  void add_padding(circle::Padding padding)
   {
     fbb_.AddElement<int8_t>(DepthwiseConv2DOptions::VT_PADDING, static_cast<int8_t>(padding), 0);
   }
@@ -3201,7 +3418,7 @@ struct DepthwiseConv2DOptionsBuilder
   {
     fbb_.AddElement<int32_t>(DepthwiseConv2DOptions::VT_DEPTH_MULTIPLIER, depth_multiplier, 0);
   }
-  void add_fused_activation_function(ActivationFunctionType fused_activation_function)
+  void add_fused_activation_function(circle::ActivationFunctionType fused_activation_function)
   {
     fbb_.AddElement<int8_t>(DepthwiseConv2DOptions::VT_FUSED_ACTIVATION_FUNCTION,
                             static_cast<int8_t>(fused_activation_function), 0);
@@ -3228,9 +3445,9 @@ struct DepthwiseConv2DOptionsBuilder
 };
 
 inline flatbuffers::Offset<DepthwiseConv2DOptions> CreateDepthwiseConv2DOptions(
-    flatbuffers::FlatBufferBuilder &_fbb, Padding padding = Padding_SAME, int32_t stride_w = 0,
-    int32_t stride_h = 0, int32_t depth_multiplier = 0,
-    ActivationFunctionType fused_activation_function = ActivationFunctionType_NONE,
+    flatbuffers::FlatBufferBuilder &_fbb, circle::Padding padding = circle::Padding_SAME,
+    int32_t stride_w = 0, int32_t stride_h = 0, int32_t depth_multiplier = 0,
+    circle::ActivationFunctionType fused_activation_function = circle::ActivationFunctionType_NONE,
     int32_t dilation_w_factor = 1, int32_t dilation_h_factor = 1)
 {
   DepthwiseConv2DOptionsBuilder builder_(_fbb);
@@ -3246,7 +3463,8 @@ inline flatbuffers::Offset<DepthwiseConv2DOptions> CreateDepthwiseConv2DOptions(
 
 struct ConcatEmbeddingsOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef ConcatEmbeddingsOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_NUM_CHANNELS = 4,
     VT_NUM_COLUMNS_PER_CHANNEL = 6,
@@ -3273,6 +3491,7 @@ struct ConcatEmbeddingsOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Ta
 
 struct ConcatEmbeddingsOptionsBuilder
 {
+  typedef ConcatEmbeddingsOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_num_channels(int32_t num_channels)
@@ -3320,21 +3539,24 @@ CreateConcatEmbeddingsOptionsDirect(flatbuffers::FlatBufferBuilder &_fbb, int32_
                                     const std::vector<int32_t> *num_columns_per_channel = nullptr,
                                     const std::vector<int32_t> *embedding_dim_per_channel = nullptr)
 {
-  return circle::CreateConcatEmbeddingsOptions(
-      _fbb, num_channels,
-      num_columns_per_channel ? _fbb.CreateVector<int32_t>(*num_columns_per_channel) : 0,
-      embedding_dim_per_channel ? _fbb.CreateVector<int32_t>(*embedding_dim_per_channel) : 0);
+  auto num_columns_per_channel__ =
+      num_columns_per_channel ? _fbb.CreateVector<int32_t>(*num_columns_per_channel) : 0;
+  auto embedding_dim_per_channel__ =
+      embedding_dim_per_channel ? _fbb.CreateVector<int32_t>(*embedding_dim_per_channel) : 0;
+  return circle::CreateConcatEmbeddingsOptions(_fbb, num_channels, num_columns_per_channel__,
+                                               embedding_dim_per_channel__);
 }
 
 struct LSHProjectionOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef LSHProjectionOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_TYPE = 4
   };
-  LSHProjectionType type() const
+  circle::LSHProjectionType type() const
   {
-    return static_cast<LSHProjectionType>(GetField<int8_t>(VT_TYPE, 0));
+    return static_cast<circle::LSHProjectionType>(GetField<int8_t>(VT_TYPE, 0));
   }
   bool Verify(flatbuffers::Verifier &verifier) const
   {
@@ -3345,9 +3567,10 @@ struct LSHProjectionOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct LSHProjectionOptionsBuilder
 {
+  typedef LSHProjectionOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_type(LSHProjectionType type)
+  void add_type(circle::LSHProjectionType type)
   {
     fbb_.AddElement<int8_t>(LSHProjectionOptions::VT_TYPE, static_cast<int8_t>(type), 0);
   }
@@ -3366,7 +3589,7 @@ struct LSHProjectionOptionsBuilder
 
 inline flatbuffers::Offset<LSHProjectionOptions>
 CreateLSHProjectionOptions(flatbuffers::FlatBufferBuilder &_fbb,
-                           LSHProjectionType type = LSHProjectionType_UNKNOWN)
+                           circle::LSHProjectionType type = circle::LSHProjectionType_UNKNOWN)
 {
   LSHProjectionOptionsBuilder builder_(_fbb);
   builder_.add_type(type);
@@ -3375,16 +3598,18 @@ CreateLSHProjectionOptions(flatbuffers::FlatBufferBuilder &_fbb,
 
 struct SVDFOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef SVDFOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_RANK = 4,
     VT_FUSED_ACTIVATION_FUNCTION = 6,
     VT_ASYMMETRIC_QUANTIZE_INPUTS = 8
   };
   int32_t rank() const { return GetField<int32_t>(VT_RANK, 0); }
-  ActivationFunctionType fused_activation_function() const
+  circle::ActivationFunctionType fused_activation_function() const
   {
-    return static_cast<ActivationFunctionType>(GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
+    return static_cast<circle::ActivationFunctionType>(
+        GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
   }
   bool asymmetric_quantize_inputs() const
   {
@@ -3400,10 +3625,11 @@ struct SVDFOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct SVDFOptionsBuilder
 {
+  typedef SVDFOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_rank(int32_t rank) { fbb_.AddElement<int32_t>(SVDFOptions::VT_RANK, rank, 0); }
-  void add_fused_activation_function(ActivationFunctionType fused_activation_function)
+  void add_fused_activation_function(circle::ActivationFunctionType fused_activation_function)
   {
     fbb_.AddElement<int8_t>(SVDFOptions::VT_FUSED_ACTIVATION_FUNCTION,
                             static_cast<int8_t>(fused_activation_function), 0);
@@ -3426,10 +3652,10 @@ struct SVDFOptionsBuilder
   }
 };
 
-inline flatbuffers::Offset<SVDFOptions>
-CreateSVDFOptions(flatbuffers::FlatBufferBuilder &_fbb, int32_t rank = 0,
-                  ActivationFunctionType fused_activation_function = ActivationFunctionType_NONE,
-                  bool asymmetric_quantize_inputs = false)
+inline flatbuffers::Offset<SVDFOptions> CreateSVDFOptions(
+    flatbuffers::FlatBufferBuilder &_fbb, int32_t rank = 0,
+    circle::ActivationFunctionType fused_activation_function = circle::ActivationFunctionType_NONE,
+    bool asymmetric_quantize_inputs = false)
 {
   SVDFOptionsBuilder builder_(_fbb);
   builder_.add_rank(rank);
@@ -3440,14 +3666,16 @@ CreateSVDFOptions(flatbuffers::FlatBufferBuilder &_fbb, int32_t rank = 0,
 
 struct RNNOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef RNNOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_FUSED_ACTIVATION_FUNCTION = 4,
     VT_ASYMMETRIC_QUANTIZE_INPUTS = 6
   };
-  ActivationFunctionType fused_activation_function() const
+  circle::ActivationFunctionType fused_activation_function() const
   {
-    return static_cast<ActivationFunctionType>(GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
+    return static_cast<circle::ActivationFunctionType>(
+        GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
   }
   bool asymmetric_quantize_inputs() const
   {
@@ -3463,9 +3691,10 @@ struct RNNOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct RNNOptionsBuilder
 {
+  typedef RNNOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_fused_activation_function(ActivationFunctionType fused_activation_function)
+  void add_fused_activation_function(circle::ActivationFunctionType fused_activation_function)
   {
     fbb_.AddElement<int8_t>(RNNOptions::VT_FUSED_ACTIVATION_FUNCTION,
                             static_cast<int8_t>(fused_activation_function), 0);
@@ -3488,10 +3717,10 @@ struct RNNOptionsBuilder
   }
 };
 
-inline flatbuffers::Offset<RNNOptions>
-CreateRNNOptions(flatbuffers::FlatBufferBuilder &_fbb,
-                 ActivationFunctionType fused_activation_function = ActivationFunctionType_NONE,
-                 bool asymmetric_quantize_inputs = false)
+inline flatbuffers::Offset<RNNOptions> CreateRNNOptions(
+    flatbuffers::FlatBufferBuilder &_fbb,
+    circle::ActivationFunctionType fused_activation_function = circle::ActivationFunctionType_NONE,
+    bool asymmetric_quantize_inputs = false)
 {
   RNNOptionsBuilder builder_(_fbb);
   builder_.add_asymmetric_quantize_inputs(asymmetric_quantize_inputs);
@@ -3501,16 +3730,18 @@ CreateRNNOptions(flatbuffers::FlatBufferBuilder &_fbb,
 
 struct SequenceRNNOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef SequenceRNNOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_TIME_MAJOR = 4,
     VT_FUSED_ACTIVATION_FUNCTION = 6,
     VT_ASYMMETRIC_QUANTIZE_INPUTS = 8
   };
   bool time_major() const { return GetField<uint8_t>(VT_TIME_MAJOR, 0) != 0; }
-  ActivationFunctionType fused_activation_function() const
+  circle::ActivationFunctionType fused_activation_function() const
   {
-    return static_cast<ActivationFunctionType>(GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
+    return static_cast<circle::ActivationFunctionType>(
+        GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
   }
   bool asymmetric_quantize_inputs() const
   {
@@ -3526,6 +3757,7 @@ struct SequenceRNNOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct SequenceRNNOptionsBuilder
 {
+  typedef SequenceRNNOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_time_major(bool time_major)
@@ -3533,7 +3765,7 @@ struct SequenceRNNOptionsBuilder
     fbb_.AddElement<uint8_t>(SequenceRNNOptions::VT_TIME_MAJOR, static_cast<uint8_t>(time_major),
                              0);
   }
-  void add_fused_activation_function(ActivationFunctionType fused_activation_function)
+  void add_fused_activation_function(circle::ActivationFunctionType fused_activation_function)
   {
     fbb_.AddElement<int8_t>(SequenceRNNOptions::VT_FUSED_ACTIVATION_FUNCTION,
                             static_cast<int8_t>(fused_activation_function), 0);
@@ -3558,7 +3790,7 @@ struct SequenceRNNOptionsBuilder
 
 inline flatbuffers::Offset<SequenceRNNOptions> CreateSequenceRNNOptions(
     flatbuffers::FlatBufferBuilder &_fbb, bool time_major = false,
-    ActivationFunctionType fused_activation_function = ActivationFunctionType_NONE,
+    circle::ActivationFunctionType fused_activation_function = circle::ActivationFunctionType_NONE,
     bool asymmetric_quantize_inputs = false)
 {
   SequenceRNNOptionsBuilder builder_(_fbb);
@@ -3570,7 +3802,8 @@ inline flatbuffers::Offset<SequenceRNNOptions> CreateSequenceRNNOptions(
 
 struct BidirectionalSequenceRNNOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef BidirectionalSequenceRNNOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_TIME_MAJOR = 4,
     VT_FUSED_ACTIVATION_FUNCTION = 6,
@@ -3578,9 +3811,10 @@ struct BidirectionalSequenceRNNOptions FLATBUFFERS_FINAL_CLASS : private flatbuf
     VT_ASYMMETRIC_QUANTIZE_INPUTS = 10
   };
   bool time_major() const { return GetField<uint8_t>(VT_TIME_MAJOR, 0) != 0; }
-  ActivationFunctionType fused_activation_function() const
+  circle::ActivationFunctionType fused_activation_function() const
   {
-    return static_cast<ActivationFunctionType>(GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
+    return static_cast<circle::ActivationFunctionType>(
+        GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
   }
   bool merge_outputs() const { return GetField<uint8_t>(VT_MERGE_OUTPUTS, 0) != 0; }
   bool asymmetric_quantize_inputs() const
@@ -3598,6 +3832,7 @@ struct BidirectionalSequenceRNNOptions FLATBUFFERS_FINAL_CLASS : private flatbuf
 
 struct BidirectionalSequenceRNNOptionsBuilder
 {
+  typedef BidirectionalSequenceRNNOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_time_major(bool time_major)
@@ -3605,7 +3840,7 @@ struct BidirectionalSequenceRNNOptionsBuilder
     fbb_.AddElement<uint8_t>(BidirectionalSequenceRNNOptions::VT_TIME_MAJOR,
                              static_cast<uint8_t>(time_major), 0);
   }
-  void add_fused_activation_function(ActivationFunctionType fused_activation_function)
+  void add_fused_activation_function(circle::ActivationFunctionType fused_activation_function)
   {
     fbb_.AddElement<int8_t>(BidirectionalSequenceRNNOptions::VT_FUSED_ACTIVATION_FUNCTION,
                             static_cast<int8_t>(fused_activation_function), 0);
@@ -3635,7 +3870,7 @@ struct BidirectionalSequenceRNNOptionsBuilder
 
 inline flatbuffers::Offset<BidirectionalSequenceRNNOptions> CreateBidirectionalSequenceRNNOptions(
     flatbuffers::FlatBufferBuilder &_fbb, bool time_major = false,
-    ActivationFunctionType fused_activation_function = ActivationFunctionType_NONE,
+    circle::ActivationFunctionType fused_activation_function = circle::ActivationFunctionType_NONE,
     bool merge_outputs = false, bool asymmetric_quantize_inputs = false)
 {
   BidirectionalSequenceRNNOptionsBuilder builder_(_fbb);
@@ -3648,20 +3883,23 @@ inline flatbuffers::Offset<BidirectionalSequenceRNNOptions> CreateBidirectionalS
 
 struct FullyConnectedOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef FullyConnectedOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_FUSED_ACTIVATION_FUNCTION = 4,
     VT_WEIGHTS_FORMAT = 6,
     VT_KEEP_NUM_DIMS = 8,
     VT_ASYMMETRIC_QUANTIZE_INPUTS = 10
   };
-  ActivationFunctionType fused_activation_function() const
+  circle::ActivationFunctionType fused_activation_function() const
   {
-    return static_cast<ActivationFunctionType>(GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
+    return static_cast<circle::ActivationFunctionType>(
+        GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
   }
-  FullyConnectedOptionsWeightsFormat weights_format() const
+  circle::FullyConnectedOptionsWeightsFormat weights_format() const
   {
-    return static_cast<FullyConnectedOptionsWeightsFormat>(GetField<int8_t>(VT_WEIGHTS_FORMAT, 0));
+    return static_cast<circle::FullyConnectedOptionsWeightsFormat>(
+        GetField<int8_t>(VT_WEIGHTS_FORMAT, 0));
   }
   bool keep_num_dims() const { return GetField<uint8_t>(VT_KEEP_NUM_DIMS, 0) != 0; }
   bool asymmetric_quantize_inputs() const
@@ -3680,14 +3918,15 @@ struct FullyConnectedOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Tabl
 
 struct FullyConnectedOptionsBuilder
 {
+  typedef FullyConnectedOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_fused_activation_function(ActivationFunctionType fused_activation_function)
+  void add_fused_activation_function(circle::ActivationFunctionType fused_activation_function)
   {
     fbb_.AddElement<int8_t>(FullyConnectedOptions::VT_FUSED_ACTIVATION_FUNCTION,
                             static_cast<int8_t>(fused_activation_function), 0);
   }
-  void add_weights_format(FullyConnectedOptionsWeightsFormat weights_format)
+  void add_weights_format(circle::FullyConnectedOptionsWeightsFormat weights_format)
   {
     fbb_.AddElement<int8_t>(FullyConnectedOptions::VT_WEIGHTS_FORMAT,
                             static_cast<int8_t>(weights_format), 0);
@@ -3717,8 +3956,9 @@ struct FullyConnectedOptionsBuilder
 
 inline flatbuffers::Offset<FullyConnectedOptions> CreateFullyConnectedOptions(
     flatbuffers::FlatBufferBuilder &_fbb,
-    ActivationFunctionType fused_activation_function = ActivationFunctionType_NONE,
-    FullyConnectedOptionsWeightsFormat weights_format = FullyConnectedOptionsWeightsFormat_DEFAULT,
+    circle::ActivationFunctionType fused_activation_function = circle::ActivationFunctionType_NONE,
+    circle::FullyConnectedOptionsWeightsFormat weights_format =
+        circle::FullyConnectedOptionsWeightsFormat_DEFAULT,
     bool keep_num_dims = false, bool asymmetric_quantize_inputs = false)
 {
   FullyConnectedOptionsBuilder builder_(_fbb);
@@ -3731,7 +3971,8 @@ inline flatbuffers::Offset<FullyConnectedOptions> CreateFullyConnectedOptions(
 
 struct SoftmaxOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef SoftmaxOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_BETA = 4
   };
@@ -3745,6 +3986,7 @@ struct SoftmaxOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct SoftmaxOptionsBuilder
 {
+  typedef SoftmaxOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_beta(float beta) { fbb_.AddElement<float>(SoftmaxOptions::VT_BETA, beta, 0.0f); }
@@ -3771,15 +4013,17 @@ CreateSoftmaxOptions(flatbuffers::FlatBufferBuilder &_fbb, float beta = 0.0f)
 
 struct ConcatenationOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef ConcatenationOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_AXIS = 4,
     VT_FUSED_ACTIVATION_FUNCTION = 6
   };
   int32_t axis() const { return GetField<int32_t>(VT_AXIS, 0); }
-  ActivationFunctionType fused_activation_function() const
+  circle::ActivationFunctionType fused_activation_function() const
   {
-    return static_cast<ActivationFunctionType>(GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
+    return static_cast<circle::ActivationFunctionType>(
+        GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
   }
   bool Verify(flatbuffers::Verifier &verifier) const
   {
@@ -3790,10 +4034,11 @@ struct ConcatenationOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct ConcatenationOptionsBuilder
 {
+  typedef ConcatenationOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_axis(int32_t axis) { fbb_.AddElement<int32_t>(ConcatenationOptions::VT_AXIS, axis, 0); }
-  void add_fused_activation_function(ActivationFunctionType fused_activation_function)
+  void add_fused_activation_function(circle::ActivationFunctionType fused_activation_function)
   {
     fbb_.AddElement<int8_t>(ConcatenationOptions::VT_FUSED_ACTIVATION_FUNCTION,
                             static_cast<int8_t>(fused_activation_function), 0);
@@ -3813,7 +4058,7 @@ struct ConcatenationOptionsBuilder
 
 inline flatbuffers::Offset<ConcatenationOptions> CreateConcatenationOptions(
     flatbuffers::FlatBufferBuilder &_fbb, int32_t axis = 0,
-    ActivationFunctionType fused_activation_function = ActivationFunctionType_NONE)
+    circle::ActivationFunctionType fused_activation_function = circle::ActivationFunctionType_NONE)
 {
   ConcatenationOptionsBuilder builder_(_fbb);
   builder_.add_axis(axis);
@@ -3823,13 +4068,15 @@ inline flatbuffers::Offset<ConcatenationOptions> CreateConcatenationOptions(
 
 struct AddOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef AddOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_FUSED_ACTIVATION_FUNCTION = 4
   };
-  ActivationFunctionType fused_activation_function() const
+  circle::ActivationFunctionType fused_activation_function() const
   {
-    return static_cast<ActivationFunctionType>(GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
+    return static_cast<circle::ActivationFunctionType>(
+        GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
   }
   bool Verify(flatbuffers::Verifier &verifier) const
   {
@@ -3840,9 +4087,10 @@ struct AddOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct AddOptionsBuilder
 {
+  typedef AddOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_fused_activation_function(ActivationFunctionType fused_activation_function)
+  void add_fused_activation_function(circle::ActivationFunctionType fused_activation_function)
   {
     fbb_.AddElement<int8_t>(AddOptions::VT_FUSED_ACTIVATION_FUNCTION,
                             static_cast<int8_t>(fused_activation_function), 0);
@@ -3860,9 +4108,9 @@ struct AddOptionsBuilder
   }
 };
 
-inline flatbuffers::Offset<AddOptions>
-CreateAddOptions(flatbuffers::FlatBufferBuilder &_fbb,
-                 ActivationFunctionType fused_activation_function = ActivationFunctionType_NONE)
+inline flatbuffers::Offset<AddOptions> CreateAddOptions(
+    flatbuffers::FlatBufferBuilder &_fbb,
+    circle::ActivationFunctionType fused_activation_function = circle::ActivationFunctionType_NONE)
 {
   AddOptionsBuilder builder_(_fbb);
   builder_.add_fused_activation_function(fused_activation_function);
@@ -3871,13 +4119,15 @@ CreateAddOptions(flatbuffers::FlatBufferBuilder &_fbb,
 
 struct MulOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef MulOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_FUSED_ACTIVATION_FUNCTION = 4
   };
-  ActivationFunctionType fused_activation_function() const
+  circle::ActivationFunctionType fused_activation_function() const
   {
-    return static_cast<ActivationFunctionType>(GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
+    return static_cast<circle::ActivationFunctionType>(
+        GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
   }
   bool Verify(flatbuffers::Verifier &verifier) const
   {
@@ -3888,9 +4138,10 @@ struct MulOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct MulOptionsBuilder
 {
+  typedef MulOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_fused_activation_function(ActivationFunctionType fused_activation_function)
+  void add_fused_activation_function(circle::ActivationFunctionType fused_activation_function)
   {
     fbb_.AddElement<int8_t>(MulOptions::VT_FUSED_ACTIVATION_FUNCTION,
                             static_cast<int8_t>(fused_activation_function), 0);
@@ -3908,9 +4159,9 @@ struct MulOptionsBuilder
   }
 };
 
-inline flatbuffers::Offset<MulOptions>
-CreateMulOptions(flatbuffers::FlatBufferBuilder &_fbb,
-                 ActivationFunctionType fused_activation_function = ActivationFunctionType_NONE)
+inline flatbuffers::Offset<MulOptions> CreateMulOptions(
+    flatbuffers::FlatBufferBuilder &_fbb,
+    circle::ActivationFunctionType fused_activation_function = circle::ActivationFunctionType_NONE)
 {
   MulOptionsBuilder builder_(_fbb);
   builder_.add_fused_activation_function(fused_activation_function);
@@ -3919,13 +4170,15 @@ CreateMulOptions(flatbuffers::FlatBufferBuilder &_fbb,
 
 struct L2NormOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef L2NormOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_FUSED_ACTIVATION_FUNCTION = 4
   };
-  ActivationFunctionType fused_activation_function() const
+  circle::ActivationFunctionType fused_activation_function() const
   {
-    return static_cast<ActivationFunctionType>(GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
+    return static_cast<circle::ActivationFunctionType>(
+        GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
   }
   bool Verify(flatbuffers::Verifier &verifier) const
   {
@@ -3936,9 +4189,10 @@ struct L2NormOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct L2NormOptionsBuilder
 {
+  typedef L2NormOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_fused_activation_function(ActivationFunctionType fused_activation_function)
+  void add_fused_activation_function(circle::ActivationFunctionType fused_activation_function)
   {
     fbb_.AddElement<int8_t>(L2NormOptions::VT_FUSED_ACTIVATION_FUNCTION,
                             static_cast<int8_t>(fused_activation_function), 0);
@@ -3956,9 +4210,9 @@ struct L2NormOptionsBuilder
   }
 };
 
-inline flatbuffers::Offset<L2NormOptions>
-CreateL2NormOptions(flatbuffers::FlatBufferBuilder &_fbb,
-                    ActivationFunctionType fused_activation_function = ActivationFunctionType_NONE)
+inline flatbuffers::Offset<L2NormOptions> CreateL2NormOptions(
+    flatbuffers::FlatBufferBuilder &_fbb,
+    circle::ActivationFunctionType fused_activation_function = circle::ActivationFunctionType_NONE)
 {
   L2NormOptionsBuilder builder_(_fbb);
   builder_.add_fused_activation_function(fused_activation_function);
@@ -3967,7 +4221,8 @@ CreateL2NormOptions(flatbuffers::FlatBufferBuilder &_fbb,
 
 struct LocalResponseNormalizationOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef LocalResponseNormalizationOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_RADIUS = 4,
     VT_BIAS = 6,
@@ -3988,6 +4243,7 @@ struct LocalResponseNormalizationOptions FLATBUFFERS_FINAL_CLASS : private flatb
 
 struct LocalResponseNormalizationOptionsBuilder
 {
+  typedef LocalResponseNormalizationOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_radius(int32_t radius)
@@ -4035,7 +4291,8 @@ CreateLocalResponseNormalizationOptions(flatbuffers::FlatBufferBuilder &_fbb, in
 
 struct LSTMOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef LSTMOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_FUSED_ACTIVATION_FUNCTION = 4,
     VT_CELL_CLIP = 6,
@@ -4043,15 +4300,16 @@ struct LSTMOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
     VT_KERNEL_TYPE = 10,
     VT_ASYMMETRIC_QUANTIZE_INPUTS = 12
   };
-  ActivationFunctionType fused_activation_function() const
+  circle::ActivationFunctionType fused_activation_function() const
   {
-    return static_cast<ActivationFunctionType>(GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
+    return static_cast<circle::ActivationFunctionType>(
+        GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
   }
   float cell_clip() const { return GetField<float>(VT_CELL_CLIP, 0.0f); }
   float proj_clip() const { return GetField<float>(VT_PROJ_CLIP, 0.0f); }
-  LSTMKernelType kernel_type() const
+  circle::LSTMKernelType kernel_type() const
   {
-    return static_cast<LSTMKernelType>(GetField<int8_t>(VT_KERNEL_TYPE, 0));
+    return static_cast<circle::LSTMKernelType>(GetField<int8_t>(VT_KERNEL_TYPE, 0));
   }
   bool asymmetric_quantize_inputs() const
   {
@@ -4070,9 +4328,10 @@ struct LSTMOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct LSTMOptionsBuilder
 {
+  typedef LSTMOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_fused_activation_function(ActivationFunctionType fused_activation_function)
+  void add_fused_activation_function(circle::ActivationFunctionType fused_activation_function)
   {
     fbb_.AddElement<int8_t>(LSTMOptions::VT_FUSED_ACTIVATION_FUNCTION,
                             static_cast<int8_t>(fused_activation_function), 0);
@@ -4085,7 +4344,7 @@ struct LSTMOptionsBuilder
   {
     fbb_.AddElement<float>(LSTMOptions::VT_PROJ_CLIP, proj_clip, 0.0f);
   }
-  void add_kernel_type(LSTMKernelType kernel_type)
+  void add_kernel_type(circle::LSTMKernelType kernel_type)
   {
     fbb_.AddElement<int8_t>(LSTMOptions::VT_KERNEL_TYPE, static_cast<int8_t>(kernel_type), 0);
   }
@@ -4107,12 +4366,12 @@ struct LSTMOptionsBuilder
   }
 };
 
-inline flatbuffers::Offset<LSTMOptions>
-CreateLSTMOptions(flatbuffers::FlatBufferBuilder &_fbb,
-                  ActivationFunctionType fused_activation_function = ActivationFunctionType_NONE,
-                  float cell_clip = 0.0f, float proj_clip = 0.0f,
-                  LSTMKernelType kernel_type = LSTMKernelType_FULL,
-                  bool asymmetric_quantize_inputs = false)
+inline flatbuffers::Offset<LSTMOptions> CreateLSTMOptions(
+    flatbuffers::FlatBufferBuilder &_fbb,
+    circle::ActivationFunctionType fused_activation_function = circle::ActivationFunctionType_NONE,
+    float cell_clip = 0.0f, float proj_clip = 0.0f,
+    circle::LSTMKernelType kernel_type = circle::LSTMKernelType_FULL,
+    bool asymmetric_quantize_inputs = false)
 {
   LSTMOptionsBuilder builder_(_fbb);
   builder_.add_proj_clip(proj_clip);
@@ -4125,7 +4384,8 @@ CreateLSTMOptions(flatbuffers::FlatBufferBuilder &_fbb,
 
 struct UnidirectionalSequenceLSTMOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef UnidirectionalSequenceLSTMOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_FUSED_ACTIVATION_FUNCTION = 4,
     VT_CELL_CLIP = 6,
@@ -4133,9 +4393,10 @@ struct UnidirectionalSequenceLSTMOptions FLATBUFFERS_FINAL_CLASS : private flatb
     VT_TIME_MAJOR = 10,
     VT_ASYMMETRIC_QUANTIZE_INPUTS = 12
   };
-  ActivationFunctionType fused_activation_function() const
+  circle::ActivationFunctionType fused_activation_function() const
   {
-    return static_cast<ActivationFunctionType>(GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
+    return static_cast<circle::ActivationFunctionType>(
+        GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
   }
   float cell_clip() const { return GetField<float>(VT_CELL_CLIP, 0.0f); }
   float proj_clip() const { return GetField<float>(VT_PROJ_CLIP, 0.0f); }
@@ -4157,9 +4418,10 @@ struct UnidirectionalSequenceLSTMOptions FLATBUFFERS_FINAL_CLASS : private flatb
 
 struct UnidirectionalSequenceLSTMOptionsBuilder
 {
+  typedef UnidirectionalSequenceLSTMOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_fused_activation_function(ActivationFunctionType fused_activation_function)
+  void add_fused_activation_function(circle::ActivationFunctionType fused_activation_function)
   {
     fbb_.AddElement<int8_t>(UnidirectionalSequenceLSTMOptions::VT_FUSED_ACTIVATION_FUNCTION,
                             static_cast<int8_t>(fused_activation_function), 0);
@@ -4200,7 +4462,7 @@ struct UnidirectionalSequenceLSTMOptionsBuilder
 inline flatbuffers::Offset<UnidirectionalSequenceLSTMOptions>
 CreateUnidirectionalSequenceLSTMOptions(
     flatbuffers::FlatBufferBuilder &_fbb,
-    ActivationFunctionType fused_activation_function = ActivationFunctionType_NONE,
+    circle::ActivationFunctionType fused_activation_function = circle::ActivationFunctionType_NONE,
     float cell_clip = 0.0f, float proj_clip = 0.0f, bool time_major = false,
     bool asymmetric_quantize_inputs = false)
 {
@@ -4215,7 +4477,8 @@ CreateUnidirectionalSequenceLSTMOptions(
 
 struct BidirectionalSequenceLSTMOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef BidirectionalSequenceLSTMOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_FUSED_ACTIVATION_FUNCTION = 4,
     VT_CELL_CLIP = 6,
@@ -4224,9 +4487,10 @@ struct BidirectionalSequenceLSTMOptions FLATBUFFERS_FINAL_CLASS : private flatbu
     VT_TIME_MAJOR = 12,
     VT_ASYMMETRIC_QUANTIZE_INPUTS = 14
   };
-  ActivationFunctionType fused_activation_function() const
+  circle::ActivationFunctionType fused_activation_function() const
   {
-    return static_cast<ActivationFunctionType>(GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
+    return static_cast<circle::ActivationFunctionType>(
+        GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
   }
   float cell_clip() const { return GetField<float>(VT_CELL_CLIP, 0.0f); }
   float proj_clip() const { return GetField<float>(VT_PROJ_CLIP, 0.0f); }
@@ -4250,9 +4514,10 @@ struct BidirectionalSequenceLSTMOptions FLATBUFFERS_FINAL_CLASS : private flatbu
 
 struct BidirectionalSequenceLSTMOptionsBuilder
 {
+  typedef BidirectionalSequenceLSTMOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_fused_activation_function(ActivationFunctionType fused_activation_function)
+  void add_fused_activation_function(circle::ActivationFunctionType fused_activation_function)
   {
     fbb_.AddElement<int8_t>(BidirectionalSequenceLSTMOptions::VT_FUSED_ACTIVATION_FUNCTION,
                             static_cast<int8_t>(fused_activation_function), 0);
@@ -4297,7 +4562,7 @@ struct BidirectionalSequenceLSTMOptionsBuilder
 
 inline flatbuffers::Offset<BidirectionalSequenceLSTMOptions> CreateBidirectionalSequenceLSTMOptions(
     flatbuffers::FlatBufferBuilder &_fbb,
-    ActivationFunctionType fused_activation_function = ActivationFunctionType_NONE,
+    circle::ActivationFunctionType fused_activation_function = circle::ActivationFunctionType_NONE,
     float cell_clip = 0.0f, float proj_clip = 0.0f, bool merge_outputs = false,
     bool time_major = true, bool asymmetric_quantize_inputs = false)
 {
@@ -4313,7 +4578,8 @@ inline flatbuffers::Offset<BidirectionalSequenceLSTMOptions> CreateBidirectional
 
 struct ResizeBilinearOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef ResizeBilinearOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_ALIGN_CORNERS = 8,
     VT_HALF_PIXEL_CENTERS = 10
@@ -4329,6 +4595,7 @@ struct ResizeBilinearOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Tabl
 
 struct ResizeBilinearOptionsBuilder
 {
+  typedef ResizeBilinearOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_align_corners(bool align_corners)
@@ -4366,7 +4633,8 @@ CreateResizeBilinearOptions(flatbuffers::FlatBufferBuilder &_fbb, bool align_cor
 
 struct ResizeNearestNeighborOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef ResizeNearestNeighborOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_ALIGN_CORNERS = 4
   };
@@ -4380,6 +4648,7 @@ struct ResizeNearestNeighborOptions FLATBUFFERS_FINAL_CLASS : private flatbuffer
 
 struct ResizeNearestNeighborOptionsBuilder
 {
+  typedef ResizeNearestNeighborOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_align_corners(bool align_corners)
@@ -4410,7 +4679,8 @@ CreateResizeNearestNeighborOptions(flatbuffers::FlatBufferBuilder &_fbb, bool al
 
 struct CallOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef CallOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_SUBGRAPH = 4
   };
@@ -4424,6 +4694,7 @@ struct CallOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct CallOptionsBuilder
 {
+  typedef CallOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_subgraph(uint32_t subgraph)
@@ -4453,6 +4724,7 @@ inline flatbuffers::Offset<CallOptions> CreateCallOptions(flatbuffers::FlatBuffe
 
 struct PadOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef PadOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -4461,6 +4733,7 @@ struct PadOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct PadOptionsBuilder
 {
+  typedef PadOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit PadOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
@@ -4484,6 +4757,7 @@ inline flatbuffers::Offset<PadOptions> CreatePadOptions(flatbuffers::FlatBufferB
 
 struct PadV2Options FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef PadV2OptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -4492,6 +4766,7 @@ struct PadV2Options FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct PadV2OptionsBuilder
 {
+  typedef PadV2Options Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit PadV2OptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
@@ -4515,7 +4790,8 @@ inline flatbuffers::Offset<PadV2Options> CreatePadV2Options(flatbuffers::FlatBuf
 
 struct ReshapeOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef ReshapeOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_NEW_SHAPE = 4
   };
@@ -4532,6 +4808,7 @@ struct ReshapeOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct ReshapeOptionsBuilder
 {
+  typedef ReshapeOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_new_shape(flatbuffers::Offset<flatbuffers::Vector<int32_t>> new_shape)
@@ -4564,11 +4841,13 @@ inline flatbuffers::Offset<ReshapeOptions>
 CreateReshapeOptionsDirect(flatbuffers::FlatBufferBuilder &_fbb,
                            const std::vector<int32_t> *new_shape = nullptr)
 {
-  return circle::CreateReshapeOptions(_fbb, new_shape ? _fbb.CreateVector<int32_t>(*new_shape) : 0);
+  auto new_shape__ = new_shape ? _fbb.CreateVector<int32_t>(*new_shape) : 0;
+  return circle::CreateReshapeOptions(_fbb, new_shape__);
 }
 
 struct SpaceToBatchNDOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef SpaceToBatchNDOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -4577,6 +4856,7 @@ struct SpaceToBatchNDOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Tabl
 
 struct SpaceToBatchNDOptionsBuilder
 {
+  typedef SpaceToBatchNDOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit SpaceToBatchNDOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
@@ -4601,6 +4881,7 @@ CreateSpaceToBatchNDOptions(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct BatchToSpaceNDOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef BatchToSpaceNDOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -4609,6 +4890,7 @@ struct BatchToSpaceNDOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Tabl
 
 struct BatchToSpaceNDOptionsBuilder
 {
+  typedef BatchToSpaceNDOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit BatchToSpaceNDOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
@@ -4633,7 +4915,8 @@ CreateBatchToSpaceNDOptions(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct SkipGramOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef SkipGramOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_NGRAM_SIZE = 4,
     VT_MAX_SKIP_SIZE = 6,
@@ -4652,6 +4935,7 @@ struct SkipGramOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct SkipGramOptionsBuilder
 {
+  typedef SkipGramOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_ngram_size(int32_t ngram_size)
@@ -4693,7 +4977,8 @@ CreateSkipGramOptions(flatbuffers::FlatBufferBuilder &_fbb, int32_t ngram_size =
 
 struct SpaceToDepthOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef SpaceToDepthOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_BLOCK_SIZE = 4
   };
@@ -4707,6 +4992,7 @@ struct SpaceToDepthOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct SpaceToDepthOptionsBuilder
 {
+  typedef SpaceToDepthOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_block_size(int32_t block_size)
@@ -4736,7 +5022,8 @@ CreateSpaceToDepthOptions(flatbuffers::FlatBufferBuilder &_fbb, int32_t block_si
 
 struct DepthToSpaceOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef DepthToSpaceOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_BLOCK_SIZE = 4
   };
@@ -4750,6 +5037,7 @@ struct DepthToSpaceOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct DepthToSpaceOptionsBuilder
 {
+  typedef DepthToSpaceOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_block_size(int32_t block_size)
@@ -4779,13 +5067,15 @@ CreateDepthToSpaceOptions(flatbuffers::FlatBufferBuilder &_fbb, int32_t block_si
 
 struct SubOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef SubOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_FUSED_ACTIVATION_FUNCTION = 4
   };
-  ActivationFunctionType fused_activation_function() const
+  circle::ActivationFunctionType fused_activation_function() const
   {
-    return static_cast<ActivationFunctionType>(GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
+    return static_cast<circle::ActivationFunctionType>(
+        GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
   }
   bool Verify(flatbuffers::Verifier &verifier) const
   {
@@ -4796,9 +5086,10 @@ struct SubOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct SubOptionsBuilder
 {
+  typedef SubOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_fused_activation_function(ActivationFunctionType fused_activation_function)
+  void add_fused_activation_function(circle::ActivationFunctionType fused_activation_function)
   {
     fbb_.AddElement<int8_t>(SubOptions::VT_FUSED_ACTIVATION_FUNCTION,
                             static_cast<int8_t>(fused_activation_function), 0);
@@ -4816,9 +5107,9 @@ struct SubOptionsBuilder
   }
 };
 
-inline flatbuffers::Offset<SubOptions>
-CreateSubOptions(flatbuffers::FlatBufferBuilder &_fbb,
-                 ActivationFunctionType fused_activation_function = ActivationFunctionType_NONE)
+inline flatbuffers::Offset<SubOptions> CreateSubOptions(
+    flatbuffers::FlatBufferBuilder &_fbb,
+    circle::ActivationFunctionType fused_activation_function = circle::ActivationFunctionType_NONE)
 {
   SubOptionsBuilder builder_(_fbb);
   builder_.add_fused_activation_function(fused_activation_function);
@@ -4827,13 +5118,15 @@ CreateSubOptions(flatbuffers::FlatBufferBuilder &_fbb,
 
 struct DivOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef DivOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_FUSED_ACTIVATION_FUNCTION = 4
   };
-  ActivationFunctionType fused_activation_function() const
+  circle::ActivationFunctionType fused_activation_function() const
   {
-    return static_cast<ActivationFunctionType>(GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
+    return static_cast<circle::ActivationFunctionType>(
+        GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
   }
   bool Verify(flatbuffers::Verifier &verifier) const
   {
@@ -4844,9 +5137,10 @@ struct DivOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct DivOptionsBuilder
 {
+  typedef DivOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_fused_activation_function(ActivationFunctionType fused_activation_function)
+  void add_fused_activation_function(circle::ActivationFunctionType fused_activation_function)
   {
     fbb_.AddElement<int8_t>(DivOptions::VT_FUSED_ACTIVATION_FUNCTION,
                             static_cast<int8_t>(fused_activation_function), 0);
@@ -4864,9 +5158,9 @@ struct DivOptionsBuilder
   }
 };
 
-inline flatbuffers::Offset<DivOptions>
-CreateDivOptions(flatbuffers::FlatBufferBuilder &_fbb,
-                 ActivationFunctionType fused_activation_function = ActivationFunctionType_NONE)
+inline flatbuffers::Offset<DivOptions> CreateDivOptions(
+    flatbuffers::FlatBufferBuilder &_fbb,
+    circle::ActivationFunctionType fused_activation_function = circle::ActivationFunctionType_NONE)
 {
   DivOptionsBuilder builder_(_fbb);
   builder_.add_fused_activation_function(fused_activation_function);
@@ -4875,6 +5169,7 @@ CreateDivOptions(flatbuffers::FlatBufferBuilder &_fbb,
 
 struct TopKV2Options FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef TopKV2OptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -4883,6 +5178,7 @@ struct TopKV2Options FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct TopKV2OptionsBuilder
 {
+  typedef TopKV2Options Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit TopKV2OptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
@@ -4906,13 +5202,14 @@ inline flatbuffers::Offset<TopKV2Options> CreateTopKV2Options(flatbuffers::FlatB
 
 struct EmbeddingLookupSparseOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef EmbeddingLookupSparseOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_COMBINER = 4
   };
-  CombinerType combiner() const
+  circle::CombinerType combiner() const
   {
-    return static_cast<CombinerType>(GetField<int8_t>(VT_COMBINER, 0));
+    return static_cast<circle::CombinerType>(GetField<int8_t>(VT_COMBINER, 0));
   }
   bool Verify(flatbuffers::Verifier &verifier) const
   {
@@ -4923,9 +5220,10 @@ struct EmbeddingLookupSparseOptions FLATBUFFERS_FINAL_CLASS : private flatbuffer
 
 struct EmbeddingLookupSparseOptionsBuilder
 {
+  typedef EmbeddingLookupSparseOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_combiner(CombinerType combiner)
+  void add_combiner(circle::CombinerType combiner)
   {
     fbb_.AddElement<int8_t>(EmbeddingLookupSparseOptions::VT_COMBINER,
                             static_cast<int8_t>(combiner), 0);
@@ -4945,7 +5243,7 @@ struct EmbeddingLookupSparseOptionsBuilder
 
 inline flatbuffers::Offset<EmbeddingLookupSparseOptions>
 CreateEmbeddingLookupSparseOptions(flatbuffers::FlatBufferBuilder &_fbb,
-                                   CombinerType combiner = CombinerType_SUM)
+                                   circle::CombinerType combiner = circle::CombinerType_SUM)
 {
   EmbeddingLookupSparseOptionsBuilder builder_(_fbb);
   builder_.add_combiner(combiner);
@@ -4954,7 +5252,8 @@ CreateEmbeddingLookupSparseOptions(flatbuffers::FlatBufferBuilder &_fbb,
 
 struct GatherOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef GatherOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_AXIS = 4
   };
@@ -4968,6 +5267,7 @@ struct GatherOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct GatherOptionsBuilder
 {
+  typedef GatherOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_axis(int32_t axis) { fbb_.AddElement<int32_t>(GatherOptions::VT_AXIS, axis, 0); }
@@ -4994,6 +5294,7 @@ inline flatbuffers::Offset<GatherOptions> CreateGatherOptions(flatbuffers::FlatB
 
 struct TransposeOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef TransposeOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -5002,6 +5303,7 @@ struct TransposeOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct TransposeOptionsBuilder
 {
+  typedef TransposeOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit TransposeOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
@@ -5026,6 +5328,7 @@ CreateTransposeOptions(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct ExpOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef ExpOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -5034,6 +5337,7 @@ struct ExpOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct ExpOptionsBuilder
 {
+  typedef ExpOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit ExpOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
@@ -5057,6 +5361,7 @@ inline flatbuffers::Offset<ExpOptions> CreateExpOptions(flatbuffers::FlatBufferB
 
 struct CosOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef CosOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -5065,6 +5370,7 @@ struct CosOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct CosOptionsBuilder
 {
+  typedef CosOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit CosOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
@@ -5088,7 +5394,8 @@ inline flatbuffers::Offset<CosOptions> CreateCosOptions(flatbuffers::FlatBufferB
 
 struct ReducerOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef ReducerOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_KEEP_DIMS = 4
   };
@@ -5102,6 +5409,7 @@ struct ReducerOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct ReducerOptionsBuilder
 {
+  typedef ReducerOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_keep_dims(bool keep_dims)
@@ -5131,7 +5439,8 @@ CreateReducerOptions(flatbuffers::FlatBufferBuilder &_fbb, bool keep_dims = fals
 
 struct SqueezeOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef SqueezeOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_SQUEEZE_DIMS = 4
   };
@@ -5148,6 +5457,7 @@ struct SqueezeOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct SqueezeOptionsBuilder
 {
+  typedef SqueezeOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_squeeze_dims(flatbuffers::Offset<flatbuffers::Vector<int32_t>> squeeze_dims)
@@ -5180,13 +5490,14 @@ inline flatbuffers::Offset<SqueezeOptions>
 CreateSqueezeOptionsDirect(flatbuffers::FlatBufferBuilder &_fbb,
                            const std::vector<int32_t> *squeeze_dims = nullptr)
 {
-  return circle::CreateSqueezeOptions(_fbb,
-                                      squeeze_dims ? _fbb.CreateVector<int32_t>(*squeeze_dims) : 0);
+  auto squeeze_dims__ = squeeze_dims ? _fbb.CreateVector<int32_t>(*squeeze_dims) : 0;
+  return circle::CreateSqueezeOptions(_fbb, squeeze_dims__);
 }
 
 struct SplitOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef SplitOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_NUM_SPLITS = 4
   };
@@ -5200,6 +5511,7 @@ struct SplitOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct SplitOptionsBuilder
 {
+  typedef SplitOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_num_splits(int32_t num_splits)
@@ -5229,7 +5541,8 @@ inline flatbuffers::Offset<SplitOptions> CreateSplitOptions(flatbuffers::FlatBuf
 
 struct SplitVOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef SplitVOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_NUM_SPLITS = 4
   };
@@ -5243,6 +5556,7 @@ struct SplitVOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct SplitVOptionsBuilder
 {
+  typedef SplitVOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_num_splits(int32_t num_splits)
@@ -5272,7 +5586,8 @@ inline flatbuffers::Offset<SplitVOptions> CreateSplitVOptions(flatbuffers::FlatB
 
 struct StridedSliceOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef StridedSliceOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_BEGIN_MASK = 4,
     VT_END_MASK = 6,
@@ -5297,6 +5612,7 @@ struct StridedSliceOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct StridedSliceOptionsBuilder
 {
+  typedef StridedSliceOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_begin_mask(int32_t begin_mask)
@@ -5348,6 +5664,7 @@ CreateStridedSliceOptions(flatbuffers::FlatBufferBuilder &_fbb, int32_t begin_ma
 
 struct LogSoftmaxOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef LogSoftmaxOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -5356,6 +5673,7 @@ struct LogSoftmaxOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct LogSoftmaxOptionsBuilder
 {
+  typedef LogSoftmaxOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit LogSoftmaxOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
@@ -5380,18 +5698,19 @@ CreateLogSoftmaxOptions(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct CastOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef CastOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_IN_DATA_TYPE = 4,
     VT_OUT_DATA_TYPE = 6
   };
-  TensorType in_data_type() const
+  circle::TensorType in_data_type() const
   {
-    return static_cast<TensorType>(GetField<int8_t>(VT_IN_DATA_TYPE, 0));
+    return static_cast<circle::TensorType>(GetField<int8_t>(VT_IN_DATA_TYPE, 0));
   }
-  TensorType out_data_type() const
+  circle::TensorType out_data_type() const
   {
-    return static_cast<TensorType>(GetField<int8_t>(VT_OUT_DATA_TYPE, 0));
+    return static_cast<circle::TensorType>(GetField<int8_t>(VT_OUT_DATA_TYPE, 0));
   }
   bool Verify(flatbuffers::Verifier &verifier) const
   {
@@ -5402,13 +5721,14 @@ struct CastOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct CastOptionsBuilder
 {
+  typedef CastOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_in_data_type(TensorType in_data_type)
+  void add_in_data_type(circle::TensorType in_data_type)
   {
     fbb_.AddElement<int8_t>(CastOptions::VT_IN_DATA_TYPE, static_cast<int8_t>(in_data_type), 0);
   }
-  void add_out_data_type(TensorType out_data_type)
+  void add_out_data_type(circle::TensorType out_data_type)
   {
     fbb_.AddElement<int8_t>(CastOptions::VT_OUT_DATA_TYPE, static_cast<int8_t>(out_data_type), 0);
   }
@@ -5427,8 +5747,8 @@ struct CastOptionsBuilder
 
 inline flatbuffers::Offset<CastOptions>
 CreateCastOptions(flatbuffers::FlatBufferBuilder &_fbb,
-                  TensorType in_data_type = TensorType_FLOAT32,
-                  TensorType out_data_type = TensorType_FLOAT32)
+                  circle::TensorType in_data_type = circle::TensorType_FLOAT32,
+                  circle::TensorType out_data_type = circle::TensorType_FLOAT32)
 {
   CastOptionsBuilder builder_(_fbb);
   builder_.add_out_data_type(out_data_type);
@@ -5438,6 +5758,7 @@ CreateCastOptions(flatbuffers::FlatBufferBuilder &_fbb,
 
 struct DequantizeOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef DequantizeOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -5446,6 +5767,7 @@ struct DequantizeOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct DequantizeOptionsBuilder
 {
+  typedef DequantizeOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit DequantizeOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
@@ -5470,6 +5792,7 @@ CreateDequantizeOptions(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct MaximumMinimumOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef MaximumMinimumOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -5478,6 +5801,7 @@ struct MaximumMinimumOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Tabl
 
 struct MaximumMinimumOptionsBuilder
 {
+  typedef MaximumMinimumOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit MaximumMinimumOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
@@ -5502,6 +5826,7 @@ CreateMaximumMinimumOptions(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct TileOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef TileOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -5510,6 +5835,7 @@ struct TileOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct TileOptionsBuilder
 {
+  typedef TileOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit TileOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
@@ -5533,13 +5859,14 @@ inline flatbuffers::Offset<TileOptions> CreateTileOptions(flatbuffers::FlatBuffe
 
 struct ArgMaxOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef ArgMaxOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_OUTPUT_TYPE = 4
   };
-  TensorType output_type() const
+  circle::TensorType output_type() const
   {
-    return static_cast<TensorType>(GetField<int8_t>(VT_OUTPUT_TYPE, 0));
+    return static_cast<circle::TensorType>(GetField<int8_t>(VT_OUTPUT_TYPE, 0));
   }
   bool Verify(flatbuffers::Verifier &verifier) const
   {
@@ -5550,9 +5877,10 @@ struct ArgMaxOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct ArgMaxOptionsBuilder
 {
+  typedef ArgMaxOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_output_type(TensorType output_type)
+  void add_output_type(circle::TensorType output_type)
   {
     fbb_.AddElement<int8_t>(ArgMaxOptions::VT_OUTPUT_TYPE, static_cast<int8_t>(output_type), 0);
   }
@@ -5571,7 +5899,7 @@ struct ArgMaxOptionsBuilder
 
 inline flatbuffers::Offset<ArgMaxOptions>
 CreateArgMaxOptions(flatbuffers::FlatBufferBuilder &_fbb,
-                    TensorType output_type = TensorType_FLOAT32)
+                    circle::TensorType output_type = circle::TensorType_FLOAT32)
 {
   ArgMaxOptionsBuilder builder_(_fbb);
   builder_.add_output_type(output_type);
@@ -5580,13 +5908,14 @@ CreateArgMaxOptions(flatbuffers::FlatBufferBuilder &_fbb,
 
 struct ArgMinOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef ArgMinOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_OUTPUT_TYPE = 4
   };
-  TensorType output_type() const
+  circle::TensorType output_type() const
   {
-    return static_cast<TensorType>(GetField<int8_t>(VT_OUTPUT_TYPE, 0));
+    return static_cast<circle::TensorType>(GetField<int8_t>(VT_OUTPUT_TYPE, 0));
   }
   bool Verify(flatbuffers::Verifier &verifier) const
   {
@@ -5597,9 +5926,10 @@ struct ArgMinOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct ArgMinOptionsBuilder
 {
+  typedef ArgMinOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_output_type(TensorType output_type)
+  void add_output_type(circle::TensorType output_type)
   {
     fbb_.AddElement<int8_t>(ArgMinOptions::VT_OUTPUT_TYPE, static_cast<int8_t>(output_type), 0);
   }
@@ -5618,7 +5948,7 @@ struct ArgMinOptionsBuilder
 
 inline flatbuffers::Offset<ArgMinOptions>
 CreateArgMinOptions(flatbuffers::FlatBufferBuilder &_fbb,
-                    TensorType output_type = TensorType_FLOAT32)
+                    circle::TensorType output_type = circle::TensorType_FLOAT32)
 {
   ArgMinOptionsBuilder builder_(_fbb);
   builder_.add_output_type(output_type);
@@ -5627,6 +5957,7 @@ CreateArgMinOptions(flatbuffers::FlatBufferBuilder &_fbb,
 
 struct GreaterOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef GreaterOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -5635,6 +5966,7 @@ struct GreaterOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct GreaterOptionsBuilder
 {
+  typedef GreaterOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit GreaterOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
@@ -5659,6 +5991,7 @@ CreateGreaterOptions(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct GreaterEqualOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef GreaterEqualOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -5667,6 +6000,7 @@ struct GreaterEqualOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct GreaterEqualOptionsBuilder
 {
+  typedef GreaterEqualOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit GreaterEqualOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
@@ -5691,6 +6025,7 @@ CreateGreaterEqualOptions(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct LessOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef LessOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -5699,6 +6034,7 @@ struct LessOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct LessOptionsBuilder
 {
+  typedef LessOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit LessOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
@@ -5722,6 +6058,7 @@ inline flatbuffers::Offset<LessOptions> CreateLessOptions(flatbuffers::FlatBuffe
 
 struct LessEqualOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef LessEqualOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -5730,6 +6067,7 @@ struct LessEqualOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct LessEqualOptionsBuilder
 {
+  typedef LessEqualOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit LessEqualOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
@@ -5754,6 +6092,7 @@ CreateLessEqualOptions(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct NegOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef NegOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -5762,6 +6101,7 @@ struct NegOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct NegOptionsBuilder
 {
+  typedef NegOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit NegOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
@@ -5785,6 +6125,7 @@ inline flatbuffers::Offset<NegOptions> CreateNegOptions(flatbuffers::FlatBufferB
 
 struct SelectOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef SelectOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -5793,6 +6134,7 @@ struct SelectOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct SelectOptionsBuilder
 {
+  typedef SelectOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit SelectOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
@@ -5816,6 +6158,7 @@ inline flatbuffers::Offset<SelectOptions> CreateSelectOptions(flatbuffers::FlatB
 
 struct SliceOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef SliceOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -5824,6 +6167,7 @@ struct SliceOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct SliceOptionsBuilder
 {
+  typedef SliceOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit SliceOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
@@ -5847,13 +6191,17 @@ inline flatbuffers::Offset<SliceOptions> CreateSliceOptions(flatbuffers::FlatBuf
 
 struct TransposeConvOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef TransposeConvOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_PADDING = 4,
     VT_STRIDE_W = 6,
     VT_STRIDE_H = 8
   };
-  Padding padding() const { return static_cast<Padding>(GetField<int8_t>(VT_PADDING, 0)); }
+  circle::Padding padding() const
+  {
+    return static_cast<circle::Padding>(GetField<int8_t>(VT_PADDING, 0));
+  }
   int32_t stride_w() const { return GetField<int32_t>(VT_STRIDE_W, 0); }
   int32_t stride_h() const { return GetField<int32_t>(VT_STRIDE_H, 0); }
   bool Verify(flatbuffers::Verifier &verifier) const
@@ -5866,9 +6214,10 @@ struct TransposeConvOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct TransposeConvOptionsBuilder
 {
+  typedef TransposeConvOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_padding(Padding padding)
+  void add_padding(circle::Padding padding)
   {
     fbb_.AddElement<int8_t>(TransposeConvOptions::VT_PADDING, static_cast<int8_t>(padding), 0);
   }
@@ -5894,8 +6243,9 @@ struct TransposeConvOptionsBuilder
 };
 
 inline flatbuffers::Offset<TransposeConvOptions>
-CreateTransposeConvOptions(flatbuffers::FlatBufferBuilder &_fbb, Padding padding = Padding_SAME,
-                           int32_t stride_w = 0, int32_t stride_h = 0)
+CreateTransposeConvOptions(flatbuffers::FlatBufferBuilder &_fbb,
+                           circle::Padding padding = circle::Padding_SAME, int32_t stride_w = 0,
+                           int32_t stride_h = 0)
 {
   TransposeConvOptionsBuilder builder_(_fbb);
   builder_.add_stride_h(stride_h);
@@ -5906,6 +6256,7 @@ CreateTransposeConvOptions(flatbuffers::FlatBufferBuilder &_fbb, Padding padding
 
 struct ExpandDimsOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef ExpandDimsOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -5914,6 +6265,7 @@ struct ExpandDimsOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct ExpandDimsOptionsBuilder
 {
+  typedef ExpandDimsOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit ExpandDimsOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
@@ -5938,7 +6290,8 @@ CreateExpandDimsOptions(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct SparseToDenseOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef SparseToDenseOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_VALIDATE_INDICES = 4
   };
@@ -5952,6 +6305,7 @@ struct SparseToDenseOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct SparseToDenseOptionsBuilder
 {
+  typedef SparseToDenseOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_validate_indices(bool validate_indices)
@@ -5982,6 +6336,7 @@ CreateSparseToDenseOptions(flatbuffers::FlatBufferBuilder &_fbb, bool validate_i
 
 struct EqualOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef EqualOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -5990,6 +6345,7 @@ struct EqualOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct EqualOptionsBuilder
 {
+  typedef EqualOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit EqualOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
@@ -6013,6 +6369,7 @@ inline flatbuffers::Offset<EqualOptions> CreateEqualOptions(flatbuffers::FlatBuf
 
 struct NotEqualOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef NotEqualOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -6021,6 +6378,7 @@ struct NotEqualOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct NotEqualOptionsBuilder
 {
+  typedef NotEqualOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit NotEqualOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
@@ -6045,11 +6403,15 @@ CreateNotEqualOptions(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct ShapeOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef ShapeOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_OUT_TYPE = 4
   };
-  TensorType out_type() const { return static_cast<TensorType>(GetField<int8_t>(VT_OUT_TYPE, 0)); }
+  circle::TensorType out_type() const
+  {
+    return static_cast<circle::TensorType>(GetField<int8_t>(VT_OUT_TYPE, 0));
+  }
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && VerifyField<int8_t>(verifier, VT_OUT_TYPE) &&
@@ -6059,9 +6421,10 @@ struct ShapeOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct ShapeOptionsBuilder
 {
+  typedef ShapeOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_out_type(TensorType out_type)
+  void add_out_type(circle::TensorType out_type)
   {
     fbb_.AddElement<int8_t>(ShapeOptions::VT_OUT_TYPE, static_cast<int8_t>(out_type), 0);
   }
@@ -6079,7 +6442,8 @@ struct ShapeOptionsBuilder
 };
 
 inline flatbuffers::Offset<ShapeOptions>
-CreateShapeOptions(flatbuffers::FlatBufferBuilder &_fbb, TensorType out_type = TensorType_FLOAT32)
+CreateShapeOptions(flatbuffers::FlatBufferBuilder &_fbb,
+                   circle::TensorType out_type = circle::TensorType_FLOAT32)
 {
   ShapeOptionsBuilder builder_(_fbb);
   builder_.add_out_type(out_type);
@@ -6088,6 +6452,7 @@ CreateShapeOptions(flatbuffers::FlatBufferBuilder &_fbb, TensorType out_type = T
 
 struct RankOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef RankOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -6096,6 +6461,7 @@ struct RankOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct RankOptionsBuilder
 {
+  typedef RankOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit RankOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
@@ -6119,6 +6485,7 @@ inline flatbuffers::Offset<RankOptions> CreateRankOptions(flatbuffers::FlatBuffe
 
 struct PowOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef PowOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -6127,6 +6494,7 @@ struct PowOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct PowOptionsBuilder
 {
+  typedef PowOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit PowOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
@@ -6150,7 +6518,8 @@ inline flatbuffers::Offset<PowOptions> CreatePowOptions(flatbuffers::FlatBufferB
 
 struct FakeQuantOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef FakeQuantOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_MIN = 4,
     VT_MAX = 6,
@@ -6171,6 +6540,7 @@ struct FakeQuantOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct FakeQuantOptionsBuilder
 {
+  typedef FakeQuantOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_min(float min) { fbb_.AddElement<float>(FakeQuantOptions::VT_MIN, min, 0.0f); }
@@ -6211,7 +6581,8 @@ CreateFakeQuantOptions(flatbuffers::FlatBufferBuilder &_fbb, float min = 0.0f, f
 
 struct PackOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef PackOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_VALUES_COUNT = 4,
     VT_AXIS = 6
@@ -6227,6 +6598,7 @@ struct PackOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct PackOptionsBuilder
 {
+  typedef PackOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_values_count(int32_t values_count)
@@ -6258,6 +6630,7 @@ CreatePackOptions(flatbuffers::FlatBufferBuilder &_fbb, int32_t values_count = 0
 
 struct LogicalOrOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef LogicalOrOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -6266,6 +6639,7 @@ struct LogicalOrOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct LogicalOrOptionsBuilder
 {
+  typedef LogicalOrOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit LogicalOrOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
@@ -6290,7 +6664,8 @@ CreateLogicalOrOptions(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct OneHotOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef OneHotOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_AXIS = 4
   };
@@ -6304,6 +6679,7 @@ struct OneHotOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct OneHotOptionsBuilder
 {
+  typedef OneHotOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_axis(int32_t axis) { fbb_.AddElement<int32_t>(OneHotOptions::VT_AXIS, axis, 0); }
@@ -6330,6 +6706,7 @@ inline flatbuffers::Offset<OneHotOptions> CreateOneHotOptions(flatbuffers::FlatB
 
 struct AbsOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef AbsOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -6338,6 +6715,7 @@ struct AbsOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct AbsOptionsBuilder
 {
+  typedef AbsOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit AbsOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
@@ -6361,6 +6739,7 @@ inline flatbuffers::Offset<AbsOptions> CreateAbsOptions(flatbuffers::FlatBufferB
 
 struct HardSwishOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef HardSwishOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -6369,6 +6748,7 @@ struct HardSwishOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct HardSwishOptionsBuilder
 {
+  typedef HardSwishOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit HardSwishOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
@@ -6393,6 +6773,7 @@ CreateHardSwishOptions(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct LogicalAndOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef LogicalAndOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -6401,6 +6782,7 @@ struct LogicalAndOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct LogicalAndOptionsBuilder
 {
+  typedef LogicalAndOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit LogicalAndOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
@@ -6425,6 +6807,7 @@ CreateLogicalAndOptions(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct LogicalNotOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef LogicalNotOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -6433,6 +6816,7 @@ struct LogicalNotOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct LogicalNotOptionsBuilder
 {
+  typedef LogicalNotOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit LogicalNotOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
@@ -6457,7 +6841,8 @@ CreateLogicalNotOptions(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct UnpackOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef UnpackOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_NUM = 4,
     VT_AXIS = 6
@@ -6473,6 +6858,7 @@ struct UnpackOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct UnpackOptionsBuilder
 {
+  typedef UnpackOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_num(int32_t num) { fbb_.AddElement<int32_t>(UnpackOptions::VT_NUM, num, 0); }
@@ -6501,6 +6887,7 @@ inline flatbuffers::Offset<UnpackOptions> CreateUnpackOptions(flatbuffers::FlatB
 
 struct FloorDivOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef FloorDivOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -6509,6 +6896,7 @@ struct FloorDivOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct FloorDivOptionsBuilder
 {
+  typedef FloorDivOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit FloorDivOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
@@ -6533,6 +6921,7 @@ CreateFloorDivOptions(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct SquareOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef SquareOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -6541,6 +6930,7 @@ struct SquareOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct SquareOptionsBuilder
 {
+  typedef SquareOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit SquareOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
@@ -6564,6 +6954,7 @@ inline flatbuffers::Offset<SquareOptions> CreateSquareOptions(flatbuffers::FlatB
 
 struct ZerosLikeOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef ZerosLikeOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -6572,6 +6963,7 @@ struct ZerosLikeOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct ZerosLikeOptionsBuilder
 {
+  typedef ZerosLikeOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit ZerosLikeOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
@@ -6596,6 +6988,7 @@ CreateZerosLikeOptions(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct FillOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef FillOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -6604,6 +6997,7 @@ struct FillOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct FillOptionsBuilder
 {
+  typedef FillOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit FillOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
@@ -6627,6 +7021,7 @@ inline flatbuffers::Offset<FillOptions> CreateFillOptions(flatbuffers::FlatBuffe
 
 struct FloorModOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef FloorModOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -6635,6 +7030,7 @@ struct FloorModOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct FloorModOptionsBuilder
 {
+  typedef FloorModOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit FloorModOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
@@ -6659,6 +7055,7 @@ CreateFloorModOptions(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct RangeOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef RangeOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -6667,6 +7064,7 @@ struct RangeOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct RangeOptionsBuilder
 {
+  typedef RangeOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit RangeOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
@@ -6690,7 +7088,8 @@ inline flatbuffers::Offset<RangeOptions> CreateRangeOptions(flatbuffers::FlatBuf
 
 struct LeakyReluOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef LeakyReluOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_ALPHA = 4
   };
@@ -6704,6 +7103,7 @@ struct LeakyReluOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct LeakyReluOptionsBuilder
 {
+  typedef LeakyReluOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_alpha(float alpha) { fbb_.AddElement<float>(LeakyReluOptions::VT_ALPHA, alpha, 0.0f); }
@@ -6730,6 +7130,7 @@ CreateLeakyReluOptions(flatbuffers::FlatBufferBuilder &_fbb, float alpha = 0.0f)
 
 struct SquaredDifferenceOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef SquaredDifferenceOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -6738,6 +7139,7 @@ struct SquaredDifferenceOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::T
 
 struct SquaredDifferenceOptionsBuilder
 {
+  typedef SquaredDifferenceOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit SquaredDifferenceOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
@@ -6762,11 +7164,15 @@ CreateSquaredDifferenceOptions(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct MirrorPadOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef MirrorPadOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_MODE = 4
   };
-  MirrorPadMode mode() const { return static_cast<MirrorPadMode>(GetField<int8_t>(VT_MODE, 0)); }
+  circle::MirrorPadMode mode() const
+  {
+    return static_cast<circle::MirrorPadMode>(GetField<int8_t>(VT_MODE, 0));
+  }
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && VerifyField<int8_t>(verifier, VT_MODE) &&
@@ -6776,9 +7182,10 @@ struct MirrorPadOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct MirrorPadOptionsBuilder
 {
+  typedef MirrorPadOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_mode(MirrorPadMode mode)
+  void add_mode(circle::MirrorPadMode mode)
   {
     fbb_.AddElement<int8_t>(MirrorPadOptions::VT_MODE, static_cast<int8_t>(mode), 0);
   }
@@ -6797,7 +7204,7 @@ struct MirrorPadOptionsBuilder
 
 inline flatbuffers::Offset<MirrorPadOptions>
 CreateMirrorPadOptions(flatbuffers::FlatBufferBuilder &_fbb,
-                       MirrorPadMode mode = MirrorPadMode_REFLECT)
+                       circle::MirrorPadMode mode = circle::MirrorPadMode_REFLECT)
 {
   MirrorPadOptionsBuilder builder_(_fbb);
   builder_.add_mode(mode);
@@ -6806,13 +7213,14 @@ CreateMirrorPadOptions(flatbuffers::FlatBufferBuilder &_fbb,
 
 struct UniqueOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef UniqueOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_IDX_OUT_TYPE = 4
   };
-  TensorType idx_out_type() const
+  circle::TensorType idx_out_type() const
   {
-    return static_cast<TensorType>(GetField<int8_t>(VT_IDX_OUT_TYPE, 2));
+    return static_cast<circle::TensorType>(GetField<int8_t>(VT_IDX_OUT_TYPE, 2));
   }
   bool Verify(flatbuffers::Verifier &verifier) const
   {
@@ -6823,9 +7231,10 @@ struct UniqueOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct UniqueOptionsBuilder
 {
+  typedef UniqueOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_idx_out_type(TensorType idx_out_type)
+  void add_idx_out_type(circle::TensorType idx_out_type)
   {
     fbb_.AddElement<int8_t>(UniqueOptions::VT_IDX_OUT_TYPE, static_cast<int8_t>(idx_out_type), 2);
   }
@@ -6844,7 +7253,7 @@ struct UniqueOptionsBuilder
 
 inline flatbuffers::Offset<UniqueOptions>
 CreateUniqueOptions(flatbuffers::FlatBufferBuilder &_fbb,
-                    TensorType idx_out_type = TensorType_INT32)
+                    circle::TensorType idx_out_type = circle::TensorType_INT32)
 {
   UniqueOptionsBuilder builder_(_fbb);
   builder_.add_idx_out_type(idx_out_type);
@@ -6853,6 +7262,7 @@ CreateUniqueOptions(flatbuffers::FlatBufferBuilder &_fbb,
 
 struct ReverseV2Options FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef ReverseV2OptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -6861,6 +7271,7 @@ struct ReverseV2Options FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct ReverseV2OptionsBuilder
 {
+  typedef ReverseV2Options Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit ReverseV2OptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
@@ -6885,6 +7296,7 @@ CreateReverseV2Options(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct AddNOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef AddNOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -6893,6 +7305,7 @@ struct AddNOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct AddNOptionsBuilder
 {
+  typedef AddNOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit AddNOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
@@ -6916,6 +7329,7 @@ inline flatbuffers::Offset<AddNOptions> CreateAddNOptions(flatbuffers::FlatBuffe
 
 struct GatherNdOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef GatherNdOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -6924,6 +7338,7 @@ struct GatherNdOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct GatherNdOptionsBuilder
 {
+  typedef GatherNdOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit GatherNdOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
@@ -6948,6 +7363,7 @@ CreateGatherNdOptions(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct WhereOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef WhereOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -6956,6 +7372,7 @@ struct WhereOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct WhereOptionsBuilder
 {
+  typedef WhereOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit WhereOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
@@ -6979,7 +7396,8 @@ inline flatbuffers::Offset<WhereOptions> CreateWhereOptions(flatbuffers::FlatBuf
 
 struct ReverseSequenceOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef ReverseSequenceOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_SEQ_DIM = 4,
     VT_BATCH_DIM = 6
@@ -6995,6 +7413,7 @@ struct ReverseSequenceOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Tab
 
 struct ReverseSequenceOptionsBuilder
 {
+  typedef ReverseSequenceOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_seq_dim(int32_t seq_dim)
@@ -7030,6 +7449,7 @@ CreateReverseSequenceOptions(flatbuffers::FlatBufferBuilder &_fbb, int32_t seq_d
 
 struct MatrixDiagOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef MatrixDiagOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -7038,6 +7458,7 @@ struct MatrixDiagOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct MatrixDiagOptionsBuilder
 {
+  typedef MatrixDiagOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit MatrixDiagOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
@@ -7062,6 +7483,7 @@ CreateMatrixDiagOptions(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct QuantizeOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef QuantizeOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -7070,6 +7492,7 @@ struct QuantizeOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct QuantizeOptionsBuilder
 {
+  typedef QuantizeOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit QuantizeOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
@@ -7094,6 +7517,7 @@ CreateQuantizeOptions(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct MatrixSetDiagOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef MatrixSetDiagOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -7102,6 +7526,7 @@ struct MatrixSetDiagOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct MatrixSetDiagOptionsBuilder
 {
+  typedef MatrixSetDiagOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit MatrixSetDiagOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
@@ -7126,7 +7551,8 @@ CreateMatrixSetDiagOptions(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct IfOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef IfOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_THEN_SUBGRAPH_INDEX = 4,
     VT_ELSE_SUBGRAPH_INDEX = 6
@@ -7142,6 +7568,7 @@ struct IfOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct IfOptionsBuilder
 {
+  typedef IfOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_then_subgraph_index(int32_t then_subgraph_index)
@@ -7177,7 +7604,8 @@ inline flatbuffers::Offset<IfOptions> CreateIfOptions(flatbuffers::FlatBufferBui
 
 struct WhileOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef WhileOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_COND_SUBGRAPH_INDEX = 4,
     VT_BODY_SUBGRAPH_INDEX = 6
@@ -7193,6 +7621,7 @@ struct WhileOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct WhileOptionsBuilder
 {
+  typedef WhileOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_cond_subgraph_index(int32_t cond_subgraph_index)
@@ -7228,6 +7657,7 @@ inline flatbuffers::Offset<WhileOptions> CreateWhileOptions(flatbuffers::FlatBuf
 
 struct NonMaxSuppressionV4Options FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef NonMaxSuppressionV4OptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -7236,6 +7666,7 @@ struct NonMaxSuppressionV4Options FLATBUFFERS_FINAL_CLASS : private flatbuffers:
 
 struct NonMaxSuppressionV4OptionsBuilder
 {
+  typedef NonMaxSuppressionV4Options Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit NonMaxSuppressionV4OptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
@@ -7260,6 +7691,7 @@ CreateNonMaxSuppressionV4Options(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct NonMaxSuppressionV5Options FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef NonMaxSuppressionV5OptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -7268,6 +7700,7 @@ struct NonMaxSuppressionV5Options FLATBUFFERS_FINAL_CLASS : private flatbuffers:
 
 struct NonMaxSuppressionV5OptionsBuilder
 {
+  typedef NonMaxSuppressionV5Options Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit NonMaxSuppressionV5OptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
@@ -7292,6 +7725,7 @@ CreateNonMaxSuppressionV5Options(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct ScatterNdOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef ScatterNdOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -7300,6 +7734,7 @@ struct ScatterNdOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct ScatterNdOptionsBuilder
 {
+  typedef ScatterNdOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit ScatterNdOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
@@ -7324,6 +7759,7 @@ CreateScatterNdOptions(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct SelectV2Options FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef SelectV2OptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -7332,6 +7768,7 @@ struct SelectV2Options FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct SelectV2OptionsBuilder
 {
+  typedef SelectV2Options Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit SelectV2OptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
@@ -7356,6 +7793,7 @@ CreateSelectV2Options(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct DensifyOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef DensifyOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -7364,6 +7802,7 @@ struct DensifyOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct DensifyOptionsBuilder
 {
+  typedef DensifyOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit DensifyOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
@@ -7388,6 +7827,7 @@ CreateDensifyOptions(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct SegmentSumOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef SegmentSumOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -7396,6 +7836,7 @@ struct SegmentSumOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct SegmentSumOptionsBuilder
 {
+  typedef SegmentSumOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit SegmentSumOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
@@ -7420,7 +7861,8 @@ CreateSegmentSumOptions(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct BatchMatMulOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef BatchMatMulOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_ADJOINT_LHS = 4,
     VT_ADJOINT_RHS = 6
@@ -7436,6 +7878,7 @@ struct BatchMatMulOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct BatchMatMulOptionsBuilder
 {
+  typedef BatchMatMulOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_adjoint_lhs(bool adjoint_lhs)
@@ -7473,7 +7916,8 @@ CreateBatchMatMulOptions(flatbuffers::FlatBufferBuilder &_fbb, bool adjoint_lhs 
 
 struct BCQGatherOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef BCQGatherOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_INPUT_HIDDEN_SIZE = 4,
     VT_AXIS = 6
@@ -7489,6 +7933,7 @@ struct BCQGatherOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct BCQGatherOptionsBuilder
 {
+  typedef BCQGatherOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_input_hidden_size(int32_t input_hidden_size)
@@ -7521,15 +7966,17 @@ CreateBCQGatherOptions(flatbuffers::FlatBufferBuilder &_fbb, int32_t input_hidde
 
 struct BCQFullyConnectedOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef BCQFullyConnectedOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_WEIGHTS_HIDDEN_SIZE = 4,
     VT_FUSED_ACTIVATION_FUNCTION = 6
   };
   int32_t weights_hidden_size() const { return GetField<int32_t>(VT_WEIGHTS_HIDDEN_SIZE, 0); }
-  ActivationFunctionType fused_activation_function() const
+  circle::ActivationFunctionType fused_activation_function() const
   {
-    return static_cast<ActivationFunctionType>(GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
+    return static_cast<circle::ActivationFunctionType>(
+        GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
   }
   bool Verify(flatbuffers::Verifier &verifier) const
   {
@@ -7540,6 +7987,7 @@ struct BCQFullyConnectedOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::T
 
 struct BCQFullyConnectedOptionsBuilder
 {
+  typedef BCQFullyConnectedOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_weights_hidden_size(int32_t weights_hidden_size)
@@ -7547,7 +7995,7 @@ struct BCQFullyConnectedOptionsBuilder
     fbb_.AddElement<int32_t>(BCQFullyConnectedOptions::VT_WEIGHTS_HIDDEN_SIZE, weights_hidden_size,
                              0);
   }
-  void add_fused_activation_function(ActivationFunctionType fused_activation_function)
+  void add_fused_activation_function(circle::ActivationFunctionType fused_activation_function)
   {
     fbb_.AddElement<int8_t>(BCQFullyConnectedOptions::VT_FUSED_ACTIVATION_FUNCTION,
                             static_cast<int8_t>(fused_activation_function), 0);
@@ -7567,7 +8015,7 @@ struct BCQFullyConnectedOptionsBuilder
 
 inline flatbuffers::Offset<BCQFullyConnectedOptions> CreateBCQFullyConnectedOptions(
     flatbuffers::FlatBufferBuilder &_fbb, int32_t weights_hidden_size = 0,
-    ActivationFunctionType fused_activation_function = ActivationFunctionType_NONE)
+    circle::ActivationFunctionType fused_activation_function = circle::ActivationFunctionType_NONE)
 {
   BCQFullyConnectedOptionsBuilder builder_(_fbb);
   builder_.add_weights_hidden_size(weights_hidden_size);
@@ -7577,15 +8025,17 @@ inline flatbuffers::Offset<BCQFullyConnectedOptions> CreateBCQFullyConnectedOpti
 
 struct InstanceNormOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef InstanceNormOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_EPSILON = 4,
     VT_FUSED_ACTIVATION_FUNCTION = 6
   };
   float epsilon() const { return GetField<float>(VT_EPSILON, 0.0f); }
-  ActivationFunctionType fused_activation_function() const
+  circle::ActivationFunctionType fused_activation_function() const
   {
-    return static_cast<ActivationFunctionType>(GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
+    return static_cast<circle::ActivationFunctionType>(
+        GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
   }
   bool Verify(flatbuffers::Verifier &verifier) const
   {
@@ -7596,13 +8046,14 @@ struct InstanceNormOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct InstanceNormOptionsBuilder
 {
+  typedef InstanceNormOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_epsilon(float epsilon)
   {
     fbb_.AddElement<float>(InstanceNormOptions::VT_EPSILON, epsilon, 0.0f);
   }
-  void add_fused_activation_function(ActivationFunctionType fused_activation_function)
+  void add_fused_activation_function(circle::ActivationFunctionType fused_activation_function)
   {
     fbb_.AddElement<int8_t>(InstanceNormOptions::VT_FUSED_ACTIVATION_FUNCTION,
                             static_cast<int8_t>(fused_activation_function), 0);
@@ -7622,7 +8073,7 @@ struct InstanceNormOptionsBuilder
 
 inline flatbuffers::Offset<InstanceNormOptions> CreateInstanceNormOptions(
     flatbuffers::FlatBufferBuilder &_fbb, float epsilon = 0.0f,
-    ActivationFunctionType fused_activation_function = ActivationFunctionType_NONE)
+    circle::ActivationFunctionType fused_activation_function = circle::ActivationFunctionType_NONE)
 {
   InstanceNormOptionsBuilder builder_(_fbb);
   builder_.add_epsilon(epsilon);
@@ -7632,15 +8083,16 @@ inline flatbuffers::Offset<InstanceNormOptions> CreateInstanceNormOptions(
 
 struct OperatorCode FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef OperatorCodeBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_BUILTIN_CODE = 4,
     VT_CUSTOM_CODE = 6,
     VT_VERSION = 8
   };
-  BuiltinOperator builtin_code() const
+  circle::BuiltinOperator builtin_code() const
   {
-    return static_cast<BuiltinOperator>(GetField<uint8_t>(VT_BUILTIN_CODE, 0));
+    return static_cast<circle::BuiltinOperator>(GetField<uint8_t>(VT_BUILTIN_CODE, 0));
   }
   const flatbuffers::String *custom_code() const
   {
@@ -7657,9 +8109,10 @@ struct OperatorCode FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct OperatorCodeBuilder
 {
+  typedef OperatorCode Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_builtin_code(BuiltinOperator builtin_code)
+  void add_builtin_code(circle::BuiltinOperator builtin_code)
   {
     fbb_.AddElement<uint8_t>(OperatorCode::VT_BUILTIN_CODE, static_cast<uint8_t>(builtin_code), 0);
   }
@@ -7686,7 +8139,7 @@ struct OperatorCodeBuilder
 
 inline flatbuffers::Offset<OperatorCode>
 CreateOperatorCode(flatbuffers::FlatBufferBuilder &_fbb,
-                   BuiltinOperator builtin_code = BuiltinOperator_ADD,
+                   circle::BuiltinOperator builtin_code = circle::BuiltinOperator_ADD,
                    flatbuffers::Offset<flatbuffers::String> custom_code = 0, int32_t version = 1)
 {
   OperatorCodeBuilder builder_(_fbb);
@@ -7698,16 +8151,17 @@ CreateOperatorCode(flatbuffers::FlatBufferBuilder &_fbb,
 
 inline flatbuffers::Offset<OperatorCode>
 CreateOperatorCodeDirect(flatbuffers::FlatBufferBuilder &_fbb,
-                         BuiltinOperator builtin_code = BuiltinOperator_ADD,
+                         circle::BuiltinOperator builtin_code = circle::BuiltinOperator_ADD,
                          const char *custom_code = nullptr, int32_t version = 1)
 {
-  return circle::CreateOperatorCode(_fbb, builtin_code,
-                                    custom_code ? _fbb.CreateString(custom_code) : 0, version);
+  auto custom_code__ = custom_code ? _fbb.CreateString(custom_code) : 0;
+  return circle::CreateOperatorCode(_fbb, builtin_code, custom_code__, version);
 }
 
 struct Operator FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef OperatorBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_OPCODE_INDEX = 4,
     VT_INPUTS = 6,
@@ -7728,646 +8182,649 @@ struct Operator FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
   {
     return GetPointer<const flatbuffers::Vector<int32_t> *>(VT_OUTPUTS);
   }
-  BuiltinOptions builtin_options_type() const
+  circle::BuiltinOptions builtin_options_type() const
   {
-    return static_cast<BuiltinOptions>(GetField<uint8_t>(VT_BUILTIN_OPTIONS_TYPE, 0));
+    return static_cast<circle::BuiltinOptions>(GetField<uint8_t>(VT_BUILTIN_OPTIONS_TYPE, 0));
   }
   const void *builtin_options() const { return GetPointer<const void *>(VT_BUILTIN_OPTIONS); }
   template <typename T> const T *builtin_options_as() const;
-  const Conv2DOptions *builtin_options_as_Conv2DOptions() const
+  const circle::Conv2DOptions *builtin_options_as_Conv2DOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_Conv2DOptions
-               ? static_cast<const Conv2DOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_Conv2DOptions
+               ? static_cast<const circle::Conv2DOptions *>(builtin_options())
                : nullptr;
   }
-  const DepthwiseConv2DOptions *builtin_options_as_DepthwiseConv2DOptions() const
+  const circle::DepthwiseConv2DOptions *builtin_options_as_DepthwiseConv2DOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_DepthwiseConv2DOptions
-               ? static_cast<const DepthwiseConv2DOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_DepthwiseConv2DOptions
+               ? static_cast<const circle::DepthwiseConv2DOptions *>(builtin_options())
                : nullptr;
   }
-  const ConcatEmbeddingsOptions *builtin_options_as_ConcatEmbeddingsOptions() const
+  const circle::ConcatEmbeddingsOptions *builtin_options_as_ConcatEmbeddingsOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_ConcatEmbeddingsOptions
-               ? static_cast<const ConcatEmbeddingsOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_ConcatEmbeddingsOptions
+               ? static_cast<const circle::ConcatEmbeddingsOptions *>(builtin_options())
                : nullptr;
   }
-  const LSHProjectionOptions *builtin_options_as_LSHProjectionOptions() const
+  const circle::LSHProjectionOptions *builtin_options_as_LSHProjectionOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_LSHProjectionOptions
-               ? static_cast<const LSHProjectionOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_LSHProjectionOptions
+               ? static_cast<const circle::LSHProjectionOptions *>(builtin_options())
                : nullptr;
   }
-  const Pool2DOptions *builtin_options_as_Pool2DOptions() const
+  const circle::Pool2DOptions *builtin_options_as_Pool2DOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_Pool2DOptions
-               ? static_cast<const Pool2DOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_Pool2DOptions
+               ? static_cast<const circle::Pool2DOptions *>(builtin_options())
                : nullptr;
   }
-  const SVDFOptions *builtin_options_as_SVDFOptions() const
+  const circle::SVDFOptions *builtin_options_as_SVDFOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_SVDFOptions
-               ? static_cast<const SVDFOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_SVDFOptions
+               ? static_cast<const circle::SVDFOptions *>(builtin_options())
                : nullptr;
   }
-  const RNNOptions *builtin_options_as_RNNOptions() const
+  const circle::RNNOptions *builtin_options_as_RNNOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_RNNOptions
-               ? static_cast<const RNNOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_RNNOptions
+               ? static_cast<const circle::RNNOptions *>(builtin_options())
                : nullptr;
   }
-  const FullyConnectedOptions *builtin_options_as_FullyConnectedOptions() const
+  const circle::FullyConnectedOptions *builtin_options_as_FullyConnectedOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_FullyConnectedOptions
-               ? static_cast<const FullyConnectedOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_FullyConnectedOptions
+               ? static_cast<const circle::FullyConnectedOptions *>(builtin_options())
                : nullptr;
   }
-  const SoftmaxOptions *builtin_options_as_SoftmaxOptions() const
+  const circle::SoftmaxOptions *builtin_options_as_SoftmaxOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_SoftmaxOptions
-               ? static_cast<const SoftmaxOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_SoftmaxOptions
+               ? static_cast<const circle::SoftmaxOptions *>(builtin_options())
                : nullptr;
   }
-  const ConcatenationOptions *builtin_options_as_ConcatenationOptions() const
+  const circle::ConcatenationOptions *builtin_options_as_ConcatenationOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_ConcatenationOptions
-               ? static_cast<const ConcatenationOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_ConcatenationOptions
+               ? static_cast<const circle::ConcatenationOptions *>(builtin_options())
                : nullptr;
   }
-  const AddOptions *builtin_options_as_AddOptions() const
+  const circle::AddOptions *builtin_options_as_AddOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_AddOptions
-               ? static_cast<const AddOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_AddOptions
+               ? static_cast<const circle::AddOptions *>(builtin_options())
                : nullptr;
   }
-  const L2NormOptions *builtin_options_as_L2NormOptions() const
+  const circle::L2NormOptions *builtin_options_as_L2NormOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_L2NormOptions
-               ? static_cast<const L2NormOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_L2NormOptions
+               ? static_cast<const circle::L2NormOptions *>(builtin_options())
                : nullptr;
   }
-  const LocalResponseNormalizationOptions *
+  const circle::LocalResponseNormalizationOptions *
   builtin_options_as_LocalResponseNormalizationOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_LocalResponseNormalizationOptions
-               ? static_cast<const LocalResponseNormalizationOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_LocalResponseNormalizationOptions
+               ? static_cast<const circle::LocalResponseNormalizationOptions *>(builtin_options())
                : nullptr;
   }
-  const LSTMOptions *builtin_options_as_LSTMOptions() const
+  const circle::LSTMOptions *builtin_options_as_LSTMOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_LSTMOptions
-               ? static_cast<const LSTMOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_LSTMOptions
+               ? static_cast<const circle::LSTMOptions *>(builtin_options())
                : nullptr;
   }
-  const ResizeBilinearOptions *builtin_options_as_ResizeBilinearOptions() const
+  const circle::ResizeBilinearOptions *builtin_options_as_ResizeBilinearOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_ResizeBilinearOptions
-               ? static_cast<const ResizeBilinearOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_ResizeBilinearOptions
+               ? static_cast<const circle::ResizeBilinearOptions *>(builtin_options())
                : nullptr;
   }
-  const CallOptions *builtin_options_as_CallOptions() const
+  const circle::CallOptions *builtin_options_as_CallOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_CallOptions
-               ? static_cast<const CallOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_CallOptions
+               ? static_cast<const circle::CallOptions *>(builtin_options())
                : nullptr;
   }
-  const ReshapeOptions *builtin_options_as_ReshapeOptions() const
+  const circle::ReshapeOptions *builtin_options_as_ReshapeOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_ReshapeOptions
-               ? static_cast<const ReshapeOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_ReshapeOptions
+               ? static_cast<const circle::ReshapeOptions *>(builtin_options())
                : nullptr;
   }
-  const SkipGramOptions *builtin_options_as_SkipGramOptions() const
+  const circle::SkipGramOptions *builtin_options_as_SkipGramOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_SkipGramOptions
-               ? static_cast<const SkipGramOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_SkipGramOptions
+               ? static_cast<const circle::SkipGramOptions *>(builtin_options())
                : nullptr;
   }
-  const SpaceToDepthOptions *builtin_options_as_SpaceToDepthOptions() const
+  const circle::SpaceToDepthOptions *builtin_options_as_SpaceToDepthOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_SpaceToDepthOptions
-               ? static_cast<const SpaceToDepthOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_SpaceToDepthOptions
+               ? static_cast<const circle::SpaceToDepthOptions *>(builtin_options())
                : nullptr;
   }
-  const EmbeddingLookupSparseOptions *builtin_options_as_EmbeddingLookupSparseOptions() const
+  const circle::EmbeddingLookupSparseOptions *
+  builtin_options_as_EmbeddingLookupSparseOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_EmbeddingLookupSparseOptions
-               ? static_cast<const EmbeddingLookupSparseOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_EmbeddingLookupSparseOptions
+               ? static_cast<const circle::EmbeddingLookupSparseOptions *>(builtin_options())
                : nullptr;
   }
-  const MulOptions *builtin_options_as_MulOptions() const
+  const circle::MulOptions *builtin_options_as_MulOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_MulOptions
-               ? static_cast<const MulOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_MulOptions
+               ? static_cast<const circle::MulOptions *>(builtin_options())
                : nullptr;
   }
-  const PadOptions *builtin_options_as_PadOptions() const
+  const circle::PadOptions *builtin_options_as_PadOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_PadOptions
-               ? static_cast<const PadOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_PadOptions
+               ? static_cast<const circle::PadOptions *>(builtin_options())
                : nullptr;
   }
-  const GatherOptions *builtin_options_as_GatherOptions() const
+  const circle::GatherOptions *builtin_options_as_GatherOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_GatherOptions
-               ? static_cast<const GatherOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_GatherOptions
+               ? static_cast<const circle::GatherOptions *>(builtin_options())
                : nullptr;
   }
-  const BatchToSpaceNDOptions *builtin_options_as_BatchToSpaceNDOptions() const
+  const circle::BatchToSpaceNDOptions *builtin_options_as_BatchToSpaceNDOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_BatchToSpaceNDOptions
-               ? static_cast<const BatchToSpaceNDOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_BatchToSpaceNDOptions
+               ? static_cast<const circle::BatchToSpaceNDOptions *>(builtin_options())
                : nullptr;
   }
-  const SpaceToBatchNDOptions *builtin_options_as_SpaceToBatchNDOptions() const
+  const circle::SpaceToBatchNDOptions *builtin_options_as_SpaceToBatchNDOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_SpaceToBatchNDOptions
-               ? static_cast<const SpaceToBatchNDOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_SpaceToBatchNDOptions
+               ? static_cast<const circle::SpaceToBatchNDOptions *>(builtin_options())
                : nullptr;
   }
-  const TransposeOptions *builtin_options_as_TransposeOptions() const
+  const circle::TransposeOptions *builtin_options_as_TransposeOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_TransposeOptions
-               ? static_cast<const TransposeOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_TransposeOptions
+               ? static_cast<const circle::TransposeOptions *>(builtin_options())
                : nullptr;
   }
-  const ReducerOptions *builtin_options_as_ReducerOptions() const
+  const circle::ReducerOptions *builtin_options_as_ReducerOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_ReducerOptions
-               ? static_cast<const ReducerOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_ReducerOptions
+               ? static_cast<const circle::ReducerOptions *>(builtin_options())
                : nullptr;
   }
-  const SubOptions *builtin_options_as_SubOptions() const
+  const circle::SubOptions *builtin_options_as_SubOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_SubOptions
-               ? static_cast<const SubOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_SubOptions
+               ? static_cast<const circle::SubOptions *>(builtin_options())
                : nullptr;
   }
-  const DivOptions *builtin_options_as_DivOptions() const
+  const circle::DivOptions *builtin_options_as_DivOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_DivOptions
-               ? static_cast<const DivOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_DivOptions
+               ? static_cast<const circle::DivOptions *>(builtin_options())
                : nullptr;
   }
-  const SqueezeOptions *builtin_options_as_SqueezeOptions() const
+  const circle::SqueezeOptions *builtin_options_as_SqueezeOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_SqueezeOptions
-               ? static_cast<const SqueezeOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_SqueezeOptions
+               ? static_cast<const circle::SqueezeOptions *>(builtin_options())
                : nullptr;
   }
-  const SequenceRNNOptions *builtin_options_as_SequenceRNNOptions() const
+  const circle::SequenceRNNOptions *builtin_options_as_SequenceRNNOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_SequenceRNNOptions
-               ? static_cast<const SequenceRNNOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_SequenceRNNOptions
+               ? static_cast<const circle::SequenceRNNOptions *>(builtin_options())
                : nullptr;
   }
-  const StridedSliceOptions *builtin_options_as_StridedSliceOptions() const
+  const circle::StridedSliceOptions *builtin_options_as_StridedSliceOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_StridedSliceOptions
-               ? static_cast<const StridedSliceOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_StridedSliceOptions
+               ? static_cast<const circle::StridedSliceOptions *>(builtin_options())
                : nullptr;
   }
-  const ExpOptions *builtin_options_as_ExpOptions() const
+  const circle::ExpOptions *builtin_options_as_ExpOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_ExpOptions
-               ? static_cast<const ExpOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_ExpOptions
+               ? static_cast<const circle::ExpOptions *>(builtin_options())
                : nullptr;
   }
-  const TopKV2Options *builtin_options_as_TopKV2Options() const
+  const circle::TopKV2Options *builtin_options_as_TopKV2Options() const
   {
-    return builtin_options_type() == BuiltinOptions_TopKV2Options
-               ? static_cast<const TopKV2Options *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_TopKV2Options
+               ? static_cast<const circle::TopKV2Options *>(builtin_options())
                : nullptr;
   }
-  const SplitOptions *builtin_options_as_SplitOptions() const
+  const circle::SplitOptions *builtin_options_as_SplitOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_SplitOptions
-               ? static_cast<const SplitOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_SplitOptions
+               ? static_cast<const circle::SplitOptions *>(builtin_options())
                : nullptr;
   }
-  const LogSoftmaxOptions *builtin_options_as_LogSoftmaxOptions() const
+  const circle::LogSoftmaxOptions *builtin_options_as_LogSoftmaxOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_LogSoftmaxOptions
-               ? static_cast<const LogSoftmaxOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_LogSoftmaxOptions
+               ? static_cast<const circle::LogSoftmaxOptions *>(builtin_options())
                : nullptr;
   }
-  const CastOptions *builtin_options_as_CastOptions() const
+  const circle::CastOptions *builtin_options_as_CastOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_CastOptions
-               ? static_cast<const CastOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_CastOptions
+               ? static_cast<const circle::CastOptions *>(builtin_options())
                : nullptr;
   }
-  const DequantizeOptions *builtin_options_as_DequantizeOptions() const
+  const circle::DequantizeOptions *builtin_options_as_DequantizeOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_DequantizeOptions
-               ? static_cast<const DequantizeOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_DequantizeOptions
+               ? static_cast<const circle::DequantizeOptions *>(builtin_options())
                : nullptr;
   }
-  const MaximumMinimumOptions *builtin_options_as_MaximumMinimumOptions() const
+  const circle::MaximumMinimumOptions *builtin_options_as_MaximumMinimumOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_MaximumMinimumOptions
-               ? static_cast<const MaximumMinimumOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_MaximumMinimumOptions
+               ? static_cast<const circle::MaximumMinimumOptions *>(builtin_options())
                : nullptr;
   }
-  const ArgMaxOptions *builtin_options_as_ArgMaxOptions() const
+  const circle::ArgMaxOptions *builtin_options_as_ArgMaxOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_ArgMaxOptions
-               ? static_cast<const ArgMaxOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_ArgMaxOptions
+               ? static_cast<const circle::ArgMaxOptions *>(builtin_options())
                : nullptr;
   }
-  const LessOptions *builtin_options_as_LessOptions() const
+  const circle::LessOptions *builtin_options_as_LessOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_LessOptions
-               ? static_cast<const LessOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_LessOptions
+               ? static_cast<const circle::LessOptions *>(builtin_options())
                : nullptr;
   }
-  const NegOptions *builtin_options_as_NegOptions() const
+  const circle::NegOptions *builtin_options_as_NegOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_NegOptions
-               ? static_cast<const NegOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_NegOptions
+               ? static_cast<const circle::NegOptions *>(builtin_options())
                : nullptr;
   }
-  const PadV2Options *builtin_options_as_PadV2Options() const
+  const circle::PadV2Options *builtin_options_as_PadV2Options() const
   {
-    return builtin_options_type() == BuiltinOptions_PadV2Options
-               ? static_cast<const PadV2Options *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_PadV2Options
+               ? static_cast<const circle::PadV2Options *>(builtin_options())
                : nullptr;
   }
-  const GreaterOptions *builtin_options_as_GreaterOptions() const
+  const circle::GreaterOptions *builtin_options_as_GreaterOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_GreaterOptions
-               ? static_cast<const GreaterOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_GreaterOptions
+               ? static_cast<const circle::GreaterOptions *>(builtin_options())
                : nullptr;
   }
-  const GreaterEqualOptions *builtin_options_as_GreaterEqualOptions() const
+  const circle::GreaterEqualOptions *builtin_options_as_GreaterEqualOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_GreaterEqualOptions
-               ? static_cast<const GreaterEqualOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_GreaterEqualOptions
+               ? static_cast<const circle::GreaterEqualOptions *>(builtin_options())
                : nullptr;
   }
-  const LessEqualOptions *builtin_options_as_LessEqualOptions() const
+  const circle::LessEqualOptions *builtin_options_as_LessEqualOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_LessEqualOptions
-               ? static_cast<const LessEqualOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_LessEqualOptions
+               ? static_cast<const circle::LessEqualOptions *>(builtin_options())
                : nullptr;
   }
-  const SelectOptions *builtin_options_as_SelectOptions() const
+  const circle::SelectOptions *builtin_options_as_SelectOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_SelectOptions
-               ? static_cast<const SelectOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_SelectOptions
+               ? static_cast<const circle::SelectOptions *>(builtin_options())
                : nullptr;
   }
-  const SliceOptions *builtin_options_as_SliceOptions() const
+  const circle::SliceOptions *builtin_options_as_SliceOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_SliceOptions
-               ? static_cast<const SliceOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_SliceOptions
+               ? static_cast<const circle::SliceOptions *>(builtin_options())
                : nullptr;
   }
-  const TransposeConvOptions *builtin_options_as_TransposeConvOptions() const
+  const circle::TransposeConvOptions *builtin_options_as_TransposeConvOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_TransposeConvOptions
-               ? static_cast<const TransposeConvOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_TransposeConvOptions
+               ? static_cast<const circle::TransposeConvOptions *>(builtin_options())
                : nullptr;
   }
-  const SparseToDenseOptions *builtin_options_as_SparseToDenseOptions() const
+  const circle::SparseToDenseOptions *builtin_options_as_SparseToDenseOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_SparseToDenseOptions
-               ? static_cast<const SparseToDenseOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_SparseToDenseOptions
+               ? static_cast<const circle::SparseToDenseOptions *>(builtin_options())
                : nullptr;
   }
-  const TileOptions *builtin_options_as_TileOptions() const
+  const circle::TileOptions *builtin_options_as_TileOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_TileOptions
-               ? static_cast<const TileOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_TileOptions
+               ? static_cast<const circle::TileOptions *>(builtin_options())
                : nullptr;
   }
-  const ExpandDimsOptions *builtin_options_as_ExpandDimsOptions() const
+  const circle::ExpandDimsOptions *builtin_options_as_ExpandDimsOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_ExpandDimsOptions
-               ? static_cast<const ExpandDimsOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_ExpandDimsOptions
+               ? static_cast<const circle::ExpandDimsOptions *>(builtin_options())
                : nullptr;
   }
-  const EqualOptions *builtin_options_as_EqualOptions() const
+  const circle::EqualOptions *builtin_options_as_EqualOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_EqualOptions
-               ? static_cast<const EqualOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_EqualOptions
+               ? static_cast<const circle::EqualOptions *>(builtin_options())
                : nullptr;
   }
-  const NotEqualOptions *builtin_options_as_NotEqualOptions() const
+  const circle::NotEqualOptions *builtin_options_as_NotEqualOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_NotEqualOptions
-               ? static_cast<const NotEqualOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_NotEqualOptions
+               ? static_cast<const circle::NotEqualOptions *>(builtin_options())
                : nullptr;
   }
-  const ShapeOptions *builtin_options_as_ShapeOptions() const
+  const circle::ShapeOptions *builtin_options_as_ShapeOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_ShapeOptions
-               ? static_cast<const ShapeOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_ShapeOptions
+               ? static_cast<const circle::ShapeOptions *>(builtin_options())
                : nullptr;
   }
-  const PowOptions *builtin_options_as_PowOptions() const
+  const circle::PowOptions *builtin_options_as_PowOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_PowOptions
-               ? static_cast<const PowOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_PowOptions
+               ? static_cast<const circle::PowOptions *>(builtin_options())
                : nullptr;
   }
-  const ArgMinOptions *builtin_options_as_ArgMinOptions() const
+  const circle::ArgMinOptions *builtin_options_as_ArgMinOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_ArgMinOptions
-               ? static_cast<const ArgMinOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_ArgMinOptions
+               ? static_cast<const circle::ArgMinOptions *>(builtin_options())
                : nullptr;
   }
-  const FakeQuantOptions *builtin_options_as_FakeQuantOptions() const
+  const circle::FakeQuantOptions *builtin_options_as_FakeQuantOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_FakeQuantOptions
-               ? static_cast<const FakeQuantOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_FakeQuantOptions
+               ? static_cast<const circle::FakeQuantOptions *>(builtin_options())
                : nullptr;
   }
-  const PackOptions *builtin_options_as_PackOptions() const
+  const circle::PackOptions *builtin_options_as_PackOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_PackOptions
-               ? static_cast<const PackOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_PackOptions
+               ? static_cast<const circle::PackOptions *>(builtin_options())
                : nullptr;
   }
-  const LogicalOrOptions *builtin_options_as_LogicalOrOptions() const
+  const circle::LogicalOrOptions *builtin_options_as_LogicalOrOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_LogicalOrOptions
-               ? static_cast<const LogicalOrOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_LogicalOrOptions
+               ? static_cast<const circle::LogicalOrOptions *>(builtin_options())
                : nullptr;
   }
-  const OneHotOptions *builtin_options_as_OneHotOptions() const
+  const circle::OneHotOptions *builtin_options_as_OneHotOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_OneHotOptions
-               ? static_cast<const OneHotOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_OneHotOptions
+               ? static_cast<const circle::OneHotOptions *>(builtin_options())
                : nullptr;
   }
-  const LogicalAndOptions *builtin_options_as_LogicalAndOptions() const
+  const circle::LogicalAndOptions *builtin_options_as_LogicalAndOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_LogicalAndOptions
-               ? static_cast<const LogicalAndOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_LogicalAndOptions
+               ? static_cast<const circle::LogicalAndOptions *>(builtin_options())
                : nullptr;
   }
-  const LogicalNotOptions *builtin_options_as_LogicalNotOptions() const
+  const circle::LogicalNotOptions *builtin_options_as_LogicalNotOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_LogicalNotOptions
-               ? static_cast<const LogicalNotOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_LogicalNotOptions
+               ? static_cast<const circle::LogicalNotOptions *>(builtin_options())
                : nullptr;
   }
-  const UnpackOptions *builtin_options_as_UnpackOptions() const
+  const circle::UnpackOptions *builtin_options_as_UnpackOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_UnpackOptions
-               ? static_cast<const UnpackOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_UnpackOptions
+               ? static_cast<const circle::UnpackOptions *>(builtin_options())
                : nullptr;
   }
-  const FloorDivOptions *builtin_options_as_FloorDivOptions() const
+  const circle::FloorDivOptions *builtin_options_as_FloorDivOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_FloorDivOptions
-               ? static_cast<const FloorDivOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_FloorDivOptions
+               ? static_cast<const circle::FloorDivOptions *>(builtin_options())
                : nullptr;
   }
-  const SquareOptions *builtin_options_as_SquareOptions() const
+  const circle::SquareOptions *builtin_options_as_SquareOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_SquareOptions
-               ? static_cast<const SquareOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_SquareOptions
+               ? static_cast<const circle::SquareOptions *>(builtin_options())
                : nullptr;
   }
-  const ZerosLikeOptions *builtin_options_as_ZerosLikeOptions() const
+  const circle::ZerosLikeOptions *builtin_options_as_ZerosLikeOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_ZerosLikeOptions
-               ? static_cast<const ZerosLikeOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_ZerosLikeOptions
+               ? static_cast<const circle::ZerosLikeOptions *>(builtin_options())
                : nullptr;
   }
-  const FillOptions *builtin_options_as_FillOptions() const
+  const circle::FillOptions *builtin_options_as_FillOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_FillOptions
-               ? static_cast<const FillOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_FillOptions
+               ? static_cast<const circle::FillOptions *>(builtin_options())
                : nullptr;
   }
-  const BidirectionalSequenceLSTMOptions *
+  const circle::BidirectionalSequenceLSTMOptions *
   builtin_options_as_BidirectionalSequenceLSTMOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_BidirectionalSequenceLSTMOptions
-               ? static_cast<const BidirectionalSequenceLSTMOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_BidirectionalSequenceLSTMOptions
+               ? static_cast<const circle::BidirectionalSequenceLSTMOptions *>(builtin_options())
                : nullptr;
   }
-  const BidirectionalSequenceRNNOptions *builtin_options_as_BidirectionalSequenceRNNOptions() const
+  const circle::BidirectionalSequenceRNNOptions *
+  builtin_options_as_BidirectionalSequenceRNNOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_BidirectionalSequenceRNNOptions
-               ? static_cast<const BidirectionalSequenceRNNOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_BidirectionalSequenceRNNOptions
+               ? static_cast<const circle::BidirectionalSequenceRNNOptions *>(builtin_options())
                : nullptr;
   }
-  const UnidirectionalSequenceLSTMOptions *
+  const circle::UnidirectionalSequenceLSTMOptions *
   builtin_options_as_UnidirectionalSequenceLSTMOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_UnidirectionalSequenceLSTMOptions
-               ? static_cast<const UnidirectionalSequenceLSTMOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_UnidirectionalSequenceLSTMOptions
+               ? static_cast<const circle::UnidirectionalSequenceLSTMOptions *>(builtin_options())
                : nullptr;
   }
-  const FloorModOptions *builtin_options_as_FloorModOptions() const
+  const circle::FloorModOptions *builtin_options_as_FloorModOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_FloorModOptions
-               ? static_cast<const FloorModOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_FloorModOptions
+               ? static_cast<const circle::FloorModOptions *>(builtin_options())
                : nullptr;
   }
-  const RangeOptions *builtin_options_as_RangeOptions() const
+  const circle::RangeOptions *builtin_options_as_RangeOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_RangeOptions
-               ? static_cast<const RangeOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_RangeOptions
+               ? static_cast<const circle::RangeOptions *>(builtin_options())
                : nullptr;
   }
-  const ResizeNearestNeighborOptions *builtin_options_as_ResizeNearestNeighborOptions() const
+  const circle::ResizeNearestNeighborOptions *
+  builtin_options_as_ResizeNearestNeighborOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_ResizeNearestNeighborOptions
-               ? static_cast<const ResizeNearestNeighborOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_ResizeNearestNeighborOptions
+               ? static_cast<const circle::ResizeNearestNeighborOptions *>(builtin_options())
                : nullptr;
   }
-  const LeakyReluOptions *builtin_options_as_LeakyReluOptions() const
+  const circle::LeakyReluOptions *builtin_options_as_LeakyReluOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_LeakyReluOptions
-               ? static_cast<const LeakyReluOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_LeakyReluOptions
+               ? static_cast<const circle::LeakyReluOptions *>(builtin_options())
                : nullptr;
   }
-  const SquaredDifferenceOptions *builtin_options_as_SquaredDifferenceOptions() const
+  const circle::SquaredDifferenceOptions *builtin_options_as_SquaredDifferenceOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_SquaredDifferenceOptions
-               ? static_cast<const SquaredDifferenceOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_SquaredDifferenceOptions
+               ? static_cast<const circle::SquaredDifferenceOptions *>(builtin_options())
                : nullptr;
   }
-  const MirrorPadOptions *builtin_options_as_MirrorPadOptions() const
+  const circle::MirrorPadOptions *builtin_options_as_MirrorPadOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_MirrorPadOptions
-               ? static_cast<const MirrorPadOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_MirrorPadOptions
+               ? static_cast<const circle::MirrorPadOptions *>(builtin_options())
                : nullptr;
   }
-  const AbsOptions *builtin_options_as_AbsOptions() const
+  const circle::AbsOptions *builtin_options_as_AbsOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_AbsOptions
-               ? static_cast<const AbsOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_AbsOptions
+               ? static_cast<const circle::AbsOptions *>(builtin_options())
                : nullptr;
   }
-  const SplitVOptions *builtin_options_as_SplitVOptions() const
+  const circle::SplitVOptions *builtin_options_as_SplitVOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_SplitVOptions
-               ? static_cast<const SplitVOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_SplitVOptions
+               ? static_cast<const circle::SplitVOptions *>(builtin_options())
                : nullptr;
   }
-  const UniqueOptions *builtin_options_as_UniqueOptions() const
+  const circle::UniqueOptions *builtin_options_as_UniqueOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_UniqueOptions
-               ? static_cast<const UniqueOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_UniqueOptions
+               ? static_cast<const circle::UniqueOptions *>(builtin_options())
                : nullptr;
   }
-  const ReverseV2Options *builtin_options_as_ReverseV2Options() const
+  const circle::ReverseV2Options *builtin_options_as_ReverseV2Options() const
   {
-    return builtin_options_type() == BuiltinOptions_ReverseV2Options
-               ? static_cast<const ReverseV2Options *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_ReverseV2Options
+               ? static_cast<const circle::ReverseV2Options *>(builtin_options())
                : nullptr;
   }
-  const AddNOptions *builtin_options_as_AddNOptions() const
+  const circle::AddNOptions *builtin_options_as_AddNOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_AddNOptions
-               ? static_cast<const AddNOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_AddNOptions
+               ? static_cast<const circle::AddNOptions *>(builtin_options())
                : nullptr;
   }
-  const GatherNdOptions *builtin_options_as_GatherNdOptions() const
+  const circle::GatherNdOptions *builtin_options_as_GatherNdOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_GatherNdOptions
-               ? static_cast<const GatherNdOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_GatherNdOptions
+               ? static_cast<const circle::GatherNdOptions *>(builtin_options())
                : nullptr;
   }
-  const CosOptions *builtin_options_as_CosOptions() const
+  const circle::CosOptions *builtin_options_as_CosOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_CosOptions
-               ? static_cast<const CosOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_CosOptions
+               ? static_cast<const circle::CosOptions *>(builtin_options())
                : nullptr;
   }
-  const WhereOptions *builtin_options_as_WhereOptions() const
+  const circle::WhereOptions *builtin_options_as_WhereOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_WhereOptions
-               ? static_cast<const WhereOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_WhereOptions
+               ? static_cast<const circle::WhereOptions *>(builtin_options())
                : nullptr;
   }
-  const RankOptions *builtin_options_as_RankOptions() const
+  const circle::RankOptions *builtin_options_as_RankOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_RankOptions
-               ? static_cast<const RankOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_RankOptions
+               ? static_cast<const circle::RankOptions *>(builtin_options())
                : nullptr;
   }
-  const ReverseSequenceOptions *builtin_options_as_ReverseSequenceOptions() const
+  const circle::ReverseSequenceOptions *builtin_options_as_ReverseSequenceOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_ReverseSequenceOptions
-               ? static_cast<const ReverseSequenceOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_ReverseSequenceOptions
+               ? static_cast<const circle::ReverseSequenceOptions *>(builtin_options())
                : nullptr;
   }
-  const MatrixDiagOptions *builtin_options_as_MatrixDiagOptions() const
+  const circle::MatrixDiagOptions *builtin_options_as_MatrixDiagOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_MatrixDiagOptions
-               ? static_cast<const MatrixDiagOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_MatrixDiagOptions
+               ? static_cast<const circle::MatrixDiagOptions *>(builtin_options())
                : nullptr;
   }
-  const QuantizeOptions *builtin_options_as_QuantizeOptions() const
+  const circle::QuantizeOptions *builtin_options_as_QuantizeOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_QuantizeOptions
-               ? static_cast<const QuantizeOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_QuantizeOptions
+               ? static_cast<const circle::QuantizeOptions *>(builtin_options())
                : nullptr;
   }
-  const MatrixSetDiagOptions *builtin_options_as_MatrixSetDiagOptions() const
+  const circle::MatrixSetDiagOptions *builtin_options_as_MatrixSetDiagOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_MatrixSetDiagOptions
-               ? static_cast<const MatrixSetDiagOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_MatrixSetDiagOptions
+               ? static_cast<const circle::MatrixSetDiagOptions *>(builtin_options())
                : nullptr;
   }
-  const HardSwishOptions *builtin_options_as_HardSwishOptions() const
+  const circle::HardSwishOptions *builtin_options_as_HardSwishOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_HardSwishOptions
-               ? static_cast<const HardSwishOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_HardSwishOptions
+               ? static_cast<const circle::HardSwishOptions *>(builtin_options())
                : nullptr;
   }
-  const IfOptions *builtin_options_as_IfOptions() const
+  const circle::IfOptions *builtin_options_as_IfOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_IfOptions
-               ? static_cast<const IfOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_IfOptions
+               ? static_cast<const circle::IfOptions *>(builtin_options())
                : nullptr;
   }
-  const WhileOptions *builtin_options_as_WhileOptions() const
+  const circle::WhileOptions *builtin_options_as_WhileOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_WhileOptions
-               ? static_cast<const WhileOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_WhileOptions
+               ? static_cast<const circle::WhileOptions *>(builtin_options())
                : nullptr;
   }
-  const DepthToSpaceOptions *builtin_options_as_DepthToSpaceOptions() const
+  const circle::DepthToSpaceOptions *builtin_options_as_DepthToSpaceOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_DepthToSpaceOptions
-               ? static_cast<const DepthToSpaceOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_DepthToSpaceOptions
+               ? static_cast<const circle::DepthToSpaceOptions *>(builtin_options())
                : nullptr;
   }
-  const NonMaxSuppressionV4Options *builtin_options_as_NonMaxSuppressionV4Options() const
+  const circle::NonMaxSuppressionV4Options *builtin_options_as_NonMaxSuppressionV4Options() const
   {
-    return builtin_options_type() == BuiltinOptions_NonMaxSuppressionV4Options
-               ? static_cast<const NonMaxSuppressionV4Options *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_NonMaxSuppressionV4Options
+               ? static_cast<const circle::NonMaxSuppressionV4Options *>(builtin_options())
                : nullptr;
   }
-  const NonMaxSuppressionV5Options *builtin_options_as_NonMaxSuppressionV5Options() const
+  const circle::NonMaxSuppressionV5Options *builtin_options_as_NonMaxSuppressionV5Options() const
   {
-    return builtin_options_type() == BuiltinOptions_NonMaxSuppressionV5Options
-               ? static_cast<const NonMaxSuppressionV5Options *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_NonMaxSuppressionV5Options
+               ? static_cast<const circle::NonMaxSuppressionV5Options *>(builtin_options())
                : nullptr;
   }
-  const ScatterNdOptions *builtin_options_as_ScatterNdOptions() const
+  const circle::ScatterNdOptions *builtin_options_as_ScatterNdOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_ScatterNdOptions
-               ? static_cast<const ScatterNdOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_ScatterNdOptions
+               ? static_cast<const circle::ScatterNdOptions *>(builtin_options())
                : nullptr;
   }
-  const SelectV2Options *builtin_options_as_SelectV2Options() const
+  const circle::SelectV2Options *builtin_options_as_SelectV2Options() const
   {
-    return builtin_options_type() == BuiltinOptions_SelectV2Options
-               ? static_cast<const SelectV2Options *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_SelectV2Options
+               ? static_cast<const circle::SelectV2Options *>(builtin_options())
                : nullptr;
   }
-  const DensifyOptions *builtin_options_as_DensifyOptions() const
+  const circle::DensifyOptions *builtin_options_as_DensifyOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_DensifyOptions
-               ? static_cast<const DensifyOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_DensifyOptions
+               ? static_cast<const circle::DensifyOptions *>(builtin_options())
                : nullptr;
   }
-  const SegmentSumOptions *builtin_options_as_SegmentSumOptions() const
+  const circle::SegmentSumOptions *builtin_options_as_SegmentSumOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_SegmentSumOptions
-               ? static_cast<const SegmentSumOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_SegmentSumOptions
+               ? static_cast<const circle::SegmentSumOptions *>(builtin_options())
                : nullptr;
   }
-  const BatchMatMulOptions *builtin_options_as_BatchMatMulOptions() const
+  const circle::BatchMatMulOptions *builtin_options_as_BatchMatMulOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_BatchMatMulOptions
-               ? static_cast<const BatchMatMulOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_BatchMatMulOptions
+               ? static_cast<const circle::BatchMatMulOptions *>(builtin_options())
                : nullptr;
   }
-  const BCQGatherOptions *builtin_options_as_BCQGatherOptions() const
+  const circle::BCQGatherOptions *builtin_options_as_BCQGatherOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_BCQGatherOptions
-               ? static_cast<const BCQGatherOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_BCQGatherOptions
+               ? static_cast<const circle::BCQGatherOptions *>(builtin_options())
                : nullptr;
   }
-  const BCQFullyConnectedOptions *builtin_options_as_BCQFullyConnectedOptions() const
+  const circle::BCQFullyConnectedOptions *builtin_options_as_BCQFullyConnectedOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_BCQFullyConnectedOptions
-               ? static_cast<const BCQFullyConnectedOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_BCQFullyConnectedOptions
+               ? static_cast<const circle::BCQFullyConnectedOptions *>(builtin_options())
                : nullptr;
   }
-  const InstanceNormOptions *builtin_options_as_InstanceNormOptions() const
+  const circle::InstanceNormOptions *builtin_options_as_InstanceNormOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_InstanceNormOptions
-               ? static_cast<const InstanceNormOptions *>(builtin_options())
+    return builtin_options_type() == circle::BuiltinOptions_InstanceNormOptions
+               ? static_cast<const circle::InstanceNormOptions *>(builtin_options())
                : nullptr;
   }
   const flatbuffers::Vector<uint8_t> *custom_options() const
   {
     return GetPointer<const flatbuffers::Vector<uint8_t> *>(VT_CUSTOM_OPTIONS);
   }
-  CustomOptionsFormat custom_options_format() const
+  circle::CustomOptionsFormat custom_options_format() const
   {
-    return static_cast<CustomOptionsFormat>(GetField<int8_t>(VT_CUSTOM_OPTIONS_FORMAT, 0));
+    return static_cast<circle::CustomOptionsFormat>(GetField<int8_t>(VT_CUSTOM_OPTIONS_FORMAT, 0));
   }
   const flatbuffers::Vector<uint8_t> *mutating_variable_inputs() const
   {
@@ -8394,568 +8851,680 @@ struct Operator FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
   }
 };
 
-template <> inline const Conv2DOptions *Operator::builtin_options_as<Conv2DOptions>() const
+template <>
+inline const circle::Conv2DOptions *Operator::builtin_options_as<circle::Conv2DOptions>() const
 {
   return builtin_options_as_Conv2DOptions();
 }
 
 template <>
-inline const DepthwiseConv2DOptions *Operator::builtin_options_as<DepthwiseConv2DOptions>() const
+inline const circle::DepthwiseConv2DOptions *
+Operator::builtin_options_as<circle::DepthwiseConv2DOptions>() const
 {
   return builtin_options_as_DepthwiseConv2DOptions();
 }
 
 template <>
-inline const ConcatEmbeddingsOptions *Operator::builtin_options_as<ConcatEmbeddingsOptions>() const
+inline const circle::ConcatEmbeddingsOptions *
+Operator::builtin_options_as<circle::ConcatEmbeddingsOptions>() const
 {
   return builtin_options_as_ConcatEmbeddingsOptions();
 }
 
 template <>
-inline const LSHProjectionOptions *Operator::builtin_options_as<LSHProjectionOptions>() const
+inline const circle::LSHProjectionOptions *
+Operator::builtin_options_as<circle::LSHProjectionOptions>() const
 {
   return builtin_options_as_LSHProjectionOptions();
 }
 
-template <> inline const Pool2DOptions *Operator::builtin_options_as<Pool2DOptions>() const
+template <>
+inline const circle::Pool2DOptions *Operator::builtin_options_as<circle::Pool2DOptions>() const
 {
   return builtin_options_as_Pool2DOptions();
 }
 
-template <> inline const SVDFOptions *Operator::builtin_options_as<SVDFOptions>() const
+template <>
+inline const circle::SVDFOptions *Operator::builtin_options_as<circle::SVDFOptions>() const
 {
   return builtin_options_as_SVDFOptions();
 }
 
-template <> inline const RNNOptions *Operator::builtin_options_as<RNNOptions>() const
+template <>
+inline const circle::RNNOptions *Operator::builtin_options_as<circle::RNNOptions>() const
 {
   return builtin_options_as_RNNOptions();
 }
 
 template <>
-inline const FullyConnectedOptions *Operator::builtin_options_as<FullyConnectedOptions>() const
+inline const circle::FullyConnectedOptions *
+Operator::builtin_options_as<circle::FullyConnectedOptions>() const
 {
   return builtin_options_as_FullyConnectedOptions();
 }
 
-template <> inline const SoftmaxOptions *Operator::builtin_options_as<SoftmaxOptions>() const
+template <>
+inline const circle::SoftmaxOptions *Operator::builtin_options_as<circle::SoftmaxOptions>() const
 {
   return builtin_options_as_SoftmaxOptions();
 }
 
 template <>
-inline const ConcatenationOptions *Operator::builtin_options_as<ConcatenationOptions>() const
+inline const circle::ConcatenationOptions *
+Operator::builtin_options_as<circle::ConcatenationOptions>() const
 {
   return builtin_options_as_ConcatenationOptions();
 }
 
-template <> inline const AddOptions *Operator::builtin_options_as<AddOptions>() const
+template <>
+inline const circle::AddOptions *Operator::builtin_options_as<circle::AddOptions>() const
 {
   return builtin_options_as_AddOptions();
 }
 
-template <> inline const L2NormOptions *Operator::builtin_options_as<L2NormOptions>() const
+template <>
+inline const circle::L2NormOptions *Operator::builtin_options_as<circle::L2NormOptions>() const
 {
   return builtin_options_as_L2NormOptions();
 }
 
 template <>
-inline const LocalResponseNormalizationOptions *
-Operator::builtin_options_as<LocalResponseNormalizationOptions>() const
+inline const circle::LocalResponseNormalizationOptions *
+Operator::builtin_options_as<circle::LocalResponseNormalizationOptions>() const
 {
   return builtin_options_as_LocalResponseNormalizationOptions();
 }
 
-template <> inline const LSTMOptions *Operator::builtin_options_as<LSTMOptions>() const
+template <>
+inline const circle::LSTMOptions *Operator::builtin_options_as<circle::LSTMOptions>() const
 {
   return builtin_options_as_LSTMOptions();
 }
 
 template <>
-inline const ResizeBilinearOptions *Operator::builtin_options_as<ResizeBilinearOptions>() const
+inline const circle::ResizeBilinearOptions *
+Operator::builtin_options_as<circle::ResizeBilinearOptions>() const
 {
   return builtin_options_as_ResizeBilinearOptions();
 }
 
-template <> inline const CallOptions *Operator::builtin_options_as<CallOptions>() const
+template <>
+inline const circle::CallOptions *Operator::builtin_options_as<circle::CallOptions>() const
 {
   return builtin_options_as_CallOptions();
 }
 
-template <> inline const ReshapeOptions *Operator::builtin_options_as<ReshapeOptions>() const
+template <>
+inline const circle::ReshapeOptions *Operator::builtin_options_as<circle::ReshapeOptions>() const
 {
   return builtin_options_as_ReshapeOptions();
 }
 
-template <> inline const SkipGramOptions *Operator::builtin_options_as<SkipGramOptions>() const
+template <>
+inline const circle::SkipGramOptions *Operator::builtin_options_as<circle::SkipGramOptions>() const
 {
   return builtin_options_as_SkipGramOptions();
 }
 
 template <>
-inline const SpaceToDepthOptions *Operator::builtin_options_as<SpaceToDepthOptions>() const
+inline const circle::SpaceToDepthOptions *
+Operator::builtin_options_as<circle::SpaceToDepthOptions>() const
 {
   return builtin_options_as_SpaceToDepthOptions();
 }
 
 template <>
-inline const EmbeddingLookupSparseOptions *
-Operator::builtin_options_as<EmbeddingLookupSparseOptions>() const
+inline const circle::EmbeddingLookupSparseOptions *
+Operator::builtin_options_as<circle::EmbeddingLookupSparseOptions>() const
 {
   return builtin_options_as_EmbeddingLookupSparseOptions();
 }
 
-template <> inline const MulOptions *Operator::builtin_options_as<MulOptions>() const
+template <>
+inline const circle::MulOptions *Operator::builtin_options_as<circle::MulOptions>() const
 {
   return builtin_options_as_MulOptions();
 }
 
-template <> inline const PadOptions *Operator::builtin_options_as<PadOptions>() const
+template <>
+inline const circle::PadOptions *Operator::builtin_options_as<circle::PadOptions>() const
 {
   return builtin_options_as_PadOptions();
 }
 
-template <> inline const GatherOptions *Operator::builtin_options_as<GatherOptions>() const
+template <>
+inline const circle::GatherOptions *Operator::builtin_options_as<circle::GatherOptions>() const
 {
   return builtin_options_as_GatherOptions();
 }
 
 template <>
-inline const BatchToSpaceNDOptions *Operator::builtin_options_as<BatchToSpaceNDOptions>() const
+inline const circle::BatchToSpaceNDOptions *
+Operator::builtin_options_as<circle::BatchToSpaceNDOptions>() const
 {
   return builtin_options_as_BatchToSpaceNDOptions();
 }
 
 template <>
-inline const SpaceToBatchNDOptions *Operator::builtin_options_as<SpaceToBatchNDOptions>() const
+inline const circle::SpaceToBatchNDOptions *
+Operator::builtin_options_as<circle::SpaceToBatchNDOptions>() const
 {
   return builtin_options_as_SpaceToBatchNDOptions();
 }
 
-template <> inline const TransposeOptions *Operator::builtin_options_as<TransposeOptions>() const
+template <>
+inline const circle::TransposeOptions *
+Operator::builtin_options_as<circle::TransposeOptions>() const
 {
   return builtin_options_as_TransposeOptions();
 }
 
-template <> inline const ReducerOptions *Operator::builtin_options_as<ReducerOptions>() const
+template <>
+inline const circle::ReducerOptions *Operator::builtin_options_as<circle::ReducerOptions>() const
 {
   return builtin_options_as_ReducerOptions();
 }
 
-template <> inline const SubOptions *Operator::builtin_options_as<SubOptions>() const
+template <>
+inline const circle::SubOptions *Operator::builtin_options_as<circle::SubOptions>() const
 {
   return builtin_options_as_SubOptions();
 }
 
-template <> inline const DivOptions *Operator::builtin_options_as<DivOptions>() const
+template <>
+inline const circle::DivOptions *Operator::builtin_options_as<circle::DivOptions>() const
 {
   return builtin_options_as_DivOptions();
 }
 
-template <> inline const SqueezeOptions *Operator::builtin_options_as<SqueezeOptions>() const
+template <>
+inline const circle::SqueezeOptions *Operator::builtin_options_as<circle::SqueezeOptions>() const
 {
   return builtin_options_as_SqueezeOptions();
 }
 
 template <>
-inline const SequenceRNNOptions *Operator::builtin_options_as<SequenceRNNOptions>() const
+inline const circle::SequenceRNNOptions *
+Operator::builtin_options_as<circle::SequenceRNNOptions>() const
 {
   return builtin_options_as_SequenceRNNOptions();
 }
 
 template <>
-inline const StridedSliceOptions *Operator::builtin_options_as<StridedSliceOptions>() const
+inline const circle::StridedSliceOptions *
+Operator::builtin_options_as<circle::StridedSliceOptions>() const
 {
   return builtin_options_as_StridedSliceOptions();
 }
 
-template <> inline const ExpOptions *Operator::builtin_options_as<ExpOptions>() const
+template <>
+inline const circle::ExpOptions *Operator::builtin_options_as<circle::ExpOptions>() const
 {
   return builtin_options_as_ExpOptions();
 }
 
-template <> inline const TopKV2Options *Operator::builtin_options_as<TopKV2Options>() const
+template <>
+inline const circle::TopKV2Options *Operator::builtin_options_as<circle::TopKV2Options>() const
 {
   return builtin_options_as_TopKV2Options();
 }
 
-template <> inline const SplitOptions *Operator::builtin_options_as<SplitOptions>() const
+template <>
+inline const circle::SplitOptions *Operator::builtin_options_as<circle::SplitOptions>() const
 {
   return builtin_options_as_SplitOptions();
 }
 
-template <> inline const LogSoftmaxOptions *Operator::builtin_options_as<LogSoftmaxOptions>() const
+template <>
+inline const circle::LogSoftmaxOptions *
+Operator::builtin_options_as<circle::LogSoftmaxOptions>() const
 {
   return builtin_options_as_LogSoftmaxOptions();
 }
 
-template <> inline const CastOptions *Operator::builtin_options_as<CastOptions>() const
+template <>
+inline const circle::CastOptions *Operator::builtin_options_as<circle::CastOptions>() const
 {
   return builtin_options_as_CastOptions();
 }
 
-template <> inline const DequantizeOptions *Operator::builtin_options_as<DequantizeOptions>() const
+template <>
+inline const circle::DequantizeOptions *
+Operator::builtin_options_as<circle::DequantizeOptions>() const
 {
   return builtin_options_as_DequantizeOptions();
 }
 
 template <>
-inline const MaximumMinimumOptions *Operator::builtin_options_as<MaximumMinimumOptions>() const
+inline const circle::MaximumMinimumOptions *
+Operator::builtin_options_as<circle::MaximumMinimumOptions>() const
 {
   return builtin_options_as_MaximumMinimumOptions();
 }
 
-template <> inline const ArgMaxOptions *Operator::builtin_options_as<ArgMaxOptions>() const
+template <>
+inline const circle::ArgMaxOptions *Operator::builtin_options_as<circle::ArgMaxOptions>() const
 {
   return builtin_options_as_ArgMaxOptions();
 }
 
-template <> inline const LessOptions *Operator::builtin_options_as<LessOptions>() const
+template <>
+inline const circle::LessOptions *Operator::builtin_options_as<circle::LessOptions>() const
 {
   return builtin_options_as_LessOptions();
 }
 
-template <> inline const NegOptions *Operator::builtin_options_as<NegOptions>() const
+template <>
+inline const circle::NegOptions *Operator::builtin_options_as<circle::NegOptions>() const
 {
   return builtin_options_as_NegOptions();
 }
 
-template <> inline const PadV2Options *Operator::builtin_options_as<PadV2Options>() const
+template <>
+inline const circle::PadV2Options *Operator::builtin_options_as<circle::PadV2Options>() const
 {
   return builtin_options_as_PadV2Options();
 }
 
-template <> inline const GreaterOptions *Operator::builtin_options_as<GreaterOptions>() const
+template <>
+inline const circle::GreaterOptions *Operator::builtin_options_as<circle::GreaterOptions>() const
 {
   return builtin_options_as_GreaterOptions();
 }
 
 template <>
-inline const GreaterEqualOptions *Operator::builtin_options_as<GreaterEqualOptions>() const
+inline const circle::GreaterEqualOptions *
+Operator::builtin_options_as<circle::GreaterEqualOptions>() const
 {
   return builtin_options_as_GreaterEqualOptions();
 }
 
-template <> inline const LessEqualOptions *Operator::builtin_options_as<LessEqualOptions>() const
+template <>
+inline const circle::LessEqualOptions *
+Operator::builtin_options_as<circle::LessEqualOptions>() const
 {
   return builtin_options_as_LessEqualOptions();
 }
 
-template <> inline const SelectOptions *Operator::builtin_options_as<SelectOptions>() const
+template <>
+inline const circle::SelectOptions *Operator::builtin_options_as<circle::SelectOptions>() const
 {
   return builtin_options_as_SelectOptions();
 }
 
-template <> inline const SliceOptions *Operator::builtin_options_as<SliceOptions>() const
+template <>
+inline const circle::SliceOptions *Operator::builtin_options_as<circle::SliceOptions>() const
 {
   return builtin_options_as_SliceOptions();
 }
 
 template <>
-inline const TransposeConvOptions *Operator::builtin_options_as<TransposeConvOptions>() const
+inline const circle::TransposeConvOptions *
+Operator::builtin_options_as<circle::TransposeConvOptions>() const
 {
   return builtin_options_as_TransposeConvOptions();
 }
 
 template <>
-inline const SparseToDenseOptions *Operator::builtin_options_as<SparseToDenseOptions>() const
+inline const circle::SparseToDenseOptions *
+Operator::builtin_options_as<circle::SparseToDenseOptions>() const
 {
   return builtin_options_as_SparseToDenseOptions();
 }
 
-template <> inline const TileOptions *Operator::builtin_options_as<TileOptions>() const
+template <>
+inline const circle::TileOptions *Operator::builtin_options_as<circle::TileOptions>() const
 {
   return builtin_options_as_TileOptions();
 }
 
-template <> inline const ExpandDimsOptions *Operator::builtin_options_as<ExpandDimsOptions>() const
+template <>
+inline const circle::ExpandDimsOptions *
+Operator::builtin_options_as<circle::ExpandDimsOptions>() const
 {
   return builtin_options_as_ExpandDimsOptions();
 }
 
-template <> inline const EqualOptions *Operator::builtin_options_as<EqualOptions>() const
+template <>
+inline const circle::EqualOptions *Operator::builtin_options_as<circle::EqualOptions>() const
 {
   return builtin_options_as_EqualOptions();
 }
 
-template <> inline const NotEqualOptions *Operator::builtin_options_as<NotEqualOptions>() const
+template <>
+inline const circle::NotEqualOptions *Operator::builtin_options_as<circle::NotEqualOptions>() const
 {
   return builtin_options_as_NotEqualOptions();
 }
 
-template <> inline const ShapeOptions *Operator::builtin_options_as<ShapeOptions>() const
+template <>
+inline const circle::ShapeOptions *Operator::builtin_options_as<circle::ShapeOptions>() const
 {
   return builtin_options_as_ShapeOptions();
 }
 
-template <> inline const PowOptions *Operator::builtin_options_as<PowOptions>() const
+template <>
+inline const circle::PowOptions *Operator::builtin_options_as<circle::PowOptions>() const
 {
   return builtin_options_as_PowOptions();
 }
 
-template <> inline const ArgMinOptions *Operator::builtin_options_as<ArgMinOptions>() const
+template <>
+inline const circle::ArgMinOptions *Operator::builtin_options_as<circle::ArgMinOptions>() const
 {
   return builtin_options_as_ArgMinOptions();
 }
 
-template <> inline const FakeQuantOptions *Operator::builtin_options_as<FakeQuantOptions>() const
+template <>
+inline const circle::FakeQuantOptions *
+Operator::builtin_options_as<circle::FakeQuantOptions>() const
 {
   return builtin_options_as_FakeQuantOptions();
 }
 
-template <> inline const PackOptions *Operator::builtin_options_as<PackOptions>() const
+template <>
+inline const circle::PackOptions *Operator::builtin_options_as<circle::PackOptions>() const
 {
   return builtin_options_as_PackOptions();
 }
 
-template <> inline const LogicalOrOptions *Operator::builtin_options_as<LogicalOrOptions>() const
+template <>
+inline const circle::LogicalOrOptions *
+Operator::builtin_options_as<circle::LogicalOrOptions>() const
 {
   return builtin_options_as_LogicalOrOptions();
 }
 
-template <> inline const OneHotOptions *Operator::builtin_options_as<OneHotOptions>() const
+template <>
+inline const circle::OneHotOptions *Operator::builtin_options_as<circle::OneHotOptions>() const
 {
   return builtin_options_as_OneHotOptions();
 }
 
-template <> inline const LogicalAndOptions *Operator::builtin_options_as<LogicalAndOptions>() const
+template <>
+inline const circle::LogicalAndOptions *
+Operator::builtin_options_as<circle::LogicalAndOptions>() const
 {
   return builtin_options_as_LogicalAndOptions();
 }
 
-template <> inline const LogicalNotOptions *Operator::builtin_options_as<LogicalNotOptions>() const
+template <>
+inline const circle::LogicalNotOptions *
+Operator::builtin_options_as<circle::LogicalNotOptions>() const
 {
   return builtin_options_as_LogicalNotOptions();
 }
 
-template <> inline const UnpackOptions *Operator::builtin_options_as<UnpackOptions>() const
+template <>
+inline const circle::UnpackOptions *Operator::builtin_options_as<circle::UnpackOptions>() const
 {
   return builtin_options_as_UnpackOptions();
 }
 
-template <> inline const FloorDivOptions *Operator::builtin_options_as<FloorDivOptions>() const
+template <>
+inline const circle::FloorDivOptions *Operator::builtin_options_as<circle::FloorDivOptions>() const
 {
   return builtin_options_as_FloorDivOptions();
 }
 
-template <> inline const SquareOptions *Operator::builtin_options_as<SquareOptions>() const
+template <>
+inline const circle::SquareOptions *Operator::builtin_options_as<circle::SquareOptions>() const
 {
   return builtin_options_as_SquareOptions();
 }
 
-template <> inline const ZerosLikeOptions *Operator::builtin_options_as<ZerosLikeOptions>() const
+template <>
+inline const circle::ZerosLikeOptions *
+Operator::builtin_options_as<circle::ZerosLikeOptions>() const
 {
   return builtin_options_as_ZerosLikeOptions();
 }
 
-template <> inline const FillOptions *Operator::builtin_options_as<FillOptions>() const
+template <>
+inline const circle::FillOptions *Operator::builtin_options_as<circle::FillOptions>() const
 {
   return builtin_options_as_FillOptions();
 }
 
 template <>
-inline const BidirectionalSequenceLSTMOptions *
-Operator::builtin_options_as<BidirectionalSequenceLSTMOptions>() const
+inline const circle::BidirectionalSequenceLSTMOptions *
+Operator::builtin_options_as<circle::BidirectionalSequenceLSTMOptions>() const
 {
   return builtin_options_as_BidirectionalSequenceLSTMOptions();
 }
 
 template <>
-inline const BidirectionalSequenceRNNOptions *
-Operator::builtin_options_as<BidirectionalSequenceRNNOptions>() const
+inline const circle::BidirectionalSequenceRNNOptions *
+Operator::builtin_options_as<circle::BidirectionalSequenceRNNOptions>() const
 {
   return builtin_options_as_BidirectionalSequenceRNNOptions();
 }
 
 template <>
-inline const UnidirectionalSequenceLSTMOptions *
-Operator::builtin_options_as<UnidirectionalSequenceLSTMOptions>() const
+inline const circle::UnidirectionalSequenceLSTMOptions *
+Operator::builtin_options_as<circle::UnidirectionalSequenceLSTMOptions>() const
 {
   return builtin_options_as_UnidirectionalSequenceLSTMOptions();
 }
 
-template <> inline const FloorModOptions *Operator::builtin_options_as<FloorModOptions>() const
+template <>
+inline const circle::FloorModOptions *Operator::builtin_options_as<circle::FloorModOptions>() const
 {
   return builtin_options_as_FloorModOptions();
 }
 
-template <> inline const RangeOptions *Operator::builtin_options_as<RangeOptions>() const
+template <>
+inline const circle::RangeOptions *Operator::builtin_options_as<circle::RangeOptions>() const
 {
   return builtin_options_as_RangeOptions();
 }
 
 template <>
-inline const ResizeNearestNeighborOptions *
-Operator::builtin_options_as<ResizeNearestNeighborOptions>() const
+inline const circle::ResizeNearestNeighborOptions *
+Operator::builtin_options_as<circle::ResizeNearestNeighborOptions>() const
 {
   return builtin_options_as_ResizeNearestNeighborOptions();
 }
 
-template <> inline const LeakyReluOptions *Operator::builtin_options_as<LeakyReluOptions>() const
+template <>
+inline const circle::LeakyReluOptions *
+Operator::builtin_options_as<circle::LeakyReluOptions>() const
 {
   return builtin_options_as_LeakyReluOptions();
 }
 
 template <>
-inline const SquaredDifferenceOptions *
-Operator::builtin_options_as<SquaredDifferenceOptions>() const
+inline const circle::SquaredDifferenceOptions *
+Operator::builtin_options_as<circle::SquaredDifferenceOptions>() const
 {
   return builtin_options_as_SquaredDifferenceOptions();
 }
 
-template <> inline const MirrorPadOptions *Operator::builtin_options_as<MirrorPadOptions>() const
+template <>
+inline const circle::MirrorPadOptions *
+Operator::builtin_options_as<circle::MirrorPadOptions>() const
 {
   return builtin_options_as_MirrorPadOptions();
 }
 
-template <> inline const AbsOptions *Operator::builtin_options_as<AbsOptions>() const
+template <>
+inline const circle::AbsOptions *Operator::builtin_options_as<circle::AbsOptions>() const
 {
   return builtin_options_as_AbsOptions();
 }
 
-template <> inline const SplitVOptions *Operator::builtin_options_as<SplitVOptions>() const
+template <>
+inline const circle::SplitVOptions *Operator::builtin_options_as<circle::SplitVOptions>() const
 {
   return builtin_options_as_SplitVOptions();
 }
 
-template <> inline const UniqueOptions *Operator::builtin_options_as<UniqueOptions>() const
+template <>
+inline const circle::UniqueOptions *Operator::builtin_options_as<circle::UniqueOptions>() const
 {
   return builtin_options_as_UniqueOptions();
 }
 
-template <> inline const ReverseV2Options *Operator::builtin_options_as<ReverseV2Options>() const
+template <>
+inline const circle::ReverseV2Options *
+Operator::builtin_options_as<circle::ReverseV2Options>() const
 {
   return builtin_options_as_ReverseV2Options();
 }
 
-template <> inline const AddNOptions *Operator::builtin_options_as<AddNOptions>() const
+template <>
+inline const circle::AddNOptions *Operator::builtin_options_as<circle::AddNOptions>() const
 {
   return builtin_options_as_AddNOptions();
 }
 
-template <> inline const GatherNdOptions *Operator::builtin_options_as<GatherNdOptions>() const
+template <>
+inline const circle::GatherNdOptions *Operator::builtin_options_as<circle::GatherNdOptions>() const
 {
   return builtin_options_as_GatherNdOptions();
 }
 
-template <> inline const CosOptions *Operator::builtin_options_as<CosOptions>() const
+template <>
+inline const circle::CosOptions *Operator::builtin_options_as<circle::CosOptions>() const
 {
   return builtin_options_as_CosOptions();
 }
 
-template <> inline const WhereOptions *Operator::builtin_options_as<WhereOptions>() const
+template <>
+inline const circle::WhereOptions *Operator::builtin_options_as<circle::WhereOptions>() const
 {
   return builtin_options_as_WhereOptions();
 }
 
-template <> inline const RankOptions *Operator::builtin_options_as<RankOptions>() const
+template <>
+inline const circle::RankOptions *Operator::builtin_options_as<circle::RankOptions>() const
 {
   return builtin_options_as_RankOptions();
 }
 
 template <>
-inline const ReverseSequenceOptions *Operator::builtin_options_as<ReverseSequenceOptions>() const
+inline const circle::ReverseSequenceOptions *
+Operator::builtin_options_as<circle::ReverseSequenceOptions>() const
 {
   return builtin_options_as_ReverseSequenceOptions();
 }
 
-template <> inline const MatrixDiagOptions *Operator::builtin_options_as<MatrixDiagOptions>() const
+template <>
+inline const circle::MatrixDiagOptions *
+Operator::builtin_options_as<circle::MatrixDiagOptions>() const
 {
   return builtin_options_as_MatrixDiagOptions();
 }
 
-template <> inline const QuantizeOptions *Operator::builtin_options_as<QuantizeOptions>() const
+template <>
+inline const circle::QuantizeOptions *Operator::builtin_options_as<circle::QuantizeOptions>() const
 {
   return builtin_options_as_QuantizeOptions();
 }
 
 template <>
-inline const MatrixSetDiagOptions *Operator::builtin_options_as<MatrixSetDiagOptions>() const
+inline const circle::MatrixSetDiagOptions *
+Operator::builtin_options_as<circle::MatrixSetDiagOptions>() const
 {
   return builtin_options_as_MatrixSetDiagOptions();
 }
 
-template <> inline const HardSwishOptions *Operator::builtin_options_as<HardSwishOptions>() const
+template <>
+inline const circle::HardSwishOptions *
+Operator::builtin_options_as<circle::HardSwishOptions>() const
 {
   return builtin_options_as_HardSwishOptions();
 }
 
-template <> inline const IfOptions *Operator::builtin_options_as<IfOptions>() const
+template <> inline const circle::IfOptions *Operator::builtin_options_as<circle::IfOptions>() const
 {
   return builtin_options_as_IfOptions();
 }
 
-template <> inline const WhileOptions *Operator::builtin_options_as<WhileOptions>() const
+template <>
+inline const circle::WhileOptions *Operator::builtin_options_as<circle::WhileOptions>() const
 {
   return builtin_options_as_WhileOptions();
 }
 
 template <>
-inline const DepthToSpaceOptions *Operator::builtin_options_as<DepthToSpaceOptions>() const
+inline const circle::DepthToSpaceOptions *
+Operator::builtin_options_as<circle::DepthToSpaceOptions>() const
 {
   return builtin_options_as_DepthToSpaceOptions();
 }
 
 template <>
-inline const NonMaxSuppressionV4Options *
-Operator::builtin_options_as<NonMaxSuppressionV4Options>() const
+inline const circle::NonMaxSuppressionV4Options *
+Operator::builtin_options_as<circle::NonMaxSuppressionV4Options>() const
 {
   return builtin_options_as_NonMaxSuppressionV4Options();
 }
 
 template <>
-inline const NonMaxSuppressionV5Options *
-Operator::builtin_options_as<NonMaxSuppressionV5Options>() const
+inline const circle::NonMaxSuppressionV5Options *
+Operator::builtin_options_as<circle::NonMaxSuppressionV5Options>() const
 {
   return builtin_options_as_NonMaxSuppressionV5Options();
 }
 
-template <> inline const ScatterNdOptions *Operator::builtin_options_as<ScatterNdOptions>() const
+template <>
+inline const circle::ScatterNdOptions *
+Operator::builtin_options_as<circle::ScatterNdOptions>() const
 {
   return builtin_options_as_ScatterNdOptions();
 }
 
-template <> inline const SelectV2Options *Operator::builtin_options_as<SelectV2Options>() const
+template <>
+inline const circle::SelectV2Options *Operator::builtin_options_as<circle::SelectV2Options>() const
 {
   return builtin_options_as_SelectV2Options();
 }
 
-template <> inline const DensifyOptions *Operator::builtin_options_as<DensifyOptions>() const
+template <>
+inline const circle::DensifyOptions *Operator::builtin_options_as<circle::DensifyOptions>() const
 {
   return builtin_options_as_DensifyOptions();
 }
 
-template <> inline const SegmentSumOptions *Operator::builtin_options_as<SegmentSumOptions>() const
+template <>
+inline const circle::SegmentSumOptions *
+Operator::builtin_options_as<circle::SegmentSumOptions>() const
 {
   return builtin_options_as_SegmentSumOptions();
 }
 
 template <>
-inline const BatchMatMulOptions *Operator::builtin_options_as<BatchMatMulOptions>() const
+inline const circle::BatchMatMulOptions *
+Operator::builtin_options_as<circle::BatchMatMulOptions>() const
 {
   return builtin_options_as_BatchMatMulOptions();
 }
 
-template <> inline const BCQGatherOptions *Operator::builtin_options_as<BCQGatherOptions>() const
+template <>
+inline const circle::BCQGatherOptions *
+Operator::builtin_options_as<circle::BCQGatherOptions>() const
 {
   return builtin_options_as_BCQGatherOptions();
 }
 
 template <>
-inline const BCQFullyConnectedOptions *
-Operator::builtin_options_as<BCQFullyConnectedOptions>() const
+inline const circle::BCQFullyConnectedOptions *
+Operator::builtin_options_as<circle::BCQFullyConnectedOptions>() const
 {
   return builtin_options_as_BCQFullyConnectedOptions();
 }
 
 template <>
-inline const InstanceNormOptions *Operator::builtin_options_as<InstanceNormOptions>() const
+inline const circle::InstanceNormOptions *
+Operator::builtin_options_as<circle::InstanceNormOptions>() const
 {
   return builtin_options_as_InstanceNormOptions();
 }
 
 struct OperatorBuilder
 {
+  typedef Operator Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_opcode_index(uint32_t opcode_index)
@@ -8970,7 +9539,7 @@ struct OperatorBuilder
   {
     fbb_.AddOffset(Operator::VT_OUTPUTS, outputs);
   }
-  void add_builtin_options_type(BuiltinOptions builtin_options_type)
+  void add_builtin_options_type(circle::BuiltinOptions builtin_options_type)
   {
     fbb_.AddElement<uint8_t>(Operator::VT_BUILTIN_OPTIONS_TYPE,
                              static_cast<uint8_t>(builtin_options_type), 0);
@@ -8983,7 +9552,7 @@ struct OperatorBuilder
   {
     fbb_.AddOffset(Operator::VT_CUSTOM_OPTIONS, custom_options);
   }
-  void add_custom_options_format(CustomOptionsFormat custom_options_format)
+  void add_custom_options_format(circle::CustomOptionsFormat custom_options_format)
   {
     fbb_.AddElement<int8_t>(Operator::VT_CUSTOM_OPTIONS_FORMAT,
                             static_cast<int8_t>(custom_options_format), 0);
@@ -9010,16 +9579,16 @@ struct OperatorBuilder
   }
 };
 
-inline flatbuffers::Offset<Operator>
-CreateOperator(flatbuffers::FlatBufferBuilder &_fbb, uint32_t opcode_index = 0,
-               flatbuffers::Offset<flatbuffers::Vector<int32_t>> inputs = 0,
-               flatbuffers::Offset<flatbuffers::Vector<int32_t>> outputs = 0,
-               BuiltinOptions builtin_options_type = BuiltinOptions_NONE,
-               flatbuffers::Offset<void> builtin_options = 0,
-               flatbuffers::Offset<flatbuffers::Vector<uint8_t>> custom_options = 0,
-               CustomOptionsFormat custom_options_format = CustomOptionsFormat_FLEXBUFFERS,
-               flatbuffers::Offset<flatbuffers::Vector<uint8_t>> mutating_variable_inputs = 0,
-               flatbuffers::Offset<flatbuffers::Vector<int32_t>> intermediates = 0)
+inline flatbuffers::Offset<Operator> CreateOperator(
+    flatbuffers::FlatBufferBuilder &_fbb, uint32_t opcode_index = 0,
+    flatbuffers::Offset<flatbuffers::Vector<int32_t>> inputs = 0,
+    flatbuffers::Offset<flatbuffers::Vector<int32_t>> outputs = 0,
+    circle::BuiltinOptions builtin_options_type = circle::BuiltinOptions_NONE,
+    flatbuffers::Offset<void> builtin_options = 0,
+    flatbuffers::Offset<flatbuffers::Vector<uint8_t>> custom_options = 0,
+    circle::CustomOptionsFormat custom_options_format = circle::CustomOptionsFormat_FLEXBUFFERS,
+    flatbuffers::Offset<flatbuffers::Vector<uint8_t>> mutating_variable_inputs = 0,
+    flatbuffers::Offset<flatbuffers::Vector<int32_t>> intermediates = 0)
 {
   OperatorBuilder builder_(_fbb);
   builder_.add_intermediates(intermediates);
@@ -9034,28 +9603,31 @@ CreateOperator(flatbuffers::FlatBufferBuilder &_fbb, uint32_t opcode_index = 0,
   return builder_.Finish();
 }
 
-inline flatbuffers::Offset<Operator>
-CreateOperatorDirect(flatbuffers::FlatBufferBuilder &_fbb, uint32_t opcode_index = 0,
-                     const std::vector<int32_t> *inputs = nullptr,
-                     const std::vector<int32_t> *outputs = nullptr,
-                     BuiltinOptions builtin_options_type = BuiltinOptions_NONE,
-                     flatbuffers::Offset<void> builtin_options = 0,
-                     const std::vector<uint8_t> *custom_options = nullptr,
-                     CustomOptionsFormat custom_options_format = CustomOptionsFormat_FLEXBUFFERS,
-                     const std::vector<uint8_t> *mutating_variable_inputs = nullptr,
-                     const std::vector<int32_t> *intermediates = nullptr)
+inline flatbuffers::Offset<Operator> CreateOperatorDirect(
+    flatbuffers::FlatBufferBuilder &_fbb, uint32_t opcode_index = 0,
+    const std::vector<int32_t> *inputs = nullptr, const std::vector<int32_t> *outputs = nullptr,
+    circle::BuiltinOptions builtin_options_type = circle::BuiltinOptions_NONE,
+    flatbuffers::Offset<void> builtin_options = 0,
+    const std::vector<uint8_t> *custom_options = nullptr,
+    circle::CustomOptionsFormat custom_options_format = circle::CustomOptionsFormat_FLEXBUFFERS,
+    const std::vector<uint8_t> *mutating_variable_inputs = nullptr,
+    const std::vector<int32_t> *intermediates = nullptr)
 {
-  return circle::CreateOperator(
-      _fbb, opcode_index, inputs ? _fbb.CreateVector<int32_t>(*inputs) : 0,
-      outputs ? _fbb.CreateVector<int32_t>(*outputs) : 0, builtin_options_type, builtin_options,
-      custom_options ? _fbb.CreateVector<uint8_t>(*custom_options) : 0, custom_options_format,
-      mutating_variable_inputs ? _fbb.CreateVector<uint8_t>(*mutating_variable_inputs) : 0,
-      intermediates ? _fbb.CreateVector<int32_t>(*intermediates) : 0);
+  auto inputs__ = inputs ? _fbb.CreateVector<int32_t>(*inputs) : 0;
+  auto outputs__ = outputs ? _fbb.CreateVector<int32_t>(*outputs) : 0;
+  auto custom_options__ = custom_options ? _fbb.CreateVector<uint8_t>(*custom_options) : 0;
+  auto mutating_variable_inputs__ =
+      mutating_variable_inputs ? _fbb.CreateVector<uint8_t>(*mutating_variable_inputs) : 0;
+  auto intermediates__ = intermediates ? _fbb.CreateVector<int32_t>(*intermediates) : 0;
+  return circle::CreateOperator(_fbb, opcode_index, inputs__, outputs__, builtin_options_type,
+                                builtin_options, custom_options__, custom_options_format,
+                                mutating_variable_inputs__, intermediates__);
 }
 
 struct SubGraph FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef SubGraphBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_TENSORS = 4,
     VT_INPUTS = 6,
@@ -9064,9 +9636,9 @@ struct SubGraph FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
     VT_NAME = 12,
     VT_DATA_FORMAT = 14
   };
-  const flatbuffers::Vector<flatbuffers::Offset<Tensor>> *tensors() const
+  const flatbuffers::Vector<flatbuffers::Offset<circle::Tensor>> *tensors() const
   {
-    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<Tensor>> *>(VT_TENSORS);
+    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<circle::Tensor>> *>(VT_TENSORS);
   }
   const flatbuffers::Vector<int32_t> *inputs() const
   {
@@ -9076,17 +9648,18 @@ struct SubGraph FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
   {
     return GetPointer<const flatbuffers::Vector<int32_t> *>(VT_OUTPUTS);
   }
-  const flatbuffers::Vector<flatbuffers::Offset<Operator>> *operators() const
+  const flatbuffers::Vector<flatbuffers::Offset<circle::Operator>> *operators() const
   {
-    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<Operator>> *>(VT_OPERATORS);
+    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<circle::Operator>> *>(
+        VT_OPERATORS);
   }
   const flatbuffers::String *name() const
   {
     return GetPointer<const flatbuffers::String *>(VT_NAME);
   }
-  DataFormat data_format() const
+  circle::DataFormat data_format() const
   {
-    return static_cast<DataFormat>(GetField<int8_t>(VT_DATA_FORMAT, 0));
+    return static_cast<circle::DataFormat>(GetField<int8_t>(VT_DATA_FORMAT, 0));
   }
   bool Verify(flatbuffers::Verifier &verifier) const
   {
@@ -9103,9 +9676,11 @@ struct SubGraph FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct SubGraphBuilder
 {
+  typedef SubGraph Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_tensors(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<Tensor>>> tensors)
+  void
+  add_tensors(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<circle::Tensor>>> tensors)
   {
     fbb_.AddOffset(SubGraph::VT_TENSORS, tensors);
   }
@@ -9117,8 +9692,8 @@ struct SubGraphBuilder
   {
     fbb_.AddOffset(SubGraph::VT_OUTPUTS, outputs);
   }
-  void
-  add_operators(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<Operator>>> operators)
+  void add_operators(
+      flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<circle::Operator>>> operators)
   {
     fbb_.AddOffset(SubGraph::VT_OPERATORS, operators);
   }
@@ -9126,7 +9701,7 @@ struct SubGraphBuilder
   {
     fbb_.AddOffset(SubGraph::VT_NAME, name);
   }
-  void add_data_format(DataFormat data_format)
+  void add_data_format(circle::DataFormat data_format)
   {
     fbb_.AddElement<int8_t>(SubGraph::VT_DATA_FORMAT, static_cast<int8_t>(data_format), 0);
   }
@@ -9145,12 +9720,12 @@ struct SubGraphBuilder
 
 inline flatbuffers::Offset<SubGraph> CreateSubGraph(
     flatbuffers::FlatBufferBuilder &_fbb,
-    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<Tensor>>> tensors = 0,
+    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<circle::Tensor>>> tensors = 0,
     flatbuffers::Offset<flatbuffers::Vector<int32_t>> inputs = 0,
     flatbuffers::Offset<flatbuffers::Vector<int32_t>> outputs = 0,
-    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<Operator>>> operators = 0,
+    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<circle::Operator>>> operators = 0,
     flatbuffers::Offset<flatbuffers::String> name = 0,
-    DataFormat data_format = DataFormat_CHANNELS_LAST)
+    circle::DataFormat data_format = circle::DataFormat_CHANNELS_LAST)
 {
   SubGraphBuilder builder_(_fbb);
   builder_.add_name(name);
@@ -9162,25 +9737,27 @@ inline flatbuffers::Offset<SubGraph> CreateSubGraph(
   return builder_.Finish();
 }
 
-inline flatbuffers::Offset<SubGraph>
-CreateSubGraphDirect(flatbuffers::FlatBufferBuilder &_fbb,
-                     const std::vector<flatbuffers::Offset<Tensor>> *tensors = nullptr,
-                     const std::vector<int32_t> *inputs = nullptr,
-                     const std::vector<int32_t> *outputs = nullptr,
-                     const std::vector<flatbuffers::Offset<Operator>> *operators = nullptr,
-                     const char *name = nullptr, DataFormat data_format = DataFormat_CHANNELS_LAST)
+inline flatbuffers::Offset<SubGraph> CreateSubGraphDirect(
+    flatbuffers::FlatBufferBuilder &_fbb,
+    const std::vector<flatbuffers::Offset<circle::Tensor>> *tensors = nullptr,
+    const std::vector<int32_t> *inputs = nullptr, const std::vector<int32_t> *outputs = nullptr,
+    const std::vector<flatbuffers::Offset<circle::Operator>> *operators = nullptr,
+    const char *name = nullptr, circle::DataFormat data_format = circle::DataFormat_CHANNELS_LAST)
 {
-  return circle::CreateSubGraph(
-      _fbb, tensors ? _fbb.CreateVector<flatbuffers::Offset<Tensor>>(*tensors) : 0,
-      inputs ? _fbb.CreateVector<int32_t>(*inputs) : 0,
-      outputs ? _fbb.CreateVector<int32_t>(*outputs) : 0,
-      operators ? _fbb.CreateVector<flatbuffers::Offset<Operator>>(*operators) : 0,
-      name ? _fbb.CreateString(name) : 0, data_format);
+  auto tensors__ = tensors ? _fbb.CreateVector<flatbuffers::Offset<circle::Tensor>>(*tensors) : 0;
+  auto inputs__ = inputs ? _fbb.CreateVector<int32_t>(*inputs) : 0;
+  auto outputs__ = outputs ? _fbb.CreateVector<int32_t>(*outputs) : 0;
+  auto operators__ =
+      operators ? _fbb.CreateVector<flatbuffers::Offset<circle::Operator>>(*operators) : 0;
+  auto name__ = name ? _fbb.CreateString(name) : 0;
+  return circle::CreateSubGraph(_fbb, tensors__, inputs__, outputs__, operators__, name__,
+                                data_format);
 }
 
 struct Buffer FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef BufferBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_DATA = 4
   };
@@ -9197,6 +9774,7 @@ struct Buffer FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct BufferBuilder
 {
+  typedef Buffer Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_data(flatbuffers::Offset<flatbuffers::Vector<uint8_t>> data)
@@ -9228,12 +9806,18 @@ CreateBuffer(flatbuffers::FlatBufferBuilder &_fbb,
 inline flatbuffers::Offset<Buffer> CreateBufferDirect(flatbuffers::FlatBufferBuilder &_fbb,
                                                       const std::vector<uint8_t> *data = nullptr)
 {
-  return circle::CreateBuffer(_fbb, data ? _fbb.CreateVector<uint8_t>(*data) : 0);
+  if (data)
+  {
+    _fbb.ForceVectorAlignment(data->size(), sizeof(uint8_t), 16);
+  }
+  auto data__ = data ? _fbb.CreateVector<uint8_t>(*data) : 0;
+  return circle::CreateBuffer(_fbb, data__);
 }
 
 struct Metadata FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef MetadataBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_NAME = 4,
     VT_BUFFER = 6
@@ -9253,6 +9837,7 @@ struct Metadata FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct MetadataBuilder
 {
+  typedef Metadata Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_name(flatbuffers::Offset<flatbuffers::String> name)
@@ -9287,12 +9872,14 @@ inline flatbuffers::Offset<Metadata> CreateMetadataDirect(flatbuffers::FlatBuffe
                                                           const char *name = nullptr,
                                                           uint32_t buffer = 0)
 {
-  return circle::CreateMetadata(_fbb, name ? _fbb.CreateString(name) : 0, buffer);
+  auto name__ = name ? _fbb.CreateString(name) : 0;
+  return circle::CreateMetadata(_fbb, name__, buffer);
 }
 
 struct Model FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef ModelBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_VERSION = 4,
     VT_OPERATOR_CODES = 6,
@@ -9303,30 +9890,32 @@ struct Model FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
     VT_METADATA = 16
   };
   uint32_t version() const { return GetField<uint32_t>(VT_VERSION, 0); }
-  const flatbuffers::Vector<flatbuffers::Offset<OperatorCode>> *operator_codes() const
+  const flatbuffers::Vector<flatbuffers::Offset<circle::OperatorCode>> *operator_codes() const
   {
-    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<OperatorCode>> *>(
+    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<circle::OperatorCode>> *>(
         VT_OPERATOR_CODES);
   }
-  const flatbuffers::Vector<flatbuffers::Offset<SubGraph>> *subgraphs() const
+  const flatbuffers::Vector<flatbuffers::Offset<circle::SubGraph>> *subgraphs() const
   {
-    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<SubGraph>> *>(VT_SUBGRAPHS);
+    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<circle::SubGraph>> *>(
+        VT_SUBGRAPHS);
   }
   const flatbuffers::String *description() const
   {
     return GetPointer<const flatbuffers::String *>(VT_DESCRIPTION);
   }
-  const flatbuffers::Vector<flatbuffers::Offset<Buffer>> *buffers() const
+  const flatbuffers::Vector<flatbuffers::Offset<circle::Buffer>> *buffers() const
   {
-    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<Buffer>> *>(VT_BUFFERS);
+    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<circle::Buffer>> *>(VT_BUFFERS);
   }
   const flatbuffers::Vector<int32_t> *metadata_buffer() const
   {
     return GetPointer<const flatbuffers::Vector<int32_t> *>(VT_METADATA_BUFFER);
   }
-  const flatbuffers::Vector<flatbuffers::Offset<Metadata>> *metadata() const
+  const flatbuffers::Vector<flatbuffers::Offset<circle::Metadata>> *metadata() const
   {
-    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<Metadata>> *>(VT_METADATA);
+    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<circle::Metadata>> *>(
+        VT_METADATA);
   }
   bool Verify(flatbuffers::Verifier &verifier) const
   {
@@ -9345,16 +9934,18 @@ struct Model FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct ModelBuilder
 {
+  typedef Model Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_version(uint32_t version) { fbb_.AddElement<uint32_t>(Model::VT_VERSION, version, 0); }
   void add_operator_codes(
-      flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<OperatorCode>>> operator_codes)
+      flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<circle::OperatorCode>>>
+          operator_codes)
   {
     fbb_.AddOffset(Model::VT_OPERATOR_CODES, operator_codes);
   }
-  void
-  add_subgraphs(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<SubGraph>>> subgraphs)
+  void add_subgraphs(
+      flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<circle::SubGraph>>> subgraphs)
   {
     fbb_.AddOffset(Model::VT_SUBGRAPHS, subgraphs);
   }
@@ -9362,7 +9953,8 @@ struct ModelBuilder
   {
     fbb_.AddOffset(Model::VT_DESCRIPTION, description);
   }
-  void add_buffers(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<Buffer>>> buffers)
+  void
+  add_buffers(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<circle::Buffer>>> buffers)
   {
     fbb_.AddOffset(Model::VT_BUFFERS, buffers);
   }
@@ -9370,8 +9962,8 @@ struct ModelBuilder
   {
     fbb_.AddOffset(Model::VT_METADATA_BUFFER, metadata_buffer);
   }
-  void
-  add_metadata(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<Metadata>>> metadata)
+  void add_metadata(
+      flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<circle::Metadata>>> metadata)
   {
     fbb_.AddOffset(Model::VT_METADATA, metadata);
   }
@@ -9390,12 +9982,13 @@ struct ModelBuilder
 
 inline flatbuffers::Offset<Model> CreateModel(
     flatbuffers::FlatBufferBuilder &_fbb, uint32_t version = 0,
-    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<OperatorCode>>> operator_codes = 0,
-    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<SubGraph>>> subgraphs = 0,
+    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<circle::OperatorCode>>>
+        operator_codes = 0,
+    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<circle::SubGraph>>> subgraphs = 0,
     flatbuffers::Offset<flatbuffers::String> description = 0,
-    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<Buffer>>> buffers = 0,
+    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<circle::Buffer>>> buffers = 0,
     flatbuffers::Offset<flatbuffers::Vector<int32_t>> metadata_buffer = 0,
-    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<Metadata>>> metadata = 0)
+    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<circle::Metadata>>> metadata = 0)
 {
   ModelBuilder builder_(_fbb);
   builder_.add_metadata(metadata);
@@ -9408,23 +10001,27 @@ inline flatbuffers::Offset<Model> CreateModel(
   return builder_.Finish();
 }
 
-inline flatbuffers::Offset<Model>
-CreateModelDirect(flatbuffers::FlatBufferBuilder &_fbb, uint32_t version = 0,
-                  const std::vector<flatbuffers::Offset<OperatorCode>> *operator_codes = nullptr,
-                  const std::vector<flatbuffers::Offset<SubGraph>> *subgraphs = nullptr,
-                  const char *description = nullptr,
-                  const std::vector<flatbuffers::Offset<Buffer>> *buffers = nullptr,
-                  const std::vector<int32_t> *metadata_buffer = nullptr,
-                  const std::vector<flatbuffers::Offset<Metadata>> *metadata = nullptr)
+inline flatbuffers::Offset<Model> CreateModelDirect(
+    flatbuffers::FlatBufferBuilder &_fbb, uint32_t version = 0,
+    const std::vector<flatbuffers::Offset<circle::OperatorCode>> *operator_codes = nullptr,
+    const std::vector<flatbuffers::Offset<circle::SubGraph>> *subgraphs = nullptr,
+    const char *description = nullptr,
+    const std::vector<flatbuffers::Offset<circle::Buffer>> *buffers = nullptr,
+    const std::vector<int32_t> *metadata_buffer = nullptr,
+    const std::vector<flatbuffers::Offset<circle::Metadata>> *metadata = nullptr)
 {
-  return circle::CreateModel(
-      _fbb, version,
-      operator_codes ? _fbb.CreateVector<flatbuffers::Offset<OperatorCode>>(*operator_codes) : 0,
-      subgraphs ? _fbb.CreateVector<flatbuffers::Offset<SubGraph>>(*subgraphs) : 0,
-      description ? _fbb.CreateString(description) : 0,
-      buffers ? _fbb.CreateVector<flatbuffers::Offset<Buffer>>(*buffers) : 0,
-      metadata_buffer ? _fbb.CreateVector<int32_t>(*metadata_buffer) : 0,
-      metadata ? _fbb.CreateVector<flatbuffers::Offset<Metadata>>(*metadata) : 0);
+  auto operator_codes__ =
+      operator_codes ? _fbb.CreateVector<flatbuffers::Offset<circle::OperatorCode>>(*operator_codes)
+                     : 0;
+  auto subgraphs__ =
+      subgraphs ? _fbb.CreateVector<flatbuffers::Offset<circle::SubGraph>>(*subgraphs) : 0;
+  auto description__ = description ? _fbb.CreateString(description) : 0;
+  auto buffers__ = buffers ? _fbb.CreateVector<flatbuffers::Offset<circle::Buffer>>(*buffers) : 0;
+  auto metadata_buffer__ = metadata_buffer ? _fbb.CreateVector<int32_t>(*metadata_buffer) : 0;
+  auto metadata__ =
+      metadata ? _fbb.CreateVector<flatbuffers::Offset<circle::Metadata>>(*metadata) : 0;
+  return circle::CreateModel(_fbb, version, operator_codes__, subgraphs__, description__, buffers__,
+                             metadata_buffer__, metadata__);
 }
 
 inline bool VerifyQuantizationDetails(flatbuffers::Verifier &verifier, const void *obj,
@@ -9438,11 +10035,11 @@ inline bool VerifyQuantizationDetails(flatbuffers::Verifier &verifier, const voi
     }
     case QuantizationDetails_CustomQuantization:
     {
-      auto ptr = reinterpret_cast<const CustomQuantization *>(obj);
+      auto ptr = reinterpret_cast<const circle::CustomQuantization *>(obj);
       return verifier.VerifyTable(ptr);
     }
     default:
-      return false;
+      return true;
   }
 }
 
@@ -9477,21 +10074,21 @@ inline bool VerifySparseIndexVector(flatbuffers::Verifier &verifier, const void 
     }
     case SparseIndexVector_Int32Vector:
     {
-      auto ptr = reinterpret_cast<const Int32Vector *>(obj);
+      auto ptr = reinterpret_cast<const circle::Int32Vector *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case SparseIndexVector_Uint16Vector:
     {
-      auto ptr = reinterpret_cast<const Uint16Vector *>(obj);
+      auto ptr = reinterpret_cast<const circle::Uint16Vector *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case SparseIndexVector_Uint8Vector:
     {
-      auto ptr = reinterpret_cast<const Uint8Vector *>(obj);
+      auto ptr = reinterpret_cast<const circle::Uint8Vector *>(obj);
       return verifier.VerifyTable(ptr);
     }
     default:
-      return false;
+      return true;
   }
 }
 
@@ -9525,526 +10122,526 @@ inline bool VerifyBuiltinOptions(flatbuffers::Verifier &verifier, const void *ob
     }
     case BuiltinOptions_Conv2DOptions:
     {
-      auto ptr = reinterpret_cast<const Conv2DOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::Conv2DOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_DepthwiseConv2DOptions:
     {
-      auto ptr = reinterpret_cast<const DepthwiseConv2DOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::DepthwiseConv2DOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_ConcatEmbeddingsOptions:
     {
-      auto ptr = reinterpret_cast<const ConcatEmbeddingsOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::ConcatEmbeddingsOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_LSHProjectionOptions:
     {
-      auto ptr = reinterpret_cast<const LSHProjectionOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::LSHProjectionOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_Pool2DOptions:
     {
-      auto ptr = reinterpret_cast<const Pool2DOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::Pool2DOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_SVDFOptions:
     {
-      auto ptr = reinterpret_cast<const SVDFOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::SVDFOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_RNNOptions:
     {
-      auto ptr = reinterpret_cast<const RNNOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::RNNOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_FullyConnectedOptions:
     {
-      auto ptr = reinterpret_cast<const FullyConnectedOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::FullyConnectedOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_SoftmaxOptions:
     {
-      auto ptr = reinterpret_cast<const SoftmaxOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::SoftmaxOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_ConcatenationOptions:
     {
-      auto ptr = reinterpret_cast<const ConcatenationOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::ConcatenationOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_AddOptions:
     {
-      auto ptr = reinterpret_cast<const AddOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::AddOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_L2NormOptions:
     {
-      auto ptr = reinterpret_cast<const L2NormOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::L2NormOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_LocalResponseNormalizationOptions:
     {
-      auto ptr = reinterpret_cast<const LocalResponseNormalizationOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::LocalResponseNormalizationOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_LSTMOptions:
     {
-      auto ptr = reinterpret_cast<const LSTMOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::LSTMOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_ResizeBilinearOptions:
     {
-      auto ptr = reinterpret_cast<const ResizeBilinearOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::ResizeBilinearOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_CallOptions:
     {
-      auto ptr = reinterpret_cast<const CallOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::CallOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_ReshapeOptions:
     {
-      auto ptr = reinterpret_cast<const ReshapeOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::ReshapeOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_SkipGramOptions:
     {
-      auto ptr = reinterpret_cast<const SkipGramOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::SkipGramOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_SpaceToDepthOptions:
     {
-      auto ptr = reinterpret_cast<const SpaceToDepthOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::SpaceToDepthOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_EmbeddingLookupSparseOptions:
     {
-      auto ptr = reinterpret_cast<const EmbeddingLookupSparseOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::EmbeddingLookupSparseOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_MulOptions:
     {
-      auto ptr = reinterpret_cast<const MulOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::MulOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_PadOptions:
     {
-      auto ptr = reinterpret_cast<const PadOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::PadOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_GatherOptions:
     {
-      auto ptr = reinterpret_cast<const GatherOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::GatherOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_BatchToSpaceNDOptions:
     {
-      auto ptr = reinterpret_cast<const BatchToSpaceNDOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::BatchToSpaceNDOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_SpaceToBatchNDOptions:
     {
-      auto ptr = reinterpret_cast<const SpaceToBatchNDOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::SpaceToBatchNDOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_TransposeOptions:
     {
-      auto ptr = reinterpret_cast<const TransposeOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::TransposeOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_ReducerOptions:
     {
-      auto ptr = reinterpret_cast<const ReducerOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::ReducerOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_SubOptions:
     {
-      auto ptr = reinterpret_cast<const SubOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::SubOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_DivOptions:
     {
-      auto ptr = reinterpret_cast<const DivOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::DivOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_SqueezeOptions:
     {
-      auto ptr = reinterpret_cast<const SqueezeOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::SqueezeOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_SequenceRNNOptions:
     {
-      auto ptr = reinterpret_cast<const SequenceRNNOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::SequenceRNNOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_StridedSliceOptions:
     {
-      auto ptr = reinterpret_cast<const StridedSliceOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::StridedSliceOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_ExpOptions:
     {
-      auto ptr = reinterpret_cast<const ExpOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::ExpOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_TopKV2Options:
     {
-      auto ptr = reinterpret_cast<const TopKV2Options *>(obj);
+      auto ptr = reinterpret_cast<const circle::TopKV2Options *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_SplitOptions:
     {
-      auto ptr = reinterpret_cast<const SplitOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::SplitOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_LogSoftmaxOptions:
     {
-      auto ptr = reinterpret_cast<const LogSoftmaxOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::LogSoftmaxOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_CastOptions:
     {
-      auto ptr = reinterpret_cast<const CastOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::CastOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_DequantizeOptions:
     {
-      auto ptr = reinterpret_cast<const DequantizeOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::DequantizeOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_MaximumMinimumOptions:
     {
-      auto ptr = reinterpret_cast<const MaximumMinimumOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::MaximumMinimumOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_ArgMaxOptions:
     {
-      auto ptr = reinterpret_cast<const ArgMaxOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::ArgMaxOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_LessOptions:
     {
-      auto ptr = reinterpret_cast<const LessOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::LessOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_NegOptions:
     {
-      auto ptr = reinterpret_cast<const NegOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::NegOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_PadV2Options:
     {
-      auto ptr = reinterpret_cast<const PadV2Options *>(obj);
+      auto ptr = reinterpret_cast<const circle::PadV2Options *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_GreaterOptions:
     {
-      auto ptr = reinterpret_cast<const GreaterOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::GreaterOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_GreaterEqualOptions:
     {
-      auto ptr = reinterpret_cast<const GreaterEqualOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::GreaterEqualOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_LessEqualOptions:
     {
-      auto ptr = reinterpret_cast<const LessEqualOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::LessEqualOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_SelectOptions:
     {
-      auto ptr = reinterpret_cast<const SelectOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::SelectOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_SliceOptions:
     {
-      auto ptr = reinterpret_cast<const SliceOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::SliceOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_TransposeConvOptions:
     {
-      auto ptr = reinterpret_cast<const TransposeConvOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::TransposeConvOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_SparseToDenseOptions:
     {
-      auto ptr = reinterpret_cast<const SparseToDenseOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::SparseToDenseOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_TileOptions:
     {
-      auto ptr = reinterpret_cast<const TileOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::TileOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_ExpandDimsOptions:
     {
-      auto ptr = reinterpret_cast<const ExpandDimsOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::ExpandDimsOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_EqualOptions:
     {
-      auto ptr = reinterpret_cast<const EqualOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::EqualOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_NotEqualOptions:
     {
-      auto ptr = reinterpret_cast<const NotEqualOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::NotEqualOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_ShapeOptions:
     {
-      auto ptr = reinterpret_cast<const ShapeOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::ShapeOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_PowOptions:
     {
-      auto ptr = reinterpret_cast<const PowOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::PowOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_ArgMinOptions:
     {
-      auto ptr = reinterpret_cast<const ArgMinOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::ArgMinOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_FakeQuantOptions:
     {
-      auto ptr = reinterpret_cast<const FakeQuantOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::FakeQuantOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_PackOptions:
     {
-      auto ptr = reinterpret_cast<const PackOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::PackOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_LogicalOrOptions:
     {
-      auto ptr = reinterpret_cast<const LogicalOrOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::LogicalOrOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_OneHotOptions:
     {
-      auto ptr = reinterpret_cast<const OneHotOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::OneHotOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_LogicalAndOptions:
     {
-      auto ptr = reinterpret_cast<const LogicalAndOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::LogicalAndOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_LogicalNotOptions:
     {
-      auto ptr = reinterpret_cast<const LogicalNotOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::LogicalNotOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_UnpackOptions:
     {
-      auto ptr = reinterpret_cast<const UnpackOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::UnpackOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_FloorDivOptions:
     {
-      auto ptr = reinterpret_cast<const FloorDivOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::FloorDivOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_SquareOptions:
     {
-      auto ptr = reinterpret_cast<const SquareOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::SquareOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_ZerosLikeOptions:
     {
-      auto ptr = reinterpret_cast<const ZerosLikeOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::ZerosLikeOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_FillOptions:
     {
-      auto ptr = reinterpret_cast<const FillOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::FillOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_BidirectionalSequenceLSTMOptions:
     {
-      auto ptr = reinterpret_cast<const BidirectionalSequenceLSTMOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::BidirectionalSequenceLSTMOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_BidirectionalSequenceRNNOptions:
     {
-      auto ptr = reinterpret_cast<const BidirectionalSequenceRNNOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::BidirectionalSequenceRNNOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_UnidirectionalSequenceLSTMOptions:
     {
-      auto ptr = reinterpret_cast<const UnidirectionalSequenceLSTMOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::UnidirectionalSequenceLSTMOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_FloorModOptions:
     {
-      auto ptr = reinterpret_cast<const FloorModOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::FloorModOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_RangeOptions:
     {
-      auto ptr = reinterpret_cast<const RangeOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::RangeOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_ResizeNearestNeighborOptions:
     {
-      auto ptr = reinterpret_cast<const ResizeNearestNeighborOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::ResizeNearestNeighborOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_LeakyReluOptions:
     {
-      auto ptr = reinterpret_cast<const LeakyReluOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::LeakyReluOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_SquaredDifferenceOptions:
     {
-      auto ptr = reinterpret_cast<const SquaredDifferenceOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::SquaredDifferenceOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_MirrorPadOptions:
     {
-      auto ptr = reinterpret_cast<const MirrorPadOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::MirrorPadOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_AbsOptions:
     {
-      auto ptr = reinterpret_cast<const AbsOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::AbsOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_SplitVOptions:
     {
-      auto ptr = reinterpret_cast<const SplitVOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::SplitVOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_UniqueOptions:
     {
-      auto ptr = reinterpret_cast<const UniqueOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::UniqueOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_ReverseV2Options:
     {
-      auto ptr = reinterpret_cast<const ReverseV2Options *>(obj);
+      auto ptr = reinterpret_cast<const circle::ReverseV2Options *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_AddNOptions:
     {
-      auto ptr = reinterpret_cast<const AddNOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::AddNOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_GatherNdOptions:
     {
-      auto ptr = reinterpret_cast<const GatherNdOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::GatherNdOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_CosOptions:
     {
-      auto ptr = reinterpret_cast<const CosOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::CosOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_WhereOptions:
     {
-      auto ptr = reinterpret_cast<const WhereOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::WhereOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_RankOptions:
     {
-      auto ptr = reinterpret_cast<const RankOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::RankOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_ReverseSequenceOptions:
     {
-      auto ptr = reinterpret_cast<const ReverseSequenceOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::ReverseSequenceOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_MatrixDiagOptions:
     {
-      auto ptr = reinterpret_cast<const MatrixDiagOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::MatrixDiagOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_QuantizeOptions:
     {
-      auto ptr = reinterpret_cast<const QuantizeOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::QuantizeOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_MatrixSetDiagOptions:
     {
-      auto ptr = reinterpret_cast<const MatrixSetDiagOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::MatrixSetDiagOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_HardSwishOptions:
     {
-      auto ptr = reinterpret_cast<const HardSwishOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::HardSwishOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_IfOptions:
     {
-      auto ptr = reinterpret_cast<const IfOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::IfOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_WhileOptions:
     {
-      auto ptr = reinterpret_cast<const WhileOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::WhileOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_DepthToSpaceOptions:
     {
-      auto ptr = reinterpret_cast<const DepthToSpaceOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::DepthToSpaceOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_NonMaxSuppressionV4Options:
     {
-      auto ptr = reinterpret_cast<const NonMaxSuppressionV4Options *>(obj);
+      auto ptr = reinterpret_cast<const circle::NonMaxSuppressionV4Options *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_NonMaxSuppressionV5Options:
     {
-      auto ptr = reinterpret_cast<const NonMaxSuppressionV5Options *>(obj);
+      auto ptr = reinterpret_cast<const circle::NonMaxSuppressionV5Options *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_ScatterNdOptions:
     {
-      auto ptr = reinterpret_cast<const ScatterNdOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::ScatterNdOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_SelectV2Options:
     {
-      auto ptr = reinterpret_cast<const SelectV2Options *>(obj);
+      auto ptr = reinterpret_cast<const circle::SelectV2Options *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_DensifyOptions:
     {
-      auto ptr = reinterpret_cast<const DensifyOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::DensifyOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_SegmentSumOptions:
     {
-      auto ptr = reinterpret_cast<const SegmentSumOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::SegmentSumOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_BatchMatMulOptions:
     {
-      auto ptr = reinterpret_cast<const BatchMatMulOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::BatchMatMulOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_BCQGatherOptions:
     {
-      auto ptr = reinterpret_cast<const BCQGatherOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::BCQGatherOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_BCQFullyConnectedOptions:
     {
-      auto ptr = reinterpret_cast<const BCQFullyConnectedOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::BCQFullyConnectedOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_InstanceNormOptions:
     {
-      auto ptr = reinterpret_cast<const InstanceNormOptions *>(obj);
+      auto ptr = reinterpret_cast<const circle::InstanceNormOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     default:
-      return false;
+      return true;
   }
 }
 


### PR DESCRIPTION
It updates circle_schema_generated.h as circle_schema.fbs is updated.
It has SHUFFLED16x1FLOAT32 for fullyconnected weight format.
Also, the generated code is changed perhaps it is generated with flatbuffers
v1.12.0. Old one seems generated with older flatc.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>