### PR TITLE
[circlechef] Skip message for CMakeLists

### DIFF
--- a/compiler/circlechef/CMakeLists.txt
+++ b/compiler/circlechef/CMakeLists.txt
@@ -1,10 +1,12 @@
 nnas_find_package(Protobuf QUIET)
 
 if(NOT Protobuf_FOUND)
+  message(STATUS "circlechef: SKIP (missing Protobuf)")
   return()
 endif(NOT Protobuf_FOUND)
 
 if(NOT TARGET mio_circle)
+  message(STATUS "circlechef: SKIP (missing mio-circle)")
   return()
 endif(NOT TARGET mio_circle)
 


### PR DESCRIPTION
This will add cmake skip message if required libraries are missing.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>