### PR TITLE
[luci] Use unsigned for width/height attributes

### DIFF
--- a/compiler/luci/lang/include/luci/IR/AttrDilation.h
+++ b/compiler/luci/lang/include/luci/IR/AttrDilation.h
@@ -18,6 +18,7 @@
 #define __LUCI_IR_ATTRDILATION_H__
 
 #include <stdint.h>
+#include <cassert>
 
 namespace luci
 {
@@ -27,15 +28,25 @@ class Dilation final
 public:
   Dilation() : _w(1), _h(1) {}
 
-  int32_t w() const { return _w; }
-  void w(int32_t w) { _w = w; }
+  uint32_t w() const { return _w; }
+  void w(uint32_t w) { _w = w; }
+  void w(int32_t w)
+  {
+    assert(w >= 0);
+    _w = static_cast<uint32_t>(w);
+  }
 
-  int32_t h() const { return _h; }
-  void h(int32_t h) { _h = h; }
+  uint32_t h() const { return _h; }
+  void h(uint32_t h) { _h = h; }
+  void h(int32_t h)
+  {
+    assert(h >= 0);
+    _h = static_cast<uint32_t>(h);
+  }
 
 private:
-  int32_t _w;
-  int32_t _h;
+  uint32_t _w;
+  uint32_t _h;
 };
 
 } // namespace luci

--- a/compiler/luci/lang/include/luci/IR/AttrDilation.h
+++ b/compiler/luci/lang/include/luci/IR/AttrDilation.h
@@ -18,7 +18,6 @@
 #define __LUCI_IR_ATTRDILATION_H__
 
 #include <stdint.h>
-#include <cassert>
 
 namespace luci
 {
@@ -30,19 +29,11 @@ public:
 
   uint32_t w() const { return _w; }
   void w(uint32_t w) { _w = w; }
-  void w(int32_t w)
-  {
-    assert(w >= 0);
-    _w = static_cast<uint32_t>(w);
-  }
+  void w(int32_t w);
 
   uint32_t h() const { return _h; }
   void h(uint32_t h) { _h = h; }
-  void h(int32_t h)
-  {
-    assert(h >= 0);
-    _h = static_cast<uint32_t>(h);
-  }
+  void h(int32_t h);
 
 private:
   uint32_t _w;

--- a/compiler/luci/lang/include/luci/IR/AttrFilter.h
+++ b/compiler/luci/lang/include/luci/IR/AttrFilter.h
@@ -18,6 +18,7 @@
 #define __LUCI_IR_ATTRFILTER_H__
 
 #include <stdint.h>
+#include <cassert>
 
 namespace luci
 {
@@ -27,15 +28,25 @@ class Filter final
 public:
   Filter() : _w(1), _h(1) {}
 
-  int32_t w() const { return _w; }
-  void w(int32_t w) { _w = w; }
+  uint32_t w() const { return _w; }
+  void w(uint32_t w) { _w = w; }
+  void w(int32_t w)
+  {
+    assert(w >= 0);
+    _w = static_cast<uint32_t>(w);
+  }
 
-  int32_t h() const { return _h; }
-  void h(int32_t h) { _h = h; }
+  uint32_t h() const { return _h; }
+  void h(uint32_t h) { _h = h; }
+  void h(int32_t h)
+  {
+    assert(h >= 0);
+    _h = static_cast<uint32_t>(h);
+  }
 
 private:
-  int32_t _w;
-  int32_t _h;
+  uint32_t _w;
+  uint32_t _h;
 };
 
 } // namespace luci

--- a/compiler/luci/lang/include/luci/IR/AttrFilter.h
+++ b/compiler/luci/lang/include/luci/IR/AttrFilter.h
@@ -18,7 +18,6 @@
 #define __LUCI_IR_ATTRFILTER_H__
 
 #include <stdint.h>
-#include <cassert>
 
 namespace luci
 {
@@ -30,19 +29,11 @@ public:
 
   uint32_t w() const { return _w; }
   void w(uint32_t w) { _w = w; }
-  void w(int32_t w)
-  {
-    assert(w >= 0);
-    _w = static_cast<uint32_t>(w);
-  }
+  void w(int32_t w);
 
   uint32_t h() const { return _h; }
   void h(uint32_t h) { _h = h; }
-  void h(int32_t h)
-  {
-    assert(h >= 0);
-    _h = static_cast<uint32_t>(h);
-  }
+  void h(int32_t h);
 
 private:
   uint32_t _w;

--- a/compiler/luci/lang/include/luci/IR/AttrStride.h
+++ b/compiler/luci/lang/include/luci/IR/AttrStride.h
@@ -18,6 +18,7 @@
 #define __LUCI_IR_ATTRSTRIDE_H__
 
 #include <stdint.h>
+#include <cassert>
 
 namespace luci
 {
@@ -27,15 +28,25 @@ class Stride final
 public:
   Stride() : _w(1), _h(1) {}
 
-  int32_t w() const { return _w; }
-  void w(int32_t w) { _w = w; }
+  uint32_t w() const { return _w; }
+  void w(uint32_t w) { _w = w; }
+  void w(int32_t w)
+  {
+    assert(w >= 0);
+    _w = static_cast<uint32_t>(w);
+  }
 
-  int32_t h() const { return _h; }
-  void h(int32_t h) { _h = h; }
+  uint32_t h() const { return _h; }
+  void h(uint32_t h) { _h = h; }
+  void h(int32_t h)
+  {
+    assert(h >= 0);
+    _h = static_cast<uint32_t>(h);
+  }
 
 private:
-  int32_t _w;
-  int32_t _h;
+  uint32_t _w;
+  uint32_t _h;
 };
 
 } // namespace luci

--- a/compiler/luci/lang/src/AttrDilation.cpp
+++ b/compiler/luci/lang/src/AttrDilation.cpp
@@ -14,32 +14,23 @@
  * limitations under the License.
  */
 
-#ifndef __LUCI_IR_ATTRSTRIDE_H__
-#define __LUCI_IR_ATTRSTRIDE_H__
+#include "luci/IR/AttrDilation.h"
 
-#include <stdint.h>
+#include <cassert>
 
 namespace luci
 {
 
-class Stride final
+void Dilation::w(int32_t w)
 {
-public:
-  Stride() : _w(1), _h(1) {}
+  assert(w >= 0);
+  _w = static_cast<uint32_t>(w);
+}
 
-  uint32_t w() const { return _w; }
-  void w(uint32_t w) { _w = w; }
-  void w(int32_t w);
-
-  uint32_t h() const { return _h; }
-  void h(uint32_t h) { _h = h; }
-  void h(int32_t h);
-
-private:
-  uint32_t _w;
-  uint32_t _h;
-};
+void Dilation::h(int32_t h)
+{
+  assert(h >= 0);
+  _h = static_cast<uint32_t>(h);
+}
 
 } // namespace luci
-
-#endif // __LUCI_IR_ATTRSTRIDE_H__

--- a/compiler/luci/lang/src/AttrDilation.test.cpp
+++ b/compiler/luci/lang/src/AttrDilation.test.cpp
@@ -14,32 +14,23 @@
  * limitations under the License.
  */
 
-#ifndef __LUCI_IR_ATTRSTRIDE_H__
-#define __LUCI_IR_ATTRSTRIDE_H__
+#include "luci/IR/AttrDilation.h"
 
-#include <stdint.h>
+#include <gtest/gtest.h>
 
-namespace luci
+TEST(CircleAttrDilationTest, set)
 {
+  auto d = luci::Dilation();
 
-class Stride final
-{
-public:
-  Stride() : _w(1), _h(1) {}
+  d.h(10u);
+  d.w(10u);
 
-  uint32_t w() const { return _w; }
-  void w(uint32_t w) { _w = w; }
-  void w(int32_t w);
+  ASSERT_EQ(d.h(), 10u);
+  ASSERT_EQ(d.w(), 10u);
 
-  uint32_t h() const { return _h; }
-  void h(uint32_t h) { _h = h; }
-  void h(int32_t h);
+  d.h(10); // int32_t
+  d.w(10);
 
-private:
-  uint32_t _w;
-  uint32_t _h;
-};
-
-} // namespace luci
-
-#endif // __LUCI_IR_ATTRSTRIDE_H__
+  ASSERT_EQ(d.h(), 10u);
+  ASSERT_EQ(d.w(), 10u);
+}

--- a/compiler/luci/lang/src/AttrFilter.cpp
+++ b/compiler/luci/lang/src/AttrFilter.cpp
@@ -14,32 +14,23 @@
  * limitations under the License.
  */
 
-#ifndef __LUCI_IR_ATTRSTRIDE_H__
-#define __LUCI_IR_ATTRSTRIDE_H__
+#include "luci/IR/AttrFilter.h"
 
-#include <stdint.h>
+#include <cassert>
 
 namespace luci
 {
 
-class Stride final
+void Filter::w(int32_t w)
 {
-public:
-  Stride() : _w(1), _h(1) {}
+  assert(w >= 0);
+  _w = static_cast<uint32_t>(w);
+}
 
-  uint32_t w() const { return _w; }
-  void w(uint32_t w) { _w = w; }
-  void w(int32_t w);
-
-  uint32_t h() const { return _h; }
-  void h(uint32_t h) { _h = h; }
-  void h(int32_t h);
-
-private:
-  uint32_t _w;
-  uint32_t _h;
-};
+void Filter::h(int32_t h)
+{
+  assert(h >= 0);
+  _h = static_cast<uint32_t>(h);
+}
 
 } // namespace luci
-
-#endif // __LUCI_IR_ATTRSTRIDE_H__

--- a/compiler/luci/lang/src/AttrFilter.test.cpp
+++ b/compiler/luci/lang/src/AttrFilter.test.cpp
@@ -14,32 +14,23 @@
  * limitations under the License.
  */
 
-#ifndef __LUCI_IR_ATTRSTRIDE_H__
-#define __LUCI_IR_ATTRSTRIDE_H__
+#include "luci/IR/AttrFilter.h"
 
-#include <stdint.h>
+#include <gtest/gtest.h>
 
-namespace luci
+TEST(CircleAttrFilterTest, set)
 {
+  auto f = luci::Filter();
 
-class Stride final
-{
-public:
-  Stride() : _w(1), _h(1) {}
+  f.h(10u);
+  f.w(10u);
 
-  uint32_t w() const { return _w; }
-  void w(uint32_t w) { _w = w; }
-  void w(int32_t w);
+  ASSERT_EQ(f.h(), 10u);
+  ASSERT_EQ(f.w(), 10u);
 
-  uint32_t h() const { return _h; }
-  void h(uint32_t h) { _h = h; }
-  void h(int32_t h);
+  f.h(10); // int32_t
+  f.w(10);
 
-private:
-  uint32_t _w;
-  uint32_t _h;
-};
-
-} // namespace luci
-
-#endif // __LUCI_IR_ATTRSTRIDE_H__
+  ASSERT_EQ(f.h(), 10u);
+  ASSERT_EQ(f.w(), 10u);
+}

--- a/compiler/luci/lang/src/AttrStride.cpp
+++ b/compiler/luci/lang/src/AttrStride.cpp
@@ -14,32 +14,23 @@
  * limitations under the License.
  */
 
-#ifndef __LUCI_IR_ATTRSTRIDE_H__
-#define __LUCI_IR_ATTRSTRIDE_H__
+#include "luci/IR/AttrStride.h"
 
-#include <stdint.h>
+#include <cassert>
 
 namespace luci
 {
 
-class Stride final
+void Stride::w(int32_t w)
 {
-public:
-  Stride() : _w(1), _h(1) {}
+  assert(w >= 0);
+  _w = static_cast<uint32_t>(w);
+}
 
-  uint32_t w() const { return _w; }
-  void w(uint32_t w) { _w = w; }
-  void w(int32_t w);
-
-  uint32_t h() const { return _h; }
-  void h(uint32_t h) { _h = h; }
-  void h(int32_t h);
-
-private:
-  uint32_t _w;
-  uint32_t _h;
-};
+void Stride::h(int32_t h)
+{
+  assert(h >= 0);
+  _h = static_cast<uint32_t>(h);
+}
 
 } // namespace luci
-
-#endif // __LUCI_IR_ATTRSTRIDE_H__

--- a/compiler/luci/lang/src/AttrStride.test.cpp
+++ b/compiler/luci/lang/src/AttrStride.test.cpp
@@ -14,32 +14,23 @@
  * limitations under the License.
  */
 
-#ifndef __LUCI_IR_ATTRSTRIDE_H__
-#define __LUCI_IR_ATTRSTRIDE_H__
+#include "luci/IR/AttrStride.h"
 
-#include <stdint.h>
+#include <gtest/gtest.h>
 
-namespace luci
+TEST(CircleAttrStrideTest, set)
 {
+  auto s = luci::Stride();
 
-class Stride final
-{
-public:
-  Stride() : _w(1), _h(1) {}
+  s.h(10u);
+  s.w(10u);
 
-  uint32_t w() const { return _w; }
-  void w(uint32_t w) { _w = w; }
-  void w(int32_t w);
+  ASSERT_EQ(s.h(), 10u);
+  ASSERT_EQ(s.w(), 10u);
 
-  uint32_t h() const { return _h; }
-  void h(uint32_t h) { _h = h; }
-  void h(int32_t h);
+  s.h(10); // int32_t
+  s.w(10);
 
-private:
-  uint32_t _w;
-  uint32_t _h;
-};
-
-} // namespace luci
-
-#endif // __LUCI_IR_ATTRSTRIDE_H__
+  ASSERT_EQ(s.h(), 10u);
+  ASSERT_EQ(s.w(), 10u);
+}


### PR DESCRIPTION
This will revise luci width/height of Dilation, Filter and Stride to use
unsigned values.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>