### PR TITLE
[onecc] Print driver name in error message

### DIFF
--- a/compiler/one-cmds/onecc
+++ b/compiler/one-cmds/onecc
@@ -52,7 +52,7 @@ def _call_driver(driver_name, options):
     with subprocess.Popen(
             cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, bufsize=1) as p:
         for line in p.stdout:
-            sys.stdout.buffer.write(line)
+            sys.stdout.buffer.write(f"{driver_name}: ".encode() + line)
             sys.stdout.buffer.flush()
     if p.returncode != 0:
         sys.exit(p.returncode)


### PR DESCRIPTION
When user run `onecc -C`, several steps are done by configuration.
In this case, it would be better to print driver name that the error
occurred in.

Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>