### PR TITLE
[luci/import] Use direct tensors from TransposeConv to While

### DIFF
--- a/compiler/luci/import/src/Nodes/CircleTransposeConv.cpp
+++ b/compiler/luci/import/src/Nodes/CircleTransposeConv.cpp
@@ -31,11 +31,13 @@ bool CircleTransposeConvGraphBuilder::validate(const ValidateArgs &args) const
     return false;
 
   const auto &inputs = args.op.inputs;
-  const auto &tensors = args.reader.tensors();
-  const auto &filter_tensor = tensors.at(inputs.at(1));
-  const auto &filter_shape = filter_tensor.get()->shape;
-  const auto &ifm_tensor = tensors.at(inputs.at(2));
-  const auto &ifm_shape = ifm_tensor.get()->shape;
+  const auto tensors = args.reader.native_tensors();
+  const auto filter_tensor = tensors.at(inputs.at(1));
+  assert(filter_tensor != nullptr);
+  const auto filter_shape = wrap(filter_tensor->shape());
+  const auto ifm_tensor = tensors.at(inputs.at(2));
+  assert(ifm_tensor != nullptr);
+  const auto ifm_shape = wrap(ifm_tensor->shape());
 
   // ifm and filters must be 4-D tensor
   if (ifm_shape.size() != 4)
@@ -45,7 +47,7 @@ bool CircleTransposeConvGraphBuilder::validate(const ValidateArgs &args) const
 
   // input shape : [batch, height, width, in_channels]
   // filters shape : [output_channels, height, weight, in_channels]
-  if (ifm_tensor.get()->shape.at(3) != filter_tensor.get()->shape.at(3))
+  if (ifm_shape.at(3) != filter_shape.at(3))
     return false;
 
   return true;

--- a/compiler/luci/import/src/Nodes/CircleUnpack.cpp
+++ b/compiler/luci/import/src/Nodes/CircleUnpack.cpp
@@ -46,8 +46,8 @@ bool CircleUnpackGraphBuilder::validate(const ValidateArgs &args) const
   {
     if (settings->get(luci::UserSettings::Key::DisableValidation))
     {
-      const auto &tensors = args.reader.tensors();
-      const circle::TensorT &output_tensor = *tensors[outputs[0]];
+      const auto tensors = args.reader.native_tensors();
+      const auto output_tensor = tensors[outputs[0]];
       auto name = tensor_name(output_tensor);
       WARN(l) << "Warning: import Unpack(" << name << ") 'num' is not same as outputs used";
     }
@@ -58,9 +58,10 @@ bool CircleUnpackGraphBuilder::validate(const ValidateArgs &args) const
   if (options->num < 0)
     return false;
 
-  const auto &tensors = args.reader.tensors();
-  const auto &tensor = tensors.at(inputs.at(0));
-  const auto &shape = tensor->shape;
+  const auto tensors = args.reader.native_tensors();
+  const auto tensor = tensors.at(inputs.at(0));
+  assert(tensor != nullptr);
+  const auto shape = wrap(tensor->shape());
   auto shape_size = static_cast<int32_t>(shape.size());
   if (shape_size > 0)
   {

--- a/compiler/luci/import/src/Nodes/CircleWhere.cpp
+++ b/compiler/luci/import/src/Nodes/CircleWhere.cpp
@@ -30,14 +30,16 @@ bool CircleWhereGraphBuilder::validate(const ValidateArgs &args) const
 
   const auto &inputs = args.op.inputs;
   const auto &outputs = args.op.outputs;
-  const auto &tensors = args.reader.tensors();
-  const auto &tensor_condition = tensors.at(inputs.at(0));
-  const auto &tensor_out = tensors.at(outputs[0]);
+  const auto tensors = args.reader.native_tensors();
+  const auto tensor_condition = tensors.at(inputs.at(0));
+  const auto tensor_out = tensors.at(outputs[0]);
+  assert(tensor_condition != nullptr);
+  assert(tensor_out != nullptr);
 
-  if (tensor_condition->type != circle::TensorType_BOOL)
+  if (tensor_condition->type() != circle::TensorType_BOOL)
     return false;
 
-  if (tensor_out->type != circle::TensorType_INT64)
+  if (tensor_out->type() != circle::TensorType_INT64)
     return false;
 
   return true;

--- a/compiler/luci/import/src/Nodes/CircleWhile.cpp
+++ b/compiler/luci/import/src/Nodes/CircleWhile.cpp
@@ -67,7 +67,7 @@ CircleNode *CircleWhileGraphBuilder::build(const circle::OperatorT &op,
 
   const std::vector<int32_t> &inputs = op.inputs;
   const std::vector<int32_t> &outputs = op.outputs;
-  const auto &tensors = context->reader()->tensors();
+  const auto tensors = context->reader()->native_tensors();
   const auto opcodes = context->reader()->native_opcodes();
 
   std::vector<CircleNode *> input_nodes;
@@ -96,7 +96,8 @@ CircleNode *CircleWhileGraphBuilder::build(const circle::OperatorT &op,
   assert(outputs.size() > 0);
   {
     // Lets use name of output 0 as While name
-    const circle::TensorT &output_tensor = *tensors[outputs[0]];
+    const auto output_tensor = tensors[outputs[0]];
+    assert(output_tensor != nullptr);
     node->name(tensor_name(output_tensor));
     assert(opcodes[op.opcode_index] != nullptr);
     node->op_version(opcodes[op.opcode_index]->version());
@@ -107,7 +108,8 @@ CircleNode *CircleWhileGraphBuilder::build(const circle::OperatorT &op,
   // Create virtual outputs of While
   for (uint32_t n = 0; n < output_count; ++n)
   {
-    const circle::TensorT &output_tensor = *tensors[outputs[n]];
+    const auto output_tensor = tensors[outputs[n]];
+    assert(output_tensor != nullptr);
 
     auto *nodeout = graph->nodes()->create<CircleWhileOut>();
 


### PR DESCRIPTION
This commit replaces tensors() to native_tensors() in all builders from `CircleTransposeConv` to `CircleWhile`.

ONE-DCO-1.0-Signed-off-by: Maksim Bronnikov <max120199@gmail.com>

---------------

For: #7886
Draft: #7901