### PR TITLE
[luci] Extract InstNorm match for version 0,1

### DIFF
--- a/compiler/luci/pass/src/FuseInstanceNormPass.cpp
+++ b/compiler/luci/pass/src/FuseInstanceNormPass.cpp
@@ -349,6 +349,144 @@ private:
   if (not(condition))             \
     return false;
 
+template <> bool InstanceNormPattern::match<InstanceNormPattern::PatternVersion::Version_0>()
+{
+  // Code inside extra curly brace is different part between Version_0 and Version_1
+  {
+    CHECK_OR_FALSE(luci::fill(&mul_as_scaled_ifm, &sub).with_commutative_args_of(add_as_terminal));
+    CHECK_OR_FALSE(luci::fill(&ifm, &mul_gamma).with_commutative_args_of(mul_as_scaled_ifm));
+  }
+
+  auto ifm_circle = loco::must_cast<luci::CircleNode *>(ifm);
+  CHECK_OR_FALSE(ifm_circle->shape_status() == luci::ShapeStatus::VALID);
+  CHECK_OR_FALSE(ifm_circle->rank() == 4);
+  CHECK_OR_FALSE(ifm_circle->dim(3).known());
+  uint32_t ifm_channel_depth = ifm_circle->dim(3).value();
+
+  CHECK_OR_FALSE(luci::fill(&rsqrt, &const_as_gamma).with_commutative_args_of(mul_gamma));
+
+  {
+    CHECK_OR_FALSE(is_1D_with_dummy_dim(const_as_gamma, ifm_channel_depth));
+  }
+
+  add_as_variance = dynamic_cast<luci::CircleAdd *>(rsqrt->x());
+  CHECK_OR_FALSE(add_as_variance);
+
+  CHECK_OR_FALSE(
+    luci::fill(&mean_as_variance, &const_as_epsilon).with_commutative_args_of(add_as_variance));
+
+  CHECK_OR_FALSE(const_as_epsilon->dtype() == loco::DataType::FLOAT32);
+  // TODO Support regarding broadcast
+  CHECK_OR_FALSE(const_as_epsilon->size<loco::DataType::FLOAT32>() == 1);
+
+  {
+    CHECK_OR_FALSE(is_instance_mean_v0(mean_as_variance));
+  }
+
+  sqdiff = dynamic_cast<luci::CircleSquaredDifference *>(mean_as_variance->input());
+  CHECK_OR_FALSE(sqdiff);
+
+  {
+    loco::Node *ifm_should_be = nullptr;
+    CHECK_OR_FALSE(luci::fill(&ifm_should_be, &mean_of_ifm).with_commutative_args_of(sqdiff));
+    CHECK_OR_FALSE(ifm == ifm_should_be);
+    CHECK_OR_FALSE(is_instance_mean_v0(mean_of_ifm));
+    CHECK_OR_FALSE(ifm == mean_of_ifm->input());
+  }
+
+  {
+    const_as_beta = dynamic_cast<luci::CircleConst *>(sub->x());
+    CHECK_OR_FALSE(const_as_beta);
+    CHECK_OR_FALSE(is_1D_with_dummy_dim(const_as_beta, ifm_channel_depth));
+  }
+
+  luci::CircleMul *mul_gamma_should_be = nullptr;
+  luci::CircleMean *mean_of_ifm_should_be = nullptr;
+
+  {
+    mul_as_scaled_mean = dynamic_cast<luci::CircleMul *>(sub->y());
+    CHECK_OR_FALSE(mul_as_scaled_mean);
+    CHECK_OR_FALSE(luci::fill(&mul_gamma_should_be, &mean_of_ifm_should_be)
+                     .with_commutative_args_of(mul_as_scaled_mean));
+    CHECK_OR_FALSE(mul_gamma == mul_gamma_should_be);
+    CHECK_OR_FALSE(mean_of_ifm == mean_of_ifm_should_be);
+  }
+
+  _matched = true;
+  return true;
+}
+
+template <> bool InstanceNormPattern::match<InstanceNormPattern::PatternVersion::Version_1>()
+{
+  // Code inside extra curly brace is different part between Version_0 and Version_1
+  {
+    CHECK_OR_FALSE(
+      luci::fill(&mul_as_scaled_reshape, &sub).with_commutative_args_of(add_as_terminal));
+    CHECK_OR_FALSE(
+      luci::fill(&reshape_of_ifm, &mul_gamma).with_commutative_args_of(mul_as_scaled_reshape));
+    ifm = reshape_of_ifm->tensor();
+  }
+
+  auto ifm_circle = loco::must_cast<luci::CircleNode *>(ifm);
+  CHECK_OR_FALSE(ifm_circle->shape_status() == luci::ShapeStatus::VALID);
+  CHECK_OR_FALSE(ifm_circle->rank() == 4);
+  CHECK_OR_FALSE(ifm_circle->dim(3).known());
+  uint32_t ifm_channel_depth = ifm_circle->dim(3).value();
+
+  CHECK_OR_FALSE(luci::fill(&rsqrt, &const_as_gamma).with_commutative_args_of(mul_gamma));
+
+  {
+    CHECK_OR_FALSE(is_quasi_1D_with_dummy_dim(const_as_gamma, ifm_channel_depth));
+  }
+
+  add_as_variance = dynamic_cast<luci::CircleAdd *>(rsqrt->x());
+  CHECK_OR_FALSE(add_as_variance);
+
+  CHECK_OR_FALSE(
+    luci::fill(&mean_as_variance, &const_as_epsilon).with_commutative_args_of(add_as_variance));
+
+  CHECK_OR_FALSE(const_as_epsilon->dtype() == loco::DataType::FLOAT32);
+  // TODO Support regarding broadcast
+  CHECK_OR_FALSE(const_as_epsilon->size<loco::DataType::FLOAT32>() == 1);
+
+  {
+    CHECK_OR_FALSE(is_instance_mean_v1(mean_as_variance));
+  }
+
+  sqdiff = dynamic_cast<luci::CircleSquaredDifference *>(mean_as_variance->input());
+  CHECK_OR_FALSE(sqdiff);
+
+  {
+    loco::Node *reshape_should_be = nullptr;
+    CHECK_OR_FALSE(
+      luci::fill(&reshape_should_be, &mean_of_reshape).with_commutative_args_of(sqdiff));
+    CHECK_OR_FALSE(reshape_of_ifm == reshape_should_be);
+    CHECK_OR_FALSE(is_instance_mean_v1(mean_of_reshape));
+    CHECK_OR_FALSE(reshape_of_ifm == mean_of_reshape->input());
+  }
+
+  {
+    const_as_beta = dynamic_cast<luci::CircleConst *>(sub->x());
+    CHECK_OR_FALSE(const_as_beta);
+    CHECK_OR_FALSE(is_quasi_1D_with_dummy_dim(const_as_beta, ifm_channel_depth));
+  }
+
+  luci::CircleMul *mul_gamma_should_be = nullptr;
+  luci::CircleMean *mean_of_reshape_should_be = nullptr;
+
+  {
+    mul_as_scaled_mean = dynamic_cast<luci::CircleMul *>(sub->y());
+    CHECK_OR_FALSE(mul_as_scaled_mean);
+    CHECK_OR_FALSE(luci::fill(&mul_gamma_should_be, &mean_of_reshape_should_be)
+                     .with_commutative_args_of(mul_as_scaled_mean));
+    CHECK_OR_FALSE(mul_gamma == mul_gamma_should_be);
+    CHECK_OR_FALSE(mean_of_reshape == mean_of_reshape_should_be);
+  }
+
+  _matched = true;
+  return true;
+}
+
 template <> bool InstanceNormPattern::match<InstanceNormPattern::PatternVersion::Version_2>()
 {
   CHECK_OR_FALSE(luci::fill(&mul_gamma, &const_as_beta).with_commutative_args_of(add_as_terminal));
@@ -418,6 +556,10 @@ bool InstanceNormPattern::matched()
 
   switch (_pv)
   {
+    case PatternVersion::Version_0:
+      return match<PatternVersion::Version_0>();
+    case PatternVersion::Version_1:
+      return match<PatternVersion::Version_1>();
     case PatternVersion::Version_2:
       return match<PatternVersion::Version_2>();
 
@@ -490,7 +632,7 @@ bool InstanceNormPattern::matched()
     return true;
   }
 #endif
-
+#if 0
   if (_pv == PatternVersion::Version_0)
   {
     CHECK_OR_FALSE(luci::fill(&mul_as_scaled_ifm, &sub).with_commutative_args_of(add_as_terminal));
@@ -598,6 +740,8 @@ bool InstanceNormPattern::matched()
 
   _matched = true;
   return true;
+#endif
+  throw std::runtime_error("Invalid InstanceNorm PatternVersion.");
 }
 
 #undef CHECK_OR_FALSE


### PR DESCRIPTION
This will extract InstanceNorm pattern match for version 0 and 1 to its
own method.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>