### PR TITLE
[luci] Introduce RemoveQuantDequantSeq

### DIFF
--- a/compiler/luci/pass/include/luci/CircleOptimizer.h
+++ b/compiler/luci/pass/include/luci/CircleOptimizer.h
@@ -70,6 +70,7 @@ public:
       SubstituteTransposeToReshape,
       RemoveRedundantReshape,
       RemoveFakeQuant,
+      RemoveQuantDequantSeq,
     };
 
     enum AlgorithmParameters

--- a/compiler/luci/pass/src/CircleOptimizer.cpp
+++ b/compiler/luci/pass/src/CircleOptimizer.cpp
@@ -33,6 +33,7 @@
 #include "luci/Pass/MakeBatchNormGammaPositivePass.h"
 #include "luci/Pass/PropagateQuantParamPass.h"
 #include "luci/Pass/RemoveFakeQuantPass.h"
+#include "luci/Pass/RemoveQuantDequantSeqPass.h"
 #include "luci/Pass/RemoveRedundantReshapePass.h"
 #include "luci/Pass/RemoveRedundantTransposePass.h"
 #include "luci/Pass/RemoveUnnecessaryReshapePass.h"
@@ -236,6 +237,10 @@ void CircleOptimizer::optimize(loco::Graph *g) const
   if (_options->query(Options::Algorithm::RemoveFakeQuant))
   {
     phase.emplace_back(std::make_unique<luci::RemoveFakeQuantPass>());
+  }
+  if (_options->query(Options::Algorithm::RemoveQuantDequantSeq))
+  {
+    phase.emplace_back(std::make_unique<luci::RemoveQuantDequantSeqPass>());
   }
   if (_options->query(Options::Algorithm::RemoveUnnecessaryReshape))
   {


### PR DESCRIPTION
This will introduce RemoveQuantDequantSeq enum and connect with
RemoveQuantDequantSeqPass.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>