### PR TITLE
[circle-quantizer] Verify the granularity of node and its inputs

### DIFF
--- a/compiler/luci/pass/src/VerifyQuantizedNodeS16Type.h
+++ b/compiler/luci/pass/src/VerifyQuantizedNodeS16Type.h
@@ -31,6 +31,14 @@ using Type = loco::DataType;
 namespace luci
 {
 
+/**
+ * @brief Verify the data type of INT16 quantized node
+ * @details
+ *
+ * Targets to verify
+ * - node's output (i.e., node itself)
+ * - node's inputs
+ */
 struct VerifyQuantizedNodeS16Type final : public luci::CircleNodeVisitor<bool>
 {
 private:

--- a/compiler/luci/pass/src/VerifyQuantizedNodeU8Type.h
+++ b/compiler/luci/pass/src/VerifyQuantizedNodeU8Type.h
@@ -31,6 +31,14 @@ using Type = loco::DataType;
 namespace luci
 {
 
+/**
+ * @brief Verify the data type of UINT8 quantized node
+ * @details
+ *
+ * Targets to verify
+ * - node's output (i.e., node itself)
+ * - node's inputs
+ */
 struct VerifyQuantizedNodeU8Type final : public luci::CircleNodeVisitor<bool>
 {
 private:


### PR DESCRIPTION
This verifies the granularity of the node and its inputs.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>