### PR TITLE
[luci/export] Export source_table in Module

### DIFF
--- a/compiler/luci/export/src/CircleExporterImpl.cpp
+++ b/compiler/luci/export/src/CircleExporterImpl.cpp
@@ -224,6 +224,7 @@ void CircleExporterImpl::exportModule(Module *module)
   auto description = _builder.CreateString(description_str);
 
   // Metadata
+  md._metadata.source_table(module->source_table());
   auto metadata_vec = createCircleMetadataVector(_builder, md);
   auto metadata = _builder.CreateVector(std::vector<Offset<Metadata>>(metadata_vec));
 

--- a/compiler/luci/export/src/SerializedData.h
+++ b/compiler/luci/export/src/SerializedData.h
@@ -51,6 +51,8 @@ struct OpCode
 class CircleExportMetadata
 {
 public:
+  void source_table(const std::map<uint32_t, std::string> &table) { _source_table = table; }
+
   void add_source_table(uint32_t source_id, std::string origin_name)
   {
     // Model with multiple subgraph may have different origin_name


### PR DESCRIPTION
Parent issue : #6952
Draft : #6953

Until now, newly generated `source_table` was exported.
From now on, this commit enable exporting `source_table` in `luci::Module`.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>