### PR TITLE
[bcq-tools] Fix typo in generate_bcq_output_arrays.py

### DIFF
--- a/compiler/bcq-tools/generate_bcq_output_arrays.py
+++ b/compiler/bcq-tools/generate_bcq_output_arrays.py
@@ -85,7 +85,7 @@ def get_bcqinfo_output_arrays_v1(input_path, output_arrays):
     ret_output_arrays = ['one_compiler/bcqinfo_one_metadata']
 
     # given node from user
-    ret_output_arrays.append += output_arrays.split(',')
+    ret_output_arrays += output_arrays.split(',')
 
     # all pairs of a constant node and related BCQ information nodes.
     for prefix in prefix_set:


### PR DESCRIPTION
This commit will fix a typo in `generate-bcq_output_arrays.py`

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>