### PR TITLE
[luci] Quantize low weights to 16-bit zero

### DIFF
--- a/compiler/luci/pass/src/QuantizeDequantizeWeightsPass.cpp
+++ b/compiler/luci/pass/src/QuantizeDequantizeWeightsPass.cpp
@@ -124,6 +124,14 @@ void sym_wquant_per_channel(CircleConst *node, std::vector<float> &min, std::vec
 
   auto quantize = [&](uint32_t *indices, loco::TensorShape &dimension, int channel_dim_index) {
     int channel_idx = indices[channel_dim_index];
+
+    // Small scale factor produced by small weights, which can be quantized to 0 with scale 1.0f
+    // TODO find better way to fix very low scales
+    if (scaling_factor[channel_idx] < std::numeric_limits<float>::epsilon())
+    {
+      scaling_factor[channel_idx] = 1.0f;
+    }
+
     const float scaling_factor_inv = 1.0 / scaling_factor[channel_idx];
     auto data = node->at<loco::DataType::FLOAT32>(cal_offset(dimension, indices));
     data = data < nudged_min[channel_idx] ? nudged_min[channel_idx] : data;


### PR DESCRIPTION
This commit adds 16-bit quantization of low weights values to zero in QuantizeDequantizeWeightsPass.

ONE-DCO-1.0-Signed-off-by: Maksim Bronnikov <max120199@gmail.com>

-----------------

For: #6970