### PR TITLE
[luci-interpreter] Support INT8 Slice operation

### DIFF
--- a/compiler/luci-interpreter/src/kernels/Slice.cpp
+++ b/compiler/luci-interpreter/src/kernels/Slice.cpp
@@ -139,6 +139,11 @@ void Slice::execute() const
                                   getTensorData<uint8_t>(input()), getTensorShape(output()),
                                   getTensorData<uint8_t>(output()));
       break;
+    case DataType::S8:
+      luci_interpreter_pal::Slice(op_params, getTensorShape(input()),
+                                  getTensorData<int8_t>(input()), getTensorShape(output()),
+                                  getTensorData<int8_t>(output()));
+      break;
     default:
       throw std::runtime_error("Unsupported input type.");
   }

--- a/compiler/luci-interpreter/src/kernels/Slice.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/Slice.test.cpp
@@ -31,7 +31,7 @@ template <typename T> class SliceTest : public ::testing::Test
 {
 };
 
-using DataTypes = ::testing::Types<float, uint8_t>;
+using DataTypes = ::testing::Types<float, uint8_t, int8_t>;
 TYPED_TEST_CASE(SliceTest, DataTypes);
 
 TYPED_TEST(SliceTest, SimpleTest)


### PR DESCRIPTION
This pr enables int8 Slice operation in luci-interpreter.

issue: #8075 

ONE-DCO-1.0-Signed-off-by: Artem Balyshev a.balyshev@partner.samsung.com