### PR TITLE
[compute/ruy] Update clang-format

### DIFF
--- a/compute/ruy/.clang-format
+++ b/compute/ruy/.clang-format
@@ -1,0 +1,1 @@
+../../.clang-format.8

--- a/compute/ruy/include/ruy/RuySupport.h
+++ b/compute/ruy/include/ruy/RuySupport.h
@@ -52,7 +52,7 @@ void MakeRuyMatrix(const MatrixParams<Scalar> &params, DataPointer data_ptr,
                    ::ruy::Matrix<Scalar> *dst, bool use_caching = false)
 {
   ::ruy::Order ruy_order =
-      params.order == Order::kColMajor ? ::ruy::Order::kColMajor : ::ruy::Order::kRowMajor;
+    params.order == Order::kColMajor ? ::ruy::Order::kColMajor : ::ruy::Order::kRowMajor;
   ::ruy::MakeSimpleLayout(params.rows, params.cols, ruy_order, dst->mutable_layout());
   // Note that ruy::Matrix::data is a ConstCheckingPtr, not a plain pointer.
   // It does care whether we assign to it a Scalar* or a const Scalar*.

--- a/compute/ruy/include/ruy/Types.h
+++ b/compute/ruy/include/ruy/Types.h
@@ -187,9 +187,9 @@ enum class QuantizationFlavor
 // (only those that need perchannel quantization do).
 template <typename AccumScalar, typename DstScalar,
           QuantizationFlavor quantization_flavor =
-              std::is_floating_point<AccumScalar>::value
-                  ? QuantizationFlavor::kFloatingPoint
-                  : QuantizationFlavor::kIntegerWithUniformMultiplier>
+            std::is_floating_point<AccumScalar>::value
+              ? QuantizationFlavor::kFloatingPoint
+              : QuantizationFlavor::kIntegerWithUniformMultiplier>
 struct GemmParams
 {
   // Only for non-floating-point cases. The fixed-point part (i.e. the mantissa)
@@ -216,12 +216,12 @@ struct GemmParams
   const AccumScalar *bias = nullptr;
   // min clamp bound of destination values.
   DstScalar clamp_min = std::is_floating_point<DstScalar>::value
-                            ? -std::numeric_limits<DstScalar>::infinity()
-                            : std::numeric_limits<DstScalar>::lowest();
+                          ? -std::numeric_limits<DstScalar>::infinity()
+                          : std::numeric_limits<DstScalar>::lowest();
   // max clamp bound of destination values.
   DstScalar clamp_max = std::is_floating_point<DstScalar>::value
-                            ? std::numeric_limits<DstScalar>::infinity()
-                            : std::numeric_limits<DstScalar>::max();
+                          ? std::numeric_limits<DstScalar>::infinity()
+                          : std::numeric_limits<DstScalar>::max();
 };
 
 // Validates self-consistency of GemmParams.

--- a/compute/ruy/include/ruy/Utils.h
+++ b/compute/ruy/include/ruy/Utils.h
@@ -108,7 +108,7 @@ inline void ExtractPatchIntoBufferColumn(const Shape &input_shape, int w, int h,
   {
     const int bottom_row_elements = (bottom_padding * kwidth * in_depth);
     const int bottom_start =
-        output_row_offset + ((top_padding + (ih_end - ih_start)) * kwidth * in_depth);
+      output_row_offset + ((top_padding + (ih_end - ih_start)) * kwidth * in_depth);
     memset(conv_buffer_data + bottom_start, zero_byte, (bottom_row_elements * sizeof(T)));
   }
 }
@@ -156,7 +156,7 @@ void DilatedIm2col(const ConvParams &params, const Shape &input_shape, const T *
   for (int batch = 0; batch < batches; ++batch)
   {
     const T zero_byte =
-        zero_bytes_len > 1 ? static_cast<T>(zero_bytes[batch]) : static_cast<T>(zero_bytes[0]);
+      zero_bytes_len > 1 ? static_cast<T>(zero_bytes[batch]) : static_cast<T>(zero_bytes[0]);
     for (int out_y = 0; out_y < output_height; ++out_y)
     {
       for (int out_x = 0; out_x < output_width; ++out_x)

--- a/compute/ruy/include/ruy/operation/Conv.h
+++ b/compute/ruy/include/ruy/operation/Conv.h
@@ -111,7 +111,7 @@ private:
     const int filter_height = filter_shape.Dims(1);
     const bool need_dilated_im2col = dilation_width_factor != 1 || dilation_height_factor != 1;
     const bool need_im2col =
-        stride_width != 1 || stride_height != 1 || filter_width != 1 || filter_height != 1;
+      stride_width != 1 || stride_height != 1 || filter_width != 1 || filter_height != 1;
     if (need_dilated_im2col)
     {
       DilatedIm2col(params, float_zero_byte, input_shape, input_data, filter_shape, output_shape,


### PR DESCRIPTION
Use clang-format-8 style for compute/ruy

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>