### PR TITLE
[circle-execution-plan] Support scratchpad size for BatchMatMul

### DIFF
--- a/compiler/circle-execution-plan/pal/IScratchpadHelper.h
+++ b/compiler/circle-execution-plan/pal/IScratchpadHelper.h
@@ -18,6 +18,7 @@
 #define CIRCLE_EXECUTION_PLAN_ISRCRATCHPAD_HELPER_H
 
 #include <luci/IR/Nodes/CircleAveragePool2D.h>
+#include <luci/IR/Nodes/CircleBatchMatMul.h>
 #include <luci/IR/Nodes/CircleConv2D.h>
 #include <luci/IR/Nodes/CircleDepthwiseConv2D.h>
 #include <luci/IR/Nodes/CircleSVDF.h>
@@ -31,6 +32,9 @@ class IScratchpadHelper
 public:
   virtual uint32_t
   ComputeScratchpadSizeAveragePool2d(const luci::CircleAveragePool2D *avg_pool) = 0;
+
+  virtual std::vector<uint32_t>
+  ComputeScratchpadSizeBatchMatMul(const luci::CircleBatchMatMul *batch_mat_mul) = 0;
 
   virtual uint32_t ComputeScratchpadSizeConv2d(const luci::CircleConv2D *conv) = 0;
 

--- a/compiler/circle-execution-plan/pal/ScratchpadHelperCMSISNN.h
+++ b/compiler/circle-execution-plan/pal/ScratchpadHelperCMSISNN.h
@@ -58,6 +58,12 @@ public:
     return depth * sizeof(int32_t);
   }
 
+  std::vector<uint32_t>
+  ComputeScratchpadSizeBatchMatMul(const luci::CircleBatchMatMul *batch_mat_mul) final
+  {
+    throw std::runtime_error("BatchMatMul is not currently supported for cmsisnn platform");
+  }
+
   uint32_t ComputeScratchpadSizeConv2d(const luci::CircleConv2D *conv) final
   {
     // Main logic of arm_convolve_wrapper_s8_get_buffer_size

--- a/compiler/circle-execution-plan/pal/ScratchpadHelperLinux.h
+++ b/compiler/circle-execution-plan/pal/ScratchpadHelperLinux.h
@@ -32,6 +32,31 @@ public:
     return 0;
   }
 
+  std::vector<uint32_t>
+  ComputeScratchpadSizeBatchMatMul(const luci::CircleBatchMatMul *batch_mat_mul) final
+  {
+    const auto lhs = loco::must_cast<luci::CircleNode *>(batch_mat_mul->x());
+    const auto rhs = loco::must_cast<luci::CircleNode *>(batch_mat_mul->y());
+
+    std::vector<uint32_t> scratchpad_sizes;
+
+    // Scratchpad for lhs
+    uint32_t scratchpad_size = 1;
+    for (int32_t i = 0; i < lhs->rank(); ++i)
+      scratchpad_size *= lhs->dim(i).value();
+
+    scratchpad_sizes.push_back(scratchpad_size * loco::size(lhs->dtype()));
+
+    // Scratchpad for rhs
+    scratchpad_size = 1;
+    for (int32_t i = 0; i < rhs->rank(); ++i)
+      scratchpad_size *= rhs->dim(i).value();
+
+    scratchpad_sizes.push_back(scratchpad_size * loco::size(rhs->dtype()));
+
+    return scratchpad_sizes;
+  }
+
   uint32_t ComputeScratchpadSizeConv2d(const luci::CircleConv2D *conv) final
   {
     const auto conv_input = loco::must_cast<luci::CircleNode *>(conv->input());

--- a/compiler/circle-execution-plan/pal/ScratchpadHelperMCU.h
+++ b/compiler/circle-execution-plan/pal/ScratchpadHelperMCU.h
@@ -31,6 +31,12 @@ public:
     return 0;
   }
 
+  std::vector<uint32_t>
+  ComputeScratchpadSizeBatchMatMul(const luci::CircleBatchMatMul *batch_mat_mul) final
+  {
+    throw std::runtime_error("BatchMatMul is not currently supported for mcu platform");
+  }
+
   uint32_t ComputeScratchpadSizeConv2d(const luci::CircleConv2D *) final
   {
     // for mcu scratchpad size = 0

--- a/compiler/circle-execution-plan/src/ExecutionPlanner.cpp
+++ b/compiler/circle-execution-plan/src/ExecutionPlanner.cpp
@@ -315,6 +315,12 @@ void ExecutionPlanner::create_alloc_node_inform_vector(bool null_consts, bool nu
             _scratchpad_helper->ComputeScratchpadSizeAveragePool2d(avg_pool));
           break;
         }
+        case luci::CircleOpcode::BATCH_MATMUL:
+        {
+          const auto batch_mat_mul = loco::must_cast<const luci::CircleBatchMatMul *>(circle_node);
+          scratchpad_sizes = _scratchpad_helper->ComputeScratchpadSizeBatchMatMul(batch_mat_mul);
+          break;
+        }
         case luci::CircleOpcode::CONV_2D:
         {
           const auto conv = loco::must_cast<const luci::CircleConv2D *>(circle_node);


### PR DESCRIPTION
This pr adds support calculation for BatchMatMul scratchpad tensors for circle execution planner.

issue #8354

ONE-DCO-1.0-Signed-off-by: Artem Balyshev a.balyshev@partner.samsung.com