### PR TITLE
[luci/env] Introduce ProfilingDataGen setting

### DIFF
--- a/compiler/luci/env/include/luci/UserSettings.h
+++ b/compiler/luci/env/include/luci/UserSettings.h
@@ -32,6 +32,7 @@ struct UserSettings
     Undefined,
     MuteWarnings,
     DisableValidation,
+    ProfilingDataGen,
   };
 
   static UserSettings *settings();

--- a/compiler/luci/env/src/UserSettings.cpp
+++ b/compiler/luci/env/src/UserSettings.cpp
@@ -30,6 +30,7 @@ public:
 private:
   bool _MuteWarnings{false};
   bool _DisableValidation{false};
+  bool _ProfilingDataGen{false};
 };
 
 void UserSettingsImpl::set(const Key key, bool value)
@@ -41,6 +42,9 @@ void UserSettingsImpl::set(const Key key, bool value)
       break;
     case Key::DisableValidation:
       _DisableValidation = value;
+      break;
+    case Key::ProfilingDataGen:
+      _ProfilingDataGen = value;
       break;
     default:
       throw std::runtime_error("Invalid key in boolean set");
@@ -56,6 +60,8 @@ bool UserSettingsImpl::get(const Key key) const
       return _MuteWarnings;
     case Key::DisableValidation:
       return _DisableValidation;
+    case Key::ProfilingDataGen:
+      return _ProfilingDataGen;
     default:
       throw std::runtime_error("Invalid key in boolean get");
       break;

--- a/compiler/luci/env/src/UserSettings.test.cpp
+++ b/compiler/luci/env/src/UserSettings.test.cpp
@@ -51,6 +51,18 @@ TEST(UserSettings, DisableValidation)
   ASSERT_TRUE(settings->get(luci::UserSettings::Key::DisableValidation));
 }
 
+TEST(UserSettings, ProfilingDataGen)
+{
+  auto settings = luci::UserSettings::settings();
+  ASSERT_NE(nullptr, settings);
+
+  settings->set(luci::UserSettings::Key::ProfilingDataGen, false);
+  ASSERT_FALSE(settings->get(luci::UserSettings::Key::ProfilingDataGen));
+
+  settings->set(luci::UserSettings::Key::ProfilingDataGen, true);
+  ASSERT_TRUE(settings->get(luci::UserSettings::Key::ProfilingDataGen));
+}
+
 TEST(UserSettings, undefined_set_NEG)
 {
   auto settings = luci::UserSettings::settings();


### PR DESCRIPTION
Parent Issue : #6080
Draft : #6101

This commit will introduce `ProfilingDataGen` setting for generating profiling data.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>