### PR TITLE
[bcq-tools] Update output array generation algorithm

### DIFF
--- a/compiler/bcq-tools/generate_bcq_output_arrays
+++ b/compiler/bcq-tools/generate_bcq_output_arrays
@@ -112,128 +112,22 @@ def print_bcqinfo_output_arrays_v1(flags):
             if infoname == "bcqinfo_dequant_weight":
                 has_dequant_weight = True
 
-    # Ideal situation is that the user nodes of BCQ applicable constant nodes
-    # are BCQ applicable operations such as MatMul, GatherV2, etc.
-    # However, operations which do not change original values such as
-    # Ideneity or Transpose can exist between them. In view of TensorFlow Lite,
-    # real user nodes of BCQ applicable constant nodes must be found first.
-    # This work is done by BFS search with queue.
-
-    prefix_node_dict = {}  # key : prefix / value : list of candidates
-    matmul_node_prefix_dict = {}  # key : Name of MatMul node / value : prefix
-
-    queue_prefix = list(prefix_set)
-    queue_nodename = [queue_prefix[idx] + ":0" for idx in range(len(queue_prefix))]
-
-    while len(queue_prefix) > 0:
-        prefix = queue_prefix.pop(0)
-        nodename = queue_nodename.pop(0)
-        if prefix not in prefix_node_dict.keys():
-            prefix_node_dict[prefix] = []
-
-        # Usually, output name of op is like "outputname:0"
-        # -2 is for removing ":0"
-        for op in ops:
-            if op.type == "MatMul" and (op.inputs[0].name == nodename
-                                        or op.inputs[1].name == nodename):
-                prefix_node_dict[prefix].append(op.outputs[0].name[:-2])
-                matmul_node_prefix_dict[op.outputs[0].name[:-2]] = prefix
-            elif op.type == "Einsum" and (op.inputs[0].name == nodename
-                                          or op.inputs[1].name == nodename):
-                prefix_node_dict[prefix].append(op.outputs[0].name[:-2])
-            elif op.type == "GatherV2" and op.inputs[0].name == nodename:
-                prefix_node_dict[prefix].append(op.outputs[0].name[:-2])
-            elif len(op.outputs) == 1:
-                for i in range(len(op.inputs)):
-                    if op.inputs[i].name == nodename:
-                        queue_prefix.append(prefix)
-                        queue_nodename.append(op.outputs[0].name)
-                        break
-
-    # When TensorFlow model is converted to TensorFlow Lite model,
-    # more than one operation can be fused as one.
-    # For example, MatMul + BiasAdd + ReLU in TensorFlow can be fused as
-    # one FullyConnected in TensorFlow Lite.
-    # It means that even real user nodes of BCQ applicable constant nodes
-    # in TensorFlow are found, they may be real user nodes in TensorFlow Lite.
-    # Therefore additional candidates of real user nodes should be found either.
-    # Finding additional candidates is done by BFS search with queue.
-
-    fuseop_prefix_dict = {}  # key : Candidate operation / Value : prefix
-
-    # These ops can be candidate. However other candidates may exists after these ops.
-    mark_type = ["Add", "AddV2", "BiasAdd", "Reshape", "Transpose"]
-
-    # These ops can be candidate. And no more candidates will be found after these ops.
-    mark_and_stop_type = ["Relu", "Relu6", "Tanh"]
-
-    # These ops cannot be candidates but other candidates may exists after these ops.
-    # NOTE : Some of following ops may be removed from the list but not sure for now.
-    pass_type = [
-        "BatchToSpaceND", "Cast", "DepthToSpace", "ExpandDims", "ResizeBilinear",
-        "ResizeNearestNeighbor", "ScatterNd", "SpaceToBatchND", "SpaceToDepth", "Squeeze",
-        "Identity", "Pack", "Unpack", "Stack"
-    ]
-
-    queue_prefix = list(matmul_node_prefix_dict.values())
-    queue_nodename = [matmul + ":0" for matmul in matmul_node_prefix_dict.keys()]
-
-    visited_nodes = set(queue_nodename)
-    while len(queue_prefix) > 0:
-        prefix = queue_prefix.pop(0)
-        nodename = queue_nodename.pop(0)
-
-        # Usually, output name of op is like "outputname:0"
-        # -2 is for removing ":0"
-        for op in ops:
-            for i in range(len(op.inputs)):
-                if nodename == op.inputs[i].name:
-                    if op.type in mark_type:
-                        if op.outputs[0].name[:-2] not in fuseop_prefix_dict.keys():
-                            fuseop_prefix_dict[op.outputs[0].name[:-2]] = set()
-                        fuseop_prefix_dict[op.outputs[0].name[:-2]].add(prefix)
-                        if op.outputs[0].name not in visited_nodes:
-                            queue_prefix.append(prefix)
-                            queue_nodename.append(op.outputs[0].name)
-                            visited_nodes.add(op.outputs[0].name)
-                    elif op.type in mark_and_stop_type:
-                        if op.outputs[0].name[:-2] not in fuseop_prefix_dict.keys():
-                            fuseop_prefix_dict[op.outputs[0].name[:-2]] = set()
-                        fuseop_prefix_dict[op.outputs[0].name[:-2]].add(prefix)
-                    elif op.type in pass_type and op.outputs[0].name not in visited_nodes:
-                        queue_prefix.append(prefix)
-                        queue_nodename.append(op.outputs[0].name)
-                        visited_nodes.add(op.outputs[0].name)
-
     # Write the name of metadata node
     with open(flags.metadata_path, 'w') as f_metadata:
         f_metadata.write("one_compiler/bcqinfo_one_metadata,")
 
-    # Write all pairs of candidate operations and related BCQ information nodes.
+    # Write all pairs of a constant node and related BCQ information nodes.
     with open(flags.output_arrays_path, 'w') as f_arrays:
         for prefix in prefix_set:
-            for fusable_op in prefix_node_dict[prefix]:
-                f_arrays.write("," + prefix + "/bcqinfo_do_w_x")
-                f_arrays.write("," + prefix + "/bcqinfo_alpha")
-                f_arrays.write("," + prefix + "/bcqinfo_packed_binary_code")
-                f_arrays.write("," + prefix + "/bcqinfo_number_of_clusters")
-                f_arrays.write("," + prefix + "/bcqinfo_size_of_clusters")
-                f_arrays.write("," + prefix + "/bcqinfo_qbits_of_clusters")
-                f_arrays.write("," + fusable_op)
-                if has_dequant_weight:
-                    f_arrays.write("," + prefix + "/bcqinfo_dequant_weight")
-        for fuseop in fuseop_prefix_dict.keys():
-            if len(fuseop_prefix_dict[fuseop]) == 1:
-                prefix = fuseop_prefix_dict[fuseop].pop()
-                f_arrays.write("," + prefix + "/bcqinfo_do_w_x")
-                f_arrays.write("," + prefix + "/bcqinfo_alpha")
-                f_arrays.write("," + prefix + "/bcqinfo_packed_binary_code")
-                f_arrays.write("," + prefix + "/bcqinfo_number_of_clusters")
-                f_arrays.write("," + prefix + "/bcqinfo_size_of_clusters")
-                f_arrays.write("," + prefix + "/bcqinfo_qbits_of_clusters")
-                f_arrays.write("," + fuseop)
-                if has_dequant_weight:
-                    f_arrays.write("," + prefix + "/bcqinfo_dequant_weight")
+            f_arrays.write("," + prefix + "/bcqinfo_do_w_x")
+            f_arrays.write("," + prefix + "/bcqinfo_alpha")
+            f_arrays.write("," + prefix + "/bcqinfo_packed_binary_code")
+            f_arrays.write("," + prefix + "/bcqinfo_number_of_clusters")
+            f_arrays.write("," + prefix + "/bcqinfo_size_of_clusters")
+            f_arrays.write("," + prefix + "/bcqinfo_qbits_of_clusters")
+            f_arrays.write("," + prefix)
+            if has_dequant_weight:
+                f_arrays.write("," + prefix + "/bcqinfo_dequant_weight")
 
 
 def print_bcq_output_arrays(flags):

--- a/compiler/bcq-tools/generate_bcq_output_arrays.py
+++ b/compiler/bcq-tools/generate_bcq_output_arrays.py
@@ -81,129 +81,23 @@ def get_bcqinfo_output_arrays_v1(input_path, output_arrays):
             if infoname == "bcqinfo_dequant_weight":
                 has_dequant_weight = True
 
-    # Ideal situation is that the user nodes of BCQ applicable constant nodes
-    # are BCQ applicable operations such as MatMul, GatherV2, etc.
-    # However, operations which do not change original values such as
-    # Ideneity or Transpose can exist between them. In view of TensorFlow Lite,
-    # real user nodes of BCQ applicable constant nodes must be found first.
-    # This work is done by BFS search with queue.
-
-    prefix_node_dict = {}  # key : prefix / value : list of candidates
-    matmul_node_prefix_dict = {}  # key : Name of MatMul node / value : prefix
-
-    queue_prefix = list(prefix_set)
-    queue_nodename = [queue_prefix[idx] + ":0" for idx in range(len(queue_prefix))]
-
-    while len(queue_prefix) > 0:
-        prefix = queue_prefix.pop(0)
-        nodename = queue_nodename.pop(0)
-        if prefix not in prefix_node_dict.keys():
-            prefix_node_dict[prefix] = []
-
-        # Usually, output name of op is like "outputname:0"
-        # -2 is for removing ":0"
-        for op in ops:
-            if op.type == "MatMul" and (op.inputs[0].name == nodename
-                                        or op.inputs[1].name == nodename):
-                prefix_node_dict[prefix].append(op.outputs[0].name[:-2])
-                matmul_node_prefix_dict[op.outputs[0].name[:-2]] = prefix
-            elif op.type == "Einsum" and (op.inputs[0].name == nodename
-                                          or op.inputs[1].name == nodename):
-                prefix_node_dict[prefix].append(op.outputs[0].name[:-2])
-            elif op.type == "GatherV2" and op.inputs[0].name == nodename:
-                prefix_node_dict[prefix].append(op.outputs[0].name[:-2])
-            elif len(op.outputs) == 1:
-                for i in range(len(op.inputs)):
-                    if op.inputs[i].name == nodename:
-                        queue_prefix.append(prefix)
-                        queue_nodename.append(op.outputs[0].name)
-                        break
-
-    # When TensorFlow model is converted to TensorFlow Lite model,
-    # more than one operation can be fused as one.
-    # For example, MatMul + BiasAdd + ReLU in TensorFlow can be fused as
-    # one FullyConnected in TensorFlow Lite.
-    # It means that even real user nodes of BCQ applicable constant nodes
-    # in TensorFlow are found, they may be real user nodes in TensorFlow Lite.
-    # Therefore additional candidates of real user nodes should be found either.
-    # Finding additional candidates is done by BFS search with queue.
-
-    fuseop_prefix_dict = {}  # key : Candidate operation / Value : prefix
-
-    # These ops can be candidate. However other candidates may exists after these ops.
-    mark_type = ["Add", "AddV2", "BiasAdd", "Reshape", "Transpose"]
-
-    # These ops can be candidate. And no more candidates will be found after these ops.
-    mark_and_stop_type = ["Relu", "Relu6", "Tanh"]
-
-    # These ops cannot be candidates but other candidates may exists after these ops.
-    # NOTE : Some of following ops may be removed from the list but not sure for now.
-    pass_type = [
-        "BatchToSpaceND", "Cast", "DepthToSpace", "ExpandDims", "ResizeBilinear",
-        "ResizeNearestNeighbor", "ScatterNd", "SpaceToBatchND", "SpaceToDepth", "Squeeze",
-        "Identity", "Pack", "Unpack", "Stack"
-    ]
-
-    queue_prefix = list(matmul_node_prefix_dict.values())
-    queue_nodename = [matmul + ":0" for matmul in matmul_node_prefix_dict.keys()]
-
-    visited_nodes = set(queue_nodename)
-    while len(queue_prefix) > 0:
-        prefix = queue_prefix.pop(0)
-        nodename = queue_nodename.pop(0)
-
-        # Usually, output name of op is like "outputname:0"
-        # -2 is for removing ":0"
-        for op in ops:
-            for i in range(len(op.inputs)):
-                if nodename == op.inputs[i].name:
-                    if op.type in mark_type:
-                        if op.outputs[0].name[:-2] not in fuseop_prefix_dict.keys():
-                            fuseop_prefix_dict[op.outputs[0].name[:-2]] = set()
-                        fuseop_prefix_dict[op.outputs[0].name[:-2]].add(prefix)
-                        if op.outputs[0].name not in visited_nodes:
-                            queue_prefix.append(prefix)
-                            queue_nodename.append(op.outputs[0].name)
-                            visited_nodes.add(op.outputs[0].name)
-                    elif op.type in mark_and_stop_type:
-                        if op.outputs[0].name[:-2] not in fuseop_prefix_dict.keys():
-                            fuseop_prefix_dict[op.outputs[0].name[:-2]] = set()
-                        fuseop_prefix_dict[op.outputs[0].name[:-2]].add(prefix)
-                    elif op.type in pass_type and op.outputs[0].name not in visited_nodes:
-                        queue_prefix.append(prefix)
-                        queue_nodename.append(op.outputs[0].name)
-                        visited_nodes.add(op.outputs[0].name)
-
     # the name of metadata node
     ret_output_arrays = ['one_compiler/bcqinfo_one_metadata']
 
     # given node from user
     ret_output_arrays.append(output_arrays)
 
-    # all pairs of candidate operations and related BCQ information nodes
+    # all pairs of a constant node and related BCQ information nodes.
     for prefix in prefix_set:
-        for fusable_op in prefix_node_dict[prefix]:
-            ret_output_arrays.append(prefix + '/bcqinfo_do_w_x')
-            ret_output_arrays.append(prefix + '/bcqinfo_alpha')
-            ret_output_arrays.append(prefix + '/bcqinfo_packed_binary_code')
-            ret_output_arrays.append(prefix + '/bcqinfo_number_of_clusters')
-            ret_output_arrays.append(prefix + '/bcqinfo_size_of_clusters')
-            ret_output_arrays.append(prefix + '/bcqinfo_qbits_of_clusters')
-            ret_output_arrays.append(fusable_op)
-            if has_dequant_weight:
-                ret_output_arrays.append(prefix + '/bcqinfo_dequant_weight')
-    for fuseop in fuseop_prefix_dict.keys():
-        if len(fuseop_prefix_dict[fuseop]) == 1:
-            prefix = fuseop_prefix_dict[fuseop].pop()
-            ret_output_arrays.append(prefix + '/bcqinfo_do_w_x')
-            ret_output_arrays.append(prefix + '/bcqinfo_alpha')
-            ret_output_arrays.append(prefix + '/bcqinfo_packed_binary_code')
-            ret_output_arrays.append(prefix + '/bcqinfo_number_of_clusters')
-            ret_output_arrays.append(prefix + '/bcqinfo_size_of_clusters')
-            ret_output_arrays.append(prefix + '/bcqinfo_qbits_of_clusters')
-            ret_output_arrays.append(fuseop)
-            if has_dequant_weight:
-                ret_output_arrays.append(prefix + '/bcqinfo_dequant_weight')
+        ret_output_arrays.append(prefix + '/bcqinfo_do_w_x')
+        ret_output_arrays.append(prefix + '/bcqinfo_alpha')
+        ret_output_arrays.append(prefix + '/bcqinfo_packed_binary_code')
+        ret_output_arrays.append(prefix + '/bcqinfo_number_of_clusters')
+        ret_output_arrays.append(prefix + '/bcqinfo_size_of_clusters')
+        ret_output_arrays.append(prefix + '/bcqinfo_qbits_of_clusters')
+        ret_output_arrays.append(prefix)
+        if has_dequant_weight:
+            ret_output_arrays.append(prefix + '/bcqinfo_dequant_weight')
 
     return ret_output_arrays
 


### PR DESCRIPTION
Parent Issue : #4961

Until now, `output_arrays` are generated by all pairs of candidate operations and BCQ info nodes.
This commit will substitute candidate operations to a constant node.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>