### PR TITLE
[locop] Add NNCC_LIBRARY_NO_PIC option to CMakeLists.txt

### DIFF
--- a/compiler/locop/CMakeLists.txt
+++ b/compiler/locop/CMakeLists.txt
@@ -3,7 +3,9 @@ file(GLOB_RECURSE TESTS "src/*.test.cpp")
 list(REMOVE_ITEM SOURCES ${TESTS})
 
 add_library(locop STATIC ${SOURCES})
-set_target_properties(locop PROPERTIES POSITION_INDEPENDENT_CODE ON)
+if (NOT LOCOP_NO_PIC)
+  set_target_properties(locop PROPERTIES POSITION_INDEPENDENT_CODE ON)
+endif(NOT LOCOP_NO_PIC)
 target_include_directories(locop PUBLIC include)
 target_link_libraries(locop PUBLIC loco)
 # Let's apply nncc common compile options

--- a/compiler/locop/CMakeLists.txt
+++ b/compiler/locop/CMakeLists.txt
@@ -3,9 +3,9 @@ file(GLOB_RECURSE TESTS "src/*.test.cpp")
 list(REMOVE_ITEM SOURCES ${TESTS})
 
 add_library(locop STATIC ${SOURCES})
-if (NOT LOCOP_NO_PIC)
+if (NOT NNCC_LIBRARY_NO_PIC)
   set_target_properties(locop PROPERTIES POSITION_INDEPENDENT_CODE ON)
-endif(NOT LOCOP_NO_PIC)
+endif(NOT NNCC_LIBRARY_NO_PIC)
 target_include_directories(locop PUBLIC include)
 target_link_libraries(locop PUBLIC loco)
 # Let's apply nncc common compile options


### PR DESCRIPTION
This commit adds NNCC_LIBRARY_NO_PIC option to have an opportunity to disable POSITION_INDEPENDENT_CODE property.

ONE-DCO-1.0-Signed-off-by: Vyacheslav Bazhenov slavikmipt@gmail.com