### PR TITLE
[luci-value-test] Enable Part_While tests

### DIFF
--- a/compiler/luci-value-test/test.lst
+++ b/compiler/luci-value-test/test.lst
@@ -182,3 +182,7 @@ addeval(Unpack_003)
 #addeval(While_003)
 #addeval(YUV_TO_RGB_U8_000)
 #addeval(ZerosLike_000)
+
+# Simple Network test
+addeval(Part_While_000)
+addeval(Part_While_001)


### PR DESCRIPTION
This will enable value testing of Part_While models for WHILE with float32.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>