### PR TITLE
[onert/util] introduce external config_source

### DIFF
--- a/runtime/onert/core/include/util/ConfigSource.h
+++ b/runtime/onert/core/include/util/ConfigSource.h
@@ -27,6 +27,7 @@ namespace util
 {
 
 void config_source(std::unique_ptr<IConfigSource> &&source);
+void config_source_ext(std::unique_ptr<IConfigSource> &&source);
 
 bool toBool(const std::string &val);
 int toInt(const std::string &val);

--- a/runtime/onert/core/src/util/ConfigSource.cc
+++ b/runtime/onert/core/src/util/ConfigSource.cc
@@ -30,8 +30,10 @@ namespace util
 {
 
 static std::unique_ptr<IConfigSource> _source;
+static std::unique_ptr<IConfigSource> _source_ext;
 
 void config_source(std::unique_ptr<IConfigSource> &&source) { _source = std::move(source); }
+void config_source_ext(std::unique_ptr<IConfigSource> &&source) { _source_ext = std::move(source); }
 
 static IConfigSource *config_source()
 {
@@ -65,6 +67,15 @@ static std::string getConfigOrDefault(const std::string &key)
 
   // Treat empty string and absence of the value to be the same
   auto ret = config_source()->get(key);
+  if (ret.empty())
+  {
+    // if env is not set, search from external
+    if (_source_ext.get())
+    {
+      ret = _source_ext.get()->get(key);
+    }
+  }
+  // if not found search from defaults
   if (ret.empty())
   {
     auto itr = defaults.find(key);


### PR DESCRIPTION
This will introduce external config_source that can override default configuration values

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>