### PR TITLE
[luci] Substitute shape_known/dtype_known functions to luci

### DIFF
--- a/compiler/luci/service/src/CircleShapeInference.cpp
+++ b/compiler/luci/service/src/CircleShapeInference.cpp
@@ -32,7 +32,7 @@ namespace luci
 
 ShapeDescription ShapeInference::get(loco::Node *node)
 {
-  assert(loco::shape_known(node));
+  assert(luci::shape_known(node));
   return to_shape_description(luci::shape_get(node));
 }
 

--- a/compiler/luci/service/src/CircleTypeInference.cpp
+++ b/compiler/luci/service/src/CircleTypeInference.cpp
@@ -68,7 +68,7 @@ namespace luci
 
 circle::TensorType TypeInference::get(loco::Node *node)
 {
-  assert(loco::dtype_known(node));
+  assert(luci::dtype_known(node));
   return translateLocoTypeToCircle(luci::dtype_get(node));
 }
 


### PR DESCRIPTION
Parent Issue : #5501

This commit will substitute `loco::shape_known` and `loco::dtype_known` functions to
`luci::shape_known` and `luci::dtype_known` functions.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>