### PR TITLE
[infra] Add ENABLE_ONE_IMPORT_PYTORCH option

### DIFF
--- a/infra/nncc/CMakeLists.txt
+++ b/infra/nncc/CMakeLists.txt
@@ -144,6 +144,11 @@ option(STATIC_LUCI "Build luci as a static libraries" OFF)
 # do not benefit from it, so we prefer to disable PIC.
 option(NNCC_LIBRARY_NO_PIC "Disable PIC option for libraries" OFF)
 
+# one-cmds PyTorch importer is an experimental feature, it is not used in default configuration.
+# This option enables installation of one-import-pytorch utility and
+# generation of related testsuite.
+option(ENABLE_ONE_IMPORT_PYTORCH "Enable deploy of one-cmds pytoch importer and related tests" OFF)
+
 ###
 ### Target
 ###


### PR DESCRIPTION
This PR adds ENABLE_ONE_IMPORT_PYTORCH option in nncc root CMakeLists.txt.

continuation of #8118

ONE-DCO-1.0-Signed-off-by: Alexander Efimov <a.efimov@samsung.com>