### PR TITLE
[res] Disable language detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 tests/nnapi/specs/* linguist-detectable=false
+res/* linguist-detectable=false


### PR DESCRIPTION
This commit set linguist-detectable false to skip language detection under res/ directory by github linguist.

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>