### PR TITLE
[res] PyTorchExamples add note to Bilinear

### DIFF
--- a/res/PyTorchExamples/examples/Bilinear/__init__.py
+++ b/res/PyTorchExamples/examples/Bilinear/__init__.py
@@ -16,3 +16,5 @@ _model_ = net_Bilinear()
 
 # dummy input for onnx generation
 _dummy_ = [torch.randn(128, 20), torch.randn(128, 30)]
+
+# Note: this model has problem when exporting to ONNX


### PR DESCRIPTION
This will add a note to Bilinear PyTorchExample that has problem
exporting to ONNX

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>