### PR TITLE
[tflitefile_tools] Revisit ModelParser and TFLiteParser

### DIFF
--- a/tools/tflitefile_tool/model_parser.py
+++ b/tools/tflitefile_tool/model_parser.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 import argparse
-from parser.model_parser import TFLiteModelFileParser
+from parser.tflite_parser import TFLiteParser
 '''
 Why is this file named as `model_parser.py` which is same to `parser/model_parser.py`?
 - Until now, users have used by the path `tools/tflitefile_tool/model_parser.py`.
@@ -85,5 +85,6 @@ if __name__ == '__main__':
         '-p', '--prefix', help="file prefix to be saved (with -c/--config option)")
     args = arg_parser.parse_args()
 
+    # TODO: Call TFLiteParser if file's extension is 'tflite'
     # Call main function
-    TFLiteModelFileParser(MainOption(args)).main()
+    TFLiteParser(MainOption(args)).main()

--- a/tools/tflitefile_tool/parser/tflite_parser.py
+++ b/tools/tflitefile_tool/parser/tflite_parser.py
@@ -17,22 +17,23 @@
 import tflite.Model
 import tflite.SubGraph
 from ir import graph_stats
+from .model_parser import ModelParser
 from .operator_parser import OperatorParser
 
 
-class TFLiteParser(object):
-    def __init__(self, tflite_file):
-        self.tflite_file = tflite_file
-        self.subg_list = list()
+class TFLiteParser(ModelParser):
+    def __init__(self, option):
+        super(TFLiteParser, self).__init__(option)
 
-    def parse(self):
+    def Parse(self):
         # Generate Model: top structure of tflite model file
-        buf = self.tflite_file.read()
+        buf = self.option.model_file.read()
         buf = bytearray(buf)
         tf_model = tflite.Model.Model.GetRootAsModel(buf, 0)
 
         stats = graph_stats.GraphStats()
         # Model file can have many models
+        self.subg_list = list()
         for subgraph_index in range(tf_model.SubgraphsLength()):
             tf_subgraph = tf_model.Subgraphs(subgraph_index)
             model_name = "#{0} {1}".format(subgraph_index, tf_subgraph.Name())


### PR DESCRIPTION
Let's revisit ModelParser and TFLiteParser so that there are now
parent(ModelParser) and child(TFLiteParser).

Signed-off-by: Yongseop Kim <yons.kim@samsung.com>

---

for https://github.com/Samsung/ONE/issues/8086