### PR TITLE
[tfl-inspect] Update clang-format version

### DIFF
--- a/compiler/tfl-inspect/.clang-format
+++ b/compiler/tfl-inspect/.clang-format
@@ -1,0 +1,1 @@
+../../.clang-format.8

--- a/compiler/tfl-inspect/driver/Driver.cpp
+++ b/compiler/tfl-inspect/driver/Driver.cpp
@@ -32,8 +32,8 @@ int entry(int argc, char **argv)
                      "Lite model files"};
   arser.add_argument("--operators").nargs(0).help("Dump operators in tflite file");
   arser.add_argument("--conv2d_weight")
-      .nargs(0)
-      .help("Dump Conv2D series weight operators in tflite file");
+    .nargs(0)
+    .help("Dump Conv2D series weight operators in tflite file");
   arser.add_argument("--op_version").nargs(0).help("Dump versions of the operators in tflite file");
   arser.add_argument("tflite").type(arser::DataType::STR).help("TFLite file to inspect");
 


### PR DESCRIPTION
Use clang-format-8 style for tfl-inspect

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>