### PR TITLE
[luci] Remove relocated csv_to_vector

### DIFF
--- a/compiler/luci/pass/src/helpers/Strings.h
+++ b/compiler/luci/pass/src/helpers/Strings.h
@@ -38,20 +38,6 @@ loco::DataType str_to_dtype(const std::string &);
 
 QuantizationGranularity str_to_granularity(const std::string &);
 
-template <typename T> std::vector<T> csv_to_vector(const std::string &str)
-{
-  std::vector<T> ret;
-  std::istringstream is(str);
-  for (T i; is >> i;)
-  {
-    assert(i != ',');
-    ret.push_back(i);
-    if (is.peek() == ',')
-      is.ignore();
-  }
-  return ret;
-}
-
 } // namespace luci
 
 #endif // __LUCI_PASS_HELPERS_STRINGS_H__

--- a/compiler/luci/pass/src/helpers/Strings.test.cpp
+++ b/compiler/luci/pass/src/helpers/Strings.test.cpp
@@ -48,11 +48,3 @@ TEST(StringsTest, str_to_granularity)
 
   EXPECT_THROW(luci::str_to_granularity("foo"), std::runtime_error);
 }
-
-TEST(StringsTest, csv_to_vector_int32)
-{
-  auto ret = luci::csv_to_vector<int32_t>("1,2,3");
-  ASSERT_EQ(3, ret.size());
-  ASSERT_EQ(1, ret.at(0));
-  ASSERT_EQ(3, ret.at(2));
-}


### PR DESCRIPTION
This will remove relocated to pepper-csv2vec module for method csv_to_vector.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>