### PR TITLE
[onert] Show shape information in Chrome Tracing

### DIFF
--- a/runtime/onert/core/src/util/EventCollector.cc
+++ b/runtime/onert/core/src/util/EventCollector.cc
@@ -38,14 +38,16 @@ class DurationEventBuilder
 public:
   DurationEventBuilder(const std::string &ts) : _ts{ts} {}
 
-  DurationEvent build(const std::string &tid, const std::string &name, const std::string &ph) const
+  DurationEvent build(const EventCollector::Event &evt_collected, const std::string &ph) const
   {
     DurationEvent evt;
 
-    evt.name = name;
-    evt.tid = tid;
+    evt.name = evt_collected.label;
+    evt.tid = evt_collected.backend;
     evt.ph = ph;
     evt.ts = _ts;
+
+    evt.args = evt_collected.userData;
 
     return evt;
   }
@@ -93,11 +95,11 @@ void EventCollector::onEvent(const Event &event)
   switch (event.edge)
   {
     case Edge::BEGIN:
-      _rec->emit(DurationEventBuilder(ts).build(event.backend, event.label, "B"));
+      _rec->emit(DurationEventBuilder(ts).build(event, "B"));
       break;
 
     case Edge::END:
-      _rec->emit(DurationEventBuilder(ts).build(event.backend, event.label, "E"));
+      _rec->emit(DurationEventBuilder(ts).build(event, "E"));
       break;
   }
 

--- a/runtime/onert/core/src/util/EventCollector.h
+++ b/runtime/onert/core/src/util/EventCollector.h
@@ -19,6 +19,10 @@
 
 #include "util/EventRecorder.h"
 
+#include <vector>
+#include <utility>
+#include <string>
+
 class EventCollector
 {
 public:
@@ -33,6 +37,14 @@ public:
     Edge edge;
     std::string backend;
     std::string label;
+
+    // user-defined data: pairs of (key, value)
+    std::vector<std::pair<std::string, std::string>> userData;
+
+    Event(Edge a_edge, const std::string &a_backend, const std::string &a_label)
+        : edge(a_edge), backend(a_backend), label(a_label)
+    { /* empty */
+    }
   };
 
 public:

--- a/runtime/onert/core/src/util/EventRecorder.h
+++ b/runtime/onert/core/src/util/EventRecorder.h
@@ -27,8 +27,9 @@ struct Event
 {
   std::string name;
   std::string tid;
-  std::string ph; /* REQUIRED */
-  std::string ts; /* REQUIRED */
+  std::string ph;                                        /* REQUIRED */
+  std::string ts;                                        /* REQUIRED */
+  std::vector<std::pair<std::string, std::string>> args; // user-defined data: pairs of (key, value)
 };
 
 struct DurationEvent : public Event

--- a/runtime/onert/core/src/util/EventWriter.cc
+++ b/runtime/onert/core/src/util/EventWriter.cc
@@ -89,6 +89,7 @@ void fill(Content &content, const Event &evt)
   content.flds.emplace_back("tid", evt.tid);
   content.flds.emplace_back("ph", evt.ph);
   content.flds.emplace_back("ts", evt.ts);
+  content.args = evt.args;
 }
 
 std::string object(const DurationEvent &evt)


### PR DESCRIPTION
This adds user data field where we can store input shape that eventually
be shown in Chrome Tracing.

During testing a model I am working on, I needed this feature. For example,

- Assume that you have a model with 1000 operations where 20 operation
  is op type _FOO_.
- Some conversion is done to convert _FOO_ to optimized _BAR_ op
  and your converter reduced the total number of operations to 80
  after optimization.
- Now, you want to compare the performance of a specific _FOO_ and _BAR._
  The _FOO_ op has operation index, e.g, 30, but 30th op in optimized model
  is not BAR. (since the total number of operations are reduced).

In such case, some hint should be provided to find the right _BAR._
You can use this input shape as a hint if `FOO's input share == BAR's input shape`.

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>