### PR TITLE
[luci/profile] Add nullptr handling logic

### DIFF
--- a/compiler/luci/profile/src/CircleNodeOrigin.cpp
+++ b/compiler/luci/profile/src/CircleNodeOrigin.cpp
@@ -146,6 +146,9 @@ bool has_origin(const luci::CircleNode *circle_node)
 
 void add_origin(luci::CircleNode *circle_node, const std::shared_ptr<CircleNodeOrigin> origin)
 {
+  if (origin == nullptr)
+    return;
+
   circle_node->annot<CircleNodeOriginAnnotation>(nullptr);
   circle_node->annot(std::make_unique<CircleNodeOriginAnnotation>(origin));
 }
@@ -155,6 +158,7 @@ const std::shared_ptr<luci::CircleNodeOrigin> get_origin(const luci::CircleNode 
   if (!has_origin(circle_node))
     return nullptr;
 
+  assert(circle_node->annot<CircleNodeOriginAnnotation>()->origin() != nullptr);
   return circle_node->annot<CircleNodeOriginAnnotation>()->origin();
 }
 


### PR DESCRIPTION
If `origin` is `nullptr`, not adding origin seems better.
And for safety, adding an assert seems better.
This commit add them.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>