### PR TITLE
[tflchef] Remove nnkit dependency for tests

### DIFF
--- a/compiler/tflchef/tests/CMakeLists.txt
+++ b/compiler/tflchef/tests/CMakeLists.txt
@@ -1,11 +1,3 @@
-if(NOT TARGET nnkit-run)
-  return()
-endif(NOT TARGET nnkit-run)
-
-if(NOT TARGET nnkit_tflite_backend)
-  return()
-endif(NOT TARGET nnkit_tflite_backend)
-
 nncc_find_resource(TensorFlowLiteRecipes)
 set(TENSORFLOWLITERECIPES_DIR "${TensorFlowLiteRecipes_DIR}")
 


### PR DESCRIPTION
This will remove nnkit dependency check for running tests.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>