### PR TITLE
[luci] Remove clang-format off

### DIFF
--- a/compiler/luci/pass/src/CircleShapeInferencePass.cpp
+++ b/compiler/luci/pass/src/CircleShapeInferencePass.cpp
@@ -68,25 +68,22 @@ bool CircleShapeInferencePass::run(loco::Graph *g)
   luci::sinf::Rule shape_infer_rule;
   bool changed = false;
 
-  // TODO Remove clang-format off
-  // clang-format off
   for (auto node : inference_candidates(g))
+  {
+    loco::TensorShape shape;
+    auto circle_node = loco::must_cast<luci::CircleNode *>(node);
+
+    if (shape_infer_rule.infer(circle_node, shape) && !is_same_shape(circle_node, shape))
     {
-      loco::TensorShape shape;
-      auto circle_node = loco::must_cast<luci::CircleNode *>(node);
+      circle_node->rank(shape.rank());
+      for (uint32_t i = 0; i < shape.rank(); ++i)
+        circle_node->dim(i) = shape.dim(i);
 
-      if (shape_infer_rule.infer(circle_node, shape) && !is_same_shape(circle_node, shape))
-      {
-        circle_node->rank(shape.rank());
-        for (uint32_t i = 0; i < shape.rank(); ++i)
-          circle_node->dim(i) = shape.dim(i);
+      circle_node->shape_status(luci::ShapeStatus::VALID);
 
-        circle_node->shape_status(luci::ShapeStatus::VALID);
-
-        changed = true;
-      }
+      changed = true;
     }
-  // clang-format on
+  }
 
   return changed;
 }

--- a/compiler/luci/pass/src/CircleTypeInferencePass.cpp
+++ b/compiler/luci/pass/src/CircleTypeInferencePass.cpp
@@ -43,20 +43,17 @@ bool CircleTypeInferencePass::run(loco::Graph *g)
   luci::tinf::Rule type_infer_rule;
   bool changed = false;
 
-  // TODO Remove clang-format off
-  // clang-format off
   for (auto node : inference_candidates(g))
-    {
-      loco::DataType dtype;
-      auto circle_node = loco::must_cast<luci::CircleNode *>(node);
+  {
+    loco::DataType dtype;
+    auto circle_node = loco::must_cast<luci::CircleNode *>(node);
 
-      if (type_infer_rule.infer(circle_node, dtype) && circle_node->dtype() != dtype)
-      {
-        circle_node->dtype(dtype);
-        changed = true;
-      }
+    if (type_infer_rule.infer(circle_node, dtype) && circle_node->dtype() != dtype)
+    {
+      circle_node->dtype(dtype);
+      changed = true;
     }
-  // clang-format on
+  }
 
   return changed;
 }


### PR DESCRIPTION
`clang-format off` are used to make PR review easier and no more used.
This commit will remove temporary `clang-format off`.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>