### PR TITLE
[onert] Rename "controlflow" backend to "builtin"

### DIFF
--- a/docs/runtime/backend-api.md
+++ b/docs/runtime/backend-api.md
@@ -37,15 +37,15 @@ Please refer to each class document for details. You may refer to [Bundle Backen
 
 ## Provided Backend Implementations
 
-We provide some backends along with the runtime. There is the special backend `controlflow` which is part of runtime core, and some bundle backends which are baseline backends and samples of backend implementation.
+We provide some backends along with the runtime. There is the special backend `builtin` which is part of runtime core, and some bundle backends which are baseline backends and samples of backend implementation.
 
-## `controlflow` Backend
+## `builtin` Backend
 
-`controlflow` is a special backend that is always loaded(statically linked, part of runtime core). It is implemented just like other backends, but there are some things that it does exclusively.
+`builtin` is a special backend that is always loaded(statically linked, part of runtime core). It is implemented just like other backends, but there are some things that it does exclusively.
 
 - Has kernels for If, While and Permute operations (Kernels from other backends are never be used)
-- The runtime core directly creates `controlflow`'s tensor objects to accept user-given input and output buffers
-- The runtime core gives the executor context to `controlflow` backend which allows control flow ops can change execution flow properly
+- The runtime core directly creates `builtin`'s tensor objects to accept user-given input and output buffers
+- The runtime core gives the executor context to `builtin` backend which allows control flow ops can change execution flow properly
 
 ## Bundle Backends
 

--- a/runtime/onert/core/include/compiler/BackendManager.h
+++ b/runtime/onert/core/include/compiler/BackendManager.h
@@ -22,7 +22,7 @@
 
 #include "ir/Operands.h"
 #include "backend/Backend.h"
-#include "backend/controlflow/Backend.h"
+#include "backend/builtin/Backend.h"
 
 namespace onert
 {
@@ -41,7 +41,7 @@ public:
 public:
   backend::Backend *get(const std::string &key);
   const backend::Backend *get(const std::string &key) const;
-  const backend::controlflow::Backend *getControlflow() const;
+  const backend::builtin::Backend *getControlflow() const;
   const std::vector<const backend::Backend *> getAll() const
   {
     std::vector<const backend::Backend *> v;
@@ -65,9 +65,9 @@ private:
 private:
   std::map<std::string, std::unique_ptr<void, dlhandle_destroy_t>> _handle_map;
   std::map<std::string, std::unique_ptr<backend::Backend, backend_destroy_t>> _gen_map;
-  backend::controlflow::Backend *_controlflow{nullptr};
+  backend::builtin::Backend *_controlflow{nullptr};
   /**
-   * @brief load controlflow backend
+   * @brief load builtin backend
    *
    * @param backend backend to be loaded
    *

--- a/runtime/onert/core/include/compiler/BackendManager.h
+++ b/runtime/onert/core/include/compiler/BackendManager.h
@@ -41,7 +41,7 @@ public:
 public:
   backend::Backend *get(const std::string &key);
   const backend::Backend *get(const std::string &key) const;
-  const backend::builtin::Backend *getControlflow() const;
+  const backend::builtin::Backend *getBuiltin() const;
   const std::vector<const backend::Backend *> getAll() const
   {
     std::vector<const backend::Backend *> v;
@@ -65,7 +65,7 @@ private:
 private:
   std::map<std::string, std::unique_ptr<void, dlhandle_destroy_t>> _handle_map;
   std::map<std::string, std::unique_ptr<backend::Backend, backend_destroy_t>> _gen_map;
-  backend::builtin::Backend *_controlflow{nullptr};
+  backend::builtin::Backend *_builtin{nullptr};
   /**
    * @brief load builtin backend
    *
@@ -73,7 +73,7 @@ private:
    *
    * @return
    */
-  void loadControlflowBackend();
+  void loadBuiltinBackend();
 };
 
 } // namespace compiler

--- a/runtime/onert/core/include/exec/IExecutor.h
+++ b/runtime/onert/core/include/exec/IExecutor.h
@@ -36,7 +36,7 @@ namespace onert
 namespace backend
 {
 class IPortableTensor;
-namespace controlflow
+namespace builtin
 {
 class IOTensor;
 }
@@ -97,7 +97,7 @@ struct IExecutor
    *
    * @return Vector of @c IOTensor
    */
-  virtual const std::vector<backend::controlflow::IOTensor *> &getOutputTensors() const = 0;
+  virtual const std::vector<backend::builtin::IOTensor *> &getOutputTensors() const = 0;
 };
 
 using ExecutorMap = std::unordered_map<ir::SubgraphIndex, std::unique_ptr<IExecutor>>;

--- a/runtime/onert/core/src/backend/builtin/Backend.h
+++ b/runtime/onert/core/src/backend/builtin/Backend.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef __ONERT_BACKEND_CONTROLFLOW_BACKEND_H__
-#define __ONERT_BACKEND_CONTROLFLOW_BACKEND_H__
+#ifndef __ONERT_BACKEND_BUILTIN_BACKEND_H__
+#define __ONERT_BACKEND_BUILTIN_BACKEND_H__
 
 #include "BackendContext.h"
 #include "Config.h"
@@ -80,4 +80,4 @@ private:
 } // namespace backend
 } // namespace onert
 
-#endif // __ONERT_BACKEND_CONTROLFLOW_BACKEND_H__
+#endif // __ONERT_BACKEND_BUILTIN_BACKEND_H__

--- a/runtime/onert/core/src/backend/builtin/Backend.h
+++ b/runtime/onert/core/src/backend/builtin/Backend.h
@@ -31,7 +31,7 @@ namespace onert
 {
 namespace backend
 {
-namespace controlflow
+namespace builtin
 {
 
 class Backend : public ::onert::backend::Backend
@@ -76,7 +76,7 @@ private:
   std::shared_ptr<IConfig> _config;
 };
 
-} // namespace controlflow
+} // namespace builtin
 } // namespace backend
 } // namespace onert
 

--- a/runtime/onert/core/src/backend/builtin/BackendContext.cc
+++ b/runtime/onert/core/src/backend/builtin/BackendContext.cc
@@ -23,7 +23,7 @@ namespace onert
 {
 namespace backend
 {
-namespace controlflow
+namespace builtin
 {
 
 ITensorRegistry *BackendContext::genTensors(const std::vector<onert::ir::OpSequenceIndex> &order,
@@ -117,6 +117,6 @@ FunctionMap BackendContext::genKernels(const std::vector<ir::OpSequenceIndex> &o
   return ret;
 }
 
-} // namespace controlflow
+} // namespace builtin
 } // namespace backend
 } // namespace onert

--- a/runtime/onert/core/src/backend/builtin/BackendContext.h
+++ b/runtime/onert/core/src/backend/builtin/BackendContext.h
@@ -26,7 +26,7 @@ namespace onert
 {
 namespace backend
 {
-namespace controlflow
+namespace builtin
 {
 
 class BackendContext : public onert::backend::BackendContext
@@ -67,7 +67,7 @@ private:
   std::shared_ptr<ExternalContext> _external_context;
 };
 
-} // namespace controlflow
+} // namespace builtin
 } // namespace backend
 } // namespace onert
 

--- a/runtime/onert/core/src/backend/builtin/BackendContext.h
+++ b/runtime/onert/core/src/backend/builtin/BackendContext.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef __ONERT_BACKEND_CONTROLFLOW_BACKEND_CONTEXT_H__
-#define __ONERT_BACKEND_CONTROLFLOW_BACKEND_CONTEXT_H__
+#ifndef __ONERT_BACKEND_BUILTIN_BACKEND_CONTEXT_H__
+#define __ONERT_BACKEND_BUILTIN_BACKEND_CONTEXT_H__
 
 #include <backend/BackendContext.h>
 #include "TensorBuilder.h"
@@ -71,4 +71,4 @@ private:
 } // namespace backend
 } // namespace onert
 
-#endif // __ONERT_BACKEND_CONTROLFLOW_BACKEND_CONTEXT_H__
+#endif // __ONERT_BACKEND_BUILTIN_BACKEND_CONTEXT_H__

--- a/runtime/onert/core/src/backend/builtin/Config.cc
+++ b/runtime/onert/core/src/backend/builtin/Config.cc
@@ -14,22 +14,24 @@
  * limitations under the License.
  */
 
-#ifndef __ONERT_COMPILER_CONTROLFLOW_CONSTANT_INITIALIZER_H__
-#define __ONERT_COMPILER_CONTROLFLOW_CONSTANT_INITIALIZER_H__
-
-#include <backend/cpu_common/ConstantInitializer.h>
+#include "Config.h"
 
 namespace onert
 {
 namespace backend
 {
-namespace controlflow
+namespace builtin
 {
 
-using ConstantInitializer = cpu_common::ConstantInitializer;
+std::string Config::ID = "builtin";
 
-} // namespace controlflow
+bool Config::initialize() { return true; }
+
+ir::Layout Config::supportLayout(const ir::Operation &, ir::Layout frontend_layout)
+{
+  return frontend_layout;
+}
+
+} // namespace builtin
 } // namespace backend
 } // namespace onert
-
-#endif // __ONERT_COMPILER_CONTROLFLOW_CONSTANT_INITIALIZER_H__

--- a/runtime/onert/core/src/backend/builtin/Config.h
+++ b/runtime/onert/core/src/backend/builtin/Config.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef __ONERT_BACKEND_CONTROLFLOW_CONFIG_H__
-#define __ONERT_BACKEND_CONTROLFLOW_CONFIG_H__
+#ifndef __ONERT_BACKEND_BUILTIN_CONFIG_H__
+#define __ONERT_BACKEND_BUILTIN_CONFIG_H__
 
 #include <backend/IConfig.h>
 #include <memory>
@@ -50,4 +50,4 @@ public:
 } // namespace backend
 } // namespace onert
 
-#endif // __ONERT_BACKEND_CONTROLFLOW_CONFIG_H__
+#endif // __ONERT_BACKEND_BUILTIN_CONFIG_H__

--- a/runtime/onert/core/src/backend/builtin/Config.h
+++ b/runtime/onert/core/src/backend/builtin/Config.h
@@ -25,7 +25,7 @@ namespace onert
 {
 namespace backend
 {
-namespace controlflow
+namespace builtin
 {
 
 class Config : public IConfig
@@ -46,7 +46,7 @@ public:
   std::unique_ptr<util::ITimer> timer() override { return std::make_unique<util::CPUTimer>(); }
 };
 
-} // namespace controlflow
+} // namespace builtin
 } // namespace backend
 } // namespace onert
 

--- a/runtime/onert/core/src/backend/builtin/ConstantInitializer.h
+++ b/runtime/onert/core/src/backend/builtin/ConstantInitializer.h
@@ -14,39 +14,22 @@
  * limitations under the License.
  */
 
-#include "IOTensor.h"
+#ifndef __ONERT_COMPILER_CONTROLFLOW_CONSTANT_INITIALIZER_H__
+#define __ONERT_COMPILER_CONTROLFLOW_CONSTANT_INITIALIZER_H__
 
-#include <assert.h>
+#include <backend/cpu_common/ConstantInitializer.h>
 
 namespace onert
 {
 namespace backend
 {
-namespace controlflow
+namespace builtin
 {
 
-IOTensor::IOTensor(const ir::OperandInfo &info, ir::Layout layout)
-  : IPortableTensor{info}, _orig_info{info}, _orig_layout{layout}
-{
-  setUserTensor(nullptr, 0);
-}
+using ConstantInitializer = cpu_common::ConstantInitializer;
 
-void IOTensor::setTensor(IPortableTensor *tensor)
-{
-  assert(tensor);
-  assert(tensor != this);
-  // TODO Handle when layout was changed
-  assert(tensor->layout() == _orig_layout); // Changing layout is not considered yet
-  _user_tensor.reset();
-  _tensor = tensor;
-}
-
-void IOTensor::setUserTensor(uint8_t *buffer, size_t size)
-{
-  _user_tensor = std::make_unique<UserTensor>(_orig_info, _orig_layout, buffer, size);
-  _tensor = _user_tensor.get();
-}
-
-} // namespace controlflow
+} // namespace builtin
 } // namespace backend
 } // namespace onert
+
+#endif // __ONERT_COMPILER_CONTROLFLOW_CONSTANT_INITIALIZER_H__

--- a/runtime/onert/core/src/backend/builtin/ConstantInitializer.h
+++ b/runtime/onert/core/src/backend/builtin/ConstantInitializer.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef __ONERT_COMPILER_CONTROLFLOW_CONSTANT_INITIALIZER_H__
-#define __ONERT_COMPILER_CONTROLFLOW_CONSTANT_INITIALIZER_H__
+#ifndef __ONERT_COMPILER_BUILTIN_CONSTANT_INITIALIZER_H__
+#define __ONERT_COMPILER_BUILTIN_CONSTANT_INITIALIZER_H__
 
 #include <backend/cpu_common/ConstantInitializer.h>
 
@@ -32,4 +32,4 @@ using ConstantInitializer = cpu_common::ConstantInitializer;
 } // namespace backend
 } // namespace onert
 
-#endif // __ONERT_COMPILER_CONTROLFLOW_CONSTANT_INITIALIZER_H__
+#endif // __ONERT_COMPILER_BUILTIN_CONSTANT_INITIALIZER_H__

--- a/runtime/onert/core/src/backend/builtin/DynamicTensorManager.h
+++ b/runtime/onert/core/src/backend/builtin/DynamicTensorManager.h
@@ -14,24 +14,25 @@
  * limitations under the License.
  */
 
-#include "Config.h"
+#ifndef __ONERT_BACKEND_CONTROLFLOW_DYNAMICTENSOR_MANAGER_H__
+#define __ONERT_BACKEND_CONTROLFLOW_DYNAMICTENSOR_MANAGER_H__
+
+#include "TensorRegistry.h"
+#include "Tensor.h"
+
+#include <backend/cpu_common/DynamicTensorManager.h>
 
 namespace onert
 {
 namespace backend
 {
-namespace controlflow
+namespace builtin
 {
 
-std::string Config::ID = "controlflow";
+using DynamicTensorManager = cpu_common::DynamicTensorManager;
 
-bool Config::initialize() { return true; }
-
-ir::Layout Config::supportLayout(const ir::Operation &, ir::Layout frontend_layout)
-{
-  return frontend_layout;
-}
-
-} // namespace controlflow
+} // namespace builtin
 } // namespace backend
 } // namespace onert
+
+#endif // __ONERT_BACKEND_CONTROLFLOW_DYNAMICTENSOR_MANAGER_H__

--- a/runtime/onert/core/src/backend/builtin/DynamicTensorManager.h
+++ b/runtime/onert/core/src/backend/builtin/DynamicTensorManager.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef __ONERT_BACKEND_CONTROLFLOW_DYNAMICTENSOR_MANAGER_H__
-#define __ONERT_BACKEND_CONTROLFLOW_DYNAMICTENSOR_MANAGER_H__
+#ifndef __ONERT_BACKEND_BUILTIN_DYNAMICTENSOR_MANAGER_H__
+#define __ONERT_BACKEND_BUILTIN_DYNAMICTENSOR_MANAGER_H__
 
 #include "TensorRegistry.h"
 #include "Tensor.h"
@@ -35,4 +35,4 @@ using DynamicTensorManager = cpu_common::DynamicTensorManager;
 } // namespace backend
 } // namespace onert
 
-#endif // __ONERT_BACKEND_CONTROLFLOW_DYNAMICTENSOR_MANAGER_H__
+#endif // __ONERT_BACKEND_BUILTIN_DYNAMICTENSOR_MANAGER_H__

--- a/runtime/onert/core/src/backend/builtin/ExternalContext.h
+++ b/runtime/onert/core/src/backend/builtin/ExternalContext.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef __ONERT_BACKEND_CONTROLFLOW_EXTERNAL_CONTEXT_H__
-#define __ONERT_BACKEND_CONTROLFLOW_EXTERNAL_CONTEXT_H__
+#ifndef __ONERT_BACKEND_BUILTIN_EXTERNAL_CONTEXT_H__
+#define __ONERT_BACKEND_BUILTIN_EXTERNAL_CONTEXT_H__
 
 #include <util/ConfigSource.h>
 
@@ -74,4 +74,4 @@ private:
 } // namespace backend
 } // namespace onert
 
-#endif // __ONERT_BACKEND_CONTROLFLOW_EXTERNAL_CONTEXT_H__
+#endif // __ONERT_BACKEND_BUILTIN_EXTERNAL_CONTEXT_H__

--- a/runtime/onert/core/src/backend/builtin/ExternalContext.h
+++ b/runtime/onert/core/src/backend/builtin/ExternalContext.h
@@ -28,7 +28,7 @@ namespace onert
 {
 namespace backend
 {
-namespace controlflow
+namespace builtin
 {
 
 // TODO Unify this with cpu::ExternalContext
@@ -70,7 +70,7 @@ private:
   const std::unique_ptr<ruy::Context> _ruy_context;
 };
 
-} // namespace controlflow
+} // namespace builtin
 } // namespace backend
 } // namespace onert
 

--- a/runtime/onert/core/src/backend/builtin/IOTensor.cc
+++ b/runtime/onert/core/src/backend/builtin/IOTensor.cc
@@ -14,23 +14,39 @@
  * limitations under the License.
  */
 
-#ifndef __ONERT_BACKEND_CONTROLFLOW_TENSOR_H__
-#define __ONERT_BACKEND_CONTROLFLOW_TENSOR_H__
+#include "IOTensor.h"
 
-#include <backend/cpu_common/Tensor.h>
+#include <assert.h>
 
 namespace onert
 {
 namespace backend
 {
-namespace controlflow
+namespace builtin
 {
 
-using Tensor = cpu_common::Tensor;
-using ExternalTensor = cpu_common::ExternalTensor;
+IOTensor::IOTensor(const ir::OperandInfo &info, ir::Layout layout)
+  : IPortableTensor{info}, _orig_info{info}, _orig_layout{layout}
+{
+  setUserTensor(nullptr, 0);
+}
 
-} // namespace controlflow
+void IOTensor::setTensor(IPortableTensor *tensor)
+{
+  assert(tensor);
+  assert(tensor != this);
+  // TODO Handle when layout was changed
+  assert(tensor->layout() == _orig_layout); // Changing layout is not considered yet
+  _user_tensor.reset();
+  _tensor = tensor;
+}
+
+void IOTensor::setUserTensor(uint8_t *buffer, size_t size)
+{
+  _user_tensor = std::make_unique<UserTensor>(_orig_info, _orig_layout, buffer, size);
+  _tensor = _user_tensor.get();
+}
+
+} // namespace builtin
 } // namespace backend
 } // namespace onert
-
-#endif // __ONERT_BACKEND_CONTROLFLOW_TENSOR_H__

--- a/runtime/onert/core/src/backend/builtin/IOTensor.h
+++ b/runtime/onert/core/src/backend/builtin/IOTensor.h
@@ -24,7 +24,7 @@ namespace onert
 {
 namespace backend
 {
-namespace controlflow
+namespace builtin
 {
 
 /**
@@ -91,7 +91,7 @@ private:
   std::unique_ptr<UserTensor> _user_tensor; //< If it is a user tensor, it is managed by this object
 };
 
-} // namespace controlflow
+} // namespace builtin
 } // namespace backend
 } // namespace onert
 

--- a/runtime/onert/core/src/backend/builtin/IOTensor.h
+++ b/runtime/onert/core/src/backend/builtin/IOTensor.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef __ONERT_BACKEND_CONTROLFLOW_IO_TENSOR_H__
-#define __ONERT_BACKEND_CONTROLFLOW_IO_TENSOR_H__
+#ifndef __ONERT_BACKEND_BUILTIN_IO_TENSOR_H__
+#define __ONERT_BACKEND_BUILTIN_IO_TENSOR_H__
 
 #include "backend/IPortableTensor.h"
 #include "UserTensor.h"
@@ -95,4 +95,4 @@ private:
 } // namespace backend
 } // namespace onert
 
-#endif // __ONERT_BACKEND_CONTROLFLOW_IO_TENSOR_H__
+#endif // __ONERT_BACKEND_BUILTIN_IO_TENSOR_H__

--- a/runtime/onert/core/src/backend/builtin/KernelGenerator.cc
+++ b/runtime/onert/core/src/backend/builtin/KernelGenerator.cc
@@ -28,7 +28,7 @@ namespace onert
 {
 namespace backend
 {
-namespace controlflow
+namespace builtin
 {
 
 KernelGenerator::KernelGenerator(const ir::Graph &graph, DynamicTensorManager *dyn_tensor_manager,
@@ -95,7 +95,7 @@ void KernelGenerator::visit(const ir::operation::If &node)
   // creating executor recusively
   const auto cond_tensor = input_tensors.front();
   input_tensors.erase(input_tensors.begin());
-  auto fn = std::make_unique<::onert::backend::controlflow::kernel::IfLayer>(
+  auto fn = std::make_unique<::onert::backend::builtin::kernel::IfLayer>(
     cond_tensor, input_tensors, output_tensors, then_subg_index, else_subg_index, _executor_map,
     _external_context);
 
@@ -121,7 +121,7 @@ void KernelGenerator::visit(const ir::operation::While &node)
   const auto cond_subg_index = node.param().cond_subg_index;
   const auto body_subg_index = node.param().body_subg_index;
 
-  // This op does not support input as a constant, because controlflow backend does not have
+  // This op does not support input as a constant, because builtin backend does not have
   // TensorBuilder
   std::vector<backend::IPortableTensor *> input_tensors;
   for (const auto input_index : node.getInputs())
@@ -139,7 +139,7 @@ void KernelGenerator::visit(const ir::operation::While &node)
 
   // WhileLayer just set ExecutorMap instead of cond and body executor to avoid complexity of
   // creating executor recusively
-  auto fn = std::make_unique<::onert::backend::controlflow::kernel::WhileLayer>(
+  auto fn = std::make_unique<::onert::backend::builtin::kernel::WhileLayer>(
     input_tensors, output_tensors, cond_subg_index, body_subg_index, _executor_map,
     _dyn_tensor_manager->dynamic_mem_mgr().get(), _external_context);
 
@@ -161,6 +161,6 @@ backend::IPortableTensor *KernelGenerator::getPortableTensor(const ir::OperandIn
   return ret;
 }
 
-} // namespace controlflow
+} // namespace builtin
 } // namespace backend
 } // namespace onert

--- a/runtime/onert/core/src/backend/builtin/KernelGenerator.h
+++ b/runtime/onert/core/src/backend/builtin/KernelGenerator.h
@@ -29,7 +29,7 @@ namespace onert
 {
 namespace backend
 {
-namespace controlflow
+namespace builtin
 {
 
 class KernelGenerator : public cpu_common::KernelGeneratorBase
@@ -67,7 +67,7 @@ private:
   const std::shared_ptr<ExternalContext> _external_context;
 };
 
-} // namespace controlflow
+} // namespace builtin
 } // namespace backend
 } // namespace onert
 

--- a/runtime/onert/core/src/backend/builtin/KernelGenerator.h
+++ b/runtime/onert/core/src/backend/builtin/KernelGenerator.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef __ONERT_BACKEND_CONTROLFLOW_KERNEL_GENERATOR_H__
-#define __ONERT_BACKEND_CONTROLFLOW_KERNEL_GENERATOR_H__
+#ifndef __ONERT_BACKEND_BUILTIN_KERNEL_GENERATOR_H__
+#define __ONERT_BACKEND_BUILTIN_KERNEL_GENERATOR_H__
 
 #include <exec/IExecutor.h>
 #include "ExternalContext.h"
@@ -71,4 +71,4 @@ private:
 } // namespace backend
 } // namespace onert
 
-#endif // __ONERT_BACKEND_CONTROLFLOW_KERNEL_GENERATOR_H__
+#endif // __ONERT_BACKEND_BUILTIN_KERNEL_GENERATOR_H__

--- a/runtime/onert/core/src/backend/builtin/Tensor.h
+++ b/runtime/onert/core/src/backend/builtin/Tensor.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef __ONERT_BACKEND_CONTROLFLOW_TENSOR_H__
-#define __ONERT_BACKEND_CONTROLFLOW_TENSOR_H__
+#ifndef __ONERT_BACKEND_BUILTIN_TENSOR_H__
+#define __ONERT_BACKEND_BUILTIN_TENSOR_H__
 
 #include <backend/cpu_common/Tensor.h>
 
@@ -33,4 +33,4 @@ using ExternalTensor = cpu_common::ExternalTensor;
 } // namespace backend
 } // namespace onert
 
-#endif // __ONERT_BACKEND_CONTROLFLOW_TENSOR_H__
+#endif // __ONERT_BACKEND_BUILTIN_TENSOR_H__

--- a/runtime/onert/core/src/backend/builtin/Tensor.h
+++ b/runtime/onert/core/src/backend/builtin/Tensor.h
@@ -14,25 +14,23 @@
  * limitations under the License.
  */
 
-#ifndef __ONERT_BACKEND_CONTROLFLOW_DYNAMICTENSOR_MANAGER_H__
-#define __ONERT_BACKEND_CONTROLFLOW_DYNAMICTENSOR_MANAGER_H__
+#ifndef __ONERT_BACKEND_CONTROLFLOW_TENSOR_H__
+#define __ONERT_BACKEND_CONTROLFLOW_TENSOR_H__
 
-#include "TensorRegistry.h"
-#include "Tensor.h"
-
-#include <backend/cpu_common/DynamicTensorManager.h>
+#include <backend/cpu_common/Tensor.h>
 
 namespace onert
 {
 namespace backend
 {
-namespace controlflow
+namespace builtin
 {
 
-using DynamicTensorManager = cpu_common::DynamicTensorManager;
+using Tensor = cpu_common::Tensor;
+using ExternalTensor = cpu_common::ExternalTensor;
 
-} // namespace controlflow
+} // namespace builtin
 } // namespace backend
 } // namespace onert
 
-#endif // __ONERT_BACKEND_CONTROLFLOW_DYNAMICTENSOR_MANAGER_H__
+#endif // __ONERT_BACKEND_CONTROLFLOW_TENSOR_H__

--- a/runtime/onert/core/src/backend/builtin/TensorBuilder.cc
+++ b/runtime/onert/core/src/backend/builtin/TensorBuilder.cc
@@ -24,7 +24,7 @@ namespace onert
 {
 namespace backend
 {
-namespace controlflow
+namespace builtin
 {
 
 TensorBuilder::TensorBuilder(const std::shared_ptr<TensorRegistry> &tensor_reg)
@@ -99,6 +99,6 @@ cpu_common::Tensor *TensorBuilder::nativeOwnTensorAt(const ir::OperandIndex &ind
   return _tensor_reg->getNativeOwnTensor(ind);
 }
 
-} // namespace controlflow
+} // namespace builtin
 } // namespace backend
 } // namespace onert

--- a/runtime/onert/core/src/backend/builtin/TensorBuilder.h
+++ b/runtime/onert/core/src/backend/builtin/TensorBuilder.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef __ONERT_BACKEND_CONTROLFLOW_TENSOR_BUILDER_H__
-#define __ONERT_BACKEND_CONTROLFLOW_TENSOR_BUILDER_H__
+#ifndef __ONERT_BACKEND_BUILTIN_TENSOR_BUILDER_H__
+#define __ONERT_BACKEND_BUILTIN_TENSOR_BUILDER_H__
 
 #include <backend/cpu_common/StaticTensorManager.h>
 #include <backend/cpu_common/TensorRegistry.h>
@@ -76,4 +76,4 @@ private:
 } // namespace backend
 } // namespace onert
 
-#endif // __ONERT_BACKEND_CONTROLFLOW_TENSOR_BUILDER_H__
+#endif // __ONERT_BACKEND_BUILTIN_TENSOR_BUILDER_H__

--- a/runtime/onert/core/src/backend/builtin/TensorBuilder.h
+++ b/runtime/onert/core/src/backend/builtin/TensorBuilder.h
@@ -31,7 +31,7 @@ namespace onert
 {
 namespace backend
 {
-namespace controlflow
+namespace builtin
 {
 
 class TensorBuilder
@@ -72,7 +72,7 @@ private:
   ir::OperandIndexMap<ir::OperandInfo> _tensor_info_map;
 };
 
-} // namespace controlflow
+} // namespace builtin
 } // namespace backend
 } // namespace onert
 

--- a/runtime/onert/core/src/backend/builtin/TensorRegistry.h
+++ b/runtime/onert/core/src/backend/builtin/TensorRegistry.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef __ONERT_BACKEND_CONTROLFLOW_TENSOR_REGISTRY_H__
-#define __ONERT_BACKEND_CONTROLFLOW_TENSOR_REGISTRY_H__
+#ifndef __ONERT_BACKEND_BUILTIN_TENSOR_REGISTRY_H__
+#define __ONERT_BACKEND_BUILTIN_TENSOR_REGISTRY_H__
 
 #include "backend/cpu_common/TensorRegistry.h"
 #include "backend/ITensorRegistry.h"
@@ -131,4 +131,4 @@ private:
 } // namespace backend
 } // namespace onert
 
-#endif // ifndef __ONERT_BACKEND_CONTROLFLOW_TENSOR_REGISTRY_H__
+#endif // ifndef __ONERT_BACKEND_BUILTIN_TENSOR_REGISTRY_H__

--- a/runtime/onert/core/src/backend/builtin/TensorRegistry.h
+++ b/runtime/onert/core/src/backend/builtin/TensorRegistry.h
@@ -27,11 +27,11 @@ namespace onert
 {
 namespace backend
 {
-namespace controlflow
+namespace builtin
 {
 
 /**
- * @brief Tensor registry class for controlflow backend
+ * @brief Tensor registry class for builtin backend
  *
  * This class contains three types of tensors. Two native tensors(tensors that are managed by this
  * backend) and the other is migrant tensor.
@@ -127,7 +127,7 @@ private:
   ir::OperandIndexMap<std::unique_ptr<IOTensor>> _native_io_tensors;
 };
 
-} // namespace controlflow
+} // namespace builtin
 } // namespace backend
 } // namespace onert
 

--- a/runtime/onert/core/src/backend/builtin/UserTensor.cc
+++ b/runtime/onert/core/src/backend/builtin/UserTensor.cc
@@ -23,7 +23,7 @@ namespace onert
 {
 namespace backend
 {
-namespace controlflow
+namespace builtin
 {
 
 size_t UserTensor::calcOffset(const ir::Coordinates &coords) const
@@ -48,6 +48,6 @@ bool UserTensor::applyShape(const ir::Shape &new_shape)
   return true;
 }
 
-} // namespace controlflow
+} // namespace builtin
 } // namespace backend
 } // namespace onert

--- a/runtime/onert/core/src/backend/builtin/UserTensor.h
+++ b/runtime/onert/core/src/backend/builtin/UserTensor.h
@@ -24,7 +24,7 @@ namespace onert
 {
 namespace backend
 {
-namespace controlflow
+namespace builtin
 {
 
 /**
@@ -76,7 +76,7 @@ private:
   bool _dynamic;
 };
 
-} // namespace controlflow
+} // namespace builtin
 } // namespace backend
 } // namespace onert
 

--- a/runtime/onert/core/src/backend/builtin/UserTensor.h
+++ b/runtime/onert/core/src/backend/builtin/UserTensor.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef __ONERT_BACKEND_CONTROLFLOW_USER_TENSOR_H__
-#define __ONERT_BACKEND_CONTROLFLOW_USER_TENSOR_H__
+#ifndef __ONERT_BACKEND_BUILTIN_USER_TENSOR_H__
+#define __ONERT_BACKEND_BUILTIN_USER_TENSOR_H__
 
 #include "ir/OperandInfo.h"
 #include "backend/IPortableTensor.h"
@@ -80,4 +80,4 @@ private:
 } // namespace backend
 } // namespace onert
 
-#endif // __ONERT_BACKEND_CONTROLFLOW_USER_TENSOR_H__
+#endif // __ONERT_BACKEND_BUILTIN_USER_TENSOR_H__

--- a/runtime/onert/core/src/backend/builtin/kernel/IfLayer.cc
+++ b/runtime/onert/core/src/backend/builtin/kernel/IfLayer.cc
@@ -24,7 +24,7 @@ namespace onert
 {
 namespace backend
 {
-namespace controlflow
+namespace builtin
 {
 namespace kernel
 {
@@ -79,6 +79,6 @@ void IfLayer::run()
 }
 
 } // namespace kernel
-} // namespace controlflow
+} // namespace builtin
 } // namespace backend
 } // namespace onert

--- a/runtime/onert/core/src/backend/builtin/kernel/IfLayer.h
+++ b/runtime/onert/core/src/backend/builtin/kernel/IfLayer.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef __ONERT_BACKEND_CONTROLFLOW_KERNEL_IF_LAYER_H__
-#define __ONERT_BACKEND_CONTROLFLOW_KERNEL_IF_LAYER_H__
+#ifndef __ONERT_BACKEND_BUILTIN_KERNEL_IF_LAYER_H__
+#define __ONERT_BACKEND_BUILTIN_KERNEL_IF_LAYER_H__
 
 #include <backend/IPortableTensor.h>
 #include <exec/IExecutor.h>
@@ -58,4 +58,4 @@ private:
 } // namespace backend
 } // namespace onert
 
-#endif // __ONERT_BACKEND_CONTROLFLOW_KERNEL_IF_LAYER_H__
+#endif // __ONERT_BACKEND_BUILTIN_KERNEL_IF_LAYER_H__

--- a/runtime/onert/core/src/backend/builtin/kernel/IfLayer.h
+++ b/runtime/onert/core/src/backend/builtin/kernel/IfLayer.h
@@ -25,7 +25,7 @@ namespace onert
 {
 namespace backend
 {
-namespace controlflow
+namespace builtin
 {
 namespace kernel
 {
@@ -54,7 +54,7 @@ private:
 };
 
 } // namespace kernel
-} // namespace controlflow
+} // namespace builtin
 } // namespace backend
 } // namespace onert
 

--- a/runtime/onert/core/src/backend/builtin/kernel/PermuteLayer.cc
+++ b/runtime/onert/core/src/backend/builtin/kernel/PermuteLayer.cc
@@ -24,7 +24,7 @@ namespace onert
 {
 namespace backend
 {
-namespace controlflow
+namespace builtin
 {
 namespace kernel
 {
@@ -307,6 +307,6 @@ void PermuteLayer::run()
 }
 
 } // namespace kernel
-} // namespace controlflow
+} // namespace builtin
 } // namespace backend
 } // namespace onert

--- a/runtime/onert/core/src/backend/builtin/kernel/PermuteLayer.h
+++ b/runtime/onert/core/src/backend/builtin/kernel/PermuteLayer.h
@@ -26,7 +26,7 @@ namespace onert
 {
 namespace backend
 {
-namespace controlflow
+namespace builtin
 {
 namespace kernel
 {
@@ -143,7 +143,7 @@ private:
 };
 
 } // namespace kernel
-} // namespace controlflow
+} // namespace builtin
 } // namespace backend
 } // namespace onert
 

--- a/runtime/onert/core/src/backend/builtin/kernel/PermuteLayer.h
+++ b/runtime/onert/core/src/backend/builtin/kernel/PermuteLayer.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef __ONERT_BACKEND_CONTROLFLOW_KERNEL_PERMUTELAYER_H__
-#define __ONERT_BACKEND_CONTROLFLOW_KERNEL_PERMUTELAYER_H__
+#ifndef __ONERT_BACKEND_BUILTIN_KERNEL_PERMUTELAYER_H__
+#define __ONERT_BACKEND_BUILTIN_KERNEL_PERMUTELAYER_H__
 
 #include "exec/IPermuteFunction.h"
 #include "exec/IExecutor.h"
@@ -147,4 +147,4 @@ private:
 } // namespace backend
 } // namespace onert
 
-#endif // __ONERT_BACKEND_CONTROLFLOW_KERNEL_PERMUTELAYER_H__
+#endif // __ONERT_BACKEND_BUILTIN_KERNEL_PERMUTELAYER_H__

--- a/runtime/onert/core/src/backend/builtin/kernel/WhileLayer.cc
+++ b/runtime/onert/core/src/backend/builtin/kernel/WhileLayer.cc
@@ -26,7 +26,7 @@ namespace onert
 {
 namespace backend
 {
-namespace controlflow
+namespace builtin
 {
 namespace kernel
 {
@@ -143,6 +143,6 @@ void WhileLayer::run()
 }
 
 } // namespace kernel
-} // namespace controlflow
+} // namespace builtin
 } // namespace backend
 } // namespace onert

--- a/runtime/onert/core/src/backend/builtin/kernel/WhileLayer.h
+++ b/runtime/onert/core/src/backend/builtin/kernel/WhileLayer.h
@@ -30,7 +30,7 @@ namespace onert
 {
 namespace backend
 {
-namespace controlflow
+namespace builtin
 {
 namespace kernel
 {
@@ -58,7 +58,7 @@ private:
 };
 
 } // namespace kernel
-} // namespace controlflow
+} // namespace builtin
 } // namespace backend
 } // namespace onert
 

--- a/runtime/onert/core/src/backend/builtin/kernel/WhileLayer.h
+++ b/runtime/onert/core/src/backend/builtin/kernel/WhileLayer.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef __ONERT_BACKEND_CONTROLFLOW_KERNEL_WHILE_LAYER_H__
-#define __ONERT_BACKEND_CONTROLFLOW_KERNEL_WHILE_LAYER_H__
+#ifndef __ONERT_BACKEND_BUILTIN_KERNEL_WHILE_LAYER_H__
+#define __ONERT_BACKEND_BUILTIN_KERNEL_WHILE_LAYER_H__
 
 #include <backend/IPortableTensor.h>
 #include <exec/IExecutor.h>
@@ -62,4 +62,4 @@ private:
 } // namespace backend
 } // namespace onert
 
-#endif // __ONERT_BACKEND_CONTROLFLOW_KERNEL_WHILE_LAYER_H__
+#endif // __ONERT_BACKEND_BUILTIN_KERNEL_WHILE_LAYER_H__

--- a/runtime/onert/core/src/compiler/BackendManager.cc
+++ b/runtime/onert/core/src/compiler/BackendManager.cc
@@ -45,9 +45,9 @@ BackendManager &BackendManager::get()
   return object;
 }
 
-BackendManager::BackendManager() { loadControlflowBackend(); }
+BackendManager::BackendManager() { loadBuiltinBackend(); }
 
-void BackendManager::loadControlflowBackend()
+void BackendManager::loadBuiltinBackend()
 {
   auto backend_object = std::unique_ptr<backend::builtin::Backend, backend_destroy_t>(
     new backend::builtin::Backend, [](backend::Backend *backend) { delete backend; });
@@ -57,8 +57,8 @@ void BackendManager::loadControlflowBackend()
   {
     throw std::runtime_error(backend::builtin::Config::ID + " backend initialization failed");
   }
-  _controlflow = backend_object.get(); // Save the builtin backend implementation pointer
-  assert(_controlflow);
+  _builtin = backend_object.get(); // Save the builtin backend implementation pointer
+  assert(_builtin);
   _gen_map.emplace(backend_object->config()->id(), std::move(backend_object));
 }
 
@@ -158,7 +158,7 @@ const backend::Backend *BackendManager::get(const std::string &key) const
   return nullptr;
 }
 
-const backend::builtin::Backend *BackendManager::getControlflow() const { return _controlflow; }
+const backend::builtin::Backend *BackendManager::getBuiltin() const { return _builtin; }
 
 } // namespace compiler
 } // namespace onert

--- a/runtime/onert/core/src/compiler/BackendManager.cc
+++ b/runtime/onert/core/src/compiler/BackendManager.cc
@@ -20,8 +20,8 @@
 #include <dlfcn.h>
 
 #include "backend/Backend.h"
-#include "backend/controlflow/Backend.h"
-#include "backend/controlflow/Config.h"
+#include "backend/builtin/Backend.h"
+#include "backend/builtin/Config.h"
 #include "backend/IConfig.h"
 #include "util/logging.h"
 #include "util/ConfigSource.h"
@@ -49,15 +49,15 @@ BackendManager::BackendManager() { loadControlflowBackend(); }
 
 void BackendManager::loadControlflowBackend()
 {
-  auto backend_object = std::unique_ptr<backend::controlflow::Backend, backend_destroy_t>(
-    new backend::controlflow::Backend, [](backend::Backend *backend) { delete backend; });
+  auto backend_object = std::unique_ptr<backend::builtin::Backend, backend_destroy_t>(
+    new backend::builtin::Backend, [](backend::Backend *backend) { delete backend; });
 
   bool initialized = backend_object->config()->initialize(); // Call initialize here?
   if (!initialized)
   {
-    throw std::runtime_error(backend::controlflow::Config::ID + " backend initialization failed");
+    throw std::runtime_error(backend::builtin::Config::ID + " backend initialization failed");
   }
-  _controlflow = backend_object.get(); // Save the controlflow backend implementation pointer
+  _controlflow = backend_object.get(); // Save the builtin backend implementation pointer
   assert(_controlflow);
   _gen_map.emplace(backend_object->config()->id(), std::move(backend_object));
 }
@@ -158,7 +158,7 @@ const backend::Backend *BackendManager::get(const std::string &key) const
   return nullptr;
 }
 
-const backend::controlflow::Backend *BackendManager::getControlflow() const { return _controlflow; }
+const backend::builtin::Backend *BackendManager::getControlflow() const { return _controlflow; }
 
 } // namespace compiler
 } // namespace onert

--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -21,7 +21,7 @@
 #include "ShapeValidator.h"
 #include "Fp32ToFp16Converter.h"
 
-#include <backend/controlflow/Config.h>
+#include <backend/builtin/Config.h>
 #include "compiler/BackendManager.h"
 #include "compiler/IScheduler.h"
 #include "compiler/ManualScheduler.h"
@@ -157,7 +157,7 @@ std::shared_ptr<exec::ExecutorMap> Compiler::compile(void)
 {
   // Set control flow backend for control flow operators
   {
-    auto &cfid = backend::controlflow::Config::ID;
+    auto &cfid = backend::builtin::Config::ID;
     _options.manual_scheduler_options.opcode_to_backend[ir::OpCode::If] = cfid;
     _options.manual_scheduler_options.opcode_to_backend[ir::OpCode::While] = cfid;
     _options.manual_scheduler_options.opcode_to_backend[ir::OpCode::Permute] = cfid;
@@ -240,7 +240,7 @@ std::shared_ptr<exec::ExecutorMap> Compiler::compile(void)
     for (auto it = contexts.begin(); it != contexts.end(); it++)
     {
       // Controlflow backend is not for actual computaion of operations so it is an exception
-      if (it->first->config()->id() != backend::controlflow::Config::ID)
+      if (it->first->config()->id() != backend::builtin::Config::ID)
         backends_support_fp16 &= it->first->config()->supportFP16();
     }
 

--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -157,10 +157,10 @@ std::shared_ptr<exec::ExecutorMap> Compiler::compile(void)
 {
   // Set control flow backend for control flow operators
   {
-    auto &cfid = backend::builtin::Config::ID;
-    _options.manual_scheduler_options.opcode_to_backend[ir::OpCode::If] = cfid;
-    _options.manual_scheduler_options.opcode_to_backend[ir::OpCode::While] = cfid;
-    _options.manual_scheduler_options.opcode_to_backend[ir::OpCode::Permute] = cfid;
+    auto &builtin_id = backend::builtin::Config::ID;
+    _options.manual_scheduler_options.opcode_to_backend[ir::OpCode::If] = builtin_id;
+    _options.manual_scheduler_options.opcode_to_backend[ir::OpCode::While] = builtin_id;
+    _options.manual_scheduler_options.opcode_to_backend[ir::OpCode::Permute] = builtin_id;
   }
 
   // FIXME This is a workaround for bcq operations, should remove it
@@ -239,7 +239,7 @@ std::shared_ptr<exec::ExecutorMap> Compiler::compile(void)
     auto &contexts = (*lowered_subgs[index]).backend_contexts();
     for (auto it = contexts.begin(); it != contexts.end(); it++)
     {
-      // Controlflow backend is not for actual computaion of operations so it is an exception
+      // Builtin backend is not for actual computaion of operations so it is an exception
       if (it->first->config()->id() != backend::builtin::Config::ID)
         backends_support_fp16 &= it->first->config()->supportFP16();
     }

--- a/runtime/onert/core/src/compiler/ExecutorFactory.cc
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.cc
@@ -27,10 +27,10 @@
 #include "exec/ExecTime.h"
 #include "compiler/Linear.h"
 #include "backend/IPortableTensor.h"
-#include "backend/controlflow/Config.h"
-#include "backend/controlflow/KernelGenerator.h"
-#include "backend/controlflow/UserTensor.h"
-#include "backend/controlflow/TensorBuilder.h"
+#include "backend/builtin/Config.h"
+#include "backend/builtin/KernelGenerator.h"
+#include "backend/builtin/UserTensor.h"
+#include "backend/builtin/TensorBuilder.h"
 #include "util/TracingCtx.h"
 
 #include <memory>
@@ -67,16 +67,16 @@ private:
 void initializeSubgraphIOTensors(compiler::LoweredGraph &lowered_graph,
                                  const ir::OperandIndexSequence &indices)
 {
-  // TODO Store controlflow backend in BackendContext
-  std::shared_ptr<backend::controlflow::TensorRegistry> cf_tensor_reg;
+  // TODO Store builtin backend in BackendContext
+  std::shared_ptr<backend::builtin::TensorRegistry> cf_tensor_reg;
   for (const auto &e : lowered_graph.backend_contexts())
   {
     auto backend = e.first;
     auto &context = e.second;
-    if (backend->config()->id() == backend::controlflow::Config::ID)
+    if (backend->config()->id() == backend::builtin::Config::ID)
     {
       cf_tensor_reg =
-        std::dynamic_pointer_cast<backend::controlflow::TensorRegistry>(context->tensor_registry);
+        std::dynamic_pointer_cast<backend::builtin::TensorRegistry>(context->tensor_registry);
     }
   }
   assert(cf_tensor_reg);
@@ -84,12 +84,12 @@ void initializeSubgraphIOTensors(compiler::LoweredGraph &lowered_graph,
   for (auto ind : indices)
   {
     const auto &operand = lowered_graph.graph().operands().at(ind);
-    auto tensor = std::make_unique<backend::controlflow::IOTensor>(
+    auto tensor = std::make_unique<backend::builtin::IOTensor>(
       operand.info(),
       ir::Layout::NHWC /* FIXME find op_seq for this operand and use frontend_layout */
     );
 
-    // Add tensor to controlflow TensorRegistry.
+    // Add tensor to builtin TensorRegistry.
     cf_tensor_reg->setNativeIOTensor(ind, std::move(tensor));
   }
 }
@@ -216,10 +216,10 @@ ExecutorFactory::createLinearExecutor(std::unique_ptr<compiler::LoweredGraph> lo
 
   prepareMigrantTensors(*lowered_graph);
 
-  // Give some runtime objects to controlflow KernelGenerator
+  // Give some runtime objects to builtin KernelGenerator
   for (auto &pair : backend_contexts)
   {
-    auto cf_context = dynamic_cast<backend::controlflow::BackendContext *>(pair.second.get());
+    auto cf_context = dynamic_cast<backend::builtin::BackendContext *>(pair.second.get());
     if (cf_context != nullptr)
     {
       auto cf_kernel_gen = cf_context->kernel_gen;
@@ -234,11 +234,11 @@ ExecutorFactory::createLinearExecutor(std::unique_ptr<compiler::LoweredGraph> lo
   std::deque<std::pair<const backend::Backend *, backend::BackendContext *>> ordered_contexts;
   for (auto &pair : backend_contexts)
   {
-    // NOTE controlflow backend must be processed lastly.
+    // NOTE builtin backend must be processed lastly.
     // This is because of Permute layer's specialty which is the only operation that could have
     // different ITensor objects for the input and the output. And it requires all other backends'
     // tensors are ready to use.
-    if (pair.first->config()->id() == "controlflow")
+    if (pair.first->config()->id() == "builtin")
       ordered_contexts.emplace_back(pair.first, pair.second.get());
     else
       ordered_contexts.emplace_front(pair.first, pair.second.get());
@@ -302,10 +302,10 @@ exec::IExecutor *ExecutorFactory::createDataflowExecutor(
 
   prepareMigrantTensors(*lowered_graph);
 
-  // Give some runtime objects to controlflow KernelGenerator
+  // Give some runtime objects to builtin KernelGenerator
   for (auto &pair : backend_contexts)
   {
-    auto cf_context = dynamic_cast<backend::controlflow::BackendContext *>(pair.second.get());
+    auto cf_context = dynamic_cast<backend::builtin::BackendContext *>(pair.second.get());
     if (cf_context != nullptr)
     {
       auto cf_kernel_gen = cf_context->kernel_gen;
@@ -320,11 +320,11 @@ exec::IExecutor *ExecutorFactory::createDataflowExecutor(
   std::deque<std::pair<const backend::Backend *, backend::BackendContext *>> ordered_contexts;
   for (auto &pair : backend_contexts)
   {
-    // NOTE controlflow backend must be processed lastly.
+    // NOTE builtin backend must be processed lastly.
     // This is because of Permute layer's specialty which is the only operation that could have
     // different ITensor objects for the input and the output. And it requires all other backends'
     // tensors are ready to use.
-    if (pair.first->config()->id() == "controlflow")
+    if (pair.first->config()->id() == "builtin")
       ordered_contexts.emplace_back(pair.first, pair.second.get());
     else
       ordered_contexts.emplace_front(pair.first, pair.second.get());

--- a/runtime/onert/core/src/compiler/ExecutorFactory.cc
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.cc
@@ -68,18 +68,18 @@ void initializeSubgraphIOTensors(compiler::LoweredGraph &lowered_graph,
                                  const ir::OperandIndexSequence &indices)
 {
   // TODO Store builtin backend in BackendContext
-  std::shared_ptr<backend::builtin::TensorRegistry> cf_tensor_reg;
+  std::shared_ptr<backend::builtin::TensorRegistry> builtin_tensor_reg;
   for (const auto &e : lowered_graph.backend_contexts())
   {
     auto backend = e.first;
     auto &context = e.second;
     if (backend->config()->id() == backend::builtin::Config::ID)
     {
-      cf_tensor_reg =
+      builtin_tensor_reg =
         std::dynamic_pointer_cast<backend::builtin::TensorRegistry>(context->tensor_registry);
     }
   }
-  assert(cf_tensor_reg);
+  assert(builtin_tensor_reg);
 
   for (auto ind : indices)
   {
@@ -90,7 +90,7 @@ void initializeSubgraphIOTensors(compiler::LoweredGraph &lowered_graph,
     );
 
     // Add tensor to builtin TensorRegistry.
-    cf_tensor_reg->setNativeIOTensor(ind, std::move(tensor));
+    builtin_tensor_reg->setNativeIOTensor(ind, std::move(tensor));
   }
 }
 
@@ -219,12 +219,12 @@ ExecutorFactory::createLinearExecutor(std::unique_ptr<compiler::LoweredGraph> lo
   // Give some runtime objects to builtin KernelGenerator
   for (auto &pair : backend_contexts)
   {
-    auto cf_context = dynamic_cast<backend::builtin::BackendContext *>(pair.second.get());
-    if (cf_context != nullptr)
+    auto builtin_context = dynamic_cast<backend::builtin::BackendContext *>(pair.second.get());
+    if (builtin_context != nullptr)
     {
-      auto cf_kernel_gen = cf_context->kernel_gen;
-      cf_kernel_gen->setTensorRegistries(tensor_regs);
-      cf_kernel_gen->setExecutorMap(executor_map);
+      auto builtin_kernel_gen = builtin_context->kernel_gen;
+      builtin_kernel_gen->setTensorRegistries(tensor_regs);
+      builtin_kernel_gen->setExecutorMap(executor_map);
     }
   }
 
@@ -305,12 +305,12 @@ exec::IExecutor *ExecutorFactory::createDataflowExecutor(
   // Give some runtime objects to builtin KernelGenerator
   for (auto &pair : backend_contexts)
   {
-    auto cf_context = dynamic_cast<backend::builtin::BackendContext *>(pair.second.get());
-    if (cf_context != nullptr)
+    auto builtin_context = dynamic_cast<backend::builtin::BackendContext *>(pair.second.get());
+    if (builtin_context != nullptr)
     {
-      auto cf_kernel_gen = cf_context->kernel_gen;
-      cf_kernel_gen->setTensorRegistries(tensor_regs);
-      cf_kernel_gen->setExecutorMap(executor_map);
+      auto builtin_kernel_gen = builtin_context->kernel_gen;
+      builtin_kernel_gen->setTensorRegistries(tensor_regs);
+      builtin_kernel_gen->setExecutorMap(executor_map);
     }
   }
 

--- a/runtime/onert/core/src/compiler/HEScheduler.cc
+++ b/runtime/onert/core/src/compiler/HEScheduler.cc
@@ -393,7 +393,7 @@ int64_t HEScheduler::DFSChildrenMaxRank(const ir::OperationIndex &index)
         {
           continue;
         }
-        // TODO Change it to controlflow backend
+        // TODO Change it to builtin backend
         auto transfer_cost =
           getPermuteTime(backend, other_backend, quant, operand.info().total_size());
         avg_transfer_cost += transfer_cost;

--- a/runtime/onert/core/src/compiler/HEScheduler.h
+++ b/runtime/onert/core/src/compiler/HEScheduler.h
@@ -173,7 +173,7 @@ private:
   std::unique_ptr<exec::ExecTime> _exec_time;
   const ir::Graph *_graph{nullptr};
   std::vector<const backend::Backend *> _all_backends;
-  const backend::Backend *_cpu_backend{nullptr}; // TODO Change this to controlflow_backend
+  const backend::Backend *_cpu_backend{nullptr}; // TODO Change this to _builtin_backend
   bool _is_profiling_mode;
   bool _is_linear_exec;
   bool _is_parallel_exec;

--- a/runtime/onert/core/src/compiler/HEScheduler.h
+++ b/runtime/onert/core/src/compiler/HEScheduler.h
@@ -58,7 +58,7 @@ public:
   {
     for (auto &entry : backend_contexts)
     {
-      if (entry.first->config()->id() == backend::controlflow::Config::ID)
+      if (entry.first->config()->id() == backend::builtin::Config::ID)
         continue;
       _all_backends.push_back(entry.first);
     }

--- a/runtime/onert/core/src/compiler/LoweredGraph.cc
+++ b/runtime/onert/core/src/compiler/LoweredGraph.cc
@@ -502,7 +502,7 @@ bool LoweredGraph::mergeable(const ir::OpSequenceIndex &op_seq_index,
     {
       // TODO Fix this workaround for the case of model outputs that are used by another operation
       //      This is needed since the branching is decided by operation, but for model outputs,
-      //      there is controlflow backen(use backend) but no actual use operation exists
+      //      there is builtin backen(use backend) but no actual use operation exists
       if (_graph.getOutputs().contains(output))
         return false;
 

--- a/runtime/onert/core/src/compiler/LoweredGraph.cc
+++ b/runtime/onert/core/src/compiler/LoweredGraph.cc
@@ -53,10 +53,10 @@ LoweredGraph::LoweredGraph(const ir::Graph &graph, const CompilerOptions &option
   // Build backend contexts
   auto &backend_manager = BackendManager::get();
 
-  // Always create Controlflow backend context
-  auto cf_backend = backend_manager.getControlflow();
-  _backend_contexts.emplace(
-    cf_backend, cf_backend->newContext(_graph, _graph.getKernelBuilder(), linear_executor));
+  // Always create Builtin backend context
+  auto builtin_backend = backend_manager.getBuiltin();
+  _backend_contexts.emplace(builtin_backend, builtin_backend->newContext(
+                                               _graph, _graph.getKernelBuilder(), linear_executor));
 
   // Create contexts for other backends
   for (auto backend_str : options.backend_list)
@@ -335,10 +335,10 @@ void LoweredGraph::makeOpSequences(
 void LoweredGraph::manipulateLowerInfo(
   ir::OperandIndexMap<std::unique_ptr<ir::operand::LowerInfo>> &operands_lower_info)
 {
-  const auto controlflow_backend = BackendManager::get().getControlflow();
+  const auto builtin_backend = BackendManager::get().getBuiltin();
 
   // TODO Rather than using NHWC Get frontend layout of this node from IR
-  auto factor = ir::operand::PermuteFactor{controlflow_backend, ir::Layout::NHWC};
+  auto factor = ir::operand::PermuteFactor{builtin_backend, ir::Layout::NHWC};
   for (auto index : _graph.getInputs() | ir::Remove::UNDEFINED)
   {
     auto &&lower_info = operands_lower_info.at(index);
@@ -357,7 +357,7 @@ void LoweredGraph::manipulateLowerInfo(
     {
       // In case of that an operand is Graph's output and not input or output of any operation
       lower_info->addDefPermuteFactor(ir::operand::PermuteFactor{
-        controlflow_backend,
+        builtin_backend,
         ir::Layout::NHWC // TODO Get frontend layout of this node from IR
       });
     }

--- a/runtime/onert/core/src/compiler/TensorRegistries.h
+++ b/runtime/onert/core/src/compiler/TensorRegistries.h
@@ -21,9 +21,9 @@
 #include <memory>
 #include "backend/BackendContext.h"
 #include "backend/Backend.h"
-#include "backend/controlflow/Config.h"
-#include "backend/controlflow/TensorBuilder.h"
-#include "backend/controlflow/TensorRegistry.h"
+#include "backend/builtin/Config.h"
+#include "backend/builtin/TensorBuilder.h"
+#include "backend/builtin/TensorRegistry.h"
 
 namespace onert
 {
@@ -41,10 +41,9 @@ public:
     for (const auto &e : backend_contexts)
     {
       auto tensor_reg = e.second->tensor_registry;
-      if (e.first->config()->id() == backend::controlflow::Config::ID)
+      if (e.first->config()->id() == backend::builtin::Config::ID)
       {
-        _cf_tensor_reg =
-          std::dynamic_pointer_cast<backend::controlflow::TensorRegistry>(tensor_reg);
+        _cf_tensor_reg = std::dynamic_pointer_cast<backend::builtin::TensorRegistry>(tensor_reg);
         if (include_controlflow)
           _tensor_regs.insert(tensor_reg);
       }
@@ -64,7 +63,7 @@ public:
     return _tensor_regs.cend();
   }
 
-  std::shared_ptr<backend::controlflow::TensorRegistry> getControlflowTensorRegistry() const
+  std::shared_ptr<backend::builtin::TensorRegistry> getControlflowTensorRegistry() const
   {
     return _cf_tensor_reg;
   }
@@ -82,7 +81,7 @@ public:
 
 private:
   std::unordered_set<std::shared_ptr<backend::ITensorRegistry>> _tensor_regs;
-  std::shared_ptr<backend::controlflow::TensorRegistry> _cf_tensor_reg;
+  std::shared_ptr<backend::builtin::TensorRegistry> _cf_tensor_reg;
 };
 
 } // namespace compiler

--- a/runtime/onert/core/src/compiler/TensorRegistries.h
+++ b/runtime/onert/core/src/compiler/TensorRegistries.h
@@ -35,16 +35,16 @@ class TensorRegistries
 public:
   TensorRegistries() = default;
 
-  TensorRegistries(const onert::backend::BackendContexts &backend_contexts,
-                   bool include_controlflow)
+  TensorRegistries(const onert::backend::BackendContexts &backend_contexts, bool include_builtin)
   {
     for (const auto &e : backend_contexts)
     {
       auto tensor_reg = e.second->tensor_registry;
       if (e.first->config()->id() == backend::builtin::Config::ID)
       {
-        _cf_tensor_reg = std::dynamic_pointer_cast<backend::builtin::TensorRegistry>(tensor_reg);
-        if (include_controlflow)
+        _builtin_tensor_reg =
+          std::dynamic_pointer_cast<backend::builtin::TensorRegistry>(tensor_reg);
+        if (include_builtin)
           _tensor_regs.insert(tensor_reg);
       }
       else
@@ -63,9 +63,9 @@ public:
     return _tensor_regs.cend();
   }
 
-  std::shared_ptr<backend::builtin::TensorRegistry> getControlflowTensorRegistry() const
+  std::shared_ptr<backend::builtin::TensorRegistry> getBuiltinTensorRegistry() const
   {
-    return _cf_tensor_reg;
+    return _builtin_tensor_reg;
   }
 
   backend::ITensor *getITensor(ir::OperandIndex ind) const
@@ -81,7 +81,7 @@ public:
 
 private:
   std::unordered_set<std::shared_ptr<backend::ITensorRegistry>> _tensor_regs;
-  std::shared_ptr<backend::builtin::TensorRegistry> _cf_tensor_reg;
+  std::shared_ptr<backend::builtin::TensorRegistry> _builtin_tensor_reg;
 };
 
 } // namespace compiler

--- a/runtime/onert/core/src/compiler/pass/PermutationEliminationPass.cc
+++ b/runtime/onert/core/src/compiler/pass/PermutationEliminationPass.cc
@@ -15,7 +15,7 @@
  */
 
 #include "PermutationEliminationPass.h"
-#include "backend/controlflow/Config.h"
+#include "backend/builtin/Config.h"
 
 #include "util/logging.h"
 

--- a/runtime/onert/core/src/compiler/pass/PermutationEliminationPass.h
+++ b/runtime/onert/core/src/compiler/pass/PermutationEliminationPass.h
@@ -35,7 +35,7 @@ namespace pass
  * are compatible and layouts match.
  *
  * Permute input tensor is kept and the output is removed for all the cases, except model outputs.
- * As all output tensors have to be controlflow backend, so the output is kept.
+ * As all output tensors have to be builtin backend, so the output is kept.
  *
  * @note This is an optimization pass which means that everything should work fine even if this pass
  *       was skipped.

--- a/runtime/onert/core/src/compiler/pass/PermutationInsertionPass.cc
+++ b/runtime/onert/core/src/compiler/pass/PermutationInsertionPass.cc
@@ -20,7 +20,7 @@
 #include <utility>
 #include <unordered_map>
 
-#include "backend/controlflow/Config.h"
+#include "backend/builtin/Config.h"
 #include "ir/Operand.h"
 #include "ir/operation/LowerInfo.h"
 #include "ir/Graph.h"
@@ -130,7 +130,7 @@ ir::OperationIndex PermutationInsertionPass::insertPermute(const ir::OperandInde
 
   // Generate output operand and permute operation
   auto out_operand_index = _graph.addOperand(operand.shape(), operand.typeInfo());
-  // change model output if operand_index is model output index and the out operand is controlflow
+  // change model output if operand_index is model output index and the out operand is builtin
   // backend
   auto &model_outputs = _graph.getOutputs();
   const backend::Backend *cf_backend = compiler::BackendManager::get().getControlflow();

--- a/runtime/onert/core/src/compiler/pass/PermutationInsertionPass.cc
+++ b/runtime/onert/core/src/compiler/pass/PermutationInsertionPass.cc
@@ -133,8 +133,8 @@ ir::OperationIndex PermutationInsertionPass::insertPermute(const ir::OperandInde
   // change model output if operand_index is model output index and the out operand is builtin
   // backend
   auto &model_outputs = _graph.getOutputs();
-  const backend::Backend *cf_backend = compiler::BackendManager::get().getControlflow();
-  if (model_outputs.contains(operand_index) && factor.backend() == cf_backend)
+  const backend::Backend *builtin_backend = compiler::BackendManager::get().getBuiltin();
+  if (model_outputs.contains(operand_index) && factor.backend() == builtin_backend)
   {
     model_outputs.replace(operand_index, out_operand_index);
   }
@@ -147,7 +147,7 @@ ir::OperationIndex PermutationInsertionPass::insertPermute(const ir::OperandInde
   // different.
   const auto permute_node_layout = ir::Layout::UNKNOWN;
   // NOTE If one backend supports several layout, the backend must support Permute operation
-  const backend::Backend *permute_node_backend = compiler::BackendManager::get().getControlflow();
+  const backend::Backend *permute_node_backend = compiler::BackendManager::get().getBuiltin();
   if (input_backend == output_backend)
   {
     permute_node_backend = input_backend;

--- a/runtime/onert/core/src/exec/ExecutorBase.cc
+++ b/runtime/onert/core/src/exec/ExecutorBase.cc
@@ -17,7 +17,7 @@
 #include "ExecutorBase.h"
 #include "ShapeConverter.h"
 
-#include "backend/controlflow/UserTensor.h"
+#include "backend/builtin/UserTensor.h"
 #include "util/logging.h"
 #include "misc/polymorphic_downcast.h"
 
@@ -38,7 +38,7 @@ ExecutorBase::ExecutorBase(std::unique_ptr<compiler::LoweredGraph> &&lowered_gra
     {
       backend::ITensor *tensor = tensor_regs.getITensor(ind);
       assert(tensor != nullptr);
-      auto io_tensor = nnfw::misc::polymorphic_downcast<backend::controlflow::IOTensor *>(tensor);
+      auto io_tensor = nnfw::misc::polymorphic_downcast<backend::builtin::IOTensor *>(tensor);
       tensors.push_back(io_tensor);
     }
   };

--- a/runtime/onert/core/src/exec/ExecutorBase.h
+++ b/runtime/onert/core/src/exec/ExecutorBase.h
@@ -29,7 +29,7 @@
 #include "ir/OperationIndexMap.h"
 #include "compiler/LoweredGraph.h"
 #include "compiler/TensorRegistries.h"
-#include "backend/controlflow/IOTensor.h"
+#include "backend/builtin/IOTensor.h"
 #include "util/TracingCtx.h"
 
 #include <cstdint>
@@ -72,7 +72,7 @@ public:
 
   void addObserver(std::unique_ptr<IExecutionObserver> ref) { _subject.add(std::move(ref)); };
 
-  const std::vector<backend::controlflow::IOTensor *> &getOutputTensors() const override
+  const std::vector<backend::builtin::IOTensor *> &getOutputTensors() const override
   {
     return _output_tensors;
   }
@@ -88,8 +88,8 @@ protected:
   std::shared_ptr<ir::OperationIndexMap<int64_t>> _indexed_ranks;
   std::unique_ptr<compiler::LoweredGraph> _lowered_graph;
   const ir::Graph &_graph;
-  std::vector<backend::controlflow::IOTensor *> _input_tensors;
-  std::vector<backend::controlflow::IOTensor *> _output_tensors;
+  std::vector<backend::builtin::IOTensor *> _input_tensors;
+  std::vector<backend::builtin::IOTensor *> _output_tensors;
   std::mutex _mutex;
   const util::TracingCtx *_tracing_ctx;
 

--- a/runtime/onert/core/src/interp/InterpExecutor.h
+++ b/runtime/onert/core/src/interp/InterpExecutor.h
@@ -63,7 +63,7 @@ public:
   {
     throw new std::runtime_error{"Interpreter does not support subgraph calls(control flow ops)"};
   }
-  const std::vector<backend::controlflow::IOTensor *> &getOutputTensors() const final
+  const std::vector<backend::builtin::IOTensor *> &getOutputTensors() const final
   {
     throw new std::runtime_error{"Interpreter does not support this function."};
   }


### PR DESCRIPTION
Rename "controlflow" backend to "builtin". As it does much  more than
supporting controlflow operations.

- Provide kernels for special operations
    - Control Flow Operation
    - Permute(Forward tensors between backend boundary) Operation
- Manages Subgraph's In/Output tensors

Related Issue : #4139

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>