### PR TITLE
[circle-quantizer] Update clang-format version

### DIFF
--- a/compiler/circle-quantizer/.clang-format
+++ b/compiler/circle-quantizer/.clang-format
@@ -1,0 +1,1 @@
+../../.clang-format.8

--- a/compiler/circle-quantizer/src/CircleQuantizer.cpp
+++ b/compiler/circle-quantizer/src/CircleQuantizer.cpp
@@ -65,35 +65,35 @@ int entry(int argc, char **argv)
   arser::Arser arser("circle-quantizer provides circle model quantization");
 
   arser.add_argument("--version")
-      .nargs(0)
-      .required(false)
-      .default_value(false)
-      .help("Show version information and exit")
-      .exit_with(print_version);
+    .nargs(0)
+    .required(false)
+    .default_value(false)
+    .help("Show version information and exit")
+    .exit_with(print_version);
 
   arser.add_argument(qdqw)
-      .nargs(3)
-      .type(arser::DataType::STR_VEC)
-      .required(false)
-      .help("Quantize-dequantize weight values required action before quantization. "
-            "Three arguments required: input_dtype(float32) "
-            "output_dtype(uint8) granularity(layer, channel)");
+    .nargs(3)
+    .type(arser::DataType::STR_VEC)
+    .required(false)
+    .help("Quantize-dequantize weight values required action before quantization. "
+          "Three arguments required: input_dtype(float32) "
+          "output_dtype(uint8) granularity(layer, channel)");
 
   arser.add_argument(qwmm)
-      .nargs(3)
-      .type(arser::DataType::STR_VEC)
-      .required(false)
-      .help("Quantize with min/max values. "
-            "Three arguments required: input_dtype(float32) "
-            "output_dtype(uint8) granularity(layer, channel)");
+    .nargs(3)
+    .type(arser::DataType::STR_VEC)
+    .required(false)
+    .help("Quantize with min/max values. "
+          "Three arguments required: input_dtype(float32) "
+          "output_dtype(uint8) granularity(layer, channel)");
 
   arser.add_argument(rq)
-      .nargs(2)
-      .type(arser::DataType::STR_VEC)
-      .required(false)
-      .help("Requantize a quantized model. "
-            "Two arguments required: input_dtype(int8) "
-            "output_dtype(uint8)");
+    .nargs(2)
+    .type(arser::DataType::STR_VEC)
+    .required(false)
+    .help("Requantize a quantized model. "
+          "Two arguments required: input_dtype(int8) "
+          "output_dtype(uint8)");
 
   arser.add_argument("input").nargs(1).type(arser::DataType::STR).help("Input circle model");
   arser.add_argument("output").nargs(1).type(arser::DataType::STR).help("Output circle model");


### PR DESCRIPTION
Use clang-format-8 style for circle-quantizer

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>