### PR TITLE
[DRAFT] Add new attribute and update shape inference for FullyConnected

### DIFF
--- a/compiler/circledump/src/OpPrinter.cpp
+++ b/compiler/circledump/src/OpPrinter.cpp
@@ -341,6 +341,7 @@ public:
          << ") ";
       os << "Activation(" << EnumNameActivationFunctionType(params->fused_activation_function())
          << ") ";
+      os << "keep_num_dims(" << params->keep_num_dims() << ") ";
 
       os << std::endl;
     }

--- a/compiler/luci-interpreter/src/core/KernelParams.h
+++ b/compiler/luci-interpreter/src/core/KernelParams.h
@@ -89,6 +89,7 @@ struct DivParams
 struct FullyConnectedParams
 {
   Activation activation;
+  bool keep_num_dims = false;
 };
 
 struct GatherParams

--- a/compiler/luci-interpreter/src/kernels/FullyConnected.cpp
+++ b/compiler/luci-interpreter/src/kernels/FullyConnected.cpp
@@ -73,7 +73,16 @@ void FullyConnected::configure()
   if (bias())
     LUCI_INTERPRETER_CHECK(bias()->shape().num_elements() == weights()->shape().dim(0));
 
-  output()->resize({batch_size, num_units});
+  if (params().keep_num_dims == false)
+    output()->resize({batch_size, num_units});
+  else
+  {
+    luci_interpreter::Shape output_shape(input_shape.num_dims());
+    for (int i = 0; i < input_shape.num_dims(); ++i)
+      output_shape.dim(i) = input_shape.dim(i);
+    output_shape.dim(input_shape.num_dims() - 1) = num_units;
+    output()->resize(output_shape);
+  }
 }
 
 void FullyConnected::execute() const

--- a/compiler/luci-interpreter/src/loader/nodes/FullyConnected.cpp
+++ b/compiler/luci-interpreter/src/loader/nodes/FullyConnected.cpp
@@ -36,6 +36,7 @@ std::unique_ptr<Kernel> build_kernel_CircleFullyConnected(const luci::CircleNode
 
   FullyConnectedParams params{};
   params.activation = node->fusedActivationFunction();
+  params.keep_num_dims = node->keep_num_dims();
 
   return std::make_unique<kernels::FullyConnected>(input, weights, bias, output, params);
 }

--- a/compiler/luci/export/src/CircleBuiltinTypesExtractor.h
+++ b/compiler/luci/export/src/CircleBuiltinTypesExtractor.h
@@ -170,9 +170,9 @@ public:
   }
   flatbuffers::Offset<void> visit(luci::CircleFullyConnected *node)
   {
-    return circle::CreateFullyConnectedOptions(_builder,
-                                               to_circle_actfunc(node->fusedActivationFunction()),
-                                               to_circle_weightsformat(node->weights_format()))
+    return circle::CreateFullyConnectedOptions(
+             _builder, to_circle_actfunc(node->fusedActivationFunction()),
+             to_circle_weightsformat(node->weights_format()), node->keep_num_dims())
       .Union();
   }
   flatbuffers::Offset<void> visit(luci::CircleGather *node)

--- a/compiler/luci/import/src/Nodes/CircleFullyConnected.cpp
+++ b/compiler/luci/import/src/Nodes/CircleFullyConnected.cpp
@@ -42,6 +42,7 @@ CircleNode *CircleFullyConnectedGraphBuilder::build_node(const circle::OperatorT
   const auto *options = op.builtin_options.AsFullyConnectedOptions();
   node->fusedActivationFunction(luci_actfunc(options->fused_activation_function));
   node->weights_format(luci_weights_format(options->weights_format));
+  node->keep_num_dims(options->keep_num_dims);
 
   return node;
 }

--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleFullyConnected.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleFullyConnected.h
@@ -58,8 +58,12 @@ public:
   WeightsFormat weights_format(void) const { return _weights_format; }
   void weights_format(WeightsFormat weights_format) { _weights_format = weights_format; }
 
+  bool keep_num_dims(void) const { return _keep_num_dims; }
+  void keep_num_dims(bool keep_num_dims) { _keep_num_dims = keep_num_dims; }
+
 private:
   WeightsFormat _weights_format{WeightsFormat::DEFAULT};
+  bool _keep_num_dims = false;
 };
 
 } // namespace luci

--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2017 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -720,27 +721,36 @@ loco::NodeShape infer_fully_connected(const luci::CircleFullyConnected *node)
 {
   auto input_shape = luci::shape_get(node->input()).as<loco::TensorShape>();
   auto weights_shape = luci::shape_get(node->weights()).as<loco::TensorShape>();
-
-  // Checking shape capability for fully connected layer
-  // Input: a tensor of at least rank 2 [D1, D2, ... Dn]
-  // Weight: [# of units, K]
-  // Output: [D1 * D2 * ... * Dn / K, # of units]
-  if (input_shape.rank() < 2 || weights_shape.rank() != 2)
-  {
-    // Return node own shape if shape inference is not possible
-    return use_own(node);
-  }
-
-  uint32_t input_size = 1;
-  for (uint32_t i = 0; i < input_shape.rank(); i++)
-  {
-    input_size = input_size * input_shape.dim(i).value();
-  }
-  const uint32_t batch_size = input_size / weights_shape.dim(1).value();
   loco::TensorShape out_shape;
-  out_shape.rank(2);
-  out_shape.dim(0) = batch_size;
-  out_shape.dim(1) = weights_shape.dim(0);
+
+  // https://github.com/tensorflow/tensorflow/blob/ea33c1e7a25d8025e8ee405ad8ab7be261798d76/tensorflow/lite/kernels/fully_connected.cc#L194
+  LUCI_ASSERT(input_shape.rank() == 2 || input_shape.rank() == 3,
+              "Input rank of FullyConnected should be 2 or 3");
+
+  // https://github.com/tensorflow/tensorflow/blob/ea33c1e7a25d8025e8ee405ad8ab7be261798d76/tensorflow/lite/kernels/fully_connected.cc#L225
+  LUCI_ASSERT(weights_shape.rank() == 2, "Weights of FullyConnected should be 2");
+
+  // TODO Consider unknown dimension
+  // https://github.com/tensorflow/tensorflow/blob/ea33c1e7a25d8025e8ee405ad8ab7be261798d76/tensorflow/lite/kernels/fully_connected.cc#L353-L367
+  if (node->keep_num_dims())
+  {
+    out_shape.rank(input_shape.rank());
+    for (uint32_t i = 0; i < input_shape.rank(); ++i)
+      out_shape.dim(i) = input_shape.dim(i);
+    out_shape.dim(out_shape.rank() - 1) = weights_shape.dim(0);
+  }
+  else
+  {
+    uint32_t input_size = 1;
+    for (uint32_t i = 0; i < input_shape.rank(); i++)
+    {
+      input_size = input_size * input_shape.dim(i).value();
+    }
+    const uint32_t batch_size = input_size / weights_shape.dim(1).value();
+    out_shape.rank(2);
+    out_shape.dim(0) = batch_size;
+    out_shape.dim(1) = weights_shape.dim(0);
+  }
 
   return loco::NodeShape{out_shape};
 }

--- a/compiler/tflchef/core/src/Op/FullyConnected.cpp
+++ b/compiler/tflchef/core/src/Op/FullyConnected.cpp
@@ -29,6 +29,7 @@ flatbuffers::Offset<void> FullyConnectedChef::value(flatbuffers::FlatBufferBuild
 
   tflite::FullyConnectedOptionsBuilder fc_options_builder{fbb};
   fc_options_builder.add_fused_activation_function(tflite_activation);
+  fc_options_builder.add_keep_num_dims(operation.fullyconnected_options().keep_num_dims());
 
   return fc_options_builder.Finish().Union();
 }

--- a/compiler/tflchef/proto/tflchef.proto
+++ b/compiler/tflchef/proto/tflchef.proto
@@ -182,6 +182,7 @@ message FloorModOptions {
 
 message FullyConnectedOptions {
   optional Activation activation = 1 [default = NONE];
+  optional bool keep_num_dims = 2 [ default = false ];
 }
 
 message AddOptions {

--- a/compiler/tflchef/tflite/src/Op/FullyConnected.cpp
+++ b/compiler/tflchef/tflite/src/Op/FullyConnected.cpp
@@ -48,6 +48,7 @@ tflchef::Operation *TFliteOpFullyConnected::build(const tflite::Operator *op, TF
   auto op_options = operation->mutable_fullyconnected_options();
 
   op_options->set_activation(as_tflchef_activation(op_params->fused_activation_function()));
+  op_options->set_keep_num_dims(op_params->keep_num_dims());
 
   return operation;
 }

--- a/compiler/tflite2circle/src/BuildBuiltinOptions/FullyConnectedOptions.cpp
+++ b/compiler/tflite2circle/src/BuildBuiltinOptions/FullyConnectedOptions.cpp
@@ -37,6 +37,7 @@ build_circle_FullyConnectedOptions(flatbuffers::FlatBufferBuilder &fb, const tfl
   else if (tflite_weight_format == tflite::FullyConnectedOptionsWeightsFormat_SHUFFLED4x16INT8)
     builtin_options_builder.add_weights_format(
       circle::FullyConnectedOptionsWeightsFormat_SHUFFLED4x16INT8);
+  builtin_options_builder.add_keep_num_dims(tflite_builtin_options->keep_num_dims());
   return builtin_options_builder.Finish();
 }
 

--- a/res/TensorFlowLiteRecipes/FullyConnected_001/test.recipe
+++ b/res/TensorFlowLiteRecipes/FullyConnected_001/test.recipe
@@ -1,7 +1,7 @@
 operand {
   name: "in"
   type: FLOAT32
-  shape { dim: 1 dim: 1 dim: 1 dim: 4 }
+  shape { dim: 1 dim: 1 dim: 4 }
 }
 operand {
   name: "weight"

--- a/res/TensorFlowLiteRecipes/FullyConnected_006/test.recipe
+++ b/res/TensorFlowLiteRecipes/FullyConnected_006/test.recipe
@@ -11,12 +11,13 @@ operand {
 operand {
   name: "out"
   type: FLOAT32
-  shape { dim: 1 dim: 2 }
+  shape { dim: 1 dim: 1 dim: 2 }
 }
 operation {
   type: "FullyConnected"
   fullyconnected_options {
     activation: NONE
+    keep_num_dims: true
   }
   input: "in"
   input: "weight"

--- a/res/TensorFlowLiteRecipes/YUV_TO_RGB_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/YUV_TO_RGB_000/test.recipe
@@ -1,7 +1,7 @@
 operand {
   name: "input"
   type: FLOAT32
-  shape { dim: 1 dim: 4 dim: 4 dim: 3 }
+  shape { dim: 16 dim: 3 }
 }
 operand {
   name: "weight"

--- a/res/TensorFlowLiteRecipes/YUV_TO_RGB_U8_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/YUV_TO_RGB_U8_000/test.recipe
@@ -2,7 +2,7 @@ operand {
   name: "input"
   type: UINT8
   quant { min: -0.5 max: 1.0 scale: 0.005882 zero_point: 85 }
-  shape { dim: 1 dim: 4 dim: 4 dim: 3 }
+  shape { dim: 16 dim: 3 }
 }
 operand {
   name: "weight"


### PR DESCRIPTION
This draft is for adding new attribute `keep_num_dims` and updating
shape inference algorithm for `CircleFullyConnected`.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>

---

Parent Issue : #8400