### PR TITLE
[one-cmd] Fix typo

### DIFF
--- a/compiler/one-cmds/tests/onecc_neg_003.test
+++ b/compiler/one-cmds/tests/onecc_neg_003.test
@@ -21,7 +21,7 @@ filename="${filename_ext%.*}"
 
 trap_err_onexit()
 {
-  if grep -q "\[onecc\] section is required in configuraion file" "${filename}.log"; then
+  if grep -q "\[onecc\] section is required in configuration file" "${filename}.log"; then
     echo "${filename_ext} SUCCESS"
     exit 0
   fi


### PR DESCRIPTION
This commit will fix onecc_neg_003.test typo.

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

resolve #7426