### PR TITLE
[exo] Revise to use circle schema from res folder

### DIFF
--- a/compiler/exo/CMakeLists.txt
+++ b/compiler/exo/CMakeLists.txt
@@ -15,7 +15,7 @@ endif(NOT TensorFlowSource_FOUND)
 message(STATUS "Build exo: TRUE")
 
 set(TFLITE_SCHEMA_DIR "${TensorFlowSource_DIR}/tensorflow/lite/schema")
-set(CIRCLE_SCHEMA_DIR "${NNAS_PROJECT_SOURCE_DIR}/nnpackage/schema")
+set(CIRCLE_SCHEMA_DIR "${NNAS_PROJECT_SOURCE_DIR}/res/CircleSchema/0.3")
 
 FlatBuffers_Target(exo_tflite_fbs
   OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/gen"


### PR DESCRIPTION
This will revise to use circle schema from res folder so that upgrading
will not break exo.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>