### PR TITLE
[ONE/hermes] Initialize Severity in Message

### DIFF
--- a/compiler/hermes/include/hermes/core/Message.h
+++ b/compiler/hermes/include/hermes/core/Message.h
@@ -69,7 +69,7 @@ public:
 
 private:
   std::unique_ptr<MessageText> _text;
-  SeverityCategory _severity;
+  SeverityCategory _severity = SeverityCategory::INFO;
 };
 
 } // namespace hermes

--- a/compiler/hermes/include/hermes/core/MessageBuffer.h
+++ b/compiler/hermes/include/hermes/core/MessageBuffer.h
@@ -43,7 +43,7 @@ public:
 
 private:
   MessageBus *_bus;
-  SeverityCategory _severity;
+  SeverityCategory _severity = SeverityCategory::INFO;
 
   /// @brief Content buffer
   std::stringstream _ss;


### PR DESCRIPTION
This commit initializes severity member in hermes::Message.

Signed-off-by: Andrey Shedko <a.shedko@samsung.com>