### PR TITLE
[luci] Revise CircleCustom to have 0 in, 0 out

### DIFF
--- a/compiler/luci/import/src/GraphBuilderMultiOutput.cpp
+++ b/compiler/luci/import/src/GraphBuilderMultiOutput.cpp
@@ -60,7 +60,8 @@ CircleNode *GraphBuilderMultiOutput::build(const circle::OperatorT &op,
   auto *node = build_node(bna);
 
   uint32_t output_count = outputs.size();
-  assert(output_count > 0);
+  // NOTE CustomOp inherits GraphBuilderMultiOutput and can have 0 output
+  if (output_count > 0)
   {
     // Let's use attributes from output 0 for this node
     const circle::TensorT &output_tensor = *tensors[outputs[0]];

--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleCustom.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleCustom.h
@@ -32,9 +32,8 @@ public:
   CircleCustom(uint32_t arity, uint32_t out)
     : VariadicArityNode<CircleNodeImpl<CircleOpcode::CUSTOM>>(arity), _output_count(out)
   {
-    // TODO Support when arity is 0
-    assert(arity >= 1);
-    assert(out > 0);
+    // NOTE Custom can have 0 input or 0 output but not both
+    assert(arity != 0 || out != 0);
   }
 
 public:


### PR DESCRIPTION
This will revise CircleCustom to have 0 input or 0 output but not both.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>