### PR TITLE
[onert] Fix gbs build for nnfw_api_gtest

### DIFF
--- a/infra/cmake/packages/Opencl_HeadersConfig.cmake
+++ b/infra/cmake/packages/Opencl_HeadersConfig.cmake
@@ -1,16 +1,21 @@
 function(_Opencl_Headers_import)
   nnas_find_package(Opencl_HeadersSource QUIET)
 
+  # NOTE This line prevents multiple definitions of target
+  if(TARGET Headers)
+    set(Opencl_HeadersSource_DIR ${Opencl_HeadersSource_DIR} PARENT_SCOPE)
+    set(Opencl_Headers_FOUND TRUE PARENT_SCOPE)
+    return()
+  endif(TARGET Headers)
+
   if(NOT Opencl_HeadersSource_FOUND)
+    message(STATUS "Opencl_Headers: Source not found")
     set(Opencl_Headers_FOUND FALSE PARENT_SCOPE)
     return()
   endif(NOT Opencl_HeadersSource_FOUND)
 
-  if(NOT TARGET opencl_headers)
-    nnas_include(ExternalProjectTools)
-    add_extdirectory("${Opencl_HeadersSource_DIR}" OPENCL_HEADERS)
-  endif(NOT TARGET opencl_headers)
-
+  add_extdirectory("${Opencl_HeadersSource_DIR}" OPENCL_HEADERS EXCLUDE_FROM_ALL)
+  set(Opencl_Headers_DIR ${Opencl_HeadersSource_DIR} PARENT_SCOPE)
   set(Opencl_Headers_FOUND TRUE PARENT_SCOPE)
 endfunction(_Opencl_Headers_import)
 

--- a/tests/nnfw_api/CMakeLists.txt
+++ b/tests/nnfw_api/CMakeLists.txt
@@ -24,6 +24,7 @@ if(Xnnpack_FOUND)
   target_compile_definitions(${RUNTIME_NNFW_API_TEST} PRIVATE TEST_XNNPACK_BACKEND)
 endif(Xnnpack_FOUND)
 
+nnas_find_package(Opencl_Headers QUIET)
 if(Opencl_Headers_FOUND)
   target_compile_definitions(${RUNTIME_NNFW_API_TEST} PRIVATE TEST_GPU_CL_BACKEND)
 endif(Opencl_Headers_FOUND)


### PR DESCRIPTION
TEST_GPU_CL_BACKEND was not enable because Opencl_Headers was not found on gbs build.
So, Fixed by adding nnas_find_package(Opencl_Headers QUIET).

Signed-off-by: hj0412-yi <hj0412.yi@samsung.com>