### PR TITLE
[onert] Pass TracingCtx to Executors and EventObserver

### DIFF
--- a/runtime/onert/core/src/exec/DataflowExecutor.cc
+++ b/runtime/onert/core/src/exec/DataflowExecutor.cc
@@ -79,8 +79,10 @@ bool DataflowExecutor::noWaitingJobs()
 
 DataflowExecutor::DataflowExecutor(std::unique_ptr<compiler::LoweredGraph> lowered_graph,
                                    const compiler::TensorRegistries &tensor_regs,
-                                   compiler::CodeMap &&code_map)
-    : ExecutorBase{std::move(lowered_graph), tensor_regs}, _code_map{std::move(code_map)}
+                                   compiler::CodeMap &&code_map,
+                                   const util::TracingCtx *tracing_ctx)
+    : ExecutorBase{std::move(lowered_graph), tensor_regs, tracing_ctx},
+      _code_map{std::move(code_map)}
 {
   VERBOSE(DataflowExecutor) << "Constructing Dataflow Executor" << std::endl;
 

--- a/runtime/onert/core/src/exec/DataflowExecutor.h
+++ b/runtime/onert/core/src/exec/DataflowExecutor.h
@@ -28,6 +28,7 @@
 #include <memory>
 #include "exec/ExecutorBase.h"
 #include "compiler/CodeMap.h"
+#include "util/TracingCtx.h"
 
 namespace onert
 {
@@ -50,7 +51,8 @@ public:
    * @param code_map OpSequence and its code map
    */
   DataflowExecutor(std::unique_ptr<compiler::LoweredGraph> lowered_graph,
-                   const compiler::TensorRegistries &tensor_regs, compiler::CodeMap &&code_map);
+                   const compiler::TensorRegistries &tensor_regs, compiler::CodeMap &&code_map,
+                   const util::TracingCtx *tracing_ctx);
 
   void executeImpl() override;
 

--- a/runtime/onert/core/src/exec/ExecutionObservers.cc
+++ b/runtime/onert/core/src/exec/ExecutionObservers.cc
@@ -119,8 +119,10 @@ void ProfileObserver::handleJobEnd(IExecutor *exec, const ir::OpSequence *op_seq
   }
 };
 
-TracingObserver::TracingObserver(const std::string &filepath, const ir::Graph &graph)
-    : _base_filepath(filepath), _recorder{}, _collector{&_recorder}, _graph{graph}
+TracingObserver::TracingObserver(const std::string &filepath, const ir::Graph &graph,
+                                 const util::TracingCtx *tracing_ctx)
+    : _base_filepath(filepath), _recorder{}, _collector{&_recorder}, _graph{graph},
+      _tracing_ctx{tracing_ctx}
 {
 }
 

--- a/runtime/onert/core/src/exec/ExecutionObservers.cc
+++ b/runtime/onert/core/src/exec/ExecutionObservers.cc
@@ -24,6 +24,7 @@
 #include "misc/polymorphic_downcast.h"
 #include "ir/OpSequence.h"
 #include "util/EventWriter.h"
+#include "util/Utils.h"
 
 namespace
 {
@@ -124,6 +125,8 @@ TracingObserver::TracingObserver(const std::string &filepath, const ir::Graph &g
     : _base_filepath(filepath), _recorder{}, _collector{&_recorder}, _graph{graph},
       _tracing_ctx{tracing_ctx}
 {
+  // TODO Remove below after using _tracing_ctx
+  UNUSED_RELEASE(_tracing_ctx);
 }
 
 TracingObserver::~TracingObserver()

--- a/runtime/onert/core/src/exec/ExecutionObservers.h
+++ b/runtime/onert/core/src/exec/ExecutionObservers.h
@@ -24,6 +24,7 @@
 #include "exec/IExecutor.h"
 #include "util/EventCollector.h"
 #include "util/EventRecorder.h"
+#include "util/TracingCtx.h"
 
 namespace onert
 {
@@ -65,7 +66,8 @@ private:
 class TracingObserver : public IExecutionObserver
 {
 public:
-  TracingObserver(const std::string &filepath, const ir::Graph &graph);
+  TracingObserver(const std::string &filepath, const ir::Graph &graph,
+                  const util::TracingCtx *tracing_ctx);
   ~TracingObserver();
   void handleSubgraphBegin(IExecutor *) override;
   void handleJobBegin(IExecutor *, const ir::OpSequence *, const backend::Backend *) override;
@@ -80,6 +82,7 @@ private:
   EventRecorder _recorder;
   EventCollector _collector;
   const ir::Graph &_graph;
+  const util::TracingCtx *_tracing_ctx;
 };
 
 } // namespace exec

--- a/runtime/onert/core/src/exec/ExecutorBase.cc
+++ b/runtime/onert/core/src/exec/ExecutorBase.cc
@@ -27,8 +27,10 @@ namespace exec
 {
 
 ExecutorBase::ExecutorBase(std::unique_ptr<compiler::LoweredGraph> &&lowered_graph,
-                           const compiler::TensorRegistries &tensor_regs)
-    : _lowered_graph{std::move(lowered_graph)}, _graph{_lowered_graph->graph()}, _mutex()
+                           const compiler::TensorRegistries &tensor_regs,
+                           const util::TracingCtx *tracing_ctx)
+    : _lowered_graph{std::move(lowered_graph)}, _graph{_lowered_graph->graph()}, _mutex(),
+      _tracing_ctx(tracing_ctx)
 {
   auto build_tensor_list = [&](const auto &ind_seq, auto &tensors) {
     assert(tensors.empty());

--- a/runtime/onert/core/src/exec/ExecutorBase.h
+++ b/runtime/onert/core/src/exec/ExecutorBase.h
@@ -30,6 +30,7 @@
 #include "compiler/LoweredGraph.h"
 #include "compiler/TensorRegistries.h"
 #include "backend/controlflow/IOTensor.h"
+#include "util/TracingCtx.h"
 
 #include <cstdint>
 #include <memory>
@@ -50,7 +51,7 @@ public:
    * @param tensor_builders Tensor builders that are currently used
    */
   ExecutorBase(std::unique_ptr<compiler::LoweredGraph> &&lowered_graph,
-               const compiler::TensorRegistries &tensor_regs);
+               const compiler::TensorRegistries &tensor_regs, const util::TracingCtx *tracing_ctx);
 
   virtual ~ExecutorBase() = default;
 
@@ -90,6 +91,7 @@ protected:
   std::vector<backend::controlflow::IOTensor *> _input_tensors;
   std::vector<backend::controlflow::IOTensor *> _output_tensors;
   std::mutex _mutex;
+  const util::TracingCtx *_tracing_ctx;
 
 private:
   void handleDynamicInputTensor(ir::IOIndex input_index, const IODescription &desc);

--- a/runtime/onert/core/src/exec/LinearExecutor.h
+++ b/runtime/onert/core/src/exec/LinearExecutor.h
@@ -27,6 +27,7 @@
 #include "compiler/Linear.h"
 #include "exec/FunctionSequence.h"
 #include "compiler/CodeMap.h"
+#include "util/TracingCtx.h"
 
 namespace onert
 {
@@ -48,8 +49,8 @@ public:
    */
   LinearExecutor(std::unique_ptr<compiler::LoweredGraph> lowered_graph,
                  const compiler::TensorRegistries &tensor_regs, compiler::CodeMap &&code_map,
-                 const std::vector<ir::OpSequenceIndex> &order)
-      : ExecutorBase{std::move(lowered_graph), tensor_regs}
+                 const std::vector<ir::OpSequenceIndex> &order, const util::TracingCtx *tracing_ctx)
+      : ExecutorBase{std::move(lowered_graph), tensor_regs, tracing_ctx}
   {
     for (auto index : order)
     {

--- a/runtime/onert/core/src/exec/ParallelExecutor.cc
+++ b/runtime/onert/core/src/exec/ParallelExecutor.cc
@@ -61,8 +61,9 @@ void ParallelExecutor::notify(uint32_t finished_job_id)
 
 ParallelExecutor::ParallelExecutor(std::unique_ptr<compiler::LoweredGraph> lowered_graph,
                                    const compiler::TensorRegistries &tensor_regs,
-                                   compiler::CodeMap &&code_map)
-    : DataflowExecutor{std::move(lowered_graph), tensor_regs, std::move(code_map)}
+                                   compiler::CodeMap &&code_map,
+                                   const util::TracingCtx *tracing_ctx)
+    : DataflowExecutor{std::move(lowered_graph), tensor_regs, std::move(code_map), tracing_ctx}
 {
   VERBOSE(ParallelExecutor) << "Constructing Parallel Executor" << std::endl;
 }

--- a/runtime/onert/core/src/exec/ParallelExecutor.h
+++ b/runtime/onert/core/src/exec/ParallelExecutor.h
@@ -28,6 +28,7 @@
 #include <memory>
 #include "exec/DataflowExecutor.h"
 #include "ParallelScheduler.h"
+#include "util/TracingCtx.h"
 
 namespace onert
 {
@@ -51,7 +52,8 @@ public:
    * @param code_map OpSequence and its code map
    */
   ParallelExecutor(std::unique_ptr<compiler::LoweredGraph> lowered_graph,
-                   const compiler::TensorRegistries &tensor_regs, compiler::CodeMap &&code_map);
+                   const compiler::TensorRegistries &tensor_regs, compiler::CodeMap &&code_map,
+                   const util::TracingCtx *tracing_ctx);
 
   void executeImpl() override;
 

--- a/runtime/onert/core/src/util/EventCollector.h
+++ b/runtime/onert/core/src/util/EventCollector.h
@@ -35,7 +35,14 @@ public:
   struct Event
   {
     Edge edge;
+    uint32_t session_index;
+    uint32_t subg_index;
     std::string backend;
+    uint32_t op_index;
+    std::string op_name;
+    uint32_t op_seq_size; // if this event is for an operation sequence of multiple operations
+
+    // TODO deprecate this. label can be differ by writer. So let the writer decide label.
     std::string label;
 
     // user-defined data: pairs of (key, value)


### PR DESCRIPTION
Pass `TracingCtx` to `Executor`s and `EventObserver` to be used later for storing profiling information.

Parent issue: #4901
Draft: #4903

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>