### PR TITLE
[luci] Do not rename output tensor name

### DIFF
--- a/compiler/luci/import/src/Importer.cpp
+++ b/compiler/luci/import/src/Importer.cpp
@@ -187,7 +187,8 @@ void convert_graph(const luci::GraphBuilderSource &source, luci::CircleReader &r
     // set the graph output name and node object
     auto graph_output = graph->outputs()->create();
     std::string tname = luci::tensor_name(tensor);
-    graph_output->name("output_" + tname);
+    assert(tname.length() > 0);
+    graph_output->name(tname);
 
     luci::copy_tensor_attributes(tensor, output_node);
 


### PR DESCRIPTION
This will fix not to rename output tensor name.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>