### PR TITLE
[tfts] Check nnkit_tf_backend

### DIFF
--- a/compiler/tfts/CMakeLists.txt
+++ b/compiler/tfts/CMakeLists.txt
@@ -1,9 +1,8 @@
 nncc_find_resource(TensorFlowTests)
-nnas_find_package(TensorFlow QUIET)
 
-if(NOT TensorFlow_FOUND)
+if(NOT TARGET nnkit_tf_backend)
   return()
-endif(NOT TensorFlow_FOUND)
+endif(NOT TARGET nnkit_tf_backend)
 
 if(NOT TARGET tfkit)
   return()


### PR DESCRIPTION
Check nnkit_tf_backend instead of TensorFlow package
nnkit_tf_backend is not defined if Tensorflow package is not found

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

draft: #4807