### PR TITLE
[luci] Quantize Ops with an integer output

### DIFF
--- a/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
+++ b/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
@@ -590,6 +590,17 @@ struct QuantizeActivation final : public luci::CircleNodeMutableVisitor<bool>
           circle_node->dtype(loco::DataType::S16);
         }
 
+        // The output of these Ops should be integer, so scale should be integer
+        // TODO Handle cases where the integer scale needs to be propagated
+        if (circle_node->opcode() == CircleOpcode::FLOOR ||
+            circle_node->opcode() == CircleOpcode::FLOOR_DIV ||
+            circle_node->opcode() == CircleOpcode::FLOOR_MOD ||
+            circle_node->opcode() == CircleOpcode::CEIL)
+        {
+          assert(scaling_factor >= 0); // FIX_ME_UNLESS
+          scaling_factor = scaling_factor < 1 ? 1.0f : std::round(scaling_factor);
+        }
+
         circle_node->quantparam()->min.clear();
         circle_node->quantparam()->max.clear();
         circle_node->quantparam()->scale.push_back(scaling_factor);

--- a/compiler/luci/pass/src/VerifyQuantizedNodeS16Type.h
+++ b/compiler/luci/pass/src/VerifyQuantizedNodeS16Type.h
@@ -19,6 +19,8 @@
 #include <luci/IR/CircleNodes.h>
 #include <luci/IR/CircleNodeVisitor.h>
 
+#include <cmath>
+
 using Type = loco::DataType;
 
 // This macro is undef at the end of the file
@@ -308,6 +310,9 @@ private:
   {
     RETURN_FALSE_UNLESS(has_type(node, Type::S16))
     RETURN_FALSE_UNLESS(has_type(node->x(), Type::S16))
+
+    // This checks the value of scale is an integer
+    RETURN_FALSE_UNLESS(std::roundf(node->quantparam()->scale[0]) == node->quantparam()->scale[0]);
     return true;
   }
 
@@ -340,6 +345,9 @@ private:
     RETURN_FALSE_UNLESS(has_type(node, Type::S16))
     RETURN_FALSE_UNLESS(has_type(node->x(), Type::S16))
     RETURN_FALSE_UNLESS(has_type(node->y(), Type::S16))
+
+    // This checks the value of scale is an integer
+    RETURN_FALSE_UNLESS(std::roundf(node->quantparam()->scale[0]) == node->quantparam()->scale[0]);
     return true;
   }
 

--- a/compiler/luci/pass/src/VerifyQuantizedNodeU8Type.h
+++ b/compiler/luci/pass/src/VerifyQuantizedNodeU8Type.h
@@ -19,6 +19,8 @@
 #include <luci/IR/CircleNodes.h>
 #include <luci/IR/CircleNodeVisitor.h>
 
+#include <cmath>
+
 using Type = loco::DataType;
 
 // This macro is undef at the end of the file
@@ -308,6 +310,9 @@ private:
   {
     RETURN_FALSE_UNLESS(has_type(node, Type::U8))
     RETURN_FALSE_UNLESS(has_type(node->x(), Type::U8))
+
+    // This checks the value of scale is an integer
+    RETURN_FALSE_UNLESS(std::roundf(node->quantparam()->scale[0]) == node->quantparam()->scale[0]);
     return true;
   }
 
@@ -340,6 +345,9 @@ private:
     RETURN_FALSE_UNLESS(has_type(node, Type::U8))
     RETURN_FALSE_UNLESS(has_type(node->x(), Type::U8))
     RETURN_FALSE_UNLESS(has_type(node->y(), Type::U8))
+
+    // This checks the value of scale is an integer
+    RETURN_FALSE_UNLESS(std::roundf(node->quantparam()->scale[0]) == node->quantparam()->scale[0]);
     return true;
   }
 


### PR DESCRIPTION
This sets scale to integer for Ops with integer output.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/6804