### PR TITLE
[one-import] Support onnx as input parameter

### DIFF
--- a/compiler/one-cmds/one-import
+++ b/compiler/one-cmds/one-import
@@ -37,7 +37,8 @@ def _get_parser():
 
     # driver
     parser.add_argument(
-        'driver', type=str, help='driver name to run (supported: tf, tflite, bcq)')
+        'driver', type=str, help='driver name to run (supported: tf, tflite,' \
+        ' bcq, onnx)')
 
     # version
     dir_path = os.path.dirname(os.path.realpath(__file__))
@@ -68,7 +69,8 @@ def _get_driver_name(driver_name):
     return {
         'bcq': 'one-import-bcq',
         'tf': 'one-import-tf',
-        'tflite': 'one-import-tflite'
+        'tflite': 'one-import-tflite',
+        'onnx': 'one-import-onnx',
     }[driver_name]
 
 

--- a/compiler/one-cmds/tests/one-import_006.test
+++ b/compiler/one-cmds/tests/one-import_006.test
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# import onnx model with cfg file
+# import onnx model
 
 filename_ext="$(basename -- $0)"
 filename="${filename_ext%.*}"
@@ -27,13 +27,13 @@ trap_err_onexit()
 
 trap trap_err_onexit ERR
 
-configfile="one-import_005.cfg"
+inputfile="test_onnx_model.onnx"
 outputfile="test_onnx_model.circle"
 
 rm -f ${outputfile}
 
 # run test
-one-import onnx -C ${configfile} > ${filename}.log 2>&1
+one-import onnx -i ${inputfile} -o ${outputfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit


### PR DESCRIPTION
This commit adds onnx model case.
It invokes the one-import-onnx model when the parameter is onnx.
It contains the test case for onnx param.

Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Related issue: #7299 