### PR TITLE
[luci-interpreter] Support INT8 Pad operation

### DIFF
--- a/compiler/luci-interpreter/src/kernels/Pad.cpp
+++ b/compiler/luci-interpreter/src/kernels/Pad.cpp
@@ -93,6 +93,16 @@ void Pad::execute() const
                                  getTensorData<uint8_t>(output()));
       break;
     }
+    case DataType::S8:
+    {
+      assert(output()->zero_point() >= std::numeric_limits<int8_t>::min());
+      assert(output()->zero_point() <= std::numeric_limits<int8_t>::max());
+      const auto pad_value = static_cast<int8_t>(output()->zero_point());
+      tflite::reference_ops::Pad(params, getTensorShape(input()), getTensorData<int8_t>(input()),
+                                 &pad_value, getTensorShape(output()),
+                                 getTensorData<int8_t>(output()));
+      break;
+    }
     default:
       throw std::runtime_error("Unsupported type.");
   }


### PR DESCRIPTION
This pr enables int8 Pad operation in luci-interpreter.

issue: #8075

ONE-DCO-1.0-Signed-off-by: Artem Balyshev a.balyshev@partner.samsung.com