### PR TITLE
[luci/import] Remove UnPack API from CircleReader class

### DIFF
--- a/compiler/luci/import/include/luci/Import/CircleReader.h
+++ b/compiler/luci/import/include/luci/Import/CircleReader.h
@@ -103,13 +103,6 @@ template <typename T> VectorWrapper<T> wrap(const flatbuffers::Vector<T> *vec)
  */
 class CircleReader
 {
-private: // unpack API
-  using CircleBuffers_t = std::vector<std::unique_ptr<circle::BufferT>>;
-  using CircleTensors_t = std::vector<std::unique_ptr<circle::TensorT>>;
-  using CircleOperators_t = std::vector<std::unique_ptr<circle::OperatorT>>;
-  using CircleOperatorCodes_t = std::vector<std::unique_ptr<circle::OperatorCodeT>>;
-  using CircleMetadata_t = std::vector<std::unique_ptr<circle::MetadataT>>;
-
 private: // direct API
   using CircleBuffers = VectorWrapper<flatbuffers::Offset<circle::Buffer>>;
   using CircleTensors = VectorWrapper<flatbuffers::Offset<circle::Tensor>>;
@@ -119,20 +112,6 @@ private: // direct API
 
 public:
   CircleReader() = default;
-
-public: // unpack API
-  const CircleOperatorCodes_t &opcodes() const { return _model->operator_codes; }
-  const CircleBuffers_t &buffers() const { return _model->buffers; }
-  const CircleTensors_t &tensors() const { return _current_subgraph->tensors; }
-  const CircleOperators_t &operators() const { return _current_subgraph->operators; }
-  const std::vector<int32_t> &inputs() const { return _current_subgraph->inputs; }
-  const std::vector<int32_t> &outputs() const { return _current_subgraph->outputs; }
-  const std::string &name() const { return _current_subgraph->name; }
-  const circle::DataFormat &data_format() const { return _current_subgraph->data_format; }
-  const CircleMetadata_t &metadata() const { return _model->metadata; }
-
-  circle::BuiltinOperator builtin_code(const circle::OperatorT &op) const;
-  std::string opcode_name(const circle::OperatorT &op) const;
 
 public: // direct API
   CircleOperatorCodes native_opcodes() const { return wrap(_native_model->operator_codes()); }
@@ -155,9 +134,6 @@ public:
   bool select_subgraph(uint32_t subgraph);
 
 private:
-  std::unique_ptr<const circle::ModelT> _model;
-  const circle::SubGraphT *_current_subgraph{nullptr};
-
   const circle::Model *_native_model{nullptr};
   const circle::SubGraph *_native_subgraph{nullptr};
 };

--- a/compiler/luci/import/src/CircleReader.cpp
+++ b/compiler/luci/import/src/CircleReader.cpp
@@ -413,16 +413,6 @@ std::string fb_string2std_string(const flatbuffers::String *fb_str)
   return fb_str == nullptr ? "" : fb_str->str();
 }
 
-circle::BuiltinOperator CircleReader::builtin_code(const circle::OperatorT &op) const
-{
-  const auto &op_codes = opcodes();
-  uint32_t index = op.opcode_index;
-  assert(index < op_codes.size());
-  const circle::OperatorCodeT &opcode = *op_codes[index];
-
-  return opcode.builtin_code;
-}
-
 circle::BuiltinOperator CircleReader::builtin_code(const circle::Operator *op) const
 {
   assert(op != nullptr);
@@ -434,23 +424,6 @@ circle::BuiltinOperator CircleReader::builtin_code(const circle::Operator *op) c
   assert(opcode != nullptr);
 
   return opcode->builtin_code();
-}
-
-std::string CircleReader::opcode_name(const circle::OperatorT &op) const
-{
-  const auto &op_codes = opcodes();
-  uint32_t index = op.opcode_index;
-  assert(index < op_codes.size());
-  const circle::OperatorCodeT &opcode = *op_codes[index];
-
-  if (!is_valid(opcode))
-  {
-    std::ostringstream oss;
-    oss << "(invalid: " << index << ")";
-    return oss.str();
-  }
-
-  return ::luci::opcode_name(opcode);
 }
 
 std::string CircleReader::opcode_name(const circle::Operator *op) const
@@ -476,8 +449,6 @@ bool CircleReader::parse(const circle::Model *model)
 {
   assert(model != nullptr);
 
-  _model.reset(model->UnPack());
-
   // for direct pointer access
   _native_model = model;
 
@@ -486,13 +457,11 @@ bool CircleReader::parse(const circle::Model *model)
 
 bool CircleReader::select_subgraph(uint32_t sgindex)
 {
-  if (_model->subgraphs.size() <= sgindex)
+  if (num_subgraph() <= sgindex)
   {
     assert(false);
     return false;
   }
-
-  _current_subgraph = _model->subgraphs[sgindex].get();
 
   // for direct pointer access
   auto subgraphs = _native_model->subgraphs();


### PR DESCRIPTION
This commit removes UnPack API from CircleReader class.

ONE-DCO-1.0-Signed-off-by: Maksim Bronnikov <max120199@gmail.com>

-------------------------------

For: #7886
Draft: #7901