### PR TITLE
[luci] FuseInstNorm Version_3 pattern comment

### DIFF
--- a/compiler/luci/pass/src/FuseInstanceNormPass.cpp
+++ b/compiler/luci/pass/src/FuseInstanceNormPass.cpp
@@ -291,6 +291,45 @@ namespace
  *       |
  *       V
  *     [Out]
+ *-------------------------------------------------------------------
+ * Version_3
+ *                          [In]
+ *                            |
+ *                            V
+ *      +----+-------------- ifm ---+
+ *      |    |  (reduction    |     |  (reduction
+ *      |    |   indicies)    |     |   indicies)
+ *      |    |     |          |     |     |
+ *      |    V     V          |     V     V
+ *      |  mean_of_ifm        |   mean_of_ifm_2
+ *      |       |             |       |
+ *      V       |             V       |
+ *     sub <----+           sub_2 <---+
+ *      |                     |
+ *      |                     V
+ *      |                   square
+ *      |                     |   (reduction indicies)
+ *      |                     |            |
+ *      |                     V            |
+ *      |             mean_as_variance <---+
+ *      |                     |
+ *      |                     V
+ *      |                    sqrt    const_as_epsilon
+ *      |                     |            |
+ *      |                     V            |
+ *      |              add_as_variance <---+
+ *      |                     |
+ *      V                     |
+ *     div <------------------+    const_as_gamma
+ *      |                              |
+ *      V                              |
+ *    mul_gamma <----------------------+
+ *      |                const_as_beta
+ *      V                     |
+ *   add_as_terminal <--------+
+ *      |
+ *      V
+ *    [Out]
  */
 class InstanceNormPattern final
 {


### PR DESCRIPTION
This will add Version_3 pattern as comment of FuseInstanceNormPass.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>