### PR TITLE
[onert][gpu_cl] Apply shape on enqueueWriteBuffer/enqueueReadBuffer.

### DIFF
--- a/runtime/onert/backend/gpu_cl/open_cl/Tensor.h
+++ b/runtime/onert/backend/gpu_cl/open_cl/Tensor.h
@@ -71,7 +71,6 @@ public:
   int Channels() const { return shape_.c; }
   int Slices() const { return DivideRoundUp(shape_.c, 4); }
   int Batch() const { return shape_.b; }
-  int3 GetFullTensorRegion() const;
   TensorDescriptor GetDescriptor() const { return descriptor_; }
   DataType GetDataType() const { return descriptor_.data_type; }
   TensorStorageType GetStorageType() const { return descriptor_.storage_type; }
@@ -85,6 +84,15 @@ public:
   // memory ptr.
   cl_mem GetMemoryPtrForWriting() const;
 
+  absl::Status WriteData(CLCommandQueue *queue, const TensorFloat32 &src);
+  absl::Status WriteData(CLCommandQueue *queue,
+                         const InternalTensor<Linear, DataType::FLOAT32> &src);
+  absl::Status WriteData(CLCommandQueue *queue, const InternalTensor<HWC, DataType::FLOAT32> &src);
+
+  absl::Status WriteData(CLCommandQueue *queue, const Tensor5DFloat32 &src);
+  absl::Status ReadData(CLCommandQueue *queue, TensorFloat32 *dst) const;
+  absl::Status ReadData(CLCommandQueue *queue, Tensor5DFloat32 *dst) const;
+
   absl::Status CreateFromDescriptor(const TensorDescriptor &desc, CLContext *context);
 
 private:
@@ -94,6 +102,10 @@ private:
   int GetChannelsAlignment() const;
   int GetAlignedChannels() const;
 
+  absl::Status WriteDataBHWDC(absl::Span<const float> in, CLCommandQueue *queue);
+  absl::Status ReadDataBHWDC(absl::Span<float> out, CLCommandQueue *queue) const;
+
+  int3 GetFullTensorRegion() const;
   void Release();
 
   cl_mem memory_;

--- a/runtime/onert/backend/gpu_cl/open_cl/TensorType.cc
+++ b/runtime/onert/backend/gpu_cl/open_cl/TensorType.cc
@@ -930,6 +930,31 @@ TextureAddressMode TensorDescriptor::ModeFromState() const
   }
 }
 
+void TensorDescriptor::UploadData(const InternalTensor<HWC, DataType::FLOAT32> &src)
+{
+  shape = BHWDC(1, src.shape.h, src.shape.w, 1, src.shape.c);
+  UploadData(absl::MakeConstSpan(src.data));
+}
+
+void TensorDescriptor::UploadData(const InternalTensor<Linear, DataType::FLOAT32> &src)
+{
+  shape = BHWDC(1, 1, 1, 1, src.shape.v);
+  UploadData(absl::MakeConstSpan(src.data));
+}
+
+void TensorDescriptor::UploadData(absl::Span<const float> src)
+{
+  int aligned_channels =
+    storage_type == TensorStorageType::SINGLE_TEXTURE_2D ? shape.c : AlignByN(shape.c, 4);
+  int elements_count = shape.b * shape.w * shape.h * shape.d * aligned_channels;
+  data.resize(elements_count * SizeOf(data_type));
+  if (data_type == DataType::FLOAT32)
+  {
+    float *gpu_data = reinterpret_cast<float *>(data.data());
+    DataFromBHWDC(src, shape, *this, absl::MakeSpan(gpu_data, elements_count));
+  }
+}
+
 bool TensorDescriptor::SupportsZeroClamp(const Axis &axis) const
 {
   switch (storage_type)
@@ -972,6 +997,119 @@ bool TensorDescriptor::IsLinear() const
   return storage_type == TensorStorageType::BUFFER ||
          storage_type == TensorStorageType::IMAGE_BUFFER;
 }
+
+bool TensorDescriptor::ReturnsZeroForNegOneRead() const
+{
+  return storage_type == TensorStorageType::IMAGE_BUFFER;
+}
+
+namespace
+{
+int GetLinearIndex(const TensorDescriptor &desc, const BHWDC &shape, int b, int x, int y, int d,
+                   int s, int sub_c)
+{
+  const int slices = DivideRoundUp(shape.c, 4);
+  switch (desc.storage_type)
+  {
+    case TensorStorageType::BUFFER:
+    case TensorStorageType::IMAGE_BUFFER:
+    case TensorStorageType::TEXTURE_ARRAY:
+    case TensorStorageType::TEXTURE_3D:
+      return ((((d * slices + s) * shape.h + y) * shape.w + x) * shape.b + b) * 4 +
+             sub_c; // DSHWBC4
+    case TensorStorageType::TEXTURE_2D:
+      return ((((y * slices + s) * shape.w + x) * shape.b + b) * shape.d + d) * 4 +
+             sub_c; // HSWBDC4
+    case TensorStorageType::SINGLE_TEXTURE_2D:
+      return (((y * shape.w + x) * shape.b + b) * shape.d + d) * shape.c + sub_c; // HWBDC
+    default:
+      return -1;
+  }
+  return -1;
+}
+
+int GetChannelsAlignment(const TensorDescriptor &desc, const BHWDC &shape)
+{
+  return desc.storage_type == TensorStorageType::SINGLE_TEXTURE_2D ? shape.c : 4;
+}
+} // namespace
+
+template <typename T>
+void DataFromBHWDC(absl::Span<const float> src, const BHWDC &shape, const TensorDescriptor &desc,
+                   absl::Span<T> dst)
+{
+  const int channels_alignment = GetChannelsAlignment(desc, shape);
+  const int slices = DivideRoundUp(shape.c, 4);
+  for (int b = 0; b < shape.b; ++b)
+  {
+    for (int s = 0; s < slices; ++s)
+    {
+      for (int y = 0; y < shape.h; ++y)
+      {
+        for (int x = 0; x < shape.w; ++x)
+        {
+          for (int d = 0; d < shape.d; ++d)
+          {
+            for (int c = 0; c < channels_alignment; ++c)
+            {
+              float value;
+              if (s * 4 + c < shape.c)
+              {
+                const int cpu_index = shape.LinearIndex({b, y, x, d, s * 4 + c});
+                value = src[cpu_index];
+              }
+              else
+              {
+                value = 0.0f;
+              }
+              int gpu_index = GetLinearIndex(desc, shape, b, x, y, d, s, c);
+              dst[gpu_index] = value;
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+template void DataFromBHWDC<float>(absl::Span<const float> src, const BHWDC &shape,
+                                   const TensorDescriptor &desc, absl::Span<float> dst);
+
+template <typename T>
+void DataToBHWDC(absl::Span<const T> src, const BHWDC &shape, const TensorDescriptor &desc,
+                 absl::Span<float> dst)
+{
+  const int channels_alignment = GetChannelsAlignment(desc, shape);
+  const int slices = DivideRoundUp(shape.c, 4);
+  for (int b = 0; b < shape.b; ++b)
+  {
+    for (int s = 0; s < slices; ++s)
+    {
+      for (int y = 0; y < shape.h; ++y)
+      {
+        for (int x = 0; x < shape.w; ++x)
+        {
+          for (int d = 0; d < shape.d; ++d)
+          {
+            for (int c = 0; c < channels_alignment; ++c)
+            {
+              if (s * 4 + c >= shape.c)
+              {
+                continue;
+              }
+              int cpu_index = shape.LinearIndex({b, y, x, d, s * 4 + c});
+              int gpu_index = GetLinearIndex(desc, shape, b, x, y, d, s, c);
+              dst[cpu_index] = src[gpu_index];
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+template void DataToBHWDC<float>(absl::Span<const float> src, const BHWDC &shape,
+                                 const TensorDescriptor &desc, absl::Span<float> dst);
 
 } // namespace gpu_cl
 } // namespace backend

--- a/runtime/onert/backend/gpu_cl/open_cl/TensorType.h
+++ b/runtime/onert/backend/gpu_cl/open_cl/TensorType.h
@@ -110,8 +110,8 @@ struct TensorDescriptor : public GPUObjectDescriptor
                                                   std::string *value_name, std::string *x_coord,
                                                   std::string *y_coord, std::string *s_coord) const;
 
-  // void UploadData(const InternalTensor<HWC, DataType::FLOAT32> &src);
-  // void UploadData(const InternalTensor<Linear, DataType::FLOAT32> &src);
+  void UploadData(const InternalTensor<HWC, DataType::FLOAT32> &src);
+  void UploadData(const InternalTensor<Linear, DataType::FLOAT32> &src);
 
   bool SupportsZeroClamp(const Axis &axis) const;
   bool CanReadOutOfBorder(const Axis &axis) const;
@@ -188,7 +188,17 @@ private:
   bool ParseCoordsFromArgs(const std::vector<std::string> &args, int offset, std::string *xc,
                            std::string *yc, std::string *zc, std::string *sc,
                            std::string *bc) const;
+
+  void UploadData(absl::Span<const float> src);
 };
+
+template <typename T>
+void DataFromBHWDC(absl::Span<const float> src, const BHWDC &shape, const TensorDescriptor &desc,
+                   absl::Span<T> dst);
+
+template <typename T>
+void DataToBHWDC(absl::Span<const T> src, const BHWDC &shape, const TensorDescriptor &desc,
+                 absl::Span<float> dst);
 
 std::string ToString(TensorStorageType type);
 


### PR DESCRIPTION
Apply shape on enqueueWriteBuffer/enqueueReadBuffer.

1. When the ClBuffer is created, It was aligned by the channel size.
   So While trying to read or write the buffer, It must be aligned.
2. And it will be applied a shape on enqueueWriteBuffer/enqueueReadBuffer.

Signed-off-by: H. Kim hyunjun2.kim@samsung.com
Signed-off-by: hj0412-yi hj0412.yi@samsung.com
Signed-off-by: sungho22.lee sungho22.lee@samsung.com