### PR TITLE
[circle2circle] Support Fuse Add with FC

### DIFF
--- a/compiler/circle2circle/src/Circle2Circle.cpp
+++ b/compiler/circle2circle/src/Circle2Circle.cpp
@@ -126,7 +126,7 @@ int entry(int argc, char **argv)
     .nargs(0)
     .required(false)
     .default_value(false)
-    .help("This will fuse Add operator to Fully Connected operator");
+    .help("This will fuse Add operator to FullyConnected operator");
 
   arser.add_argument("--fuse_add_with_tconv")
     .nargs(0)

--- a/compiler/circle2circle/src/Circle2Circle.cpp
+++ b/compiler/circle2circle/src/Circle2Circle.cpp
@@ -122,6 +122,12 @@ int entry(int argc, char **argv)
     .default_value(false)
     .help("This will fuse Activation function to a preceding operator");
 
+  arser.add_argument("--fuse_add_with_fully_connected")
+    .nargs(0)
+    .required(false)
+    .default_value(false)
+    .help("This will fuse Add operator to Fully Connected operator");
+
   arser.add_argument("--fuse_add_with_tconv")
     .nargs(0)
     .required(false)
@@ -454,6 +460,8 @@ int entry(int argc, char **argv)
     options->enable(Algorithms::FuseActivationFunction);
   if (arser.get<bool>("--fuse_batchnorm_with_conv"))
     options->enable(Algorithms::FuseBatchNormWithConv);
+  if (arser.get<bool>("--fuse_add_with_fully_connected"))
+    options->enable(Algorithms::FuseAddWithFullyConnected);
   if (arser.get<bool>("--fuse_add_with_tconv"))
     options->enable(Algorithms::FuseAddWithTConv);
   if (arser.get<bool>("--fuse_batchnorm_with_dwconv"))


### PR DESCRIPTION
This supports the fuse_add_with_fully_connected option.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: #7724
Draft PR: #7746