### PR TITLE
[luci] Update dtype of LayerInfoMap

### DIFF
--- a/compiler/luci/pass/src/QuantizeDequantizeWeightsPass.cpp
+++ b/compiler/luci/pass/src/QuantizeDequantizeWeightsPass.cpp
@@ -440,7 +440,7 @@ bool QuantizeDequantizeWeightsPass::run(loco::Graph *g)
 
     // Return designated quantization dtype
     if (iter != info_by_name.end())
-      return iter->second->dtype;
+      return iter->second.dtype;
 
     // Return default quantization dtype
     return _ctx->output_model_dtype;
@@ -451,7 +451,7 @@ bool QuantizeDequantizeWeightsPass::run(loco::Graph *g)
 
     // Return designated quantization granularity
     if (iter != info_by_name.end())
-      return iter->second->granularity;
+      return iter->second.granularity;
 
     // Return default quantization granularity
     return _ctx->granularity;

--- a/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
+++ b/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
@@ -448,7 +448,7 @@ bool QuantizeWithMinMaxPass::run(loco::Graph *g)
 
     // Return designated quantization dtype
     if (iter != info_by_name.end())
-      return iter->second->dtype;
+      return iter->second.dtype;
 
     // Return default quantization dtype
     return _ctx->output_model_dtype;
@@ -459,7 +459,7 @@ bool QuantizeWithMinMaxPass::run(loco::Graph *g)
 
     // Return designated quantization granularity
     if (iter != info_by_name.end())
-      return iter->second->granularity;
+      return iter->second.granularity;
 
     // Return default quantization granularity
     return _ctx->granularity;

--- a/compiler/luci/pass/src/QuantizedModelVerifier.cpp
+++ b/compiler/luci/pass/src/QuantizedModelVerifier.cpp
@@ -38,7 +38,7 @@ void QuantizedModelVerifier::verify(loco::Graph *g)
 
     // Return designated quantization dtype
     if (iter != info_by_name.end())
-      return iter->second->dtype;
+      return iter->second.dtype;
 
     // Return default quantization dtype
     return _ctx->output_model_dtype;
@@ -49,7 +49,7 @@ void QuantizedModelVerifier::verify(loco::Graph *g)
 
     // Return designated quantization granularity
     if (iter != info_by_name.end())
-      return iter->second->granularity;
+      return iter->second.granularity;
 
     // Return default quantization granularity
     return _ctx->granularity;

--- a/compiler/luci/pass/src/helpers/LayerInfoMap.cpp
+++ b/compiler/luci/pass/src/helpers/LayerInfoMap.cpp
@@ -45,7 +45,7 @@ LayerInfoMap layer_info_map(loco::Graph *g, std::vector<LayerInfo> &layers_info)
                                    ". Check layer names in the quantization configuration file.");
         }
 
-        info_by_name[name] = &info;
+        info_by_name[name] = info;
         found = true;
         continue;
       }

--- a/compiler/luci/pass/src/helpers/LayerInfoMap.h
+++ b/compiler/luci/pass/src/helpers/LayerInfoMap.h
@@ -24,7 +24,7 @@
 namespace luci
 {
 
-using LayerInfoMap = std::unordered_map<std::string, luci::LayerInfo *>;
+using LayerInfoMap = std::unordered_map<std::string, luci::LayerInfo>;
 
 LayerInfoMap layer_info_map(loco::Graph *g, std::vector<LayerInfo> &layers_info);
 

--- a/compiler/luci/pass/src/helpers/LayerInfoMap.test.cpp
+++ b/compiler/luci/pass/src/helpers/LayerInfoMap.test.cpp
@@ -60,9 +60,9 @@ TEST(LayerInfoMapTest, simple_test)
   v.emplace_back(info);
   auto map = luci::layer_info_map(g.g(), v);
 
-  EXPECT_EQ("test", map["test"]->name);
-  EXPECT_EQ(loco::DataType::U8, map["test"]->dtype);
-  EXPECT_EQ(luci::QuantizationGranularity::ChannelWise, map["test"]->granularity);
+  EXPECT_EQ("test", map["test"].name);
+  EXPECT_EQ(loco::DataType::U8, map["test"].dtype);
+  EXPECT_EQ(luci::QuantizationGranularity::ChannelWise, map["test"].granularity);
 }
 
 TEST(LayerInfoMapTest, duplicate_name_NEG)


### PR DESCRIPTION
This updates LayerInfoMap to contain LayerInfo, not pointer.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/pull/8717#discussion_r833842255