### PR TITLE
[res] Add Part_Split_Add_000 recipe

### DIFF
--- a/res/TensorFlowLiteRecipes/Part_Split_Add_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/Part_Split_Add_000/test.recipe
@@ -1,0 +1,47 @@
+operand {
+  name: "ifm"
+  type: FLOAT32
+  shape { dim: 6 dim: 1 dim: 2 }
+}
+operand {
+  name: "split_dim"
+  type: INT32
+  shape { }
+  filler { tag: "explicit" arg: "0" }
+}
+operand {
+  name: "split1"
+  type: FLOAT32
+  shape { dim: 3 dim: 1 dim: 2 }
+}
+operand {
+  name: "split2"
+  type: FLOAT32
+  shape { dim: 3 dim: 1 dim: 2 }
+}
+operand {
+  name: "ofm"
+  type: FLOAT32
+  shape { dim: 3 dim: 1 dim: 2 }
+}
+operation {
+  type: "Split"
+  split_options {
+    num_splits: 2
+  }
+  input: "split_dim"
+  input: "ifm"
+  output: "split1"
+  output: "split2"
+}
+operation {
+  type: "Add"
+  input: "split1"
+  input: "split2"
+  output: "ofm"
+  add_options {
+    activation: NONE
+  }
+}
+input: "ifm"
+output: "ofm"


### PR DESCRIPTION
This will add Part_Split_Add_000 tflite recipe for partitioning of
multiple output nodes.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>