### PR TITLE
[mio-tflite] Add header interfaces for TF and GEMMLowp

### DIFF
--- a/compiler/mio-tflite/CMakeLists.txt
+++ b/compiler/mio-tflite/CMakeLists.txt
@@ -11,12 +11,6 @@ if(NOT TensorFlowSource_FOUND)
   return()
 endif(NOT TensorFlowSource_FOUND)
 
-nnas_find_package(TensorFlowGEMMLowpSource EXACT 2.3.0 QUIET)
-
-if(NOT TensorFlowGEMMLowpSource_FOUND)
-  return()
-endif(NOT TensorFlowGEMMLowpSource_FOUND)
-
 message(STATUS "Build mio-tflite: TRUE")
 
 set(SCHEMA_FILE "${TensorFlowSource_DIR}/tensorflow/lite/schema/schema.fbs")
@@ -35,9 +29,6 @@ FlatBuffers_Target(mio_tflite
   SCHEMA_FILES "schema.fbs"
 )
 
-target_include_directories(mio_tflite SYSTEM INTERFACE "${TensorFlowSource_DIR}")
-target_include_directories(mio_tflite SYSTEM INTERFACE "${TensorFlowGEMMLowpSource_DIR}")
-
 add_executable(mio_tflite_example example.cpp)
 target_link_libraries(mio_tflite_example mio_tflite)
 
@@ -45,3 +36,13 @@ target_link_libraries(mio_tflite_example mio_tflite)
 # TODO provide full tflite validation with runtime/interpreter
 add_executable(mio_tflite_validate example.cpp)
 target_link_libraries(mio_tflite_validate mio_tflite)
+
+nnas_find_package(TensorFlowGEMMLowpSource EXACT 2.3.0 QUIET)
+
+if(NOT TensorFlowGEMMLowpSource_FOUND)
+  return()
+endif(NOT TensorFlowGEMMLowpSource_FOUND)
+
+add_library(mio_tflite_inc INTERFACE)
+target_include_directories(mio_tflite_inc SYSTEM INTERFACE "${TensorFlowSource_DIR}")
+target_include_directories(mio_tflite_inc SYSTEM INTERFACE "${TensorFlowGEMMLowpSource_DIR}")

--- a/compiler/mio-tflite/CMakeLists.txt
+++ b/compiler/mio-tflite/CMakeLists.txt
@@ -11,6 +11,12 @@ if(NOT TensorFlowSource_FOUND)
   return()
 endif(NOT TensorFlowSource_FOUND)
 
+nnas_find_package(TensorFlowGEMMLowpSource EXACT 2.3.0 QUIET)
+
+if(NOT TensorFlowGEMMLowpSource_FOUND)
+  return()
+endif(NOT TensorFlowGEMMLowpSource_FOUND)
+
 message(STATUS "Build mio-tflite: TRUE")
 
 set(SCHEMA_FILE "${TensorFlowSource_DIR}/tensorflow/lite/schema/schema.fbs")
@@ -28,6 +34,9 @@ FlatBuffers_Target(mio_tflite
   SCHEMA_DIR "${CMAKE_CURRENT_BINARY_DIR}"
   SCHEMA_FILES "schema.fbs"
 )
+
+target_include_directories(mio_tflite SYSTEM INTERFACE "${TensorFlowSource_DIR}")
+target_include_directories(mio_tflite SYSTEM INTERFACE "${TensorFlowGEMMLowpSource_DIR}")
 
 add_executable(mio_tflite_example example.cpp)
 target_link_libraries(mio_tflite_example mio_tflite)


### PR DESCRIPTION
This commit adds TensorFlow include directories to mio_tflite_inc target with INTERFACE scope to allow usage of TF headers with `target_link_libraries(<target> mio_tflite_inc)`.

For #7505 
Draft #7582 

Signed-off-by: Alexander Moiseev <a.moiseev@samsung.com>