### PR TITLE
[luci] Rename Propagate QParam Pass

### DIFF
--- a/compiler/luci/pass/include/luci/Pass/PropagateQParamForwardPass.h
+++ b/compiler/luci/pass/include/luci/Pass/PropagateQParamForwardPass.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef __LUCI_PROPAGATE_QUANT_PARAM_PASS_H__
-#define __LUCI_PROPAGATE_QUANT_PARAM_PASS_H__
+#ifndef __LUCI_PROPAGATE_QPARAM_FORWARD_PASS_H__
+#define __LUCI_PROPAGATE_QPARAM_FORWARD_PASS_H__
 
 #include <logo/Pass.h>
 
@@ -25,13 +25,13 @@ namespace luci
 /**
  * @brief  Class to propagate quantization parameters of an operator's output to input
  */
-struct PropagateQuantParamPass final : public logo::Pass
+struct PropagateQParamForwardPass final : public logo::Pass
 {
-  PropagateQuantParamPass(bool TF_style_maxpool) : _TF_style_maxpool(TF_style_maxpool) {}
+  PropagateQParamForwardPass(bool TF_style_maxpool) : _TF_style_maxpool(TF_style_maxpool) {}
 
-  PropagateQuantParamPass() {}
+  PropagateQParamForwardPass() {}
 
-  const char *name(void) const final { return "luci::PropagateQuantParamPass"; }
+  const char *name(void) const final { return "luci::PropagateQParamForwardPass"; }
 
   bool run(loco::Graph *g) final;
 
@@ -41,4 +41,4 @@ private:
 
 } // namespace luci
 
-#endif // __LUCI_PROPAGATE_QUANT_PARAM_PASS_H__
+#endif // __LUCI_PROPAGATE_QPARAM_FORWARD_PASS_H__

--- a/compiler/luci/pass/include/luci/Pass/PropagateQParamForwardPass.h
+++ b/compiler/luci/pass/include/luci/Pass/PropagateQParamForwardPass.h
@@ -23,7 +23,7 @@ namespace luci
 {
 
 /**
- * @brief  Class to propagate quantization parameters of an operator's output to input
+ * @brief  Class to propagate quantization parameters of an operator's input to output
  */
 struct PropagateQParamForwardPass final : public logo::Pass
 {

--- a/compiler/luci/pass/src/CircleQuantizer.cpp
+++ b/compiler/luci/pass/src/CircleQuantizer.cpp
@@ -18,7 +18,7 @@
 
 #include "luci/Pass/CopyQuantParamPass.h"
 #include "luci/Pass/ForceQuantParamPass.h"
-#include "luci/Pass/PropagateQuantParamPass.h"
+#include "luci/Pass/PropagateQParamForwardPass.h"
 #include "luci/Pass/RequantizePass.h"
 #include "luci/Pass/QuantizeWithMinMaxPass.h"
 #include "luci/Pass/QuantizeDequantizeWeightsPass.h"

--- a/compiler/luci/pass/src/PropagateQParamForwardPass.cpp
+++ b/compiler/luci/pass/src/PropagateQParamForwardPass.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "luci/Pass/PropagateQuantParamPass.h"
+#include "luci/Pass/PropagateQParamForwardPass.h"
 
 #include <luci/IR/CircleNodes.h>
 #include <luci/IR/CircleNodeVisitor.h>
@@ -57,9 +57,9 @@ bool copy_qparam(luci::CircleNode *src, luci::CircleNode *dst)
 }
 
 //  Visitor to propagate quantization parameters
-struct PropagateQuantParam final : public luci::CircleNodeMutableVisitor<bool>
+struct PropagateQParamForward final : public luci::CircleNodeMutableVisitor<bool>
 {
-  PropagateQuantParam() = default;
+  PropagateQParamForward() = default;
 
   bool visit(luci::CircleNode *) { return false; }
 
@@ -114,16 +114,16 @@ struct PropagateQuantParam final : public luci::CircleNodeMutableVisitor<bool>
 namespace luci
 {
 
-bool PropagateQuantParamPass::run(loco::Graph *g)
+bool PropagateQParamForwardPass::run(loco::Graph *g)
 {
   bool changed = false;
   LOGGER(l);
   for (auto node : loco::active_nodes(loco::output_nodes(g)))
   {
     auto circle_node = loco::must_cast<luci::CircleNode *>(node);
-    INFO(l) << "PropagateQuantParamPass visit node: " << circle_node->name() << std::endl;
+    INFO(l) << "PropagateQParamForwardPass visit node: " << circle_node->name() << std::endl;
 
-    PropagateQuantParam pqp;
+    PropagateQParamForward pqp;
     if (circle_node->accept(&pqp))
       changed = true;
 

--- a/compiler/luci/pass/src/PropagateQParamForwardPass.test.cpp
+++ b/compiler/luci/pass/src/PropagateQParamForwardPass.test.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "luci/Pass/PropagateQuantParamPass.h"
+#include "luci/Pass/PropagateQParamForwardPass.h"
 
 #include <luci/IR/CircleNodes.h>
 
@@ -83,18 +83,18 @@ public:
 
 } // namespace
 
-TEST(PropagateQuantParamPassTest, name)
+TEST(PropagateQParamForwardPassTest, name)
 {
-  luci::PropagateQuantParamPass pass;
+  luci::PropagateQParamForwardPass pass;
   auto const name = pass.name();
   ASSERT_NE(nullptr, name);
 }
 
-TEST(PropagateQuantParam, simple)
+TEST(PropagateQParamForward, simple)
 {
   SimpleGraph g;
 
-  luci::PropagateQuantParamPass pass;
+  luci::PropagateQParamForwardPass pass;
   while (pass.run(&g.g))
     ;
 
@@ -106,13 +106,13 @@ TEST(PropagateQuantParam, simple)
   EXPECT_EQ(20, g.reshape->quantparam()->zerop[2]);
 }
 
-TEST(PropagateQuantParam, wrong_op_NEG)
+TEST(PropagateQParamForward, wrong_op_NEG)
 {
   SimpleGraph g;
   g.output->from(g.conv);
   g.reshape->drop();
 
-  luci::PropagateQuantParamPass pass;
+  luci::PropagateQParamForwardPass pass;
   while (pass.run(&g.g))
     ;
 

--- a/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
+++ b/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
@@ -15,7 +15,7 @@
  */
 
 #include "luci/Pass/QuantizeWithMinMaxPass.h"
-#include "luci/Pass/PropagateQuantParamPass.h"
+#include "luci/Pass/PropagateQParamForwardPass.h"
 #include "QuantizationUtils.h"
 #include "ProgressReporter.h"
 
@@ -1671,7 +1671,7 @@ void QuantizeWithMinMaxPass::set_output_type(loco::Graph *g) const
  *   - Propagate qparam of concat backward for optimization (propagate_concat_quantparam)
  *   - Quantize const inputs + propagate qparam backward (QuantizeConstInputActivation)
  *   - Quantize using pre-defined values (QuantizeSpecialActivation)
- *   - Propagate qparam forward (PropagateQuantParamPass)
+ *   - Propagate qparam forward (PropagateQParamForwardPass)
  * 2. Quantize Weights
  * 3. Quantize Bias
  * 4. Set input dtype
@@ -1738,7 +1738,7 @@ bool QuantizeWithMinMaxPass::run(loco::Graph *g)
   // Forward propagation of activation qparam
   logo::Phase phase;
 
-  phase.emplace_back(std::make_unique<luci::PropagateQuantParamPass>(_ctx->TF_style_maxpool));
+  phase.emplace_back(std::make_unique<luci::PropagateQParamForwardPass>(_ctx->TF_style_maxpool));
 
   ProgressReporter prog(g, logo::PhaseStrategy::Saturate);
   logo::PhaseRunner<logo::PhaseStrategy::Saturate> phase_runner{g};


### PR DESCRIPTION
This adds direction of propagation (Forward) to pass name.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>