### PR TITLE
[infra] Include dio-hdf5 for ARM32 build

### DIFF
--- a/infra/nncc/Makefile.arm32
+++ b/infra/nncc/Makefile.arm32
@@ -25,6 +25,7 @@ ARM32_BUILD_ITEMS+=;oops;pepper-assert
 ARM32_BUILD_ITEMS+=;hermes;hermes-std
 ARM32_BUILD_ITEMS+=;loco;locop;logo-core;logo
 ARM32_BUILD_ITEMS+=;safemain;mio-circle04;mio-tflite260
+ARM32_BUILD_ITEMS+=;dio-hdf5
 ARM32_BUILD_ITEMS+=;foder;circle-verify;souschef;arser;vconone
 ARM32_BUILD_ITEMS+=;luci
 ARM32_BUILD_ITEMS+=;luci-interpreter


### PR DESCRIPTION
This will revise ARM32 Makefile to include dio-hdf5 module.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>