### PR TITLE
[debian] compiler debian pkg version 1.18.0

### DIFF
--- a/infra/debian/compiler/changelog
+++ b/infra/debian/compiler/changelog
@@ -1,3 +1,9 @@
+one (1.18.0) bionic; urgency=medium
+
+  * More optimization pass
+
+ -- seongwoo <mhs4670go@naver.com>  Fri, 15 Oct 2021 15:23:20 +0900
+
 one (1.17.0) bionic; urgency=medium
 
   * More optimization pass


### PR DESCRIPTION
This commit updates compiler debian changelog for 1.18.0 release.

Signed-off-by: seongwoo <mhs4670go@naver.com>