### PR TITLE
[luci] Add graph transformation comment

### DIFF
--- a/compiler/luci/pass/src/ResolveCustomOpBatchMatMulPass.cpp
+++ b/compiler/luci/pass/src/ResolveCustomOpBatchMatMulPass.cpp
@@ -59,6 +59,27 @@ bool resolve_custom_op(luci::CircleCustom *cop)
 namespace luci
 {
 
+/**
+ *  BEFORE
+ *         |             |
+ *    [CircleNode]  [CircleNode]
+ *          \           /
+ *         [CircleCustom]("BatchMatMulV2")
+ *               |
+ *        [CircleCustomOut]
+ *               |
+ *          [CircleNode]
+ *               |
+ *
+ *  AFTER
+ *         |             |
+ *    [CircleNode]  [CircleNode]
+ *          \           /
+ *       [CircleBatchMatMul]
+ *               |
+ *          [CircleNode]
+ *               |
+ */
 bool ResolveCustomOpBatchMatMulPass::run(loco::Graph *g)
 {
   bool changed = false;


### PR DESCRIPTION
This will add before-after graph transformation helper comment for
better understanding what ResolveCustomOpBatchMatMulPass does.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>