### PR TITLE
DRAFT: Options to preserve input/output in ConvertNCHWToNHWC

### DIFF
--- a/compiler/circle2circle/src/Circle2Circle.cpp
+++ b/compiler/circle2circle/src/Circle2Circle.cpp
@@ -172,6 +172,18 @@ int entry(int argc, char **argv)
     .help("Experimental: This will convert NCHW operators to NHWC under the assumption that "
           "input model is NCHW.");
 
+  arser.add_argument("--nchw_to_nhwc_preserve_input_shape")
+    .nargs(0)
+    .required(false)
+    .default_value(false)
+    .help("Preserve the input shape of the model.");
+
+  arser.add_argument("--nchw_to_nhwc_preserve_output_shape")
+    .nargs(0)
+    .required(false)
+    .default_value(false)
+    .help("Preserve the output shape of the model.");
+
   arser.add_argument("--mute_warnings")
     .nargs(0)
     .required(false)
@@ -277,8 +289,6 @@ int entry(int argc, char **argv)
     options->enable(Algorithms::ShuffleWeightTo16x1Float32);
   if (arser.get<bool>("--substitute_pack_to_reshape"))
     options->enable(Algorithms::SubstitutePackToReshape);
-  if (arser.get<bool>("--convert_nchw_to_nhwc"))
-    options->enable(Algorithms::ConvertNCHWToNHWC);
 
   if (arser.get<bool>("--mute_warnings"))
     settings->set(luci::UserSettings::Key::MuteWarnings, true);
@@ -307,6 +317,15 @@ int entry(int argc, char **argv)
     }
     options->param(AlgorithmParameters::Sparsify_block_map,
                    arser.get<std::string>("--sparsify_block_map"));
+  }
+
+  if (arser.get<bool>("--convert_nchw_to_nhwc"))
+  {
+    options->enable(Algorithms::ConvertNCHWToNHWC);
+    if (arser.get<bool>("--nchw_to_nhwc_preserve_input_shape"))
+      options->param(AlgorithmParameters::NCHW_to_NHWC_preserve_input_shape, "true");
+    if (arser.get<bool>("--nchw_to_nhwc_preserve_output_shape"))
+      options->param(AlgorithmParameters::NCHW_to_NHWC_preserve_output_shape, "true");
   }
 
   // Load model from the file

--- a/compiler/luci/pass/include/luci/CircleOptimizer.h
+++ b/compiler/luci/pass/include/luci/CircleOptimizer.h
@@ -71,6 +71,10 @@ public:
       Sparsify_format,
       Sparsify_block_size,
       Sparsify_block_map,
+
+      // convert NCHW to NHWC
+      NCHW_to_NHWC_preserve_input_shape,
+      NCHW_to_NHWC_preserve_output_shape,
     };
 
     virtual ~Options() = default;

--- a/compiler/luci/pass/include/luci/Pass/ConvertNCHWToNHWCPass.h
+++ b/compiler/luci/pass/include/luci/Pass/ConvertNCHWToNHWCPass.h
@@ -35,11 +35,22 @@ namespace luci
  */
 struct ConvertNCHWToNHWCPass final : public logo::Pass
 {
+public:
+  ConvertNCHWToNHWCPass(bool preserve_input = false, bool preserve_output = false)
+    : _preserve_input(preserve_input), _preserve_output(preserve_output)
+  {
+    // Do nothing
+  }
+
   virtual ~ConvertNCHWToNHWCPass() = default;
 
   const char *name(void) const final { return "luci::ConvertNCHWToNHWCPass"; }
 
   bool run(loco::Graph *g) final;
+
+private:
+  bool _preserve_input;
+  bool _preserve_output;
 };
 
 } // namespace luci

--- a/compiler/luci/pass/src/CircleOptimizer.cpp
+++ b/compiler/luci/pass/src/CircleOptimizer.cpp
@@ -244,7 +244,13 @@ void CircleOptimizer::optimize(loco::Graph *g) const
   }
   if (_options->query(Options::Algorithm::ConvertNCHWToNHWC))
   {
-    phase.emplace_back(std::make_unique<luci::ConvertNCHWToNHWCPass>());
+    bool preserve_input =
+      _options->param(Options::AlgorithmParameters::NCHW_to_NHWC_preserve_input_shape) == "true";
+    bool preserve_output =
+      _options->param(Options::AlgorithmParameters::NCHW_to_NHWC_preserve_output_shape) == "true";
+
+    phase.emplace_back(
+      std::make_unique<luci::ConvertNCHWToNHWCPass>(preserve_input, preserve_output));
   }
 
   /* TRANSFORM DECLARATION END */

--- a/compiler/luci/pass/src/ConvertNCHWToNHWCPass.cpp
+++ b/compiler/luci/pass/src/ConvertNCHWToNHWCPass.cpp
@@ -513,7 +513,17 @@ bool ConvertNCHWToNHWCPass::run(loco::Graph *g)
     {
       // List of supported Ops
       case luci::CircleOpcode::CIRCLEINPUT:
+        if (!_preserve_input && !has_data_format(node))
+        {
+          set_data_format(node, DataFormat::NCHW);
+        }
+        break;
       case luci::CircleOpcode::CIRCLEOUTPUT:
+        if (!_preserve_output && !has_data_format(node))
+        {
+          set_data_format(node, DataFormat::NCHW);
+        }
+        break;
       case luci::CircleOpcode::ADD:
       case luci::CircleOpcode::MUL:
       case luci::CircleOpcode::PAD:


### PR DESCRIPTION
On going draft to support options to preserve input/output shape in ConvertNCHWToNHWCPass.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: #5600