### PR TITLE
[common-artifacts] Add node name not empty check

### DIFF
--- a/compiler/common-artifacts/src/TestDataGenerator.cpp
+++ b/compiler/common-artifacts/src/TestDataGenerator.cpp
@@ -243,6 +243,7 @@ int entry(int argc, char **argv)
     {
       const auto *input_node = dynamic_cast<const luci::CircleInput *>(node);
       std::string name = input_node->name();
+      assert(not name.empty());
       if (name.find(":") == std::string::npos)
         name += ":0";
 


### PR DESCRIPTION
This will add node name is not empty assert check for all nodes.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>