### PR TITLE
[onert] Adds missing header guard into GenModelTest.h

### DIFF
--- a/tests/nnfw_api/src/GenModelTest.h
+++ b/tests/nnfw_api/src/GenModelTest.h
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+#ifndef __NNFW_API_TEST_GEN_MODEL_TEST_H__
+#define __NNFW_API_TEST_GEN_MODEL_TEST_H__
+
 #include <gtest/gtest.h>
 #include <nnfw_internal.h>
 
@@ -453,3 +456,5 @@ protected:
   SessionObjectGeneric _so;
   std::unique_ptr<GenModelTestContext> _context;
 };
+
+#endif // __NNFW_API_TEST_GEN_MODEL_TEST_H__


### PR DESCRIPTION
This adds missing header guard into `GenModelTest.h`.

The prefix `__NNFW_API_TEST_` follows the way of other header files in the same directory.

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>