### PR TITLE
[Draft][luci] Preserve originally imported profiling data

### DIFF
--- a/compiler/luci/export/src/CircleExporterImpl.cpp
+++ b/compiler/luci/export/src/CircleExporterImpl.cpp
@@ -224,6 +224,7 @@ void CircleExporterImpl::exportModule(Module *module)
   auto description = _builder.CreateString(description_str);
 
   // Metadata
+  md._metadata.source_table(module->source_table());
   auto metadata_vec = createCircleMetadataVector(_builder, md);
   auto metadata = _builder.CreateVector(std::vector<Offset<Metadata>>(metadata_vec));
 

--- a/compiler/luci/export/src/CircleOperationExporter.cpp
+++ b/compiler/luci/export/src/CircleOperationExporter.cpp
@@ -1507,7 +1507,6 @@ void exportNode(loco::Node *node, flatbuffers::FlatBufferBuilder &builder, Seria
       const auto node_id = gd._operators.size() - 1;
       for (auto source : get_origin(circle_node)->sources())
       {
-        md._metadata.add_source_table(source->id(), source->name());
         md._metadata.add_op_table(node_id, source->id());
       }
     }

--- a/compiler/luci/export/src/SerializedData.h
+++ b/compiler/luci/export/src/SerializedData.h
@@ -51,13 +51,9 @@ struct OpCode
 class CircleExportMetadata
 {
 public:
-  void add_source_table(uint32_t source_id, std::string origin_name)
+  void source_table(const std::map<uint32_t, std::string>& table)
   {
-    // Model with multiple subgraph may have different origin_name
-    // even if source_id is same. However, as we do not consider about
-    // multiple subgraph in profiling for now, just do not care those cases
-    // and support them correctly in the future.
-    _source_table.emplace(source_id, origin_name);
+    _source_table = table;
   }
 
   void add_op_table(uint32_t node_id, uint32_t source_id)

--- a/compiler/luci/import/src/CircleImportMetadata.h
+++ b/compiler/luci/import/src/CircleImportMetadata.h
@@ -45,6 +45,11 @@ public:
    */
   const OriginTable origin_table(void);
 
+  const std::map<uint32_t, std::string> &source_table(void)
+  {
+    return _source_table;
+  }
+
 private:
   // Decoded metadata is stored
   std::map<uint32_t, std::string> _source_table;

--- a/compiler/luci/lang/include/luci/IR/Module.h
+++ b/compiler/luci/lang/include/luci/IR/Module.h
@@ -19,6 +19,7 @@
 
 #include <loco/IR/Graph.h>
 
+#include <map>
 #include <memory>
 #include <vector>
 
@@ -59,8 +60,33 @@ public:
 
   // TODO provide graph accessor with a name
 
+public:
+  void source_table(const std::map<uint32_t, std::string>& table)
+  {
+    _source_table = table;
+  }
+
+  const std::map<uint32_t, std::string>& source_table(void) const
+  {
+    return _source_table;
+  }
+
 private:
   std::vector<std::unique_ptr<loco::Graph>> _graphs;
+
+private:
+  /**
+   * @brief Metadata about source table for profiling
+   * 
+   * @note  Key is ID of node and value is name of node.
+   * 
+   *        If there was originally imported 'source_table' in circle model,
+   *        the table will be stored as it is.
+   *        Otherwise, new 'source_table' is created with imported nodes.
+   * 
+   *        Only supported for a module with single subgraph.
+   */
+  std::map<uint32_t, std::string> _source_table;
 };
 
 std::unique_ptr<Module> make_module(void);


### PR DESCRIPTION
Parent Issue : #6952 

This draft is for preserving originally imported profiling data, `source_table`.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>