### PR TITLE
[infra/nncc] Introduce options_armv7l-linux

### DIFF
--- a/infra/nncc/cmake/options/options_armv7l-linux.cmake
+++ b/infra/nncc/cmake/options/options_armv7l-linux.cmake
@@ -1,0 +1,6 @@
+#
+# armv7l linux cmake options
+#
+
+# TODO turn on
+option(BUILD_ARM32_NEON "Use NEON for ARM32 cross build" OFF)


### PR DESCRIPTION
This will introduce options_armv7l-linux.cmake for ARM32 configure
default options.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>