### PR TITLE
Reslove Svace/Covertiy Defect

### DIFF
--- a/runtime/onert/backend/gpu_cl/open_cl/AccessType.h
+++ b/runtime/onert/backend/gpu_cl/open_cl/AccessType.h
@@ -26,6 +26,7 @@ namespace gpu_cl
 {
 enum class AccessType
 {
+  UNKNOWN,
   READ,
   WRITE,
   READ_WRITE,

--- a/runtime/onert/backend/gpu_cl/open_cl/Arguments.cc
+++ b/runtime/onert/backend/gpu_cl/open_cl/Arguments.cc
@@ -165,6 +165,8 @@ std::string GetImageModifier(AccessType access)
       return "__write_only";
     case AccessType::READ_WRITE:
       return "__read_write";
+    default:
+      throw std::runtime_error("Invalid AccessType");
   }
   return "";
 }

--- a/runtime/onert/backend/gpu_cl/open_cl/Buffer.h
+++ b/runtime/onert/backend/gpu_cl/open_cl/Buffer.h
@@ -93,7 +93,7 @@ private:
   void Release();
 
   cl_mem buffer_ = nullptr;
-  size_t size_;
+  size_t size_ = 0;
 };
 
 absl::Status CreateReadOnlyBuffer(size_t size_in_bytes, CLContext *context, Buffer *result);

--- a/runtime/onert/backend/gpu_cl/open_cl/ClDevice.cc
+++ b/runtime/onert/backend/gpu_cl/open_cl/ClDevice.cc
@@ -24,6 +24,9 @@
 #include "Util.h"
 #include "Status.h"
 
+#include "absl/strings/numbers.h"
+#include "absl/strings/str_split.h"
+
 namespace onert
 {
 namespace backend
@@ -211,10 +214,8 @@ DeviceInfo DeviceInfoFromDeviceID(cl_device_id id)
     info.mali_info = MaliInfo(device_name);
   }
   info.cl_version = ParseCLVersion(opencl_c_version);
-  /* TODO
-    info.extensions =
-        absl::StrSplit(GetDeviceInfo<std::string>(id, CL_DEVICE_EXTENSIONS), ' ');
-  */
+  info.extensions = absl::StrSplit(GetDeviceInfo<std::string>(id, CL_DEVICE_EXTENSIONS), ' ');
+
   info.supports_fp16 = false;
   info.supports_image3d_writes = false;
   for (const auto &ext : info.extensions)

--- a/runtime/onert/backend/gpu_cl/open_cl/ClKernel.h
+++ b/runtime/onert/backend/gpu_cl/open_cl/ClKernel.h
@@ -88,7 +88,7 @@ private:
 
   int binding_counter_ = -1;
 
-  std::string function_name_;
+  std::string function_name_ = nullptr;
   // reference to program from which kernel was created
   cl_program program_ = nullptr;
   cl_kernel kernel_ = nullptr;

--- a/runtime/onert/backend/gpu_cl/open_cl/ClMemory.cc
+++ b/runtime/onert/backend/gpu_cl/open_cl/ClMemory.cc
@@ -34,6 +34,8 @@ cl_mem_flags ToClMemFlags(AccessType access_type)
       return CL_MEM_WRITE_ONLY;
     case AccessType::READ_WRITE:
       return CL_MEM_READ_WRITE;
+    default:
+      return CL_MEM_READ_ONLY; // unreachable
   }
 
   return CL_MEM_READ_ONLY; // unreachable

--- a/runtime/onert/backend/gpu_cl/open_cl/ClMemory.cc
+++ b/runtime/onert/backend/gpu_cl/open_cl/ClMemory.cc
@@ -35,7 +35,7 @@ cl_mem_flags ToClMemFlags(AccessType access_type)
     case AccessType::READ_WRITE:
       return CL_MEM_READ_WRITE;
     default:
-      return CL_MEM_READ_ONLY; // unreachable
+      throw std::runtime_error("Invalid AccessType");
   }
 
   return CL_MEM_READ_ONLY; // unreachable

--- a/runtime/onert/backend/gpu_cl/open_cl/DeviceInfo.cc
+++ b/runtime/onert/backend/gpu_cl/open_cl/DeviceInfo.cc
@@ -22,6 +22,9 @@
 #include <string>
 #include <vector>
 
+#include "absl/strings/numbers.h"
+#include "absl/strings/str_split.h"
+
 namespace onert
 {
 namespace backend
@@ -77,26 +80,27 @@ MaliGPU GetMaliGPUVersion(const std::string &device_name)
 // Returns -1 if vendor-specific information cannot be parsed
 int GetAdrenoGPUVersion(const std::string &gpu_version)
 {
-  (void)gpu_version;
-  /* TODO
-    const std::string gpu = absl::AsciiStrToLower(gpu_version);
-    const std::vector<absl::string_view> words = absl::StrSplit(gpu, ' ');
-    int i = 0;
-    for (; i < words.size(); ++i) {
-      if (words[i].find("adreno") != words[i].npos) {
-        break;
-      }
+  const std::string gpu = absl::AsciiStrToLower(gpu_version);
+  const std::vector<absl::string_view> words = absl::StrSplit(gpu, ' ');
+  size_t i = 0;
+  for (; i < words.size(); ++i)
+  {
+    if (words[i].find("adreno") != words[i].npos)
+    {
+      break;
     }
-    i += 1;
-    for (; i < words.size(); ++i) {
-      int number;
-      bool is_number = absl::SimpleAtoi(words[i], &number);
-      // Adreno GPUs starts from 2xx, but opencl support should be only from 3xx
-      if (is_number && number >= 300) {
-        return number;
-      }
+  }
+  i += 1;
+  for (; i < words.size(); ++i)
+  {
+    int number;
+    bool is_number = absl::SimpleAtoi(words[i], &number);
+    // Adreno GPUs starts from 2xx, but opencl support should be only from 3xx
+    if (is_number && number >= 300)
+    {
+      return number;
     }
-  */
+  }
   return -1;
 }
 

--- a/runtime/onert/backend/gpu_cl/open_cl/DeviceInfo.h
+++ b/runtime/onert/backend/gpu_cl/open_cl/DeviceInfo.h
@@ -47,6 +47,7 @@ std::string VendorToString(Vendor v);
 
 enum class OpenCLVersion
 {
+  UNKNOWN,
   CL_1_0,
   CL_1_1,
   CL_1_2,
@@ -112,7 +113,7 @@ struct MaliInfo
 {
   MaliInfo() = default;
   explicit MaliInfo(const std::string &device_name);
-  MaliGPU gpu_version;
+  MaliGPU gpu_version = MaliGPU::UNKNOWN;
 
   bool IsMaliT6xx() const;
   bool IsMaliT7xx() const;
@@ -155,22 +156,22 @@ struct DeviceInfo
   bool SupportsSubGroupWithSize(int sub_group_size) const;
 
   std::vector<std::string> extensions;
-  bool supports_fp16;
-  bool supports_image3d_writes;
-  Vendor vendor;
-  OpenCLVersion cl_version;
-  int compute_units_count;
-  uint64_t buffer_max_size;
-  uint64_t image2d_max_width;
-  uint64_t image2d_max_height;
-  uint64_t image_buffer_max_size;
-  uint64_t image_array_max_layers;
-  uint64_t image3d_max_width;
-  uint64_t image3d_max_height;
-  uint64_t image3d_max_depth;
-  int max_work_group_size_x;
-  int max_work_group_size_y;
-  int max_work_group_size_z;
+  bool supports_fp16 = false;
+  bool supports_image3d_writes = false;
+  Vendor vendor = Vendor::kUnknown;
+  OpenCLVersion cl_version = OpenCLVersion::UNKNOWN;
+  int compute_units_count = 0;
+  uint64_t buffer_max_size = 0;
+  uint64_t image2d_max_width = 0;
+  uint64_t image2d_max_height = 0;
+  uint64_t image_buffer_max_size = 0;
+  uint64_t image_array_max_layers = 0;
+  uint64_t image3d_max_width = 0;
+  uint64_t image3d_max_height = 0;
+  uint64_t image3d_max_depth = 0;
+  int max_work_group_size_x = 0;
+  int max_work_group_size_y = 0;
+  int max_work_group_size_z = 0;
   std::vector<int> supported_subgroup_sizes;
 
   // rtn is ROUND_TO_NEAREST
@@ -178,8 +179,8 @@ struct DeviceInfo
   // Adreno 3xx supports only rtz, Adreno 4xx and more support rtn
   // Mali from T6xx supports rtn
   // PowerVR supports only rtz
-  bool supports_fp32_rtn;
-  bool supports_fp16_rtn;
+  bool supports_fp32_rtn = false;
+  bool supports_fp16_rtn = false;
 
   bool supports_r_f16_tex2d = false;
   bool supports_rg_f16_tex2d = false;

--- a/runtime/onert/backend/gpu_cl/open_cl/GpuObject.h
+++ b/runtime/onert/backend/gpu_cl/open_cl/GpuObject.h
@@ -194,7 +194,7 @@ protected:
   // friend void Decode(const data::GPUObjectDescriptor* fb_obj,
   //                    GPUObjectDescriptor* obj);
   mutable std::map<std::string, std::string> state_vars_;
-  AccessType access_type_;
+  AccessType access_type_ = AccessType::UNKNOWN;
 };
 
 using GPUObjectDescriptorPtr = std::unique_ptr<GPUObjectDescriptor>;

--- a/runtime/onert/backend/gpu_cl/open_cl/Shape.h
+++ b/runtime/onert/backend/gpu_cl/open_cl/Shape.h
@@ -388,7 +388,7 @@ struct DimensionGetterFunc
   template <Layout T> int32_t operator()() const
   {
     uint32_t i = GetAxisIndex<T>(axis);
-    return i >= 0 && i < l->dimensions.size() ? l->dimensions[i] : -1;
+    return i < l->dimensions.size() ? l->dimensions[i] : -1;
   }
   Axis axis;
   const Shape *l;
@@ -399,7 +399,7 @@ template <Axis A> struct DimensionSetterFixedAxisFunc
   template <Layout T> bool operator()() const
   {
     constexpr uint32_t i = GetAxisIndex<T>(A);
-    if (i >= 0 && i < l->dimensions.size())
+    if (i < l->dimensions.size())
     {
       l->dimensions[i] = v;
       return true;
@@ -415,7 +415,7 @@ struct DimensionSetterFunc
   template <Layout T> bool operator()() const
   {
     uint32_t i = GetAxisIndex<T>(axis);
-    if (i >= 0 && i < l->dimensions.size())
+    if (i < l->dimensions.size())
     {
       l->dimensions[i] = v;
       return true;

--- a/runtime/onert/backend/gpu_cl/open_cl/Tensor.cc
+++ b/runtime/onert/backend/gpu_cl/open_cl/Tensor.cc
@@ -499,8 +499,8 @@ int Tensor::GetAlignedChannels() const
 
 uint64_t Tensor::GetMemorySizeInBytes() const
 {
-  const int flt_size = SizeOf(descriptor_.data_type);
-  const int flt4_size = 4 * flt_size;
+  const uint64_t flt_size = static_cast<uint64_t>(SizeOf(descriptor_.data_type));
+  const uint64_t flt4_size = 4 * flt_size;
   switch (descriptor_.storage_type)
   {
     case TensorStorageType::BUFFER:


### PR DESCRIPTION
uint32_t is always greater than or equal to 0. So the '0 <= i' conditional statement is not needed.

Signed-off-by: hj0412-yi <hj0412.yi@samsung.com>