### PR TITLE
[onert] Remove IKernelGenerator and IConstantInit

### DIFF
--- a/runtime/onert/backend/acl_cl/BackendContext.cc
+++ b/runtime/onert/backend/acl_cl/BackendContext.cc
@@ -31,6 +31,26 @@ namespace backend
 namespace acl_cl
 {
 
+void BackendContext::initConsts()
+{
+  for (auto &op : operation_list())
+  {
+    constant_initializer->setLayout(op.layout);
+    graph()->operations().at(op.index).accept(*constant_initializer);
+  }
+
+  for (auto ind : operand_list())
+  {
+    const auto &obj = graph()->operands().at(ind);
+    if (obj.isConstant() && !constant_initializer->exist(ind))
+    {
+      constant_initializer->registerDefaultInitializer(ind, obj);
+    }
+  }
+
+  constant_initializer->run();
+}
+
 void BackendContext::planTensors(const std::vector<onert::ir::OpSequenceIndex> &order,
                                  const ir::OpSequences &op_seqs, const ir::LowerInfoMap &lower_info)
 {

--- a/runtime/onert/backend/acl_cl/BackendContext.h
+++ b/runtime/onert/backend/acl_cl/BackendContext.h
@@ -19,6 +19,8 @@
 
 #include <backend/BackendContext.h>
 #include "TensorBuilder.h"
+#include "ConstantInitializer.h"
+#include "KernelGenerator.h"
 
 namespace onert
 {
@@ -35,11 +37,11 @@ public:
   BackendContext(const Backend *backend, const ir::Graph *graph,
                  std::shared_ptr<ITensorRegistry> tensor_registry = nullptr,
                  std::shared_ptr<TensorBuilder> tensor_builder = nullptr,
-                 std::shared_ptr<IConstantInitializer> constant_initializer = nullptr,
-                 std::shared_ptr<IKernelGenerator> kernel_gen = nullptr)
-      : onert::backend::BackendContext(backend, graph, tensor_registry, constant_initializer,
-                                       kernel_gen),
-        tensor_builder{tensor_builder}
+                 std::shared_ptr<ConstantInitializer> constant_initializer = nullptr,
+                 std::shared_ptr<KernelGenerator> kernel_gen = nullptr)
+      : onert::backend::BackendContext(backend, graph, tensor_registry),
+        tensor_builder{tensor_builder}, constant_initializer{constant_initializer},
+        kernel_gen{kernel_gen}
   {
   }
 
@@ -50,11 +52,14 @@ public:
                          const ir::OpSequences &op_seqs) override;
 
 private:
+  void initConsts();
   void planTensors(const std::vector<onert::ir::OpSequenceIndex> &order,
                    const ir::OpSequences &op_seqs, const ir::LowerInfoMap &lower_info);
 
 public:
   std::shared_ptr<TensorBuilder> tensor_builder;
+  std::shared_ptr<ConstantInitializer> constant_initializer;
+  std::shared_ptr<KernelGenerator> kernel_gen;
   std::shared_ptr<Optimizer> optimizer;
 };
 

--- a/runtime/onert/backend/acl_cl/KernelGenerator.h
+++ b/runtime/onert/backend/acl_cl/KernelGenerator.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_ACL_CL_KERNEL_GENERATOR_H__
 #define __ONERT_BACKEND_ACL_CL_KERNEL_GENERATOR_H__
 
-#include <backend/IKernelGenerator.h>
+#include <backend/cpu_common/KernelGeneratorBase.h>
 
 #include "ir/Operands.h"
 #include "TensorBuilder.h"
@@ -31,7 +31,7 @@ namespace backend
 namespace acl_cl
 {
 
-class KernelGenerator : public IKernelGenerator
+class KernelGenerator : public cpu_common::KernelGeneratorBase
 {
 public:
   KernelGenerator(const ir::Operands &operands_ctx, const ir::Operations &operations_ctx,

--- a/runtime/onert/backend/acl_common/AclConstantInitializer.cc
+++ b/runtime/onert/backend/acl_common/AclConstantInitializer.cc
@@ -25,7 +25,7 @@ namespace acl_common
 
 AclConstantInitializer::AclConstantInitializer(const ir::Operands &operands,
                                                const std::shared_ptr<ITensorRegistry> &tensor_reg)
-    : IConstantInitializer{operands}, _tensor_reg{tensor_reg}
+    : cpu_common::ConstantInitializerBase{operands}, _tensor_reg{tensor_reg}
 {
   // DO NOTHING
 }

--- a/runtime/onert/backend/acl_common/AclConstantInitializer.h
+++ b/runtime/onert/backend/acl_common/AclConstantInitializer.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_COMPILER_ACL_COMMON_ACLCONSTANT_INITIALIZER_H__
 #define __ONERT_COMPILER_ACL_COMMON_ACLCONSTANT_INITIALIZER_H__
 
-#include <backend/IConstantInitializer.h>
+#include <backend/cpu_common/ConstantInitializerBase.h>
 #include <ir/Operands.h>
 #include "AclTensorRegistry.h"
 
@@ -28,7 +28,7 @@ namespace backend
 namespace acl_common
 {
 
-class AclConstantInitializer : public IConstantInitializer
+class AclConstantInitializer : public cpu_common::ConstantInitializerBase
 {
 public:
   AclConstantInitializer(const ir::Operands &operands,

--- a/runtime/onert/backend/acl_neon/BackendContext.cc
+++ b/runtime/onert/backend/acl_neon/BackendContext.cc
@@ -31,6 +31,26 @@ namespace backend
 namespace acl_neon
 {
 
+void BackendContext::initConsts()
+{
+  for (auto &op : operation_list())
+  {
+    constant_initializer->setLayout(op.layout);
+    graph()->operations().at(op.index).accept(*constant_initializer);
+  }
+
+  for (auto ind : operand_list())
+  {
+    const auto &obj = graph()->operands().at(ind);
+    if (obj.isConstant() && !constant_initializer->exist(ind))
+    {
+      constant_initializer->registerDefaultInitializer(ind, obj);
+    }
+  }
+
+  constant_initializer->run();
+}
+
 void BackendContext::planTensors(const std::vector<onert::ir::OpSequenceIndex> &order,
                                  const ir::OpSequences &op_seqs, const ir::LowerInfoMap &lower_info)
 {

--- a/runtime/onert/backend/acl_neon/BackendContext.h
+++ b/runtime/onert/backend/acl_neon/BackendContext.h
@@ -37,11 +37,11 @@ public:
   BackendContext(const Backend *backend, const ir::Graph *graph,
                  std::shared_ptr<ITensorRegistry> tensor_registry = nullptr,
                  std::shared_ptr<TensorBuilder> tensor_builder = nullptr,
-                 std::shared_ptr<IConstantInitializer> constant_initializer = nullptr,
-                 std::shared_ptr<IKernelGenerator> kernel_gen = nullptr)
-      : onert::backend::BackendContext(backend, graph, tensor_registry, constant_initializer,
-                                       kernel_gen),
-        tensor_builder{tensor_builder}
+                 std::shared_ptr<ConstantInitializer> constant_initializer = nullptr,
+                 std::shared_ptr<KernelGenerator> kernel_gen = nullptr)
+      : onert::backend::BackendContext(backend, graph, tensor_registry),
+        tensor_builder{tensor_builder}, constant_initializer{constant_initializer},
+        kernel_gen{kernel_gen}
   {
   }
 
@@ -52,11 +52,15 @@ public:
                          const ir::OpSequences &op_seqs) override;
 
 private:
+  void initConsts();
   void planTensors(const std::vector<onert::ir::OpSequenceIndex> &order,
                    const ir::OpSequences &op_seqs, const ir::LowerInfoMap &lower_info);
 
 public:
+  // TODO Make it private
   std::shared_ptr<TensorBuilder> tensor_builder;
+  std::shared_ptr<ConstantInitializer> constant_initializer;
+  std::shared_ptr<KernelGenerator> kernel_gen;
   std::shared_ptr<Optimizer> optimizer;
 };
 

--- a/runtime/onert/backend/acl_neon/KernelGenerator.h
+++ b/runtime/onert/backend/acl_neon/KernelGenerator.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_ACL_NEON_KERNEL_GENERATOR_H__
 #define __ONERT_BACKEND_ACL_NEON_KERNEL_GENERATOR_H__
 
-#include <backend/IKernelGenerator.h>
+#include <backend/cpu_common/KernelGeneratorBase.h>
 
 #include "ir/Operands.h"
 #include "TensorBuilder.h"
@@ -31,7 +31,7 @@ namespace backend
 namespace acl_neon
 {
 
-class KernelGenerator : public IKernelGenerator
+class KernelGenerator : public cpu_common::KernelGeneratorBase
 {
 public:
   KernelGenerator(const ir::Operands &operands_ctx, const ir::Operations &operations_ctx,

--- a/runtime/onert/backend/cpu/BackendContext.cc
+++ b/runtime/onert/backend/cpu/BackendContext.cc
@@ -31,6 +31,26 @@ namespace backend
 namespace cpu
 {
 
+void BackendContext::initConsts()
+{
+  for (auto &op : operation_list())
+  {
+    constant_initializer->setLayout(op.layout);
+    graph()->operations().at(op.index).accept(*constant_initializer);
+  }
+
+  for (auto ind : operand_list())
+  {
+    const auto &obj = graph()->operands().at(ind);
+    if (obj.isConstant() && !constant_initializer->exist(ind))
+    {
+      constant_initializer->registerDefaultInitializer(ind, obj);
+    }
+  }
+
+  constant_initializer->run();
+}
+
 ITensorRegistry *BackendContext::genTensors(const std::vector<onert::ir::OpSequenceIndex> &order,
                                             const ir::OpSequences &op_seqs,
                                             const ir::LowerInfoMap &lower_info)

--- a/runtime/onert/backend/cpu/BackendContext.h
+++ b/runtime/onert/backend/cpu/BackendContext.h
@@ -19,6 +19,8 @@
 
 #include <backend/BackendContext.h>
 #include "TensorBuilder.h"
+#include "ConstantInitializer.h"
+#include "KernelGenerator.h"
 #include "ExternalContext.h"
 
 namespace onert
@@ -34,11 +36,11 @@ public:
   BackendContext(const Backend *backend, const ir::Graph *graph,
                  std::shared_ptr<ITensorRegistry> tensor_registry = nullptr,
                  std::shared_ptr<TensorBuilder> tensor_builder = nullptr,
-                 std::shared_ptr<IConstantInitializer> constant_initializer = nullptr,
-                 std::shared_ptr<IKernelGenerator> kernel_gen = nullptr)
-      : onert::backend::BackendContext(backend, graph, tensor_registry, constant_initializer,
-                                       kernel_gen),
-        tensor_builder{tensor_builder}, _external_context(new ExternalContext)
+                 std::shared_ptr<ConstantInitializer> constant_initializer = nullptr,
+                 std::shared_ptr<KernelGenerator> kernel_gen = nullptr)
+      : onert::backend::BackendContext(backend, graph, tensor_registry),
+        tensor_builder{tensor_builder}, constant_initializer{constant_initializer},
+        kernel_gen{kernel_gen}, _external_context(new ExternalContext)
   {
   }
 
@@ -51,12 +53,15 @@ public:
   std::shared_ptr<ExternalContext> external_context() { return _external_context; }
 
 private:
+  void initConsts();
   void planTensors(const std::vector<onert::ir::OpSequenceIndex> &order,
                    const ir::OpSequences &op_seqs, const ir::LowerInfoMap &lower_info);
 
 public:
   // TODO Make it private
   std::shared_ptr<TensorBuilder> tensor_builder;
+  std::shared_ptr<ConstantInitializer> constant_initializer;
+  std::shared_ptr<KernelGenerator> kernel_gen;
 
 private:
   // NOTE ruy context has a thread pool, and when multiple ruy contexts are created,

--- a/runtime/onert/backend/cpu/ConstantInitializer.cc
+++ b/runtime/onert/backend/cpu/ConstantInitializer.cc
@@ -26,7 +26,7 @@ namespace cpu
 
 ConstantInitializer::ConstantInitializer(const ir::Operands &operands,
                                          const std::shared_ptr<ITensorRegistry> &tensor_reg)
-    : IConstantInitializer{operands}, _tensor_reg{tensor_reg}
+    : cpu_common::ConstantInitializerBase{operands}, _tensor_reg{tensor_reg}
 {
   // DO NOTHING
 }

--- a/runtime/onert/backend/cpu/ConstantInitializer.h
+++ b/runtime/onert/backend/cpu/ConstantInitializer.h
@@ -19,7 +19,7 @@
 
 #include "backend/cpu_common/TensorRegistry.h"
 
-#include <backend/IConstantInitializer.h>
+#include <backend/cpu_common/ConstantInitializerBase.h>
 #include <ir/Operands.h>
 
 namespace onert
@@ -29,7 +29,7 @@ namespace backend
 namespace cpu
 {
 
-class ConstantInitializer : public IConstantInitializer
+class ConstantInitializer : public cpu_common::ConstantInitializerBase
 {
 public:
   ConstantInitializer(const ir::Operands &operands,
@@ -41,7 +41,7 @@ public:
   // TODO: For now the only cpu backend supports constant tensor to use data from external
   // If the other backend supports (to do this,
   // ExternalTensor should be abstract such as IExternal, maybe),
-  // this can be an interface of IConstantInitializer
+  // this can be an interface of cpu_common::ConstantInitializerBase
   void registerExternalInitializer(const ir::OperandIndex &, const ir::Operand &);
 
 public:

--- a/runtime/onert/backend/cpu/KernelGenerator.h
+++ b/runtime/onert/backend/cpu/KernelGenerator.h
@@ -23,7 +23,7 @@
 #include "Tensor.h"
 
 #include <backend/CustomKernelBuilder.h>
-#include <backend/IKernelGenerator.h>
+#include <backend/cpu_common/KernelGeneratorBase.h>
 #include <ir/Operands.h>
 #include <ir/Operations.h>
 
@@ -34,7 +34,7 @@ namespace backend
 namespace cpu
 {
 
-class KernelGenerator : public IKernelGenerator
+class KernelGenerator : public cpu_common::KernelGeneratorBase
 {
 public:
   KernelGenerator(const ir::Operands &operands_ctx, const ir::Operations &operations_ctx,
@@ -42,8 +42,6 @@ public:
                   const std::shared_ptr<cpu_common::TensorRegistry> &tensor_reg,
                   const std::shared_ptr<custom::IKernelBuilder> &kernel_builder,
                   const std::shared_ptr<ExternalContext> &external_context);
-
-  using IKernelGenerator::visit;
 
   void visit(const ir::OpSequence &) override;
 

--- a/runtime/onert/backend/ruy/BackendContext.cc
+++ b/runtime/onert/backend/ruy/BackendContext.cc
@@ -31,6 +31,26 @@ namespace backend
 namespace ruy
 {
 
+void BackendContext::initConsts()
+{
+  for (auto &op : operation_list())
+  {
+    constant_initializer->setLayout(op.layout);
+    graph()->operations().at(op.index).accept(*constant_initializer);
+  }
+
+  for (auto ind : operand_list())
+  {
+    const auto &obj = graph()->operands().at(ind);
+    if (obj.isConstant() && !constant_initializer->exist(ind))
+    {
+      constant_initializer->registerDefaultInitializer(ind, obj);
+    }
+  }
+
+  constant_initializer->run();
+}
+
 ITensorRegistry *BackendContext::genTensors(const std::vector<onert::ir::OpSequenceIndex> &order,
                                             const ir::OpSequences &op_seqs,
                                             const ir::LowerInfoMap &lower_info)

--- a/runtime/onert/backend/ruy/BackendContext.h
+++ b/runtime/onert/backend/ruy/BackendContext.h
@@ -19,6 +19,8 @@
 
 #include <backend/BackendContext.h>
 #include "TensorBuilder.h"
+#include "ConstantInitializer.h"
+#include "KernelGenerator.h"
 #include "ExternalContext.h"
 
 namespace onert
@@ -34,11 +36,11 @@ public:
   BackendContext(const Backend *backend, const ir::Graph *graph,
                  std::shared_ptr<ITensorRegistry> tensor_registry = nullptr,
                  std::shared_ptr<TensorBuilder> tensor_builder = nullptr,
-                 std::shared_ptr<IConstantInitializer> constant_initializer = nullptr,
-                 std::shared_ptr<IKernelGenerator> kernel_gen = nullptr)
-      : onert::backend::BackendContext(backend, graph, tensor_registry, constant_initializer,
-                                       kernel_gen),
-        tensor_builder{tensor_builder}, _external_context(new ExternalContext)
+                 std::shared_ptr<ConstantInitializer> constant_initializer = nullptr,
+                 std::shared_ptr<KernelGenerator> kernel_gen = nullptr)
+      : onert::backend::BackendContext(backend, graph, tensor_registry),
+        tensor_builder{tensor_builder}, constant_initializer{constant_initializer},
+        kernel_gen{kernel_gen}, _external_context(new ExternalContext)
   {
   }
 
@@ -52,12 +54,15 @@ public:
   std::shared_ptr<ExternalContext> external_context() { return _external_context; }
 
 private:
+  void initConsts();
   void planTensors(const std::vector<onert::ir::OpSequenceIndex> &order,
                    const ir::OpSequences &op_seqs, const ir::LowerInfoMap &lower_info);
 
 public:
   // TODO Make it private
   std::shared_ptr<TensorBuilder> tensor_builder;
+  std::shared_ptr<ConstantInitializer> constant_initializer;
+  std::shared_ptr<KernelGenerator> kernel_gen;
 
 private:
   // NOTE ruy context has a thread pool, and when multiple ruy contexts are created,

--- a/runtime/onert/backend/ruy/ConstantInitializer.cc
+++ b/runtime/onert/backend/ruy/ConstantInitializer.cc
@@ -26,7 +26,7 @@ namespace ruy
 
 ConstantInitializer::ConstantInitializer(const ir::Operands &operands,
                                          const std::shared_ptr<ITensorRegistry> &tensor_reg)
-    : IConstantInitializer{operands}, _tensor_reg{tensor_reg}
+    : cpu_common::ConstantInitializerBase{operands}, _tensor_reg{tensor_reg}
 {
   // DO NOTHING
 }

--- a/runtime/onert/backend/ruy/ConstantInitializer.h
+++ b/runtime/onert/backend/ruy/ConstantInitializer.h
@@ -19,7 +19,7 @@
 
 #include "backend/cpu_common/TensorRegistry.h"
 
-#include <backend/IConstantInitializer.h>
+#include <backend/cpu_common/ConstantInitializerBase.h>
 #include <ir/Operands.h>
 
 namespace onert
@@ -29,7 +29,7 @@ namespace backend
 namespace ruy
 {
 
-class ConstantInitializer : public IConstantInitializer
+class ConstantInitializer : public cpu_common::ConstantInitializerBase
 {
 public:
   ConstantInitializer(const ir::Operands &operands,
@@ -41,7 +41,7 @@ public:
   // TODO: For now the only cpu backend supports constant tensor to use data from external
   // If the other backend supports (to do this,
   // ExternalTensor should be abstract such as IExternal, maybe),
-  // this can be an interface of IConstantInitializer
+  // this can be an interface of cpu_common::ConstantInitializerBase
   void registerExternalInitializer(const ir::OperandIndex &, const ir::Operand &);
 
 public:

--- a/runtime/onert/backend/ruy/KernelGenerator.h
+++ b/runtime/onert/backend/ruy/KernelGenerator.h
@@ -23,7 +23,7 @@
 #include "Tensor.h"
 
 #include <backend/CustomKernelBuilder.h>
-#include <backend/IKernelGenerator.h>
+#include <backend/cpu_common/KernelGeneratorBase.h>
 #include <ir/Operands.h>
 #include <ir/Operations.h>
 
@@ -34,7 +34,7 @@ namespace backend
 namespace ruy
 {
 
-class KernelGenerator : public IKernelGenerator
+class KernelGenerator : public cpu_common::KernelGeneratorBase
 {
 public:
   KernelGenerator(const ir::Operands &operands_ctx, const ir::Operations &operations_ctx,
@@ -42,8 +42,6 @@ public:
                   const std::shared_ptr<cpu_common::TensorRegistry> &tensor_reg,
                   const std::shared_ptr<custom::IKernelBuilder> &kernel_builder,
                   const std::shared_ptr<ExternalContext> &external_context);
-
-  using IKernelGenerator::visit;
 
   void visit(const ir::OpSequence &) override;
   void visit(const ir::operation::Conv2D &) override;

--- a/runtime/onert/backend/xnnpack/BackendContext.cc
+++ b/runtime/onert/backend/xnnpack/BackendContext.cc
@@ -31,6 +31,26 @@ namespace backend
 namespace xnnpack
 {
 
+void BackendContext::initConsts()
+{
+  for (auto &op : operation_list())
+  {
+    constant_initializer->setLayout(op.layout);
+    graph()->operations().at(op.index).accept(*constant_initializer);
+  }
+
+  for (auto ind : operand_list())
+  {
+    const auto &obj = graph()->operands().at(ind);
+    if (obj.isConstant() && !constant_initializer->exist(ind))
+    {
+      constant_initializer->registerDefaultInitializer(ind, obj);
+    }
+  }
+
+  constant_initializer->run();
+}
+
 ITensorRegistry *BackendContext::genTensors(const std::vector<onert::ir::OpSequenceIndex> &order,
                                             const ir::OpSequences &op_seqs,
                                             const ir::LowerInfoMap &lower_info)

--- a/runtime/onert/backend/xnnpack/BackendContext.h
+++ b/runtime/onert/backend/xnnpack/BackendContext.h
@@ -20,6 +20,8 @@
 #include <backend/BackendContext.h>
 #include <util/ConfigSource.h>
 #include "TensorBuilder.h"
+#include "ConstantInitializer.h"
+#include "KernelGenerator.h"
 #include "ExternalContext.h"
 
 namespace
@@ -40,11 +42,11 @@ public:
   BackendContext(const Backend *backend, const ir::Graph *graph,
                  std::shared_ptr<ITensorRegistry> tensor_registry = nullptr,
                  std::shared_ptr<TensorBuilder> tensor_builder = nullptr,
-                 std::shared_ptr<IConstantInitializer> constant_initializer = nullptr,
-                 std::shared_ptr<IKernelGenerator> kernel_gen = nullptr)
-      : onert::backend::BackendContext(backend, graph, tensor_registry, constant_initializer,
-                                       kernel_gen),
-        tensor_builder{tensor_builder}, _external_context(nullptr)
+                 std::shared_ptr<ConstantInitializer> constant_initializer = nullptr,
+                 std::shared_ptr<KernelGenerator> kernel_gen = nullptr)
+      : onert::backend::BackendContext(backend, graph, tensor_registry),
+        tensor_builder{tensor_builder}, constant_initializer{constant_initializer},
+        kernel_gen{kernel_gen}, _external_context(nullptr)
   {
     int num_threads = util::getConfigInt(util::config::XNNPACK_THREADS);
     if (num_threads < 1)
@@ -62,11 +64,15 @@ public:
   std::shared_ptr<ExternalContext> external_context() { return _external_context; }
 
 private:
+  void initConsts();
   void planTensors(const std::vector<onert::ir::OpSequenceIndex> &order,
                    const ir::OpSequences &op_seqs, const ir::LowerInfoMap &lower_info);
 
 public:
+  // TODO Make it private
   std::shared_ptr<TensorBuilder> tensor_builder;
+  std::shared_ptr<ConstantInitializer> constant_initializer;
+  std::shared_ptr<KernelGenerator> kernel_gen;
 
 private:
   std::shared_ptr<ExternalContext> _external_context;

--- a/runtime/onert/backend/xnnpack/ConstantInitializer.cc
+++ b/runtime/onert/backend/xnnpack/ConstantInitializer.cc
@@ -26,7 +26,7 @@ namespace xnnpack
 
 ConstantInitializer::ConstantInitializer(const ir::Operands &operands,
                                          const std::shared_ptr<ITensorRegistry> &tensor_reg)
-    : IConstantInitializer{operands}, _tensor_reg{tensor_reg}
+    : cpu_common::ConstantInitializerBase{operands}, _tensor_reg{tensor_reg}
 {
   // DO NOTHING
 }

--- a/runtime/onert/backend/xnnpack/ConstantInitializer.h
+++ b/runtime/onert/backend/xnnpack/ConstantInitializer.h
@@ -19,7 +19,7 @@
 
 #include "backend/cpu_common/TensorRegistry.h"
 
-#include <backend/IConstantInitializer.h>
+#include <backend/cpu_common/ConstantInitializerBase.h>
 #include <ir/Operands.h>
 
 namespace onert
@@ -29,7 +29,7 @@ namespace backend
 namespace xnnpack
 {
 
-class ConstantInitializer : public IConstantInitializer
+class ConstantInitializer : public cpu_common::ConstantInitializerBase
 {
 public:
   ConstantInitializer(const ir::Operands &operands,
@@ -41,7 +41,7 @@ public:
   // TODO: For now the only cpu backend supports constant tensor to use data from external
   // If the other backend supports (to do this,
   // ExternalTensor should be abstract such as IExternal, maybe),
-  // this can be an interface of IConstantInitializer
+  // this can be an interface of cpu_common::ConstantInitializerBase
   void registerExternalInitializer(const ir::OperandIndex &, const ir::Operand &);
 
 public:

--- a/runtime/onert/backend/xnnpack/KernelGenerator.h
+++ b/runtime/onert/backend/xnnpack/KernelGenerator.h
@@ -23,7 +23,7 @@
 #include "Tensor.h"
 
 #include <backend/CustomKernelBuilder.h>
-#include <backend/IKernelGenerator.h>
+#include <backend/cpu_common/KernelGeneratorBase.h>
 #include <ir/Operands.h>
 #include <ir/Operations.h>
 
@@ -34,7 +34,7 @@ namespace backend
 namespace xnnpack
 {
 
-class KernelGenerator : public IKernelGenerator
+class KernelGenerator : public cpu_common::KernelGeneratorBase
 {
 public:
   KernelGenerator(const ir::Operands &operands_ctx, const ir::Operations &operations_ctx,
@@ -42,8 +42,6 @@ public:
                   const std::shared_ptr<cpu_common::TensorRegistry> &tensor_reg,
                   const std::shared_ptr<custom::IKernelBuilder> &kernel_builder,
                   const std::shared_ptr<ExternalContext> &external_context);
-
-  using IKernelGenerator::visit;
 
   void visit(const ir::OpSequence &) override;
   void visit(const ir::operation::Conv2D &) override;

--- a/runtime/onert/core/include/backend/BackendContext.h
+++ b/runtime/onert/core/include/backend/BackendContext.h
@@ -28,8 +28,6 @@ namespace backend
 {
 
 class Backend;
-class IConstantInitializer;
-class IKernelGenerator;
 struct ITensorRegistry;
 
 using FunctionMap =
@@ -48,11 +46,8 @@ public:
 
 public:
   BackendContext(const Backend *backend, const ir::Graph *graph,
-                 std::shared_ptr<ITensorRegistry> tensor_registry = nullptr,
-                 std::shared_ptr<IConstantInitializer> constant_initializer = nullptr,
-                 std::shared_ptr<IKernelGenerator> kernel_gen = nullptr)
-      : _backend{backend}, _graph{graph}, tensor_registry{tensor_registry},
-        constant_initializer{constant_initializer}, kernel_gen{kernel_gen}
+                 std::shared_ptr<ITensorRegistry> tensor_registry = nullptr)
+      : _backend{backend}, _graph{graph}, tensor_registry{tensor_registry}
   {
   }
 
@@ -86,8 +81,6 @@ private:
 
 public:
   std::shared_ptr<ITensorRegistry> tensor_registry;
-  std::shared_ptr<IConstantInitializer> constant_initializer;
-  std::shared_ptr<IKernelGenerator> kernel_gen;
 };
 
 using BackendContexts = std::unordered_map<const Backend *, std::unique_ptr<BackendContext>>;

--- a/runtime/onert/core/include/backend/cpu_common/ConstantInitializerBase.h
+++ b/runtime/onert/core/include/backend/cpu_common/ConstantInitializerBase.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef __ONERT_BACKEND_ICONSTANT_INITIALIZER_H__
-#define __ONERT_BACKEND_ICONSTANT_INITIALIZER_H__
+#ifndef __ONERT_BACKEND_CPU_COMMON_CONSTANT_INITIALIZER_BASE_H__
+#define __ONERT_BACKEND_CPU_COMMON_CONSTANT_INITIALIZER_BASE_H__
 
 #include <unordered_map>
 #include <functional>
@@ -26,6 +26,7 @@
 #include "ir/Operands.h"
 #include "ir/OperationVisitor.h"
 #include "ir/OpSequence.h"
+#include "backend/ITensorRegistry.h"
 #include "util/logging.h"
 #include "backend/ITensorRegistry.h"
 
@@ -153,11 +154,13 @@ namespace onert
 {
 namespace backend
 {
+namespace cpu_common
+{
 
-class IConstantInitializer : public ir::OperationVisitor
+class ConstantInitializerBase : public ir::OperationVisitor
 {
 public:
-  virtual ~IConstantInitializer() = default;
+  virtual ~ConstantInitializerBase() = default;
 
 public:
   void run()
@@ -178,7 +181,7 @@ public:
   }
 
 public:
-  IConstantInitializer(const ir::Operands &operands)
+  ConstantInitializerBase(const ir::Operands &operands)
       : _operands{operands}, _current_layout{ir::Layout::UNKNOWN}
   {
   }
@@ -224,7 +227,8 @@ protected:
   ir::Layout _current_layout;
 };
 
+} // namespace cpu_common
 } // namespace backend
 } // namespace onert
 
-#endif // __ONERT_BACKEND_ICONSTANT_INITIALIZER_H__
+#endif // __ONERT_BACKEND_CPU_COMMON_CONSTANT_INITIALIZER_BASE_H__

--- a/runtime/onert/core/include/backend/cpu_common/KernelGeneratorBase.h
+++ b/runtime/onert/core/include/backend/cpu_common/KernelGeneratorBase.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef __ONERT_BACKEND_IKERNEL_GENERATOR_H__
-#define __ONERT_BACKEND_IKERNEL_GENERATOR_H__
+#ifndef __ONERT_BACKEND_CPU_COMMON_KERNEL_GENERATOR_BASE_H__
+#define __ONERT_BACKEND_CPU_COMMON_KERNEL_GENERATOR_BASE_H__
 
 #include <assert.h>
 #include <memory>
@@ -31,11 +31,13 @@ namespace onert
 {
 namespace backend
 {
+namespace cpu_common
+{
 
-class IKernelGenerator : public ir::OperationVisitor
+class KernelGeneratorBase : public ir::OperationVisitor
 {
 public:
-  virtual ~IKernelGenerator() = default;
+  virtual ~KernelGeneratorBase() = default;
 
   std::unique_ptr<exec::IFunction> releaseFunction()
   {
@@ -70,7 +72,8 @@ protected:
   std::unique_ptr<exec::FunctionSequence> _return_fn_seq; // TODO Extract this out
 };
 
+} // namespace cpu_common
 } // namespace backend
 } // namespace onert
 
-#endif // __ONERT_BACKEND_IKERNEL_GENERATOR_H__
+#endif // __ONERT_BACKEND_CPU_COMMON_KERNEL_GENERATOR_BASE_H__

--- a/runtime/onert/core/src/backend/BackendContext.cc
+++ b/runtime/onert/core/src/backend/BackendContext.cc
@@ -17,7 +17,6 @@
 #include "backend/BackendContext.h"
 
 #include "ir/Operation.h"
-#include "backend/IConstantInitializer.h"
 
 namespace onert
 {
@@ -29,26 +28,6 @@ void BackendContext::initialize(const std::vector<OperationInfo> &operation_list
 {
   _operation_list = operation_list;
   _operand_list = operand_list;
-}
-
-void BackendContext::initConsts()
-{
-  for (auto &op : _operation_list)
-  {
-    constant_initializer->setLayout(op.layout);
-    _graph->operations().at(op.index).accept(*constant_initializer);
-  }
-
-  for (auto ind : _operand_list)
-  {
-    const auto &obj = _graph->operands().at(ind);
-    if (obj.isConstant() && !constant_initializer->exist(ind))
-    {
-      constant_initializer->registerDefaultInitializer(ind, obj);
-    }
-  }
-
-  constant_initializer->run();
 }
 
 } // namespace backend

--- a/runtime/onert/core/src/backend/controlflow/BackendContext.cc
+++ b/runtime/onert/core/src/backend/controlflow/BackendContext.cc
@@ -25,6 +25,26 @@ namespace backend
 namespace controlflow
 {
 
+void BackendContext::initConsts()
+{
+  for (auto &op : operation_list())
+  {
+    constant_initializer->setLayout(op.layout);
+    graph()->operations().at(op.index).accept(*constant_initializer);
+  }
+
+  for (auto ind : operand_list())
+  {
+    const auto &obj = graph()->operands().at(ind);
+    if (obj.isConstant() && !constant_initializer->exist(ind))
+    {
+      constant_initializer->registerDefaultInitializer(ind, obj);
+    }
+  }
+
+  constant_initializer->run();
+}
+
 void BackendContext::planTensors(const std::vector<onert::ir::OpSequenceIndex> &order,
                                  const ir::OpSequences &op_seqs, const ir::LowerInfoMap &lower_info)
 {

--- a/runtime/onert/core/src/backend/controlflow/BackendContext.h
+++ b/runtime/onert/core/src/backend/controlflow/BackendContext.h
@@ -36,11 +36,11 @@ public:
   BackendContext(const Backend *backend, const ir::Graph *graph,
                  std::shared_ptr<ITensorRegistry> tensor_registry = nullptr,
                  std::shared_ptr<TensorBuilder> tensor_builder = nullptr,
-                 std::shared_ptr<IConstantInitializer> constant_initializer = nullptr,
-                 std::shared_ptr<IKernelGenerator> kernel_gen = nullptr)
-      : onert::backend::BackendContext(backend, graph, tensor_registry, constant_initializer,
-                                       kernel_gen),
-        tensor_builder{tensor_builder}, _external_context(std::make_shared<ExternalContext>())
+                 std::shared_ptr<ConstantInitializer> constant_initializer = nullptr,
+                 std::shared_ptr<KernelGenerator> kernel_gen = nullptr)
+      : onert::backend::BackendContext(backend, graph, tensor_registry),
+        tensor_builder{tensor_builder}, constant_initializer{constant_initializer},
+        kernel_gen{kernel_gen}, _external_context(std::make_shared<ExternalContext>())
   {
   }
 
@@ -54,11 +54,15 @@ public:
   std::shared_ptr<ExternalContext> external_context() { return _external_context; }
 
 private:
+  void initConsts();
   void planTensors(const std::vector<onert::ir::OpSequenceIndex> &order,
                    const ir::OpSequences &op_seqs, const ir::LowerInfoMap &lower_info);
 
 public:
+  // TODO Make it private
   std::shared_ptr<TensorBuilder> tensor_builder;
+  std::shared_ptr<ConstantInitializer> constant_initializer;
+  std::shared_ptr<KernelGenerator> kernel_gen;
 
 private:
   // NOTE ruy context has a thread pool, and when multiple ruy contexts are created,

--- a/runtime/onert/core/src/backend/controlflow/ConstantInitializer.cc
+++ b/runtime/onert/core/src/backend/controlflow/ConstantInitializer.cc
@@ -26,7 +26,7 @@ namespace controlflow
 
 ConstantInitializer::ConstantInitializer(const ir::Operands &operands,
                                          const std::shared_ptr<ITensorRegistry> &tensor_reg)
-    : IConstantInitializer{operands}, _tensor_reg{tensor_reg}
+    : cpu_common::ConstantInitializerBase{operands}, _tensor_reg{tensor_reg}
 {
   // DO NOTHING
 }

--- a/runtime/onert/core/src/backend/controlflow/ConstantInitializer.h
+++ b/runtime/onert/core/src/backend/controlflow/ConstantInitializer.h
@@ -19,7 +19,7 @@
 
 #include "TensorRegistry.h"
 
-#include <backend/IConstantInitializer.h>
+#include <backend/cpu_common/ConstantInitializerBase.h>
 #include <ir/Operands.h>
 
 namespace onert
@@ -29,7 +29,7 @@ namespace backend
 namespace controlflow
 {
 
-class ConstantInitializer : public IConstantInitializer
+class ConstantInitializer : public cpu_common::ConstantInitializerBase
 {
 public:
   ConstantInitializer(const ir::Operands &operands,

--- a/runtime/onert/core/src/backend/controlflow/KernelGenerator.h
+++ b/runtime/onert/core/src/backend/controlflow/KernelGenerator.h
@@ -17,12 +17,12 @@
 #ifndef __ONERT_BACKEND_CONTROLFLOW_KERNEL_GENERATOR_H__
 #define __ONERT_BACKEND_CONTROLFLOW_KERNEL_GENERATOR_H__
 
-#include <backend/IKernelGenerator.h>
 #include <exec/IExecutor.h>
 #include "ExternalContext.h"
 #include <ir/Graph.h>
 #include "TensorBuilder.h"
 #include "compiler/TensorRegistries.h"
+#include "backend/cpu_common/KernelGeneratorBase.h"
 #include "TensorRegistry.h"
 
 namespace onert
@@ -32,7 +32,7 @@ namespace backend
 namespace controlflow
 {
 
-class KernelGenerator : public IKernelGenerator
+class KernelGenerator : public cpu_common::KernelGeneratorBase
 {
 public:
   KernelGenerator(const ir::Graph &graph, DynamicTensorManager *dyn_tensor_manager,
@@ -48,8 +48,6 @@ public:
     // FIXME Using shared_ptr's raw pointer!
     _executor_map = executor_map.get();
   }
-
-  using IKernelGenerator::visit;
 
   void visit(const ir::OpSequence &) override;
   void visit(const ir::operation::If &) override;

--- a/runtime/onert/core/src/backend/cpu_common/ConstantInitializerBase.cc
+++ b/runtime/onert/core/src/backend/cpu_common/ConstantInitializerBase.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "backend/IConstantInitializer.h"
+#include "backend/cpu_common/ConstantInitializerBase.h"
 
 #include <Half.h>
 
@@ -24,9 +24,11 @@ namespace onert
 {
 namespace backend
 {
+namespace cpu_common
+{
 
-void IConstantInitializer::registerCopyInitializer(const ir::OperandIndex &index,
-                                                   const ir::Operand &obj)
+void ConstantInitializerBase::registerCopyInitializer(const ir::OperandIndex &index,
+                                                      const ir::Operand &obj)
 {
   // For only CONSTANTS
   // TODO Add to check if tensor has been allocated
@@ -67,8 +69,8 @@ void IConstantInitializer::registerCopyInitializer(const ir::OperandIndex &index
   }
 }
 
-void IConstantInitializer::registerPermuteInitializer(const ir::OperandIndex &index,
-                                                      const ir::Operand &obj)
+void ConstantInitializerBase::registerPermuteInitializer(const ir::OperandIndex &index,
+                                                         const ir::Operand &obj)
 {
   // For only CONSTANTS
   // TODO Add to check if tensor has been allocated
@@ -110,5 +112,6 @@ void IConstantInitializer::registerPermuteInitializer(const ir::OperandIndex &in
   }
 }
 
+} // namespace cpu_common
 } // namespace backend
 } // namespace onert

--- a/runtime/onert/core/src/compiler/ExecutorFactory.cc
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.cc
@@ -217,13 +217,12 @@ ExecutorFactory::createLinearExecutor(std::unique_ptr<compiler::LoweredGraph> lo
   // Give some runtime objects to controlflow KernelGenerator
   for (auto &pair : backend_contexts)
   {
-    auto kernel_gen = pair.second->kernel_gen;
-    auto cf_kernel_gen = dynamic_cast<backend::controlflow::KernelGenerator *>(kernel_gen.get());
-    if (cf_kernel_gen != nullptr)
+    auto cf_context = dynamic_cast<backend::controlflow::BackendContext *>(pair.second.get());
+    if (cf_context != nullptr)
     {
+      auto cf_kernel_gen = cf_context->kernel_gen;
       cf_kernel_gen->setTensorRegistries(tensor_regs);
       cf_kernel_gen->setExecutorMap(executor_map);
-      break;
     }
   }
 
@@ -306,10 +305,10 @@ exec::IExecutor *ExecutorFactory::createDataflowExecutor(
   // Give some runtime objects to controlflow KernelGenerator
   for (auto &pair : backend_contexts)
   {
-    auto kernel_gen = pair.second->kernel_gen;
-    auto cf_kernel_gen = dynamic_cast<backend::controlflow::KernelGenerator *>(kernel_gen.get());
-    if (cf_kernel_gen != nullptr)
+    auto cf_context = dynamic_cast<backend::controlflow::BackendContext *>(pair.second.get());
+    if (cf_context != nullptr)
     {
+      auto cf_kernel_gen = cf_context->kernel_gen;
       cf_kernel_gen->setTensorRegistries(tensor_regs);
       cf_kernel_gen->setExecutorMap(executor_map);
     }


### PR DESCRIPTION
Remove IKernelGenerator and IConstantInitializer.

Unlike IOptimizer and ITensorBuilder, these two have a lot of code in
common, so they are renamed(to XXXBase) and moved to `cpu_common`.

Draft #5272

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>