### PR TITLE
[circlechef] Introduce INT16 test

### DIFF
--- a/compiler/circlechef/tests/short_int_datatype/test.recipe
+++ b/compiler/circlechef/tests/short_int_datatype/test.recipe
@@ -1,0 +1,32 @@
+operand {
+  name: "ifm1"
+  type: INT16
+  shape { dim: 1 dim: 4 dim: 4 dim: 3 }
+}
+operand {
+  name: "constant"
+  type: INT16
+  shape { dim: 1 dim: 4 dim: 3 dim: 4 }
+  filler {
+    tag: "gaussian"
+    arg: "3.0"
+    arg: "10.0"
+  }
+}
+operand {
+  name: "ofm"
+  type: INT16
+  shape { dim: 1 dim: 4 dim: 4 dim: 4 }
+}
+operation {
+  type: "BatchMatMul"
+  input: "ifm1"
+  input: "constant"
+  output: "ofm"
+  batch_matmul_options {
+    adjoint_lhs: false
+    adjoint_rhs: false
+  }
+}
+input: "ifm1"
+output: "ofm"


### PR DESCRIPTION
This commit adds test for INT16 tensors in recipe.

issue #6576

ONE-DCO-1.0-Signed-off-by: Alexander Efimov <a.efimov@samsung.com>