### PR TITLE
[one-cmds] Add missing import os error in generate_bcq_metadata.py

### DIFF
--- a/compiler/bcq-tools/generate_bcq_metadata.py
+++ b/compiler/bcq-tools/generate_bcq_metadata.py
@@ -19,6 +19,7 @@ import numpy as np
 import tensorflow as tf
 
 import argparse
+import os
 import sys
 
 # TODO Find better way to suppress trackback on error


### PR DESCRIPTION
It fixes import error raised during exception handling.

Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

Related: #7490 