### PR TITLE
DRAFT partitioner check FullyConnected with no bias

### DIFF
--- a/compiler/circle-part-value-test/parts/Part_Tanh_FC_nobias.part
+++ b/compiler/circle-part-value-test/parts/Part_Tanh_FC_nobias.part
@@ -1,0 +1,7 @@
+[partition]
+backends=cpu,npu
+default=npu
+comply=opcode
+
+[OPCODE]
+PACK=cpu

--- a/compiler/circle-part-value-test/parts/Part_Tanh_FC_nobias_001.part
+++ b/compiler/circle-part-value-test/parts/Part_Tanh_FC_nobias_001.part
@@ -1,0 +1,7 @@
+[partition]
+backends=cpu,npu
+default=npu
+comply=opcode
+
+[OPCODE]
+TANH=cpu

--- a/compiler/circle-part-value-test/test.lst
+++ b/compiler/circle-part-value-test/test.lst
@@ -35,3 +35,7 @@ add(Part_If_Add_Sub_001 Part_If_Add_Sub_001.001 3)
 # WHILE with subgraphs
 add(Part_While_000 Part_While_000 3)
 add(Part_While_001 Part_While_001 3)
+
+# FC with nobias testing
+add(Part_Tanh_FC_nobias Part_Tanh_FC_nobias 1)
+add(Part_Tanh_FC_nobias Part_Tanh_FC_nobias_001 2)

--- a/compiler/circle-partitioner-test/parts/Part_Tanh_FC_nobias.part
+++ b/compiler/circle-partitioner-test/parts/Part_Tanh_FC_nobias.part
@@ -1,0 +1,7 @@
+[partition]
+backends=cpu,npu
+default=npu
+comply=opcode
+
+[OPCODE]
+PACK=cpu

--- a/compiler/circle-partitioner-test/parts/Part_Tanh_FC_nobias_001.part
+++ b/compiler/circle-partitioner-test/parts/Part_Tanh_FC_nobias_001.part
@@ -1,0 +1,7 @@
+[partition]
+backends=cpu,npu
+default=npu
+comply=opcode
+
+[OPCODE]
+TANH=cpu

--- a/compiler/circle-partitioner-test/test.lst
+++ b/compiler/circle-partitioner-test/test.lst
@@ -5,3 +5,7 @@
 # add(RECIPE_NAME PART_NAME)
 
 add(Net_InstanceNorm_003 Net_InstanceNorm_003)
+
+# FC with nobias testing
+add(Part_Tanh_FC_nobias Part_Tanh_FC_nobias)
+add(Part_Tanh_FC_nobias Part_Tanh_FC_nobias_001)

--- a/compiler/luci/partition/src/PartitionMerge.cpp
+++ b/compiler/luci/partition/src/PartitionMerge.cpp
@@ -58,6 +58,9 @@ bool is_input_same(const luci::PGroup *pgroup, const luci::PGroups *pgroups)
     //         we need to clone this CircleConst for each graph of the group.
     if (dynamic_cast<const luci::CircleConst *>(input) != nullptr)
       continue;
+    // Skip also for OutputExclude
+    if (dynamic_cast<const luci::CircleOutputExclude *>(input) != nullptr)
+      continue;
 
     auto input_group = pgroups->group_of(input);
     // NOTE: all the nodes should be registered and return should be valid group.


### PR DESCRIPTION
On-going draft to check partitioner of FullyConnected with no bias.

Signed-off-by: SaeHie Park <saehie.park@gmail.com>