### PR TITLE
[luci] Revise partition connect for nodes Add and others

### DIFF
--- a/compiler/luci/partition/src/Nodes/CircleAdd.cpp
+++ b/compiler/luci/partition/src/Nodes/CircleAdd.cpp
@@ -16,16 +16,25 @@
 
 #include "ConnectNode.h"
 
+namespace
+{
+
+void connect(luci::ConnectNode *cn, const luci::CircleAdd *node)
+{
+  auto *cloned = loco::must_cast<luci::CircleAdd *>(cn->find_clone(node));
+
+  luci::CircleNode *x = loco::must_cast<luci::CircleNode *>(node->x());
+  luci::CircleNode *y = loco::must_cast<luci::CircleNode *>(node->y());
+
+  cloned->x(cn->find_clone(x));
+  cloned->y(cn->find_clone(y));
+}
+
+} // namespace
+
 namespace luci
 {
 
-void ConnectNode::visit(const luci::CircleAdd *node)
-{
-  auto *cloned = loco::must_cast<luci::CircleAdd *>(find_clone(node));
-  luci::CircleNode *in_x = loco::must_cast<luci::CircleNode *>(node->x());
-  luci::CircleNode *in_y = loco::must_cast<luci::CircleNode *>(node->y());
-  cloned->x(find_clone(in_x));
-  cloned->y(find_clone(in_y));
-}
+void ConnectNode::visit(const luci::CircleAdd *node) { connect(this, node); }
 
 } // namespace luci

--- a/compiler/luci/partition/src/Nodes/CircleDiv.cpp
+++ b/compiler/luci/partition/src/Nodes/CircleDiv.cpp
@@ -16,16 +16,25 @@
 
 #include "ConnectNode.h"
 
+namespace
+{
+
+void connect(luci::ConnectNode *cn, const luci::CircleDiv *node)
+{
+  auto *cloned = loco::must_cast<luci::CircleDiv *>(cn->find_clone(node));
+
+  luci::CircleNode *x = loco::must_cast<luci::CircleNode *>(node->x());
+  luci::CircleNode *y = loco::must_cast<luci::CircleNode *>(node->y());
+
+  cloned->x(cn->find_clone(x));
+  cloned->y(cn->find_clone(y));
+}
+
+} // namespace
+
 namespace luci
 {
 
-void ConnectNode::visit(const luci::CircleDiv *node)
-{
-  auto *cloned = loco::must_cast<luci::CircleDiv *>(find_clone(node));
-  luci::CircleNode *in_x = loco::must_cast<luci::CircleNode *>(node->x());
-  luci::CircleNode *in_y = loco::must_cast<luci::CircleNode *>(node->y());
-  cloned->x(find_clone(in_x));
-  cloned->y(find_clone(in_y));
-}
+void ConnectNode::visit(const luci::CircleDiv *node) { connect(this, node); }
 
 } // namespace luci

--- a/compiler/luci/partition/src/Nodes/CircleMul.cpp
+++ b/compiler/luci/partition/src/Nodes/CircleMul.cpp
@@ -16,16 +16,25 @@
 
 #include "ConnectNode.h"
 
+namespace
+{
+
+void connect(luci::ConnectNode *cn, const luci::CircleMul *node)
+{
+  auto *cloned = loco::must_cast<luci::CircleMul *>(cn->find_clone(node));
+
+  luci::CircleNode *x = loco::must_cast<luci::CircleNode *>(node->x());
+  luci::CircleNode *y = loco::must_cast<luci::CircleNode *>(node->y());
+
+  cloned->x(cn->find_clone(x));
+  cloned->y(cn->find_clone(y));
+}
+
+} // namespace
+
 namespace luci
 {
 
-void ConnectNode::visit(const luci::CircleMul *node)
-{
-  auto *cloned = loco::must_cast<luci::CircleMul *>(find_clone(node));
-  luci::CircleNode *in_x = loco::must_cast<luci::CircleNode *>(node->x());
-  luci::CircleNode *in_y = loco::must_cast<luci::CircleNode *>(node->y());
-  cloned->x(find_clone(in_x));
-  cloned->y(find_clone(in_y));
-}
+void ConnectNode::visit(const luci::CircleMul *node) { connect(this, node); }
 
 } // namespace luci

--- a/compiler/luci/partition/src/Nodes/CircleSub.cpp
+++ b/compiler/luci/partition/src/Nodes/CircleSub.cpp
@@ -16,16 +16,25 @@
 
 #include "ConnectNode.h"
 
+namespace
+{
+
+void connect(luci::ConnectNode *cn, const luci::CircleSub *node)
+{
+  auto *cloned = loco::must_cast<luci::CircleSub *>(cn->find_clone(node));
+
+  luci::CircleNode *x = loco::must_cast<luci::CircleNode *>(node->x());
+  luci::CircleNode *y = loco::must_cast<luci::CircleNode *>(node->y());
+
+  cloned->x(cn->find_clone(x));
+  cloned->y(cn->find_clone(y));
+}
+
+} // namespace
+
 namespace luci
 {
 
-void ConnectNode::visit(const luci::CircleSub *node)
-{
-  auto *cloned = loco::must_cast<luci::CircleSub *>(find_clone(node));
-  luci::CircleNode *in_x = loco::must_cast<luci::CircleNode *>(node->x());
-  luci::CircleNode *in_y = loco::must_cast<luci::CircleNode *>(node->y());
-  cloned->x(find_clone(in_x));
-  cloned->y(find_clone(in_y));
-}
+void ConnectNode::visit(const luci::CircleSub *node) { connect(this, node); }
 
 } // namespace luci


### PR DESCRIPTION
This will revise partition connect method for nodes Add, Div, Mul and
Sub. Purpose of this revisit is to reduce class LOC of ConnectNode as it
will grow more than 500 lines.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>