### PR TITLE
[infra] Update tf2nnpkg for circle2circle optimize option

### DIFF
--- a/infra/packaging/res/tf2nnpkg.20200630
+++ b/infra/packaging/res/tf2nnpkg.20200630
@@ -125,6 +125,6 @@ ${TF2TFLITE_CONVERT_SCRIPT}
 "${ROOT}/bin/tflite2circle" "${TMPDIR}/${MODEL_NAME}.tflite" "${TMPDIR}/${MODEL_NAME}.tmp.circle"
 
 # optimize
-"${ROOT}/bin/circle2circle" --all "${TMPDIR}/${MODEL_NAME}.tmp.circle" "${TMPDIR}/${MODEL_NAME}.circle"
+"${ROOT}/bin/circle2circle" --O1 "${TMPDIR}/${MODEL_NAME}.tmp.circle" "${TMPDIR}/${MODEL_NAME}.circle"
 
 "${ROOT}/bin/model2nnpkg.sh" -o "${OUTPUT_DIR}" "${TMPDIR}/${MODEL_NAME}.circle"


### PR DESCRIPTION
This commit fix deprecated tf2nnpkg's circle2circle optimize option "--all" to "--O1"

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: #5780