### PR TITLE
[infra] Use gtest package for gbs build

### DIFF
--- a/packaging/nnfw.spec
+++ b/packaging/nnfw.spec
@@ -55,6 +55,7 @@ BuildRequires:  hdf5-devel
 BuildRequires:  libaec-devel
 BuildRequires:  zlib-devel
 BuildRequires:  libjpeg-devel
+BuildRequires:  gtest-devel
 %endif
 
 %description


### PR DESCRIPTION
This commit updates nnfw.spec to use gtest-devel package on tizen gbs build.

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: #8572