### PR TITLE
[luci] Revise FuseBatchNormWithConvPass comment

### DIFF
--- a/compiler/luci/pass/src/FuseBatchNormWithConvPass.cpp
+++ b/compiler/luci/pass/src/FuseBatchNormWithConvPass.cpp
@@ -21,18 +21,31 @@
 namespace
 {
 /**
- *  NOTE TF's fusedBatchNorm is converted to mul and add of Circle.
+ *  Fuse Mul-Add to Conv2D if possible.
+ *
+ *  NOTE TF's BatchNormalization is converted to Mul and Add.
  *
  *  BEFORE
+ *                  |   [CircleConst]
+ *                  |  / [CircleConst]
+ *                  | / /
+ *         [CircleConv2D] [CircleConst]
+ *                  |    /
+ *            [CircleMul] [CircleConst]
+ *                  |    /
+ *             [CircleAdd]
+ *                  |
  *
- *            [CircleConv]
- *                  |
- *                [mul]
- *                  |
- *                [add]
  *  AFTER
- *
- *            [CircleConv]
+ *                  |                  [CircleConst]
+ *                  +--------------+  / [CircleConst]
+ *                  |              | / /
+ *                  |     [CircleConv2D] [CircleConst]
+ *  [CircleConst]   |              |    /
+ * [CircleConst] \  |         [CircleMul] [CircleConst]
+ *              \ \ |              |     /
+ *           [CircleConv2D]   [CircleAdd]
+ *                  |
  */
 bool fused_batch_norm_with_conv(luci::CircleAdd *add)
 {


### PR DESCRIPTION
This will revise FuseBatchNormWithConvPass comment of before-after model
diagram.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>