### PR TITLE
[luci-interpreter] Support int8 FullyConnected

### DIFF
--- a/compiler/luci-interpreter/src/kernels/FullyConnected.h
+++ b/compiler/luci-interpreter/src/kernels/FullyConnected.h
@@ -42,6 +42,7 @@ public:
 private:
   void evalFloat() const;
   void evalQuantized() const;
+  void evalQuantizedS8() const;
 };
 
 } // namespace kernels

--- a/compiler/luci-interpreter/src/kernels/TestUtils.cpp
+++ b/compiler/luci-interpreter/src/kernels/TestUtils.cpp
@@ -43,6 +43,11 @@ std::vector<float> dequantizeTensorData(const Tensor &tensor)
     std::vector<uint8_t> data = extractTensorData<uint8_t>(tensor);
     return dequantize(data.data(), data.size(), tensor.scale(), tensor.zero_point());
   }
+  if (tensor.element_type() == DataType::S8)
+  {
+    std::vector<int8_t> data = extractTensorData<int8_t>(tensor);
+    return dequantize(data.data(), data.size(), tensor.scale(), tensor.zero_point());
+  }
   else if (tensor.element_type() == DataType::S16)
   {
     // S16 quantization is symmetric, so zero point should be zero.

--- a/compiler/luci-interpreter/src/kernels/TestUtils.h
+++ b/compiler/luci-interpreter/src/kernels/TestUtils.h
@@ -170,8 +170,6 @@ std::vector<T> quantize(const float *data, size_t num_elements, float scale, int
   float q_min{}, q_max{};
   if (std::is_signed<T>::value)
   {
-    // For now, assume that signed type implies signed symmetric quantization.
-    assert(zero_point == 0);
     q_min = -std::numeric_limits<T>::max();
     q_max = std::numeric_limits<T>::max();
   }

--- a/compiler/luci-interpreter/src/kernels/Utils.cpp
+++ b/compiler/luci-interpreter/src/kernels/Utils.cpp
@@ -91,7 +91,7 @@ static void calculateActivationRangeQuantizedImpl(Activation activation, int32_t
 void calculateActivationRangeQuantized(Activation activation, const Tensor *output,
                                        int32_t *activation_min, int32_t *activation_max)
 {
-  // For now, assume that signed type implies signed symmetric quantization.
+  assert(output->zero_points().size() == 1);
   int32_t qmin{};
   int32_t qmax{};
   switch (output->element_type())
@@ -101,11 +101,11 @@ void calculateActivationRangeQuantized(Activation activation, const Tensor *outp
       qmax = std::numeric_limits<uint8_t>::max();
       break;
     case DataType::S8:
-      assert(output->zero_point() == 0);
       qmin = -std::numeric_limits<int8_t>::max();
       qmax = std::numeric_limits<int8_t>::max();
       break;
     case DataType::S16:
+      // For now, assume that signed int16 type implies signed symmetric quantization.
       assert(output->zero_point() == 0);
       qmin = -std::numeric_limits<int16_t>::max();
       qmax = std::numeric_limits<int16_t>::max();


### PR DESCRIPTION
This pr enables int8 FullyConnected operation.

Related issue: #7677

ONE-DCO-1.0-Signed-off-by: Artem Balyshev <a.balyshev@partner.samsung.com>