### PR TITLE
[infra] Enable NEON for compiler ARM32

### DIFF
--- a/infra/nncc/cmake/options/options_armv7l-linux.cmake
+++ b/infra/nncc/cmake/options/options_armv7l-linux.cmake
@@ -2,5 +2,4 @@
 # armv7l linux cmake options
 #
 
-# TODO turn on
-option(BUILD_ARM32_NEON "Use NEON for ARM32 cross build" OFF)
+option(BUILD_ARM32_NEON "Use NEON for ARM32 cross build" ON)


### PR DESCRIPTION
This will turn on NEON option for compiler ARM32 build.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>