### PR TITLE
[luci/profile] Introduce CircleNodeOrigin

### DIFF
--- a/compiler/luci/profile/include/luci/Profile/CircleNodeOrigin.h
+++ b/compiler/luci/profile/include/luci/Profile/CircleNodeOrigin.h
@@ -50,10 +50,10 @@ public:
 std::shared_ptr<CircleNodeOrigin> single_origin(uint32_t id, const std::string &name);
 
 std::shared_ptr<CircleNodeOrigin>
-composite_origin(const std::initializer_list<std::shared_ptr<CircleNodeOrigin>> &origins);
+composite_origin(const std::initializer_list<std::shared_ptr<CircleNodeOrigin>> origins);
 
 std::shared_ptr<CircleNodeOrigin>
-composite_origin(const std::vector<std::shared_ptr<CircleNodeOrigin>> &origins);
+composite_origin(const std::vector<std::shared_ptr<CircleNodeOrigin>> origins);
 
 } // namespace luci
 

--- a/compiler/luci/profile/include/luci/Profile/CircleNodeOrigin.h
+++ b/compiler/luci/profile/include/luci/Profile/CircleNodeOrigin.h
@@ -53,7 +53,7 @@ std::shared_ptr<CircleNodeOrigin>
 composite_origin(const std::initializer_list<std::shared_ptr<CircleNodeOrigin>> origins);
 
 std::shared_ptr<CircleNodeOrigin>
-composite_origin(const std::vector<std::shared_ptr<CircleNodeOrigin>> origins);
+composite_origin(const std::vector<std::shared_ptr<CircleNodeOrigin>> &origins);
 
 } // namespace luci
 

--- a/compiler/luci/profile/include/luci/Profile/CircleNodeOrigin.h
+++ b/compiler/luci/profile/include/luci/Profile/CircleNodeOrigin.h
@@ -47,13 +47,13 @@ public:
   virtual std::set<const Source *> sources(void) const = 0;
 };
 
-std::shared_ptr<CircleNodeOrigin> single_origin(uint32_t id, const std::string name);
+std::shared_ptr<CircleNodeOrigin> single_origin(uint32_t id, const std::string &name);
 
 std::shared_ptr<CircleNodeOrigin>
-composite_origin(std::initializer_list<std::shared_ptr<CircleNodeOrigin>> origins);
+composite_origin(const std::initializer_list<std::shared_ptr<CircleNodeOrigin>> &origins);
 
 std::shared_ptr<CircleNodeOrigin>
-composite_origin(std::vector<std::shared_ptr<CircleNodeOrigin>> origins);
+composite_origin(const std::vector<std::shared_ptr<CircleNodeOrigin>> &origins);
 
 } // namespace luci
 
@@ -64,7 +64,7 @@ bool has_origin(const luci::CircleNode *circle_node);
 
 void add_origin(luci::CircleNode *circle_node, const std::shared_ptr<CircleNodeOrigin> origin);
 
-// NOTE When circle_node does not have origin, nullptr will be returned
+// NOTE When circle_node does not have origin, nullptr is returned
 const std::shared_ptr<luci::CircleNodeOrigin> get_origin(const luci::CircleNode *circle_node);
 
 } // namespace luci

--- a/compiler/luci/profile/include/luci/Profile/CircleNodeOrigin.h
+++ b/compiler/luci/profile/include/luci/Profile/CircleNodeOrigin.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __LUCI_PROFILE_CIRCLE_NODE_ORIGIN_H__
+#define __LUCI_PROFILE_CIRCLE_NODE_ORIGIN_H__
+
+#include "CircleNodeID.h"
+
+#include <luci/IR/CircleNode.h>
+
+#include <set>
+
+namespace luci
+{
+
+class CircleNodeOrigin
+{
+protected:
+  struct Source
+  {
+  public:
+    std::string name(void) const { return _name; }
+    void name(const std::string &name) { _name = name; }
+
+    uint32_t id(void) const { return _id; }
+    void id(const uint32_t id) { _id = id; }
+
+  private:
+    std::string _name;
+    uint32_t _id = 0;
+  };
+
+public:
+  virtual std::set<const Source *> sources(void) const = 0;
+};
+
+std::shared_ptr<CircleNodeOrigin> single_origin(uint32_t id, const std::string name);
+
+std::shared_ptr<CircleNodeOrigin>
+composite_origin(std::initializer_list<std::shared_ptr<CircleNodeOrigin>> origins);
+
+std::shared_ptr<CircleNodeOrigin>
+composite_origin(std::vector<std::shared_ptr<CircleNodeOrigin>> origins);
+
+} // namespace luci
+
+namespace luci
+{
+
+bool has_origin(const luci::CircleNode *circle_node);
+
+void add_origin(luci::CircleNode *circle_node, const std::shared_ptr<CircleNodeOrigin> origin);
+
+// NOTE When circle_node does not have origin, nullptr will be returned
+const std::shared_ptr<luci::CircleNodeOrigin> get_origin(const luci::CircleNode *circle_node);
+
+} // namespace luci
+
+#endif // __LUCI_PROFILE_CIRCLE_NODE_ORIGIN_H__

--- a/compiler/luci/profile/src/CircleNodeOrigin.cpp
+++ b/compiler/luci/profile/src/CircleNodeOrigin.cpp
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Profile/CircleNodeOrigin.h"
+
+#include <loco.h>
+
+#include <cassert>
+#include <vector>
+
+namespace
+{
+
+/**
+ * @brief Set annotation for recording origin information
+ * @note  Once CircleNodeOrigin is annotated, it should not be changed.
+ *        If CircleNodeOrigin is needed to be changed, create new CircleNodeOrigin.
+ */
+class CircleNodeOriginAnnotation final : public loco::NodeAnnotation
+{
+public:
+  CircleNodeOriginAnnotation() = delete;
+
+  CircleNodeOriginAnnotation(const std::shared_ptr<luci::CircleNodeOrigin> origin) : _origin(origin)
+  {
+    // Do nothing
+  }
+
+public:
+  const std::shared_ptr<luci::CircleNodeOrigin> origin(void) const { return _origin; }
+  // No setter
+
+private:
+  const std::shared_ptr<luci::CircleNodeOrigin> _origin;
+};
+
+} // namespace
+
+namespace
+{
+
+class SingleOrigin final : public luci::CircleNodeOrigin
+{
+public:
+  SingleOrigin() = delete;
+
+  SingleOrigin(uint32_t id, const std::string &name)
+  {
+    _source.id(id);
+    _source.name(name);
+  }
+
+public:
+  std::set<const Source *> sources(void) const final
+  {
+    std::set<const Source *> res;
+    res.emplace(&_source);
+    return res;
+  }
+
+private:
+  Source _source;
+};
+
+class CompositeOrigin final : public luci::CircleNodeOrigin
+{
+public:
+  CompositeOrigin() = delete;
+
+  template <typename T> CompositeOrigin(T origins)
+  {
+    if (origins.size() == 0)
+      throw std::invalid_argument("No origins provided");
+
+    for (auto &origin : origins)
+    {
+      if (origin != nullptr)
+        _origins.emplace_back(origin);
+    }
+  }
+
+public:
+  std::set<const Source *> sources(void) const final
+  {
+    std::set<const Source *> res;
+
+    for (auto &origin : _origins)
+    {
+      for (auto source : origin->sources())
+      {
+        res.emplace(source);
+      }
+    }
+
+    return res;
+  }
+
+private:
+  std::vector<std::shared_ptr<CircleNodeOrigin>> _origins;
+};
+
+} // namespace
+
+namespace luci
+{
+
+std::shared_ptr<CircleNodeOrigin> single_origin(uint32_t id, const std::string name)
+{
+  return std::make_shared<SingleOrigin>(id, name);
+}
+
+std::shared_ptr<CircleNodeOrigin>
+composite_origin(std::initializer_list<std::shared_ptr<CircleNodeOrigin>> origins)
+{
+  return std::make_shared<CompositeOrigin>(origins);
+}
+
+std::shared_ptr<CircleNodeOrigin>
+composite_origin(std::vector<std::shared_ptr<CircleNodeOrigin>> origins)
+{
+  return std::make_shared<CompositeOrigin>(origins);
+}
+
+} // namespace luci
+
+namespace luci
+{
+
+bool has_origin(const luci::CircleNode *circle_node)
+{
+  return circle_node->annot<CircleNodeOriginAnnotation>() != nullptr;
+}
+
+void add_origin(luci::CircleNode *circle_node, const std::shared_ptr<CircleNodeOrigin> origin)
+{
+  circle_node->annot<CircleNodeOriginAnnotation>(nullptr);
+  circle_node->annot(std::make_unique<CircleNodeOriginAnnotation>(origin));
+}
+
+const std::shared_ptr<luci::CircleNodeOrigin> get_origin(const luci::CircleNode *circle_node)
+{
+  if (!has_origin(circle_node))
+    return nullptr;
+
+  return circle_node->annot<CircleNodeOriginAnnotation>()->origin();
+}
+
+} // namespace luci

--- a/compiler/luci/profile/src/CircleNodeOrigin.cpp
+++ b/compiler/luci/profile/src/CircleNodeOrigin.cpp
@@ -129,7 +129,7 @@ composite_origin(const std::initializer_list<std::shared_ptr<CircleNodeOrigin>> 
 }
 
 std::shared_ptr<CircleNodeOrigin>
-composite_origin(const std::vector<std::shared_ptr<CircleNodeOrigin>> origins)
+composite_origin(const std::vector<std::shared_ptr<CircleNodeOrigin>> &origins)
 {
   return std::make_shared<CompositeOrigin>(origins);
 }

--- a/compiler/luci/profile/src/CircleNodeOrigin.cpp
+++ b/compiler/luci/profile/src/CircleNodeOrigin.cpp
@@ -80,7 +80,7 @@ class CompositeOrigin final : public luci::CircleNodeOrigin
 public:
   CompositeOrigin() = delete;
 
-  template <typename T> CompositeOrigin(T origins)
+  template <typename T> CompositeOrigin(T &origins)
   {
     if (origins.size() == 0)
       throw std::invalid_argument("No origins provided");
@@ -117,19 +117,19 @@ private:
 namespace luci
 {
 
-std::shared_ptr<CircleNodeOrigin> single_origin(uint32_t id, const std::string name)
+std::shared_ptr<CircleNodeOrigin> single_origin(uint32_t id, const std::string &name)
 {
   return std::make_shared<SingleOrigin>(id, name);
 }
 
 std::shared_ptr<CircleNodeOrigin>
-composite_origin(std::initializer_list<std::shared_ptr<CircleNodeOrigin>> origins)
+composite_origin(const std::initializer_list<std::shared_ptr<CircleNodeOrigin>> &origins)
 {
   return std::make_shared<CompositeOrigin>(origins);
 }
 
 std::shared_ptr<CircleNodeOrigin>
-composite_origin(std::vector<std::shared_ptr<CircleNodeOrigin>> origins)
+composite_origin(const std::vector<std::shared_ptr<CircleNodeOrigin>> &origins)
 {
   return std::make_shared<CompositeOrigin>(origins);
 }

--- a/compiler/luci/profile/src/CircleNodeOrigin.cpp
+++ b/compiler/luci/profile/src/CircleNodeOrigin.cpp
@@ -80,7 +80,7 @@ class CompositeOrigin final : public luci::CircleNodeOrigin
 public:
   CompositeOrigin() = delete;
 
-  template <typename T> CompositeOrigin(T &origins)
+  template <typename T> CompositeOrigin(T origins)
   {
     if (origins.size() == 0)
       throw std::invalid_argument("No origins provided");
@@ -123,13 +123,13 @@ std::shared_ptr<CircleNodeOrigin> single_origin(uint32_t id, const std::string &
 }
 
 std::shared_ptr<CircleNodeOrigin>
-composite_origin(const std::initializer_list<std::shared_ptr<CircleNodeOrigin>> &origins)
+composite_origin(const std::initializer_list<std::shared_ptr<CircleNodeOrigin>> origins)
 {
   return std::make_shared<CompositeOrigin>(origins);
 }
 
 std::shared_ptr<CircleNodeOrigin>
-composite_origin(const std::vector<std::shared_ptr<CircleNodeOrigin>> &origins)
+composite_origin(const std::vector<std::shared_ptr<CircleNodeOrigin>> origins)
 {
   return std::make_shared<CompositeOrigin>(origins);
 }

--- a/compiler/luci/profile/src/CircleNodeOrigin.test.cpp
+++ b/compiler/luci/profile/src/CircleNodeOrigin.test.cpp
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Profile/CircleNodeID.h"
+#include "luci/Profile/CircleNodeOrigin.h"
+
+#include <luci/IR/CircleNodes.h>
+
+#include <gtest/gtest.h>
+
+TEST(LuciCircleNodeOrigin, simple_single_origin)
+{
+  auto g = loco::make_graph();
+  auto add = g->nodes()->create<luci::CircleAdd>();
+
+  ASSERT_FALSE(has_origin(add));
+
+  auto origin = luci::single_origin(3, "add");
+  add_origin(add, origin);
+
+  ASSERT_TRUE(has_origin(add));
+
+  auto sources = get_origin(add)->sources();
+  ASSERT_EQ(1, sources.size());
+  for (auto source : sources)
+  {
+    ASSERT_EQ(3, source->id());
+    ASSERT_EQ(0, source->name().compare("add"));
+  }
+}
+
+TEST(LuciCircleNodeOrigin, simple_composite_origin_with_initializer)
+{
+  auto g = loco::make_graph();
+  auto mul = g->nodes()->create<luci::CircleMul>();
+
+  ASSERT_FALSE(has_origin(mul));
+
+  auto origin =
+    luci::composite_origin({luci::single_origin(3, "add"), luci::single_origin(7, "sub")});
+  add_origin(mul, origin);
+
+  ASSERT_TRUE(has_origin(mul));
+
+  bool add_origin_passed = false;
+  bool sub_origin_passed = false;
+  auto sources = get_origin(mul)->sources();
+  ASSERT_EQ(2, sources.size());
+  for (auto source : sources)
+  {
+    if (source->id() == 3 && source->name().compare("add") == 0)
+      add_origin_passed = true;
+    if (source->id() == 7 && source->name().compare("sub") == 0)
+      sub_origin_passed = true;
+  }
+
+  ASSERT_EQ(true, add_origin_passed);
+  ASSERT_EQ(true, sub_origin_passed);
+}
+
+TEST(LuciCircleNodeOrigin, simple_composite_origin_with_vector)
+{
+  auto g = loco::make_graph();
+  auto mul = g->nodes()->create<luci::CircleMul>();
+
+  ASSERT_FALSE(has_origin(mul));
+
+  std::vector<std::shared_ptr<luci::CircleNodeOrigin>> vec;
+  vec.push_back(luci::single_origin(3, "add"));
+  vec.push_back(luci::single_origin(7, "sub"));
+  auto origin = luci::composite_origin(vec);
+  add_origin(mul, origin);
+
+  ASSERT_TRUE(has_origin(mul));
+
+  bool add_origin_passed = false;
+  bool sub_origin_passed = false;
+  auto sources = get_origin(mul)->sources();
+  ASSERT_EQ(2, sources.size());
+  for (auto source : sources)
+  {
+    if (source->id() == 3 && source->name().compare("add") == 0)
+      add_origin_passed = true;
+    if (source->id() == 7 && source->name().compare("sub") == 0)
+      sub_origin_passed = true;
+  }
+
+  ASSERT_EQ(true, add_origin_passed);
+  ASSERT_EQ(true, sub_origin_passed);
+}
+
+TEST(LuciCircleNodeOrigin, composite_origin_empty_ctor_NEG)
+{
+  ASSERT_ANY_THROW(luci::composite_origin({}));
+}


### PR DESCRIPTION
Parent Issue : #6080
Draft : #6079

We sometimes want to know where some nodes are originated from.
For that, this commit introduces `CircleNodeOrigin` to keep recording origin information.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>