### PR TITLE
[circle2circle-dredd-recipe-test] Add Net_BroadcastTo_AddV2

### DIFF
--- a/compiler/circle2circle-dredd-recipe-test/test.lst
+++ b/compiler/circle2circle-dredd-recipe-test/test.lst
@@ -11,6 +11,8 @@
 ## TFLITE RECIPE
 
 Add(Net_Preactivation_BN_000 PASS fuse_preactivation_batchnorm)
+Add(Net_BroadcastTo_AddV2_000 PASS resolve_customop_add)
+Add(Net_BroadcastTo_AddV2_001 PASS resolve_customop_add)
 Add(Net_Conv_Add_Mul_000 PASS fuse_batchnorm_with_conv)
 Add(Net_Conv_Add_Mul_001 PASS fuse_batchnorm_with_conv)
 Add(Net_Conv_Add_Mul_002 PASS fuse_batchnorm_with_conv)


### PR DESCRIPTION
This commit adds Net_BroadcastTo_AddV2 to the test list.

Related : #5786
Draft: #5814
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>