### PR TITLE
[infra] Fix ARM32 build items of modules

### DIFF
--- a/infra/nncc/Makefile.arm32
+++ b/infra/nncc/Makefile.arm32
@@ -31,7 +31,6 @@ ARM32_BUILD_ITEMS+=;luci-interpreter
 ARM32_BUILD_ITEMS+=;tflite2circle
 ARM32_BUILD_ITEMS+=;tflchef;circlechef
 ARM32_BUILD_ITEMS+=;circle2circle;record-minmax;circle-quantizer
-ARM32_BUILD_ITEMS+=;common-artifacts
 ARM32_BUILD_ITEMS+=;luci-eval-driver;luci-value-test
 
 ARM32_TOOLCHAIN_FILE=cmake/buildtool/cross/toolchain_armv7l-linux.cmake
@@ -49,6 +48,7 @@ ARM32_HOST_ITEMS+=;tflite2circle
 ARM32_HOST_ITEMS+=;tflchef;circlechef
 ARM32_HOST_ITEMS+=;circle-tensordump
 ARM32_HOST_ITEMS+=;circle2circle
+ARM32_HOST_ITEMS+=;common-artifacts
 ARM32_HOST_ITEMS+=;luci-eval-driver;luci-value-test
 
 


### PR DESCRIPTION
This will fix ARM32 Makefile build items of modules.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>