### PR TITLE
[luci/import] Enable reading circle metadata

### DIFF
--- a/compiler/luci/import/include/luci/Import/CircleReader.h
+++ b/compiler/luci/import/include/luci/Import/CircleReader.h
@@ -63,6 +63,7 @@ private:
   using CircleTensors_t = std::vector<std::unique_ptr<circle::TensorT>>;
   using CircleOperators_t = std::vector<std::unique_ptr<circle::OperatorT>>;
   using CircleOperatorCodes_t = std::vector<std::unique_ptr<circle::OperatorCodeT>>;
+  using CircleMetadata_t = std::vector<std::unique_ptr<circle::MetadataT>>;
 
   using CircleSubGraphsPtr_t = flatbuffers::Vector<flatbuffers::Offset<circle::SubGraph>>;
   using CircleTensorsPtr_t = flatbuffers::Vector<flatbuffers::Offset<circle::Tensor>>;
@@ -79,6 +80,7 @@ public:
   const std::vector<int32_t> &outputs() const { return _current_subgraph->outputs; }
   const std::string &name() const { return _current_subgraph->name; }
   const circle::DataFormat &data_format() const { return _current_subgraph->data_format; }
+  const CircleMetadata_t &metadata() const { return _model->metadata; }
 
   const CircleTensorsPtr_t *tensors_ptr() const { return _tensors_ptr; }
 


### PR DESCRIPTION
Parent Issue : #6080
Draft : #6101

This commit will enable reading circle metadata by introducing `CircleMetadata_t`.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>