### PR TITLE
[onert] Refactoring method names for execution observer

### DIFF
--- a/runtime/onert/core/src/exec/DataflowExecutor.cc
+++ b/runtime/onert/core/src/exec/DataflowExecutor.cc
@@ -143,7 +143,7 @@ void DataflowExecutor::executeImpl()
   }
   assert(!_ready_jobs.empty()); // Cannot begin if there is no initial jobs
 
-  _subject.notifyModelBegin(this);
+  _subject.notifySubgraphBegin(this);
 
   while (!_ready_jobs.empty())
   {
@@ -173,7 +173,7 @@ void DataflowExecutor::executeImpl()
   }
   assert(noWaitingJobs());
 
-  _subject.notifyModelEnd(this);
+  _subject.notifySubgraphEnd(this);
 
   // Reset input info for the next execution
   _input_info = _initial_input_info;

--- a/runtime/onert/core/src/exec/ExecutionObservee.cc
+++ b/runtime/onert/core/src/exec/ExecutionObservee.cc
@@ -26,19 +26,19 @@ void ExecutionObservee::add(std::unique_ptr<IExecutionObserver> observer)
   _observers.emplace_back(std::move(observer));
 }
 
-void ExecutionObservee::notifyModelBegin(IExecutor *executor)
+void ExecutionObservee::notifySubgraphBegin(IExecutor *executor)
 {
   for (auto &o : _observers)
   {
-    o->handleBegin(executor);
+    o->handleSubgraphBegin(executor);
   }
 }
 
-void ExecutionObservee::notifyModelEnd(IExecutor *executor)
+void ExecutionObservee::notifySubgraphEnd(IExecutor *executor)
 {
   for (auto &o : _observers)
   {
-    o->handleEnd(executor);
+    o->handleSubgraphEnd(executor);
   }
 }
 
@@ -47,7 +47,7 @@ void ExecutionObservee::notifyJobBegin(IExecutor *executor, const ir::OpSequence
 {
   for (auto &o : _observers)
   {
-    o->handleBegin(executor, op_seq, backend);
+    o->handleJobBegin(executor, op_seq, backend);
   }
 }
 
@@ -56,7 +56,7 @@ void ExecutionObservee::notifyJobEnd(IExecutor *executor, const ir::OpSequence *
 {
   for (auto &o : _observers)
   {
-    o->handleEnd(executor, op_seq, backend);
+    o->handleJobEnd(executor, op_seq, backend);
   }
 }
 

--- a/runtime/onert/core/src/exec/ExecutionObservee.h
+++ b/runtime/onert/core/src/exec/ExecutionObservee.h
@@ -39,8 +39,8 @@ public:
    * @param observer Observer to be added
    */
   void add(std::unique_ptr<IExecutionObserver> observer);
-  void notifyModelBegin(IExecutor *executor);
-  void notifyModelEnd(IExecutor *executor);
+  void notifySubgraphBegin(IExecutor *executor);
+  void notifySubgraphEnd(IExecutor *executor);
   void notifyJobBegin(IExecutor *executor, const ir::OpSequence *op_seq,
                       const backend::Backend *backend);
   void notifyJobEnd(IExecutor *executor, const ir::OpSequence *op_seq,

--- a/runtime/onert/core/src/exec/ExecutionObservers.cc
+++ b/runtime/onert/core/src/exec/ExecutionObservers.cc
@@ -30,8 +30,8 @@ namespace onert
 namespace exec
 {
 
-void ProfileObserver::handleBegin(onert::exec::IExecutor *, const ir::OpSequence *,
-                                  const onert::backend::Backend *backend)
+void ProfileObserver::handleJobBegin(onert::exec::IExecutor *, const ir::OpSequence *,
+                                     const onert::backend::Backend *backend)
 {
   _timer = backend->config()->timer();
   if (_timer == nullptr)
@@ -39,8 +39,8 @@ void ProfileObserver::handleBegin(onert::exec::IExecutor *, const ir::OpSequence
   _timer->handleBegin();
 }
 
-void ProfileObserver::handleEnd(IExecutor *exec, const ir::OpSequence *op_seq,
-                                const backend::Backend *backend)
+void ProfileObserver::handleJobEnd(IExecutor *exec, const ir::OpSequence *op_seq,
+                                   const backend::Backend *backend)
 {
   _timer->handleEnd();
   const auto timer_res = _timer->getTime();
@@ -87,28 +87,28 @@ ChromeTracingObserver::~ChromeTracingObserver()
   }
 }
 
-void ChromeTracingObserver::handleBegin(IExecutor *)
+void ChromeTracingObserver::handleSubgraphBegin(IExecutor *)
 {
   _collector.onEvent(EventCollector::Event{EventCollector::Edge::BEGIN, "runtime", "Graph"});
 }
 
-void ChromeTracingObserver::handleBegin(IExecutor *, const ir::OpSequence *op_seq,
-                                        const backend::Backend *backend)
+void ChromeTracingObserver::handleJobBegin(IExecutor *, const ir::OpSequence *op_seq,
+                                           const backend::Backend *backend)
 {
   std::string backend_id = backend->config()->id();
   _collector.onEvent(EventCollector::Event{EventCollector::Edge::BEGIN, backend_id,
                                            opSequenceTag(op_seq, _graph.operations())});
 }
 
-void ChromeTracingObserver::handleEnd(IExecutor *, const ir::OpSequence *op_seq,
-                                      const backend::Backend *backend)
+void ChromeTracingObserver::handleJobEnd(IExecutor *, const ir::OpSequence *op_seq,
+                                         const backend::Backend *backend)
 {
   std::string backend_id = backend->config()->id();
   _collector.onEvent(EventCollector::Event{EventCollector::Edge::END, backend_id,
                                            opSequenceTag(op_seq, _graph.operations())});
 }
 
-void ChromeTracingObserver::handleEnd(IExecutor *)
+void ChromeTracingObserver::handleSubgraphEnd(IExecutor *)
 {
   _collector.onEvent(EventCollector::Event{EventCollector::Edge::END, "runtime", "Graph"});
 }

--- a/runtime/onert/core/src/exec/ExecutionObservers.h
+++ b/runtime/onert/core/src/exec/ExecutionObservers.h
@@ -33,13 +33,13 @@ class IExecutionObserver
 {
 public:
   /// @brief Invoked just before model (not individual operation) execution begins
-  virtual void handleBegin(IExecutor *) { return; }
+  virtual void handleSubgraphBegin(IExecutor *) { return; }
 
-  virtual void handleBegin(IExecutor *, const ir::OpSequence *, const backend::Backend *) = 0;
-  virtual void handleEnd(IExecutor *, const ir::OpSequence *, const backend::Backend *) = 0;
+  virtual void handleJobBegin(IExecutor *, const ir::OpSequence *, const backend::Backend *) = 0;
+  virtual void handleJobEnd(IExecutor *, const ir::OpSequence *, const backend::Backend *) = 0;
 
   /// @brief Invoked just after model (not individual operation) execution ends
-  virtual void handleEnd(IExecutor *) { return; }
+  virtual void handleSubgraphEnd(IExecutor *) { return; }
 
   virtual ~IExecutionObserver() = default;
 };
@@ -51,10 +51,10 @@ public:
       : _et(std::move(et)), _graph(graph)
   {
   }
-  void handleBegin(IExecutor *, const ir::OpSequence *, const backend::Backend *) override;
-  void handleEnd(IExecutor *, const ir::OpSequence *, const backend::Backend *) override;
+  void handleJobBegin(IExecutor *, const ir::OpSequence *, const backend::Backend *) override;
+  void handleJobEnd(IExecutor *, const ir::OpSequence *, const backend::Backend *) override;
 
-  void handleEnd(IExecutor *) override { _et->uploadOperationsExecTime(); }
+  void handleSubgraphEnd(IExecutor *) override { _et->uploadOperationsExecTime(); }
 
 private:
   std::unique_ptr<util::ITimer> _timer;
@@ -67,10 +67,10 @@ class ChromeTracingObserver : public IExecutionObserver
 public:
   ChromeTracingObserver(const std::string &filepath, const ir::Graph &graph);
   ~ChromeTracingObserver();
-  void handleBegin(IExecutor *) override;
-  void handleBegin(IExecutor *, const ir::OpSequence *, const backend::Backend *) override;
-  void handleEnd(IExecutor *, const ir::OpSequence *, const backend::Backend *) override;
-  void handleEnd(IExecutor *) override;
+  void handleSubgraphBegin(IExecutor *) override;
+  void handleJobBegin(IExecutor *, const ir::OpSequence *, const backend::Backend *) override;
+  void handleJobEnd(IExecutor *, const ir::OpSequence *, const backend::Backend *) override;
+  void handleSubgraphEnd(IExecutor *) override;
 
 private:
   static std::string opSequenceTag(const ir::OpSequence *op_seq, const ir::Operations &operations);

--- a/runtime/onert/core/src/exec/LinearExecutor.cc
+++ b/runtime/onert/core/src/exec/LinearExecutor.cc
@@ -39,7 +39,7 @@ char *seq_to_label(const onert::ir::OpSequence *op_seq, const onert::ir::Operati
 
 void LinearExecutor::executeImpl()
 {
-  _subject.notifyModelBegin(this);
+  _subject.notifySubgraphBegin(this);
   for (auto &&code : _code)
   {
     const auto op_seq = code.op_seq;
@@ -60,7 +60,7 @@ void LinearExecutor::executeImpl()
 
     _subject.notifyJobEnd(this, op_seq, backend);
   }
-  _subject.notifyModelEnd(this);
+  _subject.notifySubgraphEnd(this);
 }
 
 } // namespace exec

--- a/runtime/onert/core/src/exec/ParallelExecutor.cc
+++ b/runtime/onert/core/src/exec/ParallelExecutor.cc
@@ -100,7 +100,7 @@ void ParallelExecutor::executeImpl()
 
   VERBOSE(ParallelExecutor) << "INITIAL JOBS : " << _ready_jobs.size() << std::endl;
 
-  _subject.notifyModelBegin(this);
+  _subject.notifySubgraphBegin(this);
   while (true)
   {
     std::unique_lock<std::mutex> lock{_mu_jobs};
@@ -146,7 +146,7 @@ void ParallelExecutor::executeImpl()
 
   // Wait for all the jobs done
   _scheduler->finish();
-  _subject.notifyModelEnd(this);
+  _subject.notifySubgraphEnd(this);
 
   // Reset input info for the next execution
   _input_info = _initial_input_info;


### PR DESCRIPTION
Refactor method names for execution observer.

For example,
- `notifyModelBegin` -> `notifySubgraphBegin` : to use the term in ONERT code
- `handleBegin` -> `handleSubgraphBegin`, `handleJobBegin` : to clearly
      distinguish subgraph and job

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>