### PR TITLE
[luci] revise get_channel_dim_index arg type

### DIFF
--- a/compiler/luci/pass/src/QuantizationUtils.cpp
+++ b/compiler/luci/pass/src/QuantizationUtils.cpp
@@ -226,7 +226,8 @@ void compute_asym_scale_zp(float min, float max, float &scaling_factor, int64_t 
   zp = nudged_zero_point;
 }
 
-bool get_channel_dim_index(CircleConst *node, loco::TensorShape &dimension, int &channel_dim_index)
+bool get_channel_dim_index(CircleConst *node, loco::TensorShape &dimension,
+                           int32_t &channel_dim_index)
 {
   auto succs = loco::succs(node);
 

--- a/compiler/luci/pass/src/QuantizationUtils.h
+++ b/compiler/luci/pass/src/QuantizationUtils.h
@@ -37,7 +37,8 @@ void symmetric_wquant_with_minmax_per_layer(CircleConst *node, float min, float 
                                             float &scaling_factor, int64_t &zp, float &nudged_min,
                                             float &nudged_max);
 
-bool get_channel_dim_index(CircleConst *node, loco::TensorShape &dimension, int &channel_dim_index);
+bool get_channel_dim_index(CircleConst *node, loco::TensorShape &dimension,
+                           int32_t &channel_dim_index);
 
 uint32_t cal_offset(loco::TensorShape &dimension, uint32_t *indices);
 

--- a/compiler/luci/pass/src/QuantizeDequantizeWeightsPass.cpp
+++ b/compiler/luci/pass/src/QuantizeDequantizeWeightsPass.cpp
@@ -30,7 +30,7 @@ namespace
 {
 
 using namespace luci;
-using IterFunc = std::function<void(uint32_t *, loco::TensorShape &, int)>;
+using IterFunc = std::function<void(uint32_t *, loco::TensorShape &, int32_t)>;
 
 void iterate_per_channel(CircleConst *node, IterFunc func)
 {
@@ -39,7 +39,7 @@ void iterate_per_channel(CircleConst *node, IterFunc func)
   uint32_t indices[4] = {
     0,
   };
-  int channel_dim_index{0};
+  int32_t channel_dim_index{0};
 
   if (!get_channel_dim_index(node, dimension, channel_dim_index))
   {
@@ -74,7 +74,7 @@ void cal_minmax_per_channel(CircleConst *node, std::vector<float> &min, std::vec
 {
   loco::TensorShape dimension;
   dimension.rank(4);
-  int channel_dim_index{0};
+  int32_t channel_dim_index{0};
   int size{0};
 
   if (!get_channel_dim_index(node, dimension, channel_dim_index))


### PR DESCRIPTION
This will revise get_channel_dim_index arg type with int32_t for
specific length.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>