### PR TITLE
[record-mimax] Add more exceptions for quantization

### DIFF
--- a/compiler/record-minmax/src/MinMaxObserver.cpp
+++ b/compiler/record-minmax/src/MinMaxObserver.cpp
@@ -55,15 +55,17 @@ void MinMaxObserver::postTensorWrite(const luci::CircleNode *node,
   // Only support recording of float32 values
   if (tensor->element_type() != DataType::FLOAT32)
   {
-    // Argmax and Cast are exceptions we can process in backends
-    // Output of arg_max is the index of the largest value across axes of a tensor
-    // Cast converts float to int
-    // these should not be quantized
+    // Exceptions that should be processed in backends
     switch (node->opcode())
     {
       case luci::CircleOpcode::ARG_MAX:
+        // Output of arg_max is the index of the largest value across axes of a tensor.
+        // It always has integer type.
       case luci::CircleOpcode::CAST:
+        // Cast is quantized only if it converts <type> -> float.
+        // Other cases should be processed in backends.
       case luci::CircleOpcode::RESHAPE:
+        // Reshape changes only shape of input tensor, efficiently is it a no-op.
         return;
       default:
         throw std::runtime_error("Tensor's data type is not float");


### PR DESCRIPTION
This commit adds type check exceptions for Reshape and Cast operations.

Related issue: #7229

Signed-off-by: Alexander Efimov <a.efimov@samsung.com>