### PR TITLE
[circle2circle] Add Fold Gather pass to circle2circle

### DIFF
--- a/compiler/circle2circle/src/Circle2Circle.cpp
+++ b/compiler/circle2circle/src/Circle2Circle.cpp
@@ -104,6 +104,12 @@ int entry(int argc, char **argv)
     .default_value(false)
     .help("This will fold Depthwise Convolution operator with constant inputs");
 
+  arser.add_argument("--fold_gather")
+    .nargs(0)
+    .required(false)
+    .default_value(false)
+    .help("This will fold Gather operator");
+
   arser.add_argument("--fold_sparse_to_dense")
     .nargs(0)
     .required(false)
@@ -458,6 +464,8 @@ int entry(int argc, char **argv)
     options->enable(Algorithms::FoldDequantize);
   if (arser.get<bool>("--fold_dwconv"))
     options->enable(Algorithms::FoldDepthwiseConv2D);
+  if (arser.get<bool>("--fold_gather"))
+    options->enable(Algorithms::FoldGather);
   if (arser.get<bool>("--fold_sparse_to_dense"))
     options->enable(Algorithms::FoldSparseToDense);
   if (arser.get<bool>("--forward_reshape_to_unaryop"))


### PR DESCRIPTION
This pr adds fold gather pass to circle2circle. This pass can remove Gather operation which can be folded

draft: https://github.com/Samsung/ONE/pull/8682
for issue: https://github.com/Samsung/ONE/issues/8375

ONE-DCO-1.0-Signed-off-by: Artem Balyshev a.balyshev@partner.samsung.com