### PR TITLE
[luci-interpreter] Suppress warnigns for unused arguments in MCU PAL

### DIFF
--- a/compiler/luci-interpreter/pal/mcu/PALConv2d.h
+++ b/compiler/luci-interpreter/pal/mcu/PALConv2d.h
@@ -29,6 +29,8 @@ static inline void Conv(const tflite::ConvParams &params, const tflite::RuntimeS
                         float *output_data, const tflite::RuntimeShape &im2col_shape,
                         float *im2col_data)
 {
+  (void)im2col_shape;
+  (void)im2col_data;
   tflite::reference_ops::Conv(params, input_shape, input_data, filter_shape, filter_data,
                               bias_shape, bias_data, output_shape, output_data,
                               tflite::RuntimeShape(), nullptr);
@@ -41,6 +43,8 @@ static inline void Conv(const tflite::ConvParams &params, const tflite::RuntimeS
                         uint8 *output_data, const tflite::RuntimeShape &im2col_shape,
                         uint8 *im2col_data)
 {
+  (void)im2col_shape;
+  (void)im2col_data;
   tflite::reference_ops::Conv(params, input_shape, input_data, filter_shape, filter_data,
                               bias_shape, bias_data, output_shape, output_data, im2col_shape,
                               im2col_data, nullptr);


### PR DESCRIPTION
This PR suppresses warnings for unused variables in Conv2d PAL for MCU.

ONE-DCO-1.0-Signed-off-by: Alexander Efimov <a.efimov@samsung.com>