### PR TITLE
DRAFT: Remove stdex usage from compiler frontend

### DIFF
--- a/compiler/stdex/CMakeLists.txt
+++ b/compiler/stdex/CMakeLists.txt
@@ -1,3 +1,5 @@
+return()
+
 file(GLOB_RECURSE TESTS "src/*.test.cpp")
 
 add_library(stdex INTERFACE)

--- a/compiler/stdex/src/Memory.test.cpp
+++ b/compiler/stdex/src/Memory.test.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "stdex/Memory.h"
+#include <memory>
 
 #include <gtest/gtest.h>
 
@@ -48,7 +48,7 @@ TEST(MemoryTest, make_unique)
   ASSERT_EQ(stat.allocated, 0);
   ASSERT_EQ(stat.freed, 0);
 
-  auto o = stdex::make_unique<::Counter>(&stat);
+  auto o = std::make_unique<::Counter>(&stat);
 
   ASSERT_EQ(stat.allocated, 1);
   ASSERT_EQ(stat.freed, 0);


### PR DESCRIPTION
on-going draft to remove stdex from compiler frontend

Signed-off-by: SaeHie Park <saehie.park@gmail.com>