### PR TITLE
[common-artifacts] Exclude Part_While

### DIFF
--- a/compiler/common-artifacts/exclude.lst
+++ b/compiler/common-artifacts/exclude.lst
@@ -88,6 +88,8 @@ tcgenerate(OneHot_003)
 tcgenerate(Pack_000)
 tcgenerate(Pack_U8_000)
 tcgenerate(PadV2_000)
+tcgenerate(Part_While_000) # TODO remove this after WHILE is supported
+tcgenerate(Part_While_001) # TODO remove this after WHILE is supported
 tcgenerate(Quantize_000)  # runtime and luci-interpreter doesn't support Quantize op yet
 tcgenerate(Range_000)
 tcgenerate(Rank_000)


### PR DESCRIPTION
This will revise to exclude Part_While_000 and Part_While_001 while code
lands and will be removed afterwards.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>