### PR TITLE
[luci] Disable old inference pass

### DIFF
--- a/compiler/luci/export/src/Optimize.cpp
+++ b/compiler/luci/export/src/Optimize.cpp
@@ -17,8 +17,6 @@
 #include "Optimize.h"
 #include "ProgressReporter.h"
 
-#include <luci/Pass/ShapeInferencePass.h>
-#include <luci/Pass/TypeInferencePass.h>
 #include <luci/Pass/CircleShapeInferencePass.h>
 #include <luci/Pass/CircleTypeInferencePass.h>
 
@@ -34,8 +32,6 @@ void optimize(loco::Graph *g)
   logo::Phase phase;
   {
     // prepare type and shape before optimization
-    phase.emplace_back(std::make_unique<TypeInferencePass>());
-    phase.emplace_back(std::make_unique<ShapeInferencePass>());
     phase.emplace_back(std::make_unique<luci::CircleShapeInferencePass>());
     phase.emplace_back(std::make_unique<luci::CircleTypeInferencePass>());
 

--- a/compiler/luci/pass/src/CircleOptimizer.cpp
+++ b/compiler/luci/pass/src/CircleOptimizer.cpp
@@ -53,8 +53,6 @@
 #include "luci/Pass/TransformMinMaxToRelu6Pass.h"
 // TODO add more passes
 
-#include "luci/Pass/ShapeInferencePass.h"
-#include "luci/Pass/TypeInferencePass.h"
 #include "luci/Pass/CircleShapeInferencePass.h"
 #include "luci/Pass/CircleTypeInferencePass.h"
 
@@ -138,8 +136,6 @@ void CircleOptimizer::optimize(luci::Module *m) const
   luci::Phase phase;
 
   // Following passes are needed everytime when other passes create new node or modify some nodes.
-  phase.emplace_back(std::make_unique<luci::ShapeInferencePass>());
-  phase.emplace_back(std::make_unique<luci::TypeInferencePass>());
   phase.emplace_back(std::make_unique<luci::CircleShapeInferencePass>());
   phase.emplace_back(std::make_unique<luci::CircleTypeInferencePass>());
 
@@ -162,8 +158,6 @@ void CircleOptimizer::optimize(loco::Graph *g) const
   phase.emplace_back(std::make_unique<logo::RemoveDeadNodeWithQueryPass>());
 
   // Following passes are needed everytime when other passes create new node or modify some nodes.
-  phase.emplace_back(std::make_unique<luci::TypeInferencePass>());
-  phase.emplace_back(std::make_unique<luci::ShapeInferencePass>());
   phase.emplace_back(std::make_unique<luci::CircleShapeInferencePass>());
   phase.emplace_back(std::make_unique<luci::CircleTypeInferencePass>());
 
@@ -376,8 +370,6 @@ void CircleOptimizer::quantize(loco::Graph *g) const
 
     phase.emplace_back(std::make_unique<luci::PropagateQuantParamPass>());
 
-    phase.emplace_back(std::make_unique<luci::ShapeInferencePass>());
-    phase.emplace_back(std::make_unique<luci::TypeInferencePass>());
     phase.emplace_back(std::make_unique<luci::CircleShapeInferencePass>());
     phase.emplace_back(std::make_unique<luci::CircleTypeInferencePass>());
     phase.emplace_back(std::make_unique<logo::RemoveDeadNodeWithQueryPass>());
@@ -412,8 +404,6 @@ void CircleOptimizer::quantize(loco::Graph *g) const
   logo::Phase phase;
 
   // Do Shape/Type inference
-  phase.emplace_back(std::make_unique<luci::ShapeInferencePass>());
-  phase.emplace_back(std::make_unique<luci::TypeInferencePass>());
   phase.emplace_back(std::make_unique<luci::CircleShapeInferencePass>());
   phase.emplace_back(std::make_unique<luci::CircleTypeInferencePass>());
 

--- a/compiler/luci/pass/src/ConvertNCHWToNHWCPass.test.cpp
+++ b/compiler/luci/pass/src/ConvertNCHWToNHWCPass.test.cpp
@@ -17,7 +17,6 @@
 #include <logo/Phase.h>
 
 #include "luci/Pass/ConvertNCHWToNHWCPass.h"
-#include "luci/Pass/ShapeInferencePass.h"
 #include "luci/Pass/CircleShapeInferencePass.h"
 
 #include <luci/IR/CircleNodes.h>
@@ -346,7 +345,6 @@ void run_phase(loco::Graph *g, bool preserve_input, bool preserve_output)
   logo::Phase phase;
 
   // Default passes.
-  phase.emplace_back(std::make_unique<luci::ShapeInferencePass>());
   phase.emplace_back(std::make_unique<luci::CircleShapeInferencePass>());
 
   // Pass to test

--- a/compiler/luci/tester/src/ReadModule.cpp
+++ b/compiler/luci/tester/src/ReadModule.cpp
@@ -53,8 +53,6 @@ std::unique_ptr<luci::Module> ReadModule(std::string &input_path)
     {
       logo::Phase phase;
 
-      phase.emplace_back(std::make_unique<luci::ShapeInferencePass>());
-      phase.emplace_back(std::make_unique<luci::TypeInferencePass>());
       phase.emplace_back(std::make_unique<luci::CircleShapeInferencePass>());
       phase.emplace_back(std::make_unique<luci::CircleTypeInferencePass>());
 


### PR DESCRIPTION
Parent Issue : #5501

This commit will disable `TypeInferencePass` and `ShapeInferencePass` which are not used anymore.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>