### PR TITLE
[res] Add PyTorchExamples of where

### DIFF
--- a/res/PyTorchExamples/examples/where/__init__.py
+++ b/res/PyTorchExamples/examples/where/__init__.py
@@ -1,0 +1,17 @@
+import torch
+import torch.nn as nn
+
+
+# model
+class net_where(nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, inputs):
+        return torch.where(inputs[0] > 0, inputs[0], inputs[1])
+
+
+_model_ = net_where()
+
+# dummy input for onnx generation
+_dummy_ = [torch.randn(1, 2, 3, 3), torch.ones(1, 2, 3, 3)]


### PR DESCRIPTION
Parent Issue: #4830 
Fired Issue: #4908 

This commit adds PyTorch Example of where.

Tested with `ptem,py` and passed the test.

Please review this PR, @seanshpark .
I'll be happy to get feedback and change to make improvement.

Thank you.

(Derived from SOS Mine Project)

Signed-off-by: underflow101 <ikarus125@gmail.com>