### PR TITLE
[onert] Make Schedulers use a backend list

### DIFF
--- a/runtime/onert/core/src/compiler/HEScheduler.h
+++ b/runtime/onert/core/src/compiler/HEScheduler.h
@@ -50,17 +50,17 @@ public:
    * @param[in] model Graph model
    * @param[in] backend_resolver backend resolver
    */
-  HEScheduler(const backend::BackendContexts &backend_contexts, const CompilerOptions &options)
+  HEScheduler(const std::vector<const backend::Backend *> &backends, const CompilerOptions &options)
     : _is_supported{}, _backends_avail_time{}, _ops_eft{},
       _op_to_rank{std::make_shared<ir::OperationIndexMap<int64_t>>()},
       _is_profiling_mode{options.he_profiling_mode}, _is_linear_exec{options.executor == "Linear"},
       _is_parallel_exec{options.executor == "Parallel"}
   {
-    for (auto &entry : backend_contexts)
+    for (auto entry : backends)
     {
-      if (entry.first->config()->id() == backend::builtin::Config::ID)
+      if (entry->config()->id() == backend::builtin::Config::ID)
         continue;
-      _all_backends.push_back(entry.first);
+      _all_backends.push_back(entry);
     }
     _backend_resolver = std::make_unique<compiler::BackendResolver>();
     _exec_time = std::make_unique<exec::ExecTime>(_all_backends);

--- a/runtime/onert/core/src/compiler/LoweredGraph.cc
+++ b/runtime/onert/core/src/compiler/LoweredGraph.cc
@@ -82,15 +82,16 @@ LoweredGraph::LoweredGraph(const ir::Graph &graph, const CompilerOptions &option
   // TODO Move "schedule" phase out of here
   // Schedule
   std::unique_ptr<BackendResolver> backend_resolver;
+  auto all_backends = backend_manager.getAll();
   if (options.he_scheduler)
   {
-    auto scheduler = HEScheduler(_backend_contexts, options);
+    auto scheduler = HEScheduler(all_backends, options);
     backend_resolver = scheduler.schedule(_graph);
     _indexed_ranks = scheduler.getIndexedRanks();
   }
   else
   {
-    auto scheduler = ManualScheduler(_backend_contexts, options);
+    auto scheduler = ManualScheduler(all_backends, options);
     backend_resolver = scheduler.schedule(_graph);
   }
 

--- a/runtime/onert/core/src/compiler/ManualScheduler.cc
+++ b/runtime/onert/core/src/compiler/ManualScheduler.cc
@@ -29,9 +29,9 @@ namespace onert
 namespace compiler
 {
 
-ManualScheduler::ManualScheduler(const backend::BackendContexts &backend_contexts,
+ManualScheduler::ManualScheduler(const std::vector<const backend::Backend *> &backends,
                                  const compiler::CompilerOptions &options)
-  : _backend_contexts{backend_contexts}, _options{options}
+  : _backends{backends}, _options{options}
 {
 }
 
@@ -88,9 +88,7 @@ std::unique_ptr<BackendResolver> ManualScheduler::schedule(const ir::Graph &grap
     try
     {
       graph.operations().at(key); // Check if exist, or this will throw
-      backend_resolver->setBackend(
-        key, BackendManager::get().get(
-               val)); // TODO Ensure this backend is available in backend contexts
+      backend_resolver->setBackend(key, BackendManager::get().get(val));
     }
     catch (...)
     {
@@ -114,7 +112,7 @@ const backend::Backend *ManualScheduler::resolveBackend(const std::string &id,
 {
   // Ensure if the backend is available in the current backend context
   const backend::Backend *backend = BackendManager::get().get(id);
-  if (!backend || _backend_contexts.find(backend) == _backend_contexts.end())
+  if (!backend || std::find(_backends.begin(), _backends.end(), backend) == _backends.end())
   {
     backend = fallback;
   }

--- a/runtime/onert/core/src/compiler/ManualScheduler.h
+++ b/runtime/onert/core/src/compiler/ManualScheduler.h
@@ -28,7 +28,7 @@ namespace compiler
 class ManualScheduler : public IScheduler
 {
 public:
-  ManualScheduler(const backend::BackendContexts &backend_contexts,
+  ManualScheduler(const std::vector<const backend::Backend *> &backends,
                   const compiler::CompilerOptions &options);
   std::unique_ptr<BackendResolver> schedule(const ir::Graph &graph) override;
 
@@ -37,7 +37,7 @@ private:
                                          const backend::Backend *fallback = nullptr);
 
 private:
-  const backend::BackendContexts &_backend_contexts;
+  std::vector<const backend::Backend *> _backends;
   compiler::CompilerOptions _options;
 };
 

--- a/runtime/onert/test/core/compiler/HEScheduler.cc
+++ b/runtime/onert/test/core/compiler/HEScheduler.cc
@@ -337,16 +337,6 @@ protected:
     setenv("PROFILING_MODE", _original_profiling_mode.c_str(), true);
   }
 
-  backend::BackendContexts buildBackendContexts(const Graph &graph)
-  {
-    backend::BackendContexts contexts;
-    for (auto backend : _mock_backends)
-    {
-      contexts.emplace(backend, backend->newContext(graph, nullptr, false));
-    }
-    return contexts;
-  }
-
   const MockBackendCPU *_cpu_backend{nullptr};
   const MockBackendGPU *_gpu_backend{nullptr};
   const MockBackendNPU *_npu_backend{nullptr};
@@ -392,9 +382,8 @@ TEST_P(HESchedulerTestWithExecutorParam, straight_graph_known_exec_time)
     et.storeOperationsExecTime();
 
     // Test scheduler
-    auto backend_contexts = buildBackendContexts(*graph);
-    auto scheduler = compiler::HEScheduler(backend_contexts,
-                                           compiler::fetchCompilerOptionsFromGlobalConfig(subgs));
+    auto scheduler =
+      compiler::HEScheduler(_mock_backends, compiler::fetchCompilerOptionsFromGlobalConfig(subgs));
     const auto br = scheduler.schedule(*graph);
     ASSERT_EQ(br->getBackend(add_op_idx)->config()->id(), "cpu");
     ASSERT_EQ(br->getBackend(sub_op_idx)->config()->id(), "gpu");
@@ -408,9 +397,8 @@ TEST_P(HESchedulerTestWithExecutorParam, straight_graph_known_exec_time)
     setPermutationsExecutionTime(_mock_backends, OPERAND_SIZE, 1e5);
 
     // Test scheduler
-    auto backend_contexts = buildBackendContexts(*graph);
-    auto scheduler = compiler::HEScheduler(backend_contexts,
-                                           compiler::fetchCompilerOptionsFromGlobalConfig(subgs));
+    auto scheduler =
+      compiler::HEScheduler(_mock_backends, compiler::fetchCompilerOptionsFromGlobalConfig(subgs));
     const auto br = scheduler.schedule(*graph);
     ASSERT_EQ(br->getBackend(add_op_idx)->config()->id(), "cpu");
     ASSERT_EQ(br->getBackend(sub_op_idx)->config()->id(), "cpu");
@@ -451,9 +439,8 @@ TEST_P(HESchedulerTestWithExecutorParam, branched_graph_known_exec_time)
     et.storeOperationsExecTime();
 
     // Test scheduler
-    auto backend_contexts = buildBackendContexts(*graph);
-    auto scheduler = compiler::HEScheduler(backend_contexts,
-                                           compiler::fetchCompilerOptionsFromGlobalConfig(subgs));
+    auto scheduler =
+      compiler::HEScheduler(_mock_backends, compiler::fetchCompilerOptionsFromGlobalConfig(subgs));
     const auto br = scheduler.schedule(*graph);
 
     std::string branch1_expected_backend("npu"), branch2_expected_backend("npu");
@@ -486,9 +473,8 @@ TEST_P(HESchedulerTestWithExecutorParam, branched_graph_known_exec_time)
     et.storeOperationsExecTime();
 
     // Test scheduler
-    auto backend_contexts = buildBackendContexts(*graph);
-    auto scheduler = compiler::HEScheduler(backend_contexts,
-                                           compiler::fetchCompilerOptionsFromGlobalConfig(subgs));
+    auto scheduler =
+      compiler::HEScheduler(_mock_backends, compiler::fetchCompilerOptionsFromGlobalConfig(subgs));
     const auto br = scheduler.schedule(*graph);
     ASSERT_EQ(br->getBackend(add_op_idx)->config()->id(), "npu");
     ASSERT_EQ(br->getBackend(mul1_op_idx)->config()->id(), "npu");
@@ -537,9 +523,8 @@ TEST_F(HESchedulerTest, branched_graph_profiling_mode)
     et.storeOperationsExecTime();
 
     // Test scheduler
-    auto backend_contexts = buildBackendContexts(*graph);
-    auto scheduler = compiler::HEScheduler(backend_contexts,
-                                           compiler::fetchCompilerOptionsFromGlobalConfig(subgs));
+    auto scheduler =
+      compiler::HEScheduler(_mock_backends, compiler::fetchCompilerOptionsFromGlobalConfig(subgs));
     const auto br = scheduler.schedule(*graph);
     ASSERT_EQ(br->getBackend(mul1_op_idx)->config()->id(), "npu");
     ASSERT_EQ(br->getBackend(mul2_op_idx)->config()->id(), "npu");
@@ -560,9 +545,8 @@ TEST_F(HESchedulerTest, branched_graph_profiling_mode)
     et.storeOperationsExecTime();
 
     // Test scheduler
-    auto backend_contexts = buildBackendContexts(*graph);
-    auto scheduler = compiler::HEScheduler(backend_contexts,
-                                           compiler::fetchCompilerOptionsFromGlobalConfig(subgs));
+    auto scheduler =
+      compiler::HEScheduler(_mock_backends, compiler::fetchCompilerOptionsFromGlobalConfig(subgs));
     const auto br = scheduler.schedule(*graph);
     ASSERT_NE(br->getBackend(add_op_idx)->config()->id(),
               br->getBackend(mul1_op_idx)->config()->id());


### PR DESCRIPTION
Make Schedulers use a backend list rather than the list of
`BackendContext`. As the schedulers do not use the contexts actually.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>