### PR TITLE
[luci] Set dummy dtype for CircleOutputExclude

### DIFF
--- a/compiler/luci/import/src/GraphBuilder.cpp
+++ b/compiler/luci/import/src/GraphBuilder.cpp
@@ -47,7 +47,11 @@ CircleNode *GraphBuilder::build(const circle::OperatorT &op, GraphBuilderContext
     else
     {
       // If there is no tensor, insert CircleOutputExclude.
-      input_nodes.push_back(context->graph()->nodes()->create<luci::CircleOutputExclude>());
+      auto *node = context->graph()->nodes()->create<luci::CircleOutputExclude>();
+      // CircleOutputExclude doesn't need a type, but since all nodes must have a type,
+      // a dummy type is inserted.
+      node->dtype(loco::DataType::FLOAT32);
+      input_nodes.push_back(node);
     }
   }
 

--- a/compiler/luci/import/src/Nodes/CircleBidirectionalSequenceLSTM.cpp
+++ b/compiler/luci/import/src/Nodes/CircleBidirectionalSequenceLSTM.cpp
@@ -86,18 +86,6 @@ CircleNode *CircleBidirectionalSequenceLSTMGraphBuilder::build_node(
   node->bw_auxillary_input_to_cell_weights(inputs.at(46));   // Optional
   node->bw_auxillary_input_to_output_weights(inputs.at(47)); // Optional
 
-  const std::vector<int32_t> optionals = {1,  5,  9,  10, 11, 12, 16, 17, 18, 22, 26, 27, 28,
-                                          29, 33, 34, 39, 40, 41, 42, 43, 44, 45, 46, 47};
-  for (auto optional : optionals)
-  {
-    if (auto inp = dynamic_cast<luci::CircleOutputExclude *>(node->arg(optional)))
-    {
-      // CircleOutputExclude doesn't need a type, but since all nodes must have a type, a dummy type
-      // is inserted.
-      inp->dtype(loco::DataType::FLOAT32);
-    }
-  }
-
   const auto *options = op.builtin_options.AsBidirectionalSequenceLSTMOptions();
   node->fusedActivationFunction(luci_actfunc(options->fused_activation_function));
   node->cell_clip(options->cell_clip);

--- a/compiler/luci/import/src/Nodes/CircleUnidirectionalSequenceLSTM.cpp
+++ b/compiler/luci/import/src/Nodes/CircleUnidirectionalSequenceLSTM.cpp
@@ -56,16 +56,6 @@ CircleNode *CircleUnidirectionalSequenceLSTMGraphBuilder::build_node(
   node->forget_layer_norm_coefficients(inputs.at(21)); // Optional
   node->cell_layer_norm_coefficients(inputs.at(22));   // Optional
   node->output_layer_norm_coefficients(inputs.at(23)); // Optional
-  const std::vector<int32_t> optionals = {1, 5, 9, 10, 11, 12, 16, 17, 20, 21, 22, 23};
-  for (auto optional : optionals)
-  {
-    if (auto inp = dynamic_cast<luci::CircleOutputExclude *>(node->arg(optional)))
-    {
-      // CircleOutputExclude doesn't need a type, but since all nodes must have a type, a dummy type
-      // is inserted.
-      inp->dtype(loco::DataType::FLOAT32);
-    }
-  }
 
   const auto *options = op.builtin_options.AsUnidirectionalSequenceLSTMOptions();
   node->fusedActivationFunction(luci_actfunc(options->fused_activation_function));


### PR DESCRIPTION
This will set dummy dtype for CircleOutputExclude node at GraphBuilder
and remove for BidirectionalSequenceLSTM and
eUnidirectionalSequenceLSTM.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>