### PR TITLE
[luci] erase luci shape in ConvertNCHWToNHWCPass

### DIFF
--- a/compiler/luci/pass/src/ConvertNCHWToNHWCPass.cpp
+++ b/compiler/luci/pass/src/ConvertNCHWToNHWCPass.cpp
@@ -355,6 +355,7 @@ class ConvertNCHWToNHWC final : public luci::CircleNodeMutableVisitor<bool>
     node->shape_status(luci::ShapeStatus::VALID);
 
     loco::shape_erase(node);
+    node->shape_status(luci::ShapeStatus::UNDEFINED);
 
     // Insert post-tranpose
     auto post_trans = create_post_transpose(node);
@@ -379,6 +380,7 @@ class ConvertNCHWToNHWC final : public luci::CircleNodeMutableVisitor<bool>
     node->from(pre_trans);
 
     loco::shape_erase(node);
+    node->shape_status(luci::ShapeStatus::UNDEFINED);
 
     // Update graph output
     const auto n = node->dim(0).value();
@@ -430,6 +432,7 @@ class ConvertNCHWToNHWC final : public luci::CircleNodeMutableVisitor<bool>
 
     // Make loco do shape inference for this node again.
     loco::shape_erase(node);
+    node->shape_status(luci::ShapeStatus::UNDEFINED);
 
     auto post_trans = create_post_transpose(node);
     loco::replace(node).with(post_trans);
@@ -467,6 +470,7 @@ class ConvertNCHWToNHWC final : public luci::CircleNodeMutableVisitor<bool>
 
     // Make loco do shape inference for this node again.
     loco::shape_erase(node);
+    node->shape_status(luci::ShapeStatus::UNDEFINED);
 
     auto post_trans = create_post_transpose(node);
     loco::replace(node).with(post_trans);
@@ -491,6 +495,7 @@ class ConvertNCHWToNHWC final : public luci::CircleNodeMutableVisitor<bool>
 
     // Make loco do shape inference for this node again.
     loco::shape_erase(node);
+    node->shape_status(luci::ShapeStatus::UNDEFINED);
 
     auto post_trans = create_post_transpose(node);
     loco::replace(node).with(post_trans);
@@ -509,6 +514,7 @@ class ConvertNCHWToNHWC final : public luci::CircleNodeMutableVisitor<bool>
 
     // Do shape inference for this node again.
     loco::shape_erase(node);
+    node->shape_status(luci::ShapeStatus::UNDEFINED);
 
     auto post_trans = create_post_transpose(node);
     loco::replace(node).with(post_trans);

--- a/compiler/luci/pass/src/ConvertNCHWToNHWCPass.cpp
+++ b/compiler/luci/pass/src/ConvertNCHWToNHWCPass.cpp
@@ -354,6 +354,7 @@ class ConvertNCHWToNHWC final : public luci::CircleNodeMutableVisitor<bool>
 
     node->shape_status(luci::ShapeStatus::VALID);
 
+    // TODO Remove loco::shape_erase()
     loco::shape_erase(node);
     node->shape_status(luci::ShapeStatus::UNDEFINED);
 
@@ -379,6 +380,7 @@ class ConvertNCHWToNHWC final : public luci::CircleNodeMutableVisitor<bool>
 
     node->from(pre_trans);
 
+    // TODO Remove loco::shape_erase()
     loco::shape_erase(node);
     node->shape_status(luci::ShapeStatus::UNDEFINED);
 
@@ -431,6 +433,7 @@ class ConvertNCHWToNHWC final : public luci::CircleNodeMutableVisitor<bool>
     }
 
     // Make loco do shape inference for this node again.
+    // TODO Remove loco::shape_erase()
     loco::shape_erase(node);
     node->shape_status(luci::ShapeStatus::UNDEFINED);
 
@@ -469,6 +472,7 @@ class ConvertNCHWToNHWC final : public luci::CircleNodeMutableVisitor<bool>
     }
 
     // Make loco do shape inference for this node again.
+    // TODO Remove loco::shape_erase()
     loco::shape_erase(node);
     node->shape_status(luci::ShapeStatus::UNDEFINED);
 
@@ -494,6 +498,7 @@ class ConvertNCHWToNHWC final : public luci::CircleNodeMutableVisitor<bool>
     node->paddings(nhwc_paddings);
 
     // Make loco do shape inference for this node again.
+    // TODO Remove loco::shape_erase()
     loco::shape_erase(node);
     node->shape_status(luci::ShapeStatus::UNDEFINED);
 
@@ -513,6 +518,7 @@ class ConvertNCHWToNHWC final : public luci::CircleNodeMutableVisitor<bool>
     node->features(pre_trans);
 
     // Do shape inference for this node again.
+    // TODO Remove loco::shape_erase()
     loco::shape_erase(node);
     node->shape_status(luci::ShapeStatus::UNDEFINED);
 


### PR DESCRIPTION
For now, only loco shape was erased for `ConvertNCHWToNHWCPass`.
This commit will erase luci shape too.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>