### PR TITLE
[circle-partitioner] Value tests of multi-output nodes

### DIFF
--- a/compiler/circle-part-value-test/parts/Net_UnpackAdd_001.001.part
+++ b/compiler/circle-part-value-test/parts/Net_UnpackAdd_001.001.part
@@ -1,0 +1,7 @@
+[partition]
+backends=cpu,npu
+default=cpu
+comply=opcode
+
+[OPCODE]
+ADD=npu

--- a/compiler/circle-part-value-test/parts/Net_UnpackAdd_001.002.part
+++ b/compiler/circle-part-value-test/parts/Net_UnpackAdd_001.002.part
@@ -1,0 +1,7 @@
+[partition]
+backends=cpu,npu
+default=cpu
+comply=opcode
+
+[OPCODE]
+UNPACK=npu

--- a/compiler/circle-part-value-test/parts/Net_UnpackAdd_001.part
+++ b/compiler/circle-part-value-test/parts/Net_UnpackAdd_001.part
@@ -1,0 +1,7 @@
+[partition]
+backends=cpu,npu
+default=npu
+comply=opcode
+
+[OPCODE]
+UNPACK=cpu

--- a/compiler/circle-part-value-test/parts/Part_Split_Add_000.part
+++ b/compiler/circle-part-value-test/parts/Part_Split_Add_000.part
@@ -1,0 +1,7 @@
+[partition]
+backends=cpu,npu
+default=npu
+comply=opcode
+
+[OPCODE]
+SPLIT=cpu

--- a/compiler/circle-part-value-test/test.lst
+++ b/compiler/circle-part-value-test/test.lst
@@ -35,3 +35,11 @@ add(Part_If_Add_Sub_001 Part_If_Add_Sub_001.001 3)
 # WHILE with subgraphs
 add(Part_While_000 Part_While_000 3)
 add(Part_While_001 Part_While_001 3)
+
+# UNPACK with multiple outputs
+add(Net_UnpackAdd_001 Net_UnpackAdd_001 2)
+add(Net_UnpackAdd_001 Net_UnpackAdd_001.001 2)
+add(Net_UnpackAdd_001 Net_UnpackAdd_001.002 2)
+
+# Other multiple outputs
+add(Part_Split_Add_000 Part_Split_Add_000 2)


### PR DESCRIPTION
This will enable circle-partitioner value testing of multi-output node types.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>