### PR TITLE
[onert] Optimize PermuteLayer of controlflow by using enqueue functions

### DIFF
--- a/runtime/onert/backend/acl_cl/operand/CLSubTensor.h
+++ b/runtime/onert/backend/acl_cl/operand/CLSubTensor.h
@@ -48,6 +48,7 @@ public:
 public:
   // This method is used to prevent the use of memcpy for SubTensor
   bool has_padding() const override { return true; }
+  bool is_subtensor() const final { return true; }
 
 private:
   std::shared_ptr<arm_compute::CLSubTensor> _cl_sub_tensor;

--- a/runtime/onert/backend/acl_cl/operand/ICLTensor.cc
+++ b/runtime/onert/backend/acl_cl/operand/ICLTensor.cc
@@ -17,6 +17,7 @@
 #include "ICLTensor.h"
 
 #include <arm_compute/runtime/CL/CLScheduler.h>
+#include <arm_compute/core/CL/OpenCL.h>
 
 namespace onert
 {
@@ -38,6 +39,20 @@ void ICLTensor::access(const std::function<void(ITensor &tensor)> &fn)
   map(queue);
   fn(*this);
   unmap(queue);
+}
+
+void ICLTensor::enqueueWriteBuffer(const void *ptr, bool blocking)
+{
+  auto &queue = ::arm_compute::CLScheduler::get().queue();
+  queue.enqueueWriteBuffer(handle()->cl_buffer(), blocking ? CL_TRUE : CL_FALSE, 0,
+                           info()->total_size(), ptr);
+}
+
+void ICLTensor::enqueueReadBuffer(void *ptr, bool blocking)
+{
+  auto &queue = ::arm_compute::CLScheduler::get().queue();
+  queue.enqueueReadBuffer(handle()->cl_buffer(), blocking ? CL_TRUE : CL_FALSE, 0,
+                          info()->total_size(), ptr);
 }
 } // namespace operand
 } // namespace acl_cl

--- a/runtime/onert/backend/acl_cl/operand/ICLTensor.h
+++ b/runtime/onert/backend/acl_cl/operand/ICLTensor.h
@@ -38,6 +38,9 @@ public:
 
 public:
   void access(const std::function<void(ITensor &tensor)> &fn) final;
+  bool needMemoryMap() const final { return true; }
+  void enqueueWriteBuffer(const void *ptr, bool blocking = true) final;
+  void enqueueReadBuffer(void *ptr, bool blocking = true) final;
 
 private:
   void map(cl::CommandQueue &q, bool blocking = true) { return handle()->map(q, blocking); }

--- a/runtime/onert/backend/acl_neon/operand/NESubTensor.h
+++ b/runtime/onert/backend/acl_neon/operand/NESubTensor.h
@@ -48,6 +48,7 @@ public:
 public:
   // This method is used to prevent the use of memcpy for SubTensor
   bool has_padding() const override { return true; }
+  bool is_subtensor() const final { return true; }
 
 private:
   std::shared_ptr<arm_compute::SubTensor> _ne_sub_tensor;

--- a/runtime/onert/core/include/backend/ITensor.h
+++ b/runtime/onert/core/include/backend/ITensor.h
@@ -103,6 +103,17 @@ public:
    * @note  Higer dimension will be placed on front.
    */
   virtual ir::Shape getShape() const;
+
+  virtual bool is_subtensor() const { return false; }
+  virtual bool needMemoryMap() const { return false; }
+  virtual void enqueueWriteBuffer(const void *, bool)
+  {
+    throw std::runtime_error("This backend does not support enqueueWriteBuffer");
+  }
+  virtual void enqueueReadBuffer(void *, bool)
+  {
+    throw std::runtime_error("This backend does not support enqueueReadBuffer");
+  }
 };
 
 } // namespace backend

--- a/runtime/onert/core/src/backend/controlflow/kernel/PermuteLayer.cc
+++ b/runtime/onert/core/src/backend/controlflow/kernel/PermuteLayer.cc
@@ -166,6 +166,19 @@ void PermuteLayer::appendPermuteTasks(const ITensor *src_tensor, ITensor *dst_te
   _tasks_map[src_tensor] = std::move(tasks);
 }
 
+void PermuteLayer::runPermuteTasks(backend::ITensor *src, uint8_t *dst_buffer)
+{
+  assert(src->getShape().num_elements() * ir::sizeOfDataType(src->data_type()) <=
+         src->total_size());
+  std::vector<PermuteWorkerTask> &tasks = _tasks_map.at(src);
+  for (size_t i = 0; i < tasks.size(); ++i)
+  {
+    tasks.at(i).setBuffers(src->buffer(), dst_buffer);
+  }
+  assert(tasks.size() >= 1);
+  _external_context->ruy_context()->mutable_thread_pool()->Execute(tasks.size(), tasks.data());
+}
+
 void PermuteLayer::run()
 {
   assert(_src_tensors.size() == _dst_tensors.size());
@@ -217,36 +230,55 @@ void PermuteLayer::run()
     auto src = *src_it;
     auto dst = *dst_it;
 
-    if (src != dst)
+    if (src->total_size() == 0)
     {
-      // Conditions to run permutation with multithreading
-      // 1. The tasks for multithreathing was created
-      // 2. The tasks's size > 1
-      // 3. Both tensors are not dynamic
-      if (_tasks_map.find(src) == _tasks_map.end() || _tasks_map.at(src).size() == 1 ||
-          src->is_dynamic() || dst->is_dynamic())
+      assert(dst->total_size() == 0);
+    }
+    else
+    {
+      if (src != dst)
       {
-        permute(src, dst, src->num_dimensions());
-      }
-      else
-      {
-        auto fn = [&](backend::ITensor &) {
-          dst->access([&](backend::ITensor &) {
-            assert(src->getShape().num_elements() * ir::sizeOfDataType(src->data_type()) <=
-                   src->total_size());
-            assert(src->getShape().num_elements() * ir::sizeOfDataType(src->data_type()) <=
-                   dst->total_size());
-            std::vector<PermuteWorkerTask> &tasks = _tasks_map.at(src);
-            for (size_t i = 0; i < tasks.size(); ++i)
-            {
-              tasks.at(i).setBuffers(src->buffer(), dst->buffer());
-            }
-            assert(tasks.size() >= 1);
-            _external_context->ruy_context()->mutable_thread_pool()->Execute(tasks.size(),
-                                                                             tasks.data());
-          });
-        };
-        src->access(fn);
+        // Conditions to run permutation with multithreading
+        // 1. The tasks for multithreathing was created
+        // 2. The tasks's size > 1
+        // 3. Both tensors are not dynamic
+        if (_tasks_map.find(src) == _tasks_map.end() || _tasks_map.at(src).size() == 1 ||
+            src->is_dynamic() || dst->is_dynamic())
+        {
+          permute(src, dst, src->num_dimensions());
+        }
+        // If dst is subtensor, we have to use clEnqueueMapBuffer instead of clEnqueueWirteBuffer
+        else if (dst->needMemoryMap() && !dst->is_subtensor())
+        {
+          if (!src->has_padding() && !dst->has_padding() && src->layout() == dst->layout())
+          {
+            // This is more effective than multi-threading
+            src->access([&](backend::ITensor &) { dst->enqueueWriteBuffer(src->buffer(), false); });
+          }
+          else
+          {
+            // TODO Optimize this block in case of that padding size of dst is big.
+            _buffers_map[dst].reserve(dst->total_size());
+            auto dst_buffer = _buffers_map[dst].data();
+
+            src->access([&](backend::ITensor &) { runPermuteTasks(src, dst_buffer); });
+            dst->enqueueWriteBuffer(dst_buffer, false);
+          }
+        }
+        else if (src->needMemoryMap() && !src->is_subtensor() && !src->has_padding() &&
+                 !dst->has_padding() && src->layout() == dst->layout())
+        {
+          // This is more effective than multi-threading
+          assert(!dst->needMemoryMap());
+          dst->access([&](backend::ITensor &) { src->enqueueReadBuffer(dst->buffer(), true); });
+        }
+        else
+        {
+          auto fn = [&](backend::ITensor &) {
+            dst->access([&](backend::ITensor &) { runPermuteTasks(src, dst->buffer()); });
+          };
+          src->access(fn);
+        }
       }
     }
     src_it++;

--- a/runtime/onert/core/src/backend/controlflow/kernel/PermuteLayer.h
+++ b/runtime/onert/core/src/backend/controlflow/kernel/PermuteLayer.h
@@ -49,6 +49,8 @@ private:
   void appendPermuteTasks(const ITensor *src_tensor, ITensor *dst_tensor,
                           const ir::Shape &loop_shape, size_t size);
 
+  void runPermuteTasks(backend::ITensor *src, uint8_t *dst_buffer);
+
   struct PermuteWorkerTask : ruy::Task
   {
     using Strides = ir::Coordinates;

--- a/runtime/onert/core/src/exec/IPermuteFunction.h
+++ b/runtime/onert/core/src/exec/IPermuteFunction.h
@@ -31,6 +31,7 @@
 #include <typeinfo>
 #include "util/Utils.h"
 #include <vector>
+#include <unordered_map>
 
 namespace onert
 {
@@ -75,6 +76,12 @@ public:
 protected:
   void permute(backend::ITensor *src_tensor, backend::ITensor *dst_tensor, size_t rank)
   {
+    if (src_tensor->total_size() == 0)
+    {
+      assert(dst_tensor->total_size() == 0);
+      return;
+    }
+
     assert(src_tensor != dst_tensor);
     assert(underlying_type(src_tensor->data_type()) == underlying_type(dst_tensor->data_type()));
     switch (src_tensor->data_type())
@@ -110,6 +117,51 @@ private:
   // TODO make src const by proving const access()
   template <class T> void permute(backend::ITensor *src, backend::ITensor *dst, size_t rank)
   {
+    assert(src->total_size() != 0 && dst->total_size() != 0);
+    // If dst is subtensor, we have to use clEnqueueMapBuffer instead of clEnqueueWirteBuffer
+    if (dst->needMemoryMap() && !dst->is_subtensor())
+    {
+      // A assertion to check mapping without calling map()
+      // Now there is no case where both src and dst have cl buffer.
+      assert(!src->needMemoryMap());
+
+      if (!src->has_padding() && !dst->has_padding() && src->layout() == dst->layout())
+      {
+        src->access([&](backend::ITensor &) { dst->enqueueWriteBuffer(src->buffer(), false); });
+      }
+      else
+      {
+        // TODO Optimize this block in case of that padding size of dst is big.
+        _buffers_map[dst].reserve(dst->total_size());
+        auto dst_buffer = _buffers_map[dst].data();
+        src->access(
+            [&](backend::ITensor &) { permute<T>(src, dst, rank, dst_buffer, dst->total_size()); });
+        dst->enqueueWriteBuffer(dst_buffer, false);
+      }
+    }
+    else if (src->needMemoryMap() && !src->is_subtensor() && !src->has_padding() &&
+             !dst->has_padding() && src->layout() == dst->layout())
+    {
+      assert(!dst->needMemoryMap());
+      dst->access([&](backend::ITensor &) { src->enqueueReadBuffer(dst->buffer(), true); });
+    }
+    else
+    {
+      auto fn = [&](backend::ITensor &) {
+        dst->access([&](backend::ITensor &) {
+          permute<T>(src, dst, rank, dst->buffer(), dst->total_size());
+        });
+      };
+      src->access(fn);
+    }
+  }
+
+  template <class T>
+  void permute(backend::ITensor *src, backend::ITensor *dst, size_t rank, uint8_t *dst_buffer,
+               size_t dst_size)
+  {
+    assert(dst_buffer != nullptr);
+    assert(dst_size == dst->total_size());
     const auto permute_type = [&]() -> PermuteType {
       if (src->layout() == ir::Layout::NHWC && dst->layout() == ir::Layout::NCHW)
       {
@@ -124,71 +176,83 @@ private:
         return PermuteType::COPY;
       }
     }();
-    auto fn = [&](backend::ITensor &src_tensor) {
-      dst->access([&](backend::ITensor &dst_tensor) {
-        if (rank == 4 && permute_type != PermuteType::COPY)
+    if (rank == 4 && permute_type != PermuteType::COPY)
+    {
+      switch (permute_type)
+      {
+        case PermuteType::NHWC_TO_NCHW:
         {
-          switch (permute_type)
-          {
-            case PermuteType::NHWC_TO_NCHW:
-            {
-              ir::FeatureShape shape;
-              shape.N = dst_tensor.dimension(0);
-              shape.C = dst_tensor.dimension(1);
-              shape.H = dst_tensor.dimension(2);
-              shape.W = dst_tensor.dimension(3);
-              const feature::nhwc::Reader<T> from(&src_tensor);
-              feature::nchw::View<T> into(&dst_tensor);
-              feature::iterate(shape)
-                  << [&](uint32_t batch, uint32_t ch, uint32_t row, uint32_t col) {
-                       const auto value = from.at(batch, row, col, ch);
-                       into.at(batch, ch, row, col) = value;
-                     };
-              break;
-            }
-            case PermuteType::NCHW_TO_NHWC:
-            {
-              ir::FeatureShape shape;
-              shape.N = src_tensor.dimension(0);
-              shape.C = src_tensor.dimension(1);
-              shape.H = src_tensor.dimension(2);
-              shape.W = src_tensor.dimension(3);
-              const feature::nchw::Reader<T> from(&src_tensor);
-              feature::nhwc::View<T> into(&dst_tensor);
-              feature::iterate(shape)
-                  << [&](uint32_t batch, uint32_t ch, uint32_t row, uint32_t col) {
-                       const auto value = from.at(batch, ch, row, col);
-                       into.at(batch, row, col, ch) = value;
-                     };
-              break;
-            }
-            default:
-            {
-              throw std::runtime_error("Unsupported Permutation");
-              break;
-            }
-          }
+          ir::FeatureShape shape;
+          shape.N = dst->dimension(0);
+          shape.C = dst->dimension(1);
+          shape.H = dst->dimension(2);
+          shape.W = dst->dimension(3);
+
+          typename feature::nchw::View<T>::Strides strides;
+          const auto start_offset = dst->calcOffset({0, 0, 0, 0});
+          strides.W = dst->dimension(3) == 1 ? 0 : dst->calcOffset({0, 0, 0, 1}) - start_offset;
+          strides.H = dst->dimension(2) == 1 ? 0 : dst->calcOffset({0, 0, 1, 0}) - start_offset;
+          strides.C = dst->dimension(1) == 1 ? 0 : dst->calcOffset({0, 1, 0, 0}) - start_offset;
+          strides.N = dst->dimension(0) == 1 ? 0 : dst->calcOffset({1, 0, 0, 0}) - start_offset;
+
+          const feature::nhwc::Reader<T> from(src);
+          feature::nchw::View<T> into(shape, strides,
+                                      reinterpret_cast<T *>(dst_buffer + start_offset), dst_size);
+          feature::iterate(shape) << [&](uint32_t batch, uint32_t ch, uint32_t row, uint32_t col) {
+            const auto value = from.at(batch, row, col, ch);
+            into.at(batch, ch, row, col) = value;
+          };
+          break;
         }
-        else if (!src_tensor.has_padding() && !dst_tensor.has_padding())
+        case PermuteType::NCHW_TO_NHWC:
         {
-          auto src_size = src_tensor.total_size();
-          assert(src_size <= dst_tensor.total_size());
-          memcpy(dst_tensor.buffer(), src_tensor.buffer(), src_size);
+          ir::FeatureShape shape;
+          shape.N = dst->dimension(0);
+          shape.H = dst->dimension(1);
+          shape.W = dst->dimension(2);
+          shape.C = dst->dimension(3);
+
+          typename feature::nhwc::View<T>::Strides strides;
+          const auto start_offset = dst->calcOffset({0, 0, 0, 0});
+          strides.C = dst->dimension(3) == 1 ? 0 : dst->calcOffset({0, 0, 0, 1}) - start_offset;
+          strides.W = dst->dimension(2) == 1 ? 0 : dst->calcOffset({0, 0, 1, 0}) - start_offset;
+          strides.H = dst->dimension(1) == 1 ? 0 : dst->calcOffset({0, 1, 0, 0}) - start_offset;
+          strides.N = dst->dimension(0) == 1 ? 0 : dst->calcOffset({1, 0, 0, 0}) - start_offset;
+
+          const feature::nchw::Reader<T> from(src);
+          feature::nhwc::View<T> into(shape, strides,
+                                      reinterpret_cast<T *>(dst_buffer + start_offset), dst_size);
+          feature::iterate(shape) << [&](uint32_t batch, uint32_t ch, uint32_t row, uint32_t col) {
+            const auto value = from.at(batch, ch, row, col);
+            into.at(batch, row, col, ch) = value;
+          };
+          break;
         }
-        else
+        default:
         {
-          auto loop_shape = src_tensor.getShape();
-          const auto copy_axis = loop_shape.rank() - 1;
-          const auto copy_len = loop_shape.dim(copy_axis) * sizeof(T);
-          loop_shape.dim(copy_axis) = 1;
-          ShapeLoop(loop_shape, [&](const onert::ir::Coordinates &coords) {
-            memcpy(dst_tensor.buffer() + dst_tensor.calcOffset(coords),
-                   src_tensor.buffer() + src_tensor.calcOffset(coords), copy_len);
-          });
+          throw std::runtime_error("Unsupported Permutation");
+          break;
         }
+      }
+    }
+    else if (!src->has_padding() && !dst->has_padding())
+    {
+      auto src_size = src->total_size();
+      assert(src_size <= dst->total_size());
+      memcpy(dst_buffer, src->buffer(), src_size);
+    }
+    else
+    {
+      auto loop_shape = src->getShape();
+      const auto copy_axis = loop_shape.rank() - 1;
+      const auto copy_len = loop_shape.dim(copy_axis) * sizeof(T);
+      loop_shape.dim(copy_axis) = 1;
+      ShapeLoop(loop_shape, [&](const onert::ir::Coordinates &coords) {
+        // Copy src tensor's data to dst_buffer with calculated offset of dst tensor
+        memcpy(dst_buffer + dst->calcOffset(coords), src->buffer() + src->calcOffset(coords),
+               copy_len);
       });
-    };
-    src->access(fn);
+    }
   }
 
 protected:
@@ -222,6 +286,7 @@ protected:
 protected:
   std::vector<backend::ITensor *> _src_tensors;
   std::vector<backend::ITensor *> _dst_tensors;
+  std::unordered_map<const backend::ITensor *, std::vector<uint8_t>> _buffers_map;
 };
 
 } // namespace exec

--- a/runtime/onert/core/src/exec/feature/nchw/View.h
+++ b/runtime/onert/core/src/exec/feature/nchw/View.h
@@ -37,8 +37,10 @@ namespace nchw
 template <typename T> class View final : public Reader<T>
 {
 public:
+  using Strides = typename Reader<T>::Strides;
   // Construct for buffer of model inputs
-  View(const ir::FeatureShape &shape, T *ptr, size_t len) : Reader<T>{shape, ptr, len}
+  View(const ir::FeatureShape &shape, const Strides &strides, T *ptr, size_t len)
+      : Reader<T>{shape, strides, ptr, len}
   {
     // DO NOTHING
   }

--- a/runtime/onert/core/src/exec/feature/nhwc/View.h
+++ b/runtime/onert/core/src/exec/feature/nhwc/View.h
@@ -38,8 +38,10 @@ namespace nhwc
 template <typename T> class View final : public Reader<T>
 {
 public:
-  // Construct for buffer of model inputs
-  View(const ir::FeatureShape &shape, T *ptr, size_t len) : Reader<T>{shape, ptr, len}
+  using Strides = typename Reader<T>::Strides;
+  // Construct for buffer and strides
+  View(const ir::FeatureShape &shape, const Strides &strides, T *ptr, size_t len)
+      : Reader<T>{shape, strides, ptr, len}
   {
     // DO NOTHING
   }


### PR DESCRIPTION
For issue #4414
Draft PR #4395

This commit Optimize PermuteLayer of controlflow by using enqueue functions instead of calling map().

Signed-off-by: ragmani <ragmani0216@gmail.com>