### PR TITLE
[luci] Correct coverage for lang

### DIFF
--- a/compiler/luci/lang/CMakeLists.txt
+++ b/compiler/luci/lang/CMakeLists.txt
@@ -7,6 +7,7 @@ target_include_directories(luci_lang PRIVATE src)
 target_include_directories(luci_lang PUBLIC include)
 target_link_libraries(luci_lang PUBLIC loco)
 target_link_libraries(luci_lang PUBLIC oops)
+target_link_libraries(luci_lang PUBLIC nncc_coverage)
 target_link_libraries(luci_lang PRIVATE logo)
 target_link_libraries(luci_lang PRIVATE nncc_common)
 


### PR DESCRIPTION
This will add link to nncc_coverage for correct coverage.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>