### PR TITLE
[circle-part-driver] Initial circle-part-driver

### DIFF
--- a/compiler/circle-part-driver/CMakeLists.txt
+++ b/compiler/circle-part-driver/CMakeLists.txt
@@ -1,0 +1,8 @@
+set(SRCS_PART_TESTER
+      src/Driver.cpp
+   )
+
+add_executable(circle_part_driver ${SRCS_PART_TESTER})
+target_link_libraries(circle_part_driver safemain)
+
+install(TARGETS circle_part_driver DESTINATION bin)

--- a/compiler/circle-part-driver/README.md
+++ b/compiler/circle-part-driver/README.md
@@ -1,0 +1,3 @@
+# luci-part-driver
+
+_luci-part-driver_ is test driver to run partitioned circle models

--- a/compiler/circle-part-driver/requires.cmake
+++ b/compiler/circle-part-driver/requires.cmake
@@ -1,0 +1,1 @@
+require("safemain")

--- a/compiler/circle-part-driver/src/Driver.cpp
+++ b/compiler/circle-part-driver/src/Driver.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cstdlib>
+#include <iostream>
+
+int entry(int argc, char **argv)
+{
+  if (argc != 5)
+  {
+    std::cerr
+      << "Usage: " << argv[0]
+      << " <path/to/partition/config> <num_inputs> <path/to/input/prefix> <path/to/output/file>\n";
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
This will introduce empty initial circle-part-driver test tool to
validate partitioned models.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>