### PR TITLE
[onert] base_loader loads channel-wise quantization params

### DIFF
--- a/runtime/onert/core/include/ir/TypeInfo.h
+++ b/runtime/onert/core/include/ir/TypeInfo.h
@@ -68,6 +68,11 @@ public:
     _quant.zero_points.resize(1);
     _quant.zero_points[0] = zero_point;
   }
+  void quantization(std::vector<float> &&scales, std::vector<int32_t> &&zero_points)
+  {
+    _quant.scales = scales;
+    _quant.zero_points = zero_points;
+  }
   void sparsity(std::shared_ptr<ir::Sparsity> sparsity) { _sparsity = sparsity; }
 
 public:


### PR DESCRIPTION
`base_loader` can load array of scales and zero_points.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>