### PR TITLE
[onert] Refine LoweredGraph ctor

### DIFF
--- a/runtime/onert/core/include/compiler/LoweredGraph.h
+++ b/runtime/onert/core/include/compiler/LoweredGraph.h
@@ -54,11 +54,7 @@ public:
   }
 
 private:
-  void makeOperationLowerInfo(
-    ir::OperandIndexMap<std::unique_ptr<compiler::OperandLowerInfo>> &operands_lower_info,
-    const compiler::BackendResolver &backend_resolver);
-  void manipulateLowerInfo(
-    ir::OperandIndexMap<std::unique_ptr<compiler::OperandLowerInfo>> &operands_lower_info);
+  void makeLowerInfo(const compiler::BackendResolver &backend_resolver);
   void dumpLowerInfo();
 
 private:


### PR DESCRIPTION
- Remove 2 private methods that were called by the constructor only
    - And those are embedded in the constructor
- Remove `operands_lower_info` which was a temporary holder
- Remove some redundant code
- Move the mandatory passes(that were run in the middle) to the end
  (Now all 4 mandatory passes run at the same point)

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>