### PR TITLE
[luci] Enable clone of CircleReshape and others

### DIFF
--- a/compiler/luci/service/src/CircleCloneNode.h
+++ b/compiler/luci/service/src/CircleCloneNode.h
@@ -103,9 +103,9 @@ public:
   luci::CircleNode *visit(const luci::CircleRelu *) final;
   luci::CircleNode *visit(const luci::CircleRelu6 *) final;
   luci::CircleNode *visit(const luci::CircleReluN1To1 *) final;
-  // luci::CircleNode *visit(const luci::CircleReshape *) final;
-  // luci::CircleNode *visit(const luci::CircleResizeBilinear *) final;
-  // luci::CircleNode *visit(const luci::CircleResizeNearestNeighbor *) final;
+  luci::CircleNode *visit(const luci::CircleReshape *) final;
+  luci::CircleNode *visit(const luci::CircleResizeBilinear *) final;
+  luci::CircleNode *visit(const luci::CircleResizeNearestNeighbor *) final;
   // luci::CircleNode *visit(const luci::CircleReverseSequence *) final;
   // luci::CircleNode *visit(const luci::CircleReverseV2 *) final;
   // luci::CircleNode *visit(const luci::CircleRound *) final;
@@ -114,7 +114,7 @@ public:
   luci::CircleNode *visit(const luci::CircleSegmentSum *) final;
   luci::CircleNode *visit(const luci::CircleSelect *) final;
   luci::CircleNode *visit(const luci::CircleSelectV2 *) final;
-  // luci::CircleNode *visit(const luci::CircleShape *) final;
+  luci::CircleNode *visit(const luci::CircleShape *) final;
   luci::CircleNode *visit(const luci::CircleSin *) final;
   // luci::CircleNode *visit(const luci::CircleSlice *) final;
   // luci::CircleNode *visit(const luci::CircleSoftmax *) final;

--- a/compiler/luci/service/src/Nodes/CircleReshape.cpp
+++ b/compiler/luci/service/src/Nodes/CircleReshape.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "CircleCloneNode.h"
+
+namespace luci
+{
+
+luci::CircleNode *CloneNode::visit(const luci::CircleReshape *node)
+{
+  auto *cloned = _graph->nodes()->create<luci::CircleReshape>();
+  if (cloned != nullptr)
+  {
+    uint32_t rank = node->newShape()->rank();
+    cloned->newShape()->rank(rank);
+    for (uint32_t r = 0; r < rank; ++r)
+    {
+      cloned->newShape()->dim(r) = node->newShape()->dim(r);
+    }
+  }
+  return cloned;
+}
+
+} // namespace luci

--- a/compiler/luci/service/src/Nodes/CircleReshape.test.cpp
+++ b/compiler/luci/service/src/Nodes/CircleReshape.test.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Service/CircleNodeClone.h"
+
+#include <gtest/gtest.h>
+
+TEST(CloneNodeTest, clone_Reshape)
+{
+  auto g = loco::make_graph();
+  auto node_reshape = g->nodes()->create<luci::CircleReshape>();
+  node_reshape->newShape()->rank(2);
+  node_reshape->newShape()->dim(0) = 3;
+  node_reshape->newShape()->dim(1) = 4;
+
+  auto gc = loco::make_graph();
+  auto cloned = luci::clone_node(node_reshape, gc.get());
+  ASSERT_NE(nullptr, cloned);
+  ASSERT_EQ(gc.get(), cloned->graph());
+
+  auto cloned_reshape = dynamic_cast<luci::CircleReshape *>(cloned);
+  ASSERT_NE(nullptr, cloned_reshape);
+  ASSERT_EQ(node_reshape->newShape()->rank(), cloned_reshape->newShape()->rank());
+  ASSERT_EQ(node_reshape->newShape()->dim(0), cloned_reshape->newShape()->dim(0));
+  ASSERT_EQ(node_reshape->newShape()->dim(1), cloned_reshape->newShape()->dim(1));
+}

--- a/compiler/luci/service/src/Nodes/CircleResizeBilinear.cpp
+++ b/compiler/luci/service/src/Nodes/CircleResizeBilinear.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "CircleCloneNode.h"
+
+namespace luci
+{
+
+luci::CircleNode *CloneNode::visit(const luci::CircleResizeBilinear *node)
+{
+  auto *cloned = _graph->nodes()->create<luci::CircleResizeBilinear>();
+  if (cloned != nullptr)
+  {
+    cloned->align_corners(node->align_corners());
+    cloned->half_pixel_centers(node->half_pixel_centers());
+  }
+  return cloned;
+}
+
+} // namespace luci

--- a/compiler/luci/service/src/Nodes/CircleResizeBilinear.test.cpp
+++ b/compiler/luci/service/src/Nodes/CircleResizeBilinear.test.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include "luci/Service/CircleNodeClone.h"
+
 #include <luci/IR/CircleNodes.h>
 #include <luci/Service/CircleShapeInference.h>
 
@@ -50,4 +52,22 @@ TEST(ShapeRuleTest, resize_bilinear_simple)
   ASSERT_EQ(16, shape.dim(1).value());
   ASSERT_EQ(16, shape.dim(2).value());
   ASSERT_EQ(3, shape.dim(3).value());
+}
+
+TEST(CloneNodeTest, clone_ResizeBilinear)
+{
+  auto g = loco::make_graph();
+  auto node_rb = g->nodes()->create<luci::CircleResizeBilinear>();
+  node_rb->align_corners(true);
+  node_rb->half_pixel_centers(true);
+
+  auto gc = loco::make_graph();
+  auto cloned = luci::clone_node(node_rb, gc.get());
+  ASSERT_NE(nullptr, cloned);
+  ASSERT_EQ(gc.get(), cloned->graph());
+
+  auto cloned_rb = dynamic_cast<luci::CircleResizeBilinear *>(cloned);
+  ASSERT_NE(nullptr, cloned_rb);
+  ASSERT_EQ(node_rb->align_corners(), cloned_rb->align_corners());
+  ASSERT_EQ(node_rb->half_pixel_centers(), cloned_rb->half_pixel_centers());
 }

--- a/compiler/luci/service/src/Nodes/CircleResizeNearestNeighbor.cpp
+++ b/compiler/luci/service/src/Nodes/CircleResizeNearestNeighbor.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "CircleCloneNode.h"
+
+namespace luci
+{
+
+luci::CircleNode *CloneNode::visit(const luci::CircleResizeNearestNeighbor *node)
+{
+  auto *cloned = _graph->nodes()->create<luci::CircleResizeNearestNeighbor>();
+  if (cloned != nullptr)
+    cloned->align_corners(node->align_corners());
+  return cloned;
+}
+
+} // namespace luci

--- a/compiler/luci/service/src/Nodes/CircleResizeNearestNeighbor.test.cpp
+++ b/compiler/luci/service/src/Nodes/CircleResizeNearestNeighbor.test.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include "luci/Service/CircleNodeClone.h"
+
 #include <luci/IR/CircleNodes.h>
 #include <luci/Service/CircleShapeInference.h>
 
@@ -50,4 +52,20 @@ TEST(ShapeRuleTest, resize_nearest_neighbor_simple)
   ASSERT_EQ(16, shape.dim(1).value());
   ASSERT_EQ(16, shape.dim(2).value());
   ASSERT_EQ(3, shape.dim(3).value());
+}
+
+TEST(CloneNodeTest, clone_ResizeNearestNeighbor)
+{
+  auto g = loco::make_graph();
+  auto node_rnn = g->nodes()->create<luci::CircleResizeNearestNeighbor>();
+  node_rnn->align_corners(true);
+
+  auto gc = loco::make_graph();
+  auto cloned = luci::clone_node(node_rnn, gc.get());
+  ASSERT_NE(nullptr, cloned);
+  ASSERT_EQ(gc.get(), cloned->graph());
+
+  auto cloned_rnn = dynamic_cast<luci::CircleResizeNearestNeighbor *>(cloned);
+  ASSERT_NE(nullptr, cloned_rnn);
+  ASSERT_EQ(node_rnn->align_corners(), cloned_rnn->align_corners());
 }

--- a/compiler/luci/service/src/Nodes/CircleShape.cpp
+++ b/compiler/luci/service/src/Nodes/CircleShape.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "CircleCloneNode.h"
+
+namespace luci
+{
+
+luci::CircleNode *CloneNode::visit(const luci::CircleShape *node)
+{
+  auto *cloned = _graph->nodes()->create<luci::CircleShape>();
+  if (cloned != nullptr)
+    cloned->out_type(node->out_type());
+  return cloned;
+}
+
+} // namespace luci

--- a/compiler/luci/service/src/Nodes/CircleShape.test.cpp
+++ b/compiler/luci/service/src/Nodes/CircleShape.test.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Service/CircleNodeClone.h"
+
+#include <gtest/gtest.h>
+
+TEST(CloneNodeTest, clone_Shape)
+{
+  auto g = loco::make_graph();
+  auto node_shape = g->nodes()->create<luci::CircleShape>();
+  node_shape->out_type(loco::DataType::S32);
+
+  auto gc = loco::make_graph();
+  auto cloned = luci::clone_node(node_shape, gc.get());
+  ASSERT_NE(nullptr, cloned);
+  ASSERT_EQ(gc.get(), cloned->graph());
+
+  auto cloned_shape = dynamic_cast<luci::CircleShape *>(cloned);
+  ASSERT_NE(nullptr, cloned_shape);
+  ASSERT_EQ(node_shape->out_type(), cloned_shape->out_type());
+}


### PR DESCRIPTION
This will enable clone of CircleReshape, CircleResizeBilinear,
CircleResizeNearestNeighbor and CircleShape.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>