### PR TITLE
[one-cmds] Introduce transform_min_max_to_relu6 option

### DIFF
--- a/compiler/one-cmds/how-to-use-one-commands.txt
+++ b/compiler/one-cmds/how-to-use-one-commands.txt
@@ -181,6 +181,7 @@ Current transformation options are
 - shuffle_weight_to_16x1float32 : This will convert weight format of FullyConnected to SHUFFLED16x1FLOAT32.
   Note that it only converts weights whose row is a multiple of 16.
 - substitute_pack_to_reshape : This will convert single input Pack to Reshape.
+- transform_min_max_to_relu6: This will transform Minimum-Maximum pattern to Relu6 operator.
 
 
 one-quantize

--- a/compiler/one-cmds/one-optimize
+++ b/compiler/one-cmds/one-optimize
@@ -136,6 +136,10 @@ def _get_parser():
         '--substitute_pack_to_reshape',
         action='store_true',
         help='convert single input Pack op to Reshape op')
+    circle2circle_group.add_argument(
+        '--transform_min_max_to_relu6',
+        action='store_true',
+        help='transform Minimum-Maximum pattern to Relu6 op')
 
     return parser
 

--- a/compiler/one-cmds/utils.py
+++ b/compiler/one-cmds/utils.py
@@ -167,6 +167,8 @@ def _make_circle2circle_cmd(args, driver_path, input_path, output_path):
         cmd.append('--shuffle_weight_to_16x1float32')
     if _is_valid_attr(args, 'substitute_pack_to_reshape'):
         cmd.append('--substitute_pack_to_reshape')
+    if _is_valid_attr(args, 'transform_min_max_to_relu6'):
+        cmd.append('--transform_min_max_to_relu6')
 
     return cmd
 


### PR DESCRIPTION
This commit introduces transform_min_max_to_relu6 option to
one-optimize.

Related: #5599
Draft: #5698
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>