### PR TITLE
[luci] Check only S32 for clone_shape

### DIFF
--- a/compiler/luci/pass/src/ForwardReshapeToUnaryOpPass.cpp
+++ b/compiler/luci/pass/src/ForwardReshapeToUnaryOpPass.cpp
@@ -37,8 +37,10 @@ luci::CircleConst *clone_shape(luci::CircleReshape *reshape)
   if (shape == nullptr)
     return nullptr;
 
+  // NOTE tflite and circle only supports S32
+  // TODO just check with assert() after import handles this
   auto dtype = shape->dtype();
-  if (dtype != loco::DataType::S32 && dtype != loco::DataType::S64)
+  if (dtype != loco::DataType::S32)
     return nullptr;
 
   return luci::clone(shape);


### PR DESCRIPTION
This will revise ForwardReshapeToUnaryOpPass to check only S32 in
clone_shape method for now and add comments about this code.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>