### PR TITLE
[luci] Fix FuseBatchNormWithConvPass bias

### DIFF
--- a/compiler/luci/pass/src/FuseBatchNormWithConvPass.cpp
+++ b/compiler/luci/pass/src/FuseBatchNormWithConvPass.cpp
@@ -171,7 +171,7 @@ bool fused_batch_norm_with_conv(luci::CircleAdd *add)
   assert(bias->rank() == 1);
   assert(bias->dim(0).value() == filter_out_channel);
   fused_bias->dtype(bias->dtype());
-  fused_bias->size<loco::DataType::FLOAT32>(filter->size<loco::DataType::FLOAT32>());
+  fused_bias->size<loco::DataType::FLOAT32>(bias->size<loco::DataType::FLOAT32>());
   fused_bias->rank(1);
   fused_bias->dim(0).set(filter_out_channel);
   fused_bias->shape_status(luci::ShapeStatus::VALID);


### PR DESCRIPTION
This will fix FuseBatchNormWithConvPass fused_base size with that of bias.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>