### PR TITLE
[luci] Add undef for CNVISIT_GRP

### DIFF
--- a/compiler/luci/service/src/CircleCloneNode.cpp
+++ b/compiler/luci/service/src/CircleCloneNode.cpp
@@ -37,6 +37,8 @@ luci::CircleNode *CloneNode::visit(const luci::CircleNode *node)
   CNVISIT_GRP(STUV);
   CNVISIT_GRP(WXYZ);
 
+#undef CNVISIT_GRP
+
   return nullptr;
 }
 


### PR DESCRIPTION
This will add undef for CNVISIT_GRP in CircleCloneNode.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>