### PR TITLE
[luci/pass] Add and fix origin annotation

### DIFF
--- a/compiler/luci/pass/src/ConvertNCHWToNHWCPass.cpp
+++ b/compiler/luci/pass/src/ConvertNCHWToNHWCPass.cpp
@@ -19,6 +19,7 @@
 
 #include <luci/IR/CircleNodes.h>
 #include <luci/IR/CircleNodeVisitor.h>
+#include <luci/Profile/CircleNodeOrigin.h>
 #include <luci/Log.h>
 
 #include <loco/Service/ShapeInference.h>
@@ -102,6 +103,7 @@ luci::CircleTranspose *create_4d_transpose(luci::CircleNode *node,
   auto trans = node->graph()->nodes()->create<luci::CircleTranspose>();
   trans->perm(perm);
   trans->name(name + "/Transpose_" + str_indices);
+  luci::add_origin(trans, luci::get_origin(node));
 
   return trans;
 }

--- a/compiler/luci/pass/src/FoldDequantizePass.cpp
+++ b/compiler/luci/pass/src/FoldDequantizePass.cpp
@@ -17,6 +17,7 @@
 #include "luci/Pass/FoldDequantizePass.h"
 
 #include <luci/IR/CircleNodes.h>
+#include <luci/Profile/CircleNodeOrigin.h>
 
 #include <loco/Service/TypeInference.h>
 
@@ -195,6 +196,8 @@ bool FoldDequantizePass::run(loco::Graph *g)
             if (replace_const_node(const_node_user, const_node))
             {
               loco::replace(dequant).with(const_node_user);
+              luci::add_origin(loco::must_cast<luci::CircleNode *>(const_node_user),
+                               luci::get_origin(dequant));
               changed = true;
             }
           }

--- a/compiler/luci/pass/src/FuseActivationFunctionPass.cpp
+++ b/compiler/luci/pass/src/FuseActivationFunctionPass.cpp
@@ -19,6 +19,7 @@
 #include <luci/IR/CircleNodes.h>
 #include <luci/IR/CircleNodeMixins.h>
 #include <luci/IR/CircleOpcode.h>
+#include <luci/Profile/CircleNodeOrigin.h>
 
 namespace luci
 {
@@ -82,6 +83,7 @@ bool fuse_activation_function(luci::CircleNode *node)
     return false;
 
   node_with_fused_act->fusedActivationFunction(target_func);
+  luci::add_origin(pred_node, luci::get_origin(node));
   loco::replace(node).with(pred_node);
 
   node->drop();

--- a/compiler/luci/pass/src/FuseBatchNormWithTConvPass.cpp
+++ b/compiler/luci/pass/src/FuseBatchNormWithTConvPass.cpp
@@ -173,6 +173,7 @@ bool fused_batch_norm_with_tconv(luci::CircleAdd *add)
     auto relu = add->graph()->nodes()->create<luci::CircleRelu6>();
     relu->features(fused_tconv);
     relu->name(name + "/Relu6");
+    luci::add_origin(relu, luci::get_origin(add));
 
     replace(add).with(relu);
   }

--- a/compiler/luci/pass/src/FuseInstanceNormPass.cpp
+++ b/compiler/luci/pass/src/FuseInstanceNormPass.cpp
@@ -593,6 +593,7 @@ void fuse_instance_norm(const InstanceNormPattern &p)
   }
   if (p.version() == InstanceNormPattern::PatternVersion::Version_2)
   {
+    origin_vec.push_back(luci::get_origin(p.mean_of_ifm));
     origin_vec.push_back(luci::get_origin(p.pow));
     origin_vec.push_back(luci::get_origin(p.div));
   }

--- a/compiler/luci/pass/src/FusePreActivationBatchNormPass.cpp
+++ b/compiler/luci/pass/src/FusePreActivationBatchNormPass.cpp
@@ -466,10 +466,12 @@ bool fuse_mul_with_conv(luci::CircleMul *mul)
 
       // Update origin
       // TODO need to remove const
-      luci::add_origin(const_cast<luci::CircleConv2D *>(conv), luci::get_origin(mul));
+      luci::add_origin(const_cast<luci::CircleConv2D *>(conv),
+                       luci::get_origin(loco::must_cast<luci::CircleNode *>(s)));
     }
 
     loco::replace(mul).with(pred_node);
+    luci::add_origin(pred_node, get_origin(mul));
     relu->features(pred_node);
 
     mul->drop();

--- a/compiler/luci/pass/src/FusePreActivationBatchNormPass.cpp
+++ b/compiler/luci/pass/src/FusePreActivationBatchNormPass.cpp
@@ -467,11 +467,10 @@ bool fuse_mul_with_conv(luci::CircleMul *mul)
       // Update origin
       // TODO need to remove const
       luci::add_origin(const_cast<luci::CircleConv2D *>(conv),
-                       luci::get_origin(loco::must_cast<luci::CircleNode *>(s)));
+                       luci::get_origin(loco::must_cast<luci::CircleNode *>(mul)));
     }
 
     loco::replace(mul).with(pred_node);
-    luci::add_origin(pred_node, get_origin(mul));
     relu->features(pred_node);
 
     mul->drop();

--- a/compiler/luci/pass/src/ResolveCustomOpMatMulPass.cpp
+++ b/compiler/luci/pass/src/ResolveCustomOpMatMulPass.cpp
@@ -147,6 +147,7 @@ bool resolve_matmul(luci::CircleCustom *cop)
     transpose_node->a(rhs);
     transpose_node->perm(perm_node);
     transpose_node->name(name + "/rhs/Transpose");
+    luci::add_origin(transpose_node, luci::get_origin(cop));
     rhs = transpose_node;
   }
 


### PR DESCRIPTION
Currently, some of `luci/pass` are not doing `add_origin` even they should do.
And some of `luci/pass` are doing wrong `add_origin`.
This commit will add and fix them.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>