### PR TITLE
[infra] Simplify file mode check

### DIFF
--- a/infra/command/format
+++ b/infra/command/format
@@ -201,11 +201,10 @@ if [[ "${CHECK_DIFF_ONLY}" = "1" ]]; then
   else
     if [[ "${CHECK_STAGED_ONLY}" = "1" ]]; then
       FILES_TO_CHECK=$(git diff --staged --name-only --diff-filter=d)
-      FILES_TO_CHECK=$(git ls-files -c -s --exclude-standard ${FILES_TO_CHECK[@]} | egrep -v '^1[26]0000' | cut -f2)
     else
       FILES_TO_CHECK=$(git diff --name-only --diff-filter=d HEAD~${DIFF_COMMITS})
-      FILES_TO_CHECK=$(git ls-files -c -s --exclude-standard ${FILES_TO_CHECK[@]} | egrep -v '^1[26]0000' | cut -f2)
     fi
+    FILES_TO_CHECK=$(git ls-files -c -s --exclude-standard ${FILES_TO_CHECK[@]} | egrep -v '^1[26]0000' | cut -f2)
   fi
 fi
 

--- a/infra/command/format
+++ b/infra/command/format
@@ -65,14 +65,6 @@ function command_exists() {
   command -v $1 > /dev/null 2>&1
 }
 
-function exclude_symbolic_links() {
-  # Check all files (CMakeLists.txt, *.cl, ... not only for C++, Python)
-  if [[ ${#FILES_TO_CHECK} -ne 0 ]]; then
-    FILES_EXCLUDE_SYMLINKS=$(file ${FILES_TO_CHECK} | grep -v "symbolic link" | cut -d':' -f1)
-    FILES_TO_CHECK=${FILES_EXCLUDE_SYMLINKS}
-  fi
-}
-
 function check_newline() {
   # Exclude binary (refer .gitattributes file)
   # TODO Remove svg file excluding
@@ -90,6 +82,7 @@ function check_newline() {
 function check_permission() {
   # Check all files except script
   # Manually ignore permission checking
+  FILES_TO_CHECK=$(git ls-files -c -s --exclude-standard ${FILES_TO_CHECK[@]} | egrep '^100755' | cut -f2)
   FILES_TO_CHECK_PERMISSION=`echo "$FILES_TO_CHECK" | tr ' ' '\n' | egrep -v '((^nnas)|(^nnfw)|(^nncc)|(\.sh)|(\.py)|(/gradlew))$'`
   FILES_TO_CHECK_PERMISSION=`echo "$FILES_TO_CHECK_PERMISSION" | egrep -v '((^infra/debian/compiler/rules)|(^infra/debian/runtime/rules))$'`
   FILES_TO_CHECK_PERMISSION+=`echo && echo "$FILES_TO_CHECK" | egrep '^tests/nnapi/specs/.*.py$'`
@@ -99,11 +92,8 @@ function check_permission() {
   if [[ ${#FILES_TO_CHECK_PERMISSION} -eq 0 ]]; then
     return
   fi
-  for FILE_TO_CHECK in ${FILES_TO_CHECK_PERMISSION[@]}; do
-    RESULT=$(stat -c '%A' ${FILE_TO_CHECK} | grep 'x')
-    if [ "${RESULT}" != "" ]; then
-      chmod a-x ${FILE_TO_CHECK}
-    fi
+  for f in ${FILES_TO_CHECK_PERMISSION[@]}; do
+    chmod a-x $f
   done
 }
 
@@ -193,7 +183,13 @@ fi
 __Check_CPP=${CHECK_CPP:-"1"}
 __Check_PYTHON=${CHECK_PYTHON:-"1"}
 
-FILES_TO_CHECK=$(git ls-files -c --exclude-standard ${DIRECTORIES_TO_BE_TESTED[@]})
+# Git file permission
+#   120000: symbolic link
+#   160000: git link
+#   100755: regular executable
+#   100644: regular readable
+# Reference: https://github.com/git/git/blob/cd42415/Documentation/technical/index-format.txt#L72-L81
+FILES_TO_CHECK=$(git ls-files -c -s --exclude-standard ${DIRECTORIES_TO_BE_TESTED[@]} | egrep -v '^1[26]0000' | cut -f2)
 if [[ "${CHECK_DIFF_ONLY}" = "1" ]]; then
   MASTER_EXIST=$(git rev-parse --verify master)
   CURRENT_BRANCH=$(git branch | grep \* | cut -d ' ' -f2-)
@@ -205,8 +201,10 @@ if [[ "${CHECK_DIFF_ONLY}" = "1" ]]; then
   else
     if [[ "${CHECK_STAGED_ONLY}" = "1" ]]; then
       FILES_TO_CHECK=$(git diff --staged --name-only --diff-filter=d)
+      FILES_TO_CHECK=$(git ls-files -c -s --exclude-standard ${FILES_TO_CHECK[@]} | egrep -v '^1[26]0000' | cut -f2)
     else
       FILES_TO_CHECK=$(git diff --name-only --diff-filter=d HEAD~${DIFF_COMMITS})
+      FILES_TO_CHECK=$(git ls-files -c -s --exclude-standard ${FILES_TO_CHECK[@]} | egrep -v '^1[26]0000' | cut -f2)
     fi
   fi
 fi
@@ -215,7 +213,6 @@ for DIR_NOT_TO_BE_TESTED in $(git ls-files -co --exclude-standard '*/.FORMATDENY
   DIRECTORIES_NOT_TO_BE_TESTED+=($(dirname "${DIR_NOT_TO_BE_TESTED}"))
 done
 
-exclude_symbolic_links
 check_newline
 check_permission
 check_cpp_files

--- a/infra/command/format
+++ b/infra/command/format
@@ -82,8 +82,8 @@ function check_newline() {
 function check_permission() {
   # Check all files except script
   # Manually ignore permission checking
-  FILES_TO_CHECK=$(git ls-files -c -s --exclude-standard ${FILES_TO_CHECK[@]} | egrep '^100755' | cut -f2)
-  FILES_TO_CHECK_PERMISSION=`echo "$FILES_TO_CHECK" | tr ' ' '\n' | egrep -v '((^nnas)|(^nnfw)|(^nncc)|(\.sh)|(\.py)|(/gradlew))$'`
+  FILES_TO_CHECK_PERMISSION=$(git ls-files -c -s --exclude-standard ${FILES_TO_CHECK[@]} | egrep '^100755' | cut -f2)
+  FILES_TO_CHECK_PERMISSION=`echo "$FILES_TO_CHECK_PERMISSION" | tr ' ' '\n' | egrep -v '((^nnas)|(^nnfw)|(^nncc)|(\.sh)|(\.py)|(/gradlew))$'`
   FILES_TO_CHECK_PERMISSION=`echo "$FILES_TO_CHECK_PERMISSION" | egrep -v '((^infra/debian/compiler/rules)|(^infra/debian/runtime/rules))$'`
   FILES_TO_CHECK_PERMISSION+=`echo && echo "$FILES_TO_CHECK" | egrep '^tests/nnapi/specs/.*.py$'`
   # Transform to array
@@ -183,7 +183,7 @@ fi
 __Check_CPP=${CHECK_CPP:-"1"}
 __Check_PYTHON=${CHECK_PYTHON:-"1"}
 
-# Git file permission
+# Git file mode
 #   120000: symbolic link
 #   160000: git link
 #   100755: regular executable


### PR DESCRIPTION
This commit simplify file mode check by using "git ls-files -s" command.
File mode check is used for
- Remove symblic link file from checlist
- Check code file invalid execution permission

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>