### PR TITLE
[luci/profile] Add a logic for has_origin

### DIFF
--- a/compiler/luci/profile/src/CircleNodeOrigin.cpp
+++ b/compiler/luci/profile/src/CircleNodeOrigin.cpp
@@ -141,7 +141,13 @@ namespace luci
 
 bool has_origin(const luci::CircleNode *circle_node)
 {
-  return circle_node->annot<CircleNodeOriginAnnotation>() != nullptr;
+  if (circle_node->annot<CircleNodeOriginAnnotation>() == nullptr)
+    return false;
+
+  if (circle_node->annot<CircleNodeOriginAnnotation>()->origin() == nullptr)
+    return false;
+
+  return true;
 }
 
 void add_origin(luci::CircleNode *circle_node, const std::shared_ptr<CircleNodeOrigin> origin)


### PR DESCRIPTION
As `get_origin` can return `nullptr`, one more `nullptr` check is needed.
This commit will add a new logic for checking whether origin of annotation is `nullptr` or not.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>