### PR TITLE
[one-cmds] Add verbose option to tf2tfliteV2 command

### DIFF
--- a/compiler/one-cmds/utils.py
+++ b/compiler/one-cmds/utils.py
@@ -138,6 +138,9 @@ def _parse_cfg(args, driver_name):
 def _make_tf2tfliteV2_cmd(args, driver_path, input_path, output_path):
     """make a command for running tf2tfliteV2.py"""
     cmd = [sys.executable, os.path.expanduser(driver_path)]
+    # verbose
+    if _is_valid_attr(args, 'verbose'):
+        cmd.append('--verbose')
     # model_format
     if _is_valid_attr(args, 'model_format_cmd'):
         cmd.append(getattr(args, 'model_format_cmd'))


### PR DESCRIPTION
This commit changes the utils file to add the verbose option to tf2tfliteV2.

Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>