### PR TITLE
[one-cmds] Add one-build_004 test

### DIFF
--- a/compiler/one-cmds/CMakeLists.txt
+++ b/compiler/one-cmds/CMakeLists.txt
@@ -78,4 +78,5 @@ if(NOT ENABLE_TEST)
   return()
 endif(NOT ENABLE_TEST)
 
+add_subdirectory(dummy-driver)
 add_subdirectory(tests)

--- a/compiler/one-cmds/dummy-driver/CMakeLists.txt
+++ b/compiler/one-cmds/dummy-driver/CMakeLists.txt
@@ -1,0 +1,12 @@
+# dummy driver for interface test
+set(DUMMY_DRIVER_SRC src/dummy-compile.cpp)
+
+add_executable(dummy-compile ${DUMMY_DRIVER_SRC})
+
+set(DUMMY_DRIVER "${CMAKE_CURRENT_BINARY_DIR}/dummy-compile")
+
+install(FILES ${DUMMY_DRIVER}
+        PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE
+                    GROUP_READ GROUP_EXECUTE
+                    WORLD_READ WORLD_EXECUTE
+        DESTINATION test)

--- a/compiler/one-cmds/dummy-driver/src/dummy-compile.cpp
+++ b/compiler/one-cmds/dummy-driver/src/dummy-compile.cpp
@@ -14,7 +14,13 @@
  * limitations under the License.
  */
 
-// dummy-compile only tests its interface rather than its functionality.
+/**
+ * dummy-compile only tests its interface rather than its functionality.
+ *
+ * ./dummy-compile -o ${OUTPUT_NAME} ${INPUT_NAME}
+ *
+ * NOTE argv[3](INPUT_NAME) is not used here.
+ */
 
 #include <iostream>
 #include <fstream>
@@ -22,13 +28,12 @@
 
 int main(int argc, char **argv)
 {
-  // Assume cmd from user will be like this.
-  // ./dummy-compile -o ${OUTPUT_NAME} ${INPUT_NAME}
   if (argc != 4)
     return EXIT_FAILURE;
 
   std::string opt_o{"-o"};
   std::string argv_1{argv[1]};
+
   if (opt_o != argv_1)
     return EXIT_FAILURE;
 

--- a/compiler/one-cmds/dummy-driver/src/dummy-compile.cpp
+++ b/compiler/one-cmds/dummy-driver/src/dummy-compile.cpp
@@ -28,12 +28,12 @@ int main(int argc, char **argv)
     return EXIT_FAILURE;
 
   std::string opt_o{"-o"};
-  std::string output_name{argv[1]};
-  if (opt_o != output_name)
+  std::string argv_1{argv[1]};
+  if (opt_o != argv_1)
     return EXIT_FAILURE;
 
-  std::string input_name{argv[2]};
-  std::ofstream outfile(input_name);
+  std::string output_name{argv[2]};
+  std::ofstream outfile(output_name);
 
   outfile << "dummy-compile dummy output!!" << std::endl;
 

--- a/compiler/one-cmds/dummy-driver/src/dummy-compile.cpp
+++ b/compiler/one-cmds/dummy-driver/src/dummy-compile.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// dummy-compile only tests its interface rather than its functionality.
+
+#include <iostream>
+#include <fstream>
+#include <string>
+
+int main(int argc, char **argv)
+{
+  // Assume cmd from user will be like this.
+  // ./dummy-compile -o ${OUTPUT_NAME} ${INPUT_NAME}
+  if (argc != 4)
+    return EXIT_FAILURE;
+
+  std::string opt_o{"-o"};
+  std::string output_name{argv[1]};
+  if (opt_o != output_name)
+    return EXIT_FAILURE;
+
+  std::string input_name{argv[2]};
+  std::ofstream outfile(input_name);
+
+  outfile << "dummy-compile dummy output!!" << std::endl;
+
+  outfile.close();
+
+  return EXIT_SUCCESS;
+}

--- a/compiler/one-cmds/tests/one-build_004.cfg
+++ b/compiler/one-cmds/tests/one-build_004.cfg
@@ -1,0 +1,20 @@
+[one-build]
+one-import-tf=True
+one-import-tflite=False
+one-import-bcq=False
+one-optimize=False
+one-quantize=False
+one-pack=False
+one-codegen=True
+
+[one-import-tf]
+input_path=inception_v3.pb
+output_path=inception_v3.circle
+input_arrays=input
+input_shapes=1,299,299,3
+output_arrays=InceptionV3/Predictions/Reshape_1
+converter_version=v1
+
+[one-codegen]
+backend=dummy
+command=-o sample.tvn inception_v3.circle

--- a/compiler/one-cmds/tests/one-build_004.test
+++ b/compiler/one-cmds/tests/one-build_004.test
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# one-import-tf -> one-codegen
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  echo "${filename_ext} FAILED"
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+configfile="one-build_004.cfg"
+outputfile="sample.tvn"
+
+rm -rf ${outputfile}
+
+# copy dummy-compile to bin folder
+cp dummy-compile ../bin/dummy-compile
+
+# run test
+one-build -C ${configfile} > /dev/null
+
+if [[ ! -s "${outputfile}" ]]; then
+  trap_err_onexit
+fi
+
+rm ../bin/dummy-compile
+
+echo "${filename_ext} SUCCESS"

--- a/compiler/one-cmds/tests/one-build_004.test
+++ b/compiler/one-cmds/tests/one-build_004.test
@@ -22,6 +22,7 @@ filename="${filename_ext%.*}"
 trap_err_onexit()
 {
   echo "${filename_ext} FAILED"
+  rm -rf ../bin/dummy-compile
   exit 255
 }
 
@@ -42,6 +43,6 @@ if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit
 fi
 
-rm ../bin/dummy-compile
+rm -rf ../bin/dummy-compile
 
 echo "${filename_ext} SUCCESS"


### PR DESCRIPTION
This commit adds one-build_004 test. This test runs `one-import-tf` and
`one-codegen` at once with `one-build`.

Related: #5375 
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>