### PR TITLE
[luci] Add CircleFakeQuant to comment list

### DIFF
--- a/compiler/luci/service/include/luci/Service/CircleShapeInference.h
+++ b/compiler/luci/service/include/luci/Service/CircleShapeInference.h
@@ -83,6 +83,7 @@ public:
   // loco::TensorShape visit(const luci::CircleEqual *node) final;
   // loco::TensorShape visit(const luci::CircleExp *node) final;
   // loco::TensorShape visit(const luci::CircleExpandDims *node) final;
+  // loco::TensorShape visit(const luci::CircleFakeQuant *node) final;
   // loco::TensorShape visit(const luci::CircleFill *node) final;
   // loco::TensorShape visit(const luci::CircleFloor *node) final;
   // loco::TensorShape visit(const luci::CircleFloorDiv *node) final;

--- a/compiler/luci/service/include/luci/Service/CircleTypeInference.h
+++ b/compiler/luci/service/include/luci/Service/CircleTypeInference.h
@@ -84,6 +84,7 @@ public:
   // loco::DataType visit(const luci::CircleEqual *node) final;
   // loco::DataType visit(const luci::CircleExp *node) final;
   // loco::DataType visit(const luci::CircleExpandDims *node) final;
+  // loco::DataType visit(const luci::CircleFakeQuant *node) final;
   // loco::DataType visit(const luci::CircleFill *node) final;
   // loco::DataType visit(const luci::CircleFloor *node) final;
   // loco::DataType visit(const luci::CircleFloorDiv *node) final;


### PR DESCRIPTION
This commit will add `CircleFakeQuant` to comment list in luci/Service.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>