### PR TITLE
[infra] format checking of one-cmds as python

### DIFF
--- a/infra/command/format
+++ b/infra/command/format
@@ -195,6 +195,14 @@ function check_python_files() {
     if [[ ${f} == *.py ]]; then
       FILES_TO_CHECK_PYTHON+=("${f}")
     fi
+    # Exceptional case: one-cmds don't have '.py' extension
+    if [[ ${f} == compiler/one-cmds/* ]]; then
+      # Ignore non-python source (cmake, etc)
+      # Ignore shell script: one-prepare-venv
+      if [[ ${f} != compiler/one-cmds/*.* ]] && [[ ${f} != compiler/one-cmds/one-prepare-venv ]]; then
+        FILES_TO_CHECK_PYTHON+=("${f}")
+      fi
+    fi
   done
   for s in ${DIRECTORIES_NOT_TO_BE_TESTED[@]}; do
     skip=${s#'.'/}/


### PR DESCRIPTION
This commit adds one-cmds to python file lists of format script.

Related : #4886

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>
Co-authored-by: Hyeongseok Oh hseok82.oh@samsung.com