### PR TITLE
[luci] Pass layer info to QuantizedModelVerifier

### DIFF
--- a/compiler/luci/pass/src/QuantizedModelVerifier.cpp
+++ b/compiler/luci/pass/src/QuantizedModelVerifier.cpp
@@ -22,13 +22,74 @@
 #include <luci/IR/CircleNodes.h>
 #include <luci/IR/CircleNodeVisitor.h>
 
+using LayerInfoMap = std::unordered_map<std::string, luci::LayerInfo *>;
+
 namespace luci
 {
+
+LayerInfoMap QuantizedModelVerifier::create_layer_info_map(loco::Graph *g) const
+{
+  LayerInfoMap info_by_name;
+
+  for (auto &&info : _ctx->layers_info)
+  {
+    auto name = info.name;
+    bool found = false;
+    for (auto node : loco::active_nodes(loco::output_nodes(g)))
+    {
+      auto cnode = loco::must_cast<luci::CircleNode *>(node);
+      if (cnode->name() == name)
+      {
+        if (info_by_name.find(name) != info_by_name.end())
+        {
+          throw std::runtime_error("Duplicate layer name " + name +
+                                   ". Check layer names in the quantization configuration file.");
+        }
+
+        info_by_name[name] = &info;
+        found = true;
+        break;
+      }
+    }
+
+    if (not found)
+      throw std::runtime_error("No such layer named " + name +
+                               ". Check layer names in the quantization configuration file.");
+  }
+
+  assert(info_by_name.size() == _ctx->layers_info.size()); // FIX_ME_UNLESS
+
+  return info_by_name;
+}
 
 void QuantizedModelVerifier::verify(loco::Graph *g)
 {
   if (_ctx->granularity != Granularity::ChannelWise && _ctx->granularity != Granularity::LayerWise)
     throw std::runtime_error("Unsupported granularity");
+
+  auto info_by_name = create_layer_info_map(g);
+
+  auto quantize_dtype = [&](const luci::CircleNode *node) {
+    auto iter = info_by_name.find(node->name());
+
+    // Return designated quantization dtype
+    if (iter != info_by_name.end())
+      return iter->second->dtype;
+
+    // Return default quantization dtype
+    return _ctx->output_model_dtype;
+  };
+
+  auto quantize_granularity = [&](const luci::CircleNode *node) {
+    auto iter = info_by_name.find(node->name());
+
+    // Return designated quantization granularity
+    if (iter != info_by_name.end())
+      return iter->second->granularity;
+
+    // Return default quantization granularity
+    return _ctx->granularity;
+  };
 
   for (auto node : loco::active_nodes(loco::output_nodes(g)))
   {
@@ -42,11 +103,12 @@ void QuantizedModelVerifier::verify(loco::Graph *g)
     };
 
     // Verify Type
-    if (!VerifyQuantizedNodeType::create(_ctx->output_model_dtype)->verify(circle_node))
+    if (!VerifyQuantizedNodeType::create(quantize_dtype(circle_node))->verify(circle_node))
       throw std::runtime_error("Wrong data type detected in " + node_name());
 
     // Verify Granularity
-    if (!circle_node->accept(VerifyQuantizedNodeGranularity::create(_ctx->granularity).get()))
+    if (!circle_node->accept(
+          VerifyQuantizedNodeGranularity::create(quantize_granularity(circle_node)).get()))
       throw std::runtime_error("Wrong granularity detected in " + node_name());
 
     // Verify Bias scale

--- a/compiler/luci/pass/src/QuantizedModelVerifier.h
+++ b/compiler/luci/pass/src/QuantizedModelVerifier.h
@@ -21,6 +21,7 @@
 
 #include <loco.h>
 
+#include <unordered_map>
 #include <memory>
 
 namespace luci
@@ -64,6 +65,9 @@ public:
   }
 
   void verify(loco::Graph *g);
+
+private:
+  std::unordered_map<std::string, LayerInfo *> create_layer_info_map(loco::Graph *g) const;
 
 private:
   std::unique_ptr<Context> _ctx;


### PR DESCRIPTION
This passes layer info to QuantizedModelVerifier.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/8512
Draft PR: https://github.com/Samsung/ONE/pull/8537