### PR TITLE
[nnkit-tflite] Remove stdex

### DIFF
--- a/compiler/nnkit-tflite/backend/Backend.cpp
+++ b/compiler/nnkit-tflite/backend/Backend.cpp
@@ -54,9 +54,10 @@ private:
 } // namespace
 
 #include <nnkit/CmdlineArguments.h>
-#include <stdex/Memory.h>
+
+#include <memory>
 
 extern "C" std::unique_ptr<nnkit::Backend> make_backend(const nnkit::CmdlineArguments &args)
 {
-  return stdex::make_unique<GenericBackend>(args.at(0));
+  return std::make_unique<GenericBackend>(args.at(0));
 }

--- a/compiler/nnkit-tflite/backend/CMakeLists.txt
+++ b/compiler/nnkit-tflite/backend/CMakeLists.txt
@@ -4,4 +4,3 @@ endif(NOT TARGET nnkit_support_tflite)
 
 add_library(nnkit_tflite_backend SHARED Backend.cpp)
 target_link_libraries(nnkit_tflite_backend nnkit_support_tflite)
-target_link_libraries(nnkit_tflite_backend stdex)

--- a/compiler/nnkit-tflite/requires.cmake
+++ b/compiler/nnkit-tflite/requires.cmake
@@ -1,2 +1,1 @@
-require("stdex")
 require("nnkit-intf")


### PR DESCRIPTION
This will remove usage of stdex.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>