### PR TITLE
[luci] Allow more dtypes in Square.

### DIFF
--- a/compiler/luci/import/src/Nodes/CircleSquare.cpp
+++ b/compiler/luci/import/src/Nodes/CircleSquare.cpp
@@ -29,14 +29,13 @@ bool CircleSquareGraphBuilder::validate(const ValidateArgs &args) const
     return false;
 
   const auto &inputs = args.op.inputs;
-  // Must be one of the following types
-  // bfloat16, half (float16), float32, float64, complex64, complex128
-  // Currently, circle supports float16, float32, complex64
   const auto tensors = args.reader.tensors();
   const auto tensor = tensors.at(inputs.at(0));
   assert(tensor != nullptr);
   switch (tensor->type())
   {
+    case circle::TensorType_UINT8:
+    case circle::TensorType_INT16:
     case circle::TensorType_INT32:
     case circle::TensorType_INT64:
     case circle::TensorType_FLOAT16:


### PR DESCRIPTION
This allows more dtypes in Square.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>