### PR TITLE
[tflite2circle] Use mio_tflite260

### DIFF
--- a/compiler/tflite2circle/CMakeLists.txt
+++ b/compiler/tflite2circle/CMakeLists.txt
@@ -1,7 +1,7 @@
 nnas_include(TargetRequire)
 
 unset(REQUIRED_TARGETS)
-list(APPEND REQUIRED_TARGETS mio_tflite)
+list(APPEND REQUIRED_TARGETS mio_tflite260)
 list(APPEND REQUIRED_TARGETS mio_circle)
 TargetRequire_Return(${REQUIRED_TARGETS})
 
@@ -12,7 +12,7 @@ target_include_directories(tflite2circle PRIVATE include)
 target_include_directories(tflite2circle PRIVATE src)
 target_link_libraries(tflite2circle arser)
 target_link_libraries(tflite2circle safemain)
-target_link_libraries(tflite2circle mio_tflite)
+target_link_libraries(tflite2circle mio_tflite260)
 target_link_libraries(tflite2circle mio_circle)
 target_link_libraries(tflite2circle vconone)
 target_link_libraries(tflite2circle nncc_coverage)

--- a/compiler/tflite2circle/requires.cmake
+++ b/compiler/tflite2circle/requires.cmake
@@ -1,5 +1,5 @@
 require("arser")
-require("mio-tflite")
+require("mio-tflite260")
 require("mio-circle")
 require("safemain")
 require("vconone")


### PR DESCRIPTION
This will revise tflite2circle to use mio_tflite260.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>