### PR TITLE
[luci] Fix wrong dimension copy in CircleShapeInferenceHelper

### DIFF
--- a/compiler/luci/service/src/CircleShapeInferenceHelper.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceHelper.cpp
@@ -26,7 +26,7 @@ loco::TensorShape circle_shape(const luci::CircleNode *node)
   loco::TensorShape shape;
   shape.rank(node->rank());
   for (uint32_t r = 0; r < node->rank(); ++r)
-    shape.dim(r) = loco::Dimension(node->dim(r).value());
+    shape.dim(r) = node->dim(r);
   return shape;
 }
 


### PR DESCRIPTION
Parent Issue : #5501

Until now, copied dimension is always known dimension even if original dimension was unknown.
This commit will fix it.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>