### PR TITLE
[one-cmds] Add missing exit command

### DIFF
--- a/compiler/one-cmds/one-build
+++ b/compiler/one-cmds/one-build
@@ -3,6 +3,7 @@
 ''''export PY_PATH=${SCRIPT_PATH}/venv/bin/python                                       # '''
 ''''test -f ${PY_PATH} && exec ${PY_PATH} "$0" "$@"                                     # '''
 ''''echo "Error: Virtual environment not found. Please run 'one-prepare-venv' command." # '''
+''''exit 255                                                                            # '''
 
 # Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
 #


### PR DESCRIPTION
Parent Issue : #5736

Exit command was missed in `one-build` command.
This commit will add it.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>