### PR TITLE
[circle2circle] Introduce profiling data gen option

### DIFF
--- a/compiler/circle2circle/src/Circle2Circle.cpp
+++ b/compiler/circle2circle/src/Circle2Circle.cpp
@@ -268,6 +268,12 @@ int entry(int argc, char **argv)
     .default_value(false)
     .help("This will turn off operator validations. May help input model investigation.");
 
+  arser.add_argument("--profiling_data_gen")
+    .nargs(0)
+    .required(false)
+    .default_value(false)
+    .help("This will turn on profiling data generation.");
+
   arser.add_argument("input").nargs(1).type(arser::DataType::STR).help("Input circle model");
   arser.add_argument("output").nargs(1).type(arser::DataType::STR).help("Output circle model");
 
@@ -390,6 +396,8 @@ int entry(int argc, char **argv)
     settings->set(luci::UserSettings::Key::MuteWarnings, true);
   if (arser.get<bool>("--disable_validation"))
     settings->set(luci::UserSettings::Key::DisableValidation, true);
+  if (arser.get<bool>("--profiling_data_gen"))
+    settings->set(luci::UserSettings::Key::ProfilingDataGen, true);
 
   std::string input_path = arser.get<std::string>("input");
   std::string output_path = arser.get<std::string>("output");


### PR DESCRIPTION
Parent Issue : #6080
Draft : #6101

This commit will introduce `--profiling_data_gen` option for generating profiling data in `circle2circle`.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>