### PR TITLE
[luci] Enable ShapeSignatureInferencePass in luci

### DIFF
--- a/compiler/luci/export/src/Optimize.cpp
+++ b/compiler/luci/export/src/Optimize.cpp
@@ -18,6 +18,7 @@
 #include "ProgressReporter.h"
 
 #include <luci/Pass/ShapeInferencePass.h>
+#include <luci/Pass/ShapeSignatureInferencePass.h>
 #include <luci/Pass/TypeInferencePass.h>
 
 #include <logo/Phase.h>
@@ -34,6 +35,7 @@ void optimize(loco::Graph *g)
     // prepare type and shape before optimization
     phase.emplace_back(std::make_unique<TypeInferencePass>());
     phase.emplace_back(std::make_unique<ShapeInferencePass>());
+    phase.emplace_back(std::make_unique<ShapeSignatureInferencePass>());
 
     // TODO add more optimization passes (with a knob)
   }

--- a/compiler/luci/pass/src/CircleOptimizer.cpp
+++ b/compiler/luci/pass/src/CircleOptimizer.cpp
@@ -36,6 +36,7 @@
 // TODO add more passes
 
 #include "luci/Pass/ShapeInferencePass.h"
+#include "luci/Pass/ShapeSignatureInferencePass.h"
 #include "luci/Pass/TypeInferencePass.h"
 
 // logo passes
@@ -195,6 +196,7 @@ void CircleOptimizer::optimize(loco::Graph *g) const
 
   // Shape inference is needed for added nodes doing above transformations
   phase.emplace_back(std::make_unique<luci::ShapeInferencePass>());
+  phase.emplace_back(std::make_unique<luci::ShapeSignatureInferencePass>());
   phase.emplace_back(std::make_unique<luci::TypeInferencePass>());
   phase.emplace_back(std::make_unique<logo::RemoveDeadNodeWithQueryPass>());
   /* TRANSFORM DECLARATION END */


### PR DESCRIPTION
Parent Issue : #4372

This commit will enable `ShapeSignatureInferencePass` in `luci`.
FYI, operations which shape signature inference algorithm is not implemented,
it returns it's own shape signature.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>