### PR TITLE
[luci/pass] Fix check_4d_reshape method

### DIFF
--- a/compiler/luci/pass/src/ConvertNCHWToNHWCPass.cpp
+++ b/compiler/luci/pass/src/ConvertNCHWToNHWCPass.cpp
@@ -228,6 +228,9 @@ bool check_4d_reshape(loco::Node *node, const std::vector<int32_t> indices)
   if (input->shape_status() != luci::ShapeStatus::VALID)
     return false;
 
+  if (input->rank() != 4)
+    return false;
+
   if (reshape->shape_status() != luci::ShapeStatus::VALID)
     return false;
 


### PR DESCRIPTION
This will fix check_4d_reshape to check input rank is 4.

Signed-off-by: SaeHie Park <saehie.park@gmail.com>