### PR TITLE
[Infra/docker] Upgrade git version

### DIFF
--- a/infra/docker/bionic/Dockerfile
+++ b/infra/docker/bionic/Dockerfile
@@ -20,6 +20,9 @@ ARG UBUNTU_MIRROR
 # Install 'add-apt-repository'
 RUN apt-get update && apt-get -qqy install software-properties-common
 
+# Git repo for latest version (github checkout@v2 action requires v2.18)
+RUN add-apt-repository ppa:git-core/ppa -y
+
 # Build tool
 RUN apt-get update && apt-get -qqy install build-essential cmake scons git g++-arm-linux-gnueabihf g++-aarch64-linux-gnu
 


### PR DESCRIPTION
Let's upgrade git version on bionic docker.

Github checkout action requires v2.18, but ubuntu bionic's default git version is v2.17.1.

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>