### PR TITLE
[res] Fix typo in MaxPoolWithArgMax recipes

### DIFF
--- a/res/TensorFlowLiteRecipes/MaxPoolWithArgmax_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/MaxPoolWithArgmax_000/test.recipe
@@ -10,21 +10,21 @@ operand {
 }
 operand {
   name: "argmax"
-  type: INT32
+  type: INT64
   shape { dim: 1 dim: 9 dim: 9 dim: 1 }
 }
 operation {
-  type: "MaxPoolWithArgMax"
+  type: "MaxPoolWithArgmax"
   input: "ifm"
   output: "ofm"
   output: "argmax"
   max_pool_with_argmax_options {
     padding: SAME
-    filter_width: 4
-    filter_height: 4
+    filter_width: 1
+    filter_height: 1
     stride_w: 2
     stride_h: 2
-    output_type: INT32
+    output_type: INT64
     include_batch_in_index: false
   }
 }

--- a/res/TensorFlowLiteRecipes/MaxPoolWithArgmax_001/test.recipe
+++ b/res/TensorFlowLiteRecipes/MaxPoolWithArgmax_001/test.recipe
@@ -6,25 +6,25 @@ operand {
 operand {
   name: "ofm"
   type: FLOAT32
-  shape { dim: 1 dim: 8 dim: 8 dim: 1 }
+  shape { dim: 1 dim: 9 dim: 9 dim: 1 }
 }
 operand {
   name: "argmax"
-  type: INT64
-  shape { dim: 1 dim: 8 dim: 8 dim: 1 }
+  type: INT32
+  shape { dim: 1 dim: 9 dim: 9 dim: 1 }
 }
 operation {
-  type: "MaxPoolWithArgMax"
+  type: "MaxPoolWithArgmax"
   input: "ifm"
   output: "ofm"
   output: "argmax"
   max_pool_with_argmax_options {
-    padding: VALID
+    padding: SAME
     filter_width: 4
     filter_height: 4
     stride_w: 2
     stride_h: 2
-    output_type: INT64
+    output_type: INT32
     include_batch_in_index: false
   }
 }

--- a/res/TensorFlowLiteRecipes/MaxPoolWithArgmax_002/test.recipe
+++ b/res/TensorFlowLiteRecipes/MaxPoolWithArgmax_002/test.recipe
@@ -6,22 +6,22 @@ operand {
 operand {
   name: "ofm"
   type: FLOAT32
-  shape { dim: 1 dim: 9 dim: 9 dim: 1 }
+  shape { dim: 1 dim: 8 dim: 8 dim: 1 }
 }
 operand {
   name: "argmax"
   type: INT64
-  shape { dim: 1 dim: 9 dim: 9 dim: 1 }
+  shape { dim: 1 dim: 8 dim: 8 dim: 1 }
 }
 operation {
-  type: "MaxPoolWithArgMax"
+  type: "MaxPoolWithArgmax"
   input: "ifm"
   output: "ofm"
   output: "argmax"
   max_pool_with_argmax_options {
-    padding: SAME
-    filter_width: 1
-    filter_height: 1
+    padding: VALID
+    filter_width: 4
+    filter_height: 4
     stride_w: 2
     stride_h: 2
     output_type: INT64


### PR DESCRIPTION
This commit changes operation MaxPoolWithArgMax to MaxPoolWithArgmax
to comply with tflite files.

Related issue: #7306

ONE-DCO-1.0-Signed-off-by: Maksim Bronnikov max120199@gmail.com