### PR TITLE
[moco-value-pbtxt-test] Check nnkit_tf_backend

### DIFF
--- a/compiler/moco-value-pbtxt-test/CMakeLists.txt
+++ b/compiler/moco-value-pbtxt-test/CMakeLists.txt
@@ -77,11 +77,10 @@ foreach(PREFIX IN ITEMS ${TESTCASES})
 
 endforeach(PREFIX)
 
-nnas_find_package(TensorFlow QUIET)
-if(NOT TensorFlow_FOUND)
-  message(STATUS "moco: Skip adding test as TensorFlow is not found")
+if(NOT TARGET nnkit_tf_backend)
+  message(STATUS "moco: Skip adding test as nnkit_tf_backend is not defined")
   return()
-endif(NOT TensorFlow_FOUND)
+endif(NOT TARGET nnkit_tf_backend)
 
 ##
 ## Copy runall.sh


### PR DESCRIPTION
Check nnkit_tf_backend instead of TensorFlow package
nnkit_tf_backend is not defined if Tensorflow package is not found

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

draft: #4807