### PR TITLE
[circle-partitioner] More tests for OPNAME

### DIFF
--- a/compiler/circle-part-value-test/parts/Net_InstanceNorm_003.003.part
+++ b/compiler/circle-part-value-test/parts/Net_InstanceNorm_003.003.part
@@ -1,0 +1,9 @@
+[partition]
+backends=cpu,acl_cl
+default=cpu
+comply=opname
+
+[OPNAME]
+Mean_as_variance=acl_cl
+Add_as_variance=acl_cl
+Pow=acl_cl

--- a/compiler/circle-part-value-test/parts/Part_Add_Sub_002.001.part
+++ b/compiler/circle-part-value-test/parts/Part_Add_Sub_002.001.part
@@ -1,0 +1,9 @@
+[partition]
+backends=cpu,acl_cl
+default=cpu
+comply=opname
+
+[OPNAME]
+add1=cpu
+add2=acl_cl
+ofm=acl_cl

--- a/compiler/circle-part-value-test/parts/Part_Add_Sub_002.002.part
+++ b/compiler/circle-part-value-test/parts/Part_Add_Sub_002.002.part
@@ -1,0 +1,9 @@
+[partition]
+backends=cpu,acl_cl
+default=cpu
+comply=opname
+
+[OPNAME]
+add1=acl_cl
+add2=acl_cl
+ofm=cpu

--- a/compiler/circle-part-value-test/test.lst
+++ b/compiler/circle-part-value-test/test.lst
@@ -24,3 +24,6 @@ add(Net_InstanceNorm_003 Net_InstanceNorm_003.002 0)
 # comply=opname
 add(Part_Add_Sub_000 Part_Add_Sub_000.001 3)
 add(Part_Add_Sub_001 Part_Add_Sub_001 3)
+add(Part_Add_Sub_002 Part_Add_Sub_002.001 2)
+add(Part_Add_Sub_002 Part_Add_Sub_002.002 2)
+add(Net_InstanceNorm_003 Net_InstanceNorm_003.003 3)


### PR DESCRIPTION
This will add more tests for circle-partitioner for comply=opname.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>