### PR TITLE
[luci] Revise ResolveCustomOp pass not to use bitwise-or

### DIFF
--- a/compiler/luci/pass/src/ResolveCustomOpAddPass.cpp
+++ b/compiler/luci/pass/src/ResolveCustomOpAddPass.cpp
@@ -145,7 +145,8 @@ bool ResolveCustomOpAddPass::run(loco::Graph *g)
     if (not cop)
       continue;
 
-    changed |= resolve_custom_op(cop);
+    if (resolve_custom_op(cop))
+      changed = true;
   }
 
   return changed;

--- a/compiler/luci/pass/src/ResolveCustomOpBatchMatMulPass.cpp
+++ b/compiler/luci/pass/src/ResolveCustomOpBatchMatMulPass.cpp
@@ -68,7 +68,8 @@ bool ResolveCustomOpBatchMatMulPass::run(loco::Graph *g)
     if (not cop)
       continue;
 
-    changed |= resolve_custom_op(cop);
+    if (resolve_custom_op(cop))
+      changed = true;
   }
 
   return changed;


### PR DESCRIPTION
This will revise ResolveCustomOpAddPass and
ResolveCustomOpBatchMatMulPass to use simple if and not bitwise-or
operator.

ONE-DCO-1.0-ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>