### PR TITLE
[luci] Enable clone of CircleEqual and others

### DIFF
--- a/compiler/luci/service/src/CircleCloneNode.h
+++ b/compiler/luci/service/src/CircleCloneNode.h
@@ -50,7 +50,7 @@ public:
   // luci::CircleNode *visit(const luci::CircleDequantize *) final;
   luci::CircleNode *visit(const luci::CircleDiv *) final;
   luci::CircleNode *visit(const luci::CircleElu *) final;
-  // luci::CircleNode *visit(const luci::CircleEqual *) final;
+  luci::CircleNode *visit(const luci::CircleEqual *) final;
   luci::CircleNode *visit(const luci::CircleExp *) final;
   // luci::CircleNode *visit(const luci::CircleExpandDims *) final;
   // luci::CircleNode *visit(const luci::CircleFakeQuant *) final;
@@ -61,14 +61,14 @@ public:
   // luci::CircleNode *visit(const luci::CircleFullyConnected *) final;
   // luci::CircleNode *visit(const luci::CircleGather *) final;
   // luci::CircleNode *visit(const luci::CircleGatherNd *) final;
-  // luci::CircleNode *visit(const luci::CircleGreater *) final;
-  // luci::CircleNode *visit(const luci::CircleGreaterEqual *) final;
+  luci::CircleNode *visit(const luci::CircleGreater *) final;
+  luci::CircleNode *visit(const luci::CircleGreaterEqual *) final;
   // luci::CircleNode *visit(const luci::CircleIf *) final;
   // luci::CircleNode *visit(const luci::CircleL2Normalize *) final;
   // luci::CircleNode *visit(const luci::CircleL2Pool2D *) final;
   // luci::CircleNode *visit(const luci::CircleLeakyRelu *) final;
-  // luci::CircleNode *visit(const luci::CircleLess *) final;
-  // luci::CircleNode *visit(const luci::CircleLessEqual *) final;
+  luci::CircleNode *visit(const luci::CircleLess *) final;
+  luci::CircleNode *visit(const luci::CircleLessEqual *) final;
   // luci::CircleNode *visit(const luci::CircleLocalResponseNormalization *) final;
   luci::CircleNode *visit(const luci::CircleLog *) final;
   // luci::CircleNode *visit(const luci::CircleLogicalAnd *) final;
@@ -87,7 +87,7 @@ public:
   luci::CircleNode *visit(const luci::CircleNeg *) final;
   // luci::CircleNode *visit(const luci::CircleNonMaxSuppressionV4 *) final;
   // luci::CircleNode *visit(const luci::CircleNonMaxSuppressionV5 *) final;
-  // luci::CircleNode *visit(const luci::CircleNotEqual *) final;
+  luci::CircleNode *visit(const luci::CircleNotEqual *) final;
   // luci::CircleNode *visit(const luci::CircleOneHot *) final;
   // luci::CircleNode *visit(const luci::CirclePack *) final;
   // luci::CircleNode *visit(const luci::CirclePad *) final;

--- a/compiler/luci/service/src/Nodes/CircleEqual.cpp
+++ b/compiler/luci/service/src/Nodes/CircleEqual.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "CircleCloneNode.h"
+
+namespace luci
+{
+
+luci::CircleNode *CloneNode::visit(const luci::CircleEqual *)
+{
+  return _graph->nodes()->create<luci::CircleEqual>();
+}
+
+} // namespace luci

--- a/compiler/luci/service/src/Nodes/CircleEqual.test.cpp
+++ b/compiler/luci/service/src/Nodes/CircleEqual.test.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Service/CircleNodeClone.h"
+
+#include <gtest/gtest.h>
+
+TEST(CloneNodeTest, clone_Equal)
+{
+  auto g = loco::make_graph();
+  auto node_eq = g->nodes()->create<luci::CircleEqual>();
+
+  auto gc = loco::make_graph();
+  auto cloned = luci::clone_node(node_eq, gc.get());
+  ASSERT_NE(nullptr, cloned);
+  ASSERT_EQ(gc.get(), cloned->graph());
+
+  auto cloned_eq = dynamic_cast<luci::CircleEqual *>(cloned);
+  ASSERT_NE(nullptr, cloned_eq);
+}

--- a/compiler/luci/service/src/Nodes/CircleGreater.cpp
+++ b/compiler/luci/service/src/Nodes/CircleGreater.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "CircleCloneNode.h"
+
+namespace luci
+{
+
+luci::CircleNode *CloneNode::visit(const luci::CircleGreater *)
+{
+  return _graph->nodes()->create<luci::CircleGreater>();
+}
+
+} // namespace luci

--- a/compiler/luci/service/src/Nodes/CircleGreater.test.cpp
+++ b/compiler/luci/service/src/Nodes/CircleGreater.test.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Service/CircleNodeClone.h"
+
+#include <gtest/gtest.h>
+
+TEST(CloneNodeTest, clone_Greater)
+{
+  auto g = loco::make_graph();
+  auto node_gt = g->nodes()->create<luci::CircleGreater>();
+
+  auto gc = loco::make_graph();
+  auto cloned = luci::clone_node(node_gt, gc.get());
+  ASSERT_NE(nullptr, cloned);
+  ASSERT_EQ(gc.get(), cloned->graph());
+
+  auto cloned_gt = dynamic_cast<luci::CircleGreater *>(cloned);
+  ASSERT_NE(nullptr, cloned_gt);
+}

--- a/compiler/luci/service/src/Nodes/CircleGreaterEqual.cpp
+++ b/compiler/luci/service/src/Nodes/CircleGreaterEqual.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "CircleCloneNode.h"
+
+namespace luci
+{
+
+luci::CircleNode *CloneNode::visit(const luci::CircleGreaterEqual *)
+{
+  return _graph->nodes()->create<luci::CircleGreaterEqual>();
+}
+
+} // namespace luci

--- a/compiler/luci/service/src/Nodes/CircleGreaterEqual.test.cpp
+++ b/compiler/luci/service/src/Nodes/CircleGreaterEqual.test.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Service/CircleNodeClone.h"
+
+#include <gtest/gtest.h>
+
+TEST(CloneNodeTest, clone_GreaterEqual)
+{
+  auto g = loco::make_graph();
+  auto node_ge = g->nodes()->create<luci::CircleGreaterEqual>();
+
+  auto gc = loco::make_graph();
+  auto cloned = luci::clone_node(node_ge, gc.get());
+  ASSERT_NE(nullptr, cloned);
+  ASSERT_EQ(gc.get(), cloned->graph());
+
+  auto cloned_ge = dynamic_cast<luci::CircleGreaterEqual *>(cloned);
+  ASSERT_NE(nullptr, cloned_ge);
+}

--- a/compiler/luci/service/src/Nodes/CircleLess.cpp
+++ b/compiler/luci/service/src/Nodes/CircleLess.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "CircleCloneNode.h"
+
+namespace luci
+{
+
+luci::CircleNode *CloneNode::visit(const luci::CircleLess *)
+{
+  return _graph->nodes()->create<luci::CircleLess>();
+}
+
+} // namespace luci

--- a/compiler/luci/service/src/Nodes/CircleLess.test.cpp
+++ b/compiler/luci/service/src/Nodes/CircleLess.test.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Service/CircleNodeClone.h"
+
+#include <gtest/gtest.h>
+
+TEST(CloneNodeTest, clone_Less)
+{
+  auto g = loco::make_graph();
+  auto node_less = g->nodes()->create<luci::CircleLess>();
+
+  auto gc = loco::make_graph();
+  auto cloned = luci::clone_node(node_less, gc.get());
+  ASSERT_NE(nullptr, cloned);
+  ASSERT_EQ(gc.get(), cloned->graph());
+
+  auto cloned_less = dynamic_cast<luci::CircleLess *>(cloned);
+  ASSERT_NE(nullptr, cloned_less);
+}

--- a/compiler/luci/service/src/Nodes/CircleLessEqual.cpp
+++ b/compiler/luci/service/src/Nodes/CircleLessEqual.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "CircleCloneNode.h"
+
+namespace luci
+{
+
+luci::CircleNode *CloneNode::visit(const luci::CircleLessEqual *)
+{
+  return _graph->nodes()->create<luci::CircleLessEqual>();
+}
+
+} // namespace luci

--- a/compiler/luci/service/src/Nodes/CircleLessEqual.test.cpp
+++ b/compiler/luci/service/src/Nodes/CircleLessEqual.test.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Service/CircleNodeClone.h"
+
+#include <gtest/gtest.h>
+
+TEST(CloneNodeTest, clone_LessEqual)
+{
+  auto g = loco::make_graph();
+  auto node_le = g->nodes()->create<luci::CircleLessEqual>();
+
+  auto gc = loco::make_graph();
+  auto cloned = luci::clone_node(node_le, gc.get());
+  ASSERT_NE(nullptr, cloned);
+  ASSERT_EQ(gc.get(), cloned->graph());
+
+  auto cloned_le = dynamic_cast<luci::CircleLessEqual *>(cloned);
+  ASSERT_NE(nullptr, cloned_le);
+}

--- a/compiler/luci/service/src/Nodes/CircleNotEqual.cpp
+++ b/compiler/luci/service/src/Nodes/CircleNotEqual.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "CircleCloneNode.h"
+
+namespace luci
+{
+
+luci::CircleNode *CloneNode::visit(const luci::CircleNotEqual *)
+{
+  return _graph->nodes()->create<luci::CircleNotEqual>();
+}
+
+} // namespace luci

--- a/compiler/luci/service/src/Nodes/CircleNotEqual.test.cpp
+++ b/compiler/luci/service/src/Nodes/CircleNotEqual.test.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Service/CircleNodeClone.h"
+
+#include <gtest/gtest.h>
+
+TEST(CloneNodeTest, clone_NotEqual)
+{
+  auto g = loco::make_graph();
+  auto node_ne = g->nodes()->create<luci::CircleNotEqual>();
+
+  auto gc = loco::make_graph();
+  auto cloned = luci::clone_node(node_ne, gc.get());
+  ASSERT_NE(nullptr, cloned);
+  ASSERT_EQ(gc.get(), cloned->graph());
+
+  auto cloned_ne = dynamic_cast<luci::CircleNotEqual *>(cloned);
+  ASSERT_NE(nullptr, cloned_ne);
+}


### PR DESCRIPTION
This will enable clone of CircleEqual, CircleGreater,
CircleGreaterEqual, CircleLess, CircleLessEqual and CircleNotEqual.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>