### PR TITLE
[circle-partitioner] Link with nncc_common

### DIFF
--- a/compiler/circle-partitioner/CMakeLists.txt
+++ b/compiler/circle-partitioner/CMakeLists.txt
@@ -12,5 +12,6 @@ target_link_libraries(circle_partitioner luci_export)
 target_link_libraries(circle_partitioner luci_partition)
 target_link_libraries(circle_partitioner arser)
 target_link_libraries(circle_partitioner vconone)
+target_link_libraries(circle_partitioner nncc_common)
 
 install(TARGETS circle_partitioner DESTINATION bin)


### PR DESCRIPTION
This will link with circle-partitioner for strict build.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>