### PR TITLE
[luci] Partition cleanup unused I/Os in PGroups

### DIFF
--- a/compiler/luci/partition/src/Partition.cpp
+++ b/compiler/luci/partition/src/Partition.cpp
@@ -18,6 +18,7 @@
 #include "PartitionIRDump.h"
 #include "PartitionPGroups.h"
 #include "PartitionMerge.h"
+#include "PartitionCleanup.h"
 
 #include "luci/Partition.h"
 #include "luci/Log.h"
@@ -42,6 +43,10 @@ PartedModules apply(Module *source, const PartitionTable &partition)
 
   auto mpgroups = merge_pgroups(pgroups.get());
   INFO(l) << "--- Partition Graph (2)------------------------";
+  INFO(l) << mpgroups.get();
+
+  remove_unused_inputoutputs(mpgroups.get(), source);
+  INFO(l) << "--- Partition Graph (3)------------------------";
   INFO(l) << mpgroups.get();
 
   // TODO add implementation


### PR DESCRIPTION
This will revise partition apply method to cleanup unused inputs/outputs
in PGroups.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>