### PR TITLE
[luci-pass-value-test] Enable Net_InstanceNorm_002

### DIFF
--- a/compiler/luci-pass-value-test/test.lst
+++ b/compiler/luci-pass-value-test/test.lst
@@ -18,5 +18,5 @@ addeval(Net_TConv_Add_002 fuse_add_with_tconv)
 addeval(Net_TConv_BN_000 fuse_batchnorm_with_tconv)
 addeval(Net_TConv_BN_001 fuse_batchnorm_with_tconv)
 addeval(Net_InstanceNorm_001 fuse_instnorm)
-# addeval(Net_InstanceNorm_002 fuse_instnorm) : core dumped
+addeval(Net_InstanceNorm_002 fuse_instnorm)
 addeval(Net_InstanceNorm_003 fuse_instnorm)


### PR DESCRIPTION
This will enable Net_InstanceNorm_002 test that is now working.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>