### PR TITLE
[pota-quant-val-test] Use explit flatbuffers ver 1.10

### DIFF
--- a/compiler/pota-quantization-value-test/CMakeLists.txt
+++ b/compiler/pota-quantization-value-test/CMakeLists.txt
@@ -1,7 +1,7 @@
 unset(QUANTIZATION_VALUE_TEST)
 unset(QUANTIZATION_VALUE_TEST_WITH_PARAM)
 
-nnas_find_package(FlatBuffers QUIET)
+nnas_find_package(FlatBuffers EXACT 1.10 QUIET)
 if(NOT FlatBuffers_FOUND)
   message(STATUS "Build pota-quantization-value-test: FAILED (missing FlatBuffers)")
   return()


### PR DESCRIPTION
This will revise explictly to use flatbuffers version 1.10.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>