### PR TITLE
[tf2tflitev2-cnv-test] Use venv_2_8_0

### DIFF
--- a/compiler/tf2tfliteV2-conversion-test/CMakeLists.txt
+++ b/compiler/tf2tfliteV2-conversion-test/CMakeLists.txt
@@ -72,7 +72,7 @@ list(APPEND TEST_DEPS "${TEST_RUNNER}")
 
 get_target_property(ARTIFACTS_BIN_PATH testDataGenerator BINARY_DIR)
 
-set(VIRTUALENV "${NNCC_OVERLAY_DIR}/venv_2_6_0")
+set(VIRTUALENV "${NNCC_OVERLAY_DIR}/venv_2_8_0")
 
 ###
 ### Generate test.config


### PR DESCRIPTION
This will revise to venv_2_8_0 having TensorFlow 2.8.0 and other latest packages.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>