### PR TITLE
[onert] Introduce zero_points and scales in ITensor

### DIFF
--- a/runtime/onert/backend/acl_common/IACLTensor.cc
+++ b/runtime/onert/backend/acl_common/IACLTensor.cc
@@ -60,6 +60,16 @@ int32_t IACLTensor::data_zero_point() const
   return info()->quantization_info().uniform().offset;
 }
 
+const std::vector<float> &IACLTensor::data_scales() const
+{
+  throw std::runtime_error("IACLTensor::data_scales() is not supported.");
+}
+
+const std::vector<int32_t> &IACLTensor::data_zero_points() const
+{
+  throw std::runtime_error("IACLTensor::data_zero_points() is not supported.");
+}
+
 } // namespace acl_common
 } // namespace backend
 } // namespace onert

--- a/runtime/onert/backend/acl_common/IACLTensor.h
+++ b/runtime/onert/backend/acl_common/IACLTensor.h
@@ -53,6 +53,8 @@ public:
   ir::DataType data_type() const final;
   float data_scale() const override;
   int32_t data_zero_point() const override;
+  const std::vector<float> &data_scales() const override;
+  const std::vector<int32_t> &data_zero_points() const override;
   bool has_padding() const override { return info()->has_padding(); }
   bool is_dynamic() const override { return false; }
   ir::Shape getShape() const override

--- a/runtime/onert/core/include/backend/IPortableTensor.h
+++ b/runtime/onert/core/include/backend/IPortableTensor.h
@@ -43,6 +43,13 @@ public:
   virtual ~IPortableTensor();
   virtual const ir::Sparsity *sparsity() const { return nullptr; }
   const ir::OperandInfo &get_info() const { return _info; }
+  float data_scale() const override { return _info.typeInfo().scale(); }
+  int32_t data_zero_point() const override { return _info.typeInfo().zero_point(); }
+  const std::vector<float> &data_scales() const override { return _info.typeInfo().scales(); }
+  const std::vector<int32_t> &data_zero_points() const override
+  {
+    return _info.typeInfo().zero_points();
+  }
 
 public:
   bool has_padding() const final { return false; }

--- a/runtime/onert/core/include/backend/ITensor.h
+++ b/runtime/onert/core/include/backend/ITensor.h
@@ -47,6 +47,8 @@ public:
   virtual ir::DataType data_type() const = 0;
   virtual float data_scale() const = 0;
   virtual int32_t data_zero_point() const = 0;
+  virtual const std::vector<float> &data_scales() const = 0;
+  virtual const std::vector<int32_t> &data_zero_points() const = 0;
   virtual bool has_padding() const = 0;
   virtual void access(const std::function<void(ITensor &tensor)> &fn) = 0;
 

--- a/runtime/onert/core/include/backend/cpu_common/Tensor.h
+++ b/runtime/onert/core/include/backend/cpu_common/Tensor.h
@@ -90,8 +90,6 @@ public:
   size_t calcOffset(const ir::Coordinates &coords) const override;
   ir::Layout layout() const override { return _layout; }
   ir::DataType data_type() const override { return _info.typeInfo().type(); }
-  float data_scale() const override { return _info.typeInfo().scale(); }
-  int32_t data_zero_point() const override { return _info.typeInfo().zero_point(); }
   bool is_constant() const override { return _info.isConstant(); }
   bool is_dynamic() const override { return _info.isDynamic(); }
   void set_dynamic() override { _info.setDynamic(); }

--- a/runtime/onert/core/include/ir/TypeInfo.h
+++ b/runtime/onert/core/include/ir/TypeInfo.h
@@ -55,11 +55,13 @@ public:
     assert(_quant.scales.size() == 1);
     return _quant.scales[0];
   }
+  const std::vector<float> &scales() const { return _quant.scales; }
   int32_t zero_point() const
   {
     assert(_quant.zero_points.size() == 1);
     return _quant.zero_points[0];
   }
+  const std::vector<int32_t> &zero_points() const { return _quant.zero_points; }
   const ir::Sparsity *sparsity() const { return _sparsity.get(); }
   void quantization(float scale, int32_t zero_point)
   {

--- a/runtime/onert/core/src/backend/builtin/IOTensor.h
+++ b/runtime/onert/core/src/backend/builtin/IOTensor.h
@@ -58,8 +58,6 @@ public:
   }
   ir::Layout layout() const override { return _tensor->layout(); }
   ir::DataType data_type() const override { return _tensor->data_type(); }
-  float data_scale() const override { return _tensor->data_scale(); }
-  int32_t data_zero_point() const override { return _tensor->data_zero_point(); }
   bool is_dynamic() const override
   {
     return _is_dynamic || _orig_info.isDynamic() || (_tensor && _tensor->is_dynamic());

--- a/runtime/onert/core/src/backend/builtin/UserTensor.h
+++ b/runtime/onert/core/src/backend/builtin/UserTensor.h
@@ -60,8 +60,6 @@ public:
   size_t calcOffset(const ir::Coordinates &coords) const override;
   ir::Layout layout() const override { return _layout; }
   ir::DataType data_type() const override { return _info.typeInfo().type(); }
-  float data_scale() const override { return _info.typeInfo().scale(); }
-  int32_t data_zero_point() const override { return _info.typeInfo().zero_point(); }
   bool is_dynamic() const override { return _dynamic; }
   void set_dynamic() override { _dynamic = true; }
   ir::Shape getShape() const override { return _info.shape(); }

--- a/runtime/onert/core/src/interp/Tensor.h
+++ b/runtime/onert/core/src/interp/Tensor.h
@@ -123,6 +123,11 @@ public:
   ir::DataType data_type() const override { return _info.typeInfo().type(); }
   float data_scale() const override { return _info.typeInfo().scale(); }
   int32_t data_zero_point() const override { return _info.typeInfo().zero_point(); }
+  const std::vector<float> &data_scales() const override { return _info.typeInfo().scales(); }
+  const std::vector<int32_t> &data_zero_points() const override
+  {
+    return _info.typeInfo().zero_points();
+  }
   const ir::OperandInfo &tensorInfo() const override { return _info; }
   uint64_t num_elements() const override { return _info.shape().num_elements(); };
   ir::Shape getShape() const override;
@@ -164,6 +169,11 @@ public:
   ir::DataType data_type() const override { return _info.typeInfo().type(); }
   float data_scale() const override { return _info.typeInfo().scale(); }
   int32_t data_zero_point() const override { return _info.typeInfo().zero_point(); }
+  const std::vector<float> &data_scales() const override { return _info.typeInfo().scales(); }
+  const std::vector<int32_t> &data_zero_points() const override
+  {
+    return _info.typeInfo().zero_points();
+  }
   const ir::OperandInfo &tensorInfo() const override { return _info; }
   uint64_t num_elements() const override { return _info.shape().num_elements(); };
   ir::Shape getShape() const override;


### PR DESCRIPTION
To support per-channel quantization, data_zero_points() and
data_scales() interfaces and implementations are added.

Also, The same implementation of data_zero_point() and data_scales() from
IPortableTensor's children are moved up into IPortableTensor.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>