### PR TITLE
[luci-interpreter] Fix wrong short circuit

### DIFF
--- a/compiler/luci-interpreter/src/BuddyMemoryManager.cpp
+++ b/compiler/luci-interpreter/src/BuddyMemoryManager.cpp
@@ -50,7 +50,7 @@ void BuddyMemoryManager::allocate_memory(luci_interpreter::Tensor &tensor)
              ? lowerLog2(footprint)
              : lowerLog2(footprint) + 1; // check footprint is pow_of_2
 
-  while (!_free_blocks[l] && l < 32)
+  while (l < 32 && !_free_blocks[l])
     l++;
 
   assert(l < 32);


### PR DESCRIPTION
Array should be accessed after index is checked first.
This commit will fix it.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>

---

### 1 approval is enough