### PR TITLE
[infra] Add crew to utcount

### DIFF
--- a/infra/nncc/command/utcount
+++ b/infra/nncc/command/utcount
@@ -13,7 +13,7 @@ BUILD_ITEMS="angkor cwrap pepper-str pepper-strcast pp \
 oops pepper-assert \
 hermes hermes-std \
 loco locop locomotiv logo-core logo \
-foder souschef arser vconone \
+foder souschef arser vconone crew \
 safemain mio-circle mio-tflite \
 tflite2circle \
 luci \


### PR DESCRIPTION
This will add crew module to utcount to count unit tests.

Signed-off-by: SaeHie Park <saehie.park@gmail.com>