### PR TITLE
[circle2circle-dredd-recipe-test] Add MaxPoolWithArgmax tests

### DIFF
--- a/compiler/circle2circle-dredd-recipe-test/test.lst
+++ b/compiler/circle2circle-dredd-recipe-test/test.lst
@@ -42,6 +42,9 @@ Add(BatchMatMulV2_000 PASS resolve_customop_batchmatmul)
 Add(MatMul_000 PASS resolve_customop_matmul)
 Add(DepthwiseConv2D_003 PASS)
 Add(StridedSlice_003 PASS substitute_strided_slice_to_reshape)
+Add(MaxPoolWithArgmax_000 PASS resolve_customop_max_pool_with_argmax)
+Add(MaxPoolWithArgmax_001 PASS resolve_customop_max_pool_with_argmax)
+Add(MaxPoolWithArgmax_002 PASS resolve_customop_max_pool_with_argmax)
 
 ## CIRCLE RECIPE
 


### PR DESCRIPTION
This commit adds MaxPoolWithArgmax to the test list.

related issue: #7229 

ONE-DCO-1.0-Signed-off-by: Alexander Efimov <a.efimov@samsung.com>