### PR TITLE
[luci] Remove deprecated member variables in QWMM

### DIFF
--- a/compiler/luci/pass/include/luci/Pass/QuantizeWithMinMaxPass.h
+++ b/compiler/luci/pass/include/luci/Pass/QuantizeWithMinMaxPass.h
@@ -47,8 +47,6 @@ public:
 public:
   QuantizeWithMinMaxPass(loco::DataType input_model_dtype, loco::DataType output_model_dtype,
                          QuantizationGranularity granularity)
-    : _input_model_dtype{input_model_dtype}, _output_model_dtype{output_model_dtype},
-      _granularity{granularity}, _input_type{output_model_dtype}, _output_type{output_model_dtype}
   {
     _ctx = std::make_unique<Context>();
     {
@@ -78,12 +76,6 @@ private:
 
 private:
   std::unique_ptr<Context> _ctx;
-  loco::DataType _input_model_dtype;
-  loco::DataType _output_model_dtype;
-  QuantizationGranularity _granularity;
-  loco::DataType _input_type;
-  loco::DataType _output_type;
-  bool _TF_style_maxpool = false;
 };
 
 } // namespace luci


### PR DESCRIPTION
This removes deprecated member variables in QuantizeWithMinMax.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/8454