### PR TITLE
[luci/export] Introduce new registerBuiltinOpcode function

### DIFF
--- a/compiler/luci/export/src/CircleExporterUtils.cpp
+++ b/compiler/luci/export/src/CircleExporterUtils.cpp
@@ -196,6 +196,22 @@ uint32_t SerializedModelData::registerCustomOpcode(const std::string &custom_cod
   return idx;
 }
 
+uint32_t SerializedModelData::registerBuiltinOpcode(circle::BuiltinOperator builtin_code,
+                                                    const std::string &custom_code,
+                                                    const int32_t op_version)
+{
+  assert(op_version > 0);
+
+  auto it = _operator_codes.find(OpCode{builtin_code, custom_code, op_version});
+  if (it != _operator_codes.end())
+  {
+    return it->second;
+  }
+  auto idx = static_cast<uint32_t>(_operator_codes.size());
+  _operator_codes.emplace(OpCode{builtin_code, custom_code, op_version}, idx);
+  return idx;
+}
+
 circle::Padding getOpPadding(const loco::Padding2D *pad, const loco::Stride<2> *stride,
                              const ShapeDescription &ifm, const ShapeDescription &ofm)
 {

--- a/compiler/luci/export/src/SerializedData.h
+++ b/compiler/luci/export/src/SerializedData.h
@@ -23,7 +23,7 @@
 #include <luci/IR/ExecutionPlanTable.h>
 
 #include <vector>
-
+#include <string>
 #include <unordered_map>
 #include <map>
 
@@ -133,6 +133,8 @@ struct SerializedModelData final
    */
   uint32_t registerBuiltinOpcode(circle::BuiltinOperator builtin_code, const int32_t op_version);
   uint32_t registerCustomOpcode(const std::string &custom_op);
+  uint32_t registerBuiltinOpcode(circle::BuiltinOperator builtin_code,
+                                 const std::string &custom_code, const int32_t op_version);
 };
 
 // Prerequisites for circle::Model object creation


### PR DESCRIPTION
For now, there were two registering Opcode functions,
`registerBuiltinOpcode` and `registerCustomOpcode`.
However, they have duplicated logics to register Opcode.
This commit introduces a new function which unfies duplicate logics as one.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>

---

Parent Issue : #8198
Draft : #8199