### PR TITLE
[luci] Revise import validate for TUWZ-Ops

### DIFF
--- a/compiler/luci/import/src/Nodes/CircleTanh.cpp
+++ b/compiler/luci/import/src/Nodes/CircleTanh.cpp
@@ -25,13 +25,11 @@ namespace luci
 
 bool CircleTanhGraphBuilder::validate(const ValidateArgs &args) const
 {
-  const auto &inputs = args.op.inputs;
-  if (inputs.size() != 1)
-    return false;
-  const auto &outputs = args.op.outputs;
-  if (outputs.size() != 1)
+  if (!GraphBuilder::validate(args, 1))
     return false;
 
+  const auto &inputs = args.op.inputs;
+  const auto &outputs = args.op.outputs;
   const auto &tensors = args.reader.tensors();
   if (tensors.at(inputs.at(0))->type != tensors.at(outputs[0])->type)
     return false;

--- a/compiler/luci/import/src/Nodes/CircleTile.cpp
+++ b/compiler/luci/import/src/Nodes/CircleTile.cpp
@@ -25,15 +25,11 @@ namespace luci
 
 bool CircleTileGraphBuilder::validate(const ValidateArgs &args) const
 {
+  if (!GraphBuilder::validate(args, 2))
+    return false;
+
   auto inputs = args.op.inputs;
   auto outputs = args.op.outputs;
-
-  if (inputs.size() != 2)
-    return false;
-
-  if (outputs.size() != 1)
-    return false;
-
   // Multiples (inputs.at(1)) must be one of the following types
   // int32, int64
   const auto &tensors = args.reader.tensors();

--- a/compiler/luci/import/src/Nodes/CircleTranspose.cpp
+++ b/compiler/luci/import/src/Nodes/CircleTranspose.cpp
@@ -25,13 +25,7 @@ namespace luci
 
 bool CircleTransposeGraphBuilder::validate(const ValidateArgs &args) const
 {
-  if (args.op.inputs.size() != 2)
-    return false;
-
-  if (args.op.outputs.size() != 1)
-    return false;
-
-  return true;
+  return GraphBuilder::validate(args, 2);
 }
 
 CircleNode *CircleTransposeGraphBuilder::build_node(const circle::OperatorT &op,

--- a/compiler/luci/import/src/Nodes/CircleUnidirectionalSequenceLSTM.cpp
+++ b/compiler/luci/import/src/Nodes/CircleUnidirectionalSequenceLSTM.cpp
@@ -25,10 +25,7 @@ namespace luci
 
 bool CircleUnidirectionalSequenceLSTMGraphBuilder::validate(const ValidateArgs &args) const
 {
-  if (args.op.inputs.size() != 24)
-    return false;
-
-  return true;
+  return GraphBuilder::validate(args, 24);
 }
 
 CircleNode *CircleUnidirectionalSequenceLSTMGraphBuilder::build_node(

--- a/compiler/luci/import/src/Nodes/CircleWhere.cpp
+++ b/compiler/luci/import/src/Nodes/CircleWhere.cpp
@@ -25,15 +25,11 @@ namespace luci
 
 bool CircleWhereGraphBuilder::validate(const ValidateArgs &args) const
 {
+  if (!GraphBuilder::validate(args, 1))
+    return false;
+
   const auto &inputs = args.op.inputs;
   const auto &outputs = args.op.outputs;
-
-  if (inputs.size() != 1)
-    return false;
-
-  if (outputs.size() != 1)
-    return false;
-
   const auto &tensors = args.reader.tensors();
   const auto &tensor_condition = tensors.at(inputs.at(0));
   const auto &tensor_out = tensors.at(outputs[0]);

--- a/compiler/luci/import/src/Nodes/CircleZerosLike.cpp
+++ b/compiler/luci/import/src/Nodes/CircleZerosLike.cpp
@@ -25,13 +25,7 @@ namespace luci
 
 bool CircleZerosLikeGraphBuilder::validate(const ValidateArgs &args) const
 {
-  if (args.op.inputs.size() != 1)
-    return false;
-
-  if (args.op.outputs.size() != 1)
-    return false;
-
-  return true;
+  return GraphBuilder::validate(args, 1);
 }
 
 CircleNode *CircleZerosLikeGraphBuilder::build_node(const circle::OperatorT &,


### PR DESCRIPTION
This will revise import validate with input count with single output for
Ops starting with T,U,W,Z.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>