### PR TITLE
[luci] Remove unused member variable in SubstitutePadV2ToPadPassTest

### DIFF
--- a/compiler/luci/pass/src/SubstitutePadV2ToPadPass.test.cpp
+++ b/compiler/luci/pass/src/SubstitutePadV2ToPadPass.test.cpp
@@ -205,7 +205,6 @@ public:
   }
 
 protected:
-  TestGraph *_graph;
   luci::SubstitutePadV2ToPadPass _pad_pass;
   luci::CircleShapeInferencePass _shapeinf_pass;
 };


### PR DESCRIPTION
This commit removes unused member variable in `SubstitutePadV2ToPadPassTest`.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>