### PR TITLE
[onert] Promote ExecutorBase methods

### DIFF
--- a/runtime/onert/core/include/exec/IExecutor.h
+++ b/runtime/onert/core/include/exec/IExecutor.h
@@ -33,6 +33,17 @@
 
 namespace onert
 {
+namespace backend
+{
+class IPortableTensor;
+namespace controlflow
+{
+class IOTensor;
+}
+}
+}
+namespace onert
+{
 namespace exec
 {
 class IExecutionObserver;
@@ -64,11 +75,29 @@ struct IExecutor
   virtual void setIndexedRanks(std::shared_ptr<ir::OperationIndexMap<int64_t>>) = 0;
 
   /**
-   * @brief     Start execution
+   * @brief     Execute with user-given input/output description (for primary subgraph)
    * @param[in] desc Input and output description
    * @note      This method should be thread-safe
    */
   virtual void execute(const IODescription &desc) = 0;
+
+  /**
+   * @brief Execute with given input/output tensors
+   *
+   * For non-primary subgraphs, input and output tensors must be given.
+   *
+   * @param[in] inputs tensors that are passed as inputs
+   * @param[in] outputs tensors that are passed as outputs
+   */
+  virtual void execute(const std::vector<backend::IPortableTensor *> &inputs,
+                       const std::vector<backend::IPortableTensor *> &outputs) = 0;
+
+  /**
+   * @brief Get output tensor objects
+   *
+   * @return Vector of @c IOTensor
+   */
+  virtual const std::vector<backend::controlflow::IOTensor *> &getOutputTensors() const = 0;
 };
 
 using ExecutorMap = std::unordered_map<ir::SubgraphIndex, std::unique_ptr<IExecutor>>;

--- a/runtime/onert/core/src/backend/controlflow/kernel/IfLayer.cc
+++ b/runtime/onert/core/src/backend/controlflow/kernel/IfLayer.cc
@@ -18,7 +18,6 @@
 
 #include <backend/ITensor.h>
 #include "exec/ExecutorBase.h"
-#include <misc/polymorphic_downcast.h>
 #include "PermuteLayer.h"
 
 namespace onert
@@ -61,19 +60,17 @@ void IfLayer::run()
     return ret;
   };
 
-  exec::ExecutorBase *subg_exec = nullptr;
+  exec::IExecutor *subg_exec = nullptr;
   bool cond_result = getResultCond(_cond_tensor);
   if (cond_result)
   {
     VERBOSE(If) << "Call to $" << _then_subg_index << " (then)" << std::endl;
-    subg_exec = nnfw::misc::polymorphic_downcast<exec::ExecutorBase *>(
-        _executor_map->at(_then_subg_index).get());
+    subg_exec = _executor_map->at(_then_subg_index).get();
   }
   else
   {
     VERBOSE(If) << "Call to $" << _else_subg_index << " (else)" << std::endl;
-    subg_exec = nnfw::misc::polymorphic_downcast<exec::ExecutorBase *>(
-        _executor_map->at(_else_subg_index).get());
+    subg_exec = _executor_map->at(_else_subg_index).get();
   }
 
   subg_exec->execute(_input_tensors, _output_tensors);

--- a/runtime/onert/core/src/backend/controlflow/kernel/WhileLayer.cc
+++ b/runtime/onert/core/src/backend/controlflow/kernel/WhileLayer.cc
@@ -56,10 +56,8 @@ void WhileLayer::run()
   // // Run cond subg
   // If there is no loop copy "_input_tensors" -> "_dst_tensors", else copy "cond subg inputs" ->
   // "_dst_tensors"
-  auto cond_exec = nnfw::misc::polymorphic_downcast<exec::ExecutorBase *>(
-      _executor_map->at(_cond_subg_index).get());
-  auto body_exec = nnfw::misc::polymorphic_downcast<exec::ExecutorBase *>(
-      _executor_map->at(_body_subg_index).get());
+  auto cond_exec = _executor_map->at(_cond_subg_index).get();
+  auto body_exec = _executor_map->at(_body_subg_index).get();
 
   // Need a temp tensor to hold the cond subgraph output
   assert(cond_exec->getOutputTensors().size() == 1);

--- a/runtime/onert/core/src/exec/ExecutorBase.h
+++ b/runtime/onert/core/src/exec/ExecutorBase.h
@@ -56,18 +56,10 @@ public:
 
   const ir::Graph &graph() final { return _graph; }
 
-  /**
-   * @brief Execute with given input/output tensors
-   *
-   * For non-primary subgraphs, input and output tensors must be given.
-   *
-   * @param inputs tensors that are passed as inputs
-   * @param outputs tensors that are passed as outputs
-   */
-  void execute(const std::vector<backend::IPortableTensor *> &inputs,
-               const std::vector<backend::IPortableTensor *> &outputs);
-
   void execute(const IODescription &desc) final;
+
+  void execute(const std::vector<backend::IPortableTensor *> &inputs,
+               const std::vector<backend::IPortableTensor *> &outputs) override;
 
   // Used only in Dataflow and Parallel Executors
   void setIndexedRanks(std::shared_ptr<ir::OperationIndexMap<int64_t>> ranks) final
@@ -79,12 +71,7 @@ public:
 
   void addObserver(std::unique_ptr<IExecutionObserver> ref) { _subject.add(std::move(ref)); };
 
-  const std::vector<backend::controlflow::IOTensor *> &getInputTensors() const
-  {
-    return _input_tensors;
-  }
-
-  const std::vector<backend::controlflow::IOTensor *> &getOutputTensors() const
+  const std::vector<backend::controlflow::IOTensor *> &getOutputTensors() const override
   {
     return _output_tensors;
   }

--- a/runtime/onert/core/src/interp/InterpExecutor.h
+++ b/runtime/onert/core/src/interp/InterpExecutor.h
@@ -58,6 +58,15 @@ public:
    * @note   It should be called after setting input and output buffer
    */
   void execute(const exec::IODescription &desc) final;
+  void execute(const std::vector<backend::IPortableTensor *> &,
+               const std::vector<backend::IPortableTensor *> &) final
+  {
+    throw new std::runtime_error{"Interpreter does not support subgraph calls(control flow ops)"};
+  }
+  const std::vector<backend::controlflow::IOTensor *> &getOutputTensors() const final
+  {
+    throw new std::runtime_error{"Interpreter does not support this function."};
+  }
 
 private:
   const ir::Graph &_graph;


### PR DESCRIPTION
Promote ExecutorBase methods to be the interface methods of `IExecutor`.

- Promote `execute(..., ...)` and `getOutputTensors()`
- Remove `getInputTensors()` as it is never used
- Remove `polymorphic_downcast` in If/While implementation

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>