### PR TITLE
[luci] Add a helper macro to QuantizedModelVerifier test

### DIFF
--- a/compiler/luci/pass/src/QuantizedModelVerifier.test.cpp
+++ b/compiler/luci/pass/src/QuantizedModelVerifier.test.cpp
@@ -884,6 +884,18 @@ private:
     EXPECT_ANY_THROW(quantize_and_verify_with_wrong_granularity(&g, type, granularity)); \
   } while (0)
 
+// Quantize and verify with wrong type
+// Users can specify the test target
+#define TEST_WITH_WRONG_TYPE_TARGET(graph, type, granularity, wrong_dtype, target)    \
+  do                                                                                  \
+  {                                                                                   \
+    graph g;                                                                          \
+    g.init();                                                                         \
+    auto node = loco::must_cast<luci::CircleNode *>(target);                          \
+    EXPECT_ANY_THROW(                                                                 \
+      quantize_and_verify_with_wrong_type(&g, type, granularity, wrong_dtype, node)); \
+  } while (0)
+
 // Quantize and verify with wrong granularity
 // Users can specify the test target
 #define TEST_WITH_WRONG_GRANULARITY_TARGET(graph, type, granularity, target)                   \


### PR DESCRIPTION
This commit adds a helper macro to a SimpleTestGraph with wrong type node.
Unlike the existing function TEST_WITH_WRONG_TYPE, this macro enables users to specify
the node to be tested.

ONE-DCO-1.0-Signed-off-by: Dayoung Lee <dayg502@gmail.com>

----

For #6652