### PR TITLE
[luci-interpreter] Simplify KernelBuilder.cpp

### DIFF
--- a/compiler/luci-interpreter/src/loader/KernelBuilder.cpp
+++ b/compiler/luci-interpreter/src/loader/KernelBuilder.cpp
@@ -31,7 +31,7 @@ namespace luci_interpreter
 enum class BuilderId
 {
 #include <luci/IR/CircleNodes.lst>
-  size // casts to count of values in BuilderId enum
+  Size // casts to count of values in BuilderId enum
 };
 
 #undef CIRCLE_VNODE
@@ -49,7 +49,7 @@ public:
   using KernelBuilderFunc = std::unique_ptr<Kernel>(const luci::CircleNode *,
                                                     KernelBuilderHelper &);
 
-  KernelBuilderRegistry() : _operator_builders(size_t(BuilderId::size), nullptr)
+  KernelBuilderRegistry() : _operator_builders(size_t(BuilderId::Size), nullptr)
   {
 #define REGISTER_KERNEL(name) \
   register_kernel_builder(BuilderId::Circle##name, build_kernel_Circle##name);

--- a/compiler/luci-interpreter/src/loader/KernelBuilder.cpp
+++ b/compiler/luci-interpreter/src/loader/KernelBuilder.cpp
@@ -61,7 +61,7 @@ public:
 
   KernelBuilderFunc *get_kernel_builder_func(luci::CircleOpcode opcode) const
   {
-    return _operator_builders[size_t(opcode)];
+    return _operator_builders.at(size_t(opcode));
   }
 
 private:
@@ -71,6 +71,7 @@ private:
   {
     // Using BuilderId is a duplicate of luci::CirclreOpcode,
     // size_t(id) is equal to size_t(corresponding operation opcode).
+    assert(size_t(id) < _operator_builders.size());
     _operator_builders[size_t(id)] = func;
   }
 };


### PR DESCRIPTION
This commit makes `KernelBuilder`'s logic easier to understand and reduces reallocations.

ONE-DCO-1.0-Signed-off-by: Maksim Bronnikov <max120199@gmail.com>