### PR TITLE
[res] Add FullyConnected recipe with keep_num_dims

### DIFF
--- a/res/TensorFlowLiteRecipes/FullyConnected_006/test.recipe
+++ b/res/TensorFlowLiteRecipes/FullyConnected_006/test.recipe
@@ -1,0 +1,29 @@
+operand {
+  name: "in"
+  type: FLOAT32
+  shape { dim: 1 dim: 1 dim: 4 }
+}
+operand {
+  name: "weight"
+  type: FLOAT32
+  shape { dim: 2 dim: 4 }
+}
+operand {
+  name: "out"
+  type: FLOAT32
+  shape { dim: 1 dim: 1 dim: 2 }
+}
+operation {
+  type: "FullyConnected"
+  fullyconnected_options {
+    activation: NONE
+    keep_num_dims: true
+  }
+  input: "in"
+  input: "weight"
+  input: ""
+  output: "out"
+}
+input: "in"
+input: "weight"
+output: "out"


### PR DESCRIPTION
This commit adds `FullyConnected_006`, which includes
recipe of `FullyConnected` with `keep_num_dims`.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>

---

Parent Issue : #8400 
Draft : #8401 