### PR TITLE
[luci] Names for new nodes in FoldDequantizePass

### DIFF
--- a/compiler/luci/pass/src/FoldDequantizePass.cpp
+++ b/compiler/luci/pass/src/FoldDequantizePass.cpp
@@ -51,6 +51,8 @@ luci::CircleConst *dequantized_const_node(luci::CircleConst *const_node)
     throw std::runtime_error("Given constant node has no quantization parameter");
   }
 
+  auto name = const_node->name();
+  assert(name.length() > 0);
   auto g = const_node->graph();
   auto new_const_node = g->nodes()->create<luci::CircleConst>();
 
@@ -64,6 +66,7 @@ luci::CircleConst *dequantized_const_node(luci::CircleConst *const_node)
   }
   new_const_node->size<loco::DataType::FLOAT32>(dim_size);
   new_const_node->shape_status(luci::ShapeStatus::VALID);
+  new_const_node->name(name + "_DQ");
 
   const int32_t q_dim = const_node->quantparam()->quantized_dimension;
   const int32_t q_dim_value = const_node->dim(q_dim).value();

--- a/compiler/luci/pass/src/FoldSparseToDensePass.cpp
+++ b/compiler/luci/pass/src/FoldSparseToDensePass.cpp
@@ -63,6 +63,8 @@ bool fold_sparse_to_dense(luci::CircleSparseToDense *stod)
     shape.push_back(dim);
   }
 
+  auto name = stod->name();
+  assert(name.length() > 0);
   auto constant = stod->graph()->nodes()->create<luci::CircleConst>();
   constant->dtype(default_value->dtype());
   constant->rank(rank);
@@ -79,6 +81,7 @@ bool fold_sparse_to_dense(luci::CircleSparseToDense *stod)
     constant->at<ValueT>(i) = value;
 
   constant->shape_status(luci::ShapeStatus::VALID);
+  constant->name(name + "_D");
 
   loco::replace(stod).with(constant);
 

--- a/compiler/luci/pass/src/ForwardReshapeToUnaryOpPass.cpp
+++ b/compiler/luci/pass/src/ForwardReshapeToUnaryOpPass.cpp
@@ -63,11 +63,14 @@ bool forward_reshape(luci::CircleReshape *reshape, luci::CircleNeg *neg)
   if (cloned_shape == nullptr)
     return false;
 
+  auto name = reshape->name();
+  assert(name.length() > 0);
   loco::Graph *graph = neg->graph();
   // create reshape placed after neg
   luci::CircleReshape *new_reshape = graph->nodes()->create<luci::CircleReshape>();
   copy_shape(reshape, new_reshape);
   new_reshape->shape(cloned_shape);
+  new_reshape->name(name + "_C");
 
   // reconnect network
   loco::replace(neg).with(new_reshape);


### PR DESCRIPTION
This will assign names for new nodes in FoldDequantizePass, 
FoldSparseToDensePass and ForwardReshapeToUnaryOpPass..

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>