### PR TITLE
[luci/import] Rename native_tensors to tensors

### DIFF
--- a/compiler/luci/import/include/luci/Import/CircleReader.h
+++ b/compiler/luci/import/include/luci/Import/CircleReader.h
@@ -116,7 +116,7 @@ public:
 public: // direct API
   CircleOperatorCodes native_opcodes() const { return wrap(_native_model->operator_codes()); }
   CircleBuffers native_buffers() const { return wrap(_native_model->buffers()); }
-  CircleTensors native_tensors() const { return wrap(_native_subgraph->tensors()); }
+  CircleTensors tensors() const { return wrap(_native_subgraph->tensors()); }
   CircleOperators native_operators() const { return wrap(_native_subgraph->operators()); }
   VectorWrapper<int32_t> native_inputs() const { return wrap(_native_subgraph->inputs()); }
   VectorWrapper<int32_t> native_outputs() const { return wrap(_native_subgraph->outputs()); }

--- a/compiler/luci/import/src/GraphBuilder.cpp
+++ b/compiler/luci/import/src/GraphBuilder.cpp
@@ -29,7 +29,7 @@ CircleNode *GraphBuilder::build(const circle::OperatorT &op, GraphBuilderContext
 
   const std::vector<int32_t> &inputs = op.inputs;
   const std::vector<int32_t> &outputs = op.outputs;
-  const auto tensors = context->reader()->native_tensors();
+  const auto tensors = context->reader()->tensors();
   const auto opcodes = context->reader()->native_opcodes();
   assert(!tensors.null());
 

--- a/compiler/luci/import/src/GraphBuilderMultiOutput.cpp
+++ b/compiler/luci/import/src/GraphBuilderMultiOutput.cpp
@@ -30,7 +30,7 @@ CircleNode *GraphBuilderMultiOutput::build(const circle::OperatorT &op,
 
   const std::vector<int32_t> &inputs = op.inputs;
   const std::vector<int32_t> &outputs = op.outputs;
-  const auto tensors = context->reader()->native_tensors();
+  const auto tensors = context->reader()->tensors();
   const auto opcodes = context->reader()->native_opcodes();
   assert(!tensors.null());
 

--- a/compiler/luci/import/src/Importer.cpp
+++ b/compiler/luci/import/src/Importer.cpp
@@ -51,7 +51,7 @@ void convert_graph(const luci::GraphBuilderSource &source, luci::CircleReader &r
   luci::GraphBuilderContext gb_context(graph, &reader, nodefinder.get(), tensoroutputs.get());
 
   const auto operators = reader.native_operators();
-  const auto tensors = reader.native_tensors();
+  const auto tensors = reader.tensors();
   assert(!tensors.null());
   auto circle_metadata = std::make_unique<luci::CircleImportMetadata>(reader);
 

--- a/compiler/luci/import/src/Nodes/CircleCast.cpp
+++ b/compiler/luci/import/src/Nodes/CircleCast.cpp
@@ -42,7 +42,7 @@ bool CircleCastGraphBuilder::validate(const ValidateArgs &args) const
   const auto *options = args.op.builtin_options.AsCastOptions();
   if (options != nullptr)
   {
-    const auto tensors = args.reader.native_tensors();
+    const auto tensors = args.reader.tensors();
     const auto output_tensor = tensors[outputs[0]];
     assert(output_tensor != nullptr);
     auto name = tensor_name(output_tensor);

--- a/compiler/luci/import/src/Nodes/CircleConst.cpp
+++ b/compiler/luci/import/src/Nodes/CircleConst.cpp
@@ -113,7 +113,7 @@ CircleConst *create_circleconst(GraphBuilderContext *context, int32_t tensor_ind
 
   auto graph = context->graph();
   auto reader = context->reader();
-  const auto tensors = reader->native_tensors();
+  const auto tensors = reader->tensors();
   const auto const_tensor = tensors[tensor_index];
   assert(const_tensor != nullptr);
 

--- a/compiler/luci/import/src/Nodes/CircleDepthToSpace.cpp
+++ b/compiler/luci/import/src/Nodes/CircleDepthToSpace.cpp
@@ -34,7 +34,7 @@ bool CircleDepthToSpaceGraphBuilder::validate(const ValidateArgs &args) const
   const auto &outputs = args.op.outputs;
 
   const auto *options = args.op.builtin_options.AsDepthToSpaceOptions();
-  const auto tensors = args.reader.native_tensors();
+  const auto tensors = args.reader.tensors();
   assert(tensors[outputs[0]] != nullptr && tensors[inputs.at(0)] != nullptr);
 
   if (tensors[outputs[0]]->type() != tensors[inputs.at(0)]->type())

--- a/compiler/luci/import/src/Nodes/CircleDepthwiseConv2D.cpp
+++ b/compiler/luci/import/src/Nodes/CircleDepthwiseConv2D.cpp
@@ -32,7 +32,7 @@ bool CircleDepthwiseConv2DGraphBuilder::validate(const ValidateArgs &args) const
   if (args.op.outputs.size() != 1)
     return false;
 
-  const auto tensors = args.reader.native_tensors();
+  const auto tensors = args.reader.tensors();
 
   // input shape
   const auto input = tensors.at(args.op.inputs.at(0));

--- a/compiler/luci/import/src/Nodes/CircleElu.cpp
+++ b/compiler/luci/import/src/Nodes/CircleElu.cpp
@@ -31,7 +31,7 @@ bool CircleEluGraphBuilder::validate(const ValidateArgs &args) const
   const auto &inputs = args.op.inputs;
   const auto &outputs = args.op.outputs;
 
-  const auto tensors = args.reader.native_tensors();
+  const auto tensors = args.reader.tensors();
   const auto tensor = tensors.at(inputs.at(0));
   assert(tensor != nullptr);
 

--- a/compiler/luci/import/src/Nodes/CircleEqual.cpp
+++ b/compiler/luci/import/src/Nodes/CircleEqual.cpp
@@ -29,7 +29,7 @@ bool CircleEqualGraphBuilder::validate(const ValidateArgs &args) const
     return false;
 
   const auto &inputs = args.op.inputs;
-  const auto tensors = args.reader.native_tensors();
+  const auto tensors = args.reader.tensors();
 
   assert(tensors[inputs.at(0)] != nullptr && tensors[inputs.at(1)] != nullptr);
   return tensors[inputs.at(0)]->type() == tensors[inputs.at(1)]->type();

--- a/compiler/luci/import/src/Nodes/CircleExp.cpp
+++ b/compiler/luci/import/src/Nodes/CircleExp.cpp
@@ -30,7 +30,7 @@ bool CircleExpGraphBuilder::validate(const ValidateArgs &args) const
 
   const auto &inputs = args.op.inputs;
   // input type check
-  const auto tensors = args.reader.native_tensors();
+  const auto tensors = args.reader.tensors();
   const auto tensor = tensors.at(inputs.at(0));
   assert(tensor != nullptr);
   switch (tensor->type())

--- a/compiler/luci/import/src/Nodes/CircleExpandDims.cpp
+++ b/compiler/luci/import/src/Nodes/CircleExpandDims.cpp
@@ -29,7 +29,7 @@ bool CircleExpandDimsGraphBuilder::validate(const ValidateArgs &args) const
     return false;
 
   const auto &inputs = args.op.inputs;
-  const auto tensors = args.reader.native_tensors();
+  const auto tensors = args.reader.tensors();
 
   assert(tensors[inputs.at(1)] != nullptr);
   return tensors[inputs.at(1)]->type() == circle::TensorType_INT32;

--- a/compiler/luci/import/src/Nodes/CircleFloorDiv.cpp
+++ b/compiler/luci/import/src/Nodes/CircleFloorDiv.cpp
@@ -30,7 +30,7 @@ bool CircleFloorDivGraphBuilder::validate(const ValidateArgs &args) const
 
   const auto &inputs = args.op.inputs;
   const auto &outputs = args.op.outputs;
-  const auto tensors = args.reader.native_tensors();
+  const auto tensors = args.reader.tensors();
   const auto tensor_in_0 = tensors.at(inputs.at(0));
   const auto tensor_in_1 = tensors.at(inputs.at(1));
   const auto tensor_out = tensors.at(outputs[0]);

--- a/compiler/luci/import/src/Nodes/CircleFloorMod.cpp
+++ b/compiler/luci/import/src/Nodes/CircleFloorMod.cpp
@@ -29,7 +29,7 @@ bool CircleFloorModGraphBuilder::validate(const ValidateArgs &args) const
     return false;
 
   const auto &inputs = args.op.inputs;
-  const auto tensors = args.reader.native_tensors();
+  const auto tensors = args.reader.tensors();
   const auto tensor_in_0 = tensors.at(inputs.at(0));
   const auto tensor_in_1 = tensors.at(inputs.at(1));
   assert(tensor_in_0 != nullptr && tensor_in_1 != nullptr);

--- a/compiler/luci/import/src/Nodes/CircleGatherNd.cpp
+++ b/compiler/luci/import/src/Nodes/CircleGatherNd.cpp
@@ -31,7 +31,7 @@ bool CircleGatherNdGraphBuilder::validate(const ValidateArgs &args) const
     return false;
 
   const auto &inputs = args.op.inputs;
-  auto indices_tensor = args.reader.native_tensors()[inputs.at(1)];
+  auto indices_tensor = args.reader.tensors()[inputs.at(1)];
   assert(indices_tensor != nullptr);
 
   if (!(indices_tensor->type() == circle::TensorType::TensorType_INT32 ||

--- a/compiler/luci/import/src/Nodes/CircleGreater.cpp
+++ b/compiler/luci/import/src/Nodes/CircleGreater.cpp
@@ -37,7 +37,7 @@ bool CircleGreaterGraphBuilder::validate(const ValidateArgs &args) const
 
   const auto &inputs = args.op.inputs;
   const auto &outputs = args.op.outputs;
-  const auto tensors = args.reader.native_tensors();
+  const auto tensors = args.reader.tensors();
 
   assert(tensors[inputs.at(0)] != nullptr && tensors[inputs.at(1)] != nullptr);
   if (tensors[inputs.at(0)]->type() != tensors[inputs.at(1)]->type())

--- a/compiler/luci/import/src/Nodes/CircleGreaterEqual.cpp
+++ b/compiler/luci/import/src/Nodes/CircleGreaterEqual.cpp
@@ -30,7 +30,7 @@ bool CircleGreaterEqualGraphBuilder::validate(const ValidateArgs &args) const
 
   const auto &inputs = args.op.inputs;
   const auto &outputs = args.op.outputs;
-  const auto tensors = args.reader.native_tensors();
+  const auto tensors = args.reader.tensors();
 
   assert(tensors[inputs.at(0)] != nullptr && tensors[inputs.at(1)] != nullptr);
   if (tensors[inputs.at(0)]->type() != tensors[inputs.at(1)]->type())

--- a/compiler/luci/import/src/Nodes/CircleIf.cpp
+++ b/compiler/luci/import/src/Nodes/CircleIf.cpp
@@ -42,7 +42,7 @@ bool CircleIfGraphBuilder::validate(const ValidateArgs &args) const
     return false;
 
   // input 0 should be BOOL type
-  const auto tensors = args.reader.native_tensors();
+  const auto tensors = args.reader.tensors();
   const auto tensor = tensors.at(inputs.at(0));
   assert(tensor != nullptr);
   if (tensor->type() != circle::TensorType_BOOL)

--- a/compiler/luci/import/src/Nodes/CircleLess.cpp
+++ b/compiler/luci/import/src/Nodes/CircleLess.cpp
@@ -30,7 +30,7 @@ bool CircleLessGraphBuilder::validate(const ValidateArgs &args) const
 
   const auto &inputs = args.op.inputs;
   const auto &outputs = args.op.outputs;
-  const auto tensors = args.reader.native_tensors();
+  const auto tensors = args.reader.tensors();
   const auto tensor = tensors.at(inputs.at(0));
   assert(tensor != nullptr);
 

--- a/compiler/luci/import/src/Nodes/CircleLessEqual.cpp
+++ b/compiler/luci/import/src/Nodes/CircleLessEqual.cpp
@@ -30,7 +30,7 @@ bool CircleLessEqualGraphBuilder::validate(const ValidateArgs &args) const
 
   const auto &inputs = args.op.inputs;
   const auto &outputs = args.op.outputs;
-  const auto tensors = args.reader.native_tensors();
+  const auto tensors = args.reader.tensors();
 
   assert(tensors[inputs.at(0)] != nullptr && tensors[inputs.at(1)] != nullptr);
   if (tensors[inputs.at(0)]->type() != tensors[inputs.at(1)]->type())

--- a/compiler/luci/import/src/Nodes/CircleLog.cpp
+++ b/compiler/luci/import/src/Nodes/CircleLog.cpp
@@ -32,7 +32,7 @@ bool CircleLogGraphBuilder::validate(const ValidateArgs &args) const
   // input type check
   // Must be one of bfloat16, half, float32, float64, complex64, complex128.
   // Currently circle supports half(float16), float32, float64, complex64.
-  const auto tensors = args.reader.native_tensors();
+  const auto tensors = args.reader.tensors();
   const auto tensor = tensors.at(inputs.at(0));
   assert(tensor != nullptr);
   switch (tensor->type())

--- a/compiler/luci/import/src/Nodes/CircleLogicalAnd.cpp
+++ b/compiler/luci/import/src/Nodes/CircleLogicalAnd.cpp
@@ -30,7 +30,7 @@ bool CircleLogicalAndGraphBuilder::validate(const ValidateArgs &args) const
 
   // Only BOOL type is allowed for inputs
   const auto &inputs = args.op.inputs;
-  const auto tensors = args.reader.native_tensors();
+  const auto tensors = args.reader.tensors();
   for (auto input : inputs)
   {
     const auto tensor = tensors.at(input);

--- a/compiler/luci/import/src/Nodes/CircleLogicalNot.cpp
+++ b/compiler/luci/import/src/Nodes/CircleLogicalNot.cpp
@@ -30,7 +30,7 @@ bool CircleLogicalNotGraphBuilder::validate(const ValidateArgs &args) const
 
   // Only BOOL type is allowed for the input
   const auto &inputs = args.op.inputs;
-  const auto tensors = args.reader.native_tensors();
+  const auto tensors = args.reader.tensors();
   const auto tensor = tensors.at(inputs.at(0));
   assert(tensor != nullptr);
   if (tensor->type() != circle::TensorType::TensorType_BOOL)

--- a/compiler/luci/import/src/Nodes/CircleLogicalOr.cpp
+++ b/compiler/luci/import/src/Nodes/CircleLogicalOr.cpp
@@ -30,7 +30,7 @@ bool CircleLogicalOrGraphBuilder::validate(const ValidateArgs &args) const
 
   // Only BOOL type is allowed for inputs
   const auto &inputs = args.op.inputs;
-  const auto tensors = args.reader.native_tensors();
+  const auto tensors = args.reader.tensors();
   for (auto input : inputs)
   {
     const auto tensor = tensors.at(input);

--- a/compiler/luci/import/src/Nodes/CircleLogistic.cpp
+++ b/compiler/luci/import/src/Nodes/CircleLogistic.cpp
@@ -30,7 +30,7 @@ bool CircleLogisticGraphBuilder::validate(const ValidateArgs &args) const
 
   const auto &inputs = args.op.inputs;
   const auto &outputs = args.op.outputs;
-  const auto tensors = args.reader.native_tensors();
+  const auto tensors = args.reader.tensors();
   assert(tensors.at(inputs.at(0)) != nullptr && tensors.at(outputs[0]) != nullptr);
   if (tensors.at(inputs.at(0))->type() != tensors.at(outputs[0])->type())
     return false;

--- a/compiler/luci/import/src/Nodes/CircleMatrixDiag.cpp
+++ b/compiler/luci/import/src/Nodes/CircleMatrixDiag.cpp
@@ -30,7 +30,7 @@ bool CircleMatrixDiagGraphBuilder::validate(const ValidateArgs &args) const
 
   const auto &inputs = args.op.inputs;
   const auto &outputs = args.op.outputs;
-  const auto tensors = args.reader.native_tensors();
+  const auto tensors = args.reader.tensors();
   const auto tensor = tensors.at(inputs.at(0));
 
   assert(tensors[outputs[0]] != nullptr && tensor != nullptr);

--- a/compiler/luci/import/src/Nodes/CircleMatrixSetDiag.cpp
+++ b/compiler/luci/import/src/Nodes/CircleMatrixSetDiag.cpp
@@ -30,7 +30,7 @@ bool CircleMatrixSetDiagGraphBuilder::validate(const ValidateArgs &args) const
 
   const auto &inputs = args.op.inputs;
   const auto &outputs = args.op.outputs;
-  const auto tensors = args.reader.native_tensors();
+  const auto tensors = args.reader.tensors();
   const auto tensor = tensors.at(inputs.at(0));
 
   assert(tensors[outputs[0]] != nullptr && tensor != nullptr);

--- a/compiler/luci/import/src/Nodes/CircleNonMaxSuppressionV4.cpp
+++ b/compiler/luci/import/src/Nodes/CircleNonMaxSuppressionV4.cpp
@@ -35,7 +35,7 @@ bool CircleNonMaxSuppressionV4GraphBuilder::validate(const ValidateArgs &args) c
   if (outputs.size() != 2)
     return false;
 
-  const auto tensors = args.reader.native_tensors();
+  const auto tensors = args.reader.tensors();
   const auto boxes_tensor = tensors.at(inputs[0]);
   assert(boxes_tensor != nullptr);
   const auto boxes_tensor_shape = wrap(boxes_tensor->shape());

--- a/compiler/luci/import/src/Nodes/CircleNonMaxSuppressionV5.cpp
+++ b/compiler/luci/import/src/Nodes/CircleNonMaxSuppressionV5.cpp
@@ -35,7 +35,7 @@ bool CircleNonMaxSuppressionV5GraphBuilder::validate(const ValidateArgs &args) c
   if (outputs.size() != 3)
     return false;
 
-  const auto tensors = args.reader.native_tensors();
+  const auto tensors = args.reader.tensors();
   const auto boxes_tensor = tensors.at(inputs[0]);
   assert(boxes_tensor != nullptr);
   const auto boxes_tensor_shape = wrap(boxes_tensor->shape());

--- a/compiler/luci/import/src/Nodes/CircleNotEqual.cpp
+++ b/compiler/luci/import/src/Nodes/CircleNotEqual.cpp
@@ -30,7 +30,7 @@ bool CircleNotEqualGraphBuilder::validate(const ValidateArgs &args) const
 
   const auto &inputs = args.op.inputs;
   const auto &outputs = args.op.outputs;
-  const auto tensors = args.reader.native_tensors();
+  const auto tensors = args.reader.tensors();
 
   assert(tensors[inputs.at(0)] != nullptr && tensors[inputs.at(1)] != nullptr);
   if (tensors[inputs.at(0)]->type() != tensors[inputs.at(1)]->type())

--- a/compiler/luci/import/src/Nodes/CircleOneHot.cpp
+++ b/compiler/luci/import/src/Nodes/CircleOneHot.cpp
@@ -32,7 +32,7 @@ bool CircleOneHotGraphBuilder::validate(const ValidateArgs &args) const
 
   const auto &inputs = args.op.inputs;
   const auto *options = args.op.builtin_options.AsOneHotOptions();
-  const auto tensors = args.reader.native_tensors();
+  const auto tensors = args.reader.tensors();
   const auto indices = tensors.at(inputs.at(0));
   const auto depth = tensors.at(inputs.at(1));
   const auto on_value = tensors.at(inputs.at(2));

--- a/compiler/luci/import/src/Nodes/CircleReduceAny.cpp
+++ b/compiler/luci/import/src/Nodes/CircleReduceAny.cpp
@@ -28,7 +28,7 @@ bool CircleReduceAnyGraphBuilder::validate(const ValidateArgs &args) const
 
   const auto &inputs = args.op.inputs;
   const auto &outputs = args.op.outputs;
-  const auto tensors = args.reader.native_tensors();
+  const auto tensors = args.reader.tensors();
   const auto tensor_0 = tensors.at(inputs.at(0));
   const auto tensor_1 = tensors.at(inputs.at(1));
   const auto tensor_o = tensors.at(outputs[0]);

--- a/compiler/luci/import/src/Nodes/CircleReduceProd.cpp
+++ b/compiler/luci/import/src/Nodes/CircleReduceProd.cpp
@@ -27,7 +27,7 @@ bool CircleReduceProdGraphBuilder::validate(const ValidateArgs &args) const
     return false;
 
   const auto &inputs = args.op.inputs;
-  const auto tensors = args.reader.native_tensors();
+  const auto tensors = args.reader.tensors();
   const auto tensor_1 = tensors.at(inputs.at(1));
   assert(tensor_1 != nullptr);
 

--- a/compiler/luci/import/src/Nodes/CircleReshape.cpp
+++ b/compiler/luci/import/src/Nodes/CircleReshape.cpp
@@ -34,7 +34,7 @@ bool CircleReshapeGraphBuilder::validate(const ValidateArgs &args) const
   if (args.op.inputs.size() == 2)
   {
     const auto &inputs = args.op.inputs;
-    const auto tensors = args.reader.native_tensors();
+    const auto tensors = args.reader.tensors();
     const auto tensor_in = tensors.at(inputs.at(1));
     assert(tensor_in != nullptr);
 

--- a/compiler/luci/import/src/Nodes/CircleReverseSequence.cpp
+++ b/compiler/luci/import/src/Nodes/CircleReverseSequence.cpp
@@ -30,7 +30,7 @@ bool CircleReverseSequenceGraphBuilder::validate(const ValidateArgs &args) const
 
   const auto &inputs = args.op.inputs;
   const auto &outputs = args.op.outputs;
-  const auto tensors = args.reader.native_tensors();
+  const auto tensors = args.reader.tensors();
   const auto tensor_in = tensors.at(inputs.at(0));
   const auto tensor_lengths = tensors.at(inputs.at(1));
   const auto tensor_out = tensors.at(outputs[0]);

--- a/compiler/luci/import/src/Nodes/CircleReverseV2.cpp
+++ b/compiler/luci/import/src/Nodes/CircleReverseV2.cpp
@@ -30,7 +30,7 @@ bool CircleReverseV2GraphBuilder::validate(const ValidateArgs &args) const
 
   const auto &inputs = args.op.inputs;
   const auto &outputs = args.op.outputs;
-  const auto tensors = args.reader.native_tensors();
+  const auto tensors = args.reader.tensors();
   const auto tensor_in = tensors.at(inputs.at(0));
   const auto tensor_axis = tensors.at(inputs.at(1));
   const auto tensor_out = tensors.at(outputs[0]);

--- a/compiler/luci/import/src/Nodes/CircleRound.cpp
+++ b/compiler/luci/import/src/Nodes/CircleRound.cpp
@@ -33,7 +33,7 @@ bool CircleRoundGraphBuilder::validate(const ValidateArgs &args) const
   // Must be one of the following types
   // bfloat16, half (float16), float32, float64, complex64, complex128
   // Currently, circle supports float16, float32, complex64
-  const auto tensors = args.reader.native_tensors();
+  const auto tensors = args.reader.tensors();
   const auto tensor_in = tensors.at(inputs.at(0));
   const auto tensor_out = tensors.at(outputs[0]);
   assert(tensor_in != nullptr);

--- a/compiler/luci/import/src/Nodes/CircleRsqrt.cpp
+++ b/compiler/luci/import/src/Nodes/CircleRsqrt.cpp
@@ -32,7 +32,7 @@ bool CircleRsqrtGraphBuilder::validate(const ValidateArgs &args) const
   // Must be one of the following types
   // bfloat16, half (float16), float32, float64, complex64, complex128
   // Currently, circle supports float16, float32, complex64
-  const auto tensors = args.reader.native_tensors();
+  const auto tensors = args.reader.tensors();
   const auto tensor = tensors.at(inputs.at(0));
   assert(tensor != nullptr);
   switch (tensor->type())

--- a/compiler/luci/import/src/Nodes/CircleScatterNd.cpp
+++ b/compiler/luci/import/src/Nodes/CircleScatterNd.cpp
@@ -30,7 +30,7 @@ bool CircleScatterNdGraphBuilder::validate(const ValidateArgs &args) const
 
   const auto &inputs = args.op.inputs;
   // indices must have the same type as shape
-  const auto tensors = args.reader.native_tensors();
+  const auto tensors = args.reader.tensors();
 
   assert(tensors[inputs.at(0)] != nullptr && tensors[inputs.at(2)] != nullptr);
   if (tensors[inputs.at(0)]->type() != tensors[inputs.at(2)]->type())

--- a/compiler/luci/import/src/Nodes/CircleSegmentSum.cpp
+++ b/compiler/luci/import/src/Nodes/CircleSegmentSum.cpp
@@ -30,7 +30,7 @@ bool CircleSegmentSumGraphBuilder::validate(const ValidateArgs &args) const
 
   const auto &inputs = args.op.inputs;
   const auto &outputs = args.op.outputs;
-  const auto tensors = args.reader.native_tensors();
+  const auto tensors = args.reader.tensors();
   const auto tensor_in = tensors.at(inputs.at(0));
   const auto tensor_out = tensors.at(outputs[0]);
   const auto tensor_ids = tensors.at(inputs.at(1));

--- a/compiler/luci/import/src/Nodes/CircleSelect.cpp
+++ b/compiler/luci/import/src/Nodes/CircleSelect.cpp
@@ -29,7 +29,7 @@ bool CircleSelectGraphBuilder::validate(const ValidateArgs &args) const
     return false;
 
   const auto &inputs = args.op.inputs;
-  const auto tensors = args.reader.native_tensors();
+  const auto tensors = args.reader.tensors();
   const auto tensor = tensors.at(inputs.at(0));
   assert(tensor != nullptr);
   if (tensor->type() != circle::TensorType_BOOL)

--- a/compiler/luci/import/src/Nodes/CircleSelectV2.cpp
+++ b/compiler/luci/import/src/Nodes/CircleSelectV2.cpp
@@ -29,7 +29,7 @@ bool CircleSelectV2GraphBuilder::validate(const ValidateArgs &args) const
     return false;
 
   const auto &inputs = args.op.inputs;
-  const auto tensors = args.reader.native_tensors();
+  const auto tensors = args.reader.tensors();
   const auto condition = tensors.at(inputs.at(0));
   assert(condition != nullptr);
   if (condition->type() != circle::TensorType_BOOL)

--- a/compiler/luci/import/src/Nodes/CircleSin.cpp
+++ b/compiler/luci/import/src/Nodes/CircleSin.cpp
@@ -30,7 +30,7 @@ bool CircleSinGraphBuilder::validate(const ValidateArgs &args) const
 
   const auto &inputs = args.op.inputs;
   // input type check
-  const auto tensors = args.reader.native_tensors();
+  const auto tensors = args.reader.tensors();
   const auto tensor = tensors.at(inputs.at(0));
   assert(tensor != nullptr);
   switch (tensor->type())

--- a/compiler/luci/import/src/Nodes/CircleSquare.cpp
+++ b/compiler/luci/import/src/Nodes/CircleSquare.cpp
@@ -32,7 +32,7 @@ bool CircleSquareGraphBuilder::validate(const ValidateArgs &args) const
   // Must be one of the following types
   // bfloat16, half (float16), float32, float64, complex64, complex128
   // Currently, circle supports float16, float32, complex64
-  const auto tensors = args.reader.native_tensors();
+  const auto tensors = args.reader.tensors();
   const auto tensor = tensors.at(inputs.at(0));
   assert(tensor != nullptr);
   switch (tensor->type())

--- a/compiler/luci/import/src/Nodes/CircleSquaredDifference.cpp
+++ b/compiler/luci/import/src/Nodes/CircleSquaredDifference.cpp
@@ -32,7 +32,7 @@ bool CircleSquaredDifferenceGraphBuilder::validate(const ValidateArgs &args) con
   const auto &outputs = args.op.outputs;
   // Inputs must be one of the following types
   // bfloat16, half(float16), float32, float64, int32, int64, complex64, complex128
-  const auto tensors = args.reader.native_tensors();
+  const auto tensors = args.reader.tensors();
   const auto tensor = tensors.at(inputs.at(0));
   assert(tensor != nullptr);
   switch (tensor->type())

--- a/compiler/luci/import/src/Nodes/CircleTanh.cpp
+++ b/compiler/luci/import/src/Nodes/CircleTanh.cpp
@@ -30,7 +30,7 @@ bool CircleTanhGraphBuilder::validate(const ValidateArgs &args) const
 
   const auto &inputs = args.op.inputs;
   const auto &outputs = args.op.outputs;
-  const auto tensors = args.reader.native_tensors();
+  const auto tensors = args.reader.tensors();
   assert(tensors.at(inputs.at(0)) != nullptr && tensors.at(outputs[0]) != nullptr);
   if (tensors.at(inputs.at(0))->type() != tensors.at(outputs[0])->type())
     return false;

--- a/compiler/luci/import/src/Nodes/CircleTile.cpp
+++ b/compiler/luci/import/src/Nodes/CircleTile.cpp
@@ -32,7 +32,7 @@ bool CircleTileGraphBuilder::validate(const ValidateArgs &args) const
   auto outputs = args.op.outputs;
   // Multiples (inputs.at(1)) must be one of the following types
   // int32, int64
-  const auto tensors = args.reader.native_tensors();
+  const auto tensors = args.reader.tensors();
   const auto tensor = tensors.at(inputs.at(1));
   assert(tensor != nullptr);
   switch (tensor->type())

--- a/compiler/luci/import/src/Nodes/CircleTopKV2.cpp
+++ b/compiler/luci/import/src/Nodes/CircleTopKV2.cpp
@@ -35,7 +35,7 @@ bool CircleTopKV2GraphBuilder::validate(const ValidateArgs &args) const
   if (outputs.size() != 2)
     return false;
 
-  const auto tensors = args.reader.native_tensors();
+  const auto tensors = args.reader.tensors();
   const auto tensor = tensors.at(inputs.at(1));
   assert(tensor != nullptr);
   if (tensor->type() != circle::TensorType_INT32)

--- a/compiler/luci/import/src/Nodes/CircleTransposeConv.cpp
+++ b/compiler/luci/import/src/Nodes/CircleTransposeConv.cpp
@@ -31,7 +31,7 @@ bool CircleTransposeConvGraphBuilder::validate(const ValidateArgs &args) const
     return false;
 
   const auto &inputs = args.op.inputs;
-  const auto tensors = args.reader.native_tensors();
+  const auto tensors = args.reader.tensors();
   const auto filter_tensor = tensors.at(inputs.at(1));
   assert(filter_tensor != nullptr);
   const auto filter_shape = wrap(filter_tensor->shape());

--- a/compiler/luci/import/src/Nodes/CircleUnpack.cpp
+++ b/compiler/luci/import/src/Nodes/CircleUnpack.cpp
@@ -46,7 +46,7 @@ bool CircleUnpackGraphBuilder::validate(const ValidateArgs &args) const
   {
     if (settings->get(luci::UserSettings::Key::DisableValidation))
     {
-      const auto tensors = args.reader.native_tensors();
+      const auto tensors = args.reader.tensors();
       const auto output_tensor = tensors[outputs[0]];
       auto name = tensor_name(output_tensor);
       WARN(l) << "Warning: import Unpack(" << name << ") 'num' is not same as outputs used";
@@ -58,7 +58,7 @@ bool CircleUnpackGraphBuilder::validate(const ValidateArgs &args) const
   if (options->num < 0)
     return false;
 
-  const auto tensors = args.reader.native_tensors();
+  const auto tensors = args.reader.tensors();
   const auto tensor = tensors.at(inputs.at(0));
   assert(tensor != nullptr);
   const auto shape = wrap(tensor->shape());

--- a/compiler/luci/import/src/Nodes/CircleWhere.cpp
+++ b/compiler/luci/import/src/Nodes/CircleWhere.cpp
@@ -30,7 +30,7 @@ bool CircleWhereGraphBuilder::validate(const ValidateArgs &args) const
 
   const auto &inputs = args.op.inputs;
   const auto &outputs = args.op.outputs;
-  const auto tensors = args.reader.native_tensors();
+  const auto tensors = args.reader.tensors();
   const auto tensor_condition = tensors.at(inputs.at(0));
   const auto tensor_out = tensors.at(outputs[0]);
   assert(tensor_condition != nullptr);

--- a/compiler/luci/import/src/Nodes/CircleWhile.cpp
+++ b/compiler/luci/import/src/Nodes/CircleWhile.cpp
@@ -67,7 +67,7 @@ CircleNode *CircleWhileGraphBuilder::build(const circle::OperatorT &op,
 
   const std::vector<int32_t> &inputs = op.inputs;
   const std::vector<int32_t> &outputs = op.outputs;
-  const auto tensors = context->reader()->native_tensors();
+  const auto tensors = context->reader()->tensors();
   const auto opcodes = context->reader()->native_opcodes();
 
   std::vector<CircleNode *> input_nodes;

--- a/compiler/luci/import/src/ValidateHelpers.cpp
+++ b/compiler/luci/import/src/ValidateHelpers.cpp
@@ -26,7 +26,7 @@ bool validate_batch_space_nd(const GraphBuilderBase::ValidateArgs &args)
     return false;
 
   // input 1 and 2 should have INT32/INT64 type
-  const auto tensors = args.reader.native_tensors();
+  const auto tensors = args.reader.tensors();
   const auto tensor_1 = tensors.at(inputs.at(1));
   assert(tensor_1 != nullptr);
   switch (tensor_1->type())
@@ -71,7 +71,7 @@ bool validate_minmax(const GraphBuilderBase::ValidateArgs &args)
   if (outputs.size() != 1)
     return false;
 
-  const auto tensors = args.reader.native_tensors();
+  const auto tensors = args.reader.tensors();
   const auto tensor = tensors.at(inputs.at(0));
   assert(tensor != nullptr);
   switch (tensor->type())
@@ -109,7 +109,7 @@ bool validate_reduce_minmax(const GraphBuilderBase::ValidateArgs &args)
   if (outputs.size() != 1)
     return false;
 
-  const auto tensors = args.reader.native_tensors();
+  const auto tensors = args.reader.tensors();
   const auto tensor_axis = tensors.at(inputs.at(1));
   assert(tensor_axis != nullptr);
   switch (tensor_axis->type())


### PR DESCRIPTION
This commit renames native_tensors method to tensors.

ONE-DCO-1.0-Signed-off-by: Maksim Bronnikov <max120199@gmail.com>

-------------------------

For: #7886
Draft: #7901