### PR TITLE
[luci] Introduce ShapeSignatureInferencePass in luci

### DIFF
--- a/compiler/luci/pass/include/luci/Pass/ShapeSignatureInferencePass.h
+++ b/compiler/luci/pass/include/luci/Pass/ShapeSignatureInferencePass.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __LUCI_SHAPE_SIGNATURE_INFERENCE_PASS_H__
+#define __LUCI_SHAPE_SIGNATURE_INFERENCE_PASS_H__
+
+#include <loco.h>
+
+#include <logo/Pass.h>
+
+namespace luci
+{
+
+/**
+ * @brief Pass to infer shape_signature of nodes
+ */
+class ShapeSignatureInferencePass : public logo::Pass
+{
+public:
+  virtual const char *name(void) const { return "luci::ShapeSignatureInferencePass"; }
+
+public:
+  bool run(loco::Graph *graph);
+};
+
+} // namespace luci
+
+#endif //__LUCI_SHAPE_SIGNATURE_INFERENCE_PASS_H__

--- a/compiler/luci/pass/src/ShapeSignatureInferencePass.cpp
+++ b/compiler/luci/pass/src/ShapeSignatureInferencePass.cpp
@@ -21,23 +21,6 @@
 
 #include <loco.h>
 
-namespace
-{
-
-bool is_same_signature(luci::ShapeSignature lhs, luci::ShapeSignature rhs)
-{
-  if (lhs.rank() != rhs.rank())
-    return false;
-
-  for (uint32_t i = 0; i < lhs.rank(); ++i)
-    if (lhs.dim(i) != rhs.dim(i))
-      return false;
-
-  return true;
-}
-
-} // namespace
-
 namespace luci
 {
 
@@ -53,7 +36,7 @@ bool ShapeSignatureInferencePass::run(loco::Graph *g)
     auto circle_node = loco::must_cast<luci::CircleNode *>(node);
     if (signature_inference_rule.infer(circle_node, shape_signature))
     {
-      if (!is_same_signature(circle_node->shape_signature(), shape_signature))
+      if (!(circle_node->shape_signature() == shape_signature))
       {
         circle_node->shape_signature(shape_signature);
         changed = true;

--- a/compiler/luci/pass/src/ShapeSignatureInferencePass.cpp
+++ b/compiler/luci/pass/src/ShapeSignatureInferencePass.cpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Pass/ShapeSignatureInferencePass.h"
+
+#include <luci/IR/CircleShapeSignature.h>
+#include <luci/Service/CircleShapeSignatureInferenceRule.h>
+
+#include <loco.h>
+
+namespace
+{
+
+bool is_same_signature(luci::ShapeSignature lhs, luci::ShapeSignature rhs)
+{
+  if (lhs.rank() != rhs.rank())
+    return false;
+
+  for (uint32_t i = 0; i < lhs.rank(); ++i)
+    if (lhs.dim(i) != rhs.dim(i))
+      return false;
+
+  return true;
+}
+
+} // namespace
+
+namespace luci
+{
+
+bool ShapeSignatureInferencePass::run(loco::Graph *g)
+{
+  luci::CircleShapeSignatureInferenceRule signature_inference_rule;
+  bool changed = false;
+
+  for (auto node : loco::postorder_traversal(loco::output_nodes(g)))
+  {
+    luci::ShapeSignature shape_signature;
+
+    auto circle_node = loco::must_cast<luci::CircleNode *>(node);
+    if (signature_inference_rule.infer(circle_node, shape_signature))
+    {
+      if (!is_same_signature(circle_node->shape_signature(), shape_signature))
+      {
+        circle_node->shape_signature(shape_signature);
+        changed = true;
+      }
+    }
+  }
+
+  return changed;
+}
+
+} // namespace luci


### PR DESCRIPTION
Parent Issue : #4372 

This commit will introduce `ShapeSigantureInferencePass` in `luci`

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>