### PR TITLE
[luci] Introduce change_outputs

### DIFF
--- a/compiler/luci/service/include/luci/Service/ChangeOutputs.h
+++ b/compiler/luci/service/include/luci/Service/ChangeOutputs.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __LUCI_SVC_CHANGE_OUTPUTS_H__
+#define __LUCI_SVC_CHANGE_OUTPUTS_H__
+
+#include <loco/IR/Graph.h>
+
+#include <string>
+#include <vector>
+
+namespace luci
+{
+
+/**
+ * @brief Change output to nodes with string name.
+ *
+ * @note  Should match existing number of nodes and all names should exist.
+ *        Will throw exception if failed.
+ */
+void change_outputs(loco::Graph *, const std::vector<std::string> &);
+
+} // namespace luci
+
+#endif // __LUCI_SVC_CHANGE_OUTPUTS_H__

--- a/compiler/luci/service/src/ChangeOutputs.cpp
+++ b/compiler/luci/service/src/ChangeOutputs.cpp
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Service/ChangeOutputs.h"
+
+#include <luci/IR/CircleNode.h>
+
+#include <loco/IR/Graph.h>
+
+#include <oops/UserExn.h>
+
+#include <cassert>
+#include <iostream>
+#include <map>
+
+namespace
+{
+
+luci::CircleNode *find_by_name(loco::Graph *g, const std::string &name)
+{
+  for (auto node : loco::all_nodes(g))
+  {
+    auto cnode = loco::must_cast<luci::CircleNode *>(node);
+    if (cnode->name() == name)
+      return cnode;
+  }
+  return nullptr;
+}
+
+} // namespace
+
+namespace luci
+{
+
+void change_outputs(loco::Graph *graph, const std::vector<std::string> &new_outputs)
+{
+  if (new_outputs.size() != graph->outputs()->size())
+  {
+    throw oops::UserExn("Change outputs failed: number of outputs should be ",
+                        graph->outputs()->size());
+  }
+
+  std::map<std::string, luci::CircleNode *> named_nodes;
+
+  for (auto &node_name : new_outputs)
+  {
+    auto node = find_by_name(graph, node_name);
+    if (node == nullptr)
+    {
+      throw oops::UserExn("Change outputs failed: node not found: ", node_name);
+    }
+    named_nodes[node_name] = node;
+  }
+  // just to be sure
+  assert(graph->outputs()->size() == named_nodes.size());
+
+  for (uint32_t out = 0; out < graph->outputs()->size(); ++out)
+  {
+    auto output = luci::output_node(graph, out); // output is CircleOutput
+    assert(output != nullptr);
+
+    auto node_name = new_outputs.at(out);
+    auto node = named_nodes[node_name];
+    assert(node != nullptr);
+
+    output->from(node);
+
+    // update GraphOutput shape, dtype to node
+    auto graph_out = graph->outputs()->at(out);
+    auto output_shape = std::make_unique<loco::TensorShape>();
+
+    output_shape->rank(node->rank());
+    for (uint32_t r = 0; r < node->rank(); ++r)
+    {
+      if (node->dim(r).known())
+        output_shape->dim(r).set(node->dim(r).value());
+      else
+        output_shape->dim(r).unset();
+    }
+    graph_out->shape(std::move(output_shape));
+    graph_out->dtype(node->dtype());
+  }
+}
+
+} // namespace luci

--- a/compiler/luci/service/src/ChangeOutputs.test.cpp
+++ b/compiler/luci/service/src/ChangeOutputs.test.cpp
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Service/ChangeOutputs.h"
+
+#include <luci/test/TestIOGraph.h>
+
+#include <luci/IR/Nodes/CircleSqrt.h>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+
+using namespace luci::test;
+
+class Sqrt2xGraphlet
+{
+public:
+  Sqrt2xGraphlet() = default;
+
+public:
+  void init(loco::Graph *g, const ShapeU32 input_shape)
+  {
+    _sqrt1 = g->nodes()->create<luci::CircleSqrt>();
+    _sqrt1->dtype(loco::DataType::S32);
+    _sqrt1->name("sqrt1");
+
+    _sqrt2 = g->nodes()->create<luci::CircleSqrt>();
+    _sqrt2->dtype(loco::DataType::S32);
+    _sqrt2->name("sqrt2");
+  }
+
+public:
+  luci::CircleSqrt *sqrt1(void) const { return _sqrt1; }
+  luci::CircleSqrt *sqrt2(void) const { return _sqrt2; }
+
+protected:
+  luci::CircleSqrt *_sqrt1 = nullptr;
+  luci::CircleSqrt *_sqrt2 = nullptr;
+};
+
+class Sqrt2xGraph : public TestIOGraph, public Sqrt2xGraphlet
+{
+public:
+  Sqrt2xGraph() = default;
+
+public:
+  void init(const ShapeU32 shape)
+  {
+    TestIOGraph::init(shape, shape);
+    Sqrt2xGraphlet::init(g(), shape);
+
+    _sqrt1->x(input());
+
+    _sqrt2->x(_sqrt1);
+
+    output()->from(_sqrt2);
+  }
+};
+
+} // namespace
+
+TEST(ChangeOutputsTest, change)
+{
+  Sqrt2xGraph g;
+
+  g.init({3, 3});
+
+  {
+    auto output = luci::output_node(g.g(), 0);
+    ASSERT_EQ(g.sqrt2(), output->from());
+  }
+
+  std::vector<std::string> names{"sqrt1"};
+
+  EXPECT_NO_THROW(luci::change_outputs(g.g(), names));
+
+  {
+    auto output = luci::output_node(g.g(), 0);
+    ASSERT_EQ(g.sqrt1(), output->from());
+  }
+}
+
+TEST(ChangeOutputsTest, name_not_found_NEG)
+{
+  Sqrt2xGraph g;
+
+  g.init({3, 3});
+
+  std::vector<std::string> names{"sqrt33"};
+
+  EXPECT_ANY_THROW(luci::change_outputs(g.g(), names));
+}
+
+TEST(ChangeOutputsTest, number_names_NEG)
+{
+  Sqrt2xGraph g;
+
+  g.init({3, 3});
+
+  std::vector<std::string> names{"sqrt1", "sqrt2"};
+
+  EXPECT_ANY_THROW(luci::change_outputs(g.g(), names));
+}


### PR DESCRIPTION
This will introduce change_outputs experimental method of luci to
change output nodes by node name.
- only work for first subgraph (main graph)

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>