### PR TITLE
[circle-quantizer-dredd-recipe-test] Add quant tests

### DIFF
--- a/compiler/circle-quantizer-dredd-recipe-test/test.lst
+++ b/compiler/circle-quantizer-dredd-recipe-test/test.lst
@@ -6,3 +6,5 @@
 ## TFLITE RECIPE
 
 Add(Quant_Conv_Mul_Add_000 DTYPE uint8 GRANULARITY channel USE_QCONFIG)
+Add(Quant_Conv_Mul_Add_001 DTYPE uint8 GRANULARITY channel USE_QCONFIG)
+Add(Quant_Conv_Mul_Add_002 DTYPE uint8 GRANULARITY channel USE_QCONFIG)


### PR DESCRIPTION
This adds tests for mixed-precision quantization.
- Quant_Conv_Mul_Add_001
- Quant_Conv_Mul_Add_002

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: #8618