### PR TITLE
[infra] Remove deprecated acl checking on android build test

### DIFF
--- a/infra/scripts/build_android_runtime_release.sh
+++ b/infra/scripts/build_android_runtime_release.sh
@@ -3,15 +3,6 @@
 CURRENT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_PATH="$CURRENT_PATH/../../"
 
-# prepare pre-built armcompute library
-# android build requires pre-built armcompute library
-# if [ ! -n "$EXT_ACL_FOLDER" ]; then
-#   echo "Please set EXT_ACL_FOLDER to use pre-built armcompute library"
-#   exit 1
-# fi
-
-unset EXT_ACL_FOLDER
-
 # prepare ndk
 if [ ! -n "$NDK_DIR" ]; then
   export NDK_DIR=$ROOT_PATH/tools/cross/ndk/r20/ndk


### PR DESCRIPTION
This commit removes checking pre-built arm compute library is installed.
Android build doesn't require pre-built arm compute library any more.

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>