### PR TITLE
[luci/import] Fix native_name with nullptr case

### DIFF
--- a/compiler/luci/import/include/luci/Import/CircleReader.h
+++ b/compiler/luci/import/include/luci/Import/CircleReader.h
@@ -65,6 +65,8 @@ luci_quantparam(const circle::QuantizationParameters *quantization);
 void copy_tensor_attributes(const circle::TensorT &tensor, CircleNode *node);
 void copy_tensor_attributes(const circle::Tensor *tensor, CircleNode *node);
 
+std::string fb_string2std_string(const flatbuffers::String *fb_str);
+
 /**
  * @brief Wrapper to use flatbuffers::Vector pointer as std::vector entity
  */
@@ -146,7 +148,7 @@ public: // direct API
   CircleOperators native_operators() const { return wrap(_native_subgraph->operators()); }
   VectorWrapper<int32_t> native_inputs() const { return wrap(_native_subgraph->inputs()); }
   VectorWrapper<int32_t> native_outputs() const { return wrap(_native_subgraph->outputs()); }
-  std::string native_name() const { return _native_subgraph->name()->str(); }
+  std::string native_name() const { return fb_string2std_string(_native_subgraph->name()); }
   circle::DataFormat native_data_format() const { return _native_subgraph->data_format(); }
   CircleMetadataSet native_metadata() const { return wrap(_native_model->metadata()); }
 

--- a/compiler/luci/import/src/CircleReader.cpp
+++ b/compiler/luci/import/src/CircleReader.cpp
@@ -408,6 +408,11 @@ void copy_tensor_attributes(const circle::Tensor *tensor, CircleNode *node)
   }
 }
 
+std::string fb_string2std_string(const flatbuffers::String *fb_str)
+{
+  return fb_str == nullptr ? "" : fb_str->str();
+}
+
 circle::BuiltinOperator CircleReader::builtin_code(const circle::OperatorT &op) const
 {
   const auto &op_codes = opcodes();


### PR DESCRIPTION
This commit fixes native_name methods in case of nullptr subgraph's name.

ONE-DCO-1.0-Signed-off-by: Maksim Bronnikov <max120199@gmail.com>

----------

Fix for importer tests.