### PR TITLE
[onert_version.sh] Use UTC time explicitly for timestamp

### DIFF
--- a/tools/release_tool/onert_version.sh
+++ b/tools/release_tool/onert_version.sh
@@ -27,7 +27,7 @@ show_version() {
   current_version=${version_line#"Version:"}
 
   if [ $nightly -eq 0 ]; then
-    echo $current_version~$(date "+%y%m%d%H")
+    echo $current_version~$(date -u "+%y%m%d%H")
   else
     echo $current_version
   fi


### PR DESCRIPTION
It uses `date` to get build timestamp. It means it uses the default
timezone setting. It will specify to use UTC time.

Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>