### PR TITLE
[angkor] Add NNCC_LIBRARY_NO_PIC option to CMakeLists.txt

### DIFF
--- a/compiler/angkor/CMakeLists.txt
+++ b/compiler/angkor/CMakeLists.txt
@@ -5,9 +5,9 @@ list(REMOVE_ITEM SOURCES ${TESTS})
 
 # NOTE STATIC is deliberately used here to allow clients to use 'angkor' without installation
 add_library(angkor STATIC ${HEADERS} ${SOURCES})
-if (NOT ANGKOR_NO_PIC)
+if (NOT NNCC_LIBRARY_NO_PIC)
   set_target_properties(angkor PROPERTIES POSITION_INDEPENDENT_CODE ON)
-endif (NOT ANGKOR_NO_PIC)
+endif (NOT NNCC_LIBRARY_NO_PIC)
 set_target_properties(angkor PROPERTIES LINKER_LANGUAGE CXX)
 target_include_directories(angkor PUBLIC include)
 target_link_libraries(angkor PRIVATE nncc_common)

--- a/compiler/angkor/CMakeLists.txt
+++ b/compiler/angkor/CMakeLists.txt
@@ -5,7 +5,9 @@ list(REMOVE_ITEM SOURCES ${TESTS})
 
 # NOTE STATIC is deliberately used here to allow clients to use 'angkor' without installation
 add_library(angkor STATIC ${HEADERS} ${SOURCES})
-set_target_properties(angkor PROPERTIES POSITION_INDEPENDENT_CODE ON)
+if (NOT ANGKOR_NO_PIC)
+  set_target_properties(angkor PROPERTIES POSITION_INDEPENDENT_CODE ON)
+endif (NOT ANGKOR_NO_PIC)
 set_target_properties(angkor PROPERTIES LINKER_LANGUAGE CXX)
 target_include_directories(angkor PUBLIC include)
 target_link_libraries(angkor PRIVATE nncc_common)


### PR DESCRIPTION
This commit adds NNCC_LIBRARY_NO_PIC option to have an opportunity to disable POSITION_INDEPENDENT_CODE property.

ONE-DCO-1.0-Signed-off-by: Vyacheslav Bazhenov slavikmipt@gmail.com