### PR TITLE
[common-artifacts] Split command for better readability

### DIFF
--- a/compiler/common-artifacts/CMakeLists.txt
+++ b/compiler/common-artifacts/CMakeLists.txt
@@ -278,7 +278,10 @@ foreach(RECIPE IN ITEMS ${RECIPES})
     set(INPUT_HDF5_FILE "${TC_DIRECTORY}/input.h5")
     set(EXPECTED_HDF5_FILE "${TC_DIRECTORY}/expected.h5")
     add_custom_command(OUTPUT ${INPUT_HDF5_FILE} ${EXPECTED_HDF5_FILE}
-      COMMAND $<TARGET_FILE:testDataGenerator> --input_data ${INPUT_HDF5_FILE} --expected_data ${EXPECTED_HDF5_FILE} ${MODEL_FILE}
+      COMMAND $<TARGET_FILE:testDataGenerator>
+              --input_data ${INPUT_HDF5_FILE}
+              --expected_data ${EXPECTED_HDF5_FILE}
+              ${MODEL_FILE}
       DEPENDS $<TARGET_FILE:testDataGenerator> ${MODEL_FILE} ${TC_DIRECTORY}
       COMMENT "Generate input.h5 and expected.h5 in ${NNPKG_FILE}/metadata/tc"
     )


### PR DESCRIPTION
This will split command to separate lines for better readability.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>