### PR TITLE
[one-cmds] Fix wrong arg and remove unnecessary comment

### DIFF
--- a/compiler/one-cmds/one-import-bcq
+++ b/compiler/one-cmds/one-import-bcq
@@ -43,13 +43,13 @@ def _get_parser():
     converter_version.add_argument(
         '--v1',
         action='store_const',
-        dest='converter_version',
+        dest='converter_version_cmd',
         const='--v1',
         help='use TensorFlow Lite Converter 1.x')
     converter_version.add_argument(
         '--v2',
         action='store_const',
-        dest='converter_version',
+        dest='converter_version_cmd',
         const='--v2',
         help='use TensorFlow Lite Converter 2.x')
 

--- a/compiler/one-cmds/one-import-tf
+++ b/compiler/one-cmds/one-import-tf
@@ -52,8 +52,6 @@ def _get_parser():
         const='--v2',
         help='use TensorFlow Lite Converter 2.x')
 
-    #converter_version.set_defaults(converter_version='--v1')
-
     parser.add_argument('--converter_version', type=str, help=argparse.SUPPRESS)
 
     # input model format


### PR DESCRIPTION
This commit fixes wrong arg and remove unnecessary comment in one-cmds.

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>