### PR TITLE
[debian] Add circle-tensordump to one-compiler-dev

### DIFF
--- a/debian/one-compiler-dev.install
+++ b/debian/one-compiler-dev.install
@@ -1,5 +1,6 @@
 # {FILES_TO_INSTALL} {DEST_DIR}
 # bin
 usr/bin/circledump usr/local/share/one/bin/
+usr/bin/circle-tensordump usr/local/share/one/bin/
 # include
 usr/include/* usr/local/share/one/include/


### PR DESCRIPTION
This commit adds `circle-tensordump` to `one-compiler-dev` package.

Related: #6717 
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>