### PR TITLE
[luci-interpreter] Support Transpose conv with channel-wise quantization 

### DIFF
--- a/compiler/luci-interpreter/src/kernels/TransposeConv.cpp
+++ b/compiler/luci-interpreter/src/kernels/TransposeConv.cpp
@@ -79,7 +79,8 @@ void TransposeConv::configure()
         input()->element_type() == DataType::S16 ? DataType::S64 : DataType::S32;
     _scratch_tensor =
         std::make_unique<Tensor>(scratch_data_type, output()->shape(), AffineQuantization{}, "");
-    const std::vector<double> real_multipliers = getQuantizedConvolutionMultiplers(input()->scale(), filter()->scales(), output()->scale());
+    const std::vector<double> real_multipliers =
+        getQuantizedConvolutionMultiplers(input()->scale(), filter()->scales(), output()->scale());
 
     *_quant_multipliers = quantizeMultipliers(real_multipliers);
   }
@@ -221,8 +222,8 @@ void TransposeConv::evalQuantizedS16() const
           {
             acc += bias_data[out_c];
           }
-          int32_t scaled_acc =
-              tflite::MultiplyByQuantizedMultiplier(acc, output_multipliers[out_c].multiplier, output_multipliers[out_c].shift);
+          int32_t scaled_acc = tflite::MultiplyByQuantizedMultiplier(
+              acc, output_multipliers[out_c].multiplier, output_multipliers[out_c].shift);
 
           scaled_acc = std::max(scaled_acc, activation_min);
           scaled_acc = std::min(scaled_acc, activation_max);

--- a/compiler/luci-interpreter/src/kernels/TransposeConv.h
+++ b/compiler/luci-interpreter/src/kernels/TransposeConv.h
@@ -20,16 +20,22 @@
 #include "core/Kernel.h"
 #include "core/KernelParams.h"
 
+#include <memory>
+
 namespace luci_interpreter
 {
 namespace kernels
 {
+
+class ChannelQuantMultipliers;
 
 class TransposeConv : public KernelWithParams<TransposeConvParams>
 {
 public:
   TransposeConv(const Tensor *output_shape, const Tensor *filter, const Tensor *input,
                 const Tensor *bias, Tensor *output, const TransposeConvParams &params);
+
+  ~TransposeConv();
 
   const Tensor *output_shape() const { return _inputs[0]; }
   const Tensor *filter() const { return _inputs[1]; }
@@ -52,8 +58,7 @@ private:
   int32_t _padding_width{};
   // The scaling factor from input to output (aka the 'real multiplier') can
   // be represented as a fixed point multiplier plus a left shift.
-  int32_t _output_multiplier = 0;
-  int _output_shift = 0;
+  std::unique_ptr<std::vector<ChannelQuantMultipliers>> _quant_multipliers;
 };
 
 } // namespace kernels

--- a/compiler/luci-interpreter/src/kernels/TransposeConv.h
+++ b/compiler/luci-interpreter/src/kernels/TransposeConv.h
@@ -20,8 +20,6 @@
 #include "core/Kernel.h"
 #include "core/KernelParams.h"
 
-#include <memory>
-
 namespace luci_interpreter
 {
 namespace kernels
@@ -58,7 +56,7 @@ private:
   int32_t _padding_width{};
   // The scaling factor from input to output (aka the 'real multiplier') can
   // be represented as a fixed point multiplier plus a left shift.
-  std::unique_ptr<std::vector<ChannelQuantMultipliers>> _quant_multipliers;
+  std::vector<ChannelQuantMultipliers> _quant_multipliers;
 };
 
 } // namespace kernels

--- a/compiler/luci-interpreter/src/kernels/TransposeConv.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/TransposeConv.test.cpp
@@ -201,21 +201,22 @@ TEST(TransposeConvTest, SInt16_CWQ_weights)
   std::vector<float> bias_data{3, 4};
 
   std::vector<float> ref_output_data{
-    4,  6,  6,  8,  10,  14,  9,  12, 13, 16, //
-    10, 12, 12, 14, 28,  32,  21, 24, 25, 28, //
-    19, 24, 27, 32, 65,  76,  45, 52, 57, 64, //
-    24, 28, 30, 34, 64,  72,  39, 44, 47, 52, //
-    42, 46, 48, 52, 106, 114, 63, 68, 71, 76, //
+      4,  6,  6,  8,  10,  14,  9,  12, 13, 16, //
+      10, 12, 12, 14, 28,  32,  21, 24, 25, 28, //
+      19, 24, 27, 32, 65,  76,  45, 52, 57, 64, //
+      24, 28, 30, 34, 64,  72,  39, 44, 47, 52, //
+      42, 46, 48, 52, 106, 114, 63, 68, 71, 76, //
   };
 
   const float input_scale = 0.25;
   const float output_scale = 0.5;
   const std::vector<float> filter_scales{0.2f, 0.5f};
-  std::vector<float> bias_scales{filter_scales[0]*input_scale, filter_scales[1]*input_scale};
+  std::vector<float> bias_scales{filter_scales[0] * input_scale, filter_scales[1] * input_scale};
   const std::vector<int32_t> zerop(2, 0);
 
   Tensor input_tensor = makeInputTensor<DataType::S16>(input_shape, input_scale, 0, input_data);
-  Tensor filter_tensor = makeInputTensor<DataType::S16>(filter_shape, filter_scales, zerop, 0, filter_data);
+  Tensor filter_tensor =
+      makeInputTensor<DataType::S16>(filter_shape, filter_scales, zerop, 0, filter_data);
   Tensor bias_tensor = makeInputTensor<DataType::S64>(bias_shape, bias_scales, zerop, 0, bias_data);
   Tensor output_shape_tensor = makeInputTensor<DataType::S32>({4}, output_shape_data);
   Tensor output_tensor = makeOutputTensor(DataType::S16, output_scale, 0);

--- a/compiler/luci-interpreter/src/kernels/TransposeConv.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/TransposeConv.test.cpp
@@ -188,6 +188,52 @@ TEST(TransposeConvTest, SInt16)
   EXPECT_THAT(dequantizeTensorData(output_tensor), FloatArrayNear(ref_output_data));
 }
 
+TEST(TransposeConvTest, SInt16_CWQ_weights)
+{
+  const int output_channels = 2;
+  const Shape input_shape{1, 2, 2, 1};
+  const Shape filter_shape{output_channels, 3, 3, 1};
+  const Shape bias_shape{output_channels};
+  std::vector<int32_t> output_shape_data{1, 5, 5, output_channels};
+
+  std::vector<float> input_data{1, 2, 3, 4};
+  std::vector<float> filter_data{1, 3, 5, 7, 9, 11, 13, 15, 17, 2, 4, 6, 8, 10, 12, 14, 16, 18};
+  std::vector<float> bias_data{3, 4};
+
+  std::vector<float> ref_output_data{
+    4,  6,  6,  8,  10,  14,  9,  12, 13, 16, //
+    10, 12, 12, 14, 28,  32,  21, 24, 25, 28, //
+    19, 24, 27, 32, 65,  76,  45, 52, 57, 64, //
+    24, 28, 30, 34, 64,  72,  39, 44, 47, 52, //
+    42, 46, 48, 52, 106, 114, 63, 68, 71, 76, //
+  };
+
+  const float input_scale = 0.25;
+  const float output_scale = 0.5;
+  const std::vector<float> filter_scales{0.2f, 0.5f};
+  std::vector<float> bias_scales{filter_scales[0]*input_scale, filter_scales[1]*input_scale};
+  const std::vector<int32_t> zerop(2, 0);
+
+  Tensor input_tensor = makeInputTensor<DataType::S16>(input_shape, input_scale, 0, input_data);
+  Tensor filter_tensor = makeInputTensor<DataType::S16>(filter_shape, filter_scales, zerop, 0, filter_data);
+  Tensor bias_tensor = makeInputTensor<DataType::S64>(bias_shape, bias_scales, zerop, 0, bias_data);
+  Tensor output_shape_tensor = makeInputTensor<DataType::S32>({4}, output_shape_data);
+  Tensor output_tensor = makeOutputTensor(DataType::S16, output_scale, 0);
+
+  TransposeConvParams params{};
+  params.padding = Padding::VALID;
+  params.stride_height = 2;
+  params.stride_width = 2;
+
+  TransposeConv kernel(&output_shape_tensor, &filter_tensor, &input_tensor, &bias_tensor,
+                       &output_tensor, params);
+  kernel.configure();
+  kernel.execute();
+
+  EXPECT_THAT(extractTensorShape(output_tensor), ::testing::ElementsAreArray(output_shape_data));
+  EXPECT_THAT(dequantizeTensorData(output_tensor), FloatArrayNear(ref_output_data));
+}
+
 } // namespace
 } // namespace kernels
 } // namespace luci_interpreter


### PR DESCRIPTION
Support channel-wise quantization of weights in Depthwise conv 2d kernel

ONE-DCO-1.0-Signed-off-by: Alexander Efimov <a.efimov@samsung.com>

need merge #4940 first