### PR TITLE
[onert] Rename offset to zero_point of TypeInfo and makes CWQ ready

### DIFF
--- a/runtime/onert/backend/acl_cl/KernelGenerator.cc
+++ b/runtime/onert/backend/acl_cl/KernelGenerator.cc
@@ -1538,7 +1538,7 @@ void KernelGenerator::visit(const ir::operation::Pad &node)
 
   auto input_type = _ctx.at(input_index).typeInfo();
   auto data_type = acl_common::asDataType(input_type.type());
-  auto quant_info = ::arm_compute::QuantizationInfo(input_type.scale(), input_type.offset());
+  auto quant_info = ::arm_compute::QuantizationInfo(input_type.scale(), input_type.zero_point());
   const auto pixel_value = ::arm_compute::PixelValue(0, data_type, quant_info);
 
   auto input = _tensor_reg->getAclTensor(input_index)->handle();

--- a/runtime/onert/backend/acl_common/AclTensorBuilder.h
+++ b/runtime/onert/backend/acl_common/AclTensorBuilder.h
@@ -368,7 +368,7 @@ void AclTensorBuilder<T_ITensor, T_Tensor, T_SubTensor>::buildTensors(void)
       assert(parent_tensor != nullptr);
 
       // Child's type should be same with parent
-      assert(tensor_info.typeInfo().offset() ==
+      assert(tensor_info.typeInfo().zero_point() ==
              parent_tensor->info()->quantization_info().uniform().offset);
       assert(tensor_info.typeInfo().scale() ==
              parent_tensor->info()->quantization_info().uniform().scale);

--- a/runtime/onert/backend/acl_common/Convert.cc
+++ b/runtime/onert/backend/acl_common/Convert.cc
@@ -137,7 +137,7 @@ namespace acl_common
 {
   ::arm_compute::TensorInfo info(
     asTensorShape(shape, frontend_layout, backend_layout, apply_dim_correction), 1,
-    asDataType(typeInfo.type()), asQuantizationInfo(typeInfo.scale(), typeInfo.offset()));
+    asDataType(typeInfo.type()), asQuantizationInfo(typeInfo.scale(), typeInfo.zero_point()));
   info.set_data_layout(asDataLayout(backend_layout));
   return info;
 }

--- a/runtime/onert/backend/acl_neon/KernelGenerator.cc
+++ b/runtime/onert/backend/acl_neon/KernelGenerator.cc
@@ -769,7 +769,7 @@ void KernelGenerator::visit(const ir::operation::Pad &node)
   UNUSED_RELEASE(input_type);
   assert(input->info()->data_type() == acl_common::asDataType(input_type.type()));
   assert(input->info()->quantization_info() ==
-         ::arm_compute::QuantizationInfo(input_type.scale(), input_type.offset()));
+         ::arm_compute::QuantizationInfo(input_type.scale(), input_type.zero_point()));
   const auto pixel_value =
     ::arm_compute::PixelValue(0, input->info()->data_type(), input->info()->quantization_info());
 

--- a/runtime/onert/core/include/backend/cpu_common/Tensor.h
+++ b/runtime/onert/core/include/backend/cpu_common/Tensor.h
@@ -91,7 +91,7 @@ public:
   ir::Layout layout() const override { return _layout; }
   ir::DataType data_type() const override { return _info.typeInfo().type(); }
   float data_scale() const override { return _info.typeInfo().scale(); }
-  int32_t data_zero_point() const override { return _info.typeInfo().offset(); }
+  int32_t data_zero_point() const override { return _info.typeInfo().zero_point(); }
   bool is_constant() const override { return _info.isConstant(); }
   bool is_dynamic() const override { return _info.isDynamic(); }
   void set_dynamic() override { _info.setDynamic(); }

--- a/runtime/onert/core/src/backend/builtin/UserTensor.h
+++ b/runtime/onert/core/src/backend/builtin/UserTensor.h
@@ -61,7 +61,7 @@ public:
   ir::Layout layout() const override { return _layout; }
   ir::DataType data_type() const override { return _info.typeInfo().type(); }
   float data_scale() const override { return _info.typeInfo().scale(); }
-  int32_t data_zero_point() const override { return _info.typeInfo().offset(); }
+  int32_t data_zero_point() const override { return _info.typeInfo().zero_point(); }
   bool is_dynamic() const override { return _dynamic; }
   void set_dynamic() override { _dynamic = true; }
   ir::Shape getShape() const override { return _info.shape(); }

--- a/runtime/onert/core/src/interp/Tensor.h
+++ b/runtime/onert/core/src/interp/Tensor.h
@@ -122,7 +122,7 @@ public:
   bool has_padding() const override { return false; }
   ir::DataType data_type() const override { return _info.typeInfo().type(); }
   float data_scale() const override { return _info.typeInfo().scale(); }
-  int32_t data_zero_point() const override { return _info.typeInfo().offset(); }
+  int32_t data_zero_point() const override { return _info.typeInfo().zero_point(); }
   const ir::OperandInfo &tensorInfo() const override { return _info; }
   uint64_t num_elements() const override { return _info.shape().num_elements(); };
   ir::Shape getShape() const override;
@@ -163,7 +163,7 @@ public:
   bool has_padding() const override { return false; }
   ir::DataType data_type() const override { return _info.typeInfo().type(); }
   float data_scale() const override { return _info.typeInfo().scale(); }
-  int32_t data_zero_point() const override { return _info.typeInfo().offset(); }
+  int32_t data_zero_point() const override { return _info.typeInfo().zero_point(); }
   const ir::OperandInfo &tensorInfo() const override { return _info; }
   uint64_t num_elements() const override { return _info.shape().num_elements(); };
   ir::Shape getShape() const override;

--- a/runtime/onert/core/src/ir/OperationValidator.cc
+++ b/runtime/onert/core/src/ir/OperationValidator.cc
@@ -60,7 +60,7 @@ bool OperationValidator::isSameQuantParam(const OperandIndex &idx1, const Operan
   if (_operands.at(idx1).typeInfo().scale() != _operands.at(idx2).typeInfo().scale())
     return false;
 
-  if (_operands.at(idx1).typeInfo().offset() != _operands.at(idx2).typeInfo().offset())
+  if (_operands.at(idx1).typeInfo().zero_point() != _operands.at(idx2).typeInfo().zero_point())
     return false;
 
   return true;

--- a/runtime/onert/core/src/ir/TypeInfo.cc
+++ b/runtime/onert/core/src/ir/TypeInfo.cc
@@ -28,7 +28,7 @@ bool operator==(const TypeInfo &lhs, const TypeInfo &rhs)
     return false;
   }
 
-  if (lhs.offset() != rhs.offset())
+  if (lhs.zero_point() != rhs.zero_point())
   {
     return false;
   }


### PR DESCRIPTION
: Rename ir::TypeInfo::offset to ir::TypeInfo::zero_point
: Make scale and zeropoint vector to store multiple values.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>