### PR TITLE
[tfldump] Fix typo in descriptor

### DIFF
--- a/compiler/tfldump/src/Load.cpp
+++ b/compiler/tfldump/src/Load.cpp
@@ -76,7 +76,7 @@ public:
   {
     if (_value != -1)
     {
-      // Close on descturction
+      // Close on destructor
       close(_value);
     }
   }


### PR DESCRIPTION
This commit fixes typo in descriptor.

ONE-DCO-1.0-Signed-off-by: yunjayh <yunjayh@gmail.com>