### PR TITLE
[moco-tf] Update clang-format version

### DIFF
--- a/compiler/moco-tf/.clang-format
+++ b/compiler/moco-tf/.clang-format
@@ -1,0 +1,1 @@
+../../.clang-format.8

--- a/compiler/moco-tf/src/BroadcastHelper.h
+++ b/compiler/moco-tf/src/BroadcastHelper.h
@@ -65,7 +65,7 @@ private:
  * This mimics "tf.broadcast_to" API in TensorFlow.
  */
 static inline auto broadcast_to(const loco::TensorShape &shape)
-    -> decltype(bino::transform_both(std::declval<BroadcastFunctor>()))
+  -> decltype(bino::transform_both(std::declval<BroadcastFunctor>()))
 {
   return bino::transform_both(BroadcastFunctor{shape});
 }

--- a/compiler/moco-tf/src/Canonicalization/Conv2DBackpropInputCanonicalizer.cpp
+++ b/compiler/moco-tf/src/Canonicalization/Conv2DBackpropInputCanonicalizer.cpp
@@ -163,9 +163,9 @@ loco::Padding2D Padding2DInference::operator()(void)
     // 'tight fit' output. When output size (set by 'input sizes' node input) is
     // larger than tight fit, extra spaces filled with zero.
     auto tight_output_vertical = tight_output_for_valid_padding(
-        input().vertical.value(), stride().vertical(), window().vertical());
+      input().vertical.value(), stride().vertical(), window().vertical());
     auto tight_output_horizontal = tight_output_for_valid_padding(
-        input().horizontal.value(), stride().horizontal(), window().horizontal());
+      input().horizontal.value(), stride().horizontal(), window().horizontal());
 
     if (output().vertical.value() < tight_output_vertical or
         output().horizontal.value() < tight_output_horizontal)
@@ -191,8 +191,8 @@ loco::Padding2D Padding2DInference::operator()(void)
     auto whole_pad_vertical = padding_needed(input().vertical.value(), output().vertical.value(),
                                              stride().vertical(), window().vertical());
     auto whole_pad_horizontal =
-        padding_needed(input().horizontal.value(), output().horizontal.value(),
-                       stride().horizontal(), window().horizontal());
+      padding_needed(input().horizontal.value(), output().horizontal.value(), stride().horizontal(),
+                     window().horizontal());
 
     loco::Padding2D res;
 

--- a/compiler/moco-tf/src/Canonicalization/DepthwiseConv2dNativeCanonicalizer.cpp
+++ b/compiler/moco-tf/src/Canonicalization/DepthwiseConv2dNativeCanonicalizer.cpp
@@ -47,28 +47,28 @@ bool canonicalize_depthwiseconv2dnative(loco::Graph *graph, moco::TFDepthwiseCon
   LOGGER(l);
 
   /**
- * @note This will replace TFDepthwiseConv2dNative node with Canonical FeatureEncode +
- *       DepthwiseFilterEncode + DepthwiseConv2D + FeatureDecode
- *
- *       Before
- *              A -+- TFDepthwiseConv2dNative - C
- *                 |
- *              B -+
- *
- *       After
- *
- *            A -+ FeatureEncode ----------------+- DepthwiseConv2D - FeatureDecode - C
- *               |                               |
- *               +-(TFDepthwiseConv2dNative)     |
- *               |                               |
- *            B -+ DepthwiseFilterEncode --------+
- *
- *       Where
- *                 A : ifm of TFDepthwiseConv2dNative
- *                 B : ker of TFDepthwiseConv2dNative
- *                 C : a node that uses TFDepthwiseConv2dNative as an input
- *                 TFDepthwiseConv2dNative is disconnected from other nodes
- */
+   * @note This will replace TFDepthwiseConv2dNative node with Canonical FeatureEncode +
+   *       DepthwiseFilterEncode + DepthwiseConv2D + FeatureDecode
+   *
+   *       Before
+   *              A -+- TFDepthwiseConv2dNative - C
+   *                 |
+   *              B -+
+   *
+   *       After
+   *
+   *            A -+ FeatureEncode ----------------+- DepthwiseConv2D - FeatureDecode - C
+   *               |                               |
+   *               +-(TFDepthwiseConv2dNative)     |
+   *               |                               |
+   *            B -+ DepthwiseFilterEncode --------+
+   *
+   *       Where
+   *                 A : ifm of TFDepthwiseConv2dNative
+   *                 B : ker of TFDepthwiseConv2dNative
+   *                 C : a node that uses TFDepthwiseConv2dNative as an input
+   *                 TFDepthwiseConv2dNative is disconnected from other nodes
+   */
 
   INFO(l) << "TFNodeCanonicalize TFDepthwiseConv2dNative begin";
 

--- a/compiler/moco-tf/src/Canonicalization/SoftmaxCanonicalizer.cpp
+++ b/compiler/moco-tf/src/Canonicalization/SoftmaxCanonicalizer.cpp
@@ -31,16 +31,16 @@ bool canonicalize_softmax(loco::Graph *graph, moco::TFSoftmax *node)
   INFO(l) << "TFNodeCanonicalize TFSoftmax begin";
 
   /**
-  * This will replace shape inferred TFSoftmax node into canonical TensorSoftmax
-  *
-  * Before
-  *           In ---- TFSoftmax ---- Out(s)
-  *
-  * After
-  *             ------ TFSoftmax
-  *            /
-  *           In ---- TensorSoftmax ----- Out(s)
-  */
+   * This will replace shape inferred TFSoftmax node into canonical TensorSoftmax
+   *
+   * Before
+   *           In ---- TFSoftmax ---- Out(s)
+   *
+   * After
+   *             ------ TFSoftmax
+   *            /
+   *           In ---- TensorSoftmax ----- Out(s)
+   */
 
   auto nodeshape = moco::node_shape(node);
   // Canonicalization into TensorSoftmax is valid when softmax has shape info

--- a/compiler/moco-tf/src/Canonicalization/SoftmaxCanonicalizer.h
+++ b/compiler/moco-tf/src/Canonicalization/SoftmaxCanonicalizer.h
@@ -30,8 +30,8 @@ namespace tf
 {
 
 /**
-* @brief Canonicalize TF-dialect TFSoftmax into canonical Softmax node
-*/
+ * @brief Canonicalize TF-dialect TFSoftmax into canonical Softmax node
+ */
 class SoftmaxCanonicalizer : public SimpleNodeTransform<moco::TFSoftmax>
 {
 public:

--- a/compiler/moco-tf/src/Canonicalization/StopGradientCanonicalizer.cpp
+++ b/compiler/moco-tf/src/Canonicalization/StopGradientCanonicalizer.cpp
@@ -30,16 +30,16 @@ bool canonicalize_stopgradient(loco::Graph *graph, moco::TFStopGradient *node)
   INFO(l) << "TFNodeCanonicalize TFStopGradient begin";
 
   /**
-  * This will replace shape inferred TFStopGradient node into canonical Forward
-  *
-  * Before
-  *           In --- TFStopGradient --- Out(s)
-  *
-  * After
-  *               -- TFStopGradient
-  *              /
-  *           In --- Forward --- Out(s)
-  */
+   * This will replace shape inferred TFStopGradient node into canonical Forward
+   *
+   * Before
+   *           In --- TFStopGradient --- Out(s)
+   *
+   * After
+   *               -- TFStopGradient
+   *              /
+   *           In --- Forward --- Out(s)
+   */
 
   // Create loco node to replace
   auto forward_node = graph->nodes()->create<loco::Forward>();

--- a/compiler/moco-tf/src/Canonicalization/StopGradientCanonicalizer.h
+++ b/compiler/moco-tf/src/Canonicalization/StopGradientCanonicalizer.h
@@ -30,8 +30,8 @@ namespace tf
 {
 
 /**
-* @brief Canonicalize TF-dialect TFStopGradient into canonical Forward node
-*/
+ * @brief Canonicalize TF-dialect TFStopGradient into canonical Forward node
+ */
 class StopGradientCanonicalizer : public SimpleNodeTransform<moco::TFStopGradient>
 {
 public:

--- a/compiler/moco-tf/src/Frontend.cpp
+++ b/compiler/moco-tf/src/Frontend.cpp
@@ -157,7 +157,7 @@ moco::GraphBuilderRegistry make_graph_builder_registry(const moco::ModelSignatur
   for (const auto &custom_op : sig.customops())
   {
     std::unique_ptr<moco::tf::COpCallGraphBuilder> builder =
-        stdex::make_unique<moco::tf::COpCallGraphBuilder>(&sig);
+      stdex::make_unique<moco::tf::COpCallGraphBuilder>(&sig);
     registry.add(custom_op, std::move(builder));
   }
 

--- a/compiler/moco-tf/src/Knob.cpp
+++ b/compiler/moco-tf/src/Knob.cpp
@@ -109,12 +109,12 @@ namespace moco
 namespace tf
 {
 
-#define KNOB_BOOL(NAME, DEFAULT, DESC)                                                           \
-  template <> typename KnobTrait<Knob::NAME>::ValueType get<Knob::NAME>(void)                    \
-  {                                                                                              \
-    static typename KnobTrait<Knob::NAME>::ValueType value =                                     \
-        ::knob_load<typename KnobTrait<Knob::NAME>::ValueType>(::knob_loader(), #NAME, DEFAULT); \
-    return value;                                                                                \
+#define KNOB_BOOL(NAME, DEFAULT, DESC)                                                         \
+  template <> typename KnobTrait<Knob::NAME>::ValueType get<Knob::NAME>(void)                  \
+  {                                                                                            \
+    static typename KnobTrait<Knob::NAME>::ValueType value =                                   \
+      ::knob_load<typename KnobTrait<Knob::NAME>::ValueType>(::knob_loader(), #NAME, DEFAULT); \
+    return value;                                                                              \
   }
 #include "Knob.lst"
 #undef KNOB_BOOL

--- a/compiler/moco-tf/src/Op/COpCall.cpp
+++ b/compiler/moco-tf/src/Op/COpCall.cpp
@@ -37,7 +37,7 @@ class COpCallGraphUpdate final : public moco::GraphUpdate
 {
 public:
   COpCallGraphUpdate(locoex::COpCall *node, const std::vector<moco::TensorName> &input_names)
-      : _node(node), _input_names(input_names)
+    : _node(node), _input_names(input_names)
   {
   }
 

--- a/compiler/moco-tf/src/Op/COpCall.h
+++ b/compiler/moco-tf/src/Op/COpCall.h
@@ -32,7 +32,9 @@ namespace tf
 class COpCallGraphBuilder final : public GraphBuilder
 {
 public:
-  COpCallGraphBuilder(const ModelSignature *signature) : _signature(signature) { /* empty */}
+  COpCallGraphBuilder(const ModelSignature *signature) : _signature(signature)
+  { /* empty */
+  }
   bool validate(const tensorflow::NodeDef &) const override;
   void build(const tensorflow::NodeDef &, GraphBuilderContext *) const override;
 

--- a/compiler/moco-tf/src/ProgressReporter.h
+++ b/compiler/moco-tf/src/ProgressReporter.h
@@ -30,7 +30,7 @@ class ProgressReporter : public logo::PhaseEventListener
 {
 public:
   ProgressReporter(loco::Graph *graph, logo::PhaseStrategy strategy)
-      : _graph{graph}, _strategy{strategy}
+    : _graph{graph}, _strategy{strategy}
   {
     // DO NOTHING
   }

--- a/compiler/moco-tf/src/Transforms/ShapeInferencePass.cpp
+++ b/compiler/moco-tf/src/Transforms/ShapeInferencePass.cpp
@@ -46,8 +46,8 @@ bool ShapeInferencePass::run(loco::Graph *graph)
   loco::MultiDialectShapeInferenceRule rules;
 
   rules.bind(loco::CanonicalDialect::get(), &canonical_rule)
-      .bind(TFDialect::get(), &tf_rule)
-      .bind(locoex::COpDialect::get(), &cop_rule);
+    .bind(TFDialect::get(), &tf_rule)
+    .bind(locoex::COpDialect::get(), &cop_rule);
 
   return loco::apply(&rules).to(graph);
 }

--- a/compiler/moco-tf/src/Transforms/TypeInferencePass.cpp
+++ b/compiler/moco-tf/src/Transforms/TypeInferencePass.cpp
@@ -42,8 +42,8 @@ bool TypeInferencePass::run(loco::Graph *graph)
   loco::MultiDialectTypeInferenceRule rules;
 
   rules.bind(loco::CanonicalDialect::get(), &canonical_rule)
-      .bind(TFDialect::get(), &tf_rule)
-      .bind(locoex::COpDialect::get(), &cop_rule);
+    .bind(TFDialect::get(), &tf_rule)
+    .bind(locoex::COpDialect::get(), &cop_rule);
 
   loco::apply(&rules).to(graph);
 


### PR DESCRIPTION
Use clang-format-8 style for moco-tf

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>