### PR TITLE
[luci] Names for new nodes in ShuffleWeightTo16x1Float32Pass

### DIFF
--- a/compiler/luci/pass/src/ShuffleWeightTo16x1Float32Pass.cpp
+++ b/compiler/luci/pass/src/ShuffleWeightTo16x1Float32Pass.cpp
@@ -72,6 +72,9 @@ luci::CircleConst *shuffle_weight(luci::CircleFullyConnected *fc)
 {
   auto the_weights = loco::must_cast<luci::CircleConst *>(fc->weights());
 
+  auto name = fc->name();
+  assert(name.length() > 0);
+
   // create CircleConst where shuffled data will be stored
   luci::CircleConst *new_weights = fc->graph()->nodes()->create<luci::CircleConst>();
   new_weights->dtype(loco::DataType::FLOAT32);
@@ -82,6 +85,7 @@ luci::CircleConst *shuffle_weight(luci::CircleFullyConnected *fc)
   {
     new_weights->dim(r).set(the_weights->dim(r).value());
   }
+  new_weights->name(name + "/shuffle_weight");
 
   // suffle weight
   const uint32_t MULTIPLE = 16;

--- a/compiler/luci/pass/src/SubstitutePackToReshapePass.cpp
+++ b/compiler/luci/pass/src/SubstitutePackToReshapePass.cpp
@@ -46,9 +46,13 @@ bool substitute_pack_to_reshape(luci::CircleNode *node)
   if (axis < 0)
     axis = axis + static_cast<int32_t>(value_node->rank()) + 1;
 
+  auto name = node->name();
+  assert(name.length() > 0);
+
   auto graph = target_node->graph();
   auto reshape_node = graph->nodes()->create<luci::CircleReshape>();
   reshape_node->tensor(value_node);
+  reshape_node->name(name + "/Reshape");
 
   auto const_node = graph->nodes()->create<luci::CircleConst>();
   const_node->dtype(loco::DataType::S32);
@@ -73,6 +77,7 @@ bool substitute_pack_to_reshape(luci::CircleNode *node)
         value_node->dim(i - 1).known() ? value_node->dim(i - 1).value() : -1;
     }
   }
+  const_node->name(name + "/Reshape/shape");
   reshape_node->shape(const_node);
   replace(target_node).with(reshape_node);
   return true;

--- a/compiler/luci/pass/src/SubstituteSqueezeToReshapePass.cpp
+++ b/compiler/luci/pass/src/SubstituteSqueezeToReshapePass.cpp
@@ -122,10 +122,15 @@ bool substitute_squeeze_to_reshape(luci::CircleSqueeze *squeeze)
   if (not is_valid_input(input, squeeze_dims))
     throw std::runtime_error("Invalid values in squeeze_dims: " + squeeze->name());
 
+  auto name = squeeze->name();
+  assert(name.length() > 0);
+
   auto reshape_shape = node_shape(squeeze);
   auto graph = squeeze->graph();
   auto reshape = graph->nodes()->create<luci::CircleReshape>();
   auto shape_const = create_shape_const(graph, reshape_shape);
+  reshape->name(name + "/Reshape");
+  shape_const->name(name + "/Reshape/shape");
 
   // graph connection
   reshape->tensor(input);

--- a/compiler/luci/pass/src/SubstituteTransposeToReshapePass.cpp
+++ b/compiler/luci/pass/src/SubstituteTransposeToReshapePass.cpp
@@ -65,6 +65,9 @@ bool substitute_transpose_to_reshape(luci::CircleTranspose *node)
     idx = perm_value;
   }
 
+  auto name = node->name();
+  assert(name.length() > 0);
+
   auto new_const_node = node->graph()->nodes()->create<luci::CircleConst>();
   new_const_node->dtype(loco::DataType::S32);
   new_const_node->size<loco::DataType::S32>(size_items);
@@ -83,6 +86,8 @@ bool substitute_transpose_to_reshape(luci::CircleTranspose *node)
   auto new_reshape_node = node->graph()->nodes()->create<luci::CircleReshape>();
   new_reshape_node->tensor(input_node);
   new_reshape_node->shape(new_const_node);
+  new_reshape_node->name(name + "/Reshape");
+  new_const_node->name(name + "/Reshape/shape");
 
   replace(node).with(new_reshape_node);
   return true;

--- a/compiler/luci/pass/src/TransformMinMaxToRelu6Pass.cpp
+++ b/compiler/luci/pass/src/TransformMinMaxToRelu6Pass.cpp
@@ -95,9 +95,13 @@ template <loco::DataType DT> bool transform_min_max_pattern(luci::CircleMaximum 
                                    static_cast<typename loco::DataTypeImpl<DT>::Type>(6)))
     return false;
 
+  auto name = maxi->name();
+  assert(name.length() > 0);
+
   // Create Relu6 op
   auto relu6 = mini->graph()->nodes()->create<luci::CircleRelu6>();
   relu6->features(mini_input);
+  relu6->name(name + "/Relu6");
 
   replace(maxi).with(relu6);
 


### PR DESCRIPTION
This will assign names for new nodes in ShuffleWeightTo16x1Float32Pass,
SubstitutePackToReshapePass, SubstituteSqueezeToReshapePass,
SubstituteTransposeToReshapePass, TransformMinMaxToRelu6Pass.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>