### PR TITLE
[circle-partitioner] Validate empty name

### DIFF
--- a/compiler/circle-partitioner/src/CirclePartitioner.cpp
+++ b/compiler/circle-partitioner/src/CirclePartitioner.cpp
@@ -119,6 +119,11 @@ bool validate_module(luci::Module *module)
       std::cerr << "ERROR: Invalid circle model" << std::endl;
       return false;
     }
+    if (!luci::validate_name(graph))
+    {
+      std::cerr << "ERROR: circle model has empty name" << std::endl;
+      return false;
+    }
   }
 
   if (!luci::validate_unique_name(module))


### PR DESCRIPTION
This will call validate_name method to check empty name for all nodes.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>