### PR TITLE
[luci/pass] Extend ConvertNCHWToNHWC with Elu

### DIFF
--- a/compiler/luci/pass/src/ConvertNCHWToNHWCPass.cpp
+++ b/compiler/luci/pass/src/ConvertNCHWToNHWCPass.cpp
@@ -807,6 +807,8 @@ class ConvertNCHWToNHWC final : public luci::CircleNodeMutableVisitor<bool>
     return true;
   }
 
+  bool visit(luci::CircleElu *node) { return convert_unary_features<luci::CircleElu>(node); }
+
   bool visit(luci::CircleLeakyRelu *node)
   {
     return convert_unary_features<luci::CircleLeakyRelu>(node);
@@ -1243,6 +1245,7 @@ bool ConvertNCHWToNHWCPass::run(loco::Graph *g)
         break;
       case luci::CircleOpcode::ADD:
       case luci::CircleOpcode::CONCATENATION:
+      case luci::CircleOpcode::ELU:
       case luci::CircleOpcode::LEAKY_RELU:
       case luci::CircleOpcode::LOGISTIC:
       case luci::CircleOpcode::MAXIMUM:

--- a/compiler/luci/pass/src/ConvertNCHWToNHWCPass.test.cpp
+++ b/compiler/luci/pass/src/ConvertNCHWToNHWCPass.test.cpp
@@ -970,7 +970,7 @@ TEST(ConvertNCHWToNHWC, Elu)
   EXPECT_EQ(1, elu_succs.size());
   check_post_trans(*elu_succs.begin());
 
-  // Check leakyrelu shape
+  // Check elu shape
   EXPECT_EQ(1, g.elu->dim(0).value());
   EXPECT_EQ(4, g.elu->dim(1).value());
   EXPECT_EQ(4, g.elu->dim(2).value());


### PR DESCRIPTION
This commit extends ConvertNCHWToNCHW pass with Elu op.

ONE-DCO-1.0-Signed-off-by: Maksim Bronnikov <max120199@gmail.com>