### PR TITLE
[luci] Shape/dtype inference for CircleFakeQuant

### DIFF
--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -197,6 +197,12 @@ template <class CIRCLENODE> loco::NodeShape broadcast_xy(const CIRCLENODE *node)
   return loco::NodeShape{output_shape};
 }
 
+template <class CIRCLENODE> loco::NodeShape use_inputs(const CIRCLENODE *node)
+{
+  auto inputs_shape = loco::shape_get(node->inputs()).template as<loco::TensorShape>();
+  return loco::NodeShape{inputs_shape};
+}
+
 template <class CIRCLENODE> loco::NodeShape use_x(const CIRCLENODE *node)
 {
   auto x_shape = loco::shape_get(node->x()).template as<loco::TensorShape>();
@@ -2113,6 +2119,8 @@ public:
   {
     return infer_expand_dims(node);
   }
+
+  loco::NodeShape visit(const luci::CircleFakeQuant *node) final { return use_inputs(node); }
 
   loco::NodeShape visit(const luci::CircleFill *node) final { return infer_fill(node); }
 

--- a/compiler/luci/service/src/CircleTypeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleTypeInferenceRule.cpp
@@ -129,6 +129,11 @@ struct TypeInferenceAlgorithm final : public luci::CircleNodeVisitor<loco::DataT
     return loco::dtype_get(node->input());
   }
 
+  loco::DataType visit(const luci::CircleFakeQuant *node) final
+  {
+    return loco::dtype_get(node->inputs());
+  }
+
   loco::DataType visit(const luci::CircleFill *node) final
   {
     return loco::dtype_get(node->value());


### PR DESCRIPTION
This will enable shape and dtype inference for CircleFakeQuant node.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>