### PR TITLE
[luci] Encode ShapeSignature using shape description

### DIFF
--- a/compiler/luci/export/src/CircleTensorExporter.cpp
+++ b/compiler/luci/export/src/CircleTensorExporter.cpp
@@ -247,12 +247,21 @@ flatbuffers::Offset<Vector<int32_t>> encodeShape(FlatBufferBuilder &builder,
 }
 
 flatbuffers::Offset<Vector<int32_t>> encodeShapeSignature(FlatBufferBuilder &builder,
-                                                          const ShapeSignature &shape_signature)
+                                                          const ShapeDescription &shape)
 {
-  if (shape_signature.rank() == 0)
-    return 0;
+  assert(shape._rank_known && "unknown number of dimensions is not supported");
+  flatbuffers::Offset<Vector<int32_t>> signature_offset;
+  bool has_unknown = false;
 
-  return builder.CreateVector(shape_signature.as_vector());
+  for (uint32_t i = 0; i < shape._dims.size(); ++i)
+    if (shape._dims.at(i) == -1)
+      has_unknown = true;
+
+  // If all of dimensions are known, shape_signature should be empty.
+  if (has_unknown)
+    signature_offset = builder.CreateVector(shape._dims);
+
+  return signature_offset;
 }
 
 flatbuffers::Offset<circle::Buffer> encodeOpBuffer(FlatBufferBuilder &builder)
@@ -444,14 +453,16 @@ void exportOpDefinedTensor(const CircleTensoInfo &info, FlatBufferBuilder &build
 {
   // Create and register output tensor shape
   flatbuffers::Offset<Vector<int32_t>> shape_offset;
+  flatbuffers::Offset<Vector<int32_t>> shape_signature_offset;
   if (info.shape_status() == ShapeStatus::VALID)
+  {
     shape_offset = encodeShape(builder, info.shape());
+    shape_signature_offset = encodeShapeSignature(builder, info.shape());
+  }
 
   auto quantparam = encodeQuantizationParameters(builder, info.quantparam());
 
   auto sparsityparam = encodeSparsityParameters(builder, info.sparsityparam());
-
-  auto shape_signature_offset = encodeShapeSignature(builder, info.shape_signature());
 
   auto buffer_id = get_buffer_id(builder, md, info.content());
 

--- a/compiler/luci/export/src/CircleTensorExporter.cpp
+++ b/compiler/luci/export/src/CircleTensorExporter.cpp
@@ -250,18 +250,13 @@ flatbuffers::Offset<Vector<int32_t>> encodeShapeSignature(FlatBufferBuilder &bui
                                                           const ShapeDescription &shape)
 {
   assert(shape._rank_known && "unknown number of dimensions is not supported");
-  flatbuffers::Offset<Vector<int32_t>> signature_offset;
-  bool has_unknown = false;
 
+  // shape_signature is set if and only if at least one of dimensions are unknown.
   for (uint32_t i = 0; i < shape._dims.size(); ++i)
     if (shape._dims.at(i) == -1)
-      has_unknown = true;
+      return builder.CreateVector(shape._dims);
 
-  // shape_signature should be empty if at least one of dimensions are unknown.
-  if (has_unknown)
-    signature_offset = builder.CreateVector(shape._dims);
-
-  return signature_offset;
+  return flatbuffers::Offset<Vector<int32_t>>();
 }
 
 flatbuffers::Offset<circle::Buffer> encodeOpBuffer(FlatBufferBuilder &builder)

--- a/compiler/luci/export/src/CircleTensorExporter.cpp
+++ b/compiler/luci/export/src/CircleTensorExporter.cpp
@@ -257,7 +257,7 @@ flatbuffers::Offset<Vector<int32_t>> encodeShapeSignature(FlatBufferBuilder &bui
     if (shape._dims.at(i) == -1)
       has_unknown = true;
 
-  // If all of dimensions are known, shape_signature should be empty.
+  // shape_signature should be empty if at least one of dimensions are unknown.
   if (has_unknown)
     signature_offset = builder.CreateVector(shape._dims);
 


### PR DESCRIPTION
Parent Issue : #5501

Until now, shape_signature was encoded using `CircleShapeSignature`.
However, as `TensorShape` of `CircleNode` can represent shape_siganture,
this commit will enable encoding shape_signature using shape description, not `CircleShapeSignature`.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>