### PR TITLE
[Draft][circle-execution-plan] Add Pal to ExecutionPlanner

### DIFF
--- a/compiler/circle-execution-plan/CMakeLists.txt
+++ b/compiler/circle-execution-plan/CMakeLists.txt
@@ -1,16 +1,3 @@
-set(SOURCES
-        src/CircleExecutionPlan.cpp
-        src/ExecutionPlanner.cpp
-        src/ExecutionPlanner.h
-        )
+set(CIRCLE_EXECUTION_PLAN_PAL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/pal")
 
-add_executable(circle_execution_plan "${SOURCES}")
-target_link_libraries(circle_execution_plan foder)
-target_link_libraries(circle_execution_plan safemain)
-target_link_libraries(circle_execution_plan luci_env)
-target_link_libraries(circle_execution_plan luci_import)
-target_link_libraries(circle_execution_plan luci_export)
-target_link_libraries(circle_execution_plan luci_plan)
-target_link_libraries(circle_execution_plan arser)
-
-install(TARGETS circle_execution_plan DESTINATION bin)
+add_subdirectory(src)

--- a/compiler/circle-execution-plan/pal/IScratchpadHelper.h
+++ b/compiler/circle-execution-plan/pal/IScratchpadHelper.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CIRCLE_EXECUTION_PLAN_ISRCRATCHPAD_HELPER_H
+#define CIRCLE_EXECUTION_PLAN_ISRCRATCHPAD_HELPER_H
+
+namespace circle_planner
+{
+
+class IScratchpadHelper
+{
+public:
+  virtual uint32_t ComputeScratchpadSizeConv2d(const luci::CircleConv2D *conv) = 0;
+
+  virtual ~IScratchpadHelper() = default;
+};
+
+} // namespace circle_planner
+
+#endif // CIRCLE_EXECUTION_PLAN_ISRCRATCHPAD_HELPER_H

--- a/compiler/circle-execution-plan/pal/ScratchpadHelperCMSISNN.h
+++ b/compiler/circle-execution-plan/pal/ScratchpadHelperCMSISNN.h
@@ -48,13 +48,13 @@ public:
     const auto dilation_height_factor = static_cast<int32_t>(conv->dilation()->h());
     const auto dilation_width_factor = static_cast<int32_t>(conv->dilation()->w());
 
-    if (dilation_width_factor != 1 and dilation_height_factor != 1)
-      return 0;
-
     auto conv_input = loco::must_cast<luci::CircleNode *>(conv->input());
     auto filter = loco::must_cast<luci::CircleNode *>(conv->filter());
 
-    assert(conv_input->dtype() == loco::DataType::S8 && "CMSISNN works with int8 models");
+    if (dilation_width_factor != 1 and dilation_height_factor != 1 or
+        conv_input->dtype() != loco::DataType::S8)
+      return 0;
+
     const auto input_depth = static_cast<int32_t>(conv_input->dim(3).value());
 
     const auto input_height = static_cast<int32_t>(conv_input->dim(1).value());

--- a/compiler/circle-execution-plan/pal/ScratchpadHelperCMSISNN.h
+++ b/compiler/circle-execution-plan/pal/ScratchpadHelperCMSISNN.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CIRCLE_EXECUTION_PLAN_SCRATCHPAD_HELPER_CMSISNN_H
+#define CIRCLE_EXECUTION_PLAN_SCRATCHPAD_HELPER_CMSISNN_H
+
+#include "IScratchpadHelper.h"
+
+namespace circle_planner
+{
+
+namespace
+{
+
+inline int32_t computePadding(int32_t stride, int32_t dilation_rate, int32_t in_size,
+                              int32_t filter_size, int32_t out_size)
+{
+  const int32_t effective_filter_size = (filter_size - 1) * dilation_rate + 1;
+  const int32_t padding = ((out_size - 1) * stride + effective_filter_size - in_size) / 2;
+  return padding > 0 ? padding : 0;
+}
+
+} // namespace
+
+class ScratchpadHelperCMSISNN : public IScratchpadHelper
+{
+public:
+  explicit ScratchpadHelperCMSISNN(bool use_dsp) : _use_dsp(use_dsp)
+  {
+    // Do nothing
+  }
+
+  uint32_t ComputeScratchpadSizeConv2d(const luci::CircleConv2D *conv) final
+  {
+    const auto dilation_height_factor = static_cast<int32_t>(conv->dilation()->h());
+    const auto dilation_width_factor = static_cast<int32_t>(conv->dilation()->w());
+
+    if (dilation_width_factor != 1 and dilation_height_factor != 1)
+      return 0;
+
+    auto conv_input = loco::must_cast<luci::CircleNode *>(conv->input());
+    auto filter = loco::must_cast<luci::CircleNode *>(conv->filter());
+
+    assert(conv_input->dtype() == loco::DataType::S8 && "CMSISNN works with int8 models");
+    const auto input_depth = static_cast<int32_t>(conv_input->dim(3).value());
+
+    const auto input_height = static_cast<int32_t>(conv_input->dim(1).value());
+    const auto input_width = static_cast<int32_t>(conv_input->dim(2).value());
+
+    const auto filter_height = static_cast<int32_t>(filter->dim(1).value());
+    const auto filter_width = static_cast<int32_t>(filter->dim(2).value());
+
+    const auto stride_height = static_cast<int32_t>(conv->stride()->h());
+    const auto stride_width = static_cast<int32_t>(conv->stride()->w());
+
+    const auto output_height = static_cast<int32_t>(conv->dim(1).value());
+    const auto output_width = static_cast<int32_t>(conv->dim(2).value());
+
+    assert(conv_input->quantparam()->zerop.size() == 1);
+    assert(conv->quantparam()->zerop.size() == 1);
+
+    const auto padding_height = computePadding(stride_height, dilation_height_factor, input_height,
+                                               filter_height, output_height);
+    const auto padding_width =
+      computePadding(stride_width, dilation_width_factor, input_width, filter_width, output_width);
+
+    if ((padding_width == 0) && (padding_height == 0) && (input_depth % 4 == 0) &&
+        (stride_width == 1) && (stride_height == 1) && (filter_width == 1) && (filter_height == 1))
+    {
+      return 0;
+    }
+
+    if (_use_dsp)
+      return (2 * input_depth * filter_width * filter_height) * sizeof(int16_t);
+
+    return 0;
+  }
+
+private:
+  bool _use_dsp;
+};
+
+} // namespace circle_planner
+
+#endif // CIRCLE_EXECUTION_PLAN_SCRATCHPAD_HELPER_CMSISNN_H

--- a/compiler/circle-execution-plan/pal/ScratchpadHelperLinux.h
+++ b/compiler/circle-execution-plan/pal/ScratchpadHelperLinux.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CIRCLE_EXECUTION_PLAN_SCRATCHPAD_HELPER_LINUX_H
+#define CIRCLE_EXECUTION_PLAN_SCRATCHPAD_HELPER_LINUX_H
+
+#include "IScratchpadHelper.h"
+
+namespace circle_planner
+{
+
+class ScratchpadHelperLinux : public IScratchpadHelper
+{
+public:
+  uint32_t ComputeScratchpadSizeConv2d(const luci::CircleConv2D *conv) final
+  {
+    const auto conv_input = loco::must_cast<luci::CircleNode *>(conv->input());
+    const auto filter = loco::must_cast<luci::CircleNode *>(conv->filter());
+
+    const uint32_t stride_height = conv->stride()->h();
+    const uint32_t stride_width = conv->stride()->w();
+
+    const uint32_t dilation_height_factor = conv->dilation()->h();
+    const uint32_t dilation_width_factor = conv->dilation()->w();
+
+    const uint32_t filter_height = filter->dim(1).value();
+    const uint32_t filter_width = filter->dim(2).value();
+
+    const bool need_dilated_im2col = dilation_height_factor != 1 || dilation_width_factor != 1;
+    const bool need_non_dilated_im2col =
+      stride_height != 1 || stride_width != 1 || filter_height != 1 || filter_width != 1;
+    const bool need_im2col = conv_input->dtype() != loco::DataType::S16 &&
+                             (need_dilated_im2col || need_non_dilated_im2col);
+
+    if (!need_im2col)
+    {
+      return 0;
+    }
+
+    const uint32_t input_depth = conv_input->dim(3).value();
+    const uint32_t batches = conv_input->dim(0).value();
+
+    const uint32_t output_height = conv->dim(1).value();
+    const uint32_t output_width = conv->dim(2).value();
+
+    return batches * output_height * output_width * input_depth * filter_height * filter_width *
+           size(conv_input->dtype());
+  }
+};
+
+} // namespace circle_planner
+
+#endif // CIRCLE_EXECUTION_PLAN_SCRATCHPAD_HELPER_LINUX_H

--- a/compiler/circle-execution-plan/pal/ScratchpadHelperMCU.h
+++ b/compiler/circle-execution-plan/pal/ScratchpadHelperMCU.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CIRCLE_EXECUTION_PLAN_SCRATCHPAD_HELPER_MCU_H
+#define CIRCLE_EXECUTION_PLAN_SCRATCHPAD_HELPER_MCU_H
+
+#include "IScratchpadHelper.h"
+
+namespace circle_planner
+{
+
+class ScratchpadHelperMCU : public IScratchpadHelper
+{
+public:
+  uint32_t ComputeScratchpadSizeConv2d(const luci::CircleConv2D *conv) final
+  {
+    // for mcu scratchpad size = 0
+    return 0;
+  }
+};
+
+} // namespace circle_planner
+
+#endif // CIRCLE_EXECUTION_PLAN_SCRATCHPAD_HELPER_MCU_H

--- a/compiler/circle-execution-plan/pal/TargetPlatform.h
+++ b/compiler/circle-execution-plan/pal/TargetPlatform.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CIRCLE_EXECUTION_PLAN_TARGET_PLATFORM_H
+#define CIRCLE_EXECUTION_PLAN_TARGET_PLATFORM_H
+
+namespace circle_planner
+{
+
+enum SupportedPlatformType
+{
+  LINUX,
+  MCU,
+  CMSISNN
+};
+
+struct TargetPlatform
+{
+  SupportedPlatformType platform_type;
+  bool use_dsp;
+};
+
+} // namespace circle_planner
+
+#endif // CIRCLE_EXECUTION_PLAN_TARGET_PLATFORM_H

--- a/compiler/circle-execution-plan/src/CMakeLists.txt
+++ b/compiler/circle-execution-plan/src/CMakeLists.txt
@@ -1,0 +1,22 @@
+set(SOURCES
+        "${CIRCLE_EXECUTION_PLAN_PAL_DIR}/IScratchpadHelper.h"
+        "${CIRCLE_EXECUTION_PLAN_PAL_DIR}/ScratchpadHelperLinux.h"
+        "${CIRCLE_EXECUTION_PLAN_PAL_DIR}/ScratchpadHelperMCU.h"
+        "${CIRCLE_EXECUTION_PLAN_PAL_DIR}/ScratchpadHelperCMSISNN.h"
+        CircleExecutionPlan.cpp
+        ExecutionPlanner.cpp
+        ExecutionPlanner.h
+        )
+
+set(CIRCLE_EXECUTION_PLAN "circle_execution_plan")
+
+add_executable(${CIRCLE_EXECUTION_PLAN} "${SOURCES}")
+target_link_libraries(${CIRCLE_EXECUTION_PLAN} foder)
+target_link_libraries(${CIRCLE_EXECUTION_PLAN} safemain)
+target_link_libraries(${CIRCLE_EXECUTION_PLAN} luci_env)
+target_link_libraries(${CIRCLE_EXECUTION_PLAN} luci_import)
+target_link_libraries(${CIRCLE_EXECUTION_PLAN} luci_export)
+target_link_libraries(${CIRCLE_EXECUTION_PLAN} luci_plan)
+target_link_libraries(${CIRCLE_EXECUTION_PLAN} arser)
+
+target_include_directories(${CIRCLE_EXECUTION_PLAN} PUBLIC "${CIRCLE_EXECUTION_PLAN_PAL_DIR}")

--- a/compiler/circle-execution-plan/src/CMakeLists.txt
+++ b/compiler/circle-execution-plan/src/CMakeLists.txt
@@ -3,6 +3,7 @@ set(SOURCES
         "${CIRCLE_EXECUTION_PLAN_PAL_DIR}/ScratchpadHelperLinux.h"
         "${CIRCLE_EXECUTION_PLAN_PAL_DIR}/ScratchpadHelperMCU.h"
         "${CIRCLE_EXECUTION_PLAN_PAL_DIR}/ScratchpadHelperCMSISNN.h"
+        "${CIRCLE_EXECUTION_PLAN_PAL_DIR}/TargetPlatform.h"
         CircleExecutionPlan.cpp
         ExecutionPlanner.cpp
         ExecutionPlanner.h

--- a/compiler/circle-execution-plan/src/CircleExecutionPlan.cpp
+++ b/compiler/circle-execution-plan/src/CircleExecutionPlan.cpp
@@ -46,7 +46,7 @@ int entry(int argc, char **argv)
     .type(arser::DataType::BOOL)
     .required(false)
     .default_value(false)
-    .help("Plan with or without dsp");
+    .help("Plan with or without dsp (now can be used only with cmsisnn)");
 
   try
   {
@@ -63,6 +63,12 @@ int entry(int argc, char **argv)
   std::string output_path = arser.get<std::string>("output");
   std::string platform_name = arser.get<std::string>("--platform");
   bool use_dsp = arser.get<bool>("--use_dsp");
+
+  if (platform_name != "cmsisnn" && use_dsp)
+  {
+    std::cerr << "ERROR: Now use_dsp can be used only with cmsisnn" << std::endl;
+    return EXIT_FAILURE;
+  }
 
   circle_planner::SupportedPlatformType platform_type;
   if (platform_name == "linux")
@@ -115,7 +121,7 @@ int entry(int argc, char **argv)
   auto module = importer.importModule(circle_model);
 
   // Do main job
-  circle_planner::ExecutionPlanner execution_planner(module->graph(), platform_type, use_dsp);
+  circle_planner::ExecutionPlanner execution_planner(module->graph(), {platform_type, use_dsp});
   execution_planner.make_execution_plan();
 
   // Export to output Circle file

--- a/compiler/circle-execution-plan/src/CircleExecutionPlan.cpp
+++ b/compiler/circle-execution-plan/src/CircleExecutionPlan.cpp
@@ -35,6 +35,18 @@ int entry(int argc, char **argv)
 
   arser.add_argument("input").nargs(1).type(arser::DataType::STR).help("Input circle model");
   arser.add_argument("output").nargs(1).type(arser::DataType::STR).help("Output circle model");
+  arser.add_argument("--platform")
+    .nargs(1)
+    .type(arser::DataType::STR)
+    .required(false)
+    .default_value("linux")
+    .help("Platform name: linux mcu cmsisnn");
+  arser.add_argument("--use_dsp")
+    .nargs(1)
+    .type(arser::DataType::BOOL)
+    .required(false)
+    .default_value(false)
+    .help("Plan with or without dsp");
 
   try
   {
@@ -49,6 +61,27 @@ int entry(int argc, char **argv)
 
   std::string input_path = arser.get<std::string>("input");
   std::string output_path = arser.get<std::string>("output");
+  std::string platform_name = arser.get<std::string>("--platform");
+  bool use_dsp = arser.get<bool>("--use_dsp");
+
+  circle_planner::SupportedPlatformType platform_type;
+  if (platform_name == "linux")
+  {
+    platform_type = circle_planner::SupportedPlatformType::LINUX;
+  }
+  else if (platform_name == "mcu")
+  {
+    platform_type = circle_planner::SupportedPlatformType::MCU;
+  }
+  else if (platform_name == "cmsisnn")
+  {
+    platform_type = circle_planner::SupportedPlatformType::CMSISNN;
+  }
+  else
+  {
+    std::cerr << "ERROR: Invalid platform name '" << platform_name << "'" << std::endl;
+    return EXIT_FAILURE;
+  }
 
   foder::FileLoader file_loader{input_path};
   std::vector<char> model_data;
@@ -82,7 +115,7 @@ int entry(int argc, char **argv)
   auto module = importer.importModule(circle_model);
 
   // Do main job
-  circle_planner::ExecutionPlanner execution_planner(module->graph());
+  circle_planner::ExecutionPlanner execution_planner(module->graph(), platform_type, use_dsp);
   execution_planner.make_execution_plan();
 
   // Export to output Circle file

--- a/compiler/circle-execution-plan/src/ExecutionPlanner.cpp
+++ b/compiler/circle-execution-plan/src/ExecutionPlanner.cpp
@@ -358,34 +358,41 @@ void ExecutionPlanner::create_alloc_node_inform_vector(bool null_consts, bool nu
       _alloc_node_inform_vector[i].size = node_size;
     }
 
-    // Im2col
-    auto opcode = circle_node->opcode();
-    if (opcode == luci::CircleOpcode::CONV_2D)
+    // Scratchpad If needed
+    uint32_t scratchpad_size;
+    switch (circle_node->opcode())
     {
-      auto conv = loco::must_cast<const luci::CircleConv2D *>(circle_node);
-      auto im2col_size = compute_im2col_size(conv);
-      if (im2col_size > 0)
+      case luci::CircleOpcode::CONV_2D:
       {
-        AllocationNodeInformation temp_alloc;
-
-        if (null_im2col)
-        {
-          temp_alloc.size = 0;
-        }
-        else
-        {
-          temp_alloc.size = im2col_size;
-        }
-
-        temp_alloc.first_node = i - 1;
-        temp_alloc.last_node = i + 1;
-        temp_alloc.node_num = i;
-        temp_alloc.is_temp = true;
-
-        _alloc_node_inform_vector.push_back(temp_alloc);
-        _alloc_node.push_back(i);
-        _dealloc_node.push_back(i);
+        auto conv = loco::must_cast<const luci::CircleConv2D *>(circle_node);
+        scratchpad_size = _scratchpad_helper->ComputeScratchpadSizeConv2d(conv);
+        break;
       }
+      default:
+        scratchpad_size = 0;
+    }
+
+    if (scratchpad_size > 0)
+    {
+      AllocationNodeInformation temp_alloc;
+
+      if (null_im2col)
+      {
+        temp_alloc.size = 0;
+      }
+      else
+      {
+        temp_alloc.size = scratchpad_size;
+      }
+
+      temp_alloc.first_node = i - 1;
+      temp_alloc.last_node = i + 1;
+      temp_alloc.node_num = i;
+      temp_alloc.is_temp = true;
+
+      _alloc_node_inform_vector.push_back(temp_alloc);
+      _alloc_node.push_back(i);
+      _dealloc_node.push_back(i);
     }
   }
   // Sort _alloc_node_inform_vector with node_compare for the greedy by size approach.

--- a/compiler/circle-execution-plan/src/ExecutionPlanner.h
+++ b/compiler/circle-execution-plan/src/ExecutionPlanner.h
@@ -23,16 +23,10 @@
 #include "ScratchpadHelperLinux.h"
 #include "ScratchpadHelperMCU.h"
 #include "ScratchpadHelperCMSISNN.h"
+#include "TargetPlatform.h"
 
 namespace circle_planner
 {
-
-enum SupportedPlatformType
-{
-  LINUX,
-  MCU,
-  CMSISNN
-};
 
 // struct for additional information for the node. it helps build allocations plan for nodes.
 struct AllocationNodeInformation
@@ -77,11 +71,9 @@ public:
     _scratchpad_helper = std::make_unique<ScratchpadHelperLinux>();
   }
 
-  explicit ExecutionPlanner(loco::Graph *graph, SupportedPlatformType platform_type,
-                            bool use_dsp = false)
-    : _graph(graph)
+  explicit ExecutionPlanner(loco::Graph *graph, TargetPlatform target_platform) : _graph(graph)
   {
-    switch (platform_type)
+    switch (target_platform.platform_type)
     {
       case LINUX:
         _scratchpad_helper = std::make_unique<ScratchpadHelperLinux>();
@@ -90,7 +82,7 @@ public:
         _scratchpad_helper = std::make_unique<ScratchpadHelperMCU>();
         break;
       case CMSISNN:
-        _scratchpad_helper = std::make_unique<ScratchpadHelperCMSISNN>(use_dsp);
+        _scratchpad_helper = std::make_unique<ScratchpadHelperCMSISNN>(target_platform.use_dsp);
         break;
       default:
         assert(false && "Use unsupported platform");


### PR DESCRIPTION
This pr adds pal interface for different platforms to correctly calculation of the size of the scratchpad.

ONE-DCO-1.0-Signed-off-by: Artem Balyshev a.balyshev@partner.samsung.com