### PR TITLE
[luci] Adjust coefficients in ResolveCustomOpMaxPoolWithArgmax pass

### DIFF
--- a/compiler/luci/pass/src/ResolveCustomOpMaxPoolWithArgmaxPass.cpp
+++ b/compiler/luci/pass/src/ResolveCustomOpMaxPoolWithArgmaxPass.cpp
@@ -280,7 +280,7 @@ void fill_coords_addition(luci::Padding padding, const luci::Stride &stride,
       // but leads to wrong results, when working with quantized numbers.
       //
       // This value is larger than quantization error,
-      // and small nough to not affect following computations
+      // and small enough to not affect following computations
       // (in particular multiplication with depth)
       const float round_adjustment = 1.0f / (depth + 1);
 


### PR DESCRIPTION
This PR introduces adjustment coefficients compensating
quantization error to fix floor/cast computation.

related issue #7229 

ONE-DCO-1.0-Signed-off-by: Alexander Efimov <a.efimov@samsung.com>