### PR TITLE
[luci-interpreter/loader] Support CircleReferencingConst load

### DIFF
--- a/compiler/luci-interpreter/src/loader/GraphLoader.cpp
+++ b/compiler/luci-interpreter/src/loader/GraphLoader.cpp
@@ -121,9 +121,11 @@ bool isExecutableNode(const luci::CircleNode *node)
     {
       auto const custom_node = loco::must_cast<const luci::CircleCustom *>(node);
 
-      // TODO handle more Custom ops here
+      // TODO handle more non-executable Custom ops here
       if (custom_node->custom_code() == "CircleReferencingConst")
         return false;
+
+      return true;
     }
     default:
       return true;

--- a/compiler/luci-interpreter/src/loader/GraphLoader.cpp
+++ b/compiler/luci-interpreter/src/loader/GraphLoader.cpp
@@ -79,6 +79,7 @@ const void *getNodeData(const luci::CircleCustom *node, size_t *data_size)
     return nullptr;
 
   // helper struct which describes data loaded to custom_options of CircleReferencingConst node
+  // TODO move this struct to header
   struct ConstDataReference
   {
     const uint8_t *data = nullptr;


### PR DESCRIPTION
This commit adds support of CircleReferencingConst custom node to loader.

ONE-DCO-1.0-Signed-off-by: Maksim Bronnikov <max120199@gmail.com>

------------------------

For: #8042
Draft: #8190