### PR TITLE
remove tflite's open_cl files from coverage test

### DIFF
--- a/infra/command/gen-coverage-report
+++ b/infra/command/gen-coverage-report
@@ -66,10 +66,13 @@ done
 "${LCOV_PATH}" -e "${RAW_COVERAGE_INFO_PATH}" -o "${EXTRACTED_COVERAGE_INFO_PATH}" \
   "${CANDIDATES[@]}"
 
+
+opencl_files=($(find ./runtime/onert/backend/gpu_cl/open_cl/ -maxdepth 1 \( -name "*.cc" -o -name "*.h" \) -exec realpath {} \; ))
+
 # Exclude *.test.cpp files from coverage report
 # Exclude flatbuffer generated files from coverage report
 "${LCOV_PATH}" -r "${EXTRACTED_COVERAGE_INFO_PATH}" -o "${EXCLUDED_COVERAGE_INFO_PATH}" \
-  '*.test.cpp' '*_schema_generated.h'
+  '*.test.cpp' '*_schema_generated.h' "${opencl_files[@]}"
 
 # Final coverage data
 cp -v ${EXCLUDED_COVERAGE_INFO_PATH} ${COVERAGE_INFO_PATH}


### PR DESCRIPTION
This is a workdaround to resolve line coverage problem.
gpu_cl's open_cl(depth1) folder contains tflite's opencl files. This
commit will remove those files from coverage test.