### PR TITLE
[luci] Refactor size-related methods in Constant OP

### DIFF
--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleConst.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleConst.h
@@ -37,6 +37,9 @@ public:
   CircleConst() = default;
 
 public:
+  uint32_t size(void) const;
+  void size(uint32_t size);
+
   template <loco::DataType DT> uint32_t size(void) const;
   template <loco::DataType DT> void size(uint32_t size);
   template <loco::DataType DT> const typename loco::DataTypeImpl<DT>::Type &at(uint32_t n) const;

--- a/compiler/luci/lang/src/Nodes/CircleConst.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleConst.cpp
@@ -21,6 +21,17 @@
 namespace luci
 {
 
+uint32_t CircleConst::size(void) const
+{
+  assert(_data.size() % loco::size(dtype()) == 0);
+  return _data.size() / loco::size(dtype());
+}
+
+void CircleConst::size(uint32_t size)
+{
+  _data.resize(size * loco::size(dtype()));
+}
+
 template <loco::DataType DT> uint32_t CircleConst::size(void) const
 {
   assert(dtype() == DT);
@@ -75,6 +86,10 @@ INSTANTIATE(loco::DataType::S32);
 INSTANTIATE(loco::DataType::S16);
 INSTANTIATE(loco::DataType::S8);
 INSTANTIATE(loco::DataType::FLOAT32);
+INSTANTIATE(loco::DataType::FLOAT64);
+INSTANTIATE(loco::DataType::U64);
+INSTANTIATE(loco::DataType::U32);
+INSTANTIATE(loco::DataType::U16);
 INSTANTIATE(loco::DataType::U8);
 INSTANTIATE(loco::DataType::BOOL);
 


### PR DESCRIPTION
- Add non-template methods
- Support more types

Depends on #5954 

ONE-DCO-1.0-Signed-off-by: Alexander Efimov <a.efimov@samsung.com>