### PR TITLE
[onert] Fix StatelessRandomUniform data type

### DIFF
--- a/compute/cker/include/cker/operation/StatelessRandomUniform.h
+++ b/compute/cker/include/cker/operation/StatelessRandomUniform.h
@@ -72,8 +72,8 @@ void Fill(random::PhiloxRandom random, Tensor *output)
                                                     Distribution());
 }
 
-inline void StatelessRandomUniform(const Shape &shape_shape, const int *shape_data,
-                                   const Shape &seed_shape, const int *seed_data,
+inline void StatelessRandomUniform(const Shape &shape_shape, const int32_t *shape_data,
+                                   const Shape &seed_shape, const int32_t *seed_data,
                                    const Shape &output_shape, float *output_data)
 {
   Tensor shape_t;

--- a/runtime/onert/backend/cpu/ops/StatelessRandomUniformLayer.cc
+++ b/runtime/onert/backend/cpu/ops/StatelessRandomUniformLayer.cc
@@ -43,8 +43,8 @@ void StatelessRandomUniformLayer::configure(const IPortableTensor *shape,
 
 void StatelessRandomUniformLayer::StatelessRandomUniformFloat32()
 {
-  nnfw::cker::StatelessRandomUniform(getShape(_shape), getBuffer<int>(_shape), getShape(_seed),
-                                     getBuffer<int>(_seed), getShape(_output),
+  nnfw::cker::StatelessRandomUniform(getShape(_shape), getBuffer<int32_t>(_shape), getShape(_seed),
+                                     getBuffer<int32_t>(_seed), getShape(_output),
                                      getBuffer<float>(_output));
 }
 

--- a/runtime/onert/core/src/ir/OperationValidator.cc
+++ b/runtime/onert/core/src/ir/OperationValidator.cc
@@ -467,6 +467,17 @@ void OperationValidator::visit(const operation::SquaredDifference &node)
   OP_REQUIRES(isSameType(lhs_index, rhs_index));
 }
 
+void OperationValidator::visit(const operation::StatelessRandomUniform &node)
+{
+  const auto output_index{node.getOutputs().at(0)};
+  const auto shape_index{node.getInputs().at(operation::StatelessRandomUniform::Input::SHAPE)};
+  const auto seed_index{node.getInputs().at(operation::StatelessRandomUniform::Input::SEED)};
+
+  OP_REQUIRES(isValidType(output_index, DataType::FLOAT32));
+  OP_REQUIRES(isValidType(shape_index, DataType::INT32));
+  OP_REQUIRES(isValidType(seed_index, DataType::INT32));
+}
+
 void OperationValidator::visit(const operation::StridedSlice &node)
 {
   const auto output_index{node.getOutputs().at(0)};

--- a/runtime/onert/core/src/ir/OperationValidator.h
+++ b/runtime/onert/core/src/ir/OperationValidator.h
@@ -74,6 +74,7 @@ public:
   void visit(const operation::SpaceToDepth &node) override;
   void visit(const operation::Split &node) override;
   void visit(const operation::SquaredDifference &node) override;
+  void visit(const operation::StatelessRandomUniform &node) override;
   void visit(const operation::StridedSlice &node) override;
   void visit(const operation::TransposeConv &node) override;
   void visit(const operation::Unpack &node) override;


### PR DESCRIPTION
- Check input(shape, seed) data type
- Use int32_t intead of int on cpu kernel to prevent bug

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>