### PR TITLE
[one-cmds] Add new options to one-optimize

### DIFF
--- a/compiler/one-cmds/how-to-use-one-commands.txt
+++ b/compiler/one-cmds/how-to-use-one-commands.txt
@@ -156,6 +156,11 @@ Current transformation options are
 - fuse_instnorm: This will convert instance normalization related operators to
   one InstanceNormalization operator that our onert provides for faster
   execution.
+- fuse_preactivation_batchnorm: This fuses batch normalization operators of pre-activations to Conv operators.
+- fuse_activation_function: This fuses Activation function to a preceding operator.
+- make_batchnorm_gamma_positive: This makes negative gamma of batch normalization into a small positive value (1e-10).
+  Note that this pass can change the execution result of the model.
+  So, use it only when the impact is known to be acceptable.
 - resolve_customop_add: This will convert Custom(Add) to normal Add operator
 - resolve_customop_batchmatmul: This will convert Custom(BatchMatMul) to
   normal BatchMatMul operator

--- a/compiler/one-cmds/one-optimize
+++ b/compiler/one-cmds/one-optimize
@@ -57,6 +57,12 @@ def _get_parser():
     circle2circle_group.add_argument(
         '--fuse_bcq', action='store_true', help='apply Binary Coded Quantization')
     circle2circle_group.add_argument(
+        '--fuse_preactivation_batchnorm', action='store_true', help='fuse BatchNorm operators of pre-activations to Convolution operator')
+    circle2circle_group.add_argument(
+        '--make_batchnorm_gamma_positive', action='store_true', help='make negative gamma of BatchNorm into a small positive value (1e-10). Note that this pass can change the execution result of the model. So, use it only when the impact is known to be acceptable.')
+    circle2circle_group.add_argument(
+        '--fuse_activation_function', action='store_true', help='fuse Activation function to a preceding operator')
+    circle2circle_group.add_argument(
         '--fuse_instnorm', action='store_true', help='fuse ops to InstanceNorm operator')
     circle2circle_group.add_argument(
         '--resolve_customop_add',

--- a/compiler/one-cmds/one-optimize
+++ b/compiler/one-cmds/one-optimize
@@ -57,11 +57,19 @@ def _get_parser():
     circle2circle_group.add_argument(
         '--fuse_bcq', action='store_true', help='apply Binary Coded Quantization')
     circle2circle_group.add_argument(
-        '--fuse_preactivation_batchnorm', action='store_true', help='fuse BatchNorm operators of pre-activations to Convolution operator')
+        '--fuse_preactivation_batchnorm',
+        action='store_true',
+        help='fuse BatchNorm operators of pre-activations to Convolution op')
     circle2circle_group.add_argument(
-        '--make_batchnorm_gamma_positive', action='store_true', help='make negative gamma of BatchNorm into a small positive value (1e-10). Note that this pass can change the execution result of the model. So, use it only when the impact is known to be acceptable.')
+        '--make_batchnorm_gamma_positive',
+        action='store_true',
+        help="""make negative gamma of BatchNorm to a small positive value (1e-10).
+        Note that this pass can change the execution result of the model.
+        So, use it only when the impact is known to be acceptable.""")
     circle2circle_group.add_argument(
-        '--fuse_activation_function', action='store_true', help='fuse Activation function to a preceding operator')
+        '--fuse_activation_function',
+        action='store_true',
+        help='fuse Activation function to a preceding operator')
     circle2circle_group.add_argument(
         '--fuse_instnorm', action='store_true', help='fuse ops to InstanceNorm operator')
     circle2circle_group.add_argument(


### PR DESCRIPTION
This adds three new options to one-optimize
--fuse_preactivation_batchnrom
--make_batchnorm_gamma_positive
--fuse_activation_function

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/4773