### PR TITLE
[luci] Revise ReplaceMulAddWithDepthwiseConvPass

### DIFF
--- a/compiler/luci/pass/src/ReplaceMulAddWithDepthwiseConvPass.cpp
+++ b/compiler/luci/pass/src/ReplaceMulAddWithDepthwiseConvPass.cpp
@@ -206,14 +206,10 @@ bool ReplaceMulAddWithDepthwiseConvPass::run(loco::Graph *g)
   bool changed = false;
   for (auto node : loco::active_nodes(loco::output_nodes(g)))
   {
-    auto add = dynamic_cast<luci::CircleAdd *>(node);
-    if (not add)
-      continue;
-
-    if (replace_mul_add_with_dwconv(add))
+    if (auto add = dynamic_cast<luci::CircleAdd *>(node))
     {
-      changed = true;
-      break;
+      if (replace_mul_add_with_dwconv(add))
+        changed = true;
     }
   }
 


### PR DESCRIPTION
Parent Issue : #5777

Current `ReplaceMulAddWithDepthwiseConvPass` is ended right after the pass is applied to only one node.
As a result, if there are a lot of nodes to apply this pass, much time is needed.
To make this pass faster, this commit will revise not to break even the pass is applied for a node.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>