### PR TITLE
[onert][gpu_cl] Add relu, relu6 and leakyrelu operations.

### DIFF
--- a/runtime/onert/backend/gpu_cl/KernelGenerator.h
+++ b/runtime/onert/backend/gpu_cl/KernelGenerator.h
@@ -46,6 +46,7 @@ public:
 
 private:
   void visit(const ir::operation::BinaryArithmetic &) override;
+  void visit(const ir::operation::ElementwiseActivation &) override;
 
 private:
   const ir::Operands &_ctx;

--- a/runtime/onert/backend/gpu_cl/open_cl/Operations.h
+++ b/runtime/onert/backend/gpu_cl/open_cl/Operations.h
@@ -82,7 +82,7 @@ enum class OperationType
   // REDUCE_MINIMUM,
   // REDUCE_PRODUCT,
   // REDUCE_SUM,
-  // RELU,
+  RELU,
   // RESHAPE,
   // RESIZE,
   // RSQRT,
@@ -100,7 +100,24 @@ enum class OperationType
   // TRANSPOSE,
 };
 
-#if 0
+// f(x):= {
+//   if x < 0  : x -> alpha * x
+//   if x >= 0 : x -> min(clip, x)
+// }
+//
+// Examples:
+//   - ReLU: clip = 0, alpha = 0
+//   - ReLU6: clip = 6, alpha = 0
+//   - Leaky ReLU: clip = 0, alpha = a
+struct ReLUAttributes
+{
+  // clip <= 0 mean it is not set.
+  float clip = 0;
+
+  float alpha = 0;
+};
+
+#if 0 // NYI
 std::string ToString(enum OperationType op);
 
 OperationType OperationTypeFromString(const std::string &name);
@@ -352,23 +369,6 @@ Padding2D CalculateSamePadding(const BHWC &input, const DepthwiseConvolution2DAt
 // @return padding for depthwise convolution operation to make sure output keep
 // the same shape as the given input.
 Padding3D CalculateSamePadding(const BHWDC &input, const DepthwiseConvolution3DAttributes &attr);
-
-// f(x):= {
-//   if x < 0  : x -> alpha * x
-//   if x >= 0 : x -> min(clip, x)
-// }
-//
-// Examples:
-//   - ReLU: clip = 0, alpha = 0
-//   - ReLU6: clip = 6, alpha = 0
-//   - Leaky ReLU: clip = 0, alpha = a
-struct ReLUAttributes
-{
-  // clip <= 0 mean it is not set.
-  float clip = 0;
-
-  float alpha = 0;
-};
 
 struct PReLUAttributes
 {

--- a/runtime/onert/backend/gpu_cl/open_cl/Spi.h
+++ b/runtime/onert/backend/gpu_cl/open_cl/Spi.h
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-#ifndef __ONERT_BACKEND_GPU_CL_OPENCL_SPI_H__
-#define __ONERT_BACKEND_GPU_CL_OPENCL_SPI_H__
+#ifndef __ONERT_BACKEND_GPU_CL_OPEN_CL_SPI_H__
+#define __ONERT_BACKEND_GPU_CL_OPEN_CL_SPI_H__
 
 #include <cstdint>
 
@@ -91,4 +91,4 @@ private:
 } // namespace backend
 } // namespace onert
 
-#endif // __ONERT_BACKEND_GPU_CL_OPENCL_SPI_H__
+#endif // __ONERT_BACKEND_GPU_CL_OPEN_CL_SPI_H__

--- a/runtime/onert/backend/gpu_cl/open_cl/kernels/Relu.cc
+++ b/runtime/onert/backend/gpu_cl/open_cl/kernels/Relu.cc
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Relu.h"
+
+#include <string>
+#include "Util.h"
+#include "GpuOperation.h"
+#include "absl/strings/str_cat.h"
+#include "open_cl/Precision.h"
+
+namespace onert
+{
+namespace backend
+{
+namespace gpu_cl
+{
+
+GPUOperation CreateReLU(const OperationDef &definition, const ReLUAttributes &attr)
+{
+  GPUOperation op(definition);
+  op.elementwise_ = true;
+
+  std::string min_func;
+  if (attr.alpha != 0.0f)
+  {
+    min_func = "min(in_out_value * args.alpha, (FLT)(0.0f))";
+    if (definition.precision == CalculationsPrecision::F32)
+    {
+      op.args_.AddFloat("alpha", attr.alpha);
+    }
+    else
+    {
+#ifdef FIXME_PORTING_HALF_REQIRED
+      op.args_.AddHalf("alpha", half(attr.alpha));
+#endif
+    }
+  }
+  else
+  {
+    min_func = "(FLT)(0.0f)";
+  }
+  if (attr.clip != 0.0f)
+  {
+    if (definition.precision == CalculationsPrecision::F32)
+    {
+      op.args_.AddFloat("clip", attr.clip);
+    }
+    else
+    {
+#ifdef FIXME_PORTING_HALF_REQIRED
+      op.args_.AddHalf("clip", half(attr.clip));
+#endif
+    }
+    op.code_ = absl::StrCat("in_out_value = clamp(in_out_value, " + min_func + ", args.clip);");
+  }
+  else
+  {
+    op.code_ = absl::StrCat("in_out_value = max(in_out_value, ", min_func, ");");
+  }
+  return op;
+}
+
+} // namespace gpu_cl
+} // namespace backend
+} // namespace onert

--- a/runtime/onert/backend/gpu_cl/open_cl/kernels/Relu.h
+++ b/runtime/onert/backend/gpu_cl/open_cl/kernels/Relu.h
@@ -15,14 +15,15 @@
  * limitations under the License.
  */
 
-#include "SimpleSelectors.h"
+#ifndef __ONERT_BACKEND_GPU_CL_OPEN_CL_KERNELS_RELU_H__
+#define __ONERT_BACKEND_GPU_CL_OPEN_CL_KERNELS_RELU_H__
 
-#include <memory>
-#include <set>
-
-#include "open_cl/kernels/Add.h"
-#include "open_cl/kernels/Relu.h"
-
+#include "open_cl/ClKernel.h"
+#include "GpuOperation.h"
+#include "open_cl/Precision.h"
+#include "open_cl/Tensor.h"
+#include "open_cl/Types.h"
+#include "open_cl/Operations.h"
 namespace onert
 {
 namespace backend
@@ -30,18 +31,10 @@ namespace backend
 namespace gpu_cl
 {
 
-void SelectAdd(const OperationDef &op_def, const std::vector<int> &channels, int dst_channels,
-               std::unique_ptr<GPUOperation> *ptr)
-{
-  GPUOperation operation = CreateAdd(op_def, channels, dst_channels);
-  *ptr = std::make_unique<GPUOperation>(std::move(operation));
-}
-
-std::unique_ptr<GPUOperation> SelectReLU(const ReLUAttributes &attr, const OperationDef &op_def)
-{
-  return absl::make_unique<GPUOperation>(CreateReLU(op_def, attr));
-}
+GPUOperation CreateReLU(const OperationDef &definition, const ReLUAttributes &attr);
 
 } // namespace gpu_cl
 } // namespace backend
 } // namespace onert
+
+#endif // __ONERT_BACKEND_GPU_CL_OPEN_CL_KERNELS_RELU_H__

--- a/runtime/onert/backend/gpu_cl/open_cl/selectors/SimpleSelectors.h
+++ b/runtime/onert/backend/gpu_cl/open_cl/selectors/SimpleSelectors.h
@@ -35,6 +35,8 @@ namespace gpu_cl
 void SelectAdd(const OperationDef &op_def, const std::vector<int> &channels, int dst_channels,
                std::unique_ptr<GPUOperation> *ptr);
 
+std::unique_ptr<GPUOperation> SelectReLU(const ReLUAttributes &attr, const OperationDef &op_def);
+
 } // namespace gpu_cl
 } // namespace backend
 } // namespace onert

--- a/tests/nnfw_api/src/CircleGen.cc
+++ b/tests/nnfw_api/src/CircleGen.cc
@@ -341,6 +341,18 @@ uint32_t CircleGen::addOperatorReduce(const OperatorParams &params,
   return addOperatorWithOptions(params, reduce_op, circle::BuiltinOptions_ReducerOptions, options);
 }
 
+uint32_t CircleGen::addOperatorRelu(const OperatorParams &params)
+{
+  return addOperatorWithOptions(params, circle::BuiltinOperator_RELU, circle::BuiltinOptions_NONE,
+                                0);
+}
+
+uint32_t CircleGen::addOperatorRelu6(const OperatorParams &params)
+{
+  return addOperatorWithOptions(params, circle::BuiltinOperator_RELU6, circle::BuiltinOptions_NONE,
+                                0);
+}
+
 uint32_t CircleGen::addOperatorReshape(const OperatorParams &params, const Shape *new_shape)
 {
   auto options = circle::CreateReshapeOptionsDirect(_fbb, new_shape).Union();

--- a/tests/nnfw_api/src/CircleGen.h
+++ b/tests/nnfw_api/src/CircleGen.h
@@ -189,6 +189,8 @@ public:
    * @brief Create circle Reshape op
    *        the second param new_shape can be optional just like circle::CreateReshapeOptionsDirect
    */
+  uint32_t addOperatorRelu(const OperatorParams &params);
+  uint32_t addOperatorRelu6(const OperatorParams &params);
   uint32_t addOperatorReshape(const OperatorParams &params, const Shape *new_shape = nullptr);
   uint32_t addOperatorResizeBilinear(const OperatorParams &params, bool align_corners = false,
                                      bool half_pixel_centers = false);

--- a/tests/nnfw_api/src/one_op_tests/Relu.cc
+++ b/tests/nnfw_api/src/one_op_tests/Relu.cc
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "GenModelTest.h"
+
+TEST_F(GenModelTest, OneOp_Relu)
+{
+  CircleGen cgen;
+  int in = cgen.addTensor({{2, 3}, circle::TensorType::TensorType_FLOAT32});
+  int out = cgen.addTensor({{2, 3}, circle::TensorType::TensorType_FLOAT32});
+  cgen.addOperatorRelu({{in}, {out}});
+  cgen.setInputsAndOutputs({in}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->addTestCase(
+    uniformTCD<float>({{0, 1.0, 3.0, 1.0, -1.0, -2.0f}}, {{0, 1.0, 3.0, 1.0, 0, 0}}));
+  _context->setBackends({"cpu", "gpu_cl"});
+
+  SUCCEED();
+}
+
+TEST_F(GenModelTest, neg_OneOp_Relu_InvalidType)
+{
+  CircleGen cgen;
+  int in = cgen.addTensor({{2, 3}, circle::TensorType::TensorType_UINT8});
+  int out = cgen.addTensor({{2, 3}, circle::TensorType::TensorType_FLOAT32});
+  cgen.addOperatorRelu({{in}, {out}});
+  cgen.setInputsAndOutputs({in}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->setBackends({"cpu", "gpu_cl"});
+  _context->expectFailModelLoad();
+
+  SUCCEED();
+}

--- a/tests/nnfw_api/src/one_op_tests/Relu6.cc
+++ b/tests/nnfw_api/src/one_op_tests/Relu6.cc
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "GenModelTest.h"
+
+TEST_F(GenModelTest, OneOp_Relu6)
+{
+  CircleGen cgen;
+  int in = cgen.addTensor({{2, 3}, circle::TensorType::TensorType_FLOAT32});
+  int out = cgen.addTensor({{2, 3}, circle::TensorType::TensorType_FLOAT32});
+  cgen.addOperatorRelu6({{in}, {out}});
+  cgen.setInputsAndOutputs({in}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->addTestCase(
+    uniformTCD<float>({{4, 7.0, 3.0, 8.0, -1.0, -2.0f}}, {{4, 6.0, 3.0, 6.0, 0, 0}}));
+  _context->setBackends({"cpu", "gpu_cl"});
+
+  SUCCEED();
+}
+
+TEST_F(GenModelTest, neg_OneOp_Relu6_InvalidType)
+{
+  CircleGen cgen;
+  int in = cgen.addTensor({{2, 3}, circle::TensorType::TensorType_UINT8});
+  int out = cgen.addTensor({{2, 3}, circle::TensorType::TensorType_FLOAT32});
+  cgen.addOperatorRelu6({{in}, {out}});
+  cgen.setInputsAndOutputs({in}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->setBackends({"cpu", "gpu_cl"});
+  _context->expectFailModelLoad();
+
+  SUCCEED();
+}


### PR DESCRIPTION
1. For gpu_cl, supports Relu, Relu6 and Leakyrelu.
2. Adds testcases.

Signed-off-by: H. Kim <hyunjun2.kim@samsung.com>
Signed-off-by: jw1772.kim <jw1772.kim@samsung.com>