### PR TITLE
[tfl-inspect] Introduce builtin_code_neutral

### DIFF
--- a/compiler/tfl-inspect/src/Reader.cpp
+++ b/compiler/tfl-inspect/src/Reader.cpp
@@ -16,21 +16,30 @@
 
 #include "Reader.h"
 
+#include <cassert>
 #include <sstream>
 #include <string>
 
 namespace tflinspect
 {
 
+// This will provide v3/v3a format neutral BuiltinOperator
+tflite::BuiltinOperator builtin_code_neutral(const tflite::OperatorCode *opcode)
+{
+  assert(opcode != nullptr);
+  // TODO support v3a
+  return opcode->builtin_code();
+}
+
 bool is_valid(const tflite::OperatorCode *opcode)
 {
-  tflite::BuiltinOperator code = opcode->builtin_code();
+  tflite::BuiltinOperator code = builtin_code_neutral(opcode);
   return (tflite::BuiltinOperator_MIN <= code && code <= tflite::BuiltinOperator_MAX);
 }
 
 bool is_custom(const tflite::OperatorCode *opcode)
 {
-  tflite::BuiltinOperator code = opcode->builtin_code();
+  tflite::BuiltinOperator code = builtin_code_neutral(opcode);
   return (code == tflite::BuiltinOperator_CUSTOM);
 }
 
@@ -56,7 +65,7 @@ std::string opcode_name(const tflite::OperatorCode *opcode)
     return custom_op;
   }
 
-  tflite::BuiltinOperator code = opcode->builtin_code();
+  tflite::BuiltinOperator code = builtin_code_neutral(opcode);
   return tflite::EnumNameBuiltinOperator(code);
 }
 
@@ -122,7 +131,7 @@ tflite::BuiltinOperator Reader::builtin_code(const tflite::Operator *op) const
   assert(index < _op_codes.size());
   const tflite::OperatorCode *opcode = _op_codes.at(index);
 
-  return opcode->builtin_code();
+  return tflinspect::builtin_code_neutral(opcode);
 }
 
 std::string Reader::opcode_name(const tflite::Operator *op) const

--- a/compiler/tfl-inspect/src/Reader.h
+++ b/compiler/tfl-inspect/src/Reader.h
@@ -36,6 +36,7 @@ template <typename T> std::vector<T> as_index_vector(const flatbuffers::Vector<T
   return ret;
 }
 
+tflite::BuiltinOperator builtin_code_neutral(const tflite::OperatorCode *opcode);
 bool is_valid(const tflite::OperatorCode *opcode);
 bool is_custom(const tflite::OperatorCode *opcode);
 std::string opcode_name(const tflite::OperatorCode *opcode);


### PR DESCRIPTION
This will introduce builtin_code_neutral method to support tflite v3a schema.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>