### PR TITLE
[one-cmds] Parse cfg file and overwrite args

### DIFF
--- a/compiler/one-cmds/utils.py
+++ b/compiler/one-cmds/utils.py
@@ -126,9 +126,34 @@ def _is_valid_attr(args, attr):
     return hasattr(args, attr) and getattr(args, attr)
 
 
+def _parse_cfg_and_overwrite(config_path, section, args):
+    """
+    parse given section of configuration file and set the values of args.
+    Even if the values parsed from the configuration file already exist in args,
+    the values are overwritten.
+    """
+    if config_path == None:
+        # DO NOTHING
+        return
+    config = configparser.ConfigParser()
+    # make option names case sensitive
+    config.optionxform = str
+    parsed = config.read(config_path)
+    if not parsed:
+        raise FileNotFoundError('Not found given configuration file')
+    if not config.has_section(section):
+        raise AssertionError('configuration file doesn\'t have \'' + section +
+                             '\' section')
+    for key in config[section]:
+        setattr(args, key, config[section][key])
+    # TODO support accumulated arguments
+
+
 def _parse_cfg(args, driver_name):
     """parse configuration file. If the option is directly given to the command line,
-       the option is processed prior to the configuration file."""
+       the option is processed prior to the configuration file.
+       That is, if the values parsed from the configuration file already exist in args,
+       the values are ignored."""
     if _is_valid_attr(args, 'config'):
         config = configparser.ConfigParser()
         config.optionxform = str


### PR DESCRIPTION
This commit adds `_parse_cfg_and_overwrite` function to utils.

`_parse_cfg` function doesn't overwrite parsed value to `args` because options from CLI has higher priority than the one from configuration file. `_parse_cfg_and_overwrite` function is introduced for a similar reason. When both of `.cfg` file and `-O` option are given, the latter has higher priority. The contents from `-O` option will overwrite existing `args`.


Related: #7513
Draft: #7866
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>