### PR TITLE
[one-cmds] Add URL info for test materials

### DIFF
--- a/compiler/one-cmds/tests/prepare_test_materials.sh
+++ b/compiler/one-cmds/tests/prepare_test_materials.sh
@@ -29,24 +29,28 @@ if [[ ! -s "while_3.pbtxt" ]]; then
     rm -rf while_3.zip
     wget https://github.com/Samsung/ONE/files/5095630/while_3.zip
     unzip while_3.zip
+    # https://github.com/Samsung/ONE/issues/4155#issuecomment-689320297
 fi
 
 if [[ ! -s "mobilenet_test_data.h5" ]]; then
     rm -rf mobilenet_test_data.zip
     wget https://github.com/Samsung/ONE/files/5139460/mobilenet_test_data.zip
     unzip mobilenet_test_data.zip
+    # https://github.com/Samsung/ONE/issues/4155#issuecomment-689321538
 fi
 
 if [[ ! -s "bcq.pb" ]]; then
     rm -rf bcq.pb.zip
     wget https://github.com/Samsung/ONE/files/5153842/bcq.pb.zip
     unzip bcq.pb.zip
+    # https://github.com/Samsung/ONE/issues/4155#issuecomment-689324597
 fi
 
 if [[ ! -s "img_files" ]]; then
     rm -rf img_files
     wget https://github.com/Samsung/ONE/files/5499172/img_files.zip
     unzip img_files.zip
+    # https://github.com/Samsung/ONE/issues/3213#issuecomment-722757499
 fi
 
 if [ ! -s "raw_files" ] && [ ! -s "datalist.txt" ]; then


### PR DESCRIPTION
This will add github issue URL info for test materials where the
download source exists

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>