### PR TITLE
[draft] Remove memcpy in reshape

### DIFF
--- a/runtime/onert/backend/cpu/StaticTensorManager.h
+++ b/runtime/onert/backend/cpu/StaticTensorManager.h
@@ -43,7 +43,7 @@ public:
   void deallocateNonconsts(void);
 
   void buildTensor(const ir::OperandIndex &ind, const ir::OperandInfo &tensor_info,
-                   ir::Layout backend_layout, bool as_const);
+                   ir::Layout backend_layout, bool as_const, unsigned int as_reshape);
 
   void claimPlan(const ir::OperandIndex &ind, uint32_t size);
   void releasePlan(const ir::OperandIndex &ind);
@@ -54,6 +54,8 @@ private:
   std::unique_ptr<cpu_common::MemoryManager> _nonconst_mgr;
   const std::shared_ptr<cpu_common::TensorRegistry> _tensors;
   ir::OperandIndexMap<bool> _as_constants;
+  ir::OperandIndexMap<bool> _as_reshape;
+  ir::OperandIndexMap<unsigned int> _as_out_reshape;
   cpu_common::DynamicTensorManager *_dynamic_tensor_manager;
 };
 

--- a/runtime/onert/backend/cpu/TensorBuilder.cc
+++ b/runtime/onert/backend/cpu/TensorBuilder.cc
@@ -39,7 +39,6 @@ void TensorBuilder::registerTensorInfo(const ir::OperandIndex &ind, const ir::Op
                                        ir::Layout layout)
 {
   _tensor_info_map.emplace(ind, info);
-
   // CPU backend supports only one layout as NHWC
   assert(layout == ir::Layout::NHWC);
   if (info.isDynamic())
@@ -48,7 +47,7 @@ void TensorBuilder::registerTensorInfo(const ir::OperandIndex &ind, const ir::Op
   }
   else
   {
-    _static_tensor_mgr->buildTensor(ind, info, layout, info.isConstant());
+    _static_tensor_mgr->buildTensor(ind, info, layout, info.isConstant(), info.isReshape());
   }
 }
 
@@ -56,7 +55,6 @@ void TensorBuilder::notifyFirstUse(const ir::OperandIndex &ind)
 {
   assert(_tensor_info_map.find(ind) != _tensor_info_map.end());
   const auto tensor_info = _tensor_info_map.at(ind);
-
   if (!_tensor_reg->getNativeTensor(ind)->is_dynamic())
   {
     const auto size = tensor_info.total_size();

--- a/runtime/onert/backend/cpu/ops/ReshapeLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ReshapeLayer.cc
@@ -32,6 +32,10 @@ ReshapeLayer::ReshapeLayer() : _input(nullptr), _shape(nullptr), _output(nullptr
 
 void ReshapeLayer::reshapeGeneric()
 {
+  if (_input->buffer() == _output->buffer())
+  {
+    return;
+  }
   size_t count = _input->total_size();
   memcpy(_output->buffer(), _input->buffer(), count);
 }

--- a/runtime/onert/core/include/ir/Operand.h
+++ b/runtime/onert/core/include/ir/Operand.h
@@ -65,6 +65,7 @@ public:
     _data = std::move(data);
     _info.setAsConstant();
   }
+  void setReshape(unsigned int mod) { _info.setAsReshape(mod); }
   const Data *data(void) const { return _data.get(); }
 
   void releaseData(void) { _data.reset(); }
@@ -77,6 +78,7 @@ public:
    */
   bool isConstant(void) const { return _info.isConstant(); }
 
+  unsigned int isReshape(void) const { return _info.isReshape(); }
 public:
   template <typename T, typename... Args> void data(Args &&... args)
   {

--- a/runtime/onert/core/include/ir/OperandInfo.h
+++ b/runtime/onert/core/include/ir/OperandInfo.h
@@ -66,9 +66,9 @@ public:
    * @param[in] alloc_type  When the thesor needs memory allocation
    */
   OperandInfo(const Shape &shape, const TypeInfo &typeInfo, MemAllocType alloc_type,
-              bool is_const = false, bool is_variable = false)
+              bool is_const = false, unsigned int is_reshape = 0, bool is_variable = false)
       : _shape(shape), _typeInfo(typeInfo), _alloc_type(alloc_type), _const(is_const),
-        _variable(is_variable)
+        _reshape(is_reshape), _variable(is_variable)
   {
     // DO NOTHING
   }
@@ -118,6 +118,7 @@ public:
 
   MemAllocType memAllocType() const { return _alloc_type; }
   void setAsConstant() { _const = true; }
+  void setAsReshape(unsigned int mod) { _reshape = mod; }
   void setAsNonConst() { _const = false; }
   bool isConstant() const
   {
@@ -125,6 +126,7 @@ public:
     assert(!(isDynamic() && _const));
     return _const;
   }
+  unsigned int isReshape() const { return _reshape; }
   void setAsVariable()
   {
     // Impossible case: constant or dynamic operand
@@ -142,6 +144,7 @@ private:
 
   MemAllocType _alloc_type;
   bool _const;
+  unsigned int _reshape;
   bool _variable;
 };
 

--- a/runtime/onert/core/src/backend/controlflow/TensorBuilder.cc
+++ b/runtime/onert/core/src/backend/controlflow/TensorBuilder.cc
@@ -42,7 +42,6 @@ void TensorBuilder::registerTensorInfo(const ir::OperandIndex &ind, const ir::Op
   _tensor_info_map.emplace(ind, info);
 
   _tensor_layout_map.insert({ind, backend_layout});
-
   if (info.isDynamic())
   {
     _dynamic_tensor_mgr->buildTensor(ind, info, _tensor_layout_map[ind]);

--- a/runtime/onert/core/src/backend/cpu_common/MemoryPlanner.cc
+++ b/runtime/onert/core/src/backend/cpu_common/MemoryPlanner.cc
@@ -128,6 +128,7 @@ void WICPlanner::claim(const ir::OperandIndex &ind, size_t size)
   {
     _interference_graph[live_operand].emplace_back(ind);
   }
+
   _live_operands.emplace(ind);
 
   VERBOSE(WIC_PLANNER) << "claim(#" << ind.value() << "): [" << size << "sz]" << std::endl;

--- a/runtime/onert/core/src/compiler/ExecutorFactory.cc
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.cc
@@ -35,6 +35,7 @@
 #include "backend/controlflow/KernelGenerator.h"
 #include "backend/controlflow/UserTensor.h"
 #include "backend/controlflow/TensorBuilder.h"
+
 #include <memory>
 
 namespace onert
@@ -176,7 +177,7 @@ void ExecutorFactory::runTensorRegistration(compiler::LoweredGraph *lowered_grap
             const auto backend_layout = operand_lower_info.layout();
             ir::OperandInfo backend_info{permuteShape(obj.shape(), frontend_layout, backend_layout),
                                          obj.typeInfo(), obj.info().memAllocType(),
-                                         obj.isConstant()};
+                                         obj.isConstant(), obj.isReshape()};
             tensor_builder->registerTensorInfo(index, backend_info, backend_layout);
           }
         }
@@ -438,6 +439,8 @@ exec::IExecutor *ExecutorFactory::createDataflowExecutor(
   {
     tensor_builder->allocate();
   }
+
+  // reshape output shared data
 
   for (auto &pair : backend_contexts)
   {

--- a/runtime/onert/core/src/compiler/Linear.h
+++ b/runtime/onert/core/src/compiler/Linear.h
@@ -46,6 +46,9 @@ public:
                    const std::vector<ir::OpSequenceIndex> &order);
   static void planTensors(const compiler::LoweredGraph &lowered_graph,
                           const std::vector<ir::OpSequenceIndex> &order);
+
+public:
+  ir::OperandIndexMap<bool> _is_reshape;
 };
 
 } // namespace compiler

--- a/runtime/onert/core/src/ir/Graph.cc
+++ b/runtime/onert/core/src/ir/Graph.cc
@@ -117,11 +117,23 @@ void Graph::initializeUseDef()
     auto outputs = node.getOutputs();
     for (auto output : outputs | ir::Remove::UNDEFINED)
     {
+      if (node.name() == "Reshape")
+      {
+        operands().at(output).setReshape((unsigned int)1 << 31);
+      }
       operands().at(output).setDef(index);
     }
 
+    bool add_reshape = false;
+
     for (auto input : node.getInputs() | ir::Remove::UNDEFINED)
     {
+      if (node.name() == "Reshape" && !add_reshape)
+      {
+        operands().at(input).setReshape(((unsigned int)1 << 30) | node.getOutputs().at(0).value());
+
+        add_reshape = true;
+      }
       operands().at(input).insertUse(index);
     }
   });


### PR DESCRIPTION
When reshape operating, we don't use memcpy.
Because, input data and output data are same.
So only move memony point.

TODO -
The input buffer should deallocated after use output buffer.
Modified to be usable in neon and acl.

Signed-off-by: YiHyunjin <hj0412.yi@samsung.com>