### PR TITLE
[SAM] Update exclude list

### DIFF
--- a/.ahub/sam/exclude.txt
+++ b/.ahub/sam/exclude.txt
@@ -19,7 +19,6 @@
 # External code: Tensorflow lite
 /ONE/runtime/libs/nnapi
 /ONE/runtime/libs/profiling
-/ONE/runtime/libs/tflite/port
 
 # External code: 3rd party
 /ONE/runtime/3rdparty


### PR DESCRIPTION
This commit updates SAM exclude list: directory removed.

ONE-DCO-1.0-Signed-off-by: Cheongyo Bahk <cg.bahk@gmail.com>

---
Directory `runtime/libs/tflite/port` removed at #7353
(I should have done https://github.com/Samsung/ONE/issues/6889 early :sob:)
