### PR TITLE
[circle-part-driver] Fix requries.cmake

### DIFF
--- a/compiler/circle-part-driver/requires.cmake
+++ b/compiler/circle-part-driver/requires.cmake
@@ -1,3 +1,5 @@
+require("foder")
+require("loco")
 require("luci")
 require("crew")
 require("safemain")


### PR DESCRIPTION
This will fix requries.cmake to include libs used.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>