### PR TITLE
[compiler] Remove symbolic link clang format style files

### DIFF
--- a/compiler/angkor/.clang-format
+++ b/compiler/angkor/.clang-format
@@ -1,1 +1,0 @@
-../../.clang-format.8

--- a/compiler/arser/.clang-format
+++ b/compiler/arser/.clang-format
@@ -1,1 +1,0 @@
-../../.clang-format.8

--- a/compiler/bino/.clang-format
+++ b/compiler/bino/.clang-format
@@ -1,1 +1,0 @@
-../../.clang-format.8

--- a/compiler/circle-inspect/.clang-format
+++ b/compiler/circle-inspect/.clang-format
@@ -1,1 +1,0 @@
-../../.clang-format.8

--- a/compiler/circle-quantizer/.clang-format
+++ b/compiler/circle-quantizer/.clang-format
@@ -1,1 +1,0 @@
-../../.clang-format.8

--- a/compiler/circle-tensordump/.clang-format
+++ b/compiler/circle-tensordump/.clang-format
@@ -1,1 +1,0 @@
-../../.clang-format.8

--- a/compiler/circle2circle/.clang-format
+++ b/compiler/circle2circle/.clang-format
@@ -1,1 +1,0 @@
-../../.clang-format.8

--- a/compiler/circlechef/.clang-format
+++ b/compiler/circlechef/.clang-format
@@ -1,1 +1,0 @@
-../../.clang-format.8

--- a/compiler/circledump/.clang-format
+++ b/compiler/circledump/.clang-format
@@ -1,1 +1,0 @@
-../../.clang-format.8

--- a/compiler/coco/.clang-format
+++ b/compiler/coco/.clang-format
@@ -1,1 +1,0 @@
-../../.clang-format.8

--- a/compiler/common-artifacts/.clang-format
+++ b/compiler/common-artifacts/.clang-format
@@ -1,1 +1,0 @@
-../../.clang-format.8

--- a/compiler/cwrap/.clang-format
+++ b/compiler/cwrap/.clang-format
@@ -1,1 +1,0 @@
-../../.clang-format.8

--- a/compiler/enco/.clang-format
+++ b/compiler/enco/.clang-format
@@ -1,1 +1,0 @@
-../../.clang-format.8

--- a/compiler/exo/.clang-format
+++ b/compiler/exo/.clang-format
@@ -1,1 +1,0 @@
-../../.clang-format.8

--- a/compiler/loco/.clang-format
+++ b/compiler/loco/.clang-format
@@ -1,1 +1,0 @@
-../../.clang-format.8

--- a/compiler/locoex-customop/.clang-format
+++ b/compiler/locoex-customop/.clang-format
@@ -1,1 +1,0 @@
-../../.clang-format.8

--- a/compiler/locomotiv/.clang-format
+++ b/compiler/locomotiv/.clang-format
@@ -1,1 +1,0 @@
-../../.clang-format.8

--- a/compiler/locop/.clang-format
+++ b/compiler/locop/.clang-format
@@ -1,1 +1,0 @@
-../../.clang-format.8

--- a/compiler/logo/.clang-format
+++ b/compiler/logo/.clang-format
@@ -1,1 +1,0 @@
-../../.clang-format.8

--- a/compiler/luci-interpreter/.clang-format
+++ b/compiler/luci-interpreter/.clang-format
@@ -1,1 +1,0 @@
-../../.clang-format.8

--- a/compiler/luci-value-test/.clang-format
+++ b/compiler/luci-value-test/.clang-format
@@ -1,1 +1,0 @@
-../../.clang-format.8

--- a/compiler/luci/.clang-format
+++ b/compiler/luci/.clang-format
@@ -1,1 +1,0 @@
-../../.clang-format.8

--- a/compiler/mir-interpreter/.clang-format
+++ b/compiler/mir-interpreter/.clang-format
@@ -1,1 +1,0 @@
-../../.clang-format.8

--- a/compiler/mir/.clang-format
+++ b/compiler/mir/.clang-format
@@ -1,1 +1,0 @@
-../../.clang-format.8

--- a/compiler/mir2loco/.clang-format
+++ b/compiler/mir2loco/.clang-format
@@ -1,1 +1,0 @@
-../../.clang-format.8

--- a/compiler/moco-tf/.clang-format
+++ b/compiler/moco-tf/.clang-format
@@ -1,1 +1,0 @@
-../../.clang-format.8

--- a/compiler/moco/.clang-format
+++ b/compiler/moco/.clang-format
@@ -1,1 +1,0 @@
-../../.clang-format.8

--- a/compiler/nest/.clang-format
+++ b/compiler/nest/.clang-format
@@ -1,1 +1,0 @@
-../../.clang-format.8

--- a/compiler/nnc/.clang-format
+++ b/compiler/nnc/.clang-format
@@ -1,1 +1,0 @@
-../../.clang-format.8

--- a/compiler/nnkit-intf/.clang-format
+++ b/compiler/nnkit-intf/.clang-format
@@ -1,1 +1,0 @@
-../../.clang-format.8

--- a/compiler/nnkit-mocotf/.clang-format
+++ b/compiler/nnkit-mocotf/.clang-format
@@ -1,1 +1,0 @@
-../../.clang-format.8

--- a/compiler/nnkit-onnxrt/.clang-format
+++ b/compiler/nnkit-onnxrt/.clang-format
@@ -1,1 +1,0 @@
-../../.clang-format.8

--- a/compiler/nnkit-tf/.clang-format
+++ b/compiler/nnkit-tf/.clang-format
@@ -1,1 +1,0 @@
-../../.clang-format.8

--- a/compiler/nnkit-tflite/.clang-format
+++ b/compiler/nnkit-tflite/.clang-format
@@ -1,1 +1,0 @@
-../../.clang-format.8

--- a/compiler/nnkit/.clang-format
+++ b/compiler/nnkit/.clang-format
@@ -1,1 +1,0 @@
-../../.clang-format.8

--- a/compiler/nnop/.clang-format
+++ b/compiler/nnop/.clang-format
@@ -1,1 +1,0 @@
-../../.clang-format.8

--- a/compiler/nnsuite/.clang-format
+++ b/compiler/nnsuite/.clang-format
@@ -1,1 +1,0 @@
-../../.clang-format.8

--- a/compiler/oneco/.clang-format
+++ b/compiler/oneco/.clang-format
@@ -1,1 +1,0 @@
-../../.clang-format.8

--- a/compiler/oops/.clang-format
+++ b/compiler/oops/.clang-format
@@ -1,1 +1,0 @@
-../../.clang-format.8

--- a/compiler/pepper-str/.clang-format
+++ b/compiler/pepper-str/.clang-format
@@ -1,1 +1,0 @@
-../../.clang-format.8

--- a/compiler/plier-tf/.clang-format
+++ b/compiler/plier-tf/.clang-format
@@ -1,1 +1,0 @@
-../../.clang-format.8

--- a/compiler/record-minmax/.clang-format
+++ b/compiler/record-minmax/.clang-format
@@ -1,1 +1,0 @@
-../../.clang-format.8

--- a/compiler/tfinfo-v2/.clang-format
+++ b/compiler/tfinfo-v2/.clang-format
@@ -1,1 +1,0 @@
-../../.clang-format.8

--- a/compiler/tfinfo/.clang-format
+++ b/compiler/tfinfo/.clang-format
@@ -1,1 +1,0 @@
-../../.clang-format.8

--- a/compiler/tfkit/.clang-format
+++ b/compiler/tfkit/.clang-format
@@ -1,1 +1,0 @@
-../../.clang-format.8

--- a/compiler/tfl-inspect/.clang-format
+++ b/compiler/tfl-inspect/.clang-format
@@ -1,1 +1,0 @@
-../../.clang-format.8

--- a/compiler/tflchef/.clang-format
+++ b/compiler/tflchef/.clang-format
@@ -1,1 +1,0 @@
-../../.clang-format.8

--- a/compiler/tfldump/.clang-format
+++ b/compiler/tfldump/.clang-format
@@ -1,1 +1,0 @@
-../../.clang-format.8

--- a/compiler/tflite2circle/.clang-format
+++ b/compiler/tflite2circle/.clang-format
@@ -1,1 +1,0 @@
-../../.clang-format.8


### PR DESCRIPTION
It removes all symbolic link clang format style file in compiler directories

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>