### PR TITLE
[onert] Change CalculateActivationRangeUint8 to cover Int8 type

### DIFF
--- a/runtime/onert/backend/cpu/ops/BinaryArithmeticLayer.cc
+++ b/runtime/onert/backend/cpu/ops/BinaryArithmeticLayer.cc
@@ -115,7 +115,8 @@ void setAddOrSubQuant8Params(const IPortableTensor *lhs, const IPortableTensor *
                              nnfw::cker::BinaryArithmeticOpParam *params)
 {
   int32_t output_activation_min, output_activation_max;
-  CalculateActivationRangeUint8(activation, output, &output_activation_min, &output_activation_max);
+  CalculateActivationRangeQuantized(activation, output, &output_activation_min,
+                                    &output_activation_max);
   nnfw::cker::BinaryArithmeticOpParam &op_params = *params;
   op_params.quantized_activation_max = output_activation_max;
   op_params.quantized_activation_min = output_activation_min;
@@ -149,7 +150,8 @@ void setMulQuant8Params(const IPortableTensor *lhs, const IPortableTensor *rhs,
                         nnfw::cker::BinaryArithmeticOpParam *params)
 {
   int32_t output_activation_min, output_activation_max;
-  CalculateActivationRangeUint8(activation, output, &output_activation_min, &output_activation_max);
+  CalculateActivationRangeQuantized(activation, output, &output_activation_min,
+                                    &output_activation_max);
   nnfw::cker::BinaryArithmeticOpParam &op_params = *params;
 
   op_params.quantized_activation_max = output_activation_max;

--- a/runtime/onert/backend/cpu/ops/ConvolutionLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ConvolutionLayer.cc
@@ -67,8 +67,8 @@ void ConvolutionLayer::convQuant8()
 {
   int32_t output_activation_min = 0;
   int32_t output_activation_max = 0;
-  CalculateActivationRangeUint8(_activation, _output, &output_activation_min,
-                                &output_activation_max);
+  CalculateActivationRangeQuantized(_activation, _output, &output_activation_min,
+                                    &output_activation_max);
 
   double real_multiplier = 0.0;
   int32_t output_multiplier = 0;

--- a/runtime/onert/backend/cpu/ops/DepthwiseConvolutionLayer.cc
+++ b/runtime/onert/backend/cpu/ops/DepthwiseConvolutionLayer.cc
@@ -55,8 +55,8 @@ void DepthwiseConvolutionLayer::convQuant8()
 {
   int32_t output_activation_min = 0;
   int32_t output_activation_max = 0;
-  CalculateActivationRangeUint8(_activation, _output, &output_activation_min,
-                                &output_activation_max);
+  CalculateActivationRangeQuantized(_activation, _output, &output_activation_min,
+                                    &output_activation_max);
 
   double real_multiplier = 0.0;
   int32_t output_multiplier = 0;

--- a/runtime/onert/backend/cpu/ops/FullyConnectedLayer.cc
+++ b/runtime/onert/backend/cpu/ops/FullyConnectedLayer.cc
@@ -63,8 +63,8 @@ void FullyConnectedLayer::fullyConnectedQuant8()
   int32_t output_activation_max = 0;
   GetQuantizedConvolutionMultiplier(_input, _weights, _bias, _output, &real_multiplier);
   QuantizeMultiplier(real_multiplier, &output_multiplier, &output_shift);
-  CalculateActivationRangeUint8(_activation, _output, &output_activation_min,
-                                &output_activation_max);
+  CalculateActivationRangeQuantized(_activation, _output, &output_activation_min,
+                                    &output_activation_max);
 
   nnfw::cker::FullyConnectedParams op_params;
   op_params.input_offset = -_input->data_offset();

--- a/runtime/onert/backend/cpu/ops/OperationUtils.h
+++ b/runtime/onert/backend/cpu/ops/OperationUtils.h
@@ -195,8 +195,8 @@ void CalculateActivationRange(ir::Activation activation, T *activation_min, T *a
   }
 }
 
-void CalculateActivationRangeUint8(ir::Activation activation, const IPortableTensor *output,
-                                   int32_t *act_min, int32_t *act_max);
+void CalculateActivationRangeQuantized(ir::Activation activation, const IPortableTensor *output,
+                                       int32_t *act_min, int32_t *act_max);
 
 bool HaveSameShapes(const IPortableTensor *input1, const IPortableTensor *input2);
 

--- a/runtime/onert/backend/cpu/ops/PoolLayer.cc
+++ b/runtime/onert/backend/cpu/ops/PoolLayer.cc
@@ -110,8 +110,8 @@ void PoolLayer::configure(const IPortableTensor *input, const uint32_t paddingLe
   {
     int32_t output_activation_min = 0;
     int32_t output_activation_max = 0;
-    CalculateActivationRangeUint8(activation, _output, &output_activation_min,
-                                  &output_activation_max);
+    CalculateActivationRangeQuantized(activation, _output, &output_activation_min,
+                                      &output_activation_max);
     op_params.quantized_activation_min = output_activation_min;
     op_params.quantized_activation_max = output_activation_max;
     _kernel = generateKernelGeneric<uint8_t>(op_params, op_type);


### PR DESCRIPTION
: CalculateActivationRangeUint8 is updated to CalculateActivationRangeQuantized
: Int16 and Channelwise Int8 cases are NOT added deliberately because no
kernel seem to support those types. Thus it will not be tested at all.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>