### PR TITLE
[circle-quantizer] Support quantization of PadV2

### DIFF
--- a/compiler/luci/pass/src/QuantizationUtils.h
+++ b/compiler/luci/pass/src/QuantizationUtils.h
@@ -44,6 +44,8 @@ uint32_t cal_offset(loco::TensorShape &dimension, uint32_t *indices);
 
 void propagate_concat_quantparam(luci::CircleConcatenation *concat, loco::DataType quant_type);
 
+void propagate_pad_v2_quantparam(luci::CirclePadV2 *pad_v2, loco::DataType quant_type);
+
 bool is_weights(CircleNode *node);
 
 bool is_quantized(const CircleNode *node);

--- a/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
+++ b/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
@@ -981,21 +981,10 @@ void quantize_const_inputs(luci::CircleNode *node, loco::DataType output_type)
       break;
 
     case luci::CircleOpcode::PADV2:
-      // Only the third input is quantized
+      // First and third constant inputs are quantized
       // Second input should not be quantized (e.g., paddings)
-      // Quant params propagated from output range to the input
-      input_node = node->arg(2);
-      const_node = dynamic_cast<luci::CircleConst *>(input_node);
-      if (const_node != nullptr && !is_quantized(const_node))
-      {
-        auto input = dynamic_cast<luci::CircleNode *>(node->arg(0));
-        assert(input->quantparam()->scale.size() == 1); // input scale's layer-wise
-
-        luci::quant_const_values(const_node, node->quantparam()->scale.at(0),
-                                 node->quantparam()->zerop.at(0), output_type);
-        luci::overwrite_quantparam(node, const_node);
-        luci::overwrite_quantparam(node, input);
-      }
+      // Quant params are propagated from output range to the non-constant input
+      propagate_pad_v2_quantparam(loco::must_cast<CirclePadV2 *>(node), output_type);
       break;
 
     default:
@@ -1091,6 +1080,73 @@ void propagate_concat_quantparam(luci::CircleConcatenation *concat, loco::DataTy
       overwrite_quantparam(concat, node);
     }
   }
+}
+
+/** BEFORE
+ *
+ *         [CircleNode] [CircleConst] [CircleConst]
+ *         (U8 qparam1)     (S32)       (FP32)
+ *                   \        |         /
+ *                    \       |        /
+ *                      [CirclePadV2]
+ *                       (U8 qparam2)
+ *
+ *  AFTER
+ *         [CircleNode] [CircleConst] [CircleConst]   [CircleConst] <- Dead node
+ *         (U8 qparam2)     (S32)      (U8 qparam2)       (FP32)
+ *                   \        |         /
+ *                    \       |        /
+ *                      [CirclePadV2]
+ *                       (U8 qparam2)
+ */
+void propagate_pad_v2_quantparam(luci::CirclePadV2 *pad_v2, loco::DataType quant_type)
+{
+  auto quant_input = [pad_v2, quant_type](void (CirclePadV2::*arg_setter)(loco::Node *),
+                                          uint32_t arg) {
+    auto node = loco::must_cast<luci::CircleNode *>(pad_v2->arg(arg));
+
+    // Quantize constant values
+    if (node->opcode() == luci::CircleOpcode::CIRCLECONST)
+    {
+      luci::CircleConst *const_node = loco::must_cast<luci::CircleConst *>(node);
+      if (is_quantized(const_node))
+        return;
+
+      if (const_node->dtype() != loco::DataType::FLOAT32)
+        throw std::runtime_error("Unsupported data type for constant input of PadV2 Op");
+
+      const auto pad_v2_qparam = pad_v2->quantparam();
+      if (pad_v2_qparam == nullptr)
+        throw std::runtime_error("quantparam of PadV2 is not found during propagation");
+
+      assert(pad_v2_qparam->scale.size() == 1);
+      const auto scaling_factor = pad_v2_qparam->scale.at(0);
+      const auto zerop = pad_v2_qparam->zerop.at(0);
+
+      auto new_const = luci::clone(const_node);
+      quant_const_values(new_const, scaling_factor, zerop, quant_type);
+      overwrite_quantparam(pad_v2, new_const);
+      (pad_v2->*arg_setter)(new_const);
+    }
+    // Subsequent PadV2 Ops quant params are not propagated
+    else if (node->opcode() == luci::CircleOpcode::PADV2)
+    {
+      return;
+    }
+    else
+    {
+      const auto succs = loco::succs(node);
+      if (succs.size() > 1)
+        return;
+
+      // Non-const input must have been quantized
+      assert(node->quantparam() != nullptr);
+      overwrite_quantparam(pad_v2, node);
+    }
+  };
+
+  quant_input(&CirclePadV2::input, 0);
+  quant_input(&CirclePadV2::constant_values, 2);
 }
 
 bool QuantizeWithMinMaxPass::run(loco::Graph *g)

--- a/compiler/luci/pass/src/QuantizedModelVerifier.test.cpp
+++ b/compiler/luci/pass/src/QuantizedModelVerifier.test.cpp
@@ -620,6 +620,34 @@ private:
   luci::CircleConst *_paddings = nullptr;
 };
 
+class PadV2TestGraph final : public SimpleTestGraph
+{
+public:
+  void init(void) override
+  {
+    TestIOGraph::init({32}, {32});
+    _paddings = g()->nodes()->create<luci::CircleConst>();
+    {
+      _paddings->dtype(Type::S32);
+    }
+    _constant_values = create_dummy_const<Type::FLOAT32>(g(), {1});
+    _pad = g()->nodes()->create<luci::CirclePadV2>();
+    {
+      _pad->input(input());
+      _pad->paddings(_paddings);
+      _pad->constant_values(_constant_values);
+    }
+    output()->from(_pad);
+
+    set_minmax_to_non_const(g(), -1, 1);
+  }
+
+private:
+  luci::CirclePadV2 *_pad = nullptr;
+  luci::CircleConst *_paddings = nullptr;
+  luci::CircleConst *_constant_values = nullptr;
+};
+
 class TransposeTestGraph final : public SimpleTestGraph
 {
 public:
@@ -1441,6 +1469,30 @@ TEST(QuantizedModelVerifierTest, Pad_wrong_granularity_NEG)
   TEST_WITH_WRONG_GRANULARITY(PadTestGraph, Type::U8, Granularity::LayerWise);
   TEST_WITH_WRONG_GRANULARITY(PadTestGraph, Type::U8, Granularity::ChannelWise);
   TEST_WITH_WRONG_GRANULARITY(PadTestGraph, Type::S16, Granularity::ChannelWise);
+  SUCCEED();
+}
+
+TEST(QuantizedModelVerifierTest, PadV2)
+{
+  TEST_WITH_GRAPH(PadV2TestGraph, Type::U8, Granularity::LayerWise);
+  TEST_WITH_GRAPH(PadV2TestGraph, Type::U8, Granularity::ChannelWise);
+  TEST_WITH_GRAPH(PadV2TestGraph, Type::S16, Granularity::ChannelWise);
+  SUCCEED();
+}
+
+TEST(QuantizedModelVerifierTest, PadV2_wrong_type_NEG)
+{
+  TEST_WITH_WRONG_TYPE(PadV2TestGraph, Type::U8, Granularity::LayerWise, Type::S16);
+  TEST_WITH_WRONG_TYPE(PadV2TestGraph, Type::U8, Granularity::ChannelWise, Type::S16);
+  TEST_WITH_WRONG_TYPE(PadV2TestGraph, Type::S16, Granularity::ChannelWise, Type::U8);
+  SUCCEED();
+}
+
+TEST(QuantizedModelVerifierTest, PadV2_wrong_granularity_NEG)
+{
+  TEST_WITH_WRONG_GRANULARITY(PadV2TestGraph, Type::U8, Granularity::LayerWise);
+  TEST_WITH_WRONG_GRANULARITY(PadV2TestGraph, Type::U8, Granularity::ChannelWise);
+  TEST_WITH_WRONG_GRANULARITY(PadV2TestGraph, Type::S16, Granularity::ChannelWise);
   SUCCEED();
 }
 

--- a/compiler/luci/pass/src/VerifyQuantizedNodeChannelWiseGranularity.h
+++ b/compiler/luci/pass/src/VerifyQuantizedNodeChannelWiseGranularity.h
@@ -139,6 +139,14 @@ private:
     return true;
   }
 
+  bool visit(const luci::CirclePadV2 *node)
+  {
+    RETURN_FALSE_UNLESS(is_lwq(node))
+    RETURN_FALSE_UNLESS(is_lwq(node->input()))
+    RETURN_FALSE_UNLESS(is_lwq(node->constant_values()))
+    return true;
+  }
+
   bool visit(const luci::CirclePRelu *node)
   {
     RETURN_FALSE_UNLESS(is_lwq(node))

--- a/compiler/luci/pass/src/VerifyQuantizedNodeLayerWiseGranularity.h
+++ b/compiler/luci/pass/src/VerifyQuantizedNodeLayerWiseGranularity.h
@@ -127,6 +127,14 @@ private:
     return true;
   }
 
+  bool visit(const luci::CirclePadV2 *node)
+  {
+    RETURN_FALSE_UNLESS(is_lwq(node))
+    RETURN_FALSE_UNLESS(is_lwq(node->input()))
+    RETURN_FALSE_UNLESS(is_lwq(node->constant_values()))
+    return true;
+  }
+
   bool visit(const luci::CirclePRelu *node)
   {
     RETURN_FALSE_UNLESS(is_lwq(node))

--- a/compiler/luci/pass/src/VerifyQuantizedNodeS16Type.h
+++ b/compiler/luci/pass/src/VerifyQuantizedNodeS16Type.h
@@ -101,6 +101,15 @@ private:
     return true;
   }
 
+  bool visit(const luci::CirclePadV2 *node)
+  {
+    RETURN_FALSE_UNLESS(has_type(node, Type::S16))
+    RETURN_FALSE_UNLESS(has_type(node->input(), Type::S16))
+    RETURN_FALSE_UNLESS(has_type(node->paddings(), Type::S32))
+    RETURN_FALSE_UNLESS(has_type(node->constant_values(), Type::S16))
+    return true;
+  }
+
   bool visit(const luci::CirclePRelu *node)
   {
     RETURN_FALSE_UNLESS(has_type(node, Type::S16))

--- a/compiler/luci/pass/src/VerifyQuantizedNodeU8Type.h
+++ b/compiler/luci/pass/src/VerifyQuantizedNodeU8Type.h
@@ -101,6 +101,15 @@ private:
     return true;
   }
 
+  bool visit(const luci::CirclePadV2 *node)
+  {
+    RETURN_FALSE_UNLESS(has_type(node, Type::U8))
+    RETURN_FALSE_UNLESS(has_type(node->input(), Type::U8))
+    RETURN_FALSE_UNLESS(has_type(node->paddings(), Type::S32))
+    RETURN_FALSE_UNLESS(has_type(node->constant_values(), Type::U8))
+    return true;
+  }
+
   bool visit(const luci::CirclePRelu *node)
   {
     RETURN_FALSE_UNLESS(has_type(node, Type::U8))


### PR DESCRIPTION
This commit adds support for quantization of PadV2.

Requires #6725 
For #6661 

ONE-DCO-1.0-Signed-off-by: Alexander Moiseev <a.moiseev@samsung.com>