### PR TITLE
[one-cmds] Add Fold Gather pass to one-cmds

### DIFF
--- a/compiler/one-cmds/how-to-use-one-commands.txt
+++ b/compiler/one-cmds/how-to-use-one-commands.txt
@@ -155,6 +155,7 @@ Current transformation options are
 - fold_cast : This removes Cast operation which can be folded
 - fold_dequantize : This removes Dequantize operation which can be folded
 - fold_dwconv : This folds Depthwise Convolution operation which can be folded
+- fold_gather : This removes Gather operation which can be folded
 - fold_sparse_to_dense : This removes SparseToDense operation which can be folded
 - forward_reshape_to_unaryop: This will move Reshape after UnaryOp for centain condition
 - fuse_add_with_fully_connected: This fuses Add operator with the preceding FullyConnected operator if possible

--- a/compiler/one-cmds/onelib/constant.py
+++ b/compiler/one-cmds/onelib/constant.py
@@ -31,6 +31,7 @@ class CONSTANT:
         ('fold_cast', 'fold Cast op with constant input'),
         ('fold_dequantize', 'fold Dequantize op'),
         ('fold_dwconv', 'fold Depthwise Convolution op with constant inputs'),
+        ('fold_gather', 'fold Gather op'),
         ('fold_sparse_to_dense', 'fold SparseToDense op'),
         ('forward_reshape_to_unaryop', 'Forward Reshape op'),
         ('fuse_add_with_tconv', 'fuse Add op to Transposed'),


### PR DESCRIPTION
This pr adds fold gather pass to one-cmds. This pass can remove Gather operation which can be folded

draft: https://github.com/Samsung/ONE/pull/8682
for issue: https://github.com/Samsung/ONE/issues/8375

ONE-DCO-1.0-Signed-off-by: Artem Balyshev a.balyshev@partner.samsung.com