### PR TITLE
[pepper-csv2vec] Introduce csv2vec

### DIFF
--- a/compiler/pepper-csv2vec/CMakeLists.txt
+++ b/compiler/pepper-csv2vec/CMakeLists.txt
@@ -1,0 +1,19 @@
+file(GLOB_RECURSE SOURCES "src/*.cpp")
+file(GLOB_RECURSE TESTS "src/*.test.cpp")
+list(REMOVE_ITEM SOURCES ${TESTS})
+
+add_library(pepper_csv2vec STATIC ${SOURCES})
+set_target_properties(pepper_csv2vec PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_include_directories(pepper_csv2vec PUBLIC include)
+target_link_libraries(pepper_csv2vec PRIVATE nncc_common)
+target_link_libraries(pepper_csv2vec PUBLIC nncc_coverage)
+
+if(NOT ENABLE_TEST)
+  return()
+endif(NOT ENABLE_TEST)
+
+# Google Test is mandatory for test
+nnas_find_package(GTest REQUIRED)
+
+GTest_AddTest(pepper_csv2vec_test ${TESTS})
+target_link_libraries(pepper_csv2vec_test pepper_csv2vec)

--- a/compiler/pepper-csv2vec/README.md
+++ b/compiler/pepper-csv2vec/README.md
@@ -1,0 +1,3 @@
+# pepper-csv2vec
+
+Returns `std::vector<T>` from CSV format string input.

--- a/compiler/pepper-csv2vec/include/pepper/csv2vec.h
+++ b/compiler/pepper-csv2vec/include/pepper/csv2vec.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __PEPPER_CSV2VEC_H__
+#define __PEPPER_CSV2VEC_H__
+
+#include <string>
+#include <vector>
+
+namespace pepper
+{
+
+template <typename T> std::vector<T> csv_to_vector(const std::string &str);
+
+template <typename T> bool is_one_of(const T &item, const std::vector<T> &items);
+
+} // namespace pepper
+
+#endif // __PEPPER_CSV2VEC_H__

--- a/compiler/pepper-csv2vec/src/pepper-csv2vec.cpp
+++ b/compiler/pepper-csv2vec/src/pepper-csv2vec.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "pepper/csv2vec.h"
+
+#include <algorithm>
+#include <sstream>
+#include <cassert>
+
+namespace pepper
+{
+
+template <> std::vector<std::string> csv_to_vector(const std::string &str)
+{
+  std::vector<std::string> ret;
+  std::istringstream is(str);
+  for (std::string item; std::getline(is, item, ',');)
+  {
+    ret.push_back(item);
+  }
+  return ret;
+}
+
+template <> bool is_one_of(const std::string &item, const std::vector<std::string> &items)
+{
+  return std::find(items.begin(), items.end(), item) != items.end();
+}
+
+} // namespace pepper

--- a/compiler/pepper-csv2vec/src/pepper-csv2vec.test.cpp
+++ b/compiler/pepper-csv2vec/src/pepper-csv2vec.test.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "pepper/csv2vec.h"
+
+#include <gtest/gtest.h>
+
+TEST(csv2vec, simple_string)
+{
+  auto ret = pepper::csv_to_vector<std::string>("hello,world");
+
+  ASSERT_EQ(2, ret.size());
+  ASSERT_TRUE("hello" == ret.at(0));
+  ASSERT_TRUE("world" == ret.at(1));
+}
+
+TEST(csv2vec, is_one_of)
+{
+  auto ret = pepper::csv_to_vector<std::string>("hello,world");
+
+  ASSERT_TRUE(pepper::is_one_of<std::string>("hello", ret));
+  ASSERT_FALSE(pepper::is_one_of<std::string>("good", ret));
+}
+
+TEST(csv2vec, empty_string_NEG)
+{
+  // should not abort
+  EXPECT_NO_THROW(pepper::csv_to_vector<std::string>(""));
+}


### PR DESCRIPTION
This will introduce pepper module csv2vec that will return vector from
CSV format text and some related helper methods.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>