### PR TITLE
[luci/import] Add VectorWrapper helper struct

### DIFF
--- a/compiler/luci/import/include/luci/Import/CircleReader.h
+++ b/compiler/luci/import/include/luci/Import/CircleReader.h
@@ -54,6 +54,37 @@ luci_quantparam(const circle::QuantizationParametersT *quantization);
 void copy_tensor_attributes(const circle::TensorT &tensor, CircleNode *node);
 
 /**
+ * @brief Wrapper to use flatbuffers::Vector pointer as std::vector entity
+ */
+template <typename T> class VectorWrapper
+{
+public:
+  explicit VectorWrapper(const flatbuffers::Vector<T> *ptr);
+
+  const T *data() const;
+  uint32_t size() const;
+
+  using iterator = typename flatbuffers::Vector<T>::const_iterator;
+  iterator begin() const;
+  iterator end() const;
+
+  using value_type = typename flatbuffers::Vector<T>::return_type;
+  value_type at(uint32_t i) const;
+  value_type operator[](uint32_t i) const;
+
+  bool null() const;
+  bool empty() const;
+
+private:
+  const flatbuffers::Vector<T> *_vector;
+};
+
+template <typename T> VectorWrapper<T> wrap(const flatbuffers::Vector<T> *vec)
+{
+  return VectorWrapper<T>(vec);
+}
+
+/**
  * @brief Loads Circle file and provides helpers to access attributes
  */
 class CircleReader

--- a/compiler/luci/import/src/CircleReader.cpp
+++ b/compiler/luci/import/src/CircleReader.cpp
@@ -350,4 +350,61 @@ bool CircleReader::select_subgraph(uint32_t sgindex)
   return true;
 }
 
+template <typename T>
+VectorWrapper<T>::VectorWrapper(const flatbuffers::Vector<T> *ptr) : _vector(ptr)
+{
+  // Do nothing
+}
+
+template <typename T> uint32_t VectorWrapper<T>::size() const
+{
+  return null() ? 0 : _vector->size();
+}
+
+template <typename T> const T *VectorWrapper<T>::data() const
+{
+  return null() ? nullptr : _vector->data();
+}
+
+template <typename T> typename VectorWrapper<T>::iterator VectorWrapper<T>::begin() const
+{
+  return null() ? iterator(nullptr, 0) : _vector->begin();
+}
+
+template <typename T> typename VectorWrapper<T>::iterator VectorWrapper<T>::end() const
+{
+  return null() ? begin() : _vector->end();
+}
+
+template <typename T> typename VectorWrapper<T>::value_type VectorWrapper<T>::at(uint32_t i) const
+{
+  if (i >= size())
+  {
+    // TODO find better error message
+    throw std::range_error("Access to prohibited vector element");
+  }
+
+  return _vector->Get(i);
+}
+
+template <typename T>
+typename VectorWrapper<T>::value_type VectorWrapper<T>::operator[](uint32_t i) const
+{
+  return at(i);
+}
+
+template <typename T> bool VectorWrapper<T>::null() const { return _vector == nullptr; }
+template <typename T> bool VectorWrapper<T>::empty() const { return size() == 0; }
+
+#define REGISTER_WRAPPER(T) template class VectorWrapper<T>
+REGISTER_WRAPPER(flatbuffers::Offset<circle::SubGraph>);
+REGISTER_WRAPPER(flatbuffers::Offset<circle::Buffer>);
+REGISTER_WRAPPER(flatbuffers::Offset<circle::Tensor>);
+REGISTER_WRAPPER(flatbuffers::Offset<circle::Operator>);
+REGISTER_WRAPPER(flatbuffers::Offset<circle::OperatorCode>);
+REGISTER_WRAPPER(flatbuffers::Offset<circle::Metadata>);
+REGISTER_WRAPPER(int32_t);
+REGISTER_WRAPPER(uint8_t);
+#undef REGISTER_WRAPPER
+
 } // namespace luci

--- a/compiler/luci/import/src/CircleReader.test.cpp
+++ b/compiler/luci/import/src/CircleReader.test.cpp
@@ -32,6 +32,23 @@ TEST(VectorWrapperTest, basic_pattern)
   ASSERT_TRUE(std::equal(wrapper.begin(), wrapper.end(), data.begin()));
 }
 
+TEST(VectorWrapperTest, wrong_data_NEG)
+{
+  auto fb_builder = flatbuffers::FlatBufferBuilder();
+
+  std::vector<int32_t> data = {1, 4, 2, 0, 7};
+  auto const vec_offset = fb_builder.CreateVector(data.data(), data.size());
+  auto const vec_pointer = GetTemporaryPointer(fb_builder, vec_offset);
+
+  auto const wrapper = luci::wrap(vec_pointer);
+
+  // change data
+  std::reverse(data.begin(), data.end());
+
+  ASSERT_EQ(wrapper.size(), data.size());
+  ASSERT_FALSE(std::equal(wrapper.begin(), wrapper.end(), data.begin()));
+}
+
 TEST(VectorWrapperTest, null_pointer)
 {
   flatbuffers::Vector<int32_t> *vec_pointer = nullptr;

--- a/compiler/luci/import/src/CircleReader.test.cpp
+++ b/compiler/luci/import/src/CircleReader.test.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Import/CircleReader.h"
+
+#include <gtest/gtest.h>
+
+TEST(VectorWrapperTest, basic_pattern_P)
+{
+  auto fb_builder = flatbuffers::FlatBufferBuilder();
+
+  const std::vector<int32_t> data = {1, 4, 2, 0, 7};
+  auto const vec_offset = fb_builder.CreateVector(data.data(), data.size());
+  auto const vec_pointer = GetTemporaryPointer(fb_builder, vec_offset);
+  assert(vec_pointer != nullptr);
+
+  auto const wrapper = luci::wrap(vec_pointer);
+
+  ASSERT_EQ(wrapper.size(), data.size());
+  ASSERT_TRUE(std::equal(wrapper.begin(), wrapper.end(), data.begin()));
+}
+
+TEST(VectorWrapperTest, null_pointer_P)
+{
+  flatbuffers::Vector<int32_t> *vec_pointer = nullptr;
+  auto const wrapper = luci::wrap(vec_pointer);
+
+  ASSERT_TRUE(wrapper.null());
+  ASSERT_TRUE(wrapper.empty());
+}
+
+TEST(VectorWrapperTest, prohibited_access_N)
+{
+  flatbuffers::Vector<uint8_t > *vec_pointer = nullptr;
+  auto const wrapper = luci::wrap(vec_pointer);
+
+  ASSERT_ANY_THROW(wrapper.at(0));
+}

--- a/compiler/luci/import/src/CircleReader.test.cpp
+++ b/compiler/luci/import/src/CircleReader.test.cpp
@@ -18,14 +18,13 @@
 
 #include <gtest/gtest.h>
 
-TEST(VectorWrapperTest, basic_pattern_P)
+TEST(VectorWrapperTest, basic_pattern)
 {
   auto fb_builder = flatbuffers::FlatBufferBuilder();
 
   const std::vector<int32_t> data = {1, 4, 2, 0, 7};
   auto const vec_offset = fb_builder.CreateVector(data.data(), data.size());
   auto const vec_pointer = GetTemporaryPointer(fb_builder, vec_offset);
-  assert(vec_pointer != nullptr);
 
   auto const wrapper = luci::wrap(vec_pointer);
 
@@ -33,7 +32,7 @@ TEST(VectorWrapperTest, basic_pattern_P)
   ASSERT_TRUE(std::equal(wrapper.begin(), wrapper.end(), data.begin()));
 }
 
-TEST(VectorWrapperTest, null_pointer_P)
+TEST(VectorWrapperTest, null_pointer)
 {
   flatbuffers::Vector<int32_t> *vec_pointer = nullptr;
   auto const wrapper = luci::wrap(vec_pointer);
@@ -42,7 +41,7 @@ TEST(VectorWrapperTest, null_pointer_P)
   ASSERT_TRUE(wrapper.empty());
 }
 
-TEST(VectorWrapperTest, prohibited_access_N)
+TEST(VectorWrapperTest, prohibited_access_NEG)
 {
   flatbuffers::Vector<uint8_t> *vec_pointer = nullptr;
   auto const wrapper = luci::wrap(vec_pointer);

--- a/compiler/luci/import/src/CircleReader.test.cpp
+++ b/compiler/luci/import/src/CircleReader.test.cpp
@@ -44,7 +44,7 @@ TEST(VectorWrapperTest, null_pointer_P)
 
 TEST(VectorWrapperTest, prohibited_access_N)
 {
-  flatbuffers::Vector<uint8_t > *vec_pointer = nullptr;
+  flatbuffers::Vector<uint8_t> *vec_pointer = nullptr;
   auto const wrapper = luci::wrap(vec_pointer);
 
   ASSERT_ANY_THROW(wrapper.at(0));


### PR DESCRIPTION
This commit adds VectorWrapper struct which helps to use `flatbuffers::Vector<>` from direct-access API.

ONE-DCO-1.0-Signed-off-by: Maksim Bronnikov max120199@gmail.com

---------------------

For: #7886
Draft: #7901