### PR TITLE
[circle-tensordump] Fix static warnings

### DIFF
--- a/compiler/circle-tensordump/src/Dump.cpp
+++ b/compiler/circle-tensordump/src/Dump.cpp
@@ -228,7 +228,7 @@ std::vector<hsize_t> hdf5_dims_cast(const flatbuffers::Vector<T> *data,
       ret.resize(rank);
       for (uint32_t d = 0; d < rank; d++)
       {
-        ret.at(d) = dims->Get(d);
+        ret.at(d) = static_cast<hsize_t>(dims->Get(d));
       }
     }
   }
@@ -305,6 +305,13 @@ void DumpTensorsToHdf5::run(std::ostream &os, const circle::Model *model,
     auto tensors = reader.tensors();
     for (const auto &tensor : *tensors)
     {
+      // If tensor does not have name, do nothing.
+      if (tensor->name() == nullptr)
+      {
+        assert(false && "There is no tensor name");
+        continue;
+      }
+
       // create a group for each tensor whose name is its tensor name
       std::string group_name = ::mangle(tensor->name()->c_str());
       std::unique_ptr<H5::Group> tensor_group =


### PR DESCRIPTION
This commit fixes static analysis warnings in `circle-tensordump`.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>