### PR TITLE
[circledump] Remove link with flatbuffers

### DIFF
--- a/compiler/circledump/CMakeLists.txt
+++ b/compiler/circledump/CMakeLists.txt
@@ -12,6 +12,5 @@ target_link_libraries(circledump arser)
 target_link_libraries(circledump mio_circle)
 target_link_libraries(circledump mio_circle_helper)
 target_link_libraries(circledump safemain)
-target_link_libraries(circledump flatbuffers-1.10)
 
 install(TARGETS circledump DESTINATION bin)


### PR DESCRIPTION
This will remove direct link with flatbuffers as mio-circle will do.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>