### PR TITLE
[luci] Relocate Relu check

### DIFF
--- a/compiler/luci/pass/src/FusePreActivationBatchNormPass.cpp
+++ b/compiler/luci/pass/src/FusePreActivationBatchNormPass.cpp
@@ -83,9 +83,6 @@ bool is_batchnorm_add(const luci::CircleAdd *add, luci::CircleMul *&mul, luci::C
   luci::CircleMul *pred = nullptr;
   luci::CircleConst *constant = nullptr;
 
-  if (add->fusedActivationFunction() != luci::FusedActFunc::RELU)
-    return false;
-
   if (x->opcode() == luci::CircleOpcode::CIRCLECONST && y->opcode() == luci::CircleOpcode::MUL)
   {
     pred = loco::must_cast<luci::CircleMul *>(y);
@@ -569,6 +566,8 @@ bool swap_mul_add(luci::CircleAdd *add, std::vector<luci::CircleMul *> &mul_list
   luci::CircleConst *gamma = nullptr;
 
   if (!is_batchnorm_add(add, mul, beta))
+    return false;
+  if (add->fusedActivationFunction() != luci::FusedActFunc::RELU)
     return false;
 
   if (loco::succs(mul).size() != 1)

--- a/compiler/luci/pass/src/MakeBatchNormGammaPositivePass.cpp
+++ b/compiler/luci/pass/src/MakeBatchNormGammaPositivePass.cpp
@@ -57,10 +57,6 @@ bool is_batchnorm_add(const luci::CircleAdd *add)
   if (constant->rank() != 1)
     return false;
 
-  // Only support Relu
-  if (add->fusedActivationFunction() != luci::FusedActFunc::RELU)
-    return false;
-
   auto channel_dim = constant->dim(0);
   if (!(channel_dim == add->dim(add->rank() - 1)))
     return false;
@@ -100,6 +96,9 @@ bool is_batchnorm_mul(const luci::CircleMul *mul, luci::CircleConst *&gamma)
     return false;
 
   if (!is_batchnorm_add(add))
+    return false;
+  // Only support Relu
+  if (add->fusedActivationFunction() != luci::FusedActFunc::RELU)
     return false;
 
   gamma = constant;


### PR DESCRIPTION
This will revise to check Add activation is Relu prior to reduce
duplicate codes: is_batchnorm_add method.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>