### PR TITLE
[onert] Pass TracingCtx to Compiler

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -160,7 +160,7 @@ void setConfigKeyValues(const CfgKeyValues &keyValues)
 nnfw_session::nnfw_session()
     : _subgraphs{nullptr}, _execution{nullptr},
       _kernel_registry{std::make_shared<onert::frontend::custom::KernelRegistry>()},
-      _tracing_ctx{std::make_unique<onert::util::TracingCtx>()}
+      _tracing_ctx{nullptr}
 {
   // DO NOTHING
 }
@@ -188,7 +188,7 @@ NNFW_STATUS nnfw_session::load_circle_from_buffer(uint8_t *buffer, size_t size)
     return NNFW_STATUS_ERROR;
   }
 
-  _tracing_ctx->setSubgraphIndices(_subgraphs.get());
+  _tracing_ctx = std::make_unique<onert::util::TracingCtx>(_subgraphs.get());
 
   _compiler = std::make_unique<onert::compiler::Compiler>(_subgraphs, _tracing_ctx.get());
 
@@ -318,7 +318,7 @@ NNFW_STATUS nnfw_session::load_model_from_file(const char *package_dir)
     return NNFW_STATUS_ERROR;
   }
 
-  _tracing_ctx->setSubgraphIndices(_subgraphs.get());
+  _tracing_ctx = std::make_unique<onert::util::TracingCtx>(_subgraphs.get());
 
   _compiler = std::make_unique<onert::compiler::Compiler>(_subgraphs, _tracing_ctx.get());
 

--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -155,18 +155,6 @@ void setConfigKeyValues(const CfgKeyValues &keyValues)
   onert::util::config_source_ext(std::move(configsrc));
 }
 
-// fill graph and subgraph index map for profiling
-void set_subgraph_indices(const onert::ir::Subgraphs *subgraphs,
-                          onert::util::TracingCtx *tracing_ctx)
-{
-  assert(subgraphs);
-  assert(tracing_ctx);
-
-  auto count = subgraphs->count();
-  for (size_t i = 0; i < count; i++)
-    tracing_ctx->setSubgraphIndex(subgraphs->at(onert::ir::SubgraphIndex(i)).get(), i);
-}
-
 } // namespace
 
 nnfw_session::nnfw_session()
@@ -200,9 +188,9 @@ NNFW_STATUS nnfw_session::load_circle_from_buffer(uint8_t *buffer, size_t size)
     return NNFW_STATUS_ERROR;
   }
 
-  set_subgraph_indices(_subgraphs.get(), _tracing_ctx.get());
+  _tracing_ctx->setSubgraphIndices(_subgraphs.get());
 
-  _compiler = std::make_unique<onert::compiler::Compiler>(_subgraphs);
+  _compiler = std::make_unique<onert::compiler::Compiler>(_subgraphs, _tracing_ctx.get());
 
   _state = State::MODEL_LOADED;
   return NNFW_STATUS_NO_ERROR;
@@ -250,7 +238,7 @@ NNFW_STATUS nnfw_session::load_model_from_modelfile(const char *model_file_path)
     return NNFW_STATUS_ERROR;
   }
 
-  _compiler = std::make_unique<onert::compiler::Compiler>(_subgraphs);
+  _compiler = std::make_unique<onert::compiler::Compiler>(_subgraphs, _tracing_ctx.get());
 
   _state = State::MODEL_LOADED;
   return NNFW_STATUS_NO_ERROR;
@@ -330,9 +318,9 @@ NNFW_STATUS nnfw_session::load_model_from_file(const char *package_dir)
     return NNFW_STATUS_ERROR;
   }
 
-  set_subgraph_indices(_subgraphs.get(), _tracing_ctx.get());
+  _tracing_ctx->setSubgraphIndices(_subgraphs.get());
 
-  _compiler = std::make_unique<onert::compiler::Compiler>(_subgraphs);
+  _compiler = std::make_unique<onert::compiler::Compiler>(_subgraphs, _tracing_ctx.get());
 
   _state = State::MODEL_LOADED;
   return NNFW_STATUS_NO_ERROR;

--- a/runtime/onert/core/include/compiler/Compiler.h
+++ b/runtime/onert/core/include/compiler/Compiler.h
@@ -24,6 +24,7 @@
 
 #include "ir/Graph.h"
 #include "exec/IExecutor.h"
+#include "util/TracingCtx.h"
 
 namespace onert
 {
@@ -59,6 +60,8 @@ struct CompilerOptions
   bool he_profiling_mode; //< Whether HEScheduler profiling mode ON/OFF
   bool disable_compile;   //< Run with Interpreter if true, try compilation otherwise
   bool fp16_enable;       //< Whether fp16 mode ON/OFF
+
+  util::TracingCtx *tracing_ctx; //< Profiling information
 };
 
 CompilerOptions fetchCompilerOptionsFromGlobalConfig(const ir::Subgraphs &subgs);
@@ -72,8 +75,9 @@ public:
   /**
    * @brief     Construct a new Compiler object
    * @param[in] subgs All subgraphs of a model
+   * @param[in] tracing_ctx Profiling information
    */
-  Compiler(const std::shared_ptr<ir::Subgraphs> &subgs);
+  Compiler(const std::shared_ptr<ir::Subgraphs> &subgs, util::TracingCtx *tracing_ctx);
 
 public:
   /**

--- a/runtime/onert/core/include/util/TracingCtx.h
+++ b/runtime/onert/core/include/util/TracingCtx.h
@@ -19,6 +19,7 @@
 
 #include "ir/Graph.h"
 #include "ir/Index.h"
+#include "ir/Subgraphs.h"
 
 #include <unordered_map>
 #include <mutex>
@@ -54,6 +55,18 @@ public:
   void setSubgraphIndex(const ir::Graph *g, uint32_t index) { _subgraph_indices.emplace(g, index); }
 
   /**
+   * @brief Set multiple subgraph indices
+   */
+  void setSubgraphIndices(const onert::ir::Subgraphs *subgraphs)
+  {
+    assert(subgraphs);
+
+    auto count = subgraphs->count();
+    for (size_t i = 0; i < count; i++)
+      setSubgraphIndex(subgraphs->at(onert::ir::SubgraphIndex(i)).get(), i);
+  }
+
+  /**
    * @brief Get subgraph index of a graph.
    */
   ir::SubgraphIndex getSubgraphIndex(const ir::Graph *g) const { return _subgraph_indices.at(g); }
@@ -61,7 +74,6 @@ public:
 private:
   std::unordered_map<const ir::Graph *, ir::SubgraphIndex> _subgraph_indices;
   uint32_t _session_id;
-
   static std::mutex _session_id_mutex;
 };
 

--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -131,13 +131,15 @@ CompilerOptions fetchCompilerOptionsFromGlobalConfig(const ir::Subgraphs &subgs)
   return options;
 }
 
-Compiler::Compiler(const std::shared_ptr<ir::Subgraphs> &subgs)
+Compiler::Compiler(const std::shared_ptr<ir::Subgraphs> &subgs, util::TracingCtx *tracing_ctx)
     : _subgraphs{subgs}, _state{State::CREATED}
 {
   // Set default values for CompilerOptions
   // All these default values should not be fetched from Env, when we stop supporting Android NN
   // API.
   _options = fetchCompilerOptionsFromGlobalConfig(*subgs);
+
+  _options.tracing_ctx = tracing_ctx;
 }
 
 void Compiler::enableToFp16() { _options.fp16_enable = true; }

--- a/runtime/onert/core/src/compiler/ExecutorFactory.cc
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.cc
@@ -345,6 +345,7 @@ ExecutorFactory::createLinearExecutor(std::unique_ptr<compiler::LoweredGraph> lo
     });
   }
 
+  // TODO pass tracing_ctx
   auto exec =
       new exec::LinearExecutor{std::move(lowered_graph), tensor_regs, std::move(code_map), order};
 
@@ -449,10 +450,12 @@ exec::IExecutor *ExecutorFactory::createDataflowExecutor(
   exec::ExecutorBase *exec = nullptr;
   if (parallel)
   {
+    // TODO pass tracing_ctx
     exec = new exec::ParallelExecutor{std::move(lowered_graph), tensor_regs, std::move(code_map)};
   }
   else
   {
+    // TODO pass tracing_ctx
     auto dataflow_exec =
         new exec::DataflowExecutor{std::move(lowered_graph), tensor_regs, std::move(code_map)};
     if (options.he_profiling_mode)

--- a/runtime/onert/core/src/compiler/LoweredGraph.cc
+++ b/runtime/onert/core/src/compiler/LoweredGraph.cc
@@ -32,6 +32,7 @@
 #include "compiler/BackendResolver.h"
 #include "compiler/ManualScheduler.h"
 #include "compiler/HEScheduler.h"
+#include "util/TracingCtx.h"
 
 namespace onert
 {
@@ -40,6 +41,13 @@ namespace compiler
 
 LoweredGraph::LoweredGraph(const ir::Graph &graph, const CompilerOptions &options) : _graph{graph}
 {
+  // set tracing_ctx for copied graph
+  if (options.tracing_ctx)
+  {
+    auto subgraph_index = options.tracing_ctx->getSubgraphIndex(&graph);
+    options.tracing_ctx->setSubgraphIndex(&_graph, subgraph_index.value());
+  }
+
   bool linear_executor = (options.executor == "Linear");
 
   // Build backend contexts

--- a/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksCompilation.cc
+++ b/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksCompilation.cc
@@ -20,15 +20,14 @@
 
 // TODO Support multiple subgraphs
 ANeuralNetworksCompilation::ANeuralNetworksCompilation(const ANeuralNetworksModel *model) noexcept
-    : _subgraphs{model->getSubGraphs()}, _tracing_ctx{std::make_unique<onert::util::TracingCtx>()},
+    : _subgraphs{model->getSubGraphs()},
+      _tracing_ctx{std::make_unique<onert::util::TracingCtx>(_subgraphs.get())},
       _compiler{new onert::compiler::Compiler{_subgraphs, _tracing_ctx.get()}}
 {
   if (model->allowedToFp16())
   {
     _compiler->enableToFp16();
   }
-
-  _tracing_ctx->setSubgraphIndices(_subgraphs.get());
 }
 
 bool ANeuralNetworksCompilation::finish() noexcept

--- a/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksCompilation.cc
+++ b/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksCompilation.cc
@@ -20,12 +20,15 @@
 
 // TODO Support multiple subgraphs
 ANeuralNetworksCompilation::ANeuralNetworksCompilation(const ANeuralNetworksModel *model) noexcept
-    : _subgraphs{model->getSubGraphs()}, _compiler{new onert::compiler::Compiler{_subgraphs}}
+    : _subgraphs{model->getSubGraphs()}, _tracing_ctx{std::make_unique<onert::util::TracingCtx>()},
+      _compiler{new onert::compiler::Compiler{_subgraphs, _tracing_ctx.get()}}
 {
   if (model->allowedToFp16())
   {
     _compiler->enableToFp16();
   }
+
+  _tracing_ctx->setSubgraphIndices(_subgraphs.get());
 }
 
 bool ANeuralNetworksCompilation::finish() noexcept

--- a/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksCompilation.h
+++ b/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksCompilation.h
@@ -23,6 +23,7 @@
 #include "ir/Graph.h"
 #include "ir/Subgraphs.h"
 #include "exec/IExecutor.h"
+#include "util/TracingCtx.h"
 
 struct ANeuralNetworksCompilation
 {
@@ -40,6 +41,14 @@ public:
 
 private:
   std::shared_ptr<onert::ir::Subgraphs> _subgraphs;
+  // TODO Refine the ownership of TracingCtx
+  // In case of nnfw API, nnfw_session has ownership of TracingCtx.
+  // In case of nnapi, there is no concept of session and primary model might have the ownership
+  // of TracingCtx.
+  // Since we don't support multiple models yet with nnapi in ONE, let's implement this later
+  // and let's make it work with one model for now.
+  std::unique_ptr<onert::util::TracingCtx> _tracing_ctx;
+
   std::shared_ptr<onert::compiler::Compiler> _compiler;
   std::shared_ptr<onert::exec::ExecutorMap> _executors;
 };

--- a/runtime/onert/test/core/exec/ExecInstance.cc
+++ b/runtime/onert/test/core/exec/ExecInstance.cc
@@ -21,6 +21,7 @@
 #include "compiler/Compiler.h"
 #include "exec/Execution.h"
 #include "ir/operation/BinaryArithmetic.h"
+#include "util/TracingCtx.h"
 
 namespace
 {
@@ -77,13 +78,15 @@ public:
     // Compile
     auto subgs = std::make_shared<onert::ir::Subgraphs>();
     subgs->push(onert::ir::SubgraphIndex{0}, graph);
-    onert::compiler::Compiler compiler{subgs};
+    tracing_ctx = std::make_unique<onert::util::TracingCtx>();
+    onert::compiler::Compiler compiler{subgs, tracing_ctx.get()};
     executors = compiler.compile();
   }
 
 public:
   std::shared_ptr<Graph> graph;
   std::shared_ptr<onert::exec::ExecutorMap> executors;
+  std::unique_ptr<onert::util::TracingCtx> tracing_ctx;
 };
 
 TEST(ExecInstance, simple)
@@ -137,7 +140,8 @@ TEST(ExecInstance, twoCompile)
   // Make new executor: compile again
   auto subgs = std::make_shared<onert::ir::Subgraphs>();
   subgs->push(onert::ir::SubgraphIndex{0}, graph);
-  onert::compiler::Compiler compiler{subgs};
+  auto tracing_ctx = std::make_unique<onert::util::TracingCtx>();
+  onert::compiler::Compiler compiler{subgs, tracing_ctx.get()};
   std::shared_ptr<onert::exec::ExecutorMap> executors2 = compiler.compile();
   onert::exec::Execution execution2{executors2};
 

--- a/runtime/onert/test/core/exec/ExecInstance.cc
+++ b/runtime/onert/test/core/exec/ExecInstance.cc
@@ -78,7 +78,7 @@ public:
     // Compile
     auto subgs = std::make_shared<onert::ir::Subgraphs>();
     subgs->push(onert::ir::SubgraphIndex{0}, graph);
-    tracing_ctx = std::make_unique<onert::util::TracingCtx>();
+    tracing_ctx = std::make_unique<onert::util::TracingCtx>(subgs.get());
     onert::compiler::Compiler compiler{subgs, tracing_ctx.get()};
     executors = compiler.compile();
   }
@@ -140,7 +140,7 @@ TEST(ExecInstance, twoCompile)
   // Make new executor: compile again
   auto subgs = std::make_shared<onert::ir::Subgraphs>();
   subgs->push(onert::ir::SubgraphIndex{0}, graph);
-  auto tracing_ctx = std::make_unique<onert::util::TracingCtx>();
+  auto tracing_ctx = std::make_unique<onert::util::TracingCtx>(subgs.get());
   onert::compiler::Compiler compiler{subgs, tracing_ctx.get()};
   std::shared_ptr<onert::exec::ExecutorMap> executors2 = compiler.compile();
   onert::exec::Execution execution2{executors2};


### PR DESCRIPTION
This passes `TracingCtx` to Compiler, which will be
passes to executors later.

Parent issue: #4901
Draft: #4903

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>