### PR TITLE
[circle-partitioner] Fix validate with partitioned modules

### DIFF
--- a/compiler/circle-partitioner/src/CirclePartitioner.cpp
+++ b/compiler/circle-partitioner/src/CirclePartitioner.cpp
@@ -219,11 +219,13 @@ int entry(int argc, char **argv)
 
   // apply partition to module
   auto pms = luci::apply(module.get(), partition);
+
+  // validate partitioned modules
   for (auto &pmodule : pms.pmodules)
   {
-    for (size_t g = 0; g < module->size(); ++g)
+    for (size_t g = 0; g < pmodule.module->size(); ++g)
     {
-      auto graph = module->graph(g);
+      auto graph = pmodule.module->graph(g);
       if (graph == nullptr)
       {
         std::cerr << "ERROR: Failed to create partition model" << std::endl;


### PR DESCRIPTION
This will fix partitioned modules to validate with results of apply.
- and also add comment for readability.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>