### PR TITLE
[luci] Skip fuse activation for CircleConcatenation

### DIFF
--- a/compiler/luci/pass/src/FuseActivationFunctionPass.cpp
+++ b/compiler/luci/pass/src/FuseActivationFunctionPass.cpp
@@ -36,6 +36,11 @@ bool fuse_activation_function(luci::CircleNode *node)
   if (node_with_fused_act == nullptr)
     return false;
 
+  // TODO remove this work-around
+  // This will skip fuse for concat as luci-interpreter doesn't support this yet
+  if (dynamic_cast<luci::CircleConcatenation *>(pred_node) != nullptr)
+    return false;
+
   auto fused_act = node_with_fused_act->fusedActivationFunction();
 
   luci::FusedActFunc target_func = luci::FusedActFunc::UNDEFINED;


### PR DESCRIPTION
This will skip fuse of activation for CircleConcatenation as a
work-around as our interpreter doesnt support this yet.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>