### PR TITLE
[bcq-tools] Fix to return correct output arrays

### DIFF
--- a/compiler/bcq-tools/generate_bcq_output_arrays.py
+++ b/compiler/bcq-tools/generate_bcq_output_arrays.py
@@ -85,7 +85,7 @@ def get_bcqinfo_output_arrays_v1(input_path, output_arrays):
     ret_output_arrays = ['one_compiler/bcqinfo_one_metadata']
 
     # given node from user
-    ret_output_arrays.append(output_arrays)
+    ret_output_arrays.append += output_arrays.split(',')
 
     # all pairs of a constant node and related BCQ information nodes.
     for prefix in prefix_set:
@@ -110,7 +110,7 @@ def get_bcq_output_arrays(input_path, output_arrays):
     if model_version == 1:
         return get_bcqinfo_output_arrays_v1(input_path, output_arrays)
     elif model_version == -1:
-        return None
+        return output_arrays.split(',')
     else:
         err_msg = "BCQ version of the model(v{}) ".format(model_version)
         err_msg += "is higher than "


### PR DESCRIPTION
This commit will following bugs

- When given output arrays from user is appended, whole string is appended.
  - As-is : ['out1','out2,out3']
  - To-be : ['out1','out2','out3']
- When BCQ information is not found, returning `None` cause runtime error at next step
  - As-is : Return `None`
  - To-be : Return list of user given output arrays

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>