### PR TITLE
[circle2circle] Add FuseBatchNormWithConv option to circle2circle

### DIFF
--- a/compiler/circle2circle/src/Circle2Circle.cpp
+++ b/compiler/circle2circle/src/Circle2Circle.cpp
@@ -84,6 +84,12 @@ int entry(int argc, char **argv)
     .default_value(false)
     .help("This will fuse Add operator to Transposed Convolution operator");
 
+  arser.add_argument("--fuse_batchnorm_with_conv")
+    .nargs(0)
+    .required(false)
+    .default_value(false)
+    .help("This will fuse BatchNorm operators to Convolution operator");
+
   arser.add_argument("--fuse_batchnorm_with_tconv")
     .nargs(0)
     .required(false)
@@ -273,6 +279,8 @@ int entry(int argc, char **argv)
     options->enable(Algorithms::FoldSparseToDense);
   if (arser.get<bool>("--fuse_activation_function"))
     options->enable(Algorithms::FuseActivationFunction);
+  if (arser.get<bool>("--fuse_batchnorm_with_conv"))
+    options->enable(Algorithms::FuseBatchNormWithConv);
   if (arser.get<bool>("--fuse_add_with_tconv"))
     options->enable(Algorithms::FuseAddWithTConv);
   if (arser.get<bool>("--fuse_batchnorm_with_tconv"))


### PR DESCRIPTION
Parent issue : #5618 

This commit will add `FuseBatchNormWithConv` option to circle2circle.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>