### PR TITLE
[onert] Introduce Operand::clearDefUse

### DIFF
--- a/runtime/onert/core/include/ir/Operand.h
+++ b/runtime/onert/core/include/ir/Operand.h
@@ -55,6 +55,7 @@ public:
   void removeUse(const OperationIndex &idx);
   void setDef(const OperationIndex &idx);
   void unsetDef();
+  void clearDefUse();
 
 public:
   void type(const DataType type) { _info.type(type); };

--- a/runtime/onert/core/src/compiler/ExecutorFactory.cc
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.cc
@@ -131,10 +131,8 @@ backend::BackendContexts createBackendContexts(const compiler::LoweredGraph &lgr
 
       // Copy the operand and insert it to the partial graph
       auto new_operand = std::make_unique<ir::Operand>(operand);
-      // TODO Introduce a method for resetting use/def values of Operand
       // NOTE Use/Def info is going to be filled in `Graph::finishBuilding`
-      const_cast<ir::OperationIndexSet &>(new_operand->getUses()).clear();
-      new_operand->unsetDef();
+      new_operand->clearDefUse();
       auto new_operand_ind = partial_graph.addOperand(operand_ind, std::move(new_operand));
       UNUSED_RELEASE(new_operand_ind);
       assert(new_operand_ind == operand_ind);
@@ -160,10 +158,8 @@ backend::BackendContexts createBackendContexts(const compiler::LoweredGraph &lgr
           // Copy the operand and insert it to the partial graph
           const auto &operand = whole_graph.operands().at(operand_ind);
           auto new_operand = std::make_unique<ir::Operand>(operand);
-          // TODO Introduce a method for resetting use/def values of Operand
           // NOTE Use/Def info is going to be filled in `Graph::finishBuilding`
-          const_cast<ir::OperationIndexSet &>(new_operand->getUses()).clear();
-          new_operand->unsetDef();
+          new_operand->clearDefUse();
           auto new_operand_ind = partial_graph.addOperand(operand_ind, std::move(new_operand));
           UNUSED_RELEASE(new_operand_ind);
           assert(new_operand_ind == operand_ind);

--- a/runtime/onert/core/src/compiler/pass/ConstantInsertionPass.cc
+++ b/runtime/onert/core/src/compiler/pass/ConstantInsertionPass.cc
@@ -45,9 +45,7 @@ void ConstantInsertionPass::callback(const ir::OperationIndex &node_index, ir::O
       if (_replace_operands_map.count(key) == 0)
       {
         ir::Operand new_object(object);
-        new_object.unsetDef();
-        // TODO Remove const_case
-        const_cast<ir::OperationIndexSet &>(new_object.getUses()).clear();
+        new_object.clearDefUse();
         const auto new_index = _graph.operands().emplace(new_object);
         _replace_operands_map[key] = new_index;
       }

--- a/runtime/onert/core/src/ir/Operand.cc
+++ b/runtime/onert/core/src/ir/Operand.cc
@@ -46,5 +46,11 @@ void Operand::setDef(const OperationIndex &idx) { _def = idx; }
 
 void Operand::unsetDef() { _def = OperationIndex{}; }
 
+void Operand::clearDefUse()
+{
+  unsetDef();
+  _uses.clear();
+}
+
 } // namespace ir
 } // namespace onert


### PR DESCRIPTION
Introduce Operand::clearDefUse for implementation convenience.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>