### PR TITLE
[luci/lang] Add keep_num_dims attribute to CircleFullyConnected

### DIFF
--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleFullyConnected.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleFullyConnected.h
@@ -58,8 +58,12 @@ public:
   WeightsFormat weights_format(void) const { return _weights_format; }
   void weights_format(WeightsFormat weights_format) { _weights_format = weights_format; }
 
+  bool keep_num_dims(void) const { return _keep_num_dims; }
+  void keep_num_dims(bool keep_num_dims) { _keep_num_dims = keep_num_dims; }
+
 private:
   WeightsFormat _weights_format{WeightsFormat::DEFAULT};
+  bool _keep_num_dims = false;
 };
 
 } // namespace luci

--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleFullyConnected.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleFullyConnected.h
@@ -63,7 +63,7 @@ public:
 
 private:
   WeightsFormat _weights_format{WeightsFormat::DEFAULT};
-  bool _keep_num_dims = false;
+  bool _keep_num_dims{false};
 };
 
 } // namespace luci

--- a/compiler/luci/lang/src/Nodes/CircleFullyConnected.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleFullyConnected.test.cpp
@@ -32,6 +32,7 @@ TEST(CircleFullyConnectedTest, constructor)
   ASSERT_EQ(nullptr, fc_node.weights());
   ASSERT_EQ(nullptr, fc_node.bias());
   ASSERT_EQ(luci::FusedActFunc::UNDEFINED, fc_node.fusedActivationFunction());
+  ASSERT_EQ(false, fc_node.keep_num_dims());
 }
 
 TEST(CircleFullyConnectedTest, input_NEG)


### PR DESCRIPTION
This commit adds `keep_num_dims` attribute to `CircleFullyConnected`.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>

---

Parent Issue : #8400
Draft : #8401