### PR TITLE
[luci/pass]Introduce RemoveRedundantReshapePass on luci/pass.

### DIFF
--- a/compiler/luci/pass/include/luci/CircleOptimizer.h
+++ b/compiler/luci/pass/include/luci/CircleOptimizer.h
@@ -53,6 +53,7 @@ public:
       RemoveRedundantTranspose,
       ReplaceMulAddWithDepthwiseConv,
       SubstitutePackToReshape,
+      RemoveRedundantReshape,
     };
 
     enum AlgorithmParameters

--- a/compiler/luci/pass/include/luci/Pass/RemoveRedundantReshapePass.h
+++ b/compiler/luci/pass/include/luci/Pass/RemoveRedundantReshapePass.h
@@ -23,7 +23,7 @@ namespace luci
 {
 
 /**
- * @brief  Class to Redundant Reshape node into 1 reshape node.
+ * @brief  Class to remove redundant Reshape node into 1 reshape node.
  */
 struct RemoveRedundantReshapePass final : public logo::Pass
 {

--- a/compiler/luci/pass/include/luci/Pass/RemoveRedundantReshapePass.h
+++ b/compiler/luci/pass/include/luci/Pass/RemoveRedundantReshapePass.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __LUCI_REMOVE_REDUNDANT_RESHAPE_PASS_H__
+#define __LUCI_REMOVE_REDUNDANT_RESHAPE_PASS_H__
+
+#include <logo/Pass.h>
+
+namespace luci
+{
+
+/**
+ * @brief  Class to Redundant Reshape node into 1 reshape node.
+ */
+struct RemoveRedundantReshapePass final : public logo::Pass
+{
+  const char *name(void) const final { return "luci::RemoveRedundantReshapePass"; }
+
+  bool run(loco::Graph *g) final;
+};
+
+} // namespace luci
+
+#endif // __LUCI_REMOVE_REDUNDANT_RESHAPE_PASS_H__

--- a/compiler/luci/pass/src/CircleOptimizer.cpp
+++ b/compiler/luci/pass/src/CircleOptimizer.cpp
@@ -26,6 +26,7 @@
 #include "luci/Pass/MakeBatchNormGammaPositivePass.h"
 #include "luci/Pass/PropagateQuantParamPass.h"
 #include "luci/Pass/RemoveRedundantTransposePass.h"
+#include "luci/Pass/RemoveRedundantReshapePass.h"
 #include "luci/Pass/ReplaceMulAddWithDepthwiseConvPass.h"
 #include "luci/Pass/ResolveCustomOpAddPass.h"
 #include "luci/Pass/ResolveCustomOpBatchMatMulPass.h"
@@ -219,6 +220,10 @@ void CircleOptimizer::optimize(loco::Graph *g) const
   if (_options->query(Options::Algorithm::RemoveRedundantTranspose))
   {
     phase.emplace_back(std::make_unique<luci::RemoveRedundantTransposePass>());
+  }
+  if (_options->query(Options::Algorithm::RemoveRedundantReshape))
+  {
+    phase.emplace_back(std::make_unique<luci::RemoveRedundantReshapePass>());
   }
   if (_options->query(Options::Algorithm::ReplaceMulAddWithDepthwiseConv))
   {

--- a/compiler/luci/pass/src/RemoveRedundantReshapePass.cpp
+++ b/compiler/luci/pass/src/RemoveRedundantReshapePass.cpp
@@ -29,8 +29,9 @@ bool remove_redundant_reshape(luci::CircleNode *node)
   auto pred_node = dynamic_cast<luci::CircleReshape *>(target_node->tensor());
   if (pred_node == nullptr)
     return false;
-  auto value_node = loco::must_cast<luci::CircleNode *>(pred_node->tensor());
-  target_node->tensor(value_node);
+  auto shape_node = loco::must_cast<luci::CircleNode *>(pred_node->shape());
+  // Check shape_node is control input(?)
+  target_node->tensor(pred_node->tensor());
   return true;
 }
 

--- a/compiler/luci/pass/src/RemoveRedundantReshapePass.cpp
+++ b/compiler/luci/pass/src/RemoveRedundantReshapePass.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Pass/RemoveRedundantReshapePass.h"
+
+#include <luci/IR/CircleNodes.h>
+
+namespace
+{
+
+bool remove_redundant_reshape(luci::CircleNode *node)
+{
+  auto target_node = dynamic_cast<luci::CircleReshape *>(node);
+  if (target_node == nullptr)
+    return false;
+  auto pred_node = dynamic_cast<luci::CircleReshape *>(target_node->tensor());
+  if (pred_node == nullptr)
+    return false;
+  auto value_node = loco::must_cast<luci::CircleNode *>(pred_node->tensor());
+  target_node->tensor(value_node);
+  return true;
+}
+
+} // namespace
+
+namespace luci
+{
+
+// Bypass redundant reshape nodes:
+//
+//    input                      input  ---+
+//      |                          |       |
+//      V                          V       |
+//   Reshape       becomes      Reshape    |
+//      |                                  |
+//      V                                  |
+//   Reshape                    Reshape  <-+
+
+bool RemoveRedundantReshapePass::run(loco::Graph *g)
+{
+  bool changed = false;
+  for (auto node : loco::active_nodes(loco::output_nodes(g)))
+  {
+    auto circle_node = loco::must_cast<luci::CircleNode *>(node);
+    if (remove_redundant_reshape(circle_node))
+    {
+      changed = true;
+    }
+  }
+  return changed;
+}
+
+} // namespace luci

--- a/compiler/luci/pass/src/RemoveRedundantReshapePass.cpp
+++ b/compiler/luci/pass/src/RemoveRedundantReshapePass.cpp
@@ -29,8 +29,13 @@ bool remove_redundant_reshape(luci::CircleNode *node)
   auto pred_node = dynamic_cast<luci::CircleReshape *>(target_node->tensor());
   if (pred_node == nullptr)
     return false;
-  auto shape_node = loco::must_cast<luci::CircleNode *>(pred_node->shape());
-  // Check shape_node is control input(?)
+  // TODO Think about reshape node's second input(shape node) is dynamic.
+  auto target_shape_node = dynamic_cast<luci::CircleConst *>(target_node->shape());
+  if (target_shape_node == nullptr)
+    return false;
+  auto pred_shape_node = dynamic_cast<luci::CircleConst *>(pred_node->shape());
+  if (pred_shape_node == nullptr)
+    return false;
   target_node->tensor(pred_node->tensor());
   return true;
 }
@@ -46,9 +51,11 @@ namespace luci
 //      |                          |       |
 //      V                          V       |
 //   Reshape       becomes      Reshape    |
+// (pred_node)                (pred_node)  |
 //      |                                  |
 //      V                                  |
 //   Reshape                    Reshape  <-+
+//(target_node)              (target_node)
 
 bool RemoveRedundantReshapePass::run(loco::Graph *g)
 {

--- a/compiler/luci/pass/src/RemoveRedundantReshapePass.test.cpp
+++ b/compiler/luci/pass/src/RemoveRedundantReshapePass.test.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "luci/Pass/RemoveRedundantReshapePass.h"
+
+#include <luci/IR/CircleNodes.h>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+
+// Bypass redundant reshape nodes:
+//
+//    input                      input  ---+
+//      |                          |       |
+//      V                          V       |
+//   Reshape       becomes      Reshape    |
+//      |                                  |
+//      V                                  |
+//   Reshape                    Reshape  <-+
+void create_remove_redundant_reshape(loco::Graph *g,
+                                     const std::initializer_list<uint32_t> base_shape,
+                                     const std::vector<int32_t> intermediate_shape,
+                                     const std::vector<int32_t> final_shape)
+{
+  // Input Create.
+  auto input = g->nodes()->create<luci::CircleInput>();
+  auto graph_input = g->inputs()->create();
+  input->index(graph_input->index());
+  input->shape_status(luci::ShapeStatus::VALID);
+  input->rank(base_shape.size());
+  input->shape(base_shape);
+
+  // Reshape Node create.
+  auto intermediate_reshape = g->nodes()->create<luci::CircleReshape>();
+  intermediate_reshape->tensor(input);
+  auto intermediate_const = g->nodes()->create<luci::CircleConst>();
+  intermediate_const->dtype(loco::DataType::S32);
+  intermediate_const->size<loco::DataType::S32>(intermediate_shape.size());
+  intermediate_const->shape_status(luci::ShapeStatus::VALID);
+  intermediate_const->rank(1);
+  intermediate_const->dim(0).set(intermediate_shape.size());
+  for (int32_t i = 0; i < intermediate_shape.size(); i++)
+  {
+    intermediate_const->at<loco::DataType::S32>(i) = intermediate_shape.at(i);
+  }
+  intermediate_reshape->shape(intermediate_const);
+
+  // Reshape Node create.
+  auto final_reshape = g->nodes()->create<luci::CircleReshape>();
+  final_reshape->tensor(intermediate_reshape);
+  auto final_const = g->nodes()->create<luci::CircleConst>();
+  final_const->dtype(loco::DataType::S32);
+  final_const->size<loco::DataType::S32>(final_shape.size());
+  final_const->shape_status(luci::ShapeStatus::VALID);
+  final_const->rank(1);
+  final_const->dim(0).set(final_shape.size());
+  for (int32_t i = 0; i < final_shape.size(); i++)
+  {
+    final_const->at<loco::DataType::S32>(i) = final_shape.at(i);
+  }
+  final_reshape->shape(final_const);
+
+  // Output Connect.
+  auto output = g->nodes()->create<luci::CircleOutput>();
+  output->from(final_reshape);
+  auto graph_output = g->outputs()->create();
+  output->index(graph_output->index());
+
+  return;
+}
+
+} // namespace
+
+TEST(RemoveRedundantReshape, simple_case)
+{
+  auto graph = loco::make_graph();
+  create_remove_redundant_reshape(graph.get(), {4, 6}, {-1, 4, 6}, {1, -1, 2, 3});
+  luci::RemoveRedundantReshapePass pass;
+  while (pass.run(graph.get()))
+    ;
+  luci::CircleReshape *reshape_node = nullptr;
+  int count = 0;
+  for (auto node : loco::active_nodes(loco::output_nodes(graph.get())))
+  {
+    if (auto reshape = dynamic_cast<luci::CircleReshape *>(node))
+    {
+      reshape_node = reshape;
+      count++;
+    }
+  }
+  ASSERT_NE(nullptr, reshape_node);
+  ASSERT_EQ(1, count);
+}


### PR DESCRIPTION
Parent Issue : #5266
Draft : #5275 
#
This commit introduce `RemoveRedundantReshapePass` on luci/pass.

ONE-DCO-1.0-Signed-off-by: KiDeuk Bang <rrstrous@nate.com>