### PR TITLE
[luci] Quantize const input before bias quantization

### DIFF
--- a/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
+++ b/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
@@ -704,6 +704,12 @@ struct QuantizeBias final : public luci::CircleNodeMutableVisitor<bool>
       auto const_bias = loco::must_cast<luci::CircleConst *>(node);
       assert(const_bias->dtype() == loco::DataType::FLOAT32);
 
+      // If input is const, it is quantized here, not in QuantizeActivation
+      if (auto const_input = dynamic_cast<luci::CircleConst *>(input))
+      {
+        quant_const(const_input, output_type);
+      }
+
       CircleConst *new_bias = nullptr;
 
       if (granularity == QuantizationGranularity::ChannelWise)


### PR DESCRIPTION
This quantizes const input before bias is quantized.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>