### PR TITLE
[one-cmds] Add dedicated builder methods for various operations

### DIFF
--- a/compiler/one-cmds/onnx_legalizer.py
+++ b/compiler/one-cmds/onnx_legalizer.py
@@ -99,7 +99,8 @@ class ModelTransformerHelper:
             list: list of output tensor names
 
         '''
-        return self.make_node('Split', [input], len(split_sizes), axis = axis, split = split_sizes)
+        return self.make_node(
+            'Split', [input], len(split_sizes), axis=axis, split=split_sizes)
 
     def make_concat(self, inputs, axis):
         '''Create Concat operation and insert it in graph.
@@ -112,7 +113,7 @@ class ModelTransformerHelper:
             str:: output tensor name
 
         '''
-        return self.make_node('Concat', inputs, 1, axis = axis)[0]
+        return self.make_node('Concat', inputs, 1, axis=axis)[0]
 
     def make_squeeze(self, input, axes):
         '''Create Squeeze operation and insert it in graph.
@@ -125,7 +126,7 @@ class ModelTransformerHelper:
             str: output tensor name
 
         '''
-        return self.make_node('Squeeze', [input], 1, axes = axes)[0]
+        return self.make_node('Squeeze', [input], 1, axes=axes)[0]
 
     def make_unsqueeze(self, input, axes):
         '''Create Unsqueeze operation and insert it in graph.
@@ -138,9 +139,9 @@ class ModelTransformerHelper:
             str: output tensor name
 
         '''
-        return self.make_node('Unsqueeze', [input], 1, axes = axes)[0]
+        return self.make_node('Unsqueeze', [input], 1, axes=axes)[0]
 
-    def make_gemm(self, A, B, C, trans_a = False, trans_b = False):
+    def make_gemm(self, A, B, C, trans_a=False, trans_b=False):
         '''Create Gemm operation and insert it in graph.
 
         Result tensor contains A*B + C
@@ -156,7 +157,8 @@ class ModelTransformerHelper:
             str: output tensor name
 
         '''
-        return self.make_node('Gemm', [A, B, C], 1, transA = bool(trans_a), transB = bool(trans_b))[0]
+        return self.make_node(
+            'Gemm', [A, B, C], 1, transA=bool(trans_a), transB=bool(trans_b))[0]
 
     def make_add(self, a, b):
         '''Creates Add operation and insert it in graph.
@@ -196,7 +198,7 @@ class ModelTransformerHelper:
             str: output tensor name
 
         '''
-        return self.make_node('Clip', [input], 1, min = min, max = max)[0]
+        return self.make_node('Clip', [input], 1, min=min, max=max)[0]
 
     def make_act(self, input, act_name):
         '''Create activation function operation and insert it in graph.
@@ -209,7 +211,7 @@ class ModelTransformerHelper:
             str: output tensor name
 
         '''
-        assert(act_name in ['Relu', 'Tanh', 'Sigmoid'])
+        assert (act_name in ['Relu', 'Tanh', 'Sigmoid'])
         return self.make_node(act_name, [input], 1)[0]
 
     def make_constant_tensor(self, tensor_data, base_name):
@@ -303,7 +305,8 @@ def generate_one_direction_RNN(transformer, X, W, R, B, initial_h, clip, activat
 
     for i in range(first_iter, seq_length):
         state_tensor = transformer.make_gemm(X[i], W, B, trans_b=True)
-        state_tensor = transformer.make_gemm(previous_state_tensor, R, state_tensor, trans_b=True)
+        state_tensor = transformer.make_gemm(
+            previous_state_tensor, R, state_tensor, trans_b=True)
         if clip != None:
             state_tensor = transformer.make_clip(state_tensor, min=-clip, max=clip)
         previous_state_tensor = transformer.make_act(state_tensor, activation_name)
@@ -321,7 +324,8 @@ def transform_unidirectional_RNN(transformer, original_node, x, tensor_infos, ac
     r = transformer.make_squeeze(inputs[2], axes=[0])
     if len(inputs) > 3 and inputs[3] != '':
         raw_bias_tensor = transformer.make_squeeze(inputs[3], axes=[0])
-        splitted_bias_tensors = transformer.make_split(raw_bias_tensor, split_sizes = [hidden_size] * 2, axis=0)
+        splitted_bias_tensors = transformer.make_split(
+            raw_bias_tensor, split_sizes=[hidden_size] * 2, axis=0)
         b = transformer.make_add(splitted_bias_tensors[0], splitted_bias_tensors[1])
     else:
         data_type = dtype_to_np(tensor_infos[inputs[2]].dtype)
@@ -340,7 +344,9 @@ def transform_unidirectional_RNN(transformer, original_node, x, tensor_infos, ac
     state_layout_tensors = []
     seq_length_dim = layout
     for state in state_tensors:
-        state_layout_tensors += [transformer.make_unsqueeze(state, axes=[seq_length_dim, y_direction_dim])]
+        state_layout_tensors += [
+            transformer.make_unsqueeze(state, axes=[seq_length_dim, y_direction_dim])
+        ]
 
     # use low-level interface to attach to existing tensors
     Y_h = transformer.make_node(
@@ -353,8 +359,8 @@ def transform_bidirectional_RNN(transformer, original_node, x, tensor_infos, act
                                 clip, hidden_size, layout):
     inputs = original_node.input
     outputs = original_node.output
-    w_bi = transformer.make_split(inputs[1], split_sizes=[1,1], axis=0)
-    r_bi = transformer.make_split(inputs[2], split_sizes = [1,1], axis=0)
+    w_bi = transformer.make_split(inputs[1], split_sizes=[1, 1], axis=0)
+    r_bi = transformer.make_split(inputs[2], split_sizes=[1, 1], axis=0)
     w = []
     r = []
     for d in range(2):
@@ -363,19 +369,26 @@ def transform_bidirectional_RNN(transformer, original_node, x, tensor_infos, act
 
     b = []
     if len(inputs) > 3 and inputs[3] != '':
-        raw_bias_tensors = transformer.make_split(inputs[3], split_sizes=[1,1], axis=0)
+        raw_bias_tensors = transformer.make_split(inputs[3], split_sizes=[1, 1], axis=0)
         for d in range(2):
-            raw_bias_tensors_squeezed = transformer.make_squeeze(raw_bias_tensors[d], axes=[0])
-            splitted_bias_tensors = transformer.make_split(raw_bias_tensors_squeezed, split_sizes=[hidden_size] * 2, axis=0)
-            b += [transformer.make_add(splitted_bias_tensors[0], splitted_bias_tensors[1])]
+            raw_bias_tensors_squeezed = transformer.make_squeeze(
+                raw_bias_tensors[d], axes=[0])
+            splitted_bias_tensors = transformer.make_split(
+                raw_bias_tensors_squeezed, split_sizes=[hidden_size] * 2, axis=0)
+            b += [
+                transformer.make_add(splitted_bias_tensors[0], splitted_bias_tensors[1])
+            ]
     else:
         data_type = dtype_to_np(tensor_infos[inputs[2]].dtype)
-        b = [transformer.make_constant_tensor(
-            np.zeros(hidden_size, dtype=data_type), "zero_bias")] * 2
+        b = [
+            transformer.make_constant_tensor(
+                np.zeros(hidden_size, dtype=data_type), "zero_bias")
+        ] * 2
     initial_h = [None, None]
     if len(inputs) > 5 and inputs[5] != '':
         direction_dim = layout
-        initial_h = transformer.make_split(inputs[5], split_sizes=[1,1], axis=direction_dim)
+        initial_h = transformer.make_split(
+            inputs[5], split_sizes=[1, 1], axis=direction_dim)
         for d in range(2):
             initial_h[d] = transformer.make_squeeze(initial_h[d], axes=[direction_dim])
 
@@ -394,17 +407,23 @@ def transform_bidirectional_RNN(transformer, original_node, x, tensor_infos, act
     for t in range(seq_length):
         state_f = state_f_tensors[t]
         state_b = state_b_tensors[t]
-        state_layout_tensors_f = transformer.make_unsqueeze(state_f, axes=[seq_length_dim, y_direction_dim])
-        state_layout_tensors_b = transformer.make_unsqueeze(state_b, axes=[seq_length_dim, y_direction_dim])
-        state_layout_tensors += [transformer.make_concat([state_layout_tensors_f, state_layout_tensors_b], axis=y_direction_dim)]
+        state_layout_tensors_f = transformer.make_unsqueeze(
+            state_f, axes=[seq_length_dim, y_direction_dim])
+        state_layout_tensors_b = transformer.make_unsqueeze(
+            state_b, axes=[seq_length_dim, y_direction_dim])
+        state_layout_tensors += [
+            transformer.make_concat(
+                [state_layout_tensors_f, state_layout_tensors_b], axis=y_direction_dim)
+        ]
 
-    last_f_state_layout_tensor = transformer.make_unsqueeze(state_f_tensors[-1], axes=[y_h_direction_dim])
-    last_b_state_layout_tensor = transformer.make_unsqueeze(state_b_tensors[0], axes=[y_h_direction_dim])
+    last_f_state_layout_tensor = transformer.make_unsqueeze(
+        state_f_tensors[-1], axes=[y_h_direction_dim])
+    last_b_state_layout_tensor = transformer.make_unsqueeze(
+        state_b_tensors[0], axes=[y_h_direction_dim])
 
     # use low-level interface to attach to existing tensors
     Y_h = transformer.make_node(
-        'Concat',
-        [last_f_state_layout_tensor, last_b_state_layout_tensor], [outputs[1]],
+        'Concat', [last_f_state_layout_tensor, last_b_state_layout_tensor], [outputs[1]],
         axis=y_h_direction_dim)
 
     Y = transformer.make_node(
@@ -451,7 +470,8 @@ def legalize_RNN(transformer, tensor_infos, node):
     if hidden_size == 0:
         hidden_size = tensor_infos[inputs[2]].shape[2]
 
-    input_split_tensor = transformer.make_split(inputs[0], split_sizes=[1] * seq_length, axis=seq_length_dim)
+    input_split_tensor = transformer.make_split(
+        inputs[0], split_sizes=[1] * seq_length, axis=seq_length_dim)
     x = []
     for i in range(len(input_split_tensor)):
         input_frame_tensor = input_split_tensor[i]
@@ -529,13 +549,18 @@ def generate_one_direction_LSTM(transformer, X, W, R, B, initial_h, initial_c, P
     R = {'i': r_tensors[0], 'o': r_tensors[1], 'f': r_tensors[2], 'c': r_tensors[3]}
 
     if B is not None:
-        separate_b_tensors = transformer.make_split(B, split_sizes=[hidden_size] * 8, axis=0)
+        separate_b_tensors = transformer.make_split(
+            B, split_sizes=[hidden_size] * 8, axis=0)
         b_tensors = []
         for i in range(4):
-            b_tensors += [transformer.make_add(separate_b_tensors[i], separate_b_tensors[i + 4])]
+            b_tensors += [
+                transformer.make_add(separate_b_tensors[i], separate_b_tensors[i + 4])
+            ]
     else:
-        b_tensors = [transformer.make_constant_tensor(
-            np.zeros((hidden_size), dtype=dtype), 'zero_b')] * 4
+        b_tensors = [
+            transformer.make_constant_tensor(
+                np.zeros((hidden_size), dtype=dtype), 'zero_b')
+        ] * 4
     B = {'i': b_tensors[0], 'o': b_tensors[1], 'f': b_tensors[2], 'c': b_tensors[3]}
 
     if initial_h is not None:
@@ -591,8 +616,8 @@ def generate_one_direction_LSTM(transformer, X, W, R, B, initial_h, initial_c, P
         previous_c_state_tensor = Ct
 
         # ot = f(Xt*(Wo^T) + Ht-1*(Ro^T) + Po (.) Ct + Wbo + Rbo)
-        ot = transformer.make_gemm(X[i], W['o'], B['o'], trans_b = True)
-        ot = transformer.make_gemm(previous_h_state_tensor, R['o'], ot, trans_b = True)
+        ot = transformer.make_gemm(X[i], W['o'], B['o'], trans_b=True)
+        ot = transformer.make_gemm(previous_h_state_tensor, R['o'], ot, trans_b=True)
         peephole_ot = transformer.make_mul(P['o'], Ct)
         ot = transformer.make_add(ot, peephole_ot)
         if clip is not None:
@@ -649,7 +674,9 @@ def transform_unidirectional_LSTM(transformer, original_node, x, tensor_infos,
     state_layout_tensors = []
     seq_length_dim = layout
     for h_state in state_h_tensors:
-        state_layout_tensors += [transformer.make_unsqueeze(h_state, axes=[seq_length_dim, y_direction_dim])]
+        state_layout_tensors += [
+            transformer.make_unsqueeze(h_state, axes=[seq_length_dim, y_direction_dim])
+        ]
 
     # use low-level interface to attach to existing tensors
     Y_h = transformer.make_node(
@@ -667,35 +694,37 @@ def transform_bidirectional_LSTM(transformer, original_node, x, tensor_infos, ac
     inputs = original_node.input
     outputs = original_node.output
 
-    w = transformer.make_split(inputs[1], split_sizes=[1,1], axis=0)
-    r = transformer.make_split(inputs[2], split_sizes=[1,1], axis=0)
+    w = transformer.make_split(inputs[1], split_sizes=[1, 1], axis=0)
+    r = transformer.make_split(inputs[2], split_sizes=[1, 1], axis=0)
     for d in range(2):
         w[d] = transformer.make_squeeze(w[d], axes=[0])
         r[d] = transformer.make_squeeze(r[d], axes=[0])
 
     b = [None, None]
     if len(inputs) > 3 and inputs[3] != '':
-        b = transformer.make_split(inputs[3], split_sizes=[1,1], axis=0)
+        b = transformer.make_split(inputs[3], split_sizes=[1, 1], axis=0)
         for d in range(2):
             b[d] = transformer.make_squeeze(b[d], axes=[0])
 
     initial_h = [None, None]
     if len(inputs) > 5 and inputs[5] != '':
         direction_dim = layout
-        initial_h = transformer.make_split(inputs[5], split_sizes=[1,1], axis=direction_dim)
+        initial_h = transformer.make_split(
+            inputs[5], split_sizes=[1, 1], axis=direction_dim)
         for d in range(2):
             initial_h[d] = transformer.make_squeeze(initial_h[d], axes=[direction_dim])
 
     initial_c = [None, None]
     if len(inputs) > 6 and inputs[6] != '':
         direction_dim = layout
-        initial_c = transformer.make_split(inputs[6], split_sizes=[1,1], axis=direction_dim)
+        initial_c = transformer.make_split(
+            inputs[6], split_sizes=[1, 1], axis=direction_dim)
         for d in range(2):
             initial_c[d] = transformer.make_squeeze(initial_c[d], axes=[direction_dim])
 
     p = [None, None]
     if len(inputs) > 7 and inputs[7] != '':
-        p = transformer.make_split(inputs[7], split_sizes=[1,1], axis=0)
+        p = transformer.make_split(inputs[7], split_sizes=[1, 1], axis=0)
         for d in range(2):
             p[d] = transformer.make_squeeze(p[d], axes=[0])
 
@@ -726,15 +755,21 @@ def transform_bidirectional_LSTM(transformer, original_node, x, tensor_infos, ac
     state_layout_tensors = []
     seq_length_dim = layout
     for f_h_state, b_h_state in zip(state_f_h_tensors, state_b_h_tensors):
-        state_f_layout_tensors = transformer.make_unsqueeze(f_h_state, axes=[seq_length_dim, y_direction_dim])
-        state_b_layout_tensors = transformer.make_unsqueeze(b_h_state, axes=[seq_length_dim, y_direction_dim])
-        state_layout_tensors += [transformer.make_concat([state_f_layout_tensors, state_b_layout_tensors], axis=y_direction_dim)]
+        state_f_layout_tensors = transformer.make_unsqueeze(
+            f_h_state, axes=[seq_length_dim, y_direction_dim])
+        state_b_layout_tensors = transformer.make_unsqueeze(
+            b_h_state, axes=[seq_length_dim, y_direction_dim])
+        state_layout_tensors += [
+            transformer.make_concat(
+                [state_f_layout_tensors, state_b_layout_tensors], axis=y_direction_dim)
+        ]
 
-    last_f_state_layout_tensor = transformer.make_unsqueeze(state_f_h_tensors[-1], axes=[y_c_direction_dim])
-    last_b_state_layout_tensor = transformer.make_unsqueeze(state_b_h_tensors[0], axes=[y_c_direction_dim])
+    last_f_state_layout_tensor = transformer.make_unsqueeze(
+        state_f_h_tensors[-1], axes=[y_c_direction_dim])
+    last_b_state_layout_tensor = transformer.make_unsqueeze(
+        state_b_h_tensors[0], axes=[y_c_direction_dim])
     Y_h = transformer.make_node(
-        'Concat',
-        [last_f_state_layout_tensor, last_b_state_layout_tensor], [outputs[1]],
+        'Concat', [last_f_state_layout_tensor, last_b_state_layout_tensor], [outputs[1]],
         axis=y_c_direction_dim)
 
     Y_f_c = transformer.make_unsqueeze(state_f_c_tensor, axes=[y_c_direction_dim])
@@ -792,7 +827,8 @@ def legalize_LSTM(transformer, tensor_infos, node):
     if hidden_size == 0:
         hidden_size = tensor_infos[inputs[2]].shape[2]
 
-    input_split_tensor = transformer.make_split(inputs[0], split_sizes=[1] * seq_length, axis=seq_length_dim)
+    input_split_tensor = transformer.make_split(
+        inputs[0], split_sizes=[1] * seq_length, axis=seq_length_dim)
     x = []
     for i in range(len(input_split_tensor)):
         input_frame_tensor = input_split_tensor[i]


### PR DESCRIPTION
This PR adds dedicated methods to create operations of particular type.
This change should improve readability and remove some code duplication.

Related issue: #8148

ONE-DCO-1.0-Signed-off-by: Alexander Efimov <a.efimov@samsung.com>