### PR TITLE
[tflite2circle] Correct coverage

### DIFF
--- a/compiler/tflite2circle/CMakeLists.txt
+++ b/compiler/tflite2circle/CMakeLists.txt
@@ -15,5 +15,6 @@ target_link_libraries(tflite2circle safemain)
 target_link_libraries(tflite2circle mio_tflite)
 target_link_libraries(tflite2circle mio_circle)
 target_link_libraries(tflite2circle vconone)
+target_link_libraries(tflite2circle nncc_coverage)
 
 install(TARGETS tflite2circle DESTINATION bin)


### PR DESCRIPTION
This will add link to nncc_coverage for correct coverage.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>