### PR TITLE
[luci] Allow backprop of qparam across the same operators

### DIFF
--- a/compiler/luci/pass/src/PropagateConcatenationQparam.test.cpp
+++ b/compiler/luci/pass/src/PropagateConcatenationQparam.test.cpp
@@ -186,7 +186,7 @@ TEST(PropagateConcatenationQparam, propagate_concat_quantparam_u8)
   // (1) normal case: qparam is propagated to input_1 and input_2
   // (2) input used by other Op: input_1 is an input of input_2. qparam is propagated only to
   // input_2
-  // (3) subsequent concat: input_1 is concat. qparam is propagated only to input_2
+  // (3) subsequent concat: input_1 is concat. qparam is propagated to subsequent concat
   // (4) const input: input_1 is const. constant values are quantized
 
   // normal case: qparam of concat_node is propagated to input_1 and input_2
@@ -210,13 +210,13 @@ TEST(PropagateConcatenationQparam, propagate_concat_quantparam_u8)
   EXPECT_FLOAT_EQ(3.14, g2.input_2.quantparam()->scale[0]);
   EXPECT_EQ(77, g2.input_2.quantparam()->zerop[0]);
 
-  // input_1 is concat. qparam is propagated only to input_2
+  // input_1 is concat. qparam is propagated to subsequent concat
   SubsequentConcatGraph sg(loco::DataType::U8);
   luci::propagate_concat_quantparam(&sg.concat_node, loco::DataType::U8);
   EXPECT_FLOAT_EQ(3.14, sg.concat_node.quantparam()->scale[0]);
   EXPECT_EQ(77, sg.concat_node.quantparam()->zerop[0]);
-  EXPECT_FLOAT_EQ(1.0, sg.input_1.quantparam()->scale[0]);
-  EXPECT_EQ(1, sg.input_1.quantparam()->zerop[0]);
+  EXPECT_FLOAT_EQ(3.14, sg.input_1.quantparam()->scale[0]);
+  EXPECT_EQ(77, sg.input_1.quantparam()->zerop[0]);
   EXPECT_FLOAT_EQ(3.14, sg.input_2.quantparam()->scale[0]);
   EXPECT_EQ(77, sg.input_2.quantparam()->zerop[0]);
 
@@ -283,7 +283,7 @@ TEST(PropagateConcatenationQparam, propagate_concat_quantparam_i16)
   // (1) normal case: qparam is propagated to input_1 and input_2
   // (2) input used by other Op: input_1 is an input of input_2. qparam is propagated only to
   // input_2
-  // (3) subsequent concat: input_1 is concat. qparam is propagated only to input_2
+  // (3) subsequent concat: input_1 is concat. qparam is propagated to subsequent concat
   // (4) const input: input_1 is const. constant values are quantized
 
   // normal case: qparam of concat_node is propagated to input_1 and input_2
@@ -312,7 +312,7 @@ TEST(PropagateConcatenationQparam, propagate_concat_quantparam_i16)
   luci::propagate_concat_quantparam(&sg.concat_node, loco::DataType::S16);
   EXPECT_FLOAT_EQ(3.14, sg.concat_node.quantparam()->scale[0]);
   EXPECT_EQ(0, sg.concat_node.quantparam()->zerop[0]);
-  EXPECT_FLOAT_EQ(1.0, sg.input_1.quantparam()->scale[0]);
+  EXPECT_FLOAT_EQ(3.14, sg.input_1.quantparam()->scale[0]);
   EXPECT_EQ(0, sg.input_1.quantparam()->zerop[0]);
   EXPECT_FLOAT_EQ(3.14, sg.input_2.quantparam()->scale[0]);
   EXPECT_EQ(0, sg.input_2.quantparam()->zerop[0]);

--- a/compiler/luci/pass/src/PropagateQParamBackwardPass.cpp
+++ b/compiler/luci/pass/src/PropagateQParamBackwardPass.cpp
@@ -179,10 +179,6 @@ void propagate_pack_quantparam(luci::CirclePack *pack, loco::DataType quant_type
   {
     auto node = loco::must_cast<luci::CircleNode *>(pack->arg(i));
 
-    // Skip if this input is PACK Op
-    if (node->opcode() == luci::CircleOpcode::PACK)
-      continue;
-
     // Quantize constant values
     if (node->opcode() == luci::CircleOpcode::CIRCLECONST)
     {
@@ -276,11 +272,6 @@ void propagate_one_hot_quantparam(luci::CircleOneHot *one_hot, loco::DataType qu
       overwrite_quantparam(one_hot, new_const);
       (one_hot->*arg_setter)(new_const);
     }
-    // Subsequent OneHot Ops quant params are not propagated
-    else if (node->opcode() == luci::CircleOpcode::ONE_HOT)
-    {
-      return;
-    }
     else
     {
       const auto succs = loco::succs(node);
@@ -345,10 +336,6 @@ void propagate_concat_quantparam(luci::CircleConcatenation *concat, loco::DataTy
   for (uint32_t i = 0; i < num_inputs; i++)
   {
     auto node = loco::must_cast<luci::CircleNode *>(concat->arg(i));
-
-    // Skip if this input is CONCAT Op
-    if (node->opcode() == luci::CircleOpcode::CONCATENATION)
-      continue;
 
     // Quantize constant values
     if (node->opcode() == luci::CircleOpcode::CIRCLECONST)
@@ -465,11 +452,6 @@ void propagate_pad_v2_quantparam(luci::CirclePadV2 *pad_v2, loco::DataType quant
       quant_const_values(new_const, scaling_factor, zerop, quant_type);
       overwrite_quantparam(pad_v2, new_const);
       (pad_v2->*arg_setter)(new_const);
-    }
-    // Subsequent PadV2 Ops quant params are not propagated
-    else if (node->opcode() == luci::CircleOpcode::PADV2)
-    {
-      return;
     }
     else
     {

--- a/compiler/luci/pass/src/PropagateQParamBackwardPass.test.cpp
+++ b/compiler/luci/pass/src/PropagateQParamBackwardPass.test.cpp
@@ -16,11 +16,152 @@
 
 #include "luci/Pass/PropagateQParamBackwardPass.h"
 
+#include <luci/IR/CircleNodes.h>
+
 #include <gtest/gtest.h>
+
+using namespace luci;
+
+namespace
+{
+
+void set_qparam(luci::CircleNode *node, float scale, int64_t zp)
+{
+  auto qparam = std::make_unique<luci::CircleQuantParam>();
+  qparam->scale.emplace_back(scale);
+  qparam->zerop.emplace_back(zp);
+
+  node->quantparam(std::move(qparam));
+}
+
+/**
+ * @brief Base Test Graph
+ */
+struct TestGraph
+{
+public:
+  virtual void init(void) = 0;
+};
+
+/**
+ *  Graph with two concats
+ *
+ *  [CircleInput]  [CircleConst]
+ *         \         /
+ *  [CircleConcatenation]  [CircleConst]
+ *           |                |
+ *          [CircleConcatenation]
+ *                  |
+ *            [CircleOutput]
+ *
+ *  BEFORE
+ *  - Concat1 and Concat 2 have different qparams
+ *
+ *  AFTER
+ *  - All Ops have the same qparam
+ */
+struct SubsequentConcatGraph : public TestGraph
+{
+public:
+  void init(void) final
+  {
+    // graph input and output
+    auto graph_input = g.inputs()->create();
+    auto graph_output = g.outputs()->create();
+
+    // input
+    input = g.nodes()->create<luci::CircleInput>();
+    input->index(graph_input->index());
+    input->shape({1, 4, 4, 3});
+    input->dtype(loco::DataType::U8);
+    set_qparam(input, 1.0, 1);
+
+    // const1
+    const1 = g.nodes()->create<luci::CircleConst>();
+    const1->shape({1, 4, 4, 3});
+    const1->dtype(loco::DataType::FLOAT32);
+    const1->size<loco::DataType::FLOAT32>(48);
+    for (uint32_t i = 0; i < 48; i++)
+      const1->at<loco::DataType::FLOAT32>(i) = i;
+
+    // concat1
+    concat1 = g.nodes()->create<luci::CircleConcatenation>(2);
+    concat1->shape({1, 4, 4, 6});
+    concat1->dtype(loco::DataType::U8);
+    set_qparam(concat1, 2.0, 2);
+    concat1->values(0, input);
+    concat1->values(1, const1);
+    concat1->fusedActivationFunction(luci::FusedActFunc::NONE);
+
+    // const2
+    const2 = g.nodes()->create<luci::CircleConst>();
+    const2->shape({1, 4, 4, 3});
+    const2->dtype(loco::DataType::FLOAT32);
+    const2->size<loco::DataType::FLOAT32>(48);
+    for (uint32_t i = 0; i < 48; i++)
+      const2->at<loco::DataType::FLOAT32>(i) = i;
+
+    // concat2
+    concat2 = g.nodes()->create<luci::CircleConcatenation>(2);
+    concat2->shape({1, 4, 4, 9});
+    concat2->dtype(loco::DataType::U8);
+    set_qparam(concat2, 3.0, 3);
+    concat2->values(0, concat1);
+    concat2->values(1, const2);
+    concat2->fusedActivationFunction(luci::FusedActFunc::NONE);
+
+    // output
+    output = g.nodes()->create<luci::CircleOutput>();
+    output->index(graph_output->index());
+    output->from(concat2);
+    output->shape({1, 4, 4, 9});
+    output->dtype(loco::DataType::U8);
+    set_qparam(output, 3.0, 3);
+  }
+
+public:
+  loco::Graph g;
+  CircleInput *input = nullptr;
+  CircleConcatenation *concat1 = nullptr;
+  CircleConcatenation *concat2 = nullptr;
+  CircleConst *const1 = nullptr;
+  CircleConst *const2 = nullptr;
+  CircleOutput *output = nullptr;
+};
+
+} // namespace
 
 TEST(PropagateQParamBackwardPassTest, name)
 {
   luci::PropagateQParamBackwardPass pass(loco::DataType::U8);
   auto const name = pass.name();
   ASSERT_NE(nullptr, name);
+}
+
+TEST(PropagateQParamBackwardPassTest, subsequent_propagation)
+{
+  SubsequentConcatGraph graph;
+
+  graph.init();
+
+  luci::PropagateQParamBackwardPass pass(loco::DataType::U8);
+
+  pass.run(&graph.g);
+
+  EXPECT_EQ(3.0, graph.concat2->quantparam()->scale[0]);
+  EXPECT_EQ(3, graph.concat2->quantparam()->zerop[0]);
+
+  auto const2 = loco::must_cast<CircleNode *>(graph.concat2->values(1));
+  EXPECT_EQ(3.0, const2->quantparam()->scale[0]);
+  EXPECT_EQ(3, const2->quantparam()->zerop[0]);
+
+  EXPECT_EQ(3.0, graph.concat1->quantparam()->scale[0]);
+  EXPECT_EQ(3, graph.concat1->quantparam()->zerop[0]);
+
+  auto const1 = loco::must_cast<CircleNode *>(graph.concat1->values(1));
+  EXPECT_EQ(3.0, const1->quantparam()->scale[0]);
+  EXPECT_EQ(3, const1->quantparam()->zerop[0]);
+
+  EXPECT_EQ(3.0, graph.input->quantparam()->scale[0]);
+  EXPECT_EQ(3, graph.input->quantparam()->zerop[0]);
 }


### PR DESCRIPTION
This allows back propagation of qparam across the same operators.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>