### PR TITLE
[luci] Enable unset unknown dimension during import

### DIFF
--- a/compiler/luci/import/src/CircleReader.cpp
+++ b/compiler/luci/import/src/CircleReader.cpp
@@ -262,6 +262,9 @@ void copy_tensor_attributes(const circle::TensorT &tensor, CircleNode *node)
   node->name(tensor_name(tensor));
   node->dtype(luci_datatype(tensor.type));
 
+  assert(tensor.shape_signature.size() == 0 ||
+         tensor.shape_signature.size() == tensor.shape.size());
+
   std::vector<int32_t> dims = tensor.shape; // in NHWC
   node->rank(dims.size());
   for (uint32_t r = 0; r < dims.size(); ++r)

--- a/compiler/luci/import/src/CircleReader.cpp
+++ b/compiler/luci/import/src/CircleReader.cpp
@@ -266,7 +266,10 @@ void copy_tensor_attributes(const circle::TensorT &tensor, CircleNode *node)
   node->rank(dims.size());
   for (uint32_t r = 0; r < dims.size(); ++r)
   {
-    node->dim(r) = loco::Dimension(dims[r]);
+    if (tensor.shape_signature.size() > 0 && tensor.shape_signature.at(r) == -1)
+      node->dim(r).unset();
+    else
+      node->dim(r).set(dims[r]);
   }
 
   const auto *quantization = tensor.quantization.get();

--- a/compiler/luci/import/src/Importer.cpp
+++ b/compiler/luci/import/src/Importer.cpp
@@ -101,7 +101,12 @@ void convert_graph(const luci::GraphBuilderSource &source, luci::CircleReader &r
     const std::vector<int32_t> &input_dims = tensor.shape; // in NHWC
     input_shape->rank(input_dims.size());
     for (uint32_t r = 0; r < input_dims.size(); ++r)
-      input_shape->dim(r) = loco::Dimension(input_dims[r]);
+    {
+      if (tensor.shape_signature.size() > 0 && tensor.shape_signature.at(r) == -1)
+        input_shape->dim(r).unset();
+      else
+        input_shape->dim(r).set(input_dims[r]);
+    }
     graph_input->shape(std::move(input_shape));
   }
 
@@ -181,7 +186,12 @@ void convert_graph(const luci::GraphBuilderSource &source, luci::CircleReader &r
     const std::vector<int32_t> &output_dims = tensor.shape; // in NHWC
     output_shape->rank(output_dims.size());
     for (uint32_t r = 0; r < output_dims.size(); ++r)
-      output_shape->dim(r) = loco::Dimension(output_dims[r]);
+    {
+      if (tensor.shape_signature.size() > 0 && tensor.shape_signature.at(r) == -1)
+        output_shape->dim(r).unset();
+      else
+        output_shape->dim(r).set(output_dims[r]);
+    }
     graph_output->shape(std::move(output_shape));
 
     // Data type

--- a/compiler/luci/import/src/Importer.cpp
+++ b/compiler/luci/import/src/Importer.cpp
@@ -96,6 +96,9 @@ void convert_graph(const luci::GraphBuilderSource &source, luci::CircleReader &r
     // Data type
     graph_input->dtype(input_node->dtype());
 
+    assert(tensor.shape_signature.size() == 0 ||
+           tensor.shape_signature.size() == tensor.shape.size());
+
     // Shape of GraphInput
     auto input_shape = std::make_unique<loco::TensorShape>();
     const std::vector<int32_t> &input_dims = tensor.shape; // in NHWC
@@ -180,6 +183,9 @@ void convert_graph(const luci::GraphBuilderSource &source, luci::CircleReader &r
 
     // Set GraphInputOutputIndex for graph
     output_node->index(graph_output->index());
+
+    assert(tensor.shape_signature.size() == 0 ||
+           tensor.shape_signature.size() == tensor.shape.size());
 
     // Shape of Output
     auto output_shape = std::make_unique<loco::TensorShape>();


### PR DESCRIPTION
Parent Issue : #5501

Until now, dimensions are always set to known.
This commit will enable unset the unknown dimensions during import step.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>