### PR TITLE
[luci] Revise PropagateQuantParamPass

### DIFF
--- a/compiler/luci/pass/src/PropagateQuantParamPass.cpp
+++ b/compiler/luci/pass/src/PropagateQuantParamPass.cpp
@@ -91,9 +91,8 @@ bool PropagateQuantParamPass::run(loco::Graph *g)
     INFO(l) << "PropagateQuantParamPass visit node: " << circle_node->name() << std::endl;
 
     PropagateQuantParam pqp;
-    changed = circle_node->accept(&pqp);
-    if (changed)
-      break;
+    if (circle_node->accept(&pqp))
+      changed = true;
   }
 
   return changed;


### PR DESCRIPTION
Parent issue : #5777 

Current `PropagateQuantParamPass` is ended right after the pass is applied to only one node.
If there are a lot of nodes to apply this pass, much time is needed.
To make this pass faster, this commit will revise not to break even the pass is applied for a node.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>