### PR TITLE
[onert] Independent cpu_common ConstantInitializer

### DIFF
--- a/runtime/onert/core/include/backend/cpu_common/ConstantInitializer.h
+++ b/runtime/onert/core/include/backend/cpu_common/ConstantInitializer.h
@@ -17,10 +17,19 @@
 #ifndef __ONERT_BACKEND_CPU_COMMON_CONSTANT_INITIALIZER_H__
 #define __ONERT_BACKEND_CPU_COMMON_CONSTANT_INITIALIZER_H__
 
-#include "TensorRegistry.h"
+#include <unordered_map>
+#include <functional>
 
-#include "ConstantInitializerBase.h"
-#include <ir/Operands.h>
+#include "TensorRegistry.h"
+#include "ir/Coordinates.h"
+#include "ir/Layout.h"
+#include "ir/Operand.h"
+#include "ir/Operands.h"
+#include "ir/OperationVisitor.h"
+#include "ir/OpSequence.h"
+#include "backend/ITensor.h"
+#include "backend/ITensorRegistry.h"
+#include "util/logging.h"
 
 namespace onert
 {
@@ -29,26 +38,53 @@ namespace backend
 namespace cpu_common
 {
 
-class ConstantInitializer : public ConstantInitializerBase
+class ConstantInitializer : public ir::OperationVisitor
 {
 public:
   ConstantInitializer(const ir::Operands &operands,
                       const std::shared_ptr<ITensorRegistry> &tensor_reg);
 
+  void run()
+  {
+    assert(_tensor_reg);
+    for (const auto &it : _init_map)
+    {
+      const auto &ind = it.first;
+      const auto &fn = it.second;
+
+      const auto &model_obj = _operands.at(ind);
+      auto tensor_obj = _tensor_reg->getNativeITensor(ind);
+      assert(tensor_obj != nullptr);
+      fn(model_obj, *tensor_obj);
+      VERBOSE(FillOperandData) << "Fill data for " << ind << std::endl;
+    }
+    _init_map.clear();
+  }
+
 public:
-  void registerDefaultInitializer(const ir::OperandIndex &index, const ir::Operand &obj) override;
+  ConstantInitializer(const ir::Operands &operands)
+    : _operands{operands}, _current_layout{ir::Layout::UNKNOWN}
+  {
+  }
 
-  // TODO: For now the only cpu backend supports constant tensor to use data from external
-  // If the other backend supports (to do this,
-  // ExternalTensor should be abstract such as IExternal, maybe),
-  // this can be an interface of cpu_common::ConstantInitializerBase
+public:
+  using Initializer = std::function<void(const ir::Operand &, backend::ITensor &)>;
+
+public:
+  void registerDefaultInitializer(const ir::OperandIndex &index, const ir::Operand &obj);
   void registerExternalInitializer(const ir::OperandIndex &, const ir::Operand &);
+  void registerCopyInitializer(const ir::OperandIndex &index, const ir::Operand &obj);
+  void registerPermuteInitializer(const ir::OperandIndex &index, const ir::Operand &obj);
+
+public:
+  void setLayout(ir::Layout layout) { _current_layout = layout; }
+  bool exist(const ir::OperandIndex &ind) { return _init_map.find(ind) != _init_map.end(); }
 
 private:
-  std::shared_ptr<ITensorRegistry> tensor_registry() const override { return _tensor_reg; }
-
-private:
+  const ir::Operands &_operands;
   std::shared_ptr<ITensorRegistry> _tensor_reg;
+  std::unordered_map<ir::OperandIndex, Initializer> _init_map;
+  ir::Layout _current_layout;
 };
 
 } // namespace cpu_common

--- a/runtime/onert/core/src/backend/cpu_common/ConstantInitializer.cc
+++ b/runtime/onert/core/src/backend/cpu_common/ConstantInitializer.cc
@@ -26,7 +26,7 @@ namespace cpu_common
 
 ConstantInitializer::ConstantInitializer(const ir::Operands &operands,
                                          const std::shared_ptr<ITensorRegistry> &tensor_reg)
-  : ConstantInitializerBase{operands}, _tensor_reg{tensor_reg}
+  : _operands{operands}, _tensor_reg{tensor_reg}, _current_layout{ir::Layout::UNKNOWN}
 {
   // DO NOTHING
 }


### PR DESCRIPTION
Make cpu_common::ConstantInitializer not derive from
`ConstantInitializerBase` which will be removed once
doing the same for `acl_common::ConstantInitializer`.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>