### PR TITLE
[luci/profile] Update logic of has_origin

### DIFF
--- a/compiler/luci/profile/src/CircleNodeOrigin.cpp
+++ b/compiler/luci/profile/src/CircleNodeOrigin.cpp
@@ -125,13 +125,25 @@ std::shared_ptr<CircleNodeOrigin> single_origin(uint32_t id, const std::string &
 std::shared_ptr<CircleNodeOrigin>
 composite_origin(const std::initializer_list<std::shared_ptr<CircleNodeOrigin>> origins)
 {
-  return std::make_shared<CompositeOrigin>(origins);
+  auto origin = std::make_shared<CompositeOrigin>(origins);
+
+  // For empty source, no need to create origin
+  if (origin->sources().empty())
+    return nullptr;
+
+  return origin;
 }
 
 std::shared_ptr<CircleNodeOrigin>
 composite_origin(const std::vector<std::shared_ptr<CircleNodeOrigin>> &origins)
 {
-  return std::make_shared<CompositeOrigin>(origins);
+  auto origin = std::make_shared<CompositeOrigin>(origins);
+
+  // For empty source, no need to create origin
+  if (origin->sources().empty())
+    return nullptr;
+
+  return origin;
 }
 
 } // namespace luci
@@ -141,7 +153,12 @@ namespace luci
 
 bool has_origin(const luci::CircleNode *circle_node)
 {
-  return circle_node->annot<CircleNodeOriginAnnotation>() != nullptr;
+  if (circle_node->annot<CircleNodeOriginAnnotation>() == nullptr)
+    return false;
+
+  assert(!circle_node->annot<CircleNodeOriginAnnotation>()->origin()->sources().empty());
+
+  return true;
 }
 
 /**
@@ -151,6 +168,10 @@ bool has_origin(const luci::CircleNode *circle_node)
  */
 void add_origin(luci::CircleNode *circle_node, const std::shared_ptr<CircleNodeOrigin> origin)
 {
+  // Nothing to add
+  if (origin == nullptr)
+    return;
+
   auto new_origin = composite_origin({get_origin(circle_node), origin});
   circle_node->annot<CircleNodeOriginAnnotation>(nullptr);
   circle_node->annot(std::make_unique<CircleNodeOriginAnnotation>(new_origin));

--- a/compiler/luci/profile/src/CircleNodeOrigin.test.cpp
+++ b/compiler/luci/profile/src/CircleNodeOrigin.test.cpp
@@ -106,3 +106,27 @@ TEST(LuciCircleNodeOrigin, composite_origin_empty_ctor_NEG)
 {
   ASSERT_ANY_THROW(luci::composite_origin({}));
 }
+
+TEST(LuciCircleNodeOrigin, add_null_origin_NEG)
+{
+  auto g = loco::make_graph();
+  auto add = g->nodes()->create<luci::CircleAdd>();
+
+  ASSERT_FALSE(has_origin(add));
+
+  add_origin(add, nullptr);
+
+  ASSERT_FALSE(has_origin(add));
+}
+
+TEST(LuciCircleNodeOrigin, add_empty_origin_NEG)
+{
+  auto g = loco::make_graph();
+  auto add = g->nodes()->create<luci::CircleAdd>();
+
+  ASSERT_FALSE(has_origin(add));
+
+  add_origin(add, luci::composite_origin({nullptr, nullptr}));
+
+  ASSERT_FALSE(has_origin(add));
+}


### PR DESCRIPTION
Originated from #7008

Until now, `has_origin` returned `true` when `sources()` is not empty.
However, empty `sources()` actually means that there are no origin information.
So this commit will update `has_origin` to return `false` when `sources()` is empty.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>