### PR TITLE
[test/nnfw_api]Fix init to use returned value from dirname

### DIFF
--- a/tests/nnfw_api/src/NNPackages.cc
+++ b/tests/nnfw_api/src/NNPackages.cc
@@ -43,11 +43,11 @@ void NNPackages::init(const char *argv0)
   char raw_dir[1024];
   char cwd[1024];
   strncpy(raw_dir, argv0, sizeof(raw_dir) - 1);
-  dirname(raw_dir);
-  if (raw_dir[0] == '/')
+  char* dir_path = dirname(raw_dir);
+  if (dir_path[0] == '/')
   {
     // If it is an absolute path, just use it
-    _base_path = raw_dir;
+    _base_path = dir_path;
   }
   else
   {
@@ -55,7 +55,7 @@ void NNPackages::init(const char *argv0)
     getcwd(cwd, sizeof(cwd));
     _base_path = cwd;
     _base_path += "/";
-    _base_path += raw_dir;
+    _base_path += dir_path;
   }
 }
 

--- a/tests/nnfw_api/src/NNPackages.cc
+++ b/tests/nnfw_api/src/NNPackages.cc
@@ -43,7 +43,7 @@ void NNPackages::init(const char *argv0)
   char raw_dir[1024];
   char cwd[1024];
   strncpy(raw_dir, argv0, sizeof(raw_dir) - 1);
-  char* dir_path = dirname(raw_dir);
+  char *dir_path = dirname(raw_dir);
   if (dir_path[0] == '/')
   {
     // If it is an absolute path, just use it


### PR DESCRIPTION
For #4702 
on Android test, `dirname(path)` return char* of directory and not update path to directory.
So, Change to use returned value.

ONE-DCO-1.0-Signed-off-by: KiDeuk Bang <rrstrous@nate.com>