### PR TITLE
[locop] Fix FormattedTensorShape test

### DIFF
--- a/compiler/locop/src/FormattedTensorShape.test.cpp
+++ b/compiler/locop/src/FormattedTensorShape.test.cpp
@@ -28,6 +28,7 @@ TEST(FormattedTensorShapeTest, BracketFormat)
 
   tensor_shape->rank(2);
   tensor_shape->dim(0) = 4;
+  tensor_shape->dim(1) = 8;
 
   std::cout << fmt<TensorShapeFormat::Bracket>(tensor_shape.get()) << std::endl;
 


### PR DESCRIPTION
This will fix FormattedTensorShape to set for dim(1).

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>