### PR TITLE
[onert] Remove LowerInfo get/setters

### DIFF
--- a/runtime/onert/backend/acl_cl/BackendContext.cc
+++ b/runtime/onert/backend/acl_cl/BackendContext.cc
@@ -63,11 +63,11 @@ void BackendContext::planTensors(const std::vector<onert::ir::OperationIndex> &o
   {
     const auto &obj = graph()->operands().at(ind);
     const auto &li = lower_info.operand.at(ind);
-    if (li->def_factors().getOnlyElement().backend() != backend())
+    if (li.def_factors().getOnlyElement().backend() != backend())
       continue;
 
     // Ignore unused tensor
-    if (li->def_factors().size() == 0 && li->use_factors().size() == 0)
+    if (li.def_factors().size() == 0 && li.use_factors().size() == 0)
     {
       VERBOSE(planTensors) << "Operand " << ind << " will not be used. no more process."
                            << std::endl;
@@ -80,7 +80,7 @@ void BackendContext::planTensors(const std::vector<onert::ir::OperationIndex> &o
     if (obj.isConstant())
       constants.append(ind);
 
-    auto factor = li->def_factors().getOnlyElement();
+    auto factor = li.def_factors().getOnlyElement();
     if (!tensor_builder->isRegistered(ind))
     {
       // These tensors do not exist in any operation (No use and def)
@@ -141,8 +141,8 @@ void BackendContext::planTensors(const std::vector<onert::ir::OperationIndex> &o
           // The variable tensor with buffer is not supported yet
           assert(operand.data() == nullptr);
           assert(operand.getUses().size() == 1 && !operand.getDef().valid());
-          assert(lower_info.operand.at(ind)->def_factors().size() == 1 &&
-                 lower_info.operand.at(ind)->use_factors().size() == 1);
+          assert(lower_info.operand.at(ind).def_factors().size() == 1 &&
+                 lower_info.operand.at(ind).use_factors().size() == 1);
           assert(uses_map[ind] == 1 && def_map[ind] == 0);
           tensor_builder->notifyFirstUse(ind);
         }
@@ -210,7 +210,7 @@ ITensorRegistry *BackendContext::genTensors(const std::vector<onert::ir::Operati
             find(operand_list().begin(), operand_list().end(), index) != operand_list().end())
         {
           const auto &operand_lower_info =
-            lower_info.operand.at(index)->def_factors().getOnlyElement();
+            lower_info.operand.at(index).def_factors().getOnlyElement();
 
           // E.g., permute (CPU) -> tensor A -> MaxPool2D(acl_cl)
           // op.getOutputs() of permute (CPU) returns tensor A

--- a/runtime/onert/backend/acl_neon/BackendContext.cc
+++ b/runtime/onert/backend/acl_neon/BackendContext.cc
@@ -63,11 +63,11 @@ void BackendContext::planTensors(const std::vector<onert::ir::OperationIndex> &o
   {
     const auto &obj = graph()->operands().at(ind);
     const auto &li = lower_info.operand.at(ind);
-    if (li->def_factors().getOnlyElement().backend() != backend())
+    if (li.def_factors().getOnlyElement().backend() != backend())
       continue;
 
     // Ignore unused tensor
-    if (li->def_factors().size() == 0 && li->use_factors().size() == 0)
+    if (li.def_factors().size() == 0 && li.use_factors().size() == 0)
     {
       VERBOSE(planTensors) << "Operand " << ind << " will not be used. no more process."
                            << std::endl;
@@ -80,7 +80,7 @@ void BackendContext::planTensors(const std::vector<onert::ir::OperationIndex> &o
     if (obj.isConstant())
       constants.append(ind);
 
-    auto factor = li->def_factors().getOnlyElement();
+    auto factor = li.def_factors().getOnlyElement();
     if (!tensor_builder->isRegistered(ind))
     {
       // These tensors do not exist in any operation (No use and def)
@@ -141,8 +141,8 @@ void BackendContext::planTensors(const std::vector<onert::ir::OperationIndex> &o
           // The variable tensor with buffer is not supported yet
           assert(operand.data() == nullptr);
           assert(operand.getUses().size() == 1 && !operand.getDef().valid());
-          assert(lower_info.operand.at(ind)->def_factors().size() == 1 &&
-                 lower_info.operand.at(ind)->use_factors().size() == 1);
+          assert(lower_info.operand.at(ind).def_factors().size() == 1 &&
+                 lower_info.operand.at(ind).use_factors().size() == 1);
           assert(uses_map[ind] == 1 && def_map[ind] == 0);
           tensor_builder->notifyFirstUse(ind);
         }
@@ -210,7 +210,7 @@ ITensorRegistry *BackendContext::genTensors(const std::vector<onert::ir::Operati
             find(operand_list().begin(), operand_list().end(), index) != operand_list().end())
         {
           const auto &operand_lower_info =
-            lower_info.operand.at(index)->def_factors().getOnlyElement();
+            lower_info.operand.at(index).def_factors().getOnlyElement();
 
           // E.g., permute (CPU) -> tensor A -> MaxPool2D(acl_cl)
           // op.getOutputs() of permute (CPU) returns tensor A

--- a/runtime/onert/core/include/backend/cpu_common/BackendContextHelpers.h
+++ b/runtime/onert/core/include/backend/cpu_common/BackendContextHelpers.h
@@ -54,7 +54,7 @@ void planTensors(const T_BackendContext &ctx, const std::vector<onert::ir::Opera
     if (model_io.contains(ind))
       continue;
     const auto &obj = graph->operands().at(ind);
-    const auto &li = lower_info.operand.at(ind);
+    const auto &li = lower_info.operand.getRawPtr(ind);
     if (li->def_factors().getOnlyElement().backend() != ctx.backend())
       continue;
 
@@ -135,8 +135,8 @@ void planTensors(const T_BackendContext &ctx, const std::vector<onert::ir::Opera
           // The variable tensor with buffer is not supported yet
           assert(operand.data() == nullptr);
           assert(operand.getUses().size() == 1 && !operand.getDef().valid());
-          assert(lower_info.operand.at(ind)->def_factors().size() == 1 &&
-                 lower_info.operand.at(ind)->use_factors().size() == 1);
+          assert(lower_info.operand.at(ind).def_factors().size() == 1 &&
+                 lower_info.operand.at(ind).use_factors().size() == 1);
           assert(uses_map[ind] == 1 && def_map[ind] == 0);
           tensor_builder->notifyFirstUse(ind);
         }
@@ -211,7 +211,8 @@ ITensorRegistry *genTensors(T_BackendContext &ctx,
       }
       return ir::Layout::UNKNOWN;
     }();
-    const auto &permute_factor = lower_info.operand.at(index)->def_factors().getOnlyElement();
+    const auto &permute_factor =
+      lower_info.operand.getRawPtr(index)->def_factors().getOnlyElement();
     if (permute_factor.backend() != ctx.backend())
       continue;
     const auto backend_layout = permute_factor.layout();

--- a/runtime/onert/core/include/compiler/GraphLowerInfo.h
+++ b/runtime/onert/core/include/compiler/GraphLowerInfo.h
@@ -22,7 +22,7 @@
 
 #include "compiler/OperandLowerInfo.h"
 #include "compiler/OperationLowerInfo.h"
-#include "ir/OperandIndexMap.h"
+#include "util/ObjectManager.h"
 #include "ir/Index.h"
 
 namespace onert
@@ -32,8 +32,8 @@ namespace compiler
 
 struct GraphLowerInfo
 {
-  std::unordered_map<ir::OperationIndex, std::unique_ptr<OperationLowerInfo>> operation;
-  ir::OperandIndexMap<std::unique_ptr<OperandLowerInfo>> operand;
+  util::ObjectManager<ir::OperationIndex, OperationLowerInfo> operation;
+  util::ObjectManager<ir::OperandIndex, OperandLowerInfo> operand;
 };
 
 } // namespace compiler

--- a/runtime/onert/core/include/compiler/LoweredGraph.h
+++ b/runtime/onert/core/include/compiler/LoweredGraph.h
@@ -39,16 +39,8 @@ public:
 
   ir::Graph &graph() { return _graph; }
   const ir::Graph &graph() const { return _graph; }
-  const compiler::GraphLowerInfo *getLowerInfo() const { return &_lower_info_map; }
-  const compiler::OperationLowerInfo *getLowerInfo(const ir::OperationIndex &op_ind) const;
-  void setLowerInfo(const ir::OperationIndex &op_ind,
-                    std::unique_ptr<compiler::OperationLowerInfo> &&lower_info);
-  void removeLowerInfo(const ir::OperationIndex &op_ind);
-  const compiler::OperandLowerInfo *getLowerInfo(const ir::OperandIndex &index) const;
-  compiler::OperandLowerInfo *getLowerInfo(const ir::OperandIndex &index);
-  void setLowerInfo(const ir::OperandIndex &index,
-                    std::unique_ptr<compiler::OperandLowerInfo> &&lower_info);
-  void removeLowerInfo(const ir::OperandIndex &index);
+  const compiler::GraphLowerInfo &lower_info() const { return _lower_info_map; }
+  compiler::GraphLowerInfo &lower_info() { return _lower_info_map; }
   std::shared_ptr<ir::OperationIndexMap<int64_t>> indexed_ranks() { return _indexed_ranks; }
 
   void setHasDynamicTensor(ir::OperationIndex ind, bool val)

--- a/runtime/onert/core/include/util/ObjectManager.h
+++ b/runtime/onert/core/include/util/ObjectManager.h
@@ -70,7 +70,6 @@ public:
       _objects.emplace(gen_index, std::move(object));
     return gen_index;
   }
-
   /**
    * @brief Put the object in the container with a newly assigned index.
    *
@@ -86,7 +85,22 @@ public:
       _objects.emplace(gen_index, std::move(object));
     return gen_index;
   }
-
+  /**
+   * @brief Set the object in the container with given index.
+   *
+   * If the index is Undefined, it will fail.
+   * If the index is already taken, it will overwrite the content.
+   *
+   * @param[in] object Object to be pushed
+   * @param[in] index Index associated with the object
+   * @return @c index if successful, an Undefined index otherwise
+   */
+  Index set(Index index, std::unique_ptr<Object> &&object)
+  {
+    if (index.valid())
+      _objects[index] = std::move(object);
+    return index;
+  }
   /**
    * @brief Remove the object that is associated with the given index
    *
@@ -98,6 +112,8 @@ public:
   /**
    * @brief Get the object that is associated with the given index
    *
+   * If such object does not exist, it will throw @c std::out_of_range
+   *
    * @param[in] index Index of the object to be returned
    * @return Object
    */
@@ -105,10 +121,44 @@ public:
   /**
    * @brief Get the object that is associated with the given index
    *
+   * If such object does not exist, it will throw @c std::out_of_range
+   *
    * @param[in] index Index of the object to be returned
    * @return Object
    */
   Object &at(const Index &index) { return *(_objects.at(index)); }
+  /**
+   * @brief Get the object that is associated with the given index
+   *
+   * If such object does not exist, it will return `nullptr`
+   *
+   * @param[in] index Index of the object to be returned
+   * @return Object
+   */
+  const Object *getRawPtr(const Index &index) const
+  {
+    auto itr = _objects.find(index);
+    if (itr == _objects.end())
+      return nullptr;
+    else
+    {
+      assert(itr->second != nullptr);
+      return itr->second.get();
+    }
+  }
+  /**
+   * @brief Get the object that is associated with the given index
+   *
+   * If such object does not exist, it will return `nullptr`
+   *
+   * @param[in] index Index of the object to be returned
+   * @return Object The found object
+   */
+  Object *getRawPtr(const Index &index)
+  {
+    return const_cast<Object *>(
+      const_cast<const ObjectManager<Index, Object> *>(this)->getRawPtr(index));
+  }
   /**
    * @brief Get the object that is associated with the given index
    *

--- a/runtime/onert/core/src/compiler/pass/ConstantInsertionPass.cc
+++ b/runtime/onert/core/src/compiler/pass/ConstantInsertionPass.cc
@@ -29,7 +29,7 @@ namespace pass
 
 void ConstantInsertionPass::callback(const ir::OperationIndex &node_index, ir::Operation &node)
 {
-  const auto op_lower_info = _lowered_graph.getLowerInfo(node_index);
+  const auto op_lower_info = _lowered_graph.lower_info().operation.getRawPtr(node_index);
   const auto backend = op_lower_info->backend();
   const auto layout = op_lower_info->layout();
   const auto factor = PermuteFactor{backend, layout};

--- a/runtime/onert/core/src/compiler/pass/ConstantLoweringPass.cc
+++ b/runtime/onert/core/src/compiler/pass/ConstantLoweringPass.cc
@@ -20,6 +20,7 @@
 #include <ir/Graph.h>
 #include <compiler/PermuteFactor.h>
 #include <util/Utils.h>
+#include "util/logging.h"
 
 namespace onert
 {
@@ -30,7 +31,7 @@ namespace pass
 
 void ConstantLoweringPass::callback(const ir::OperationIndex &node_index, ir::Operation &node)
 {
-  const auto op_lower_info = _lowered_graph.getLowerInfo(node_index);
+  const auto op_lower_info = _lowered_graph.lower_info().operation.getRawPtr(node_index);
   const auto backend = op_lower_info->backend();
   const auto layout = op_lower_info->layout();
   const auto factor = PermuteFactor{backend, layout};
@@ -43,9 +44,10 @@ void ConstantLoweringPass::callback(const ir::OperationIndex &node_index, ir::Op
     {
       // All constant operand are already assinged at each backend by ContantInsertionPass. So a
       // constant has `def` and `use` as the same PermuteFactor
-      _lowered_graph.setLowerInfo(input, std::make_unique<compiler::OperandLowerInfo>());
-      _lowered_graph.getLowerInfo(input)->addDefPermuteFactor(factor);
-      _lowered_graph.getLowerInfo(input)->addUsePermuteFactor(factor);
+      auto operand_li = std::make_unique<compiler::OperandLowerInfo>();
+      operand_li->addDefPermuteFactor(factor);
+      operand_li->addUsePermuteFactor(factor);
+      _lowered_graph.lower_info().operand.set(input, std::move(operand_li));
     }
   }
 }

--- a/runtime/onert/core/src/compiler/pass/PermutationEliminationPass.cc
+++ b/runtime/onert/core/src/compiler/pass/PermutationEliminationPass.cc
@@ -39,8 +39,9 @@ void PermutationEliminationPass::visit(const ir::operation::Permute &node)
 
   // Check if two tensors are both portable if not, we can't eliminate the node
   {
-    auto in_def_factor = _lowered_graph.getLowerInfo(in_operand)->def_factors().getOnlyElement();
-    auto out_def_factor = _lowered_graph.getLowerInfo(out_operand)->def_factors().getOnlyElement();
+    auto &operand_li_map = _lowered_graph.lower_info().operand;
+    auto in_def_factor = operand_li_map.getRawPtr(in_operand)->def_factors().getOnlyElement();
+    auto out_def_factor = operand_li_map.getRawPtr(out_operand)->def_factors().getOnlyElement();
 
     auto in_config = in_def_factor.backend()->config();
     auto out_config = out_def_factor.backend()->config();

--- a/runtime/onert/core/src/dumper/dot/DotDumper.cc
+++ b/runtime/onert/core/src/dumper/dot/DotDumper.cc
@@ -103,7 +103,7 @@ void DotDumper::dump(const std::string &tag)
         std::string fillcolor = "";
         if (_lowered_graph)
         {
-          auto lower_info = _lowered_graph->getLowerInfo(index);
+          auto lower_info = _lowered_graph->lower_info().operand.getRawPtr(index);
           const auto &def_factors = lower_info->def_factors();
           if (def_factors.size() > 0)
           {
@@ -150,7 +150,7 @@ void DotDumper::dump(const std::string &tag)
   if (_lowered_graph)
   {
     _graph.operations().iterate([&](const ir::OperationIndex &index, const ir::Operation &) {
-      const auto lower_info = _lowered_graph->getLowerInfo(index);
+      const auto lower_info = _lowered_graph->lower_info().operation.getRawPtr(index);
       if (lower_info)
       {
         auto fillcolor = backend_to_fillcolor(lower_info->backend());

--- a/runtime/onert/core/src/exec/DataflowExecutor.cc
+++ b/runtime/onert/core/src/exec/DataflowExecutor.cc
@@ -153,8 +153,7 @@ void DataflowExecutor::executeImpl()
     VERBOSE(DataflowExecutor) << "Run job " << job_index << std::endl;
 
     auto op_ind = _job_to_op[job_index];
-    const backend::Backend *backend =
-      _lowered_graph->getLowerInfo()->operation.at(op_ind)->backend();
+    const backend::Backend *backend = _lowered_graph->lower_info().operation.at(op_ind).backend();
 
     _subject.notifyJobBegin(this, profiling_subg_index, op_ind, backend);
 

--- a/runtime/onert/core/src/exec/ParallelExecutor.cc
+++ b/runtime/onert/core/src/exec/ParallelExecutor.cc
@@ -77,10 +77,10 @@ void ParallelExecutor::executeImpl()
   // Init scheduler
   // TODO Consider to have distinct backend set in GraphLowerInfo
   BackendSet backends;
-  for (auto &itr : _lowered_graph->getLowerInfo()->operation)
-  {
-    backends.add(itr.second->backend());
-  }
+  _lowered_graph->lower_info().operation.iterate(
+    [&](const ir::OperationIndex &, const compiler::OperationLowerInfo &lower_info) {
+      backends.add(lower_info.backend());
+    });
   _scheduler = std::make_unique<ParallelScheduler>(backends);
 
   assert(noWaitingJobs());
@@ -127,7 +127,7 @@ void ParallelExecutor::executeImpl()
 
     auto job_index = job->index();
     auto op_ind = _job_to_op[job_index];
-    auto backend = _lowered_graph->getLowerInfo()->operation.at(op_ind)->backend();
+    auto backend = _lowered_graph->lower_info().operation.at(op_ind).backend();
     auto setup = [&, op_ind, backend]() {
       _subject.notifyJobBegin(this, profiling_subg_index, op_ind, backend);
     };


### PR DESCRIPTION
This commit removes all LowerInfo get/setters except `GraphLowerInfo`.
With those methods, there were two ways of getting or setting
Operand/Operation LowerInfo.

- Get `GraphLowerInfo` and access with this object
- Use get/setter methods (`LoweredGraph::getLowerInfo(...)` overloads)

I felt like the second ones are redundant wrappers, so this commit
removes those in order to force just one way to do things.

Also this commit contains adding some methods to `util::ObjectManager`.

- `set` : Insert or assign
- `getRawPtr` : get the raw pointer of the object

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>