### PR TITLE
[onert] Tidy onert logging

### DIFF
--- a/runtime/onert/core/include/util/logging.h
+++ b/runtime/onert/core/include/util/logging.h
@@ -57,9 +57,11 @@ inline std::string decorated_name(const char *input)
 {
   const int min_prefix = 16;
   std::string prefix(input);
-  auto spaces_len = prefix.length() > min_prefix ? 0 : ((min_prefix - prefix.length()) / 2);
-  std::string spaces(spaces_len, ' ');
-  return (prefix.length() % 2 ? "[ " : "[") + spaces + prefix + spaces + "] ";
+  auto len_prefix = prefix.size();
+  if (len_prefix > min_prefix)
+    return "[" + prefix + "] ";
+  std::string spaces((min_prefix - len_prefix) / 2, ' ');
+  return (len_prefix % 2 ? "[ " : "[") + spaces + prefix + spaces + "] ";
 }
 
 } // namespace logging

--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -170,8 +170,7 @@ std::shared_ptr<exec::ExecutorMap> Compiler::compile(void)
   }
 
   {
-    VERBOSE(Compiler) << std::boolalpha;
-    VERBOSE(Compiler) << "==== Compiler Options ====" << std::endl;
+    VERBOSE(Compiler) << std::boolalpha << "==== Compiler Options ====" << std::endl;
     VERBOSE(Compiler) << "backend_list             : "
                       << nnfw::misc::join(_options.backend_list.begin(),
                                           _options.backend_list.end(), "/")
@@ -188,8 +187,8 @@ std::shared_ptr<exec::ExecutorMap> Compiler::compile(void)
     VERBOSE(Compiler) << "he_scheduler             : " << _options.he_scheduler << std::endl;
     VERBOSE(Compiler) << "he_profiling_mode        : " << _options.he_profiling_mode << std::endl;
     VERBOSE(Compiler) << "disable_compile          : " << _options.disable_compile << std::endl;
-    VERBOSE(Compiler) << "fp16_enable              : " << _options.fp16_enable << std::endl;
-    VERBOSE(Compiler) << std::noboolalpha;
+    VERBOSE(Compiler) << "fp16_enable              : " << _options.fp16_enable << std::endl
+                      << std::noboolalpha;
   }
 
   _subgraphs->iterate([&](const ir::SubgraphIndex &, ir::Graph &subg) {

--- a/runtime/onert/core/src/compiler/LoweredGraph.cc
+++ b/runtime/onert/core/src/compiler/LoweredGraph.cc
@@ -145,7 +145,7 @@ LoweredGraph::LoweredGraph(const ir::Graph &graph, const CompilerOptions &option
   {
     assert(ir::verifier::InputOutputChecker().verify(_graph));
     assert(ir::verifier::DAGChecker().verify(_graph));
-    assert(ir::verifier::EdgeConsistencyChecker().verify(_graph));
+    assert(ir::verifier::EdgeChecker().verify(_graph));
   }
 }
 

--- a/runtime/onert/core/src/ir/Graph.cc
+++ b/runtime/onert/core/src/ir/Graph.cc
@@ -102,7 +102,7 @@ void Graph::finishBuilding(void)
       throw std::runtime_error{"One of model input and output operands does not exist."};
     if (!verifier::DAGChecker().verify(*this))
       throw std::runtime_error{"The graph is cyclic."};
-    assert(verifier::EdgeConsistencyChecker().verify(*this));
+    assert(verifier::EdgeChecker().verify(*this));
   }
 
   // Check shape independent operation feature

--- a/runtime/onert/core/src/ir/verifier/Verifier.cc
+++ b/runtime/onert/core/src/ir/verifier/Verifier.cc
@@ -72,7 +72,7 @@ bool DAGChecker::verify(const Graph &graph) const noexcept
 // EdgeConsistencyVerifier
 //
 
-bool EdgeConsistencyChecker::verify(const Graph &graph) const noexcept
+bool EdgeChecker::verify(const Graph &graph) const noexcept
 {
   auto &operations = graph.operations();
   uint32_t errors = 0;
@@ -85,17 +85,16 @@ bool EdgeConsistencyChecker::verify(const Graph &graph) const noexcept
         bool operand_has_use = operand.getUses().contains(index);
         if (!operand_has_use)
         {
-          VERBOSE(EdgeConsistencyChecker)
-            << "[ERROR] EDGE MISMATCH : Missing USE edge - Operand " << operand_index
-            << " to Operation " << index << std::endl;
+          VERBOSE(EdgeChecker) << "[ERROR] EDGE MISMATCH : Missing USE edge - Operand "
+                               << operand_index << " to Operation " << index << std::endl;
           errors += 1;
         }
       }
       catch (const std::out_of_range &e)
       {
-        VERBOSE(EdgeConsistencyChecker)
-          << "[ERROR] OPEARAND NOT FOUND : Operation " << index << " has Operand " << operand_index
-          << ", but the operand object is not present in the graph" << std::endl;
+        VERBOSE(EdgeChecker) << "[ERROR] OPEARAND NOT FOUND : Operation " << index
+                             << " has Operand " << operand_index
+                             << ", but the operand object is not present in the graph" << std::endl;
         errors += 1;
       }
     }
@@ -106,23 +105,22 @@ bool EdgeConsistencyChecker::verify(const Graph &graph) const noexcept
         auto &operand = graph.operands().at(operand_index);
         if (operand.getDef() != index)
         {
-          VERBOSE(EdgeConsistencyChecker)
-            << "[ERROR] EDGE MISMATCH : Missing DEF edge - Operand" << operand_index
-            << " to Operation " << index << std::endl;
+          VERBOSE(EdgeChecker) << "[ERROR] EDGE MISMATCH : Missing DEF edge - Operand"
+                               << operand_index << " to Operation " << index << std::endl;
           errors += 1;
         }
       }
       catch (const std::out_of_range &e)
       {
-        VERBOSE(EdgeConsistencyChecker)
-          << "[ERROR] OPEARAND NOT FOUND : Operation " << index << " has Operand " << operand_index
-          << ", but the operand object is not present in the graph" << std::endl;
+        VERBOSE(EdgeChecker) << "[ERROR] OPEARAND NOT FOUND : Operation " << index
+                             << " has Operand " << operand_index
+                             << ", but the operand object is not present in the graph" << std::endl;
         errors += 1;
       }
     }
   });
 
-  VERBOSE(EdgeConsistencyChecker) << "Total Number of errors : " << errors << std::endl;
+  VERBOSE(EdgeChecker) << "Total Number of errors : " << errors << std::endl;
 
   return errors == 0;
 }

--- a/runtime/onert/core/src/ir/verifier/Verifier.h
+++ b/runtime/onert/core/src/ir/verifier/Verifier.h
@@ -55,7 +55,7 @@ public:
   bool verify(const Graph &graph) const noexcept override;
 };
 
-class EdgeConsistencyChecker : public IVerifier
+class EdgeChecker : public IVerifier
 {
 public:
   bool verify(const Graph &graph) const noexcept override;

--- a/runtime/onert/test/graph/verifier/Verifier.cc
+++ b/runtime/onert/test/graph/verifier/Verifier.cc
@@ -68,7 +68,7 @@ TEST(Verifier, neg_edge_consistency_checker_1)
 
   graph.operands().at(operand1).removeUse(op_ind); // Manipulate the operand alone
 
-  onert::ir::verifier::EdgeConsistencyChecker verifier;
+  onert::ir::verifier::EdgeChecker verifier;
   ASSERT_FALSE(verifier.verify(graph));
 }
 
@@ -93,6 +93,6 @@ TEST(Verifier, neg_edge_consistency_checker_2)
 
   mock_op_ptr->setInputs({operand2}); // Manipulate the operation alone
 
-  onert::ir::verifier::EdgeConsistencyChecker verifier;
+  onert::ir::verifier::EdgeChecker verifier;
   ASSERT_FALSE(verifier.verify(graph));
 }


### PR DESCRIPTION
: Remove redundant space for prefix > 16
: Rename EdgeConsistencyValidator to EdgeChecker.
: Remove not-intended log of "[  Compiler ] for format-setting.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>