### PR TITLE
[CI] Update runtime test folder list

### DIFF
--- a/.ahub/tcchecker-tca/config.yaml
+++ b/.ahub/tcchecker-tca/config.yaml
@@ -16,9 +16,7 @@ test:
       - /runtime/onert/test/graph/verifier
       - /runtime/onert/test/ir
       - /runtime/onert/test/util
-      - /tests/nnapi/src
       - /tests/nnfw_api/src
-      - /tests/tools/tflite_run/src
 
     testFile:
       - extension: cpp


### PR DESCRIPTION
This commit removes invalid test folder.
- /tests/nnapi/src: ported test from android
- /test/tools/tflite_run/src: test for tool itself (not released)

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

--- 

Draft: #7863