### PR TITLE
[debian] Fix install list

### DIFF
--- a/debian/one-compiler-test.install
+++ b/debian/one-compiler-test.install
@@ -1,3 +1,5 @@
 # {FILES_TO_INSTALL} {DEST_DIR}
+# bin
+usr/bin/luci_eval_driver usr/share/one/bin/
 # test
 usr/test/* usr/share/one/test/

--- a/debian/one-compiler.install
+++ b/debian/one-compiler.install
@@ -6,7 +6,6 @@ usr/bin/circle-quantizer usr/share/one/bin/
 usr/bin/conv_mixin_1.8.0.patch usr/share/one/bin/
 usr/bin/generate_bcq_metadata.py usr/share/one/bin/
 usr/bin/generate_bcq_output_arrays.py usr/share/one/bin/
-usr/bin/luci_eval_driver usr/share/one/bin/
 usr/bin/model2nnpkg.sh usr/share/one/bin/
 usr/bin/one-build usr/share/one/bin/
 usr/bin/one-build.template.cfg usr/share/one/bin/


### PR DESCRIPTION
This commit removes `luci_eval_driver` from one-compiler.install list.

Signed-off-by: seongwoo <mhs4670go@naver.com>