### PR TITLE
DRAFT: Add a pass to substitute SplitV to Split

### DIFF
--- a/compiler/circle2circle/src/Circle2Circle.cpp
+++ b/compiler/circle2circle/src/Circle2Circle.cpp
@@ -288,6 +288,12 @@ int entry(int argc, char **argv)
     .default_value(false)
     .help("This will convert certain condition PadV2 to Pad");
 
+  arser.add_argument("--substitute_splitv_to_split")
+    .nargs(0)
+    .required(false)
+    .default_value(false)
+    .help("This will convert certain condition SplitV to Split operator");
+
   arser.add_argument("--substitute_squeeze_to_reshape")
     .nargs(0)
     .required(false)
@@ -494,6 +500,8 @@ int entry(int argc, char **argv)
     options->enable(Algorithms::SubstitutePackToReshape);
   if (arser.get<bool>("--substitute_padv2_to_pad"))
     options->enable(Algorithms::SubstitutePadV2ToPad);
+  if (arser.get<bool>("--substitute_splitv_to_split"))
+    options->enable(Algorithms::SubstituteSplitVToSplit);
   if (arser.get<bool>("--substitute_squeeze_to_reshape"))
     options->enable(Algorithms::SubstituteSqueezeToReshape);
   if (arser.get<bool>("--substitute_strided_slice_to_reshape"))

--- a/compiler/luci/pass/include/luci/CircleOptimizer.h
+++ b/compiler/luci/pass/include/luci/CircleOptimizer.h
@@ -65,6 +65,7 @@ public:
       ReplaceSubWithAdd,
       SubstitutePackToReshape,
       SubstitutePadV2ToPad,
+      SubstituteSplitVToSplit,
       SubstituteSqueezeToReshape,
       ConvertNCHWToNHWC,
       RemoveUnnecessarySlice,

--- a/compiler/luci/pass/include/luci/Pass/SubstituteSplitVToSplitPass.h
+++ b/compiler/luci/pass/include/luci/Pass/SubstituteSplitVToSplitPass.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __LUCI_SUBSTITUTE_SPLIT_V_TO_SPLIT_PASS_H__
+#define __LUCI_SUBSTITUTE_SPLIT_V_TO_SPLIT_PASS_H__
+
+#include <logo/Pass.h>
+
+namespace luci
+{
+
+/**
+ * @brief  Class to resolve certain custom op of subgraph into matmul op in circle schema.
+ */
+struct SubstituteSplitVToSplitPass final : public logo::Pass
+{
+  const char *name(void) const final { return "luci::SubstituteSplitVToSplitPass"; }
+
+  bool run(loco::Graph *g) final;
+};
+
+} // namespace luci
+
+#endif // __LUCI_SUBSTITUTE_SPLIT_V_TO_SPLIT_PASS_H__

--- a/compiler/luci/pass/src/CircleOptimizer.cpp
+++ b/compiler/luci/pass/src/CircleOptimizer.cpp
@@ -56,6 +56,7 @@
 #include "luci/Pass/ShuffleWeightTo16x1Float32Pass.h"
 #include "luci/Pass/SubstitutePackToReshapePass.h"
 #include "luci/Pass/SubstitutePadV2ToPadPass.h"
+#include "luci/Pass/SubstituteSplitVToSplitPass.h"
 #include "luci/Pass/SubstituteSqueezeToReshapePass.h"
 #include "luci/Pass/SubstituteStridedSliceToReshapePass.h"
 #include "luci/Pass/SubstituteTransposeToReshapePass.h"
@@ -333,6 +334,10 @@ void CircleOptimizer::optimize(loco::Graph *g) const
   if (_options->query(Options::Algorithm::SubstitutePadV2ToPad))
   {
     phase.emplace_back(std::make_unique<luci::SubstitutePadV2ToPadPass>());
+  }
+  if (_options->query(Options::Algorithm::SubstituteSplitVToSplit))
+  {
+    phase.emplace_back(std::make_unique<luci::SubstituteSplitVToSplitPass>());
   }
   if (_options->query(Options::Algorithm::SubstituteSqueezeToReshape))
   {

--- a/compiler/luci/pass/src/SubstituteSplitVToSplitPass.cpp
+++ b/compiler/luci/pass/src/SubstituteSplitVToSplitPass.cpp
@@ -1,0 +1,128 @@
+
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Pass/SubstituteSplitVToSplitPass.h"
+
+#include <loco.h>
+
+#include <luci/IR/CircleNodes.h>
+#include <luci/Profile/CircleNodeOrigin.h>
+
+namespace
+{
+
+void copy_quantparam(luci::CircleNode *dst, const luci::CircleNode *src)
+{
+  auto q = src->quantparam();
+  if (q == nullptr)
+    dst->quantparam(nullptr);
+  else
+    dst->quantparam(std::make_unique<luci::CircleQuantParam>(*q));
+}
+
+bool resolve_splitv(luci::CircleSplitV *sv)
+{
+  auto size_splits = dynamic_cast<luci::CircleConst *>(sv->size_splits());
+  if (not size_splits)
+    return false;
+
+  if (size_splits->dtype() != loco::DataType::S32)
+    return false;
+
+  auto num_split = size_splits->size<loco::DataType::S32>();
+  if (static_cast<int32_t>(num_split) != sv->num_split())
+    return false;
+
+  if (num_split < 1)
+    return false;
+
+  // Check the contents of size_splits are all same
+  auto first_size = size_splits->at<loco::DataType::S32>(0);
+  for (uint32_t i = 1; i < num_split; i++)
+  {
+    if (first_size != size_splits->at<loco::DataType::S32>(i))
+      return false;
+  }
+
+  auto graph = sv->graph();
+  auto split_node = graph->nodes()->create<luci::CircleSplit>();
+  split_node->input(sv->input());
+  split_node->split_dim(sv->split_dim());
+  split_node->num_split(sv->num_split());
+  split_node->name(sv->name());
+  copy_quantparam(split_node, sv);
+  luci::add_origin(split_node, luci::get_origin(sv));
+
+  auto succs = loco::succs(sv);
+  for (auto succ : succs)
+  {
+    auto svo = loco::must_cast<luci::CircleSplitVOut *>(succ);
+    auto so_node = graph->nodes()->create<luci::CircleSplitOut>();
+    so_node->input(split_node);
+    so_node->index(svo->index());
+    so_node->name(svo->name());
+    copy_quantparam(so_node, svo);
+    luci::add_origin(so_node, luci::get_origin(svo));
+
+    replace(svo).with(so_node);
+  }
+
+  return true;
+}
+
+} // namespace
+
+namespace luci
+{
+
+/**
+ *  EXAMPLE (SplitV with num_split = 2)
+ *
+ *  BEFORE
+ *              [CircleNode]
+ *                   |
+ *             [CircleSplitV] (size_splits and split_dim are ignored)
+ *                /      \
+ *   [CircleSplitVOut]  [CircleSplitVOut]
+ *            |                 |
+ *       [CircleNode]     [CircleNode]
+ *
+ *  AFTER
+ *                    [CircleNode]
+ *                     /         \
+ *             [CircleSplit]    [CircleSplitV] (dead)
+ *                /      \               \
+ *   [CircleSplitOut]  [CircleSplitOut]  [CircleSplitVOut] * 2 (dead)
+ *            |                 |
+ *       [CircleNode]     [CircleNode]
+ */
+bool SubstituteSplitVToSplitPass::run(loco::Graph *g)
+{
+  bool changed = false;
+  for (auto node : loco::active_nodes(loco::output_nodes(g)))
+  {
+    if (auto sv = dynamic_cast<luci::CircleSplitV *>(node))
+    {
+      if (resolve_splitv(sv))
+        changed = true;
+    }
+  }
+
+  return changed;
+}
+
+} // namespace luci

--- a/compiler/luci/pass/src/SubstituteSplitVToSplitPass.test.cpp
+++ b/compiler/luci/pass/src/SubstituteSplitVToSplitPass.test.cpp
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Pass/SubstituteSplitVToSplitPass.h"
+
+#include <luci/test/TestIOGraph.h>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+
+using namespace luci::test;
+
+const int N = 1;
+const int C = 32;
+const int H = 8;
+const int W = 8;
+
+// Reduce duplicate codes in ResolveCustomOpMatMulPass.cpp
+template <typename T>
+luci::CircleConst *create_const_node(loco::Graph *g, const loco::DataType dtype,
+                                     const std::vector<uint32_t> &shape,
+                                     const std::vector<T> &values)
+{
+  auto node = g->nodes()->create<luci::CircleConst>();
+  node->dtype(dtype);
+  node->rank(shape.size());
+
+  uint32_t size = 1;
+  for (uint32_t i = 0; i < shape.size(); ++i)
+  {
+    node->dim(i) = shape.at(i);
+    size *= shape.at(i);
+  }
+  node->shape_status(luci::ShapeStatus::VALID);
+
+#define INIT_VALUES(DT)                          \
+  {                                              \
+    node->size<DT>(size);                        \
+    for (uint32_t i = 0; i < values.size(); ++i) \
+      node->at<DT>(i) = values[i];               \
+  }
+
+  switch (dtype)
+  {
+    case loco::DataType::U8:
+      INIT_VALUES(loco::DataType::U8);
+      break;
+    case loco::DataType::S16:
+      INIT_VALUES(loco::DataType::S16);
+      break;
+    case loco::DataType::S32:
+      INIT_VALUES(loco::DataType::S32);
+      break;
+    case loco::DataType::FLOAT32:
+      INIT_VALUES(loco::DataType::FLOAT32)
+      break;
+    default:
+      INTERNAL_EXN("create_const_node called with unsupported type");
+      break;
+  }
+  return node;
+}
+/**
+ *  graph having SplitV operator
+ *
+ *                [CircleInput]
+ *                      |
+ *                [CircleSplitV]
+ *                     /  \
+ *      [CircleSplitVOut] [CircleSplitVOut]
+ *             |                   |
+ *       [CircleOutput]     [CircleOutput]
+ */
+class SplitVGraphlet
+{
+public:
+  SplitVGraphlet() = default;
+
+public:
+  void init(loco::Graph *g)
+  {
+    const std::vector<int32_t> splits{16, 16};
+    auto size_splits = create_const_node(g, loco::DataType::S32, {2}, splits);
+
+    const std::vector<int32_t> dim{3};
+    auto split_dim = create_const_node(g, loco::DataType::S32, {1}, dim);
+
+    _sv = g->nodes()->create<luci::CircleSplitV>();
+    _sv->size_splits(size_splits);
+    _sv->split_dim(split_dim);
+    _sv->num_split(2);
+    _sv->name("SplitV");
+
+    _svo1 = g->nodes()->create<luci::CircleSplitVOut>();
+    _svo1->input(_sv);
+    _svo1->index(0);
+    _svo1->name("SplitV0");
+
+    _svo2 = g->nodes()->create<luci::CircleSplitVOut>();
+    _svo2->input(_sv);
+    _svo2->index(1);
+    _svo2->name("SplitV1");
+  }
+
+public:
+  luci::CircleSplitV *split_v() { return _sv; }
+  luci::CircleSplitVOut *split_vo1() { return _svo1; }
+  luci::CircleSplitVOut *split_vo2() { return _svo2; }
+
+protected:
+  luci::CircleSplitV *_sv = nullptr;
+  luci::CircleSplitVOut *_svo1 = nullptr;
+  luci::CircleSplitVOut *_svo2 = nullptr;
+};
+
+class SplitVGraph : public TestIsGraphlet<1>, public TestOsGraphlet<2>, public SplitVGraphlet
+{
+public:
+  SplitVGraph() = default;
+
+  void init(void)
+  {
+    TestIsGraphlet<1>::init(g(), {{N, C, H, W}});
+    TestOsGraphlet<2>::init(g(), {{N, C, H / 2, W / 2}, {N, C, H / 2, W / 2}});
+    SplitVGraphlet::init(g());
+
+    split_v()->input(input(0));
+
+    output(0)->from(split_vo1());
+    output(1)->from(split_vo2());
+  }
+};
+
+class SubstituteSplitVToSplitPassTest : public ::testing::Test
+{
+public:
+  SplitVGraph g;
+  luci::SubstituteSplitVToSplitPass pass;
+};
+
+} // namespace
+
+/**
+ *  Optimized graph looks like below.
+ *
+ *                [CircleInput]
+ *                      |
+ *                [CircleSplit]
+ *                     /  \
+ *      [CircleSplitOut] [CircleSplitOut]
+ *             |                 |
+ *       [CircleOutput]   [CircleOutput]
+ */
+TEST_F(SubstituteSplitVToSplitPassTest, simple_test)
+{
+  g.init();
+
+  auto ret = pass.run(g.g());
+  EXPECT_EQ(true, ret);
+
+  auto so1 = dynamic_cast<luci::CircleSplitOut *>(g.output(0)->from());
+  EXPECT_NE(nullptr, so1);
+
+  auto so2 = dynamic_cast<luci::CircleSplitOut *>(g.output(1)->from());
+  EXPECT_NE(nullptr, so2);
+
+  EXPECT_EQ(so1->input(), so2->input());
+
+  auto s = dynamic_cast<luci::CircleSplit *>(so1->input());
+  EXPECT_NE(nullptr, s);
+
+  auto input = dynamic_cast<luci::CircleInput *>(s->input());
+  EXPECT_NE(nullptr, input);
+}
+
+TEST_F(SubstituteSplitVToSplitPassTest, wrong_condition_NEG)
+{
+  g.init();
+
+  g.split_v()->num_split(3); // Wrong num_split
+  auto ret = pass.run(g.g());
+
+  EXPECT_EQ(false, ret);
+}

--- a/compiler/one-cmds/utils.py
+++ b/compiler/one-cmds/utils.py
@@ -76,6 +76,7 @@ class _CONSTANT:
          ' Note that it only converts weights whose row is a multiple of 16'),
         ('substitute_pack_to_reshape', 'convert single input Pack op to Reshape op'),
         ('substitute_padv2_to_pad', 'convert certain condition PadV2 to Pad'),
+        ('substitute_splitv_to_split', 'convert certain condition SplitV to Split'),
         ('substitute_squeeze_to_reshape', 'convert certain condition Squeeze to Reshape'),
         ('substitute_strided_slice_to_reshape',
          'convert certain condition StridedSlice to Reshape'),


### PR DESCRIPTION
On going draft to add SubstituteSplitVToSplitPass.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/7610