### PR TITLE
[circle-opselector] Introduce getModelData

### DIFF
--- a/compiler/circle-opselector/src/ModuleIO.cpp
+++ b/compiler/circle-opselector/src/ModuleIO.cpp
@@ -27,7 +27,8 @@
 namespace opselector
 {
 
-std::unique_ptr<luci::Module> getModule(std::string &input_path)
+// return circle model data.
+std::vector<char> getModelData(std::string &input_path)
 {
   // Load model from the file
   foder::FileLoader file_loader{input_path};
@@ -40,6 +41,13 @@ std::unique_ptr<luci::Module> getModule(std::string &input_path)
     std::cerr << "ERROR: Invalid input file '" << input_path << "'" << std::endl;
     exit(EXIT_FAILURE);
   }
+
+  return model_data;
+}
+
+std::unique_ptr<luci::Module> getModule(std::string &input_path)
+{
+  std::vector<char> model_data = getModelData(input_path);
 
   const circle::Model *circle_model = circle::GetModel(model_data.data());
   if (circle_model == nullptr)

--- a/compiler/circle-opselector/src/ModuleIO.h
+++ b/compiler/circle-opselector/src/ModuleIO.h
@@ -25,6 +25,7 @@
 namespace opselector
 {
 
+std::vector<char> getModelData(std::string &input_path);
 std::unique_ptr<luci::Module> getModule(std::string &input_path);
 bool exportModule(luci::Module *module, std::string &output_path);
 


### PR DESCRIPTION
This PR introduce new method of ModuleIO.
It can get model data to vector from circle file.

It return model data to vector from circle file, and this data is used to prevent error when calling `CircleReader.selecting_subgraph()`

ONE-DCO-1.0-Signed-off-by: dongyooncho <dycho96@gmail.com>