### PR TITLE
[onert] Reuse cpu_common::planTensors

### DIFF
--- a/runtime/onert/core/include/backend/cpu_common/BackendContextHelpers.h
+++ b/runtime/onert/core/include/backend/cpu_common/BackendContextHelpers.h
@@ -43,9 +43,14 @@ void planTensors(const T_BackendContext &ctx, const std::vector<onert::ir::OpSeq
   ir::OperandIndexMap<uint32_t> def_map;
   ir::OperandIndexSequence constants;
 
+  auto model_io =
+      (graph->getInputs() + graph->getOutputs()) | ir::Remove::UNDEFINED | ir::Remove::DUPLICATED;
+
   // Prepare scanning
   for (auto ind : ctx.operand_list())
   {
+    if (model_io.contains(ind))
+      continue;
     const auto &obj = graph->operands().at(ind);
     const auto &li = lower_info.operand.at(ind);
     if (li->def_factors().getOnlyElement().backend() != ctx.backend())
@@ -104,6 +109,8 @@ void planTensors(const T_BackendContext &ctx, const std::vector<onert::ir::OpSeq
       // Define outputs
       for (const auto &ind : op_outputs)
       {
+        if (model_io.contains(ind))
+          continue;
         if (!tensor_builder->isRegistered(ind))
           continue;
         assert(def_map.find(ind) != def_map.end());
@@ -119,6 +126,8 @@ void planTensors(const T_BackendContext &ctx, const std::vector<onert::ir::OpSeq
       // non-constant because of less memory usage by memory planning in here
       for (const auto &ind : op_inputs)
       {
+        if (model_io.contains(ind))
+          continue;
         if (!tensor_builder->isRegistered(ind))
           continue;
         const auto &operand = graph->operands().at(ind);
@@ -136,6 +145,8 @@ void planTensors(const T_BackendContext &ctx, const std::vector<onert::ir::OpSeq
 
       for (const auto &ind : op_inputs)
       {
+        if (model_io.contains(ind))
+          continue;
         if (!tensor_builder->isRegistered(ind))
           continue;
         assert(uses_map.find(ind) != uses_map.end());

--- a/runtime/onert/core/src/backend/controlflow/BackendContext.cc
+++ b/runtime/onert/core/src/backend/controlflow/BackendContext.cc
@@ -17,6 +17,7 @@
 #include "BackendContext.h"
 
 #include "KernelGenerator.h"
+#include "backend/cpu_common/BackendContextHelpers.h"
 
 namespace onert
 {
@@ -43,152 +44,6 @@ void BackendContext::initConsts()
   }
 
   constant_initializer->run();
-}
-
-void BackendContext::planTensors(const std::vector<onert::ir::OpSequenceIndex> &order,
-                                 const ir::OpSequences &op_seqs, const ir::LowerInfoMap &lower_info)
-{
-  ir::OperandIndexMap<uint32_t> uses_map;
-  ir::OperandIndexMap<uint32_t> def_map;
-  ir::OperandIndexSequence constants;
-
-  auto model_io = (graph()->getInputs() + graph()->getOutputs()) | ir::Remove::UNDEFINED |
-                  ir::Remove::DUPLICATED;
-
-  // Prepare scanning
-  for (auto ind : operand_list())
-  {
-    if (model_io.contains(ind))
-      continue;
-    const auto &obj = graph()->operands().at(ind);
-    const auto &li = lower_info.operand.at(ind);
-    if (li->def_factors().getOnlyElement().backend() != backend())
-      continue;
-
-    // Ignore unused tensor
-    if (li->def_factors().size() == 0 && li->use_factors().size() == 0)
-      return;
-
-    uses_map[ind] = obj.getUses().size();
-    def_map[ind] = obj.getDef().valid() ? 1 : 0;
-
-    if (obj.isConstant())
-      constants.append(ind);
-
-    auto factor = li->def_factors().getOnlyElement();
-    if (!tensor_builder->isRegistered(ind))
-    {
-      // These tensors do not exist in any op_seq (No use and def)
-      const auto info = obj.info();
-      const auto backend_layout = factor.layout();
-      // TODO Change tensor info to have permuted shape
-      tensor_builder->registerTensorInfo(ind, info, backend_layout);
-    }
-  }
-
-  // Start scanning to do notify{First|Last}Use for each tensor
-
-  // If a tensor is a constant, increase the use of the tensor and allocate it first.
-  // Increasing use count here makes the tensor never be deallocated, i.e it they will be
-  // deallocated last.
-  for (const auto &ind : constants)
-  {
-    uses_map[ind]++;
-    tensor_builder->notifyFirstUse(ind);
-  }
-
-  // At each operation,
-  // 1. Scan DEF of outputs. If the DEF, allocate it
-  // 2. Scan DEF of inputs. If variable tensor, allocate it
-  // 3. Scan USE of inputs. Decrease the USE and deallocate if the USE is 0
-  for (const auto op_seq_ind : order)
-  {
-    const auto &op_seq = op_seqs.at(op_seq_ind);
-    for (const auto &op_idx : op_seq.operations())
-    {
-      auto op_inputs = graph()->operations().at(op_idx).getInputs() | ir::Remove::DUPLICATED |
-                       ir::Remove::UNDEFINED;
-      auto op_outputs = graph()->operations().at(op_idx).getOutputs() | ir::Remove::DUPLICATED |
-                        ir::Remove::UNDEFINED;
-
-      // Define outputs
-      for (const auto &ind : op_outputs)
-      {
-        if (model_io.contains(ind))
-          continue;
-        if (!tensor_builder->isRegistered(ind))
-          continue;
-        assert(def_map.find(ind) != def_map.end());
-        if (def_map[ind])
-        {
-          def_map[ind] = 0;
-          tensor_builder->notifyFirstUse(ind);
-        }
-      }
-
-      // Scan variable tensors
-      // This tensor has features like constant. But OperandInfo and LowerInfo treat them as
-      // non-constant because of less memory usage by memory planning in here
-      for (const auto &ind : op_inputs)
-      {
-        if (model_io.contains(ind))
-          continue;
-        if (!tensor_builder->isRegistered(ind))
-          continue;
-        const auto &operand = graph()->operands().at(ind);
-        if (operand.info().isVariable())
-        {
-          // The variable tensor with buffer is not supported yet
-          assert(operand.data() == nullptr);
-          assert(operand.getUses().size() == 1 && !operand.getDef().valid());
-          assert(lower_info.operand.at(ind)->def_factors().size() == 1 &&
-                 lower_info.operand.at(ind)->use_factors().size() == 1);
-          assert(uses_map[ind] == 1 && def_map[ind] == 0);
-          tensor_builder->notifyFirstUse(ind);
-        }
-      }
-
-      for (const auto &ind : op_inputs)
-      {
-        if (model_io.contains(ind))
-          continue;
-        if (!tensor_builder->isRegistered(ind))
-          continue;
-        assert(uses_map.find(ind) != uses_map.end());
-        assert(uses_map[ind] > 0);
-        uses_map[ind]--;
-        if (uses_map[ind] == 0)
-        {
-          // plan for deallocation of static tensornode
-          tensor_builder->notifyLastUse(ind);
-
-          // plan for deallocation of dynamic tensor
-          auto dyn_tensor_manager = tensor_builder->dynamicTensorManager();
-          auto *tensor = tensor_registry->getITensor(ind);
-          assert(tensor);
-          dyn_tensor_manager->planDealloc(op_idx, tensor);
-        }
-      }
-    }
-  }
-
-  // Dispose and validate
-  for (const auto &ind : constants)
-  {
-    --uses_map[ind];
-    if (uses_map[ind] == 0) // To prevent notifyLastUse from being called twice
-    {
-      tensor_builder->notifyLastUse(ind);
-    }
-  }
-
-  assert(
-      std::all_of(uses_map.begin(), uses_map.end(),
-                  [](std::pair<const ir::OperandIndex, uint32_t> it) { return it.second == 0; }));
-
-  assert(
-      std::all_of(def_map.begin(), def_map.end(),
-                  [](std::pair<const ir::OperandIndex, uint32_t> it) { return it.second == 0; }));
 }
 
 ITensorRegistry *BackendContext::genTensors(const std::vector<onert::ir::OpSequenceIndex> &order,
@@ -225,7 +80,7 @@ ITensorRegistry *BackendContext::genTensors(const std::vector<onert::ir::OpSeque
   // TODO Get compiler options from compiler, and use it rather than getting it from Env
   if (util::getConfigString(util::config::EXECUTOR) == "Linear")
   {
-    planTensors(order, op_seqs, lower_info);
+    cpu_common::planTensors(*this, order, op_seqs, lower_info);
   }
   else
   {


### PR DESCRIPTION
Make controlflow backend reuse `cpu_common::planTensors`.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>