### PR TITLE
[res] Add FakeQuant_000 tfl recipe

### DIFF
--- a/res/TensorFlowLiteRecipes/FakeQuant_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/FakeQuant_000/test.recipe
@@ -1,0 +1,25 @@
+operand {
+  name: "ifm"
+  type: FLOAT32
+  shape { dim: 1 dim: 3 dim: 3 dim: 2 }
+}
+operand {
+  name: "ofm"
+  type: FLOAT32
+  shape { dim: 1 dim: 3 dim: 3 dim: 2 }
+}
+
+operation {
+  type: "FakeQuant"
+  fakequant_options {
+    min: 0.0
+    max: 1.0
+    num_bits: 8
+    narrow_range: false
+  }
+  input: "ifm"
+  output: "ofm"
+}
+
+input: "ifm"
+output: "ofm"


### PR DESCRIPTION
This will add FakeQuant_000 tfl recipe for basic FAKE_QUANT Op.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>