### PR TITLE
[DRAFT][WIP][luci-interpreter] Alloc memory only for module inputs

### DIFF
--- a/compiler/luci-interpreter/src/kernels/If.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/If.test.cpp
@@ -50,10 +50,6 @@ RuntimeGraph *buildAddSubgraph(RuntimeModule *module, IMemoryManager *memory_man
   Tensor *output = graph->addTensor(
     std::make_unique<Tensor>(DataType::FLOAT32, Shape{}, AffineQuantization{}, ""));
 
-  memory_manager->allocate_memory(*input1);
-  memory_manager->allocate_memory(*input2);
-  memory_manager->allocate_memory(*output);
-
   graph->setInputTensors({input1, input2});
   graph->setOutputTensors({output});
 
@@ -73,10 +69,6 @@ RuntimeGraph *buildMulSubgraph(RuntimeModule *module, IMemoryManager *memory_man
     std::make_unique<Tensor>(DataType::FLOAT32, Shape{}, AffineQuantization{}, ""));
   Tensor *output = graph->addTensor(
     std::make_unique<Tensor>(DataType::FLOAT32, Shape{}, AffineQuantization{}, ""));
-
-  memory_manager->allocate_memory(*input1);
-  memory_manager->allocate_memory(*input2);
-  memory_manager->allocate_memory(*output);
 
   graph->setInputTensors({input1, input2});
   graph->setOutputTensors({output});

--- a/compiler/luci-interpreter/src/loader/GraphLoader.cpp
+++ b/compiler/luci-interpreter/src/loader/GraphLoader.cpp
@@ -180,7 +180,6 @@ void GraphLoader::initInputOutputTensors() const
   for (size_t i = 0; i < input_nodes.size(); ++i)
   {
     input_tensors[i] = _node_to_tensor.at(input_nodes[i]);
-    _memory_manager->allocate_memory(*input_tensors[i]);
   }
   _runtime_graph->setInputTensors(input_tensors);
 

--- a/compiler/luci-interpreter/src/loader/ModuleLoader.cpp
+++ b/compiler/luci-interpreter/src/loader/ModuleLoader.cpp
@@ -30,6 +30,13 @@ ModuleLoader::ModuleLoader(const luci::Module *module, RuntimeModule *runtime_mo
 {
 }
 
+void ModuleLoader::allocate_input_tensors() const
+{
+  auto const &input_tensors = _runtime_module->getInputTensors();
+  for (auto tensor : input_tensors)
+    _memory_manager->allocate_memory(*tensor);
+}
+
 void ModuleLoader::load()
 {
   // Runtime graphs have to be created in advance, because they will be needed during the loading
@@ -48,6 +55,8 @@ void ModuleLoader::load()
     loader.initInputOutputTensors();
     loader.loadOperators();
   }
+  // allocate only module inputs
+  allocate_input_tensors();
 }
 
 } // namespace luci_interpreter

--- a/compiler/luci-interpreter/src/loader/ModuleLoader.h
+++ b/compiler/luci-interpreter/src/loader/ModuleLoader.h
@@ -39,6 +39,9 @@ public:
   void load();
 
 private:
+  void allocate_input_tensors() const;
+
+private:
   IMemoryManager *_memory_manager;
   const luci::Module *_module;
   RuntimeModule *_runtime_module;


### PR DESCRIPTION
This commit allocs memory only for inputs of main graph of runtime module.

Signed-off-by: Maksim Bronnikov <max120199@gmail.com>
