### PR TITLE
[onert/test] Change TFLite default no. of threads setting

### DIFF
--- a/tests/tools/tflite_loader/src/tflite_loader.cc
+++ b/tests/tools/tflite_loader/src/tflite_loader.cc
@@ -300,7 +300,7 @@ int main(const int argc, char **argv)
     std::cerr << e.what() << std::endl;
     exit(FILE_ERROR);
   }
-  interpreter->SetNumThreads(nnfw::misc::EnvVar("THREAD").asInt(-1));
+  interpreter->SetNumThreads(nnfw::misc::EnvVar("THREAD").asInt(1));
 
   auto sess = std::make_shared<nnfw::tflite::InterpreterSession>(interpreter.get());
   sess->prepare();

--- a/tests/tools/tflite_run/src/tflite_run.cc
+++ b/tests/tools/tflite_run/src/tflite_run.cc
@@ -112,7 +112,7 @@ int main(const int argc, char **argv)
       BuiltinOpResolver resolver;
       InterpreterBuilder builder(*model, resolver);
       TFLITE_ENSURE(builder(&interpreter))
-      interpreter->SetNumThreads(nnfw::misc::EnvVar("THREAD").asInt(-1));
+      interpreter->SetNumThreads(nnfw::misc::EnvVar("THREAD").asInt(1));
     });
   }
   catch (const std::exception &e)


### PR DESCRIPTION
This commit changes default number of threads for tflite: -1 -> 1
Setting to "-1" is not working now

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>