### PR TITLE
[infra] Revise utcount

### DIFF
--- a/infra/nncc/command/utcount
+++ b/infra/nncc/command/utcount
@@ -18,6 +18,8 @@ safemain mio-circle mio-tflite \
 tflite2circle \
 luci \
 luci-interpreter \
+luci-eval-driver \
+luci-pass-value-test \
 luci-value-test \
 record-minmax \
 circle2circle circle-quantizer"


### PR DESCRIPTION
This will revise utcount to include luci-eval-driver and
luci-pass-value-test.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>