### PR TITLE
[luci/logex] Add missing ENABLE_TEST condition to CMakeLists.txt

### DIFF
--- a/compiler/luci/logex/CMakeLists.txt
+++ b/compiler/luci/logex/CMakeLists.txt
@@ -19,6 +19,10 @@ install(TARGETS luci_logex DESTINATION lib)
 install(DIRECTORY include/ DESTINATION include
         FILES_MATCHING PATTERN "*.h")
 
+if(NOT ENABLE_TEST)
+    return()
+endif(NOT ENABLE_TEST)
+
 nnas_find_package(GTest REQUIRED)
 
 GTest_AddTest(luci_logex_test ${TESTS})


### PR DESCRIPTION
This commit adds missing `ENABLE_TEST` checking logic to `CMakeLists.txt`.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>

---

Parent Issue : #8357 
Draft : #8358 