### PR TITLE
[one-cmds] Add optional installation of one-import-pytorch

### DIFF
--- a/compiler/one-cmds/CMakeLists.txt
+++ b/compiler/one-cmds/CMakeLists.txt
@@ -14,6 +14,11 @@ set(ONE_COMMAND_FILES
     onecc
 )
 
+# pytorch importer is an experimental feature, it is not used in default configuration
+if(ENABLE_ONE_IMPORT_PYTORCH)
+  list(APPEND ONE_COMMAND_FILES one-import-pytorch)
+endif(ENABLE_ONE_IMPORT_PYTORCH)
+
 foreach(ONE_COMMAND IN ITEMS ${ONE_COMMAND_FILES})
 
   set(ONE_COMMAND_FILE ${ONE_COMMAND})

--- a/compiler/one-cmds/tests/CMakeLists.txt
+++ b/compiler/one-cmds/tests/CMakeLists.txt
@@ -75,3 +75,7 @@ install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/README.txt
         DESTINATION test)
 
 add_subdirectory(onnx-operations)
+
+if(ENABLE_ONE_IMPORT_PYTORCH)
+  add_subdirectory(pytorch-operations)
+endif(ENABLE_ONE_IMPORT_PYTORCH)


### PR DESCRIPTION
This PR introduces ENABLE_ONE_IMPORT_PYTORCH option in cmake
to enable installation of pytorch importer.

Related issue: #7939 

ONE-DCO-1.0-Signed-off-by: Alexander Efimov <a.efimov@samsung.com>