### PR TITLE
[luci] Introduce temporary luci pass for refactoring

### DIFF
--- a/compiler/luci/pass/include/luci/Pass/CopyLocoItemsToCirclePass.h
+++ b/compiler/luci/pass/include/luci/Pass/CopyLocoItemsToCirclePass.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __LUCI_COPY_LOCO_ITEMS_TO_CIRCLE_PASS_H__
+#define __LUCI_COPY_LOCO_ITEMS_TO_CIRCLE_PASS_H__
+
+#include <loco.h>
+
+#include <logo/Pass.h>
+
+namespace luci
+{
+
+/**
+ * @brief Pass to copy shape/dtype of loco to circle node
+ *
+ * CAUTION : This pass will be removed after refactoring is finished
+ */
+class CopyLocoItemsToCirclePass : public logo::Pass
+{
+public:
+  virtual const char *name(void) const { return "luci::CopyLocoItemsToCirclePass"; }
+
+public:
+  bool run(loco::Graph *graph);
+};
+
+} // namespace luci
+
+#endif //__LUCI_COPY_LOCO_ITEMS_TO_CIRCLE_PASS_H__

--- a/compiler/luci/pass/src/CopyLocoItemsToCirclePass.cpp
+++ b/compiler/luci/pass/src/CopyLocoItemsToCirclePass.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Pass/CopyLocoItemsToCirclePass.h"
+
+#include <luci/IR/CircleNodes.h>
+#include <luci/Service/CircleShapeInferenceRule.h>
+#include <luci/Service/CircleTypeInferenceRule.h>
+
+#include <loco.h>
+
+namespace
+{
+
+bool is_same_shape(luci::CircleNode *node, loco::TensorShape shape)
+{
+  if (node->rank() != shape.rank())
+    return false;
+
+  for (uint32_t i = 0; i < shape.rank(); ++i)
+    if (!(node->dim(i) == shape.dim(i)))
+      return false;
+
+  return true;
+}
+
+} // namespace
+
+namespace luci
+{
+
+bool CopyLocoItemsToCirclePass::run(loco::Graph *g)
+{
+  bool changed = false;
+
+  for (auto node : loco::postorder_traversal(loco::output_nodes(g)))
+  {
+    auto circle_node = loco::must_cast<luci::CircleNode *>(node);
+    if (loco::shape_known(node))
+    {
+      auto loco_shape = loco::shape_get(node).as<loco::TensorShape>();
+      if (!is_same_shape(circle_node, loco_shape))
+      {
+        circle_node->rank(loco_shape.rank());
+        for (uint32_t i = 0; i < loco_shape.rank(); ++i)
+          circle_node->dim(i) = loco_shape.dim(i);
+        circle_node->shape_status(luci::ShapeStatus::VALID);
+
+        changed = true;
+      }
+    }
+
+    if (loco::dtype_known(node))
+    {
+      if (loco::dtype_get(node) != circle_node->dtype())
+      {
+        circle_node->dtype(loco::dtype_get(node));
+        changed = true;
+      }
+    }
+  }
+
+  return changed;
+}
+
+} // namespace luci


### PR DESCRIPTION
Parent Issue : #4796

This commit introduce `CopyLocoItemsToCirclePass`,
which is temporary `luci/Pass` for refactoring `luci`.
When refactoring is finished, this pass will be removed.

/cc @parjong 

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>