### PR TITLE
[common-artifacts] Add path options to TestDataGenerator

### DIFF
--- a/compiler/common-artifacts/CMakeLists.txt
+++ b/compiler/common-artifacts/CMakeLists.txt
@@ -233,20 +233,7 @@ foreach(RECIPE IN ITEMS ${RECIPES})
   )
   list(APPEND TEST_DEPS ${NNPKG_PATH})
 
-  set(INPUT_HDF5_FILE "${RECIPE}${OPT_FORMAT}.input.h5")
-  set(INPUT_BIN_PATH "${CMAKE_CURRENT_BINARY_DIR}/${INPUT_HDF5_FILE}")
-
-  set(EXPECTED_HDF5_FILE "${RECIPE}${OPT_FORMAT}.expected.h5")
-  set(EXPECTED_BIN_PATH "${CMAKE_CURRENT_BINARY_DIR}/${EXPECTED_HDF5_FILE}")
-
   if(NOT DEFINED NO_TCGEN_${RECIPE})
-    # Generate input.h5, expected.h5
-    add_custom_command(OUTPUT ${INPUT_BIN_PATH} ${EXPECTED_BIN_PATH}
-      COMMAND $<TARGET_FILE:testDataGenerator> ${MODEL_FILE}
-      DEPENDS $<TARGET_FILE:testDataGenerator> ${MODEL_FILE}
-      COMMENT "Generate ${INPUT_BIN_PATH} and ${EXPECTED_BIN_PATH}"
-    )
-
     # Generate test directory
     set(TC_DIRECTORY "${NNPKG_PATH}/metadata/tc")
     add_custom_command(OUTPUT ${TC_DIRECTORY}
@@ -254,24 +241,17 @@ foreach(RECIPE IN ITEMS ${RECIPES})
       DEPENDS ${NNPKG_PATH}
       COMMENT "Generate ${RECIPE} nnpackage test directory"
     )
+    list(APPEND TEST_DEPS ${TC_DIRECTORY})
 
-    # Move input hdf5 file to test directory
-    set(INPUT_NNPKG_PATH "${TC_DIRECTORY}/input.h5")
-    add_custom_command(OUTPUT ${INPUT_NNPKG_PATH}
-      COMMAND ${CMAKE_COMMAND} -E rename ${INPUT_BIN_PATH} ${INPUT_NNPKG_PATH}
-      DEPENDS ${INPUT_BIN_PATH} ${TC_DIRECTORY}
-      COMMENT "Move ${INPUT_HDF5_FILE} to nnpackage"
+    # Generate input.h5, expected.h5
+    set(INPUT_HDF5_FILE "${TC_DIRECTORY}/input.h5")
+    set(EXPECTED_HDF5_FILE "${TC_DIRECTORY}/expected.h5")
+    add_custom_command(OUTPUT ${INPUT_HDF5_FILE} ${EXPECTED_HDF5_FILE}
+      COMMAND $<TARGET_FILE:testDataGenerator> --input_data ${INPUT_HDF5_FILE} --expected_data ${EXPECTED_HDF5_FILE} ${MODEL_FILE}
+      DEPENDS $<TARGET_FILE:testDataGenerator> ${MODEL_FILE} ${TC_DIRECTORY}
+      COMMENT "Generate ${INPUT_HDF5_FILE} and ${EXPECTED_HDF5_FILE}"
     )
-
-    # Move expected hdf5 file to test directory
-    set(EXPECTED_NNPKG_PATH "${TC_DIRECTORY}/expected.h5")
-    add_custom_command(OUTPUT ${EXPECTED_NNPKG_PATH}
-      COMMAND ${CMAKE_COMMAND} -E rename ${EXPECTED_BIN_PATH} ${EXPECTED_NNPKG_PATH}
-      DEPENDS ${EXPECTED_BIN_PATH} ${TC_DIRECTORY}
-      COMMENT "Move ${EXPECTED_HDF5_FILE} to nnpackage"
-    )
-    list(APPEND TEST_DEPS ${TC_DIRECTORY} ${INPUT_BIN_PATH} ${EXPECTED_BIN_PATH}
-                          ${INPUT_NNPKG_PATH} ${EXPECTED_NNPKG_PATH})
+    list(APPEND TEST_DEPS ${INPUT_HDF5_FILE} ${EXPECTED_HDF5_FILE})
   endif()
 endforeach()
 

--- a/compiler/common-artifacts/src/TestDataGenerator.cpp
+++ b/compiler/common-artifacts/src/TestDataGenerator.cpp
@@ -94,6 +94,16 @@ int entry(int argc, char **argv)
 {
   arser::Arser arser;
   arser.add_argument("circle").type(arser::DataType::STR).help("Circle file you want to test");
+  arser.add_argument("--input_data")
+    .required(true)
+    .nargs(1)
+    .type(arser::DataType::STR)
+    .help("Path to generate input data h5 file");
+  arser.add_argument("--expected_data")
+    .required(true)
+    .nargs(1)
+    .type(arser::DataType::STR)
+    .help("Path to generate expected data h5 file");
   arser.add_argument("--fixed_seed")
     .required(false)
     .nargs(0)
@@ -111,8 +121,6 @@ int entry(int argc, char **argv)
   }
 
   std::string circle_file = arser.get<std::string>("circle");
-  size_t last_dot_index = circle_file.find_last_of(".");
-  std::string prefix = circle_file.substr(0, last_dot_index);
 
   // load circle file
   foder::FileLoader file_loader{circle_file};
@@ -144,13 +152,13 @@ int entry(int argc, char **argv)
    *       ㄴDATA ...
    */
   // create random data and dump into hdf5 file
-  H5::H5File input_file{prefix + ".input.h5", H5F_ACC_TRUNC};
+  H5::H5File input_file{arser.get<std::string>("--input_data"), H5F_ACC_TRUNC};
   std::unique_ptr<H5::Group> input_name_group =
     std::make_unique<H5::Group>(input_file.createGroup("name"));
   std::unique_ptr<H5::Group> input_value_group =
     std::make_unique<H5::Group>(input_file.createGroup("value"));
 
-  H5::H5File output_file{prefix + ".expected.h5", H5F_ACC_TRUNC};
+  H5::H5File output_file{arser.get<std::string>("--expected_data"), H5F_ACC_TRUNC};
   std::unique_ptr<H5::Group> output_name_group =
     std::make_unique<H5::Group>(output_file.createGroup("name"));
   std::unique_ptr<H5::Group> output_value_group =


### PR DESCRIPTION
This commit adds path related options to TestDataGenerator.

There's no unnecessary test data generation anymore:)
Related : #6452
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>