### PR TITLE
[res] Fix RNN examples in PyTorchExamples

### DIFF
--- a/res/PyTorchExamples/examples/RNN-bi/__init__.py
+++ b/res/PyTorchExamples/examples/RNN-bi/__init__.py
@@ -5,13 +5,14 @@ _input_size = 3
 _seq_len = 2
 _batch = 2
 _hidden_size = 5
+_num_layers = 2
 
 
 # model
 class net_RNN(nn.Module):
     def __init__(self):
         super().__init__()
-        self.op = nn.RNN(_input_size, _hidden_size, 2, bidirectional=True)
+        self.op = nn.RNN(_input_size, _hidden_size, _num_layers, bidirectional=True)
 
     def forward(self, inputs):
         return self.op(inputs[0], inputs[1])
@@ -22,5 +23,5 @@ _model_ = net_RNN()
 # dummy input for onnx generation
 _dummy_ = [
     torch.randn(_seq_len, _batch, _input_size),
-    torch.randn(2, _batch, _hidden_size)
+    torch.randn(2 * _num_layers, _batch, _hidden_size)
 ]

--- a/res/PyTorchExamples/examples/RNN-noinit/__init__.py
+++ b/res/PyTorchExamples/examples/RNN-noinit/__init__.py
@@ -13,11 +13,11 @@ class net_RNN(nn.Module):
         super().__init__()
         self.op = nn.RNN(_input_size, _hidden_size, 1)
 
-    def forward(self, inputs):
-        return self.op(inputs[0])
+    def forward(self, input):
+        return self.op(input)
 
 
 _model_ = net_RNN()
 
 # dummy input for onnx generation
-_dummy_ = [torch.randn(_seq_len, _batch, _input_size)]
+_dummy_ = torch.randn(_seq_len, _batch, _input_size)


### PR DESCRIPTION
This PR:
- removes redundant array wrapper from input in RNN-noinit example
- fixes tensor dimensions in RNN-bi

related issue: #7939 

ONE-DCO-1.0-Signed-off-by: Alexander Efimov <a.efimov@samsung.com>