### PR TITLE
[one-cmds] Redirect stderr

### DIFF
--- a/compiler/one-cmds/tests/one-build_001.test
+++ b/compiler/one-cmds/tests/one-build_001.test
@@ -31,7 +31,7 @@ configfile="one-build_001.cfg"
 outputfile="inception_v3.opt.circle"
 
 # run test
-one-build -C ${configfile} > /dev/null
+one-build -C ${configfile} > /dev/null 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-build_002.test
+++ b/compiler/one-cmds/tests/one-build_002.test
@@ -31,7 +31,7 @@ configfile="one-build_002.cfg"
 outputfile="inception_v3_pkg"
 
 # run test
-one-build -C ${configfile} > /dev/null
+one-build -C ${configfile} > /dev/null 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-build_003.test
+++ b/compiler/one-cmds/tests/one-build_003.test
@@ -33,7 +33,7 @@ outputfile="inception_v3.quantized.circle"
 rm -rf ${outputfile}
 
 # run test
-one-build -C ${configfile} > /dev/null
+one-build -C ${configfile} > /dev/null 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-build_004.test
+++ b/compiler/one-cmds/tests/one-build_004.test
@@ -37,7 +37,7 @@ rm -rf ${outputfile}
 cp dummy-compile ../bin/dummy-compile
 
 # run test
-one-build -C ${configfile} > /dev/null
+one-build -C ${configfile} > /dev/null 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-build_005.test
+++ b/compiler/one-cmds/tests/one-build_005.test
@@ -37,7 +37,7 @@ rm -rf ${outputfile}
 cp dummy-compile ../bin/dummy-compile
 
 # run test
-one-build -C ${configfile} > /dev/null
+one-build -C ${configfile} > /dev/null 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-build_006.test
+++ b/compiler/one-cmds/tests/one-build_006.test
@@ -37,7 +37,7 @@ rm -rf ${outputfile}
 cp dummy-compile ../bin/dummy-compile
 
 # run test
-one-build -C ${configfile} > /dev/null
+one-build -C ${configfile} > /dev/null 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-build_007.test
+++ b/compiler/one-cmds/tests/one-build_007.test
@@ -33,7 +33,7 @@ outputfile="inception_v3_pkg"
 rm -rf ${outputfile}
 
 # run test
-one-build -C ${configfile} > /dev/null
+one-build -C ${configfile} > /dev/null 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-build_008.test
+++ b/compiler/one-cmds/tests/one-build_008.test
@@ -37,7 +37,7 @@ rm -rf ${outputfile}
 cp dummy-compile ../bin/dummy-compile
 
 # run test
-one-build -C ${configfile} > /dev/null
+one-build -C ${configfile} > /dev/null 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-build_009.test
+++ b/compiler/one-cmds/tests/one-build_009.test
@@ -37,7 +37,7 @@ rm -rf ${outputfile}
 cp dummy-compile ../bin/dummy-compile
 
 # run test
-one-build -C ${configfile} > /dev/null
+one-build -C ${configfile} > /dev/null 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-build_010.test
+++ b/compiler/one-cmds/tests/one-build_010.test
@@ -35,7 +35,7 @@ rm -rf ${outputfile}
 rm -rf ${intermfile}
 
 # run test
-one-build -C ${configfile} > /dev/null
+one-build -C ${configfile} > /dev/null 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-build_011.test
+++ b/compiler/one-cmds/tests/one-build_011.test
@@ -35,7 +35,7 @@ rm -rf ${outputfile}
 rm -rf ${intermfile}
 
 # run test
-one-build -C ${configfile} > /dev/null
+one-build -C ${configfile} > /dev/null 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-build_012.test
+++ b/compiler/one-cmds/tests/one-build_012.test
@@ -33,7 +33,7 @@ outputfile="inception_v3.list.quantized.circle"
 rm -rf ${outputfile}
 
 # run test
-one-build -C ${configfile} > /dev/null
+one-build -C ${configfile} > /dev/null 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-build_013.test
+++ b/compiler/one-cmds/tests/one-build_013.test
@@ -33,7 +33,7 @@ outputfile="inception_v3.dir.quantized.circle"
 rm -rf ${outputfile}
 
 # run test
-one-build -C ${configfile} > /dev/null
+one-build -C ${configfile} > /dev/null 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-codegen_001.test
+++ b/compiler/one-cmds/tests/one-codegen_001.test
@@ -29,7 +29,7 @@ trap trap_err_onexit ERR
 cp help-compile ../bin/help-compile
 
 # run test
-one-codegen -b help -- -h > ${filename}.log
+one-codegen -b help -- -h > ${filename}.log 2>&1
 
 rm -rf ../bin/help-compile
 

--- a/compiler/one-cmds/tests/one-codegen_002.test
+++ b/compiler/one-cmds/tests/one-codegen_002.test
@@ -36,7 +36,7 @@ rm -rf ${outputfile}
 cp dummy-compile ../bin/dummy-compile
 
 # run test
-one-codegen -b dummy -o ${outputfile} "dummy.circle"
+one-codegen -b dummy -o ${outputfile} "dummy.circle" > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-codegen_003.test
+++ b/compiler/one-cmds/tests/one-codegen_003.test
@@ -36,7 +36,7 @@ rm -rf ${outputfile}
 cp dummy-compile ../bin/dummy-compile
 
 # run test
-one-codegen -b dummy -- -o ${outputfile} "dummy.circle"
+one-codegen -b dummy -- -o ${outputfile} "dummy.circle" > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-codegen_004.test
+++ b/compiler/one-cmds/tests/one-codegen_004.test
@@ -28,7 +28,7 @@ trap_err_onexit()
 trap trap_err_onexit ERR
 
 # run test
-one-codegen -h > ${filename}.log
+one-codegen -h > ${filename}.log 2>&1
 
 if grep -q "command line tool for code generation" "${filename}.log"; then
   echo "${filename_ext} SUCCESS"

--- a/compiler/one-cmds/tests/one-import-bcq_001.test
+++ b/compiler/one-cmds/tests/one-import-bcq_001.test
@@ -35,7 +35,7 @@ one-import-bcq \
 --input_path ${inputfile} \
 --output_path ${outputfile} \
 --input_arrays Placeholder \
---output_arrays MatMul >> /dev/null
+--output_arrays MatMul > /dev/null 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-import-bcq_neg_001.test
+++ b/compiler/one-cmds/tests/one-import-bcq_neg_001.test
@@ -43,7 +43,7 @@ one-import-bcq \
 --input_path ${inputfile} \
 --output_path ${outputfile} \
 --input_arrays Placeholder_null \
---output_arrays MatMul > ${filename}.log
+--output_arrays MatMul > ${filename}.log 2>&1
 
 echo "${filename_ext} FAILED"
 exit 255

--- a/compiler/one-cmds/tests/one-import-bcq_neg_002.test
+++ b/compiler/one-cmds/tests/one-import-bcq_neg_002.test
@@ -43,7 +43,7 @@ one-import-bcq \
 --input_path ${inputfile} \
 --output_path ${outputfile} \
 --input_arrays Placeholder \
---output_arrays MatMul_null > ${filename}.log
+--output_arrays MatMul_null > ${filename}.log 2>&1
 
 echo "${filename_ext} FAILED"
 exit 255

--- a/compiler/one-cmds/tests/one-import-bcq_neg_003.test
+++ b/compiler/one-cmds/tests/one-import-bcq_neg_003.test
@@ -43,7 +43,7 @@ one-import-bcq \
 --input_path ${inputfile} \
 --output_path ${outputfile} \
 --input_arrays Placeholder \
---output_arrays MatMul > ${filename}.log
+--output_arrays MatMul > ${filename}.log 2>&1
 
 echo "${filename_ext} FAILED"
 exit 255

--- a/compiler/one-cmds/tests/one-import-bcq_neg_004.test
+++ b/compiler/one-cmds/tests/one-import-bcq_neg_004.test
@@ -43,7 +43,7 @@ one-import-bcq \
 --input_path ${inputfile} \
 --output_path ${outputfile} \
 --input_arrays Placeholder \
---output_arrays MatMul > ${filename}.log
+--output_arrays MatMul > ${filename}.log 2>&1
 
 echo "${filename_ext} FAILED"
 exit 255

--- a/compiler/one-cmds/tests/one-import-bcq_neg_005.test
+++ b/compiler/one-cmds/tests/one-import-bcq_neg_005.test
@@ -42,7 +42,7 @@ one-import-bcq \
 --input_path ${inputfile} \
 --output_path ${outputfile} \
 --input_arrays Placeholder \
---output_arrays MatMul > ${filename}.log
+--output_arrays MatMul > ${filename}.log 2>&1
 
 echo "${filename_ext} FAILED"
 exit 255

--- a/compiler/one-cmds/tests/one-import-bcq_neg_006.test
+++ b/compiler/one-cmds/tests/one-import-bcq_neg_006.test
@@ -42,7 +42,7 @@ one-import-bcq \
 --input_path ${inputfile} \
 --output_path ${outputfile} \
 --input_arrays Placeholder --input_shapes "1,32,32" \
---output_arrays MatMul > ${filename}.log
+--output_arrays MatMul > ${filename}.log 2>&1
 
 echo "${filename_ext} FAILED"
 exit 255

--- a/compiler/one-cmds/tests/one-import-bcq_neg_007.test
+++ b/compiler/one-cmds/tests/one-import-bcq_neg_007.test
@@ -42,7 +42,7 @@ one-import-bcq \
 --input_path ${inputfile} \
 --output_path ${outputfile} \
 --input_arrays Placeholder --input_shapes "30,30" \
---output_arrays MatMul > ${filename}.log
+--output_arrays MatMul > ${filename}.log 2>&1
 
 echo "${filename_ext} FAILED"
 exit 255

--- a/compiler/one-cmds/tests/one-import-bcq_neg_008.test
+++ b/compiler/one-cmds/tests/one-import-bcq_neg_008.test
@@ -42,7 +42,7 @@ one-import-bcq \
 --input_path ${inputfile} \
 --output_path ${outputfile} \
 --input_arrays Placeholder --input_shapes "32,O" \
---output_arrays MatMul > ${filename}.log
+--output_arrays MatMul > ${filename}.log 2>&1
 
 echo "${filename_ext} FAILED"
 exit 255

--- a/compiler/one-cmds/tests/one-import-bcq_neg_009.test
+++ b/compiler/one-cmds/tests/one-import-bcq_neg_009.test
@@ -42,7 +42,7 @@ one-import-bcq \
 --input_path ${inputfile} \
 --output_path ${outputfile} \
 --input_arrays Placeholder --input_shapes "32,32:1" \
---output_arrays MatMul > ${filename}.log
+--output_arrays MatMul > ${filename}.log 2>&1
 
 echo "${filename_ext} FAILED"
 exit 255

--- a/compiler/one-cmds/tests/one-import_001.test
+++ b/compiler/one-cmds/tests/one-import_001.test
@@ -35,7 +35,7 @@ one-import tf \
 --input_path ${inputfile} \
 --output_path ${outputfile} \
 --input_arrays input --input_shapes "1,299,299,3" \
---output_arrays InceptionV3/Predictions/Reshape_1 >> /dev/null
+--output_arrays InceptionV3/Predictions/Reshape_1 > /dev/null 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-import_002.test
+++ b/compiler/one-cmds/tests/one-import_002.test
@@ -32,7 +32,7 @@ outputfile="inception_v3_cmd.circle"
 
 # run test
 one-import tf -C ${configfile} \
---output_path=inception_v3_cmd.circle > /dev/null
+--output_path=inception_v3_cmd.circle > /dev/null 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-import_003.test
+++ b/compiler/one-cmds/tests/one-import_003.test
@@ -33,7 +33,7 @@ outputfile="test_saved_model.circle"
 rm -f ${outputfile}
 
 # run test
-one-import tf -C ${configfile} > /dev/null
+one-import tf -C ${configfile} > /dev/null 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-import_004.test
+++ b/compiler/one-cmds/tests/one-import_004.test
@@ -33,7 +33,7 @@ outputfile="test_keras_model.circle"
 rm -f ${outputfile}
 
 # run test
-one-import tf -C ${configfile} > /dev/null
+one-import tf -C ${configfile} > /dev/null 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-import_neg_001.test
+++ b/compiler/one-cmds/tests/one-import_neg_001.test
@@ -43,7 +43,7 @@ one-import tf \
 --input_path ${inputfile} \
 --output_path ${outputfile} \
 --input_arrays input --input_shapes "1,299,299,3" \
---output_arrays InceptionV3/Predictions/Reshape_1 > ${filename}.log
+--output_arrays InceptionV3/Predictions/Reshape_1 > ${filename}.log 2>&1
 
 echo "${filename_ext} FAILED"
 exit 255

--- a/compiler/one-cmds/tests/one-import_neg_002.test
+++ b/compiler/one-cmds/tests/one-import_neg_002.test
@@ -43,7 +43,7 @@ one-import tf \
 --input_path ${inputfile} \
 --output_path ${outputfile} \
 --input_arrays Hole,Hole_2 --input_shapes "1,1:1,1" \
---output_arrays Output > ${filename}.log
+--output_arrays Output > ${filename}.log 2>&1
 
 echo "${filename_ext} FAILED"
 exit 255

--- a/compiler/one-cmds/tests/one-import_neg_003.test
+++ b/compiler/one-cmds/tests/one-import_neg_003.test
@@ -51,7 +51,7 @@ one-import tf \
 --input_path ${inputfile} \
 --output_path ${outputfile} \
 --input_arrays input --input_shapes "1,299,299,3" \
---output_arrays InceptionV3/Predictions/Reshape_2 > ${filename}.log
+--output_arrays InceptionV3/Predictions/Reshape_2 > ${filename}.log 2>&1
 
 echo "${filename_ext} FAILED"
 exit 255

--- a/compiler/one-cmds/tests/one-import_neg_004.test
+++ b/compiler/one-cmds/tests/one-import_neg_004.test
@@ -43,7 +43,7 @@ one-import tf \
 --input_path ${inputfile} \
 --output_path ${outputfile} \
 --input_arrays input --input_shapes "1,299,299,1" \
---output_arrays InceptionV3/Predictions/Reshape_1 > ${filename}.log
+--output_arrays InceptionV3/Predictions/Reshape_1 > ${filename}.log 2>&1
 
 echo "${filename_ext} FAILED"
 exit 255

--- a/compiler/one-cmds/tests/one-import_neg_005.test
+++ b/compiler/one-cmds/tests/one-import_neg_005.test
@@ -43,7 +43,7 @@ one-import tf \
 --input_path ${inputfile} \
 --output_path ${outputfile} \
 --input_arrays input --input_shapes "1,299,299" \
---output_arrays InceptionV3/Predictions/Reshape_1 > ${filename}.log
+--output_arrays InceptionV3/Predictions/Reshape_1 > ${filename}.log 2>&1
 
 echo "${filename_ext} FAILED"
 exit 255

--- a/compiler/one-cmds/tests/one-import_neg_006.test
+++ b/compiler/one-cmds/tests/one-import_neg_006.test
@@ -43,7 +43,7 @@ one-import tf \
 --input_path ${inputfile} \
 --output_path ${outputfile} \
 --input_arrays input --input_shapes "0,299,299,3" \
---output_arrays InceptionV3/Predictions/Reshape_1 > ${filename}.log
+--output_arrays InceptionV3/Predictions/Reshape_1 > ${filename}.log 2>&1
 
 echo "${filename_ext} FAILED"
 exit 255

--- a/compiler/one-cmds/tests/one-import_neg_007.test
+++ b/compiler/one-cmds/tests/one-import_neg_007.test
@@ -43,7 +43,7 @@ one-import tf \
 --input_path ${inputfile} \
 --output_path ${outputfile} \
 --input_arrays input --input_shapes "None,299,299,3" \
---output_arrays InceptionV3/Predictions/Reshape_1 > ${filename}.log
+--output_arrays InceptionV3/Predictions/Reshape_1 > ${filename}.log 2>&1
 
 echo "${filename_ext} FAILED"
 exit 255

--- a/compiler/one-cmds/tests/one-import_neg_008.test
+++ b/compiler/one-cmds/tests/one-import_neg_008.test
@@ -43,7 +43,7 @@ one-import tf \
 --input_path ${inputfile} \
 --output_path ${outputfile} \
 --input_arrays input,InceptionV3/Predictions/Shape --input_shapes "1,299,299,3" \
---output_arrays InceptionV3/Predictions/Reshape_1 > ${filename}.log
+--output_arrays InceptionV3/Predictions/Reshape_1 > ${filename}.log 2>&1
 
 echo "${filename_ext} FAILED"
 exit 255

--- a/compiler/one-cmds/tests/one-import_neg_009.test
+++ b/compiler/one-cmds/tests/one-import_neg_009.test
@@ -42,7 +42,7 @@ one-import tf \
 --input_path ${inputfile} \
 --output_path ${outputfile} \
 --input_arrays input --input_shapes "1,299,299,3" \
---output_arrays InceptionV3/Predictions/Reshape_1 > ${filename}.log
+--output_arrays InceptionV3/Predictions/Reshape_1 > ${filename}.log 2>&1
 
 echo "${filename_ext} FAILED"
 exit 255

--- a/compiler/one-cmds/tests/one-import_neg_010.test
+++ b/compiler/one-cmds/tests/one-import_neg_010.test
@@ -43,7 +43,7 @@ one-import tf \
 --input_path ${inputfile} \
 --output_path ${outputfile} \
 --input_arrays input2 --input_shapes "1,299,299,3" \
---output_arrays InceptionV3/Predictions/Reshape_1 > ${filename}.log
+--output_arrays InceptionV3/Predictions/Reshape_1 > ${filename}.log 2>&1
 
 echo "${filename_ext} FAILED"
 exit 255

--- a/compiler/one-cmds/tests/one-optimize_001.test
+++ b/compiler/one-cmds/tests/one-optimize_001.test
@@ -32,7 +32,7 @@ rm -rf ${outputfile}
 
 # to create inception_v3.circle
 if [[ ! -s ${inputfile} ]]; then
-  /bin/bash one-import_001.test >> /dev/null
+  /bin/bash one-import_001.test > /dev/null 2>&1
   return_code=$?
   if [[ ${return_code} != 0 ]]; then
     trap_err_onexit
@@ -42,7 +42,7 @@ fi
 # run test
 one-optimize --O1 \
 --input_path ${inputfile} \
---output_path ${outputfile} >> /dev/null
+--output_path ${outputfile} > /dev/null 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-optimize_002.test
+++ b/compiler/one-cmds/tests/one-optimize_002.test
@@ -32,7 +32,7 @@ rm -rf ${outputfile}
 
 # to create inception_v3.circle
 if [[ ! -s ${inputfile} ]]; then
-  /bin/bash one-import_001.test >> /dev/null
+  /bin/bash one-import_001.test > /dev/null 2>&1
   return_code=$?
   if [[ ${return_code} != 0 ]]; then
     trap_err_onexit
@@ -43,7 +43,7 @@ fi
 one-optimize --O1 \
 --change_outputs InceptionV3/Logits/SpatialSqueeze1 \
 --input_path ${inputfile} \
---output_path ${outputfile} >> /dev/null
+--output_path ${outputfile} > /dev/null 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-optimize_neg_001.test
+++ b/compiler/one-cmds/tests/one-optimize_neg_001.test
@@ -41,7 +41,7 @@ rm -rf ${outputfile}.log
 # run test
 one-optimize --O1 \
 --input_path ${inputfile} \
---output_path ${outputfile} > ${filename}.log
+--output_path ${outputfile} > ${filename}.log 2>&1
 
 echo "${filename_ext} FAILED"
 exit 255

--- a/compiler/one-cmds/tests/one-optimize_neg_002.test
+++ b/compiler/one-cmds/tests/one-optimize_neg_002.test
@@ -41,7 +41,7 @@ rm -rf ${outputfile}.log
 # run test
 one-optimize --O1 \
 --input_path ${inputfile} \
---output_path ${outputfile} > ${filename}.log
+--output_path ${outputfile} > ${filename}.log 2>&1
 
 echo "${filename_ext} FAILED"
 exit 255

--- a/compiler/one-cmds/tests/one-optimize_neg_004.test
+++ b/compiler/one-cmds/tests/one-optimize_neg_004.test
@@ -42,7 +42,7 @@ rm -rf ${filename}.log
 one-optimize --O1 \
 --change_outputs non_existing_node_name \
 --input_path ${inputfile} \
---output_path ${outputfile} > ${filename}.log
+--output_path ${outputfile} > ${filename}.log 2>&1
 
 echo "${filename_ext} FAILED"
 exit 255

--- a/compiler/one-cmds/tests/one-pack_001.test
+++ b/compiler/one-cmds/tests/one-pack_001.test
@@ -32,7 +32,7 @@ rm -rf ${outputfolder}
 
 # to create inception_v3.circle
 if [[ ! -s ${inputfile} ]]; then
-  /bin/bash one-import_001.test >> /dev/null
+  /bin/bash one-import_001.test > /dev/null 2>&1
   return_code=$?
   if [[ ${return_code} != 0 ]]; then
     trap_err_onexit
@@ -42,7 +42,7 @@ fi
 # run test
 one-pack \
 -i ${inputfile} \
--o ${outputfolder} >> /dev/null
+-o ${outputfolder} > /dev/null 2>&1
 
 if [[ ! -d "${outputfolder}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-pack_neg_001.test
+++ b/compiler/one-cmds/tests/one-pack_neg_001.test
@@ -37,7 +37,7 @@ rm -rf ${filename}.log
 # run test
 one-pack \
 -i ./inception_v2.circle \
--o nnpack > ${filename}.log
+-o nnpack > ${filename}.log 2>&1
 
 echo "${filename_ext} FAILED"
 exit 255

--- a/compiler/one-cmds/tests/one-pack_neg_002.test
+++ b/compiler/one-cmds/tests/one-pack_neg_002.test
@@ -41,7 +41,7 @@ touch ./sample
 # run test
 one-pack \
 -i ./sample \
--o nnpack > ${filename}.log
+-o nnpack > ${filename}.log 2>&1
 
 echo "${filename_ext} FAILED"
 exit 255

--- a/compiler/one-cmds/tests/one-quantize_001.test
+++ b/compiler/one-cmds/tests/one-quantize_001.test
@@ -32,7 +32,7 @@ rm -rf ${outputfile}
 
 # to create inception_v3.circle
 if [[ ! -s ${inputfile} ]]; then
-  /bin/bash one-import_001.test >> /dev/null
+  /bin/bash one-import_001.test > /dev/null 2>&1
   return_code=$?
   if [[ ${return_code} != 0 ]]; then
     trap_err_onexit
@@ -45,7 +45,7 @@ one-quantize \
 --quantized_dtype uint8 \
 --input_path ./inception_v3.circle \
 --input_data ./inception_v3_test_data.h5 \
---output_path ./inception_v3.quantized.circle >> /dev/null
+--output_path ./inception_v3.quantized.circle > /dev/null 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-quantize_002.test
+++ b/compiler/one-cmds/tests/one-quantize_002.test
@@ -32,7 +32,7 @@ rm -rf ${outputfile}
 
 # to create inception_v3.circle
 if [[ ! -s ${inputfile} ]]; then
-  /bin/bash one-import_001.test >> /dev/null
+  /bin/bash one-import_001.test > /dev/null 2>&1
   return_code=$?
   if [[ ${return_code} != 0 ]]; then
     trap_err_onexit
@@ -44,7 +44,7 @@ one-quantize \
 --input_dtype float32 \
 --quantized_dtype uint8 \
 --input_path ./inception_v3.circle \
---output_path ./inception_v3.random.quantized.circle >> /dev/null
+--output_path ./inception_v3.random.quantized.circle > /dev/null 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-quantize_003.test
+++ b/compiler/one-cmds/tests/one-quantize_003.test
@@ -37,7 +37,7 @@ one-quantize \
 --input_path ./inception_v3.circle \
 --input_data ./datalist.txt \
 --input_data_format list \
---output_path ${outputfile} >> /dev/null
+--output_path ${outputfile} > /dev/null 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-quantize_004.test
+++ b/compiler/one-cmds/tests/one-quantize_004.test
@@ -37,7 +37,7 @@ one-quantize \
 --input_path ${inputfile} \
 --input_data ./raw_files \
 --input_data_format directory \
---output_path ${outputfile} >> /dev/null
+--output_path ${outputfile} > /dev/null 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-quantize_neg_001.test
+++ b/compiler/one-cmds/tests/one-quantize_neg_001.test
@@ -55,7 +55,7 @@ one-quantize \
 --quantized_dtype uint8 \
 --input_path ${inputfile} \
 --input_data ${inputdata} \
---output_path ${outputfile} > ${filename}.log
+--output_path ${outputfile} > ${filename}.log 2>&1
 
 echo "${filename_ext} FAILED"
 exit 255

--- a/compiler/one-cmds/tests/one-quantize_neg_002.test
+++ b/compiler/one-cmds/tests/one-quantize_neg_002.test
@@ -54,7 +54,7 @@ one-quantize \
 --quantized_dtype uint16 \
 --input_path ${inputfile} \
 --input_data ${inputdata} \
---output_path ${outputfile} > ${filename}.log
+--output_path ${outputfile} > ${filename}.log 2>&1
 
 echo "${filename_ext} FAILED"
 exit 255

--- a/compiler/one-cmds/tests/one-quantize_neg_003.test
+++ b/compiler/one-cmds/tests/one-quantize_neg_003.test
@@ -53,7 +53,7 @@ one-quantize \
 --quantized_dtype uint8 \
 --input_path ${inputfile} \
 --input_data ./mobilenet_test_data.h5 \
---output_path ${outputfile} > ${filename}.log
+--output_path ${outputfile} > ${filename}.log 2>&1
 
 echo "${filename_ext} FAILED"
 exit 255

--- a/compiler/one-cmds/tests/one-quantize_neg_004.test
+++ b/compiler/one-cmds/tests/one-quantize_neg_004.test
@@ -53,7 +53,7 @@ one-quantize \
 --quantized_dtype uint8 \
 --input_path ${inputfile} \
 --input_data ${inputdata} \
---output_path ${outputfile} > ${filename}.log
+--output_path ${outputfile} > ${filename}.log 2>&1
 
 echo "${filename_ext} FAILED"
 exit 255

--- a/compiler/one-cmds/tests/one-quantize_neg_005.test
+++ b/compiler/one-cmds/tests/one-quantize_neg_005.test
@@ -44,7 +44,7 @@ one-quantize \
 --quantized_dtype uint8 \
 --input_path ${inputfile} \
 --input_data ${inputdata} \
---output_path ${outputfile} > ${filename}.log
+--output_path ${outputfile} > ${filename}.log 2>&1
 
 echo "${filename_ext} FAILED"
 exit 255

--- a/compiler/one-cmds/tests/one-quantize_neg_006.test
+++ b/compiler/one-cmds/tests/one-quantize_neg_006.test
@@ -44,7 +44,7 @@ one-quantize \
 --quantized_dtype uint8 \
 --input_path ${inputfile} \
 --input_data ${inputdata} \
---output_path ${outputfile} > ${filename}.log
+--output_path ${outputfile} > ${filename}.log 2>&1
 
 echo "${filename_ext} FAILED"
 exit 255

--- a/compiler/one-cmds/tests/one-quantize_neg_007.test
+++ b/compiler/one-cmds/tests/one-quantize_neg_007.test
@@ -53,7 +53,7 @@ one-quantize \
 --quantized_dtype uint8 \
 --input_path ${inputfile} \
 --input_data ${inputdata} \
---output_path ${outputfile} > ${filename}.log
+--output_path ${outputfile} > ${filename}.log 2>&1
 
 echo "${filename_ext} FAILED"
 exit 255

--- a/compiler/one-cmds/tests/one-quantize_neg_008.test
+++ b/compiler/one-cmds/tests/one-quantize_neg_008.test
@@ -54,7 +54,7 @@ one-quantize \
 --input_path ${inputfile} \
 --input_data ${inputdata} \
 --mode average \
---output_path ${outputfile} > ${filename}.log
+--output_path ${outputfile} > ${filename}.log 2>&1
 
 echo "${filename_ext} FAILED"
 exit 255

--- a/compiler/one-cmds/tests/one-quantize_neg_009.test
+++ b/compiler/one-cmds/tests/one-quantize_neg_009.test
@@ -54,7 +54,7 @@ one-quantize \
 --input_path ${inputfile} \
 --input_data ${inputdata} \
 --max_percentile 101 \
---output_path ${outputfile} > ${filename}.log
+--output_path ${outputfile} > ${filename}.log 2>&1
 
 echo "${filename_ext} FAILED"
 exit 255

--- a/compiler/one-cmds/tests/one-quantize_neg_010.test
+++ b/compiler/one-cmds/tests/one-quantize_neg_010.test
@@ -54,7 +54,7 @@ one-quantize \
 --input_path ${inputfile} \
 --input_data ${inputdata} \
 --max_percentile -1 \
---output_path ${outputfile} > ${filename}.log
+--output_path ${outputfile} > ${filename}.log 2>&1
 
 echo "${filename_ext} FAILED"
 exit 255

--- a/compiler/one-cmds/tests/one-quantize_neg_011.test
+++ b/compiler/one-cmds/tests/one-quantize_neg_011.test
@@ -54,7 +54,7 @@ one-quantize \
 --input_path ${inputfile} \
 --input_data ${inputdata} \
 --min_percentile 101 \
---output_path ${outputfile} > ${filename}.log
+--output_path ${outputfile} > ${filename}.log 2>&1
 
 echo "${filename_ext} FAILED"
 exit 255

--- a/compiler/one-cmds/tests/one-quantize_neg_012.test
+++ b/compiler/one-cmds/tests/one-quantize_neg_012.test
@@ -54,7 +54,7 @@ one-quantize \
 --input_path ${inputfile} \
 --input_data ${inputdata} \
 --min_percentile -1 \
---output_path ${outputfile} > ${filename}.log
+--output_path ${outputfile} > ${filename}.log 2>&1
 
 echo "${filename_ext} FAILED"
 exit 255

--- a/compiler/one-cmds/tests/one-quantize_neg_013.test
+++ b/compiler/one-cmds/tests/one-quantize_neg_013.test
@@ -54,7 +54,7 @@ one-quantize \
 --input_path ${inputfile} \
 --input_data ${inputdata} \
 --granularity layered \
---output_path ${outputfile} > ${filename}.log
+--output_path ${outputfile} > ${filename}.log 2>&1
 
 echo "${filename_ext} FAILED"
 exit 255

--- a/compiler/one-cmds/tests/one-quantize_neg_014.test
+++ b/compiler/one-cmds/tests/one-quantize_neg_014.test
@@ -46,7 +46,7 @@ one-quantize \
 --input_data ${inputdata} \
 --input_data_format h5 \
 --granularity channel \
---output_path ${outputfile} > ${filename}.log
+--output_path ${outputfile} > ${filename}.log 2>&1
 
 echo "${filename_ext} FAILED"
 exit 255

--- a/compiler/one-cmds/tests/one-quantize_neg_015.test
+++ b/compiler/one-cmds/tests/one-quantize_neg_015.test
@@ -46,7 +46,7 @@ one-quantize \
 --input_data ${inputdata} \
 --input_data_format list \
 --granularity channel \
---output_path ${outputfile} > ${filename}.log
+--output_path ${outputfile} > ${filename}.log 2>&1
 
 echo "${filename_ext} FAILED"
 exit 255

--- a/compiler/one-cmds/tests/one-quantize_neg_016.test
+++ b/compiler/one-cmds/tests/one-quantize_neg_016.test
@@ -46,7 +46,7 @@ one-quantize \
 --input_data ${inputdata} \
 --input_data_format h5list \
 --granularity channel \
---output_path ${outputfile} > ${filename}.log
+--output_path ${outputfile} > ${filename}.log 2>&1
 
 echo "${filename_ext} FAILED"
 exit 255

--- a/compiler/one-cmds/tests/one-quantize_neg_017.test
+++ b/compiler/one-cmds/tests/one-quantize_neg_017.test
@@ -46,7 +46,7 @@ one-quantize \
 --input_data ${inputdata} \
 --input_data_format directory \
 --granularity channel \
---output_path ${outputfile} > ${filename}.log
+--output_path ${outputfile} > ${filename}.log 2>&1
 
 echo "${filename_ext} FAILED"
 exit 255

--- a/compiler/one-cmds/tests/onecc_001.test
+++ b/compiler/one-cmds/tests/onecc_001.test
@@ -31,7 +31,7 @@ configfile="onecc_001.cfg"
 outputfile="inception_v3.opt.circle"
 
 # run test
-onecc -C ${configfile} > /dev/null
+onecc -C ${configfile} > /dev/null 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/onecc_002.test
+++ b/compiler/one-cmds/tests/onecc_002.test
@@ -31,7 +31,7 @@ configfile="onecc_002.cfg"
 outputfile="inception_v3_pkg"
 
 # run test
-onecc -C ${configfile} > /dev/null
+onecc -C ${configfile} > /dev/null 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/onecc_003.test
+++ b/compiler/one-cmds/tests/onecc_003.test
@@ -33,7 +33,7 @@ outputfile="inception_v3.quantized.circle"
 rm -rf ${outputfile}
 
 # run test
-onecc -C ${configfile} > /dev/null
+onecc -C ${configfile} > /dev/null 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/onecc_004.test
+++ b/compiler/one-cmds/tests/onecc_004.test
@@ -37,7 +37,7 @@ rm -rf ${outputfile}
 cp dummy-compile ../bin/dummy-compile
 
 # run test
-onecc -C ${configfile} > /dev/null
+onecc -C ${configfile} > /dev/null 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/onecc_005.test
+++ b/compiler/one-cmds/tests/onecc_005.test
@@ -37,7 +37,7 @@ rm -rf ${outputfile}
 cp dummy-compile ../bin/dummy-compile
 
 # run test
-onecc -C ${configfile} > /dev/null
+onecc -C ${configfile} > /dev/null 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/onecc_006.test
+++ b/compiler/one-cmds/tests/onecc_006.test
@@ -37,7 +37,7 @@ rm -rf ${outputfile}
 cp dummy-compile ../bin/dummy-compile
 
 # run test
-onecc -C ${configfile} > /dev/null
+onecc -C ${configfile} > /dev/null 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/onecc_007.test
+++ b/compiler/one-cmds/tests/onecc_007.test
@@ -33,7 +33,7 @@ outputfile="inception_v3_pkg"
 rm -rf ${outputfile}
 
 # run test
-onecc -C ${configfile} > /dev/null
+onecc -C ${configfile} > /dev/null 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/onecc_008.test
+++ b/compiler/one-cmds/tests/onecc_008.test
@@ -37,7 +37,7 @@ rm -rf ${outputfile}
 cp dummy-compile ../bin/dummy-compile
 
 # run test
-onecc -C ${configfile} > /dev/null
+onecc -C ${configfile} > /dev/null 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/onecc_009.test
+++ b/compiler/one-cmds/tests/onecc_009.test
@@ -37,7 +37,7 @@ rm -rf ${outputfile}
 cp dummy-compile ../bin/dummy-compile
 
 # run test
-onecc -C ${configfile} > /dev/null
+onecc -C ${configfile} > /dev/null 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/onecc_010.test
+++ b/compiler/one-cmds/tests/onecc_010.test
@@ -35,7 +35,7 @@ rm -rf ${outputfile}
 rm -rf ${intermfile}
 
 # run test
-onecc -C ${configfile} > /dev/null
+onecc -C ${configfile} > /dev/null 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/onecc_011.test
+++ b/compiler/one-cmds/tests/onecc_011.test
@@ -35,7 +35,7 @@ rm -rf ${outputfile}
 rm -rf ${intermfile}
 
 # run test
-onecc -C ${configfile} > /dev/null
+onecc -C ${configfile} > /dev/null 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/onecc_012.test
+++ b/compiler/one-cmds/tests/onecc_012.test
@@ -33,7 +33,7 @@ outputfile="inception_v3.list.quantized.circle"
 rm -rf ${outputfile}
 
 # run test
-onecc -C ${configfile} > /dev/null
+onecc -C ${configfile} > /dev/null 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/onecc_013.test
+++ b/compiler/one-cmds/tests/onecc_013.test
@@ -33,7 +33,7 @@ outputfile="inception_v3.circle"
 rm -rf ${outputfile}
 
 # run test
-onecc import tf -C ${configfile} > /dev/null
+onecc import tf -C ${configfile} > /dev/null 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/onecc_014.test
+++ b/compiler/one-cmds/tests/onecc_014.test
@@ -33,7 +33,7 @@ outputfile="inception_v3.circle"
 rm -rf ${outputfile}
 
 # run test
-onecc import tflite -C ${configfile} > /dev/null
+onecc import tflite -C ${configfile} > /dev/null 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/onecc_015.test
+++ b/compiler/one-cmds/tests/onecc_015.test
@@ -33,7 +33,7 @@ outputfile="bcq.circle"
 rm -rf ${outputfile}
 
 # run test
-onecc import bcq -C ${configfile} > /dev/null
+onecc import bcq -C ${configfile} > /dev/null 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/onecc_016.test
+++ b/compiler/one-cmds/tests/onecc_016.test
@@ -33,7 +33,7 @@ outputfile="test_onnx_model.circle"
 rm -rf ${outputfile}
 
 # run test
-onecc import onnx -C ${configfile} > /dev/null
+onecc import onnx -C ${configfile} > /dev/null 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/onecc_017.test
+++ b/compiler/one-cmds/tests/onecc_017.test
@@ -38,7 +38,7 @@ fi
 rm -rf ${outputfile}
 
 # run test
-onecc optimize -i ${inputfile} -o ${outputfile} > /dev/null
+onecc optimize -i ${inputfile} -o ${outputfile} > /dev/null 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/onecc_018.test
+++ b/compiler/one-cmds/tests/onecc_018.test
@@ -39,7 +39,7 @@ fi
 rm -rf ${outputfile}
 
 # run test
-onecc quantize -i ${inputfile} -o ${outputfile} -d ${inputdata} > /dev/null
+onecc quantize -i ${inputfile} -o ${outputfile} -d ${inputdata} > /dev/null 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/onecc_019.test
+++ b/compiler/one-cmds/tests/onecc_019.test
@@ -38,7 +38,7 @@ fi
 rm -rf ${outputfile}
 
 # run test
-onecc pack -i ${inputfile} -o ${outputfile} > /dev/null
+onecc pack -i ${inputfile} -o ${outputfile} > /dev/null 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/onecc_020.test
+++ b/compiler/one-cmds/tests/onecc_020.test
@@ -44,7 +44,7 @@ rm -rf ${outputfile}
 cp dummy-compile ../bin/dummy-compile
 
 # run test
-onecc codegen -b dummy -o ${outputfile} ${inputfile} > /dev/null
+onecc codegen -b dummy -o ${outputfile} ${inputfile} > /dev/null 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit


### PR DESCRIPTION
This commit redirects stderr to stdout in tests.

Current `one-cmds` print `stdout` to log file and print `stderr` to the console. This change prevents the console from printing `stderr` and fixes `_neg` tests.

Related: #7485 
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>