### PR TITLE
[TensorFlowLiteRecipes] Add Net_Maximum_Minimum_000 recipe

### DIFF
--- a/res/TensorFlowLiteRecipes/Net_Maximum_Minimum_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/Net_Maximum_Minimum_000/test.recipe
@@ -1,0 +1,86 @@
+operand {
+  name: "Const"
+  type: FLOAT32
+  shape {
+  }
+  filler {
+    tag: "explicit"
+    arg: "6"
+  }
+  quant {
+    quantized_dimension: 0
+  }
+  is_variable: false
+}
+operand {
+  name: "Const_1"
+  type: FLOAT32
+  shape {
+  }
+  filler {
+    tag: "explicit"
+    arg: "0"
+  }
+  quant {
+    quantized_dimension: 0
+  }
+  is_variable: false
+}
+operand {
+  name: "Hole"
+  type: FLOAT32
+  shape {
+    dim: 1
+    dim: 3
+    dim: 3
+    dim: 4
+  }
+  quant {
+    min: 0
+    max: 255
+    quantized_dimension: 0
+  }
+  is_variable: false
+}
+operand {
+  name: "Maximum"
+  type: FLOAT32
+  shape {
+    dim: 1
+    dim: 3
+    dim: 3
+    dim: 4
+  }
+  quant {
+    quantized_dimension: 0
+  }
+  is_variable: false
+}
+operand {
+  name: "Minimum"
+  type: FLOAT32
+  shape {
+    dim: 1
+    dim: 3
+    dim: 3
+    dim: 4
+  }
+  quant {
+    quantized_dimension: 0
+  }
+  is_variable: false
+}
+operation {
+  type: "Minimum"
+  input: "Hole"
+  input: "Const"
+  output: "Minimum"
+}
+operation {
+  type: "Maximum"
+  input: "Minimum"
+  input: "Const_1"
+  output: "Maximum"
+}
+input: "Hole"
+output: "Maximum"

--- a/res/TensorFlowLiteRecipes/Net_Maximum_Minimum_000/test.rule
+++ b/res/TensorFlowLiteRecipes/Net_Maximum_Minimum_000/test.rule
@@ -1,0 +1,7 @@
+# To check if Maximum and Minimum is fused to Relu6.
+
+RULE    "VERIFY_FILE_FORMAT"      $(verify_file_format) '=' 1
+
+RULE    "RELU6_EXIST"             $(op_count RELU6) '=' 1
+RULE    "NO_MAXIMUM"              $(op_count MAXIMUM) '=' 0
+RULE    "NO_MINIMUM"              $(op_count MINIMUM) '=' 0


### PR DESCRIPTION
This commit adds Net_Maximum_Minimum_000 recipe.

FYI, this network will be fused to single relu6 operator.

Related : #5599
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>