### PR TITLE
[infra] General build command for `./nnfw build`

### DIFF
--- a/infra/nnfw/command/build
+++ b/infra/nnfw/command/build
@@ -8,4 +8,4 @@ if [[ ! -d "${BUILD_PATH}" ]]; then
 fi
 
 cd ${BUILD_PATH}
-make "$@"
+cmake --build . -- "$@"


### PR DESCRIPTION
General build command for `./nnfw build`, this allows other build tools
that are generated by CMake, not only 'Make' but 'Ninja' and so on.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>