### PR TITLE
[luci] Apply fake quantization to visitor target

### DIFF
--- a/compiler/luci/pass/src/QuantizeDequantizeWeightsPass.cpp
+++ b/compiler/luci/pass/src/QuantizeDequantizeWeightsPass.cpp
@@ -369,21 +369,15 @@ private:
     assert(output_type == loco::DataType::U8 || output_type == loco::DataType::S16);
     LOGGER(l);
     INFO(l) << "QuantizeDequantizeWeights visit node: " << node->name() << std::endl;
-    auto arity = node->arity();
-    for (uint32_t i = 0; i < arity; i++)
-    {
-      auto input_node = node->arg(i);
-      auto circle_node = loco::must_cast<luci::CircleNode *>(input_node);
 
-      if (not is_quantizable(input_node))
-        continue;
+    if (not is_quantizable(node))
+      return false;
 
-      if (not is_weights(circle_node))
-        continue;
+    if (not is_weights(node))
+      return false;
 
-      auto circle_const = loco::must_cast<luci::CircleConst *>(input_node);
-      fake_quantize(circle_const);
-    }
+    auto circle_const = loco::must_cast<luci::CircleConst *>(node);
+    fake_quantize(circle_const);
     return false;
   }
 };


### PR DESCRIPTION
This applies fake quantization to visitor target, not args.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/pull/8470