### PR TITLE
[circle-quantizer] Remove input output dtype option

### DIFF
--- a/compiler/luci/pass/include/luci/CircleOptimizer.h
+++ b/compiler/luci/pass/include/luci/CircleOptimizer.h
@@ -106,9 +106,6 @@ public:
       // convert NCHW to NHWC
       NCHW_to_NHWC_input_shape,
       NCHW_to_NHWC_output_shape,
-
-      Quantize_input_dtype = Quantize_input_model_dtype,   // TODO Remove this
-      Quantize_output_dtype = Quantize_output_model_dtype, // TODO Remove this
     };
 
     virtual ~Options() = default;


### PR DESCRIPTION
This removes unnecessary input/output_dtype options.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: #7832