### PR TITLE
[luci/pass] Introduce SubstituteTransposeToReshape on luci/pass

### DIFF
--- a/compiler/luci/pass/include/luci/CircleOptimizer.h
+++ b/compiler/luci/pass/include/luci/CircleOptimizer.h
@@ -62,6 +62,7 @@ public:
       RemoveUnnecessarySplit,
       RemoveUnnecessaryReshape,
       TransformMinMaxToRelu6Pass,
+      SubstituteTransposeToReshape,
     };
 
     enum AlgorithmParameters

--- a/compiler/luci/pass/include/luci/Pass/SubstituteTransposeToReshapePass.h
+++ b/compiler/luci/pass/include/luci/Pass/SubstituteTransposeToReshapePass.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __LUCI_SUBSTITUTE_TRANSPOSE_TO_RESHAPE_PASS_H__
+#define __LUCI_SUBSTITUTE_TRANSPOSE_TO_RESHAPE_PASS_H__
+
+#include <logo/Pass.h>
+
+namespace luci
+{
+
+/**
+ * @brief  Class to Substitute Transpose with certain input shape condition to single reshape node.
+ */
+struct SubstituteTransposeToReshapePass final : public logo::Pass
+{
+  const char *name(void) const final { return "luci::SubstituteTransposeToReshapePass"; }
+
+  bool run(loco::Graph *g) final;
+};
+
+} // namespace luci
+
+#endif // __LUCI_SUBSTITUTE_TRANSPOSE_TO_RESHAPE_PASS_H__

--- a/compiler/luci/pass/src/CircleOptimizer.cpp
+++ b/compiler/luci/pass/src/CircleOptimizer.cpp
@@ -44,7 +44,9 @@
 #include "luci/Pass/SparsifyTensorPass.h"
 #include "luci/Pass/ShuffleWeightTo16x1Float32Pass.h"
 #include "luci/Pass/SubstitutePackToReshapePass.h"
+#include "luci/Pass/SubstituteTransposeToReshapePass.h"
 #include "luci/Pass/TransformMinMaxToRelu6Pass.h"
+
 // TODO add more passes
 
 #include "luci/Pass/ShapeInferencePass.h"
@@ -258,6 +260,10 @@ void CircleOptimizer::optimize(loco::Graph *g) const
   if (_options->query(Options::Algorithm::SubstitutePackToReshape))
   {
     phase.emplace_back(std::make_unique<luci::SubstitutePackToReshapePass>());
+  }
+  if (_options->query(Options::Algorithm::SubstituteTransposeToReshape))
+  {
+    phase.emplace_back(std::make_unique<luci::SubstituteTransposeToReshapePass>());
   }
   if (_options->query(Options::Algorithm::TransformMinMaxToRelu6Pass))
   {

--- a/compiler/luci/pass/src/CircleOptimizer.cpp
+++ b/compiler/luci/pass/src/CircleOptimizer.cpp
@@ -46,7 +46,6 @@
 #include "luci/Pass/SubstitutePackToReshapePass.h"
 #include "luci/Pass/SubstituteTransposeToReshapePass.h"
 #include "luci/Pass/TransformMinMaxToRelu6Pass.h"
-
 // TODO add more passes
 
 #include "luci/Pass/ShapeInferencePass.h"

--- a/compiler/luci/pass/src/SubstituteTransposeToReshapePass.cpp
+++ b/compiler/luci/pass/src/SubstituteTransposeToReshapePass.cpp
@@ -25,10 +25,10 @@ namespace
  * @brief Convert transpose op in a certain condition to reshape op
  * @details Convert transpose op if it have condition below
  *          1. have a CircleConst perm value.
- *          2. input have a unknown shape less then 2
+ *          2. input have an unknown dimension less then 2
  *          3. the order of shape that except dim value 1 remains same on input and output
- *          eg) input shape  = (1, 2, 3, 4, 5, 1, 1, 1) => (2, 3, 4, 5)
- *              output shape = (2, 1, 3, 1, 1, 4, 5, 1) => (2, 3, 4, 5)
+ *             eg) input shape  = (126, 201, 1, 1) => (126, 201)
+ *                 output shape = (1, 126, 1, 201) => (126, 201)
  */
 bool substitute_transpose_to_reshape(luci::CircleNode *node)
 {
@@ -60,13 +60,13 @@ bool substitute_transpose_to_reshape(luci::CircleNode *node)
   {
     assert(perm_const->at<loco::DataType::S32>(i) >= 0 &&
            perm_const->at<loco::DataType::S32>(i) < static_cast<int32_t>(input_node->rank()));
-    if (input_node->dim(static_cast<uint32_t>(perm_const->at<loco::DataType::S32>(i))).known() &&
-        input_node->dim(static_cast<uint32_t>(perm_const->at<loco::DataType::S32>(i))).value() == 1)
+    const auto perm_value = static_cast<uint32_t>(perm_const->at<loco::DataType::S32>(i));
+    if (input_node->dim(perm_value).known() && input_node->dim(perm_value).value() == 1)
       continue;
     // To check idx values are increasing
-    if (idx > static_cast<uint32_t>(perm_const->at<loco::DataType::S32>(i)))
+    if (idx > perm_value)
       return false;
-    idx = static_cast<uint32_t>(perm_const->at<loco::DataType::S32>(i));
+    idx = perm_value;
   }
 
   auto new_const_node = node->graph()->nodes()->create<luci::CircleConst>();

--- a/compiler/luci/pass/src/SubstituteTransposeToReshapePass.cpp
+++ b/compiler/luci/pass/src/SubstituteTransposeToReshapePass.cpp
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Pass/SubstituteTransposeToReshapePass.h"
+
+#include <luci/IR/CircleNodes.h>
+
+namespace
+{
+
+/**
+ * @brief Convert transpose op in a certain condition to reshape op
+ * @details Convert transpose op if it have condition below
+ *          1. have a CircleConst perm value.
+ *          2. input have a unknown shape less then 2
+ *          3. the order of shape that except dim value 1 remains same on input and output
+ *          eg) input shape  = (1, 2, 3, 4, 5, 1, 1, 1) => (2, 3, 4, 5)
+ *              output shape = (2, 1, 3, 1, 1, 4, 5, 1) => (2, 3, 4, 5)
+ */
+bool substitute_transpose_to_reshape(luci::CircleNode *node)
+{
+  auto target_node = dynamic_cast<luci::CircleTranspose *>(node);
+  if (target_node == nullptr)
+    return false;
+
+  auto perm_const = dynamic_cast<luci::CircleConst *>(target_node->perm());
+  if (perm_const == nullptr)
+    return false;
+
+  assert(perm_const->dtype() == loco::DataType::S32);
+
+  auto input_node = loco::must_cast<luci::CircleNode *>(target_node->a());
+  if (perm_const->dim(0).value() != input_node->rank())
+    return false;
+  // If input have more than 2 unknown dimension, transpose will not changed.
+  int count = 0;
+  for (uint32_t i = 0; i < input_node->rank(); i++)
+    if (!input_node->dim(i).known())
+      count++;
+  if (count > 1)
+    return false;
+
+  uint32_t idx = 0;
+  for (uint32_t i = 0; i < perm_const->size<loco::DataType::S32>(); i++)
+  {
+    assert(perm_const->at<loco::DataType::S32>(i) >= 0 &&
+           perm_const->at<loco::DataType::S32>(i) < static_cast<int32_t>(input_node->rank()));
+    if (input_node->dim(static_cast<uint32_t>(perm_const->at<loco::DataType::S32>(i))).known() &&
+        input_node->dim(static_cast<uint32_t>(perm_const->at<loco::DataType::S32>(i))).value() == 1)
+      continue;
+    if (idx > static_cast<uint32_t>(perm_const->at<loco::DataType::S32>(i)))
+      return false;
+    idx = static_cast<uint32_t>(perm_const->at<loco::DataType::S32>(i));
+  }
+
+  auto new_const_node = node->graph()->nodes()->create<luci::CircleConst>();
+  new_const_node->dtype(loco::DataType::S32);
+  new_const_node->size<loco::DataType::S32>(perm_const->size<loco::DataType::S32>());
+  new_const_node->shape_status(luci::ShapeStatus::VALID);
+  new_const_node->rank(1);
+  new_const_node->dim(0).set(perm_const->size<loco::DataType::S32>());
+  for (uint32_t i = 0; i < perm_const->size<loco::DataType::S32>(); i++)
+  {
+    if (input_node->dim(static_cast<uint32_t>(perm_const->at<loco::DataType::S32>(i))).known())
+      new_const_node->at<loco::DataType::S32>(i) = static_cast<int32_t>(
+        input_node->dim(static_cast<uint32_t>(perm_const->at<loco::DataType::S32>(i))).value());
+    else
+      new_const_node->at<loco::DataType::S32>(i) = -1;
+  }
+
+  auto new_reshape_node = node->graph()->nodes()->create<luci::CircleReshape>();
+  new_reshape_node->tensor(input_node);
+  new_reshape_node->shape(new_const_node);
+
+  replace(target_node).with(new_reshape_node);
+  return true;
+}
+
+} // namespace
+
+namespace luci
+{
+
+/**
+ *   BEFORE
+ *
+ * [CircleNode]  [CircleConst]
+ *       \             /
+ *      [CircleTranspose]
+ *             |
+ *        [CircleNode]
+ *
+ *    AFTER
+ *
+ * [CircleNode]  [CircleConst]
+ *       \             /
+ *       [CircleReshape]
+ *             |
+ *        [CircleNode]
+ *
+ */
+bool SubstituteTransposeToReshapePass::run(loco::Graph *g)
+{
+  bool changed = false;
+  for (auto node : loco::active_nodes(loco::output_nodes(g)))
+  {
+    auto circle_node = loco::must_cast<luci::CircleNode *>(node);
+    if (substitute_transpose_to_reshape(circle_node))
+    {
+      changed = true;
+    }
+  }
+  return changed;
+}
+
+} // namespace luci

--- a/compiler/luci/pass/src/SubstituteTransposeToReshapePass.test.cpp
+++ b/compiler/luci/pass/src/SubstituteTransposeToReshapePass.test.cpp
@@ -73,9 +73,9 @@ TEST_F(SubstituteTransposeToReshapeTest, simple_case)
 {
   // Create graph that tranpose input {126, 201, 1, 1} with permutation {2, 0, 3, 1}
   buildGraph({126, 201, 1, 1}, std::vector<int32_t>({2, 0, 3, 1}));
-  // on this input shape and permutation value, output shape will be {1, 126, 1, 201}
-  // the value in buffer will not change as order of value is same
-  // so, this transpose operation will change into reshape with new_shape value {1, 126, 1, 201}
+  // With this input shape and permutation values, output shape will be [1, 126, 1, 201].
+  // The order of non-one values is unchanged (126, 201).
+  // So this Transpose op can be converted to Reshape op.
   luci::SubstituteTransposeToReshapePass pass;
   while (pass.run(&g))
     ;
@@ -91,15 +91,13 @@ TEST_F(SubstituteTransposeToReshapeTest, simple_case)
   ASSERT_EQ(201, new_shape->at<loco::DataType::S32>(3));
 }
 
-TEST_F(SubstituteTransposeToReshapeTest, simple_case_NEG)
+TEST_F(SubstituteTransposeToReshapeTest, simple_case_not_convert)
 {
   // Create graph that tranpose input {126, 201, 1, 1} with permutation {2, 1, 3, 0}
   buildGraph({126, 201, 1, 1}, std::vector<int32_t>({2, 1, 3, 0}));
-  // on this input shape and permutation value, output shape will be {1, 201, 1, 126}
-  // the value in buffer also change as index become reversed
-  // for example, index 1 value in input will value.at[0][1][0][0], output will be
-  // value.at[0][0][0][1] which is same with input value.at[1][0][0][0]. so this transpose cannot
-  // convert to reshape.
+  // With this input shape and permutation values, output shape will be [1, 201, 1, 126].
+  // The order of non-one values is changed (126, 201) -> (201, 126).
+  // So this Transpose op cannot be converted to Reshape op.
   luci::SubstituteTransposeToReshapePass pass;
   while (pass.run(&g))
     ;

--- a/compiler/luci/pass/src/SubstituteTransposeToReshapePass.test.cpp
+++ b/compiler/luci/pass/src/SubstituteTransposeToReshapePass.test.cpp
@@ -91,7 +91,7 @@ TEST_F(SubstituteTransposeToReshapeTest, simple_case)
   ASSERT_EQ(201, new_shape->at<loco::DataType::S32>(3));
 }
 
-TEST_F(SubstituteTransposeToReshapeTest, simple_case_not_convert)
+TEST_F(SubstituteTransposeToReshapeTest, simple_case_NEG)
 {
   // Create graph that tranpose input {126, 201, 1, 1} with permutation {2, 1, 3, 0}
   buildGraph({126, 201, 1, 1}, std::vector<int32_t>({2, 1, 3, 0}));

--- a/compiler/luci/pass/src/SubstituteTransposeToReshapePass.test.cpp
+++ b/compiler/luci/pass/src/SubstituteTransposeToReshapePass.test.cpp
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "luci/Pass/SubstituteTransposeToReshapePass.h"
+
+#include <luci/IR/CircleNodes.h>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+
+void create_substitute_transpose_to_reshape(loco::Graph *g,
+                                            const std::initializer_list<uint32_t> shape,
+                                            const std::vector<int32_t> perm)
+{
+  assert(g);
+  // Input Create.
+  auto input = g->nodes()->create<luci::CircleInput>();
+  auto graph_input = g->inputs()->create();
+  input->index(graph_input->index());
+  input->shape_status(luci::ShapeStatus::VALID);
+  input->rank(shape.size());
+  input->shape(shape);
+
+  // Permutation Create.
+  auto perm_const = g->nodes()->create<luci::CircleConst>();
+  perm_const->dtype(loco::DataType::S32);
+  perm_const->size<loco::DataType::S32>(perm.size());
+  perm_const->shape_status(luci::ShapeStatus::VALID);
+  perm_const->rank(1);
+  perm_const->dim(0).set(perm.size());
+  for (uint32_t i = 0; i < static_cast<uint32_t>(perm.size()); i++)
+  {
+    perm_const->at<loco::DataType::S32>(i) = perm.at(i);
+  }
+
+  // Transpose Create.
+  auto transpose_node = g->nodes()->create<luci::CircleTranspose>();
+  transpose_node->a(input);
+  transpose_node->perm(perm_const);
+
+  // Output Connect.
+  auto output = g->nodes()->create<luci::CircleOutput>();
+  output->from(transpose_node);
+  auto graph_output = g->outputs()->create();
+  output->index(graph_output->index());
+}
+
+} // namespace
+
+TEST(SubstituteTransposeToReshapePass, simple_case)
+{
+  auto graph = loco::make_graph();
+  create_substitute_transpose_to_reshape(graph.get(), {126, 201, 1, 1},
+                                         std::vector<int32_t>({2, 0, 3, 1}));
+  luci::SubstituteTransposeToReshapePass pass;
+  while (pass.run(graph.get()))
+    ;
+  luci::CircleReshape *reshape_node = nullptr;
+  luci::CircleTranspose *transpose_node = nullptr;
+  for (auto node : loco::active_nodes(loco::output_nodes(graph.get())))
+  {
+    if (auto reshape = dynamic_cast<luci::CircleReshape *>(node))
+      reshape_node = reshape;
+    else if (auto pack = dynamic_cast<luci::CircleTranspose *>(node))
+      transpose_node = pack;
+  }
+  ASSERT_NE(nullptr, reshape_node);
+  ASSERT_EQ(nullptr, transpose_node);
+  auto new_shape = loco::must_cast<luci::CircleConst *>(reshape_node->shape());
+  ASSERT_EQ(1, new_shape->at<loco::DataType::S32>(0));
+  ASSERT_EQ(126, new_shape->at<loco::DataType::S32>(1));
+  ASSERT_EQ(1, new_shape->at<loco::DataType::S32>(2));
+  ASSERT_EQ(201, new_shape->at<loco::DataType::S32>(3));
+}
+
+TEST(SubstituteTransposeToReshapePass, simple_case_NEG)
+{
+  auto graph = loco::make_graph();
+  create_substitute_transpose_to_reshape(graph.get(), {126, 201, 1, 1},
+                                         std::vector<int32_t>({2, 1, 3, 0}));
+  luci::SubstituteTransposeToReshapePass pass;
+  while (pass.run(graph.get()))
+    ;
+  luci::CircleReshape *reshape_node = nullptr;
+  luci::CircleTranspose *transpose_node = nullptr;
+  for (auto node : loco::active_nodes(loco::output_nodes(graph.get())))
+  {
+    if (auto reshape = dynamic_cast<luci::CircleReshape *>(node))
+      reshape_node = reshape;
+    else if (auto tran = dynamic_cast<luci::CircleTranspose *>(node))
+      transpose_node = tran;
+  }
+  ASSERT_EQ(nullptr, reshape_node);
+  ASSERT_NE(nullptr, transpose_node);
+  auto perm = loco::must_cast<luci::CircleConst *>(transpose_node->perm());
+  ASSERT_EQ(2, perm->at<loco::DataType::S32>(0));
+  ASSERT_EQ(1, perm->at<loco::DataType::S32>(1));
+  ASSERT_EQ(3, perm->at<loco::DataType::S32>(2));
+  ASSERT_EQ(0, perm->at<loco::DataType::S32>(3));
+}

--- a/compiler/luci/pass/src/SubstituteTransposeToReshapePass.test.cpp
+++ b/compiler/luci/pass/src/SubstituteTransposeToReshapePass.test.cpp
@@ -91,7 +91,7 @@ TEST_F(SubstituteTransposeToReshapeTest, simple_case)
   ASSERT_EQ(201, new_shape->at<loco::DataType::S32>(3));
 }
 
-TEST_F(SubstituteTransposeToReshapeTest, simple_case_NEG)
+TEST_F(SubstituteTransposeToReshapeTest, failed_to_substitute_NEG)
 {
   // Create graph that tranpose input {126, 201, 1, 1} with permutation {2, 1, 3, 0}
   buildGraph({126, 201, 1, 1}, std::vector<int32_t>({2, 1, 3, 0}));
@@ -106,9 +106,4 @@ TEST_F(SubstituteTransposeToReshapeTest, simple_case_NEG)
   auto transpose_node = dynamic_cast<luci::CircleTranspose *>(output->from());
   ASSERT_EQ(nullptr, reshape_node);
   ASSERT_NE(nullptr, transpose_node);
-  auto perm = loco::must_cast<luci::CircleConst *>(transpose_node->perm());
-  ASSERT_EQ(2, perm->at<loco::DataType::S32>(0));
-  ASSERT_EQ(1, perm->at<loco::DataType::S32>(1));
-  ASSERT_EQ(3, perm->at<loco::DataType::S32>(2));
-  ASSERT_EQ(0, perm->at<loco::DataType::S32>(3));
 }


### PR DESCRIPTION
For #5703 

This commit will introduce `SubstituteTransposeToReshape` on luci/pass.

ONE-DCO-1.0-Signed-off-by: KiDeuk Bang <rrstrous@nate.com>