### PR TITLE
[luci] Add CircleReader data_format method

### DIFF
--- a/compiler/luci/import/include/luci/Import/CircleReader.h
+++ b/compiler/luci/import/include/luci/Import/CircleReader.h
@@ -78,6 +78,7 @@ public:
   const std::vector<int32_t> &inputs() const { return _current_subgraph->inputs; }
   const std::vector<int32_t> &outputs() const { return _current_subgraph->outputs; }
   const std::string &name() const { return _current_subgraph->name; }
+  const circle::DataFormat &data_format() const { return _current_subgraph->data_format; }
 
   const CircleTensorsPtr_t *tensors_ptr() const { return _tensors_ptr; }
 


### PR DESCRIPTION
This commit is to add a CircleReader interface getting `data_format`.

ONE-DCO-1.0-Signed-off-by: dayo09 <dayg502@gmail.com>