### PR TITLE
[onert] Fix wrong parameter in while dumper

### DIFF
--- a/runtime/onert/core/src/ir/OperationDumper.cc
+++ b/runtime/onert/core/src/ir/OperationDumper.cc
@@ -520,7 +520,7 @@ void OperationDumper::visit(const While &node)
   }
   VERBOSE(LIR) << "  - Inputs : "
                << "Cond subgraph (" << node.param().cond_subg_index << ") Body subgraph ("
-               << node.param().cond_subg_index << ") Inputs(" << inputs << ")" << std::endl;
+               << node.param().body_subg_index << ") Inputs(" << inputs << ")" << std::endl;
   std::string outputs;
   const auto &output_indices = node.getOutputs();
   for (auto it = std::begin(output_indices); it != std::end(output_indices); ++it)


### PR DESCRIPTION
This commit will fix wrong parameter in `while` operation dumper

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>