### PR TITLE
[luci] Fix unreachable loop in ExpandBroadcastConstPass

### DIFF
--- a/compiler/luci/pass/src/ExpandBroadcastConstPass.cpp
+++ b/compiler/luci/pass/src/ExpandBroadcastConstPass.cpp
@@ -133,13 +133,19 @@ bool expand_broadcast_const(luci::CircleConst *node)
     switch (circle_successor->opcode())
     {
       case luci::CircleOpcode::ADD:
-        changed = changed || expand_node_input<luci::CircleAdd>(node, circle_successor);
+        if (expand_node_input<luci::CircleAdd>(node, circle_successor))
+          changed = true;
+        break;
       case luci::CircleOpcode::MUL:
-        changed = changed || expand_node_input<luci::CircleMul>(node, circle_successor);
+        if (expand_node_input<luci::CircleMul>(node, circle_successor))
+          changed = true;
+        break;
       case luci::CircleOpcode::DIV:
-        changed = changed || expand_node_input<luci::CircleDiv>(node, circle_successor);
+        if (expand_node_input<luci::CircleDiv>(node, circle_successor))
+          changed = true;
+        break;
       default:
-        continue; // Unsupported successor node
+        break; // Unsupported successor node
     }
   }
 

--- a/compiler/luci/pass/src/ExpandBroadcastConstPass.cpp
+++ b/compiler/luci/pass/src/ExpandBroadcastConstPass.cpp
@@ -125,22 +125,25 @@ bool expand_broadcast_const(luci::CircleConst *node)
   if (node->dtype() != loco::DataType::FLOAT32)
     return false; // Unsupported data type
 
+  bool changed = false;
+
   for (auto successor : loco::succs(node))
   {
     auto const circle_successor = loco::must_cast<luci::CircleNode *>(successor);
     switch (circle_successor->opcode())
     {
       case luci::CircleOpcode::ADD:
-        return expand_node_input<luci::CircleAdd>(node, circle_successor);
+        changed = changed || expand_node_input<luci::CircleAdd>(node, circle_successor);
       case luci::CircleOpcode::MUL:
-        return expand_node_input<luci::CircleMul>(node, circle_successor);
+        changed = changed || expand_node_input<luci::CircleMul>(node, circle_successor);
       case luci::CircleOpcode::DIV:
-        return expand_node_input<luci::CircleDiv>(node, circle_successor);
+        changed = changed || expand_node_input<luci::CircleDiv>(node, circle_successor);
       default:
-        return false; // Unsupported successor node
+        continue; // Unsupported successor node
     }
   }
-  return false;
+
+  return changed;
 }
 
 } // namespace


### PR DESCRIPTION
From second loop, current code is not reachable
because the function is always returned at first iteration.
This commit will fix it.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>