### PR TITLE
[crew] Rename test for negative case

### DIFF
--- a/compiler/crew/src/PConfigIni.test.cpp
+++ b/compiler/crew/src/PConfigIni.test.cpp
@@ -48,7 +48,7 @@ TEST(ConfigIniTest, read_ini_simple)
   EXPECT_TRUE("world" == it->second);
 }
 
-TEST(ConfigIniTest, read_ini_simple_N)
+TEST(ConfigIniTest, read_ini_simple_NEG)
 {
   std::stringstream ss;
 


### PR DESCRIPTION
This will rename to fix negative test case suffix.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>