### PR TITLE
[luci] Export ShapeSignature only when size is larger than 0

### DIFF
--- a/compiler/luci/export/src/CircleTensorExporter.cpp
+++ b/compiler/luci/export/src/CircleTensorExporter.cpp
@@ -243,6 +243,9 @@ flatbuffers::Offset<Vector<int32_t>> encodeShape(FlatBufferBuilder &builder,
 flatbuffers::Offset<Vector<int32_t>> encodeShapeSignature(FlatBufferBuilder &builder,
                                                           const ShapeSignature &shape_signature)
 {
+  if (shape_signature.rank() == 0)
+    return 0;
+
   return builder.CreateVector(shape_signature.as_vector());
 }
 


### PR DESCRIPTION
Parent Issue : #4372

If rank of `ShapeSignature` is 0, we do not need to export it.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>