### PR TITLE
[one-cmds] Enable fuse_batchnorm_with_dwconv option

### DIFF
--- a/compiler/one-cmds/how-to-use-one-commands.txt
+++ b/compiler/one-cmds/how-to-use-one-commands.txt
@@ -156,6 +156,7 @@ Current transformation options are
 - fold_sparse_to_dense : This removes SparseToDense operation which can be folded
 - fuse_add_with_tconv: This fuses Add operator with the preceding TConv operator if possible
 - fuse_batchnorm_with_conv : This fuses BatchNorm operator to convolution operator
+- fuse_batchnorm_with_dwconv : This fuses BatchNorm operator to depthwise convolution operator
 - fuse_batchnorm_with_tconv : This fuses BatchNorm operator to transpose convolution operator
 - fuse_bcq: This enables Binary-Coded-bases Quantized DNNs
    - read https://arxiv.org/abs/2005.09904 for detailed information

--- a/compiler/one-cmds/one-optimize
+++ b/compiler/one-cmds/one-optimize
@@ -74,6 +74,10 @@ def _get_parser():
         action='store_true',
         help='fuse BatchNorm op to Convolution op')
     circle2circle_group.add_argument(
+        '--fuse_batchnorm_with_dwconv',
+        action='store_true',
+        help='fuse BatchNorm op to Depthwise Convolution op')
+    circle2circle_group.add_argument(
         '--fuse_batchnorm_with_tconv',
         action='store_true',
         help='fuse BatchNorm op to Transposed Convolution op')

--- a/compiler/one-cmds/utils.py
+++ b/compiler/one-cmds/utils.py
@@ -135,6 +135,8 @@ def _make_circle2circle_cmd(args, driver_path, input_path, output_path):
         cmd.append('--fuse_add_with_tconv')
     if _is_valid_attr(args, 'fuse_batchnorm_with_conv'):
         cmd.append('--fuse_batchnorm_with_conv')
+    if _is_valid_attr(args, 'fuse_batchnorm_with_dwconv'):
+        cmd.append('--fuse_batchnorm_with_dwconv')
     if _is_valid_attr(args, 'fuse_batchnorm_with_tconv'):
         cmd.append('--fuse_batchnorm_with_tconv')
     if _is_valid_attr(args, 'fuse_bcq'):


### PR DESCRIPTION
This will enable to use fuse_batchnorm_with_dwconv in one-cmds.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>