### PR TITLE
[luci] Support quantization of constant logistic

### DIFF
--- a/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
+++ b/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
@@ -933,6 +933,7 @@ void quantize_const_inputs(luci::CircleNode *node, loco::DataType output_type)
     case luci::CircleOpcode::GREATER_EQUAL:
     case luci::CircleOpcode::LESS:
     case luci::CircleOpcode::LESS_EQUAL:
+    case luci::CircleOpcode::LOGISTIC:
     case luci::CircleOpcode::MAXIMUM:
     case luci::CircleOpcode::MINIMUM:
     case luci::CircleOpcode::MUL:


### PR DESCRIPTION
This supports quantization of logistic with constant input.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: #6367