### PR TITLE
[luci] Add SubstitutePadV2ToPad into CircleOptimizer

### DIFF
--- a/compiler/luci/pass/include/luci/CircleOptimizer.h
+++ b/compiler/luci/pass/include/luci/CircleOptimizer.h
@@ -63,6 +63,7 @@ public:
       ReplaceMulAddWithDepthwiseConv,
       ReplaceSubWithAdd,
       SubstitutePackToReshape,
+      SubstitutePadV2ToPad,
       SubstituteSqueezeToReshape,
       ConvertNCHWToNHWC,
       RemoveUnnecessarySlice,

--- a/compiler/luci/pass/src/CircleOptimizer.cpp
+++ b/compiler/luci/pass/src/CircleOptimizer.cpp
@@ -54,6 +54,7 @@
 #include "luci/Pass/SparsifyTensorPass.h"
 #include "luci/Pass/ShuffleWeightTo16x1Float32Pass.h"
 #include "luci/Pass/SubstitutePackToReshapePass.h"
+#include "luci/Pass/SubstitutePadV2ToPadPass.h"
 #include "luci/Pass/SubstituteSqueezeToReshapePass.h"
 #include "luci/Pass/SubstituteStridedSliceToReshapePass.h"
 #include "luci/Pass/SubstituteTransposeToReshapePass.h"
@@ -323,6 +324,10 @@ void CircleOptimizer::optimize(loco::Graph *g) const
   if (_options->query(Options::Algorithm::SubstitutePackToReshape))
   {
     phase.emplace_back(std::make_unique<luci::SubstitutePackToReshapePass>());
+  }
+  if (_options->query(Options::Algorithm::SubstitutePadV2ToPad))
+  {
+    phase.emplace_back(std::make_unique<luci::SubstitutePadV2ToPadPass>());
   }
   if (_options->query(Options::Algorithm::SubstituteSqueezeToReshape))
   {


### PR DESCRIPTION
This adds SubstitutePadV2ToPad into CircleOptimizer.

For #7477
Draft #7478

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>