### PR TITLE
[luci-interpreter] Fix shift type in Quantize kernel

### DIFF
--- a/compiler/luci-interpreter/src/kernels/Quantize.cpp
+++ b/compiler/luci-interpreter/src/kernels/Quantize.cpp
@@ -29,7 +29,7 @@ namespace
 template <typename input_dtype> void call_requantize(const Tensor *input, Tensor *output)
 {
   int32_t multiplier;
-  int32_t shift;
+  int shift;
 
   const double effective_output_scale = input->scale() / output->scale();
   quantizeMultiplier(effective_output_scale, &multiplier, &shift);


### PR DESCRIPTION
This commit fixes shift type in Quantize kernel: int32_t to int.

ONE-DCO-1.0-Signed-off-by: Vyacheslav Bazhenov <slavikmipt@gmail.com>