### PR TITLE
[res] PyTorchExamples for logical Ops

### DIFF
--- a/res/PyTorchExamples/examples/logical_and/__init__.py
+++ b/res/PyTorchExamples/examples/logical_and/__init__.py
@@ -1,0 +1,19 @@
+import torch
+import torch.nn as nn
+
+
+# model
+class net_logical_and(nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, inputs):
+        return torch.logical_and(inputs[0], inputs[1])
+
+
+_model_ = net_logical_and()
+
+# dummy input for onnx generation
+_dummy_ = [torch.randn(1, 2, 3, 3).bool(), torch.randn(1, 2, 3, 3).bool()]
+
+# Note: this model has problem when exporting to ONNX

--- a/res/PyTorchExamples/examples/logical_or/__init__.py
+++ b/res/PyTorchExamples/examples/logical_or/__init__.py
@@ -1,0 +1,19 @@
+import torch
+import torch.nn as nn
+
+
+# model
+class net_logical_or(nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, inputs):
+        return torch.logical_or(inputs[0], inputs[1])
+
+
+_model_ = net_logical_or()
+
+# dummy input for onnx generation
+_dummy_ = [torch.randn(1, 2, 3, 3).bool(), torch.randn(1, 2, 3, 3).bool()]
+
+# Note: this model has problem when exporting to ONNX

--- a/res/PyTorchExamples/examples/logical_xor/__init__.py
+++ b/res/PyTorchExamples/examples/logical_xor/__init__.py
@@ -1,0 +1,19 @@
+import torch
+import torch.nn as nn
+
+
+# model
+class net_logical_xor(nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, inputs):
+        return torch.logical_xor(inputs[0], inputs[1])
+
+
+_model_ = net_logical_xor()
+
+# dummy input for onnx generation
+_dummy_ = [torch.randn(1, 2, 3, 3).bool(), torch.randn(1, 2, 3, 3).bool()]
+
+# Note: this model has problem when exporting to ONNX


### PR DESCRIPTION
This will introduce PyTorchExamples for logical_and, logical_or and logical_xor
- These have problem exporting to ONNX as of now

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>