### PR TITLE
[onert/lib] Move CopyInputInitializer class definition

### DIFF
--- a/runtime/libs/tflite/include/tflite/CopyInputInitializer.h
+++ b/runtime/libs/tflite/include/tflite/CopyInputInitializer.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __NNFW_TFLITE_COPY_INPUT_INITIALIZER_H__
+#define __NNFW_TFLITE_COPY_INPUT_INITIALIZER_H__
+
+#include <tensorflow/lite/interpreter.h>
+
+namespace nnfw
+{
+namespace tflite
+{
+
+class CopyInputInitializer
+{
+public:
+  CopyInputInitializer(::tflite::Interpreter &from) : _from{from}
+  {
+    // DO NOTHING
+  }
+
+  void run(::tflite::Interpreter &interp);
+
+private:
+  template <typename T> void setValue(::tflite::Interpreter &interp, int tensor_idx);
+
+private:
+  ::tflite::Interpreter &_from;
+};
+
+} // namespace tflite
+} // namespace nnfw
+
+#endif // __NNFW_TFLITE_COPY_INPUT_INITIALIZER_H__

--- a/runtime/libs/tflite/src/CopyInputInitializer.cpp
+++ b/runtime/libs/tflite/src/CopyInputInitializer.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "tflite/CopyInputInitializer.h"
+#include "tflite/TensorView.h"
+
+#include <misc/tensor/IndexIterator.h>
+
+namespace nnfw
+{
+namespace tflite
+{
+
+void CopyInputInitializer::run(::tflite::Interpreter &interp)
+{
+  for (const auto &tensor_idx : interp.inputs())
+  {
+    TfLiteTensor *tensor = interp.tensor(tensor_idx);
+    if (tensor->type == kTfLiteInt32)
+    {
+      setValue<int32_t>(interp, tensor_idx);
+    }
+    else if (tensor->type == kTfLiteUInt8)
+    {
+      setValue<uint8_t>(interp, tensor_idx);
+    }
+    else if (tensor->type == kTfLiteInt8)
+    {
+      setValue<int8_t>(interp, tensor_idx);
+    }
+    else if (tensor->type == kTfLiteBool)
+    {
+      setValue<bool>(interp, tensor_idx);
+    }
+    else
+    {
+      assert(tensor->type == kTfLiteFloat32);
+
+      setValue<float>(interp, tensor_idx);
+    }
+  }
+}
+
+template <typename T>
+void CopyInputInitializer::setValue(::tflite::Interpreter &interp, int tensor_idx)
+{
+  auto tensor_from_view = nnfw::tflite::TensorView<T>::make(_from, tensor_idx);
+  auto tensor_to_view = nnfw::tflite::TensorView<T>::make(interp, tensor_idx);
+
+  nnfw::misc::tensor::iterate(tensor_from_view.shape())
+    << [&](const nnfw::misc::tensor::Index &ind) {
+         tensor_to_view.at(ind) = tensor_from_view.at(ind);
+       };
+}
+
+} // namespace tflite
+} // namespace nnfw

--- a/runtime/libs/tflite/src/CopyInputInitializer.cpp
+++ b/runtime/libs/tflite/src/CopyInputInitializer.cpp
@@ -29,27 +29,25 @@ void CopyInputInitializer::run(::tflite::Interpreter &interp)
   for (const auto &tensor_idx : interp.inputs())
   {
     TfLiteTensor *tensor = interp.tensor(tensor_idx);
-    if (tensor->type == kTfLiteInt32)
+    switch (tensor->type)
     {
-      setValue<int32_t>(interp, tensor_idx);
-    }
-    else if (tensor->type == kTfLiteUInt8)
-    {
-      setValue<uint8_t>(interp, tensor_idx);
-    }
-    else if (tensor->type == kTfLiteInt8)
-    {
-      setValue<int8_t>(interp, tensor_idx);
-    }
-    else if (tensor->type == kTfLiteBool)
-    {
-      setValue<bool>(interp, tensor_idx);
-    }
-    else
-    {
-      assert(tensor->type == kTfLiteFloat32);
-
-      setValue<float>(interp, tensor_idx);
+      case kTfLiteInt32:
+        setValue<int32_t>(interp, tensor_idx);
+        break;
+      case kTfLiteUInt8:
+        setValue<uint8_t>(interp, tensor_idx);
+        break;
+      case kTfLiteInt8:
+        setValue<int8_t>(interp, tensor_idx);
+        break;
+      case kTfLiteBool:
+        setValue<bool>(interp, tensor_idx);
+        break;
+      case kTfLiteFloat32:
+        setValue<float>(interp, tensor_idx);
+        break;
+      default:
+        throw std::runtime_error{"Not supported input type"};
     }
   }
 }

--- a/runtime/libs/tflite/src/RandomTestRunner.cpp
+++ b/runtime/libs/tflite/src/RandomTestRunner.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "tflite/CopyInputInitializer.h"
 #include "tflite/OutputResetter.h"
 #include "tflite/RandomInputInitializer.h"
 #include "tflite/RandomTestRunner.h"
@@ -37,60 +38,6 @@ namespace tflite
 {
 
 using namespace std::placeholders;
-
-class CopyInputInitializer
-{
-public:
-  CopyInputInitializer(::tflite::Interpreter &from) : _from{from}
-  {
-    // DO NOTHING
-  }
-
-  void run(::tflite::Interpreter &interp)
-  {
-    for (const auto &tensor_idx : interp.inputs())
-    {
-      TfLiteTensor *tensor = interp.tensor(tensor_idx);
-      if (tensor->type == kTfLiteInt32)
-      {
-        setValue<int32_t>(interp, tensor_idx);
-      }
-      else if (tensor->type == kTfLiteUInt8)
-      {
-        setValue<uint8_t>(interp, tensor_idx);
-      }
-      else if (tensor->type == kTfLiteInt8)
-      {
-        setValue<int8_t>(interp, tensor_idx);
-      }
-      else if (tensor->type == kTfLiteBool)
-      {
-        setValue<bool>(interp, tensor_idx);
-      }
-      else
-      {
-        assert(tensor->type == kTfLiteFloat32);
-
-        setValue<float>(interp, tensor_idx);
-      }
-    }
-  }
-
-private:
-  template <typename T> void setValue(::tflite::Interpreter &interp, int tensor_idx)
-  {
-    auto tensor_from_view = nnfw::tflite::TensorView<T>::make(_from, tensor_idx);
-    auto tensor_to_view = nnfw::tflite::TensorView<T>::make(interp, tensor_idx);
-
-    nnfw::misc::tensor::iterate(tensor_from_view.shape())
-      << [&](const nnfw::misc::tensor::Index &ind) {
-           tensor_to_view.at(ind) = tensor_from_view.at(ind);
-         };
-  }
-
-private:
-  ::tflite::Interpreter &_from;
-};
 
 void RandomTestRunner::compile(const nnfw::tflite::Builder &builder)
 {


### PR DESCRIPTION
This commit get CopyInputInitializer out of RandomTestRunner.cpp like RandomInputInitializer

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: https://github.com/Samsung/ONE/pull/6049#discussion_r577284326