### PR TITLE
[one-cmds] add converter_version option to cfg

### DIFF
--- a/compiler/one-cmds/one-build.template.cfg
+++ b/compiler/one-cmds/one-build.template.cfg
@@ -13,7 +13,7 @@ output_path=inception_v3.circle
 input_arrays=input
 input_shapes=1,299,299,3
 output_arrays=InceptionV3/Predictions/Reshape_1
-v2=True
+converter_version=v1
 
 [one-optimize]
 input_path=inception_v3.circle

--- a/compiler/one-cmds/one-import-bcq
+++ b/compiler/one-cmds/one-import-bcq
@@ -53,7 +53,7 @@ def _get_parser():
         const='--v2',
         help='use TensorFlow Lite Converter 2.x')
 
-    converter_version.set_defaults(converter_version='--v1')
+    parser.add_argument('--converter_version', type=str, help=argparse.SUPPRESS)
 
     # input and output path.
     tf2tfliteV2_group.add_argument(

--- a/compiler/one-cmds/one-import-tf
+++ b/compiler/one-cmds/one-import-tf
@@ -42,17 +42,19 @@ def _get_parser():
     converter_version.add_argument(
         '--v1',
         action='store_const',
-        dest='converter_version',
+        dest='converter_version_cmd',
         const='--v1',
         help='use TensorFlow Lite Converter 1.x')
     converter_version.add_argument(
         '--v2',
         action='store_const',
-        dest='converter_version',
+        dest='converter_version_cmd',
         const='--v2',
         help='use TensorFlow Lite Converter 2.x')
 
-    converter_version.set_defaults(converter_version='--v1')
+    #converter_version.set_defaults(converter_version='--v1')
+
+    parser.add_argument('--converter_version', type=str, help=argparse.SUPPRESS)
 
     # input model format
     model_format_arg = tf2tfliteV2_group.add_mutually_exclusive_group()

--- a/compiler/one-cmds/utils.py
+++ b/compiler/one-cmds/utils.py
@@ -71,8 +71,12 @@ def _make_tf2tfliteV2_cmd(args, driver_path, input_path, output_path):
     if _is_valid_attr(args, 'model_format'):
         cmd.append(getattr(args, 'model_format'))
     # converter version
-    if _is_valid_attr(args, 'converter_version'):
-        cmd.append(getattr(args, 'converter_version'))
+    if _is_valid_attr(args, 'converter_version_cmd'):
+        cmd.append(getattr(args, 'converter_version_cmd'))
+    elif _is_valid_attr(args, 'converter_version'):
+        cmd.append('--' + getattr(args, 'converter_version'))
+    else:
+        cmd.append('--v1')  # default value
     # input_path
     if _is_valid_attr(args, 'input_path'):
         cmd.append('--input_path')


### PR DESCRIPTION
This commit adds converter_version option to cfg file.

```bash
$ cat one-build.template.cfg
[one-import-tf]
input_path=/path/to/inception_v3.pb
output_path=inception_v3.circle
input_arrays=input
input_shapes=1,299,299,3
output_arrays=InceptionV3/Predictions/Reshape_1
# converter_version=v1

$ ./one-import-tf -C one-build.template.cfg        # use v1
$ ./one-import-tf -C one-build.template.cfg --v2   # use v2

$ cat one-build.template.cfg
[one-import-tf]
input_path=/path/to/inception_v3.pb
output_path=inception_v3.circle
input_arrays=input
input_shapes=1,299,299,3
output_arrays=InceptionV3/Predictions/Reshape_1
converter_version=v2

$ ./one-import-tf -C one-build.template.cfg        # use v2
$ ./one-import-tf -C one-build.template.cfg --v1   # use v1

```
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>