### PR TITLE
[luci] Support mixed-precision in Ops with multiple outputs

### DIFF
--- a/compiler/luci/pass/src/helpers/LayerInfoMap.cpp
+++ b/compiler/luci/pass/src/helpers/LayerInfoMap.cpp
@@ -102,7 +102,7 @@ bool same_setting(const LayerInfo &left, const LayerInfo &right)
 }
 
 void add_multi_output_node(LayerInfoMap &info_by_name, LayerInfo &layer_info,
-                           const luci::CircleNode *node, std::vector<LayerInfo> &layers_info)
+                           const luci::CircleNode *node)
 {
   assert(is_multiple_output_node(node)); // FIX_CALLER_UNLESS
 
@@ -158,7 +158,7 @@ LayerInfoMap layer_info_map(loco::Graph *g, std::vector<LayerInfo> &layers_info)
         // Check and add multiple-output node and its outputs to info_by_name
         if (const auto multi_output = get_multi_output_node(cnode))
         {
-          add_multi_output_node(info_by_name, info, multi_output, layers_info);
+          add_multi_output_node(info_by_name, info, multi_output);
           found = true;
           continue;
         }

--- a/compiler/luci/pass/src/helpers/LayerInfoMap.cpp
+++ b/compiler/luci/pass/src/helpers/LayerInfoMap.cpp
@@ -125,47 +125,15 @@ void add_multi_output_node(LayerInfoMap &info_by_name, LayerInfo &layer_info,
   }
 
   // Add multiple output node to info_by_name
-  if (layer_info.name == name)
-  {
-    info_by_name[name] = layer_info;
-  }
-  else
-  {
-    auto it = std::find_if(layers_info.begin(), layers_info.end(),
-                           [&name](const auto &info) { return name == info.name; });
-
-    if (it == layers_info.end())
-    {
-      info_by_name[name] = {name, layer_info.dtype, layer_info.granularity};
-    }
-    else
-    {
-      info_by_name[name] = *it;
-    }
-  }
+  info_by_name[name] = {name, layer_info.dtype, layer_info.granularity};
 
   // Add outputs node to info_by_name
   for (const auto succs_node : succs_nodes)
   {
     const auto succs_circle_node = loco::must_cast<luci::CircleNode *>(succs_node);
     const auto succs_circle_node_name = succs_circle_node->name();
-    if (name != succs_circle_node_name)
-    {
-      auto it = std::find_if(layers_info.begin(), layers_info.end(),
-                             [&succs_circle_node_name](const auto &info) {
-                               return succs_circle_node_name == info.name;
-                             });
-
-      if (it == layers_info.end())
-      {
-        info_by_name[succs_circle_node_name] = {succs_circle_node_name, layer_info.dtype,
-                                                layer_info.granularity};
-      }
-      else
-      {
-        info_by_name[succs_circle_node_name] = *it;
-      }
-    }
+    info_by_name[succs_circle_node_name] = {succs_circle_node_name, layer_info.dtype,
+                                            layer_info.granularity};
   }
 }
 
@@ -211,6 +179,9 @@ LayerInfoMap layer_info_map(loco::Graph *g, std::vector<LayerInfo> &layers_info)
       throw std::runtime_error("No such layer named " + name +
                                ". Check layer names in the quantization configuration file.");
   }
+
+  // TODO Check all names in layers_info exist in the info_by_name
+  // TODO Check names in info_by_name but not in layers_info are from virtual outputs
 
   return info_by_name;
 }

--- a/compiler/luci/pass/src/helpers/LayerInfoMap.test.cpp
+++ b/compiler/luci/pass/src/helpers/LayerInfoMap.test.cpp
@@ -43,6 +43,61 @@ private:
   luci::CircleSoftmax *_softmax = nullptr;
 };
 
+class SplitAddTestGraph : public luci::test::TestIOGraph
+{
+public:
+  void init(void)
+  {
+    TestIOGraph::init({6, 1, 2}, {3, 1, 2});
+    _split_dim = g()->nodes()->create<luci::CircleConst>();
+    {
+      _split_dim->rank(1);
+      _split_dim->dtype(loco::DataType::S32);
+      _split_dim->size<loco::DataType::S32>(1);
+      _split_dim->at<loco::DataType::S32>(0);
+      _split_dim->shape({1});
+      _split_dim->name("split_dim");
+    }
+
+    _split = g()->nodes()->create<luci::CircleSplit>();
+    {
+      _split->input(input());
+      _split->num_split(2);
+      _split->split_dim(_split_dim);
+      _split->name("split0");
+    }
+
+    _split_out_1 = g()->nodes()->create<luci::CircleSplitOut>();
+    {
+      _split_out_1->input(_split);
+      _split_out_1->index(0);
+      _split_out_1->name("split0");
+    }
+
+    _split_out_2 = g()->nodes()->create<luci::CircleSplitOut>();
+    {
+      _split_out_2->input(_split);
+      _split_out_2->index(1);
+      _split_out_2->name("split1");
+    }
+
+    _add = g()->nodes()->create<luci::CircleAdd>();
+    {
+      _add->x(_split_out_1);
+      _add->y(_split_out_2);
+      _add->name("add");
+    }
+    output()->from(_add);
+  }
+
+private:
+  luci::CircleSplit *_split = nullptr;
+  luci::CircleSplitOut *_split_out_1 = nullptr;
+  luci::CircleSplitOut *_split_out_2 = nullptr;
+  luci::CircleConst *_split_dim = nullptr;
+  luci::CircleAdd *_add = nullptr;
+};
+
 } // namespace
 
 TEST(LayerInfoMapTest, simple_test)
@@ -63,6 +118,53 @@ TEST(LayerInfoMapTest, simple_test)
   EXPECT_EQ("test", map["test"].name);
   EXPECT_EQ(loco::DataType::U8, map["test"].dtype);
   EXPECT_EQ(luci::QuantizationGranularity::ChannelWise, map["test"].granularity);
+}
+
+TEST(LayerInfoMapTest, multiple_output_node_test)
+{
+  SplitAddTestGraph g;
+  g.init();
+
+  luci::LayerInfo info;
+  {
+    info.name = "split0";
+    info.dtype = loco::DataType::U8;
+    info.granularity = luci::QuantizationGranularity::ChannelWise;
+  }
+  std::vector<luci::LayerInfo> v;
+  v.emplace_back(info);
+  auto map = luci::layer_info_map(g.g(), v);
+
+  EXPECT_EQ(map.size(), 2);
+  EXPECT_EQ("split0", map["split0"].name);
+  EXPECT_EQ("split1", map["split1"].name);
+
+  EXPECT_EQ(loco::DataType::U8, map["split0"].dtype);
+  EXPECT_EQ(luci::QuantizationGranularity::ChannelWise, map["split0"].granularity);
+}
+
+TEST(LayerInfoMapTest, invalid_layer_info_multiple_output_node_NEG)
+{
+  SplitAddTestGraph g;
+  g.init();
+
+  luci::LayerInfo info_0;
+  {
+    info_0.name = "split0";
+    info_0.dtype = loco::DataType::U8;
+    info_0.granularity = luci::QuantizationGranularity::ChannelWise;
+  }
+  luci::LayerInfo info_1;
+  {
+    info_1.name = "split1";
+    info_1.dtype = loco::DataType::S16;
+    info_1.granularity = luci::QuantizationGranularity::ChannelWise;
+  }
+  std::vector<luci::LayerInfo> v;
+  v.emplace_back(info_0);
+  v.emplace_back(info_1);
+
+  EXPECT_ANY_THROW(luci::layer_info_map(g.g(), v));
 }
 
 TEST(LayerInfoMapTest, duplicate_name_NEG)


### PR DESCRIPTION
This commit adds support for mixed-precision in Ops with multiple outputs.

draft: #8673
issue: #8654

ONE-DCO-1.0-Signed-off-by: Artem Balyshev a.balyshev@partner.samsung.com