### PR TITLE
[onert] Refactor ir::Graph::sweepGarbageOperands

### DIFF
--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -30,6 +30,7 @@
 #include "compiler/pass/ConstantOutputPass.h"
 #include "compiler/pass/OddOutputPass.h"
 #include "compiler/pass/PassRunner.h"
+#include "compiler/pass/UnusedOperandEliminationPass.h"
 #include "exec/ExecTime.h"
 #include "ir/verifier/Verifier.h"
 #include "dumper/dot/DotDumper.h"
@@ -191,6 +192,9 @@ std::shared_ptr<exec::ExecutorMap> Compiler::compile(void)
       .append(std::make_unique<pass::ConstantOutputPass>(subg))
       .append(std::make_unique<pass::OddOutputPass>(subg))
       .run();
+
+    // Optimizations
+    pass::PassRunner{}.append(std::make_unique<pass::UnusedOperandEliminationPass>(subg)).run();
   });
 
   /***************************************************

--- a/runtime/onert/core/src/compiler/pass/UnusedOperandEliminationPass.cc
+++ b/runtime/onert/core/src/compiler/pass/UnusedOperandEliminationPass.cc
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Pass.h"
+
+#include "UnusedOperandEliminationPass.h"
+#include "ir/OperandIndexMap.h"
+#include "ir/Graph.h"
+
+/**
+ * @file  UnusedOperandEliminationPass.cc
+ * @brief This file contains UnusedOperandEliminationPass class implementation
+ */
+
+namespace onert
+{
+namespace compiler
+{
+namespace pass
+{
+
+void UnusedOperandEliminationPass::run()
+{
+  // Remove operands that are not used by any operations, except Graph inputs/outputs
+  ir::OperandIndexMap<bool> visited;
+
+  _graph.operations().iterate([&](const ir::OperationIndex &, const ir::Operation &node) {
+    for (auto ind : node.getInputs() + node.getOutputs())
+    {
+      visited[ind] = true;
+    }
+  });
+
+  // Graph's inputs/outputs are always reachable
+  for (auto ind : _graph.getInputs() + _graph.getOutputs())
+  {
+    visited[ind] = true;
+  }
+
+  _graph.operands().iterate([&](const ir::OperandIndex &ind, const ir::Operand &) {
+    if (!visited[ind])
+    {
+      VERBOSE() << "Remove unused operand " << ind << std::endl;
+      _graph.operands().remove(ind);
+    }
+  });
+}
+
+} // namespace pass
+} // namespace compiler
+} // namespace onert

--- a/runtime/onert/core/src/compiler/pass/UnusedOperandEliminationPass.h
+++ b/runtime/onert/core/src/compiler/pass/UnusedOperandEliminationPass.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file  UnusedOperandEliminationPass.h
+ * @brief This file contains UnusedOperandEliminationPass class
+ */
+
+#ifndef __ONERT_COMPILER_PASS_UNUSED_OPERAND_ELIMINATION_PASS_H__
+#define __ONERT_COMPILER_PASS_UNUSED_OPERAND_ELIMINATION_PASS_H__
+
+#include "Pass.h"
+
+namespace onert
+{
+namespace compiler
+{
+namespace pass
+{
+
+/**
+ * @brief  A pass to eliminate unused operands from the graph
+ */
+class UnusedOperandEliminationPass : public Pass
+{
+public:
+  using Pass::Pass;
+
+public:
+  std::string id() override { return "UnusedOperandEliminationPass"; }
+  void run() final;
+};
+
+} // namespace pass
+} // namespace compiler
+} // namespace onert
+
+#endif // __ONERT_COMPILER_PASS_UNUSED_OPERAND_ELIMINATION_PASS_H__

--- a/runtime/onert/core/src/ir/Graph.cc
+++ b/runtime/onert/core/src/ir/Graph.cc
@@ -166,33 +166,6 @@ void Graph::initializeUseDef()
   });
 }
 
-void Graph::sweepGarbageOperands()
-{
-  // Remove operands that are not used by any operations, except Graph inputs/outputs
-  ir::OperandIndexMap<bool> visited;
-
-  operations().iterate([&](const OperationIndex &, const Operation &node) {
-    for (auto ind : node.getInputs() + node.getOutputs())
-    {
-      visited[ind] = true;
-    }
-  });
-
-  // Graph's inputs/outputs are always reachable
-  for (auto ind : getInputs() + getOutputs())
-  {
-    visited[ind] = true;
-  }
-
-  operands().iterate([&](const OperandIndex &ind, const Operand &) {
-    if (!visited[ind])
-    {
-      VERBOSE(Graph::sweepGarbageOperands) << "Sweep garbage operand " << ind << std::endl;
-      operands().remove(ind);
-    }
-  });
-}
-
 std::vector<ir::OperationIndex> Graph::topolSortOperations() const
 {
   std::vector<ir::OperationIndex> ret;

--- a/runtime/onert/test/core/compiler/pass/UnusedOperandEliminationPass.cc
+++ b/runtime/onert/test/core/compiler/pass/UnusedOperandEliminationPass.cc
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include "ir/Graph.h"
+#include "compiler/pass/UnusedOperandEliminationPass.h"
+
+using namespace onert::ir;
+using namespace onert::compiler::pass;
+
+TEST(UnusedOperandEliminationPass, Simple)
+{
+  Graph graph;
+
+  // Add tensors
+  Shape shape{1, 2, 2, 1};
+  TypeInfo type{DataType::FLOAT32};
+  auto in = graph.addOperand(shape, type);
+  auto out = graph.addOperand(shape, type);
+
+  auto unused = graph.addOperand(shape, type);
+
+  // Set model inputs/outputs
+  graph.addInput(in);
+  graph.addOutput(out);
+
+  UnusedOperandEliminationPass{graph}.run();
+
+  ASSERT_TRUE(graph.operands().exist(in));
+  ASSERT_TRUE(graph.operands().exist(out));
+  ASSERT_FALSE(graph.operands().exist(unused));
+}

--- a/runtime/onert/test/graph/operand/LayoutSet.cc
+++ b/runtime/onert/test/graph/operand/LayoutSet.cc
@@ -36,6 +36,15 @@ TEST(ir_LayoutSet, neg_add_remove)
   ASSERT_EQ(set.size(), 0);
 }
 
+TEST(ir_LayoutSet, neg_add_twice)
+{
+  LayoutSet set;
+  set.add(Layout::NHWC);
+  ASSERT_EQ(set.size(), 1);
+  set.add(Layout::NHWC);
+  ASSERT_EQ(set.size(), 1);
+}
+
 TEST(ir_LayoutSet, set_operators)
 {
   LayoutSet set1{Layout::NCHW};


### PR DESCRIPTION
Make "sweeping garbage operands" as a graph pass.

- Remove method `ir::Graph::sweepGarbageOperands`
- Introudce a pass `compiler::pass::UnusedOperandEliminationPass`

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>