### PR TITLE
[luci] Fix bias scale quantization

### DIFF
--- a/compiler/luci/pass/include/luci/Pass/QuantizeWithMinMaxPass.h
+++ b/compiler/luci/pass/include/luci/Pass/QuantizeWithMinMaxPass.h
@@ -56,6 +56,10 @@ public:
 public:
   bool run(loco::Graph *graph);
 
+public:
+  void TF_style_maxpool(bool val) { _TF_style_maxpool = val; }
+  bool TF_style_maxpool() const { return _TF_style_maxpool; }
+
 private:
   void set_input_type(loco::Graph *graph) const;
   void set_output_type(loco::Graph *graph) const;
@@ -66,6 +70,7 @@ private:
   QuantizationGranularity _granularity;
   loco::DataType _input_type;
   loco::DataType _output_type;
+  bool _TF_style_maxpool = false;
 };
 
 } // namespace luci

--- a/compiler/luci/pass/include/luci/Pass/QuantizeWithMinMaxPass.h
+++ b/compiler/luci/pass/include/luci/Pass/QuantizeWithMinMaxPass.h
@@ -45,9 +45,10 @@ public:
 public:
   QuantizeWithMinMaxPass(loco::DataType input_model_dtype, loco::DataType output_model_dtype,
                          QuantizationGranularity granularity, loco::DataType input_type,
-                         loco::DataType output_type)
+                         loco::DataType output_type, bool TF_style_maxpool)
     : _input_model_dtype{input_model_dtype}, _output_model_dtype{output_model_dtype},
-      _granularity{granularity}, _input_type{input_type}, _output_type{output_type}
+      _granularity{granularity}, _input_type{input_type}, _output_type{output_type},
+      _TF_style_maxpool{TF_style_maxpool}
   {
     // DO NOTHING
   }
@@ -55,10 +56,6 @@ public:
 
 public:
   bool run(loco::Graph *graph);
-
-public:
-  void TF_style_maxpool(bool val) { _TF_style_maxpool = val; }
-  bool TF_style_maxpool() const { return _TF_style_maxpool; }
 
 private:
   void set_input_type(loco::Graph *graph) const;

--- a/compiler/luci/pass/src/CircleOptimizer.cpp
+++ b/compiler/luci/pass/src/CircleOptimizer.cpp
@@ -512,9 +512,8 @@ void CircleOptimizer::quantize(loco::Graph *g) const
 
     luci::QuantizeWithMinMaxPass quantizer(
       str_to_dtype(input_model_dtype), str_to_dtype(output_model_dtype),
-      str_to_granularity(granularity), str_to_dtype(input_type), str_to_dtype(output_type));
-
-    quantizer.TF_style_maxpool(TF_style_maxpool);
+      str_to_granularity(granularity), str_to_dtype(input_type), str_to_dtype(output_type),
+      TF_style_maxpool);
 
     quantizer.run(g);
 


### PR DESCRIPTION
This reorders quantization steps to ensure input scale is not changed after bias is quantized.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: #8385
Draft PR: https://github.com/Samsung/ONE/pull/8382
