### PR TITLE
[res] PyTorchExamples for LSTM, RNN

### DIFF
--- a/res/PyTorchExamples/examples/LSTM/__init__.py
+++ b/res/PyTorchExamples/examples/LSTM/__init__.py
@@ -1,0 +1,20 @@
+import torch
+import torch.nn as nn
+
+
+# model
+class net_LSTM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.op = nn.LSTM(10, 20, 1)
+
+    def forward(self, inputs):
+        return self.op(inputs[0], (inputs[1], inputs[2]))
+
+
+_model_ = net_LSTM()
+
+# dummy input for onnx generation
+_dummy_ = [torch.randn(5, 3, 10), torch.randn(1, 3, 20), torch.randn(1, 3, 20)]
+
+# Note: this model has problem when converting ONNX to TensorFlow

--- a/res/PyTorchExamples/examples/RNN/__init__.py
+++ b/res/PyTorchExamples/examples/RNN/__init__.py
@@ -1,0 +1,20 @@
+import torch
+import torch.nn as nn
+
+
+# model
+class net_RNN(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.op = nn.RNN(2, 2, 1)
+
+    def forward(self, inputs):
+        return self.op(inputs[0], inputs[1])
+
+
+_model_ = net_RNN()
+
+# dummy input for onnx generation
+_dummy_ = [torch.randn(2, 2, 2), torch.randn(1, 2, 2)]
+
+# Note: this model has problem when converting ONNX to TensorFlow


### PR DESCRIPTION
This will introduce PyTorchExamples for LSTM and RNN
- These two fails to convert from ONNX to TensorFlow as of now

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>