### PR TITLE
[luci] Separate testhelper from pass

### DIFF
--- a/compiler/luci/testhelper/CMakeLists.txt
+++ b/compiler/luci/testhelper/CMakeLists.txt
@@ -1,0 +1,10 @@
+if(NOT ENABLE_TEST)
+  return()
+endif(NOT ENABLE_TEST)
+
+file(GLOB_RECURSE TESTS "src/*.test.cpp")
+
+add_library(luci_testhelper STATIC ${TESTS})
+target_include_directories(luci_testhelper PRIVATE src)
+target_include_directories(luci_testhelper PUBLIC include)
+target_link_libraries(luci_testhelper luci_lang)

--- a/compiler/luci/testhelper/README.md
+++ b/compiler/luci/testhelper/README.md
@@ -1,0 +1,3 @@
+# luci-testhelper
+
+_luci-testhelper_ provides Helper classes for unit testing

--- a/compiler/luci/testhelper/include/luci/test/TestIOGraph.h
+++ b/compiler/luci/testhelper/include/luci/test/TestIOGraph.h
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __LUCI_TESTHELPER_TEST_IO_GRAPH_H__
+#define __LUCI_TESTHELPER_TEST_IO_GRAPH_H__
+
+#include "TestShape.h"
+
+#include <luci/IR/CircleNodes.h>
+#include <luci/IR/Module.h>
+
+#include <memory>
+
+namespace luci
+{
+namespace test
+{
+
+/**
+ * @brief Graphlet with Inputs and loco::Graph for multiple inputs
+ * @note  Every Graph will have Input(s) and Output(s)
+ *        We put loco::Graph only in IsGraphlet not to declare separate
+ *        class for loco::Graph
+ */
+template <unsigned N> class TestIsGraphlet
+{
+public:
+  TestIsGraphlet()
+  {
+    for (uint32_t n = 0; n < N; ++n)
+    {
+      _graph_inputs[n] = nullptr;
+      _inputs[n] = nullptr;
+    }
+    _g = loco::make_graph();
+  }
+
+public:
+  virtual void init(loco::Graph *g, const ShapeU32 shape_in)
+  {
+    for (uint32_t n = 0; n < N; ++n)
+    {
+      _graph_inputs[n] = g->inputs()->create();
+
+      _inputs[n] = g->nodes()->create<luci::CircleInput>();
+      _inputs[n]->shape(shape_in);
+      _inputs[n]->shape_status(luci::ShapeStatus::VALID);
+      _inputs[n]->dtype(loco::DataType::FLOAT32);
+      _inputs[n]->name("input_" + std::to_string(n));
+
+      _inputs[n]->index(_graph_inputs[n]->index());
+
+      auto input_shape = std::make_unique<loco::TensorShape>();
+      set_shape_vector(input_shape.get(), shape_in);
+      _graph_inputs[n]->shape(std::move(input_shape));
+      _graph_inputs[n]->dtype(loco::DataType::FLOAT32);
+    }
+  }
+
+public:
+  loco::Graph *g(void) { return _g.get(); }
+  luci::CircleInput *input(int idx) { return _inputs[idx]; }
+
+public:
+  void transfer_to(luci::Module *module)
+  {
+    // WARNING: after g is transfered, _graph_inputs, _inputs
+    //          and _graph_outputs, _outputs in TestOsGraphlet will be invalid.
+    //          arrays are not cleared as this is just helpers to unit tests
+    module->add(std::move(_g));
+  }
+
+protected:
+  std::unique_ptr<loco::Graph> _g;
+  std::array<loco::GraphInput *, N> _graph_inputs;
+  std::array<luci::CircleInput *, N> _inputs;
+};
+
+/**
+ * @brief Graphlet with one Input
+ */
+class TestIGraphlet : public TestIsGraphlet<1>
+{
+public:
+  luci::CircleInput *input() { return _inputs[0]; }
+};
+
+/**
+ * @brief Graphlet with Outputs for multiple outputs
+ */
+template <unsigned N> class TestOsGraphlet
+{
+public:
+  TestOsGraphlet()
+  {
+    for (uint32_t n = 0; n < N; ++n)
+    {
+      _graph_outputs[n] = nullptr;
+      _outputs[n] = nullptr;
+    }
+  }
+
+public:
+  virtual void init(loco::Graph *g, const ShapeU32 shape_out)
+  {
+    for (uint32_t n = 0; n < N; ++n)
+    {
+      _graph_outputs[n] = g->outputs()->create();
+
+      _outputs[n] = g->nodes()->create<luci::CircleOutput>();
+      _outputs[n]->shape(shape_out);
+      _outputs[n]->shape_status(luci::ShapeStatus::VALID);
+      _outputs[n]->dtype(loco::DataType::FLOAT32);
+      _outputs[n]->name("output_" + std::to_string(n));
+
+      _outputs[n]->index(_graph_outputs[n]->index());
+
+      auto output_shape = std::make_unique<loco::TensorShape>();
+      set_shape_vector(output_shape.get(), shape_out);
+      _graph_outputs[n]->shape(std::move(output_shape));
+      _graph_outputs[n]->dtype(loco::DataType::FLOAT32);
+    }
+  }
+
+public:
+  luci::CircleOutput *output(int idx) { return _outputs[idx]; }
+
+protected:
+  std::array<loco::GraphOutput *, N> _graph_outputs;
+  std::array<luci::CircleOutput *, N> _outputs;
+};
+
+/**
+ * @brief Graphlet with one Output
+ */
+class TestOGraphlet : public TestOsGraphlet<1>
+{
+public:
+  luci::CircleOutput *output() { return _outputs[0]; }
+};
+
+/**
+ * @brief Graph with Input and Output
+ */
+class TestIOGraph : public TestIGraphlet, public TestOGraphlet
+{
+public:
+  TestIOGraph() = default;
+
+public:
+  virtual void init(const ShapeU32 shape_in, const ShapeU32 shape_out)
+  {
+    TestIsGraphlet<1>::init(g(), shape_in);
+    TestOsGraphlet<1>::init(g(), shape_out);
+  }
+};
+
+} // namespace test
+} // namespace luci
+
+#endif // __LUCI_TESTHELPER_TEST_IO_GRAPH_H__

--- a/compiler/luci/testhelper/include/luci/test/TestShape.h
+++ b/compiler/luci/testhelper/include/luci/test/TestShape.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __LUCI_TESTHELPER_TEST_SHAPE_H__
+#define __LUCI_TESTHELPER_TEST_SHAPE_H__
+
+#include <luci/IR/CircleNode.h>
+
+#include <initializer_list>
+
+namespace luci
+{
+namespace test
+{
+
+using ShapeU32 = std::initializer_list<uint32_t>;
+using ShapeI32 = std::initializer_list<int32_t>;
+
+void set_shape_vector(loco::TensorShape *shape, const ShapeU32 &values);
+void set_shape_vector(luci::CircleConst *const_node, const ShapeI32 &values);
+
+uint32_t num_elements(const ShapeU32 shape);
+
+} // namespace test
+} // namespace luci
+
+#endif // __LUCI_TESTHELPER_TEST_SHAPE_H__

--- a/compiler/luci/testhelper/src/TestIOGraph.test.cpp
+++ b/compiler/luci/testhelper/src/TestIOGraph.test.cpp
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/test/TestIOGraph.h"
+
+// This file validates "TestIOGraph.h". Pleaes DO NOT remove this file.

--- a/compiler/luci/testhelper/src/TestShape.test.cpp
+++ b/compiler/luci/testhelper/src/TestShape.test.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/test/TestShape.h"
+
+/**
+ * @note This file does not hold any test cases but provides methods for tests
+ */
+
+namespace luci
+{
+namespace test
+{
+
+void set_shape_vector(loco::TensorShape *shape, const ShapeU32 &values)
+{
+  uint32_t r = 0;
+  shape->rank(values.size());
+  for (auto v : values)
+    shape->dim(r++).set(v);
+}
+
+void set_shape_vector(luci::CircleConst *const_node, const ShapeI32 &values)
+{
+  const_node->rank(1);
+  const_node->dim(0).set(values.size());
+  const_node->shape_status(luci::ShapeStatus::VALID);
+  const_node->dtype(loco::DataType::S32);
+  const_node->size<loco::DataType::S32>(values.size());
+  uint32_t idx = 0;
+  for (auto val : values)
+    const_node->at<loco::DataType::S32>(idx++) = val;
+}
+
+uint32_t num_elements(const ShapeU32 shape)
+{
+  uint32_t result = 1;
+  for (auto val : shape)
+    result = result * val;
+  return result;
+}
+
+} // namespace test
+} // namespace luci


### PR DESCRIPTION
This will separate test graph builder from pass to independent module.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>