### PR TITLE
[luci] Add const to a function in CircleShapeSignature

### DIFF
--- a/compiler/luci/lang/include/luci/IR/CircleShapeSignature.h
+++ b/compiler/luci/lang/include/luci/IR/CircleShapeSignature.h
@@ -34,7 +34,7 @@ public:
   }
 
 public:
-  std::vector<int32_t> as_vector() { return _shape_signature; }
+  const std::vector<int32_t> &as_vector() const { return _shape_signature; }
 
   int32_t dim(uint32_t d) const { return _shape_signature.at(d); }
   int32_t &dim(uint32_t d) { return _shape_signature.at(d); }


### PR DESCRIPTION
Parent Issue : #4372 

If `as_vector()` function do not have `const` keyword, build is failed.
This commit will fix it.

Build fail as following
https://github.com/Samsung/ONE/blob/b11505e89ac277f4177d913d9bdd4de24af3a5bf/compiler/luci/export/src/CircleTensorExporter.cpp#L256

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>