### PR TITLE
[luci] Add test for quantized bias scale

### DIFF
--- a/compiler/luci/pass/src/QuantizedModelVerifier.cpp
+++ b/compiler/luci/pass/src/QuantizedModelVerifier.cpp
@@ -17,6 +17,7 @@
 
 #include "VerifyQuantizedNodeGranularity.h"
 #include "VerifyQuantizedNodeType.h"
+#include "VerifyQuantizedBiasScale.h"
 
 #include <luci/IR/CircleNodes.h>
 #include <luci/IR/CircleNodeVisitor.h>
@@ -47,6 +48,10 @@ void QuantizedModelVerifier::verify(loco::Graph *g)
     // Verify Granularity
     if (!circle_node->accept(VerifyQuantizedNodeGranularity::create(_granularity).get()))
       throw std::runtime_error("Wrong granularity detected in " + node_name());
+
+    // Verify Bias scale
+    if (!VerifyQuantizedBiasScale::create()->verify(circle_node))
+      throw std::runtime_error("Wrong bias scale detected in " + node_name());
   }
 }
 

--- a/compiler/luci/pass/src/VerifyQuantizedBiasScale.cpp
+++ b/compiler/luci/pass/src/VerifyQuantizedBiasScale.cpp
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "VerifyQuantizedBiasScale.h"
+
+#include <cmath>
+
+// This macro is undef at the end of the file
+#define RETURN_FALSE_UNLESS(ARG) \
+  if (not(ARG))                  \
+  {                              \
+    return false;                \
+  }
+
+namespace
+{
+bool same(float a, float b)
+{
+  constexpr float epsilon = 1e-10;
+  return abs(a - b) < epsilon;
+}
+
+// Check bias scale = input scale * weight scale
+// This function checks both LWQ and CWQ
+bool check_bias_scale(const loco::Node *input, const loco::Node *weights, const loco::Node *bias)
+{
+  auto input_node = loco::must_cast<const luci::CircleNode *>(input);
+  auto input_qparam = input_node->quantparam();
+  RETURN_FALSE_UNLESS(input_qparam != nullptr);
+
+  auto weights_node = loco::must_cast<const luci::CircleNode *>(weights);
+  auto weights_qparam = weights_node->quantparam();
+  RETURN_FALSE_UNLESS(weights_qparam != nullptr);
+
+  auto bias_node = loco::must_cast<const luci::CircleNode *>(bias);
+  auto bias_qparam = bias_node->quantparam();
+  RETURN_FALSE_UNLESS(bias_qparam != nullptr);
+
+  RETURN_FALSE_UNLESS(input_qparam->scale.size() == 1);
+  RETURN_FALSE_UNLESS(weights_qparam->scale.size() == bias_qparam->scale.size());
+
+  auto input_scale = input_qparam->scale[0];
+  for (uint32_t i = 0; i < weights_qparam->scale.size(); i++)
+  {
+    auto weights_scale = weights_qparam->scale[i];
+    auto bias_scale = bias_qparam->scale[i];
+    RETURN_FALSE_UNLESS(same(bias_scale, input_scale * weights_scale));
+  }
+  return true;
+}
+} // namespace
+
+namespace luci
+{
+
+bool VerifyQuantizedBiasScale::visit(const luci::CircleConv2D *node)
+{
+  RETURN_FALSE_UNLESS(check_bias_scale(node->input(), node->filter(), node->bias()));
+  return true;
+}
+
+bool VerifyQuantizedBiasScale::visit(const luci::CircleDepthwiseConv2D *node)
+{
+  RETURN_FALSE_UNLESS(check_bias_scale(node->input(), node->filter(), node->bias()));
+  return true;
+}
+
+bool VerifyQuantizedBiasScale::visit(const luci::CircleFullyConnected *node)
+{
+  luci::CircleConst *bias = dynamic_cast<luci::CircleConst *>(node->bias());
+  if (bias != nullptr)
+  {
+    RETURN_FALSE_UNLESS(check_bias_scale(node->input(), node->weights(), node->bias()));
+  }
+  return true;
+}
+
+bool VerifyQuantizedBiasScale::visit(const luci::CircleTransposeConv *node)
+{
+  luci::CircleConst *bias = dynamic_cast<luci::CircleConst *>(node->bias());
+  if (bias != nullptr)
+  {
+    RETURN_FALSE_UNLESS(check_bias_scale(node->outBackprop(), node->filter(), node->bias()));
+  }
+  return true;
+}
+
+} // namespace luci
+
+#undef RETURN_FALSE_UNLESS

--- a/compiler/luci/pass/src/VerifyQuantizedBiasScale.cpp
+++ b/compiler/luci/pass/src/VerifyQuantizedBiasScale.cpp
@@ -27,6 +27,7 @@
 
 namespace
 {
+
 bool same(float a, float b)
 {
   constexpr float epsilon = 1e-10;
@@ -61,6 +62,7 @@ bool check_bias_scale(const loco::Node *input, const loco::Node *weights, const 
   }
   return true;
 }
+
 } // namespace
 
 namespace luci

--- a/compiler/luci/pass/src/VerifyQuantizedBiasScale.h
+++ b/compiler/luci/pass/src/VerifyQuantizedBiasScale.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __LUCI_VERIFY_QUANTIZED_BIAS_SCALE_H__
+#define __LUCI_VERIFY_QUANTIZED_BIAS_SCALE_H__
+
+#include <luci/IR/CircleNodes.h>
+#include <luci/IR/CircleNodeVisitor.h>
+
+#include <memory>
+
+namespace luci
+{
+
+/**
+ * @brief Verify the scale of quantized bias node
+ * @details
+ *
+ * Bias of CONV, DCONV, TCONV, FC layers should meet the following condition.
+ *
+ * bias scale = input scale * weights scale
+ */
+class VerifyQuantizedBiasScale : public luci::CircleNodeVisitor<bool>
+{
+public:
+  static std::shared_ptr<VerifyQuantizedBiasScale> create()
+  {
+    return std::make_shared<VerifyQuantizedBiasScale>();
+  };
+
+public:
+  bool verify(luci::CircleNode *node) { return node->accept(this); }
+
+private:
+  // Operators with bias
+  bool visit(const luci::CircleConv2D *node);
+  bool visit(const luci::CircleDepthwiseConv2D *node);
+  bool visit(const luci::CircleFullyConnected *node);
+  bool visit(const luci::CircleTransposeConv *node);
+
+  bool visit(const luci::CircleNode *) { return true; }
+};
+
+} // namespace luci
+
+#endif // __LUCI_VERIFY_QUANTIZED_BIAS_SCALE_H__


### PR DESCRIPTION
This tests the scale of quantized bias.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
This PR ensures bias scale = input scale * weights scale (related to: https://github.com/Samsung/ONE/issues/8385)