### PR TITLE
[infra] Temporary disable using NEON

### DIFF
--- a/infra/nncc/cmake/buildtool/config/config_armv7l-linux.cmake
+++ b/infra/nncc/cmake/buildtool/config/config_armv7l-linux.cmake
@@ -11,7 +11,8 @@ include("${CMAKE_CURRENT_LIST_DIR}/config_linux.cmake")
 set(FLAGS_COMMON ${FLAGS_COMMON}
     "-mcpu=cortex-a7"
     "-mfloat-abi=hard"
-    "-mfpu=neon-vfpv4"
+# TODO enable neon
+#   "-mfpu=neon-vfpv4"
     "-ftree-vectorize"
     "-mfp16-format=ieee"
     )


### PR DESCRIPTION
This will temporary disable using NEON for ARM32 cross build.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>