### PR TITLE
[infra] Fix gbs build error and warning

### DIFF
--- a/infra/nnfw/cmake/packages/CpuInfoConfig.cmake
+++ b/infra/nnfw/cmake/packages/CpuInfoConfig.cmake
@@ -14,6 +14,8 @@ function(_CpuInfo_Build)
     return()
   endif(NOT CpuInfoSource_FOUND)
 
+  nnas_include(ExternalProjectTools)
+
   set(CPUINFO_BUILD_TOOLS OFF CACHE BOOL "Build command-line tools")
   set(CPUINFO_BUILD_BENCHMARKS OFF CACHE BOOL "Build cpuinfo unit tests")
   set(CPUINFO_BUILD_UNIT_TESTS OFF CACHE BOOL "Build cpuinfo mock tests")

--- a/infra/nnfw/cmake/packages/GTestConfig.cmake
+++ b/infra/nnfw/cmake/packages/GTestConfig.cmake
@@ -20,7 +20,7 @@ if(NOT GTest_FOUND)
   # Reset package config directory cache to prevent recursive find
   unset(GTest_DIR CACHE)
   find_package(GTest)
-endif(GTest_FOUND)
+endif(NOT GTest_FOUND)
 find_package(Threads)
 
 if(${GTEST_FOUND} AND TARGET Threads::Threads)


### PR DESCRIPTION
This commit removes tizen gbs build error by add_extdirectory macro and warning message.

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>