### PR TITLE
[luci] Update status after ShuffleWeightTo16x1Float32Pass is ended

### DIFF
--- a/compiler/luci/pass/src/ShuffleWeightTo16x1Float32Pass.cpp
+++ b/compiler/luci/pass/src/ShuffleWeightTo16x1Float32Pass.cpp
@@ -131,6 +131,8 @@ bool ShuffleWeightTo16x1Float32Pass::run(loco::Graph *g)
       fc->weights(new_weights);
       fc->weights_format(luci::CircleFullyConnected::WeightsFormat::SHUFFLED16x1FLOAT32);
     }
+
+    changed = true;
   }
 
   return changed;


### PR DESCRIPTION
Until now, `changed` variable was not updated even after the pass is applied.
This commit will update the `changed` variable.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>