### PR TITLE
[luci] Separate testhelper test from library

### DIFF
--- a/compiler/luci/testhelper/CMakeLists.txt
+++ b/compiler/luci/testhelper/CMakeLists.txt
@@ -4,9 +4,22 @@ endif(NOT ENABLE_TEST)
 
 nnas_find_package(GTest REQUIRED)
 
-file(GLOB_RECURSE TESTS "src/*.test.cpp")
+# NOTE we are using "*.test.cpp" NOT to be included in static analyzer tools
 
-add_library(luci_testhelper STATIC ${TESTS})
+# testhelper library itself
+set(HELPER_SOURCE
+      src/TestShape.test.cpp
+   )
+
+add_library(luci_testhelper STATIC ${HELPER_SOURCE})
 target_include_directories(luci_testhelper PRIVATE src)
 target_include_directories(luci_testhelper PUBLIC include)
 target_link_libraries(luci_testhelper luci_lang)
+
+# test for testhelper library
+set(TESTER_SOURCE
+      src/TestIOGraph.test.cpp
+   )
+
+GTest_AddTest(luci_testhelper_test ${TESTER_SOURCE})
+target_link_libraries(luci_testhelper_test luci_testhelper)


### PR DESCRIPTION
This will separate testhelper test executable from library itself.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>