### PR TITLE
[luci/export] Introduce new util functions

### DIFF
--- a/compiler/luci/export/src/CircleExporterUtils.cpp
+++ b/compiler/luci/export/src/CircleExporterUtils.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "CircleExporterUtils.h"
+#include "CircleBuiltinTypesMappingRule.h"
 
 #include <oops/InternalExn.h>
 
@@ -161,6 +162,45 @@ circle::SparseIndexVector to_circle_sparse_index_vector_type(luci::SparseIndexVe
       INTERNAL_EXN_V("trying to convert unsupported luci::SparseIndexVectorType",
                      oops::to_uint32(type));
   }
+}
+
+circle::BuiltinOperator circle_builtin_operator(const luci::CircleNode *node)
+{
+  return node->accept(&BuiltinOperatorMappingRule::get());
+}
+
+circle::BuiltinOptions circle_builtin_options(const luci::CircleNode *node)
+{
+  if (auto cast = dynamic_cast<const luci::CircleCast *>(node))
+  {
+    return (cast->out_data_type() == loco::DataType::Unknown) ? circle::BuiltinOptions_NONE
+                                                              : circle::BuiltinOptions_CastOptions;
+  }
+
+  return node->accept(&BuiltinOptionsMappingRule::get());
+}
+
+std::string circle_custom_code(const luci::CircleNode *node)
+{
+  if (auto custom_node = dynamic_cast<const luci::CircleCustom *>(node))
+  {
+    return custom_node->custom_code();
+  }
+
+  return "";
+}
+
+flatbuffers::Offset<flatbuffers::Vector<uint8_t>>
+circle_custom_options(flatbuffers::FlatBufferBuilder &fb, const luci::CircleNode *node)
+{
+  if (auto custom_node = dynamic_cast<const luci::CircleCustom *>(node))
+  {
+    std::vector<uint8_t> custom_options_vec{custom_node->custom_options().begin(),
+                                            custom_node->custom_options().end()};
+    return fb.CreateVector(custom_options_vec);
+  }
+
+  return 0;
 }
 
 } // namespace luci

--- a/compiler/luci/export/src/CircleExporterUtils.h
+++ b/compiler/luci/export/src/CircleExporterUtils.h
@@ -26,8 +26,6 @@
 
 #include <mio/circle/schema_generated.h>
 
-#include <flatbuffers/flexbuffers.h>
-
 namespace luci
 {
 

--- a/compiler/luci/export/src/CircleExporterUtils.h
+++ b/compiler/luci/export/src/CircleExporterUtils.h
@@ -26,6 +26,8 @@
 
 #include <mio/circle/schema_generated.h>
 
+#include <flatbuffers/flexbuffers.h>
+
 namespace luci
 {
 
@@ -38,6 +40,12 @@ circle::DimensionType to_circle_dimensiontype(luci::DimensionType type);
 flatbuffers::Offset<void> to_circle_sparse_index_vector(flatbuffers::FlatBufferBuilder &fb,
                                                         const SparseIndexVector &sparse_idx_vec);
 circle::SparseIndexVector to_circle_sparse_index_vector_type(luci::SparseIndexVectorType type);
+
+circle::BuiltinOperator circle_builtin_operator(const luci::CircleNode *node);
+circle::BuiltinOptions circle_builtin_options(const luci::CircleNode *node);
+std::string circle_custom_code(const luci::CircleNode *node);
+flatbuffers::Offset<flatbuffers::Vector<uint8_t>>
+circle_custom_options(flatbuffers::FlatBufferBuilder &fb, const luci::CircleNode *node);
 
 } // namespace luci
 


### PR DESCRIPTION
This commit will introduce following new util functions for export.
- `circle_builtin_operator`
- `circle_builtin_options`
- `circle_custom_code`
- `circle_custom_options`

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>

---

Parent Issue : #8198
Draft : #8199