### PR TITLE
[generate_bcq_metatdata] Prepend tool name to error messages

### DIFF
--- a/compiler/bcq-tools/generate_bcq_metadata.py
+++ b/compiler/bcq-tools/generate_bcq_metadata.py
@@ -219,4 +219,9 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except Exception as e:
+        prog_name = os.path.basename(__file__)
+        print(f"{prog_name}: {type(e).__name__}: " + str(e))
+        sys.exit(255)


### PR DESCRIPTION
It prepend `generate_bcq_metadata.py` to error messages.

Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

1 Approval Please since it is basically same change to #7439, though I split this into two to conform `compiler/*` rule imposed by maintainer.

@mhs4670go or @jinevening 