### PR TITLE
[luci] Set origin of Quantize Ops

### DIFF
--- a/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
+++ b/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
@@ -20,6 +20,7 @@
 #include <luci/IR/CircleNodes.h>
 #include <luci/IR/CircleNodeVisitor.h>
 #include <luci/Service/Nodes/CircleConst.h>
+#include <luci/Profile/CircleNodeOrigin.h>
 #include <luci/Log.h>
 
 #include <oops/UserExn.h>
@@ -1529,6 +1530,14 @@ void QuantizeWithMinMaxPass::set_input_type(loco::Graph *g) const
     loco::replace(input).with(quant_op);
     quant_op->input(input);
 
+    // TODO Set a proper origin (Quantize should have its own Origin)
+    {
+      auto succs = loco::succs(quant_op);
+      assert(succs.size() > 0);
+      auto succ = loco::must_cast<luci::CircleNode *>(*succs.begin());
+      luci::add_origin(quant_op, luci::get_origin(succ));
+    }
+
     // Requantize input
     {
       auto quantparam = input->quantparam();
@@ -1585,6 +1594,9 @@ void QuantizeWithMinMaxPass::set_output_type(loco::Graph *g) const
     auto quant_op = create_quantize_op(from, _output_type);
     loco::replace(from).with(quant_op);
     quant_op->input(from);
+
+    // TODO Set a proper origin (Quantize should have its own Origin)
+    luci::add_origin(quant_op, luci::get_origin(from));
 
     auto graph_output = outputs->at(output->index());
     graph_output->dtype(_output_type);


### PR DESCRIPTION
This sets origin of Quantize Ops in QuantizeWithMinMaxPass.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: #7832
Draft PR: #7833