### PR TITLE
[luci/import] Add node builder for CircleConst

### DIFF
--- a/compiler/luci/import/include/luci/Import/Nodes/CircleConst.h
+++ b/compiler/luci/import/include/luci/Import/Nodes/CircleConst.h
@@ -17,20 +17,21 @@
 #ifndef __LUCI_IMPORT_OP_CIRCLE_CONST_H__
 #define __LUCI_IMPORT_OP_CIRCLE_CONST_H__
 
-#include "luci/Import/GraphBuilderContext.h"
+#include "luci/Import/NodeBuilder.h"
 
 #include <luci/IR/Nodes/CircleConst.h>
-
-/*
- * @note  Circle does not have Const operator.
- *        Methods here provide helper that creates CircleConst from
- *        Tensor and Buffer in circle flatbuffer file.
- */
 
 namespace luci
 {
 
-CircleConst *create_circleconst(GraphBuilderContext *context, int32_t tensor_index);
+/**
+ * @brief Builder creates CircleConst node from Tensor with buffer.
+ */
+class CircleConstNodeBuilder : public TypedNodeBuilder<NodeBuilderType::BUFFER>
+{
+public:
+  CircleNode *build(TensorIndex tensor_index, GraphBuilderContext *ctx) const final;
+};
 
 } // namespace luci
 

--- a/compiler/luci/import/src/GraphBuilderRegistry.cpp
+++ b/compiler/luci/import/src/GraphBuilderRegistry.cpp
@@ -165,7 +165,7 @@ GraphBuilderRegistry::GraphBuilderRegistry()
   // Register builders for nodes which not handles in builders registered above.
 #define CIRCLE_NODE(CLASS) add(std::make_unique<CLASS>())
 
-  // TODO add ops
+  CIRCLE_NODE(CircleConstNodeBuilder);
 
 #undef CIRCLE_NODE
 }

--- a/compiler/luci/import/src/Importer.cpp
+++ b/compiler/luci/import/src/Importer.cpp
@@ -121,11 +121,15 @@ void convert_graph(const luci::GraphBuilderSource &source, luci::CircleReader &r
     graph_input->shape(std::move(input_shape));
   }
 
-  // Create CircleConst nodes for constant tensors.
+  // Create CircleNodes for constant tensors.
   // NOTE Origin is intentionally not provided for constants.
+  auto const_builder = source.lookup(luci::NodeBuilderType::BUFFER);
+  if (not const_builder)
+    throw oops::UserExn("Not supported", "tensor with buffer builder");
+
   for (uint32_t i = 0; i < tensors.size(); ++i)
   {
-    luci::CircleConst *const_node = luci::create_circleconst(&gb_context, i);
+    auto *const_node = const_builder->build(i, &gb_context);
     if (const_node != nullptr)
       nodefinder->enroll(i, const_node);
   }

--- a/compiler/luci/import/src/Nodes/CircleConst.cpp
+++ b/compiler/luci/import/src/Nodes/CircleConst.cpp
@@ -107,8 +107,10 @@ void copy_data<loco::DataType::STRING>(const VectorWrapper<uint8_t> &raw_data,
 namespace luci
 {
 
-CircleConst *create_circleconst(GraphBuilderContext *context, int32_t tensor_index)
+CircleNode *CircleConstNodeBuilder::build(TensorIndex tensor_index,
+                                          GraphBuilderContext *context) const
 {
+  assert(tensor_index >= 0);
   LOGGER(l);
 
   auto graph = context->graph();


### PR DESCRIPTION
This commit introduces builder for CircleConst node and extracts node creation to this builder.

ONE-DCO-1.0-Signed-off-by: Maksim Bronnikov <max120199@gmail.com>

------------------

For: #8042
Draft: #8190