### PR TITLE
[onert/test] Fix test model download

### DIFF
--- a/infra/scripts/common.sh
+++ b/infra/scripts/common.sh
@@ -31,11 +31,11 @@ function CheckTestPrepared()
 {
   # Model download server setting
   if [[ -z "${MODELFILE_SERVER}" ]]; then
-    echo "[WARNING] Model file server is not set"
-    echo "          Try to use pre-downloaed model"
+    echo "Model file server is not set. Try to use default setting."
   else
     echo "Model Server: ${MODELFILE_SERVER}"
   fi
+  $INSTALL_PATH/test/onert-test prepare-model
 }
 
 # $1: (required) backend

--- a/infra/scripts/test_ubuntu_runtime_mixed.sh
+++ b/infra/scripts/test_ubuntu_runtime_mixed.sh
@@ -17,7 +17,6 @@ pushd ${ROOT_PATH} > /dev/null
 echo ""
 echo "==== Run standalone unittest begin ===="
 echo ""
-Product/out/test/onert-test prepare-model --model=nnpackage
 Product/out/test/onert-test unittest --unittestdir=Product/out/unittest_standalone
 echo ""
 echo "==== Run standalone unittest end ===="

--- a/tests/scripts/command/verify-tflite
+++ b/tests/scripts/command/verify-tflite
@@ -85,6 +85,7 @@ else
 fi
 
 $INSTALL_DIR/test/models/run_test.sh --driverbin=$TEST_DRIVER \
+    --download=off --run=on \
     --reportdir=$REPORT_DIR \
     --tapname=$TAP_NAME \
     ${MODELLIST:-} > $REPORT_DIR/verification_test.log 2>&1

--- a/tests/scripts/models/run_test.sh
+++ b/tests/scripts/models/run_test.sh
@@ -96,7 +96,7 @@ do
             TAP_NAME=${i#*=}
             ;;
         --download=*)
-            DOWNLOAD_MODE=${i#*=}
+            DOWNLOAD_MODEL=${i#*=}
             ;;
         --md5=*)
             MD5_CHECK=${i#*=}


### PR DESCRIPTION
- Don't need to set download server if user want to use default server
- verify-tfilte command don't download model file
- Download model file on prepare
- Fix typo in run_test.sh

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>