### PR TITLE
[onert] Refine topological sort impl

### DIFF
--- a/runtime/onert/core/src/compiler/LoweredGraph.cc
+++ b/runtime/onert/core/src/compiler/LoweredGraph.cc
@@ -547,15 +547,15 @@ bool LoweredGraph::mergeable(const ir::OpSequenceIndex &op_seq_index,
 std::vector<ir::OpSequenceIndex> LoweredGraph::topolSortOpSeqs() const
 {
   std::vector<ir::OpSequenceIndex> ret;
-  std::unordered_map<ir::OpSequenceIndex, bool> visited;
+  util::Set<ir::OpSequenceIndex> unvisited;
   op_seqs().iterate(
-    [&](const ir::OpSequenceIndex &index, const ir::OpSequence &) { visited[index] = false; });
+    [&](const ir::OpSequenceIndex &index, const ir::OpSequence &) { unvisited.add(index); });
 
   std::function<void(const ir::OpSequenceIndex &, const ir::OpSequence &)> dfs =
     [&](const ir::OpSequenceIndex &index, const ir::OpSequence &op_seq) {
-      if (visited[index])
+      if (!unvisited.contains(index))
         return;
-      visited[index] = true;
+      unvisited.remove(index);
 
       for (const auto output : op_seq.getOutputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED)
       {
@@ -570,9 +570,7 @@ std::vector<ir::OpSequenceIndex> LoweredGraph::topolSortOpSeqs() const
     };
   op_seqs().iterate(dfs);
 
-  // All of the operations(nodes) must have been visited.
-  assert(std::all_of(visited.begin(), visited.end(),
-                     [](const std::pair<const ir::OpSequenceIndex, bool> &v) { return v.second; }));
+  assert(unvisited.empty()); // All of the nodes must have been visited
   // Reversing Postorder DFS result to make it sorted in topoligical order
   std::reverse(ret.begin(), ret.end());
   return ret;

--- a/runtime/onert/core/src/ir/Graph.cc
+++ b/runtime/onert/core/src/ir/Graph.cc
@@ -157,15 +157,15 @@ void Graph::sweepGarbageOperands()
 std::vector<ir::OperationIndex> Graph::topolSortOperations() const
 {
   std::vector<ir::OperationIndex> ret;
-  ir::OperationIndexMap<bool> visited;
+  util::Set<ir::OperationIndex> unvisited;
   operations().iterate(
-    [&](const ir::OperationIndex &index, const ir::Operation &) { visited[index] = false; });
+    [&](const ir::OperationIndex &index, const ir::Operation &) { unvisited.add(index); });
 
   std::function<void(const ir::OperationIndex &, const ir::Operation &)> dfs =
     [&](const ir::OperationIndex &index, const ir::Operation &op) -> void {
-    if (visited[index])
+    if (!unvisited.contains(index))
       return;
-    visited[index] = true;
+    unvisited.remove(index);
 
     for (const auto output : op.getOutputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED)
     {
@@ -179,9 +179,7 @@ std::vector<ir::OperationIndex> Graph::topolSortOperations() const
   };
   operations().iterate(dfs);
 
-  // All of the operations(nodes) must have been visited.
-  assert(std::all_of(visited.begin(), visited.end(),
-                     [](const std::pair<const ir::OperationIndex, bool> &v) { return v.second; }));
+  assert(unvisited.empty()); // All of the nodes must have been visited
   // Reversing Postorder DFS result to make it sorted in topoligical order
   std::reverse(ret.begin(), ret.end());
   return ret;


### PR DESCRIPTION
Refine topological sort implemenatation.

Switch data structure for visit check to Set.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>