### PR TITLE
[one-cmds] Revise one-prepare-venv to split onnx install

### DIFF
--- a/compiler/one-cmds/one-prepare-venv
+++ b/compiler/one-cmds/one-prepare-venv
@@ -72,9 +72,11 @@ ${VENV_PYTHON} -m pip ${PIP_OPTIONS} install torch==1.10.0+cpu -f ${TORCH_STABLE
 # TODO remove this when VER_TENSORFLOW > 2.6.0
 ${VENV_PYTHON} -m pip ${PIP_OPTIONS} install keras==2.6.0
 
+${VENV_PYTHON} -m pip ${PIP_OPTIONS} install onnx==${VER_ONNX}
+
 # Provide install of custom onnx-tf
 if [ -n "${EXT_ONNX_TF_WHL}" ]; then
-  ${VENV_PYTHON} -m pip ${PIP_OPTIONS} install onnx==${VER_ONNX} ${EXT_ONNX_TF_WHL}
+  ${VENV_PYTHON} -m pip ${PIP_OPTIONS} install ${EXT_ONNX_TF_WHL}
 else
-  ${VENV_PYTHON} -m pip ${PIP_OPTIONS} install onnx==${VER_ONNX} onnx-tf==${VER_ONNX_TF}
+  ${VENV_PYTHON} -m pip ${PIP_OPTIONS} install onnx-tf==${VER_ONNX_TF}
 fi


### PR DESCRIPTION
This will revise one-prepare-venv to split onnx and onnx-tf install
in separate command.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>