### PR TITLE
[onert] Change print symbols for ops

### DIFF
--- a/runtime/onert/core/include/ir/Index.h
+++ b/runtime/onert/core/include/ir/Index.h
@@ -52,12 +52,12 @@ std::ostream &_index_print_impl(std::ostream &o, const std::string &prefix, Inde
 
 inline std::ostream &operator<<(std::ostream &o, const OperationIndex &i)
 {
-  return _index_print_impl(o, "OPERATION", i);
+  return _index_print_impl(o, "@", i);
 }
 
 inline std::ostream &operator<<(std::ostream &o, const OperandIndex &i)
 {
-  return _index_print_impl(o, "$", i);
+  return _index_print_impl(o, "%", i);
 }
 
 inline std::ostream &operator<<(std::ostream &o, const IOIndex &i)


### PR DESCRIPTION
Change print symbols for operations and operands.
This is LLVM(or MLIR) style.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>