### PR TITLE
[model2nnpkg.sh] Print name for stdout message

### DIFF
--- a/tools/nnpackage_tool/model2nnpkg/model2nnpkg.sh
+++ b/tools/nnpackage_tool/model2nnpkg/model2nnpkg.sh
@@ -67,7 +67,7 @@ if [ -z "$name" ]; then
 fi
 extension=${modelfile##*.}
 
-echo "Generating nnpackage "$name" in "$outdir""
+echo "$progname: Generating nnpackage "$name" in "$outdir""
 mkdir -p "$outdir"/"$name"/metadata
 
 if [ -s "$config_src" ]; then


### PR DESCRIPTION
`model2nnpkg.sh` will print its name for stdout message.

Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

ONE approval please

Related: #7422