### PR TITLE
[onert] Independent acl ConstantInitializer

### DIFF
--- a/runtime/onert/backend/acl_common/AclConstantInitializer.cc
+++ b/runtime/onert/backend/acl_common/AclConstantInitializer.cc
@@ -25,7 +25,7 @@ namespace acl_common
 
 AclConstantInitializer::AclConstantInitializer(const ir::Operands &operands,
                                                const std::shared_ptr<ITensorRegistry> &tensor_reg)
-  : cpu_common::ConstantInitializerBase{operands}, _tensor_reg{tensor_reg}
+  : _operands{operands}, _tensor_reg{tensor_reg}, _current_layout{ir::Layout::UNKNOWN}
 {
   // DO NOTHING
 }
@@ -124,6 +124,94 @@ void AclConstantInitializer::visit(const ir::operation::RNN &node)
 void AclConstantInitializer::visit(const ir::operation::TransposeConv &node)
 {
   permuteInputInitialize(node, ir::operation::TransposeConv::KERNEL);
+}
+
+// NOTE Workaround for 16b float type. Here, this is enough since only the size of bytes matters.
+using float16 = uint16_t;
+
+void AclConstantInitializer::registerCopyInitializer(const ir::OperandIndex &index,
+                                                     const ir::Operand &obj)
+{
+  // For only CONSTANTS
+  // TODO Add to check if tensor has been allocated
+  if (!obj.isConstant())
+    return;
+
+  const auto type = obj.typeInfo().type();
+  using ir::DataType;
+
+  switch (type)
+  {
+    case DataType::FLOAT32:
+      _init_map[index] = copyInit<float>;
+      break;
+    case DataType::INT32:
+      _init_map[index] = copyInit<int32_t>;
+      break;
+    case DataType::UINT32:
+      _init_map[index] = copyInit<uint32_t>;
+      break;
+    case DataType::BOOL8:
+    case DataType::QUANT_UINT8_ASYMM:
+      _init_map[index] = copyInit<uint8_t>;
+      break;
+    case DataType::QUANT_INT8_SYMM:
+    case DataType::QUANT_INT8_ASYMM:
+      _init_map[index] = copyInit<int8_t>;
+      break;
+    case DataType::FLOAT16:
+      _init_map[index] = copyInit<float16>;
+      break;
+    case DataType::INT64:
+      _init_map[index] = copyInit<int64_t>;
+      break;
+    default:
+      throw std::runtime_error("Not supported, yet");
+      break;
+  }
+}
+
+void AclConstantInitializer::registerPermuteInitializer(const ir::OperandIndex &index,
+                                                        const ir::Operand &obj)
+{
+  // For only CONSTANTS
+  // TODO Add to check if tensor has been allocated
+  if (!obj.isConstant())
+    return;
+
+  const auto type = obj.typeInfo().type();
+  using ir::DataType;
+  using namespace std::placeholders;
+
+  switch (type)
+  {
+    case DataType::FLOAT32:
+      _init_map[index] = std::bind(permuteInit<float>, _1, _2, _current_layout);
+      break;
+    case DataType::INT32:
+      _init_map[index] = std::bind(permuteInit<int32_t>, _1, _2, _current_layout);
+      break;
+    case DataType::UINT32:
+      _init_map[index] = std::bind(permuteInit<uint32_t>, _1, _2, _current_layout);
+      break;
+    case DataType::BOOL8:
+    case DataType::QUANT_UINT8_ASYMM:
+      _init_map[index] = std::bind(permuteInit<uint8_t>, _1, _2, _current_layout);
+      break;
+    case DataType::QUANT_INT8_SYMM:
+    case DataType::QUANT_INT8_ASYMM:
+      _init_map[index] = std::bind(permuteInit<int8_t>, _1, _2, _current_layout);
+      break;
+    case DataType::FLOAT16:
+      _init_map[index] = std::bind(permuteInit<float16>, _1, _2, _current_layout);
+      break;
+    case DataType::INT64:
+      _init_map[index] = std::bind(permuteInit<int64_t>, _1, _2, _current_layout);
+      break;
+    default:
+      throw std::runtime_error("Not supported, yet");
+      break;
+  }
 }
 
 } // namespace acl_common

--- a/runtime/onert/backend/acl_common/AclConstantInitializer.h
+++ b/runtime/onert/backend/acl_common/AclConstantInitializer.h
@@ -17,9 +17,19 @@
 #ifndef __ONERT_COMPILER_ACL_COMMON_ACLCONSTANT_INITIALIZER_H__
 #define __ONERT_COMPILER_ACL_COMMON_ACLCONSTANT_INITIALIZER_H__
 
-#include <backend/cpu_common/ConstantInitializerBase.h>
-#include <ir/Operands.h>
 #include "AclTensorRegistry.h"
+
+#include <unordered_map>
+#include <functional>
+
+#include <ir/Coordinates.h>
+#include <ir/Layout.h>
+#include <ir/Operand.h>
+#include <ir/Operands.h>
+#include <ir/OperationVisitor.h>
+#include <ir/OpSequence.h>
+#include <backend/ITensorRegistry.h>
+#include <util/logging.h>
 
 namespace onert
 {
@@ -28,11 +38,160 @@ namespace backend
 namespace acl_common
 {
 
-class AclConstantInitializer : public cpu_common::ConstantInitializerBase
+template <typename T>
+static void Init(const onert::ir::Operand &model_obj, onert::backend::ITensor &obj, const bool copy,
+                 const onert::ir::Layout frontend_layout = onert::ir::Layout::UNKNOWN)
 {
+  const auto shape = model_obj.shape();
+  assert(model_obj.data());
+  auto base = reinterpret_cast<const T *>(model_obj.data()->base());
+
+  obj.access([&](::onert::backend::ITensor &tensor) {
+    switch (shape.rank())
+    {
+      case 0:
+      {
+        assert(model_obj.data()->size() == sizeof(T));
+        const auto value = *reinterpret_cast<const T *>(base);
+        T *into = reinterpret_cast<T *>(tensor.buffer());
+        *into = value;
+        break;
+      }
+      case 1:
+      {
+        auto vec_size = shape.dim(0);
+        for (int32_t n = 0; n < vec_size; ++n)
+        {
+          const T *from = reinterpret_cast<const T *>(base) + n;
+          const auto value = *from;
+
+          T *into = reinterpret_cast<T *>(tensor.buffer()) + n;
+
+          *into = value;
+        }
+        break;
+      }
+      case 2:
+      {
+        const int32_t copy_len = shape.dim(1);
+
+        for (auto i = 0; i < shape.dim(0); ++i)
+        {
+          ::onert::ir::Coordinates coords{i, 0};
+          memcpy(tensor.buffer() + tensor.calcOffset(coords), base + i * copy_len,
+                 copy_len * sizeof(T));
+        }
+        break;
+      }
+      case 3:
+      {
+        const int32_t width = shape.dim(1);
+        const int32_t copy_len = shape.dim(2);
+
+        for (auto i = 0; i < shape.dim(0); ++i)
+        {
+          for (auto j = 0; j < shape.dim(1); ++j)
+          {
+            ::onert::ir::Coordinates coords{i, j, 0};
+            memcpy(tensor.buffer() + tensor.calcOffset(coords),
+                   base + i * width * copy_len + j * copy_len, copy_len * sizeof(T));
+          }
+        }
+        break;
+      }
+      case 4:
+      {
+        const int32_t height = shape.dim(1);
+        const int32_t width = shape.dim(2);
+        const int32_t copy_len = shape.dim(3);
+        for (auto i = 0; i < shape.dim(0); ++i)
+        {
+          for (auto j = 0; j < shape.dim(1); ++j)
+          {
+            for (auto k = 0; k < shape.dim(2); ++k)
+            {
+              if (copy)
+              {
+                ::onert::ir::Coordinates coords{i, j, k, 0};
+                memcpy(tensor.buffer() + tensor.calcOffset(coords),
+                       base + i * height * width * copy_len + j * width * copy_len + k * copy_len,
+                       copy_len * sizeof(T));
+              }
+              else
+              {
+                for (auto l = 0; l < shape.dim(3); ++l)
+                {
+                  const auto coords =
+                    ::onert::ir::convertCoordinates({i, j, k, l}, frontend_layout, tensor.layout());
+                  T *into = reinterpret_cast<T *>(tensor.buffer() + tensor.calcOffset(coords));
+                  T value = *(base + i * height * width * copy_len + j * width * copy_len +
+                              k * copy_len + l);
+                  *into = value;
+                }
+              }
+            }
+          }
+        }
+        break;
+      }
+      default:
+        throw std::runtime_error{"Not yet supported"};
+    }
+  });
+}
+
+template <typename T>
+void copyInit(const onert::ir::Operand &model_obj, onert::backend::ITensor &obj)
+{
+  Init<T>(model_obj, obj, true);
+}
+
+template <typename T>
+void permuteInit(const onert::ir::Operand &model_obj, onert::backend::ITensor &obj,
+                 const onert::ir::Layout frontend_layout)
+{
+  const bool copy = frontend_layout == obj.layout();
+  Init<T>(model_obj, obj, copy, frontend_layout);
+}
+
+class AclConstantInitializer : public ir::OperationVisitor
+{
+public:
+  void run()
+  {
+    assert(_tensor_reg);
+    for (const auto &it : _init_map)
+    {
+      const auto &ind = it.first;
+      const auto &fn = it.second;
+
+      const auto &model_obj = _operands.at(ind);
+      auto tensor_obj = _tensor_reg->getNativeITensor(ind);
+      assert(tensor_obj != nullptr);
+      fn(model_obj, *tensor_obj);
+      VERBOSE(FillOperandData) << "Fill data for operand " << ind << std::endl;
+    }
+    _init_map.clear();
+  }
+
 public:
   AclConstantInitializer(const ir::Operands &operands,
                          const std::shared_ptr<ITensorRegistry> &tensor_reg);
+
+public:
+  using Initializer = std::function<void(const ir::Operand &, backend::ITensor &)>;
+
+public:
+  void registerDefaultInitializer(const ir::OperandIndex &index, const ir::Operand &obj)
+  {
+    registerPermuteInitializer(index, obj);
+  }
+  void registerCopyInitializer(const ir::OperandIndex &index, const ir::Operand &obj);
+  void registerPermuteInitializer(const ir::OperandIndex &index, const ir::Operand &obj);
+
+public:
+  void setLayout(ir::Layout layout) { _current_layout = layout; }
+  bool exist(const ir::OperandIndex &ind) { return _init_map.find(ind) != _init_map.end(); }
 
 public:
   void visit(const ir::operation::BatchToSpaceND &) override;
@@ -47,11 +206,11 @@ protected:
   void copyInputInitialize(const ir::Operation &node, uint32_t index);
   void permuteInputInitialize(const ir::Operation &node, uint32_t index);
 
-private:
-  std::shared_ptr<ITensorRegistry> tensor_registry() const final { return _tensor_reg; }
-
 protected:
+  const ir::Operands &_operands;
   std::shared_ptr<ITensorRegistry> _tensor_reg;
+  std::unordered_map<ir::OperandIndex, Initializer> _init_map;
+  ir::Layout _current_layout;
 };
 
 } // namespace acl_common


### PR DESCRIPTION
Make cpu_common::ConstantInitializer not derive from
`ConstantInitializerBase`.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>