### PR TITLE
[onert/frontend] Use flatc 2.0 for header generation

### DIFF
--- a/runtime/onert/frontend/circle_schema/include/circle_schema_generated.h
+++ b/runtime/onert/frontend/circle_schema/include/circle_schema_generated.h
@@ -378,7 +378,7 @@ struct MetadataBuilder;
 struct Model;
 struct ModelBuilder;
 
-enum TensorType
+enum TensorType : int8_t
 {
   TensorType_FLOAT32 = 0,
   TensorType_FLOAT16 = 1,
@@ -420,7 +420,7 @@ inline const char *EnumNameTensorType(TensorType e)
   return EnumNamesTensorType()[index];
 }
 
-enum QuantizationDetails
+enum QuantizationDetails : uint8_t
 {
   QuantizationDetails_NONE = 0,
   QuantizationDetails_CustomQuantization = 1,
@@ -465,7 +465,7 @@ bool VerifyQuantizationDetailsVector(flatbuffers::Verifier &verifier,
                                      const flatbuffers::Vector<flatbuffers::Offset<void>> *values,
                                      const flatbuffers::Vector<uint8_t> *types);
 
-enum DimensionType
+enum DimensionType : int8_t
 {
   DimensionType_DENSE = 0,
   DimensionType_SPARSE_CSR = 1,
@@ -493,7 +493,7 @@ inline const char *EnumNameDimensionType(DimensionType e)
   return EnumNamesDimensionType()[index];
 }
 
-enum SparseIndexVector
+enum SparseIndexVector : uint8_t
 {
   SparseIndexVector_NONE = 0,
   SparseIndexVector_Int32Vector = 1,
@@ -552,7 +552,7 @@ bool VerifySparseIndexVectorVector(flatbuffers::Verifier &verifier,
                                    const flatbuffers::Vector<flatbuffers::Offset<void>> *values,
                                    const flatbuffers::Vector<uint8_t> *types);
 
-enum BuiltinOperator
+enum BuiltinOperator : uint8_t
 {
   BuiltinOperator_ADD = 0,
   BuiltinOperator_AVERAGE_POOL_2D = 1,
@@ -1092,7 +1092,7 @@ inline const char *EnumNameBuiltinOperator(BuiltinOperator e)
   return EnumNamesBuiltinOperator()[index];
 }
 
-enum BuiltinOptions
+enum BuiltinOptions : uint8_t
 {
   BuiltinOptions_NONE = 0,
   BuiltinOptions_Conv2DOptions = 1,
@@ -2112,7 +2112,7 @@ bool VerifyBuiltinOptionsVector(flatbuffers::Verifier &verifier,
                                 const flatbuffers::Vector<flatbuffers::Offset<void>> *values,
                                 const flatbuffers::Vector<uint8_t> *types);
 
-enum Padding
+enum Padding : int8_t
 {
   Padding_SAME = 0,
   Padding_VALID = 1,
@@ -2140,7 +2140,7 @@ inline const char *EnumNamePadding(Padding e)
   return EnumNamesPadding()[index];
 }
 
-enum ActivationFunctionType
+enum ActivationFunctionType : int8_t
 {
   ActivationFunctionType_NONE = 0,
   ActivationFunctionType_RELU = 1,
@@ -2175,7 +2175,7 @@ inline const char *EnumNameActivationFunctionType(ActivationFunctionType e)
   return EnumNamesActivationFunctionType()[index];
 }
 
-enum LSHProjectionType
+enum LSHProjectionType : int8_t
 {
   LSHProjectionType_UNKNOWN = 0,
   LSHProjectionType_SPARSE = 1,
@@ -2205,7 +2205,7 @@ inline const char *EnumNameLSHProjectionType(LSHProjectionType e)
   return EnumNamesLSHProjectionType()[index];
 }
 
-enum FullyConnectedOptionsWeightsFormat
+enum FullyConnectedOptionsWeightsFormat : int8_t
 {
   FullyConnectedOptionsWeightsFormat_DEFAULT = 0,
   FullyConnectedOptionsWeightsFormat_SHUFFLED4x16INT8 = 1,
@@ -2237,7 +2237,7 @@ inline const char *EnumNameFullyConnectedOptionsWeightsFormat(FullyConnectedOpti
   }
 }
 
-enum LSTMKernelType
+enum LSTMKernelType : int8_t
 {
   LSTMKernelType_FULL = 0,
   LSTMKernelType_BASIC = 1,
@@ -2265,7 +2265,7 @@ inline const char *EnumNameLSTMKernelType(LSTMKernelType e)
   return EnumNamesLSTMKernelType()[index];
 }
 
-enum CombinerType
+enum CombinerType : int8_t
 {
   CombinerType_SUM = 0,
   CombinerType_MEAN = 1,
@@ -2294,7 +2294,7 @@ inline const char *EnumNameCombinerType(CombinerType e)
   return EnumNamesCombinerType()[index];
 }
 
-enum MirrorPadMode
+enum MirrorPadMode : int8_t
 {
   MirrorPadMode_REFLECT = 0,
   MirrorPadMode_SYMMETRIC = 1,
@@ -2322,7 +2322,7 @@ inline const char *EnumNameMirrorPadMode(MirrorPadMode e)
   return EnumNamesMirrorPadMode()[index];
 }
 
-enum CustomOptionsFormat
+enum CustomOptionsFormat : int8_t
 {
   CustomOptionsFormat_FLEXBUFFERS = 0,
   CustomOptionsFormat_MIN = CustomOptionsFormat_FLEXBUFFERS,
@@ -2349,7 +2349,7 @@ inline const char *EnumNameCustomOptionsFormat(CustomOptionsFormat e)
   return EnumNamesCustomOptionsFormat()[index];
 }
 
-enum DataFormat
+enum DataFormat : int8_t
 {
   DataFormat_CHANNELS_LAST = 0,
   DataFormat_CHANNELS_FIRST = 1,
@@ -2408,7 +2408,6 @@ struct CustomQuantizationBuilder
   {
     start_ = fbb_.StartTable();
   }
-  CustomQuantizationBuilder &operator=(const CustomQuantizationBuilder &);
   flatbuffers::Offset<CustomQuantization> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -2539,7 +2538,6 @@ struct QuantizationParametersBuilder
   {
     start_ = fbb_.StartTable();
   }
-  QuantizationParametersBuilder &operator=(const QuantizationParametersBuilder &);
   flatbuffers::Offset<QuantizationParameters> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -2613,7 +2611,6 @@ struct Int32VectorBuilder
   {
     start_ = fbb_.StartTable();
   }
-  Int32VectorBuilder &operator=(const Int32VectorBuilder &);
   flatbuffers::Offset<Int32Vector> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -2670,7 +2667,6 @@ struct Uint16VectorBuilder
   {
     start_ = fbb_.StartTable();
   }
-  Uint16VectorBuilder &operator=(const Uint16VectorBuilder &);
   flatbuffers::Offset<Uint16Vector> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -2731,7 +2727,6 @@ struct Uint8VectorBuilder
   {
     start_ = fbb_.StartTable();
   }
-  Uint8VectorBuilder &operator=(const Uint8VectorBuilder &);
   flatbuffers::Offset<Uint8Vector> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -2912,7 +2907,6 @@ struct DimensionMetadataBuilder
   {
     start_ = fbb_.StartTable();
   }
-  DimensionMetadataBuilder &operator=(const DimensionMetadataBuilder &);
   flatbuffers::Offset<DimensionMetadata> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -2994,7 +2988,6 @@ struct SparsityParametersBuilder
   {
     start_ = fbb_.StartTable();
   }
-  SparsityParametersBuilder &operator=(const SparsityParametersBuilder &);
   flatbuffers::Offset<SparsityParameters> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -3121,7 +3114,6 @@ struct TensorBuilder
   {
     start_ = fbb_.StartTable();
   }
-  TensorBuilder &operator=(const TensorBuilder &);
   flatbuffers::Offset<Tensor> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -3235,7 +3227,6 @@ struct Conv2DOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  Conv2DOptionsBuilder &operator=(const Conv2DOptionsBuilder &);
   flatbuffers::Offset<Conv2DOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -3330,7 +3321,6 @@ struct Pool2DOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  Pool2DOptionsBuilder &operator=(const Pool2DOptionsBuilder &);
   flatbuffers::Offset<Pool2DOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -3431,7 +3421,6 @@ struct DepthwiseConv2DOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  DepthwiseConv2DOptionsBuilder &operator=(const DepthwiseConv2DOptionsBuilder &);
   flatbuffers::Offset<DepthwiseConv2DOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -3509,7 +3498,6 @@ struct ConcatEmbeddingsOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  ConcatEmbeddingsOptionsBuilder &operator=(const ConcatEmbeddingsOptionsBuilder &);
   flatbuffers::Offset<ConcatEmbeddingsOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -3574,7 +3562,6 @@ struct LSHProjectionOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  LSHProjectionOptionsBuilder &operator=(const LSHProjectionOptionsBuilder &);
   flatbuffers::Offset<LSHProjectionOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -3639,7 +3626,6 @@ struct SVDFOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  SVDFOptionsBuilder &operator=(const SVDFOptionsBuilder &);
   flatbuffers::Offset<SVDFOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -3704,7 +3690,6 @@ struct RNNOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  RNNOptionsBuilder &operator=(const RNNOptionsBuilder &);
   flatbuffers::Offset<RNNOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -3775,7 +3760,6 @@ struct SequenceRNNOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  SequenceRNNOptionsBuilder &operator=(const SequenceRNNOptionsBuilder &);
   flatbuffers::Offset<SequenceRNNOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -3855,7 +3839,6 @@ struct BidirectionalSequenceRNNOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  BidirectionalSequenceRNNOptionsBuilder &operator=(const BidirectionalSequenceRNNOptionsBuilder &);
   flatbuffers::Offset<BidirectionalSequenceRNNOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -3941,7 +3924,6 @@ struct FullyConnectedOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  FullyConnectedOptionsBuilder &operator=(const FullyConnectedOptionsBuilder &);
   flatbuffers::Offset<FullyConnectedOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -3990,7 +3972,6 @@ struct SoftmaxOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  SoftmaxOptionsBuilder &operator=(const SoftmaxOptionsBuilder &);
   flatbuffers::Offset<SoftmaxOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -4043,7 +4024,6 @@ struct ConcatenationOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  ConcatenationOptionsBuilder &operator=(const ConcatenationOptionsBuilder &);
   flatbuffers::Offset<ConcatenationOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -4095,7 +4075,6 @@ struct AddOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  AddOptionsBuilder &operator=(const AddOptionsBuilder &);
   flatbuffers::Offset<AddOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -4146,7 +4125,6 @@ struct MulOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  MulOptionsBuilder &operator=(const MulOptionsBuilder &);
   flatbuffers::Offset<MulOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -4197,7 +4175,6 @@ struct L2NormOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  L2NormOptionsBuilder &operator=(const L2NormOptionsBuilder &);
   flatbuffers::Offset<L2NormOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -4263,8 +4240,6 @@ struct LocalResponseNormalizationOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  LocalResponseNormalizationOptionsBuilder &
-  operator=(const LocalResponseNormalizationOptionsBuilder &);
   flatbuffers::Offset<LocalResponseNormalizationOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -4353,7 +4328,6 @@ struct LSTMOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  LSTMOptionsBuilder &operator=(const LSTMOptionsBuilder &);
   flatbuffers::Offset<LSTMOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -4445,8 +4419,6 @@ struct UnidirectionalSequenceLSTMOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  UnidirectionalSequenceLSTMOptionsBuilder &
-  operator=(const UnidirectionalSequenceLSTMOptionsBuilder &);
   flatbuffers::Offset<UnidirectionalSequenceLSTMOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -4546,8 +4518,6 @@ struct BidirectionalSequenceLSTMOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  BidirectionalSequenceLSTMOptionsBuilder &
-  operator=(const BidirectionalSequenceLSTMOptionsBuilder &);
   flatbuffers::Offset<BidirectionalSequenceLSTMOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -4608,7 +4578,6 @@ struct ResizeBilinearOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  ResizeBilinearOptionsBuilder &operator=(const ResizeBilinearOptionsBuilder &);
   flatbuffers::Offset<ResizeBilinearOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -4656,7 +4625,6 @@ struct ResizeNearestNeighborOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  ResizeNearestNeighborOptionsBuilder &operator=(const ResizeNearestNeighborOptionsBuilder &);
   flatbuffers::Offset<ResizeNearestNeighborOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -4701,7 +4669,6 @@ struct CallOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  CallOptionsBuilder &operator=(const CallOptionsBuilder &);
   flatbuffers::Offset<CallOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -4736,7 +4703,6 @@ struct PadOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  PadOptionsBuilder &operator=(const PadOptionsBuilder &);
   flatbuffers::Offset<PadOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -4769,7 +4735,6 @@ struct PadV2OptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  PadV2OptionsBuilder &operator=(const PadV2OptionsBuilder &);
   flatbuffers::Offset<PadV2Options> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -4815,7 +4780,6 @@ struct ReshapeOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  ReshapeOptionsBuilder &operator=(const ReshapeOptionsBuilder &);
   flatbuffers::Offset<ReshapeOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -4859,7 +4823,6 @@ struct SpaceToBatchNDOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  SpaceToBatchNDOptionsBuilder &operator=(const SpaceToBatchNDOptionsBuilder &);
   flatbuffers::Offset<SpaceToBatchNDOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -4893,7 +4856,6 @@ struct BatchToSpaceNDOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  BatchToSpaceNDOptionsBuilder &operator=(const BatchToSpaceNDOptionsBuilder &);
   flatbuffers::Offset<BatchToSpaceNDOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -4951,7 +4913,6 @@ struct SkipGramOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  SkipGramOptionsBuilder &operator=(const SkipGramOptionsBuilder &);
   flatbuffers::Offset<SkipGramOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -4999,7 +4960,6 @@ struct SpaceToDepthOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  SpaceToDepthOptionsBuilder &operator=(const SpaceToDepthOptionsBuilder &);
   flatbuffers::Offset<SpaceToDepthOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -5044,7 +5004,6 @@ struct DepthToSpaceOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  DepthToSpaceOptionsBuilder &operator=(const DepthToSpaceOptionsBuilder &);
   flatbuffers::Offset<DepthToSpaceOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -5094,7 +5053,6 @@ struct SubOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  SubOptionsBuilder &operator=(const SubOptionsBuilder &);
   flatbuffers::Offset<SubOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -5145,7 +5103,6 @@ struct DivOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  DivOptionsBuilder &operator=(const DivOptionsBuilder &);
   flatbuffers::Offset<DivOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -5181,7 +5138,6 @@ struct TopKV2OptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  TopKV2OptionsBuilder &operator=(const TopKV2OptionsBuilder &);
   flatbuffers::Offset<TopKV2Options> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -5228,7 +5184,6 @@ struct EmbeddingLookupSparseOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  EmbeddingLookupSparseOptionsBuilder &operator=(const EmbeddingLookupSparseOptionsBuilder &);
   flatbuffers::Offset<EmbeddingLookupSparseOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -5271,7 +5226,6 @@ struct GatherOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  GatherOptionsBuilder &operator=(const GatherOptionsBuilder &);
   flatbuffers::Offset<GatherOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -5306,7 +5260,6 @@ struct TransposeOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  TransposeOptionsBuilder &operator=(const TransposeOptionsBuilder &);
   flatbuffers::Offset<TransposeOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -5340,7 +5293,6 @@ struct ExpOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  ExpOptionsBuilder &operator=(const ExpOptionsBuilder &);
   flatbuffers::Offset<ExpOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -5373,7 +5325,6 @@ struct CosOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  CosOptionsBuilder &operator=(const CosOptionsBuilder &);
   flatbuffers::Offset<CosOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -5416,7 +5367,6 @@ struct ReducerOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  ReducerOptionsBuilder &operator=(const ReducerOptionsBuilder &);
   flatbuffers::Offset<ReducerOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -5464,7 +5414,6 @@ struct SqueezeOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  SqueezeOptionsBuilder &operator=(const SqueezeOptionsBuilder &);
   flatbuffers::Offset<SqueezeOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -5518,7 +5467,6 @@ struct SplitOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  SplitOptionsBuilder &operator=(const SplitOptionsBuilder &);
   flatbuffers::Offset<SplitOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -5563,7 +5511,6 @@ struct SplitVOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  SplitVOptionsBuilder &operator=(const SplitVOptionsBuilder &);
   flatbuffers::Offset<SplitVOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -5635,7 +5582,6 @@ struct StridedSliceOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  StridedSliceOptionsBuilder &operator=(const StridedSliceOptionsBuilder &);
   flatbuffers::Offset<StridedSliceOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -5676,7 +5622,6 @@ struct LogSoftmaxOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  LogSoftmaxOptionsBuilder &operator=(const LogSoftmaxOptionsBuilder &);
   flatbuffers::Offset<LogSoftmaxOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -5732,7 +5677,6 @@ struct CastOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  CastOptionsBuilder &operator=(const CastOptionsBuilder &);
   flatbuffers::Offset<CastOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -5770,7 +5714,6 @@ struct DequantizeOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  DequantizeOptionsBuilder &operator=(const DequantizeOptionsBuilder &);
   flatbuffers::Offset<DequantizeOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -5804,7 +5747,6 @@ struct MaximumMinimumOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  MaximumMinimumOptionsBuilder &operator=(const MaximumMinimumOptionsBuilder &);
   flatbuffers::Offset<MaximumMinimumOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -5838,7 +5780,6 @@ struct TileOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  TileOptionsBuilder &operator=(const TileOptionsBuilder &);
   flatbuffers::Offset<TileOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -5884,7 +5825,6 @@ struct ArgMaxOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  ArgMaxOptionsBuilder &operator=(const ArgMaxOptionsBuilder &);
   flatbuffers::Offset<ArgMaxOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -5933,7 +5873,6 @@ struct ArgMinOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  ArgMinOptionsBuilder &operator=(const ArgMinOptionsBuilder &);
   flatbuffers::Offset<ArgMinOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -5969,7 +5908,6 @@ struct GreaterOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  GreaterOptionsBuilder &operator=(const GreaterOptionsBuilder &);
   flatbuffers::Offset<GreaterOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -6003,7 +5941,6 @@ struct GreaterEqualOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  GreaterEqualOptionsBuilder &operator=(const GreaterEqualOptionsBuilder &);
   flatbuffers::Offset<GreaterEqualOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -6037,7 +5974,6 @@ struct LessOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  LessOptionsBuilder &operator=(const LessOptionsBuilder &);
   flatbuffers::Offset<LessOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -6070,7 +6006,6 @@ struct LessEqualOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  LessEqualOptionsBuilder &operator=(const LessEqualOptionsBuilder &);
   flatbuffers::Offset<LessEqualOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -6104,7 +6039,6 @@ struct NegOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  NegOptionsBuilder &operator=(const NegOptionsBuilder &);
   flatbuffers::Offset<NegOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -6137,7 +6071,6 @@ struct SelectOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  SelectOptionsBuilder &operator=(const SelectOptionsBuilder &);
   flatbuffers::Offset<SelectOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -6170,7 +6103,6 @@ struct SliceOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  SliceOptionsBuilder &operator=(const SliceOptionsBuilder &);
   flatbuffers::Offset<SliceOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -6229,7 +6161,6 @@ struct TransposeConvOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  TransposeConvOptionsBuilder &operator=(const TransposeConvOptionsBuilder &);
   flatbuffers::Offset<TransposeConvOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -6268,7 +6199,6 @@ struct ExpandDimsOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  ExpandDimsOptionsBuilder &operator=(const ExpandDimsOptionsBuilder &);
   flatbuffers::Offset<ExpandDimsOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -6313,7 +6243,6 @@ struct SparseToDenseOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  SparseToDenseOptionsBuilder &operator=(const SparseToDenseOptionsBuilder &);
   flatbuffers::Offset<SparseToDenseOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -6348,7 +6277,6 @@ struct EqualOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  EqualOptionsBuilder &operator=(const EqualOptionsBuilder &);
   flatbuffers::Offset<EqualOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -6381,7 +6309,6 @@ struct NotEqualOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  NotEqualOptionsBuilder &operator=(const NotEqualOptionsBuilder &);
   flatbuffers::Offset<NotEqualOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -6428,7 +6355,6 @@ struct ShapeOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  ShapeOptionsBuilder &operator=(const ShapeOptionsBuilder &);
   flatbuffers::Offset<ShapeOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -6464,7 +6390,6 @@ struct RankOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  RankOptionsBuilder &operator=(const RankOptionsBuilder &);
   flatbuffers::Offset<RankOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -6497,7 +6422,6 @@ struct PowOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  PowOptionsBuilder &operator=(const PowOptionsBuilder &);
   flatbuffers::Offset<PowOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -6554,7 +6478,6 @@ struct FakeQuantOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  FakeQuantOptionsBuilder &operator=(const FakeQuantOptionsBuilder &);
   flatbuffers::Offset<FakeQuantOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -6606,7 +6529,6 @@ struct PackOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  PackOptionsBuilder &operator=(const PackOptionsBuilder &);
   flatbuffers::Offset<PackOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -6642,7 +6564,6 @@ struct LogicalOrOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  LogicalOrOptionsBuilder &operator=(const LogicalOrOptionsBuilder &);
   flatbuffers::Offset<LogicalOrOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -6683,7 +6604,6 @@ struct OneHotOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  OneHotOptionsBuilder &operator=(const OneHotOptionsBuilder &);
   flatbuffers::Offset<OneHotOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -6718,7 +6638,6 @@ struct AbsOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  AbsOptionsBuilder &operator=(const AbsOptionsBuilder &);
   flatbuffers::Offset<AbsOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -6751,7 +6670,6 @@ struct HardSwishOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  HardSwishOptionsBuilder &operator=(const HardSwishOptionsBuilder &);
   flatbuffers::Offset<HardSwishOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -6785,7 +6703,6 @@ struct LogicalAndOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  LogicalAndOptionsBuilder &operator=(const LogicalAndOptionsBuilder &);
   flatbuffers::Offset<LogicalAndOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -6819,7 +6736,6 @@ struct LogicalNotOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  LogicalNotOptionsBuilder &operator=(const LogicalNotOptionsBuilder &);
   flatbuffers::Offset<LogicalNotOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -6863,7 +6779,6 @@ struct UnpackOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  UnpackOptionsBuilder &operator=(const UnpackOptionsBuilder &);
   flatbuffers::Offset<UnpackOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -6899,7 +6814,6 @@ struct FloorDivOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  FloorDivOptionsBuilder &operator=(const FloorDivOptionsBuilder &);
   flatbuffers::Offset<FloorDivOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -6933,7 +6847,6 @@ struct SquareOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  SquareOptionsBuilder &operator=(const SquareOptionsBuilder &);
   flatbuffers::Offset<SquareOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -6966,7 +6879,6 @@ struct ZerosLikeOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  ZerosLikeOptionsBuilder &operator=(const ZerosLikeOptionsBuilder &);
   flatbuffers::Offset<ZerosLikeOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -7000,7 +6912,6 @@ struct FillOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  FillOptionsBuilder &operator=(const FillOptionsBuilder &);
   flatbuffers::Offset<FillOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -7033,7 +6944,6 @@ struct FloorModOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  FloorModOptionsBuilder &operator=(const FloorModOptionsBuilder &);
   flatbuffers::Offset<FloorModOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -7067,7 +6977,6 @@ struct RangeOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  RangeOptionsBuilder &operator=(const RangeOptionsBuilder &);
   flatbuffers::Offset<RangeOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -7107,7 +7016,6 @@ struct LeakyReluOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  LeakyReluOptionsBuilder &operator=(const LeakyReluOptionsBuilder &);
   flatbuffers::Offset<LeakyReluOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -7142,7 +7050,6 @@ struct SquaredDifferenceOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  SquaredDifferenceOptionsBuilder &operator=(const SquaredDifferenceOptionsBuilder &);
   flatbuffers::Offset<SquaredDifferenceOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -7189,7 +7096,6 @@ struct MirrorPadOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  MirrorPadOptionsBuilder &operator=(const MirrorPadOptionsBuilder &);
   flatbuffers::Offset<MirrorPadOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -7238,7 +7144,6 @@ struct UniqueOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  UniqueOptionsBuilder &operator=(const UniqueOptionsBuilder &);
   flatbuffers::Offset<UniqueOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -7274,7 +7179,6 @@ struct ReverseV2OptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  ReverseV2OptionsBuilder &operator=(const ReverseV2OptionsBuilder &);
   flatbuffers::Offset<ReverseV2Options> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -7308,7 +7212,6 @@ struct AddNOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  AddNOptionsBuilder &operator=(const AddNOptionsBuilder &);
   flatbuffers::Offset<AddNOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -7341,7 +7244,6 @@ struct GatherNdOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  GatherNdOptionsBuilder &operator=(const GatherNdOptionsBuilder &);
   flatbuffers::Offset<GatherNdOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -7375,7 +7277,6 @@ struct WhereOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  WhereOptionsBuilder &operator=(const WhereOptionsBuilder &);
   flatbuffers::Offset<WhereOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -7424,7 +7325,6 @@ struct ReverseSequenceOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  ReverseSequenceOptionsBuilder &operator=(const ReverseSequenceOptionsBuilder &);
   flatbuffers::Offset<ReverseSequenceOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -7461,7 +7361,6 @@ struct MatrixDiagOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  MatrixDiagOptionsBuilder &operator=(const MatrixDiagOptionsBuilder &);
   flatbuffers::Offset<MatrixDiagOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -7495,7 +7394,6 @@ struct QuantizeOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  QuantizeOptionsBuilder &operator=(const QuantizeOptionsBuilder &);
   flatbuffers::Offset<QuantizeOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -7529,7 +7427,6 @@ struct MatrixSetDiagOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  MatrixSetDiagOptionsBuilder &operator=(const MatrixSetDiagOptionsBuilder &);
   flatbuffers::Offset<MatrixSetDiagOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -7579,7 +7476,6 @@ struct IfOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  IfOptionsBuilder &operator=(const IfOptionsBuilder &);
   flatbuffers::Offset<IfOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -7632,7 +7528,6 @@ struct WhileOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  WhileOptionsBuilder &operator=(const WhileOptionsBuilder &);
   flatbuffers::Offset<WhileOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -7669,7 +7564,6 @@ struct NonMaxSuppressionV4OptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  NonMaxSuppressionV4OptionsBuilder &operator=(const NonMaxSuppressionV4OptionsBuilder &);
   flatbuffers::Offset<NonMaxSuppressionV4Options> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -7703,7 +7597,6 @@ struct NonMaxSuppressionV5OptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  NonMaxSuppressionV5OptionsBuilder &operator=(const NonMaxSuppressionV5OptionsBuilder &);
   flatbuffers::Offset<NonMaxSuppressionV5Options> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -7737,7 +7630,6 @@ struct ScatterNdOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  ScatterNdOptionsBuilder &operator=(const ScatterNdOptionsBuilder &);
   flatbuffers::Offset<ScatterNdOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -7771,7 +7663,6 @@ struct SelectV2OptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  SelectV2OptionsBuilder &operator=(const SelectV2OptionsBuilder &);
   flatbuffers::Offset<SelectV2Options> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -7805,7 +7696,6 @@ struct DensifyOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  DensifyOptionsBuilder &operator=(const DensifyOptionsBuilder &);
   flatbuffers::Offset<DensifyOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -7839,7 +7729,6 @@ struct SegmentSumOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  SegmentSumOptionsBuilder &operator=(const SegmentSumOptionsBuilder &);
   flatbuffers::Offset<SegmentSumOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -7891,7 +7780,6 @@ struct BatchMatMulOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  BatchMatMulOptionsBuilder &operator=(const BatchMatMulOptionsBuilder &);
   flatbuffers::Offset<BatchMatMulOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -7941,7 +7829,6 @@ struct BCQGatherOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  BCQGatherOptionsBuilder &operator=(const BCQGatherOptionsBuilder &);
   flatbuffers::Offset<BCQGatherOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -8000,7 +7887,6 @@ struct BCQFullyConnectedOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  BCQFullyConnectedOptionsBuilder &operator=(const BCQFullyConnectedOptionsBuilder &);
   flatbuffers::Offset<BCQFullyConnectedOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -8058,7 +7944,6 @@ struct InstanceNormOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  InstanceNormOptionsBuilder &operator=(const InstanceNormOptionsBuilder &);
   flatbuffers::Offset<InstanceNormOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -8124,7 +8009,6 @@ struct OperatorCodeBuilder
   {
     start_ = fbb_.StartTable();
   }
-  OperatorCodeBuilder &operator=(const OperatorCodeBuilder &);
   flatbuffers::Offset<OperatorCode> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -9566,7 +9450,6 @@ struct OperatorBuilder
   {
     start_ = fbb_.StartTable();
   }
-  OperatorBuilder &operator=(const OperatorBuilder &);
   flatbuffers::Offset<Operator> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -9705,7 +9588,6 @@ struct SubGraphBuilder
   {
     start_ = fbb_.StartTable();
   }
-  SubGraphBuilder &operator=(const SubGraphBuilder &);
   flatbuffers::Offset<SubGraph> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -9781,7 +9663,6 @@ struct BufferBuilder
   {
     start_ = fbb_.StartTable();
   }
-  BufferBuilder &operator=(const BufferBuilder &);
   flatbuffers::Offset<Buffer> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -9845,7 +9726,6 @@ struct MetadataBuilder
   {
     start_ = fbb_.StartTable();
   }
-  MetadataBuilder &operator=(const MetadataBuilder &);
   flatbuffers::Offset<Metadata> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -9967,7 +9847,6 @@ struct ModelBuilder
   {
     start_ = fbb_.StartTable();
   }
-  ModelBuilder &operator=(const ModelBuilder &);
   flatbuffers::Offset<Model> Finish()
   {
     const auto end = fbb_.EndTable(start_);

--- a/runtime/onert/frontend/tflite/src/tflite_schema_generated.h
+++ b/runtime/onert/frontend/tflite/src/tflite_schema_generated.h
@@ -26,236 +26,351 @@ namespace onert_tflite
 {
 
 struct CustomQuantization;
+struct CustomQuantizationBuilder;
 
 struct QuantizationParameters;
+struct QuantizationParametersBuilder;
 
 struct Int32Vector;
+struct Int32VectorBuilder;
 
 struct Uint16Vector;
+struct Uint16VectorBuilder;
 
 struct Uint8Vector;
+struct Uint8VectorBuilder;
 
 struct DimensionMetadata;
+struct DimensionMetadataBuilder;
 
 struct SparsityParameters;
+struct SparsityParametersBuilder;
 
 struct Tensor;
+struct TensorBuilder;
 
 struct Conv2DOptions;
+struct Conv2DOptionsBuilder;
 
 struct Pool2DOptions;
+struct Pool2DOptionsBuilder;
 
 struct DepthwiseConv2DOptions;
+struct DepthwiseConv2DOptionsBuilder;
 
 struct ConcatEmbeddingsOptions;
+struct ConcatEmbeddingsOptionsBuilder;
 
 struct LSHProjectionOptions;
+struct LSHProjectionOptionsBuilder;
 
 struct SVDFOptions;
+struct SVDFOptionsBuilder;
 
 struct RNNOptions;
+struct RNNOptionsBuilder;
 
 struct SequenceRNNOptions;
+struct SequenceRNNOptionsBuilder;
 
 struct BidirectionalSequenceRNNOptions;
+struct BidirectionalSequenceRNNOptionsBuilder;
 
 struct FullyConnectedOptions;
+struct FullyConnectedOptionsBuilder;
 
 struct SoftmaxOptions;
+struct SoftmaxOptionsBuilder;
 
 struct ConcatenationOptions;
+struct ConcatenationOptionsBuilder;
 
 struct AddOptions;
+struct AddOptionsBuilder;
 
 struct MulOptions;
+struct MulOptionsBuilder;
 
 struct L2NormOptions;
+struct L2NormOptionsBuilder;
 
 struct LocalResponseNormalizationOptions;
+struct LocalResponseNormalizationOptionsBuilder;
 
 struct LSTMOptions;
+struct LSTMOptionsBuilder;
 
 struct UnidirectionalSequenceLSTMOptions;
+struct UnidirectionalSequenceLSTMOptionsBuilder;
 
 struct BidirectionalSequenceLSTMOptions;
+struct BidirectionalSequenceLSTMOptionsBuilder;
 
 struct ResizeBilinearOptions;
+struct ResizeBilinearOptionsBuilder;
 
 struct ResizeNearestNeighborOptions;
+struct ResizeNearestNeighborOptionsBuilder;
 
 struct CallOptions;
+struct CallOptionsBuilder;
 
 struct PadOptions;
+struct PadOptionsBuilder;
 
 struct PadV2Options;
+struct PadV2OptionsBuilder;
 
 struct ReshapeOptions;
+struct ReshapeOptionsBuilder;
 
 struct SpaceToBatchNDOptions;
+struct SpaceToBatchNDOptionsBuilder;
 
 struct BatchToSpaceNDOptions;
+struct BatchToSpaceNDOptionsBuilder;
 
 struct SkipGramOptions;
+struct SkipGramOptionsBuilder;
 
 struct SpaceToDepthOptions;
+struct SpaceToDepthOptionsBuilder;
 
 struct DepthToSpaceOptions;
+struct DepthToSpaceOptionsBuilder;
 
 struct SubOptions;
+struct SubOptionsBuilder;
 
 struct DivOptions;
+struct DivOptionsBuilder;
 
 struct TopKV2Options;
+struct TopKV2OptionsBuilder;
 
 struct EmbeddingLookupSparseOptions;
+struct EmbeddingLookupSparseOptionsBuilder;
 
 struct GatherOptions;
+struct GatherOptionsBuilder;
 
 struct TransposeOptions;
+struct TransposeOptionsBuilder;
 
 struct ExpOptions;
+struct ExpOptionsBuilder;
 
 struct CosOptions;
+struct CosOptionsBuilder;
 
 struct ReducerOptions;
+struct ReducerOptionsBuilder;
 
 struct SqueezeOptions;
+struct SqueezeOptionsBuilder;
 
 struct SplitOptions;
+struct SplitOptionsBuilder;
 
 struct SplitVOptions;
+struct SplitVOptionsBuilder;
 
 struct StridedSliceOptions;
+struct StridedSliceOptionsBuilder;
 
 struct LogSoftmaxOptions;
+struct LogSoftmaxOptionsBuilder;
 
 struct CastOptions;
+struct CastOptionsBuilder;
 
 struct DequantizeOptions;
+struct DequantizeOptionsBuilder;
 
 struct MaximumMinimumOptions;
+struct MaximumMinimumOptionsBuilder;
 
 struct TileOptions;
+struct TileOptionsBuilder;
 
 struct ArgMaxOptions;
+struct ArgMaxOptionsBuilder;
 
 struct ArgMinOptions;
+struct ArgMinOptionsBuilder;
 
 struct GreaterOptions;
+struct GreaterOptionsBuilder;
 
 struct GreaterEqualOptions;
+struct GreaterEqualOptionsBuilder;
 
 struct LessOptions;
+struct LessOptionsBuilder;
 
 struct LessEqualOptions;
+struct LessEqualOptionsBuilder;
 
 struct NegOptions;
+struct NegOptionsBuilder;
 
 struct SelectOptions;
+struct SelectOptionsBuilder;
 
 struct SliceOptions;
+struct SliceOptionsBuilder;
 
 struct TransposeConvOptions;
+struct TransposeConvOptionsBuilder;
 
 struct ExpandDimsOptions;
+struct ExpandDimsOptionsBuilder;
 
 struct SparseToDenseOptions;
+struct SparseToDenseOptionsBuilder;
 
 struct EqualOptions;
+struct EqualOptionsBuilder;
 
 struct NotEqualOptions;
+struct NotEqualOptionsBuilder;
 
 struct ShapeOptions;
+struct ShapeOptionsBuilder;
 
 struct RankOptions;
+struct RankOptionsBuilder;
 
 struct PowOptions;
+struct PowOptionsBuilder;
 
 struct FakeQuantOptions;
+struct FakeQuantOptionsBuilder;
 
 struct PackOptions;
+struct PackOptionsBuilder;
 
 struct LogicalOrOptions;
+struct LogicalOrOptionsBuilder;
 
 struct OneHotOptions;
+struct OneHotOptionsBuilder;
 
 struct AbsOptions;
+struct AbsOptionsBuilder;
 
 struct HardSwishOptions;
+struct HardSwishOptionsBuilder;
 
 struct LogicalAndOptions;
+struct LogicalAndOptionsBuilder;
 
 struct LogicalNotOptions;
+struct LogicalNotOptionsBuilder;
 
 struct UnpackOptions;
+struct UnpackOptionsBuilder;
 
 struct FloorDivOptions;
+struct FloorDivOptionsBuilder;
 
 struct SquareOptions;
+struct SquareOptionsBuilder;
 
 struct ZerosLikeOptions;
+struct ZerosLikeOptionsBuilder;
 
 struct FillOptions;
+struct FillOptionsBuilder;
 
 struct FloorModOptions;
+struct FloorModOptionsBuilder;
 
 struct RangeOptions;
+struct RangeOptionsBuilder;
 
 struct LeakyReluOptions;
+struct LeakyReluOptionsBuilder;
 
 struct SquaredDifferenceOptions;
+struct SquaredDifferenceOptionsBuilder;
 
 struct MirrorPadOptions;
+struct MirrorPadOptionsBuilder;
 
 struct UniqueOptions;
+struct UniqueOptionsBuilder;
 
 struct ReverseV2Options;
+struct ReverseV2OptionsBuilder;
 
 struct AddNOptions;
+struct AddNOptionsBuilder;
 
 struct GatherNdOptions;
+struct GatherNdOptionsBuilder;
 
 struct WhereOptions;
+struct WhereOptionsBuilder;
 
 struct ReverseSequenceOptions;
+struct ReverseSequenceOptionsBuilder;
 
 struct MatrixDiagOptions;
+struct MatrixDiagOptionsBuilder;
 
 struct QuantizeOptions;
+struct QuantizeOptionsBuilder;
 
 struct MatrixSetDiagOptions;
+struct MatrixSetDiagOptionsBuilder;
 
 struct IfOptions;
+struct IfOptionsBuilder;
 
 struct WhileOptions;
+struct WhileOptionsBuilder;
 
 struct NonMaxSuppressionV4Options;
+struct NonMaxSuppressionV4OptionsBuilder;
 
 struct NonMaxSuppressionV5Options;
+struct NonMaxSuppressionV5OptionsBuilder;
 
 struct ScatterNdOptions;
+struct ScatterNdOptionsBuilder;
 
 struct SelectV2Options;
+struct SelectV2OptionsBuilder;
 
 struct DensifyOptions;
+struct DensifyOptionsBuilder;
 
 struct SegmentSumOptions;
+struct SegmentSumOptionsBuilder;
 
 struct BatchMatMulOptions;
+struct BatchMatMulOptionsBuilder;
 
 struct OperatorCode;
+struct OperatorCodeBuilder;
 
 struct Operator;
+struct OperatorBuilder;
 
 struct SubGraph;
+struct SubGraphBuilder;
 
 struct Buffer;
+struct BufferBuilder;
 
 struct Metadata;
+struct MetadataBuilder;
 
 struct Model;
+struct ModelBuilder;
 
-enum TensorType
+enum TensorType : int8_t
 {
   TensorType_FLOAT32 = 0,
   TensorType_FLOAT16 = 1,
@@ -283,19 +398,21 @@ inline const TensorType (&EnumValuesTensorType())[11]
 
 inline const char *const *EnumNamesTensorType()
 {
-  static const char *const names[] = {"FLOAT32",   "FLOAT16", "INT32",   "UINT8",
-                                      "INT64",     "STRING",  "BOOL",    "INT16",
-                                      "COMPLEX64", "INT8",    "FLOAT64", nullptr};
+  static const char *const names[12] = {"FLOAT32",   "FLOAT16", "INT32",   "UINT8",
+                                        "INT64",     "STRING",  "BOOL",    "INT16",
+                                        "COMPLEX64", "INT8",    "FLOAT64", nullptr};
   return names;
 }
 
 inline const char *EnumNameTensorType(TensorType e)
 {
-  const size_t index = static_cast<int>(e);
+  if (flatbuffers::IsOutRange(e, TensorType_FLOAT32, TensorType_FLOAT64))
+    return "";
+  const size_t index = static_cast<size_t>(e);
   return EnumNamesTensorType()[index];
 }
 
-enum QuantizationDetails
+enum QuantizationDetails : uint8_t
 {
   QuantizationDetails_NONE = 0,
   QuantizationDetails_CustomQuantization = 1,
@@ -312,13 +429,15 @@ inline const QuantizationDetails (&EnumValuesQuantizationDetails())[2]
 
 inline const char *const *EnumNamesQuantizationDetails()
 {
-  static const char *const names[] = {"NONE", "CustomQuantization", nullptr};
+  static const char *const names[3] = {"NONE", "CustomQuantization", nullptr};
   return names;
 }
 
 inline const char *EnumNameQuantizationDetails(QuantizationDetails e)
 {
-  const size_t index = static_cast<int>(e);
+  if (flatbuffers::IsOutRange(e, QuantizationDetails_NONE, QuantizationDetails_CustomQuantization))
+    return "";
+  const size_t index = static_cast<size_t>(e);
   return EnumNamesQuantizationDetails()[index];
 }
 
@@ -327,7 +446,7 @@ template <typename T> struct QuantizationDetailsTraits
   static const QuantizationDetails enum_value = QuantizationDetails_NONE;
 };
 
-template <> struct QuantizationDetailsTraits<CustomQuantization>
+template <> struct QuantizationDetailsTraits<onert_tflite::CustomQuantization>
 {
   static const QuantizationDetails enum_value = QuantizationDetails_CustomQuantization;
 };
@@ -338,7 +457,7 @@ bool VerifyQuantizationDetailsVector(flatbuffers::Verifier &verifier,
                                      const flatbuffers::Vector<flatbuffers::Offset<void>> *values,
                                      const flatbuffers::Vector<uint8_t> *types);
 
-enum DimensionType
+enum DimensionType : int8_t
 {
   DimensionType_DENSE = 0,
   DimensionType_SPARSE_CSR = 1,
@@ -354,17 +473,19 @@ inline const DimensionType (&EnumValuesDimensionType())[2]
 
 inline const char *const *EnumNamesDimensionType()
 {
-  static const char *const names[] = {"DENSE", "SPARSE_CSR", nullptr};
+  static const char *const names[3] = {"DENSE", "SPARSE_CSR", nullptr};
   return names;
 }
 
 inline const char *EnumNameDimensionType(DimensionType e)
 {
-  const size_t index = static_cast<int>(e);
+  if (flatbuffers::IsOutRange(e, DimensionType_DENSE, DimensionType_SPARSE_CSR))
+    return "";
+  const size_t index = static_cast<size_t>(e);
   return EnumNamesDimensionType()[index];
 }
 
-enum SparseIndexVector
+enum SparseIndexVector : uint8_t
 {
   SparseIndexVector_NONE = 0,
   SparseIndexVector_Int32Vector = 1,
@@ -384,14 +505,16 @@ inline const SparseIndexVector (&EnumValuesSparseIndexVector())[4]
 
 inline const char *const *EnumNamesSparseIndexVector()
 {
-  static const char *const names[] = {"NONE", "Int32Vector", "Uint16Vector", "Uint8Vector",
-                                      nullptr};
+  static const char *const names[5] = {"NONE", "Int32Vector", "Uint16Vector", "Uint8Vector",
+                                       nullptr};
   return names;
 }
 
 inline const char *EnumNameSparseIndexVector(SparseIndexVector e)
 {
-  const size_t index = static_cast<int>(e);
+  if (flatbuffers::IsOutRange(e, SparseIndexVector_NONE, SparseIndexVector_Uint8Vector))
+    return "";
+  const size_t index = static_cast<size_t>(e);
   return EnumNamesSparseIndexVector()[index];
 }
 
@@ -400,17 +523,17 @@ template <typename T> struct SparseIndexVectorTraits
   static const SparseIndexVector enum_value = SparseIndexVector_NONE;
 };
 
-template <> struct SparseIndexVectorTraits<Int32Vector>
+template <> struct SparseIndexVectorTraits<onert_tflite::Int32Vector>
 {
   static const SparseIndexVector enum_value = SparseIndexVector_Int32Vector;
 };
 
-template <> struct SparseIndexVectorTraits<Uint16Vector>
+template <> struct SparseIndexVectorTraits<onert_tflite::Uint16Vector>
 {
   static const SparseIndexVector enum_value = SparseIndexVector_Uint16Vector;
 };
 
-template <> struct SparseIndexVectorTraits<Uint8Vector>
+template <> struct SparseIndexVectorTraits<onert_tflite::Uint8Vector>
 {
   static const SparseIndexVector enum_value = SparseIndexVector_Uint8Vector;
 };
@@ -421,7 +544,7 @@ bool VerifySparseIndexVectorVector(flatbuffers::Verifier &verifier,
                                    const flatbuffers::Vector<flatbuffers::Offset<void>> *values,
                                    const flatbuffers::Vector<uint8_t> *types);
 
-enum BuiltinOperator
+enum BuiltinOperator : int8_t
 {
   BuiltinOperator_ADD = 0,
   BuiltinOperator_AVERAGE_POOL_2D = 1,
@@ -688,144 +811,146 @@ inline const BuiltinOperator (&EnumValuesBuiltinOperator())[127]
 
 inline const char *const *EnumNamesBuiltinOperator()
 {
-  static const char *const names[] = {"ADD",
-                                      "AVERAGE_POOL_2D",
-                                      "CONCATENATION",
-                                      "CONV_2D",
-                                      "DEPTHWISE_CONV_2D",
-                                      "DEPTH_TO_SPACE",
-                                      "DEQUANTIZE",
-                                      "EMBEDDING_LOOKUP",
-                                      "FLOOR",
-                                      "FULLY_CONNECTED",
-                                      "HASHTABLE_LOOKUP",
-                                      "L2_NORMALIZATION",
-                                      "L2_POOL_2D",
-                                      "LOCAL_RESPONSE_NORMALIZATION",
-                                      "LOGISTIC",
-                                      "LSH_PROJECTION",
-                                      "LSTM",
-                                      "MAX_POOL_2D",
-                                      "MUL",
-                                      "RELU",
-                                      "RELU_N1_TO_1",
-                                      "RELU6",
-                                      "RESHAPE",
-                                      "RESIZE_BILINEAR",
-                                      "RNN",
-                                      "SOFTMAX",
-                                      "SPACE_TO_DEPTH",
-                                      "SVDF",
-                                      "TANH",
-                                      "CONCAT_EMBEDDINGS",
-                                      "SKIP_GRAM",
-                                      "CALL",
-                                      "CUSTOM",
-                                      "EMBEDDING_LOOKUP_SPARSE",
-                                      "PAD",
-                                      "UNIDIRECTIONAL_SEQUENCE_RNN",
-                                      "GATHER",
-                                      "BATCH_TO_SPACE_ND",
-                                      "SPACE_TO_BATCH_ND",
-                                      "TRANSPOSE",
-                                      "MEAN",
-                                      "SUB",
-                                      "DIV",
-                                      "SQUEEZE",
-                                      "UNIDIRECTIONAL_SEQUENCE_LSTM",
-                                      "STRIDED_SLICE",
-                                      "BIDIRECTIONAL_SEQUENCE_RNN",
-                                      "EXP",
-                                      "TOPK_V2",
-                                      "SPLIT",
-                                      "LOG_SOFTMAX",
-                                      "DELEGATE",
-                                      "BIDIRECTIONAL_SEQUENCE_LSTM",
-                                      "CAST",
-                                      "PRELU",
-                                      "MAXIMUM",
-                                      "ARG_MAX",
-                                      "MINIMUM",
-                                      "LESS",
-                                      "NEG",
-                                      "PADV2",
-                                      "GREATER",
-                                      "GREATER_EQUAL",
-                                      "LESS_EQUAL",
-                                      "SELECT",
-                                      "SLICE",
-                                      "SIN",
-                                      "TRANSPOSE_CONV",
-                                      "SPARSE_TO_DENSE",
-                                      "TILE",
-                                      "EXPAND_DIMS",
-                                      "EQUAL",
-                                      "NOT_EQUAL",
-                                      "LOG",
-                                      "SUM",
-                                      "SQRT",
-                                      "RSQRT",
-                                      "SHAPE",
-                                      "POW",
-                                      "ARG_MIN",
-                                      "FAKE_QUANT",
-                                      "REDUCE_PROD",
-                                      "REDUCE_MAX",
-                                      "PACK",
-                                      "LOGICAL_OR",
-                                      "ONE_HOT",
-                                      "LOGICAL_AND",
-                                      "LOGICAL_NOT",
-                                      "UNPACK",
-                                      "REDUCE_MIN",
-                                      "FLOOR_DIV",
-                                      "REDUCE_ANY",
-                                      "SQUARE",
-                                      "ZEROS_LIKE",
-                                      "FILL",
-                                      "FLOOR_MOD",
-                                      "RANGE",
-                                      "RESIZE_NEAREST_NEIGHBOR",
-                                      "LEAKY_RELU",
-                                      "SQUARED_DIFFERENCE",
-                                      "MIRROR_PAD",
-                                      "ABS",
-                                      "SPLIT_V",
-                                      "UNIQUE",
-                                      "CEIL",
-                                      "REVERSE_V2",
-                                      "ADD_N",
-                                      "GATHER_ND",
-                                      "COS",
-                                      "WHERE",
-                                      "RANK",
-                                      "ELU",
-                                      "REVERSE_SEQUENCE",
-                                      "MATRIX_DIAG",
-                                      "QUANTIZE",
-                                      "MATRIX_SET_DIAG",
-                                      "ROUND",
-                                      "HARD_SWISH",
-                                      "IF",
-                                      "WHILE",
-                                      "NON_MAX_SUPPRESSION_V4",
-                                      "NON_MAX_SUPPRESSION_V5",
-                                      "SCATTER_ND",
-                                      "SELECT_V2",
-                                      "DENSIFY",
-                                      "SEGMENT_SUM",
-                                      "BATCH_MATMUL",
-                                      nullptr};
+  static const char *const names[128] = {"ADD",
+                                         "AVERAGE_POOL_2D",
+                                         "CONCATENATION",
+                                         "CONV_2D",
+                                         "DEPTHWISE_CONV_2D",
+                                         "DEPTH_TO_SPACE",
+                                         "DEQUANTIZE",
+                                         "EMBEDDING_LOOKUP",
+                                         "FLOOR",
+                                         "FULLY_CONNECTED",
+                                         "HASHTABLE_LOOKUP",
+                                         "L2_NORMALIZATION",
+                                         "L2_POOL_2D",
+                                         "LOCAL_RESPONSE_NORMALIZATION",
+                                         "LOGISTIC",
+                                         "LSH_PROJECTION",
+                                         "LSTM",
+                                         "MAX_POOL_2D",
+                                         "MUL",
+                                         "RELU",
+                                         "RELU_N1_TO_1",
+                                         "RELU6",
+                                         "RESHAPE",
+                                         "RESIZE_BILINEAR",
+                                         "RNN",
+                                         "SOFTMAX",
+                                         "SPACE_TO_DEPTH",
+                                         "SVDF",
+                                         "TANH",
+                                         "CONCAT_EMBEDDINGS",
+                                         "SKIP_GRAM",
+                                         "CALL",
+                                         "CUSTOM",
+                                         "EMBEDDING_LOOKUP_SPARSE",
+                                         "PAD",
+                                         "UNIDIRECTIONAL_SEQUENCE_RNN",
+                                         "GATHER",
+                                         "BATCH_TO_SPACE_ND",
+                                         "SPACE_TO_BATCH_ND",
+                                         "TRANSPOSE",
+                                         "MEAN",
+                                         "SUB",
+                                         "DIV",
+                                         "SQUEEZE",
+                                         "UNIDIRECTIONAL_SEQUENCE_LSTM",
+                                         "STRIDED_SLICE",
+                                         "BIDIRECTIONAL_SEQUENCE_RNN",
+                                         "EXP",
+                                         "TOPK_V2",
+                                         "SPLIT",
+                                         "LOG_SOFTMAX",
+                                         "DELEGATE",
+                                         "BIDIRECTIONAL_SEQUENCE_LSTM",
+                                         "CAST",
+                                         "PRELU",
+                                         "MAXIMUM",
+                                         "ARG_MAX",
+                                         "MINIMUM",
+                                         "LESS",
+                                         "NEG",
+                                         "PADV2",
+                                         "GREATER",
+                                         "GREATER_EQUAL",
+                                         "LESS_EQUAL",
+                                         "SELECT",
+                                         "SLICE",
+                                         "SIN",
+                                         "TRANSPOSE_CONV",
+                                         "SPARSE_TO_DENSE",
+                                         "TILE",
+                                         "EXPAND_DIMS",
+                                         "EQUAL",
+                                         "NOT_EQUAL",
+                                         "LOG",
+                                         "SUM",
+                                         "SQRT",
+                                         "RSQRT",
+                                         "SHAPE",
+                                         "POW",
+                                         "ARG_MIN",
+                                         "FAKE_QUANT",
+                                         "REDUCE_PROD",
+                                         "REDUCE_MAX",
+                                         "PACK",
+                                         "LOGICAL_OR",
+                                         "ONE_HOT",
+                                         "LOGICAL_AND",
+                                         "LOGICAL_NOT",
+                                         "UNPACK",
+                                         "REDUCE_MIN",
+                                         "FLOOR_DIV",
+                                         "REDUCE_ANY",
+                                         "SQUARE",
+                                         "ZEROS_LIKE",
+                                         "FILL",
+                                         "FLOOR_MOD",
+                                         "RANGE",
+                                         "RESIZE_NEAREST_NEIGHBOR",
+                                         "LEAKY_RELU",
+                                         "SQUARED_DIFFERENCE",
+                                         "MIRROR_PAD",
+                                         "ABS",
+                                         "SPLIT_V",
+                                         "UNIQUE",
+                                         "CEIL",
+                                         "REVERSE_V2",
+                                         "ADD_N",
+                                         "GATHER_ND",
+                                         "COS",
+                                         "WHERE",
+                                         "RANK",
+                                         "ELU",
+                                         "REVERSE_SEQUENCE",
+                                         "MATRIX_DIAG",
+                                         "QUANTIZE",
+                                         "MATRIX_SET_DIAG",
+                                         "ROUND",
+                                         "HARD_SWISH",
+                                         "IF",
+                                         "WHILE",
+                                         "NON_MAX_SUPPRESSION_V4",
+                                         "NON_MAX_SUPPRESSION_V5",
+                                         "SCATTER_ND",
+                                         "SELECT_V2",
+                                         "DENSIFY",
+                                         "SEGMENT_SUM",
+                                         "BATCH_MATMUL",
+                                         nullptr};
   return names;
 }
 
 inline const char *EnumNameBuiltinOperator(BuiltinOperator e)
 {
-  const size_t index = static_cast<int>(e);
+  if (flatbuffers::IsOutRange(e, BuiltinOperator_ADD, BuiltinOperator_BATCH_MATMUL))
+    return "";
+  const size_t index = static_cast<size_t>(e);
   return EnumNamesBuiltinOperator()[index];
 }
 
-enum BuiltinOptions
+enum BuiltinOptions : uint8_t
 {
   BuiltinOptions_NONE = 0,
   BuiltinOptions_Conv2DOptions = 1,
@@ -1042,115 +1167,117 @@ inline const BuiltinOptions (&EnumValuesBuiltinOptions())[102]
 
 inline const char *const *EnumNamesBuiltinOptions()
 {
-  static const char *const names[] = {"NONE",
-                                      "Conv2DOptions",
-                                      "DepthwiseConv2DOptions",
-                                      "ConcatEmbeddingsOptions",
-                                      "LSHProjectionOptions",
-                                      "Pool2DOptions",
-                                      "SVDFOptions",
-                                      "RNNOptions",
-                                      "FullyConnectedOptions",
-                                      "SoftmaxOptions",
-                                      "ConcatenationOptions",
-                                      "AddOptions",
-                                      "L2NormOptions",
-                                      "LocalResponseNormalizationOptions",
-                                      "LSTMOptions",
-                                      "ResizeBilinearOptions",
-                                      "CallOptions",
-                                      "ReshapeOptions",
-                                      "SkipGramOptions",
-                                      "SpaceToDepthOptions",
-                                      "EmbeddingLookupSparseOptions",
-                                      "MulOptions",
-                                      "PadOptions",
-                                      "GatherOptions",
-                                      "BatchToSpaceNDOptions",
-                                      "SpaceToBatchNDOptions",
-                                      "TransposeOptions",
-                                      "ReducerOptions",
-                                      "SubOptions",
-                                      "DivOptions",
-                                      "SqueezeOptions",
-                                      "SequenceRNNOptions",
-                                      "StridedSliceOptions",
-                                      "ExpOptions",
-                                      "TopKV2Options",
-                                      "SplitOptions",
-                                      "LogSoftmaxOptions",
-                                      "CastOptions",
-                                      "DequantizeOptions",
-                                      "MaximumMinimumOptions",
-                                      "ArgMaxOptions",
-                                      "LessOptions",
-                                      "NegOptions",
-                                      "PadV2Options",
-                                      "GreaterOptions",
-                                      "GreaterEqualOptions",
-                                      "LessEqualOptions",
-                                      "SelectOptions",
-                                      "SliceOptions",
-                                      "TransposeConvOptions",
-                                      "SparseToDenseOptions",
-                                      "TileOptions",
-                                      "ExpandDimsOptions",
-                                      "EqualOptions",
-                                      "NotEqualOptions",
-                                      "ShapeOptions",
-                                      "PowOptions",
-                                      "ArgMinOptions",
-                                      "FakeQuantOptions",
-                                      "PackOptions",
-                                      "LogicalOrOptions",
-                                      "OneHotOptions",
-                                      "LogicalAndOptions",
-                                      "LogicalNotOptions",
-                                      "UnpackOptions",
-                                      "FloorDivOptions",
-                                      "SquareOptions",
-                                      "ZerosLikeOptions",
-                                      "FillOptions",
-                                      "BidirectionalSequenceLSTMOptions",
-                                      "BidirectionalSequenceRNNOptions",
-                                      "UnidirectionalSequenceLSTMOptions",
-                                      "FloorModOptions",
-                                      "RangeOptions",
-                                      "ResizeNearestNeighborOptions",
-                                      "LeakyReluOptions",
-                                      "SquaredDifferenceOptions",
-                                      "MirrorPadOptions",
-                                      "AbsOptions",
-                                      "SplitVOptions",
-                                      "UniqueOptions",
-                                      "ReverseV2Options",
-                                      "AddNOptions",
-                                      "GatherNdOptions",
-                                      "CosOptions",
-                                      "WhereOptions",
-                                      "RankOptions",
-                                      "ReverseSequenceOptions",
-                                      "MatrixDiagOptions",
-                                      "QuantizeOptions",
-                                      "MatrixSetDiagOptions",
-                                      "HardSwishOptions",
-                                      "IfOptions",
-                                      "WhileOptions",
-                                      "DepthToSpaceOptions",
-                                      "NonMaxSuppressionV4Options",
-                                      "NonMaxSuppressionV5Options",
-                                      "ScatterNdOptions",
-                                      "SelectV2Options",
-                                      "DensifyOptions",
-                                      "SegmentSumOptions",
-                                      "BatchMatMulOptions",
-                                      nullptr};
+  static const char *const names[103] = {"NONE",
+                                         "Conv2DOptions",
+                                         "DepthwiseConv2DOptions",
+                                         "ConcatEmbeddingsOptions",
+                                         "LSHProjectionOptions",
+                                         "Pool2DOptions",
+                                         "SVDFOptions",
+                                         "RNNOptions",
+                                         "FullyConnectedOptions",
+                                         "SoftmaxOptions",
+                                         "ConcatenationOptions",
+                                         "AddOptions",
+                                         "L2NormOptions",
+                                         "LocalResponseNormalizationOptions",
+                                         "LSTMOptions",
+                                         "ResizeBilinearOptions",
+                                         "CallOptions",
+                                         "ReshapeOptions",
+                                         "SkipGramOptions",
+                                         "SpaceToDepthOptions",
+                                         "EmbeddingLookupSparseOptions",
+                                         "MulOptions",
+                                         "PadOptions",
+                                         "GatherOptions",
+                                         "BatchToSpaceNDOptions",
+                                         "SpaceToBatchNDOptions",
+                                         "TransposeOptions",
+                                         "ReducerOptions",
+                                         "SubOptions",
+                                         "DivOptions",
+                                         "SqueezeOptions",
+                                         "SequenceRNNOptions",
+                                         "StridedSliceOptions",
+                                         "ExpOptions",
+                                         "TopKV2Options",
+                                         "SplitOptions",
+                                         "LogSoftmaxOptions",
+                                         "CastOptions",
+                                         "DequantizeOptions",
+                                         "MaximumMinimumOptions",
+                                         "ArgMaxOptions",
+                                         "LessOptions",
+                                         "NegOptions",
+                                         "PadV2Options",
+                                         "GreaterOptions",
+                                         "GreaterEqualOptions",
+                                         "LessEqualOptions",
+                                         "SelectOptions",
+                                         "SliceOptions",
+                                         "TransposeConvOptions",
+                                         "SparseToDenseOptions",
+                                         "TileOptions",
+                                         "ExpandDimsOptions",
+                                         "EqualOptions",
+                                         "NotEqualOptions",
+                                         "ShapeOptions",
+                                         "PowOptions",
+                                         "ArgMinOptions",
+                                         "FakeQuantOptions",
+                                         "PackOptions",
+                                         "LogicalOrOptions",
+                                         "OneHotOptions",
+                                         "LogicalAndOptions",
+                                         "LogicalNotOptions",
+                                         "UnpackOptions",
+                                         "FloorDivOptions",
+                                         "SquareOptions",
+                                         "ZerosLikeOptions",
+                                         "FillOptions",
+                                         "BidirectionalSequenceLSTMOptions",
+                                         "BidirectionalSequenceRNNOptions",
+                                         "UnidirectionalSequenceLSTMOptions",
+                                         "FloorModOptions",
+                                         "RangeOptions",
+                                         "ResizeNearestNeighborOptions",
+                                         "LeakyReluOptions",
+                                         "SquaredDifferenceOptions",
+                                         "MirrorPadOptions",
+                                         "AbsOptions",
+                                         "SplitVOptions",
+                                         "UniqueOptions",
+                                         "ReverseV2Options",
+                                         "AddNOptions",
+                                         "GatherNdOptions",
+                                         "CosOptions",
+                                         "WhereOptions",
+                                         "RankOptions",
+                                         "ReverseSequenceOptions",
+                                         "MatrixDiagOptions",
+                                         "QuantizeOptions",
+                                         "MatrixSetDiagOptions",
+                                         "HardSwishOptions",
+                                         "IfOptions",
+                                         "WhileOptions",
+                                         "DepthToSpaceOptions",
+                                         "NonMaxSuppressionV4Options",
+                                         "NonMaxSuppressionV5Options",
+                                         "ScatterNdOptions",
+                                         "SelectV2Options",
+                                         "DensifyOptions",
+                                         "SegmentSumOptions",
+                                         "BatchMatMulOptions",
+                                         nullptr};
   return names;
 }
 
 inline const char *EnumNameBuiltinOptions(BuiltinOptions e)
 {
-  const size_t index = static_cast<int>(e);
+  if (flatbuffers::IsOutRange(e, BuiltinOptions_NONE, BuiltinOptions_BatchMatMulOptions))
+    return "";
+  const size_t index = static_cast<size_t>(e);
   return EnumNamesBuiltinOptions()[index];
 }
 
@@ -1159,507 +1286,507 @@ template <typename T> struct BuiltinOptionsTraits
   static const BuiltinOptions enum_value = BuiltinOptions_NONE;
 };
 
-template <> struct BuiltinOptionsTraits<Conv2DOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::Conv2DOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_Conv2DOptions;
 };
 
-template <> struct BuiltinOptionsTraits<DepthwiseConv2DOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::DepthwiseConv2DOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_DepthwiseConv2DOptions;
 };
 
-template <> struct BuiltinOptionsTraits<ConcatEmbeddingsOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::ConcatEmbeddingsOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_ConcatEmbeddingsOptions;
 };
 
-template <> struct BuiltinOptionsTraits<LSHProjectionOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::LSHProjectionOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_LSHProjectionOptions;
 };
 
-template <> struct BuiltinOptionsTraits<Pool2DOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::Pool2DOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_Pool2DOptions;
 };
 
-template <> struct BuiltinOptionsTraits<SVDFOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::SVDFOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_SVDFOptions;
 };
 
-template <> struct BuiltinOptionsTraits<RNNOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::RNNOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_RNNOptions;
 };
 
-template <> struct BuiltinOptionsTraits<FullyConnectedOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::FullyConnectedOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_FullyConnectedOptions;
 };
 
-template <> struct BuiltinOptionsTraits<SoftmaxOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::SoftmaxOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_SoftmaxOptions;
 };
 
-template <> struct BuiltinOptionsTraits<ConcatenationOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::ConcatenationOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_ConcatenationOptions;
 };
 
-template <> struct BuiltinOptionsTraits<AddOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::AddOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_AddOptions;
 };
 
-template <> struct BuiltinOptionsTraits<L2NormOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::L2NormOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_L2NormOptions;
 };
 
-template <> struct BuiltinOptionsTraits<LocalResponseNormalizationOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::LocalResponseNormalizationOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_LocalResponseNormalizationOptions;
 };
 
-template <> struct BuiltinOptionsTraits<LSTMOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::LSTMOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_LSTMOptions;
 };
 
-template <> struct BuiltinOptionsTraits<ResizeBilinearOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::ResizeBilinearOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_ResizeBilinearOptions;
 };
 
-template <> struct BuiltinOptionsTraits<CallOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::CallOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_CallOptions;
 };
 
-template <> struct BuiltinOptionsTraits<ReshapeOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::ReshapeOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_ReshapeOptions;
 };
 
-template <> struct BuiltinOptionsTraits<SkipGramOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::SkipGramOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_SkipGramOptions;
 };
 
-template <> struct BuiltinOptionsTraits<SpaceToDepthOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::SpaceToDepthOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_SpaceToDepthOptions;
 };
 
-template <> struct BuiltinOptionsTraits<EmbeddingLookupSparseOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::EmbeddingLookupSparseOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_EmbeddingLookupSparseOptions;
 };
 
-template <> struct BuiltinOptionsTraits<MulOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::MulOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_MulOptions;
 };
 
-template <> struct BuiltinOptionsTraits<PadOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::PadOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_PadOptions;
 };
 
-template <> struct BuiltinOptionsTraits<GatherOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::GatherOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_GatherOptions;
 };
 
-template <> struct BuiltinOptionsTraits<BatchToSpaceNDOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::BatchToSpaceNDOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_BatchToSpaceNDOptions;
 };
 
-template <> struct BuiltinOptionsTraits<SpaceToBatchNDOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::SpaceToBatchNDOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_SpaceToBatchNDOptions;
 };
 
-template <> struct BuiltinOptionsTraits<TransposeOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::TransposeOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_TransposeOptions;
 };
 
-template <> struct BuiltinOptionsTraits<ReducerOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::ReducerOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_ReducerOptions;
 };
 
-template <> struct BuiltinOptionsTraits<SubOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::SubOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_SubOptions;
 };
 
-template <> struct BuiltinOptionsTraits<DivOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::DivOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_DivOptions;
 };
 
-template <> struct BuiltinOptionsTraits<SqueezeOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::SqueezeOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_SqueezeOptions;
 };
 
-template <> struct BuiltinOptionsTraits<SequenceRNNOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::SequenceRNNOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_SequenceRNNOptions;
 };
 
-template <> struct BuiltinOptionsTraits<StridedSliceOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::StridedSliceOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_StridedSliceOptions;
 };
 
-template <> struct BuiltinOptionsTraits<ExpOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::ExpOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_ExpOptions;
 };
 
-template <> struct BuiltinOptionsTraits<TopKV2Options>
+template <> struct BuiltinOptionsTraits<onert_tflite::TopKV2Options>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_TopKV2Options;
 };
 
-template <> struct BuiltinOptionsTraits<SplitOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::SplitOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_SplitOptions;
 };
 
-template <> struct BuiltinOptionsTraits<LogSoftmaxOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::LogSoftmaxOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_LogSoftmaxOptions;
 };
 
-template <> struct BuiltinOptionsTraits<CastOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::CastOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_CastOptions;
 };
 
-template <> struct BuiltinOptionsTraits<DequantizeOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::DequantizeOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_DequantizeOptions;
 };
 
-template <> struct BuiltinOptionsTraits<MaximumMinimumOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::MaximumMinimumOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_MaximumMinimumOptions;
 };
 
-template <> struct BuiltinOptionsTraits<ArgMaxOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::ArgMaxOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_ArgMaxOptions;
 };
 
-template <> struct BuiltinOptionsTraits<LessOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::LessOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_LessOptions;
 };
 
-template <> struct BuiltinOptionsTraits<NegOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::NegOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_NegOptions;
 };
 
-template <> struct BuiltinOptionsTraits<PadV2Options>
+template <> struct BuiltinOptionsTraits<onert_tflite::PadV2Options>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_PadV2Options;
 };
 
-template <> struct BuiltinOptionsTraits<GreaterOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::GreaterOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_GreaterOptions;
 };
 
-template <> struct BuiltinOptionsTraits<GreaterEqualOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::GreaterEqualOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_GreaterEqualOptions;
 };
 
-template <> struct BuiltinOptionsTraits<LessEqualOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::LessEqualOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_LessEqualOptions;
 };
 
-template <> struct BuiltinOptionsTraits<SelectOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::SelectOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_SelectOptions;
 };
 
-template <> struct BuiltinOptionsTraits<SliceOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::SliceOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_SliceOptions;
 };
 
-template <> struct BuiltinOptionsTraits<TransposeConvOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::TransposeConvOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_TransposeConvOptions;
 };
 
-template <> struct BuiltinOptionsTraits<SparseToDenseOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::SparseToDenseOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_SparseToDenseOptions;
 };
 
-template <> struct BuiltinOptionsTraits<TileOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::TileOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_TileOptions;
 };
 
-template <> struct BuiltinOptionsTraits<ExpandDimsOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::ExpandDimsOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_ExpandDimsOptions;
 };
 
-template <> struct BuiltinOptionsTraits<EqualOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::EqualOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_EqualOptions;
 };
 
-template <> struct BuiltinOptionsTraits<NotEqualOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::NotEqualOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_NotEqualOptions;
 };
 
-template <> struct BuiltinOptionsTraits<ShapeOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::ShapeOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_ShapeOptions;
 };
 
-template <> struct BuiltinOptionsTraits<PowOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::PowOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_PowOptions;
 };
 
-template <> struct BuiltinOptionsTraits<ArgMinOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::ArgMinOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_ArgMinOptions;
 };
 
-template <> struct BuiltinOptionsTraits<FakeQuantOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::FakeQuantOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_FakeQuantOptions;
 };
 
-template <> struct BuiltinOptionsTraits<PackOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::PackOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_PackOptions;
 };
 
-template <> struct BuiltinOptionsTraits<LogicalOrOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::LogicalOrOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_LogicalOrOptions;
 };
 
-template <> struct BuiltinOptionsTraits<OneHotOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::OneHotOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_OneHotOptions;
 };
 
-template <> struct BuiltinOptionsTraits<LogicalAndOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::LogicalAndOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_LogicalAndOptions;
 };
 
-template <> struct BuiltinOptionsTraits<LogicalNotOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::LogicalNotOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_LogicalNotOptions;
 };
 
-template <> struct BuiltinOptionsTraits<UnpackOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::UnpackOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_UnpackOptions;
 };
 
-template <> struct BuiltinOptionsTraits<FloorDivOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::FloorDivOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_FloorDivOptions;
 };
 
-template <> struct BuiltinOptionsTraits<SquareOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::SquareOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_SquareOptions;
 };
 
-template <> struct BuiltinOptionsTraits<ZerosLikeOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::ZerosLikeOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_ZerosLikeOptions;
 };
 
-template <> struct BuiltinOptionsTraits<FillOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::FillOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_FillOptions;
 };
 
-template <> struct BuiltinOptionsTraits<BidirectionalSequenceLSTMOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::BidirectionalSequenceLSTMOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_BidirectionalSequenceLSTMOptions;
 };
 
-template <> struct BuiltinOptionsTraits<BidirectionalSequenceRNNOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::BidirectionalSequenceRNNOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_BidirectionalSequenceRNNOptions;
 };
 
-template <> struct BuiltinOptionsTraits<UnidirectionalSequenceLSTMOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::UnidirectionalSequenceLSTMOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_UnidirectionalSequenceLSTMOptions;
 };
 
-template <> struct BuiltinOptionsTraits<FloorModOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::FloorModOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_FloorModOptions;
 };
 
-template <> struct BuiltinOptionsTraits<RangeOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::RangeOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_RangeOptions;
 };
 
-template <> struct BuiltinOptionsTraits<ResizeNearestNeighborOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::ResizeNearestNeighborOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_ResizeNearestNeighborOptions;
 };
 
-template <> struct BuiltinOptionsTraits<LeakyReluOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::LeakyReluOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_LeakyReluOptions;
 };
 
-template <> struct BuiltinOptionsTraits<SquaredDifferenceOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::SquaredDifferenceOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_SquaredDifferenceOptions;
 };
 
-template <> struct BuiltinOptionsTraits<MirrorPadOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::MirrorPadOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_MirrorPadOptions;
 };
 
-template <> struct BuiltinOptionsTraits<AbsOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::AbsOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_AbsOptions;
 };
 
-template <> struct BuiltinOptionsTraits<SplitVOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::SplitVOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_SplitVOptions;
 };
 
-template <> struct BuiltinOptionsTraits<UniqueOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::UniqueOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_UniqueOptions;
 };
 
-template <> struct BuiltinOptionsTraits<ReverseV2Options>
+template <> struct BuiltinOptionsTraits<onert_tflite::ReverseV2Options>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_ReverseV2Options;
 };
 
-template <> struct BuiltinOptionsTraits<AddNOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::AddNOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_AddNOptions;
 };
 
-template <> struct BuiltinOptionsTraits<GatherNdOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::GatherNdOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_GatherNdOptions;
 };
 
-template <> struct BuiltinOptionsTraits<CosOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::CosOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_CosOptions;
 };
 
-template <> struct BuiltinOptionsTraits<WhereOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::WhereOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_WhereOptions;
 };
 
-template <> struct BuiltinOptionsTraits<RankOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::RankOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_RankOptions;
 };
 
-template <> struct BuiltinOptionsTraits<ReverseSequenceOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::ReverseSequenceOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_ReverseSequenceOptions;
 };
 
-template <> struct BuiltinOptionsTraits<MatrixDiagOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::MatrixDiagOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_MatrixDiagOptions;
 };
 
-template <> struct BuiltinOptionsTraits<QuantizeOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::QuantizeOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_QuantizeOptions;
 };
 
-template <> struct BuiltinOptionsTraits<MatrixSetDiagOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::MatrixSetDiagOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_MatrixSetDiagOptions;
 };
 
-template <> struct BuiltinOptionsTraits<HardSwishOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::HardSwishOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_HardSwishOptions;
 };
 
-template <> struct BuiltinOptionsTraits<IfOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::IfOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_IfOptions;
 };
 
-template <> struct BuiltinOptionsTraits<WhileOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::WhileOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_WhileOptions;
 };
 
-template <> struct BuiltinOptionsTraits<DepthToSpaceOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::DepthToSpaceOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_DepthToSpaceOptions;
 };
 
-template <> struct BuiltinOptionsTraits<NonMaxSuppressionV4Options>
+template <> struct BuiltinOptionsTraits<onert_tflite::NonMaxSuppressionV4Options>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_NonMaxSuppressionV4Options;
 };
 
-template <> struct BuiltinOptionsTraits<NonMaxSuppressionV5Options>
+template <> struct BuiltinOptionsTraits<onert_tflite::NonMaxSuppressionV5Options>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_NonMaxSuppressionV5Options;
 };
 
-template <> struct BuiltinOptionsTraits<ScatterNdOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::ScatterNdOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_ScatterNdOptions;
 };
 
-template <> struct BuiltinOptionsTraits<SelectV2Options>
+template <> struct BuiltinOptionsTraits<onert_tflite::SelectV2Options>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_SelectV2Options;
 };
 
-template <> struct BuiltinOptionsTraits<DensifyOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::DensifyOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_DensifyOptions;
 };
 
-template <> struct BuiltinOptionsTraits<SegmentSumOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::SegmentSumOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_SegmentSumOptions;
 };
 
-template <> struct BuiltinOptionsTraits<BatchMatMulOptions>
+template <> struct BuiltinOptionsTraits<onert_tflite::BatchMatMulOptions>
 {
   static const BuiltinOptions enum_value = BuiltinOptions_BatchMatMulOptions;
 };
@@ -1669,7 +1796,7 @@ bool VerifyBuiltinOptionsVector(flatbuffers::Verifier &verifier,
                                 const flatbuffers::Vector<flatbuffers::Offset<void>> *values,
                                 const flatbuffers::Vector<uint8_t> *types);
 
-enum Padding
+enum Padding : int8_t
 {
   Padding_SAME = 0,
   Padding_VALID = 1,
@@ -1685,17 +1812,19 @@ inline const Padding (&EnumValuesPadding())[2]
 
 inline const char *const *EnumNamesPadding()
 {
-  static const char *const names[] = {"SAME", "VALID", nullptr};
+  static const char *const names[3] = {"SAME", "VALID", nullptr};
   return names;
 }
 
 inline const char *EnumNamePadding(Padding e)
 {
-  const size_t index = static_cast<int>(e);
+  if (flatbuffers::IsOutRange(e, Padding_SAME, Padding_VALID))
+    return "";
+  const size_t index = static_cast<size_t>(e);
   return EnumNamesPadding()[index];
 }
 
-enum ActivationFunctionType
+enum ActivationFunctionType : int8_t
 {
   ActivationFunctionType_NONE = 0,
   ActivationFunctionType_RELU = 1,
@@ -1717,18 +1846,20 @@ inline const ActivationFunctionType (&EnumValuesActivationFunctionType())[6]
 
 inline const char *const *EnumNamesActivationFunctionType()
 {
-  static const char *const names[] = {"NONE", "RELU",     "RELU_N1_TO_1", "RELU6",
-                                      "TANH", "SIGN_BIT", nullptr};
+  static const char *const names[7] = {"NONE", "RELU",     "RELU_N1_TO_1", "RELU6",
+                                       "TANH", "SIGN_BIT", nullptr};
   return names;
 }
 
 inline const char *EnumNameActivationFunctionType(ActivationFunctionType e)
 {
-  const size_t index = static_cast<int>(e);
+  if (flatbuffers::IsOutRange(e, ActivationFunctionType_NONE, ActivationFunctionType_SIGN_BIT))
+    return "";
+  const size_t index = static_cast<size_t>(e);
   return EnumNamesActivationFunctionType()[index];
 }
 
-enum LSHProjectionType
+enum LSHProjectionType : int8_t
 {
   LSHProjectionType_UNKNOWN = 0,
   LSHProjectionType_SPARSE = 1,
@@ -1746,17 +1877,19 @@ inline const LSHProjectionType (&EnumValuesLSHProjectionType())[3]
 
 inline const char *const *EnumNamesLSHProjectionType()
 {
-  static const char *const names[] = {"UNKNOWN", "SPARSE", "DENSE", nullptr};
+  static const char *const names[4] = {"UNKNOWN", "SPARSE", "DENSE", nullptr};
   return names;
 }
 
 inline const char *EnumNameLSHProjectionType(LSHProjectionType e)
 {
-  const size_t index = static_cast<int>(e);
+  if (flatbuffers::IsOutRange(e, LSHProjectionType_UNKNOWN, LSHProjectionType_DENSE))
+    return "";
+  const size_t index = static_cast<size_t>(e);
   return EnumNamesLSHProjectionType()[index];
 }
 
-enum FullyConnectedOptionsWeightsFormat
+enum FullyConnectedOptionsWeightsFormat : int8_t
 {
   FullyConnectedOptionsWeightsFormat_DEFAULT = 0,
   FullyConnectedOptionsWeightsFormat_SHUFFLED4x16INT8 = 1,
@@ -1774,17 +1907,20 @@ inline const FullyConnectedOptionsWeightsFormat (&EnumValuesFullyConnectedOption
 
 inline const char *const *EnumNamesFullyConnectedOptionsWeightsFormat()
 {
-  static const char *const names[] = {"DEFAULT", "SHUFFLED4x16INT8", nullptr};
+  static const char *const names[3] = {"DEFAULT", "SHUFFLED4x16INT8", nullptr};
   return names;
 }
 
 inline const char *EnumNameFullyConnectedOptionsWeightsFormat(FullyConnectedOptionsWeightsFormat e)
 {
-  const size_t index = static_cast<int>(e);
+  if (flatbuffers::IsOutRange(e, FullyConnectedOptionsWeightsFormat_DEFAULT,
+                              FullyConnectedOptionsWeightsFormat_SHUFFLED4x16INT8))
+    return "";
+  const size_t index = static_cast<size_t>(e);
   return EnumNamesFullyConnectedOptionsWeightsFormat()[index];
 }
 
-enum LSTMKernelType
+enum LSTMKernelType : int8_t
 {
   LSTMKernelType_FULL = 0,
   LSTMKernelType_BASIC = 1,
@@ -1800,17 +1936,19 @@ inline const LSTMKernelType (&EnumValuesLSTMKernelType())[2]
 
 inline const char *const *EnumNamesLSTMKernelType()
 {
-  static const char *const names[] = {"FULL", "BASIC", nullptr};
+  static const char *const names[3] = {"FULL", "BASIC", nullptr};
   return names;
 }
 
 inline const char *EnumNameLSTMKernelType(LSTMKernelType e)
 {
-  const size_t index = static_cast<int>(e);
+  if (flatbuffers::IsOutRange(e, LSTMKernelType_FULL, LSTMKernelType_BASIC))
+    return "";
+  const size_t index = static_cast<size_t>(e);
   return EnumNamesLSTMKernelType()[index];
 }
 
-enum CombinerType
+enum CombinerType : int8_t
 {
   CombinerType_SUM = 0,
   CombinerType_MEAN = 1,
@@ -1827,17 +1965,19 @@ inline const CombinerType (&EnumValuesCombinerType())[3]
 
 inline const char *const *EnumNamesCombinerType()
 {
-  static const char *const names[] = {"SUM", "MEAN", "SQRTN", nullptr};
+  static const char *const names[4] = {"SUM", "MEAN", "SQRTN", nullptr};
   return names;
 }
 
 inline const char *EnumNameCombinerType(CombinerType e)
 {
-  const size_t index = static_cast<int>(e);
+  if (flatbuffers::IsOutRange(e, CombinerType_SUM, CombinerType_SQRTN))
+    return "";
+  const size_t index = static_cast<size_t>(e);
   return EnumNamesCombinerType()[index];
 }
 
-enum MirrorPadMode
+enum MirrorPadMode : int8_t
 {
   MirrorPadMode_REFLECT = 0,
   MirrorPadMode_SYMMETRIC = 1,
@@ -1853,17 +1993,19 @@ inline const MirrorPadMode (&EnumValuesMirrorPadMode())[2]
 
 inline const char *const *EnumNamesMirrorPadMode()
 {
-  static const char *const names[] = {"REFLECT", "SYMMETRIC", nullptr};
+  static const char *const names[3] = {"REFLECT", "SYMMETRIC", nullptr};
   return names;
 }
 
 inline const char *EnumNameMirrorPadMode(MirrorPadMode e)
 {
-  const size_t index = static_cast<int>(e);
+  if (flatbuffers::IsOutRange(e, MirrorPadMode_REFLECT, MirrorPadMode_SYMMETRIC))
+    return "";
+  const size_t index = static_cast<size_t>(e);
   return EnumNamesMirrorPadMode()[index];
 }
 
-enum CustomOptionsFormat
+enum CustomOptionsFormat : int8_t
 {
   CustomOptionsFormat_FLEXBUFFERS = 0,
   CustomOptionsFormat_MIN = CustomOptionsFormat_FLEXBUFFERS,
@@ -1878,19 +2020,22 @@ inline const CustomOptionsFormat (&EnumValuesCustomOptionsFormat())[1]
 
 inline const char *const *EnumNamesCustomOptionsFormat()
 {
-  static const char *const names[] = {"FLEXBUFFERS", nullptr};
+  static const char *const names[2] = {"FLEXBUFFERS", nullptr};
   return names;
 }
 
 inline const char *EnumNameCustomOptionsFormat(CustomOptionsFormat e)
 {
-  const size_t index = static_cast<int>(e);
+  if (flatbuffers::IsOutRange(e, CustomOptionsFormat_FLEXBUFFERS, CustomOptionsFormat_FLEXBUFFERS))
+    return "";
+  const size_t index = static_cast<size_t>(e);
   return EnumNamesCustomOptionsFormat()[index];
 }
 
 struct CustomQuantization FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef CustomQuantizationBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_CUSTOM = 4
   };
@@ -1907,6 +2052,7 @@ struct CustomQuantization FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct CustomQuantizationBuilder
 {
+  typedef CustomQuantization Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_custom(flatbuffers::Offset<flatbuffers::Vector<uint8_t>> custom)
@@ -1917,7 +2063,6 @@ struct CustomQuantizationBuilder
   {
     start_ = fbb_.StartTable();
   }
-  CustomQuantizationBuilder &operator=(const CustomQuantizationBuilder &);
   flatbuffers::Offset<CustomQuantization> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -1939,13 +2084,18 @@ inline flatbuffers::Offset<CustomQuantization>
 CreateCustomQuantizationDirect(flatbuffers::FlatBufferBuilder &_fbb,
                                const std::vector<uint8_t> *custom = nullptr)
 {
-  return onert_tflite::CreateCustomQuantization(_fbb,
-                                                custom ? _fbb.CreateVector<uint8_t>(*custom) : 0);
+  if (custom)
+  {
+    _fbb.ForceVectorAlignment(custom->size(), sizeof(uint8_t), 16);
+  }
+  auto custom__ = custom ? _fbb.CreateVector<uint8_t>(*custom) : 0;
+  return onert_tflite::CreateCustomQuantization(_fbb, custom__);
 }
 
 struct QuantizationParameters FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef QuantizationParametersBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_MIN = 4,
     VT_MAX = 6,
@@ -1971,16 +2121,16 @@ struct QuantizationParameters FLATBUFFERS_FINAL_CLASS : private flatbuffers::Tab
   {
     return GetPointer<const flatbuffers::Vector<int64_t> *>(VT_ZERO_POINT);
   }
-  QuantizationDetails details_type() const
+  onert_tflite::QuantizationDetails details_type() const
   {
-    return static_cast<QuantizationDetails>(GetField<uint8_t>(VT_DETAILS_TYPE, 0));
+    return static_cast<onert_tflite::QuantizationDetails>(GetField<uint8_t>(VT_DETAILS_TYPE, 0));
   }
   const void *details() const { return GetPointer<const void *>(VT_DETAILS); }
   template <typename T> const T *details_as() const;
-  const CustomQuantization *details_as_CustomQuantization() const
+  const onert_tflite::CustomQuantization *details_as_CustomQuantization() const
   {
-    return details_type() == QuantizationDetails_CustomQuantization
-             ? static_cast<const CustomQuantization *>(details())
+    return details_type() == onert_tflite::QuantizationDetails_CustomQuantization
+             ? static_cast<const onert_tflite::CustomQuantization *>(details())
              : nullptr;
   }
   int32_t quantized_dimension() const { return GetField<int32_t>(VT_QUANTIZED_DIMENSION, 0); }
@@ -1998,13 +2148,15 @@ struct QuantizationParameters FLATBUFFERS_FINAL_CLASS : private flatbuffers::Tab
 };
 
 template <>
-inline const CustomQuantization *QuantizationParameters::details_as<CustomQuantization>() const
+inline const onert_tflite::CustomQuantization *
+QuantizationParameters::details_as<onert_tflite::CustomQuantization>() const
 {
   return details_as_CustomQuantization();
 }
 
 struct QuantizationParametersBuilder
 {
+  typedef QuantizationParameters Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_min(flatbuffers::Offset<flatbuffers::Vector<float>> min)
@@ -2023,7 +2175,7 @@ struct QuantizationParametersBuilder
   {
     fbb_.AddOffset(QuantizationParameters::VT_ZERO_POINT, zero_point);
   }
-  void add_details_type(QuantizationDetails details_type)
+  void add_details_type(onert_tflite::QuantizationDetails details_type)
   {
     fbb_.AddElement<uint8_t>(QuantizationParameters::VT_DETAILS_TYPE,
                              static_cast<uint8_t>(details_type), 0);
@@ -2041,7 +2193,6 @@ struct QuantizationParametersBuilder
   {
     start_ = fbb_.StartTable();
   }
-  QuantizationParametersBuilder &operator=(const QuantizationParametersBuilder &);
   flatbuffers::Offset<QuantizationParameters> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -2050,14 +2201,13 @@ struct QuantizationParametersBuilder
   }
 };
 
-inline flatbuffers::Offset<QuantizationParameters>
-CreateQuantizationParameters(flatbuffers::FlatBufferBuilder &_fbb,
-                             flatbuffers::Offset<flatbuffers::Vector<float>> min = 0,
-                             flatbuffers::Offset<flatbuffers::Vector<float>> max = 0,
-                             flatbuffers::Offset<flatbuffers::Vector<float>> scale = 0,
-                             flatbuffers::Offset<flatbuffers::Vector<int64_t>> zero_point = 0,
-                             QuantizationDetails details_type = QuantizationDetails_NONE,
-                             flatbuffers::Offset<void> details = 0, int32_t quantized_dimension = 0)
+inline flatbuffers::Offset<QuantizationParameters> CreateQuantizationParameters(
+  flatbuffers::FlatBufferBuilder &_fbb, flatbuffers::Offset<flatbuffers::Vector<float>> min = 0,
+  flatbuffers::Offset<flatbuffers::Vector<float>> max = 0,
+  flatbuffers::Offset<flatbuffers::Vector<float>> scale = 0,
+  flatbuffers::Offset<flatbuffers::Vector<int64_t>> zero_point = 0,
+  onert_tflite::QuantizationDetails details_type = onert_tflite::QuantizationDetails_NONE,
+  flatbuffers::Offset<void> details = 0, int32_t quantized_dimension = 0)
 {
   QuantizationParametersBuilder builder_(_fbb);
   builder_.add_quantized_dimension(quantized_dimension);
@@ -2074,19 +2224,21 @@ inline flatbuffers::Offset<QuantizationParameters> CreateQuantizationParametersD
   flatbuffers::FlatBufferBuilder &_fbb, const std::vector<float> *min = nullptr,
   const std::vector<float> *max = nullptr, const std::vector<float> *scale = nullptr,
   const std::vector<int64_t> *zero_point = nullptr,
-  QuantizationDetails details_type = QuantizationDetails_NONE,
+  onert_tflite::QuantizationDetails details_type = onert_tflite::QuantizationDetails_NONE,
   flatbuffers::Offset<void> details = 0, int32_t quantized_dimension = 0)
 {
-  return onert_tflite::CreateQuantizationParameters(
-    _fbb, min ? _fbb.CreateVector<float>(*min) : 0, max ? _fbb.CreateVector<float>(*max) : 0,
-    scale ? _fbb.CreateVector<float>(*scale) : 0,
-    zero_point ? _fbb.CreateVector<int64_t>(*zero_point) : 0, details_type, details,
-    quantized_dimension);
+  auto min__ = min ? _fbb.CreateVector<float>(*min) : 0;
+  auto max__ = max ? _fbb.CreateVector<float>(*max) : 0;
+  auto scale__ = scale ? _fbb.CreateVector<float>(*scale) : 0;
+  auto zero_point__ = zero_point ? _fbb.CreateVector<int64_t>(*zero_point) : 0;
+  return onert_tflite::CreateQuantizationParameters(_fbb, min__, max__, scale__, zero_point__,
+                                                    details_type, details, quantized_dimension);
 }
 
 struct Int32Vector FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef Int32VectorBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_VALUES = 4
   };
@@ -2103,6 +2255,7 @@ struct Int32Vector FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct Int32VectorBuilder
 {
+  typedef Int32Vector Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_values(flatbuffers::Offset<flatbuffers::Vector<int32_t>> values)
@@ -2113,7 +2266,6 @@ struct Int32VectorBuilder
   {
     start_ = fbb_.StartTable();
   }
-  Int32VectorBuilder &operator=(const Int32VectorBuilder &);
   flatbuffers::Offset<Int32Vector> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -2135,12 +2287,14 @@ inline flatbuffers::Offset<Int32Vector>
 CreateInt32VectorDirect(flatbuffers::FlatBufferBuilder &_fbb,
                         const std::vector<int32_t> *values = nullptr)
 {
-  return onert_tflite::CreateInt32Vector(_fbb, values ? _fbb.CreateVector<int32_t>(*values) : 0);
+  auto values__ = values ? _fbb.CreateVector<int32_t>(*values) : 0;
+  return onert_tflite::CreateInt32Vector(_fbb, values__);
 }
 
 struct Uint16Vector FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef Uint16VectorBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_VALUES = 4
   };
@@ -2157,6 +2311,7 @@ struct Uint16Vector FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct Uint16VectorBuilder
 {
+  typedef Uint16Vector Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_values(flatbuffers::Offset<flatbuffers::Vector<uint16_t>> values)
@@ -2167,7 +2322,6 @@ struct Uint16VectorBuilder
   {
     start_ = fbb_.StartTable();
   }
-  Uint16VectorBuilder &operator=(const Uint16VectorBuilder &);
   flatbuffers::Offset<Uint16Vector> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -2189,12 +2343,18 @@ inline flatbuffers::Offset<Uint16Vector>
 CreateUint16VectorDirect(flatbuffers::FlatBufferBuilder &_fbb,
                          const std::vector<uint16_t> *values = nullptr)
 {
-  return onert_tflite::CreateUint16Vector(_fbb, values ? _fbb.CreateVector<uint16_t>(*values) : 0);
+  if (values)
+  {
+    _fbb.ForceVectorAlignment(values->size(), sizeof(uint16_t), 4);
+  }
+  auto values__ = values ? _fbb.CreateVector<uint16_t>(*values) : 0;
+  return onert_tflite::CreateUint16Vector(_fbb, values__);
 }
 
 struct Uint8Vector FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef Uint8VectorBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_VALUES = 4
   };
@@ -2211,6 +2371,7 @@ struct Uint8Vector FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct Uint8VectorBuilder
 {
+  typedef Uint8Vector Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_values(flatbuffers::Offset<flatbuffers::Vector<uint8_t>> values)
@@ -2221,7 +2382,6 @@ struct Uint8VectorBuilder
   {
     start_ = fbb_.StartTable();
   }
-  Uint8VectorBuilder &operator=(const Uint8VectorBuilder &);
   flatbuffers::Offset<Uint8Vector> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -2243,12 +2403,18 @@ inline flatbuffers::Offset<Uint8Vector>
 CreateUint8VectorDirect(flatbuffers::FlatBufferBuilder &_fbb,
                         const std::vector<uint8_t> *values = nullptr)
 {
-  return onert_tflite::CreateUint8Vector(_fbb, values ? _fbb.CreateVector<uint8_t>(*values) : 0);
+  if (values)
+  {
+    _fbb.ForceVectorAlignment(values->size(), sizeof(uint8_t), 4);
+  }
+  auto values__ = values ? _fbb.CreateVector<uint8_t>(*values) : 0;
+  return onert_tflite::CreateUint8Vector(_fbb, values__);
 }
 
 struct DimensionMetadata FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef DimensionMetadataBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_FORMAT = 4,
     VT_DENSE_SIZE = 6,
@@ -2257,57 +2423,59 @@ struct DimensionMetadata FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
     VT_ARRAY_INDICES_TYPE = 12,
     VT_ARRAY_INDICES = 14
   };
-  DimensionType format() const
+  onert_tflite::DimensionType format() const
   {
-    return static_cast<DimensionType>(GetField<int8_t>(VT_FORMAT, 0));
+    return static_cast<onert_tflite::DimensionType>(GetField<int8_t>(VT_FORMAT, 0));
   }
   int32_t dense_size() const { return GetField<int32_t>(VT_DENSE_SIZE, 0); }
-  SparseIndexVector array_segments_type() const
+  onert_tflite::SparseIndexVector array_segments_type() const
   {
-    return static_cast<SparseIndexVector>(GetField<uint8_t>(VT_ARRAY_SEGMENTS_TYPE, 0));
+    return static_cast<onert_tflite::SparseIndexVector>(
+      GetField<uint8_t>(VT_ARRAY_SEGMENTS_TYPE, 0));
   }
   const void *array_segments() const { return GetPointer<const void *>(VT_ARRAY_SEGMENTS); }
   template <typename T> const T *array_segments_as() const;
-  const Int32Vector *array_segments_as_Int32Vector() const
+  const onert_tflite::Int32Vector *array_segments_as_Int32Vector() const
   {
-    return array_segments_type() == SparseIndexVector_Int32Vector
-             ? static_cast<const Int32Vector *>(array_segments())
+    return array_segments_type() == onert_tflite::SparseIndexVector_Int32Vector
+             ? static_cast<const onert_tflite::Int32Vector *>(array_segments())
              : nullptr;
   }
-  const Uint16Vector *array_segments_as_Uint16Vector() const
+  const onert_tflite::Uint16Vector *array_segments_as_Uint16Vector() const
   {
-    return array_segments_type() == SparseIndexVector_Uint16Vector
-             ? static_cast<const Uint16Vector *>(array_segments())
+    return array_segments_type() == onert_tflite::SparseIndexVector_Uint16Vector
+             ? static_cast<const onert_tflite::Uint16Vector *>(array_segments())
              : nullptr;
   }
-  const Uint8Vector *array_segments_as_Uint8Vector() const
+  const onert_tflite::Uint8Vector *array_segments_as_Uint8Vector() const
   {
-    return array_segments_type() == SparseIndexVector_Uint8Vector
-             ? static_cast<const Uint8Vector *>(array_segments())
+    return array_segments_type() == onert_tflite::SparseIndexVector_Uint8Vector
+             ? static_cast<const onert_tflite::Uint8Vector *>(array_segments())
              : nullptr;
   }
-  SparseIndexVector array_indices_type() const
+  onert_tflite::SparseIndexVector array_indices_type() const
   {
-    return static_cast<SparseIndexVector>(GetField<uint8_t>(VT_ARRAY_INDICES_TYPE, 0));
+    return static_cast<onert_tflite::SparseIndexVector>(
+      GetField<uint8_t>(VT_ARRAY_INDICES_TYPE, 0));
   }
   const void *array_indices() const { return GetPointer<const void *>(VT_ARRAY_INDICES); }
   template <typename T> const T *array_indices_as() const;
-  const Int32Vector *array_indices_as_Int32Vector() const
+  const onert_tflite::Int32Vector *array_indices_as_Int32Vector() const
   {
-    return array_indices_type() == SparseIndexVector_Int32Vector
-             ? static_cast<const Int32Vector *>(array_indices())
+    return array_indices_type() == onert_tflite::SparseIndexVector_Int32Vector
+             ? static_cast<const onert_tflite::Int32Vector *>(array_indices())
              : nullptr;
   }
-  const Uint16Vector *array_indices_as_Uint16Vector() const
+  const onert_tflite::Uint16Vector *array_indices_as_Uint16Vector() const
   {
-    return array_indices_type() == SparseIndexVector_Uint16Vector
-             ? static_cast<const Uint16Vector *>(array_indices())
+    return array_indices_type() == onert_tflite::SparseIndexVector_Uint16Vector
+             ? static_cast<const onert_tflite::Uint16Vector *>(array_indices())
              : nullptr;
   }
-  const Uint8Vector *array_indices_as_Uint8Vector() const
+  const onert_tflite::Uint8Vector *array_indices_as_Uint8Vector() const
   {
-    return array_indices_type() == SparseIndexVector_Uint8Vector
-             ? static_cast<const Uint8Vector *>(array_indices())
+    return array_indices_type() == onert_tflite::SparseIndexVector_Uint8Vector
+             ? static_cast<const onert_tflite::Uint8Vector *>(array_indices())
              : nullptr;
   }
   bool Verify(flatbuffers::Verifier &verifier) const
@@ -2324,41 +2492,54 @@ struct DimensionMetadata FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
   }
 };
 
-template <> inline const Int32Vector *DimensionMetadata::array_segments_as<Int32Vector>() const
+template <>
+inline const onert_tflite::Int32Vector *
+DimensionMetadata::array_segments_as<onert_tflite::Int32Vector>() const
 {
   return array_segments_as_Int32Vector();
 }
 
-template <> inline const Uint16Vector *DimensionMetadata::array_segments_as<Uint16Vector>() const
+template <>
+inline const onert_tflite::Uint16Vector *
+DimensionMetadata::array_segments_as<onert_tflite::Uint16Vector>() const
 {
   return array_segments_as_Uint16Vector();
 }
 
-template <> inline const Uint8Vector *DimensionMetadata::array_segments_as<Uint8Vector>() const
+template <>
+inline const onert_tflite::Uint8Vector *
+DimensionMetadata::array_segments_as<onert_tflite::Uint8Vector>() const
 {
   return array_segments_as_Uint8Vector();
 }
 
-template <> inline const Int32Vector *DimensionMetadata::array_indices_as<Int32Vector>() const
+template <>
+inline const onert_tflite::Int32Vector *
+DimensionMetadata::array_indices_as<onert_tflite::Int32Vector>() const
 {
   return array_indices_as_Int32Vector();
 }
 
-template <> inline const Uint16Vector *DimensionMetadata::array_indices_as<Uint16Vector>() const
+template <>
+inline const onert_tflite::Uint16Vector *
+DimensionMetadata::array_indices_as<onert_tflite::Uint16Vector>() const
 {
   return array_indices_as_Uint16Vector();
 }
 
-template <> inline const Uint8Vector *DimensionMetadata::array_indices_as<Uint8Vector>() const
+template <>
+inline const onert_tflite::Uint8Vector *
+DimensionMetadata::array_indices_as<onert_tflite::Uint8Vector>() const
 {
   return array_indices_as_Uint8Vector();
 }
 
 struct DimensionMetadataBuilder
 {
+  typedef DimensionMetadata Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_format(DimensionType format)
+  void add_format(onert_tflite::DimensionType format)
   {
     fbb_.AddElement<int8_t>(DimensionMetadata::VT_FORMAT, static_cast<int8_t>(format), 0);
   }
@@ -2366,7 +2547,7 @@ struct DimensionMetadataBuilder
   {
     fbb_.AddElement<int32_t>(DimensionMetadata::VT_DENSE_SIZE, dense_size, 0);
   }
-  void add_array_segments_type(SparseIndexVector array_segments_type)
+  void add_array_segments_type(onert_tflite::SparseIndexVector array_segments_type)
   {
     fbb_.AddElement<uint8_t>(DimensionMetadata::VT_ARRAY_SEGMENTS_TYPE,
                              static_cast<uint8_t>(array_segments_type), 0);
@@ -2375,7 +2556,7 @@ struct DimensionMetadataBuilder
   {
     fbb_.AddOffset(DimensionMetadata::VT_ARRAY_SEGMENTS, array_segments);
   }
-  void add_array_indices_type(SparseIndexVector array_indices_type)
+  void add_array_indices_type(onert_tflite::SparseIndexVector array_indices_type)
   {
     fbb_.AddElement<uint8_t>(DimensionMetadata::VT_ARRAY_INDICES_TYPE,
                              static_cast<uint8_t>(array_indices_type), 0);
@@ -2388,7 +2569,6 @@ struct DimensionMetadataBuilder
   {
     start_ = fbb_.StartTable();
   }
-  DimensionMetadataBuilder &operator=(const DimensionMetadataBuilder &);
   flatbuffers::Offset<DimensionMetadata> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -2397,13 +2577,13 @@ struct DimensionMetadataBuilder
   }
 };
 
-inline flatbuffers::Offset<DimensionMetadata>
-CreateDimensionMetadata(flatbuffers::FlatBufferBuilder &_fbb,
-                        DimensionType format = DimensionType_DENSE, int32_t dense_size = 0,
-                        SparseIndexVector array_segments_type = SparseIndexVector_NONE,
-                        flatbuffers::Offset<void> array_segments = 0,
-                        SparseIndexVector array_indices_type = SparseIndexVector_NONE,
-                        flatbuffers::Offset<void> array_indices = 0)
+inline flatbuffers::Offset<DimensionMetadata> CreateDimensionMetadata(
+  flatbuffers::FlatBufferBuilder &_fbb,
+  onert_tflite::DimensionType format = onert_tflite::DimensionType_DENSE, int32_t dense_size = 0,
+  onert_tflite::SparseIndexVector array_segments_type = onert_tflite::SparseIndexVector_NONE,
+  flatbuffers::Offset<void> array_segments = 0,
+  onert_tflite::SparseIndexVector array_indices_type = onert_tflite::SparseIndexVector_NONE,
+  flatbuffers::Offset<void> array_indices = 0)
 {
   DimensionMetadataBuilder builder_(_fbb);
   builder_.add_array_indices(array_indices);
@@ -2417,7 +2597,8 @@ CreateDimensionMetadata(flatbuffers::FlatBufferBuilder &_fbb,
 
 struct SparsityParameters FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef SparsityParametersBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_TRAVERSAL_ORDER = 4,
     VT_BLOCK_MAP = 6,
@@ -2431,9 +2612,11 @@ struct SparsityParameters FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
   {
     return GetPointer<const flatbuffers::Vector<int32_t> *>(VT_BLOCK_MAP);
   }
-  const flatbuffers::Vector<flatbuffers::Offset<DimensionMetadata>> *dim_metadata() const
+  const flatbuffers::Vector<flatbuffers::Offset<onert_tflite::DimensionMetadata>> *
+  dim_metadata() const
   {
-    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<DimensionMetadata>> *>(
+    return GetPointer<
+      const flatbuffers::Vector<flatbuffers::Offset<onert_tflite::DimensionMetadata>> *>(
       VT_DIM_METADATA);
   }
   bool Verify(flatbuffers::Verifier &verifier) const
@@ -2448,6 +2631,7 @@ struct SparsityParameters FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct SparsityParametersBuilder
 {
+  typedef SparsityParameters Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_traversal_order(flatbuffers::Offset<flatbuffers::Vector<int32_t>> traversal_order)
@@ -2459,7 +2643,8 @@ struct SparsityParametersBuilder
     fbb_.AddOffset(SparsityParameters::VT_BLOCK_MAP, block_map);
   }
   void add_dim_metadata(
-    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<DimensionMetadata>>> dim_metadata)
+    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<onert_tflite::DimensionMetadata>>>
+      dim_metadata)
   {
     fbb_.AddOffset(SparsityParameters::VT_DIM_METADATA, dim_metadata);
   }
@@ -2467,7 +2652,6 @@ struct SparsityParametersBuilder
   {
     start_ = fbb_.StartTable();
   }
-  SparsityParametersBuilder &operator=(const SparsityParametersBuilder &);
   flatbuffers::Offset<SparsityParameters> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -2480,7 +2664,8 @@ inline flatbuffers::Offset<SparsityParameters> CreateSparsityParameters(
   flatbuffers::FlatBufferBuilder &_fbb,
   flatbuffers::Offset<flatbuffers::Vector<int32_t>> traversal_order = 0,
   flatbuffers::Offset<flatbuffers::Vector<int32_t>> block_map = 0,
-  flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<DimensionMetadata>>> dim_metadata = 0)
+  flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<onert_tflite::DimensionMetadata>>>
+    dim_metadata = 0)
 {
   SparsityParametersBuilder builder_(_fbb);
   builder_.add_dim_metadata(dim_metadata);
@@ -2492,17 +2677,22 @@ inline flatbuffers::Offset<SparsityParameters> CreateSparsityParameters(
 inline flatbuffers::Offset<SparsityParameters> CreateSparsityParametersDirect(
   flatbuffers::FlatBufferBuilder &_fbb, const std::vector<int32_t> *traversal_order = nullptr,
   const std::vector<int32_t> *block_map = nullptr,
-  const std::vector<flatbuffers::Offset<DimensionMetadata>> *dim_metadata = nullptr)
+  const std::vector<flatbuffers::Offset<onert_tflite::DimensionMetadata>> *dim_metadata = nullptr)
 {
-  return onert_tflite::CreateSparsityParameters(
-    _fbb, traversal_order ? _fbb.CreateVector<int32_t>(*traversal_order) : 0,
-    block_map ? _fbb.CreateVector<int32_t>(*block_map) : 0,
-    dim_metadata ? _fbb.CreateVector<flatbuffers::Offset<DimensionMetadata>>(*dim_metadata) : 0);
+  auto traversal_order__ = traversal_order ? _fbb.CreateVector<int32_t>(*traversal_order) : 0;
+  auto block_map__ = block_map ? _fbb.CreateVector<int32_t>(*block_map) : 0;
+  auto dim_metadata__ =
+    dim_metadata
+      ? _fbb.CreateVector<flatbuffers::Offset<onert_tflite::DimensionMetadata>>(*dim_metadata)
+      : 0;
+  return onert_tflite::CreateSparsityParameters(_fbb, traversal_order__, block_map__,
+                                                dim_metadata__);
 }
 
 struct Tensor FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef TensorBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_SHAPE = 4,
     VT_TYPE = 6,
@@ -2517,20 +2707,23 @@ struct Tensor FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
   {
     return GetPointer<const flatbuffers::Vector<int32_t> *>(VT_SHAPE);
   }
-  TensorType type() const { return static_cast<TensorType>(GetField<int8_t>(VT_TYPE, 0)); }
+  onert_tflite::TensorType type() const
+  {
+    return static_cast<onert_tflite::TensorType>(GetField<int8_t>(VT_TYPE, 0));
+  }
   uint32_t buffer() const { return GetField<uint32_t>(VT_BUFFER, 0); }
   const flatbuffers::String *name() const
   {
     return GetPointer<const flatbuffers::String *>(VT_NAME);
   }
-  const QuantizationParameters *quantization() const
+  const onert_tflite::QuantizationParameters *quantization() const
   {
-    return GetPointer<const QuantizationParameters *>(VT_QUANTIZATION);
+    return GetPointer<const onert_tflite::QuantizationParameters *>(VT_QUANTIZATION);
   }
   bool is_variable() const { return GetField<uint8_t>(VT_IS_VARIABLE, 0) != 0; }
-  const SparsityParameters *sparsity() const
+  const onert_tflite::SparsityParameters *sparsity() const
   {
-    return GetPointer<const SparsityParameters *>(VT_SPARSITY);
+    return GetPointer<const onert_tflite::SparsityParameters *>(VT_SPARSITY);
   }
   const flatbuffers::Vector<int32_t> *shape_signature() const
   {
@@ -2551,13 +2744,14 @@ struct Tensor FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct TensorBuilder
 {
+  typedef Tensor Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_shape(flatbuffers::Offset<flatbuffers::Vector<int32_t>> shape)
   {
     fbb_.AddOffset(Tensor::VT_SHAPE, shape);
   }
-  void add_type(TensorType type)
+  void add_type(onert_tflite::TensorType type)
   {
     fbb_.AddElement<int8_t>(Tensor::VT_TYPE, static_cast<int8_t>(type), 0);
   }
@@ -2566,7 +2760,7 @@ struct TensorBuilder
   {
     fbb_.AddOffset(Tensor::VT_NAME, name);
   }
-  void add_quantization(flatbuffers::Offset<QuantizationParameters> quantization)
+  void add_quantization(flatbuffers::Offset<onert_tflite::QuantizationParameters> quantization)
   {
     fbb_.AddOffset(Tensor::VT_QUANTIZATION, quantization);
   }
@@ -2574,7 +2768,7 @@ struct TensorBuilder
   {
     fbb_.AddElement<uint8_t>(Tensor::VT_IS_VARIABLE, static_cast<uint8_t>(is_variable), 0);
   }
-  void add_sparsity(flatbuffers::Offset<SparsityParameters> sparsity)
+  void add_sparsity(flatbuffers::Offset<onert_tflite::SparsityParameters> sparsity)
   {
     fbb_.AddOffset(Tensor::VT_SPARSITY, sparsity);
   }
@@ -2586,7 +2780,6 @@ struct TensorBuilder
   {
     start_ = fbb_.StartTable();
   }
-  TensorBuilder &operator=(const TensorBuilder &);
   flatbuffers::Offset<Tensor> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -2595,14 +2788,13 @@ struct TensorBuilder
   }
 };
 
-inline flatbuffers::Offset<Tensor>
-CreateTensor(flatbuffers::FlatBufferBuilder &_fbb,
-             flatbuffers::Offset<flatbuffers::Vector<int32_t>> shape = 0,
-             TensorType type = TensorType_FLOAT32, uint32_t buffer = 0,
-             flatbuffers::Offset<flatbuffers::String> name = 0,
-             flatbuffers::Offset<QuantizationParameters> quantization = 0, bool is_variable = false,
-             flatbuffers::Offset<SparsityParameters> sparsity = 0,
-             flatbuffers::Offset<flatbuffers::Vector<int32_t>> shape_signature = 0)
+inline flatbuffers::Offset<Tensor> CreateTensor(
+  flatbuffers::FlatBufferBuilder &_fbb, flatbuffers::Offset<flatbuffers::Vector<int32_t>> shape = 0,
+  onert_tflite::TensorType type = onert_tflite::TensorType_FLOAT32, uint32_t buffer = 0,
+  flatbuffers::Offset<flatbuffers::String> name = 0,
+  flatbuffers::Offset<onert_tflite::QuantizationParameters> quantization = 0,
+  bool is_variable = false, flatbuffers::Offset<onert_tflite::SparsityParameters> sparsity = 0,
+  flatbuffers::Offset<flatbuffers::Vector<int32_t>> shape_signature = 0)
 {
   TensorBuilder builder_(_fbb);
   builder_.add_shape_signature(shape_signature);
@@ -2618,20 +2810,23 @@ CreateTensor(flatbuffers::FlatBufferBuilder &_fbb,
 
 inline flatbuffers::Offset<Tensor> CreateTensorDirect(
   flatbuffers::FlatBufferBuilder &_fbb, const std::vector<int32_t> *shape = nullptr,
-  TensorType type = TensorType_FLOAT32, uint32_t buffer = 0, const char *name = nullptr,
-  flatbuffers::Offset<QuantizationParameters> quantization = 0, bool is_variable = false,
-  flatbuffers::Offset<SparsityParameters> sparsity = 0,
+  onert_tflite::TensorType type = onert_tflite::TensorType_FLOAT32, uint32_t buffer = 0,
+  const char *name = nullptr,
+  flatbuffers::Offset<onert_tflite::QuantizationParameters> quantization = 0,
+  bool is_variable = false, flatbuffers::Offset<onert_tflite::SparsityParameters> sparsity = 0,
   const std::vector<int32_t> *shape_signature = nullptr)
 {
-  return onert_tflite::CreateTensor(
-    _fbb, shape ? _fbb.CreateVector<int32_t>(*shape) : 0, type, buffer,
-    name ? _fbb.CreateString(name) : 0, quantization, is_variable, sparsity,
-    shape_signature ? _fbb.CreateVector<int32_t>(*shape_signature) : 0);
+  auto shape__ = shape ? _fbb.CreateVector<int32_t>(*shape) : 0;
+  auto name__ = name ? _fbb.CreateString(name) : 0;
+  auto shape_signature__ = shape_signature ? _fbb.CreateVector<int32_t>(*shape_signature) : 0;
+  return onert_tflite::CreateTensor(_fbb, shape__, type, buffer, name__, quantization, is_variable,
+                                    sparsity, shape_signature__);
 }
 
 struct Conv2DOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef Conv2DOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_PADDING = 4,
     VT_STRIDE_W = 6,
@@ -2640,12 +2835,16 @@ struct Conv2DOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
     VT_DILATION_W_FACTOR = 12,
     VT_DILATION_H_FACTOR = 14
   };
-  Padding padding() const { return static_cast<Padding>(GetField<int8_t>(VT_PADDING, 0)); }
+  onert_tflite::Padding padding() const
+  {
+    return static_cast<onert_tflite::Padding>(GetField<int8_t>(VT_PADDING, 0));
+  }
   int32_t stride_w() const { return GetField<int32_t>(VT_STRIDE_W, 0); }
   int32_t stride_h() const { return GetField<int32_t>(VT_STRIDE_H, 0); }
-  ActivationFunctionType fused_activation_function() const
+  onert_tflite::ActivationFunctionType fused_activation_function() const
   {
-    return static_cast<ActivationFunctionType>(GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
+    return static_cast<onert_tflite::ActivationFunctionType>(
+      GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
   }
   int32_t dilation_w_factor() const { return GetField<int32_t>(VT_DILATION_W_FACTOR, 1); }
   int32_t dilation_h_factor() const { return GetField<int32_t>(VT_DILATION_H_FACTOR, 1); }
@@ -2662,9 +2861,10 @@ struct Conv2DOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct Conv2DOptionsBuilder
 {
+  typedef Conv2DOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_padding(Padding padding)
+  void add_padding(onert_tflite::Padding padding)
   {
     fbb_.AddElement<int8_t>(Conv2DOptions::VT_PADDING, static_cast<int8_t>(padding), 0);
   }
@@ -2676,7 +2876,7 @@ struct Conv2DOptionsBuilder
   {
     fbb_.AddElement<int32_t>(Conv2DOptions::VT_STRIDE_H, stride_h, 0);
   }
-  void add_fused_activation_function(ActivationFunctionType fused_activation_function)
+  void add_fused_activation_function(onert_tflite::ActivationFunctionType fused_activation_function)
   {
     fbb_.AddElement<int8_t>(Conv2DOptions::VT_FUSED_ACTIVATION_FUNCTION,
                             static_cast<int8_t>(fused_activation_function), 0);
@@ -2693,7 +2893,6 @@ struct Conv2DOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  Conv2DOptionsBuilder &operator=(const Conv2DOptionsBuilder &);
   flatbuffers::Offset<Conv2DOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -2703,9 +2902,11 @@ struct Conv2DOptionsBuilder
 };
 
 inline flatbuffers::Offset<Conv2DOptions>
-CreateConv2DOptions(flatbuffers::FlatBufferBuilder &_fbb, Padding padding = Padding_SAME,
+CreateConv2DOptions(flatbuffers::FlatBufferBuilder &_fbb,
+                    onert_tflite::Padding padding = onert_tflite::Padding_SAME,
                     int32_t stride_w = 0, int32_t stride_h = 0,
-                    ActivationFunctionType fused_activation_function = ActivationFunctionType_NONE,
+                    onert_tflite::ActivationFunctionType fused_activation_function =
+                      onert_tflite::ActivationFunctionType_NONE,
                     int32_t dilation_w_factor = 1, int32_t dilation_h_factor = 1)
 {
   Conv2DOptionsBuilder builder_(_fbb);
@@ -2720,7 +2921,8 @@ CreateConv2DOptions(flatbuffers::FlatBufferBuilder &_fbb, Padding padding = Padd
 
 struct Pool2DOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef Pool2DOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_PADDING = 4,
     VT_STRIDE_W = 6,
@@ -2729,14 +2931,18 @@ struct Pool2DOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
     VT_FILTER_HEIGHT = 12,
     VT_FUSED_ACTIVATION_FUNCTION = 14
   };
-  Padding padding() const { return static_cast<Padding>(GetField<int8_t>(VT_PADDING, 0)); }
+  onert_tflite::Padding padding() const
+  {
+    return static_cast<onert_tflite::Padding>(GetField<int8_t>(VT_PADDING, 0));
+  }
   int32_t stride_w() const { return GetField<int32_t>(VT_STRIDE_W, 0); }
   int32_t stride_h() const { return GetField<int32_t>(VT_STRIDE_H, 0); }
   int32_t filter_width() const { return GetField<int32_t>(VT_FILTER_WIDTH, 0); }
   int32_t filter_height() const { return GetField<int32_t>(VT_FILTER_HEIGHT, 0); }
-  ActivationFunctionType fused_activation_function() const
+  onert_tflite::ActivationFunctionType fused_activation_function() const
   {
-    return static_cast<ActivationFunctionType>(GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
+    return static_cast<onert_tflite::ActivationFunctionType>(
+      GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
   }
   bool Verify(flatbuffers::Verifier &verifier) const
   {
@@ -2751,9 +2957,10 @@ struct Pool2DOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct Pool2DOptionsBuilder
 {
+  typedef Pool2DOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_padding(Padding padding)
+  void add_padding(onert_tflite::Padding padding)
   {
     fbb_.AddElement<int8_t>(Pool2DOptions::VT_PADDING, static_cast<int8_t>(padding), 0);
   }
@@ -2773,7 +2980,7 @@ struct Pool2DOptionsBuilder
   {
     fbb_.AddElement<int32_t>(Pool2DOptions::VT_FILTER_HEIGHT, filter_height, 0);
   }
-  void add_fused_activation_function(ActivationFunctionType fused_activation_function)
+  void add_fused_activation_function(onert_tflite::ActivationFunctionType fused_activation_function)
   {
     fbb_.AddElement<int8_t>(Pool2DOptions::VT_FUSED_ACTIVATION_FUNCTION,
                             static_cast<int8_t>(fused_activation_function), 0);
@@ -2782,7 +2989,6 @@ struct Pool2DOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  Pool2DOptionsBuilder &operator=(const Pool2DOptionsBuilder &);
   flatbuffers::Offset<Pool2DOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -2791,11 +2997,11 @@ struct Pool2DOptionsBuilder
   }
 };
 
-inline flatbuffers::Offset<Pool2DOptions>
-CreatePool2DOptions(flatbuffers::FlatBufferBuilder &_fbb, Padding padding = Padding_SAME,
-                    int32_t stride_w = 0, int32_t stride_h = 0, int32_t filter_width = 0,
-                    int32_t filter_height = 0,
-                    ActivationFunctionType fused_activation_function = ActivationFunctionType_NONE)
+inline flatbuffers::Offset<Pool2DOptions> CreatePool2DOptions(
+  flatbuffers::FlatBufferBuilder &_fbb, onert_tflite::Padding padding = onert_tflite::Padding_SAME,
+  int32_t stride_w = 0, int32_t stride_h = 0, int32_t filter_width = 0, int32_t filter_height = 0,
+  onert_tflite::ActivationFunctionType fused_activation_function =
+    onert_tflite::ActivationFunctionType_NONE)
 {
   Pool2DOptionsBuilder builder_(_fbb);
   builder_.add_filter_height(filter_height);
@@ -2809,7 +3015,8 @@ CreatePool2DOptions(flatbuffers::FlatBufferBuilder &_fbb, Padding padding = Padd
 
 struct DepthwiseConv2DOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef DepthwiseConv2DOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_PADDING = 4,
     VT_STRIDE_W = 6,
@@ -2819,13 +3026,17 @@ struct DepthwiseConv2DOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Tab
     VT_DILATION_W_FACTOR = 14,
     VT_DILATION_H_FACTOR = 16
   };
-  Padding padding() const { return static_cast<Padding>(GetField<int8_t>(VT_PADDING, 0)); }
+  onert_tflite::Padding padding() const
+  {
+    return static_cast<onert_tflite::Padding>(GetField<int8_t>(VT_PADDING, 0));
+  }
   int32_t stride_w() const { return GetField<int32_t>(VT_STRIDE_W, 0); }
   int32_t stride_h() const { return GetField<int32_t>(VT_STRIDE_H, 0); }
   int32_t depth_multiplier() const { return GetField<int32_t>(VT_DEPTH_MULTIPLIER, 0); }
-  ActivationFunctionType fused_activation_function() const
+  onert_tflite::ActivationFunctionType fused_activation_function() const
   {
-    return static_cast<ActivationFunctionType>(GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
+    return static_cast<onert_tflite::ActivationFunctionType>(
+      GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
   }
   int32_t dilation_w_factor() const { return GetField<int32_t>(VT_DILATION_W_FACTOR, 1); }
   int32_t dilation_h_factor() const { return GetField<int32_t>(VT_DILATION_H_FACTOR, 1); }
@@ -2843,9 +3054,10 @@ struct DepthwiseConv2DOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Tab
 
 struct DepthwiseConv2DOptionsBuilder
 {
+  typedef DepthwiseConv2DOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_padding(Padding padding)
+  void add_padding(onert_tflite::Padding padding)
   {
     fbb_.AddElement<int8_t>(DepthwiseConv2DOptions::VT_PADDING, static_cast<int8_t>(padding), 0);
   }
@@ -2861,7 +3073,7 @@ struct DepthwiseConv2DOptionsBuilder
   {
     fbb_.AddElement<int32_t>(DepthwiseConv2DOptions::VT_DEPTH_MULTIPLIER, depth_multiplier, 0);
   }
-  void add_fused_activation_function(ActivationFunctionType fused_activation_function)
+  void add_fused_activation_function(onert_tflite::ActivationFunctionType fused_activation_function)
   {
     fbb_.AddElement<int8_t>(DepthwiseConv2DOptions::VT_FUSED_ACTIVATION_FUNCTION,
                             static_cast<int8_t>(fused_activation_function), 0);
@@ -2878,7 +3090,6 @@ struct DepthwiseConv2DOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  DepthwiseConv2DOptionsBuilder &operator=(const DepthwiseConv2DOptionsBuilder &);
   flatbuffers::Offset<DepthwiseConv2DOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -2888,9 +3099,10 @@ struct DepthwiseConv2DOptionsBuilder
 };
 
 inline flatbuffers::Offset<DepthwiseConv2DOptions> CreateDepthwiseConv2DOptions(
-  flatbuffers::FlatBufferBuilder &_fbb, Padding padding = Padding_SAME, int32_t stride_w = 0,
-  int32_t stride_h = 0, int32_t depth_multiplier = 0,
-  ActivationFunctionType fused_activation_function = ActivationFunctionType_NONE,
+  flatbuffers::FlatBufferBuilder &_fbb, onert_tflite::Padding padding = onert_tflite::Padding_SAME,
+  int32_t stride_w = 0, int32_t stride_h = 0, int32_t depth_multiplier = 0,
+  onert_tflite::ActivationFunctionType fused_activation_function =
+    onert_tflite::ActivationFunctionType_NONE,
   int32_t dilation_w_factor = 1, int32_t dilation_h_factor = 1)
 {
   DepthwiseConv2DOptionsBuilder builder_(_fbb);
@@ -2906,7 +3118,8 @@ inline flatbuffers::Offset<DepthwiseConv2DOptions> CreateDepthwiseConv2DOptions(
 
 struct ConcatEmbeddingsOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef ConcatEmbeddingsOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_NUM_CHANNELS = 4,
     VT_NUM_COLUMNS_PER_CHANNEL = 6,
@@ -2933,6 +3146,7 @@ struct ConcatEmbeddingsOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Ta
 
 struct ConcatEmbeddingsOptionsBuilder
 {
+  typedef ConcatEmbeddingsOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_num_channels(int32_t num_channels)
@@ -2954,7 +3168,6 @@ struct ConcatEmbeddingsOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  ConcatEmbeddingsOptionsBuilder &operator=(const ConcatEmbeddingsOptionsBuilder &);
   flatbuffers::Offset<ConcatEmbeddingsOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -2980,21 +3193,24 @@ CreateConcatEmbeddingsOptionsDirect(flatbuffers::FlatBufferBuilder &_fbb, int32_
                                     const std::vector<int32_t> *num_columns_per_channel = nullptr,
                                     const std::vector<int32_t> *embedding_dim_per_channel = nullptr)
 {
-  return onert_tflite::CreateConcatEmbeddingsOptions(
-    _fbb, num_channels,
-    num_columns_per_channel ? _fbb.CreateVector<int32_t>(*num_columns_per_channel) : 0,
-    embedding_dim_per_channel ? _fbb.CreateVector<int32_t>(*embedding_dim_per_channel) : 0);
+  auto num_columns_per_channel__ =
+    num_columns_per_channel ? _fbb.CreateVector<int32_t>(*num_columns_per_channel) : 0;
+  auto embedding_dim_per_channel__ =
+    embedding_dim_per_channel ? _fbb.CreateVector<int32_t>(*embedding_dim_per_channel) : 0;
+  return onert_tflite::CreateConcatEmbeddingsOptions(_fbb, num_channels, num_columns_per_channel__,
+                                                     embedding_dim_per_channel__);
 }
 
 struct LSHProjectionOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef LSHProjectionOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_TYPE = 4
   };
-  LSHProjectionType type() const
+  onert_tflite::LSHProjectionType type() const
   {
-    return static_cast<LSHProjectionType>(GetField<int8_t>(VT_TYPE, 0));
+    return static_cast<onert_tflite::LSHProjectionType>(GetField<int8_t>(VT_TYPE, 0));
   }
   bool Verify(flatbuffers::Verifier &verifier) const
   {
@@ -3005,9 +3221,10 @@ struct LSHProjectionOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct LSHProjectionOptionsBuilder
 {
+  typedef LSHProjectionOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_type(LSHProjectionType type)
+  void add_type(onert_tflite::LSHProjectionType type)
   {
     fbb_.AddElement<int8_t>(LSHProjectionOptions::VT_TYPE, static_cast<int8_t>(type), 0);
   }
@@ -3015,7 +3232,6 @@ struct LSHProjectionOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  LSHProjectionOptionsBuilder &operator=(const LSHProjectionOptionsBuilder &);
   flatbuffers::Offset<LSHProjectionOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -3024,9 +3240,9 @@ struct LSHProjectionOptionsBuilder
   }
 };
 
-inline flatbuffers::Offset<LSHProjectionOptions>
-CreateLSHProjectionOptions(flatbuffers::FlatBufferBuilder &_fbb,
-                           LSHProjectionType type = LSHProjectionType_UNKNOWN)
+inline flatbuffers::Offset<LSHProjectionOptions> CreateLSHProjectionOptions(
+  flatbuffers::FlatBufferBuilder &_fbb,
+  onert_tflite::LSHProjectionType type = onert_tflite::LSHProjectionType_UNKNOWN)
 {
   LSHProjectionOptionsBuilder builder_(_fbb);
   builder_.add_type(type);
@@ -3035,16 +3251,18 @@ CreateLSHProjectionOptions(flatbuffers::FlatBufferBuilder &_fbb,
 
 struct SVDFOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef SVDFOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_RANK = 4,
     VT_FUSED_ACTIVATION_FUNCTION = 6,
     VT_ASYMMETRIC_QUANTIZE_INPUTS = 8
   };
   int32_t rank() const { return GetField<int32_t>(VT_RANK, 0); }
-  ActivationFunctionType fused_activation_function() const
+  onert_tflite::ActivationFunctionType fused_activation_function() const
   {
-    return static_cast<ActivationFunctionType>(GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
+    return static_cast<onert_tflite::ActivationFunctionType>(
+      GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
   }
   bool asymmetric_quantize_inputs() const
   {
@@ -3060,10 +3278,11 @@ struct SVDFOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct SVDFOptionsBuilder
 {
+  typedef SVDFOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_rank(int32_t rank) { fbb_.AddElement<int32_t>(SVDFOptions::VT_RANK, rank, 0); }
-  void add_fused_activation_function(ActivationFunctionType fused_activation_function)
+  void add_fused_activation_function(onert_tflite::ActivationFunctionType fused_activation_function)
   {
     fbb_.AddElement<int8_t>(SVDFOptions::VT_FUSED_ACTIVATION_FUNCTION,
                             static_cast<int8_t>(fused_activation_function), 0);
@@ -3077,7 +3296,6 @@ struct SVDFOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  SVDFOptionsBuilder &operator=(const SVDFOptionsBuilder &);
   flatbuffers::Offset<SVDFOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -3088,7 +3306,8 @@ struct SVDFOptionsBuilder
 
 inline flatbuffers::Offset<SVDFOptions>
 CreateSVDFOptions(flatbuffers::FlatBufferBuilder &_fbb, int32_t rank = 0,
-                  ActivationFunctionType fused_activation_function = ActivationFunctionType_NONE,
+                  onert_tflite::ActivationFunctionType fused_activation_function =
+                    onert_tflite::ActivationFunctionType_NONE,
                   bool asymmetric_quantize_inputs = false)
 {
   SVDFOptionsBuilder builder_(_fbb);
@@ -3100,14 +3319,16 @@ CreateSVDFOptions(flatbuffers::FlatBufferBuilder &_fbb, int32_t rank = 0,
 
 struct RNNOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef RNNOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_FUSED_ACTIVATION_FUNCTION = 4,
     VT_ASYMMETRIC_QUANTIZE_INPUTS = 6
   };
-  ActivationFunctionType fused_activation_function() const
+  onert_tflite::ActivationFunctionType fused_activation_function() const
   {
-    return static_cast<ActivationFunctionType>(GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
+    return static_cast<onert_tflite::ActivationFunctionType>(
+      GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
   }
   bool asymmetric_quantize_inputs() const
   {
@@ -3123,9 +3344,10 @@ struct RNNOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct RNNOptionsBuilder
 {
+  typedef RNNOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_fused_activation_function(ActivationFunctionType fused_activation_function)
+  void add_fused_activation_function(onert_tflite::ActivationFunctionType fused_activation_function)
   {
     fbb_.AddElement<int8_t>(RNNOptions::VT_FUSED_ACTIVATION_FUNCTION,
                             static_cast<int8_t>(fused_activation_function), 0);
@@ -3139,7 +3361,6 @@ struct RNNOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  RNNOptionsBuilder &operator=(const RNNOptionsBuilder &);
   flatbuffers::Offset<RNNOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -3150,7 +3371,8 @@ struct RNNOptionsBuilder
 
 inline flatbuffers::Offset<RNNOptions>
 CreateRNNOptions(flatbuffers::FlatBufferBuilder &_fbb,
-                 ActivationFunctionType fused_activation_function = ActivationFunctionType_NONE,
+                 onert_tflite::ActivationFunctionType fused_activation_function =
+                   onert_tflite::ActivationFunctionType_NONE,
                  bool asymmetric_quantize_inputs = false)
 {
   RNNOptionsBuilder builder_(_fbb);
@@ -3161,16 +3383,18 @@ CreateRNNOptions(flatbuffers::FlatBufferBuilder &_fbb,
 
 struct SequenceRNNOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef SequenceRNNOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_TIME_MAJOR = 4,
     VT_FUSED_ACTIVATION_FUNCTION = 6,
     VT_ASYMMETRIC_QUANTIZE_INPUTS = 8
   };
   bool time_major() const { return GetField<uint8_t>(VT_TIME_MAJOR, 0) != 0; }
-  ActivationFunctionType fused_activation_function() const
+  onert_tflite::ActivationFunctionType fused_activation_function() const
   {
-    return static_cast<ActivationFunctionType>(GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
+    return static_cast<onert_tflite::ActivationFunctionType>(
+      GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
   }
   bool asymmetric_quantize_inputs() const
   {
@@ -3186,6 +3410,7 @@ struct SequenceRNNOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct SequenceRNNOptionsBuilder
 {
+  typedef SequenceRNNOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_time_major(bool time_major)
@@ -3193,7 +3418,7 @@ struct SequenceRNNOptionsBuilder
     fbb_.AddElement<uint8_t>(SequenceRNNOptions::VT_TIME_MAJOR, static_cast<uint8_t>(time_major),
                              0);
   }
-  void add_fused_activation_function(ActivationFunctionType fused_activation_function)
+  void add_fused_activation_function(onert_tflite::ActivationFunctionType fused_activation_function)
   {
     fbb_.AddElement<int8_t>(SequenceRNNOptions::VT_FUSED_ACTIVATION_FUNCTION,
                             static_cast<int8_t>(fused_activation_function), 0);
@@ -3207,7 +3432,6 @@ struct SequenceRNNOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  SequenceRNNOptionsBuilder &operator=(const SequenceRNNOptionsBuilder &);
   flatbuffers::Offset<SequenceRNNOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -3216,10 +3440,11 @@ struct SequenceRNNOptionsBuilder
   }
 };
 
-inline flatbuffers::Offset<SequenceRNNOptions> CreateSequenceRNNOptions(
-  flatbuffers::FlatBufferBuilder &_fbb, bool time_major = false,
-  ActivationFunctionType fused_activation_function = ActivationFunctionType_NONE,
-  bool asymmetric_quantize_inputs = false)
+inline flatbuffers::Offset<SequenceRNNOptions>
+CreateSequenceRNNOptions(flatbuffers::FlatBufferBuilder &_fbb, bool time_major = false,
+                         onert_tflite::ActivationFunctionType fused_activation_function =
+                           onert_tflite::ActivationFunctionType_NONE,
+                         bool asymmetric_quantize_inputs = false)
 {
   SequenceRNNOptionsBuilder builder_(_fbb);
   builder_.add_asymmetric_quantize_inputs(asymmetric_quantize_inputs);
@@ -3230,7 +3455,8 @@ inline flatbuffers::Offset<SequenceRNNOptions> CreateSequenceRNNOptions(
 
 struct BidirectionalSequenceRNNOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef BidirectionalSequenceRNNOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_TIME_MAJOR = 4,
     VT_FUSED_ACTIVATION_FUNCTION = 6,
@@ -3238,9 +3464,10 @@ struct BidirectionalSequenceRNNOptions FLATBUFFERS_FINAL_CLASS : private flatbuf
     VT_ASYMMETRIC_QUANTIZE_INPUTS = 10
   };
   bool time_major() const { return GetField<uint8_t>(VT_TIME_MAJOR, 0) != 0; }
-  ActivationFunctionType fused_activation_function() const
+  onert_tflite::ActivationFunctionType fused_activation_function() const
   {
-    return static_cast<ActivationFunctionType>(GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
+    return static_cast<onert_tflite::ActivationFunctionType>(
+      GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
   }
   bool merge_outputs() const { return GetField<uint8_t>(VT_MERGE_OUTPUTS, 0) != 0; }
   bool asymmetric_quantize_inputs() const
@@ -3258,6 +3485,7 @@ struct BidirectionalSequenceRNNOptions FLATBUFFERS_FINAL_CLASS : private flatbuf
 
 struct BidirectionalSequenceRNNOptionsBuilder
 {
+  typedef BidirectionalSequenceRNNOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_time_major(bool time_major)
@@ -3265,7 +3493,7 @@ struct BidirectionalSequenceRNNOptionsBuilder
     fbb_.AddElement<uint8_t>(BidirectionalSequenceRNNOptions::VT_TIME_MAJOR,
                              static_cast<uint8_t>(time_major), 0);
   }
-  void add_fused_activation_function(ActivationFunctionType fused_activation_function)
+  void add_fused_activation_function(onert_tflite::ActivationFunctionType fused_activation_function)
   {
     fbb_.AddElement<int8_t>(BidirectionalSequenceRNNOptions::VT_FUSED_ACTIVATION_FUNCTION,
                             static_cast<int8_t>(fused_activation_function), 0);
@@ -3284,7 +3512,6 @@ struct BidirectionalSequenceRNNOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  BidirectionalSequenceRNNOptionsBuilder &operator=(const BidirectionalSequenceRNNOptionsBuilder &);
   flatbuffers::Offset<BidirectionalSequenceRNNOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -3295,7 +3522,8 @@ struct BidirectionalSequenceRNNOptionsBuilder
 
 inline flatbuffers::Offset<BidirectionalSequenceRNNOptions> CreateBidirectionalSequenceRNNOptions(
   flatbuffers::FlatBufferBuilder &_fbb, bool time_major = false,
-  ActivationFunctionType fused_activation_function = ActivationFunctionType_NONE,
+  onert_tflite::ActivationFunctionType fused_activation_function =
+    onert_tflite::ActivationFunctionType_NONE,
   bool merge_outputs = false, bool asymmetric_quantize_inputs = false)
 {
   BidirectionalSequenceRNNOptionsBuilder builder_(_fbb);
@@ -3308,20 +3536,23 @@ inline flatbuffers::Offset<BidirectionalSequenceRNNOptions> CreateBidirectionalS
 
 struct FullyConnectedOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef FullyConnectedOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_FUSED_ACTIVATION_FUNCTION = 4,
     VT_WEIGHTS_FORMAT = 6,
     VT_KEEP_NUM_DIMS = 8,
     VT_ASYMMETRIC_QUANTIZE_INPUTS = 10
   };
-  ActivationFunctionType fused_activation_function() const
+  onert_tflite::ActivationFunctionType fused_activation_function() const
   {
-    return static_cast<ActivationFunctionType>(GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
+    return static_cast<onert_tflite::ActivationFunctionType>(
+      GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
   }
-  FullyConnectedOptionsWeightsFormat weights_format() const
+  onert_tflite::FullyConnectedOptionsWeightsFormat weights_format() const
   {
-    return static_cast<FullyConnectedOptionsWeightsFormat>(GetField<int8_t>(VT_WEIGHTS_FORMAT, 0));
+    return static_cast<onert_tflite::FullyConnectedOptionsWeightsFormat>(
+      GetField<int8_t>(VT_WEIGHTS_FORMAT, 0));
   }
   bool keep_num_dims() const { return GetField<uint8_t>(VT_KEEP_NUM_DIMS, 0) != 0; }
   bool asymmetric_quantize_inputs() const
@@ -3340,14 +3571,15 @@ struct FullyConnectedOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Tabl
 
 struct FullyConnectedOptionsBuilder
 {
+  typedef FullyConnectedOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_fused_activation_function(ActivationFunctionType fused_activation_function)
+  void add_fused_activation_function(onert_tflite::ActivationFunctionType fused_activation_function)
   {
     fbb_.AddElement<int8_t>(FullyConnectedOptions::VT_FUSED_ACTIVATION_FUNCTION,
                             static_cast<int8_t>(fused_activation_function), 0);
   }
-  void add_weights_format(FullyConnectedOptionsWeightsFormat weights_format)
+  void add_weights_format(onert_tflite::FullyConnectedOptionsWeightsFormat weights_format)
   {
     fbb_.AddElement<int8_t>(FullyConnectedOptions::VT_WEIGHTS_FORMAT,
                             static_cast<int8_t>(weights_format), 0);
@@ -3366,7 +3598,6 @@ struct FullyConnectedOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  FullyConnectedOptionsBuilder &operator=(const FullyConnectedOptionsBuilder &);
   flatbuffers::Offset<FullyConnectedOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -3375,11 +3606,13 @@ struct FullyConnectedOptionsBuilder
   }
 };
 
-inline flatbuffers::Offset<FullyConnectedOptions> CreateFullyConnectedOptions(
-  flatbuffers::FlatBufferBuilder &_fbb,
-  ActivationFunctionType fused_activation_function = ActivationFunctionType_NONE,
-  FullyConnectedOptionsWeightsFormat weights_format = FullyConnectedOptionsWeightsFormat_DEFAULT,
-  bool keep_num_dims = false, bool asymmetric_quantize_inputs = false)
+inline flatbuffers::Offset<FullyConnectedOptions>
+CreateFullyConnectedOptions(flatbuffers::FlatBufferBuilder &_fbb,
+                            onert_tflite::ActivationFunctionType fused_activation_function =
+                              onert_tflite::ActivationFunctionType_NONE,
+                            onert_tflite::FullyConnectedOptionsWeightsFormat weights_format =
+                              onert_tflite::FullyConnectedOptionsWeightsFormat_DEFAULT,
+                            bool keep_num_dims = false, bool asymmetric_quantize_inputs = false)
 {
   FullyConnectedOptionsBuilder builder_(_fbb);
   builder_.add_asymmetric_quantize_inputs(asymmetric_quantize_inputs);
@@ -3391,7 +3624,8 @@ inline flatbuffers::Offset<FullyConnectedOptions> CreateFullyConnectedOptions(
 
 struct SoftmaxOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef SoftmaxOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_BETA = 4
   };
@@ -3405,6 +3639,7 @@ struct SoftmaxOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct SoftmaxOptionsBuilder
 {
+  typedef SoftmaxOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_beta(float beta) { fbb_.AddElement<float>(SoftmaxOptions::VT_BETA, beta, 0.0f); }
@@ -3412,7 +3647,6 @@ struct SoftmaxOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  SoftmaxOptionsBuilder &operator=(const SoftmaxOptionsBuilder &);
   flatbuffers::Offset<SoftmaxOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -3431,15 +3665,17 @@ CreateSoftmaxOptions(flatbuffers::FlatBufferBuilder &_fbb, float beta = 0.0f)
 
 struct ConcatenationOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef ConcatenationOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_AXIS = 4,
     VT_FUSED_ACTIVATION_FUNCTION = 6
   };
   int32_t axis() const { return GetField<int32_t>(VT_AXIS, 0); }
-  ActivationFunctionType fused_activation_function() const
+  onert_tflite::ActivationFunctionType fused_activation_function() const
   {
-    return static_cast<ActivationFunctionType>(GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
+    return static_cast<onert_tflite::ActivationFunctionType>(
+      GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
   }
   bool Verify(flatbuffers::Verifier &verifier) const
   {
@@ -3450,10 +3686,11 @@ struct ConcatenationOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct ConcatenationOptionsBuilder
 {
+  typedef ConcatenationOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_axis(int32_t axis) { fbb_.AddElement<int32_t>(ConcatenationOptions::VT_AXIS, axis, 0); }
-  void add_fused_activation_function(ActivationFunctionType fused_activation_function)
+  void add_fused_activation_function(onert_tflite::ActivationFunctionType fused_activation_function)
   {
     fbb_.AddElement<int8_t>(ConcatenationOptions::VT_FUSED_ACTIVATION_FUNCTION,
                             static_cast<int8_t>(fused_activation_function), 0);
@@ -3462,7 +3699,6 @@ struct ConcatenationOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  ConcatenationOptionsBuilder &operator=(const ConcatenationOptionsBuilder &);
   flatbuffers::Offset<ConcatenationOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -3471,9 +3707,10 @@ struct ConcatenationOptionsBuilder
   }
 };
 
-inline flatbuffers::Offset<ConcatenationOptions> CreateConcatenationOptions(
-  flatbuffers::FlatBufferBuilder &_fbb, int32_t axis = 0,
-  ActivationFunctionType fused_activation_function = ActivationFunctionType_NONE)
+inline flatbuffers::Offset<ConcatenationOptions>
+CreateConcatenationOptions(flatbuffers::FlatBufferBuilder &_fbb, int32_t axis = 0,
+                           onert_tflite::ActivationFunctionType fused_activation_function =
+                             onert_tflite::ActivationFunctionType_NONE)
 {
   ConcatenationOptionsBuilder builder_(_fbb);
   builder_.add_axis(axis);
@@ -3483,13 +3720,15 @@ inline flatbuffers::Offset<ConcatenationOptions> CreateConcatenationOptions(
 
 struct AddOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef AddOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_FUSED_ACTIVATION_FUNCTION = 4
   };
-  ActivationFunctionType fused_activation_function() const
+  onert_tflite::ActivationFunctionType fused_activation_function() const
   {
-    return static_cast<ActivationFunctionType>(GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
+    return static_cast<onert_tflite::ActivationFunctionType>(
+      GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
   }
   bool Verify(flatbuffers::Verifier &verifier) const
   {
@@ -3500,9 +3739,10 @@ struct AddOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct AddOptionsBuilder
 {
+  typedef AddOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_fused_activation_function(ActivationFunctionType fused_activation_function)
+  void add_fused_activation_function(onert_tflite::ActivationFunctionType fused_activation_function)
   {
     fbb_.AddElement<int8_t>(AddOptions::VT_FUSED_ACTIVATION_FUNCTION,
                             static_cast<int8_t>(fused_activation_function), 0);
@@ -3511,7 +3751,6 @@ struct AddOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  AddOptionsBuilder &operator=(const AddOptionsBuilder &);
   flatbuffers::Offset<AddOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -3522,7 +3761,8 @@ struct AddOptionsBuilder
 
 inline flatbuffers::Offset<AddOptions>
 CreateAddOptions(flatbuffers::FlatBufferBuilder &_fbb,
-                 ActivationFunctionType fused_activation_function = ActivationFunctionType_NONE)
+                 onert_tflite::ActivationFunctionType fused_activation_function =
+                   onert_tflite::ActivationFunctionType_NONE)
 {
   AddOptionsBuilder builder_(_fbb);
   builder_.add_fused_activation_function(fused_activation_function);
@@ -3531,13 +3771,15 @@ CreateAddOptions(flatbuffers::FlatBufferBuilder &_fbb,
 
 struct MulOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef MulOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_FUSED_ACTIVATION_FUNCTION = 4
   };
-  ActivationFunctionType fused_activation_function() const
+  onert_tflite::ActivationFunctionType fused_activation_function() const
   {
-    return static_cast<ActivationFunctionType>(GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
+    return static_cast<onert_tflite::ActivationFunctionType>(
+      GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
   }
   bool Verify(flatbuffers::Verifier &verifier) const
   {
@@ -3548,9 +3790,10 @@ struct MulOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct MulOptionsBuilder
 {
+  typedef MulOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_fused_activation_function(ActivationFunctionType fused_activation_function)
+  void add_fused_activation_function(onert_tflite::ActivationFunctionType fused_activation_function)
   {
     fbb_.AddElement<int8_t>(MulOptions::VT_FUSED_ACTIVATION_FUNCTION,
                             static_cast<int8_t>(fused_activation_function), 0);
@@ -3559,7 +3802,6 @@ struct MulOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  MulOptionsBuilder &operator=(const MulOptionsBuilder &);
   flatbuffers::Offset<MulOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -3570,7 +3812,8 @@ struct MulOptionsBuilder
 
 inline flatbuffers::Offset<MulOptions>
 CreateMulOptions(flatbuffers::FlatBufferBuilder &_fbb,
-                 ActivationFunctionType fused_activation_function = ActivationFunctionType_NONE)
+                 onert_tflite::ActivationFunctionType fused_activation_function =
+                   onert_tflite::ActivationFunctionType_NONE)
 {
   MulOptionsBuilder builder_(_fbb);
   builder_.add_fused_activation_function(fused_activation_function);
@@ -3579,13 +3822,15 @@ CreateMulOptions(flatbuffers::FlatBufferBuilder &_fbb,
 
 struct L2NormOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef L2NormOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_FUSED_ACTIVATION_FUNCTION = 4
   };
-  ActivationFunctionType fused_activation_function() const
+  onert_tflite::ActivationFunctionType fused_activation_function() const
   {
-    return static_cast<ActivationFunctionType>(GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
+    return static_cast<onert_tflite::ActivationFunctionType>(
+      GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
   }
   bool Verify(flatbuffers::Verifier &verifier) const
   {
@@ -3596,9 +3841,10 @@ struct L2NormOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct L2NormOptionsBuilder
 {
+  typedef L2NormOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_fused_activation_function(ActivationFunctionType fused_activation_function)
+  void add_fused_activation_function(onert_tflite::ActivationFunctionType fused_activation_function)
   {
     fbb_.AddElement<int8_t>(L2NormOptions::VT_FUSED_ACTIVATION_FUNCTION,
                             static_cast<int8_t>(fused_activation_function), 0);
@@ -3607,7 +3853,6 @@ struct L2NormOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  L2NormOptionsBuilder &operator=(const L2NormOptionsBuilder &);
   flatbuffers::Offset<L2NormOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -3618,7 +3863,8 @@ struct L2NormOptionsBuilder
 
 inline flatbuffers::Offset<L2NormOptions>
 CreateL2NormOptions(flatbuffers::FlatBufferBuilder &_fbb,
-                    ActivationFunctionType fused_activation_function = ActivationFunctionType_NONE)
+                    onert_tflite::ActivationFunctionType fused_activation_function =
+                      onert_tflite::ActivationFunctionType_NONE)
 {
   L2NormOptionsBuilder builder_(_fbb);
   builder_.add_fused_activation_function(fused_activation_function);
@@ -3627,7 +3873,8 @@ CreateL2NormOptions(flatbuffers::FlatBufferBuilder &_fbb,
 
 struct LocalResponseNormalizationOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef LocalResponseNormalizationOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_RADIUS = 4,
     VT_BIAS = 6,
@@ -3648,6 +3895,7 @@ struct LocalResponseNormalizationOptions FLATBUFFERS_FINAL_CLASS : private flatb
 
 struct LocalResponseNormalizationOptionsBuilder
 {
+  typedef LocalResponseNormalizationOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_radius(int32_t radius)
@@ -3671,8 +3919,6 @@ struct LocalResponseNormalizationOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  LocalResponseNormalizationOptionsBuilder &
-  operator=(const LocalResponseNormalizationOptionsBuilder &);
   flatbuffers::Offset<LocalResponseNormalizationOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -3695,7 +3941,8 @@ CreateLocalResponseNormalizationOptions(flatbuffers::FlatBufferBuilder &_fbb, in
 
 struct LSTMOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef LSTMOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_FUSED_ACTIVATION_FUNCTION = 4,
     VT_CELL_CLIP = 6,
@@ -3703,15 +3950,16 @@ struct LSTMOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
     VT_KERNEL_TYPE = 10,
     VT_ASYMMETRIC_QUANTIZE_INPUTS = 12
   };
-  ActivationFunctionType fused_activation_function() const
+  onert_tflite::ActivationFunctionType fused_activation_function() const
   {
-    return static_cast<ActivationFunctionType>(GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
+    return static_cast<onert_tflite::ActivationFunctionType>(
+      GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
   }
   float cell_clip() const { return GetField<float>(VT_CELL_CLIP, 0.0f); }
   float proj_clip() const { return GetField<float>(VT_PROJ_CLIP, 0.0f); }
-  LSTMKernelType kernel_type() const
+  onert_tflite::LSTMKernelType kernel_type() const
   {
-    return static_cast<LSTMKernelType>(GetField<int8_t>(VT_KERNEL_TYPE, 0));
+    return static_cast<onert_tflite::LSTMKernelType>(GetField<int8_t>(VT_KERNEL_TYPE, 0));
   }
   bool asymmetric_quantize_inputs() const
   {
@@ -3730,9 +3978,10 @@ struct LSTMOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct LSTMOptionsBuilder
 {
+  typedef LSTMOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_fused_activation_function(ActivationFunctionType fused_activation_function)
+  void add_fused_activation_function(onert_tflite::ActivationFunctionType fused_activation_function)
   {
     fbb_.AddElement<int8_t>(LSTMOptions::VT_FUSED_ACTIVATION_FUNCTION,
                             static_cast<int8_t>(fused_activation_function), 0);
@@ -3745,7 +3994,7 @@ struct LSTMOptionsBuilder
   {
     fbb_.AddElement<float>(LSTMOptions::VT_PROJ_CLIP, proj_clip, 0.0f);
   }
-  void add_kernel_type(LSTMKernelType kernel_type)
+  void add_kernel_type(onert_tflite::LSTMKernelType kernel_type)
   {
     fbb_.AddElement<int8_t>(LSTMOptions::VT_KERNEL_TYPE, static_cast<int8_t>(kernel_type), 0);
   }
@@ -3758,7 +4007,6 @@ struct LSTMOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  LSTMOptionsBuilder &operator=(const LSTMOptionsBuilder &);
   flatbuffers::Offset<LSTMOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -3769,9 +4017,10 @@ struct LSTMOptionsBuilder
 
 inline flatbuffers::Offset<LSTMOptions>
 CreateLSTMOptions(flatbuffers::FlatBufferBuilder &_fbb,
-                  ActivationFunctionType fused_activation_function = ActivationFunctionType_NONE,
+                  onert_tflite::ActivationFunctionType fused_activation_function =
+                    onert_tflite::ActivationFunctionType_NONE,
                   float cell_clip = 0.0f, float proj_clip = 0.0f,
-                  LSTMKernelType kernel_type = LSTMKernelType_FULL,
+                  onert_tflite::LSTMKernelType kernel_type = onert_tflite::LSTMKernelType_FULL,
                   bool asymmetric_quantize_inputs = false)
 {
   LSTMOptionsBuilder builder_(_fbb);
@@ -3785,7 +4034,8 @@ CreateLSTMOptions(flatbuffers::FlatBufferBuilder &_fbb,
 
 struct UnidirectionalSequenceLSTMOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef UnidirectionalSequenceLSTMOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_FUSED_ACTIVATION_FUNCTION = 4,
     VT_CELL_CLIP = 6,
@@ -3793,9 +4043,10 @@ struct UnidirectionalSequenceLSTMOptions FLATBUFFERS_FINAL_CLASS : private flatb
     VT_TIME_MAJOR = 10,
     VT_ASYMMETRIC_QUANTIZE_INPUTS = 12
   };
-  ActivationFunctionType fused_activation_function() const
+  onert_tflite::ActivationFunctionType fused_activation_function() const
   {
-    return static_cast<ActivationFunctionType>(GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
+    return static_cast<onert_tflite::ActivationFunctionType>(
+      GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
   }
   float cell_clip() const { return GetField<float>(VT_CELL_CLIP, 0.0f); }
   float proj_clip() const { return GetField<float>(VT_PROJ_CLIP, 0.0f); }
@@ -3817,9 +4068,10 @@ struct UnidirectionalSequenceLSTMOptions FLATBUFFERS_FINAL_CLASS : private flatb
 
 struct UnidirectionalSequenceLSTMOptionsBuilder
 {
+  typedef UnidirectionalSequenceLSTMOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_fused_activation_function(ActivationFunctionType fused_activation_function)
+  void add_fused_activation_function(onert_tflite::ActivationFunctionType fused_activation_function)
   {
     fbb_.AddElement<int8_t>(UnidirectionalSequenceLSTMOptions::VT_FUSED_ACTIVATION_FUNCTION,
                             static_cast<int8_t>(fused_activation_function), 0);
@@ -3847,8 +4099,6 @@ struct UnidirectionalSequenceLSTMOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  UnidirectionalSequenceLSTMOptionsBuilder &
-  operator=(const UnidirectionalSequenceLSTMOptionsBuilder &);
   flatbuffers::Offset<UnidirectionalSequenceLSTMOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -3860,7 +4110,8 @@ struct UnidirectionalSequenceLSTMOptionsBuilder
 inline flatbuffers::Offset<UnidirectionalSequenceLSTMOptions>
 CreateUnidirectionalSequenceLSTMOptions(
   flatbuffers::FlatBufferBuilder &_fbb,
-  ActivationFunctionType fused_activation_function = ActivationFunctionType_NONE,
+  onert_tflite::ActivationFunctionType fused_activation_function =
+    onert_tflite::ActivationFunctionType_NONE,
   float cell_clip = 0.0f, float proj_clip = 0.0f, bool time_major = false,
   bool asymmetric_quantize_inputs = false)
 {
@@ -3875,7 +4126,8 @@ CreateUnidirectionalSequenceLSTMOptions(
 
 struct BidirectionalSequenceLSTMOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef BidirectionalSequenceLSTMOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_FUSED_ACTIVATION_FUNCTION = 4,
     VT_CELL_CLIP = 6,
@@ -3884,9 +4136,10 @@ struct BidirectionalSequenceLSTMOptions FLATBUFFERS_FINAL_CLASS : private flatbu
     VT_TIME_MAJOR = 12,
     VT_ASYMMETRIC_QUANTIZE_INPUTS = 14
   };
-  ActivationFunctionType fused_activation_function() const
+  onert_tflite::ActivationFunctionType fused_activation_function() const
   {
-    return static_cast<ActivationFunctionType>(GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
+    return static_cast<onert_tflite::ActivationFunctionType>(
+      GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
   }
   float cell_clip() const { return GetField<float>(VT_CELL_CLIP, 0.0f); }
   float proj_clip() const { return GetField<float>(VT_PROJ_CLIP, 0.0f); }
@@ -3910,9 +4163,10 @@ struct BidirectionalSequenceLSTMOptions FLATBUFFERS_FINAL_CLASS : private flatbu
 
 struct BidirectionalSequenceLSTMOptionsBuilder
 {
+  typedef BidirectionalSequenceLSTMOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_fused_activation_function(ActivationFunctionType fused_activation_function)
+  void add_fused_activation_function(onert_tflite::ActivationFunctionType fused_activation_function)
   {
     fbb_.AddElement<int8_t>(BidirectionalSequenceLSTMOptions::VT_FUSED_ACTIVATION_FUNCTION,
                             static_cast<int8_t>(fused_activation_function), 0);
@@ -3945,8 +4199,6 @@ struct BidirectionalSequenceLSTMOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  BidirectionalSequenceLSTMOptionsBuilder &
-  operator=(const BidirectionalSequenceLSTMOptionsBuilder &);
   flatbuffers::Offset<BidirectionalSequenceLSTMOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -3957,7 +4209,8 @@ struct BidirectionalSequenceLSTMOptionsBuilder
 
 inline flatbuffers::Offset<BidirectionalSequenceLSTMOptions> CreateBidirectionalSequenceLSTMOptions(
   flatbuffers::FlatBufferBuilder &_fbb,
-  ActivationFunctionType fused_activation_function = ActivationFunctionType_NONE,
+  onert_tflite::ActivationFunctionType fused_activation_function =
+    onert_tflite::ActivationFunctionType_NONE,
   float cell_clip = 0.0f, float proj_clip = 0.0f, bool merge_outputs = false,
   bool time_major = true, bool asymmetric_quantize_inputs = false)
 {
@@ -3973,7 +4226,8 @@ inline flatbuffers::Offset<BidirectionalSequenceLSTMOptions> CreateBidirectional
 
 struct ResizeBilinearOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef ResizeBilinearOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_ALIGN_CORNERS = 8,
     VT_HALF_PIXEL_CENTERS = 10
@@ -3989,6 +4243,7 @@ struct ResizeBilinearOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Tabl
 
 struct ResizeBilinearOptionsBuilder
 {
+  typedef ResizeBilinearOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_align_corners(bool align_corners)
@@ -4005,7 +4260,6 @@ struct ResizeBilinearOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  ResizeBilinearOptionsBuilder &operator=(const ResizeBilinearOptionsBuilder &);
   flatbuffers::Offset<ResizeBilinearOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -4026,7 +4280,8 @@ CreateResizeBilinearOptions(flatbuffers::FlatBufferBuilder &_fbb, bool align_cor
 
 struct ResizeNearestNeighborOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef ResizeNearestNeighborOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_ALIGN_CORNERS = 4
   };
@@ -4040,6 +4295,7 @@ struct ResizeNearestNeighborOptions FLATBUFFERS_FINAL_CLASS : private flatbuffer
 
 struct ResizeNearestNeighborOptionsBuilder
 {
+  typedef ResizeNearestNeighborOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_align_corners(bool align_corners)
@@ -4051,7 +4307,6 @@ struct ResizeNearestNeighborOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  ResizeNearestNeighborOptionsBuilder &operator=(const ResizeNearestNeighborOptionsBuilder &);
   flatbuffers::Offset<ResizeNearestNeighborOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -4070,7 +4325,8 @@ CreateResizeNearestNeighborOptions(flatbuffers::FlatBufferBuilder &_fbb, bool al
 
 struct CallOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef CallOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_SUBGRAPH = 4
   };
@@ -4084,6 +4340,7 @@ struct CallOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct CallOptionsBuilder
 {
+  typedef CallOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_subgraph(uint32_t subgraph)
@@ -4094,7 +4351,6 @@ struct CallOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  CallOptionsBuilder &operator=(const CallOptionsBuilder &);
   flatbuffers::Offset<CallOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -4113,6 +4369,7 @@ inline flatbuffers::Offset<CallOptions> CreateCallOptions(flatbuffers::FlatBuffe
 
 struct PadOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef PadOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -4121,13 +4378,13 @@ struct PadOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct PadOptionsBuilder
 {
+  typedef PadOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit PadOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
   {
     start_ = fbb_.StartTable();
   }
-  PadOptionsBuilder &operator=(const PadOptionsBuilder &);
   flatbuffers::Offset<PadOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -4144,6 +4401,7 @@ inline flatbuffers::Offset<PadOptions> CreatePadOptions(flatbuffers::FlatBufferB
 
 struct PadV2Options FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef PadV2OptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -4152,13 +4410,13 @@ struct PadV2Options FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct PadV2OptionsBuilder
 {
+  typedef PadV2Options Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit PadV2OptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
   {
     start_ = fbb_.StartTable();
   }
-  PadV2OptionsBuilder &operator=(const PadV2OptionsBuilder &);
   flatbuffers::Offset<PadV2Options> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -4175,7 +4433,8 @@ inline flatbuffers::Offset<PadV2Options> CreatePadV2Options(flatbuffers::FlatBuf
 
 struct ReshapeOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef ReshapeOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_NEW_SHAPE = 4
   };
@@ -4192,6 +4451,7 @@ struct ReshapeOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct ReshapeOptionsBuilder
 {
+  typedef ReshapeOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_new_shape(flatbuffers::Offset<flatbuffers::Vector<int32_t>> new_shape)
@@ -4202,7 +4462,6 @@ struct ReshapeOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  ReshapeOptionsBuilder &operator=(const ReshapeOptionsBuilder &);
   flatbuffers::Offset<ReshapeOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -4224,12 +4483,13 @@ inline flatbuffers::Offset<ReshapeOptions>
 CreateReshapeOptionsDirect(flatbuffers::FlatBufferBuilder &_fbb,
                            const std::vector<int32_t> *new_shape = nullptr)
 {
-  return onert_tflite::CreateReshapeOptions(_fbb,
-                                            new_shape ? _fbb.CreateVector<int32_t>(*new_shape) : 0);
+  auto new_shape__ = new_shape ? _fbb.CreateVector<int32_t>(*new_shape) : 0;
+  return onert_tflite::CreateReshapeOptions(_fbb, new_shape__);
 }
 
 struct SpaceToBatchNDOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef SpaceToBatchNDOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -4238,13 +4498,13 @@ struct SpaceToBatchNDOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Tabl
 
 struct SpaceToBatchNDOptionsBuilder
 {
+  typedef SpaceToBatchNDOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit SpaceToBatchNDOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
   {
     start_ = fbb_.StartTable();
   }
-  SpaceToBatchNDOptionsBuilder &operator=(const SpaceToBatchNDOptionsBuilder &);
   flatbuffers::Offset<SpaceToBatchNDOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -4262,6 +4522,7 @@ CreateSpaceToBatchNDOptions(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct BatchToSpaceNDOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef BatchToSpaceNDOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -4270,13 +4531,13 @@ struct BatchToSpaceNDOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Tabl
 
 struct BatchToSpaceNDOptionsBuilder
 {
+  typedef BatchToSpaceNDOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit BatchToSpaceNDOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
   {
     start_ = fbb_.StartTable();
   }
-  BatchToSpaceNDOptionsBuilder &operator=(const BatchToSpaceNDOptionsBuilder &);
   flatbuffers::Offset<BatchToSpaceNDOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -4294,7 +4555,8 @@ CreateBatchToSpaceNDOptions(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct SkipGramOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef SkipGramOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_NGRAM_SIZE = 4,
     VT_MAX_SKIP_SIZE = 6,
@@ -4313,6 +4575,7 @@ struct SkipGramOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct SkipGramOptionsBuilder
 {
+  typedef SkipGramOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_ngram_size(int32_t ngram_size)
@@ -4332,7 +4595,6 @@ struct SkipGramOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  SkipGramOptionsBuilder &operator=(const SkipGramOptionsBuilder &);
   flatbuffers::Offset<SkipGramOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -4354,7 +4616,8 @@ CreateSkipGramOptions(flatbuffers::FlatBufferBuilder &_fbb, int32_t ngram_size =
 
 struct SpaceToDepthOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef SpaceToDepthOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_BLOCK_SIZE = 4
   };
@@ -4368,6 +4631,7 @@ struct SpaceToDepthOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct SpaceToDepthOptionsBuilder
 {
+  typedef SpaceToDepthOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_block_size(int32_t block_size)
@@ -4378,7 +4642,6 @@ struct SpaceToDepthOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  SpaceToDepthOptionsBuilder &operator=(const SpaceToDepthOptionsBuilder &);
   flatbuffers::Offset<SpaceToDepthOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -4397,7 +4660,8 @@ CreateSpaceToDepthOptions(flatbuffers::FlatBufferBuilder &_fbb, int32_t block_si
 
 struct DepthToSpaceOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef DepthToSpaceOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_BLOCK_SIZE = 4
   };
@@ -4411,6 +4675,7 @@ struct DepthToSpaceOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct DepthToSpaceOptionsBuilder
 {
+  typedef DepthToSpaceOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_block_size(int32_t block_size)
@@ -4421,7 +4686,6 @@ struct DepthToSpaceOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  DepthToSpaceOptionsBuilder &operator=(const DepthToSpaceOptionsBuilder &);
   flatbuffers::Offset<DepthToSpaceOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -4440,13 +4704,15 @@ CreateDepthToSpaceOptions(flatbuffers::FlatBufferBuilder &_fbb, int32_t block_si
 
 struct SubOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef SubOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_FUSED_ACTIVATION_FUNCTION = 4
   };
-  ActivationFunctionType fused_activation_function() const
+  onert_tflite::ActivationFunctionType fused_activation_function() const
   {
-    return static_cast<ActivationFunctionType>(GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
+    return static_cast<onert_tflite::ActivationFunctionType>(
+      GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
   }
   bool Verify(flatbuffers::Verifier &verifier) const
   {
@@ -4457,9 +4723,10 @@ struct SubOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct SubOptionsBuilder
 {
+  typedef SubOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_fused_activation_function(ActivationFunctionType fused_activation_function)
+  void add_fused_activation_function(onert_tflite::ActivationFunctionType fused_activation_function)
   {
     fbb_.AddElement<int8_t>(SubOptions::VT_FUSED_ACTIVATION_FUNCTION,
                             static_cast<int8_t>(fused_activation_function), 0);
@@ -4468,7 +4735,6 @@ struct SubOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  SubOptionsBuilder &operator=(const SubOptionsBuilder &);
   flatbuffers::Offset<SubOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -4479,7 +4745,8 @@ struct SubOptionsBuilder
 
 inline flatbuffers::Offset<SubOptions>
 CreateSubOptions(flatbuffers::FlatBufferBuilder &_fbb,
-                 ActivationFunctionType fused_activation_function = ActivationFunctionType_NONE)
+                 onert_tflite::ActivationFunctionType fused_activation_function =
+                   onert_tflite::ActivationFunctionType_NONE)
 {
   SubOptionsBuilder builder_(_fbb);
   builder_.add_fused_activation_function(fused_activation_function);
@@ -4488,13 +4755,15 @@ CreateSubOptions(flatbuffers::FlatBufferBuilder &_fbb,
 
 struct DivOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef DivOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_FUSED_ACTIVATION_FUNCTION = 4
   };
-  ActivationFunctionType fused_activation_function() const
+  onert_tflite::ActivationFunctionType fused_activation_function() const
   {
-    return static_cast<ActivationFunctionType>(GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
+    return static_cast<onert_tflite::ActivationFunctionType>(
+      GetField<int8_t>(VT_FUSED_ACTIVATION_FUNCTION, 0));
   }
   bool Verify(flatbuffers::Verifier &verifier) const
   {
@@ -4505,9 +4774,10 @@ struct DivOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct DivOptionsBuilder
 {
+  typedef DivOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_fused_activation_function(ActivationFunctionType fused_activation_function)
+  void add_fused_activation_function(onert_tflite::ActivationFunctionType fused_activation_function)
   {
     fbb_.AddElement<int8_t>(DivOptions::VT_FUSED_ACTIVATION_FUNCTION,
                             static_cast<int8_t>(fused_activation_function), 0);
@@ -4516,7 +4786,6 @@ struct DivOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  DivOptionsBuilder &operator=(const DivOptionsBuilder &);
   flatbuffers::Offset<DivOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -4527,7 +4796,8 @@ struct DivOptionsBuilder
 
 inline flatbuffers::Offset<DivOptions>
 CreateDivOptions(flatbuffers::FlatBufferBuilder &_fbb,
-                 ActivationFunctionType fused_activation_function = ActivationFunctionType_NONE)
+                 onert_tflite::ActivationFunctionType fused_activation_function =
+                   onert_tflite::ActivationFunctionType_NONE)
 {
   DivOptionsBuilder builder_(_fbb);
   builder_.add_fused_activation_function(fused_activation_function);
@@ -4536,6 +4806,7 @@ CreateDivOptions(flatbuffers::FlatBufferBuilder &_fbb,
 
 struct TopKV2Options FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef TopKV2OptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -4544,13 +4815,13 @@ struct TopKV2Options FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct TopKV2OptionsBuilder
 {
+  typedef TopKV2Options Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit TopKV2OptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
   {
     start_ = fbb_.StartTable();
   }
-  TopKV2OptionsBuilder &operator=(const TopKV2OptionsBuilder &);
   flatbuffers::Offset<TopKV2Options> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -4567,13 +4838,14 @@ inline flatbuffers::Offset<TopKV2Options> CreateTopKV2Options(flatbuffers::FlatB
 
 struct EmbeddingLookupSparseOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef EmbeddingLookupSparseOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_COMBINER = 4
   };
-  CombinerType combiner() const
+  onert_tflite::CombinerType combiner() const
   {
-    return static_cast<CombinerType>(GetField<int8_t>(VT_COMBINER, 0));
+    return static_cast<onert_tflite::CombinerType>(GetField<int8_t>(VT_COMBINER, 0));
   }
   bool Verify(flatbuffers::Verifier &verifier) const
   {
@@ -4584,9 +4856,10 @@ struct EmbeddingLookupSparseOptions FLATBUFFERS_FINAL_CLASS : private flatbuffer
 
 struct EmbeddingLookupSparseOptionsBuilder
 {
+  typedef EmbeddingLookupSparseOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_combiner(CombinerType combiner)
+  void add_combiner(onert_tflite::CombinerType combiner)
   {
     fbb_.AddElement<int8_t>(EmbeddingLookupSparseOptions::VT_COMBINER,
                             static_cast<int8_t>(combiner), 0);
@@ -4595,7 +4868,6 @@ struct EmbeddingLookupSparseOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  EmbeddingLookupSparseOptionsBuilder &operator=(const EmbeddingLookupSparseOptionsBuilder &);
   flatbuffers::Offset<EmbeddingLookupSparseOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -4604,9 +4876,9 @@ struct EmbeddingLookupSparseOptionsBuilder
   }
 };
 
-inline flatbuffers::Offset<EmbeddingLookupSparseOptions>
-CreateEmbeddingLookupSparseOptions(flatbuffers::FlatBufferBuilder &_fbb,
-                                   CombinerType combiner = CombinerType_SUM)
+inline flatbuffers::Offset<EmbeddingLookupSparseOptions> CreateEmbeddingLookupSparseOptions(
+  flatbuffers::FlatBufferBuilder &_fbb,
+  onert_tflite::CombinerType combiner = onert_tflite::CombinerType_SUM)
 {
   EmbeddingLookupSparseOptionsBuilder builder_(_fbb);
   builder_.add_combiner(combiner);
@@ -4615,7 +4887,8 @@ CreateEmbeddingLookupSparseOptions(flatbuffers::FlatBufferBuilder &_fbb,
 
 struct GatherOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef GatherOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_AXIS = 4
   };
@@ -4629,6 +4902,7 @@ struct GatherOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct GatherOptionsBuilder
 {
+  typedef GatherOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_axis(int32_t axis) { fbb_.AddElement<int32_t>(GatherOptions::VT_AXIS, axis, 0); }
@@ -4636,7 +4910,6 @@ struct GatherOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  GatherOptionsBuilder &operator=(const GatherOptionsBuilder &);
   flatbuffers::Offset<GatherOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -4655,6 +4928,7 @@ inline flatbuffers::Offset<GatherOptions> CreateGatherOptions(flatbuffers::FlatB
 
 struct TransposeOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef TransposeOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -4663,13 +4937,13 @@ struct TransposeOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct TransposeOptionsBuilder
 {
+  typedef TransposeOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit TransposeOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
   {
     start_ = fbb_.StartTable();
   }
-  TransposeOptionsBuilder &operator=(const TransposeOptionsBuilder &);
   flatbuffers::Offset<TransposeOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -4687,6 +4961,7 @@ CreateTransposeOptions(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct ExpOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef ExpOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -4695,13 +4970,13 @@ struct ExpOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct ExpOptionsBuilder
 {
+  typedef ExpOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit ExpOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
   {
     start_ = fbb_.StartTable();
   }
-  ExpOptionsBuilder &operator=(const ExpOptionsBuilder &);
   flatbuffers::Offset<ExpOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -4718,6 +4993,7 @@ inline flatbuffers::Offset<ExpOptions> CreateExpOptions(flatbuffers::FlatBufferB
 
 struct CosOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef CosOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -4726,13 +5002,13 @@ struct CosOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct CosOptionsBuilder
 {
+  typedef CosOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit CosOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
   {
     start_ = fbb_.StartTable();
   }
-  CosOptionsBuilder &operator=(const CosOptionsBuilder &);
   flatbuffers::Offset<CosOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -4749,7 +5025,8 @@ inline flatbuffers::Offset<CosOptions> CreateCosOptions(flatbuffers::FlatBufferB
 
 struct ReducerOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef ReducerOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_KEEP_DIMS = 4
   };
@@ -4763,6 +5040,7 @@ struct ReducerOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct ReducerOptionsBuilder
 {
+  typedef ReducerOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_keep_dims(bool keep_dims)
@@ -4773,7 +5051,6 @@ struct ReducerOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  ReducerOptionsBuilder &operator=(const ReducerOptionsBuilder &);
   flatbuffers::Offset<ReducerOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -4792,7 +5069,8 @@ CreateReducerOptions(flatbuffers::FlatBufferBuilder &_fbb, bool keep_dims = fals
 
 struct SqueezeOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef SqueezeOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_SQUEEZE_DIMS = 4
   };
@@ -4809,6 +5087,7 @@ struct SqueezeOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct SqueezeOptionsBuilder
 {
+  typedef SqueezeOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_squeeze_dims(flatbuffers::Offset<flatbuffers::Vector<int32_t>> squeeze_dims)
@@ -4819,7 +5098,6 @@ struct SqueezeOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  SqueezeOptionsBuilder &operator=(const SqueezeOptionsBuilder &);
   flatbuffers::Offset<SqueezeOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -4841,13 +5119,14 @@ inline flatbuffers::Offset<SqueezeOptions>
 CreateSqueezeOptionsDirect(flatbuffers::FlatBufferBuilder &_fbb,
                            const std::vector<int32_t> *squeeze_dims = nullptr)
 {
-  return onert_tflite::CreateSqueezeOptions(
-    _fbb, squeeze_dims ? _fbb.CreateVector<int32_t>(*squeeze_dims) : 0);
+  auto squeeze_dims__ = squeeze_dims ? _fbb.CreateVector<int32_t>(*squeeze_dims) : 0;
+  return onert_tflite::CreateSqueezeOptions(_fbb, squeeze_dims__);
 }
 
 struct SplitOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef SplitOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_NUM_SPLITS = 4
   };
@@ -4861,6 +5140,7 @@ struct SplitOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct SplitOptionsBuilder
 {
+  typedef SplitOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_num_splits(int32_t num_splits)
@@ -4871,7 +5151,6 @@ struct SplitOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  SplitOptionsBuilder &operator=(const SplitOptionsBuilder &);
   flatbuffers::Offset<SplitOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -4890,7 +5169,8 @@ inline flatbuffers::Offset<SplitOptions> CreateSplitOptions(flatbuffers::FlatBuf
 
 struct SplitVOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef SplitVOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_NUM_SPLITS = 4
   };
@@ -4904,6 +5184,7 @@ struct SplitVOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct SplitVOptionsBuilder
 {
+  typedef SplitVOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_num_splits(int32_t num_splits)
@@ -4914,7 +5195,6 @@ struct SplitVOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  SplitVOptionsBuilder &operator=(const SplitVOptionsBuilder &);
   flatbuffers::Offset<SplitVOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -4933,7 +5213,8 @@ inline flatbuffers::Offset<SplitVOptions> CreateSplitVOptions(flatbuffers::FlatB
 
 struct StridedSliceOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef StridedSliceOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_BEGIN_MASK = 4,
     VT_END_MASK = 6,
@@ -4958,6 +5239,7 @@ struct StridedSliceOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct StridedSliceOptionsBuilder
 {
+  typedef StridedSliceOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_begin_mask(int32_t begin_mask)
@@ -4984,7 +5266,6 @@ struct StridedSliceOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  StridedSliceOptionsBuilder &operator=(const StridedSliceOptionsBuilder &);
   flatbuffers::Offset<StridedSliceOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -5009,6 +5290,7 @@ CreateStridedSliceOptions(flatbuffers::FlatBufferBuilder &_fbb, int32_t begin_ma
 
 struct LogSoftmaxOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef LogSoftmaxOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -5017,13 +5299,13 @@ struct LogSoftmaxOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct LogSoftmaxOptionsBuilder
 {
+  typedef LogSoftmaxOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit LogSoftmaxOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
   {
     start_ = fbb_.StartTable();
   }
-  LogSoftmaxOptionsBuilder &operator=(const LogSoftmaxOptionsBuilder &);
   flatbuffers::Offset<LogSoftmaxOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -5041,18 +5323,19 @@ CreateLogSoftmaxOptions(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct CastOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef CastOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_IN_DATA_TYPE = 4,
     VT_OUT_DATA_TYPE = 6
   };
-  TensorType in_data_type() const
+  onert_tflite::TensorType in_data_type() const
   {
-    return static_cast<TensorType>(GetField<int8_t>(VT_IN_DATA_TYPE, 0));
+    return static_cast<onert_tflite::TensorType>(GetField<int8_t>(VT_IN_DATA_TYPE, 0));
   }
-  TensorType out_data_type() const
+  onert_tflite::TensorType out_data_type() const
   {
-    return static_cast<TensorType>(GetField<int8_t>(VT_OUT_DATA_TYPE, 0));
+    return static_cast<onert_tflite::TensorType>(GetField<int8_t>(VT_OUT_DATA_TYPE, 0));
   }
   bool Verify(flatbuffers::Verifier &verifier) const
   {
@@ -5063,13 +5346,14 @@ struct CastOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct CastOptionsBuilder
 {
+  typedef CastOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_in_data_type(TensorType in_data_type)
+  void add_in_data_type(onert_tflite::TensorType in_data_type)
   {
     fbb_.AddElement<int8_t>(CastOptions::VT_IN_DATA_TYPE, static_cast<int8_t>(in_data_type), 0);
   }
-  void add_out_data_type(TensorType out_data_type)
+  void add_out_data_type(onert_tflite::TensorType out_data_type)
   {
     fbb_.AddElement<int8_t>(CastOptions::VT_OUT_DATA_TYPE, static_cast<int8_t>(out_data_type), 0);
   }
@@ -5077,7 +5361,6 @@ struct CastOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  CastOptionsBuilder &operator=(const CastOptionsBuilder &);
   flatbuffers::Offset<CastOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -5088,8 +5371,8 @@ struct CastOptionsBuilder
 
 inline flatbuffers::Offset<CastOptions>
 CreateCastOptions(flatbuffers::FlatBufferBuilder &_fbb,
-                  TensorType in_data_type = TensorType_FLOAT32,
-                  TensorType out_data_type = TensorType_FLOAT32)
+                  onert_tflite::TensorType in_data_type = onert_tflite::TensorType_FLOAT32,
+                  onert_tflite::TensorType out_data_type = onert_tflite::TensorType_FLOAT32)
 {
   CastOptionsBuilder builder_(_fbb);
   builder_.add_out_data_type(out_data_type);
@@ -5099,6 +5382,7 @@ CreateCastOptions(flatbuffers::FlatBufferBuilder &_fbb,
 
 struct DequantizeOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef DequantizeOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -5107,13 +5391,13 @@ struct DequantizeOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct DequantizeOptionsBuilder
 {
+  typedef DequantizeOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit DequantizeOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
   {
     start_ = fbb_.StartTable();
   }
-  DequantizeOptionsBuilder &operator=(const DequantizeOptionsBuilder &);
   flatbuffers::Offset<DequantizeOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -5131,6 +5415,7 @@ CreateDequantizeOptions(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct MaximumMinimumOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef MaximumMinimumOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -5139,13 +5424,13 @@ struct MaximumMinimumOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Tabl
 
 struct MaximumMinimumOptionsBuilder
 {
+  typedef MaximumMinimumOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit MaximumMinimumOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
   {
     start_ = fbb_.StartTable();
   }
-  MaximumMinimumOptionsBuilder &operator=(const MaximumMinimumOptionsBuilder &);
   flatbuffers::Offset<MaximumMinimumOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -5163,6 +5448,7 @@ CreateMaximumMinimumOptions(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct TileOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef TileOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -5171,13 +5457,13 @@ struct TileOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct TileOptionsBuilder
 {
+  typedef TileOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit TileOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
   {
     start_ = fbb_.StartTable();
   }
-  TileOptionsBuilder &operator=(const TileOptionsBuilder &);
   flatbuffers::Offset<TileOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -5194,13 +5480,14 @@ inline flatbuffers::Offset<TileOptions> CreateTileOptions(flatbuffers::FlatBuffe
 
 struct ArgMaxOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef ArgMaxOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_OUTPUT_TYPE = 4
   };
-  TensorType output_type() const
+  onert_tflite::TensorType output_type() const
   {
-    return static_cast<TensorType>(GetField<int8_t>(VT_OUTPUT_TYPE, 0));
+    return static_cast<onert_tflite::TensorType>(GetField<int8_t>(VT_OUTPUT_TYPE, 0));
   }
   bool Verify(flatbuffers::Verifier &verifier) const
   {
@@ -5211,9 +5498,10 @@ struct ArgMaxOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct ArgMaxOptionsBuilder
 {
+  typedef ArgMaxOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_output_type(TensorType output_type)
+  void add_output_type(onert_tflite::TensorType output_type)
   {
     fbb_.AddElement<int8_t>(ArgMaxOptions::VT_OUTPUT_TYPE, static_cast<int8_t>(output_type), 0);
   }
@@ -5221,7 +5509,6 @@ struct ArgMaxOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  ArgMaxOptionsBuilder &operator=(const ArgMaxOptionsBuilder &);
   flatbuffers::Offset<ArgMaxOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -5232,7 +5519,7 @@ struct ArgMaxOptionsBuilder
 
 inline flatbuffers::Offset<ArgMaxOptions>
 CreateArgMaxOptions(flatbuffers::FlatBufferBuilder &_fbb,
-                    TensorType output_type = TensorType_FLOAT32)
+                    onert_tflite::TensorType output_type = onert_tflite::TensorType_FLOAT32)
 {
   ArgMaxOptionsBuilder builder_(_fbb);
   builder_.add_output_type(output_type);
@@ -5241,13 +5528,14 @@ CreateArgMaxOptions(flatbuffers::FlatBufferBuilder &_fbb,
 
 struct ArgMinOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef ArgMinOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_OUTPUT_TYPE = 4
   };
-  TensorType output_type() const
+  onert_tflite::TensorType output_type() const
   {
-    return static_cast<TensorType>(GetField<int8_t>(VT_OUTPUT_TYPE, 0));
+    return static_cast<onert_tflite::TensorType>(GetField<int8_t>(VT_OUTPUT_TYPE, 0));
   }
   bool Verify(flatbuffers::Verifier &verifier) const
   {
@@ -5258,9 +5546,10 @@ struct ArgMinOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct ArgMinOptionsBuilder
 {
+  typedef ArgMinOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_output_type(TensorType output_type)
+  void add_output_type(onert_tflite::TensorType output_type)
   {
     fbb_.AddElement<int8_t>(ArgMinOptions::VT_OUTPUT_TYPE, static_cast<int8_t>(output_type), 0);
   }
@@ -5268,7 +5557,6 @@ struct ArgMinOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  ArgMinOptionsBuilder &operator=(const ArgMinOptionsBuilder &);
   flatbuffers::Offset<ArgMinOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -5279,7 +5567,7 @@ struct ArgMinOptionsBuilder
 
 inline flatbuffers::Offset<ArgMinOptions>
 CreateArgMinOptions(flatbuffers::FlatBufferBuilder &_fbb,
-                    TensorType output_type = TensorType_FLOAT32)
+                    onert_tflite::TensorType output_type = onert_tflite::TensorType_FLOAT32)
 {
   ArgMinOptionsBuilder builder_(_fbb);
   builder_.add_output_type(output_type);
@@ -5288,6 +5576,7 @@ CreateArgMinOptions(flatbuffers::FlatBufferBuilder &_fbb,
 
 struct GreaterOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef GreaterOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -5296,13 +5585,13 @@ struct GreaterOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct GreaterOptionsBuilder
 {
+  typedef GreaterOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit GreaterOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
   {
     start_ = fbb_.StartTable();
   }
-  GreaterOptionsBuilder &operator=(const GreaterOptionsBuilder &);
   flatbuffers::Offset<GreaterOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -5320,6 +5609,7 @@ CreateGreaterOptions(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct GreaterEqualOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef GreaterEqualOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -5328,13 +5618,13 @@ struct GreaterEqualOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct GreaterEqualOptionsBuilder
 {
+  typedef GreaterEqualOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit GreaterEqualOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
   {
     start_ = fbb_.StartTable();
   }
-  GreaterEqualOptionsBuilder &operator=(const GreaterEqualOptionsBuilder &);
   flatbuffers::Offset<GreaterEqualOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -5352,6 +5642,7 @@ CreateGreaterEqualOptions(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct LessOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef LessOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -5360,13 +5651,13 @@ struct LessOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct LessOptionsBuilder
 {
+  typedef LessOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit LessOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
   {
     start_ = fbb_.StartTable();
   }
-  LessOptionsBuilder &operator=(const LessOptionsBuilder &);
   flatbuffers::Offset<LessOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -5383,6 +5674,7 @@ inline flatbuffers::Offset<LessOptions> CreateLessOptions(flatbuffers::FlatBuffe
 
 struct LessEqualOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef LessEqualOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -5391,13 +5683,13 @@ struct LessEqualOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct LessEqualOptionsBuilder
 {
+  typedef LessEqualOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit LessEqualOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
   {
     start_ = fbb_.StartTable();
   }
-  LessEqualOptionsBuilder &operator=(const LessEqualOptionsBuilder &);
   flatbuffers::Offset<LessEqualOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -5415,6 +5707,7 @@ CreateLessEqualOptions(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct NegOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef NegOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -5423,13 +5716,13 @@ struct NegOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct NegOptionsBuilder
 {
+  typedef NegOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit NegOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
   {
     start_ = fbb_.StartTable();
   }
-  NegOptionsBuilder &operator=(const NegOptionsBuilder &);
   flatbuffers::Offset<NegOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -5446,6 +5739,7 @@ inline flatbuffers::Offset<NegOptions> CreateNegOptions(flatbuffers::FlatBufferB
 
 struct SelectOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef SelectOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -5454,13 +5748,13 @@ struct SelectOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct SelectOptionsBuilder
 {
+  typedef SelectOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit SelectOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
   {
     start_ = fbb_.StartTable();
   }
-  SelectOptionsBuilder &operator=(const SelectOptionsBuilder &);
   flatbuffers::Offset<SelectOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -5477,6 +5771,7 @@ inline flatbuffers::Offset<SelectOptions> CreateSelectOptions(flatbuffers::FlatB
 
 struct SliceOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef SliceOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -5485,13 +5780,13 @@ struct SliceOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct SliceOptionsBuilder
 {
+  typedef SliceOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit SliceOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
   {
     start_ = fbb_.StartTable();
   }
-  SliceOptionsBuilder &operator=(const SliceOptionsBuilder &);
   flatbuffers::Offset<SliceOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -5508,13 +5803,17 @@ inline flatbuffers::Offset<SliceOptions> CreateSliceOptions(flatbuffers::FlatBuf
 
 struct TransposeConvOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef TransposeConvOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_PADDING = 4,
     VT_STRIDE_W = 6,
     VT_STRIDE_H = 8
   };
-  Padding padding() const { return static_cast<Padding>(GetField<int8_t>(VT_PADDING, 0)); }
+  onert_tflite::Padding padding() const
+  {
+    return static_cast<onert_tflite::Padding>(GetField<int8_t>(VT_PADDING, 0));
+  }
   int32_t stride_w() const { return GetField<int32_t>(VT_STRIDE_W, 0); }
   int32_t stride_h() const { return GetField<int32_t>(VT_STRIDE_H, 0); }
   bool Verify(flatbuffers::Verifier &verifier) const
@@ -5527,9 +5826,10 @@ struct TransposeConvOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct TransposeConvOptionsBuilder
 {
+  typedef TransposeConvOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_padding(Padding padding)
+  void add_padding(onert_tflite::Padding padding)
   {
     fbb_.AddElement<int8_t>(TransposeConvOptions::VT_PADDING, static_cast<int8_t>(padding), 0);
   }
@@ -5545,7 +5845,6 @@ struct TransposeConvOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  TransposeConvOptionsBuilder &operator=(const TransposeConvOptionsBuilder &);
   flatbuffers::Offset<TransposeConvOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -5555,7 +5854,8 @@ struct TransposeConvOptionsBuilder
 };
 
 inline flatbuffers::Offset<TransposeConvOptions>
-CreateTransposeConvOptions(flatbuffers::FlatBufferBuilder &_fbb, Padding padding = Padding_SAME,
+CreateTransposeConvOptions(flatbuffers::FlatBufferBuilder &_fbb,
+                           onert_tflite::Padding padding = onert_tflite::Padding_SAME,
                            int32_t stride_w = 0, int32_t stride_h = 0)
 {
   TransposeConvOptionsBuilder builder_(_fbb);
@@ -5567,6 +5867,7 @@ CreateTransposeConvOptions(flatbuffers::FlatBufferBuilder &_fbb, Padding padding
 
 struct ExpandDimsOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef ExpandDimsOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -5575,13 +5876,13 @@ struct ExpandDimsOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct ExpandDimsOptionsBuilder
 {
+  typedef ExpandDimsOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit ExpandDimsOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
   {
     start_ = fbb_.StartTable();
   }
-  ExpandDimsOptionsBuilder &operator=(const ExpandDimsOptionsBuilder &);
   flatbuffers::Offset<ExpandDimsOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -5599,7 +5900,8 @@ CreateExpandDimsOptions(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct SparseToDenseOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef SparseToDenseOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_VALIDATE_INDICES = 4
   };
@@ -5613,6 +5915,7 @@ struct SparseToDenseOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct SparseToDenseOptionsBuilder
 {
+  typedef SparseToDenseOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_validate_indices(bool validate_indices)
@@ -5624,7 +5927,6 @@ struct SparseToDenseOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  SparseToDenseOptionsBuilder &operator=(const SparseToDenseOptionsBuilder &);
   flatbuffers::Offset<SparseToDenseOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -5643,6 +5945,7 @@ CreateSparseToDenseOptions(flatbuffers::FlatBufferBuilder &_fbb, bool validate_i
 
 struct EqualOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef EqualOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -5651,13 +5954,13 @@ struct EqualOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct EqualOptionsBuilder
 {
+  typedef EqualOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit EqualOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
   {
     start_ = fbb_.StartTable();
   }
-  EqualOptionsBuilder &operator=(const EqualOptionsBuilder &);
   flatbuffers::Offset<EqualOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -5674,6 +5977,7 @@ inline flatbuffers::Offset<EqualOptions> CreateEqualOptions(flatbuffers::FlatBuf
 
 struct NotEqualOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef NotEqualOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -5682,13 +5986,13 @@ struct NotEqualOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct NotEqualOptionsBuilder
 {
+  typedef NotEqualOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit NotEqualOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
   {
     start_ = fbb_.StartTable();
   }
-  NotEqualOptionsBuilder &operator=(const NotEqualOptionsBuilder &);
   flatbuffers::Offset<NotEqualOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -5706,11 +6010,15 @@ CreateNotEqualOptions(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct ShapeOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef ShapeOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_OUT_TYPE = 4
   };
-  TensorType out_type() const { return static_cast<TensorType>(GetField<int8_t>(VT_OUT_TYPE, 0)); }
+  onert_tflite::TensorType out_type() const
+  {
+    return static_cast<onert_tflite::TensorType>(GetField<int8_t>(VT_OUT_TYPE, 0));
+  }
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && VerifyField<int8_t>(verifier, VT_OUT_TYPE) &&
@@ -5720,9 +6028,10 @@ struct ShapeOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct ShapeOptionsBuilder
 {
+  typedef ShapeOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_out_type(TensorType out_type)
+  void add_out_type(onert_tflite::TensorType out_type)
   {
     fbb_.AddElement<int8_t>(ShapeOptions::VT_OUT_TYPE, static_cast<int8_t>(out_type), 0);
   }
@@ -5730,7 +6039,6 @@ struct ShapeOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  ShapeOptionsBuilder &operator=(const ShapeOptionsBuilder &);
   flatbuffers::Offset<ShapeOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -5740,7 +6048,8 @@ struct ShapeOptionsBuilder
 };
 
 inline flatbuffers::Offset<ShapeOptions>
-CreateShapeOptions(flatbuffers::FlatBufferBuilder &_fbb, TensorType out_type = TensorType_FLOAT32)
+CreateShapeOptions(flatbuffers::FlatBufferBuilder &_fbb,
+                   onert_tflite::TensorType out_type = onert_tflite::TensorType_FLOAT32)
 {
   ShapeOptionsBuilder builder_(_fbb);
   builder_.add_out_type(out_type);
@@ -5749,6 +6058,7 @@ CreateShapeOptions(flatbuffers::FlatBufferBuilder &_fbb, TensorType out_type = T
 
 struct RankOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef RankOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -5757,13 +6067,13 @@ struct RankOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct RankOptionsBuilder
 {
+  typedef RankOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit RankOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
   {
     start_ = fbb_.StartTable();
   }
-  RankOptionsBuilder &operator=(const RankOptionsBuilder &);
   flatbuffers::Offset<RankOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -5780,6 +6090,7 @@ inline flatbuffers::Offset<RankOptions> CreateRankOptions(flatbuffers::FlatBuffe
 
 struct PowOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef PowOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -5788,13 +6099,13 @@ struct PowOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct PowOptionsBuilder
 {
+  typedef PowOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit PowOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
   {
     start_ = fbb_.StartTable();
   }
-  PowOptionsBuilder &operator=(const PowOptionsBuilder &);
   flatbuffers::Offset<PowOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -5811,7 +6122,8 @@ inline flatbuffers::Offset<PowOptions> CreatePowOptions(flatbuffers::FlatBufferB
 
 struct FakeQuantOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef FakeQuantOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_MIN = 4,
     VT_MAX = 6,
@@ -5832,6 +6144,7 @@ struct FakeQuantOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct FakeQuantOptionsBuilder
 {
+  typedef FakeQuantOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_min(float min) { fbb_.AddElement<float>(FakeQuantOptions::VT_MIN, min, 0.0f); }
@@ -5849,7 +6162,6 @@ struct FakeQuantOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  FakeQuantOptionsBuilder &operator=(const FakeQuantOptionsBuilder &);
   flatbuffers::Offset<FakeQuantOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -5872,7 +6184,8 @@ CreateFakeQuantOptions(flatbuffers::FlatBufferBuilder &_fbb, float min = 0.0f, f
 
 struct PackOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef PackOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_VALUES_COUNT = 4,
     VT_AXIS = 6
@@ -5888,6 +6201,7 @@ struct PackOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct PackOptionsBuilder
 {
+  typedef PackOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_values_count(int32_t values_count)
@@ -5899,7 +6213,6 @@ struct PackOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  PackOptionsBuilder &operator=(const PackOptionsBuilder &);
   flatbuffers::Offset<PackOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -5919,6 +6232,7 @@ CreatePackOptions(flatbuffers::FlatBufferBuilder &_fbb, int32_t values_count = 0
 
 struct LogicalOrOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef LogicalOrOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -5927,13 +6241,13 @@ struct LogicalOrOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct LogicalOrOptionsBuilder
 {
+  typedef LogicalOrOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit LogicalOrOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
   {
     start_ = fbb_.StartTable();
   }
-  LogicalOrOptionsBuilder &operator=(const LogicalOrOptionsBuilder &);
   flatbuffers::Offset<LogicalOrOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -5951,7 +6265,8 @@ CreateLogicalOrOptions(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct OneHotOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef OneHotOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_AXIS = 4
   };
@@ -5965,6 +6280,7 @@ struct OneHotOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct OneHotOptionsBuilder
 {
+  typedef OneHotOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_axis(int32_t axis) { fbb_.AddElement<int32_t>(OneHotOptions::VT_AXIS, axis, 0); }
@@ -5972,7 +6288,6 @@ struct OneHotOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  OneHotOptionsBuilder &operator=(const OneHotOptionsBuilder &);
   flatbuffers::Offset<OneHotOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -5991,6 +6306,7 @@ inline flatbuffers::Offset<OneHotOptions> CreateOneHotOptions(flatbuffers::FlatB
 
 struct AbsOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef AbsOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -5999,13 +6315,13 @@ struct AbsOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct AbsOptionsBuilder
 {
+  typedef AbsOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit AbsOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
   {
     start_ = fbb_.StartTable();
   }
-  AbsOptionsBuilder &operator=(const AbsOptionsBuilder &);
   flatbuffers::Offset<AbsOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -6022,6 +6338,7 @@ inline flatbuffers::Offset<AbsOptions> CreateAbsOptions(flatbuffers::FlatBufferB
 
 struct HardSwishOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef HardSwishOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -6030,13 +6347,13 @@ struct HardSwishOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct HardSwishOptionsBuilder
 {
+  typedef HardSwishOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit HardSwishOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
   {
     start_ = fbb_.StartTable();
   }
-  HardSwishOptionsBuilder &operator=(const HardSwishOptionsBuilder &);
   flatbuffers::Offset<HardSwishOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -6054,6 +6371,7 @@ CreateHardSwishOptions(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct LogicalAndOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef LogicalAndOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -6062,13 +6380,13 @@ struct LogicalAndOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct LogicalAndOptionsBuilder
 {
+  typedef LogicalAndOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit LogicalAndOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
   {
     start_ = fbb_.StartTable();
   }
-  LogicalAndOptionsBuilder &operator=(const LogicalAndOptionsBuilder &);
   flatbuffers::Offset<LogicalAndOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -6086,6 +6404,7 @@ CreateLogicalAndOptions(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct LogicalNotOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef LogicalNotOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -6094,13 +6413,13 @@ struct LogicalNotOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct LogicalNotOptionsBuilder
 {
+  typedef LogicalNotOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit LogicalNotOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
   {
     start_ = fbb_.StartTable();
   }
-  LogicalNotOptionsBuilder &operator=(const LogicalNotOptionsBuilder &);
   flatbuffers::Offset<LogicalNotOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -6118,7 +6437,8 @@ CreateLogicalNotOptions(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct UnpackOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef UnpackOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_NUM = 4,
     VT_AXIS = 6
@@ -6134,6 +6454,7 @@ struct UnpackOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct UnpackOptionsBuilder
 {
+  typedef UnpackOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_num(int32_t num) { fbb_.AddElement<int32_t>(UnpackOptions::VT_NUM, num, 0); }
@@ -6142,7 +6463,6 @@ struct UnpackOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  UnpackOptionsBuilder &operator=(const UnpackOptionsBuilder &);
   flatbuffers::Offset<UnpackOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -6162,6 +6482,7 @@ inline flatbuffers::Offset<UnpackOptions> CreateUnpackOptions(flatbuffers::FlatB
 
 struct FloorDivOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef FloorDivOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -6170,13 +6491,13 @@ struct FloorDivOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct FloorDivOptionsBuilder
 {
+  typedef FloorDivOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit FloorDivOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
   {
     start_ = fbb_.StartTable();
   }
-  FloorDivOptionsBuilder &operator=(const FloorDivOptionsBuilder &);
   flatbuffers::Offset<FloorDivOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -6194,6 +6515,7 @@ CreateFloorDivOptions(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct SquareOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef SquareOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -6202,13 +6524,13 @@ struct SquareOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct SquareOptionsBuilder
 {
+  typedef SquareOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit SquareOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
   {
     start_ = fbb_.StartTable();
   }
-  SquareOptionsBuilder &operator=(const SquareOptionsBuilder &);
   flatbuffers::Offset<SquareOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -6225,6 +6547,7 @@ inline flatbuffers::Offset<SquareOptions> CreateSquareOptions(flatbuffers::FlatB
 
 struct ZerosLikeOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef ZerosLikeOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -6233,13 +6556,13 @@ struct ZerosLikeOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct ZerosLikeOptionsBuilder
 {
+  typedef ZerosLikeOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit ZerosLikeOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
   {
     start_ = fbb_.StartTable();
   }
-  ZerosLikeOptionsBuilder &operator=(const ZerosLikeOptionsBuilder &);
   flatbuffers::Offset<ZerosLikeOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -6257,6 +6580,7 @@ CreateZerosLikeOptions(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct FillOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef FillOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -6265,13 +6589,13 @@ struct FillOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct FillOptionsBuilder
 {
+  typedef FillOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit FillOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
   {
     start_ = fbb_.StartTable();
   }
-  FillOptionsBuilder &operator=(const FillOptionsBuilder &);
   flatbuffers::Offset<FillOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -6288,6 +6612,7 @@ inline flatbuffers::Offset<FillOptions> CreateFillOptions(flatbuffers::FlatBuffe
 
 struct FloorModOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef FloorModOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -6296,13 +6621,13 @@ struct FloorModOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct FloorModOptionsBuilder
 {
+  typedef FloorModOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit FloorModOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
   {
     start_ = fbb_.StartTable();
   }
-  FloorModOptionsBuilder &operator=(const FloorModOptionsBuilder &);
   flatbuffers::Offset<FloorModOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -6320,6 +6645,7 @@ CreateFloorModOptions(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct RangeOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef RangeOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -6328,13 +6654,13 @@ struct RangeOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct RangeOptionsBuilder
 {
+  typedef RangeOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit RangeOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
   {
     start_ = fbb_.StartTable();
   }
-  RangeOptionsBuilder &operator=(const RangeOptionsBuilder &);
   flatbuffers::Offset<RangeOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -6351,7 +6677,8 @@ inline flatbuffers::Offset<RangeOptions> CreateRangeOptions(flatbuffers::FlatBuf
 
 struct LeakyReluOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef LeakyReluOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_ALPHA = 4
   };
@@ -6365,6 +6692,7 @@ struct LeakyReluOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct LeakyReluOptionsBuilder
 {
+  typedef LeakyReluOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_alpha(float alpha) { fbb_.AddElement<float>(LeakyReluOptions::VT_ALPHA, alpha, 0.0f); }
@@ -6372,7 +6700,6 @@ struct LeakyReluOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  LeakyReluOptionsBuilder &operator=(const LeakyReluOptionsBuilder &);
   flatbuffers::Offset<LeakyReluOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -6391,6 +6718,7 @@ CreateLeakyReluOptions(flatbuffers::FlatBufferBuilder &_fbb, float alpha = 0.0f)
 
 struct SquaredDifferenceOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef SquaredDifferenceOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -6399,13 +6727,13 @@ struct SquaredDifferenceOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::T
 
 struct SquaredDifferenceOptionsBuilder
 {
+  typedef SquaredDifferenceOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit SquaredDifferenceOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
   {
     start_ = fbb_.StartTable();
   }
-  SquaredDifferenceOptionsBuilder &operator=(const SquaredDifferenceOptionsBuilder &);
   flatbuffers::Offset<SquaredDifferenceOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -6423,11 +6751,15 @@ CreateSquaredDifferenceOptions(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct MirrorPadOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef MirrorPadOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_MODE = 4
   };
-  MirrorPadMode mode() const { return static_cast<MirrorPadMode>(GetField<int8_t>(VT_MODE, 0)); }
+  onert_tflite::MirrorPadMode mode() const
+  {
+    return static_cast<onert_tflite::MirrorPadMode>(GetField<int8_t>(VT_MODE, 0));
+  }
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && VerifyField<int8_t>(verifier, VT_MODE) &&
@@ -6437,9 +6769,10 @@ struct MirrorPadOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct MirrorPadOptionsBuilder
 {
+  typedef MirrorPadOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_mode(MirrorPadMode mode)
+  void add_mode(onert_tflite::MirrorPadMode mode)
   {
     fbb_.AddElement<int8_t>(MirrorPadOptions::VT_MODE, static_cast<int8_t>(mode), 0);
   }
@@ -6447,7 +6780,6 @@ struct MirrorPadOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  MirrorPadOptionsBuilder &operator=(const MirrorPadOptionsBuilder &);
   flatbuffers::Offset<MirrorPadOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -6458,7 +6790,7 @@ struct MirrorPadOptionsBuilder
 
 inline flatbuffers::Offset<MirrorPadOptions>
 CreateMirrorPadOptions(flatbuffers::FlatBufferBuilder &_fbb,
-                       MirrorPadMode mode = MirrorPadMode_REFLECT)
+                       onert_tflite::MirrorPadMode mode = onert_tflite::MirrorPadMode_REFLECT)
 {
   MirrorPadOptionsBuilder builder_(_fbb);
   builder_.add_mode(mode);
@@ -6467,13 +6799,14 @@ CreateMirrorPadOptions(flatbuffers::FlatBufferBuilder &_fbb,
 
 struct UniqueOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef UniqueOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_IDX_OUT_TYPE = 4
   };
-  TensorType idx_out_type() const
+  onert_tflite::TensorType idx_out_type() const
   {
-    return static_cast<TensorType>(GetField<int8_t>(VT_IDX_OUT_TYPE, 2));
+    return static_cast<onert_tflite::TensorType>(GetField<int8_t>(VT_IDX_OUT_TYPE, 2));
   }
   bool Verify(flatbuffers::Verifier &verifier) const
   {
@@ -6484,9 +6817,10 @@ struct UniqueOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct UniqueOptionsBuilder
 {
+  typedef UniqueOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_idx_out_type(TensorType idx_out_type)
+  void add_idx_out_type(onert_tflite::TensorType idx_out_type)
   {
     fbb_.AddElement<int8_t>(UniqueOptions::VT_IDX_OUT_TYPE, static_cast<int8_t>(idx_out_type), 2);
   }
@@ -6494,7 +6828,6 @@ struct UniqueOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  UniqueOptionsBuilder &operator=(const UniqueOptionsBuilder &);
   flatbuffers::Offset<UniqueOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -6505,7 +6838,7 @@ struct UniqueOptionsBuilder
 
 inline flatbuffers::Offset<UniqueOptions>
 CreateUniqueOptions(flatbuffers::FlatBufferBuilder &_fbb,
-                    TensorType idx_out_type = TensorType_INT32)
+                    onert_tflite::TensorType idx_out_type = onert_tflite::TensorType_INT32)
 {
   UniqueOptionsBuilder builder_(_fbb);
   builder_.add_idx_out_type(idx_out_type);
@@ -6514,6 +6847,7 @@ CreateUniqueOptions(flatbuffers::FlatBufferBuilder &_fbb,
 
 struct ReverseV2Options FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef ReverseV2OptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -6522,13 +6856,13 @@ struct ReverseV2Options FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct ReverseV2OptionsBuilder
 {
+  typedef ReverseV2Options Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit ReverseV2OptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
   {
     start_ = fbb_.StartTable();
   }
-  ReverseV2OptionsBuilder &operator=(const ReverseV2OptionsBuilder &);
   flatbuffers::Offset<ReverseV2Options> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -6546,6 +6880,7 @@ CreateReverseV2Options(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct AddNOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef AddNOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -6554,13 +6889,13 @@ struct AddNOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct AddNOptionsBuilder
 {
+  typedef AddNOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit AddNOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
   {
     start_ = fbb_.StartTable();
   }
-  AddNOptionsBuilder &operator=(const AddNOptionsBuilder &);
   flatbuffers::Offset<AddNOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -6577,6 +6912,7 @@ inline flatbuffers::Offset<AddNOptions> CreateAddNOptions(flatbuffers::FlatBuffe
 
 struct GatherNdOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef GatherNdOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -6585,13 +6921,13 @@ struct GatherNdOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct GatherNdOptionsBuilder
 {
+  typedef GatherNdOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit GatherNdOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
   {
     start_ = fbb_.StartTable();
   }
-  GatherNdOptionsBuilder &operator=(const GatherNdOptionsBuilder &);
   flatbuffers::Offset<GatherNdOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -6609,6 +6945,7 @@ CreateGatherNdOptions(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct WhereOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef WhereOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -6617,13 +6954,13 @@ struct WhereOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct WhereOptionsBuilder
 {
+  typedef WhereOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit WhereOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
   {
     start_ = fbb_.StartTable();
   }
-  WhereOptionsBuilder &operator=(const WhereOptionsBuilder &);
   flatbuffers::Offset<WhereOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -6640,7 +6977,8 @@ inline flatbuffers::Offset<WhereOptions> CreateWhereOptions(flatbuffers::FlatBuf
 
 struct ReverseSequenceOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef ReverseSequenceOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_SEQ_DIM = 4,
     VT_BATCH_DIM = 6
@@ -6656,6 +6994,7 @@ struct ReverseSequenceOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Tab
 
 struct ReverseSequenceOptionsBuilder
 {
+  typedef ReverseSequenceOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_seq_dim(int32_t seq_dim)
@@ -6670,7 +7009,6 @@ struct ReverseSequenceOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  ReverseSequenceOptionsBuilder &operator=(const ReverseSequenceOptionsBuilder &);
   flatbuffers::Offset<ReverseSequenceOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -6691,6 +7029,7 @@ CreateReverseSequenceOptions(flatbuffers::FlatBufferBuilder &_fbb, int32_t seq_d
 
 struct MatrixDiagOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef MatrixDiagOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -6699,13 +7038,13 @@ struct MatrixDiagOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct MatrixDiagOptionsBuilder
 {
+  typedef MatrixDiagOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit MatrixDiagOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
   {
     start_ = fbb_.StartTable();
   }
-  MatrixDiagOptionsBuilder &operator=(const MatrixDiagOptionsBuilder &);
   flatbuffers::Offset<MatrixDiagOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -6723,6 +7062,7 @@ CreateMatrixDiagOptions(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct QuantizeOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef QuantizeOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -6731,13 +7071,13 @@ struct QuantizeOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct QuantizeOptionsBuilder
 {
+  typedef QuantizeOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit QuantizeOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
   {
     start_ = fbb_.StartTable();
   }
-  QuantizeOptionsBuilder &operator=(const QuantizeOptionsBuilder &);
   flatbuffers::Offset<QuantizeOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -6755,6 +7095,7 @@ CreateQuantizeOptions(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct MatrixSetDiagOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef MatrixSetDiagOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -6763,13 +7104,13 @@ struct MatrixSetDiagOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct MatrixSetDiagOptionsBuilder
 {
+  typedef MatrixSetDiagOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit MatrixSetDiagOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
   {
     start_ = fbb_.StartTable();
   }
-  MatrixSetDiagOptionsBuilder &operator=(const MatrixSetDiagOptionsBuilder &);
   flatbuffers::Offset<MatrixSetDiagOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -6787,7 +7128,8 @@ CreateMatrixSetDiagOptions(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct IfOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef IfOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_THEN_SUBGRAPH_INDEX = 4,
     VT_ELSE_SUBGRAPH_INDEX = 6
@@ -6803,6 +7145,7 @@ struct IfOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct IfOptionsBuilder
 {
+  typedef IfOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_then_subgraph_index(int32_t then_subgraph_index)
@@ -6817,7 +7160,6 @@ struct IfOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  IfOptionsBuilder &operator=(const IfOptionsBuilder &);
   flatbuffers::Offset<IfOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -6838,7 +7180,8 @@ inline flatbuffers::Offset<IfOptions> CreateIfOptions(flatbuffers::FlatBufferBui
 
 struct WhileOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef WhileOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_COND_SUBGRAPH_INDEX = 4,
     VT_BODY_SUBGRAPH_INDEX = 6
@@ -6854,6 +7197,7 @@ struct WhileOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct WhileOptionsBuilder
 {
+  typedef WhileOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_cond_subgraph_index(int32_t cond_subgraph_index)
@@ -6868,7 +7212,6 @@ struct WhileOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  WhileOptionsBuilder &operator=(const WhileOptionsBuilder &);
   flatbuffers::Offset<WhileOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -6889,6 +7232,7 @@ inline flatbuffers::Offset<WhileOptions> CreateWhileOptions(flatbuffers::FlatBuf
 
 struct NonMaxSuppressionV4Options FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef NonMaxSuppressionV4OptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -6897,13 +7241,13 @@ struct NonMaxSuppressionV4Options FLATBUFFERS_FINAL_CLASS : private flatbuffers:
 
 struct NonMaxSuppressionV4OptionsBuilder
 {
+  typedef NonMaxSuppressionV4Options Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit NonMaxSuppressionV4OptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
   {
     start_ = fbb_.StartTable();
   }
-  NonMaxSuppressionV4OptionsBuilder &operator=(const NonMaxSuppressionV4OptionsBuilder &);
   flatbuffers::Offset<NonMaxSuppressionV4Options> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -6921,6 +7265,7 @@ CreateNonMaxSuppressionV4Options(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct NonMaxSuppressionV5Options FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef NonMaxSuppressionV5OptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -6929,13 +7274,13 @@ struct NonMaxSuppressionV5Options FLATBUFFERS_FINAL_CLASS : private flatbuffers:
 
 struct NonMaxSuppressionV5OptionsBuilder
 {
+  typedef NonMaxSuppressionV5Options Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit NonMaxSuppressionV5OptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
   {
     start_ = fbb_.StartTable();
   }
-  NonMaxSuppressionV5OptionsBuilder &operator=(const NonMaxSuppressionV5OptionsBuilder &);
   flatbuffers::Offset<NonMaxSuppressionV5Options> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -6953,6 +7298,7 @@ CreateNonMaxSuppressionV5Options(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct ScatterNdOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef ScatterNdOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -6961,13 +7307,13 @@ struct ScatterNdOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct ScatterNdOptionsBuilder
 {
+  typedef ScatterNdOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit ScatterNdOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
   {
     start_ = fbb_.StartTable();
   }
-  ScatterNdOptionsBuilder &operator=(const ScatterNdOptionsBuilder &);
   flatbuffers::Offset<ScatterNdOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -6985,6 +7331,7 @@ CreateScatterNdOptions(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct SelectV2Options FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef SelectV2OptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -6993,13 +7340,13 @@ struct SelectV2Options FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct SelectV2OptionsBuilder
 {
+  typedef SelectV2Options Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit SelectV2OptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
   {
     start_ = fbb_.StartTable();
   }
-  SelectV2OptionsBuilder &operator=(const SelectV2OptionsBuilder &);
   flatbuffers::Offset<SelectV2Options> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -7017,6 +7364,7 @@ CreateSelectV2Options(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct DensifyOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef DensifyOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -7025,13 +7373,13 @@ struct DensifyOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct DensifyOptionsBuilder
 {
+  typedef DensifyOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit DensifyOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
   {
     start_ = fbb_.StartTable();
   }
-  DensifyOptionsBuilder &operator=(const DensifyOptionsBuilder &);
   flatbuffers::Offset<DensifyOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -7049,6 +7397,7 @@ CreateDensifyOptions(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct SegmentSumOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
+  typedef SegmentSumOptionsBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const
   {
     return VerifyTableStart(verifier) && verifier.EndTable();
@@ -7057,13 +7406,13 @@ struct SegmentSumOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct SegmentSumOptionsBuilder
 {
+  typedef SegmentSumOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit SegmentSumOptionsBuilder(flatbuffers::FlatBufferBuilder &_fbb) : fbb_(_fbb)
   {
     start_ = fbb_.StartTable();
   }
-  SegmentSumOptionsBuilder &operator=(const SegmentSumOptionsBuilder &);
   flatbuffers::Offset<SegmentSumOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -7081,7 +7430,8 @@ CreateSegmentSumOptions(flatbuffers::FlatBufferBuilder &_fbb)
 
 struct BatchMatMulOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef BatchMatMulOptionsBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_ADJOINT_LHS = 4,
     VT_ADJOINT_RHS = 6
@@ -7097,6 +7447,7 @@ struct BatchMatMulOptions FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct BatchMatMulOptionsBuilder
 {
+  typedef BatchMatMulOptions Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_adjoint_lhs(bool adjoint_lhs)
@@ -7113,7 +7464,6 @@ struct BatchMatMulOptionsBuilder
   {
     start_ = fbb_.StartTable();
   }
-  BatchMatMulOptionsBuilder &operator=(const BatchMatMulOptionsBuilder &);
   flatbuffers::Offset<BatchMatMulOptions> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -7134,15 +7484,16 @@ CreateBatchMatMulOptions(flatbuffers::FlatBufferBuilder &_fbb, bool adjoint_lhs 
 
 struct OperatorCode FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef OperatorCodeBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_BUILTIN_CODE = 4,
     VT_CUSTOM_CODE = 6,
     VT_VERSION = 8
   };
-  BuiltinOperator builtin_code() const
+  onert_tflite::BuiltinOperator builtin_code() const
   {
-    return static_cast<BuiltinOperator>(GetField<int8_t>(VT_BUILTIN_CODE, 0));
+    return static_cast<onert_tflite::BuiltinOperator>(GetField<int8_t>(VT_BUILTIN_CODE, 0));
   }
   const flatbuffers::String *custom_code() const
   {
@@ -7159,9 +7510,10 @@ struct OperatorCode FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct OperatorCodeBuilder
 {
+  typedef OperatorCode Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_builtin_code(BuiltinOperator builtin_code)
+  void add_builtin_code(onert_tflite::BuiltinOperator builtin_code)
   {
     fbb_.AddElement<int8_t>(OperatorCode::VT_BUILTIN_CODE, static_cast<int8_t>(builtin_code), 0);
   }
@@ -7177,7 +7529,6 @@ struct OperatorCodeBuilder
   {
     start_ = fbb_.StartTable();
   }
-  OperatorCodeBuilder &operator=(const OperatorCodeBuilder &);
   flatbuffers::Offset<OperatorCode> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -7188,7 +7539,7 @@ struct OperatorCodeBuilder
 
 inline flatbuffers::Offset<OperatorCode>
 CreateOperatorCode(flatbuffers::FlatBufferBuilder &_fbb,
-                   BuiltinOperator builtin_code = BuiltinOperator_ADD,
+                   onert_tflite::BuiltinOperator builtin_code = onert_tflite::BuiltinOperator_ADD,
                    flatbuffers::Offset<flatbuffers::String> custom_code = 0, int32_t version = 1)
 {
   OperatorCodeBuilder builder_(_fbb);
@@ -7198,18 +7549,19 @@ CreateOperatorCode(flatbuffers::FlatBufferBuilder &_fbb,
   return builder_.Finish();
 }
 
-inline flatbuffers::Offset<OperatorCode>
-CreateOperatorCodeDirect(flatbuffers::FlatBufferBuilder &_fbb,
-                         BuiltinOperator builtin_code = BuiltinOperator_ADD,
-                         const char *custom_code = nullptr, int32_t version = 1)
+inline flatbuffers::Offset<OperatorCode> CreateOperatorCodeDirect(
+  flatbuffers::FlatBufferBuilder &_fbb,
+  onert_tflite::BuiltinOperator builtin_code = onert_tflite::BuiltinOperator_ADD,
+  const char *custom_code = nullptr, int32_t version = 1)
 {
-  return onert_tflite::CreateOperatorCode(
-    _fbb, builtin_code, custom_code ? _fbb.CreateString(custom_code) : 0, version);
+  auto custom_code__ = custom_code ? _fbb.CreateString(custom_code) : 0;
+  return onert_tflite::CreateOperatorCode(_fbb, builtin_code, custom_code__, version);
 }
 
 struct Operator FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef OperatorBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_OPCODE_INDEX = 4,
     VT_INPUTS = 6,
@@ -7230,628 +7582,637 @@ struct Operator FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
   {
     return GetPointer<const flatbuffers::Vector<int32_t> *>(VT_OUTPUTS);
   }
-  BuiltinOptions builtin_options_type() const
+  onert_tflite::BuiltinOptions builtin_options_type() const
   {
-    return static_cast<BuiltinOptions>(GetField<uint8_t>(VT_BUILTIN_OPTIONS_TYPE, 0));
+    return static_cast<onert_tflite::BuiltinOptions>(GetField<uint8_t>(VT_BUILTIN_OPTIONS_TYPE, 0));
   }
   const void *builtin_options() const { return GetPointer<const void *>(VT_BUILTIN_OPTIONS); }
   template <typename T> const T *builtin_options_as() const;
-  const Conv2DOptions *builtin_options_as_Conv2DOptions() const
+  const onert_tflite::Conv2DOptions *builtin_options_as_Conv2DOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_Conv2DOptions
-             ? static_cast<const Conv2DOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_Conv2DOptions
+             ? static_cast<const onert_tflite::Conv2DOptions *>(builtin_options())
              : nullptr;
   }
-  const DepthwiseConv2DOptions *builtin_options_as_DepthwiseConv2DOptions() const
+  const onert_tflite::DepthwiseConv2DOptions *builtin_options_as_DepthwiseConv2DOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_DepthwiseConv2DOptions
-             ? static_cast<const DepthwiseConv2DOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_DepthwiseConv2DOptions
+             ? static_cast<const onert_tflite::DepthwiseConv2DOptions *>(builtin_options())
              : nullptr;
   }
-  const ConcatEmbeddingsOptions *builtin_options_as_ConcatEmbeddingsOptions() const
+  const onert_tflite::ConcatEmbeddingsOptions *builtin_options_as_ConcatEmbeddingsOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_ConcatEmbeddingsOptions
-             ? static_cast<const ConcatEmbeddingsOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_ConcatEmbeddingsOptions
+             ? static_cast<const onert_tflite::ConcatEmbeddingsOptions *>(builtin_options())
              : nullptr;
   }
-  const LSHProjectionOptions *builtin_options_as_LSHProjectionOptions() const
+  const onert_tflite::LSHProjectionOptions *builtin_options_as_LSHProjectionOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_LSHProjectionOptions
-             ? static_cast<const LSHProjectionOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_LSHProjectionOptions
+             ? static_cast<const onert_tflite::LSHProjectionOptions *>(builtin_options())
              : nullptr;
   }
-  const Pool2DOptions *builtin_options_as_Pool2DOptions() const
+  const onert_tflite::Pool2DOptions *builtin_options_as_Pool2DOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_Pool2DOptions
-             ? static_cast<const Pool2DOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_Pool2DOptions
+             ? static_cast<const onert_tflite::Pool2DOptions *>(builtin_options())
              : nullptr;
   }
-  const SVDFOptions *builtin_options_as_SVDFOptions() const
+  const onert_tflite::SVDFOptions *builtin_options_as_SVDFOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_SVDFOptions
-             ? static_cast<const SVDFOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_SVDFOptions
+             ? static_cast<const onert_tflite::SVDFOptions *>(builtin_options())
              : nullptr;
   }
-  const RNNOptions *builtin_options_as_RNNOptions() const
+  const onert_tflite::RNNOptions *builtin_options_as_RNNOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_RNNOptions
-             ? static_cast<const RNNOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_RNNOptions
+             ? static_cast<const onert_tflite::RNNOptions *>(builtin_options())
              : nullptr;
   }
-  const FullyConnectedOptions *builtin_options_as_FullyConnectedOptions() const
+  const onert_tflite::FullyConnectedOptions *builtin_options_as_FullyConnectedOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_FullyConnectedOptions
-             ? static_cast<const FullyConnectedOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_FullyConnectedOptions
+             ? static_cast<const onert_tflite::FullyConnectedOptions *>(builtin_options())
              : nullptr;
   }
-  const SoftmaxOptions *builtin_options_as_SoftmaxOptions() const
+  const onert_tflite::SoftmaxOptions *builtin_options_as_SoftmaxOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_SoftmaxOptions
-             ? static_cast<const SoftmaxOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_SoftmaxOptions
+             ? static_cast<const onert_tflite::SoftmaxOptions *>(builtin_options())
              : nullptr;
   }
-  const ConcatenationOptions *builtin_options_as_ConcatenationOptions() const
+  const onert_tflite::ConcatenationOptions *builtin_options_as_ConcatenationOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_ConcatenationOptions
-             ? static_cast<const ConcatenationOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_ConcatenationOptions
+             ? static_cast<const onert_tflite::ConcatenationOptions *>(builtin_options())
              : nullptr;
   }
-  const AddOptions *builtin_options_as_AddOptions() const
+  const onert_tflite::AddOptions *builtin_options_as_AddOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_AddOptions
-             ? static_cast<const AddOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_AddOptions
+             ? static_cast<const onert_tflite::AddOptions *>(builtin_options())
              : nullptr;
   }
-  const L2NormOptions *builtin_options_as_L2NormOptions() const
+  const onert_tflite::L2NormOptions *builtin_options_as_L2NormOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_L2NormOptions
-             ? static_cast<const L2NormOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_L2NormOptions
+             ? static_cast<const onert_tflite::L2NormOptions *>(builtin_options())
              : nullptr;
   }
-  const LocalResponseNormalizationOptions *
+  const onert_tflite::LocalResponseNormalizationOptions *
   builtin_options_as_LocalResponseNormalizationOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_LocalResponseNormalizationOptions
-             ? static_cast<const LocalResponseNormalizationOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_LocalResponseNormalizationOptions
+             ? static_cast<const onert_tflite::LocalResponseNormalizationOptions *>(
+                 builtin_options())
              : nullptr;
   }
-  const LSTMOptions *builtin_options_as_LSTMOptions() const
+  const onert_tflite::LSTMOptions *builtin_options_as_LSTMOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_LSTMOptions
-             ? static_cast<const LSTMOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_LSTMOptions
+             ? static_cast<const onert_tflite::LSTMOptions *>(builtin_options())
              : nullptr;
   }
-  const ResizeBilinearOptions *builtin_options_as_ResizeBilinearOptions() const
+  const onert_tflite::ResizeBilinearOptions *builtin_options_as_ResizeBilinearOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_ResizeBilinearOptions
-             ? static_cast<const ResizeBilinearOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_ResizeBilinearOptions
+             ? static_cast<const onert_tflite::ResizeBilinearOptions *>(builtin_options())
              : nullptr;
   }
-  const CallOptions *builtin_options_as_CallOptions() const
+  const onert_tflite::CallOptions *builtin_options_as_CallOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_CallOptions
-             ? static_cast<const CallOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_CallOptions
+             ? static_cast<const onert_tflite::CallOptions *>(builtin_options())
              : nullptr;
   }
-  const ReshapeOptions *builtin_options_as_ReshapeOptions() const
+  const onert_tflite::ReshapeOptions *builtin_options_as_ReshapeOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_ReshapeOptions
-             ? static_cast<const ReshapeOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_ReshapeOptions
+             ? static_cast<const onert_tflite::ReshapeOptions *>(builtin_options())
              : nullptr;
   }
-  const SkipGramOptions *builtin_options_as_SkipGramOptions() const
+  const onert_tflite::SkipGramOptions *builtin_options_as_SkipGramOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_SkipGramOptions
-             ? static_cast<const SkipGramOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_SkipGramOptions
+             ? static_cast<const onert_tflite::SkipGramOptions *>(builtin_options())
              : nullptr;
   }
-  const SpaceToDepthOptions *builtin_options_as_SpaceToDepthOptions() const
+  const onert_tflite::SpaceToDepthOptions *builtin_options_as_SpaceToDepthOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_SpaceToDepthOptions
-             ? static_cast<const SpaceToDepthOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_SpaceToDepthOptions
+             ? static_cast<const onert_tflite::SpaceToDepthOptions *>(builtin_options())
              : nullptr;
   }
-  const EmbeddingLookupSparseOptions *builtin_options_as_EmbeddingLookupSparseOptions() const
+  const onert_tflite::EmbeddingLookupSparseOptions *
+  builtin_options_as_EmbeddingLookupSparseOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_EmbeddingLookupSparseOptions
-             ? static_cast<const EmbeddingLookupSparseOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_EmbeddingLookupSparseOptions
+             ? static_cast<const onert_tflite::EmbeddingLookupSparseOptions *>(builtin_options())
              : nullptr;
   }
-  const MulOptions *builtin_options_as_MulOptions() const
+  const onert_tflite::MulOptions *builtin_options_as_MulOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_MulOptions
-             ? static_cast<const MulOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_MulOptions
+             ? static_cast<const onert_tflite::MulOptions *>(builtin_options())
              : nullptr;
   }
-  const PadOptions *builtin_options_as_PadOptions() const
+  const onert_tflite::PadOptions *builtin_options_as_PadOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_PadOptions
-             ? static_cast<const PadOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_PadOptions
+             ? static_cast<const onert_tflite::PadOptions *>(builtin_options())
              : nullptr;
   }
-  const GatherOptions *builtin_options_as_GatherOptions() const
+  const onert_tflite::GatherOptions *builtin_options_as_GatherOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_GatherOptions
-             ? static_cast<const GatherOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_GatherOptions
+             ? static_cast<const onert_tflite::GatherOptions *>(builtin_options())
              : nullptr;
   }
-  const BatchToSpaceNDOptions *builtin_options_as_BatchToSpaceNDOptions() const
+  const onert_tflite::BatchToSpaceNDOptions *builtin_options_as_BatchToSpaceNDOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_BatchToSpaceNDOptions
-             ? static_cast<const BatchToSpaceNDOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_BatchToSpaceNDOptions
+             ? static_cast<const onert_tflite::BatchToSpaceNDOptions *>(builtin_options())
              : nullptr;
   }
-  const SpaceToBatchNDOptions *builtin_options_as_SpaceToBatchNDOptions() const
+  const onert_tflite::SpaceToBatchNDOptions *builtin_options_as_SpaceToBatchNDOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_SpaceToBatchNDOptions
-             ? static_cast<const SpaceToBatchNDOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_SpaceToBatchNDOptions
+             ? static_cast<const onert_tflite::SpaceToBatchNDOptions *>(builtin_options())
              : nullptr;
   }
-  const TransposeOptions *builtin_options_as_TransposeOptions() const
+  const onert_tflite::TransposeOptions *builtin_options_as_TransposeOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_TransposeOptions
-             ? static_cast<const TransposeOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_TransposeOptions
+             ? static_cast<const onert_tflite::TransposeOptions *>(builtin_options())
              : nullptr;
   }
-  const ReducerOptions *builtin_options_as_ReducerOptions() const
+  const onert_tflite::ReducerOptions *builtin_options_as_ReducerOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_ReducerOptions
-             ? static_cast<const ReducerOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_ReducerOptions
+             ? static_cast<const onert_tflite::ReducerOptions *>(builtin_options())
              : nullptr;
   }
-  const SubOptions *builtin_options_as_SubOptions() const
+  const onert_tflite::SubOptions *builtin_options_as_SubOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_SubOptions
-             ? static_cast<const SubOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_SubOptions
+             ? static_cast<const onert_tflite::SubOptions *>(builtin_options())
              : nullptr;
   }
-  const DivOptions *builtin_options_as_DivOptions() const
+  const onert_tflite::DivOptions *builtin_options_as_DivOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_DivOptions
-             ? static_cast<const DivOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_DivOptions
+             ? static_cast<const onert_tflite::DivOptions *>(builtin_options())
              : nullptr;
   }
-  const SqueezeOptions *builtin_options_as_SqueezeOptions() const
+  const onert_tflite::SqueezeOptions *builtin_options_as_SqueezeOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_SqueezeOptions
-             ? static_cast<const SqueezeOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_SqueezeOptions
+             ? static_cast<const onert_tflite::SqueezeOptions *>(builtin_options())
              : nullptr;
   }
-  const SequenceRNNOptions *builtin_options_as_SequenceRNNOptions() const
+  const onert_tflite::SequenceRNNOptions *builtin_options_as_SequenceRNNOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_SequenceRNNOptions
-             ? static_cast<const SequenceRNNOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_SequenceRNNOptions
+             ? static_cast<const onert_tflite::SequenceRNNOptions *>(builtin_options())
              : nullptr;
   }
-  const StridedSliceOptions *builtin_options_as_StridedSliceOptions() const
+  const onert_tflite::StridedSliceOptions *builtin_options_as_StridedSliceOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_StridedSliceOptions
-             ? static_cast<const StridedSliceOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_StridedSliceOptions
+             ? static_cast<const onert_tflite::StridedSliceOptions *>(builtin_options())
              : nullptr;
   }
-  const ExpOptions *builtin_options_as_ExpOptions() const
+  const onert_tflite::ExpOptions *builtin_options_as_ExpOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_ExpOptions
-             ? static_cast<const ExpOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_ExpOptions
+             ? static_cast<const onert_tflite::ExpOptions *>(builtin_options())
              : nullptr;
   }
-  const TopKV2Options *builtin_options_as_TopKV2Options() const
+  const onert_tflite::TopKV2Options *builtin_options_as_TopKV2Options() const
   {
-    return builtin_options_type() == BuiltinOptions_TopKV2Options
-             ? static_cast<const TopKV2Options *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_TopKV2Options
+             ? static_cast<const onert_tflite::TopKV2Options *>(builtin_options())
              : nullptr;
   }
-  const SplitOptions *builtin_options_as_SplitOptions() const
+  const onert_tflite::SplitOptions *builtin_options_as_SplitOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_SplitOptions
-             ? static_cast<const SplitOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_SplitOptions
+             ? static_cast<const onert_tflite::SplitOptions *>(builtin_options())
              : nullptr;
   }
-  const LogSoftmaxOptions *builtin_options_as_LogSoftmaxOptions() const
+  const onert_tflite::LogSoftmaxOptions *builtin_options_as_LogSoftmaxOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_LogSoftmaxOptions
-             ? static_cast<const LogSoftmaxOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_LogSoftmaxOptions
+             ? static_cast<const onert_tflite::LogSoftmaxOptions *>(builtin_options())
              : nullptr;
   }
-  const CastOptions *builtin_options_as_CastOptions() const
+  const onert_tflite::CastOptions *builtin_options_as_CastOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_CastOptions
-             ? static_cast<const CastOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_CastOptions
+             ? static_cast<const onert_tflite::CastOptions *>(builtin_options())
              : nullptr;
   }
-  const DequantizeOptions *builtin_options_as_DequantizeOptions() const
+  const onert_tflite::DequantizeOptions *builtin_options_as_DequantizeOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_DequantizeOptions
-             ? static_cast<const DequantizeOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_DequantizeOptions
+             ? static_cast<const onert_tflite::DequantizeOptions *>(builtin_options())
              : nullptr;
   }
-  const MaximumMinimumOptions *builtin_options_as_MaximumMinimumOptions() const
+  const onert_tflite::MaximumMinimumOptions *builtin_options_as_MaximumMinimumOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_MaximumMinimumOptions
-             ? static_cast<const MaximumMinimumOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_MaximumMinimumOptions
+             ? static_cast<const onert_tflite::MaximumMinimumOptions *>(builtin_options())
              : nullptr;
   }
-  const ArgMaxOptions *builtin_options_as_ArgMaxOptions() const
+  const onert_tflite::ArgMaxOptions *builtin_options_as_ArgMaxOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_ArgMaxOptions
-             ? static_cast<const ArgMaxOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_ArgMaxOptions
+             ? static_cast<const onert_tflite::ArgMaxOptions *>(builtin_options())
              : nullptr;
   }
-  const LessOptions *builtin_options_as_LessOptions() const
+  const onert_tflite::LessOptions *builtin_options_as_LessOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_LessOptions
-             ? static_cast<const LessOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_LessOptions
+             ? static_cast<const onert_tflite::LessOptions *>(builtin_options())
              : nullptr;
   }
-  const NegOptions *builtin_options_as_NegOptions() const
+  const onert_tflite::NegOptions *builtin_options_as_NegOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_NegOptions
-             ? static_cast<const NegOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_NegOptions
+             ? static_cast<const onert_tflite::NegOptions *>(builtin_options())
              : nullptr;
   }
-  const PadV2Options *builtin_options_as_PadV2Options() const
+  const onert_tflite::PadV2Options *builtin_options_as_PadV2Options() const
   {
-    return builtin_options_type() == BuiltinOptions_PadV2Options
-             ? static_cast<const PadV2Options *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_PadV2Options
+             ? static_cast<const onert_tflite::PadV2Options *>(builtin_options())
              : nullptr;
   }
-  const GreaterOptions *builtin_options_as_GreaterOptions() const
+  const onert_tflite::GreaterOptions *builtin_options_as_GreaterOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_GreaterOptions
-             ? static_cast<const GreaterOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_GreaterOptions
+             ? static_cast<const onert_tflite::GreaterOptions *>(builtin_options())
              : nullptr;
   }
-  const GreaterEqualOptions *builtin_options_as_GreaterEqualOptions() const
+  const onert_tflite::GreaterEqualOptions *builtin_options_as_GreaterEqualOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_GreaterEqualOptions
-             ? static_cast<const GreaterEqualOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_GreaterEqualOptions
+             ? static_cast<const onert_tflite::GreaterEqualOptions *>(builtin_options())
              : nullptr;
   }
-  const LessEqualOptions *builtin_options_as_LessEqualOptions() const
+  const onert_tflite::LessEqualOptions *builtin_options_as_LessEqualOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_LessEqualOptions
-             ? static_cast<const LessEqualOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_LessEqualOptions
+             ? static_cast<const onert_tflite::LessEqualOptions *>(builtin_options())
              : nullptr;
   }
-  const SelectOptions *builtin_options_as_SelectOptions() const
+  const onert_tflite::SelectOptions *builtin_options_as_SelectOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_SelectOptions
-             ? static_cast<const SelectOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_SelectOptions
+             ? static_cast<const onert_tflite::SelectOptions *>(builtin_options())
              : nullptr;
   }
-  const SliceOptions *builtin_options_as_SliceOptions() const
+  const onert_tflite::SliceOptions *builtin_options_as_SliceOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_SliceOptions
-             ? static_cast<const SliceOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_SliceOptions
+             ? static_cast<const onert_tflite::SliceOptions *>(builtin_options())
              : nullptr;
   }
-  const TransposeConvOptions *builtin_options_as_TransposeConvOptions() const
+  const onert_tflite::TransposeConvOptions *builtin_options_as_TransposeConvOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_TransposeConvOptions
-             ? static_cast<const TransposeConvOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_TransposeConvOptions
+             ? static_cast<const onert_tflite::TransposeConvOptions *>(builtin_options())
              : nullptr;
   }
-  const SparseToDenseOptions *builtin_options_as_SparseToDenseOptions() const
+  const onert_tflite::SparseToDenseOptions *builtin_options_as_SparseToDenseOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_SparseToDenseOptions
-             ? static_cast<const SparseToDenseOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_SparseToDenseOptions
+             ? static_cast<const onert_tflite::SparseToDenseOptions *>(builtin_options())
              : nullptr;
   }
-  const TileOptions *builtin_options_as_TileOptions() const
+  const onert_tflite::TileOptions *builtin_options_as_TileOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_TileOptions
-             ? static_cast<const TileOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_TileOptions
+             ? static_cast<const onert_tflite::TileOptions *>(builtin_options())
              : nullptr;
   }
-  const ExpandDimsOptions *builtin_options_as_ExpandDimsOptions() const
+  const onert_tflite::ExpandDimsOptions *builtin_options_as_ExpandDimsOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_ExpandDimsOptions
-             ? static_cast<const ExpandDimsOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_ExpandDimsOptions
+             ? static_cast<const onert_tflite::ExpandDimsOptions *>(builtin_options())
              : nullptr;
   }
-  const EqualOptions *builtin_options_as_EqualOptions() const
+  const onert_tflite::EqualOptions *builtin_options_as_EqualOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_EqualOptions
-             ? static_cast<const EqualOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_EqualOptions
+             ? static_cast<const onert_tflite::EqualOptions *>(builtin_options())
              : nullptr;
   }
-  const NotEqualOptions *builtin_options_as_NotEqualOptions() const
+  const onert_tflite::NotEqualOptions *builtin_options_as_NotEqualOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_NotEqualOptions
-             ? static_cast<const NotEqualOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_NotEqualOptions
+             ? static_cast<const onert_tflite::NotEqualOptions *>(builtin_options())
              : nullptr;
   }
-  const ShapeOptions *builtin_options_as_ShapeOptions() const
+  const onert_tflite::ShapeOptions *builtin_options_as_ShapeOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_ShapeOptions
-             ? static_cast<const ShapeOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_ShapeOptions
+             ? static_cast<const onert_tflite::ShapeOptions *>(builtin_options())
              : nullptr;
   }
-  const PowOptions *builtin_options_as_PowOptions() const
+  const onert_tflite::PowOptions *builtin_options_as_PowOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_PowOptions
-             ? static_cast<const PowOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_PowOptions
+             ? static_cast<const onert_tflite::PowOptions *>(builtin_options())
              : nullptr;
   }
-  const ArgMinOptions *builtin_options_as_ArgMinOptions() const
+  const onert_tflite::ArgMinOptions *builtin_options_as_ArgMinOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_ArgMinOptions
-             ? static_cast<const ArgMinOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_ArgMinOptions
+             ? static_cast<const onert_tflite::ArgMinOptions *>(builtin_options())
              : nullptr;
   }
-  const FakeQuantOptions *builtin_options_as_FakeQuantOptions() const
+  const onert_tflite::FakeQuantOptions *builtin_options_as_FakeQuantOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_FakeQuantOptions
-             ? static_cast<const FakeQuantOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_FakeQuantOptions
+             ? static_cast<const onert_tflite::FakeQuantOptions *>(builtin_options())
              : nullptr;
   }
-  const PackOptions *builtin_options_as_PackOptions() const
+  const onert_tflite::PackOptions *builtin_options_as_PackOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_PackOptions
-             ? static_cast<const PackOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_PackOptions
+             ? static_cast<const onert_tflite::PackOptions *>(builtin_options())
              : nullptr;
   }
-  const LogicalOrOptions *builtin_options_as_LogicalOrOptions() const
+  const onert_tflite::LogicalOrOptions *builtin_options_as_LogicalOrOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_LogicalOrOptions
-             ? static_cast<const LogicalOrOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_LogicalOrOptions
+             ? static_cast<const onert_tflite::LogicalOrOptions *>(builtin_options())
              : nullptr;
   }
-  const OneHotOptions *builtin_options_as_OneHotOptions() const
+  const onert_tflite::OneHotOptions *builtin_options_as_OneHotOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_OneHotOptions
-             ? static_cast<const OneHotOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_OneHotOptions
+             ? static_cast<const onert_tflite::OneHotOptions *>(builtin_options())
              : nullptr;
   }
-  const LogicalAndOptions *builtin_options_as_LogicalAndOptions() const
+  const onert_tflite::LogicalAndOptions *builtin_options_as_LogicalAndOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_LogicalAndOptions
-             ? static_cast<const LogicalAndOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_LogicalAndOptions
+             ? static_cast<const onert_tflite::LogicalAndOptions *>(builtin_options())
              : nullptr;
   }
-  const LogicalNotOptions *builtin_options_as_LogicalNotOptions() const
+  const onert_tflite::LogicalNotOptions *builtin_options_as_LogicalNotOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_LogicalNotOptions
-             ? static_cast<const LogicalNotOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_LogicalNotOptions
+             ? static_cast<const onert_tflite::LogicalNotOptions *>(builtin_options())
              : nullptr;
   }
-  const UnpackOptions *builtin_options_as_UnpackOptions() const
+  const onert_tflite::UnpackOptions *builtin_options_as_UnpackOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_UnpackOptions
-             ? static_cast<const UnpackOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_UnpackOptions
+             ? static_cast<const onert_tflite::UnpackOptions *>(builtin_options())
              : nullptr;
   }
-  const FloorDivOptions *builtin_options_as_FloorDivOptions() const
+  const onert_tflite::FloorDivOptions *builtin_options_as_FloorDivOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_FloorDivOptions
-             ? static_cast<const FloorDivOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_FloorDivOptions
+             ? static_cast<const onert_tflite::FloorDivOptions *>(builtin_options())
              : nullptr;
   }
-  const SquareOptions *builtin_options_as_SquareOptions() const
+  const onert_tflite::SquareOptions *builtin_options_as_SquareOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_SquareOptions
-             ? static_cast<const SquareOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_SquareOptions
+             ? static_cast<const onert_tflite::SquareOptions *>(builtin_options())
              : nullptr;
   }
-  const ZerosLikeOptions *builtin_options_as_ZerosLikeOptions() const
+  const onert_tflite::ZerosLikeOptions *builtin_options_as_ZerosLikeOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_ZerosLikeOptions
-             ? static_cast<const ZerosLikeOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_ZerosLikeOptions
+             ? static_cast<const onert_tflite::ZerosLikeOptions *>(builtin_options())
              : nullptr;
   }
-  const FillOptions *builtin_options_as_FillOptions() const
+  const onert_tflite::FillOptions *builtin_options_as_FillOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_FillOptions
-             ? static_cast<const FillOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_FillOptions
+             ? static_cast<const onert_tflite::FillOptions *>(builtin_options())
              : nullptr;
   }
-  const BidirectionalSequenceLSTMOptions *
+  const onert_tflite::BidirectionalSequenceLSTMOptions *
   builtin_options_as_BidirectionalSequenceLSTMOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_BidirectionalSequenceLSTMOptions
-             ? static_cast<const BidirectionalSequenceLSTMOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_BidirectionalSequenceLSTMOptions
+             ? static_cast<const onert_tflite::BidirectionalSequenceLSTMOptions *>(
+                 builtin_options())
              : nullptr;
   }
-  const BidirectionalSequenceRNNOptions *builtin_options_as_BidirectionalSequenceRNNOptions() const
+  const onert_tflite::BidirectionalSequenceRNNOptions *
+  builtin_options_as_BidirectionalSequenceRNNOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_BidirectionalSequenceRNNOptions
-             ? static_cast<const BidirectionalSequenceRNNOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_BidirectionalSequenceRNNOptions
+             ? static_cast<const onert_tflite::BidirectionalSequenceRNNOptions *>(builtin_options())
              : nullptr;
   }
-  const UnidirectionalSequenceLSTMOptions *
+  const onert_tflite::UnidirectionalSequenceLSTMOptions *
   builtin_options_as_UnidirectionalSequenceLSTMOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_UnidirectionalSequenceLSTMOptions
-             ? static_cast<const UnidirectionalSequenceLSTMOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_UnidirectionalSequenceLSTMOptions
+             ? static_cast<const onert_tflite::UnidirectionalSequenceLSTMOptions *>(
+                 builtin_options())
              : nullptr;
   }
-  const FloorModOptions *builtin_options_as_FloorModOptions() const
+  const onert_tflite::FloorModOptions *builtin_options_as_FloorModOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_FloorModOptions
-             ? static_cast<const FloorModOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_FloorModOptions
+             ? static_cast<const onert_tflite::FloorModOptions *>(builtin_options())
              : nullptr;
   }
-  const RangeOptions *builtin_options_as_RangeOptions() const
+  const onert_tflite::RangeOptions *builtin_options_as_RangeOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_RangeOptions
-             ? static_cast<const RangeOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_RangeOptions
+             ? static_cast<const onert_tflite::RangeOptions *>(builtin_options())
              : nullptr;
   }
-  const ResizeNearestNeighborOptions *builtin_options_as_ResizeNearestNeighborOptions() const
+  const onert_tflite::ResizeNearestNeighborOptions *
+  builtin_options_as_ResizeNearestNeighborOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_ResizeNearestNeighborOptions
-             ? static_cast<const ResizeNearestNeighborOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_ResizeNearestNeighborOptions
+             ? static_cast<const onert_tflite::ResizeNearestNeighborOptions *>(builtin_options())
              : nullptr;
   }
-  const LeakyReluOptions *builtin_options_as_LeakyReluOptions() const
+  const onert_tflite::LeakyReluOptions *builtin_options_as_LeakyReluOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_LeakyReluOptions
-             ? static_cast<const LeakyReluOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_LeakyReluOptions
+             ? static_cast<const onert_tflite::LeakyReluOptions *>(builtin_options())
              : nullptr;
   }
-  const SquaredDifferenceOptions *builtin_options_as_SquaredDifferenceOptions() const
+  const onert_tflite::SquaredDifferenceOptions *builtin_options_as_SquaredDifferenceOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_SquaredDifferenceOptions
-             ? static_cast<const SquaredDifferenceOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_SquaredDifferenceOptions
+             ? static_cast<const onert_tflite::SquaredDifferenceOptions *>(builtin_options())
              : nullptr;
   }
-  const MirrorPadOptions *builtin_options_as_MirrorPadOptions() const
+  const onert_tflite::MirrorPadOptions *builtin_options_as_MirrorPadOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_MirrorPadOptions
-             ? static_cast<const MirrorPadOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_MirrorPadOptions
+             ? static_cast<const onert_tflite::MirrorPadOptions *>(builtin_options())
              : nullptr;
   }
-  const AbsOptions *builtin_options_as_AbsOptions() const
+  const onert_tflite::AbsOptions *builtin_options_as_AbsOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_AbsOptions
-             ? static_cast<const AbsOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_AbsOptions
+             ? static_cast<const onert_tflite::AbsOptions *>(builtin_options())
              : nullptr;
   }
-  const SplitVOptions *builtin_options_as_SplitVOptions() const
+  const onert_tflite::SplitVOptions *builtin_options_as_SplitVOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_SplitVOptions
-             ? static_cast<const SplitVOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_SplitVOptions
+             ? static_cast<const onert_tflite::SplitVOptions *>(builtin_options())
              : nullptr;
   }
-  const UniqueOptions *builtin_options_as_UniqueOptions() const
+  const onert_tflite::UniqueOptions *builtin_options_as_UniqueOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_UniqueOptions
-             ? static_cast<const UniqueOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_UniqueOptions
+             ? static_cast<const onert_tflite::UniqueOptions *>(builtin_options())
              : nullptr;
   }
-  const ReverseV2Options *builtin_options_as_ReverseV2Options() const
+  const onert_tflite::ReverseV2Options *builtin_options_as_ReverseV2Options() const
   {
-    return builtin_options_type() == BuiltinOptions_ReverseV2Options
-             ? static_cast<const ReverseV2Options *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_ReverseV2Options
+             ? static_cast<const onert_tflite::ReverseV2Options *>(builtin_options())
              : nullptr;
   }
-  const AddNOptions *builtin_options_as_AddNOptions() const
+  const onert_tflite::AddNOptions *builtin_options_as_AddNOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_AddNOptions
-             ? static_cast<const AddNOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_AddNOptions
+             ? static_cast<const onert_tflite::AddNOptions *>(builtin_options())
              : nullptr;
   }
-  const GatherNdOptions *builtin_options_as_GatherNdOptions() const
+  const onert_tflite::GatherNdOptions *builtin_options_as_GatherNdOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_GatherNdOptions
-             ? static_cast<const GatherNdOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_GatherNdOptions
+             ? static_cast<const onert_tflite::GatherNdOptions *>(builtin_options())
              : nullptr;
   }
-  const CosOptions *builtin_options_as_CosOptions() const
+  const onert_tflite::CosOptions *builtin_options_as_CosOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_CosOptions
-             ? static_cast<const CosOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_CosOptions
+             ? static_cast<const onert_tflite::CosOptions *>(builtin_options())
              : nullptr;
   }
-  const WhereOptions *builtin_options_as_WhereOptions() const
+  const onert_tflite::WhereOptions *builtin_options_as_WhereOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_WhereOptions
-             ? static_cast<const WhereOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_WhereOptions
+             ? static_cast<const onert_tflite::WhereOptions *>(builtin_options())
              : nullptr;
   }
-  const RankOptions *builtin_options_as_RankOptions() const
+  const onert_tflite::RankOptions *builtin_options_as_RankOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_RankOptions
-             ? static_cast<const RankOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_RankOptions
+             ? static_cast<const onert_tflite::RankOptions *>(builtin_options())
              : nullptr;
   }
-  const ReverseSequenceOptions *builtin_options_as_ReverseSequenceOptions() const
+  const onert_tflite::ReverseSequenceOptions *builtin_options_as_ReverseSequenceOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_ReverseSequenceOptions
-             ? static_cast<const ReverseSequenceOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_ReverseSequenceOptions
+             ? static_cast<const onert_tflite::ReverseSequenceOptions *>(builtin_options())
              : nullptr;
   }
-  const MatrixDiagOptions *builtin_options_as_MatrixDiagOptions() const
+  const onert_tflite::MatrixDiagOptions *builtin_options_as_MatrixDiagOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_MatrixDiagOptions
-             ? static_cast<const MatrixDiagOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_MatrixDiagOptions
+             ? static_cast<const onert_tflite::MatrixDiagOptions *>(builtin_options())
              : nullptr;
   }
-  const QuantizeOptions *builtin_options_as_QuantizeOptions() const
+  const onert_tflite::QuantizeOptions *builtin_options_as_QuantizeOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_QuantizeOptions
-             ? static_cast<const QuantizeOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_QuantizeOptions
+             ? static_cast<const onert_tflite::QuantizeOptions *>(builtin_options())
              : nullptr;
   }
-  const MatrixSetDiagOptions *builtin_options_as_MatrixSetDiagOptions() const
+  const onert_tflite::MatrixSetDiagOptions *builtin_options_as_MatrixSetDiagOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_MatrixSetDiagOptions
-             ? static_cast<const MatrixSetDiagOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_MatrixSetDiagOptions
+             ? static_cast<const onert_tflite::MatrixSetDiagOptions *>(builtin_options())
              : nullptr;
   }
-  const HardSwishOptions *builtin_options_as_HardSwishOptions() const
+  const onert_tflite::HardSwishOptions *builtin_options_as_HardSwishOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_HardSwishOptions
-             ? static_cast<const HardSwishOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_HardSwishOptions
+             ? static_cast<const onert_tflite::HardSwishOptions *>(builtin_options())
              : nullptr;
   }
-  const IfOptions *builtin_options_as_IfOptions() const
+  const onert_tflite::IfOptions *builtin_options_as_IfOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_IfOptions
-             ? static_cast<const IfOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_IfOptions
+             ? static_cast<const onert_tflite::IfOptions *>(builtin_options())
              : nullptr;
   }
-  const WhileOptions *builtin_options_as_WhileOptions() const
+  const onert_tflite::WhileOptions *builtin_options_as_WhileOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_WhileOptions
-             ? static_cast<const WhileOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_WhileOptions
+             ? static_cast<const onert_tflite::WhileOptions *>(builtin_options())
              : nullptr;
   }
-  const DepthToSpaceOptions *builtin_options_as_DepthToSpaceOptions() const
+  const onert_tflite::DepthToSpaceOptions *builtin_options_as_DepthToSpaceOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_DepthToSpaceOptions
-             ? static_cast<const DepthToSpaceOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_DepthToSpaceOptions
+             ? static_cast<const onert_tflite::DepthToSpaceOptions *>(builtin_options())
              : nullptr;
   }
-  const NonMaxSuppressionV4Options *builtin_options_as_NonMaxSuppressionV4Options() const
+  const onert_tflite::NonMaxSuppressionV4Options *
+  builtin_options_as_NonMaxSuppressionV4Options() const
   {
-    return builtin_options_type() == BuiltinOptions_NonMaxSuppressionV4Options
-             ? static_cast<const NonMaxSuppressionV4Options *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_NonMaxSuppressionV4Options
+             ? static_cast<const onert_tflite::NonMaxSuppressionV4Options *>(builtin_options())
              : nullptr;
   }
-  const NonMaxSuppressionV5Options *builtin_options_as_NonMaxSuppressionV5Options() const
+  const onert_tflite::NonMaxSuppressionV5Options *
+  builtin_options_as_NonMaxSuppressionV5Options() const
   {
-    return builtin_options_type() == BuiltinOptions_NonMaxSuppressionV5Options
-             ? static_cast<const NonMaxSuppressionV5Options *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_NonMaxSuppressionV5Options
+             ? static_cast<const onert_tflite::NonMaxSuppressionV5Options *>(builtin_options())
              : nullptr;
   }
-  const ScatterNdOptions *builtin_options_as_ScatterNdOptions() const
+  const onert_tflite::ScatterNdOptions *builtin_options_as_ScatterNdOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_ScatterNdOptions
-             ? static_cast<const ScatterNdOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_ScatterNdOptions
+             ? static_cast<const onert_tflite::ScatterNdOptions *>(builtin_options())
              : nullptr;
   }
-  const SelectV2Options *builtin_options_as_SelectV2Options() const
+  const onert_tflite::SelectV2Options *builtin_options_as_SelectV2Options() const
   {
-    return builtin_options_type() == BuiltinOptions_SelectV2Options
-             ? static_cast<const SelectV2Options *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_SelectV2Options
+             ? static_cast<const onert_tflite::SelectV2Options *>(builtin_options())
              : nullptr;
   }
-  const DensifyOptions *builtin_options_as_DensifyOptions() const
+  const onert_tflite::DensifyOptions *builtin_options_as_DensifyOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_DensifyOptions
-             ? static_cast<const DensifyOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_DensifyOptions
+             ? static_cast<const onert_tflite::DensifyOptions *>(builtin_options())
              : nullptr;
   }
-  const SegmentSumOptions *builtin_options_as_SegmentSumOptions() const
+  const onert_tflite::SegmentSumOptions *builtin_options_as_SegmentSumOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_SegmentSumOptions
-             ? static_cast<const SegmentSumOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_SegmentSumOptions
+             ? static_cast<const onert_tflite::SegmentSumOptions *>(builtin_options())
              : nullptr;
   }
-  const BatchMatMulOptions *builtin_options_as_BatchMatMulOptions() const
+  const onert_tflite::BatchMatMulOptions *builtin_options_as_BatchMatMulOptions() const
   {
-    return builtin_options_type() == BuiltinOptions_BatchMatMulOptions
-             ? static_cast<const BatchMatMulOptions *>(builtin_options())
+    return builtin_options_type() == onert_tflite::BuiltinOptions_BatchMatMulOptions
+             ? static_cast<const onert_tflite::BatchMatMulOptions *>(builtin_options())
              : nullptr;
   }
   const flatbuffers::Vector<uint8_t> *custom_options() const
   {
     return GetPointer<const flatbuffers::Vector<uint8_t> *>(VT_CUSTOM_OPTIONS);
   }
-  CustomOptionsFormat custom_options_format() const
+  onert_tflite::CustomOptionsFormat custom_options_format() const
   {
-    return static_cast<CustomOptionsFormat>(GetField<int8_t>(VT_CUSTOM_OPTIONS_FORMAT, 0));
+    return static_cast<onert_tflite::CustomOptionsFormat>(
+      GetField<int8_t>(VT_CUSTOM_OPTIONS_FORMAT, 0));
   }
   const flatbuffers::Vector<uint8_t> *mutating_variable_inputs() const
   {
@@ -7878,550 +8239,715 @@ struct Operator FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
   }
 };
 
-template <> inline const Conv2DOptions *Operator::builtin_options_as<Conv2DOptions>() const
+template <>
+inline const onert_tflite::Conv2DOptions *
+Operator::builtin_options_as<onert_tflite::Conv2DOptions>() const
 {
   return builtin_options_as_Conv2DOptions();
 }
 
 template <>
-inline const DepthwiseConv2DOptions *Operator::builtin_options_as<DepthwiseConv2DOptions>() const
+inline const onert_tflite::DepthwiseConv2DOptions *
+Operator::builtin_options_as<onert_tflite::DepthwiseConv2DOptions>() const
 {
   return builtin_options_as_DepthwiseConv2DOptions();
 }
 
 template <>
-inline const ConcatEmbeddingsOptions *Operator::builtin_options_as<ConcatEmbeddingsOptions>() const
+inline const onert_tflite::ConcatEmbeddingsOptions *
+Operator::builtin_options_as<onert_tflite::ConcatEmbeddingsOptions>() const
 {
   return builtin_options_as_ConcatEmbeddingsOptions();
 }
 
 template <>
-inline const LSHProjectionOptions *Operator::builtin_options_as<LSHProjectionOptions>() const
+inline const onert_tflite::LSHProjectionOptions *
+Operator::builtin_options_as<onert_tflite::LSHProjectionOptions>() const
 {
   return builtin_options_as_LSHProjectionOptions();
 }
 
-template <> inline const Pool2DOptions *Operator::builtin_options_as<Pool2DOptions>() const
+template <>
+inline const onert_tflite::Pool2DOptions *
+Operator::builtin_options_as<onert_tflite::Pool2DOptions>() const
 {
   return builtin_options_as_Pool2DOptions();
 }
 
-template <> inline const SVDFOptions *Operator::builtin_options_as<SVDFOptions>() const
+template <>
+inline const onert_tflite::SVDFOptions *
+Operator::builtin_options_as<onert_tflite::SVDFOptions>() const
 {
   return builtin_options_as_SVDFOptions();
 }
 
-template <> inline const RNNOptions *Operator::builtin_options_as<RNNOptions>() const
+template <>
+inline const onert_tflite::RNNOptions *
+Operator::builtin_options_as<onert_tflite::RNNOptions>() const
 {
   return builtin_options_as_RNNOptions();
 }
 
 template <>
-inline const FullyConnectedOptions *Operator::builtin_options_as<FullyConnectedOptions>() const
+inline const onert_tflite::FullyConnectedOptions *
+Operator::builtin_options_as<onert_tflite::FullyConnectedOptions>() const
 {
   return builtin_options_as_FullyConnectedOptions();
 }
 
-template <> inline const SoftmaxOptions *Operator::builtin_options_as<SoftmaxOptions>() const
+template <>
+inline const onert_tflite::SoftmaxOptions *
+Operator::builtin_options_as<onert_tflite::SoftmaxOptions>() const
 {
   return builtin_options_as_SoftmaxOptions();
 }
 
 template <>
-inline const ConcatenationOptions *Operator::builtin_options_as<ConcatenationOptions>() const
+inline const onert_tflite::ConcatenationOptions *
+Operator::builtin_options_as<onert_tflite::ConcatenationOptions>() const
 {
   return builtin_options_as_ConcatenationOptions();
 }
 
-template <> inline const AddOptions *Operator::builtin_options_as<AddOptions>() const
+template <>
+inline const onert_tflite::AddOptions *
+Operator::builtin_options_as<onert_tflite::AddOptions>() const
 {
   return builtin_options_as_AddOptions();
 }
 
-template <> inline const L2NormOptions *Operator::builtin_options_as<L2NormOptions>() const
+template <>
+inline const onert_tflite::L2NormOptions *
+Operator::builtin_options_as<onert_tflite::L2NormOptions>() const
 {
   return builtin_options_as_L2NormOptions();
 }
 
 template <>
-inline const LocalResponseNormalizationOptions *
-Operator::builtin_options_as<LocalResponseNormalizationOptions>() const
+inline const onert_tflite::LocalResponseNormalizationOptions *
+Operator::builtin_options_as<onert_tflite::LocalResponseNormalizationOptions>() const
 {
   return builtin_options_as_LocalResponseNormalizationOptions();
 }
 
-template <> inline const LSTMOptions *Operator::builtin_options_as<LSTMOptions>() const
+template <>
+inline const onert_tflite::LSTMOptions *
+Operator::builtin_options_as<onert_tflite::LSTMOptions>() const
 {
   return builtin_options_as_LSTMOptions();
 }
 
 template <>
-inline const ResizeBilinearOptions *Operator::builtin_options_as<ResizeBilinearOptions>() const
+inline const onert_tflite::ResizeBilinearOptions *
+Operator::builtin_options_as<onert_tflite::ResizeBilinearOptions>() const
 {
   return builtin_options_as_ResizeBilinearOptions();
 }
 
-template <> inline const CallOptions *Operator::builtin_options_as<CallOptions>() const
+template <>
+inline const onert_tflite::CallOptions *
+Operator::builtin_options_as<onert_tflite::CallOptions>() const
 {
   return builtin_options_as_CallOptions();
 }
 
-template <> inline const ReshapeOptions *Operator::builtin_options_as<ReshapeOptions>() const
+template <>
+inline const onert_tflite::ReshapeOptions *
+Operator::builtin_options_as<onert_tflite::ReshapeOptions>() const
 {
   return builtin_options_as_ReshapeOptions();
 }
 
-template <> inline const SkipGramOptions *Operator::builtin_options_as<SkipGramOptions>() const
+template <>
+inline const onert_tflite::SkipGramOptions *
+Operator::builtin_options_as<onert_tflite::SkipGramOptions>() const
 {
   return builtin_options_as_SkipGramOptions();
 }
 
 template <>
-inline const SpaceToDepthOptions *Operator::builtin_options_as<SpaceToDepthOptions>() const
+inline const onert_tflite::SpaceToDepthOptions *
+Operator::builtin_options_as<onert_tflite::SpaceToDepthOptions>() const
 {
   return builtin_options_as_SpaceToDepthOptions();
 }
 
 template <>
-inline const EmbeddingLookupSparseOptions *
-Operator::builtin_options_as<EmbeddingLookupSparseOptions>() const
+inline const onert_tflite::EmbeddingLookupSparseOptions *
+Operator::builtin_options_as<onert_tflite::EmbeddingLookupSparseOptions>() const
 {
   return builtin_options_as_EmbeddingLookupSparseOptions();
 }
 
-template <> inline const MulOptions *Operator::builtin_options_as<MulOptions>() const
+template <>
+inline const onert_tflite::MulOptions *
+Operator::builtin_options_as<onert_tflite::MulOptions>() const
 {
   return builtin_options_as_MulOptions();
 }
 
-template <> inline const PadOptions *Operator::builtin_options_as<PadOptions>() const
+template <>
+inline const onert_tflite::PadOptions *
+Operator::builtin_options_as<onert_tflite::PadOptions>() const
 {
   return builtin_options_as_PadOptions();
 }
 
-template <> inline const GatherOptions *Operator::builtin_options_as<GatherOptions>() const
+template <>
+inline const onert_tflite::GatherOptions *
+Operator::builtin_options_as<onert_tflite::GatherOptions>() const
 {
   return builtin_options_as_GatherOptions();
 }
 
 template <>
-inline const BatchToSpaceNDOptions *Operator::builtin_options_as<BatchToSpaceNDOptions>() const
+inline const onert_tflite::BatchToSpaceNDOptions *
+Operator::builtin_options_as<onert_tflite::BatchToSpaceNDOptions>() const
 {
   return builtin_options_as_BatchToSpaceNDOptions();
 }
 
 template <>
-inline const SpaceToBatchNDOptions *Operator::builtin_options_as<SpaceToBatchNDOptions>() const
+inline const onert_tflite::SpaceToBatchNDOptions *
+Operator::builtin_options_as<onert_tflite::SpaceToBatchNDOptions>() const
 {
   return builtin_options_as_SpaceToBatchNDOptions();
 }
 
-template <> inline const TransposeOptions *Operator::builtin_options_as<TransposeOptions>() const
+template <>
+inline const onert_tflite::TransposeOptions *
+Operator::builtin_options_as<onert_tflite::TransposeOptions>() const
 {
   return builtin_options_as_TransposeOptions();
 }
 
-template <> inline const ReducerOptions *Operator::builtin_options_as<ReducerOptions>() const
+template <>
+inline const onert_tflite::ReducerOptions *
+Operator::builtin_options_as<onert_tflite::ReducerOptions>() const
 {
   return builtin_options_as_ReducerOptions();
 }
 
-template <> inline const SubOptions *Operator::builtin_options_as<SubOptions>() const
+template <>
+inline const onert_tflite::SubOptions *
+Operator::builtin_options_as<onert_tflite::SubOptions>() const
 {
   return builtin_options_as_SubOptions();
 }
 
-template <> inline const DivOptions *Operator::builtin_options_as<DivOptions>() const
+template <>
+inline const onert_tflite::DivOptions *
+Operator::builtin_options_as<onert_tflite::DivOptions>() const
 {
   return builtin_options_as_DivOptions();
 }
 
-template <> inline const SqueezeOptions *Operator::builtin_options_as<SqueezeOptions>() const
+template <>
+inline const onert_tflite::SqueezeOptions *
+Operator::builtin_options_as<onert_tflite::SqueezeOptions>() const
 {
   return builtin_options_as_SqueezeOptions();
 }
 
 template <>
-inline const SequenceRNNOptions *Operator::builtin_options_as<SequenceRNNOptions>() const
+inline const onert_tflite::SequenceRNNOptions *
+Operator::builtin_options_as<onert_tflite::SequenceRNNOptions>() const
 {
   return builtin_options_as_SequenceRNNOptions();
 }
 
 template <>
-inline const StridedSliceOptions *Operator::builtin_options_as<StridedSliceOptions>() const
+inline const onert_tflite::StridedSliceOptions *
+Operator::builtin_options_as<onert_tflite::StridedSliceOptions>() const
 {
   return builtin_options_as_StridedSliceOptions();
 }
 
-template <> inline const ExpOptions *Operator::builtin_options_as<ExpOptions>() const
+template <>
+inline const onert_tflite::ExpOptions *
+Operator::builtin_options_as<onert_tflite::ExpOptions>() const
 {
   return builtin_options_as_ExpOptions();
 }
 
-template <> inline const TopKV2Options *Operator::builtin_options_as<TopKV2Options>() const
+template <>
+inline const onert_tflite::TopKV2Options *
+Operator::builtin_options_as<onert_tflite::TopKV2Options>() const
 {
   return builtin_options_as_TopKV2Options();
 }
 
-template <> inline const SplitOptions *Operator::builtin_options_as<SplitOptions>() const
+template <>
+inline const onert_tflite::SplitOptions *
+Operator::builtin_options_as<onert_tflite::SplitOptions>() const
 {
   return builtin_options_as_SplitOptions();
 }
 
-template <> inline const LogSoftmaxOptions *Operator::builtin_options_as<LogSoftmaxOptions>() const
+template <>
+inline const onert_tflite::LogSoftmaxOptions *
+Operator::builtin_options_as<onert_tflite::LogSoftmaxOptions>() const
 {
   return builtin_options_as_LogSoftmaxOptions();
 }
 
-template <> inline const CastOptions *Operator::builtin_options_as<CastOptions>() const
+template <>
+inline const onert_tflite::CastOptions *
+Operator::builtin_options_as<onert_tflite::CastOptions>() const
 {
   return builtin_options_as_CastOptions();
 }
 
-template <> inline const DequantizeOptions *Operator::builtin_options_as<DequantizeOptions>() const
+template <>
+inline const onert_tflite::DequantizeOptions *
+Operator::builtin_options_as<onert_tflite::DequantizeOptions>() const
 {
   return builtin_options_as_DequantizeOptions();
 }
 
 template <>
-inline const MaximumMinimumOptions *Operator::builtin_options_as<MaximumMinimumOptions>() const
+inline const onert_tflite::MaximumMinimumOptions *
+Operator::builtin_options_as<onert_tflite::MaximumMinimumOptions>() const
 {
   return builtin_options_as_MaximumMinimumOptions();
 }
 
-template <> inline const ArgMaxOptions *Operator::builtin_options_as<ArgMaxOptions>() const
+template <>
+inline const onert_tflite::ArgMaxOptions *
+Operator::builtin_options_as<onert_tflite::ArgMaxOptions>() const
 {
   return builtin_options_as_ArgMaxOptions();
 }
 
-template <> inline const LessOptions *Operator::builtin_options_as<LessOptions>() const
+template <>
+inline const onert_tflite::LessOptions *
+Operator::builtin_options_as<onert_tflite::LessOptions>() const
 {
   return builtin_options_as_LessOptions();
 }
 
-template <> inline const NegOptions *Operator::builtin_options_as<NegOptions>() const
+template <>
+inline const onert_tflite::NegOptions *
+Operator::builtin_options_as<onert_tflite::NegOptions>() const
 {
   return builtin_options_as_NegOptions();
 }
 
-template <> inline const PadV2Options *Operator::builtin_options_as<PadV2Options>() const
+template <>
+inline const onert_tflite::PadV2Options *
+Operator::builtin_options_as<onert_tflite::PadV2Options>() const
 {
   return builtin_options_as_PadV2Options();
 }
 
-template <> inline const GreaterOptions *Operator::builtin_options_as<GreaterOptions>() const
+template <>
+inline const onert_tflite::GreaterOptions *
+Operator::builtin_options_as<onert_tflite::GreaterOptions>() const
 {
   return builtin_options_as_GreaterOptions();
 }
 
 template <>
-inline const GreaterEqualOptions *Operator::builtin_options_as<GreaterEqualOptions>() const
+inline const onert_tflite::GreaterEqualOptions *
+Operator::builtin_options_as<onert_tflite::GreaterEqualOptions>() const
 {
   return builtin_options_as_GreaterEqualOptions();
 }
 
-template <> inline const LessEqualOptions *Operator::builtin_options_as<LessEqualOptions>() const
+template <>
+inline const onert_tflite::LessEqualOptions *
+Operator::builtin_options_as<onert_tflite::LessEqualOptions>() const
 {
   return builtin_options_as_LessEqualOptions();
 }
 
-template <> inline const SelectOptions *Operator::builtin_options_as<SelectOptions>() const
+template <>
+inline const onert_tflite::SelectOptions *
+Operator::builtin_options_as<onert_tflite::SelectOptions>() const
 {
   return builtin_options_as_SelectOptions();
 }
 
-template <> inline const SliceOptions *Operator::builtin_options_as<SliceOptions>() const
+template <>
+inline const onert_tflite::SliceOptions *
+Operator::builtin_options_as<onert_tflite::SliceOptions>() const
 {
   return builtin_options_as_SliceOptions();
 }
 
 template <>
-inline const TransposeConvOptions *Operator::builtin_options_as<TransposeConvOptions>() const
+inline const onert_tflite::TransposeConvOptions *
+Operator::builtin_options_as<onert_tflite::TransposeConvOptions>() const
 {
   return builtin_options_as_TransposeConvOptions();
 }
 
 template <>
-inline const SparseToDenseOptions *Operator::builtin_options_as<SparseToDenseOptions>() const
+inline const onert_tflite::SparseToDenseOptions *
+Operator::builtin_options_as<onert_tflite::SparseToDenseOptions>() const
 {
   return builtin_options_as_SparseToDenseOptions();
 }
 
-template <> inline const TileOptions *Operator::builtin_options_as<TileOptions>() const
+template <>
+inline const onert_tflite::TileOptions *
+Operator::builtin_options_as<onert_tflite::TileOptions>() const
 {
   return builtin_options_as_TileOptions();
 }
 
-template <> inline const ExpandDimsOptions *Operator::builtin_options_as<ExpandDimsOptions>() const
+template <>
+inline const onert_tflite::ExpandDimsOptions *
+Operator::builtin_options_as<onert_tflite::ExpandDimsOptions>() const
 {
   return builtin_options_as_ExpandDimsOptions();
 }
 
-template <> inline const EqualOptions *Operator::builtin_options_as<EqualOptions>() const
+template <>
+inline const onert_tflite::EqualOptions *
+Operator::builtin_options_as<onert_tflite::EqualOptions>() const
 {
   return builtin_options_as_EqualOptions();
 }
 
-template <> inline const NotEqualOptions *Operator::builtin_options_as<NotEqualOptions>() const
+template <>
+inline const onert_tflite::NotEqualOptions *
+Operator::builtin_options_as<onert_tflite::NotEqualOptions>() const
 {
   return builtin_options_as_NotEqualOptions();
 }
 
-template <> inline const ShapeOptions *Operator::builtin_options_as<ShapeOptions>() const
+template <>
+inline const onert_tflite::ShapeOptions *
+Operator::builtin_options_as<onert_tflite::ShapeOptions>() const
 {
   return builtin_options_as_ShapeOptions();
 }
 
-template <> inline const PowOptions *Operator::builtin_options_as<PowOptions>() const
+template <>
+inline const onert_tflite::PowOptions *
+Operator::builtin_options_as<onert_tflite::PowOptions>() const
 {
   return builtin_options_as_PowOptions();
 }
 
-template <> inline const ArgMinOptions *Operator::builtin_options_as<ArgMinOptions>() const
+template <>
+inline const onert_tflite::ArgMinOptions *
+Operator::builtin_options_as<onert_tflite::ArgMinOptions>() const
 {
   return builtin_options_as_ArgMinOptions();
 }
 
-template <> inline const FakeQuantOptions *Operator::builtin_options_as<FakeQuantOptions>() const
+template <>
+inline const onert_tflite::FakeQuantOptions *
+Operator::builtin_options_as<onert_tflite::FakeQuantOptions>() const
 {
   return builtin_options_as_FakeQuantOptions();
 }
 
-template <> inline const PackOptions *Operator::builtin_options_as<PackOptions>() const
+template <>
+inline const onert_tflite::PackOptions *
+Operator::builtin_options_as<onert_tflite::PackOptions>() const
 {
   return builtin_options_as_PackOptions();
 }
 
-template <> inline const LogicalOrOptions *Operator::builtin_options_as<LogicalOrOptions>() const
+template <>
+inline const onert_tflite::LogicalOrOptions *
+Operator::builtin_options_as<onert_tflite::LogicalOrOptions>() const
 {
   return builtin_options_as_LogicalOrOptions();
 }
 
-template <> inline const OneHotOptions *Operator::builtin_options_as<OneHotOptions>() const
+template <>
+inline const onert_tflite::OneHotOptions *
+Operator::builtin_options_as<onert_tflite::OneHotOptions>() const
 {
   return builtin_options_as_OneHotOptions();
 }
 
-template <> inline const LogicalAndOptions *Operator::builtin_options_as<LogicalAndOptions>() const
+template <>
+inline const onert_tflite::LogicalAndOptions *
+Operator::builtin_options_as<onert_tflite::LogicalAndOptions>() const
 {
   return builtin_options_as_LogicalAndOptions();
 }
 
-template <> inline const LogicalNotOptions *Operator::builtin_options_as<LogicalNotOptions>() const
+template <>
+inline const onert_tflite::LogicalNotOptions *
+Operator::builtin_options_as<onert_tflite::LogicalNotOptions>() const
 {
   return builtin_options_as_LogicalNotOptions();
 }
 
-template <> inline const UnpackOptions *Operator::builtin_options_as<UnpackOptions>() const
+template <>
+inline const onert_tflite::UnpackOptions *
+Operator::builtin_options_as<onert_tflite::UnpackOptions>() const
 {
   return builtin_options_as_UnpackOptions();
 }
 
-template <> inline const FloorDivOptions *Operator::builtin_options_as<FloorDivOptions>() const
+template <>
+inline const onert_tflite::FloorDivOptions *
+Operator::builtin_options_as<onert_tflite::FloorDivOptions>() const
 {
   return builtin_options_as_FloorDivOptions();
 }
 
-template <> inline const SquareOptions *Operator::builtin_options_as<SquareOptions>() const
+template <>
+inline const onert_tflite::SquareOptions *
+Operator::builtin_options_as<onert_tflite::SquareOptions>() const
 {
   return builtin_options_as_SquareOptions();
 }
 
-template <> inline const ZerosLikeOptions *Operator::builtin_options_as<ZerosLikeOptions>() const
+template <>
+inline const onert_tflite::ZerosLikeOptions *
+Operator::builtin_options_as<onert_tflite::ZerosLikeOptions>() const
 {
   return builtin_options_as_ZerosLikeOptions();
 }
 
-template <> inline const FillOptions *Operator::builtin_options_as<FillOptions>() const
+template <>
+inline const onert_tflite::FillOptions *
+Operator::builtin_options_as<onert_tflite::FillOptions>() const
 {
   return builtin_options_as_FillOptions();
 }
 
 template <>
-inline const BidirectionalSequenceLSTMOptions *
-Operator::builtin_options_as<BidirectionalSequenceLSTMOptions>() const
+inline const onert_tflite::BidirectionalSequenceLSTMOptions *
+Operator::builtin_options_as<onert_tflite::BidirectionalSequenceLSTMOptions>() const
 {
   return builtin_options_as_BidirectionalSequenceLSTMOptions();
 }
 
 template <>
-inline const BidirectionalSequenceRNNOptions *
-Operator::builtin_options_as<BidirectionalSequenceRNNOptions>() const
+inline const onert_tflite::BidirectionalSequenceRNNOptions *
+Operator::builtin_options_as<onert_tflite::BidirectionalSequenceRNNOptions>() const
 {
   return builtin_options_as_BidirectionalSequenceRNNOptions();
 }
 
 template <>
-inline const UnidirectionalSequenceLSTMOptions *
-Operator::builtin_options_as<UnidirectionalSequenceLSTMOptions>() const
+inline const onert_tflite::UnidirectionalSequenceLSTMOptions *
+Operator::builtin_options_as<onert_tflite::UnidirectionalSequenceLSTMOptions>() const
 {
   return builtin_options_as_UnidirectionalSequenceLSTMOptions();
 }
 
-template <> inline const FloorModOptions *Operator::builtin_options_as<FloorModOptions>() const
+template <>
+inline const onert_tflite::FloorModOptions *
+Operator::builtin_options_as<onert_tflite::FloorModOptions>() const
 {
   return builtin_options_as_FloorModOptions();
 }
 
-template <> inline const RangeOptions *Operator::builtin_options_as<RangeOptions>() const
+template <>
+inline const onert_tflite::RangeOptions *
+Operator::builtin_options_as<onert_tflite::RangeOptions>() const
 {
   return builtin_options_as_RangeOptions();
 }
 
 template <>
-inline const ResizeNearestNeighborOptions *
-Operator::builtin_options_as<ResizeNearestNeighborOptions>() const
+inline const onert_tflite::ResizeNearestNeighborOptions *
+Operator::builtin_options_as<onert_tflite::ResizeNearestNeighborOptions>() const
 {
   return builtin_options_as_ResizeNearestNeighborOptions();
 }
 
-template <> inline const LeakyReluOptions *Operator::builtin_options_as<LeakyReluOptions>() const
+template <>
+inline const onert_tflite::LeakyReluOptions *
+Operator::builtin_options_as<onert_tflite::LeakyReluOptions>() const
 {
   return builtin_options_as_LeakyReluOptions();
 }
 
 template <>
-inline const SquaredDifferenceOptions *
-Operator::builtin_options_as<SquaredDifferenceOptions>() const
+inline const onert_tflite::SquaredDifferenceOptions *
+Operator::builtin_options_as<onert_tflite::SquaredDifferenceOptions>() const
 {
   return builtin_options_as_SquaredDifferenceOptions();
 }
 
-template <> inline const MirrorPadOptions *Operator::builtin_options_as<MirrorPadOptions>() const
+template <>
+inline const onert_tflite::MirrorPadOptions *
+Operator::builtin_options_as<onert_tflite::MirrorPadOptions>() const
 {
   return builtin_options_as_MirrorPadOptions();
 }
 
-template <> inline const AbsOptions *Operator::builtin_options_as<AbsOptions>() const
+template <>
+inline const onert_tflite::AbsOptions *
+Operator::builtin_options_as<onert_tflite::AbsOptions>() const
 {
   return builtin_options_as_AbsOptions();
 }
 
-template <> inline const SplitVOptions *Operator::builtin_options_as<SplitVOptions>() const
+template <>
+inline const onert_tflite::SplitVOptions *
+Operator::builtin_options_as<onert_tflite::SplitVOptions>() const
 {
   return builtin_options_as_SplitVOptions();
 }
 
-template <> inline const UniqueOptions *Operator::builtin_options_as<UniqueOptions>() const
+template <>
+inline const onert_tflite::UniqueOptions *
+Operator::builtin_options_as<onert_tflite::UniqueOptions>() const
 {
   return builtin_options_as_UniqueOptions();
 }
 
-template <> inline const ReverseV2Options *Operator::builtin_options_as<ReverseV2Options>() const
+template <>
+inline const onert_tflite::ReverseV2Options *
+Operator::builtin_options_as<onert_tflite::ReverseV2Options>() const
 {
   return builtin_options_as_ReverseV2Options();
 }
 
-template <> inline const AddNOptions *Operator::builtin_options_as<AddNOptions>() const
+template <>
+inline const onert_tflite::AddNOptions *
+Operator::builtin_options_as<onert_tflite::AddNOptions>() const
 {
   return builtin_options_as_AddNOptions();
 }
 
-template <> inline const GatherNdOptions *Operator::builtin_options_as<GatherNdOptions>() const
+template <>
+inline const onert_tflite::GatherNdOptions *
+Operator::builtin_options_as<onert_tflite::GatherNdOptions>() const
 {
   return builtin_options_as_GatherNdOptions();
 }
 
-template <> inline const CosOptions *Operator::builtin_options_as<CosOptions>() const
+template <>
+inline const onert_tflite::CosOptions *
+Operator::builtin_options_as<onert_tflite::CosOptions>() const
 {
   return builtin_options_as_CosOptions();
 }
 
-template <> inline const WhereOptions *Operator::builtin_options_as<WhereOptions>() const
+template <>
+inline const onert_tflite::WhereOptions *
+Operator::builtin_options_as<onert_tflite::WhereOptions>() const
 {
   return builtin_options_as_WhereOptions();
 }
 
-template <> inline const RankOptions *Operator::builtin_options_as<RankOptions>() const
+template <>
+inline const onert_tflite::RankOptions *
+Operator::builtin_options_as<onert_tflite::RankOptions>() const
 {
   return builtin_options_as_RankOptions();
 }
 
 template <>
-inline const ReverseSequenceOptions *Operator::builtin_options_as<ReverseSequenceOptions>() const
+inline const onert_tflite::ReverseSequenceOptions *
+Operator::builtin_options_as<onert_tflite::ReverseSequenceOptions>() const
 {
   return builtin_options_as_ReverseSequenceOptions();
 }
 
-template <> inline const MatrixDiagOptions *Operator::builtin_options_as<MatrixDiagOptions>() const
+template <>
+inline const onert_tflite::MatrixDiagOptions *
+Operator::builtin_options_as<onert_tflite::MatrixDiagOptions>() const
 {
   return builtin_options_as_MatrixDiagOptions();
 }
 
-template <> inline const QuantizeOptions *Operator::builtin_options_as<QuantizeOptions>() const
+template <>
+inline const onert_tflite::QuantizeOptions *
+Operator::builtin_options_as<onert_tflite::QuantizeOptions>() const
 {
   return builtin_options_as_QuantizeOptions();
 }
 
 template <>
-inline const MatrixSetDiagOptions *Operator::builtin_options_as<MatrixSetDiagOptions>() const
+inline const onert_tflite::MatrixSetDiagOptions *
+Operator::builtin_options_as<onert_tflite::MatrixSetDiagOptions>() const
 {
   return builtin_options_as_MatrixSetDiagOptions();
 }
 
-template <> inline const HardSwishOptions *Operator::builtin_options_as<HardSwishOptions>() const
+template <>
+inline const onert_tflite::HardSwishOptions *
+Operator::builtin_options_as<onert_tflite::HardSwishOptions>() const
 {
   return builtin_options_as_HardSwishOptions();
 }
 
-template <> inline const IfOptions *Operator::builtin_options_as<IfOptions>() const
+template <>
+inline const onert_tflite::IfOptions *Operator::builtin_options_as<onert_tflite::IfOptions>() const
 {
   return builtin_options_as_IfOptions();
 }
 
-template <> inline const WhileOptions *Operator::builtin_options_as<WhileOptions>() const
+template <>
+inline const onert_tflite::WhileOptions *
+Operator::builtin_options_as<onert_tflite::WhileOptions>() const
 {
   return builtin_options_as_WhileOptions();
 }
 
 template <>
-inline const DepthToSpaceOptions *Operator::builtin_options_as<DepthToSpaceOptions>() const
+inline const onert_tflite::DepthToSpaceOptions *
+Operator::builtin_options_as<onert_tflite::DepthToSpaceOptions>() const
 {
   return builtin_options_as_DepthToSpaceOptions();
 }
 
 template <>
-inline const NonMaxSuppressionV4Options *
-Operator::builtin_options_as<NonMaxSuppressionV4Options>() const
+inline const onert_tflite::NonMaxSuppressionV4Options *
+Operator::builtin_options_as<onert_tflite::NonMaxSuppressionV4Options>() const
 {
   return builtin_options_as_NonMaxSuppressionV4Options();
 }
 
 template <>
-inline const NonMaxSuppressionV5Options *
-Operator::builtin_options_as<NonMaxSuppressionV5Options>() const
+inline const onert_tflite::NonMaxSuppressionV5Options *
+Operator::builtin_options_as<onert_tflite::NonMaxSuppressionV5Options>() const
 {
   return builtin_options_as_NonMaxSuppressionV5Options();
 }
 
-template <> inline const ScatterNdOptions *Operator::builtin_options_as<ScatterNdOptions>() const
+template <>
+inline const onert_tflite::ScatterNdOptions *
+Operator::builtin_options_as<onert_tflite::ScatterNdOptions>() const
 {
   return builtin_options_as_ScatterNdOptions();
 }
 
-template <> inline const SelectV2Options *Operator::builtin_options_as<SelectV2Options>() const
+template <>
+inline const onert_tflite::SelectV2Options *
+Operator::builtin_options_as<onert_tflite::SelectV2Options>() const
 {
   return builtin_options_as_SelectV2Options();
 }
 
-template <> inline const DensifyOptions *Operator::builtin_options_as<DensifyOptions>() const
+template <>
+inline const onert_tflite::DensifyOptions *
+Operator::builtin_options_as<onert_tflite::DensifyOptions>() const
 {
   return builtin_options_as_DensifyOptions();
 }
 
-template <> inline const SegmentSumOptions *Operator::builtin_options_as<SegmentSumOptions>() const
+template <>
+inline const onert_tflite::SegmentSumOptions *
+Operator::builtin_options_as<onert_tflite::SegmentSumOptions>() const
 {
   return builtin_options_as_SegmentSumOptions();
 }
 
 template <>
-inline const BatchMatMulOptions *Operator::builtin_options_as<BatchMatMulOptions>() const
+inline const onert_tflite::BatchMatMulOptions *
+Operator::builtin_options_as<onert_tflite::BatchMatMulOptions>() const
 {
   return builtin_options_as_BatchMatMulOptions();
 }
 
 struct OperatorBuilder
 {
+  typedef Operator Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_opcode_index(uint32_t opcode_index)
@@ -8436,7 +8962,7 @@ struct OperatorBuilder
   {
     fbb_.AddOffset(Operator::VT_OUTPUTS, outputs);
   }
-  void add_builtin_options_type(BuiltinOptions builtin_options_type)
+  void add_builtin_options_type(onert_tflite::BuiltinOptions builtin_options_type)
   {
     fbb_.AddElement<uint8_t>(Operator::VT_BUILTIN_OPTIONS_TYPE,
                              static_cast<uint8_t>(builtin_options_type), 0);
@@ -8449,7 +8975,7 @@ struct OperatorBuilder
   {
     fbb_.AddOffset(Operator::VT_CUSTOM_OPTIONS, custom_options);
   }
-  void add_custom_options_format(CustomOptionsFormat custom_options_format)
+  void add_custom_options_format(onert_tflite::CustomOptionsFormat custom_options_format)
   {
     fbb_.AddElement<int8_t>(Operator::VT_CUSTOM_OPTIONS_FORMAT,
                             static_cast<int8_t>(custom_options_format), 0);
@@ -8467,7 +8993,6 @@ struct OperatorBuilder
   {
     start_ = fbb_.StartTable();
   }
-  OperatorBuilder &operator=(const OperatorBuilder &);
   flatbuffers::Offset<Operator> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -8476,16 +9001,17 @@ struct OperatorBuilder
   }
 };
 
-inline flatbuffers::Offset<Operator>
-CreateOperator(flatbuffers::FlatBufferBuilder &_fbb, uint32_t opcode_index = 0,
-               flatbuffers::Offset<flatbuffers::Vector<int32_t>> inputs = 0,
-               flatbuffers::Offset<flatbuffers::Vector<int32_t>> outputs = 0,
-               BuiltinOptions builtin_options_type = BuiltinOptions_NONE,
-               flatbuffers::Offset<void> builtin_options = 0,
-               flatbuffers::Offset<flatbuffers::Vector<uint8_t>> custom_options = 0,
-               CustomOptionsFormat custom_options_format = CustomOptionsFormat_FLEXBUFFERS,
-               flatbuffers::Offset<flatbuffers::Vector<uint8_t>> mutating_variable_inputs = 0,
-               flatbuffers::Offset<flatbuffers::Vector<int32_t>> intermediates = 0)
+inline flatbuffers::Offset<Operator> CreateOperator(
+  flatbuffers::FlatBufferBuilder &_fbb, uint32_t opcode_index = 0,
+  flatbuffers::Offset<flatbuffers::Vector<int32_t>> inputs = 0,
+  flatbuffers::Offset<flatbuffers::Vector<int32_t>> outputs = 0,
+  onert_tflite::BuiltinOptions builtin_options_type = onert_tflite::BuiltinOptions_NONE,
+  flatbuffers::Offset<void> builtin_options = 0,
+  flatbuffers::Offset<flatbuffers::Vector<uint8_t>> custom_options = 0,
+  onert_tflite::CustomOptionsFormat custom_options_format =
+    onert_tflite::CustomOptionsFormat_FLEXBUFFERS,
+  flatbuffers::Offset<flatbuffers::Vector<uint8_t>> mutating_variable_inputs = 0,
+  flatbuffers::Offset<flatbuffers::Vector<int32_t>> intermediates = 0)
 {
   OperatorBuilder builder_(_fbb);
   builder_.add_intermediates(intermediates);
@@ -8500,28 +9026,32 @@ CreateOperator(flatbuffers::FlatBufferBuilder &_fbb, uint32_t opcode_index = 0,
   return builder_.Finish();
 }
 
-inline flatbuffers::Offset<Operator>
-CreateOperatorDirect(flatbuffers::FlatBufferBuilder &_fbb, uint32_t opcode_index = 0,
-                     const std::vector<int32_t> *inputs = nullptr,
-                     const std::vector<int32_t> *outputs = nullptr,
-                     BuiltinOptions builtin_options_type = BuiltinOptions_NONE,
-                     flatbuffers::Offset<void> builtin_options = 0,
-                     const std::vector<uint8_t> *custom_options = nullptr,
-                     CustomOptionsFormat custom_options_format = CustomOptionsFormat_FLEXBUFFERS,
-                     const std::vector<uint8_t> *mutating_variable_inputs = nullptr,
-                     const std::vector<int32_t> *intermediates = nullptr)
+inline flatbuffers::Offset<Operator> CreateOperatorDirect(
+  flatbuffers::FlatBufferBuilder &_fbb, uint32_t opcode_index = 0,
+  const std::vector<int32_t> *inputs = nullptr, const std::vector<int32_t> *outputs = nullptr,
+  onert_tflite::BuiltinOptions builtin_options_type = onert_tflite::BuiltinOptions_NONE,
+  flatbuffers::Offset<void> builtin_options = 0,
+  const std::vector<uint8_t> *custom_options = nullptr,
+  onert_tflite::CustomOptionsFormat custom_options_format =
+    onert_tflite::CustomOptionsFormat_FLEXBUFFERS,
+  const std::vector<uint8_t> *mutating_variable_inputs = nullptr,
+  const std::vector<int32_t> *intermediates = nullptr)
 {
-  return onert_tflite::CreateOperator(
-    _fbb, opcode_index, inputs ? _fbb.CreateVector<int32_t>(*inputs) : 0,
-    outputs ? _fbb.CreateVector<int32_t>(*outputs) : 0, builtin_options_type, builtin_options,
-    custom_options ? _fbb.CreateVector<uint8_t>(*custom_options) : 0, custom_options_format,
-    mutating_variable_inputs ? _fbb.CreateVector<uint8_t>(*mutating_variable_inputs) : 0,
-    intermediates ? _fbb.CreateVector<int32_t>(*intermediates) : 0);
+  auto inputs__ = inputs ? _fbb.CreateVector<int32_t>(*inputs) : 0;
+  auto outputs__ = outputs ? _fbb.CreateVector<int32_t>(*outputs) : 0;
+  auto custom_options__ = custom_options ? _fbb.CreateVector<uint8_t>(*custom_options) : 0;
+  auto mutating_variable_inputs__ =
+    mutating_variable_inputs ? _fbb.CreateVector<uint8_t>(*mutating_variable_inputs) : 0;
+  auto intermediates__ = intermediates ? _fbb.CreateVector<int32_t>(*intermediates) : 0;
+  return onert_tflite::CreateOperator(_fbb, opcode_index, inputs__, outputs__, builtin_options_type,
+                                      builtin_options, custom_options__, custom_options_format,
+                                      mutating_variable_inputs__, intermediates__);
 }
 
 struct SubGraph FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef SubGraphBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_TENSORS = 4,
     VT_INPUTS = 6,
@@ -8529,9 +9059,10 @@ struct SubGraph FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
     VT_OPERATORS = 10,
     VT_NAME = 12
   };
-  const flatbuffers::Vector<flatbuffers::Offset<Tensor>> *tensors() const
+  const flatbuffers::Vector<flatbuffers::Offset<onert_tflite::Tensor>> *tensors() const
   {
-    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<Tensor>> *>(VT_TENSORS);
+    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<onert_tflite::Tensor>> *>(
+      VT_TENSORS);
   }
   const flatbuffers::Vector<int32_t> *inputs() const
   {
@@ -8541,9 +9072,10 @@ struct SubGraph FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
   {
     return GetPointer<const flatbuffers::Vector<int32_t> *>(VT_OUTPUTS);
   }
-  const flatbuffers::Vector<flatbuffers::Offset<Operator>> *operators() const
+  const flatbuffers::Vector<flatbuffers::Offset<onert_tflite::Operator>> *operators() const
   {
-    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<Operator>> *>(VT_OPERATORS);
+    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<onert_tflite::Operator>> *>(
+      VT_OPERATORS);
   }
   const flatbuffers::String *name() const
   {
@@ -8563,9 +9095,11 @@ struct SubGraph FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct SubGraphBuilder
 {
+  typedef SubGraph Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_tensors(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<Tensor>>> tensors)
+  void add_tensors(
+    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<onert_tflite::Tensor>>> tensors)
   {
     fbb_.AddOffset(SubGraph::VT_TENSORS, tensors);
   }
@@ -8577,8 +9111,8 @@ struct SubGraphBuilder
   {
     fbb_.AddOffset(SubGraph::VT_OUTPUTS, outputs);
   }
-  void
-  add_operators(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<Operator>>> operators)
+  void add_operators(
+    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<onert_tflite::Operator>>> operators)
   {
     fbb_.AddOffset(SubGraph::VT_OPERATORS, operators);
   }
@@ -8590,7 +9124,6 @@ struct SubGraphBuilder
   {
     start_ = fbb_.StartTable();
   }
-  SubGraphBuilder &operator=(const SubGraphBuilder &);
   flatbuffers::Offset<SubGraph> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -8601,10 +9134,11 @@ struct SubGraphBuilder
 
 inline flatbuffers::Offset<SubGraph> CreateSubGraph(
   flatbuffers::FlatBufferBuilder &_fbb,
-  flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<Tensor>>> tensors = 0,
+  flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<onert_tflite::Tensor>>> tensors = 0,
   flatbuffers::Offset<flatbuffers::Vector<int32_t>> inputs = 0,
   flatbuffers::Offset<flatbuffers::Vector<int32_t>> outputs = 0,
-  flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<Operator>>> operators = 0,
+  flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<onert_tflite::Operator>>> operators =
+    0,
   flatbuffers::Offset<flatbuffers::String> name = 0)
 {
   SubGraphBuilder builder_(_fbb);
@@ -8618,21 +9152,25 @@ inline flatbuffers::Offset<SubGraph> CreateSubGraph(
 
 inline flatbuffers::Offset<SubGraph> CreateSubGraphDirect(
   flatbuffers::FlatBufferBuilder &_fbb,
-  const std::vector<flatbuffers::Offset<Tensor>> *tensors = nullptr,
+  const std::vector<flatbuffers::Offset<onert_tflite::Tensor>> *tensors = nullptr,
   const std::vector<int32_t> *inputs = nullptr, const std::vector<int32_t> *outputs = nullptr,
-  const std::vector<flatbuffers::Offset<Operator>> *operators = nullptr, const char *name = nullptr)
+  const std::vector<flatbuffers::Offset<onert_tflite::Operator>> *operators = nullptr,
+  const char *name = nullptr)
 {
-  return onert_tflite::CreateSubGraph(
-    _fbb, tensors ? _fbb.CreateVector<flatbuffers::Offset<Tensor>>(*tensors) : 0,
-    inputs ? _fbb.CreateVector<int32_t>(*inputs) : 0,
-    outputs ? _fbb.CreateVector<int32_t>(*outputs) : 0,
-    operators ? _fbb.CreateVector<flatbuffers::Offset<Operator>>(*operators) : 0,
-    name ? _fbb.CreateString(name) : 0);
+  auto tensors__ =
+    tensors ? _fbb.CreateVector<flatbuffers::Offset<onert_tflite::Tensor>>(*tensors) : 0;
+  auto inputs__ = inputs ? _fbb.CreateVector<int32_t>(*inputs) : 0;
+  auto outputs__ = outputs ? _fbb.CreateVector<int32_t>(*outputs) : 0;
+  auto operators__ =
+    operators ? _fbb.CreateVector<flatbuffers::Offset<onert_tflite::Operator>>(*operators) : 0;
+  auto name__ = name ? _fbb.CreateString(name) : 0;
+  return onert_tflite::CreateSubGraph(_fbb, tensors__, inputs__, outputs__, operators__, name__);
 }
 
 struct Buffer FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef BufferBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_DATA = 4
   };
@@ -8649,6 +9187,7 @@ struct Buffer FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct BufferBuilder
 {
+  typedef Buffer Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_data(flatbuffers::Offset<flatbuffers::Vector<uint8_t>> data)
@@ -8659,7 +9198,6 @@ struct BufferBuilder
   {
     start_ = fbb_.StartTable();
   }
-  BufferBuilder &operator=(const BufferBuilder &);
   flatbuffers::Offset<Buffer> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -8680,12 +9218,18 @@ CreateBuffer(flatbuffers::FlatBufferBuilder &_fbb,
 inline flatbuffers::Offset<Buffer> CreateBufferDirect(flatbuffers::FlatBufferBuilder &_fbb,
                                                       const std::vector<uint8_t> *data = nullptr)
 {
-  return onert_tflite::CreateBuffer(_fbb, data ? _fbb.CreateVector<uint8_t>(*data) : 0);
+  if (data)
+  {
+    _fbb.ForceVectorAlignment(data->size(), sizeof(uint8_t), 16);
+  }
+  auto data__ = data ? _fbb.CreateVector<uint8_t>(*data) : 0;
+  return onert_tflite::CreateBuffer(_fbb, data__);
 }
 
 struct Metadata FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef MetadataBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_NAME = 4,
     VT_BUFFER = 6
@@ -8705,6 +9249,7 @@ struct Metadata FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct MetadataBuilder
 {
+  typedef Metadata Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_name(flatbuffers::Offset<flatbuffers::String> name)
@@ -8716,7 +9261,6 @@ struct MetadataBuilder
   {
     start_ = fbb_.StartTable();
   }
-  MetadataBuilder &operator=(const MetadataBuilder &);
   flatbuffers::Offset<Metadata> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -8739,12 +9283,14 @@ inline flatbuffers::Offset<Metadata> CreateMetadataDirect(flatbuffers::FlatBuffe
                                                           const char *name = nullptr,
                                                           uint32_t buffer = 0)
 {
-  return onert_tflite::CreateMetadata(_fbb, name ? _fbb.CreateString(name) : 0, buffer);
+  auto name__ = name ? _fbb.CreateString(name) : 0;
+  return onert_tflite::CreateMetadata(_fbb, name__, buffer);
 }
 
 struct Model FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 {
-  enum
+  typedef ModelBuilder Builder;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE
   {
     VT_VERSION = 4,
     VT_OPERATOR_CODES = 6,
@@ -8755,30 +9301,33 @@ struct Model FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
     VT_METADATA = 16
   };
   uint32_t version() const { return GetField<uint32_t>(VT_VERSION, 0); }
-  const flatbuffers::Vector<flatbuffers::Offset<OperatorCode>> *operator_codes() const
+  const flatbuffers::Vector<flatbuffers::Offset<onert_tflite::OperatorCode>> *operator_codes() const
   {
-    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<OperatorCode>> *>(
+    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<onert_tflite::OperatorCode>> *>(
       VT_OPERATOR_CODES);
   }
-  const flatbuffers::Vector<flatbuffers::Offset<SubGraph>> *subgraphs() const
+  const flatbuffers::Vector<flatbuffers::Offset<onert_tflite::SubGraph>> *subgraphs() const
   {
-    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<SubGraph>> *>(VT_SUBGRAPHS);
+    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<onert_tflite::SubGraph>> *>(
+      VT_SUBGRAPHS);
   }
   const flatbuffers::String *description() const
   {
     return GetPointer<const flatbuffers::String *>(VT_DESCRIPTION);
   }
-  const flatbuffers::Vector<flatbuffers::Offset<Buffer>> *buffers() const
+  const flatbuffers::Vector<flatbuffers::Offset<onert_tflite::Buffer>> *buffers() const
   {
-    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<Buffer>> *>(VT_BUFFERS);
+    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<onert_tflite::Buffer>> *>(
+      VT_BUFFERS);
   }
   const flatbuffers::Vector<int32_t> *metadata_buffer() const
   {
     return GetPointer<const flatbuffers::Vector<int32_t> *>(VT_METADATA_BUFFER);
   }
-  const flatbuffers::Vector<flatbuffers::Offset<Metadata>> *metadata() const
+  const flatbuffers::Vector<flatbuffers::Offset<onert_tflite::Metadata>> *metadata() const
   {
-    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<Metadata>> *>(VT_METADATA);
+    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<onert_tflite::Metadata>> *>(
+      VT_METADATA);
   }
   bool Verify(flatbuffers::Verifier &verifier) const
   {
@@ -8797,16 +9346,18 @@ struct Model FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 
 struct ModelBuilder
 {
+  typedef Model Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_version(uint32_t version) { fbb_.AddElement<uint32_t>(Model::VT_VERSION, version, 0); }
   void add_operator_codes(
-    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<OperatorCode>>> operator_codes)
+    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<onert_tflite::OperatorCode>>>
+      operator_codes)
   {
     fbb_.AddOffset(Model::VT_OPERATOR_CODES, operator_codes);
   }
-  void
-  add_subgraphs(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<SubGraph>>> subgraphs)
+  void add_subgraphs(
+    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<onert_tflite::SubGraph>>> subgraphs)
   {
     fbb_.AddOffset(Model::VT_SUBGRAPHS, subgraphs);
   }
@@ -8814,7 +9365,8 @@ struct ModelBuilder
   {
     fbb_.AddOffset(Model::VT_DESCRIPTION, description);
   }
-  void add_buffers(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<Buffer>>> buffers)
+  void add_buffers(
+    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<onert_tflite::Buffer>>> buffers)
   {
     fbb_.AddOffset(Model::VT_BUFFERS, buffers);
   }
@@ -8822,8 +9374,8 @@ struct ModelBuilder
   {
     fbb_.AddOffset(Model::VT_METADATA_BUFFER, metadata_buffer);
   }
-  void
-  add_metadata(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<Metadata>>> metadata)
+  void add_metadata(
+    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<onert_tflite::Metadata>>> metadata)
   {
     fbb_.AddOffset(Model::VT_METADATA, metadata);
   }
@@ -8831,7 +9383,6 @@ struct ModelBuilder
   {
     start_ = fbb_.StartTable();
   }
-  ModelBuilder &operator=(const ModelBuilder &);
   flatbuffers::Offset<Model> Finish()
   {
     const auto end = fbb_.EndTable(start_);
@@ -8842,12 +9393,15 @@ struct ModelBuilder
 
 inline flatbuffers::Offset<Model> CreateModel(
   flatbuffers::FlatBufferBuilder &_fbb, uint32_t version = 0,
-  flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<OperatorCode>>> operator_codes = 0,
-  flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<SubGraph>>> subgraphs = 0,
+  flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<onert_tflite::OperatorCode>>>
+    operator_codes = 0,
+  flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<onert_tflite::SubGraph>>> subgraphs =
+    0,
   flatbuffers::Offset<flatbuffers::String> description = 0,
-  flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<Buffer>>> buffers = 0,
+  flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<onert_tflite::Buffer>>> buffers = 0,
   flatbuffers::Offset<flatbuffers::Vector<int32_t>> metadata_buffer = 0,
-  flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<Metadata>>> metadata = 0)
+  flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<onert_tflite::Metadata>>> metadata =
+    0)
 {
   ModelBuilder builder_(_fbb);
   builder_.add_metadata(metadata);
@@ -8860,23 +9414,29 @@ inline flatbuffers::Offset<Model> CreateModel(
   return builder_.Finish();
 }
 
-inline flatbuffers::Offset<Model>
-CreateModelDirect(flatbuffers::FlatBufferBuilder &_fbb, uint32_t version = 0,
-                  const std::vector<flatbuffers::Offset<OperatorCode>> *operator_codes = nullptr,
-                  const std::vector<flatbuffers::Offset<SubGraph>> *subgraphs = nullptr,
-                  const char *description = nullptr,
-                  const std::vector<flatbuffers::Offset<Buffer>> *buffers = nullptr,
-                  const std::vector<int32_t> *metadata_buffer = nullptr,
-                  const std::vector<flatbuffers::Offset<Metadata>> *metadata = nullptr)
+inline flatbuffers::Offset<Model> CreateModelDirect(
+  flatbuffers::FlatBufferBuilder &_fbb, uint32_t version = 0,
+  const std::vector<flatbuffers::Offset<onert_tflite::OperatorCode>> *operator_codes = nullptr,
+  const std::vector<flatbuffers::Offset<onert_tflite::SubGraph>> *subgraphs = nullptr,
+  const char *description = nullptr,
+  const std::vector<flatbuffers::Offset<onert_tflite::Buffer>> *buffers = nullptr,
+  const std::vector<int32_t> *metadata_buffer = nullptr,
+  const std::vector<flatbuffers::Offset<onert_tflite::Metadata>> *metadata = nullptr)
 {
-  return onert_tflite::CreateModel(
-    _fbb, version,
-    operator_codes ? _fbb.CreateVector<flatbuffers::Offset<OperatorCode>>(*operator_codes) : 0,
-    subgraphs ? _fbb.CreateVector<flatbuffers::Offset<SubGraph>>(*subgraphs) : 0,
-    description ? _fbb.CreateString(description) : 0,
-    buffers ? _fbb.CreateVector<flatbuffers::Offset<Buffer>>(*buffers) : 0,
-    metadata_buffer ? _fbb.CreateVector<int32_t>(*metadata_buffer) : 0,
-    metadata ? _fbb.CreateVector<flatbuffers::Offset<Metadata>>(*metadata) : 0);
+  auto operator_codes__ =
+    operator_codes
+      ? _fbb.CreateVector<flatbuffers::Offset<onert_tflite::OperatorCode>>(*operator_codes)
+      : 0;
+  auto subgraphs__ =
+    subgraphs ? _fbb.CreateVector<flatbuffers::Offset<onert_tflite::SubGraph>>(*subgraphs) : 0;
+  auto description__ = description ? _fbb.CreateString(description) : 0;
+  auto buffers__ =
+    buffers ? _fbb.CreateVector<flatbuffers::Offset<onert_tflite::Buffer>>(*buffers) : 0;
+  auto metadata_buffer__ = metadata_buffer ? _fbb.CreateVector<int32_t>(*metadata_buffer) : 0;
+  auto metadata__ =
+    metadata ? _fbb.CreateVector<flatbuffers::Offset<onert_tflite::Metadata>>(*metadata) : 0;
+  return onert_tflite::CreateModel(_fbb, version, operator_codes__, subgraphs__, description__,
+                                   buffers__, metadata_buffer__, metadata__);
 }
 
 inline bool VerifyQuantizationDetails(flatbuffers::Verifier &verifier, const void *obj,
@@ -8890,11 +9450,11 @@ inline bool VerifyQuantizationDetails(flatbuffers::Verifier &verifier, const voi
     }
     case QuantizationDetails_CustomQuantization:
     {
-      auto ptr = reinterpret_cast<const CustomQuantization *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::CustomQuantization *>(obj);
       return verifier.VerifyTable(ptr);
     }
     default:
-      return false;
+      return true;
   }
 }
 
@@ -8929,21 +9489,21 @@ inline bool VerifySparseIndexVector(flatbuffers::Verifier &verifier, const void 
     }
     case SparseIndexVector_Int32Vector:
     {
-      auto ptr = reinterpret_cast<const Int32Vector *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::Int32Vector *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case SparseIndexVector_Uint16Vector:
     {
-      auto ptr = reinterpret_cast<const Uint16Vector *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::Uint16Vector *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case SparseIndexVector_Uint8Vector:
     {
-      auto ptr = reinterpret_cast<const Uint8Vector *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::Uint8Vector *>(obj);
       return verifier.VerifyTable(ptr);
     }
     default:
-      return false;
+      return true;
   }
 }
 
@@ -8977,511 +9537,511 @@ inline bool VerifyBuiltinOptions(flatbuffers::Verifier &verifier, const void *ob
     }
     case BuiltinOptions_Conv2DOptions:
     {
-      auto ptr = reinterpret_cast<const Conv2DOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::Conv2DOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_DepthwiseConv2DOptions:
     {
-      auto ptr = reinterpret_cast<const DepthwiseConv2DOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::DepthwiseConv2DOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_ConcatEmbeddingsOptions:
     {
-      auto ptr = reinterpret_cast<const ConcatEmbeddingsOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::ConcatEmbeddingsOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_LSHProjectionOptions:
     {
-      auto ptr = reinterpret_cast<const LSHProjectionOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::LSHProjectionOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_Pool2DOptions:
     {
-      auto ptr = reinterpret_cast<const Pool2DOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::Pool2DOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_SVDFOptions:
     {
-      auto ptr = reinterpret_cast<const SVDFOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::SVDFOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_RNNOptions:
     {
-      auto ptr = reinterpret_cast<const RNNOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::RNNOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_FullyConnectedOptions:
     {
-      auto ptr = reinterpret_cast<const FullyConnectedOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::FullyConnectedOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_SoftmaxOptions:
     {
-      auto ptr = reinterpret_cast<const SoftmaxOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::SoftmaxOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_ConcatenationOptions:
     {
-      auto ptr = reinterpret_cast<const ConcatenationOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::ConcatenationOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_AddOptions:
     {
-      auto ptr = reinterpret_cast<const AddOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::AddOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_L2NormOptions:
     {
-      auto ptr = reinterpret_cast<const L2NormOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::L2NormOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_LocalResponseNormalizationOptions:
     {
-      auto ptr = reinterpret_cast<const LocalResponseNormalizationOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::LocalResponseNormalizationOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_LSTMOptions:
     {
-      auto ptr = reinterpret_cast<const LSTMOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::LSTMOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_ResizeBilinearOptions:
     {
-      auto ptr = reinterpret_cast<const ResizeBilinearOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::ResizeBilinearOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_CallOptions:
     {
-      auto ptr = reinterpret_cast<const CallOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::CallOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_ReshapeOptions:
     {
-      auto ptr = reinterpret_cast<const ReshapeOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::ReshapeOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_SkipGramOptions:
     {
-      auto ptr = reinterpret_cast<const SkipGramOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::SkipGramOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_SpaceToDepthOptions:
     {
-      auto ptr = reinterpret_cast<const SpaceToDepthOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::SpaceToDepthOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_EmbeddingLookupSparseOptions:
     {
-      auto ptr = reinterpret_cast<const EmbeddingLookupSparseOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::EmbeddingLookupSparseOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_MulOptions:
     {
-      auto ptr = reinterpret_cast<const MulOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::MulOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_PadOptions:
     {
-      auto ptr = reinterpret_cast<const PadOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::PadOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_GatherOptions:
     {
-      auto ptr = reinterpret_cast<const GatherOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::GatherOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_BatchToSpaceNDOptions:
     {
-      auto ptr = reinterpret_cast<const BatchToSpaceNDOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::BatchToSpaceNDOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_SpaceToBatchNDOptions:
     {
-      auto ptr = reinterpret_cast<const SpaceToBatchNDOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::SpaceToBatchNDOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_TransposeOptions:
     {
-      auto ptr = reinterpret_cast<const TransposeOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::TransposeOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_ReducerOptions:
     {
-      auto ptr = reinterpret_cast<const ReducerOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::ReducerOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_SubOptions:
     {
-      auto ptr = reinterpret_cast<const SubOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::SubOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_DivOptions:
     {
-      auto ptr = reinterpret_cast<const DivOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::DivOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_SqueezeOptions:
     {
-      auto ptr = reinterpret_cast<const SqueezeOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::SqueezeOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_SequenceRNNOptions:
     {
-      auto ptr = reinterpret_cast<const SequenceRNNOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::SequenceRNNOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_StridedSliceOptions:
     {
-      auto ptr = reinterpret_cast<const StridedSliceOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::StridedSliceOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_ExpOptions:
     {
-      auto ptr = reinterpret_cast<const ExpOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::ExpOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_TopKV2Options:
     {
-      auto ptr = reinterpret_cast<const TopKV2Options *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::TopKV2Options *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_SplitOptions:
     {
-      auto ptr = reinterpret_cast<const SplitOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::SplitOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_LogSoftmaxOptions:
     {
-      auto ptr = reinterpret_cast<const LogSoftmaxOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::LogSoftmaxOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_CastOptions:
     {
-      auto ptr = reinterpret_cast<const CastOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::CastOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_DequantizeOptions:
     {
-      auto ptr = reinterpret_cast<const DequantizeOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::DequantizeOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_MaximumMinimumOptions:
     {
-      auto ptr = reinterpret_cast<const MaximumMinimumOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::MaximumMinimumOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_ArgMaxOptions:
     {
-      auto ptr = reinterpret_cast<const ArgMaxOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::ArgMaxOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_LessOptions:
     {
-      auto ptr = reinterpret_cast<const LessOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::LessOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_NegOptions:
     {
-      auto ptr = reinterpret_cast<const NegOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::NegOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_PadV2Options:
     {
-      auto ptr = reinterpret_cast<const PadV2Options *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::PadV2Options *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_GreaterOptions:
     {
-      auto ptr = reinterpret_cast<const GreaterOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::GreaterOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_GreaterEqualOptions:
     {
-      auto ptr = reinterpret_cast<const GreaterEqualOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::GreaterEqualOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_LessEqualOptions:
     {
-      auto ptr = reinterpret_cast<const LessEqualOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::LessEqualOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_SelectOptions:
     {
-      auto ptr = reinterpret_cast<const SelectOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::SelectOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_SliceOptions:
     {
-      auto ptr = reinterpret_cast<const SliceOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::SliceOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_TransposeConvOptions:
     {
-      auto ptr = reinterpret_cast<const TransposeConvOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::TransposeConvOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_SparseToDenseOptions:
     {
-      auto ptr = reinterpret_cast<const SparseToDenseOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::SparseToDenseOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_TileOptions:
     {
-      auto ptr = reinterpret_cast<const TileOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::TileOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_ExpandDimsOptions:
     {
-      auto ptr = reinterpret_cast<const ExpandDimsOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::ExpandDimsOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_EqualOptions:
     {
-      auto ptr = reinterpret_cast<const EqualOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::EqualOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_NotEqualOptions:
     {
-      auto ptr = reinterpret_cast<const NotEqualOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::NotEqualOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_ShapeOptions:
     {
-      auto ptr = reinterpret_cast<const ShapeOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::ShapeOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_PowOptions:
     {
-      auto ptr = reinterpret_cast<const PowOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::PowOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_ArgMinOptions:
     {
-      auto ptr = reinterpret_cast<const ArgMinOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::ArgMinOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_FakeQuantOptions:
     {
-      auto ptr = reinterpret_cast<const FakeQuantOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::FakeQuantOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_PackOptions:
     {
-      auto ptr = reinterpret_cast<const PackOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::PackOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_LogicalOrOptions:
     {
-      auto ptr = reinterpret_cast<const LogicalOrOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::LogicalOrOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_OneHotOptions:
     {
-      auto ptr = reinterpret_cast<const OneHotOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::OneHotOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_LogicalAndOptions:
     {
-      auto ptr = reinterpret_cast<const LogicalAndOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::LogicalAndOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_LogicalNotOptions:
     {
-      auto ptr = reinterpret_cast<const LogicalNotOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::LogicalNotOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_UnpackOptions:
     {
-      auto ptr = reinterpret_cast<const UnpackOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::UnpackOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_FloorDivOptions:
     {
-      auto ptr = reinterpret_cast<const FloorDivOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::FloorDivOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_SquareOptions:
     {
-      auto ptr = reinterpret_cast<const SquareOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::SquareOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_ZerosLikeOptions:
     {
-      auto ptr = reinterpret_cast<const ZerosLikeOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::ZerosLikeOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_FillOptions:
     {
-      auto ptr = reinterpret_cast<const FillOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::FillOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_BidirectionalSequenceLSTMOptions:
     {
-      auto ptr = reinterpret_cast<const BidirectionalSequenceLSTMOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::BidirectionalSequenceLSTMOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_BidirectionalSequenceRNNOptions:
     {
-      auto ptr = reinterpret_cast<const BidirectionalSequenceRNNOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::BidirectionalSequenceRNNOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_UnidirectionalSequenceLSTMOptions:
     {
-      auto ptr = reinterpret_cast<const UnidirectionalSequenceLSTMOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::UnidirectionalSequenceLSTMOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_FloorModOptions:
     {
-      auto ptr = reinterpret_cast<const FloorModOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::FloorModOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_RangeOptions:
     {
-      auto ptr = reinterpret_cast<const RangeOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::RangeOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_ResizeNearestNeighborOptions:
     {
-      auto ptr = reinterpret_cast<const ResizeNearestNeighborOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::ResizeNearestNeighborOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_LeakyReluOptions:
     {
-      auto ptr = reinterpret_cast<const LeakyReluOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::LeakyReluOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_SquaredDifferenceOptions:
     {
-      auto ptr = reinterpret_cast<const SquaredDifferenceOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::SquaredDifferenceOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_MirrorPadOptions:
     {
-      auto ptr = reinterpret_cast<const MirrorPadOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::MirrorPadOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_AbsOptions:
     {
-      auto ptr = reinterpret_cast<const AbsOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::AbsOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_SplitVOptions:
     {
-      auto ptr = reinterpret_cast<const SplitVOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::SplitVOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_UniqueOptions:
     {
-      auto ptr = reinterpret_cast<const UniqueOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::UniqueOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_ReverseV2Options:
     {
-      auto ptr = reinterpret_cast<const ReverseV2Options *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::ReverseV2Options *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_AddNOptions:
     {
-      auto ptr = reinterpret_cast<const AddNOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::AddNOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_GatherNdOptions:
     {
-      auto ptr = reinterpret_cast<const GatherNdOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::GatherNdOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_CosOptions:
     {
-      auto ptr = reinterpret_cast<const CosOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::CosOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_WhereOptions:
     {
-      auto ptr = reinterpret_cast<const WhereOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::WhereOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_RankOptions:
     {
-      auto ptr = reinterpret_cast<const RankOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::RankOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_ReverseSequenceOptions:
     {
-      auto ptr = reinterpret_cast<const ReverseSequenceOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::ReverseSequenceOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_MatrixDiagOptions:
     {
-      auto ptr = reinterpret_cast<const MatrixDiagOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::MatrixDiagOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_QuantizeOptions:
     {
-      auto ptr = reinterpret_cast<const QuantizeOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::QuantizeOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_MatrixSetDiagOptions:
     {
-      auto ptr = reinterpret_cast<const MatrixSetDiagOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::MatrixSetDiagOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_HardSwishOptions:
     {
-      auto ptr = reinterpret_cast<const HardSwishOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::HardSwishOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_IfOptions:
     {
-      auto ptr = reinterpret_cast<const IfOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::IfOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_WhileOptions:
     {
-      auto ptr = reinterpret_cast<const WhileOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::WhileOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_DepthToSpaceOptions:
     {
-      auto ptr = reinterpret_cast<const DepthToSpaceOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::DepthToSpaceOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_NonMaxSuppressionV4Options:
     {
-      auto ptr = reinterpret_cast<const NonMaxSuppressionV4Options *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::NonMaxSuppressionV4Options *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_NonMaxSuppressionV5Options:
     {
-      auto ptr = reinterpret_cast<const NonMaxSuppressionV5Options *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::NonMaxSuppressionV5Options *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_ScatterNdOptions:
     {
-      auto ptr = reinterpret_cast<const ScatterNdOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::ScatterNdOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_SelectV2Options:
     {
-      auto ptr = reinterpret_cast<const SelectV2Options *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::SelectV2Options *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_DensifyOptions:
     {
-      auto ptr = reinterpret_cast<const DensifyOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::DensifyOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_SegmentSumOptions:
     {
-      auto ptr = reinterpret_cast<const SegmentSumOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::SegmentSumOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case BuiltinOptions_BatchMatMulOptions:
     {
-      auto ptr = reinterpret_cast<const BatchMatMulOptions *>(obj);
+      auto ptr = reinterpret_cast<const onert_tflite::BatchMatMulOptions *>(obj);
       return verifier.VerifyTable(ptr);
     }
     default:
-      return false;
+      return true;
   }
 }
 


### PR DESCRIPTION
This commit updates circle_schema_generated.h and tflite_schema_generated.h to use flatbuffers 2.0 flatc.

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>