### PR TITLE
[luci/import] Use direct access for buffers

### DIFF
--- a/compiler/luci/import/src/CircleImportMetadata.cpp
+++ b/compiler/luci/import/src/CircleImportMetadata.cpp
@@ -21,8 +21,10 @@
 namespace
 {
 
-uint32_t read_u32(const std::vector<uint8_t> &buffer, uint32_t idx)
+template <typename VECTORTYPE> uint32_t read_u32(const VECTORTYPE &buffer, uint32_t idx)
 {
+  static_assert(std::is_same<typename VECTORTYPE::value_type, uint8_t>::value, "Types mismatch!");
+
   uint32_t val = 0;
   val += (buffer.at(idx + 0) << 0 * 8);
   val += (buffer.at(idx + 1) << 1 * 8);
@@ -37,9 +39,11 @@ namespace
 {
 
 // 'source_table' is decoded to std::map<uint32_t, std::string> format.
-const std::map<uint32_t, std::string>
-decoded_source_table(const std::vector<uint8_t> &source_table_data)
+template <typename VECTORTYPE>
+const std::map<uint32_t, std::string> decoded_source_table(const VECTORTYPE &source_table_data)
 {
+  static_assert(std::is_same<typename VECTORTYPE::value_type, uint8_t>::value, "Types mismatch!");
+
   std::map<uint32_t, std::string> source_id_name_map;
   uint32_t idx = 0;
 
@@ -86,9 +90,11 @@ decoded_source_table(const std::vector<uint8_t> &source_table_data)
 }
 
 // 'op_table' is decoded to std::map<uint32_t, std::set<uint32_t>> format.
-const std::map<uint32_t, std::set<uint32_t>>
-decoded_op_table(const std::vector<uint8_t> &op_table_data)
+template <typename VECTORTYPE>
+const std::map<uint32_t, std::set<uint32_t>> decoded_op_table(const VECTORTYPE &op_table_data)
 {
+  static_assert(std::is_same<typename VECTORTYPE::value_type, uint8_t>::value, "Types mismatch!");
+
   std::map<uint32_t, std::set<uint32_t>> node_source_ids_map;
   uint32_t idx = 0;
 
@@ -135,9 +141,11 @@ decoded_op_table(const std::vector<uint8_t> &op_table_data)
 }
 
 // 'execution_plan_table' is decoded to std::map<uint32_t, std::vector<uint32_t>> format.
-const luci::ExecutionPlanTable
-decoded_execution_plan(const std::vector<uint8_t> &execution_plan_data)
+template <typename VECTORTYPE>
+const luci::ExecutionPlanTable decoded_execution_plan(const VECTORTYPE &execution_plan_data)
 {
+  static_assert(std::is_same<typename VECTORTYPE::value_type, uint8_t>::value, "Types mismatch!");
+
   luci::ExecutionPlanTable execution_plan_table;
   uint32_t idx = 0;
 
@@ -200,8 +208,9 @@ CircleImportMetadata::CircleImportMetadata(const luci::CircleReader &reader)
     const auto *meta = metadata[i];
     assert(meta != nullptr);
 
-    assert(meta->buffer() < reader.buffers().size());
-    const std::vector<uint8_t> &buffer = reader.buffers()[meta->buffer()]->data;
+    assert(meta->buffer() < reader.native_buffers().size());
+    assert(reader.native_buffers()[meta->buffer()] != nullptr);
+    const auto buffer = luci::wrap(reader.native_buffers()[meta->buffer()]->data());
 
     assert(meta->name() != nullptr);
     if (meta->name()->str().compare("ONE_op_table") == 0)

--- a/compiler/luci/import/src/Nodes/CircleConst.cpp
+++ b/compiler/luci/import/src/Nodes/CircleConst.cpp
@@ -46,7 +46,8 @@ std::ostream &operator<<(std::ostream &os, const luci::VectorWrapper<int32_t> &v
 using namespace luci;
 
 template <loco::DataType DT>
-void copy_data(const std::vector<uint8_t> &raw_data, uint32_t num_elements, CircleConst *const_node)
+void copy_data(const VectorWrapper<uint8_t> &raw_data, uint32_t num_elements,
+               CircleConst *const_node)
 {
   using T = typename loco::DataTypeImpl<DT>::Type;
 
@@ -67,8 +68,8 @@ void copy_data(const std::vector<uint8_t> &raw_data, uint32_t num_elements, Circ
 }
 
 template <>
-void copy_data<loco::DataType::STRING>(const std::vector<uint8_t> &raw_data, uint32_t num_elements,
-                                       CircleConst *const_node)
+void copy_data<loco::DataType::STRING>(const VectorWrapper<uint8_t> &raw_data,
+                                       uint32_t num_elements, CircleConst *const_node)
 {
   assert(const_node->sparsityparam() == nullptr);
 
@@ -116,7 +117,8 @@ CircleConst *create_circleconst(GraphBuilderContext *context, int32_t tensor_ind
   const auto const_tensor = tensors[tensor_index];
   assert(const_tensor != nullptr);
 
-  const std::vector<uint8_t> &buffer = reader->buffers()[const_tensor->buffer()]->data;
+  assert(reader->native_buffers()[const_tensor->buffer()] != nullptr);
+  const auto buffer = wrap(reader->native_buffers()[const_tensor->buffer()]->data());
   const auto const_dims = wrap(const_tensor->shape()); // in NHWC
   if (const_dims.size() == 0 && buffer.empty())
   {


### PR DESCRIPTION
This commit replaces usage of buffers() to native_buffers() method.

ONE-DCO-1.0-Signed-off-by: Maksim Bronnikov <max120199@gmail.com>

------------------

For: #7886
Draft: #7901
