### PR TITLE
[luci/service] Remove loco shape/dtype getter function

### DIFF
--- a/compiler/luci/service/src/CircleShapeInferenceHelper.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceHelper.cpp
@@ -23,14 +23,8 @@ namespace luci
 
 loco::NodeShape shape_get(const loco::Node *node)
 {
-  // NOTE This function is subject to change after refactoring is finished.
-  //      If shape of CircleNode is returned, ShapeInferencePass may cause errors.
-  //      If shape of loco::Node is returned, CircleShapeInferencePass may cause errors.
-  //      Therefore until refactoring is finished, both kind of shape should be used.
-  if (luci::shape_known(node))
-    return loco::NodeShape{sinf::circle_shape(loco::must_cast<const luci::CircleNode *>(node))};
-  assert(loco::shape_known(node));
-  return loco::shape_get(node);
+  assert(luci::shape_known(node));
+  return loco::NodeShape{sinf::circle_shape(loco::must_cast<const luci::CircleNode *>(node))};
 }
 
 bool shape_known(const loco::Node *node)

--- a/compiler/luci/service/src/CircleTypeInferenceHelper.cpp
+++ b/compiler/luci/service/src/CircleTypeInferenceHelper.cpp
@@ -23,14 +23,8 @@ namespace luci
 
 loco::DataType dtype_get(const loco::Node *node)
 {
-  // NOTE This function is subject to change after refactoring is finished.
-  //      If type of CircleNode is returned, TypeInferencePass may cause errors.
-  //      If type of loco::Node is returned, CircleTypeInferencePass may cause errors.
-  //      Therefore until refactoring is finished, both kind of type should be used.
-  if (luci::dtype_known(node))
-    return loco::must_cast<const luci::CircleNode *>(node)->dtype();
-  assert(loco::dtype_known(node));
-  return loco::dtype_get(node);
+  assert(luci::dtype_known(node));
+  return loco::must_cast<const luci::CircleNode *>(node)->dtype();
 }
 
 bool dtype_known(const loco::Node *node)


### PR DESCRIPTION
Parent Issue : #5501

This commit will remove loco shape/dtype getter function in `luci/service`,
because the functions are no more needed.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>