### PR TITLE
[record-minmax] Reject extremely small numbers from statistics

### DIFF
--- a/compiler/record-minmax/src/MinMaxObserver.cpp
+++ b/compiler/record-minmax/src/MinMaxObserver.cpp
@@ -86,6 +86,10 @@ void MinMaxObserver::postTensorWrite(const luci::CircleNode *node,
     if (isnan(number))
       continue;
 
+    // TODO use metadata hints to detect such cases
+    if (number == std::numeric_limits<float>::lowest())
+      continue;
+
     all_nan = false;
 
     if (number > max)


### PR DESCRIPTION
This commit adds filter that rejects numbers that are too small.
Such numbers are produced by MaxPoolWithArgmax resolving pass.

related issue: #7229

ONE-DCO-1.0-Signed-off-by: Alexander Efimov <a.efimov@samsung.com>