### PR TITLE
[one-cmds] Suppress trackback on error from one-build

### DIFF
--- a/compiler/one-cmds/one-build
+++ b/compiler/one-cmds/one-build
@@ -27,6 +27,8 @@ import sys
 
 import utils as _utils
 
+# TODO Find better way to suppress trackback on error
+# This suppression is applied only to `one-build`
 sys.tracebacklimit = 0
 
 

--- a/compiler/one-cmds/one-build
+++ b/compiler/one-cmds/one-build
@@ -27,6 +27,8 @@ import sys
 
 import utils as _utils
 
+sys.tracebacklimit = 0
+
 
 def _get_parser():
     parser = argparse.ArgumentParser(


### PR DESCRIPTION
one-build is an end user tool.
It would be good to suppress traceback by default.

Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

Related: #7297 