### PR TITLE
[common-artifacts] Add recipe Net_Gather_SparseToDense_AddV2_000 to exlude.lst

### DIFF
--- a/compiler/common-artifacts/exclude.lst
+++ b/compiler/common-artifacts/exclude.lst
@@ -73,6 +73,7 @@ tcgenerate(Neg_000)
 tcgenerate(Net_BroadcastTo_AddV2_001) # luci-interpreter doesn't support custom operator
 tcgenerate(Net_Conv_FakeQuant_000) # luci-interpreter doesn't support FakeQuant yet
 tcgenerate(Net_Dangle_001)
+tcgenerate(Net_Gather_SparseToDense_AddV2_000) # luci-interpreter doesn't support custom operator
 tcgenerate(Net_ZeroDim_001) # luci-interpreter doesn't support zero dim
 tcgenerate(OneHot_000)
 tcgenerate(OneHot_001)


### PR DESCRIPTION
This commit adds recipe Net_Gather_SparseToDense_AddV2_000 to exlude.lst.

Draft: #8674
for https://github.com/Samsung/ONE/issues/8375#issuecomment-1070126309

ONE-DCO-1.0-Signed-off-by: Artem Balyshev a.balyshev@partner.samsung.com