### PR TITLE
[one-cmds] Run one-quantize without input_data

### DIFF
--- a/compiler/one-cmds/one-quantize
+++ b/compiler/one-cmds/one-quantize
@@ -38,7 +38,12 @@ def _get_parser():
     parser.add_argument(
         '-i', '--input_path', type=str, help='full filepath of the input file')
     parser.add_argument(
-        '-d', '--input_data', type=str, help='full filepath of the input data file')
+        '-d',
+        '--input_data',
+        type=str,
+        help=
+        'full filepath of the input data file. if not specified, run with random input data.'
+    )
     parser.add_argument(
         '-o', '--output_path', type=str, help='full filepath of the output file')
 
@@ -84,8 +89,6 @@ def _verify_arg(parser, args):
     missing = []
     if not _utils._is_valid_attr(args, 'input_path'):
         missing.append('-i/--input_path')
-    if not _utils._is_valid_attr(args, 'input_data'):
-        missing.append('-d/--input_data')
     if not _utils._is_valid_attr(args, 'output_path'):
         missing.append('-o/--output_path')
     if len(missing):

--- a/compiler/one-cmds/tests/one-quantize_002.test
+++ b/compiler/one-cmds/tests/one-quantize_002.test
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  echo "${filename_ext} FAILED"
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+inputfile="./inception_v3.circle"
+outputfile="./inception_v3.random.quantized.circle"
+
+rm -rf ${outputfile}
+
+# to create inception_v3.circle
+if [[ ! -s ${inputfile} ]]; then
+  /bin/bash one-import_001.test >> /dev/null
+  return_code=$?
+  if [[ ${return_code} != 0 ]]; then
+    trap_err_onexit
+  fi
+fi
+
+# run test without input data
+one-quantize \
+--input_dtype float32 \
+--quantized_dtype uint8 \
+--input_path ./inception_v3.circle \
+--output_path ./inception_v3.random.quantized.circle >> /dev/null
+
+if [[ ! -s "${outputfile}" ]]; then
+  trap_err_onexit
+fi
+
+echo "${filename_ext} SUCCESS"


### PR DESCRIPTION
This enables one-quantize to run without input_data.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: #5886
Draft PR: #5897