### PR TITLE
[onert] Remove unused member in TensorBuilder

### DIFF
--- a/runtime/onert/core/src/backend/controlflow/TensorBuilder.cc
+++ b/runtime/onert/core/src/backend/controlflow/TensorBuilder.cc
@@ -40,15 +40,13 @@ void TensorBuilder::registerTensorInfo(const ir::OperandIndex &ind, const ir::Op
 {
   _tensor_info_map.emplace(ind, info);
 
-  _tensor_layout_map.insert({ind, backend_layout});
-
   if (info.isDynamic())
   {
-    _dynamic_tensor_mgr->buildTensor(ind, info, _tensor_layout_map[ind]);
+    _dynamic_tensor_mgr->buildTensor(ind, info, backend_layout);
   }
   else
   {
-    _static_tensor_mgr->buildTensor(ind, info, _tensor_layout_map[ind], info.isConstant());
+    _static_tensor_mgr->buildTensor(ind, info, backend_layout, info.isConstant());
   }
 }
 

--- a/runtime/onert/core/src/backend/controlflow/TensorBuilder.h
+++ b/runtime/onert/core/src/backend/controlflow/TensorBuilder.h
@@ -74,7 +74,6 @@ private:
   std::unique_ptr<DynamicTensorManager> _dynamic_tensor_mgr;
   std::unique_ptr<cpu_common::StaticTensorManager> _static_tensor_mgr;
   ir::OperandIndexMap<ir::OperandInfo> _tensor_info_map;
-  ir::OperandIndexMap<ir::Layout> _tensor_layout_map;
 };
 
 } // namespace controlflow


### PR DESCRIPTION
Remove unused member `_tensor_layout_map` in TensorBuilder.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>