### PR TITLE
[onert] Remove BackendContext default impl

### DIFF
--- a/runtime/onert/core/include/backend/BackendContext.h
+++ b/runtime/onert/core/include/backend/BackendContext.h
@@ -68,8 +68,8 @@ public:
   const ir::OperandIndexMap<ir::Layout> &operand_layouts() const { return _data.operand_layouts; }
   const ContextData &data() const { return _data; }
 
-  virtual ITensorRegistry *genTensors() { return nullptr; }
-  virtual FunctionMap genKernels() { return {}; }
+  virtual ITensorRegistry *genTensors() = 0;
+  virtual FunctionMap genKernels() = 0;
 
 protected:
   const Backend *_backend{nullptr};

--- a/runtime/onert/test/core/compiler/HEScheduler.cc
+++ b/runtime/onert/test/core/compiler/HEScheduler.cc
@@ -49,12 +49,20 @@ struct MockConfigCPU : public IConfig
   bool supportFP16() override { return false; }
 };
 
+class MockBackendContext : public BackendContext
+{
+public:
+  using BackendContext::BackendContext;
+  ITensorRegistry *genTensors() override { return nullptr; }
+  FunctionMap genKernels() override { return {}; }
+};
+
 struct MockBackendCPU : public Backend
 {
   std::shared_ptr<IConfig> config() const override { return std::make_shared<MockConfigCPU>(); }
   std::unique_ptr<BackendContext> newContext(ContextData &&data) const override
   {
-    return std::make_unique<BackendContext>(this, std::move(data), nullptr);
+    return std::make_unique<MockBackendContext>(this, std::move(data), nullptr);
   }
 };
 
@@ -76,7 +84,7 @@ struct MockBackendGPU : public Backend
   std::shared_ptr<IConfig> config() const override { return std::make_shared<MockConfigGPU>(); }
   std::unique_ptr<BackendContext> newContext(ContextData &&data) const override
   {
-    return std::make_unique<BackendContext>(this, std::move(data), nullptr);
+    return std::make_unique<MockBackendContext>(this, std::move(data), nullptr);
   }
 };
 
@@ -98,7 +106,7 @@ struct MockBackendNPU : public Backend
   std::shared_ptr<IConfig> config() const override { return std::make_shared<MockConfigNPU>(); }
   std::unique_ptr<BackendContext> newContext(ContextData &&data) const override
   {
-    return std::make_unique<BackendContext>(this, std::move(data), nullptr);
+    return std::make_unique<MockBackendContext>(this, std::move(data), nullptr);
   }
 };
 


### PR DESCRIPTION
Remove BackendContext default implementations of interfaces.

ONE-DCO-1.0-Signed-off-by: Hanjoung Lee <hanjoung.lee@samsung.com>