### PR TITLE
[onert] Initialize DurationEvent fields

### DIFF
--- a/runtime/onert/core/src/util/EventRecorder.h
+++ b/runtime/onert/core/src/util/EventRecorder.h
@@ -39,8 +39,8 @@ struct Event
 
 struct DurationEvent : public Event
 {
-  uint32_t session_index;
-  uint32_t subg_index;
+  uint32_t session_index = 0;
+  uint32_t subg_index = 0;
 
 protected:
   DurationEvent() = default;


### PR DESCRIPTION
This commit initializes DurationEvent struct fields

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: #6182
Part of #6243