### PR TITLE
[luci] Fix wrong header files in optimizer util

### DIFF
--- a/compiler/luci/pass/src/CircleOptimizerUtils.h
+++ b/compiler/luci/pass/src/CircleOptimizerUtils.h
@@ -17,8 +17,7 @@
 #ifndef __LUCI_CIRCLE_OPTIMIZER_UTILS_H__
 #define __LUCI_CIRCLE_OPTIMIZER_UTILS_H__
 
-#include "luci/Pass/QuantizeDequantizeWeightsPass.h"
-#include "luci/Pass/QuantizeWithMinMaxPass.h"
+#include "luci/Pass/QuantizationParameters.h"
 
 #include <loco.h>
 


### PR DESCRIPTION
This commit will fix wrong header files in `CircleOptimizerUtils.h`.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>