### PR TITLE
[one-cmd] Use latest pip and setuptools

### DIFF
--- a/compiler/one-cmds/one-prepare-venv
+++ b/compiler/one-cmds/one-prepare-venv
@@ -54,7 +54,7 @@ if [[ ! -z "$ONE_PREPVENV_PIP_OPTION" ]]; then
   PIP_OPTIONS+=" ${ONE_PREPVENV_PIP_OPTION} "
 fi
 
-${VENV_PYTHON} -m pip ${PIP_OPTIONS} install pip setuptools
+${VENV_PYTHON} -m pip ${PIP_OPTIONS} install --upgrade pip setuptools
 ${VENV_PYTHON} -m pip ${PIP_OPTIONS} install tensorflow-cpu==${VER_TENSORFLOW}
 ${VENV_PYTHON} -m pip ${PIP_OPTIONS} install Pillow==6.2.2
 


### PR DESCRIPTION
This commit will allow to maintain latest pip and setuptools version.

Sometimes new library version installation requrires new pip version.

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>