### PR TITLE
[debian] Modify .install

### DIFF
--- a/infra/debian/compiler/one-compiler.install
+++ b/infra/debian/compiler/one-compiler.install
@@ -22,8 +22,8 @@ usr/bin/one-prepare-venv usr/share/one/bin/
 usr/bin/one-profile usr/share/one/bin/
 usr/bin/one-quantize usr/share/one/bin/
 usr/bin/one-version usr/share/one/bin/
-usr/bin/python/constant.py usr/share/one/bin/python/
-usr/bin/python/make_cmd.py usr/share/one/bin/python/
+usr/bin/onelib/constant.py usr/share/one/bin/onelib/
+usr/bin/onelib/make_cmd.py usr/share/one/bin/onelib/
 usr/bin/rawdata2hdf5 usr/share/one/bin/
 usr/bin/record-minmax usr/share/one/bin/
 usr/bin/tf2nnpkg usr/share/one/bin/


### PR DESCRIPTION
This commit modifies one-compiler.install for applying previous relocation of python lib.

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>