### PR TITLE
[tflit2circle] Update clang-format version

### DIFF
--- a/compiler/tflite2circle/.clang-format
+++ b/compiler/tflite2circle/.clang-format
@@ -1,0 +1,1 @@
+../../.clang-format.8

--- a/compiler/tflite2circle/driver/Driver.cpp
+++ b/compiler/tflite2circle/driver/Driver.cpp
@@ -37,16 +37,16 @@ int entry(int argc, char **argv)
   arser::Arser arser{"tflite2circle is a Tensorflow lite to circle model converter"};
 
   arser.add_argument("--version")
-      .nargs(0)
-      .required(false)
-      .default_value(false)
-      .help("Show version information and exit")
-      .exit_with(print_version);
+    .nargs(0)
+    .required(false)
+    .default_value(false)
+    .help("Show version information and exit")
+    .exit_with(print_version);
 
   arser.add_argument("tflite")
-      .nargs(1)
-      .type(arser::DataType::STR)
-      .help("Source tflite file path to convert");
+    .nargs(1)
+    .type(arser::DataType::STR)
+    .help("Source tflite file path to convert");
   arser.add_argument("circle").nargs(1).type(arser::DataType::STR).help("Target circle file path");
 
   try

--- a/compiler/tflite2circle/src/BuildBuiltinOptions/AddOptions.cpp
+++ b/compiler/tflite2circle/src/BuildBuiltinOptions/AddOptions.cpp
@@ -29,7 +29,7 @@ flatbuffers::Offset<circle::AddOptions> build_circle_AddOptions(flatbuffers::Fla
   assert(tflite_builtin_options);
   circle::AddOptionsBuilder builtin_options_builder{fb};
   builtin_options_builder.add_fused_activation_function(
-      get_circle_activation_function_type(tflite_builtin_options->fused_activation_function()));
+    get_circle_activation_function_type(tflite_builtin_options->fused_activation_function()));
   return builtin_options_builder.Finish();
 }
 

--- a/compiler/tflite2circle/src/BuildBuiltinOptions/ArgMaxOptions.cpp
+++ b/compiler/tflite2circle/src/BuildBuiltinOptions/ArgMaxOptions.cpp
@@ -29,7 +29,7 @@ build_circle_ArgMaxOptions(flatbuffers::FlatBufferBuilder &fb, const tflite::Ope
   assert(tflite_builtin_options);
   circle::ArgMaxOptionsBuilder builtin_options_builder{fb};
   builtin_options_builder.add_output_type(
-      get_circle_tensortype(tflite_builtin_options->output_type()));
+    get_circle_tensortype(tflite_builtin_options->output_type()));
   return builtin_options_builder.Finish();
 }
 

--- a/compiler/tflite2circle/src/BuildBuiltinOptions/ArgMinOptions.cpp
+++ b/compiler/tflite2circle/src/BuildBuiltinOptions/ArgMinOptions.cpp
@@ -29,7 +29,7 @@ build_circle_ArgMinOptions(flatbuffers::FlatBufferBuilder &fb, const tflite::Ope
   assert(tflite_builtin_options);
   circle::ArgMinOptionsBuilder builtin_options_builder{fb};
   builtin_options_builder.add_output_type(
-      get_circle_tensortype(tflite_builtin_options->output_type()));
+    get_circle_tensortype(tflite_builtin_options->output_type()));
   return builtin_options_builder.Finish();
 }
 

--- a/compiler/tflite2circle/src/BuildBuiltinOptions/CastOptions.cpp
+++ b/compiler/tflite2circle/src/BuildBuiltinOptions/CastOptions.cpp
@@ -31,9 +31,9 @@ build_circle_CastOptions(flatbuffers::FlatBufferBuilder &fb, const tflite::Opera
 
   circle::CastOptionsBuilder builtin_options_builder{fb};
   builtin_options_builder.add_in_data_type(
-      get_circle_tensortype(tflite_builtin_options->in_data_type()));
+    get_circle_tensortype(tflite_builtin_options->in_data_type()));
   builtin_options_builder.add_out_data_type(
-      get_circle_tensortype(tflite_builtin_options->out_data_type()));
+    get_circle_tensortype(tflite_builtin_options->out_data_type()));
   return builtin_options_builder.Finish();
 }
 

--- a/compiler/tflite2circle/src/BuildBuiltinOptions/ConcatenationOptions.cpp
+++ b/compiler/tflite2circle/src/BuildBuiltinOptions/ConcatenationOptions.cpp
@@ -30,7 +30,7 @@ build_circle_ConcatenationOptions(flatbuffers::FlatBufferBuilder &fb, const tfli
   circle::ConcatenationOptionsBuilder builtin_options_builder{fb};
   builtin_options_builder.add_axis(tflite_builtin_options->axis());
   builtin_options_builder.add_fused_activation_function(
-      get_circle_activation_function_type(tflite_builtin_options->fused_activation_function()));
+    get_circle_activation_function_type(tflite_builtin_options->fused_activation_function()));
   return builtin_options_builder.Finish();
 }
 

--- a/compiler/tflite2circle/src/BuildBuiltinOptions/Conv2DOptions.cpp
+++ b/compiler/tflite2circle/src/BuildBuiltinOptions/Conv2DOptions.cpp
@@ -32,7 +32,7 @@ build_circle_Conv2DOptions(flatbuffers::FlatBufferBuilder &fb, const tflite::Ope
   builtin_options_builder.add_stride_w(tflite_builtin_options->stride_w());
   builtin_options_builder.add_stride_h(tflite_builtin_options->stride_h());
   builtin_options_builder.add_fused_activation_function(
-      get_circle_activation_function_type(tflite_builtin_options->fused_activation_function()));
+    get_circle_activation_function_type(tflite_builtin_options->fused_activation_function()));
   builtin_options_builder.add_dilation_w_factor(tflite_builtin_options->dilation_w_factor());
   builtin_options_builder.add_dilation_h_factor(tflite_builtin_options->dilation_h_factor());
   return builtin_options_builder.Finish();

--- a/compiler/tflite2circle/src/BuildBuiltinOptions/DepthwiseConv2DOptions.cpp
+++ b/compiler/tflite2circle/src/BuildBuiltinOptions/DepthwiseConv2DOptions.cpp
@@ -33,7 +33,7 @@ build_circle_DepthwiseConv2DOptions(flatbuffers::FlatBufferBuilder &fb, const tf
   builtin_options_builder.add_stride_h(tflite_builtin_options->stride_h());
   builtin_options_builder.add_depth_multiplier(tflite_builtin_options->depth_multiplier());
   builtin_options_builder.add_fused_activation_function(
-      get_circle_activation_function_type(tflite_builtin_options->fused_activation_function()));
+    get_circle_activation_function_type(tflite_builtin_options->fused_activation_function()));
   builtin_options_builder.add_dilation_w_factor(tflite_builtin_options->dilation_w_factor());
   builtin_options_builder.add_dilation_h_factor(tflite_builtin_options->dilation_h_factor());
   return builtin_options_builder.Finish();

--- a/compiler/tflite2circle/src/BuildBuiltinOptions/DivOptions.cpp
+++ b/compiler/tflite2circle/src/BuildBuiltinOptions/DivOptions.cpp
@@ -29,7 +29,7 @@ flatbuffers::Offset<circle::DivOptions> build_circle_DivOptions(flatbuffers::Fla
   assert(tflite_builtin_options);
   circle::DivOptionsBuilder builtin_options_builder{fb};
   builtin_options_builder.add_fused_activation_function(
-      get_circle_activation_function_type(tflite_builtin_options->fused_activation_function()));
+    get_circle_activation_function_type(tflite_builtin_options->fused_activation_function()));
   return builtin_options_builder.Finish();
 }
 

--- a/compiler/tflite2circle/src/BuildBuiltinOptions/FullyConnectedOptions.cpp
+++ b/compiler/tflite2circle/src/BuildBuiltinOptions/FullyConnectedOptions.cpp
@@ -29,14 +29,14 @@ build_circle_FullyConnectedOptions(flatbuffers::FlatBufferBuilder &fb, const tfl
   assert(tflite_builtin_options);
   circle::FullyConnectedOptionsBuilder builtin_options_builder{fb};
   builtin_options_builder.add_fused_activation_function(
-      get_circle_activation_function_type(tflite_builtin_options->fused_activation_function()));
+    get_circle_activation_function_type(tflite_builtin_options->fused_activation_function()));
   // Get FullyConnectedOptionsWeightsFormat
   auto tflite_weight_format = tflite_builtin_options->weights_format();
   if (tflite_weight_format == tflite::FullyConnectedOptionsWeightsFormat_DEFAULT)
     builtin_options_builder.add_weights_format(circle::FullyConnectedOptionsWeightsFormat_DEFAULT);
   else if (tflite_weight_format == tflite::FullyConnectedOptionsWeightsFormat_SHUFFLED4x16INT8)
     builtin_options_builder.add_weights_format(
-        circle::FullyConnectedOptionsWeightsFormat_SHUFFLED4x16INT8);
+      circle::FullyConnectedOptionsWeightsFormat_SHUFFLED4x16INT8);
   return builtin_options_builder.Finish();
 }
 

--- a/compiler/tflite2circle/src/BuildBuiltinOptions/L2NormalizeOptions.cpp
+++ b/compiler/tflite2circle/src/BuildBuiltinOptions/L2NormalizeOptions.cpp
@@ -29,7 +29,7 @@ build_circle_L2NormOptions(flatbuffers::FlatBufferBuilder &fb, const tflite::Ope
   assert(tflite_builtin_options);
   circle::L2NormOptionsBuilder builtin_options_builder{fb};
   builtin_options_builder.add_fused_activation_function(
-      get_circle_activation_function_type(tflite_builtin_options->fused_activation_function()));
+    get_circle_activation_function_type(tflite_builtin_options->fused_activation_function()));
   return builtin_options_builder.Finish();
 }
 

--- a/compiler/tflite2circle/src/BuildBuiltinOptions/MulOptions.cpp
+++ b/compiler/tflite2circle/src/BuildBuiltinOptions/MulOptions.cpp
@@ -29,7 +29,7 @@ flatbuffers::Offset<circle::MulOptions> build_circle_MulOptions(flatbuffers::Fla
   assert(tflite_builtin_options);
   circle::MulOptionsBuilder builtin_options_builder{fb};
   builtin_options_builder.add_fused_activation_function(
-      get_circle_activation_function_type(tflite_builtin_options->fused_activation_function()));
+    get_circle_activation_function_type(tflite_builtin_options->fused_activation_function()));
   return builtin_options_builder.Finish();
 }
 

--- a/compiler/tflite2circle/src/BuildBuiltinOptions/Pool2DOptions.cpp
+++ b/compiler/tflite2circle/src/BuildBuiltinOptions/Pool2DOptions.cpp
@@ -34,7 +34,7 @@ build_circle_Pool2DOptions(flatbuffers::FlatBufferBuilder &fb, const tflite::Ope
   builtin_options_builder.add_filter_width(tflite_builtin_options->filter_width());
   builtin_options_builder.add_filter_height(tflite_builtin_options->filter_height());
   builtin_options_builder.add_fused_activation_function(
-      get_circle_activation_function_type(tflite_builtin_options->fused_activation_function()));
+    get_circle_activation_function_type(tflite_builtin_options->fused_activation_function()));
   return builtin_options_builder.Finish();
 }
 

--- a/compiler/tflite2circle/src/BuildBuiltinOptions/SubOptions.cpp
+++ b/compiler/tflite2circle/src/BuildBuiltinOptions/SubOptions.cpp
@@ -29,7 +29,7 @@ flatbuffers::Offset<circle::SubOptions> build_circle_SubOptions(flatbuffers::Fla
   assert(tflite_builtin_options);
   circle::SubOptionsBuilder builtin_options_builder{fb};
   builtin_options_builder.add_fused_activation_function(
-      get_circle_activation_function_type(tflite_builtin_options->fused_activation_function()));
+    get_circle_activation_function_type(tflite_builtin_options->fused_activation_function()));
   return builtin_options_builder.Finish();
 }
 

--- a/compiler/tflite2circle/src/BuildBuiltinOptions/UnidirectionalSequenceLSTMOptions.cpp
+++ b/compiler/tflite2circle/src/BuildBuiltinOptions/UnidirectionalSequenceLSTMOptions.cpp
@@ -29,12 +29,12 @@ build_circle_UnidirectionalSequenceLSTMOptions(flatbuffers::FlatBufferBuilder &f
   auto tflite_builtin_options = op->builtin_options_as_UnidirectionalSequenceLSTMOptions();
   circle::UnidirectionalSequenceLSTMOptionsBuilder builtin_options_builder{fb};
   builtin_options_builder.add_fused_activation_function(
-      get_circle_activation_function_type(tflite_builtin_options->fused_activation_function()));
+    get_circle_activation_function_type(tflite_builtin_options->fused_activation_function()));
   builtin_options_builder.add_cell_clip(tflite_builtin_options->cell_clip());
   builtin_options_builder.add_proj_clip(tflite_builtin_options->proj_clip());
   builtin_options_builder.add_time_major(tflite_builtin_options->time_major());
   builtin_options_builder.add_asymmetric_quantize_inputs(
-      tflite_builtin_options->asymmetric_quantize_inputs());
+    tflite_builtin_options->asymmetric_quantize_inputs());
   return builtin_options_builder.Finish();
 }
 

--- a/compiler/tflite2circle/src/BuildBuiltinOptions/UniqueOptions.cpp
+++ b/compiler/tflite2circle/src/BuildBuiltinOptions/UniqueOptions.cpp
@@ -29,7 +29,7 @@ build_circle_UniqueOptions(flatbuffers::FlatBufferBuilder &fb, const tflite::Ope
   assert(tflite_builtin_options);
   circle::UniqueOptionsBuilder builtin_options_builder{fb};
   builtin_options_builder.add_idx_out_type(
-      get_circle_tensortype(tflite_builtin_options->idx_out_type()));
+    get_circle_tensortype(tflite_builtin_options->idx_out_type()));
   return builtin_options_builder.Finish();
 }
 

--- a/compiler/tflite2circle/src/CircleModel.cpp
+++ b/compiler/tflite2circle/src/CircleModel.cpp
@@ -126,13 +126,13 @@ Offset<SubGraphLink>::Offset(FlatBufBuilder &fb, const TFLFlatBufVec *tflite_fla
         flatbuffers::Offset<flatbuffers::Vector<int32_t>> traversal_order;
         flatbuffers::Offset<flatbuffers::Vector<int32_t>> block_map;
         flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<circle::DimensionMetadata>>>
-            dim_metadata;
+          dim_metadata;
 
         // traversal_order
         if (it->sparsity()->traversal_order())
         {
           auto traversal_order_vec = std::vector<int32_t>{
-              it->sparsity()->traversal_order()->begin(), it->sparsity()->traversal_order()->end()};
+            it->sparsity()->traversal_order()->begin(), it->sparsity()->traversal_order()->end()};
           traversal_order = fb->CreateVector(traversal_order_vec);
         }
 
@@ -152,16 +152,16 @@ Offset<SubGraphLink>::Offset(FlatBufBuilder &fb, const TFLFlatBufVec *tflite_fla
           // array_segments
           auto tflite_array_segments_type = it->array_segments_type();
           auto circle_array_segments =
-              get_circle_sparse_index_vector(*fb, it->array_segments(), tflite_array_segments_type);
+            get_circle_sparse_index_vector(*fb, it->array_segments(), tflite_array_segments_type);
           auto circle_array_segments_type =
-              get_circle_sparse_index_vector_type(tflite_array_segments_type);
+            get_circle_sparse_index_vector_type(tflite_array_segments_type);
 
           // array_indices
           auto tflite_array_indices_type = it->array_indices_type();
           auto circle_array_indices =
-              get_circle_sparse_index_vector(*fb, it->array_indices(), tflite_array_indices_type);
+            get_circle_sparse_index_vector(*fb, it->array_indices(), tflite_array_indices_type);
           auto circle_array_indices_type =
-              get_circle_sparse_index_vector_type(tflite_array_indices_type);
+            get_circle_sparse_index_vector_type(tflite_array_indices_type);
 
           auto circle_dim_metadata_builder = circle::DimensionMetadataBuilder{*fb};
 
@@ -184,7 +184,7 @@ Offset<SubGraphLink>::Offset(FlatBufBuilder &fb, const TFLFlatBufVec *tflite_fla
       if (it->shape_signature())
       {
         auto shape_signature_vec =
-            std::vector<int32_t>({it->shape_signature()->begin(), it->shape_signature()->end()});
+          std::vector<int32_t>({it->shape_signature()->begin(), it->shape_signature()->end()});
         shape_signature = fb->CreateVector(shape_signature_vec);
       }
 
@@ -297,7 +297,7 @@ Offset<OperatorCodeLink>::Offset(FlatBufBuilder &fb, const TFLFlatBufVec *tflite
 }
 
 CircleModel::CircleModel(FlatBufBuilder &fb, TFLModel &model)
-    : _version{0}, _description{fb->CreateString("nnpackage")}, _fb{fb}
+  : _version{0}, _description{fb->CreateString("nnpackage")}, _fb{fb}
 {
   const tflite::Model *tfl_model = model.load_model();
   // verify flatbuffers
@@ -309,11 +309,11 @@ CircleModel::CircleModel(FlatBufBuilder &fb, TFLModel &model)
   }
 
   _operator_codes_offset =
-      std::make_unique<Offset<OperatorCodeLink>>(fb, tfl_model->operator_codes());
+    std::make_unique<Offset<OperatorCodeLink>>(fb, tfl_model->operator_codes());
   _subGraphs_offset = std::make_unique<Offset<SubGraphLink>>(fb, tfl_model->subgraphs());
   _buffers_offset = std::make_unique<Offset<BufferLink>>(fb, tfl_model->buffers());
   _metadata_buffer_offset =
-      std::make_unique<Offset<MetaDataBufferLink>>(fb, tfl_model->metadata_buffer());
+    std::make_unique<Offset<MetaDataBufferLink>>(fb, tfl_model->metadata_buffer());
   model_build();
 }
 

--- a/compiler/tflite2circle/src/DataLookup.cpp
+++ b/compiler/tflite2circle/src/DataLookup.cpp
@@ -148,7 +148,7 @@ get_circle_sparse_index_vector(flatbuffers::FlatBufferBuilder &fb, const void *v
     {
       const tflite::Int32Vector *i32_array = static_cast<const tflite::Int32Vector *>(v_array);
       auto values_vec_int32 =
-          std::vector<int32_t>{i32_array->values()->begin(), i32_array->values()->end()};
+        std::vector<int32_t>{i32_array->values()->begin(), i32_array->values()->end()};
       auto values_int32 = fb.CreateVector(values_vec_int32);
       circle::Int32VectorBuilder int32_vector_builder{fb};
       int32_vector_builder.add_values(values_int32);
@@ -158,7 +158,7 @@ get_circle_sparse_index_vector(flatbuffers::FlatBufferBuilder &fb, const void *v
     {
       const tflite::Uint16Vector *u16_array = static_cast<const tflite::Uint16Vector *>(v_array);
       auto values_vec_uint16 =
-          std::vector<uint16_t>{u16_array->values()->begin(), u16_array->values()->end()};
+        std::vector<uint16_t>{u16_array->values()->begin(), u16_array->values()->end()};
       auto values_uint16 = fb.CreateVector(values_vec_uint16);
       circle::Uint16VectorBuilder uint16_vector_builder{fb};
       uint16_vector_builder.add_values(values_uint16);
@@ -168,7 +168,7 @@ get_circle_sparse_index_vector(flatbuffers::FlatBufferBuilder &fb, const void *v
     {
       const tflite::Uint8Vector *u8_array = static_cast<const tflite::Uint8Vector *>(v_array);
       auto values_vec_uint8 =
-          std::vector<uint8_t>{u8_array->values()->begin(), u8_array->values()->end()};
+        std::vector<uint8_t>{u8_array->values()->begin(), u8_array->values()->end()};
       auto values_uint8 = fb.CreateVector(values_vec_uint8);
       circle::Uint8VectorBuilder uint8_vector_builder{fb};
       uint8_vector_builder.add_values(values_uint8);

--- a/compiler/tflite2circle/src/DataLookup.h
+++ b/compiler/tflite2circle/src/DataLookup.h
@@ -27,19 +27,19 @@ namespace tflite2circle
  * @brief Returns circle builtin_code according to tflite.
  *
  * @note You can see a list of currently supported BuiltinOperator in TFLOperator.lst file.
-*/
+ */
 circle::BuiltinOperator get_circle_builtin_code(tflite::BuiltinOperator tfl_bop);
 
 /**
  * @brief Returns circle TensorType according to tflite.
  *
  * @note You can see a list of currently supported TensorType in TFLTensorType.lst file.
-*/
+ */
 circle::TensorType get_circle_tensortype(tflite::TensorType tfl_tt);
 
 /**
  * @brief Returns circle Padding enum according to tflite.
-*/
+ */
 circle::Padding get_circle_padding(tflite::Padding tfl_p);
 
 /**
@@ -47,7 +47,7 @@ circle::Padding get_circle_padding(tflite::Padding tfl_p);
  *
  * @note You can see a list of currently supported ActivationFunctionType in
  *       TFLActivationFunctionType.lst file.
-*/
+ */
 circle::ActivationFunctionType
 get_circle_activation_function_type(tflite::ActivationFunctionType tfl_aft);
 
@@ -60,7 +60,7 @@ get_circle_activation_function_type(tflite::ActivationFunctionType tfl_aft);
  *       This function calls the build_circle_##BuiltinOptions internally(e.g.
  *       build_circle_AbsOptions, build_circle_AddOptions, etc.), so refer to it for a more
  *       detailed implementation.
-*/
+ */
 flatbuffers::Offset<void> get_circle_builtin_options(flatbuffers::FlatBufferBuilder &fb,
                                                      const tflite::Operator *op);
 
@@ -68,29 +68,29 @@ flatbuffers::Offset<void> get_circle_builtin_options(flatbuffers::FlatBufferBuil
  * @brief Returns circle builtin_options_type according to tflite.
  *
  * @note You can see a list of currently supported BuiltinOptions in TFLBuiltinOptions.lst file.
-*/
+ */
 circle::BuiltinOptions get_circle_builtin_options_type(const tflite::Operator *op);
 
 /**
  * @brief Returns circle MirrorPadMode according to tflite.
-*/
+ */
 circle::MirrorPadMode get_circle_mirrorpad_mode(tflite::MirrorPadMode tfl_mode);
 
 /**
  * @brief Returns circle DimensionType according to tflite.
-*/
+ */
 circle::DimensionType get_circle_dimension_type(tflite::DimensionType tfl_dim_type);
 
 /**
  * @brief Returns circle SparseIndexVector according to tflite.
-*/
+ */
 flatbuffers::Offset<void>
 get_circle_sparse_index_vector(flatbuffers::FlatBufferBuilder &fb, const void *values,
                                const tflite::SparseIndexVector &tfl_sparse_index_vector_type);
 
 /**
  * @brief Returns circle SparseIndexVector type according to tflite.
-*/
+ */
 circle::SparseIndexVector
 get_circle_sparse_index_vector_type(const tflite::SparseIndexVector &tfl_sparse_index_vector_type);
 


### PR DESCRIPTION
Use clang-format-8 style for tflit2circle

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>