### PR TITLE
[luci] Options to preserve input/output in ConvertNCHWToNHWC

### DIFF
--- a/compiler/luci/pass/include/luci/CircleOptimizer.h
+++ b/compiler/luci/pass/include/luci/CircleOptimizer.h
@@ -71,6 +71,10 @@ public:
       Sparsify_format,
       Sparsify_block_size,
       Sparsify_block_map,
+
+      // convert NCHW to NHWC
+      NCHW_to_NHWC_preserve_input_shape,
+      NCHW_to_NHWC_preserve_output_shape,
     };
 
     virtual ~Options() = default;

--- a/compiler/luci/pass/include/luci/Pass/ConvertNCHWToNHWCPass.h
+++ b/compiler/luci/pass/include/luci/Pass/ConvertNCHWToNHWCPass.h
@@ -49,8 +49,8 @@ public:
   bool run(loco::Graph *g) final;
 
 private:
-  bool _preserve_input;
-  bool _preserve_output;
+  bool _preserve_input = false;
+  bool _preserve_output = false;
 };
 
 } // namespace luci

--- a/compiler/luci/pass/include/luci/Pass/ConvertNCHWToNHWCPass.h
+++ b/compiler/luci/pass/include/luci/Pass/ConvertNCHWToNHWCPass.h
@@ -35,11 +35,22 @@ namespace luci
  */
 struct ConvertNCHWToNHWCPass final : public logo::Pass
 {
+public:
+  ConvertNCHWToNHWCPass(bool preserve_input = false, bool preserve_output = false)
+    : _preserve_input(preserve_input), _preserve_output(preserve_output)
+  {
+    // Do nothing
+  }
+
   virtual ~ConvertNCHWToNHWCPass() = default;
 
   const char *name(void) const final { return "luci::ConvertNCHWToNHWCPass"; }
 
   bool run(loco::Graph *g) final;
+
+private:
+  bool _preserve_input;
+  bool _preserve_output;
 };
 
 } // namespace luci

--- a/compiler/luci/pass/include/luci/Pass/ConvertNCHWToNHWCPass.h
+++ b/compiler/luci/pass/include/luci/Pass/ConvertNCHWToNHWCPass.h
@@ -36,11 +36,13 @@ namespace luci
 struct ConvertNCHWToNHWCPass final : public logo::Pass
 {
 public:
-  ConvertNCHWToNHWCPass(bool preserve_input = false, bool preserve_output = false)
+  ConvertNCHWToNHWCPass(bool preserve_input, bool preserve_output)
     : _preserve_input(preserve_input), _preserve_output(preserve_output)
   {
     // Do nothing
   }
+
+  ConvertNCHWToNHWCPass() = delete;
 
   virtual ~ConvertNCHWToNHWCPass() = default;
 

--- a/compiler/luci/pass/src/CircleOptimizer.cpp
+++ b/compiler/luci/pass/src/CircleOptimizer.cpp
@@ -244,7 +244,13 @@ void CircleOptimizer::optimize(loco::Graph *g) const
   }
   if (_options->query(Options::Algorithm::ConvertNCHWToNHWC))
   {
-    phase.emplace_back(std::make_unique<luci::ConvertNCHWToNHWCPass>());
+    bool preserve_input =
+      _options->param(Options::AlgorithmParameters::NCHW_to_NHWC_preserve_input_shape) == "true";
+    bool preserve_output =
+      _options->param(Options::AlgorithmParameters::NCHW_to_NHWC_preserve_output_shape) == "true";
+
+    phase.emplace_back(
+      std::make_unique<luci::ConvertNCHWToNHWCPass>(preserve_input, preserve_output));
   }
 
   /* TRANSFORM DECLARATION END */

--- a/compiler/luci/pass/src/ConvertNCHWToNHWCPass.cpp
+++ b/compiler/luci/pass/src/ConvertNCHWToNHWCPass.cpp
@@ -513,7 +513,17 @@ bool ConvertNCHWToNHWCPass::run(loco::Graph *g)
     {
       // List of supported Ops
       case luci::CircleOpcode::CIRCLEINPUT:
+        if (!_preserve_input && !has_data_format(node))
+        {
+          set_data_format(node, DataFormat::NCHW);
+        }
+        break;
       case luci::CircleOpcode::CIRCLEOUTPUT:
+        if (!_preserve_output && !has_data_format(node))
+        {
+          set_data_format(node, DataFormat::NCHW);
+        }
+        break;
       case luci::CircleOpcode::ADD:
       case luci::CircleOpcode::MUL:
       case luci::CircleOpcode::PAD:

--- a/compiler/luci/pass/src/ConvertNCHWToNHWCPass.test.cpp
+++ b/compiler/luci/pass/src/ConvertNCHWToNHWCPass.test.cpp
@@ -238,7 +238,7 @@ void check_post_trans(loco::Node *node)
   EXPECT_EQ(2, post_trans_perm->at<loco::DataType::S32>(3));
 }
 
-void run_phase(loco::Graph *g, bool preserve_input = false, bool preserve_output = false)
+void run_phase(loco::Graph *g, bool preserve_input, bool preserve_output)
 {
   logo::Phase phase;
 
@@ -262,7 +262,7 @@ TEST(ConvertNCHWToNHWC, Add)
   AddGraph g;
   g.init();
 
-  run_phase(&g.g);
+  run_phase(&g.g, false, false);
 
   auto input_succs = loco::succs(g.input);
   EXPECT_EQ(1, input_succs.size());
@@ -291,7 +291,7 @@ TEST(ConvertNCHWToNHWC, Mul)
   MulGraph g;
   g.init();
 
-  run_phase(&g.g);
+  run_phase(&g.g, false, false);
 
   auto input_succs = loco::succs(g.input);
   EXPECT_EQ(1, input_succs.size());
@@ -320,7 +320,7 @@ TEST(ConvertNCHWToNHWC, Pad)
   PadGraph g;
   g.init();
 
-  run_phase(&g.g);
+  run_phase(&g.g, false, false);
 
   auto input_succs = loco::succs(g.input);
   EXPECT_EQ(1, input_succs.size());
@@ -359,7 +359,7 @@ TEST(ConvertNCHWToNHWC, Unknown_Shape_NEG)
   g.add->dim(0).unset();
   g.output->dim(0).unset();
 
-  luci::ConvertNCHWToNHWCPass pass;
+  luci::ConvertNCHWToNHWCPass pass(false, false);
   EXPECT_EQ(false, pass.run(&g.g));
 }
 


### PR DESCRIPTION
This adds options to preserve input/output shape in ConvertNCHWToNHWCPass.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: #5600 
Draft PR: #5601

