### PR TITLE
[luci] Add missed SpliVOut quantization visit

### DIFF
--- a/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
+++ b/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
@@ -609,6 +609,20 @@ struct QuantizeSpecialActivation final : public luci::CircleNodeMutableVisitor<v
     set_act_qparam(node, i_scale, i_zp);
   }
 
+  void visit(luci::CircleSplitVOut *node)
+  {
+    auto splitv = loco::must_cast<luci::CircleSplitV *>(node->input());
+    auto input = loco::must_cast<luci::CircleNode *>(splitv->input());
+    auto i_qparam = input->quantparam();
+    assert(i_qparam);
+    assert(i_qparam->scale.size() == 1); // FIX_CALLER_UNLESS
+    assert(i_qparam->zerop.size() == 1); // FIX_CALLER_UNLESS
+    auto i_scale = i_qparam->scale[0];
+    auto i_zp = i_qparam->zerop[0];
+
+    set_act_qparam(node, i_scale, i_zp);
+  }
+
   void visit(luci::CircleUnpackOut *node)
   {
     auto unpack = loco::must_cast<luci::CircleUnpack *>(node->input());


### PR DESCRIPTION
This commit adds missed `visit` method for SplitVOut node.

ONE-DCO-1.0-Signed-off-by: Maksim Bronnikov <max120199@gmail.com>

----------------

In addition to: #7665