### PR TITLE
[luci/export] Deprecate metadata_buffer in CircleExporter

### DIFF
--- a/compiler/luci/export/src/CircleExporterImpl.cpp
+++ b/compiler/luci/export/src/CircleExporterImpl.cpp
@@ -161,13 +161,9 @@ void CircleExporterImpl::exportGraph(loco::Graph *graph)
   // create array of buffers
   auto buffers = _builder.CreateVector(md._buffers);
 
-  // empty metadata
-  std::vector<int> metadata_buffer_vec;
-  auto metadata_buffer = _builder.CreateVector(metadata_buffer_vec);
-
   // Model
   auto model_offset = CreateModel(_builder, version, operator_codes, subgraphs, description,
-                                  buffers, metadata_buffer);
+                                  buffers, 0 /* metadata_buffer */);
   FinishModelBuffer(_builder, model_offset);
 }
 

--- a/compiler/luci/export/src/CircleExporterImpl.cpp
+++ b/compiler/luci/export/src/CircleExporterImpl.cpp
@@ -221,16 +221,12 @@ void CircleExporterImpl::exportModule(Module *module)
   // create array of buffers
   auto buffers = _builder.CreateVector(md._buffers);
 
-  // empty metadata
-  std::vector<int> metadata_buffer_vec;
-  auto metadata_buffer = _builder.CreateVector(metadata_buffer_vec);
-
   // This version is taken from comment in fbs
   constexpr uint32_t version = 0;
 
   // Model
   auto model_offset = CreateModel(_builder, version, operator_codes, subgraphs, description,
-                                  buffers, metadata_buffer);
+                                  buffers, 0 /* metadata_buffer */);
   FinishModelBuffer(_builder, model_offset);
 }
 


### PR DESCRIPTION
This commit deprecates `metadata_buffer` at `CircleExporterImpl.cpp` with following reasons.

- `metadata_buffer` is deprecated in schema and there was no models which use it.
- Current code generate empty vector, which is exactly same with 0.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>