### PR TITLE
DRAFT: Input/output type options in circle-quantize

### DIFF
--- a/compiler/circle-quantizer/src/CircleQuantizer.cpp
+++ b/compiler/circle-quantizer/src/CircleQuantizer.cpp
@@ -116,6 +116,18 @@ int entry(int argc, char **argv)
           "Three arguments required: tensor_name(string), "
           "scale(float) zero_point(int)");
 
+  arser.add_argument("--input_type")
+    .nargs(1)
+    .type(arser::DataType::STR)
+    .required(false)
+    .help("Input type of quantized model (uint8 or int16)");
+
+  arser.add_argument("--output_type")
+    .nargs(1)
+    .type(arser::DataType::STR)
+    .required(false)
+    .help("Output type of quantized model (uint8 or int16)");
+
   arser.add_argument("input").nargs(1).type(arser::DataType::STR).help("Input circle model");
   arser.add_argument("output").nargs(1).type(arser::DataType::STR).help("Output circle model");
 
@@ -181,6 +193,14 @@ int entry(int argc, char **argv)
     options->param(AlgorithmParameters::Quantize_input_dtype, values.at(0));
     options->param(AlgorithmParameters::Quantize_output_dtype, values.at(1));
     options->param(AlgorithmParameters::Quantize_granularity, values.at(2));
+
+    if (arser["--input_type"])
+      options->param(AlgorithmParameters::Quantize_input_type,
+                     arser.get<std::string>("--input_type"));
+
+    if (arser["--output_type"])
+      options->param(AlgorithmParameters::Quantize_output_type,
+                     arser.get<std::string>("--output_type"));
   }
 
   if (arser[rq])

--- a/compiler/luci/pass/include/luci/CircleOptimizer.h
+++ b/compiler/luci/pass/include/luci/CircleOptimizer.h
@@ -93,6 +93,8 @@ public:
       Quantize_tensor_names,
       Quantize_scales,
       Quantize_zero_points,
+      Quantize_input_type,  // TODO Rename input_dtype to avoid confusion
+      Quantize_output_type, // TODO Rename output_dtype to avoid confusion
 
       // sparsify
       Sparsify_tensor_name,

--- a/compiler/luci/pass/include/luci/Pass/QuantizeWithMinMaxPass.h
+++ b/compiler/luci/pass/include/luci/Pass/QuantizeWithMinMaxPass.h
@@ -31,10 +31,23 @@ namespace luci
  */
 class QuantizeWithMinMaxPass : public logo::Pass
 {
+  // For backward-compatibility
+  // TODO Remove this constructor
 public:
   QuantizeWithMinMaxPass(loco::DataType input_dtype, loco::DataType output_dtype,
                          QuantizationGranularity granularity)
-    : _input_dtype{input_dtype}, _output_dtype{output_dtype}, _granularity{granularity}
+    : _input_dtype{input_dtype}, _output_dtype{output_dtype}, _granularity{granularity},
+      _input_type{output_dtype}, _output_type{output_dtype}
+  {
+    // DO NOTHING
+  }
+
+public:
+  QuantizeWithMinMaxPass(loco::DataType input_dtype, loco::DataType output_dtype,
+                         QuantizationGranularity granularity, loco::DataType input_type,
+                         loco::DataType output_type)
+    : _input_dtype{input_dtype}, _output_dtype{output_dtype}, _granularity{granularity},
+      _input_type{input_type}, _output_type{output_type}
   {
     // DO NOTHING
   }
@@ -47,6 +60,8 @@ private:
   loco::DataType _input_dtype;
   loco::DataType _output_dtype;
   QuantizationGranularity _granularity;
+  loco::DataType _input_type;
+  loco::DataType _output_type;
 };
 
 } // namespace luci

--- a/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
+++ b/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
@@ -63,6 +63,52 @@ void iterate_per_channel(CircleConst *node, int32_t &channel_dim_index, IterFunc
   }
 }
 
+// Create a Quantize Op whose
+// dtype is out_type
+// shape is the same with node
+// qparam is computed using node's min/max
+luci::CircleQuantize *create_quantize_op(luci::CircleNode *node, loco::DataType out_type)
+{
+  auto quantize = node->graph()->nodes()->create<CircleQuantize>();
+  quantize->name(node->name() + "_Quantize");
+  quantize->dtype(out_type);
+  quantize->rank(node->rank());
+  for (uint32_t i = 0; i < node->rank(); i++)
+    quantize->dim(i).set(node->dim(i).value());
+
+  quantize->shape_status(luci::ShapeStatus::VALID);
+
+  auto qparam = node->quantparam();
+  assert(qparam);                  // FIX_CALLER_UNLESS
+  assert(qparam->min.size() == 1); // FIX_CALLER_UNLESS
+  assert(qparam->max.size() == 1); // FIX_CALLER_UNLESS
+  auto min = qparam->min[0];
+  auto max = qparam->max[0];
+
+  float scaling_factor{0};
+  int64_t zp{0};
+  float nudged_min{0};
+  float nudged_max{0};
+
+  if (out_type == loco::DataType::U8)
+  {
+    compute_asym_scale_zp(min, max, scaling_factor, zp, nudged_min, nudged_max);
+  }
+  else
+  {
+    assert(out_type == loco::DataType::S16);
+    compute_sym_scale_zp(min, max, scaling_factor, zp, nudged_min, nudged_max);
+  }
+
+  auto quantparam = std::make_unique<CircleQuantParam>();
+  quantparam->scale.push_back(scaling_factor);
+  quantparam->zerop.push_back(zp);
+
+  quantize->quantparam(std::move(quantparam));
+
+  return quantize;
+}
+
 } // namespace
 
 namespace luci
@@ -743,8 +789,6 @@ struct QuantizeActivation final : public luci::CircleNodeMutableVisitor<bool>
           scaling_factor = scaling_factor < 1 ? 1.0f : std::round(scaling_factor);
         }
 
-        circle_node->quantparam()->min.clear();
-        circle_node->quantparam()->max.clear();
         circle_node->quantparam()->scale.push_back(scaling_factor);
         circle_node->quantparam()->zerop.push_back(zp);
       }
@@ -1536,6 +1580,93 @@ bool QuantizeWithMinMaxPass::run(loco::Graph *g)
       circle_node->dtype(_output_dtype);
       auto graph_output = graph_outputs->at(circle_node->index());
       graph_output->dtype(_output_dtype);
+    }
+  }
+
+  // Set input type
+  auto inputs = g->inputs();
+  for (auto node : loco::input_nodes(g))
+  {
+    auto input = loco::must_cast<luci::CircleInput *>(node);
+    if (input->dtype() == _input_type)
+      continue;
+
+    // Bool type is not quantizable
+    if (input->dtype() == loco::DataType::BOOL)
+      continue;
+
+    // Insert Quantize Op
+    auto quant_op = create_quantize_op(input, input->dtype());
+    loco::replace(input).with(quant_op);
+    quant_op->input(input);
+
+    // Requantize input
+    {
+      auto quantparam = input->quantparam();
+      assert(quantparam);
+      assert(quantparam->min.size() == 1); // only support layer-wise quant
+      assert(quantparam->max.size() == 1); // only support layer-wise quant
+      auto min = quantparam->min[0];
+      auto max = quantparam->max[0];
+
+      float scaling_factor{0};
+      int64_t zp{0};
+      float nudged_min{0};
+      float nudged_max{0};
+
+      if (_input_type == loco::DataType::U8)
+      {
+        compute_asym_scale_zp(min, max, scaling_factor, zp, nudged_min, nudged_max);
+      }
+      else
+      {
+        assert(_input_type == loco::DataType::S16);
+        compute_sym_scale_zp(min, max, scaling_factor, zp, nudged_min, nudged_max);
+      }
+      input->dtype(_input_type);
+      input->quantparam()->scale[0] = scaling_factor;
+      input->quantparam()->zerop[0] = zp;
+    }
+
+    auto graph_input = inputs->at(input->index());
+    graph_input->dtype(_input_type);
+  }
+
+  // Set output type
+  auto outputs = g->outputs();
+  for (auto node : loco::output_nodes(g))
+  {
+    auto output = loco::must_cast<luci::CircleOutput *>(node);
+    if (output->dtype() == _output_type)
+      continue;
+
+    // Bool type is not quantizable
+    if (output->dtype() == loco::DataType::BOOL)
+      continue;
+
+    auto from = loco::must_cast<luci::CircleNode *>(output->from());
+
+    // The last Op is not quantizable Op (ex: ArgMax)
+    if (not from->quantparam())
+      continue;
+
+    // Insert Quantize Op
+    auto quant_op = create_quantize_op(from, _output_type);
+    loco::replace(from).with(quant_op);
+    quant_op->input(from);
+
+    auto graph_output = outputs->at(output->index());
+    graph_output->dtype(_output_type);
+  }
+
+  // Remove min/max values
+  for (auto node : loco::active_nodes(loco::output_nodes(g)))
+  {
+    auto circle_node = loco::must_cast<luci::CircleNode *>(node);
+    if (auto qparam = circle_node->quantparam())
+    {
+      qparam->min.clear();
+      qparam->max.clear();
     }
   }
 

--- a/compiler/one-cmds/one-quantize
+++ b/compiler/one-cmds/one-quantize
@@ -249,6 +249,12 @@ def _quantize(args):
             circle_quantizer_cmd.append(getattr(args, 'quantized_dtype'))
         if _utils._is_valid_attr(args, 'granularity'):
             circle_quantizer_cmd.append(getattr(args, 'granularity'))
+        if _utils._is_valid_attr(args, 'input_type'):
+            circle_quantizer_cmd.append('--input_type')
+            circle_quantizer_cmd.append(getattr(args, 'input_type'))
+        if _utils._is_valid_attr(args, 'output_type'):
+            circle_quantizer_cmd.append('--output_type')
+            circle_quantizer_cmd.append(getattr(args, 'output_type'))
         # input and output path
         circle_quantizer_cmd.append(tmp_output_path_2)
         if _utils._is_valid_attr(args, 'output_path'):


### PR DESCRIPTION
On going draft to support input/output_type in circle-quantizer.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/7832