### PR TITLE
[onert] Reallocate backends to operations at runtime

### DIFF
--- a/runtime/onert/api/include/nnfw_experimental.h
+++ b/runtime/onert/api/include/nnfw_experimental.h
@@ -96,4 +96,20 @@ NNFW_STATUS nnfw_input_tensorindex(nnfw_session *session, const char *tensorname
  */
 NNFW_STATUS nnfw_output_tensorindex(nnfw_session *session, const char *tensorname, uint32_t *index);
 
+/**
+ * @brief Set the backend for each operation in the session
+ *
+ * This function assigns backends (acl_cl, acl_neon, cpu) to each operation in the session.
+ * If successful,the function returns @c NNFW_STATUS_NO_ERROR. Otherwise, the function returns
+ * @c NNFW_STATUS_ERROR.
+ *
+ * @note The argument specifying backends must be in the format
+ *       "OP_BACKEND_MAP=\"0=acl_cl;1=cpu;2=acl_cl\"".
+ *
+ * @param[in]  session          the session object
+ * @param[in]  backend_settings String containing backend assignments indexed by operation sequence
+ * @return     @c NNFW_STATUS_NO_ERROR if successful
+ */
+NNFW_STATUS nnfw_set_backends_per_operation(nnfw_session *session, const char *backend_settings);
+
 #endif // __NNFW_EXPERIMENTAL_H__

--- a/runtime/onert/api/src/nnfw_api.cc
+++ b/runtime/onert/api/src/nnfw_api.cc
@@ -367,3 +367,9 @@ NNFW_STATUS nnfw_output_tensorindex(nnfw_session *session, const char *tensornam
   NNFW_RETURN_ERROR_IF_NULL(session);
   return session->output_tensorindex(tensorname, index);
 }
+
+NNFW_STATUS nnfw_set_backends_per_operation(nnfw_session *session, const char *backend_settings)
+{
+  NNFW_RETURN_ERROR_IF_NULL(session);
+  return session->set_backends_per_operation(backend_settings);
+}

--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -1010,3 +1010,13 @@ NNFW_STATUS nnfw_session::output_tensorindex(const char *tensorname, uint32_t *i
 {
   return getTensorIndexImpl(*primary_subgraph(), tensorname, index, false);
 }
+
+NNFW_STATUS nnfw_session::set_backends_per_operation(const char *backend_settings)
+{
+  if (backend_settings == NULL)
+  {
+    return NNFW_STATUS_ERROR;
+  }
+  _compiler->set_backend_from_str(backend_settings);
+  return NNFW_STATUS_NO_ERROR;
+}

--- a/runtime/onert/api/src/nnfw_api_internal.h
+++ b/runtime/onert/api/src/nnfw_api_internal.h
@@ -139,6 +139,7 @@ public:
   NNFW_STATUS register_custom_operation(const std::string &id, nnfw_custom_eval eval_func);
   NNFW_STATUS input_tensorindex(const char *tensorname, uint32_t *index);
   NNFW_STATUS output_tensorindex(const char *tensorname, uint32_t *index);
+  NNFW_STATUS set_backends_per_operation(const char *backend_settings);
 
 private:
   const onert::ir::Graph *primary_subgraph();

--- a/runtime/onert/core/include/compiler/Compiler.h
+++ b/runtime/onert/core/include/compiler/Compiler.h
@@ -95,6 +95,12 @@ public:
    */
   void enableToFp16();
 
+  /**
+   * @brief   Set backends from string-encoded mappings from operation index to backend type (cpu,
+   * acl_cl)
+   */
+  void set_backend_from_str(const char *backend_settings);
+
 private:
   void checkProfilerConditions();
   std::shared_ptr<ir::Graph> &primary_subgraph() { return _subgraphs->at(ir::SubgraphIndex{0}); }

--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -139,6 +139,26 @@ Compiler::Compiler(const std::shared_ptr<ir::Subgraphs> &subgs, util::TracingCtx
 
 void Compiler::enableToFp16() { _options.fp16_enable = true; }
 
+void Compiler::set_backend_from_str(const char *backend_settings)
+{
+  // Backend for all
+  auto &ms_options = _options.manual_scheduler_options;
+  auto key_val_list = nnfw::misc::split(backend_settings, ';');
+  for (const auto &key_val_str : key_val_list)
+  {
+    if (key_val_str.empty())
+    {
+      continue;
+    }
+
+    auto key_val = nnfw::misc::split(key_val_str, '=');
+    const auto &key_str = key_val.at(0);
+    const auto &val = key_val.at(1);
+    auto key = static_cast<uint32_t>(std::stoi(key_str));
+    ms_options.index_to_backend.emplace(ir::OperationIndex{key}, val);
+  }
+}
+
 void Compiler::checkProfilerConditions()
 {
   if (!_options.he_scheduler)


### PR DESCRIPTION
Reconfigure backend allocation at runtime. This feature entails changes to `nnfw` source and header files, as well as the onert `Compiler` module.

Signed-off-by: venkat.iyer venkat.iyer@samsung.com 