### PR TITLE
[luci] Revise partition merge with inputs

### DIFF
--- a/compiler/luci/partition/src/PartitionMerge.cpp
+++ b/compiler/luci/partition/src/PartitionMerge.cpp
@@ -113,6 +113,12 @@ void merge_into(luci::PGroup *pgroup, luci::PGroup *pgroup_i)
         break;
       }
     }
+    // skip if this input is already in the inputs
+    auto fit = std::find(pgroup_i->inputs.begin(), pgroup_i->inputs.end(), input);
+    if (fit != pgroup_i->inputs.end())
+    {
+      found_in_pgroup_i = true;
+    }
     // note: if we force found_in_pgroup_i to false, for testing there will be
     // unnecessary inputs
     if (not found_in_pgroup_i)


### PR DESCRIPTION
This will revise partition merge of two pgroup not to add same input.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>