### PR TITLE
[luci/pass] Introduce RemoveUnnecessaryReshapePass on luci/pass

### DIFF
--- a/compiler/luci/pass/include/luci/CircleOptimizer.h
+++ b/compiler/luci/pass/include/luci/CircleOptimizer.h
@@ -56,6 +56,7 @@ public:
       ConvertNCHWToNHWC,
       RemoveUnnecessarySlice,
       RemoveUnnecessarySplit,
+      RemoveUnnecessaryReshape,
     };
 
     enum AlgorithmParameters

--- a/compiler/luci/pass/include/luci/Pass/RemoveUnnecessaryReshapePass.h
+++ b/compiler/luci/pass/include/luci/Pass/RemoveUnnecessaryReshapePass.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __LUCI_REMOVE_UNNECESSARY_RESHAPE_PASS_H__
+#define __LUCI_REMOVE_UNNECESSARY_RESHAPE_PASS_H__
+
+#include <logo/Pass.h>
+
+namespace luci
+{
+
+/**
+ * @brief  Class to Remove Unnecessary(input shape and output shape same) Reshape node.
+ */
+struct RemoveUnnecessaryReshapePass final : public logo::Pass
+{
+  const char *name(void) const final { return "luci::RemoveUnnecessaryReshapePass"; }
+
+  bool run(loco::Graph *g) final;
+};
+
+} // namespace luci
+
+#endif // __LUCI_REMOVE_UNNECESSARY_RESHAPE_PASS_H__

--- a/compiler/luci/pass/src/CircleOptimizer.cpp
+++ b/compiler/luci/pass/src/CircleOptimizer.cpp
@@ -27,6 +27,7 @@
 #include "luci/Pass/MakeBatchNormGammaPositivePass.h"
 #include "luci/Pass/PropagateQuantParamPass.h"
 #include "luci/Pass/RemoveRedundantTransposePass.h"
+#include "luci/Pass/RemoveUnnecessaryReshapePass.h"
 #include "luci/Pass/RemoveUnnecessarySlicePass.h"
 #include "luci/Pass/RemoveUnnecessarySplitPass.h"
 #include "luci/Pass/ReplaceMulAddWithDepthwiseConvPass.h"
@@ -221,6 +222,10 @@ void CircleOptimizer::optimize(loco::Graph *g) const
   if (_options->query(Options::Algorithm::ShuffleWeightTo16x1Float32))
   {
     phase.emplace_back(std::make_unique<luci::ShuffleWeightTo16x1Float32Pass>());
+  }
+  if (_options->query(Options::Algorithm::RemoveUnnecessaryReshape))
+  {
+    phase.emplace_back(std::make_unique<luci::RemoveUnnecessaryReshapePass>());
   }
   if (_options->query(Options::Algorithm::RemoveUnnecessarySlice))
   {

--- a/compiler/luci/pass/src/RemoveUnnecessaryReshapePass.cpp
+++ b/compiler/luci/pass/src/RemoveUnnecessaryReshapePass.cpp
@@ -27,43 +27,25 @@ bool remove_no_effect_reshape(luci::CircleNode *node)
   if (target_node == nullptr)
     return false;
 
-  std::vector<int32_t> shape_info;
   auto new_shape = dynamic_cast<luci::CircleConst *>(target_node->shape());
-  // If shape node is not a const node, get updated shape info from option.
   if (new_shape == nullptr)
-  {
-    auto dummy_shape = dynamic_cast<luci::CircleOutputDummy *>(target_node->shape());
-    if (dummy_shape == nullptr)
-      return false;
-
-    // Need to extract new_shape info on target_node->newShape()
-    shape_info.resize(target_node->newShape()->rank());
-    for (uint32_t i = 0; i < target_node->newShape()->rank(); i++)
-      shape_info.at(i) = target_node->newShape()->dim(i);
-  }
-  // If shape node is presented as const node, extract updated shape from const node.
-  else
-  {
-    shape_info.resize(new_shape->dim(0).value());
-    for (uint32_t i = 0; i < new_shape->dim(0).value(); i++)
-      shape_info.at(i) = new_shape->at<loco::DataType::S32>(i);
-  }
+    return false;
 
   // Compare updated shape and input shape.
   auto input_node = loco::must_cast<luci::CircleNode *>(target_node->tensor());
-  if (input_node->rank() != shape_info.size())
+  if (input_node->rank() != new_shape->dim(0).value())
     return false;
   for (uint32_t i = 0; i < input_node->rank(); i++)
   {
     // If update_shape is -1, don't care
     // TODO check updated shape has value -1 at most one.
-    if (shape_info.at(i) == -1)
+    if (new_shape->at<loco::DataType::S32>(i) == -1)
       continue;
     // If input_shape dynamic, can't remove this.
     if (!input_node->dim(i).known())
       return false;
     // If input_shape and updated shape differ, also can't remove.
-    if (input_node->dim(i).value() != static_cast<uint32_t>(shape_info.at(i)))
+    if (input_node->dim(i).value() != static_cast<uint32_t>(new_shape->at<loco::DataType::S32>(i)))
       return false;
   }
 

--- a/compiler/luci/pass/src/RemoveUnnecessaryReshapePass.cpp
+++ b/compiler/luci/pass/src/RemoveUnnecessaryReshapePass.cpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Pass/RemoveUnnecessaryReshapePass.h"
+
+#include <luci/IR/CircleNodes.h>
+
+namespace
+{
+
+bool remove_no_effect_reshape(luci::CircleNode *node)
+{
+  auto target_node = dynamic_cast<luci::CircleReshape *>(node);
+  if (target_node == nullptr)
+    return false;
+
+  std::vector<int32_t> shape_info;
+  auto new_shape = dynamic_cast<luci::CircleConst *>(target_node->shape());
+  // If shape node is not a const node, get updated shape info from option.
+  if (new_shape == nullptr)
+  {
+    auto dummy_shape = dynamic_cast<luci::CircleOutputDummy *>(target_node->shape());
+    if (dummy_shape == nullptr)
+      return false;
+
+    // Need to extract new_shape info on target_node->newShape()
+    shape_info.resize(target_node->newShape()->rank());
+    for (uint32_t i = 0; i < target_node->newShape()->rank(); i++)
+      shape_info.at(i) = target_node->newShape()->dim(i);
+  }
+  // If shape node is presented as const node, extract updated shape from const node.
+  else
+  {
+    shape_info.resize(new_shape->dim(0).value());
+    for (uint32_t i = 0; i < new_shape->dim(0).value(); i++)
+      shape_info.at(i) = new_shape->at<loco::DataType::S32>(i);
+  }
+
+  // Compare updated shape and input shape.
+  auto input_node = loco::must_cast<luci::CircleNode *>(target_node->tensor());
+  if (input_node->rank() != shape_info.size())
+    return false;
+  for (uint32_t i = 0; i < input_node->rank(); i++)
+  {
+    // If update_shape is -1, don't care
+    // TODO check updated shape has value -1 at most one.
+    if (shape_info.at(i) == -1)
+      continue;
+    // If input_shape dynamic, can't remove this.
+    if (!input_node->dim(i).known())
+      return false;
+    // If input_shape and updated shape differ, also can't remove.
+    if (input_node->dim(i).value() != static_cast<uint32_t>(shape_info.at(i)))
+      return false;
+  }
+
+  replace(target_node).with(input_node);
+  return true;
+}
+
+} // namespace
+
+namespace luci
+{
+
+bool RemoveUnnecessaryReshapePass::run(loco::Graph *g)
+{
+  bool changed = false;
+  for (auto node : loco::active_nodes(loco::output_nodes(g)))
+  {
+    auto circle_node = loco::must_cast<luci::CircleNode *>(node);
+    if (remove_no_effect_reshape(circle_node))
+    {
+      changed = true;
+    }
+  }
+  return changed;
+}
+
+} // namespace luci

--- a/compiler/luci/pass/src/RemoveUnnecessaryReshapePass.test.cpp
+++ b/compiler/luci/pass/src/RemoveUnnecessaryReshapePass.test.cpp
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Pass/RemoveUnnecessaryReshapePass.h"
+
+#include <luci/IR/CircleNodes.h>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+
+void create_unnecessary_reshape_graph(loco::Graph *g,
+                                      const std::initializer_list<uint32_t> input_shape,
+                                      bool remove)
+{
+  assert(g);
+
+  // Input create
+  auto input = g->nodes()->create<luci::CircleInput>();
+  auto graph_input = g->inputs()->create();
+  input->index(graph_input->index());
+  input->shape_status(luci::ShapeStatus::VALID);
+  input->rank(input_shape.size());
+  input->shape(input_shape);
+
+  // Output_shape CircleConst create
+  std::vector<uint32_t> shape_vector{input_shape};
+  auto output_shape = g->nodes()->create<luci::CircleConst>();
+  output_shape->shape_status(luci::ShapeStatus::VALID);
+  output_shape->dtype(loco::DataType::S32);
+  output_shape->rank(1);
+  output_shape->dim(0).set(remove ? shape_vector.size() : 1);
+  output_shape->size<loco::DataType::S32>(remove ? shape_vector.size() : 1);
+  for (uint32_t i = 0; i < output_shape->dim(0).value(); i++)
+  {
+    if (remove)
+      output_shape->at<loco::DataType::S32>(i) = static_cast<int32_t>(shape_vector.at(i));
+    else
+      output_shape->at<loco::DataType::S32>(i) = -1;
+  }
+
+  // Reshape create
+  auto reshape_node = g->nodes()->create<luci::CircleReshape>();
+  reshape_node->tensor(input);
+  reshape_node->shape(output_shape);
+  reshape_node->newShape()->rank(remove ? shape_vector.size() : 1);
+  for (uint32_t i = 0; i < reshape_node->newShape()->rank(); i++)
+  {
+    if (remove)
+      reshape_node->newShape()->dim(i) = static_cast<int32_t>(shape_vector.at(i));
+    else
+      reshape_node->newShape()->dim(i) = -1;
+  }
+
+  // Output create
+  auto output = g->nodes()->create<luci::CircleOutput>();
+  output->from(reshape_node);
+  auto graph_output = g->outputs()->create();
+  output->index(graph_output->index());
+}
+
+} // namespace
+
+TEST(RemoveUnnecessaryReshapePass, create_unnecessary_reshape)
+{
+  auto graph = loco::make_graph();
+  create_unnecessary_reshape_graph(graph.get(), {1, 2, 3, 4}, true);
+  luci::CircleReshape *reshape_node = nullptr;
+  for (auto node : loco::active_nodes(loco::output_nodes(graph.get())))
+  {
+    auto reshape = dynamic_cast<luci::CircleReshape *>(node);
+    if (not reshape)
+      continue;
+    reshape_node = reshape;
+    break;
+  }
+  ASSERT_NE(nullptr, reshape_node);
+  luci::RemoveUnnecessaryReshapePass pass;
+  while (pass.run(graph.get()))
+    ;
+  reshape_node = nullptr;
+  for (auto node : loco::active_nodes(loco::output_nodes(graph.get())))
+  {
+    auto reshape = dynamic_cast<luci::CircleReshape *>(node);
+    if (not reshape)
+      continue;
+    reshape_node = reshape;
+    break;
+  }
+  ASSERT_EQ(nullptr, reshape_node);
+}
+
+TEST(RemoveUnnecessaryReshapePass, create_unnecessary_reshape_NEG)
+{
+  auto graph = loco::make_graph();
+  create_unnecessary_reshape_graph(graph.get(), {1, 2, 3, 4}, false);
+  luci::CircleReshape *reshape_node = nullptr;
+  for (auto node : loco::active_nodes(loco::output_nodes(graph.get())))
+  {
+    auto reshape = dynamic_cast<luci::CircleReshape *>(node);
+    if (not reshape)
+      continue;
+    reshape_node = reshape;
+    break;
+  }
+  ASSERT_NE(nullptr, reshape_node);
+  luci::RemoveUnnecessaryReshapePass pass;
+  while (pass.run(graph.get()))
+    ;
+  reshape_node = nullptr;
+  for (auto node : loco::active_nodes(loco::output_nodes(graph.get())))
+  {
+    auto reshape = dynamic_cast<luci::CircleReshape *>(node);
+    if (not reshape)
+      continue;
+    reshape_node = reshape;
+    break;
+  }
+  ASSERT_NE(nullptr, reshape_node);
+}


### PR DESCRIPTION
For #5575 

This commit introduce a `RemoveUnnecessaryReshapePass` on luci/pass.

ONE-DCO-1.0-Signed-off-by: KiDeuk Bang <rrstrous@nate.com>