### PR TITLE
[luci] Group CloneNode to small subclass for S to Z

### DIFF
--- a/compiler/luci/service/src/CircleCloneNode.cpp
+++ b/compiler/luci/service/src/CircleCloneNode.cpp
@@ -34,6 +34,8 @@ luci::CircleNode *CloneNode::visit(const luci::CircleNode *node)
   CNVISIT_GRP(GHIJ);
   CNVISIT_GRP(KLMN);
   CNVISIT_GRP(OPQR);
+  CNVISIT_GRP(STUV);
+  CNVISIT_GRP(VWXYZ);
 
   return nullptr;
 }

--- a/compiler/luci/service/src/CircleCloneNode.h
+++ b/compiler/luci/service/src/CircleCloneNode.h
@@ -32,6 +32,8 @@ enum class CN
   GHIJ,
   KLMN,
   OPQR,
+  STUV,
+  VWXYZ,
 };
 
 template <CN ct> class CloneNodeLet;
@@ -182,10 +184,10 @@ protected:
   loco::Graph *_graph = nullptr;
 };
 
-class CloneNode final : public luci::CircleNodeVisitor<luci::CircleNode *>
+template <> class CloneNodeLet<CN::STUV> final : public luci::CircleNodeVisitor<luci::CircleNode *>
 {
 public:
-  CloneNode(loco::Graph *graph) : _graph(graph){};
+  CloneNodeLet(loco::Graph *graph) : _graph(graph){};
 
 public:
   luci::CircleNode *visit(const luci::CircleScatterNd *) final;
@@ -216,10 +218,35 @@ public:
   luci::CircleNode *visit(const luci::CircleUnidirectionalSequenceLSTM *) final;
   luci::CircleNode *visit(const luci::CircleUnique *) final;
   luci::CircleNode *visit(const luci::CircleUnpack *) final;
+
+  luci::CircleNode *visit(const luci::CircleNode *) final { return nullptr; }
+
+protected:
+  loco::Graph *_graph = nullptr;
+};
+
+template <> class CloneNodeLet<CN::VWXYZ> final : public luci::CircleNodeVisitor<luci::CircleNode *>
+{
+public:
+  CloneNodeLet(loco::Graph *graph) : _graph(graph){};
+
+public:
   luci::CircleNode *visit(const luci::CircleWhere *) final;
   // luci::CircleNode *visit(const luci::CircleWhile *) final;
   luci::CircleNode *visit(const luci::CircleZerosLike *) final;
 
+  luci::CircleNode *visit(const luci::CircleNode *) final { return nullptr; }
+
+protected:
+  loco::Graph *_graph = nullptr;
+};
+
+class CloneNode final : public luci::CircleNodeVisitor<luci::CircleNode *>
+{
+public:
+  CloneNode(loco::Graph *graph) : _graph(graph){};
+
+public:
   // Circle Only
   luci::CircleNode *visit(const luci::CircleBCQFullyConnected *) final;
   luci::CircleNode *visit(const luci::CircleBCQGather *) final;

--- a/compiler/luci/service/src/Nodes/CircleScatterNd.cpp
+++ b/compiler/luci/service/src/Nodes/CircleScatterNd.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleScatterNd *)
+luci::CircleNode *CloneNodeLet<CN::STUV>::visit(const luci::CircleScatterNd *)
 {
   return _graph->nodes()->create<luci::CircleScatterNd>();
 }

--- a/compiler/luci/service/src/Nodes/CircleSegmentSum.cpp
+++ b/compiler/luci/service/src/Nodes/CircleSegmentSum.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleSegmentSum *)
+luci::CircleNode *CloneNodeLet<CN::STUV>::visit(const luci::CircleSegmentSum *)
 {
   return _graph->nodes()->create<luci::CircleSegmentSum>();
 }

--- a/compiler/luci/service/src/Nodes/CircleSelect.cpp
+++ b/compiler/luci/service/src/Nodes/CircleSelect.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleSelect *)
+luci::CircleNode *CloneNodeLet<CN::STUV>::visit(const luci::CircleSelect *)
 {
   return _graph->nodes()->create<luci::CircleSelect>();
 }

--- a/compiler/luci/service/src/Nodes/CircleSelectV2.cpp
+++ b/compiler/luci/service/src/Nodes/CircleSelectV2.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleSelectV2 *)
+luci::CircleNode *CloneNodeLet<CN::STUV>::visit(const luci::CircleSelectV2 *)
 {
   return _graph->nodes()->create<luci::CircleSelectV2>();
 }

--- a/compiler/luci/service/src/Nodes/CircleShape.cpp
+++ b/compiler/luci/service/src/Nodes/CircleShape.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleShape *node)
+luci::CircleNode *CloneNodeLet<CN::STUV>::visit(const luci::CircleShape *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleShape>();
   if (cloned != nullptr)

--- a/compiler/luci/service/src/Nodes/CircleSin.cpp
+++ b/compiler/luci/service/src/Nodes/CircleSin.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleSin *)
+luci::CircleNode *CloneNodeLet<CN::STUV>::visit(const luci::CircleSin *)
 {
   return _graph->nodes()->create<luci::CircleSin>();
 }

--- a/compiler/luci/service/src/Nodes/CircleSlice.cpp
+++ b/compiler/luci/service/src/Nodes/CircleSlice.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleSlice *)
+luci::CircleNode *CloneNodeLet<CN::STUV>::visit(const luci::CircleSlice *)
 {
   return _graph->nodes()->create<luci::CircleSlice>();
 }

--- a/compiler/luci/service/src/Nodes/CircleSoftmax.cpp
+++ b/compiler/luci/service/src/Nodes/CircleSoftmax.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleSoftmax *node)
+luci::CircleNode *CloneNodeLet<CN::STUV>::visit(const luci::CircleSoftmax *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleSoftmax>();
   if (cloned != nullptr)

--- a/compiler/luci/service/src/Nodes/CircleSpaceToBatchND.cpp
+++ b/compiler/luci/service/src/Nodes/CircleSpaceToBatchND.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleSpaceToBatchND *)
+luci::CircleNode *CloneNodeLet<CN::STUV>::visit(const luci::CircleSpaceToBatchND *)
 {
   return _graph->nodes()->create<luci::CircleSpaceToBatchND>();
 }

--- a/compiler/luci/service/src/Nodes/CircleSpaceToDepth.cpp
+++ b/compiler/luci/service/src/Nodes/CircleSpaceToDepth.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleSpaceToDepth *node)
+luci::CircleNode *CloneNodeLet<CN::STUV>::visit(const luci::CircleSpaceToDepth *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleSpaceToDepth>();
   if (cloned != nullptr)

--- a/compiler/luci/service/src/Nodes/CircleSparseToDense.cpp
+++ b/compiler/luci/service/src/Nodes/CircleSparseToDense.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleSparseToDense *node)
+luci::CircleNode *CloneNodeLet<CN::STUV>::visit(const luci::CircleSparseToDense *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleSparseToDense>();
   if (cloned != nullptr)

--- a/compiler/luci/service/src/Nodes/CircleSplit.cpp
+++ b/compiler/luci/service/src/Nodes/CircleSplit.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleSplit *node)
+luci::CircleNode *CloneNodeLet<CN::STUV>::visit(const luci::CircleSplit *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleSplit>();
   if (cloned != nullptr)

--- a/compiler/luci/service/src/Nodes/CircleSplitV.cpp
+++ b/compiler/luci/service/src/Nodes/CircleSplitV.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleSplitV *node)
+luci::CircleNode *CloneNodeLet<CN::STUV>::visit(const luci::CircleSplitV *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleSplitV>();
   if (cloned != nullptr)

--- a/compiler/luci/service/src/Nodes/CircleSqrt.cpp
+++ b/compiler/luci/service/src/Nodes/CircleSqrt.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleSqrt *)
+luci::CircleNode *CloneNodeLet<CN::STUV>::visit(const luci::CircleSqrt *)
 {
   return _graph->nodes()->create<luci::CircleSqrt>();
 }

--- a/compiler/luci/service/src/Nodes/CircleSquare.cpp
+++ b/compiler/luci/service/src/Nodes/CircleSquare.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleSquare *)
+luci::CircleNode *CloneNodeLet<CN::STUV>::visit(const luci::CircleSquare *)
 {
   return _graph->nodes()->create<luci::CircleSquare>();
 }

--- a/compiler/luci/service/src/Nodes/CircleSquaredDifference.cpp
+++ b/compiler/luci/service/src/Nodes/CircleSquaredDifference.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleSquaredDifference *)
+luci::CircleNode *CloneNodeLet<CN::STUV>::visit(const luci::CircleSquaredDifference *)
 {
   return _graph->nodes()->create<luci::CircleSquaredDifference>();
 }

--- a/compiler/luci/service/src/Nodes/CircleSqueeze.cpp
+++ b/compiler/luci/service/src/Nodes/CircleSqueeze.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleSqueeze *node)
+luci::CircleNode *CloneNodeLet<CN::STUV>::visit(const luci::CircleSqueeze *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleSqueeze>();
   if (cloned != nullptr)

--- a/compiler/luci/service/src/Nodes/CircleStridedSlice.cpp
+++ b/compiler/luci/service/src/Nodes/CircleStridedSlice.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleStridedSlice *node)
+luci::CircleNode *CloneNodeLet<CN::STUV>::visit(const luci::CircleStridedSlice *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleStridedSlice>();
   if (cloned != nullptr)

--- a/compiler/luci/service/src/Nodes/CircleSub.cpp
+++ b/compiler/luci/service/src/Nodes/CircleSub.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleSub *node)
+luci::CircleNode *CloneNodeLet<CN::STUV>::visit(const luci::CircleSub *node)
 {
   if (node->fusedActivationFunction() == luci::FusedActFunc::UNDEFINED)
     return nullptr;

--- a/compiler/luci/service/src/Nodes/CircleSum.cpp
+++ b/compiler/luci/service/src/Nodes/CircleSum.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleSum *node)
+luci::CircleNode *CloneNodeLet<CN::STUV>::visit(const luci::CircleSum *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleSum>();
   if (cloned != nullptr)

--- a/compiler/luci/service/src/Nodes/CircleTanh.cpp
+++ b/compiler/luci/service/src/Nodes/CircleTanh.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleTanh *)
+luci::CircleNode *CloneNodeLet<CN::STUV>::visit(const luci::CircleTanh *)
 {
   return _graph->nodes()->create<luci::CircleTanh>();
 }

--- a/compiler/luci/service/src/Nodes/CircleTile.cpp
+++ b/compiler/luci/service/src/Nodes/CircleTile.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleTile *)
+luci::CircleNode *CloneNodeLet<CN::STUV>::visit(const luci::CircleTile *)
 {
   return _graph->nodes()->create<luci::CircleTile>();
 }

--- a/compiler/luci/service/src/Nodes/CircleTopKV2.cpp
+++ b/compiler/luci/service/src/Nodes/CircleTopKV2.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleTopKV2 *)
+luci::CircleNode *CloneNodeLet<CN::STUV>::visit(const luci::CircleTopKV2 *)
 {
   return _graph->nodes()->create<luci::CircleTopKV2>();
 }

--- a/compiler/luci/service/src/Nodes/CircleTranspose.cpp
+++ b/compiler/luci/service/src/Nodes/CircleTranspose.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleTranspose *)
+luci::CircleNode *CloneNodeLet<CN::STUV>::visit(const luci::CircleTranspose *)
 {
   return _graph->nodes()->create<luci::CircleTranspose>();
 }

--- a/compiler/luci/service/src/Nodes/CircleTransposeConv.cpp
+++ b/compiler/luci/service/src/Nodes/CircleTransposeConv.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleTransposeConv *node)
+luci::CircleNode *CloneNodeLet<CN::STUV>::visit(const luci::CircleTransposeConv *node)
 {
   if (node->padding() == luci::Padding::UNDEFINED)
     return nullptr;

--- a/compiler/luci/service/src/Nodes/CircleUnidirectionalSequenceLSTM.cpp
+++ b/compiler/luci/service/src/Nodes/CircleUnidirectionalSequenceLSTM.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleUnidirectionalSequenceLSTM *node)
+luci::CircleNode *CloneNodeLet<CN::STUV>::visit(const luci::CircleUnidirectionalSequenceLSTM *node)
 {
   if (node->fusedActivationFunction() == luci::FusedActFunc::UNDEFINED)
     return nullptr;

--- a/compiler/luci/service/src/Nodes/CircleUnique.cpp
+++ b/compiler/luci/service/src/Nodes/CircleUnique.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleUnique *node)
+luci::CircleNode *CloneNodeLet<CN::STUV>::visit(const luci::CircleUnique *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleUnique>();
   if (cloned != nullptr)

--- a/compiler/luci/service/src/Nodes/CircleUnpack.cpp
+++ b/compiler/luci/service/src/Nodes/CircleUnpack.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleUnpack *node)
+luci::CircleNode *CloneNodeLet<CN::STUV>::visit(const luci::CircleUnpack *node)
 {
   auto *cloned = _graph->nodes()->create<luci::CircleUnpack>();
   if (cloned != nullptr)

--- a/compiler/luci/service/src/Nodes/CircleWhere.cpp
+++ b/compiler/luci/service/src/Nodes/CircleWhere.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleWhere *)
+luci::CircleNode *CloneNodeLet<CN::VWXYZ>::visit(const luci::CircleWhere *)
 {
   return _graph->nodes()->create<luci::CircleWhere>();
 }

--- a/compiler/luci/service/src/Nodes/CircleZerosLike.cpp
+++ b/compiler/luci/service/src/Nodes/CircleZerosLike.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNode::visit(const luci::CircleZerosLike *)
+luci::CircleNode *CloneNodeLet<CN::VWXYZ>::visit(const luci::CircleZerosLike *)
 {
   return _graph->nodes()->create<luci::CircleZerosLike>();
 }


### PR DESCRIPTION
This will group CloneNode to small subclass from S to Z.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>