### PR TITLE
[luci-interpreter] Install header files

### DIFF
--- a/compiler/luci-interpreter/src/CMakeLists.txt
+++ b/compiler/luci-interpreter/src/CMakeLists.txt
@@ -39,3 +39,5 @@ target_link_libraries(luci_interpreter
     PRIVATE nncc_common)
 
 install(TARGETS luci_interpreter DESTINATION lib)
+install(DIRECTORY include/ DESTINATION include
+        FILES_MATCHING PATTERN "*.h")


### PR DESCRIPTION
This commit makes luci-interpreter header files installed to `include`
dir.

Related: #6726
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>