### PR TITLE
[luci] Add ExecutionPlan to UserSettings

### DIFF
--- a/compiler/luci/env/include/luci/UserSettings.h
+++ b/compiler/luci/env/include/luci/UserSettings.h
@@ -33,6 +33,7 @@ struct UserSettings
     MuteWarnings,
     DisableValidation,
     ProfilingDataGen,
+    ExecutionPlanGen,
   };
 
   static UserSettings *settings();

--- a/compiler/luci/env/src/UserSettings.cpp
+++ b/compiler/luci/env/src/UserSettings.cpp
@@ -31,6 +31,7 @@ private:
   bool _MuteWarnings{false};
   bool _DisableValidation{false};
   bool _ProfilingDataGen{false};
+  bool _ExecutionPlanGen{false};
 };
 
 void UserSettingsImpl::set(const Key key, bool value)
@@ -45,6 +46,9 @@ void UserSettingsImpl::set(const Key key, bool value)
       break;
     case Key::ProfilingDataGen:
       _ProfilingDataGen = value;
+      break;
+    case Key::ExecutionPlanGen:
+      _ExecutionPlanGen = value;
       break;
     default:
       throw std::runtime_error("Invalid key in boolean set");
@@ -62,6 +66,8 @@ bool UserSettingsImpl::get(const Key key) const
       return _DisableValidation;
     case Key::ProfilingDataGen:
       return _ProfilingDataGen;
+    case Key::ExecutionPlanGen:
+      return _ExecutionPlanGen;
     default:
       throw std::runtime_error("Invalid key in boolean get");
       break;


### PR DESCRIPTION
This pr adds ExecutionPlanGen to UserSettings. This will be used further in importer and exporter to import and export execution_plan metadata. This is next step of merging #7773.

Merging it only after this pr is merged #7804

issue #7522

ONE-DCO-1.0-Signed-off-by: Artem Balyshev a.balyshev@partner.samsung.com