### PR TITLE
[luci/import] Use direct tensors from ReduceAny to Reverse

### DIFF
--- a/compiler/luci/import/src/Nodes/CircleReduceAny.cpp
+++ b/compiler/luci/import/src/Nodes/CircleReduceAny.cpp
@@ -28,17 +28,20 @@ bool CircleReduceAnyGraphBuilder::validate(const ValidateArgs &args) const
 
   const auto &inputs = args.op.inputs;
   const auto &outputs = args.op.outputs;
-  const auto &tensors = args.reader.tensors();
-  const auto &tensor_0 = tensors.at(inputs.at(0));
-  const auto &tensor_1 = tensors.at(inputs.at(1));
-  const auto &tensor_o = tensors.at(outputs[0]);
+  const auto tensors = args.reader.native_tensors();
+  const auto tensor_0 = tensors.at(inputs.at(0));
+  const auto tensor_1 = tensors.at(inputs.at(1));
+  const auto tensor_o = tensors.at(outputs[0]);
+  assert(tensor_0 != nullptr);
+  assert(tensor_1 != nullptr);
+  assert(tensor_o != nullptr);
 
-  if (tensor_0->type != circle::TensorType_BOOL)
+  if (tensor_0->type() != circle::TensorType_BOOL)
     return false;
-  if (tensor_o->type != circle::TensorType_BOOL)
+  if (tensor_o->type() != circle::TensorType_BOOL)
     return false;
 
-  switch (tensor_1->type)
+  switch (tensor_1->type())
   {
     case circle::TensorType_INT32:
     case circle::TensorType_INT64:

--- a/compiler/luci/import/src/Nodes/CircleReduceProd.cpp
+++ b/compiler/luci/import/src/Nodes/CircleReduceProd.cpp
@@ -27,13 +27,14 @@ bool CircleReduceProdGraphBuilder::validate(const ValidateArgs &args) const
     return false;
 
   const auto &inputs = args.op.inputs;
-  const auto &tensors = args.reader.tensors();
-  const auto &tensor_1 = tensors.at(inputs.at(1));
+  const auto tensors = args.reader.native_tensors();
+  const auto tensor_1 = tensors.at(inputs.at(1));
+  assert(tensor_1 != nullptr);
 
   // TODO check input types
 
   // Check for reduction_indices types
-  switch (tensor_1->type)
+  switch (tensor_1->type())
   {
     case circle::TensorType_INT32:
     case circle::TensorType_INT64:

--- a/compiler/luci/import/src/Nodes/CircleReshape.cpp
+++ b/compiler/luci/import/src/Nodes/CircleReshape.cpp
@@ -34,12 +34,13 @@ bool CircleReshapeGraphBuilder::validate(const ValidateArgs &args) const
   if (args.op.inputs.size() == 2)
   {
     const auto &inputs = args.op.inputs;
-    const auto &tensors = args.reader.tensors();
-    const auto &tensor_in = tensors.at(inputs.at(1));
+    const auto tensors = args.reader.native_tensors();
+    const auto tensor_in = tensors.at(inputs.at(1));
+    assert(tensor_in != nullptr);
 
     // NOTE fix this if there is any other case
     // TensorFlow lite and circle only supports S32
-    if (tensor_in->type != circle::TensorType::TensorType_INT32)
+    if (tensor_in->type() != circle::TensorType::TensorType_INT32)
       return false;
   }
 

--- a/compiler/luci/import/src/Nodes/CircleReverseSequence.cpp
+++ b/compiler/luci/import/src/Nodes/CircleReverseSequence.cpp
@@ -30,12 +30,15 @@ bool CircleReverseSequenceGraphBuilder::validate(const ValidateArgs &args) const
 
   const auto &inputs = args.op.inputs;
   const auto &outputs = args.op.outputs;
-  const auto &tensors = args.reader.tensors();
-  const auto &tensor_in = tensors.at(inputs.at(0));
-  const auto &tensor_lengths = tensors.at(inputs.at(1));
-  const auto &tensor_out = tensors.at(outputs[0]);
+  const auto tensors = args.reader.native_tensors();
+  const auto tensor_in = tensors.at(inputs.at(0));
+  const auto tensor_lengths = tensors.at(inputs.at(1));
+  const auto tensor_out = tensors.at(outputs[0]);
+  assert(tensor_in != nullptr);
+  assert(tensor_lengths != nullptr);
+  assert(tensor_out != nullptr);
 
-  switch (tensor_lengths->type)
+  switch (tensor_lengths->type())
   {
     case circle::TensorType_INT32:
     case circle::TensorType_INT64:
@@ -44,7 +47,7 @@ bool CircleReverseSequenceGraphBuilder::validate(const ValidateArgs &args) const
       return false;
   }
 
-  if (tensor_in->type != tensor_out->type)
+  if (tensor_in->type() != tensor_out->type())
     return false;
 
   return true;

--- a/compiler/luci/import/src/Nodes/CircleReverseV2.cpp
+++ b/compiler/luci/import/src/Nodes/CircleReverseV2.cpp
@@ -30,12 +30,15 @@ bool CircleReverseV2GraphBuilder::validate(const ValidateArgs &args) const
 
   const auto &inputs = args.op.inputs;
   const auto &outputs = args.op.outputs;
-  const auto &tensors = args.reader.tensors();
-  const auto &tensor_in = tensors.at(inputs.at(0));
-  const auto &tensor_axis = tensors.at(inputs.at(1));
-  const auto &tensor_out = tensors.at(outputs[0]);
+  const auto tensors = args.reader.native_tensors();
+  const auto tensor_in = tensors.at(inputs.at(0));
+  const auto tensor_axis = tensors.at(inputs.at(1));
+  const auto tensor_out = tensors.at(outputs[0]);
+  assert(tensor_in != nullptr);
+  assert(tensor_axis != nullptr);
+  assert(tensor_out != nullptr);
 
-  switch (tensor_axis->type)
+  switch (tensor_axis->type())
   {
     case circle::TensorType_INT32:
     case circle::TensorType_INT64:
@@ -44,7 +47,7 @@ bool CircleReverseV2GraphBuilder::validate(const ValidateArgs &args) const
       return false;
   }
 
-  if (tensor_out->type != tensor_in->type)
+  if (tensor_out->type() != tensor_in->type())
     return false;
 
   return true;


### PR DESCRIPTION
This commit replaces tensors() to native_tensors() in all builders from `CircleReduceAny` to `CircleReverseV2`.

ONE-DCO-1.0-Signed-off-by: Maksim Bronnikov <max120199@gmail.com>

--------------

For: #7886
Draft: #7901