### PR TITLE
[DRAFT] [onert] Refactor BackendContext (except ACL backends)

### DIFF
--- a/runtime/onert/backend/CMakeLists.txt
+++ b/runtime/onert/backend/CMakeLists.txt
@@ -1,8 +1,8 @@
 set(LIB_ONERT_BACKEND_ACL_COMMON onert_backend_acl_common)
 
 add_subdirectory(cpu)
-add_subdirectory(acl_cl)
-add_subdirectory(acl_neon)
-add_subdirectory(acl_common)
+#add_subdirectory(acl_cl)
+#add_subdirectory(acl_neon)
+#add_subdirectory(acl_common)
 add_subdirectory(ruy)
 add_subdirectory(xnnpack)

--- a/runtime/onert/backend/cpu/Backend.h
+++ b/runtime/onert/backend/cpu/Backend.h
@@ -39,17 +39,17 @@ public:
 
   std::shared_ptr<IConfig> config() const override { return _config; }
 
-  std::unique_ptr<onert::backend::BackendContext>
-  newContext(const ir::Graph &graph, const std::shared_ptr<custom::IKernelBuilder> &kb,
-             bool) const override
+  std::unique_ptr<onert::backend::BackendContext> newContext(ContextData &&data) const override
   {
-    auto context = std::make_unique<BackendContext>(this, &graph);
+    auto custom_kernel_builder = data.custom_kernel_builder;
+    auto &graph = *data.graph;
+    auto context = std::make_unique<BackendContext>(this, std::move(data));
     auto tr = std::make_shared<cpu_common::TensorRegistry>();
     auto tb = std::make_shared<TensorBuilder>(tr);
     context->tensor_registry = tr;
     context->tensor_builder = tb;
-    context->kernel_gen =
-      std::make_shared<KernelGenerator>(graph, tb, tr, kb, context->external_context());
+    context->kernel_gen = std::make_shared<KernelGenerator>(graph, tb, tr, custom_kernel_builder,
+                                                            context->external_context());
     return context;
   }
 

--- a/runtime/onert/backend/cpu/BackendContext.cc
+++ b/runtime/onert/backend/cpu/BackendContext.cc
@@ -31,24 +31,17 @@ namespace backend
 namespace cpu
 {
 
-ITensorRegistry *BackendContext::genTensors(const std::vector<onert::ir::OperationIndex> &order,
-                                            const compiler::GraphLowerInfo &lower_info)
+ITensorRegistry *BackendContext::genTensors()
 {
-  return cpu_common::genTensors(*this, order, lower_info);
+  return cpu_common::genTensors(*this, _data.op_order);
 }
 
-FunctionMap BackendContext::genKernels(const std::vector<onert::ir::OperationIndex> &order)
+FunctionMap BackendContext::genKernels()
 {
   FunctionMap ret;
 
-  for (auto op_ind : order)
+  for (auto op_ind : _data.op_order)
   {
-    // Skip if operation is not assigned to the backend
-    auto &ops = operation_list();
-    bool assigned = std::any_of(ops.begin(), ops.end(),
-                                [&](const OperationInfo &info) { return info.index == op_ind; });
-    if (!assigned)
-      continue;
     auto fn_seq = kernel_gen->generate(op_ind);
     ret.emplace_back(op_ind, std::move(fn_seq));
   }
@@ -56,12 +49,9 @@ FunctionMap BackendContext::genKernels(const std::vector<onert::ir::OperationInd
   cpu_common::initConsts(*this);
 
   // NOTE For memory optimization, we want to free some operand data
-  for (auto ind : operand_list())
-  {
-    // TODO Remove const_cast
-    auto &obj = const_cast<ir::Graph *>(graph())->operands().at(ind);
-    obj.releaseData();
-  }
+  const_cast<ir::Graph &>(*_data.graph)
+    .operands()
+    .iterate([&](const ir::OperandIndex &, ir::Operand &obj) { obj.releaseData(); });
 
   for (auto &it : ret)
   {

--- a/runtime/onert/backend/cpu/BackendContext.h
+++ b/runtime/onert/backend/cpu/BackendContext.h
@@ -32,24 +32,19 @@ namespace cpu
 class BackendContext : public onert::backend::BackendContext
 {
 public:
-  BackendContext(const Backend *backend, const ir::Graph *graph,
+  BackendContext(const Backend *backend, ContextData &&data,
                  std::shared_ptr<ITensorRegistry> tensor_registry = nullptr,
                  std::shared_ptr<TensorBuilder> tensor_builder = nullptr,
                  std::shared_ptr<KernelGenerator> kernel_gen = nullptr)
-    : onert::backend::BackendContext(backend, graph, tensor_registry),
+    : onert::backend::BackendContext(backend, std::move(data), tensor_registry),
       tensor_builder{tensor_builder}, kernel_gen{kernel_gen}, _external_context(new ExternalContext)
   {
   }
 
-  ITensorRegistry *genTensors(const std::vector<onert::ir::OperationIndex> &order,
-                              const compiler::GraphLowerInfo &lower_info) override;
-  FunctionMap genKernels(const std::vector<onert::ir::OperationIndex> &order) override;
+  ITensorRegistry *genTensors() override;
+  FunctionMap genKernels() override;
 
   std::shared_ptr<ExternalContext> external_context() { return _external_context; }
-
-private:
-  void planTensors(const std::vector<onert::ir::OperationIndex> &order,
-                   const compiler::GraphLowerInfo &lower_info);
 
 public:
   // TODO Make it private

--- a/runtime/onert/backend/ruy/Backend.h
+++ b/runtime/onert/backend/ruy/Backend.h
@@ -39,17 +39,17 @@ public:
 
   std::shared_ptr<IConfig> config() const override { return _config; }
 
-  std::unique_ptr<onert::backend::BackendContext>
-  newContext(const ir::Graph &graph, const std::shared_ptr<custom::IKernelBuilder> &kb,
-             bool) const override
+  std::unique_ptr<onert::backend::BackendContext> newContext(ContextData &&data) const override
   {
-    auto context = std::make_unique<BackendContext>(this, &graph);
+    auto custom_kernel_builder = data.custom_kernel_builder;
+    auto &graph = *data.graph;
+    auto context = std::make_unique<BackendContext>(this, std::move(data));
     auto tr = std::make_shared<cpu_common::TensorRegistry>();
     auto tb = std::make_shared<TensorBuilder>(tr);
     context->tensor_registry = tr;
     context->tensor_builder = tb;
-    context->kernel_gen =
-      std::make_shared<KernelGenerator>(graph, tb, tr, kb, context->external_context());
+    context->kernel_gen = std::make_shared<KernelGenerator>(graph, tb, tr, custom_kernel_builder,
+                                                            context->external_context());
     return context;
   }
 

--- a/runtime/onert/backend/ruy/BackendContext.cc
+++ b/runtime/onert/backend/ruy/BackendContext.cc
@@ -31,24 +31,17 @@ namespace backend
 namespace ruy
 {
 
-ITensorRegistry *BackendContext::genTensors(const std::vector<onert::ir::OperationIndex> &order,
-                                            const compiler::GraphLowerInfo &lower_info)
+ITensorRegistry *BackendContext::genTensors()
 {
-  return cpu_common::genTensors(*this, order, lower_info);
+  return cpu_common::genTensors(*this, _data.op_order);
 }
 
-FunctionMap BackendContext::genKernels(const std::vector<onert::ir::OperationIndex> &order)
+FunctionMap BackendContext::genKernels()
 {
   FunctionMap ret;
 
-  for (auto op_ind : order)
+  for (auto op_ind : _data.op_order)
   {
-    // Skip if operation is not assigned to the backend
-    auto &ops = operation_list();
-    bool assigned = std::any_of(ops.begin(), ops.end(),
-                                [&](const OperationInfo &info) { return info.index == op_ind; });
-    if (!assigned)
-      continue;
     auto fn_seq = kernel_gen->generate(op_ind);
     ret.emplace_back(op_ind, std::move(fn_seq));
   }
@@ -56,12 +49,9 @@ FunctionMap BackendContext::genKernels(const std::vector<onert::ir::OperationInd
   cpu_common::initConsts(*this);
 
   // NOTE For memory optimization, we want to free some operand data
-  for (auto ind : operand_list())
-  {
-    // TODO Remove const_cast
-    auto &obj = const_cast<ir::Graph *>(graph())->operands().at(ind);
-    obj.releaseData();
-  }
+  const_cast<ir::Graph &>(*_data.graph)
+    .operands()
+    .iterate([&](const ir::OperandIndex &, ir::Operand &obj) { obj.releaseData(); });
 
   for (auto &it : ret)
   {

--- a/runtime/onert/backend/ruy/BackendContext.h
+++ b/runtime/onert/backend/ruy/BackendContext.h
@@ -32,19 +32,18 @@ namespace ruy
 class BackendContext : public onert::backend::BackendContext
 {
 public:
-  BackendContext(const Backend *backend, const ir::Graph *graph,
+  BackendContext(const Backend *backend, ContextData &&data,
                  std::shared_ptr<ITensorRegistry> tensor_registry = nullptr,
                  std::shared_ptr<TensorBuilder> tensor_builder = nullptr,
                  std::shared_ptr<KernelGenerator> kernel_gen = nullptr)
-    : onert::backend::BackendContext(backend, graph, tensor_registry),
+    : onert::backend::BackendContext(backend, std::move(data), tensor_registry),
       tensor_builder{tensor_builder}, kernel_gen{kernel_gen}, _external_context(new ExternalContext)
   {
   }
 
-  ITensorRegistry *genTensors(const std::vector<onert::ir::OperationIndex> &order,
-                              const compiler::GraphLowerInfo &lower_info) override;
+  ITensorRegistry *genTensors() override;
 
-  FunctionMap genKernels(const std::vector<ir::OperationIndex> &order) override;
+  FunctionMap genKernels() override;
 
   std::shared_ptr<ExternalContext> external_context() { return _external_context; }
 

--- a/runtime/onert/backend/xnnpack/Backend.h
+++ b/runtime/onert/backend/xnnpack/Backend.h
@@ -39,17 +39,17 @@ public:
 
   std::shared_ptr<IConfig> config() const override { return _config; }
 
-  std::unique_ptr<onert::backend::BackendContext>
-  newContext(const ir::Graph &graph, const std::shared_ptr<custom::IKernelBuilder> &kb,
-             bool) const override
+  std::unique_ptr<onert::backend::BackendContext> newContext(ContextData &&data) const override
   {
-    auto context = std::make_unique<BackendContext>(this, &graph);
+    auto custom_kernel_builder = data.custom_kernel_builder;
+    auto &graph = *data.graph;
+    auto context = std::make_unique<BackendContext>(this, std::move(data));
     auto tr = std::make_shared<cpu_common::TensorRegistry>();
     auto tb = std::make_shared<TensorBuilder>(tr);
     context->tensor_registry = tr;
     context->tensor_builder = tb;
-    context->kernel_gen =
-      std::make_shared<KernelGenerator>(graph, tb, tr, kb, context->external_context());
+    context->kernel_gen = std::make_shared<KernelGenerator>(graph, tb, tr, custom_kernel_builder,
+                                                            context->external_context());
     return context;
   }
 

--- a/runtime/onert/backend/xnnpack/BackendContext.cc
+++ b/runtime/onert/backend/xnnpack/BackendContext.cc
@@ -31,24 +31,17 @@ namespace backend
 namespace xnnpack
 {
 
-ITensorRegistry *BackendContext::genTensors(const std::vector<onert::ir::OperationIndex> &order,
-                                            const compiler::GraphLowerInfo &lower_info)
+ITensorRegistry *BackendContext::genTensors()
 {
-  return cpu_common::genTensors(*this, order, lower_info);
+  return cpu_common::genTensors(*this, _data.op_order);
 }
 
-FunctionMap BackendContext::genKernels(const std::vector<onert::ir::OperationIndex> &order)
+FunctionMap BackendContext::genKernels()
 {
   FunctionMap ret;
 
-  for (auto op_ind : order)
+  for (auto op_ind : _data.op_order)
   {
-    // Skip if operation is not assigned to the backend
-    auto &ops = operation_list();
-    bool assigned = std::any_of(ops.begin(), ops.end(),
-                                [&](const OperationInfo &info) { return info.index == op_ind; });
-    if (!assigned)
-      continue;
     auto fn_seq = kernel_gen->generate(op_ind);
     ret.emplace_back(op_ind, std::move(fn_seq));
   }
@@ -56,12 +49,9 @@ FunctionMap BackendContext::genKernels(const std::vector<onert::ir::OperationInd
   cpu_common::initConsts(*this);
 
   // NOTE For memory optimization, we want to free some operand data
-  for (auto ind : operand_list())
-  {
-    // TODO Remove const_cast
-    auto &obj = const_cast<ir::Graph *>(graph())->operands().at(ind);
-    obj.releaseData();
-  }
+  const_cast<ir::Graph &>(*_data.graph)
+    .operands()
+    .iterate([&](const ir::OperandIndex &, ir::Operand &obj) { obj.releaseData(); });
 
   for (auto &it : ret)
   {

--- a/runtime/onert/backend/xnnpack/BackendContext.h
+++ b/runtime/onert/backend/xnnpack/BackendContext.h
@@ -35,11 +35,11 @@ namespace xnnpack
 class BackendContext : public onert::backend::BackendContext
 {
 public:
-  BackendContext(const Backend *backend, const ir::Graph *graph,
+  BackendContext(const Backend *backend, ContextData &&data,
                  std::shared_ptr<ITensorRegistry> tensor_registry = nullptr,
                  std::shared_ptr<TensorBuilder> tensor_builder = nullptr,
                  std::shared_ptr<KernelGenerator> kernel_gen = nullptr)
-    : onert::backend::BackendContext(backend, graph, tensor_registry),
+    : onert::backend::BackendContext(backend, std::move(data), tensor_registry),
       tensor_builder{tensor_builder}, kernel_gen{kernel_gen}, _external_context(nullptr)
   {
     int num_threads = util::getConfigInt(util::config::XNNPACK_THREADS);
@@ -48,10 +48,8 @@ public:
     _external_context.reset(new ExternalContext(static_cast<size_t>(num_threads)));
   }
 
-  ITensorRegistry *genTensors(const std::vector<onert::ir::OperationIndex> &order,
-                              const compiler::GraphLowerInfo &lower_info) override;
-
-  FunctionMap genKernels(const std::vector<ir::OperationIndex> &order) override;
+  ITensorRegistry *genTensors() override;
+  FunctionMap genKernels() override;
 
   std::shared_ptr<ExternalContext> external_context() { return _external_context; }
 

--- a/runtime/onert/core/include/backend/Backend.h
+++ b/runtime/onert/core/include/backend/Backend.h
@@ -39,9 +39,7 @@ public:
   virtual ~Backend() = default;
   virtual std::shared_ptr<onert::backend::IConfig> config() const = 0;
 
-  virtual std::unique_ptr<BackendContext>
-  newContext(const ir::Graph &graph, const std::shared_ptr<backend::custom::IKernelBuilder> &kb,
-             bool is_linear_executor) const = 0;
+  virtual std::unique_ptr<BackendContext> newContext(ContextData &&) const = 0;
 };
 
 } // namespace backend

--- a/runtime/onert/core/include/backend/BackendContext.h
+++ b/runtime/onert/core/include/backend/BackendContext.h
@@ -33,46 +33,36 @@ struct ITensorRegistry;
 using FunctionMap =
   std::vector<std::pair<ir::OperationIndex, std::unique_ptr<exec::FunctionSequence>>>;
 
+struct ContextData
+{
+  std::unique_ptr<ir::Graph> graph;
+  std::vector<onert::ir::OperationIndex> op_order;
+  util::Set<ir::OperandIndex> external_operands;
+  std::shared_ptr<custom::IKernelBuilder> custom_kernel_builder;
+  bool is_linear_executor;
+};
+
 class BackendContext
 {
 public:
-  struct OperationInfo
-  {
-    ir::OperationIndex index;
-    ir::Layout layout;
-
-    OperationInfo(ir::OperationIndex index, ir::Layout layout) : index{index}, layout{layout} {}
-  };
-
-public:
-  BackendContext(const Backend *backend, const ir::Graph *graph,
+  BackendContext(const Backend *backend, ContextData &&data,
                  std::shared_ptr<ITensorRegistry> tensor_registry = nullptr)
-    : _backend{backend}, _graph{graph}, tensor_registry{tensor_registry}
+    : _backend{backend}, _data{std::move(data)}, tensor_registry{tensor_registry}
   {
   }
 
   virtual ~BackendContext() = default;
 
-  void initialize(const std::vector<OperationInfo> &operation_list,
-                  const std::vector<ir::OperandIndex> &operand_list);
-
   const Backend *backend() const { return _backend; }
-  const ir::Graph *graph() const { return _graph; }
-  const std::vector<OperationInfo> &operation_list() const { return _operation_list; }
-  const std::vector<ir::OperandIndex> &operand_list() const { return _operand_list; }
+  const ir::Graph *graph() const { return _data.graph.get(); }
+  const util::Set<ir::OperandIndex> &external_operands() const { return _data.external_operands; }
 
-  virtual ITensorRegistry *genTensors(const std::vector<onert::ir::OperationIndex> &,
-                                      const compiler::GraphLowerInfo &)
-  {
-    return nullptr;
-  }
-  virtual FunctionMap genKernels(const std::vector<onert::ir::OperationIndex> &) { return {}; }
+  virtual ITensorRegistry *genTensors() { return nullptr; }
+  virtual FunctionMap genKernels() { return {}; }
 
-private:
+protected:
   const Backend *_backend{nullptr};
-  const ir::Graph *_graph{nullptr};
-  std::vector<OperationInfo> _operation_list;
-  std::vector<ir::OperandIndex> _operand_list;
+  ContextData _data;
 
 public:
   std::shared_ptr<ITensorRegistry> tensor_registry;

--- a/runtime/onert/core/include/ir/Graph.h
+++ b/runtime/onert/core/include/ir/Graph.h
@@ -56,7 +56,31 @@ public:
   // Graph Building
 public:
   OperandIndex addOperand(const Shape &shape, const TypeInfo &type);
+  /**
+   * @brief Add an operand to the graph with the given index and object
+   *
+   * If the given index is available, it succeeds. And @c operand is moved which invalidates the
+   * caller's pointer. If the given index is already taken, it fails. And @c operand will not be
+   * moved so the caller's pointer will be still valid.
+   *
+   * @param[in] index Index to be added
+   * @param[in] operand Operand to be added
+   * @return OperandIndex @c index if successful, Undefined otherwise
+   */
+  OperandIndex addOperand(OperandIndex index, std::unique_ptr<Operand> &&operand);
   OperationIndex addOperation(std::unique_ptr<Operation> &&node);
+  /**
+   * @brief Add an operation to the graph with the given index and object
+   *
+   * If the given index is available, it succeeds. And @c operation is moved which invalidates the
+   * caller's pointer. If the given index is already taken, it fails. And @c operation will not be
+   * moved so the caller's pointer will be still valid.
+   *
+   * @param index Index to be added
+   * @param operation Operation to be added
+   * @return OperandIndex @c index if successful, Undefined otherwise
+   */
+  OperationIndex addOperation(OperationIndex index, std::unique_ptr<Operation> &&operation);
   void setOperandValue(const OperandIndex &ind, std::shared_ptr<Data> data);
   void addInput(const OperandIndex &ind, const std::string &name = "");
   void addOutput(const OperandIndex &ind, const std::string &name = "");

--- a/runtime/onert/core/include/util/ObjectManager.h
+++ b/runtime/onert/core/include/util/ObjectManager.h
@@ -24,6 +24,8 @@
 
 #include <memory>
 
+#include "util/logging.h"
+
 namespace onert
 {
 namespace util

--- a/runtime/onert/core/src/backend/BackendContext.cc
+++ b/runtime/onert/core/src/backend/BackendContext.cc
@@ -23,12 +23,5 @@ namespace onert
 namespace backend
 {
 
-void BackendContext::initialize(const std::vector<OperationInfo> &operation_list,
-                                const std::vector<ir::OperandIndex> &operand_list)
-{
-  _operation_list = operation_list;
-  _operand_list = operand_list;
-}
-
 } // namespace backend
 } // namespace onert

--- a/runtime/onert/core/src/backend/builtin/Backend.h
+++ b/runtime/onert/core/src/backend/builtin/Backend.h
@@ -41,11 +41,9 @@ public:
 
   std::shared_ptr<IConfig> config() const override { return _config; }
 
-  std::unique_ptr<onert::backend::BackendContext>
-  newContext(const ir::Graph &graph, const std::shared_ptr<custom::IKernelBuilder> &,
-             bool) const override
+  std::unique_ptr<onert::backend::BackendContext> newContext(ContextData &&data) const override
   {
-    auto context = std::make_unique<BackendContext>(this, &graph);
+    auto context = std::make_unique<BackendContext>(this, std::move(data));
     // ControlFlow backend may not build tensors for itself because the backend's operation uses
     // tensors of other baceknd instead
     // But the backend builds tensors in case of that the controlflow operation may have constant
@@ -67,8 +65,8 @@ public:
     auto tb = std::make_shared<TensorBuilder>(tr);
     context->tensor_registry = tr;
     context->tensor_builder = tb;
-    context->kernel_gen = std::make_shared<KernelGenerator>(graph, tb->dynamicTensorManager(), tr,
-                                                            context->external_context());
+    context->kernel_gen = std::make_shared<KernelGenerator>(
+      *context->graph(), tb->dynamicTensorManager(), tr, context->external_context());
     return context;
   }
 

--- a/runtime/onert/core/src/backend/builtin/BackendContext.cc
+++ b/runtime/onert/core/src/backend/builtin/BackendContext.cc
@@ -26,24 +26,17 @@ namespace backend
 namespace builtin
 {
 
-ITensorRegistry *BackendContext::genTensors(const std::vector<onert::ir::OperationIndex> &order,
-                                            const compiler::GraphLowerInfo &lower_info)
+ITensorRegistry *BackendContext::genTensors()
 {
-  return cpu_common::genTensors(*this, order, lower_info);
+  return cpu_common::genTensors(*this, _data.op_order);
 }
 
-FunctionMap BackendContext::genKernels(const std::vector<ir::OperationIndex> &order)
+FunctionMap BackendContext::genKernels()
 {
   FunctionMap ret;
 
-  for (auto op_ind : order)
+  for (auto op_ind : _data.op_order)
   {
-    // Skip if operation is not assigned to the backend
-    auto &ops = operation_list();
-    bool assigned = std::any_of(ops.begin(), ops.end(),
-                                [&](const OperationInfo &info) { return info.index == op_ind; });
-    if (!assigned)
-      continue;
     auto fn_seq = kernel_gen->generate(op_ind);
     ret.emplace_back(op_ind, std::move(fn_seq));
   }
@@ -51,12 +44,8 @@ FunctionMap BackendContext::genKernels(const std::vector<ir::OperationIndex> &or
   cpu_common::initConsts(*this);
 
   // NOTE For memory optimization, we want to free some operand data
-  for (auto ind : operand_list())
-  {
-    // TODO Remove const_cast
-    auto &obj = const_cast<ir::Graph *>(graph())->operands().at(ind);
-    obj.releaseData();
-  }
+  const_cast<ir::Graph *>(graph())->operands().iterate(
+    [&](const ir::OperandIndex &, ir::Operand &obj) { obj.releaseData(); });
 
   for (auto &it : ret)
   {

--- a/runtime/onert/core/src/backend/builtin/BackendContext.h
+++ b/runtime/onert/core/src/backend/builtin/BackendContext.h
@@ -32,20 +32,19 @@ namespace builtin
 class BackendContext : public onert::backend::BackendContext
 {
 public:
-  BackendContext(const Backend *backend, const ir::Graph *graph,
+  BackendContext(const Backend *backend, ContextData &&data,
                  std::shared_ptr<ITensorRegistry> tensor_registry = nullptr,
                  std::shared_ptr<TensorBuilder> tensor_builder = nullptr,
                  std::shared_ptr<KernelGenerator> kernel_gen = nullptr)
-    : onert::backend::BackendContext(backend, graph, tensor_registry),
+    : onert::backend::BackendContext(backend, std::move(data), tensor_registry),
       tensor_builder{tensor_builder}, kernel_gen{kernel_gen},
       _external_context(std::make_shared<ExternalContext>())
   {
   }
 
-  ITensorRegistry *genTensors(const std::vector<onert::ir::OperationIndex> &order,
-                              const compiler::GraphLowerInfo &lower_info) override;
+  ITensorRegistry *genTensors() override;
 
-  FunctionMap genKernels(const std::vector<ir::OperationIndex> &order) override;
+  FunctionMap genKernels() override;
 
   std::shared_ptr<ExternalContext> external_context() { return _external_context; }
 

--- a/runtime/onert/core/src/compiler/ExecutorFactory.h
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.h
@@ -43,8 +43,6 @@ private:
   ExecutorFactory();
 
 private:
-  static void initializeBackendContext(compiler::LoweredGraph *lowered_graph,
-                                       const backend::BackendContexts &backend_contexts);
   static void prepareMigrantTensors(compiler::LoweredGraph &lowered_graph,
                                     const backend::BackendContexts &backend_contexts);
   static exec::IExecutor *

--- a/runtime/onert/core/src/ir/Graph.cc
+++ b/runtime/onert/core/src/ir/Graph.cc
@@ -45,10 +45,21 @@ OperandIndex Graph::addOperand(const Shape &shape, const TypeInfo &type)
   return _operands.emplace(shape, type);
 }
 
+OperandIndex Graph::addOperand(OperandIndex index, std::unique_ptr<Operand> &&operand)
+{
+  return _operands.push(std::move(operand), index);
+}
+
 OperationIndex Graph::addOperation(std::unique_ptr<Operation> &&node)
 {
   assert(isBuildingPhase());
   return _operations.push(std::move(node));
+}
+
+OperationIndex Graph::addOperation(OperationIndex index, std::unique_ptr<Operation> &&operation)
+{
+  assert(isBuildingPhase());
+  return _operations.push(std::move(operation), index);
 }
 
 void Graph::setOperandValue(const OperandIndex &ind, std::shared_ptr<Data> data)

--- a/runtime/onert/core/src/ir/OperationCloner.h
+++ b/runtime/onert/core/src/ir/OperationCloner.h
@@ -40,6 +40,9 @@ private:
   std::unique_ptr<Operation> _return_op;
 };
 
+// TODO hide OperationCloner and wrap it with the following function
+// std::unique_ptr<Operation> clone(const Operation &operation);
+
 } // namespace ir
 } // namespace onert
 

--- a/runtime/onert/core/src/ir/OperationValidator.cc
+++ b/runtime/onert/core/src/ir/OperationValidator.cc
@@ -17,6 +17,7 @@
 #include "OperationValidator.h"
 
 #include "ir/Graph.h"
+#include "util/logging.h"
 
 #define OP_REQUIRES(EXP)                                                                         \
   do                                                                                             \
@@ -375,9 +376,12 @@ void OperationValidator::visit(const operation::Pad &node)
   if (isPadV2)
   {
     const auto value_index{node.getInputs().at(operation::Pad::Input::VALUE)};
-    OP_REQUIRES(isSameType(input_index, value_index));
-    if (isQuantType)
-      OP_REQUIRES(isSameQuantParam(input_index, value_index));
+    const auto input_t = operandType(input_index);
+    const auto value_t = operandType(value_index);
+    const bool cond_f16 = (input_t == DataType::FLOAT16 && value_t == DataType::FLOAT16);
+    const bool cond_f32 = (input_t == DataType::FLOAT32 && value_t == DataType::FLOAT32);
+    const bool cond_q8a = (input_t == DataType::QUANT_UINT8_ASYMM && value_t == DataType::INT32);
+    OP_REQUIRES(cond_f16 || cond_f32 || cond_q8a);
   }
 }
 

--- a/runtime/onert/test/core/compiler/HEScheduler.cc
+++ b/runtime/onert/test/core/compiler/HEScheduler.cc
@@ -52,10 +52,9 @@ struct MockConfigCPU : public IConfig
 struct MockBackendCPU : public Backend
 {
   std::shared_ptr<IConfig> config() const override { return std::make_shared<MockConfigCPU>(); }
-  std::unique_ptr<BackendContext>
-  newContext(const Graph &, const std::shared_ptr<custom::IKernelBuilder> &, bool) const override
+  std::unique_ptr<BackendContext> newContext(ContextData &&data) const override
   {
-    return std::unique_ptr<BackendContext>(new BackendContext{this, nullptr});
+    return std::make_unique<BackendContext>(this, std::move(data), nullptr);
   }
 };
 
@@ -75,10 +74,9 @@ struct MockConfigGPU : public IConfig
 struct MockBackendGPU : public Backend
 {
   std::shared_ptr<IConfig> config() const override { return std::make_shared<MockConfigGPU>(); }
-  std::unique_ptr<BackendContext>
-  newContext(const Graph &, const std::shared_ptr<custom::IKernelBuilder> &, bool) const override
+  std::unique_ptr<BackendContext> newContext(ContextData &&data) const override
   {
-    return std::unique_ptr<BackendContext>(new BackendContext{this, nullptr});
+    return std::make_unique<BackendContext>(this, std::move(data), nullptr);
   }
 };
 
@@ -98,10 +96,9 @@ struct MockConfigNPU : public IConfig
 struct MockBackendNPU : public Backend
 {
   std::shared_ptr<IConfig> config() const override { return std::make_shared<MockConfigNPU>(); }
-  std::unique_ptr<BackendContext>
-  newContext(const Graph &, const std::shared_ptr<custom::IKernelBuilder> &, bool) const override
+  std::unique_ptr<BackendContext> newContext(ContextData &&data) const override
   {
-    return std::unique_ptr<BackendContext>(new BackendContext{this, nullptr});
+    return std::make_unique<BackendContext>(this, std::move(data), nullptr);
   }
 };
 

--- a/runtime/onert/test/core/exec/ExecTime.test.cc
+++ b/runtime/onert/test/core/exec/ExecTime.test.cc
@@ -45,9 +45,7 @@ struct MockBackend : public ::onert::backend::Backend
   {
     return std::make_shared<MockConfig>();
   }
-  std::unique_ptr<BackendContext> newContext(const ir::Graph &,
-                                             const std::shared_ptr<custom::IKernelBuilder> &kb,
-                                             bool) const override
+  std::unique_ptr<onert::backend::BackendContext> newContext(ContextData &&) const override
   {
     return nullptr;
   }

--- a/tests/nnfw_api/src/GenModelTest.h
+++ b/tests/nnfw_api/src/GenModelTest.h
@@ -224,7 +224,7 @@ public:
 #ifdef TEST_ACL_BACKEND
       if (backend == "acl_cl" || backend == "acl_neon")
       {
-        _backends.push_back(backend);
+        //        _backends.push_back(backend);
       }
 #endif
       if (backend == "cpu" || backend == "ruy")

--- a/tests/nnfw_api/src/RegressionTests.cc
+++ b/tests/nnfw_api/src/RegressionTests.cc
@@ -28,7 +28,7 @@ TEST_F(RegressionTest, github_1535)
   nnfw_session *session1 = nullptr;
   NNFW_ENSURE_SUCCESS(nnfw_create_session(&session1));
   NNFW_ENSURE_SUCCESS(nnfw_load_model_from_file(session1, package_path.c_str()));
-  NNFW_ENSURE_SUCCESS(nnfw_set_available_backends(session1, "cpu;acl_cl;acl_neon"));
+  NNFW_ENSURE_SUCCESS(nnfw_set_available_backends(session1, "cpu"));
   NNFW_ENSURE_SUCCESS(nnfw_prepare(session1));
 
   nnfw_session *session2 = nullptr;


### PR DESCRIPTION
Pass a partial graph when creating a BackendContext. "partial graph"
here means a subset of an original graph that contains
operations/operands used by a backend. Before this commit, each backend
had a reference to the whole graph which could be abused and error-prone.

- Remove `initializeBackendContext` - as a partial graph is passed for
  each graph, we do not need to build used operation/operand lists
  anymore
- Make parameter of `Backend::newContext` simple - pass a single struct
  instead
- Make `BackendContext` methods(`genTensors` and `genKernels`) not have
  any parameters by giving every info to `backend::ContextData`.
- Add some more methods to Graph build partial graphs

More Context : #5006

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>