### PR TITLE
[onert] Use fixed-width prefix for logging

### DIFF
--- a/runtime/onert/core/include/util/logging.h
+++ b/runtime/onert/core/include/util/logging.h
@@ -18,6 +18,7 @@
 #define __ONERT_UTIL_LOGGING_H__
 
 #include <iostream>
+#include <cstring>
 
 #include "util/ConfigSource.h"
 
@@ -52,17 +53,26 @@ private:
 
 static Context &ctx = Context::get();
 
+inline std::string decorated_name(const char *input)
+{
+  const int min_prefix = 16;
+  std::string prefix(input);
+  auto spaces_len = prefix.length() > min_prefix ? 0 : ((min_prefix - prefix.length()) / 2);
+  std::string spaces(spaces_len, ' ');
+  return (prefix.length() % 2 ? "[ " : "[") + spaces + prefix + spaces + "] ";
+}
+
 } // namespace logging
 } // namespace util
 } // namespace onert
 
 #define VERBOSE(name)                        \
   if (::onert::util::logging::ctx.enabled()) \
-  std::cout << "[" << #name << "] "
+  std::cout << ::onert::util::logging::decorated_name(#name)
 
 #define VERBOSE_F()                          \
   if (::onert::util::logging::ctx.enabled()) \
-  std::cout << "[" << __func__ << "] "
+  std::cout << ::onert::util::logging::decorated_name(__func__)
 
 #define WHEN_LOG_ENABLED(METHOD)             \
   if (::onert::util::logging::ctx.enabled()) \


### PR DESCRIPTION
It uses fixed-width prefix for printing modules or function names.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>