### PR TITLE
[record-minmax] Change the verbose behavior

### DIFF
--- a/compiler/record-minmax/driver/Driver.cpp
+++ b/compiler/record-minmax/driver/Driver.cpp
@@ -105,9 +105,11 @@ int entry(const int argc, char **argv)
   }
 
   if (arser.get<bool>("--verbose"))
-    setenv("LUCI_LOG", "100", true);
-  else
-    setenv("LUCI_LOG", "0", true);
+  {
+    // The third parameter of setenv means REPLACE.
+    // If REPLACE is zero, it does not overwrite an existing value.
+    setenv("LUCI_LOG", "100", 0);
+  }
 
   auto settings = luci::UserSettings::settings();
 


### PR DESCRIPTION
This commit changes the verbose behavior.
The LUCI_LOG value set by the user should have higher priority
than the value of --verbose option.

Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Related issue: #7521