### PR TITLE
[luci] Rename as csv_to_vector in Pass

### DIFF
--- a/compiler/luci/pass/src/CircleOptimizer.cpp
+++ b/compiler/luci/pass/src/CircleOptimizer.cpp
@@ -73,20 +73,6 @@
 namespace
 {
 
-std::vector<int> parseIntFromCommadelimitedStr(std::string str)
-{
-  std::vector<int> ret;
-  std::istringstream is(str);
-  for (uint32_t i; is >> i;)
-  {
-    assert(i != ',');
-    ret.push_back(i);
-    if (is.peek() == ',')
-      is.ignore();
-  }
-  return ret;
-}
-
 using namespace luci;
 
 class OptimizeOptionsImpl final : public luci::CircleOptimizer::Options
@@ -444,7 +430,7 @@ void CircleOptimizer::sparsify(loco::Graph *g) const
     std::string str_block_map = _options->param(Options::AlgorithmParameters::Sparsify_block_map);
 
     // traversal order
-    std::vector<int32_t> traversal_order = parseIntFromCommadelimitedStr(str_tarversal_order);
+    std::vector<int32_t> traversal_order = csv_to_vector<int32_t>(str_tarversal_order);
     // format
     std::vector<DimensionType> format;
     std::istringstream is(str_format);
@@ -459,9 +445,9 @@ void CircleOptimizer::sparsify(loco::Graph *g) const
         is.ignore();
     }
     // block size
-    std::vector<int32_t> block_size = parseIntFromCommadelimitedStr(str_block_size);
+    std::vector<int32_t> block_size = csv_to_vector<int32_t>(str_block_size);
     // block map
-    std::vector<int32_t> block_map = parseIntFromCommadelimitedStr(str_block_map);
+    std::vector<int32_t> block_map = csv_to_vector<int32_t>(str_block_map);
 
     luci::SparsifyTensorPass sparsifier{tensor_name, traversal_order, format, block_size,
                                         block_map};

--- a/compiler/luci/pass/src/helpers/Strings.h
+++ b/compiler/luci/pass/src/helpers/Strings.h
@@ -38,6 +38,20 @@ loco::DataType str_to_dtype(const std::string &);
 
 QuantizationGranularity str_to_granularity(const std::string &);
 
+template <typename T> std::vector<T> csv_to_vector(const std::string &str)
+{
+  std::vector<T> ret;
+  std::istringstream is(str);
+  for (T i; is >> i;)
+  {
+    assert(i != ',');
+    ret.push_back(i);
+    if (is.peek() == ',')
+      is.ignore();
+  }
+  return ret;
+}
+
 } // namespace luci
 
 #endif // __LUCI_PASS_HELPERS_STRINGS_H__

--- a/compiler/luci/pass/src/helpers/Strings.test.cpp
+++ b/compiler/luci/pass/src/helpers/Strings.test.cpp
@@ -48,3 +48,11 @@ TEST(StringsTest, str_to_granularity)
 
   EXPECT_THROW(luci::str_to_granularity("foo"), std::runtime_error);
 }
+
+TEST(StringsTest, csv_to_vector_int32)
+{
+  auto ret = luci::csv_to_vector<int32_t>("1,2,3");
+  ASSERT_EQ(3, ret.size());
+  ASSERT_EQ(1, ret.at(0));
+  ASSERT_EQ(3, ret.at(2));
+}


### PR DESCRIPTION
This will rename parseIntFromCommadelimitedStr as csv_to_vector into
Pass Strings helpers.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>