### PR TITLE
[luci] Remove unused optimization options

### DIFF
--- a/compiler/luci/pass/include/luci/CircleOptimizer.h
+++ b/compiler/luci/pass/include/luci/CircleOptimizer.h
@@ -87,9 +87,6 @@ public:
       Sparsify_block_map,
 
       // convert NCHW to NHWC
-      // TODO remove preserve options
-      NCHW_to_NHWC_preserve_input_shape,
-      NCHW_to_NHWC_preserve_output_shape,
       NCHW_to_NHWC_input_shape,
       NCHW_to_NHWC_output_shape,
     };


### PR DESCRIPTION
This will remove not used anymore NCHW_to_NHWC_preserve_input_shape and
NCHW_to_NHWC_preserve_output_shape option enums.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>