### PR TITLE
[luci/pass] Use explit flatbuffers ver 1.10

### DIFF
--- a/compiler/luci/pass/CMakeLists.txt
+++ b/compiler/luci/pass/CMakeLists.txt
@@ -1,4 +1,4 @@
-nnas_find_package(FlatBuffers QUIET)
+nnas_find_package(FlatBuffers EXACT 1.10 QUIET)
 if(NOT FlatBuffers_FOUND)
   message(STATUS "FlatBuffers NOT FOUND")
   return()


### PR DESCRIPTION
This will revise explictly to use flatbuffers version 1.10.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>