### PR TITLE
[onert] Refactor BackendContext

### DIFF
--- a/runtime/onert/backend/acl_cl/Backend.h
+++ b/runtime/onert/backend/acl_cl/Backend.h
@@ -42,13 +42,12 @@ public:
 
   std::shared_ptr<IConfig> config() const override { return _config; }
 
-  std::unique_ptr<backend::BackendContext>
-  newContext(const ir::Graph &graph, const std::shared_ptr<custom::IKernelBuilder> &,
-             bool is_linear_executor) const override
+  std::unique_ptr<backend::BackendContext> newContext(ContextData &&data) const override
   {
-    const auto &operands = graph.operands();
-    auto context = std::make_unique<acl_cl::BackendContext>(this, &graph);
-    auto tm = createTensorManager(is_linear_executor);
+    const auto &graph = *data.graph;
+    const auto &operands = data.graph->operands();
+    auto context = std::make_unique<acl_cl::BackendContext>(this, std::move(data));
+    auto tm = createTensorManager(data.is_linear_executor);
     auto tr = std::make_shared<acl_common::AclTensorRegistry<TensorManager>>(tm);
     auto tb = std::make_shared<TensorBuilder>(operands, tm);
     context->tensor_registry = tr;

--- a/runtime/onert/backend/acl_cl/BackendContext.cc
+++ b/runtime/onert/backend/acl_cl/BackendContext.cc
@@ -33,46 +33,34 @@ namespace acl_cl
 
 void BackendContext::initConsts()
 {
-  for (auto &op : operation_list())
-  {
-    constant_initializer->setLayout(op.layout);
-    graph()->operations().at(op.index).accept(*constant_initializer);
-  }
+  _data.graph->operations().iterate([&](const ir::OperationIndex &, const ir::Operation &op) {
+    constant_initializer->setLayout(graph()->layout());
+    op.accept(*constant_initializer);
+  });
 
-  for (auto ind : operand_list())
-  {
+  _data.graph->operands().iterate([&](const ir::OperandIndex &ind, const ir::Operand &operand) {
+    if (_data.external_operands.contains(ind) || !operand.isConstant())
+      return;
     const auto &obj = graph()->operands().at(ind);
     if (obj.isConstant() && !constant_initializer->exist(ind))
     {
       constant_initializer->registerDefaultInitializer(ind, obj);
     }
-  }
+  });
 
   constant_initializer->run();
 }
 
-void BackendContext::planTensors(const std::vector<onert::ir::OperationIndex> &order,
-                                 const compiler::GraphLowerInfo &lower_info)
+void BackendContext::planTensors()
 {
   ir::OperandIndexMap<uint32_t> uses_map;
   ir::OperandIndexMap<uint32_t> def_map;
   ir::OperandIndexSequence constants;
 
   // Prepare scanning
-  for (auto ind : operand_list())
-  {
-    const auto &obj = graph()->operands().at(ind);
-    const auto &li = lower_info.operand.at(ind);
-    if (li.def_factors().getOnlyElement().backend() != backend())
-      continue;
-
-    // Ignore unused tensor
-    if (li.def_factors().size() == 0 && li.use_factors().size() == 0)
-    {
-      VERBOSE(planTensors) << "Operand " << ind << " will not be used. no more process."
-                           << std::endl;
+  _data.graph->operands().iterate([&](const ir::OperandIndex &ind, const ir::Operand &obj) {
+    if (_data.external_operands.contains(ind))
       return;
-    }
 
     uses_map[ind] = obj.getUses().size();
     def_map[ind] = obj.getDef().valid() ? 1 : 0;
@@ -80,16 +68,15 @@ void BackendContext::planTensors(const std::vector<onert::ir::OperationIndex> &o
     if (obj.isConstant())
       constants.append(ind);
 
-    auto factor = li.def_factors().getOnlyElement();
     if (!tensor_builder->isRegistered(ind))
     {
       // These tensors do not exist in any operation (No use and def)
       const auto info = obj.info();
-      const auto backend_layout = factor.layout();
+      const auto layout = _data.operand_layouts.at(ind);
       // TODO Change tensor info to have permuted shape
-      tensor_builder->registerTensorInfo(ind, info, backend_layout);
+      tensor_builder->registerTensorInfo(ind, info, layout);
     }
-  }
+  });
 
   // Start scanning to do notify{First|Last}Use for each tensor
 
@@ -107,10 +94,10 @@ void BackendContext::planTensors(const std::vector<onert::ir::OperationIndex> &o
   // 1. Scan DEF of outputs. If the DEF, allocate it
   // 2. Scan DEF of inputs. If variable tensor, allocate it
   // 3. Scan USE of inputs. Decrease the USE and deallocate if the USE is 0
-  for (const auto op_ind : order)
+  for (const auto op_ind : _data.op_order)
   {
-    const auto &op = graph()->operations().at(op_ind);
     // TODO Remove indentation
+    const auto &op = graph()->operations().at(op_ind);
     {
       auto op_inputs = op.getInputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED;
       auto op_outputs = op.getOutputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED;
@@ -141,8 +128,6 @@ void BackendContext::planTensors(const std::vector<onert::ir::OperationIndex> &o
           // The variable tensor with buffer is not supported yet
           assert(operand.data() == nullptr);
           assert(operand.getUses().size() == 1 && !operand.getDef().valid());
-          assert(lower_info.operand.at(ind).def_factors().size() == 1 &&
-                 lower_info.operand.at(ind).use_factors().size() == 1);
           assert(uses_map[ind] == 1 && def_map[ind] == 0);
           tensor_builder->notifyFirstUse(ind);
         }
@@ -164,6 +149,13 @@ void BackendContext::planTensors(const std::vector<onert::ir::OperationIndex> &o
     }
   }
 
+  _data.graph->operands().iterate([&](const ir::OperandIndex &ind, const ir::Operand &) {
+    if (uses_map[ind] == 0)
+    {
+      tensor_builder->notifyLastUse(ind);
+    }
+  });
+
   // Dispose and validate
   for (const auto &ind : constants)
   {
@@ -183,67 +175,34 @@ void BackendContext::planTensors(const std::vector<onert::ir::OperationIndex> &o
                 [](std::pair<const ir::OperandIndex, uint32_t> it) { return it.second == 0; }));
 }
 
-ITensorRegistry *BackendContext::genTensors(const std::vector<onert::ir::OperationIndex> &order,
-                                            const compiler::GraphLowerInfo &lower_info)
+ITensorRegistry *BackendContext::genTensors()
 {
   optimizer->optimize();
 
-  for (const auto op_ind : order)
-  {
-    const auto &op = graph()->operations().at(op_ind);
-    auto model_io = (graph()->getInputs() + graph()->getOutputs()) | ir::Remove::UNDEFINED |
-                    ir::Remove::DUPLICATED;
-    // TODO Remove indentation
-    {
-      bool op_assigned = [&]() {
-        for (auto &op_info : operation_list())
-          if (op_info.index == op_ind)
-            return true;
-        return false;
-      }();
-      if (!op_assigned)
-        continue;
+  graph()->operands().iterate([&](const ir::OperandIndex &ind, const ir::Operand &obj) {
+    if (external_operands().contains(ind))
+      return;
 
-      for (const auto &index : (op.getInputs() + op.getOutputs()) | ir::Remove::UNDEFINED)
-      {
-        if (!tensor_builder->isRegistered(index) && !model_io.contains(index) &&
-            find(operand_list().begin(), operand_list().end(), index) != operand_list().end())
-        {
-          const auto &operand_lower_info =
-            lower_info.operand.at(index).def_factors().getOnlyElement();
-
-          // E.g., permute (CPU) -> tensor A -> MaxPool2D(acl_cl)
-          // op.getOutputs() of permute (CPU) returns tensor A
-          // but tensor A belongs to the backend of acl_cl.
-          // So, we have to make this tensor NOT registered for CPU.
-          if (operand_lower_info.backend() != backend())
-            continue;
-
-          const auto &obj = graph()->operands().at(index);
-          const auto frontend_layout = graph()->layout();
-          const auto backend_layout = operand_lower_info.layout();
-          ir::OperandInfo backend_info{permuteShape(obj.shape(), frontend_layout, backend_layout),
-                                       obj.typeInfo(), obj.info().memAllocType(), obj.isConstant()};
-          tensor_builder->registerTensorInfo(index, backend_info, backend_layout);
-        }
-      }
-    }
-  }
+    const auto frontend_layout = graph()->layout();
+    const auto backend_layout = operand_layouts().at(ind);
+    ir::OperandInfo backend_info{permuteShape(obj.shape(), frontend_layout, backend_layout),
+                                 obj.typeInfo(), obj.info().memAllocType(), obj.isConstant()};
+    tensor_builder->registerTensorInfo(ind, backend_info, backend_layout);
+  });
 
   // TODO Get compiler options from compiler, and use it rather than getting it from Env
   if (util::getConfigString(util::config::EXECUTOR) == "Linear")
   {
-    planTensors(order, lower_info);
+    planTensors();
   }
   else
   {
     // For the executors that does not have fixed linear execution order:
     // To make tensors never be deallocated, this is a workaround to use static memory planner
-    for (auto ind : operand_list())
-    {
+    graph()->operands().iterate([&](const ir::OperandIndex &ind, const ir::Operand &) {
       if (tensor_builder->isRegistered(ind))
         tensor_builder->notifyFirstUse(ind);
-    }
+    });
   }
 
   tensor_builder->prepare();
@@ -251,18 +210,12 @@ ITensorRegistry *BackendContext::genTensors(const std::vector<onert::ir::Operati
   return tensor_registry.get();
 }
 
-FunctionMap BackendContext::genKernels(const std::vector<onert::ir::OperationIndex> &order)
+FunctionMap BackendContext::genKernels()
 {
   FunctionMap ret;
 
-  for (auto op_ind : order)
+  for (auto op_ind : _data.op_order)
   {
-    // Skip if operation is not assigned to the backend
-    auto &ops = operation_list();
-    bool assigned = std::any_of(ops.begin(), ops.end(),
-                                [&](const OperationInfo &info) { return info.index == op_ind; });
-    if (!assigned)
-      continue;
     auto fn_seq = kernel_gen->generate(op_ind);
     ret.emplace_back(op_ind, std::move(fn_seq));
   }
@@ -271,12 +224,9 @@ FunctionMap BackendContext::genKernels(const std::vector<onert::ir::OperationInd
   initConsts();
 
   // NOTE For memory optimization, we want to free some operand data
-  for (auto ind : operand_list())
-  {
-    // TODO Remove const_cast
-    auto &obj = const_cast<ir::Graph *>(graph())->operands().at(ind);
-    obj.releaseData();
-  }
+  const_cast<ir::Graph &>(*_data.graph)
+    .operands()
+    .iterate([&](const ir::OperandIndex &, ir::Operand &obj) { obj.releaseData(); });
 
   for (auto &it : ret)
   {

--- a/runtime/onert/backend/acl_cl/BackendContext.h
+++ b/runtime/onert/backend/acl_cl/BackendContext.h
@@ -34,25 +34,23 @@ class Optimizer;
 class BackendContext : public onert::backend::BackendContext
 {
 public:
-  BackendContext(const Backend *backend, const ir::Graph *graph,
+  BackendContext(const Backend *backend, ContextData &&data,
                  std::shared_ptr<ITensorRegistry> tensor_registry = nullptr,
                  std::shared_ptr<TensorBuilder> tensor_builder = nullptr,
                  std::shared_ptr<ConstantInitializer> constant_initializer = nullptr,
                  std::shared_ptr<KernelGenerator> kernel_gen = nullptr)
-    : onert::backend::BackendContext(backend, graph, tensor_registry),
+    : onert::backend::BackendContext(backend, std::move(data), tensor_registry),
       tensor_builder{tensor_builder}, constant_initializer{constant_initializer}, kernel_gen{
                                                                                     kernel_gen}
   {
   }
 
-  ITensorRegistry *genTensors(const std::vector<onert::ir::OperationIndex> &order,
-                              const compiler::GraphLowerInfo &lower_info) override;
-  FunctionMap genKernels(const std::vector<onert::ir::OperationIndex> &order) override;
+  ITensorRegistry *genTensors() override;
+  FunctionMap genKernels() override;
 
 private:
   void initConsts();
-  void planTensors(const std::vector<onert::ir::OperationIndex> &order,
-                   const compiler::GraphLowerInfo &lower_info);
+  void planTensors();
 
 public:
   std::shared_ptr<TensorBuilder> tensor_builder;

--- a/runtime/onert/backend/acl_cl/Optimizer.cc
+++ b/runtime/onert/backend/acl_cl/Optimizer.cc
@@ -43,12 +43,11 @@ void Optimizer::optimize()
   {
     acl_common::AclSubTensorAnalyzer sa{*_context->graph()};
     sa.setUsePadding();
-    for (auto op_info : _context->operation_list())
-    {
-      auto &op = _context->graph()->operations().at(op_info.index);
-      sa.setLayout(op_info.layout);
-      op.accept(sa);
-    }
+    _context->graph()->operations().iterate(
+      [&](const ir::OperationIndex &, const ir::Operation &op) {
+        sa.setLayout(_context->graph()->layout());
+        op.accept(sa);
+      });
 
     _tensor_builder->parent_map(sa.releaseParentMap());
   }

--- a/runtime/onert/backend/acl_neon/Backend.h
+++ b/runtime/onert/backend/acl_neon/Backend.h
@@ -42,13 +42,12 @@ public:
 
   std::shared_ptr<IConfig> config() const override { return _config; }
 
-  std::unique_ptr<backend::BackendContext>
-  newContext(const ir::Graph &graph, const std::shared_ptr<custom::IKernelBuilder> &,
-             bool is_linear_executor) const override
+  std::unique_ptr<backend::BackendContext> newContext(ContextData &&data) const override
   {
-    const auto &operands = graph.operands();
-    auto context = std::make_unique<acl_neon::BackendContext>(this, &graph);
-    auto tm = createTensorManager(is_linear_executor);
+    const auto &graph = *data.graph;
+    const auto &operands = data.graph->operands();
+    auto context = std::make_unique<acl_neon::BackendContext>(this, std::move(data));
+    auto tm = createTensorManager(data.is_linear_executor);
     auto tr = std::make_shared<acl_common::AclTensorRegistry<TensorManager>>(tm);
     auto tb = std::make_shared<TensorBuilder>(operands, tm);
     context->tensor_registry = tr;

--- a/runtime/onert/backend/acl_neon/BackendContext.cc
+++ b/runtime/onert/backend/acl_neon/BackendContext.cc
@@ -33,46 +33,34 @@ namespace acl_neon
 
 void BackendContext::initConsts()
 {
-  for (auto &op : operation_list())
-  {
-    constant_initializer->setLayout(op.layout);
-    graph()->operations().at(op.index).accept(*constant_initializer);
-  }
+  _data.graph->operations().iterate([&](const ir::OperationIndex &, const ir::Operation &op) {
+    constant_initializer->setLayout(graph()->layout());
+    op.accept(*constant_initializer);
+  });
 
-  for (auto ind : operand_list())
-  {
+  _data.graph->operands().iterate([&](const ir::OperandIndex &ind, const ir::Operand &operand) {
+    if (_data.external_operands.contains(ind) || !operand.isConstant())
+      return;
     const auto &obj = graph()->operands().at(ind);
     if (obj.isConstant() && !constant_initializer->exist(ind))
     {
       constant_initializer->registerDefaultInitializer(ind, obj);
     }
-  }
+  });
 
   constant_initializer->run();
 }
 
-void BackendContext::planTensors(const std::vector<onert::ir::OperationIndex> &order,
-                                 const compiler::GraphLowerInfo &lower_info)
+void BackendContext::planTensors()
 {
   ir::OperandIndexMap<uint32_t> uses_map;
   ir::OperandIndexMap<uint32_t> def_map;
   ir::OperandIndexSequence constants;
 
   // Prepare scanning
-  for (auto ind : operand_list())
-  {
-    const auto &obj = graph()->operands().at(ind);
-    const auto &li = lower_info.operand.at(ind);
-    if (li.def_factors().getOnlyElement().backend() != backend())
-      continue;
-
-    // Ignore unused tensor
-    if (li.def_factors().size() == 0 && li.use_factors().size() == 0)
-    {
-      VERBOSE(planTensors) << "Operand " << ind << " will not be used. no more process."
-                           << std::endl;
+  _data.graph->operands().iterate([&](const ir::OperandIndex &ind, const ir::Operand &obj) {
+    if (_data.external_operands.contains(ind))
       return;
-    }
 
     uses_map[ind] = obj.getUses().size();
     def_map[ind] = obj.getDef().valid() ? 1 : 0;
@@ -80,16 +68,15 @@ void BackendContext::planTensors(const std::vector<onert::ir::OperationIndex> &o
     if (obj.isConstant())
       constants.append(ind);
 
-    auto factor = li.def_factors().getOnlyElement();
     if (!tensor_builder->isRegistered(ind))
     {
       // These tensors do not exist in any operation (No use and def)
       const auto info = obj.info();
-      const auto backend_layout = factor.layout();
+      const auto layout = _data.operand_layouts.at(ind);
       // TODO Change tensor info to have permuted shape
-      tensor_builder->registerTensorInfo(ind, info, backend_layout);
+      tensor_builder->registerTensorInfo(ind, info, layout);
     }
-  }
+  });
 
   // Start scanning to do notify{First|Last}Use for each tensor
 
@@ -107,13 +94,14 @@ void BackendContext::planTensors(const std::vector<onert::ir::OperationIndex> &o
   // 1. Scan DEF of outputs. If the DEF, allocate it
   // 2. Scan DEF of inputs. If variable tensor, allocate it
   // 3. Scan USE of inputs. Decrease the USE and deallocate if the USE is 0
-  for (const auto op_ind : order)
+  for (const auto op_ind : _data.op_order)
   {
-    auto &op = graph()->operations().at(op_ind);
     // TODO Remove indentation
     {
-      auto op_inputs = op.getInputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED;
-      auto op_outputs = op.getOutputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED;
+      auto op_inputs = graph()->operations().at(op_ind).getInputs() | ir::Remove::DUPLICATED |
+                       ir::Remove::UNDEFINED;
+      auto op_outputs = graph()->operations().at(op_ind).getOutputs() | ir::Remove::DUPLICATED |
+                        ir::Remove::UNDEFINED;
 
       // Define outputs
       for (const auto &ind : op_outputs)
@@ -141,8 +129,6 @@ void BackendContext::planTensors(const std::vector<onert::ir::OperationIndex> &o
           // The variable tensor with buffer is not supported yet
           assert(operand.data() == nullptr);
           assert(operand.getUses().size() == 1 && !operand.getDef().valid());
-          assert(lower_info.operand.at(ind).def_factors().size() == 1 &&
-                 lower_info.operand.at(ind).use_factors().size() == 1);
           assert(uses_map[ind] == 1 && def_map[ind] == 0);
           tensor_builder->notifyFirstUse(ind);
         }
@@ -164,6 +150,13 @@ void BackendContext::planTensors(const std::vector<onert::ir::OperationIndex> &o
     }
   }
 
+  _data.graph->operands().iterate([&](const ir::OperandIndex &ind, const ir::Operand &) {
+    if (uses_map[ind] == 0)
+    {
+      tensor_builder->notifyLastUse(ind);
+    }
+  });
+
   // Dispose and validate
   for (const auto &ind : constants)
   {
@@ -183,67 +176,34 @@ void BackendContext::planTensors(const std::vector<onert::ir::OperationIndex> &o
                 [](std::pair<const ir::OperandIndex, uint32_t> it) { return it.second == 0; }));
 }
 
-ITensorRegistry *BackendContext::genTensors(const std::vector<onert::ir::OperationIndex> &order,
-                                            const compiler::GraphLowerInfo &lower_info)
+ITensorRegistry *BackendContext::genTensors()
 {
   optimizer->optimize();
 
-  for (const auto op_ind : order)
-  {
-    const auto &op = graph()->operations().at(op_ind);
-    auto model_io = (graph()->getInputs() + graph()->getOutputs()) | ir::Remove::UNDEFINED |
-                    ir::Remove::DUPLICATED;
-    // TODO Remove indentation
-    {
-      bool op_assigned = [&]() {
-        for (auto &op_info : operation_list())
-          if (op_info.index == op_ind)
-            return true;
-        return false;
-      }();
-      if (!op_assigned)
-        continue;
+  graph()->operands().iterate([&](const ir::OperandIndex &ind, const ir::Operand &obj) {
+    if (external_operands().contains(ind))
+      return;
 
-      for (const auto &index : (op.getInputs() + op.getOutputs()) | ir::Remove::UNDEFINED)
-      {
-        if (!tensor_builder->isRegistered(index) && !model_io.contains(index) &&
-            find(operand_list().begin(), operand_list().end(), index) != operand_list().end())
-        {
-          const auto &operand_lower_info =
-            lower_info.operand.at(index).def_factors().getOnlyElement();
-
-          // E.g., permute (CPU) -> tensor A -> MaxPool2D(acl_cl)
-          // op.getOutputs() of permute (CPU) returns tensor A
-          // but tensor A belongs to the backend of acl_cl.
-          // So, we have to make this tensor NOT registered for CPU.
-          if (operand_lower_info.backend() != backend())
-            continue;
-
-          const auto &obj = graph()->operands().at(index);
-          const auto frontend_layout = graph()->layout();
-          const auto backend_layout = operand_lower_info.layout();
-          ir::OperandInfo backend_info{permuteShape(obj.shape(), frontend_layout, backend_layout),
-                                       obj.typeInfo(), obj.info().memAllocType(), obj.isConstant()};
-          tensor_builder->registerTensorInfo(index, backend_info, backend_layout);
-        }
-      }
-    }
-  }
+    const auto frontend_layout = graph()->layout();
+    const auto backend_layout = operand_layouts().at(ind);
+    ir::OperandInfo backend_info{permuteShape(obj.shape(), frontend_layout, backend_layout),
+                                 obj.typeInfo(), obj.info().memAllocType(), obj.isConstant()};
+    tensor_builder->registerTensorInfo(ind, backend_info, backend_layout);
+  });
 
   // TODO Get compiler options from compiler, and use it rather than getting it from Env
   if (util::getConfigString(util::config::EXECUTOR) == "Linear")
   {
-    planTensors(order, lower_info);
+    planTensors();
   }
   else
   {
     // For the executors that does not have fixed linear execution order:
     // To make tensors never be deallocated, this is a workaround to use static memory planner
-    for (auto ind : operand_list())
-    {
+    graph()->operands().iterate([&](const ir::OperandIndex &ind, const ir::Operand &) {
       if (tensor_builder->isRegistered(ind))
         tensor_builder->notifyFirstUse(ind);
-    }
+    });
   }
 
   tensor_builder->prepare();
@@ -251,18 +211,12 @@ ITensorRegistry *BackendContext::genTensors(const std::vector<onert::ir::Operati
   return tensor_registry.get();
 }
 
-FunctionMap BackendContext::genKernels(const std::vector<onert::ir::OperationIndex> &order)
+FunctionMap BackendContext::genKernels()
 {
   FunctionMap ret;
 
-  for (auto op_ind : order)
+  for (auto op_ind : _data.op_order)
   {
-    // Skip if operation is not assigned to the backend
-    auto &ops = operation_list();
-    bool assigned = std::any_of(ops.begin(), ops.end(),
-                                [&](const OperationInfo &info) { return info.index == op_ind; });
-    if (!assigned)
-      continue;
     auto fn_seq = kernel_gen->generate(op_ind);
     ret.emplace_back(op_ind, std::move(fn_seq));
   }
@@ -271,12 +225,9 @@ FunctionMap BackendContext::genKernels(const std::vector<onert::ir::OperationInd
   initConsts();
 
   // NOTE For memory optimization, we want to free some operand data
-  for (auto ind : operand_list())
-  {
-    // TODO Remove const_cast
-    auto &obj = const_cast<ir::Graph *>(graph())->operands().at(ind);
-    obj.releaseData();
-  }
+  const_cast<ir::Graph &>(*_data.graph)
+    .operands()
+    .iterate([&](const ir::OperandIndex &, ir::Operand &obj) { obj.releaseData(); });
 
   for (auto &it : ret)
   {

--- a/runtime/onert/backend/acl_neon/BackendContext.h
+++ b/runtime/onert/backend/acl_neon/BackendContext.h
@@ -34,25 +34,23 @@ class Optimizer;
 class BackendContext : public onert::backend::BackendContext
 {
 public:
-  BackendContext(const Backend *backend, const ir::Graph *graph,
+  BackendContext(const Backend *backend, ContextData &&data,
                  std::shared_ptr<ITensorRegistry> tensor_registry = nullptr,
                  std::shared_ptr<TensorBuilder> tensor_builder = nullptr,
                  std::shared_ptr<ConstantInitializer> constant_initializer = nullptr,
                  std::shared_ptr<KernelGenerator> kernel_gen = nullptr)
-    : onert::backend::BackendContext(backend, graph, tensor_registry),
+    : onert::backend::BackendContext(backend, std::move(data), tensor_registry),
       tensor_builder{tensor_builder}, constant_initializer{constant_initializer}, kernel_gen{
                                                                                     kernel_gen}
   {
   }
 
-  ITensorRegistry *genTensors(const std::vector<onert::ir::OperationIndex> &order,
-                              const compiler::GraphLowerInfo &lower_info) override;
-  FunctionMap genKernels(const std::vector<onert::ir::OperationIndex> &order) override;
+  ITensorRegistry *genTensors() override;
+  FunctionMap genKernels() override;
 
 private:
   void initConsts();
-  void planTensors(const std::vector<onert::ir::OperationIndex> &order,
-                   const compiler::GraphLowerInfo &lower_info);
+  void planTensors();
 
 public:
   // TODO Make it private

--- a/runtime/onert/backend/acl_neon/Optimizer.cc
+++ b/runtime/onert/backend/acl_neon/Optimizer.cc
@@ -42,14 +42,12 @@ void Optimizer::optimize()
   // Concat elimination (build subtensor info)
   {
     acl_common::AclSubTensorAnalyzer sa{*_context->graph()};
-    for (auto op_info : _context->operation_list())
-    {
-      auto &op = _context->graph()->operations().at(op_info.index);
-      sa.setLayout(op_info.layout);
-      op.accept(sa);
-    }
-
-    _tensor_builder->parent_map(sa.releaseParentMap());
+    sa.setUsePadding();
+    _context->graph()->operations().iterate(
+      [&](const ir::OperationIndex &, const ir::Operation &op) {
+        sa.setLayout(_context->graph()->layout());
+        op.accept(sa);
+      });
   }
 }
 

--- a/runtime/onert/backend/cpu/Backend.h
+++ b/runtime/onert/backend/cpu/Backend.h
@@ -39,17 +39,17 @@ public:
 
   std::shared_ptr<IConfig> config() const override { return _config; }
 
-  std::unique_ptr<onert::backend::BackendContext>
-  newContext(const ir::Graph &graph, const std::shared_ptr<custom::IKernelBuilder> &kb,
-             bool) const override
+  std::unique_ptr<onert::backend::BackendContext> newContext(ContextData &&data) const override
   {
-    auto context = std::make_unique<BackendContext>(this, &graph);
+    auto custom_kernel_builder = data.custom_kernel_builder;
+    auto &graph = *data.graph;
+    auto context = std::make_unique<BackendContext>(this, std::move(data));
     auto tr = std::make_shared<cpu_common::TensorRegistry>();
     auto tb = std::make_shared<TensorBuilder>(tr);
     context->tensor_registry = tr;
     context->tensor_builder = tb;
-    context->kernel_gen =
-      std::make_shared<KernelGenerator>(graph, tb, tr, kb, context->external_context());
+    context->kernel_gen = std::make_shared<KernelGenerator>(graph, tb, tr, custom_kernel_builder,
+                                                            context->external_context());
     return context;
   }
 

--- a/runtime/onert/backend/cpu/BackendContext.cc
+++ b/runtime/onert/backend/cpu/BackendContext.cc
@@ -31,24 +31,14 @@ namespace backend
 namespace cpu
 {
 
-ITensorRegistry *BackendContext::genTensors(const std::vector<onert::ir::OperationIndex> &order,
-                                            const compiler::GraphLowerInfo &lower_info)
-{
-  return cpu_common::genTensors(*this, order, lower_info);
-}
+ITensorRegistry *BackendContext::genTensors() { return cpu_common::genTensors(*this); }
 
-FunctionMap BackendContext::genKernels(const std::vector<onert::ir::OperationIndex> &order)
+FunctionMap BackendContext::genKernels()
 {
   FunctionMap ret;
 
-  for (auto op_ind : order)
+  for (auto op_ind : _data.op_order)
   {
-    // Skip if operation is not assigned to the backend
-    auto &ops = operation_list();
-    bool assigned = std::any_of(ops.begin(), ops.end(),
-                                [&](const OperationInfo &info) { return info.index == op_ind; });
-    if (!assigned)
-      continue;
     auto fn_seq = kernel_gen->generate(op_ind);
     ret.emplace_back(op_ind, std::move(fn_seq));
   }
@@ -56,12 +46,9 @@ FunctionMap BackendContext::genKernels(const std::vector<onert::ir::OperationInd
   cpu_common::initConsts(*this);
 
   // NOTE For memory optimization, we want to free some operand data
-  for (auto ind : operand_list())
-  {
-    // TODO Remove const_cast
-    auto &obj = const_cast<ir::Graph *>(graph())->operands().at(ind);
-    obj.releaseData();
-  }
+  const_cast<ir::Graph &>(*_data.graph)
+    .operands()
+    .iterate([&](const ir::OperandIndex &, ir::Operand &obj) { obj.releaseData(); });
 
   for (auto &it : ret)
   {

--- a/runtime/onert/backend/cpu/BackendContext.h
+++ b/runtime/onert/backend/cpu/BackendContext.h
@@ -32,24 +32,19 @@ namespace cpu
 class BackendContext : public onert::backend::BackendContext
 {
 public:
-  BackendContext(const Backend *backend, const ir::Graph *graph,
+  BackendContext(const Backend *backend, ContextData &&data,
                  std::shared_ptr<ITensorRegistry> tensor_registry = nullptr,
                  std::shared_ptr<TensorBuilder> tensor_builder = nullptr,
                  std::shared_ptr<KernelGenerator> kernel_gen = nullptr)
-    : onert::backend::BackendContext(backend, graph, tensor_registry),
+    : onert::backend::BackendContext(backend, std::move(data), tensor_registry),
       tensor_builder{tensor_builder}, kernel_gen{kernel_gen}, _external_context(new ExternalContext)
   {
   }
 
-  ITensorRegistry *genTensors(const std::vector<onert::ir::OperationIndex> &order,
-                              const compiler::GraphLowerInfo &lower_info) override;
-  FunctionMap genKernels(const std::vector<onert::ir::OperationIndex> &order) override;
+  ITensorRegistry *genTensors() override;
+  FunctionMap genKernels() override;
 
   std::shared_ptr<ExternalContext> external_context() { return _external_context; }
-
-private:
-  void planTensors(const std::vector<onert::ir::OperationIndex> &order,
-                   const compiler::GraphLowerInfo &lower_info);
 
 public:
   // TODO Make it private

--- a/runtime/onert/backend/ruy/Backend.h
+++ b/runtime/onert/backend/ruy/Backend.h
@@ -39,17 +39,17 @@ public:
 
   std::shared_ptr<IConfig> config() const override { return _config; }
 
-  std::unique_ptr<onert::backend::BackendContext>
-  newContext(const ir::Graph &graph, const std::shared_ptr<custom::IKernelBuilder> &kb,
-             bool) const override
+  std::unique_ptr<onert::backend::BackendContext> newContext(ContextData &&data) const override
   {
-    auto context = std::make_unique<BackendContext>(this, &graph);
+    auto custom_kernel_builder = data.custom_kernel_builder;
+    auto &graph = *data.graph;
+    auto context = std::make_unique<BackendContext>(this, std::move(data));
     auto tr = std::make_shared<cpu_common::TensorRegistry>();
     auto tb = std::make_shared<TensorBuilder>(tr);
     context->tensor_registry = tr;
     context->tensor_builder = tb;
-    context->kernel_gen =
-      std::make_shared<KernelGenerator>(graph, tb, tr, kb, context->external_context());
+    context->kernel_gen = std::make_shared<KernelGenerator>(graph, tb, tr, custom_kernel_builder,
+                                                            context->external_context());
     return context;
   }
 

--- a/runtime/onert/backend/ruy/BackendContext.cc
+++ b/runtime/onert/backend/ruy/BackendContext.cc
@@ -31,24 +31,14 @@ namespace backend
 namespace ruy
 {
 
-ITensorRegistry *BackendContext::genTensors(const std::vector<onert::ir::OperationIndex> &order,
-                                            const compiler::GraphLowerInfo &lower_info)
-{
-  return cpu_common::genTensors(*this, order, lower_info);
-}
+ITensorRegistry *BackendContext::genTensors() { return cpu_common::genTensors(*this); }
 
-FunctionMap BackendContext::genKernels(const std::vector<onert::ir::OperationIndex> &order)
+FunctionMap BackendContext::genKernels()
 {
   FunctionMap ret;
 
-  for (auto op_ind : order)
+  for (auto op_ind : _data.op_order)
   {
-    // Skip if operation is not assigned to the backend
-    auto &ops = operation_list();
-    bool assigned = std::any_of(ops.begin(), ops.end(),
-                                [&](const OperationInfo &info) { return info.index == op_ind; });
-    if (!assigned)
-      continue;
     auto fn_seq = kernel_gen->generate(op_ind);
     ret.emplace_back(op_ind, std::move(fn_seq));
   }
@@ -56,12 +46,9 @@ FunctionMap BackendContext::genKernels(const std::vector<onert::ir::OperationInd
   cpu_common::initConsts(*this);
 
   // NOTE For memory optimization, we want to free some operand data
-  for (auto ind : operand_list())
-  {
-    // TODO Remove const_cast
-    auto &obj = const_cast<ir::Graph *>(graph())->operands().at(ind);
-    obj.releaseData();
-  }
+  const_cast<ir::Graph &>(*_data.graph)
+    .operands()
+    .iterate([&](const ir::OperandIndex &, ir::Operand &obj) { obj.releaseData(); });
 
   for (auto &it : ret)
   {

--- a/runtime/onert/backend/ruy/BackendContext.h
+++ b/runtime/onert/backend/ruy/BackendContext.h
@@ -32,19 +32,18 @@ namespace ruy
 class BackendContext : public onert::backend::BackendContext
 {
 public:
-  BackendContext(const Backend *backend, const ir::Graph *graph,
+  BackendContext(const Backend *backend, ContextData &&data,
                  std::shared_ptr<ITensorRegistry> tensor_registry = nullptr,
                  std::shared_ptr<TensorBuilder> tensor_builder = nullptr,
                  std::shared_ptr<KernelGenerator> kernel_gen = nullptr)
-    : onert::backend::BackendContext(backend, graph, tensor_registry),
+    : onert::backend::BackendContext(backend, std::move(data), tensor_registry),
       tensor_builder{tensor_builder}, kernel_gen{kernel_gen}, _external_context(new ExternalContext)
   {
   }
 
-  ITensorRegistry *genTensors(const std::vector<onert::ir::OperationIndex> &order,
-                              const compiler::GraphLowerInfo &lower_info) override;
+  ITensorRegistry *genTensors() override;
 
-  FunctionMap genKernels(const std::vector<ir::OperationIndex> &order) override;
+  FunctionMap genKernels() override;
 
   std::shared_ptr<ExternalContext> external_context() { return _external_context; }
 

--- a/runtime/onert/backend/xnnpack/Backend.h
+++ b/runtime/onert/backend/xnnpack/Backend.h
@@ -39,17 +39,17 @@ public:
 
   std::shared_ptr<IConfig> config() const override { return _config; }
 
-  std::unique_ptr<onert::backend::BackendContext>
-  newContext(const ir::Graph &graph, const std::shared_ptr<custom::IKernelBuilder> &kb,
-             bool) const override
+  std::unique_ptr<onert::backend::BackendContext> newContext(ContextData &&data) const override
   {
-    auto context = std::make_unique<BackendContext>(this, &graph);
+    auto custom_kernel_builder = data.custom_kernel_builder;
+    auto &graph = *data.graph;
+    auto context = std::make_unique<BackendContext>(this, std::move(data));
     auto tr = std::make_shared<cpu_common::TensorRegistry>();
     auto tb = std::make_shared<TensorBuilder>(tr);
     context->tensor_registry = tr;
     context->tensor_builder = tb;
-    context->kernel_gen =
-      std::make_shared<KernelGenerator>(graph, tb, tr, kb, context->external_context());
+    context->kernel_gen = std::make_shared<KernelGenerator>(graph, tb, tr, custom_kernel_builder,
+                                                            context->external_context());
     return context;
   }
 

--- a/runtime/onert/backend/xnnpack/BackendContext.cc
+++ b/runtime/onert/backend/xnnpack/BackendContext.cc
@@ -31,24 +31,14 @@ namespace backend
 namespace xnnpack
 {
 
-ITensorRegistry *BackendContext::genTensors(const std::vector<onert::ir::OperationIndex> &order,
-                                            const compiler::GraphLowerInfo &lower_info)
-{
-  return cpu_common::genTensors(*this, order, lower_info);
-}
+ITensorRegistry *BackendContext::genTensors() { return cpu_common::genTensors(*this); }
 
-FunctionMap BackendContext::genKernels(const std::vector<onert::ir::OperationIndex> &order)
+FunctionMap BackendContext::genKernels()
 {
   FunctionMap ret;
 
-  for (auto op_ind : order)
+  for (auto op_ind : _data.op_order)
   {
-    // Skip if operation is not assigned to the backend
-    auto &ops = operation_list();
-    bool assigned = std::any_of(ops.begin(), ops.end(),
-                                [&](const OperationInfo &info) { return info.index == op_ind; });
-    if (!assigned)
-      continue;
     auto fn_seq = kernel_gen->generate(op_ind);
     ret.emplace_back(op_ind, std::move(fn_seq));
   }
@@ -56,12 +46,9 @@ FunctionMap BackendContext::genKernels(const std::vector<onert::ir::OperationInd
   cpu_common::initConsts(*this);
 
   // NOTE For memory optimization, we want to free some operand data
-  for (auto ind : operand_list())
-  {
-    // TODO Remove const_cast
-    auto &obj = const_cast<ir::Graph *>(graph())->operands().at(ind);
-    obj.releaseData();
-  }
+  const_cast<ir::Graph &>(*_data.graph)
+    .operands()
+    .iterate([&](const ir::OperandIndex &, ir::Operand &obj) { obj.releaseData(); });
 
   for (auto &it : ret)
   {

--- a/runtime/onert/backend/xnnpack/BackendContext.h
+++ b/runtime/onert/backend/xnnpack/BackendContext.h
@@ -35,11 +35,11 @@ namespace xnnpack
 class BackendContext : public onert::backend::BackendContext
 {
 public:
-  BackendContext(const Backend *backend, const ir::Graph *graph,
+  BackendContext(const Backend *backend, ContextData &&data,
                  std::shared_ptr<ITensorRegistry> tensor_registry = nullptr,
                  std::shared_ptr<TensorBuilder> tensor_builder = nullptr,
                  std::shared_ptr<KernelGenerator> kernel_gen = nullptr)
-    : onert::backend::BackendContext(backend, graph, tensor_registry),
+    : onert::backend::BackendContext(backend, std::move(data), tensor_registry),
       tensor_builder{tensor_builder}, kernel_gen{kernel_gen}, _external_context(nullptr)
   {
     int num_threads = util::getConfigInt(util::config::XNNPACK_THREADS);
@@ -48,10 +48,8 @@ public:
     _external_context.reset(new ExternalContext(static_cast<size_t>(num_threads)));
   }
 
-  ITensorRegistry *genTensors(const std::vector<onert::ir::OperationIndex> &order,
-                              const compiler::GraphLowerInfo &lower_info) override;
-
-  FunctionMap genKernels(const std::vector<ir::OperationIndex> &order) override;
+  ITensorRegistry *genTensors() override;
+  FunctionMap genKernels() override;
 
   std::shared_ptr<ExternalContext> external_context() { return _external_context; }
 

--- a/runtime/onert/core/include/backend/Backend.h
+++ b/runtime/onert/core/include/backend/Backend.h
@@ -39,9 +39,7 @@ public:
   virtual ~Backend() = default;
   virtual std::shared_ptr<onert::backend::IConfig> config() const = 0;
 
-  virtual std::unique_ptr<BackendContext>
-  newContext(const ir::Graph &graph, const std::shared_ptr<backend::custom::IKernelBuilder> &kb,
-             bool is_linear_executor) const = 0;
+  virtual std::unique_ptr<BackendContext> newContext(ContextData &&) const = 0;
 };
 
 } // namespace backend

--- a/runtime/onert/core/include/backend/BackendContext.h
+++ b/runtime/onert/core/include/backend/BackendContext.h
@@ -19,6 +19,8 @@
 
 #include <memory>
 #include "ir/Graph.h"
+#include "ir/OperationIndexMap.h"
+#include "ir/OperandIndexMap.h"
 #include "compiler/GraphLowerInfo.h"
 #include "exec/FunctionSequence.h"
 
@@ -33,46 +35,45 @@ struct ITensorRegistry;
 using FunctionMap =
   std::vector<std::pair<ir::OperationIndex, std::unique_ptr<exec::FunctionSequence>>>;
 
+struct ContextData
+{
+  /* A partial graph that only includes used operand/operations of the original graph */
+  std::unique_ptr<ir::Graph> graph;
+  /* A linear order of operations. This is neccessary for when a graph is not fully connected */
+  std::vector<onert::ir::OperationIndex> op_order;
+  /* Operands that are defined by other backends */
+  util::Set<ir::OperandIndex> external_operands;
+  /* Operand layout info */
+  ir::OperandIndexMap<ir::Layout> operand_layouts;
+  /* Custom kernel builder */
+  std::shared_ptr<custom::IKernelBuilder> custom_kernel_builder;
+  /* Is linear executor or not */
+  bool is_linear_executor;
+};
+
 class BackendContext
 {
 public:
-  struct OperationInfo
-  {
-    ir::OperationIndex index;
-    ir::Layout layout;
-
-    OperationInfo(ir::OperationIndex index, ir::Layout layout) : index{index}, layout{layout} {}
-  };
-
-public:
-  BackendContext(const Backend *backend, const ir::Graph *graph,
+  BackendContext(const Backend *backend, ContextData &&data,
                  std::shared_ptr<ITensorRegistry> tensor_registry = nullptr)
-    : _backend{backend}, _graph{graph}, tensor_registry{tensor_registry}
+    : _backend{backend}, _data{std::move(data)}, tensor_registry{tensor_registry}
   {
   }
 
   virtual ~BackendContext() = default;
 
-  void initialize(const std::vector<OperationInfo> &operation_list,
-                  const std::vector<ir::OperandIndex> &operand_list);
-
   const Backend *backend() const { return _backend; }
-  const ir::Graph *graph() const { return _graph; }
-  const std::vector<OperationInfo> &operation_list() const { return _operation_list; }
-  const std::vector<ir::OperandIndex> &operand_list() const { return _operand_list; }
+  const ir::Graph *graph() const { return _data.graph.get(); }
+  const util::Set<ir::OperandIndex> &external_operands() const { return _data.external_operands; }
+  const ir::OperandIndexMap<ir::Layout> &operand_layouts() const { return _data.operand_layouts; }
+  const ContextData &data() const { return _data; }
 
-  virtual ITensorRegistry *genTensors(const std::vector<onert::ir::OperationIndex> &,
-                                      const compiler::GraphLowerInfo &)
-  {
-    return nullptr;
-  }
-  virtual FunctionMap genKernels(const std::vector<onert::ir::OperationIndex> &) { return {}; }
+  virtual ITensorRegistry *genTensors() { return nullptr; }
+  virtual FunctionMap genKernels() { return {}; }
 
-private:
+protected:
   const Backend *_backend{nullptr};
-  const ir::Graph *_graph{nullptr};
-  std::vector<OperationInfo> _operation_list;
-  std::vector<ir::OperandIndex> _operand_list;
+  ContextData _data;
 
 public:
   std::shared_ptr<ITensorRegistry> tensor_registry;

--- a/runtime/onert/core/include/ir/Graph.h
+++ b/runtime/onert/core/include/ir/Graph.h
@@ -92,6 +92,8 @@ public:
 
 private:
   void initializeUseDef();
+  // TODO Rename to `sweepUnusedOperands`
+  // TODO Make this public
   void sweepGarbageOperands();
 
   // Custom operations support

--- a/runtime/onert/core/include/util/ObjectManager.h
+++ b/runtime/onert/core/include/util/ObjectManager.h
@@ -24,6 +24,8 @@
 
 #include <memory>
 
+#include "util/logging.h"
+
 namespace onert
 {
 namespace util

--- a/runtime/onert/core/src/backend/BackendContext.cc
+++ b/runtime/onert/core/src/backend/BackendContext.cc
@@ -23,12 +23,5 @@ namespace onert
 namespace backend
 {
 
-void BackendContext::initialize(const std::vector<OperationInfo> &operation_list,
-                                const std::vector<ir::OperandIndex> &operand_list)
-{
-  _operation_list = operation_list;
-  _operand_list = operand_list;
-}
-
 } // namespace backend
 } // namespace onert

--- a/runtime/onert/core/src/backend/builtin/Backend.h
+++ b/runtime/onert/core/src/backend/builtin/Backend.h
@@ -41,11 +41,9 @@ public:
 
   std::shared_ptr<IConfig> config() const override { return _config; }
 
-  std::unique_ptr<onert::backend::BackendContext>
-  newContext(const ir::Graph &graph, const std::shared_ptr<custom::IKernelBuilder> &,
-             bool) const override
+  std::unique_ptr<onert::backend::BackendContext> newContext(ContextData &&data) const override
   {
-    auto context = std::make_unique<BackendContext>(this, &graph);
+    auto context = std::make_unique<BackendContext>(this, std::move(data));
     // ControlFlow backend may not build tensors for itself because the backend's operation uses
     // tensors of other baceknd instead
     // But the backend builds tensors in case of that the controlflow operation may have constant
@@ -67,8 +65,8 @@ public:
     auto tb = std::make_shared<TensorBuilder>(tr);
     context->tensor_registry = tr;
     context->tensor_builder = tb;
-    context->kernel_gen = std::make_shared<KernelGenerator>(graph, tb->dynamicTensorManager(), tr,
-                                                            context->external_context());
+    context->kernel_gen = std::make_shared<KernelGenerator>(
+      *context->graph(), tb->dynamicTensorManager(), tr, context->external_context());
     return context;
   }
 

--- a/runtime/onert/core/src/backend/builtin/BackendContext.cc
+++ b/runtime/onert/core/src/backend/builtin/BackendContext.cc
@@ -26,24 +26,14 @@ namespace backend
 namespace builtin
 {
 
-ITensorRegistry *BackendContext::genTensors(const std::vector<onert::ir::OperationIndex> &order,
-                                            const compiler::GraphLowerInfo &lower_info)
-{
-  return cpu_common::genTensors(*this, order, lower_info);
-}
+ITensorRegistry *BackendContext::genTensors() { return cpu_common::genTensors(*this); }
 
-FunctionMap BackendContext::genKernels(const std::vector<ir::OperationIndex> &order)
+FunctionMap BackendContext::genKernels()
 {
   FunctionMap ret;
 
-  for (auto op_ind : order)
+  for (auto op_ind : _data.op_order)
   {
-    // Skip if operation is not assigned to the backend
-    auto &ops = operation_list();
-    bool assigned = std::any_of(ops.begin(), ops.end(),
-                                [&](const OperationInfo &info) { return info.index == op_ind; });
-    if (!assigned)
-      continue;
     auto fn_seq = kernel_gen->generate(op_ind);
     ret.emplace_back(op_ind, std::move(fn_seq));
   }
@@ -51,12 +41,8 @@ FunctionMap BackendContext::genKernels(const std::vector<ir::OperationIndex> &or
   cpu_common::initConsts(*this);
 
   // NOTE For memory optimization, we want to free some operand data
-  for (auto ind : operand_list())
-  {
-    // TODO Remove const_cast
-    auto &obj = const_cast<ir::Graph *>(graph())->operands().at(ind);
-    obj.releaseData();
-  }
+  const_cast<ir::Graph *>(graph())->operands().iterate(
+    [&](const ir::OperandIndex &, ir::Operand &obj) { obj.releaseData(); });
 
   for (auto &it : ret)
   {

--- a/runtime/onert/core/src/backend/builtin/BackendContext.h
+++ b/runtime/onert/core/src/backend/builtin/BackendContext.h
@@ -32,20 +32,19 @@ namespace builtin
 class BackendContext : public onert::backend::BackendContext
 {
 public:
-  BackendContext(const Backend *backend, const ir::Graph *graph,
+  BackendContext(const Backend *backend, ContextData &&data,
                  std::shared_ptr<ITensorRegistry> tensor_registry = nullptr,
                  std::shared_ptr<TensorBuilder> tensor_builder = nullptr,
                  std::shared_ptr<KernelGenerator> kernel_gen = nullptr)
-    : onert::backend::BackendContext(backend, graph, tensor_registry),
+    : onert::backend::BackendContext(backend, std::move(data), tensor_registry),
       tensor_builder{tensor_builder}, kernel_gen{kernel_gen},
       _external_context(std::make_shared<ExternalContext>())
   {
   }
 
-  ITensorRegistry *genTensors(const std::vector<onert::ir::OperationIndex> &order,
-                              const compiler::GraphLowerInfo &lower_info) override;
+  ITensorRegistry *genTensors() override;
 
-  FunctionMap genKernels(const std::vector<ir::OperationIndex> &order) override;
+  FunctionMap genKernels() override;
 
   std::shared_ptr<ExternalContext> external_context() { return _external_context; }
 

--- a/runtime/onert/core/src/backend/builtin/TensorBuilder.cc
+++ b/runtime/onert/core/src/backend/builtin/TensorBuilder.cc
@@ -40,6 +40,7 @@ void TensorBuilder::registerTensorInfo(const ir::OperandIndex &ind, const ir::Op
 {
   _tensor_info_map.emplace(ind, info);
 
+  VERBOSE_F() << "cpucommon REGISTER!! " << ind << std::endl;
   if (info.isDynamic())
   {
     _dynamic_tensor_mgr->buildTensor(ind, info, backend_layout);

--- a/runtime/onert/core/src/compiler/ExecutorFactory.h
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.h
@@ -43,8 +43,6 @@ private:
   ExecutorFactory();
 
 private:
-  static void initializeBackendContext(compiler::LoweredGraph *lowered_graph,
-                                       const backend::BackendContexts &backend_contexts);
   static void prepareMigrantTensors(compiler::LoweredGraph &lowered_graph,
                                     const backend::BackendContexts &backend_contexts);
   static exec::IExecutor *

--- a/runtime/onert/core/src/ir/Graph.cc
+++ b/runtime/onert/core/src/ir/Graph.cc
@@ -70,7 +70,6 @@ void Graph::setOperandValue(const OperandIndex &ind, std::shared_ptr<Data> data)
 
 void Graph::addInput(const OperandIndex &ind, const std::string &name)
 {
-  assert(isBuildingPhase());
   if (!name.empty())
     _name_to_input.emplace(name, IOIndex{_inputs.size()});
   _inputs.append(ind);
@@ -78,7 +77,6 @@ void Graph::addInput(const OperandIndex &ind, const std::string &name)
 
 void Graph::addOutput(const OperandIndex &ind, const std::string &name)
 {
-  assert(isBuildingPhase());
   if (!name.empty())
     _name_to_output.emplace(name, IOIndex{_outputs.size()});
   _outputs.append(ind);
@@ -102,7 +100,8 @@ void Graph::finishBuilding(void)
   _phase = Phase::MODEL;
 
   initializeUseDef();
-  sweepGarbageOperands();
+  // Temporarilly disabled since it may cause error for partial graphs of backend contexts
+  // sweepGarbageOperands();
 
   // Call graph verifications for the MODEL phase
   {

--- a/runtime/onert/core/src/ir/OperationCloner.cc
+++ b/runtime/onert/core/src/ir/OperationCloner.cc
@@ -25,6 +25,7 @@ namespace ir
 
 namespace
 {
+
 class OperationCloner : public OperationVisitor
 {
 public:

--- a/runtime/onert/core/src/ir/OperationValidator.cc
+++ b/runtime/onert/core/src/ir/OperationValidator.cc
@@ -17,6 +17,7 @@
 #include "OperationValidator.h"
 
 #include "ir/Graph.h"
+#include "util/logging.h"
 
 #define OP_REQUIRES(EXP)                                                                         \
   do                                                                                             \

--- a/runtime/onert/test/core/compiler/HEScheduler.cc
+++ b/runtime/onert/test/core/compiler/HEScheduler.cc
@@ -52,10 +52,9 @@ struct MockConfigCPU : public IConfig
 struct MockBackendCPU : public Backend
 {
   std::shared_ptr<IConfig> config() const override { return std::make_shared<MockConfigCPU>(); }
-  std::unique_ptr<BackendContext>
-  newContext(const Graph &, const std::shared_ptr<custom::IKernelBuilder> &, bool) const override
+  std::unique_ptr<BackendContext> newContext(ContextData &&data) const override
   {
-    return std::unique_ptr<BackendContext>(new BackendContext{this, nullptr});
+    return std::make_unique<BackendContext>(this, std::move(data), nullptr);
   }
 };
 
@@ -75,10 +74,9 @@ struct MockConfigGPU : public IConfig
 struct MockBackendGPU : public Backend
 {
   std::shared_ptr<IConfig> config() const override { return std::make_shared<MockConfigGPU>(); }
-  std::unique_ptr<BackendContext>
-  newContext(const Graph &, const std::shared_ptr<custom::IKernelBuilder> &, bool) const override
+  std::unique_ptr<BackendContext> newContext(ContextData &&data) const override
   {
-    return std::unique_ptr<BackendContext>(new BackendContext{this, nullptr});
+    return std::make_unique<BackendContext>(this, std::move(data), nullptr);
   }
 };
 
@@ -98,10 +96,9 @@ struct MockConfigNPU : public IConfig
 struct MockBackendNPU : public Backend
 {
   std::shared_ptr<IConfig> config() const override { return std::make_shared<MockConfigNPU>(); }
-  std::unique_ptr<BackendContext>
-  newContext(const Graph &, const std::shared_ptr<custom::IKernelBuilder> &, bool) const override
+  std::unique_ptr<BackendContext> newContext(ContextData &&data) const override
   {
-    return std::unique_ptr<BackendContext>(new BackendContext{this, nullptr});
+    return std::make_unique<BackendContext>(this, std::move(data), nullptr);
   }
 };
 

--- a/runtime/onert/test/core/exec/ExecTime.test.cc
+++ b/runtime/onert/test/core/exec/ExecTime.test.cc
@@ -45,9 +45,7 @@ struct MockBackend : public ::onert::backend::Backend
   {
     return std::make_shared<MockConfig>();
   }
-  std::unique_ptr<BackendContext> newContext(const ir::Graph &,
-                                             const std::shared_ptr<custom::IKernelBuilder> &kb,
-                                             bool) const override
+  std::unique_ptr<onert::backend::BackendContext> newContext(ContextData &&) const override
   {
     return nullptr;
   }


### PR DESCRIPTION
Pass a partial graph when creating a BackendContext. "partial graph"
here means a subset of an original graph that contains
operations/operands used by a backend. Before this commit, each backend
had a reference to the whole graph which could be abused and error-prone.

- Remove `initializeBackendContext` - as a partial graph is passed for
  each graph, we do not need to build used operation/operand lists
  anymore
- Introduce `ContextData` which contains all the data for the backend
  - Make parameter of `Backend::newContext` simple - pass a single
    struct `ContextData` instead
  - Make `BackendContext` methods(`genTensors` and `genKernels`) not
    have any parameters, just use `ContextData`.

More Context : #5006 , https://github.com/Samsung/ONE/issues/5352#issuecomment-747361763

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>