### PR TITLE
[onert/frontend] Use std::string to pass package dir path

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -274,8 +274,8 @@ NNFW_STATUS nnfw_session::load_model_from_nnpackage(const char *package_dir)
 
   try
   {
-    std::string manifest_file_name(package_dir);
-    manifest_file_name += "/metadata/MANIFEST";
+    std::string package_path(package_dir);
+    std::string manifest_file_name = package_path + "/metadata/MANIFEST";
     std::ifstream mfs(manifest_file_name);
 
     // extract the filename of the first(index 0) model
@@ -288,7 +288,7 @@ NNFW_STATUS nnfw_session::load_model_from_nnpackage(const char *package_dir)
 
     if (!configs.empty() && !configs[0].empty())
     {
-      auto filepath = package_dir + std::string("/metadata/") + configs[0].asCString();
+      auto filepath = package_path + std::string("/metadata/") + configs[0].asString();
 
       CfgKeyValues keyValues;
       if (loadConfigure(filepath, keyValues))
@@ -297,15 +297,15 @@ NNFW_STATUS nnfw_session::load_model_from_nnpackage(const char *package_dir)
       }
     }
 
-    auto model_file_path = package_dir + std::string("/") + models[0].asString(); // first model
+    auto model_file_path = package_path + std::string("/") + models[0].asString(); // first model
     auto model_type = model_types[0].asString(); // first model's type
     if (model_type == "tflite")
     {
-      _subgraphs = onert::tflite_loader::loadModel(model_file_path.c_str());
+      _subgraphs = onert::tflite_loader::loadModel(model_file_path);
     }
     else if (model_type == "circle")
     {
-      _subgraphs = onert::circle_loader::loadModel(model_file_path.c_str());
+      _subgraphs = onert::circle_loader::loadModel(model_file_path);
     }
     else
     {

--- a/runtime/onert/frontend/base_loader/include/base_loader.h
+++ b/runtime/onert/frontend/base_loader/include/base_loader.h
@@ -78,7 +78,7 @@ public:
    *
    * @param file_path
    */
-  void loadFromFile(const char *file_path);
+  void loadFromFile(const std::string &file_path);
   /**
    * @brief Load a model from a buffer
    *
@@ -192,19 +192,18 @@ protected:
 };
 
 template <typename LoaderDomain>
-void BaseLoader<LoaderDomain>::BaseLoader::loadFromFile(const char *file_path)
+void BaseLoader<LoaderDomain>::BaseLoader::loadFromFile(const std::string &file_path)
 {
-  _fd = open(file_path, O_RDONLY);
+  _fd = open(file_path.c_str(), O_RDONLY);
   if (_fd < 0)
   {
-    throw std::runtime_error("Failed to open file " + std::string(file_path));
+    throw std::runtime_error("Failed to open file " + file_path);
   }
 
   struct stat file_stat;
   if (fstat(_fd, &file_stat) != 0)
   {
-    throw std::runtime_error("Fstat failed or file " + std::string(file_path) +
-                             " is not a regular file");
+    throw std::runtime_error("Fstat failed or file " + file_path + " is not a regular file");
   }
   int size = file_stat.st_size;
 

--- a/runtime/onert/frontend/circle/include/circle_loader.h
+++ b/runtime/onert/frontend/circle/include/circle_loader.h
@@ -25,7 +25,7 @@ namespace onert
 {
 namespace circle_loader
 {
-std::unique_ptr<ir::Subgraphs> loadModel(const char *filename);
+std::unique_ptr<ir::Subgraphs> loadModel(const std::string &filename);
 std::unique_ptr<ir::Subgraphs> loadModel(uint8_t *buffer, size_t size);
 } // namespace circle_loader
 } // namespace onert

--- a/runtime/onert/frontend/circle/src/circle_loader.cc
+++ b/runtime/onert/frontend/circle/src/circle_loader.cc
@@ -202,7 +202,7 @@ void CircleLoader::loadBCQFullyConnected(const Operator *op, ir::Graph &subg)
 
 } // namespace
 
-std::unique_ptr<ir::Subgraphs> loadModel(const char *filename)
+std::unique_ptr<ir::Subgraphs> loadModel(const std::string &filename)
 {
   auto subgraphs = std::make_unique<ir::Subgraphs>();
   CircleLoader loader(subgraphs);

--- a/runtime/onert/frontend/tflite/include/tflite_loader.h
+++ b/runtime/onert/frontend/tflite/include/tflite_loader.h
@@ -26,7 +26,7 @@ namespace onert
 namespace tflite_loader
 {
 
-std::unique_ptr<ir::Subgraphs> loadModel(const char *filename);
+std::unique_ptr<ir::Subgraphs> loadModel(const std::string &filename);
 
 } // namespace tflite_loader
 } // namespace onert

--- a/runtime/onert/frontend/tflite/src/tflite_loader.cc
+++ b/runtime/onert/frontend/tflite/src/tflite_loader.cc
@@ -115,7 +115,7 @@ private:
 
 } // namespace
 
-std::unique_ptr<ir::Subgraphs> loadModel(const char *filename)
+std::unique_ptr<ir::Subgraphs> loadModel(const std::string &filename)
 {
   auto subgraphs = std::make_unique<ir::Subgraphs>();
   TFLiteLoader loader(subgraphs);


### PR DESCRIPTION
This commit changes char pointer to std::string to pass package dir in onert frontend.
NNFW API still uses C-type char pointer.

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>