### PR TITLE
[compute] Update clang-format

### DIFF
--- a/compute/.clang-format
+++ b/compute/.clang-format
@@ -1,0 +1,1 @@
+../.clang-format.8

--- a/compute/ARMComputeEx/.clang-format
+++ b/compute/ARMComputeEx/.clang-format
@@ -1,1 +1,0 @@
-../../.clang-format.8

--- a/compute/cker/.clang-format
+++ b/compute/cker/.clang-format
@@ -1,1 +1,0 @@
-../../.clang-format.8

--- a/compute/ruy/.clang-format
+++ b/compute/ruy/.clang-format
@@ -1,1 +1,0 @@
-../../.clang-format.8

--- a/compute/test/cker/Range.cc
+++ b/compute/test/cker/Range.cc
@@ -48,9 +48,7 @@ TEST(CKer_Operation, Range)
     const float start = 3;
     const float limit = 1;
     const float delta = -0.5;
-    std::vector<float> expected = {
-        3, 2.5, 2, 1.5,
-    };
+    std::vector<float> expected = {3, 2.5, 2, 1.5};
     std::vector<float> actual(expected.size());
     nnfw::cker::Range<float>(&start, &limit, &delta, actual.data());
 


### PR DESCRIPTION
Use clang-format-8 style for all compute library and test

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>