### PR TITLE
[infra] Add gcc-arm-none-eabi build tool on CI

### DIFF
--- a/infra/docker/bionic/Dockerfile
+++ b/infra/docker/bionic/Dockerfile
@@ -26,6 +26,9 @@ RUN add-apt-repository ppa:git-core/ppa -y
 # Build tool
 RUN apt-get update && apt-get -qqy install build-essential cmake scons git g++-arm-linux-gnueabihf g++-aarch64-linux-gnu
 
+# ARM none eabi build tool
+RUN apt-get update && apt-get -qqy install gcc-arm-none-eabi
+
 # Debian build tool
 RUN apt-get update && apt-get -qqy install fakeroot devscripts debhelper python3-all
 


### PR DESCRIPTION
This commit adds gcc-arm-none-eabi build tool on CI

ONE-DCO-1.0-Signed-off-by: Vyacheslav Bazhenov <slavikmipt@gmail.com>