### PR TITLE
[res] PyTorch examples for spatial block rearrangement operations

### DIFF
--- a/res/PyTorchExamples/examples/BatchToSpaceND/__init__.py
+++ b/res/PyTorchExamples/examples/BatchToSpaceND/__init__.py
@@ -1,0 +1,49 @@
+import torch
+import torch.nn as nn
+import numpy as np
+
+
+# model equivalent to tensorflow batch_to_space, but with channels first layout
+class net_BatchToSpaceND(nn.Module):
+    def __init__(self, block_shape, crop):
+        super().__init__()
+        self.block_shape = block_shape
+        self.crop = crop
+
+    def forward(self, input):
+        # Prepare attributes
+        input_shape = list(map(int, list(input.shape)))
+        block_shape = self.block_shape
+        crop = self.crop
+
+        # number of spatial dimensions
+        m = len(block_shape)
+        # rest of dimensions
+        n = len(input.shape) - m
+        # output batch size
+        batch_size = input_shape[0] // np.product(block_shape)
+
+        unfolded_shape = list(block_shape) + [batch_size] + input_shape[1:]
+        fold_shape = [batch_size] + input_shape[1:n] + [
+            input_shape[i + n] * block_shape[i] for i in range(m)
+        ]
+        permute_dims = list(range(
+            m, m + n)) + [i + mod for i in range(m) for mod in [n + m, 0]]
+
+        # Actual model starts here
+        unfolded_input = input.reshape(unfolded_shape)
+        permuted = torch.permute(unfolded_input, permute_dims)
+        full_output = permuted.reshape(fold_shape)
+        # crop output tensor
+        crop_output = full_output
+        for i in range(m):
+            crop_size = sum(crop[i])
+            crop_output = crop_output.narrow(i + n, crop[i][0],
+                                             fold_shape[i + n] - crop_size)
+        return crop_output
+
+
+_model_ = net_BatchToSpaceND([2, 2], [[1, 0], [0, 1]])
+
+# dummy input for onnx generation
+_dummy_ = torch.randn(8, 4, 3, 3)

--- a/res/PyTorchExamples/examples/PixelShuffle/__init__.py
+++ b/res/PyTorchExamples/examples/PixelShuffle/__init__.py
@@ -1,0 +1,18 @@
+import torch
+import torch.nn as nn
+
+
+# model
+class net_PixelShuffle(nn.Module):
+    def __init__(self, upscale_factor):
+        super().__init__()
+        self.op = torch.nn.PixelShuffle(upscale_factor)
+
+    def forward(self, input):
+        return self.op(input)
+
+
+_model_ = net_PixelShuffle(2)
+
+# dummy input for onnx generation
+_dummy_ = torch.randn(1, 8, 3, 3)

--- a/res/PyTorchExamples/examples/SpaceToBatchND/__init__.py
+++ b/res/PyTorchExamples/examples/SpaceToBatchND/__init__.py
@@ -1,0 +1,52 @@
+import torch
+import torch.nn as nn
+import numpy as np
+
+
+# model equivalent to tensorflow space_to_batch, but with channels first layout
+class net_SpaceToBatchND(nn.Module):
+    def __init__(self, block_shape, pad):
+        super().__init__()
+        self.block_shape = block_shape
+        self.pad = pad
+
+    def forward(self, input):
+        # Prepare attributes
+        input_shape = list(map(int, list(input.shape)))
+        block_shape = self.block_shape
+        pad = self.pad
+
+        # number of spatial dimensions
+        m = len(block_shape)
+        # rest of dimensions
+        n = len(input.shape) - m
+        print(pad)
+        # output batch size
+        batch_size = input_shape[0]
+
+        out_spatial_dim = [
+            (input_shape[i + n] + pad[i * 2] + pad[i * 2 + 1]) // block_shape[i]
+            for i in range(m)
+        ]
+        unfolded_shape = [batch_size] + input_shape[1:n] + [
+            dim for i in range(m) for dim in [out_spatial_dim[i], block_shape[i]]
+        ]
+        fold_shape = [batch_size * np.prod(block_shape)
+                      ] + input_shape[1:n] + out_spatial_dim
+        permute_dims = list(range(n + 1, n + 2 * m, 2)) + list(range(n)) + list(
+            range(n, n + 2 * m, 2))
+
+        # Actual model starts here
+        padded_input = torch.nn.functional.pad(input, pad)
+        print(input.shape)
+        print(padded_input.shape)
+        unfolded_input = padded_input.reshape(unfolded_shape)
+        permuted = torch.permute(unfolded_input, permute_dims)
+        output = permuted.reshape(fold_shape)
+        return output
+
+
+_model_ = net_SpaceToBatchND([2, 2], [1, 0, 0, 1])
+
+# dummy input for onnx generation
+_dummy_ = torch.randn(2, 4, 5, 5)

--- a/res/PyTorchExamples/examples/SpaceToDepth/__init__.py
+++ b/res/PyTorchExamples/examples/SpaceToDepth/__init__.py
@@ -1,0 +1,30 @@
+import torch
+import torch.nn as nn
+import numpy as np
+
+
+# model, equivalent to torch.pixel_unshuffle from torch 1.9+
+class net_SpaceToDepth(nn.Module):
+    def __init__(self, block_size):
+        super().__init__()
+        self.block_size = block_size
+
+    def forward(self, input):
+        # Prepare attributes
+        b_size = self.block_size
+        batch, input_c, input_h, input_w = list(map(int, list(input.shape)))
+        out_c = input_c * b_size * b_size
+        out_h = input_h // b_size
+        out_w = input_w // b_size
+
+        # Actual model starts here
+        x = input.reshape(batch, input_c, out_h, b_size, out_w, b_size)
+        x = x.permute([0, 1, 3, 5, 2, 4])
+        x = x.reshape([batch, out_c, out_h, out_w])
+        return x
+
+
+_model_ = net_SpaceToDepth(2)
+
+# dummy input for onnx generation
+_dummy_ = torch.randn(1, 2, 6, 6)


### PR DESCRIPTION
This PR adds examples:
- BatchToSpaceND
- SpaceToBatchND
- PixelShuffle (DepthToSpace)
- SpaceToDepth

Related issue:  #7939 

ONE-DCO-1.0-Signed-off-by: Alexander Efimov <a.efimov@samsung.com>