### PR TITLE
[luci/import] Rename inputs, outputs, name and data_format

### DIFF
--- a/compiler/luci/import/include/luci/Import/CircleReader.h
+++ b/compiler/luci/import/include/luci/Import/CircleReader.h
@@ -118,10 +118,10 @@ public: // direct API
   CircleBuffers native_buffers() const { return wrap(_native_model->buffers()); }
   CircleTensors native_tensors() const { return wrap(_native_subgraph->tensors()); }
   CircleOperators native_operators() const { return wrap(_native_subgraph->operators()); }
-  VectorWrapper<int32_t> native_inputs() const { return wrap(_native_subgraph->inputs()); }
-  VectorWrapper<int32_t> native_outputs() const { return wrap(_native_subgraph->outputs()); }
-  std::string native_name() const { return fb_string2std_string(_native_subgraph->name()); }
-  circle::DataFormat native_data_format() const { return _native_subgraph->data_format(); }
+  VectorWrapper<int32_t> inputs() const { return wrap(_native_subgraph->inputs()); }
+  VectorWrapper<int32_t> outputs() const { return wrap(_native_subgraph->outputs()); }
+  std::string name() const { return fb_string2std_string(_native_subgraph->name()); }
+  circle::DataFormat data_format() const { return _native_subgraph->data_format(); }
   CircleMetadataSet native_metadata() const { return wrap(_native_model->metadata()); }
 
   uint32_t num_subgraph() const { return wrap(_native_model->subgraphs()).size(); }

--- a/compiler/luci/import/src/Importer.cpp
+++ b/compiler/luci/import/src/Importer.cpp
@@ -73,7 +73,7 @@ void convert_graph(const luci::GraphBuilderSource &source, luci::CircleReader &r
   // graph inputs; there are no input nodes in TFlite but just Tensors
   // creating virtual input nodes will make possible to connect nodes that uses them
   // all attributes of tensor should be copied to CircleInput node
-  for (const auto input : reader.native_inputs())
+  for (const auto input : reader.inputs())
   {
     auto input_node = graph->nodes()->create<luci::CircleInput>();
     assert(input_node != nullptr);
@@ -167,7 +167,7 @@ void convert_graph(const luci::GraphBuilderSource &source, luci::CircleReader &r
   }
 
   // graph outputs
-  for (auto output : reader.native_outputs())
+  for (auto output : reader.outputs())
   {
     const auto tensor = tensors[output];
     assert(tensor != nullptr);
@@ -310,7 +310,7 @@ std::unique_ptr<Module> Importer::importModule(const circle::Model *model) const
     if (!reader.select_subgraph(g))
       return nullptr;
 
-    graph->name(reader.native_name());
+    graph->name(reader.name());
 
     // Convert circle::Model to loco::Graph
     convert_graph(*source_ptr, reader, graph.get());


### PR DESCRIPTION
This commit removes native prefix from input, outputs, name and data_format methods.

ONE-DCO-1.0-Signed-off-by: Maksim Bronnikov <max120199@gmail.com>

--------------------

For: #7886
Draft: #7901