### PR TITLE
[luci] Enable clone for CircleOutputDummy and other

### DIFF
--- a/compiler/luci/service/src/CircleCloneNode.h
+++ b/compiler/luci/service/src/CircleCloneNode.h
@@ -154,8 +154,8 @@ public:
   luci::CircleNode *visit(const luci::CircleNonMaxSuppressionV4Out *) final;
   luci::CircleNode *visit(const luci::CircleNonMaxSuppressionV5Out *) final;
   // luci::CircleNode *visit(const luci::CircleOutput *) final;
-  // luci::CircleNode *visit(const luci::CircleOutputDummy *) final;
-  // luci::CircleNode *visit(const luci::CircleOutputExclude *) final;
+  luci::CircleNode *visit(const luci::CircleOutputDummy *) final;
+  luci::CircleNode *visit(const luci::CircleOutputExclude *) final;
   luci::CircleNode *visit(const luci::CircleSplitOut *) final;
   luci::CircleNode *visit(const luci::CircleSplitVOut *) final;
   luci::CircleNode *visit(const luci::CircleTopKV2Out *) final;

--- a/compiler/luci/service/src/Nodes/CircleOutputDummy.cpp
+++ b/compiler/luci/service/src/Nodes/CircleOutputDummy.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "CircleCloneNode.h"
+
+namespace luci
+{
+
+luci::CircleNode *CloneNode::visit(const luci::CircleOutputDummy *)
+{
+  return _graph->nodes()->create<luci::CircleOutputDummy>();
+}
+
+} // namespace luci

--- a/compiler/luci/service/src/Nodes/CircleOutputDummy.test.cpp
+++ b/compiler/luci/service/src/Nodes/CircleOutputDummy.test.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Service/CircleNodeClone.h"
+
+#include <gtest/gtest.h>
+
+TEST(CloneNodeTest, clone_OutputDummy)
+{
+  auto g = loco::make_graph();
+  auto node_dummy = g->nodes()->create<luci::CircleOutputDummy>();
+
+  auto gc = loco::make_graph();
+  auto cloned = luci::clone_node(node_dummy, gc.get());
+  ASSERT_NE(nullptr, cloned);
+  ASSERT_EQ(gc.get(), cloned->graph());
+
+  auto cloned_dummy = dynamic_cast<luci::CircleOutputDummy *>(cloned);
+  ASSERT_NE(nullptr, cloned_dummy);
+}

--- a/compiler/luci/service/src/Nodes/CircleOutputExclude.cpp
+++ b/compiler/luci/service/src/Nodes/CircleOutputExclude.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "CircleCloneNode.h"
+
+namespace luci
+{
+
+luci::CircleNode *CloneNode::visit(const luci::CircleOutputExclude *)
+{
+  return _graph->nodes()->create<luci::CircleOutputExclude>();
+}
+
+} // namespace luci

--- a/compiler/luci/service/src/Nodes/CircleOutputExclude.test.cpp
+++ b/compiler/luci/service/src/Nodes/CircleOutputExclude.test.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Service/CircleNodeClone.h"
+
+#include <gtest/gtest.h>
+
+TEST(CloneNodeTest, clone_OutputExclude)
+{
+  auto g = loco::make_graph();
+  auto node_outex = g->nodes()->create<luci::CircleOutputExclude>();
+
+  auto gc = loco::make_graph();
+  auto cloned = luci::clone_node(node_outex, gc.get());
+  ASSERT_NE(nullptr, cloned);
+  ASSERT_EQ(gc.get(), cloned->graph());
+
+  auto cloned_outex = dynamic_cast<luci::CircleOutputExclude *>(cloned);
+  ASSERT_NE(nullptr, cloned_outex);
+}


### PR DESCRIPTION
This will enable clone for CircleOutputDummy and CircleOutputExclude.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>