### PR TITLE
[one-cmds] Add one-profile to debian package

### DIFF
--- a/infra/debian/compiler/one-compiler.install
+++ b/infra/debian/compiler/one-compiler.install
@@ -20,6 +20,7 @@ usr/bin/one-import-tflite usr/share/one/bin/
 usr/bin/one-optimize usr/share/one/bin/
 usr/bin/one-pack usr/share/one/bin/
 usr/bin/one-prepare-venv usr/share/one/bin/
+usr/bin/one-profile usr/share/one/bin/
 usr/bin/one-quantize usr/share/one/bin/
 usr/bin/one-version usr/share/one/bin/
 usr/bin/rawdata2hdf5 usr/share/one/bin/


### PR DESCRIPTION
This commit installs one-profile binary to /usr/share/one/bin.

Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>