### PR TITLE
[one-cmds] Flush commands

### DIFF
--- a/compiler/one-cmds/one-build
+++ b/compiler/one-cmds/one-build
@@ -132,6 +132,7 @@ def main():
                 cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, bufsize=1) as p:
             for line in p.stdout:
                 sys.stdout.buffer.write(line)
+                sys.stdout.buffer.flush()
         if p.returncode != 0:
             sys.exit(p.returncode)
 

--- a/compiler/one-cmds/one-codegen
+++ b/compiler/one-cmds/one-codegen
@@ -159,6 +159,7 @@ def main():
             bufsize=1) as p:
         for line in p.stdout:
             sys.stdout.buffer.write(line)
+            sys.stdout.buffer.flush()
     if p.returncode != 0:
         sys.exit(p.returncode)
 

--- a/compiler/one-cmds/one-import-bcq
+++ b/compiler/one-cmds/one-import-bcq
@@ -147,6 +147,7 @@ def _convert(args):
                 bufsize=1) as p:
             for line in p.stdout:
                 sys.stdout.buffer.write(line)
+                sys.stdout.buffer.flush()
                 f.write(line)
         if p.returncode != 0:
             sys.exit(p.returncode)
@@ -178,6 +179,7 @@ def _convert(args):
                 bufsize=1) as p:
             for line in p.stdout:
                 sys.stdout.buffer.write(line)
+                sys.stdout.buffer.flush()
                 f.write(line)
         if p.returncode != 0:
             sys.exit(p.returncode)

--- a/compiler/one-cmds/one-import-onnx
+++ b/compiler/one-cmds/one-import-onnx
@@ -126,6 +126,7 @@ def _convert(args):
                 bufsize=1) as p:
             for line in p.stdout:
                 sys.stdout.buffer.write(line)
+                sys.stdout.buffer.flush()
                 f.write(line)
         if p.returncode != 0:
             sys.exit(p.returncode)
@@ -146,6 +147,7 @@ def _convert(args):
                 bufsize=1) as p:
             for line in p.stdout:
                 sys.stdout.buffer.write(line)
+                sys.stdout.buffer.flush()
                 f.write(line)
         if p.returncode != 0:
             sys.exit(p.returncode)

--- a/compiler/one-cmds/one-import-tf
+++ b/compiler/one-cmds/one-import-tf
@@ -158,6 +158,7 @@ def _convert(args):
                 bufsize=1) as p:
             for line in p.stdout:
                 sys.stdout.buffer.write(line)
+                sys.stdout.buffer.flush()
                 f.write(line)
         if p.returncode != 0:
             sys.exit(p.returncode)
@@ -178,6 +179,7 @@ def _convert(args):
                 bufsize=1) as p:
             for line in p.stdout:
                 sys.stdout.buffer.write(line)
+                sys.stdout.buffer.flush()
                 f.write(line)
         if p.returncode != 0:
             sys.exit(p.returncode)

--- a/compiler/one-cmds/one-import-tflite
+++ b/compiler/one-cmds/one-import-tflite
@@ -88,6 +88,7 @@ def _convert(args):
                 bufsize=1) as p:
             for line in p.stdout:
                 sys.stdout.buffer.write(line)
+                sys.stdout.buffer.flush()
                 f.write(line)
         if p.returncode != 0:
             sys.exit(p.returncode)

--- a/compiler/one-cmds/one-optimize
+++ b/compiler/one-cmds/one-optimize
@@ -111,6 +111,7 @@ def _optimize(args):
                 bufsize=1) as p:
             for line in p.stdout:
                 sys.stdout.buffer.write(line)
+                sys.stdout.buffer.flush()
                 f.write(line)
         if p.returncode != 0:
             sys.exit(p.returncode)

--- a/compiler/one-cmds/one-pack
+++ b/compiler/one-cmds/one-pack
@@ -96,6 +96,7 @@ def _pack(args):
                 bufsize=1) as p:
             for line in p.stdout:
                 sys.stdout.buffer.write(line)
+                sys.stdout.buffer.flush()
                 f.write(line)
         if p.returncode != 0:
             sys.exit(p.returncode)

--- a/compiler/one-cmds/one-quantize
+++ b/compiler/one-cmds/one-quantize
@@ -158,6 +158,7 @@ def _quantize(args):
                 bufsize=1) as p:
             for line in p.stdout:
                 sys.stdout.buffer.write(line)
+                sys.stdout.buffer.flush()
                 f.write(line)
         if p.returncode != 0:
             sys.exit(p.returncode)
@@ -201,6 +202,7 @@ def _quantize(args):
                 bufsize=1) as p:
             for line in p.stdout:
                 sys.stdout.buffer.write(line)
+                sys.stdout.buffer.flush()
                 f.write(line)
         if p.returncode != 0:
             sys.exit(p.returncode)
@@ -233,6 +235,7 @@ def _quantize(args):
                 bufsize=1) as p:
             for line in p.stdout:
                 sys.stdout.buffer.write(line)
+                sys.stdout.buffer.flush()
                 f.write(line)
         if p.returncode != 0:
             sys.exit(p.returncode)


### PR DESCRIPTION
This will add flush write execution to show log immediatly for long
execution commands, such as record-minmax.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>