### PR TITLE
[one-cmds] Receive -O option internally

### DIFF
--- a/compiler/one-cmds/one-optimize
+++ b/compiler/one-cmds/one-optimize
@@ -64,6 +64,9 @@ def _get_parser():
         # opt = (option_name, help_message)
         circle2circle_group.add_argument('--' + opt[0], action='store_true', help=opt[1])
 
+    # optimization option from one-build
+    parser.add_argument('-O', type=str, help=argparse.SUPPRESS)
+
     return parser
 
 
@@ -113,6 +116,15 @@ def _optimize(args):
         _utils._run(circle2circle_cmd, err_prefix="circle2circle", logfile=f)
 
 
+def _parse_opt(args):
+    if _utils._is_valid_attr(args, 'O'):
+        opt_name_path_dic = dict(
+            zip(_utils._get_optimization_list(get_name=True),
+                _utils._get_optimization_list()))
+        config_path = opt_name_path_dic['O' + getattr(args, 'O')]
+        _utils._parse_cfg_and_overwrite(config_path, 'one-optimize', args)
+
+
 def main():
     # parse arguments
     parser = _get_parser()
@@ -120,6 +132,11 @@ def main():
 
     # parse configuration file
     _utils._parse_cfg(args, 'one-optimize')
+
+    # parse optimization file
+    # NOTE if there is a `one-optimize` section in above configuration file as well,
+    # it will be overwritten
+    _parse_opt(args)
 
     # verify arguments
     _verify_arg(parser, args)


### PR DESCRIPTION
This commit make `one-optimize` receive -O option internally. This change is needed because `one-build` passes `-O` option to `one-optimize`. Argument parser receives it as a `SUPPRESS` option.

Related: #7513
Related: #7866 
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>