### PR TITLE
[infra/cmd] Fix gen-coverage-report

### DIFF
--- a/infra/command/gen-coverage-report
+++ b/infra/command/gen-coverage-report
@@ -67,7 +67,7 @@ done
   "${CANDIDATES[@]}"
 
 
-opencl_files=($(find ./runtime/onert/backend/gpu_cl/open_cl/ \( -name "*.cc" -o -name "*.h" \) -exec realpath {} \; ))
+opencl_files=($(find ./runtime/onert/backend/gpu_cl/open_cl/ \( -name "*.cc" -o -name "*.h" \) -exec realpath {} \; | true))
 
 # Exclude *.test.cpp files from coverage report
 # Exclude flatbuffer generated files from coverage report


### PR DESCRIPTION
Let's skip fail from finding gpu_cl file.
It can return fail if candidates don't include gpu-cl backend directory.

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>