### PR TITLE
[luci] Add ExecutionPlanTable to luci/IR

### DIFF
--- a/compiler/luci/lang/include/luci/IR/ExecutionPlanTable.h
+++ b/compiler/luci/lang/include/luci/IR/ExecutionPlanTable.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __LUCI_EXECUTION_PLAN_TABLE_H__
+#define __LUCI_EXECUTION_PLAN_TABLE_H__
+
+namespace luci
+{
+
+using ExecutionPlanTable = std::map<uint32_t, std::vector<uint32_t>>;
+
+} // namespace luci
+
+#endif // __LUCI_EXECUTION_PLAN_TABLE_H__


### PR DESCRIPTION
This commit adds ExecutionPlanTable to luci/IR according to https://github.com/Samsung/ONE/pull/7772#discussion_r718938557. This will be used further in importer and exporter to import and export execution_plan metadata. This is next step of merging #7773.

Merging it only after this pr is merged #7804

ONE-DCO-1.0-Signed-off-by: Artem Balyshev a.balyshev@partner.samsung.com