### PR TITLE
[luci-interpreter] Introduce output tensor shape getter

### DIFF
--- a/compiler/luci-interpreter/include/luci_interpreter/Interpreter.h
+++ b/compiler/luci-interpreter/include/luci_interpreter/Interpreter.h
@@ -57,6 +57,8 @@ public:
 
   void readOutputTensor(const luci::CircleOutput *output_node, void *data, size_t data_size);
 
+  const std::vector<int32_t> getOutputTensorShape(const luci::CircleOutput *output_node);
+
   void interpret();
 
   void attachObserver(ExecutionObserver *observer);

--- a/compiler/luci-interpreter/src/Interpreter.cpp
+++ b/compiler/luci-interpreter/src/Interpreter.cpp
@@ -106,6 +106,21 @@ void Interpreter::readOutputTensor(const luci::CircleOutput *output_node, void *
     tensor->readData(data, data_size);
 }
 
+const std::vector<int32_t> Interpreter::getOutputTensorShape(const luci::CircleOutput *output_node)
+{
+  Tensor *tensor = _runtime_module->getOutputTensors()[output_node->index()];
+  if (tensor == nullptr)
+  {
+    const std::string &name = output_node->name();
+    throw std::runtime_error("Cannot find tensor for output node named \"" + name + "\".");
+  }
+
+  std::vector<int32_t> output_shape;
+  for (int32_t i = 0; i < tensor->shape().num_dims(); ++i)
+    output_shape.push_back(tensor->shape().dim(i));
+  return output_shape;
+}
+
 void Interpreter::interpret() { _runtime_module->execute(); }
 
 void Interpreter::attachObserver(ExecutionObserver *observer)


### PR DESCRIPTION
Parent Issue : #5501

Current `TestDataGenerator` assumes that output tensor shape can be get even before interpreter calculation.
However `TestDataGenerator` sometimes cannot inference the shape of output tensor in advance.
Therefore, we need to get a shape of output tensor shape as interpreter calculation result.
This commit will introduce it.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>