### PR TITLE
[circledump] Introduce MetadataPrinter

### DIFF
--- a/compiler/circledump/src/Dump.cpp
+++ b/compiler/circledump/src/Dump.cpp
@@ -18,6 +18,7 @@
 
 #include "Read.h"
 #include "OpPrinter.h"
+#include "MetadataPrinter.h"
 
 #include <ostream>
 
@@ -402,8 +403,16 @@ void dump_model(std::ostream &os, const circle::Model *model)
     os << "metadata : B(index) name" << std::endl;
     for (uint32_t i = 0; i < metadata->Length(); ++i)
     {
-      os << "B(" << metadata->Get(i)->buffer() << ") " << metadata->Get(i)->name()->str()
-         << std::endl;
+      const auto buff_id = metadata->Get(i)->buffer();
+      const auto metadata_name = metadata->Get(i)->name()->str();
+      os << "B(" << buff_id << ") " << metadata_name << std::endl;
+
+      const uint8_t *buff_data;
+      reader.buffer_info(buff_id, &buff_data);
+      if (auto meta_prn = MetadataPrinterRegistry::get().lookup(metadata_name))
+      {
+        meta_prn->print(buff_data, os);
+      }
     }
     os << std::endl;
   }

--- a/compiler/circledump/src/MetadataPrinter.cpp
+++ b/compiler/circledump/src/MetadataPrinter.cpp
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "MetadataPrinter.h"
+
+#include <cassert>
+#include <string>
+#include <vector>
+
+namespace circledump
+{
+
+class SourceTablePrinter : public MetadataPrinter
+{
+public:
+  /**
+   *  source table consists of following parts
+   *  - [ entry_number : uint32_t ]
+   *  - [ id : uint32_t ][ length : uint32_t ][ data : 'length' Bytes ] * entry_number
+   */
+  virtual void print(const uint8_t *buffer, std::ostream &os) const override
+  {
+    if (buffer)
+    {
+      os << "    [node_id : node_name]" << std::endl;
+      auto cur = buffer;
+      // entry number
+      const uint32_t num = *reinterpret_cast<const uint32_t *>(cur);
+      cur += sizeof(uint32_t);
+      for (uint32_t entry = 0; entry < num; entry++)
+      {
+        // id
+        const uint32_t node_id = *reinterpret_cast<const uint32_t *>(cur);
+        cur += sizeof(uint32_t);
+        // length
+        const uint32_t len = *reinterpret_cast<const uint32_t *>(cur);
+        cur += sizeof(uint32_t);
+        assert(len != 0);
+        // data
+        // non-empty 'data' has trailing '\0'. Let's exclude it.
+        std::string node_name = std::string(cur, len > 0 ? cur + len - 1 : cur + len);
+        cur += len;
+
+        // print
+        os << "    [" << node_id << " : " << node_name << "]" << std::endl;
+      }
+    }
+  }
+};
+
+class OpTablePrinter : public MetadataPrinter
+{
+public:
+  /**
+   *  op table consists of following parts
+   *  - [ entry_number : uint32_t ]
+   *  - [ id : uint32_t ][ length : uint32_t ][ origin_ids : length * uint32_t ] * entry_number
+   */
+  virtual void print(const uint8_t *buffer, std::ostream &os) const override
+  {
+    if (buffer)
+    {
+      os << "    [node_id : origin_ids]" << std::endl;
+      auto cur = buffer;
+      // entry number
+      const uint32_t num = *reinterpret_cast<const uint32_t *>(cur);
+      cur += sizeof(uint32_t);
+      for (uint32_t entry = 0; entry < num; entry++)
+      {
+        // id
+        const uint32_t node_id = *reinterpret_cast<const uint32_t *>(cur);
+        cur += sizeof(uint32_t);
+        // length
+        const uint32_t len = *reinterpret_cast<const uint32_t *>(cur);
+        cur += sizeof(uint32_t);
+        assert(len != 0);
+        // origin_ids
+        std::vector<uint32_t> origin_ids;
+        for (uint32_t o = 0; o < len; o++)
+        {
+          origin_ids.push_back(*reinterpret_cast<const uint32_t *>(cur));
+          cur += sizeof(uint32_t);
+        }
+
+        // print
+        os << "    [" << node_id << " : ";
+        uint32_t i = 0;
+        for (const auto &id : origin_ids)
+        {
+          if (i++)
+            os << ", ";
+          os << id;
+        }
+        os << "]" << std::endl;
+      }
+    }
+  }
+};
+
+MetadataPrinterRegistry::MetadataPrinterRegistry()
+{
+  _metadata_map["source_table"] = std::make_unique<SourceTablePrinter>();
+  _metadata_map["op_table"] = std::make_unique<OpTablePrinter>();
+}
+
+} // namespace circledump

--- a/compiler/circledump/src/MetadataPrinter.cpp
+++ b/compiler/circledump/src/MetadataPrinter.cpp
@@ -51,7 +51,7 @@ public:
         assert(len != 0);
         // data
         // non-empty 'data' has trailing '\0'. Let's exclude it.
-        std::string node_name = std::string(cur, len > 0 ? cur + len - 1 : cur + len);
+        std::string node_name = std::string(cur, cur + len - 1);
         cur += len;
 
         // print
@@ -112,8 +112,8 @@ public:
 
 MetadataPrinterRegistry::MetadataPrinterRegistry()
 {
-  _metadata_map["source_table"] = std::make_unique<SourceTablePrinter>();
-  _metadata_map["op_table"] = std::make_unique<OpTablePrinter>();
+  _metadata_map["ONE_source_table"] = std::make_unique<SourceTablePrinter>();
+  _metadata_map["ONE_op_table"] = std::make_unique<OpTablePrinter>();
 }
 
 } // namespace circledump

--- a/compiler/circledump/src/MetadataPrinter.h
+++ b/compiler/circledump/src/MetadataPrinter.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __CIRCLEDUMP_METADATA_PRINTER_H__
+#define __CIRCLEDUMP_METADATA_PRINTER_H__
+
+#include <ostream>
+#include <string>
+#include <map>
+#include <memory>
+
+namespace circledump
+{
+
+class MetadataPrinter
+{
+public:
+  virtual void print(const uint8_t * /* buffer */, std::ostream &) const = 0;
+};
+
+class MetadataPrinterRegistry
+{
+public:
+  MetadataPrinterRegistry();
+
+public:
+  const MetadataPrinter *lookup(std::string op) const
+  {
+    if (_metadata_map.find(op) == _metadata_map.end())
+      return nullptr;
+
+    return _metadata_map.at(op).get();
+  }
+
+public:
+  static MetadataPrinterRegistry &get()
+  {
+    static MetadataPrinterRegistry me;
+    return me;
+  }
+
+private:
+  std::map<std::string /* metadata name */, std::unique_ptr<MetadataPrinter>> _metadata_map;
+};
+
+} // namespace circledump
+
+#endif // __CIRCLEDUMP_METADATA_PRINTER_H__


### PR DESCRIPTION
This commit introduces MetadataPrinter to circledump.

Related: #6080 
Draft: #6217 
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>