### PR TITLE
[onexxx,tf2tfliteV2] Print module name for error messages (hybrid)

### DIFF
--- a/compiler/one-cmds/one-build
+++ b/compiler/one-cmds/one-build
@@ -142,4 +142,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    _utils._safemain(main, __file__)

--- a/compiler/one-cmds/one-codegen
+++ b/compiler/one-cmds/one-codegen
@@ -161,11 +161,11 @@ def main():
             codegen_cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
             bufsize=1) as p:
         for line in p.stdout:
-            sys.stdout.buffer.write(line)
+            sys.stdout.buffer.write(f"{backend_base}: ".encode() + line)
             sys.stdout.buffer.flush()
     if p.returncode != 0:
         sys.exit(p.returncode)
 
 
 if __name__ == '__main__':
-    main()
+    _utils._safemain(main, __file__)

--- a/compiler/one-cmds/one-import
+++ b/compiler/one-cmds/one-import
@@ -100,4 +100,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    _utils._safemain(main, __file__)

--- a/compiler/one-cmds/one-import-bcq
+++ b/compiler/one-cmds/one-import-bcq
@@ -224,4 +224,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    _utils._safemain(main, __file__)

--- a/compiler/one-cmds/one-import-onnx
+++ b/compiler/one-cmds/one-import-onnx
@@ -172,4 +172,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    _utils._safemain(main, __file__)

--- a/compiler/one-cmds/one-import-tf
+++ b/compiler/one-cmds/one-import-tf
@@ -178,7 +178,7 @@ def _convert(args):
                 stderr=subprocess.STDOUT,
                 bufsize=1) as p:
             for line in p.stdout:
-                sys.stdout.buffer.write(line)
+                sys.stdout.buffer.write("tflite2circle: ".encode() + line)
                 sys.stdout.buffer.flush()
                 f.write(line)
         if p.returncode != 0:
@@ -201,4 +201,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    _utils._safemain(main, __file__)

--- a/compiler/one-cmds/one-import-tflite
+++ b/compiler/one-cmds/one-import-tflite
@@ -113,4 +113,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    _utils._safemain(main, __file__)

--- a/compiler/one-cmds/one-optimize
+++ b/compiler/one-cmds/one-optimize
@@ -136,4 +136,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    _utils._safemain(main, __file__)

--- a/compiler/one-cmds/one-pack
+++ b/compiler/one-cmds/one-pack
@@ -121,4 +121,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    _utils._safemain(main, __file__)

--- a/compiler/one-cmds/one-quantize
+++ b/compiler/one-cmds/one-quantize
@@ -167,7 +167,7 @@ def _quantize(args):
                 stderr=subprocess.STDOUT,
                 bufsize=1) as p:
             for line in p.stdout:
-                sys.stdout.buffer.write(line)
+                sys.stdout.buffer.write("circle_quantizer: ".encode() + line)
                 sys.stdout.buffer.flush()
                 f.write(line)
         if p.returncode != 0:
@@ -214,7 +214,7 @@ def _quantize(args):
                 stderr=subprocess.STDOUT,
                 bufsize=1) as p:
             for line in p.stdout:
-                sys.stdout.buffer.write(line)
+                sys.stdout.buffer.write("record_minmax: ".encode() + line)
                 sys.stdout.buffer.flush()
                 f.write(line)
         if p.returncode != 0:
@@ -247,7 +247,7 @@ def _quantize(args):
                 stderr=subprocess.STDOUT,
                 bufsize=1) as p:
             for line in p.stdout:
-                sys.stdout.buffer.write(line)
+                sys.stdout.buffer.write("circle_quantizer: ".encode() + line)
                 sys.stdout.buffer.flush()
                 f.write(line)
         if p.returncode != 0:
@@ -273,4 +273,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    _utils._safemain(main, __file__)

--- a/compiler/one-cmds/onecc
+++ b/compiler/one-cmds/onecc
@@ -52,7 +52,7 @@ def _call_driver(driver_name, options):
     with subprocess.Popen(
             cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, bufsize=1) as p:
         for line in p.stdout:
-            sys.stdout.buffer.write(f"{driver_name}: ".encode() + line)
+            sys.stdout.buffer.write(line)
             sys.stdout.buffer.flush()
     if p.returncode != 0:
         sys.exit(p.returncode)
@@ -195,4 +195,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    _utils._safemain(main, __file__)

--- a/compiler/one-cmds/utils.py
+++ b/compiler/one-cmds/utils.py
@@ -216,3 +216,13 @@ def _print_version_and_exit(file_path):
     # run one-version
     subprocess.call([os.path.join(dir_path, 'one-version'), script_name])
     sys.exit()
+
+
+def _safemain(main, mainpath):
+    """execute given method and print with program name for all uncaught exceptions"""
+    try:
+        main()
+    except Exception as e:
+        prog_name = os.path.basename(mainpath)
+        print(f"{prog_name}: {type(e).__name__}: " + str(e))
+        sys.exit(-1)

--- a/compiler/tf2tfliteV2/tf2tfliteV2.py
+++ b/compiler/tf2tfliteV2/tf2tfliteV2.py
@@ -261,4 +261,9 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except Exception as e:
+        prog_name = os.path.basename(__file__)
+        print(f"{prog_name}: {type(e).__name__}: " + str(e))
+        sys.exit(-1)


### PR DESCRIPTION
Most user tools in Python (`onecc` and `one-xxx`) will print its name by
its own. Nested modules from external or in C++ get the name printed by
Python caller.

Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

Another draft for #7422