### PR TITLE
[one-cmds] fix one-quantize to propagate profile data properly

### DIFF
--- a/compiler/one-cmds/one-quantize
+++ b/compiler/one-cmds/one-quantize
@@ -187,6 +187,9 @@ def _quantize(args):
         if _utils._is_valid_attr(args, 'mode'):
             circle_record_minmax_cmd.append('--mode')
             circle_record_minmax_cmd.append(getattr(args, 'mode'))
+        # profiling
+        if _utils._is_valid_attr(args, 'generate_profile_data'):
+            circle_record_minmax_cmd.append('--generate_profile_data')
 
         f.write((' '.join(circle_record_minmax_cmd) + '\n').encode())
 


### PR DESCRIPTION
This commit fixes `one-quantize` to propagate profile data properly.

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>