### PR TITLE
[record-minmax] Skip recording bool type tensor

### DIFF
--- a/compiler/record-minmax/src/MinMaxObserver.cpp
+++ b/compiler/record-minmax/src/MinMaxObserver.cpp
@@ -51,17 +51,9 @@ void MinMaxObserver::postTensorWrite(const luci::CircleNode *node,
     return;
   }
 
-  if (node->opcode() == luci::CircleOpcode::GREATER ||
-      node->opcode() == luci::CircleOpcode::GREATER_EQUAL ||
-      node->opcode() == luci::CircleOpcode::LESS ||
-      node->opcode() == luci::CircleOpcode::LESS_EQUAL ||
-      node->opcode() == luci::CircleOpcode::LOGICAL_AND ||
-      node->opcode() == luci::CircleOpcode::LOGICAL_NOT ||
-      node->opcode() == luci::CircleOpcode::LOGICAL_OR ||
-      node->opcode() == luci::CircleOpcode::EQUAL ||
-      node->opcode() == luci::CircleOpcode::NOT_EQUAL)
+  if (node->dtype() == DataType::BOOL)
   {
-    // Output of these operators is bool type, which is not quantized
+    // Bool type tensor is not quantized
     return;
   }
 


### PR DESCRIPTION
This skips recording bool type tensor.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---

Related to: #6367
Draft PR: #6526