### PR TITLE
Fix wrong compilation option in some tizen toolchains

### DIFF
--- a/infra/nnfw/cmake/packages/XnnpackConfig.cmake
+++ b/infra/nnfw/cmake/packages/XnnpackConfig.cmake
@@ -31,6 +31,9 @@ function(_Xnnpack_Build)
   set(Xnnpack_FOUND TRUE PARENT_SCOPE)
 endfunction(_Xnnpack_Build)
 
+string(REGEX REPLACE "-flto" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+string(REGEX REPLACE "-flto" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+
 if(BUILD_XNNPACK)
   _Xnnpack_Build()
 else(BUILD_XNNPACK)


### PR DESCRIPTION
Some compilers on tizen provide -flto option, which produces compilation
error on xnnpack build. We will remove lto from xnnpack build.

Signed-off-by: Chunseok Lee <chunseok.lee@samsung.com>