### PR TITLE
[infra] Ignore debian/rules permission checking

### DIFF
--- a/infra/command/format
+++ b/infra/command/format
@@ -109,7 +109,8 @@ function check_permission() {
   FILES_TO_CHECK_PERMISSION=()
   for f in ${FILES_TO_CHECK[@]}; do
     # Manually ignore permission checking
-    if [[ ${f} == !(nnas|nnfw|nncc|*.sh|*.py|*/gradlew) ]] || [[ ${f} == tests/nnapi/specs/**/*.py ]]; then
+    if [[ ${f} == !(nnas|nnfw|nncc|*.sh|*.py|*/gradlew|debian/rules) ]] \
+	    || [[ ${f} == tests/nnapi/specs/**/*.py ]]; then
       FILES_TO_CHECK_PERMISSION+=("${f}")
     fi
   done


### PR DESCRIPTION
This commit ignores debian/rules permission checking.

`rules` file should have execute permission for package building.
Signed-off-by: seongwoo <mhs4670go@naver.com>