### PR TITLE
[souschef] Close parenthesis in CMake

### DIFF
--- a/compiler/souschef/CMakeLists.txt
+++ b/compiler/souschef/CMakeLists.txt
@@ -1,7 +1,7 @@
 nnas_find_package(Protobuf QUIET)
 
 if(NOT Protobuf_FOUND)
-  message(STATUS "Build souschef: FAILED (missing Protobuf")
+  message(STATUS "Build souschef: FAILED (missing Protobuf)")
   return()
 endif(NOT Protobuf_FOUND)
 


### PR DESCRIPTION
This will close missing parenthesis in CMakeLists.txt message.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>