### PR TITLE
[res] Fix Sqrt_000 recipe

### DIFF
--- a/res/TensorFlowLiteRecipes/Sqrt_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/Sqrt_000/test.recipe
@@ -14,5 +14,4 @@ operation {
   input: "ifm"
   output: "ofm"
 }
-input: "ifm"
 output: "ofm"


### PR DESCRIPTION
This commit removes constant operation's input from list of model's inputs.

ONE-DCO-1.0-Signed-off-by: Maksim Bronnikov <max120199@gmail.com>

-------------------------

For: https://github.com/Samsung/ONE/issues/8310#issuecomment-1018500541