### PR TITLE
[luci] Supprt import U8/S16 for SquaredDifference

### DIFF
--- a/compiler/luci/import/src/Nodes/CircleSquaredDifference.cpp
+++ b/compiler/luci/import/src/Nodes/CircleSquaredDifference.cpp
@@ -44,6 +44,10 @@ bool CircleSquaredDifferenceGraphBuilder::validate(const ValidateArgs &args) con
     case circle::TensorType_COMPLEX64:
       break;
     // TODO support bfloat16, complex128
+    // Additional support for quantized tensors
+    case circle::TensorType_UINT8:
+    case circle::TensorType_INT16:
+      break;
     default:
       return false;
   }


### PR DESCRIPTION
This will fix import of SquaredDifference to support U8/S16 tensor types.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>