### PR TITLE
[luci] Add a helper function to QuantizedModelVerifier test

### DIFF
--- a/compiler/luci/pass/src/QuantizedModelVerifier.test.cpp
+++ b/compiler/luci/pass/src/QuantizedModelVerifier.test.cpp
@@ -127,6 +127,19 @@ void quantize_and_verify_with_wrong_type(luci::test::TestIOGraph *g, Type quanti
   verifier.verify(g->g());
 }
 
+void quantize_and_verify_with_wrong_type(luci::test::TestIOGraph *g, Type quantized_dtype,
+                                         Granularity granularity, Type wrong_dtype,
+                                         luci::CircleNode *target)
+{
+  luci::QuantizeWithMinMaxPass pass(Type::FLOAT32, quantized_dtype, granularity);
+  pass.run(g->g());
+
+  target->dtype(wrong_dtype);
+
+  luci::QuantizedModelVerifier verifier(quantized_dtype, granularity);
+  verifier.verify(g->g());
+}
+
 // Helper function to reduce duplicate test codes
 // Assumption: g->output()->from() is the target node
 void quantize_and_verify_with_wrong_granularity(luci::test::TestIOGraph *g, Type quantized_dtype,


### PR DESCRIPTION
This commit adds a helper function to test a quantized graph with wrong type.
Previously there was a function with the same name that tests verifier with wrongly typed output's from node.
This function tests verifier with wrongly typed user-given node.

ONE-DCO-1.0-Signed-off-by: Dayoung Lee <dayg502@gmail.com>

-----

From #6652