### PR TITLE
[tf2tfliteV2] Prepend tf2tfliteV2 to error message

### DIFF
--- a/compiler/tf2tfliteV2/tf2tfliteV2.py
+++ b/compiler/tf2tfliteV2/tf2tfliteV2.py
@@ -261,4 +261,9 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except Exception as e:
+        prog_name = os.path.basename(__file__)
+        print(f"{prog_name}: {type(e).__name__}: " + str(e))
+        sys.exit(255)


### PR DESCRIPTION
It prepends tf2tfliteV2.py to message from uncaught errors.

Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>