### PR TITLE
DRAFT Compiler FE: Provide valid names for CircleNodes

### DIFF
--- a/compiler/luci/import/src/CircleReader.cpp
+++ b/compiler/luci/import/src/CircleReader.cpp
@@ -63,6 +63,9 @@ const char *tensor_name(const circle::TensorT &tensor)
   if (!tensor.name.empty())
     return tensor.name.c_str();
 
+  // let's see if there is a case
+  assert(false);
+
   return kEmptyTensorName;
 }
 

--- a/compiler/luci/import/src/Nodes/CircleReshape.cpp
+++ b/compiler/luci/import/src/Nodes/CircleReshape.cpp
@@ -30,6 +30,18 @@ bool CircleReshapeGraphBuilder::validate(const ValidateArgs &args) const
   if (args.op.outputs.size() != 1)
     return false;
 
+  // for two inputs, check if type is S32
+  if (args.op.inputs.size() == 2)
+  {
+    const auto &inputs = args.op.inputs;
+    const auto &tensors = args.reader.tensors();
+    const auto &tensor_in = tensors.at(inputs.at(1));
+
+    // TensorFlow lite and circle only supports S32
+    if (tensor_in->type != circle::TensorType::TensorType_INT32)
+      return false;
+  }
+
   return true;
 }
 

--- a/compiler/luci/service/src/Nodes/CircleConst.cpp
+++ b/compiler/luci/service/src/Nodes/CircleConst.cpp
@@ -47,8 +47,7 @@ luci::CircleConst *clone(luci::CircleConst *node)
 {
   auto cloned = node->graph()->nodes()->create<luci::CircleConst>();
 
-  // TODO: We don't have any naming policy for newly created nodes yet.
-  //       Fix this when we have one.
+  // NOTE unique name should be assigned in export
   cloned->name(node->name());
 
   // dtype/shape


### PR DESCRIPTION
on-going draft to provide valid names for CircleNodes.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>