### PR TITLE
[luci] Skip WhileOut in validate_shape_dtype

### DIFF
--- a/compiler/luci/service/src/Validate.cpp
+++ b/compiler/luci/service/src/Validate.cpp
@@ -102,6 +102,9 @@ bool validate_shape_dtype(loco::Graph *g)
     // Shape and dtype validation for CiecleOutputExclude is not needed
     if (dynamic_cast<luci::CircleOutputExclude *>(circle_node))
       continue;
+    // Skip as initial status is UNDEFINED for CircleWhileOut
+    if (dynamic_cast<luci::CircleWhileOut *>(circle_node))
+      continue;
 
     assert(circle_node->shape_status() != luci::ShapeStatus::UNDEFINED);
 


### PR DESCRIPTION
This will skip WhileOut Op in validate_shape_dtype method.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>