### PR TITLE
[locop] Add format test for Plain

### DIFF
--- a/compiler/locop/src/FormattedTensorShape.test.cpp
+++ b/compiler/locop/src/FormattedTensorShape.test.cpp
@@ -40,6 +40,7 @@ TEST(FormattedTensorShapeTest, PlainFormat)
 
   tensor_shape->rank(2);
   tensor_shape->dim(0) = 4;
+  tensor_shape->dim(1) = 8;
 
   std::cout << fmt<TensorShapeFormat::Plain>(tensor_shape.get()) << std::endl;
 

--- a/compiler/locop/src/FormattedTensorShape.test.cpp
+++ b/compiler/locop/src/FormattedTensorShape.test.cpp
@@ -33,3 +33,15 @@ TEST(FormattedTensorShapeTest, BracketFormat)
 
   SUCCEED();
 }
+
+TEST(FormattedTensorShapeTest, PlainFormat)
+{
+  auto tensor_shape = stdex::make_unique<loco::TensorShape>();
+
+  tensor_shape->rank(2);
+  tensor_shape->dim(0) = 4;
+
+  std::cout << fmt<TensorShapeFormat::Plain>(tensor_shape.get()) << std::endl;
+
+  SUCCEED();
+}


### PR DESCRIPTION
This will add FormattedTensorShape test for Plain format.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>