### PR TITLE
[luci] Fix luci build for external projects

### DIFF
--- a/compiler/luci/env/CMakeLists.txt
+++ b/compiler/luci/env/CMakeLists.txt
@@ -2,6 +2,10 @@ file(GLOB_RECURSE SOURCES "src/*.cpp")
 file(GLOB_RECURSE TESTS "src/*.test.cpp")
 list(REMOVE_ITEM SOURCES ${TESTS})
 
+if (NOT LIBRARY_TYPE)
+  set(LIBRARY_TYPE "SHARED")
+endif(NOT LIBRARY_TYPE)
+
 add_library(luci_env ${LIBRARY_TYPE} ${SOURCES})
 target_include_directories(luci_env PUBLIC include)
 target_link_libraries(luci_env PRIVATE nncc_common)

--- a/compiler/luci/export/CMakeLists.txt
+++ b/compiler/luci/export/CMakeLists.txt
@@ -3,6 +3,10 @@ file(GLOB_RECURSE SOURCES "src/*.cpp")
 #file(GLOB_RECURSE TESTS "src/*.test.cpp")
 #list(REMOVE_ITEM SOURCES ${TESTS})
 
+if (NOT LIBRARY_TYPE)
+    set(LIBRARY_TYPE "SHARED")
+endif(NOT LIBRARY_TYPE)
+
 add_library(luci_export ${LIBRARY_TYPE} ${SOURCES})
 target_include_directories(luci_export PRIVATE src)
 target_include_directories(luci_export PUBLIC include)

--- a/compiler/luci/import/CMakeLists.txt
+++ b/compiler/luci/import/CMakeLists.txt
@@ -2,6 +2,10 @@ file(GLOB_RECURSE SOURCES "src/*.cpp")
 file(GLOB_RECURSE TESTS "src/*.test.cpp")
 list(REMOVE_ITEM SOURCES ${TESTS})
 
+if (NOT LIBRARY_TYPE)
+  set(LIBRARY_TYPE "SHARED")
+endif(NOT LIBRARY_TYPE)
+
 add_library(luci_import ${LIBRARY_TYPE} ${SOURCES})
 target_include_directories(luci_import PRIVATE src)
 target_include_directories(luci_import PUBLIC include)

--- a/compiler/luci/lang/CMakeLists.txt
+++ b/compiler/luci/lang/CMakeLists.txt
@@ -2,6 +2,10 @@ file(GLOB_RECURSE SOURCES "src/*.cpp")
 file(GLOB_RECURSE TESTS "src/*.test.cpp")
 list(REMOVE_ITEM SOURCES ${TESTS})
 
+if (NOT LIBRARY_TYPE)
+  set(LIBRARY_TYPE "SHARED")
+endif(NOT LIBRARY_TYPE)
+
 add_library(luci_lang ${LIBRARY_TYPE} ${SOURCES})
 target_include_directories(luci_lang PRIVATE src)
 target_include_directories(luci_lang PUBLIC include)

--- a/compiler/luci/log/CMakeLists.txt
+++ b/compiler/luci/log/CMakeLists.txt
@@ -1,6 +1,10 @@
 # TODO Find how to test logging framework
 file(GLOB_RECURSE SOURCES "src/*.cpp")
 
+if (NOT LIBRARY_TYPE)
+    set(LIBRARY_TYPE "SHARED")
+endif(NOT LIBRARY_TYPE)
+
 add_library(luci_log ${LIBRARY_TYPE} ${SOURCES})
 target_include_directories(luci_log PUBLIC include)
 target_link_libraries(luci_log PUBLIC hermes)

--- a/compiler/luci/logex/CMakeLists.txt
+++ b/compiler/luci/logex/CMakeLists.txt
@@ -1,6 +1,10 @@
 # TODO Find how to test logging-ex utility
 file(GLOB_RECURSE SOURCES "src/*.cpp")
 
+if (NOT LIBRARY_TYPE)
+    set(LIBRARY_TYPE "SHARED")
+endif(NOT LIBRARY_TYPE)
+
 add_library(luci_logex ${LIBRARY_TYPE} ${SOURCES})
 target_include_directories(luci_logex PUBLIC include)
 target_link_libraries(luci_logex PUBLIC loco)

--- a/compiler/luci/partition/CMakeLists.txt
+++ b/compiler/luci/partition/CMakeLists.txt
@@ -2,6 +2,10 @@ file(GLOB_RECURSE SOURCES "src/*.cpp")
 file(GLOB_RECURSE TESTS "src/*.test.cpp")
 list(REMOVE_ITEM SOURCES ${TESTS})
 
+if (NOT LIBRARY_TYPE)
+  set(LIBRARY_TYPE "SHARED")
+endif(NOT LIBRARY_TYPE)
+
 add_library(luci_partition ${LIBRARY_TYPE} ${SOURCES})
 target_include_directories(luci_partition PRIVATE src)
 target_include_directories(luci_partition PUBLIC include)

--- a/compiler/luci/pass/CMakeLists.txt
+++ b/compiler/luci/pass/CMakeLists.txt
@@ -8,6 +8,10 @@ file(GLOB_RECURSE SOURCES "src/*.cpp")
 file(GLOB_RECURSE TESTS "src/*.test.cpp")
 list(REMOVE_ITEM SOURCES ${TESTS})
 
+if (NOT LIBRARY_TYPE)
+  set(LIBRARY_TYPE "SHARED")
+endif(NOT LIBRARY_TYPE)
+
 add_library(luci_pass ${LIBRARY_TYPE} ${SOURCES})
 target_include_directories(luci_pass PRIVATE src)
 target_include_directories(luci_pass PUBLIC include)

--- a/compiler/luci/plan/CMakeLists.txt
+++ b/compiler/luci/plan/CMakeLists.txt
@@ -1,5 +1,9 @@
 file(GLOB_RECURSE SOURCES "src/*.cpp")
 
+if (NOT LIBRARY_TYPE)
+    set(LIBRARY_TYPE "SHARED")
+endif(NOT LIBRARY_TYPE)
+
 add_library(luci_plan ${LIBRARY_TYPE} ${SOURCES})
 target_include_directories(luci_plan PRIVATE src)
 target_include_directories(luci_plan PUBLIC include)

--- a/compiler/luci/profile/CMakeLists.txt
+++ b/compiler/luci/profile/CMakeLists.txt
@@ -2,6 +2,10 @@ file(GLOB_RECURSE SOURCES "src/*.cpp")
 file(GLOB_RECURSE TESTS "src/*.test.cpp")
 list(REMOVE_ITEM SOURCES ${TESTS})
 
+if (NOT LIBRARY_TYPE)
+  set(LIBRARY_TYPE "SHARED")
+endif(NOT LIBRARY_TYPE)
+
 add_library(luci_profile ${LIBRARY_TYPE} ${SOURCES})
 target_include_directories(luci_profile PRIVATE src)
 target_include_directories(luci_profile PUBLIC include)

--- a/compiler/luci/service/CMakeLists.txt
+++ b/compiler/luci/service/CMakeLists.txt
@@ -2,6 +2,10 @@ file(GLOB_RECURSE SOURCES "src/*.cpp")
 file(GLOB_RECURSE TESTS "src/*.test.cpp")
 list(REMOVE_ITEM SOURCES ${TESTS})
 
+if (NOT LIBRARY_TYPE)
+  set(LIBRARY_TYPE "SHARED")
+endif(NOT LIBRARY_TYPE)
+
 add_library(luci_service ${LIBRARY_TYPE} ${SOURCES})
 target_include_directories(luci_service PRIVATE src)
 target_include_directories(luci_service PUBLIC include)


### PR DESCRIPTION
This PR modifies CMakeLists.txt to enable external projects include luci partially.

ONE-DCO-1.0-Signed-off-by: Alexander Efimov <a.efimov@samsung.com>