### PR TITLE
[hermes-std] Remove stdex

### DIFF
--- a/compiler/hermes-std/CMakeLists.txt
+++ b/compiler/hermes-std/CMakeLists.txt
@@ -6,7 +6,6 @@ add_library(hermes_std STATIC ${SOURCES})
 set_target_properties(hermes_std PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_include_directories(hermes_std PUBLIC include)
 target_link_libraries(hermes_std PUBLIC hermes)
-target_link_libraries(hermes_std PRIVATE stdex)
 target_link_libraries(hermes_std PRIVATE pepper_strcast)
 # Let's apply nncc common compile options
 #
@@ -23,5 +22,4 @@ endif(NOT ENABLE_TEST)
 nnas_find_package(GTest REQUIRED)
 
 GTest_AddTest(hermes_std_test ${TESTS})
-target_link_libraries(hermes_std_test stdex)
 target_link_libraries(hermes_std_test hermes_std)

--- a/compiler/hermes-std/src/ConsoleReporter.test.cpp
+++ b/compiler/hermes-std/src/ConsoleReporter.test.cpp
@@ -16,8 +16,7 @@
 
 #include "hermes/ConsoleReporter.h"
 
-#include <stdex/Memory.h>
-
+#include <memory>
 #include <sstream>
 
 #include <gtest/gtest.h>
@@ -37,7 +36,7 @@ TEST(ConsoleReporterTest, notify)
 
     ss << "Hello" << std::endl;
 
-    m.text(stdex::make_unique<hermes::MessageText>(ss));
+    m.text(std::make_unique<hermes::MessageText>(ss));
   }
 
   hermes::ConsoleReporter r;


### PR DESCRIPTION
This will remove usage of stdex.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>