### PR TITLE
[one-cmds] Add profile option to onecc

### DIFF
--- a/compiler/one-cmds/onecc
+++ b/compiler/one-cmds/onecc
@@ -41,6 +41,7 @@ subtool_list = {
     },
     'backend': {
         'codegen': 'Code generation tool',
+        'profile': 'Profile backend model file',
     },
 }
 
@@ -110,7 +111,8 @@ def _get_driver_name(driver_name):
         'one-optimize': 'one-optimize',
         'one-quantize': 'one-quantize',
         'one-pack': 'one-pack',
-        'one-codegen': 'one-codegen'
+        'one-codegen': 'one-codegen',
+        'one-profile': 'one-profile'
     }[driver_name]
 
 
@@ -170,7 +172,7 @@ def main():
     # verify configuration file
     drivers = [
         'one-import-tf', 'one-import-tflite', 'one-import-bcq', 'one-import-onnx',
-        'one-optimize', 'one-quantize', 'one-pack', 'one-codegen'
+        'one-optimize', 'one-quantize', 'one-pack', 'one-codegen', 'one-profile'
     ]
     _verify_cfg(drivers, config)
 

--- a/compiler/one-cmds/onecc.template.cfg
+++ b/compiler/one-cmds/onecc.template.cfg
@@ -7,6 +7,7 @@ one-optimize=True
 one-quantize=False
 one-pack=True
 one-codegen=False
+one-profile=False
 
 [one-import-tf]
 input_path=/path/to/inception_v3.pb

--- a/compiler/one-cmds/tests/onecc_021.cfg
+++ b/compiler/one-cmds/tests/onecc_021.cfg
@@ -1,0 +1,14 @@
+[onecc]
+one-import-tf=False
+one-import-tflite=False
+one-import-bcq=False
+one-import-onnx=False
+one-optimize=False
+one-quantize=False
+one-pack=False
+one-codegen=False
+one-profile=True
+
+[one-profile]
+backend=dummy
+command=test_onnx_model.bin

--- a/compiler/one-cmds/tests/onecc_021.test
+++ b/compiler/one-cmds/tests/onecc_021.test
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# one-profile
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  echo "${filename_ext} FAILED"
+  rm -rf ../bin/dummy-profile
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+configfile="onecc_021.cfg"
+
+# copy dummy-profile to bin folder
+cp dummy-profile ../bin/dummy-profile
+
+# run test
+onecc -C ${configfile} > ${filename}.log
+
+rm -rf ../bin/dummy-profile
+
+if grep -q "dummy-profile dummy output!!!" "${filename}.log"; then
+  echo "${filename_ext} SUCCESS"
+  exit 0
+fi
+
+trap_err_onexit


### PR DESCRIPTION
This commit adds profile option to onecc.
It contains the test case for one-profile though onecc.

Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>