### PR TITLE
[luci] Introduce progress reporter for Module

### DIFF
--- a/compiler/luci/pass/src/ProgressReporter.cpp
+++ b/compiler/luci/pass/src/ProgressReporter.cpp
@@ -81,4 +81,46 @@ void ProgressReporter::notify(const logo::PhaseEventInfo<logo::PhaseEvent::PassE
   INFO(prime) << luci::fmt(graph());
 }
 
+void ModuleProgressReporter::notify(const logo::PhaseEventInfo<logo::PhaseEvent::PhaseBegin> *)
+{
+  LOGGER(prime);
+
+  INFO(prime) << "==============================================================";
+  INFO(prime) << "ModulePhaseRunner<" << to_str(strategy()) << ">";
+  INFO(prime) << "Initial graphs";
+  for (size_t g = 0; g < module()->size(); ++g)
+  {
+    INFO(prime) << "graphs #" << g;
+    INFO(prime) << luci::fmt(module()->graph(g));
+  }
+}
+
+void ModuleProgressReporter::notify(const logo::PhaseEventInfo<logo::PhaseEvent::PhaseEnd> *)
+{
+  LOGGER(prime);
+
+  INFO(prime) << "ModulePhaseRunner<" << to_str(strategy()) << "> - done";
+}
+
+void ModuleProgressReporter::notify(const logo::PhaseEventInfo<logo::PhaseEvent::PassBegin> *info)
+{
+  LOGGER(prime);
+
+  INFO(prime) << "--------------------------------------------------------------";
+  INFO(prime) << "Before " << logo::pass_name(info->pass());
+}
+
+void ModuleProgressReporter::notify(const logo::PhaseEventInfo<logo::PhaseEvent::PassEnd> *info)
+{
+  LOGGER(prime);
+
+  INFO(prime) << "After " << logo::pass_name(info->pass())
+              << " (changed: " << to_char(info->changed()) << ")";
+  for (size_t g = 0; g < module()->size(); ++g)
+  {
+    INFO(prime) << "graphs #" << g;
+    INFO(prime) << luci::fmt(module()->graph(g));
+  }
+}
+
 } // namespace luci

--- a/compiler/luci/pass/src/ProgressReporter.h
+++ b/compiler/luci/pass/src/ProgressReporter.h
@@ -21,6 +21,8 @@
 
 #include <loco.h>
 
+#include <luci/IR/Module.h>
+
 namespace luci
 {
 
@@ -45,6 +47,30 @@ public:
 
 private:
   loco::Graph *_graph;
+  logo::PhaseStrategy _strategy;
+};
+
+class ModuleProgressReporter : public logo::PhaseEventListener
+{
+public:
+  ModuleProgressReporter(luci::Module *module, logo::PhaseStrategy strategy)
+      : _module{module}, _strategy{strategy}
+  {
+    // DO NOTHING
+  }
+
+public:
+  void notify(const logo::PhaseEventInfo<logo::PhaseEvent::PhaseBegin> *) override;
+  void notify(const logo::PhaseEventInfo<logo::PhaseEvent::PhaseEnd> *) override;
+  void notify(const logo::PhaseEventInfo<logo::PhaseEvent::PassBegin> *) override;
+  void notify(const logo::PhaseEventInfo<logo::PhaseEvent::PassEnd> *) override;
+
+public:
+  luci::Module *module(void) const { return _module; }
+  logo::PhaseStrategy strategy(void) const { return _strategy; }
+
+private:
+  luci::Module *_module;
   logo::PhaseStrategy _strategy;
 };
 


### PR DESCRIPTION
Parent Issue : #4961
Draft Code : #4962

Current `ProgressReporter` only supports for `loco::Graph`.
However, after `luci::Pass` is introduced, `ProgressReporter` for `luci::Module` is needed
because `luci::Pass` supports optimizations for `luci::Module`.
This commit will introduce `ModuleProgressReporter`, which supports reporting about module progress.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>