### PR TITLE
[circle2circle] Enable REGRESS_ONNX_Conv_BN_Relu6_001

### DIFF
--- a/compiler/circle2circle-dredd-recipe-test/test.lst
+++ b/compiler/circle2circle-dredd-recipe-test/test.lst
@@ -58,3 +58,12 @@ Add(REGRESS_ONNX_Conv_BN_001 PASS
       remove_redundant_reshape
       remove_unnecessary_reshape
       fuse_batchnorm_with_conv)
+
+Add(REGRESS_ONNX_Conv_BN_Relu6_001 PASS
+      convert_nchw_to_nhwc
+      nchw_to_nhwc_input_shape
+      nchw_to_nhwc_output_shape
+      remove_redundant_transpose
+      transform_min_max_to_relu6
+      fuse_batchnorm_with_conv
+      fuse_activation_function)


### PR DESCRIPTION
This will enable regression test for ONNX import
- REGRESS_ONNX_Conv_BN_Relu6_001

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>