### PR TITLE
[one-cmds] Add '--substitute_padv2_to_pad' Option

### DIFF
--- a/compiler/one-cmds/how-to-use-one-commands.txt
+++ b/compiler/one-cmds/how-to-use-one-commands.txt
@@ -192,6 +192,7 @@ Current transformation options are
 - shuffle_weight_to_16x1float32 : This will convert weight format of FullyConnected to SHUFFLED16x1FLOAT32.
   Note that it only converts weights whose row is a multiple of 16.
 - substitute_pack_to_reshape : This will convert single input Pack to Reshape.
+- substitute_padv2_to_pad : This will convert certain condition PadV2 to Pad.
 - substitute_squeeze_to_reshape : This will convert certain condition Squeeze to Reshape.
 - substitute_strided_slice_to_reshape : This will convert certain condition StridedSlice to Reshape.
 - substitute_transpose_to_reshape : This will convert certain condition Transpose to Reshape.

--- a/compiler/one-cmds/utils.py
+++ b/compiler/one-cmds/utils.py
@@ -74,6 +74,7 @@ class _CONSTANT:
          'convert weight format of FullyConnected op to SHUFFLED16x1FLOAT32.'
          ' Note that it only converts weights whose row is a multiple of 16'),
         ('substitute_pack_to_reshape', 'convert single input Pack op to Reshape op'),
+        ('substitute_padv2_to_pad', 'convert certain condition PadV2 to Pad'),
         ('substitute_squeeze_to_reshape', 'convert certain condition Squeeze to Reshape'),
         ('substitute_strided_slice_to_reshape',
          'convert certain condition StridedSlice to Reshape'),


### PR DESCRIPTION
This adds '--substitute_padv2_to_pad' option for _one-optimize_.

For #7477
Draft #7478

Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>