### PR TITLE
[luci/service] Add BidirectionalSequenceLSTM operation

### DIFF
--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -1729,6 +1729,17 @@ loco::NodeShape infer_bcq_gather(const luci::CircleBCQGather *node)
   return loco::NodeShape{output_shape};
 }
 
+loco::NodeShape infer_bidirectionalsequencelstm(const luci::CircleBidirectionalSequenceLSTM *node)
+{
+  auto input_shape = loco::shape_get(node->input()).as<loco::TensorShape>();
+  assert(input_shape.rank() == 3);
+
+  loco::TensorShape shape_output;
+  shape_output = own_shape(node);
+
+  return loco::NodeShape{shape_output};
+}
+
 // Virtual
 loco::NodeShape infer_input(const luci::CircleInput *node)
 {
@@ -1748,6 +1759,39 @@ loco::NodeShape infer_output(const luci::CircleOutput *node)
   auto output_shape = graph_output->shape();
 
   return loco::NodeShape{*output_shape};
+}
+
+// Virtual
+loco::NodeShape
+infer_bidirectionalsequencelstmOut(const luci::CircleBidirectionalSequenceLSTMOut *node)
+{
+  auto bidi_lstm = loco::must_cast<luci::CircleBidirectionalSequenceLSTM *>(node->input());
+  auto bidi_lstm_shape = loco::shape_get(bidi_lstm->input()).as<loco::TensorShape>();
+
+  assert(bidi_lstm_shape.rank() == 3);
+
+  auto input_shape = loco::shape_get(bidi_lstm->input()).as<loco::TensorShape>();
+  auto fw_recurrent_to_output_weights =
+    loco::shape_get(bidi_lstm->fw_recurrent_to_output_weights()).as<loco::TensorShape>();
+  auto rank = input_shape.rank();
+  loco::TensorShape output_shape;
+  output_shape.rank(rank);
+  for (uint32_t i = 0; i < rank - 1; i++)
+  {
+    output_shape.dim(i) = input_shape.dim(i);
+  }
+  if (bidi_lstm->merge_outputs() == true)
+  {
+    auto bw_recurrent_to_output_weights =
+      loco::shape_get(bidi_lstm->bw_recurrent_to_output_weights()).as<loco::TensorShape>();
+    output_shape.dim(rank - 1).set(fw_recurrent_to_output_weights.dim(1).value() +
+                                   bw_recurrent_to_output_weights.dim(1).value());
+  }
+  else
+  {
+    output_shape.dim(rank - 1) = fw_recurrent_to_output_weights.dim(1);
+  }
+  return loco::NodeShape{output_shape};
 }
 
 loco::NodeShape infer_if_out(const luci::CircleIfOut *node)
@@ -2072,6 +2116,11 @@ public:
   loco::NodeShape visit(const luci::CircleBatchToSpaceND *node) final
   {
     return infer_batch_to_space_nd(node);
+  }
+
+  loco::NodeShape visit(const luci::CircleBidirectionalSequenceLSTM *node) final
+  {
+    return infer_bidirectionalsequencelstm(node);
   }
 
   loco::NodeShape visit(const luci::CircleCast *node) final { return use_x(node); }
@@ -2482,6 +2531,12 @@ public:
   loco::NodeShape visit(const luci::CircleOutputDummy *node) final { return use_own(node); }
 
   loco::NodeShape visit(const luci::CircleOutputExclude *node) final { return use_own(node); }
+
+  // Virtual
+  loco::NodeShape visit(const luci::CircleBidirectionalSequenceLSTMOut *node) final
+  {
+    return infer_bidirectionalsequencelstmOut(node);
+  }
 
   loco::NodeShape visit(const luci::CircleCustomOut *node) final { return use_own(node); }
 

--- a/compiler/luci/service/src/CircleTypeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleTypeInferenceRule.cpp
@@ -69,6 +69,11 @@ struct TypeInferenceAlgorithm final : public luci::CircleNodeVisitor<loco::DataT
     return luci::dtype_get(node->input());
   }
 
+  loco::DataType visit(const luci::CircleBidirectionalSequenceLSTM *node) final
+  {
+    return loco::dtype_get(node->input());
+  }
+
   loco::DataType visit(const luci::CircleCast *node) final { return node->dtype(); }
 
   loco::DataType visit(const luci::CircleCeil *node) final { return luci::dtype_get(node->x()); }
@@ -562,6 +567,11 @@ struct TypeInferenceAlgorithm final : public luci::CircleNodeVisitor<loco::DataT
   loco::DataType visit(const luci::CircleOutputDummy *node) final { return node->dtype(); }
 
   loco::DataType visit(const luci::CircleOutputExclude *node) final { return node->dtype(); }
+
+  loco::DataType visit(const luci::CircleBidirectionalSequenceLSTMOut *node) final
+  {
+    return loco::dtype_get(node->input());
+  }
 
   loco::DataType visit(const luci::CircleCustomOut *node) final { return node->dtype(); }
 


### PR DESCRIPTION
This commit adds BidirectionalSequenceLSTM operation to luci service.

ONE-DCO-1.0-Signed-off-by: venkat.iyervenkat.iyer@samsung.com