### PR TITLE
[luci-interpreter] Enable Softmax for int8

### DIFF
--- a/compiler/luci-interpreter/src/kernels/Softmax.cpp
+++ b/compiler/luci-interpreter/src/kernels/Softmax.cpp
@@ -40,7 +40,9 @@ void Softmax::configure()
   LUCI_INTERPRETER_CHECK(input()->shape().num_dims() >= 1);
   if (input()->element_type() == DataType::U8 || input()->element_type() == DataType::S8)
   {
-    LUCI_INTERPRETER_CHECK(output()->zero_point() == 0);
+    LUCI_INTERPRETER_CHECK(input()->element_type() == DataType::S8 || output()->zero_point() == 0);
+    LUCI_INTERPRETER_CHECK(input()->element_type() == DataType::U8 ||
+                           output()->zero_point() == std::numeric_limits<int8_t>::min());
     tflite::SoftmaxParams op_params{};
     op_params.table = _table;
     luci_interpreter_pal::PopulateSoftmaxLookupTable(&op_params, input()->scale(), params().beta);


### PR DESCRIPTION
This PR enables Softmax for int8 datatype.

related issue: #7677

ONE-DCO-1.0-Signed-off-by: Alexander Efimov <a.efimov@samsung.com>