### PR TITLE
[record-minmax] Apply verbose operation

### DIFF
--- a/compiler/record-minmax/driver/Driver.cpp
+++ b/compiler/record-minmax/driver/Driver.cpp
@@ -41,6 +41,12 @@ int entry(const int argc, char **argv)
     .help("Show version information and exit")
     .exit_with(print_version);
 
+  arser.add_argument("-V", "--verbose")
+    .nargs(0)
+    .required(false)
+    .default_value(false)
+    .help("output additional information to stdout or stderr");
+
   arser.add_argument("--input_model")
     .nargs(1)
     .type(arser::DataType::STR)
@@ -97,6 +103,11 @@ int entry(const int argc, char **argv)
     std::cout << arser;
     return 255;
   }
+
+  if (arser.get<bool>("--verbose"))
+    setenv("LUCI_LOG", "100", true);
+  else
+    setenv("LUCI_LOG", "0", true);
 
   auto settings = luci::UserSettings::settings();
 


### PR DESCRIPTION
This commit adds verbose option.
If the --verbose option is specified, it prints out the detail logs.

Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>