### PR TITLE
[one-cmds] Use utils._run instead of subprocess.Popen

### DIFF
--- a/compiler/one-cmds/one-profile
+++ b/compiler/one-cmds/one-profile
@@ -157,14 +157,7 @@ def main():
         profile_cmd += getattr(args, 'command').split()
 
     # run backend driver
-    with subprocess.Popen(
-            profile_cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-            bufsize=1) as p:
-        for line in p.stdout:
-            sys.stdout.buffer.write(line)
-            sys.stdout.buffer.flush()
-    if p.returncode != 0:
-        sys.exit(p.returncode)
+    _utils._run(profile_cmd, err_prefix=backend_base)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The common code for executing command in process is encapsulated in
utils.py. Let's use this function like all other one-cmds.

Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

1 Approval Please