### PR TITLE
[onert] disable fp32 to fp16 conversion (temp)

### DIFF
--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -19,7 +19,6 @@
 #include "ParamChecker.h"
 #include "ExecutorFactory.h"
 #include "ShapeValidator.h"
-#include "Fp32ToFp16Converter.h"
 
 #include <backend/builtin/Config.h>
 #include "compiler/BackendManager.h"
@@ -233,22 +232,6 @@ std::shared_ptr<exec::ExecutorMap> Compiler::compile(void)
 
     // Lower: Assign backend
     lowered_subgs[index] = std::make_unique<compiler::LoweredGraph>(subg, _options);
-
-    // Check backend(s) for subgraph support FP16
-    bool backends_support_fp16 = true;
-    auto all_backends = BackendManager::get().getAll();
-    for (auto backend : all_backends)
-    {
-      // Builtin backend is not for actual computaion of operations so it is an exception
-      if (backend->config()->id() != backend::builtin::Config::ID)
-        backends_support_fp16 &= backend->config()->supportFP16();
-    }
-
-    if (_options.fp16_enable && backends_support_fp16)
-    {
-      // NOTE: the only acl_cl backend enables fp16 mode
-      Fp32ToFp16Converter(*lowered_subgs[index]).run();
-    }
 
     subg.setSubgraphs(nullptr);
   });

--- a/runtime/onert/core/src/compiler/Fp32ToFp16Converter.cc
+++ b/runtime/onert/core/src/compiler/Fp32ToFp16Converter.cc
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#if 0 // This file is temporarily unused
+
 #include "Fp32ToFp16Converter.h"
 #include "ir/operation/ConvertFp32ToFp16.h"
 #include "ir/operation/ConvertFp16ToFp32.h"
@@ -950,3 +952,5 @@ void Fp32ToFp16Converter::deleteContiguousOpSequences(
 } // namespace compiler
 
 } // namespace onert
+
+#endif

--- a/runtime/onert/core/src/compiler/Fp32ToFp16Converter.h
+++ b/runtime/onert/core/src/compiler/Fp32ToFp16Converter.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#if 0 // This file is temporarily unused
+
 #ifndef __ONERT_COMPILER_FP32_TO_FP16_CONVERTER_H__
 #define __ONERT_COMPILER_FP32_TO_FP16_CONVERTER_H__
 
@@ -99,3 +101,5 @@ private:
 } // namespace onert
 
 #endif // __ONERT_COMPILER_FP32_TO_FP16_CONVERTER_H__
+
+#endif


### PR DESCRIPTION
Temporarily disable fp32 to fp16 conversion.

Draft : #5537 (it explains why we need this change)

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>