### PR TITLE
[one-cmds] Upgrade venv onnx-tf to 1.8.0

### DIFF
--- a/compiler/one-cmds/CMakeLists.txt
+++ b/compiler/one-cmds/CMakeLists.txt
@@ -38,6 +38,7 @@ endforeach(ONE_COMMAND)
 set(ONE_UTILITY_FILES
     one-build.template.cfg
     utils.py
+    conv_mixin_1.8.0.patch
 )
 
 foreach(ONE_UTILITY IN ITEMS ${ONE_UTILITY_FILES})

--- a/compiler/one-cmds/conv_mixin_1.8.0.patch
+++ b/compiler/one-cmds/conv_mixin_1.8.0.patch
@@ -1,0 +1,11 @@
+--- a/onnx_tf/handlers/backend/conv_mixin.py
++++ b/onnx_tf/handlers/backend/conv_mixin.py
+@@ -98,7 +98,7 @@
+     depthwise = (x_rank == 4 and len(weight_shape) == 4 and group != 1 and
+                  not transpose and not (None in weight_shape))
+     if depthwise and isinstance(x_shape, np.ndarray):
+-      depthwise = group == x_shape[1]
++      depthwise = bool(group == x_shape[1])
+ 
+     if depthwise is True:
+       # Depthwise convolution.

--- a/compiler/one-cmds/one-prepare-venv
+++ b/compiler/one-cmds/one-prepare-venv
@@ -46,7 +46,7 @@ fi
 
 VER_TENSORFLOW=2.3.0
 VER_ONNX=1.8.0
-VER_ONNX_TF=1.7.0
+VER_ONNX_TF=1.8.0
 
 # Install tensorflow
 source "${VENV_ACTIVATE}"
@@ -80,3 +80,17 @@ fi
 # Create python symoblic link
 rm -f ${DRIVER_PATH}/python
 ln -s venv/bin/python ${DRIVER_PATH}/python
+
+# TODO remove this patch after onnx-tf next release
+# apply patch for DWConv conversion bug: https://github.com/onnx/onnx-tensorflow/pull/905
+if [[ -z "${EXT_ONNX_TF_WHL}" ]]; then
+  PY_SITE_PACKAGES=$(python -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')
+  if [[ -d ${PY_SITE_PACKAGES} ]]; then
+    pushd ${PY_SITE_PACKAGES} > /dev/null
+    PATCH_TARGET_FILE=onnx_tf/handlers/backend/conv_mixin.py
+    if [[ -f "${PATCH_TARGET_FILE}" ]]; then
+      patch -t -p1 < ${DRIVER_PATH}/conv_mixin_1.8.0.patch
+    fi
+    popd > /dev/null
+  fi
+fi


### PR DESCRIPTION
This will upgrade venv onnx-tf to 1.8.0 with a minor patch for
DepthwiseConv2D conversion.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>