### PR TITLE
[TensorFlowPythonExamples] Add minimum-maximum small network

### DIFF
--- a/res/TensorFlowPythonModels/examples/minimum-maximum/__init__.py
+++ b/res/TensorFlowPythonModels/examples/minimum-maximum/__init__.py
@@ -1,0 +1,15 @@
+import tensorflow as tf
+
+in_ = tf.compat.v1.placeholder(dtype=tf.float32, shape=(1, 16, 160, 160), name="Hole")
+
+upper_ = tf.compat.v1.constant(6.)
+lower_ = tf.compat.v1.constant(0.)
+
+min_ = tf.compat.v1.minimum(in_, upper_)
+max_ = tf.compat.v1.maximum(min_, lower_)
+'''
+python ../../compiler/tf2tfliteV2/tf2tfliteV2.py --v1 \
+-i minimum-maximum.pbtxt \
+-o minimum-maximum.tflite \
+-I Hole -O Maximum
+'''


### PR DESCRIPTION
This commit adds minimum-maximum pattern network.

Related : #5599 
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>