### PR TITLE
[onert] Fix warnings

### DIFF
--- a/runtime/onert/core/include/backend/cpu_common/BackendContextHelpers.h
+++ b/runtime/onert/core/include/backend/cpu_common/BackendContextHelpers.h
@@ -242,7 +242,10 @@ inline void initConsts(BackendContext &ctx)
     auto data = operand.shareData();
     assert(data && data->base());
     ExternalTensor *ext_tensor = dynamic_cast<ExternalTensor *>(tensor);
-    assert(ext_tensor);
+
+    if (ext_tensor == nullptr)
+      throw std::runtime_error{"This tensor is not external tensor"};
+
     ext_tensor->setData(data);
   });
 }

--- a/runtime/onert/core/src/ir/OperationValidator.cc
+++ b/runtime/onert/core/src/ir/OperationValidator.cc
@@ -396,7 +396,7 @@ void OperationValidator::visit(const operation::Pad &node)
     const auto value_t = operandType(value_index);
     // NNAPI accepts this case. scale and zeroPoint are assumed to be the same as in input0.
     const bool cond_quant8 =
-      ((input_t == DataType::QUANT_UINT8_ASYMM || input_t == DataType::QUANT_UINT8_ASYMM) &&
+      ((input_t == DataType::QUANT_UINT8_ASYMM || input_t == DataType::QUANT_INT8_ASYMM) &&
        value_t == DataType::INT32);
     OP_REQUIRES((cond_same && cond_same_quant) || cond_quant8);
   }

--- a/runtime/onert/core/src/util/EventRecorder.h
+++ b/runtime/onert/core/src/util/EventRecorder.h
@@ -39,8 +39,8 @@ struct Event
 
 struct DurationEvent : public Event
 {
-  uint32_t session_index;
-  uint32_t subg_index;
+  uint32_t session_index = 0;
+  uint32_t subg_index = 0;
 
 protected:
   DurationEvent() = default;

--- a/runtime/onert/core/src/util/MDTableEventWriter.cc
+++ b/runtime/onert/core/src/util/MDTableEventWriter.cc
@@ -235,7 +235,11 @@ struct MDTableBuilder
       for (size_t i = begin_idx + 1; i < end_idx; ++i)
       {
         const auto *evt = dynamic_cast<const OpSeqDurationEvent *>(_duration_events[i].get());
-        assert(evt != nullptr);
+        if (evt == nullptr)
+        {
+          continue;
+        }
+
         const std::string evt_name = getLabel(*evt);
         assert(evt->ph.compare("B") == 0 || evt->ph.compare("E") == 0);
         if (evt->ph.compare("B") == 0)


### PR DESCRIPTION
- Throw exception when dynamic casting return nullptr
- Fix OperationValidator bug
- Initialize DurationEvent fields

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>