### PR TITLE
[luci] Change default shape/type inference algorithm

### DIFF
--- a/compiler/luci/service/include/luci/Service/CircleShapeInference.h
+++ b/compiler/luci/service/include/luci/Service/CircleShapeInference.h
@@ -24,6 +24,7 @@
 #include <luci/IR/CircleNodes.h>
 #include <luci/IR/CircleNodeVisitor.h>
 #include <luci/Service/CircleShapeInferenceHelper.h>
+#include <luci/Service/CircleShapeInferenceRule.h>
 
 namespace luci
 {
@@ -52,7 +53,12 @@ class Algorithm final : public luci::CircleNodeVisitor<loco::TensorShape>
 {
 public:
   // TODO Remove this when all of visit function is implemented
-  loco::TensorShape visit(const luci::CircleNode *node) final { return sinf::circle_shape(node); }
+  loco::TensorShape visit(const luci::CircleNode *node) final
+  {
+    loco::NodeShape shape;
+    luci::CircleShapeInferenceRule().infer(node, shape);
+    return shape.as<loco::TensorShape>();
+  }
 
   // loco::TensorShape visit(const luci::CircleAbs *node) final;
   // loco::TensorShape visit(const luci::CircleAdd *node) final;

--- a/compiler/luci/service/include/luci/Service/CircleTypeInference.h
+++ b/compiler/luci/service/include/luci/Service/CircleTypeInference.h
@@ -24,6 +24,7 @@
 #include <luci/IR/CircleNodes.h>
 #include <luci/IR/CircleNodeVisitor.h>
 #include <luci/Service/CircleTypeInferenceHelper.h>
+#include <luci/Service/CircleTypeInferenceRule.h>
 
 namespace luci
 {
@@ -53,7 +54,12 @@ class Algorithm final : public luci::CircleNodeVisitor<loco::DataType>
 {
 public:
   // TODO Remove this when all of visit function is implemented
-  loco::DataType visit(const luci::CircleNode *node) final { return node->dtype(); }
+  loco::DataType visit(const luci::CircleNode *node) final
+  {
+    loco::DataType dtype;
+    luci::CircleTypeInferenceRule().infer(node, dtype);
+    return dtype;
+  }
 
   // loco::DataType visit(const luci::CircleAbs *node) final;
   // loco::DataType visit(const luci::CircleAdd *node) final;


### PR DESCRIPTION
Until now, default inference algorithm for shape and type was returning meaningless things.
By changing the default inference algorithm of shape and type, original inference rule of shape and type will be used,
if new shape/type inference algorithm of an operation are not implemented yet.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>