### PR TITLE
[cker] Initialize broadcast_category field

### DIFF
--- a/compute/cker/include/cker/Types.h
+++ b/compute/cker/include/cker/Types.h
@@ -172,7 +172,7 @@ struct ComparisonParams
 struct BinaryArithmeticOpParam
 {
   // Shape dependent / common to data / op types.
-  BroadcastableOpCategory broadcast_category;
+  BroadcastableOpCategory broadcast_category{BroadcastableOpCategory::kNone};
   // uint8 inference params.
   int32_t input1_offset;
   int32_t input2_offset;


### PR DESCRIPTION
Set default value of BinaryArithmeticOpParam's  broadcast_category field

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Resolve coverity warning: CID 1193045