### PR TITLE
[tflchef] Add assert for SVDF inputs size

### DIFF
--- a/compiler/tflchef/tflite/src/Op/SVDF.cpp
+++ b/compiler/tflchef/tflite/src/Op/SVDF.cpp
@@ -25,6 +25,7 @@ void TFliteOpSVDF::filler(const tflite::Operator *op, TFliteImport *import,
                           tflchef::ModelRecipe *model_recipe) const
 {
   const std::vector<int32_t> &inputs = as_index_vector(op->inputs());
+  assert(inputs.size() == 5);
 
   // optional input tensor idx has minus value.
   const bool hasBias = (inputs.at(3) >= 0);


### PR DESCRIPTION
This commit adds assert for fixed SVDF's inputs size.

ONE-DCO-1.0-Signed-off-by: Maksim Bronnikov <max120199@gmail.com>

--------------------------

For: #8203
Draft: #8365