### PR TITLE
[circle2circle] Add RemoveUnnecessaryStridedSlicePass to circle2circle

### DIFF
--- a/compiler/circle2circle/src/Circle2Circle.cpp
+++ b/compiler/circle2circle/src/Circle2Circle.cpp
@@ -170,6 +170,12 @@ int entry(int argc, char **argv)
     .default_value(false)
     .help("This will remove unnecessary slice operators");
 
+  arser.add_argument("--remove_unnecessary_strided_slice")
+    .nargs(0)
+    .required(false)
+    .default_value(false)
+    .help("This will remove unnecessary strided slice operators");
+
   arser.add_argument("--remove_unnecessary_split")
     .nargs(0)
     .required(false)
@@ -357,6 +363,8 @@ int entry(int argc, char **argv)
     options->enable(Algorithms::RemoveUnnecessaryReshape);
   if (arser.get<bool>("--remove_unnecessary_slice"))
     options->enable(Algorithms::RemoveUnnecessarySlice);
+  if (arser.get<bool>("--remove_unnecessary_strided_slice"))
+    options->enable(Algorithms::RemoveUnnecessaryStridedSlice);
   if (arser.get<bool>("--remove_unnecessary_split"))
     options->enable(Algorithms::RemoveUnnecessarySplit);
   if (arser.get<bool>("--replace_cw_mul_add_with_depthwise_conv"))


### PR DESCRIPTION
This commit introduce `RemoveUnnecessaryStridedSlicePass` for circle2circle

ONE-DCO-1.0-Signed-off-by: Anton Zhukov <anton.v.zhukov@gmail.com>

Related PR: https://github.com/Samsung/ONE/pull/5721

Draft: https://github.com/Samsung/ONE/pull/5876