### PR TITLE
[luci] Shape Signature inference algo for OutputDummy,OutputExclude

### DIFF
--- a/compiler/luci/service/include/luci/Service/CircleShapeSignatureInference.h
+++ b/compiler/luci/service/include/luci/Service/CircleShapeSignatureInference.h
@@ -158,8 +158,8 @@ public:
   // Virtual
   ShapeSignature visit(const luci::CircleInput *node) final;
   ShapeSignature visit(const luci::CircleOutput *node) final;
-  // ShapeSignature visit(const luci::CircleOutputDummy *node) final;
-  // ShapeSignature visit(const luci::CircleOutputExclude *node) final;
+  ShapeSignature visit(const luci::CircleOutputDummy *node) final;
+  ShapeSignature visit(const luci::CircleOutputExclude *node) final;
   // ShapeSignature visit(const luci::CircleCustomOut *node) final;
   // ShapeSignature visit(const luci::CircleIfOut *node) final;
   // ShapeSignature visit(const luci::CircleNonMaxSuppressionV4Out *node) final;

--- a/compiler/luci/service/src/Nodes/CircleOutputDummy.cpp
+++ b/compiler/luci/service/src/Nodes/CircleOutputDummy.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <luci/Service/CircleShapeSignatureInference.h>
+
+namespace luci
+{
+
+ShapeSignature ssinf::Algorithm::visit(const luci::CircleOutputDummy *node)
+{
+  return ShapeSignature();
+}
+
+} // namespace luci

--- a/compiler/luci/service/src/Nodes/CircleOutputDummy.cpp
+++ b/compiler/luci/service/src/Nodes/CircleOutputDummy.cpp
@@ -19,9 +19,6 @@
 namespace luci
 {
 
-ShapeSignature ssinf::Algorithm::visit(const luci::CircleOutputDummy *node)
-{
-  return ShapeSignature();
-}
+ShapeSignature ssinf::Algorithm::visit(const luci::CircleOutputDummy *) { return ShapeSignature(); }
 
 } // namespace luci

--- a/compiler/luci/service/src/Nodes/CircleOutputExclude.cpp
+++ b/compiler/luci/service/src/Nodes/CircleOutputExclude.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-ShapeSignature ssinf::Algorithm::visit(const luci::CircleOutputExclude *node)
+ShapeSignature ssinf::Algorithm::visit(const luci::CircleOutputExclude *)
 {
   return ShapeSignature();
 }

--- a/compiler/luci/service/src/Nodes/CircleOutputExclude.cpp
+++ b/compiler/luci/service/src/Nodes/CircleOutputExclude.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <luci/Service/CircleShapeSignatureInference.h>
+
+namespace luci
+{
+
+ShapeSignature ssinf::Algorithm::visit(const luci::CircleOutputExclude *node)
+{
+  return ShapeSignature();
+}
+
+} // namespace luci


### PR DESCRIPTION
Parent issue : #5037 

This commit introduces `ShapeSIgnatureInferenceAlgorithm` for

- `CircleOutputDummy`
- `CircleOutputExclude`

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>