### PR TITLE
[luci] Move header include in CirlceNodeConnect

### DIFF
--- a/compiler/luci/partition/src/CircleNodeConnect.cpp
+++ b/compiler/luci/partition/src/CircleNodeConnect.cpp
@@ -16,6 +16,8 @@
 
 #include "CircleNodeConnect.h"
 
+#include <luci/IR/CircleNodeVisitor.h>
+
 #include <oops/UserExn.h>
 
 namespace

--- a/compiler/luci/partition/src/CircleNodeConnect.h
+++ b/compiler/luci/partition/src/CircleNodeConnect.h
@@ -20,7 +20,6 @@
 #define __LUCI_CIRCLE_NODE_CONNECT__
 
 #include <luci/IR/CircleNodes.h>
-#include <luci/IR/CircleNodeVisitor.h>
 
 #include <loco/IR/Graph.h>
 


### PR DESCRIPTION
This will move CircleNodeVisitor header include to source file.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>