### PR TITLE
[luci] Revise partition check_allocate_partition

### DIFF
--- a/compiler/luci/partition/src/PartitionPGroups.cpp
+++ b/compiler/luci/partition/src/PartitionPGroups.cpp
@@ -44,7 +44,18 @@ public:
 bool check_allocate_partition(const luci::CircleNode *node)
 {
   IsVirtualNode query;
-  return not node->accept(&query);
+  if (node->accept(&query))
+    return false;
+  /**
+   * @note About CircleConst
+   *       CirleConst acts like a part of some CircleNode and managing mulitiple
+   *       used(referenced) CircleConst is a bit difficult if it's used across
+   *       different PGroup. So we treat this different to other types.
+   *       https://github.com/Samsung/ONE/issues/6230#issuecomment-809802813
+   */
+  if (dynamic_cast<const luci::CircleConst *>(node) != nullptr)
+    return false;
+  return true;
 }
 
 } // namespace


### PR DESCRIPTION
This will revise check_allocate_partition in partition to skip
CircleConst for making PNode and so on.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>