### PR TITLE
[luci-value-test] Update clang-format version

### DIFF
--- a/compiler/luci-value-test/.clang-format
+++ b/compiler/luci-value-test/.clang-format
@@ -1,0 +1,1 @@
+../../.clang-format.8

--- a/compiler/luci-value-test/tester/src/EvalTester.cpp
+++ b/compiler/luci-value-test/tester/src/EvalTester.cpp
@@ -83,8 +83,8 @@ int entry(int argc, char **argv)
   if (argc != 5)
   {
     std::cerr
-        << "Usage: " << argv[0]
-        << " <path/to/circle/model> <num_inputs> <path/to/input/prefix> <path/to/output/file>\n";
+      << "Usage: " << argv[0]
+      << " <path/to/circle/model> <num_inputs> <path/to/input/prefix> <path/to/output/file>\n";
     return EXIT_FAILURE;
   }
 


### PR DESCRIPTION
Use clang-format-8 style for luci-value-test

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>