### PR TITLE
[circle-tensordump] Update clang-format version

### DIFF
--- a/compiler/circle-tensordump/.clang-format
+++ b/compiler/circle-tensordump/.clang-format
@@ -1,0 +1,1 @@
+../../.clang-format.8

--- a/compiler/circle-tensordump/driver/Driver.cpp
+++ b/compiler/circle-tensordump/driver/Driver.cpp
@@ -29,14 +29,14 @@
 int entry(int argc, char **argv)
 {
   arser::Arser arser{
-      "circle-tensordump allows users to retrieve tensor information from a Circle model file"};
+    "circle-tensordump allows users to retrieve tensor information from a Circle model file"};
 
   arser.add_argument("circle").nargs(1).type(arser::DataType::STR).help("Circle file path to dump");
   arser.add_argument("--tensors").nargs(0).help("Dump to console");
   arser.add_argument("--tensors_to_hdf5")
-      .nargs(1)
-      .type(arser::DataType::STR)
-      .help("Dump to hdf5 file. Specify hdf5 file path to be dumped");
+    .nargs(1)
+    .type(arser::DataType::STR)
+    .help("Dump to hdf5 file. Specify hdf5 file path to be dumped");
 
   try
   {

--- a/compiler/circle-tensordump/src/Dump.cpp
+++ b/compiler/circle-tensordump/src/Dump.cpp
@@ -253,7 +253,7 @@ void write_vector_data_to_hdf5(H5::H5File &file, std::string &group_name, std::s
     return;
   auto dataspace = std::make_unique<H5::DataSpace>(dims.size(), dims.data());
   auto dataset = std::make_unique<H5::DataSet>(
-      file.createDataSet(group_name + "/" + dataset_name, type, *dataspace));
+    file.createDataSet(group_name + "/" + dataset_name, type, *dataspace));
   dataset->write(data->data(), type);
 }
 
@@ -264,7 +264,7 @@ void write_scalar_data_to_hdf5(H5::H5File &file, std::string &group_name, std::s
 {
   auto dataspace = std::make_unique<H5::DataSpace>(H5S_SCALAR);
   auto dataset = std::make_unique<H5::DataSet>(
-      file.createDataSet(group_name + "/" + dataset_name, type, *dataspace));
+    file.createDataSet(group_name + "/" + dataset_name, type, *dataspace));
   dataset->write(&data, type);
 }
 
@@ -308,7 +308,7 @@ void DumpTensorsToHdf5::run(std::ostream &os, const circle::Model *model,
       // create a group for each tensor whose name is its tensor name
       std::string group_name = ::mangle(tensor->name()->c_str());
       std::unique_ptr<H5::Group> tensor_group =
-          std::make_unique<H5::Group>(file.createGroup(group_name));
+        std::make_unique<H5::Group>(file.createGroup(group_name));
 
       // write a buffer data
       uint32_t buff_idx = tensor->buffer();


### PR DESCRIPTION
Use clang-format-8 style for circle-tensordump

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>