### PR TITLE
[luci/import] Add and rename CircleReader members

### DIFF
--- a/compiler/luci/import/include/luci/Import/CircleReader.h
+++ b/compiler/luci/import/include/luci/Import/CircleReader.h
@@ -97,8 +97,9 @@ private:
   std::unique_ptr<const circle::ModelT> _model;
   const circle::SubGraphT *_current_subgraph{nullptr};
 
-  const circle::Model *_model_ptr{nullptr};
+  const circle::Model *_native_model{nullptr};
   const CircleTensorsPtr_t *_tensors_ptr{nullptr};
+  const circle::SubGraph *_native_subgraph{nullptr};
 };
 
 } // namespace luci

--- a/compiler/luci/import/src/CircleReader.cpp
+++ b/compiler/luci/import/src/CircleReader.cpp
@@ -326,7 +326,7 @@ bool CircleReader::parse(const circle::Model *model)
   _model.reset(model->UnPack());
 
   // for direct pointer access
-  _model_ptr = model;
+  _native_model = model;
 
   return true;
 }
@@ -342,10 +342,13 @@ bool CircleReader::select_subgraph(uint32_t sgindex)
   _current_subgraph = _model->subgraphs[sgindex].get();
 
   // for direct pointer access
-  auto subgraphs = _model_ptr->subgraphs();
-  const circle::SubGraph *subgraph = (*subgraphs)[sgindex];
+  auto subgraphs = _native_model->subgraphs();
+  assert(subgraphs != nullptr);
 
-  _tensors_ptr = subgraph->tensors();
+  _native_subgraph = subgraphs->Get(sgindex);
+  assert(_native_subgraph != nullptr);
+
+  _tensors_ptr = _native_subgraph->tensors();
 
   return true;
 }


### PR DESCRIPTION
This commit adds `_native_subgraph` and renames `_model_ptr` to `_native_model` in order to use them similar to `_model` and `_current_subgraph` members for direct API support.

ONE-DCO-1.0-Signed-off-by: Maksim Bronnikov <max120199@gmail.com>