### PR TITLE
[one-cmds] missing codes that return exit code

### DIFF
--- a/compiler/one-cmds/one-codegen
+++ b/compiler/one-cmds/one-codegen
@@ -121,6 +121,8 @@ def main():
             bufsize=1) as p:
         for line in p.stdout:
             sys.stdout.buffer.write(line)
+    if p.returncode != 0:
+        sys.exit(p.returncode)
 
 
 if __name__ == '__main__':

--- a/compiler/one-cmds/one-import-tflite
+++ b/compiler/one-cmds/one-import-tflite
@@ -90,6 +90,8 @@ def _convert(args):
             for line in p.stdout:
                 sys.stdout.buffer.write(line)
                 f.write(line)
+        if p.returncode != 0:
+            sys.exit(p.returncode)
 
 
 def main():


### PR DESCRIPTION
This commit adds missing codes that enable them to return exit code.

Related: #6310 
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>