### PR TITLE
[one-cmds] Apply verbose operation to one-quantize

### DIFF
--- a/compiler/one-cmds/one-quantize
+++ b/compiler/one-cmds/one-quantize
@@ -139,6 +139,9 @@ def _quantize(args):
 
         ## make a command to quantize and dequantize the weights of the model
         circle_quantizer_cmd = [circle_quantizer_path]
+        # verbose
+        if _utils._is_valid_attr(args, 'verbose'):
+            circle_quantizer_cmd.append('--verbose')
         # quantize_dequantize_weights
         circle_quantizer_cmd.append('--quantize_dequantize_weights')
         if _utils._is_valid_attr(args, 'input_dtype'):
@@ -165,6 +168,9 @@ def _quantize(args):
 
         ## make a command to record min-max value of each tensor while running the representative dataset
         circle_record_minmax_cmd = [record_minmax_path]
+        # verbose
+        if _utils._is_valid_attr(args, 'verbose'):
+            circle_record_minmax_cmd.append('--verbose')
         # input and output path
         circle_record_minmax_cmd.append('--input_model')
         circle_record_minmax_cmd.append(tmp_output_path_1)
@@ -202,6 +208,9 @@ def _quantize(args):
 
         ## make a second command to quantize the model using the embedded information
         circle_quantizer_cmd = [circle_quantizer_path]
+        # verbose
+        if _utils._is_valid_attr(args, 'verbose'):
+            circle_quantizer_cmd.append('--verbose')
         # quantize_dequantize_weights
         circle_quantizer_cmd.append('--quantize_with_minmax')
         if _utils._is_valid_attr(args, 'input_dtype'):


### PR DESCRIPTION
This commit applies verbose operation to one-quantize.
If --verbose is specified, it pass the verbose option to native modules.

Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>