### PR TITLE
[one-cmds] Prepend name to error message from c++/bash executables

### DIFF
--- a/compiler/one-cmds/one-codegen
+++ b/compiler/one-cmds/one-codegen
@@ -161,7 +161,7 @@ def main():
             codegen_cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
             bufsize=1) as p:
         for line in p.stdout:
-            sys.stdout.buffer.write(line)
+            sys.stdout.buffer.write(f"{backend_base}: ".encode() + line)
             sys.stdout.buffer.flush()
     if p.returncode != 0:
         sys.exit(p.returncode)

--- a/compiler/one-cmds/one-import-bcq
+++ b/compiler/one-cmds/one-import-bcq
@@ -202,7 +202,7 @@ def _convert(args):
                 stderr=subprocess.STDOUT,
                 bufsize=1) as p:
             for line in p.stdout:
-                sys.stdout.buffer.write(line)
+                sys.stdout.buffer.write("tflite2circle: ".encode() + line)
                 f.write(line)
         if p.returncode != 0:
             sys.exit(p.returncode)

--- a/compiler/one-cmds/one-import-onnx
+++ b/compiler/one-cmds/one-import-onnx
@@ -149,7 +149,7 @@ def _convert(args):
                 stderr=subprocess.STDOUT,
                 bufsize=1) as p:
             for line in p.stdout:
-                sys.stdout.buffer.write(line)
+                sys.stdout.buffer.write("tflite2circle: ".encode() + line)
                 sys.stdout.buffer.flush()
                 f.write(line)
         if p.returncode != 0:

--- a/compiler/one-cmds/one-import-tf
+++ b/compiler/one-cmds/one-import-tf
@@ -178,7 +178,7 @@ def _convert(args):
                 stderr=subprocess.STDOUT,
                 bufsize=1) as p:
             for line in p.stdout:
-                sys.stdout.buffer.write(line)
+                sys.stdout.buffer.write("tflite2circle: ".encode() + line)
                 sys.stdout.buffer.flush()
                 f.write(line)
         if p.returncode != 0:

--- a/compiler/one-cmds/one-import-tflite
+++ b/compiler/one-cmds/one-import-tflite
@@ -90,7 +90,7 @@ def _convert(args):
                 stderr=subprocess.STDOUT,
                 bufsize=1) as p:
             for line in p.stdout:
-                sys.stdout.buffer.write(line)
+                sys.stdout.buffer.write("tflite2circle: ".encode() + line)
                 sys.stdout.buffer.flush()
                 f.write(line)
         if p.returncode != 0:

--- a/compiler/one-cmds/one-optimize
+++ b/compiler/one-cmds/one-optimize
@@ -113,7 +113,7 @@ def _optimize(args):
                 stderr=subprocess.STDOUT,
                 bufsize=1) as p:
             for line in p.stdout:
-                sys.stdout.buffer.write(line)
+                sys.stdout.buffer.write("circle2circle: ".encode() + line)
                 sys.stdout.buffer.flush()
                 f.write(line)
         if p.returncode != 0:

--- a/compiler/one-cmds/one-pack
+++ b/compiler/one-cmds/one-pack
@@ -98,7 +98,7 @@ def _pack(args):
                 model2nnpkg_cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
                 bufsize=1) as p:
             for line in p.stdout:
-                sys.stdout.buffer.write(line)
+                sys.stdout.buffer.write("model2nnpkg.sh: ".encode() + line)
                 sys.stdout.buffer.flush()
                 f.write(line)
         if p.returncode != 0:

--- a/compiler/one-cmds/one-quantize
+++ b/compiler/one-cmds/one-quantize
@@ -167,7 +167,7 @@ def _quantize(args):
                 stderr=subprocess.STDOUT,
                 bufsize=1) as p:
             for line in p.stdout:
-                sys.stdout.buffer.write(line)
+                sys.stdout.buffer.write("circle_quantizer: ".encode() + line)
                 sys.stdout.buffer.flush()
                 f.write(line)
         if p.returncode != 0:
@@ -214,7 +214,7 @@ def _quantize(args):
                 stderr=subprocess.STDOUT,
                 bufsize=1) as p:
             for line in p.stdout:
-                sys.stdout.buffer.write(line)
+                sys.stdout.buffer.write("record_minmax: ".encode() + line)
                 sys.stdout.buffer.flush()
                 f.write(line)
         if p.returncode != 0:
@@ -247,7 +247,7 @@ def _quantize(args):
                 stderr=subprocess.STDOUT,
                 bufsize=1) as p:
             for line in p.stdout:
-                sys.stdout.buffer.write(line)
+                sys.stdout.buffer.write("circle_quantizer: ".encode() + line)
                 sys.stdout.buffer.flush()
                 f.write(line)
         if p.returncode != 0:


### PR DESCRIPTION
It prepends module name to error messages from c++ executables
(e.g. `circle_quantizer`, `record_minmax`, ....).

Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

Related: #7422
A part of #7427