### PR TITLE
[one-cmds] Remove virtualenv installation command

### DIFF
--- a/compiler/one-cmds/one-prepare-venv
+++ b/compiler/one-cmds/one-prepare-venv
@@ -24,12 +24,10 @@ VENV_ACTIVATE=${DRIVER_PATH}/venv/bin/activate
 # Since debian maintainer script is called with sudo, `source activation` is ignored.
 VENV_PYTHON=${DRIVER_PATH}/venv/bin/python
 
-
 if [ ! -f ${VENV_ACTIVATE} ]; then
   # Create python virtual enviornment
   python3 -m venv "${DRIVER_PATH}/venv"
 fi
-
 
 # NOTE version
 # - https://github.com/onnx/onnx/blob/master/docs/Versioning.md

--- a/compiler/one-cmds/one-prepare-venv
+++ b/compiler/one-cmds/one-prepare-venv
@@ -36,9 +36,6 @@ function error_no_ensurepip ()
 }
 
 if [ ! -f ${VENV_ACTIVATE} ]; then
-  # Install prerequisites
-  python3 -m ensurepip --version > /dev/null 2>&1 || error_no_ensurepip
-  python3 -m pip install --user -U virtualenv
   # Create python virtual enviornment
   python3 -m venv "${DRIVER_PATH}/venv"
 fi

--- a/compiler/one-cmds/one-prepare-venv
+++ b/compiler/one-cmds/one-prepare-venv
@@ -24,16 +24,6 @@ VENV_ACTIVATE=${DRIVER_PATH}/venv/bin/activate
 # Since debian maintainer script is called with sudo, `source activation` is ignored.
 VENV_PYTHON=${DRIVER_PATH}/venv/bin/python
 
-function error_no_ensurepip ()
-{
-  echo "ERROR: python3 'ensurepip' module is not found."
-  echo "       On ubuntu, try following command:"
-  echo
-  echo "         apt install python$(python3 --version | awk '{print $2}' | awk -F. '{print $1"."$2}')-venv"
-  echo
-  echo "       You may need root privilege for this."
-  exit 1
-}
 
 if [ ! -f ${VENV_ACTIVATE} ]; then
   # Create python virtual enviornment


### PR DESCRIPTION
This commit removes virtualenv installation command.

> python3 -m venv "${DRIVER_PATH}/venv"

Since we use `venv` package to create virtual env folder, there is no need to install `virtualenv` package.

Related: #7218 
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>