### PR TITLE
[infra] Revise gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,16 @@
-tests/nnapi/specs/* linguist-detectable=false
-res/* linguist-detectable=false
+# Exclude from git language statistics
+tests/nnapi/specs/** linguist-detectable=false
+res/** linguist-detectable=false
+
+# Default: text file
+# - Set End-Of-Line type
+* text eol=lf
+
+# Binary - ignore text file setting
+*.caffemodel -text
+*.png -text
+*.pdf -text
+*.h5 -text
+*.tar.gz -text
+*.tflite -text
+*.bmp -text


### PR DESCRIPTION
This commit updates .gitattributes file for basic format setting.

- Fix invalid language statics pattern
- Set default EOL type: LF

We can remove EOL type checker by this update.

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>