### PR TITLE
DRAFT: Fold SparseToDense with zero-sized indices

### DIFF
--- a/compiler/circle2circle/src/Circle2Circle.cpp
+++ b/compiler/circle2circle/src/Circle2Circle.cpp
@@ -66,6 +66,12 @@ int entry(int argc, char **argv)
     .default_value(false)
     .help("This will fold dequantize op");
 
+  arser.add_argument("--fold_sparse_to_dense")
+    .nargs(0)
+    .required(false)
+    .default_value(false)
+    .help("This will fold SparseToDense");
+
   arser.add_argument("--fuse_activation_function")
     .nargs(0)
     .required(false)
@@ -251,6 +257,8 @@ int entry(int argc, char **argv)
   }
   if (arser.get<bool>("--fold_dequantize"))
     options->enable(Algorithms::FoldDequantize);
+  if (arser.get<bool>("--fold_sparse_to_dense"))
+    options->enable(Algorithms::FoldSparseToDense);
   if (arser.get<bool>("--fuse_activation_function"))
     options->enable(Algorithms::FuseActivationFunction);
   if (arser.get<bool>("--fuse_add_with_tconv"))

--- a/compiler/luci/pass/include/luci/CircleOptimizer.h
+++ b/compiler/luci/pass/include/luci/CircleOptimizer.h
@@ -45,6 +45,7 @@ public:
       QuantizeWithMinMax,
       Requantize,
       FoldDequantize,
+      FoldSparseToDense,
       SparsifyTensorPass,
       FusePreActivationBatchNorm,
       MakeBatchNormGammaPositive,

--- a/compiler/luci/pass/include/luci/Pass/FoldSparseToDensePass.h
+++ b/compiler/luci/pass/include/luci/Pass/FoldSparseToDensePass.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __LUCI_FOLD_SPARSE_TO_DENSE_PASS_H__
+#define __LUCI_FOLD_SPARSE_TO_DENSE_PASS_H__
+
+#include <logo/Pass.h>
+
+namespace luci
+{
+
+/**
+ * @brief  Class to fold SparseToDense to a constant tensor
+ *
+ */
+struct FoldSparseToDensePass final : public logo::Pass
+{
+  const char *name(void) const final { return "luci::FoldSparseToDensePass"; }
+
+  bool run(loco::Graph *g) final;
+};
+
+} // namespace luci
+
+#endif // __LUCI_FOLD_SPARSE_TO_DENSE_PASS_H__

--- a/compiler/luci/pass/src/CircleOptimizer.cpp
+++ b/compiler/luci/pass/src/CircleOptimizer.cpp
@@ -18,6 +18,7 @@
 
 #include "luci/Pass/ConvertNCHWToNHWCPass.h"
 #include "luci/Pass/FoldDequantizePass.h"
+#include "luci/Pass/FoldSparseToDensePass.h"
 #include "luci/Pass/FuseActivationFunctionPass.h"
 #include "luci/Pass/FuseAddWithTConvPass.h"
 #include "luci/Pass/FuseBatchNormWithTConv.h"
@@ -201,6 +202,10 @@ void CircleOptimizer::optimize(loco::Graph *g) const
   if (_options->query(Options::Algorithm::FoldDequantize))
   {
     phase.emplace_back(std::make_unique<luci::FoldDequantizePass>());
+  }
+  if (_options->query(Options::Algorithm::FoldSparseToDense))
+  {
+    phase.emplace_back(std::make_unique<luci::FoldSparseToDensePass>());
   }
   if (_options->query(Options::Algorithm::FusePreActivationBatchNorm))
   {

--- a/compiler/luci/pass/src/FoldSparseToDensePass.cpp
+++ b/compiler/luci/pass/src/FoldSparseToDensePass.cpp
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Pass/FoldSparseToDensePass.h"
+#include "CircleOptimizerUtils.h"
+
+#include <luci/IR/CircleNodes.h>
+
+namespace
+{
+
+/**
+ * Fold to const if
+ *
+ * 1. indices has 0-sized static shape (i.e., output is filled with default value)
+ * 2. defalut_value: const scalar
+ * 3. output_shape: const
+ *
+ * TODO: Support more general patterns
+ **/
+template <loco::DataType IndexT, loco::DataType ValueT>
+bool fold_sparse_to_dense(luci::CircleSparseToDense *stod)
+{
+  const auto indices = loco::must_cast<luci::CircleNode *>(stod->indices());
+  const auto default_value = loco::must_cast<luci::CircleConst *>(stod->default_value());
+  const auto output_shape = loco::must_cast<luci::CircleConst *>(stod->output_shape());
+
+  int32_t indices_size = 1;
+  for (uint32_t i = 0; i < indices->rank(); i++)
+  {
+    if (!indices->dim(i).known())
+      return false;
+    indices_size *= indices->dim(i).value();
+  }
+
+  if (indices_size != 0)
+    return false;
+
+  if (default_value->rank() != 0 || default_value->size<ValueT>() != 1)
+    return false;
+
+  auto rank = output_shape->size<IndexT>();
+  std::vector<uint32_t> shape;
+  for (uint32_t i = 0; i < rank; i++)
+  {
+    auto dim = output_shape->at<IndexT>(i);
+    assert(dim >= 0 && dim <= std::numeric_limits<uint32_t>::max());
+    if (!(dim >= 0 && dim <= std::numeric_limits<uint32_t>::max()))
+      return false;
+
+    shape.push_back(dim);
+  }
+
+  auto constant = stod->graph()->nodes()->create<luci::CircleConst>();
+  constant->dtype(default_value->dtype());
+  constant->rank(rank);
+  uint32_t dim_size = 1;
+  for (uint32_t i = 0; i < rank; i++)
+  {
+    constant->dim(i).set(shape[i]);
+    dim_size *= shape[i];
+  }
+
+  constant->size<ValueT>(dim_size);
+  const auto value = default_value->scalar<ValueT>();
+  for (uint32_t i = 0; i < dim_size; i++)
+    constant->at<ValueT>(i) = value;
+
+  constant->shape_status(luci::ShapeStatus::VALID);
+
+  loco::replace(stod).with(constant);
+
+  return true;
+}
+
+bool fold_sparse_to_dense(luci::CircleSparseToDense *stod)
+{
+  auto indices = loco::must_cast<luci::CircleNode *>(stod->indices());
+  auto default_value = dynamic_cast<luci::CircleConst *>(stod->default_value());
+  if (not default_value)
+    return false;
+
+  auto output_shape = dynamic_cast<luci::CircleConst *>(stod->output_shape());
+  if (not output_shape)
+    return false;
+
+  // Illegal input check
+  if (indices->dtype() != output_shape->dtype())
+    throw std::runtime_error("indices and output_shape of SparseToDense must have the same dtype");
+
+  // TODO: Support more data types
+  if (indices->dtype() == loco::DataType::S64)
+  {
+    if (default_value->dtype() == loco::DataType::S64)
+    {
+      return fold_sparse_to_dense<loco::DataType::S64, loco::DataType::S64>(stod);
+    }
+  }
+  return false;
+}
+
+} // namespace
+
+namespace luci
+{
+
+/**
+ * Constant Folding for SparseToDense Op
+ **/
+bool FoldSparseToDensePass::run(loco::Graph *g)
+{
+  for (auto node : loco::active_nodes(loco::output_nodes(g)))
+  {
+    if (auto stod = dynamic_cast<luci::CircleSparseToDense *>(node))
+    {
+      if (fold_sparse_to_dense(stod))
+        return true;
+    }
+  }
+
+  return false;
+}
+
+} // namespace luci

--- a/compiler/luci/pass/src/FoldSparseToDensePass.test.cpp
+++ b/compiler/luci/pass/src/FoldSparseToDensePass.test.cpp
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Pass/FoldSparseToDensePass.h"
+#include "PassTestUtils.h"
+
+#include <luci/IR/CircleNodes.h>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+
+/**
+ *  Graph that has a SparseToDense Op with zero-sized indices
+ *
+ *    BEFORE
+ *    - shape of indices: [0,1]
+ *    - output_shape: [3]
+ *    - default_value: scalar 2
+ *
+ *     [indices] [output_shape] [values] [default_value]
+ *            |         |          |      |
+ *            +------[SparseToDense]------+
+ *
+ *    AFTER
+ *
+ *            [Const] (shape: [3], values: [2, 2, 2])
+ *
+ */
+class S64SparseToDenseZeroIndicesGraph final : public luci::ConstantFoldingTestGraph
+{
+public:
+  S64SparseToDenseZeroIndicesGraph(std::vector<int32_t> input_shape, loco::DataType input_dtype)
+    : luci::ConstantFoldingTestGraph(input_shape, input_dtype)
+  {
+  }
+
+public:
+  loco::Node *createFoldedPattern() override
+  {
+    stod = g.nodes()->create<luci::CircleSparseToDense>();
+    indices = g.nodes()->create<luci::CircleConst>();
+    output_shape = g.nodes()->create<luci::CircleConst>();
+    values = g.nodes()->create<luci::CircleConst>();
+    default_value = g.nodes()->create<luci::CircleConst>();
+
+    stod->dtype(loco::DataType::S64);
+    indices->dtype(loco::DataType::S64);
+    output_shape->dtype(loco::DataType::S64);
+    values->dtype(loco::DataType::S64);
+    default_value->dtype(loco::DataType::S64);
+
+    indices->shape({0, 1});
+    output_shape->shape({1});
+    values->shape({0});
+    default_value->rank(0);
+
+    indices->size<loco::DataType::S64>(0);
+    output_shape->size<loco::DataType::S64>(1);
+    output_shape->at<loco::DataType::S64>(0) = 3;
+    values->size<loco::DataType::S64>(0);
+    default_value->size<loco::DataType::S64>(1);
+    default_value->at<loco::DataType::S64>(0) = 2;
+
+    stod->indices(indices);
+    stod->output_shape(output_shape);
+    stod->values(values);
+    stod->default_value(default_value);
+
+    return stod;
+  }
+
+public:
+  luci::CircleSparseToDense *stod = nullptr;
+  luci::CircleConst *indices = nullptr;
+  luci::CircleConst *output_shape = nullptr;
+  luci::CircleConst *values = nullptr;
+  luci::CircleConst *default_value = nullptr;
+};
+
+} // namespace
+
+TEST(FoldSparseToDense, S64Value)
+{
+  S64SparseToDenseZeroIndicesGraph g({3}, loco::DataType::S64);
+  g.init();
+
+  luci::FoldSparseToDensePass pass;
+  while (pass.run(&g.g))
+    ;
+
+  auto folded_const = dynamic_cast<luci::CircleConst *>(g.add->y());
+  EXPECT_NE(nullptr, folded_const);
+
+  // Chec type, shape, values of folded const
+  EXPECT_EQ(loco::DataType::S64, folded_const->dtype());
+  EXPECT_EQ(1, folded_const->rank());
+  EXPECT_EQ(3, folded_const->dim(0).value());
+  EXPECT_EQ(2, folded_const->at<loco::DataType::S64>(0));
+  EXPECT_EQ(2, folded_const->at<loco::DataType::S64>(1));
+  EXPECT_EQ(2, folded_const->at<loco::DataType::S64>(2));
+}
+
+TEST(FoldSparseToDense, Illegal_input_NEG)
+{
+  S64SparseToDenseZeroIndicesGraph g({3}, loco::DataType::S64);
+  g.init();
+
+  g.indices->dtype(loco::DataType::S32);
+
+  luci::FoldSparseToDensePass pass;
+  EXPECT_ANY_THROW(pass.run(&g.g));
+}

--- a/compiler/luci/pass/src/PassTestUtils.h
+++ b/compiler/luci/pass/src/PassTestUtils.h
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __LUCI_PASS_TEST_UTILS_H__
+#define __LUCI_PASS_TEST_UTILS_H__
+
+#include <loco.h>
+#include <luci/IR/CircleNodes.h>
+
+namespace luci
+{
+
+/**
+ *
+ *  Graph for testing a Pass that performs constant folding
+ *    - Input type == Output type
+ *    - Input shape == Output shape
+ *    - Folded pattern must have the same type with Input/Output
+ *
+ *      [Input]   [Folded pattern] (Implemented by child class)
+ *           \     /
+ *            [Add]
+ *              |
+ *           [Output]
+ *
+ */
+class ConstantFoldingTestGraph
+{
+public:
+  ConstantFoldingTestGraph(std::vector<int32_t> input_shape, loco::DataType input_dtype)
+  {
+    input = g.nodes()->create<luci::CircleInput>();
+    add = g.nodes()->create<luci::CircleAdd>();
+    output = g.nodes()->create<luci::CircleOutput>();
+
+    auto graph_input = g.inputs()->create();
+    input->index(graph_input->index());
+    auto graph_output = g.outputs()->create();
+    output->index(graph_output->index());
+
+    graph_input->dtype(input_dtype);
+    graph_output->dtype(input_dtype);
+    input->dtype(input_dtype);
+    add->dtype(input_dtype);
+    output->dtype(input_dtype);
+
+    auto input_tensor_shape = std::make_unique<loco::TensorShape>();
+    input_tensor_shape->rank(input_shape.size());
+    for (int i = 0; i < input_shape.size(); i++)
+      input_tensor_shape->dim(i) = input_shape[i];
+    graph_input->shape(std::move(input_tensor_shape));
+
+    auto output_tensor_shape = std::make_unique<loco::TensorShape>();
+    output_tensor_shape->rank(input_shape.size());
+    for (int i = 0; i < input_shape.size(); i++)
+      output_tensor_shape->dim(i) = input_shape[i];
+    graph_output->shape(std::move(output_tensor_shape));
+
+    input->rank(input_shape.size());
+    for (int i = 0; i < input_shape.size(); i++)
+      input->dim(i).set(input_shape[i]);
+
+    add->rank(input_shape.size());
+    for (int i = 0; i < input_shape.size(); i++)
+      add->dim(i).set(input_shape[i]);
+
+    output->rank(input_shape.size());
+    for (int i = 0; i < input_shape.size(); i++)
+      output->dim(i).set(input_shape[i]);
+
+    add->x(input);
+    output->from(add);
+  }
+
+public:
+  void init() { add->y(createFoldedPattern()); }
+
+  virtual ~ConstantFoldingTestGraph() = default;
+
+protected:
+  virtual loco::Node *createFoldedPattern() = 0;
+
+public:
+  loco::Graph g;
+  luci::CircleInput *input = nullptr;
+  luci::CircleAdd *add = nullptr;
+  luci::CircleOutput *output = nullptr;
+};
+
+} // namespace luci
+
+#endif // __LUCI_PASS_TEST_UTILS_H__

--- a/compiler/one-cmds/how-to-use-one-commands.txt
+++ b/compiler/one-cmds/how-to-use-one-commands.txt
@@ -150,6 +150,7 @@ one-optimize provides network or operator transformation shown below.
 
 Current transformation options are
 - fold_dequantize : This removes Dequantize operation which can be folded
+- fold_sparse_to_dense : This removes SparseToDense operation which can be folded
 - fuse_add_with_tconv: This fuses Add operator with the preceding TConv operator if possible
 - fuse_bcq: This enables Binary-Coded-bases Quantized DNNs
    - read https://arxiv.org/abs/2005.09904 for detailed information

--- a/compiler/one-cmds/one-optimize
+++ b/compiler/one-cmds/one-optimize
@@ -49,6 +49,8 @@ def _get_parser():
     circle2circle_group.add_argument(
         '--fold_dequantize', action='store_true', help='fold Dequantize op')
     circle2circle_group.add_argument(
+        '--fold_sparse_to_dense', action='store_true', help='fold SparseToDense op')
+    circle2circle_group.add_argument(
         '--fuse_add_with_tconv', action='store_true', help='fuse Add op to Transposed')
     circle2circle_group.add_argument(
         '--fuse_batchnorm_with_tconv',

--- a/compiler/one-cmds/utils.py
+++ b/compiler/one-cmds/utils.py
@@ -119,6 +119,8 @@ def _make_circle2circle_cmd(args, driver_path, input_path, output_path):
         cmd.append('--all')
     if _is_valid_attr(args, 'fold_dequantize'):
         cmd.append('--fold_dequantize')
+    if _is_valid_attr(args, 'fold_sparse_to_dense'):
+        cmd.append('--fold_sparse_to_dense')
     if _is_valid_attr(args, 'fuse_add_with_tconv'):
         cmd.append('--fuse_add_with_tconv')
     if _is_valid_attr(args, 'fuse_batchnorm_with_tconv'):


### PR DESCRIPTION
On going draft to fold SparseToDense with zero-sized indices.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to : https://github.com/Samsung/ONE/issues/5598