### PR TITLE
[luci] Support unknown dimension expression in ShapeDescription

### DIFF
--- a/compiler/luci/service/src/ShapeDescription.cpp
+++ b/compiler/luci/service/src/ShapeDescription.cpp
@@ -31,7 +31,7 @@ ShapeDescription to_shape_description(const luci::CircleNode *circle_node)
 
   res._dims.resize(circle_node->rank());
   for (uint32_t i = 0; i < circle_node->rank(); ++i)
-    res._dims.at(i) = circle_node->dim(i).value();
+    res._dims.at(i) = circle_node->dim(i).known() ? circle_node->dim(i).value() : -1;
 
   return res;
 }


### PR DESCRIPTION
Parent Issue : #5501

Until now, unknown dimension was represented as 0.
This commit will fix it.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>