### PR TITLE
[circle-part-eval] Introduce requires.cmake

### DIFF
--- a/compiler/circle-part-eval/requires.cmake
+++ b/compiler/circle-part-eval/requires.cmake
@@ -1,0 +1,3 @@
+require("common-artifacts")
+require("circle-partitioner")
+require("circle-part-driver")


### PR DESCRIPTION
This will introduce requires.cmake for circle-part-eval.

Signed-off-by: SaeHie Park <saehie.park@gmail.com>