### PR TITLE
[luci-interpreter] Rename Reverse -> ReverseV2

### DIFF
--- a/compiler/luci-interpreter/src/kernels/CMakeLists.txt
+++ b/compiler/luci-interpreter/src/kernels/CMakeLists.txt
@@ -99,8 +99,8 @@ set(SOURCES
     ResizeBilinear.cpp
     ResizeNearestNeighbor.h
     ResizeNearestNeighbor.cpp
-    Reverse.h
-    Reverse.cpp
+    ReverseV2.h
+    ReverseV2.cpp
     Rsqrt.h
     Rsqrt.cpp
     Slice.h
@@ -209,7 +209,7 @@ set(TEST_SOURCES
     Reshape.test.cpp
     ResizeBilinear.test.cpp
     ResizeNearestNeighbor.test.cpp
-    Reverse.test.cpp
+    ReverseV2.test.cpp
     Rsqrt.test.cpp
     Slice.test.cpp
     Softmax.test.cpp

--- a/compiler/luci-interpreter/src/kernels/ReverseV2.cpp
+++ b/compiler/luci-interpreter/src/kernels/ReverseV2.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "kernels/Reverse.h"
+#include "kernels/ReverseV2.h"
 #include "kernels/Utils.h"
 #include <tensorflow/lite/kernels/internal/reference/reference_ops.h>
 
@@ -24,12 +24,12 @@ namespace luci_interpreter
 namespace kernels
 {
 
-Reverse::Reverse(const Tensor *input, const Tensor *axes, Tensor *output)
+ReverseV2::ReverseV2(const Tensor *input, const Tensor *axes, Tensor *output)
   : Kernel({input, axes}, {output})
 {
 }
 
-void Reverse::configure()
+void ReverseV2::configure()
 {
   assert(axes()->shape().num_dims() == 1);
   assert(input()->shape().num_dims() >= axes()->shape().num_elements());
@@ -57,7 +57,7 @@ void Reverse::configure()
   output()->resize(input()->shape());
 }
 
-void Reverse::execute() const
+void ReverseV2::execute() const
 {
   int axis_value = getTensorData<int32_t>(axes())[0];
   switch (output()->element_type())

--- a/compiler/luci-interpreter/src/kernels/ReverseV2.h
+++ b/compiler/luci-interpreter/src/kernels/ReverseV2.h
@@ -24,10 +24,10 @@ namespace luci_interpreter
 namespace kernels
 {
 
-class Reverse : public Kernel
+class ReverseV2 : public Kernel
 {
 public:
-  Reverse(const Tensor *input, const Tensor *axes, Tensor *output);
+  ReverseV2(const Tensor *input, const Tensor *axes, Tensor *output);
 
   const Tensor *input() const { return _inputs[0]; }
   const Tensor *axes() const { return _inputs[1]; }

--- a/compiler/luci-interpreter/src/kernels/ReverseV2.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/ReverseV2.test.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-#include "kernels/Reverse.h"
+#include "kernels/ReverseV2.h"
 #include "kernels/TestUtils.h"
 
 namespace luci_interpreter
@@ -27,14 +27,14 @@ namespace
 
 using namespace testing;
 
-template <typename T> class ReverseTest : public ::testing::Test
+template <typename T> class ReverseV2Test : public ::testing::Test
 {
 };
 
 using DataTypes = ::testing::Types<float, uint8_t>;
-TYPED_TEST_CASE(ReverseTest, DataTypes);
+TYPED_TEST_CASE(ReverseV2Test, DataTypes);
 
-TYPED_TEST(ReverseTest, MultiDimensions)
+TYPED_TEST(ReverseV2Test, MultiDimensions)
 {
   // TypeParam
   std::vector<TypeParam> input_data{1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12,
@@ -52,7 +52,7 @@ TYPED_TEST(ReverseTest, MultiDimensions)
 
   Tensor output_tensor = makeOutputTensor(getElementType<TypeParam>());
 
-  Reverse kernel = Reverse(&input_tensor, &axis_tensor, &output_tensor);
+  ReverseV2 kernel = ReverseV2(&input_tensor, &axis_tensor, &output_tensor);
   kernel.configure();
   kernel.execute();
 

--- a/compiler/luci-interpreter/src/loader/KernelBuilder.cpp
+++ b/compiler/luci-interpreter/src/loader/KernelBuilder.cpp
@@ -65,7 +65,7 @@
 #include "kernels/Reshape.h"
 #include "kernels/ResizeBilinear.h"
 #include "kernels/ResizeNearestNeighbor.h"
-#include "kernels/Reverse.h"
+#include "kernels/ReverseV2.h"
 #include "kernels/Rsqrt.h"
 #include "kernels/Slice.h"
 #include "kernels/Softmax.h"
@@ -1015,7 +1015,7 @@ std::unique_ptr<Kernel> KernelBuilderLet<KB::OPQR>::visit(const luci::CircleReve
   const Tensor *axes = getInputTensor(node->axis());
   Tensor *output = getOutputTensor(node);
 
-  return std::make_unique<kernels::Reverse>(input, axes, output);
+  return std::make_unique<kernels::ReverseV2>(input, axes, output);
 }
 
 std::unique_ptr<Kernel> KernelBuilderLet<KB::OPQR>::visit(const luci::CircleRsqrt *node)

--- a/compiler/luci-interpreter/src/loader/KernelBuilder.test.cpp
+++ b/compiler/luci-interpreter/src/loader/KernelBuilder.test.cpp
@@ -62,7 +62,7 @@
 #include <kernels/Reshape.h>
 #include <kernels/ResizeBilinear.h>
 #include <kernels/ResizeNearestNeighbor.h>
-#include <kernels/Reverse.h>
+#include <kernels/ReverseV2.h>
 #include <kernels/Rsqrt.h>
 #include <kernels/Slice.h>
 #include <kernels/Softmax.h>
@@ -993,7 +993,7 @@ TEST_F(KernelBuilderTest, ReverseV2)
   op->tensor(input);
   op->axis(axes);
 
-  auto kernel = buildKernel<kernels::Reverse>(op);
+  auto kernel = buildKernel<kernels::ReverseV2>(op);
   ASSERT_THAT(kernel, NotNull());
 
   checkTensor(kernel->input(), input);


### PR DESCRIPTION
This commit renames Reverse -> ReverseV2 class and .cpp/.h files to support configurable build.

Draft: https://github.com/Samsung/ONE/pull/7304

ONE-DCO-1.0-Signed-off-by: Vyacheslav Bazhenov <slavikmipt@gmail.com>