### PR TITLE
[common-artifacts] Remove prepare of venv of TF2.3.0

### DIFF
--- a/compiler/common-artifacts/CMakeLists.txt
+++ b/compiler/common-artifacts/CMakeLists.txt
@@ -15,8 +15,6 @@ endif()
 # Create python virtual environment with tensorflow 1.13.2
 set(VIRTUALENV_OVERLAY_TF_1_13_2 "${NNCC_OVERLAY_DIR}/venv_1_13_2")
 
-# Create python virtual environment with tensorflow 2.3.0
-set(VIRTUALENV_OVERLAY_TF_2_3_0 "${NNCC_OVERLAY_DIR}/venv_2_3_0")
 # Create python virtual environment with tensorflow 2.6.0
 set(VIRTUALENV_OVERLAY_TF_2_6_0 "${NNCC_OVERLAY_DIR}/venv_2_6_0")
 
@@ -26,10 +24,6 @@ add_custom_command(
 )
 
 add_custom_command(
-  OUTPUT ${VIRTUALENV_OVERLAY_TF_2_3_0}
-  COMMAND ${PYTHON_EXECUTABLE} -m venv ${VIRTUALENV_OVERLAY_TF_2_3_0}
-)
-add_custom_command(
   OUTPUT ${VIRTUALENV_OVERLAY_TF_2_6_0}
   COMMAND ${PYTHON_EXECUTABLE} -m venv ${VIRTUALENV_OVERLAY_TF_2_6_0}
 )
@@ -37,7 +31,6 @@ add_custom_command(
 # Create requirements.txt and install required pip packages
 set(REQUIREMENTS_FILE "requirements.txt")
 set(REQUIREMENTS_OVERLAY_PATH_TF_1_13_2 "${VIRTUALENV_OVERLAY_TF_1_13_2}/${REQUIREMENTS_FILE}")
-set(REQUIREMENTS_OVERLAY_PATH_TF_2_3_0 "${VIRTUALENV_OVERLAY_TF_2_3_0}/${REQUIREMENTS_FILE}")
 set(REQUIREMENTS_OVERLAY_PATH_TF_2_6_0 "${VIRTUALENV_OVERLAY_TF_2_6_0}/${REQUIREMENTS_FILE}")
 
 # TODO remove version number of '--upgrade pip==20.2.1 setuptools==49.3.0'
@@ -48,16 +41,6 @@ add_custom_command(
   COMMAND ${VIRTUALENV_OVERLAY_TF_1_13_2}/bin/python -m pip --default-timeout=1000 install --upgrade pip==20.2.1 setuptools==49.3.0
   COMMAND ${VIRTUALENV_OVERLAY_TF_1_13_2}/bin/python -m pip --default-timeout=1000 install -r ${REQUIREMENTS_OVERLAY_PATH_TF_1_13_2} --upgrade
   DEPENDS ${VIRTUALENV_OVERLAY_TF_1_13_2}
-)
-
-add_custom_command(
-  OUTPUT ${REQUIREMENTS_OVERLAY_PATH_TF_2_3_0}
-  COMMAND ${CMAKE_COMMAND} -E remove -f ${REQUIREMENTS_OVERLAY_PATH_TF_2_3_0}
-  COMMAND ${CMAKE_COMMAND} -E echo "tensorflow-cpu==2.3.0" >> ${REQUIREMENTS_OVERLAY_PATH_TF_2_3_0}
-  COMMAND ${CMAKE_COMMAND} -E echo "flatbuffers==1.12" >> ${REQUIREMENTS_OVERLAY_PATH_TF_2_3_0}
-  COMMAND ${VIRTUALENV_OVERLAY_TF_2_3_0}/bin/python -m pip --default-timeout=1000 install --upgrade pip==20.2.1 setuptools==49.3.0
-  COMMAND ${VIRTUALENV_OVERLAY_TF_2_3_0}/bin/python -m pip --default-timeout=1000 install -r ${REQUIREMENTS_OVERLAY_PATH_TF_2_3_0} --upgrade
-  DEPENDS ${VIRTUALENV_OVERLAY_TF_2_3_0}
 )
 
 add_custom_command(
@@ -72,10 +55,8 @@ add_custom_command(
 
 add_custom_target(common_artifacts_python_deps ALL
   DEPENDS ${VIRTUALENV_OVERLAY_TF_1_13_2}
-          ${VIRTUALENV_OVERLAY_TF_2_3_0}
           ${VIRTUALENV_OVERLAY_TF_2_6_0}
           ${REQUIREMENTS_OVERLAY_PATH_TF_1_13_2}
-          ${REQUIREMENTS_OVERLAY_PATH_TF_2_3_0}
           ${REQUIREMENTS_OVERLAY_PATH_TF_2_6_0}
 )
 


### PR DESCRIPTION
This will remove prepare of python venv of TF 2.3.0 as it's not used anymore.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>