### PR TITLE
[luci] Fix Cast attributes after quantization

### DIFF
--- a/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
+++ b/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
@@ -734,6 +734,9 @@ struct QuantizeActivation final : public luci::CircleNodeMutableVisitor<bool>
       {
         auto *cast = loco::must_cast<luci::CircleCast *>(circle_node);
         auto *cast_input = loco::must_cast<luci::CircleNode *>(cast->x());
+
+        // make sure that cast_input is already quantized
+        assert(cast_input->dtype() != loco::DataType::FLOAT32);
         cast->in_data_type(cast_input->dtype());
         cast->out_data_type(cast->dtype());
       }

--- a/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
+++ b/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
@@ -729,6 +729,14 @@ struct QuantizeActivation final : public luci::CircleNodeMutableVisitor<bool>
         circle_node->quantparam()->scale.push_back(scaling_factor);
         circle_node->quantparam()->zerop.push_back(zp);
       }
+      // Fix special attributes
+      if (circle_node->opcode() == luci::CircleOpcode::CAST)
+      {
+        auto *cast = loco::must_cast<luci::CircleCast *>(circle_node);
+        auto *cast_input = loco::must_cast<luci::CircleNode *>(cast->x());
+        cast->in_data_type(cast_input->dtype());
+        cast->out_data_type(cast->dtype());
+      }
     }
     return false;
   }


### PR DESCRIPTION
This commit adjusts Cast attributes after quantization.

Related issue: #7229

Requested by https://github.com/Samsung/ONE/pull/7387#issuecomment-893116766

ONE-DCO-1.0-Signed-off-by: Alexander Efimov <a.efimov@samsung.com>