### PR TITLE
[circle-part-eval] Introduce initial empty module

### DIFF
--- a/compiler/circle-part-eval/CMakeLists.txt
+++ b/compiler/circle-part-eval/CMakeLists.txt
@@ -1,0 +1,8 @@
+#
+# this project validates partitioned models produced by circle-partitioner
+# with circle-part-driver and two scripts; part_eval_all.sh and part_eval_one.py
+#
+
+if(NOT ENABLE_TEST)
+  return()
+endif(NOT ENABLE_TEST)

--- a/compiler/circle-part-eval/README.md
+++ b/compiler/circle-part-eval/README.md
@@ -1,0 +1,15 @@
+# circle-part-eval
+
+_circle-part-eval_ evaluates partitioned models produced by circle-partitioner.
+
+### Process of evaluation
+
+Evaluation process is like how _luci-value-test_ does.
+
+1) generates random input and stores to reference input file(s)
+2) executes tflite file from common-artifacts for reference output
+3) partions circle file with .part file and produces into output folder
+4) executes produced partitioned circle models with reference input file(s)
+5) saves output(s) of circle models to file(s)
+6) compares reference output with saved output file(s)
+7) fail test if values differ

--- a/compiler/circle-part-eval/README.md
+++ b/compiler/circle-part-eval/README.md
@@ -8,7 +8,7 @@ Evaluation process is like how _luci-value-test_ does.
 
 1) generates random input and stores to reference input file(s)
 2) executes tflite file from common-artifacts for reference output
-3) partions circle file with .part file and produces into output folder
+3) partitions circle file with .part file and produces into output folder
 4) executes produced partitioned circle models with reference input file(s)
 5) saves output(s) of circle models to file(s)
 6) compares reference output with saved output file(s)


### PR DESCRIPTION
This will introduce initial emtpy circle-part-eval module.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>