### PR TITLE
[circle-execution-plan] Add command line interface and TargetPlatform

### DIFF
--- a/compiler/circle-execution-plan/CMakeLists.txt
+++ b/compiler/circle-execution-plan/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(SOURCES
+        pal/TargetPlatform.h
         src/CircleExecutionPlan.cpp
         src/ExecutionPlanner.cpp
         src/ExecutionPlanner.h
@@ -13,4 +14,5 @@ target_link_libraries(circle_execution_plan luci_export)
 target_link_libraries(circle_execution_plan luci_plan)
 target_link_libraries(circle_execution_plan arser)
 
+target_include_directories(circle_execution_plan PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/pal")
 install(TARGETS circle_execution_plan DESTINATION bin)

--- a/compiler/circle-execution-plan/pal/TargetPlatform.h
+++ b/compiler/circle-execution-plan/pal/TargetPlatform.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/compiler/circle-execution-plan/pal/TargetPlatform.h
+++ b/compiler/circle-execution-plan/pal/TargetPlatform.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CIRCLE_EXECUTION_PLAN_TARGET_PLATFORM_H
+#define CIRCLE_EXECUTION_PLAN_TARGET_PLATFORM_H
+
+namespace circle_planner
+{
+
+enum SupportedPlatformType
+{
+  LINUX,
+  MCU,
+  CMSISNN
+};
+
+struct TargetPlatform
+{
+  SupportedPlatformType platform_type;
+  bool use_dsp;
+};
+
+} // namespace circle_planner
+
+#endif // CIRCLE_EXECUTION_PLAN_TARGET_PLATFORM_H

--- a/compiler/circle-execution-plan/src/CircleExecutionPlan.cpp
+++ b/compiler/circle-execution-plan/src/CircleExecutionPlan.cpp
@@ -59,10 +59,10 @@ int entry(int argc, char **argv)
     return 255;
   }
 
-  std::string input_path = arser.get<std::string>("input");
-  std::string output_path = arser.get<std::string>("output");
-  std::string platform_name = arser.get<std::string>("--platform");
-  bool use_dsp = arser.get<bool>("--use_dsp");
+  const std::string input_path = arser.get<std::string>("input");
+  const std::string output_path = arser.get<std::string>("output");
+  const std::string platform_name = arser.get<std::string>("--platform");
+  const bool use_dsp = arser.get<bool>("--use_dsp");
 
   if (platform_name != "cmsisnn" && use_dsp)
   {

--- a/compiler/circle-execution-plan/src/ExecutionPlanner.cpp
+++ b/compiler/circle-execution-plan/src/ExecutionPlanner.cpp
@@ -74,6 +74,7 @@ bool isTensorProducingNode(const luci::CircleNode *node)
 }
 
 // Method finds (if necessary) size for im2col temporary tensor.
+// TODO: remove it when ScratchpadHelper will be added
 uint32_t compute_im2col_size(const luci::CircleConv2D *conv)
 {
   auto conv_input = loco::must_cast<luci::CircleNode *>(conv->input());
@@ -358,34 +359,42 @@ void ExecutionPlanner::create_alloc_node_inform_vector(bool null_consts, bool nu
       _alloc_node_inform_vector[i].size = node_size;
     }
 
-    // Im2col
-    auto opcode = circle_node->opcode();
-    if (opcode == luci::CircleOpcode::CONV_2D)
+    // Scratchpad If needed
+    uint32_t scratchpad_size = 0;
+    switch (circle_node->opcode())
     {
-      auto conv = loco::must_cast<const luci::CircleConv2D *>(circle_node);
-      auto im2col_size = compute_im2col_size(conv);
-      if (im2col_size > 0)
+      case luci::CircleOpcode::CONV_2D:
       {
-        AllocationNodeInformation temp_alloc;
-
-        if (null_im2col)
-        {
-          temp_alloc.size = 0;
-        }
-        else
-        {
-          temp_alloc.size = im2col_size;
-        }
-
-        temp_alloc.first_node = i - 1;
-        temp_alloc.last_node = i + 1;
-        temp_alloc.node_num = i;
-        temp_alloc.is_temp = true;
-
-        _alloc_node_inform_vector.push_back(temp_alloc);
-        _alloc_node.push_back(i);
-        _dealloc_node.push_back(i);
+        auto conv = loco::must_cast<const luci::CircleConv2D *>(circle_node);
+        scratchpad_size = compute_im2col_size(
+          conv); // TODO: rewrite it with ScratchpadHelper method when it will be added
+        break;
       }
+      default:
+        scratchpad_size = 0;
+    }
+
+    if (scratchpad_size > 0)
+    {
+      AllocationNodeInformation temp_alloc;
+
+      if (null_im2col)
+      {
+        temp_alloc.size = 0;
+      }
+      else
+      {
+        temp_alloc.size = scratchpad_size;
+      }
+
+      temp_alloc.first_node = i - 1;
+      temp_alloc.last_node = i + 1;
+      temp_alloc.node_num = i;
+      temp_alloc.is_temp = true;
+
+      _alloc_node_inform_vector.push_back(temp_alloc);
+      _alloc_node.push_back(i);
+      _dealloc_node.push_back(i);
     }
   }
   // Sort _alloc_node_inform_vector with node_compare for the greedy by size approach.

--- a/compiler/circle-execution-plan/src/ExecutionPlanner.cpp
+++ b/compiler/circle-execution-plan/src/ExecutionPlanner.cpp
@@ -295,7 +295,7 @@ uint32_t ExecutionPlanner::greedy_by_size_approach()
 }
 
 void ExecutionPlanner::create_alloc_node_inform_vector(bool null_consts, bool null_inputs,
-                                                       bool null_im2col)
+                                                       bool null_scratchpad)
 {
   auto node_compare = [this](const AllocationNodeInformation &alloc_1,
                              const AllocationNodeInformation &alloc_2) {
@@ -366,8 +366,8 @@ void ExecutionPlanner::create_alloc_node_inform_vector(bool null_consts, bool nu
       case luci::CircleOpcode::CONV_2D:
       {
         auto conv = loco::must_cast<const luci::CircleConv2D *>(circle_node);
-        scratchpad_size = compute_im2col_size(
-          conv); // TODO: rewrite it with ScratchpadHelper method when it will be added
+        // TODO: rewrite it with ScratchpadHelper method when it will be added
+        scratchpad_size = null_scratchpad ? 0 : compute_im2col_size(conv);
         break;
       }
       default:
@@ -378,15 +378,7 @@ void ExecutionPlanner::create_alloc_node_inform_vector(bool null_consts, bool nu
     {
       AllocationNodeInformation temp_alloc;
 
-      if (null_im2col)
-      {
-        temp_alloc.size = 0;
-      }
-      else
-      {
-        temp_alloc.size = scratchpad_size;
-      }
-
+      temp_alloc.size = scratchpad_size;
       temp_alloc.first_node = i - 1;
       temp_alloc.last_node = i + 1;
       temp_alloc.node_num = i;

--- a/compiler/circle-execution-plan/src/ExecutionPlanner.h
+++ b/compiler/circle-execution-plan/src/ExecutionPlanner.h
@@ -19,6 +19,7 @@
 
 #include <luci/IR/Module.h>
 #include <luci/Plan/CircleNodeExecutionPlan.h>
+#include "TargetPlatform.h"
 
 namespace circle_planner
 {
@@ -60,7 +61,16 @@ class ExecutionPlanner
 {
 public:
   ExecutionPlanner() = delete;
-  explicit ExecutionPlanner(loco::Graph *graph) { _graph = graph; };
+  explicit ExecutionPlanner(loco::Graph *graph) : _graph(graph)
+  {
+    // Do nothing
+  }
+
+  explicit ExecutionPlanner(loco::Graph *graph, TargetPlatform target_platform) : _graph(graph)
+  {
+    // target_platform will be used when ScratchpadHelper is added
+    (void)target_platform;
+  };
 
   // Method provides execution plan, which contains execution order and
   // memory offsets for all nodes in _graph.

--- a/compiler/circle-execution-plan/src/ExecutionPlanner.h
+++ b/compiler/circle-execution-plan/src/ExecutionPlanner.h
@@ -111,12 +111,12 @@ private:
   // Method creates and fills _alloc_node_inform_vector with usage interval inform and node's sizes.
   // null_consts = true - size of const nodes will be equal 0;
   // null_inputs = true - size of input nodes will be equal 0;
-  // null_im2col = true - size of im2col nodes will be equal 0;
-  // It using if we don't want to take input(const or im2col) nodes into account
+  // null_scratchpad = true - size of scratchpad nodes will be equal 0;
+  // It using if we don't want to take input(const or scratchpads) nodes into account
   // when determining offsets and calculating the required buffer size. This is uses for
   // experiments.
   void create_alloc_node_inform_vector(bool null_consts = false, bool null_inputs = false,
-                                       bool null_im2col = false);
+                                       bool null_scratchpad = false);
 
   // Stores allocation additional information for the all nodes from _graph.
   std::vector<AllocationNodeInformation> _alloc_node_inform_vector;

--- a/compiler/circle-execution-plan/src/ExecutionPlanner.h
+++ b/compiler/circle-execution-plan/src/ExecutionPlanner.h
@@ -17,9 +17,9 @@
 #ifndef CIRCLE_EXECUTION_PLANNER_H
 #define CIRCLE_EXECUTION_PLANNER_H
 
+#include "TargetPlatform.h"
 #include <luci/IR/Module.h>
 #include <luci/Plan/CircleNodeExecutionPlan.h>
-#include "TargetPlatform.h"
 
 namespace circle_planner
 {


### PR DESCRIPTION
This pr adds command line interface + TargetPlatform structure and it's usage in ExecutionPlanner. This is first part of changes for adding pal to circle-execution-planner. 

draft: #8128 

ONE-DCO-1.0-Signed-off-by: Artem Balyshev a.balyshev@partner.samsung.com