### PR TITLE
[luci] Set valid values of clone negative test

### DIFF
--- a/compiler/luci/service/src/Nodes/CircleConv2D.test.cpp
+++ b/compiler/luci/service/src/Nodes/CircleConv2D.test.cpp
@@ -41,6 +41,7 @@ TEST(CloneNodeTest, clone_Conv2D_fusedact_NEG)
   auto g = loco::make_graph();
   auto node_conv2d = g->nodes()->create<luci::CircleConv2D>();
   node_conv2d->fusedActivationFunction(luci::FusedActFunc::UNDEFINED);
+  node_conv2d->padding(luci::Padding::SAME);
 
   auto gc = loco::make_graph();
   auto cloned = luci::clone_node(node_conv2d, gc.get());
@@ -51,6 +52,7 @@ TEST(CloneNodeTest, clone_Conv2D_padding_NEG)
 {
   auto g = loco::make_graph();
   auto node_conv2d = g->nodes()->create<luci::CircleConv2D>();
+  node_conv2d->fusedActivationFunction(luci::FusedActFunc::RELU);
   node_conv2d->padding(luci::Padding::UNDEFINED);
 
   auto gc = loco::make_graph();

--- a/compiler/luci/service/src/Nodes/CircleDepthwiseConv2D.test.cpp
+++ b/compiler/luci/service/src/Nodes/CircleDepthwiseConv2D.test.cpp
@@ -41,6 +41,7 @@ TEST(CloneNodeTest, clone_DepthwiseConv2D_fusedact_NEG)
   auto g = loco::make_graph();
   auto node_dwconv2d = g->nodes()->create<luci::CircleDepthwiseConv2D>();
   node_dwconv2d->fusedActivationFunction(luci::FusedActFunc::UNDEFINED);
+  node_dwconv2d->padding(luci::Padding::SAME);
 
   auto gc = loco::make_graph();
   auto cloned = luci::clone_node(node_dwconv2d, gc.get());
@@ -51,6 +52,7 @@ TEST(CloneNodeTest, clone_DepthwiseConv2D_padding_NEG)
 {
   auto g = loco::make_graph();
   auto node_dwconv2d = g->nodes()->create<luci::CircleDepthwiseConv2D>();
+  node_dwconv2d->fusedActivationFunction(luci::FusedActFunc::RELU);
   node_dwconv2d->padding(luci::Padding::UNDEFINED);
 
   auto gc = loco::make_graph();

--- a/compiler/luci/service/src/Nodes/CircleFullyConnected.test.cpp
+++ b/compiler/luci/service/src/Nodes/CircleFullyConnected.test.cpp
@@ -41,6 +41,7 @@ TEST(CloneNodeTest, clone_FullyConnected_fusedact_NEG)
   auto g = loco::make_graph();
   auto node_fc = g->nodes()->create<luci::CircleFullyConnected>();
   node_fc->fusedActivationFunction(luci::FusedActFunc::UNDEFINED);
+  node_fc->weights_format(luci::CircleFullyConnected::WeightsFormat::DEFAULT);
 
   auto gc = loco::make_graph();
   auto cloned = luci::clone_node(node_fc, gc.get());
@@ -51,6 +52,7 @@ TEST(CloneNodeTest, clone_FullyConnected_wf_NEG)
 {
   auto g = loco::make_graph();
   auto node_fc = g->nodes()->create<luci::CircleFullyConnected>();
+  node_fc->fusedActivationFunction(luci::FusedActFunc::RELU);
   node_fc->weights_format(luci::CircleFullyConnected::WeightsFormat::UNDEFINED);
 
   auto gc = loco::make_graph();


### PR DESCRIPTION
This will set valid values for items that should be valid
for correct negative testing of invalid attributes.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>