### PR TITLE
[res] interpolate PyTorch example

### DIFF
--- a/res/PyTorchExamples/examples/interpolate/__init__.py
+++ b/res/PyTorchExamples/examples/interpolate/__init__.py
@@ -1,0 +1,23 @@
+import torch
+import torch.nn as nn
+
+
+# model
+class net_interpolate(nn.Module):
+    def __init__(self, scale_factor):
+        super().__init__()
+        self.scale_factor = scale_factor
+
+    def forward(self, input):
+        return torch.nn.functional.interpolate(
+            input,
+            scale_factor=self.scale_factor,
+            mode='bilinear',
+            align_corners=True,
+            recompute_scale_factor=True)
+
+
+_model_ = net_interpolate([2, 2])
+
+# dummy input for onnx generation
+_dummy_ = torch.randn(1, 2, 3, 3)

--- a/res/PyTorchExamples/examples/interpolate/__init__.py
+++ b/res/PyTorchExamples/examples/interpolate/__init__.py
@@ -16,6 +16,9 @@ class net_interpolate(nn.Module):
             align_corners=True,
             recompute_scale_factor=True)
 
+    def onnx_opset_version(self):
+        return 11
+
 
 _model_ = net_interpolate([2, 2])
 

--- a/res/PyTorchExamples/examples/interpolate/__init__.py
+++ b/res/PyTorchExamples/examples/interpolate/__init__.py
@@ -3,6 +3,10 @@ import torch.nn as nn
 
 
 # model
+#
+# Notes:
+# - This operation requires minimum 11 onnx opset version
+# - tf_onnx 1.9 fails to convert this model using opcode version 13+, because unsqueeze operation is not supported yet
 class net_interpolate(nn.Module):
     def __init__(self, scale_factor):
         super().__init__()


### PR DESCRIPTION
This PR adds interpolate PyTorch example with bilinear mode.

Related issue: #7939 

ONE-DCO-1.0-Signed-off-by: Alexander Efimov <a.efimov@samsung.com>