### PR TITLE
[tf2tfliteV2] Fix default value of input_shapes

### DIFF
--- a/compiler/tf2tfliteV2/tf2tfliteV2.py
+++ b/compiler/tf2tfliteV2/tf2tfliteV2.py
@@ -180,7 +180,7 @@ def _v2_convert(flags):
             raise ValueError("--input_arrays must be provided")
         if not flags.output_arrays:
             raise ValueError("--output_arrays must be provided")
-        input_shapes = None
+        input_shapes = []
         if flags.input_shapes:
             input_shapes = [
                 _parse_array(shape, type_fn=int)


### PR DESCRIPTION
When `input_shapes` is not given for `_v2_convert`, input_shapes becomes `None` and
it causes an error at `len(input_shapes)`.
This commit will fix it.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>