### PR TITLE
[onert] Remove config OP_SEQ_MAX_NODE

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -840,10 +840,6 @@ NNFW_STATUS nnfw_session::set_config(const char *key, const char *value)
   {
     options.graph_dump_level = toInt(value);
   }
-  else if (skey == config::OP_SEQ_MAX_NODE)
-  {
-    options.op_seq_max_node = toInt(value);
-  }
   else if (skey == config::EXECUTOR)
   {
     options.executor = value;

--- a/runtime/onert/core/include/compiler/Compiler.h
+++ b/runtime/onert/core/include/compiler/Compiler.h
@@ -53,7 +53,6 @@ struct CompilerOptions
   // OPTIONS ONLY FOR DEBUGGING/PROFILING
   std::string trace_filepath; //< File path to save trace records
   int graph_dump_level;       //< Graph dump level, values between 0 and 2 are valid
-  int op_seq_max_node;        //< Number of nodes that can be
   std::string executor;       //< Executor name to use
   ManualSchedulerOptions manual_scheduler_options; //< Options for ManualScheduler
   bool he_scheduler;      //< HEScheduler if true, ManualScheduler otherwise

--- a/runtime/onert/core/include/util/Config.lst
+++ b/runtime/onert/core/include/util/Config.lst
@@ -31,7 +31,6 @@ CONFIG(ACL_LAYOUT              , std::string  , "none")
 CONFIG(NCNN_LAYOUT             , std::string  , "NCHW")
 CONFIG(PROFILING_MODE          , bool         , "0")
 CONFIG(USE_SCHEDULER           , bool         , "0")
-CONFIG(OP_SEQ_MAX_NODE         , int          , "0")
 CONFIG(TRACE_FILEPATH          , std::string  , "")
 CONFIG(FP16_ENABLE             , bool         , "0")
 CONFIG(RUY_THREADS             , int          , "-1")
@@ -44,4 +43,3 @@ CONFIG(USE_MMAPED_DATA         , bool         , "0")
     CONFIG(OP_BACKEND_ ## InternalName, std::string, "")
 #include "ir/Operations.lst"
 #undef OP
-

--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -77,15 +77,11 @@ CompilerOptions fetchCompilerOptionsFromGlobalConfig(const ir::Subgraphs &subgs)
   options.backend_list = nnfw::misc::split(util::getConfigString(util::config::BACKENDS), ';');
   options.trace_filepath = util::getConfigString(util::config::TRACE_FILEPATH);
   options.graph_dump_level = util::getConfigInt(util::config::GRAPH_DOT_DUMP);
-  options.op_seq_max_node = util::getConfigInt(util::config::OP_SEQ_MAX_NODE);
   options.executor = util::getConfigString(util::config::EXECUTOR);
   options.he_scheduler = util::getConfigBool(util::config::USE_SCHEDULER);
   options.he_profiling_mode = util::getConfigBool(util::config::PROFILING_MODE);
   options.disable_compile = util::getConfigBool(util::config::DISABLE_COMPILE);
   options.fp16_enable = util::getConfigBool(util::config::FP16_ENABLE);
-#ifdef RUY_PROFILER
-  options.op_seq_max_node = 1;
-#endif
 
   {
     // Backend for all
@@ -177,7 +173,6 @@ std::shared_ptr<exec::ExecutorMap> Compiler::compile(void)
                       << std::endl;
     VERBOSE(Compiler) << "trace_filepath           : " << _options.trace_filepath << std::endl;
     VERBOSE(Compiler) << "graph_dump_level         : " << _options.graph_dump_level << std::endl;
-    VERBOSE(Compiler) << "op_seq_max_node          : " << _options.op_seq_max_node << std::endl;
     VERBOSE(Compiler) << "executor                 : " << _options.executor << std::endl;
     VERBOSE(Compiler) << "manual backend_for_all   : "
                       << _options.manual_scheduler_options.backend_for_all << std::endl;

--- a/runtime/onert/core/src/compiler/LoweredGraph.cc
+++ b/runtime/onert/core/src/compiler/LoweredGraph.cc
@@ -237,9 +237,7 @@ void LoweredGraph::makeOpSequences(
   ir::OperandIndexMap<std::unique_ptr<compiler::OperandLowerInfo>> &operands_lower_info,
   const CompilerOptions &options, const BackendResolver &backend_resolver)
 {
-  // if SUBG_MAX_NODE == 0, no limit on nodes of a op_seq
-  const int op_seq_max_node = options.op_seq_max_node;
-  assert(op_seq_max_node >= 0);
+  const int op_seq_max_node = 1;
 
   bool is_profiling = options.he_profiling_mode;
   ir::OpSequence *op_seq = nullptr;

--- a/tests/nnfw_api/src/ValidationTestAddModelLoaded.cc
+++ b/tests/nnfw_api/src/ValidationTestAddModelLoaded.cc
@@ -200,8 +200,6 @@ TEST_F(ValidationTestAddModelLoaded, debug_set_config)
   NNFW_ENSURE_SUCCESS(nnfw_set_config(_session, "GRAPH_DOT_DUMP", "0"));
   NNFW_ENSURE_SUCCESS(nnfw_set_config(_session, "GRAPH_DOT_DUMP", "1"));
   NNFW_ENSURE_SUCCESS(nnfw_set_config(_session, "GRAPH_DOT_DUMP", "2"));
-  NNFW_ENSURE_SUCCESS(nnfw_set_config(_session, "OP_SEQ_MAX_NODE", "0"));
-  NNFW_ENSURE_SUCCESS(nnfw_set_config(_session, "OP_SEQ_MAX_NODE", "1"));
   NNFW_ENSURE_SUCCESS(nnfw_set_config(_session, "EXECUTOR", "Linear"));
   NNFW_ENSURE_SUCCESS(nnfw_set_config(_session, "OP_BACKEND_ALLOPS", "cpu"));
   NNFW_ENSURE_SUCCESS(nnfw_set_config(_session, "USE_SCHEDULER", "0"));

--- a/tests/scripts/benchmark.sh
+++ b/tests/scripts/benchmark.sh
@@ -92,7 +92,7 @@ $BRIDGE shell tar -zxf $TEST_ROOT/nnpkg.tar.gz -C $TEST_ROOT/nnpkg
 $BRIDGE shell rm $TEST_ROOT/nnpkg.tar.gz
 
 # 1. Run
-$BRIDGE shell LD_LIBRARY_PATH=$TEST_ROOT/Product/out/lib OP_SEQ_MAX_NODE=1 TRACE_FILEPATH=$TEST_ROOT/trace.json BACKENDS=$BACKENDS $TEST_ROOT/Product/out/bin/nnpackage_run --nnpackage $NNPKG_PATH_TARGET -r $NUM_RUNS
+$BRIDGE shell LD_LIBRARY_PATH=$TEST_ROOT/Product/out/lib TRACE_FILEPATH=$TEST_ROOT/trace.json BACKENDS=$BACKENDS $TEST_ROOT/Product/out/bin/nnpackage_run --nnpackage $NNPKG_PATH_TARGET -r $NUM_RUNS
 
 # 2. Pull result file
 echo "Pulling data from target to trace.json"


### PR DESCRIPTION
Before removing OpSequence, this removes the config(compiler option)
OP_SEQ_MAX_NODE first.

Part of #5537

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>