### PR TITLE
[luci] Enable new shape inference pass in ConvertNCHWToNHWCPass

### DIFF
--- a/compiler/luci/pass/src/ConvertNCHWToNHWCPass.test.cpp
+++ b/compiler/luci/pass/src/ConvertNCHWToNHWCPass.test.cpp
@@ -18,6 +18,7 @@
 
 #include "luci/Pass/ConvertNCHWToNHWCPass.h"
 #include "luci/Pass/ShapeInferencePass.h"
+#include "luci/Pass/CircleShapeInferencePass.h"
 
 // TODO: Remove this after refactoring is done
 #include "luci/Pass/MigrateLegacyShapeDtypePass.h"
@@ -246,6 +247,7 @@ void run_phase(loco::Graph *g)
   // TODO: Remove this after refactoring is done
   phase.emplace_back(std::make_unique<luci::MigrateLegacyShapeDtypePass>());
   phase.emplace_back(std::make_unique<luci::ShapeInferencePass>());
+  phase.emplace_back(std::make_unique<luci::CircleShapeInferencePass>());
 
   // Pass to test
   phase.emplace_back(std::make_unique<luci::ConvertNCHWToNHWCPass>());


### PR DESCRIPTION
Parent Issue : #5501

This commit will enable new shape inference pass, `CircleShapeInferencePass` in `ConvertNCHWToNHWCPass`.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>