### PR TITLE
[circle2circle] Support RemoveRedundantQuantizePass in circle2circle

### DIFF
--- a/compiler/circle2circle/src/Circle2Circle.cpp
+++ b/compiler/circle2circle/src/Circle2Circle.cpp
@@ -203,6 +203,12 @@ int entry(int argc, char **argv)
     .default_value(false)
     .help("This will remove Quantize-Dequantize sequence");
 
+  arser.add_argument("--remove_redundant_quantize")
+    .nargs(0)
+    .required(false)
+    .default_value(false)
+    .help("This will remove redundant Quantize operators");
+
   arser.add_argument("--remove_redundant_reshape")
     .nargs(0)
     .required(false)
@@ -484,6 +490,8 @@ int entry(int argc, char **argv)
     options->enable(Algorithms::RemoveFakeQuant);
   if (arser.get<bool>("--remove_quantdequant"))
     options->enable(Algorithms::RemoveQuantDequantSeq);
+  if (arser.get<bool>("--remove_redundant_quantize"))
+    options->enable(Algorithms::RemoveRedundantQuantize);
   if (arser.get<bool>("--remove_redundant_reshape"))
     options->enable(Algorithms::RemoveRedundantReshape);
   if (arser.get<bool>("--remove_redundant_transpose"))


### PR DESCRIPTION
This commit adds support of RemoveRedundantQuantizePass in circle2circle.

for issue: https://github.com/Samsung/ONE/issues/8526

second step of https://github.com/Samsung/ONE/pull/8530

ONE-DCO-1.0-Signed-off-by: Artem Balyshev a.balyshev@partner.samsung.com