### PR TITLE
[luci-interpreter] Support DepthwiseConv2D channel-wise quantization

### DIFF
--- a/compiler/luci-interpreter/src/kernels/DepthwiseConv2D.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/DepthwiseConv2D.test.cpp
@@ -174,21 +174,21 @@ TEST(DepthwiseConv2DTest, SInt16_CWQ_weights)
   std::vector<int32_t> ref_output_shape{1, 2, 1, output_channels};
 
   std::vector<float> input_data{
-    1,  2,  7,  8,  //
-    3,  4,  9,  10, //
-    5,  6,  11, 12, //
-    13, 14, 15, 16, //
+      1,  2,  7,  8,  //
+      3,  4,  9,  10, //
+      5,  6,  11, 12, //
+      13, 14, 15, 16, //
   };
   std::vector<float> filter_data{
-    1,  2,   3,   4,   //
-    -9, 10,  -11, 12,  //
-    5,  6,   7,   8,   //
-    13, -14, 15,  -16, //
+      1,  2,   3,   4,   //
+      -9, 10,  -11, 12,  //
+      5,  6,   7,   8,   //
+      13, -14, 15,  -16, //
   };
   std::vector<float> bias_data{1, 2, 3, 4};
   std::vector<float> ref_output_data{
-    71,  0, 99,  0,  //
-    167, 0, 227, 28, //
+      71,  0, 99,  0,  //
+      167, 0, 227, 28, //
   };
 
   float input_scale = 0.25;
@@ -198,7 +198,8 @@ TEST(DepthwiseConv2DTest, SInt16_CWQ_weights)
     bias_scales.push_back(filter_scales[i] * input_scale);
   std::vector<int32_t> zerop(4, 0);
   Tensor input_tensor = makeInputTensor<DataType::S16>(input_shape, input_scale, 0, input_data);
-  Tensor filter_tensor = makeInputTensor<DataType::S16>(filter_shape, filter_scales, zerop, 3, filter_data);
+  Tensor filter_tensor =
+      makeInputTensor<DataType::S16>(filter_shape, filter_scales, zerop, 3, filter_data);
   Tensor bias_tensor = makeInputTensor<DataType::S64>(bias_shape, bias_scales, zerop, 0, bias_data);
   Tensor output_tensor = makeOutputTensor(DataType::S16, 0.5, 0);
 

--- a/compiler/luci-interpreter/src/kernels/DepthwiseConv2D.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/DepthwiseConv2D.test.cpp
@@ -165,6 +165,60 @@ TEST(DepthwiseConv2DTest, SInt16)
   EXPECT_THAT(dequantizeTensorData(output_tensor), FloatArrayNear(ref_output_data));
 }
 
+TEST(DepthwiseConv2DTest, SInt16_CWQ_weights)
+{
+  const int output_channels = 4;
+  Shape input_shape{1, 4, 2, 2};
+  Shape filter_shape{1, 2, 2, output_channels};
+  Shape bias_shape{4};
+  std::vector<int32_t> ref_output_shape{1, 2, 1, output_channels};
+
+  std::vector<float> input_data{
+    1,  2,  7,  8,  //
+    3,  4,  9,  10, //
+    5,  6,  11, 12, //
+    13, 14, 15, 16, //
+  };
+  std::vector<float> filter_data{
+    1,  2,   3,   4,   //
+    -9, 10,  -11, 12,  //
+    5,  6,   7,   8,   //
+    13, -14, 15,  -16, //
+  };
+  std::vector<float> bias_data{1, 2, 3, 4};
+  std::vector<float> ref_output_data{
+    71,  0, 99,  0,  //
+    167, 0, 227, 28, //
+  };
+
+  float input_scale = 0.25;
+  std::vector<float> filter_scales{0.2f, 1.f, 0.5f, 0.1f};
+  std::vector<float> bias_scales;
+  for (int i = 0; i < output_channels; ++i)
+    bias_scales.push_back(filter_scales[i] * input_scale);
+  std::vector<int32_t> zerop(4, 0);
+  Tensor input_tensor = makeInputTensor<DataType::S16>(input_shape, input_scale, 0, input_data);
+  Tensor filter_tensor = makeInputTensor<DataType::S16>(filter_shape, filter_scales, zerop, 3, filter_data);
+  Tensor bias_tensor = makeInputTensor<DataType::S64>(bias_shape, bias_scales, zerop, 0, bias_data);
+  Tensor output_tensor = makeOutputTensor(DataType::S16, 0.5, 0);
+
+  DepthwiseConv2DParams params{};
+  params.padding = Padding::VALID;
+  params.depth_multiplier = 2;
+  params.stride_height = 2;
+  params.stride_width = 1;
+  params.dilation_height_factor = 1;
+  params.dilation_width_factor = 1;
+  params.activation = Activation::RELU;
+
+  DepthwiseConv2D kernel(&input_tensor, &filter_tensor, &bias_tensor, &output_tensor, params);
+  kernel.configure();
+  kernel.execute();
+
+  EXPECT_THAT(extractTensorShape(output_tensor), ::testing::ElementsAreArray(ref_output_shape));
+  EXPECT_THAT(dequantizeTensorData(output_tensor), FloatArrayNear(ref_output_data));
+}
+
 TEST(DepthwiseConv2DTest, InvalidBiasType_NEG)
 {
   Shape input_shape{1, 4, 2, 2};

--- a/compiler/luci-interpreter/src/kernels/Utils.h
+++ b/compiler/luci-interpreter/src/kernels/Utils.h
@@ -108,6 +108,51 @@ inline double getQuantizedConvolutionMultipler(float input_scale, float filter_s
   return input_product_scale / static_cast<double>(output_scale);
 }
 
+inline std::vector<double> getQuantizedConvolutionMultiplers(float input_scale,
+                                                      const std::vector<float> &filter_scale,
+                                                      float output_scale)
+{
+  std::vector<double> effective_output_scales;
+  size_t n = filter_scale.size();
+  effective_output_scales.reserve(n);
+  for (size_t i = 0; i < n; ++i)
+  {
+    effective_output_scales.push_back(
+      getQuantizedConvolutionMultipler(input_scale, filter_scale[i], output_scale));
+  }
+  return effective_output_scales;
+}
+
+struct ChannelQuantMultipliers
+{
+  int shift;
+  int32_t multiplier;
+  ChannelQuantMultipliers() = default;
+};
+
+inline std::vector<ChannelQuantMultipliers> quantizeMultipliers(const std::vector<double> &effective_scale)
+{
+  size_t n = effective_scale.size();
+  std::vector<ChannelQuantMultipliers> params(n);
+  for (size_t i = 0; i < n; ++i)
+  {
+    quantizeMultiplier(effective_scale[i], &params[i].multiplier, &params[i].shift);
+  }
+  return params;
+}
+
+// Helper wrapper to hide broadcast logic
+template <typename T> class BroadcastableWrapper
+{
+public:
+  BroadcastableWrapper(const std::vector<T> &v) : _v(v), _stride(v.size() == 1 ? 0 : 1) {}
+
+  T operator[](int idx) { return _v[idx * _stride]; }
+private:
+  const std::vector<T> &_v;
+  int _stride;
+};
+
 inline tflite::RuntimeShape getTensorShape(const Tensor *tensor)
 {
   if (tensor == nullptr)

--- a/compiler/luci-interpreter/src/kernels/Utils.h
+++ b/compiler/luci-interpreter/src/kernels/Utils.h
@@ -109,8 +109,8 @@ inline double getQuantizedConvolutionMultipler(float input_scale, float filter_s
 }
 
 inline std::vector<double> getQuantizedConvolutionMultiplers(float input_scale,
-                                                      const std::vector<float> &filter_scale,
-                                                      float output_scale)
+                                                             const std::vector<float> &filter_scale,
+                                                             float output_scale)
 {
   std::vector<double> effective_output_scales;
   size_t n = filter_scale.size();
@@ -118,7 +118,7 @@ inline std::vector<double> getQuantizedConvolutionMultiplers(float input_scale,
   for (size_t i = 0; i < n; ++i)
   {
     effective_output_scales.push_back(
-      getQuantizedConvolutionMultipler(input_scale, filter_scale[i], output_scale));
+        getQuantizedConvolutionMultipler(input_scale, filter_scale[i], output_scale));
   }
   return effective_output_scales;
 }
@@ -130,7 +130,8 @@ struct ChannelQuantMultipliers
   ChannelQuantMultipliers() = default;
 };
 
-inline std::vector<ChannelQuantMultipliers> quantizeMultipliers(const std::vector<double> &effective_scale)
+inline std::vector<ChannelQuantMultipliers>
+quantizeMultipliers(const std::vector<double> &effective_scale)
 {
   size_t n = effective_scale.size();
   std::vector<ChannelQuantMultipliers> params(n);


### PR DESCRIPTION
Supports channel-wise quantization of weights in DepthwiseConv2D sint16 kernel

ONE-DCO-1.0-Signed-off-by: Alexander Efimov <a.efimov@samsung.com>