### PR TITLE
[luci/pass] Add comment for RemoveUnnecessaryReshapePass

### DIFF
--- a/compiler/luci/pass/src/RemoveUnnecessaryReshapePass.cpp
+++ b/compiler/luci/pass/src/RemoveUnnecessaryReshapePass.cpp
@@ -58,6 +58,25 @@ bool remove_no_effect_reshape(luci::CircleNode *node)
 namespace luci
 {
 
+/**
+ * BEFORE
+ *      [CircleNode]
+ *            |
+ *     [CircleReshape]
+ *            |
+ *      [CircleNode]
+ *
+ * AFTER
+ *      [CircleNode]
+ *            |  \
+ *            |  [CircleReshape]
+ *            |
+ *      [CircleNode]
+ *
+ * NOTE
+ *     This pass will remove Reshape when input and output has same shape
+ */
+
 bool RemoveUnnecessaryReshapePass::run(loco::Graph *g)
 {
   bool changed = false;


### PR DESCRIPTION
This will add before/after graph comment for RemoveUnnecessaryReshapePass.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>