### PR TITLE
[onert/test] Clean test file excludes for tcchecker

### DIFF
--- a/.ahub/tcchecker-tca/config.yaml
+++ b/.ahub/tcchecker-tca/config.yaml
@@ -25,12 +25,6 @@ test:
         any: true
       - extension: cc
         any: true
-      - excludes :
-        - Fill.cc
-        - If.cc
-        - Reduce.cc
-        - ResizeBilinear.c
-        - While.cc
     testCase:
       - condition:
         - functionName:


### PR DESCRIPTION
This commit removes file excludes for tcchecker. Remain excluded tests use parameter for negative tests.

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>