### PR TITLE
[luci] Add missing nnas_find_package

### DIFF
--- a/compiler/luci/testhelper/CMakeLists.txt
+++ b/compiler/luci/testhelper/CMakeLists.txt
@@ -2,6 +2,8 @@ if(NOT ENABLE_TEST)
   return()
 endif(NOT ENABLE_TEST)
 
+nnas_find_package(GTest REQUIRED)
+
 file(GLOB_RECURSE TESTS "src/*.test.cpp")
 
 add_library(luci_testhelper STATIC ${TESTS})


### PR DESCRIPTION
This commit adds missing nnas_find_package to find Gtest.

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>