### PR TITLE
[luci] Enable FuseBatchNormWithConvPass in CircleOptimizer

### DIFF
--- a/compiler/luci/pass/include/luci/CircleOptimizer.h
+++ b/compiler/luci/pass/include/luci/CircleOptimizer.h
@@ -35,6 +35,7 @@ public:
     enum Algorithm
     {
       FuseAddWithTConv,
+      FuseBatchNormWithConv,
       FuseBatchNormWithTConv,
       FuseBCQ,
       FuseInstanceNorm,

--- a/compiler/luci/pass/src/CircleOptimizer.cpp
+++ b/compiler/luci/pass/src/CircleOptimizer.cpp
@@ -21,6 +21,7 @@
 #include "luci/Pass/FoldSparseToDensePass.h"
 #include "luci/Pass/FuseActivationFunctionPass.h"
 #include "luci/Pass/FuseAddWithTConvPass.h"
+#include "luci/Pass/FuseBatchNormWithConvPass.h"
 #include "luci/Pass/FuseBatchNormWithTConv.h"
 #include "luci/Pass/FuseBCQPass.h"
 #include "luci/Pass/FuseInstanceNormPass.h"
@@ -186,6 +187,10 @@ void CircleOptimizer::optimize(loco::Graph *g) const
   if (_options->query(Options::Algorithm::FuseInstanceNorm))
   {
     phase.emplace_back(std::make_unique<FuseInstanceNormPass>());
+  }
+  if (_options->query(Options::Algorithm::FuseBatchNormWithConv))
+  {
+    phase.emplace_back(std::make_unique<FuseBatchNormWithConvPass>());
   }
   if (_options->query(Options::Algorithm::FuseBatchNormWithTConv))
   {


### PR DESCRIPTION
Parent Issue : #5618 

This commit will enalble `FuseBatchNormWithConvPass` in `CircleOptimizer`.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>