### PR TITLE
[one-cmds] Support mixed-precision quantization

### DIFF
--- a/compiler/one-cmds/one-quantize
+++ b/compiler/one-cmds/one-quantize
@@ -125,6 +125,12 @@ def _get_parser():
         help=
         "Force MaxPool Op to have the same input/output quantparams. NOTE: This option can degrade accuracy of some models.)"
     )
+    quantization_group.add_argument(
+        '--quant_config',
+        type=str,
+        help=
+        "Path to the quantization configuration file.)"
+    )
 
     # arguments for force_quantparam option
     force_quantparam_group = parser.add_argument_group(
@@ -337,6 +343,11 @@ def _quantize(args):
         if _utils._is_valid_attr(args, 'output_type'):
             circle_quantizer_cmd.append('--output_type')
             circle_quantizer_cmd.append(getattr(args, 'output_type'))
+        if _utils._is_valid_attr(args, 'quant_config'):
+            # NOTE --config conflicts with --config option in onecc, so
+            # we use quant_config for one-quantize
+            circle_quantizer_cmd.append('--config')
+            circle_quantizer_cmd.append(getattr(args, 'quant_config'))
         # input and output path
         circle_quantizer_cmd.append(tmp_output_path_2)
         if _utils._is_valid_attr(args, 'output_path'):

--- a/compiler/one-cmds/one-quantize
+++ b/compiler/one-cmds/one-quantize
@@ -129,7 +129,7 @@ def _get_parser():
         '--quant_config',
         type=str,
         help=
-        "Path to the quantization configuration file.)"
+        "Path to the quantization configuration file."
     )
 
     # arguments for force_quantparam option

--- a/compiler/one-cmds/tests/CMakeLists.txt
+++ b/compiler/one-cmds/tests/CMakeLists.txt
@@ -3,6 +3,7 @@
 # Gather test scripts
 file(GLOB TESTITEMS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "./*.test")
 file(GLOB CONFIGITEMS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "./*.cfg")
+file(GLOB QCONFIGITEMS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "./*.qconf.json")
 
 # Create a script to run the tests at installation folder
 set(DRIVER_SCRIPT "${CMAKE_CURRENT_BINARY_DIR}/runtestall.sh")
@@ -38,6 +39,11 @@ foreach(CONFIGITEM IN ITEMS ${CONFIGITEMS})
   get_filename_component(ITEM_PREFIX ${CONFIGITEM} NAME_WE)
   install(FILES ${CONFIGITEM} DESTINATION test)
 endforeach(CONFIGITEM)
+
+foreach(QCONFIGITEM IN ITEMS ${QCONFIGITEMS})
+  get_filename_component(ITEM_PREFIX ${QCONFIGITEM} NAME_WE)
+  install(FILES ${QCONFIGITEM} DESTINATION test)
+endforeach(QCONFIGITEM)
 
 file(APPEND "${DRIVER_SCRIPT}" "popd > /dev/null\n\n")
 

--- a/compiler/one-cmds/tests/one-quantize_009.qconf.json
+++ b/compiler/one-cmds/tests/one-quantize_009.qconf.json
@@ -1,0 +1,43 @@
+// Quantization configuration file
+{
+    "default_quantization_dtype" : "uint8",
+    "default_granularity" : "channel",
+    "layers" : [
+        {
+            // Normal convolution
+            "name" : "InceptionV3/InceptionV3/Conv2d_2b_3x3/Relu;InceptionV3/InceptionV3/Conv2d_2b_3x3/BatchNorm/FusedBatchNorm;InceptionV3/InceptionV3/Mixed_6a/Branch_1/Conv2d_0a_1x1/Conv2D;InceptionV3/InceptionV3/Conv2d_2b_3x3/Conv2D",
+            "dtype" : "int16",
+            "granularity" : "channel"
+        },
+        {
+            // Maxpool with multiple users
+            "name" : "InceptionV3/InceptionV3/MaxPool_5a_3x3/MaxPool",
+            "dtype" : "int16",
+            "granularity" : "channel"
+        },
+        {
+            // Concat with multiple inputs
+            "name" : "InceptionV3/InceptionV3/Mixed_5b/concat",
+            "dtype" : "int16",
+            "granularity" : "channel"
+        },
+        {
+            // Averagepool
+            "name" : "InceptionV3/InceptionV3/Mixed_5b/Branch_3/AvgPool_0a_3x3/AvgPool",
+            "dtype" : "int16",
+            "granularity" : "channel"
+        },
+        {
+            // Consecutive concat
+            "name" : "InceptionV3/InceptionV3/Mixed_7c/concat",
+            "dtype" : "int16",
+            "granularity" : "channel"
+        },
+        {
+            // Softmax
+            "name" : "InceptionV3/Predictions/Reshape_1",
+            "dtype" : "int16",
+            "granularity" : "channel"
+        }
+    ]
+}

--- a/compiler/one-cmds/tests/one-quantize_009.qconf.json
+++ b/compiler/one-cmds/tests/one-quantize_009.qconf.json
@@ -1,40 +1,33 @@
-// Quantization configuration file
 {
     "default_quantization_dtype" : "uint8",
     "default_granularity" : "channel",
     "layers" : [
         {
-            // Normal convolution
             "name" : "InceptionV3/InceptionV3/Conv2d_2b_3x3/Relu;InceptionV3/InceptionV3/Conv2d_2b_3x3/BatchNorm/FusedBatchNorm;InceptionV3/InceptionV3/Mixed_6a/Branch_1/Conv2d_0a_1x1/Conv2D;InceptionV3/InceptionV3/Conv2d_2b_3x3/Conv2D",
             "dtype" : "int16",
             "granularity" : "channel"
         },
         {
-            // Maxpool with multiple users
             "name" : "InceptionV3/InceptionV3/MaxPool_5a_3x3/MaxPool",
             "dtype" : "int16",
             "granularity" : "channel"
         },
         {
-            // Concat with multiple inputs
             "name" : "InceptionV3/InceptionV3/Mixed_5b/concat",
             "dtype" : "int16",
             "granularity" : "channel"
         },
         {
-            // Averagepool
             "name" : "InceptionV3/InceptionV3/Mixed_5b/Branch_3/AvgPool_0a_3x3/AvgPool",
             "dtype" : "int16",
             "granularity" : "channel"
         },
         {
-            // Consecutive concat
             "name" : "InceptionV3/InceptionV3/Mixed_7c/concat",
             "dtype" : "int16",
             "granularity" : "channel"
         },
         {
-            // Softmax
             "name" : "InceptionV3/Predictions/Reshape_1",
             "dtype" : "int16",
             "granularity" : "channel"

--- a/compiler/one-cmds/tests/one-quantize_009.test
+++ b/compiler/one-cmds/tests/one-quantize_009.test
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  echo "${filename_ext} FAILED"
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+inputfile="./inception_v3.circle"
+outputfile="./inception_v3.random.quantized.mixed.circle"
+
+rm -rf ${outputfile}
+
+# to create inception_v3.circle
+if [[ ! -s ${inputfile} ]]; then
+  /bin/bash one-import_001.test > /dev/null 2>&1
+  return_code=$?
+  if [[ ${return_code} != 0 ]]; then
+    trap_err_onexit
+  fi
+fi
+
+# run test without input data
+one-quantize \
+--input_dtype float32 \
+--quantized_dtype uint8 \
+--granularity channel \
+--quant_config one-quantize_009.qconf.json \
+--input_path ${inputfile} \
+--output_path ${outputfile} > /dev/null 2>&1
+
+if [[ ! -s "${outputfile}" ]]; then
+  trap_err_onexit
+fi
+
+echo "${filename_ext} SUCCESS"


### PR DESCRIPTION
This adds an option for mixed-precision quantization and its test.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

--
Related to: https://github.com/Samsung/ONE/issues/8398