### PR TITLE
[onert/test] Fix reshape test

### DIFF
--- a/tests/nnfw_api/src/GenModelTests.cc
+++ b/tests/nnfw_api/src/GenModelTests.cc
@@ -308,7 +308,7 @@ TEST_F(GenModelTest, Reshape_without_shape_param)
   CircleGen::Shape new_shape_val{2, 2};
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
   _context->addTestCase(uniformTCD<int32_t>({{1, 2, 3, 4}, new_shape_val}, {{1, 2, 3, 4}}));
-  _context->output_sizes(0, sizeof(i32) * 4);
+  _context->output_sizes(0, sizeof(int32_t) * 4);
   _context->setBackends({"cpu" /* "acl_cl", "acl_neon" does not support dynamic tensor */});
 
   SUCCEED();


### PR DESCRIPTION
This commit fixes Reshape dynamic shape test output size.
Variable `i32` can be byte type by `flatc` 2.0.

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: #8713