### PR TITLE
[one-cmds] Use --O1 for one-optimize tests

### DIFF
--- a/compiler/one-cmds/tests/one-optimize_001.test
+++ b/compiler/one-cmds/tests/one-optimize_001.test
@@ -40,7 +40,7 @@ if [[ ! -s ${inputfile} ]]; then
 fi
 
 # run test
-one-optimize --all \
+one-optimize --O1 \
 --input_path ${inputfile} \
 --output_path ${outputfile} >> /dev/null
 

--- a/compiler/one-cmds/tests/one-optimize_neg_001.test
+++ b/compiler/one-cmds/tests/one-optimize_neg_001.test
@@ -39,7 +39,7 @@ rm -rf ${outputfile}
 rm -rf ${outputfile}.log
 
 # run test
-one-optimize --all \
+one-optimize --O1 \
 --input_path ${inputfile} \
 --output_path ${outputfile} > ${filename}.log
 

--- a/compiler/one-cmds/tests/one-optimize_neg_002.test
+++ b/compiler/one-cmds/tests/one-optimize_neg_002.test
@@ -39,7 +39,7 @@ rm -rf ${outputfile}
 rm -rf ${outputfile}.log
 
 # run test
-one-optimize --all \
+one-optimize --O1 \
 --input_path ${inputfile} \
 --output_path ${outputfile} > ${filename}.log
 

--- a/compiler/one-cmds/tests/one-optimize_neg_003.test
+++ b/compiler/one-cmds/tests/one-optimize_neg_003.test
@@ -44,7 +44,7 @@ if [[ ! -s ${inputfile} ]]; then
 fi
 
 # run test
-one-optimize --all \
+one-optimize --O1 \
 --input_path "${inputfile}" > "${filename}.log" 2>&1
 
 echo "${filename_ext} FAILED"


### PR DESCRIPTION
This will revise one-optimize tests to use --O1 for --all.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>