### PR TITLE
[one-cmds,tf2tfliteV2] Print module name for error messages

### DIFF
--- a/compiler/circle-quantizer/src/CircleQuantizer.cpp
+++ b/compiler/circle-quantizer/src/CircleQuantizer.cpp
@@ -111,8 +111,8 @@ int entry(int argc, char **argv)
   }
   catch (const std::runtime_error &err)
   {
-    std::cout << err.what() << std::endl;
-    std::cout << arser;
+    std::cerr << "circle-quantizer: " << err.what() << std::endl;
+    std::cerr << arser;
     return 255;
   }
 
@@ -180,7 +180,16 @@ int entry(int argc, char **argv)
 
   // Load model from the file
   foder::FileLoader file_loader{input_path};
-  std::vector<char> model_data = file_loader.load();
+  std::vector<char> model_data;
+  try
+  {
+    model_data = file_loader.load();
+  }
+  catch (const std::runtime_error &err)
+  {
+    std::cerr << "circle-quantizer: ERROR: " << err.what() << std::endl;
+    return 255;
+  }
 
   // Verify flatbuffers
   flatbuffers::Verifier verifier{reinterpret_cast<uint8_t *>(model_data.data()), model_data.size()};

--- a/compiler/one-cmds/one-import-tf
+++ b/compiler/one-cmds/one-import-tf
@@ -201,4 +201,9 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    try:
+        main()
+    except Exception as e:
+        prog_name = os.path.basename(__file__)
+        print(f"{prog_name}: {type(e).__name__}: " + str(e))
+        sys.exit(-1)

--- a/compiler/one-cmds/one-quantize
+++ b/compiler/one-cmds/one-quantize
@@ -273,4 +273,9 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    try:
+        main()
+    except Exception as e:
+        prog_name = os.path.basename(__file__)
+        print(f"{prog_name}: {type(e).__name__}: " + str(e))
+        sys.exit(-1)

--- a/compiler/one-cmds/onecc
+++ b/compiler/one-cmds/onecc
@@ -52,7 +52,7 @@ def _call_driver(driver_name, options):
     with subprocess.Popen(
             cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, bufsize=1) as p:
         for line in p.stdout:
-            sys.stdout.buffer.write(f"{driver_name}: ".encode() + line)
+            sys.stdout.buffer.write(line)
             sys.stdout.buffer.flush()
     if p.returncode != 0:
         sys.exit(p.returncode)

--- a/compiler/tf2tfliteV2/tf2tfliteV2.py
+++ b/compiler/tf2tfliteV2/tf2tfliteV2.py
@@ -261,4 +261,9 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except Exception as e:
+        prog_name = os.path.basename(__file__)
+        print(f"{prog_name}: {type(e).__name__}: " + str(e))
+        sys.exit(-1)


### PR DESCRIPTION
Instead of printing driver in `onecc`, each module print its name by its own.

Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

It is a draft for #7422