### PR TITLE
[circle-quantizer] print usage to stdout w/o prefix

### DIFF
--- a/compiler/circle-quantizer/src/CircleQuantizer.cpp
+++ b/compiler/circle-quantizer/src/CircleQuantizer.cpp
@@ -112,7 +112,7 @@ int entry(int argc, char **argv)
   catch (const std::runtime_error &err)
   {
     std::cerr << err.what() << std::endl;
-    std::cerr << arser;
+    std::cout << arser;
     return 255;
   }
 


### PR DESCRIPTION
It prints usage without the prefix "circle_quantizer: " on every line.

Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

ONE approval please.