### PR TITLE
[luci] Add create_const helper to QuantizedModelVerifier test

### DIFF
--- a/compiler/luci/pass/src/QuantizedModelVerifier.test.cpp
+++ b/compiler/luci/pass/src/QuantizedModelVerifier.test.cpp
@@ -72,7 +72,6 @@ template <Type T> luci::CircleConst *create_dummy_const(loco::Graph *g, luci::te
 
 /**
  * @brief A helper function to create const node with value
- *
  */
 template <Type DT, typename T>
 luci::CircleConst *create_const(loco::Graph *g, luci::test::ShapeU32 shape,
@@ -888,16 +887,6 @@ TEST(QuantizedModelVerifierTest, LocalCreateConst)
   {
     EXPECT_EQ(node->at<Type::FLOAT32>(index++), val);
   }
-}
-
-TEST(QuantizedModelVerifierTest, LocalCreateConst_NEG)
-{
-  loco::Graph g;
-  std::initializer_list<float> values = {0.1, 0, -5, 100};
-  luci::CircleConst *node = create_const<Type::FLOAT32, float>(&g, {2, 2}, values);
-
-  // access out of bound
-  EXPECT_DEATH(node->at<Type::FLOAT32>(4), "Assertion `n < size<DT>()");
 }
 
 TEST(QuantizedModelVerifierTest, InstanceNorm)

--- a/compiler/luci/pass/src/QuantizedModelVerifier.test.cpp
+++ b/compiler/luci/pass/src/QuantizedModelVerifier.test.cpp
@@ -70,6 +70,32 @@ template <Type T> luci::CircleConst *create_dummy_const(loco::Graph *g, luci::te
   return node;
 }
 
+/**
+ * @brief A helper function to create const node with value
+ *
+ */
+template <Type DT, typename T>
+luci::CircleConst *create_const(loco::Graph *g, luci::test::ShapeU32 shape,
+                                std::initializer_list<T> values)
+{
+  auto node = g->nodes()->create<luci::CircleConst>();
+  {
+    node->dtype(DT);
+    node->shape(shape);
+    node->size<DT>(luci::test::num_elements(shape));
+
+    assert(values.size() == node->size<DT>());
+
+    uint32_t index = 0;
+    for (auto val : values)
+    {
+      node->at<DT>(index++) = static_cast<T>(val);
+    }
+  }
+
+  return node;
+}
+
 void insert_scale_zp(luci::CircleNode *node, float scale, int64_t zp)
 {
   auto qparam = node->quantparam();
@@ -849,6 +875,29 @@ TEST(QuantizedModelVerifierTest, LocalCreateDummyConst)
   loco::Graph g;
 
   EXPECT_NO_THROW(create_dummy_const<Type::FLOAT32>(&g, {32, 32}));
+}
+
+TEST(QuantizedModelVerifierTest, LocalCreateConst)
+{
+  loco::Graph g;
+  std::initializer_list<float> values = {0.1, 0, -5, 100};
+  luci::CircleConst *node = create_const<Type::FLOAT32, float>(&g, {2, 2}, values);
+
+  uint32_t index = 0;
+  for (auto val : values)
+  {
+    EXPECT_EQ(node->at<Type::FLOAT32>(index++), val);
+  }
+}
+
+TEST(QuantizedModelVerifierTest, LocalCreateConst_NEG)
+{
+  loco::Graph g;
+  std::initializer_list<float> values = {0.1, 0, -5, 100};
+  luci::CircleConst *node = create_const<Type::FLOAT32, float>(&g, {2, 2}, values);
+
+  // access out of bound
+  EXPECT_DEATH(node->at<Type::FLOAT32>(4), "Assertion `n < size<DT>()");
 }
 
 TEST(QuantizedModelVerifierTest, InstanceNorm)


### PR DESCRIPTION
This commit adds create_const helper function to create const node with value

ONE-DCO-1.0-Signed-off-by: Dayoung Lee <dayg502@gmail.com>

-----

From #6618