### PR TITLE
[luci-interpreter] Support int8 AveragePool2D

### DIFF
--- a/compiler/luci-interpreter/src/kernels/AveragePool2D.cpp
+++ b/compiler/luci-interpreter/src/kernels/AveragePool2D.cpp
@@ -70,6 +70,11 @@ void AveragePool2D::configure()
     LUCI_INTERPRETER_CHECK(std::abs(output()->scale() - input()->scale()) <= 1.0e-6);
     LUCI_INTERPRETER_CHECK(input()->zero_point() == 0 && output()->zero_point() == 0);
   }
+  else if (input()->element_type() == DataType::S8)
+  {
+    LUCI_INTERPRETER_CHECK(std::abs(output()->scale() - input()->scale()) <= 1.0e-6);
+    LUCI_INTERPRETER_CHECK(output()->zero_point() == input()->zero_point());
+  }
   output()->resize({batches, output_height, output_width, depth});
 }
 
@@ -85,6 +90,9 @@ void AveragePool2D::execute() const
       break;
     case DataType::S16:
       evalSInt16();
+      break;
+    case DataType::S8:
+      evalSInt8();
       break;
     default:
       throw std::runtime_error("Unsupported type.");
@@ -130,6 +138,26 @@ void AveragePool2D::evalQuantized() const
   tflite::reference_ops::AveragePool(params, getTensorShape(input()),
                                      getTensorData<uint8_t>(input()), getTensorShape(output()),
                                      getTensorData<uint8_t>(output()));
+}
+
+void AveragePool2D::evalSInt8() const
+{
+  int32_t activation_min{};
+  int32_t activation_max{};
+  calculateActivationRangeQuantized(_params.activation, output(), &activation_min, &activation_max);
+  tflite::PoolParams params{};
+  params.padding_values.height = _padding_height;
+  params.padding_values.width = _padding_width;
+  params.stride_height = _params.stride_height;
+  params.stride_width = _params.stride_width;
+  params.filter_height = _params.filter_height;
+  params.filter_width = _params.filter_width;
+  params.quantized_activation_min = activation_min;
+  params.quantized_activation_max = activation_max;
+
+  tflite::reference_integer_ops::AveragePool(
+    params, getTensorShape(input()), getTensorData<int8_t>(input()), getTensorShape(output()),
+    getTensorData<int8_t>(output()));
 }
 
 void AveragePool2D::evalSInt16() const

--- a/compiler/luci-interpreter/src/kernels/AveragePool2D.h
+++ b/compiler/luci-interpreter/src/kernels/AveragePool2D.h
@@ -40,6 +40,7 @@ private:
   void evalFloat() const;
   void evalQuantized() const;
   void evalSInt16() const;
+  void evalSInt8() const;
 
 private:
   int32_t _padding_height{};

--- a/compiler/luci-interpreter/src/kernels/TestUtils.cpp
+++ b/compiler/luci-interpreter/src/kernels/TestUtils.cpp
@@ -43,6 +43,11 @@ std::vector<float> dequantizeTensorData(const Tensor &tensor)
     std::vector<uint8_t> data = extractTensorData<uint8_t>(tensor);
     return dequantize(data.data(), data.size(), tensor.scale(), tensor.zero_point());
   }
+  if (tensor.element_type() == DataType::S8)
+  {
+    std::vector<int8_t> data = extractTensorData<int8_t>(tensor);
+    return dequantize(data.data(), data.size(), tensor.scale(), tensor.zero_point());
+  }
   else if (tensor.element_type() == DataType::S16)
   {
     // S16 quantization is symmetric, so zero point should be zero.

--- a/compiler/luci-interpreter/src/kernels/TestUtils.h
+++ b/compiler/luci-interpreter/src/kernels/TestUtils.h
@@ -170,8 +170,6 @@ std::vector<T> quantize(const float *data, size_t num_elements, float scale, int
   float q_min{}, q_max{};
   if (std::is_signed<T>::value)
   {
-    // For now, assume that signed type implies signed symmetric quantization.
-    assert(zero_point == 0);
     q_min = -std::numeric_limits<T>::max();
     q_max = std::numeric_limits<T>::max();
   }

--- a/compiler/luci-interpreter/src/kernels/Utils.cpp
+++ b/compiler/luci-interpreter/src/kernels/Utils.cpp
@@ -91,7 +91,7 @@ static void calculateActivationRangeQuantizedImpl(Activation activation, int32_t
 void calculateActivationRangeQuantized(Activation activation, const Tensor *output,
                                        int32_t *activation_min, int32_t *activation_max)
 {
-  // For now, assume that signed type implies signed symmetric quantization.
+  assert(output->zero_points().size() == 1);
   int32_t qmin{};
   int32_t qmax{};
   switch (output->element_type())
@@ -101,11 +101,11 @@ void calculateActivationRangeQuantized(Activation activation, const Tensor *outp
       qmax = std::numeric_limits<uint8_t>::max();
       break;
     case DataType::S8:
-      assert(output->zero_point() == 0);
       qmin = -std::numeric_limits<int8_t>::max();
       qmax = std::numeric_limits<int8_t>::max();
       break;
     case DataType::S16:
+      // For now, assume that signed int16 type implies signed symmetric quantization.
       assert(output->zero_point() == 0);
       qmin = -std::numeric_limits<int16_t>::max();
       qmax = std::numeric_limits<int16_t>::max();


### PR DESCRIPTION
This pr enables int8 AveragePool2D operation.
Related issue: #7677

ONE-DCO-1.0-Signed-off-by: Artem Balyshev <a.balyshev@partner.samsung.com>