### PR TITLE
[luci] Enable clone for CircleCustomOut and others

### DIFF
--- a/compiler/luci/service/src/CircleCloneNode.h
+++ b/compiler/luci/service/src/CircleCloneNode.h
@@ -148,19 +148,19 @@ public:
   // luci::CircleNode *visit(const luci::CircleInstanceNorm *) final;
 
   // Virtual
-  // luci::CircleNode *visit(const luci::CircleCustomOut *) final;
+  luci::CircleNode *visit(const luci::CircleCustomOut *) final;
   // luci::CircleNode *visit(const luci::CircleIfOut *) final;
   // luci::CircleNode *visit(const luci::CircleInput *) final;
-  // luci::CircleNode *visit(const luci::CircleNonMaxSuppressionV4Out *) final;
-  // luci::CircleNode *visit(const luci::CircleNonMaxSuppressionV5Out *) final;
+  luci::CircleNode *visit(const luci::CircleNonMaxSuppressionV4Out *) final;
+  luci::CircleNode *visit(const luci::CircleNonMaxSuppressionV5Out *) final;
   // luci::CircleNode *visit(const luci::CircleOutput *) final;
   // luci::CircleNode *visit(const luci::CircleOutputDummy *) final;
   // luci::CircleNode *visit(const luci::CircleOutputExclude *) final;
-  // luci::CircleNode *visit(const luci::CircleSplitOut *) final;
-  // luci::CircleNode *visit(const luci::CircleSplitVOut *) final;
-  // luci::CircleNode *visit(const luci::CircleTopKV2Out *) final;
-  // luci::CircleNode *visit(const luci::CircleUniqueOut *) final;
-  // luci::CircleNode *visit(const luci::CircleUnpackOut *) final;
+  luci::CircleNode *visit(const luci::CircleSplitOut *) final;
+  luci::CircleNode *visit(const luci::CircleSplitVOut *) final;
+  luci::CircleNode *visit(const luci::CircleTopKV2Out *) final;
+  luci::CircleNode *visit(const luci::CircleUniqueOut *) final;
+  luci::CircleNode *visit(const luci::CircleUnpackOut *) final;
   // luci::CircleNode *visit(const luci::CircleWhileOut *) final;
 
   // NOTE CircleNodeVisitor will throw if not supported here

--- a/compiler/luci/service/src/Nodes/CircleCustomOut.cpp
+++ b/compiler/luci/service/src/Nodes/CircleCustomOut.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "CircleCloneNode.h"
+
+namespace luci
+{
+
+luci::CircleNode *CloneNode::visit(const luci::CircleCustomOut *node)
+{
+  auto *cloned = _graph->nodes()->create<luci::CircleCustomOut>();
+  if (cloned != nullptr)
+    cloned->index(node->index());
+  return cloned;
+}
+
+} // namespace luci

--- a/compiler/luci/service/src/Nodes/CircleCustomOut.test.cpp
+++ b/compiler/luci/service/src/Nodes/CircleCustomOut.test.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Service/CircleNodeClone.h"
+
+#include <gtest/gtest.h>
+
+TEST(CloneNodeTest, clone_CustomOut)
+{
+  auto g = loco::make_graph();
+  auto node_cout = g->nodes()->create<luci::CircleCustomOut>();
+  node_cout->index(1);
+
+  auto gc = loco::make_graph();
+  auto cloned = luci::clone_node(node_cout, gc.get());
+  ASSERT_NE(nullptr, cloned);
+  ASSERT_EQ(gc.get(), cloned->graph());
+
+  auto cloned_cout = dynamic_cast<luci::CircleCustomOut *>(cloned);
+  ASSERT_NE(nullptr, cloned_cout);
+  ASSERT_EQ(node_cout->index(), cloned_cout->index());
+}

--- a/compiler/luci/service/src/Nodes/CircleNonMaxSuppressionV4Out.cpp
+++ b/compiler/luci/service/src/Nodes/CircleNonMaxSuppressionV4Out.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "CircleCloneNode.h"
+
+namespace luci
+{
+
+luci::CircleNode *CloneNode::visit(const luci::CircleNonMaxSuppressionV4Out *node)
+{
+  auto *cloned = _graph->nodes()->create<luci::CircleNonMaxSuppressionV4Out>();
+  if (cloned != nullptr)
+    cloned->index(node->index());
+  return cloned;
+}
+
+} // namespace luci

--- a/compiler/luci/service/src/Nodes/CircleNonMaxSuppressionV4Out.test.cpp
+++ b/compiler/luci/service/src/Nodes/CircleNonMaxSuppressionV4Out.test.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Service/CircleNodeClone.h"
+
+#include <gtest/gtest.h>
+
+TEST(CloneNodeTest, clone_NonMaxSuppressionV4Out)
+{
+  auto g = loco::make_graph();
+  auto node_nout = g->nodes()->create<luci::CircleNonMaxSuppressionV4Out>();
+  node_nout->index(1);
+
+  auto gc = loco::make_graph();
+  auto cloned = luci::clone_node(node_nout, gc.get());
+  ASSERT_NE(nullptr, cloned);
+  ASSERT_EQ(gc.get(), cloned->graph());
+
+  auto cloned_nout = dynamic_cast<luci::CircleNonMaxSuppressionV4Out *>(cloned);
+  ASSERT_NE(nullptr, cloned_nout);
+  ASSERT_EQ(node_nout->index(), cloned_nout->index());
+}

--- a/compiler/luci/service/src/Nodes/CircleNonMaxSuppressionV5Out.cpp
+++ b/compiler/luci/service/src/Nodes/CircleNonMaxSuppressionV5Out.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "CircleCloneNode.h"
+
+namespace luci
+{
+
+luci::CircleNode *CloneNode::visit(const luci::CircleNonMaxSuppressionV5Out *node)
+{
+  auto *cloned = _graph->nodes()->create<luci::CircleNonMaxSuppressionV5Out>();
+  if (cloned != nullptr)
+    cloned->index(node->index());
+  return cloned;
+}
+
+} // namespace luci

--- a/compiler/luci/service/src/Nodes/CircleNonMaxSuppressionV5Out.test.cpp
+++ b/compiler/luci/service/src/Nodes/CircleNonMaxSuppressionV5Out.test.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Service/CircleNodeClone.h"
+
+#include <gtest/gtest.h>
+
+TEST(CloneNodeTest, clone_NonMaxSuppressionV5Out)
+{
+  auto g = loco::make_graph();
+  auto node_nout = g->nodes()->create<luci::CircleNonMaxSuppressionV5Out>();
+  node_nout->index(1);
+
+  auto gc = loco::make_graph();
+  auto cloned = luci::clone_node(node_nout, gc.get());
+  ASSERT_NE(nullptr, cloned);
+  ASSERT_EQ(gc.get(), cloned->graph());
+
+  auto cloned_nout = dynamic_cast<luci::CircleNonMaxSuppressionV5Out *>(cloned);
+  ASSERT_NE(nullptr, cloned_nout);
+  ASSERT_EQ(node_nout->index(), cloned_nout->index());
+}

--- a/compiler/luci/service/src/Nodes/CircleSplitOut.cpp
+++ b/compiler/luci/service/src/Nodes/CircleSplitOut.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "CircleCloneNode.h"
+
+namespace luci
+{
+
+luci::CircleNode *CloneNode::visit(const luci::CircleSplitOut *node)
+{
+  auto *cloned = _graph->nodes()->create<luci::CircleSplitOut>();
+  if (cloned != nullptr)
+    cloned->index(node->index());
+  return cloned;
+}
+
+} // namespace luci

--- a/compiler/luci/service/src/Nodes/CircleSplitOut.test.cpp
+++ b/compiler/luci/service/src/Nodes/CircleSplitOut.test.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Service/CircleNodeClone.h"
+
+#include <gtest/gtest.h>
+
+TEST(CloneNodeTest, clone_SplitOut)
+{
+  auto g = loco::make_graph();
+  auto node_sout = g->nodes()->create<luci::CircleSplitOut>();
+  node_sout->index(1);
+
+  auto gc = loco::make_graph();
+  auto cloned = luci::clone_node(node_sout, gc.get());
+  ASSERT_NE(nullptr, cloned);
+  ASSERT_EQ(gc.get(), cloned->graph());
+
+  auto cloned_sout = dynamic_cast<luci::CircleSplitOut *>(cloned);
+  ASSERT_NE(nullptr, cloned_sout);
+  ASSERT_EQ(node_sout->index(), cloned_sout->index());
+}

--- a/compiler/luci/service/src/Nodes/CircleSplitVOut.cpp
+++ b/compiler/luci/service/src/Nodes/CircleSplitVOut.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "CircleCloneNode.h"
+
+namespace luci
+{
+
+luci::CircleNode *CloneNode::visit(const luci::CircleSplitVOut *node)
+{
+  auto *cloned = _graph->nodes()->create<luci::CircleSplitVOut>();
+  if (cloned != nullptr)
+    cloned->index(node->index());
+  return cloned;
+}
+
+} // namespace luci

--- a/compiler/luci/service/src/Nodes/CircleSplitVOut.test.cpp
+++ b/compiler/luci/service/src/Nodes/CircleSplitVOut.test.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Service/CircleNodeClone.h"
+
+#include <gtest/gtest.h>
+
+TEST(CloneNodeTest, clone_SplitVOut)
+{
+  auto g = loco::make_graph();
+  auto node_sout = g->nodes()->create<luci::CircleSplitVOut>();
+  node_sout->index(1);
+
+  auto gc = loco::make_graph();
+  auto cloned = luci::clone_node(node_sout, gc.get());
+  ASSERT_NE(nullptr, cloned);
+  ASSERT_EQ(gc.get(), cloned->graph());
+
+  auto cloned_sout = dynamic_cast<luci::CircleSplitVOut *>(cloned);
+  ASSERT_NE(nullptr, cloned_sout);
+  ASSERT_EQ(node_sout->index(), cloned_sout->index());
+}

--- a/compiler/luci/service/src/Nodes/CircleTopKV2Out.cpp
+++ b/compiler/luci/service/src/Nodes/CircleTopKV2Out.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "CircleCloneNode.h"
+
+namespace luci
+{
+
+luci::CircleNode *CloneNode::visit(const luci::CircleTopKV2Out *node)
+{
+  auto *cloned = _graph->nodes()->create<luci::CircleTopKV2Out>();
+  if (cloned != nullptr)
+    cloned->index(node->index());
+  return cloned;
+}
+
+} // namespace luci

--- a/compiler/luci/service/src/Nodes/CircleTopKV2Out.test.cpp
+++ b/compiler/luci/service/src/Nodes/CircleTopKV2Out.test.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Service/CircleNodeClone.h"
+
+#include <gtest/gtest.h>
+
+TEST(CloneNodeTest, clone_TopKV2Out)
+{
+  auto g = loco::make_graph();
+  auto node_tout = g->nodes()->create<luci::CircleTopKV2Out>();
+  node_tout->index(1);
+
+  auto gc = loco::make_graph();
+  auto cloned = luci::clone_node(node_tout, gc.get());
+  ASSERT_NE(nullptr, cloned);
+  ASSERT_EQ(gc.get(), cloned->graph());
+
+  auto cloned_tout = dynamic_cast<luci::CircleTopKV2Out *>(cloned);
+  ASSERT_NE(nullptr, cloned_tout);
+  ASSERT_EQ(node_tout->index(), cloned_tout->index());
+}

--- a/compiler/luci/service/src/Nodes/CircleUniqueOut.cpp
+++ b/compiler/luci/service/src/Nodes/CircleUniqueOut.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "CircleCloneNode.h"
+
+namespace luci
+{
+
+luci::CircleNode *CloneNode::visit(const luci::CircleUniqueOut *node)
+{
+  auto *cloned = _graph->nodes()->create<luci::CircleUniqueOut>();
+  if (cloned != nullptr)
+    cloned->index(node->index());
+  return cloned;
+}
+
+} // namespace luci

--- a/compiler/luci/service/src/Nodes/CircleUniqueOut.test.cpp
+++ b/compiler/luci/service/src/Nodes/CircleUniqueOut.test.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Service/CircleNodeClone.h"
+
+#include <gtest/gtest.h>
+
+TEST(CloneNodeTest, clone_UniqueOut)
+{
+  auto g = loco::make_graph();
+  auto node_uout = g->nodes()->create<luci::CircleUniqueOut>();
+  node_uout->index(1);
+
+  auto gc = loco::make_graph();
+  auto cloned = luci::clone_node(node_uout, gc.get());
+  ASSERT_NE(nullptr, cloned);
+  ASSERT_EQ(gc.get(), cloned->graph());
+
+  auto cloned_uout = dynamic_cast<luci::CircleUniqueOut *>(cloned);
+  ASSERT_NE(nullptr, cloned_uout);
+  ASSERT_EQ(node_uout->index(), cloned_uout->index());
+}

--- a/compiler/luci/service/src/Nodes/CircleUnpackOut.cpp
+++ b/compiler/luci/service/src/Nodes/CircleUnpackOut.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "CircleCloneNode.h"
+
+namespace luci
+{
+
+luci::CircleNode *CloneNode::visit(const luci::CircleUnpackOut *node)
+{
+  auto *cloned = _graph->nodes()->create<luci::CircleUnpackOut>();
+  if (cloned != nullptr)
+    cloned->index(node->index());
+  return cloned;
+}
+
+} // namespace luci

--- a/compiler/luci/service/src/Nodes/CircleUnpackOut.test.cpp
+++ b/compiler/luci/service/src/Nodes/CircleUnpackOut.test.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Service/CircleNodeClone.h"
+
+#include <gtest/gtest.h>
+
+TEST(CloneNodeTest, clone_UnpackOut)
+{
+  auto g = loco::make_graph();
+  auto node_uout = g->nodes()->create<luci::CircleUnpackOut>();
+  node_uout->index(1);
+
+  auto gc = loco::make_graph();
+  auto cloned = luci::clone_node(node_uout, gc.get());
+  ASSERT_NE(nullptr, cloned);
+  ASSERT_EQ(gc.get(), cloned->graph());
+
+  auto cloned_uout = dynamic_cast<luci::CircleUnpackOut *>(cloned);
+  ASSERT_NE(nullptr, cloned_uout);
+  ASSERT_EQ(node_uout->index(), cloned_uout->index());
+}


### PR DESCRIPTION
This will enable clone for CircleCustomOut and other virtual nodes for
multiple outputs.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>