### PR TITLE
[mio-circle] Skip message for flatbuffers not found

### DIFF
--- a/compiler/mio-circle/CMakeLists.txt
+++ b/compiler/mio-circle/CMakeLists.txt
@@ -1,7 +1,7 @@
 nnas_find_package(FlatBuffers EXACT 1.10 QUIET)
 
 if(NOT FlatBuffers_FOUND)
-  message(STATUS "mio-circle skip: FlatBuffers 1.12 NOT FOUND")
+  message(STATUS "mio-circle skip: FlatBuffers 1.10 NOT FOUND")
   return()
 endif(NOT FlatBuffers_FOUND)
 

--- a/compiler/mio-circle/CMakeLists.txt
+++ b/compiler/mio-circle/CMakeLists.txt
@@ -1,6 +1,7 @@
 nnas_find_package(FlatBuffers EXACT 1.10 QUIET)
 
 if(NOT FlatBuffers_FOUND)
+  message(STATUS "mio-circle skip: FlatBuffers 1.12 NOT FOUND")
   return()
 endif(NOT FlatBuffers_FOUND)
 


### PR DESCRIPTION
This will add skip message in CMakeLists when FlatBuffers is not found.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>