### PR TITLE
[tflite2circle] Revise CircleModel CTOR and add load_offsets

### DIFF
--- a/compiler/tflite2circle/driver/Driver.cpp
+++ b/compiler/tflite2circle/driver/Driver.cpp
@@ -80,7 +80,10 @@ int entry(int argc, char **argv)
   auto flatbuffer_builder = std::make_unique<flatbuffers::FlatBufferBuilder>(1024);
 
   // convert tflite to circle
-  tflite2circle::CircleModel circle_model{flatbuffer_builder, tfl_model.get_model()};
+  tflite2circle::CircleModel circle_model{flatbuffer_builder};
+
+  circle_model.load_offsets(flatbuffer_builder, tfl_model.get_model());
+  circle_model.model_build();
 
   std::ofstream outfile{circle_path, std::ios::binary};
 

--- a/compiler/tflite2circle/include/CircleModel.h
+++ b/compiler/tflite2circle/include/CircleModel.h
@@ -84,9 +84,10 @@ private:
 
 public:
   CircleModel(void) = delete;
-  CircleModel(FlatBufBuilder &fb, const tflite::Model *tfl_model);
+  CircleModel(FlatBufBuilder &fb);
 
 public:
+  void load_offsets(FlatBufBuilder &fb, const tflite::Model *tfl_model);
   void model_build(void) const;
   const char *base(void) const;
   size_t size(void) const;

--- a/compiler/tflite2circle/src/CircleModel.cpp
+++ b/compiler/tflite2circle/src/CircleModel.cpp
@@ -311,8 +311,13 @@ void Offset<OperatorCodeLink>::build(FlatBufBuilder &fb, const TFLFlatBufVec *tf
   _circle_flatbuffer_vec_offset = fb->CreateVector(operator_code_vec);
 }
 
-CircleModel::CircleModel(FlatBufBuilder &fb, const tflite::Model *tfl_model)
+CircleModel::CircleModel(FlatBufBuilder &fb)
   : _version{0}, _description{fb->CreateString("ONE-tflite2circle")}, _fb{fb}
+{
+  // NOTHING TODO
+}
+
+void CircleModel::load_offsets(FlatBufBuilder &fb, const tflite::Model *tfl_model)
 {
   _operator_codes_offset = std::make_unique<Offset<OperatorCodeLink>>(fb);
   _subGraphs_offset = std::make_unique<Offset<SubGraphLink>>(fb);
@@ -323,8 +328,6 @@ CircleModel::CircleModel(FlatBufBuilder &fb, const tflite::Model *tfl_model)
   _subGraphs_offset->build(fb, tfl_model->subgraphs());
   _buffers_offset->build(fb, tfl_model->buffers());
   _metadata_buffer_offset->build(fb, tfl_model->metadata_buffer());
-
-  model_build();
 }
 
 void CircleModel::model_build(void) const


### PR DESCRIPTION
This will revise CircleModel CTOR to do nothing and extract to
load_offsets() method, also revise Driver to call new method.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>