### PR TITLE
[luci] Fix wrong replacement in ResolveCustomOpMatMulPass

### DIFF
--- a/compiler/luci/pass/src/ResolveCustomOpMatMulPass.cpp
+++ b/compiler/luci/pass/src/ResolveCustomOpMatMulPass.cpp
@@ -151,7 +151,9 @@ bool resolve_matmul(luci::CircleCustom *cop)
   fc_node->bias(empty_bias);
   fc_node->fusedActivationFunction(luci::FusedActFunc::NONE);
 
-  replace(cop).with(fc_node);
+  auto customOut = loco::succs(cop);
+  assert(customOut.size() == 1);
+  replace(*customOut.begin()).with(fc_node);
   return true;
 }
 


### PR DESCRIPTION
Until now, wrong node were replaced and wrong optimized graph was generated.
This commit will fix it.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>