### PR TITLE
[infra] Use FlatBuffers 2.0 fo TFLite 1.13.1

### DIFF
--- a/infra/cmake/packages/TensorFlowLite-1.13.1/Lite/CMakeLists.txt
+++ b/infra/cmake/packages/TensorFlowLite-1.13.1/Lite/CMakeLists.txt
@@ -1,7 +1,7 @@
 # NOTE The followings SHOULD be defined before using this CMakeLists.txt
 #
 #  'TensorFlowSource_DIR' variable
-#  'FlatBuffersSource_DIR' variable
+#  'flatbuffers-2.0' target
 #  'eigen' target
 #  'gemmlowp' target
 #  'neon2sse' target
@@ -37,10 +37,9 @@ CHECK_CXX_COMPILER_FLAG(-Wno-extern-c-compat COMPILER_SUPPORT_EXTERN_C_COMPAT_WA
 add_library(tensorflowlite-1.13.1 ${SRCS})
 set_target_properties(tensorflowlite-1.13.1 PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_include_directories(tensorflowlite-1.13.1 PUBLIC ${TensorFlowSource_DIR})
-target_include_directories(tensorflowlite-1.13.1 PUBLIC ${FlatBuffersSource_DIR}/include)
 target_compile_options(tensorflowlite-1.13.1 PUBLIC -Wno-ignored-attributes)
 if(COMPILER_SUPPORT_EXTERN_C_COMPAT_WARNING)
   target_compile_options(tensorflowlite-1.13.1 PUBLIC -Wno-extern-c-compat)
 endif(COMPILER_SUPPORT_EXTERN_C_COMPAT_WARNING)
 target_compile_definitions(tensorflowlite-1.13.1 PUBLIC "GEMMLOWP_ALLOW_SLOW_SCALAR_FALLBACK")
-target_link_libraries(tensorflowlite-1.13.1 eigen gemmlowp neon2sse farmhash abseil dl)
+target_link_libraries(tensorflowlite-1.13.1 flatbuffers-2.0 eigen gemmlowp neon2sse farmhash abseil dl)

--- a/infra/cmake/packages/TensorFlowLite-1.13.1/Lite/CMakeLists.txt
+++ b/infra/cmake/packages/TensorFlowLite-1.13.1/Lite/CMakeLists.txt
@@ -1,4 +1,6 @@
 # NOTE The followings SHOULD be defined before using this CMakeLists.txt
+# NOTE TensorFlow 1.13.1 uses flatbuffers-1.10
+#      but we use flatbuffers-2.0 to match with all other modules flatbuffers version.
 #
 #  'TensorFlowSource_DIR' variable
 #  'flatbuffers-2.0' target

--- a/infra/cmake/packages/TensorFlowLite-1.13.1/TensorFlowLiteConfig.cmake
+++ b/infra/cmake/packages/TensorFlowLite-1.13.1/TensorFlowLiteConfig.cmake
@@ -6,12 +6,12 @@ function(_TensorFlowLite_import)
     return()
   endif(NOT TensorFlowSource_FOUND)
 
-  nnas_find_package(FlatBuffersSource EXACT 1.10 QUIET)
+  nnas_find_package(FlatBuffers EXACT 2.0 QUIET)
 
-  if(NOT FlatBuffersSource_FOUND)
+  if(NOT FlatBuffers_FOUND)
     set(TensorFlowLite_FOUND FALSE PARENT_SCOPE)
     return()
-  endif(NOT FlatBuffersSource_FOUND)
+  endif(NOT FlatBuffers_FOUND)
 
   nnas_find_package(Farmhash QUIET)
 


### PR DESCRIPTION
This commit updates cmake for TFLite 1.13.1 to link flatbuffers-2.0.

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: https://github.com/Samsung/ONE/issues/8499