### PR TITLE
[luci] Revise temporary shape/dtype getter function

### DIFF
--- a/compiler/luci/service/src/CircleShapeInferenceHelper.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceHelper.cpp
@@ -23,6 +23,10 @@ namespace luci
 
 loco::NodeShape shape_get(const loco::Node *node)
 {
+  // NOTE This function is subject to change after refactoring is finished.
+  //      If shape of CircleNode is returned, ShapeInferencePass may cause errors.
+  //      If shape of loco::Node is returned, CircleShapeInferencePass may cause errors.
+  //      Therefore until refactoring is finished, both kind of shape should be used.
   if (luci::shape_known(node))
     return loco::NodeShape{sinf::circle_shape(loco::must_cast<const luci::CircleNode *>(node))};
   assert(loco::shape_known(node));

--- a/compiler/luci/service/src/CircleShapeInferenceHelper.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceHelper.cpp
@@ -16,13 +16,17 @@
 
 #include "CircleShapeInferenceHelper.h"
 
+#include <loco/Service/ShapeInference.h>
+
 namespace luci
 {
 
 loco::NodeShape shape_get(const loco::Node *node)
 {
-  assert(shape_known(node));
-  return loco::NodeShape{sinf::circle_shape(loco::must_cast<const luci::CircleNode *>(node))};
+  if (luci::shape_known(node))
+    return loco::NodeShape{sinf::circle_shape(loco::must_cast<const luci::CircleNode *>(node))};
+  assert(loco::shape_known(node));
+  return loco::shape_get(node);
 }
 
 bool shape_known(const loco::Node *node)

--- a/compiler/luci/service/src/CircleTypeInferenceHelper.cpp
+++ b/compiler/luci/service/src/CircleTypeInferenceHelper.cpp
@@ -23,6 +23,10 @@ namespace luci
 
 loco::DataType dtype_get(const loco::Node *node)
 {
+  // NOTE This function is subject to change after refactoring is finished.
+  //      If type of CircleNode is returned, TypeInferencePass may cause errors.
+  //      If type of loco::Node is returned, CircleTypeInferencePass may cause errors.
+  //      Therefore until refactoring is finished, both kind of type should be used.
   if (luci::dtype_known(node))
     return loco::must_cast<const luci::CircleNode *>(node)->dtype();
   assert(loco::dtype_known(node));

--- a/compiler/luci/service/src/CircleTypeInferenceHelper.cpp
+++ b/compiler/luci/service/src/CircleTypeInferenceHelper.cpp
@@ -16,13 +16,17 @@
 
 #include "CircleTypeInferenceHelper.h"
 
+#include <loco/Service/TypeInference.h>
+
 namespace luci
 {
 
 loco::DataType dtype_get(const loco::Node *node)
 {
-  assert(dtype_known(node));
-  return loco::must_cast<const luci::CircleNode *>(node)->dtype();
+  if (luci::dtype_known(node))
+    return loco::must_cast<const luci::CircleNode *>(node)->dtype();
+  assert(loco::dtype_known(node));
+  return loco::dtype_get(node);
 }
 
 bool dtype_known(const loco::Node *node)


### PR DESCRIPTION
Parent Issue : #5501

During refactoring for deprecating original `ShapeInferencePass` and `TypeInferencePass`,
newly created nodes does not have shape and dtype of `CircleNode`.
However, if `luci::dtype_get` and `luci::shape_get` only returns shape and dtype of `CircleNode`,
wrong result would be returned.
Until the refactoring is finished, revise helper function to return correct result.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>