### PR TITLE
[infra] Fix docker build nncc script

### DIFF
--- a/infra/scripts/docker_build_nncc.sh
+++ b/infra/scripts/docker_build_nncc.sh
@@ -66,9 +66,8 @@ tar -zcf ${ARCHIVE_PATH}/nncc-package.tar.gz -C ${NNCC_INSTALL_PREFIX} \
 tar -zcf ${ARCHIVE_PATH}/nncc-test-package.tar.gz -C ${NNCC_INSTALL_PREFIX} ./test
 
 if [ -z ${RELEASE_VERSION} ] || [ ${RELEASE_VERSION} == "nightly" ]; then
-  NEXT_VERSION=$(${ROOT_PATH}/tools/release_tool/onert_version.sh)
   ./nncc docker-run /bin/bash -c \
-	'dch -v $NEXT_VERSION~$(date "+%y%m%d%H") "nightly release" -D $(lsb_release --short --codename)'
+	  'dch -v $($(pwd)/tools/release_tool/onert_version.sh)~$(date "+%y%m%d%H") "nightly release" -D $(lsb_release --short --codename)'
   ./nncc docker-run dch -r ''
 fi
 


### PR DESCRIPTION
This commit fixes docker build nncc script. `-c` option ignores outside environment variables.

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>