### PR TITLE
[record-minmax-cnv-test] Use venv_2_8_0

### DIFF
--- a/compiler/record-minmax-conversion-test/CMakeLists.txt
+++ b/compiler/record-minmax-conversion-test/CMakeLists.txt
@@ -37,6 +37,6 @@ add_test(
   COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/testall.sh"
           "${TEST_CONFIG}"
           "${ARTIFACTS_BIN_PATH}"
-          "${NNCC_OVERLAY_DIR}/venv_2_6_0"
+          "${NNCC_OVERLAY_DIR}/venv_2_8_0"
           ${RECORD_MINMAX_CONVERSION_TEST}
 )


### PR DESCRIPTION
This will revise to venv_2_8_0 having TensorFlow 2.8.0 and other latest packages.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>