### PR TITLE
[luci/partition] Remove check for single graph

### DIFF
--- a/compiler/luci/partition/src/PartitionCleanup.cpp
+++ b/compiler/luci/partition/src/PartitionCleanup.cpp
@@ -71,9 +71,6 @@ void remove_unused_inputoutputs(luci::PGroups *pgroups, const luci::Module *sour
 
   LOGGER(l);
 
-  // TODO support multiple subgraph
-  assert(source->size() == 1);
-
   INFO(l) << "--- Cleanup unused inputs/outputs";
 
   // remove input within same pgroup

--- a/compiler/luci/partition/src/PartitionPGroups.cpp
+++ b/compiler/luci/partition/src/PartitionPGroups.cpp
@@ -67,8 +67,8 @@ std::unique_ptr<luci::PGroups> produce_pgroups(const luci::Module *source,
                                                const luci::PartitionTable &partition)
 {
   assert(source != nullptr);
-  // TODO support multiple subgraphs
-  assert(source->size() == 1);
+  // NOTE Only main graph (subgraph index 0) will be partitioned.
+  // Other subgraphs will follow the owner (IF/WHILE/...) group
 
   LOGGER(l);
 


### PR DESCRIPTION
This will remove check for single graph as to support multiple subgraphs.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>