### PR TITLE
[res] Add PyTorchExamples of AdaptiveMaxPool2d

### DIFF
--- a/res/PyTorchExamples/examples/AdaptiveMaxPool2d/__init__.py
+++ b/res/PyTorchExamples/examples/AdaptiveMaxPool2d/__init__.py
@@ -1,0 +1,18 @@
+import torch
+import torch.nn as nn
+
+
+# model
+class net_AdaptiveMaxPool2d(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.op = nn.AdaptiveMaxPool2d(1)
+
+    def forward(self, input):
+        return self.op(input)
+
+
+_model_ = net_AdaptiveMaxPool2d()
+
+# dummy input for onnx generation
+_dummy_ = torch.randn(1, 2, 3, 3)


### PR DESCRIPTION
Parent Issue: #4830 
Fired Issue: #4889 

This commit adds PyTorch Example of nn.AdaptiveMaxPool2d.

Tested with `ptem,py` and passed the test.

Please review this PR, @seanshpark .
I'll be happy to get feedback and change to make improvement.

Thank you.

(Derived from SOS Mine Project)

Signed-off-by: underflow101 <ikarus125@gmail.com>