### PR TITLE
[circle-partitioner] Separate section reading

### DIFF
--- a/compiler/circle-partitioner/src/PartitionRead.cpp
+++ b/compiler/circle-partitioner/src/PartitionRead.cpp
@@ -39,6 +39,7 @@ luci::PartitionTable parse_table(const crew::Sections &sections)
 {
   luci::PartitionTable table;
 
+  // read main '[partition]' first
   for (auto &section : sections)
   {
     if (section.name == _section_partition)
@@ -56,7 +57,12 @@ luci::PartitionTable parse_table(const crew::Sections &sections)
       table.groups = csv_to_vector<std::string>(items.at(_key_backends));
       table.default_group = items.at(_key_default);
     }
-    else if (section.name == _section_OPCODE)
+  }
+
+  // read other sections
+  for (auto &section : sections)
+  {
+    if (section.name == _section_OPCODE)
     {
       auto &items = section.items;
 


### PR DESCRIPTION
This will revise parse_table method to read main '[partition]' section
first then read other sections.
- to prevent default group settings when orders are inverted

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>