### PR TITLE
[onert] Remove redundant check in `initConsts`

### DIFF
--- a/runtime/onert/core/include/backend/cpu_common/BackendContextHelpers.h
+++ b/runtime/onert/core/include/backend/cpu_common/BackendContextHelpers.h
@@ -257,9 +257,6 @@ inline void initConsts(BackendContext &ctx)
 
     VERBOSE(FillOperandData) << "Fill data for " << ind << std::endl;
 
-    if (!operand.isConstant())
-      continue;
-
     auto data = operand.shareData();
     assert(data && data->base());
     ExternalTensor *ext_tensor = dynamic_cast<ExternalTensor *>(tensor);


### PR DESCRIPTION
Remove redundant check in `initConsts`, it is already done a few lines
above.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>