### PR TITLE
[SAM] Run SAM on AHUB

### DIFF
--- a/.ahub/sam/advanced.cfg
+++ b/.ahub/sam/advanced.cfg
@@ -1,0 +1,2 @@
+[SamPolicy]
+preset=CCD_FOR_OO

--- a/.ahub/sam/exclude.txt
+++ b/.ahub/sam/exclude.txt
@@ -1,0 +1,15 @@
+/ONE/compiler/ann-api/include/NeuralNetworks.h
+/ONE/compiler/ann-ref
+/ONE/compiler/nnc/backends/soft_backend/code_snippets/eigen.def
+/ONE/tests
+/ONE/runtime/onert/frontend/circle_schema/include/circle_schema_generated.h
+/ONE/runtime/onert/frontend/tflite/src/tflite_schema_generated.h
+/ONE/runtime/nnapi-header/include/NeuralNetworks.h
+/ONE/runtime/nnapi-header/include/NeuralNetworksExtensions.h
+/ONE/runtime/libs/nnapi
+/ONE/runtime/libs/profiling
+/ONE/runtime/libs/tflite/port
+/ONE/runtime/3rdparty
+/ONE/compute
+/ONE/runtime/contrib
+/ONE/externals


### PR DESCRIPTION
This commit adds SAM configuration scripts. The content locations and
definition defined by AHUB.

ONE-DCO-1.0-Signed-off-by: Cheongyo Bahk <cg.bahk@gmail.com>

---

With this, we can run SAM analysis with SVACE


Tested in draft #6851

See https://github.com/Samsung/ONE/pull/6851#issuecomment-844701787 for detail
