### PR TITLE
[infra/cmake] Fix to use RESULT_VARIABLE

### DIFF
--- a/infra/cmake/modules/ExternalSourceTools.cmake
+++ b/infra/cmake/modules/ExternalSourceTools.cmake
@@ -104,11 +104,12 @@ function(ExternalSource_Download PREFIX)
     message(STATUS "Extract ${PREFIX}")
     execute_process(COMMAND ${CMAKE_COMMAND} -E tar xfz "${DOWNLOAD_PATH}"
                     WORKING_DIRECTORY "${TMP_DIR}"
+                    RESULT_VARIABLE EXTRACTION_RESULT
                     ERROR_VARIABLE EXTRACTION_ERROR)
 
-    if(EXTRACTION_ERROR)
-      message(FATAL_ERROR "Extract ${PREFIX} - failed")
-    endif(EXTRACTION_ERROR)
+    if(EXTRACTION_RESULT)
+      message(FATAL_ERROR "Extract ${PREFIX} - failed: ${EXTRACTION_ERROR}")
+    endif()
 
     file(REMOVE "${DOWNLOAD_PATH}")
     message(STATUS "Extract ${PREFIX} - done")

--- a/infra/cmake/modules/ExternalSourceTools.cmake
+++ b/infra/cmake/modules/ExternalSourceTools.cmake
@@ -107,7 +107,7 @@ function(ExternalSource_Download PREFIX)
                     RESULT_VARIABLE EXTRACTION_RESULT
                     ERROR_VARIABLE EXTRACTION_ERROR)
 
-    if(EXTRACTION_RESULT)
+    if(EXTRACTION_RESULT AND NOT EXTRACTION_RESULT EQUAL 0)
       message(FATAL_ERROR "Extract ${PREFIX} - failed: ${EXTRACTION_ERROR}")
     endif()
 


### PR DESCRIPTION
Use RESULT_VARIABLE to get exact result status. ERROR_VARIABLE has some
content even when COMMAND prints warning.

ONE-DCO-1.0-Signed-off-by: Yongseop Kim <yons.kim@samsung.com>

---

draft https://github.com/Samsung/ONE/pull/8290