### PR TITLE
[circle2circle] Use strncpy instead of strcpy

### DIFF
--- a/compiler/circle2circle/src/TestHelper.h
+++ b/compiler/circle2circle/src/TestHelper.h
@@ -39,7 +39,7 @@ public:
   {
     assert(_ptr < N);
     _argv[_ptr] = new char[strlen(in) + 1];
-    strcpy(_argv[_ptr], in);
+    strncpy(_argv[_ptr], in, strlen(in) + 1);
     _ptr++;
   }
 


### PR DESCRIPTION
This commit replace vulnerable function `strcpy` to `strncpy`.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>