### PR TITLE
Group CloneNode to smaller subclass for DEF

### DIFF
--- a/compiler/luci/service/src/CircleCloneNode.cpp
+++ b/compiler/luci/service/src/CircleCloneNode.cpp
@@ -30,6 +30,7 @@ luci::CircleNode *CloneNode::visit(const luci::CircleNode *node)
   }
 
   CNVISIT_GRP(ABC);
+  CNVISIT_GRP(DEF);
 
   return nullptr;
 }

--- a/compiler/luci/service/src/CircleCloneNode.h
+++ b/compiler/luci/service/src/CircleCloneNode.h
@@ -28,6 +28,7 @@ namespace luci
 enum class CN
 {
   ABC,
+  DEF,
 };
 
 template <CN ct> class CloneNodeLet;
@@ -60,10 +61,10 @@ protected:
   loco::Graph *_graph = nullptr;
 };
 
-class CloneNode final : public luci::CircleNodeVisitor<luci::CircleNode *>
+template <> class CloneNodeLet<CN::DEF> final : public luci::CircleNodeVisitor<luci::CircleNode *>
 {
 public:
-  CloneNode(loco::Graph *graph) : _graph(graph){};
+  CloneNodeLet(loco::Graph *graph) : _graph(graph){};
 
 public:
   luci::CircleNode *visit(const luci::CircleDepthToSpace *) final;
@@ -80,6 +81,19 @@ public:
   luci::CircleNode *visit(const luci::CircleFloorDiv *) final;
   luci::CircleNode *visit(const luci::CircleFloorMod *) final;
   luci::CircleNode *visit(const luci::CircleFullyConnected *) final;
+
+  luci::CircleNode *visit(const luci::CircleNode *) final { return nullptr; }
+
+protected:
+  loco::Graph *_graph = nullptr;
+};
+
+class CloneNode final : public luci::CircleNodeVisitor<luci::CircleNode *>
+{
+public:
+  CloneNode(loco::Graph *graph) : _graph(graph){};
+
+public:
   luci::CircleNode *visit(const luci::CircleGather *) final;
   luci::CircleNode *visit(const luci::CircleGatherNd *) final;
   luci::CircleNode *visit(const luci::CircleGreater *) final;

--- a/compiler/luci/service/src/Nodes/CircleDepthToSpace.cpp
+++ b/compiler/luci/service/src/Nodes/CircleDepthToSpace.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleDepthToSpace *node)
+luci::CircleNode *CloneNodeLet<CN::DEF>::visit(const luci::CircleDepthToSpace *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleDepthToSpace>();
   if (cloned != nullptr)

--- a/compiler/luci/service/src/Nodes/CircleDepthwiseConv2D.cpp
+++ b/compiler/luci/service/src/Nodes/CircleDepthwiseConv2D.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleDepthwiseConv2D *node)
+luci::CircleNode *CloneNodeLet<CN::DEF>::visit(const luci::CircleDepthwiseConv2D *node)
 {
   if (node->fusedActivationFunction() == luci::FusedActFunc::UNDEFINED)
     return nullptr;

--- a/compiler/luci/service/src/Nodes/CircleDequantize.cpp
+++ b/compiler/luci/service/src/Nodes/CircleDequantize.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleDequantize *)
+luci::CircleNode *CloneNodeLet<CN::DEF>::visit(const luci::CircleDequantize *)
 {
   return _graph->nodes()->create<luci::CircleDequantize>();
 }

--- a/compiler/luci/service/src/Nodes/CircleDiv.cpp
+++ b/compiler/luci/service/src/Nodes/CircleDiv.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleDiv *node)
+luci::CircleNode *CloneNodeLet<CN::DEF>::visit(const luci::CircleDiv *node)
 {
   if (node->fusedActivationFunction() == luci::FusedActFunc::UNDEFINED)
     return nullptr;

--- a/compiler/luci/service/src/Nodes/CircleElu.cpp
+++ b/compiler/luci/service/src/Nodes/CircleElu.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleElu *)
+luci::CircleNode *CloneNodeLet<CN::DEF>::visit(const luci::CircleElu *)
 {
   return _graph->nodes()->create<luci::CircleElu>();
 }

--- a/compiler/luci/service/src/Nodes/CircleEqual.cpp
+++ b/compiler/luci/service/src/Nodes/CircleEqual.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleEqual *)
+luci::CircleNode *CloneNodeLet<CN::DEF>::visit(const luci::CircleEqual *)
 {
   return _graph->nodes()->create<luci::CircleEqual>();
 }

--- a/compiler/luci/service/src/Nodes/CircleExp.cpp
+++ b/compiler/luci/service/src/Nodes/CircleExp.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleExp *)
+luci::CircleNode *CloneNodeLet<CN::DEF>::visit(const luci::CircleExp *)
 {
   return _graph->nodes()->create<luci::CircleExp>();
 }

--- a/compiler/luci/service/src/Nodes/CircleExpandDims.cpp
+++ b/compiler/luci/service/src/Nodes/CircleExpandDims.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleExpandDims *)
+luci::CircleNode *CloneNodeLet<CN::DEF>::visit(const luci::CircleExpandDims *)
 {
   return _graph->nodes()->create<luci::CircleExpandDims>();
 }

--- a/compiler/luci/service/src/Nodes/CircleFakeQuant.cpp
+++ b/compiler/luci/service/src/Nodes/CircleFakeQuant.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleFakeQuant *node)
+luci::CircleNode *CloneNodeLet<CN::DEF>::visit(const luci::CircleFakeQuant *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleFakeQuant>();
   if (cloned != nullptr)

--- a/compiler/luci/service/src/Nodes/CircleFill.cpp
+++ b/compiler/luci/service/src/Nodes/CircleFill.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleFill *)
+luci::CircleNode *CloneNodeLet<CN::DEF>::visit(const luci::CircleFill *)
 {
   return _graph->nodes()->create<luci::CircleFill>();
 }

--- a/compiler/luci/service/src/Nodes/CircleFloor.cpp
+++ b/compiler/luci/service/src/Nodes/CircleFloor.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleFloor *)
+luci::CircleNode *CloneNodeLet<CN::DEF>::visit(const luci::CircleFloor *)
 {
   return _graph->nodes()->create<luci::CircleFloor>();
 }

--- a/compiler/luci/service/src/Nodes/CircleFloorDiv.cpp
+++ b/compiler/luci/service/src/Nodes/CircleFloorDiv.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleFloorDiv *)
+luci::CircleNode *CloneNodeLet<CN::DEF>::visit(const luci::CircleFloorDiv *)
 {
   return _graph->nodes()->create<luci::CircleFloorDiv>();
 }

--- a/compiler/luci/service/src/Nodes/CircleFloorMod.cpp
+++ b/compiler/luci/service/src/Nodes/CircleFloorMod.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleFloorMod *)
+luci::CircleNode *CloneNodeLet<CN::DEF>::visit(const luci::CircleFloorMod *)
 {
   return _graph->nodes()->create<luci::CircleFloorMod>();
 }

--- a/compiler/luci/service/src/Nodes/CircleFullyConnected.cpp
+++ b/compiler/luci/service/src/Nodes/CircleFullyConnected.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleFullyConnected *node)
+luci::CircleNode *CloneNodeLet<CN::DEF>::visit(const luci::CircleFullyConnected *node)
 {
   if (node->fusedActivationFunction() == luci::FusedActFunc::UNDEFINED)
     return nullptr;


### PR DESCRIPTION
This will group CloneNode to smaller subclass for DEF.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>