### PR TITLE
[luci] Fix to print Mem comment only once

### DIFF
--- a/compiler/luci/logex/src/FormattedGraph.cpp
+++ b/compiler/luci/logex/src/FormattedGraph.cpp
@@ -1421,12 +1421,15 @@ bool CircleNodeSummaryBuilderBase::build(const loco::Node *node, locop::NodeSumm
     return ss.str();
   };
 
-#define CIRCLE_NODE(OPCODE, CLASS)                        \
-  if (dynamic_cast<const CLASS *>(node))                  \
-  {                                                       \
-    s.opname(circle_opname(node->opnum()));               \
-    s.comments().append("Mem = " + ptr_to_str(node));     \
-    return summary(dynamic_cast<const CLASS *>(node), s); \
+#define CIRCLE_NODE(OPCODE, CLASS)                      \
+  if (dynamic_cast<const CLASS *>(node))                \
+  {                                                     \
+    if (summary(dynamic_cast<const CLASS *>(node), s))  \
+    {                                                   \
+      s.opname(circle_opname(node->opnum()));           \
+      s.comments().append("Mem = " + ptr_to_str(node)); \
+      return true;                                      \
+    }                                                   \
   }
 #define CIRCLE_VNODE CIRCLE_NODE
 #include <luci/IR/CircleNodes.lst>


### PR DESCRIPTION
This will revise to log for Mem value only if summary method of the CLASS is handled.
This is to prevent multiple Mem logs where dynamic_cast itself is
executed by multiple times as ther are multiple 'SummaryBuilderLet' classes.

Signed-off-by: SaeHie Park <saehie.park@gmail.com>