### PR TITLE
[tflchef] Use mio_tflite260

### DIFF
--- a/compiler/tflchef/tests/CMakeLists.txt
+++ b/compiler/tflchef/tests/CMakeLists.txt
@@ -125,5 +125,5 @@ add_custom_target(tflchef_testfiles ALL DEPENDS ${TESTFILES})
 # TODO do testing with running the model with runtime/interpreter
 add_test(NAME tflchef_test
          COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/runvalidate.sh"
-                 $<TARGET_FILE:mio_tflite_validate>
+                 $<TARGET_FILE:mio_tflite260_validate>
                  ${TESTS})


### PR DESCRIPTION
This will revise to use mio_tflite260_validate as tflchef is using
mio_tflite260.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>