### PR TITLE
[luci] Rename ShapeSignature inference helper function

### DIFF
--- a/compiler/luci/service/include/luci/Service/CircleShapeSignatureInferenceHelper.h
+++ b/compiler/luci/service/include/luci/Service/CircleShapeSignatureInferenceHelper.h
@@ -28,7 +28,7 @@ namespace ssinf // Namespace for Shape Signature Inference
 
 ShapeSignature reduced_signature(const loco::Node *node, const loco::Node *indices, bool keep_dims);
 
-ShapeSignature signature_of_arg(const luci::CircleNode *node, uint32_t index);
+ShapeSignature input_arg_signature(const luci::CircleNode *node, uint32_t index);
 
 } // namespace ssinf
 

--- a/compiler/luci/service/src/CircleShapeSignatureInferenceHelper.cpp
+++ b/compiler/luci/service/src/CircleShapeSignatureInferenceHelper.cpp
@@ -142,7 +142,7 @@ ShapeSignature reduced_signature(const loco::Node *node, const loco::Node *indic
   return clean_signature(output_signature);
 }
 
-ShapeSignature signature_of_arg(const luci::CircleNode *node, uint32_t index)
+ShapeSignature input_arg_signature(const luci::CircleNode *node, uint32_t index)
 {
   auto circle_input = loco::must_cast<luci::CircleNode *>(node->arg(index));
   return circle_input->shape_signature();

--- a/compiler/luci/service/src/Nodes/CircleOutput.cpp
+++ b/compiler/luci/service/src/Nodes/CircleOutput.cpp
@@ -21,7 +21,7 @@ namespace luci
 
 ShapeSignature ssinf::Algorithm::visit(const luci::CircleOutput *node)
 {
-  return signature_of_arg(node, 0);
+  return input_arg_signature(node, 0);
 }
 
 } // namespace luci

--- a/compiler/luci/service/src/Nodes/CircleRelu.cpp
+++ b/compiler/luci/service/src/Nodes/CircleRelu.cpp
@@ -21,7 +21,7 @@ namespace luci
 
 ShapeSignature ssinf::Algorithm::visit(const luci::CircleRelu *node)
 {
-  return signature_of_arg(node, 0);
+  return input_arg_signature(node, 0);
 }
 
 } // namespace luci

--- a/compiler/luci/service/src/Nodes/CircleRelu6.cpp
+++ b/compiler/luci/service/src/Nodes/CircleRelu6.cpp
@@ -21,7 +21,7 @@ namespace luci
 
 ShapeSignature ssinf::Algorithm::visit(const luci::CircleRelu6 *node)
 {
-  return signature_of_arg(node, 0);
+  return input_arg_signature(node, 0);
 }
 
 } // namespace luci

--- a/compiler/luci/service/src/Nodes/CircleReluN1To1.cpp
+++ b/compiler/luci/service/src/Nodes/CircleReluN1To1.cpp
@@ -21,7 +21,7 @@ namespace luci
 
 ShapeSignature ssinf::Algorithm::visit(const luci::CircleReluN1To1 *node)
 {
-  return signature_of_arg(node, 0);
+  return input_arg_signature(node, 0);
 }
 
 } // namespace luci


### PR DESCRIPTION
Parent Issue : #5037

This commit will rename `signature_of_arg` to `input_arg_signature`.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>