### PR TITLE
[luci-micro] Change CMake message mode

### DIFF
--- a/compiler/luci-micro/CMakeLists.txt
+++ b/compiler/luci-micro/CMakeLists.txt
@@ -6,7 +6,7 @@ set(ARM_OBJCOPY "arm-none-eabi-objcopy")
 find_program(ARM_C_COMPILER_PATH ${ARM_C_COMPILER})
 
 if(NOT ARM_C_COMPILER_PATH)
-  message(WARNING "ARM compiler is NOT FOUND, skipping luci-micro build")
+  message(STATUS "Build luci-micro: FALSE(ARM compiler is NOT FOUND)")
   return()
 endif()
 


### PR DESCRIPTION
This PR changes CMake message about missing arm compiler from Warning to Stats.

related issue: #8337

ONE-DCO-1.0-Signed-off-by: Alexander Efimov <a.efimov@samsung.com>