### PR TITLE
[luci] Requantize tensor after floor op in ResolveCustomOpMaxPoolWithArgmax pass

### DIFF
--- a/compiler/luci/pass/src/ResolveCustomOpMaxPoolWithArgmaxPass.cpp
+++ b/compiler/luci/pass/src/ResolveCustomOpMaxPoolWithArgmaxPass.cpp
@@ -824,7 +824,7 @@ namespace luci
  *   |                \
  *   |              [Floor]
  *   |                 |
- *   |            [Requantize]
+ *   |    [DepthwiseConv2D for requantize]
  *   |              /     \
  *   | [Mul window width] |
  *   \       /           /


### PR DESCRIPTION
This commit adds requantization node in ResolveCustomOpMaxPoolWithArgmax
to force circle-quantizer produce tensors with real scales after floor instead of 1.0.

related issue #7229

ONE-DCO-1.0-Signed-off-by: Alexander Efimov <a.efimov@samsung.com>