### PR TITLE
[onert] Add more ops into OneOp_While test

### DIFF
--- a/runtime/onert/core/src/backend/controlflow/kernel/PermuteLayer.cc
+++ b/runtime/onert/core/src/backend/controlflow/kernel/PermuteLayer.cc
@@ -55,7 +55,10 @@ void PermuteLayer::optimize()
     {
       auto src = *src_it;
       auto dst = *dst_it;
-      assert(underlying_type(src->data_type()) == underlying_type(dst->data_type()));
+
+      if (underlying_type(src->data_type()) != underlying_type(dst->data_type()))
+        throw std::runtime_error("data type does not match");
+
       const auto permute_type = [&]() -> PermuteType {
         if (src->num_dimensions() == 4 && src->layout() == ir::Layout::NHWC &&
             dst->layout() == ir::Layout::NCHW)


### PR DESCRIPTION
This add `cast` before calling `while` and 
add another `cast` after calling `while`. 


This is to check if input and output of `while` is handled well.

for issue https://github.com/Samsung/ONE/issues/4901 to check if we also see other ops well before and after `while`.

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>