### PR TITLE
[test/nnfw_api] Fix nnfw_api_gtest fail on x86_64

### DIFF
--- a/tests/nnfw_api/CMakeLists.txt
+++ b/tests/nnfw_api/CMakeLists.txt
@@ -19,6 +19,11 @@ if(ARMCompute_FOUND)
   target_compile_definitions(${RUNTIME_NNFW_API_TEST} PRIVATE TEST_ACL_BACKEND)
 endif(ARMCompute_FOUND)
 
+nnfw_find_package(Xnnpack QUIET)
+if(Xnnpack_FOUND)
+  target_compile_definitions(${RUNTIME_NNFW_API_TEST} PRIVATE TEST_XNNPACK_BACKEND)
+endif(Xnnpack_FOUND)
+
 set(RUNTIME_NNFW_API_TEST_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/include
                                   ${CMAKE_CURRENT_SOURCE_DIR}/src)
 target_include_directories(${RUNTIME_NNFW_API_TEST} PRIVATE ${RUNTIME_NNFW_API_TEST_INCLUDE})

--- a/tests/nnfw_api/src/GenModelTest.h
+++ b/tests/nnfw_api/src/GenModelTest.h
@@ -224,10 +224,16 @@ public:
         _backends.push_back(backend);
       }
 #endif
-      if (backend == "cpu" || backend == "ruy" || backend == "xnnpack")
+      if (backend == "cpu" || backend == "ruy")
       {
         _backends.push_back(backend);
       }
+#ifdef TEST_XNNPACK_BACKEND
+      if (backend == "xnnpack")
+      {
+        _backends.push_back(backend);
+      }
+#endif
     }
   }
 


### PR DESCRIPTION
Disable xnnpack backend test if xnnpack is not used

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>