### PR TITLE
[luci] Quantize const inputs shared by multiple nodes

### DIFF
--- a/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
+++ b/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
@@ -919,7 +919,7 @@ void quantize_const_inputs(luci::CircleNode *node, loco::DataType output_type)
       // Ex: axis, paddings
       input_node = node->arg(0);
       const_node = dynamic_cast<luci::CircleConst *>(input_node);
-      if (const_node != nullptr)
+      if (const_node != nullptr && !is_quantized(const_node))
         quant_const(const_node, output_type);
       break;
 
@@ -941,7 +941,7 @@ void quantize_const_inputs(luci::CircleNode *node, loco::DataType output_type)
       {
         input_node = node->arg(i);
         const_node = dynamic_cast<luci::CircleConst *>(input_node);
-        if (const_node != nullptr)
+        if (const_node != nullptr && !is_quantized(const_node))
           quant_const(const_node, output_type);
       }
       break;


### PR DESCRIPTION
This supports quantization of const inputs shared by multiple nodes.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: #5785