### PR TITLE
[circle-quantizer-dredd-recipe-test] Add tests with multiple-output nodes

### DIFF
--- a/compiler/circle-quantizer-dredd-recipe-test/test.lst
+++ b/compiler/circle-quantizer-dredd-recipe-test/test.lst
@@ -8,3 +8,5 @@
 Add(Quant_Conv_Mul_Add_000 DTYPE uint8 GRANULARITY channel USE_QCONFIG)
 Add(Quant_Conv_Mul_Add_001 DTYPE uint8 GRANULARITY channel USE_QCONFIG)
 Add(Quant_Conv_Mul_Add_002 DTYPE uint8 GRANULARITY channel USE_QCONFIG)
+Add(Quant_Split_Add_000 DTYPE uint8 GRANULARITY channel USE_QCONFIG)
+Add(Quant_Split_Add_001 DTYPE uint8 GRANULARITY channel USE_QCONFIG)


### PR DESCRIPTION
This commit adds test recipes with multiple-outputs nodes

draft: https://github.com/Samsung/ONE/pull/8673
issue: https://github.com/Samsung/ONE/issues/8654

ONE-DCO-1.0-Signed-off-by: Artem Balyshev a.balyshev@partner.samsung.com