### PR TITLE
[luci] Simplify cal_minmax_per_channel

### DIFF
--- a/compiler/luci/pass/src/QuantizeDequantizeWeightsPass.cpp
+++ b/compiler/luci/pass/src/QuantizeDequantizeWeightsPass.cpp
@@ -75,14 +75,13 @@ void cal_minmax_per_channel(CircleConst *node, std::vector<float> &min, std::vec
   loco::TensorShape dimension;
   dimension.rank(4);
   int32_t channel_dim_index{0};
-  int size{0};
 
   if (!get_channel_dim_index(node, dimension, channel_dim_index))
   {
     assert(false);
     return;
   }
-  size = dimension.dim(channel_dim_index).value();
+  auto size = dimension.dim(channel_dim_index).value();
 
   std::vector<bool> has_min_max_value(size, false);
   min.resize(size);


### PR DESCRIPTION
This will simplify cal_minmax_per_channel method in
QuantizeDequantizeWeightsPass with size variable.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>