### PR TITLE
[tflitefile_tool] select_operator will handle quantized_dimension

### DIFF
--- a/tools/tflitefile_tool/select_operator.py
+++ b/tools/tflitefile_tool/select_operator.py
@@ -188,6 +188,11 @@ def GenerateQuantization(new_builder, selected_quantization):
         tflite.QuantizationParameters.QuantizationParametersAddZeroPoint(
             new_builder, new_zeropoint)
 
+    quantized_dimension = selected_quantization.QuantizedDimension()
+    if quantized_dimension != 0:
+        tflite.QuantizationParameters.QuantizationParametersAddQuantizedDimension(
+            new_builder, quantized_dimension)
+
     return tflite.QuantizationParameters.QuantizationParametersEnd(new_builder)
 
 


### PR DESCRIPTION
Without proper quantized_dimension, tensorflow lite fails
to build tflite interpreter.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>