### PR TITLE
Cherry-pick missing note of 1.7.0 release to master branch.

### DIFF
--- a/docs/release/1.7/release-note-1.7.0.md
+++ b/docs/release/1.7/release-note-1.7.0.md
@@ -1,0 +1,46 @@
+## Feature Highlights
+
+- **ONE** Compiler
+  - Compiler supports more operations
+  - New command line interface for user interface consistancy
+- **ONE** Runtime
+  - Runtime CPU backend supports more operations
+  - Runtime CPU backend supports more quant8 operations
+  - API changes
+  - New optimization
+  
+## ONE Compiler
+
+### Compiler supports more operations
+
+- MatrixDiag, MatrixSetDiag, ReverseSequence, ReverseV2, SegmentSum, SelectV2, SparseToDense, Where
+
+### New command line interface for user interface consistancy
+
+- one-import: imports conventional model files to circle
+   - one-import-tf: imports TensorFlow model to circle
+   - one-import-tflite: imports TensorFlow lite model to circle
+- one-optimize: circle optimize command
+- one-quantize: circle quantize command
+   - supports float32 to uint8, layer wise (for Conv series)
+- one-pack: package command
+- one-prepare-venv: prepares python virtual environment for importing TensorFlow model
+- one-codegen: backend(if available) code generator
+
+## ONE Runtime
+
+### Runtime CPU backend supports more operations
+
+- LogSoftmax, SpaceToBatchND
+
+### Runtime CPU backend supports more quant8 operations
+
+- Logistic, Mul, Tanh, SpaceToBatchND, Transpose, Sub, Max, Min, Less, Greater, GreaterEqual, LessEqual, Equal, NotEqual
+
+### API changes
+
+- Introduce basic asynchronous execution API
+
+### New optimization
+    
+- Remove dynamic tensor overhead from static models


### PR DESCRIPTION
Release Note for 1.7.0 (#3420)

* Release Note for 1.7.0

Release note for 1.7.0 is added

ONE-DCO-1.0-Signed-off-by: Chunseok Lee <chunseok.lee@samsung.com>

* Update docs/release/1.7/release-note-1.7.0.md

Co-authored-by: Seok Namkoong <seok9311@naver.com>
Co-authored-by: twoflower <chunseoklee@gmail.com>
Co-authored-by: Seok Namkoong <seok9311@naver.com>

Signed-off-by: Sung-Jae Lee <sj925.lee@samsung.com>