### PR TITLE
[luci-interpreter] Let PAL cast temporary tensors for Conv2d

### DIFF
--- a/compiler/luci-interpreter/pal/cmsisnn/PALConv2d.h
+++ b/compiler/luci-interpreter/pal/cmsisnn/PALConv2d.h
@@ -136,7 +136,7 @@ static inline void ConvPerChannel(const tflite::ConvParams &params, const int32_
 }
 
 static inline void SetupScratchpadTensor(luci_interpreter::Tensor *scratchpad,
-                                         const luci_interpreter::DataType &data_type,
+                                         const luci_interpreter::DataType &input_data_type,
                                          const tflite::ConvParams &params,
                                          const tflite::RuntimeShape &input_shape,
                                          const tflite::RuntimeShape &filter_shape,
@@ -148,6 +148,7 @@ static inline void SetupScratchpadTensor(luci_interpreter::Tensor *scratchpad,
 
   if (conv_params.dilation.h == 1 && conv_params.dilation.w == 1)
   {
+    assert(input_data_type == loco::DataType::S8);
     const int32_t batches = tflite::MatchingDim(input_shape, 0, output_shape, 0);
     const int32_t input_depth = tflite::MatchingDim(input_shape, 3, filter_shape, 3);
     const int32_t output_depth = tflite::MatchingDim(filter_shape, 0, output_shape, 3);

--- a/compiler/luci-interpreter/pal/mcu/PALConv2d.h
+++ b/compiler/luci-interpreter/pal/mcu/PALConv2d.h
@@ -66,13 +66,13 @@ static inline void ConvPerChannel(const tflite::ConvParams &params, const int32_
 }
 
 static inline void SetupScratchpadTensor(luci_interpreter::Tensor *scratchpad,
-                                         const luci_interpreter::DataType &data_type,
+                                         const luci_interpreter::DataType &input_data_type,
                                          const tflite::ConvParams &params,
                                          const tflite::RuntimeShape &input_shape,
                                          const tflite::RuntimeShape &filter_shape,
                                          const tflite::RuntimeShape &output_shape)
 {
-  (void)data_type;
+  (void)input_data_type;
   (void)params;
   (void)input_shape;
   (void)filter_shape;

--- a/compiler/luci-interpreter/src/loader/nodes/Conv2D.cpp
+++ b/compiler/luci-interpreter/src/loader/nodes/Conv2D.cpp
@@ -35,8 +35,9 @@ std::unique_ptr<Kernel> build_kernel_CircleConv2D(const luci::CircleNode *circle
   const Tensor *bias = helper.getOptionalInputTensor(node->bias());
   Tensor *output = helper.getOutputTensor(node);
 
-  auto scratchpad =
-    std::make_unique<Tensor>(input->element_type(), Shape({}), AffineQuantization{}, "");
+  // It is unknown what data will be stored in scratchpad tensor,
+  // using UINT8 as a most general option
+  auto scratchpad = std::make_unique<Tensor>(DataType::U8, Shape({}), AffineQuantization{}, "");
   scratchpad->set_observable(false);
   scratchpad->set_data_buffer(nullptr);
   // If node has execution plan then read memory offsets for scratchpad temporary tensor


### PR DESCRIPTION
This commit lets change data type for temporary tensors for Conv2d in PAL interface using new tensor method.

according to https://github.com/Samsung/ONE/pull/8047#discussion_r758394641 comment

ONE-DCO-1.0-Signed-off-by: Artem Balyshev a.balyshev@partner.samsung.com