### PR TITLE
[luci] Substitute loco getter functino to luci getter function

### DIFF
--- a/compiler/luci/service/src/CircleShapeInference.cpp
+++ b/compiler/luci/service/src/CircleShapeInference.cpp
@@ -33,7 +33,7 @@ namespace luci
 ShapeDescription ShapeInference::get(loco::Node *node)
 {
   assert(loco::shape_known(node));
-  return to_shape_description(loco::shape_get(node));
+  return to_shape_description(luci::shape_get(node));
 }
 
 } // namespace luci

--- a/compiler/luci/service/src/CircleShapeInferenceRule.test.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.test.cpp
@@ -16,6 +16,7 @@
 
 #include "TestGraph.h"
 #include "luci/Service/CircleShapeInferenceRule.h"
+#include "CircleShapeInferenceHelper.h"
 
 #include <luci/IR/CircleNodes.h>
 #include <luci/IR/CircleDialect.h>
@@ -80,9 +81,9 @@ TEST(CircleShapeInferenceRuleTest, minimal_with_CircleRelu)
   // Verify
   {
     ASSERT_TRUE(loco::shape_known(relu_node));
-    ASSERT_EQ(loco::Domain::Tensor, loco::shape_get(relu_node).domain());
+    ASSERT_EQ(loco::Domain::Tensor, luci::shape_get(relu_node).domain());
 
-    auto shape = loco::shape_get(relu_node).as<loco::TensorShape>();
+    auto shape = luci::shape_get(relu_node).as<loco::TensorShape>();
     ASSERT_EQ(2, shape.rank());
     ASSERT_EQ(3, shape.dim(0));
     ASSERT_EQ(4, shape.dim(1));
@@ -125,9 +126,9 @@ TEST(CircleShapeInferenceRuleTest, avgpool2d_valid)
   // Verify
   {
     ASSERT_TRUE(loco::shape_known(avg_node));
-    ASSERT_EQ(loco::Domain::Tensor, loco::shape_get(avg_node).domain());
+    ASSERT_EQ(loco::Domain::Tensor, luci::shape_get(avg_node).domain());
 
-    auto shape = loco::shape_get(avg_node).as<loco::TensorShape>();
+    auto shape = luci::shape_get(avg_node).as<loco::TensorShape>();
     ASSERT_EQ(4, shape.rank());
     ASSERT_EQ(1, shape.dim(0).value());
     ASSERT_EQ(2, shape.dim(1).value());
@@ -172,9 +173,9 @@ TEST(CircleShapeInferenceRuleTest, avgpool2d_same)
   // Verify
   {
     ASSERT_TRUE(loco::shape_known(avg_node));
-    ASSERT_EQ(loco::Domain::Tensor, loco::shape_get(avg_node).domain());
+    ASSERT_EQ(loco::Domain::Tensor, luci::shape_get(avg_node).domain());
 
-    auto shape = loco::shape_get(avg_node).as<loco::TensorShape>();
+    auto shape = luci::shape_get(avg_node).as<loco::TensorShape>();
     ASSERT_EQ(4, shape.rank());
     ASSERT_EQ(1, shape.dim(0).value());
     ASSERT_EQ(2, shape.dim(1).value());
@@ -249,9 +250,9 @@ TEST(CircleShapeInferenceRuleTest, TFAdd_shapeinf_different)
   // Verify
   {
     ASSERT_TRUE(loco::shape_known(add_node));
-    ASSERT_EQ(loco::Domain::Tensor, loco::shape_get(add_node).domain());
+    ASSERT_EQ(loco::Domain::Tensor, luci::shape_get(add_node).domain());
 
-    auto shape = loco::shape_get(add_node).as<loco::TensorShape>();
+    auto shape = luci::shape_get(add_node).as<loco::TensorShape>();
     ASSERT_EQ(3, shape.rank());
     ASSERT_EQ(2, shape.dim(0));
     ASSERT_EQ(3, shape.dim(1));
@@ -290,7 +291,7 @@ TEST(CircleShapeInferenceRuleTest, CircleTranspose_simple)
   {
     ASSERT_TRUE(loco::shape_known(g.transpose_node));
 
-    auto shape = loco::shape_get(g.transpose_node).as<loco::TensorShape>();
+    auto shape = luci::shape_get(g.transpose_node).as<loco::TensorShape>();
     ASSERT_EQ(3, shape.rank());
     ASSERT_EQ(8, shape.dim(0));
     ASSERT_EQ(1, shape.dim(1));
@@ -329,7 +330,7 @@ TEST(CircleShapeInferenceRuleTest, CircleSqueeze)
   {
     ASSERT_TRUE(loco::shape_known(squeeze_node));
 
-    auto shape = loco::shape_get(squeeze_node).as<loco::TensorShape>();
+    auto shape = luci::shape_get(squeeze_node).as<loco::TensorShape>();
     ASSERT_EQ(3, shape.rank());
     ASSERT_EQ(4, shape.dim(0));
     ASSERT_EQ(3, shape.dim(1));
@@ -370,7 +371,7 @@ TEST(CircleShapeInferenceRuleTest, CircleExpandDims)
   {
     ASSERT_TRUE(loco::shape_known(expand_dims));
 
-    auto shape = loco::shape_get(expand_dims).as<loco::TensorShape>();
+    auto shape = luci::shape_get(expand_dims).as<loco::TensorShape>();
 
     ASSERT_EQ(3, shape.rank());
     ASSERT_EQ(4, shape.dim(0));
@@ -410,7 +411,7 @@ TEST(CircleShapeInferenceRuleTest, CircleSqueezeAll)
   {
     ASSERT_TRUE(loco::shape_known(squeeze_node));
 
-    auto shape = loco::shape_get(squeeze_node).as<loco::TensorShape>();
+    auto shape = luci::shape_get(squeeze_node).as<loco::TensorShape>();
     ASSERT_EQ(2, shape.rank());
     ASSERT_EQ(4, shape.dim(0));
     ASSERT_EQ(3, shape.dim(1));
@@ -450,7 +451,7 @@ TEST(CircleShapeInferenceRuleTest, CircleGatherNd_simple)
   {
     ASSERT_TRUE(loco::shape_known(gather_nd_node));
 
-    auto shape = loco::shape_get(gather_nd_node).as<loco::TensorShape>();
+    auto shape = luci::shape_get(gather_nd_node).as<loco::TensorShape>();
     ASSERT_EQ(3, shape.rank());
     ASSERT_EQ(1, shape.dim(0));
     ASSERT_EQ(2, shape.dim(1));
@@ -491,7 +492,7 @@ TEST(CircleShapeInferenceRuleTest, CircleGatherNd_slices)
   {
     ASSERT_TRUE(loco::shape_known(gather_nd_node));
 
-    auto shape = loco::shape_get(gather_nd_node).as<loco::TensorShape>();
+    auto shape = luci::shape_get(gather_nd_node).as<loco::TensorShape>();
     ASSERT_EQ(5, shape.rank());
     ASSERT_EQ(1, shape.dim(0));
     ASSERT_EQ(2, shape.dim(1));
@@ -572,7 +573,7 @@ TEST(CircleShapeInferenceRuleTest, CircleResizeNearestNeighbor)
   {
     ASSERT_TRUE(loco::shape_known(resize_node));
 
-    auto shape = loco::shape_get(resize_node).as<loco::TensorShape>();
+    auto shape = luci::shape_get(resize_node).as<loco::TensorShape>();
     ASSERT_EQ(4, shape.rank());
     ASSERT_EQ(1, shape.dim(0));
     ASSERT_EQ(16, shape.dim(1));
@@ -616,7 +617,7 @@ TEST(CircleShapeInferenceRuleTest, CircleResizeBilinear)
   {
     ASSERT_TRUE(loco::shape_known(resize_node));
 
-    auto shape = loco::shape_get(resize_node).as<loco::TensorShape>();
+    auto shape = luci::shape_get(resize_node).as<loco::TensorShape>();
     ASSERT_EQ(4, shape.rank());
     ASSERT_EQ(1, shape.dim(0));
     ASSERT_EQ(16, shape.dim(1));

--- a/compiler/luci/service/src/CircleTypeInference.cpp
+++ b/compiler/luci/service/src/CircleTypeInference.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "luci/Service/CircleTypeInference.h"
+#include "CircleTypeInferenceHelper.h"
 
 #include <luci/Log.h>
 
@@ -68,7 +69,7 @@ namespace luci
 circle::TensorType TypeInference::get(loco::Node *node)
 {
   assert(loco::dtype_known(node));
-  return translateLocoTypeToCircle(loco::dtype_get(node));
+  return translateLocoTypeToCircle(luci::dtype_get(node));
 }
 
 } // namespace luci

--- a/compiler/luci/service/src/CircleTypeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleTypeInferenceRule.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "luci/Service/CircleTypeInferenceRule.h"
+#include "CircleTypeInferenceHelper.h"
 
 #include <luci/IR/CircleDialect.h>
 #include <luci/IR/CircleNodeVisitor.h>
@@ -29,24 +30,24 @@ struct TypeInferenceAlgorithm final : public luci::CircleNodeVisitor<loco::DataT
 {
   // TODO Given a tensor x of complex numbers, Abs operation returns a tensor of type float32 or
   // float64.
-  loco::DataType visit(const luci::CircleAbs *node) final { return loco::dtype_get(node->x()); }
+  loco::DataType visit(const luci::CircleAbs *node) final { return luci::dtype_get(node->x()); }
 
-  loco::DataType visit(const luci::CircleAdd *node) final { return loco::dtype_get(node->x()); }
+  loco::DataType visit(const luci::CircleAdd *node) final { return luci::dtype_get(node->x()); }
 
   loco::DataType visit(const luci::CircleAddN *node) final
   {
-    auto dtype = loco::dtype_get(node->inputs(0));
+    auto dtype = luci::dtype_get(node->inputs(0));
 
     for (uint32_t idx = 1; idx < node->arity(); ++idx)
     {
-      auto dtype_idx = loco::dtype_get(node->inputs(idx));
+      auto dtype_idx = luci::dtype_get(node->inputs(idx));
       if (dtype != dtype_idx)
       {
         INTERNAL_EXN_V("ADD_N dtype not same as the first input: ", idx);
       }
     }
 
-    return loco::dtype_get(node->inputs(0));
+    return luci::dtype_get(node->inputs(0));
   }
 
   loco::DataType visit(const luci::CircleArgMax *node) final { return node->output_type(); }
@@ -55,22 +56,22 @@ struct TypeInferenceAlgorithm final : public luci::CircleNodeVisitor<loco::DataT
 
   loco::DataType visit(const luci::CircleAveragePool2D *node) final
   {
-    return loco::dtype_get(node->value());
+    return luci::dtype_get(node->value());
   }
 
   loco::DataType visit(const luci::CircleBatchMatMul *node) final
   {
-    return loco::dtype_get(node->x());
+    return luci::dtype_get(node->x());
   }
 
   loco::DataType visit(const luci::CircleBatchToSpaceND *node) final
   {
-    return loco::dtype_get(node->input());
+    return luci::dtype_get(node->input());
   }
 
   loco::DataType visit(const luci::CircleCast *node) final { return node->dtype(); }
 
-  loco::DataType visit(const luci::CircleCeil *node) final { return loco::dtype_get(node->x()); }
+  loco::DataType visit(const luci::CircleCeil *node) final { return luci::dtype_get(node->x()); }
 
   loco::DataType visit(const luci::CircleConcatenation *node) final
   {
@@ -78,92 +79,92 @@ struct TypeInferenceAlgorithm final : public luci::CircleNodeVisitor<loco::DataT
     assert(node->numValues() > 0);
 
     for (uint32_t i = 1; i < node->numValues(); ++i)
-      assert(loco::dtype_get(node->values(i - 1)) == loco::dtype_get(node->values(i)));
+      assert(luci::dtype_get(node->values(i - 1)) == luci::dtype_get(node->values(i)));
 
-    return loco::dtype_get(node->values(0));
+    return luci::dtype_get(node->values(0));
   }
 
   loco::DataType visit(const luci::CircleConst *node) final { return node->dtype(); }
 
   loco::DataType visit(const luci::CircleConv2D *node) final
   {
-    return loco::dtype_get(node->input());
+    return luci::dtype_get(node->input());
   }
 
-  loco::DataType visit(const luci::CircleCos *node) final { return loco::dtype_get(node->x()); }
+  loco::DataType visit(const luci::CircleCos *node) final { return luci::dtype_get(node->x()); }
 
   loco::DataType visit(const luci::CircleCustom *node) final
   {
     if (node->custom_code() == "BatchMatMulV2")
     {
-      return loco::dtype_get(node->inputs(0));
+      return luci::dtype_get(node->inputs(0));
     }
     return node->dtype();
   }
 
   loco::DataType visit(const luci::CircleDepthToSpace *node) final
   {
-    return loco::dtype_get(node->input());
+    return luci::dtype_get(node->input());
   }
 
   loco::DataType visit(const luci::CircleDepthwiseConv2D *node) final
   {
-    return loco::dtype_get(node->input());
+    return luci::dtype_get(node->input());
   }
 
   loco::DataType visit(const luci::CircleDequantize *) final { return loco::DataType::FLOAT32; }
 
-  loco::DataType visit(const luci::CircleDiv *node) final { return loco::dtype_get(node->x()); }
+  loco::DataType visit(const luci::CircleDiv *node) final { return luci::dtype_get(node->x()); }
 
   loco::DataType visit(const luci::CircleElu *node) final
   {
-    return loco::dtype_get(node->features());
+    return luci::dtype_get(node->features());
   }
 
   loco::DataType visit(const luci::CircleEqual *) final { return loco::DataType::BOOL; }
 
-  loco::DataType visit(const luci::CircleExp *node) final { return loco::dtype_get(node->x()); }
+  loco::DataType visit(const luci::CircleExp *node) final { return luci::dtype_get(node->x()); }
 
   loco::DataType visit(const luci::CircleExpandDims *node) final
   {
-    return loco::dtype_get(node->input());
+    return luci::dtype_get(node->input());
   }
 
   loco::DataType visit(const luci::CircleFakeQuant *node) final
   {
-    return loco::dtype_get(node->inputs());
+    return luci::dtype_get(node->inputs());
   }
 
   loco::DataType visit(const luci::CircleFill *node) final
   {
-    return loco::dtype_get(node->value());
+    return luci::dtype_get(node->value());
   }
 
-  loco::DataType visit(const luci::CircleFloor *node) final { return loco::dtype_get(node->x()); }
+  loco::DataType visit(const luci::CircleFloor *node) final { return luci::dtype_get(node->x()); }
 
   loco::DataType visit(const luci::CircleFloorDiv *node) final
   {
-    return loco::dtype_get(node->x());
+    return luci::dtype_get(node->x());
   }
 
   loco::DataType visit(const luci::CircleFloorMod *node) final
   {
-    return loco::dtype_get(node->x());
+    return luci::dtype_get(node->x());
   }
 
   loco::DataType visit(const luci::CircleFullyConnected *node) final
   {
-    return loco::dtype_get(node->input());
+    return luci::dtype_get(node->input());
   }
 
   loco::DataType visit(const luci::CircleGather *node) final
   {
-    return loco::dtype_get(node->params());
+    return luci::dtype_get(node->params());
   }
 
   loco::DataType visit(const luci::CircleGatherNd *node) final
   {
-    return loco::dtype_get(node->params());
+    return luci::dtype_get(node->params());
   }
 
   loco::DataType visit(const luci::CircleGreater *) final { return loco::DataType::BOOL; }
@@ -174,22 +175,22 @@ struct TypeInferenceAlgorithm final : public luci::CircleNodeVisitor<loco::DataT
   {
     // Type of If is not used. Just use input 0
     assert(node->input_count() > 0);
-    return loco::dtype_get(node->input(0));
+    return luci::dtype_get(node->input(0));
   }
 
   loco::DataType visit(const luci::CircleL2Normalize *node) final
   {
-    return loco::dtype_get(node->x());
+    return luci::dtype_get(node->x());
   }
 
   loco::DataType visit(const luci::CircleL2Pool2D *node) final
   {
-    return loco::dtype_get(node->value());
+    return luci::dtype_get(node->value());
   }
 
   loco::DataType visit(const luci::CircleLeakyRelu *node) final
   {
-    return loco::dtype_get(node->features());
+    return luci::dtype_get(node->features());
   }
 
   loco::DataType visit(const luci::CircleLess *) final { return loco::DataType::BOOL; }
@@ -198,75 +199,75 @@ struct TypeInferenceAlgorithm final : public luci::CircleNodeVisitor<loco::DataT
 
   loco::DataType visit(const luci::CircleLocalResponseNormalization *node) final
   {
-    return loco::dtype_get(node->input());
+    return luci::dtype_get(node->input());
   }
 
-  loco::DataType visit(const luci::CircleLog *node) final { return loco::dtype_get(node->x()); }
+  loco::DataType visit(const luci::CircleLog *node) final { return luci::dtype_get(node->x()); }
 
   loco::DataType visit(const luci::CircleLogicalAnd *node) final
   {
-    return loco::dtype_get(node->x());
+    return luci::dtype_get(node->x());
   }
 
   loco::DataType visit(const luci::CircleLogicalNot *node) final
   {
-    return loco::dtype_get(node->x());
+    return luci::dtype_get(node->x());
   }
 
   loco::DataType visit(const luci::CircleLogicalOr *node) final
   {
-    return loco::dtype_get(node->x());
+    return luci::dtype_get(node->x());
   }
 
   loco::DataType visit(const luci::CircleLogistic *node) final
   {
-    return loco::dtype_get(node->x());
+    return luci::dtype_get(node->x());
   }
 
   loco::DataType visit(const luci::CircleLogSoftmax *node) final
   {
-    return loco::dtype_get(node->logits());
+    return luci::dtype_get(node->logits());
   }
 
   loco::DataType visit(const luci::CircleMatrixDiag *node) final
   {
-    return loco::dtype_get(node->diagonal());
+    return luci::dtype_get(node->diagonal());
   }
 
   loco::DataType visit(const luci::CircleMatrixSetDiag *node) final
   {
-    return loco::dtype_get(node->input());
+    return luci::dtype_get(node->input());
   }
 
-  loco::DataType visit(const luci::CircleMaximum *node) final { return loco::dtype_get(node->x()); }
+  loco::DataType visit(const luci::CircleMaximum *node) final { return luci::dtype_get(node->x()); }
 
   loco::DataType visit(const luci::CircleMaxPool2D *node) final
   {
-    return loco::dtype_get(node->value());
+    return luci::dtype_get(node->value());
   }
 
   loco::DataType visit(const luci::CircleMean *node) final
   {
-    return loco::dtype_get(node->input());
+    return luci::dtype_get(node->input());
   }
 
-  loco::DataType visit(const luci::CircleMinimum *node) final { return loco::dtype_get(node->x()); }
+  loco::DataType visit(const luci::CircleMinimum *node) final { return luci::dtype_get(node->x()); }
 
   loco::DataType visit(const luci::CircleMirrorPad *node) final
   {
-    return loco::dtype_get(node->input());
+    return luci::dtype_get(node->input());
   }
 
-  loco::DataType visit(const luci::CircleNeg *node) final { return loco::dtype_get(node->x()); }
+  loco::DataType visit(const luci::CircleNeg *node) final { return luci::dtype_get(node->x()); }
 
   loco::DataType visit(const luci::CircleNonMaxSuppressionV4 *node) final
   {
-    return loco::dtype_get(node->boxes());
+    return luci::dtype_get(node->boxes());
   }
 
   loco::DataType visit(const luci::CircleNonMaxSuppressionV5 *node) final
   {
-    return loco::dtype_get(node->boxes());
+    return luci::dtype_get(node->boxes());
   }
 
   loco::DataType visit(const luci::CircleNotEqual *) final { return loco::DataType::BOOL; }
@@ -276,25 +277,25 @@ struct TypeInferenceAlgorithm final : public luci::CircleNodeVisitor<loco::DataT
     // Only support CirclePack with one or more inputs
     assert(node->values_count() > 0);
 
-    auto first_value_type = loco::dtype_get(node->values(0));
+    auto first_value_type = luci::dtype_get(node->values(0));
     for (uint32_t i = 1; i < node->values_count(); ++i)
-      assert(first_value_type == loco::dtype_get(node->values(i)));
+      assert(first_value_type == luci::dtype_get(node->values(i)));
 
     return first_value_type;
   }
 
-  loco::DataType visit(const luci::CirclePad *node) final { return loco::dtype_get(node->input()); }
+  loco::DataType visit(const luci::CirclePad *node) final { return luci::dtype_get(node->input()); }
 
   loco::DataType visit(const luci::CirclePadV2 *node) final
   {
-    return loco::dtype_get(node->input());
+    return luci::dtype_get(node->input());
   }
 
   loco::DataType visit(const luci::CirclePow *node) final
   {
     // TODO make sure types cannot differ
-    auto x_type = loco::dtype_get(node->x());
-    auto y_type = loco::dtype_get(node->y());
+    auto x_type = luci::dtype_get(node->x());
+    auto y_type = luci::dtype_get(node->y());
 
     if (x_type != y_type)
       INTERNAL_EXN("Different datatype for x and y are not supported");
@@ -304,8 +305,8 @@ struct TypeInferenceAlgorithm final : public luci::CircleNodeVisitor<loco::DataT
 
   loco::DataType visit(const luci::CirclePRelu *node) final
   {
-    auto input_type = loco::dtype_get(node->input());
-    auto alpha_type = loco::dtype_get(node->alpha());
+    auto input_type = luci::dtype_get(node->input());
+    auto alpha_type = luci::dtype_get(node->alpha());
 
     if (input_type != alpha_type)
       INTERNAL_EXN("Different datatype for input and alpha are not supported");
@@ -315,201 +316,201 @@ struct TypeInferenceAlgorithm final : public luci::CircleNodeVisitor<loco::DataT
 
   loco::DataType visit(const luci::CircleRange *node) final
   {
-    return loco::dtype_get(node->start());
+    return luci::dtype_get(node->start());
   }
 
   loco::DataType visit(const luci::CircleRank *) final { return loco::DataType::S32; }
 
-  loco::DataType visit(const luci::CircleMul *node) final { return loco::dtype_get(node->x()); }
+  loco::DataType visit(const luci::CircleMul *node) final { return luci::dtype_get(node->x()); }
 
   loco::DataType visit(const luci::CircleOneHot *node) final
   {
-    return loco::dtype_get(node->on_value());
+    return luci::dtype_get(node->on_value());
   }
 
   loco::DataType visit(const luci::CircleReduceAny *node) final
   {
-    return loco::dtype_get(node->input());
+    return luci::dtype_get(node->input());
   }
 
   loco::DataType visit(const luci::CircleReduceMax *node) final
   {
-    return loco::dtype_get(node->input());
+    return luci::dtype_get(node->input());
   }
 
   loco::DataType visit(const luci::CircleReduceMin *node) final
   {
-    return loco::dtype_get(node->input());
+    return luci::dtype_get(node->input());
   }
 
   loco::DataType visit(const luci::CircleReduceProd *node) final
   {
-    return loco::dtype_get(node->input());
+    return luci::dtype_get(node->input());
   }
 
   loco::DataType visit(const luci::CircleRelu *node) final
   {
-    return loco::dtype_get(node->features());
+    return luci::dtype_get(node->features());
   }
 
   loco::DataType visit(const luci::CircleRelu6 *node) final
   {
-    return loco::dtype_get(node->features());
+    return luci::dtype_get(node->features());
   }
 
   loco::DataType visit(const luci::CircleReluN1To1 *node) final
   {
-    return loco::dtype_get(node->features());
+    return luci::dtype_get(node->features());
   }
 
   loco::DataType visit(const luci::CircleReshape *node) final
   {
-    return loco::dtype_get(node->tensor());
+    return luci::dtype_get(node->tensor());
   }
 
   loco::DataType visit(const luci::CircleResizeBilinear *node) final
   {
-    return loco::dtype_get(node->input());
+    return luci::dtype_get(node->input());
   }
 
   loco::DataType visit(const luci::CircleResizeNearestNeighbor *node) final
   {
-    return loco::dtype_get(node->input());
+    return luci::dtype_get(node->input());
   }
 
   loco::DataType visit(const luci::CircleReverseSequence *node) final
   {
-    return loco::dtype_get(node->input());
+    return luci::dtype_get(node->input());
   }
 
   loco::DataType visit(const luci::CircleReverseV2 *node) final
   {
-    return loco::dtype_get(node->tensor());
+    return luci::dtype_get(node->tensor());
   }
 
-  loco::DataType visit(const luci::CircleRound *node) final { return loco::dtype_get(node->x()); }
+  loco::DataType visit(const luci::CircleRound *node) final { return luci::dtype_get(node->x()); }
 
-  loco::DataType visit(const luci::CircleRsqrt *node) final { return loco::dtype_get(node->x()); }
+  loco::DataType visit(const luci::CircleRsqrt *node) final { return luci::dtype_get(node->x()); }
 
   loco::DataType visit(const luci::CircleScatterNd *node) final
   {
-    return loco::dtype_get(node->updates());
+    return luci::dtype_get(node->updates());
   }
 
   loco::DataType visit(const luci::CircleSegmentSum *node) final
   {
-    return loco::dtype_get(node->input());
+    return luci::dtype_get(node->input());
   }
 
   loco::DataType visit(const luci::CircleSelect *node) final
   {
-    assert(loco::dtype_get(node->t()) == loco::dtype_get(node->e()));
-    return loco::dtype_get(node->t());
+    assert(luci::dtype_get(node->t()) == luci::dtype_get(node->e()));
+    return luci::dtype_get(node->t());
   }
 
   loco::DataType visit(const luci::CircleSelectV2 *node) final
   {
-    assert(loco::dtype_get(node->t()) == loco::dtype_get(node->e()));
-    return loco::dtype_get(node->t());
+    assert(luci::dtype_get(node->t()) == luci::dtype_get(node->e()));
+    return luci::dtype_get(node->t());
   }
 
   loco::DataType visit(const luci::CircleShape *node) final { return node->out_type(); }
 
-  loco::DataType visit(const luci::CircleSin *node) final { return loco::dtype_get(node->x()); }
+  loco::DataType visit(const luci::CircleSin *node) final { return luci::dtype_get(node->x()); }
 
   loco::DataType visit(const luci::CircleSlice *node) final
   {
-    return loco::dtype_get(node->input());
+    return luci::dtype_get(node->input());
   }
 
   loco::DataType visit(const luci::CircleSoftmax *node) final
   {
-    return loco::dtype_get(node->logits());
+    return luci::dtype_get(node->logits());
   }
 
   loco::DataType visit(const luci::CircleSpaceToBatchND *node) final
   {
-    return loco::dtype_get(node->input());
+    return luci::dtype_get(node->input());
   }
 
   loco::DataType visit(const luci::CircleSpaceToDepth *node) final
   {
-    return loco::dtype_get(node->input());
+    return luci::dtype_get(node->input());
   }
 
   loco::DataType visit(const luci::CircleSparseToDense *node) final
   {
-    return loco::dtype_get(node->values());
+    return luci::dtype_get(node->values());
   }
 
   loco::DataType visit(const luci::CircleSplit *node) final
   {
-    return loco::dtype_get(node->input());
+    return luci::dtype_get(node->input());
   }
 
   loco::DataType visit(const luci::CircleSplitV *node) final
   {
-    return loco::dtype_get(node->input());
+    return luci::dtype_get(node->input());
   }
 
-  loco::DataType visit(const luci::CircleSqrt *node) final { return loco::dtype_get(node->x()); }
+  loco::DataType visit(const luci::CircleSqrt *node) final { return luci::dtype_get(node->x()); }
 
-  loco::DataType visit(const luci::CircleSquare *node) final { return loco::dtype_get(node->x()); }
+  loco::DataType visit(const luci::CircleSquare *node) final { return luci::dtype_get(node->x()); }
 
   loco::DataType visit(const luci::CircleSquaredDifference *node) final
   {
-    return loco::dtype_get(node->x());
+    return luci::dtype_get(node->x());
   }
 
   loco::DataType visit(const luci::CircleSqueeze *node) final
   {
-    return loco::dtype_get(node->input());
+    return luci::dtype_get(node->input());
   }
 
   loco::DataType visit(const luci::CircleStridedSlice *node) final
   {
-    return loco::dtype_get(node->input());
+    return luci::dtype_get(node->input());
   }
 
-  loco::DataType visit(const luci::CircleSub *node) final { return loco::dtype_get(node->x()); }
+  loco::DataType visit(const luci::CircleSub *node) final { return luci::dtype_get(node->x()); }
 
-  loco::DataType visit(const luci::CircleSum *node) final { return loco::dtype_get(node->input()); }
+  loco::DataType visit(const luci::CircleSum *node) final { return luci::dtype_get(node->input()); }
 
-  loco::DataType visit(const luci::CircleTanh *node) final { return loco::dtype_get(node->x()); }
+  loco::DataType visit(const luci::CircleTanh *node) final { return luci::dtype_get(node->x()); }
 
   loco::DataType visit(const luci::CircleTile *node) final
   {
-    return loco::dtype_get(node->input());
+    return luci::dtype_get(node->input());
   }
 
   loco::DataType visit(const luci::CircleTopKV2 *node) final
   {
-    return loco::dtype_get(node->input());
+    return luci::dtype_get(node->input());
   }
 
   loco::DataType visit(const luci::CircleTranspose *node) final
   {
-    return loco::dtype_get(node->a());
+    return luci::dtype_get(node->a());
   }
 
   loco::DataType visit(const luci::CircleTransposeConv *node) final
   {
-    return loco::dtype_get(node->outBackprop());
+    return luci::dtype_get(node->outBackprop());
   }
 
   loco::DataType visit(const luci::CircleUnidirectionalSequenceLSTM *node) final
   {
-    return loco::dtype_get(node->input());
+    return luci::dtype_get(node->input());
   }
 
   loco::DataType visit(const luci::CircleUnique *node) final
   {
-    return loco::dtype_get(node->input());
+    return luci::dtype_get(node->input());
   }
 
   loco::DataType visit(const luci::CircleUnpack *node) final
   {
-    return loco::dtype_get(node->value());
+    return luci::dtype_get(node->value());
   }
 
   loco::DataType visit(const luci::CircleWhere *) final { return loco::DataType::S64; }
@@ -518,12 +519,12 @@ struct TypeInferenceAlgorithm final : public luci::CircleNodeVisitor<loco::DataT
   {
     // Type of While is not used. Just use input 0
     assert(node->input_count() > 0);
-    return loco::dtype_get(node->input(0));
+    return luci::dtype_get(node->input(0));
   }
 
   loco::DataType visit(const luci::CircleZerosLike *node) final
   {
-    return loco::dtype_get(node->input());
+    return luci::dtype_get(node->input());
   }
 
   // Circle Only
@@ -536,7 +537,7 @@ struct TypeInferenceAlgorithm final : public luci::CircleNodeVisitor<loco::DataT
 
   loco::DataType visit(const luci::CircleInstanceNorm *node) final
   {
-    return loco::dtype_get(node->input());
+    return luci::dtype_get(node->input());
   }
 
   // Virtual
@@ -553,7 +554,7 @@ struct TypeInferenceAlgorithm final : public luci::CircleNodeVisitor<loco::DataT
     {
       // We don't care for the type if from() is CircleOutputDummy or CircleOutputExclude
       // from() type should match that of CircleOutput
-      assert(output_dtype == loco::dtype_get(node->from()));
+      assert(output_dtype == luci::dtype_get(node->from()));
     }
     return output_dtype;
   }
@@ -624,19 +625,19 @@ struct TypeInferenceAlgorithm final : public luci::CircleNodeVisitor<loco::DataT
 
   loco::DataType visit(const luci::CircleSplitOut *node) final
   {
-    return loco::dtype_get(node->input());
+    return luci::dtype_get(node->input());
   }
 
   loco::DataType visit(const luci::CircleSplitVOut *node) final
   {
-    return loco::dtype_get(node->input());
+    return luci::dtype_get(node->input());
   }
 
   loco::DataType visit(const luci::CircleTopKV2Out *node) final
   {
     // First output is same as input
     if (node->index() == 0)
-      return loco::dtype_get(node->input());
+      return luci::dtype_get(node->input());
     // Second outout is always S32
     assert(node->index() == 1);
     return loco::DataType::S32;
@@ -646,7 +647,7 @@ struct TypeInferenceAlgorithm final : public luci::CircleNodeVisitor<loco::DataT
   {
     if (node->index() == 0)
     {
-      return loco::dtype_get(node->input());
+      return luci::dtype_get(node->input());
     }
     assert(node->index() == 1);
     auto unique = loco::must_cast<luci::CircleUnique *>(node->input());
@@ -655,7 +656,7 @@ struct TypeInferenceAlgorithm final : public luci::CircleNodeVisitor<loco::DataT
 
   loco::DataType visit(const luci::CircleUnpackOut *node) final
   {
-    return loco::dtype_get(node->input());
+    return luci::dtype_get(node->input());
   }
 
   loco::DataType visit(const luci::CircleWhileOut *node) final

--- a/compiler/luci/service/src/CircleTypeInferenceRule.test.cpp
+++ b/compiler/luci/service/src/CircleTypeInferenceRule.test.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "TestGraph.h"
+#include "CircleTypeInferenceHelper.h"
 #include <luci/Service/CircleTypeInferenceRule.h>
 
 #include <luci/IR/CircleNodes.h>
@@ -57,6 +58,6 @@ TEST(CircleTypeInferenceRuleTest, minimal_with_CircleRelu)
 
   // Verify
   ASSERT_TRUE(loco::dtype_known(relu_node));
-  auto type = loco::dtype_get(relu_node);
+  auto type = luci::dtype_get(relu_node);
   ASSERT_EQ(loco::DataType::S32, type);
 }

--- a/compiler/luci/service/src/ShapeInfer_StridedSlice.cpp
+++ b/compiler/luci/service/src/ShapeInfer_StridedSlice.cpp
@@ -17,6 +17,7 @@
 
 #include "ShapeInfer_StridedSlice.h"
 #include "Check.h"
+#include "CircleShapeInferenceHelper.h"
 
 #include <luci/IR/CircleNode.h>
 #include <loco/IR/DataType.h>
@@ -245,7 +246,7 @@ loco::TensorShape infer_output_shape(const CircleStridedSlice *node)
   assert(node->new_axis_mask() == 0);
 
   auto op_params = BuildStridedSliceParams(node);
-  loco::TensorShape input_shape = loco::shape_get(input_node).as<loco::TensorShape>();
+  loco::TensorShape input_shape = luci::shape_get(input_node).as<loco::TensorShape>();
 
   uint32_t num_input_axes = input_shape.rank();
   assert(begin_node->size<S32>() <= num_input_axes);


### PR DESCRIPTION
Parent Issue : #5501

This commit will substitute `loco::shape_get` and `loco::dtype_get` functions to
`luci::shape_get` and `luci::dtype_get` functions.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>