### PR TITLE
[one-cmds] Prepend module name to error message by its own

### DIFF
--- a/compiler/one-cmds/one-build
+++ b/compiler/one-cmds/one-build
@@ -142,4 +142,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    _utils._safemain(main, __file__)

--- a/compiler/one-cmds/one-codegen
+++ b/compiler/one-cmds/one-codegen
@@ -168,4 +168,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    _utils._safemain(main, __file__)

--- a/compiler/one-cmds/one-import
+++ b/compiler/one-cmds/one-import
@@ -100,4 +100,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    _utils._safemain(main, __file__)

--- a/compiler/one-cmds/one-import-bcq
+++ b/compiler/one-cmds/one-import-bcq
@@ -224,4 +224,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    _utils._safemain(main, __file__)

--- a/compiler/one-cmds/one-import-onnx
+++ b/compiler/one-cmds/one-import-onnx
@@ -172,4 +172,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    _utils._safemain(main, __file__)

--- a/compiler/one-cmds/one-import-tf
+++ b/compiler/one-cmds/one-import-tf
@@ -201,4 +201,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    _utils._safemain(main, __file__)

--- a/compiler/one-cmds/one-import-tflite
+++ b/compiler/one-cmds/one-import-tflite
@@ -113,4 +113,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    _utils._safemain(main, __file__)

--- a/compiler/one-cmds/one-optimize
+++ b/compiler/one-cmds/one-optimize
@@ -136,4 +136,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    _utils._safemain(main, __file__)

--- a/compiler/one-cmds/one-pack
+++ b/compiler/one-cmds/one-pack
@@ -121,4 +121,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    _utils._safemain(main, __file__)

--- a/compiler/one-cmds/one-quantize
+++ b/compiler/one-cmds/one-quantize
@@ -273,4 +273,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    _utils._safemain(main, __file__)

--- a/compiler/one-cmds/onecc
+++ b/compiler/one-cmds/onecc
@@ -52,7 +52,7 @@ def _call_driver(driver_name, options):
     with subprocess.Popen(
             cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, bufsize=1) as p:
         for line in p.stdout:
-            sys.stdout.buffer.write(f"{driver_name}: ".encode() + line)
+            sys.stdout.buffer.write(line)
             sys.stdout.buffer.flush()
     if p.returncode != 0:
         sys.exit(p.returncode)
@@ -195,4 +195,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    _utils._safemain(main, __file__)

--- a/compiler/one-cmds/utils.py
+++ b/compiler/one-cmds/utils.py
@@ -216,3 +216,13 @@ def _print_version_and_exit(file_path):
     # run one-version
     subprocess.call([os.path.join(dir_path, 'one-version'), script_name])
     sys.exit()
+
+
+def _safemain(main, mainpath):
+    """execute given method and print with program name for all uncaught exceptions"""
+    try:
+        main()
+    except Exception as e:
+        prog_name = os.path.basename(mainpath)
+        print(f"{prog_name}: {type(e).__name__}: " + str(e))
+        sys.exit(255)


### PR DESCRIPTION
`one-xxx` will prepend its name to messages from uncaught errors.
`onecc` (the caller) does not prepend backend names for callee any longer.
It means `one-xxx` will get prepended error messages when it is executed
directly, not through `onecc`.

Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

Related: #7422
First part of #7427