### PR TITLE
[onert] Remove BackendContexts from LoweredGraph

### DIFF
--- a/runtime/onert/core/include/compiler/LoweredGraph.h
+++ b/runtime/onert/core/include/compiler/LoweredGraph.h
@@ -56,8 +56,6 @@ public:
     const std::function<void(const ir::OpSequenceIndex &, const ir::OpSequence &)> &fn) const;
   void
   iterateTopolOpSeqs(const std::function<void(const ir::OpSequenceIndex &, ir::OpSequence &)> &fn);
-  const backend::BackendContexts &backend_contexts() { return _backend_contexts; }
-  const backend::BackendContexts &backend_contexts() const { return _backend_contexts; }
   std::shared_ptr<ir::OperationIndexMap<int64_t>> indexed_ranks() { return _indexed_ranks; }
 
 private:
@@ -76,7 +74,6 @@ private:
 
 private:
   ir::Graph _graph;
-  backend::BackendContexts _backend_contexts;
   std::shared_ptr<ir::OperationIndexMap<int64_t>> _indexed_ranks;
   ir::LowerInfoMap _lower_info_map;
   // Pass(for Perm) can accept only graph so that Graph has OpSequences as a member

--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -236,12 +236,12 @@ std::shared_ptr<exec::ExecutorMap> Compiler::compile(void)
 
     // Check backend(s) for subgraph support FP16
     bool backends_support_fp16 = true;
-    auto &contexts = (*lowered_subgs[index]).backend_contexts();
-    for (auto it = contexts.begin(); it != contexts.end(); it++)
+    auto all_backends = BackendManager::get().getAll();
+    for (auto backend : all_backends)
     {
       // Builtin backend is not for actual computaion of operations so it is an exception
-      if (it->first->config()->id() != backend::builtin::Config::ID)
-        backends_support_fp16 &= it->first->config()->supportFP16();
+      if (backend->config()->id() != backend::builtin::Config::ID)
+        backends_support_fp16 &= backend->config()->supportFP16();
     }
 
     if (_options.fp16_enable && backends_support_fp16)

--- a/runtime/onert/core/src/compiler/ExecutorFactory.h
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.h
@@ -43,10 +43,12 @@ private:
   ExecutorFactory();
 
 private:
-  static void initializeBackendContext(compiler::LoweredGraph *lowered_graph);
+  static void initializeBackendContext(compiler::LoweredGraph *lowered_graph,
+                                       const backend::BackendContexts &backend_contexts);
   static void runTensorRegistration(compiler::LoweredGraph *lowered_graph,
                                     const std::vector<ir::OpSequenceIndex> &order);
-  static void prepareMigrantTensors(compiler::LoweredGraph &lowered_graph);
+  static void prepareMigrantTensors(compiler::LoweredGraph &lowered_graph,
+                                    const backend::BackendContexts &backend_contexts);
   static exec::IExecutor *
   createLinearExecutor(std::unique_ptr<compiler::LoweredGraph> lowered_graph,
                        const compiler::CompilerOptions &options,

--- a/runtime/onert/core/src/compiler/LoweredGraph.cc
+++ b/runtime/onert/core/src/compiler/LoweredGraph.cc
@@ -48,16 +48,8 @@ LoweredGraph::LoweredGraph(const ir::Graph &graph, const CompilerOptions &option
     options.tracing_ctx->setSubgraphIndex(&_graph, subgraph_index.value());
   }
 
-  bool linear_executor = (options.executor == "Linear");
-
   // Build backend contexts
   auto &backend_manager = BackendManager::get();
-
-  // Always create Builtin backend context
-  auto builtin_backend = backend_manager.getBuiltin();
-  _backend_contexts.emplace(builtin_backend, builtin_backend->newContext(
-                                               _graph, _graph.getKernelBuilder(), linear_executor));
-
   // Create contexts for other backends
   for (auto backend_str : options.backend_list)
   {
@@ -72,9 +64,6 @@ LoweredGraph::LoweredGraph(const ir::Graph &graph, const CompilerOptions &option
       VERBOSE(LoweredGraph) << "Cannot load backend - " << backend_str << std::endl;
       continue;
     }
-
-    _backend_contexts.emplace(
-      backend, backend->newContext(_graph, _graph.getKernelBuilder(), linear_executor));
   }
   if (backend_manager.num_backends() == 0)
     throw std::runtime_error{"No available backends loaded."};

--- a/runtime/onert/core/src/exec/DataflowExecutor.cc
+++ b/runtime/onert/core/src/exec/DataflowExecutor.cc
@@ -78,10 +78,12 @@ bool DataflowExecutor::noWaitingJobs()
 }
 
 DataflowExecutor::DataflowExecutor(std::unique_ptr<compiler::LoweredGraph> lowered_graph,
+                                   backend::BackendContexts &&backend_contexts,
                                    const compiler::TensorRegistries &tensor_regs,
                                    compiler::CodeMap &&code_map,
                                    const util::TracingCtx *tracing_ctx)
-  : ExecutorBase{std::move(lowered_graph), tensor_regs, tracing_ctx}, _code_map{std::move(code_map)}
+  : ExecutorBase{std::move(lowered_graph), std::move(backend_contexts), tensor_regs, tracing_ctx},
+    _code_map{std::move(code_map)}
 {
   VERBOSE(DataflowExecutor) << "Constructing Dataflow Executor" << std::endl;
 

--- a/runtime/onert/core/src/exec/DataflowExecutor.h
+++ b/runtime/onert/core/src/exec/DataflowExecutor.h
@@ -51,6 +51,7 @@ public:
    * @param code_map OpSequence and its code map
    */
   DataflowExecutor(std::unique_ptr<compiler::LoweredGraph> lowered_graph,
+                   backend::BackendContexts &&backend_contexts,
                    const compiler::TensorRegistries &tensor_regs, compiler::CodeMap &&code_map,
                    const util::TracingCtx *tracing_ctx);
 

--- a/runtime/onert/core/src/exec/ExecutorBase.cc
+++ b/runtime/onert/core/src/exec/ExecutorBase.cc
@@ -27,9 +27,11 @@ namespace exec
 {
 
 ExecutorBase::ExecutorBase(std::unique_ptr<compiler::LoweredGraph> &&lowered_graph,
+                           backend::BackendContexts &&backend_contexts,
                            const compiler::TensorRegistries &tensor_regs,
                            const util::TracingCtx *tracing_ctx)
-  : _lowered_graph{std::move(lowered_graph)}, _graph{_lowered_graph->graph()}, _mutex(),
+  : _lowered_graph{std::move(lowered_graph)},
+    _backend_contexts{std::move(backend_contexts)}, _graph{_lowered_graph->graph()}, _mutex(),
     _tracing_ctx(tracing_ctx)
 {
   auto build_tensor_list = [&](const auto &ind_seq, auto &tensors) {

--- a/runtime/onert/core/src/exec/ExecutorBase.h
+++ b/runtime/onert/core/src/exec/ExecutorBase.h
@@ -51,6 +51,7 @@ public:
    * @param tensor_builders Tensor builders that are currently used
    */
   ExecutorBase(std::unique_ptr<compiler::LoweredGraph> &&lowered_graph,
+               backend::BackendContexts &&backend_contexts,
                const compiler::TensorRegistries &tensor_regs, const util::TracingCtx *tracing_ctx);
 
   virtual ~ExecutorBase() = default;
@@ -87,6 +88,7 @@ protected:
   ExecutionObservee _subject;
   std::shared_ptr<ir::OperationIndexMap<int64_t>> _indexed_ranks;
   std::unique_ptr<compiler::LoweredGraph> _lowered_graph;
+  backend::BackendContexts _backend_contexts;
   const ir::Graph &_graph;
   std::vector<backend::builtin::IOTensor *> _input_tensors;
   std::vector<backend::builtin::IOTensor *> _output_tensors;

--- a/runtime/onert/core/src/exec/LinearExecutor.h
+++ b/runtime/onert/core/src/exec/LinearExecutor.h
@@ -48,9 +48,10 @@ public:
    * @param code_map OpSequence and its code map
    */
   LinearExecutor(std::unique_ptr<compiler::LoweredGraph> lowered_graph,
+                 backend::BackendContexts &&backend_contexts,
                  const compiler::TensorRegistries &tensor_regs, compiler::CodeMap &&code_map,
                  const std::vector<ir::OpSequenceIndex> &order, const util::TracingCtx *tracing_ctx)
-    : ExecutorBase{std::move(lowered_graph), tensor_regs, tracing_ctx}
+    : ExecutorBase{std::move(lowered_graph), std::move(backend_contexts), tensor_regs, tracing_ctx}
   {
     for (auto index : order)
     {

--- a/runtime/onert/core/src/exec/ParallelExecutor.cc
+++ b/runtime/onert/core/src/exec/ParallelExecutor.cc
@@ -60,10 +60,12 @@ void ParallelExecutor::notify(uint32_t finished_job_id)
 }
 
 ParallelExecutor::ParallelExecutor(std::unique_ptr<compiler::LoweredGraph> lowered_graph,
+                                   backend::BackendContexts &&backend_contexts,
                                    const compiler::TensorRegistries &tensor_regs,
                                    compiler::CodeMap &&code_map,
                                    const util::TracingCtx *tracing_ctx)
-  : DataflowExecutor{std::move(lowered_graph), tensor_regs, std::move(code_map), tracing_ctx}
+  : DataflowExecutor{std::move(lowered_graph), std::move(backend_contexts), tensor_regs,
+                     std::move(code_map), tracing_ctx}
 {
   VERBOSE(ParallelExecutor) << "Constructing Parallel Executor" << std::endl;
 }

--- a/runtime/onert/core/src/exec/ParallelExecutor.h
+++ b/runtime/onert/core/src/exec/ParallelExecutor.h
@@ -52,6 +52,7 @@ public:
    * @param code_map OpSequence and its code map
    */
   ParallelExecutor(std::unique_ptr<compiler::LoweredGraph> lowered_graph,
+                   backend::BackendContexts &&backend_contexts,
                    const compiler::TensorRegistries &tensor_regs, compiler::CodeMap &&code_map,
                    const util::TracingCtx *tracing_ctx);
 


### PR DESCRIPTION
Remove BackendContexts from LoweredGraph as it should not belong to
LoweredGraph.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>