### PR TITLE
[onert] Remove ConstantInitializer in cpu_common

### DIFF
--- a/runtime/onert/backend/cpu/Backend.h
+++ b/runtime/onert/backend/cpu/Backend.h
@@ -51,7 +51,6 @@ public:
     auto tb = std::make_shared<TensorBuilder>(tr);
     context->tensor_registry = tr;
     context->tensor_builder = tb;
-    context->constant_initializer = std::make_shared<ConstantInitializer>(operands, tr);
     context->kernel_gen = std::make_shared<KernelGenerator>(operands, operations, tb, tr, kb,
                                                             context->external_context());
     return context;

--- a/runtime/onert/backend/cpu/BackendContext.cc
+++ b/runtime/onert/backend/cpu/BackendContext.cc
@@ -31,26 +31,6 @@ namespace backend
 namespace cpu
 {
 
-void BackendContext::initConsts()
-{
-  for (auto &op : operation_list())
-  {
-    constant_initializer->setLayout(op.layout);
-    graph()->operations().at(op.index).accept(*constant_initializer);
-  }
-
-  for (auto ind : operand_list())
-  {
-    const auto &obj = graph()->operands().at(ind);
-    if (obj.isConstant() && !constant_initializer->exist(ind))
-    {
-      constant_initializer->registerDefaultInitializer(ind, obj);
-    }
-  }
-
-  constant_initializer->run();
-}
-
 ITensorRegistry *BackendContext::genTensors(const std::vector<onert::ir::OpSequenceIndex> &order,
                                             const ir::OpSequences &op_seqs,
                                             const ir::LowerInfoMap &lower_info)
@@ -78,7 +58,7 @@ FunctionMap BackendContext::genKernels(const std::vector<onert::ir::OpSequenceIn
     ret.emplace_back(op_seq_ind, std::move(fn_seq));
   }
 
-  initConsts();
+  cpu_common::initConsts(*this);
 
   // NOTE For memory optimization, we want to free some operand data
   for (auto ind : operand_list())

--- a/runtime/onert/backend/cpu/BackendContext.h
+++ b/runtime/onert/backend/cpu/BackendContext.h
@@ -36,11 +36,9 @@ public:
   BackendContext(const Backend *backend, const ir::Graph *graph,
                  std::shared_ptr<ITensorRegistry> tensor_registry = nullptr,
                  std::shared_ptr<TensorBuilder> tensor_builder = nullptr,
-                 std::shared_ptr<ConstantInitializer> constant_initializer = nullptr,
                  std::shared_ptr<KernelGenerator> kernel_gen = nullptr)
     : onert::backend::BackendContext(backend, graph, tensor_registry),
-      tensor_builder{tensor_builder}, constant_initializer{constant_initializer},
-      kernel_gen{kernel_gen}, _external_context(new ExternalContext)
+      tensor_builder{tensor_builder}, kernel_gen{kernel_gen}, _external_context(new ExternalContext)
   {
   }
 
@@ -53,14 +51,12 @@ public:
   std::shared_ptr<ExternalContext> external_context() { return _external_context; }
 
 private:
-  void initConsts();
   void planTensors(const std::vector<onert::ir::OpSequenceIndex> &order,
                    const ir::OpSequences &op_seqs, const ir::LowerInfoMap &lower_info);
 
 public:
   // TODO Make it private
   std::shared_ptr<TensorBuilder> tensor_builder;
-  std::shared_ptr<ConstantInitializer> constant_initializer;
   std::shared_ptr<KernelGenerator> kernel_gen;
 
 private:

--- a/runtime/onert/backend/ruy/Backend.h
+++ b/runtime/onert/backend/ruy/Backend.h
@@ -51,7 +51,6 @@ public:
     auto tb = std::make_shared<TensorBuilder>(tr);
     context->tensor_registry = tr;
     context->tensor_builder = tb;
-    context->constant_initializer = std::make_shared<ConstantInitializer>(operands, tr);
     context->kernel_gen = std::make_shared<KernelGenerator>(operands, operations, tb, tr, kb,
                                                             context->external_context());
     return context;

--- a/runtime/onert/backend/ruy/BackendContext.cc
+++ b/runtime/onert/backend/ruy/BackendContext.cc
@@ -31,26 +31,6 @@ namespace backend
 namespace ruy
 {
 
-void BackendContext::initConsts()
-{
-  for (auto &op : operation_list())
-  {
-    constant_initializer->setLayout(op.layout);
-    graph()->operations().at(op.index).accept(*constant_initializer);
-  }
-
-  for (auto ind : operand_list())
-  {
-    const auto &obj = graph()->operands().at(ind);
-    if (obj.isConstant() && !constant_initializer->exist(ind))
-    {
-      constant_initializer->registerDefaultInitializer(ind, obj);
-    }
-  }
-
-  constant_initializer->run();
-}
-
 ITensorRegistry *BackendContext::genTensors(const std::vector<onert::ir::OpSequenceIndex> &order,
                                             const ir::OpSequences &op_seqs,
                                             const ir::LowerInfoMap &lower_info)
@@ -78,7 +58,7 @@ FunctionMap BackendContext::genKernels(const std::vector<onert::ir::OpSequenceIn
     ret.emplace_back(op_seq_ind, std::move(fn_seq));
   }
 
-  initConsts();
+  cpu_common::initConsts(*this);
 
   // NOTE For memory optimization, we want to free some operand data
   for (auto ind : operand_list())

--- a/runtime/onert/backend/ruy/BackendContext.h
+++ b/runtime/onert/backend/ruy/BackendContext.h
@@ -36,11 +36,9 @@ public:
   BackendContext(const Backend *backend, const ir::Graph *graph,
                  std::shared_ptr<ITensorRegistry> tensor_registry = nullptr,
                  std::shared_ptr<TensorBuilder> tensor_builder = nullptr,
-                 std::shared_ptr<ConstantInitializer> constant_initializer = nullptr,
                  std::shared_ptr<KernelGenerator> kernel_gen = nullptr)
     : onert::backend::BackendContext(backend, graph, tensor_registry),
-      tensor_builder{tensor_builder}, constant_initializer{constant_initializer},
-      kernel_gen{kernel_gen}, _external_context(new ExternalContext)
+      tensor_builder{tensor_builder}, kernel_gen{kernel_gen}, _external_context(new ExternalContext)
   {
   }
 
@@ -54,14 +52,12 @@ public:
   std::shared_ptr<ExternalContext> external_context() { return _external_context; }
 
 private:
-  void initConsts();
   void planTensors(const std::vector<onert::ir::OpSequenceIndex> &order,
                    const ir::OpSequences &op_seqs, const ir::LowerInfoMap &lower_info);
 
 public:
   // TODO Make it private
   std::shared_ptr<TensorBuilder> tensor_builder;
-  std::shared_ptr<ConstantInitializer> constant_initializer;
   std::shared_ptr<KernelGenerator> kernel_gen;
 
 private:

--- a/runtime/onert/backend/xnnpack/Backend.h
+++ b/runtime/onert/backend/xnnpack/Backend.h
@@ -19,7 +19,6 @@
 
 #include "BackendContext.h"
 #include "Config.h"
-#include "ConstantInitializer.h"
 #include "KernelGenerator.h"
 
 #include <backend/Backend.h>
@@ -51,7 +50,6 @@ public:
     auto tb = std::make_shared<TensorBuilder>(tr);
     context->tensor_registry = tr;
     context->tensor_builder = tb;
-    context->constant_initializer = std::make_shared<ConstantInitializer>(operands, tr);
     context->kernel_gen = std::make_shared<KernelGenerator>(operands, operations, tb, tr, kb,
                                                             context->external_context());
     return context;

--- a/runtime/onert/backend/xnnpack/BackendContext.cc
+++ b/runtime/onert/backend/xnnpack/BackendContext.cc
@@ -31,26 +31,6 @@ namespace backend
 namespace xnnpack
 {
 
-void BackendContext::initConsts()
-{
-  for (auto &op : operation_list())
-  {
-    constant_initializer->setLayout(op.layout);
-    graph()->operations().at(op.index).accept(*constant_initializer);
-  }
-
-  for (auto ind : operand_list())
-  {
-    const auto &obj = graph()->operands().at(ind);
-    if (obj.isConstant() && !constant_initializer->exist(ind))
-    {
-      constant_initializer->registerDefaultInitializer(ind, obj);
-    }
-  }
-
-  constant_initializer->run();
-}
-
 ITensorRegistry *BackendContext::genTensors(const std::vector<onert::ir::OpSequenceIndex> &order,
                                             const ir::OpSequences &op_seqs,
                                             const ir::LowerInfoMap &lower_info)
@@ -78,7 +58,7 @@ FunctionMap BackendContext::genKernels(const std::vector<onert::ir::OpSequenceIn
     ret.emplace_back(op_seq_ind, std::move(fn_seq));
   }
 
-  initConsts();
+  cpu_common::initConsts(*this);
 
   // NOTE For memory optimization, we want to free some operand data
   for (auto ind : operand_list())

--- a/runtime/onert/backend/xnnpack/BackendContext.h
+++ b/runtime/onert/backend/xnnpack/BackendContext.h
@@ -20,7 +20,6 @@
 #include <backend/BackendContext.h>
 #include <util/ConfigSource.h>
 #include "TensorBuilder.h"
-#include "ConstantInitializer.h"
 #include "KernelGenerator.h"
 #include "ExternalContext.h"
 
@@ -39,11 +38,9 @@ public:
   BackendContext(const Backend *backend, const ir::Graph *graph,
                  std::shared_ptr<ITensorRegistry> tensor_registry = nullptr,
                  std::shared_ptr<TensorBuilder> tensor_builder = nullptr,
-                 std::shared_ptr<ConstantInitializer> constant_initializer = nullptr,
                  std::shared_ptr<KernelGenerator> kernel_gen = nullptr)
     : onert::backend::BackendContext(backend, graph, tensor_registry),
-      tensor_builder{tensor_builder}, constant_initializer{constant_initializer},
-      kernel_gen{kernel_gen}, _external_context(nullptr)
+      tensor_builder{tensor_builder}, kernel_gen{kernel_gen}, _external_context(nullptr)
   {
     int num_threads = util::getConfigInt(util::config::XNNPACK_THREADS);
     if (num_threads < 1)
@@ -61,14 +58,12 @@ public:
   std::shared_ptr<ExternalContext> external_context() { return _external_context; }
 
 private:
-  void initConsts();
   void planTensors(const std::vector<onert::ir::OpSequenceIndex> &order,
                    const ir::OpSequences &op_seqs, const ir::LowerInfoMap &lower_info);
 
 public:
   // TODO Make it private
   std::shared_ptr<TensorBuilder> tensor_builder;
-  std::shared_ptr<ConstantInitializer> constant_initializer;
   std::shared_ptr<KernelGenerator> kernel_gen;
 
 private:

--- a/runtime/onert/core/include/backend/BackendContext.h
+++ b/runtime/onert/core/include/backend/BackendContext.h
@@ -55,7 +55,6 @@ public:
 
   void initialize(const std::vector<OperationInfo> &operation_list,
                   const std::vector<ir::OperandIndex> &operand_list);
-  void initConsts();
 
   const Backend *backend() const { return _backend; }
   const ir::Graph *graph() const { return _graph; }

--- a/runtime/onert/core/src/backend/controlflow/Backend.h
+++ b/runtime/onert/core/src/backend/controlflow/Backend.h
@@ -19,7 +19,6 @@
 
 #include "BackendContext.h"
 #include "Config.h"
-#include "ConstantInitializer.h"
 #include "KernelGenerator.h"
 #include "TensorBuilder.h"
 #include "Tensor.h"
@@ -46,7 +45,6 @@ public:
   newContext(const ir::Graph &graph, const std::shared_ptr<custom::IKernelBuilder> &,
              bool) const override
   {
-    const auto &operands = graph.operands();
     auto context = std::make_unique<BackendContext>(this, &graph);
     // ControlFlow backend may not build tensors for itself because the backend's operation uses
     // tensors of other baceknd instead
@@ -69,7 +67,6 @@ public:
     auto tb = std::make_shared<TensorBuilder>(tr);
     context->tensor_registry = tr;
     context->tensor_builder = tb;
-    context->constant_initializer = std::make_shared<ConstantInitializer>(operands, tr);
     context->kernel_gen = std::make_shared<KernelGenerator>(graph, tb->dynamicTensorManager(), tr,
                                                             context->external_context());
     return context;

--- a/runtime/onert/core/src/backend/controlflow/BackendContext.cc
+++ b/runtime/onert/core/src/backend/controlflow/BackendContext.cc
@@ -26,26 +26,6 @@ namespace backend
 namespace controlflow
 {
 
-void BackendContext::initConsts()
-{
-  for (auto &op : operation_list())
-  {
-    constant_initializer->setLayout(op.layout);
-    graph()->operations().at(op.index).accept(*constant_initializer);
-  }
-
-  for (auto ind : operand_list())
-  {
-    const auto &obj = graph()->operands().at(ind);
-    if (obj.isConstant() && !constant_initializer->exist(ind))
-    {
-      constant_initializer->registerDefaultInitializer(ind, obj);
-    }
-  }
-
-  constant_initializer->run();
-}
-
 ITensorRegistry *BackendContext::genTensors(const std::vector<onert::ir::OpSequenceIndex> &order,
                                             const ir::OpSequences &op_seqs,
                                             const ir::LowerInfoMap &lower_info)
@@ -118,7 +98,7 @@ FunctionMap BackendContext::genKernels(const std::vector<ir::OpSequenceIndex> &o
     ret.emplace_back(op_seq_ind, std::move(fn_seq));
   }
 
-  initConsts();
+  cpu_common::initConsts(*this);
 
   // NOTE For memory optimization, we want to free some operand data
   for (auto ind : operand_list())

--- a/runtime/onert/core/src/backend/controlflow/BackendContext.h
+++ b/runtime/onert/core/src/backend/controlflow/BackendContext.h
@@ -19,7 +19,6 @@
 
 #include <backend/BackendContext.h>
 #include "TensorBuilder.h"
-#include "ConstantInitializer.h"
 #include "KernelGenerator.h"
 #include "ExternalContext.h"
 
@@ -36,11 +35,10 @@ public:
   BackendContext(const Backend *backend, const ir::Graph *graph,
                  std::shared_ptr<ITensorRegistry> tensor_registry = nullptr,
                  std::shared_ptr<TensorBuilder> tensor_builder = nullptr,
-                 std::shared_ptr<ConstantInitializer> constant_initializer = nullptr,
                  std::shared_ptr<KernelGenerator> kernel_gen = nullptr)
     : onert::backend::BackendContext(backend, graph, tensor_registry),
-      tensor_builder{tensor_builder}, constant_initializer{constant_initializer},
-      kernel_gen{kernel_gen}, _external_context(std::make_shared<ExternalContext>())
+      tensor_builder{tensor_builder}, kernel_gen{kernel_gen},
+      _external_context(std::make_shared<ExternalContext>())
   {
   }
 
@@ -54,14 +52,12 @@ public:
   std::shared_ptr<ExternalContext> external_context() { return _external_context; }
 
 private:
-  void initConsts();
   void planTensors(const std::vector<onert::ir::OpSequenceIndex> &order,
                    const ir::OpSequences &op_seqs, const ir::LowerInfoMap &lower_info);
 
 public:
   // TODO Make it private
   std::shared_ptr<TensorBuilder> tensor_builder;
-  std::shared_ptr<ConstantInitializer> constant_initializer;
   std::shared_ptr<KernelGenerator> kernel_gen;
 
 private:


### PR DESCRIPTION
As cpu constant initialization is simple, we do not need
ConstantInitializer in cpu_common.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>