### PR TITLE
[luci/pass] Quantize OneHot indices

### DIFF
--- a/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
+++ b/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
@@ -1215,9 +1215,10 @@ void quantize_one_hot_indices(luci::CircleOneHot *one_hot, loco::DataType quant_
 
   // check indices can be represented by quantized values range
   assert(quant_type == loco::DataType::U8 || quant_type == loco::DataType::S16);
-  if (quant_type == loco::DataType::U8 && std::numeric_limits<uint8_t>::max() < depth_value)
+  if (quant_type == loco::DataType::U8 && std::numeric_limits<uint8_t>::max() + 1 < depth_value)
     throw std::runtime_error("Impossible to quantize input range with quantization type");
-  else if (quant_type == loco::DataType::S16 && std::numeric_limits<int16_t>::max() < depth_value)
+  else if (quant_type == loco::DataType::S16 &&
+           std::numeric_limits<int16_t>::max() + 1 < depth_value)
     throw std::runtime_error("Impossible to quantize input range with quantization type");
 
   // skip if already quantized

--- a/compiler/luci/pass/src/VerifyQuantizedNodeChannelWiseGranularity.h
+++ b/compiler/luci/pass/src/VerifyQuantizedNodeChannelWiseGranularity.h
@@ -261,6 +261,7 @@ private:
   bool visit(const luci::CircleOneHot *node)
   {
     RETURN_FALSE_UNLESS(is_lwq(node));
+    RETURN_FALSE_UNLESS(is_lwq(node->indices()));
     RETURN_FALSE_UNLESS(is_lwq(node->off_value()));
     RETURN_FALSE_UNLESS(is_lwq(node->on_value()));
     return true;

--- a/compiler/luci/pass/src/VerifyQuantizedNodeLayerWiseGranularity.h
+++ b/compiler/luci/pass/src/VerifyQuantizedNodeLayerWiseGranularity.h
@@ -246,6 +246,7 @@ private:
 
   bool visit(const luci::CircleOneHot *node)
   {
+    RETURN_FALSE_UNLESS(is_lwq(node->indices()));
     RETURN_FALSE_UNLESS(is_lwq(node->off_value()));
     RETURN_FALSE_UNLESS(is_lwq(node->on_value()));
     RETURN_FALSE_UNLESS(is_lwq(node));

--- a/compiler/luci/pass/src/VerifyQuantizedNodeS16Type.h
+++ b/compiler/luci/pass/src/VerifyQuantizedNodeS16Type.h
@@ -224,8 +224,7 @@ private:
   bool visit(const luci::CircleOneHot *node)
   {
     RETURN_FALSE_UNLESS(has_type(node, loco::DataType::S16));
-    RETURN_FALSE_UNLESS(has_type(node->indices(), loco::DataType::S32) ||
-                        has_type(node->indices(), loco::DataType::S64));
+    RETURN_FALSE_UNLESS(has_type(node->indices(), loco::DataType::S16));
     RETURN_FALSE_UNLESS(has_type(node->depth(), loco::DataType::S32));
     RETURN_FALSE_UNLESS(has_type(node->on_value(), loco::DataType::S16));
     RETURN_FALSE_UNLESS(has_type(node->off_value(), loco::DataType::S16));

--- a/compiler/luci/pass/src/VerifyQuantizedNodeU8Type.h
+++ b/compiler/luci/pass/src/VerifyQuantizedNodeU8Type.h
@@ -231,8 +231,7 @@ private:
   bool visit(const luci::CircleOneHot *node)
   {
     RETURN_FALSE_UNLESS(has_type(node, loco::DataType::U8));
-    RETURN_FALSE_UNLESS(has_type(node->indices(), loco::DataType::S32) ||
-                        has_type(node->indices(), loco::DataType::S64));
+    RETURN_FALSE_UNLESS(has_type(node->indices(), loco::DataType::U8));
     RETURN_FALSE_UNLESS(has_type(node->depth(), loco::DataType::S32));
     RETURN_FALSE_UNLESS(has_type(node->on_value(), loco::DataType::U8));
     RETURN_FALSE_UNLESS(has_type(node->off_value(), loco::DataType::U8));


### PR DESCRIPTION
This commit enables quantization of OneHot's integer indices.

ONE-DCO-1.0-Signed-off-by: Maksim Bronnikov <max120199@gmail.com>

-----------

For avoiding not `U8/S16` model's inputs.