### PR TITLE
[onert] Fix when subgraph shapes are not updated

### DIFF
--- a/runtime/onert/core/src/backend/controlflow/IOTensor.h
+++ b/runtime/onert/core/src/backend/controlflow/IOTensor.h
@@ -82,6 +82,9 @@ public:
     return _tensor->applyShape(shape);
   }
 
+public:
+  void setShapeOfIPortableTensor(const ir::Shape &shape) { _info.shape(shape); }
+
 private:
   const ir::OperandInfo _orig_info;
   const ir::Layout _orig_layout;

--- a/runtime/onert/core/src/exec/ExecutorBase.cc
+++ b/runtime/onert/core/src/exec/ExecutorBase.cc
@@ -68,6 +68,12 @@ void ExecutorBase::execute(const std::vector<backend::IPortableTensor *> &inputs
       const auto orig_input_shape = input_tensor->orig_info().shape();
       const auto changed_input_shape =
         convertShape(input->getShape(), input->layout(), input_tensor->orig_layout());
+      if (input_tensor->get_info().shape() != changed_input_shape)
+      {
+        // TODO Fix this workaround that is introduced since cpu based kernels directly use `_info`
+        // rather than interface methods to avoid virtual function calls.
+        input_tensor->setShapeOfIPortableTensor(changed_input_shape);
+      }
       if (orig_input_shape != changed_input_shape)
       {
         input_tensor->set_dynamic();


### PR DESCRIPTION
For `IOTensor`, it must update `_info` as well.
This is actually a workaround.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>