### PR TITLE
[luci] Support const input quantization of Gather

### DIFF
--- a/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
+++ b/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
@@ -1227,6 +1227,7 @@ void quantize_const_inputs(luci::CircleNode *node, loco::DataType output_type)
     case luci::CircleOpcode::ARG_MAX:
     case luci::CircleOpcode::ARG_MIN:
     case luci::CircleOpcode::BATCH_TO_SPACE_ND:
+    case luci::CircleOpcode::GATHER:
     case luci::CircleOpcode::LOCAL_RESPONSE_NORMALIZATION:
     case luci::CircleOpcode::MEAN:
     case luci::CircleOpcode::MIRROR_PAD:


### PR DESCRIPTION
This commit adds support for const input quantization for Gather op.

Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>