### PR TITLE
[luci] Set ShapeStatus of CircleConst in ResolveCustomOpMatMulPass

### DIFF
--- a/compiler/luci/pass/src/ResolveCustomOpMatMulPass.cpp
+++ b/compiler/luci/pass/src/ResolveCustomOpMatMulPass.cpp
@@ -42,6 +42,7 @@ luci::CircleConst *create_const_node(loco::Graph *g, const loco::DataType dtype,
     node->dim(i) = shape.at(i);
     size *= shape.at(i);
   }
+  node->shape_status(luci::ShapeStatus::VALID);
 
 #define INIT_VALUES(DT)                          \
   {                                              \


### PR DESCRIPTION
This commit will set `ShapeStatus` of newly created `CircleConst` in `ResolveCustomOpMatMulPass`.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>