### PR TITLE
[luci] Fix typo in ResolveCustomOpMaxPoolWithArgmax

### DIFF
--- a/compiler/luci/pass/src/ResolveCustomOpMaxPoolWithArgmaxPass.cpp
+++ b/compiler/luci/pass/src/ResolveCustomOpMaxPoolWithArgmaxPass.cpp
@@ -759,7 +759,7 @@ namespace luci
  *                 |
  *            [CircleNode]
  *                 |
- *     [CUSTOM(MaxPoolWithArgmax]
+ *     [CUSTOM(MaxPoolWithArgmax)]
  *         |              |
  *  [MaxPool output]  [Argmax output]
  *


### PR DESCRIPTION
This PR fixes typo in ResolveCustomOpMaxPoolWithArgmax description.

related issue #7229

fix for https://github.com/Samsung/ONE/pull/7471#discussion_r690042478

ONE-DCO-1.0-Signed-off-by: Alexander Efimov <a.efimov@samsung.com>