### PR TITLE
[luci] Change public to find_connect method

### DIFF
--- a/compiler/luci/partition/src/ConnectNode.h
+++ b/compiler/luci/partition/src/ConnectNode.h
@@ -192,7 +192,7 @@ public:
   // void visit(const luci::CircleUnpackOut *) final;
   // void visit(const luci::CircleWhileOut *) final;
 
-protected:
+public:
   luci::CircleNode *find_clone(const luci::CircleNode *node);
 
 protected:


### PR DESCRIPTION
This will change scope public to find_connect method of ConnectNode
class.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>