### PR TITLE
[plier-tf] Update clang-format version

### DIFF
--- a/compiler/plier-tf/.clang-format
+++ b/compiler/plier-tf/.clang-format
@@ -1,0 +1,1 @@
+../../.clang-format.8

--- a/compiler/plier-tf/src/TestHelper.cpp
+++ b/compiler/plier-tf/src/TestHelper.cpp
@@ -40,7 +40,7 @@ struct membuf : std::streambuf
 struct imemstream : virtual membuf, std::istream
 {
   imemstream(char const *base, size_t size)
-      : membuf(base, size), std::istream(static_cast<std::streambuf *>(this))
+    : membuf(base, size), std::istream(static_cast<std::streambuf *>(this))
   {
   }
 };


### PR DESCRIPTION
Use clang-format-8 style for plier-tf

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>