### PR TITLE
[luci] Make dynamic shape determinant function as public

### DIFF
--- a/compiler/luci/pass/src/CircleOptimizerUtils.cpp
+++ b/compiler/luci/pass/src/CircleOptimizerUtils.cpp
@@ -16,6 +16,8 @@
 
 #include "CircleOptimizerUtils.h"
 
+#include <luci/IR/CircleNode.h>
+
 namespace luci
 {
 
@@ -84,6 +86,15 @@ QuantizationGranularity str_to_granularity(const std::string &str)
     return QuantizationGranularity::ChannelWise;
 
   throw std::runtime_error("Quantization granularity must be either 'layer' or 'channel'");
+}
+
+bool has_dynamic_shape(const loco::Node *node)
+{
+  const auto circle_node = loco::must_cast<const luci::CircleNode *>(node);
+  for (uint32_t i = 0; i < circle_node->rank(); ++i)
+    if (!circle_node->dim(i).known())
+      return true;
+  return false;
 }
 
 } // namespace luci

--- a/compiler/luci/pass/src/CircleOptimizerUtils.h
+++ b/compiler/luci/pass/src/CircleOptimizerUtils.h
@@ -36,6 +36,8 @@ loco::DataType str_to_dtype(const std::string &);
 
 QuantizationGranularity str_to_granularity(const std::string &);
 
+bool has_dynamic_shape(const loco::Node *node);
+
 } // namespace luci
 
 #endif // __LUCI_CIRCLE_OPTIMIZER_UTILS_H__

--- a/compiler/luci/pass/src/ConvertNCHWToNHWCPass.cpp
+++ b/compiler/luci/pass/src/ConvertNCHWToNHWCPass.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "luci/Pass/ConvertNCHWToNHWCPass.h"
+#include "CircleOptimizerUtils.h"
 
 #include <luci/IR/CircleNodes.h>
 #include <luci/IR/CircleNodeVisitor.h>
@@ -65,15 +66,6 @@ DataFormat get_data_format(loco::Node *node)
 }
 
 bool has_data_format(loco::Node *node) { return node->annot<DataFormatAnnotation>() != nullptr; }
-
-bool has_dynamic_shape(const loco::Node *node)
-{
-  const auto circle_node = loco::must_cast<const luci::CircleNode *>(node);
-  for (uint32_t i = 0; i < circle_node->rank(); ++i)
-    if (!circle_node->dim(i).known())
-      return true;
-  return false;
-}
 
 luci::CircleTranspose *create_4d_transpose(luci::CircleNode *node,
                                            const std::vector<int32_t> indices)


### PR DESCRIPTION
`has_dynamic_shape` in `ConvertNCHWtoNHWCPass` is for determining whether a node has dynamic shape.
Since some of other passes also needs this function, this commit will make it as public.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>