### PR TITLE
[luci] Support more activation functions in FuseBatchNormWithDwConvPass

### DIFF
--- a/compiler/luci/pass/src/FuseBatchNormWithDwConvPass.cpp
+++ b/compiler/luci/pass/src/FuseBatchNormWithDwConvPass.cpp
@@ -96,10 +96,6 @@ bool fused_batch_norm_with_dwconv(luci::CircleAdd *add)
     return false;
   if (add->dtype() != loco::DataType::FLOAT32)
     return false;
-  // TODO support more Activations
-  if (add->fusedActivationFunction() != luci::FusedActFunc::NONE &&
-      add->fusedActivationFunction() != luci::FusedActFunc::RELU6)
-    return false;
 
   // get weight of dwconv
   auto filter = dynamic_cast<luci::CircleConst *>(dwconv->filter());


### PR DESCRIPTION
This support more activation functions in FuseBatchNormWithDwConvPass.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>