### PR TITLE
[one-cmds] Add helper scripts for onnx_legalizer.py testing

### DIFF
--- a/compiler/one-cmds/tests/onnx_legalize_run_compare.py
+++ b/compiler/one-cmds/tests/onnx_legalize_run_compare.py
@@ -35,10 +35,9 @@ def _compare_resuts(ref_outputs, test_outputs, tolerance):
     return True
 
 if __name__ == '__main__':
-    # this manipulation is needed to add searcg path where onnx_legalizer is installed
+    # this manipulation is needed to add search path where onnx_legalizer is installed
     sys.path += os.environ['PATH'].split(':')
     import onnx_legalizer
-
 
     if len(sys.argv) < 5:
         exit('expecting 4 arguments: path to input model, path to "legalized" model,'

--- a/compiler/one-cmds/tests/onnx_legalize_run_compare.py
+++ b/compiler/one-cmds/tests/onnx_legalize_run_compare.py
@@ -4,16 +4,18 @@ import sys
 import os
 import numpy as np
 
+
 def _generate_inputs(model):
     inputs = {}
     for input in model.graph.input:
         # check if elem type is float32
-        assert(input.type.tensor_type.elem_type == 1)
+        assert (input.type.tensor_type.elem_type == 1)
         input_shape = []
         for dim in input.type.tensor_type.shape.dim:
             input_shape += [dim.dim_value]
         inputs[input.name] = np.random.random(input_shape).astype(np.float32)
     return inputs
+
 
 def _run_model(model, inputs):
     output_names = list(map(lambda output: output.name, model.graph.output))
@@ -21,18 +23,22 @@ def _run_model(model, inputs):
     outputs = session.run(output_names, inputs)
     return outputs
 
+
 def _compare_resuts(ref_outputs, test_outputs, tolerance):
     num_outputs = len(ref_outputs)
-    assert(len(test_outputs) == num_outputs)
+    assert (len(test_outputs) == num_outputs)
     for i in range(num_outputs):
         if ref_outputs[i].shape != test_outputs[i].shape:
             print("output {} shape mismatch".format(i))
             return False
-        peak_error = np.abs(ref_outputs[i] - test_outputs[i]).max()/np.abs(ref_outputs[i]).max()
+        peak_error = np.abs(ref_outputs[i] - test_outputs[i]).max() / np.abs(
+            ref_outputs[i]).max()
         if peak_error > tolerance:
-            print("output {} peak error to value ratio {} is too big".format(i, peak_error))
+            print("output {} peak error to value ratio {} is too big".format(
+                i, peak_error))
             return False
     return True
+
 
 if __name__ == '__main__':
     # this manipulation is needed to add search path where onnx_legalizer is installed

--- a/compiler/one-cmds/tests/onnx_legalize_run_compare.py
+++ b/compiler/one-cmds/tests/onnx_legalize_run_compare.py
@@ -76,8 +76,11 @@ def _compare_results(ref_outputs, test_outputs, tolerance):
             print("output {} shape mismatch: ref({}) vs test({})".format(
                 i, ref_outputs[i].shape, test_outputs[i].shape))
             return False
-        peak_error = np.abs(ref_outputs[i] - test_outputs[i]).max() / np.abs(
-            ref_outputs[i]).max()
+
+        abs_difference = np.abs(ref_outputs[i] - test_outputs[i])
+        abs_ref_maximum = np.abs(ref_outputs[i]).max()
+        peak_error = abs_difference.max() / abs_ref_maximum
+
         if peak_error > tolerance:
             print("output {} peak error to value ratio {} is too big".format(
                 i, peak_error))

--- a/compiler/one-cmds/tests/onnx_legalize_run_compare.py
+++ b/compiler/one-cmds/tests/onnx_legalize_run_compare.py
@@ -1,0 +1,71 @@
+import onnxruntime as rt
+import onnx
+import sys
+import os
+import numpy as np
+
+def _generate_inputs(model):
+    inputs = {}
+    for input in model.graph.input:
+        # check if elem type is float32
+        assert(input.type.tensor_type.elem_type == 1)
+        input_shape = []
+        for dim in input.type.tensor_type.shape.dim:
+            input_shape += [dim.dim_value]
+        inputs[input.name] = np.random.random(input_shape).astype(np.float32)
+    return inputs
+
+def _run_model(model, inputs):
+    output_names = list(map(lambda output: output.name, model.graph.output))
+    session = rt.InferenceSession(model.SerializeToString())
+    outputs = session.run(output_names, inputs)
+    return outputs
+
+def _compare_resuts(ref_outputs, test_outputs, tolerance):
+    num_outputs = len(ref_outputs)
+    assert(len(test_outputs) == num_outputs)
+    for i in range(num_outputs):
+        if ref_outputs[i].shape != test_outputs[i].shape:
+            print("output {} shape mismatch".format(i))
+            return False
+        peak_error = np.abs(ref_outputs[i] - test_outputs[i]).max()/np.abs(ref_outputs[i]).max()
+        if peak_error > tolerance:
+            print("output {} peak error to value ratio {} is too big".format(i, peak_error))
+            return False
+    return True
+
+if __name__ == '__main__':
+    # this manipulation is needed to add searcg path where onnx_legalizer is installed
+    sys.path += os.environ['PATH'].split(':')
+    import onnx_legalizer
+
+
+    if len(sys.argv) < 5:
+        exit('expecting 4 arguments: path to input model, path to "legalized" model,'
+             'base name for generated test inputs, output tolerance')
+    input_model_path = sys.argv[1]
+    output_model_path = sys.argv[2]
+    input_dump_path = sys.argv[3]
+    tolerance = float(sys.argv[4])
+
+    model = onnx.load(input_model_path)
+
+    inputs = _generate_inputs(model)
+
+    for i in inputs:
+        np.save('{}_{}.npy'.format(input_dump_path, i), inputs[i])
+
+    ref_outputs = _run_model(model, inputs)
+
+    options = onnx_legalizer.LegalizeOptions()
+    options.unroll_rnn = True
+    options.unroll_lstm = True
+    onnx_legalizer.legalize(model, options)
+
+    with open(output_model_path, 'wb') as f:
+        f.write(model.SerializeToString())
+
+    test_outputs = _run_model(model, inputs)
+
+    if not _compare_resuts(ref_outputs, test_outputs, tolerance):
+        exit('comparison failed')

--- a/compiler/one-cmds/tests/print_onnx_model.py
+++ b/compiler/one-cmds/tests/print_onnx_model.py
@@ -1,0 +1,6 @@
+import onnx
+import sys
+
+if __name__ == '__main__':
+    model = onnx.load(sys.argv[1])
+    print(model)

--- a/compiler/one-cmds/tests/print_onnx_model.py
+++ b/compiler/one-cmds/tests/print_onnx_model.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import onnx
 import sys
 


### PR DESCRIPTION
This PR adds onnx_legalize_run_compare.py and
print_onnx_model.py to test onnx_lagalizer correctness.

Related issue #8395

ONE-DCO-1.0-Signed-off-by: Alexander Efimov <a.efimov@samsung.com>