### PR TITLE
[onert] Introduce TraceCtx that has profiling information per session

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -172,10 +172,9 @@ void set_subgraph_indices(const onert::ir::Subgraphs *subgraphs,
 nnfw_session::nnfw_session()
     : _subgraphs{nullptr}, _execution{nullptr},
       _kernel_registry{std::make_shared<onert::frontend::custom::KernelRegistry>()},
-      _tracing_ctx{std::make_shared<onert::util::TracingCtx>()}
+      _tracing_ctx{std::make_unique<onert::util::TracingCtx>()}
 {
-  // TODO make _tracing_ctx null when no user option for profiling was given
-  _tracing_ctx->makeSessionId();
+  // DO NOTHING
 }
 
 nnfw_session::~nnfw_session() = default;

--- a/runtime/onert/api/src/nnfw_api_internal.h
+++ b/runtime/onert/api/src/nnfw_api_internal.h
@@ -158,7 +158,7 @@ private:
   std::shared_ptr<onert::exec::Execution> _execution;
   std::shared_ptr<onert::frontend::custom::KernelRegistry> _kernel_registry;
 
-  std::shared_ptr<onert::util::TracingCtx> _tracing_ctx;
+  std::unique_ptr<onert::util::TracingCtx> _tracing_ctx;
 };
 
 #endif // __API_NNFW_API_INTERNAL_H__

--- a/runtime/onert/api/src/nnfw_api_internal.h
+++ b/runtime/onert/api/src/nnfw_api_internal.h
@@ -21,6 +21,7 @@
 #include "nnfw_experimental.h"
 
 #include <util/GeneralConfigSource.h>
+#include <util/TracingCtx.h>
 
 #include <string>
 #include <memory>
@@ -156,6 +157,8 @@ private:
   std::unique_ptr<onert::compiler::Compiler> _compiler;
   std::shared_ptr<onert::exec::Execution> _execution;
   std::shared_ptr<onert::frontend::custom::KernelRegistry> _kernel_registry;
+
+  std::shared_ptr<onert::util::TracingCtx> _tracing_ctx;
 };
 
 #endif // __API_NNFW_API_INTERNAL_H__

--- a/runtime/onert/core/include/ir/Subgraphs.h
+++ b/runtime/onert/core/include/ir/Subgraphs.h
@@ -120,7 +120,7 @@ public:
    *
    * @return count of Subgraphs
    */
-  size_t count() { return _subgraphs.size(); }
+  size_t count() const { return _subgraphs.size(); }
 
   /**
    * @brief Return the primary subgraph

--- a/runtime/onert/core/include/util/TracingCtx.h
+++ b/runtime/onert/core/include/util/TracingCtx.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_UTIL_TRACING_CTX_H__
+#define __ONERT_UTIL_TRACING_CTX_H__
+
+#include "ir/Graph.h"
+#include "ir/Index.h"
+
+#include <unordered_map>
+#include <mutex>
+
+namespace onert
+{
+namespace util
+{
+
+/**
+ * @brief Class to maintain information about profiling per session
+ */
+class TracingCtx
+{
+public:
+  // create and store unique session id managed by this class
+  void makeSessionId()
+  {
+    std::unique_lock<std::mutex> lock{_session_id_mutex};
+
+    static uint32_t session_id = 0;
+    _session_id = session_id++;
+
+    lock.unlock();
+  }
+
+  uint32_t getSessionId() { return _session_id; }
+
+  /**
+   * @brief Set subgraph index of a graph
+   */
+  void setSubgraphIndex(const ir::Graph *g, uint32_t index) { _subgraph_indices.emplace(g, index); }
+
+  /**
+   * @brief Get subgraph index of a graph. If there is no such key (g),
+   *        ir::SubgraphIndex(0) will be returned.
+   */
+  ir::SubgraphIndex getSubgraphIndex(const ir::Graph *g) const
+  {
+    auto find = _subgraph_indices.find(g);
+
+    return find == _subgraph_indices.end() ? getDefaultSubgraphIndex() : find->second;
+  }
+
+  /**
+   * @brief Get the Default Subgraph Index object. Call this when there is no subgraph index
+   *        information or when TracingCtx object is nullptr
+   *
+   * @return const ir::SubgraphIndex
+   */
+  static const ir::SubgraphIndex getDefaultSubgraphIndex() { return ir::SubgraphIndex{0}; }
+
+private:
+  std::unordered_map<const ir::Graph *, ir::SubgraphIndex> _subgraph_indices;
+  uint32_t _session_id;
+  std::mutex _session_id_mutex;
+};
+
+} // namespace util
+} // namespace onert
+
+#endif // __ONERT_UTIL_TRACING_CTX_H__

--- a/runtime/onert/core/include/util/TracingCtx.h
+++ b/runtime/onert/core/include/util/TracingCtx.h
@@ -61,7 +61,8 @@ public:
 private:
   std::unordered_map<const ir::Graph *, ir::SubgraphIndex> _subgraph_indices;
   uint32_t _session_id;
-  std::mutex _session_id_mutex;
+
+  static std::mutex _session_id_mutex;
 };
 
 } // namespace util

--- a/runtime/onert/core/src/util/TracingCtx.cc
+++ b/runtime/onert/core/src/util/TracingCtx.cc
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "util/TracingCtx.h"
+
+namespace onert
+{
+namespace util
+{
+
+// initializing static member var
+std::mutex TracingCtx::_session_id_mutex;
+
+} // namespace util
+} // namespace onert


### PR DESCRIPTION
This introduces `TraceCtx` that has profiling information per session.

Why designed this way:
- Designing an object per session is better for multi-threads where a thread
runs a session

Replaces #5101
Parent issue: #4901
Draft: #4903

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>