### PR TITLE
[onert] Skip permute shape calculation

### DIFF
--- a/runtime/onert/core/src/ir/Shape.cc
+++ b/runtime/onert/core/src/ir/Shape.cc
@@ -91,6 +91,8 @@ Shape permuteShape(const Shape &shape, Layout from, Layout to)
 {
   assert(shape.rank() <= Shape::MAX_RANK);
   Shape ret{shape};
+  if (from == to)
+    return ret;
   if (shape.rank() < 4)
     return ret;
   // Permutation changing layout beyond 4-D is not supported yet


### PR DESCRIPTION
This commit skip permute shape calculation when from and to layout is same.

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>