### PR TITLE
[luci] Reorder by alphabet order comments

### DIFF
--- a/compiler/luci/service/include/luci/Service/CircleShapeInference.h
+++ b/compiler/luci/service/include/luci/Service/CircleShapeInference.h
@@ -112,10 +112,12 @@ public:
   // loco::TensorShape visit(const luci::CircleMean *node) final;
   // loco::TensorShape visit(const luci::CircleMinimum *node) final;
   // loco::TensorShape visit(const luci::CircleMirrorPad *node) final;
+  // loco::TensorShape visit(const luci::CircleMul *node) final;
   // loco::TensorShape visit(const luci::CircleNeg *node) final;
   // loco::TensorShape visit(const luci::CircleNonMaxSuppressionV4 *node) final;
   // loco::TensorShape visit(const luci::CircleNonMaxSuppressionV5 *node) final;
   // loco::TensorShape visit(const luci::CircleNotEqual *node) final;
+  // loco::TensorShape visit(const luci::CircleOneHot *node) final;
   // loco::TensorShape visit(const luci::CirclePack *node) final;
   // loco::TensorShape visit(const luci::CirclePad *node) final;
   // loco::TensorShape visit(const luci::CirclePadV2 *node) final;
@@ -123,8 +125,6 @@ public:
   // loco::TensorShape visit(const luci::CirclePRelu *node) final;
   // loco::TensorShape visit(const luci::CircleRange *node) final;
   // loco::TensorShape visit(const luci::CircleRank *node) final;
-  // loco::TensorShape visit(const luci::CircleMul *node) final;
-  // loco::TensorShape visit(const luci::CircleOneHot *node) final;
   // loco::TensorShape visit(const luci::CircleReduceAny *node) final;
   // loco::TensorShape visit(const luci::CircleReduceMax *node) final;
   // loco::TensorShape visit(const luci::CircleReduceMin *node) final;
@@ -177,14 +177,14 @@ public:
   // loco::TensorShape visit(const luci::CircleInstanceNorm *node) final;
 
   // Virtual
+  // loco::TensorShape visit(const luci::CircleCustomOut *node) final;
+  // loco::TensorShape visit(const luci::CircleIfOut *node) final;
   // loco::TensorShape visit(const luci::CircleInput *node) final;
+  // loco::TensorShape visit(const luci::CircleNonMaxSuppressionV4Out *node) final;
+  // loco::TensorShape visit(const luci::CircleNonMaxSuppressionV5Out *node) final;
   // loco::TensorShape visit(const luci::CircleOutput *node) final;
   // loco::TensorShape visit(const luci::CircleOutputDummy *node) final;
   // loco::TensorShape visit(const luci::CircleOutputExclude *node) final;
-  // loco::TensorShape visit(const luci::CircleCustomOut *node) final;
-  // loco::TensorShape visit(const luci::CircleIfOut *node) final;
-  // loco::TensorShape visit(const luci::CircleNonMaxSuppressionV4Out *node) final;
-  // loco::TensorShape visit(const luci::CircleNonMaxSuppressionV5Out *node) final;
   // loco::TensorShape visit(const luci::CircleSplitOut *node) final;
   // loco::TensorShape visit(const luci::CircleSplitVOut *node) final;
   // loco::TensorShape visit(const luci::CircleTopKV2Out *node) final;

--- a/compiler/luci/service/include/luci/Service/CircleTypeInference.h
+++ b/compiler/luci/service/include/luci/Service/CircleTypeInference.h
@@ -63,7 +63,6 @@ public:
   // loco::DataType visit(const luci::CircleAbs *node) final;
   // loco::DataType visit(const luci::CircleAdd *node) final;
   // loco::DataType visit(const luci::CircleAddN *node) final;
-  // loco::DataType visit(const luci::CircleAll *node) final;
   // loco::DataType visit(const luci::CircleArgMax *node) final;
   // loco::DataType visit(const luci::CircleArgMin *node) final;
   // loco::DataType visit(const luci::CircleAveragePool2D *node) final;
@@ -114,12 +113,10 @@ public:
   // loco::DataType visit(const luci::CircleMean *node) final;
   // loco::DataType visit(const luci::CircleMinimum *node) final;
   // loco::DataType visit(const luci::CircleMirrorPad *node) final;
-  // loco::DataType visit(const luci::CircleMul *node) final;
   // loco::DataType visit(const luci::CircleNeg *node) final;
   // loco::DataType visit(const luci::CircleNonMaxSuppressionV4 *node) final;
   // loco::DataType visit(const luci::CircleNonMaxSuppressionV5 *node) final;
   // loco::DataType visit(const luci::CircleNotEqual *node) final;
-  // loco::DataType visit(const luci::CircleOneHot *node) final;
   // loco::DataType visit(const luci::CirclePack *node) final;
   // loco::DataType visit(const luci::CirclePad *node) final;
   // loco::DataType visit(const luci::CirclePadV2 *node) final;
@@ -127,6 +124,8 @@ public:
   // loco::DataType visit(const luci::CirclePRelu *node) final;
   // loco::DataType visit(const luci::CircleRange *node) final;
   // loco::DataType visit(const luci::CircleRank *node) final;
+  // loco::DataType visit(const luci::CircleMul *node) final;
+  // loco::DataType visit(const luci::CircleOneHot *node) final;
   // loco::DataType visit(const luci::CircleReduceAny *node) final;
   // loco::DataType visit(const luci::CircleReduceMax *node) final;
   // loco::DataType visit(const luci::CircleReduceMin *node) final;
@@ -179,14 +178,14 @@ public:
   // loco::DataType visit(const luci::CircleInstanceNorm *node) final;
 
   // Virtual
-  // loco::DataType visit(const luci::CircleCustomOut *node) final;
-  // loco::DataType visit(const luci::CircleIfOut *node) final;
   // loco::DataType visit(const luci::CircleInput *node) final;
-  // loco::DataType visit(const luci::CircleNonMaxSuppressionV4Out *node) final;
-  // loco::DataType visit(const luci::CircleNonMaxSuppressionV5Out *node) final;
   // loco::DataType visit(const luci::CircleOutput *node) final;
   // loco::DataType visit(const luci::CircleOutputDummy *node) final;
   // loco::DataType visit(const luci::CircleOutputExclude *node) final;
+  // loco::DataType visit(const luci::CircleCustomOut *node) final;
+  // loco::DataType visit(const luci::CircleIfOut *node) final;
+  // loco::DataType visit(const luci::CircleNonMaxSuppressionV4Out *node) final;
+  // loco::DataType visit(const luci::CircleNonMaxSuppressionV5Out *node) final;
   // loco::DataType visit(const luci::CircleSplitOut *node) final;
   // loco::DataType visit(const luci::CircleSplitVOut *node) final;
   // loco::DataType visit(const luci::CircleTopKV2Out *node) final;

--- a/compiler/luci/service/include/luci/Service/CircleTypeInference.h
+++ b/compiler/luci/service/include/luci/Service/CircleTypeInference.h
@@ -63,6 +63,7 @@ public:
   // loco::DataType visit(const luci::CircleAbs *node) final;
   // loco::DataType visit(const luci::CircleAdd *node) final;
   // loco::DataType visit(const luci::CircleAddN *node) final;
+  // loco::DataType visit(const luci::CircleAll *node) final;
   // loco::DataType visit(const luci::CircleArgMax *node) final;
   // loco::DataType visit(const luci::CircleArgMin *node) final;
   // loco::DataType visit(const luci::CircleAveragePool2D *node) final;
@@ -113,10 +114,12 @@ public:
   // loco::DataType visit(const luci::CircleMean *node) final;
   // loco::DataType visit(const luci::CircleMinimum *node) final;
   // loco::DataType visit(const luci::CircleMirrorPad *node) final;
+  // loco::DataType visit(const luci::CircleMul *node) final;
   // loco::DataType visit(const luci::CircleNeg *node) final;
   // loco::DataType visit(const luci::CircleNonMaxSuppressionV4 *node) final;
   // loco::DataType visit(const luci::CircleNonMaxSuppressionV5 *node) final;
   // loco::DataType visit(const luci::CircleNotEqual *node) final;
+  // loco::DataType visit(const luci::CircleOneHot *node) final;
   // loco::DataType visit(const luci::CirclePack *node) final;
   // loco::DataType visit(const luci::CirclePad *node) final;
   // loco::DataType visit(const luci::CirclePadV2 *node) final;
@@ -124,8 +127,6 @@ public:
   // loco::DataType visit(const luci::CirclePRelu *node) final;
   // loco::DataType visit(const luci::CircleRange *node) final;
   // loco::DataType visit(const luci::CircleRank *node) final;
-  // loco::DataType visit(const luci::CircleMul *node) final;
-  // loco::DataType visit(const luci::CircleOneHot *node) final;
   // loco::DataType visit(const luci::CircleReduceAny *node) final;
   // loco::DataType visit(const luci::CircleReduceMax *node) final;
   // loco::DataType visit(const luci::CircleReduceMin *node) final;
@@ -178,14 +179,14 @@ public:
   // loco::DataType visit(const luci::CircleInstanceNorm *node) final;
 
   // Virtual
+  // loco::DataType visit(const luci::CircleCustomOut *node) final;
+  // loco::DataType visit(const luci::CircleIfOut *node) final;
   // loco::DataType visit(const luci::CircleInput *node) final;
+  // loco::DataType visit(const luci::CircleNonMaxSuppressionV4Out *node) final;
+  // loco::DataType visit(const luci::CircleNonMaxSuppressionV5Out *node) final;
   // loco::DataType visit(const luci::CircleOutput *node) final;
   // loco::DataType visit(const luci::CircleOutputDummy *node) final;
   // loco::DataType visit(const luci::CircleOutputExclude *node) final;
-  // loco::DataType visit(const luci::CircleCustomOut *node) final;
-  // loco::DataType visit(const luci::CircleIfOut *node) final;
-  // loco::DataType visit(const luci::CircleNonMaxSuppressionV4Out *node) final;
-  // loco::DataType visit(const luci::CircleNonMaxSuppressionV5Out *node) final;
   // loco::DataType visit(const luci::CircleSplitOut *node) final;
   // loco::DataType visit(const luci::CircleSplitVOut *node) final;
   // loco::DataType visit(const luci::CircleTopKV2Out *node) final;


### PR DESCRIPTION
This commit will reorder nodes in comments by alphabet order.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>