### PR TITLE
[onert] Refine UnusedOperandEliminationPass

### DIFF
--- a/runtime/onert/core/src/compiler/pass/UnusedOperandEliminationPass.h
+++ b/runtime/onert/core/src/compiler/pass/UnusedOperandEliminationPass.h
@@ -33,6 +33,9 @@ namespace pass
 
 /**
  * @brief  A pass to eliminate unused operands from the graph
+ *
+ * Remove operands that are not used by any operations, except Graph inputs/outputs.
+ *
  */
 class UnusedOperandEliminationPass : public Pass
 {


### PR DESCRIPTION
Refine implementation of UnusedOperandEliminationPass.

- Add more description with comments
- Simplify data structure - switch from Map<bool> to Set

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>