### PR TITLE
[luci] Check nullptr for Sub clone

### DIFF
--- a/compiler/luci/service/src/Nodes/CircleSub.cpp
+++ b/compiler/luci/service/src/Nodes/CircleSub.cpp
@@ -25,7 +25,8 @@ luci::CircleNode *CloneNode::visit(const luci::CircleSub *node)
     return nullptr;
 
   auto *cloned = _graph->nodes()->create<luci::CircleSub>();
-  cloned->fusedActivationFunction(node->fusedActivationFunction());
+  if (cloned != nullptr)
+    cloned->fusedActivationFunction(node->fusedActivationFunction());
   return cloned;
 }
 


### PR DESCRIPTION
This will add nullptr check for clone node creation of Sub Op.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>