### PR TITLE
[luci] Add num_outputs for TestOsGraphlet

### DIFF
--- a/compiler/luci/testhelper/include/luci/test/TestIOGraph.h
+++ b/compiler/luci/testhelper/include/luci/test/TestIOGraph.h
@@ -156,6 +156,7 @@ public:
 
 public:
   luci::CircleOutput *output(int idx) { return _outputs[idx]; }
+  uint32_t num_outputs(void) { return N; }
 
 protected:
   std::array<loco::GraphOutput *, N> _graph_outputs;


### PR DESCRIPTION
This will add num_outputs attribute for TestOsGraphlet.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>