### PR TITLE
[luci] prepare_inputs for TestIOGraph

### DIFF
--- a/compiler/luci/partition/src/ConnectNode.test.h
+++ b/compiler/luci/partition/src/ConnectNode.test.h
@@ -106,6 +106,19 @@ public:
   }
 
   /**
+   * @note although there is only one input, method name has 's' to make test simple
+   */
+  void prepare_inputs(TestIOGraph *isograph)
+  {
+    assert(1 == isograph->num_inputs());
+
+    auto *input = _graph_clone->nodes()->create<luci::CircleInput>();
+    luci::copy_common_attributes(isograph->input(), input);
+    _clonectx.emplace(isograph->input(), input);
+    _inputs.push_back(input);
+  }
+
+  /**
    * @note prepare_inputs_miss is for negative testing
    */
   template <unsigned N> void prepare_inputs_miss(TestIsOGraph<N> *isograph)
@@ -120,6 +133,16 @@ public:
         _clonectx.emplace(isograph->input(i), input);
       _inputs.push_back(input);
     }
+  }
+
+  void prepare_inputs_miss(TestIOGraph *isograph)
+  {
+    assert(1 == isograph->num_inputs());
+
+    auto *input = _graph_clone->nodes()->create<luci::CircleInput>();
+    luci::copy_common_attributes(isograph->input(), input);
+    // _clonectx.emplace() is NOT called on purpose
+    _inputs.push_back(input);
   }
 
   void clone_connect(luci::CircleNode *node, luci::CircleNode *clone)


### PR DESCRIPTION
This will introduce prepare_inputs and prepare_inputs_miss method for
TestIOGraph.
- although it's single input, has 's' to make test codes simple

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>