### PR TITLE
[circle-partitioner] Enable value test for Part_While

### DIFF
--- a/compiler/circle-part-value-test/parts/Part_While_000.part
+++ b/compiler/circle-part-value-test/parts/Part_While_000.part
@@ -1,0 +1,7 @@
+[partition]
+backends=cpu,acl_cl
+default=cpu
+comply=opcode
+
+[OPCODE]
+MAXIMUM=acl_cl

--- a/compiler/circle-part-value-test/parts/Part_While_001.part
+++ b/compiler/circle-part-value-test/parts/Part_While_001.part
@@ -1,0 +1,7 @@
+[partition]
+backends=cpu,acl_cl
+default=cpu
+comply=opcode
+
+[OPCODE]
+MAXIMUM=acl_cl

--- a/compiler/circle-part-value-test/test.lst
+++ b/compiler/circle-part-value-test/test.lst
@@ -31,3 +31,7 @@ add(Net_InstanceNorm_003 Net_InstanceNorm_003.003 3)
 # IF with subgraphs
 add(Part_If_Add_Sub_000 Part_If_Add_Sub_000.001 3)
 add(Part_If_Add_Sub_001 Part_If_Add_Sub_001.001 3)
+
+# WHILE with subgraphs
+add(Part_While_000 Part_While_000 3)
+add(Part_While_001 Part_While_001 3)


### PR DESCRIPTION
This will enable circle-partitioner value test for Part_While_000 and
Part_While_001 models.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>