### PR TITLE
[onert] Fix runtime test

### DIFF
--- a/runtime/onert/backend/gpu_cl/Backend.h
+++ b/runtime/onert/backend/gpu_cl/Backend.h
@@ -60,11 +60,9 @@ public:
     auto tr = std::make_shared<ClTensorRegistry<TensorManager>>(tm);
 
     InferenceContext::CreateInferenceInfo create_info;
-    create_info.precision = environment->IsSupported(CalculationsPrecision::F16)
-                              ? CalculationsPrecision::F16
-                              : CalculationsPrecision::F32;
-    create_info.storage_type = GetFastestStorageType(environment->device().GetInfo());
-
+    create_info.precision = CalculationsPrecision::F32;
+    create_info.storage_type =
+      GetStorageTypeWithMinimalMemoryConsumption(environment->device().GetInfo());
     create_info.hints.Add(ModelHints::kFastestInference);
 
     auto cc = std::make_shared<CreationContext>();

--- a/runtime/onert/backend/gpu_cl/open_cl/ClKernel.h
+++ b/runtime/onert/backend/gpu_cl/open_cl/ClKernel.h
@@ -88,7 +88,7 @@ private:
 
   int binding_counter_ = -1;
 
-  std::string function_name_ = nullptr;
+  std::string function_name_ = "";
   // reference to program from which kernel was created
   cl_program program_ = nullptr;
   cl_kernel kernel_ = nullptr;


### PR DESCRIPTION
F16 is not implemented yet, so it is fixed as F32.
Currently, when reading and writing images, it is reading and writing in multiples of 16 bytes.
There is still a memory issue, not a 16byte multiple in cpu memory.

Signed-off-by: hj0412-yi <hj0412.yi@samsung.com>