### PR TITLE
[record-minmax] Add requires to luci-interpreter

### DIFF
--- a/compiler/record-minmax/requires.cmake
+++ b/compiler/record-minmax/requires.cmake
@@ -1,4 +1,5 @@
 require("luci")
+require("luci-interpreter")
 require("safemain")
 require("arser")
 require("vconone")


### PR DESCRIPTION
This will revise requires.cmake to include luci-interpreter.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>