### PR TITLE
[luci] Remove unnecessary return value of visitors

### DIFF
--- a/compiler/luci/pass/src/QuantizeDequantizeWeightsPass.cpp
+++ b/compiler/luci/pass/src/QuantizeDequantizeWeightsPass.cpp
@@ -366,7 +366,7 @@ private:
   }
 
   // Default behavior (Do nothing)
-  void visit(luci::CircleNode *) { return; }
+  void visit(luci::CircleNode *) {}
 
   void visit(luci::CircleConv2D *node)
   {
@@ -380,7 +380,6 @@ private:
     auto new_weights = luci::clone(weights);
     node->filter(new_weights);
     fake_quantize(new_weights);
-    return;
   }
 
   void visit(luci::CircleDepthwiseConv2D *node)
@@ -395,7 +394,6 @@ private:
     auto new_weights = luci::clone(weights);
     node->filter(new_weights);
     fake_quantize(new_weights);
-    return;
   }
 
   void visit(luci::CircleTransposeConv *node)
@@ -410,7 +408,6 @@ private:
     auto new_weights = luci::clone(weights);
     node->filter(new_weights);
     fake_quantize(new_weights);
-    return;
   }
 
   void visit(luci::CircleFullyConnected *node)
@@ -425,7 +422,6 @@ private:
     auto new_weights = luci::clone(weights);
     node->weights(new_weights);
     fake_quantize(new_weights);
-    return;
   }
 };
 

--- a/compiler/luci/pass/src/QuantizeDequantizeWeightsPass.cpp
+++ b/compiler/luci/pass/src/QuantizeDequantizeWeightsPass.cpp
@@ -252,7 +252,7 @@ void asymmetric_wdequant_with_minmax_per_layer(CircleConst *node, float scaling_
  * @brief QuantizeDequantizeWeights quantizes and dequantizes tensors for weights
  * @details Find min/max values on the fly, quantize the model, and dequantize the model
  */
-struct QuantizeDequantizeWeights final : public luci::CircleNodeMutableVisitor<bool>
+struct QuantizeDequantizeWeights final : public luci::CircleNodeMutableVisitor<void>
 {
   QuantizeDequantizeWeights(loco::DataType input, loco::DataType output,
                             QuantizationGranularity granularity)
@@ -366,66 +366,66 @@ private:
   }
 
   // Default behavior (Do nothing)
-  bool visit(luci::CircleNode *) { return false; }
+  void visit(luci::CircleNode *) { return; }
 
-  bool visit(luci::CircleConv2D *node)
+  void visit(luci::CircleConv2D *node)
   {
     LOGGER(l);
     INFO(l) << "QuantizeDequantizeWeights visit node: " << node->name() << std::endl;
 
     if (not is_quantizable(node->filter()))
-      return false;
+      return;
 
     auto weights = loco::must_cast<luci::CircleConst *>(node->filter());
     auto new_weights = luci::clone(weights);
     node->filter(new_weights);
     fake_quantize(new_weights);
-    return true;
+    return;
   }
 
-  bool visit(luci::CircleDepthwiseConv2D *node)
+  void visit(luci::CircleDepthwiseConv2D *node)
   {
     LOGGER(l);
     INFO(l) << "QuantizeDequantizeWeights visit node: " << node->name() << std::endl;
 
     if (not is_quantizable(node->filter()))
-      return false;
+      return;
 
     auto weights = loco::must_cast<luci::CircleConst *>(node->filter());
     auto new_weights = luci::clone(weights);
     node->filter(new_weights);
     fake_quantize(new_weights);
-    return true;
+    return;
   }
 
-  bool visit(luci::CircleTransposeConv *node)
+  void visit(luci::CircleTransposeConv *node)
   {
     LOGGER(l);
     INFO(l) << "QuantizeDequantizeWeights visit node: " << node->name() << std::endl;
 
     if (not is_quantizable(node->filter()))
-      return false;
+      return;
 
     auto weights = loco::must_cast<luci::CircleConst *>(node->filter());
     auto new_weights = luci::clone(weights);
     node->filter(new_weights);
     fake_quantize(new_weights);
-    return true;
+    return;
   }
 
-  bool visit(luci::CircleFullyConnected *node)
+  void visit(luci::CircleFullyConnected *node)
   {
     LOGGER(l);
     INFO(l) << "QuantizeDequantizeWeights visit node: " << node->name() << std::endl;
 
     if (not is_quantizable(node->weights()))
-      return false;
+      return;
 
     auto weights = loco::must_cast<luci::CircleConst *>(node->weights());
     auto new_weights = luci::clone(weights);
     node->weights(new_weights);
     fake_quantize(new_weights);
-    return true;
+    return;
   }
 };
 

--- a/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
+++ b/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
@@ -1028,7 +1028,7 @@ private:
     }
   }
 
-  void visit(luci::CircleNode *) { return; }
+  void visit(luci::CircleNode *) {}
 };
 
 /** EXAMPLE


### PR DESCRIPTION
This removes unnecessary return value of visitors
  - QuantizeDequantizeWeights
  - QuantizeActivation
  - QuantizeWeights
  - QuantizeBias

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/pull/8474#discussion_r811485934