### PR TITLE
[one-cmds] Fix one-prepare-venv for onnx-tf

### DIFF
--- a/compiler/one-cmds/one-prepare-venv
+++ b/compiler/one-cmds/one-prepare-venv
@@ -57,7 +57,7 @@ python -m pip --default-timeout=1000 --trusted-host pypi.org --trusted-host file
   install torch==1.7.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
 
 # Provide install of custom onnx-tf
-if [ -n ${EXT_ONNX_TF_WHL} ]; then
+if [ -n "${EXT_ONNX_TF_WHL}" ]; then
   python -m pip --default-timeout=1000 install ${EXT_ONNX_TF_WHL}
 else
   python -m pip --default-timeout=1000 --trusted-host pypi.org --trusted-host files.pythonhost.org \


### PR DESCRIPTION
This will fix one-prepare-venv for onnx-tf where current variable check is not correct.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>