### PR TITLE
[debian] Add preserve environment option

### DIFF
--- a/infra/debian/compiler/postinst
+++ b/infra/debian/compiler/postinst
@@ -9,4 +9,4 @@ set -e
 # which causes invalid permission problem.
 # e.g. When `pip` installs user packages, it proceeds based on $HOME.
 # To proper installation, $HOME should be root.
-su - $(whoami) -c '/usr/share/one/bin/one-prepare-venv' # $(whoami) = root
+su - $(whoami) -p -c '/usr/share/one/bin/one-prepare-venv' # $(whoami) = root


### PR DESCRIPTION
This commit adds -p option to postinst script that preserves current environment.

This change fixes a bug where current user env variables are not passed properly.
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>