### PR TITLE
[res] Introduce Part_Add recipes for multiple I/O

### DIFF
--- a/res/TensorFlowLiteRecipes/Part_Add_Sqrt_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/Part_Add_Sqrt_000/test.recipe
@@ -1,0 +1,48 @@
+operand {
+  name: "ifm1"
+  type: FLOAT32
+  shape { dim: 1 dim: 3 dim: 3 dim: 2 }
+}
+operand {
+  name: "ifm2"
+  type: FLOAT32
+  shape { dim: 1 dim: 3 dim: 3 dim: 2 }
+}
+operand {
+  name: "add"
+  type: FLOAT32
+  shape { dim: 1 dim: 3 dim: 3 dim: 2 }
+}
+operand {
+  name: "ofm1"
+  type: FLOAT32
+  shape { dim: 1 dim: 3 dim: 3 dim: 2 }
+}
+operand {
+  name: "ofm2"
+  type: FLOAT32
+  shape { dim: 1 dim: 3 dim: 3 dim: 2 }
+}
+operation {
+  type: "Add"
+  add_options {
+    activation: NONE
+  }
+  input: "ifm1"
+  input: "ifm2"
+  output: "add"
+}
+operation {
+  type: "Sqrt"
+  input: "add"
+  output: "ofm1"
+}
+operation {
+  type: "Sqrt"
+  input: "add"
+  output: "ofm2"
+}
+input: "ifm1"
+input: "ifm2"
+output: "ofm1"
+output: "ofm2"

--- a/res/TensorFlowLiteRecipes/Part_Add_Sqrt_Rsqrt_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/Part_Add_Sqrt_Rsqrt_000/test.recipe
@@ -1,0 +1,68 @@
+operand {
+  name: "ifm1"
+  type: FLOAT32
+  shape { dim: 1 dim: 3 dim: 3 dim: 2 }
+}
+operand {
+  name: "ifm2"
+  type: FLOAT32
+  shape { dim: 1 dim: 3 dim: 3 dim: 2 }
+}
+operand {
+  name: "add"
+  type: FLOAT32
+  shape { dim: 1 dim: 3 dim: 3 dim: 2 }
+}
+operand {
+  name: "sqrt1"
+  type: FLOAT32
+  shape { dim: 1 dim: 3 dim: 3 dim: 2 }
+}
+operand {
+  name: "sqrt2"
+  type: FLOAT32
+  shape { dim: 1 dim: 3 dim: 3 dim: 2 }
+}
+operand {
+  name: "ofm1"
+  type: FLOAT32
+  shape { dim: 1 dim: 3 dim: 3 dim: 2 }
+}
+operand {
+  name: "ofm2"
+  type: FLOAT32
+  shape { dim: 1 dim: 3 dim: 3 dim: 2 }
+}
+operation {
+  type: "Add"
+  add_options {
+    activation: NONE
+  }
+  input: "ifm1"
+  input: "ifm2"
+  output: "add"
+}
+operation {
+  type: "Sqrt"
+  input: "add"
+  output: "sqrt1"
+}
+operation {
+  type: "Sqrt"
+  input: "add"
+  output: "sqrt2"
+}
+operation {
+  type: "Rsqrt"
+  input: "sqrt1"
+  output: "ofm1"
+}
+operation {
+  type: "Rsqrt"
+  input: "sqrt2"
+  output: "ofm2"
+}
+input: "ifm1"
+input: "ifm2"
+output: "ofm1"
+output: "ofm2"


### PR DESCRIPTION
This will introduce Part_Add_Sqrt_000 and Part_Add_Sqrt_Rsqrt_000
recipes to check multiple inputs and outputs partitioning.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>