### PR TITLE
[luci-interpreter] Split interpreter constructor in two

### DIFF
--- a/compiler/luci-interpreter/include/luci_interpreter/Interpreter.h
+++ b/compiler/luci-interpreter/include/luci_interpreter/Interpreter.h
@@ -50,7 +50,9 @@ public:
 class Interpreter
 {
 public:
-  explicit Interpreter(const luci::Module *module, IMemoryManager *memory_manager = nullptr);
+  explicit Interpreter(const luci::Module *module);
+
+  explicit Interpreter(const luci::Module *module, IMemoryManager *memory_manager);
 
   ~Interpreter();
 


### PR DESCRIPTION
This PR eliminates default value for memory_manager in interpreter constructors.

ONE-DCO-1.0-Signed-off-by: Alexander Efimov <a.efimov@samsung.com>