### PR TITLE
[circle-part-eval] Introduce Add_ part files

### DIFF
--- a/compiler/circle-part-eval/parts/Part_Add_Sqrt_000.part
+++ b/compiler/circle-part-eval/parts/Part_Add_Sqrt_000.part
@@ -1,0 +1,7 @@
+[partition]
+backends=cpu,acl_cl
+default=cpu
+comply=opcode
+
+[OPCODE]
+SQRT=acl_cl

--- a/compiler/circle-part-eval/parts/Part_Add_Sqrt_Rsqrt_000.part
+++ b/compiler/circle-part-eval/parts/Part_Add_Sqrt_Rsqrt_000.part
@@ -1,0 +1,7 @@
+[partition]
+backends=cpu,acl_cl
+default=cpu
+comply=opcode
+
+[OPCODE]
+RSQRT=acl_cl

--- a/compiler/circle-part-eval/parts/Part_Add_Sub_000.part
+++ b/compiler/circle-part-eval/parts/Part_Add_Sub_000.part
@@ -1,0 +1,7 @@
+[partition]
+backends=cpu,acl_cl
+default=cpu
+comply=opcode
+
+[OPCODE]
+SUB=acl_cl


### PR DESCRIPTION
This will introduce Add_Sqrt and Add_Sub partition files to test
multiple inputs or outputs of partitioning.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>