### PR TITLE
[luci] Support importing/exporting shape signature

### DIFF
--- a/compiler/luci/export/src/CircleTensorExporter.cpp
+++ b/compiler/luci/export/src/CircleTensorExporter.cpp
@@ -19,6 +19,7 @@
 
 #include <luci/IR/CircleNodes.h>
 #include <luci/IR/CircleNodeVisitor.h>
+#include <luci/IR/CircleShapeSignature.h>
 #include <luci/Service/CircleTypeInference.h>
 #include <luci/Service/CircleShapeInference.h>
 #include <luci/Log.h>
@@ -53,6 +54,9 @@ public:
   const ShapeDescription &shape(void) const { return _shape; }
   void shape(const ShapeDescription &shape) { _shape = shape; }
 
+  const ShapeSignature &shape_signature(void) const { return _shape_signature; }
+  void shape_signature(const ShapeSignature &ss) { _shape_signature = ss; }
+
   luci::ShapeStatus shape_status(void) const { return _shape_status; }
   void shape_status(luci::ShapeStatus ss) { _shape_status = ss; }
 
@@ -71,6 +75,7 @@ private:
 
   circle::TensorType _dtype{circle::TensorType_FLOAT32};
   ShapeDescription _shape{};
+  ShapeSignature _shape_signature;
   luci::ShapeStatus _shape_status{luci::ShapeStatus::UNDEFINED};
 
   luci::CircleConst *_content = nullptr;
@@ -107,6 +112,7 @@ void allocateCircleTensorInfo(CircleNode *node, CircleTensorContext &ctx)
 
   tensor_info.name(tensor_name);
   tensor_info.dtype(to_circle_tensortype(luci::node_dtype(node)));
+  tensor_info.shape_signature(node->shape_signature());
   if (node->shape_status() == ShapeStatus::VALID)
     tensor_info.shape(to_shape_description(luci::node_shape(node)));
   tensor_info.shape_status(node->shape_status());
@@ -232,6 +238,12 @@ flatbuffers::Offset<Vector<int32_t>> encodeShape(FlatBufferBuilder &builder,
 {
   assert(shape._rank_known && "unknown number of dimensions is not supported");
   return builder.CreateVector(shape._dims);
+}
+
+flatbuffers::Offset<Vector<int32_t>> encodeShapeSignature(FlatBufferBuilder &builder,
+                                                          const ShapeSignature &shape_signature)
+{
+  return builder.CreateVector(shape_signature.as_vector());
 }
 
 flatbuffers::Offset<circle::Buffer> encodeOpBuffer(FlatBufferBuilder &builder)
@@ -430,11 +442,14 @@ void exportOpDefinedTensor(const CircleTensoInfo &info, FlatBufferBuilder &build
 
   auto sparsityparam = encodeSparsityParameters(builder, info.sparsityparam());
 
+  auto shape_signature_offset = encodeShapeSignature(builder, info.shape_signature());
+
   auto buffer_id = get_buffer_id(builder, md, info.content());
 
   auto name_offset = builder.CreateString(info.name());
-  auto tensor_offset = CreateTensor(builder, shape_offset, info.dtype(), buffer_id, name_offset,
-                                    quantparam, /*is_variable*/ false, sparsityparam);
+  auto tensor_offset =
+      CreateTensor(builder, shape_offset, info.dtype(), buffer_id, name_offset, quantparam,
+                   /*is_variable*/ false, sparsityparam, shape_signature_offset);
   gd._tensors.push_back(tensor_offset);
 }
 

--- a/compiler/luci/import/include/luci/Import/CircleReader.h
+++ b/compiler/luci/import/include/luci/Import/CircleReader.h
@@ -23,6 +23,7 @@
 #include <luci/IR/AttrPadding.h>
 #include <luci/IR/CircleNode.h>
 #include <luci/IR/CircleQuantParam.h>
+#include <luci/IR/CircleShapeSignature.h>
 #include <luci/IR/SparsityParam.h>
 
 #include <loco.h>

--- a/compiler/luci/import/src/CircleReader.cpp
+++ b/compiler/luci/import/src/CircleReader.cpp
@@ -253,6 +253,8 @@ void copy_tensor_attributes(const circle::TensorT &tensor, CircleNode *node)
     node->dim(r) = loco::Dimension(dims[r]);
   }
 
+  node->shape_signature(tensor.shape_signature);
+
   const auto *quantization = tensor.quantization.get();
   if (quantization != nullptr)
   {


### PR DESCRIPTION
Parent Issue : #4372

This commit will enable supporting importing/exporting
`ShapeSignature` in `luci`.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>