### PR TITLE
[luci] Make faster RemoveUnnecessarySplitPass

### DIFF
--- a/compiler/luci/pass/src/RemoveUnnecessarySplitPass.cpp
+++ b/compiler/luci/pass/src/RemoveUnnecessarySplitPass.cpp
@@ -56,7 +56,6 @@ bool RemoveUnnecessarySplitPass::run(loco::Graph *g)
     if (remove_unnecessary_split(circle_node))
     {
       changed = true;
-      break;
     }
   }
   return changed;


### PR DESCRIPTION
Since `RemoveUnnecessarySplitPass` does not generate new nodes, there is no reason to break after each nodes.
This commit will remove break and make `RemoveUnnecessarySplitPass` more faster.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>