### PR TITLE
[circledump] Remove stdex

### DIFF
--- a/compiler/circledump/README.md
+++ b/compiler/circledump/README.md
@@ -67,5 +67,4 @@ O T(3) ofm
 
 - mio-circle
 - safemain
-- stdex
 - FlatBuffers


### PR DESCRIPTION
This will remove usage of stdex.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>