### PR TITLE
[luci] Remove unnecessary check in PropagateQuantParam

### DIFF
--- a/compiler/luci/pass/src/PropagateQuantParamPass.cpp
+++ b/compiler/luci/pass/src/PropagateQuantParamPass.cpp
@@ -65,11 +65,7 @@ struct PropagateQuantParam final : public luci::CircleNodeMutableVisitor<bool>
 
   bool visit(luci::CircleReshape *node)
   {
-    auto input = node->tensor();
-    if (loco::succs(input).size() != 1)
-      return false;
-
-    auto input_node = loco::must_cast<luci::CircleNode *>(input);
+    auto input_node = loco::must_cast<luci::CircleNode *>(node->tensor());
     return copy_qparam(input_node, node);
   }
 


### PR DESCRIPTION
This removes unnecessary successor check.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>