### PR TITLE
[doc] Update runtime cross build document for ACL build

### DIFF
--- a/docs/howto/how-to-cross-build-runtime-for-arm.md
+++ b/docs/howto/how-to-cross-build-runtime-for-arm.md
@@ -105,7 +105,13 @@ Then, copy `libstdc++.so.6.0.24` into `/usr/lib/arm-linux-gnueabihf`, and update
 
 ## Build and install ARM Compute Library
 
-Mostly you only need once of ACL build.
+Mostly you only need once of ACL (ARM Compute Library) build.
+
+To build ACL, you need to install scons
+
+```
+$ sudo apt-get install scons
+```
 
 ACL will be automatically installed in `externals/acl` when you build runtime without any changes.
 


### PR DESCRIPTION
To build ACL, need to install `scons`

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>