### PR TITLE
[luci-interpreter] Fallback logic for Conv2D if bad_alloc

### DIFF
--- a/compiler/luci-interpreter/src/kernels/Conv2D.cpp
+++ b/compiler/luci-interpreter/src/kernels/Conv2D.cpp
@@ -118,6 +118,7 @@ void Conv2D::configure()
     catch (std::bad_alloc &ba)
     {
       // Failed memory allocation
+      _im2col = nullptr;
     }
   }
 }


### PR DESCRIPTION
Fall back to reference kernel if memory allocation fails

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/4874