### PR TITLE
[onert] Pass subgraph index to ExecutionObservers

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -238,6 +238,8 @@ NNFW_STATUS nnfw_session::load_model_from_modelfile(const char *model_file_path)
     return NNFW_STATUS_ERROR;
   }
 
+  _tracing_ctx = std::make_unique<onert::util::TracingCtx>(_subgraphs.get());
+
   _compiler = std::make_unique<onert::compiler::Compiler>(_subgraphs, _tracing_ctx.get());
 
   _state = State::MODEL_LOADED;

--- a/runtime/onert/core/src/exec/ExecutionObservee.cc
+++ b/runtime/onert/core/src/exec/ExecutionObservee.cc
@@ -26,37 +26,38 @@ void ExecutionObservee::add(std::unique_ptr<IExecutionObserver> observer)
   _observers.emplace_back(std::move(observer));
 }
 
-void ExecutionObservee::notifySubgraphBegin(IExecutor *executor)
+void ExecutionObservee::notifySubgraphBegin(ir::SubgraphIndex ind)
 {
   for (auto &o : _observers)
   {
-    o->handleSubgraphBegin(executor);
+    o->handleSubgraphBegin(ind);
   }
 }
 
-void ExecutionObservee::notifySubgraphEnd(IExecutor *executor)
+void ExecutionObservee::notifySubgraphEnd(ir::SubgraphIndex ind)
 {
   for (auto &o : _observers)
   {
-    o->handleSubgraphEnd(executor);
+    o->handleSubgraphEnd(ind);
   }
 }
 
-void ExecutionObservee::notifyJobBegin(IExecutor *executor, const ir::OpSequence *op_seq,
+void ExecutionObservee::notifyJobBegin(IExecutor *executor, ir::SubgraphIndex index,
+                                       const ir::OpSequence *op_seq,
                                        const backend::Backend *backend)
 {
   for (auto &o : _observers)
   {
-    o->handleJobBegin(executor, op_seq, backend);
+    o->handleJobBegin(executor, index, op_seq, backend);
   }
 }
 
-void ExecutionObservee::notifyJobEnd(IExecutor *executor, const ir::OpSequence *op_seq,
-                                     const backend::Backend *backend)
+void ExecutionObservee::notifyJobEnd(IExecutor *executor, ir::SubgraphIndex index,
+                                     const ir::OpSequence *op_seq, const backend::Backend *backend)
 {
   for (auto &o : _observers)
   {
-    o->handleJobEnd(executor, op_seq, backend);
+    o->handleJobEnd(executor, index, op_seq, backend);
   }
 }
 

--- a/runtime/onert/core/src/exec/ExecutionObservee.h
+++ b/runtime/onert/core/src/exec/ExecutionObservee.h
@@ -20,6 +20,7 @@
 #include <list>
 
 #include "exec/ExecutionObservers.h"
+#include "ir/Index.h"
 
 namespace onert
 {
@@ -39,11 +40,11 @@ public:
    * @param observer Observer to be added
    */
   void add(std::unique_ptr<IExecutionObserver> observer);
-  void notifySubgraphBegin(IExecutor *executor);
-  void notifySubgraphEnd(IExecutor *executor);
-  void notifyJobBegin(IExecutor *executor, const ir::OpSequence *op_seq,
+  void notifySubgraphBegin(ir::SubgraphIndex ind);
+  void notifySubgraphEnd(ir::SubgraphIndex ind);
+  void notifyJobBegin(IExecutor *executor, ir::SubgraphIndex index, const ir::OpSequence *op_seq,
                       const backend::Backend *backend);
-  void notifyJobEnd(IExecutor *executor, const ir::OpSequence *op_seq,
+  void notifyJobEnd(IExecutor *executor, ir::SubgraphIndex index, const ir::OpSequence *op_seq,
                     const backend::Backend *backend);
 
 private:

--- a/runtime/onert/core/src/exec/ExecutionObservers.cc
+++ b/runtime/onert/core/src/exec/ExecutionObservers.cc
@@ -80,8 +80,8 @@ namespace onert
 namespace exec
 {
 
-void ProfileObserver::handleJobBegin(onert::exec::IExecutor *, const ir::OpSequence *,
-                                     const onert::backend::Backend *backend)
+void ProfileObserver::handleJobBegin(onert::exec::IExecutor *, ir::SubgraphIndex,
+                                     const ir::OpSequence *, const onert::backend::Backend *backend)
 {
   _timer = backend->config()->timer();
   if (_timer == nullptr)
@@ -89,7 +89,7 @@ void ProfileObserver::handleJobBegin(onert::exec::IExecutor *, const ir::OpSeque
   _timer->handleBegin();
 }
 
-void ProfileObserver::handleJobEnd(IExecutor *exec, const ir::OpSequence *op_seq,
+void ProfileObserver::handleJobEnd(IExecutor *exec, ir::SubgraphIndex, const ir::OpSequence *op_seq,
                                    const backend::Backend *backend)
 {
   _timer->handleEnd();
@@ -141,14 +141,19 @@ TracingObserver::~TracingObserver()
   }
 }
 
-void TracingObserver::handleSubgraphBegin(IExecutor *)
+void TracingObserver::handleSubgraphBegin(ir::SubgraphIndex subg_ind)
 {
+  // TODO Write subg_ind into profling result
+  UNUSED_RELEASE(subg_ind);
   _collector.onEvent(EventCollector::Event{EventCollector::Edge::BEGIN, "runtime", "Graph"});
 }
 
-void TracingObserver::handleJobBegin(IExecutor *, const ir::OpSequence *op_seq,
-                                     const backend::Backend *backend)
+void TracingObserver::handleJobBegin(IExecutor *, ir::SubgraphIndex subg_ind,
+                                     const ir::OpSequence *op_seq, const backend::Backend *backend)
 {
+  // TODO Write subg_ind into profling result
+  UNUSED_RELEASE(subg_ind);
+
   std::string backend_id = backend->config()->id();
 
   auto ev = EventCollector::Event{EventCollector::Edge::BEGIN, backend_id,
@@ -159,16 +164,22 @@ void TracingObserver::handleJobBegin(IExecutor *, const ir::OpSequence *op_seq,
   _collector.onEvent(ev);
 }
 
-void TracingObserver::handleJobEnd(IExecutor *, const ir::OpSequence *op_seq,
-                                   const backend::Backend *backend)
+void TracingObserver::handleJobEnd(IExecutor *, ir::SubgraphIndex subg_ind,
+                                   const ir::OpSequence *op_seq, const backend::Backend *backend)
 {
+  // TODO Write subg_ind into profling result
+  UNUSED_RELEASE(subg_ind);
+
   std::string backend_id = backend->config()->id();
   _collector.onEvent(EventCollector::Event{EventCollector::Edge::END, backend_id,
                                            opSequenceTag(op_seq, _graph.operations())});
 }
 
-void TracingObserver::handleSubgraphEnd(IExecutor *)
+void TracingObserver::handleSubgraphEnd(ir::SubgraphIndex subg_ind)
 {
+  // TODO Write subg_ind into profling result
+  UNUSED_RELEASE(subg_ind);
+
   _collector.onEvent(EventCollector::Event{EventCollector::Edge::END, "runtime", "Graph"});
 }
 

--- a/runtime/onert/core/src/exec/ExecutionObservers.h
+++ b/runtime/onert/core/src/exec/ExecutionObservers.h
@@ -18,12 +18,14 @@
 #define __ONERT_EXEC_OBSREVERS_H__
 
 #include "exec/IFunction.h"
+#include "ir/Index.h"
 #include "ir/OpSequence.h"
 #include "ExecTime.h"
 #include "util/ITimer.h"
 #include "exec/IExecutor.h"
 #include "util/EventCollector.h"
 #include "util/EventRecorder.h"
+#include "util/EventWriter.h"
 #include "util/TracingCtx.h"
 
 namespace onert
@@ -34,13 +36,15 @@ class IExecutionObserver
 {
 public:
   /// @brief Invoked just before model (not individual operation) execution begins
-  virtual void handleSubgraphBegin(IExecutor *) { return; }
+  virtual void handleSubgraphBegin(ir::SubgraphIndex) { return; }
 
-  virtual void handleJobBegin(IExecutor *, const ir::OpSequence *, const backend::Backend *) = 0;
-  virtual void handleJobEnd(IExecutor *, const ir::OpSequence *, const backend::Backend *) = 0;
+  virtual void handleJobBegin(IExecutor *, ir::SubgraphIndex, const ir::OpSequence *,
+                              const backend::Backend *) = 0;
+  virtual void handleJobEnd(IExecutor *, ir::SubgraphIndex, const ir::OpSequence *,
+                            const backend::Backend *) = 0;
 
   /// @brief Invoked just after model (not individual operation) execution ends
-  virtual void handleSubgraphEnd(IExecutor *) { return; }
+  virtual void handleSubgraphEnd(ir::SubgraphIndex) { return; }
 
   virtual ~IExecutionObserver() = default;
 };
@@ -52,10 +56,12 @@ public:
       : _et(std::move(et)), _graph(graph)
   {
   }
-  void handleJobBegin(IExecutor *, const ir::OpSequence *, const backend::Backend *) override;
-  void handleJobEnd(IExecutor *, const ir::OpSequence *, const backend::Backend *) override;
+  void handleJobBegin(IExecutor *, ir::SubgraphIndex, const ir::OpSequence *,
+                      const backend::Backend *) override;
+  void handleJobEnd(IExecutor *, ir::SubgraphIndex, const ir::OpSequence *,
+                    const backend::Backend *) override;
 
-  void handleSubgraphEnd(IExecutor *) override { _et->storeOperationsExecTime(); }
+  void handleSubgraphEnd(ir::SubgraphIndex) override { _et->storeOperationsExecTime(); }
 
 private:
   std::unique_ptr<util::ITimer> _timer;
@@ -69,10 +75,12 @@ public:
   TracingObserver(const std::string &filepath, const ir::Graph &graph,
                   const util::TracingCtx *tracing_ctx);
   ~TracingObserver();
-  void handleSubgraphBegin(IExecutor *) override;
-  void handleJobBegin(IExecutor *, const ir::OpSequence *, const backend::Backend *) override;
-  void handleJobEnd(IExecutor *, const ir::OpSequence *, const backend::Backend *) override;
-  void handleSubgraphEnd(IExecutor *) override;
+  void handleSubgraphBegin(ir::SubgraphIndex) override;
+  void handleJobBegin(IExecutor *, ir::SubgraphIndex, const ir::OpSequence *,
+                      const backend::Backend *) override;
+  void handleJobEnd(IExecutor *, ir::SubgraphIndex, const ir::OpSequence *,
+                    const backend::Backend *) override;
+  void handleSubgraphEnd(ir::SubgraphIndex) override;
 
 private:
   static std::string opSequenceTag(const ir::OpSequence *op_seq, const ir::Operations &operations);


### PR DESCRIPTION
This passes subgraph index to ExecutionObservers, which will be later
used to organize profiling information.

Parent issue: #4901
Draft: #4903

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>