### PR TITLE
[onert] Add methods for adding operands/operations

### DIFF
--- a/runtime/onert/core/include/ir/Graph.h
+++ b/runtime/onert/core/include/ir/Graph.h
@@ -56,7 +56,31 @@ public:
   // Graph Building
 public:
   OperandIndex addOperand(const Shape &shape, const TypeInfo &type);
+  /**
+   * @brief Add an operand to the graph with the given index and object
+   *
+   * If the given index is available, it succeeds. And @c operand is moved which invalidates the
+   * caller's pointer. If the given index is already taken, it fails. And @c operand will not be
+   * moved so the caller's pointer will be still valid.
+   *
+   * @param[in] index Index to be added
+   * @param[in] operand Operand to be added
+   * @return OperandIndex @c index if successful, Undefined otherwise
+   */
+  OperandIndex addOperand(OperandIndex index, std::unique_ptr<Operand> &&operand);
   OperationIndex addOperation(std::unique_ptr<Operation> &&node);
+  /**
+   * @brief Add an operation to the graph with the given index and object
+   *
+   * If the given index is available, it succeeds. And @c operation is moved which invalidates the
+   * caller's pointer. If the given index is already taken, it fails. And @c operation will not be
+   * moved so the caller's pointer will be still valid.
+   *
+   * @param index Index to be added
+   * @param operation Operation to be added
+   * @return OperandIndex @c index if successful, Undefined otherwise
+   */
+  OperationIndex addOperation(OperationIndex index, std::unique_ptr<Operation> &&operation);
   void setOperandValue(const OperandIndex &ind, std::shared_ptr<Data> data);
   void addInput(const OperandIndex &ind, const std::string &name = "");
   void addOutput(const OperandIndex &ind, const std::string &name = "");

--- a/runtime/onert/core/src/ir/Graph.cc
+++ b/runtime/onert/core/src/ir/Graph.cc
@@ -45,10 +45,20 @@ OperandIndex Graph::addOperand(const Shape &shape, const TypeInfo &type)
   return _operands.emplace(shape, type);
 }
 
+OperandIndex Graph::addOperand(OperandIndex index, std::unique_ptr<Operand> &&operand)
+{
+  return _operands.push(std::move(operand), index);
+}
+
 OperationIndex Graph::addOperation(std::unique_ptr<Operation> &&node)
 {
   assert(isBuildingPhase());
   return _operations.push(std::move(node));
+}
+
+OperationIndex Graph::addOperation(OperationIndex index, std::unique_ptr<Operation> &&operation)
+{
+  return _operations.push(std::move(operation), index);
 }
 
 void Graph::setOperandValue(const OperandIndex &ind, std::shared_ptr<Data> data)


### PR DESCRIPTION
Add methods for adding operands/operantions with given indices.

These methods are going to be used for building partial graphs.

This makes use of #5481 and also is part of #5773 .

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>