### PR TITLE
[circle-part-value-test] Save expected count

### DIFF
--- a/compiler/circle-part-value-test/CMakeLists.txt
+++ b/compiler/circle-part-value-test/CMakeLists.txt
@@ -11,11 +11,13 @@ get_target_property(ARTIFACTS_BIN_PATH testDataGenerator BINARY_DIR)
 
 unset(RECIPE_LIST)
 unset(PARTITION_LIST)
+unset(OUTPUT_COUNT_LIST)
 unset(TEST_DEPS)
 
-macro(add RECIPE_NAME PARTITION_NAME)
+macro(add RECIPE_NAME PARTITION_NAME OUTPUT_COUNT)
   list(APPEND RECIPE_LIST ${RECIPE_NAME})
   list(APPEND PARTITION_LIST ${PARTITION_NAME})
+  list(APPEND OUTPUT_COUNT_LIST ${OUTPUT_COUNT})
 endmacro(add)
 
 # Read "test.lst"
@@ -27,6 +29,7 @@ math(EXPR RECIPE_LENGTH_M1 "${RECIPE_LENGTH} - 1")
 foreach(IDX RANGE ${RECIPE_LENGTH_M1})
   list(GET RECIPE_LIST ${IDX} RECIPE_NAME)
   list(GET PARTITION_LIST ${IDX} PARTITION_NAME)
+  list(GET OUTPUT_COUNT_LIST ${IDX} OUTPUT_COUNT)
 
   # NOTE about the name:
   # Use '.recipe' name for source tflite and circle files
@@ -84,6 +87,16 @@ foreach(IDX RANGE ${RECIPE_LENGTH_M1})
     COMMENT "Parition ${RECIPE_NAME}.circle with ${PART_FILE}"
   )
   list(APPEND TEST_DEPS ${PARTITIONER_CONN_JSON})
+
+  # Write .excnt file; expected count of output models
+  set(COUNT_FILE "${PARTITION_NAME}.excnt")
+  set(COUNT_FILE_PATH "${PARTITIONER_OUTPUT_PATH}/${COUNT_FILE}")
+  add_custom_command(OUTPUT ${COUNT_FILE_PATH}
+    COMMAND echo ${OUTPUT_COUNT} > ${COUNT_FILE_PATH}
+    DEPENDS ${PART_SRC_PATH}
+    COMMENT "Write ${COUNT_FILE} with ${OUTPUT_COUNT}"
+  )
+  list(APPEND TEST_DEPS ${COUNT_FILE_PATH})
 endforeach(IDX)
 
 add_custom_target(circle_part_value_test_prepare ALL DEPENDS ${TEST_DEPS})

--- a/compiler/circle-part-value-test/test.lst
+++ b/compiler/circle-part-value-test/test.lst
@@ -1,24 +1,26 @@
 # Add recipe names from /res/TensorFlowLiteRecipes to test.
 # Only add items exist in common-artifacts test: tflite/circle files are copied as source.
 #
-# add(RECIPE_NAME PARTITION_NAME)
+# add(RECIPE_NAME PARTITION_NAME EXPECTED_OUTPUT_COUNT)
+#     EXPECTED_OUTPUT_COUNT: 0 for skip expected count test
 
-add(Part_Add_Sub_000 Part_Add_Sub_000)
-add(Part_Sqrt_Rsqrt_000 Part_Sqrt_Rsqrt_000)
-add(Part_Sqrt_Rsqrt_001 Part_Sqrt_Rsqrt_001)
-add(Part_Sqrt_Rsqrt_002 Part_Sqrt_Rsqrt_002)
-add(Part_Sqrt_Rsqrt_003 Part_Sqrt_Rsqrt_003)
-add(Part_Sqrt_Rsqrt_Add_000 Part_Sqrt_Rsqrt_Add_000)
-add(Part_Sqrt_Rsqrt_Add_001 Part_Sqrt_Rsqrt_Add_001)
-add(Part_Sqrt_Rsqrt_Add_002 Part_Sqrt_Rsqrt_Add_002)
-add(Part_Sqrt_Rsqrt_Add_003 Part_Sqrt_Rsqrt_Add_003)
-add(Part_Sqrt_Rsqrt_Add_004 Part_Sqrt_Rsqrt_Add_004)
-add(Part_Add_Sqrt_000 Part_Add_Sqrt_000)
-add(Part_Add_Sqrt_Rsqrt_000 Part_Add_Sqrt_Rsqrt_000)
-add(Net_InstanceNorm_003 Net_InstanceNorm_003)
-add(Net_InstanceNorm_003 Net_InstanceNorm_003.001)
-add(Net_InstanceNorm_003 Net_InstanceNorm_003.002)
+add(Part_Add_Sub_000 Part_Add_Sub_000 2)
+add(Part_Sqrt_Rsqrt_000 Part_Sqrt_Rsqrt_000 2)
+add(Part_Sqrt_Rsqrt_001 Part_Sqrt_Rsqrt_001 2)
+add(Part_Sqrt_Rsqrt_002 Part_Sqrt_Rsqrt_002 4)
+add(Part_Sqrt_Rsqrt_003 Part_Sqrt_Rsqrt_003 3)
+add(Part_Sqrt_Rsqrt_Add_000 Part_Sqrt_Rsqrt_Add_000 3)
+add(Part_Sqrt_Rsqrt_Add_001 Part_Sqrt_Rsqrt_Add_001 3)
+add(Part_Sqrt_Rsqrt_Add_002 Part_Sqrt_Rsqrt_Add_002 4)
+add(Part_Sqrt_Rsqrt_Add_003 Part_Sqrt_Rsqrt_Add_003 1)
+add(Part_Sqrt_Rsqrt_Add_004 Part_Sqrt_Rsqrt_Add_004 1)
+add(Part_Add_Sqrt_000 Part_Add_Sqrt_000 3)
+add(Part_Add_Sqrt_Rsqrt_000 Part_Add_Sqrt_Rsqrt_000 3)
+add(Net_InstanceNorm_003 Net_InstanceNorm_003 3)
+add(Net_InstanceNorm_003 Net_InstanceNorm_003.001 5)
+# skip expected count for now
+add(Net_InstanceNorm_003 Net_InstanceNorm_003.002 0)
 
 # comply=opname
-add(Part_Add_Sub_000 Part_Add_Sub_000.001)
-add(Part_Add_Sub_001 Part_Add_Sub_001)
+add(Part_Add_Sub_000 Part_Add_Sub_000.001 3)
+add(Part_Add_Sub_001 Part_Add_Sub_001 3)


### PR DESCRIPTION
This will revise cmake to save expected paritioned models count of partitioning.

ONE-DCO-1.0-ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>