### PR TITLE
[tf2tfliteV2] Revise to use venv_2_6_0

### DIFF
--- a/compiler/tf2tfliteV2-conversion-test/CMakeLists.txt
+++ b/compiler/tf2tfliteV2-conversion-test/CMakeLists.txt
@@ -72,7 +72,7 @@ list(APPEND TEST_DEPS "${TEST_RUNNER}")
 
 get_target_property(ARTIFACTS_BIN_PATH testDataGenerator BINARY_DIR)
 
-set(VIRTUALENV "${NNCC_OVERLAY_DIR}/venv_1_13_2")
+set(VIRTUALENV "${NNCC_OVERLAY_DIR}/venv_2_6_0")
 
 ###
 ### Generate test.config


### PR DESCRIPTION
This will revise test environment to use venv with TF2.6.0.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>