### PR TITLE
[debian] Relocate dh_install command

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -14,6 +14,6 @@ override_dh_auto_install:
 	cmake --build "$(NNAS_BUILD_PREFIX)/nncc" -- install
 
 override_dh_install:
-	dh_install
 	install -t "$(_DESTDIR)/bin" -D "tools/nnpackage_tool/model2nnpkg/model2nnpkg.sh"
 	install -T -m 755 -D "infra/packaging/res/tf2nnpkg.${PRESET}" "$(_DESTDIR)/bin/tf2nnpkg"
+	dh_install


### PR DESCRIPTION
This commit relocates dh_install command. `dh_install` should be run at the end.

Signed-off-by: seongwoo <mhs4670go@naver.com>