### PR TITLE
[onert] add indentation for each subgraph in StaticShapeInferer

### DIFF
--- a/runtime/onert/core/src/compiler/StaticShapeInferer.cc
+++ b/runtime/onert/core/src/compiler/StaticShapeInferer.cc
@@ -136,7 +136,7 @@ void StaticShapeInferer::dump()
     lowered_subg->graph().operands().iterate(
       [&](const ir::OperandIndex &ind, const ir::Operand &operand) {
         VERBOSE(StaticShapeInferer)
-          << ind << ", " << (operand.info().isDynamic() ? "Dynamic" : "Static") << ", "
+          << "  " << ind << ", " << (operand.info().isDynamic() ? "Dynamic" : "Static") << ", "
           << get_shape_str(operand.info().shape()) << std::endl;
       });
   }


### PR DESCRIPTION
It adds indentation for each subgraph's information.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>