### PR TITLE
[luci] Extract is_add_input_mul_const for FuseInstNorm

### DIFF
--- a/compiler/luci/pass/src/FuseInstanceNormPass.cpp
+++ b/compiler/luci/pass/src/FuseInstanceNormPass.cpp
@@ -603,6 +603,19 @@ void fuse_instance_norm(const InstanceNormPattern &p)
 
 } // namespace
 
+namespace
+{
+
+bool is_add_input_mul_const(luci::CircleAdd *add)
+{
+  luci::CircleMul *p_mul = nullptr;
+  luci::CircleConst *p_const = nullptr;
+
+  return luci::fill(&p_mul, &p_const).with_commutative_args_of(add);
+}
+
+} // namespace
+
 namespace luci
 {
 
@@ -622,12 +635,7 @@ bool FuseInstanceNormPass::run(loco::Graph *g)
         continue;
       pv = InstanceNormPattern::PatternVersion::Version_0;
 
-      auto x = loco::must_cast<luci::CircleNode *>(add->x());
-      auto y = loco::must_cast<luci::CircleNode *>(add->y());
-      if ((x->opcode() == luci::CircleOpcode::MUL &&
-           y->opcode() == luci::CircleOpcode::CIRCLECONST) ||
-          (x->opcode() == luci::CircleOpcode::CIRCLECONST &&
-           y->opcode() == luci::CircleOpcode::MUL))
+      if (is_add_input_mul_const(add))
         pv = InstanceNormPattern::PatternVersion::Version_2;
     }
     else


### PR DESCRIPTION
This will extract is_add_input_mul_const() method FuseInstanceNormPass
to check input of Add is Mul/Const.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>