### PR TITLE
[luci/import] Remove native_ prefix from CircleReader methods

### DIFF
--- a/compiler/luci/import/include/luci/Import/CircleReader.h
+++ b/compiler/luci/import/include/luci/Import/CircleReader.h
@@ -102,15 +102,15 @@ public:
   CircleReader() = default;
 
 public: // direct API
-  CircleOperatorCodes native_opcodes() const { return wrap(_native_model->operator_codes()); }
-  CircleBuffers native_buffers() const { return wrap(_native_model->buffers()); }
+  CircleOperatorCodes opcodes() const { return wrap(_native_model->operator_codes()); }
+  CircleBuffers buffers() const { return wrap(_native_model->buffers()); }
   CircleTensors tensors() const { return wrap(_native_subgraph->tensors()); }
-  CircleOperators native_operators() const { return wrap(_native_subgraph->operators()); }
+  CircleOperators operators() const { return wrap(_native_subgraph->operators()); }
   VectorWrapper<int32_t> inputs() const { return wrap(_native_subgraph->inputs()); }
   VectorWrapper<int32_t> outputs() const { return wrap(_native_subgraph->outputs()); }
   std::string name() const { return fb_string2std_string(_native_subgraph->name()); }
   circle::DataFormat data_format() const { return _native_subgraph->data_format(); }
-  CircleMetadataSet native_metadata() const { return wrap(_native_model->metadata()); }
+  CircleMetadataSet metadata() const { return wrap(_native_model->metadata()); }
 
   uint32_t num_subgraph() const { return wrap(_native_model->subgraphs()).size(); }
 

--- a/compiler/luci/import/src/CircleImportMetadata.cpp
+++ b/compiler/luci/import/src/CircleImportMetadata.cpp
@@ -202,15 +202,15 @@ namespace luci
 
 CircleImportMetadata::CircleImportMetadata(const luci::CircleReader &reader)
 {
-  const auto metadata = reader.native_metadata();
+  const auto metadata = reader.metadata();
   for (uint32_t i = 0; i < metadata.size(); ++i)
   {
     const auto *meta = metadata[i];
     assert(meta != nullptr);
 
-    assert(meta->buffer() < reader.native_buffers().size());
-    assert(reader.native_buffers()[meta->buffer()] != nullptr);
-    const auto buffer = luci::wrap(reader.native_buffers()[meta->buffer()]->data());
+    assert(meta->buffer() < reader.buffers().size());
+    assert(reader.buffers()[meta->buffer()] != nullptr);
+    const auto buffer = luci::wrap(reader.buffers()[meta->buffer()]->data());
 
     assert(meta->name() != nullptr);
     if (meta->name()->str().compare("ONE_op_table") == 0)

--- a/compiler/luci/import/src/CircleReader.cpp
+++ b/compiler/luci/import/src/CircleReader.cpp
@@ -334,7 +334,7 @@ circle::BuiltinOperator CircleReader::builtin_code(const circle::Operator *op) c
 {
   assert(op != nullptr);
 
-  const auto op_codes = native_opcodes();
+  const auto op_codes = opcodes();
   uint32_t index = op->opcode_index();
   assert(index < op_codes.size());
   const auto opcode = op_codes[index];
@@ -347,7 +347,7 @@ std::string CircleReader::opcode_name(const circle::Operator *op) const
 {
   assert(op != nullptr);
 
-  const auto op_codes = native_opcodes();
+  const auto op_codes = opcodes();
   uint32_t index = op->opcode_index();
   assert(index < op_codes.size());
   const auto opcode = op_codes[index];

--- a/compiler/luci/import/src/GraphBuilder.cpp
+++ b/compiler/luci/import/src/GraphBuilder.cpp
@@ -30,7 +30,7 @@ CircleNode *GraphBuilder::build(const circle::OperatorT &op, GraphBuilderContext
   const std::vector<int32_t> &inputs = op.inputs;
   const std::vector<int32_t> &outputs = op.outputs;
   const auto tensors = context->reader()->tensors();
-  const auto opcodes = context->reader()->native_opcodes();
+  const auto opcodes = context->reader()->opcodes();
   assert(!tensors.null());
 
   std::vector<CircleNode *> input_nodes;

--- a/compiler/luci/import/src/GraphBuilderMultiOutput.cpp
+++ b/compiler/luci/import/src/GraphBuilderMultiOutput.cpp
@@ -31,7 +31,7 @@ CircleNode *GraphBuilderMultiOutput::build(const circle::OperatorT &op,
   const std::vector<int32_t> &inputs = op.inputs;
   const std::vector<int32_t> &outputs = op.outputs;
   const auto tensors = context->reader()->tensors();
-  const auto opcodes = context->reader()->native_opcodes();
+  const auto opcodes = context->reader()->opcodes();
   assert(!tensors.null());
 
   std::vector<CircleNode *> input_nodes;

--- a/compiler/luci/import/src/Importer.cpp
+++ b/compiler/luci/import/src/Importer.cpp
@@ -50,7 +50,7 @@ void convert_graph(const luci::GraphBuilderSource &source, luci::CircleReader &r
 
   luci::GraphBuilderContext gb_context(graph, &reader, nodefinder.get(), tensoroutputs.get());
 
-  const auto operators = reader.native_operators();
+  const auto operators = reader.operators();
   const auto tensors = reader.tensors();
   assert(!tensors.null());
   auto circle_metadata = std::make_unique<luci::CircleImportMetadata>(reader);

--- a/compiler/luci/import/src/Nodes/CircleConst.cpp
+++ b/compiler/luci/import/src/Nodes/CircleConst.cpp
@@ -117,8 +117,8 @@ CircleConst *create_circleconst(GraphBuilderContext *context, int32_t tensor_ind
   const auto const_tensor = tensors[tensor_index];
   assert(const_tensor != nullptr);
 
-  assert(reader->native_buffers()[const_tensor->buffer()] != nullptr);
-  const auto buffer = wrap(reader->native_buffers()[const_tensor->buffer()]->data());
+  assert(reader->buffers()[const_tensor->buffer()] != nullptr);
+  const auto buffer = wrap(reader->buffers()[const_tensor->buffer()]->data());
   const auto const_dims = wrap(const_tensor->shape()); // in NHWC
   if (const_dims.size() == 0 && buffer.empty())
   {

--- a/compiler/luci/import/src/Nodes/CircleCustom.cpp
+++ b/compiler/luci/import/src/Nodes/CircleCustom.cpp
@@ -39,7 +39,7 @@ CircleNode *CircleCustomGraphBuilder::build_node(const BuildNodeArgs &bna) const
     node->inputs(idx, bna.input_nodes[idx]);
   }
 
-  const auto opcodes = bna.context->reader()->native_opcodes();
+  const auto opcodes = bna.context->reader()->opcodes();
   const uint32_t opcode_index = bna.op.opcode_index;
   const auto opcode = opcodes[opcode_index];
   assert(opcode != nullptr);

--- a/compiler/luci/import/src/Nodes/CircleWhile.cpp
+++ b/compiler/luci/import/src/Nodes/CircleWhile.cpp
@@ -68,7 +68,7 @@ CircleNode *CircleWhileGraphBuilder::build(const circle::OperatorT &op,
   const std::vector<int32_t> &inputs = op.inputs;
   const std::vector<int32_t> &outputs = op.outputs;
   const auto tensors = context->reader()->tensors();
-  const auto opcodes = context->reader()->native_opcodes();
+  const auto opcodes = context->reader()->opcodes();
 
   std::vector<CircleNode *> input_nodes;
   for (const int32_t input_tensor_index : inputs)


### PR DESCRIPTION
This commit removes native_ prefix from other CircleReader's methods.

ONE-DCO-1.0-Signed-off-by: Maksim Bronnikov <max120199@gmail.com>

------------------

For: #7886
Draft: #7901