### PR TITLE
[circle-part-driver] Link with nncc_common

### DIFF
--- a/compiler/circle-part-driver/CMakeLists.txt
+++ b/compiler/circle-part-driver/CMakeLists.txt
@@ -12,5 +12,6 @@ target_link_libraries(circle_part_driver luci_log)
 target_link_libraries(circle_part_driver luci_interpreter)
 target_link_libraries(circle_part_driver crew)
 target_link_libraries(circle_part_driver safemain)
+target_link_libraries(circle_part_driver nncc_common)
 
 install(TARGETS circle_part_driver DESTINATION bin)


### PR DESCRIPTION
This will enable circle-part-driver to link with nncc_common.

Signed-off-by: SaeHie Park <saehie.park@gmail.com>