### PR TITLE
[circlechef] Add STRING TensorType in proto

### DIFF
--- a/compiler/circlechef/proto/circlechef.proto
+++ b/compiler/circlechef/proto/circlechef.proto
@@ -18,6 +18,7 @@ enum TensorType {
   INT32 = 2;
   UINT8 = 3;
   INT64 = 4;
+  STRING = 5;
   BOOL = 6;
   INT16 = 7;
 }


### PR DESCRIPTION
This will introduce STRING TensorType in proto file.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>