### PR TITLE
[tflite2circle] Fix error message

### DIFF
--- a/compiler/tflite2circle/src/CircleModel.cpp
+++ b/compiler/tflite2circle/src/CircleModel.cpp
@@ -305,7 +305,7 @@ CircleModel::CircleModel(FlatBufBuilder &fb, TFLModel &model)
                                  model._data.size()};
   if (!tflite::VerifyModelBuffer(verifier))
   {
-    throw std::runtime_error("ERROR: Failed to verify tflite");
+    throw std::runtime_error("Failed to verify tflite");
   }
 
   _operator_codes_offset =


### PR DESCRIPTION
This commit fixes error message.

runtime_error prints `ERROR: ` comment by default.
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>