### PR TITLE
[ONE] Revert android build runtime release shell script.

### DIFF
--- a/infra/scripts/build_android_runtime_release.sh
+++ b/infra/scripts/build_android_runtime_release.sh
@@ -5,12 +5,10 @@ ROOT_PATH="$CURRENT_PATH/../../"
 
 # prepare pre-built armcompute library
 # android build requires pre-built armcompute library
-# if [ ! -n "$EXT_ACL_FOLDER" ]; then
-#   echo "Please set EXT_ACL_FOLDER to use pre-built armcompute library"
-#   exit 1
-# fi
-
-unset EXT_ACL_FOLDER
+if [ ! -n "$EXT_ACL_FOLDER" ]; then
+  echo "Please set EXT_ACL_FOLDER to use pre-built armcompute library"
+  exit 1
+fi
 
 # prepare ndk
 if [ ! -n "$NDK_DIR" ]; then


### PR DESCRIPTION
- In previously, To adapt armcompute library v21.02,
  The 'EXT_ACL_FOLDER' was commented out.
  If not, It tried to build with v20.05 and showed some errors.
  Because the binary of library was not update on CI.

ONE-DCO-1.0-Signed-off-by: <Hyunjun Kim> <hyunjun2.kim@samsung.com>