### PR TITLE
[luci] Use common BatchNormPatternFinder methods

### DIFF
--- a/compiler/luci/pass/src/ReplaceMulAddWithDepthwiseConvPass.cpp
+++ b/compiler/luci/pass/src/ReplaceMulAddWithDepthwiseConvPass.cpp
@@ -16,6 +16,8 @@
 
 #include "luci/Pass/ReplaceMulAddWithDepthwiseConvPass.h"
 
+#include "BatchNormPatternFinder.h"
+
 #include <luci/IR/CircleNodes.h>
 
 namespace
@@ -70,79 +72,6 @@ luci::CircleConst *create_bias_from_beta(luci::CircleConst *beta)
   bias->name(name + "_bias");
 
   return bias;
-}
-
-bool is_batchnorm_add(const luci::CircleAdd *add, luci::CircleMul *&mul, luci::CircleConst *&beta)
-{
-  auto x = loco::must_cast<luci::CircleNode *>(add->x());
-  auto y = loco::must_cast<luci::CircleNode *>(add->y());
-
-  luci::CircleMul *pred = nullptr;
-  luci::CircleConst *constant = nullptr;
-
-  if (x->opcode() == luci::CircleOpcode::CIRCLECONST && y->opcode() == luci::CircleOpcode::MUL)
-  {
-    pred = loco::must_cast<luci::CircleMul *>(y);
-    constant = loco::must_cast<luci::CircleConst *>(x);
-  }
-  else if (x->opcode() == luci::CircleOpcode::MUL && y->opcode() == luci::CircleOpcode::CIRCLECONST)
-  {
-    pred = loco::must_cast<luci::CircleMul *>(x);
-    constant = loco::must_cast<luci::CircleConst *>(y);
-  }
-  else
-  {
-    return false;
-  }
-
-  if (constant->rank() != 1)
-    return false;
-
-  auto channel_dim = constant->dim(0);
-  // Assumption: Layout is channel-last
-  if (!(channel_dim == add->dim(add->rank() - 1)))
-    return false;
-
-  mul = pred;
-  beta = constant;
-  return true;
-}
-
-// Check if mul is batchnorm mul
-bool is_batchnorm_mul(const luci::CircleMul *mul, luci::CircleNode *&pred_node,
-                      luci::CircleConst *&gamma)
-{
-  auto x = dynamic_cast<luci::CircleConst *>(mul->x());
-  auto y = dynamic_cast<luci::CircleConst *>(mul->y());
-
-  luci::CircleNode *pred = nullptr;
-  luci::CircleConst *constant = nullptr;
-
-  if (x != nullptr && y == nullptr)
-  {
-    pred = loco::must_cast<luci::CircleNode *>(mul->y());
-    constant = x;
-  }
-  else if (x == nullptr && y != nullptr)
-  {
-    pred = loco::must_cast<luci::CircleNode *>(mul->x());
-    constant = y;
-  }
-  else
-  {
-    return false;
-  }
-
-  if (constant->rank() != 1)
-    return false;
-
-  auto channel_dim = constant->dim(0);
-  if (!(channel_dim == mul->dim(mul->rank() - 1)))
-    return false;
-
-  pred_node = pred;
-  gamma = constant;
-  return true;
 }
 
 /**


### PR DESCRIPTION
This will revise to use BatchNormPatternFinder common methods
is_batchnorm_add and is_batchnorm_mul.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>