### PR TITLE
[one-cmds] Revise one-prepare-venv with onnx

### DIFF
--- a/compiler/one-cmds/one-prepare-venv
+++ b/compiler/one-cmds/one-prepare-venv
@@ -56,9 +56,11 @@ python -m pip --default-timeout=1000 --trusted-host pypi.org --trusted-host file
   --trusted-host download.pytorch.org \
   install torch==1.7.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
 
+# NOTE Latest onnx 1.8.1 has compatibility issue with onnx-tf 1.7.0
+#      MUST install with onnx==1.8.0
 # Provide install of custom onnx-tf
 if [ -n "${EXT_ONNX_TF_WHL}" ]; then
-  python -m pip --default-timeout=1000 install ${EXT_ONNX_TF_WHL}
+  python -m pip --default-timeout=1000 install onnx==1.8.0 ${EXT_ONNX_TF_WHL}
 else
   python -m pip --default-timeout=1000 --trusted-host pypi.org --trusted-host files.pythonhost.org \
     install onnx==1.8.0 onnx-tf==1.7.0


### PR DESCRIPTION
This will revise one-prepare-venv to install onnx 1.8.0 for custom
onnx-tensorflow and add a note about this.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>