### PR TITLE
[pota-value-test] Support comparison of scalar weights

### DIFF
--- a/compiler/pota-quantization-value-test/compare_tensors.py
+++ b/compiler/pota-quantization-value-test/compare_tensors.py
@@ -68,7 +68,7 @@ def compare_quantization(tensor, tensor_name, expect_dir):
     for key in json_load:
         if key == "weights":
             expected_weights = np.array(json_load["weights"])
-            input_weights = tensor["weights"][:]
+            input_weights = tensor["weights"][()]
             abs_tolerance = 1
             # We use higher tolerance for int64 data (bias of int16-quantized model)
             if tensor["weights"].dtype == 'int64':


### PR DESCRIPTION
This supports comparison of scalar weights.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>