### PR TITLE
[luci/export] Add keep_num_dims to CircleFullyConnected

### DIFF
--- a/compiler/luci/export/src/CircleBuiltinTypesExtractor.h
+++ b/compiler/luci/export/src/CircleBuiltinTypesExtractor.h
@@ -170,9 +170,9 @@ public:
   }
   flatbuffers::Offset<void> visit(luci::CircleFullyConnected *node)
   {
-    return circle::CreateFullyConnectedOptions(_builder,
-                                               to_circle_actfunc(node->fusedActivationFunction()),
-                                               to_circle_weightsformat(node->weights_format()))
+    return circle::CreateFullyConnectedOptions(
+             _builder, to_circle_actfunc(node->fusedActivationFunction()),
+             to_circle_weightsformat(node->weights_format()), node->keep_num_dims())
       .Union();
   }
   flatbuffers::Offset<void> visit(luci::CircleGather *node)


### PR DESCRIPTION
This commit adds `keep_num_dims` to `CircleFullyConnected`.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>

---

Parent Issue : #8400 
Draft : #8401