### PR TITLE
[onert] Support fullyconnected with shuffled16x1float32 weights

### DIFF
--- a/compute/cker/include/cker/operation/FullyConnected.h
+++ b/compute/cker/include/cker/operation/FullyConnected.h
@@ -19,11 +19,13 @@
 #define __NNFW_CKER_FULLY_CONNECTED_H__
 
 #include <ruy/context.h>
+#include "cker/operation/FullyConnectedDense16x1.h"
 #include "cker/operation/FullyConnectedSparse16x1.h"
 #include "cker/Shape.h"
 #include "cker/Types.h"
 #include "cker/Utils.h"
 #include "cker/TensorUtils.h"
+#include "cker/neon/neon_check.h"
 
 namespace nnfw
 {

--- a/compute/cker/include/cker/operation/FullyConnectedDense16x1.h
+++ b/compute/cker/include/cker/operation/FullyConnectedDense16x1.h
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* Copyright (c) 2018 Mozilla
+                 2008-2011 Octasic Inc.
+                 2012-2017 Jean-Marc Valin */
+/*
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+
+   - Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+   - Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR
+   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+   EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+   PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+   PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+   LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef __NNFW_CKER_FULLY_CONNECTED_DENSE16x1_H__
+#define __NNFW_CKER_FULLY_CONNECTED_DENSE16x1_H__
+
+#include "cker/Shape.h"
+#include "cker/Types.h"
+#include "cker/Utils.h"
+#include "cker/TensorUtils.h"
+
+namespace nnfw
+{
+namespace cker
+{
+#if defined(__aarch64__) && defined(USE_NEON)
+inline void FullyConnected16x1Float32(const FullyConnectedParams &params, const Shape &input_shape,
+                                      const float *input_data, const Shape &weights_shape,
+                                      const float *weights_data, const Shape &,
+                                      const float *bias_data, const Shape &, float *output_data)
+{
+  int total_input_size = input_shape.FlatSize();
+  int input_size = weights_shape.Dims(1);
+  const int batch_size = total_input_size / input_size;
+  const int num_units = weights_shape.Dims(0);
+
+  float *out = output_data;
+  const float *weights = weights_data;
+  int rows = num_units;
+  int cols = input_size;
+  int col_stride = input_size;
+  const float *x = input_data;
+
+  // Output = bias if bias tensor exists.
+  if (bias_data)
+  {
+    VectorBatchVectorAssign(bias_data, num_units, batch_size, output_data);
+  }
+  else
+  {
+    ZeroVector(output_data, batch_size * num_units);
+  }
+
+  //  rows : out, cols : in
+  int i, j;
+  for (i = 0; i < rows; i += 16)
+  {
+    const float *w = &weights[i * col_stride];
+
+    /* keep y[0..15] in registers for duration of inner loop */
+    float *__restrict y = &out[i];
+
+    float32x4_t y0_3 = vld1q_f32(&y[0]);
+    float32x4_t y4_7 = vld1q_f32(&y[4]);
+    float32x4_t y8_11 = vld1q_f32(&y[8]);
+    float32x4_t y12_15 = vld1q_f32(&y[12]);
+
+    for (j = 0; j < cols; j++)
+    {
+      float32x4_t wvec0_3, wvec4_7, wvec8_11, wvec12_15;
+      float32x4_t xj;
+
+      xj = vld1q_dup_f32(&x[j]);
+
+      wvec0_3 = vld1q_f32(&w[0]);
+      y0_3 = vmlaq_f32(y0_3, wvec0_3, xj);
+      wvec4_7 = vld1q_f32(&w[4]);
+      y4_7 = vmlaq_f32(y4_7, wvec4_7, xj);
+      wvec8_11 = vld1q_f32(&w[8]);
+      y8_11 = vmlaq_f32(y8_11, wvec8_11, xj);
+      wvec12_15 = vld1q_f32(&w[12]);
+      y12_15 = vmlaq_f32(y12_15, wvec12_15, xj);
+
+      w += 16;
+    }
+
+    /* save y[0..15] back to memory */
+
+    vst1q_f32(&y[0], y0_3);
+    vst1q_f32(&y[4], y4_7);
+    vst1q_f32(&y[8], y8_11);
+    vst1q_f32(&y[12], y12_15);
+  }
+  if (params.activation != FusedActivationFunctionType::kNone)
+  {
+    // Apply activation function
+    ApplyActivationToVector(output_data, batch_size * num_units, params.activation, output_data);
+  }
+}
+#endif
+} // namespace cker
+} // namespace nnfw
+#endif // __NNFW_CKER_FULLY_CONNECTED_DENSE16x1_H__

--- a/runtime/onert/backend/acl_cl/KernelGenerator.cc
+++ b/runtime/onert/backend/acl_cl/KernelGenerator.cc
@@ -270,6 +270,9 @@ void KernelGenerator::visit(const ir::operation::FullyConnected &node)
   const auto output_index{node.getOutputs().at(0)};
   auto output_tensor = _tensor_reg->getAclTensor(output_index);
   const auto activation = node.param().activation;
+  if (node.param().weights_format == ir::FullyConnectedWeightsFormat::Shuffled16x1Float32)
+    throw std::runtime_error(
+        "KernelGenerator(acl_cl): FullyConnected 16x1Float32 weights is not supported.");
 
   auto fn = acl_common::kernelGenFullyConnected<acl_common::AclFunction, ::arm_compute::ICLTensor,
                                                 ::arm_compute::CLFullyConnectedReshapingLayer>(

--- a/runtime/onert/backend/acl_neon/KernelGenerator.cc
+++ b/runtime/onert/backend/acl_neon/KernelGenerator.cc
@@ -500,6 +500,9 @@ void KernelGenerator::visit(const ir::operation::FullyConnected &node)
   const auto output_index{node.getOutputs().at(0)};
   auto output_tensor = _tensor_reg->getAclTensor(output_index);
   const auto activation = node.param().activation;
+  if (node.param().weights_format == ir::FullyConnectedWeightsFormat::Shuffled16x1Float32)
+    throw std::runtime_error(
+        "KernelGenerator(acl_neon): FullyConnected 16x1Float32 weights is not supported.");
 
   auto fn = acl_common::kernelGenFullyConnected<acl_common::AclFunction, ::arm_compute::ITensor,
                                                 ::arm_compute::NEFullyConnectedReshapingLayer>(

--- a/runtime/onert/backend/cpu/KernelGenerator.cc
+++ b/runtime/onert/backend/cpu/KernelGenerator.cc
@@ -446,6 +446,7 @@ void KernelGenerator::visit(const ir::operation::FullyConnected &node)
   const auto weight_index{node.getInputs().at(FullyConnected::Input::WEIGHT)};
   const auto bias_index{node.getInputs().at(FullyConnected::Input::BIAS)};
   const auto activation = node.param().activation;
+  const auto weights_format = node.param().weights_format;
 
   auto output_tensor = _tensor_reg->getPortableTensor(output_index);
   auto input_tensor = _tensor_reg->getPortableTensor(input_index);
@@ -454,7 +455,7 @@ void KernelGenerator::visit(const ir::operation::FullyConnected &node)
 
   auto fn = std::make_unique<ops::FullyConnectedLayer>();
 
-  fn->configure(input_tensor, weight_tensor, bias_tensor, activation, output_tensor,
+  fn->configure(input_tensor, weight_tensor, bias_tensor, activation, weights_format, output_tensor,
                 _external_context);
 
   _return_fn = std::move(fn);

--- a/runtime/onert/backend/cpu/ops/FullyConnectedLayer.h
+++ b/runtime/onert/backend/cpu/ops/FullyConnectedLayer.h
@@ -55,8 +55,11 @@ public:
 
   void fullyConnectedSparseWeight();
 
+  void fullyConnected16x1Float32();
+
   void configure(const IPortableTensor *input, const IPortableTensor *weights,
-                 const IPortableTensor *bias, ir::Activation activation, IPortableTensor *output,
+                 const IPortableTensor *bias, ir::Activation activation,
+                 ir::FullyConnectedWeightsFormat weights_format, IPortableTensor *output,
                  const std::shared_ptr<ExternalContext> &external_context);
 
   void run() override;
@@ -74,7 +77,8 @@ private:
 
   std::shared_ptr<ExternalContext> _external_context;
 
-  bool _is_hybrid;
+  bool _is_hybrid : 1;
+  bool _is_shuffled16x1float32 : 1;
 
 #ifdef USE_RUY_GEMV
   uint8_t *_cached_weights = nullptr; // weights to be cached and a key

--- a/runtime/onert/core/include/ir/InternalType.h
+++ b/runtime/onert/core/include/ir/InternalType.h
@@ -46,6 +46,13 @@ struct Dilation
   uint32_t height_factor;
 };
 
+enum class FullyConnectedWeightsFormat
+{
+  Default = 0,
+  Shuffled4x16Int8 = 1,
+  Shuffled16x1Float32 = 127
+};
+
 } // namespace ir
 } // namespace onert
 

--- a/runtime/onert/core/include/ir/operation/FullyConnected.h
+++ b/runtime/onert/core/include/ir/operation/FullyConnected.h
@@ -42,6 +42,7 @@ public:
   struct Param
   {
     Activation activation;
+    FullyConnectedWeightsFormat weights_format;
   };
 
 public:

--- a/runtime/onert/frontend/base_loader/include/base_loader.h
+++ b/runtime/onert/frontend/base_loader/include/base_loader.h
@@ -684,7 +684,7 @@ void BaseLoader<LoaderDomain>::loadFC(const Operator *op, ir::Graph &subg)
   const auto *options = op->builtin_options_as_FullyConnectedOptions();
 
   param.activation = convertActivation(options->fused_activation_function());
-  // weights_format unused
+  param.weights_format = static_cast<ir::FullyConnectedWeightsFormat>(options->weights_format());
 
   const auto fc = loadOperationTo<ir::operation::FullyConnected>(op, subg, param);
 

--- a/runtime/onert/frontend/nnapi/wrapper/OperationFactory.cc
+++ b/runtime/onert/frontend/nnapi/wrapper/OperationFactory.cc
@@ -487,6 +487,7 @@ OperationFactory::OperationFactory()
     const auto activation_index = OperandIndex{init_param.inputs[3]};
     param.activation =
         NNAPIConvert::getFusedActivation(operands.at(activation_index).asScalar<FuseCode>());
+    param.weights_format = FullyConnectedWeightsFormat::Default;
 
     return new operation::FullyConnected{inputs, outputs, param};
   };

--- a/tests/nnfw_api/src/CircleGen.cc
+++ b/tests/nnfw_api/src/CircleGen.cc
@@ -148,9 +148,13 @@ uint32_t CircleGen::addOperatorEqual(const OperatorParams &params)
                                 circle::BuiltinOptions_EqualOptions, options);
 }
 
-uint32_t CircleGen::addOperatorFullyConnected(const OperatorParams &params)
+uint32_t
+CircleGen::addOperatorFullyConnected(const OperatorParams &params,
+                                     circle::FullyConnectedOptionsWeightsFormat weights_format)
 {
-  auto options = circle::CreateFullyConnectedOptions(_fbb).Union();
+  auto options =
+      circle::CreateFullyConnectedOptions(_fbb, circle::ActivationFunctionType_NONE, weights_format)
+          .Union();
   return addOperatorWithOptions(params, circle::BuiltinOperator_FULLY_CONNECTED,
                                 circle::BuiltinOptions_FullyConnectedOptions, options);
 }

--- a/tests/nnfw_api/src/CircleGen.h
+++ b/tests/nnfw_api/src/CircleGen.h
@@ -150,7 +150,9 @@ public:
   uint32_t addOperatorEqual(const OperatorParams &params);
   uint32_t addOperatorFill(const OperatorParams &params);
   uint32_t addOperatorFloor(const OperatorParams &params);
-  uint32_t addOperatorFullyConnected(const OperatorParams &params);
+  uint32_t addOperatorFullyConnected(const OperatorParams &params,
+                                     circle::FullyConnectedOptionsWeightsFormat weights_format =
+                                         circle::FullyConnectedOptionsWeightsFormat_DEFAULT);
   uint32_t addOperatorIf(const OperatorParams &params, uint32_t then_subg, uint32_t else_subg);
   uint32_t addOperatorInstanceNorm(const OperatorParams &params, float epsilon,
                                    circle::ActivationFunctionType actfn);


### PR DESCRIPTION
- It supports shuffled16x1float32 weights in cpu backends on aarch64.
- It has unit tests changes:
 : Add shuffled16x1float positive test (cpu backend)
 : Add shuffled16x1float negative test (acl_cl, acl_neon backend)
 : Rename FullyConnected16x1 to FullyConnected16x1Sparse

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

[onert] Add unittest for shuffled16x1float32

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>