### PR TITLE
[luci-interpreter] Fix scale_1_b and scale_2_b types in SVDF kernel

### DIFF
--- a/compiler/luci-interpreter/pal/cmsisnn/PALSVDF.h
+++ b/compiler/luci-interpreter/pal/cmsisnn/PALSVDF.h
@@ -30,8 +30,8 @@ IntegerSVDF(const TfLiteSVDFParams &params, const tflite::RuntimeShape &input_sh
             const int16_t *weight_time_data, const tflite::RuntimeShape &bias_shape,
             const int32_t *bias_data, int16_t *activation_state_data,
             const tflite::RuntimeShape &output_shape, int8_t *output_data, int32_t *scratchpad_data,
-            int32_t *output_temp_data, int32_t scale_1_a, int32_t scale_1_b, int32_t scale_2_a,
-            int32_t scale_2_b, int32_t input_zp, int32_t output_zp)
+            int32_t *output_temp_data, int32_t scale_1_a, int scale_1_b, int32_t scale_2_a,
+            int scale_2_b, int32_t input_zp, int32_t output_zp)
 {
   const int32_t rank = params.rank;
   const int32_t batch_size = input_shape.Dims(0);

--- a/compiler/luci-interpreter/pal/linux/PALSVDF.h
+++ b/compiler/luci-interpreter/pal/linux/PALSVDF.h
@@ -28,8 +28,8 @@ IntegerSVDF(const TfLiteSVDFParams &params, const tflite::RuntimeShape &input_sh
             const int16_t *weight_time_data, const tflite::RuntimeShape &bias_shape,
             const int32_t *bias_data, int16_t *activation_state_data,
             const tflite::RuntimeShape &output_shape, int8_t *output_data, int32_t *scratchpad_data,
-            int32_t *output_temp_data, int32_t scale_1_a, int32_t scale_1_b, int32_t scale_2_a,
-            int32_t scale_2_b, int32_t input_zp, int32_t output_zp)
+            int32_t *output_temp_data, int32_t scale_1_a, int scale_1_b, int32_t scale_2_a,
+            int scale_2_b, int32_t input_zp, int32_t output_zp)
 {
   tflite::reference_ops::EvalIntegerSVDF(&params, input_shape, input_data, weight_feature_shape,
                                          weight_feature_data, weight_time_shape, weight_time_data,

--- a/compiler/luci-interpreter/pal/mcu/PALSVDF.h
+++ b/compiler/luci-interpreter/pal/mcu/PALSVDF.h
@@ -29,8 +29,8 @@ IntegerSVDF(const TfLiteSVDFParams &params, const tflite::RuntimeShape &input_sh
             const int16_t *weight_time_data, const tflite::RuntimeShape &bias_shape,
             const int32_t *bias_data, int16_t *activation_state_data,
             const tflite::RuntimeShape &output_shape, int8_t *output_data, int32_t *scratchpad_data,
-            int32_t *output_temp_data, int32_t scale_1_a, int32_t scale_1_b, int32_t scale_2_a,
-            int32_t scale_2_b, int32_t input_zp, int32_t output_zp)
+            int32_t *output_temp_data, int32_t scale_1_a, int scale_1_b, int32_t scale_2_a,
+            int scale_2_b, int32_t input_zp, int32_t output_zp)
 {
   const int n_rank = params.rank;
   const int n_batch = input_shape.Dims(0);

--- a/compiler/luci-interpreter/src/kernels/SVDF.cpp
+++ b/compiler/luci-interpreter/src/kernels/SVDF.cpp
@@ -181,9 +181,9 @@ void SVDF::evalInteger() const
                                                      weight_time()->scale() / output()->scale());
 
   int32_t effective_scale_1_a;
-  int32_t effective_scale_1_b;
+  int effective_scale_1_b;
   int32_t effective_scale_2_a;
-  int32_t effective_scale_2_b;
+  int effective_scale_2_b;
 
   tflite::QuantizeMultiplier(effective_scale_1, &effective_scale_1_a, &effective_scale_1_b);
   tflite::QuantizeMultiplier(effective_scale_2, &effective_scale_2_a, &effective_scale_2_b);


### PR DESCRIPTION
This commit fixes scale_1_b and scale_2_b types in SVDF kernel: int32_t to int.

ONE-DCO-1.0-Signed-off-by: Vyacheslav Bazhenov <slavikmipt@gmail.com>