### PR TITLE
[one-cmds] Remove onnx patch file

### DIFF
--- a/compiler/one-cmds/CMakeLists.txt
+++ b/compiler/one-cmds/CMakeLists.txt
@@ -41,7 +41,6 @@ set(ONE_UTILITY_FILES
     one-build.template.cfg
     onecc.template.cfg
     utils.py
-    conv_mixin_1.8.0.patch
 )
 
 foreach(ONE_UTILITY IN ITEMS ${ONE_UTILITY_FILES})


### PR DESCRIPTION
This will remove conv_mixin_1.8.0.patch file as we don't need this anymore.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>