### PR TITLE
[luci-interpreter] Node name for unsupported op msg

### DIFF
--- a/compiler/luci-interpreter/src/loader/KernelBuilder.cpp
+++ b/compiler/luci-interpreter/src/loader/KernelBuilder.cpp
@@ -320,8 +320,9 @@ std::unique_ptr<Kernel> KernelBuilder::build(const luci::CircleNode *node)
   VISIT_KB(STUV);
 
 #undef VISIT_KB
-
-  throw std::invalid_argument("Unsupported operator.");
+  std::string msg = "Unsupported operator: ";
+  msg += std::to_string(static_cast<uint32_t>(node->opcode())) + " " + std::string(node->name());
+  throw std::invalid_argument(msg.c_str());
 }
 
 std::unique_ptr<Kernel> KernelBuilderLet<KB::ABC>::visit(const luci::CircleAdd *node)


### PR DESCRIPTION
This will revise error message to show node name to help finding the
problem.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>