### PR TITLE
[arser] Help message test

### DIFF
--- a/compiler/arser/CMakeLists.txt
+++ b/compiler/arser/CMakeLists.txt
@@ -11,6 +11,7 @@ if(NOT ENABLE_TEST)
 endif(NOT ENABLE_TEST)
 
 nnas_find_package(GTest REQUIRED)
-set(TESTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/arser.test.cpp")
+set(TESTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/arser.test.cpp"
+          "${CMAKE_CURRENT_SOURCE_DIR}/tests/HelpMessage.test.cpp")
 GTest_AddTest(arser_test ${TESTS})
 target_link_libraries(arser_test arser)

--- a/compiler/arser/tests/HelpMessage.test.cpp
+++ b/compiler/arser/tests/HelpMessage.test.cpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "arser/arser.h"
+
+#include "Prompt.h"
+
+using namespace arser;
+
+/**
+ * [WARNING] DO NOT GIVE THE ARSER '-h' or '--help' OPTION IN BELOW TESTS.
+ *
+ * arser exits with code 0 when '-h' option is given, which forces googletest to pass.
+ */
+
+TEST(HelpMessageTest, Default)
+{
+  /* arrange */
+  Arser arser;
+
+  arser.add_argument("--dummy").nargs(0).help("Dummy optional argument");
+
+  std::ostringstream oss;
+  std::string expected_out = "Usage: ./arser [-h] [--dummy] \n"
+                             "\n"
+                             "[Optional argument]\n"
+                             "-h, --help	Show help message and exit\n"
+                             "--dummy   \tDummy optional argument\n";
+
+  test::Prompt prompt("./arser --dummy");
+  /* act */
+  arser.parse(prompt.argc(), prompt.argv());
+  oss << arser;
+
+  /* assert */
+  EXPECT_EQ(expected_out, oss.str());
+}
+
+TEST(HelpMessageTest, ShortOption)
+{
+  /* arrange */
+  Arser arser;
+
+  arser.add_argument("-v", "--verbose").nargs(0).help("Provides additional details");
+
+  std::ostringstream oss;
+  std::string expected_out = "Usage: ./arser [-h] [-v] \n"
+                             "\n"
+                             "[Optional argument]\n"
+                             "-h, --help   \tShow help message and exit\n"
+                             "-v, --verbose\tProvides additional details\n";
+
+  test::Prompt prompt("./arser -v");
+  /* act */
+  arser.parse(prompt.argc(), prompt.argv());
+  oss << arser;
+
+  /* assert */
+  EXPECT_EQ(expected_out, oss.str());
+}

--- a/compiler/arser/tests/Prompt.h
+++ b/compiler/arser/tests/Prompt.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ARSER_PROMPT_H__
+#define __ARSER_PROMPT_H__
+
+#include <iterator>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace arser
+{
+namespace test
+{
+
+class Prompt
+{
+public:
+  Prompt(const std::string &command)
+  {
+    std::istringstream iss(command);
+    std::vector<std::string> token(std::istream_iterator<std::string>{iss},
+                                   std::istream_iterator<std::string>());
+    _arg = std::move(token);
+    _argv.reserve(_arg.size());
+    for (const auto &t : _arg)
+    {
+      _argv.push_back(const_cast<char *>(t.data()));
+    }
+  }
+  int argc(void) const { return _argv.size(); }
+  char **argv(void) { return _argv.data(); }
+
+private:
+  std::vector<char *> _argv;
+  std::vector<std::string> _arg;
+};
+
+} // namespace test
+} // namespace arser
+
+#endif // __ARSER_PROMPT_H__


### PR DESCRIPTION
This commit adds help message test to arser.

Related: #6592 
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>