### PR TITLE
[luci] Revise import validate for BC-Ops

### DIFF
--- a/compiler/luci/import/src/Nodes/CircleBCQFullyConnected.cpp
+++ b/compiler/luci/import/src/Nodes/CircleBCQFullyConnected.cpp
@@ -25,10 +25,7 @@ namespace luci
 
 bool CircleBCQFullyConnectedGraphBuilder::validate(const ValidateArgs &args) const
 {
-  if (args.op.inputs.size() != 5)
-    return false;
-
-  return true;
+  return GraphBuilder::validate(args, 5);
 }
 
 CircleNode *CircleBCQFullyConnectedGraphBuilder::build_node(const circle::OperatorT &op,

--- a/compiler/luci/import/src/Nodes/CircleBCQGather.cpp
+++ b/compiler/luci/import/src/Nodes/CircleBCQGather.cpp
@@ -25,10 +25,7 @@ namespace luci
 
 bool CircleBCQGatherGraphBuilder::validate(const ValidateArgs &args) const
 {
-  if (args.op.inputs.size() != 4)
-    return false;
-
-  return true;
+  return GraphBuilder::validate(args, 4);
 }
 
 CircleNode *CircleBCQGatherGraphBuilder::build_node(const circle::OperatorT &op,

--- a/compiler/luci/import/src/Nodes/CircleBatchMatMul.cpp
+++ b/compiler/luci/import/src/Nodes/CircleBatchMatMul.cpp
@@ -23,10 +23,7 @@ namespace luci
 
 bool CircleBatchMatMulGraphBuilder::validate(const ValidateArgs &args) const
 {
-  if (args.op.inputs.size() != 2)
-    return false;
-
-  return true;
+  return GraphBuilder::validate(args, 2);
 }
 
 CircleNode *CircleBatchMatMulGraphBuilder::build_node(const circle::OperatorT &op,

--- a/compiler/luci/import/src/Nodes/CircleCast.cpp
+++ b/compiler/luci/import/src/Nodes/CircleCast.cpp
@@ -30,14 +30,13 @@ bool CircleCastGraphBuilder::validate(const ValidateArgs &args) const
 {
   LOGGER(l);
 
+  if (!GraphBuilder::validate(args, 1))
+    return false;
+
   auto settings = luci::UserSettings::settings();
 
   const auto &inputs = args.op.inputs;
   const auto &outputs = args.op.outputs;
-  if (inputs.size() != 1)
-    return false;
-  if (outputs.size() != 1)
-    return false;
 
   // NOTE real models do have type mismatch
   const auto *options = args.op.builtin_options.AsCastOptions();

--- a/compiler/luci/import/src/Nodes/CircleCeil.cpp
+++ b/compiler/luci/import/src/Nodes/CircleCeil.cpp
@@ -25,16 +25,8 @@ namespace luci
 
 bool CircleCeilGraphBuilder::validate(const ValidateArgs &args) const
 {
-  const auto &inputs = args.op.inputs;
-  const auto &outputs = args.op.outputs;
-  if (inputs.size() != 1)
-    return false;
-  if (outputs.size() != 1)
-    return false;
-
   // TODO dtype check
-
-  return true;
+  return GraphBuilder::validate(args, 1);
 }
 
 CircleNode *CircleCeilGraphBuilder::build_node(const circle::OperatorT &,

--- a/compiler/luci/import/src/Nodes/CircleConv2D.cpp
+++ b/compiler/luci/import/src/Nodes/CircleConv2D.cpp
@@ -28,10 +28,7 @@ namespace luci
 bool CircleConv2DGraphBuilder::validate(const ValidateArgs &args) const
 {
   // Circle Conv2D may not have a bias but we won't support this
-  if (args.op.inputs.size() != 3)
-    return false;
-
-  return true;
+  return GraphBuilder::validate(args, 3);
 }
 
 CircleNode *CircleConv2DGraphBuilder::build_node(const circle::OperatorT &op,

--- a/compiler/luci/import/src/Nodes/CircleCos.cpp
+++ b/compiler/luci/import/src/Nodes/CircleCos.cpp
@@ -25,10 +25,7 @@ namespace luci
 
 bool CircleCosGraphBuilder::validate(const ValidateArgs &args) const
 {
-  if (args.op.inputs.size() != 1)
-    return false;
-
-  return true;
+  return GraphBuilder::validate(args, 1);
 }
 
 CircleNode *CircleCosGraphBuilder::build_node(const circle::OperatorT &,


### PR DESCRIPTION
This will revise import validate with input count with single output for
Ops starting with B,C.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>