### PR TITLE
[common-artifacts] Exclude Net_Conv_FakeQuant_000

### DIFF
--- a/compiler/common-artifacts/exclude.lst
+++ b/compiler/common-artifacts/exclude.lst
@@ -76,6 +76,7 @@ tcgenerate(MirrorPad_000)
 tcgenerate(Mul_U8_000)
 tcgenerate(Neg_000)
 tcgenerate(Net_BroadcastTo_AddV2_001) # luci-interpreter doesn't support custom operator
+tcgenerate(Net_Conv_FakeQuant_000) # luci-interpreter doesn't support FakeQuant yet
 tcgenerate(Net_Dangle_001)
 tcgenerate(Net_ZeroDim_001) # luci-interpreter doesn't support zero dim
 tcgenerate(OneHot_000)


### PR DESCRIPTION
This will exclude Net_Conv_FakeQuant_000 test data generation.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>