### PR TITLE
[record-minmax] Revise to use venv_2_6_0

### DIFF
--- a/compiler/record-minmax-conversion-test/CMakeLists.txt
+++ b/compiler/record-minmax-conversion-test/CMakeLists.txt
@@ -37,6 +37,6 @@ add_test(
   COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/testall.sh"
           "${TEST_CONFIG}"
           "${ARTIFACTS_BIN_PATH}"
-          "${NNCC_OVERLAY_DIR}/venv_1_13_2"
+          "${NNCC_OVERLAY_DIR}/venv_2_6_0"
           ${RECORD_MINMAX_CONVERSION_TEST}
 )


### PR DESCRIPTION
This will revise test environment to use venv with TF2.6.0.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>