### PR TITLE
[mir-interpreter] Update clang-format version

### DIFF
--- a/compiler/mir-interpreter/.clang-format
+++ b/compiler/mir-interpreter/.clang-format
@@ -1,0 +1,1 @@
+../../.clang-format.8

--- a/compiler/mir-interpreter/src/ops/Add.cpp
+++ b/compiler/mir-interpreter/src/ops/Add.cpp
@@ -106,13 +106,13 @@ void AddImpl<uint8_t>::run(const TensorVariant &lhs, const TensorVariant &rhs, T
     const int32_t shifted_lhs_val = lhs_val * (1 << left_shift);
     const int32_t shifted_rhs_val = rhs_val * (1 << left_shift);
     const int32_t scaled_lhs_val =
-        MultiplyByQuantizedMultiplierSmallerThanOneExp(shifted_lhs_val, lhs_multiplier, lhs_shift);
+      MultiplyByQuantizedMultiplierSmallerThanOneExp(shifted_lhs_val, lhs_multiplier, lhs_shift);
     const int32_t scaled_rhs_val =
-        MultiplyByQuantizedMultiplierSmallerThanOneExp(shifted_rhs_val, rhs_multiplier, rhs_shift);
+      MultiplyByQuantizedMultiplierSmallerThanOneExp(shifted_rhs_val, rhs_multiplier, rhs_shift);
     const int32_t raw_sum = scaled_lhs_val + scaled_rhs_val;
     const int32_t raw_output =
-        MultiplyByQuantizedMultiplierSmallerThanOneExp(raw_sum, output_multiplier, output_shift) +
-        output_offset;
+      MultiplyByQuantizedMultiplierSmallerThanOneExp(raw_sum, output_multiplier, output_shift) +
+      output_offset;
     const int32_t clamped_output = std::min(output_max, std::max(output_min, raw_output));
     res_accessor.at(index) = static_cast<uint8_t>(clamped_output);
   }

--- a/compiler/mir-interpreter/src/ops/AvgPool2D.cpp
+++ b/compiler/mir-interpreter/src/ops/AvgPool2D.cpp
@@ -72,7 +72,7 @@ void AvgPool2DImpl<T>::run(const ops::AvgPool2DOp &op, const TensorVariant &inpu
       // Assuming NHWC format.
       for (int i = 0; i < num_spatial_dims; ++i)
         in_index.at(1 + i) =
-            out_index.at(1 + i) * strides[i] + window_index.at(i) - padding_before[i];
+          out_index.at(1 + i) * strides[i] + window_index.at(i) - padding_before[i];
 
       if (in_range.contains(in_index))
       {
@@ -145,7 +145,7 @@ void AvgPool2DImpl<uint8_t>::run(const ops::AvgPool2DOp &op, const TensorVariant
       // Assuming NHWC format.
       for (int i = 0; i < num_spatial_dims; ++i)
         in_index.at(1 + i) =
-            out_index.at(1 + i) * strides[i] + window_index.at(i) - padding_before[i];
+          out_index.at(1 + i) * strides[i] + window_index.at(i) - padding_before[i];
 
       if (in_range.contains(in_index))
       {

--- a/compiler/mir-interpreter/src/ops/CappedReLU.cpp
+++ b/compiler/mir-interpreter/src/ops/CappedReLU.cpp
@@ -68,7 +68,7 @@ template <> struct CappedReLUImpl<uint8_t>
     {
       auto value = dequantize(arg_accessor.at(index), quant_info);
       auto out_value =
-          quantize(std::min(std::max(value, 0.0f), cap), result.getType().getQuantization());
+        quantize(std::min(std::max(value, 0.0f), cap), result.getType().getQuantization());
       res_accessor.at(index) = out_value;
     }
   }

--- a/compiler/mir-interpreter/src/ops/Concat.cpp
+++ b/compiler/mir-interpreter/src/ops/Concat.cpp
@@ -90,8 +90,8 @@ template <> struct ConcatImpl<uint8_t>
 };
 
 void ConcatImpl<uint8_t>::run(
-    const std::vector<std::reference_wrapper<const mir::TensorVariant>> &inputs, int axis,
-    mir::TensorVariant &output)
+  const std::vector<std::reference_wrapper<const mir::TensorVariant>> &inputs, int axis,
+  mir::TensorVariant &output)
 {
   const size_t inputs_count = inputs.size();
   std::vector<int32_t> input_zeropoints(inputs_count);
@@ -154,7 +154,7 @@ void ConcatImpl<uint8_t>::run(
         for (int j = 0; j < copy_size; ++j)
         {
           const int32_t value =
-              static_cast<int32_t>(std::round(input_ptr[j] * scale + bias)) + output_zeropoint;
+            static_cast<int32_t>(std::round(input_ptr[j] * scale + bias)) + output_zeropoint;
           output_ptr[j] = static_cast<uint8_t>(std::max(std::min(255, value), 0));
         }
       }

--- a/compiler/mir-interpreter/src/ops/Conv2D.cpp
+++ b/compiler/mir-interpreter/src/ops/Conv2D.cpp
@@ -109,9 +109,9 @@ void Conv2DImpl<T>::run(const TensorVariant &input, const TensorVariant &kernel,
                   if ((in_y >= 0 && in_y < input_height) && (in_x >= 0 && in_x < input_width))
                   {
                     const std::int32_t in_offset =
-                        calcOffset(input_shape, batch, in_y, in_x, in_group_offset + in_c);
-                    const std::int32_t kernel_offset = calcOffset(
-                        kernel_shape, out_group_offset + out_c, kernel_y, kernel_x, in_c);
+                      calcOffset(input_shape, batch, in_y, in_x, in_group_offset + in_c);
+                    const std::int32_t kernel_offset =
+                      calcOffset(kernel_shape, out_group_offset + out_c, kernel_y, kernel_x, in_c);
                     const T input_val = input_data[in_offset];
                     const T kernel_val = kernel_data[kernel_offset];
                     sum += kernel_val * input_val;
@@ -121,7 +121,7 @@ void Conv2DImpl<T>::run(const TensorVariant &input, const TensorVariant &kernel,
             }
 
             const std::int32_t out_offset =
-                calcOffset(output_shape, batch, out_y, out_x, out_group_offset + out_c);
+              calcOffset(output_shape, batch, out_y, out_x, out_group_offset + out_c);
             result_data[out_offset] = sum;
           }
         }

--- a/compiler/mir-interpreter/src/ops/DeConv2D.cpp
+++ b/compiler/mir-interpreter/src/ops/DeConv2D.cpp
@@ -98,9 +98,9 @@ void DeConv2DImpl<T>::run(const TensorVariant &input, const TensorVariant &kerne
                 for (int32_t out_c = 0; out_c < num_out_channels; ++out_c)
                 {
                   const int32_t kernel_offset =
-                      calcOffset(kernel_shape, in_c, kernel_y, kernel_x, out_c);
+                    calcOffset(kernel_shape, in_c, kernel_y, kernel_x, out_c);
                   const int32_t output_offset =
-                      calcOffset(output_shape, batch, out_y, out_x, out_c);
+                    calcOffset(output_shape, batch, out_y, out_x, out_c);
                   const T kernel_val = kernel_data[kernel_offset];
                   output_data[output_offset] += input_val * kernel_val;
                 }

--- a/compiler/mir-interpreter/src/ops/Gather.cpp
+++ b/compiler/mir-interpreter/src/ops/Gather.cpp
@@ -64,7 +64,7 @@ void GatherImpl<T, IndicesT>::run(const TensorVariant &datav, const TensorVarian
       for (int32_t inner = 0; inner < inner_size; inner++)
       {
         output.atOffset((outer * num_indices + i) * inner_size + inner) =
-            data.atOffset((outer * axis_size + index) * inner_size + inner);
+          data.atOffset((outer * axis_size + index) * inner_size + inner);
       }
     }
   }

--- a/compiler/mir-interpreter/src/ops/MaxPool2D.cpp
+++ b/compiler/mir-interpreter/src/ops/MaxPool2D.cpp
@@ -72,7 +72,7 @@ void MaxPool2DImpl<T>::run(const TensorVariant &inputv, const ops::MaxPool2DOp &
       // Assuming NHWC format.
       for (int i = 0; i < num_spatial_dims; ++i)
         in_index.at(1 + i) =
-            out_index.at(1 + i) * strides[i] + window_index.at(i) - padding_before[i];
+          out_index.at(1 + i) * strides[i] + window_index.at(i) - padding_before[i];
 
       if (in_range.contains(in_index))
       {
@@ -137,7 +137,7 @@ void MaxPool2DImpl<uint8_t>::run(const TensorVariant &input, const ops::MaxPool2
       // Assuming NHWC format.
       for (int i = 0; i < num_spatial_dims; ++i)
         in_index.at(1 + i) =
-            out_index.at(1 + i) * strides[i] + window_index.at(i) - padding_before[i];
+          out_index.at(1 + i) * strides[i] + window_index.at(i) - padding_before[i];
 
       if (in_range.contains(in_index))
       {

--- a/compiler/mir-interpreter/src/ops/QuantizationHelpers.h
+++ b/compiler/mir-interpreter/src/ops/QuantizationHelpers.h
@@ -110,7 +110,7 @@ inline int32_t MultiplyByQuantizedMultiplier(int32_t x, int32_t quantized_multip
   int left_shift = shift > 0 ? shift : 0;
   int right_shift = shift > 0 ? 0 : -shift;
   return RoundingDivideByPOT(
-      SaturatingRoundingDoublingHighMul(x * (1 << left_shift), quantized_multiplier), right_shift);
+    SaturatingRoundingDoublingHighMul(x * (1 << left_shift), quantized_multiplier), right_shift);
 }
 
 inline int32_t MultiplyByQuantizedMultiplierSmallerThanOneExp(int32_t x,

--- a/compiler/mir-interpreter/src/ops/Softmax.cpp
+++ b/compiler/mir-interpreter/src/ops/Softmax.cpp
@@ -70,7 +70,7 @@ void SoftmaxImpl<T>::run(const mir::TensorVariant &arg, int axis, mir::TensorVar
     mir::Index expsum_index = res_index;
     expsum_index.at(axis) = 0;
     res_accessor.at(res_index) =
-        std::exp(arg_accessor.at(res_index)) / expsum_accessor.at(expsum_index);
+      std::exp(arg_accessor.at(res_index)) / expsum_accessor.at(expsum_index);
   }
 }
 
@@ -140,7 +140,7 @@ void SoftmaxImpl<uint8_t>::run(const mir::TensorVariant &input, int axis,
       const float prob_rescaled = table_offset[input_data[j]] * inv_sum_exp;
       const int32_t prob_quantized = static_cast<int32_t>(prob_rescaled + 0.5);
       output_data[j] =
-          static_cast<uint8_t>(std::max(std::min(clamp_max, prob_quantized), clamp_min));
+        static_cast<uint8_t>(std::max(std::min(clamp_max, prob_quantized), clamp_min));
     }
     input_data += last_dim;
     output_data += last_dim;


### PR DESCRIPTION
Use clang-format-8 style for mir-interpreter

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>