### PR TITLE
[luci-interpreter] Bump used TF version to 2.6.0

### DIFF
--- a/compiler/luci-interpreter/pal/linux/PALArgMax.h
+++ b/compiler/luci-interpreter/pal/linux/PALArgMax.h
@@ -17,7 +17,7 @@
 #ifndef LUCI_INTERPRETER_PAL_ARGMAX_H
 #define LUCI_INTERPRETER_PAL_ARGMAX_H
 
-#include <tensorflow/lite/kernels/internal/optimized/optimized_ops.h>
+#include <tensorflow/lite/kernels/internal/reference/arg_min_max.h>
 
 namespace luci_interpreter_pal
 {
@@ -26,7 +26,7 @@ static inline void ArgMinMax(const tflite::RuntimeShape &input1_shape, const T1 
                              const T2 *axis, const tflite::RuntimeShape &output_shape,
                              T3 *output_data, const std::greater<T1> cmp)
 {
-  tflite::optimized_ops::ArgMinMax(input1_shape, input1_data, axis, output_shape, output_data, cmp);
+  tflite::reference_ops::ArgMinMax(input1_shape, input1_data, axis, output_shape, output_data, cmp);
 }
 } // namespace luci_interpreter_pal
 

--- a/compiler/luci-interpreter/pal/linux/PALResizeBilinear.h
+++ b/compiler/luci-interpreter/pal/linux/PALResizeBilinear.h
@@ -17,7 +17,7 @@
 #ifndef LUCI_INTERPRETER_PAL_RESIZEBILINEAR_H
 #define LUCI_INTERPRETER_PAL_RESIZEBILINEAR_H
 
-#include <tensorflow/lite/kernels/internal/optimized/optimized_ops.h>
+#include <tensorflow/lite/kernels/internal/optimized/resize_bilinear.h>
 
 namespace luci_interpreter_pal
 {

--- a/compiler/luci-interpreter/pal/linux/pal.cmake
+++ b/compiler/luci-interpreter/pal/linux/pal.cmake
@@ -1,8 +1,8 @@
 macro(initialize_pal)
-    nnas_find_package(TensorFlowSource EXACT 2.3.0 QUIET)
-    nnas_find_package(TensorFlowGEMMLowpSource EXACT 2.3.0 QUIET)
-    nnas_find_package(TensorFlowEigenSource EXACT 2.3.0 QUIET)
-    nnas_find_package(TensorFlowRuySource EXACT 2.3.0 QUIET)
+    nnas_find_package(TensorFlowSource EXACT 2.6.0 QUIET)
+    nnas_find_package(TensorFlowGEMMLowpSource EXACT 2.6.0 QUIET)
+    nnas_find_package(TensorFlowEigenSource EXACT 2.6.0 QUIET)
+    nnas_find_package(TensorFlowRuySource EXACT 2.6.0 QUIET)
 
     if (NOT TensorFlowSource_FOUND)
         message(STATUS "Skipping luci-interpreter: TensorFlow not found")

--- a/compiler/luci-interpreter/pal/mcu/pal.cmake
+++ b/compiler/luci-interpreter/pal/mcu/pal.cmake
@@ -1,8 +1,8 @@
 macro(initialize_pal)
-    nnas_find_package(TensorFlowSource EXACT 2.3.0 QUIET)
-    nnas_find_package(TensorFlowGEMMLowpSource EXACT 2.3.0 QUIET)
-    nnas_find_package(TensorFlowEigenSource EXACT 2.3.0 QUIET)
-    nnas_find_package(TensorFlowRuySource EXACT 2.3.0 QUIET)
+    nnas_find_package(TensorFlowSource EXACT 2.6.0 QUIET)
+    nnas_find_package(TensorFlowGEMMLowpSource EXACT 2.6.0 QUIET)
+    nnas_find_package(TensorFlowEigenSource EXACT 2.6.0 QUIET)
+    nnas_find_package(TensorFlowRuySource EXACT 2.6.0 QUIET)
 
     if (NOT TensorFlowSource_FOUND)
         message(STATUS "Skipping luci-interpreter: TensorFlow not found")


### PR DESCRIPTION
This PR moves TF version from 2.3.0 to 2.6.0.

related issue: #7288

ONE-DCO-1.0-Signed-off-by: Alexander Efimov <a.efimov@samsung.com>