### PR TITLE
[vconone] Fix compiler version

### DIFF
--- a/compiler/vconone/CMakeLists.txt
+++ b/compiler/vconone/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (NOT VCONONE_VERSION)
-  set(VCONONE_VERSION 0x0000000100120000)
+  set(VCONONE_VERSION 0x0000000000120001)
   # NOTE order is [build patch minor major]
   # if VCONONE_VERSION is set with -D option, it will be cached
   # you may have to remove cache file if you remove -D option


### PR DESCRIPTION
This commit fixes compiler version to be printed.

Signed-off-by: seongwoo <mhs4670go@naver.com>