### PR TITLE
[tflitefile_tool] Use workaround for EndVector

### DIFF
--- a/tools/tflitefile_tool/select_operator.py
+++ b/tools/tflitefile_tool/select_operator.py
@@ -25,10 +25,10 @@ import argparse
 import pkg_resources
 
 
-# On flatbuffers 2.0, EndVector doesn't requires length argument any more.
+# On flatbuffers 2.0, EndVector doesn't require length argument any more.
 # But flatbuffers under 2.0 (ex. 1.12) requires length argument.
 # We need this workaround until we abandon flatbuffers 1.12.
-# Refernece: https://github.com/google/flatbuffers/issues/6858
+# Reference: https://github.com/google/flatbuffers/issues/6858
 def EndVector(builder, len):
     flat_version = pkg_resources.get_distribution('flatbuffers').version
     if pkg_resources.parse_version(flat_version) < pkg_resources.parse_version("2.0"):


### PR DESCRIPTION
Flatbuffers changes EndVector argument on 2.0.
Let's use workaround to support flatbuffers 1.12 and 2.0 for a while.

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>