### PR TITLE
[circle-quantizer] Add --config option

### DIFF
--- a/compiler/circle-quantizer/CMakeLists.txt
+++ b/compiler/circle-quantizer/CMakeLists.txt
@@ -1,6 +1,15 @@
+nnas_find_package(Jsoncpp)
+if(NOT Jsoncpp_FOUND)
+  message(STATUS "Build jsoncpp: FAILED (missing jsoncpp)")
+  return()
+endif(NOT Jsoncpp_FOUND)
+
 set (SOURCES src/CircleQuantizer.cpp)
 
 add_executable(circle-quantizer "${SOURCES}")
+target_include_directories(circle-quantizer PRIVATE ${Jsoncpp_INCLUDE_DIRS})
+
+target_link_libraries(circle-quantizer ${Jsoncpp_STATIC_LIB})
 target_link_libraries(circle-quantizer foder)
 target_link_libraries(circle-quantizer safemain)
 target_link_libraries(circle-quantizer oops)

--- a/compiler/circle-quantizer/src/CircleQuantizer.cpp
+++ b/compiler/circle-quantizer/src/CircleQuantizer.cpp
@@ -186,7 +186,7 @@ int entry(int argc, char **argv)
     .nargs(1)
     .type(arser::DataType::STR)
     .required(false)
-    .help("Path to the quantization configuration file (string)");
+    .help("Path to the quantization configuration file");
 
   arser.add_argument("input").nargs(1).type(arser::DataType::STR).help("Input circle model");
   arser.add_argument("output").nargs(1).type(arser::DataType::STR).help("Output circle model");


### PR DESCRIPTION
This adds an option for quantization configuration file.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/8399
Draft PR: https://github.com/Samsung/ONE/pull/8460