### PR TITLE
[circle2circle] Change the verbose behavior

### DIFF
--- a/compiler/circle2circle/src/Circle2Circle.cpp
+++ b/compiler/circle2circle/src/Circle2Circle.cpp
@@ -399,10 +399,11 @@ int entry(int argc, char **argv)
   }
 
   if (arser.get<bool>("--verbose"))
-    setenv("LUCI_LOG", "100", true);
-  else
-    setenv("LUCI_LOG", "0", true);
-
+  {
+    // The third parameter of setenv means REPLACE.
+    // If REPLACE is zero, it does not overwrite an existing value.
+    setenv("LUCI_LOG", "100", 0);
+  }
   if (arser.get<bool>("--O1"))
   {
     options->enable(Algorithms::FuseBCQ);


### PR DESCRIPTION
This commit changes the verbose behavior.
The LUCI_LOG value set by the user should have higher priority
than the value of --verbose option.

Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Related issue: #7521 