### PR TITLE
[luci/part] Fix is_input_same to check group value

### DIFF
--- a/compiler/luci/partition/src/PartitionMerge.cpp
+++ b/compiler/luci/partition/src/PartitionMerge.cpp
@@ -87,7 +87,7 @@ bool is_input_same(const luci::PGroup *pgroup, const luci::PGroups *pgroups)
         input_pgroup = pgroup_input;
       else
       {
-        if (input_pgroup != pgroup_input)
+        if (input_pgroup->group != pgroup_input->group)
           return false;
       }
     }


### PR DESCRIPTION
This will fix is_input_same method to check group value not the group ptr.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>