### PR TITLE
[circle-part-driver] Remove check for single graph

### DIFF
--- a/compiler/circle-part-driver/src/PModelsRunner.cpp
+++ b/compiler/circle-part-driver/src/PModelsRunner.cpp
@@ -171,8 +171,6 @@ bool PModelsRunner::run(void)
         luci_interpreter::Interpreter interpreter(module.get());
 
         // Set input
-        // TODO support multiple subgraphs
-        assert(module->size() == 1);
         const auto input_nodes = loco::input_nodes(module->graph());
         int32_t num_inputs = static_cast<int32_t>(input_nodes.size());
         for (int32_t i = 0; i < num_inputs; i++)


### PR DESCRIPTION
This will remove check for single graph as to support multiple subgraphs.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>