### PR TITLE
[luci-interpreter] Move common activation related code to utils

### DIFF
--- a/compiler/luci-interpreter/src/kernels/Add.cpp
+++ b/compiler/luci-interpreter/src/kernels/Add.cpp
@@ -76,13 +76,8 @@ void Add::execute() const
 
 void Add::evalFloat() const
 {
-  float activation_min{};
-  float activation_max{};
-  calculateActivationRange(_params.activation, &activation_min, &activation_max);
-
   tflite::ArithmeticParams params{};
-  params.float_activation_min = activation_min;
-  params.float_activation_max = activation_max;
+  fillArithmeticActivationRange<float>(params, _params.activation);
 
   const bool need_broadcast = tflite::reference_ops::ProcessBroadcastShapes(
     getTensorShape(input1()), getTensorShape(input2()), &params);
@@ -104,23 +99,7 @@ void Add::evalFloat() const
 template <typename T> void Add::evalInteger() const
 {
   tflite::ArithmeticParams params{};
-  if (std::is_same<T, int32_t>::value)
-  {
-    int32_t activation_min{};
-    int32_t activation_max{};
-    calculateActivationRange(_params.activation, &activation_min, &activation_max);
-    params.quantized_activation_min = activation_min;
-    params.quantized_activation_max = activation_max;
-  }
-  else
-  {
-    assert((std::is_same<T, int64_t>::value));
-    int64_t activation_min{};
-    int64_t activation_max{};
-    calculateActivationRange(_params.activation, &activation_min, &activation_max);
-    params.int64_activation_min = activation_min;
-    params.int64_activation_max = activation_max;
-  }
+  fillArithmeticActivationRange<T>(params, _params.activation);
 
   const bool need_broadcast = tflite::reference_ops::ProcessBroadcastShapes(
     getTensorShape(input1()), getTensorShape(input2()), &params);

--- a/compiler/luci-interpreter/src/kernels/Div.cpp
+++ b/compiler/luci-interpreter/src/kernels/Div.cpp
@@ -62,13 +62,9 @@ void Div::execute() const
 
 void Div::evalFloat() const
 {
-  float activation_min{};
-  float activation_max{};
-  calculateActivationRange(_params.activation, &activation_min, &activation_max);
-
   tflite::ArithmeticParams params{};
-  params.float_activation_min = activation_min;
-  params.float_activation_max = activation_max;
+  fillArithmeticActivationRange<float>(params, _params.activation);
+
   const bool need_broadcast = tflite::reference_ops::ProcessBroadcastShapes(
     getTensorShape(input1()), getTensorShape(input2()), &params);
 
@@ -88,22 +84,8 @@ void Div::evalFloat() const
 
 template <typename T> void Div::evalInteger() const
 {
-  T activation_min{};
-  T activation_max{};
-  calculateActivationRange(_params.activation, &activation_min, &activation_max);
-
   tflite::ArithmeticParams params{};
-  if (std::is_same<T, int32_t>::value)
-  {
-    params.quantized_activation_min = activation_min;
-    params.quantized_activation_max = activation_max;
-  }
-  else
-  {
-    assert((std::is_same<T, int64_t>::value));
-    params.int64_activation_min = activation_min;
-    params.int64_activation_max = activation_max;
-  }
+  fillArithmeticActivationRange<T>(params, _params.activation);
 
   const bool need_broadcast = tflite::reference_ops::ProcessBroadcastShapes(
     getTensorShape(input1()), getTensorShape(input2()), &params);

--- a/compiler/luci-interpreter/src/kernels/Mul.cpp
+++ b/compiler/luci-interpreter/src/kernels/Mul.cpp
@@ -74,13 +74,8 @@ void Mul::execute() const
 
 void Mul::evalFloat() const
 {
-  float activation_min{};
-  float activation_max{};
-  calculateActivationRange(_params.activation, &activation_min, &activation_max);
-
   tflite::ArithmeticParams params{};
-  params.float_activation_min = activation_min;
-  params.float_activation_max = activation_max;
+  fillArithmeticActivationRange<float>(params, _params.activation);
 
   const bool need_broadcast = tflite::reference_ops::ProcessBroadcastShapes(
     getTensorShape(input1()), getTensorShape(input2()), &params);
@@ -101,22 +96,8 @@ void Mul::evalFloat() const
 
 template <typename T> void Mul::evalInteger() const
 {
-  T activation_min{};
-  T activation_max{};
-  calculateActivationRange(_params.activation, &activation_min, &activation_max);
-
   tflite::ArithmeticParams params{};
-  if (std::is_same<T, int32_t>::value)
-  {
-    params.quantized_activation_min = activation_min;
-    params.quantized_activation_max = activation_max;
-  }
-  else
-  {
-    assert((std::is_same<T, int64_t>::value));
-    params.int64_activation_min = activation_min;
-    params.int64_activation_max = activation_max;
-  }
+  fillArithmeticActivationRange<T>(params, _params.activation);
 
   const bool need_broadcast = tflite::reference_ops::ProcessBroadcastShapes(
     getTensorShape(input1()), getTensorShape(input2()), &params);

--- a/compiler/luci-interpreter/src/kernels/Sub.cpp
+++ b/compiler/luci-interpreter/src/kernels/Sub.cpp
@@ -64,13 +64,8 @@ void Sub::execute() const
 
 void Sub::evalFloat() const
 {
-  float activation_min{};
-  float activation_max{};
-  calculateActivationRange(_params.activation, &activation_min, &activation_max);
-
   tflite::ArithmeticParams params{};
-  params.float_activation_min = activation_min;
-  params.float_activation_max = activation_max;
+  fillArithmeticActivationRange<float>(params, _params.activation);
 
   const bool need_broadcast = tflite::reference_ops::ProcessBroadcastShapes(
     getTensorShape(input1()), getTensorShape(input2()), &params);
@@ -92,23 +87,7 @@ void Sub::evalFloat() const
 template <typename T> void Sub::evalInteger() const
 {
   tflite::ArithmeticParams params{};
-  if (std::is_same<T, int32_t>::value)
-  {
-    int32_t activation_min{};
-    int32_t activation_max{};
-    calculateActivationRange(_params.activation, &activation_min, &activation_max);
-    params.quantized_activation_min = activation_min;
-    params.quantized_activation_max = activation_max;
-  }
-  else
-  {
-    assert((std::is_same<T, int64_t>::value));
-    int64_t activation_min{};
-    int64_t activation_max{};
-    calculateActivationRange(_params.activation, &activation_min, &activation_max);
-    params.int64_activation_min = activation_min;
-    params.int64_activation_max = activation_max;
-  }
+  fillArithmeticActivationRange<T>(params, _params.activation);
 
   const bool need_broadcast = tflite::reference_ops::ProcessBroadcastShapes(
     getTensorShape(input1()), getTensorShape(input2()), &params);

--- a/compiler/luci-interpreter/src/kernels/Utils.h
+++ b/compiler/luci-interpreter/src/kernels/Utils.h
@@ -82,6 +82,36 @@ void calculateActivationRange(Activation activation, T *activation_min, T *activ
 void calculateActivationRangeQuantized(Activation activation, const Tensor *output,
                                        int32_t *activation_min, int32_t *activation_max);
 
+template <typename T> constexpr bool one_of_types() { return false; }
+
+// Checks if T is equal to one of {U,Other} types
+template <typename T, typename U, typename... Other> constexpr bool one_of_types()
+{
+  return std::is_same<T, U>::value || one_of_types<T, Other...>();
+}
+
+/**
+ * Fills activation min and max parameters depending on given data type and activation
+ *
+ * T is a template parameter, so after optimization this code left with only required if case
+ *
+ * @tparam T data type of arithmetic operation output tensor
+ * @param params tflite params to fill
+ * @param activation luci_interpreter::Activation of arithmetic operation
+ */
+template <typename T>
+void fillArithmeticActivationRange(tflite::ArithmeticParams &p, Activation act)
+{
+  static_assert(one_of_types<T, float, int32_t, int64_t>(), "Unsupported dtype");
+
+  if (std::is_same<T, float>::value)
+    calculateActivationRange(act, &p.float_activation_min, &p.float_activation_max);
+  if (std::is_same<T, int32_t>::value)
+    calculateActivationRange(act, &p.quantized_activation_min, &p.quantized_activation_max);
+  else
+    calculateActivationRange(act, &p.int64_activation_min, &p.int64_activation_max);
+}
+
 // Decompose a double multiplier into a Q0.31 int32 representation of its
 // significand, and shift representation of its exponent.
 //


### PR DESCRIPTION
This PR moves computation of min/max activation values from arithmetic kernels
to Utils.h for float, S32 and S64 types.

Simplify code added in #8155 

ONE-DCO-1.0-Signed-off-by: Alexander Efimov <a.efimov@samsung.com>