### PR TITLE
[circle2circle-dredd] Add test for FusePreActivationBatchNormPass

### DIFF
--- a/compiler/circle2circle-dredd-recipe-test/test.lst
+++ b/compiler/circle2circle-dredd-recipe-test/test.lst
@@ -10,6 +10,7 @@
 
 ## TFLITE RECIPE
 
+Add(Net_Preactivation_BN_000 PASS fuse_preactivation_batchnorm)
 Add(Net_TConv_Add_000 PASS fuse_add_with_tconv)
 Add(Net_TConv_Add_001 PASS fuse_add_with_tconv)
 Add(Net_TConv_Add_002 PASS fuse_add_with_tconv)


### PR DESCRIPTION
This adds a test for FusePreActivationBatchNormPass

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: #4773
