### PR TITLE
[one-cmds] Add parameter to autodetect drivers

### DIFF
--- a/compiler/one-cmds/one-build
+++ b/compiler/one-cmds/one-build
@@ -154,7 +154,8 @@ def main():
     config = _parse_cfg(args)
 
     # verify configuration file
-    import_drivers_dict = _utils._detect_one_import_drivers()
+    bin_dir = os.path.dirname(os.path.realpath(__file__))
+    import_drivers_dict = _utils._detect_one_import_drivers(bin_dir)
     transform_drivers = [
         'one-optimize', 'one-quantize', 'one-pack', 'one-codegen', 'one-profile'
     ]

--- a/compiler/one-cmds/onecc
+++ b/compiler/one-cmds/onecc
@@ -162,7 +162,8 @@ def main():
     config = _parse_cfg(args)
 
     # verify configuration file
-    import_drivers_dict = _utils._detect_one_import_drivers()
+    bin_dir = os.path.dirname(os.path.realpath(__file__))
+    import_drivers_dict = _utils._detect_one_import_drivers(bin_dir)
     transform_drivers = [
         'one-optimize', 'one-quantize', 'one-pack', 'one-codegen', 'one-profile'
     ]

--- a/compiler/one-cmds/utils.py
+++ b/compiler/one-cmds/utils.py
@@ -374,8 +374,11 @@ def _get_optimization_list(get_name=False):
     return opt_list
 
 
-def _detect_one_import_drivers():
-    """Looks for import drivers, located in same directory as utils module
+def _detect_one_import_drivers(search_path):
+    """Looks for import drivers in given directory
+
+    Args:
+        search_path: path to the directory where to search import drivers
 
     Returns:
     dict: each entry is related to single detected driver,
@@ -383,9 +386,8 @@ def _detect_one_import_drivers():
 
     """
     import_drivers_dict = {}
-    bin_dir = os.path.dirname(os.path.realpath(__file__))
-    for module_name in os.listdir(bin_dir):
-        full_path = os.path.join(bin_dir, module_name)
+    for module_name in os.listdir(search_path):
+        full_path = os.path.join(search_path, module_name)
         if not os.path.isfile(full_path):
             continue
         if module_name.find("one-import-") != 0:


### PR DESCRIPTION
This PR adds search path parameter to _detect_one_import_drivers.

Related issue: #8169.

ONE-DCO-1.0-Signed-off-by: Alexander Efimov <a.efimov@samsung.com>