### PR TITLE
[Tensorflow/Recipes] Add Net_Remove_Redundant_Reshape recipe

### DIFF
--- a/res/TensorFlowLiteRecipes/Net_Remove_Redundant_Reshape_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/Net_Remove_Redundant_Reshape_000/test.recipe
@@ -31,7 +31,6 @@ operation {
   input: "shape1"
   output: "reshape_out"
 }
-
 operation {
   type: "Reshape"
   input: "reshape_out"

--- a/res/TensorFlowLiteRecipes/Net_Remove_Redundant_Reshape_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/Net_Remove_Redundant_Reshape_000/test.recipe
@@ -1,0 +1,43 @@
+operand {
+  name: "ifm"
+  type: FLOAT32
+  shape { dim: 2 dim: 3 dim: 6}
+}
+operand {
+  name: "shape1"
+  type: INT32
+  shape { dim: 2 }
+  filler { tag: "explicit" arg: "6" arg: "6" }
+}
+operand {
+  name: "shape2"
+  type: INT32
+  shape { dim: 3 }
+  filler { tag: "explicit" arg: "6" arg: "2"  arg: "3" }
+}
+operand {
+  name: "reshape_out"
+  type: FLOAT32
+  shape { dim: 6 dim: 6 }
+}
+operand {
+  name: "ofm"
+  type: FLOAT32
+  shape { dim: 6 dim: 2 dim: 3 }
+}
+operation {
+  type: "Reshape"
+  input: "ifm"
+  input: "shape1"
+  output: "reshape_out"
+}
+
+operation {
+  type: "Reshape"
+  input: "reshape_out"
+  input: "shape2"
+  output: "ofm"
+}
+
+input: "ifm"
+output: "ofm"

--- a/res/TensorFlowLiteRecipes/Net_Remove_Redundant_Reshape_000/test.rule
+++ b/res/TensorFlowLiteRecipes/Net_Remove_Redundant_Reshape_000/test.rule
@@ -1,0 +1,5 @@
+# To check if Redundant Reshape removed.
+
+RULE    "VERIFY_FILE_FORMAT"      $(verify_file_format) '=' 1
+
+RULE    "RESHAPE_EXIST"             $(op_count RESHAPE) '=' 1


### PR DESCRIPTION
For #5266 

This commit add `Net_Remove_Redundant_Reshape` on TensorflowLiteRecipes.

ONE-DCO-1.0-Signed-off-by: KiDeuk Bang <rrstrous@nate.com>