### PR TITLE
[infra] Register luci_plan to one-compiler.links

### DIFF
--- a/infra/debian/compiler/one-compiler.links
+++ b/infra/debian/compiler/one-compiler.links
@@ -13,4 +13,5 @@ usr/share/one/lib/libluci_log.so usr/lib/libluci_log.so
 usr/share/one/lib/libluci_partition.so usr/lib/libluci_partition.so
 usr/share/one/lib/libluci_pass.so usr/lib/libluci_pass.so
 usr/share/one/lib/libluci_profile.so usr/lib/libluci_profile.so
+usr/share/one/lib/libluci_plan.so usr/lib/libluci_plan.so
 usr/share/one/lib/libluci_service.so usr/lib/libluci_service.so


### PR DESCRIPTION
This pr registers luci_plan to infra/debian/compiler/one-compiler.links , according to this comment https://github.com/Samsung/ONE/pull/7773#discussion_r722086854

ONE-DCO-1.0-Signed-off-by: Artem Balyshev a.balyshev@partner.samsung.com