### PR TITLE
[circle-quantizer] Add support for MirrorPad

### DIFF
--- a/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
+++ b/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
@@ -925,6 +925,7 @@ void quantize_const_inputs(luci::CircleNode *node, loco::DataType output_type)
     case luci::CircleOpcode::LOCAL_RESPONSE_NORMALIZATION:
     case luci::CircleOpcode::MEAN:
     case luci::CircleOpcode::PAD:
+    case luci::CircleOpcode::MIRROR_PAD:
     case luci::CircleOpcode::REDUCE_ANY:
     case luci::CircleOpcode::REDUCE_PROD:
     case luci::CircleOpcode::REDUCE_MAX:


### PR DESCRIPTION
This commit adds support for MirrorPad quantization.

ONE-DCO-1.0-Signed-off-by: Alexander Moiseev <a.moiseev@samsung.com>