### PR TITLE
[circle/partition] Use TF2.6.0 virt-env for value test

### DIFF
--- a/compiler/circle-part-value-test/CMakeLists.txt
+++ b/compiler/circle-part-value-test/CMakeLists.txt
@@ -106,7 +106,7 @@ add_dependencies(circle_part_value_test_prepare common_artifacts_deps)
 add_test(NAME circle_part_value_test
   COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/part_eval_all.sh"
           "${CMAKE_CURRENT_BINARY_DIR}"
-          "${NNCC_OVERLAY_DIR}/venv_2_3_0"
+          "${NNCC_OVERLAY_DIR}/venv_2_6_0"
           "$<TARGET_FILE:circle_part_driver>"
           ${PARTITION_LIST}
 )


### PR DESCRIPTION
This will revise circle-part-value-test to use TF2.6.0 virt-environment.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>