### PR TITLE
[luci] opcode_name of partition

### DIFF
--- a/compiler/luci/partition/CMakeLists.txt
+++ b/compiler/luci/partition/CMakeLists.txt
@@ -1,0 +1,24 @@
+file(GLOB_RECURSE SOURCES "src/*.cpp")
+file(GLOB_RECURSE TESTS "src/*.test.cpp")
+list(REMOVE_ITEM SOURCES ${TESTS})
+
+add_library(luci_partition SHARED ${SOURCES})
+target_include_directories(luci_partition PRIVATE src)
+target_include_directories(luci_partition PUBLIC include)
+target_link_libraries(luci_partition PUBLIC luci_lang)
+target_link_libraries(luci_partition PRIVATE luci_log)
+target_link_libraries(luci_partition PRIVATE luci_logex)
+target_link_libraries(luci_partition PRIVATE mio_circle)
+
+install(TARGETS luci_partition DESTINATION lib)
+
+if(NOT ENABLE_TEST)
+  return()
+endif(NOT ENABLE_TEST)
+
+nnas_find_package(GTest REQUIRED)
+
+GTest_AddTest(luci_partition_test ${TESTS})
+target_include_directories(luci_partition_test PRIVATE src)
+target_link_libraries(luci_partition_test luci_lang)
+target_link_libraries(luci_partition_test luci_partition)

--- a/compiler/luci/partition/README.md
+++ b/compiler/luci/partition/README.md
@@ -1,0 +1,4 @@
+# luci-partition
+
+`luci-partition` provides partition of a model to two or more sub models and
+its connection configuration having same computational results.

--- a/compiler/luci/partition/src/CircleOpCode.cpp
+++ b/compiler/luci/partition/src/CircleOpCode.cpp
@@ -34,7 +34,7 @@ public:
   BuiltinOperator visit(const CircleRsqrt *) final { return BuiltinOperator_RSQRT; }
   BuiltinOperator visit(const CircleSqrt *) final { return BuiltinOperator_SQRT; }
 
-  // NOTE only buildin operators should be called (NOT virtual nodes)
+  // NOTE only builtin operators should be called (NOT virtual nodes)
 };
 
 } // namespace

--- a/compiler/luci/partition/src/CircleOpCode.cpp
+++ b/compiler/luci/partition/src/CircleOpCode.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "CircleOpCode.h"
+
+#include <luci/IR/CircleNodes.h>
+#include <luci/IR/CircleNodeVisitor.h>
+
+#include <mio/circle/schema_generated.h>
+
+namespace
+{
+
+using namespace luci;
+using namespace circle;
+
+class QueryOpCode final : public CircleNodeVisitor<BuiltinOperator>
+{
+public:
+  // TODO add CircleNodes
+  BuiltinOperator visit(const CircleRsqrt *) final { return BuiltinOperator_RSQRT; }
+  BuiltinOperator visit(const CircleSqrt *) final { return BuiltinOperator_SQRT; }
+
+  // NOTE only buildin operators should be called (NOT virtual nodes)
+};
+
+} // namespace
+
+namespace luci
+{
+
+std::string opcode_name(const CircleNode *node)
+{
+  QueryOpCode qoc;
+  auto opcode = node->accept(&qoc);
+  auto name = circle::EnumNameBuiltinOperator(opcode);
+  return std::string(name);
+}
+
+} // namespace luci

--- a/compiler/luci/partition/src/CircleOpCode.h
+++ b/compiler/luci/partition/src/CircleOpCode.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __LUCI_PARTITION_CIRCLE_OP_CODE_H__
+#define __LUCI_PARTITION_CIRCLE_OP_CODE_H__
+
+#include <luci/IR/CircleNode.h>
+
+#include <string>
+
+namespace luci
+{
+
+std::string opcode_name(const CircleNode *node);
+
+} // namespace luci
+
+#endif // __LUCI_PARTITION_CIRCLE_OP_CODE_H__

--- a/compiler/luci/partition/src/CircleOpCode.test.cpp
+++ b/compiler/luci/partition/src/CircleOpCode.test.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "CircleOpCode.h"
+
+// NOTE any node will do for testing
+#include <luci/IR/Nodes/CircleSqrt.h>
+
+#include <gtest/gtest.h>
+
+TEST(CircleOpCodeTest, name)
+{
+  auto g = loco::make_graph();
+  auto node = g->nodes()->create<luci::CircleSqrt>();
+
+  auto name = luci::opcode_name(node);
+  ASSERT_EQ(name, "SQRT");
+}


### PR DESCRIPTION
This will introduce first luci parition change with a method
to get string name of OpCode of circle format.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>