### PR TITLE
[tool/stab] Introduce static backend scheduler

### DIFF
--- a/tools/stab/README.md
+++ b/tools/stab/README.md
@@ -1,0 +1,51 @@
+# Stab - Static Backend Scheduler
+
+`Stab` is a tool to schedule backend for each opration using profiled data
+
+nnpackage with backend configuration will be created at `./tools/stab/nnpkg_sched`
+
+## Scheduling Process
+
+1. Upload ONE runtime and nnpackage to remote device
+   - Use `/tmp/ONE` folder on remote device
+1. Profile execution time of each backend on remote device
+1. Get profile result from remote device
+   - Profile result is saved at `./tools/stab/traces` on host
+1. Scheduler backend for each operation to get fastest inference time
+   - Use fastest backend for each operation
+1. Generate nnpackage with backend configuration
+   - Generated at `./tools/stab/nnpkg_sched`
+
+## Prerequisite
+
+- Install Python>=3. Tested on Python 3.6.9 and 3.7.5
+- Register SSH keys to use ssh commands without entering password
+  ```bash
+  ssh-keygen -t rsa
+  ssh-copy-id -i ~/.ssh/id_rsa.pub remote_user@remote_ip
+  ```
+
+## Usage
+
+```
+Usage: python3 ./tools/stab/stab.py --nnpackage nnpackage_dir --ip <IP>
+Runs nnpackage on remote device and create nnpackaged with scheduled backends
+
+required arguments:
+  --nnpackage NNPACKAGE
+                        nnpackage folder to profile
+  --ip IP               IP address of remote client
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -n NUM_THREADS, --num_threads NUM_THREADS
+                        Number of threads used by one runtime
+  -u USER, --user USER  User of remote client
+  -v, --verbose         Print verbose message
+  --no-profile          Disable profiling
+
+Examples:
+    python3 ./tools/stab/stab.py --nnpackage ../nnpkg_tst/inception --ip 1.1.1.1               => Profile on remote device 1.1.1.1 with current user
+    python3 ./tools/stab/stab.py --nnpackage ../nnpkg_tst/inception --ip 1.1.1.1 -n 4          => Profile on remote device 1.1.1.1 using 4 thread for ONE runtime
+    python3 ./tools/stab/stab.py --nnpackage ../nnpkg_tst/inception --ip 1.1.1.1 --user odroid => Profile on remote device 1.1.1.1 with user odroid
+```

--- a/tools/stab/README.md
+++ b/tools/stab/README.md
@@ -4,6 +4,9 @@
 
 nnpackage with backend configuration will be created at `./tools/stab/nnpkg_sched`
 
+Supported backends : `cpu`, `ruy`, and `xnnpack`
+- Other backends will be supported when `stab` can measure and use permutation time between backends
+
 ## Scheduling Process
 
 1. Upload ONE runtime and nnpackage to remote device

--- a/tools/stab/backend_profiler.py
+++ b/tools/stab/backend_profiler.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+# Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/stab/backend_profiler.py
+++ b/tools/stab/backend_profiler.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from op_list_parser import OpListParser
+from remote import RemoteSSH
+
+
+class BackendProfiler():
+    """
+    Run ONE runtime on remote device to create TRACE file which has operation execution time
+
+    TODO : Support Android device profiling
+    """
+
+    def __init__(self, user, ip, nnpackage_dir, num_threads):
+        self.remote_ssh = RemoteSSH(user, ip, nnpackage_dir, num_threads)
+        self.backend_op_list = OpListParser().parse()
+        self.backend_list = ["cpu"]
+        self.backend_list.extend([backend for backend in self.backend_op_list])
+
+    def sync(self):
+        logging.info("Upload ONE runtime and nnpackage to remote device")
+        self.remote_ssh.sync_binary()
+
+    def profile(self):
+        for backend in self.backend_list:
+            logging.info(f"Profiling {backend} backend")
+            self.remote_ssh.profile_backend(backend, self.backend_op_list)
+            self.remote_ssh.sync_trace(backend)

--- a/tools/stab/backend_scheduler.py
+++ b/tools/stab/backend_scheduler.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json, logging
+from pathlib import Path
+from op_list_parser import OpListParser
+from nnpkg_helper import NnpkgHelper
+
+
+class BackendScheduler:
+    """
+    Read profiled data and select proper backend for each operation
+    Scheduled nnpackage is saved at ./tools/stab/nnpkg_sched
+
+    TODO : Use permutation time for better scheduling
+    """
+
+    def __init__(self, nnpkg_dir, num_threads):
+        self.nnpkg_dir = Path(nnpkg_dir).resolve()
+        self.num_threads = num_threads
+        self.root_path = Path(__file__).parents[2]
+        self.nnpkg_helper = NnpkgHelper()
+
+    def read_traces(self, backend_list):
+        op_time = {}
+        inference_time = {}
+        for backend in backend_list:
+            try:
+                # Trace file is located at ./tools/stab/traces
+                trace_path = Path(
+                    __file__
+                ).parent / 'traces' / f"{self.nnpkg_dir.name}_{backend}_{self.num_threads}"
+                logging.debug(f"Trace path : {trace_path}")
+                with open(trace_path) as f:
+                    data = json.load(f)
+                    execution_data = data['Execution_Data']
+                    for entry in execution_data:
+                        if entry == "memory":
+                            continue
+                        elif entry == "runtime":
+                            inference_time[backend] = execution_data['runtime']['Graph'][
+                                'Avg_Time']
+                            continue
+                        op_backend = entry
+                        backend_data = execution_data[op_backend]
+                        for op in backend_data:
+                            op_index = int(op.split(' ')[2][1:])
+                            op_type = op.split(' ')[-1]
+                            time = int(backend_data[op]["Avg_Time"])
+                            if op_index not in op_time.keys():
+                                op_time[op_index] = {op_backend: time}
+                                op_time[op_index].update({"type": op_type})
+                            else:
+                                op_time[op_index].update({op_backend: time})
+            except IOError as e:
+                logging.warning(e)
+        return op_time, inference_time
+
+    def schedule(self):
+        backend_op_list = OpListParser().parse()
+        backend_list = ["cpu"]
+        backend_list.extend([backend for backend in backend_op_list])
+
+        op_time, backend_infer_time = self.read_traces(backend_list)
+
+        backend_mapping = {}
+
+        target_ops = set()
+        for _, v in backend_op_list.items():
+            target_ops.update(v)
+
+        # Find fastest backend for each operation
+        for op_index, value in sorted(op_time.items()):
+            op_type = value['type']
+            if op_type not in target_ops:
+                continue
+
+            logging.debug(f"----- Operation {op_index} -----")
+            op_infer_time = 0
+            for backend in backend_list:
+                if backend not in value:
+                    continue
+                backend_time = value[backend]
+
+                logging.debug(f"{backend}[{backend_time}]")
+                if op_infer_time == 0 or backend_time < op_infer_time:
+                    op_infer_time = backend_time
+                    backend_mapping[op_index] = backend
+
+        # Find default backend for Conv2D
+        default_backend = min(backend_infer_time, key=backend_infer_time.get)
+
+        # Create OP_BACKEND_MAP string
+        backend_conf = ""
+        for op_index, backend in sorted(backend_mapping.items()):
+            if backend != default_backend:
+                backend_conf += "{}={};".format(op_index, backend)
+
+        # Select fastet backend for each operation
+        logging.info("-------- Expected inference time ---------")
+        inference_time = {}
+        for backend in backend_list:
+            inference_time[backend] = 0
+            for op_index, value in sorted(op_time.items()):
+                if backend in value:
+                    inference_time[backend] += value[backend]
+                else:
+                    inference_time[backend] += value["cpu"]
+
+        schedule_time = 0
+        for op_index, value in sorted(op_time.items()):
+            op_type = value['type']
+            if op_type not in target_ops:
+                schedule_time += value["cpu"]
+                continue
+            else:
+                op_backend = backend_mapping[op_index]
+                schedule_time += value[op_backend]
+                if (default_backend != op_backend):
+                    logging.debug("[{}] {} -> {} : {:.2f} ms decrease".format(
+                        op_index, default_backend, op_backend,
+                        (value[default_backend] - value[op_backend]) / 1000))
+
+        for backend in backend_list:
+            logging.info(f"{backend} backend : {inference_time[backend]/1000:.2f} ms")
+        logging.info(f"Backend scheduling : {schedule_time / 1000:.2f} ms")
+
+        logging.info("-------- Backend Scheduling --------")
+        cmd = []
+        cmd += [f"OP_BACKEND_MAP={backend_conf}"]
+        for target_backend, op_list in backend_op_list.items():
+            if default_backend == target_backend:
+                for op in op_list:
+                    cmd += [f"OP_BACKEND_{op}={default_backend}"]
+        cmd += [f"BACKENDS={';'.join(backend_list)}"]
+        cmd += [f"RUY_THREADS={self.num_threads}"]
+        cmd += [f"XNNPACK_THREADS={self.num_threads}"]
+        logging.info(' '.join(cmd))
+
+        # Create nnpackage with backend mapping
+        dst_dir = Path(__file__).parent / 'nnpkg_sched' / self.nnpkg_dir.name
+        self.nnpkg_helper.copy(self.nnpkg_dir, dst_dir)
+        self.nnpkg_helper.add_config(dst_dir, cmd)

--- a/tools/stab/backend_scheduler.py
+++ b/tools/stab/backend_scheduler.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+# Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/stab/nnpkg_helper.py
+++ b/tools/stab/nnpkg_helper.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+# Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/stab/nnpkg_helper.py
+++ b/tools/stab/nnpkg_helper.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json, logging
+from distutils.dir_util import copy_tree
+from pathlib import Path
+
+
+class NnpkgHelper:
+    """
+    Helper class for nnpackage
+    """
+
+    def __init__(self):
+        self.config_name = 'config.cfg'
+
+    def copy(self, src, dst):
+        copy_tree(str(src), str(dst))
+
+    def add_config(self, src, configs):
+        manifest_path = Path(src).resolve() / 'metadata' / 'MANIFEST'
+        config_path = Path(src).resolve() / 'metadata' / self.config_name
+
+        try:
+            # Read MANIFEST file
+            with open(manifest_path, 'r') as manifest_file:
+                data = json.load(manifest_file)
+
+            # Add configs to MANIFEST file
+            with open(manifest_path, 'w') as manifest_file:
+                data['configs'] = [self.config_name]
+                json.dump(data, manifest_file, indent=2)
+
+            # Write config.cfg file
+            with open(config_path, 'w') as config_file:
+                config_file.write('\n'.join(configs))
+
+            logging.info(f"Scheduled nnpackage is saved at {src}")
+
+        except IOError as e:
+            logging.warn(e)
+        except:
+            logging.warn("Error")

--- a/tools/stab/op_list.txt
+++ b/tools/stab/op_list.txt
@@ -1,0 +1,2 @@
+ruy:Conv2D,FullyConnected
+xnnpack:Conv2D,DepthwiseConv2D,FullyConnected

--- a/tools/stab/op_list_parser.py
+++ b/tools/stab/op_list_parser.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+# Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/stab/op_list_parser.py
+++ b/tools/stab/op_list_parser.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+
+class OpListParser():
+    """
+    Read op_list.txt to create supported operation list for each backend
+
+    TODO : Reads supported tensor type for each operation (FP32 or INT8)
+    """
+
+    def __init__(self):
+        self.file_name = "op_list.txt"
+        self.op_list_file = Path(__file__).parent / self.file_name
+
+    def parse(self):
+        backend_op_list = {}
+        with open(self.op_list_file, 'r') as f:
+            lines = f.readlines()
+            for line in lines:
+                line = line.rstrip()
+                backend, _, op_list_str = line.partition(':')
+                op_list = op_list_str.split(',')
+                backend_op_list[backend] = op_list
+        return backend_op_list

--- a/tools/stab/remote.py
+++ b/tools/stab/remote.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+# Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/stab/remote.py
+++ b/tools/stab/remote.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import subprocess, logging
+from pathlib import Path
+
+
+class RemoteSSH():
+    """
+    Execute commands on remove device using SSH
+
+    TODO : Using SSH library instead of direct ssh call
+    """
+
+    def __init__(self, user, ip, nnpkg_dir, num_threads):
+        self.base_dir = Path('/tmp/ONE')
+        self.trace_dir = 'traces'
+        self.host = f"{user}@{ip}" if user != None else ip
+        self.nnpkg_dir = Path(nnpkg_dir).resolve()
+        self.nnpkg_name = self.nnpkg_dir.name
+        self.root_path = Path(__file__).resolve().parents[2]
+        self.num_threads = num_threads
+
+    def sync_binary(self):
+        bin_dir = self.root_path / 'Product/armv7l-linux.release/out'
+        if (not bin_dir.is_dir()):
+            logging.warn(f"Build dir [{bin_dir}] is not exist")
+            exit()
+        elif (not self.nnpkg_dir.is_dir()):
+            logging.warn(f"nnpackage dir [{self.nnpkg_dir}] is not exist")
+            exit()
+        else:
+            # Create temporary folder
+            subprocess.call(
+                ["ssh", f"{self.host}", "mkdir", "-p", self.base_dir / self.trace_dir])
+            # Syne ONE runtime
+            subprocess.call([
+                "rsync", "-az", "--exclude", "test-suite.tar.gz", bin_dir,
+                self.remote(self.base_dir)
+            ])
+            # Sync target nnpackage
+            subprocess.call(["rsync", "-az", self.nnpkg_dir, self.remote(self.base_dir)])
+
+    def sync_trace(self, backend):
+        remote_trace_path = self.remote_trace_path(backend)
+        local_trace_path = self.local_trace_path(backend)
+        local_trace_path.parent.mkdir(parents=True, exist_ok=True)
+        logging.debug(f"Remote trace path : {self.remote(remote_trace_path)}")
+        logging.debug(f"Local trace path : {local_trace_path}")
+        # Sync trace file
+        subprocess.call(
+            ["rsync", "-az",
+             self.remote(remote_trace_path), local_trace_path])
+
+    def profile_backend(self, backend, backend_op_list):
+        nnpkg_run_path = self.base_dir / 'out/bin/nnpackage_run'
+        nnpkg_path = self.base_dir / self.nnpkg_dir.name
+
+        cmd = ["ssh", f"{self.host}"]
+        cmd += [f"TRACE_FILEPATH={self.remote_trace_path(backend)}"]
+        for target_backend, op_list in backend_op_list.items():
+            if backend == target_backend:
+                for op in op_list:
+                    cmd += [f"OP_BACKEND_{op}={backend}"]
+        cmd += [f"XNNPACK_THREADS={self.num_threads}"]
+        cmd += [f"RUY_THREADS={self.num_threads}"]
+        cmd += [f"BACKENDS=\'{';'.join(['cpu', backend])}\'"]
+        cmd += [f"{nnpkg_run_path}"]
+        cmd += [f"--nnpackage"]
+        cmd += [f"{nnpkg_path}"]
+        cmd += [f"-w5 -r50"]
+        logging.debug(f"SSH command : {' '.join(cmd)}")
+        subprocess.call(cmd)
+
+    def base_path():
+        pass
+
+    def remote(self, path):
+        return f"{self.host}:{path}"
+
+    # TODO Create class for path generation
+    def trace_name(self, backend):
+        return f"{self.nnpkg_name}_{backend}_{self.num_threads}"
+
+    def remote_trace_path(self, backend):
+        return self.base_dir / self.trace_dir / self.trace_name(backend)
+
+    def local_trace_path(self, backend):
+        return Path(__file__).parent / self.trace_dir / self.trace_name(backend)

--- a/tools/stab/stab.py
+++ b/tools/stab/stab.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+# Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/stab/stab.py
+++ b/tools/stab/stab.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse, logging, sys
+from backend_profiler import BackendProfiler
+from backend_scheduler import BackendScheduler
+
+
+def main(args):
+    if args.profile:
+        backend_profiler = BackendProfiler(args.user, args.ip, args.nnpackage,
+                                           args.num_threads)
+        backend_profiler.sync()
+        backend_profiler.profile()
+    backend_scheduler = BackendScheduler(args.nnpackage, args.num_threads)
+    backend_scheduler.schedule()
+
+
+if __name__ == "__main__":
+    arg_parser = argparse.ArgumentParser(add_help=False)
+    required = arg_parser.add_argument_group('required arguments')
+    optional = arg_parser.add_argument_group('optional arguments')
+
+    # Add back help
+    optional.add_argument(
+        '-h',
+        '--help',
+        action='help',
+        default=argparse.SUPPRESS,
+        help='show this help message and exit')
+    required.add_argument(
+        "--nnpackage", type=str, required=True, help="nnpackage folder to profile")
+    required.add_argument(
+        "--ip", type=str, required=True, help="IP address of remote client")
+    optional.add_argument(
+        "-n",
+        "--num_threads",
+        type=int,
+        default=1,
+        help="Number of threads used by one runtime")
+    optional.add_argument("-u", "--user", type=str, help="User of remote client")
+    optional.add_argument(
+        "-v",
+        "--verbose",
+        action='store_const',
+        dest="verbose_level",
+        default=logging.INFO,
+        const=logging.DEBUG,
+        help="Print verbose message")
+    optional.add_argument(
+        "--no-profile", dest='profile', action='store_false', help="Disable profiling")
+    optional.set_defaults(profile=True)
+    args = arg_parser.parse_args()
+
+    logging.basicConfig(
+        stream=sys.stdout,
+        level=args.verbose_level,
+        format="[%(levelname).5s] %(message)s")
+
+    main(args)


### PR DESCRIPTION
- This commit introduces static basckend scheduler (`Stab`)
  - `Stab` is a tool to schedule backend for each opration using profiled data
  - Target nnpackage is executed on remote device using ssh
  - `Stab` uses profiled data to select fastes backend for each operation
  - nnpackage with backend configuration will be created at `./tools/stab/nnpkg_sched`

ONE-DCO-1.0-Signed-off-by: JiHwan Yeo <jihwan.yeo@samsung.com>

---

For issue #5118 
From draft #5110