### PR TITLE
[DRAFT] Introduce TypeMapper

### DIFF
--- a/compiler/luci/pass/src/helpers/TypeMapper.cpp
+++ b/compiler/luci/pass/src/helpers/TypeMapper.cpp
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "TypeMapper.h"
+
+// NOTE Do NOT delete this file; this file enforces compiler to check whether 'TypeMapper.h' is
+//      complete.

--- a/compiler/luci/pass/src/helpers/TypeMapper.h
+++ b/compiler/luci/pass/src/helpers/TypeMapper.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <loco/IR/DataType.h>
+
+#include <cstdint>
+
+namespace luci
+{
+
+/**
+ * @brief TypeMapper maps between plain type and loco::DataType.
+ */
+template <typename T> struct TypeMapper
+{
+  static constexpr loco::DataType get() { return loco::DataType::Unknown; }
+};
+
+template <> struct TypeMapper<float>
+{
+  static constexpr loco::DataType get() { return loco::DataType::FLOAT32; }
+};
+
+template <> struct TypeMapper<uint8_t>
+{
+  static constexpr loco::DataType get() { return loco::DataType::U8; }
+};
+
+template <> struct TypeMapper<int16_t>
+{
+  static constexpr loco::DataType get() { return loco::DataType::S16; }
+};
+
+template <> struct TypeMapper<int32_t>
+{
+  static constexpr loco::DataType get() { return loco::DataType::S32; }
+};
+
+} // namespace luci

--- a/compiler/luci/pass/src/helpers/TypeMapper.test.cpp
+++ b/compiler/luci/pass/src/helpers/TypeMapper.test.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <luci/IR/CircleNodes.h>
+
+#include <gtest/gtest.h>
+
+#include "TypeMapper.h"
+
+TEST(TypeMapperTest, simple_test)
+{
+  EXPECT_EQ(loco::DataType::FLOAT32, luci::TypeMapper<float>::get());
+  EXPECT_EQ(loco::DataType::U8, luci::TypeMapper<uint8_t>::get());
+  EXPECT_EQ(loco::DataType::S16, luci::TypeMapper<int16_t>::get());
+}
+
+TEST(TypeMapperTest, wrong_condition_NEG)
+{
+  EXPECT_EQ(loco::DataType::Unknown, luci::TypeMapper<double>::get());
+}


### PR DESCRIPTION
This draft is to introduces TypeMapper.

> Sometimes, we need to use switch-case even if we use template because `CircleConst` methods needs explicit loco data type. Maybe this TypeMapper makes it easy to generalize these functions.

Well, on second thought, it needs explicit plain data type:(. 

But, this helpers will be helped when there is a plain type container with `CircleNode` whose dtype is equal to its container. `ResolveCustomOpMatMulPass.cpp` will be good example.

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>