### PR TITLE
[runtime] Remove clang-format style file symbolic link

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,3 @@
----
 Language:        Cpp
 BasedOnStyle: Google
 AccessModifierOffset: -2
@@ -21,17 +20,18 @@ AlwaysBreakTemplateDeclarations: false
 BinPackArguments: true
 BinPackParameters: true
 BraceWrapping:
-  AfterClass:      true
-  AfterControlStatement: true
-  AfterEnum:       true
-  AfterFunction:   true
-  AfterNamespace:  true
-  AfterObjCDeclaration: false
-  AfterStruct:     true
-  AfterUnion:      false
-  BeforeCatch:     true
-  BeforeElse:      true
-  IndentBraces:    false
+  AfterClass:             true
+  AfterControlStatement:  true
+  AfterEnum:              true
+  AfterFunction:          true
+  AfterNamespace:         true
+  AfterObjCDeclaration:   false
+  AfterStruct:            true
+  AfterUnion:             false
+  AfterExternBlock:       false
+  BeforeCatch:            true
+  BeforeElse:             true
+  IndentBraces:           false
 BreakBeforeBraces: Custom
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializersBeforeComma: false
@@ -40,12 +40,13 @@ BreakStringLiterals: true
 ColumnLimit:     100
 CommentPragmas:  '^ IWYU pragma:'
 ConstructorInitializerAllOnOneLineOrOnePerLine: false
-ConstructorInitializerIndentWidth: 4
-ContinuationIndentWidth: 4
+ConstructorInitializerIndentWidth: 2
+ContinuationIndentWidth: 2
 Cpp11BracedListStyle: true
 DerivePointerAlignment: false
 DisableFormat:   false
 ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
 IncludeCategories:
   - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
     Priority:        2
@@ -75,6 +76,7 @@ PenaltyReturnTypeOnItsOwnLine: 60
 PointerAlignment: Right
 ReflowComments:  true
 SortIncludes:    false
+SortUsingDeclarations: false
 SpaceAfterCStyleCast: false
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeParens: ControlStatements
@@ -86,5 +88,5 @@ SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
 Standard:        Cpp11
-TabWidth:        4
+TabWidth:        2
 UseTab:          Never

--- a/compute/.clang-format
+++ b/compute/.clang-format
@@ -1,1 +1,0 @@
-../.clang-format.8

--- a/runtime/.clang-format
+++ b/runtime/.clang-format
@@ -1,1 +1,0 @@
-../.clang-format.8

--- a/tests/.clang-format
+++ b/tests/.clang-format
@@ -1,1 +1,0 @@
-../.clang-format.8

--- a/tools/.clang-format
+++ b/tools/.clang-format
@@ -1,1 +1,0 @@
-../.clang-format.8


### PR DESCRIPTION
Use clang-format style file for version 8
Remove symbolic link file to .clang-format.8 for runtime code

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>