### PR TITLE
[csv2vec] Enable int32_t type for csv_to_vector

### DIFF
--- a/compiler/pepper-csv2vec/src/pepper-csv2vec.cpp
+++ b/compiler/pepper-csv2vec/src/pepper-csv2vec.cpp
@@ -34,6 +34,22 @@ template <> std::vector<std::string> csv_to_vector(const std::string &str)
   return ret;
 }
 
+// TODO merge std::string and int32_t type
+
+template <> std::vector<int32_t> csv_to_vector(const std::string &str)
+{
+  std::vector<int32_t> ret;
+  std::istringstream is(str);
+  for (int32_t i; is >> i;)
+  {
+    assert(i != ',');
+    ret.push_back(i);
+    if (is.peek() == ',')
+      is.ignore();
+  }
+  return ret;
+}
+
 template <> bool is_one_of(const std::string &item, const std::vector<std::string> &items)
 {
   return std::find(items.begin(), items.end(), item) != items.end();

--- a/compiler/pepper-csv2vec/src/pepper-csv2vec.test.cpp
+++ b/compiler/pepper-csv2vec/src/pepper-csv2vec.test.cpp
@@ -27,6 +27,15 @@ TEST(csv2vec, simple_string)
   ASSERT_TRUE("world" == ret.at(1));
 }
 
+TEST(csv2vec, simple_int32)
+{
+  auto ret = pepper::csv_to_vector<int32_t>("1,2,3");
+
+  ASSERT_EQ(3, ret.size());
+  ASSERT_EQ(1, ret.at(0));
+  ASSERT_EQ(3, ret.at(2));
+}
+
 TEST(csv2vec, is_one_of)
 {
   auto ret = pepper::csv_to_vector<std::string>("hello,world");
@@ -39,4 +48,11 @@ TEST(csv2vec, empty_string_NEG)
 {
   // should not abort
   EXPECT_NO_THROW(pepper::csv_to_vector<std::string>(""));
+}
+
+TEST(csv2vec, invalid_int32_NEG)
+{
+  auto ret = pepper::csv_to_vector<int32_t>("hello,world");
+
+  ASSERT_EQ(0, ret.size());
 }


### PR DESCRIPTION
This will eanble int32_t type for csv_to_vector.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>