### PR TITLE
[mio-circle] Revise to use circle schema from res folder

### DIFF
--- a/compiler/mio-circle/CMakeLists.txt
+++ b/compiler/mio-circle/CMakeLists.txt
@@ -8,7 +8,7 @@ endif(NOT FlatBuffers_FOUND)
 message(STATUS "Build mio-circle: TRUE")
 
 # TODO Find a better way
-set(SCHEMA_FILE "${NNAS_PROJECT_SOURCE_DIR}/nnpackage/schema/circle_schema.fbs")
+set(SCHEMA_FILE "${NNAS_PROJECT_SOURCE_DIR}/res/CircleSchema/0.3/circle_schema.fbs")
 
 # NOTE Copy circle_schema.fbs as schema.fbs to generate "schema_generated.fbs" instead of "circle_schema_generated.fbs"
 add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/schema.fbs"


### PR DESCRIPTION
This will revise to use circle schema from res folder so that upgrading
will not change version of mio-circle.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>