### PR TITLE
[luci-interpreter] Add reading execution plan annotations.

### DIFF
--- a/compiler/luci-interpreter/src/loader/CMakeLists.txt
+++ b/compiler/luci-interpreter/src/loader/CMakeLists.txt
@@ -22,8 +22,8 @@ target_include_directories(${LUCI_INTERPRETER_LOADER} PUBLIC "${LUCI_INTERPRETER
 target_include_directories(${LUCI_INTERPRETER_LOADER} PUBLIC "${LUCI_INTERPRETER_SOURCE_DIR}")
 
 target_link_libraries(${LUCI_INTERPRETER_LOADER}
-        PUBLIC luci_lang luci_plan ${LUCI_INTERPRETER_CORE}
-        PRIVATE ${LUCI_INTERPRETER_KERNELS} nncc_common)
+        PUBLIC luci_lang ${LUCI_INTERPRETER_CORE}
+        PRIVATE ${LUCI_INTERPRETER_KERNELS} nncc_common luci_plan)
 
 if(NOT ENABLE_TEST)
   return()

--- a/compiler/luci-interpreter/src/loader/CMakeLists.txt
+++ b/compiler/luci-interpreter/src/loader/CMakeLists.txt
@@ -22,7 +22,7 @@ target_include_directories(${LUCI_INTERPRETER_LOADER} PUBLIC "${LUCI_INTERPRETER
 target_include_directories(${LUCI_INTERPRETER_LOADER} PUBLIC "${LUCI_INTERPRETER_SOURCE_DIR}")
 
 target_link_libraries(${LUCI_INTERPRETER_LOADER}
-        PUBLIC luci_lang ${LUCI_INTERPRETER_CORE}
+        PUBLIC luci_lang luci_plan ${LUCI_INTERPRETER_CORE}
         PRIVATE ${LUCI_INTERPRETER_KERNELS} nncc_common)
 
 if(NOT ENABLE_TEST)

--- a/compiler/luci-interpreter/src/loader/GraphLoader.cpp
+++ b/compiler/luci-interpreter/src/loader/GraphLoader.cpp
@@ -17,8 +17,8 @@
 #include "loader/GraphLoader.h"
 
 #include "loader/KernelBuilder.h"
-#include <luci/Plan/CircleNodeExecutionPlan.h>
 
+#include <luci/Plan/CircleNodeExecutionPlan.h>
 #include <loco/IR/Algorithm.h>
 
 namespace luci_interpreter

--- a/compiler/luci-interpreter/src/loader/nodes/Conv2D.cpp
+++ b/compiler/luci-interpreter/src/loader/nodes/Conv2D.cpp
@@ -42,6 +42,7 @@ std::unique_ptr<Kernel> build_kernel_CircleConv2D(const luci::CircleNode *circle
   // If node has execution plan then read memory offsets for im2col temporary tensor
   // from the beginning of shared memory buffer.
   // Used in Static Memory Manager.
+  // TODO move tensors offset initialization to one place
   if (luci::has_execution_plan(node))
   {
     auto memory_plan = luci::get_execution_plan(node);

--- a/compiler/luci-interpreter/src/loader/nodes/Conv2D.cpp
+++ b/compiler/luci-interpreter/src/loader/nodes/Conv2D.cpp
@@ -45,11 +45,11 @@ std::unique_ptr<Kernel> build_kernel_CircleConv2D(const luci::CircleNode *circle
   // TODO move tensors offset initialization to one place
   if (luci::has_execution_plan(node))
   {
-    auto memory_plan = luci::get_execution_plan(node);
+    const auto execution_plan = luci::get_execution_plan(node);
     // Check whether the offset for the current CircleConv2D temporary was found.
-    if (memory_plan.offsets().size() > 1)
+    if (execution_plan.offsets().size() > 1)
       // If this is true, then we keep this offset in im2col.
-      im2col->set_offset(memory_plan.offsets().at(1));
+      im2col->set_offset(execution_plan.offsets().at(1));
   }
   Tensor *tmp = helper.getRuntimeGraph(node->graph())->addTensor(std::move(im2col));
 


### PR DESCRIPTION
This pr adds reading execution plan annotations to luci-interpreter.
Add reading execution order from node annotations in GraphLoader and reading offset also from node annotations for im2col temporary tensor.

issue #7522

ONE-DCO-1.0-Signed-off-by: Artem Balyshev a.balyshev@partner.samsung.com