### PR TITLE
[infra] Disable tests when creating package

### DIFF
--- a/infra/packaging/preset/20220323
+++ b/infra/packaging/preset/20220323
@@ -39,6 +39,7 @@ function preset_configure()
 
   # TODO Use "nncc configure" and "nncc build"
   cmake \
+    -DENABLE_TEST=OFF \
     -DCMAKE_INSTALL_PREFIX="${NNCC_INSTALL_PREFIX}" \
     -DCMAKE_BUILD_TYPE=release \
     -DBUILD_WHITELIST=$(join_by ";" "${REQUIRED_UNITS[@]}") \


### PR DESCRIPTION
This commit disable tests when package is created.

ONE-DCO-1.0-Signed-off-by: Seok NamKoong <seok9311@naver.com>

---

This PR aims to 
- Disable tests which are not needed when package is created
- Make more precise static analysis