### PR TITLE
[luci] Revise QuantizeWithMinMaxPass use luci::clone

### DIFF
--- a/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
+++ b/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
@@ -19,6 +19,7 @@
 
 #include <luci/IR/CircleNodes.h>
 #include <luci/IR/CircleNodeVisitor.h>
+#include <luci/Service/Nodes/CircleConst.h>
 #include <luci/Log.h>
 
 #include <oops/UserExn.h>
@@ -759,7 +760,7 @@ private:
     auto weights = loco::must_cast<luci::CircleConst *>(node->filter());
     if (!is_quantized(weights))
     {
-      auto new_weights = clone_const_from<loco::DataType::FLOAT32>(weights);
+      auto new_weights = luci::clone(weights);
       node->filter(new_weights);
       quantize_weights(new_weights);
       return true;
@@ -775,7 +776,7 @@ private:
     auto weights = loco::must_cast<luci::CircleConst *>(node->filter());
     if (!is_quantized(weights))
     {
-      auto new_weights = clone_const_from<loco::DataType::FLOAT32>(weights);
+      auto new_weights = luci::clone(weights);
       node->filter(new_weights);
       quantize_weights(new_weights);
       return true;
@@ -791,7 +792,7 @@ private:
     auto weights = loco::must_cast<luci::CircleConst *>(node->filter());
     if (!is_quantized(weights))
     {
-      auto new_weights = clone_const_from<loco::DataType::FLOAT32>(weights);
+      auto new_weights = luci::clone(weights);
       node->filter(new_weights);
       quantize_weights(new_weights);
       return true;
@@ -807,7 +808,7 @@ private:
     auto weights = loco::must_cast<luci::CircleConst *>(node->weights());
     if (!is_quantized(weights))
     {
-      auto new_weights = clone_const_from<loco::DataType::FLOAT32>(weights);
+      auto new_weights = luci::clone(weights);
       node->weights(new_weights);
       quantize_weights(new_weights);
       return true;


### PR DESCRIPTION
This will revise QuantizeWithMinMaxPass to use luci::clone for
CircleConst.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>