### PR TITLE
[luci] Removed dtype settings for CircleOutputExclude

### DIFF
--- a/compiler/luci/import/src/Nodes/CircleBCQFullyConnected.cpp
+++ b/compiler/luci/import/src/Nodes/CircleBCQFullyConnected.cpp
@@ -40,15 +40,6 @@ CircleNode *CircleBCQFullyConnectedGraphBuilder::build_node(const circle::Operat
   node->bias(inputs.at(3));
   node->weights_clusters(inputs.at(4));
 
-  // TODO Find and move to appropriate place for setting optional input
-  if (auto bias = dynamic_cast<luci::CircleOutputExclude *>(node->bias()))
-  {
-    // bias is not used for type inference, but node itself should have a type
-    bias->dtype(loco::DataType::FLOAT32);
-
-    // bias is not used for shape inference
-  }
-
   const auto *options = op.builtin_options.AsBCQFullyConnectedOptions();
   node->weights_hidden_size(options->weights_hidden_size);
   node->fusedActivationFunction(luci_actfunc(options->fused_activation_function));

--- a/compiler/luci/import/src/Nodes/CircleFullyConnected.cpp
+++ b/compiler/luci/import/src/Nodes/CircleFullyConnected.cpp
@@ -39,15 +39,6 @@ CircleNode *CircleFullyConnectedGraphBuilder::build_node(const circle::OperatorT
   node->weights(inputs.at(1));
   node->bias(inputs.at(2)); // bias is optional
 
-  // TODO Find and move to appropriate place for setting optional input
-  if (auto bias = dynamic_cast<luci::CircleOutputExclude *>(node->bias()))
-  {
-    // bias is not used for type inference, but node itself should have a type
-    bias->dtype(loco::DataType::FLOAT32);
-
-    // bias is not used for shape inference
-  }
-
   const auto *options = op.builtin_options.AsFullyConnectedOptions();
   node->fusedActivationFunction(luci_actfunc(options->fused_activation_function));
   node->weights_format(luci_weights_format(options->weights_format));

--- a/compiler/luci/import/src/Nodes/CircleTransposeConv.cpp
+++ b/compiler/luci/import/src/Nodes/CircleTransposeConv.cpp
@@ -61,16 +61,15 @@ CircleNode *CircleTransposeConvGraphBuilder::build_node(const circle::OperatorT 
   node->filter(inputs.at(1));
   node->outBackprop(inputs.at(2));
   if (inputs.size() == 3)
-    node->bias(graph->nodes()->create<CircleOutputExclude>());
+  {
+    auto *bias = graph->nodes()->create<CircleOutputExclude>();
+    // CircleOutputExclude doesn't need a type, but since all nodes must have a type,
+    // a dummy type is inserted.
+    bias->dtype(loco::DataType::FLOAT32);
+    node->bias(bias);
+  }
   else
     node->bias(inputs.at(3));
-
-  if (auto bias = dynamic_cast<luci::CircleOutputExclude *>(node->bias()))
-  {
-    // CircleOutputExclude doesn't need a type, but since all nodes must have a type, a dummy type
-    // is inserted.
-    bias->dtype(loco::DataType::FLOAT32);
-  }
 
   const auto *options = op.builtin_options.AsTransposeConvOptions();
   node->padding(luci_padding(options->padding));


### PR DESCRIPTION
This will remove dtype settings for CircleOutputExclude that is now set
at caller GraphBuilder class.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>