### PR TITLE
[luci] Add layer info to QWMM context

### DIFF
--- a/compiler/luci/pass/include/luci/Pass/QuantizationParameters.h
+++ b/compiler/luci/pass/include/luci/Pass/QuantizationParameters.h
@@ -17,6 +17,10 @@
 #ifndef __LUCI_QUANTIZATION_PARAMETERS_H__
 #define __LUCI_QUANTIZATION_PARAMETERS_H__
 
+#include <loco.h>
+
+#include <string>
+
 namespace luci
 {
 
@@ -24,6 +28,13 @@ enum QuantizationGranularity
 {
   LayerWise = 0,
   ChannelWise = 1,
+};
+
+struct LayerInfo
+{
+  std::string name;
+  loco::DataType dtype;
+  QuantizationGranularity granularity;
 };
 
 } // namespace luci

--- a/compiler/luci/pass/include/luci/Pass/QuantizeWithMinMaxPass.h
+++ b/compiler/luci/pass/include/luci/Pass/QuantizeWithMinMaxPass.h
@@ -23,6 +23,8 @@
 
 #include <luci/Pass/QuantizationParameters.h>
 
+#include <vector>
+
 namespace luci
 {
 

--- a/compiler/luci/pass/include/luci/Pass/QuantizeWithMinMaxPass.h
+++ b/compiler/luci/pass/include/luci/Pass/QuantizeWithMinMaxPass.h
@@ -40,6 +40,7 @@ public:
     loco::DataType input_type;
     loco::DataType output_type;
     bool TF_style_maxpool = false;
+    std::vector<LayerInfo> layers_info;
   };
 
   // For backward-compatibility


### PR DESCRIPTION
This adds layer information to QuantizeWithMinMax context.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/8399
Draft PR: https://github.com/Samsung/ONE/pull/8460