### PR TITLE
[tflite2circle] Relocate verify tflite model

### DIFF
--- a/compiler/tflite2circle/driver/Driver.cpp
+++ b/compiler/tflite2circle/driver/Driver.cpp
@@ -75,6 +75,11 @@ int entry(int argc, char **argv)
     std::cerr << "ERROR: Failed to load tflite '" << tfl_path << "'" << std::endl;
     return 255;
   }
+  if (!tfl_model.verify_model())
+  {
+    std::cerr << "ERROR: Failed to verify tflite '" << tfl_path << "'" << std::endl;
+    return 255;
+  }
 
   // create flatbuffer builder
   auto flatbuffer_builder = std::make_unique<flatbuffers::FlatBufferBuilder>(1024);

--- a/compiler/tflite2circle/include/TFLModel.h
+++ b/compiler/tflite2circle/include/TFLModel.h
@@ -38,6 +38,7 @@ public:
 
 public:
   bool is_valid(void) { return _valid; }
+  bool verify_model(void);
 
 private:
   const tflite::Model *load_model(void);
@@ -46,6 +47,7 @@ private:
   std::ifstream _infile;
   DataBuffer _data;
   bool _valid;
+  bool _loaded = false;
 
   friend class CircleModel;
 };

--- a/compiler/tflite2circle/src/CircleModel.cpp
+++ b/compiler/tflite2circle/src/CircleModel.cpp
@@ -314,13 +314,6 @@ CircleModel::CircleModel(FlatBufBuilder &fb, TFLModel &model)
   : _version{0}, _description{fb->CreateString("ONE-tflite2circle")}, _fb{fb}
 {
   const tflite::Model *tfl_model = model.load_model();
-  // verify flatbuffers
-  flatbuffers::Verifier verifier{reinterpret_cast<const uint8_t *>(model._data.data()),
-                                 model._data.size()};
-  if (!tflite::VerifyModelBuffer(verifier))
-  {
-    throw std::runtime_error("Failed to verify tflite");
-  }
 
   _operator_codes_offset =
     std::make_unique<Offset<OperatorCodeLink>>(fb, tfl_model->operator_codes());

--- a/compiler/tflite2circle/src/TFLModel.cpp
+++ b/compiler/tflite2circle/src/TFLModel.cpp
@@ -30,14 +30,27 @@ TFLModel::TFLModel(const std::string &path)
 const tflite::Model *TFLModel::load_model(void)
 {
   assert(_valid == true);
-  _infile.seekg(0, std::ios::end);
-  auto fileSize = _infile.tellg();
-  _infile.seekg(0, std::ios::beg);
-  _data.resize(fileSize);
-  _infile.read(_data.data(), fileSize);
-  _infile.close();
+
+  if (!_loaded)
+  {
+    _infile.seekg(0, std::ios::end);
+    auto fileSize = _infile.tellg();
+    _infile.seekg(0, std::ios::beg);
+    _data.resize(fileSize);
+    _infile.read(_data.data(), fileSize);
+    _infile.close();
+  }
+  _loaded = true;
 
   return tflite::GetModel(_data.data());
+}
+
+bool TFLModel::verify_model(void)
+{
+  load_model();
+
+  flatbuffers::Verifier verifier{reinterpret_cast<const uint8_t *>(_data.data()), _data.size()};
+  return tflite::VerifyModelBuffer(verifier);
 }
 
 } // namespace tflite2circle


### PR DESCRIPTION
This will relocate verify tflite model into TFLModel class.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>