### PR TITLE
[circle-partition] Enable value test with comply OPNAME

### DIFF
--- a/compiler/circle-part-value-test/parts/Part_Add_Sub_000.001.part
+++ b/compiler/circle-part-value-test/parts/Part_Add_Sub_000.001.part
@@ -1,0 +1,7 @@
+[partition]
+backends=cpu,acl_cl
+default=cpu
+comply=opname
+
+[OPNAME]
+add1=acl_cl

--- a/compiler/circle-part-value-test/parts/Part_Add_Sub_001.part
+++ b/compiler/circle-part-value-test/parts/Part_Add_Sub_001.part
@@ -1,0 +1,7 @@
+[partition]
+backends=cpu,acl_cl
+default=cpu
+comply=opname
+
+[OPNAME]
+some/node/add2;and/another=acl_cl

--- a/compiler/circle-part-value-test/test.lst
+++ b/compiler/circle-part-value-test/test.lst
@@ -18,3 +18,7 @@ add(Part_Add_Sqrt_Rsqrt_000 Part_Add_Sqrt_Rsqrt_000)
 add(Net_InstanceNorm_003 Net_InstanceNorm_003)
 add(Net_InstanceNorm_003 Net_InstanceNorm_003.001)
 add(Net_InstanceNorm_003 Net_InstanceNorm_003.002)
+
+# comply=opname
+add(Part_Add_Sub_000 Part_Add_Sub_000.001)
+add(Part_Add_Sub_001 Part_Add_Sub_001)


### PR DESCRIPTION
This will enable basic value test for comply OPNAME with simple Add-Sub model.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>