### PR TITLE
[luci] Fix invalid type inference test code

### DIFF
--- a/compiler/luci/service/src/CircleTypeInferenceRule.test.cpp
+++ b/compiler/luci/service/src/CircleTypeInferenceRule.test.cpp
@@ -35,7 +35,7 @@ TEST(CircleTypeInferenceRuleTest, minimal_with_CircleRelu)
   auto relu_node = graph.append<luci::CircleRelu>(graph.input_node);
   graph.complete(relu_node);
 
-  // set dtype for nodes; like setting them in import
+  // set dtype for I/O nodes
   graph.input_node->dtype(loco::DataType::S32);
   graph.output_node->dtype(loco::DataType::S32);
 

--- a/compiler/luci/service/src/CircleTypeInferenceRule.test.cpp
+++ b/compiler/luci/service/src/CircleTypeInferenceRule.test.cpp
@@ -37,7 +37,6 @@ TEST(CircleTypeInferenceRuleTest, minimal_with_CircleRelu)
 
   // set dtype for nodes; like setting them in import
   graph.input_node->dtype(loco::DataType::S32);
-  relu_node->dtype(loco::DataType::S32);
   graph.output_node->dtype(loco::DataType::S32);
 
   luci::test::graph_input_dtype(graph.input_node);


### PR DESCRIPTION
`minimal_with_CircleRelu` test is for checking whether `relu_node` is inferred correctly.
However, as type of `relu_node` is set at first, the meaning is crahsed with pre-check.
i.e, type of `relu_node` is set to `S32` but `loco::dtype_known(relu_node)` should be `false` at pre-check.
This is definitely strange so this commit will fix it.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>