### PR TITLE
[one-cmds] Add Remove redundant Quantize op optimization option

### DIFF
--- a/compiler/one-cmds/how-to-use-one-commands.txt
+++ b/compiler/one-cmds/how-to-use-one-commands.txt
@@ -178,6 +178,7 @@ Current transformation options are
 - generate_profile_data : This will turn on profiling data generation.
 - remove_fakequant : This will remove all fakequant operators.
 - remove_quantdequant : This will remove all Quantize-Dequantize sequence.
+- remove_redundant_quantize : This removes redundant quantize operators.
 - remove_redundant_reshape : This fuses or removes redundant reshape operators.
 - remove_redundant_transpose : This fuses or removes redundant transpose operators.
 - remove_unnecessary_reshape : This removes unnecessary reshape operators.

--- a/compiler/one-cmds/onelib/constant.py
+++ b/compiler/one-cmds/onelib/constant.py
@@ -54,6 +54,7 @@ class CONSTANT:
          'replace channel-wise Mul/Add with DepthwiseConv2D'),
         ('remove_fakequant', 'remove FakeQuant ops'),
         ('remove_quantdequant', 'remove Quantize-Dequantize sequence'),
+        ('remove_redundant_quantize', 'remove redundant Quantize ops'),
         ('remove_redundant_reshape', 'fuse or remove subsequent Reshape ops'),
         ('remove_redundant_transpose', 'fuse or remove subsequent Transpose ops'),
         ('remove_unnecessary_reshape', 'remove unnecessary reshape ops'),


### PR DESCRIPTION
This commit adds Remove redundant Quantize op optimization option.

for issue https://github.com/Samsung/ONE/issues/8526

ONE-DCO-1.0-Signed-off-by: Artem Balyshev a.balyshev@partner.samsung.com