### PR TITLE
[bcq-tools] Suppress trackback on error from generate_bcq_metadata.py

### DIFF
--- a/compiler/bcq-tools/generate_bcq_metadata.py
+++ b/compiler/bcq-tools/generate_bcq_metadata.py
@@ -21,6 +21,9 @@ import tensorflow as tf
 import argparse
 import sys
 
+# TODO Find better way to suppress trackback on error
+sys.tracebacklimit = 0
+
 ONE_START_MAGICNUM = int(-2e9 + 27)
 ONE_END_MAGICNUM = int(2e9 - 27)
 


### PR DESCRIPTION
It suppresses traceback from generate_bcq_metadata.py.

Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>