### PR TITLE
[dredd-rule-lib] Add rule to check tensor dtype

### DIFF
--- a/compiler/dredd-rule-lib/rule-lib.sh
+++ b/compiler/dredd-rule-lib/rule-lib.sh
@@ -217,4 +217,21 @@ op_version()
   echo ${ACTUAL}
 }
 
+tensor_dtype()
+{
+  argc_check $# 1
+  file_path_check ${COMPILED_FILE}
+  file_path_check ${INSPECT_PROG_PATH}
+
+  set -o pipefail
+
+  ACTUAL=`init_error_log ; \
+          ${INSPECT_PROG_PATH} --tensor_dtype ${COMPILED_FILE} | \
+          awk -v opname="$1" '{ if ($1 == opname) print $2}'`
+
+  check_success_exit_code $? 0
+
+  echo ${ACTUAL}
+}
+
 # TODO define more qullity test function

--- a/compiler/dredd-rule-lib/rule-lib.sh
+++ b/compiler/dredd-rule-lib/rule-lib.sh
@@ -227,7 +227,7 @@ tensor_dtype()
 
   ACTUAL=`init_error_log ; \
           ${INSPECT_PROG_PATH} --tensor_dtype ${COMPILED_FILE} | \
-          awk -v opname="$1" '{ if ($1 == opname) print $2}'`
+          awk -v tensor_name="$1" '{ if ($1 == tensor_name) print $2}'`
 
   check_success_exit_code $? 0
 


### PR DESCRIPTION
This adds rule to check tensor dtype.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/8597
Draft PR: https://github.com/Samsung/ONE/pull/8602