### PR TITLE
[onert/cpu] Use vector for AddN variable input tensor configuration

### DIFF
--- a/runtime/onert/backend/cpu/KernelGenerator.cc
+++ b/runtime/onert/backend/cpu/KernelGenerator.cc
@@ -226,8 +226,6 @@ void KernelGenerator::visit(const ir::operation::AddN &node)
 {
   const auto output_index{node.getOutputs().at(0)};
 
-  int size = node.getInputs().size();
-
   std::vector<const IPortableTensor *> input_tensors;
   for (auto &input_idx : node.getInputs())
     input_tensors.emplace_back(_tensor_reg->getPortableTensor(input_idx));
@@ -236,7 +234,7 @@ void KernelGenerator::visit(const ir::operation::AddN &node)
 
   auto fn = std::make_unique<ops::AddNLayer>();
 
-  fn->configure(std::move(input_tensors), size, output_tensor);
+  fn->configure(std::move(input_tensors), output_tensor);
 
   _return_fn = std::move(fn);
 }

--- a/runtime/onert/backend/cpu/KernelGenerator.cc
+++ b/runtime/onert/backend/cpu/KernelGenerator.cc
@@ -227,21 +227,16 @@ void KernelGenerator::visit(const ir::operation::AddN &node)
   const auto output_index{node.getOutputs().at(0)};
 
   int size = node.getInputs().size();
-  const IPortableTensor **input_tensors =
-      (const IPortableTensor **)malloc(sizeof(IPortableTensor *) * size);
 
-  for (int i = 0; i < size; i++)
-  {
-    const auto input_index{node.getInputs().at(i)};
-    auto input_tensor = _tensor_reg->getPortableTensor(input_index);
-    input_tensors[i] = input_tensor;
-  }
+  std::vector<const IPortableTensor *> input_tensors;
+  for (auto &input_idx : node.getInputs())
+    input_tensors.emplace_back(_tensor_reg->getPortableTensor(input_idx));
 
   auto output_tensor = _tensor_reg->getPortableTensor(output_index);
 
   auto fn = std::make_unique<ops::AddNLayer>();
 
-  fn->configure(input_tensors, size, output_tensor);
+  fn->configure(std::move(input_tensors), size, output_tensor);
 
   _return_fn = std::move(fn);
 }

--- a/runtime/onert/backend/cpu/ops/AddNLayer.cc
+++ b/runtime/onert/backend/cpu/ops/AddNLayer.cc
@@ -30,34 +30,33 @@ namespace cpu
 namespace ops
 {
 
-void AddNLayer::configure(std::vector<const IPortableTensor *> &&inputs, size_t num_inputs,
-                          IPortableTensor *output)
+void AddNLayer::configure(std::vector<const IPortableTensor *> &&inputs, IPortableTensor *output)
 {
   _inputs = std::move(inputs);
-  _num_inputs = num_inputs;
   _output = output;
 }
 
 void AddNLayer::run()
 {
+  size_t input_size = _inputs.size();
   if (_output->data_type() == ir::DataType::INT32)
   {
-    std::vector<const int32_t *> input_buffers(_num_inputs);
-    for (size_t i = 0; i < _num_inputs; i++)
+    std::vector<const int32_t *> input_buffers(input_size);
+    for (size_t i = 0; i < input_size; i++)
     {
       input_buffers[i] = reinterpret_cast<int32_t *>(_inputs[i]->buffer());
     }
-    AddN(getTensorShape(_inputs[0]), _num_inputs, input_buffers.data(),
+    AddN(getTensorShape(_inputs[0]), input_size, input_buffers.data(),
          reinterpret_cast<int32_t *>(_output->buffer()));
   }
   else if (_output->data_type() == ir::DataType::FLOAT32)
   {
-    std::vector<const float *> input_buffers(_num_inputs);
-    for (size_t i = 0; i < _num_inputs; i++)
+    std::vector<const float *> input_buffers(input_size);
+    for (size_t i = 0; i < input_size; i++)
     {
       input_buffers[i] = reinterpret_cast<float *>(_inputs[i]->buffer());
     }
-    AddN(getTensorShape(_inputs[0]), _num_inputs, input_buffers.data(),
+    AddN(getTensorShape(_inputs[0]), input_size, input_buffers.data(),
          reinterpret_cast<float *>(_output->buffer()));
   }
   else

--- a/runtime/onert/backend/cpu/ops/AddNLayer.cc
+++ b/runtime/onert/backend/cpu/ops/AddNLayer.cc
@@ -30,10 +30,10 @@ namespace cpu
 namespace ops
 {
 
-void AddNLayer::configure(const IPortableTensor **inputs, size_t num_inputs,
+void AddNLayer::configure(std::vector<const IPortableTensor *> &&inputs, size_t num_inputs,
                           IPortableTensor *output)
 {
-  _inputs = inputs;
+  _inputs = std::move(inputs);
   _num_inputs = num_inputs;
   _output = output;
 }

--- a/runtime/onert/backend/cpu/ops/AddNLayer.h
+++ b/runtime/onert/backend/cpu/ops/AddNLayer.h
@@ -33,17 +33,15 @@ namespace ops
 class AddNLayer : public ::onert::exec::IFunction
 {
 public:
-  AddNLayer() : _inputs(), _num_inputs(0), _output(nullptr) {}
+  AddNLayer() : _inputs(), _output(nullptr) {}
 
 public:
-  void configure(std::vector<const IPortableTensor *> &&inputs, size_t num_inputs,
-                 IPortableTensor *output);
+  void configure(std::vector<const IPortableTensor *> &&inputs, IPortableTensor *output);
 
   void run() override;
 
 private:
   std::vector<const IPortableTensor *> _inputs;
-  size_t _num_inputs;
   IPortableTensor *_output;
 };
 

--- a/runtime/onert/backend/cpu/ops/AddNLayer.h
+++ b/runtime/onert/backend/cpu/ops/AddNLayer.h
@@ -33,15 +33,16 @@ namespace ops
 class AddNLayer : public ::onert::exec::IFunction
 {
 public:
-  AddNLayer() : _inputs(nullptr), _num_inputs(0), _output(nullptr) {}
+  AddNLayer() : _inputs(), _num_inputs(0), _output(nullptr) {}
 
 public:
-  void configure(const IPortableTensor **inputs, size_t num_inputs, IPortableTensor *output);
+  void configure(std::vector<const IPortableTensor *> &&inputs, size_t num_inputs,
+                 IPortableTensor *output);
 
   void run() override;
 
 private:
-  const IPortableTensor **_inputs;
+  std::vector<const IPortableTensor *> _inputs;
   size_t _num_inputs;
   IPortableTensor *_output;
 };


### PR DESCRIPTION
Use vector in KernelGenerator for AddN variable input tensor configuration
Remove _num_inputs member in AddNLayer 

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>