### PR TITLE
[tflitefile_tools] Rename properly to subgraph

### DIFF
--- a/tools/tflitefile_tool/ir/graph_stats.py
+++ b/tools/tflitefile_tool/ir/graph_stats.py
@@ -39,17 +39,17 @@ class GraphStats():
         return self
 
 
-def CalcGraphStats(op_parser):
+def CalcGraphStats(subg_parser):
     stats = GraphStats()
 
-    for type_str, oper_list in op_parser.operators_per_type.items():
+    for type_str, oper_list in subg_parser.operators_per_type.items():
         # number of occurrence of this operator type
         occur = len(oper_list)
         stats.accumulate_op_count(type_str, occur)
 
     total_memory = 0
     filled_memory = 0  # only memory for constant
-    for tensor in op_parser.GetAllTensors():
+    for tensor in subg_parser.GetAllTensors():
         if tensor.tf_buffer.DataLength() != 0:
             filled_memory += tensor.memory_size
         total_memory += tensor.memory_size

--- a/tools/tflitefile_tool/model_parser.py
+++ b/tools/tflitefile_tool/model_parser.py
@@ -64,8 +64,8 @@ class MainOption(object):
             self.save_prefix = args.prefix
 
 
-def PrintModel(option, model_name, op_parser):
-    printer = SubgraphPrinter(option.print_level, op_parser, model_name)
+def PrintSubgraph(option, model_name, subg_parser):
+    printer = SubgraphPrinter(option.print_level, subg_parser, model_name)
 
     if option.print_all_tensor == False:
         printer.SetPrintSpecificTensors(option.print_tensor_index)
@@ -76,8 +76,8 @@ def PrintModel(option, model_name, op_parser):
     printer.PrintInfo()
 
 
-def SaveModel(option, model_name, op_parser):
-    saver = ModelSaver(model_name, op_parser)
+def SaveSubgraph(option, model_name, subg_parser):
+    saver = ModelSaver(model_name, subg_parser)
 
     if option.save_config == True:
         saver.SaveConfigInfo(option.save_prefix)
@@ -109,10 +109,10 @@ if __name__ == '__main__':
 
     (subg_list, stats) = ModelParser(option.model_file).Parse()
 
-    for model_name, op_parser in subg_list:
+    for model_name, subg_parser in subg_list:
         if option.save == False:
             # print all of operators or requested objects
-            PrintModel(option, model_name, op_parser)
+            PrintSubgraph(option, model_name, subg_parser)
         else:
             # save all of operators in this model
-            SaveModel(option, model_name, op_parser)
+            SaveSubgraph(option, model_name, subg_parser)

--- a/tools/tflitefile_tool/parser/subgraph_parser.py
+++ b/tools/tflitefile_tool/parser/subgraph_parser.py
@@ -13,7 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+# TODO: Do not use this module
 import tflite.Model
 import tflite.SubGraph
 import tflite.Operator
@@ -23,7 +23,7 @@ from parser.tflite.operator_wrapping import Operator, EnumStrMaps
 from parser.tflite.tensor_wrapping import Tensor, SetTensorTypeStr
 
 
-class OperatorParser(object):
+class SubgraphParser(object):
     def __init__(self, tf_model, tf_subgraph):
         self.tf_model = tf_model
         self.tf_subgraph = tf_subgraph

--- a/tools/tflitefile_tool/parser/tflite_parser.py
+++ b/tools/tflitefile_tool/parser/tflite_parser.py
@@ -13,11 +13,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+# TODO: Do not use this module
 import tflite.Model
 import tflite.SubGraph
 from ir import graph_stats
-from .operator_parser import OperatorParser
+from .subgraph_parser import SubgraphParser
 
 
 class TFLiteParser(object):
@@ -40,13 +40,13 @@ class TFLiteParser(object):
             if (subgraph_index == 0):
                 model_name += " (MAIN)"
 
-            # Parse Operators
-            op_parser = OperatorParser(tf_model, tf_subgraph)
-            op_parser.Parse()
+            # Parse Subgraphs
+            subg_parser = SubgraphParser(tf_model, tf_subgraph)
+            subg_parser.Parse()
 
-            stats += graph_stats.CalcGraphStats(op_parser)
+            stats += graph_stats.CalcGraphStats(subg_parser)
 
-            subg = (model_name, op_parser)
+            subg = (model_name, subg_parser)
             subg_list.append(subg)
 
         # Validate

--- a/tools/tflitefile_tool/saver/model_saver.py
+++ b/tools/tflitefile_tool/saver/model_saver.py
@@ -18,13 +18,13 @@ from .config_saver import ConfigSaver
 
 
 class ModelSaver(object):
-    def __init__(self, model_name, op_parser):
+    def __init__(self, model_name, subg_parser):
         self.model_name = model_name
-        self.op_parser = op_parser
+        self.subg_parser = subg_parser
 
     def SaveConfigInfo(self, prefix):
         print("Save model configuration file")
-        for type_str, oper_list in self.op_parser.operators_per_type.items():
+        for type_str, oper_list in self.subg_parser.operators_per_type.items():
             if prefix:
                 file_name = "{}_{}_{}.config".format(prefix, self.model_name, type_str)
             else:


### PR DESCRIPTION
Let's rename model and operator parser to subgraph.

Signed-off-by: Yongseop Kim <yons.kim@samsung.com>

---

for https://github.com/Samsung/ONE/issues/8086
draft https://github.com/Samsung/ONE/pull/8184

PTAL @hseok-oh and @chunseoklee 