### PR TITLE
[circle2circle] Rename DConv fold option as 'fold_dwconv'

### DIFF
--- a/compiler/circle2circle/src/Circle2Circle.cpp
+++ b/compiler/circle2circle/src/Circle2Circle.cpp
@@ -92,17 +92,17 @@ int entry(int argc, char **argv)
     .default_value(false)
     .help("This will fold Cast operators with constant input");
 
-  arser.add_argument("--fold_depthwise_conv_2d")
-    .nargs(0)
-    .required(false)
-    .default_value(false)
-    .help("This will fold DepthwiseConv2D operators with constant inputs");
-
   arser.add_argument("--fold_dequantize")
     .nargs(0)
     .required(false)
     .default_value(false)
     .help("This will fold dequantize op");
+
+  arser.add_argument("--fold_dwconv")
+    .nargs(0)
+    .required(false)
+    .default_value(false)
+    .help("This will fold Depthwise Convolution operator with constant inputs");
 
   arser.add_argument("--fold_sparse_to_dense")
     .nargs(0)
@@ -430,10 +430,10 @@ int entry(int argc, char **argv)
     options->enable(Algorithms::FoldAddV2);
   if (arser.get<bool>("--fold_cast"))
     options->enable(Algorithms::FoldCast);
-  if (arser.get<bool>("--fold_depthwise_conv_2d"))
-    options->enable(Algorithms::FoldDepthwiseConv2D);
   if (arser.get<bool>("--fold_dequantize"))
     options->enable(Algorithms::FoldDequantize);
+  if (arser.get<bool>("--fold_dwconv"))
+    options->enable(Algorithms::FoldDepthwiseConv2D);
   if (arser.get<bool>("--fold_sparse_to_dense"))
     options->enable(Algorithms::FoldSparseToDense);
   if (arser.get<bool>("--forward_reshape_to_unaryop"))


### PR DESCRIPTION
This commit renames 'fold_depthwise_conv_2d' option in circle2circle into 'fold_dwconv' to be more consistent with other option names.

For #7505 

Signed-off-by: Alexander Moiseev <a.moiseev@samsung.com>