### PR TITLE
[luci] Support FuseBCQPass for Module

### DIFF
--- a/compiler/luci/pass/include/luci/Pass/FuseBCQPass.h
+++ b/compiler/luci/pass/include/luci/Pass/FuseBCQPass.h
@@ -31,7 +31,7 @@ struct FuseBCQPass final : public luci::Pass
   const char *name(void) const final { return "luci::FuseBCQPass"; }
 
   bool run(luci::Module *m) final;
-  bool run(loco::Graph *) final;
+  bool run(loco::Graph *g) final;
 };
 
 } // namespace luci

--- a/compiler/luci/pass/include/luci/Pass/FuseBCQPass.h
+++ b/compiler/luci/pass/include/luci/Pass/FuseBCQPass.h
@@ -17,7 +17,7 @@
 #ifndef __LUCI_FUSE_BCQ_PASS_H__
 #define __LUCI_FUSE_BCQ_PASS_H__
 
-#include <logo/Pass.h>
+#include <luci/ModulePass.h>
 
 namespace luci
 {
@@ -26,10 +26,11 @@ namespace luci
  * @brief  Class to fuse certain pattern of subgraph into CircleBCQFullyConnected or CircleBCQGather
  *
  */
-struct FuseBCQPass final : public logo::Pass
+struct FuseBCQPass final : public luci::Pass
 {
   const char *name(void) const final { return "luci::FuseBCQPass"; }
 
+  bool run(luci::Module *m) final;
   bool run(loco::Graph *g) final;
 };
 

--- a/compiler/luci/pass/include/luci/Pass/FuseBCQPass.h
+++ b/compiler/luci/pass/include/luci/Pass/FuseBCQPass.h
@@ -31,7 +31,7 @@ struct FuseBCQPass final : public luci::Pass
   const char *name(void) const final { return "luci::FuseBCQPass"; }
 
   bool run(luci::Module *m) final;
-  bool run(loco::Graph *g) final;
+  bool run(loco::Graph *) final;
 };
 
 } // namespace luci

--- a/compiler/luci/pass/src/FuseBCQPass.cpp
+++ b/compiler/luci/pass/src/FuseBCQPass.cpp
@@ -664,7 +664,7 @@ bool FuseBCQPass::run(luci::Module *m)
   return changed;
 }
 
-bool FuseBCQPass::run(loco::Graph *g)
+bool FuseBCQPass::run(loco::Graph *)
 {
   // Do nothing for graph
   return false;

--- a/compiler/luci/pass/src/FuseBCQPass.cpp
+++ b/compiler/luci/pass/src/FuseBCQPass.cpp
@@ -584,17 +584,17 @@ private:
 namespace luci
 {
 
-bool FuseBCQPass::run(loco::Graph *g)
+bool FuseBCQPass::run(luci::Module *m)
 {
   bool changed = false;
 
   const int32_t start_magicnum = -2e9 + 27;
   const int32_t end_magicnum = 2e9 - 27;
 
-  loco::Graph *main_graph = g;
+  loco::Graph *main_graph = m->graph(0);
 
   luci::CircleConst *metadata_node = nullptr;
-  for (auto node : loco::output_nodes(g))
+  for (auto node : loco::output_nodes(main_graph))
   {
     auto output_node = loco::must_cast<luci::CircleOutput *>(node);
 
@@ -634,8 +634,9 @@ bool FuseBCQPass::run(loco::Graph *g)
       BCQFuser<1> fuser{original_output_cnt, bundle_cnt};
       fuser.register_bcq_info(main_graph);
 
-      if (fuser.fuseBCQ(g))
-        changed = true;
+      for (size_t g = 0; g < m->size(); ++g)
+        if (fuser.fuseBCQ(m->graph(g)))
+          changed = true;
     }
     else
     {
@@ -661,6 +662,12 @@ bool FuseBCQPass::run(loco::Graph *g)
   }
 
   return changed;
+}
+
+bool FuseBCQPass::run(loco::Graph *g)
+{
+  // Do nothing for graph
+  return false;
 }
 
 } // namespace luci


### PR DESCRIPTION
Parent Issue : #4961

Until now, `FuseBCQPass` was just available for `loco::Graph`.
This commit will enable supporting for `luci::Module` and change
`run(loco::Graph *)` to do nothing.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>