### PR TITLE
[onert] Fix OperationValidator bug

### DIFF
--- a/runtime/onert/core/src/ir/OperationValidator.cc
+++ b/runtime/onert/core/src/ir/OperationValidator.cc
@@ -396,7 +396,7 @@ void OperationValidator::visit(const operation::Pad &node)
     const auto value_t = operandType(value_index);
     // NNAPI accepts this case. scale and zeroPoint are assumed to be the same as in input0.
     const bool cond_quant8 =
-      ((input_t == DataType::QUANT_UINT8_ASYMM || input_t == DataType::QUANT_UINT8_ASYMM) &&
+      ((input_t == DataType::QUANT_UINT8_ASYMM || input_t == DataType::QUANT_INT8_ASYMM) &&
        value_t == DataType::INT32);
     OP_REQUIRES((cond_same && cond_same_quant) || cond_quant8);
   }


### PR DESCRIPTION
This commit fixes Pad operation's data type check typo bug.

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: #6182
Part of #6243