### PR TITLE
[one-cmds] Redirect _safemain's error message

### DIFF
--- a/compiler/one-cmds/utils.py
+++ b/compiler/one-cmds/utils.py
@@ -225,7 +225,7 @@ def _safemain(main, mainpath):
         main()
     except Exception as e:
         prog_name = os.path.basename(mainpath)
-        print(f"{prog_name}: {type(e).__name__}: " + str(e))
+        print(f"{prog_name}: {type(e).__name__}: " + str(e), file=sys.stderr)
         sys.exit(255)
 
 


### PR DESCRIPTION
This commit redirects _safemain's error message to stderr.

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>