### PR TITLE
[circle2circle] Write errors to stderr, not to stdout

### DIFF
--- a/compiler/circle2circle/src/Circle2Circle.cpp
+++ b/compiler/circle2circle/src/Circle2Circle.cpp
@@ -374,7 +374,7 @@ int entry(int argc, char **argv)
   }
   catch (const std::runtime_error &err)
   {
-    std::cout << err.what() << std::endl;
+    std::cerr << err.what() << std::endl;
     std::cout << arser;
     return 255;
   }


### PR DESCRIPTION
It writes errors to stderr, not to stdout.

Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

One of twin from #7442