### PR TITLE
[luci] Fix nullptr warning in FusePreActivationBatchNormPass

### DIFF
--- a/compiler/luci/pass/src/FusePreActivationBatchNormPass.cpp
+++ b/compiler/luci/pass/src/FusePreActivationBatchNormPass.cpp
@@ -508,8 +508,7 @@ bool fuse_mul_with_conv(luci::CircleMul *mul)
   auto mul_succ = loco::succs(mul);
   assert(mul_succ.size() == 1);
 
-  auto relu = dynamic_cast<luci::CircleRelu *>(*mul_succ.begin());
-  assert(relu != nullptr);
+  auto relu = loco::must_cast<luci::CircleRelu *>(*mul_succ.begin());
 
   auto channel_size = gamma->dim(0).value();
 


### PR DESCRIPTION
This commit will fix `nullptr` warning in `FusePreActivationBatchNormPass`

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>