### PR TITLE
[luci] Remove shape/dtype setting in FusePreActivationBatchNormPass

### DIFF
--- a/compiler/luci/pass/src/FusePreActivationBatchNormPass.cpp
+++ b/compiler/luci/pass/src/FusePreActivationBatchNormPass.cpp
@@ -283,12 +283,6 @@ bool update_conv_bias_with_beta(luci::CircleConv2D *conv, const luci::CircleCons
 luci::CircleSub *insert_sub(luci::CircleNode *pred, luci::CircleConst *beta)
 {
   auto sub = pred->graph()->nodes()->create<luci::CircleSub>();
-  sub->dtype(loco::DataType::FLOAT32);
-  sub->rank(pred->rank());
-  for (uint32_t i = 0; i < sub->rank(); i++)
-  {
-    sub->dim(i).set(pred->dim(i).value());
-  }
   sub->fusedActivationFunction(luci::FusedActFunc::NONE);
 
   loco::replace(pred).with(sub);


### PR DESCRIPTION
Parent Issue : #5501

Until now, shape setting for `CircleSub` was done in `insert_sub` function.
However, this is redundant and inefficient because of following reasons.

- `ShapeInferencePass` exists exactly for the same purpose and more precise.
- If there are some unknown dimension in `pred`, this is not handled.

Therefore this commit will remove it.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>