### PR TITLE
[res] Add Tflite Net with Mean + Mean model

### DIFF
--- a/res/TensorFlowLiteRecipes/Net_Mean_Mean_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/Net_Mean_Mean_000/test.recipe
@@ -1,0 +1,47 @@
+operand {
+  name: "ifm"
+  type: FLOAT32
+  shape { dim: 3 dim: 8 dim: 8 dim: 4 }
+}
+operand {
+  name: "inner"
+  type: FLOAT32
+  shape { dim: 3 dim: 4 }
+}
+operand {
+  name: "reduction_indices1"
+  type: INT32
+  shape { dim: 2 }
+  filler { tag: "explicit" arg: "1" arg: "2" }
+}
+operand {
+  name: "reduction_indices2"
+  type: INT32
+  shape { dim: 1 }
+  filler { tag: "explicit" arg: "1"}
+}
+operand {
+  name: "ofm"
+  type: FLOAT32
+  shape { dim: 3 }
+}
+operation {
+  type: "Mean"
+  mean_options {
+    keep_dims: false
+  }
+  input: "ifm"
+  input: "reduction_indices1"
+  output: "inner"
+}
+operation {
+  type: "Mean"
+  mean_options {
+    keep_dims: false
+  }
+  input: "inner"
+  input: "reduction_indices2"
+  output: "ofm"
+}
+input: "ifm"
+output: "ofm"

--- a/res/TensorFlowLiteRecipes/Net_Mean_Mean_000/test.rule
+++ b/res/TensorFlowLiteRecipes/Net_Mean_Mean_000/test.rule
@@ -1,0 +1,5 @@
+# To check if Maximum and Minimum is fused to Relu6.
+
+RULE    "VERIFY_FILE_FORMAT"      $(verify_file_format) '=' 1
+
+RULE    "MEAN_SINGLE"             $(op_count MEAN) '=' 1

--- a/res/TensorFlowLiteRecipes/Net_Mean_Mean_001/test.recipe
+++ b/res/TensorFlowLiteRecipes/Net_Mean_Mean_001/test.recipe
@@ -1,0 +1,47 @@
+operand {
+  name: "ifm"
+  type: FLOAT32
+  shape { dim: 3 dim: 8 dim: 8 dim: 4 }
+}
+operand {
+  name: "inner"
+  type: FLOAT32
+  shape { dim: 3 dim: 8 dim: 1 dim: 4 }
+}
+operand {
+  name: "reduction_indices1"
+  type: INT32
+  shape { dim: 1 }
+  filler { tag: "explicit" arg: "2" }
+}
+operand {
+  name: "reduction_indices2"
+  type: INT32
+  shape { dim: 1 }
+  filler { tag: "explicit" arg: "1"}
+}
+operand {
+  name: "ofm"
+  type: FLOAT32
+  shape { dim: 3 dim: 1 dim: 1 dim: 4}
+}
+operation {
+  type: "Mean"
+  mean_options {
+    keep_dims: true
+  }
+  input: "ifm"
+  input: "reduction_indices1"
+  output: "inner"
+}
+operation {
+  type: "Mean"
+  mean_options {
+    keep_dims: true
+  }
+  input: "inner"
+  input: "reduction_indices2"
+  output: "ofm"
+}
+input: "ifm"
+output: "ofm"

--- a/res/TensorFlowLiteRecipes/Net_Mean_Mean_001/test.rule
+++ b/res/TensorFlowLiteRecipes/Net_Mean_Mean_001/test.rule
@@ -1,0 +1,5 @@
+# To check if Maximum and Minimum is fused to Relu6.
+
+RULE    "VERIFY_FILE_FORMAT"      $(verify_file_format) '=' 1
+
+RULE    "MEAN_SINGLE"             $(op_count MEAN) '=' 1

--- a/res/TensorFlowLiteRecipes/Net_Mean_Transpose_Mean_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/Net_Mean_Transpose_Mean_000/test.recipe
@@ -1,0 +1,66 @@
+operand {
+  name: "ifm"
+  type: FLOAT32
+  shape { dim: 3 dim: 8 dim: 8 dim: 4 }
+}
+operand {
+  name: "inner1"
+  type: FLOAT32
+  shape { dim: 3 dim: 8 dim: 1 dim: 4 }
+}
+operand {
+  name: "inner2"
+  type: FLOAT32
+  shape { dim: 3 dim: 1 dim: 4 dim: 8 }
+}
+operand {
+  name: "reduction_indices1"
+  type: INT32
+  shape { dim: 1 }
+  filler { tag: "explicit" arg: "2" }
+}
+operand {
+  name: "reduction_indices2"
+  type: INT32
+  shape { dim: 1 }
+  filler { tag: "explicit" arg: "3"}
+}
+operand {
+  name: "perm"
+  type: INT32
+  shape { dim: 4 }
+  filler { tag: "explicit" arg: "0" arg: "2" arg: "3" arg: "1" }
+}
+operand {
+  name: "ofm"
+  type: FLOAT32
+  shape { dim: 3 dim: 1 dim: 4 dim: 1 }
+}
+operation {
+  type: "Mean"
+  mean_options {
+    keep_dims: true
+  }
+  input: "ifm"
+  input: "reduction_indices1"
+  output: "inner1"
+}
+operation {
+  type: "Transpose"
+  transpose_options {
+  }
+  input: "inner1"
+  input: "perm"
+  output: "inner2"
+}
+operation {
+  type: "Mean"
+  mean_options {
+    keep_dims: true
+  }
+  input: "inner2"
+  input: "reduction_indices2"
+  output: "ofm"
+}
+input: "ifm"
+output: "ofm"

--- a/res/TensorFlowLiteRecipes/Net_Mean_Transpose_Mean_000/test.rule
+++ b/res/TensorFlowLiteRecipes/Net_Mean_Transpose_Mean_000/test.rule
@@ -1,0 +1,5 @@
+# To check if Maximum and Minimum is fused to Relu6.
+
+RULE    "VERIFY_FILE_FORMAT"      $(verify_file_format) '=' 1
+
+RULE    "MEAN_SINGLE"             $(op_count MEAN) '=' 1


### PR DESCRIPTION
This commit adds resources for fuse_mean_with_mean pass tests.

related issue #7335

ONE-DCO-1.0-Signed-off-by: Alexander Efimov <a.efimov@samsung.com>