### PR TITLE
[circle-quantizer] Support BatchMatMul Op

### DIFF
--- a/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
+++ b/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
@@ -1258,6 +1258,7 @@ void quantize_const_inputs(luci::CircleNode *node, loco::DataType output_type)
 
     case luci::CircleOpcode::ADD:
     case luci::CircleOpcode::ADD_N:
+    case luci::CircleOpcode::BATCH_MATMUL:
     case luci::CircleOpcode::DEPTH_TO_SPACE:
     case luci::CircleOpcode::DIV:
     case luci::CircleOpcode::ELU:


### PR DESCRIPTION
This supports BatchMatMul Op in quantizer.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Draft PR: #8334
Related to: #8325