### PR TITLE
[onert] Revise Event and EventWriter classes

### DIFF
--- a/runtime/onert/core/include/util/TracingCtx.h
+++ b/runtime/onert/core/include/util/TracingCtx.h
@@ -64,6 +64,13 @@ public:
   uint32_t getSessionId() const { return _session_id; }
 
   /**
+   * @brief Return true if more than 1 session exist
+   *
+   * @note  This method is NOT thread-safe. Call this in thread-safe situation.
+   */
+  bool hasMultipleSessions() const { return _next_session_id > 1; }
+
+  /**
    * @brief Set subgraph index of a graph
    */
   void setSubgraphIndex(const ir::Graph *g, uint32_t index) { _subgraph_indices.emplace(g, index); }
@@ -78,14 +85,14 @@ private:
   {
     std::unique_lock<std::mutex> lock{_session_id_mutex};
 
-    static uint32_t next_session_id = 0;
-    _session_id = next_session_id++;
+    _session_id = _next_session_id++;
   }
 
 private:
   std::unordered_map<const ir::Graph *, ir::SubgraphIndex> _subgraph_indices;
   uint32_t _session_id;
   static std::mutex _session_id_mutex;
+  static uint32_t _next_session_id;
 };
 
 } // namespace util

--- a/runtime/onert/core/src/exec/ExecutionObservers.cc
+++ b/runtime/onert/core/src/exec/ExecutionObservers.cc
@@ -154,7 +154,7 @@ void TracingObserver::handleJobBegin(IExecutor *, ir::SubgraphIndex subg_ind,
   const auto &first_op_idx = op_seq->operations().at(0);
 
   std::string backend_id = backend->config()->id();
-  auto ev = EventCollector::OpEvent{
+  auto ev = EventCollector::OpSeqEvent{
     _tracing_ctx,  EventCollector::Edge::BEGIN, subg_ind.value(),
     backend_id,    first_op_idx.value(),        _graph.operations().at(first_op_idx).name(),
     op_seq->size()};
@@ -171,7 +171,7 @@ void TracingObserver::handleJobEnd(IExecutor *, ir::SubgraphIndex subg_ind,
   const auto &first_op_idx = op_seq->operations().at(0);
 
   std::string backend_id = backend->config()->id();
-  _collector.onEvent(EventCollector::OpEvent{
+  _collector.onEvent(EventCollector::OpSeqEvent{
     _tracing_ctx, EventCollector::Edge::END, subg_ind.value(), backend_id, first_op_idx.value(),
     _graph.operations().at(first_op_idx).name(), op_seq->size()});
 }

--- a/runtime/onert/core/src/util/ChromeTracingEventWriter.cc
+++ b/runtime/onert/core/src/util/ChromeTracingEventWriter.cc
@@ -135,10 +135,10 @@ std::string getSubgLabel(const DurationEvent &evt)
 std::string getOpLabel(const OpSeqDurationEvent &evt)
 {
   if (evt.op_seq_size > 1)
-    return "$" + std::to_string(evt.op_index) + " " + evt.op_name + " (" +
+    return "@" + std::to_string(evt.op_index) + " " + evt.op_name + " (" +
            std::to_string(evt.op_seq_size) + ")";
   else
-    return "$" + std::to_string(evt.op_index) + " " + evt.op_name;
+    return "@" + std::to_string(evt.op_index) + " " + evt.op_name;
 }
 
 std::string getLabel(const DurationEvent &evt)

--- a/runtime/onert/core/src/util/EventCollector.h
+++ b/runtime/onert/core/src/util/EventCollector.h
@@ -18,6 +18,7 @@
 #define __ONERT_UTIL_EVENT_COLLECTOR_H__
 
 #include "util/EventRecorder.h"
+#include "util/TracingCtx.h"
 
 #include <vector>
 #include <utility>
@@ -32,26 +33,85 @@ public:
     END
   };
 
+  struct SubgEvent;
+  struct OpEvent;
+
+  class EventVisitor
+  {
+  public:
+    virtual ~EventVisitor() = default;
+
+    virtual std::unique_ptr<DurationEvent> visit(const SubgEvent &, const std::string &) const
+    {
+      throw std::runtime_error("Please implement");
+    }
+    virtual std::unique_ptr<DurationEvent> visit(const OpEvent &, const std::string &) const
+    {
+      throw std::runtime_error("Please implement");
+    }
+  };
+
   struct Event
   {
+    const onert::util::TracingCtx *tracing_ctx;
+
     Edge edge;
     uint32_t session_index;
     uint32_t subg_index;
+
+    // user-defined data: pairs of (key, value)
+    std::vector<std::pair<std::string, std::string>> userData;
+
+    virtual std::unique_ptr<DurationEvent> accept(const EventVisitor &,
+                                                  const std::string &) const = 0;
+
+  protected:
+    Event(const onert::util::TracingCtx *a_tracing_ctx, Edge a_edge, uint32_t a_subg_index)
+      : tracing_ctx(a_tracing_ctx), edge(a_edge), session_index(tracing_ctx->getSessionId()),
+        subg_index(a_subg_index)
+    { /* empty */
+    }
+
+    virtual ~Event() = default;
+  };
+
+  struct SubgEvent : public Event
+  {
+    // constructor for subgraph start and end event
+    SubgEvent(const onert::util::TracingCtx *a_tracing_ctx, Edge a_edge, uint32_t a_subg_index)
+      : Event(a_tracing_ctx, a_edge, a_subg_index)
+    { /* empty */
+    }
+
+    std::unique_ptr<DurationEvent> accept(const EventVisitor &v,
+                                          const std::string &ph) const override
+    {
+      return v.visit(*this, ph);
+    }
+  };
+
+  struct OpEvent : public Event
+  {
     std::string backend;
     uint32_t op_index;
     std::string op_name;
     uint32_t op_seq_size; // if this event is for an operation sequence of multiple operations
 
-    // TODO deprecate this. label can be differ by writer. So let the writer decide label.
-    std::string label;
+    OpEvent(const onert::util::TracingCtx *a_tracing_ctx, Edge a_edge, uint32_t a_subg_index,
+            const std::string a_backend, uint32_t a_op_index, const std::string a_op_name,
+            uint32_t a_op_seq_size)
+      : Event(a_tracing_ctx, a_edge, a_subg_index)
+    {
+      backend.assign(a_backend);
+      op_index = a_op_index;
+      op_name.assign(a_op_name);
+      op_seq_size = a_op_seq_size;
+    }
 
-    // user-defined data: pairs of (key, value)
-    std::vector<std::pair<std::string, std::string>> userData;
-
-    Event(Edge a_edge, const std::string &a_backend, const std::string &a_label)
-      : edge(a_edge), session_index(0), subg_index(0), backend(a_backend), op_index(0),
-        op_seq_size(0), label(a_label)
-    { /* empty */
+    std::unique_ptr<DurationEvent> accept(const EventVisitor &v,
+                                          const std::string &ph) const override
+    {
+      return v.visit(*this, ph);
     }
   };
 

--- a/runtime/onert/core/src/util/EventCollector.h
+++ b/runtime/onert/core/src/util/EventCollector.h
@@ -62,9 +62,6 @@ public:
     // user-defined data: pairs of (key, value)
     std::vector<std::pair<std::string, std::string>> userData;
 
-    virtual std::unique_ptr<DurationEvent> accept(const EventVisitor &,
-                                                  const std::string &) const = 0;
-
   protected:
     Event(const onert::util::TracingCtx *a_tracing_ctx, Edge a_edge, uint32_t a_subg_index)
       : tracing_ctx(a_tracing_ctx), edge(a_edge), session_index(tracing_ctx->getSessionId()),
@@ -82,36 +79,24 @@ public:
       : Event(a_tracing_ctx, a_edge, a_subg_index)
     { /* empty */
     }
-
-    std::unique_ptr<DurationEvent> accept(const EventVisitor &v,
-                                          const std::string &ph) const override
-    {
-      return v.visit(*this, ph);
-    }
   };
 
-  struct OpEvent : public Event
+  struct OpSeqEvent : public Event
   {
     std::string backend;
     uint32_t op_index;
     std::string op_name;
     uint32_t op_seq_size; // if this event is for an operation sequence of multiple operations
 
-    OpEvent(const onert::util::TracingCtx *a_tracing_ctx, Edge a_edge, uint32_t a_subg_index,
-            const std::string a_backend, uint32_t a_op_index, const std::string a_op_name,
-            uint32_t a_op_seq_size)
+    OpSeqEvent(const onert::util::TracingCtx *a_tracing_ctx, Edge a_edge, uint32_t a_subg_index,
+               const std::string a_backend, uint32_t a_op_index, const std::string a_op_name,
+               uint32_t a_op_seq_size)
       : Event(a_tracing_ctx, a_edge, a_subg_index)
     {
       backend.assign(a_backend);
       op_index = a_op_index;
       op_name.assign(a_op_name);
       op_seq_size = a_op_seq_size;
-    }
-
-    std::unique_ptr<DurationEvent> accept(const EventVisitor &v,
-                                          const std::string &ph) const override
-    {
-      return v.visit(*this, ph);
     }
   };
 
@@ -122,7 +107,7 @@ public:
   }
 
 public:
-  void onEvent(const Event &event);
+  template <typename EventT> void onEvent(const EventT &event);
 
 protected:
   EventRecorder *_rec;

--- a/runtime/onert/core/src/util/EventRecorder.cc
+++ b/runtime/onert/core/src/util/EventRecorder.cc
@@ -16,11 +16,11 @@
 
 #include "util/EventRecorder.h"
 
-void EventRecorder::emit(const DurationEvent &evt)
+void EventRecorder::emit(std::unique_ptr<DurationEvent> &&evt)
 {
   std::lock_guard<std::mutex> lock{_mu};
 
-  _duration_events.push_back(evt);
+  _duration_events.push_back(std::move(evt));
 }
 
 void EventRecorder::emit(const CounterEvent &evt)

--- a/runtime/onert/core/src/util/EventRecorder.h
+++ b/runtime/onert/core/src/util/EventRecorder.h
@@ -17,28 +17,75 @@
 #ifndef __ONERT_UTIL_EVENT_RECORDER_H__
 #define __ONERT_UTIL_EVENT_RECORDER_H__
 
+#include "util/TracingCtx.h"
+
 #include <map>
 #include <memory>
 #include <mutex>
 
 #include <vector>
 
+struct SubgDurationEvent;
+struct OpDurationEvent;
+
+class DurationEventVisitor
+{
+public:
+  virtual ~DurationEventVisitor() = default;
+
+  virtual std::string visit(const SubgDurationEvent &) const
+  {
+    throw std::runtime_error("Please implement");
+  }
+  virtual std::string visit(const OpDurationEvent &) const
+  {
+    throw std::runtime_error("Please implement");
+  }
+};
+
+// refer to https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/edit#
 struct Event
 {
-  std::string name;
-  std::string tid;
-  std::string ph;                                        /* REQUIRED */
-  std::string ts;                                        /* REQUIRED */
+  const onert::util::TracingCtx *tracing_ctx;
+
+  std::string ph;                                        // Event type.
+  std::string ts;                                        // tracing clock of timestamp of this event
   std::vector<std::pair<std::string, std::string>> args; // user-defined data: pairs of (key, value)
+
+  virtual ~Event() = default;
 };
 
 struct DurationEvent : public Event
 {
-  // TO BE FILLED
+  uint32_t session_index;
+  uint32_t subg_index;
+
+  virtual std::string accept(DurationEventVisitor &visitor) const = 0;
+
+protected:
+  DurationEvent() = default;
+};
+
+struct SubgDurationEvent : public DurationEvent
+{
+  std::string accept(DurationEventVisitor &visitor) const override { return visitor.visit(*this); }
+};
+
+struct OpDurationEvent : public DurationEvent
+{
+  // Note: DurationEvent's name and tid will be set by EventWriter
+  std::string backend;
+  uint32_t op_index;
+  std::string op_name;
+  uint32_t op_seq_size; // if this event is for an operation sequence of multiple operations
+
+  std::string accept(DurationEventVisitor &visitor) const override { return visitor.visit(*this); }
 };
 
 struct CounterEvent : public Event
 {
+  std::string name; // name of event
+  std::string tid;  // thread ID
   std::map<std::string, std::string> values;
 };
 
@@ -53,17 +100,20 @@ public:
   EventRecorder() = default;
 
 public:
-  void emit(const DurationEvent &evt);
+  void emit(std::unique_ptr<DurationEvent> &&evt);
   void emit(const CounterEvent &evt);
 
 public:
   bool empty() { return _duration_events.empty() && _counter_events.empty(); }
-  const std::vector<DurationEvent> &duration_events() const { return _duration_events; }
+  const std::vector<std::unique_ptr<DurationEvent>> &duration_events() const
+  {
+    return _duration_events;
+  }
   const std::vector<CounterEvent> &counter_events() const { return _counter_events; }
 
 private:
   std::mutex _mu;
-  std::vector<DurationEvent> _duration_events;
+  std::vector<std::unique_ptr<DurationEvent>> _duration_events;
   std::vector<CounterEvent> _counter_events;
 };
 

--- a/runtime/onert/core/src/util/EventRecorder.h
+++ b/runtime/onert/core/src/util/EventRecorder.h
@@ -25,24 +25,6 @@
 
 #include <vector>
 
-struct SubgDurationEvent;
-struct OpDurationEvent;
-
-class DurationEventVisitor
-{
-public:
-  virtual ~DurationEventVisitor() = default;
-
-  virtual std::string visit(const SubgDurationEvent &) const
-  {
-    throw std::runtime_error("Please implement");
-  }
-  virtual std::string visit(const OpDurationEvent &) const
-  {
-    throw std::runtime_error("Please implement");
-  }
-};
-
 // refer to https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/edit#
 struct Event
 {
@@ -60,26 +42,21 @@ struct DurationEvent : public Event
   uint32_t session_index;
   uint32_t subg_index;
 
-  virtual std::string accept(DurationEventVisitor &visitor) const = 0;
-
 protected:
   DurationEvent() = default;
 };
 
 struct SubgDurationEvent : public DurationEvent
-{
-  std::string accept(DurationEventVisitor &visitor) const override { return visitor.visit(*this); }
+{ /* same with DurationEvent */
 };
 
-struct OpDurationEvent : public DurationEvent
+struct OpSeqDurationEvent : public DurationEvent
 {
   // Note: DurationEvent's name and tid will be set by EventWriter
   std::string backend;
   uint32_t op_index;
   std::string op_name;
   uint32_t op_seq_size; // if this event is for an operation sequence of multiple operations
-
-  std::string accept(DurationEventVisitor &visitor) const override { return visitor.visit(*this); }
 };
 
 struct CounterEvent : public Event
@@ -104,7 +81,6 @@ public:
   void emit(const CounterEvent &evt);
 
 public:
-  bool empty() { return _duration_events.empty() && _counter_events.empty(); }
   const std::vector<std::unique_ptr<DurationEvent>> &duration_events() const
   {
     return _duration_events;

--- a/runtime/onert/core/src/util/EventWriter.h
+++ b/runtime/onert/core/src/util/EventWriter.h
@@ -45,6 +45,8 @@ public:
   SNPEWriter(const std::string &filepath) : EventFormatWriter(filepath)
   { /* empty */
   }
+  ~SNPEWriter() {}
+
   void flush(const std::vector<std::unique_ptr<EventRecorder>> &) override;
 };
 
@@ -54,6 +56,8 @@ public:
   ChromeTracingWriter(const std::string &filepath) : EventFormatWriter(filepath)
   { /* empty */
   }
+  ~ChromeTracingWriter() {}
+
   void flush(const std::vector<std::unique_ptr<EventRecorder>> &) override;
 
 private:
@@ -66,11 +70,12 @@ public:
   MDTableWriter(const std::string &filepath) : EventFormatWriter(filepath)
   { /* empty */
   }
-  void flush(const std::vector<std::unique_ptr<EventRecorder>> &) override;
+  ~MDTableWriter() {}
 
-private:
-  void flushOneRecord(const EventRecorder &);
+  void flush(const std::vector<std::unique_ptr<EventRecorder>> &) override;
 };
+
+#include <mutex>
 
 class EventWriter
 {

--- a/runtime/onert/core/src/util/MDTableEventWriter.cc
+++ b/runtime/onert/core/src/util/MDTableEventWriter.cc
@@ -181,7 +181,7 @@ struct Graph : public MDContent
 std::string getLabel(const OpSeqDurationEvent &evt)
 {
   std::string subg_label("$" + std::to_string(evt.subg_index) + " subgraph");
-  std::string op_label("$" + std::to_string(evt.op_index) + " " + evt.op_name);
+  std::string op_label("@" + std::to_string(evt.op_index) + " " + evt.op_name);
 
   return subg_label + " " + op_label;
 }

--- a/runtime/onert/core/src/util/TracingCtx.cc
+++ b/runtime/onert/core/src/util/TracingCtx.cc
@@ -24,6 +24,7 @@ namespace util
 
 // initializing static member var
 std::mutex TracingCtx::_session_id_mutex;
+uint32_t TracingCtx::_next_session_id = 0;
 
 } // namespace util
 } // namespace onert


### PR DESCRIPTION
This revises `Event` and `EventWriter` classes.

Parent issue: #4901
Draft: #4903

This is the last PR for the draft.

Sorry about large PR but it's kinda hard to split this into several PRs.

Major changes are:
1. Refine `Event` class (`EventCollector.h`) to have two child classes: `SubgEvent` and `OpEvent`
2. Refine `DurationEvent` class (`DurationEventRecorder.h`) 
    - to have two child classes: `SubgDurationEvent` and `OpDurationEvent`
    - to have higher member vars. Previously, it had, e.g., `tid` (thread id), which is specific to Chrome Tracing. However `tid` is not meaningful to `MDEventWriter` or `SNPEEventWriter`
3. Make specific event writer decide labels (and tid)
   - So writers (`ChromeTracingEventWriter`, `MDEventWriter` and `SNPEEventWriter`) now have, its own, e.g., `LabelMaker`
4. Add session and subgraph index into label

I will also leave some explanations in code.

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>