### PR TITLE
[infra] Revise debian to use preset 20220323

### DIFF
--- a/infra/debian/compiler/rules
+++ b/infra/debian/compiler/rules
@@ -1,7 +1,7 @@
 #!/usr/bin/make -f
 export DH_VERBOSE = 1
 export NNAS_BUILD_PREFIX = build
-export PRESET = 20210910
+export PRESET = 20220323
 export _DESTDIR = debian/tmp/usr
 
 %:


### PR DESCRIPTION
This will revise debian rules to use preset 20220323 that includes mio-circle04.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>