### PR TITLE
[infra] Revise preset 20220323

### DIFF
--- a/infra/packaging/preset/20220323
+++ b/infra/packaging/preset/20220323
@@ -20,7 +20,7 @@ function preset_configure()
   # loco IR and related utilities
   REQUIRED_UNITS+=("loco" "locop" "locomotiv" "logo-core" "logo")
   # Flatbuffer I/O
-  REQUIRED_UNITS+=("mio-tflite" "mio-tflite260" "mio-circle" "mio-circle04")
+  REQUIRED_UNITS+=("mio-tflite" "mio-tflite260" "mio-circle04")
   # Circle compiler library (.circle -> .circle)
   REQUIRED_UNITS+=("luci")
   # Tools

--- a/infra/packaging/preset/20220323_windows
+++ b/infra/packaging/preset/20220323_windows
@@ -15,7 +15,7 @@ function preset_configure()
   # loco IR and related utilities
   REQUIRED_UNITS+=("loco" "locop" "locomotiv" "logo-core" "logo")
   # Flatbuffer I/O
-  REQUIRED_UNITS+=("mio-tflite" "mio-tflite260" "mio-circle" "mio-circle04")
+  REQUIRED_UNITS+=("mio-tflite" "mio-tflite260" "mio-circle04")
   # Circle compiler library (.circle -> .circle)
   REQUIRED_UNITS+=("luci")
   # Tools


### PR DESCRIPTION
This will revise preset 20220323 to exclude mio-circle as it is not used anymore.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>