### PR TITLE
[onert] Change 'backend' field of chrome tracing

### DIFF
--- a/runtime/onert/core/src/exec/ExecutionObservers.cc
+++ b/runtime/onert/core/src/exec/ExecutionObservers.cc
@@ -37,16 +37,16 @@ void setHexId(const void *src, std::string &hex_id)
 }
 
 // category is shown as a row in Chrome Tracing
-std::string getSubgraphCatetory(const onert::exec::IExecutor *executor)
+std::string getSubgraphCategory(const onert::exec::IExecutor *executor)
 {
   std::string hex_id;
   setHexId(executor, hex_id);
   return "Subgraph(" + hex_id + ")";
 }
 
-std::string getOpCatetory(const onert::exec::IExecutor *executor, const std::string &backend_id)
+std::string getOpCategory(const onert::exec::IExecutor *executor, const std::string &backend_id)
 {
-  return getSubgraphCatetory(executor) + ": " + backend_id;
+  return getSubgraphCategory(executor) + ": " + backend_id;
 }
 
 } // namespace
@@ -116,14 +116,14 @@ ChromeTracingObserver::~ChromeTracingObserver()
 
 void ChromeTracingObserver::handleBegin(IExecutor *executor)
 {
-  std::string category(getSubgraphCatetory(executor));
+  std::string category(getSubgraphCategory(executor));
   _collector.onEvent(EventCollector::Event{EventCollector::Edge::BEGIN, category, "Subgraph"});
 }
 
 void ChromeTracingObserver::handleBegin(IExecutor *executor, const ir::OpSequence *op_seq,
                                         const backend::Backend *backend)
 {
-  std::string category(getOpCatetory(executor, backend->config()->id()));
+  std::string category(getOpCategory(executor, backend->config()->id()));
   _collector.onEvent(EventCollector::Event{EventCollector::Edge::BEGIN, category,
                                            opSequenceTag(op_seq, _graph.operations())});
 }
@@ -131,14 +131,14 @@ void ChromeTracingObserver::handleBegin(IExecutor *executor, const ir::OpSequenc
 void ChromeTracingObserver::handleEnd(IExecutor *executor, const ir::OpSequence *op_seq,
                                       const backend::Backend *backend)
 {
-  std::string category(getOpCatetory(executor, backend->config()->id()));
+  std::string category(getOpCategory(executor, backend->config()->id()));
   _collector.onEvent(EventCollector::Event{EventCollector::Edge::END, category,
                                            opSequenceTag(op_seq, _graph.operations())});
 }
 
 void ChromeTracingObserver::handleEnd(IExecutor *executor)
 {
-  std::string category(getSubgraphCatetory(executor));
+  std::string category(getSubgraphCategory(executor));
   _collector.onEvent(EventCollector::Event{EventCollector::Edge::END, category, "Subgraph"});
 }
 

--- a/runtime/onert/core/src/util/EventCollector.cc
+++ b/runtime/onert/core/src/util/EventCollector.cc
@@ -93,11 +93,11 @@ void EventCollector::onEvent(const Event &event)
   switch (event.edge)
   {
     case Edge::BEGIN:
-      _rec->emit(DurationEventBuilder(ts).build(event.backend, event.label, "B"));
+      _rec->emit(DurationEventBuilder(ts).build(event.category, event.label, "B"));
       break;
 
     case Edge::END:
-      _rec->emit(DurationEventBuilder(ts).build(event.backend, event.label, "E"));
+      _rec->emit(DurationEventBuilder(ts).build(event.category, event.label, "E"));
       break;
   }
 

--- a/runtime/onert/core/src/util/EventCollector.h
+++ b/runtime/onert/core/src/util/EventCollector.h
@@ -31,7 +31,7 @@ public:
   struct Event
   {
     Edge edge;
-    std::string backend;
+    std::string category;
     std::string label;
   };
 

--- a/runtime/onert/core/src/util/EventWriter.cc
+++ b/runtime/onert/core/src/util/EventWriter.cc
@@ -313,7 +313,7 @@ struct MDTableBuilder
       for (size_t i = begin_idx + 1; i < end_idx; ++i)
       {
         const auto &evt = _duration_events[i];
-        assert(evt.name.compare("Graph") != 0);
+        assert(evt.name.compare("Subgraph") != 0);
         assert(evt.ph.compare("B") == 0 || evt.ph.compare("E") == 0);
         if (evt.ph.compare("B") == 0)
         {
@@ -340,7 +340,7 @@ struct MDTableBuilder
     for (size_t i = 0, begin_idx = 0; i < _duration_events.size(); ++i)
     {
       const auto &evt = _duration_events.at(i);
-      if (evt.name.compare("Graph") == 0)
+      if (evt.name.compare("Subgraph") == 0)
       {
         if (evt.ph.compare("B") == 0)
           begin_idx = i;
@@ -383,7 +383,7 @@ struct MDTableBuilder
                   const std::map<std::string, OpSeq> &name_to_opseq)
   {
     Graph graph;
-    graph.name = "Graph";
+    graph.name = "Subgraph";
     graph.begin_ts = std::stoull(_duration_events[begin_idx].ts);
     graph.end_ts = std::stoull(_duration_events[end_idx].ts);
     graph.setOpSeqs(name_to_opseq);


### PR DESCRIPTION
For #4901
Draft #4903

This changes `backend` field of chrome tracing to `category` and put subgraph and backend info into `category`.

Consider we have a model that has 2 subgraphs that runs on CPU. Only with `backend`, CPU backend of subgraph A and suggraph B cannot be distinguished. So now it has subgraph info as well as backend info.

For subgraph level, previously `backend` contains `"Runtime"` string which is not quite right. So I changed the name to `category`. 

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>