### PR TITLE
[luci] Support mixed-quantization for pooling Ops

### DIFF
--- a/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
+++ b/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
@@ -198,6 +198,7 @@ private:
   void visit(luci::CircleOutput *) {}
 
   // Ops that receive a single activation as an input
+  INSERT_QUANTIZE_TO_UNARY_OP(luci::CircleAveragePool2D, value)
   INSERT_QUANTIZE_TO_UNARY_OP(luci::CircleBatchToSpaceND, input)
   INSERT_QUANTIZE_TO_UNARY_OP(luci::CircleConv2D, input)
   INSERT_QUANTIZE_TO_UNARY_OP(luci::CircleDepthToSpace, input)
@@ -210,6 +211,7 @@ private:
   INSERT_QUANTIZE_TO_UNARY_OP(luci::CircleInstanceNorm, input)
   INSERT_QUANTIZE_TO_UNARY_OP(luci::CircleLocalResponseNormalization, input)
   INSERT_QUANTIZE_TO_UNARY_OP(luci::CircleLogistic, x)
+  INSERT_QUANTIZE_TO_UNARY_OP(luci::CircleMaxPool2D, value)
   INSERT_QUANTIZE_TO_UNARY_OP(luci::CircleMean, input)
   INSERT_QUANTIZE_TO_UNARY_OP(luci::CircleMirrorPad, input)
   INSERT_QUANTIZE_TO_UNARY_OP(luci::CirclePad, input)


### PR DESCRIPTION
This supports mixed-quantization for MaxPool and AveragePool.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>