### PR TITLE
[onert/cpu] Fix LSTMLayer optional inputs

### DIFF
--- a/runtime/onert/backend/cpu/ops/LSTMLayer.cc
+++ b/runtime/onert/backend/cpu/ops/LSTMLayer.cc
@@ -134,44 +134,24 @@ void LSTMLayer::LSTMFloat()
     output_gate_scratch = scratch_buffer_buf + 3 * n_cell * n_batch;
   }
 
+  auto optional_tensor_ptr = [](const IPortableTensor *tensor) {
+    // If tensor is not given or the tensor size is 0, consider it was not given
+    return (tensor && tensor->total_size() > 0) ? reinterpret_cast<float *>(tensor->buffer())
+                                                : nullptr;
+  };
   // Optional inputs
-  float *input_to_input_weights_ptr =
-      _input_to_input_weights ? reinterpret_cast<float *>(_input_to_input_weights->buffer())
-                              : nullptr;
-  float *recurrent_to_input_weights_ptr =
-      _recurrent_to_input_weights ? reinterpret_cast<float *>(_recurrent_to_input_weights->buffer())
-                                  : nullptr;
-  float *cell_to_input_weights_ptr =
-      _cell_to_input_weights ? reinterpret_cast<float *>(_cell_to_input_weights->buffer())
-                             : nullptr;
-  float *cell_to_forget_weights_ptr =
-      _cell_to_forget_weights ? reinterpret_cast<float *>(_cell_to_forget_weights->buffer())
-                              : nullptr;
-  float *cell_to_output_weights_ptr =
-      _cell_to_output_weights ? reinterpret_cast<float *>(_cell_to_output_weights->buffer())
-                              : nullptr;
-  float *input_gate_bias_ptr =
-      _input_gate_bias ? reinterpret_cast<float *>(_input_gate_bias->buffer()) : nullptr;
-  float *projection_weights_ptr =
-      _projection_weights ? reinterpret_cast<float *>(_projection_weights->buffer()) : nullptr;
-  float *projection_bias_ptr =
-      _projection_bias ? reinterpret_cast<float *>(_projection_bias->buffer()) : nullptr;
-  float *input_layer_norm_coefficients_ptr =
-      _input_layer_norm_coefficients
-          ? reinterpret_cast<float *>(_input_layer_norm_coefficients->buffer())
-          : nullptr;
-  float *forget_layer_norm_coefficients_ptr =
-      _forget_layer_norm_coefficients
-          ? reinterpret_cast<float *>(_forget_layer_norm_coefficients->buffer())
-          : nullptr;
-  float *cell_layer_norm_coefficients_ptr =
-      _cell_layer_norm_coefficients
-          ? reinterpret_cast<float *>(_cell_layer_norm_coefficients->buffer())
-          : nullptr;
-  float *output_layer_norm_coefficients_ptr =
-      _output_layer_norm_coefficients
-          ? reinterpret_cast<float *>(_output_layer_norm_coefficients->buffer())
-          : nullptr;
+  float *input_to_input_weights_ptr = optional_tensor_ptr(_input_to_input_weights);
+  float *recurrent_to_input_weights_ptr = optional_tensor_ptr(_recurrent_to_input_weights);
+  float *cell_to_input_weights_ptr = optional_tensor_ptr(_cell_to_input_weights);
+  float *cell_to_forget_weights_ptr = optional_tensor_ptr(_cell_to_forget_weights);
+  float *cell_to_output_weights_ptr = optional_tensor_ptr(_cell_to_output_weights);
+  float *input_gate_bias_ptr = optional_tensor_ptr(_input_gate_bias);
+  float *projection_weights_ptr = optional_tensor_ptr(_projection_weights);
+  float *projection_bias_ptr = optional_tensor_ptr(_projection_bias);
+  float *input_layer_norm_coefficients_ptr = optional_tensor_ptr(_input_layer_norm_coefficients);
+  float *forget_layer_norm_coefficients_ptr = optional_tensor_ptr(_forget_layer_norm_coefficients);
+  float *cell_layer_norm_coefficients_ptr = optional_tensor_ptr(_cell_layer_norm_coefficients);
+  float *output_layer_norm_coefficients_ptr = optional_tensor_ptr(_output_layer_norm_coefficients);
 
   // Copy out the LSTM specific params so they can be passed in the function.
   nnfw::cker::LSTMParams lstm_params;


### PR DESCRIPTION
When LSTMLayer gets an optional input of size 0, make the corresponding
input to be null, as the kernel implementation assumes it is ungiven
only if it is null.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>