### PR TITLE
DRAFT install imgdata2hdf5.py for one-quantize

### DIFF
--- a/compiler/imgdata2hdf5/CMakeLists.txt
+++ b/compiler/imgdata2hdf5/CMakeLists.txt
@@ -10,4 +10,8 @@ add_custom_command(OUTPUT ${imgdata2hdf5_BIN}
 
 add_custom_target(imgdata2hdf5 ALL DEPENDS ${imgdata2hdf5_BIN})
 
-install(FILES ${imgdata2hdf5_BIN} DESTINATION bin)
+install(FILES ${imgdata2hdf5_BIN}
+        PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE
+                    GROUP_READ GROUP_EXECUTE
+                    WORLD_READ WORLD_EXECUTE
+        DESTINATION bin)

--- a/compiler/imgdata2hdf5/imgdata2hdf5.py
+++ b/compiler/imgdata2hdf5/imgdata2hdf5.py
@@ -1,4 +1,19 @@
 #!/usr/bin/env python3
+
+# Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import h5py as h5
 import numpy as np
 import argparse

--- a/infra/packaging/preset/20200630
+++ b/infra/packaging/preset/20200630
@@ -26,7 +26,7 @@ function preset_configure()
   # Tools
   REQUIRED_UNITS+=("tflite2circle" "circle2circle" "tflchef" "circlechef")
   REQUIRED_UNITS+=("tf2tfliteV2" "luci-interpreter" "circle-verify")
-  REQUIRED_UNITS+=("record-minmax" "circle-quantizer")
+  REQUIRED_UNITS+=("record-minmax" "circle-quantizer" "imgdata2hdf5")
   REQUIRED_UNITS+=("one-cmds")
   REQUIRED_UNITS+=("bcq-tools")
 

--- a/infra/packaging/preset/20200731_windows
+++ b/infra/packaging/preset/20200731_windows
@@ -21,7 +21,7 @@ function preset_configure()
   # Tools
   REQUIRED_UNITS+=("tflite2circle" "circle2circle" "tflchef" "circlechef")
   REQUIRED_UNITS+=("tf2tfliteV2" "luci-interpreter" "circle-verify")
-  REQUIRED_UNITS+=("record-minmax" "circle-quantizer")
+  REQUIRED_UNITS+=("record-minmax" "circle-quantizer" "imgdata2hdf5")
   REQUIRED_UNITS+=("one-cmds")
   REQUIRED_UNITS+=("bcq-tools")
 


### PR DESCRIPTION
draft to install imgdata2hdf5.py tool for one-quantize data generation

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@samsung.com>