### PR TITLE
[luci-pass-value-test] Revise comment

### DIFF
--- a/compiler/luci-pass-value-test/test.lst
+++ b/compiler/luci-pass-value-test/test.lst
@@ -5,7 +5,8 @@
 # PASS: Optimization Pass to test. Supports only one Pass for now.
 #
 
-# addeval(Net_Preactivation_BN_000 fuse_preactivation_batchnorm) : Segmentation fault
+# addeval(Net_Preactivation_BN_000 fuse_preactivation_batchnorm) : value diff exist
+# --> https://github.com/Samsung/ONE/issues/5782
 addeval(Net_Conv_Add_Mul_000 fuse_batchnorm_with_conv)
 addeval(Net_Conv_Add_Mul_000 fuse_batchnorm_with_conv)
 addeval(Net_Conv_Add_Mul_001 fuse_batchnorm_with_conv)


### PR DESCRIPTION
This will revise comment for Net_Preactivation_BN_000 model using fuse_preactivation_batchnorm
as segmentation fault is fixed but there exist value difference for this Pass.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>