### PR TITLE
[luci] Fix type of input shape in PassTestGraphs.h

### DIFF
--- a/compiler/luci/pass/src/PassTestGraphs.h
+++ b/compiler/luci/pass/src/PassTestGraphs.h
@@ -42,7 +42,7 @@ namespace luci
 class ConstantFoldingTestGraph
 {
 public:
-  ConstantFoldingTestGraph(std::vector<int32_t> input_shape, loco::DataType input_dtype)
+  ConstantFoldingTestGraph(std::vector<uint32_t> input_shape, loco::DataType input_dtype)
   {
     input = g.nodes()->create<luci::CircleInput>();
     add = g.nodes()->create<luci::CircleAdd>();


### PR DESCRIPTION
This fixes int32_t type of input shape to uint32_t.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>