### PR TITLE
Requires libarmcl for arm architecture

### DIFF
--- a/packaging/nnfw.spec
+++ b/packaging/nnfw.spec
@@ -39,6 +39,10 @@ BuildRequires:  python
 BuildRequires:  libarmcl-devel >= v20.05
 %endif
 
+%ifarch %{arm} aarch64
+Requires: libarmcl
+%endif
+
 Requires(post): /sbin/ldconfig
 Requires(postun): /sbin/ldconfig
 


### PR DESCRIPTION
- Add libarmcl runtime dep into spec file

Change-Id: If9beb0722d2c4fa55ea811a6a5bd4053bd67c2e0
Signed-off-by: Chunseok Lee <chunseok.lee@samsung.com>