### PR TITLE
[circle2circle-dredd-recipe-test] Add Net_Conv_Add_Mul recipes

### DIFF
--- a/compiler/circle2circle-dredd-recipe-test/test.lst
+++ b/compiler/circle2circle-dredd-recipe-test/test.lst
@@ -11,6 +11,9 @@
 ## TFLITE RECIPE
 
 Add(Net_Preactivation_BN_000 PASS fuse_preactivation_batchnorm)
+Add(Net_Conv_Add_Mul_000 PASS fuse_batchnorm_with_conv)
+Add(Net_Conv_Add_Mul_001 PASS fuse_batchnorm_with_conv)
+Add(Net_Conv_Add_Mul_002 PASS fuse_batchnorm_with_conv)
 Add(Net_TConv_Add_000 PASS fuse_add_with_tconv)
 Add(Net_TConv_Add_001 PASS fuse_add_with_tconv)
 Add(Net_TConv_Add_002 PASS fuse_add_with_tconv)


### PR DESCRIPTION
Parent Issue : #5618

This commit will add `Net_Conv_Add_Mul_*` recipes to test lists of `circle2circle-dredd-recipe-test`.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>