### PR TITLE
[onert] Make Param as public member on Bulk operation

### DIFF
--- a/runtime/onert/core/include/ir/operation/Bulk.h
+++ b/runtime/onert/core/include/ir/operation/Bulk.h
@@ -28,7 +28,7 @@ namespace operation
 
 class Bulk : public Operation
 {
-
+public:
   struct Param
   {
     std::string binary_path;


### PR DESCRIPTION
This commit makes Param as public member on Bulk operation.
The Param should be public to access elsewhere.

Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>