### PR TITLE
[onert/cpu] Initialize LSTMLayer and DepthwiseConvolutionLayer members

### DIFF
--- a/runtime/onert/backend/cpu/ops/DepthwiseConvolutionLayer.cc
+++ b/runtime/onert/backend/cpu/ops/DepthwiseConvolutionLayer.cc
@@ -27,14 +27,6 @@ namespace cpu
 namespace ops
 {
 
-DepthwiseConvolutionLayer::DepthwiseConvolutionLayer()
-    : _input(nullptr), _kernel(nullptr), _bias(nullptr), _output(nullptr), _paddingLeft(0),
-      _paddingTop(0), _paddingRight(0), _paddingBottom(0), _strideWidth(0), _strideHeight(0),
-      _multiplier(0), _activation(ir::Activation::NONE)
-{
-  // DO NOTHING
-}
-
 void DepthwiseConvolutionLayer::convFloat32()
 {
   float output_activation_min = 0, output_activation_max = 0;

--- a/runtime/onert/backend/cpu/ops/DepthwiseConvolutionLayer.h
+++ b/runtime/onert/backend/cpu/ops/DepthwiseConvolutionLayer.h
@@ -34,7 +34,7 @@ namespace ops
 class DepthwiseConvolutionLayer : public ::onert::exec::IFunction
 {
 public:
-  DepthwiseConvolutionLayer();
+  DepthwiseConvolutionLayer() = default;
 
 public:
   void convFloat32();
@@ -52,25 +52,25 @@ public:
   void run() override;
 
 private:
-  const IPortableTensor *_input;
-  const IPortableTensor *_kernel;
-  const IPortableTensor *_bias;
-  IPortableTensor *_output;
+  const IPortableTensor *_input{nullptr};
+  const IPortableTensor *_kernel{nullptr};
+  const IPortableTensor *_bias{nullptr};
+  IPortableTensor *_output{nullptr};
 
-  uint32_t _paddingLeft;
-  uint32_t _paddingTop;
-  uint32_t _paddingRight;
-  uint32_t _paddingBottom;
+  uint32_t _paddingLeft{0};
+  uint32_t _paddingTop{0};
+  uint32_t _paddingRight{0};
+  uint32_t _paddingBottom{0};
 
-  uint32_t _strideWidth;
-  uint32_t _strideHeight;
+  uint32_t _strideWidth{0};
+  uint32_t _strideHeight{0};
 
-  uint32_t _multiplier;
+  uint32_t _multiplier{0};
 
-  uint32_t _dilationWidth;
-  uint32_t _dilationHeight;
+  uint32_t _dilationWidth{1};
+  uint32_t _dilationHeight{1};
 
-  ir::Activation _activation;
+  ir::Activation _activation{ir::Activation::NONE};
 };
 
 } // namespace ops

--- a/runtime/onert/backend/cpu/ops/LSTMLayer.cc
+++ b/runtime/onert/backend/cpu/ops/LSTMLayer.cc
@@ -60,25 +60,6 @@ inline void initializeStateBuffer(const onert::backend::IPortableTensor *tensor_
 }
 }
 
-LSTMLayer::LSTMLayer()
-    : _input(nullptr), _input_to_input_weights(nullptr), _input_to_forget_weights(nullptr),
-      _input_to_cell_weights(nullptr), _input_to_output_weights(nullptr),
-      _recurrent_to_input_weights(nullptr), _recurrent_to_forget_weights(nullptr),
-      _recurrent_to_cell_weights(nullptr), _recurrent_to_output_weights(nullptr),
-      _cell_to_input_weights(nullptr), _cell_to_forget_weights(nullptr),
-      _cell_to_output_weights(nullptr), _input_layer_norm_coefficients(nullptr),
-      _forget_layer_norm_coefficients(nullptr), _cell_layer_norm_coefficients(nullptr),
-      _output_layer_norm_coefficients(nullptr), _input_gate_bias(nullptr),
-      _forget_gate_bias(nullptr), _cell_gate_bias(nullptr), _output_gate_bias(nullptr),
-      _projection_weights(nullptr), _projection_bias(nullptr), _output_state_in(nullptr),
-      _cell_state_in(nullptr), _scratch_buffer(nullptr), _output_state(nullptr),
-      _cell_state(nullptr), _output(nullptr), _scratch_vec(), _output_state_vec(),
-      _cell_state_vec(), _params(), _forward_sequence(true), _time_major(true), _output_offset(0),
-      _has_output_state_data(false), _has_cell_state_data(false)
-{
-  // DO NOTHING
-}
-
 void LSTMLayer::LSTMFloat()
 {
   assert(_input->num_dimensions() >= 2 && _input->num_dimensions() <= 3);

--- a/runtime/onert/backend/cpu/ops/LSTMLayer.h
+++ b/runtime/onert/backend/cpu/ops/LSTMLayer.h
@@ -44,7 +44,7 @@ namespace ops
 class LSTMLayer : public ::onert::exec::IFunction
 {
 public:
-  LSTMLayer();
+  LSTMLayer() = default;
 
 public:
   void LSTMFloat();
@@ -80,48 +80,48 @@ public:
   void run() override;
 
 private:
-  const IPortableTensor *_input;
-  const IPortableTensor *_input_to_input_weights;
-  const IPortableTensor *_input_to_forget_weights;
-  const IPortableTensor *_input_to_cell_weights;
-  const IPortableTensor *_input_to_output_weights;
-  const IPortableTensor *_recurrent_to_input_weights;
-  const IPortableTensor *_recurrent_to_forget_weights;
-  const IPortableTensor *_recurrent_to_cell_weights;
-  const IPortableTensor *_recurrent_to_output_weights;
-  const IPortableTensor *_cell_to_input_weights;
-  const IPortableTensor *_cell_to_forget_weights;
-  const IPortableTensor *_cell_to_output_weights;
-  const IPortableTensor *_input_layer_norm_coefficients;
-  const IPortableTensor *_forget_layer_norm_coefficients;
-  const IPortableTensor *_cell_layer_norm_coefficients;
-  const IPortableTensor *_output_layer_norm_coefficients;
-  const IPortableTensor *_aux_input;
-  const IPortableTensor *_aux_input_to_input_weights;
-  const IPortableTensor *_aux_input_to_forget_weights;
-  const IPortableTensor *_aux_input_to_cell_weights;
-  const IPortableTensor *_aux_input_to_output_weights;
-  const IPortableTensor *_input_gate_bias;
-  const IPortableTensor *_forget_gate_bias;
-  const IPortableTensor *_cell_gate_bias;
-  const IPortableTensor *_output_gate_bias;
-  const IPortableTensor *_projection_weights;
-  const IPortableTensor *_projection_bias;
-  const IPortableTensor *_output_state_in;
-  const IPortableTensor *_cell_state_in;
-  IPortableTensor *_scratch_buffer;
-  IPortableTensor *_output_state;
-  IPortableTensor *_cell_state;
-  IPortableTensor *_output;
-  std::vector<uint8_t> _scratch_vec;
-  std::vector<uint8_t> _output_state_vec;
-  std::vector<uint8_t> _cell_state_vec;
-  ir::operation::LSTM::Param _params;
-  bool _forward_sequence;
-  bool _time_major;
-  int32_t _output_offset;
-  bool _has_output_state_data;
-  bool _has_cell_state_data;
+  const IPortableTensor *_input{nullptr};
+  const IPortableTensor *_input_to_input_weights{nullptr};
+  const IPortableTensor *_input_to_forget_weights{nullptr};
+  const IPortableTensor *_input_to_cell_weights{nullptr};
+  const IPortableTensor *_input_to_output_weights{nullptr};
+  const IPortableTensor *_recurrent_to_input_weights{nullptr};
+  const IPortableTensor *_recurrent_to_forget_weights{nullptr};
+  const IPortableTensor *_recurrent_to_cell_weights{nullptr};
+  const IPortableTensor *_recurrent_to_output_weights{nullptr};
+  const IPortableTensor *_cell_to_input_weights{nullptr};
+  const IPortableTensor *_cell_to_forget_weights{nullptr};
+  const IPortableTensor *_cell_to_output_weights{nullptr};
+  const IPortableTensor *_input_layer_norm_coefficients{nullptr};
+  const IPortableTensor *_forget_layer_norm_coefficients{nullptr};
+  const IPortableTensor *_cell_layer_norm_coefficients{nullptr};
+  const IPortableTensor *_output_layer_norm_coefficients{nullptr};
+  const IPortableTensor *_aux_input{nullptr};
+  const IPortableTensor *_aux_input_to_input_weights{nullptr};
+  const IPortableTensor *_aux_input_to_forget_weights{nullptr};
+  const IPortableTensor *_aux_input_to_cell_weights{nullptr};
+  const IPortableTensor *_aux_input_to_output_weights{nullptr};
+  const IPortableTensor *_input_gate_bias{nullptr};
+  const IPortableTensor *_forget_gate_bias{nullptr};
+  const IPortableTensor *_cell_gate_bias{nullptr};
+  const IPortableTensor *_output_gate_bias{nullptr};
+  const IPortableTensor *_projection_weights{nullptr};
+  const IPortableTensor *_projection_bias{nullptr};
+  const IPortableTensor *_output_state_in{nullptr};
+  const IPortableTensor *_cell_state_in{nullptr};
+  IPortableTensor *_scratch_buffer{nullptr};
+  IPortableTensor *_output_state{nullptr};
+  IPortableTensor *_cell_state{nullptr};
+  IPortableTensor *_output{nullptr};
+  std::vector<uint8_t> _scratch_vec{};
+  std::vector<uint8_t> _output_state_vec{};
+  std::vector<uint8_t> _cell_state_vec{};
+  ir::operation::LSTM::Param _params{};
+  bool _forward_sequence{true};
+  bool _time_major{true};
+  int32_t _output_offset{0};
+  bool _has_output_state_data{false};
+  bool _has_cell_state_data{false};
 };
 
 } // namespace ops


### PR DESCRIPTION
Fix uninitialized member warning: set default value by default member initializer

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>