### PR TITLE
[onert] Fix NDK dynamic_cast issue of weak RTTI typeinfo

### DIFF
--- a/runtime/onert/core/include/backend/ITensor.h
+++ b/runtime/onert/core/include/backend/ITensor.h
@@ -37,7 +37,7 @@ struct IDynamicTensorManager;
 class ITensor
 {
 public:
-  virtual ~ITensor() = default;
+  virtual ~ITensor();
 
 public:
   virtual uint8_t *buffer() const = 0;

--- a/runtime/onert/core/src/backend/ITensor.cc
+++ b/runtime/onert/core/src/backend/ITensor.cc
@@ -14,43 +14,16 @@
  * limitations under the License.
  */
 
-#include "IOTensor.h"
-
-#include <assert.h>
+#include "backend/ITensor.h"
 
 namespace onert
 {
 namespace backend
 {
-namespace builtin
-{
 
 // `dynamic_cast` not working across library boundaries on NDK
 // With this as a key function, `dynamic_cast` works across dl
-IOTensor::~IOTensor() {}
+ITensor::~ITensor() {}
 
-IOTensor::IOTensor(const ir::OperandInfo &info, ir::Layout layout)
-  : IPortableTensor{info}, _orig_info{info}, _orig_layout{layout}
-{
-  setUserTensor(nullptr, 0);
-}
-
-void IOTensor::setTensor(IPortableTensor *tensor)
-{
-  assert(tensor);
-  assert(tensor != this);
-  // TODO Handle when layout was changed
-  assert(tensor->layout() == _orig_layout); // Changing layout is not considered yet
-  _user_tensor.reset();
-  _tensor = tensor;
-}
-
-void IOTensor::setUserTensor(uint8_t *buffer, size_t size)
-{
-  _user_tensor = std::make_unique<UserTensor>(_orig_info, _orig_layout, buffer, size);
-  _tensor = _user_tensor.get();
-}
-
-} // namespace builtin
 } // namespace backend
 } // namespace onert

--- a/runtime/onert/core/src/backend/builtin/IOTensor.h
+++ b/runtime/onert/core/src/backend/builtin/IOTensor.h
@@ -42,6 +42,7 @@ class IOTensor : public IPortableTensor
 {
 public:
   IOTensor(const ir::OperandInfo &info, ir::Layout layout);
+  ~IOTensor();
 
 public:
   void setTensor(IPortableTensor *tensor);


### PR DESCRIPTION
This commit fixes nullptr dereferencing issue by dynamic_cast,
which is not supported with weak RTTI typeinfo via NDK.

ONE-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>