### PR TITLE
[luci] Revise ShapeSignatureInferenceHelper functions

### DIFF
--- a/compiler/luci/service/include/luci/Service/CircleShapeSignatureInferenceHelper.h
+++ b/compiler/luci/service/include/luci/Service/CircleShapeSignatureInferenceHelper.h
@@ -26,8 +26,16 @@ namespace luci
 namespace ssinf // Namespace for Shape Signature Inference
 {
 
+// Return empty signature if all of dimensions are known.
+// If one of dimensions is unknown, return signature without change.
+ShapeSignature clean_signature(const luci::ShapeSignature &signature);
+
+// Return reduced input_signature with indices and keep_dims.
+//  - indices : reduction index
+//  - keep_dims : If true, rank is not changed. If false, rank is reduced along indices.
 ShapeSignature reduced_signature(const loco::Node *node, const loco::Node *indices, bool keep_dims);
 
+// Return signature of index-th argument of node.
 ShapeSignature input_arg_signature(const luci::CircleNode *node, uint32_t index);
 
 } // namespace ssinf

--- a/compiler/luci/service/include/luci/Service/CircleShapeSignatureInferenceHelper.h
+++ b/compiler/luci/service/include/luci/Service/CircleShapeSignatureInferenceHelper.h
@@ -27,8 +27,8 @@ namespace ssinf // Namespace for Shape Signature Inference
 {
 
 // Return empty signature if all of dimensions are known.
-// If one of dimensions is unknown, return signature without change.
-ShapeSignature clean_signature(const luci::ShapeSignature &signature);
+// If at least one of dimensions is unknown, return signature without change.
+ShapeSignature legalized_signature(const luci::ShapeSignature &signature);
 
 // Return reduced input_signature with indices and keep_dims.
 //  - indices : reduction index

--- a/compiler/luci/service/src/CircleShapeSignatureInferenceHelper.cpp
+++ b/compiler/luci/service/src/CircleShapeSignatureInferenceHelper.cpp
@@ -22,7 +22,10 @@
 
 #include <oops/InternalExn.h>
 
-namespace
+namespace luci
+{
+
+namespace ssinf
 {
 
 luci::ShapeSignature clean_signature(const luci::ShapeSignature &signature)
@@ -35,14 +38,6 @@ luci::ShapeSignature clean_signature(const luci::ShapeSignature &signature)
   // If all dimensions are static, return empty shape signature.
   return luci::ShapeSignature();
 }
-
-} // namespace
-
-namespace luci
-{
-
-namespace ssinf
-{
 
 ShapeSignature reduced_signature(const loco::Node *node, const loco::Node *indices, bool keep_dims)
 {

--- a/compiler/luci/service/src/CircleShapeSignatureInferenceHelper.cpp
+++ b/compiler/luci/service/src/CircleShapeSignatureInferenceHelper.cpp
@@ -28,7 +28,7 @@ namespace luci
 namespace ssinf
 {
 
-luci::ShapeSignature clean_signature(const luci::ShapeSignature &signature)
+luci::ShapeSignature legalized_signature(const luci::ShapeSignature &signature)
 {
   // If shape signature has at least one -1, it is not static.
   for (uint32_t i = 0; i < signature.rank(); ++i)
@@ -146,7 +146,7 @@ ShapeSignature reduced_signature(const loco::Node *node, const loco::Node *indic
         output_signature.dim(j++) = input_signature.dim(i);
   }
 
-  return clean_signature(output_signature);
+  return output_signature;
 }
 
 ShapeSignature input_arg_signature(const luci::CircleNode *node, uint32_t index)

--- a/compiler/luci/service/src/Nodes/CircleMean.cpp
+++ b/compiler/luci/service/src/Nodes/CircleMean.cpp
@@ -21,7 +21,7 @@ namespace luci
 
 ShapeSignature ssinf::Algorithm::visit(const luci::CircleMean *node)
 {
-  return clean_signature(
+  return legalized_signature(
       reduced_signature(node->input(), node->reduction_indices(), node->keep_dims()));
 }
 

--- a/compiler/luci/service/src/Nodes/CircleMean.cpp
+++ b/compiler/luci/service/src/Nodes/CircleMean.cpp
@@ -21,7 +21,8 @@ namespace luci
 
 ShapeSignature ssinf::Algorithm::visit(const luci::CircleMean *node)
 {
-  return reduced_signature(node->input(), node->reduction_indices(), node->keep_dims());
+  return clean_signature(
+      reduced_signature(node->input(), node->reduction_indices(), node->keep_dims()));
 }
 
 } // namespace luci

--- a/compiler/luci/service/src/Nodes/CircleReduceAny.cpp
+++ b/compiler/luci/service/src/Nodes/CircleReduceAny.cpp
@@ -21,7 +21,8 @@ namespace luci
 
 ShapeSignature ssinf::Algorithm::visit(const luci::CircleReduceAny *node)
 {
-  return reduced_signature(node->input(), node->reduction_indices(), node->keep_dims());
+  return clean_signature(
+      reduced_signature(node->input(), node->reduction_indices(), node->keep_dims()));
 }
 
 } // namespace luci

--- a/compiler/luci/service/src/Nodes/CircleReduceAny.cpp
+++ b/compiler/luci/service/src/Nodes/CircleReduceAny.cpp
@@ -21,7 +21,7 @@ namespace luci
 
 ShapeSignature ssinf::Algorithm::visit(const luci::CircleReduceAny *node)
 {
-  return clean_signature(
+  return legalized_signature(
       reduced_signature(node->input(), node->reduction_indices(), node->keep_dims()));
 }
 

--- a/compiler/luci/service/src/Nodes/CircleReduceMax.cpp
+++ b/compiler/luci/service/src/Nodes/CircleReduceMax.cpp
@@ -21,7 +21,8 @@ namespace luci
 
 ShapeSignature ssinf::Algorithm::visit(const luci::CircleReduceMax *node)
 {
-  return reduced_signature(node->input(), node->reduction_indices(), node->keep_dims());
+  return clean_signature(
+      reduced_signature(node->input(), node->reduction_indices(), node->keep_dims()));
 }
 
 } // namespace luci

--- a/compiler/luci/service/src/Nodes/CircleReduceMax.cpp
+++ b/compiler/luci/service/src/Nodes/CircleReduceMax.cpp
@@ -21,7 +21,7 @@ namespace luci
 
 ShapeSignature ssinf::Algorithm::visit(const luci::CircleReduceMax *node)
 {
-  return clean_signature(
+  return legalized_signature(
       reduced_signature(node->input(), node->reduction_indices(), node->keep_dims()));
 }
 

--- a/compiler/luci/service/src/Nodes/CircleReduceMin.cpp
+++ b/compiler/luci/service/src/Nodes/CircleReduceMin.cpp
@@ -21,7 +21,7 @@ namespace luci
 
 ShapeSignature ssinf::Algorithm::visit(const luci::CircleReduceMin *node)
 {
-  return clean_signature(
+  return legalized_signature(
       reduced_signature(node->input(), node->reduction_indices(), node->keep_dims()));
 }
 

--- a/compiler/luci/service/src/Nodes/CircleReduceMin.cpp
+++ b/compiler/luci/service/src/Nodes/CircleReduceMin.cpp
@@ -21,7 +21,8 @@ namespace luci
 
 ShapeSignature ssinf::Algorithm::visit(const luci::CircleReduceMin *node)
 {
-  return reduced_signature(node->input(), node->reduction_indices(), node->keep_dims());
+  return clean_signature(
+      reduced_signature(node->input(), node->reduction_indices(), node->keep_dims()));
 }
 
 } // namespace luci

--- a/compiler/luci/service/src/Nodes/CircleReduceProd.cpp
+++ b/compiler/luci/service/src/Nodes/CircleReduceProd.cpp
@@ -21,7 +21,7 @@ namespace luci
 
 ShapeSignature ssinf::Algorithm::visit(const luci::CircleReduceProd *node)
 {
-  return clean_signature(
+  return legalized_signature(
       reduced_signature(node->input(), node->reduction_indices(), node->keep_dims()));
 }
 

--- a/compiler/luci/service/src/Nodes/CircleReduceProd.cpp
+++ b/compiler/luci/service/src/Nodes/CircleReduceProd.cpp
@@ -21,7 +21,8 @@ namespace luci
 
 ShapeSignature ssinf::Algorithm::visit(const luci::CircleReduceProd *node)
 {
-  return reduced_signature(node->input(), node->reduction_indices(), node->keep_dims());
+  return clean_signature(
+      reduced_signature(node->input(), node->reduction_indices(), node->keep_dims()));
 }
 
 } // namespace luci

--- a/compiler/luci/service/src/Nodes/CircleSum.cpp
+++ b/compiler/luci/service/src/Nodes/CircleSum.cpp
@@ -21,7 +21,7 @@ namespace luci
 
 ShapeSignature ssinf::Algorithm::visit(const luci::CircleSum *node)
 {
-  return clean_signature(
+  return legalized_signature(
       reduced_signature(node->input(), node->reduction_indices(), node->keep_dims()));
 }
 

--- a/compiler/luci/service/src/Nodes/CircleSum.cpp
+++ b/compiler/luci/service/src/Nodes/CircleSum.cpp
@@ -21,7 +21,8 @@ namespace luci
 
 ShapeSignature ssinf::Algorithm::visit(const luci::CircleSum *node)
 {
-  return reduced_signature(node->input(), node->reduction_indices(), node->keep_dims());
+  return clean_signature(
+      reduced_signature(node->input(), node->reduction_indices(), node->keep_dims()));
 }
 
 } // namespace luci


### PR DESCRIPTION
Parent Issue : #4796

This commit will revise following things

- Move `clean_signature` to `namespace luci`
  - It would be better to make it re-usable
- Revise `reduced_signature` to return redundant signature
  - Core logic can be shared by `ShapeInference`
  - Then code duplication would be reduced
- Add more comments for detailed description

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>