### PR TITLE
[luci/pass] Fix RemoveUnnecessarySlice not to use shape_signature.

### DIFF
--- a/compiler/luci/pass/src/RemoveUnnecessarySlicePass.cpp
+++ b/compiler/luci/pass/src/RemoveUnnecessarySlicePass.cpp
@@ -64,7 +64,7 @@ bool remove_no_effect_slice(luci::CircleNode *node)
     if (size_value != static_cast<int64_t>(input_node->dim(i).value()))
       return false;
 
-    if (input_node->shape_signature().rank() != 0 && input_node->shape_signature().dim(i) == -1)
+    if (!input_node->dim(i).known())
       return false;
   }
   replace(target_node).with(input_node);


### PR DESCRIPTION
Follow from https://github.com/Samsung/ONE/pull/5576#discussion_r552365098

this commit update checking dynamic shape check logic using `Dimension.known()`.

ONE-DCO-1.0-Signed-off-by: KiDeuk Bang <rrstrous@nate.com>