### PR TITLE
[foder] Do not delete move members

### DIFF
--- a/compiler/foder/include/foder/FileLoader.h
+++ b/compiler/foder/include/foder/FileLoader.h
@@ -33,7 +33,7 @@ public:
 
 public:
   FileLoader(const FileLoader &) = delete;
-  FileLoader(FileLoader &&) = delete;
+  FileLoader &operator=(const FileLoader &) = delete;
 
 public:
   DataBuffer load(void) const


### PR DESCRIPTION
This commit removes `delete` keyword of move members.

I just wanted the class to be not copyable. Turns out that move members shouldn't be deleted at any conditions.

For more details, please refer to https://stackoverflow.com/a/38820178/8741151.
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>