### PR TITLE
[luci] Add an ArgMax SimpleTestGraph dimension getter

### DIFF
--- a/compiler/luci/pass/src/QuantizedModelVerifier.test.cpp
+++ b/compiler/luci/pass/src/QuantizedModelVerifier.test.cpp
@@ -518,6 +518,7 @@ public:
 public:
   // NOTE: Do not override `luci::CircleNode* input(void)` incidentally
   loco::Node *input_argmax(void) { return _argmax->input(); }
+  loco::Node *dimension(void) { return _argmax->dimension(); }
 
 private:
   luci::CircleArgMax *_argmax = nullptr;


### PR DESCRIPTION
This commit adds an interface for getting argmax SimpleTestGraph dimension node

ONE-DCO-1.0-Signed-off-by: Dayoung Lee <dayg502@gmail.com>

----

Originated from #6657