### PR TITLE
[nnpkg_run] Allows NNFW_TYPE_TENSOR_QUANT8_ASYMM_SIGNED input type

### DIFF
--- a/tests/tools/nnpackage_run/src/nnpackage_run.cc
+++ b/tests/tools/nnpackage_run/src/nnpackage_run.cc
@@ -97,7 +97,7 @@ int main(const int argc, char **argv)
         nnfw_tensorinfo ti;
         NNPR_ENSURE_STATUS(nnfw_input_tensorinfo(session, i, &ti));
 
-        if (ti.dtype < NNFW_TYPE_TENSOR_FLOAT32 || ti.dtype > NNFW_TYPE_TENSOR_INT64)
+        if (ti.dtype < NNFW_TYPE_TENSOR_FLOAT32 || ti.dtype > NNFW_TYPE_TENSOR_QUANT8_ASYMM_SIGNED)
         {
           std::cerr << "E: not supported input type" << std::endl;
           exit(-1);


### PR DESCRIPTION
`nnpkg_run` will allow NNFW_TYPE_TENSOR_QUANT8_ASYMM_SIGNED input type.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>