### PR TITLE
[luci] Introduce operator== for ShapeSignature

### DIFF
--- a/compiler/luci/lang/include/luci/IR/CircleShapeSignature.h
+++ b/compiler/luci/lang/include/luci/IR/CircleShapeSignature.h
@@ -46,6 +46,8 @@ private:
   std::vector<int32_t> _shape_signature{};
 };
 
+bool operator==(const ShapeSignature &lhs, const ShapeSignature &rhs);
+
 } // namespace luci
 
 #endif // __LUCI_IR_SHAPE_SIGNATURE_H__

--- a/compiler/luci/lang/src/CircleShapeSignature.cpp
+++ b/compiler/luci/lang/src/CircleShapeSignature.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/IR/CircleShapeSignature.h"
+
+namespace luci
+{
+
+bool operator==(const ShapeSignature &lhs, const ShapeSignature &rhs)
+{
+  if (lhs.rank() != rhs.rank())
+    return false;
+
+  for (uint32_t i = 0; i < lhs.rank(); ++i)
+    if (lhs.dim(i) != rhs.dim(i))
+      return false;
+
+  return true;
+}
+
+} // namespace luci


### PR DESCRIPTION
Parent Issue : #4372

This commit will introduce `operator==` for `ShapeSignature`

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>