### PR TITLE
[onert] Fix typo in ElementwiseUnaryLayer::configure error message

### DIFF
--- a/runtime/onert/backend/cpu/ops/ElementwiseUnaryLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ElementwiseUnaryLayer.cc
@@ -410,7 +410,7 @@ void ElementwiseUnaryLayer::configure(const IPortableTensor *input, IPortableTen
       }
       break;
     default:
-      throw std::runtime_error{"ElementwiseBinary: Unsupported ElementwiseBinary type"};
+      throw std::runtime_error{"ElementwiseUnary: Unsupported ElementwiseUnary type"};
   }
 }
 


### PR DESCRIPTION
It fixes the typo of ElementwiseBinary to ElementwiseUnary.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>