### PR TITLE
[luci] Add const keyword to parameter of CircleNodeID functions

### DIFF
--- a/compiler/luci/profile/include/luci/Profile/CircleNodeID.h
+++ b/compiler/luci/profile/include/luci/Profile/CircleNodeID.h
@@ -24,11 +24,11 @@ namespace luci
 
 using CircleNodeID = uint32_t;
 
-bool has_node_id(luci::CircleNode *circle_node);
+bool has_node_id(const luci::CircleNode *circle_node);
 
 void set_node_id(luci::CircleNode *circle_node, CircleNodeID id);
 
-CircleNodeID get_node_id(luci::CircleNode *circle_node);
+CircleNodeID get_node_id(const luci::CircleNode *circle_node);
 
 } // namespace luci
 

--- a/compiler/luci/profile/src/CircleNodeID.cpp
+++ b/compiler/luci/profile/src/CircleNodeID.cpp
@@ -51,7 +51,7 @@ private:
 namespace luci
 {
 
-bool has_node_id(luci::CircleNode *circle_node)
+bool has_node_id(const luci::CircleNode *circle_node)
 {
   return circle_node->annot<CircleNodeIDAnnotation>() != nullptr;
 }
@@ -62,7 +62,7 @@ void set_node_id(luci::CircleNode *circle_node, luci::CircleNodeID id)
   circle_node->annot(std::make_unique<CircleNodeIDAnnotation>(id));
 }
 
-luci::CircleNodeID get_node_id(luci::CircleNode *circle_node)
+luci::CircleNodeID get_node_id(const luci::CircleNode *circle_node)
 {
   if (!has_node_id(circle_node))
     throw std::runtime_error("Cannot find CircleNodeID");


### PR DESCRIPTION
`has_node_id` and `get_node_id` functions have no needs to change `circle_node`.
Therefore adding `const` keyword to them is safe.
This commit will add `const` keyword to parameters of `CircleNodeID` functions.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>