### PR TITLE
[loco] Add inheritance mode option to FixedArity mixin

### DIFF
--- a/compiler/loco/include/loco/IR/NodeMixins.h
+++ b/compiler/loco/include/loco/IR/NodeMixins.h
@@ -83,9 +83,22 @@ private:
   std::vector<Dimension> _dims;
 };
 
-template <uint32_t N> struct FixedArity
+// Inheritance type wrapper which provides ability to change inheritance mode
+// (direct or virtual) by specifying one of the types
+struct InheritanceMode
 {
-  template <typename Base> class Mixin : public virtual Base
+  template <typename Base = void> struct Virtual : public virtual Base
+  {
+  };
+  template <typename Base = void> struct Direct : public Base
+  {
+  };
+};
+
+template <uint32_t N, template <class> class InheritanceMode = InheritanceMode::Virtual>
+struct FixedArity
+{
+  template <typename Base> class Mixin : public InheritanceMode<Base>
   {
   public:
     Mixin()

--- a/compiler/loco/include/loco/IR/NodeMixins.h
+++ b/compiler/loco/include/loco/IR/NodeMixins.h
@@ -132,8 +132,14 @@ template <uint32_t N> struct FixedArity
     std::array<std::unique_ptr<Use>, N> _args{};
   };
 
-  template <typename Base> using Mixin = MixinImpl<Base, loco::InheritanceMode::Virtual>;
-  template <typename Base> using DirectMixin = MixinImpl<Base, loco::InheritanceMode::Direct>;
+  template <typename Base = void>
+  class Mixin : public MixinImpl<Base, loco::InheritanceMode::Virtual>
+  {
+  };
+  template <typename Base = void>
+  class DirectMixin : public MixinImpl<Base, loco::InheritanceMode::Direct>
+  {
+  };
 };
 
 template <NodeTrait Trait> struct With

--- a/compiler/loco/include/loco/IR/NodeMixins.h
+++ b/compiler/loco/include/loco/IR/NodeMixins.h
@@ -95,13 +95,13 @@ struct InheritanceMode
   };
 };
 
-template <uint32_t N, template <class> class InheritanceMode = InheritanceMode::Virtual>
-struct FixedArity
+template <uint32_t N> struct FixedArity
 {
-  template <typename Base> class Mixin : public InheritanceMode<Base>
+  template <typename Base, template <class> class Inheritance>
+  class MixinImpl : public Inheritance<Base>
   {
   public:
-    Mixin()
+    MixinImpl()
     {
       for (uint32_t n = 0; n < N; ++n)
       {
@@ -109,7 +109,7 @@ struct FixedArity
       }
     }
 
-    virtual ~Mixin() = default;
+    virtual ~MixinImpl() = default;
 
   public:
     uint32_t arity(void) const final { return N; }
@@ -131,6 +131,9 @@ struct FixedArity
   private:
     std::array<std::unique_ptr<Use>, N> _args{};
   };
+
+  template <typename Base> using Mixin = MixinImpl<Base, loco::InheritanceMode::Virtual>;
+  template <typename Base> using DirectMixin = MixinImpl<Base, loco::InheritanceMode::Direct>;
 };
 
 template <NodeTrait Trait> struct With


### PR DESCRIPTION
This commit adds optional inheritance type template parameter (represented as a wrapper Virtual/Direct type) to FixedArity node mixin.

For #8529

Signed-off-by: Alexander Moiseev <a.moiseev@samsung.com>