### PR TITLE
[loco] Install header files

### DIFF
--- a/compiler/loco/CMakeLists.txt
+++ b/compiler/loco/CMakeLists.txt
@@ -14,6 +14,8 @@ target_link_libraries(loco PRIVATE nncc_common)
 target_link_libraries(loco PUBLIC nncc_coverage)
 # Q. HOW TO MAKE DEV PACKAGE(?)
 install(TARGETS loco DESTINATION lib)
+install(DIRECTORY include/ DESTINATION include
+        FILES_MATCHING PATTERN "*.h")
 
 if(NOT ENABLE_TEST)
   return()


### PR DESCRIPTION
This commit makes loco header files installed to `include` dir.

Related: #6726 
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>