### PR TITLE
[one-cmds] Options to preserve NCHW input/output shape

### DIFF
--- a/compiler/one-cmds/one-optimize
+++ b/compiler/one-cmds/one-optimize
@@ -54,11 +54,11 @@ def _get_parser():
     circle2circle_group.add_argument(
         '--nchw_to_nhwc_preserve_input_shape',
         action='store_true',
-        help='preserve the input shape of the model')
+        help='preserve the input shape of the model (argument for convert_nchw_to_nhwc)')
     circle2circle_group.add_argument(
         '--nchw_to_nhwc_preserve_output_shape',
         action='store_true',
-        help='preserve the output shape of the model')
+        help='preserve the output shape of the model (argument for convert_nchw_to_nhwc)')
     circle2circle_group.add_argument(
         '--fold_dequantize', action='store_true', help='fold Dequantize op')
     circle2circle_group.add_argument(

--- a/compiler/one-cmds/one-optimize
+++ b/compiler/one-cmds/one-optimize
@@ -52,6 +52,14 @@ def _get_parser():
         help="""Experimental: This will convert NCHW operators to NHWC under the
         assumption that input model is NCHW.""")
     circle2circle_group.add_argument(
+        '--nchw_to_nhwc_preserve_input_shape',
+        action='store_true',
+        help='preserve the input shape of the model')
+    circle2circle_group.add_argument(
+        '--nchw_to_nhwc_preserve_output_shape',
+        action='store_true',
+        help='preserve the output shape of the model')
+    circle2circle_group.add_argument(
         '--fold_dequantize', action='store_true', help='fold Dequantize op')
     circle2circle_group.add_argument(
         '--fuse_add_with_tconv', action='store_true', help='fuse Add op to Transposed')

--- a/compiler/one-cmds/utils.py
+++ b/compiler/one-cmds/utils.py
@@ -119,6 +119,10 @@ def _make_circle2circle_cmd(args, driver_path, input_path, output_path):
         cmd.append('--all')
     if _is_valid_attr(args, 'convert_nchw_to_nhwc'):
         cmd.append('--convert_nchw_to_nhwc')
+    if _is_valid_attr(args, 'nchw_to_nhwc_preserve_input_shape'):
+        cmd.append('--nchw_to_nhwc_preserve_input_shape')
+    if _is_valid_attr(args, 'nchw_to_nhwc_preserve_output_shape'):
+        cmd.append('--nchw_to_nhwc_preserve_output_shape')
     if _is_valid_attr(args, 'fold_dequantize'):
         cmd.append('--fold_dequantize')
     if _is_valid_attr(args, 'fuse_add_with_tconv'):


### PR DESCRIPTION
This adds options to preserve input/output shape in ConvertNCHWToNHWCPass.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: #5600
Draft PR: #5601