### PR TITLE
[onert] Make EventWriter work with multiple TracingObservers

### DIFF
--- a/runtime/onert/core/src/exec/ExecutionObservers.h
+++ b/runtime/onert/core/src/exec/ExecutionObservers.h
@@ -25,6 +25,7 @@
 #include "util/EventCollector.h"
 #include "util/EventRecorder.h"
 #include "util/TracingCtx.h"
+#include "util/EventWriter.h"
 
 namespace onert
 {
@@ -78,10 +79,10 @@ private:
   static std::string opSequenceTag(const ir::OpSequence *op_seq, const ir::Operations &operations);
 
 private:
-  const std::string &_base_filepath;
-  EventRecorder _recorder;
+  std::unique_ptr<EventRecorder> _recorder;
   EventCollector _collector;
   const ir::Graph &_graph;
+  EventWriter *_event_writer;
   const util::TracingCtx *_tracing_ctx;
 };
 


### PR DESCRIPTION
Parent issue: #4901
Draft: #4903

This makes `EventWriter` work with multiple `TracingObserver`s.

Background:
- One `TracingObserver` is allocated to one executor.
- When a model contains multiple subgraphs, each subgraph is run by
  its executor.
- When multiple `TracingObserver`s are destroyed
  profiling file should be written after destroying the last `TracingObject`.

Note:
- `EventWriter` is implemented as a singleton but guarded with mutex.
- To fully profile a model with multiple subgraphs, more PRs should be pushed to write subgraph index into profiling data.

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>
