### PR TITLE
[luci] Introduce RemoveFakeQuantPass

### DIFF
--- a/compiler/luci/pass/include/luci/Pass/RemoveFakeQuantPass.h
+++ b/compiler/luci/pass/include/luci/Pass/RemoveFakeQuantPass.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __LUCI_REMOVE_FAKEQUANT_PASS_H__
+#define __LUCI_REMOVE_FAKEQUANT_PASS_H__
+
+#include <logo/Pass.h>
+
+namespace luci
+{
+
+/**
+ * @brief  Class to Remove FakeQuant node.
+ */
+struct RemoveFakeQuantPass final : public logo::Pass
+{
+  const char *name(void) const final { return "luci::RemoveFakeQuantPass"; }
+
+  bool run(loco::Graph *g) final;
+};
+
+} // namespace luci
+
+#endif // __LUCI_REMOVE_FAKEQUANT_PASS_H__

--- a/compiler/luci/pass/src/RemoveFakeQuantPass.cpp
+++ b/compiler/luci/pass/src/RemoveFakeQuantPass.cpp
@@ -23,10 +23,10 @@ namespace
 
 bool remove_fake_quant(luci::CircleFakeQuant *fakequant)
 {
-  if (fakequant == nullptr)
-    return false;
+  assert(fakequant != nullptr);
 
   auto input_node = loco::must_cast<luci::CircleNode *>(fakequant->inputs());
+
   replace(fakequant).with(input_node);
 
   return true;

--- a/compiler/luci/pass/src/RemoveFakeQuantPass.cpp
+++ b/compiler/luci/pass/src/RemoveFakeQuantPass.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Pass/RemoveFakeQuantPass.h"
+
+#include <luci/IR/CircleNodes.h>
+
+namespace
+{
+
+bool remove_fake_quant(luci::CircleFakeQuant *fakequant)
+{
+  if (fakequant == nullptr)
+    return false;
+
+  auto input_node = loco::must_cast<luci::CircleNode *>(fakequant->inputs());
+  replace(fakequant).with(input_node);
+
+  return true;
+}
+
+} // namespace
+
+namespace luci
+{
+/**
+ * BEFORE
+ *
+ *    [CircleNode]
+ *          |
+ *    [CircleFakeQuant]
+ *          |
+ *    [CircleNode]
+ *
+ * AFTER
+ *
+ *    [CircleNode]
+ *          |
+ *    [CircleNode]   [CircleFakeQuant]
+ *
+ * CircleFakeQuant OP will be removed from the output graph
+ */
+bool RemoveFakeQuantPass::run(loco::Graph *g)
+{
+  bool changed = false;
+  for (auto node : loco::active_nodes(loco::output_nodes(g)))
+  {
+    auto target_node = dynamic_cast<luci::CircleFakeQuant *>(node);
+    if (target_node != nullptr)
+      if (remove_fake_quant(target_node))
+        changed = true;
+  }
+  return changed;
+}
+
+} // namespace luci

--- a/compiler/luci/pass/src/RemoveFakeQuantPass.cpp
+++ b/compiler/luci/pass/src/RemoveFakeQuantPass.cpp
@@ -21,15 +21,13 @@
 namespace
 {
 
-bool remove_fake_quant(luci::CircleFakeQuant *fakequant)
+void remove_fake_quant(luci::CircleFakeQuant *fakequant)
 {
   assert(fakequant != nullptr);
 
   auto input_node = loco::must_cast<luci::CircleNode *>(fakequant->inputs());
 
   replace(fakequant).with(input_node);
-
-  return true;
 }
 
 } // namespace
@@ -60,8 +58,10 @@ bool RemoveFakeQuantPass::run(loco::Graph *g)
   {
     auto target_node = dynamic_cast<luci::CircleFakeQuant *>(node);
     if (target_node != nullptr)
-      if (remove_fake_quant(target_node))
-        changed = true;
+    {
+      remove_fake_quant(target_node);
+      changed = true;
+    }
   }
   return changed;
 }

--- a/compiler/luci/pass/src/RemoveFakeQuantPass.test.cpp
+++ b/compiler/luci/pass/src/RemoveFakeQuantPass.test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/compiler/luci/pass/src/RemoveFakeQuantPass.test.cpp
+++ b/compiler/luci/pass/src/RemoveFakeQuantPass.test.cpp
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Pass/RemoveFakeQuantPass.h"
+
+#include <luci/IR/CircleNodes.h>
+
+#include <luci/test/TestIOGraph.h>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+
+using namespace luci::test;
+
+class FakeQuantGraphlet
+{
+public:
+  FakeQuantGraphlet() = default;
+
+public:
+  void init(loco::Graph *g)
+  {
+    _fq = g->nodes()->create<luci::CircleFakeQuant>();
+    _fq->name("fq");
+  }
+
+protected:
+  luci::CircleFakeQuant *_fq = nullptr;
+};
+
+class FakeQuantGraph : public TestIOGraph, public FakeQuantGraphlet
+{
+public:
+  FakeQuantGraph() = default;
+
+public:
+  void init(void)
+  {
+    TestIOGraph::init({1}, {1});
+    FakeQuantGraphlet::init(g());
+
+    _fq->inputs(input());
+
+    output()->from(_fq);
+  }
+};
+
+} // namespace
+
+TEST(RemoveFakeQuantPass, name)
+{
+  luci::RemoveFakeQuantPass pass;
+  auto const name = pass.name();
+  ASSERT_NE(nullptr, name);
+}
+
+TEST(RemoveFakeQuantPass, remove_fakequant)
+{
+  FakeQuantGraph g;
+  luci::RemoveFakeQuantPass pass;
+
+  g.init();
+
+  EXPECT_TRUE(pass.run(g.g()));
+
+  auto *node1 = loco::must_cast<luci::CircleNode *>(g.output()->from());
+  auto *node2 = loco::must_cast<luci::CircleNode *>(g.input());
+  EXPECT_EQ(node1, node2);
+}


### PR DESCRIPTION
This will introduce RemoveFakeQuantPass that will remove all FakeQuant
Ops in the graph.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>