### PR TITLE
[luci] Fix CloneNode typo in enum CN

### DIFF
--- a/compiler/luci/service/src/CircleCloneNode.cpp
+++ b/compiler/luci/service/src/CircleCloneNode.cpp
@@ -35,7 +35,7 @@ luci::CircleNode *CloneNode::visit(const luci::CircleNode *node)
   CNVISIT_GRP(KLMN);
   CNVISIT_GRP(OPQR);
   CNVISIT_GRP(STUV);
-  CNVISIT_GRP(VWXYZ);
+  CNVISIT_GRP(WXYZ);
 
   return nullptr;
 }

--- a/compiler/luci/service/src/CircleCloneNode.h
+++ b/compiler/luci/service/src/CircleCloneNode.h
@@ -33,7 +33,7 @@ enum class CN
   KLMN,
   OPQR,
   STUV,
-  VWXYZ,
+  WXYZ,
 };
 
 template <CN ct> class CloneNodeLet;
@@ -225,7 +225,7 @@ protected:
   loco::Graph *_graph = nullptr;
 };
 
-template <> class CloneNodeLet<CN::VWXYZ> final : public luci::CircleNodeVisitor<luci::CircleNode *>
+template <> class CloneNodeLet<CN::WXYZ> final : public luci::CircleNodeVisitor<luci::CircleNode *>
 {
 public:
   CloneNodeLet(loco::Graph *graph) : _graph(graph){};

--- a/compiler/luci/service/src/Nodes/CircleWhere.cpp
+++ b/compiler/luci/service/src/Nodes/CircleWhere.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNodeLet<CN::VWXYZ>::visit(const luci::CircleWhere *)
+luci::CircleNode *CloneNodeLet<CN::WXYZ>::visit(const luci::CircleWhere *)
 {
   return _graph->nodes()->create<luci::CircleWhere>();
 }

--- a/compiler/luci/service/src/Nodes/CircleZerosLike.cpp
+++ b/compiler/luci/service/src/Nodes/CircleZerosLike.cpp
@@ -19,7 +19,7 @@
 namespace luci
 {
 
-luci::CircleNode *CloneNodeLet<CN::VWXYZ>::visit(const luci::CircleZerosLike *)
+luci::CircleNode *CloneNodeLet<CN::WXYZ>::visit(const luci::CircleZerosLike *)
 {
   return _graph->nodes()->create<luci::CircleZerosLike>();
 }


### PR DESCRIPTION
This will fix CloneNode typo in enum class CN as WXYZ as V is declared two times.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>