### PR TITLE
[circle-part-driver] Introduce empty PModelsRunner

### DIFF
--- a/compiler/circle-part-driver/CMakeLists.txt
+++ b/compiler/circle-part-driver/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(SRCS_PART_TESTER
       src/Driver.cpp
+      src/PModelsRunner.cpp
    )
 
 add_executable(circle_part_driver ${SRCS_PART_TESTER})

--- a/compiler/circle-part-driver/src/Driver.cpp
+++ b/compiler/circle-part-driver/src/Driver.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include "PModelsRunner.h"
+
 #include <luci/Log.h>
 #include <cstdlib>
 #include <iostream>
@@ -35,13 +37,21 @@ int entry(int argc, char **argv)
   const char *input_prefix = argv[3];
   const char *output_file = argv[4];
 
+  prunner::PModelsRunner pmrunner;
+
   INFO(l) << "Read config file: " << config_filename << std::endl;
+  if (not pmrunner.load_config(config_filename))
+    return EXIT_FAILURE;
 
   INFO(l) << "Read input file: " << input_prefix << ", #inputs: " << num_inputs << std::endl;
+  pmrunner.load_inputs(input_prefix, num_inputs);
 
   INFO(l) << "Run all partitioned models..." << std::endl;
+  if (!pmrunner.run())
+    return EXIT_FAILURE;
 
   INFO(l) << "Save output file: " << output_file << std::endl;
+  pmrunner.save_outputs(output_file);
 
   return EXIT_SUCCESS;
 }

--- a/compiler/circle-part-driver/src/PModelsRunner.cpp
+++ b/compiler/circle-part-driver/src/PModelsRunner.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "PModelsRunner.h"
+
+namespace prunner
+{
+
+bool PModelsRunner::load_config(const std::string &filename)
+{
+  // TODO add implementation
+  (void)filename;
+  return true;
+}
+
+void PModelsRunner::load_inputs(const std::string &input_prefix, int32_t num_inputs)
+{
+  // TODO add implementation
+  (void)input_prefix;
+  (void)num_inputs;
+}
+
+bool PModelsRunner::run(void)
+{
+  // TODO add implementation
+  return true;
+}
+
+void PModelsRunner::save_outputs(const std::string &output_file)
+{
+  // TODO add implementation
+  (void)output_file;
+}
+
+} // namespace prunner

--- a/compiler/circle-part-driver/src/PModelsRunner.h
+++ b/compiler/circle-part-driver/src/PModelsRunner.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __CIRCLE_PRUNNER_PMODELS_RUNNER_H__
+#define __CIRCLE_PRUNNER_PMODELS_RUNNER_H__
+
+#include <string>
+
+namespace prunner
+{
+
+/**
+ * @brief PModelsRunner runs partitioned models from input data file and stores
+ *        output data to a file
+ */
+class PModelsRunner
+{
+public:
+  PModelsRunner() = default;
+
+public:
+  bool load_config(const std::string &filename);
+  void load_inputs(const std::string &input_prefix, int32_t num_inputs);
+  bool run(void);
+  void save_outputs(const std::string &output_file);
+};
+
+} // namespace prunner
+
+#endif // __CIRCLE_PRUNNER_PMODELS_RUNNER_H__


### PR DESCRIPTION
This will introduce empty PModelsRunner that will run partitioned
models.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>