### PR TITLE
[onert] Remove interp::ITensor methods (dups)

### DIFF
--- a/runtime/onert/core/src/interp/Tensor.h
+++ b/runtime/onert/core/src/interp/Tensor.h
@@ -70,8 +70,6 @@ public:
   virtual void releaseData() = 0;
 
   virtual size_t total_size() const = 0;
-  virtual size_t dimension(size_t index) const = 0;
-  virtual size_t num_dimensions() const = 0;
   virtual size_t calcOffset(const ir::Coordinates &coords) const = 0;
 
   virtual bool has_padding() const = 0;
@@ -118,8 +116,6 @@ public:
   void releaseData() override { _data = nullptr; }
 
   size_t total_size() const override { return _info.total_size(); }
-  size_t dimension(size_t index) const override { return _info.shape().dim(index); }
-  size_t num_dimensions() const override { return _info.shape().rank(); }
   size_t calcOffset(const ir::Coordinates &coords) const override;
   ir::Layout layout() const override;
   bool is_dynamic() const override { return false; }
@@ -161,8 +157,6 @@ public:
   void releaseData() override { _buffer = nullptr; }
 
   size_t total_size() const override { return _info.total_size(); }
-  size_t dimension(size_t index) const override { return _info.shape().dim(index); }
-  size_t num_dimensions() const override { return _info.shape().rank(); }
   size_t calcOffset(const ir::Coordinates &coords) const override;
   ir::Layout layout() const override;
   bool is_dynamic() const override { return false; }

--- a/runtime/onert/core/src/interp/operations/Concat.cc
+++ b/runtime/onert/core/src/interp/operations/Concat.cc
@@ -39,22 +39,22 @@ void prepareConcat(ExecEnv *env, const ir::Operation &node)
   const auto first_tensor = env->tensorAt(first_index);
   uint32_t out_axis_dimension = 0;
   const int32_t axis_raw = concat_node.param().axis;
-  const uint32_t axis = (axis_raw < 0) ? (axis_raw + first_tensor->num_dimensions()) : axis_raw;
+  const int32_t axis = (axis_raw < 0) ? (axis_raw + first_tensor->getShape().rank()) : axis_raw;
 
   // All inputs shape should be same except axis dimension
   // All inputs type should be same
   for (auto input : node.getInputs())
   {
-    assert(first_tensor->num_dimensions() == env->tensorAt(input)->num_dimensions());
+    assert(first_tensor->getShape().rank() == env->tensorAt(input)->getShape().rank());
     assert(first_tensor->data_type() == env->tensorAt(input)->data_type());
-    for (uint32_t i = 0; i < first_tensor->num_dimensions(); i++)
+    for (int i = 0; i < first_tensor->getShape().rank(); i++)
     {
       if (i == axis)
       {
-        out_axis_dimension += env->tensorAt(input)->dimension(i);
+        out_axis_dimension += env->tensorAt(input)->getShape().dim(i);
         continue;
       }
-      assert(first_tensor->dimension(i) == env->tensorAt(input)->dimension(i));
+      assert(first_tensor->getShape().dim(i) == env->tensorAt(input)->getShape().dim(i));
     }
   }
 
@@ -67,16 +67,16 @@ void prepareConcat(ExecEnv *env, const ir::Operation &node)
   auto out_tensor = env->tensorAt(out_index);
   UNUSED_RELEASE(out_tensor);
 
-  // Output shape should be same with input except axis dimension
+  // Output shape should be same with input except axis getShape().dim
   // Output type should be same with input
   assert(first_tensor->data_type() == out_tensor->data_type());
-  for (uint32_t i = 0; i < first_tensor->num_dimensions(); i++)
+  for (int i = 0; i < first_tensor->getShape().rank(); i++)
   {
     if (i == axis)
     {
       continue;
     }
-    assert(first_tensor->dimension(i) == out_tensor->dimension(i));
+    assert(first_tensor->getShape().dim(i) == out_tensor->getShape().dim(i));
   }
 }
 
@@ -123,7 +123,7 @@ void invokeConcat(const ExecEnv *env, const ir::Operation &node)
 
   const auto out_index = node.getOutputs().at(0);
   const auto out_tensor = env->tensorAt(out_index);
-  const uint32_t axis = (axis_raw < 0) ? (axis_raw + out_tensor->num_dimensions()) : axis_raw;
+  const uint32_t axis = (axis_raw < 0) ? (axis_raw + out_tensor->getShape().rank()) : axis_raw;
 
   const auto data_type = in_tensors[0]->data_type();
   if (data_type == ir::DataType::FLOAT32)

--- a/runtime/onert/core/src/interp/operations/Conv2D.cc
+++ b/runtime/onert/core/src/interp/operations/Conv2D.cc
@@ -42,9 +42,9 @@ void prepareConv2D(ExecEnv *env, const ir::Operation &node)
   const auto kernel_tensor = env->tensorAt(kernel_index);
   const auto bias_tensor = env->tensorAt(bias_index);
 
-  assert(in_tensor->num_dimensions() == 4);
-  assert(kernel_tensor->num_dimensions() == 4);
-  assert(bias_tensor->num_dimensions() == 1);
+  assert(in_tensor->getShape().rank() == 4);
+  assert(kernel_tensor->getShape().rank() == 4);
+  assert(bias_tensor->getShape().rank() == 1);
 
   UNUSED_RELEASE(in_tensor);
   UNUSED_RELEASE(kernel_tensor);
@@ -70,7 +70,7 @@ void prepareConv2D(ExecEnv *env, const ir::Operation &node)
 
   // Handle same ifm & ofm data type only
   assert(in_tensor->data_type() == out_tensor->data_type());
-  assert(out_tensor->num_dimensions() == 4);
+  assert(out_tensor->getShape().rank() == 4);
 }
 
 void invoke(const ITensor *ifm_tensor, const ITensor *ker_tensor, const ITensor *bias_tensor,

--- a/runtime/onert/core/src/interp/operations/DepthwiseConv2D.cc
+++ b/runtime/onert/core/src/interp/operations/DepthwiseConv2D.cc
@@ -43,9 +43,9 @@ void prepareDepthwiseConv(ExecEnv *env, const ir::Operation &node)
   const auto kernel_tensor = env->tensorAt(kernel_index);
   const auto bias_tensor = env->tensorAt(bias_index);
 
-  assert(in_tensor->num_dimensions() == 4);
-  assert(kernel_tensor->num_dimensions() == 4);
-  assert(bias_tensor->num_dimensions() == 1);
+  assert(in_tensor->getShape().rank() == 4);
+  assert(kernel_tensor->getShape().rank() == 4);
+  assert(bias_tensor->getShape().rank() == 1);
 
   UNUSED_RELEASE(in_tensor);
   UNUSED_RELEASE(kernel_tensor);
@@ -75,7 +75,7 @@ void prepareDepthwiseConv(ExecEnv *env, const ir::Operation &node)
 
   // Handle same ifm & ofm data type only
   assert(in_tensor->data_type() == out_tensor->data_type());
-  assert(out_tensor->num_dimensions() == 4);
+  assert(out_tensor->getShape().rank() == 4);
 }
 
 void invoke(const ITensor *ifm_tensor, const ITensor *ker_tensor, const ITensor *bias_tensor,

--- a/runtime/onert/core/src/interp/operations/FullyConnected.cc
+++ b/runtime/onert/core/src/interp/operations/FullyConnected.cc
@@ -44,16 +44,16 @@ void prepareFC(ExecEnv *env, const ir::Operation &node)
   UNUSED_RELEASE(kernel_tensor);
   UNUSED_RELEASE(bias_tensor);
 
-  assert(in_tensor->num_dimensions() >= 2);
-  assert(kernel_tensor->num_dimensions() == 2);
-  assert(bias_tensor->num_dimensions() == 1);
+  assert(in_tensor->getShape().rank() >= 2);
+  assert(kernel_tensor->getShape().rank() == 2);
+  assert(bias_tensor->getShape().rank() == 1);
 
   const auto input_size_with_batch = in_tensor->num_elements();
-  const auto num_units = kernel_tensor->dimension(0);
-  const auto input_size = kernel_tensor->dimension(1);
-  const auto batch_size = input_size_with_batch / input_size;
+  const auto num_units = kernel_tensor->getShape().dim(0);
+  const auto input_size = kernel_tensor->getShape().dim(1);
+  const int32_t batch_size = input_size_with_batch / input_size;
   assert(input_size_with_batch % input_size == 0);
-  assert(num_units == bias_tensor->dimension(0));
+  assert(num_units == bias_tensor->getShape().dim(0));
 
   // Make output tensor info
   ir::Shape output_shape(2);
@@ -68,9 +68,9 @@ void prepareFC(ExecEnv *env, const ir::Operation &node)
 
   // Handle same ifm & ofm data type only
   assert(in_tensor->data_type() == out_tensor->data_type());
-  assert(out_tensor->num_dimensions() == 2);
-  assert(out_tensor->dimension(0) == batch_size);
-  assert(out_tensor->dimension(1) == num_units);
+  assert(out_tensor->getShape().rank() == 2);
+  assert(out_tensor->getShape().dim(0) == batch_size);
+  assert(out_tensor->getShape().dim(1) == num_units);
 }
 
 void invoke(const ITensor *ifm_tensor, const ITensor *ker_tensor, const ITensor *bias_tensor,

--- a/runtime/onert/core/src/interp/operations/Gather.cc
+++ b/runtime/onert/core/src/interp/operations/Gather.cc
@@ -56,9 +56,9 @@ void prepareGather(ExecEnv *env, const ir::Operation &node)
   }
 
   auto output_tensor = env->tensorAt(output_index);
-  auto output_rank = input_tensor->num_dimensions() + indices_tensor->num_dimensions() - 1;
+  auto output_rank = input_tensor->getShape().rank() + indices_tensor->getShape().rank() - 1;
 
-  if (output_rank != output_tensor->num_dimensions())
+  if (output_rank != output_tensor->getShape().rank())
   {
     throw std::runtime_error{"Interp(Gather): Invalid output rank"};
   }
@@ -106,7 +106,7 @@ void invokeGather(const ExecEnv *env, const ir::Operation &node)
   const auto input_tensor = env->tensorAt(input_index);
   const auto indices_tensor = env->tensorAt(indices_index);
   const auto output_tensor = env->tensorAt(output_index);
-  const uint32_t axis = (axis_raw < 0) ? (axis_raw + input_tensor->num_dimensions()) : axis_raw;
+  const uint32_t axis = (axis_raw < 0) ? (axis_raw + input_tensor->getShape().rank()) : axis_raw;
 
   const auto data_type = input_tensor->data_type();
 

--- a/runtime/onert/core/src/interp/operations/InstanceNorm.cc
+++ b/runtime/onert/core/src/interp/operations/InstanceNorm.cc
@@ -38,7 +38,7 @@ void prepareInstanceNorm(ExecEnv *env, const ir::Operation &node)
   const auto output_index = node.getOutputs().at(0);
   const auto input_tensor = env->tensorAt(input_index);
 
-  if (input_tensor->num_dimensions() != 4)
+  if (input_tensor->getShape().rank() != 4)
   {
     throw std::runtime_error{"Interp(InstanceNorm): Input should be 4D-tensor"};
   }

--- a/runtime/onert/core/src/interp/operations/Pad.cc
+++ b/runtime/onert/core/src/interp/operations/Pad.cc
@@ -61,7 +61,7 @@ void invoke(const ITensor *input_tensor, const ITensor *pad_tensor, const ITenso
   const auto pad_buffer = pad_tensor->bufferRO();
   auto output_buffer = output_tensor->buffer();
 
-  int32_t pad_rank = pad_tensor->dimension(0);
+  int32_t pad_rank = pad_tensor->getShape().dim(0);
 
   const auto cker_input_shape = convertShape(input_tensor->tensorInfo().shape());
   const auto cker_output_shape = convertShape(output_tensor->tensorInfo().shape());

--- a/runtime/onert/core/src/interp/operations/Pool2D.cc
+++ b/runtime/onert/core/src/interp/operations/Pool2D.cc
@@ -41,7 +41,7 @@ void preparePool2D(ExecEnv *env, const ir::Operation &node)
   const auto in_tensor = env->tensorAt(in_index);
   UNUSED_RELEASE(in_tensor);
 
-  assert(in_tensor->num_dimensions() == 4);
+  assert(in_tensor->getShape().rank() == 4);
 
   const auto output_info = env->graph().operands().at(out_index).info();
   if (output_info.total_size() == 0)
@@ -62,7 +62,7 @@ void preparePool2D(ExecEnv *env, const ir::Operation &node)
 
   // Handle same ifm & ofm data type only
   assert(in_tensor->data_type() == out_tensor->data_type());
-  assert(out_tensor->num_dimensions() == 4);
+  assert(out_tensor->getShape().rank() == 4);
 }
 
 template <typename T>

--- a/runtime/onert/core/src/interp/operations/Softmax.cc
+++ b/runtime/onert/core/src/interp/operations/Softmax.cc
@@ -37,7 +37,7 @@ void prepareSoftMax(ExecEnv *env, const ir::Operation &node)
   const auto in_tensor = env->tensorAt(in_index);
   UNUSED_RELEASE(in_tensor);
 
-  assert((in_tensor->num_dimensions() == 4) || (in_tensor->num_dimensions() == 2));
+  assert((in_tensor->getShape().rank() == 4) || (in_tensor->getShape().rank() == 2));
 
   // Output shape should be same with input
   // Output type is pre-defined in model
@@ -51,10 +51,10 @@ void prepareSoftMax(ExecEnv *env, const ir::Operation &node)
   UNUSED_RELEASE(out_tensor);
 
   // Check output shape is same with input
-  assert(out_tensor->num_dimensions() == out_tensor->num_dimensions());
-  for (uint32_t i = 0; i < in_tensor->num_dimensions(); i++)
+  assert(out_tensor->getShape().rank() == out_tensor->getShape().rank());
+  for (int32_t i = 0; i < in_tensor->getShape().rank(); i++)
   {
-    assert(in_tensor->dimension(i) == out_tensor->dimension(i));
+    assert(in_tensor->getShape().dim(i) == out_tensor->getShape().dim(i));
   }
 }
 
@@ -66,14 +66,14 @@ void invoke(const ITensor *in_tensor, const ITensor *out_tensor,
 
   float beta = param.beta;
 
-  if (in_tensor->num_dimensions() == 2)
+  if (in_tensor->getShape().rank() == 2)
   {
-    uint32_t batch_size = in_tensor->dimension(0);
-    uint32_t input_size = in_tensor->dimension(1);
+    uint32_t batch_size = in_tensor->getShape().dim(0);
+    uint32_t input_size = in_tensor->getShape().dim(1);
 
     nnfw::cker::Softmax(in_ptr, input_size, batch_size, beta, out_ptr);
   }
-  else if (in_tensor->num_dimensions() == 4)
+  else if (in_tensor->getShape().rank() == 4)
   {
     const auto in_shape = convertShape(in_tensor->tensorInfo().shape());
     const auto out_shape = convertShape(out_tensor->tensorInfo().shape());

--- a/runtime/onert/core/src/interp/operations/TransposeConv.cc
+++ b/runtime/onert/core/src/interp/operations/TransposeConv.cc
@@ -40,9 +40,9 @@ void prepareTransposeConv(ExecEnv *env, const ir::Operation &node)
   const auto ker_tensor = env->tensorAt(ker_index);
   const auto ofm_shape_tensor = env->tensorAt(ofm_shape_index);
 
-  assert(ifm_tensor->num_dimensions() == 4);
-  assert(ker_tensor->num_dimensions() == 4);
-  assert(ofm_shape_tensor->num_dimensions() == 1);
+  assert(ifm_tensor->getShape().rank() == 4);
+  assert(ker_tensor->getShape().rank() == 4);
+  assert(ofm_shape_tensor->getShape().rank() == 1);
 
   UNUSED_RELEASE(ifm_tensor);
   UNUSED_RELEASE(ker_tensor);
@@ -68,7 +68,7 @@ void prepareTransposeConv(ExecEnv *env, const ir::Operation &node)
     throw std::runtime_error{"Interp(TConv): Different I/O data dype"};
   }
 
-  if (ofm_tensor->num_dimensions() != 4)
+  if (ofm_tensor->getShape().rank() != 4)
   {
     throw std::runtime_error{"Interp(TConv): Invalid output rank"};
   }


### PR DESCRIPTION
Remove  interp::ITensor method `num_dimensions` and `dimension` as
those are duplications of `getShape`.

% In the same context with #5363

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>