### PR TITLE
[luci] Add test for quantization with layer info

### DIFF
--- a/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
+++ b/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
@@ -244,6 +244,7 @@ private:
   INSERT_QUANTIZE_TO_BINARY_OP(luci::CircleMinimum, x, y)
   INSERT_QUANTIZE_TO_BINARY_OP(luci::CircleMul, x, y)
   INSERT_QUANTIZE_TO_BINARY_OP(luci::CircleNotEqual, x, y)
+  INSERT_QUANTIZE_TO_BINARY_OP(luci::CircleOneHot, on_value, off_value)
   INSERT_QUANTIZE_TO_BINARY_OP(luci::CirclePow, x, y)
   INSERT_QUANTIZE_TO_BINARY_OP(luci::CircleSub, x, y)
 


### PR DESCRIPTION
This adds test for quantization with layer info.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/pull/8558#issuecomment-1057792092