### PR TITLE
[luci] Change method for getting shape and dtype in CircleTensorExporter

### DIFF
--- a/compiler/luci/export/src/CircleTensorExporter.cpp
+++ b/compiler/luci/export/src/CircleTensorExporter.cpp
@@ -111,10 +111,10 @@ void allocateCircleTensorInfo(CircleNode *node, CircleTensorContext &ctx)
   CircleTensoInfo tensor_info;
 
   tensor_info.name(tensor_name);
-  tensor_info.dtype(to_circle_tensortype(luci::node_dtype(node)));
+  tensor_info.dtype(to_circle_tensortype(node->dtype()));
   tensor_info.shape_signature(node->shape_signature());
   if (node->shape_status() == ShapeStatus::VALID)
-    tensor_info.shape(to_shape_description(luci::node_shape(node)));
+    tensor_info.shape(to_shape_description(node));
   tensor_info.shape_status(node->shape_status());
 
   tensor_info.content(dynamic_cast<luci::CircleConst *>(node));

--- a/compiler/luci/service/include/luci/Service/ShapeDescription.h
+++ b/compiler/luci/service/include/luci/Service/ShapeDescription.h
@@ -20,6 +20,8 @@
 #include <loco/IR/PermutingCodec.h>
 #include <loco/IR/NodeShape.h>
 
+#include <luci/IR/CircleNodes.h>
+
 #include <cstdint>
 #include <vector>
 
@@ -33,6 +35,7 @@ struct ShapeDescription
 };
 
 // TODO remove these when CircleDialect is fully functioal
+ShapeDescription to_shape_description(const luci::CircleNode *node);
 ShapeDescription to_shape_description(const loco::TensorShape &shape);
 ShapeDescription to_shape_description(const loco::FeatureShape &shape);
 ShapeDescription to_shape_description(const loco::FilterShape &shape);

--- a/compiler/luci/service/src/ShapeDescription.cpp
+++ b/compiler/luci/service/src/ShapeDescription.cpp
@@ -23,6 +23,20 @@
 namespace luci
 {
 
+ShapeDescription to_shape_description(const luci::CircleNode *circle_node)
+{
+  ShapeDescription res;
+
+  res._rank_known = true;
+
+  res._dims.resize(circle_node->rank());
+  for (uint32_t i = 0; i < circle_node->rank(); ++i)
+    res._dims.at(i) = circle_node->dim(i).value();
+  res._rank_known = true;
+
+  return res;
+}
+
 ShapeDescription to_shape_description(const loco::TensorShape &shape)
 {
   ShapeDescription res;

--- a/compiler/luci/service/src/ShapeDescription.cpp
+++ b/compiler/luci/service/src/ShapeDescription.cpp
@@ -32,7 +32,6 @@ ShapeDescription to_shape_description(const luci::CircleNode *circle_node)
   res._dims.resize(circle_node->rank());
   for (uint32_t i = 0; i < circle_node->rank(); ++i)
     res._dims.at(i) = circle_node->dim(i).value();
-  res._rank_known = true;
 
   return res;
 }


### PR DESCRIPTION
Parent Issue : #4796

This commit will change a method for getting shape and dtype in `CircleTensorExporter`.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>