### PR TITLE
[onert] Remove unnamed namespaces in headers

### DIFF
--- a/runtime/onert/backend/acl_common/AclLinearMemoryManager.h
+++ b/runtime/onert/backend/acl_common/AclLinearMemoryManager.h
@@ -23,7 +23,11 @@
 #include "ir/OperandIndexMap.h"
 #include "util/logging.h"
 
-namespace
+namespace onert
+{
+namespace backend
+{
+namespace acl_common
 {
 
 template <typename T_MemoryManager, typename T_PoolManager, typename T_LifetimeManager>
@@ -36,15 +40,6 @@ std::shared_ptr<T_MemoryManager> createMemoryManager()
     std::make_shared<T_MemoryManager>(lifetime_mgr, pool_mgr);
   return mem_mgr;
 }
-
-} // namespace
-
-namespace onert
-{
-namespace backend
-{
-namespace acl_common
-{
 
 template <typename T_ITensor, typename T_Tensor, typename T_SubTensor, typename T_MemoryManager,
           typename T_PoolManager, typename T_LifetimeManager, typename T_Allocator,

--- a/runtime/onert/backend/cpu/ExternalContext.h
+++ b/runtime/onert/backend/cpu/ExternalContext.h
@@ -20,11 +20,6 @@
 #include <util/ConfigSource.h>
 #include <ruy/context.h>
 
-namespace
-{
-const int kDefaultNumThreadpoolThreads = 1;
-}
-
 namespace onert
 {
 namespace backend
@@ -34,6 +29,9 @@ namespace cpu
 
 class ExternalContext
 {
+private:
+  static const int kDefaultNumThreadpoolThreads = 1;
+
 public:
   ExternalContext() : _ruy_context(new ruy::Context)
   {

--- a/runtime/onert/backend/ruy/ExternalContext.h
+++ b/runtime/onert/backend/ruy/ExternalContext.h
@@ -20,11 +20,6 @@
 #include <util/ConfigSource.h>
 #include <ruy/context.h>
 
-namespace
-{
-const int kDefaultNumThreadpoolThreads = 4;
-}
-
 namespace onert
 {
 namespace backend
@@ -34,6 +29,9 @@ namespace ruy
 
 class ExternalContext
 {
+private:
+  static const int kDefaultNumThreadpoolThreads = 4;
+
 public:
   ExternalContext() : _ruy_context(new ::ruy::Context)
   {

--- a/runtime/onert/backend/xnnpack/BackendContext.h
+++ b/runtime/onert/backend/xnnpack/BackendContext.h
@@ -24,10 +24,7 @@
 #include "KernelGenerator.h"
 #include "ExternalContext.h"
 
-namespace
-{
 const int kDefaultNumThreadpoolThreads = 1;
-}
 
 namespace onert
 {

--- a/runtime/onert/core/include/backend/cpu_common/ConstantInitializerBase.h
+++ b/runtime/onert/core/include/backend/cpu_common/ConstantInitializerBase.h
@@ -30,8 +30,13 @@
 #include "util/logging.h"
 #include "backend/ITensorRegistry.h"
 
-namespace
+namespace onert
 {
+namespace backend
+{
+namespace cpu_common
+{
+
 template <typename T>
 static void Init(const onert::ir::Operand &model_obj, onert::backend::ITensor &obj, const bool copy,
                  const onert::ir::Layout frontend_layout = onert::ir::Layout::UNKNOWN)
@@ -147,15 +152,6 @@ void permuteInit(const onert::ir::Operand &model_obj, onert::backend::ITensor &o
   const bool copy = frontend_layout == obj.layout();
   Init<T>(model_obj, obj, copy, frontend_layout);
 }
-
-} // namespace
-
-namespace onert
-{
-namespace backend
-{
-namespace cpu_common
-{
 
 class ConstantInitializerBase : public ir::OperationVisitor
 {

--- a/runtime/onert/core/src/backend/controlflow/ExternalContext.h
+++ b/runtime/onert/core/src/backend/controlflow/ExternalContext.h
@@ -24,11 +24,6 @@
 #include <ruy/ctx.h>
 #include <ruy/tune.h>
 
-namespace
-{
-const int kDefaultNumThreadpoolThreads = 1;
-}
-
 namespace onert
 {
 namespace backend
@@ -39,6 +34,9 @@ namespace controlflow
 // TODO Unify this with cpu::ExternalContext
 class ExternalContext
 {
+private:
+  static const int kDefaultNumThreadpoolThreads = 1;
+
 public:
   ExternalContext() : _ruy_context(std::make_unique<ruy::Context>())
   {


### PR DESCRIPTION
Unnamed namespaces in headers are almost always bad since:

> Due to default internal linkage, each translation unit will define its
  own unique instance of members of the unnamed namespace that are
  ODR-used within that translation unit.
> This can cause unexpected results, bloat the resulting executable, or
  inadvertently trigger undefined behavior due to one-definition rule
  (ODR) violations.

See also:

https://wiki.sei.cmu.edu/confluence/display/cplusplus/DCL59-CPP.+Do+not+define+an+unnamed+namespace+in+a+header+file
http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#sf21-dont-use-an-unnamed-anonymous-namespace-in-a-header

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>