### PR TITLE
[luci] Revise is_input_same for partition merge

### DIFF
--- a/compiler/luci/partition/src/PartitionMerge.cpp
+++ b/compiler/luci/partition/src/PartitionMerge.cpp
@@ -50,9 +50,18 @@ bool is_input_same(const luci::PGroup *pgroup, const luci::PGroups *pgroups)
   std::string group;
   for (auto &input : pgroup->inputs)
   {
+    // We ignore below logic for CircleConst.
+    // CircleConst will be cloned if they are not found in pgroup as an input.
+    // Refer build_graph(), "add CircleConst for inputs"
+    // Reason: CircleConst can be shared as input to multiple nodes
+    //         where each node can be placed in different groups. For this case
+    //         we need to clone this CircleConst for each graph of the group.
+    if (dynamic_cast<const luci::CircleConst *>(input) != nullptr)
+      continue;
+
     auto input_group = pgroups->group_of(input);
     // NOTE: all the nodes should be registered and return should be valid group.
-    // convert_to_proups() should ensure this.
+    // produce_pgroups() should ensure this, except CircleConst, Input, Outputs.
     // assert here to find if there is any problem with this.
     assert(not input_group.empty());
     if (input_group.empty())


### PR DESCRIPTION
This will re vise is_input_same method for partition merge to skip for CircleConst.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>