### PR TITLE
[onert] Refine cpu_common::Tenosr::applyShape

### DIFF
--- a/runtime/onert/core/include/backend/cpu_common/Tensor.h
+++ b/runtime/onert/core/include/backend/cpu_common/Tensor.h
@@ -53,24 +53,12 @@ public:
   /**
    * @brief Set the Buffer object. This method is called for static and non-const tensor
    */
-  void setBuffer(uint8_t *buffer)
-  {
-    assert(_buffer == nullptr);
-    _buffer = buffer;
-  }
+  void setBuffer(uint8_t *buffer) { _buffer = buffer; }
 
   /**
    * @brief Set the Buffer object. This method is called for dynamic or const tensor
    */
   void setBuffer(const std::shared_ptr<Allocator> &alloc)
-  {
-    assert(_buffer == nullptr);
-    _allocator = alloc;
-    _buffer = alloc->base();
-  }
-
-  // This works just as setBuffer but it simply overwrite existing Allocator without nullptr check
-  void overwriteBuffer(const std::shared_ptr<Allocator> &alloc)
   {
     _allocator = alloc;
     _buffer = alloc->base();


### PR DESCRIPTION
- Revise `allocTensorMem` (Remove param `overwrite`)
- Merge two cases - "previously static" and "buffer is null"
- Remove method `overwriteTensor`

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>