### PR TITLE
[one-cmds] Use store_true in one-cmd utils

### DIFF
--- a/compiler/one-cmds/utils.py
+++ b/compiler/one-cmds/utils.py
@@ -96,9 +96,7 @@ def _add_default_arg(parser):
     parser.add_argument(
         '-V',
         '--verbose',
-        action='store_const',
-        default='0',
-        const='1',
+        action='store_true',
         help='output additional information to stdout or stderr')
 
     # configuration file


### PR DESCRIPTION
This commit changes the action way to use store_true instead of store_const.
The store_true means if the option is specified, assign the value True to verbose.
Not specifying it implies False.
The actual operation is the same as before.

Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>