### PR TITLE
[luci-interpreter] Let PALAveragePool2d cast temporary tensors

### DIFF
--- a/compiler/luci-interpreter/pal/cmsisnn/PALAveragePool2d.h
+++ b/compiler/luci-interpreter/pal/cmsisnn/PALAveragePool2d.h
@@ -94,6 +94,7 @@ inline void AveragePool<int8_t>(const tflite::PoolParams &params,
 }
 
 static inline void SetupScratchpadTensor(luci_interpreter::Tensor *scratchpad,
+                                         const luci_interpreter::DataType &input_data_type,
                                          const tflite::RuntimeShape &input_shape,
                                          const tflite::RuntimeShape &output_shape)
 
@@ -105,7 +106,9 @@ static inline void SetupScratchpadTensor(luci_interpreter::Tensor *scratchpad,
   const int32_t depth = tflite::MatchingDim(input_shape, 3, output_shape, 3);
 
   const int32_t buf_size = arm_avgpool_s8_get_buffer_size(output_width, depth);
-  luci_interpreter::Shape scratchpad_shape{buf_size};
+  auto data_type_size = static_cast<int32_t>(luci_interpreter::getDataTypeSize(input_data_type));
+
+  luci_interpreter::Shape scratchpad_shape{buf_size * data_type_size};
   scratchpad->resize(scratchpad_shape);
 }
 

--- a/compiler/luci-interpreter/pal/cmsisnn/PALAveragePool2d.h
+++ b/compiler/luci-interpreter/pal/cmsisnn/PALAveragePool2d.h
@@ -99,17 +99,24 @@ static inline void SetupScratchpadTensor(luci_interpreter::Tensor *scratchpad,
                                          const tflite::RuntimeShape &output_shape)
 
 {
-  assert(input_shape.DimensionsCount() == 4);
-  assert(output_shape.DimensionsCount() == 4);
+  if (input_data_type == luci_interpreter::DataType::S8)
+  {
+    assert(input_shape.DimensionsCount() == 4);
+    assert(output_shape.DimensionsCount() == 4);
 
-  const int32_t output_width = output_shape.Dims(2);
-  const int32_t depth = tflite::MatchingDim(input_shape, 3, output_shape, 3);
+    const int32_t output_width = output_shape.Dims(2);
+    const int32_t depth = tflite::MatchingDim(input_shape, 3, output_shape, 3);
 
-  const int32_t buf_size = arm_avgpool_s8_get_buffer_size(output_width, depth);
-  auto data_type_size = static_cast<int32_t>(luci_interpreter::getDataTypeSize(input_data_type));
+    const int32_t buf_size = arm_avgpool_s8_get_buffer_size(output_width, depth);
+    auto data_type_size = static_cast<int32_t>(luci_interpreter::getDataTypeSize(input_data_type));
 
-  luci_interpreter::Shape scratchpad_shape{buf_size * data_type_size};
-  scratchpad->resize(scratchpad_shape);
+    luci_interpreter::Shape scratchpad_shape{buf_size * data_type_size};
+    scratchpad->resize(scratchpad_shape);
+  }
+  else
+  {
+    scratchpad->set_allocatable(false);
+  }
 }
 
 } // namespace luci_interpreter_pal

--- a/compiler/luci-interpreter/pal/linux/PALAveragePool2d.h
+++ b/compiler/luci-interpreter/pal/linux/PALAveragePool2d.h
@@ -56,10 +56,12 @@ inline void AveragePool<int8_t>(const tflite::PoolParams &params,
 }
 
 static inline void SetupScratchpadTensor(luci_interpreter::Tensor *scratchpad,
+                                         const luci_interpreter::DataType &input_data_type,
                                          const tflite::RuntimeShape &input_shape,
                                          const tflite::RuntimeShape &output_shape)
 
 {
+  (void)input_data_type;
   (void)input_shape;
   (void)output_shape;
 

--- a/compiler/luci-interpreter/pal/mcu/PALAveragePool2d.h
+++ b/compiler/luci-interpreter/pal/mcu/PALAveragePool2d.h
@@ -56,10 +56,12 @@ inline void AveragePool<int8_t>(const tflite::PoolParams &params,
 }
 
 static inline void SetupScratchpadTensor(luci_interpreter::Tensor *scratchpad,
+                                         const luci_interpreter::DataType &input_data_type,
                                          const tflite::RuntimeShape &input_shape,
                                          const tflite::RuntimeShape &output_shape)
 
 {
+  (void)input_data_type;
   (void)input_shape;
   (void)output_shape;
 

--- a/compiler/luci-interpreter/src/kernels/AveragePool2D.cpp
+++ b/compiler/luci-interpreter/src/kernels/AveragePool2D.cpp
@@ -80,8 +80,8 @@ void AveragePool2D::configure()
   if (input()->element_type() == DataType::S8)
   {
     auto scratchpad = getOutputTensors()[1];
-    luci_interpreter_pal::SetupScratchpadTensor(scratchpad, getTensorShape(input()),
-                                                getTensorShape(output()));
+    luci_interpreter_pal::SetupScratchpadTensor(scratchpad, input()->element_type(),
+                                                getTensorShape(input()), getTensorShape(output()));
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/AveragePool2D.cpp
+++ b/compiler/luci-interpreter/src/kernels/AveragePool2D.cpp
@@ -77,12 +77,9 @@ void AveragePool2D::configure()
   }
   output()->resize({batches, output_height, output_width, depth});
 
-  if (input()->element_type() == DataType::S8)
-  {
-    auto scratchpad = getOutputTensors()[1];
-    luci_interpreter_pal::SetupScratchpadTensor(scratchpad, input()->element_type(),
-                                                getTensorShape(input()), getTensorShape(output()));
-  }
+  auto scratchpad = getOutputTensors()[1];
+  luci_interpreter_pal::SetupScratchpadTensor(scratchpad, input()->element_type(),
+                                              getTensorShape(input()), getTensorShape(output()));
 }
 
 void AveragePool2D::execute() const

--- a/compiler/luci-interpreter/src/loader/nodes/AveragePool2D.cpp
+++ b/compiler/luci-interpreter/src/loader/nodes/AveragePool2D.cpp
@@ -41,8 +41,9 @@ std::unique_ptr<Kernel> build_kernel_CircleAveragePool2D(const luci::CircleNode 
   params.stride_width = node->stride()->w();
   params.activation = node->fusedActivationFunction();
 
-  auto scratchpad =
-    std::make_unique<Tensor>(input->element_type(), Shape({}), AffineQuantization{}, "");
+  // It is unknown what data will be stored in scratchpad tensor,
+  // using UINT8 as a most general option
+  auto scratchpad = std::make_unique<Tensor>(DataType::U8, Shape({}), AffineQuantization{}, "");
   scratchpad->set_observable(false);
   scratchpad->set_data_buffer(nullptr);
   // If node has execution plan then read memory offsets for scratchpad temporary tensor


### PR DESCRIPTION
This pr lets set data type for temporary tensors in PAL interface for AveragePool2D kernel.

according to #8047 (comment) comment

ONE-DCO-1.0-Signed-off-by: Artem Balyshev a.balyshev@partner.samsung.com