### PR TITLE
[circle2circle] Enable module optimization

### DIFF
--- a/compiler/circle2circle/src/Circle2Circle.cpp
+++ b/compiler/circle2circle/src/Circle2Circle.cpp
@@ -290,11 +290,14 @@ int entry(int argc, char **argv)
   luci::Importer importer;
   auto module = importer.importModule(circle_model);
 
+  // call luci optimizations for module
+  optimizer.optimize(module.get());
+
   for (size_t idx = 0; idx < module->size(); ++idx)
   {
     auto graph = module->graph(idx);
 
-    // call luci optimizations
+    // call luci optimizations for graph
     optimizer.optimize(graph);
     optimizer.sparsify(graph);
 


### PR DESCRIPTION
Parent Issue : #4961 

Until now, only graph optimizations were possible.
This commit will enable module optimization in `circle2circle`.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>