### PR TITLE
[luci] Reorder incorrect test code

### DIFF
--- a/compiler/luci/pass/src/ConvertNCHWToNHWCPass.test.cpp
+++ b/compiler/luci/pass/src/ConvertNCHWToNHWCPass.test.cpp
@@ -209,8 +209,8 @@ public:
 void check_pre_trans(loco::Node *node)
 {
   auto pre_trans = dynamic_cast<luci::CircleTranspose *>(node);
-  auto pre_trans_perm = dynamic_cast<luci::CircleConst *>(pre_trans->perm());
   EXPECT_NE(nullptr, pre_trans);
+  auto pre_trans_perm = dynamic_cast<luci::CircleConst *>(pre_trans->perm());
   EXPECT_NE(nullptr, pre_trans_perm);
   EXPECT_EQ(1, pre_trans_perm->rank());
   EXPECT_EQ(4, pre_trans_perm->dim(0).value());


### PR DESCRIPTION
This commit will fix the sequence of test codes in `ConvertNCHWToNHWCPass.test.cpp`.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>