### PR TITLE
[luci] Add RemoveRedundantQuantizePass

### DIFF
--- a/compiler/luci/pass/include/luci/CircleOptimizer.h
+++ b/compiler/luci/pass/include/luci/CircleOptimizer.h
@@ -75,6 +75,7 @@ public:
       TransformMinReluToRelu6Pass,
       SubstituteStridedSliceToReshape,
       SubstituteTransposeToReshape,
+      RemoveRedundantQuantize,
       RemoveRedundantReshape,
       RemoveFakeQuant,
       RemoveQuantDequantSeq,

--- a/compiler/luci/pass/include/luci/Pass/RemoveRedundantQuantizePass.h
+++ b/compiler/luci/pass/include/luci/Pass/RemoveRedundantQuantizePass.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __LUCI_REMOVE_REDUNDANT_QUANTIZE_PASS_H__
+#define __LUCI_REMOVE_REDUNDANT_QUANTIZE_PASS_H__
+
+#include <logo/Pass.h>
+
+namespace luci
+{
+
+/**
+ * @brief  Class to remove redundant quantize operations
+ */
+struct RemoveRedundantQuantizePass final : public logo::Pass
+{
+  const char *name(void) const final { return "luci::RemoveRedundantQuantizePass"; }
+
+  bool run(loco::Graph *g) final;
+};
+
+} // namespace luci
+
+#endif // __LUCI_REMOVE_REDUNDANT_QUANTIZE_PASS_H__

--- a/compiler/luci/pass/src/CircleOptimizer.cpp
+++ b/compiler/luci/pass/src/CircleOptimizer.cpp
@@ -40,6 +40,7 @@
 #include "luci/Pass/RemoveQuantDequantSeqPass.h"
 #include "luci/Pass/RemoveRedundantReshapePass.h"
 #include "luci/Pass/RemoveRedundantTransposePass.h"
+#include "luci/Pass/RemoveRedundantQuantizePass.h"
 #include "luci/Pass/RemoveUnnecessaryReshapePass.h"
 #include "luci/Pass/RemoveUnnecessarySlicePass.h"
 #include "luci/Pass/RemoveUnnecessaryStridedSlicePass.h"
@@ -342,6 +343,10 @@ void CircleOptimizer::optimize(loco::Graph *g) const
   if (_options->query(Options::Algorithm::RemoveRedundantTranspose))
   {
     phase.emplace_back(std::make_unique<luci::RemoveRedundantTransposePass>());
+  }
+  if (_options->query(Options::Algorithm::RemoveRedundantQuantize))
+  {
+    phase.emplace_back(std::make_unique<luci::RemoveRedundantQuantizePass>());
   }
   if (_options->query(Options::Algorithm::ReplaceMulAddWithDepthwiseConv))
   {

--- a/compiler/luci/pass/src/RemoveRedundantQuantizePass.cpp
+++ b/compiler/luci/pass/src/RemoveRedundantQuantizePass.cpp
@@ -51,9 +51,6 @@ bool remove_redundant_quantize(luci::CircleQuantize *node)
 {
   auto pred_node = loco::must_cast<luci::CircleNode *>(node->input());
 
-  if (pred_node == nullptr)
-    return false;
-
   if (node->quantparam() == nullptr or pred_node->quantparam() == nullptr)
     return false;
 
@@ -93,7 +90,7 @@ namespace luci
 bool RemoveRedundantQuantizePass::run(loco::Graph *g)
 {
   bool changed = false;
-  for (auto node : loco::active_nodes(loco::output_nodes(g)))
+  for (auto node : loco::postorder_traversal(loco::output_nodes(g)))
   {
     if (auto quantize_node = dynamic_cast<luci::CircleQuantize *>(node))
     {

--- a/compiler/luci/pass/src/RemoveRedundantQuantizePass.cpp
+++ b/compiler/luci/pass/src/RemoveRedundantQuantizePass.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Pass/RemoveRedundantQuantizePass.h"
+
+#include <luci/IR/CircleNode.h>
+
+/**
+ *  Remove redundant quantize operations. For subsequent Quantize Ops,
+ *  only the last Quantize Op is valid, so we can remove the rest of the Quantize Op.
+ *
+ *  BEFORE
+ *                                          [CircleNode_1]
+ *                                                |
+ *                             [CircleQuantize, dtype_1, scale_1, zero_point_1]
+ *                                                |
+ *                             [CircleQuantize, dtype_2, scale_2, zero_point_2]
+ *                                                |
+ *                                         [CircleNode_2]
+ *
+ *  AFTER
+ *                                          [CircleNode_1]
+ *                                         /              \
+ *                                      /                    \
+ *                                   /                          \
+ *                                /                                \
+ *                             /                                      \
+ * [CircleQuantize, dtype_2, scale_2, zero_point_2] [CircleQuantize, dtype_1, scale_1, zero_point_1]
+ *                          |
+ *                   [CircleNode_2]
+ *
+ */
+
+namespace
+{
+
+bool remove_redundant_quantize(luci::CircleQuantize *node)
+{
+  auto pred_node = loco::must_cast<luci::CircleNode *>(node->input());
+
+  if (pred_node == nullptr)
+    return false;
+
+  if (node->quantparam() == nullptr or pred_node->quantparam() == nullptr)
+    return false;
+
+  if (node->quantparam()->scale.size() != 1 or node->quantparam()->zerop.size() != 1 or
+      pred_node->quantparam()->scale.size() != 1 or pred_node->quantparam()->zerop.size() != 1)
+  {
+    return false;
+  }
+
+  if (node->dtype() != pred_node->dtype() or
+      pred_node->quantparam()->scale.at(0) != node->quantparam()->scale.at(0) or
+      pred_node->quantparam()->zerop.at(0) != node->quantparam()->zerop.at(0))
+  {
+    return false;
+  }
+
+  replace(node).with(pred_node);
+
+  return true;
+}
+
+bool remove_redundant_subsequent_quantize(luci::CircleQuantize *node)
+{
+  auto pred_node = dynamic_cast<luci::CircleQuantize *>(node->input());
+  if (pred_node == nullptr)
+    return remove_redundant_quantize(node);
+
+  node->input(pred_node->input());
+  return true;
+}
+
+} // namespace
+
+namespace luci
+{
+
+bool RemoveRedundantQuantizePass::run(loco::Graph *g)
+{
+  bool changed = false;
+  for (auto node : loco::active_nodes(loco::output_nodes(g)))
+  {
+    if (auto quantize_node = dynamic_cast<luci::CircleQuantize *>(node))
+    {
+      if (remove_redundant_subsequent_quantize(quantize_node))
+        changed = true;
+    }
+  }
+  return changed;
+}
+
+} // namespace luci

--- a/compiler/luci/pass/src/RemoveRedundantQuantizePass.test.cpp
+++ b/compiler/luci/pass/src/RemoveRedundantQuantizePass.test.cpp
@@ -108,9 +108,8 @@ public:
     }
 
     _first_quantize->input(input());
-    _second_quantize->input(_first_quantize);
 
-    output()->from(_second_quantize);
+    output()->from(_first_quantize);
     output()->dtype(loco::DataType::U8);
   }
 };

--- a/compiler/luci/pass/src/RemoveRedundantQuantizePass.test.cpp
+++ b/compiler/luci/pass/src/RemoveRedundantQuantizePass.test.cpp
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Pass/RemoveRedundantQuantizePass.h"
+
+#include <luci/IR/CircleNodes.h>
+
+#include <luci/test/TestIOGraph.h>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+
+using namespace luci::test;
+
+class QuantizeGraphlet
+{
+public:
+  QuantizeGraphlet() = default;
+
+public:
+  void init(loco::Graph *g)
+  {
+    _first_quantize = g->nodes()->create<luci::CircleQuantize>();
+    _first_quantize->dtype(loco::DataType::U8);
+    {
+      auto quantize_param = std::make_unique<luci::CircleQuantParam>();
+      quantize_param->scale = {0.5};
+      quantize_param->zerop = {0};
+      _first_quantize->quantparam(std::move(quantize_param));
+    }
+    _first_quantize->name("first_quantize");
+
+    _second_quantize = g->nodes()->create<luci::CircleQuantize>();
+    _second_quantize->dtype(loco::DataType::U8);
+    {
+      auto quantize_param = std::make_unique<luci::CircleQuantParam>();
+      quantize_param->scale = {0.5};
+      quantize_param->zerop = {0};
+      _second_quantize->quantparam(std::move(quantize_param));
+    }
+    _second_quantize->name("second_quantize");
+  }
+
+protected:
+  luci::CircleQuantize *_first_quantize = nullptr;
+  luci::CircleQuantize *_second_quantize = nullptr;
+};
+
+class RedundantSubsequentQuantizeGraph : public TestIOGraph, public QuantizeGraphlet
+{
+public:
+  RedundantSubsequentQuantizeGraph() = default;
+
+public:
+  void init(void)
+  {
+    TestIOGraph::init({1}, {1});
+    QuantizeGraphlet::init(g());
+
+    input()->dtype(loco::DataType::U8);
+    {
+      auto quantize_param = std::make_unique<luci::CircleQuantParam>();
+      quantize_param->scale = {1};
+      quantize_param->zerop = {1};
+      input()->quantparam(std::move(quantize_param));
+    }
+
+    _first_quantize->input(input());
+    _second_quantize->input(_first_quantize);
+
+    output()->from(_second_quantize);
+    output()->dtype(loco::DataType::U8);
+  }
+};
+
+class RedundantQuantizeGraph : public TestIOGraph, public QuantizeGraphlet
+{
+public:
+  RedundantQuantizeGraph() = default;
+
+public:
+  void init(void)
+  {
+    TestIOGraph::init({1}, {1});
+    QuantizeGraphlet::init(g());
+
+    input()->dtype(loco::DataType::U8);
+    {
+      auto quantize_param = std::make_unique<luci::CircleQuantParam>();
+      quantize_param->scale = {0.5};
+      quantize_param->zerop = {0};
+      input()->quantparam(std::move(quantize_param));
+    }
+
+    _first_quantize->input(input());
+    _second_quantize->input(_first_quantize);
+
+    output()->from(_second_quantize);
+    output()->dtype(loco::DataType::U8);
+  }
+};
+
+} // namespace
+
+TEST(RemoveRedundantQuantizePass, name)
+{
+  luci::RemoveRedundantQuantizePass pass;
+  auto const name = pass.name();
+  ASSERT_NE(nullptr, name);
+}
+
+TEST(RemoveRedundantQuantizePass, remove_subsequent_quantize)
+{
+  RedundantSubsequentQuantizeGraph g;
+  luci::RemoveRedundantQuantizePass pass;
+
+  g.init();
+
+  EXPECT_TRUE(pass.run(g.g()));
+
+  int count = 0;
+  for (auto node : loco::active_nodes(loco::output_nodes(g.g())))
+  {
+    if (dynamic_cast<luci::CircleQuantize *>(node))
+    {
+      count++;
+    }
+  }
+
+  ASSERT_EQ(1, count);
+}
+
+TEST(RemoveRedundantQuantizePass, remove_quantize)
+{
+  RedundantQuantizeGraph g;
+  luci::RemoveRedundantQuantizePass pass;
+
+  g.init();
+
+  EXPECT_TRUE(pass.run(g.g()));
+
+  int count = 0;
+  for (auto node : loco::active_nodes(loco::output_nodes(g.g())))
+  {
+    if (dynamic_cast<luci::CircleQuantize *>(node))
+    {
+      count++;
+    }
+  }
+
+  ASSERT_EQ(0, count);
+}


### PR DESCRIPTION
This commit adds new pass for removing redundant quantize operations in luci.

for issue: https://github.com/Samsung/ONE/issues/8526

first step of #8530

ONE-DCO-1.0-Signed-off-by: Artem Balyshev a.balyshev@partner.samsung.com