### PR TITLE
[onert] ostream overloads for index types

### DIFF
--- a/runtime/onert/backend/acl_cl/BackendContext.cc
+++ b/runtime/onert/backend/acl_cl/BackendContext.cc
@@ -69,7 +69,7 @@ void BackendContext::planTensors(const std::vector<onert::ir::OpSequenceIndex> &
     // Ignore unused tensor
     if (li->def_factors().size() == 0 && li->use_factors().size() == 0)
     {
-      VERBOSE(planTensors) << "Operand #" << ind.value() << " will not be used. no more process."
+      VERBOSE(planTensors) << "Operand " << ind << " will not be used. no more process."
                            << std::endl;
       return;
     }

--- a/runtime/onert/backend/acl_common/AclTensorManager.h
+++ b/runtime/onert/backend/acl_common/AclTensorManager.h
@@ -286,7 +286,7 @@ void AclTensorManager<T_ITensor, T_Tensor, T_SubTensor>::tryDeallocConstants(voi
     // used in several nodes.
     if (tensor->handle() && !tensor->handle()->is_used() && tensor->num_uses() < 2)
     {
-      VERBOSE(AclTensorManager) << "Tensor #" << ind.value()
+      VERBOSE(AclTensorManager) << "Tensor " << ind
                                 << " will be deallocated as an unused constant tensor" << std::endl;
       tensor->allocator()->free();
       tensor.reset();

--- a/runtime/onert/backend/acl_neon/BackendContext.cc
+++ b/runtime/onert/backend/acl_neon/BackendContext.cc
@@ -69,7 +69,7 @@ void BackendContext::planTensors(const std::vector<onert::ir::OpSequenceIndex> &
     // Ignore unused tensor
     if (li->def_factors().size() == 0 && li->use_factors().size() == 0)
     {
-      VERBOSE(planTensors) << "Operand #" << ind.value() << " will not be used. no more process."
+      VERBOSE(planTensors) << "Operand " << ind << " will not be used. no more process."
                            << std::endl;
       return;
     }

--- a/runtime/onert/core/include/backend/cpu_common/BackendContextHelpers.h
+++ b/runtime/onert/core/include/backend/cpu_common/BackendContextHelpers.h
@@ -59,8 +59,7 @@ void planTensors(const T_BackendContext &ctx, const std::vector<onert::ir::OpSeq
     // Ignore unused tensor
     if (li->def_factors().size() == 0 && li->use_factors().size() == 0)
     {
-      VERBOSE_F() << "Operand #" << ind.value() << " will not be used. no more process."
-                  << std::endl;
+      VERBOSE_F() << "Operand " << ind << " will not be used. no more process." << std::endl;
       return;
     }
 

--- a/runtime/onert/core/include/backend/cpu_common/ConstantInitializerBase.h
+++ b/runtime/onert/core/include/backend/cpu_common/ConstantInitializerBase.h
@@ -175,7 +175,7 @@ public:
       auto tensor_obj = tensor_registry()->getNativeITensor(ind);
       assert(tensor_obj != nullptr);
       fn(model_obj, *tensor_obj);
-      VERBOSE(FillOperandData) << "Fill data for operand " << ind.value() << std::endl;
+      VERBOSE(FillOperandData) << "Fill data for operand " << ind << std::endl;
     }
     _init_map.clear();
   }

--- a/runtime/onert/core/include/ir/Index.h
+++ b/runtime/onert/core/include/ir/Index.h
@@ -19,6 +19,8 @@
 
 #include "util/Index.h"
 
+#include <ostream>
+
 namespace onert
 {
 namespace ir
@@ -38,6 +40,40 @@ using OpSequenceIndex = ::onert::util::Index<uint32_t, OpSequenceIndexTag>;
 
 struct SubgraphIndexTag;
 using SubgraphIndex = ::onert::util::Index<uint32_t, SubgraphIndexTag>;
+
+template <typename IndexType>
+std::ostream &_index_print_impl(std::ostream &o, const std::string &prefix, IndexType index)
+{
+  if (index.undefined())
+    return o << prefix << std::string("?");
+  else
+    return o << prefix << index.value();
+}
+
+inline std::ostream &operator<<(std::ostream &o, const OperationIndex &i)
+{
+  return _index_print_impl(o, "OPERATION", i);
+}
+
+inline std::ostream &operator<<(std::ostream &o, const OperandIndex &i)
+{
+  return _index_print_impl(o, "$", i);
+}
+
+inline std::ostream &operator<<(std::ostream &o, const IOIndex &i)
+{
+  return _index_print_impl(o, "IO", i);
+}
+
+inline std::ostream &operator<<(std::ostream &o, const OpSequenceIndex &i)
+{
+  return _index_print_impl(o, "OPSEQUENCE", i);
+}
+
+inline std::ostream &operator<<(std::ostream &o, const SubgraphIndex &i)
+{
+  return _index_print_impl(o, "SUBGRAPH", i); // $ubgraph
+}
 
 } // namespace ir
 } // namespace onert

--- a/runtime/onert/core/include/util/Index.h
+++ b/runtime/onert/core/include/util/Index.h
@@ -138,14 +138,6 @@ public:
    */
   T value() const { return _index; }
 
-  friend std::ostream &operator<<(std::ostream &o, const Index &t)
-  {
-    if (t.undefined())
-      return o << std::string("undefined");
-    else
-      return o << t.value();
-  }
-
 private:
   T _index;
 };

--- a/runtime/onert/core/src/backend/cpu_common/DynamicTensorManager.cc
+++ b/runtime/onert/core/src/backend/cpu_common/DynamicTensorManager.cc
@@ -64,7 +64,7 @@ void DynamicTensorManager::deallocInput(ir::OperationIndex op_ind)
     cpu_tensor->resetBuffer();
 
     VERBOSE(DynamicTensorManager) << "Deallocating tensor " << (void *)cpu_tensor
-                                  << " (input of op_ind: " << op_ind.value() << ")" << std::endl;
+                                  << " (input of op_ind: " << op_ind << ")" << std::endl;
   }
 }
 

--- a/runtime/onert/core/src/backend/cpu_common/MemoryPlanner.cc
+++ b/runtime/onert/core/src/backend/cpu_common/MemoryPlanner.cc
@@ -31,13 +31,12 @@ void BumpPlanner::claim(const ir::OperandIndex &ind, size_t size)
   _mem_plans[ind] = blk;
   _capacity += size;
 
-  VERBOSE(BP_PLANNER) << "CLAIM(#" << ind.value() << "): " << blk.offset << ", " << blk.size
-                      << std::endl;
+  VERBOSE(BP_PLANNER) << "CLAIM(" << ind << "): " << blk.offset << ", " << blk.size << std::endl;
 }
 
 void BumpPlanner::release(const ir::OperandIndex &ind)
 {
-  VERBOSE(BP_PLANNER) << "RELEASE(#" << ind.value() << "): "
+  VERBOSE(BP_PLANNER) << "RELEASE(" << ind << "): "
                       << "NOTHING does" << std::endl;
 }
 
@@ -77,7 +76,7 @@ void FirstFitPlanner::claim(const ir::OperandIndex &ind, size_t size)
   _claim_table[next_offset] = ind;
   _mem_plans[ind] = {next_offset, size};
 
-  VERBOSE(FF_PLANNER) << "claim(#" << ind.value() << "): [+" << next_offset << ", " << size << "sz]"
+  VERBOSE(FF_PLANNER) << "claim(" << ind << "): [+" << next_offset << ", " << size << "sz]"
                       << std::endl;
 
   if (_capacity < next_offset + size)
@@ -98,7 +97,7 @@ void FirstFitPlanner::release(const ir::OperandIndex &ind)
 
       _claim_table.erase(it);
 
-      VERBOSE(FF_PLANNER) << "release(#" << index << "): [+" << offset << ", " << size << "sz]"
+      VERBOSE(FF_PLANNER) << "release(" << index << "): [+" << offset << ", " << size << "sz]"
                           << std::endl;
       return;
     }
@@ -124,13 +123,13 @@ void WICPlanner::claim(const ir::OperandIndex &ind, size_t size)
   }
   _live_operands.emplace(ind);
 
-  VERBOSE(WIC_PLANNER) << "claim(#" << ind.value() << "): [" << size << "sz]" << std::endl;
+  VERBOSE(WIC_PLANNER) << "claim(" << ind << "): [" << size << "sz]" << std::endl;
 }
 
 void WICPlanner::release(const ir::OperandIndex &ind)
 {
   _live_operands.erase(ind);
-  VERBOSE(WIC_PLANNER) << "release(#" << ind.value() << ")" << std::endl;
+  VERBOSE(WIC_PLANNER) << "release(" << ind << ")" << std::endl;
 }
 
 /*
@@ -148,7 +147,7 @@ void WICPlanner::buildMemoryPlans()
   {
     uint32_t size = operand.first;
     const ir::OperandIndex &ind = operand.second;
-    VERBOSE(WIC_PLANNER) << "build_plan(#" << ind.value() << "): [" << size << "sz]" << std::endl;
+    VERBOSE(WIC_PLANNER) << "build_plan(" << ind << "): [" << size << "sz]" << std::endl;
 
     uint32_t next_offset = 0;
     if (_interference_graph.count(ind))
@@ -184,8 +183,8 @@ void WICPlanner::buildMemoryPlans()
     }
 
     _mem_plans[ind] = {next_offset, size};
-    VERBOSE(WIC_PLANNER) << "alloc(#" << ind.value() << "): [+" << next_offset << ", " << size
-                         << "sz]" << std::endl;
+    VERBOSE(WIC_PLANNER) << "alloc(" << ind << "): [+" << next_offset << ", " << size << "sz]"
+                         << std::endl;
 
     if (_capacity < next_offset + size)
     {

--- a/runtime/onert/core/src/backend/cpu_common/StaticTensorManager.cc
+++ b/runtime/onert/core/src/backend/cpu_common/StaticTensorManager.cc
@@ -49,7 +49,7 @@ void StaticTensorManager::allocateNonconsts(void)
       tensor->setBuffer(buffer);
 
       VERBOSE(CPU_StaticTensorManager)
-        << "TENSOR(#" << ind.value() << "): " << static_cast<void *>(buffer) << std::endl;
+        << "TENSOR " << ind << " : " << static_cast<void *>(buffer) << std::endl;
     }
   }
 }

--- a/runtime/onert/core/src/compiler/Fp32ToFp16Converter.cc
+++ b/runtime/onert/core/src/compiler/Fp32ToFp16Converter.cc
@@ -405,7 +405,7 @@ void Fp32ToFp16Converter::convertOperandsOfOpSequence(ir::OpSequence &op_seq)
 
       obj.type(ir::DataType::FLOAT16);
 
-      VERBOSE(Fp32ToFp16Converter) << "Input Operand #" << ind.value() << ": fp16" << std::endl;
+      VERBOSE(Fp32ToFp16Converter) << "Input Operand " << ind << ": fp16" << std::endl;
     }
 
     for (auto &ind : node.getOutputs())
@@ -419,7 +419,7 @@ void Fp32ToFp16Converter::convertOperandsOfOpSequence(ir::OpSequence &op_seq)
 
       obj.type(ir::DataType::FLOAT16);
 
-      VERBOSE(Fp32ToFp16Converter) << "Output Operand #" << ind.value() << ": fp16" << std::endl;
+      VERBOSE(Fp32ToFp16Converter) << "Output Operand " << ind << ": fp16" << std::endl;
     }
   }
 }
@@ -444,7 +444,7 @@ void Fp32ToFp16Converter::convertDatas()
 
       obj.data(std::move(new_data));
       obj.type(ir::DataType::FLOAT16);
-      VERBOSE(Fp32ToFp16Converter) << "Constant Operand #" << ind.value() << ": fp16" << std::endl;
+      VERBOSE(Fp32ToFp16Converter) << "Constant Operand " << ind << ": fp16" << std::endl;
     }
   });
 }
@@ -759,9 +759,8 @@ Fp32ToFp16Converter::findOpSequencesContiguous(const InputToOpSeqs &input_to_op_
           opseq_map_to_delete[op_seq_ind_fp16_to_fp32].insert(op_seq_ind);
         }
 
-        VERBOSE(Fp32ToFp16Converter)
-          << "Contiguous from OpSeq#" << op_seq_ind_fp16_to_fp32.value() << "(ToFp32)"
-          << " to OpSeq#" << op_seq_ind.value() << "(ToFp16)" << std::endl;
+        VERBOSE(Fp32ToFp16Converter) << "Contiguous from " << op_seq_ind_fp16_to_fp32 << "(ToFp32)"
+                                     << " to " << op_seq_ind << "(ToFp16)" << std::endl;
       }
     }
   }
@@ -904,21 +903,21 @@ void Fp32ToFp16Converter::deleteContiguousOpSequences(
   {
     auto &op_seq = op_seqs.at(op_seq_ind);
     assert(op_seq.size() == 1);
-    VERBOSE(Fp32ToFp16Converter) << "Delete OpSeq #" << op_seq_ind.value() << std::endl;
+    VERBOSE(Fp32ToFp16Converter) << "Delete OpSeq " << op_seq_ind << std::endl;
 
     auto &first_node_ind = op_seq.operations().at(0);
     auto &first_node = operations.at(first_node_ind);
     assert(first_node.opcode() == ir::OpCode::ConvertFp32ToFp16 ||
            first_node.opcode() == ir::OpCode::ConvertFp16ToFp32);
-    VERBOSE(Fp32ToFp16Converter) << "Delete Node #" << first_node_ind.value() << std::endl;
+    VERBOSE(Fp32ToFp16Converter) << "Delete Node " << first_node_ind << std::endl;
 
     // Uses
     for (auto &ind : first_node.getInputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED)
     {
       auto &obj = operands.at(ind);
       obj.removeUse(first_node_ind);
-      VERBOSE(Fp32ToFp16Converter) << "Operand #" << ind.value() << "'s Use(Node#"
-                                   << first_node_ind.value() << ") is removed" << std::endl;
+      VERBOSE(Fp32ToFp16Converter)
+        << "Operand " << ind << "'s Use(Node" << first_node_ind << ") is removed" << std::endl;
     }
 
     // Def
@@ -927,24 +926,24 @@ void Fp32ToFp16Converter::deleteContiguousOpSequences(
       auto &obj = operands.at(ind);
       assert(obj.getDef() == first_node_ind);
       obj.unsetDef();
-      VERBOSE(Fp32ToFp16Converter) << "Operand #" << ind.value() << "'s Def(Node#"
-                                   << first_node_ind.value() << ") is removed" << std::endl;
+      VERBOSE(Fp32ToFp16Converter)
+        << "Operand " << ind << "'s Def(Node" << first_node_ind << ") is removed" << std::endl;
     }
 
     // Operation
     operations.remove(first_node_ind);
-    VERBOSE(Fp32ToFp16Converter) << "Node#" << first_node_ind.value() << " is removed" << std::endl;
+    VERBOSE(Fp32ToFp16Converter) << "Node" << first_node_ind << " is removed" << std::endl;
 
     // OpSequence
     op_seqs.remove(op_seq_ind);
-    VERBOSE(Fp32ToFp16Converter) << "OpSeq#" << op_seq_ind.value() << " is removed" << std::endl;
+    VERBOSE(Fp32ToFp16Converter) << "OpSeq" << op_seq_ind << " is removed" << std::endl;
   }
 
   // Operand
   for (auto &ind : list_to_delete_ops)
   {
     operands.remove(ind);
-    VERBOSE(Fp32ToFp16Converter) << "Operand #" << ind.value() << " is removed" << std::endl;
+    VERBOSE(Fp32ToFp16Converter) << "Operand " << ind << " is removed" << std::endl;
   }
 }
 

--- a/runtime/onert/core/src/compiler/HEScheduler.cc
+++ b/runtime/onert/core/src/compiler/HEScheduler.cc
@@ -101,7 +101,7 @@ void HEScheduler::scheduleShufflingBackends()
   size_t backend_ind = 0;
   for (const auto &rank : _rank_to_op)
   {
-    VERBOSE(HEScheduler::schedule) << "scheduling (" << rank.second.value() << ")" << std::endl;
+    VERBOSE(HEScheduler::schedule) << "scheduling (" << rank.second << ")" << std::endl;
     const auto &node = _graph->operations().at(rank.second);
     const bool quant = isQuant(*_graph, node);
     const auto size = getOperationsFlattenedIOSize(*_graph, node);
@@ -370,7 +370,7 @@ int64_t HEScheduler::DFSMaxRank(const ir::OperationIndex &index)
   _rank_to_op.emplace(rank, index);
   _op_to_rank->emplace(index, rank);
   VERBOSE(HEScheduler::DFSMaxRank)
-    << "rank of operation (" << index.value() << ")" << node.name() << " is " << rank << std::endl;
+    << "rank of operation (" << index << ")" << node.name() << " is " << rank << std::endl;
 
   return rank;
 }
@@ -428,7 +428,7 @@ int64_t HEScheduler::backendAvailableTime(const backend::Backend *backend,
 
 bool HEScheduler::schedule(const ir::OperationIndex &index, const backend::Backend *parent_backend)
 {
-  VERBOSE(HEScheduler::schedule) << "scheduling (" << index.value() << ")" << std::endl;
+  VERBOSE(HEScheduler::schedule) << "scheduling (" << index << ")" << std::endl;
   int64_t eft = std::numeric_limits<int64_t>::max(), selected_exec_time = 0;
   const auto &node = _graph->operations().at(index);
 
@@ -551,14 +551,14 @@ HEScheduler::ESTAndExecTime(const backend::Backend *backend, const ir::Operation
   if (!_is_parallel_exec)
   {
     VERBOSE(HEScheduler::ESTAndExecTime)
-      << "exec_time of (" << index.value() << ") " << node.name() << " quant==" << quant << " on "
+      << "exec_time of (" << index << ") " << node.name() << " quant==" << quant << " on "
       << backend->config()->id() << " is " << exec_time
       << " microseconds. Data transfer cost: " << total_transfer_cost << std::endl;
 
     return {total_transfer_cost, exec_time};
   }
   VERBOSE(HEScheduler::ESTAndExecTime)
-    << "exec_time of (" << index.value() << ") " << node.name() << " quant==" << quant << " on "
+    << "exec_time of (" << index << ") " << node.name() << " quant==" << quant << " on "
     << backend->config()->id() << ": " << exec_time
     << " microseconds. Backend available time: " << prev_op_ft
     << " Parent's max eft: " << max_pred_eft - total_transfer_cost

--- a/runtime/onert/core/src/compiler/LoweredGraph.cc
+++ b/runtime/onert/core/src/compiler/LoweredGraph.cc
@@ -310,8 +310,8 @@ void LoweredGraph::makeOpSequences(
       op_seq_index = new_op_seq_index;
       op_seq = &(_op_seqs.at(new_op_seq_index));
 
-      VERBOSE(Lower) << "OpSequence#" << op_seq_index.value() << " is created for "
-                     << "NODE#" << node_index.value() << "(" << node.name() << ")" << std::endl;
+      VERBOSE(Lower) << op_seq_index << " is created for " << node_index << "(" << node.name()
+                     << ")" << std::endl;
     }
     else
     {
@@ -326,8 +326,8 @@ void LoweredGraph::makeOpSequences(
       }
       op_seq->setInputs(new_inputs);
 
-      VERBOSE(Lower) << "OpSequence#" << op_seq_index.value() << " merges "
-                     << "NODE#" << node_index.value() << "(" << node.name() << ")" << std::endl;
+      VERBOSE(Lower) << op_seq_index << " merges " << node_index << "(" << node.name() << ")"
+                     << std::endl;
     }
   });
 }
@@ -422,7 +422,7 @@ void LoweredGraph::dumpLowerInfo()
       std::string use_ops = operation_index_to_string(object.getUses());
       std::string def_layouts = factors_to_string(lower_info->def_factors());
       std::string use_layouts = factors_to_string(lower_info->use_factors());
-      sstream << "Operand #" << index.value() << " LowerInfo" << std::endl;
+      sstream << "Operand " << index << " LowerInfo" << std::endl;
       sstream << "  - Shape           : { ";
       for (auto i = 0; i < shape.rank(); ++i)
       {
@@ -466,10 +466,10 @@ bool LoweredGraph::mergeable(const ir::OpSequenceIndex &op_seq_index,
     const auto op_seq_backend_layout = getLowerInfo(op_seq_index)->layout();
     const auto &op_seq_backend_id = getLowerInfo(op_seq_index)->backend()->config()->id();
     const auto &node_backend_id = backend_resolver.getBackend(node_index)->config()->id();
-    VERBOSE(Lower) << "OpSequence#" << op_seq_index.value() << " { " << op_seq_backend_id << "("
+    VERBOSE(Lower) << "OpSequence" << op_seq_index << " { " << op_seq_backend_id << "("
                    << to_string(op_seq_backend_layout) << ") } "
-                   << " NODE#" << node_index.value() << " (" << node.name() << ") { "
-                   << node_backend_id << "(" << to_string(layout) << ") } " << std::endl;
+                   << " NODE" << node_index << " (" << node.name() << ") { " << node_backend_id
+                   << "(" << to_string(layout) << ") } " << std::endl;
     if (op_seq_backend_id != node_backend_id || op_seq_backend_layout != layout)
       return false;
   }
@@ -535,9 +535,9 @@ bool LoweredGraph::mergeable(const ir::OpSequenceIndex &op_seq_index,
       {
         if (node_outputs.contains(input))
         {
-          VERBOSE(Lower) << "OpSequence#" << op_seq_index.value() << " 's NODE#" << n_index.value()
-                         << "(" << n.name() << ") is connected to NODE#" << node_index.value()
-                         << "(" << node.name() << ")" << std::endl;
+          VERBOSE(Lower) << "OpSequence" << op_seq_index << " 's NODE" << n_index.value() << "("
+                         << n.name() << ") is connected to NODE" << node_index.value() << "("
+                         << node.name() << ")" << std::endl;
           return true;
         }
       }
@@ -547,16 +547,15 @@ bool LoweredGraph::mergeable(const ir::OpSequenceIndex &op_seq_index,
       {
         if (node_inputs.contains(output))
         {
-          VERBOSE(Lower) << "OpSequence#" << op_seq_index.value() << " 's NODE#" << n_index.value()
-                         << " (" << n.name() << ") is connected to NODE#" << node_index.value()
-                         << std::endl;
+          VERBOSE(Lower) << "OpSequence" << op_seq_index << " 's NODE" << n_index.value() << " ("
+                         << n.name() << ") is connected to NODE" << node_index.value() << std::endl;
           return true;
         }
       }
     }
 
-    VERBOSE(Lower) << "OpSequence#" << op_seq_index.value() << " is not connected to NODE#"
-                   << node_index.value() << "(" << node.name() << ")" << std::endl;
+    VERBOSE(Lower) << "OpSequence" << op_seq_index << " is not connected to NODE" << node_index
+                   << "(" << node.name() << ")" << std::endl;
   }
 
   return false;

--- a/runtime/onert/core/src/compiler/ManualScheduler.cc
+++ b/runtime/onert/core/src/compiler/ManualScheduler.cc
@@ -94,16 +94,16 @@ std::unique_ptr<BackendResolver> ManualScheduler::schedule(const ir::Graph &grap
     }
     catch (...)
     {
-      VERBOSE(ManualScheduler) << "Invalid value while OperationIndex to Backend mapping : @"
-                               << key.value() << " -> \"" << val << "\"" << std::endl;
+      VERBOSE(ManualScheduler) << "Invalid value while OperationIndex to Backend mapping : @" << key
+                               << " -> \"" << val << "\"" << std::endl;
     }
   }
 
   // Dump final assignment
   WHEN_LOG_ENABLED(backend_resolver->iterate(
     [&](const ir::OperationIndex &index, const backend::Backend &backend) {
-      VERBOSE(ManualScheduler) << "backend for operation #" << index.value() << ": "
-                               << backend.config()->id() << std::endl;
+      VERBOSE(ManualScheduler) << "backend for " << index << ": " << backend.config()->id()
+                               << std::endl;
     }));
 
   return backend_resolver;

--- a/runtime/onert/core/src/compiler/StaticShapeInferer.cc
+++ b/runtime/onert/core/src/compiler/StaticShapeInferer.cc
@@ -132,12 +132,12 @@ void StaticShapeInferer::dump()
   {
     const auto index = pair.first;
     const auto &lowered_subg = pair.second;
-    VERBOSE(StaticShapeInferer) << "SubGraph #" << index.value() << std::endl;
+    VERBOSE(StaticShapeInferer) << index << std::endl;
     lowered_subg->graph().operands().iterate(
       [&](const ir::OperandIndex &ind, const ir::Operand &operand) {
-        VERBOSE(StaticShapeInferer) << "Operand #" << ind.value() << ", "
-                                    << (operand.info().isDynamic() ? "Dynamic" : "Static") << ", "
-                                    << get_shape_str(operand.info().shape()) << std::endl;
+        VERBOSE(StaticShapeInferer)
+          << ind << ", " << (operand.info().isDynamic() ? "Dynamic" : "Static") << ", "
+          << get_shape_str(operand.info().shape()) << std::endl;
       });
   }
 }

--- a/runtime/onert/core/src/dumper/dot/DotBuilder.cc
+++ b/runtime/onert/core/src/dumper/dot/DotBuilder.cc
@@ -37,18 +37,18 @@ void DotBuilder::update(const Node &node_info)
 
 void DotBuilder::addOpSequence(const DotSubgraphInfo &subgraph_info)
 {
-  _dot << "subgraph cluster_" << subgraph_info.index().value() << " {\n";
+  _dot << "subgraph cluster_" << subgraph_info.index() << " {\n";
   _dot << "  label=\"" << subgraph_info.label() << "\";\n";
   _dot << "  style=filled;\n";
   _dot << "  color=lightgrey;\n";
   _dot << "  ";
   for (auto op : subgraph_info.operations())
   {
-    _dot << "operation" << op.value() << "; ";
+    _dot << "operation" << op << "; ";
   }
   for (auto op : subgraph_info.operands())
   {
-    _dot << "operand" << op.value() << "; ";
+    _dot << "operand" << op << "; ";
   }
   _dot << "\n";
   _dot << "}\n";

--- a/runtime/onert/core/src/exec/DataflowExecutor.cc
+++ b/runtime/onert/core/src/exec/DataflowExecutor.cc
@@ -90,8 +90,8 @@ DataflowExecutor::DataflowExecutor(std::unique_ptr<compiler::LoweredGraph> lower
   uint32_t next_job_index = 0;
   std::unordered_map<ir::OpSequenceIndex, uint32_t> op_seq_to_job;
   op_seqs.iterate([&](const ir::OpSequenceIndex &op_seq_index, const ir::OpSequence &) {
-    VERBOSE(DataflowExecutor) << "Create a job #" << next_job_index << " with OpSequenceIndex "
-                              << op_seq_index.value() << std::endl;
+    VERBOSE(DataflowExecutor) << "Create a job " << next_job_index << " with OpSequenceIndex "
+                              << op_seq_index << std::endl;
     _finished_jobs.emplace_back(
       std::make_unique<Job>(next_job_index, _code_map.at(op_seq_index).fn_seq.get()));
     op_seq_to_job[op_seq_index] = next_job_index++;
@@ -150,7 +150,7 @@ void DataflowExecutor::executeImpl()
     auto job = std::move((_ready_jobs.begin())->second);
     _ready_jobs.erase(_ready_jobs.begin());
     auto job_index = job->index();
-    VERBOSE(DataflowExecutor) << "Run job #" << job_index << std::endl;
+    VERBOSE(DataflowExecutor) << "Run job " << job_index << std::endl;
 
     auto op_seq_index = _job_to_op_seq[job_index];
     auto op_seq = &_lowered_graph->op_seqs().at(op_seq_index);

--- a/runtime/onert/core/src/exec/Execution.cc
+++ b/runtime/onert/core/src/exec/Execution.cc
@@ -40,7 +40,7 @@ void Execution::changeInputShape(const ir::IOIndex &index, const ir::Shape &new_
   _io_desc.dynamic_input_shapes[index] = new_shape;
 
   VERBOSE(Execution) << "Model input shape will be changed at the start of execute()"
-                     << "(index: " << index.value() << ")" << std::endl;
+                     << "(index: " << index << ")" << std::endl;
 }
 
 // TODO Remove default parameter
@@ -159,7 +159,7 @@ ir::Shape Execution::getInputShape(ir::IOIndex ind) const
   auto itr = _io_desc.dynamic_input_shapes.find(ind);
   if (itr == _io_desc.dynamic_input_shapes.end())
   {
-    auto operand_idx = primary_subgraph().getInputs().at(ind.value());
+    auto operand_idx = primary_subgraph().getInputs().at(ind);
     return primary_subgraph().operands().at(operand_idx).shape();
   }
   else

--- a/runtime/onert/core/src/exec/ParallelExecutor.cc
+++ b/runtime/onert/core/src/exec/ParallelExecutor.cc
@@ -121,7 +121,7 @@ void ParallelExecutor::executeImpl()
 
     lock.unlock();
 
-    VERBOSE(ParallelExecutor) << "Assigning fn #" << job->index() << std::endl;
+    VERBOSE(ParallelExecutor) << "Assigning fn " << job->index() << std::endl;
 
     auto job_index = job->index();
     auto op_sequence_index = _job_to_op_seq[job_index];

--- a/runtime/onert/core/src/interp/InterpExecutor.cc
+++ b/runtime/onert/core/src/interp/InterpExecutor.cc
@@ -66,7 +66,7 @@ void InterpExecutor::execute(const exec::IODescription &desc)
   {
     if (tensor_map.find(index) != tensor_map.end())
     {
-      VERBOSE(INTERPRETER) << "Assign input tensor. operand index:" << index.value() << std::endl;
+      VERBOSE(INTERPRETER) << "Assign input tensor. operand index:" << index << std::endl;
       interp_env->assignTensor(index, tensor_map.at(index));
     }
   }
@@ -94,7 +94,7 @@ void InterpExecutor::execute(const exec::IODescription &desc)
   _graph.operands().iterate([&](const ir::OperandIndex &ind, const ir::Operand &obj) {
     if (obj.isConstant())
     {
-      VERBOSE(INTERPRETER) << "Allocate and assign constant tensor. operand index:" << ind.value()
+      VERBOSE(INTERPRETER) << "Allocate and assign constant tensor. operand index:" << ind
                            << std::endl;
 
       assert(obj.data());

--- a/runtime/onert/core/src/interp/Interpreter.cc
+++ b/runtime/onert/core/src/interp/Interpreter.cc
@@ -49,7 +49,7 @@ public:
     const ir::Operation &node = _env->graph().operations().at(idx);
     const auto nodeName = node.name();
     VERBOSE(INTERPRETER) << "Prepare output operands and execute " << nodeName
-                         << " operation (id: " << idx.value() << ")" << std::endl;
+                         << " operation (id: " << idx << ")" << std::endl;
 
     const auto nodeOpCode = node.opcode();
     if (_kernels.find(nodeOpCode) == _kernels.end())
@@ -83,7 +83,7 @@ void Interpreter::run()
   //       But that scenario may not exist
   for (auto ind : _env->graph().getInputs())
   {
-    VERBOSE(INTERPRETER) << "Input: Push to operand stack " << ind.value() << std::endl;
+    VERBOSE(INTERPRETER) << "Input: Push to operand stack " << ind << std::endl;
 
     operand_stack.push(ind);
   }
@@ -91,7 +91,7 @@ void Interpreter::run()
   _env->graph().operands().iterate([&](const ir::OperandIndex &ind, const ir::Operand &obj) {
     if (obj.isConstant())
     {
-      VERBOSE(INTERPRETER) << "Constant: Push to operand stack " << ind.value() << std::endl;
+      VERBOSE(INTERPRETER) << "Constant: Push to operand stack " << ind << std::endl;
 
       operand_stack.push(ind);
     }
@@ -129,7 +129,7 @@ void Interpreter::run()
 
       if (operator_ready)
       {
-        VERBOSE(INTERPRETER) << "Ready to execute operation " << use_operator.value() << std::endl;
+        VERBOSE(INTERPRETER) << "Ready to execute operation " << use_operator << std::endl;
         operation_stack.push(use_operator);
       }
     }
@@ -138,7 +138,7 @@ void Interpreter::run()
     {
       const auto current_operation_index = operation_stack.top();
       operation_stack.pop();
-      VERBOSE(INTERPRETER) << "Poped operation: " << current_operation_index.value() << "("
+      VERBOSE(INTERPRETER) << "Poped operation: " << current_operation_index << "("
                            << _env->graph().operations().at(current_operation_index).name() << ")"
                            << std::endl;
 

--- a/runtime/onert/core/src/ir/Graph.cc
+++ b/runtime/onert/core/src/ir/Graph.cc
@@ -148,7 +148,7 @@ void Graph::sweepGarbageOperands()
   operands().iterate([&](const OperandIndex &ind, const Operand &) {
     if (!visited[ind])
     {
-      VERBOSE(Graph::sweepGarbageOperands) << "Sweep garbage operand " << ind.value() << std::endl;
+      VERBOSE(Graph::sweepGarbageOperands) << "Sweep garbage operand " << ind << std::endl;
       operands().remove(ind);
     }
   });

--- a/runtime/onert/core/src/ir/OpSequence.cc
+++ b/runtime/onert/core/src/ir/OpSequence.cc
@@ -25,12 +25,12 @@ namespace
 
 std::string getStrFromIndice(const onert::ir::OperandIndexSequence &indice)
 {
-  std::string str;
+  std::stringstream sstr;
   for (const auto &ind : indice)
   {
-    str += std::to_string(ind.value());
-    str.push_back(',');
+    sstr << ind << ',';
   }
+  auto str = sstr.str();
   if (str.back() == ',')
     str.pop_back();
 
@@ -53,12 +53,12 @@ void OpSequence::accept(OperationVisitor &v) const { v.visit(*this); }
 // TODO: Impl Dumper instead of this method
 std::string getStrFromOpSeq(const OpSequence &op_seq, const Operations &operations)
 {
-  // "  OpSequence IN(0,1,2) -> { op0(0,1,2:3), op1(3:4), op2(4:5) } -> OUT(5)"
+  // "  IN($0,$1,$2) -> { OPERATION0($0,$1,$2:$3), op1($3:$4), op2($4:$5) } -> OUT($5)"
   std::stringstream ss;
-  ss << "  OpSequence IN(" << getStrFromIndice(op_seq.getInputs()) << ") -> {";
+  ss << " IN(" << getStrFromIndice(op_seq.getInputs()) << ") -> {";
   for (const auto &op_idx : op_seq)
   {
-    ss << " " << op_idx.value() << "(" << operations.at(op_idx).name() << ":"
+    ss << " " << op_idx << "(" << operations.at(op_idx).name() << ":"
        << getStrFromIndice(operations.at(op_idx).getInputs()) << ":"
        << getStrFromIndice(operations.at(op_idx).getOutputs()) << ")";
   }

--- a/runtime/onert/core/src/ir/OpSequences.cc
+++ b/runtime/onert/core/src/ir/OpSequences.cc
@@ -116,7 +116,7 @@ OpSequenceIndex OpSequences::findOperation(const OperationIndex &operation_index
 void dumpOpSequences(const OpSequences &op_seqs, const Operations &operations)
 {
   op_seqs.iterate([&](const OpSequenceIndex &idx, const OpSequence &op_seq) {
-    VERBOSE(OpSequences) << idx.value() << "] " << getStrFromOpSeq(op_seq, operations) << std::endl;
+    VERBOSE(OpSequences) << idx << "] " << getStrFromOpSeq(op_seq, operations) << std::endl;
   });
 }
 


### PR DESCRIPTION
Introduce ostream overloads for index types. Each types of indexes
has its own prefix.

Plus, this commit includes usage fixes.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>

## 5+ Reviews to merge