### PR TITLE
[onert] Rename ChromeTracingObserver

### DIFF
--- a/runtime/onert/core/src/compiler/ExecutorFactory.cc
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.cc
@@ -362,7 +362,7 @@ ExecutorFactory::createLinearExecutor(std::unique_ptr<compiler::LoweredGraph> lo
   if (!options.trace_filepath.empty())
   {
     std::unique_ptr<exec::IExecutionObserver> ctp =
-        std::make_unique<exec::ChromeTracingObserver>(options.trace_filepath, exec->graph());
+        std::make_unique<exec::TracingObserver>(options.trace_filepath, exec->graph());
     exec->addObserver(std::move(ctp));
   }
 
@@ -489,7 +489,7 @@ exec::IExecutor *ExecutorFactory::createDataflowExecutor(
   if (!options.trace_filepath.empty())
   {
     std::unique_ptr<exec::IExecutionObserver> ctp =
-        std::make_unique<exec::ChromeTracingObserver>(options.trace_filepath, exec->graph());
+        std::make_unique<exec::TracingObserver>(options.trace_filepath, exec->graph());
     exec->addObserver(std::move(ctp));
   }
 

--- a/runtime/onert/core/src/exec/ExecutionObservers.cc
+++ b/runtime/onert/core/src/exec/ExecutionObservers.cc
@@ -70,12 +70,12 @@ void ProfileObserver::handleJobEnd(IExecutor *exec, const ir::OpSequence *op_seq
   }
 };
 
-ChromeTracingObserver::ChromeTracingObserver(const std::string &filepath, const ir::Graph &graph)
+TracingObserver::TracingObserver(const std::string &filepath, const ir::Graph &graph)
     : _base_filepath(filepath), _recorder{}, _collector{&_recorder}, _graph{graph}
 {
 }
 
-ChromeTracingObserver::~ChromeTracingObserver()
+TracingObserver::~TracingObserver()
 {
   try
   {
@@ -83,38 +83,38 @@ ChromeTracingObserver::~ChromeTracingObserver()
   }
   catch (const std::exception &e)
   {
-    std::cerr << "E: Fail to record event in ChromeTracingObserver: " << e.what() << std::endl;
+    std::cerr << "E: Fail to record event in TracingObserver: " << e.what() << std::endl;
   }
 }
 
-void ChromeTracingObserver::handleSubgraphBegin(IExecutor *)
+void TracingObserver::handleSubgraphBegin(IExecutor *)
 {
   _collector.onEvent(EventCollector::Event{EventCollector::Edge::BEGIN, "runtime", "Graph"});
 }
 
-void ChromeTracingObserver::handleJobBegin(IExecutor *, const ir::OpSequence *op_seq,
-                                           const backend::Backend *backend)
+void TracingObserver::handleJobBegin(IExecutor *, const ir::OpSequence *op_seq,
+                                     const backend::Backend *backend)
 {
   std::string backend_id = backend->config()->id();
   _collector.onEvent(EventCollector::Event{EventCollector::Edge::BEGIN, backend_id,
                                            opSequenceTag(op_seq, _graph.operations())});
 }
 
-void ChromeTracingObserver::handleJobEnd(IExecutor *, const ir::OpSequence *op_seq,
-                                         const backend::Backend *backend)
+void TracingObserver::handleJobEnd(IExecutor *, const ir::OpSequence *op_seq,
+                                   const backend::Backend *backend)
 {
   std::string backend_id = backend->config()->id();
   _collector.onEvent(EventCollector::Event{EventCollector::Edge::END, backend_id,
                                            opSequenceTag(op_seq, _graph.operations())});
 }
 
-void ChromeTracingObserver::handleSubgraphEnd(IExecutor *)
+void TracingObserver::handleSubgraphEnd(IExecutor *)
 {
   _collector.onEvent(EventCollector::Event{EventCollector::Edge::END, "runtime", "Graph"});
 }
 
-std::string ChromeTracingObserver::opSequenceTag(const ir::OpSequence *op_seq,
-                                                 const ir::Operations &operations)
+std::string TracingObserver::opSequenceTag(const ir::OpSequence *op_seq,
+                                           const ir::Operations &operations)
 {
   if (op_seq->size() == 0)
     return "Empty OpSequence";

--- a/runtime/onert/core/src/exec/ExecutionObservers.h
+++ b/runtime/onert/core/src/exec/ExecutionObservers.h
@@ -62,11 +62,11 @@ private:
   const ir::Graph &_graph;
 };
 
-class ChromeTracingObserver : public IExecutionObserver
+class TracingObserver : public IExecutionObserver
 {
 public:
-  ChromeTracingObserver(const std::string &filepath, const ir::Graph &graph);
-  ~ChromeTracingObserver();
+  TracingObserver(const std::string &filepath, const ir::Graph &graph);
+  ~TracingObserver();
   void handleSubgraphBegin(IExecutor *) override;
   void handleJobBegin(IExecutor *, const ir::OpSequence *, const backend::Backend *) override;
   void handleJobEnd(IExecutor *, const ir::OpSequence *, const backend::Backend *) override;


### PR DESCRIPTION
Rename ChromeTracingObserver to TracingObserver as it is now general.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>