### PR TITLE
[onert] Refine nnfw_api_internal.cc

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.h
+++ b/runtime/onert/api/src/nnfw_api_internal.h
@@ -144,7 +144,7 @@ public:
   NNFW_STATUS output_tensorindex(const char *tensorname, uint32_t *index);
 
 private:
-  onert::ir::Graph *primary_subgraph();
+  const onert::ir::Graph *primary_subgraph();
   bool isStateInitialized();
   bool isStateModelLoaded();
   bool isStatePrepared();


### PR DESCRIPTION
Remove const_cast in `primary_subgraph()`

- Make `primary_subgraph()` return a const pointer
- Replace `primary_subgraph()` use with `_subgraphs->primary()`
  when it is in the right state

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>