### PR TITLE
[luci/svc] Shape and dtype inference of CircleVariable

### DIFF
--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -2486,6 +2486,8 @@ public:
 
   loco::NodeShape visit(const luci::CircleUnpackOut *node) final { return infer_unpack_out(node); }
 
+  loco::NodeShape visit(const luci::CircleVariable *node) final { return use_own(node); }
+
   loco::NodeShape visit(const luci::CircleWhileOut *node) final { return infer_while_out(node); }
 };
 

--- a/compiler/luci/service/src/CircleTypeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleTypeInferenceRule.cpp
@@ -605,6 +605,8 @@ struct TypeInferenceAlgorithm final : public luci::CircleNodeVisitor<loco::DataT
     return loco::DataType::S32;
   }
 
+  loco::DataType visit(const luci::CircleVariable *node) final { return node->dtype(); }
+
   loco::DataType visit(const luci::CircleUniqueOut *node) final
   {
     if (node->index() == 0)


### PR DESCRIPTION
This will enable shape and dtype inference of CircleVariable Node.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>