### PR TITLE
[infra/debian] Use circle-partitioner

### DIFF
--- a/infra/debian/compiler/one-compiler.install
+++ b/infra/debian/compiler/one-compiler.install
@@ -1,7 +1,7 @@
 # {FILES_TO_INSTALL} {DEST_DIR}
 # bin
 usr/bin/circle2circle usr/share/one/bin/
-usr/bin/circle_partitioner usr/share/one/bin/
+usr/bin/circle-partitioner usr/share/one/bin/
 usr/bin/circle-quantizer usr/share/one/bin/
 usr/bin/generate_bcq_metadata.py usr/share/one/bin/
 usr/bin/generate_bcq_output_arrays.py usr/share/one/bin/


### PR DESCRIPTION
This will revise to install circle-partitioner tool with hyphen.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>