### PR TITLE
[onert] Support cpu backend ResizeBilinear int8 datatype

### DIFF
--- a/runtime/onert/backend/cpu/ops/ResizeBilinearLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ResizeBilinearLayer.cc
@@ -100,6 +100,12 @@ void ResizeBilinearLayer::run()
         getTensorShape(_output), reinterpret_cast<uint8_t *>(_output->buffer()));
       break;
 
+    case OperandType::QUANT_INT8_ASYMM:
+      nnfw::cker::ResizeBilinear(
+        params, getTensorShape(_input), reinterpret_cast<const int8_t *>(_input->buffer()),
+        getTensorShape(_output), reinterpret_cast<int8_t *>(_output->buffer()));
+      break;
+
     case OperandType::UINT8:
     case OperandType::BOOL8:
     case OperandType::FLOAT16:

--- a/tests/nnfw_api/src/one_op_tests/ResizeBilinear.cc
+++ b/tests/nnfw_api/src/one_op_tests/ResizeBilinear.cc
@@ -18,24 +18,51 @@
 
 #include <memory>
 
-TEST_F(GenModelTest, OneOp_ResizeBilinear_SizeToConst)
+struct ResizeBilinearParam
 {
+  TestCaseData tcd;
+  circle::TensorType data_type = circle::TensorType::TensorType_FLOAT32;
+  float scale = 0.0f;
+  int64_t zero_point = 0;
+};
+
+class ResizeBilinearVariation : public GenModelTest,
+                                public ::testing::WithParamInterface<ResizeBilinearParam>
+{
+};
+
+TEST_P(ResizeBilinearVariation, Test)
+{
+  auto &param = GetParam();
+
   CircleGen cgen;
   std::vector<int32_t> size_data{3, 3};
   uint32_t size_buf = cgen.addBuffer(size_data);
   int size = cgen.addTensor({{1}, circle::TensorType::TensorType_INT32, size_buf});
-  int in = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_FLOAT32});
-  int out = cgen.addTensor({{1, 3, 3, 1}, circle::TensorType::TensorType_FLOAT32});
+  int in = cgen.addTensor({{1, 2, 2, 1}, param.data_type}, param.scale, param.zero_point);
+  int out = cgen.addTensor({{1, 3, 3, 1}, param.data_type}, param.scale, param.zero_point);
   cgen.addOperatorResizeBilinear({{in, size}, {out}});
   cgen.setInputsAndOutputs({in}, {out});
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
-  _context->addTestCase(
-    uniformTCD<float>({{1, 1, 2, 2}}, {{1, 1, 1, 1.666666667, 1.666666667, 1.666666667, 2, 2, 2}}));
+  _context->addTestCase(param.tcd);
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
 
   SUCCEED();
 }
+
+INSTANTIATE_TEST_CASE_P(
+  GenModelTest, ResizeBilinearVariation,
+  ::testing::Values(
+    // float value
+    ResizeBilinearParam{uniformTCD<float>({{1, 1, 2, 2}}, {{1, 1, 1, 1.666666667, 1.666666667,
+                                                            1.666666667, 2, 2, 2}})},
+    // uint8 value
+    ResizeBilinearParam{uniformTCD<uint8_t>({{3, 6, 9, 12}}, {{3, 5, 6, 7, 9, 10, 9, 11, 12}}),
+                        circle::TensorType::TensorType_UINT8, 1.0, 0},
+    // int8 value
+    ResizeBilinearParam{uniformTCD<int8_t>({{-6, -3, 9, 12}}, {{-6, -4, -3, 4, 6, 7, 9, 11, 12}}),
+                        circle::TensorType::TensorType_INT8, 1.0, 0}));
 
 TEST_F(GenModelTest, OneOp_ResizeBilinear_SizeToVar)
 {


### PR DESCRIPTION
- Port tensorflow lite ResizeBilinear int8 kernel
- Add one op test for ResizeBilinear quantization data type

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: #4664