### PR TITLE
DRAFT: Support TF-style MaxPool Quantization

### DIFF
--- a/compiler/circle-quantizer/src/CircleQuantizer.cpp
+++ b/compiler/circle-quantizer/src/CircleQuantizer.cpp
@@ -66,6 +66,8 @@ int entry(int argc, char **argv)
   const std::string rq = "--requantize";
   const std::string fq = "--force_quantparam";
 
+  const std::string tf_maxpool = "--TF-style_maxpool";
+
   const std::string gpd = "--generate_profile_data";
 
   arser::Arser arser("circle-quantizer provides circle model quantization");
@@ -98,6 +100,13 @@ int entry(int argc, char **argv)
     .help("Quantize with min/max values. "
           "Three arguments required: input_model_dtype(float32) "
           "output_model_dtype(uint8) granularity(layer, channel)");
+
+  arser.add_argument(tf_maxpool)
+    .nargs(0)
+    .required(false)
+    .default_value(false)
+    .help("Force MaxPool Op to have the same input/output quantparams. NOTE: This feature can "
+          "degrade accuracy of some models");
 
   arser.add_argument(rq)
     .nargs(2)
@@ -201,6 +210,9 @@ int entry(int argc, char **argv)
     if (arser["--output_type"])
       options->param(AlgorithmParameters::Quantize_output_type,
                      arser.get<std::string>("--output_type"));
+
+    if (arser[tf_maxpool] and arser.get<bool>(tf_maxpool))
+      options->param(AlgorithmParameters::Quantize_TF_style_maxpool, "True");
   }
 
   if (arser[rq])

--- a/compiler/luci/pass/include/luci/CircleOptimizer.h
+++ b/compiler/luci/pass/include/luci/CircleOptimizer.h
@@ -95,6 +95,7 @@ public:
       Quantize_zero_points,
       Quantize_input_type,
       Quantize_output_type,
+      Quantize_TF_style_maxpool,
 
       // sparsify
       Sparsify_tensor_name,

--- a/compiler/luci/pass/include/luci/Pass/PropagateQuantParamPass.h
+++ b/compiler/luci/pass/include/luci/Pass/PropagateQuantParamPass.h
@@ -27,9 +27,17 @@ namespace luci
  */
 struct PropagateQuantParamPass final : public logo::Pass
 {
+  PropagateQuantParamPass(bool TF_style_maxpool) : _TF_style_maxpool(TF_style_maxpool) {}
+
+  // For backward compatibility
+  PropagateQuantParamPass() {}
+
   const char *name(void) const final { return "luci::PropagateQuantParamPass"; }
 
   bool run(loco::Graph *g) final;
+
+private:
+  bool _TF_style_maxpool = false;
 };
 
 } // namespace luci

--- a/compiler/luci/pass/src/CircleOptimizer.cpp
+++ b/compiler/luci/pass/src/CircleOptimizer.cpp
@@ -483,6 +483,9 @@ void CircleOptimizer::quantize(loco::Graph *g) const
     if (output_type.empty())
       output_type = output_model_dtype;
 
+    bool TF_style_maxpool =
+      not _options->param(Options::AlgorithmParameters::Quantize_TF_style_maxpool).empty();
+
     if (!in_array(to_lower_case(input_model_dtype), qwmm_supported_input_model_dtype))
       throw std::runtime_error("Unsupported input type. List of supported input types: " +
                                to_string(qwmm_supported_input_model_dtype));
@@ -515,7 +518,7 @@ void CircleOptimizer::quantize(loco::Graph *g) const
     // Post-quantization optimizations
     logo::Phase phase;
 
-    phase.emplace_back(std::make_unique<luci::PropagateQuantParamPass>());
+    phase.emplace_back(std::make_unique<luci::PropagateQuantParamPass>(TF_style_maxpool));
 
     phase.emplace_back(std::make_unique<luci::CircleShapeInferencePass>());
     phase.emplace_back(std::make_unique<luci::CircleTypeInferencePass>());

--- a/compiler/luci/pass/src/PropagateQuantParamPass.cpp
+++ b/compiler/luci/pass/src/PropagateQuantParamPass.cpp
@@ -120,6 +120,15 @@ bool PropagateQuantParamPass::run(loco::Graph *g)
     PropagateQuantParam pqp;
     if (circle_node->accept(&pqp))
       changed = true;
+
+    if (_TF_style_maxpool)
+    {
+      if (auto maxpool = dynamic_cast<luci::CircleMaxPool2D *>(node))
+      {
+        auto input = loco::must_cast<luci::CircleNode *>(maxpool->value());
+        copy_qparam(input, maxpool);
+      }
+    }
   }
 
   return changed;

--- a/compiler/one-cmds/one-quantize
+++ b/compiler/one-cmds/one-quantize
@@ -119,6 +119,12 @@ def _get_parser():
         help=
         "calibration algorithm for post-training quantization (supported: percentile/moving_average, default=percentile). 'percentile' mode uses the n-th percentiles as min/max values. 'moving_average' mode records the moving average of min/max."
     )
+    quantization_group.add_argument(
+        '--TF-style_maxpool',
+        action='store_true',
+        help=
+        "Force MaxPool Op to have the same input/output quantparams. NOTE: This option can degrade accuracy of some models.)"
+    )
 
     # arguments for force_quantparam option
     force_quantparam_group = parser.add_argument_group(
@@ -294,6 +300,8 @@ def _quantize(args):
             circle_quantizer_cmd.append(getattr(args, 'quantized_dtype'))
         if _utils._is_valid_attr(args, 'granularity'):
             circle_quantizer_cmd.append(getattr(args, 'granularity'))
+        if _utils._is_valid_attr(args, 'TF-style_maxpool'):
+            circle_quantizer_cmd.append('--TF-style_maxpool')
         if _utils._is_valid_attr(args, 'input_type'):
             circle_quantizer_cmd.append('--input_type')
             circle_quantizer_cmd.append(getattr(args, 'input_type'))


### PR DESCRIPTION
On going draft to support TF-style MaxPool Quantization.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: #8055