### PR TITLE
[onert] Move GetQuantizedMultipliersAndShifts out of Conv

### DIFF
--- a/compute/cker/include/cker/operation/Conv.h
+++ b/compute/cker/include/cker/operation/Conv.h
@@ -83,33 +83,6 @@ public:
     }
   }
 
-  void getQuantizedConvolutionMultipliersAndShifts(float input_scale, float output_scale,
-                                                   const float *filter_scales,
-                                                   size_t filter_scales_size, int num_channels)
-  {
-    // Originates from tflite's PopulateConvolutionQuantizationParams()
-    _per_channel_output_multiplier.resize(num_channels);
-    _per_channel_output_shift.resize(num_channels);
-
-    const bool is_per_channel = filter_scales_size > 1;
-    auto per_channel_multiplier = _per_channel_output_multiplier.data();
-    auto per_channel_shift = _per_channel_output_shift.data();
-    for (int i = 0; i < num_channels; ++i)
-    {
-      // If per-tensor quantization parameter is specified, broadcast it along the
-      // quantization dimension (channels_out).
-      const float scale = is_per_channel ? filter_scales[i] : filter_scales[0];
-      const double filter_scale = static_cast<double>(scale);
-      const double effective_output_scale =
-        static_cast<double>(input_scale) * filter_scale / static_cast<double>(output_scale);
-      int32_t significand;
-      int channel_shift;
-      QuantizeMultiplier(effective_output_scale, &significand, &channel_shift);
-      per_channel_multiplier[i] = significand;
-      per_channel_shift[i] = channel_shift;
-    }
-  }
-
   void operator()(const ConvParams &params, const Shape &input_shape, const float *input_data,
                   const Shape &filter_shape, const float *filter_data, const Shape &bias_shape,
                   const float *bias_data, const Shape &output_shape, float *output_data)
@@ -173,6 +146,8 @@ public:
                     input_shape, input_data, filter_shape, filter_data, bias_shape, bias_data,
                     output_shape, output_data);
   }
+  std::vector<int32_t> &per_channel_output_multiplier() { return _per_channel_output_multiplier; }
+  std::vector<int> &per_channel_output_shift() { return _per_channel_output_shift; }
 
 private:
   bool usableMultiThreaded(PaddingType padding_type, uint32_t dilation_width_factor,

--- a/runtime/onert/backend/cpu/ops/ConvolutionLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ConvolutionLayer.cc
@@ -15,6 +15,7 @@
  */
 
 #include "ConvolutionLayer.h"
+#include "OperationUtils.h"
 
 #include "../Tensor.h"
 #include "ir/Padding.h"
@@ -231,9 +232,10 @@ void ConvolutionLayer::prepare()
   {
     if (_kernel->is_constant() && !_input->is_dynamic() && !_output->is_dynamic())
     {
-      kernel.getQuantizedConvolutionMultipliersAndShifts(
+      GetQuantizedConvolutionMultipliersAndShifts(
         _input->data_scale(), _output->data_scale(), _kernel->data_scales().data(),
-        _kernel->data_scales().size(), getShape(_kernel).Dims(0));
+        _kernel->data_scales().size(), getShape(_kernel).Dims(0),
+        kernel.per_channel_output_multiplier(), kernel.per_channel_output_shift());
     }
     else
     {

--- a/runtime/onert/backend/cpu/ops/OperationUtils.h
+++ b/runtime/onert/backend/cpu/ops/OperationUtils.h
@@ -161,6 +161,11 @@ void GetQuantizedConvolutionMultiplier(const IPortableTensor *inputDescr,
 void QuantizeMultiplierGreaterThanOne(double double_multiplier, int32_t *quantized_multiplier,
                                       int *left_shift);
 
+void GetQuantizedConvolutionMultipliersAndShifts(
+  float input_scale, float output_scale, const float *filter_scales, size_t filter_scales_size,
+  int num_channels, std::vector<int32_t> &per_channel_output_multiplier,
+  std::vector<int> &per_channel_output_shift);
+
 template <typename T>
 void CalculateActivationRange(ir::Activation activation, T *activation_min, T *activation_max)
 {


### PR DESCRIPTION
GetQuantizedMultipliersAndShifts is used in DepthwiseConv2D also.
Thus, now it is moved to OperationUtils, out of Conv.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>