### PR TITLE
[one-cmds] Fix prepare of rawdata2hdf5

### DIFF
--- a/compiler/one-cmds/tests/prepare_test_materials.sh
+++ b/compiler/one-cmds/tests/prepare_test_materials.sh
@@ -52,11 +52,11 @@ fi
 if [ ! -s "raw_files" ] && [ ! -s "datalist.txt" ]; then
     rm -rf raw_files
     rm -rf datalist.txt
-    ../bin/python preprocess_images.py
+    ../bin/venv/bin/python preprocess_images.py
 fi
 
 if [[ ! -s "inception_v3_test_data.h5" ]]; then
-  ../bin/python ../bin/rawdata2hdf5 \
+  ../bin/venv/bin/python ../bin/rawdata2hdf5 \
   --data_list datalist.txt \
   --output_path inception_v3_test_data.h5
 fi


### PR DESCRIPTION
This will fix prepare_test_materials for calling rawdata2hdf5

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>