### PR TITLE
[luci/import] Introduce getter of source_table

### DIFF
--- a/compiler/luci/import/src/CircleImportMetadata.h
+++ b/compiler/luci/import/src/CircleImportMetadata.h
@@ -45,6 +45,8 @@ public:
    */
   const OriginTable origin_table(void);
 
+  const std::map<uint32_t, std::string> &source_table(void) const { return _source_table; }
+
 private:
   // Decoded metadata is stored
   std::map<uint32_t, std::string> _source_table;


### PR DESCRIPTION
Parent Issue : #6952
Draft : #6953

This commit introduces getter of `source_table` in `CircleImportMetadata.h`.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>