### PR TITLE
[cli] Remove stdex

### DIFF
--- a/compiler/cli/CMakeLists.txt
+++ b/compiler/cli/CMakeLists.txt
@@ -12,4 +12,3 @@ endif(NOT GTest_FOUND)
 
 GTest_AddTEst(cli_test ${TESTS})
 target_link_libraries(cli_test cli)
-target_link_libraries(cli_test stdex)

--- a/compiler/cli/src/App.test.cpp
+++ b/compiler/cli/src/App.test.cpp
@@ -16,7 +16,7 @@
 
 #include "cli/App.h"
 
-#include <stdex/Memory.h>
+#include <memory>
 
 #include <gtest/gtest.h>
 
@@ -52,7 +52,7 @@ TEST(APP, run)
   cli::App app("test");
 
   std::string args;
-  app.insert("record", stdex::make_unique<RecordCommand>(3, args));
+  app.insert("record", std::make_unique<RecordCommand>(3, args));
 
   const char *argv[] = {"record", "hello", "world"};
 


### PR DESCRIPTION
This will remove usage of stdex.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>