### PR TITLE
[luci-interpreter] Revise KernelBuilder

### DIFF
--- a/compiler/luci-interpreter/src/loader/GraphLoader.cpp
+++ b/compiler/luci-interpreter/src/loader/GraphLoader.cpp
@@ -195,7 +195,7 @@ void GraphLoader::loadOperators()
 
     if (isExecutableNode(node))
     {
-      std::unique_ptr<Kernel> kernel = node->accept(&kernel_builder);
+      std::unique_ptr<Kernel> kernel = kernel_builder.build(node);
       _runtime_to_ir.kernel_to_node.emplace(kernel.get(), node);
       _runtime_graph->addKernel(std::move(kernel));
     }

--- a/compiler/luci-interpreter/src/loader/KernelBuilder.cpp
+++ b/compiler/luci-interpreter/src/loader/KernelBuilder.cpp
@@ -299,7 +299,7 @@ public:
 
 #undef DECLARE_VISIT
 
-std::unique_ptr<Kernel> KernelBuilder::visit(const luci::CircleNode *node)
+std::unique_ptr<Kernel> KernelBuilder::build(const luci::CircleNode *node)
 {
 #define VISIT_KB(GRP)                                                          \
   do                                                                           \

--- a/compiler/luci-interpreter/src/loader/KernelBuilder.h
+++ b/compiler/luci-interpreter/src/loader/KernelBuilder.h
@@ -30,8 +30,7 @@
 namespace luci_interpreter
 {
 
-class KernelBuilder : public luci::CircleNodeVisitor<std::unique_ptr<Kernel>>,
-                      public KernelBuilderHelper
+class KernelBuilder : public KernelBuilderHelper
 {
 public:
   KernelBuilder(
@@ -41,7 +40,7 @@ public:
   {
   }
 
-  std::unique_ptr<Kernel> visit(const luci::CircleNode *node) override;
+  std::unique_ptr<Kernel> build(const luci::CircleNode *node);
 };
 
 } // namespace luci_interpreter

--- a/compiler/luci-interpreter/src/loader/KernelBuilder.test.cpp
+++ b/compiler/luci-interpreter/src/loader/KernelBuilder.test.cpp
@@ -121,7 +121,7 @@ protected:
 
     KernelBuilder kernel_builder(graph_to_runtime_graph, _node_to_tensor);
 
-    auto kernel = op->accept(&kernel_builder);
+    auto kernel = kernel_builder.build(op);
     return std::unique_ptr<KernelT>(dynamic_cast<KernelT *>(kernel.release()));
   }
 


### PR DESCRIPTION
This will revise KernelBuild class not to inherit from Visitor as not
needed anymore and rename visit method to build.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>