### PR TITLE
[luci/profile] Synchronize meaning and action of add_origin

### DIFF
--- a/compiler/luci/profile/src/CircleNodeOrigin.cpp
+++ b/compiler/luci/profile/src/CircleNodeOrigin.cpp
@@ -146,6 +146,8 @@ bool has_origin(const luci::CircleNode *circle_node)
 
 /**
  * @brief 'origin' is added to the existing origin of circle_node.
+ * @note  If 'origin' is nullptr, nothing is changed.
+ *        For more detail, please refer to CompositeOrigin constructor.
  */
 void add_origin(luci::CircleNode *circle_node, const std::shared_ptr<CircleNodeOrigin> origin)
 {

--- a/compiler/luci/profile/src/CircleNodeOrigin.cpp
+++ b/compiler/luci/profile/src/CircleNodeOrigin.cpp
@@ -144,13 +144,14 @@ bool has_origin(const luci::CircleNode *circle_node)
   return circle_node->annot<CircleNodeOriginAnnotation>() != nullptr;
 }
 
+/**
+ * @brief 'origin' is added to the existing origin of circle_node.
+ */
 void add_origin(luci::CircleNode *circle_node, const std::shared_ptr<CircleNodeOrigin> origin)
 {
-  if (origin == nullptr)
-    return;
-
+  auto new_origin = composite_origin({get_origin(circle_node), origin});
   circle_node->annot<CircleNodeOriginAnnotation>(nullptr);
-  circle_node->annot(std::make_unique<CircleNodeOriginAnnotation>(origin));
+  circle_node->annot(std::make_unique<CircleNodeOriginAnnotation>(new_origin));
 }
 
 const std::shared_ptr<luci::CircleNodeOrigin> get_origin(const luci::CircleNode *circle_node)


### PR DESCRIPTION
Currently, `add_origin` is executes like setting origin, not adding.
This is dangerous because mismatch between meaning and actual action cause confusion.
This commit will synchronize meaning and action of `add_origin`.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>