### PR TITLE
[onert] Make getter method be const

### DIFF
--- a/runtime/onert/core/include/backend/BackendContext.h
+++ b/runtime/onert/core/include/backend/BackendContext.h
@@ -64,8 +64,8 @@ public:
 
   const Backend *backend() const { return _backend; }
   const ir::Graph *graph() const { return _graph; }
-  const std::vector<OperationInfo> &operation_list() { return _operation_list; }
-  const std::vector<ir::OperandIndex> &operand_list() { return _operand_list; }
+  const std::vector<OperationInfo> &operation_list() const { return _operation_list; }
+  const std::vector<ir::OperandIndex> &operand_list() const { return _operand_list; }
 
 private:
   const Backend *_backend{nullptr};


### PR DESCRIPTION
Make `operation_list` and `operand_list` be const.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>