### PR TITLE
[luci-interpreter] Support CWQ convolution op 

### DIFF
--- a/compiler/luci-interpreter/include/luci_interpreter/core/Tensor.h
+++ b/compiler/luci-interpreter/include/luci_interpreter/core/Tensor.h
@@ -101,7 +101,7 @@ public:
     return _quantization.scale[0];
   }
 
-  float zero_point() const
+  int32_t zero_point() const
   {
     assert(_quantization.zero_point.size() == 1);
     return _quantization.zero_point[0];

--- a/compiler/luci-interpreter/src/kernels/Conv2D.cpp
+++ b/compiler/luci-interpreter/src/kernels/Conv2D.cpp
@@ -203,6 +203,50 @@ void Conv2D::evalQuantized() const
       getTensorData<uint8_t>(_im2col.get()), gemmlowp_context.get());
 }
 
+// Helper wrapper to hide broadcast logic
+template <typename T>
+class BroadcastableWrapper
+{
+public:
+  BroadcastableWrapper(const std::vector<T> &v) : _v(v), _stride(v.size() == 1 ? 0: 1) {}
+
+  T operator[](int idx) { return _v[idx*_stride]; }
+private:
+  const std::vector<T> &_v;
+  int _stride;
+};
+
+struct ChannelQuantMultipliers
+{
+  int shift;
+  int32_t multiplier;
+  ChannelQuantMultipliers() = default;
+};
+
+std::vector<double> getQuantizedConvolutionMultiplers(float input_scale, const std::vector<float> &filter_scale, float output_scale)
+{
+  std::vector<double> effective_output_scales;
+  size_t n = filter_scale.size();
+  effective_output_scales.reserve(n);
+  for (size_t i = 0; i < n; ++i)
+  {
+    effective_output_scales.push_back(
+        getQuantizedConvolutionMultipler(input_scale, filter_scale[i], output_scale));
+  }
+  return effective_output_scales;
+}
+
+std::vector<ChannelQuantMultipliers> quantizeMultipliers(const std::vector<double> &effective_scale)
+{
+  size_t n = effective_scale.size();
+  std::vector<ChannelQuantMultipliers> params(n);
+  for (int i = 0; i < n; ++i)
+  {
+    quantizeMultiplier(effective_scale[i], &params[i].multiplier, &params[i].shift);
+  }
+  return params;
+}
+
 void Conv2D::evalQuantizedS16() const
 {
   const auto *input_data = getTensorData<int16_t>(input());
@@ -233,12 +277,10 @@ void Conv2D::evalQuantizedS16() const
   int32_t activation_max{};
   calculateActivationRangeQuantized(_params.activation, output(), &activation_min, &activation_max);
 
-  const double effective_output_scale =
-      getQuantizedConvolutionMultipler(input()->scale(), filter()->scale(), output()->scale());
+  const std::vector<double> effective_output_scale = getQuantizedConvolutionMultiplers(input()->scale(), filter()->scales(), output()->scale());
 
-  int32_t output_multiplier{};
-  int output_shift{};
-  quantizeMultiplier(effective_output_scale, &output_multiplier, &output_shift);
+  const std::vector<ChannelQuantMultipliers> multipliers_raw = quantizeMultipliers(effective_output_scale);
+  BroadcastableWrapper<ChannelQuantMultipliers> multipliers(multipliers_raw);
 
   for (int32_t batch = 0; batch < batches; ++batch)
   {
@@ -276,7 +318,7 @@ void Conv2D::evalQuantizedS16() const
           }
 
           int32_t scaled_acc =
-              tflite::MultiplyByQuantizedMultiplier(acc, output_multiplier, output_shift);
+              tflite::MultiplyByQuantizedMultiplier(acc, multipliers[out_c].multiplier, multipliers[out_c].shift);
 
           scaled_acc = std::max(scaled_acc, activation_min);
           scaled_acc = std::min(scaled_acc, activation_max);

--- a/compiler/luci-interpreter/src/kernels/Conv2D.cpp
+++ b/compiler/luci-interpreter/src/kernels/Conv2D.cpp
@@ -241,7 +241,7 @@ std::vector<ChannelQuantMultipliers> quantizeMultipliers(const std::vector<doubl
 {
   size_t n = effective_scale.size();
   std::vector<ChannelQuantMultipliers> params(n);
-  for (int i = 0; i < n; ++i)
+  for (size_t i = 0; i < n; ++i)
   {
     quantizeMultiplier(effective_scale[i], &params[i].multiplier, &params[i].shift);
   }

--- a/compiler/luci-interpreter/src/kernels/Conv2D.cpp
+++ b/compiler/luci-interpreter/src/kernels/Conv2D.cpp
@@ -204,13 +204,12 @@ void Conv2D::evalQuantized() const
 }
 
 // Helper wrapper to hide broadcast logic
-template <typename T>
-class BroadcastableWrapper
+template <typename T> class BroadcastableWrapper
 {
 public:
-  BroadcastableWrapper(const std::vector<T> &v) : _v(v), _stride(v.size() == 1 ? 0: 1) {}
+  BroadcastableWrapper(const std::vector<T> &v) : _v(v), _stride(v.size() == 1 ? 0 : 1) {}
 
-  T operator[](int idx) { return _v[idx*_stride]; }
+  T operator[](int idx) { return _v[idx * _stride]; }
 private:
   const std::vector<T> &_v;
   int _stride;
@@ -223,7 +222,9 @@ struct ChannelQuantMultipliers
   ChannelQuantMultipliers() = default;
 };
 
-std::vector<double> getQuantizedConvolutionMultiplers(float input_scale, const std::vector<float> &filter_scale, float output_scale)
+std::vector<double> getQuantizedConvolutionMultiplers(float input_scale,
+                                                      const std::vector<float> &filter_scale,
+                                                      float output_scale)
 {
   std::vector<double> effective_output_scales;
   size_t n = filter_scale.size();
@@ -277,9 +278,11 @@ void Conv2D::evalQuantizedS16() const
   int32_t activation_max{};
   calculateActivationRangeQuantized(_params.activation, output(), &activation_min, &activation_max);
 
-  const std::vector<double> effective_output_scale = getQuantizedConvolutionMultiplers(input()->scale(), filter()->scales(), output()->scale());
+  const std::vector<double> effective_output_scale =
+      getQuantizedConvolutionMultiplers(input()->scale(), filter()->scales(), output()->scale());
 
-  const std::vector<ChannelQuantMultipliers> multipliers_raw = quantizeMultipliers(effective_output_scale);
+  const std::vector<ChannelQuantMultipliers> multipliers_raw =
+      quantizeMultipliers(effective_output_scale);
   BroadcastableWrapper<ChannelQuantMultipliers> multipliers(multipliers_raw);
 
   for (int32_t batch = 0; batch < batches; ++batch)
@@ -317,8 +320,8 @@ void Conv2D::evalQuantizedS16() const
             acc += bias_data[out_c];
           }
 
-          int32_t scaled_acc =
-              tflite::MultiplyByQuantizedMultiplier(acc, multipliers[out_c].multiplier, multipliers[out_c].shift);
+          int32_t scaled_acc = tflite::MultiplyByQuantizedMultiplier(
+              acc, multipliers[out_c].multiplier, multipliers[out_c].shift);
 
           scaled_acc = std::max(scaled_acc, activation_min);
           scaled_acc = std::min(scaled_acc, activation_max);

--- a/compiler/luci-interpreter/src/kernels/Conv2D.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/Conv2D.test.cpp
@@ -229,16 +229,16 @@ TEST(Conv2DTest, SInt16_CWQ_weights)
       7, 8, // row = 1, col 1
   };
   std::vector<float> filter_data{
-      4,  -3, // out = 0
-      1, -3,  // out = 1
-      5,  -3, // out = 2
+      4, -3, // out = 0
+      1, -3, // out = 1
+      5, -3, // out = 2
   };
   std::vector<float> bias_data{1, 10, 5};
   std::vector<float> ref_output_data{
-      0, 5, 4,   // row 0, col 0
-      1, 1, 8,   // row 0, col 1
-      3, 0, 12,  // row 1, col 0
-      5, 0, 16,  // row 1, col 1
+      0, 5, 4,  // row 0, col 0
+      1, 1, 8,  // row 0, col 1
+      3, 0, 12, // row 1, col 0
+      5, 0, 16, // row 1, col 1
   };
 
   float input_scale = 0.25f;

--- a/compiler/luci-interpreter/src/kernels/Conv2D.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/Conv2D.test.cpp
@@ -215,6 +215,62 @@ TEST(Conv2DTest, SInt16)
   EXPECT_THAT(dequantizeTensorData(output_tensor), FloatArrayNear(ref_output_data));
 }
 
+TEST(Conv2DTest, SInt16_CWQ_weights)
+{
+  Shape input_shape{1, 2, 2, 2};  // Batch x H x W x C
+  Shape filter_shape{3, 1, 1, 2}; // Out channels x H x W x In Channels
+  Shape bias_shape{3};
+  std::vector<int32_t> ref_output_shape{1, 2, 2, 3};
+
+  std::vector<float> input_data{
+      1, 2, // row = 0, col 0
+      3, 4, // row = 0, col 1
+      5, 6, // row = 1, col 0
+      7, 8, // row = 1, col 1
+  };
+  std::vector<float> filter_data{
+      4,  -3, // out = 0
+      1, -3,  // out = 1
+      5,  -3, // out = 2
+  };
+  std::vector<float> bias_data{1, 10, 5};
+  std::vector<float> ref_output_data{
+      0, 5, 4,   // row 0, col 0
+      1, 1, 8,   // row 0, col 1
+      3, 0, 12,  // row 1, col 0
+      5, 0, 16,  // row 1, col 1
+  };
+
+  float input_scale = 0.25f;
+  float output_scale = 0.05f;
+  std::vector<float> filter_scales = {0.25f, 0.2f, 0.1f};
+  std::vector<float> bias_scales;
+  for (int i = 0; i < filter_scales.size(); ++i)
+    bias_scales.push_back(filter_scales[i] * input_scale);
+  std::vector<int32_t> zerop = {0, 0, 0};
+
+  Tensor input_tensor = makeInputTensor<DataType::S16>(input_shape, input_scale, 0, input_data);
+  Tensor filter_tensor =
+      makeInputTensor<DataType::S16>(filter_shape, filter_scales, zerop, 0, filter_data);
+  Tensor bias_tensor = makeInputTensor<DataType::S64>(bias_shape, bias_scales, zerop, 0, bias_data);
+  Tensor output_tensor = makeOutputTensor(DataType::S16, output_scale, 0);
+
+  Conv2DParams params{};
+  params.padding = Padding::VALID;
+  params.stride_height = 1;
+  params.stride_width = 1;
+  params.dilation_height_factor = 1;
+  params.dilation_width_factor = 1;
+  params.activation = Activation::RELU;
+
+  Conv2D kernel(&input_tensor, &filter_tensor, &bias_tensor, &output_tensor, params);
+  kernel.configure();
+  kernel.execute();
+
+  EXPECT_THAT(extractTensorShape(output_tensor), ::testing::ElementsAreArray(ref_output_shape));
+  EXPECT_THAT(dequantizeTensorData(output_tensor), FloatArrayNear(ref_output_data));
+}
+
 TEST(Conv2DTest, Unsupported_Type_Configure_NEG)
 {
   Shape input_shape{1, 4, 3, 2};

--- a/compiler/luci-interpreter/src/kernels/TestUtils.cpp
+++ b/compiler/luci-interpreter/src/kernels/TestUtils.cpp
@@ -46,7 +46,7 @@ std::vector<float> dequantizeTensorData(const Tensor &tensor)
   else if (tensor.element_type() == DataType::S16)
   {
     // S16 quantization is symmetric, so zero point should be zero.
-    for (auto zp:tensor.zero_points())
+    for (auto zp : tensor.zero_points())
     {
       (void)zp;
       assert(zp == 0);
@@ -85,7 +85,8 @@ std::vector<float> dequantizeTensorData(const Tensor &tensor)
         size_t offset = inner_dims_size * (quant_dim_size * outer_it + channel);
         std::vector<float> part_dequantized_data =
             dequantize(data.data() + offset, inner_dims_size, scale, 0);
-        dequantized_data.insert(dequantized_data.end(), part_dequantized_data.begin(), part_dequantized_data.end());
+        dequantized_data.insert(dequantized_data.end(), part_dequantized_data.begin(),
+                                part_dequantized_data.end());
       }
     return dequantized_data;
   }

--- a/compiler/luci-interpreter/src/kernels/TestUtils.cpp
+++ b/compiler/luci-interpreter/src/kernels/TestUtils.cpp
@@ -40,13 +40,54 @@ std::vector<float> dequantizeTensorData(const Tensor &tensor)
 {
   if (tensor.element_type() == DataType::U8)
   {
-    return dequantize(extractTensorData<uint8_t>(tensor), tensor.scale(), tensor.zero_point());
+    std::vector<uint8_t> data = extractTensorData<uint8_t>(tensor);
+    return dequantize(data.data(), data.size(), tensor.scale(), tensor.zero_point());
   }
   else if (tensor.element_type() == DataType::S16)
   {
     // S16 quantization is symmetric, so zero point should be zero.
-    assert(tensor.zero_point() == 0);
-    return dequantize(extractTensorData<int16_t>(tensor), tensor.scale(), 0);
+    for (auto zp:tensor.zero_points())
+    {
+      (void)zp;
+      assert(zp == 0);
+    }
+
+    std::vector<int16_t> data = extractTensorData<int16_t>(tensor);
+    if (tensor.scales().size() == 1)
+    {
+      return dequantize(data.data(), data.size(), tensor.scale(), 0);
+    }
+
+    // quantize_dimension breaks shape into two parts:
+    // inner dimensions that contains continuous data with one quantization type
+    // outer dimensions that contains other dimensions
+    const Shape shape = tensor.shape();
+    const int32_t quantized_dimension = tensor.quantized_dimension();
+    assert(quantized_dimension < shape.num_dims());
+    size_t outer_dims_size = 1;
+    size_t quant_dim_size = shape.dim(quantized_dimension);
+    size_t inner_dims_size = 1;
+    assert(quant_dim_size == tensor.scales().size());
+
+    for (int i = 0; i < quantized_dimension; ++i)
+      outer_dims_size *= shape.dim(i);
+    for (int i = quantized_dimension + 1; i < shape.num_dims(); ++i)
+      inner_dims_size *= shape.dim(i);
+
+    assert(shape.num_elements() == outer_dims_size * quant_dim_size * inner_dims_size);
+
+    std::vector<float> dequantized_data;
+    dequantized_data.reserve(shape.num_elements());
+    for (size_t outer_it = 0; outer_it < outer_dims_size; ++outer_it)
+      for (size_t channel = 0; channel < quant_dim_size; ++channel)
+      {
+        float scale = tensor.scales()[channel];
+        size_t offset = inner_dims_size * (quant_dim_size * outer_it + channel);
+        std::vector<float> part_dequantized_data =
+            dequantize(data.data() + offset, inner_dims_size, scale, 0);
+        dequantized_data.insert(dequantized_data.end(), part_dequantized_data.begin(), part_dequantized_data.end());
+      }
+    return dequantized_data;
   }
   else
   {

--- a/compiler/luci-interpreter/src/kernels/TestUtils.h
+++ b/compiler/luci-interpreter/src/kernels/TestUtils.h
@@ -58,7 +58,8 @@ Tensor makeInputTensor(const Shape &shape, float scale, int32_t zero_point,
 {
   using NativeT = typename DataTypeImpl<DT>::Type;
   Tensor tensor(DT, shape, {{scale}, {zero_point}}, "");
-  std::vector<NativeT> quantized_data = quantize<NativeT>(data.data(), data.size(), scale, zero_point);
+  std::vector<NativeT> quantized_data =
+      quantize<NativeT>(data.data(), data.size(), scale, zero_point);
   tensor.writeData(quantized_data.data(), quantized_data.size() * sizeof(NativeT));
   return tensor;
 }
@@ -74,8 +75,9 @@ Tensor makeInputTensor(const Shape &shape, float scale, int32_t zero_point,
  * @return created tensor
  */
 template <DataType DT>
-Tensor makeInputTensor(const Shape &shape, const std::vector<float> &scales, const std::vector<int32_t> &zero_points,
-                       int quantized_dimension, const std::vector<float> &data)
+Tensor makeInputTensor(const Shape &shape, const std::vector<float> &scales,
+                       const std::vector<int32_t> &zero_points, int quantized_dimension,
+                       const std::vector<float> &data)
 {
   using NativeT = typename DataTypeImpl<DT>::Type;
   assert(quantized_dimension < shape.num_dims());
@@ -107,7 +109,8 @@ Tensor makeInputTensor(const Shape &shape, const std::vector<float> &scales, con
       size_t offset = inner_dims_size * (quant_dim_size * outer_it + channel);
       std::vector<NativeT> part_quantized_data =
           quantize<NativeT>(data.data() + offset, inner_dims_size, scale, zero_point);
-      quantized_data.insert(quantized_data.end(), part_quantized_data.begin(), part_quantized_data.end());
+      quantized_data.insert(quantized_data.end(), part_quantized_data.begin(),
+                            part_quantized_data.end());
     }
   assert(quantized_data.size() == shape.num_elements());
   tensor.writeData(quantized_data.data(), quantized_data.size() * sizeof(NativeT));

--- a/compiler/luci-interpreter/src/kernels/TestUtils.h
+++ b/compiler/luci-interpreter/src/kernels/TestUtils.h
@@ -33,7 +33,7 @@ namespace testing
 {
 
 template <typename T>
-std::vector<T> quantize(const std::vector<float> &data, float scale, int32_t zero_point);
+std::vector<T> quantize(const float *data, size_t num_elements, float scale, int32_t zero_point);
 
 template <DataType DT>
 Tensor makeInputTensor(const Shape &shape, const std::vector<typename DataTypeImpl<DT>::Type> &data)
@@ -43,13 +43,73 @@ Tensor makeInputTensor(const Shape &shape, const std::vector<typename DataTypeIm
   return tensor;
 }
 
+/**
+ * @brief Create layer-wise quantized tensor
+ * @tparam DT base integer data type, for example DataType::U8, DataType::S16, DataType::S64
+ * @param shape desired tensor shape
+ * @param scale scale of quantized number
+ * @param zero_point zero point of quantized number, should be 0 for signed datatypes
+ * @param data floating point data for quantization
+ * @return created tensor
+ */
 template <DataType DT>
 Tensor makeInputTensor(const Shape &shape, float scale, int32_t zero_point,
                        const std::vector<float> &data)
 {
   using NativeT = typename DataTypeImpl<DT>::Type;
   Tensor tensor(DT, shape, {{scale}, {zero_point}}, "");
-  std::vector<NativeT> quantized_data = quantize<NativeT>(data, scale, zero_point);
+  std::vector<NativeT> quantized_data = quantize<NativeT>(data.data(), data.size(), scale, zero_point);
+  tensor.writeData(quantized_data.data(), quantized_data.size() * sizeof(NativeT));
+  return tensor;
+}
+
+/**
+ * @brief Create channel-wise quantized tensor
+ * @tparam DT base integer data type, for example DataType::U8, DataType::S16, DataType::S64
+ * @param shape desired tensor shape
+ * @param scales scales of quantized number
+ * @param zero_points zero points of quantized number, should be 0 for signed datatypes
+ * @param quantize_dimension dimension to apply quantization along. Usually channels/output channels
+ * @param data floating point data for quantization
+ * @return created tensor
+ */
+template <DataType DT>
+Tensor makeInputTensor(const Shape &shape, const std::vector<float> &scales, const std::vector<int32_t> &zero_points,
+                       int quantized_dimension, const std::vector<float> &data)
+{
+  using NativeT = typename DataTypeImpl<DT>::Type;
+  assert(quantized_dimension < shape.num_dims());
+  Tensor tensor(DT, shape, {scales, zero_points, quantized_dimension}, "");
+
+  // quantize_dimension breaks shape into two parts:
+  // inner dimensions that contains continuous data with one quantization type
+  // outer dimensions that contains other dimensions
+  size_t outer_dims_size = 1;
+  size_t quant_dim_size = shape.dim(quantized_dimension);
+  size_t inner_dims_size = 1;
+  assert(quant_dim_size == scales.size());
+  assert(quant_dim_size == zero_points.size());
+
+  for (int i = 0; i < quantized_dimension; ++i)
+    outer_dims_size *= shape.dim(i);
+  for (int i = quantized_dimension + 1; i < shape.num_dims(); ++i)
+    inner_dims_size *= shape.dim(i);
+
+  assert(shape.num_elements() == outer_dims_size * quant_dim_size * inner_dims_size);
+
+  std::vector<NativeT> quantized_data;
+  quantized_data.reserve(shape.num_elements());
+  for (size_t outer_it = 0; outer_it < outer_dims_size; ++outer_it)
+    for (size_t channel = 0; channel < quant_dim_size; ++channel)
+    {
+      int32_t zero_point = zero_points[channel];
+      float scale = scales[channel];
+      size_t offset = inner_dims_size * (quant_dim_size * outer_it + channel);
+      std::vector<NativeT> part_quantized_data =
+          quantize<NativeT>(data.data() + offset, inner_dims_size, scale, zero_point);
+      quantized_data.insert(quantized_data.end(), part_quantized_data.begin(), part_quantized_data.end());
+    }
+  assert(quantized_data.size() == shape.num_elements());
   tensor.writeData(quantized_data.data(), quantized_data.size() * sizeof(NativeT));
   return tensor;
 }
@@ -86,7 +146,7 @@ std::vector<float> dequantizeTensorData(const Tensor &tensor);
                                                       float max_abs_error = 1.0e-5f);
 
 template <typename T>
-std::vector<T> quantize(const std::vector<float> &data, float scale, int32_t zero_point)
+std::vector<T> quantize(const float *data, size_t num_elements, float scale, int32_t zero_point)
 {
   static_assert(std::is_integral<T>::value, "Integral type expected.");
 
@@ -105,8 +165,9 @@ std::vector<T> quantize(const std::vector<float> &data, float scale, int32_t zer
   }
 
   std::vector<T> q;
-  for (const auto &f : data)
+  for (size_t i = 0; i < num_elements; ++i)
   {
+    const auto &f = data[i];
     q.push_back(static_cast<T>(
         std::max<float>(q_min, std::min<float>(q_max, std::round(zero_point + (f / scale))))));
   }
@@ -114,12 +175,13 @@ std::vector<T> quantize(const std::vector<float> &data, float scale, int32_t zer
 }
 
 template <typename T>
-std::vector<float> dequantize(const std::vector<T> &data, float scale, int32_t zero_point)
+std::vector<float> dequantize(const T *data, size_t num_elements, float scale, int32_t zero_point)
 {
   static_assert(std::is_integral<T>::value, "Integral type expected.");
   std::vector<float> f;
-  for (const T &q : data)
+  for (size_t i = 0; i < num_elements; ++i)
   {
+    const T &q = data[i];
     f.push_back(scale * (q - zero_point));
   }
   return f;

--- a/compiler/luci-interpreter/src/loader/GraphLoader.cpp
+++ b/compiler/luci-interpreter/src/loader/GraphLoader.cpp
@@ -135,6 +135,7 @@ void GraphLoader::loadTensors()
     if (node->quantparam() != nullptr)
     {
       const luci::CircleQuantParam *params = node->quantparam();
+      assert(params->scale.size() == params->zerop.size());
       quantization.scale.assign(params->scale.cbegin(), params->scale.cend());
       quantization.zero_point.assign(params->zerop.cbegin(), params->zerop.cend());
       quantization.quantized_dimension = params->quantized_dimension;


### PR DESCRIPTION
Support convolution with channel-wise quantized weights and
layer-wise quantized activations (input and output of conv layer)

ONE-DCO-1.0-Signed-off-by: Alexander Efimov <a.efimov@samsung.com>