### PR TITLE
[nnfwapi] Add DepthwiseConv2D tests (stride=2)

### DIFF
--- a/tests/nnfw_api/src/one_op_tests/DepthwiseConv2D.cc
+++ b/tests/nnfw_api/src/one_op_tests/DepthwiseConv2D.cc
@@ -170,34 +170,39 @@ CircleBuffer genNegTestDepthwiseConv2DModel(circle::Padding padding, int stride_
   return cgen.finish();
 }
 
-CircleBuffer genSimpleDepthwiseConv2DQuantizedModel(int input_depth, int depth_multiplier)
+CircleBuffer genSimpleDepthwiseConv2DQuantizedModel(int stride, int input_depth,
+                                                    int depth_multiplier)
 {
+  assert(1 <= stride && stride <= 2);
   assert(1 <= input_depth && input_depth <= 16);
-  assert(1 <= depth_multiplier && depth_multiplier <= 16);
+  assert(1 <= depth_multiplier && depth_multiplier <= 32);
 
   const int output_depth = input_depth * depth_multiplier;
-  assert(1 <= output_depth && output_depth <= 16);
+  assert(1 <= output_depth && output_depth <= 32);
 
   CircleGen cgen;
-  uint32_t ker_buf = cgen.addBuffer(
-      std::vector<uint8_t>{0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1,
-                           2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3,
-                           0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3});
+  uint32_t ker_buf = cgen.addBuffer(std::vector<uint8_t>{
+      0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1,
+      2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3,
+      0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1,
+      2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3,
+      0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3});
   uint32_t bias_buf = cgen.addBuffer(std::vector<int32_t>(output_depth, 0));
   int in = cgen.addTensor({{1, 2, 2, input_depth}, circle::TensorType_UINT8}, 0.5, 0);
   int ker = cgen.addTensor({{1, 2, 2, output_depth}, circle::TensorType_UINT8, ker_buf}, 0.5, 0);
   int bias = cgen.addTensor({{output_depth}, circle::TensorType_INT32, bias_buf}, 0.25, 0);
   int out = cgen.addTensor({{1, 1, 1, output_depth}, circle::TensorType_UINT8}, 1, 0);
-  cgen.addOperatorDepthwiseConv2D({{in, ker, bias}, {out}}, circle::Padding::Padding_VALID, 1, 1,
-                                  depth_multiplier, circle::ActivationFunctionType_NONE);
+  cgen.addOperatorDepthwiseConv2D({{in, ker, bias}, {out}}, circle::Padding::Padding_VALID, stride,
+                                  stride, depth_multiplier, circle::ActivationFunctionType_NONE);
   cgen.setInputsAndOutputs({in}, {out});
   return cgen.finish();
 }
 
 struct DepthwiseConv2DVariationParam
 {
-  int input_depth = 0;
-  int depth_multiplier = 0;
+  int stride = 1; // Used for both height and width
+  int input_depth = 1;
+  int depth_multiplier = 1;
   std::vector<uint8_t> ref_output;
 };
 
@@ -206,16 +211,17 @@ class DepthwiseConv2DVariation : public GenModelTest,
 {
 };
 
-static std::vector<uint8_t> input64{
-    0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 5, 4, 3, 2, 5, 4, 3, 2, 5, 4, 3, 2, 5, 4, 3, 2,
-    2, 4, 6, 8, 2, 4, 6, 8, 2, 4, 6, 8, 2, 4, 6, 8, 2, 3, 5, 8, 8, 5, 3, 2, 1, 2, 3, 4, 5, 4, 3, 2};
-
 TEST_P(DepthwiseConv2DVariation, Test)
 {
-  // These values must be less than 0 or greater than 2
+  // Same input is used for all tests but output differs
+  static const std::vector<uint8_t> input64{0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3,
+                                            5, 4, 3, 2, 5, 4, 3, 2, 5, 4, 3, 2, 5, 4, 3, 2,
+                                            2, 4, 6, 8, 2, 4, 6, 8, 2, 4, 6, 8, 2, 4, 6, 8,
+                                            2, 3, 5, 8, 8, 5, 3, 2, 1, 2, 3, 4, 5, 4, 3, 2};
+
   auto &param = GetParam();
-  _context = std::make_unique<GenModelTestContext>(
-      genSimpleDepthwiseConv2DQuantizedModel(param.input_depth, param.depth_multiplier));
+  _context = std::make_unique<GenModelTestContext>(genSimpleDepthwiseConv2DQuantizedModel(
+      param.stride, param.input_depth, param.depth_multiplier));
   std::vector<uint8_t> ref_input(input64.begin(), input64.begin() + param.input_depth * 4);
   _context->addTestCase(uniformTCD<uint8_t>({ref_input}, {param.ref_output}));
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
@@ -228,19 +234,36 @@ TEST_P(DepthwiseConv2DVariation, Test)
 INSTANTIATE_TEST_CASE_P(
     GenModelTest, DepthwiseConv2DVariation,
     ::testing::Values(
-        DepthwiseConv2DVariationParam{8, 1, std::vector<uint8_t>{0, 3, 5, 8, 0, 3, 5, 8}},
-        DepthwiseConv2DVariationParam{4, 2, std::vector<uint8_t>{0, 0, 2, 3, 0, 2, 6, 9}},
+        // Stride == 1
+        DepthwiseConv2DVariationParam{1, 8, 1, std::vector<uint8_t>{0, 3, 5, 8, 0, 3, 5, 8}},
+        DepthwiseConv2DVariationParam{1, 4, 2, std::vector<uint8_t>{0, 0, 2, 3, 0, 2, 6, 9}},
         DepthwiseConv2DVariationParam{
-            2, 8, std::vector<uint8_t>{0, 1, 2, 3, 0, 1, 2, 3, 0, 2, 4, 6, 0, 2, 4, 6}},
-        DepthwiseConv2DVariationParam{2, 2, std::vector<uint8_t>{0, 1, 4, 6}},
-        DepthwiseConv2DVariationParam{2, 1, std::vector<uint8_t>{2, 5}},
-        DepthwiseConv2DVariationParam{1, 2, std::vector<uint8_t>{2, 4}},
-        DepthwiseConv2DVariationParam{1, 4, std::vector<uint8_t>{0, 2, 3, 5}},
-        DepthwiseConv2DVariationParam{4, 1, std::vector<uint8_t>{0, 1, 4, 9}},
+            1, 2, 8, std::vector<uint8_t>{0, 1, 2, 3, 0, 1, 2, 3, 0, 2, 4, 6, 0, 2, 4, 6}},
+        DepthwiseConv2DVariationParam{1, 2, 2, std::vector<uint8_t>{0, 1, 4, 6}},
+        DepthwiseConv2DVariationParam{1, 2, 1, std::vector<uint8_t>{2, 5}},
+        DepthwiseConv2DVariationParam{1, 1, 2, std::vector<uint8_t>{2, 4}},
+        DepthwiseConv2DVariationParam{1, 1, 4, std::vector<uint8_t>{0, 2, 3, 5}},
+        DepthwiseConv2DVariationParam{1, 4, 1, std::vector<uint8_t>{0, 1, 4, 9}},
         DepthwiseConv2DVariationParam{
-            4, 4, std::vector<uint8_t>{0, 0, 0, 0, 0, 1, 2, 3, 0, 2, 4, 6, 0, 3, 6, 9}},
+            1, 4, 4, std::vector<uint8_t>{0, 0, 0, 0, 0, 1, 2, 3, 0, 2, 4, 6, 0, 3, 6, 9}},
+        DepthwiseConv2DVariationParam{1, 12, 1,
+                                      std::vector<uint8_t>{0, 3, 7, 12, 0, 4, 7, 12, 0, 4, 9, 16}},
+        // Stride == 2
+        DepthwiseConv2DVariationParam{2, 4, 1, std::vector<uint8_t>{0, 1, 4, 9}},
+        DepthwiseConv2DVariationParam{2, 2, 1, std::vector<uint8_t>{2, 5}},
+        DepthwiseConv2DVariationParam{2, 1, 8, std::vector<uint8_t>{0, 2, 3, 5, 0, 2, 3, 5}},
         DepthwiseConv2DVariationParam{
-            12, 1, std::vector<uint8_t>{0, 3, 7, 12, 0, 4, 7, 12, 0, 4, 9, 16}}));
+            2, 1, 32, std::vector<uint8_t>{0, 2, 3, 5, 0, 2, 3, 5, 0, 2, 3, 5, 0, 2, 3, 5,
+                                           0, 2, 3, 5, 0, 2, 3, 5, 0, 2, 3, 5, 0, 2, 3, 5}},
+        DepthwiseConv2DVariationParam{2, 1, 20, std::vector<uint8_t>{0, 2, 3, 5, 0, 2, 3, 5, 0, 2,
+                                                                     3, 5, 0, 2, 3, 5, 0, 2, 3, 5}},
+        DepthwiseConv2DVariationParam{
+            2, 1, 16, std::vector<uint8_t>{0, 2, 3, 5, 0, 2, 3, 5, 0, 2, 3, 5, 0, 2, 3, 5}},
+        DepthwiseConv2DVariationParam{2, 8, 1, std::vector<uint8_t>{0, 3, 5, 8, 0, 3, 5, 8}},
+        DepthwiseConv2DVariationParam{
+            2, 8, 2, std::vector<uint8_t>{0, 3, 5, 8, 0, 3, 5, 8, 0, 3, 5, 8, 0, 3, 5, 8}},
+        DepthwiseConv2DVariationParam{
+            2, 16, 1, std::vector<uint8_t>{0, 3, 8, 16, 0, 4, 7, 12, 0, 3, 7, 13, 0, 4, 7, 12}}));
 
 TEST_F(GenModelTest, neg_OneOp_DepthwiseConv2D_InvalidPaddingType)
 {


### PR DESCRIPTION
Add tests to #4906 - when stride is 2.

This is to test optimized CPU kernels.
(`compute/cker/include/cker/operation/optimized/DepthwiseConvUint8.h`)

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>