### PR TITLE
Fix coverity 1229862 : uinit variable in PoolParams

### DIFF
--- a/compute/cker/include/cker/Types.h
+++ b/compute/cker/include/cker/Types.h
@@ -80,8 +80,6 @@ enum class BroadcastableOpCategory : uint8_t
 
 struct PoolParams
 {
-  FusedActivationFunctionType activation;
-  PaddingType padding_type;
   PaddingValues padding_values;
   int stride_height;
   int stride_width;

--- a/runtime/onert/backend/cpu/ops/PoolLayer.cc
+++ b/runtime/onert/backend/cpu/ops/PoolLayer.cc
@@ -79,7 +79,11 @@ PoolLayer::PoolLayer() : _input(nullptr), _output(nullptr), _kernel()
   op_params.filter_height = kernelHeight;               \
   op_params.filter_width = kernelWidth;                 \
   op_params.padding_values.height = (int8_t)paddingTop; \
-  op_params.padding_values.width = (int8_t)paddingLeft;
+  op_params.padding_values.width = (int8_t)paddingLeft; \
+  op_params.float_activation_min = 0;                   \
+  op_params.float_activation_max = 0;                   \
+  op_params.quantized_activation_min = 0;               \
+  op_params.quantized_activation_max = 0;
 
 void PoolLayer::configure(const IPortableTensor *input, const uint32_t paddingLeft, const uint32_t,
                           const uint32_t paddingTop, const uint32_t, const uint32_t strideWidth,


### PR DESCRIPTION
Remove activation, padding_type
Add initilization for others

ONE-DCO-1.0-Signed-off-by: Chunseok Lee <chunseok.lee@samsung.com>