### PR TITLE
[infra] Introduce STATIC_LUCI option

### DIFF
--- a/infra/nncc/CMakeLists.txt
+++ b/infra/nncc/CMakeLists.txt
@@ -130,6 +130,11 @@ option(ENABLE_STRICT_BUILD "Treat warning as error" OFF)
 # Check our ProtobufConfig.cmake for its usage.
 option(USE_PROTOBUF_LEGACY_IMPORT "Use legacy MODULE mode import rather than CONFIG mode" OFF)
 
+# This option might be turned ON for MCU builds of luci related components.
+# It specify which library type to use for build:
+# if set ON - luci libraries are static, otherwise - shared.
+option(STATIC_LUCI "Build luci as a static libraries" OFF)
+
 ###
 ### Target
 ###


### PR DESCRIPTION
This PR introduces STATIC_LUCI option to enable static build of luci libraries.

For #7759

ONE-DCO-1.0-Signed-off-by: Alexander Efimov <a.efimov@samsung.com>