### PR TITLE
[one-cmds] Fix one-build_014 test

### DIFF
--- a/compiler/one-cmds/tests/one-build_014.test
+++ b/compiler/one-cmds/tests/one-build_014.test
@@ -65,7 +65,7 @@ fi
 cp OONE-BUILD_014.cfg ../optimization
 
 # run test
-LUCI_LOG=1 one-build -C ${configfile} -OONE-BUILD_014 > ${filename}.log 2>&1
+LUCI_LOG=5 one-build -C ${configfile} -OONE-BUILD_014 > ${filename}.log 2>&1
 
 clean_envir
 


### PR DESCRIPTION
This commit fixes one-build_014 test.

Related: #7891 
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>