### PR TITLE
[luci] Add nullptr check in QuantizeWithMinMaxPass

### DIFF
--- a/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
+++ b/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
@@ -69,6 +69,9 @@ void overwrite_quantparam(luci::CircleConcatenation *concat, luci::CircleNode *t
     auto quantparam = std::make_unique<CircleQuantParam>();
     target->quantparam(std::move(quantparam));
     target_qparam = target->quantparam();
+
+    if (target_qparam == nullptr)
+      throw std::runtime_error("Creating new quant param failed");
   }
   target_qparam->min = concat_qparam->min;
   target_qparam->max = concat_qparam->max;


### PR DESCRIPTION
This commit will add an additional nullptr check in `QuantizeWithMinMaxPass`.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>