### PR TITLE
[luci] Tidy IR style

### DIFF
--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleAveragePool2D.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleAveragePool2D.h
@@ -37,14 +37,10 @@ class CircleAveragePool2D final
     public CircleNodeMixin<CircleNodeTrait::FusedActFunc>
 {
 public:
-  CircleAveragePool2D() : _padding(Padding::UNDEFINED)
-  { /* empty */
-  }
-
-public:
   loco::Node *value(void) const { return at(0)->node(); }
   void value(loco::Node *node) { at(0)->node(node); }
 
+public:
   Padding padding() const { return _padding; }
   void padding(Padding padding) { _padding = padding; }
 
@@ -55,7 +51,7 @@ public:
   Stride *stride(void) { return &_stride; }
 
 private:
-  Padding _padding;
+  Padding _padding{Padding::UNDEFINED};
   Stride _stride;
   Filter _filter;
 };

--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleBCQFullyConnected.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleBCQFullyConnected.h
@@ -58,7 +58,7 @@ public:
   }
 
 private:
-  int32_t _weights_hidden_size = 0;
+  int32_t _weights_hidden_size{0};
 };
 
 } // namespace luci

--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleBCQGather.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleBCQGather.h
@@ -51,8 +51,8 @@ public:
   void input_hidden_size(int32_t input_hidden_size) { _input_hidden_size = input_hidden_size; }
 
 private:
-  int32_t _axis = 0;
-  int32_t _input_hidden_size = 0;
+  int32_t _axis{0};
+  int32_t _input_hidden_size{0};
 };
 
 } // namespace luci

--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleBatchMatMul.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleBatchMatMul.h
@@ -45,8 +45,8 @@ public:
   void adj_y(bool arg) { _adj_y = arg; }
 
 private:
-  bool _adj_x = false;
-  bool _adj_y = false;
+  bool _adj_x{false};
+  bool _adj_y{false};
 };
 
 } // namespace luci

--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleBidirectionalSequenceLSTM.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleBidirectionalSequenceLSTM.h
@@ -160,11 +160,11 @@ public:
   }
 
 private:
-  float _cell_clip = 0.0f;
-  float _proj_clip = 0.0f;
-  bool _merge_outputs = false;
-  bool _time_major = false;
-  bool _asymmetric_quantize_inputs = false;
+  float _cell_clip{0.0f};
+  float _proj_clip{0.0f};
+  bool _merge_outputs{false};
+  bool _time_major{false};
+  bool _asymmetric_quantize_inputs{false};
 };
 
 } // namespace luci

--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleConv2D.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleConv2D.h
@@ -57,7 +57,7 @@ public:
   Dilation *dilation(void) { return &_dilation; }
 
 private:
-  Padding _padding = Padding::UNDEFINED;
+  Padding _padding{Padding::UNDEFINED};
   Stride _stride;
   Dilation _dilation;
 };

--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleCustom.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleCustom.h
@@ -45,6 +45,7 @@ public:
   Node *inputs(uint32_t index) const { return at(index)->node(); }
   void inputs(uint32_t index, Node *node) { at(index)->node(node); }
 
+public:
   const std::vector<uint8_t> &custom_options(void) const { return _custom_options; }
   void custom_options(const std::vector<uint8_t> &custom_options)
   {

--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleDepthwiseConv2D.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleDepthwiseConv2D.h
@@ -62,9 +62,9 @@ public:
   Dilation *dilation(void) { return &_dilation; }
 
 private:
-  Padding _padding = Padding::UNDEFINED;
+  Padding _padding{Padding::UNDEFINED};
   Stride _stride;
-  int32_t _depth_multiplier = 0;
+  int32_t _depth_multiplier{0};
   Dilation _dilation;
 };
 

--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleFakeQuant.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleFakeQuant.h
@@ -49,10 +49,10 @@ public:
   void narrow_range(bool narrow_range) { _narrow_range = narrow_range; }
 
 private:
-  float _min = 0.0f;
-  float _max = 0.0f;
-  int32_t _num_bits = 0;
-  bool _narrow_range = false;
+  float _min{0.0f};
+  float _max{0.0f};
+  int32_t _num_bits{0};
+  bool _narrow_range{false};
 };
 
 } // namespace luci

--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleGather.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleGather.h
@@ -42,7 +42,7 @@ public:
   void axis(int32_t axis) { _axis = axis; }
 
 private:
-  int32_t _axis = 0;
+  int32_t _axis{0};
 };
 
 } // namespace luci

--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleInput.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleInput.h
@@ -41,7 +41,7 @@ public:
   bool indexed(void) const { return _index != -1; }
 
 private:
-  int64_t _index = -1; // Uninitialized
+  int64_t _index{-1}; // Uninitialized
 };
 
 } // namespace luci

--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleInstanceNorm.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleInstanceNorm.h
@@ -44,11 +44,12 @@ public:
   loco::Node *beta(void) const { return at(2)->node(); }
   void beta(loco::Node *node) { at(2)->node(node); }
 
+public:
   float epsilon() const { return _epsilon; }
   void epsilon(float epsilon) { _epsilon = epsilon; }
 
 private:
-  float _epsilon = 1e-05;
+  float _epsilon{1e-05};
 };
 
 } // namespace luci

--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleL2Pool2D.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleL2Pool2D.h
@@ -36,14 +36,10 @@ class CircleL2Pool2D final : public FixedArityNode<1, CircleNodeImpl<CircleOpcod
                              public CircleNodeMixin<CircleNodeTrait::FusedActFunc>
 {
 public:
-  CircleL2Pool2D() : _padding(Padding::UNDEFINED)
-  { /* empty */
-  }
-
-public:
   loco::Node *value(void) const { return at(0)->node(); }
   void value(loco::Node *node) { at(0)->node(node); }
 
+public:
   Padding padding() const { return _padding; }
   void padding(Padding padding) { _padding = padding; }
 
@@ -54,7 +50,7 @@ public:
   Stride *stride(void) { return &_stride; }
 
 private:
-  Padding _padding;
+  Padding _padding{Padding::UNDEFINED};
   Stride _stride;
   Filter _filter;
 };

--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleLeakyRelu.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleLeakyRelu.h
@@ -34,11 +34,12 @@ public:
   loco::Node *features(void) const { return at(0)->node(); }
   void features(loco::Node *node) { at(0)->node(node); }
 
+public:
   float alpha() const { return _alpha; }
   void alpha(float alpha) { _alpha = alpha; }
 
 private:
-  float _alpha = 0.2f;
+  float _alpha{0.2f};
 };
 
 } // namespace luci

--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleMaxPool2D.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleMaxPool2D.h
@@ -36,14 +36,10 @@ class CircleMaxPool2D final : public FixedArityNode<1, CircleNodeImpl<CircleOpco
                               public CircleNodeMixin<CircleNodeTrait::FusedActFunc>
 {
 public:
-  CircleMaxPool2D() : _padding(Padding::UNDEFINED)
-  { /* empty */
-  }
-
-public:
   loco::Node *value(void) const { return at(0)->node(); }
   void value(loco::Node *node) { at(0)->node(node); }
 
+public:
   Padding padding() const { return _padding; }
   void padding(Padding padding) { _padding = padding; }
 
@@ -54,7 +50,7 @@ public:
   Stride *stride(void) { return &_stride; }
 
 private:
-  Padding _padding;
+  Padding _padding{Padding::UNDEFINED};
   Stride _stride;
   Filter _filter;
 };

--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleMean.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleMean.h
@@ -42,7 +42,7 @@ public:
   void keep_dims(bool keep_dims) { _keep_dims = keep_dims; }
 
 private:
-  bool _keep_dims = false;
+  bool _keep_dims{false};
 };
 
 } // namespace luci

--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleOneHot.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleOneHot.h
@@ -48,7 +48,7 @@ public:
   void axis(int32_t axis) { _axis = axis; }
 
 private:
-  int32_t _axis = -1;
+  int32_t _axis{-1};
 };
 
 } // namespace luci

--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleOutput.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleOutput.h
@@ -44,7 +44,7 @@ public:
   void from(loco::Node *node) { at(0)->node(node); }
 
 private:
-  int64_t _index = -1; // Uninitialized
+  int64_t _index{-1}; // Uninitialized
 };
 
 /**

--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleReduceAny.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleReduceAny.h
@@ -42,7 +42,7 @@ public:
   void keep_dims(bool keep_dims) { _keep_dims = keep_dims; }
 
 private:
-  bool _keep_dims = false;
+  bool _keep_dims{false};
 };
 
 } // namespace luci

--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleReduceMax.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleReduceMax.h
@@ -42,7 +42,7 @@ public:
   void keep_dims(bool keep_dims) { _keep_dims = keep_dims; }
 
 private:
-  bool _keep_dims = false;
+  bool _keep_dims{false};
 };
 
 } // namespace luci

--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleReduceMin.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleReduceMin.h
@@ -42,7 +42,7 @@ public:
   void keep_dims(bool keep_dims) { _keep_dims = keep_dims; }
 
 private:
-  bool _keep_dims = false;
+  bool _keep_dims{false};
 };
 
 } // namespace luci

--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleReduceProd.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleReduceProd.h
@@ -42,7 +42,7 @@ public:
   void keep_dims(bool keep_dims) { _keep_dims = keep_dims; }
 
 private:
-  bool _keep_dims = false;
+  bool _keep_dims{false};
 };
 
 } // namespace luci

--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleResizeBilinear.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleResizeBilinear.h
@@ -38,6 +38,7 @@ public:
   loco::Node *size(void) const { return at(1)->node(); }
   void size(loco::Node *node) { at(1)->node(node); }
 
+public:
   bool align_corners() const { return _align_corners; }
   void align_corners(bool value) { _align_corners = value; }
 
@@ -45,8 +46,8 @@ public:
   void half_pixel_centers(bool value) { _half_pixel_centers = value; }
 
 private:
-  bool _align_corners = false;
-  bool _half_pixel_centers = false;
+  bool _align_corners{false};
+  bool _half_pixel_centers{false};
 };
 
 } // namespace luci

--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleResizeNearestNeighbor.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleResizeNearestNeighbor.h
@@ -38,11 +38,12 @@ public:
   loco::Node *size(void) const { return at(1)->node(); }
   void size(loco::Node *node) { at(1)->node(node); }
 
+public:
   bool align_corners() const { return _align_corners; }
   void align_corners(bool value) { _align_corners = value; }
 
 private:
-  bool _align_corners = false;
+  bool _align_corners{false};
 };
 
 } // namespace luci

--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleTranspose.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleTranspose.h
@@ -31,10 +31,7 @@ namespace luci
 class CircleTranspose final : public FixedArityNode<2, CircleNodeImpl<CircleOpcode::TRANSPOSE>>
 {
 public:
-  /// @brief Get the input node to transpose
   loco::Node *a(void) const { return at(0)->node(); }
-
-  /// @brief Set the input node to transpose
   void a(loco::Node *node) { at(0)->node(node); }
 
   loco::Node *perm(void) const { return at(1)->node(); }

--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleUnidirectionalSequenceLSTM.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleUnidirectionalSequenceLSTM.h
@@ -104,10 +104,10 @@ public:
   }
 
 private:
-  float _cell_clip = 0.0f;
-  float _proj_clip = 0.0f;
-  bool _time_major = false;
-  bool _asymmetric_quantize_inputs = false;
+  float _cell_clip{0.0f};
+  float _proj_clip{0.0f};
+  bool _time_major{false};
+  bool _asymmetric_quantize_inputs{false};
 };
 
 } // namespace luci

--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleZerosLike.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleZerosLike.h
@@ -31,10 +31,7 @@ namespace luci
 class CircleZerosLike final : public FixedArityNode<1, CircleNodeImpl<CircleOpcode::ZEROS_LIKE>>
 {
 public:
-  /// @brief Get the input node
   loco::Node *input(void) const { return at(0)->node(); }
-
-  /// @brief Set the input node
   void input(loco::Node *node) { at(0)->node(node); }
 };
 


### PR DESCRIPTION
This will tidy IR style as follows;
- use initialize with {...}
- remove initialize in CTOR
- remove unnecessary accessor comments
- insert public: keyword between input and attributes accessor

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>