### PR TITLE
[luci] Clone empty for OutputDummy and OutputExclude

### DIFF
--- a/compiler/luci/partition/src/ConnectNode.h
+++ b/compiler/luci/partition/src/ConnectNode.h
@@ -183,8 +183,8 @@ public:
   void visit(const luci::CircleNonMaxSuppressionV4Out *) final;
   void visit(const luci::CircleNonMaxSuppressionV5Out *) final;
   // void visit(const luci::CircleOutput *) final;
-  // void visit(const luci::CircleOutputDummy *) final;
-  // void visit(const luci::CircleOutputExclude *) final;
+  void visit(const luci::CircleOutputDummy *) final;
+  void visit(const luci::CircleOutputExclude *) final;
   void visit(const luci::CircleSplitOut *) final;
   void visit(const luci::CircleSplitVOut *) final;
   // void visit(const luci::CircleTopKV2Out *) final;

--- a/compiler/luci/partition/src/Nodes/CircleOutputDummy.cpp
+++ b/compiler/luci/partition/src/Nodes/CircleOutputDummy.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ConnectNode.h"
+
+namespace luci
+{
+
+void ConnectNode::visit(const luci::CircleOutputDummy *)
+{
+  // Nothing to do
+}
+
+} // namespace luci

--- a/compiler/luci/partition/src/Nodes/CircleOutputExclude.cpp
+++ b/compiler/luci/partition/src/Nodes/CircleOutputExclude.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ConnectNode.h"
+
+namespace luci
+{
+
+void ConnectNode::visit(const luci::CircleOutputExclude *)
+{
+  // Nothing to do
+}
+
+} // namespace luci


### PR DESCRIPTION
This will add empty connection for CircleOutputDummy and
CircleOutputExclude. These two has no inputs so doesn't
do any actions.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>