### PR TITLE
[onert] Rename Tensor::data_offset to data_zero_point

### DIFF
--- a/runtime/onert/backend/acl_common/IACLTensor.cc
+++ b/runtime/onert/backend/acl_common/IACLTensor.cc
@@ -54,7 +54,7 @@ float IACLTensor::data_scale() const
   return info()->quantization_info().uniform().scale;
 }
 
-int32_t IACLTensor::data_offset() const
+int32_t IACLTensor::data_zero_point() const
 {
   // FIXME What if quantization info is non-uniform?
   return info()->quantization_info().uniform().offset;

--- a/runtime/onert/backend/acl_common/IACLTensor.h
+++ b/runtime/onert/backend/acl_common/IACLTensor.h
@@ -52,7 +52,7 @@ public:
   ir::Layout layout() const final;
   ir::DataType data_type() const final;
   float data_scale() const override;
-  int32_t data_offset() const override;
+  int32_t data_zero_point() const override;
   bool has_padding() const override { return info()->has_padding(); }
   bool is_dynamic() const override { return false; }
   ir::Shape getShape() const override

--- a/runtime/onert/backend/cpu/ops/BinaryArithmeticLayer.cc
+++ b/runtime/onert/backend/cpu/ops/BinaryArithmeticLayer.cc
@@ -123,9 +123,9 @@ void setAddOrSubQuant8Params(const IPortableTensor *lhs, const IPortableTensor *
   // Parameters for scaled quantized computation
   op_params.left_shift = 20;
   // Zero-points of input and output tensors
-  op_params.input1_offset = -lhs->data_offset();
-  op_params.input2_offset = -rhs->data_offset();
-  op_params.output_offset = output->data_offset();
+  op_params.input1_offset = -lhs->data_zero_point();
+  op_params.input2_offset = -rhs->data_zero_point();
+  op_params.output_offset = output->data_zero_point();
   assert((op_params.input1_offset <= 0) && (op_params.input1_offset >= -255));
   assert((op_params.input2_offset <= 0) && (op_params.input2_offset >= -255));
   assert((op_params.output_offset >= 0) && (op_params.output_offset <= 255));
@@ -156,9 +156,9 @@ void setMulQuant8Params(const IPortableTensor *lhs, const IPortableTensor *rhs,
 
   op_params.quantized_activation_max = output_activation_max;
   op_params.quantized_activation_min = output_activation_min;
-  op_params.input1_offset = -lhs->data_offset();
-  op_params.input2_offset = -rhs->data_offset();
-  op_params.output_offset = output->data_offset();
+  op_params.input1_offset = -lhs->data_zero_point();
+  op_params.input2_offset = -rhs->data_zero_point();
+  op_params.output_offset = output->data_zero_point();
 
   double real_multiplier = lhs->data_scale() * rhs->data_scale() / output->data_scale();
   QuantizeMultiplier(real_multiplier, &op_params.output_multiplier, &op_params.output_shift);

--- a/runtime/onert/backend/cpu/ops/CompareLayer.cc
+++ b/runtime/onert/backend/cpu/ops/CompareLayer.cc
@@ -49,8 +49,8 @@ void compareQuant8(const IPortableTensor *lhs, const IPortableTensor *rhs, IPort
 {
   nnfw::cker::ComparisonParams params;
   params.left_shift = 8;
-  params.input1_offset = -lhs->data_offset();
-  params.input2_offset = -rhs->data_offset();
+  params.input1_offset = -lhs->data_zero_point();
+  params.input2_offset = -rhs->data_zero_point();
   const double norm_max_scale =
     2 * std::max(std::abs(lhs->data_scale()), std::abs(rhs->data_scale()));
   const double adjusted_lhs_scale = lhs->data_scale() / norm_max_scale;

--- a/runtime/onert/backend/cpu/ops/ConcatLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ConcatLayer.cc
@@ -71,7 +71,7 @@ void ConcatLayer::concatenationQuant8()
   std::vector<float> input_scales(num_inputs);
   for (uint32_t i = 0; i < num_inputs; i++)
   {
-    input_zeropoints[i] = _inputs[i]->data_offset();
+    input_zeropoints[i] = _inputs[i]->data_zero_point();
     input_scales[i] = _inputs[i]->data_scale();
   }
 
@@ -80,7 +80,7 @@ void ConcatLayer::concatenationQuant8()
   op_params.inputs_count = num_inputs;
   op_params.input_zeropoint = input_zeropoints.data();
   op_params.input_scale = input_scales.data();
-  op_params.output_zeropoint = _output->data_offset();
+  op_params.output_zeropoint = _output->data_zero_point();
   op_params.output_scale = _output->data_scale();
 
   std::vector<nnfw::cker::Shape *> inputDimsPtr;

--- a/runtime/onert/backend/cpu/ops/ConvolutionLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ConvolutionLayer.cc
@@ -84,9 +84,9 @@ void ConvolutionLayer::convQuant8()
   op_params.padding_type = getPaddingType(_paddingType);
   op_params.padding_values.width = _paddingLeft;
   op_params.padding_values.height = _paddingTop;
-  op_params.input_offset = -_input->data_offset();
-  op_params.weights_offset = -_kernel->data_offset();
-  op_params.output_offset = _output->data_offset();
+  op_params.input_offset = -_input->data_zero_point();
+  op_params.weights_offset = -_kernel->data_zero_point();
+  op_params.output_offset = _output->data_zero_point();
   op_params.output_multiplier = output_multiplier;
   op_params.output_shift = output_shift;
   op_params.quantized_activation_min = output_activation_min;

--- a/runtime/onert/backend/cpu/ops/DepthwiseConvolutionLayer.cc
+++ b/runtime/onert/backend/cpu/ops/DepthwiseConvolutionLayer.cc
@@ -72,9 +72,9 @@ void DepthwiseConvolutionLayer::convQuant8()
   op_params.padding_values.width = _paddingLeft;
   op_params.padding_values.height = _paddingTop;
   op_params.depth_multiplier = _multiplier;
-  op_params.input_offset = -_input->data_offset();
-  op_params.weights_offset = -_kernel->data_offset();
-  op_params.output_offset = _output->data_offset();
+  op_params.input_offset = -_input->data_zero_point();
+  op_params.weights_offset = -_kernel->data_zero_point();
+  op_params.output_offset = _output->data_zero_point();
   op_params.output_multiplier = output_multiplier;
   op_params.output_shift = output_shift;
   op_params.quantized_activation_min = output_activation_min;

--- a/runtime/onert/backend/cpu/ops/ElementwiseActivationLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ElementwiseActivationLayer.cc
@@ -43,9 +43,9 @@ ElementwiseActivationLayer::ElementwiseActivationLayer()
 void ElementwiseActivationLayer::PopulateLookupTable(const ElementwiseActivationType op_type)
 {
   const auto input_scale = static_cast<double>(_input->data_scale());
-  const auto input_zero_point = static_cast<int32_t>(_input->data_offset());
+  const auto input_zero_point = static_cast<int32_t>(_input->data_zero_point());
   const auto output_scale = static_cast<double>(_output->data_scale());
-  const auto output_zero_point = static_cast<int32_t>(_output->data_offset());
+  const auto output_zero_point = static_cast<int32_t>(_output->data_zero_point());
   const float inverse_scale = 1 / output_scale;
   int32_t maxval = std::numeric_limits<uint8_t>::max();
   int32_t minval = std::numeric_limits<uint8_t>::min();

--- a/runtime/onert/backend/cpu/ops/ElementwiseBinaryLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ElementwiseBinaryLayer.cc
@@ -91,7 +91,8 @@ bool haveSameQauntInfo(const IPortableTensor *lhs, const IPortableTensor *rhs,
                        const IPortableTensor *output)
 {
   return (lhs->data_scale() == rhs->data_scale() && lhs->data_scale() == output->data_scale()) &&
-         (lhs->data_offset() == rhs->data_offset() && lhs->data_offset() == output->data_offset());
+         (lhs->data_zero_point() == rhs->data_zero_point() &&
+          lhs->data_zero_point() == output->data_zero_point());
 }
 } // namespace
 

--- a/runtime/onert/backend/cpu/ops/ElementwiseUnaryLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ElementwiseUnaryLayer.cc
@@ -122,14 +122,14 @@ void dequantizeInt8(const IPortableTensor *input, IPortableTensor *output)
 {
   nnfw::cker::Dequantize(getTensorShape(input), reinterpret_cast<const int8_t *>(input->buffer()),
                          getTensorShape(output), reinterpret_cast<float *>(output->buffer()),
-                         input->data_scale(), input->data_offset());
+                         input->data_scale(), input->data_zero_point());
 }
 
 void dequantizeUint8(const IPortableTensor *input, IPortableTensor *output)
 {
   nnfw::cker::Dequantize(getTensorShape(input), reinterpret_cast<const uint8_t *>(input->buffer()),
                          getTensorShape(output), reinterpret_cast<float *>(output->buffer()),
-                         input->data_scale(), input->data_offset());
+                         input->data_scale(), input->data_zero_point());
 }
 
 void expFloat32(const IPortableTensor *input, IPortableTensor *output)

--- a/runtime/onert/backend/cpu/ops/FullyConnectedLayer.cc
+++ b/runtime/onert/backend/cpu/ops/FullyConnectedLayer.cc
@@ -67,9 +67,9 @@ void FullyConnectedLayer::fullyConnectedQuant8()
                                     &output_activation_max);
 
   nnfw::cker::FullyConnectedParams op_params;
-  op_params.input_offset = -_input->data_offset();
-  op_params.weights_offset = -_weights->data_offset();
-  op_params.output_offset = _output->data_offset();
+  op_params.input_offset = -_input->data_zero_point();
+  op_params.weights_offset = -_weights->data_zero_point();
+  op_params.output_offset = _output->data_zero_point();
   op_params.output_multiplier = output_multiplier;
   op_params.output_shift = output_shift;
   op_params.quantized_activation_min = output_activation_min;

--- a/runtime/onert/backend/cpu/ops/L2NormLayer.cc
+++ b/runtime/onert/backend/cpu/ops/L2NormLayer.cc
@@ -52,8 +52,8 @@ void L2NormLayer::run()
     case OperandType::QUANT_UINT8_ASYMM:
     {
       nnfw::cker::L2NormParams params;
-      assert(_input->data_offset() == 128);
-      params.input_zero_point = _input->data_offset();
+      assert(_input->data_zero_point() == 128);
+      params.input_zero_point = _input->data_zero_point();
       nnfw::cker::L2NormalizeQuant8(
         params, getTensorShape(_input), reinterpret_cast<const uint8_t *>(_input->buffer()),
         getTensorShape(_output), reinterpret_cast<uint8_t *>(_output->buffer()));

--- a/runtime/onert/backend/cpu/ops/LogSoftMaxLayer.cc
+++ b/runtime/onert/backend/cpu/ops/LogSoftMaxLayer.cc
@@ -60,7 +60,7 @@ void LogSoftMaxLayer::logsoftmaxQuant8()
   op_params.beta = _beta;
   op_params.axis = _axis;
   op_params.table = _table;
-  op_params.zero_point = _output->data_offset();
+  op_params.zero_point = _output->data_zero_point();
   op_params.scale = _output->data_scale();
   nnfw::cker::LogSoftmax(op_params, _input->data_scale(), getTensorShape(_input),
                          reinterpret_cast<const uint8_t *>(_input->buffer()),

--- a/runtime/onert/backend/cpu/ops/MeanLayer.cc
+++ b/runtime/onert/backend/cpu/ops/MeanLayer.cc
@@ -60,9 +60,9 @@ void MeanLayer::MeanQuant8()
 {
   nnfw::cker::MeanQ8Asymm(getTensorShape(_input),
                           reinterpret_cast<const uint8_t *>(_input->buffer()), _input->data_scale(),
-                          _input->data_offset(), getTensorShape(_output),
+                          _input->data_zero_point(), getTensorShape(_output),
                           reinterpret_cast<uint8_t *>(_output->buffer()), _output->data_scale(),
-                          _output->data_offset(), getReducerAxes(_axes));
+                          _output->data_zero_point(), getReducerAxes(_axes));
 }
 
 void MeanLayer::configure(const IPortableTensor *input, const IPortableTensor *axes,

--- a/runtime/onert/backend/cpu/ops/OperationUtils.cc
+++ b/runtime/onert/backend/cpu/ops/OperationUtils.cc
@@ -135,7 +135,7 @@ void CalculateActivationRangeQuantized(ir::Activation activation, const IPortabl
   }
 
   const auto scale = output->data_scale();
-  const auto zero_point = output->data_offset();
+  const auto zero_point = output->data_zero_point();
   auto quantize = [scale, zero_point](float f) {
     return zero_point + static_cast<int32_t>(std::round(f / scale));
   };

--- a/runtime/onert/backend/cpu/ops/PadLayer.cc
+++ b/runtime/onert/backend/cpu/ops/PadLayer.cc
@@ -60,7 +60,7 @@ void PadLayer::run()
   {
     if (_constantValueData.u8 == nullptr)
     {
-      uint8_t pad_value = static_cast<uint8_t>(_output->data_offset());
+      uint8_t pad_value = static_cast<uint8_t>(_output->data_zero_point());
       padImpl<uint8_t>(&pad_value);
     }
     else

--- a/runtime/onert/backend/cpu/ops/QuantizeLayer.cc
+++ b/runtime/onert/backend/cpu/ops/QuantizeLayer.cc
@@ -37,7 +37,7 @@ void affineQuantize(const IPortableTensor *input, IPortableTensor *output)
 {
   nnfw::cker::Quantize(getTensorShape(input), reinterpret_cast<const InputT *>(input->buffer()),
                        getTensorShape(output), reinterpret_cast<OutputT *>(output->buffer()),
-                       output->data_scale(), output->data_offset());
+                       output->data_scale(), output->data_zero_point());
 }
 
 void QuantizeLayer::configure(const IPortableTensor *input, IPortableTensor *output)
@@ -79,7 +79,7 @@ void QuantizeLayer::run()
     nnfw::cker::Requantize<uint8_t, int8_t>(
       reinterpret_cast<const uint8_t *>(_input->buffer()),
       MatchingFlatSize(getTensorShape(_input), getTensorShape(_output)), _output_multiplier,
-      _output_shift, _input->data_offset(), _output->data_offset(),
+      _output_shift, _input->data_zero_point(), _output->data_zero_point(),
       reinterpret_cast<int8_t *>(_output->buffer()));
   }
   else if ((_input->data_type() == OperandType::QUANT_INT8_ASYMM) &&
@@ -88,7 +88,7 @@ void QuantizeLayer::run()
     nnfw::cker::Requantize<int8_t, uint8_t>(
       reinterpret_cast<const int8_t *>(_input->buffer()),
       MatchingFlatSize(getTensorShape(_input), getTensorShape(_output)), _output_multiplier,
-      _output_shift, _input->data_offset(), _output->data_offset(),
+      _output_shift, _input->data_zero_point(), _output->data_zero_point(),
       reinterpret_cast<uint8_t *>(_output->buffer()));
   }
   else

--- a/runtime/onert/backend/cpu/ops/ReduceLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ReduceLayer.cc
@@ -126,8 +126,8 @@ void evalSumQuantized(const IPortableTensor *input, IPortableTensor *output,
                       const std::vector<int> &axes, bool keep_dims,
                       nnfw::cker::Reduce &reduce_kernel)
 {
-  const bool same_scale =
-    (input->data_scale() == output->data_scale() && input->data_offset() == output->data_offset());
+  const bool same_scale = (input->data_scale() == output->data_scale() &&
+                           input->data_zero_point() == output->data_zero_point());
 
   reduce_kernel.prepare(input->getShape().rank(), axes.size());
 
@@ -135,10 +135,10 @@ void evalSumQuantized(const IPortableTensor *input, IPortableTensor *output,
   {
     std::vector<int32_t> temp_sum(output->getShape().num_elements());
     bool result = reduce_kernel.QuantizedMeanOrSum<uint8_t, int32_t>(
-      reinterpret_cast<const uint8_t *>(input->buffer()), input->data_offset(), input->data_scale(),
-      getTensorShape(input), reinterpret_cast<uint8_t *>(output->buffer()), output->data_offset(),
-      output->data_scale(), getTensorShape(output), axes, keep_dims, temp_sum.data(), true,
-      [](const int32_t current, const uint8_t in) -> int32_t {
+      reinterpret_cast<const uint8_t *>(input->buffer()), input->data_zero_point(),
+      input->data_scale(), getTensorShape(input), reinterpret_cast<uint8_t *>(output->buffer()),
+      output->data_zero_point(), output->data_scale(), getTensorShape(output), axes, keep_dims,
+      temp_sum.data(), true, [](const int32_t current, const uint8_t in) -> int32_t {
         const int32_t actual_in = static_cast<int32_t>(in);
         return current + actual_in;
       });

--- a/runtime/onert/backend/cpu/ops/SoftMaxLayer.cc
+++ b/runtime/onert/backend/cpu/ops/SoftMaxLayer.cc
@@ -74,7 +74,7 @@ void SoftMaxLayer::softmaxQuant8()
 {
   nnfw::cker::SoftmaxParams op_params;
   op_params.scale = _output->data_scale();
-  op_params.zero_point = _output->data_offset();
+  op_params.zero_point = _output->data_zero_point();
   op_params.uint8_table1 = _uint8_table1;
   op_params.uint8_table2 = _uint8_table2;
   op_params.table = _table;

--- a/runtime/onert/backend/cpu/ops/SpaceToBatchNDLayer.cc
+++ b/runtime/onert/backend/cpu/ops/SpaceToBatchNDLayer.cc
@@ -66,7 +66,7 @@ void SpaceToBatchNDLayer::checkDimension()
 }
 
 template <> uint32_t SpaceToBatchNDLayer::getPad<float>() { return 0; }
-template <> uint32_t SpaceToBatchNDLayer::getPad<uint8_t>() { return _output->data_offset(); }
+template <> uint32_t SpaceToBatchNDLayer::getPad<uint8_t>() { return _output->data_zero_point(); }
 
 template <typename T> void SpaceToBatchNDLayer::spaceToBatchND()
 {

--- a/runtime/onert/backend/cpu/ops/TransposeLayer.cc
+++ b/runtime/onert/backend/cpu/ops/TransposeLayer.cc
@@ -65,7 +65,7 @@ template <typename T> void TransposeLayer::transpose()
 
 void TransposeLayer::transposeQuant8()
 {
-  if (_input->data_offset() != _output->data_offset())
+  if (_input->data_zero_point() != _output->data_zero_point())
   {
     throw std::runtime_error("TransposeLayer : qassym8 input and output offsets unmatched");
   }

--- a/runtime/onert/core/include/backend/ITensor.h
+++ b/runtime/onert/core/include/backend/ITensor.h
@@ -46,7 +46,7 @@ public:
   virtual ir::Layout layout() const = 0;
   virtual ir::DataType data_type() const = 0;
   virtual float data_scale() const = 0;
-  virtual int32_t data_offset() const = 0;
+  virtual int32_t data_zero_point() const = 0;
   virtual bool has_padding() const = 0;
   virtual void access(const std::function<void(ITensor &tensor)> &fn) = 0;
 

--- a/runtime/onert/core/include/backend/cpu_common/Tensor.h
+++ b/runtime/onert/core/include/backend/cpu_common/Tensor.h
@@ -91,7 +91,7 @@ public:
   ir::Layout layout() const override { return _layout; }
   ir::DataType data_type() const override { return _info.typeInfo().type(); }
   float data_scale() const override { return _info.typeInfo().scale(); }
-  int32_t data_offset() const override { return _info.typeInfo().offset(); }
+  int32_t data_zero_point() const override { return _info.typeInfo().offset(); }
   bool is_constant() const override { return _info.isConstant(); }
   bool is_dynamic() const override { return _info.isDynamic(); }
   void set_dynamic() override { _info.setDynamic(); }

--- a/runtime/onert/core/src/backend/builtin/IOTensor.h
+++ b/runtime/onert/core/src/backend/builtin/IOTensor.h
@@ -59,7 +59,7 @@ public:
   ir::Layout layout() const override { return _tensor->layout(); }
   ir::DataType data_type() const override { return _tensor->data_type(); }
   float data_scale() const override { return _tensor->data_scale(); }
-  int32_t data_offset() const override { return _tensor->data_offset(); }
+  int32_t data_zero_point() const override { return _tensor->data_zero_point(); }
   bool is_dynamic() const override
   {
     return _is_dynamic || _orig_info.isDynamic() || (_tensor && _tensor->is_dynamic());

--- a/runtime/onert/core/src/backend/builtin/UserTensor.h
+++ b/runtime/onert/core/src/backend/builtin/UserTensor.h
@@ -61,7 +61,7 @@ public:
   ir::Layout layout() const override { return _layout; }
   ir::DataType data_type() const override { return _info.typeInfo().type(); }
   float data_scale() const override { return _info.typeInfo().scale(); }
-  int32_t data_offset() const override { return _info.typeInfo().offset(); }
+  int32_t data_zero_point() const override { return _info.typeInfo().offset(); }
   bool is_dynamic() const override { return _dynamic; }
   void set_dynamic() override { _dynamic = true; }
   ir::Shape getShape() const override { return _info.shape(); }

--- a/runtime/onert/core/src/interp/Tensor.h
+++ b/runtime/onert/core/src/interp/Tensor.h
@@ -122,7 +122,7 @@ public:
   bool has_padding() const override { return false; }
   ir::DataType data_type() const override { return _info.typeInfo().type(); }
   float data_scale() const override { return _info.typeInfo().scale(); }
-  int32_t data_offset() const override { return _info.typeInfo().offset(); }
+  int32_t data_zero_point() const override { return _info.typeInfo().offset(); }
   const ir::OperandInfo &tensorInfo() const override { return _info; }
   uint64_t num_elements() const override { return _info.shape().num_elements(); };
   ir::Shape getShape() const override;
@@ -163,7 +163,7 @@ public:
   bool has_padding() const override { return false; }
   ir::DataType data_type() const override { return _info.typeInfo().type(); }
   float data_scale() const override { return _info.typeInfo().scale(); }
-  int32_t data_offset() const override { return _info.typeInfo().offset(); }
+  int32_t data_zero_point() const override { return _info.typeInfo().offset(); }
   const ir::OperandInfo &tensorInfo() const override { return _info; }
   uint64_t num_elements() const override { return _info.shape().num_elements(); };
   ir::Shape getShape() const override;


### PR DESCRIPTION
"data_offset" is replaced with more specific word "zero_point".

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>