### PR TITLE
[nnfwapi] Test: fix Add model test bug 2

### DIFF
--- a/tests/nnfw_api/src/fixtures.h
+++ b/tests/nnfw_api/src/fixtures.h
@@ -189,6 +189,7 @@ protected:
       auto cbuf = genAddModel();
       NNFW_ENSURE_SUCCESS(nnfw_load_circle_from_buffer(obj.session, cbuf.buffer(), cbuf.size()));
       ASSERT_EQ(nnfw_prepare(obj.session), NNFW_STATUS_NO_ERROR);
+      _cbufs.push_back(std::move(cbuf)); // Keep the buffer so it can outlive the session
 
       uint32_t num_inputs;
       ASSERT_EQ(nnfw_input_size(obj.session, &num_inputs), NNFW_STATUS_NO_ERROR);
@@ -231,6 +232,7 @@ protected:
 
 protected:
   std::array<SessionObject, NUM_SESSIONS> _objects;
+  std::vector<CircleBuffer> _cbufs;
 };
 
 class ValidationTestTwoSessions : public ValidationTest


### PR DESCRIPTION
As `nnfw_load_circle_from_buffer` requires the input buffer to outlive
the session, so this change makes `_cbuf` as a member.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>