### PR TITLE
[tflchef] Fix type check

### DIFF
--- a/compiler/tflchef/core/src/CustomOp/MaxPoolWithArgMax.cpp
+++ b/compiler/tflchef/core/src/CustomOp/MaxPoolWithArgMax.cpp
@@ -65,13 +65,13 @@ MaxPoolWithArgMaxChef::custom_value(flatbuffers::FlatBufferBuilder &fbb) const
   flex_buffers->Add(1);
   flex_buffers->EndVector(start, /*typed=*/true, /*fixed=*/false);
   auto output_type = operation.max_pool_with_argmax_options().output_type();
-  assert(output_type == tflite::TensorType_INT64 || output_type == tflite::TensorType_INT32);
+  assert(output_type == tflchef::INT64 || output_type == tflchef::INT32);
   flex_buffers->Int("Targmax", output_type);
   std::string padding = operation.max_pool_with_argmax_options().padding() ? "VALID" : "SAME";
   flex_buffers->String("padding", padding);
   flex_buffers->Bool("include_batch_in_index",
                      operation.max_pool_with_argmax_options().include_batch_in_index());
-  flex_buffers->Int("T", tflite::TensorType_FLOAT32);
+  flex_buffers->Int("T", tflchef::FLOAT32);
   flex_buffers->EndMap(map_start);
   flex_buffers->Finish();
 


### PR DESCRIPTION
This will fix type check namespace in MaxPoolWithArgMax

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>