### PR TITLE
[circle-partition] Value test with SignatureDef

### DIFF
--- a/compiler/circle-part-value-test/parts/SignatureDef_MultiOut_000.part
+++ b/compiler/circle-part-value-test/parts/SignatureDef_MultiOut_000.part
@@ -1,0 +1,7 @@
+[partition]
+backends=cpu,acl_cl
+default=cpu
+comply=opcode
+
+[OPCODE]
+MAXIMUM=acl_cl

--- a/compiler/circle-part-value-test/parts/SignatureDef_MultiOut_001.part
+++ b/compiler/circle-part-value-test/parts/SignatureDef_MultiOut_001.part
@@ -1,0 +1,7 @@
+[partition]
+backends=cpu,acl_cl
+default=cpu
+comply=opcode
+
+[OPCODE]
+MAXIMUM=acl_cl

--- a/compiler/circle-part-value-test/test.lst
+++ b/compiler/circle-part-value-test/test.lst
@@ -43,3 +43,7 @@ add(Net_UnpackAdd_001 Net_UnpackAdd_001.002 2)
 
 # Other multiple outputs
 add(Part_Split_Add_000 Part_Split_Add_000 2)
+
+# test SignatureDef, with any OPCODE
+add(SignatureDef_MultiOut_000 SignatureDef_MultiOut_000 0)
+add(SignatureDef_MultiOut_001 SignatureDef_MultiOut_001 0)


### PR DESCRIPTION
This will enable value test with SignatureDef with multiple outputs.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>