### PR TITLE
[tflitefile_tool] Print STRIDED_SLICE's option

### DIFF
--- a/tools/tflitefile_tool/option_printer.py
+++ b/tools/tflitefile_tool/option_printer.py
@@ -66,9 +66,11 @@ class OptionPrinter(object):
                 "DepthMultiplier = {}".format(self.options.DepthMultiplier()))
             # yapf: enable
         elif (self.op_name == "STRIDED_SLICE"):
+            # yapf: disable
             return "{}, {}, {}, {}, {}".format(
                 "begin_mask({})".format(self.options.BeginMask()),
                 "end_mask({})".format(self.options.EndMask()),
                 "ellipsis_mask({})".format(self.options.EllipsisMask()),
                 "new_axis_mask({})".format(self.options.NewAxisMask()),
                 "shrink_axis_mask({})".format(self.options.ShrinkAxisMask()))
+            # yapf: enable

--- a/tools/tflitefile_tool/option_printer.py
+++ b/tools/tflitefile_tool/option_printer.py
@@ -65,3 +65,10 @@ class OptionPrinter(object):
                 "Padding = {}".format(self.GetPadding()),
                 "DepthMultiplier = {}".format(self.options.DepthMultiplier()))
             # yapf: enable
+        elif (self.op_name == "STRIDED_SLICE"):
+            return "{}, {}, {}, {}, {}".format(
+                "begin_mask({})".format(self.options.BeginMask()),
+                "end_mask({})".format(self.options.EndMask()),
+                "ellipsis_mask({})".format(self.options.EllipsisMask()),
+                "new_axis_mask({})".format(self.options.NewAxisMask()),
+                "shrink_axis_mask({})".format(self.options.ShrinkAxisMask()))


### PR DESCRIPTION
model_parser prints strided_slice's 5 option fields like :

```
        Output Tensors[45]
                Tensor   45 : buffer 46    |  Empty | FLOAT32 | Memory 24.0K  | Shape [4, 1536] (b'strided_slice_3')
        Options
                begin_mask(5), end_mask(5), ellipsis_mask(0), new_axis_mask(0), shrink_axis_mask(2)
```

ONE-DCO-1.0-Signed-off-by: Chunseok Lee <chunseok.lee@samsung.com>