### PR TITLE
[luci] Set default comply for test codes

### DIFF
--- a/compiler/luci/partition/src/Partition.test.cpp
+++ b/compiler/luci/partition/src/Partition.test.cpp
@@ -73,6 +73,7 @@ TEST(PartitionTest, simple_apply)
 
   luci::PartitionTable pt;
   pt.default_group = "A";
+  pt.comply = luci::PartitionTable::COMPLY::OPCODE;
 
   auto pms = apply(&module, pt);
 

--- a/compiler/luci/partition/src/PartitionPGroups.test.cpp
+++ b/compiler/luci/partition/src/PartitionPGroups.test.cpp
@@ -73,6 +73,7 @@ TEST(PartitionPGroupsTest, simple_produce)
 
   luci::PartitionTable pt;
   pt.default_group = "A";
+  pt.comply = luci::PartitionTable::COMPLY::OPCODE;
 
   auto pgs = produce_pgroups(&module, pt);
 

--- a/compiler/luci/partition/src/PartitionPModules.test.cpp
+++ b/compiler/luci/partition/src/PartitionPModules.test.cpp
@@ -74,6 +74,7 @@ TEST(PartitionPModulesTest, simple_convert)
 
   luci::PartitionTable pt;
   pt.default_group = "A";
+  pt.comply = luci::PartitionTable::COMPLY::OPCODE;
 
   auto pgs = produce_pgroups(&module, pt);
   auto pms = produce_pmodules(pgs.get());


### PR DESCRIPTION
This will revise paritioner test codes to have OPCODE comply as default.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>