### PR TITLE
[luci] Support quantization of LogicalOr

### DIFF
--- a/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
+++ b/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
@@ -904,6 +904,10 @@ void quantize_const_inputs(luci::CircleNode *node, loco::DataType output_type)
       // Handled in propagate_concat_quantparam
       break;
 
+    case luci::CircleOpcode::LOGICAL_OR:
+      // Inputs of logical Ops are bool, thus not quantized
+      break;
+
     case luci::CircleOpcode::ARG_MAX:
     case luci::CircleOpcode::ARG_MIN:
     case luci::CircleOpcode::MEAN:

--- a/compiler/luci/pass/src/VerifyQuantizedNodeChannelWiseGranularity.h
+++ b/compiler/luci/pass/src/VerifyQuantizedNodeChannelWiseGranularity.h
@@ -159,6 +159,13 @@ private:
     return true;
   }
 
+  bool visit(const luci::CircleLogicalOr *)
+  {
+    // Logical OR has bool-type inputs and output
+    // Nothing to be checked
+    return true;
+  }
+
   bool visit(const luci::CircleMaxPool2D *node)
   {
     RETURN_FALSE_UNLESS(is_lwq(node));

--- a/compiler/luci/pass/src/VerifyQuantizedNodeLayerWiseGranularity.h
+++ b/compiler/luci/pass/src/VerifyQuantizedNodeLayerWiseGranularity.h
@@ -146,6 +146,13 @@ private:
     return true;
   }
 
+  bool visit(const luci::CircleLogicalOr *)
+  {
+    // Logical OR has bool-type inputs and output
+    // Nothing to be checked
+    return true;
+  }
+
   bool visit(const luci::CircleMaxPool2D *node)
   {
     RETURN_FALSE_UNLESS(is_lwq(node))

--- a/compiler/luci/pass/src/VerifyQuantizedNodeS16Type.h
+++ b/compiler/luci/pass/src/VerifyQuantizedNodeS16Type.h
@@ -119,6 +119,14 @@ private:
     return true;
   }
 
+  bool visit(const luci::CircleLogicalOr *node)
+  {
+    RETURN_FALSE_UNLESS(has_type(node, Type::BOOL))
+    RETURN_FALSE_UNLESS(has_type(node->x(), Type::BOOL))
+    RETURN_FALSE_UNLESS(has_type(node->y(), Type::BOOL))
+    return true;
+  }
+
   bool visit(const luci::CircleMaxPool2D *node)
   {
     RETURN_FALSE_UNLESS(has_type(node, Type::S16))

--- a/compiler/luci/pass/src/VerifyQuantizedNodeU8Type.h
+++ b/compiler/luci/pass/src/VerifyQuantizedNodeU8Type.h
@@ -119,6 +119,14 @@ private:
     return true;
   }
 
+  bool visit(const luci::CircleLogicalOr *node)
+  {
+    RETURN_FALSE_UNLESS(has_type(node, Type::BOOL))
+    RETURN_FALSE_UNLESS(has_type(node->x(), Type::BOOL))
+    RETURN_FALSE_UNLESS(has_type(node->y(), Type::BOOL))
+    return true;
+  }
+
   bool visit(const luci::CircleMaxPool2D *node)
   {
     RETURN_FALSE_UNLESS(has_type(node, Type::U8))


### PR DESCRIPTION
This supports quantization of LogicalOr op.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/6367