### PR TITLE
[luci] Remove name length assert

### DIFF
--- a/compiler/luci/pass/src/SubstituteSqueezeToReshapePass.cpp
+++ b/compiler/luci/pass/src/SubstituteSqueezeToReshapePass.cpp
@@ -136,7 +136,6 @@ bool substitute_squeeze_to_reshape(luci::CircleSqueeze *squeeze)
     throw std::runtime_error("Invalid values in squeeze_dims: " + squeeze->name());
 
   auto name = squeeze->name();
-  assert(name.length() > 0);
 
   auto reshape_shape = node_shape(squeeze);
   auto graph = squeeze->graph();


### PR DESCRIPTION
This commit removes unnecessary length `assert` in SubstituteSqueezeToReshape pass.

ONE-DCO-1.0-Signed-off-by: Maksim Bronnikov <max120199@gmail.com>