### PR TITLE
[infra] Remove remain ARMCompute test build

### DIFF
--- a/infra/nnfw/cmake/packages/ARMComputeConfig.cmake
+++ b/infra/nnfw/cmake/packages/ARMComputeConfig.cmake
@@ -129,6 +129,8 @@ function(_ARMCompute_Build ARMComputeInstall_DIR)
   list(APPEND SCONS_OPTIONS "benchmark_tests=0")
   list(APPEND SCONS_OPTIONS "validation_tests=0")
   list(APPEND SCONS_OPTIONS "benchmark_examples=0")
+  list(APPEND SCONS_OPTIONS "validate_examples=0")
+  list(APPEND SCONS_OPTIONS "reference_openmp=0")
 
   if(DEFINED EXTERNALS_BUILD_THREADS)
     set(N ${EXTERNALS_BUILD_THREADS})


### PR DESCRIPTION
ARMCompute still build some tests. Let's remove remain test build.

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>