### PR TITLE
[luci] Quantization of SPLIT Op

### DIFF
--- a/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
+++ b/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
@@ -953,6 +953,14 @@ void quantize_const_inputs(luci::CircleNode *node, loco::DataType output_type)
       }
       break;
 
+    case luci::CircleOpcode::SPLIT:
+      // Only the second input is quantized
+      input_node = node->arg(1);
+      const_node = dynamic_cast<luci::CircleConst *>(input_node);
+      if (const_node != nullptr && !is_quantized(const_node))
+        quant_const(const_node, output_type);
+      break;
+
     default:
       for (uint32_t i = 0; i < arity; i++)
       {

--- a/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
+++ b/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
@@ -955,6 +955,7 @@ void quantize_const_inputs(luci::CircleNode *node, loco::DataType output_type)
 
     case luci::CircleOpcode::SPLIT:
       // Only the second input is quantized
+      // First input should not be quantized (e.g., split_dim)
       input_node = node->arg(1);
       const_node = dynamic_cast<luci::CircleConst *>(input_node);
       if (const_node != nullptr && !is_quantized(const_node))


### PR DESCRIPTION
This supports quantization of SPLIT Op.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

--
Related to: #6161
Draft PR: #6167