### PR TITLE
[nnpkgrun] add bufsize_for int8 qasym type

### DIFF
--- a/tests/tools/nnpackage_run/src/nnfw_util.cc
+++ b/tests/tools/nnpackage_run/src/nnfw_util.cc
@@ -40,7 +40,7 @@ uint64_t bufsize_for(const nnfw_tensorinfo *ti)
     sizeof(bool),    /* NNFW_TYPE_TENSOR_BOOL = 3 */
     sizeof(uint8_t), /* NNFW_TYPE_TENSOR_UINT8 = 4 */
     sizeof(int64_t), /* NNFW_TYPE_TENSOR_INT64 = 5 */
-
+    sizeof(int8_t),  /* NNFW_TYPE_TENSOR_QUANT8_ASYMM_SIGNED = 6 */
   };
   return elmsize[ti->dtype] * num_elems(ti);
 }


### PR DESCRIPTION
It adds missing qasym i8 input type in bufsize_for.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>