### PR TITLE
[luci] Update own_shape to consider unknown dimension

### DIFF
--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -56,7 +56,15 @@ loco::TensorShape own_shape(const luci::CircleNode *node)
   loco::TensorShape shape;
   shape.rank(node->rank());
   for (uint32_t r = 0; r < node->rank(); ++r)
-    shape.dim(r) = loco::Dimension(node->dim(r).value());
+  {
+    // Shape inference rules in this file did not consider unknown dimension.
+    // If some node has unknown dimension, 0 is inserted and wrong shape
+    // inference was done as a result.
+    // To fix this, new shape inference algorithm is being implemented.
+    // Until new inference algorithm is fully implemented, unknown dimension
+    // would be represented as 1 along with TFLite expression.
+    shape.dim(r) = node->dim(r).known() ? node->dim(r).value() : 1;
+  }
   return shape;
 }
 


### PR DESCRIPTION
Parent Issue : #5501

Until now, `own_shape` did not consider unknown dimension.
As a result, if some node has unknown dimension, 0 is inserted.
This commit will fix it.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>