### PR TITLE
[luci] Disable copying shape and dtype when export

### DIFF
--- a/compiler/luci/export/src/CircleExporterImpl.cpp
+++ b/compiler/luci/export/src/CircleExporterImpl.cpp
@@ -16,7 +16,6 @@
 
 #include "CircleExporterImpl.h"
 #include "Optimize.h"
-#include "TypeBridge.h"
 #include "CircleTensorExporter.h"
 #include "CircleOperationExporter.h"
 #include "CircleExporterUtils.h"
@@ -150,9 +149,6 @@ void CircleExporterImpl::exportGraph(loco::Graph *graph)
   // do graph optimization
   optimize(graph);
 
-  // copy shape/dtype inference data to CircleNode
-  copy_shape_dtype(graph);
-
   _builder.Clear();
 
   SerializedModelData md;
@@ -222,9 +218,6 @@ void CircleExporterImpl::exportModule(Module *module)
     auto graph = module->graph(g);
 
     optimize(graph);
-
-    // copy shape/dtype inference data to CircleNode
-    copy_shape_dtype(graph);
 
     SerializedGraphData gd;
 


### PR DESCRIPTION
Parent Issue : #4796

As `MigrateLegacyShapeDtypePass` is enabled, copying dtype and shape in `luci/export` is not needed.
This commit will remove it.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>