### PR TITLE
[luci] Extract layer info map code

### DIFF
--- a/compiler/luci/pass/include/luci/Pass/QuantizeWithMinMaxPass.h
+++ b/compiler/luci/pass/include/luci/Pass/QuantizeWithMinMaxPass.h
@@ -24,7 +24,6 @@
 #include <luci/Pass/QuantizationParameters.h>
 
 #include <vector>
-#include <unordered_map>
 
 namespace luci
 {
@@ -77,9 +76,6 @@ public:
 private:
   void set_input_type(loco::Graph *graph) const;
   void set_output_type(loco::Graph *graph) const;
-
-private:
-  std::unordered_map<std::string, LayerInfo *> create_layer_info_map(loco::Graph *g) const;
 
 private:
   std::unique_ptr<Context> _ctx;

--- a/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
+++ b/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
@@ -23,6 +23,7 @@
 #include "QuantizeBias.h"
 #include "QuantizationUtils.h"
 #include "ProgressReporter.h"
+#include "helpers/LayerInfoMap.h"
 
 #include <luci/IR/CircleNodes.h>
 #include <luci/IR/CircleNodeVisitor.h>
@@ -35,8 +36,6 @@
 
 #include <iostream>
 #include <cmath>
-
-using LayerInfoMap = std::unordered_map<std::string, luci::LayerInfo *>;
 
 namespace
 {
@@ -376,41 +375,6 @@ void QuantizeWithMinMaxPass::set_output_type(loco::Graph *g) const
   }
 }
 
-LayerInfoMap QuantizeWithMinMaxPass::create_layer_info_map(loco::Graph *g) const
-{
-  LayerInfoMap info_by_name;
-
-  for (auto &&info : _ctx->layers_info)
-  {
-    auto name = info.name;
-    bool found = false;
-    for (auto node : loco::active_nodes(loco::output_nodes(g)))
-    {
-      auto cnode = loco::must_cast<luci::CircleNode *>(node);
-      if (cnode->name() == name)
-      {
-        if (info_by_name.find(name) != info_by_name.end())
-        {
-          throw std::runtime_error("Duplicate layer name " + name +
-                                   ". Check layer names in the quantization configuration file.");
-        }
-
-        info_by_name[name] = &info;
-        found = true;
-        break;
-      }
-    }
-
-    if (not found)
-      throw std::runtime_error("No such layer named " + name +
-                               ". Check layer names in the quantization configuration file.");
-  }
-
-  assert(info_by_name.size() == _ctx->layers_info.size()); // FIX_ME_UNLESS
-
-  return info_by_name;
-}
-
 /**
  * How QuantizeWithMinMax works?
  *
@@ -462,7 +426,7 @@ bool QuantizeWithMinMaxPass::run(loco::Graph *g)
   LOGGER(l);
   INFO(l) << "QuantizeWithMinMaxPass Start" << std::endl;
 
-  auto info_by_name = create_layer_info_map(g);
+  auto info_by_name = layer_info_map(g, _ctx->layers_info);
 
   auto quantize_dtype = [&](const luci::CircleNode *node) {
     auto iter = info_by_name.find(node->name());

--- a/compiler/luci/pass/src/QuantizedModelVerifier.h
+++ b/compiler/luci/pass/src/QuantizedModelVerifier.h
@@ -21,7 +21,6 @@
 
 #include <loco.h>
 
-#include <unordered_map>
 #include <memory>
 
 namespace luci
@@ -65,9 +64,6 @@ public:
   }
 
   void verify(loco::Graph *g);
-
-private:
-  std::unordered_map<std::string, LayerInfo *> create_layer_info_map(loco::Graph *g) const;
 
 private:
   std::unique_ptr<Context> _ctx;

--- a/compiler/luci/pass/src/helpers/LayerInfoMap.cpp
+++ b/compiler/luci/pass/src/helpers/LayerInfoMap.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "LayerInfoMap.h"
+
+#include <luci/IR/CircleNode.h>
+
+#include <cassert>
+
+namespace luci
+{
+
+LayerInfoMap layer_info_map(loco::Graph *g, std::vector<LayerInfo> &layers_info)
+{
+  LayerInfoMap info_by_name;
+
+  for (auto &&info : layers_info)
+  {
+    auto name = info.name;
+    bool found = false;
+    for (auto node : loco::active_nodes(loco::output_nodes(g)))
+    {
+      auto cnode = loco::must_cast<luci::CircleNode *>(node);
+      if (cnode->name() == name)
+      {
+        if (info_by_name.find(name) != info_by_name.end())
+        {
+          throw std::runtime_error("Duplicate layer name " + name +
+                                   ". Check layer names in the quantization configuration file.");
+        }
+
+        info_by_name[name] = &info;
+        found = true;
+        continue;
+      }
+    }
+
+    if (not found)
+      throw std::runtime_error("No such layer named " + name +
+                               ". Check layer names in the quantization configuration file.");
+  }
+
+  assert(info_by_name.size() == layers_info.size()); // FIX_ME_UNLESS
+
+  return info_by_name;
+}
+
+} // namespace luci

--- a/compiler/luci/pass/src/helpers/LayerInfoMap.h
+++ b/compiler/luci/pass/src/helpers/LayerInfoMap.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __LUCI_PASS_HELPERS_LAYER_INFO_MAP_H__
+#define __LUCI_PASS_HELPERS_LAYER_INFO_MAP_H__
+
+#include <luci/Pass/QuantizationParameters.h>
+
+#include <unordered_map>
+
+namespace luci
+{
+
+using LayerInfoMap = std::unordered_map<std::string, luci::LayerInfo *>;
+
+LayerInfoMap layer_info_map(loco::Graph *g, std::vector<LayerInfo> &layers_info);
+
+} // namespace luci
+
+#endif // __LUCI_PASS_HELPERS_LAYER_INFO_MAP_H__

--- a/compiler/luci/pass/src/helpers/LayerInfoMap.test.cpp
+++ b/compiler/luci/pass/src/helpers/LayerInfoMap.test.cpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "LayerInfoMap.h"
+
+#include <luci/IR/CircleNode.h>
+#include <luci/test/TestIOGraph.h>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+
+class SoftmaxTestGraph : public luci::test::TestIOGraph
+{
+public:
+  void init(void)
+  {
+    TestIOGraph::init({32}, {32});
+    _softmax = g()->nodes()->create<luci::CircleSoftmax>();
+    {
+      _softmax->logits(input());
+      _softmax->beta(0.1);
+      _softmax->name("test");
+    }
+    output()->from(_softmax);
+  }
+
+private:
+  luci::CircleSoftmax *_softmax = nullptr;
+};
+
+} // namespace
+
+TEST(LayerInfoMapTest, simple_test)
+{
+  SoftmaxTestGraph g;
+  g.init();
+
+  luci::LayerInfo info;
+  {
+    info.name = "test";
+    info.dtype = loco::DataType::U8;
+    info.granularity = luci::QuantizationGranularity::ChannelWise;
+  }
+  std::vector<luci::LayerInfo> v;
+  v.emplace_back(info);
+  auto map = luci::layer_info_map(g.g(), v);
+
+  EXPECT_EQ("test", map["test"]->name);
+  EXPECT_EQ(loco::DataType::U8, map["test"]->dtype);
+  EXPECT_EQ(luci::QuantizationGranularity::ChannelWise, map["test"]->granularity);
+}
+
+TEST(LayerInfoMapTest, duplicate_name_NEG)
+{
+  SoftmaxTestGraph g;
+  g.init();
+  g.input()->name("test");
+
+  luci::LayerInfo info;
+  {
+    info.name = "test";
+    info.dtype = loco::DataType::U8;
+    info.granularity = luci::QuantizationGranularity::ChannelWise;
+  }
+  std::vector<luci::LayerInfo> v;
+  v.emplace_back(info);
+  EXPECT_ANY_THROW(luci::layer_info_map(g.g(), v));
+}
+
+TEST(LayerInfoMapTest, no_name_NEG)
+{
+  SoftmaxTestGraph g;
+  g.init();
+
+  luci::LayerInfo info;
+  {
+    info.name = "noname";
+    info.dtype = loco::DataType::U8;
+    info.granularity = luci::QuantizationGranularity::ChannelWise;
+  }
+  std::vector<luci::LayerInfo> v;
+  v.emplace_back(info);
+  EXPECT_ANY_THROW(luci::layer_info_map(g.g(), v));
+}


### PR DESCRIPTION
This extracts code for layer info map to reduce duplication.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>