### PR TITLE
[luci] Remove unused accessor in CircleUnique

### DIFF
--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleUnique.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleUnique.h
@@ -36,8 +36,6 @@ public:
 
 public:
   loco::DataType idx_out_type(void) const { return _idx_out_type; }
-  // TODO remove output_type
-  void output_type(loco::DataType ot) { _idx_out_type = ot; }
   void idx_out_type(loco::DataType ot) { _idx_out_type = ot; }
 
 private:


### PR DESCRIPTION
This will remove unused accessor output_type() in CircleUnique IR.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>