### PR TITLE
[luci/logex] Introduce CircleNode SummaryBuilder Helper functions

### DIFF
--- a/compiler/luci/logex/src/CircleNodeSummaryBuilderHelper.cpp
+++ b/compiler/luci/logex/src/CircleNodeSummaryBuilderHelper.cpp
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "CircleNodeSummaryBuilderHelper.h"
+
+namespace luci
+{
+
+std::string to_str(bool value) { return value ? "true" : "false"; }
+
+std::string to_str(loco::DataType type)
+{
+  switch (type)
+  {
+    case loco::DataType::U8:
+      return "UINT8";
+    case loco::DataType::U16:
+      return "UINT16";
+    case loco::DataType::U32:
+      return "UINT32";
+    case loco::DataType::U64:
+      return "UINT64";
+
+    case loco::DataType::S8:
+      return "INT8";
+    case loco::DataType::S16:
+      return "INT16";
+    case loco::DataType::S32:
+      return "INT32";
+    case loco::DataType::S64:
+      return "INT64";
+
+    case loco::DataType::FLOAT16:
+      return "FLOAT16";
+    case loco::DataType::FLOAT32:
+      return "FLOAT32";
+    case loco::DataType::FLOAT64:
+      return "FLOAT64";
+
+    case loco::DataType::BOOL:
+      return "BOOL";
+
+    default:
+      return "Error";
+  }
+}
+
+std::string to_str(luci::FusedActFunc fused)
+{
+  switch (fused)
+  {
+    case luci::FusedActFunc::NONE:
+      return "NONE";
+    case luci::FusedActFunc::RELU:
+      return "RELU";
+    case luci::FusedActFunc::RELU_N1_TO_1:
+      return "RELU_N1_TO_1";
+    case luci::FusedActFunc::RELU6:
+      return "RELU6";
+    case luci::FusedActFunc::TANH:
+      return "TANH";
+    case luci::FusedActFunc::SIGN_BIT:
+      return "SIGN_BIT";
+    default:
+      return "Error";
+  }
+}
+
+std::string to_str(luci::Padding padding)
+{
+  switch (padding)
+  {
+    case luci::Padding::SAME:
+      return "SAME";
+    case luci::Padding::VALID:
+      return "VALID";
+    default:
+      return "Error";
+  }
+}
+
+std::string to_str(luci::MirrorPadMode mode)
+{
+  switch (mode)
+  {
+    case luci::MirrorPadMode::REFLECT:
+      return "REFLECT";
+    case luci::MirrorPadMode::SYMMETRIC:
+      return "SYMMETRIC";
+    default:
+      return "Error";
+  }
+}
+
+std::string to_str(const luci::Stride *stride)
+{
+  return std::to_string(stride->h()) + "," + std::to_string(stride->w());
+}
+
+std::string to_str(const luci::Filter *filter)
+{
+  return std::to_string(filter->h()) + "," + std::to_string(filter->w());
+}
+
+std::string circle_opname(luci::CircleOpcode opcode)
+{
+  static const std::string prefix{"circle."};
+
+  switch (opcode)
+  {
+#define CIRCLE_NODE(OPCODE, CLASS) \
+  case luci::CircleOpcode::OPCODE: \
+    return prefix + #OPCODE;
+#define CIRCLE_VNODE CIRCLE_NODE
+#include <luci/IR/CircleNodes.lst>
+#undef CIRCLE_VNODE
+#undef CIRCLE_NODE
+    default:
+      break;
+  };
+
+  return prefix + "Invalid";
+}
+
+} // namespace luci

--- a/compiler/luci/logex/src/CircleNodeSummaryBuilderHelper.h
+++ b/compiler/luci/logex/src/CircleNodeSummaryBuilderHelper.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __LUCI_LOGEX_CIRCLE_NODE_SUMMARY_BUILDER_HELPER__
+#define __LUCI_LOGEX_CIRCLE_NODE_SUMMARY_BUILDER_HELPER__
+
+#include <luci/IR/AttrFusedActFunc.h>
+#include <luci/IR/AttrPadding.h>
+#include <luci/IR/AttrMirrorPadMode.h>
+#include <luci/IR/AttrStride.h>
+#include <luci/IR/AttrFilter.h>
+#include <luci/IR/CircleOpcode.h>
+#include <loco/IR/DataType.h>
+
+#include <string>
+
+namespace luci
+{
+
+std::string to_str(bool value);
+std::string to_str(loco::DataType type);
+std::string to_str(luci::FusedActFunc fused);
+std::string to_str(luci::Padding padding);
+std::string to_str(luci::MirrorPadMode mode);
+std::string to_str(const luci::Stride *stride);
+std::string to_str(const luci::Filter *filter);
+
+std::string circle_opname(luci::CircleOpcode opcode);
+
+} // namespace luci
+
+#endif // __LUCI_LOGEX_CIRCLE_NODE_SUMMARY_BUILDER_HELPER__


### PR DESCRIPTION
This commit introduces `CircleNodeSummaryBuilderHelper`,
which includes helper functions for `CircleNodeSummaryBuilder`.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>

---

Parent Issue : #8357 
Draft : #8358