### PR TITLE
[luci] Fix header guard typo

### DIFF
--- a/compiler/luci/partition/src/PartitionIR.h
+++ b/compiler/luci/partition/src/PartitionIR.h
@@ -69,4 +69,4 @@ struct PGraphs
 
 } // namespace luci
 
-#endif // __LUCI_PARTITON_IR_H__
+#endif // __LUCI_PARTITION_IR_H__


### PR DESCRIPTION
This will fix header guard type of partition IR.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>