### PR TITLE
[one-cmds] Not allow space string in optimization name

### DIFF
--- a/compiler/one-cmds/one-build
+++ b/compiler/one-cmds/one-build
@@ -69,6 +69,8 @@ def _verify_arg(parser, args):
     opt_name_list = _utils._get_optimization_list(get_name=True)
     opt_name_list = [_utils._remove_prefix(s, 'O') for s in opt_name_list]
     if _utils._is_valid_attr(args, 'O'):
+        if ' ' in getattr(args, 'O'):
+            parser.error('Not allowed to have space in the optimization name')
         if not getattr(args, 'O') in opt_name_list:
             parser.error('Invalid optimization option')
 

--- a/compiler/one-cmds/tests/one-build_neg_009.test
+++ b/compiler/one-cmds/tests/one-build_neg_009.test
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Have space in the optimization name
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  if grep -q "Not allowed to have space in the optimization name" "${filename}.log"; then
+    echo "${filename_ext} SUCCESS"
+    exit 0
+  fi
+
+  echo "${filename_ext} FAILED"
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+configfile=".."
+
+# run test
+one-build -C ${configfile} "-O SPACE OPTION" > ${filename}.log 2>&1
+
+echo "${filename_ext} FAILED"
+exit 255

--- a/compiler/one-cmds/utils.py
+++ b/compiler/one-cmds/utils.py
@@ -352,6 +352,8 @@ def _get_optimization_list(get_name=False):
 
     # optimization folder
     files = [f for f in glob.glob(dir_path + '/../optimization/O*.cfg', recursive=True)]
+    # exclude if the name has space
+    files = [s for s in files if not ' ' in s]
 
     opt_list = []
     for cand in files:


### PR DESCRIPTION
This commit excludes optimization names that includes space string.

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>