### PR TITLE
[locoex-customop] Update clang-format version

### DIFF
--- a/compiler/locoex-customop/.clang-format
+++ b/compiler/locoex-customop/.clang-format
@@ -1,0 +1,1 @@
+../../.clang-format.8

--- a/compiler/locoex-customop/src/COpCall.cpp
+++ b/compiler/locoex-customop/src/COpCall.cpp
@@ -57,7 +57,7 @@ std::vector<std::string> COpCall::attr_names() const
 
 #define INSTANTIATE(AT)                                                                            \
   template const typename AttrTypeTrait<AT>::Type *COpCall::attr<AT>(const std::string &attr_name) \
-      const;
+    const;
 
 INSTANTIATE(COpAttrType::Float)
 INSTANTIATE(COpAttrType::Int)

--- a/compiler/locoex-customop/src/VariadicArityNode.test.cpp
+++ b/compiler/locoex-customop/src/VariadicArityNode.test.cpp
@@ -47,7 +47,7 @@ class BinaryInputNode : public TestNode
 public:
   BinaryInputNode() : TestNode(2) {}
 };
-}
+} // namespace
 
 TEST(CustomOpTest, VariadicArityNode_arity_0)
 {


### PR DESCRIPTION
Use clang-format-8 style for locoex-customop

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>