### PR TITLE
[onert] Allow size 0 tensors

### DIFF
--- a/compute/cker/include/cker/Shape.h
+++ b/compute/cker/include/cker/Shape.h
@@ -172,7 +172,6 @@ public:
     for (int i = 0; i < _size; i++)
     {
       const int dim = dims_data[i];
-      assert(dim >= 1);
       buffer_size *= dim;
     }
     return buffer_size;

--- a/runtime/onert/core/src/backend/cpu_common/MemoryPlanner.cc
+++ b/runtime/onert/core/src/backend/cpu_common/MemoryPlanner.cc
@@ -27,8 +27,6 @@ namespace cpu_common
 
 void BumpPlanner::claim(const ir::OperandIndex &ind, size_t size)
 {
-  assert(size != 0);
-
   Block blk{_capacity, size};
   _mem_plans[ind] = blk;
   _capacity += size;
@@ -59,8 +57,6 @@ void BumpPlanner::release(const ir::OperandIndex &ind)
 //    the previous claim_base_offset.
 void FirstFitPlanner::claim(const ir::OperandIndex &ind, size_t size)
 {
-  assert(size != 0);
-
   // Find the right position for claiming
   uint32_t next_offset = 0;
   for (auto &mem_claim : _claim_table)
@@ -119,8 +115,6 @@ WICPlanner::WICPlanner()
 
 void WICPlanner::claim(const ir::OperandIndex &ind, size_t size)
 {
-  assert(size != 0);
-
   _operands.emplace(size, ind);
   _interference_graph[ind].insert(_interference_graph[ind].end(), _live_operands.cbegin(),
                                   _live_operands.cend());

--- a/tests/nnfw_api/src/GenModelTest.h
+++ b/tests/nnfw_api/src/GenModelTest.h
@@ -330,7 +330,6 @@ protected:
           _so.outputs[ind].resize(size);
         }
 
-        ASSERT_GT(_so.outputs[ind].size(), 0) << "Please make sure TC output is non-empty.";
         ASSERT_EQ(nnfw_set_output(_so.session, ind, ti.dtype, _so.outputs[ind].data(),
                                   _so.outputs[ind].size()),
                   NNFW_STATUS_NO_ERROR);

--- a/tests/nnfw_api/src/one_op_tests/Add.cc
+++ b/tests/nnfw_api/src/one_op_tests/Add.cc
@@ -84,6 +84,25 @@ TEST_F(GenModelTest, OneOp_Add_VarToVarSame)
   SUCCEED();
 }
 
+TEST_F(GenModelTest, OneOp_Add_VarToVarSize0)
+{
+  CircleGen cgen;
+  int a = cgen.addTensor({{0}, circle::TensorType::TensorType_FLOAT32});
+  int b = cgen.addTensor({{0}, circle::TensorType::TensorType_FLOAT32});
+  int c = cgen.addTensor({{0}, circle::TensorType::TensorType_FLOAT32});
+  int m = cgen.addTensor({{0}, circle::TensorType::TensorType_FLOAT32});
+  int out = cgen.addTensor({{0}, circle::TensorType::TensorType_FLOAT32});
+  cgen.addOperatorAdd({{a, b}, {m}}, circle::ActivationFunctionType_NONE);
+  cgen.addOperatorAdd({{m, c}, {out}}, circle::ActivationFunctionType_NONE);
+  cgen.setInputsAndOutputs({a, b, c}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->addTestCase(uniformTCD<float>({{}, {}, {}}, {{}}));
+  _context->setBackends({"cpu"});
+
+  SUCCEED();
+}
+
 TEST_F(GenModelTest, neg_OneOp_Add_InvalidType)
 {
   CircleGen cgen;
@@ -193,6 +212,25 @@ TEST_F(GenModelTest, neg_OneOp_Add_InvalidActivation)
   _context->addTestCase(uniformTCD<float>({{1, 3, 2, 4}, {5, 4, 7, 4}}, {{6, 7, 9, 8}}));
   _context->setBackends({"cpu"});
   _context->expectFailModelLoad();
+
+  SUCCEED();
+}
+
+TEST_F(GenModelTest, neg_OneOp_Add_VarToVarSize0_InvalidShape)
+{
+  CircleGen cgen;
+  int a = cgen.addTensor({{0}, circle::TensorType::TensorType_FLOAT32});
+  int b = cgen.addTensor({{0}, circle::TensorType::TensorType_FLOAT32});
+  int c = cgen.addTensor({{2}, circle::TensorType::TensorType_FLOAT32});
+  int m = cgen.addTensor({{0}, circle::TensorType::TensorType_FLOAT32});
+  int out = cgen.addTensor({{0}, circle::TensorType::TensorType_FLOAT32});
+  cgen.addOperatorAdd({{a, b}, {m}}, circle::ActivationFunctionType_NONE);
+  cgen.addOperatorAdd({{m, c}, {out}}, circle::ActivationFunctionType_NONE);
+  cgen.setInputsAndOutputs({a, b, c}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->expectFailCompile();
+  _context->setBackends({"cpu"});
 
   SUCCEED();
 }


### PR DESCRIPTION
Allow size 0 tensors in CPU memory planner.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>