### PR TITLE
[one-cmds] Enable substitute_squeeze_to_reshape

### DIFF
--- a/compiler/one-cmds/how-to-use-one-commands.txt
+++ b/compiler/one-cmds/how-to-use-one-commands.txt
@@ -183,6 +183,7 @@ Current transformation options are
 - shuffle_weight_to_16x1float32 : This will convert weight format of FullyConnected to SHUFFLED16x1FLOAT32.
   Note that it only converts weights whose row is a multiple of 16.
 - substitute_pack_to_reshape : This will convert single input Pack to Reshape.
+- substitute_squeeze_to_reshape : This will convert certain condition Squeeze to Reshape.
 - substitute_transpose_to_reshape : This will convert certain condition Transpose to Reshape.
 - transform_min_max_to_relu6: This will transform Minimum-Maximum pattern to Relu6 operator.
 

--- a/compiler/one-cmds/one-optimize
+++ b/compiler/one-cmds/one-optimize
@@ -145,6 +145,10 @@ def _get_parser():
         action='store_true',
         help='convert single input Pack op to Reshape op')
     circle2circle_group.add_argument(
+        '--substitute_squeeze_to_reshape',
+        action='store_true',
+        help='convert certain condition Squeeze to Reshape')
+    circle2circle_group.add_argument(
         '--substitute_transpose_to_reshape',
         action='store_true',
         help='convert certain condition Transpose to Reshape')

--- a/compiler/one-cmds/utils.py
+++ b/compiler/one-cmds/utils.py
@@ -171,6 +171,8 @@ def _make_circle2circle_cmd(args, driver_path, input_path, output_path):
         cmd.append('--shuffle_weight_to_16x1float32')
     if _is_valid_attr(args, 'substitute_pack_to_reshape'):
         cmd.append('--substitute_pack_to_reshape')
+    if _is_valid_attr(args, 'substitute_squeeze_to_reshape'):
+        cmd.append('--substitute_squeeze_to_reshape')
     if _is_valid_attr(args, 'substitute_transpose_to_reshape'):
         cmd.append('--substitute_transpose_to_reshape')
     if _is_valid_attr(args, 'transform_min_max_to_relu6'):


### PR DESCRIPTION
This will enable substitute_squeeze_to_reshape option in one-cmds.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>