### PR TITLE
[record-minmax] Skip minmax recording for integer tensors

### DIFF
--- a/compiler/record-minmax/src/MinMaxObserver.cpp
+++ b/compiler/record-minmax/src/MinMaxObserver.cpp
@@ -51,6 +51,16 @@ void MinMaxObserver::postTensorWrite(const luci::CircleNode *node,
     // Bool type tensor is not quantized
     return;
   }
+  if (node->dtype() == DataType::S32)
+  {
+    // Integer type tensor is not quantized
+    return;
+  }
+  if (node->dtype() == DataType::S64)
+  {
+    // Integer type tensor is not quantized
+    return;
+  }
 
   // Only support recording of float32 values
   if (tensor->element_type() != DataType::FLOAT32)


### PR DESCRIPTION
This commit introduces skip of min/max recording for integer tensors.

ONE-DCO-1.0-Signed-off-by: Maksim Bronnikov <max120199@gmail.com>

-------------

For: #8065
Draft: #8171