### PR TITLE
[circledump] Add keep_num_dims to FullyConnectedPrinter

### DIFF
--- a/compiler/circledump/src/OpPrinter.cpp
+++ b/compiler/circledump/src/OpPrinter.cpp
@@ -341,6 +341,7 @@ public:
          << ") ";
       os << "Activation(" << EnumNameActivationFunctionType(params->fused_activation_function())
          << ") ";
+      os << "keep_num_dims(" << params->keep_num_dims() << ") ";
 
       os << std::endl;
     }


### PR DESCRIPTION
This commit adds `keep_num_dims` to `FullyConnectedPrinter`.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>

---

Parent Issue : #8400
Draft : #8401