### PR TITLE
[record-minmax] Remove redundant ArgMax case

### DIFF
--- a/compiler/record-minmax/src/MinMaxObserver.cpp
+++ b/compiler/record-minmax/src/MinMaxObserver.cpp
@@ -68,9 +68,6 @@ void MinMaxObserver::postTensorWrite(const luci::CircleNode *node,
     // Exceptions that should be processed in backends
     switch (node->opcode())
     {
-      case luci::CircleOpcode::ARG_MAX:
-        // Output of arg_max is the index of the largest value across axes of a tensor.
-        // It always has integer type.
       case luci::CircleOpcode::CAST:
         // Cast is quantized only if it converts <type> -> float.
         // Other cases should be processed in backends.


### PR DESCRIPTION
This commit removes redundant ArgMax's case in MinMaxObserver.

ONE-DCO-1.0-Signed-off-by: Maksim Bronnikov <max120199@gmail.com>

------------------

For: https://github.com/Samsung/ONE/pull/8171#discussion_r770117180