### PR TITLE
[luci] Introduce refactored tests for Relu in luci/service 

### DIFF
--- a/compiler/luci/service/src/Nodes/CircleRelu.test.cpp
+++ b/compiler/luci/service/src/Nodes/CircleRelu.test.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <luci/IR/CircleNodes.h>
+#include <luci/Service/CircleShapeInference.h>
+#include <luci/Service/CircleTypeInference.h>
+
+#include <loco/IR/TensorShape.h>
+
+#include <gtest/gtest.h>
+
+TEST(ShapeRuleTest, simple_relu)
+{
+  luci::CircleInput input;
+  luci::CircleRelu relu;
+
+  input.shape({3, 4});
+  input.shape_status(luci::ShapeStatus::VALID);
+
+  relu.features(&input);
+
+  loco::TensorShape shape;
+  luci::sinf::Rule shape_inf_rule;
+
+  ASSERT_TRUE(shape_inf_rule.infer(&relu, shape));
+  ASSERT_EQ(2, shape.rank());
+  ASSERT_EQ(3, shape.dim(0).value());
+  ASSERT_EQ(4, shape.dim(1).value());
+}
+
+TEST(DataTypeRuleTest, simple_relu)
+{
+  luci::CircleInput input;
+  luci::CircleRelu relu;
+
+  input.dtype(loco::DataType::S32);
+
+  relu.features(&input);
+
+  loco::DataType dtype;
+  luci::tinf::Rule type_inf_rule;
+
+  ASSERT_TRUE(type_inf_rule.infer(&relu, dtype));
+  ASSERT_EQ(loco::DataType::S32, dtype);
+}


### PR DESCRIPTION
Parent Issue : #6062
Draft : #5811

This commit will introduce new tests for `CircleRelu` in `luci/Service`.
The new tests are refactored with current tests in `Circle*Rule.test.cpp`.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>