### PR TITLE
[luci] Support luci/Service passes for Module

### DIFF
--- a/compiler/luci/pass/include/luci/Pass/ShapeInferencePass.h
+++ b/compiler/luci/pass/include/luci/Pass/ShapeInferencePass.h
@@ -34,7 +34,7 @@ public:
 
 public:
   bool run(luci::Module *m);
-  bool run(loco::Graph *g);
+  bool run(loco::Graph *graph);
 };
 
 } // namespace luci

--- a/compiler/luci/pass/include/luci/Pass/ShapeInferencePass.h
+++ b/compiler/luci/pass/include/luci/Pass/ShapeInferencePass.h
@@ -19,7 +19,7 @@
 
 #include <loco.h>
 
-#include <logo/Pass.h>
+#include <luci/ModulePass.h>
 
 namespace luci
 {
@@ -27,13 +27,14 @@ namespace luci
 /**
  * @brief Pass to infer shape of nodes
  */
-class ShapeInferencePass : public logo::Pass
+class ShapeInferencePass : public luci::Pass
 {
 public:
   virtual const char *name(void) const { return "luci::ShapeInferencePass"; }
 
 public:
-  bool run(loco::Graph *graph);
+  bool run(luci::Module *m);
+  bool run(loco::Graph *g);
 };
 
 } // namespace luci

--- a/compiler/luci/pass/include/luci/Pass/ShapeSignatureInferencePass.h
+++ b/compiler/luci/pass/include/luci/Pass/ShapeSignatureInferencePass.h
@@ -19,7 +19,7 @@
 
 #include <loco.h>
 
-#include <logo/Pass.h>
+#include <luci/ModulePass.h>
 
 namespace luci
 {
@@ -27,13 +27,14 @@ namespace luci
 /**
  * @brief Pass to infer shape_signature of nodes
  */
-class ShapeSignatureInferencePass : public logo::Pass
+class ShapeSignatureInferencePass : public luci::Pass
 {
 public:
   virtual const char *name(void) const { return "luci::ShapeSignatureInferencePass"; }
 
 public:
-  bool run(loco::Graph *graph);
+  bool run(luci::Module *m);
+  bool run(loco::Graph *g);
 };
 
 } // namespace luci

--- a/compiler/luci/pass/include/luci/Pass/ShapeSignatureInferencePass.h
+++ b/compiler/luci/pass/include/luci/Pass/ShapeSignatureInferencePass.h
@@ -34,7 +34,7 @@ public:
 
 public:
   bool run(luci::Module *m);
-  bool run(loco::Graph *g);
+  bool run(loco::Graph *graph);
 };
 
 } // namespace luci

--- a/compiler/luci/pass/include/luci/Pass/TypeInferencePass.h
+++ b/compiler/luci/pass/include/luci/Pass/TypeInferencePass.h
@@ -35,7 +35,7 @@ public:
 
 public:
   bool run(luci::Module *m);
-  bool run(loco::Graph *g);
+  bool run(loco::Graph *graph);
 };
 
 } // namespace luci

--- a/compiler/luci/pass/include/luci/Pass/TypeInferencePass.h
+++ b/compiler/luci/pass/include/luci/Pass/TypeInferencePass.h
@@ -20,7 +20,7 @@
 
 #include <loco.h>
 
-#include <logo/Pass.h>
+#include <luci/ModulePass.h>
 
 namespace luci
 {
@@ -28,13 +28,14 @@ namespace luci
 /**
  * @brief Pass to infer type of nodes
  */
-class TypeInferencePass : public logo::Pass
+class TypeInferencePass : public luci::Pass
 {
 public:
   virtual const char *name(void) const { return "luci::TypeInferencePass"; }
 
 public:
-  bool run(loco::Graph *graph);
+  bool run(luci::Module *m);
+  bool run(loco::Graph *g);
 };
 
 } // namespace luci

--- a/compiler/luci/pass/src/ShapeInferencePass.cpp
+++ b/compiler/luci/pass/src/ShapeInferencePass.cpp
@@ -28,6 +28,19 @@
 namespace luci
 {
 
+bool ShapeInferencePass::run(luci::Module *m)
+{
+  bool changed = false;
+
+  for (size_t g = 0; g < m->size(); ++g)
+  {
+    if (run(m->graph(g)))
+      changed = true;
+  }
+
+  return changed;
+}
+
 bool ShapeInferencePass::run(loco::Graph *g)
 {
   loco::CanonicalShapeInferenceRule canonical_rule;

--- a/compiler/luci/pass/src/ShapeSignatureInferencePass.cpp
+++ b/compiler/luci/pass/src/ShapeSignatureInferencePass.cpp
@@ -24,6 +24,19 @@
 namespace luci
 {
 
+bool ShapeSignatureInferencePass::run(luci::Module *m)
+{
+  bool changed = false;
+
+  for (size_t g = 0; g < m->size(); ++g)
+  {
+    if (run(m->graph(g)))
+      changed = true;
+  }
+
+  return changed;
+}
+
 bool ShapeSignatureInferencePass::run(loco::Graph *g)
 {
   luci::ssinf::Rule signature_inference_rule;

--- a/compiler/luci/pass/src/TypeInferencePass.cpp
+++ b/compiler/luci/pass/src/TypeInferencePass.cpp
@@ -26,6 +26,19 @@
 namespace luci
 {
 
+bool TypeInferencePass::run(luci::Module *m)
+{
+  bool changed = false;
+
+  for (size_t g = 0; g < m->size(); ++g)
+  {
+    if (run(m->graph(g)))
+      changed = true;
+  }
+
+  return changed;
+}
+
 bool TypeInferencePass::run(loco::Graph *g)
 {
   loco::CanonicalTypeInferenceRule canonical_rule;


### PR DESCRIPTION
Parent Issue : #4961

Until now, `ShapeInferencePass`, `TypeInferencePass`, `ShapeSigantureInferencePass`\
only supports for `loco::Graph`, not for `luci::Module`.
However, if some new optimizations for `luci::Module` is introduced, such basic service passes
are needed to be done for `luci::Module`.
As a result, this commit will support the basic service pass for `luci::Module`

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>