### PR TITLE
[circle-part-driver] Fix README

### DIFF
--- a/compiler/circle-part-driver/README.md
+++ b/compiler/circle-part-driver/README.md
@@ -1,3 +1,3 @@
-# luci-part-driver
+# circle-part-driver
 
-_luci-part-driver_ is test driver to run partitioned circle models
+_circle-part-driver_ is test driver to run partitioned circle models


### PR DESCRIPTION
This will fix README with module name.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>