### PR TITLE
[luci] Introduce Module optimizer in luci

### DIFF
--- a/compiler/luci/pass/include/luci/CircleOptimizer.h
+++ b/compiler/luci/pass/include/luci/CircleOptimizer.h
@@ -19,6 +19,8 @@
 
 #include <loco.h>
 
+#include <luci/IR/Module.h>
+
 #include <string>
 #include <vector>
 
@@ -78,6 +80,8 @@ public:
   Options *options(void);
 
 public:
+  void optimize(luci::Module *) const;
+
   void optimize(loco::Graph *) const;
 
   void quantize(loco::Graph *) const;

--- a/compiler/luci/pass/src/CircleOptimizer.cpp
+++ b/compiler/luci/pass/src/CircleOptimizer.cpp
@@ -130,7 +130,7 @@ void CircleOptimizer::optimize(luci::Module *m) const
 {
   luci::Phase phase;
 
-  // Paases will be inserted here
+  // Passes will be inserted here
 
   ModuleProgressReporter prog(m, logo::PhaseStrategy::Restart);
   PhaseRunner<logo::PhaseStrategy::Restart> phase_runner{m};

--- a/compiler/luci/pass/src/CircleOptimizer.cpp
+++ b/compiler/luci/pass/src/CircleOptimizer.cpp
@@ -40,6 +40,7 @@
 // logo passes
 #include <logo/RemoveDeadNodeWithQueryPass.h>
 
+#include "ModulePhase.h"
 #include "ProgressReporter.h"
 #include "CircleOptimizerUtils.h"
 
@@ -123,6 +124,18 @@ CircleOptimizer::Options *CircleOptimizer::options(void)
   }
 
   return _options.get();
+}
+
+void CircleOptimizer::optimize(luci::Module *m) const
+{
+  luci::Phase phase;
+
+  // Paases will be inserted here
+
+  ModuleProgressReporter prog(m, logo::PhaseStrategy::Restart);
+  PhaseRunner<logo::PhaseStrategy::Restart> phase_runner{m};
+  phase_runner.attach(&prog);
+  phase_runner.run(phase);
 }
 
 void CircleOptimizer::optimize(loco::Graph *g) const


### PR DESCRIPTION
Parent Issue : #4961

Until now, optimizations only for `logo::Graph` was available.
This commit will introduce an optimization functino for `luci::Module`,
which enables `Module` optimization

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>