### PR TITLE
[mio-circle] Use FlatBuffers 2.0

### DIFF
--- a/compiler/mio-circle/CMakeLists.txt
+++ b/compiler/mio-circle/CMakeLists.txt
@@ -1,7 +1,7 @@
-nnas_find_package(FlatBuffers EXACT 1.10 QUIET)
+nnas_find_package(FlatBuffers EXACT 2.0 QUIET)
 
 if(NOT FlatBuffers_FOUND)
-  message(STATUS "mio-circle skip: FlatBuffers 1.10 NOT FOUND")
+  message(STATUS "mio-circle skip: FlatBuffers 2.0 NOT FOUND")
   return()
 endif(NOT FlatBuffers_FOUND)
 


### PR DESCRIPTION
This commit updates mio-circle to use FlatBuffers 2.0.

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: https://github.com/Samsung/ONE/pull/8492