### PR TITLE
[luci] Move backward propagation of qparam codes

### DIFF
--- a/compiler/luci/pass/src/PropagateQParamBackwardPass.cpp
+++ b/compiler/luci/pass/src/PropagateQParamBackwardPass.cpp
@@ -504,11 +504,11 @@ private:
 
   void visit(luci::CircleConcatenation *node) { propagate_concat_quantparam(node, _output_type); }
 
-  void visit(luci::CirclePadV2 *node) { propagate_pad_v2_quantparam(node, _output_type); }
+  void visit(luci::CircleOneHot *node) { propagate_one_hot_quantparam(node, _output_type); }
 
   void visit(luci::CirclePack *node) { propagate_pack_quantparam(node, _output_type); }
 
-  void visit(luci::CircleOneHot *node) { propagate_one_hot_quantparam(node, _output_type); }
+  void visit(luci::CirclePadV2 *node) { propagate_pad_v2_quantparam(node, _output_type); }
 };
 
 } // namespace

--- a/compiler/luci/pass/src/PropagateQParamBackwardPass.cpp
+++ b/compiler/luci/pass/src/PropagateQParamBackwardPass.cpp
@@ -127,6 +127,176 @@ void overwrite_quantparam(luci::CircleNode *source, luci::CircleNode *target)
   target_qparam->quantized_dimension = source_qparam->quantized_dimension;
 }
 
+/**
+ * tells if pad_v2 quantization should ignore padding value
+ * In that case padding const will be quantized with input parameters, and probably clipped
+ */
+bool ignore_pad_v2_const_quantization(luci::CirclePadV2 *pad)
+{
+  // This is a workaround to quantize pad generated from MaxPoolWithArgmax operation properly
+  // TODO use metadata hints to detect this case
+  auto const_value_node = dynamic_cast<luci::CircleConst *>(pad->arg(2));
+  if (!const_value_node)
+    return false;
+  if (const_value_node->dtype() == loco::DataType::FLOAT32)
+  {
+    float const_value = const_value_node->at<loco::DataType::FLOAT32>(0);
+    if (const_value == std::numeric_limits<float>::lowest())
+      return true;
+  }
+  return false;
+}
+
+/** EXAMPLE
+ *
+ * BEFORE
+ *
+ *         [CircleNode]       [CircleConst]
+ *           (qparam1)           (FP32)
+ *                   \            /
+ *                    \          /
+ *                    [CirclePack]
+ *                     (qparam2)
+ *
+ *  AFTER
+ *
+ *         [CircleNode]        [CircleConst]   [CircleConst] <- Dead node
+ *           (qparam2)           (qparam2)         (FP32)
+ *                   \            /
+ *                    \          /
+ *                    [CirclePack]
+ *                     (qparam2)
+ *
+ * NOTE Quantization parameter of CirclePack (qparam2) is propagated to the inputs.
+ */
+void propagate_pack_quantparam(luci::CirclePack *pack, loco::DataType quant_type)
+{
+  assert(pack->quantparam() != nullptr);
+
+  const auto num_inputs = pack->values_count();
+
+  for (uint32_t i = 0; i < num_inputs; i++)
+  {
+    auto node = loco::must_cast<luci::CircleNode *>(pack->arg(i));
+
+    // Skip if this input is PACK Op
+    if (node->opcode() == luci::CircleOpcode::PACK)
+      continue;
+
+    // Quantize constant values
+    if (node->opcode() == luci::CircleOpcode::CIRCLECONST)
+    {
+      luci::CircleConst *const_node = loco::must_cast<luci::CircleConst *>(node);
+      if (const_node->dtype() != loco::DataType::FLOAT32)
+        throw std::runtime_error("Unsupported data type for constant input of pack Op");
+
+      const auto pack_qparam = pack->quantparam();
+      if (pack_qparam == nullptr)
+        throw std::runtime_error("quantparam of pack is not found during propagation");
+
+      assert(pack_qparam->scale.size() == 1);
+      assert(pack_qparam->zerop.size() == 1);
+      const auto scaling_factor = pack_qparam->scale[0];
+      const auto zerop = pack_qparam->zerop[0];
+
+      auto new_const = luci::clone(const_node);
+      quant_const_values(new_const, scaling_factor, zerop, quant_type);
+      pack->values(i, new_const);
+      overwrite_quantparam(pack, new_const);
+    }
+    else
+    {
+      const auto succs = loco::succs(node);
+      if (succs.size() > 1)
+        continue;
+
+      // Non-const input must have been quantized
+      assert(node->quantparam() != nullptr);
+      overwrite_quantparam(pack, node);
+    }
+  }
+}
+
+/** EXAMPLE
+ *
+ *
+ *
+ * BEFORE
+ *
+ *      [CircleNode] [CircleConst] [CircleConst] [CircleNode]
+ *          (S32)        (S32)        (FP32)     (U8 qparam1)
+ *              \          \           /            /
+ *               \          \        /            /
+ *                \          \     /            /
+ *                 -------[CircleOneHot]-------
+ *                         (U8 qparam2)
+ *
+ *  AFTER
+ *
+ *      [CircleNode] [CircleConst] [CircleConst] [CircleNode]      [CircleConst] <- Dead node
+ *          (S32)        (S32)     (U8 qparam2)  (U8 qparam2)         (FP32)
+ *              \          \           /           /
+ *               \          \        /            /
+ *                \          \     /            /
+ *                 -------[CircleOneHot]-------
+ *                         (U8 qparam2)
+ *
+ * NOTE Quantization parameter of CircleOneHot (qparam2) is propagated to on_value/off_value.
+ */
+void propagate_one_hot_quantparam(luci::CircleOneHot *one_hot, loco::DataType quant_type)
+{
+  assert(one_hot->quantparam() != nullptr);
+
+  // Propagate quantization parameters from output to inputs,
+  // to fit both input and counstant_value in one quant range.
+  auto quant_input = [one_hot, quant_type](void (luci::CircleOneHot::*arg_setter)(loco::Node *),
+                                           loco::Node *(luci::CircleOneHot::*arg_getter)() const) {
+    auto node = loco::must_cast<luci::CircleNode *>((one_hot->*arg_getter)());
+
+    // Quantize constant values
+    if (node->opcode() == luci::CircleOpcode::CIRCLECONST)
+    {
+      luci::CircleConst *const_node = loco::must_cast<luci::CircleConst *>(node);
+      if (is_quantized(const_node))
+        return;
+
+      if (const_node->dtype() != loco::DataType::FLOAT32)
+        throw std::runtime_error("Unsupported data type for constant input of OneHot Op");
+
+      const auto qparam = one_hot->quantparam();
+      if (qparam == nullptr)
+        throw std::runtime_error("quantparam of OneHot is not found during propagation");
+
+      assert(qparam->scale.size() == 1);
+      const auto scaling_factor = qparam->scale.at(0);
+      const auto zerop = qparam->zerop.at(0);
+
+      auto new_const = luci::clone(const_node);
+      quant_const_values(new_const, scaling_factor, zerop, quant_type);
+      overwrite_quantparam(one_hot, new_const);
+      (one_hot->*arg_setter)(new_const);
+    }
+    // Subsequent OneHot Ops quant params are not propagated
+    else if (node->opcode() == luci::CircleOpcode::ONE_HOT)
+    {
+      return;
+    }
+    else
+    {
+      const auto succs = loco::succs(node);
+      if (succs.size() > 1)
+        return;
+
+      // Non-const input must have been quantized
+      assert(node->quantparam() != nullptr);
+      overwrite_quantparam(one_hot, node);
+    }
+  };
+
+  quant_input(&luci::CircleOneHot::on_value, &luci::CircleOneHot::on_value);
+  quant_input(&luci::CircleOneHot::off_value, &luci::CircleOneHot::off_value);
+}
+
 } // namespace
 
 namespace luci
@@ -208,6 +378,115 @@ void propagate_concat_quantparam(luci::CircleConcatenation *concat, loco::DataTy
   }
 }
 
+/** BEFORE
+ *
+ *         [CircleNode] [CircleConst] [CircleConst]
+ *         (U8 qparam1)     (S32)       (FP32)
+ *                   \        |         /
+ *                    \       |        /
+ *                      [CirclePadV2]
+ *                       (U8 qparam2)
+ *
+ *  AFTER (case 1)
+ *
+ *  By default qparam is propagated from output to inputs to meet backend requirements.
+ *
+ *         [CircleNode] [CircleConst] [CircleConst]   [CircleConst] <- Dead node
+ *         (U8 qparam2)     (S32)      (U8 qparam2)       (FP32)
+ *                   \        |         /
+ *                    \       |        /
+ *                      [CirclePadV2]
+ *                       (U8 qparam2)
+ *
+ *  AFTER (case 2)
+ *
+ * In case padded value is the lowest float value
+ * Qparam is propagated from input to output and constant.
+ *
+ * This is a special case for optimization constructed pad, needed to guarantee that
+ * extremely large negative constant do not stretch output quantization range.
+ *
+ *         [CircleNode] [CircleConst] [CircleConst]   [CircleConst] <- Dead node
+ *         (U8 qparam1)     (S32)      (U8 qparam1)       (FP32)
+ *                   \        |         /
+ *                    \       |        /
+ *                      [CirclePadV2]
+ *                       (U8 qparam1)
+ */
+void propagate_pad_v2_quantparam(luci::CirclePadV2 *pad_v2, loco::DataType quant_type)
+{
+  if (ignore_pad_v2_const_quantization(pad_v2))
+  {
+    // propagate input quantization paramters from input to output and padding const value
+    auto pad_v2_input = loco::must_cast<luci::CircleNode *>(pad_v2->arg(0));
+    overwrite_quantparam(pad_v2_input, pad_v2);
+
+    auto const_value_node = loco::must_cast<luci::CircleConst *>(
+      pad_v2->arg(2)); // FIX ignore_pad_v2_const_quantization UNLESS
+    auto new_const = luci::clone(const_value_node);
+
+    const auto pad_v2_input_qparam = pad_v2_input->quantparam();
+    assert(pad_v2_input_qparam != nullptr);
+    assert(pad_v2_input_qparam->scale.size() == 1);
+    const auto scaling_factor = pad_v2_input_qparam->scale.at(0);
+    const auto zerop = pad_v2_input_qparam->zerop.at(0);
+
+    quant_const_values(new_const, scaling_factor, zerop, quant_type);
+    overwrite_quantparam(pad_v2_input, new_const);
+    pad_v2->constant_values(new_const);
+    return;
+  }
+
+  // Propagate quantization paramters from output to inputs,
+  // to fit both input and counstant_value in one quant range.
+  auto quant_input = [pad_v2, quant_type](void (CirclePadV2::*arg_setter)(loco::Node *),
+                                          uint32_t arg) {
+    auto node = loco::must_cast<luci::CircleNode *>(pad_v2->arg(arg));
+
+    // Quantize constant values
+    if (node->opcode() == luci::CircleOpcode::CIRCLECONST)
+    {
+      luci::CircleConst *const_node = loco::must_cast<luci::CircleConst *>(node);
+      if (is_quantized(const_node))
+        return;
+
+      if (const_node->dtype() != loco::DataType::FLOAT32)
+        throw std::runtime_error("Unsupported data type for constant input of PadV2 Op");
+
+      const auto pad_v2_qparam = pad_v2->quantparam();
+      if (pad_v2_qparam == nullptr)
+        throw std::runtime_error("quantparam of PadV2 is not found during propagation");
+
+      assert(pad_v2_qparam->scale.size() == 1);
+      const auto scaling_factor = pad_v2_qparam->scale.at(0);
+      const auto zerop = pad_v2_qparam->zerop.at(0);
+
+      auto new_const = luci::clone(const_node);
+      quant_const_values(new_const, scaling_factor, zerop, quant_type);
+      overwrite_quantparam(pad_v2, new_const);
+      (pad_v2->*arg_setter)(new_const);
+    }
+    // Subsequent PadV2 Ops quant params are not propagated
+    else if (node->opcode() == luci::CircleOpcode::PADV2)
+    {
+      return;
+    }
+    else
+    {
+      const auto succs = loco::succs(node);
+      if (succs.size() > 1)
+        return;
+
+      // Non-const input must have been quantized
+      assert(node->quantparam() != nullptr);
+      overwrite_quantparam(pad_v2, node);
+    }
+  };
+
+  quant_input(&CirclePadV2::input, 0);
+  quant_input(&CirclePadV2::constant_values, 2);
+}
+
 } // namespace luci
 
 namespace
@@ -224,6 +503,12 @@ private:
   void visit(luci::CircleNode *) {}
 
   void visit(luci::CircleConcatenation *node) { propagate_concat_quantparam(node, _output_type); }
+
+  void visit(luci::CirclePadV2 *node) { propagate_pad_v2_quantparam(node, _output_type); }
+
+  void visit(luci::CirclePack *node) { propagate_pack_quantparam(node, _output_type); }
+
+  void visit(luci::CircleOneHot *node) { propagate_one_hot_quantparam(node, _output_type); }
 };
 
 } // namespace

--- a/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
+++ b/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
@@ -146,68 +146,6 @@ luci::CircleConst *create_empty_const_from(luci::CircleConst *node, uint32_t siz
   return new_node;
 }
 
-void overwrite_quantparam(luci::CircleNode *source, luci::CircleNode *target)
-{
-  auto source_qparam = source->quantparam();
-  if (source_qparam == nullptr)
-    throw std::runtime_error("source quantparam is not found during overwrite");
-
-  auto target_qparam = target->quantparam();
-  if (target_qparam == nullptr)
-  {
-    auto quantparam = std::make_unique<CircleQuantParam>();
-    target->quantparam(std::move(quantparam));
-    target_qparam = target->quantparam();
-
-    if (target_qparam == nullptr)
-      throw std::runtime_error("Creating new quant param failed");
-  }
-  target_qparam->min = source_qparam->min;
-  target_qparam->max = source_qparam->max;
-  target_qparam->scale = source_qparam->scale;
-  target_qparam->zerop = source_qparam->zerop;
-  target_qparam->quantized_dimension = source_qparam->quantized_dimension;
-}
-
-void quant_const_values(luci::CircleConst *const_node, float scaling_factor, float zerop,
-                        loco::DataType quant_type)
-{
-  uint32_t size = const_node->size<loco::DataType::FLOAT32>();
-
-  const float scaling_factor_inv = 1.0 / scaling_factor;
-  std::vector<int32_t> quantized_values(size);
-  for (uint32_t i = 0; i < size; ++i)
-  {
-    auto data = static_cast<double>(const_node->at<loco::DataType::FLOAT32>(i));
-    double quantized_float = std::round(data * scaling_factor_inv) + zerop;
-    constexpr auto int_max = static_cast<double>(std::numeric_limits<int32_t>::max());
-    constexpr auto int_min = static_cast<double>(std::numeric_limits<int32_t>::min());
-    quantized_float = std::min(int_max, std::max(int_min, quantized_float));
-
-    quantized_values[i] = static_cast<int32_t>(quantized_float);
-  }
-
-  switch (quant_type)
-  {
-    case loco::DataType::U8:
-      const_node->dtype(loco::DataType::U8);      // change the type of tensor
-      const_node->size<loco::DataType::U8>(size); // resize tensor
-      for (uint32_t i = 0; i < size; ++i)
-        const_node->at<loco::DataType::U8>(i) = std::min(255, std::max(0, quantized_values[i]));
-      break;
-    case loco::DataType::S16:
-      assert(zerop == 0);
-      const_node->dtype(loco::DataType::S16);      // change the type of tensor
-      const_node->size<loco::DataType::S16>(size); // resize tensor
-      for (uint32_t i = 0; i < size; ++i)
-        const_node->at<loco::DataType::S16>(i) =
-          std::min(32767, std::max(-32767, quantized_values[i]));
-      break;
-    default:
-      throw std::runtime_error("Unsupported data type");
-  }
-}
-
 // Quantize const per channel
 //
 // The last dimension of const is the same as the dimension of channel
@@ -1032,156 +970,6 @@ private:
   void visit(luci::CircleNode *) {}
 };
 
-/** EXAMPLE
- *
- * BEFORE
- *
- *         [CircleNode]       [CircleConst]
- *           (qparam1)           (FP32)
- *                   \            /
- *                    \          /
- *                    [CirclePack]
- *                     (qparam2)
- *
- *  AFTER
- *
- *         [CircleNode]        [CircleConst]   [CircleConst] <- Dead node
- *           (qparam2)           (qparam2)         (FP32)
- *                   \            /
- *                    \          /
- *                    [CirclePack]
- *                     (qparam2)
- *
- * NOTE Quantization parameter of CirclePack (qparam2) is propagated to the inputs.
- */
-void propagate_pack_quantparam(luci::CirclePack *pack, loco::DataType quant_type)
-{
-  assert(pack->quantparam() != nullptr);
-
-  const auto num_inputs = pack->values_count();
-
-  for (uint32_t i = 0; i < num_inputs; i++)
-  {
-    auto node = loco::must_cast<luci::CircleNode *>(pack->arg(i));
-
-    // Skip if this input is PACK Op
-    if (node->opcode() == luci::CircleOpcode::PACK)
-      continue;
-
-    // Quantize constant values
-    if (node->opcode() == luci::CircleOpcode::CIRCLECONST)
-    {
-      luci::CircleConst *const_node = loco::must_cast<luci::CircleConst *>(node);
-      if (const_node->dtype() != loco::DataType::FLOAT32)
-        throw std::runtime_error("Unsupported data type for constant input of pack Op");
-
-      const auto pack_qparam = pack->quantparam();
-      if (pack_qparam == nullptr)
-        throw std::runtime_error("quantparam of pack is not found during propagation");
-
-      assert(pack_qparam->scale.size() == 1);
-      assert(pack_qparam->zerop.size() == 1);
-      const auto scaling_factor = pack_qparam->scale[0];
-      const auto zerop = pack_qparam->zerop[0];
-
-      auto new_const = luci::clone(const_node);
-      quant_const_values(new_const, scaling_factor, zerop, quant_type);
-      pack->values(i, new_const);
-      overwrite_quantparam(pack, new_const);
-    }
-    else
-    {
-      const auto succs = loco::succs(node);
-      if (succs.size() > 1)
-        continue;
-
-      // Non-const input must have been quantized
-      assert(node->quantparam() != nullptr);
-      overwrite_quantparam(pack, node);
-    }
-  }
-}
-
-/** EXAMPLE
- *
- *
- *
- * BEFORE
- *
- *      [CircleNode] [CircleConst] [CircleConst] [CircleNode]
- *          (S32)        (S32)        (FP32)     (U8 qparam1)
- *              \          \           /            /
- *               \          \        /            /
- *                \          \     /            /
- *                 -------[CircleOneHot]-------
- *                         (U8 qparam2)
- *
- *  AFTER
- *
- *      [CircleNode] [CircleConst] [CircleConst] [CircleNode]      [CircleConst] <- Dead node
- *          (S32)        (S32)     (U8 qparam2)  (U8 qparam2)         (FP32)
- *              \          \           /           /
- *               \          \        /            /
- *                \          \     /            /
- *                 -------[CircleOneHot]-------
- *                         (U8 qparam2)
- *
- * NOTE Quantization parameter of CircleOneHot (qparam2) is propagated to on_value/off_value.
- */
-void propagate_one_hot_quantparam(luci::CircleOneHot *one_hot, loco::DataType quant_type)
-{
-  assert(one_hot->quantparam() != nullptr);
-
-  // Propagate quantization parameters from output to inputs,
-  // to fit both input and counstant_value in one quant range.
-  auto quant_input = [one_hot, quant_type](void (CircleOneHot::*arg_setter)(loco::Node *),
-                                           loco::Node *(CircleOneHot::*arg_getter)() const) {
-    auto node = loco::must_cast<luci::CircleNode *>((one_hot->*arg_getter)());
-
-    // Quantize constant values
-    if (node->opcode() == luci::CircleOpcode::CIRCLECONST)
-    {
-      luci::CircleConst *const_node = loco::must_cast<luci::CircleConst *>(node);
-      if (is_quantized(const_node))
-        return;
-
-      if (const_node->dtype() != loco::DataType::FLOAT32)
-        throw std::runtime_error("Unsupported data type for constant input of OneHot Op");
-
-      const auto qparam = one_hot->quantparam();
-      if (qparam == nullptr)
-        throw std::runtime_error("quantparam of OneHot is not found during propagation");
-
-      assert(qparam->scale.size() == 1);
-      const auto scaling_factor = qparam->scale.at(0);
-      const auto zerop = qparam->zerop.at(0);
-
-      auto new_const = luci::clone(const_node);
-      quant_const_values(new_const, scaling_factor, zerop, quant_type);
-      overwrite_quantparam(one_hot, new_const);
-      (one_hot->*arg_setter)(new_const);
-    }
-    // Subsequent OneHot Ops quant params are not propagated
-    else if (node->opcode() == luci::CircleOpcode::ONE_HOT)
-    {
-      return;
-    }
-    else
-    {
-      const auto succs = loco::succs(node);
-      if (succs.size() > 1)
-        return;
-
-      // Non-const input must have been quantized
-      assert(node->quantparam() != nullptr);
-      overwrite_quantparam(one_hot, node);
-    }
-  };
-
-  quant_input(&CircleOneHot::on_value, &CircleOneHot::on_value);
-  quant_input(&CircleOneHot::off_value, &CircleOneHot::off_value);
-}
-
 // Quantize constant input activation of a node
 // The input of a node is quantized if it is
 // 1. Constant (instance of CircleConst*)
@@ -1255,6 +1043,9 @@ private:
 
   // Handled in PropagateQParamBackwardPass
   SKIP(luci::CircleConcatenation)
+  SKIP(luci::CirclePadV2)
+  SKIP(luci::CirclePack)
+  SKIP(luci::CircleOneHot)
 
   // Inputs of logical Ops are bool, thus not quantized
   SKIP(luci::CircleLogicalOr)
@@ -1333,146 +1124,12 @@ private:
     }
   }
 
-  // Ops whose input qparam is determined by output qparam
-  void visit(luci::CirclePadV2 *node) { propagate_pad_v2_quantparam(node, _output_type); }
-  void visit(luci::CirclePack *node) { propagate_pack_quantparam(node, _output_type); }
-  void visit(luci::CircleOneHot *node) { propagate_one_hot_quantparam(node, _output_type); }
-
 #undef SKIP
 #undef QUANTIZE_SINGLE_CONST_INPUT
 #undef QUANTIZE_TWO_CONST_INPUTS
 };
 
 } // namespace
-
-/**
- * tells if pad_v2 quantization should ignore padding value
- * In that case padding const will be quantized with input parameters, and probably clipped
- */
-bool ignore_pad_v2_const_quantization(luci::CirclePadV2 *pad)
-{
-  // This is a workaround to quantize pad generated from MaxPoolWithArgmax operation properly
-  // TODO use metadata hints to detect this case
-  auto const_value_node = dynamic_cast<luci::CircleConst *>(pad->arg(2));
-  if (!const_value_node)
-    return false;
-  if (const_value_node->dtype() == loco::DataType::FLOAT32)
-  {
-    float const_value = const_value_node->at<loco::DataType::FLOAT32>(0);
-    if (const_value == std::numeric_limits<float>::lowest())
-      return true;
-  }
-  return false;
-}
-
-/** BEFORE
- *
- *         [CircleNode] [CircleConst] [CircleConst]
- *         (U8 qparam1)     (S32)       (FP32)
- *                   \        |         /
- *                    \       |        /
- *                      [CirclePadV2]
- *                       (U8 qparam2)
- *
- *  AFTER (case 1)
- *
- *  By default qparam is propagated from output to inputs to meet backend requirements.
- *
- *         [CircleNode] [CircleConst] [CircleConst]   [CircleConst] <- Dead node
- *         (U8 qparam2)     (S32)      (U8 qparam2)       (FP32)
- *                   \        |         /
- *                    \       |        /
- *                      [CirclePadV2]
- *                       (U8 qparam2)
- *
- *  AFTER (case 2)
- *
- * In case padded value is the lowest float value
- * Qparam is propagated from input to output and constant.
- *
- * This is a special case for optimization constructed pad, needed to guarantee that
- * extremely large negative constant do not stretch output quantization range.
- *
- *         [CircleNode] [CircleConst] [CircleConst]   [CircleConst] <- Dead node
- *         (U8 qparam1)     (S32)      (U8 qparam1)       (FP32)
- *                   \        |         /
- *                    \       |        /
- *                      [CirclePadV2]
- *                       (U8 qparam1)
- */
-void propagate_pad_v2_quantparam(luci::CirclePadV2 *pad_v2, loco::DataType quant_type)
-{
-  if (ignore_pad_v2_const_quantization(pad_v2))
-  {
-    // propagate input quantization paramters from input to output and padding const value
-    auto pad_v2_input = loco::must_cast<luci::CircleNode *>(pad_v2->arg(0));
-    overwrite_quantparam(pad_v2_input, pad_v2);
-
-    auto const_value_node = loco::must_cast<luci::CircleConst *>(
-      pad_v2->arg(2)); // FIX ignore_pad_v2_const_quantization UNLESS
-    auto new_const = luci::clone(const_value_node);
-
-    const auto pad_v2_input_qparam = pad_v2_input->quantparam();
-    assert(pad_v2_input_qparam != nullptr);
-    assert(pad_v2_input_qparam->scale.size() == 1);
-    const auto scaling_factor = pad_v2_input_qparam->scale.at(0);
-    const auto zerop = pad_v2_input_qparam->zerop.at(0);
-
-    quant_const_values(new_const, scaling_factor, zerop, quant_type);
-    overwrite_quantparam(pad_v2_input, new_const);
-    pad_v2->constant_values(new_const);
-    return;
-  }
-
-  // Propagate quantization paramters from output to inputs,
-  // to fit both input and counstant_value in one quant range.
-  auto quant_input = [pad_v2, quant_type](void (CirclePadV2::*arg_setter)(loco::Node *),
-                                          uint32_t arg) {
-    auto node = loco::must_cast<luci::CircleNode *>(pad_v2->arg(arg));
-
-    // Quantize constant values
-    if (node->opcode() == luci::CircleOpcode::CIRCLECONST)
-    {
-      luci::CircleConst *const_node = loco::must_cast<luci::CircleConst *>(node);
-      if (is_quantized(const_node))
-        return;
-
-      if (const_node->dtype() != loco::DataType::FLOAT32)
-        throw std::runtime_error("Unsupported data type for constant input of PadV2 Op");
-
-      const auto pad_v2_qparam = pad_v2->quantparam();
-      if (pad_v2_qparam == nullptr)
-        throw std::runtime_error("quantparam of PadV2 is not found during propagation");
-
-      assert(pad_v2_qparam->scale.size() == 1);
-      const auto scaling_factor = pad_v2_qparam->scale.at(0);
-      const auto zerop = pad_v2_qparam->zerop.at(0);
-
-      auto new_const = luci::clone(const_node);
-      quant_const_values(new_const, scaling_factor, zerop, quant_type);
-      overwrite_quantparam(pad_v2, new_const);
-      (pad_v2->*arg_setter)(new_const);
-    }
-    // Subsequent PadV2 Ops quant params are not propagated
-    else if (node->opcode() == luci::CircleOpcode::PADV2)
-    {
-      return;
-    }
-    else
-    {
-      const auto succs = loco::succs(node);
-      if (succs.size() > 1)
-        return;
-
-      // Non-const input must have been quantized
-      assert(node->quantparam() != nullptr);
-      overwrite_quantparam(pad_v2, node);
-    }
-  };
-
-  quant_input(&CirclePadV2::input, 0);
-  quant_input(&CirclePadV2::constant_values, 2);
-}
 
 void QuantizeWithMinMaxPass::set_input_type(loco::Graph *g) const
 {
@@ -1594,7 +1251,7 @@ void QuantizeWithMinMaxPass::set_output_type(loco::Graph *g) const
  * 1. Quantize Activation
  *   - Quantize using recorded min/max (QuantizeActivation)
  *   - Propagate qparam backward (PropagateQParamBackwardPass)
- *   - Quantize const inputs + propagate qparam backward (QuantizeConstInputActivation)
+ *   - Quantize const inputs (QuantizeConstInputActivation)
  *   - Quantize using pre-defined values (QuantizeSpecialActivation)
  *   - Propagate qparam forward (PropagateQParamForwardPass)
  * 2. Quantize Weights


### PR DESCRIPTION
This moves backward propagation of qparam codes for PadV2, Pack, OneHot.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/8497
Draft PR: https://github.com/Samsung/ONE/pull/8500