### PR TITLE
Fix No_Assertion Error on TCM Analysis

### DIFF
--- a/tests/nnfw_api/src/ValidationTestPipelineSession.cc
+++ b/tests/nnfw_api/src/ValidationTestPipelineSession.cc
@@ -52,6 +52,7 @@ TEST_F(ValidationTestPipelineSession, create_pipeline_001)
 {
   NNFW_ENSURE_SUCCESS(nnfw_create_session(&_session));
   NNFW_ENSURE_SUCCESS(nnfw_close_session(_session));
+  SUCCEED();
 }
 
 TEST_F(ValidationTestPipelineSession, pipeline_session_test_model)
@@ -71,6 +72,7 @@ TEST_F(ValidationTestPipelineSession, pipeline_session_test_model)
   NNFW_ENSURE_SUCCESS(nnfw_close_session(_session));
 
   remove("./partition_map.json");
+  SUCCEED();
 }
 
 TEST_F(ValidationTestPipelineSession, prepare_pipeline_001)
@@ -105,6 +107,8 @@ TEST_F(ValidationTestPipelineSession, prepare_pipeline_002)
   NNFW_ENSURE_SUCCESS(nnfw_close_session(_session));
 
   remove("./partition_map.json");
+
+  SUCCEED();
 }
 
 TEST_F(ValidationTestPipelineSession, input_tensorinfo_pipeline)
@@ -126,6 +130,8 @@ TEST_F(ValidationTestPipelineSession, input_tensorinfo_pipeline)
   NNFW_ENSURE_SUCCESS(nnfw_close_session(_session));
 
   remove("./partition_map.json");
+
+  SUCCEED();
 }
 
 TEST_F(ValidationTestPipelineSession, output_tensorinfo_pipeline)
@@ -147,6 +153,8 @@ TEST_F(ValidationTestPipelineSession, output_tensorinfo_pipeline)
   NNFW_ENSURE_SUCCESS(nnfw_close_session(_session));
 
   remove("./partition_map.json");
+
+  SUCCEED();
 }
 
 TEST_F(ValidationTestPipelineSession, input_size_pipeline)
@@ -528,4 +536,6 @@ TEST_F(ValidationTestPipelineSession, run_pipeline)
   NNFW_ENSURE_SUCCESS(nnfw_close_session(_session));
 
   remove("./partition_map.json");
+
+  SUCCEED();
 }


### PR DESCRIPTION
This commit resolve "no assertion" on tcm analysys by adding `SUCCEED()`

ONE-DCO-1.0-Signed-off-by: Chunseok Lee <chunseok.lee@samsung.com>