### PR TITLE
[luci] Introduce idx_out_type for CircleUnique IR

### DIFF
--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleUnique.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleUnique.h
@@ -36,7 +36,9 @@ public:
 
 public:
   loco::DataType idx_out_type(void) const { return _idx_out_type; }
+  // TODO remove output_type
   void output_type(loco::DataType ot) { _idx_out_type = ot; }
+  void idx_out_type(loco::DataType ot) { _idx_out_type = ot; }
 
 private:
   loco::DataType _idx_out_type{loco::DataType::S32};


### PR DESCRIPTION
This will add idx_out_type() accessor with a comment in CircleUnique IR
to relace existing idx_out_type.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>