### PR TITLE
[res] Fix Gather_000 recipe

### DIFF
--- a/res/TensorFlowLiteRecipes/Gather_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/Gather_000/test.recipe
@@ -24,5 +24,4 @@ operation {
   output: "ofm"
 }
 input: "param"
-input: "indices"
 output: "ofm"


### PR DESCRIPTION
This will remove graph input for indices in Gather_000 recipe
as indices is constant buffer.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>