### PR TITLE
[DRAFT] Introduce Circle-Memory-Planner tool

### DIFF
--- a/compiler/circle-memory-plan/CMakeLists.txt
+++ b/compiler/circle-memory-plan/CMakeLists.txt
@@ -1,0 +1,16 @@
+set(SOURCES
+        src/CircleMemoryPlan.cpp
+        src/MemoryPlanner.cpp
+        src/MemoryPlanner.h
+        )
+
+add_executable(circle_memory_plan "${SOURCES}")
+target_link_libraries(circle_memory_plan foder)
+target_link_libraries(circle_memory_plan safemain)
+target_link_libraries(circle_memory_plan luci_env)
+target_link_libraries(circle_memory_plan luci_import)
+target_link_libraries(circle_memory_plan luci_export)
+target_link_libraries(circle_memory_plan arser)
+
+install(TARGETS circle_memory_plan DESTINATION bin)
+

--- a/compiler/circle-memory-plan/requires.cmake
+++ b/compiler/circle-memory-plan/requires.cmake
@@ -1,0 +1,4 @@
+require(foder)
+require(safemain)
+require(luci)
+require(arser)

--- a/compiler/circle-memory-plan/src/CircleMemoryPlan.cpp
+++ b/compiler/circle-memory-plan/src/CircleMemoryPlan.cpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <foder/FileLoader.h>
+
+#include <luci/Importer.h>
+#include <luci/CircleExporter.h>
+#include <luci/CircleFileExpContract.h>
+#include "MemoryPlanner.h"
+
+#include <arser/arser.h>
+
+#include <functional>
+#include <iostream>
+#include <string>
+#include <vector>
+#include <cstdlib>
+
+int entry(int argc, char **argv)
+{
+  arser::Arser arser("circle_memory_plan provides model with memory plan meta information");
+
+  arser.add_argument("input").nargs(1).type(arser::DataType::STR).help("Input circle model");
+  arser.add_argument("output").nargs(1).type(arser::DataType::STR).help("Output circle model");
+
+  try
+  {
+    arser.parse(argc, argv);
+  }
+  catch (const std::runtime_error &err)
+  {
+    std::cerr << err.what() << std::endl;
+    std::cout << arser;
+    return 255;
+  }
+
+  std::string input_path = arser.get<std::string>("input");
+  std::string output_path = arser.get<std::string>("output");
+
+  foder::FileLoader file_loader{input_path};
+  std::vector<char> model_data;
+
+  try
+  {
+    model_data = file_loader.load();
+  }
+  catch (const std::runtime_error &err)
+  {
+    std::cerr << err.what() << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  flatbuffers::Verifier verifier{reinterpret_cast<uint8_t *>(model_data.data()), model_data.size()};
+  if (!circle::VerifyModelBuffer(verifier))
+  {
+    std::cerr << "ERROR: Invalid input file '" << input_path << "'" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  const circle::Model *circle_model = circle::GetModel(model_data.data());
+  if (circle_model == nullptr)
+  {
+    std::cerr << "ERROR: Failed to load circle '" << input_path << "'" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  // Import from input Circle file
+  luci::Importer importer;
+  auto module = importer.importModule(circle_model);
+
+  // Do main job
+  luci::MemoryPlanner memory_planner(module.get());
+  memory_planner.PlanAllocations();
+
+  // Export to output Circle file
+  luci::CircleExporter exporter;
+
+  luci::CircleFileExpContract contract(module.get(), output_path);
+
+  if (!exporter.invoke(&contract))
+  {
+    std::cerr << "ERROR: Failed to export '" << output_path << "'" << std::endl;
+    return 255;
+  }
+
+  return 0;
+}

--- a/compiler/circle-memory-plan/src/MemoryPlanner.cpp
+++ b/compiler/circle-memory-plan/src/MemoryPlanner.cpp
@@ -1,0 +1,475 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "MemoryPlanner.h"
+#include <loco/IR/Algorithm.h>
+#include <luci/UserSettings.h>
+
+namespace luci
+{
+namespace
+{
+
+constexpr uint32_t nodeNotAssigned = std::numeric_limits<int32_t>::max();
+
+uint32_t computeOutputSize(Padding padding, uint32_t image_size, uint32_t filter_size,
+                           uint32_t stride, uint32_t dilation_rate = 1)
+{
+  const int32_t effective_filter_size = (filter_size - 1) * dilation_rate + 1;
+  switch (padding)
+  {
+    case Padding::SAME:
+      return (image_size + stride - 1) / stride;
+    case Padding::VALID:
+      return (image_size + stride - effective_filter_size) / stride;
+    default:
+      assert(false);
+  }
+}
+
+} // namespace
+uint32_t MemoryPlanner::PlanAllocations()
+{
+  PlanOrder();
+  _required_size = PlanOffset();
+  for (uint32_t i = 0; i < _ordered_nodes.size(); i++)
+  {
+    luci::CircleNodeMemoryPlan memory_plan(i, _offsets[i]);
+    luci::add_memory_plan(loco::must_cast<luci::CircleNode *>(_ordered_nodes[i]), memory_plan);
+  }
+  auto settings = luci::UserSettings::settings();
+  settings->set(luci::UserSettings::Key::MemoryPlanGen, true);
+  return _required_size;
+}
+
+void MemoryPlanner::PlanOrder()
+{
+  // Get execution order in _ordered_nodes
+  _ordered_nodes = loco::postorder_traversal(loco::output_nodes(const_cast<loco::Graph *>(_graph)));
+
+  // Initialize vectors of first and last node for usage interval
+  _alloc_node.assign(_ordered_nodes.size(), nodeNotAssigned);
+  _dealloc_node.assign(_ordered_nodes.size(), nodeNotAssigned);
+
+  // Vector for count usages
+  std::vector<int> usages_counts(_ordered_nodes.size(), 0);
+
+  auto allocate = [this](uint32_t node, uint32_t tensor) {
+    if (_alloc_node[tensor] != nodeNotAssigned)
+    {
+      return;
+    }
+    assert(_dealloc_node[tensor] == nodeNotAssigned);
+    _alloc_node[tensor] = node;
+  };
+
+  auto deallocate = [this](uint32_t node, uint32_t tensor) {
+    assert(_dealloc_node[tensor] == nodeNotAssigned);
+    _dealloc_node[tensor] = node;
+  };
+
+  // Increase refcounts for graph outputs and inputs nodes
+  for (auto &output_node : output_nodes(_graph))
+  {
+    auto it = std::find(_ordered_nodes.begin(), _ordered_nodes.end(), output_node);
+    size_t index = std::distance(_ordered_nodes.begin(), it);
+    usages_counts[index]++;
+  }
+
+  for (auto &input_node : input_nodes(_graph))
+  {
+    auto it = std::find(_ordered_nodes.begin(), _ordered_nodes.end(), input_node);
+    size_t index = std::distance(_ordered_nodes.begin(), it);
+    usages_counts[index]++;
+    allocate(0, index);
+  }
+
+  for (uint32_t i = 0; i < _ordered_nodes.size(); i++)
+  {
+    const auto node = _ordered_nodes.at(i);
+    auto prev_nodes = preds(node);
+    for (auto &prev_node : prev_nodes)
+    {
+      auto it = std::find(_ordered_nodes.begin(), _ordered_nodes.end(), prev_node);
+      size_t index = std::distance(_ordered_nodes.begin(), it);
+      usages_counts[index]++;
+    }
+  }
+
+  for (uint32_t i = 0; i < _ordered_nodes.size(); i++)
+  {
+    const auto node = _ordered_nodes.at(i);
+    if (const auto *const_node = dynamic_cast<const luci::CircleConst *>(node))
+    {
+      allocate(0, i);
+    }
+    allocate(i, i);
+
+    auto prev_nodes = preds(node);
+    for (auto &prev_node : prev_nodes)
+    {
+      auto it = std::find(_ordered_nodes.begin(), _ordered_nodes.end(), prev_node);
+      size_t index = std::distance(_ordered_nodes.begin(), it);
+      usages_counts[index]--;
+      if (usages_counts[index] == 0)
+      {
+        deallocate(i, index);
+      }
+    }
+  }
+}
+
+void MemoryPlanner::GetSizesInformation(uint32_t required_size)
+{
+  size_t consts_size = 0;
+  size_t input_size = 0;
+
+  for (const auto &alloc : _alloc_inform_vector)
+  {
+    if (const auto *const_node =
+          dynamic_cast<const luci::CircleConst *>(_ordered_nodes[alloc.node_num]))
+    {
+      consts_size += alloc.size;
+      required_size -= alloc.size;
+    }
+  }
+
+  for (auto &input_node : input_nodes(_graph))
+  {
+    auto it = std::find(_ordered_nodes.begin(), _ordered_nodes.end(), input_node);
+    size_t input_index = std::distance(_ordered_nodes.begin(), it);
+
+    for (const auto &alloc : _alloc_inform_vector)
+    {
+      if (alloc.node_num == input_index)
+      {
+        input_size += alloc.size;
+      }
+    }
+  }
+
+  printf("Size of inputs is = %ld\n", input_size);
+  printf("Size of constant nodes = %ld\n", consts_size);
+  printf("Required size of greedy_by_size approach without constant nodes is = %d\n",
+         required_size);
+  printf("Required size of greedy_by_size approach without constant and input nodes is = %ld\n",
+         required_size - input_size);
+}
+
+// Get required sizes for naive approach and greedy by size offset calculation approach
+// Get offsets for greedy by size approach and fill offsets vector
+uint32_t MemoryPlanner::PlanOffset()
+{
+  // To have required size for naive approach
+  // auto naive_size = NaiveSize();
+  auto greedy_by_size = GreedyBySize();
+
+  _offsets.resize(_ordered_nodes.size());
+  for (const auto &alloc : _alloc_inform_vector)
+  {
+    // Fill offsets vector: the last one should be offsets for temporaries tensors
+    if (alloc.is_temp)
+    {
+      _offsets[alloc.node_num].push_back(alloc.offset);
+    }
+    else
+    {
+      _offsets[alloc.node_num].insert(_offsets[alloc.node_num].begin(), alloc.offset);
+    }
+  }
+
+  // printf("Required size with greedy_by_size approach = %d\n", greedy_by_size);
+
+  // GetSizesInformation(greedy_by_size);
+
+  return greedy_by_size;
+}
+
+// null_consts = true - size of consts nodes will be equal 0;
+// null_inputs = true - size of inputs nodes will be equal 0;
+// null_im2col = true - size of im2col nodes will be equal 0;
+void MemoryPlanner::CreateAllocVector(bool null_consts, bool null_inputs, bool null_im2col)
+{
+  auto node_compare = [this](const AllocNodeInform &alloc_1, const AllocNodeInform &alloc_2) {
+    auto idx1 = alloc_1.node_num;
+    auto idx2 = alloc_2.node_num;
+
+    if (this->_alloc_node[idx1] == 0 && this->_dealloc_node[idx1] == nodeNotAssigned)
+    {
+      if (this->_alloc_node[idx2] == 0 && this->_dealloc_node[idx2] == nodeNotAssigned)
+      {
+        return idx1 < idx2;
+      }
+      return true;
+    }
+    if (this->_alloc_node[idx2] == 0 && this->_dealloc_node[idx2] == nodeNotAssigned)
+    {
+      return false;
+    }
+
+    auto size_1 = alloc_1.size;
+    auto size_2 = alloc_2.size;
+
+    if (size_1 != size_2)
+    {
+      return size_1 > size_2;
+    }
+    return this->_alloc_node[idx1] < this->_alloc_node[idx2];
+  };
+
+  _alloc_inform_vector.resize(_ordered_nodes.size());
+
+  for (size_t i = 0; i < _ordered_nodes.size(); i++)
+  {
+    auto circle_node = loco::must_cast<luci::CircleNode *>(_ordered_nodes[i]);
+    auto node_size = 1;
+    for (uint32_t axis = 0; axis < circle_node->rank(); ++axis)
+    {
+      node_size *= circle_node->dim(axis).value();
+    }
+    node_size *= size(circle_node->dtype());
+
+    _alloc_inform_vector[i].node_num = i;
+    _alloc_inform_vector[i].first_node = _alloc_node[i];
+    _alloc_inform_vector[i].last_node = _dealloc_node[i];
+
+    const auto *const_node = dynamic_cast<const luci::CircleConst *>(circle_node);
+    if (i == 0 && null_inputs)
+    {
+      _alloc_inform_vector[i].size = 0;
+    }
+    else if (const_node && null_consts)
+    {
+      _alloc_inform_vector[i].size = 0;
+    }
+    else
+    {
+      _alloc_inform_vector[i].size = node_size;
+    }
+
+    // Im2col
+    auto opcode = circle_node->opcode();
+    if (opcode == luci::CircleOpcode::CONV_2D)
+    {
+      auto conv = loco::must_cast<const luci::CircleConv2D *>(circle_node);
+      auto im2col_size = Im2colSize(conv);
+      if (im2col_size > 0)
+      {
+        AllocNodeInform temp_alloc;
+
+        if (null_im2col)
+        {
+          temp_alloc.size = 0;
+        }
+        else
+        {
+          temp_alloc.size = im2col_size;
+        }
+
+        temp_alloc.first_node = i - 1;
+        temp_alloc.last_node = i + 1;
+        temp_alloc.node_num = i;
+        temp_alloc.is_temp = true;
+
+        _alloc_inform_vector.push_back(temp_alloc);
+        _alloc_node.push_back(i);
+        _dealloc_node.push_back(i);
+      }
+    }
+  }
+  // Sort alloc_inform_vector with node_compare for the greedy by size approach.
+  std::sort(_alloc_inform_vector.begin(), _alloc_inform_vector.end(), node_compare);
+}
+
+uint32_t MemoryPlanner::GreedyBySize()
+{
+  size_t result_size = 0;
+  CreateAllocVector(false, false, false);
+  std::vector<AllocNodeInform> ordered_alloc_inform;
+  for (auto &current_node : _alloc_inform_vector)
+  {
+    if (current_node.size == 0)
+    {
+      current_node.offset = 0;
+      continue;
+    }
+    const uint32_t offsetNotAssigned = std::numeric_limits<uint32_t>::max();
+    size_t best_offset = offsetNotAssigned;
+    uint32_t best_offset_fit = offsetNotAssigned;
+
+    uint32_t current_offset = 0;
+
+    for (const auto &alloc_inform : ordered_alloc_inform)
+    {
+      if ((alloc_inform.last_node < current_node.first_node ||
+           alloc_inform.first_node > current_node.last_node))
+      {
+        continue;
+      }
+
+      if (current_offset + current_node.size <= alloc_inform.offset &&
+          alloc_inform.offset - current_offset < best_offset_fit)
+      {
+        best_offset = current_offset;
+        best_offset_fit = alloc_inform.offset - current_offset;
+      }
+      current_offset = std::max(current_offset, alloc_inform.offset + alloc_inform.size);
+    }
+    if (best_offset == offsetNotAssigned)
+    {
+      best_offset = current_offset;
+    }
+
+    result_size = std::max(result_size, best_offset + current_node.size);
+    current_node.offset = best_offset;
+
+    auto insertion_it =
+      std::upper_bound(ordered_alloc_inform.begin(), ordered_alloc_inform.end(), current_node);
+    ordered_alloc_inform.insert(insertion_it, current_node);
+  }
+  return result_size;
+}
+
+uint32_t MemoryPlanner::NaiveSize()
+{
+  uint32_t i = 0;
+  int32_t required_size = 0;
+  int32_t offset = 0;
+
+  for (auto &node : _ordered_nodes)
+  {
+    uint32_t current_size = 1;
+    uint32_t im2col_size = 0;
+    auto circle_node = loco::must_cast<luci::CircleNode *>(node);
+
+    for (uint32_t axis = 0; axis < circle_node->rank(); ++axis)
+    {
+      current_size *= circle_node->dim(axis).value();
+    }
+    current_size *= size(circle_node->dtype());
+    auto opcode = circle_node->opcode();
+    if (opcode == luci::CircleOpcode::CONV_2D)
+    {
+      auto conv = loco::must_cast<const luci::CircleConv2D *>(node);
+
+      im2col_size += Im2colSize(conv);
+    }
+
+    required_size += current_size + im2col_size;
+
+    offset += current_size + im2col_size;
+    i++;
+  }
+  return required_size;
+}
+
+uint32_t MemoryPlanner::Im2colSize(const luci::CircleConv2D *conv)
+{
+  auto conv_input = loco::must_cast<luci::CircleNode *>(conv->input());
+  auto filter = loco::must_cast<luci::CircleNode *>(conv->filter());
+  auto padding = (conv->padding());
+  uint32_t stride_height = conv->stride()->h();
+  uint32_t stride_width = conv->stride()->w();
+
+  uint32_t dilation_height_factor = conv->dilation()->h();
+  uint32_t dilation_width_factor = conv->dilation()->w();
+
+  uint32_t filter_height = filter->dim(1).value();
+  uint32_t filter_width = filter->dim(2).value();
+
+  const bool need_dilated_im2col = dilation_height_factor != 1 || dilation_width_factor != 1;
+  const bool need_non_dilated_im2col =
+    stride_height != 1 || stride_width != 1 || filter_height != 1 || filter_width != 1;
+  bool need_im2col =
+    conv_input->dtype() != loco::DataType::S16 && (need_dilated_im2col || need_non_dilated_im2col);
+
+  if (!need_im2col)
+  {
+    return 0;
+  }
+
+  uint32_t input_depth = conv_input->dim(3).value();
+  uint32_t input_height = conv_input->dim(1).value();
+  uint32_t input_width = conv_input->dim(2).value();
+
+  uint32_t output_height =
+    computeOutputSize(padding, input_height, filter_height, stride_height, dilation_height_factor);
+  uint32_t output_width =
+    computeOutputSize(padding, input_width, filter_width, stride_width, dilation_width_factor);
+
+  uint32_t batches = conv_input->dim(0).value();
+
+  return batches * output_height * output_width * input_depth * filter_height * filter_width *
+         size(conv_input->dtype());
+}
+
+void MemoryPlanner::DumpInform()
+{
+  uint32_t max_breadth = 0;
+
+  for (uint32_t i = 0; i < _ordered_nodes.size(); i++)
+  {
+    auto current_node_it =
+      std::find_if(_alloc_inform_vector.begin(), _alloc_inform_vector.end(),
+                   [this, i](const AllocNodeInform &x) { return x.node_num == i && !x.is_temp; });
+    for (uint32_t j = 0; j < _ordered_nodes.size(); j++)
+    {
+      auto first_node = _alloc_node[j];
+      auto last_node = _dealloc_node[j];
+
+      auto it =
+        std::find_if(_alloc_inform_vector.begin(), _alloc_inform_vector.end(),
+                     [this, j](const AllocNodeInform &x) { return x.node_num == j && !x.is_temp; });
+      if (i >= first_node && i <= last_node)
+      {
+        current_node_it->breadth += it->size;
+      }
+    }
+    if (max_breadth < current_node_it->breadth)
+    {
+      max_breadth = current_node_it->breadth;
+    }
+
+    auto node = loco::must_cast<luci::CircleNode *>(_ordered_nodes.at(i));
+    printf("i = %d   name = %s    with size = %d    with offset = %d    with breadth = %u\n "
+           "first_node = %d   last_node = %d\n",
+           i, node->name().c_str(), current_node_it->size, current_node_it->offset,
+           current_node_it->breadth, current_node_it->first_node, current_node_it->last_node);
+  }
+  printf("Lower bound is = %u\n", max_breadth);
+  std::sort(_alloc_inform_vector.begin(), _alloc_inform_vector.end(),
+            [](const AllocNodeInform &first, const AllocNodeInform &second) {
+              if (first.breadth != second.breadth)
+                return first.breadth > second.breadth;
+              return first.node_num < second.node_num;
+            });
+
+  for (const auto alloc_inform : _alloc_inform_vector)
+  {
+    if (alloc_inform.is_temp)
+    {
+      continue;
+    }
+    auto node = loco::must_cast<luci::CircleNode *>(_ordered_nodes.at(alloc_inform.node_num));
+    printf("i = %d   name = %s    with breadth = %u\n", // name = %s    with size = %d    with
+                                                        // offset = %d    with breadth = %u\n ",
+           alloc_inform.node_num, node->name().c_str(),
+           alloc_inform.breadth); // node->name().c_str(), alloc_inform.size, alloc_inform.offset,
+                                  // alloc_inform.breadth);
+  }
+}
+
+} // namespace luci

--- a/compiler/circle-memory-plan/src/MemoryPlanner.h
+++ b/compiler/circle-memory-plan/src/MemoryPlanner.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef LUCI_INTERPRETER_MEMORY_PLANNER_H
+#define LUCI_INTERPRETER_MEMORY_PLANNER_H
+
+#include <luci/IR/Module.h>
+#include <luci/Profile/CircleNodeMemoryPlan.h>
+
+namespace luci
+{
+
+struct AllocNodeInform
+{
+
+  AllocNodeInform()
+  {
+    offset = 0;
+    size = 0;
+    node_num = -1;
+    first_node = -1;
+    last_node = -1;
+    is_temp = false;
+    breadth = 0;
+  }
+
+  uint32_t offset;
+  uint32_t size;
+  uint32_t node_num;
+  uint32_t first_node;
+  uint32_t last_node;
+  bool is_temp;
+  uint32_t breadth;
+
+  bool operator<(const AllocNodeInform &other) const { return offset < other.offset; }
+};
+
+class MemoryPlanner
+{
+public:
+  MemoryPlanner() = delete;
+  explicit MemoryPlanner(luci::Module *module) { _graph = module->graph(); };
+
+  // Method plans memory allocations for nodes.
+  // And then write in nodes annotation information about necessary offsets in arena memory buffer.
+  uint32_t PlanAllocations();
+
+private:
+  // Method gets nodes usage information.
+  void PlanOrder();
+  // Method gets information about sizes of different type of nodes.
+  void GetSizesInformation(uint32_t required_size);
+  // Method dump information about nodes required sizes.
+  void DumpInform();
+
+  // Method finds offset for nodes in some buffer.
+  uint32_t PlanOffset();
+  // Method finds size of buffer for naive approach.
+  uint32_t NaiveSize();
+  // Method realizes greedy_by_size approach.
+  uint32_t GreedyBySize();
+  // Method finds (if necessary) size for im2col temporary tensor.
+  uint32_t Im2colSize(const luci::CircleConv2D *conv);
+  // Method creates and fills _alloc_inform_vector with usage interval inform and node's sizes.
+  void CreateAllocVector(bool null_consts = false, bool null_inputs = false,
+                         bool null_im2col = false);
+
+  // Stores allocation data for all tensors.
+  std::vector<AllocNodeInform> _alloc_inform_vector;
+  // Stores nodes in execution order.
+  std::vector<loco::Node *> _ordered_nodes;
+  // Stores nodes offsets in arena buffer
+  std::vector<std::vector<uint32_t>> _offsets;
+  // Stores position (in _ordered_nodes vector) of node,
+  // where node in i'th position in this vector first use
+  std::vector<uint32_t> _alloc_node;
+  // Stores position (in _ordered_nodes vector) of node,
+  // where node in i'th position in this vector last use
+  std::vector<uint32_t> _dealloc_node;
+
+  loco::Graph *_graph;
+  uint32_t _required_size = 0;
+};
+
+} // namespace luci
+
+#endif // LUCI_INTERPRETER_MEMORY_PLANNER_H

--- a/compiler/luci-interpreter/src/loader/CMakeLists.txt
+++ b/compiler/luci-interpreter/src/loader/CMakeLists.txt
@@ -22,7 +22,7 @@ target_include_directories(${LUCI_INTERPRETER_LOADER} PUBLIC "${LUCI_INTERPRETER
 target_include_directories(${LUCI_INTERPRETER_LOADER} PUBLIC "${LUCI_INTERPRETER_SOURCE_DIR}")
 
 target_link_libraries(${LUCI_INTERPRETER_LOADER}
-        PUBLIC luci_lang ${LUCI_INTERPRETER_CORE}
+        PUBLIC luci_lang luci_profile ${LUCI_INTERPRETER_CORE}
         PRIVATE ${LUCI_INTERPRETER_KERNELS} nncc_common)
 
 if(NOT ENABLE_TEST)

--- a/compiler/luci-interpreter/src/loader/GraphLoader.cpp
+++ b/compiler/luci-interpreter/src/loader/GraphLoader.cpp
@@ -17,6 +17,7 @@
 #include "loader/GraphLoader.h"
 
 #include "loader/KernelBuilder.h"
+#include <luci/Profile/CircleNodeMemoryPlan.h>
 
 #include <loco/IR/Algorithm.h>
 
@@ -154,6 +155,11 @@ void GraphLoader::loadTensors()
 
     auto tensor = std::make_unique<Tensor>(node->dtype(), std::move(shape), std::move(quantization),
                                            node->name());
+    if (luci::has_memory_plan(node))
+    {
+      auto memory_plan = luci::get_memory_plan(node);
+      tensor->set_offset(memory_plan.offsets()[0]);
+    }
 
     if (const auto *const_node = dynamic_cast<const luci::CircleConst *>(node))
     {
@@ -198,17 +204,47 @@ void GraphLoader::loadOperators()
 {
   KernelBuilder kernel_builder(_graph_to_runtime_graph, _node_to_tensor);
 
-  // Create kernels for executable nodes. This has to be done in execution order.
-  for (const loco::Node *loco_node :
-       loco::postorder_traversal(loco::output_nodes(const_cast<loco::Graph *>(_graph))))
-  {
-    const auto *node = loco::must_cast<const luci::CircleNode *>(loco_node);
+  auto graph = const_cast<loco::Graph *>(_graph);
+  std::vector<const luci::CircleNode *> ordered_nodes(loco::all_nodes(graph).size());
 
-    if (isExecutableNode(node))
+  bool has_memory_annotation = true;
+
+  for (const loco::Node *loco_node : loco::all_nodes(graph))
+  {
+    auto current_node = dynamic_cast<const luci::CircleNode *>(loco_node);
+    if (!luci::has_memory_plan(current_node))
     {
-      std::unique_ptr<Kernel> kernel = kernel_builder.build(node);
-      _runtime_to_ir.kernel_to_node.emplace(kernel.get(), node);
-      _runtime_graph->addKernel(std::move(kernel));
+      has_memory_annotation = false;
+      break;
+    }
+    auto memory_plan = luci::get_memory_plan(current_node);
+    ordered_nodes.at(memory_plan.order_in_plan()) = current_node;
+  }
+
+  if (has_memory_annotation)
+  {
+    for (auto node : ordered_nodes)
+    {
+      if (isExecutableNode(node))
+      {
+        std::unique_ptr<Kernel> kernel = kernel_builder.build(node);
+        _runtime_to_ir.kernel_to_node.emplace(kernel.get(), node);
+        _runtime_graph->addKernel(std::move(kernel));
+      }
+    }
+  }
+  else
+  {
+    for (const loco::Node *loco_node :
+         loco::postorder_traversal(loco::output_nodes(const_cast<loco::Graph *>(_graph))))
+    {
+      const auto *node = loco::must_cast<const luci::CircleNode *>(loco_node);
+      if (isExecutableNode(node))
+      {
+        std::unique_ptr<Kernel> kernel = kernel_builder.build(node);
+        _runtime_to_ir.kernel_to_node.emplace(kernel.get(), node);
+        _runtime_graph->addKernel(std::move(kernel));
+      }
     }
   }
 }

--- a/compiler/luci/env/include/luci/UserSettings.h
+++ b/compiler/luci/env/include/luci/UserSettings.h
@@ -33,6 +33,7 @@ struct UserSettings
     MuteWarnings,
     DisableValidation,
     ProfilingDataGen,
+    MemoryPlanGen,
   };
 
   static UserSettings *settings();

--- a/compiler/luci/env/src/UserSettings.cpp
+++ b/compiler/luci/env/src/UserSettings.cpp
@@ -31,6 +31,7 @@ private:
   bool _MuteWarnings{false};
   bool _DisableValidation{false};
   bool _ProfilingDataGen{false};
+  bool _MemoryPlanGen{false};
 };
 
 void UserSettingsImpl::set(const Key key, bool value)
@@ -45,6 +46,9 @@ void UserSettingsImpl::set(const Key key, bool value)
       break;
     case Key::ProfilingDataGen:
       _ProfilingDataGen = value;
+      break;
+    case Key::MemoryPlanGen:
+      _MemoryPlanGen = value;
       break;
     default:
       throw std::runtime_error("Invalid key in boolean set");
@@ -62,6 +66,8 @@ bool UserSettingsImpl::get(const Key key) const
       return _DisableValidation;
     case Key::ProfilingDataGen:
       return _ProfilingDataGen;
+    case Key::MemoryPlanGen:
+      return _MemoryPlanGen;
     default:
       throw std::runtime_error("Invalid key in boolean get");
       break;

--- a/compiler/luci/export/src/CircleExportMetadata.cpp
+++ b/compiler/luci/export/src/CircleExportMetadata.cpp
@@ -44,6 +44,31 @@ flatbuffers::Offset<circle::Metadata> metadata_offset(flatbuffers::FlatBufferBui
 namespace luci
 {
 
+// 'mem_planner_table' is encoded to binary format.
+const std::vector<uint8_t> CircleExportMetadata::encoded_memory_plan_table()
+{
+  std::vector<uint8_t> data;
+
+  write_u32(data, _memory_plan_table.size());
+
+  for (auto &kv : _memory_plan_table)
+  {
+    const auto id = kv.first;
+    write_u32(data, id);
+
+    const auto plan_vector = kv.second;
+    const auto size = plan_vector.size();
+    write_u32(data, size);
+
+    for (auto elem : plan_vector)
+    {
+      write_u32(data, elem);
+    }
+  }
+
+  return data;
+}
+
 // 'source_table' is encoded to binary format.
 const std::vector<uint8_t> CircleExportMetadata::encoded_source_table(void)
 {
@@ -114,7 +139,11 @@ createCircleMetadataVector(flatbuffers::FlatBufferBuilder &builder, luci::Serial
     metadata_vec.emplace_back(
       metadata_offset(builder, md, md._metadata.encoded_op_table(), "ONE_op_table"));
   }
-
+  if (settings->get(luci::UserSettings::Key::MemoryPlanGen))
+  {
+    metadata_vec.emplace_back(
+      metadata_offset(builder, md, md._metadata.encoded_memory_plan_table(), "ONE_memory_plan"));
+  }
   return metadata_vec;
 }
 

--- a/compiler/luci/export/src/CircleOperationExporter.cpp
+++ b/compiler/luci/export/src/CircleOperationExporter.cpp
@@ -22,6 +22,9 @@
 #include <luci/IR/CircleNodes.h>
 #include <luci/IR/CircleNodeVisitor.h>
 #include <luci/Profile/CircleNodeOrigin.h>
+
+#include <luci/Profile/CircleNodeMemoryPlan.h>
+
 #include <luci/UserSettings.h>
 #include <luci/Log.h>
 
@@ -1684,7 +1687,7 @@ void OpExporterLet<OE::CIRC>::visit(luci::CircleInstanceNorm *node)
 }
 
 void exportNode(loco::Node *node, flatbuffers::FlatBufferBuilder &builder, SerializedModelData &md,
-                SerializedGraphData &gd)
+                SerializedGraphData &gd, uint32_t node_position)
 {
   if (auto circle_node = dynamic_cast<luci::CircleNode *>(node))
   {
@@ -1702,6 +1705,20 @@ void exportNode(loco::Node *node, flatbuffers::FlatBufferBuilder &builder, Seria
         md._metadata.add_op_table(node_id, source->id());
       }
     }
+    if (has_memory_plan(circle_node))
+    {
+      // Add to node (in node_position) metadata vector with memory_plan information:
+      // order of execution, and offsets (first go offset of current node
+      // and then offsets of temporary nodes if needed)
+      const auto memory_plan = get_memory_plan(circle_node);
+      std::vector<uint32_t> memory_plan_vector;
+      memory_plan_vector.push_back(memory_plan.order_in_plan());
+      for (auto offset : memory_plan.offsets())
+      {
+        memory_plan_vector.push_back(offset);
+      }
+      md._metadata.add_memory_plan_table(node_position, memory_plan_vector);
+    }
   }
   else
   {
@@ -1717,9 +1734,11 @@ namespace luci
 void exportNodes(loco::Graph *g, FlatBufferBuilder &builder, SerializedModelData &md,
                  SerializedGraphData &gd)
 {
+  uint32_t node_position = 0;
   for (auto node : loco::postorder_traversal(loco::output_nodes(g)))
   {
-    exportNode(node, builder, md, gd);
+    exportNode(node, builder, md, gd, node_position);
+    node_position++;
   }
 }
 

--- a/compiler/luci/export/src/SerializedData.h
+++ b/compiler/luci/export/src/SerializedData.h
@@ -63,13 +63,22 @@ public:
     _op_table.at(node_id).emplace(source_id);
   }
 
+  void add_memory_plan_table(uint32_t node_id, const std::vector<uint32_t> &memory_plan_inform)
+  {
+    _memory_plan_table[node_id] = memory_plan_inform;
+  }
+
 public:
   const std::vector<uint8_t> encoded_source_table(void);
   const std::vector<uint8_t> encoded_op_table(void);
+  const std::vector<uint8_t> encoded_memory_plan_table(void);
 
 private:
   std::map<uint32_t, std::string> _source_table;
   std::map<uint32_t, std::set<uint32_t>> _op_table;
+  // _memory_plan_table stores for node with node_id order of execution, and offsets:
+  // first go offset of current node and then offsets of temporary nodes if needed
+  std::map<uint32_t, std::vector<uint32_t>> _memory_plan_table;
 };
 
 } // namespace luci

--- a/compiler/luci/import/src/CircleImportMetadata.cpp
+++ b/compiler/luci/import/src/CircleImportMetadata.cpp
@@ -134,6 +134,55 @@ decoded_op_table(const std::vector<uint8_t> &op_table_data)
   return node_source_ids_map;
 }
 
+// 'memory_plan_table' is decoded to std::map<uint32_t, std::vector<uint32_t>> format.
+const std::map<uint32_t, std::vector<uint32_t>>
+decoded_memory_plan(const std::vector<uint8_t> &memory_plan_data)
+{
+  std::map<uint32_t, std::vector<uint32_t>> memory_plan_table;
+  uint32_t idx = 0;
+
+  if (memory_plan_data.size() < 4)
+    throw std::runtime_error("Op table decode error : invalid entry number");
+
+  uint32_t entry_number = read_u32(memory_plan_data, idx);
+  idx += sizeof(uint32_t);
+
+  while (idx < memory_plan_data.size())
+  {
+    if (idx + 2 * sizeof(uint32_t) > memory_plan_data.size())
+      throw std::runtime_error("Op table decode error : invalid entry item");
+
+    uint32_t id = read_u32(memory_plan_data, idx);
+    idx += sizeof(uint32_t);
+
+    uint32_t size = read_u32(memory_plan_data, idx);
+    idx += sizeof(uint32_t);
+
+    if (idx + sizeof(uint32_t) * size > memory_plan_data.size())
+      throw std::runtime_error("Source table decode error : invalid entry data");
+
+    std::vector<uint32_t> memory_plan_vector;
+    for (uint32_t j = 0; j < size; ++j)
+    {
+      uint32_t memory_plan_inform = read_u32(memory_plan_data, idx);
+      idx += sizeof(uint32_t);
+
+      memory_plan_vector.push_back(memory_plan_inform);
+    }
+
+    if (memory_plan_table.insert({id, memory_plan_vector}).second == false)
+      throw std::runtime_error("Op table decode error : duplicated origin ID");
+  }
+
+  if (idx != memory_plan_data.size())
+    throw std::runtime_error("Op table decode error : data size invalid");
+
+  if (memory_plan_table.size() != entry_number)
+    throw std::runtime_error("Op table decode error : entry number invalid");
+
+  return memory_plan_table;
+}
+
 } // namespace
 
 namespace luci
@@ -153,6 +202,8 @@ CircleImportMetadata::CircleImportMetadata(const luci::CircleReader &reader)
       _op_table = decoded_op_table(buffer);
     else if (meta.name.compare("ONE_source_table") == 0)
       _source_table = decoded_source_table(buffer);
+    else if (meta.name.compare("ONE_memory_plan") == 0)
+      _memory_plan_table = decoded_memory_plan(buffer);
   }
 }
 

--- a/compiler/luci/import/src/CircleImportMetadata.h
+++ b/compiler/luci/import/src/CircleImportMetadata.h
@@ -47,10 +47,18 @@ public:
 
   const std::map<uint32_t, std::string> &source_table(void) const { return _source_table; }
 
+  const std::map<uint32_t, std::vector<uint32_t>> &memory_plan_table(void) const
+  {
+    return _memory_plan_table;
+  }
+
 private:
   // Decoded metadata is stored
   std::map<uint32_t, std::string> _source_table;
   std::map<uint32_t, std::set<uint32_t>> _op_table;
+  // _memory_plan_table stores for node with node_id order of execution, and offsets:
+  // first go offset of current node and then offsets of temporary nodes if needed
+  std::map<uint32_t, std::vector<uint32_t>> _memory_plan_table;
 };
 
 } // namespace luci

--- a/compiler/luci/import/src/Importer.cpp
+++ b/compiler/luci/import/src/Importer.cpp
@@ -315,8 +315,14 @@ std::unique_ptr<Module> Importer::importModule(const circle::Model *model) const
 
   post_import_graph(module.get(), reader);
 
-  // Initialize 'source_table'
+  // Initialize 'memory_plan_table'
   auto circle_metadata = std::make_unique<luci::CircleImportMetadata>(reader);
+  if (circle_metadata->memory_plan_table().size() > 0)
+  {
+    module->memory_plan(circle_metadata->memory_plan_table());
+  }
+
+  // Initialize 'source_table'
   if (circle_metadata->source_table().size() > 0)
   {
     // If there is 'source_table' metadata in circle model, copy the table.

--- a/compiler/luci/lang/include/luci/IR/Module.h
+++ b/compiler/luci/lang/include/luci/IR/Module.h
@@ -65,6 +65,13 @@ public:
 
   const std::map<uint32_t, std::string> &source_table(void) const { return _source_table; }
 
+  void memory_plan(const std::map<uint32_t, std::vector<uint32_t>> &memory_plan)
+  {
+    _memory_plan = memory_plan;
+  }
+
+  const std::map<uint32_t, std::vector<uint32_t>> &memory_plan(void) const { return _memory_plan; }
+
 private:
   std::vector<std::unique_ptr<loco::Graph>> _graphs;
 
@@ -81,6 +88,8 @@ private:
    *        Even if Module has multiple subgraphs, only first subgraph is considered.
    */
   std::map<uint32_t, std::string> _source_table;
+
+  std::map<uint32_t, std::vector<uint32_t>> _memory_plan;
 };
 
 std::unique_ptr<Module> make_module(void);

--- a/compiler/luci/profile/include/luci/Profile/CircleNodeMemoryPlan.h
+++ b/compiler/luci/profile/include/luci/Profile/CircleNodeMemoryPlan.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __LUCI_PROFILE_CIRCLE_NODE_MEMORY_PLAN_H__
+#define __LUCI_PROFILE_CIRCLE_NODE_MEMORY_PLAN_H__
+
+#include <luci/IR/CircleNode.h>
+
+#include <utility>
+
+namespace luci
+{
+
+class CircleNodeMemoryPlan
+{
+public:
+  CircleNodeMemoryPlan() = delete;
+
+  CircleNodeMemoryPlan(uint32_t order_in_plan, std::vector<uint32_t> offsets)
+  {
+    _order_in_plan = order_in_plan;
+    _offsets = std::move(offsets);
+  }
+
+  uint32_t order_in_plan(void) const { return _order_in_plan; }
+  void order_in_plan(const uint32_t &order_in_plan) { _order_in_plan = order_in_plan; }
+
+  std::vector<uint32_t> offsets(void) const { return _offsets; }
+  void offsets(const std::vector<uint32_t> &offsets) { _offsets = offsets; }
+
+private:
+  uint32_t _order_in_plan;
+  std::vector<uint32_t> _offsets;
+};
+
+bool has_memory_plan(const luci::CircleNode *circle_node);
+
+void add_memory_plan(luci::CircleNode *circle_node, const luci::CircleNodeMemoryPlan &memory_plan);
+
+luci::CircleNodeMemoryPlan get_memory_plan(const luci::CircleNode *circle_node);
+
+} // namespace luci
+
+#endif // __LUCI_PROFILE_CIRCLE_NODE_MEMORY_PLAN_H__

--- a/compiler/luci/profile/src/CircleNodeMemoryPlan.cpp
+++ b/compiler/luci/profile/src/CircleNodeMemoryPlan.cpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Profile/CircleNodeMemoryPlan.h"
+
+#include <loco.h>
+
+#include <stdexcept>
+#include <utility>
+
+namespace
+{
+
+/**
+ * @brief Set annotation for circle node memory plan
+ * @note  Once CircleMemoryPlanAnnotation is annotated, it should not be changed.
+ *        If CircleMemoryPlanAnnotation is needed to be changed, create
+ *        new CircleMemoryPlanAnnotation.
+ */
+class CircleMemoryPlanAnnotation final : public loco::NodeAnnotation
+{
+public:
+  CircleMemoryPlanAnnotation() = delete;
+
+  explicit CircleMemoryPlanAnnotation(luci::CircleNodeMemoryPlan memory_plan)
+    : _memory_plan{std::move(memory_plan)}
+  {
+    // Do nothing
+  }
+
+public:
+  luci::CircleNodeMemoryPlan memory_plan(void) const { return _memory_plan; }
+  // No setter
+
+private:
+  luci::CircleNodeMemoryPlan _memory_plan;
+};
+
+} // namespace
+
+namespace luci
+{
+
+bool has_memory_plan(const luci::CircleNode *circle_node)
+{
+  return circle_node->annot<CircleMemoryPlanAnnotation>() != nullptr;
+}
+
+void add_memory_plan(luci::CircleNode *circle_node, const luci::CircleNodeMemoryPlan &memory_plan)
+{
+  circle_node->annot<CircleMemoryPlanAnnotation>(nullptr);
+  circle_node->annot(std::make_unique<CircleMemoryPlanAnnotation>(memory_plan));
+}
+
+luci::CircleNodeMemoryPlan get_memory_plan(const luci::CircleNode *circle_node)
+{
+  if (!has_memory_plan(circle_node))
+    throw std::runtime_error("Cannot find CircleNodeMemoryPlanAnnotation");
+
+  return circle_node->annot<CircleMemoryPlanAnnotation>()->memory_plan();
+}
+
+} // namespace luci


### PR DESCRIPTION
This pr adds circle-memory-planner tool and all necessary code to CircleImportMetadata and CircleExportMetadata. This tool accepts a circle file as input. Then MemoryPlanner works and the found information is recorded in the circle file metadata.

issue #7522
first draft #7573


ONE-DCO-1.0-Signed-off-by: Artem Balyshev a.balyshev@partner.samsung.com