### PR TITLE
[res] MaxPool2d with argmax for PyTorch Examples

### DIFF
--- a/res/PyTorchExamples/examples/MaxPool2d-am/__init__.py
+++ b/res/PyTorchExamples/examples/MaxPool2d-am/__init__.py
@@ -1,0 +1,18 @@
+import torch
+import torch.nn as nn
+
+
+# model
+class net_MaxPool2d(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.op = nn.MaxPool2d(3, stride=1, return_indices=True)
+
+    def forward(self, input):
+        return self.op(input)
+
+
+_model_ = net_MaxPool2d()
+
+# dummy input for onnx generation
+_dummy_ = torch.randn(1, 2, 4, 4)


### PR DESCRIPTION
This PR adds MaxPool2d with indeces output in PyTorch examples.

Related issue: #7939 

ONE-DCO-1.0-Signed-off-by: Alexander Efimov <a.efimov@samsung.com>