### PR TITLE
[luci] Introduce PartitionPGroups

### DIFF
--- a/compiler/luci/partition/src/PartitionPGroups.cpp
+++ b/compiler/luci/partition/src/PartitionPGroups.cpp
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "PartitionPGroups.h"
+#include "PartitionIR.h"
+#include "CircleOpCode.h"
+
+#include "luci/Partition.h"
+#include "luci/Log.h"
+#include "luci/LogHelper.h"
+
+#include <luci/IR/CircleNodes.h>
+#include <luci/IR/CircleNodeVisitor.h>
+
+#include <loco.h>
+
+namespace
+{
+
+class IsVirtualNode final : public luci::CircleNodeVisitor<bool>
+{
+public:
+  bool visit(const luci::CircleInput *) final { return true; }
+  bool visit(const luci::CircleOutput *) final { return true; }
+  // TODO add all virtual nodes
+
+  // default is false
+  bool visit(const luci::CircleNode *) final { return false; }
+};
+
+bool check_allocate_partition(const luci::CircleNode *node)
+{
+  IsVirtualNode query;
+  return not node->accept(&query);
+}
+
+} // namespace
+
+namespace luci
+{
+
+std::unique_ptr<luci::PGroups> produce_pgroups(const luci::Module *source,
+                                               const luci::PartitionTable &partition)
+{
+  assert(source != nullptr);
+  // TODO support multiple subgraphs
+  assert(source->size() == 1);
+
+  LOGGER(l);
+
+  auto pgroups = std::make_unique<luci::PGroups>();
+
+  pgroups->default_group = partition.default_group;
+
+  // Create a PGroup per CircleNode: each PGroup will have one CircleNode
+  auto graph = source->graph();
+  auto nodes = graph->nodes();
+  for (uint32_t idx = 0; idx < nodes->size(); ++idx)
+  {
+    auto node = loco::must_cast<luci::CircleNode *>(nodes->at(idx));
+
+    // check if node is normal node that we are interested
+    if (check_allocate_partition(node))
+    {
+      auto opcodename = luci::opcode_name(node);
+      assert(!opcodename.empty());
+
+      auto group = partition.default_group;
+      auto it = partition.byopcodes.find(opcodename);
+      if (it != partition.byopcodes.end())
+        group = it->second;
+
+      INFO(l) << "Op: " << node->name() << ": " << opcodename << ", " << node << ", " << group
+              << std::endl;
+
+      auto pgroup = std::make_unique<luci::PGroup>();
+      pgroup->group = group;
+      pgroup->id = idx + 1;
+
+      auto pnode = std::make_unique<luci::PNode>();
+      pnode->node = node;
+      pnode->group = group;
+      pnode->pgroup = pgroup.get();
+
+      pgroup->pnodes.push_back(std::move(pnode));
+
+      // Set input of PGroup
+      for (uint32_t in = 0; in < node->arity(); ++in)
+      {
+        auto input = loco::must_cast<luci::CircleNode *>(node->arg(in));
+        // this input maybe CircleInput in source graph
+        // --> not confident this is safe
+        pgroup->inputs.push_back(input);
+      }
+      // Set output of PGroup: node itself or multiple virtual outputs
+      // TODO support multiple virtual outputs
+      pgroup->outputs.push_back(node);
+
+      pgroups->node2group[node] = group;
+      pgroups->id2pgroup[pgroup->id] = pgroup.get();
+
+      pgroups->pgroups.push_back(std::move(pgroup));
+    }
+    else
+    {
+      INFO(l) << "Skip Op: " << node->name() << std::endl;
+      // record as default group
+      pgroups->node2group[node] = partition.default_group;
+    }
+  }
+
+  return std::move(pgroups);
+}
+
+} // namespace luci

--- a/compiler/luci/partition/src/PartitionPGroups.h
+++ b/compiler/luci/partition/src/PartitionPGroups.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __LUCI_PARTITON_PGROUPS_H__
+#define __LUCI_PARTITON_PGROUPS_H__
+
+#include "PartitionIR.h"
+
+#include "luci/Partition.h"
+
+#include <luci/IR/Module.h>
+
+namespace luci
+{
+
+/**
+ * @brief This will produce a PGroups from Module and PartitionTable.
+ * @note  Each PGroup will hold one CircleNode and partition key value as group.
+ *        Supports only single Graph in the Module for now.
+ */
+std::unique_ptr<luci::PGroups> produce_pgroups(const luci::Module *source,
+                                               const luci::PartitionTable &partition);
+
+} // namespace luci
+
+#endif // __LUCI_PARTITON_PGROUPS_H__

--- a/compiler/luci/partition/src/PartitionPGroups.test.cpp
+++ b/compiler/luci/partition/src/PartitionPGroups.test.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "PartitionPGroups.h"
+
+#include <luci/test/TestIOGraph.h>
+
+#include <luci/IR/Nodes/CircleSqrt.h>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+
+using namespace luci::test;
+
+class SqrtGraphlet
+{
+public:
+  SqrtGraphlet() = default;
+
+public:
+  void init(loco::Graph *g, const ShapeU32 input_shape)
+  {
+    _sqrt = g->nodes()->create<luci::CircleSqrt>();
+    _sqrt->dtype(loco::DataType::S32);
+    _sqrt->name("sqrt");
+  }
+
+protected:
+  luci::CircleSqrt *_sqrt = nullptr;
+};
+
+class SqrtGraph : public TestIOGraph, public SqrtGraphlet
+{
+public:
+  SqrtGraph() = default;
+
+public:
+  void init(const ShapeU32 shape)
+  {
+    TestIOGraph::init(shape, shape);
+    SqrtGraphlet::init(g(), shape);
+
+    _sqrt->x(input());
+
+    output()->from(_sqrt);
+  }
+};
+
+} // namespace
+
+TEST(PartitionPGroupsTest, simple_produce)
+{
+  luci::Module module;
+
+  SqrtGraph g;
+  g.init({3, 3});
+  g.transfer_to(&module);
+
+  luci::PartitionTable pt;
+  pt.default_group = "A";
+
+  auto pgs = produce_pgroups(&module, pt);
+
+  ASSERT_EQ(1, pgs->pgroups.size());
+}


### PR DESCRIPTION
This will introduce PartitionPGroups with produce_pgroups method that
will produce luci::PGroups from luci::Module and luci::PartitionTable.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>