### PR TITLE
[luci/logex] Log memory address

### DIFF
--- a/compiler/luci/logex/src/FormattedGraph.cpp
+++ b/compiler/luci/logex/src/FormattedGraph.cpp
@@ -1176,10 +1176,17 @@ bool CircleNodeSummaryBuilderBase::build(const loco::Node *node, locop::NodeSumm
   if (node->dialect() != luci::CircleDialect::get())
     return false;
 
+  auto ptr_to_str = [](const void *ptr) {
+    std::stringstream ss;
+    ss << ptr;
+    return ss.str();
+  };
+
 #define CIRCLE_NODE(OPCODE, CLASS)                        \
   if (dynamic_cast<const CLASS *>(node))                  \
   {                                                       \
     s.opname(circle_opname(node->opnum()));               \
+    s.comments().append("Mem = " + ptr_to_str(node));     \
     return summary(dynamic_cast<const CLASS *>(node), s); \
   }
 #include <luci/IR/CircleNodes.lst>


### PR DESCRIPTION
This commit adds memory address info for each node on logging.

ONE-DCO-1.0-Signed-off-by: Cheongyo Bahk <cg.bahk@gmail.com>

---

IMO it is sometimes useful to log memory address of nodes.
Use case: when error occurred on node `0xBAADF00D` -> We can directly search in log what and where the node is.

It will looks
```
; Mem = 0x559a39c0bfa0
%0 = circle.CIRCLEINPUT()
; Mem = 0x559a39dbc030
%1 = circle.CIRCLECONST(...)
```