### PR TITLE
[luci] Re-design shape signature inference service

### DIFF
--- a/compiler/luci/pass/src/ShapeSignatureInferencePass.cpp
+++ b/compiler/luci/pass/src/ShapeSignatureInferencePass.cpp
@@ -17,7 +17,7 @@
 #include "luci/Pass/ShapeSignatureInferencePass.h"
 
 #include <luci/IR/CircleShapeSignature.h>
-#include <luci/Service/CircleShapeSignatureInferenceRule.h>
+#include <luci/Service/CircleShapeSignatureInference.h>
 
 #include <loco.h>
 
@@ -26,7 +26,7 @@ namespace luci
 
 bool ShapeSignatureInferencePass::run(loco::Graph *g)
 {
-  luci::CircleShapeSignatureInferenceRule signature_inference_rule;
+  luci::ssinf::Rule signature_inference_rule;
   bool changed = false;
 
   for (auto node : loco::postorder_traversal(loco::output_nodes(g)))

--- a/compiler/luci/service/include/luci/Service/CircleShapeSignatureInference.h
+++ b/compiler/luci/service/include/luci/Service/CircleShapeSignatureInference.h
@@ -24,12 +24,15 @@
 namespace luci
 {
 
-struct CircleShapeSignatureInferenceRule
+namespace ssinf // namespace for Shape Signature Inference
+{
+
+struct Rule
 {
   bool infer(const luci::CircleNode *, ShapeSignature &) const;
 };
 
-class ShapeSignatureInferenceAlgorithm final : public luci::CircleNodeVisitor<ShapeSignature>
+class Algorithm final : public luci::CircleNodeVisitor<ShapeSignature>
 {
 public:
   // TODO Remove this when visit function is implemented for all the operations.
@@ -167,6 +170,8 @@ public:
   // ShapeSignature visit(const luci::CircleUnpackOut *node) final;
   // ShapeSignature visit(const luci::CircleWhileOut *node) final;
 };
+
+} // namespace ssinf
 
 } // namespace luci
 

--- a/compiler/luci/service/src/CircleShapeSignatureInference.cpp
+++ b/compiler/luci/service/src/CircleShapeSignatureInference.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "luci/Service/CircleShapeSignatureInferenceRule.h"
+#include "luci/Service/CircleShapeSignatureInference.h"
 
 #include <luci/Log.h>
 
@@ -39,14 +39,16 @@ std::ostream &operator<<(std::ostream &os, const luci::ShapeSignature &shape_sig
 namespace luci
 {
 
-bool CircleShapeSignatureInferenceRule::infer(const luci::CircleNode *circle_node,
-                                              ShapeSignature &shape_signature) const
+namespace ssinf
+{
+
+bool Rule::infer(const luci::CircleNode *circle_node, ShapeSignature &shape_signature) const
 {
   LOGGER(l);
 
   // There is nothing to check before ShapeSignatureInference.
 
-  ShapeSignatureInferenceAlgorithm alg;
+  Algorithm alg;
 
   shape_signature = circle_node->accept(&alg);
 
@@ -56,5 +58,7 @@ bool CircleShapeSignatureInferenceRule::infer(const luci::CircleNode *circle_nod
 
   return true;
 }
+
+} // namespace ssinf
 
 } // namespace luci


### PR DESCRIPTION
Parent Issue : #4372 

This commit will re-design `luci/Service` of `ShapeSignature` by
- Introducing inner namespace
- Renaming class/struct/file

and apply those changes to `CircleShapeSignatureInferencePass`

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>