### PR TITLE
Group CloneNode to small subclass for GHIJ

### DIFF
--- a/compiler/luci/service/src/CircleCloneNode.cpp
+++ b/compiler/luci/service/src/CircleCloneNode.cpp
@@ -31,6 +31,7 @@ luci::CircleNode *CloneNode::visit(const luci::CircleNode *node)
 
   CNVISIT_GRP(ABC);
   CNVISIT_GRP(DEF);
+  CNVISIT_GRP(GHIJ);
 
   return nullptr;
 }

--- a/compiler/luci/service/src/CircleCloneNode.h
+++ b/compiler/luci/service/src/CircleCloneNode.h
@@ -29,6 +29,7 @@ enum class CN
 {
   ABC,
   DEF,
+  GHIJ,
 };
 
 template <CN ct> class CloneNodeLet;
@@ -88,10 +89,10 @@ protected:
   loco::Graph *_graph = nullptr;
 };
 
-class CloneNode final : public luci::CircleNodeVisitor<luci::CircleNode *>
+template <> class CloneNodeLet<CN::GHIJ> final : public luci::CircleNodeVisitor<luci::CircleNode *>
 {
 public:
-  CloneNode(loco::Graph *graph) : _graph(graph){};
+  CloneNodeLet(loco::Graph *graph) : _graph(graph){};
 
 public:
   luci::CircleNode *visit(const luci::CircleGather *) final;
@@ -99,6 +100,19 @@ public:
   luci::CircleNode *visit(const luci::CircleGreater *) final;
   luci::CircleNode *visit(const luci::CircleGreaterEqual *) final;
   // luci::CircleNode *visit(const luci::CircleIf *) final;
+
+  luci::CircleNode *visit(const luci::CircleNode *) final { return nullptr; }
+
+protected:
+  loco::Graph *_graph = nullptr;
+};
+
+class CloneNode final : public luci::CircleNodeVisitor<luci::CircleNode *>
+{
+public:
+  CloneNode(loco::Graph *graph) : _graph(graph){};
+
+public:
   luci::CircleNode *visit(const luci::CircleL2Normalize *) final;
   luci::CircleNode *visit(const luci::CircleL2Pool2D *) final;
   luci::CircleNode *visit(const luci::CircleLeakyRelu *) final;

--- a/compiler/luci/service/src/Nodes/CircleGather.cpp
+++ b/compiler/luci/service/src/Nodes/CircleGather.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleGather *node)
+luci::CircleNode *CloneNodeLet<CN::GHIJ>::visit(const luci::CircleGather *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleGather>();
   if (cloned != nullptr)

--- a/compiler/luci/service/src/Nodes/CircleGatherNd.cpp
+++ b/compiler/luci/service/src/Nodes/CircleGatherNd.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleGatherNd *)
+luci::CircleNode *CloneNodeLet<CN::GHIJ>::visit(const luci::CircleGatherNd *)
 {
   return _graph->nodes()->create<luci::CircleGatherNd>();
 }

--- a/compiler/luci/service/src/Nodes/CircleGreater.cpp
+++ b/compiler/luci/service/src/Nodes/CircleGreater.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleGreater *)
+luci::CircleNode *CloneNodeLet<CN::GHIJ>::visit(const luci::CircleGreater *)
 {
   return _graph->nodes()->create<luci::CircleGreater>();
 }

--- a/compiler/luci/service/src/Nodes/CircleGreaterEqual.cpp
+++ b/compiler/luci/service/src/Nodes/CircleGreaterEqual.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleGreaterEqual *)
+luci::CircleNode *CloneNodeLet<CN::GHIJ>::visit(const luci::CircleGreaterEqual *)
 {
   return _graph->nodes()->create<luci::CircleGreaterEqual>();
 }


### PR DESCRIPTION
This will group CloneNode to smaller subclass for GHIJ.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>