### PR TITLE
[luci] Revise SubstitutePackToReshapePass diagram

### DIFF
--- a/compiler/luci/pass/src/SubstitutePackToReshapePass.cpp
+++ b/compiler/luci/pass/src/SubstitutePackToReshapePass.cpp
@@ -84,24 +84,23 @@ namespace luci
 {
 
 /**
- *   BEFORE
- *      |
- * [CircleNode]
- *      |
- * [CirclePack]
- *      |
- * [CircleNode]
- *      |
+ * BEFORE
+ *           |
+ *      [CircleNode]
+ *           |
+ *      [CirclePack]
+ *           |
+ *      [CircleNode]
+ *           |
  *
- *    AFTER
- *      |
- * [CircleNode]  [CircleConst]
- *       \             /
- *       [CircleReshape]
+ * AFTER
  *             |
- *        [CircleNode]
- *             |
- *
+ *        [CircleNode]  [CircleConst]
+ *           |   \             /
+ *  [CirclePack] [CircleReshape]
+ *                      |
+ *                 [CircleNode]
+ *                      |
  */
 bool SubstitutePackToReshapePass::run(loco::Graph *g)
 {

--- a/compiler/luci/pass/src/SubstitutePackToReshapePass.test.cpp
+++ b/compiler/luci/pass/src/SubstitutePackToReshapePass.test.cpp
@@ -22,26 +22,6 @@
 namespace
 {
 
-/**
- *           BEFORE
- *             |
- *        [CircleNode]
- *             |
- *        [CirclePack]
- *             |
- *        [CircleNode]
- *             |
- *
- *           AFTER
- *      |
- * [CircleNode]  [CircleConst]
- *       \             /
- *       [CircleReshape]
- *             |
- *        [CircleNode]
- *             |
- *
- */
 void create_substitute_pack_to_reshape(loco::Graph *g, const std::initializer_list<uint32_t> shape,
                                        int32_t axis)
 {


### PR DESCRIPTION
This will revise SubstitutePackToReshapePass diagram indentation and
remove same diagram in test source.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>