### PR TITLE
[luci] Support quantization of ResizeBilinear

### DIFF
--- a/compiler/luci/pass/src/QuantizedModelVerifier.test.cpp
+++ b/compiler/luci/pass/src/QuantizedModelVerifier.test.cpp
@@ -828,10 +828,10 @@ private:
   luci::CircleConst *_const = nullptr;
 };
 
-class ResizeBilinearTestGraph final : public luci::test::TestIOGraph
+class ResizeBilinearTestGraph final : public SimpleTestGraph
 {
 public:
-  void init(void)
+  void init(void) override
   {
     TestIOGraph::init({1, 4, 4, 1}, {1, 8, 8, 1});
 
@@ -846,6 +846,7 @@ public:
     set_minmax_to_non_const(g(), -1, 1);
   }
 
+private:
   luci::CircleResizeBilinear *_resize_bilinear = nullptr;
   luci::CircleConst *_size = nullptr;
 };

--- a/compiler/luci/pass/src/QuantizedModelVerifier.test.cpp
+++ b/compiler/luci/pass/src/QuantizedModelVerifier.test.cpp
@@ -836,21 +836,17 @@ public:
     TestIOGraph::init({1, 4, 4, 1}, {1, 8, 8, 1});
 
     _size = create_const<Type::S32, int32_t>(g(), {2}, {8, 8});
-    _resizebilinear = g()->nodes()->create<luci::CircleResizeBilinear>();
+    _resize_bilinear = g()->nodes()->create<luci::CircleResizeBilinear>();
     {
-      _resizebilinear->input(input());
-      _resizebilinear->size(_size);
+      _resize_bilinear->input(input());
+      _resize_bilinear->size(_size);
     }
-    output()->from(_resizebilinear);
+    output()->from(_resize_bilinear);
 
     set_minmax_to_non_const(g(), -1, 1);
   }
 
-  // Avoid overriding TestIOGraph::input()
-  loco::Node *input_rbl() { return _resizebilinear->input(); }
-  loco::Node *size() { return _resizebilinear->size(); }
-
-  luci::CircleResizeBilinear *_resizebilinear = nullptr;
+  luci::CircleResizeBilinear *_resize_bilinear = nullptr;
   luci::CircleConst *_size = nullptr;
 };
 

--- a/compiler/luci/pass/src/VerifyQuantizedNodeChannelWiseGranularity.h
+++ b/compiler/luci/pass/src/VerifyQuantizedNodeChannelWiseGranularity.h
@@ -382,6 +382,13 @@ private:
     return true;
   }
 
+  bool visit(const luci::CircleResizeBilinear *node)
+  {
+    RETURN_FALSE_UNLESS(is_lwq(node));
+    RETURN_FALSE_UNLESS(is_lwq(node->input()));
+    return true;
+  }
+
   // TODO: Implement more Ops
 
   bool visit(const luci::CircleNode *) { return true; }

--- a/compiler/luci/pass/src/VerifyQuantizedNodeLayerWiseGranularity.h
+++ b/compiler/luci/pass/src/VerifyQuantizedNodeLayerWiseGranularity.h
@@ -369,6 +369,13 @@ private:
     return true;
   }
 
+  bool visit(const luci::CircleResizeBilinear *node)
+  {
+    RETURN_FALSE_UNLESS(is_lwq(node));
+    RETURN_FALSE_UNLESS(is_lwq(node->input()));
+    return true;
+  }
+
   // TODO: Implement more Ops
 
   bool visit(const luci::CircleNode *) { return true; }

--- a/compiler/luci/pass/src/VerifyQuantizedNodeS16Type.h
+++ b/compiler/luci/pass/src/VerifyQuantizedNodeS16Type.h
@@ -356,6 +356,13 @@ private:
     return true;
   }
 
+  bool visit(const luci::CircleResizeBilinear *node)
+  {
+    RETURN_FALSE_UNLESS(has_type(node, Type::S16))
+    RETURN_FALSE_UNLESS(has_type(node->input(), Type::S16))
+    return true;
+  }
+
   // TODO: Implement more Ops
 
   bool visit(const luci::CircleNode *) { return true; }

--- a/compiler/luci/pass/src/VerifyQuantizedNodeU8Type.h
+++ b/compiler/luci/pass/src/VerifyQuantizedNodeU8Type.h
@@ -356,6 +356,13 @@ private:
     return true;
   }
 
+  bool visit(const luci::CircleResizeBilinear *node)
+  {
+    RETURN_FALSE_UNLESS(has_type(node, Type::U8))
+    RETURN_FALSE_UNLESS(has_type(node->input(), Type::U8))
+    return true;
+  }
+
   // TODO: Implement more Ops
 
   bool visit(const luci::CircleNode *) { return true; }


### PR DESCRIPTION
This commit supports quantization and its unittest of ResizeBilinear operation.

ONE-DCO-1.0-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>

------------

For #6367