### PR TITLE
[onecc] Add onecc.template.cfg to debian package

### DIFF
--- a/compiler/one-cmds/CMakeLists.txt
+++ b/compiler/one-cmds/CMakeLists.txt
@@ -38,6 +38,7 @@ endforeach(ONE_COMMAND)
 
 set(ONE_UTILITY_FILES
     one-build.template.cfg
+    onecc.template.cfg
     utils.py
     conv_mixin_1.8.0.patch
 )

--- a/infra/debian/compiler/one-compiler.install
+++ b/infra/debian/compiler/one-compiler.install
@@ -8,6 +8,7 @@ usr/bin/generate_bcq_metadata.py usr/share/one/bin/
 usr/bin/generate_bcq_output_arrays.py usr/share/one/bin/
 usr/bin/model2nnpkg.sh usr/share/one/bin/
 usr/bin/onecc usr/share/one/bin/
+usr/bin/onecc.template.cfg usr/share/one/bin/
 usr/bin/one-build usr/share/one/bin/
 usr/bin/one-build.template.cfg usr/share/one/bin/
 usr/bin/one-codegen usr/share/one/bin/


### PR DESCRIPTION
This commit adds onecc.template.cfg file to debian package.
It will be installed under /usr/share/one/bin/.

Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>