### PR TITLE
[circle-tensordump] Install circle-tensordump

### DIFF
--- a/compiler/circle-tensordump/CMakeLists.txt
+++ b/compiler/circle-tensordump/CMakeLists.txt
@@ -21,3 +21,5 @@ target_link_libraries(circle-tensordump PRIVATE arser)
 target_link_libraries(circle-tensordump PRIVATE foder)
 target_link_libraries(circle-tensordump PRIVATE mio_circle)
 target_link_libraries(circle-tensordump PRIVATE safemain)
+
+install(TARGETS circle-tensordump DESTINATION bin)


### PR DESCRIPTION
This commit adds `install` command.

Related: #6717 
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>