### PR TITLE
[luci] Introduce substitutive function of loco shape/dtype getter

### DIFF
--- a/compiler/luci/service/src/CircleShapeInferenceHelper.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceHelper.cpp
@@ -18,6 +18,23 @@
 
 namespace luci
 {
+
+loco::NodeShape shape_get(const loco::Node *node)
+{
+  assert(shape_known(node));
+  return loco::NodeShape{sinf::circle_shape(loco::must_cast<const luci::CircleNode *>(node))};
+}
+
+bool shape_known(const loco::Node *node)
+{
+  return loco::must_cast<const luci::CircleNode *>(node)->shape_status() !=
+         luci::ShapeStatus::UNDEFINED;
+}
+
+} // namespace luci
+
+namespace luci
+{
 namespace sinf
 {
 

--- a/compiler/luci/service/src/CircleShapeInferenceHelper.h
+++ b/compiler/luci/service/src/CircleShapeInferenceHelper.h
@@ -17,9 +17,24 @@
 #ifndef __LUCI_CIRCLE_SHAPE_INFERENCE_HELPER_H__
 #define __LUCI_CIRCLE_SHAPE_INFERENCE_HELPER_H__
 
+#include <loco/IR/NodeShape.h>
 #include <loco/IR/TensorShape.h>
 
 #include <luci/IR/CircleNodes.h>
+
+namespace luci
+{
+
+// NOTE Functions in this namespace will be removed after new inference
+//      algorithms are fully implemented.
+
+// This function is temporary function for deprecating loco::shape_get
+loco::NodeShape shape_get(const loco::Node *node);
+
+// This function is temporary function for deprecating loco::shape_known
+bool shape_known(const loco::Node *node);
+
+} // namespace luci
 
 namespace luci
 {

--- a/compiler/luci/service/src/CircleTypeInferenceHelper.cpp
+++ b/compiler/luci/service/src/CircleTypeInferenceHelper.cpp
@@ -18,6 +18,22 @@
 
 namespace luci
 {
+
+loco::DataType dtype_get(const loco::Node *node)
+{
+  assert(dtype_known(node));
+  return loco::must_cast<const luci::CircleNode *>(node)->dtype();
+}
+
+bool dtype_known(const loco::Node *node)
+{
+  return loco::must_cast<const luci::CircleNode *>(node)->dtype() != loco::DataType::Unknown;
+}
+
+} // namespace luci
+
+namespace luci
+{
 namespace tinf
 {
 

--- a/compiler/luci/service/src/CircleTypeInferenceHelper.h
+++ b/compiler/luci/service/src/CircleTypeInferenceHelper.h
@@ -23,6 +23,20 @@
 
 namespace luci
 {
+
+// NOTE Functions in this namespace will be removed after new inference
+//      algorithms are fully implemented.
+
+// This function is temporary function for deprecating loco::dtype_get
+loco::DataType dtype_get(const loco::Node *node);
+
+// This function is temporary function for deprecating loco::dtype_known
+bool dtype_known(const loco::Node *node);
+
+} // namespace luci
+
+namespace luci
+{
 namespace tinf // Namespace for Type Inference
 {
 


### PR DESCRIPTION
Parent issue : #5501

To deprecate `TypeInferencePass` and `ShapeInferencePass`, following functions should be removed.

- shape_get
- shape_known
- dtype_get
- dtype_known

Until now, replacing them as `rank` and `dim` of `CircleNode` was used.
However, `CircleShapeInferenceRule.cpp` and `CircleTypeInferenceRule.cpp` are using them so much.
As a result, if we do not introduce substitutive functions for them, code diff will be a lot.
Therefore, this commit will introduce substitutive functions for shape and dtype getter of loco.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>