### PR TITLE
[coco] Update clang-format version

### DIFF
--- a/compiler/coco/.clang-format
+++ b/compiler/coco/.clang-format
@@ -1,0 +1,1 @@
+../../.clang-format.8

--- a/compiler/coco/core/include/coco/IR/FeatureShape.h
+++ b/compiler/coco/core/include/coco/IR/FeatureShape.h
@@ -31,13 +31,13 @@ class FeatureShape : public nncc::core::ADT::feature::Shape
 {
 public:
   FeatureShape(uint32_t depth, uint32_t height, uint32_t width)
-      : Shape{depth, height, width}, _batch{1}
+    : Shape{depth, height, width}, _batch{1}
   {
     // DO NOTHING
   }
 
   FeatureShape(uint32_t batch, uint32_t depth, uint32_t height, uint32_t width)
-      : Shape{depth, height, width}, _batch{batch}
+    : Shape{depth, height, width}, _batch{batch}
   {
     // DO NOTHING
   }

--- a/compiler/coco/core/include/coco/IR/Locatable.h
+++ b/compiler/coco/core/include/coco/IR/Locatable.h
@@ -24,7 +24,7 @@ namespace coco
 
 /**
  * @brief Return the associated instruction if exists.
-  */
+ */
 struct Locatable
 {
   virtual ~Locatable() = default;

--- a/compiler/coco/core/include/coco/IR/Ops.h
+++ b/compiler/coco/core/include/coco/IR/Ops.h
@@ -407,6 +407,6 @@ public:
   const Sqrt *asSqrt(void) const override { return this; }
 };
 
-} // namesapce coco
+} // namespace coco
 
 #endif // __COCO_IR_OPS_H__

--- a/compiler/coco/core/include/coco/IR/Padding2D.h
+++ b/compiler/coco/core/include/coco/IR/Padding2D.h
@@ -32,7 +32,7 @@ public:
 
 public:
   Padding2D(uint32_t top, uint32_t bottom, uint32_t left, uint32_t right)
-      : _top{top}, _bottom{bottom}, _left{left}, _right{right}
+    : _top{top}, _bottom{bottom}, _left{left}, _right{right}
   {
     // DO NOTHING
   }

--- a/compiler/coco/core/src/ADT/PtrList.test.cpp
+++ b/compiler/coco/core/src/ADT/PtrList.test.cpp
@@ -25,7 +25,7 @@ namespace
 struct Object
 {
 };
-}
+} // namespace
 
 TEST(ADT_PTR_LIST, ctor)
 {

--- a/compiler/coco/core/src/ADT/PtrManager.test.cpp
+++ b/compiler/coco/core/src/ADT/PtrManager.test.cpp
@@ -61,7 +61,7 @@ struct ObjectManager final : public coco::PtrManager<Object>
 
   void free(Object *o) { release(o); }
 };
-}
+} // namespace
 
 TEST(ADT_PTR_MANAGER, usecase)
 {

--- a/compiler/coco/generic/src/IR/Data.cpp
+++ b/compiler/coco/generic/src/IR/Data.cpp
@@ -71,7 +71,7 @@ public:
 private:
   std::map<const coco::Bag *, std::unique_ptr<std::vector<uint8_t>>> _data;
 };
-}
+} // namespace
 
 namespace
 {


### PR DESCRIPTION
Use clang-format-8 style for coco

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>