### PR TITLE
[tfldump] Support to dump metadata in Model

### DIFF
--- a/compiler/tfldump/src/Dump.cpp
+++ b/compiler/tfldump/src/Dump.cpp
@@ -384,12 +384,15 @@ void dump_model(std::ostream &os, const tflite::Model *model)
   os << std::endl;
 
   // dump metadata
-  os << "metadata : B(index) name" << std::endl;
-  for (uint32_t i = 0; i < metadata->Length(); ++i)
+  if (metadata != nullptr)
   {
-    os << "B(" << metadata->Get(i)->buffer() << ") " << metadata->Get(i)->name()->c_str();
+    os << "metadata : B(index) name" << std::endl;
+    for (uint32_t i = 0; i < metadata->Length(); ++i)
+    {
+      os << "B(" << metadata->Get(i)->buffer() << ") " << metadata->Get(i)->name()->c_str();
+    }
+    os << std::endl;
   }
-  os << std::endl;
 
   for (uint32_t sg = 0; sg < num_subgraph; ++sg)
   {

--- a/compiler/tfldump/src/Dump.cpp
+++ b/compiler/tfldump/src/Dump.cpp
@@ -349,6 +349,7 @@ void dump_model(std::ostream &os, const tflite::Model *model)
 
   auto opcodes = reader.opcodes();
   auto buffers = reader.buffers();
+  auto metadata = reader.metadata();
 
   // dump operator_codes
   os << "Operator Codes: [order] OpCodeName (OpCode Enum)" << std::endl;
@@ -379,6 +380,14 @@ void dump_model(std::ostream &os, const tflite::Model *model)
       dump_buffer(os, buff_data, size, 16);
     }
     os << std::endl;
+  }
+  os << std::endl;
+
+  // dump metadata
+  os << "metadata : B(index) name" << std::endl;
+  for (uint32_t i = 0; i < metadata->Length(); ++i)
+  {
+    os << "B(" << metadata->Get(i)->buffer() << ") " << metadata->Get(i)->name()->c_str();
   }
   os << std::endl;
 

--- a/compiler/tfldump/src/Read.cpp
+++ b/compiler/tfldump/src/Read.cpp
@@ -81,6 +81,7 @@ Reader::Reader(const tflite::Model *model)
   _version = model->version();
   _subgraphs = model->subgraphs();
   _buffers = model->buffers();
+  _metadata = model->metadata();
 
   auto opcodes = model->operator_codes();
   for (const ::tflite::OperatorCode *opcode : *opcodes)

--- a/compiler/tfldump/src/Read.h
+++ b/compiler/tfldump/src/Read.h
@@ -52,6 +52,7 @@ private:
   using TFliteBuffers_t = flatbuffers::Vector<flatbuffers::Offset<tflite::Buffer>>;
   using TFliteTensors_t = flatbuffers::Vector<flatbuffers::Offset<tflite::Tensor>>;
   using TFliteOperators_t = flatbuffers::Vector<flatbuffers::Offset<tflite::Operator>>;
+  using TFliteMetadata_t = flatbuffers::Vector<flatbuffers::Offset<tflite::Metadata>>;
 
 public:
   Reader(const tflite::Model *model);
@@ -67,6 +68,7 @@ public:
   const TFliteOperators_t *operators() { return _operators; }
   const std::vector<int32_t> &inputs() const { return _inputs; }
   const std::vector<int32_t> &outputs() const { return _outputs; }
+  const TFliteMetadata_t *metadata() const { return _metadata; }
 
   uint32_t num_subgraph() const { return _subgraphs->Length(); }
 
@@ -86,6 +88,7 @@ private:
   const TFliteBuffers_t *_buffers{nullptr};
   const TFliteTensors_t *_tensors{nullptr};
   const TFliteOperators_t *_operators{nullptr};
+  const TFliteMetadata_t *_metadata{nullptr};
 
   uint32_t _subgraph_index;
   std::string _subgraph_name;


### PR DESCRIPTION
If we dump `.tflite` file, there was always one dummy buffer with some values.
It was turned out to `metadata` in `Model`.
This commit will enable supporting to dump `metadata` in `Model`.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>