### PR TITLE
[luci] Fix wrong checking in CIrcleTypeInference

### DIFF
--- a/compiler/luci/service/src/CircleTypeInference.cpp
+++ b/compiler/luci/service/src/CircleTypeInference.cpp
@@ -80,7 +80,8 @@ bool inputs_dtype_ready(const luci::CircleNode *node)
 {
   for (uint32_t arity = 0; arity < node->arity(); ++arity)
   {
-    if (node->dtype() == loco::DataType::Unknown)
+    auto input_node = loco::must_cast<luci::CircleNode *>(node->arg(arity));
+    if (input_node->dtype() == loco::DataType::Unknown)
       return false;
   }
 


### PR DESCRIPTION
`inputs_dtype_ready` should check `dtyps` of input nodes but until now,
original node was only checked.
This commit will fix it.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>