### PR TITLE
[luci/import] Use direct access for opcodes

### DIFF
--- a/compiler/luci/import/src/GraphBuilder.cpp
+++ b/compiler/luci/import/src/GraphBuilder.cpp
@@ -30,7 +30,7 @@ CircleNode *GraphBuilder::build(const circle::OperatorT &op, GraphBuilderContext
   const std::vector<int32_t> &inputs = op.inputs;
   const std::vector<int32_t> &outputs = op.outputs;
   const auto &tensors = context->reader()->tensors();
-  const auto &opcodes = context->reader()->opcodes();
+  const auto opcodes = context->reader()->native_opcodes();
   auto tensors_ptr = context->reader()->tensors_ptr();
   assert(tensors_ptr != nullptr);
 
@@ -69,7 +69,8 @@ CircleNode *GraphBuilder::build(const circle::OperatorT &op, GraphBuilderContext
       node->shape_status(ShapeStatus::VALID);
 
     // mark operator version
-    node->op_version(opcodes[op.opcode_index].get()->version);
+    assert(opcodes[op.opcode_index] != nullptr);
+    node->op_version(opcodes[op.opcode_index]->version());
   }
 
   // Register node's only output.

--- a/compiler/luci/import/src/GraphBuilderMultiOutput.cpp
+++ b/compiler/luci/import/src/GraphBuilderMultiOutput.cpp
@@ -31,7 +31,7 @@ CircleNode *GraphBuilderMultiOutput::build(const circle::OperatorT &op,
   const std::vector<int32_t> &inputs = op.inputs;
   const std::vector<int32_t> &outputs = op.outputs;
   const auto &tensors = context->reader()->tensors();
-  const auto &opcodes = context->reader()->opcodes();
+  const auto opcodes = context->reader()->native_opcodes();
   auto tensors_ptr = context->reader()->tensors_ptr();
   assert(tensors_ptr != nullptr);
 
@@ -69,7 +69,8 @@ CircleNode *GraphBuilderMultiOutput::build(const circle::OperatorT &op,
     node->dtype(luci_datatype(output_tensor.type));
 
     // mark operator version
-    node->op_version(opcodes[op.opcode_index].get()->version);
+    assert(opcodes[op.opcode_index] != nullptr);
+    node->op_version(opcodes[op.opcode_index]->version());
 
     // NOTE We don't set quantization for multiple output nodes but to virtual outputs
   }

--- a/compiler/luci/import/src/Nodes/CircleCustom.cpp
+++ b/compiler/luci/import/src/Nodes/CircleCustom.cpp
@@ -39,13 +39,15 @@ CircleNode *CircleCustomGraphBuilder::build_node(const BuildNodeArgs &bna) const
     node->inputs(idx, bna.input_nodes[idx]);
   }
 
-  const auto &opcodes = bna.context->reader()->opcodes();
+  const auto opcodes = bna.context->reader()->native_opcodes();
   const uint32_t opcode_index = bna.op.opcode_index;
-  const circle::OperatorCodeT &opcode = *opcodes[opcode_index];
+  const auto opcode = opcodes[opcode_index];
+  assert(opcode != nullptr);
 
   node->custom_options(
     std::vector<uint8_t>{bna.op.custom_options.begin(), bna.op.custom_options.end()});
-  node->custom_code(opcode.custom_code);
+  assert(opcode->custom_code() != nullptr);
+  node->custom_code(opcode->custom_code()->c_str());
 
   // NOTE Operator version of custom is always 1
 

--- a/compiler/luci/import/src/Nodes/CircleWhile.cpp
+++ b/compiler/luci/import/src/Nodes/CircleWhile.cpp
@@ -68,7 +68,7 @@ CircleNode *CircleWhileGraphBuilder::build(const circle::OperatorT &op,
   const std::vector<int32_t> &inputs = op.inputs;
   const std::vector<int32_t> &outputs = op.outputs;
   const auto &tensors = context->reader()->tensors();
-  const auto &opcodes = context->reader()->opcodes();
+  const auto opcodes = context->reader()->native_opcodes();
 
   std::vector<CircleNode *> input_nodes;
   for (const int32_t input_tensor_index : inputs)
@@ -98,7 +98,8 @@ CircleNode *CircleWhileGraphBuilder::build(const circle::OperatorT &op,
     // Lets use name of output 0 as While name
     const circle::TensorT &output_tensor = *tensors[outputs[0]];
     node->name(tensor_name(output_tensor));
-    node->op_version(opcodes[op.opcode_index].get()->version);
+    assert(opcodes[op.opcode_index] != nullptr);
+    node->op_version(opcodes[op.opcode_index]->version());
 
     // NOTE We don't set quantization for While itself but to virtual outputs
   }


### PR DESCRIPTION
This commit replaces usage of opcodes() to native_opcodes() method.

ONE-DCO-1.0-Signed-off-by: Maksim Bronnikov <max120199@gmail.com>

-----------------

For: #7886
Draft: #7901