### PR TITLE
[one-cmds] Make configparser preserve the case

### DIFF
--- a/compiler/one-cmds/one-build
+++ b/compiler/one-cmds/one-build
@@ -68,6 +68,7 @@ def _get_driver_name(driver_name):
 
 def _parse_cfg(args):
     config = configparser.ConfigParser()
+    config.optionxform = str
     parsed = config.read(os.path.expanduser(getattr(args, 'config')))
     if not parsed:
         raise FileNotFoundError('Not found given configuration file')

--- a/compiler/one-cmds/utils.py
+++ b/compiler/one-cmds/utils.py
@@ -101,6 +101,7 @@ def _parse_cfg(args, driver_name):
        the option is processed prior to the configuration file."""
     if _is_valid_attr(args, 'config'):
         config = configparser.ConfigParser()
+        config.optionxform = str
         config.read(args.config)
         # if section is given, verify given section
         if _is_valid_attr(args, 'section'):


### PR DESCRIPTION
This commit makes configparser preserve the case.

Related: #6854 
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>