### PR TITLE
[circle-partitioner] Rename tool

### DIFF
--- a/compiler/circle-partitioner/CMakeLists.txt
+++ b/compiler/circle-partitioner/CMakeLists.txt
@@ -1,5 +1,24 @@
 file(GLOB_RECURSE SOURCES "src/*.cpp")
 
+add_executable(circle-partitioner "${SOURCES}")
+target_link_libraries(circle-partitioner foder)
+target_link_libraries(circle-partitioner crew)
+target_link_libraries(circle-partitioner safemain)
+target_link_libraries(circle-partitioner luci_lang)
+target_link_libraries(circle-partitioner luci_log)
+target_link_libraries(circle-partitioner luci_import)
+target_link_libraries(circle-partitioner luci_service)
+target_link_libraries(circle-partitioner luci_pass)
+target_link_libraries(circle-partitioner luci_export)
+target_link_libraries(circle-partitioner luci_partition)
+target_link_libraries(circle-partitioner arser)
+target_link_libraries(circle-partitioner pepper_csv2vec)
+target_link_libraries(circle-partitioner vconone)
+target_link_libraries(circle-partitioner nncc_common)
+
+install(TARGETS circle-partitioner DESTINATION bin)
+
+# TODO remove circle_partitioner
 add_executable(circle_partitioner "${SOURCES}")
 target_link_libraries(circle_partitioner foder)
 target_link_libraries(circle_partitioner crew)

--- a/compiler/circle-partitioner/README.md
+++ b/compiler/circle-partitioner/README.md
@@ -94,7 +94,7 @@ Net_InstanceNorm_003/
 
 Command example
 ```
-./circle_partitioner Net_InstanceNorm_003.part Net_InstanceNorm_003.circle Net_InstanceNorm_003
+./circle-partitioner Net_InstanceNorm_003.part Net_InstanceNorm_003.circle Net_InstanceNorm_003
 ```
 
 Result of _circle-partitioner_


### PR DESCRIPTION
This will add tool as circle-partitioner to follow other command naming
conventions. Old name will be removed after changing other codes.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>