### PR TITLE
[circle2circle] Introduce RemoveUnnecessarySplit on circle2circle.

### DIFF
--- a/compiler/circle2circle/src/Circle2Circle.cpp
+++ b/compiler/circle2circle/src/Circle2Circle.cpp
@@ -122,6 +122,12 @@ int entry(int argc, char **argv)
     .default_value(false)
     .help("This will remove unnecessary slice operators");
 
+  arser.add_argument("--remove_unnecessary_split")
+    .nargs(0)
+    .required(false)
+    .default_value(false)
+    .help("This will remove unnecessary split operators");
+
   arser.add_argument("--replace_cw_mul_add_with_depthwise_conv")
     .nargs(0)
     .required(false)
@@ -250,6 +256,8 @@ int entry(int argc, char **argv)
     options->enable(Algorithms::RemoveRedundantTranspose);
   if (arser.get<bool>("--remove_unnecessary_slice"))
     options->enable(Algorithms::RemoveUnnecessarySlice);
+  if (arser.get<bool>("--remove_unnecessary_split"))
+    options->enable(Algorithms::RemoveUnnecessarySplit);
   if (arser.get<bool>("--replace_cw_mul_add_with_depthwise_conv"))
     options->enable(Algorithms::ReplaceMulAddWithDepthwiseConv);
   if (arser.get<bool>("--resolve_customop_add"))


### PR DESCRIPTION
For #5456 

This commit introduce `RemoveUnnecessarySplit` on circle2circle.

ONE-DCO-1.0-Signed-off-by: KiDeuk Bang <rrstrous@nate.com>