### PR TITLE
Group CloneNode to smaller subclass for ABC

### DIFF
--- a/compiler/luci/service/src/CircleCloneNode.cpp
+++ b/compiler/luci/service/src/CircleCloneNode.cpp
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,18 +19,19 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNodeLet<CN::ABC>::visit(const luci::CircleConcatenation *node)
+luci::CircleNode *CloneNode::visit(const luci::CircleNode *node)
 {
-  if (node->fusedActivationFunction() == luci::FusedActFunc::UNDEFINED)
-    return nullptr;
-
-  auto *cloned = _graph->nodes()->create<luci::CircleConcatenation>(node->numValues());
-  if (cloned != nullptr)
-  {
-    cloned->fusedActivationFunction(node->fusedActivationFunction());
-    cloned->axis(node->axis());
+#define CNVISIT_GRP(GRP)              \
+  {                                   \
+    CloneNodeLet<CN::GRP> cn(_graph); \
+    auto cloned = node->accept(&cn);  \
+    if (cloned != nullptr)            \
+      return cloned;                  \
   }
-  return cloned;
+
+  CNVISIT_GRP(ABC);
+
+  return nullptr;
 }
 
 } // namespace luci

--- a/compiler/luci/service/src/CircleCloneNode.h
+++ b/compiler/luci/service/src/CircleCloneNode.h
@@ -24,10 +24,18 @@
 namespace luci
 {
 
-class CloneNode final : public luci::CircleNodeVisitor<luci::CircleNode *>
+// CloneNode-let type
+enum class CN
+{
+  ABC,
+};
+
+template <CN ct> class CloneNodeLet;
+
+template <> class CloneNodeLet<CN::ABC> final : public luci::CircleNodeVisitor<luci::CircleNode *>
 {
 public:
-  CloneNode(loco::Graph *graph) : _graph(graph){};
+  CloneNodeLet(loco::Graph *graph) : _graph(graph){};
 
 public:
   luci::CircleNode *visit(const luci::CircleAbs *) final;
@@ -45,6 +53,19 @@ public:
   luci::CircleNode *visit(const luci::CircleConv2D *) final;
   luci::CircleNode *visit(const luci::CircleCos *) final;
   luci::CircleNode *visit(const luci::CircleCustom *) final;
+
+  luci::CircleNode *visit(const luci::CircleNode *) final { return nullptr; }
+
+protected:
+  loco::Graph *_graph = nullptr;
+};
+
+class CloneNode final : public luci::CircleNodeVisitor<luci::CircleNode *>
+{
+public:
+  CloneNode(loco::Graph *graph) : _graph(graph){};
+
+public:
   luci::CircleNode *visit(const luci::CircleDepthToSpace *) final;
   luci::CircleNode *visit(const luci::CircleDepthwiseConv2D *) final;
   luci::CircleNode *visit(const luci::CircleDequantize *) final;
@@ -166,6 +187,9 @@ public:
   luci::CircleNode *visit(const luci::CircleUniqueOut *) final;
   luci::CircleNode *visit(const luci::CircleUnpackOut *) final;
   // luci::CircleNode *visit(const luci::CircleWhileOut *) final;
+
+  // Handle in CircleNode
+  luci::CircleNode *visit(const luci::CircleNode *) final;
 
   // NOTE CircleNodeVisitor will throw if not supported here
 

--- a/compiler/luci/service/src/Nodes/CircleAbs.cpp
+++ b/compiler/luci/service/src/Nodes/CircleAbs.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleAbs *)
+luci::CircleNode *CloneNodeLet<CN::ABC>::visit(const luci::CircleAbs *)
 {
   return _graph->nodes()->create<luci::CircleAbs>();
 }

--- a/compiler/luci/service/src/Nodes/CircleAdd.cpp
+++ b/compiler/luci/service/src/Nodes/CircleAdd.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleAdd *node)
+luci::CircleNode *CloneNodeLet<CN::ABC>::visit(const luci::CircleAdd *node)
 {
   if (node->fusedActivationFunction() == luci::FusedActFunc::UNDEFINED)
     return nullptr;

--- a/compiler/luci/service/src/Nodes/CircleAddN.cpp
+++ b/compiler/luci/service/src/Nodes/CircleAddN.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleAddN *node)
+luci::CircleNode *CloneNodeLet<CN::ABC>::visit(const luci::CircleAddN *node)
 {
   auto arity = node->arity();
   return _graph->nodes()->create<luci::CircleAddN>(arity);

--- a/compiler/luci/service/src/Nodes/CircleArgMax.cpp
+++ b/compiler/luci/service/src/Nodes/CircleArgMax.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleArgMax *node)
+luci::CircleNode *CloneNodeLet<CN::ABC>::visit(const luci::CircleArgMax *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleArgMax>();
   if (cloned != nullptr)

--- a/compiler/luci/service/src/Nodes/CircleArgMin.cpp
+++ b/compiler/luci/service/src/Nodes/CircleArgMin.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleArgMin *node)
+luci::CircleNode *CloneNodeLet<CN::ABC>::visit(const luci::CircleArgMin *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleArgMin>();
   if (cloned != nullptr)

--- a/compiler/luci/service/src/Nodes/CircleAveragePool2D.cpp
+++ b/compiler/luci/service/src/Nodes/CircleAveragePool2D.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleAveragePool2D *node)
+luci::CircleNode *CloneNodeLet<CN::ABC>::visit(const luci::CircleAveragePool2D *node)
 {
   if (node->fusedActivationFunction() == luci::FusedActFunc::UNDEFINED)
     return nullptr;

--- a/compiler/luci/service/src/Nodes/CircleBatchMatMul.cpp
+++ b/compiler/luci/service/src/Nodes/CircleBatchMatMul.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleBatchMatMul *node)
+luci::CircleNode *CloneNodeLet<CN::ABC>::visit(const luci::CircleBatchMatMul *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleBatchMatMul>();
   if (cloned != nullptr)

--- a/compiler/luci/service/src/Nodes/CircleBatchToSpaceND.cpp
+++ b/compiler/luci/service/src/Nodes/CircleBatchToSpaceND.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleBatchToSpaceND *)
+luci::CircleNode *CloneNodeLet<CN::ABC>::visit(const luci::CircleBatchToSpaceND *)
 {
   return _graph->nodes()->create<luci::CircleBatchToSpaceND>();
 }

--- a/compiler/luci/service/src/Nodes/CircleCast.cpp
+++ b/compiler/luci/service/src/Nodes/CircleCast.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleCast *node)
+luci::CircleNode *CloneNodeLet<CN::ABC>::visit(const luci::CircleCast *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleCast>();
   if (cloned != nullptr)

--- a/compiler/luci/service/src/Nodes/CircleCeil.cpp
+++ b/compiler/luci/service/src/Nodes/CircleCeil.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleCeil *)
+luci::CircleNode *CloneNodeLet<CN::ABC>::visit(const luci::CircleCeil *)
 {
   return _graph->nodes()->create<luci::CircleCeil>();
 }

--- a/compiler/luci/service/src/Nodes/CircleConst.cpp
+++ b/compiler/luci/service/src/Nodes/CircleConst.cpp
@@ -110,7 +110,7 @@ luci::CircleConst *clone(luci::CircleConst *node)
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleConst *node)
+luci::CircleNode *CloneNodeLet<CN::ABC>::visit(const luci::CircleConst *node)
 {
   return clone_circleconst(node, _graph);
 }

--- a/compiler/luci/service/src/Nodes/CircleConv2D.cpp
+++ b/compiler/luci/service/src/Nodes/CircleConv2D.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleConv2D *node)
+luci::CircleNode *CloneNodeLet<CN::ABC>::visit(const luci::CircleConv2D *node)
 {
   if (node->fusedActivationFunction() == luci::FusedActFunc::UNDEFINED)
     return nullptr;

--- a/compiler/luci/service/src/Nodes/CircleCos.cpp
+++ b/compiler/luci/service/src/Nodes/CircleCos.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleCos *)
+luci::CircleNode *CloneNodeLet<CN::ABC>::visit(const luci::CircleCos *)
 {
   return _graph->nodes()->create<luci::CircleCos>();
 }

--- a/compiler/luci/service/src/Nodes/CircleCustom.cpp
+++ b/compiler/luci/service/src/Nodes/CircleCustom.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleCustom *node)
+luci::CircleNode *CloneNodeLet<CN::ABC>::visit(const luci::CircleCustom *node)
 {
   uint32_t num_in = node->numInputs();
   uint32_t num_out = node->numOutputs();


### PR DESCRIPTION
This will group CloneNode to smaller subclass for ABC to reduce LoC of
CloneNode class.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>