### PR TITLE
[luci/export] Remove no-effect function

### DIFF
--- a/compiler/luci/export/src/CircleOperationExporter.cpp
+++ b/compiler/luci/export/src/CircleOperationExporter.cpp
@@ -1507,7 +1507,6 @@ void exportNode(loco::Node *node, flatbuffers::FlatBufferBuilder &builder, Seria
       const auto node_id = gd._operators.size() - 1;
       for (auto source : get_origin(circle_node)->sources())
       {
-        md._metadata.add_source_table(source->id(), source->name());
         md._metadata.add_op_table(node_id, source->id());
       }
     }

--- a/compiler/luci/export/src/SerializedData.h
+++ b/compiler/luci/export/src/SerializedData.h
@@ -53,15 +53,6 @@ class CircleExportMetadata
 public:
   void source_table(const std::map<uint32_t, std::string> &table) { _source_table = table; }
 
-  void add_source_table(uint32_t source_id, std::string origin_name)
-  {
-    // Model with multiple subgraph may have different origin_name
-    // even if source_id is same. However, as we do not consider about
-    // multiple subgraph in profiling for now, just do not care those cases
-    // and support them correctly in the future.
-    _source_table.emplace(source_id, origin_name);
-  }
-
   void add_op_table(uint32_t node_id, uint32_t source_id)
   {
     // Model with multiple subgraph may have duplicated node id.


### PR DESCRIPTION
Parent issue : #6952
Draft : #6953

As `source_table` in `luci::Module` is overwritten, `add_source_table` has no effect.
This commit removes the function.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>