### PR TITLE
[luci] Revise FuseAddWithTConvPass comment

### DIFF
--- a/compiler/luci/pass/src/FuseAddWithTConvPass.cpp
+++ b/compiler/luci/pass/src/FuseAddWithTConvPass.cpp
@@ -21,16 +21,25 @@
 namespace
 {
 /**
- *  Fuse add to TCONV if possible
+ *  Fuse Add to TransposeConv if possible
  *
  *  BEFORE
- *
- *         [CircleTransposeConv]
+ *                     |
+ *   [CircleConst]  [CircleTransposeConv]
+ *               \     |
+ *             [CircleAdd]
  *                  |
- *                [add]
- *  AFTER
  *
- *         [CircleTransposeConv]
+ *  AFTER
+ *                  |
+ *   [CircleConst]  |
+ *             \    |
+ *         [CircleTransposeConv]   [CircleAdd]
+ *                  |
+ *            ([CircleRelu6])
+ *                  |
+ *
+ *  Note: CircleRelu6 is inserted if Add activation is ReLU6
  */
 bool fuse_add_with_tconv(luci::CircleTransposeConv *tconv)
 {


### PR DESCRIPTION
This will revise FuseAddWithTConvPass comment of before-after model
diagram.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>