### PR TITLE
[luci] Revise logger

### DIFF
--- a/compiler/luci/log/include/luci/Log.h
+++ b/compiler/luci/log/include/luci/Log.h
@@ -48,7 +48,6 @@ public:
 
 private:
   bool _show_warn = true;
-  bool _show_info = false;
   int _show_verbose = 0;
 };
 
@@ -67,8 +66,8 @@ private:
 #define LOGGER(name) ::luci::Logger name{::luci::LoggingContext::get()};
 
 // TODO Support FATAL, ERROR
-#define INFO(name) HERMES_INFO(name)
-#define WARN(name) HERMES_WARN(name)
+#define INFO(name) HERMES_VERBOSE(name, 3)
+#define WARN(name) HERMES_VERBOSE(name, 2)
 #define VERBOSE(name, lv) HERMES_VERBOSE(name, lv)
 
 // WARNING!


### PR DESCRIPTION
This commit revises logger to print proper log message.

From this PR, logger will do like this.
`LUCI_LOG=0` -> print nothing
`LUCI_LOG=1` -> print `FATAL(l)` things
`LUCI_LOG=2` -> print `FATAL(l)` + `ERROR(l)` things
`LUCI_LOG=3` -> print `FATAL(l)` + `ERROR(l)` + `WARN(l)` things
`LUCI_LOG=4` -> print `FATAL(l)` + `ERROR(l)` + `WARN(l)` + `INFO(l)` things

Related: #7893 
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>