### PR TITLE
[luci] Enable new shape/type inference pass

### DIFF
--- a/compiler/luci/export/src/Optimize.cpp
+++ b/compiler/luci/export/src/Optimize.cpp
@@ -19,6 +19,8 @@
 
 #include <luci/Pass/ShapeInferencePass.h>
 #include <luci/Pass/TypeInferencePass.h>
+#include <luci/Pass/CircleShapeInferencePass.h>
+#include <luci/Pass/CircleTypeInferencePass.h>
 
 #include <logo/Phase.h>
 
@@ -34,6 +36,8 @@ void optimize(loco::Graph *g)
     // prepare type and shape before optimization
     phase.emplace_back(std::make_unique<TypeInferencePass>());
     phase.emplace_back(std::make_unique<ShapeInferencePass>());
+    phase.emplace_back(std::make_unique<luci::CircleShapeInferencePass>());
+    phase.emplace_back(std::make_unique<luci::CircleTypeInferencePass>());
 
     // TODO add more optimization passes (with a knob)
   }

--- a/compiler/luci/pass/src/CircleOptimizer.cpp
+++ b/compiler/luci/pass/src/CircleOptimizer.cpp
@@ -43,6 +43,8 @@
 
 #include "luci/Pass/ShapeInferencePass.h"
 #include "luci/Pass/TypeInferencePass.h"
+#include "luci/Pass/CircleShapeInferencePass.h"
+#include "luci/Pass/CircleTypeInferencePass.h"
 
 // Following passes will be removed after refactoring is finished
 #include "luci/Pass/MigrateLegacyShapeDtypePass.h"
@@ -146,6 +148,8 @@ void CircleOptimizer::optimize(luci::Module *m) const
   // Following passes are needed everytime when other passes create new node or modify some nodes.
   phase.emplace_back(std::make_unique<luci::ShapeInferencePass>());
   phase.emplace_back(std::make_unique<luci::TypeInferencePass>());
+  phase.emplace_back(std::make_unique<luci::CircleShapeInferencePass>());
+  phase.emplace_back(std::make_unique<luci::CircleTypeInferencePass>());
 
   if (_options->query(Options::Algorithm::FuseBCQ))
   {
@@ -171,6 +175,8 @@ void CircleOptimizer::optimize(loco::Graph *g) const
   // Following passes are needed everytime when other passes create new node or modify some nodes.
   phase.emplace_back(std::make_unique<luci::TypeInferencePass>());
   phase.emplace_back(std::make_unique<luci::ShapeInferencePass>());
+  phase.emplace_back(std::make_unique<luci::CircleShapeInferencePass>());
+  phase.emplace_back(std::make_unique<luci::CircleTypeInferencePass>());
 
   if (_options->query(Options::Algorithm::ResolveCustomOpAdd))
   {
@@ -329,6 +335,8 @@ void CircleOptimizer::quantize(loco::Graph *g) const
 
     phase.emplace_back(std::make_unique<luci::ShapeInferencePass>());
     phase.emplace_back(std::make_unique<luci::TypeInferencePass>());
+    phase.emplace_back(std::make_unique<luci::CircleShapeInferencePass>());
+    phase.emplace_back(std::make_unique<luci::CircleTypeInferencePass>());
     phase.emplace_back(std::make_unique<logo::RemoveDeadNodeWithQueryPass>());
 
     ProgressReporter prog(g, logo::PhaseStrategy::Saturate);
@@ -363,6 +371,8 @@ void CircleOptimizer::quantize(loco::Graph *g) const
   // Do Shape/Type inference
   phase.emplace_back(std::make_unique<luci::ShapeInferencePass>());
   phase.emplace_back(std::make_unique<luci::TypeInferencePass>());
+  phase.emplace_back(std::make_unique<luci::CircleShapeInferencePass>());
+  phase.emplace_back(std::make_unique<luci::CircleTypeInferencePass>());
 
   ProgressReporter prog(g, logo::PhaseStrategy::Saturate);
   logo::PhaseRunner<logo::PhaseStrategy::Saturate> phase_runner{g};

--- a/compiler/luci/tester/src/ReadTester.cpp
+++ b/compiler/luci/tester/src/ReadTester.cpp
@@ -20,6 +20,8 @@
 #include <luci/Service/Validate.h>
 #include <luci/Pass/ShapeInferencePass.h>
 #include <luci/Pass/TypeInferencePass.h>
+#include <luci/Pass/CircleShapeInferencePass.h>
+#include <luci/Pass/CircleTypeInferencePass.h>
 
 // Following passes will be removed after refactoring is finished
 #include <luci/Pass/MigrateLegacyShapeDtypePass.h>
@@ -95,6 +97,16 @@ int entry(int argc, char **argv)
     }
     {
       luci::TypeInferencePass pass;
+      while (pass.run(graph) == true)
+        ;
+    }
+    {
+      luci::CircleShapeInferencePass pass;
+      while (pass.run(graph) == true)
+        ;
+    }
+    {
+      luci::CircleTypeInferencePass pass;
       while (pass.run(graph) == true)
         ;
     }

--- a/compiler/luci/tester/src/WriteTester.cpp
+++ b/compiler/luci/tester/src/WriteTester.cpp
@@ -19,6 +19,8 @@
 #include <luci/Importer.h>
 #include <luci/Pass/ShapeInferencePass.h>
 #include <luci/Pass/TypeInferencePass.h>
+#include <luci/Pass/CircleShapeInferencePass.h>
+#include <luci/Pass/CircleTypeInferencePass.h>
 #include <luci/Service/Validate.h>
 #include <luci/CircleExporter.h>
 #include <oops/InternalExn.h>
@@ -139,6 +141,16 @@ int entry(int argc, char **argv)
     }
     {
       luci::TypeInferencePass pass;
+      while (pass.run(graph) == true)
+        ;
+    }
+    {
+      luci::CircleShapeInferencePass pass;
+      while (pass.run(graph) == true)
+        ;
+    }
+    {
+      luci::CircleTypeInferencePass pass;
       while (pass.run(graph) == true)
         ;
     }


### PR DESCRIPTION
Parent Issue : #5501

This commit will enable new shape/type inference pass in `luci`.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>