### PR TITLE
[luci] Introduce SubstitutePadV2ToPadPass

### DIFF
--- a/compiler/luci/pass/include/luci/Pass/SubstitutePadV2ToPadPass.h
+++ b/compiler/luci/pass/include/luci/Pass/SubstitutePadV2ToPadPass.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __LUCI_SUBSTITUTE_PADV2_TO_PAD_PASS_H__
+#define __LUCI_SUBSTITUTE_PADV2_TO_PAD_PASS_H__
+
+#include <logo/Pass.h>
+
+namespace luci
+{
+
+/**
+ * @brief  Class to substitute PadV2 in certain condition to Pad.
+ */
+struct SubstitutePadV2ToPadPass final : public logo::Pass
+{
+  const char *name(void) const final { return "luci::SubstitutePadV2ToPadPass"; }
+
+  bool run(loco::Graph *g) final;
+};
+
+} // namespace luci
+
+#endif // __LUCI_SUBSTITUTE_PADV2_TO_PAD_PASS_H__

--- a/compiler/luci/pass/src/SubstitutePadV2ToPadPass.cpp
+++ b/compiler/luci/pass/src/SubstitutePadV2ToPadPass.cpp
@@ -1,0 +1,314 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Pass/SubstitutePadV2ToPadPass.h"
+
+#include <luci/IR/CircleNodes.h>
+#include <luci/Profile/CircleNodeOrigin.h>
+
+#include <vector>
+
+/**
+ * @brief Convert PadV2 op in a certain condition to Pad
+ * @details Convert PadV2 op in a certain condition to Pad if the following conditions are true:
+ *
+ *    C1) For all i, PadV2.input[i] >= 0
+ *    C2) For all c, PadV2.constant_values[c] <= 0
+ *    C3) PadV2 == MaxPool2D.value()
+ *    C4) number of padded values at left < MaxPool2D.Filter.W
+ *       number of padded values at right < MaxPool2D.Filter.W
+ *       number of padded values at top < MaxPool2D.Filter.H
+ *       number of padded values at bottom < MaxPool2D.Filter.H
+ *
+ * In this case, it's OK to pad with const value 0, which is what Pad op does.
+ *
+ * Note1: PadV2.input could be 'reshaping op' (op that does not change the value of tensor
+ *        but changes position of tensor value)
+ *        Examples are Transpose, Reshape, StridedSlice, etc.
+ *        In such case, to see condition C1 we have to check if each value of input of
+ *        'reshaping op' >= 0
+ *
+ * Note2: Between PadV2 and MaxPool2D, there can be 'reshaping op'.
+ *        In this case, considition C4 should be met against output of 'reshaping op'.
+ *
+ * Why this pass is required?
+ *
+ *        When PyTorch model is converted into Circle model, some model contain
+ *        PadV2 like below:
+ *
+ *        %1 = Circle.Conv2D(..., activation = Relu)
+ *        %2 = Circle.Transpose(%1, perm=[0,3,1,2])
+ *        %3 = Circle.PadV2(%2, constant_values = -3.4028234663852886e+38)
+ *        %4 = Circle.Transpose(%3, perm=[0,2,3,1])
+ *        %5 = Circle.MaxPool2D(%4, filter=[3,3], padding="VALID")
+ *
+ *        Large negative padding constant of %3 caused problem when we quantized this model.
+ *        So we need to convert the negative number to some number in reasonable range, e.g., zero.
+ *        (Transpose was inserted to convert NCHW to NHWC.)
+ */
+namespace
+{
+
+struct ReshapingNode
+{
+  /// @brief Check if node is 'reshaping op'
+  static bool check(loco::Node *node)
+  {
+    if (dynamic_cast<luci::CircleTranspose *>(node))
+      return true;
+    // add more 'reshaping op'
+
+    return false;
+  }
+
+  /// @brief Retuen reshaping op's input
+  static loco::Node *input(loco::Node *node)
+  {
+    if (auto transpose = dynamic_cast<luci::CircleTranspose *>(node))
+      return transpose->a();
+    // add more 'reshaping op'
+
+    throw std::runtime_error("Not yet supported reshaping op");
+  }
+};
+
+// Check condition C1)
+bool positive_or_zero(loco::Node *ifm)
+{
+  assert(ifm);
+
+  if (ReshapingNode::check(ifm))
+    return positive_or_zero(ReshapingNode::input(ifm));
+
+  // Since Relu.output[i] >= 0
+  if (dynamic_cast<luci::CircleRelu *>(ifm))
+    return true;
+  if (auto conv = dynamic_cast<luci::CircleConv2D *>(ifm))
+  {
+    if (conv->fusedActivationFunction() == luci::FusedActFunc::RELU)
+      return true;
+    // Add more FusedActFunc
+  }
+  // Add more ops of which output[i] >= 0
+
+  return false;
+}
+
+template <loco::DataType DT> bool has_all_positive_values(luci::CircleConst *node)
+{
+  // Only numeric datatype is allowed
+  static_assert(DT != loco::DataType::Unknown);
+  static_assert(DT != loco::DataType::STRING);
+
+  assert(node);
+
+  auto size = node->size<DT>();
+  for (decltype(size) t = 0; t < size; t++)
+  {
+    typename loco::DataTypeImpl<DT>::Type val = node->at<DT>(t);
+    if (val <= 0)
+      return false;
+  }
+
+  return true;
+}
+
+// To check condition C2)
+bool has_all_positive_values(luci::CircleConst *node)
+{
+  assert(node);
+
+  if (node->dtype() == loco::DataType::FLOAT32)
+    return has_all_positive_values<loco::DataType::FLOAT32>(node);
+  // Add more datatype
+
+  throw std::runtime_error("Not yet supported datatype");
+}
+
+// Check condition C3) and C4)
+bool used_by_maxpool_only(luci::CirclePadV2 *node)
+{
+
+  //
+  // TODO Implement this
+  //
+
+  return false;
+}
+
+loco::Node *build_pad_from(luci::CirclePadV2 *pad_v2)
+{
+  auto copy_shape = [](const luci::CircleNode *src, luci::CircleNode *dest) {
+    auto rank = src->rank();
+    dest->rank(rank);
+
+    for (decltype(rank) axis = 0; axis < rank; axis++)
+      dest->dim(axis) = src->dim(axis);
+  };
+
+  auto g = pad_v2->graph();
+
+  auto pad = g->nodes()->create<luci::CirclePad>();
+  {
+    pad->name(pad_v2->name() + "/pad");
+    luci::add_origin(pad, luci::get_origin(pad_v2));
+
+    pad->dtype(pad_v2->dtype());
+    copy_shape(pad_v2, pad);
+
+    pad->input(pad_v2->input());
+    pad->paddings(pad_v2->paddings());
+  }
+
+  return pad;
+}
+
+luci::CirclePadV2 *get_padv2(loco::Node *node)
+{
+  if (auto padv2 = dynamic_cast<luci::CirclePadV2 *>(node))
+    return padv2;
+
+  if (ReshapingNode::check(node))
+    return get_padv2(ReshapingNode::input(node));
+
+  return nullptr;
+}
+
+bool substitute_padv2_to_pad(luci::CircleMaxPool2D *maxp)
+{
+  // precondition
+  assert(maxp);
+  assert(maxp->value());
+
+  auto pad_v2 = get_padv2(maxp->value());
+
+  if (pad_v2 == nullptr)
+    return false;
+
+  assert(pad_v2->input());
+
+  auto paddings = loco::must_cast<luci::CircleConst *>(pad_v2->paddings());
+  auto constant_values = loco::must_cast<luci::CircleConst *>(pad_v2->constant_values());
+
+  (void)paddings;
+  assert(paddings);
+  assert(paddings->dtype() == loco::DataType::S32);
+  assert(constant_values);
+  assert(constant_values->dtype() == pad_v2->dtype());
+
+  if (not positive_or_zero(pad_v2->input()))
+    return false;
+
+  if (has_all_positive_values(constant_values))
+    return false;
+
+  if (not used_by_maxpool_only(pad_v2))
+    return false;
+
+  auto pad = build_pad_from(pad_v2);
+
+  replace(pad_v2).with(pad);
+
+  return true;
+}
+
+} // namespace
+
+namespace luci
+{
+
+/**
+ * Case 1) Basic case
+ *
+ * BEFORE
+ *     [CircleRelu]
+ *          |
+ *          |       [CircleConst] [CircleConst]
+ *          |             |              |
+ *          -------+----------------------
+ *                 |
+ *            [CirclePadV2]
+ *                 |
+ *          [CircleMaxPool2D]
+ *                 |
+ *
+ * AFTER
+ *     [CircleRelu]
+ *          |
+ *          |           [CircleConst]    [CircleNode] [CircleConst]
+ *          |             |      |            |              |
+ *          -------+-------      -------------+--------------+
+ *                 |                          |
+ *            [CirclePad]                [CirclePadV2]
+ *                 |
+ *         [CircleMaxPool2D]
+ *                 |
+ *
+ * Case 2) Model in Pytorch can be converted to circle (via Onnx)
+ * In such case, it is common that seme 'Reshaping op', e.g., CircleTranspose,
+ * are inserted in-between operations. This pass also needs to handle such situation.
+ *
+ * BEFORE
+ *
+ * BEFORE
+ *     [CircleRelu]
+ *          |
+ *          |       [CircleConst] [CircleConst]
+ *          |             |              |
+ *          -------+----------------------
+ *                 |
+ *          [CircleTranspose]
+ *                 |
+ *            [CirclePadV2]
+ *                 |
+ *          [CircleTranspose]
+ *                 |
+ *          [CircleMaxPool2D]
+ *                 |
+ *
+ * AFTER
+ *     [CircleRelu]
+ *          |
+ *          |           [CircleConst]    [CircleNode] [CircleConst]
+ *          |             |      |            |              |
+ *          -------+-------      -------------+--------------+
+ *                 |                          |
+ *          [CircleTranspose]           [CirclePadV2]
+ *                 |
+ *            [CirclePad]
+ *                 |
+ *          [CircleTranspose]
+ *                 |
+ *          [CircleMaxPool2D]
+ *                 |
+ */
+bool SubstitutePadV2ToPadPass::run(loco::Graph *g)
+{
+  bool changed = false;
+  for (auto node : loco::active_nodes(loco::output_nodes(g)))
+  {
+    if (auto circle_node = dynamic_cast<luci::CircleMaxPool2D *>(node))
+    {
+      if (substitute_padv2_to_pad(circle_node))
+      {
+        changed = true;
+      }
+    }
+  }
+  return changed;
+}
+
+} // namespace luci

--- a/compiler/luci/pass/src/SubstitutePadV2ToPadPass.cpp
+++ b/compiler/luci/pass/src/SubstitutePadV2ToPadPass.cpp
@@ -23,7 +23,7 @@
 
 /**
  * @brief Convert PadV2 op in a certain condition to Pad
- * @details Convert PadV2 op in a certain condition to Pad.
+ * @details Condition to convert PadV2 to Pad is like below:
  *
  * Basic Condition)
  *


### PR DESCRIPTION
This introduces `SubstitutePadV2ToPadPass` pass that converts `PadV2` op under a certain condition to `Pad` op.

For #7477
Draft #7478 

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>