### PR TITLE
[debian] Add python3-things to dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Homepage: https://github.com/Samsung/ONE
 Package: one-compiler
 Architecture: amd64
 Multi-Arch: foreign
-Depends: ${misc:Depends}, ${shlibs:Depends}
+Depends: ${misc:Depends}, ${shlibs:Depends}, python3-venv, python3-pip
 Description: On-device Neural Engine compiler package
 
 Package: one-compiler-dev


### PR DESCRIPTION
This commit adds python3-things to one-compiler's dependencies.

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>