### PR TITLE
[luci] Support STRING in Const

### DIFF
--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleConst.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleConst.h
@@ -44,6 +44,8 @@ public:
 
 private:
   std::vector<uint8_t> _data;
+  // TODO use _data for STRING and remove _strings
+  std::vector<std::string> _strings; // for STRING type
 };
 
 } // namespace luci

--- a/compiler/luci/lang/src/Nodes/CircleConst.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleConst.cpp
@@ -80,4 +80,48 @@ INSTANTIATE(loco::DataType::BOOL);
 
 #undef INSTANTIATE
 
+// CircleConst implementations for loco::DataType::STRING
+
+template <> uint32_t CircleConst::size<loco::DataType::STRING>(void) const
+{
+  assert(dtype() == loco::DataType::STRING);
+  assert(_data.size() == 0);
+  return _strings.size();
+}
+
+template <> void CircleConst::size<loco::DataType::STRING>(uint32_t l)
+{
+  assert(dtype() == loco::DataType::STRING);
+  assert(_data.size() == 0);
+  _strings.resize(l);
+}
+
+template <> const std::string &CircleConst::at<loco::DataType::STRING>(uint32_t n) const
+{
+  assert(dtype() == loco::DataType::STRING);
+  assert(n < _strings.size());
+  return _strings.at(n);
+}
+
+template <> std::string &CircleConst::at<loco::DataType::STRING>(uint32_t n)
+{
+  assert(dtype() == loco::DataType::STRING);
+  assert(n < _strings.size());
+  return _strings.at(n);
+}
+
+template <> const std::string &CircleConst::scalar<loco::DataType::STRING>(void) const
+{
+  assert(dtype() == loco::DataType::STRING);
+  assert(1 == _strings.size());
+  return _strings.at(0);
+}
+
+template <> std::string &CircleConst::scalar<loco::DataType::STRING>(void)
+{
+  assert(dtype() == loco::DataType::STRING);
+  assert(1 == _strings.size());
+  return _strings.at(0);
+}
+
 } // namespace luci

--- a/compiler/luci/lang/src/Nodes/CircleConst.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleConst.test.cpp
@@ -51,3 +51,16 @@ TEST(CircleConstTest, scalar)
   auto const &cs = const_node.scalar<loco::DataType::S32>();
   ASSERT_EQ(1, cs);
 }
+
+TEST(CircleConstTest, string)
+{
+  luci::CircleConst const_node;
+
+  const_node.dtype(loco::DataType::STRING);
+  const_node.size<loco::DataType::STRING>(1);
+  const_node.at<loco::DataType::STRING>(0) = std::string("Hello");
+
+  ASSERT_EQ(loco::DataType::STRING, const_node.dtype());
+  ASSERT_EQ(1, const_node.size<loco::DataType::STRING>());
+  EXPECT_TRUE(std::string("Hello") == const_node.at<loco::DataType::STRING>(0));
+}


### PR DESCRIPTION
This will enable support of STRING TensorType for CircleConst.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>