### PR TITLE
[luci] Introduce node graphlet create helper classes

### DIFF
--- a/compiler/luci/partition/src/ConnectNode.test.h
+++ b/compiler/luci/partition/src/ConnectNode.test.h
@@ -47,6 +47,38 @@ public:
   }
 };
 
+template <class T> class NodeGraphletT
+{
+public:
+  virtual void init(loco::Graph *g)
+  {
+    _node = g->nodes()->create<T>();
+    _node->dtype(loco::DataType::S32);
+    _node->name("node");
+  }
+
+  T *node(void) const { return _node; }
+
+protected:
+  T *_node{nullptr};
+};
+
+template <class T> class NodeIsGraphletT
+{
+public:
+  virtual void init(loco::Graph *g, uint32_t n)
+  {
+    _node = g->nodes()->create<T>(n);
+    _node->dtype(loco::DataType::S32);
+    _node->name("node");
+  }
+
+  T *node(void) const { return _node; }
+
+protected:
+  T *_node{nullptr};
+};
+
 } // namespace test
 } // namespace luci
 


### PR DESCRIPTION
This will introduce two helper classes NodeIsGraphletT and
NodeIsGraphletT that will create node graphlet that will provide one
input or arbitrary inputs.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>