### PR TITLE
[onert] Fix acl-neon backend softmax

### DIFF
--- a/runtime/onert/backend/acl_neon/KernelGenerator.cc
+++ b/runtime/onert/backend/acl_neon/KernelGenerator.cc
@@ -987,9 +987,10 @@ void KernelGenerator::visit(const ir::operation::Softmax &node)
     acl_common::disableDimCorrection(input_tensor);
   }
 
+  // NOTE NESoftmaxLayer's default axis is -1
   auto fn = acl_common::generateLayer<arm_compute::NESoftmaxLayer>(
     _tensor_builder->acl_tensor_manager()->internal_buffer_manager(), input_tensor->handle(),
-    output_tensor->handle(), beta);
+    output_tensor->handle(), beta, 1);
 
   // Revert disabling applied dim_correction
   if (input_tensor->getShape().dim(0) == 1)

--- a/tests/nnfw_api/src/one_op_tests/Softmax.cc
+++ b/tests/nnfw_api/src/one_op_tests/Softmax.cc
@@ -57,8 +57,7 @@ TEST_P(SoftmaxVariation, Test)
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
   _context->addTestCase(param.tcd);
-  // TODO Enable acl-neon test
-  _context->setBackends({"cpu", "acl_cl"});
+  _context->setBackends({"cpu", "acl_neon", "acl_cl"});
 
   SUCCEED();
 }


### PR DESCRIPTION
Fix test fail by calling acl-neon backend disableDimCorrection call for softmax operation

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>