### PR TITLE
[one-cmds] Fix typo in how-to-use-one-commands

### DIFF
--- a/compiler/one-cmds/how-to-use-one-commands.txt
+++ b/compiler/one-cmds/how-to-use-one-commands.txt
@@ -155,8 +155,8 @@ Current transformation options are
 - fold_dequantize : This removes Dequantize operation which can be folded
 - fold_sparse_to_dense : This removes SparseToDense operation which can be folded
 - fuse_add_with_tconv: This fuses Add operator with the preceding TConv operator if possible
-- fuse_batchnorm_wich_conv : This fuses BatchNorm operator to convolution operator
-- fuse_batchnorm_wich_tconv : This fuses BatchNorm operator to transpose convolution operator
+- fuse_batchnorm_with_conv : This fuses BatchNorm operator to convolution operator
+- fuse_batchnorm_with_tconv : This fuses BatchNorm operator to transpose convolution operator
 - fuse_bcq: This enables Binary-Coded-bases Quantized DNNs
    - read https://arxiv.org/abs/2005.09904 for detailed information
 - fuse_instnorm: This will convert instance normalization related operators to


### PR DESCRIPTION
This will fix typo in how-to-use-one-commands.txt file.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>