### PR TITLE
[luci-interpreter] Extract KernelBuilderLet for group ABC

### DIFF
--- a/compiler/luci-interpreter/src/loader/KernelBuilder.cpp
+++ b/compiler/luci-interpreter/src/loader/KernelBuilder.cpp
@@ -141,7 +141,7 @@ public:
   DECLARE_VISIT(CircleConv2D);
 };
 
-#undef DECLARE
+#undef DECLARE_VISIT
 
 std::unique_ptr<Kernel> KernelBuilder::visit(const luci::CircleNode *node)
 {
@@ -155,6 +155,8 @@ std::unique_ptr<Kernel> KernelBuilder::visit(const luci::CircleNode *node)
   } while (false)
 
   VISIT_KB(ABC);
+
+#undef VISIT_KB
 
   throw std::invalid_argument("Unsupported operator.");
 }

--- a/compiler/luci-interpreter/src/loader/KernelBuilder.h
+++ b/compiler/luci-interpreter/src/loader/KernelBuilder.h
@@ -43,13 +43,6 @@ public:
 
   std::unique_ptr<Kernel> visit(const luci::CircleNode *node) override;
 
-  std::unique_ptr<Kernel> visit(const luci::CircleAdd *node) override;
-  std::unique_ptr<Kernel> visit(const luci::CircleArgMax *node) override;
-  std::unique_ptr<Kernel> visit(const luci::CircleAveragePool2D *node) override;
-  std::unique_ptr<Kernel> visit(const luci::CircleBatchToSpaceND *node) override;
-  std::unique_ptr<Kernel> visit(const luci::CircleConcatenation *node) override;
-  std::unique_ptr<Kernel> visit(const luci::CircleConst *node) override;
-  std::unique_ptr<Kernel> visit(const luci::CircleConv2D *node) override;
   std::unique_ptr<Kernel> visit(const luci::CircleDepthToSpace *node) override;
   std::unique_ptr<Kernel> visit(const luci::CircleDepthwiseConv2D *node) override;
   std::unique_ptr<Kernel> visit(const luci::CircleDiv *node) override;


### PR DESCRIPTION
This will extract KernelBuilderLet for circle IR group ABC to reduce
class LoC violation score.

ONE-DCO-1.0-Signed-off-by: SaeHie Park saehie.park@gmail.com