### PR TITLE
[one-cmds] Remove --all option in one-optimize

### DIFF
--- a/compiler/one-cmds/one-optimize
+++ b/compiler/one-cmds/one-optimize
@@ -44,9 +44,6 @@ def _get_parser():
         '-o', '--output_path', type=str, help='full filepath of the output file')
 
     # optimization pass
-    # TODO remove all
-    circle2circle_group.add_argument(
-        '--all', action='store_true', help='enable all optimization pass')
     circle2circle_group.add_argument(
         '--O1', action='store_true', help='enable O1 optimization pass')
     circle2circle_group.add_argument(

--- a/compiler/one-cmds/utils.py
+++ b/compiler/one-cmds/utils.py
@@ -115,9 +115,6 @@ def _make_circle2circle_cmd(args, driver_path, input_path, output_path):
     """make a command for running circle2circle"""
     cmd = [os.path.expanduser(c) for c in [driver_path, input_path, output_path]]
     # optimization pass
-    # TODO remove all
-    if _is_valid_attr(args, 'all'):
-        cmd.append('--all')
     if _is_valid_attr(args, 'O1'):
         cmd.append('--O1')
     if _is_valid_attr(args, 'convert_nchw_to_nhwc'):


### PR DESCRIPTION
This will remove not used anymore --all option in one-optimize.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>