### PR TITLE
[luci] Enable passes for module optimizations

### DIFF
--- a/compiler/luci/pass/src/CircleOptimizer.cpp
+++ b/compiler/luci/pass/src/CircleOptimizer.cpp
@@ -132,7 +132,14 @@ void CircleOptimizer::optimize(luci::Module *m) const
 {
   luci::Phase phase;
 
-  // Passes will be inserted here
+  phase.emplace_back(std::make_unique<luci::ShapeInferencePass>());
+  phase.emplace_back(std::make_unique<luci::ShapeSignatureInferencePass>());
+  phase.emplace_back(std::make_unique<luci::TypeInferencePass>());
+
+  if (_options->query(Options::Algorithm::FuseBCQ))
+  {
+    phase.emplace_back(std::make_unique<FuseBCQPass>());
+  }
 
   ModuleProgressReporter prog(m, logo::PhaseStrategy::Restart);
   PhaseRunner<logo::PhaseStrategy::Restart> phase_runner{m};
@@ -160,10 +167,6 @@ void CircleOptimizer::optimize(loco::Graph *g) const
   if (_options->query(Options::Algorithm::FuseInstanceNorm))
   {
     phase.emplace_back(std::make_unique<FuseInstanceNormPass>());
-  }
-  if (_options->query(Options::Algorithm::FuseBCQ))
-  {
-    phase.emplace_back(std::make_unique<FuseBCQPass>());
   }
   if (_options->query(Options::Algorithm::FuseBatchNormWithTConv))
   {


### PR DESCRIPTION
Parent Issue : #4961

Until now, optimizations are done only for `loco::Graph`.
This commit will enable optimizations for `luci::Module` such as `FuseBCQPass`
and add basic `luci` service passes for `luci::Module`

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>