### PR TITLE
[circle-partitioner] Tidy requires.cmake

### DIFF
--- a/compiler/circle-partitioner/requires.cmake
+++ b/compiler/circle-partitioner/requires.cmake
@@ -1,7 +1,6 @@
 require("foder")
 require("crew")
 require("safemain")
-require("mio-circle")
 require("luci")
 require("arser")
 require("vconone")


### PR DESCRIPTION
This will removed unused module of circle-partitioner.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>