### PR TITLE
[tflitefile_tools] Revise printer/

### DIFF
--- a/tools/tflitefile_tool/printer/subgraph_printer.py
+++ b/tools/tflitefile_tool/printer/subgraph_printer.py
@@ -71,7 +71,7 @@ class SubgraphPrinter(object):
             return
 
         for operator in self.op_parser.operators_in_list:
-            info = StringBuilder(self.verbose).Operator(operator)
+            info = StringBuilder().Operator(operator)
             if info is not None:
                 print(info)
                 print('')
@@ -80,19 +80,21 @@ class SubgraphPrinter(object):
 
     def PrintSpecificTensors(self, print_tensor_index_list, depth_str=""):
         for tensor in self.op_parser.GetTensors(print_tensor_index_list):
-            info = StringBuilder(self.verbose).Tensor(tensor, depth_str)
+            info = StringBuilder().Tensor(tensor, depth_str)
             if info is not None:
                 print(info)
 
     def PrintSpecificOperators(self, print_operator_index_list):
         for operator in self.op_parser.operators_in_list:
             if operator.operator_idx in print_operator_index_list:
-                info = StringBuilder(self.verbose).Operator(operator)
+                info = StringBuilder().Operator(operator)
                 if info is not None:
                     print(info)
                     print('')
 
     def PrintGraphStats(self, stats):
-        info = StringBuilder(self.verbose).GraphStats(stats)
+        info = StringBuilder().GraphStats(stats)
         if info is not None:
             print(info)
+
+    # TODO: def PrintBuffers(self)


### PR DESCRIPTION
Let's revise printer files.
- '\t' -> '  ' (two spaces)
- The only SubgraphPrinter has `verbose`
- '#', '%', or '&' instead of string

Signed-off-by: Yongseop Kim <yons.kim@samsung.com>

---

for https://github.com/Samsung/ONE/issues/8086
draft https://github.com/Samsung/ONE/pull/8184

PTAL @hseok-oh and @chunseoklee 