### PR TITLE
[one-cmds] Fix wrong commands

### DIFF
--- a/compiler/one-cmds/one-import-onnx
+++ b/compiler/one-cmds/one-import-onnx
@@ -135,7 +135,7 @@ def _convert(args):
         f.write((' '.join(tflite2circle_cmd) + '\n').encode())
 
         # convert tflite to circle
-        _util._run(tflite2circle_cmd, err_prefix="tflite2circle", logfile=f)
+        _utils._run(tflite2circle_cmd, err_prefix="tflite2circle", logfile=f)
 
 
 def main():

--- a/compiler/one-cmds/one-quantize
+++ b/compiler/one-cmds/one-quantize
@@ -221,7 +221,7 @@ def _quantize(args):
         f.write((' '.join(circle_quantizer_cmd) + '\n').encode())
 
         # run circle-quantizer
-        _utils._run(circle2circle_cmd, err_prefix="circle_quantizer", logfile=f)
+        _utils._run(circle_quantizer_cmd, err_prefix="circle_quantizer", logfile=f)
 
 
 def main():


### PR DESCRIPTION
This commit fixes wrong commands.

Related: #7485 
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>