### PR TITLE
[luci] Support import of partially defined execution plan

### DIFF
--- a/compiler/luci/import/src/CircleImportMetadata.cpp
+++ b/compiler/luci/import/src/CircleImportMetadata.cpp
@@ -156,6 +156,10 @@ decoded_execution_plan(const std::vector<uint8_t> &execution_plan_data)
     idx += sizeof(uint32_t);
 
     uint32_t size = read_u32(execution_plan_data, idx);
+
+    if (size == 0)
+      throw std::runtime_error("Op table decode error : empty execution plan entry");
+
     idx += sizeof(uint32_t);
 
     if (idx + sizeof(uint32_t) * size > execution_plan_data.size())

--- a/compiler/luci/import/src/Importer.cpp
+++ b/compiler/luci/import/src/Importer.cpp
@@ -361,7 +361,12 @@ std::unique_ptr<Module> Importer::importModule(const circle::Model *model) const
     {
       if (auto circle_node = dynamic_cast<luci::CircleNode *>(node))
       {
+        if (execution_plan_table.count(node_position) == 0)
+          continue;
+
         auto node_plan = execution_plan_table[node_position];
+        assert(node_plan.size() > 0);
+
         luci::add_execution_plan(
           circle_node,
           luci::CircleNodeExecutionPlan(


### PR DESCRIPTION
This PR enables import of graphs with with execution plan defined for
subset of operations.

related issue: #7831
for comment: https://github.com/Samsung/ONE/pull/7903#discussion_r740456803
    
ONE-DCO-1.0-Signed-off-by: Alexander Efimov <a.efimov@samsung.com>