### PR TITLE
[luci] Revise import validate for DE-Ops

### DIFF
--- a/compiler/luci/import/src/Nodes/CircleDepthToSpace.cpp
+++ b/compiler/luci/import/src/Nodes/CircleDepthToSpace.cpp
@@ -27,17 +27,13 @@ namespace luci
 
 bool CircleDepthToSpaceGraphBuilder::validate(const ValidateArgs &args) const
 {
+  if (!GraphBuilder::validate(args, 1))
+    return false;
+
   const auto &inputs = args.op.inputs;
   const auto &outputs = args.op.outputs;
 
   const auto *options = args.op.builtin_options.AsDepthToSpaceOptions();
-
-  if (inputs.size() != 1)
-    return false;
-
-  if (outputs.size() != 1)
-    return false;
-
   const auto &tensors = args.reader.tensors();
 
   if (tensors[outputs[0]]->type != tensors[inputs.at(0)]->type)

--- a/compiler/luci/import/src/Nodes/CircleDequantize.cpp
+++ b/compiler/luci/import/src/Nodes/CircleDequantize.cpp
@@ -25,10 +25,7 @@ namespace luci
 
 bool CircleDequantizeGraphBuilder::validate(const ValidateArgs &args) const
 {
-  if (args.op.inputs.size() != 1)
-    return false;
-
-  return true;
+  return GraphBuilder::validate(args, 1);
 }
 
 CircleNode *CircleDequantizeGraphBuilder::build_node(const circle::OperatorT &,

--- a/compiler/luci/import/src/Nodes/CircleDiv.cpp
+++ b/compiler/luci/import/src/Nodes/CircleDiv.cpp
@@ -23,13 +23,7 @@ namespace luci
 
 bool CircleDivGraphBuilder::validate(const ValidateArgs &args) const
 {
-  if (args.op.inputs.size() != 2)
-    return false;
-
-  if (args.op.outputs.size() != 1)
-    return false;
-
-  return true;
+  return GraphBuilder::validate(args, 2);
 }
 
 CircleNode *CircleDivGraphBuilder::build_node(const circle::OperatorT &op,

--- a/compiler/luci/import/src/Nodes/CircleElu.cpp
+++ b/compiler/luci/import/src/Nodes/CircleElu.cpp
@@ -25,14 +25,11 @@ namespace luci
 
 bool CircleEluGraphBuilder::validate(const ValidateArgs &args) const
 {
+  if (!GraphBuilder::validate(args, 1))
+    return false;
+
   const auto &inputs = args.op.inputs;
   const auto &outputs = args.op.outputs;
-
-  if (inputs.size() != 1)
-    return false;
-
-  if (outputs.size() != 1)
-    return false;
 
   const auto &tensors = args.reader.tensors();
   const auto &tensor = tensors.at(inputs.at(0));

--- a/compiler/luci/import/src/Nodes/CircleEqual.cpp
+++ b/compiler/luci/import/src/Nodes/CircleEqual.cpp
@@ -25,13 +25,10 @@ namespace luci
 
 bool CircleEqualGraphBuilder::validate(const ValidateArgs &args) const
 {
-  const auto &inputs = args.op.inputs;
-
-  if (inputs.size() != 2)
-  {
+  if (!GraphBuilder::validate(args, 2))
     return false;
-  }
 
+  const auto &inputs = args.op.inputs;
   const auto &tensors = args.reader.tensors();
 
   return tensors[inputs.at(0)]->type == tensors[inputs.at(1)]->type;

--- a/compiler/luci/import/src/Nodes/CircleExp.cpp
+++ b/compiler/luci/import/src/Nodes/CircleExp.cpp
@@ -25,10 +25,10 @@ namespace luci
 
 bool CircleExpGraphBuilder::validate(const ValidateArgs &args) const
 {
-  const auto &inputs = args.op.inputs;
-  if (inputs.size() != 1)
+  if (!GraphBuilder::validate(args, 1))
     return false;
 
+  const auto &inputs = args.op.inputs;
   // input type check
   const auto &tensors = args.reader.tensors();
   const auto &tensor = tensors.at(inputs.at(0));

--- a/compiler/luci/import/src/Nodes/CircleExpandDims.cpp
+++ b/compiler/luci/import/src/Nodes/CircleExpandDims.cpp
@@ -25,13 +25,10 @@ namespace luci
 
 bool CircleExpandDimsGraphBuilder::validate(const ValidateArgs &args) const
 {
-  const auto &inputs = args.op.inputs;
-
-  if (inputs.size() != 2)
-  {
+  if (!GraphBuilder::validate(args, 2))
     return false;
-  }
 
+  const auto &inputs = args.op.inputs;
   const auto &tensors = args.reader.tensors();
 
   return tensors[inputs.at(1)]->type == circle::TensorType_INT32;


### PR DESCRIPTION
This will revise import validate with input count with single output for
Ops starting with D,E.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>