### PR TITLE
[luci] Use TF2.6.0 for value test

### DIFF
--- a/compiler/luci-value-test/CMakeLists.txt
+++ b/compiler/luci-value-test/CMakeLists.txt
@@ -18,7 +18,7 @@ add_test(NAME luci_value_test
   COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/evalverify.sh"
           "${CMAKE_CURRENT_BINARY_DIR}"
           "${ARTIFACTS_BIN_PATH}"
-          "${NNCC_OVERLAY_DIR}/venv_2_3_0"
+          "${NNCC_OVERLAY_DIR}/venv_2_6_0"
           "$<TARGET_FILE:luci_eval_driver>"
           ${LUCI_VALUE_TESTS}
 )


### PR DESCRIPTION
This will revise luci-value-test to run in TF2.6.0 virt-environment.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>