### PR TITLE
[compiler/ahub] Remove stdex

### DIFF
--- a/compiler/.ahub/tcchecker-tca/config.yaml
+++ b/compiler/.ahub/tcchecker-tca/config.yaml
@@ -32,7 +32,6 @@ test:
       - ./record-minmax
       - ./safemain
       - ./souschef
-      - ./stdex
       - ./tflite2circle
 
     testFile:


### PR DESCRIPTION
This will remove stdex item as not used anymore.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>