### PR TITLE
[debian] Add constant.py to install list

### DIFF
--- a/infra/debian/compiler/one-compiler.install
+++ b/infra/debian/compiler/one-compiler.install
@@ -22,6 +22,7 @@ usr/bin/one-prepare-venv usr/share/one/bin/
 usr/bin/one-profile usr/share/one/bin/
 usr/bin/one-quantize usr/share/one/bin/
 usr/bin/one-version usr/share/one/bin/
+usr/bin/python/constant.py usr/share/one/bin/python/
 usr/bin/rawdata2hdf5 usr/share/one/bin/
 usr/bin/record-minmax usr/share/one/bin/
 usr/bin/tf2nnpkg usr/share/one/bin/


### PR DESCRIPTION
This commit adds constant.py to install list.

Related: #8169
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>