### PR TITLE
[pepper-str] Correct coverage

### DIFF
--- a/compiler/pepper-str/CMakeLists.txt
+++ b/compiler/pepper-str/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(pepper_str INTERFACE)
 target_include_directories(pepper_str INTERFACE include)
+target_link_libraries(pepper_str INTERFACE nncc_coverage)
 
 if(NOT ENABLE_TEST)
   return()


### PR DESCRIPTION
This will add link to nncc_coverage for correct coverage.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>