### PR TITLE
[infra] Fix one-codegen man page

### DIFF
--- a/infra/debian/compiler/docs/one-codegen.1
+++ b/infra/debian/compiler/docs/one-codegen.1
@@ -17,8 +17,7 @@ show program's version number and exit
 run with configuation file
 .TP
 \fB\-b\fR BACKEND, \fB\-\-backend\fR BACKEND
-backend name to use (There is no available backend
-drivers)
+backend name to use
 .SH COPYRIGHT
 Copyright \(co 2020\-2021 Samsung Electronics Co., Ltd. All Rights Reserved
 Licensed under the Apache License, Version 2.0


### PR DESCRIPTION
This commit fixes one-codegen man page.

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>