### PR TITLE
[luci] Revise eval_verifier

### DIFF
--- a/compiler/luci-value-test/luci_eval_verifier.py
+++ b/compiler/luci-value-test/luci_eval_verifier.py
@@ -57,14 +57,16 @@ subprocess.run(
     check=True)
 
 # Compare the results.
-for idx in range(len(interpreter.get_output_details())):
-    output_details = interpreter.get_output_details()[idx]
+inpt_output_details = interpreter.get_output_details()
+for idx in range(len(inpt_output_details)):
+    output_details = inpt_output_details[idx]
     output_data = np.fromfile(circle_model + ".output" + str(idx),
                               output_details["dtype"])
     shape_file = open(circle_model + ".output" + str(idx) + ".shape", 'r')
     output_shape = [int(i) for i in shape_file.read().split(',')]
     luci_output_data = np.reshape(output_data, output_shape)
-    intp_output_data = interpreter.get_tensor(output_details["index"])
+    output_tensor = output_details["index"]
+    intp_output_data = interpreter.get_tensor(output_tensor)
     try:
         if output_details["dtype"] == np.uint8:
             if np.allclose(luci_output_data, intp_output_data, rtol=0, atol=0) == False:


### PR DESCRIPTION
This will revise luci_eval_verifier python script to use variables.
- this is to prepare next revision to support SignatureDef

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>