### PR TITLE
[infra/cmake] Introduce TRIXEngine_INCLUDE_DIRS

### DIFF
--- a/infra/nnfw/cmake/packages/TRIXEngineConfig.cmake
+++ b/infra/nnfw/cmake/packages/TRIXEngineConfig.cmake
@@ -36,6 +36,7 @@ function(_TRIXEngine_import)
   endif(NOT TRIXEngine_FOUND)
 
   set(TRIXEngine_FOUND ${TRIXEngine_FOUND} PARENT_SCOPE)
+  set(TRIXEngine_INCLUDE_DIRS ${TRIXEngine_INCLUDE_DIR} PARENT_SCOPE)
 endfunction(_TRIXEngine_import)
 
 _TRIXEngine_import()


### PR DESCRIPTION
This commit introduce TRIXEngine_INCLUDE_DIRS for find_package(TRIXEngine).
We can refer header only by using this variable.

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>