### PR TITLE
[common-artifacts] Enable Quantize for circle2circle

### DIFF
--- a/compiler/common-artifacts/exclude.lst
+++ b/compiler/common-artifacts/exclude.lst
@@ -6,7 +6,6 @@
 #[[ optimize : Exclude from circle optimization(circle2circle) ]]
 ## TensorFlowLiteRecipes
 optimize(UnidirectionalSequenceLSTM_001) # This recipe contains is_variable Tensor
-optimize(Quantize_000)
 
 ## CircleRecipes
 


### PR DESCRIPTION
This will remove exclude item to enble Quantize Op of circle2circle.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>