### PR TITLE
[luci] Revise ConvertNCHWToNHWCPass

### DIFF
--- a/compiler/luci/pass/src/ConvertNCHWToNHWCPass.cpp
+++ b/compiler/luci/pass/src/ConvertNCHWToNHWCPass.cpp
@@ -604,7 +604,6 @@ bool ConvertNCHWToNHWCPass::run(loco::Graph *g)
       {
         set_data_format(node, DataFormat::NHWC);
         changed = true;
-        break;
       }
       else
       {


### PR DESCRIPTION
Parent Issue : #5777

Current `ConvertNCHWToNHWCPass` is ended right after the pass is applied to only one node.
If there are a lot of nodes to apply this pass, much time is needed.
To make this pass faster, this commit will revise not to break even the pass is applied for a node.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>