### PR TITLE
[res] Add test recipes with multiple-outputs nodes

### DIFF
--- a/res/TensorFlowLiteRecipes/Quant_Split_Add_000/test.qconf.json
+++ b/res/TensorFlowLiteRecipes/Quant_Split_Add_000/test.qconf.json
@@ -1,0 +1,11 @@
+{
+  "default_quantization_dtype" : "uint8",
+  "default_granularity" : "channel",
+  "layers" : [
+    {
+      "name" : "ofm1",
+      "dtype" : "int16",
+      "granularity" : "channel"
+    }
+  ]
+}

--- a/res/TensorFlowLiteRecipes/Quant_Split_Add_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/Quant_Split_Add_000/test.recipe
@@ -1,0 +1,47 @@
+operand {
+  name: "ifm"
+  type: FLOAT32
+  shape { dim: 6 dim: 1 dim: 2 }
+}
+operand {
+  name: "split_dim"
+  type: INT32
+  shape { }
+  filler { tag: "explicit" arg: "0" }
+}
+operand {
+  name: "ofm1"
+  type: FLOAT32
+  shape { dim: 3 dim: 1 dim: 2 }
+}
+operand {
+  name: "ofm2"
+  type: FLOAT32
+  shape { dim: 3 dim: 1 dim: 2 }
+}
+operation {
+  type: "Split"
+  split_options {
+    num_splits: 2
+  }
+  input: "split_dim"
+  input: "ifm"
+  output: "ofm1"
+  output: "ofm2"
+}
+operand {
+  name: "ofm"
+  type: FLOAT32
+  shape { dim: 3 dim: 1 dim: 2 }
+}
+operation {
+  type: "Add"
+  input: "ofm1"
+  input: "ofm2"
+  output: "ofm"
+  add_options {
+    activation: NONE
+  }
+}
+input: "ifm"
+output: "ofm"

--- a/res/TensorFlowLiteRecipes/Quant_Split_Add_000/test.rule
+++ b/res/TensorFlowLiteRecipes/Quant_Split_Add_000/test.rule
@@ -1,0 +1,11 @@
+# To check mixed-precision quantization for multiple output node.
+# Split: int16, Add: u8
+# Quantize Ops are inserted before Split and after all Split output nodes.
+
+RULE    "VERIFY_FILE_FORMAT"      $(verify_file_format) '=' 1
+
+RULE    "INPUT_UINT8"             $(tensor_dtype ifm) '=' UINT8
+RULE    "SPLIT_OUT_1_INT16"       $(tensor_dtype ofm1) '=' INT16
+RULE    "SPLIT_OUT_2_INT16"       $(tensor_dtype ofm2) '=' INT16
+RULE    "ADD_UINT8"               $(tensor_dtype ofm) '=' UINT8
+RULE    "QUANTIZE_OP"             $(op_count QUANTIZE) '=' 3

--- a/res/TensorFlowLiteRecipes/Quant_Split_Add_001/test.qconf.json
+++ b/res/TensorFlowLiteRecipes/Quant_Split_Add_001/test.qconf.json
@@ -1,0 +1,11 @@
+{
+  "default_quantization_dtype" : "uint8",
+  "default_granularity" : "channel",
+  "layers" : [
+    {
+      "name" : "ofm2",
+      "dtype" : "int16",
+      "granularity" : "channel"
+    }
+  ]
+}

--- a/res/TensorFlowLiteRecipes/Quant_Split_Add_001/test.recipe
+++ b/res/TensorFlowLiteRecipes/Quant_Split_Add_001/test.recipe
@@ -1,0 +1,47 @@
+operand {
+  name: "ifm"
+  type: FLOAT32
+  shape { dim: 6 dim: 1 dim: 2 }
+}
+operand {
+  name: "split_dim"
+  type: INT32
+  shape { }
+  filler { tag: "explicit" arg: "0" }
+}
+operand {
+  name: "ofm1"
+  type: FLOAT32
+  shape { dim: 3 dim: 1 dim: 2 }
+}
+operand {
+  name: "ofm2"
+  type: FLOAT32
+  shape { dim: 3 dim: 1 dim: 2 }
+}
+operation {
+  type: "Split"
+  split_options {
+    num_splits: 2
+  }
+  input: "split_dim"
+  input: "ifm"
+  output: "ofm1"
+  output: "ofm2"
+}
+operand {
+  name: "ofm"
+  type: FLOAT32
+  shape { dim: 3 dim: 1 dim: 2 }
+}
+operation {
+  type: "Add"
+  input: "ofm1"
+  input: "ofm2"
+  output: "ofm"
+  add_options {
+    activation: NONE
+  }
+}
+input: "ifm"
+output: "ofm"

--- a/res/TensorFlowLiteRecipes/Quant_Split_Add_001/test.rule
+++ b/res/TensorFlowLiteRecipes/Quant_Split_Add_001/test.rule
@@ -1,0 +1,11 @@
+# To check mixed-precision quantization for multiple output node.
+# Split: int16, Add: u8
+# Quantize Ops are inserted before Split and after all Split output nodes.
+
+RULE    "VERIFY_FILE_FORMAT"      $(verify_file_format) '=' 1
+
+RULE    "INPUT_UINT8"             $(tensor_dtype ifm) '=' UINT8
+RULE    "SPLIT_OUT_1_INT16"       $(tensor_dtype ofm1) '=' INT16
+RULE    "SPLIT_OUT_2_INT16"       $(tensor_dtype ofm2) '=' INT16
+RULE    "ADD_UINT8"               $(tensor_dtype ofm) '=' UINT8
+RULE    "QUANTIZE_OP"             $(op_count QUANTIZE) '=' 3


### PR DESCRIPTION
This commit adds test recipes with multiple-outputs nodes

draft: https://github.com/Samsung/ONE/pull/8673
issue: https://github.com/Samsung/ONE/issues/8654

ONE-DCO-1.0-Signed-off-by: Artem Balyshev a.balyshev@partner.samsung.com