### PR TITLE
[luci] Add missing checks for granularity

### DIFF
--- a/compiler/luci/pass/src/VerifyQuantizedNodeChannelWiseGranularity.h
+++ b/compiler/luci/pass/src/VerifyQuantizedNodeChannelWiseGranularity.h
@@ -47,6 +47,9 @@ private:
   {
     auto circle_node = loco::must_cast<const luci::CircleNode *>(node);
 
+    if (circle_node->quantparam() == nullptr)
+      return false;
+
     if (circle_node->quantparam()->scale.size() != 1)
       return false;
 
@@ -68,6 +71,12 @@ private:
 
     assert(channel_dim < circle_node->rank()); // FIX_CALLER_UNLESS
     auto channel_size = circle_node->dim(channel_dim).value();
+
+    if (circle_node->quantparam() == nullptr)
+      return false;
+
+    if (circle_node->quantparam()->quantized_dimension != static_cast<int32_t>(channel_dim))
+      return false;
 
     if (circle_node->quantparam()->scale.size() != channel_size)
       return false;

--- a/compiler/luci/pass/src/VerifyQuantizedNodeLayerWiseGranularity.h
+++ b/compiler/luci/pass/src/VerifyQuantizedNodeLayerWiseGranularity.h
@@ -47,6 +47,9 @@ private:
   {
     auto circle_node = loco::must_cast<const luci::CircleNode *>(node);
 
+    if (circle_node->quantparam() == nullptr)
+      return false;
+
     if (circle_node->quantparam()->scale.size() != 1)
       return false;
 
@@ -59,6 +62,9 @@ private:
   bool is_lwq_const(const loco::Node *node)
   {
     auto circle_node = loco::must_cast<const luci::CircleConst *>(node);
+
+    if (circle_node->quantparam() == nullptr)
+      return false;
 
     if (circle_node->quantparam()->scale.size() != 1)
       return false;


### PR DESCRIPTION
This adds missing checks for granularity.
- non-quantized case
- quantized_dimension

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: #6367