### PR TITLE
[res] Introduce Net_DwConv_BN_000 and Net_DwConv_BN_001

### DIFF
--- a/res/TensorFlowLiteRecipes/Net_DwConv_BN_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/Net_DwConv_BN_000/test.recipe
@@ -1,0 +1,91 @@
+operand {
+  name: "ifm"
+  type: FLOAT32
+  shape { dim: 1 dim: 64 dim: 64 dim: 8 }
+}
+operand {
+  name: "filter"
+  type: FLOAT32
+  shape { dim: 1 dim: 3 dim: 3 dim: 8 }
+  filler {
+    tag: "gaussian"
+    arg: "0.0"
+    arg: "1.0"
+  }
+}
+operand {
+  name: "bias"
+  type: FLOAT32
+  shape { dim: 8 }
+  filler {
+    tag: "constant"
+    arg: "1.1"
+  }
+}
+operand {
+  name: "scale"
+  type: FLOAT32
+  shape { dim: 8 }
+  filler {
+    tag: "constant"
+    arg: "1.1"
+  }
+}
+operand {
+  name: "shift"
+  type: FLOAT32
+  shape { dim: 8 }
+  filler {
+    tag: "constant"
+    arg: "1.1"
+  }
+}
+operand {
+  name: "dwout"
+  type: FLOAT32
+  shape { dim: 1 dim: 64 dim: 64 dim: 8 }
+}
+operand {
+  name: "mulout"
+  type: FLOAT32
+  shape { dim: 1 dim: 64 dim: 64 dim: 8 }
+}
+operand {
+  name: "ofm"
+  type: FLOAT32
+  shape { dim: 1 dim: 64 dim: 64 dim: 8 }
+}
+operation {
+  type: "DepthwiseConv2D"
+  depthwiseconv2d_options {
+    padding: SAME
+    stride_w: 1
+    stride_h: 1
+    depth_multiplier: 1
+    activation : NONE
+  }
+  input: "ifm"
+  input: "filter"
+  input: "bias"
+  output: "dwout"
+}
+operation {
+  type: "Mul"
+  input: "dwout"
+  input: "scale"
+  output: "mulout"
+  mul_options {
+    activation: NONE
+  }
+}
+operation {
+  type: "Add"
+  input: "mulout"
+  input: "shift"
+  output: "ofm"
+  add_options {
+    activation: RELU6
+  }
+}
+input: "ifm"
+output: "ofm"

--- a/res/TensorFlowLiteRecipes/Net_DwConv_BN_000/test.rule
+++ b/res/TensorFlowLiteRecipes/Net_DwConv_BN_000/test.rule
@@ -1,0 +1,7 @@
+# To check if BatchNorm op(mul + add) is fused to Depthwise Convolution op
+
+RULE    "VERIFY_FILE_FORMAT"      $(verify_file_format) '=' 1
+
+RULE    "DWCONV_EXIST"            $(op_count DEPTHWISE_CONV_2D) '=' 1
+RULE    "NO_MUL"                  $(op_count MUL) '=' 0
+RULE    "NO_ADD"                  $(op_count ADD) '=' 0

--- a/res/TensorFlowLiteRecipes/Net_DwConv_BN_001/test.recipe
+++ b/res/TensorFlowLiteRecipes/Net_DwConv_BN_001/test.recipe
@@ -1,0 +1,91 @@
+operand {
+  name: "ifm"
+  type: FLOAT32
+  shape { dim: 1 dim: 64 dim: 64 dim: 8 }
+}
+operand {
+  name: "filter"
+  type: FLOAT32
+  shape { dim: 1 dim: 3 dim: 3 dim: 8 }
+  filler {
+    tag: "gaussian"
+    arg: "0.0"
+    arg: "1.0"
+  }
+}
+operand {
+  name: "bias"
+  type: FLOAT32
+  shape { dim: 8 }
+  filler {
+    tag: "constant"
+    arg: "1.1"
+  }
+}
+operand {
+  name: "scale"
+  type: FLOAT32
+  shape { dim: 1 dim: 1 dim: 1 dim: 8 }
+  filler {
+    tag: "constant"
+    arg: "1.1"
+  }
+}
+operand {
+  name: "shift"
+  type: FLOAT32
+  shape { dim: 1 dim: 1 dim: 1 dim: 8 }
+  filler {
+    tag: "constant"
+    arg: "1.1"
+  }
+}
+operand {
+  name: "dwout"
+  type: FLOAT32
+  shape { dim: 1 dim: 64 dim: 64 dim: 8 }
+}
+operand {
+  name: "mulout"
+  type: FLOAT32
+  shape { dim: 1 dim: 64 dim: 64 dim: 8 }
+}
+operand {
+  name: "ofm"
+  type: FLOAT32
+  shape { dim: 1 dim: 64 dim: 64 dim: 8 }
+}
+operation {
+  type: "DepthwiseConv2D"
+  depthwiseconv2d_options {
+    padding: SAME
+    stride_w: 1
+    stride_h: 1
+    depth_multiplier: 1
+    activation : NONE
+  }
+  input: "ifm"
+  input: "filter"
+  input: "bias"
+  output: "dwout"
+}
+operation {
+  type: "Mul"
+  input: "dwout"
+  input: "scale"
+  output: "mulout"
+  mul_options {
+    activation: NONE
+  }
+}
+operation {
+  type: "Add"
+  input: "mulout"
+  input: "shift"
+  output: "ofm"
+  add_options {
+    activation: RELU6
+  }
+}
+input: "ifm"
+output: "ofm"

--- a/res/TensorFlowLiteRecipes/Net_DwConv_BN_001/test.rule
+++ b/res/TensorFlowLiteRecipes/Net_DwConv_BN_001/test.rule
@@ -1,0 +1,7 @@
+# To check if BatchNorm op(mul + add) is fused to Depthwise Convolution op
+
+RULE    "VERIFY_FILE_FORMAT"      $(verify_file_format) '=' 1
+
+RULE    "DWCONV_EXIST"            $(op_count DEPTHWISE_CONV_2D) '=' 1
+RULE    "NO_MUL"                  $(op_count MUL) '=' 0
+RULE    "NO_ADD"                  $(op_count ADD) '=' 0


### PR DESCRIPTION
This will introduce TensorFlowLiteRecipes for small network of
DepthwiseConv2D + Mul + Add sequence.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>