### PR TITLE
[tflchef] Add keep_num_dims to FullyConnectedOption

### DIFF
--- a/compiler/tflchef/core/src/Op/FullyConnected.cpp
+++ b/compiler/tflchef/core/src/Op/FullyConnected.cpp
@@ -29,6 +29,7 @@ flatbuffers::Offset<void> FullyConnectedChef::value(flatbuffers::FlatBufferBuild
 
   tflite::FullyConnectedOptionsBuilder fc_options_builder{fbb};
   fc_options_builder.add_fused_activation_function(tflite_activation);
+  fc_options_builder.add_keep_num_dims(operation.fullyconnected_options().keep_num_dims());
 
   return fc_options_builder.Finish().Union();
 }

--- a/compiler/tflchef/proto/tflchef.proto
+++ b/compiler/tflchef/proto/tflchef.proto
@@ -182,6 +182,7 @@ message FloorModOptions {
 
 message FullyConnectedOptions {
   optional Activation activation = 1 [default = NONE];
+  optional bool keep_num_dims = 2 [ default = false ];
 }
 
 message AddOptions {

--- a/compiler/tflchef/tflite/src/Op/FullyConnected.cpp
+++ b/compiler/tflchef/tflite/src/Op/FullyConnected.cpp
@@ -48,6 +48,7 @@ tflchef::Operation *TFliteOpFullyConnected::build(const tflite::Operator *op, TF
   auto op_options = operation->mutable_fullyconnected_options();
 
   op_options->set_activation(as_tflchef_activation(op_params->fused_activation_function()));
+  op_options->set_keep_num_dims(op_params->keep_num_dims());
 
   return operation;
 }


### PR DESCRIPTION
This commit adds `keep_num_dims` to `FulltConnectedOption`.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>

---

Parent Issue : #8400
Draft : #8401 