### PR TITLE
[record-minmax] Do not record min/max of bool type

### DIFF
--- a/compiler/record-minmax/src/MinMaxObserver.cpp
+++ b/compiler/record-minmax/src/MinMaxObserver.cpp
@@ -51,6 +51,20 @@ void MinMaxObserver::postTensorWrite(const luci::CircleNode *node,
     return;
   }
 
+  if (node->opcode() == luci::CircleOpcode::GREATER ||
+      node->opcode() == luci::CircleOpcode::GREATER_EQUAL ||
+      node->opcode() == luci::CircleOpcode::LESS ||
+      node->opcode() == luci::CircleOpcode::LESS_EQUAL ||
+      node->opcode() == luci::CircleOpcode::LOGICAL_AND ||
+      node->opcode() == luci::CircleOpcode::LOGICAL_NOT ||
+      node->opcode() == luci::CircleOpcode::LOGICAL_OR ||
+      node->opcode() == luci::CircleOpcode::EQUAL ||
+      node->opcode() == luci::CircleOpcode::NOT_EQUAL)
+  {
+    // Output of these operators is bool type, which is not quantized
+    return;
+  }
+
   // Only support recording of float32 values
   if (tensor->element_type() != DataType::FLOAT32)
     throw std::runtime_error("Tensor's data type is not float");


### PR DESCRIPTION
This makes record-minmax not record min/max of bool type.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/6367