### PR TITLE
[luci] Enable clone of CircleScatterNd and others

### DIFF
--- a/compiler/luci/service/src/CircleCloneNode.h
+++ b/compiler/luci/service/src/CircleCloneNode.h
@@ -110,10 +110,10 @@ public:
   // luci::CircleNode *visit(const luci::CircleReverseV2 *) final;
   // luci::CircleNode *visit(const luci::CircleRound *) final;
   luci::CircleNode *visit(const luci::CircleRsqrt *) final;
-  // luci::CircleNode *visit(const luci::CircleScatterNd *) final;
-  // luci::CircleNode *visit(const luci::CircleSegmentSum *) final;
-  // luci::CircleNode *visit(const luci::CircleSelect *) final;
-  // luci::CircleNode *visit(const luci::CircleSelectV2 *) final;
+  luci::CircleNode *visit(const luci::CircleScatterNd *) final;
+  luci::CircleNode *visit(const luci::CircleSegmentSum *) final;
+  luci::CircleNode *visit(const luci::CircleSelect *) final;
+  luci::CircleNode *visit(const luci::CircleSelectV2 *) final;
   // luci::CircleNode *visit(const luci::CircleShape *) final;
   luci::CircleNode *visit(const luci::CircleSin *) final;
   // luci::CircleNode *visit(const luci::CircleSlice *) final;

--- a/compiler/luci/service/src/Nodes/CircleScatterNd.cpp
+++ b/compiler/luci/service/src/Nodes/CircleScatterNd.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "CircleCloneNode.h"
+
+namespace luci
+{
+
+luci::CircleNode *CloneNode::visit(const luci::CircleScatterNd *)
+{
+  return _graph->nodes()->create<luci::CircleScatterNd>();
+}
+
+} // namespace luci

--- a/compiler/luci/service/src/Nodes/CircleScatterNd.test.cpp
+++ b/compiler/luci/service/src/Nodes/CircleScatterNd.test.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Service/CircleNodeClone.h"
+
+#include <gtest/gtest.h>
+
+TEST(CloneNodeTest, clone_ScatterNd)
+{
+  auto g = loco::make_graph();
+  auto node_snd = g->nodes()->create<luci::CircleScatterNd>();
+
+  auto gc = loco::make_graph();
+  auto cloned = luci::clone_node(node_snd, gc.get());
+  ASSERT_NE(nullptr, cloned);
+  ASSERT_EQ(gc.get(), cloned->graph());
+
+  auto cloned_snd = dynamic_cast<luci::CircleScatterNd *>(cloned);
+  ASSERT_NE(nullptr, cloned_snd);
+}

--- a/compiler/luci/service/src/Nodes/CircleSegmentSum.cpp
+++ b/compiler/luci/service/src/Nodes/CircleSegmentSum.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "CircleCloneNode.h"
+
+namespace luci
+{
+
+luci::CircleNode *CloneNode::visit(const luci::CircleSegmentSum *)
+{
+  return _graph->nodes()->create<luci::CircleSegmentSum>();
+}
+
+} // namespace luci

--- a/compiler/luci/service/src/Nodes/CircleSegmentSum.test.cpp
+++ b/compiler/luci/service/src/Nodes/CircleSegmentSum.test.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Service/CircleNodeClone.h"
+
+#include <gtest/gtest.h>
+
+TEST(CloneNodeTest, clone_SegmentSum)
+{
+  auto g = loco::make_graph();
+  auto node_ss = g->nodes()->create<luci::CircleSegmentSum>();
+
+  auto gc = loco::make_graph();
+  auto cloned = luci::clone_node(node_ss, gc.get());
+  ASSERT_NE(nullptr, cloned);
+  ASSERT_EQ(gc.get(), cloned->graph());
+
+  auto cloned_ss = dynamic_cast<luci::CircleSegmentSum *>(cloned);
+  ASSERT_NE(nullptr, cloned_ss);
+}

--- a/compiler/luci/service/src/Nodes/CircleSelect.cpp
+++ b/compiler/luci/service/src/Nodes/CircleSelect.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "CircleCloneNode.h"
+
+namespace luci
+{
+
+luci::CircleNode *CloneNode::visit(const luci::CircleSelect *)
+{
+  return _graph->nodes()->create<luci::CircleSelect>();
+}
+
+} // namespace luci

--- a/compiler/luci/service/src/Nodes/CircleSelect.test.cpp
+++ b/compiler/luci/service/src/Nodes/CircleSelect.test.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Service/CircleNodeClone.h"
+
+#include <gtest/gtest.h>
+
+TEST(CloneNodeTest, clone_Select)
+{
+  auto g = loco::make_graph();
+  auto node_sel = g->nodes()->create<luci::CircleSelect>();
+
+  auto gc = loco::make_graph();
+  auto cloned = luci::clone_node(node_sel, gc.get());
+  ASSERT_NE(nullptr, cloned);
+  ASSERT_EQ(gc.get(), cloned->graph());
+
+  auto cloned_sel = dynamic_cast<luci::CircleSelect *>(cloned);
+  ASSERT_NE(nullptr, cloned_sel);
+}

--- a/compiler/luci/service/src/Nodes/CircleSelectV2.cpp
+++ b/compiler/luci/service/src/Nodes/CircleSelectV2.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "CircleCloneNode.h"
+
+namespace luci
+{
+
+luci::CircleNode *CloneNode::visit(const luci::CircleSelectV2 *)
+{
+  return _graph->nodes()->create<luci::CircleSelectV2>();
+}
+
+} // namespace luci

--- a/compiler/luci/service/src/Nodes/CircleSelectV2.test.cpp
+++ b/compiler/luci/service/src/Nodes/CircleSelectV2.test.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Service/CircleNodeClone.h"
+
+#include <gtest/gtest.h>
+
+TEST(CloneNodeTest, clone_SelectV2)
+{
+  auto g = loco::make_graph();
+  auto node_sel = g->nodes()->create<luci::CircleSelectV2>();
+
+  auto gc = loco::make_graph();
+  auto cloned = luci::clone_node(node_sel, gc.get());
+  ASSERT_NE(nullptr, cloned);
+  ASSERT_EQ(gc.get(), cloned->graph());
+
+  auto cloned_sel = dynamic_cast<luci::CircleSelectV2 *>(cloned);
+  ASSERT_NE(nullptr, cloned_sel);
+}


### PR DESCRIPTION
This will enable clone of CircleScatterNd, CircleSegmentSum,
CircleSelect and CircleSelectV2.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>