### PR TITLE
[luci] Rename Argmax QuantizedModelVerifier Test

### DIFF
--- a/compiler/luci/pass/src/QuantizedModelVerifier.test.cpp
+++ b/compiler/luci/pass/src/QuantizedModelVerifier.test.cpp
@@ -1132,7 +1132,7 @@ TEST(QuantizedModelVerifierTest, ArgMax)
   SUCCEED();
 }
 
-TEST(QuantizedModelVerifierTest, ArgMax_wrong_dimension_type_NEG)
+TEST(QuantizedModelVerifierTest, ArgMax_wrong_input_type_NEG)
 {
   TEST_WITH_WRONG_TYPE(ArgMaxTestGraph<Type::S32>, Type::U8, Granularity::LayerWise, Type::S16);
   TEST_WITH_WRONG_TYPE(ArgMaxTestGraph<Type::S32>, Type::U8, Granularity::ChannelWise, Type::S16);


### PR DESCRIPTION
This commit renames a test which targets an input node, not a dimension node.
Therefore the name is changed from 'ArgMax_wrong_dimension_type_NEG' to 'ArgMax_wrong_input_type_NEG'.

ONE-DCO-1.0-Signed-off-by: Dayoung Lee <dayg502@gmail.com>

----

From #6652