### PR TITLE
[onert] Fix dilation parameter setting bug

### DIFF
--- a/runtime/onert/backend/acl_neon/KernelGenerator.cc
+++ b/runtime/onert/backend/acl_neon/KernelGenerator.cc
@@ -240,12 +240,12 @@ void KernelGenerator::visit(const ir::operation::DepthwiseConv2D &node)
   const auto ker_width = ker_shape.dim(2);
 
   const auto stride = node.param().stride;
-  const auto padding = ir::calculatePadding(node.param().padding, ifm_shape, ofm_shape, stride,
-                                            ker_width, ker_height);
+  const auto dilation = node.param().dilation;
+  const auto padding =
+      ir::calculatePadding(node.param().padding, ifm_shape, ofm_shape, stride, ker_width,
+                           ker_height, dilation.width_factor, dilation.height_factor);
   const auto multiplier = node.param().multiplier;
   const auto activation = node.param().activation;
-  const auto dilation = acl_common::asDilation(node.param().dilation.width_factor,
-                                               node.param().dilation.height_factor);
 
   auto ofm_tensor = _tensor_reg->getAclTensor(ofm_index);
   auto ifm_tensor = _tensor_reg->getAclTensor(ifm_index);
@@ -254,14 +254,13 @@ void KernelGenerator::visit(const ir::operation::DepthwiseConv2D &node)
 
   const auto conv_info = acl_common::asPadStrideInfo(padding, stride);
   const auto act_info = acl_common::asActivationLayerInfo(activation);
+  const auto dilation_info = acl_common::asDilation(dilation.width_factor, dilation.height_factor);
 
-  {
-    auto fn = acl_common::generateLayer<arm_compute::NEDepthwiseConvolutionLayer>(
-        ifm_tensor->handle(), ker_tensor->handle(), bias_tensor->handle(), ofm_tensor->handle(),
-        conv_info, multiplier, act_info, dilation);
+  auto fn = acl_common::generateLayer<arm_compute::NEDepthwiseConvolutionLayer>(
+      ifm_tensor->handle(), ker_tensor->handle(), bias_tensor->handle(), ofm_tensor->handle(),
+      conv_info, multiplier, act_info, dilation_info);
 
-    _return_fn = asAclFunction(std::move(fn));
-  }
+  _return_fn = asAclFunction(std::move(fn));
 }
 
 void KernelGenerator::visit(const ir::operation::Concat &node)

--- a/runtime/onert/backend/cpu/KernelGenerator.cc
+++ b/runtime/onert/backend/cpu/KernelGenerator.cc
@@ -355,12 +355,12 @@ void KernelGenerator::visit(const ir::operation::DepthwiseConv2D &node)
   const auto &ker_shape = _ctx.at(ker_index).shape();
   const auto ker_height = ker_shape.dim(1);
   const auto ker_width = ker_shape.dim(2);
-  const auto padding = ir::calculatePadding(node.param().padding, ifm_shape, ofm_shape, stride,
-                                            ker_width, ker_height);
-  const auto multiplier = node.param().multiplier;
-  const auto activation = node.param().activation;
   const auto dilation_width = node.param().dilation.width_factor;
   const auto dilation_height = node.param().dilation.height_factor;
+  const auto padding = ir::calculatePadding(node.param().padding, ifm_shape, ofm_shape, stride,
+                                            ker_width, ker_height, dilation_width, dilation_height);
+  const auto multiplier = node.param().multiplier;
+  const auto activation = node.param().activation;
 
   auto ofm_tensor = _tensor_reg->getPortableTensor(ofm_index);
   auto ifm_tensor = _tensor_reg->getPortableTensor(ifm_index);

--- a/runtime/onert/core/src/ir/OperationValidator.cc
+++ b/runtime/onert/core/src/ir/OperationValidator.cc
@@ -136,8 +136,11 @@ void OperationValidator::visit(const operation::DepthwiseConv2D &node)
 
   uint32_t stride_horizontal = node.param().stride.horizontal;
   uint32_t stride_vertical = node.param().stride.vertical;
+  uint32_t dilation_width = node.param().dilation.width_factor;
+  uint32_t dilation_height = node.param().dilation.height_factor;
 
   OP_REQUIRES((stride_horizontal > 0) && (stride_vertical > 0));
+  OP_REQUIRES((dilation_width > 0) && (dilation_height > 0));
   OP_REQUIRES(isSameType(input_index, output_index));
 }
 

--- a/runtime/onert/core/src/util/ShapeInference.cc
+++ b/runtime/onert/core/src/util/ShapeInference.cc
@@ -361,7 +361,7 @@ ir::Shape inferDepthwiseConv2DShape(const ir::Shape &in_shape, const ir::Shape &
   assert(kf_shape.N == 1);
 
   const auto out_h_w = calcConvLikeHeightAndWidth(ifm_shape.H, ifm_shape.W, kf_shape.H, kf_shape.W,
-                                                  param.padding, param.stride);
+                                                  param.padding, param.stride, param.dilation);
 
   return ir::Shape{ifm_shape.N, out_h_w.first, out_h_w.second, kf_shape.C};
 }

--- a/runtime/onert/test/util/ShapeInference.cc
+++ b/runtime/onert/test/util/ShapeInference.cc
@@ -188,7 +188,7 @@ TEST(ShapeInference, DepthwiseConv2D)
   Shape ker_shape{1, 3, 6, 60};
 
   operation::DepthwiseConv2D::Param param{Stride{3, 7}, Padding{PaddingType::VALID}, 3,
-                                          Activation::NONE};
+                                          Activation::NONE, Dilation{1, 1}};
   auto infered_out_shape =
       onert::shape_inference::inferDepthwiseConv2DShape(in_shape, ker_shape, param);
 
@@ -199,7 +199,7 @@ TEST(ShapeInference, DepthwiseConv2D)
   ASSERT_EQ(infered_out_shape.asFeature(Layout::NHWC).C, 60);
 
   param = operation::DepthwiseConv2D::Param{Stride{3, 7}, Padding{PaddingType::SAME}, 3,
-                                            Activation::NONE};
+                                            Activation::NONE, Dilation{1, 1}};
   infered_out_shape = onert::shape_inference::inferDepthwiseConv2DShape(in_shape, ker_shape, param);
 
   ASSERT_EQ(infered_out_shape.rank(), 4);
@@ -208,7 +208,8 @@ TEST(ShapeInference, DepthwiseConv2D)
   ASSERT_EQ(infered_out_shape.asFeature(Layout::NHWC).W, 2);
   ASSERT_EQ(infered_out_shape.asFeature(Layout::NHWC).C, 60);
 
-  param = operation::DepthwiseConv2D::Param{Stride{3, 7}, Padding{4, 3, 2, 1}, 3, Activation::NONE};
+  param = operation::DepthwiseConv2D::Param{Stride{3, 7}, Padding{4, 3, 2, 1}, 3, Activation::NONE,
+                                            Dilation{1, 1}};
   infered_out_shape = onert::shape_inference::inferDepthwiseConv2DShape(in_shape, ker_shape, param);
 
   ASSERT_EQ(infered_out_shape.rank(), 4);
@@ -224,7 +225,7 @@ TEST(ShapeInference, neg_DepthwiseConv2D_InvalidSride)
   Shape ker_shape{1, 3, 6, 60};
 
   operation::DepthwiseConv2D::Param param{Stride{3, 0}, Padding{PaddingType::VALID}, 3,
-                                          Activation::NONE};
+                                          Activation::NONE, Dilation{1, 1}};
   ASSERT_THROW(onert::shape_inference::inferDepthwiseConv2DShape(in_shape, ker_shape, param),
                std::runtime_error);
 }


### PR DESCRIPTION
- Fix shape inference when dilation is not 1
- Fix cpu/acl-cl/acl-neon padding info setting when dilation is not 1
- Check dilation param validation
- Add 1 positive and 1 negative tests

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: #4828
Fix bug when padding is same padding