### PR TITLE
[luci/profile] Add negative origin test

### DIFF
--- a/compiler/luci/profile/src/CircleNodeOrigin.test.cpp
+++ b/compiler/luci/profile/src/CircleNodeOrigin.test.cpp
@@ -42,6 +42,18 @@ TEST(LuciCircleNodeOrigin, simple_single_origin)
   }
 }
 
+TEST(LuciCircleNodeOrigin, add_null_origin_NEG)
+{
+  auto g = loco::make_graph();
+  auto add = g->nodes()->create<luci::CircleAdd>();
+
+  ASSERT_FALSE(has_origin(add));
+
+  add_origin(add, nullptr);
+
+  ASSERT_FALSE(has_origin(add));
+}
+
 TEST(LuciCircleNodeOrigin, simple_composite_origin_with_initializer)
 {
   auto g = loco::make_graph();


### PR DESCRIPTION
This commit adds negative test for origin: the case when adding null
origin.

ONE-DCO-1.0-Signed-off-by: Cheongyo Bahk <cg.bahk@gmail.com>

---

Testing with CI as I have no local build env :sob: