### PR TITLE
[luci] Fix name for fused InstNorm node

### DIFF
--- a/compiler/luci/pass/src/FuseInstanceNormPass.cpp
+++ b/compiler/luci/pass/src/FuseInstanceNormPass.cpp
@@ -566,7 +566,7 @@ void fuse_instance_norm(const InstanceNormPattern &p)
   instance_norm->epsilon(epsilon);
   instance_norm->fusedActivationFunction(p.add_as_terminal->fusedActivationFunction());
   // NOTE unique name should be assigned in export
-  instance_norm->name("InstanceNorm");
+  instance_norm->name("FusedInstNorm/" + p.add_as_terminal->name());
 
   // set origin
   std::vector<std::shared_ptr<luci::CircleNodeOrigin>> origin_vec{


### PR DESCRIPTION
This will fix name for fused InstNorm node to be unique for multiple
instances.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>