### PR TITLE
[infra] Fix indent for nnas_find_package macro

### DIFF
--- a/infra/nncc/CMakeLists.txt
+++ b/infra/nncc/CMakeLists.txt
@@ -40,10 +40,10 @@ macro(nnas_include PREFIX)
 endmacro(nnas_include)
 
 macro(nnas_find_package PREFIX)
-  find_package(${PREFIX} CONFIG NO_DEFAULT_PATH
-    PATHS ${NNAS_PROJECT_SOURCE_DIR}/infra/cmake/packages
-    ${ARGN}
-  )
+  find_package(${PREFIX}
+               CONFIG NO_DEFAULT_PATH
+               PATHS ${NNAS_PROJECT_SOURCE_DIR}/infra/cmake/packages
+               ${ARGN})
 endmacro(nnas_find_package)
 
 # nncc_find_resource(NAME) will update the following variables


### PR DESCRIPTION
This will fix indentation for nnas_find_package macro.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>