### PR TITLE
[luci] Provide ver 1,2 for FuseInstanceNorm::apply

### DIFF
--- a/compiler/luci/pass/src/FuseInstanceNormPass.cpp
+++ b/compiler/luci/pass/src/FuseInstanceNormPass.cpp
@@ -837,6 +837,56 @@ template <> void FuseInstanceNorm::apply<InstanceNormPattern::PatternVersion::Ve
   replace(_p.add_as_terminal).with(instance_norm);
 }
 
+template <> void FuseInstanceNorm::apply<InstanceNormPattern::PatternVersion::Version_1>()
+{
+  auto graph = _p.add_as_terminal->graph();
+
+  reshape_gamma_beta();
+
+  auto instance_norm = create_inst_norm(graph);
+
+  // set origin
+  std::vector<std::shared_ptr<luci::CircleNodeOrigin>> origin_vec{
+    luci::get_origin(_p.reshape_of_ifm),
+    luci::get_origin(_p.mean_of_reshape),
+    luci::get_origin(_p.sqdiff),
+    luci::get_origin(_p.mean_as_variance),
+    luci::get_origin(_p.add_as_variance),
+    luci::get_origin(_p.rsqrt),
+    luci::get_origin(_p.mul_gamma),
+    luci::get_origin(_p.mul_as_scaled_mean),
+    luci::get_origin(_p.mul_as_scaled_reshape),
+    luci::get_origin(_p.sub),
+    luci::get_origin(_p.add_as_terminal)};
+
+  luci::add_origin(instance_norm, luci::composite_origin(origin_vec));
+
+  replace(_p.add_as_terminal).with(instance_norm);
+}
+
+template <> void FuseInstanceNorm::apply<InstanceNormPattern::PatternVersion::Version_2>()
+{
+  auto graph = _p.add_as_terminal->graph();
+
+  auto instance_norm = create_inst_norm(graph);
+
+  // set origin
+  std::vector<std::shared_ptr<luci::CircleNodeOrigin>> origin_vec{
+    luci::get_origin(_p.mean_of_ifm),
+    luci::get_origin(_p.sqdiff),
+    luci::get_origin(_p.mean_as_variance),
+    luci::get_origin(_p.add_as_variance),
+    luci::get_origin(_p.pow),
+    luci::get_origin(_p.sub),
+    luci::get_origin(_p.div),
+    luci::get_origin(_p.mul_gamma),
+    luci::get_origin(_p.add_as_terminal)};
+
+  luci::add_origin(instance_norm, luci::composite_origin(origin_vec));
+
+  replace(_p.add_as_terminal).with(instance_norm);
+}
+
 // TODO change return type void
 bool FuseInstanceNorm::apply()
 {
@@ -846,6 +896,12 @@ bool FuseInstanceNorm::apply()
   {
     case InstanceNormPattern::PatternVersion::Version_0:
       apply<InstanceNormPattern::PatternVersion::Version_0>();
+      return true;
+    case InstanceNormPattern::PatternVersion::Version_1:
+      apply<InstanceNormPattern::PatternVersion::Version_1>();
+      return true;
+    case InstanceNormPattern::PatternVersion::Version_2:
+      apply<InstanceNormPattern::PatternVersion::Version_2>();
       return true;
 
     default:


### PR DESCRIPTION
This will provide FuseInstanceNorm::apply() method for pattern version 1 and 2.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>