### PR TITLE
[luci] Sort MultiOutputDetector item

### DIFF
--- a/compiler/luci/export/src/CircleTensorExporter.cpp
+++ b/compiler/luci/export/src/CircleTensorExporter.cpp
@@ -139,14 +139,13 @@ private:
   }
 
 public:
+  bool visit(luci::CircleBidirectionalSequenceLSTMOut *) final { return true; }
   bool visit(luci::CircleIfOut *) final { return true; }
   bool visit(luci::CircleSplitOut *) final { return true; }
   bool visit(luci::CircleSplitVOut *) final { return true; }
   bool visit(luci::CircleTopKV2Out *) final { return true; }
   bool visit(luci::CircleUnpackOut *) final { return true; }
   bool visit(luci::CircleWhileOut *) final { return true; }
-
-  bool visit(luci::CircleBidirectionalSequenceLSTMOut *) final { return true; }
 
   bool visit(luci::CircleBidirectionalSequenceLSTM *node) final
   {


### PR DESCRIPTION
This will sort CircleBidirectionalSequenceLSTMOut in
MultiOutputDetector.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>