### PR TITLE
[onert] Refactor cloning operations

### DIFF
--- a/runtime/onert/core/src/ir/OperationCloner.cc
+++ b/runtime/onert/core/src/ir/OperationCloner.cc
@@ -23,6 +23,22 @@ namespace onert
 namespace ir
 {
 
+namespace
+{
+class OperationCloner : public OperationVisitor
+{
+public:
+#define OP(Name) void visit(const operation::Name &o) override;
+#include "ir/Operations.lst"
+#undef OP
+
+public:
+  std::unique_ptr<Operation> releaseClone();
+
+private:
+  std::unique_ptr<Operation> _return_op;
+};
+
 #define OP(Name)                                        \
   void OperationCloner::visit(const operation::Name &o) \
   {                                                     \
@@ -36,6 +52,15 @@ std::unique_ptr<Operation> OperationCloner::releaseClone()
 {
   assert(_return_op);
   return std::move(_return_op);
+}
+
+} // namespace
+
+std::unique_ptr<Operation> clone(const Operation &operation)
+{
+  OperationCloner cloner;
+  operation.accept(cloner);
+  return cloner.releaseClone();
 }
 
 } // namespace ir

--- a/runtime/onert/core/src/ir/OperationCloner.h
+++ b/runtime/onert/core/src/ir/OperationCloner.h
@@ -26,19 +26,7 @@ namespace onert
 namespace ir
 {
 
-class OperationCloner : public OperationVisitor
-{
-public:
-#define OP(Name) void visit(const operation::Name &o) override;
-#include "ir/Operations.lst"
-#undef OP
-
-public:
-  std::unique_ptr<Operation> releaseClone();
-
-private:
-  std::unique_ptr<Operation> _return_op;
-};
+std::unique_ptr<Operation> clone(const Operation &operation);
 
 } // namespace ir
 } // namespace onert

--- a/runtime/onert/core/src/ir/Operations.cc
+++ b/runtime/onert/core/src/ir/Operations.cc
@@ -25,11 +25,8 @@ namespace ir
 
 Operations::Operations(const Operations &obj)
 {
-  obj.iterate([&](const OperationIndex &index, const Operation &op) {
-    OperationCloner cloner;
-    op.accept(cloner);
-    _objects.emplace(index, cloner.releaseClone());
-  });
+  obj.iterate(
+    [&](const OperationIndex &index, const Operation &op) { _objects.emplace(index, clone(op)); });
   _next_index = obj._next_index;
 }
 


### PR DESCRIPTION
Expose `clone` function and hide `OperationCloner` class for
convenience.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>