### PR TITLE
[luci] Names for new nodes in RemoveRedundantTransposePass

### DIFF
--- a/compiler/luci/pass/src/RemoveRedundantTransposePass.cpp
+++ b/compiler/luci/pass/src/RemoveRedundantTransposePass.cpp
@@ -56,6 +56,9 @@ bool remove_consecutive_transpose_function(luci::CircleTranspose *target_node)
   }
   else
   {
+    auto name = target_node->name();
+    assert(name.length() > 0);
+
     auto g = main_perm->graph();
     auto new_const_node = g->nodes()->create<luci::CircleConst>();
 
@@ -69,12 +72,14 @@ bool remove_consecutive_transpose_function(luci::CircleTranspose *target_node)
       new_const_node->at<loco::DataType::S32>(i) =
         pred_perm->at<loco::DataType::S32>(main_perm->at<loco::DataType::S32>(i));
     }
+    new_const_node->name(name + "/Transpose/perm");
 
     // Create New Transpose Node
     auto new_transpose_node = g->nodes()->create<luci::CircleTranspose>();
     new_transpose_node->dtype(target_node->dtype());
     new_transpose_node->a(main_node);
     new_transpose_node->perm(new_const_node);
+    new_transpose_node->name(name + "/Transpose");
 
     replace(target_node).with(new_transpose_node);
   }

--- a/compiler/luci/pass/src/ResolveCustomOpAddPass.cpp
+++ b/compiler/luci/pass/src/ResolveCustomOpAddPass.cpp
@@ -67,10 +67,15 @@ bool resolve_with_BroadcastTo(luci::CircleCustom *addv2)
   auto input = loco::must_cast<const luci::CircleCustomOut *>(addv2->inputs(broadcastTo_idx));
   auto broadcastTo = loco::must_cast<luci::CircleCustom *>(input->input());
 
+  auto name = addv2->name();
+  assert(name.length() > 0);
+
   auto add = addv2->graph()->nodes()->create<luci::CircleAdd>();
   add->fusedActivationFunction(luci::FusedActFunc::NONE);
   add->x(addv2->inputs(1 - broadcastTo_idx));
   add->y(broadcastTo->inputs(0));
+  add->name(name + "/Add");
+
   auto customOut = loco::succs(addv2);
   assert(customOut.size() == 1);
   replace(*customOut.begin()).with(add);
@@ -109,10 +114,15 @@ bool resolve_custom_op(luci::CircleCustom *addv2)
   if (resolve_with_BroadcastTo(addv2))
     return true;
 
+  auto name = addv2->name();
+  assert(name.length() > 0);
+
   auto add = addv2->graph()->nodes()->create<luci::CircleAdd>();
   add->fusedActivationFunction(luci::FusedActFunc::NONE);
   add->x(addv2->inputs(0));
   add->y(addv2->inputs(1));
+  add->name(name + "/Add");
+
   auto customOut = loco::succs(addv2);
   assert(customOut.size() == 1);
   replace(*customOut.begin()).with(add);

--- a/compiler/luci/pass/src/ResolveCustomOpBatchMatMulPass.cpp
+++ b/compiler/luci/pass/src/ResolveCustomOpBatchMatMulPass.cpp
@@ -30,6 +30,9 @@ bool resolve_custom_op(luci::CircleCustom *cop)
 
   if (custom_code == "BatchMatMulV2")
   {
+    auto name = cop->name();
+    assert(name.length() > 0);
+
     auto batch_matmul = cop->graph()->nodes()->create<luci::CircleBatchMatMul>();
     // input
     batch_matmul->x(cop->inputs(0));
@@ -39,6 +42,7 @@ bool resolve_custom_op(luci::CircleCustom *cop)
     auto map = flexbuffers::GetRoot(custom_options).AsMap();
     batch_matmul->adj_x(map["adj_x"].AsBool());
     batch_matmul->adj_y(map["adj_y"].AsBool());
+    batch_matmul->name(name + "/BatchMatMul");
 
     auto customOut = loco::succs(cop);
     assert(customOut.size() == 1);


### PR DESCRIPTION
This will assign names for new nodes in RemoveRedundantTransposePass,
ReplaceMulAddWithDepthwiseConvPass, ResolveCustomOpAddPass,
ResolveCustomOpBatchMatMulPass and ResolveCustomOpMatMulPass.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>