### PR TITLE
[luci-interpreter] Add check for concat activation function

### DIFF
--- a/compiler/luci-interpreter/src/core/KernelParams.h
+++ b/compiler/luci-interpreter/src/core/KernelParams.h
@@ -44,6 +44,7 @@ struct ArgMaxParams
 struct ConcatenationParams
 {
   int axis;
+  Activation activation;
 };
 
 struct Conv2DParams

--- a/compiler/luci-interpreter/src/kernels/Concatenation.cpp
+++ b/compiler/luci-interpreter/src/kernels/Concatenation.cpp
@@ -39,6 +39,9 @@ void Concatenation::configure()
   LUCI_INTERPRETER_CHECK(num_inputs > 0);
   const Tensor *t0 = _inputs[0];
 
+  // TODO: Support concat with fused activation function
+  LUCI_INTERPRETER_CHECK(params().activation == luci::FusedActFunc::NONE);
+
   int axis = _params.axis;
   if (axis < 0)
     axis += t0->shape().num_dims();

--- a/compiler/luci-interpreter/src/kernels/Concatenation.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/Concatenation.test.cpp
@@ -174,6 +174,7 @@ TEST(ConcatenationTest, Unsupported_Configure_Type_NEG)
   EXPECT_ANY_THROW(kernel.configure());
 }
 
+// TODO: Remove this test when concat w/ fused_activation is supported
 TEST(ConcatenationTest, With_Fused_Activation_NEG)
 {
   std::vector<float> input1_data{1, 2, 3, 4, 5, 6};

--- a/compiler/luci-interpreter/src/kernels/Concatenation.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/Concatenation.test.cpp
@@ -38,6 +38,7 @@ TEST(ConcatenationTest, Float)
   // Try different 'axis' and expect different results.
   {
     params.axis = 0;
+    params.activation = luci::FusedActFunc::NONE;
 
     Concatenation kernel({&input1_tensor, &input2_tensor}, &output_tensor, params);
     kernel.configure();
@@ -48,6 +49,7 @@ TEST(ConcatenationTest, Float)
   }
   {
     params.axis = -2; // Same as '0'.
+    params.activation = luci::FusedActFunc::NONE;
 
     Concatenation kernel({&input1_tensor, &input2_tensor}, &output_tensor, params);
     kernel.configure();
@@ -58,6 +60,7 @@ TEST(ConcatenationTest, Float)
   }
   {
     params.axis = 1;
+    params.activation = luci::FusedActFunc::NONE;
 
     Concatenation kernel({&input1_tensor, &input2_tensor}, &output_tensor, params);
     kernel.configure();
@@ -68,6 +71,7 @@ TEST(ConcatenationTest, Float)
   }
   {
     params.axis = -1; // Same as '1'.
+    params.activation = luci::FusedActFunc::NONE;
 
     Concatenation kernel({&input1_tensor, &input2_tensor}, &output_tensor, params);
     kernel.configure();
@@ -84,6 +88,7 @@ TEST(ConcatenationTest, Input_Number_Check_NEG)
   ConcatenationParams params{};
 
   params.axis = -1;
+  params.activation = luci::FusedActFunc::NONE;
 
   Concatenation kernel({}, &output_tensor, params);
   EXPECT_ANY_THROW(kernel.configure());
@@ -99,6 +104,7 @@ TEST(ConcatenationTest, Invalid_Axis_NEG)
   ConcatenationParams params{};
 
   params.axis = -3;
+  params.activation = luci::FusedActFunc::NONE;
 
   Concatenation kernel({&input1_tensor, &input2_tensor}, &output_tensor, params);
   EXPECT_ANY_THROW(kernel.configure());
@@ -114,6 +120,7 @@ TEST(ConcatenationTest, Mismatching_Input_Type_NEG)
   ConcatenationParams params{};
 
   params.axis = -1;
+  params.activation = luci::FusedActFunc::NONE;
 
   Concatenation kernel({&input1_tensor, &input2_tensor}, &output_tensor, params);
   EXPECT_ANY_THROW(kernel.configure());
@@ -129,6 +136,7 @@ TEST(ConcatenationTest, Mismatching_Input_Dimension_Num_NEG)
   ConcatenationParams params{};
 
   params.axis = -1;
+  params.activation = luci::FusedActFunc::NONE;
 
   Concatenation kernel({&input1_tensor, &input2_tensor}, &output_tensor, params);
   EXPECT_ANY_THROW(kernel.configure());
@@ -144,6 +152,7 @@ TEST(ConcatenationTest, Mismatching_Input_Dimension_NEG)
   ConcatenationParams params{};
 
   params.axis = -1;
+  params.activation = luci::FusedActFunc::NONE;
 
   Concatenation kernel({&input1_tensor, &input2_tensor}, &output_tensor, params);
   EXPECT_ANY_THROW(kernel.configure());
@@ -159,6 +168,23 @@ TEST(ConcatenationTest, Unsupported_Configure_Type_NEG)
   ConcatenationParams params{};
 
   params.axis = -1;
+  params.activation = luci::FusedActFunc::NONE;
+
+  Concatenation kernel({&input1_tensor, &input2_tensor}, &output_tensor, params);
+  EXPECT_ANY_THROW(kernel.configure());
+}
+
+TEST(ConcatenationTest, With_Fused_Activation_NEG)
+{
+  std::vector<float> input1_data{1, 2, 3, 4, 5, 6};
+  std::vector<float> input2_data{7, 8, 9, 10, 11, 12};
+  Tensor input1_tensor = makeInputTensor<DataType::FLOAT32>({2, 3}, input1_data);
+  Tensor input2_tensor = makeInputTensor<DataType::FLOAT32>({2, 3}, input2_data);
+  Tensor output_tensor = makeOutputTensor(DataType::FLOAT32);
+  ConcatenationParams params{};
+
+  params.axis = 1;
+  params.activation = luci::FusedActFunc::RELU;
 
   Concatenation kernel({&input1_tensor, &input2_tensor}, &output_tensor, params);
   EXPECT_ANY_THROW(kernel.configure());

--- a/compiler/luci-interpreter/src/loader/KernelBuilder.cpp
+++ b/compiler/luci-interpreter/src/loader/KernelBuilder.cpp
@@ -191,6 +191,7 @@ std::unique_ptr<Kernel> KernelBuilder::visit(const luci::CircleConcatenation *no
 
   ConcatenationParams params{};
   params.axis = node->axis();
+  params.activation = node->fusedActivationFunction();
 
   return std::make_unique<kernels::Concatenation>(std::move(inputs), output, params);
 }

--- a/compiler/luci-interpreter/src/loader/KernelBuilder.test.cpp
+++ b/compiler/luci-interpreter/src/loader/KernelBuilder.test.cpp
@@ -217,6 +217,7 @@ TEST_F(KernelBuilderTest, Concatenation)
   checkTensor(kernel->input(1), input2);
   checkTensor(kernel->output(), op);
   EXPECT_THAT(kernel->params().axis, Eq(op->axis()));
+  EXPECT_THAT(kernel->params().activation, Eq(op->fusedActivationFunction()));
 }
 
 TEST_F(KernelBuilderTest, Conv2D)


### PR DESCRIPTION
This adds a check if concat has a fused activation function.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>