### PR TITLE
[one-cmds] fix typo

### DIFF
--- a/compiler/one-cmds/tests/prepare_test_materials.sh
+++ b/compiler/one-cmds/tests/prepare_test_materials.sh
@@ -49,7 +49,7 @@ if [[ ! -s "bcq.pb" ]]; then
     unzip bcq.pb.zip
 fi
 
-# prepare 'inception_v3.circle' file used for quantizatio test
+# prepare 'inception_v3.circle' file used for quantization test
 inputfile="./inception_v3.pb"
 outputfile="./inception_v3.circle"
 


### PR DESCRIPTION
This commit fixes typo in `prepare_test_materials.sh` sciprt.

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>