### PR TITLE
[luci] Add TODO comment

### DIFF
--- a/compiler/luci/import/src/CircleReader.cpp
+++ b/compiler/luci/import/src/CircleReader.cpp
@@ -31,6 +31,7 @@ bool is_valid(const circle::OperatorCode *opcode)
   // but on FlatBuffers 2.0, circle::BuiltinOperator becomes enum uint8_t type.
   // So comparison with circle::BuiltinOperator_MIN becomes true always
   // because BuiltinOperator_MIN is 0, and it makes compiler warning.
+  // TODO: revisit this for schema v3b
   return (/*circle::BuiltinOperator_MIN <= code &&*/ code <= circle::BuiltinOperator_MAX);
 }
 


### PR DESCRIPTION
This commit adds TODO comment for is_valid(OperatorCode) function.

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: https://github.com/Samsung/ONE/pull/8627#discussion_r825793545