### PR TITLE
[luci] Revise toNHWC to use convert_unary_x

### DIFF
--- a/compiler/luci/pass/src/ConvertNCHWToNHWCPass.cpp
+++ b/compiler/luci/pass/src/ConvertNCHWToNHWCPass.cpp
@@ -996,23 +996,7 @@ class ConvertNCHWToNHWC final : public luci::CircleNodeMutableVisitor<bool>
     return true;
   }
 
-  bool visit(luci::CircleNeg *node)
-  {
-    const auto pred_node = loco::must_cast<luci::CircleNode *>(node->x());
-    auto pre_trans = create_pre_transpose(node);
-    pre_trans->a(pred_node);
-    node->x(pre_trans);
-
-    // Do shape inference for this node again.
-    node->shape_status(luci::ShapeStatus::UNDEFINED);
-
-    auto post_trans = create_post_transpose(node);
-    loco::replace(node).with(post_trans);
-
-    post_trans->a(node);
-
-    return true;
-  }
+  bool visit(luci::CircleNeg *node) { return convert_unary_x<luci::CircleNeg>(node); }
 
   bool visit(luci::CirclePad *node)
   {
@@ -1068,23 +1052,7 @@ class ConvertNCHWToNHWC final : public luci::CircleNodeMutableVisitor<bool>
 
   bool visit(luci::CircleRelu6 *node) { return convert_unary_features<luci::CircleRelu6>(node); }
 
-  bool visit(luci::CircleRsqrt *node)
-  {
-    const auto pred_node = loco::must_cast<luci::CircleNode *>(node->x());
-    auto pre_trans = create_pre_transpose(node);
-    pre_trans->a(pred_node);
-    node->x(pre_trans);
-
-    // Do shape inference for this node again.
-    node->shape_status(luci::ShapeStatus::UNDEFINED);
-
-    auto post_trans = create_post_transpose(node);
-    loco::replace(node).with(post_trans);
-
-    post_trans->a(node);
-
-    return true;
-  }
+  bool visit(luci::CircleRsqrt *node) { return convert_unary_x<luci::CircleRsqrt>(node); }
 
   bool visit(luci::CircleSquaredDifference *node)
   {


### PR DESCRIPTION
This will revise toNHWC for Ops with one x() to use convert_unary_x method.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>