### PR TITLE
[circle-tensordump] link hdf5 with static

### DIFF
--- a/compiler/circle-tensordump/CMakeLists.txt
+++ b/compiler/circle-tensordump/CMakeLists.txt
@@ -2,7 +2,7 @@ if(NOT TARGET mio_circle)
   return()
 endif(NOT TARGET mio_circle)
 
-nnas_find_package(HDF5 QUIET)
+nnas_find_package(HDF5 COMPONENTS STATIC QUIET)
 
 if(NOT HDF5_FOUND)
   message(STATUS "Build circle-tensordump: FAILED (missing HDF5)")


### PR DESCRIPTION
This commit changes the way hdf5 is linked to static.

Related: #6760 
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>