### PR TITLE
[luci] Relocate CHECK_OR_FALSE outside of method

### DIFF
--- a/compiler/luci/pass/src/FuseInstanceNormPass.cpp
+++ b/compiler/luci/pass/src/FuseInstanceNormPass.cpp
@@ -339,14 +339,14 @@ private:
   PatternVersion _pv;
 };
 
+#define CHECK_OR_FALSE(condition) \
+  if (not(condition))             \
+    return false;
+
 bool InstanceNormPattern::matched()
 {
   if (_matched)
     return true;
-
-#define CHECK_OR_FALSE(condition) \
-  if (not(condition))             \
-    return false;
 
   // Check order is DFS
 
@@ -518,10 +518,11 @@ bool InstanceNormPattern::matched()
     CHECK_OR_FALSE(mean_of_reshape == mean_of_reshape_should_be);
   }
 
-#undef CHECK_OR_FALSE
   _matched = true;
   return true;
 }
+
+#undef CHECK_OR_FALSE
 
 /**
  * Instance norm pattern would be fused like following diagram:


### PR DESCRIPTION
This will relocate CHECK_OR_FALSE macro outside of method.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>