### PR TITLE
[circle-execution-plan] Some fixes in execution planner

### DIFF
--- a/compiler/circle-execution-plan/README.md
+++ b/compiler/circle-execution-plan/README.md
@@ -10,13 +10,12 @@ The output circle file contains plan (`CircleNodeMemoryPlan`) information for ev
 - number which determines order in which nodes will be executed
 - memory offsets for node output tensors from the beginning of shared memory buffer
 
-In order to record and read this metadata, we use `CircleImportMetadata` and `CircleExportMetadata`.
-For this purpose we use `std::map<uint32_t, std::vector<uint32_t>> _memory_plan_table` which for each node with key ID contains encoded `CircleNodeMemoryPlan` data.
+In order to record and read this data, we use `luci::CircleNodeExecutionPlan`.
 
 ### Execution plan building
 
 In order to build "execution plan" we use `ExecutionPlanner` class.
-The main method is `get_execution_plan()` which for each node finds and writes to its annotations 
+The main method is `make_execution_plan()` which for each node finds and writes to its annotations 
 "execution plan". For this purpose there are two steps:
 - determining the order of execution of nodes, which is stored in `_ordered_nodes` vector.
 Now for this purpose there is only one default method `get_default_execution_order_plan()` that uses `loco::postorder_traversal(const std::vector<loco::Node *> &roots)`.

--- a/compiler/circle-execution-plan/src/CircleExecutionPlan.cpp
+++ b/compiler/circle-execution-plan/src/CircleExecutionPlan.cpp
@@ -82,8 +82,8 @@ int entry(int argc, char **argv)
   auto module = importer.importModule(circle_model);
 
   // Do main job
-  luci::ExecutionPlanner execution_planner(module->graph());
-  execution_planner.get_execution_plan();
+  circle_planner::ExecutionPlanner execution_planner(module->graph());
+  execution_planner.make_execution_plan();
 
   // Export to output Circle file
   luci::CircleExporter exporter;

--- a/compiler/circle-execution-plan/src/ExecutionPlanner.h
+++ b/compiler/circle-execution-plan/src/ExecutionPlanner.h
@@ -20,7 +20,7 @@
 #include <luci/IR/Module.h>
 #include <luci/Plan/CircleNodeExecutionPlan.h>
 
-namespace luci
+namespace circle_planner
 {
 // struct for additional information for the node. it helps build allocations plan for nodes.
 struct AllocationNodeInformation
@@ -50,7 +50,7 @@ struct AllocationNodeInformation
   uint32_t last_node;
   // is the current node temporary or not
   bool is_temp;
-  // operation breadth of current node
+  // Breadth is a sum of live tensors sizes at the moment of execution of given node
   uint32_t breadth;
 
   bool operator<(const AllocationNodeInformation &other) const { return offset < other.offset; }
@@ -65,7 +65,7 @@ public:
   // Method provides execution plan, which contains execution order and
   // memory offsets for all nodes in _graph.
   // This plan writes in nodes annotation information with help of CircleNodeExecutionPlan class.
-  void get_execution_plan();
+  void make_execution_plan();
 
 private:
   // Method gets default execution order plan and saves it in _ordered_nodes vector.
@@ -83,7 +83,8 @@ private:
   // Return: required size of buffer.
   uint32_t get_offsets_with_greedy_by_size();
 
-  // Realization of greedy by size approach to find offsets for nodes.
+  // Realization of greedy by size approach (algorithm is mentioned in
+  // "EFFICIENT MEMORY MANAGEMENT FOR DEEP NEURAL NET INFERENCE" paper) to find offsets for nodes.
   uint32_t greedy_by_size_approach();
 
   // Method creates and fills _alloc_node_inform_vector with usage interval inform and node's sizes.
@@ -125,6 +126,6 @@ private:
   uint32_t _required_size = 0;
 };
 
-} // namespace luci
+} // namespace circle_planner
 
 #endif // CIRCLE_EXECUTION_PLANNER_H


### PR DESCRIPTION
This pr makes some fixes in circle-execution-planner. It changes namespace, method naming, some comments and code style.

Fixes from previous pr with circle-execution-planner: #7813

ONE-DCO-1.0-Signed-off-by: Artem Balyshev a.balyshev@partner.samsung.com