### PR TITLE
[luci/export] Introduce circle metadata generator

### DIFF
--- a/compiler/luci/export/src/CircleExportMetadata.cpp
+++ b/compiler/luci/export/src/CircleExportMetadata.cpp
@@ -35,11 +35,8 @@ flatbuffers::Offset<circle::Metadata> metadata_offset(flatbuffers::FlatBufferBui
                                                       const std::string &metadata_name)
 {
   auto buffer_id = static_cast<uint32_t>(md._buffers.size());
-  auto vec_offset = builder.CreateVector(data.data(), data.size());
-  md._buffers.push_back(circle::CreateBuffer(builder, vec_offset));
-  flatbuffers::Offset<circle::Metadata> metadata =
-    circle::CreateMetadata(builder, builder.CreateString(metadata_name), buffer_id);
-  return metadata;
+  md._buffers.push_back(circle::CreateBufferDirect(builder, &data));
+  return circle::CreateMetadataDirect(builder, metadata_name.c_str(), buffer_id);
 }
 
 } // namespace

--- a/compiler/luci/export/src/CircleExportMetadata.h
+++ b/compiler/luci/export/src/CircleExportMetadata.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __LUCI_CIRCLE_EXPORT_METADATA_H__
+#define __LUCI_CIRCLE_EXPORT_METADATA_H__
+
+#include "SerializedData.h"
+
+#include <flatbuffers/flatbuffers.h>
+#include <mio/circle/schema_generated.h>
+
+namespace luci
+{
+
+/**
+ * @brief  Create Metadata corresponding to model metadata
+ */
+std::vector<flatbuffers::Offset<circle::Metadata>>
+createCircleMetadataVector(flatbuffers::FlatBufferBuilder &builder, SerializedModelData &md);
+
+} // namespace luci
+
+#endif // __LUCI_CIRCLE_EXPORT_METADATA_H__


### PR DESCRIPTION
Parent Issue : #6080
Draft : #6101

This commit introduces `craeteCircleMetadataVector`, which creates vector of circle::Metadata.
The result is exported to circle file by exporter.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>