### PR TITLE
[luci/export] Revise exportNodes function

### DIFF
--- a/compiler/luci/export/src/CircleOperationExporter.cpp
+++ b/compiler/luci/export/src/CircleOperationExporter.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "CircleOperationExporter.h"
+#include "CircleOperationExporterRule.h"
 #include "CircleExporterUtils.h"
 #include "Check.h"
 
@@ -31,6 +32,7 @@
 
 #include <flatbuffers/flexbuffers.h>
 
+#if 0
 using namespace flatbuffers;
 using namespace circle;
 
@@ -1724,17 +1726,53 @@ void exportNode(loco::Node *node, flatbuffers::FlatBufferBuilder &builder, Seria
 }
 
 } // namespace
+#endif
 
 namespace luci
 {
 
-void exportNodes(loco::Graph *g, FlatBufferBuilder &builder, SerializedModelData &md,
+void exportNodes(loco::Graph *g, flatbuffers::FlatBufferBuilder &builder, SerializedModelData &md,
                  SerializedGraphData &gd)
 {
   uint32_t node_position = 0;
   for (auto node : loco::postorder_traversal(loco::output_nodes(g)))
   {
-    exportNode(node, builder, md, gd, node_position);
+    // exportNode(node, builder, md, gd, node_position);
+    if (auto circle_node = dynamic_cast<luci::CircleNode *>(node))
+    {
+      ExportContext ctx{builder, md, gd};
+      OperationExporterRule exporter_rule{ctx};
+
+      const auto ops_size = gd._operators.size();
+
+      circle_node->accept(&exporter_rule);
+      if (has_origin(circle_node) && ops_size != gd._operators.size())
+      {
+        const auto node_id = gd._operators.size() - 1;
+        for (auto source : get_origin(circle_node)->sources())
+        {
+          md._metadata.add_op_table(node_id, source->id());
+        }
+      }
+      if (has_execution_plan(circle_node))
+      {
+        // Add to node (in node_position) metadata vector with execution_plan information:
+        // order of execution, and offsets output tensors.
+        const auto execution_plan = get_execution_plan(circle_node);
+        std::vector<uint32_t> execution_plan_vector;
+        execution_plan_vector.push_back(execution_plan.order_in_plan());
+        for (auto offset : execution_plan.offsets())
+        {
+          execution_plan_vector.push_back(offset);
+        }
+        md._metadata.add_execution_plan_table(node_position, execution_plan_vector);
+      }
+    }
+    else
+    {
+      INTERNAL_EXN("Node with unsupported dialect found");
+    }
+
     node_position++;
   }
 }


### PR DESCRIPTION
This commit revise `exportNodes` function with following updates.
- Integrate `exportNode` into `exportNodes`
- Substitute `OperationExporter` with `OperationExporterRule`

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>

---

Parent Issue : #8198
Draft : #8199