### PR TITLE
[onert] Introduce text graph dumper

### DIFF
--- a/runtime/onert/core/include/ir/OpSequences.h
+++ b/runtime/onert/core/include/ir/OpSequences.h
@@ -77,14 +77,6 @@ private:
   mutable std::unordered_map<OperationIndex, OpSequenceIndex> _seq_indexes;
 };
 
-/**
- * @brief Dump OpSequences
- *
- * @param op_seqs Operation Sequences
- * @param operations Operation context
- */
-void dumpOpSequences(const OpSequences &op_seqs, const Operations &operations);
-
 } // namespace ir
 } // namespace onert
 

--- a/runtime/onert/core/src/compiler/Linear.cc
+++ b/runtime/onert/core/src/compiler/Linear.cc
@@ -15,12 +15,14 @@
  */
 
 #include <algorithm>
+#include <sstream>
 
 #include "Linear.h"
 
 #include "backend/IConfig.h"
 #include "backend/Backend.h"
 #include "util/logging.h"
+#include "dumper/text/GraphDumper.h"
 
 namespace onert
 {
@@ -41,21 +43,14 @@ void Linear::dump(const compiler::LoweredGraph &lowered_graph,
                   const std::vector<ir::OpSequenceIndex> &order)
 {
   {
-    const auto &toString = [](const onert::backend::Backend *backend) {
-      assert(backend);
-      std::string str;
-      str += backend->config()->id();
-      return "{" + str + "}";
-    };
-
-    VERBOSE(Linear) << "Final OpSequence" << std::endl;
+    VERBOSE(Linear) << "Final OpSequences" << std::endl;
     for (const auto index : order)
     {
-      const auto &op_seq = lowered_graph.op_seqs().at(index);
-      const auto lower_info = lowered_graph.getLowerInfo(index);
-      const auto &operations = lowered_graph.graph().operations();
-      VERBOSE(Linear) << "* OP_SEQ " << toString(lower_info->backend()) << " "
-                      << ir::getStrFromOpSeq(op_seq, operations) << std::endl;
+      // TODO Could logging system can handle this? (Inserting prefix for each line)
+      std::istringstream iss{dumper::text::formatOpSequence(lowered_graph, index)};
+      std::string line;
+      while (std::getline(iss, line))
+        VERBOSE(GraphDumper) << line << std::endl;
     }
   }
 }

--- a/runtime/onert/core/src/compiler/LoweredGraph.cc
+++ b/runtime/onert/core/src/compiler/LoweredGraph.cc
@@ -26,6 +26,7 @@
 #include "compiler/pass/PermutationOperationPass.h"
 #include "compiler/pass/PermutationInsertionPass.h"
 #include "compiler/pass/PermutationEliminationPass.h"
+#include "dumper/text/GraphDumper.h"
 #include "ir/verifier/Verifier.h"
 #include "backend/Backend.h"
 #include "backend/IConfig.h"
@@ -101,7 +102,7 @@ LoweredGraph::LoweredGraph(const ir::Graph &graph, const CompilerOptions &option
     });
 
     VERBOSE(OpSequences) << "dump before permutation insertion" << std::endl;
-    dumpOpSequences(_op_seqs, _graph.operations());
+    dumper::text::dumpLoweredGraph(*this);
 
     // Mandatory passes
     pass::PassRunner{}
@@ -129,7 +130,7 @@ LoweredGraph::LoweredGraph(const ir::Graph &graph, const CompilerOptions &option
     VERBOSE(LoweredGraph) << "Graph Input : " << operand << std::endl;
   for (auto operand : _graph.getOutputs())
     VERBOSE(LoweredGraph) << "Graph Output : " << operand << std::endl;
-  dumpOpSequences(_op_seqs, _graph.operations());
+  dumper::text::dumpLoweredGraph(*this);
 
   // Graph verifications
   {

--- a/runtime/onert/core/src/dumper/text/GraphDumper.cc
+++ b/runtime/onert/core/src/dumper/text/GraphDumper.cc
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "GraphDumper.h"
+
+#include "ir/Graph.h"
+#include "compiler/LoweredGraph.h"
+#include "util/logging.h"
+#include "misc/string_helpers.h"
+
+namespace onert
+{
+namespace dumper
+{
+namespace text
+{
+
+namespace
+{
+
+std::string formatOperandIndexSequence(const ir::OperandIndexSequence &seq)
+{
+  std::vector<std::string> strs;
+  for (auto ind : seq)
+    strs.push_back(dumper::text::formatOperandBrief(ind));
+  return nnfw::misc::join(strs.begin(), strs.end(), ", ");
+}
+
+} // namespace
+
+std::string formatOperandBrief(ir::OperandIndex ind)
+{
+  std::stringstream ss;
+  ss << ind;
+  return ss.str();
+}
+
+std::string formatOperand(const ir::Graph &, ir::OperandIndex ind)
+{
+  std::stringstream ss;
+  ss << ind;
+  // TODO Print shape, type and maybe more
+  return ss.str();
+}
+
+std::string formatOperation(const ir::Graph &graph, ir::OperationIndex ind)
+{
+  std::stringstream ss;
+  const auto &op = graph.operations().at(ind);
+
+  ss << formatOperandIndexSequence(op.getOutputs());
+  ss << " = ";
+  ss << ind << "_" << op.name() << "(";
+  ss << formatOperandIndexSequence(op.getInputs());
+  ss << ")";
+  return ss.str();
+}
+
+std::string formatOpSequence(const compiler::LoweredGraph &lgraph, ir::OpSequenceIndex ind)
+{
+  std::stringstream ss;
+  const auto &lower_info = lgraph.getLowerInfo()->op_seq.at(ind);
+
+  const auto &op_seq = lgraph.op_seqs().at(ind);
+  std::string inputs_str = formatOperandIndexSequence(op_seq.getInputs());
+  std::string outputs_str = formatOperandIndexSequence(op_seq.getOutputs());
+  VERBOSE(GraphDumper) << ind << " {" << lower_info->backend()->config()->id() << "} In("
+                       << inputs_str << ") Out(" << outputs_str << "):" << std::endl;
+  for (auto op_ind : op_seq.operations())
+  {
+    ss << "  " << formatOperation(lgraph.graph(), op_ind) << "\n";
+  }
+  return ss.str();
+}
+
+void dumpGraph(const ir::Graph &graph)
+{
+  VERBOSE(GraphDumper) << "{\n";
+  auto ops_topol = graph.topolSortOperations();
+  for (auto op_ind : ops_topol)
+  {
+    VERBOSE(GraphDumper) << "  " << formatOperation(graph, op_ind) << "\n";
+  }
+  VERBOSE(GraphDumper) << "}\n";
+  VERBOSE(GraphDumper) << std::endl;
+}
+
+void dumpLoweredGraph(const compiler::LoweredGraph &lgraph)
+{
+  VERBOSE(GraphDumper) << "{\n";
+  // TODO Could logging system handle this? (Inserting prefix for each line)
+  lgraph.iterateTopolOpSeqs([&](const ir::OpSequenceIndex &ind, const ir::OpSequence &) {
+    std::istringstream iss{dumper::text::formatOpSequence(lgraph, ind)};
+    std::string line;
+    while (std::getline(iss, line))
+      VERBOSE(GraphDumper) << line << std::endl;
+  });
+  VERBOSE(GraphDumper) << "}\n";
+  VERBOSE(GraphDumper) << std::endl;
+}
+
+} // namespace text
+} // namespace dumper
+} // namespace onert

--- a/runtime/onert/core/src/dumper/text/GraphDumper.h
+++ b/runtime/onert/core/src/dumper/text/GraphDumper.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_DUMPER_TEXT_GRAPH_DUMPER_H__
+#define __ONERT_DUMPER_TEXT_GRAPH_DUMPER_H__
+
+#include <ir/Index.h>
+
+namespace onert
+{
+namespace ir
+{
+class Graph;
+}
+} // namespace onert
+
+namespace onert
+{
+namespace compiler
+{
+class LoweredGraph;
+}
+} // namespace onert
+
+namespace onert
+{
+namespace dumper
+{
+namespace text
+{
+
+std::string formatOperandBrief(ir::OperandIndex ind);
+std::string formatOperand(const ir::Graph &, ir::OperandIndex ind);
+std::string formatOperation(const ir::Graph &graph, ir::OperationIndex ind);
+std::string formatOpSequence(const compiler::LoweredGraph &lgraph, ir::OpSequenceIndex ind);
+void dumpGraph(const ir::Graph &graph);
+void dumpLoweredGraph(const compiler::LoweredGraph &lgraph);
+
+} // namespace text
+} // namespace dumper
+} // namespace onert
+
+#endif // __ONERT_DUMPER_TEXT_GRAPH_DUMPER_H__

--- a/runtime/onert/core/src/ir/Graph.cc
+++ b/runtime/onert/core/src/ir/Graph.cc
@@ -19,6 +19,7 @@
 #include "OperationValidator.h"
 
 #include <algorithm>
+
 #include <bitset>
 #include <sstream>
 
@@ -29,6 +30,7 @@
 #include "ir/operand/PermuteFactor.h"
 #include "ir/OperandIndexMap.h"
 #include "ir/OperationIndexMap.h"
+#include "dumper/text/GraphDumper.h"
 #include "backend/IConfig.h"
 
 namespace onert
@@ -109,6 +111,8 @@ void Graph::finishBuilding(void)
   // - Operand type
   // - Shape independent parameter
   OperationValidator{*this}();
+
+  dumper::text::dumpGraph(*this);
 }
 
 void Graph::initializeUseDef()

--- a/runtime/onert/core/src/ir/OpSequence.cc
+++ b/runtime/onert/core/src/ir/OpSequence.cc
@@ -50,7 +50,7 @@ OpSequence::OpSequence(Layout layout) : _layout{layout}, _has_dynamic_tensor{fal
 
 void OpSequence::accept(OperationVisitor &v) const { v.visit(*this); }
 
-// TODO: Impl Dumper instead of this method
+// TODO Remove this and replace the calls to this with dumper::text::formatOpSequence.
 std::string getStrFromOpSeq(const OpSequence &op_seq, const Operations &operations)
 {
   // "  IN($0,$1,$2) -> { OPERATION0($0,$1,$2:$3), op1($3:$4), op2($4:$5) } -> OUT($5)"

--- a/runtime/onert/core/src/ir/OpSequences.cc
+++ b/runtime/onert/core/src/ir/OpSequences.cc
@@ -113,12 +113,5 @@ OpSequenceIndex OpSequences::findOperation(const OperationIndex &operation_index
   throw std::runtime_error("Operation not found");
 }
 
-void dumpOpSequences(const OpSequences &op_seqs, const Operations &operations)
-{
-  op_seqs.iterate([&](const OpSequenceIndex &idx, const OpSequence &op_seq) {
-    VERBOSE(OpSequences) << idx << "] " << getStrFromOpSeq(op_seq, operations) << std::endl;
-  });
-}
-
 } // namespace ir
 } // namespace onert


### PR DESCRIPTION
This commit introduces a text-based human-readable dumper.
Its syntax is partially similar to MLIR/LLVMIR. However it has its own
way too.

It contains Graph and LoweredGraph dumper.

- OpSequence Dump is partially replaced with this
- Dump the graph on `Graph::finishBuilding`

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>