### PR TITLE
[circledump] Dump metadata in circle file

### DIFF
--- a/compiler/circledump/src/Dump.cpp
+++ b/compiler/circledump/src/Dump.cpp
@@ -362,6 +362,7 @@ void dump_model(std::ostream &os, const circle::Model *model)
 
   auto opcodes = reader.opcodes();
   auto buffers = reader.buffers();
+  auto metadata = reader.metadata();
 
   // dump operator_codes
   os << "Operator Codes: [order] OpCodeName (OpCode Enum)" << std::endl;
@@ -394,6 +395,18 @@ void dump_model(std::ostream &os, const circle::Model *model)
     os << std::endl;
   }
   os << std::endl;
+
+  // dump metadata
+  if (metadata != nullptr)
+  {
+    os << "metadata : B(index) name" << std::endl;
+    for (uint32_t i = 0; i < metadata->Length(); ++i)
+    {
+      os << "B(" << metadata->Get(i)->buffer() << ") " << metadata->Get(i)->name()->str()
+         << std::endl;
+    }
+    os << std::endl;
+  }
 
   for (uint32_t sg = 0; sg < num_subgraph; ++sg)
   {

--- a/compiler/circledump/src/Read.cpp
+++ b/compiler/circledump/src/Read.cpp
@@ -81,6 +81,7 @@ Reader::Reader(const circle::Model *model)
   _version = model->version();
   _subgraphs = model->subgraphs();
   _buffers = model->buffers();
+  _metadata = model->metadata();
 
   auto opcodes = model->operator_codes();
   for (const ::circle::OperatorCode *opcode : *opcodes)

--- a/compiler/circledump/src/Read.h
+++ b/compiler/circledump/src/Read.h
@@ -52,6 +52,7 @@ private:
   using CircleBuffers_t = flatbuffers::Vector<flatbuffers::Offset<circle::Buffer>>;
   using CircleTensors_t = flatbuffers::Vector<flatbuffers::Offset<circle::Tensor>>;
   using CircleOperators_t = flatbuffers::Vector<flatbuffers::Offset<circle::Operator>>;
+  using CircleMetadata_t = flatbuffers::Vector<flatbuffers::Offset<circle::Metadata>>;
 
 public:
   Reader(const circle::Model *model);
@@ -68,6 +69,7 @@ public:
   const std::vector<int32_t> &inputs() const { return _inputs; }
   const std::vector<int32_t> &outputs() const { return _outputs; }
   const circle::DataFormat &data_format() const { return _data_format; }
+  const CircleMetadata_t *metadata() const { return _metadata; }
 
   uint32_t num_subgraph() const { return _subgraphs->Length(); }
 
@@ -87,6 +89,7 @@ private:
   const CircleBuffers_t *_buffers{nullptr};
   const CircleTensors_t *_tensors{nullptr};
   const CircleOperators_t *_operators{nullptr};
+  const CircleMetadata_t *_metadata{nullptr};
 
   uint32_t _subgraph_index;
   std::string _subgraph_name;


### PR DESCRIPTION
Until now, `circledump` did not dump metadata in circle file.
This commit will enable dumping metadata in circle file.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>