### PR TITLE
[one-cmds] Make up for insufficient description of one-codegen

### DIFF
--- a/compiler/one-cmds/one-codegen
+++ b/compiler/one-cmds/one-codegen
@@ -42,7 +42,9 @@ def _get_backends_list():
 
 
 def _get_parser():
-    parser = argparse.ArgumentParser(description='command line tool for code generation')
+    codegen_usage = 'one-codegen [-h] [-v] [-C CONFIG] [-b BACKEND] -- [COMMANDS FOR BACKEND]'
+    parser = argparse.ArgumentParser(
+        description='command line tool for code generation', usage=codegen_usage)
 
     _utils._add_default_arg(parser)
 


### PR DESCRIPTION
This commit makes up for insufficient description of one-codegen.

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>