### PR TITLE
[infra] Add failure when package not extracted

### DIFF
--- a/infra/cmake/modules/ExternalSourceTools.cmake
+++ b/infra/cmake/modules/ExternalSourceTools.cmake
@@ -103,7 +103,13 @@ function(ExternalSource_Download PREFIX)
 
     message(STATUS "Extract ${PREFIX}")
     execute_process(COMMAND ${CMAKE_COMMAND} -E tar xfz "${DOWNLOAD_PATH}"
-                    WORKING_DIRECTORY "${TMP_DIR}")
+                    WORKING_DIRECTORY "${TMP_DIR}"
+                    ERROR_VARIABLE EXTRACTION_ERROR)
+
+    if(EXTRACTION_ERROR)
+      message(FATAL_ERROR "Extract ${PREFIX} - failed")
+    endif(EXTRACTION_ERROR)
+
     file(REMOVE "${DOWNLOAD_PATH}")
     message(STATUS "Extract ${PREFIX} - done")
 


### PR DESCRIPTION
This commit adds failure in cases when package is not extracted from archive.

ONE-DCO-1.0-Signed-off-by: Maksim Bronnikov <max120199@gmail.com>

--------------

Related with: #7783