### PR TITLE
[luci] Introduce NCHW to NHWC convert sub option enums

### DIFF
--- a/compiler/luci/pass/include/luci/CircleOptimizer.h
+++ b/compiler/luci/pass/include/luci/CircleOptimizer.h
@@ -87,8 +87,11 @@ public:
       Sparsify_block_map,
 
       // convert NCHW to NHWC
+      // TODO remove preserve options
       NCHW_to_NHWC_preserve_input_shape,
       NCHW_to_NHWC_preserve_output_shape,
+      NCHW_to_NHWC_input_shape,
+      NCHW_to_NHWC_output_shape,
     };
 
     virtual ~Options() = default;


### PR DESCRIPTION
This will introduce two sub option enums for ConvertNCHWToNHWC to
convert also with I/O that will replace 'preserve' sub options.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>