### PR TITLE
[luci/svc] Use copy_quantparam in copy_common_attriburtes

### DIFF
--- a/compiler/luci/service/src/CircleNodeClone.cpp
+++ b/compiler/luci/service/src/CircleNodeClone.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "luci/IR/CircleQuantParam.h"
 #include "luci/Service/CircleNodeClone.h"
 
 #include "CircleCloneNode.h"
@@ -45,18 +46,7 @@ void copy_common_attributes(const luci::CircleNode *src, luci::CircleNode *dst)
   dst->shape_status(src->shape_status());
 
   // quantparam
-  const auto *quantparam = src->quantparam();
-  if (quantparam != nullptr)
-  {
-    auto qparam = std::make_unique<luci::CircleQuantParam>();
-    qparam->scale = quantparam->scale;
-    qparam->zerop = quantparam->zerop;
-    qparam->min = quantparam->min;
-    qparam->max = quantparam->max;
-    qparam->quantized_dimension = quantparam->quantized_dimension;
-
-    dst->quantparam(std::move(qparam));
-  }
+  copy_quantparam(src, dst);
 
   // sparsity
   const auto *sparsity = src->sparsityparam();


### PR DESCRIPTION
This will revise copy_common_attributes method to use copy_quantparam method.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>