### PR TITLE
[onert/api] Revise CustomKernel

### DIFF
--- a/runtime/onert/api/src/CustomKernel.cc
+++ b/runtime/onert/api/src/CustomKernel.cc
@@ -18,9 +18,7 @@
 
 namespace onert
 {
-namespace frontend
-{
-namespace custom
+namespace api
 {
 
 using namespace backend::custom;
@@ -64,12 +62,12 @@ public:
   }
 };
 
-Kernel::Kernel(const nnfw_custom_eval evalFunction)
+CustomKernel::CustomKernel(const nnfw_custom_eval evalFunction)
   : _in_params(), _userdata(nullptr), _userdata_size(0), _evalFunction(evalFunction)
 {
 }
 
-void Kernel::configure(CustomKernelConfigParams &&inParams)
+void CustomKernel::configure(CustomKernelConfigParams &&inParams)
 {
   _userdata = inParams.userdata;
   _userdata_size = inParams.userdata_size;
@@ -77,7 +75,7 @@ void Kernel::configure(CustomKernelConfigParams &&inParams)
   _in_params = std::move(inParams);
 }
 
-void Kernel::run()
+void CustomKernel::run()
 {
   nnfw_custom_kernel_params params;
 
@@ -109,6 +107,5 @@ void Kernel::run()
   delete[] params.outputs;
 }
 
-} // namespace custom
-} // namespace frontend
+} // namespace api
 } // namespace onert

--- a/runtime/onert/api/src/CustomKernel.h
+++ b/runtime/onert/api/src/CustomKernel.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef __ONERT_BACKEND_CUSTOM_KERNEL_H__
-#define __ONERT_BACKEND_CUSTOM_KERNEL_H__
+#ifndef __ONERT_API_CUSTOM_KERNEL_H__
+#define __ONERT_API_CUSTOM_KERNEL_H__
 
 #include "nnfw_experimental.h"
 
@@ -26,15 +26,13 @@
 
 namespace onert
 {
-namespace frontend
-{
-namespace custom
+namespace api
 {
 
-class Kernel : public ::onert::exec::IFunction
+class CustomKernel : public ::onert::exec::IFunction
 {
 public:
-  explicit Kernel(nnfw_custom_eval evalFunction);
+  explicit CustomKernel(nnfw_custom_eval evalFunction);
 
   backend::custom::CustomKernelConfigParams _in_params;
 
@@ -53,8 +51,7 @@ public:
   void run() override;
 };
 
-} // namespace custom
-} // namespace frontend
+} // namespace api
 } // namespace onert
 
-#endif // __ONERT_BACKEND_CUSTOM_KERNEL_H__
+#endif // __ONERT_API_CUSTOM_KERNEL_H__

--- a/runtime/onert/api/src/CustomKernelRegistry.h
+++ b/runtime/onert/api/src/CustomKernelRegistry.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef __ONERT_BACKEND_CUSTOM_KERNEL_REGISTRY_H__
-#define __ONERT_BACKEND_CUSTOM_KERNEL_REGISTRY_H__
+#ifndef __ONERT_API_CUSTOM_KERNEL_REGISTRY_H__
+#define __ONERT_API_CUSTOM_KERNEL_REGISTRY_H__
 
 #include "CustomKernel.h"
 
@@ -27,38 +27,22 @@
 
 namespace onert
 {
-namespace frontend
-{
-namespace custom
+namespace api
 {
 
-class KernelRegistry
+class CustomKernelRegistry
 {
 public:
   void registerKernel(const std::string &id, nnfw_custom_eval evalFunction);
 
   std::shared_ptr<backend::custom::IKernelBuilder> getBuilder();
-  std::unique_ptr<Kernel> buildKernelForOp(const std::string &id);
+  std::unique_ptr<CustomKernel> buildKernelForOp(const std::string &id);
 
 private:
   std::unordered_map<std::string, nnfw_custom_eval> _storage;
 };
 
-class KernelBuilder : public backend::custom::IKernelBuilder
-{
-public:
-  KernelBuilder(KernelRegistry *registry);
-
-  std::unique_ptr<exec::IFunction>
-  buildKernel(const std::string &id,
-              backend::custom::CustomKernelConfigParams &&params) const override;
-
-private:
-  KernelRegistry *_registry;
-};
-
-} // namespace custom
-} // namespace frontend
+} // namespace api
 } // namespace onert
 
-#endif // __ONERT_BACKEND_CUSTOM_KERNEL_REGISTRY_H__
+#endif // __ONERT_API_CUSTOM_KERNEL_REGISTRY_H__

--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -159,8 +159,7 @@ void setConfigKeyValues(const CfgKeyValues &keyValues)
 
 nnfw_session::nnfw_session()
   : _subgraphs{nullptr}, _execution{nullptr},
-    _kernel_registry{std::make_shared<onert::frontend::custom::KernelRegistry>()}, _tracing_ctx{
-                                                                                     nullptr}
+    _kernel_registry{std::make_shared<onert::api::CustomKernelRegistry>()}, _tracing_ctx{nullptr}
 {
   // DO NOTHING
 }

--- a/runtime/onert/api/src/nnfw_api_internal.h
+++ b/runtime/onert/api/src/nnfw_api_internal.h
@@ -28,13 +28,10 @@
 
 namespace onert
 {
-namespace frontend
+namespace api
 {
-namespace custom
-{
-class KernelRegistry;
-}
-} // namespace frontend
+class CustomKernelRegistry;
+} // namespace api
 namespace exec
 {
 class Execution;
@@ -157,7 +154,7 @@ private:
   std::shared_ptr<onert::ir::Subgraphs> _subgraphs;
   std::unique_ptr<onert::compiler::Compiler> _compiler;
   std::unique_ptr<onert::exec::Execution> _execution;
-  std::shared_ptr<onert::frontend::custom::KernelRegistry> _kernel_registry;
+  std::shared_ptr<onert::api::CustomKernelRegistry> _kernel_registry;
 
   std::unique_ptr<onert::util::TracingCtx> _tracing_ctx;
 };


### PR DESCRIPTION
This commit revises CustomKernel and CustomKernelRegistry.
- Change namespace: onert::frontend::custom -> onert::api
- Change class name: Kernel -> CustomKernel, KernelRegistry -> CustomKernelRegistry
- Update header guard
- Move KernelBuilder internally

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>