### PR TITLE
[one-cmds] Revise doc of forward_reshape_to_unaryop

### DIFF
--- a/compiler/one-cmds/how-to-use-one-commands.txt
+++ b/compiler/one-cmds/how-to-use-one-commands.txt
@@ -154,7 +154,7 @@ Current transformation options are
 - fold_cast : This removes Cast operation which can be folded
 - fold_dequantize : This removes Dequantize operation which can be folded
 - fold_sparse_to_dense : This removes SparseToDense operation which can be folded
-- forward_reshape_to_unaryop: This will move Reshape after certain UnaryOp(Neg)
+- forward_reshape_to_unaryop: This will move Reshape after UnaryOp for centain condition
 - fuse_add_with_tconv: This fuses Add operator with the preceding TConv operator if possible
 - fuse_batchnorm_with_conv : This fuses BatchNorm operator to convolution operator
 - fuse_batchnorm_with_dwconv : This fuses BatchNorm operator to depthwise convolution operator


### PR DESCRIPTION
This will revise forward_reshape_to_unaryop in how-to-use-one-commands.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>