### PR TITLE
[luci] Add default_group to PGroups

### DIFF
--- a/compiler/luci/partition/src/PartitionIR.h
+++ b/compiler/luci/partition/src/PartitionIR.h
@@ -66,6 +66,9 @@ struct PGroups
   // id2pngroup is to find *pngroup from pngroup id
   std::map<uint32_t, PGroup *> id2pgroup;
 
+  // default group key for reference
+  std::string default_group;
+
 public:
   /**
    * @brief return a copy of PGroups


### PR DESCRIPTION
This will add default_group member for default group in PGroups.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>