### PR TITLE
[runtime] Bump to version 1.17.0

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@ copyright = '2020, Samsung Research & contributors'
 author = 'Samsung Research & contributors'
 
 # The full version, including alpha/beta/rc tags
-release = '1.16.0'
+release = '1.17.0'
 
 # -- General configuration ---------------------------------------------------
 

--- a/packaging/nnfw.spec
+++ b/packaging/nnfw.spec
@@ -1,6 +1,6 @@
 Name:    nnfw
 Summary: nnfw
-Version: 1.16.0
+Version: 1.17.0
 Release: 1
 Group:   Development
 License: Apache-2.0 and MIT and BSD-2-Clause

--- a/runtime/contrib/android/api/build.gradle
+++ b/runtime/contrib/android/api/build.gradle
@@ -8,7 +8,7 @@ android {
         minSdkVersion 26
         targetSdkVersion 29
         versionCode 1
-        versionName "1.16.0"
+        versionName "1.17.0"
 
         externalNativeBuild {
             ndkBuild {

--- a/runtime/onert/api/include/nnfw_version.h
+++ b/runtime/onert/api/include/nnfw_version.h
@@ -21,6 +21,6 @@
  * NNFW_VERSION is a uint32 value representing nnfw runtime version
  * in 0xMMmmmmPP, where MM = major, mmmm = minor, PP = patch
  */
-#define NNFW_VERSION 0x01001000
+#define NNFW_VERSION 0x01001100
 
 #endif // __NNFW_VERSION_H__


### PR DESCRIPTION
- Use version 1.17.0

ONE-DCO-1.0-Signed-off-by: Chunseok Lee <chunseok.lee@samsung.com>