### PR TITLE
[debian] install luci-eval-driver

### DIFF
--- a/debian/one-compiler.install
+++ b/debian/one-compiler.install
@@ -5,6 +5,7 @@ usr/bin/circle_partitioner usr/share/one/bin/
 usr/bin/circle-quantizer usr/share/one/bin/
 usr/bin/generate_bcq_metadata.py usr/share/one/bin/
 usr/bin/generate_bcq_output_arrays.py usr/share/one/bin/
+usr/bin/luci_eval_driver usr/share/one/bin/
 usr/bin/one-build usr/share/one/bin/
 usr/bin/one-build.template.cfg usr/share/one/bin/
 usr/bin/one-codegen usr/share/one/bin/


### PR DESCRIPTION
This commit installs luci-eval-driver.

Signed-off-by: seongwoo <mhs4670go@naver.com>