### PR TITLE
[onert/test] Use nnfw API for tflite loader test

### DIFF
--- a/tests/tools/tflite_loader/CMakeLists.txt
+++ b/tests/tools/tflite_loader/CMakeLists.txt
@@ -16,7 +16,7 @@ nnfw_find_package(Boost REQUIRED program_options system filesystem)
 add_executable(tflite_loader_test_tool ${SOURCES})
 target_include_directories(tflite_loader_test_tool PRIVATE ${Boost_INCLUDE_DIRS})
 
-target_link_libraries(tflite_loader_test_tool onert_core onert tflite_loader)
+target_link_libraries(tflite_loader_test_tool nnfw-dev onert_core onert tflite_loader)
 target_link_libraries(tflite_loader_test_tool nnfw_lib_tflite nnfw_lib_misc)
 target_link_libraries(tflite_loader_test_tool ${Boost_PROGRAM_OPTIONS_LIBRARY} ${Boost_SYSTEM_LIBRARY} ${Boost_FILESYSTEM_LIBRARY})
 


### PR DESCRIPTION
TFLite loader test tool uses nnfw API for onert inference

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>