### PR TITLE
[infra/nncc] Enable NEON with option

### DIFF
--- a/infra/nncc/cmake/buildtool/config/config_armv7l-linux.cmake
+++ b/infra/nncc/cmake/buildtool/config/config_armv7l-linux.cmake
@@ -11,8 +11,14 @@ include("${CMAKE_CURRENT_LIST_DIR}/config_linux.cmake")
 set(FLAGS_COMMON ${FLAGS_COMMON}
     "-mcpu=cortex-a7"
     "-mfloat-abi=hard"
-# TODO enable neon
-#   "-mfpu=neon-vfpv4"
     "-ftree-vectorize"
     "-mfp16-format=ieee"
     )
+
+if(BUILD_ARM32_NEON)
+  set(FLAGS_COMMON ${FLAGS_COMMON}
+      "-mfpu=neon-vfpv4"
+      )
+else(BUILD_ARM32_NEON)
+  message(STATUS "ARMv7l: NEON is disabled")
+endif(BUILD_ARM32_NEON)


### PR DESCRIPTION
This will enable NEON compile option with BUILD_ARM32_NEON option.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>