### PR TITLE
[tool/tflitefile] Fix requirements.txt

### DIFF
--- a/tools/tflitefile_tool/requirements.txt
+++ b/tools/tflitefile_tool/requirements.txt
@@ -1,2 +1,2 @@
-flatbuffers>=1.12
+flatbuffers==1.12
 numpy


### PR DESCRIPTION
This commit fixes 'flatbuffers' version for `tflitefile` tools, like
`select_operator.py`.

ONE-DCO-1.0-Signed-off-by: Cheongyo Bahk <cg.bahk@gmail.com>

---
Due to https://github.com/Samsung/ONE/issues/7086

Not sure `requirements.txt` is only for `select_operator.py`