### PR TITLE
[circle-execution-plan] Support scratchpad size for DepthwiseConv2d

### DIFF
--- a/compiler/circle-execution-plan/pal/IScratchpadHelper.h
+++ b/compiler/circle-execution-plan/pal/IScratchpadHelper.h
@@ -18,6 +18,7 @@
 #define CIRCLE_EXECUTION_PLAN_ISRCRATCHPAD_HELPER_H
 
 #include <luci/IR/Nodes/CircleConv2D.h>
+#include <luci/IR/Nodes/CircleDepthwiseConv2D.h>
 #include <cstdint>
 
 namespace circle_planner
@@ -27,6 +28,9 @@ class IScratchpadHelper
 {
 public:
   virtual uint32_t ComputeScratchpadSizeConv2d(const luci::CircleConv2D *conv) = 0;
+
+  virtual uint32_t
+  ComputeScratchpadSizeDepthwiseConv2d(const luci::CircleDepthwiseConv2D *depthwise_conv) = 0;
 
   virtual ~IScratchpadHelper() = default;
 };

--- a/compiler/circle-execution-plan/pal/ScratchpadHelperLinux.h
+++ b/compiler/circle-execution-plan/pal/ScratchpadHelperLinux.h
@@ -60,6 +60,13 @@ public:
     return batches * output_height * output_width * input_depth * filter_height * filter_width *
            size(conv_input->dtype());
   }
+
+  uint32_t
+  ComputeScratchpadSizeDepthwiseConv2d(const luci::CircleDepthwiseConv2D *depthwise_conv) final
+  {
+    // for linux DepthwiseConv2d scratchpad tensors size = 0
+    return 0;
+  }
 };
 
 } // namespace circle_planner

--- a/compiler/circle-execution-plan/pal/ScratchpadHelperMCU.h
+++ b/compiler/circle-execution-plan/pal/ScratchpadHelperMCU.h
@@ -30,6 +30,13 @@ public:
     // for mcu scratchpad size = 0
     return 0;
   }
+
+  uint32_t
+  ComputeScratchpadSizeDepthwiseConv2d(const luci::CircleDepthwiseConv2D *depthwise_conv) final
+  {
+    // for mcu DepthwiseConv2d scratchpad tensors size = 0
+    return 0;
+  }
 };
 
 } // namespace circle_planner

--- a/compiler/circle-execution-plan/src/ExecutionPlanner.cpp
+++ b/compiler/circle-execution-plan/src/ExecutionPlanner.cpp
@@ -304,17 +304,27 @@ void ExecutionPlanner::create_alloc_node_inform_vector(bool null_consts, bool nu
 
     // Scratchpad If needed
     uint32_t scratchpad_size = 0;
-    switch (circle_node->opcode())
+    if (!null_scratchpad)
     {
-      case luci::CircleOpcode::CONV_2D:
+      switch (circle_node->opcode())
       {
-        auto conv = loco::must_cast<const luci::CircleConv2D *>(circle_node);
-        scratchpad_size =
-          null_scratchpad ? 0 : _scratchpad_helper->ComputeScratchpadSizeConv2d(conv);
-        break;
+        case luci::CircleOpcode::CONV_2D:
+        {
+          const auto conv = loco::must_cast<const luci::CircleConv2D *>(circle_node);
+          scratchpad_size = _scratchpad_helper->ComputeScratchpadSizeConv2d(conv);
+          break;
+        }
+        case luci::CircleOpcode::DEPTHWISE_CONV_2D:
+        {
+          const auto depthwise_conv =
+            loco::must_cast<const luci::CircleDepthwiseConv2D *>(circle_node);
+          scratchpad_size =
+            _scratchpad_helper->ComputeScratchpadSizeDepthwiseConv2d(depthwise_conv);
+          break;
+        }
+        default:
+          scratchpad_size = 0;
       }
-      default:
-        scratchpad_size = 0;
     }
 
     if (scratchpad_size > 0)


### PR DESCRIPTION
This pr adds support calculation for DepthwiseConv2d scratchpad tensors for circle execution planner.

issue #8354 

ONE-DCO-1.0-Signed-off-by: Artem Balyshev a.balyshev@partner.samsung.com