### PR TITLE
[infra] Update docker_build_nncc script

### DIFF
--- a/infra/scripts/docker_build_nncc.sh
+++ b/infra/scripts/docker_build_nncc.sh
@@ -61,4 +61,11 @@ tar -zcf ${ARCHIVE_PATH}/nncc-package.tar.gz -C ${NNCC_INSTALL_PREFIX} \
     --exclude test --exclude tflchef* --exclude circle-tensordump --exclude circledump ./
 tar -zcf ${ARCHIVE_PATH}/nncc-test-package.tar.gz -C ${NNCC_INSTALL_PREFIX} ./test
 
+./nncc docker-run /bin/bash -c \
+        'dch -v $(dpkg-parsechangelog --show-field Version)-$(date "+%y%m%d%H") "nightly release"'
+./nncc docker-run dch -r ''
+
+./nncc docker-run debuild --preserve-env --no-lintian -us -uc \
+        -b --buildinfo-option=-ubuild --changes-option=-ubuild
+
 popd > /dev/null


### PR DESCRIPTION
This commit updates docker_build_nncc script for debian packaging.

For reviewers' information,

`--no-lintian` : Do not run `lintian`(Static analysis tool for Debian packages).
`-us -uc`: No singing.
`--buildinfo-option=-ubuild --changes-option=-ubuild`: For changing the directory where `*.deb` files are generated.

Related: #6764 
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>