### PR TITLE
[one-cmds] Enable remove_fakequant

### DIFF
--- a/compiler/one-cmds/how-to-use-one-commands.txt
+++ b/compiler/one-cmds/how-to-use-one-commands.txt
@@ -171,6 +171,7 @@ Current transformation options are
   So, use it only when the impact is known to be acceptable.
 - mute_warnings : This will turn off warning messages.
 - generate_profile_data : This will turn on profiling data generation.
+- remove_fakequant : This will remove all fakequant operators.
 - remove_redundant_reshape : This fuses or removes redundant reshape operators.
 - remove_redundant_transpose : This fuses or removes redundant transpose operators.
 - remove_unnecessary_reshape : This removes unnecessary reshape operators.

--- a/compiler/one-cmds/utils.py
+++ b/compiler/one-cmds/utils.py
@@ -53,6 +53,7 @@ class _CONSTANT:
         ('fuse_instnorm', 'fuse ops to InstanceNorm operator'),
         ('replace_cw_mul_add_with_depthwise_conv',
          'replace channel-wise Mul/Add with DepthwiseConv2D'),
+        ('remove_fakequant', 'remove FakeQuant ops'),
         ('remove_redundant_reshape', 'fuse or remove subsequent Reshape ops'),
         ('remove_redundant_transpose', 'fuse or remove subsequent Transpose ops'),
         ('remove_unnecessary_reshape', 'remove unnecessary reshape ops'),


### PR DESCRIPTION
This will enable remove_fakequant option to remove FakeQuant Ops.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>