### PR TITLE
[infra] Revise GTestConfig with external build

### DIFF
--- a/infra/cmake/packages/GTestConfig.cmake
+++ b/infra/cmake/packages/GTestConfig.cmake
@@ -17,6 +17,11 @@ function(_GTest_build)
                       IDENTIFIER  "1.8.0-fix1"
                       PKG_NAME    "GTEST")
 
+  set(GTEST_FOUND TRUE PARENT_SCOPE)
+  set(GTEST_INCLUDE_DIRS ${EXT_OVERLAY_DIR}/include PARENT_SCOPE)
+  set(GTEST_LIBRARIES ${EXT_OVERLAY_DIR}/lib/libgtest.a PARENT_SCOPE)
+  set(GTEST_MAIN_LIBRARIES ${EXT_OVERLAY_DIR}/lib/libgtest_main.a PARENT_SCOPE)
+
 endfunction(_GTest_build)
 
 _GTest_build()
@@ -25,7 +30,10 @@ _GTest_build()
 # Note: cmake supports GTest and does not find GTestConfig.cmake or GTest-config.cmake.
 # Refer to "https://cmake.org/cmake/help/v3.5/module/FindGTest.html"
 # find_package(GTest) creates options like GTEST_FOUND, not GTest_FOUND.
-find_package(GTest)
+if(NOT GTEST_FOUND)
+  message(STATUS "GTEST_FOUND false: call find_package(GTest)")
+  find_package(GTest)
+endif(NOT GTEST_FOUND)
 find_package(Threads)
 
 if(${GTEST_FOUND} AND TARGET Threads::Threads)


### PR DESCRIPTION
This will revise GTestConfig to manually set GTEST variables to
external build and run find_package only when external build fails.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>