### PR TITLE
[tflitefile_tool] model_parser will use current environment's python

### DIFF
--- a/tools/tflitefile_tool/model_parser.py
+++ b/tools/tflitefile_tool/model_parser.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # Copyright (c) 2018 Samsung Electronics Co., Ltd. All Rights Reserved
 #


### PR DESCRIPTION
It fixes errors like numpy is not found in python venv environment,
when the module is installed in venv only.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>