### PR TITLE
[luci/import] Enable CircleVariable

### DIFF
--- a/compiler/luci/import/include/luci/Import/Nodes.h
+++ b/compiler/luci/import/include/luci/Import/Nodes.h
@@ -130,6 +130,7 @@
 #include "Nodes/CircleUnidirectionalSequenceLSTM.h"
 #include "Nodes/CircleUnique.h"
 #include "Nodes/CircleUnpack.h"
+#include "Nodes/CircleVariable.h"
 #include "Nodes/CircleWhere.h"
 #include "Nodes/CircleWhile.h"
 #include "Nodes/CircleZerosLike.h"

--- a/compiler/luci/import/include/luci/Import/Nodes/CircleVariable.h
+++ b/compiler/luci/import/include/luci/Import/Nodes/CircleVariable.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __LUCI_IMPORT_OP_CIRCLE_VARIABLE_H__
+#define __LUCI_IMPORT_OP_CIRCLE_VARIABLE_H__
+
+#include "luci/Import/GraphBuilderContext.h"
+
+#include <luci/IR/Nodes/CircleVariable.h>
+
+/*
+ * @note  Circle does not have node for variable tensor
+ *        Methods here provide helper that creates CircleVariable from
+ *        Tensor having is_variable true value.
+ */
+
+namespace luci
+{
+
+CircleVariable *create_circlevariable(GraphBuilderContext *context, int32_t tensor_index);
+
+} // namespace luci
+
+#endif // __LUCI_IMPORT_OP_CIRCLE_VARIABLE_H__

--- a/compiler/luci/import/src/Importer.cpp
+++ b/compiler/luci/import/src/Importer.cpp
@@ -23,6 +23,7 @@
 #include "luci/Import/GraphBuilderRegistry.h"
 #include "luci/Import/CircleReader.h"
 #include "luci/Import/Nodes/CircleConst.h"
+#include "luci/Import/Nodes/CircleVariable.h"
 
 #include <luci/IR/Module.h>
 #include <luci/IR/CircleNodes.h>
@@ -132,6 +133,15 @@ void convert_graph(const luci::GraphBuilderSource &source, luci::CircleReader &r
     auto *const_node = const_builder->build(i, &gb_context);
     if (const_node != nullptr)
       nodefinder->enroll(i, const_node);
+  }
+
+  // Create CircleVariable nodes for variable tensors
+  // TODO Add Origin if needed, skip for now
+  for (uint32_t i = 0; i < tensors.size(); ++i)
+  {
+    luci::CircleVariable *variable_node = luci::create_circlevariable(&gb_context, i);
+    if (variable_node != nullptr)
+      nodefinder->enroll(i, variable_node);
   }
 
   // Import the operators.

--- a/compiler/luci/import/src/Nodes/CircleVariable.cpp
+++ b/compiler/luci/import/src/Nodes/CircleVariable.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Import/Nodes/CircleVariable.h"
+
+#include <luci/IR/Nodes/CircleVariable.h>
+#include <luci/Log.h>
+
+#include <cassert>
+#include <ostream>
+#include <string>
+#include <vector>
+
+namespace
+{
+
+std::ostream &operator<<(std::ostream &os, const luci::VectorWrapper<int32_t> &vect)
+{
+  uint32_t seq = 0;
+  for (const auto &v : vect)
+  {
+    if (seq)
+      os << ", ";
+    os << v;
+    seq++;
+  }
+  return os;
+}
+
+} // namespace
+
+namespace luci
+{
+
+CircleVariable *create_circlevariable(GraphBuilderContext *context, int32_t tensor_index)
+{
+  LOGGER(l);
+
+  auto graph = context->graph();
+  auto reader = context->reader();
+  const auto tensors = reader->tensors();
+  const auto variable_tensor = tensors[tensor_index];
+  assert(variable_tensor != nullptr);
+
+  if (not variable_tensor->is_variable())
+  {
+    // not a variable
+    return nullptr;
+  }
+  {
+    // check if there is no buffer as we don't support this for now
+    // TODO use buffer when this is enabled in Kernel
+    assert(reader->buffers()[variable_tensor->buffer()] != nullptr);
+    assert(reader->buffers()[variable_tensor->buffer()]->data() == nullptr);
+  }
+
+  auto variable_node = graph->nodes()->create<CircleVariable>();
+  copy_tensor_attributes(variable_tensor, variable_node);
+  variable_node->shape_status(luci::ShapeStatus::VALID);
+
+  INFO(l) << "[luci] NodeFinder variable node(" << tensor_index << ") -> " << variable_node << " "
+          << wrap(variable_tensor->shape()) << std::endl;
+
+  return variable_node;
+}
+
+} // namespace luci


### PR DESCRIPTION
This will enable import of variable tensor as CircleVariable Node.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>