### PR TITLE
[luci-interpreter] Let PALDepthwiseConv2d cast temporary tensors

### DIFF
--- a/compiler/luci-interpreter/pal/linux/PALDepthwiseConv2d.h
+++ b/compiler/luci-interpreter/pal/linux/PALDepthwiseConv2d.h
@@ -71,12 +71,14 @@ inline void DepthwiseConvPerChannel<int8_t>(
 
 static inline void SetupScratchpadTensor(luci_interpreter::Tensor *scratchpad,
                                          const tflite::DepthwiseParams &params,
+                                         const luci_interpreter::DataType &input_data_type,
                                          const tflite::RuntimeShape &input_shape,
                                          const tflite::RuntimeShape &filter_shape,
                                          const tflite::RuntimeShape &output_shape)
 
 {
   (void)params;
+  (void)input_data_type;
   (void)input_shape;
   (void)filter_shape;
   (void)output_shape;

--- a/compiler/luci-interpreter/pal/mcu/PALDepthwiseConv2d.h
+++ b/compiler/luci-interpreter/pal/mcu/PALDepthwiseConv2d.h
@@ -71,12 +71,14 @@ inline void DepthwiseConvPerChannel<int8_t>(
 
 static inline void SetupScratchpadTensor(luci_interpreter::Tensor *scratchpad,
                                          const tflite::DepthwiseParams &params,
+                                         const luci_interpreter::DataType &input_data_type,
                                          const tflite::RuntimeShape &input_shape,
                                          const tflite::RuntimeShape &filter_shape,
                                          const tflite::RuntimeShape &output_shape)
 
 {
   (void)params;
+  (void)input_data_type;
   (void)input_shape;
   (void)filter_shape;
   (void)output_shape;

--- a/compiler/luci-interpreter/src/kernels/DepthwiseConv2D.cpp
+++ b/compiler/luci-interpreter/src/kernels/DepthwiseConv2D.cpp
@@ -115,8 +115,9 @@ void DepthwiseConv2D::configure()
   params.dilation_width_factor = _params.dilation_width_factor;
 
   auto scratchpad = getOutputTensors()[1];
-  luci_interpreter_pal::SetupScratchpadTensor(scratchpad, params, getTensorShape(input()),
-                                              getTensorShape(filter()), getTensorShape(output()));
+  luci_interpreter_pal::SetupScratchpadTensor(scratchpad, params, input()->element_type(),
+                                              getTensorShape(input()), getTensorShape(filter()),
+                                              getTensorShape(output()));
 }
 
 void DepthwiseConv2D::execute() const

--- a/compiler/luci-interpreter/src/loader/nodes/DepthwiseConv2D.cpp
+++ b/compiler/luci-interpreter/src/loader/nodes/DepthwiseConv2D.cpp
@@ -44,8 +44,9 @@ std::unique_ptr<Kernel> build_kernel_CircleDepthwiseConv2D(const luci::CircleNod
   params.dilation_width_factor = node->dilation()->w();
   params.activation = node->fusedActivationFunction();
 
-  auto scratchpad =
-    std::make_unique<Tensor>(input->element_type(), Shape({}), AffineQuantization{}, "");
+  // It is unknown what data will be stored in scratchpad tensor,
+  // using UINT8 as a most general option
+  auto scratchpad = std::make_unique<Tensor>(DataType::U8, Shape({}), AffineQuantization{}, "");
   scratchpad->set_observable(false);
   scratchpad->set_data_buffer(nullptr);
   // If node has execution plan then read memory offsets for scratchpad temporary tensor


### PR DESCRIPTION
This commit lets set data type for temporary tensors in PAL interface for DepthwiseConv2D kernel.

according to #8047 (comment) comment

ONE-DCO-1.0-Signed-off-by: Artem Balyshev a.balyshev@partner.samsung.com