### PR TITLE
[luci] Update opcode validation check function

### DIFF
--- a/compiler/luci/import/src/CircleReader.cpp
+++ b/compiler/luci/import/src/CircleReader.cpp
@@ -27,7 +27,11 @@ bool is_valid(const circle::OperatorCode *opcode)
 {
   assert(opcode != nullptr);
   circle::BuiltinOperator code = opcode->builtin_code();
-  return (circle::BuiltinOperator_MIN <= code && code <= circle::BuiltinOperator_MAX);
+  // Under FlatBuffers 1.10, circle::BuiltinOperator is enum type,
+  // but on FlatBuffers 2.0, circle::BuiltinOperator becomes enum uint8_t type.
+  // So comparison with circle::BuiltinOperator_MIN becomes true always
+  // because BuiltinOperator_MIN is 0, and it makes compiler warning.
+  return (/*circle::BuiltinOperator_MIN <= code &&*/ code <= circle::BuiltinOperator_MAX);
 }
 
 bool is_custom(const circle::OperatorCode *opcode)


### PR DESCRIPTION
This commit removes under-bound check on opcode validation check function is_valid().
It makes build error on flatbuffers 2.0.

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: #8492