### PR TITLE
[circle2circle] Introduce FuseMeanWithMean in circle2circle

### DIFF
--- a/compiler/circle2circle/src/Circle2Circle.cpp
+++ b/compiler/circle2circle/src/Circle2Circle.cpp
@@ -145,6 +145,13 @@ int entry(int argc, char **argv)
     .default_value(false)
     .help("This will fuse operators to InstanceNorm operator");
 
+  arser.add_argument("--fuse_mean_with_mean")
+    .nargs(0)
+    .required(false)
+    .default_value(false)
+    .help("This will fuse two Mean operations when they follow one by one."
+          "This will fold them into one operation and merge reduction indices.");
+
   arser.add_argument("--make_batchnorm_gamma_positive")
     .nargs(0)
     .required(false)
@@ -406,6 +413,8 @@ int entry(int argc, char **argv)
     options->enable(Algorithms::FuseBCQ);
   if (arser.get<bool>("--fuse_instnorm"))
     options->enable(Algorithms::FuseInstanceNorm);
+  if (arser.get<bool>("--fuse_mean_with_mean"))
+    options->enable(Algorithms::FuseMeanWithMean);
   if (arser.get<bool>("--make_batchnorm_gamma_positive"))
     options->enable(Algorithms::MakeBatchNormGammaPositive);
   if (arser.get<bool>("--fuse_preactivation_batchnorm"))


### PR DESCRIPTION
This commit introduce some changes in Circle2Circle.cpp for using FuseMeanWithMean pass

issue #7335
related PR  #7354

ONE-DCO-1.0-Signed-off-by: Artem Balyshev <a.balyshev@partner.samsung.com>