### PR TITLE
[one-cmds] Add comments to one-build test

### DIFF
--- a/compiler/one-cmds/tests/one-build_001.test
+++ b/compiler/one-cmds/tests/one-build_001.test
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# one-import-tf -> one-optimize
+
 filename_ext="$(basename -- $0)"
 filename="${filename_ext%.*}"
 

--- a/compiler/one-cmds/tests/one-build_002.test
+++ b/compiler/one-cmds/tests/one-build_002.test
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# one-import-tf -> one-optimize -> one-pack
+
 filename_ext="$(basename -- $0)"
 filename="${filename_ext%.*}"
 

--- a/compiler/one-cmds/tests/one-build_003.test
+++ b/compiler/one-cmds/tests/one-build_003.test
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# one-import-tf -> one-quantize
+
 filename_ext="$(basename -- $0)"
 filename="${filename_ext%.*}"
 


### PR DESCRIPTION
This commit adds some comments to one-build test to let users know the
drvier execution seqeunce.

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>