### PR TITLE
[onert] Rename nnfw_session::load_model_from_file()

### DIFF
--- a/runtime/onert/api/src/nnfw_api.cc
+++ b/runtime/onert/api/src/nnfw_api.cc
@@ -90,7 +90,7 @@ NNFW_STATUS nnfw_close_session(nnfw_session *session)
 NNFW_STATUS nnfw_load_model_from_file(nnfw_session *session, const char *pacakge_file_path)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->load_model_from_file(pacakge_file_path);
+  return session->load_model_from_nnpackage(pacakge_file_path);
 }
 
 /*

--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -244,7 +244,7 @@ NNFW_STATUS nnfw_session::load_model_from_modelfile(const char *model_file_path)
   return NNFW_STATUS_NO_ERROR;
 }
 
-NNFW_STATUS nnfw_session::load_model_from_file(const char *package_dir)
+NNFW_STATUS nnfw_session::load_model_from_nnpackage(const char *package_dir)
 {
   if (!isStateInitialized())
     return NNFW_STATUS_INVALID_STATE;

--- a/runtime/onert/api/src/nnfw_api_internal.h
+++ b/runtime/onert/api/src/nnfw_api_internal.h
@@ -101,7 +101,7 @@ public:
   nnfw_session();
   ~nnfw_session();
 
-  NNFW_STATUS load_model_from_file(const char *package_file_path);
+  NNFW_STATUS load_model_from_nnpackage(const char *package_file_path);
   NNFW_STATUS prepare();
   NNFW_STATUS run();
 


### PR DESCRIPTION
Rename `nnfw_session::load_model_from_file()` to
`nnfw_session::load_model_from_nnpackage()`.

Why?
- We already have `nnfw_session::load_model_from_modelfile()` and
the name, `nnfw_session::load_model_from_file()`, is very broad
any make people confused when they want to run, e.g., circle file.

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>