### PR TITLE
[tflite2circle] Revise to use member _fb

### DIFF
--- a/compiler/tflite2circle/driver/Driver.cpp
+++ b/compiler/tflite2circle/driver/Driver.cpp
@@ -82,7 +82,7 @@ int entry(int argc, char **argv)
   // convert tflite to circle
   tflite2circle::CircleModel circle_model{flatbuffer_builder};
 
-  circle_model.load_offsets(flatbuffer_builder, tfl_model.get_model());
+  circle_model.load_offsets(tfl_model.get_model());
   circle_model.model_build();
 
   std::ofstream outfile{circle_path, std::ios::binary};

--- a/compiler/tflite2circle/include/CircleModel.h
+++ b/compiler/tflite2circle/include/CircleModel.h
@@ -67,7 +67,7 @@ public:
 
 public:
   // TODO use _fb
-  void build(FlatBufBuilder &fb, const TFLFlatBufVec *tflite_flatbuffer_vec);
+  void build(const TFLFlatBufVec *tflite_flatbuffer_vec);
 
 public:
   CIRFlatBufVecOffset offset(void) const { return _circle_flatbuffer_vec_offset; }
@@ -87,7 +87,7 @@ public:
   CircleModel(FlatBufBuilder &fb);
 
 public:
-  void load_offsets(FlatBufBuilder &fb, const tflite::Model *tfl_model);
+  void load_offsets(const tflite::Model *tfl_model);
   void model_build(void) const;
   const char *base(void) const;
   size_t size(void) const;


### PR DESCRIPTION
This will revise to use member _fb for FlatBufferBuilder parameter.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>