### PR TITLE
[circle-part-eval] Introduce Net_InstanceNorm part files

### DIFF
--- a/compiler/circle-part-eval/parts/Net_InstanceNorm_003.001.part
+++ b/compiler/circle-part-eval/parts/Net_InstanceNorm_003.001.part
@@ -1,0 +1,7 @@
+[partition]
+backends=cpu,acl_cl
+default=cpu
+comply=opcode
+
+[OPCODE]
+ADD=acl_cl

--- a/compiler/circle-part-eval/parts/Net_InstanceNorm_003.002.part
+++ b/compiler/circle-part-eval/parts/Net_InstanceNorm_003.002.part
@@ -1,0 +1,8 @@
+[partition]
+backends=cpu,acl_cl
+default=cpu
+comply=opcode
+
+[OPCODE]
+SUB=acl_cl
+DIV=acl_cl

--- a/compiler/circle-part-eval/parts/Net_InstanceNorm_003.part
+++ b/compiler/circle-part-eval/parts/Net_InstanceNorm_003.part
@@ -1,0 +1,7 @@
+[partition]
+backends=cpu,acl_cl
+default=cpu
+comply=opcode
+
+[OPCODE]
+DIV=acl_cl


### PR DESCRIPTION
This will introduce Net_InstanceNorm partition files to test with a bit
complicated network of partitioning.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>