### PR TITLE
[onnxkit] Remove redundant "ERROR" string

### DIFF
--- a/compiler/onnxkit/src/Support.cpp
+++ b/compiler/onnxkit/src/Support.cpp
@@ -35,7 +35,7 @@ std::unique_ptr<T> open_fstream(const std::string &path, std::ios_base::openmode
   auto stream = std::make_unique<T>(path.c_str(), mode);
   if (!stream->is_open())
   {
-    throw std::runtime_error{"ERROR: Failed to open " + path};
+    throw std::runtime_error{"Failed to open " + path};
   }
   return stream;
 }


### PR DESCRIPTION
This commit removes redundant ERROR string from error message.

Related: #7152
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>