### PR TITLE
[luci] Remove redundant argument from PropagateQParamBackward

### DIFF
--- a/compiler/luci/pass/src/PropagateConcatenationQparam.test.cpp
+++ b/compiler/luci/pass/src/PropagateConcatenationQparam.test.cpp
@@ -191,7 +191,7 @@ TEST(PropagateConcatenationQparam, propagate_concat_quantparam_u8)
 
   // normal case: qparam of concat_node is propagated to input_1 and input_2
   SimpleConcatGraph g(loco::DataType::U8);
-  luci::propagate_concat_quantparam(&g.concat_node, loco::DataType::U8);
+  luci::propagate_concat_quantparam(&g.concat_node);
   EXPECT_FLOAT_EQ(3.14, g.concat_node.quantparam()->scale[0]);
   EXPECT_EQ(77, g.concat_node.quantparam()->zerop[0]);
   EXPECT_FLOAT_EQ(3.14, g.input_1.quantparam()->scale[0]);
@@ -202,7 +202,7 @@ TEST(PropagateConcatenationQparam, propagate_concat_quantparam_u8)
   // input_1 is an input of input_2. qparam is propagated only to input_2
   SimpleConcatGraph g2(loco::DataType::U8);
   g2.input_2.input(&g2.input_1);
-  luci::propagate_concat_quantparam(&g2.concat_node, loco::DataType::U8);
+  luci::propagate_concat_quantparam(&g2.concat_node);
   EXPECT_FLOAT_EQ(3.14, g2.concat_node.quantparam()->scale[0]);
   EXPECT_EQ(77, g2.concat_node.quantparam()->zerop[0]);
   EXPECT_FLOAT_EQ(1.0, g2.input_1.quantparam()->scale[0]);
@@ -212,7 +212,7 @@ TEST(PropagateConcatenationQparam, propagate_concat_quantparam_u8)
 
   // input_1 is concat. qparam is propagated to subsequent concat
   SubsequentConcatGraph sg(loco::DataType::U8);
-  luci::propagate_concat_quantparam(&sg.concat_node, loco::DataType::U8);
+  luci::propagate_concat_quantparam(&sg.concat_node);
   EXPECT_FLOAT_EQ(3.14, sg.concat_node.quantparam()->scale[0]);
   EXPECT_EQ(77, sg.concat_node.quantparam()->zerop[0]);
   EXPECT_FLOAT_EQ(3.14, sg.input_1.quantparam()->scale[0]);
@@ -222,7 +222,7 @@ TEST(PropagateConcatenationQparam, propagate_concat_quantparam_u8)
 
   // input_1 is const. const values are quantized with the qparam of concat
   ConstInputConcatGraph cg(loco::DataType::U8);
-  luci::propagate_concat_quantparam(cg.concat_node, loco::DataType::U8);
+  luci::propagate_concat_quantparam(cg.concat_node);
   EXPECT_FLOAT_EQ(0.1, cg.concat_node->quantparam()->scale[0]);
   EXPECT_EQ(10, cg.concat_node->quantparam()->zerop[0]);
   const auto cg_input_1 = loco::must_cast<luci::CircleConst *>(cg.concat_node->values(0));
@@ -248,7 +248,7 @@ TEST(PropagateConcatenationQparam, propagate_concat_quantparam_u8_NEG)
 
   // concat has fused activation function
   g.concat_node.fusedActivationFunction(luci::FusedActFunc::RELU);
-  luci::propagate_concat_quantparam(&g.concat_node, loco::DataType::U8);
+  luci::propagate_concat_quantparam(&g.concat_node);
   EXPECT_FLOAT_EQ(3.14, g.concat_node.quantparam()->scale[0]);
   EXPECT_EQ(77, g.concat_node.quantparam()->zerop[0]);
   EXPECT_FLOAT_EQ(1.0, g.input_1.quantparam()->scale[0]);
@@ -261,7 +261,7 @@ TEST(PropagateConcatenationQparam, propagate_concat_quantparam_u8_NEG)
   // const values are quantized using its min/max
   ConstInputConcatGraph cg(loco::DataType::U8);
   cg.concat_node->fusedActivationFunction(luci::FusedActFunc::RELU);
-  luci::propagate_concat_quantparam(cg.concat_node, loco::DataType::U8);
+  luci::propagate_concat_quantparam(cg.concat_node);
   EXPECT_FLOAT_EQ(0.1, cg.concat_node->quantparam()->scale[0]);
   EXPECT_EQ(10, cg.concat_node->quantparam()->zerop[0]);
   const auto cg_input_1 = loco::must_cast<luci::CircleConst *>(cg.concat_node->values(0));
@@ -288,7 +288,7 @@ TEST(PropagateConcatenationQparam, propagate_concat_quantparam_i16)
 
   // normal case: qparam of concat_node is propagated to input_1 and input_2
   SimpleConcatGraph g(loco::DataType::S16);
-  luci::propagate_concat_quantparam(&g.concat_node, loco::DataType::S16);
+  luci::propagate_concat_quantparam(&g.concat_node);
   EXPECT_FLOAT_EQ(3.14, g.concat_node.quantparam()->scale[0]);
   EXPECT_EQ(0, g.concat_node.quantparam()->zerop[0]);
   EXPECT_FLOAT_EQ(3.14, g.input_1.quantparam()->scale[0]);
@@ -299,7 +299,7 @@ TEST(PropagateConcatenationQparam, propagate_concat_quantparam_i16)
   // input_1 is an input of input_2. qparam is propagated only to input_2
   SimpleConcatGraph g2(loco::DataType::S16);
   g2.input_2.input(&g2.input_1);
-  luci::propagate_concat_quantparam(&g2.concat_node, loco::DataType::S16);
+  luci::propagate_concat_quantparam(&g2.concat_node);
   EXPECT_FLOAT_EQ(3.14, g2.concat_node.quantparam()->scale[0]);
   EXPECT_EQ(0, g2.concat_node.quantparam()->zerop[0]);
   EXPECT_FLOAT_EQ(1.0, g2.input_1.quantparam()->scale[0]);
@@ -309,7 +309,7 @@ TEST(PropagateConcatenationQparam, propagate_concat_quantparam_i16)
 
   // input_1 is concat. qparam is propagated only to input_2
   SubsequentConcatGraph sg(loco::DataType::S16);
-  luci::propagate_concat_quantparam(&sg.concat_node, loco::DataType::S16);
+  luci::propagate_concat_quantparam(&sg.concat_node);
   EXPECT_FLOAT_EQ(3.14, sg.concat_node.quantparam()->scale[0]);
   EXPECT_EQ(0, sg.concat_node.quantparam()->zerop[0]);
   EXPECT_FLOAT_EQ(3.14, sg.input_1.quantparam()->scale[0]);
@@ -319,7 +319,7 @@ TEST(PropagateConcatenationQparam, propagate_concat_quantparam_i16)
 
   // input_1 is const. const values are quantized with the qparam of concat
   ConstInputConcatGraph cg(loco::DataType::S16);
-  luci::propagate_concat_quantparam(cg.concat_node, loco::DataType::S16);
+  luci::propagate_concat_quantparam(cg.concat_node);
   EXPECT_FLOAT_EQ(0.1, cg.concat_node->quantparam()->scale[0]);
   EXPECT_EQ(0, cg.concat_node->quantparam()->zerop[0]);
   const auto cg_input_1 = loco::must_cast<luci::CircleConst *>(cg.concat_node->values(0));
@@ -345,7 +345,7 @@ TEST(PropagateConcatenationQparam, propagate_concat_quantparam_i16_NEG)
 
   // concat has fused activation function
   g.concat_node.fusedActivationFunction(luci::FusedActFunc::RELU);
-  luci::propagate_concat_quantparam(&g.concat_node, loco::DataType::S16);
+  luci::propagate_concat_quantparam(&g.concat_node);
   EXPECT_FLOAT_EQ(3.14, g.concat_node.quantparam()->scale[0]);
   EXPECT_EQ(0, g.concat_node.quantparam()->zerop[0]);
   EXPECT_FLOAT_EQ(1.0, g.input_1.quantparam()->scale[0]);
@@ -358,7 +358,7 @@ TEST(PropagateConcatenationQparam, propagate_concat_quantparam_i16_NEG)
   // const values are quantized using its min/max
   ConstInputConcatGraph cg(loco::DataType::S16);
   cg.concat_node->fusedActivationFunction(luci::FusedActFunc::RELU);
-  luci::propagate_concat_quantparam(cg.concat_node, loco::DataType::S16);
+  luci::propagate_concat_quantparam(cg.concat_node);
   EXPECT_FLOAT_EQ(0.1, cg.concat_node->quantparam()->scale[0]);
   EXPECT_EQ(0, cg.concat_node->quantparam()->zerop[0]);
   const auto cg_input_1 = loco::must_cast<luci::CircleConst *>(cg.concat_node->values(0));

--- a/compiler/luci/pass/src/PropagateQParamBackwardPass.cpp
+++ b/compiler/luci/pass/src/PropagateQParamBackwardPass.cpp
@@ -169,7 +169,7 @@ bool ignore_pad_v2_const_quantization(const luci::CirclePadV2 *pad)
  *
  * NOTE Quantization parameter of CirclePack (qparam2) is propagated to the inputs.
  */
-void propagate_pack_quantparam(luci::CirclePack *pack, loco::DataType quant_type)
+void propagate_pack_quantparam(luci::CirclePack *pack)
 {
   assert(pack->quantparam() != nullptr);
 
@@ -196,7 +196,7 @@ void propagate_pack_quantparam(luci::CirclePack *pack, loco::DataType quant_type
       const auto zerop = pack_qparam->zerop[0];
 
       auto new_const = luci::clone(const_node);
-      quant_const_values(new_const, scaling_factor, zerop, quant_type);
+      quant_const_values(new_const, scaling_factor, zerop, pack->dtype());
       pack->values(i, new_const);
       overwrite_quantparam(pack, new_const);
     }
@@ -239,14 +239,14 @@ void propagate_pack_quantparam(luci::CirclePack *pack, loco::DataType quant_type
  *
  * NOTE Quantization parameter of CircleOneHot (qparam2) is propagated to on_value/off_value.
  */
-void propagate_one_hot_quantparam(luci::CircleOneHot *one_hot, loco::DataType quant_type)
+void propagate_one_hot_quantparam(luci::CircleOneHot *one_hot)
 {
   assert(one_hot->quantparam() != nullptr);
 
   // Propagate quantization parameters from output to inputs,
   // to fit both input and counstant_value in one quant range.
-  auto quant_input = [one_hot, quant_type](void (luci::CircleOneHot::*arg_setter)(loco::Node *),
-                                           loco::Node *(luci::CircleOneHot::*arg_getter)() const) {
+  auto quant_input = [one_hot](void (luci::CircleOneHot::*arg_setter)(loco::Node *),
+                               loco::Node *(luci::CircleOneHot::*arg_getter)() const) {
     auto node = loco::must_cast<luci::CircleNode *>((one_hot->*arg_getter)());
 
     // Quantize constant values
@@ -268,7 +268,7 @@ void propagate_one_hot_quantparam(luci::CircleOneHot *one_hot, loco::DataType qu
       const auto zerop = qparam->zerop.at(0);
 
       auto new_const = luci::clone(const_node);
-      quant_const_values(new_const, scaling_factor, zerop, quant_type);
+      quant_const_values(new_const, scaling_factor, zerop, one_hot->dtype());
       overwrite_quantparam(one_hot, new_const);
       (one_hot->*arg_setter)(new_const);
     }
@@ -310,7 +310,7 @@ namespace luci
  *                    [CircleConcatenation]
  *                        (U8 qparam2)
  */
-void propagate_concat_quantparam(luci::CircleConcatenation *concat, loco::DataType quant_type)
+void propagate_concat_quantparam(luci::CircleConcatenation *concat)
 {
   assert(concat->quantparam() != nullptr);
 
@@ -326,7 +326,7 @@ void propagate_concat_quantparam(luci::CircleConcatenation *concat, loco::DataTy
       if (const_node != nullptr)
       {
         auto new_const = luci::clone(const_node);
-        quant_const(new_const, quant_type);
+        quant_const(new_const, concat->dtype());
         concat->values(i, new_const);
       }
     }
@@ -348,7 +348,7 @@ void propagate_concat_quantparam(luci::CircleConcatenation *concat, loco::DataTy
       const auto zerop = concat_qparam->zerop[0];
 
       auto new_const = luci::clone(const_node);
-      quant_const_values(new_const, scaling_factor, zerop, quant_type);
+      quant_const_values(new_const, scaling_factor, zerop, concat->dtype());
       concat->values(i, new_const);
       overwrite_quantparam(concat, new_const);
     }
@@ -400,7 +400,7 @@ void propagate_concat_quantparam(luci::CircleConcatenation *concat, loco::DataTy
  *                      [CirclePadV2]
  *                       (U8 qparam1)
  */
-void propagate_pad_v2_quantparam(luci::CirclePadV2 *pad_v2, loco::DataType quant_type)
+void propagate_pad_v2_quantparam(luci::CirclePadV2 *pad_v2)
 {
   if (ignore_pad_v2_const_quantization(pad_v2))
   {
@@ -418,7 +418,7 @@ void propagate_pad_v2_quantparam(luci::CirclePadV2 *pad_v2, loco::DataType quant
     const auto scaling_factor = pad_v2_input_qparam->scale.at(0);
     const auto zerop = pad_v2_input_qparam->zerop.at(0);
 
-    quant_const_values(new_const, scaling_factor, zerop, quant_type);
+    quant_const_values(new_const, scaling_factor, zerop, pad_v2->dtype());
     overwrite_quantparam(pad_v2_input, new_const);
     pad_v2->constant_values(new_const);
     return;
@@ -426,8 +426,7 @@ void propagate_pad_v2_quantparam(luci::CirclePadV2 *pad_v2, loco::DataType quant
 
   // Propagate quantization paramters from output to inputs,
   // to fit both input and counstant_value in one quant range.
-  auto quant_input = [pad_v2, quant_type](void (CirclePadV2::*arg_setter)(loco::Node *),
-                                          uint32_t arg) {
+  auto quant_input = [pad_v2](void (CirclePadV2::*arg_setter)(loco::Node *), uint32_t arg) {
     auto node = loco::must_cast<luci::CircleNode *>(pad_v2->arg(arg));
 
     // Quantize constant values
@@ -449,7 +448,7 @@ void propagate_pad_v2_quantparam(luci::CirclePadV2 *pad_v2, loco::DataType quant
       const auto zerop = pad_v2_qparam->zerop.at(0);
 
       auto new_const = luci::clone(const_node);
-      quant_const_values(new_const, scaling_factor, zerop, quant_type);
+      quant_const_values(new_const, scaling_factor, zerop, pad_v2->dtype());
       overwrite_quantparam(pad_v2, new_const);
       (pad_v2->*arg_setter)(new_const);
     }
@@ -477,20 +476,15 @@ namespace
 // Visitor to propagate quantization parameters backwards
 struct PropagateQParamBackward final : public luci::CircleNodeMutableVisitor<void>
 {
-  PropagateQParamBackward(loco::DataType output) : _output_type(output) {}
-
-private:
-  loco::DataType _output_type;
-
   void visit(luci::CircleNode *) {}
 
-  void visit(luci::CircleConcatenation *node) { propagate_concat_quantparam(node, _output_type); }
+  void visit(luci::CircleConcatenation *node) { propagate_concat_quantparam(node); }
 
-  void visit(luci::CircleOneHot *node) { propagate_one_hot_quantparam(node, _output_type); }
+  void visit(luci::CircleOneHot *node) { propagate_one_hot_quantparam(node); }
 
-  void visit(luci::CirclePack *node) { propagate_pack_quantparam(node, _output_type); }
+  void visit(luci::CirclePack *node) { propagate_pack_quantparam(node); }
 
-  void visit(luci::CirclePadV2 *node) { propagate_pad_v2_quantparam(node, _output_type); }
+  void visit(luci::CirclePadV2 *node) { propagate_pad_v2_quantparam(node); }
 };
 
 } // namespace
@@ -510,7 +504,7 @@ bool PropagateQParamBackwardPass::run(loco::Graph *g)
     auto circle_node = loco::must_cast<luci::CircleNode *>(node);
     INFO(l) << "PropagateQParamBackwardPass visit node: " << circle_node->name() << std::endl;
 
-    PropagateQParamBackward pqb(_output_model_dtype);
+    PropagateQParamBackward pqb;
     circle_node->accept(&pqb);
   }
 

--- a/compiler/luci/pass/src/QuantizationUtils.h
+++ b/compiler/luci/pass/src/QuantizationUtils.h
@@ -42,9 +42,9 @@ bool get_channel_dim_index(CircleConst *node, loco::TensorShape &dimension,
 
 uint32_t cal_offset(loco::TensorShape &dimension, uint32_t *indices);
 
-void propagate_concat_quantparam(luci::CircleConcatenation *concat, loco::DataType quant_type);
+void propagate_concat_quantparam(luci::CircleConcatenation *concat);
 
-void propagate_pad_v2_quantparam(luci::CirclePadV2 *pad_v2, loco::DataType quant_type);
+void propagate_pad_v2_quantparam(luci::CirclePadV2 *pad_v2);
 
 bool is_weights(CircleNode *node);
 


### PR DESCRIPTION
This removes redundant argument from PropagateQParamBackward.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>