### PR TITLE
[luci-interpreter] Remove redundant field

### DIFF
--- a/compiler/luci-interpreter/include/luci_interpreter/Interpreter.h
+++ b/compiler/luci-interpreter/include/luci_interpreter/Interpreter.h
@@ -71,7 +71,6 @@ private:
   // the order of deletion in the destructor
   std::unique_ptr<IMemoryManager> _default_memory_manager = nullptr;
   std::unique_ptr<class RuntimeModule> _runtime_module;
-  IMemoryManager *_memory_manager = nullptr;
 
   // Observer functionality support.
   std::unique_ptr<struct RuntimeToIR> _runtime_to_ir;

--- a/compiler/luci-interpreter/src/Interpreter.cpp
+++ b/compiler/luci-interpreter/src/Interpreter.cpp
@@ -77,10 +77,9 @@ Interpreter::Interpreter(const luci::Module *module)
   _runtime_module = std::make_unique<RuntimeModule>(_event_notifier.get());
 
   _default_memory_manager = std::make_unique<SimpleMemoryManager>();
-  _memory_manager = _default_memory_manager.get();
 
   ModuleLoader loader(module, _runtime_module.get(), *_runtime_to_ir, _node_to_tensor,
-                      _memory_manager);
+                      _default_memory_manager.get());
   loader.load();
 }
 
@@ -93,10 +92,8 @@ Interpreter::Interpreter(const luci::Module *module,
   _event_notifier = std::make_unique<EventNotifierImpl>(*_runtime_to_ir, _observers);
   _runtime_module = std::make_unique<RuntimeModule>(_event_notifier.get());
 
-  _memory_manager = memory_manager;
-
   ModuleLoader loader(module, _runtime_module.get(), *_runtime_to_ir, _node_to_tensor,
-                      _memory_manager);
+                      memory_manager);
   loader.load();
 }
 


### PR DESCRIPTION
This PR removes _memory_manager field, because it is unused.

ONE-DCO-1.0-Signed-off-by: Alexander Efimov <a.efimov@samsung.com>