### PR TITLE
[onert] ObjectManager can specify Index

### DIFF
--- a/runtime/onert/core/include/util/ObjectManager.h
+++ b/runtime/onert/core/include/util/ObjectManager.h
@@ -185,6 +185,8 @@ private:
   // Generate a new index with `_next_index`
   Index generateIndex()
   {
+    // No need to check if there is an entry with _next_index since
+    // _next_index is always ("the highest index in the object map" + 1)
     if (Index{_next_index}.valid())
       return Index{_next_index++};
     else

--- a/runtime/onert/core/src/ir/Operands.cc
+++ b/runtime/onert/core/src/ir/Operands.cc
@@ -29,7 +29,7 @@ Operands::Operands(const Operands &obj)
   obj.iterate([&](const OperandIndex &index, const Operand &operand) {
     _objects.emplace(index, std::make_unique<Operand>(operand));
   });
-  _index_count = obj._index_count;
+  _next_index = obj._next_index;
 }
 
 } // namespace ir

--- a/runtime/onert/core/src/ir/Operations.cc
+++ b/runtime/onert/core/src/ir/Operations.cc
@@ -30,7 +30,7 @@ Operations::Operations(const Operations &obj)
     op.accept(cloner);
     _objects.emplace(index, cloner.releaseClone());
   });
-  _index_count = obj._index_count;
+  _next_index = obj._next_index;
 }
 
 } // namespace ir

--- a/runtime/onert/test/util/ObjectManager.cc
+++ b/runtime/onert/test/util/ObjectManager.cc
@@ -103,6 +103,50 @@ TEST(ObjectManager, neg_push)
   ASSERT_FALSE(index2.valid());
 }
 
+static const uint32_t kMaxUInt32 = std::numeric_limits<uint32_t>::max();
+
+TEST(ObjectManager, neg_push_undefined_index)
+{
+  util::ObjectManager<Index, int> man;
+
+  // Try inserting invalid(undefined) index
+  auto index = man.push(std::make_unique<int>(100), Index{kMaxUInt32});
+  ASSERT_FALSE(index.valid());
+  ASSERT_EQ(man.size(), 0);
+}
+
+TEST(ObjectManager, neg_push_max_index)
+{
+  util::ObjectManager<Index, int> man;
+
+  // Insert an object with maximum valid index
+  auto index = man.push(std::make_unique<int>(100), Index{kMaxUInt32 - 1});
+  ASSERT_EQ(index.value(), kMaxUInt32 - 1);
+  ASSERT_EQ(man.at(index), 100);
+  ASSERT_EQ(man.size(), 1);
+
+  // Reached to the final index so next push/emplace must fail
+  auto index2 = man.push(std::make_unique<int>(200));
+  ASSERT_EQ(man.size(), 1);
+  ASSERT_FALSE(index2.valid());
+}
+
+TEST(ObjectManager, neg_emplace_max_index)
+{
+  util::ObjectManager<Index, int> man;
+
+  // Insert an object with maximum valid index
+  auto index = man.push(std::make_unique<int>(100), Index{kMaxUInt32 - 1});
+  ASSERT_EQ(index.value(), kMaxUInt32 - 1);
+  ASSERT_EQ(man.at(index), 100);
+  ASSERT_EQ(man.size(), 1);
+
+  // Reached to the final index so next push/emplace must fail
+  auto index3 = man.emplace(200);
+  ASSERT_EQ(man.size(), 1);
+  ASSERT_FALSE(index3.valid());
+}
+
 TEST(ObjectManager, const_iterate)
 {
   util::ObjectManager<Index, int> man;

--- a/runtime/onert/test/util/ObjectManager.cc
+++ b/runtime/onert/test/util/ObjectManager.cc
@@ -65,8 +65,42 @@ TEST(ObjectManager, push)
 {
   util::ObjectManager<Index, int> man;
 
-  auto index = man.push(std::unique_ptr<int>{new int{100}});
+  // Not specify index
+  auto index = man.push(std::make_unique<int>(100));
   ASSERT_EQ(man.at(index), 100);
+
+  // Specify index
+  auto index2 = man.push(std::make_unique<int>(200), Index{33});
+  ASSERT_EQ(index2.value(), 33);
+  ASSERT_EQ(man.at(index2), 200);
+
+  auto index3 = man.push(std::make_unique<int>(300));
+  // NOTE auto-generated index number is always (biggest index in the ObjectManager + 1)
+  ASSERT_EQ(index3.value(), 34);
+  ASSERT_EQ(man.at(index3), 300);
+
+  auto index4 = man.push(std::make_unique<int>(400), Index{22});
+  ASSERT_EQ(index4.value(), 22);
+  ASSERT_EQ(man.at(index4), 400);
+
+  auto index5 = man.push(std::make_unique<int>(500));
+  // NOTE auto-generated index number is always (biggest index in the ObjectManager + 1)
+  ASSERT_EQ(index5.value(), 35);
+  ASSERT_EQ(man.at(index5), 500);
+}
+
+TEST(ObjectManager, neg_push)
+{
+  util::ObjectManager<Index, int> man;
+
+  // Specify index
+  auto index = man.push(std::make_unique<int>(100), Index{55});
+  ASSERT_EQ(index.value(), 55);
+  ASSERT_EQ(man.at(index), 100);
+
+  // Specify the same index
+  auto index2 = man.push(std::make_unique<int>(200), Index{55});
+  ASSERT_FALSE(index2.valid());
 }
 
 TEST(ObjectManager, const_iterate)


### PR DESCRIPTION
Allow ObjectManager can add an object with specifying an index for it.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>