### PR TITLE
[one-cmds] Add README for tests

### DIFF
--- a/compiler/one-cmds/tests/README.txt
+++ b/compiler/one-cmds/tests/README.txt
@@ -1,6 +1,8 @@
 one-cmds testing
 ================
 
+NOTE. `one-compiler` should be installed before testing.
+
 Run 'runtestall.sh' program to test ONE command line programs, all at once.
 
 Steps:


### PR DESCRIPTION
This commit adds README.md to `tests/` for developers.

Related: #7292
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>