### PR TITLE
[one-cmds] Apply verbose option to one-optimize

### DIFF
--- a/compiler/one-cmds/one-optimize
+++ b/compiler/one-cmds/one-optimize
@@ -100,6 +100,9 @@ def _optimize(args):
                                                            getattr(args, 'input_path'),
                                                            getattr(args, 'output_path'))
 
+        # verbose
+        if _utils._is_valid_attr(args, 'verbose'):
+            circle2circle_cmd.append('--verbose')
         if _utils._is_valid_attr(args, 'change_outputs'):
             circle2circle_cmd.append('--change_outputs')
             circle2circle_cmd.append(getattr(args, 'change_outputs'))


### PR DESCRIPTION
This commit applies the verbose option to one-optimize.
If --verbose option is specified, it passes the verbose option to circle2circle.

Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>