### PR TITLE
[luci] Introduce SubstituteSqueezeToReshapePass

### DIFF
--- a/compiler/luci/pass/include/luci/CircleOptimizer.h
+++ b/compiler/luci/pass/include/luci/CircleOptimizer.h
@@ -58,6 +58,7 @@ public:
       RemoveRedundantTranspose,
       ReplaceMulAddWithDepthwiseConv,
       SubstitutePackToReshape,
+      SubstituteSqueezeToReshape,
       ConvertNCHWToNHWC,
       RemoveUnnecessarySlice,
       RemoveUnnecessarySplit,

--- a/compiler/luci/pass/include/luci/Pass/SubstituteSqueezeToReshapePass.h
+++ b/compiler/luci/pass/include/luci/Pass/SubstituteSqueezeToReshapePass.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __LUCI_SUBSTITUTE_SQUEEZE_TO_RESHAPE_PASS_H__
+#define __LUCI_SUBSTITUTE_SQUEEZE_TO_RESHAPE_PASS_H__
+
+#include <logo/Pass.h>
+
+namespace luci
+{
+
+/**
+ * @brief  Class to Substitute Squeeze to Reshape node for certain conditions.
+ */
+struct SubstituteSqueezeToReshapePass final : public logo::Pass
+{
+  const char *name(void) const final { return "luci::SubstituteSqueezeToReshapePass"; }
+
+  bool run(loco::Graph *g) final;
+};
+
+} // namespace luci
+
+#endif // __LUCI_SUBSTITUTE_SQUEEZE_TO_RESHAPE_PASS_H__

--- a/compiler/luci/pass/src/CircleOptimizer.cpp
+++ b/compiler/luci/pass/src/CircleOptimizer.cpp
@@ -46,6 +46,7 @@
 #include "luci/Pass/SparsifyTensorPass.h"
 #include "luci/Pass/ShuffleWeightTo16x1Float32Pass.h"
 #include "luci/Pass/SubstitutePackToReshapePass.h"
+#include "luci/Pass/SubstituteSqueezeToReshapePass.h"
 #include "luci/Pass/SubstituteTransposeToReshapePass.h"
 #include "luci/Pass/TransformMinMaxToRelu6Pass.h"
 // TODO add more passes
@@ -269,6 +270,10 @@ void CircleOptimizer::optimize(loco::Graph *g) const
   if (_options->query(Options::Algorithm::SubstitutePackToReshape))
   {
     phase.emplace_back(std::make_unique<luci::SubstitutePackToReshapePass>());
+  }
+  if (_options->query(Options::Algorithm::SubstituteSqueezeToReshape))
+  {
+    phase.emplace_back(std::make_unique<luci::SubstituteSqueezeToReshapePass>());
   }
   if (_options->query(Options::Algorithm::SubstituteTransposeToReshape))
   {

--- a/compiler/luci/pass/src/SubstituteSqueezeToReshapePass.cpp
+++ b/compiler/luci/pass/src/SubstituteSqueezeToReshapePass.cpp
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Pass/SubstituteSqueezeToReshapePass.h"
+
+#include <luci/IR/CircleNodes.h>
+
+namespace
+{
+
+/**
+ * @brief return TRUE if all dim is known && dim > 0
+ */
+bool can_squeeze_shape(const luci::CircleNode *node)
+{
+  for (uint32_t r = 0; r < node->rank(); ++r)
+  {
+    if (not node->dim(r).known())
+      return false;
+    if (node->dim(r).value() < 1)
+      return false;
+  }
+  return true;
+}
+
+/**
+ * @brief return valid unsigned dim value from 0 ~ rank
+ * @note  dim can be -rank to rank
+ */
+uint32_t valid_unsigned_dim(uint32_t rank, int32_t dim)
+{
+  int32_t irank = static_cast<int32_t>(rank);
+  return dim >= 0 ? static_cast<uint32_t>(dim) : static_cast<uint32_t>(irank + dim);
+}
+
+/**
+ * @brief return TRUE if input dim is 1 for squeeze_dims values
+ */
+bool is_valid_input(const luci::CircleNode *node, const std::vector<int32_t> &squeeze_dims)
+{
+  auto rank = node->rank();
+  for (auto dim : squeeze_dims)
+  {
+    auto udim = valid_unsigned_dim(rank, dim);
+    if (node->dim(udim).value() != 1)
+      return false;
+  }
+  return true;
+}
+
+/**
+ * @brief return shape vector from input
+ */
+std::vector<uint32_t> node_shape(const luci::CircleNode *input)
+{
+  std::vector<uint32_t> shape;
+  uint32_t rank = input->rank();
+  for (uint32_t r = 0; r < rank; ++r)
+    shape.push_back(input->dim(r).value());
+
+  return shape;
+}
+
+/**
+ * @brief return CircleConst ptr with values of new_shape
+ */
+luci::CircleConst *create_shape_const(loco::Graph *graph, const std::vector<uint32_t> &new_shape)
+{
+  uint32_t dim_size = static_cast<uint32_t>(new_shape.size());
+
+  auto shape_const = graph->nodes()->create<luci::CircleConst>();
+
+  // const shape/dtype
+  shape_const->dtype(loco::DataType::S32);
+  shape_const->shape({dim_size});
+  shape_const->shape_status(luci::ShapeStatus::VALID);
+
+  // constant values
+  shape_const->size<loco::DataType::S32>(dim_size);
+  for (uint32_t i = 0; i < new_shape.size(); ++i)
+    shape_const->at<loco::DataType::S32>(i) = new_shape.at(i);
+
+  return shape_const;
+}
+
+bool substitute_squeeze_to_reshape(luci::CircleSqueeze *squeeze)
+{
+  assert(squeeze != nullptr);
+
+  auto input = loco::must_cast<luci::CircleNode *>(squeeze->input());
+  // we need input node shape and all dim should be known
+  if (input->shape_status() != luci::ShapeStatus::VALID)
+    return false;
+  if (not can_squeeze_shape(input))
+    return false;
+
+  // we will use squeeze shape for new shape
+  if (squeeze->shape_status() != luci::ShapeStatus::VALID)
+    return false;
+
+  auto squeeze_dims = squeeze->squeeze_dims();
+  if (not is_valid_input(input, squeeze_dims))
+    return false;
+
+  auto new_shape = node_shape(squeeze);
+  auto graph = squeeze->graph();
+  auto reshape = graph->nodes()->create<luci::CircleReshape>();
+  auto shape_const = create_shape_const(graph, new_shape);
+
+  // graph connection
+  reshape->tensor(input);
+  reshape->shape(shape_const);
+  replace(squeeze).with(reshape);
+
+  return true;
+}
+
+} // namespace
+
+namespace luci
+{
+
+/**
+ * BEFORE
+ *           |
+ *      [CircleNode]
+ *           |
+ *    [CircleSqueeze]
+ *           |
+ *      [CircleNode]
+ *           |
+ *
+ * AFTER
+ *               |
+ *          [CircleNode]  [CircleConst]
+ *             |    \             /
+ *  [CircleSqueeze] [CircleReshape]
+ *                        |
+ *                   [CircleNode]
+ *                        |
+ */
+bool SubstituteSqueezeToReshapePass::run(loco::Graph *g)
+{
+  bool changed = false;
+  for (auto node : loco::active_nodes(loco::output_nodes(g)))
+  {
+    if (auto squeeze = dynamic_cast<luci::CircleSqueeze *>(node))
+    {
+      if (substitute_squeeze_to_reshape(squeeze))
+        changed = true;
+    }
+  }
+  return changed;
+}
+
+} // namespace luci

--- a/compiler/luci/pass/src/SubstituteSqueezeToReshapePass.cpp
+++ b/compiler/luci/pass/src/SubstituteSqueezeToReshapePass.cpp
@@ -120,12 +120,12 @@ bool substitute_squeeze_to_reshape(luci::CircleSqueeze *squeeze)
 
   auto squeeze_dims = squeeze->squeeze_dims();
   if (not is_valid_input(input, squeeze_dims))
-    return false;
+    throw std::runtime_error("Invalid values in squeeze_dims: " + squeeze->name());
 
-  auto new_shape = node_shape(squeeze);
+  auto reshape_shape = node_shape(squeeze);
   auto graph = squeeze->graph();
   auto reshape = graph->nodes()->create<luci::CircleReshape>();
-  auto shape_const = create_shape_const(graph, new_shape);
+  auto shape_const = create_shape_const(graph, reshape_shape);
 
   // graph connection
   reshape->tensor(input);

--- a/compiler/luci/pass/src/SubstituteSqueezeToReshapePass.cpp
+++ b/compiler/luci/pass/src/SubstituteSqueezeToReshapePass.cpp
@@ -22,15 +22,13 @@ namespace
 {
 
 /**
- * @brief return TRUE if all dim is known && dim > 0
+ * @brief return TRUE if all dim is known
  */
 bool can_squeeze_shape(const luci::CircleNode *node)
 {
   for (uint32_t r = 0; r < node->rank(); ++r)
   {
     if (not node->dim(r).known())
-      return false;
-    if (node->dim(r).value() < 1)
       return false;
   }
   return true;

--- a/compiler/luci/pass/src/SubstituteSqueezeToReshapePass.cpp
+++ b/compiler/luci/pass/src/SubstituteSqueezeToReshapePass.cpp
@@ -23,6 +23,8 @@ namespace
 
 /**
  * @brief return TRUE if all dim is known
+ * @note This pass can be applied even some of dimensions are unknown.
+         For now, do not consider about it and update logic later.
  */
 bool can_squeeze_shape(const luci::CircleNode *node)
 {

--- a/compiler/luci/pass/src/SubstituteSqueezeToReshapePass.test.cpp
+++ b/compiler/luci/pass/src/SubstituteSqueezeToReshapePass.test.cpp
@@ -161,6 +161,18 @@ TEST_F(SubstituteSqueezeToReshapeTest, nothing_to_squeeze)
   ASSERT_EQ(nullptr, squeeze);
 }
 
+TEST_F(SubstituteSqueezeToReshapeTest, all_to_squeeze)
+{
+  _graph.init({1, 1}, {}, {});
+
+  run_pass();
+
+  auto reshape = dynamic_cast<luci::CircleReshape *>(_graph.output()->from());
+  auto squeeze = dynamic_cast<luci::CircleSqueeze *>(_graph.output()->from());
+  ASSERT_NE(nullptr, reshape);
+  ASSERT_EQ(nullptr, squeeze);
+}
+
 TEST_F(SubstituteSqueezeToReshapeTest, wrong_squeeze_dims_NEG)
 {
   _graph.init({1, 16, 1, 1}, {1, 16, 1, 1}, {1});

--- a/compiler/luci/pass/src/SubstituteSqueezeToReshapePass.test.cpp
+++ b/compiler/luci/pass/src/SubstituteSqueezeToReshapePass.test.cpp
@@ -128,10 +128,10 @@ TEST_F(SubstituteSqueezeToReshapeTest, simple_with_squeeze_dims)
   auto squeeze = dynamic_cast<luci::CircleSqueeze *>(_graph.output()->from());
   ASSERT_NE(nullptr, reshape);
   ASSERT_EQ(nullptr, squeeze);
-  auto new_shape = loco::must_cast<luci::CircleConst *>(reshape->shape());
-  ASSERT_EQ(2, new_shape->size<loco::DataType::S32>());
-  ASSERT_EQ(1, new_shape->at<loco::DataType::S32>(0));
-  ASSERT_EQ(16, new_shape->at<loco::DataType::S32>(1));
+  auto reshape_shape = loco::must_cast<luci::CircleConst *>(reshape->shape());
+  ASSERT_EQ(2, reshape_shape->size<loco::DataType::S32>());
+  ASSERT_EQ(1, reshape_shape->at<loco::DataType::S32>(0));
+  ASSERT_EQ(16, reshape_shape->at<loco::DataType::S32>(1));
 }
 
 TEST_F(SubstituteSqueezeToReshapeTest, simple_without_squeeze_dims)
@@ -144,9 +144,25 @@ TEST_F(SubstituteSqueezeToReshapeTest, simple_without_squeeze_dims)
   auto squeeze = dynamic_cast<luci::CircleSqueeze *>(_graph.output()->from());
   ASSERT_NE(nullptr, reshape);
   ASSERT_EQ(nullptr, squeeze);
-  auto new_shape = loco::must_cast<luci::CircleConst *>(reshape->shape());
-  ASSERT_EQ(1, new_shape->size<loco::DataType::S32>());
-  ASSERT_EQ(16, new_shape->at<loco::DataType::S32>(0));
+  auto reshape_shape = loco::must_cast<luci::CircleConst *>(reshape->shape());
+  ASSERT_EQ(1, reshape_shape->size<loco::DataType::S32>());
+  ASSERT_EQ(16, reshape_shape->at<loco::DataType::S32>(0));
+}
+
+TEST_F(SubstituteSqueezeToReshapeTest, input_with_0_dims)
+{
+  _graph.init({1, 16, 0, 1}, {16, 0}, {});
+
+  run_pass();
+
+  auto reshape = dynamic_cast<luci::CircleReshape *>(_graph.output()->from());
+  auto squeeze = dynamic_cast<luci::CircleSqueeze *>(_graph.output()->from());
+  ASSERT_NE(nullptr, reshape);
+  ASSERT_EQ(nullptr, squeeze);
+  auto reshape_shape = loco::must_cast<luci::CircleConst *>(reshape->shape());
+  ASSERT_EQ(2, reshape_shape->size<loco::DataType::S32>());
+  ASSERT_EQ(16, reshape_shape->at<loco::DataType::S32>(0));
+  ASSERT_EQ(0, reshape_shape->at<loco::DataType::S32>(1));
 }
 
 TEST_F(SubstituteSqueezeToReshapeTest, nothing_to_squeeze)

--- a/compiler/luci/pass/src/SubstituteSqueezeToReshapePass.test.cpp
+++ b/compiler/luci/pass/src/SubstituteSqueezeToReshapePass.test.cpp
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "luci/Pass/SubstituteSqueezeToReshapePass.h"
+#include "luci/Pass/CircleShapeInferencePass.h"
+
+#include <luci/IR/CircleNodes.h>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+
+using uilist = std::initializer_list<uint32_t>;
+using ilist = std::initializer_list<int32_t>;
+
+class PassTestGraph
+{
+public:
+  PassTestGraph() = default;
+
+public:
+  void init(const uilist shape_in, const uilist shape_out)
+  {
+    _graph_input = _g.inputs()->create();
+    _graph_output = _g.outputs()->create();
+
+    _input = _g.nodes()->create<luci::CircleInput>();
+    _input->shape(shape_in);
+    _input->shape_status(luci::ShapeStatus::VALID);
+
+    _output = _g.nodes()->create<luci::CircleOutput>();
+    _output->shape(shape_out);
+    _output->shape_status(luci::ShapeStatus::VALID);
+
+    _input->index(_graph_input->index());
+    _output->index(_graph_output->index());
+
+    auto input_shape = std::make_unique<loco::TensorShape>();
+    set(input_shape.get(), shape_in);
+    _graph_input->shape(std::move(input_shape));
+
+    auto output_shape = std::make_unique<loco::TensorShape>();
+    set(output_shape.get(), shape_out);
+    _graph_output->shape(std::move(output_shape));
+  }
+
+protected:
+  void set(loco::TensorShape *shape, const uilist &values)
+  {
+    uint32_t r = 0;
+    shape->rank(values.size());
+    for (auto v : values)
+      shape->dim(r++).set(v);
+  }
+
+public:
+  loco::Graph *g(void) { return &_g; }
+  luci::CircleOutput *output(void) { return _output; }
+
+protected:
+  loco::Graph _g;
+  loco::GraphInput *_graph_input = nullptr;
+  loco::GraphOutput *_graph_output = nullptr;
+  luci::CircleInput *_input = nullptr;
+  luci::CircleOutput *_output = nullptr;
+};
+
+class SubstituteSqueezeToReshapeGraph : public PassTestGraph
+{
+public:
+  SubstituteSqueezeToReshapeGraph() = default;
+
+public:
+  void init(const uilist shape_in, const uilist shape_out, const ilist squeeze_dims)
+  {
+    PassTestGraph::init(shape_in, shape_out);
+
+    _squeeze = _g.nodes()->create<luci::CircleSqueeze>();
+    _squeeze->input(_input);
+    _squeeze->squeeze_dims(squeeze_dims);
+
+    _output->from(_squeeze);
+  }
+
+protected:
+  luci::CircleSqueeze *_squeeze = nullptr;
+};
+
+class SubstituteSqueezeToReshapeTest : public ::testing::Test
+{
+public:
+  SubstituteSqueezeToReshapeTest() = default;
+
+  void run_pass(void)
+  {
+    while (_shapeinf.run(_graph.g()) || _pass.run(_graph.g()))
+      ;
+  }
+
+protected:
+  SubstituteSqueezeToReshapeGraph _graph;
+  luci::SubstituteSqueezeToReshapePass _pass;
+  luci::CircleShapeInferencePass _shapeinf;
+};
+
+} // namespace
+
+TEST_F(SubstituteSqueezeToReshapeTest, simple_with_squeeze_dims)
+{
+  _graph.init({1, 16, 1, 1}, {1, 16}, {2, 3});
+
+  run_pass();
+
+  auto reshape = dynamic_cast<luci::CircleReshape *>(_graph.output()->from());
+  auto squeeze = dynamic_cast<luci::CircleSqueeze *>(_graph.output()->from());
+  ASSERT_NE(nullptr, reshape);
+  ASSERT_EQ(nullptr, squeeze);
+  auto new_shape = loco::must_cast<luci::CircleConst *>(reshape->shape());
+  ASSERT_EQ(2, new_shape->size<loco::DataType::S32>());
+  ASSERT_EQ(1, new_shape->at<loco::DataType::S32>(0));
+  ASSERT_EQ(16, new_shape->at<loco::DataType::S32>(1));
+}
+
+TEST_F(SubstituteSqueezeToReshapeTest, simple_without_squeeze_dims)
+{
+  _graph.init({1, 16, 1, 1}, {16}, {});
+
+  run_pass();
+
+  auto reshape = dynamic_cast<luci::CircleReshape *>(_graph.output()->from());
+  auto squeeze = dynamic_cast<luci::CircleSqueeze *>(_graph.output()->from());
+  ASSERT_NE(nullptr, reshape);
+  ASSERT_EQ(nullptr, squeeze);
+  auto new_shape = loco::must_cast<luci::CircleConst *>(reshape->shape());
+  ASSERT_EQ(1, new_shape->size<loco::DataType::S32>());
+  ASSERT_EQ(16, new_shape->at<loco::DataType::S32>(0));
+}
+
+TEST_F(SubstituteSqueezeToReshapeTest, nothing_to_squeeze)
+{
+  _graph.init({2, 16, 16, 3}, {2, 16, 16, 3}, {});
+
+  run_pass();
+
+  auto reshape = dynamic_cast<luci::CircleReshape *>(_graph.output()->from());
+  auto squeeze = dynamic_cast<luci::CircleSqueeze *>(_graph.output()->from());
+  ASSERT_NE(nullptr, reshape);
+  ASSERT_EQ(nullptr, squeeze);
+}
+
+TEST_F(SubstituteSqueezeToReshapeTest, wrong_squeeze_dims_NEG)
+{
+  _graph.init({1, 16, 1, 1}, {1, 16, 1, 1}, {1});
+
+  // shape inference will throw for invalid squeeze_dims
+  EXPECT_THROW(run_pass(), std::exception);
+}


### PR DESCRIPTION
This will introduce SubstituteSqueezeToReshapePass that will substitute
CircleSqueeze to CircleReshape for certain conditions.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>