### PR TITLE
[one-cmds] add command option to one-codegen

### DIFF
--- a/compiler/one-cmds/one-codegen
+++ b/compiler/one-cmds/one-codegen
@@ -87,24 +87,19 @@ def main():
     # verify arguments
     _verify_arg(parser, args)
 
-    # get file path to log
+    # make a command to run given backend driver
     dir_path = os.path.dirname(os.path.realpath(__file__))
-    logfile_path = os.path.realpath(args.output_path) + '.log'
+    codegen_path = os.path.join(dir_path, getattr(args, 'backend') + '-compile')
+    codegen_cmd = [codegen_path] + unknown_args
+    if _utils._is_valid_attr(args, 'command'):
+        codegen_cmd += getattr(args, 'command').split()
 
-    with open(logfile_path, 'wb') as f:
-        # make a command to run given backend driver
-        codegen_path = os.path.join(dir_path, getattr(args, 'backend') + '-compile')
-        codegen_cmd = [codegen_path] + unknown_args
-
-        f.write((' '.join(codegen_cmd) + '\n').encode())
-
-        # run backend driver
-        with subprocess.Popen(
-                codegen_cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-                bufsize=1) as p:
-            for line in p.stdout:
-                sys.stdout.buffer.write(line)
-                f.write(line)
+    # run backend driver
+    with subprocess.Popen(
+            codegen_cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            bufsize=1) as p:
+        for line in p.stdout:
+            sys.stdout.buffer.write(line)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This commit has two changes.
- Don't make a log file
`one-codegen` is a driver that runs specific backend driver given from user. Other `one-cmds` driver generates the log file whose name is from its output file. But we can't determine the name of log file in case of `one-codegen` because we can't know the output file name in advance. Also, since we generates a log file for testing, we don't need the log file here because `backend` test should be tested at `backend` repo:)

- Add command option to configuration file
We can't know what the command is in advance because there are many different backend. So, `command` option will be written by its user.

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>