### PR TITLE
[circle-part-driver] Add log at save_outputs

### DIFF
--- a/compiler/circle-part-driver/src/PModelsRunner.cpp
+++ b/compiler/circle-part-driver/src/PModelsRunner.cpp
@@ -226,10 +226,13 @@ bool PModelsRunner::run(void)
 
 void PModelsRunner::save_outputs(const std::string &output_file)
 {
+  LOGGER(l);
+
   // load source model as we need to get both shape and node name
   // TODO check for unknown shape
   auto source_fname = _pconfig.source.model_file;
 
+  INFO(l) << "save_outputs() loading file: " << source_fname << std::endl;
   auto module = import_circle(source_fname);
 
   const auto output_nodes = loco::output_nodes(module->graph());
@@ -238,6 +241,7 @@ void PModelsRunner::save_outputs(const std::string &output_file)
     const auto *output_node = loco::must_cast<const luci::CircleOutput *>(output_nodes[i]);
 
     auto output_name = output_node->name();
+    INFO(l) << "save_outputs() save output node: " << output_name << std::endl;
     assert(_data_stage.find(output_name) != _data_stage.end());
 
     auto tensor_data = _data_stage[output_name];


### PR DESCRIPTION
This will add log message at save_outputs method to help debugging.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>