### PR TITLE
[model2nnpkg] Fix typo

### DIFF
--- a/tools/nnpackage_tool/model2nnpkg/model2nnpkg.sh
+++ b/tools/nnpackage_tool/model2nnpkg/model2nnpkg.sh
@@ -80,7 +80,7 @@ cat > "$outdir"/"$name"/metadata/MANIFEST <<-EOF
   "major-version" : "1",
   "minor-version" : "1",
   "patch-version" : "0",
-  "configs      : [ "$config" ],
+  "configs"     : [ "$config" ],
   "models"      : [ "$modelfile" ],
   "model-types" : [ "$extension" ]
 }


### PR DESCRIPTION
Fix parsing error by typo in MANIFEST file

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>