### PR TITLE
[luci-interpreter] Add keep_num_dims to FullyConnected

### DIFF
--- a/compiler/luci-interpreter/src/core/KernelParams.h
+++ b/compiler/luci-interpreter/src/core/KernelParams.h
@@ -89,6 +89,7 @@ struct DivParams
 struct FullyConnectedParams
 {
   Activation activation;
+  bool keep_num_dims = false;
 };
 
 struct GatherParams

--- a/compiler/luci-interpreter/src/kernels/FullyConnected.cpp
+++ b/compiler/luci-interpreter/src/kernels/FullyConnected.cpp
@@ -73,7 +73,18 @@ void FullyConnected::configure()
   if (bias())
     LUCI_INTERPRETER_CHECK(bias()->shape().num_elements() == weights()->shape().dim(0));
 
-  output()->resize({batch_size, num_units});
+  if (params().keep_num_dims == false)
+  {
+    output()->resize({batch_size, num_units});
+  }
+  else
+  {
+    luci_interpreter::Shape output_shape(input_shape.num_dims());
+    for (int i = 0; i < input_shape.num_dims(); ++i)
+      output_shape.dim(i) = input_shape.dim(i);
+    output_shape.dim(input_shape.num_dims() - 1) = num_units;
+    output()->resize(output_shape);
+  }
 }
 
 void FullyConnected::execute() const

--- a/compiler/luci-interpreter/src/loader/nodes/FullyConnected.cpp
+++ b/compiler/luci-interpreter/src/loader/nodes/FullyConnected.cpp
@@ -36,6 +36,7 @@ std::unique_ptr<Kernel> build_kernel_CircleFullyConnected(const luci::CircleNode
 
   FullyConnectedParams params{};
   params.activation = node->fusedActivationFunction();
+  params.keep_num_dims = node->keep_num_dims();
 
   return std::make_unique<kernels::FullyConnected>(input, weights, bias, output, params);
 }


### PR DESCRIPTION
This commit adds `keep_num_dims` to `FullyConnected`.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>

---

Parent issue : #8400 
Draft : #8401