### PR TITLE
[luci] Remove shape_erase in luci

### DIFF
--- a/compiler/luci/pass/src/ConvertNCHWToNHWCPass.cpp
+++ b/compiler/luci/pass/src/ConvertNCHWToNHWCPass.cpp
@@ -377,8 +377,6 @@ template <class T> bool convert_unary_features(T *node)
   node->features(pre_trans);
 
   // Do shape inference for this node again.
-  // TODO Remove loco::shape_erase()
-  loco::shape_erase(node);
   node->shape_status(luci::ShapeStatus::UNDEFINED);
 
   auto post_trans = create_post_transpose(node);
@@ -408,10 +406,7 @@ class ConvertNCHWToNHWC final : public luci::CircleNodeMutableVisitor<bool>
     node->dim(2) = w;
     node->dim(3) = c;
 
-    node->shape_status(luci::ShapeStatus::VALID);
-
-    // TODO Remove loco::shape_erase()
-    loco::shape_erase(node);
+    // Do shape inference for this node again.
     node->shape_status(luci::ShapeStatus::UNDEFINED);
 
     // Insert post-tranpose
@@ -436,8 +431,7 @@ class ConvertNCHWToNHWC final : public luci::CircleNodeMutableVisitor<bool>
 
     node->from(pre_trans);
 
-    // TODO Remove loco::shape_erase()
-    loco::shape_erase(node);
+    // Do shape inference for this node again.
     node->shape_status(luci::ShapeStatus::UNDEFINED);
 
     // Update graph output
@@ -488,9 +482,7 @@ class ConvertNCHWToNHWC final : public luci::CircleNodeMutableVisitor<bool>
       return false;
     }
 
-    // Make loco do shape inference for this node again.
-    // TODO Remove loco::shape_erase()
-    loco::shape_erase(node);
+    // Do shape inference for this node again.
     node->shape_status(luci::ShapeStatus::UNDEFINED);
 
     auto post_trans = create_post_transpose(node);
@@ -512,8 +504,6 @@ class ConvertNCHWToNHWC final : public luci::CircleNodeMutableVisitor<bool>
     }
 
     // Do shape inference for this node again.
-    // TODO Remove loco::shape_erase()
-    loco::shape_erase(node);
     node->shape_status(luci::ShapeStatus::UNDEFINED);
 
     node->axis(nchw_axis_to_nhwc(node->axis()));
@@ -558,9 +548,7 @@ class ConvertNCHWToNHWC final : public luci::CircleNodeMutableVisitor<bool>
       return false;
     }
 
-    // Make loco do shape inference for this node again.
-    // TODO Remove loco::shape_erase()
-    loco::shape_erase(node);
+    // Do shape inference for this node again.
     node->shape_status(luci::ShapeStatus::UNDEFINED);
 
     auto post_trans = create_post_transpose(node);
@@ -578,8 +566,6 @@ class ConvertNCHWToNHWC final : public luci::CircleNodeMutableVisitor<bool>
     node->x(pre_trans);
 
     // Do shape inference for this node again.
-    // TODO Remove loco::shape_erase()
-    loco::shape_erase(node);
     node->shape_status(luci::ShapeStatus::UNDEFINED);
 
     auto post_trans = create_post_transpose(node);
@@ -604,9 +590,7 @@ class ConvertNCHWToNHWC final : public luci::CircleNodeMutableVisitor<bool>
     const auto nhwc_paddings = create_NHWC_paddings(nchw_paddings);
     node->paddings(nhwc_paddings);
 
-    // Make loco do shape inference for this node again.
-    // TODO Remove loco::shape_erase()
-    loco::shape_erase(node);
+    // Do shape inference for this node again.
     node->shape_status(luci::ShapeStatus::UNDEFINED);
 
     auto post_trans = create_post_transpose(node);

--- a/compiler/luci/pass/src/ForwardReshapeToUnaryOpPass.cpp
+++ b/compiler/luci/pass/src/ForwardReshapeToUnaryOpPass.cpp
@@ -79,9 +79,7 @@ bool forward_reshape(luci::CircleReshape *reshape, luci::CircleNeg *neg)
   neg->x(reshape->tensor());
   new_reshape->tensor(neg);
 
-  // need to reset shape as it leaped over Reshape
-  // TODO Remove loco::shape_erase()
-  loco::shape_erase(neg);
+  // Do shape inference for this node again.
   neg->shape_status(luci::ShapeStatus::UNDEFINED);
 
   return true;

--- a/compiler/luci/pass/src/FuseInstanceNormPass.cpp
+++ b/compiler/luci/pass/src/FuseInstanceNormPass.cpp
@@ -553,8 +553,8 @@ void fuse_instance_norm(const InstanceNormPattern &p)
     p.const_as_beta->rank(1);
     p.const_as_beta->dim(0).set(p.const_as_beta->size<loco::DataType::FLOAT32>());
 
-    loco::shape_erase(p.const_as_gamma);
-    loco::shape_erase(p.const_as_beta);
+    p.const_as_gamma->shape_status(luci::ShapeStatus::UNDEFINED);
+    p.const_as_beta->shape_status(luci::ShapeStatus::UNDEFINED);
   }
 
   // Make Instance Norm to replace


### PR DESCRIPTION
Parent Issue : #5501

This commit will remove `shape_erase` in `luci` because loco shape related functions are no more used.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>