### PR TITLE
[debian] Revise preset to 20210706

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -1,7 +1,7 @@
 #!/usr/bin/make -f
 export DH_VERBOSE = 1
 export NNAS_BUILD_PREFIX = build
-export PRESET = 20210406
+export PRESET = 20210706
 export _DESTDIR = debian/tmp/usr
 
 %:


### PR DESCRIPTION
This will revise debian build preset to latest 20210706.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>