### PR TITLE
[one-cmds] Upgrade to python3.8 and latest packages

### DIFF
--- a/compiler/one-cmds/how-to-prepare-virtualenv.txt
+++ b/compiler/one-cmds/how-to-prepare-virtualenv.txt
@@ -5,7 +5,7 @@ Last update: 2020-09-15
 
 This document explains about 'one-prepare-venv' command.
 
-'one-prepare-venv' will prepare python3 virtual environment with tensorflow-cpu
+'one-prepare-venv' will prepare python3.8 virtual environment with tensorflow-cpu
 version 2.3.0, recommanded 2.x version as of now, so that 'one-import-tf'
 command can execute properly.
 
@@ -20,7 +20,7 @@ Please install these required packages before venv preparation.
 
 $ sudo apt-get update
 $ sudo apt-get upgrade
-$ sudo apt-get install python3-pip python3-venv
+$ sudo apt-get install python3.8 python3-pip python3.8-venv
 
 
 How to run for Ubuntu

--- a/compiler/one-cmds/one-prepare-venv
+++ b/compiler/one-cmds/one-prepare-venv
@@ -26,17 +26,17 @@ VENV_PYTHON=${DRIVER_PATH}/venv/bin/python
 
 if [ ! -f ${VENV_ACTIVATE} ]; then
   # Create python virtual enviornment
-  python3 -m venv "${DRIVER_PATH}/venv"
+  python3.8 -m venv "${DRIVER_PATH}/venv"
 fi
 
 # NOTE version
 # - https://github.com/onnx/onnx/blob/master/docs/Versioning.md
 # - https://github.com/onnx/onnx-tensorflow/blob/master/Versioning.md
 
-VER_TENSORFLOW=2.6.0
-VER_ONNX=1.10.1
-VER_ONNXRUNTIME=1.10.0
-VER_ONNX_TF=1.9.0
+VER_TENSORFLOW=2.8.0
+VER_ONNX=1.11.0
+VER_ONNXRUNTIME=1.11.0
+VER_ONNX_TF=1.10.0
 
 # Install tensorflow
 
@@ -61,7 +61,8 @@ if [ -n "${EXT_TENSORFLOW_WHL}" ]; then
 else
   ${VENV_PYTHON} -m pip ${PIP_OPTIONS} install tensorflow-cpu==${VER_TENSORFLOW}
 fi
-${VENV_PYTHON} -m pip ${PIP_OPTIONS} install Pillow==6.2.2
+${VENV_PYTHON} -m pip ${PIP_OPTIONS} install Pillow
+${VENV_PYTHON} -m pip ${PIP_OPTIONS} install tensorflow_probability
 
 # Install PyTorch and ONNX related
 # NOTE set ONE_PREPVENV_TORCH_STABLE to override 'torch_stable.html' URL.
@@ -71,11 +72,7 @@ TORCH_STABLE_URL="https://download.pytorch.org/whl/torch_stable.html"
 if [[ ! -z "$ONE_PREPVENV_TORCH_STABLE" ]]; then
   TORCH_STABLE_URL="${ONE_PREPVENV_TORCH_STABLE}"
 fi
-${VENV_PYTHON} -m pip ${PIP_OPTIONS} install torch==1.10.0+cpu -f ${TORCH_STABLE_URL}
-
-# Fix for error with keras > 2.6.0 with VER_TENSORFLOW=2.6.0
-# TODO remove this when VER_TENSORFLOW > 2.6.0
-${VENV_PYTHON} -m pip ${PIP_OPTIONS} install keras==2.6.0
+${VENV_PYTHON} -m pip ${PIP_OPTIONS} install torch==1.11.0+cpu -f ${TORCH_STABLE_URL}
 
 ${VENV_PYTHON} -m pip ${PIP_OPTIONS} install onnx==${VER_ONNX}
 


### PR DESCRIPTION
This will revise one-prepare-venv to use python3.8 and latest packages
- add required and remove needless packages to follow updates

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>