### PR TITLE
[circle2circle] Add option for RemoveRedundantReshape

### DIFF
--- a/compiler/circle2circle/src/Circle2Circle.cpp
+++ b/compiler/circle2circle/src/Circle2Circle.cpp
@@ -140,6 +140,12 @@ int entry(int argc, char **argv)
     .default_value(false)
     .help("This will fuse BatchNorm operators of pre-activations to Convolution operator");
 
+  arser.add_argument("--remove_redundant_reshape")
+    .nargs(0)
+    .required(false)
+    .default_value(false)
+    .help("This will fuse or remove subsequent Reshape operators");
+
   arser.add_argument("--remove_redundant_transpose")
     .nargs(0)
     .required(false)
@@ -323,6 +329,8 @@ int entry(int argc, char **argv)
     options->enable(Algorithms::MakeBatchNormGammaPositive);
   if (arser.get<bool>("--fuse_preactivation_batchnorm"))
     options->enable(Algorithms::FusePreActivationBatchNorm);
+  if (arser.get<bool>("--remove_redundant_reshape"))
+    options->enable(Algorithms::RemoveRedundantReshape);
   if (arser.get<bool>("--remove_redundant_transpose"))
     options->enable(Algorithms::RemoveRedundantTranspose);
   if (arser.get<bool>("--remove_unnecessary_reshape"))


### PR DESCRIPTION
For #5266 

This commit will add `--remove_redundant_reshape` on circle2circle.

ONE-DCO-1.0-Signed-off-by: KiDeuk Bang <rrstrous@nate.com>