### PR TITLE
[luci] Shape signature inference algorithm for Input,Output

### DIFF
--- a/compiler/luci/service/include/luci/Service/CircleShapeSignatureInference.h
+++ b/compiler/luci/service/include/luci/Service/CircleShapeSignatureInference.h
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-#ifndef __LUCI_CIRCLE_SHAPE_SIGNATURE_INFERENCE_RULE_H__
-#define __LUCI_CIRCLE_SHAPE_SIGNATURE_INFERENCE_RULE_H__
+#ifndef __LUCI_CIRCLE_SHAPE_SIGNATURE_INFERENCE_H__
+#define __LUCI_CIRCLE_SHAPE_SIGNATURE_INFERENCE_H__
 
 #include <luci/IR/CircleNodes.h>
 #include <luci/IR/CircleNodeVisitor.h>
 #include <luci/IR/CircleShapeSignature.h>
+#include <luci/Service/CircleShapeSignatureInferenceHelper.h>
 
 namespace luci
 {
@@ -155,8 +156,8 @@ public:
   // ShapeSignature visit(const luci::CircleInstanceNorm *node) final;
 
   // Virtual
-  // ShapeSignature visit(const luci::CircleInput *node) final;
-  // ShapeSignature visit(const luci::CircleOutput *node) final;
+  ShapeSignature visit(const luci::CircleInput *node) final;
+  ShapeSignature visit(const luci::CircleOutput *node) final;
   // ShapeSignature visit(const luci::CircleOutputDummy *node) final;
   // ShapeSignature visit(const luci::CircleOutputExclude *node) final;
   // ShapeSignature visit(const luci::CircleCustomOut *node) final;
@@ -175,4 +176,4 @@ public:
 
 } // namespace luci
 
-#endif // __LUCI_CIRCLE_SHAPE_SIGNATURE_INFERENCE_RULE_H__
+#endif // __LUCI_CIRCLE_SHAPE_SIGNATURE_INFERENCE_H__

--- a/compiler/luci/service/include/luci/Service/CircleShapeSignatureInferenceHelper.h
+++ b/compiler/luci/service/include/luci/Service/CircleShapeSignatureInferenceHelper.h
@@ -26,7 +26,7 @@ namespace luci
 namespace ssinf // Namespace for Shape Signature Inference
 {
 
-ShapeSignature signature_of_input(const luci::CircleNode *node, uint32_t index);
+ShapeSignature signature_of_arg(const luci::CircleNode *node, uint32_t index);
 
 } // namespace ssinf
 

--- a/compiler/luci/service/include/luci/Service/CircleShapeSignatureInferenceHelper.h
+++ b/compiler/luci/service/include/luci/Service/CircleShapeSignatureInferenceHelper.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __LUCI_CIRCLE_SHAPE_SIGNATURE_INFERENCE_HELPER_H__
+#define __LUCI_CIRCLE_SHAPE_SIGNATURE_INFERENCE_HELPER_H__
+
+#include <luci/IR/CircleNodes.h>
+#include <luci/IR/CircleShapeSignature.h>
+
+namespace luci
+{
+
+namespace ssinf // Namespace for Shape Signature Inference
+{
+
+ShapeSignature signature_of_input(const luci::CircleNode *node, uint32_t index);
+
+} // namespace ssinf
+
+} // namespace luci
+
+#endif // __LUCI_CIRCLE_SHAPE_SIGNATURE_INFERENCE_HELPER_H__

--- a/compiler/luci/service/src/CircleShapeSignatureInferenceHelper.cpp
+++ b/compiler/luci/service/src/CircleShapeSignatureInferenceHelper.cpp
@@ -22,7 +22,7 @@ namespace luci
 namespace ssinf
 {
 
-ShapeSignature signature_of_input(const luci::CircleNode *node, uint32_t index)
+ShapeSignature signature_of_arg(const luci::CircleNode *node, uint32_t index)
 {
   auto circle_input = loco::must_cast<luci::CircleNode *>(node->arg(index));
   return circle_input->shape_signature();

--- a/compiler/luci/service/src/CircleShapeSignatureInferenceHelper.cpp
+++ b/compiler/luci/service/src/CircleShapeSignatureInferenceHelper.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Service/CircleShapeSignatureInferenceHelper.h"
+
+namespace luci
+{
+
+namespace ssinf
+{
+
+ShapeSignature signature_of_input(const luci::CircleNode *node, uint32_t index)
+{
+  auto circle_input = loco::must_cast<luci::CircleNode *>(node->arg(index));
+  return circle_input->shape_signature();
+}
+
+} // namespace ssinf
+
+} // namespace luci

--- a/compiler/luci/service/src/Nodes/CircleInput.cpp
+++ b/compiler/luci/service/src/Nodes/CircleInput.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <luci/Service/CircleShapeSignatureInference.h>
+
+namespace luci
+{
+
+ShapeSignature ssinf::Algorithm::visit(const luci::CircleInput *node)
+{
+  return node->shape_signature();
+}
+
+} // namespace luci

--- a/compiler/luci/service/src/Nodes/CircleOutput.cpp
+++ b/compiler/luci/service/src/Nodes/CircleOutput.cpp
@@ -21,7 +21,7 @@ namespace luci
 
 ShapeSignature ssinf::Algorithm::visit(const luci::CircleOutput *node)
 {
-  return signature_of_input(node, 0);
+  return signature_of_arg(node, 0);
 }
 
 } // namespace luci

--- a/compiler/luci/service/src/Nodes/CircleOutput.cpp
+++ b/compiler/luci/service/src/Nodes/CircleOutput.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <luci/Service/CircleShapeSignatureInference.h>
+
+namespace luci
+{
+
+ShapeSignature ssinf::Algorithm::visit(const luci::CircleOutput *node)
+{
+  return signature_of_input(node, 0);
+}
+
+} // namespace luci


### PR DESCRIPTION
Parent Issue : #5037

This commit introduces `ShapeSignatureInferenceAlgorithm` for

- `CircleInput`
- `CircleOutput`

and `ShapeSignatureInferenceHelper`.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>