### PR TITLE
[one-cmds] Add Fold DepthwiseConv2D optimization option

### DIFF
--- a/compiler/one-cmds/how-to-use-one-commands.txt
+++ b/compiler/one-cmds/how-to-use-one-commands.txt
@@ -152,7 +152,7 @@ Current transformation options are
 - disable_validation : This will turn off operator validations.
 - fold_add_v2 : This removes AddV2 operation which can be folded
 - fold_cast : This removes Cast operation which can be folded
-- fold_depthwise_conv_2d : This folds DepthwiseConv2D operation which can be folded
+- fold_dwconv : This folds Depthwise Convolution operation which can be folded
 - fold_dequantize : This removes Dequantize operation which can be folded
 - fold_sparse_to_dense : This removes SparseToDense operation which can be folded
 - forward_reshape_to_unaryop: This will move Reshape after UnaryOp for centain condition

--- a/compiler/one-cmds/how-to-use-one-commands.txt
+++ b/compiler/one-cmds/how-to-use-one-commands.txt
@@ -152,6 +152,7 @@ Current transformation options are
 - disable_validation : This will turn off operator validations.
 - fold_add_v2 : This removes AddV2 operation which can be folded
 - fold_cast : This removes Cast operation which can be folded
+- fold_depthwise_conv_2d : This folds DepthwiseConv2D operation which can be folded
 - fold_dequantize : This removes Dequantize operation which can be folded
 - fold_sparse_to_dense : This removes SparseToDense operation which can be folded
 - forward_reshape_to_unaryop: This will move Reshape after UnaryOp for centain condition

--- a/compiler/one-cmds/utils.py
+++ b/compiler/one-cmds/utils.py
@@ -35,7 +35,7 @@ class _CONSTANT:
          'convert the output shape of the model (argument for convert_nchw_to_nhwc)'),
         ('fold_add_v2', 'fold AddV2 op with constant inputs'),
         ('fold_cast', 'fold Cast op with constant input'),
-        ('fold_depthwise_conv_2d', 'fold DepthwiseConv2D op with constant inputs'),
+        ('fold_dwconv', 'fold Depthwise Convolution op with constant inputs'),
         ('fold_dequantize', 'fold Dequantize op'),
         ('fold_sparse_to_dense', 'fold SparseToDense op'),
         ('forward_reshape_to_unaryop', 'Forward Reshape op'),

--- a/compiler/one-cmds/utils.py
+++ b/compiler/one-cmds/utils.py
@@ -35,6 +35,7 @@ class _CONSTANT:
          'convert the output shape of the model (argument for convert_nchw_to_nhwc)'),
         ('fold_add_v2', 'fold AddV2 op with constant inputs'),
         ('fold_cast', 'fold Cast op with constant input'),
+        ('fold_depthwise_conv_2d', 'fold DepthwiseConv2D op with constant inputs'),
         ('fold_dequantize', 'fold Dequantize op'),
         ('fold_sparse_to_dense', 'fold SparseToDense op'),
         ('forward_reshape_to_unaryop', 'Forward Reshape op'),


### PR DESCRIPTION
This commit adds `fold_depthwise_conv_2d` optimization option to `one-build` config.

For #7505 

Signed-off-by: Alexander Moiseev <a.moiseev@samsung.com>