### PR TITLE
[luci-interpreter] Add CMSISNN sources to luci_interpreeter_cmsisnn_pal library

### DIFF
--- a/compiler/luci-interpreter/pal/cmsisnn/pal.cmake
+++ b/compiler/luci-interpreter/pal/cmsisnn/pal.cmake
@@ -42,9 +42,9 @@ macro(add_pal_to_target TGT)
             "${TensorFlowSource_DIR}")
     target_include_directories(${TGT} PRIVATE ${LUCI_INTERPRETER_PAL_DIR})
 
-    set(PAL_SOURCES ${TensorFlowSource_DIR}/tensorflow/lite/kernels/internal/quantization_util.cc)
+    file(GLOB_RECURSE PAL_SOURCES "${CMSISSource_DIR}/CMSIS/NN/Source/*.c")
+    list(APPEND PAL_SOURCES ${TensorFlowSource_DIR}/tensorflow/lite/kernels/internal/quantization_util.cc)
     add_library(luci_interpreter_cmsisnn_pal STATIC ${PAL_SOURCES})
-    set_target_properties(luci_interpreter_cmsisnn_pal PROPERTIES POSITION_INDEPENDENT_CODE ON)
     target_include_directories(luci_interpreter_cmsisnn_pal PRIVATE
             "${TensorFlowRuySource_DIR}"
             "${TensorFlowGEMMLowpSource_DIR}"
@@ -53,7 +53,7 @@ macro(add_pal_to_target TGT)
     )
 
     add_subdirectory(${CMSISSource_DIR}/CMSIS/NN ${CMAKE_CURRENT_BINARY_DIR}/CMSISNN)
-    target_include_directories(luci_interpreter_cmsisnn_pal PRIVATE
+    target_include_directories(luci_interpreter_cmsisnn_pal PUBLIC
             "${CMSISSource_DIR}/CMSIS/NN/Include"
             "${CMSISSource_DIR}/CMSIS/DSP/Include"
             "${CMSISSource_DIR}/CMSIS/Core/Include")


### PR DESCRIPTION
This commit adds CMSISNN sources to luci_interpreeter_cmsisnn_pal library.

ONE-DCO-1.0-Signed-off-by: Vyacheslav Bazhenov <slavikmipt@gmail.com>