### PR TITLE
[luci] Print unknown dimension as question mark

### DIFF
--- a/compiler/luci/service/src/CircleShapeInference.cpp
+++ b/compiler/luci/service/src/CircleShapeInference.cpp
@@ -46,7 +46,11 @@ std::ostream &operator<<(std::ostream &os, const loco::TensorShape &tensor_shape
   {
     if (r)
       os << ",";
-    os << tensor_shape.dim(r).value();
+
+    if (tensor_shape.dim(r).known())
+      os << tensor_shape.dim(r).value();
+    else
+      os << "?";
   }
   os << "]";
   return os;

--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -41,7 +41,11 @@ std::ostream &operator<<(std::ostream &os, const loco::TensorShape &tensor_shape
   {
     if (r)
       os << ",";
-    os << tensor_shape.dim(r).value();
+
+    if (tensor_shape.dim(r).known())
+      os << tensor_shape.dim(r).value();
+    else
+      os << "?";
   }
   os << "]";
   return os;

--- a/compiler/luci/service/src/Validate.cpp
+++ b/compiler/luci/service/src/Validate.cpp
@@ -36,7 +36,11 @@ std::ostream &operator<<(std::ostream &os, const loco::TensorShape &tensor_shape
   {
     if (r)
       os << ",";
-    os << tensor_shape.dim(r).value();
+
+    if (tensor_shape.dim(r).known())
+      os << tensor_shape.dim(r).value();
+    else
+      os << "?";
   }
   os << "]";
   return os;
@@ -49,7 +53,11 @@ std::ostream &operator<<(std::ostream &os, const luci::CircleNode *circle_node)
   {
     if (r)
       os << ",";
-    os << circle_node->dim(r).value();
+
+    if (circle_node->dim(r).known())
+      os << circle_node->dim(r).value();
+    else
+      os << "?";
   }
   os << "]";
   return os;


### PR DESCRIPTION
Parent Issue : #5501

Until now, unknown dimension was printed as 0.
This commit will fix it.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>