### PR TITLE
[luci] Enable MigrateLegacyShapeDtypePass in luci

### DIFF
--- a/compiler/luci/pass/src/CircleOptimizer.cpp
+++ b/compiler/luci/pass/src/CircleOptimizer.cpp
@@ -42,6 +42,9 @@
 #include "luci/Pass/ShapeSignatureInferencePass.h"
 #include "luci/Pass/TypeInferencePass.h"
 
+// Following passes will be removed after refactoring is finished
+#include "luci/Pass/MigrateLegacyShapeDtypePass.h"
+
 // logo passes
 #include <logo/RemoveDeadNodeWithQueryPass.h>
 
@@ -135,6 +138,9 @@ void CircleOptimizer::optimize(luci::Module *m) const
 {
   luci::Phase phase;
 
+  // Following passes will be deprecated after refactoring is finished.
+  phase.emplace_back(std::make_unique<luci::MigrateLegacyShapeDtypePass>());
+
   // Following passes are needed everytime when other passes create new node or modify some nodes.
   phase.emplace_back(std::make_unique<luci::ShapeInferencePass>());
   phase.emplace_back(std::make_unique<luci::ShapeSignatureInferencePass>());
@@ -157,6 +163,9 @@ void CircleOptimizer::optimize(loco::Graph *g) const
 
   /* TRANSFORM DECLARATION BEGIN */
   phase.emplace_back(std::make_unique<logo::RemoveDeadNodeWithQueryPass>());
+
+  // Following passes will be deprecated after refactoring is finished.
+  phase.emplace_back(std::make_unique<luci::MigrateLegacyShapeDtypePass>());
 
   // Following passes are needed everytime when other passes create new node or modify some nodes.
   phase.emplace_back(std::make_unique<luci::TypeInferencePass>());

--- a/compiler/luci/tester/src/ReadTester.cpp
+++ b/compiler/luci/tester/src/ReadTester.cpp
@@ -21,6 +21,9 @@
 #include <luci/Pass/ShapeInferencePass.h>
 #include <luci/Pass/TypeInferencePass.h>
 
+// Following passes will be removed after refactoring is finished
+#include <luci/Pass/MigrateLegacyShapeDtypePass.h>
+
 #include <iostream>
 #include <map>
 #include <string>
@@ -92,6 +95,12 @@ int entry(int argc, char **argv)
     }
     {
       luci::TypeInferencePass pass;
+      while (pass.run(graph) == true)
+        ;
+    }
+    {
+      // This pass will be removed after refactoring is finished
+      luci::MigrateLegacyShapeDtypePass pass;
       while (pass.run(graph) == true)
         ;
     }

--- a/compiler/luci/tester/src/WriteTester.cpp
+++ b/compiler/luci/tester/src/WriteTester.cpp
@@ -23,6 +23,9 @@
 #include <luci/CircleExporter.h>
 #include <oops/InternalExn.h>
 
+// Following passes will be removed after refactoring is finished
+#include <luci/Pass/MigrateLegacyShapeDtypePass.h>
+
 #include <fstream>
 #include <iostream>
 #include <map>
@@ -136,6 +139,12 @@ int entry(int argc, char **argv)
     }
     {
       luci::TypeInferencePass pass;
+      while (pass.run(graph) == true)
+        ;
+    }
+    {
+      // This pass will be removed after refactoring is finished
+      luci::MigrateLegacyShapeDtypePass pass;
       while (pass.run(graph) == true)
         ;
     }


### PR DESCRIPTION
Parent Issue : #4796

This commit will enable `MigrateLegacyShapeDtypePass` in `luci`.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>