### PR TITLE
[luci] Names for new nodes in FuseAddWithTConvPass

### DIFF
--- a/compiler/luci/pass/src/FuseAddWithTConvPass.cpp
+++ b/compiler/luci/pass/src/FuseAddWithTConvPass.cpp
@@ -90,9 +90,12 @@ bool fuse_add_with_tconv(luci::CircleTransposeConv *tconv)
 
   if (add->fusedActivationFunction() == luci::FusedActFunc::RELU6)
   {
+    auto name = addition->name();
+    assert(name.length() > 0);
     // separate relu op from add op
     auto relu = add->graph()->nodes()->create<luci::CircleRelu6>();
     relu->features(tconv);
+    relu->name(name + "/Relu6");
 
     // remove add node
     replace(add).with(relu);


### PR DESCRIPTION
This will assign names for new nodes in FuseAddWithTConvPass,
FuseBatchNormWithConvPass, FuseBatchNormWithDwConvPass and
FuseBatchNormWithTConvPass.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>