### PR TITLE
[luci] Change assert to if condition in DepthwiseConv2D validation

### DIFF
--- a/compiler/luci/import/src/Nodes/CircleDepthwiseConv2D.cpp
+++ b/compiler/luci/import/src/Nodes/CircleDepthwiseConv2D.cpp
@@ -20,8 +20,6 @@
 
 #include <oops/UserExn.h>
 
-#include <cassert>
-
 namespace luci
 {
 
@@ -39,12 +37,18 @@ bool CircleDepthwiseConv2DGraphBuilder::validate(const ValidateArgs &args) const
   // input shape
   const auto &input = tensors.at(args.op.inputs.at(0));
   const auto &input_shape = input->shape;
-  assert(input_shape.size() == 4);
+
+  // input shape must be rank 4
+  if (input_shape.size() != 4)
+    return false;
 
   // filter shape
   const auto &filter = tensors.at(args.op.inputs.at(1));
   const auto &filter_shape = filter->shape;
-  assert(filter_shape.size() == 4);
+
+  // filter shape must be rank 4
+  if (filter_shape.size() != 4)
+    return false;
 
   // multiplier
   const auto *options = args.op.builtin_options.AsDepthwiseConv2DOptions();


### PR DESCRIPTION
This commit changes `assert` to `if` in DepthwiseConv2D validation.

To make validation more meaningful, it would be better to use `if` condition instead of `assert`.

FYI, 
```bash
$ cd tensorflow
$ cat tensorflow/tensorflow/core/framework/common_shape_fns.cc
...
Status DepthwiseConv2DNativeShapeImpl(shape_inference::InferenceContext* c,
                                      bool supports_explicit_padding) {
  ShapeHandle input_shape;
  TF_RETURN_IF_ERROR(c->WithRank(c->input(0), 4 /* NOTE HERE */, &input_shape));
  ShapeHandle filter_shape;
  TF_RETURN_IF_ERROR(c->WithRank(c->input(1), 4 /* NOTE HERE */, &filter_shape));
...
```
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>