### PR TITLE
[luci] Names for new nodes in FuseInstanceNormPass

### DIFF
--- a/compiler/luci/pass/src/FuseInstanceNormPass.cpp
+++ b/compiler/luci/pass/src/FuseInstanceNormPass.cpp
@@ -564,6 +564,8 @@ void fuse_instance_norm(const InstanceNormPattern &p)
   float epsilon = p.const_as_epsilon->at<loco::DataType::FLOAT32>(0);
   instance_norm->epsilon(epsilon);
   instance_norm->fusedActivationFunction(p.add_as_terminal->fusedActivationFunction());
+  // NOTE unique name should be assigned in export
+  instance_norm->name("InstanceNorm");
 
   replace(p.add_as_terminal).with(instance_norm);
 }


### PR DESCRIPTION
This will assign names for new nodes in FuseInstanceNormPass and
FusePreActivationBatchNormPass.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>