### PR TITLE
[onert] Make Bulk param public

### DIFF
--- a/runtime/onert/core/include/ir/operation/Bulk.h
+++ b/runtime/onert/core/include/ir/operation/Bulk.h
@@ -28,7 +28,7 @@ namespace operation
 
 class Bulk : public Operation
 {
-
+public:
   struct Param
   {
     std::string binary_path;


### PR DESCRIPTION
Bulk operation's param must be public to be accessable from frontend
like other operation's param.

Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>