### PR TITLE
[onert/cpu] Fix BackedContext getTensor bug

### DIFF
--- a/runtime/onert/backend/cpu/BackendContext.cc
+++ b/runtime/onert/backend/cpu/BackendContext.cc
@@ -62,6 +62,8 @@ ITensorRegistry *BackendContext::genTensors(const std::vector<onert::ir::OpSeque
     if (model_io.contains(index))
       continue;
     const auto &obj = graph()->operands().at(index);
+    if (obj.getUses().size() == 0) // Defined by operation, but used nowhere
+      continue;
     const auto frontend_layout = [&]() {
       auto use_op_ind = *obj.getUses().begin(); // FIXME What if it has two or more uses?
       for (auto &operation_info : operation_list())

--- a/runtime/onert/backend/cpu/BackendContext.cc
+++ b/runtime/onert/backend/cpu/BackendContext.cc
@@ -62,9 +62,9 @@ ITensorRegistry *BackendContext::genTensors(const std::vector<onert::ir::OpSeque
     if (model_io.contains(index))
       continue;
     const auto &obj = graph()->operands().at(index);
-    if (obj.getUses().size() == 0) // Defined by operation, but used nowhere
-      continue;
     const auto frontend_layout = [&]() {
+      if (obj.getUses().size() == 0)
+        return ir::Layout::UNKNOWN;
       auto use_op_ind = *obj.getUses().begin(); // FIXME What if it has two or more uses?
       for (auto &operation_info : operation_list())
       {

--- a/runtime/onert/backend/ruy/BackendContext.cc
+++ b/runtime/onert/backend/ruy/BackendContext.cc
@@ -63,6 +63,8 @@ ITensorRegistry *BackendContext::genTensors(const std::vector<onert::ir::OpSeque
       continue;
     const auto &obj = graph()->operands().at(index);
     const auto frontend_layout = [&]() {
+      if (obj.getUses().size() == 0)
+        return ir::Layout::UNKNOWN;
       auto use_op_ind = *obj.getUses().begin(); // FIXME What if it has two or more uses?
       for (auto &operation_info : operation_list())
       {

--- a/runtime/onert/backend/xnnpack/BackendContext.cc
+++ b/runtime/onert/backend/xnnpack/BackendContext.cc
@@ -63,6 +63,8 @@ ITensorRegistry *BackendContext::genTensors(const std::vector<onert::ir::OpSeque
       continue;
     const auto &obj = graph()->operands().at(index);
     const auto frontend_layout = [&]() {
+      if (obj.getUses().size() == 0)
+        return ir::Layout::UNKNOWN;
       auto use_op_ind = *obj.getUses().begin(); // FIXME What if it has two or more uses?
       for (auto &operation_info : operation_list())
       {


### PR DESCRIPTION
Skip finding tensor's use set when tensor is defined but used nowhere

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

It will resolve test fail https://github.com/Samsung/ONE/issues/5271#issuecomment-737858216
Test: `res/TensorFlowLiteRecipes/Unpack_003/test.recipe`