### PR TITLE
[one-cmds] Add onnx_legalize options in one-import-pytorch

### DIFF
--- a/compiler/one-cmds/one-import-pytorch
+++ b/compiler/one-cmds/one-import-pytorch
@@ -79,6 +79,9 @@ def _get_parser():
     tf2tflite_group.add_argument('--model_format', default='saved_model')
     tf2tflite_group.add_argument('--converter_version', default='v2')
 
+    parser.add_argument('--unroll_rnn', action='store_true', help='Unroll RNN operators')
+    parser.add_argument('--unroll_lstm', action='store_true', help='Unroll LSTM operators')
+
     # save intermediate file(s)
     parser.add_argument(
         '--save_intermediate',
@@ -304,7 +307,12 @@ def _convert(args):
 
         # convert onnx to tf saved mode
         onnx_model = onnx.load(onnx_output_path)
-        onnx_legalizer.legalize(onnx_model)
+
+        options = onnx_legalizer.LegalizeOptions()
+        options.unroll_rnn = _utils._is_valid_attr(args, 'unroll_rnn')
+        options.unroll_lstm = _utils._is_valid_attr(args, 'unroll_lstm')
+        onnx_legalizer.legalize(onnx_model, options)
+
         tf_savedmodel = onnx_tf.backend.prepare(onnx_model)
 
         savedmodel_name = os.path.splitext(os.path.basename(

--- a/compiler/one-cmds/tests/pytorch-operations/CMakeLists.txt
+++ b/compiler/one-cmds/tests/pytorch-operations/CMakeLists.txt
@@ -9,6 +9,8 @@ set(TEST_DST test/pytorch-operations)
 
 install(DIRECTORY "${NNAS_PROJECT_SOURCE_DIR}/res/PyTorchExamples/" DESTINATION "${TEST_DST}")
 
+set(PYTORCH_IMPORT_OPTIONS "--unroll_rnn --unroll_lstm")
+
 foreach(TEST_ITEM IN ITEMS ${TEST_EXAMPLES})
   set(TEST_SCRIPT "${CMAKE_CURRENT_BINARY_DIR}/${TEST_ITEM}.test")
 
@@ -25,7 +27,8 @@ foreach(TEST_ITEM IN ITEMS ${TEST_EXAMPLES})
   file(APPEND "${TEST_SCRIPT}" "outputfile=\"${TEST_ITEM}.circle\"\n")
   file(APPEND "${TEST_SCRIPT}" "input_shapes=\$(head -n 1 ${TEST_ITEM}.spec)\n")
   file(APPEND "${TEST_SCRIPT}" "input_types=\$(tail -n 1 ${TEST_ITEM}.spec)\n")
-  file(APPEND "${TEST_SCRIPT}" "one-import-pytorch --input_path=${TEST_ITEM}.pth --output_path=${TEST_ITEM}.circle --input_shapes=\${input_shapes} --input_types=\${input_types} &> /dev/null\n")
+  file(APPEND "${TEST_SCRIPT}" "one-import-pytorch --input_path=${TEST_ITEM}.pth --output_path=${TEST_ITEM}.circle\
+    ${PYTORCH_IMPORT_OPTIONS} --input_shapes=\${input_shapes} --input_types=\${input_types} &> /dev/null\n")
   file(APPEND "${TEST_SCRIPT}" "if [[ ! -s \"\${outputfile}\" ]]; then\n")
   file(APPEND "${TEST_SCRIPT}" "  trap_err_onexit\n")
   file(APPEND "${TEST_SCRIPT}" "fi\n")


### PR DESCRIPTION
This PR adds --unroll_rnn --unroll_lstm options in
one-import-pytorch and pytorch_operations tests.

ONE-DCO-1.0-Signed-off-by: Alexander Efimov <a.efimov@samsung.com>