### PR TITLE
[docker] Install debian build tool

### DIFF
--- a/infra/docker/bionic/Dockerfile
+++ b/infra/docker/bionic/Dockerfile
@@ -23,6 +23,9 @@ RUN apt-get update && apt-get -qqy install software-properties-common
 # Build tool
 RUN apt-get update && apt-get -qqy install build-essential cmake scons git g++-arm-linux-gnueabihf g++-aarch64-linux-gnu
 
+# Debian build tool
+RUN apt-get update && apt-get -qqy install fakeroot devscripts debhelper
+
 # Install extra dependencies (Caffe, nnkit)
 RUN apt-get update && apt-get -qqy install libboost-all-dev libgflags-dev libgoogle-glog-dev libatlas-base-dev libhdf5-dev
 


### PR DESCRIPTION
This commit adds debian build tool to docker file.

Related: #6764 
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>