### PR TITLE
[luci/service] Fix CircleQuantize type inference logic

### DIFF
--- a/compiler/luci/service/src/CircleTypeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleTypeInferenceRule.cpp
@@ -314,8 +314,7 @@ struct TypeInferenceAlgorithm final : public luci::CircleNodeVisitor<loco::DataT
     return input_type;
   }
 
-  // TODO support S16
-  loco::DataType visit(const luci::CircleQuantize *) final { return loco::DataType::U8; }
+  loco::DataType visit(const luci::CircleQuantize *node) final { return luci::dtype_get(node); }
 
   loco::DataType visit(const luci::CircleRange *node) final
   {


### PR DESCRIPTION
This commit fixed `CircleQuantize` type inference logic.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>