### PR TITLE
[common-artifacts] Remove exclude item for STRING

### DIFF
--- a/compiler/common-artifacts/exclude.lst
+++ b/compiler/common-artifacts/exclude.lst
@@ -6,8 +6,6 @@
 #[[ optimize : Exclude from circle optimization(circle2circle) ]]
 ## TensorFlowLiteRecipes
 optimize(UnidirectionalSequenceLSTM_001) # This recipe contains is_variable Tensor
-optimize(Add_STR_000) # remove this after luci import/export supports STRING TensorType
-optimize(Add_STR_001) # remove this after luci import/export supports STRING TensorType
 
 ## CircleRecipes
 


### PR DESCRIPTION
This will remove exclude item for STRING TensorType of circle2circle
optimization test.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>