### PR TITLE
[one-cmds] Remove nchw_to_nhwc preserve options

### DIFF
--- a/compiler/one-cmds/utils.py
+++ b/compiler/one-cmds/utils.py
@@ -29,10 +29,6 @@ class _CONSTANT:
         ('convert_nchw_to_nhwc',
          'Experimental: This will convert NCHW operators to NHWC under the assumption that input model is NCHW.'
          ),
-        ('nchw_to_nhwc_preserve_input_shape',
-         'preserve the input shape of the model (argument for convert_nchw_to_nhwc)'),
-        ('nchw_to_nhwc_preserve_output_shape',
-         'preserve the output shape of the model (argument for convert_nchw_to_nhwc)'),
         ('nchw_to_nhwc_input_shape',
          'convert the input shape of the model (argument for convert_nchw_to_nhwc)'),
         ('nchw_to_nhwc_output_shape',


### PR DESCRIPTION
This will remove not used anymore nchw_to_nhwc preserve options.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>