### PR TITLE
[onert] Refine TensorBuilder impl

### DIFF
--- a/runtime/onert/core/include/backend/cpu_common/BackendContextHelpers.h
+++ b/runtime/onert/core/include/backend/cpu_common/BackendContextHelpers.h
@@ -237,7 +237,7 @@ ITensorRegistry *genTensors(T_BackendContext &ctx,
     }
   }
 
-  tensor_builder->prepare();
+  tensor_builder->allocate();
 
   return ctx.tensor_registry.get();
 }

--- a/runtime/onert/core/include/backend/cpu_common/TensorBuilder.h
+++ b/runtime/onert/core/include/backend/cpu_common/TensorBuilder.h
@@ -53,11 +53,7 @@ public:
 
   bool isRegistered(const ir::OperandIndex &) const;
 
-  void prepare(void);
-  void allocate();
-  void postFunctionPrepare()
-  { /* DO NOTHING */
-  }
+  void allocate(void);
 
   IDynamicTensorManager *dynamicTensorManager(void) { return _dynamic_tensor_mgr.get(); }
 

--- a/runtime/onert/core/src/backend/controlflow/BackendContext.cc
+++ b/runtime/onert/core/src/backend/controlflow/BackendContext.cc
@@ -93,7 +93,7 @@ ITensorRegistry *BackendContext::genTensors(const std::vector<onert::ir::OpSeque
     }
   }
 
-  tensor_builder->prepare();
+  tensor_builder->allocate();
 
   return tensor_registry.get();
 }

--- a/runtime/onert/core/src/backend/controlflow/TensorBuilder.cc
+++ b/runtime/onert/core/src/backend/controlflow/TensorBuilder.cc
@@ -89,13 +89,7 @@ bool TensorBuilder::isRegistered(const ir::OperandIndex &ind) const
   return _tensor_info_map.find(ind) != _tensor_info_map.end();
 }
 
-void TensorBuilder::prepare(void) { _static_tensor_mgr->allocateNonconsts(); }
-
-void TensorBuilder::allocate()
-{
-  // NOTE For now nothing to do. Allocation is done in prepare stage, which is not appropriate
-  //      This is because CPU kernels require `ITensor`s to be allocated before Kernel Generation.
-}
+void TensorBuilder::allocate(void) { _static_tensor_mgr->allocateNonconsts(); }
 
 DynamicTensorManager *TensorBuilder::dynamicTensorManager(void)
 {

--- a/runtime/onert/core/src/backend/controlflow/TensorBuilder.h
+++ b/runtime/onert/core/src/backend/controlflow/TensorBuilder.h
@@ -53,11 +53,7 @@ public:
 
   bool isRegistered(const ir::OperandIndex &) const;
 
-  void prepare(void);
-  void allocate();
-  void postFunctionPrepare()
-  { /* DO NOTHING */
-  }
+  void allocate(void);
 
   DynamicTensorManager *dynamicTensorManager(void);
 

--- a/runtime/onert/core/src/backend/cpu_common/TensorBuilder.cc
+++ b/runtime/onert/core/src/backend/cpu_common/TensorBuilder.cc
@@ -76,13 +76,7 @@ bool TensorBuilder::isRegistered(const ir::OperandIndex &ind) const
   return _tensor_info_map.find(ind) != _tensor_info_map.end();
 }
 
-void TensorBuilder::prepare(void) { _static_tensor_mgr->allocateNonconsts(); }
-
-void TensorBuilder::allocate()
-{
-  // NOTE For now nothing to do. Allocation is done in prepare stage, which is not appropriate
-  //      This is because CPU kernels require `ITensor`s to be allocated before Kernel Generation.
-}
+void TensorBuilder::allocate(void) { _static_tensor_mgr->allocateNonconsts(); }
 
 } // namespace cpu_common
 } // namespace backend


### PR DESCRIPTION
Refine controlflow/cpu_common TensorBuilder implemenatation.

- Remove method `postFunctionPrepare`
- Remove method `allocate`
- Rename method `prepare` to `allocate`

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>