### PR TITLE
[circle-quantizer] print error to cerr, not cout

### DIFF
--- a/compiler/circle-quantizer/src/CircleQuantizer.cpp
+++ b/compiler/circle-quantizer/src/CircleQuantizer.cpp
@@ -111,8 +111,8 @@ int entry(int argc, char **argv)
   }
   catch (const std::runtime_error &err)
   {
-    std::cout << err.what() << std::endl;
-    std::cout << arser;
+    std::cerr << err.what() << std::endl;
+    std::cerr << arser;
     return 255;
   }
 


### PR DESCRIPTION
Error messages will be printed to cerr.

Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

1 approval please