### PR TITLE
[luci-pass-value-test] Use venv_2_8_0

### DIFF
--- a/compiler/luci-pass-value-test/CMakeLists.txt
+++ b/compiler/luci-pass-value-test/CMakeLists.txt
@@ -38,7 +38,7 @@ add_test(NAME luci_pass_value_test
   COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/eval_driver.sh"
           "${CMAKE_CURRENT_BINARY_DIR}"
           "${ARTIFACTS_BIN_PATH}"
-          "${NNCC_OVERLAY_DIR}/venv_2_6_0"
+          "${NNCC_OVERLAY_DIR}/venv_2_8_0"
           "$<TARGET_FILE:luci_eval_driver>"
           ${LUCI_PASS_VALUE_TESTS}
 )


### PR DESCRIPTION
This will revise to venv_2_8_0 having TensorFlow 2.8.0 and other latest packages.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>