### PR TITLE
[luci] Fix assert in Concat shape inference rule

### DIFF
--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -549,7 +549,8 @@ loco::NodeShape infer_concatenation(const luci::CircleConcatenation *node)
       if (j == static_cast<uint32_t>(axis))
         output_shape.dim(j) = output_shape.dim(j).value() + input_shape.dim(j).value();
       else
-        assert(output_shape.dim(j) == input_shape.dim(j));
+        assert(!output_shape.dim(j).known() || !input_shape.dim(j).known() ||
+               output_shape.dim(j) == input_shape.dim(j));
     }
   }
 

--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -547,7 +547,12 @@ loco::NodeShape infer_concatenation(const luci::CircleConcatenation *node)
     for (uint32_t j = 0; j < output_shape.rank(); ++j)
     {
       if (j == static_cast<uint32_t>(axis))
+      {
+        // If dimension is unknown, value() will return 0.
+        // This is wrong but until new inference algorithm is implemented,
+        // this code will not be modified to keep compatibility.
         output_shape.dim(j) = output_shape.dim(j).value() + input_shape.dim(j).value();
+      }
       else
         assert(!output_shape.dim(j).known() || !input_shape.dim(j).known() ||
                output_shape.dim(j) == input_shape.dim(j));


### PR DESCRIPTION
If one of dimensions in `axis` are unknown, it can also be accepted.
This commit will fix the assert in shape inference rule of `CircleConcat`.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>