### PR TITLE
[luci] Use must_cast in ResolveCustomOpAddPass

### DIFF
--- a/compiler/luci/pass/src/ResolveCustomOpAddPass.cpp
+++ b/compiler/luci/pass/src/ResolveCustomOpAddPass.cpp
@@ -92,7 +92,7 @@ bool resolve_custom_op(luci::CircleCustom *addv2)
   // check if inputs are suppport data types
   for (uint32_t i = 0; i < addv2->numInputs(); i++)
   {
-    auto input = dynamic_cast<luci::CircleNode *>(addv2->inputs(i));
+    auto input = loco::must_cast<luci::CircleNode *>(addv2->inputs(i));
     switch (input->dtype())
     {
       case loco::DataType::U8:


### PR DESCRIPTION
Until now, if `input` is `nullptr`, this is not handled.
This commit will change `dynamic_cast` to `loco::must_cast` to catch the error.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>