### PR TITLE
[luci/service] Update shape inference logic of CircleFullyConnected

### DIFF
--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -743,6 +743,8 @@ loco::NodeShape infer_fully_connected(const luci::CircleFullyConnected *node)
 
   loco::TensorShape out_shape;
 
+  // NOTE Some recipes in some repositories are using rank 4 input for FullyConnected.
+  //      Until they are all fixed, disable following assert.
   // TODO Enable following assert after related fixes are applied
   // https://github.com/tensorflow/tensorflow/blob/ea33c1e7a25d8025e8ee405ad8ab7be261798d76/tensorflow/lite/kernels/fully_connected.cc#L194
   // LUCI_ASSERT(input_shape.rank() == 2 || input_shape.rank() == 3,


### PR DESCRIPTION
This commit updates shape inference logic of `CircleFullyConnected`
with new attribute `keep_num_dims`.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>

---

Parent Issue : #8400 
Draft : #8401 