### PR TITLE
[res] Remove redundant ShapeSignature in recipes

### DIFF
--- a/res/TensorFlowLiteRecipes/ReduceAny_dynamic_002/test.recipe
+++ b/res/TensorFlowLiteRecipes/ReduceAny_dynamic_002/test.recipe
@@ -17,7 +17,6 @@ operand {
   name: "ofm"
   type: BOOL
   shape { dim: 1 dim: 1 dim: 1 }
-  shape_signature { dim: -1 dim: 1 dim: 1 }
 }
 operation {
   type: "ReduceAny"

--- a/res/TensorFlowLiteRecipes/ReduceAny_dynamic_003/test.recipe
+++ b/res/TensorFlowLiteRecipes/ReduceAny_dynamic_003/test.recipe
@@ -17,7 +17,6 @@ operand {
   name: "ofm"
   type: BOOL
   shape { dim: 2 dim: 1 dim: 4 }
-  shape_signature { dim: 2 dim: -1 dim: 4 }
 }
 operation {
   type: "ReduceAny"

--- a/res/TensorFlowLiteRecipes/ReduceProd_dynamic_002/test.recipe
+++ b/res/TensorFlowLiteRecipes/ReduceProd_dynamic_002/test.recipe
@@ -17,7 +17,6 @@ operand {
   name: "ofm"
   type: FLOAT32
   shape { dim: 1 dim: 1 dim: 1 }
-  shape_signature { dim: -1 dim: 1 dim: 1 }
 }
 operation {
   type: "ReduceProd"

--- a/res/TensorFlowLiteRecipes/ReduceProd_dynamic_003/test.recipe
+++ b/res/TensorFlowLiteRecipes/ReduceProd_dynamic_003/test.recipe
@@ -17,7 +17,6 @@ operand {
   name: "ofm"
   type: FLOAT32
   shape { dim: 2 dim: 1 dim: 4 }
-  shape_signature { dim: 2 dim: -1 dim: 4 }
 }
 operation {
   type: "ReduceProd"


### PR DESCRIPTION
Parent Issue : #5037
Fix #5152 

---

Some of recipes include redundant `ShapeSignature` in their recipes.

For example, let's see `ReduceAny_dynamic_003`.
Since `reduction_indices` is 1, second dimension is reduced to 1 whatever the
real value of the dimension is.

- When input shape is [2, 2, 4], output shape is [2, 1, 4]
- When input shape is [2, 3, 4], output shape is [2, 1, 4]
- ...

As a result, even the second dimension has unknown dimension,
the output shape is not dynamic!
It means that output tensor may not have shape signature.

This commit will fix those cases.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>