### PR TITLE
[luci] Fix wrong substitution in ResolveCustomOpBatchMatMulPass

### DIFF
--- a/compiler/luci/pass/src/ResolveCustomOpBatchMatMulPass.cpp
+++ b/compiler/luci/pass/src/ResolveCustomOpBatchMatMulPass.cpp
@@ -42,14 +42,9 @@ bool resolve_custom_op(luci::CircleCustom *cop)
     batch_matmul->adj_x(map["adj_x"].AsBool());
     batch_matmul->adj_y(map["adj_y"].AsBool());
 
-    for (auto s : loco::succs(cop))
-    {
-      if (auto cop_out = dynamic_cast<luci::CircleCustomOut *>(s))
-      {
-        replace(cop_out).with(batch_matmul);
-        changed = true;
-      }
-    }
+    auto customOut = loco::succs(cop);
+    assert(customOut.size() == 1);
+    replace(*customOut.begin()).with(batch_matmul);
   }
 
   return changed;

--- a/compiler/luci/pass/src/ResolveCustomOpBatchMatMulPass.cpp
+++ b/compiler/luci/pass/src/ResolveCustomOpBatchMatMulPass.cpp
@@ -25,8 +25,6 @@ namespace
 
 bool resolve_custom_op(luci::CircleCustom *cop)
 {
-  bool changed = false;
-
   const std::string custom_code = cop->custom_code();
   const std::vector<uint8_t> custom_options = cop->custom_options();
 
@@ -45,9 +43,11 @@ bool resolve_custom_op(luci::CircleCustom *cop)
     auto customOut = loco::succs(cop);
     assert(customOut.size() == 1);
     replace(*customOut.begin()).with(batch_matmul);
+
+    return true;
   }
 
-  return changed;
+  return false;
 }
 
 } // namespace


### PR DESCRIPTION
Until now, `ResolveCUstomOpBatchMatMulPass` was substituting original
custom operation, not `CircleCustomOut`.
As a result, wrong optimization was done.
This commit will fix it.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>