### PR TITLE
[circle-quantizer] Fix bug in fused TANH quantization

### DIFF
--- a/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
+++ b/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
@@ -694,7 +694,6 @@ struct QuantizeActivation final : public luci::CircleNodeMutableVisitor<bool>
             scaling_factor = 1.0f / 32768.0f;
             zp = 0;
           }
-          continue;
         }
 
         // The output of these Ops should be integer, so scale should be integer


### PR DESCRIPTION
This fixes a bug in fused TANH quantization.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>