### PR TITLE
[one-cmds] Introduce FuseBatchNormWithConv in one-cmds

### DIFF
--- a/compiler/one-cmds/one-optimize
+++ b/compiler/one-cmds/one-optimize
@@ -64,6 +64,10 @@ def _get_parser():
     circle2circle_group.add_argument(
         '--fuse_add_with_tconv', action='store_true', help='fuse Add op to Transposed')
     circle2circle_group.add_argument(
+        '--fuse_batchnorm_with_conv',
+        action='store_true',
+        help='fuse BatchNorm op to Convolution op')
+    circle2circle_group.add_argument(
         '--fuse_batchnorm_with_tconv',
         action='store_true',
         help='fuse BatchNorm op to Transposed Convolution op')

--- a/compiler/one-cmds/utils.py
+++ b/compiler/one-cmds/utils.py
@@ -127,6 +127,8 @@ def _make_circle2circle_cmd(args, driver_path, input_path, output_path):
         cmd.append('--fold_dequantize')
     if _is_valid_attr(args, 'fuse_add_with_tconv'):
         cmd.append('--fuse_add_with_tconv')
+    if _is_valid_attr(args, 'fuse_batchnorm_with_conv'):
+        cmd.append('--fuse_batchnorm_with_conv')
     if _is_valid_attr(args, 'fuse_batchnorm_with_tconv'):
         cmd.append('--fuse_batchnorm_with_tconv')
     if _is_valid_attr(args, 'fuse_bcq'):


### PR DESCRIPTION
Parent Issue : #5618 

This commit will introduce `FuseBatchNormWithConv` in `one-optimize` and `utils.py`.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>