### PR TITLE
[circle-quantizer] Follow order for MirrorPad

### DIFF
--- a/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
+++ b/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
@@ -924,8 +924,8 @@ void quantize_const_inputs(luci::CircleNode *node, loco::DataType output_type)
     case luci::CircleOpcode::BATCH_TO_SPACE_ND:
     case luci::CircleOpcode::LOCAL_RESPONSE_NORMALIZATION:
     case luci::CircleOpcode::MEAN:
-    case luci::CircleOpcode::PAD:
     case luci::CircleOpcode::MIRROR_PAD:
+    case luci::CircleOpcode::PAD:
     case luci::CircleOpcode::REDUCE_ANY:
     case luci::CircleOpcode::REDUCE_PROD:
     case luci::CircleOpcode::REDUCE_MAX:


### PR DESCRIPTION
This commit makes MirrorPad case follow alphabetical order.

For #6856 

Signed-off-by: Alexander Moiseev <a.moiseev@samsung.com>