### PR TITLE
[exo] Use explit flatbuffers ver 1.10

### DIFF
--- a/compiler/exo/CMakeLists.txt
+++ b/compiler/exo/CMakeLists.txt
@@ -1,4 +1,4 @@
-nnas_find_package(FlatBuffers QUIET)
+nnas_find_package(FlatBuffers EXACT 1.10 QUIET)
 
 if(NOT FlatBuffers_FOUND)
   message(STATUS "Build exo: FALSE (missing FlatBuffers)")


### PR DESCRIPTION
This will revise explictly to use flatbuffers version 1.10.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>