### PR TITLE
[nnkit-tflite] Update clang-format version

### DIFF
--- a/compiler/nnkit-tflite/.clang-format
+++ b/compiler/nnkit-tflite/.clang-format
@@ -1,0 +1,1 @@
+../../.clang-format.8

--- a/compiler/nnkit-tflite/backend/Backend.cpp
+++ b/compiler/nnkit-tflite/backend/Backend.cpp
@@ -51,7 +51,7 @@ private:
   std::unique_ptr<::tflite::FlatBufferModel> _model;
   std::unique_ptr<::tflite::Interpreter> _interp;
 };
-}
+} // namespace
 
 #include <nnkit/CmdlineArguments.h>
 #include <stdex/Memory.h>


### PR DESCRIPTION
Use clang-format-8 style for nnkit-tflite

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>