### PR TITLE
[onert] Make ctor of ir::Graph take subgraph index param

### DIFF
--- a/runtime/onert/core/include/ir/Graph.h
+++ b/runtime/onert/core/include/ir/Graph.h
@@ -52,7 +52,13 @@ private:
   };
 
 public:
-  Graph(void);
+  /**
+   * @brief Construct a new ir::Graph object
+   *
+   * @param subg_index Subgraph index from tflite or circle subgraph
+   *                   Pass 0 if a model has only 1 subgraph. (0 means primary subgraph)
+   */
+  Graph(uint32_t subg_index);
   ~Graph(void);
 
   // Graph Building
@@ -103,6 +109,11 @@ public:
   const std::shared_ptr<Subgraphs> &subgraphs() const { return _subgraphs; }
   std::shared_ptr<Subgraphs> &subgraphs() { return _subgraphs; }
   Layout layout() const { return _layout; }
+  SubgraphIndex subg_index() const
+  {
+    assert(!_subg_index.undefined());
+    return _subg_index;
+  }
 
 private:
   Phase _phase{Phase::BUILDING};
@@ -116,6 +127,9 @@ private:
   std::shared_ptr<Subgraphs> _subgraphs;
   // TFLite and circle's default layout is NHWC;
   Layout _layout{Layout::NHWC};
+
+  // subgraph index of this subgraph in a model
+  SubgraphIndex _subg_index;
 };
 
 } // namespace ir

--- a/runtime/onert/core/src/ir/Graph.cc
+++ b/runtime/onert/core/src/ir/Graph.cc
@@ -36,7 +36,7 @@ namespace onert
 namespace ir
 {
 
-Graph::Graph() = default;
+Graph::Graph(uint32_t subg_index) : _subg_index(subg_index) { /* empty */}
 
 Graph::~Graph(void) = default;
 

--- a/runtime/onert/frontend/base_loader/include/base_loader.h
+++ b/runtime/onert/frontend/base_loader/include/base_loader.h
@@ -110,7 +110,7 @@ protected:
   template <typename Param> void loadPool2DOptions(Param &param, const Pool2DOptions *options);
 
 private:
-  virtual std::unique_ptr<ir::Graph> loadSubgraph(const SubGraph *subg) = 0;
+  virtual std::unique_ptr<ir::Graph> loadSubgraph(const SubGraph *subg, uint32_t index) = 0;
   // Operations
   template <typename OpIR, typename... Args>
   const OpIR *loadOperationTo(const Operator *op, ir::Graph &subg, Args &&... args);
@@ -1577,7 +1577,7 @@ template <typename LoaderDomain> void BaseLoader<LoaderDomain>::loadModel()
   auto subgraphs = std::make_unique<ir::Subgraphs>();
   for (uint32_t subgraph_index = 0; subgraph_index < domain_subgraphs->size(); ++subgraph_index)
   {
-    auto subg = loadSubgraph((*_model->subgraphs())[subgraph_index]);
+    auto subg = loadSubgraph((*_model->subgraphs())[subgraph_index], subgraph_index);
     subgraphs->push(ir::SubgraphIndex{subgraph_index}, std::move(subg));
   }
   _subgraphs = std::move(subgraphs);

--- a/runtime/onert/frontend/circle/src/circle_loader.cc
+++ b/runtime/onert/frontend/circle/src/circle_loader.cc
@@ -93,9 +93,10 @@ public:
   }
 
 private:
-  std::unique_ptr<ir::Graph> loadSubgraph(const circle::SubGraph *circle_subg) override
+  std::unique_ptr<ir::Graph> loadSubgraph(const circle::SubGraph *circle_subg,
+                                          uint32_t index) override
   {
-    auto subg = std::make_unique<ir::Graph>();
+    auto subg = std::make_unique<ir::Graph>(index);
     // Load tensors
     _tensor_to_operand.resize(circle_subg->tensors()->size());
     for (flatbuffers::uoffset_t i = 0; i < circle_subg->tensors()->size(); ++i)

--- a/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksModel.cc
+++ b/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksModel.cc
@@ -29,7 +29,8 @@
 ANeuralNetworksModel::ANeuralNetworksModel() noexcept
     : _optional_operands{}, _operand_usages{}, _allowFloat32toFloat16{false}
 {
-  _graph = std::make_shared<onert::ir::Graph>();
+  uint32_t primary_subgraph_index = 0;
+  _graph = std::make_shared<onert::ir::Graph>(primary_subgraph_index);
 }
 
 bool ANeuralNetworksModel::addOperand(const ANeuralNetworksOperandType *type) noexcept

--- a/runtime/onert/frontend/tflite/src/tflite_loader.cc
+++ b/runtime/onert/frontend/tflite/src/tflite_loader.cc
@@ -80,9 +80,10 @@ public:
   }
 
 private:
-  std::unique_ptr<ir::Graph> loadSubgraph(const onert_tflite::SubGraph *tflite_subg) override
+  std::unique_ptr<ir::Graph> loadSubgraph(const onert_tflite::SubGraph *tflite_subg,
+                                          uint32_t index) override
   {
-    auto subg = std::make_unique<ir::Graph>();
+    auto subg = std::make_unique<ir::Graph>(index);
     // Load tensors
     _tensor_to_operand.resize(tflite_subg->tensors()->size());
     for (flatbuffers::uoffset_t i = 0; i < tflite_subg->tensors()->size(); ++i)

--- a/runtime/onert/test/core/compiler/Scheduler.cc
+++ b/runtime/onert/test/core/compiler/Scheduler.cc
@@ -217,7 +217,7 @@ OperationIndex create(std::shared_ptr<Graph> graph, Types &&... args)
 // Create straight graph: Add->Sub->Mul
 std::shared_ptr<Graph> createStraightGraph()
 {
-  auto graph = std::make_shared<Graph>();
+  auto graph = std::make_shared<Graph>(0);
   const TypeInfo float_op(DataType::FLOAT32);
 
   // Create add node
@@ -254,7 +254,7 @@ std::shared_ptr<Graph> createStraightGraph()
  */
 std::shared_ptr<Graph> createBranchedGraph()
 {
-  auto graph = std::make_shared<Graph>();
+  auto graph = std::make_shared<Graph>(0);
   const TypeInfo float_op(DataType::FLOAT32);
 
   // Create add node

--- a/runtime/onert/test/core/exec/ExecInstance.cc
+++ b/runtime/onert/test/core/exec/ExecInstance.cc
@@ -40,7 +40,7 @@ public:
     // result2 <= (result1 + rhs2)
     // lhs, rhs1, rh2, result1, result2 shape: {1, 2, 2, 1}
     // activation: none (constant)
-    graph = std::make_shared<Graph>();
+    graph = std::make_shared<Graph>(0);
     // 1st add operands (result1 <= lhs + rhs1)
     Shape shape{1, 2, 2, 1};
     TypeInfo type{DataType::FLOAT32};

--- a/runtime/onert/test/core/interp/ExecManager.cc
+++ b/runtime/onert/test/core/interp/ExecManager.cc
@@ -42,7 +42,7 @@ protected:
     // model output: add result
     // lhs, rhs, result shape: {1, 2, 2, 1}
     // activation: none (constant)
-    _graph = std::make_unique<Graph>();
+    _graph = std::make_unique<Graph>(0);
 
     // Add operands
 
@@ -92,7 +92,7 @@ protected:
     // result2 <= (result1 + rhs2)
     // lhs, rhs1, rh2, result1, result2 shape: {1, 2, 2, 1}
     // activation: none (constant)
-    _graph = std::make_unique<Graph>();
+    _graph = std::make_unique<Graph>(0);
 
     // 1st add operands (result1 <= lhs + rhs1)
 
@@ -154,7 +154,7 @@ protected:
     // model output: add result
     // lhs, rhs, result shape: {1, unknown, 2, 1}
     // activation: none (constant)
-    _graph = std::make_unique<Graph>();
+    _graph = std::make_unique<Graph>(0);
 
     // Add operands
 
@@ -213,7 +213,7 @@ protected:
 
 TEST_F(InterpExecutorTest, create_empty)
 {
-  Graph graph;
+  Graph graph{0};
   graph.finishBuilding();
   auto executor = std::make_unique<InterpExecutor>(graph);
   ASSERT_NE(executor, nullptr);

--- a/runtime/onert/test/graph/Graph.cc
+++ b/runtime/onert/test/graph/Graph.cc
@@ -22,7 +22,7 @@
 
 TEST(Graph, neg_inputs_and_outputs)
 {
-  onert::ir::Graph graph;
+  onert::ir::Graph graph{0};
 
   onert::ir::OperandIndex index0{0u};
   onert::ir::OperandIndex index1{1u};
@@ -71,7 +71,7 @@ TEST(Graph, OneOpGraphFinish)
 {
   // Simple Graph with just one Add operation
 
-  Graph graph;
+  Graph graph{0};
 
   // Add tensors
   Shape shape{1, 2, 2, 1};
@@ -94,7 +94,7 @@ TEST(Graph, OneOpGraphFinish)
 
 TEST(Graph, neg_InvalidGraphFinish_BadInput)
 {
-  Graph graph;
+  Graph graph{0};
 
   // Add tensors
   Shape shape{1, 2, 2, 1};
@@ -112,7 +112,7 @@ TEST(Graph, neg_InvalidGraphFinish_BadInput)
 
 TEST(Graph, neg_InvalidGraphFinish_BadOutput)
 {
-  Graph graph;
+  Graph graph{0};
 
   // Add tensors
   Shape shape{1, 2, 2, 1};
@@ -130,7 +130,7 @@ TEST(Graph, neg_InvalidGraphFinish_BadOutput)
 
 TEST(Graph, neg_InvalidGraphFinish_BadInputOutputForOp)
 {
-  Graph graph;
+  Graph graph{0};
 
   // Add tensors
   Shape shape{1, 2, 2, 1};

--- a/runtime/onert/test/graph/operand/UseDef.cc
+++ b/runtime/onert/test/graph/operand/UseDef.cc
@@ -33,7 +33,7 @@ using Mock = onert_test::ir::SimpleMock;
 
 TEST(ir_Operand, neg_usedef)
 {
-  onert::ir::Graph graph;
+  onert::ir::Graph graph{0};
   onert::ir::verifier::DAGChecker verifier;
 
   onert::ir::Shape shape(3);

--- a/runtime/onert/test/graph/operation/SetIO.cc
+++ b/runtime/onert/test/graph/operation/SetIO.cc
@@ -31,7 +31,7 @@ using IndexSet = onert::ir::OperandIndexSequence;
 
 TEST(ir_Operation_setIO, operation_setIO_conv)
 {
-  onert::ir::Graph graph;
+  onert::ir::Graph graph{0};
 
   onert::ir::Shape shape{3};
   onert::ir::TypeInfo type{onert::ir::DataType::INT32};
@@ -64,7 +64,7 @@ TEST(ir_Operation_setIO, operation_setIO_conv)
 
 TEST(ir_Operation_setIO, neg_operation_setIO_concat)
 {
-  onert::ir::Graph graph;
+  onert::ir::Graph graph{0};
 
   onert::ir::Shape shape{3};
 

--- a/runtime/onert/test/graph/verifier/Verifier.cc
+++ b/runtime/onert/test/graph/verifier/Verifier.cc
@@ -28,7 +28,7 @@ using Mock = onert_test::ir::SimpleMock;
 
 TEST(Verifier, dag_checker)
 {
-  onert::ir::Graph graph;
+  onert::ir::Graph graph{0};
 
   onert::ir::Shape shape{3};
   onert::ir::TypeInfo type{onert::ir::DataType::INT32};
@@ -50,7 +50,7 @@ TEST(Verifier, dag_checker)
 
 TEST(Verifier, neg_edge_consistency_checker_1)
 {
-  onert::ir::Graph graph;
+  onert::ir::Graph graph{0};
 
   onert::ir::Shape shape{3};
   onert::ir::TypeInfo type{onert::ir::DataType::INT32};
@@ -74,7 +74,7 @@ TEST(Verifier, neg_edge_consistency_checker_1)
 
 TEST(Verifier, neg_edge_consistency_checker_2)
 {
-  onert::ir::Graph graph;
+  onert::ir::Graph graph{0};
 
   onert::ir::Shape shape{3};
   onert::ir::TypeInfo type{onert::ir::DataType::INT32};


### PR DESCRIPTION
Make ctor of `ir::Graph` take subgraph index param.

- Parent issue: #4901
- Draft: https://github.com/Samsung/ONE/pull/4903

Background:

To produce right profiling information about multiple subgraphs at execution time, each executor needs to know which _subgraph_ they are executing. The proper place to keep the subgraph index seems to be `ir::Graph`.
The subgraph index in `ir::Graph` will be passed to `EventObservers` and displayed to users.

(If we don't want to keep the index in Graph, we need a map of subgraph index and Graph object, which is created at loading time and passed all the way to execution time, which seems complicated.)

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>
