### PR TITLE
[onert] Remove Graph state

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -947,7 +947,6 @@ bool nnfw_session::isStateModelLoaded()
     assert(_subgraphs);
     assert(_compiler);
     assert(!_execution);
-    assert(!primary_subgraph()->isBuildingPhase());
     return true;
   }
   else
@@ -963,7 +962,6 @@ bool nnfw_session::isStatePrepared()
     assert(!_subgraphs);
     assert(_compiler);
     assert(_execution);
-    assert(!primary_subgraph()->isBuildingPhase());
     return true;
   }
   else
@@ -979,7 +977,6 @@ bool nnfw_session::isStateRunning()
     assert(!_subgraphs);
     assert(_compiler);
     assert(_execution);
-    assert(!primary_subgraph()->isBuildingPhase());
     return true;
   }
   return false;
@@ -992,7 +989,6 @@ bool nnfw_session::isStateFinishedRun()
     assert(!_subgraphs);
     assert(_compiler);
     assert(_execution);
-    assert(!primary_subgraph()->isBuildingPhase());
     return true;
   }
   else

--- a/runtime/onert/core/include/ir/Graph.h
+++ b/runtime/onert/core/include/ir/Graph.h
@@ -84,13 +84,14 @@ public:
   void setOperandValue(const OperandIndex &ind, std::shared_ptr<Data> data);
   void addInput(const OperandIndex &ind, const std::string &name = "");
   void addOutput(const OperandIndex &ind, const std::string &name = "");
-  void finishBuilding(void);
+  void verify(void);
   void removeOperand(const OperandIndex &ind) { _operands.remove(ind); }
-  bool isBuildingPhase(void) const { return _phase == Phase::BUILDING; }
   void setLayout(Layout layout) { _layout = layout; }
   void setSubgraphs(const std::shared_ptr<Subgraphs> &subgs) { _subgraphs = subgs; }
 
 private:
+  bool checkOperandsForOperation(const Operation &operation);
+  void linkOperandToOperation(OperationIndex index, const Operation &operation);
   void initializeUseDef();
   // TODO Rename to `sweepUnusedOperands`
   // TODO Make this public
@@ -133,7 +134,6 @@ public:
   std::vector<ir::OperationIndex> topolSortOperations() const;
 
 private:
-  Phase _phase{Phase::BUILDING};
   Operations _operations;
   Operands _operands;
   OperandIndexSequence _inputs;

--- a/runtime/onert/core/src/compiler/pass/PermutationInsertionPass.cc
+++ b/runtime/onert/core/src/compiler/pass/PermutationInsertionPass.cc
@@ -117,8 +117,6 @@ void PermutationInsertionPass::callback(const ir::OperandIndex &index, ir::Opera
 ir::OperationIndex PermutationInsertionPass::insertPermute(const ir::OperandIndex &operand_index,
                                                            const PermuteFactor &factor)
 {
-  assert(!_graph.isBuildingPhase());
-
   auto &operand = _graph.operands().at(operand_index);
 
   // Generate output operand and permute operation

--- a/runtime/onert/frontend/circle/src/circle_loader.cc
+++ b/runtime/onert/frontend/circle/src/circle_loader.cc
@@ -122,7 +122,7 @@ private:
 
     subg->setLayout(convertDataFormat(circle_subg->data_format()));
 
-    subg->finishBuilding();
+    subg->verify();
 
     return subg;
   }

--- a/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksModel.cc
+++ b/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksModel.cc
@@ -27,7 +27,8 @@
 // ANeuralNetworksModel
 //
 ANeuralNetworksModel::ANeuralNetworksModel() noexcept
-  : _optional_operands{}, _operand_usages{}, _allowFloat32toFloat16{false}
+  : _finished_building{false}, _optional_operands{}, _operand_usages{}, _allowFloat32toFloat16{
+                                                                          false}
 {
   _graph = std::make_shared<onert::ir::Graph>();
 }
@@ -208,9 +209,9 @@ bool ANeuralNetworksModel::finish() noexcept
   {
     fillOptionalOperand();
 
-    _graph->finishBuilding();
-
+    _graph->verify();
     _operand_usages.clear();
+    _finished_building = true;
   }
   catch (const std::exception &e)
   {
@@ -222,7 +223,7 @@ bool ANeuralNetworksModel::finish() noexcept
   return true;
 }
 
-bool ANeuralNetworksModel::isFinished() noexcept { return !_graph->isBuildingPhase(); }
+bool ANeuralNetworksModel::isFinished() noexcept { return _finished_building; }
 
 bool ANeuralNetworksModel::isExistOperand(uint32_t index) noexcept
 {

--- a/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksModel.h
+++ b/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksModel.h
@@ -67,6 +67,7 @@ private:
 
 private:
   std::shared_ptr<onert::ir::Graph> _graph;
+  bool _finished_building;
   std::unordered_set<onert::ir::OperandIndex> _optional_operands;
   std::vector<OperandUsage> _operand_usages;
   bool _allowFloat32toFloat16;

--- a/runtime/onert/frontend/tflite/src/tflite_loader.cc
+++ b/runtime/onert/frontend/tflite/src/tflite_loader.cc
@@ -107,7 +107,7 @@ private:
       loadOperation(op, *subg);
     }
 
-    subg->finishBuilding();
+    subg->verify();
 
     return subg;
   }

--- a/runtime/onert/test/core/compiler/HEScheduler.cc
+++ b/runtime/onert/test/core/compiler/HEScheduler.cc
@@ -233,7 +233,7 @@ std::shared_ptr<Graph> createStraightGraph()
   BinaryArithmetic::Param mul_op_params{BinaryArithmetic::ArithmeticType::MUL, Activation::NONE};
   create<BinaryArithmetic>(graph, OIS{sub_out_idx, mul_const_idx}, OIS{mul_out_idx}, mul_op_params);
 
-  graph->finishBuilding();
+  graph->verify();
   return graph;
 }
 
@@ -289,7 +289,7 @@ std::shared_ptr<Graph> createBranchedGraph()
   BinaryArithmetic::Param sub_op_params{BinaryArithmetic::ArithmeticType::SUB, Activation::NONE};
   create<BinaryArithmetic>(graph, OIS{mul2_out_idx, fc2_out_idx}, OIS{sub_out_idx}, sub_op_params);
 
-  graph->finishBuilding();
+  graph->verify();
   return graph;
 }
 

--- a/runtime/onert/test/core/exec/ExecInstance.cc
+++ b/runtime/onert/test/core/exec/ExecInstance.cc
@@ -73,7 +73,7 @@ public:
     graph->addInput(operand_lhs);
     graph->addInput(operand_rhs1);
     graph->addOutput(operand_result2);
-    graph->finishBuilding();
+    graph->verify();
 
     // Compile
     auto subgs = std::make_shared<onert::ir::Subgraphs>();

--- a/runtime/onert/test/core/interp/ExecManager.cc
+++ b/runtime/onert/test/core/interp/ExecManager.cc
@@ -71,7 +71,7 @@ protected:
     _graph->getInputs().append(operand_rhs);
     _graph->getOutputs().append(operand_result);
 
-    _graph->finishBuilding();
+    _graph->verify();
 
     auto subgs = std::make_shared<onert::ir::Subgraphs>();
     subgs->push(onert::ir::SubgraphIndex{0}, _graph);
@@ -136,7 +136,7 @@ protected:
     _graph->getInputs().append(operand_rhs1);
     _graph->getOutputs().append(operand_result2);
 
-    _graph->finishBuilding();
+    _graph->verify();
 
     auto subgs = std::make_shared<onert::ir::Subgraphs>();
     subgs->push(onert::ir::SubgraphIndex{0}, _graph);
@@ -189,7 +189,7 @@ protected:
     _graph->getInputs().append(operand_rhs);
     _graph->getOutputs().append(operand_result);
 
-    _graph->finishBuilding();
+    _graph->verify();
 
     auto subgs = std::make_shared<onert::ir::Subgraphs>();
     subgs->push(onert::ir::SubgraphIndex{0}, _graph);
@@ -213,7 +213,7 @@ protected:
 TEST_F(InterpExecutorTest, create_empty)
 {
   Graph graph;
-  graph.finishBuilding();
+  graph.verify();
   auto executor = std::make_unique<InterpExecutor>(graph);
   ASSERT_NE(executor, nullptr);
 }

--- a/runtime/onert/test/graph/Graph.cc
+++ b/runtime/onert/test/graph/Graph.cc
@@ -67,7 +67,7 @@ OperationIndex addAddOperation(Graph &graph, const OperandIndexSequence inputs,
   return graph.addOperation(std::make_unique<operation::BinaryArithmetic>(inputs, outputs, param));
 }
 
-TEST(Graph, OneOpGraphFinish)
+TEST(Graph, OneOpGraphSimpleValid)
 {
   // Simple Graph with just one Add operation
 
@@ -87,12 +87,12 @@ TEST(Graph, OneOpGraphFinish)
   graph.addInput(rhs);
   graph.addOutput(res);
 
-  graph.finishBuilding();
+  graph.verify();
 
   SUCCEED();
 }
 
-TEST(Graph, neg_InvalidGraphFinish_BadInput)
+TEST(Graph, neg_InvalidGraph_BadInput)
 {
   Graph graph;
 
@@ -107,10 +107,10 @@ TEST(Graph, neg_InvalidGraphFinish_BadInput)
   graph.addOutput(out);
   graph.addInput(OperandIndex{89}); // Non-exisiting operand!
 
-  EXPECT_ANY_THROW(graph.finishBuilding());
+  EXPECT_ANY_THROW(graph.verify());
 }
 
-TEST(Graph, neg_InvalidGraphFinish_BadOutput)
+TEST(Graph, neg_InvalidGraph_BadOutput)
 {
   Graph graph;
 
@@ -125,10 +125,10 @@ TEST(Graph, neg_InvalidGraphFinish_BadOutput)
   graph.addOutput(out);
   graph.addOutput(OperandIndex{12}); // Non-exisiting operand!
 
-  EXPECT_ANY_THROW(graph.finishBuilding());
+  EXPECT_ANY_THROW(graph.verify());
 }
 
-TEST(Graph, neg_InvalidGraphFinish_BadInputOutputForOp)
+TEST(Graph, neg_InvalidAddOperation_BadInputIndex)
 {
   Graph graph;
 
@@ -139,12 +139,10 @@ TEST(Graph, neg_InvalidGraphFinish_BadInputOutputForOp)
   auto rhs = graph.addOperand(shape, type);
   auto res = graph.addOperand(shape, type);
 
-  addAddOperation(graph, {lhs, OperandIndex{99}}, {res});
-
   // Set model inputs/outputs
   graph.addInput(lhs);
   graph.addInput(rhs);
   graph.addOutput(res);
 
-  EXPECT_ANY_THROW(graph.finishBuilding());
+  ASSERT_FALSE(addAddOperation(graph, {lhs, OperandIndex{99}}, {res}).valid());
 }

--- a/runtime/onert/test/graph/operand/UseDef.cc
+++ b/runtime/onert/test/graph/operand/UseDef.cc
@@ -60,7 +60,7 @@ TEST(ir_Operand, neg_usedef)
   auto multiinput_index = graph.addOperation(
     std::make_unique<Mock>(IndexSet{operand_index1, operand_index2}, IndexSet{output_operand}));
 
-  graph.finishBuilding();
+  graph.verify();
 
   ASSERT_TRUE(verifier.verify(graph));
 

--- a/runtime/onert/test/graph/verifier/Verifier.cc
+++ b/runtime/onert/test/graph/verifier/Verifier.cc
@@ -41,8 +41,6 @@ TEST(Verifier, dag_checker)
 
   graph.addOperation(std::make_unique<Mock>(IndexSet{operand1}, IndexSet{operand2}));
 
-  graph.finishBuilding();
-
   onert::ir::verifier::DAGChecker verifier;
 
   ASSERT_TRUE(verifier.verify(graph));
@@ -63,8 +61,6 @@ TEST(Verifier, neg_edge_consistency_checker_1)
 
   auto mock_op = std::make_unique<Mock>(IndexSet{operand1}, IndexSet{operand2});
   auto op_ind = graph.addOperation(std::move(mock_op));
-
-  graph.finishBuilding();
 
   graph.operands().at(operand1).removeUse(op_ind); // Manipulate the operand alone
 
@@ -88,8 +84,6 @@ TEST(Verifier, neg_edge_consistency_checker_2)
   auto mock_op = std::make_unique<Mock>(IndexSet{operand1}, IndexSet{operand2});
   auto mock_op_ptr = mock_op.get();
   auto op_ind = graph.addOperation(std::move(mock_op));
-
-  graph.finishBuilding();
 
   mock_op_ptr->setInputs({operand2}); // Manipulate the operation alone
 


### PR DESCRIPTION
As we have a lot of things that manipulate a graph after finishing
building, so let's remove the graph state.

- Remove graph state (BUILDING/FINISHED)
- Graph now should always be valid
    - No mismatches of edges between operations/operands
    - And so on...
- From now on, operands must be added before operations are added
    - Operands should not contain Def/Use info when it first is added
    - This looks not very good, let's make it better gradually

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>