### PR TITLE
[one-cmds] Fix wrong argument value

### DIFF
--- a/compiler/one-cmds/one-import-bcq
+++ b/compiler/one-cmds/one-import-bcq
@@ -44,13 +44,13 @@ def _get_parser():
         '--v1',
         action='store_const',
         dest='converter_version',
-        const='--v1',
+        const='v1',
         help='use TensorFlow Lite Converter 1.x')
     converter_version.add_argument(
         '--v2',
         action='store_const',
         dest='converter_version',
-        const='--v2',
+        const='v2',
         help='use TensorFlow Lite Converter 2.x')
 
     parser.add_argument('--converter_version', type=str, help=argparse.SUPPRESS)


### PR DESCRIPTION
This commit will fix wrong argument value.
If `converter_version` is used, `--` should be removed

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>