### PR TITLE
[one-cmds] Enable forward_reshape_to_unaryop option

### DIFF
--- a/compiler/one-cmds/how-to-use-one-commands.txt
+++ b/compiler/one-cmds/how-to-use-one-commands.txt
@@ -154,6 +154,7 @@ Current transformation options are
 - fold_cast : This removes Cast operation which can be folded
 - fold_dequantize : This removes Dequantize operation which can be folded
 - fold_sparse_to_dense : This removes SparseToDense operation which can be folded
+- forward_reshape_to_unaryop: This will move Reshape after certain UnaryOp(Neg)
 - fuse_add_with_tconv: This fuses Add operator with the preceding TConv operator if possible
 - fuse_batchnorm_with_conv : This fuses BatchNorm operator to convolution operator
 - fuse_batchnorm_with_dwconv : This fuses BatchNorm operator to depthwise convolution operator

--- a/compiler/one-cmds/one-optimize
+++ b/compiler/one-cmds/one-optimize
@@ -68,6 +68,8 @@ def _get_parser():
     circle2circle_group.add_argument(
         '--fold_sparse_to_dense', action='store_true', help='fold SparseToDense op')
     circle2circle_group.add_argument(
+        '--forward_reshape_to_unaryop', action='store_true', help='Forward Reshape op')
+    circle2circle_group.add_argument(
         '--fuse_add_with_tconv', action='store_true', help='fuse Add op to Transposed')
     circle2circle_group.add_argument(
         '--fuse_batchnorm_with_conv',

--- a/compiler/one-cmds/utils.py
+++ b/compiler/one-cmds/utils.py
@@ -131,6 +131,8 @@ def _make_circle2circle_cmd(args, driver_path, input_path, output_path):
         cmd.append('--fold_dequantize')
     if _is_valid_attr(args, 'fold_sparse_to_dense'):
         cmd.append('--fold_sparse_to_dense')
+    if _is_valid_attr(args, 'forward_reshape_to_unaryop'):
+        cmd.append('--forward_reshape_to_unaryop')
     if _is_valid_attr(args, 'fuse_add_with_tconv'):
         cmd.append('--fuse_add_with_tconv')
     if _is_valid_attr(args, 'fuse_batchnorm_with_conv'):


### PR DESCRIPTION
This will enable forward_reshape_to_unaryop option in one-optimize.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>