### PR TITLE
[common-artifacts] Exclude MaxPoolWithArgmax from test data generation

### DIFF
--- a/compiler/common-artifacts/exclude.lst
+++ b/compiler/common-artifacts/exclude.lst
@@ -63,6 +63,9 @@ tcgenerate(MatrixSetDiag_000)
 tcgenerate(MaxPoolWithArgMax_000)
 tcgenerate(MaxPoolWithArgMax_001)
 tcgenerate(MaxPoolWithArgMax_002)
+tcgenerate(MaxPoolWithArgmax_000)
+tcgenerate(MaxPoolWithArgmax_001)
+tcgenerate(MaxPoolWithArgmax_002)
 tcgenerate(Mean_dynamic_000) # TestDataGenerator does not support unknown dimension
 tcgenerate(Mean_dynamic_001) # TestDataGenerator does not support unknown dimension
 tcgenerate(Mean_U8_dynamic_000) # TestDataGenerator does not support unknown dimension


### PR DESCRIPTION
This commit excludes MaxPoolWithArgmax in addition to MaxPoolWithArgMax.

Related issue: #7306 

ONE-DCO-1.0-Signed-off-by: Alexander Efimov <a.efimov@samsung.com>