### PR TITLE
[luci] Quantize Softmax using fixed values

### DIFF
--- a/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
+++ b/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
@@ -574,6 +574,13 @@ struct QuantizeActivation final : public luci::CircleNodeMutableVisitor<bool>
         auto min = quantparam->min[0];
         auto max = quantparam->max[0];
 
+        // Special values
+        if (circle_node->opcode() == luci::CircleOpcode::SOFTMAX)
+        {
+          min = 0.0f;
+          max = 1.0f;
+        }
+
         float scaling_factor{0};
         int64_t zp{0};
         float nudged_min{0};

--- a/compiler/luci/pass/src/VerifyQuantizedNodeS16Type.h
+++ b/compiler/luci/pass/src/VerifyQuantizedNodeS16Type.h
@@ -229,6 +229,9 @@ private:
   {
     RETURN_FALSE_UNLESS(has_type(node, Type::S16))
     RETURN_FALSE_UNLESS(has_type(node->logits(), Type::S16))
+
+    RETURN_FALSE_UNLESS(node->quantparam()->scale[0] == 1.0f / 32767.0f);
+    RETURN_FALSE_UNLESS(node->quantparam()->zerop[0] == 0);
     return true;
   }
 

--- a/compiler/luci/pass/src/VerifyQuantizedNodeU8Type.h
+++ b/compiler/luci/pass/src/VerifyQuantizedNodeU8Type.h
@@ -236,6 +236,9 @@ private:
   {
     RETURN_FALSE_UNLESS(has_type(node, Type::U8))
     RETURN_FALSE_UNLESS(has_type(node->logits(), Type::U8))
+
+    RETURN_FALSE_UNLESS(node->quantparam()->scale[0] == 1.0f / 255.0f);
+    RETURN_FALSE_UNLESS(node->quantparam()->zerop[0] == 0);
     return true;
   }
 


### PR DESCRIPTION
This quantizes Softmax using fixed values (min: 0, max: 1).

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>