### PR TITLE
[onert] Remove unnecessary undef macro

### DIFF
--- a/runtime/onert/backend/cpu/ops/ConvolutionLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ConvolutionLayer.cc
@@ -203,8 +203,6 @@ void ConvolutionLayer::prepare()
   _prepare = true;
 }
 
-#undef ANDROID_NN_CONV_PARAMETERS
-
 } // namespace ops
 } // namespace cpu
 } // namespace backend


### PR DESCRIPTION
- This commit remove unnecessary undef macro
  - Macro definition was removed a while ago

ONE-DCO-1.0-Signed-off-by: JiHwan Yeo <jihwan.yeo@samsung.com>