### PR TITLE
[one-cmds] Add substitute splitv to split option

### DIFF
--- a/compiler/one-cmds/how-to-use-one-commands.txt
+++ b/compiler/one-cmds/how-to-use-one-commands.txt
@@ -194,6 +194,7 @@ Current transformation options are
   Note that it only converts weights whose row is a multiple of 16.
 - substitute_pack_to_reshape : This will convert single input Pack to Reshape.
 - substitute_padv2_to_pad : This will convert certain condition PadV2 to Pad.
+- substitute_splitv_to_split : This will convert certain condition SplitV to Split.
 - substitute_squeeze_to_reshape : This will convert certain condition Squeeze to Reshape.
 - substitute_strided_slice_to_reshape : This will convert certain condition StridedSlice to Reshape.
 - substitute_transpose_to_reshape : This will convert certain condition Transpose to Reshape.

--- a/compiler/one-cmds/utils.py
+++ b/compiler/one-cmds/utils.py
@@ -76,6 +76,7 @@ class _CONSTANT:
          ' Note that it only converts weights whose row is a multiple of 16'),
         ('substitute_pack_to_reshape', 'convert single input Pack op to Reshape op'),
         ('substitute_padv2_to_pad', 'convert certain condition PadV2 to Pad'),
+        ('substitute_splitv_to_split', 'convert certain condition SplitV to Split'),
         ('substitute_squeeze_to_reshape', 'convert certain condition Squeeze to Reshape'),
         ('substitute_strided_slice_to_reshape',
          'convert certain condition StridedSlice to Reshape'),


### PR DESCRIPTION
This adds substitute splitv to split option.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: #7610
Draft PR: #7621