### PR TITLE
[circledump] Install circledump

### DIFF
--- a/compiler/circledump/CMakeLists.txt
+++ b/compiler/circledump/CMakeLists.txt
@@ -12,3 +12,5 @@ target_link_libraries(circledump arser)
 target_link_libraries(circledump mio_circle)
 target_link_libraries(circledump safemain)
 target_link_libraries(circledump flatbuffers)
+
+install(TARGETS circledump DESTINATION bin)


### PR DESCRIPTION
This commit adds `install` command.

Related: #6717 
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>