### PR TITLE
[luci] Relocate clone_connect method

### DIFF
--- a/compiler/luci/partition/src/ConnectNode.cpp
+++ b/compiler/luci/partition/src/ConnectNode.cpp
@@ -21,6 +21,12 @@
 namespace luci
 {
 
+void clone_connect(const luci::CircleNode *node, luci::CloneContext &clonecontext)
+{
+  ConnectNode cn(clonecontext);
+  node->accept(&cn);
+}
+
 luci::CircleNode *ConnectNode::find_clone(const luci::CircleNode *node)
 {
   auto it = _clonecontext.find(node);

--- a/compiler/luci/partition/src/ConnectNode.h
+++ b/compiler/luci/partition/src/ConnectNode.h
@@ -199,6 +199,11 @@ protected:
   luci::CloneContext &_clonecontext;
 };
 
+/**
+ * @brief Connect cloned node from input node
+ */
+void clone_connect(const luci::CircleNode *node, luci::CloneContext &clonecontext);
+
 } // namespace luci
 
 #endif // __LUCI_PARTITION_CONNECT_NODE_H__

--- a/compiler/luci/partition/src/PartitionPModules.cpp
+++ b/compiler/luci/partition/src/PartitionPModules.cpp
@@ -76,15 +76,6 @@ void add_graph_output(loco::Graph *graph, luci::CircleOutput *output_node)
 }
 
 /**
- * @brief Connect cloned node from input node
- */
-void clone_connect(const luci::CircleNode *node, luci::CloneContext &clonecontext)
-{
-  luci::ConnectNode cn(clonecontext);
-  node->accept(&cn);
-}
-
-/**
  * @brief Build loco::graph from pgroup into graph
  */
 void build_graph(loco::Graph *graph, const luci::PGroup *pgroup)


### PR DESCRIPTION
This will relocate clone_connect method so that this method can be
called from other places.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>