### PR TITLE
[nnfwapi] Test: revise the way to add TestCaseData

### DIFF
--- a/tests/nnfw_api/src/GenModelTest.h
+++ b/tests/nnfw_api/src/GenModelTest.h
@@ -69,7 +69,11 @@ struct TestCaseData
    * @tparam T Data type
    * @param data vector data array
    */
-  template <typename T> void addInput(const std::vector<T> &data) { addData(inputs, data); }
+  template <typename T> TestCaseData &addInput(const std::vector<T> &data)
+  {
+    addData(inputs, data);
+    return *this;
+  }
 
   /**
    * @brief Append vector data to inputs
@@ -77,12 +81,20 @@ struct TestCaseData
    * @tparam T Data type
    * @param data vector data array
    */
-  template <typename T> void addOutput(const std::vector<T> &data) { addData(outputs, data); }
+  template <typename T> TestCaseData &addOutput(const std::vector<T> &data)
+  {
+    addData(outputs, data);
+    return *this;
+  }
 
   /**
    * @brief Call this when @c nnfw_run() for this test case is expected to be failed
    */
-  void expectFailRun() { _expected_fail_run = true; }
+  TestCaseData &expectFailRun()
+  {
+    _expected_fail_run = true;
+    return *this;
+  }
   bool expected_fail_run() const { return _expected_fail_run; }
 
 private:

--- a/tests/nnfw_api/src/ModelTestDynamicTensor.cc
+++ b/tests/nnfw_api/src/ModelTestDynamicTensor.cc
@@ -144,10 +144,7 @@ TEST_F(GenModelTest, dynamic_reshape_from_2x3_to_3x2)
 
   _context = std::make_unique<GenModelTestContext>(build_dynamic_Reshape());
   {
-    TestCaseData tcd;
-    tcd.addInput(new_shape);
-    tcd.addOutput(expected);
-    _context->addTestCase(tcd);
+    _context->addTestCase(TestCaseData{}.addInput(new_shape).addOutput(expected));
     _context->setBackends({"cpu"}); // Currently, dynamic tensor runs on "cpu" only
     _context->output_sizes(0, sizeof(float) * expected.size());
   }
@@ -166,12 +163,8 @@ TEST_F(GenModelTest, neg_reshape_from_2x3_to_wrong_3x3)
 
   _context = std::make_unique<GenModelTestContext>(build_dynamic_Reshape());
   {
-    TestCaseData tcd;
-    tcd.addInput(wrong_shape);
-    tcd.addOutput(expected);
-    tcd.expectFailRun();
 
-    _context->addTestCase(tcd);
+    _context->addTestCase(TestCaseData{}.addInput(wrong_shape).addOutput(expected).expectFailRun());
     _context->setBackends({"cpu"}); // Currently, dynamic tensor runs on "cpu" only
     _context->output_sizes(0, sizeof(float) * expected.size());
   }
@@ -184,18 +177,11 @@ TEST_F(GenModelTest, reshape_multiple_executions)
   std::vector<int> new_shape;
   std::vector<float> expected = {-1.5, -1.0, -0.5, 0.5, 1.0, 1.5};
 
-  auto add_tcd = [&](const decltype(new_shape) &&new_shape) {
-    TestCaseData tcd;
-    tcd.addInput(new_shape);
-    tcd.addOutput(expected);
-    _context->addTestCase(tcd);
-  };
-
   _context = std::make_unique<GenModelTestContext>(build_dynamic_Reshape());
   {
-    add_tcd({3, 2});
-    add_tcd({1, 6});
-    add_tcd({6, 1});
+    _context->addTestCase(TestCaseData{}.addInput<int>({3, 2}).addOutput(expected));
+    _context->addTestCase(TestCaseData{}.addInput<int>({1, 6}).addOutput(expected));
+    _context->addTestCase(TestCaseData{}.addInput<int>({6, 1}).addOutput(expected));
 
     _context->setBackends({"cpu"}); // Currently, dynamic tensor runs on "cpu" only
     _context->output_sizes(0, sizeof(float) * expected.size());
@@ -211,8 +197,7 @@ TEST_F(GenModelTest, neg_reshape_multiple_executions)
 
   auto add_tcd = [&](const decltype(new_shape) &&new_shape, bool expect_fail_on_run) {
     TestCaseData tcd;
-    tcd.addInput(new_shape);
-    tcd.addOutput(expected);
+    tcd.addInput(new_shape).addOutput(expected);
     if (expect_fail_on_run)
       tcd.expectFailRun();
     _context->addTestCase(tcd);

--- a/tests/nnfw_api/src/one_op_tests/ArgMax.cc
+++ b/tests/nnfw_api/src/one_op_tests/ArgMax.cc
@@ -31,10 +31,7 @@ TEST_F(GenModelTest, OneOp_ArgMax_AxisToConst)
   cgen.setInputsAndOutputs({in}, {out});
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
-  TestCaseData tcd;
-  tcd.addInput(std::vector<float>{1, 4, 2, 3});
-  tcd.addOutput(std::vector<int32_t>{1, 0});
-  _context->addTestCase(tcd);
+  _context->addTestCase(TestCaseData{}.addInput<float>({1, 4, 2, 3}).addOutput<int32_t>({1, 0}));
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
 
   SUCCEED();
@@ -53,10 +50,7 @@ TEST_F(GenModelTest, OneOp_ArgMax_Int64_AxisToConst)
   cgen.setInputsAndOutputs({in}, {out});
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
-  TestCaseData tcd;
-  tcd.addInput(std::vector<float>{1, 4, 2, 3});
-  tcd.addOutput(std::vector<int64_t>{1, 0});
-  _context->addTestCase(tcd);
+  _context->addTestCase(TestCaseData{}.addInput<float>({1, 4, 2, 3}).addOutput<int64_t>({1, 0}));
   _context->setBackends({"acl_cl"});
 
   SUCCEED();
@@ -73,11 +67,10 @@ TEST_F(GenModelTest, OneOp_ArgMax_AxisToVar)
   cgen.setInputsAndOutputs({in, axis}, {out});
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
-  TestCaseData tcd;
-  tcd.addInput(std::vector<float>{1, 4, 2, 3});
-  tcd.addInput(std::vector<int32_t>{-3});
-  tcd.addOutput(std::vector<int32_t>{1, 0});
-  _context->addTestCase(tcd);
+  _context->addTestCase(TestCaseData{}
+                            .addInput<float>({1, 4, 2, 3})
+                            .addInput<int32_t>({-3})
+                            .addOutput<int32_t>({1, 0}));
   _context->setBackends({"cpu"});
 
   SUCCEED();

--- a/tests/nnfw_api/src/one_op_tests/Cast.cc
+++ b/tests/nnfw_api/src/one_op_tests/Cast.cc
@@ -33,10 +33,8 @@ TEST_F(GenModelTest, OneOp_Cast_Int32ToFloat32)
   CircleGen cgen = genSimpleCastModel(circle::TensorType_INT32, circle::TensorType_FLOAT32);
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
-  TestCaseData tcd;
-  tcd.addInput(std::vector<int32_t>{1, 2, 3, 4});
-  tcd.addOutput(std::vector<float>{1, 2, 3, 4});
-  _context->addTestCase(tcd);
+  _context->addTestCase(
+      TestCaseData{}.addInput<int32_t>({1, 2, 3, 4}).addOutput<float>({1, 2, 3, 4}));
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
 
   SUCCEED();
@@ -47,10 +45,8 @@ TEST_F(GenModelTest, OneOp_Cast_Float32ToInt32)
   CircleGen cgen = genSimpleCastModel(circle::TensorType_FLOAT32, circle::TensorType_INT32);
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
-  TestCaseData tcd;
-  tcd.addInput(std::vector<float>{1, 2, 3, 4});
-  tcd.addOutput(std::vector<int32_t>{1, 2, 3, 4});
-  _context->addTestCase(tcd);
+  _context->addTestCase(
+      TestCaseData{}.addInput<float>({1, 2, 3, 4}).addOutput<int32_t>({1, 2, 3, 4}));
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
 
   SUCCEED();
@@ -61,10 +57,8 @@ TEST_F(GenModelTest, OneOp_Cast_BoolToFloat32)
   CircleGen cgen = genSimpleCastModel(circle::TensorType_BOOL, circle::TensorType_FLOAT32);
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
-  TestCaseData tcd;
-  tcd.addInput(std::vector<bool>{true, false, true, true});
-  tcd.addOutput(std::vector<float>{1, 0, 1, 1});
-  _context->addTestCase(tcd);
+  _context->addTestCase(
+      TestCaseData{}.addInput<bool>({true, false, true, true}).addOutput<float>({1, 0, 1, 1}));
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
 
   SUCCEED();
@@ -75,10 +69,9 @@ TEST_F(GenModelTest, OneOp_Cast_BoolToUInt8)
   CircleGen cgen = genSimpleCastModel(circle::TensorType_BOOL, circle::TensorType_UINT8);
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
-  TestCaseData tcd;
-  tcd.addInput(std::vector<bool>{true, false, true, true});
-  tcd.addOutput(std::vector<uint8_t>{1, 0, 1, 1});
-  _context->addTestCase(tcd);
+  _context->addTestCase(TestCaseData{}
+                            .addInput<bool>({true, false, true, true})
+                            .addOutput(std::vector<uint8_t>{1, 0, 1, 1}));
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
 
   SUCCEED();
@@ -89,10 +82,8 @@ TEST_F(GenModelTest, OneOp_Cast_BoolToInt32)
   CircleGen cgen = genSimpleCastModel(circle::TensorType_BOOL, circle::TensorType_INT32);
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
-  TestCaseData tcd;
-  tcd.addInput(std::vector<bool>{true, false, true, true});
-  tcd.addOutput(std::vector<int32_t>{1, 0, 1, 1});
-  _context->addTestCase(tcd);
+  _context->addTestCase(
+      TestCaseData{}.addInput<bool>({true, false, true, true}).addOutput<int32_t>({1, 0, 1, 1}));
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
 
   SUCCEED();

--- a/tests/nnfw_api/src/one_op_tests/Equal.cc
+++ b/tests/nnfw_api/src/one_op_tests/Equal.cc
@@ -26,11 +26,10 @@ TEST_F(GenModelTest, OneOp_Equal)
   cgen.setInputsAndOutputs({lhs, rhs}, {out});
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
-  TestCaseData tcd;
-  tcd.addInput(std::vector<float>{0.1, 0.3, 0.5, 0.7});
-  tcd.addInput(std::vector<float>{0.1, 0.2, 0.3, 0.4});
-  tcd.addOutput(std::vector<bool>{true, false, false, false});
-  _context->addTestCase(tcd);
+  _context->addTestCase(TestCaseData{}
+                            .addInput<float>({0.1, 0.3, 0.5, 0.7})
+                            .addInput<float>({0.1, 0.2, 0.3, 0.4})
+                            .addOutput<bool>({true, false, false, false}));
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
 
   SUCCEED();

--- a/tests/nnfw_api/src/one_op_tests/Fill.cc
+++ b/tests/nnfw_api/src/one_op_tests/Fill.cc
@@ -28,12 +28,9 @@ TEST_F(GenModelTest, OneOp_Fill_Int32)
   cgen.addOperatorFill({{in, value}, {out}});
   cgen.setInputsAndOutputs({in}, {out});
 
-  TestCaseData tcd;
-  tcd.addInput(std::vector<int32_t>{2, 3});
-  tcd.addOutput(std::vector<int32_t>{13, 13, 13, 13, 13, 13});
-
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
-  _context->addTestCase(tcd);
+  _context->addTestCase(
+      TestCaseData{}.addInput<int32_t>({2, 3}).addOutput<int32_t>({13, 13, 13, 13, 13, 13}));
   _context->setBackends({"cpu"});
 
   SUCCEED();
@@ -51,12 +48,9 @@ TEST_F(GenModelTest, OneOp_Fill_Int64)
   cgen.addOperatorFill({{in, value}, {out}});
   cgen.setInputsAndOutputs({in}, {out});
 
-  TestCaseData tcd;
-  tcd.addInput(std::vector<int32_t>{2, 3});
-  tcd.addOutput(std::vector<int64_t>{13, 13, 13, 13, 13, 13});
-
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
-  _context->addTestCase(tcd);
+  _context->addTestCase(
+      TestCaseData{}.addInput<int32_t>({2, 3}).addOutput<int64_t>({13, 13, 13, 13, 13, 13}));
   _context->setBackends({"cpu"});
 
   SUCCEED();
@@ -74,12 +68,9 @@ TEST_F(GenModelTest, OneOp_Fill_Float32)
   cgen.addOperatorFill({{in, value}, {out}});
   cgen.setInputsAndOutputs({in}, {out});
 
-  TestCaseData tcd;
-  tcd.addInput(std::vector<int32_t>{2, 3});
-  tcd.addOutput(std::vector<float>{1.3, 1.3, 1.3, 1.3, 1.3, 1.3});
-
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
-  _context->addTestCase(tcd);
+  _context->addTestCase(
+      TestCaseData{}.addInput<int32_t>({2, 3}).addOutput<float>({1.3, 1.3, 1.3, 1.3, 1.3, 1.3}));
   _context->setBackends({"cpu"});
 
   SUCCEED();
@@ -94,12 +85,9 @@ TEST_F(GenModelTest, neg_OneOp_Fill_Int32_oneoperand)
   cgen.addOperatorFill({{in}, {out}});
   cgen.setInputsAndOutputs({in}, {out});
 
-  TestCaseData tcd;
-  tcd.addInput(std::vector<int32_t>{2, 3});
-  tcd.addOutput(std::vector<int32_t>{13, 13, 13, 13, 13, 13});
-
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
-  _context->addTestCase(tcd);
+  _context->addTestCase(
+      TestCaseData{}.addInput<int32_t>({2, 3}).addOutput<int32_t>({13, 13, 13, 13, 13, 13}));
   _context->setBackends({"cpu"});
   _context->expectFailModelLoad();
 
@@ -115,12 +103,9 @@ TEST_F(GenModelTest, neg_OneOp_Fill_Int64_oneoperand)
   cgen.addOperatorFill({{in}, {out}});
   cgen.setInputsAndOutputs({in}, {out});
 
-  TestCaseData tcd;
-  tcd.addInput(std::vector<int32_t>{2, 3});
-  tcd.addOutput(std::vector<int64_t>{13, 13, 13, 13, 13, 13});
-
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
-  _context->addTestCase(tcd);
+  _context->addTestCase(
+      TestCaseData{}.addInput<int32_t>({2, 3}).addOutput<int64_t>({13, 13, 13, 13, 13, 13}));
   _context->setBackends({"cpu"});
   _context->expectFailModelLoad();
 
@@ -136,12 +121,9 @@ TEST_F(GenModelTest, neg_OneOp_Fill_Float32_oneoperand)
   cgen.addOperatorFill({{in}, {out}});
   cgen.setInputsAndOutputs({in}, {out});
 
-  TestCaseData tcd;
-  tcd.addInput(std::vector<int32_t>{2, 3});
-  tcd.addOutput(std::vector<float>{1.3, 1.3, 1.3, 1.3, 1.3, 1.3});
-
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
-  _context->addTestCase(tcd);
+  _context->addTestCase(
+      TestCaseData{}.addInput<int32_t>({2, 3}).addOutput<float>({1.3, 1.3, 1.3, 1.3, 1.3, 1.3}));
   _context->setBackends({"cpu"});
   _context->expectFailModelLoad();
 

--- a/tests/nnfw_api/src/one_op_tests/OneHot.cc
+++ b/tests/nnfw_api/src/one_op_tests/OneHot.cc
@@ -35,11 +35,10 @@ TEST_F(GenModelTest, OneOp_OneHot_OffValueToConst)
   cgen.setInputsAndOutputs({indices, on_value}, {out});
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
-  TestCaseData tcd;
-  tcd.addInput(std::vector<int32_t>{1, 2, 0, 2});
-  tcd.addInput(std::vector<float>{1});
-  tcd.addOutput(std::vector<float>{0, 0, 1, 0, 0, 1, 1, 0, 0, 0, 0, 1});
-  _context->addTestCase(tcd);
+  _context->addTestCase(TestCaseData{}
+                            .addInput<int32_t>({1, 2, 0, 2})
+                            .addInput<float>({1})
+                            .addOutput<float>({0, 0, 1, 0, 0, 1, 1, 0, 0, 0, 0, 1}));
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
 
   SUCCEED();
@@ -60,12 +59,11 @@ TEST_F(GenModelTest, OneOp_OneHot_OffValueToNotZero)
   cgen.setInputsAndOutputs({indices, on_value, off_value}, {out});
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
-  TestCaseData tcd;
-  tcd.addInput(std::vector<int32_t>{1, 2, 0, 2});
-  tcd.addInput(std::vector<float>{1});
-  tcd.addInput(std::vector<float>{-1});
-  tcd.addOutput(std::vector<float>{-1, -1, 1, -1, -1, 1, 1, -1, -1, -1, -1, 1});
-  _context->addTestCase(tcd);
+  _context->addTestCase(TestCaseData{}
+                            .addInput<int32_t>({1, 2, 0, 2})
+                            .addInput<float>({1})
+                            .addInput<float>({-1})
+                            .addOutput<float>({-1, -1, 1, -1, -1, 1, 1, -1, -1, -1, -1, 1}));
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
 
   SUCCEED();
@@ -88,11 +86,10 @@ TEST_F(GenModelTest, OneOp_OneHot_IndicesValueToNeg_OffValueToConst)
   cgen.setInputsAndOutputs({indices, on_value}, {out});
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
-  TestCaseData tcd;
-  tcd.addInput(std::vector<int32_t>{1, 2, 0, -1});
-  tcd.addInput(std::vector<float>{1});
-  tcd.addOutput(std::vector<float>{0, 1, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0});
-  _context->addTestCase(tcd);
+  _context->addTestCase(TestCaseData{}
+                            .addInput<int32_t>({1, 2, 0, -1})
+                            .addInput<float>({1})
+                            .addOutput<float>({0, 1, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0}));
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
 
   SUCCEED();
@@ -113,12 +110,11 @@ TEST_F(GenModelTest, OneOp_OneHot_IndicesValueToNeg_OffValueToVar)
   cgen.setInputsAndOutputs({indices, on_value, off_value}, {out});
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
-  TestCaseData tcd;
-  tcd.addInput(std::vector<int32_t>{1, 2, 0, -1});
-  tcd.addInput(std::vector<float>{1});
-  tcd.addInput(std::vector<float>{0});
-  tcd.addOutput(std::vector<float>{0, 1, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0});
-  _context->addTestCase(tcd);
+  _context->addTestCase(TestCaseData{}
+                            .addInput<int32_t>({1, 2, 0, -1})
+                            .addInput<float>({1})
+                            .addInput<float>({0})
+                            .addOutput<float>({0, 1, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0}));
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
 
   SUCCEED();

--- a/tests/nnfw_api/src/one_op_tests/Rank.cc
+++ b/tests/nnfw_api/src/one_op_tests/Rank.cc
@@ -26,10 +26,10 @@ TEST_F(GenModelTest, OneOp_Rank)
   cgen.addOperatorRank({{in}, {out}});
   cgen.setInputsAndOutputs({in}, {out});
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
-  TestCaseData tcd;
-  tcd.addInput(std::vector<float>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18});
-  tcd.addOutput(std::vector<int32_t>{4});
-  _context->addTestCase(tcd);
+  _context->addTestCase(
+      TestCaseData{}
+          .addInput<float>({1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18})
+          .addOutput<int32_t>({4}));
   _context->setBackends({"cpu"});
 
   SUCCEED();

--- a/tests/nnfw_api/src/one_op_tests/ResizeBilinear.cc
+++ b/tests/nnfw_api/src/one_op_tests/ResizeBilinear.cc
@@ -47,10 +47,9 @@ TEST_F(GenModelTest, OneOp_ResizeBilinear_SizeToVar)
   cgen.setInputsAndOutputs({in, size}, {out});
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
-  TestCaseData tcd;
-  tcd.addInput(std::vector<int32_t>{3, 3});
-  tcd.addInput(std::vector<float>{1, 1, 2, 2});
-  tcd.addOutput(std::vector<float>{1, 1, 1, 1.666666667, 1.666666667, 1.666666667, 2, 2, 2});
+  // FIXME enable a test case the below is not a valid test case
+  //_context->addTestCase(TestCaseData{}.addInput<int32_t>({3, 3}).addInput<float>({1, 1, 2,
+  // 2}).addOutput<float>({1, 1, 1, 1.666666667, 1.666666667, 1.666666667, 2, 2, 2}));
   _context->setBackends({"cpu"});
 
   SUCCEED();

--- a/tests/nnfw_api/src/one_op_tests/Shape.cc
+++ b/tests/nnfw_api/src/one_op_tests/Shape.cc
@@ -26,10 +26,10 @@ TEST_F(GenModelTest, OneOp_Shape)
   cgen.addOperatorShape({{in}, {out}}, circle::TensorType::TensorType_INT32);
   cgen.setInputsAndOutputs({in}, {out});
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
-  TestCaseData tcd;
-  tcd.addInput(std::vector<float>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18});
-  tcd.addOutput(std::vector<int32_t>{1, 3, 3, 2});
-  _context->addTestCase(tcd);
+  _context->addTestCase(
+      TestCaseData{}
+          .addInput<float>({1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18})
+          .addOutput<int32_t>({1, 3, 3, 2}));
   _context->setBackends({"cpu"});
 
   SUCCEED();
@@ -45,10 +45,10 @@ TEST_F(GenModelTest, OneOp_Shape_Int64)
   cgen.addOperatorShape({{in}, {out}}, circle::TensorType::TensorType_INT64);
   cgen.setInputsAndOutputs({in}, {out});
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
-  TestCaseData tcd;
-  tcd.addInput(std::vector<float>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18});
-  tcd.addOutput(std::vector<int64_t>{1, 3, 3, 2});
-  _context->addTestCase(tcd);
+  _context->addTestCase(
+      TestCaseData{}
+          .addInput<float>({1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18})
+          .addOutput<int64_t>({1, 3, 3, 2}));
   _context->setBackends({"cpu"});
 
   SUCCEED();

--- a/tests/nnfw_api/src/one_op_tests/Split.cc
+++ b/tests/nnfw_api/src/one_op_tests/Split.cc
@@ -51,14 +51,11 @@ TEST_F(GenModelTest, OneOp_SplitNonConstAxis)
   cgen.setInputsAndOutputs({axis, in}, {out1, out2});
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
-
-  TestCaseData tcd;
-  tcd.addInput(std::vector<int32_t>{1});
-  tcd.addInput(std::vector<float>{1, 2, 3, 4, 5, 6, 7, 8});
-  tcd.addOutput(std::vector<float>{1, 2, 5, 6});
-  tcd.addOutput(std::vector<float>{3, 4, 7, 8});
-
-  _context->addTestCase(tcd);
+  _context->addTestCase(TestCaseData{}
+                            .addInput<int32_t>({1})
+                            .addInput<float>({1, 2, 3, 4, 5, 6, 7, 8})
+                            .addOutput<float>({1, 2, 5, 6})
+                            .addOutput<float>({3, 4, 7, 8}));
   _context->setBackends({"cpu"});
 
   SUCCEED();

--- a/tests/nnfw_api/src/one_op_tests/Tile.cc
+++ b/tests/nnfw_api/src/one_op_tests/Tile.cc
@@ -66,13 +66,12 @@ TEST_F(GenModelTest, OneOp_Tile_MulToVar)
   cgen.setInputsAndOutputs({in, multiplies}, {out});
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
-  TestCaseData tcd;
-  tcd.addInput(std::vector<float>{11, 12, 13, 21, 22, 23});
-  tcd.addInput(std::vector<int32_t>{2, 3, 1});
-  tcd.addOutput(std::vector<float>{11, 12, 13, 21, 22, 23, 11, 12, 13, 21, 22, 23,
-                                   11, 12, 13, 21, 22, 23, 11, 12, 13, 21, 22, 23,
-                                   11, 12, 13, 21, 22, 23, 11, 12, 13, 21, 22, 23});
-  _context->addTestCase(tcd);
+  _context->addTestCase(TestCaseData{}
+                            .addInput<float>({11, 12, 13, 21, 22, 23})
+                            .addInput<int32_t>({2, 3, 1})
+                            .addOutput<float>({11, 12, 13, 21, 22, 23, 11, 12, 13, 21, 22, 23,
+                                               11, 12, 13, 21, 22, 23, 11, 12, 13, 21, 22, 23,
+                                               11, 12, 13, 21, 22, 23, 11, 12, 13, 21, 22, 23}));
   _context->setBackends({"cpu"});
 
   SUCCEED();
@@ -88,11 +87,10 @@ TEST_F(GenModelTest, OneOp_Tile_VarMul)
   cgen.setInputsAndOutputs({in, mul}, {out});
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
-  TestCaseData tcd;
-  tcd.addInput(std::vector<float>{1, 2, 3, 4, 5, 6});
-  tcd.addInput(std::vector<int32_t>{1, 2});
-  tcd.addOutput(std::vector<float>{1, 2, 3, 1, 2, 3, 4, 5, 6, 4, 5, 6});
-  _context->addTestCase(tcd);
+  _context->addTestCase(TestCaseData{}
+                            .addInput<float>({1, 2, 3, 4, 5, 6})
+                            .addInput<int32_t>({1, 2})
+                            .addOutput<float>({1, 2, 3, 1, 2, 3, 4, 5, 6, 4, 5, 6}));
   _context->setBackends({"cpu"});
 
   SUCCEED();

--- a/tests/nnfw_api/src/one_op_tests/Transpose.cc
+++ b/tests/nnfw_api/src/one_op_tests/Transpose.cc
@@ -60,11 +60,10 @@ TEST_F(GenModelTest, OneOp_Transpose_PermsToVar)
   cgen.setInputsAndOutputs({in, perms}, {out});
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
-  TestCaseData tcd;
-  tcd.addInput(std::vector<float>{1, 2, 3, 4, 5, 6});
-  tcd.addInput(std::vector<int32_t>{0, 2, 1, 3});
-  tcd.addOutput(std::vector<float>{1, 4, 2, 5, 3, 6});
-  _context->addTestCase(tcd);
+  _context->addTestCase(TestCaseData{}
+                            .addInput<float>({1, 2, 3, 4, 5, 6})
+                            .addInput<int32_t>({0, 2, 1, 3})
+                            .addOutput<float>({1, 4, 2, 5, 3, 6}));
   _context->setBackends({"cpu"});
 
   SUCCEED();
@@ -80,11 +79,10 @@ TEST_F(GenModelTest, OneOp_Transpose_RegularTranspose)
   cgen.setInputsAndOutputs({in, perms}, {out});
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
-  TestCaseData tcd;
-  tcd.addInput(std::vector<float>{1, 2, 3, 4, 5, 6});
-  tcd.addInput(std::vector<int32_t>{});
-  tcd.addOutput(std::vector<float>{1, 4, 2, 5, 3, 6});
-  _context->addTestCase(tcd);
+  _context->addTestCase(TestCaseData{}
+                            .addInput<float>({1, 2, 3, 4, 5, 6})
+                            .addInput<int32_t>({})
+                            .addOutput<float>({1, 4, 2, 5, 3, 6}));
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
 
   SUCCEED();


### PR DESCRIPTION
Revise the way to add TestCaseData, to make them one-liners for many
cases. `TestCaseData` methods return `this` for convenience.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>