### PR TITLE
[pota-quant] Revise value test with TF2.6.0

### DIFF
--- a/compiler/pota-quantization-value-test/CMakeLists.txt
+++ b/compiler/pota-quantization-value-test/CMakeLists.txt
@@ -25,7 +25,7 @@ get_target_property(SCHEMA_BIN_PATH mio_circle BINARY_DIR)
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/gen_h5_explicit_inputs.py"
                "${CMAKE_CURRENT_BINARY_DIR}/gen_h5_explicit_inputs.py" COPYONLY)
 
-set(VIRTUALENV "${NNCC_OVERLAY_DIR}/venv_2_3_0")
+set(VIRTUALENV "${NNCC_OVERLAY_DIR}/venv_2_6_0")
 
 ###
 ### Generate test.config


### PR DESCRIPTION
This will revise pota-quantization-value-test to run in TF2.6.0 virt-environment.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>