### PR TITLE
[nnkit-mocotf] Update clang-format version

### DIFF
--- a/compiler/nnkit-mocotf/.clang-format
+++ b/compiler/nnkit-mocotf/.clang-format
@@ -1,0 +1,1 @@
+../../.clang-format.8

--- a/compiler/nnkit-mocotf/support/src/InputTensorContext.cpp
+++ b/compiler/nnkit-mocotf/support/src/InputTensorContext.cpp
@@ -37,7 +37,7 @@ void InputTensorContext::getMutableFloatTensor(uint32_t n,
 }
 
 void InputTensorContext::getConstFloatTensor(
-    uint32_t n, const nnkit::TensorContext::TypedReader<float> &f) const
+  uint32_t n, const nnkit::TensorContext::TypedReader<float> &f) const
 {
   auto buf = _buffers.at(n).get();
   f(*this, n, *buf);

--- a/compiler/nnkit-mocotf/support/src/InputTensorContext.h
+++ b/compiler/nnkit-mocotf/support/src/InputTensorContext.h
@@ -45,7 +45,7 @@ class InputTensorContext final : public TensorContext
 
 public:
   InputTensorContext(const ParsedTensors &parsed_tensors, const Buffers &buffers)
-      : TensorContext(parsed_tensors), _buffers(buffers)
+    : TensorContext(parsed_tensors), _buffers(buffers)
   { /* empty */
   }
 

--- a/compiler/nnkit-mocotf/support/src/OutputTensorContext.cpp
+++ b/compiler/nnkit-mocotf/support/src/OutputTensorContext.cpp
@@ -30,7 +30,7 @@ namespace tf
 {
 
 void OutputTensorContext::getConstFloatTensor(
-    uint32_t n, const nnkit::TensorContext::TypedReader<float> &f) const
+  uint32_t n, const nnkit::TensorContext::TypedReader<float> &f) const
 { // for output
   using nncc::core::ADT::tensor::LexicalLayout;
   using nncc::core::ADT::tensor::make_overlay;

--- a/compiler/nnkit-mocotf/support/src/OutputTensorContext.h
+++ b/compiler/nnkit-mocotf/support/src/OutputTensorContext.h
@@ -43,7 +43,7 @@ class OutputTensorContext final : public TensorContext
 {
 public:
   OutputTensorContext(const ParsedTensors &parsed_tensors, locomotiv::Session *sess)
-      : TensorContext(parsed_tensors), _sess(sess)
+    : TensorContext(parsed_tensors), _sess(sess)
   { /* empty */
   }
 


### PR DESCRIPTION
Use clang-format-8 style for nnkit-mocotf

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>