### PR TITLE
[tflite2circle] Revise description

### DIFF
--- a/compiler/tflite2circle/src/CircleModel.cpp
+++ b/compiler/tflite2circle/src/CircleModel.cpp
@@ -297,7 +297,7 @@ Offset<OperatorCodeLink>::Offset(FlatBufBuilder &fb, const TFLFlatBufVec *tflite
 }
 
 CircleModel::CircleModel(FlatBufBuilder &fb, TFLModel &model)
-  : _version{0}, _description{fb->CreateString("nnpackage")}, _fb{fb}
+  : _version{0}, _description{fb->CreateString("ONE-tflite2circle")}, _fb{fb}
 {
   const tflite::Model *tfl_model = model.load_model();
   // verify flatbuffers


### PR DESCRIPTION
This will revice circle description to 'ONE-tflite2circle' to reflect
this tool's name.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>