### PR TITLE
[luci] Introduce node accessors to QuantizedModelVerifier test graphs

### DIFF
--- a/compiler/luci/pass/src/QuantizedModelVerifier.test.cpp
+++ b/compiler/luci/pass/src/QuantizedModelVerifier.test.cpp
@@ -418,6 +418,9 @@ public:
     set_minmax_to_non_const(g(), -1, 1);
   }
 
+  const loco::Node *x(void) const { return _op->x(); }
+  const loco::Node *y(void) const { return _op->y(); }
+
 public:
   Op *_op = nullptr;
   luci::CircleConst *_y = nullptr;
@@ -452,8 +455,8 @@ public:
     set_minmax_to_non_const(g(), -1, 1);
   }
 
-  loco::Node *x() { return _op->x(); }
-  loco::Node *y() { return _op->y(); }
+  const loco::Node *x(void) const { return _op->x(); }
+  const loco::Node *y(void) const { return _op->y(); }
 
 public:
   Op *_op = nullptr;

--- a/compiler/luci/pass/src/QuantizedModelVerifier.test.cpp
+++ b/compiler/luci/pass/src/QuantizedModelVerifier.test.cpp
@@ -418,8 +418,8 @@ public:
     set_minmax_to_non_const(g(), -1, 1);
   }
 
-  const loco::Node *x(void) const { return _op->x(); }
-  const loco::Node *y(void) const { return _op->y(); }
+  loco::Node *x(void) const { return _op->x(); }
+  loco::Node *y(void) const { return _op->y(); }
 
 public:
   Op *_op = nullptr;
@@ -455,8 +455,8 @@ public:
     set_minmax_to_non_const(g(), -1, 1);
   }
 
-  const loco::Node *x(void) const { return _op->x(); }
-  const loco::Node *y(void) const { return _op->y(); }
+  loco::Node *x(void) const { return _op->x(); }
+  loco::Node *y(void) const { return _op->y(); }
 
 public:
   Op *_op = nullptr;

--- a/compiler/luci/pass/src/QuantizedModelVerifier.test.cpp
+++ b/compiler/luci/pass/src/QuantizedModelVerifier.test.cpp
@@ -452,6 +452,9 @@ public:
     set_minmax_to_non_const(g(), -1, 1);
   }
 
+  loco::Node *x() { return _op->x(); }
+  loco::Node *y() { return _op->y(); }
+
 public:
   Op *_op = nullptr;
   luci::CircleConst *_y = nullptr;
@@ -860,18 +863,18 @@ TEST(QuantizedModelVerifierTest, GreaterEqual_wrong_type_NEG)
 TEST(QuantizedModelVerifierTest, GreaterEqual_wrong_granularity_NEG)
 {
   TEST_WITH_WRONG_GRANULARITY_TARGET(ComparisonOpTestGraph<luci::CircleGreaterEqual>, Type::U8,
-                                     Granularity::LayerWise, g._op->x());
+                                     Granularity::LayerWise, g.x());
   TEST_WITH_WRONG_GRANULARITY_TARGET(ComparisonOpTestGraph<luci::CircleGreaterEqual>, Type::U8,
-                                     Granularity::ChannelWise, g._op->x());
+                                     Granularity::ChannelWise, g.x());
   TEST_WITH_WRONG_GRANULARITY_TARGET(ComparisonOpTestGraph<luci::CircleGreaterEqual>, Type::S16,
-                                     Granularity::ChannelWise, g._op->x());
+                                     Granularity::ChannelWise, g.x());
 
   TEST_WITH_WRONG_GRANULARITY_TARGET(ComparisonOpTestGraph<luci::CircleGreaterEqual>, Type::U8,
-                                     Granularity::LayerWise, g._y);
+                                     Granularity::LayerWise, g.y());
   TEST_WITH_WRONG_GRANULARITY_TARGET(ComparisonOpTestGraph<luci::CircleGreaterEqual>, Type::U8,
-                                     Granularity::ChannelWise, g._y);
+                                     Granularity::ChannelWise, g.y());
   TEST_WITH_WRONG_GRANULARITY_TARGET(ComparisonOpTestGraph<luci::CircleGreaterEqual>, Type::S16,
-                                     Granularity::ChannelWise, g._y);
+                                     Granularity::ChannelWise, g.y());
 }
 
 TEST(QuantizedModelVerifierTest, Greater)
@@ -894,18 +897,18 @@ TEST(QuantizedModelVerifierTest, Greater_wrong_type_NEG)
 TEST(QuantizedModelVerifierTest, Greater_wrong_granularity_NEG)
 {
   TEST_WITH_WRONG_GRANULARITY_TARGET(ComparisonOpTestGraph<luci::CircleGreater>, Type::U8,
-                                     Granularity::LayerWise, g._op->x());
+                                     Granularity::LayerWise, g.x());
   TEST_WITH_WRONG_GRANULARITY_TARGET(ComparisonOpTestGraph<luci::CircleGreater>, Type::U8,
-                                     Granularity::ChannelWise, g._op->x());
+                                     Granularity::ChannelWise, g.x());
   TEST_WITH_WRONG_GRANULARITY_TARGET(ComparisonOpTestGraph<luci::CircleGreater>, Type::S16,
-                                     Granularity::ChannelWise, g._op->x());
+                                     Granularity::ChannelWise, g.x());
 
   TEST_WITH_WRONG_GRANULARITY_TARGET(ComparisonOpTestGraph<luci::CircleGreater>, Type::U8,
-                                     Granularity::LayerWise, g._y);
+                                     Granularity::LayerWise, g.y());
   TEST_WITH_WRONG_GRANULARITY_TARGET(ComparisonOpTestGraph<luci::CircleGreater>, Type::U8,
-                                     Granularity::ChannelWise, g._y);
+                                     Granularity::ChannelWise, g.y());
   TEST_WITH_WRONG_GRANULARITY_TARGET(ComparisonOpTestGraph<luci::CircleGreater>, Type::S16,
-                                     Granularity::ChannelWise, g._y);
+                                     Granularity::ChannelWise, g.y());
 }
 
 TEST(QuantizedModelVerifierTest, NotEqual)
@@ -928,18 +931,18 @@ TEST(QuantizedModelVerifierTest, NotEqual_wrong_type_NEG)
 TEST(QuantizedModelVerifierTest, NotEqual_wrong_granularity_NEG)
 {
   TEST_WITH_WRONG_GRANULARITY_TARGET(ComparisonOpTestGraph<luci::CircleNotEqual>, Type::U8,
-                                     Granularity::LayerWise, g._op->x());
+                                     Granularity::LayerWise, g.x());
   TEST_WITH_WRONG_GRANULARITY_TARGET(ComparisonOpTestGraph<luci::CircleNotEqual>, Type::U8,
-                                     Granularity::ChannelWise, g._op->x());
+                                     Granularity::ChannelWise, g.x());
   TEST_WITH_WRONG_GRANULARITY_TARGET(ComparisonOpTestGraph<luci::CircleNotEqual>, Type::S16,
-                                     Granularity::ChannelWise, g._op->x());
+                                     Granularity::ChannelWise, g.x());
 
   TEST_WITH_WRONG_GRANULARITY_TARGET(ComparisonOpTestGraph<luci::CircleNotEqual>, Type::U8,
-                                     Granularity::LayerWise, g._y);
+                                     Granularity::LayerWise, g.y());
   TEST_WITH_WRONG_GRANULARITY_TARGET(ComparisonOpTestGraph<luci::CircleNotEqual>, Type::U8,
-                                     Granularity::ChannelWise, g._y);
+                                     Granularity::ChannelWise, g.y());
   TEST_WITH_WRONG_GRANULARITY_TARGET(ComparisonOpTestGraph<luci::CircleNotEqual>, Type::S16,
-                                     Granularity::ChannelWise, g._y);
+                                     Granularity::ChannelWise, g.y());
 }
 
 TEST(QuantizedModelVerifierTest, Div)


### PR DESCRIPTION
This commit introduces node accessors to TestGraph classes.

ONE-DCO-1.0-Signed-off-by: Dayoung Lee <dayg502@gmail.com>

----

From #6558