### PR TITLE
[luci/part] Revise for OutputExclude

### DIFF
--- a/compiler/luci/partition/src/PartitionMerge.cpp
+++ b/compiler/luci/partition/src/PartitionMerge.cpp
@@ -58,9 +58,6 @@ bool is_input_same(const luci::PGroup *pgroup, const luci::PGroups *pgroups)
     //         we need to clone this CircleConst for each graph of the group.
     if (dynamic_cast<const luci::CircleConst *>(input) != nullptr)
       continue;
-    // Skip also for OutputExclude
-    if (dynamic_cast<const luci::CircleOutputExclude *>(input) != nullptr)
-      continue;
 
     auto input_group = pgroups->group_of(input);
     // NOTE: all the nodes should be registered and return should be valid group.

--- a/compiler/luci/partition/src/PartitionPGroups.cpp
+++ b/compiler/luci/partition/src/PartitionPGroups.cpp
@@ -46,6 +46,8 @@ public:
   bool visit(const luci::CircleUniqueOut *) final { return true; }
   bool visit(const luci::CircleUnpackOut *) final { return true; }
   bool visit(const luci::CircleWhileOut *) final { return true; }
+  // For inputs not used
+  bool visit(const luci::CircleOutputExclude *) final { return true; }
   // TODO add all virtual nodes
 
   // default is false


### PR DESCRIPTION
This will revise condition for CircleOutputExclude node as this node
type is treated in preparing PGroup objects.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>