### PR TITLE
[luci] Fix for wrong assert in ConvertNCHWToNHWCPass.

### DIFF
--- a/compiler/luci/pass/src/ConvertNCHWToNHWCPass.cpp
+++ b/compiler/luci/pass/src/ConvertNCHWToNHWCPass.cpp
@@ -55,7 +55,6 @@ private:
 
 void set_data_format(loco::Node *node, const DataFormat &format)
 {
-  assert(node->annot<DataFormatAnnotation>() == nullptr);
   node->annot(std::make_unique<DataFormatAnnotation>(format));
 }
 


### PR DESCRIPTION
This removes wrong assert in ConvertNCHWToNHWCPass.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>