### PR TITLE
[circle-inspect] Update clang-format version

### DIFF
--- a/compiler/circle-inspect/.clang-format
+++ b/compiler/circle-inspect/.clang-format
@@ -1,0 +1,1 @@
+../../.clang-format.8

--- a/compiler/circle-inspect/driver/Driver.cpp
+++ b/compiler/circle-inspect/driver/Driver.cpp
@@ -29,11 +29,11 @@
 int entry(int argc, char **argv)
 {
   arser::Arser arser{
-      "circle-inspect allows users to retrieve various information from a Circle model file"};
+    "circle-inspect allows users to retrieve various information from a Circle model file"};
   arser.add_argument("--operators").nargs(0).help("Dump operators in circle file");
   arser.add_argument("--conv2d_weight")
-      .nargs(0)
-      .help("Dump Conv2D series weight operators in circle file");
+    .nargs(0)
+    .help("Dump Conv2D series weight operators in circle file");
   arser.add_argument("--op_version").nargs(0).help("Dump versions of the operators in circle file");
   arser.add_argument("circle").type(arser::DataType::STR).help("Circle file to inspect");
 


### PR DESCRIPTION
Use clang-format-8 style for circle-inspect

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>