### PR TITLE
[luci/import] Remove tensors_ptr from CircleReader

### DIFF
--- a/compiler/luci/import/include/luci/Import/CircleReader.h
+++ b/compiler/luci/import/include/luci/Import/CircleReader.h
@@ -117,9 +117,6 @@ private: // direct API
   using CircleOperatorCodes = VectorWrapper<flatbuffers::Offset<circle::OperatorCode>>;
   using CircleMetadataSet = VectorWrapper<flatbuffers::Offset<circle::Metadata>>;
 
-  using CircleSubGraphsPtr_t = flatbuffers::Vector<flatbuffers::Offset<circle::SubGraph>>;
-  using CircleTensorsPtr_t = flatbuffers::Vector<flatbuffers::Offset<circle::Tensor>>;
-
 public:
   CircleReader() = default;
 
@@ -133,8 +130,6 @@ public: // unpack API
   const std::string &name() const { return _current_subgraph->name; }
   const circle::DataFormat &data_format() const { return _current_subgraph->data_format; }
   const CircleMetadata_t &metadata() const { return _model->metadata; }
-
-  const CircleTensorsPtr_t *tensors_ptr() const { return _tensors_ptr; }
 
   uint32_t num_subgraph() const { return _model->subgraphs.size(); }
 
@@ -164,7 +159,6 @@ private:
   const circle::SubGraphT *_current_subgraph{nullptr};
 
   const circle::Model *_native_model{nullptr};
-  const CircleTensorsPtr_t *_tensors_ptr{nullptr};
   const circle::SubGraph *_native_subgraph{nullptr};
 };
 

--- a/compiler/luci/import/src/CircleReader.cpp
+++ b/compiler/luci/import/src/CircleReader.cpp
@@ -501,8 +501,6 @@ bool CircleReader::select_subgraph(uint32_t sgindex)
   _native_subgraph = subgraphs->Get(sgindex);
   assert(_native_subgraph != nullptr);
 
-  _tensors_ptr = _native_subgraph->tensors();
-
   return true;
 }
 


### PR DESCRIPTION
This commit removes `tensors_ptr` from CircleReader with related type aliases.

ONE-DCO-1.0-Signed-off-by: Maksim Bronnikov <max120199@gmail.com>

-------------------

For: #7886
Draft: #7901