### PR TITLE
[res] Add_STR recipes for luci testing

### DIFF
--- a/res/TensorFlowLiteRecipes/Add_STR_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/Add_STR_000/test.recipe
@@ -1,0 +1,33 @@
+# This is test for import/export of STRING tensortype
+# interpreter or runtime may fail as Add won't support this
+
+operand {
+  name: "ifm"
+  type: STRING
+  shape { }
+}
+operand {
+  name: "suffix"
+  type: STRING
+  shape { }
+  filler {
+    tag: "explicit"
+    arg: "Hello"
+  }
+}
+operand {
+  name: "ofm"
+  type: STRING
+  shape { }
+}
+operation {
+  type: "Add"
+  input: "ifm"
+  input: "suffix"
+  output: "ofm"
+  add_options {
+    activation: NONE
+  }
+}
+input: "ifm"
+output: "ofm"

--- a/res/TensorFlowLiteRecipes/Add_STR_001/test.recipe
+++ b/res/TensorFlowLiteRecipes/Add_STR_001/test.recipe
@@ -1,0 +1,34 @@
+# This is test for import/export of STRING tensortype
+# interpreter or runtime may fail as Add won't support this
+
+operand {
+  name: "ifm"
+  type: STRING
+  shape { }
+}
+operand {
+  name: "suffix"
+  type: STRING
+  shape { dim: 2 }
+  filler {
+    tag: "explicit"
+    arg: "Hello"
+    arg: "World"
+  }
+}
+operand {
+  name: "ofm"
+  type: STRING
+  shape { }
+}
+operation {
+  type: "Add"
+  input: "ifm"
+  input: "suffix"
+  output: "ofm"
+  add_options {
+    activation: NONE
+  }
+}
+input: "ifm"
+output: "ofm"


### PR DESCRIPTION
This will add introduce Add_STR_000 and Add_STR_001 recipes for luci
import/export testing with STRING TensorType.
- "Add" Op with STRING is not supported in any current backends

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>