### PR TITLE
[luci-interpreter] Use switch-case instead if-else

### DIFF
--- a/compiler/luci-interpreter/src/loader/GraphLoader.cpp
+++ b/compiler/luci-interpreter/src/loader/GraphLoader.cpp
@@ -195,21 +195,16 @@ void GraphLoader::loadTensors()
     // Only Input, Const, Custom and Variable nodes have shapes. Shapes of intermediate tensors will
     // be inferred.
     Shape shape{};
-    if (const auto *input_node = dynamic_cast<const luci::CircleInput *>(node))
+    switch (node->opcode())
     {
-      shape = getNodeShape(input_node);
-    }
-    else if (const auto *const_node = dynamic_cast<const luci::CircleConst *>(node))
-    {
-      shape = getNodeShape(const_node);
-    }
-    else if (const auto *variable_node = dynamic_cast<const luci::CircleVariable *>(node))
-    {
-      shape = getNodeShape(variable_node);
-    }
-    else if (const auto *custom_out_node = dynamic_cast<const luci::CircleCustomOut *>(node))
-    {
-      shape = getNodeShape(custom_out_node);
+      case luci::CircleOpcode::CIRCLECONST:
+      case luci::CircleOpcode::CIRCLECUSTOMOUT:
+      case luci::CircleOpcode::CIRCLEINPUT:
+      case luci::CircleOpcode::CIRCLEVARIABLE:
+        shape = getNodeShape(node);
+        break;
+      default:
+        break;
     }
 
     AffineQuantization quantization;


### PR DESCRIPTION
This commit replaces if-else statements with dynamic_cast to switch-case with opcodes.

ONE-DCO-1.0-Signed-off-by: Maksim Bronnikov <max120199@gmail.com>

--------------

For: https://github.com/Samsung/ONE/pull/8321#discussion_r792179741