### PR TITLE
[infra] Get arch from env var in runtime test script

### DIFF
--- a/infra/scripts/test_ubuntu_runtime.sh
+++ b/infra/scripts/test_ubuntu_runtime.sh
@@ -3,8 +3,8 @@
 set -eo pipefail
 source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 
+: ${TEST_ARCH:=$(uname -m | tr '[:upper:]' '[:lower:]')}
 BACKEND="cpu"
-TEST_ARCH=$(uname -m | tr '[:upper:]' '[:lower:]')
 TEST_OS="linux"
 TEST_PLATFORM="$TEST_ARCH-$TEST_OS"
 TFLITE_LOADER="0"

--- a/infra/scripts/test_ubuntu_runtime_mixed.sh
+++ b/infra/scripts/test_ubuntu_runtime_mixed.sh
@@ -6,7 +6,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 CheckTestPrepared
 
 # TODO Get argument for mix configuration
-TEST_ARCH=$(uname -m | tr '[:upper:]' '[:lower:]')
+: ${TEST_ARCH:=$(uname -m | tr '[:upper:]' '[:lower:]')}
 TEST_OS="linux"
 
 # nnfw_api_gtest


### PR DESCRIPTION
This commit makes runtime test script possible to get arch from env var.

Related : #4957 
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>