### PR TITLE
[one-cmds] Remove python symbolic link

### DIFF
--- a/compiler/one-cmds/one-prepare-venv
+++ b/compiler/one-cmds/one-prepare-venv
@@ -77,10 +77,6 @@ else
   ${VENV_PYTHON} -m pip ${PIP_OPTIONS} install onnx==${VER_ONNX} onnx-tf==${VER_ONNX_TF}
 fi
 
-# Create python symoblic link
-rm -f ${DRIVER_PATH}/python
-ln -s venv/bin/python ${DRIVER_PATH}/python
-
 # TODO remove this patch after onnx-tf next release
 # apply patch for DWConv conversion bug: https://github.com/onnx/onnx-tensorflow/pull/905
 if [[ -z "${EXT_ONNX_TF_WHL}" ]]; then


### PR DESCRIPTION
This commit removes ln command that makes venv python's symbolic link.

Related: #6902 
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>