### PR TITLE
[record-minmax] Support directory as an input data format

### DIFF
--- a/compiler/record-minmax/driver/Driver.cpp
+++ b/compiler/record-minmax/driver/Driver.cpp
@@ -154,6 +154,12 @@ int entry(const int argc, char **argv)
       // Profile min/max while executing the list of Raw data
       rmm.profileRawData(mode, input_data_path, min_percentile, max_percentile);
     }
+    else if (input_data_format == "directory" || input_data_format == "dir")
+    {
+      // Profile min/max while executing all files under the given directory
+      // The contents of each file is same as the raw data in the 'list' type
+      rmm.profileRawDataDirectory(mode, input_data_path, min_percentile, max_percentile);
+    }
     else
     {
       throw std::runtime_error(

--- a/compiler/record-minmax/include/RecordMinMax.h
+++ b/compiler/record-minmax/include/RecordMinMax.h
@@ -42,6 +42,9 @@ public:
   void profileRawData(const std::string &mode, const std::string &input_data_path,
                       float min_percentile, float max_percentile);
 
+  void profileRawDataDirectory(const std::string &mode, const std::string &input_data_path,
+                               float min_percentile, float max_percentile);
+
   void profileDataWithRandomInputs(const std::string &mode, float min_percentile,
                                    float max_percentile);
 


### PR DESCRIPTION
This supports directory as an input data format.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: #7398
Draft PR: #7401