### PR TITLE
[luci] Null check for clone_node

### DIFF
--- a/compiler/luci/service/src/CircleNodeClone.cpp
+++ b/compiler/luci/service/src/CircleNodeClone.cpp
@@ -79,10 +79,13 @@ void copy_common_attributes(const luci::CircleNode *src, luci::CircleNode *dst)
  */
 luci::CircleNode *clone_node(const luci::CircleNode *node, loco::Graph *graph)
 {
+  if (node == nullptr || graph == nullptr)
+    return nullptr;
+
   CloneNode cn(graph);
   auto cloned = node->accept(&cn);
-  assert(cloned);
-  copy_common_attributes(node, cloned);
+  if (cloned != nullptr)
+    copy_common_attributes(node, cloned);
   return cloned;
 }
 

--- a/compiler/luci/service/src/CircleNodeClone.test.cpp
+++ b/compiler/luci/service/src/CircleNodeClone.test.cpp
@@ -94,3 +94,15 @@ TEST(CircleNodeCloneTest, clone_add_node)
   ASSERT_EQ(node->rank(), clone->rank());
   ASSERT_EQ(node->shape_status(), clone->shape_status());
 }
+
+TEST(CircleNodeCloneTest, clone_node_NEG)
+{
+  auto g = loco::make_graph();
+  auto node = build_simple_add_graph(g.get());
+
+  auto cg = loco::make_graph();
+  auto clone = luci::clone_node(nullptr, cg.get());
+  ASSERT_EQ(nullptr, clone);
+  auto clone2 = luci::clone_node(node, nullptr);
+  ASSERT_EQ(nullptr, clone2);
+}


### PR DESCRIPTION
This will add nullptr check for clone_node method.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>