### PR TITLE
[infra] Remove DOWNLOAD_CMSIS option from CMSISSourceConfig.cmake

### DIFF
--- a/infra/cmake/packages/CMSISSource-5.8.0/CMSISSourceConfig.cmake
+++ b/infra/cmake/packages/CMSISSource-5.8.0/CMSISSourceConfig.cmake
@@ -1,9 +1,4 @@
 function(_CMSISSource_import)
-  if(NOT DOWNLOAD_CMSIS)
-    set(CMSIS_FOUND FALSE PARENT_SCOPE)
-    return()
-  endif(NOT DOWNLOAD_CMSIS)
-
   nnas_include(ExternalSourceTools)
   nnas_include(OptionTools)
 


### PR DESCRIPTION
This commit removes DOWNLOAD_CMSIS option from CMSISSourceConfig.cmake

ONE-DCO-1.0-Signed-off-by: Vyacheslav Bazhenov <slavikmipt@gmail.com>