### PR TITLE
[infra] Add dh-python to focal Dockerfile

### DIFF
--- a/infra/docker/focal/Dockerfile
+++ b/infra/docker/focal/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && apt-get -qqy install software-properties-common
 RUN apt-get update && apt-get -qqy install build-essential cmake scons git lcov g++-arm-linux-gnueabihf g++-aarch64-linux-gnu
 
 # Debian build tool
-RUN apt-get update && apt-get -qqy install fakeroot devscripts debhelper python3-all
+RUN apt-get update && apt-get -qqy install fakeroot devscripts debhelper python3-all dh-python
 
 # Install extra dependencies (Caffe, nnkit)
 RUN apt-get update && apt-get -qqy install libboost-all-dev libgflags-dev libgoogle-glog-dev libatlas-base-dev libhdf5-dev


### PR DESCRIPTION
This commit adds `dh-python` to focal Dockerfile.

Related: #6978 
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>