### PR TITLE
[res] add tflite recipes for circle-opselector-test

### DIFF
--- a/res/TensorFlowLiteRecipes/OpSel_Part_Sqrt_Rsqrt_002_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/OpSel_Part_Sqrt_Rsqrt_002_000/test.recipe
@@ -1,0 +1,37 @@
+operand {
+  name: "sqrt"
+  type: FLOAT32
+  shape { dim: 1 dim: 3 dim: 3 dim: 2 }
+}
+operand {
+  name: "rsqrt"
+  type: FLOAT32
+  shape { dim: 1 dim: 3 dim: 3 dim: 2 }
+}
+operand {
+  name: "sqrt2"
+  type: FLOAT32
+  shape { dim: 1 dim: 3 dim: 3 dim: 2 }
+}
+operand {
+  name: "ofm"
+  type: FLOAT32
+  shape { dim: 1 dim: 3 dim: 3 dim: 2 }
+}
+operation {
+  type: "Rsqrt"
+  input: "sqrt"
+  output: "rsqrt"
+}
+operation {
+  type: "Sqrt"
+  input: "rsqrt"
+  output: "sqrt2"
+}
+operation {
+  type: "Rsqrt"
+  input: "sqrt2"
+  output: "ofm"
+}
+input: "sqrt"
+output: "ofm"

--- a/res/TensorFlowLiteRecipes/OpSel_Part_Sqrt_Rsqrt_002_001/test.recipe
+++ b/res/TensorFlowLiteRecipes/OpSel_Part_Sqrt_Rsqrt_002_001/test.recipe
@@ -1,0 +1,44 @@
+operand {
+  name: "ifm"
+  type: FLOAT32
+  shape { dim: 1 dim: 3 dim: 3 dim: 2 }
+}
+operand {
+  name: "sqrt"
+  type: FLOAT32
+  shape { dim: 1 dim: 3 dim: 3 dim: 2 }
+}
+operand {
+  name: "rsqrt"
+  type: FLOAT32
+  shape { dim: 1 dim: 3 dim: 3 dim: 2 }
+}
+operand {
+  name: "sqrt2"
+  type: FLOAT32
+  shape { dim: 1 dim: 3 dim: 3 dim: 2 }
+}
+operand {
+  name: "ofm"
+  type: FLOAT32
+  shape { dim: 1 dim: 3 dim: 3 dim: 2 }
+}
+operation {
+  type: "Sqrt"
+  input: "ifm"
+  output: "sqrt"
+}
+operation {
+  type: "Rsqrt"
+  input: "sqrt"
+  output: "rsqrt"
+}
+operation {
+  type: "Rsqrt"
+  input: "sqrt2"
+  output: "ofm"
+}
+input: "ifm"
+input: "sqrt2"
+output: "rsqrt"
+output: "ofm"

--- a/res/TensorFlowLiteRecipes/OpSel_Part_Sqrt_Rsqrt_002_002/test.recipe
+++ b/res/TensorFlowLiteRecipes/OpSel_Part_Sqrt_Rsqrt_002_002/test.recipe
@@ -1,0 +1,27 @@
+operand {
+  name: "rsqrt"
+  type: FLOAT32
+  shape { dim: 1 dim: 3 dim: 3 dim: 2 }
+}
+operand {
+  name: "sqrt2"
+  type: FLOAT32
+  shape { dim: 1 dim: 3 dim: 3 dim: 2 }
+}
+operand {
+  name: "ofm"
+  type: FLOAT32
+  shape { dim: 1 dim: 3 dim: 3 dim: 2 }
+}
+operation {
+  type: "Sqrt"
+  input: "rsqrt"
+  output: "sqrt2"
+}
+operation {
+  type: "Rsqrt"
+  input: "sqrt2"
+  output: "ofm"
+}
+input: "rsqrt"
+output: "ofm"

--- a/res/TensorFlowLiteRecipes/OpSel_Part_Sqrt_Rsqrt_Add_002_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/OpSel_Part_Sqrt_Rsqrt_Add_002_000/test.recipe
@@ -1,0 +1,37 @@
+operand {
+  name: "ifm"
+  type: FLOAT32
+  shape { dim: 1 dim: 3 dim: 3 dim: 2 }
+}
+operand {
+  name: "rsqrt"
+  type: FLOAT32
+  shape { dim: 1 dim: 3 dim: 3 dim: 2 }
+}
+operand {
+  name: "sqrt"
+  type: FLOAT32
+  shape { dim: 1 dim: 3 dim: 3 dim: 2 }
+}
+operand {
+  name: "rsqrt3"
+  type: FLOAT32
+  shape { dim: 1 dim: 3 dim: 3 dim: 2 }
+}
+operation {
+  type: "Rsqrt"
+  input: "ifm"
+  output: "rsqrt"
+}
+operation {
+  type: "Sqrt"
+  input: "rsqrt"
+  output: "sqrt"
+}
+operation {
+  type: "Rsqrt"
+  input: "sqrt"
+  output: "rsqrt3"
+}
+input: "ifm"
+output: "rsqrt3"

--- a/res/TensorFlowLiteRecipes/OpSel_Part_Sqrt_Rsqrt_Add_002_001/test.recipe
+++ b/res/TensorFlowLiteRecipes/OpSel_Part_Sqrt_Rsqrt_Add_002_001/test.recipe
@@ -1,0 +1,37 @@
+operand {
+  name: "ifm"
+  type: FLOAT32
+  shape { dim: 1 dim: 3 dim: 3 dim: 2 }
+}
+operand {
+  name: "rsqrt"
+  type: FLOAT32
+  shape { dim: 1 dim: 3 dim: 3 dim: 2 }
+}
+operand {
+  name: "rsqrt2"
+  type: FLOAT32
+  shape { dim: 1 dim: 3 dim: 3 dim: 2 }
+}
+operand {
+  name: "rsqrt4"
+  type: FLOAT32
+  shape { dim: 1 dim: 3 dim: 3 dim: 2 }
+}
+operation {
+  type: "Rsqrt"
+  input: "ifm"
+  output: "rsqrt"
+}
+operation {
+  type: "Rsqrt"
+  input: "rsqrt"
+  output: "rsqrt2"
+}
+operation {
+  type: "Rsqrt"
+  input: "rsqrt2"
+  output: "rsqrt4"
+}
+input: "ifm"
+output: "rsqrt4"

--- a/res/TensorFlowLiteRecipes/OpSel_Part_Sqrt_Rsqrt_Add_002_002/test.recipe
+++ b/res/TensorFlowLiteRecipes/OpSel_Part_Sqrt_Rsqrt_Add_002_002/test.recipe
@@ -1,0 +1,47 @@
+operand {
+  name: "sqrt"
+  type: FLOAT32
+  shape { dim: 1 dim: 3 dim: 3 dim: 2 }
+}
+operand {
+  name: "rsqrt2"
+  type: FLOAT32
+  shape { dim: 1 dim: 3 dim: 3 dim: 2 }
+}
+operand {
+  name: "rsqrt3"
+  type: FLOAT32
+  shape { dim: 1 dim: 3 dim: 3 dim: 2 }
+}
+operand {
+  name: "rsqrt4"
+  type: FLOAT32
+  shape { dim: 1 dim: 3 dim: 3 dim: 2 }
+}
+operand {
+  name: "ofm"
+  type: FLOAT32
+  shape { dim: 1 dim: 3 dim: 3 dim: 2 }
+}
+operation {
+  type: "Rsqrt"
+  input: "sqrt"
+  output: "rsqrt3"
+}
+operation {
+  type: "Rsqrt"
+  input: "rsqrt2"
+  output: "rsqrt4"
+}
+operation {
+  type: "Add"
+  add_options {
+    activation: NONE
+  }
+  input: "rsqrt3"
+  input: "rsqrt4"
+  output: "ofm"
+}
+input: "sqrt"
+input: "rsqrt2"
+output: "ofm"

--- a/res/TensorFlowLiteRecipes/OpSel_Part_Sqrt_Rsqrt_Add_002_003/test.recipe
+++ b/res/TensorFlowLiteRecipes/OpSel_Part_Sqrt_Rsqrt_Add_002_003/test.recipe
@@ -1,0 +1,58 @@
+operand {
+  name: "ifm"
+  type: FLOAT32
+  shape { dim: 1 dim: 3 dim: 3 dim: 2 }
+}
+operand {
+  name: "rsqrt"
+  type: FLOAT32
+  shape { dim: 1 dim: 3 dim: 3 dim: 2 }
+}
+operand {
+  name: "sqrt"
+  type: FLOAT32
+  shape { dim: 1 dim: 3 dim: 3 dim: 2 }
+}
+operand {
+  name: "rsqrt2"
+  type: FLOAT32
+  shape { dim: 1 dim: 3 dim: 3 dim: 2 }
+}
+operand {
+  name: "rsqrt3"
+  type: FLOAT32
+  shape { dim: 1 dim: 3 dim: 3 dim: 2 }
+}
+operand {
+  name: "rsqrt4"
+  type: FLOAT32
+  shape { dim: 1 dim: 3 dim: 3 dim: 2 }
+}
+operation {
+  type: "Rsqrt"
+  input: "ifm"
+  output: "rsqrt"
+}
+operation {
+  type: "Sqrt"
+  input: "rsqrt"
+  output: "sqrt"
+}
+operation {
+  type: "Rsqrt"
+  input: "rsqrt"
+  output: "rsqrt2"
+}
+operation {
+  type: "Rsqrt"
+  input: "sqrt"
+  output: "rsqrt3"
+}
+operation {
+  type: "Rsqrt"
+  input: "rsqrt2"
+  output: "rsqrt4"
+}
+input: "ifm"
+output: "rsqrt3"
+output: "rsqrt4"


### PR DESCRIPTION
Related PR about circle-opselector-test is #7765 
The file name's format is OpSel_{origin_recipe_name}_00x
ex) OpSel_Part_Sqrt_Rsqrt_002_001 consists of partial nodes from Part_Sqrt_Rsqrt_002.
+Other test cases will be submitted(creating new recipes take time so much...)
ONE-DCO-1.0-Signed-off-by: parkeunsang <dislive@naver.com>