### PR TITLE
[infra] Revise nncc CMakeLists

### DIFF
--- a/infra/nncc/CMakeLists.txt
+++ b/infra/nncc/CMakeLists.txt
@@ -88,6 +88,10 @@ message(STATUS "Use '${CMAKE_BUILD_TYPE}' configuration")
 #
 set(THREADS_PREFER_PTHREAD_FLAG TRUE)
 
+# identify platform: HOST_PLATFORM, TARGET_PLATFORM and related
+# note: this should be placed before flags and options setting
+nnas_include(IdentifyPlatform)
+
 ###
 ### Configuration
 ###


### PR DESCRIPTION
This will revise nncc CMakeLists to include 'IdentifyPlatform' for cross build.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>