### PR TITLE
[tflitefile_tools] Fix ModelParser's hierarchy

### DIFF
--- a/tools/tflitefile_tool/model_parser.py
+++ b/tools/tflitefile_tool/model_parser.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 import argparse
-from parser.tflite_parser import TFLiteParser
+from parser.model_parser import ModelParser
 from printer.subgraph_printer import SubgraphPrinter
 from saver.model_saver import ModelSaver
 '''
@@ -107,8 +107,7 @@ if __name__ == '__main__':
     args = arg_parser.parse_args()
     option = MainOption(args)
 
-    # TODO: Call TFLiteParser if file's extension is 'tflite'
-    (subg_list, stats) = TFLiteParser(option.model_file).Parse()
+    (subg_list, stats) = ModelParser(option.model_file).Parse()
 
     for model_name, op_parser in subg_list:
         if option.save == False:

--- a/tools/tflitefile_tool/parser/model_parser.py
+++ b/tools/tflitefile_tool/parser/model_parser.py
@@ -14,12 +14,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from parser.tflite_parser import TFLiteParser
+
 
 class ModelParser(object):
     def __init__(self, model_file):
-        self.model_file = model_file
+        self.parser = None
+        # model_file: _io.BufferedReader
+        if model_file.name.endswith("tflite"):
+            self.parser = TFLiteParser(model_file)
+        # TODO: Add more parser
 
-    # to be overriden
     def Parse(self):
-        # Should return (subg_list, stats)
-        raise NotImplementedError
+        if self.parser is None:
+            raise NotImplementedError
+        return self.parser.Parse()

--- a/tools/tflitefile_tool/parser/tflite_parser.py
+++ b/tools/tflitefile_tool/parser/tflite_parser.py
@@ -17,13 +17,12 @@
 import tflite.Model
 import tflite.SubGraph
 from ir import graph_stats
-from .model_parser import ModelParser
 from .operator_parser import OperatorParser
 
 
-class TFLiteParser(ModelParser):
+class TFLiteParser(object):
     def __init__(self, model_file):
-        super(TFLiteParser, self).__init__(model_file)
+        self.model_file = model_file
 
     def Parse(self):
         # Generate Model: top structure of tflite model file


### PR DESCRIPTION
Let's fix ModelParser's hierarchy from `is-a` to `has-a`.

Signed-off-by: Yongseop Kim <yons.kim@samsung.com>

---

for https://github.com/Samsung/ONE/issues/8086
draft https://github.com/Samsung/ONE/pull/8184

PTAL @hseok-oh and @chunseoklee 