### PR TITLE
[luci] Rename LuciPass to ModulePass and Refactoring

### DIFF
--- a/compiler/luci/pass/include/luci/ModulePass.h
+++ b/compiler/luci/pass/include/luci/ModulePass.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef __LUCI_PASS_H__
-#define __LUCI_PASS_H__
+#ifndef __MODULE_PASS_H__
+#define __MODULE_PASS_H__
 
 #include <loco.h>
 #include <logo/Pass.h>
@@ -28,19 +28,10 @@ namespace luci
 class Pass : public logo::Pass
 {
 public:
-  /**
-   * @brief  Run the pass
-   *
-   * @return false if there was nothing changed.
-   */
-
   // Run module pass and return false if there was nothing changed
   virtual bool run(luci::Module *) = 0;
-
-  // Run graph pass and return false if there was nothing changed
-  virtual bool run(loco::Graph *) { return false; }
 };
 
 } // namespace luci
 
-#endif // __LUCI_PASS_H__
+#endif // __MODULE_PASS_H__

--- a/compiler/luci/pass/src/ModulePhase.h
+++ b/compiler/luci/pass/src/ModulePhase.h
@@ -17,7 +17,7 @@
 #ifndef __MODULE_PHASE_H__
 #define __MODULE_PHASE_H__
 
-#include <luci/LuciPass.h>
+#include <luci/ModulePass.h>
 
 #include <logo/Phase.h>
 


### PR DESCRIPTION
Parent Issue : #4961

`LuciPass` is so generic that the meaning is ambiguous.
In addition, just default definition of `run(loco::Graph *)` is also weird.
This commit will rename `LuciPass` to `ModulePass` and refactor it.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>