### PR TITLE
[luci] Add num_inputs to TestIsGraphlet

### DIFF
--- a/compiler/luci/testhelper/include/luci/test/TestIOGraph.h
+++ b/compiler/luci/testhelper/include/luci/test/TestIOGraph.h
@@ -80,6 +80,7 @@ public:
 public:
   loco::Graph *g(void) { return _g.get(); }
   luci::CircleInput *input(int idx) { return _inputs[idx]; }
+  uint32_t num_inputs(void) { return N; }
 
 public:
   void transfer_to(luci::Module *module)


### PR DESCRIPTION
This will add num_inputs method to access number of inputs of TestIsGraphlet.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>