### PR TITLE
[circle2circle-dredd-recipe-test] Remove Trailing Space

### DIFF
--- a/compiler/circle2circle-dredd-recipe-test/CMakeLists.txt
+++ b/compiler/circle2circle-dredd-recipe-test/CMakeLists.txt
@@ -69,7 +69,7 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E remove -f ${TEST_CONFIG}
   COMMAND ${CMAKE_COMMAND} -E echo 'CIRCLE_INSPECT_PATH=\"$<TARGET_FILE:circle-inspect>\"' >> ${TEST_CONFIG}
   COMMAND ${CMAKE_COMMAND} -E echo 'CIRCLE_VERIFY_PATH=\"$<TARGET_FILE:circle-verify>\"' >> ${TEST_CONFIG}
-  DEPENDS 
+  DEPENDS
     circle-inspect
     circle-verify
   COMMENT "Generate test configuration"


### PR DESCRIPTION
This removes unnecessary trailing space in CMakeLists.txt file.

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>