### PR TITLE
[nnpackage_run] Introduce load and dump raw

### DIFF
--- a/tests/tools/nnpackage_run/CMakeLists.txt
+++ b/tests/tools/nnpackage_run/CMakeLists.txt
@@ -10,6 +10,7 @@ list(APPEND NNPACKAGE_RUN_SRCS "src/nnpackage_run.cc")
 list(APPEND NNPACKAGE_RUN_SRCS "src/args.cc")
 list(APPEND NNPACKAGE_RUN_SRCS "src/nnfw_util.cc")
 list(APPEND NNPACKAGE_RUN_SRCS "src/randomgen.cc")
+list(APPEND NNPACKAGE_RUN_SRCS "src/rawformatter.cc")
 
 nnfw_find_package(Boost REQUIRED program_options)
 nnfw_find_package(Ruy QUIET)

--- a/tests/tools/nnpackage_run/src/args.cc
+++ b/tests/tools/nnpackage_run/src/args.cc
@@ -201,6 +201,8 @@ void Args::Initialize(void)
     ("dump,d", po::value<std::string>()->default_value("")->notifier([&](const auto &v) { _dump_filename = v; }), "Output filename")
     ("load,l", po::value<std::string>()->default_value("")->notifier([&](const auto &v) { _load_filename = v; }), "Input filename")
 #endif
+    ("dump:raw", po::value<std::string>()->default_value("")->notifier([&](const auto &v) { _dump_raw_filename = v; }), "Raw Output filename")
+    ("load:raw", po::value<std::string>()->default_value("")->notifier([&](const auto &v) { _load_raw_filename = v; }), "Raw Input filename")
     ("output_sizes", po::value<std::string>()->notifier(process_output_sizes),
         "The output buffer size in JSON 1D array\n"
         "If not given, the model's output sizes are used\n"

--- a/tests/tools/nnpackage_run/src/args.h
+++ b/tests/tools/nnpackage_run/src/args.h
@@ -52,6 +52,8 @@ public:
   const std::string &getLoadFilename(void) const { return _load_filename; }
   WhenToUseH5Shape getWhenToUseH5Shape(void) const { return _when_to_use_h5_shape; }
 #endif
+  const std::string &getDumpRawFilename(void) const { return _dump_raw_filename; }
+  const std::string &getLoadRawFilename(void) const { return _load_raw_filename; }
   const int getNumRuns(void) const { return _num_runs; }
   const int getWarmupRuns(void) const { return _warmup_runs; }
   const int getRunDelay(void) const { return _run_delay; }
@@ -80,6 +82,8 @@ private:
   std::string _load_filename;
   WhenToUseH5Shape _when_to_use_h5_shape = WhenToUseH5Shape::NOT_PROVIDED;
 #endif
+  std::string _dump_raw_filename;
+  std::string _load_raw_filename;
   TensorShapeMap _shape_prepare;
   TensorShapeMap _shape_run;
   int _num_runs;

--- a/tests/tools/nnpackage_run/src/formatter.h
+++ b/tests/tools/nnpackage_run/src/formatter.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __NNPACKAGE_RUN_FORMATTER_H__
+#define __NNPACKAGE_RUN_FORMATTER_H__
+
+#include <string>
+#include <vector>
+
+#include "types.h"
+#include "allocation.h"
+
+struct nnfw_session;
+
+namespace nnpkg_run
+{
+class Formatter
+{
+public:
+  virtual ~Formatter() = default;
+  Formatter(nnfw_session *sess) : session_(sess) {}
+  virtual void loadInputs(const std::string &filename, std::vector<Allocation> &inputs) = 0;
+  virtual void dumpOutputs(const std::string &filename, std::vector<Allocation> &outputs) = 0;
+  virtual std::vector<TensorShape> readTensorShapes(const std::string &filename)
+  {
+    return std::vector<TensorShape>();
+  };
+
+protected:
+  nnfw_session *session_;
+};
+} // namespace nnpkg_run
+
+#endif // __NNPACKAGE_RUN_FORMATTER_H__

--- a/tests/tools/nnpackage_run/src/nnpackage_run.cc
+++ b/tests/tools/nnpackage_run/src/nnpackage_run.cc
@@ -24,6 +24,7 @@
 #include "nnfw_util.h"
 #include "nnfw_internal.h"
 #include "randomgen.h"
+#include "rawformatter.h"
 #ifdef RUY_PROFILER
 #include "ruy/profiler/profiler.h"
 #endif
@@ -194,10 +195,15 @@ int main(const int argc, char **argv)
 #if defined(ONERT_HAVE_HDF5) && ONERT_HAVE_HDF5 == 1
     if (!args.getLoadFilename().empty())
       H5Formatter(session).loadInputs(args.getLoadFilename(), inputs);
+    else if (!args.getLoadRawFilename().empty())
+      RawFormatter(session).loadInputs(args.getLoadRawFilename(), inputs);
     else
       RandomGenerator(session).generate(inputs);
 #else
-    RandomGenerator(session).generate(inputs);
+    if (!args.getLoadRawFilename().empty())
+      RawFormatter(session).loadInputs(args.getLoadRawFilename(), inputs);
+    else
+      RandomGenerator(session).generate(inputs);
 #endif
 
     // prepare output
@@ -267,6 +273,8 @@ int main(const int argc, char **argv)
     if (!args.getDumpFilename().empty())
       H5Formatter(session).dumpOutputs(args.getDumpFilename(), outputs);
 #endif
+    if (!args.getDumpRawFilename().empty())
+      RawFormatter(session).dumpOutputs(args.getDumpRawFilename(), outputs);
 
     NNPR_ENSURE_STATUS(nnfw_close_session(session));
 

--- a/tests/tools/nnpackage_run/src/rawformatter.cc
+++ b/tests/tools/nnpackage_run/src/rawformatter.cc
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2019 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "rawformatter.h"
+#include "nnfw.h"
+#include "nnfw_util.h"
+
+#include <iostream>
+#include <fstream>
+#include <stdexcept>
+
+namespace nnpkg_run
+{
+void RawFormatter::loadInputs(const std::string &filename, std::vector<Allocation> &inputs)
+{
+  uint32_t num_inputs;
+  NNPR_ENSURE_STATUS(nnfw_input_size(session_, &num_inputs));
+
+  // TODO: Support multiple inputs
+  // Option 1. Get comman-separated input file list like --load:raw in.0,in.1,in.2
+  // Option 2. Get prefix --load:raw out
+  //           Internally access out.0, out.1, out.2, ... out.{N} where N is determined by api.
+  if (num_inputs != 1)
+  {
+    throw std::runtime_error("Only 1 input is supported for raw input");
+  }
+  try
+  {
+    for (uint32_t i = 0; i < num_inputs; ++i)
+    {
+      nnfw_tensorinfo ti;
+      NNPR_ENSURE_STATUS(nnfw_input_tensorinfo(session_, i, &ti));
+
+      // allocate memory for data
+      auto bufsz = bufsize_for(&ti);
+      inputs[i].alloc(bufsz);
+
+      std::ifstream file(filename, std::ios::ate | std::ios::binary);
+      auto filesz = file.tellg();
+      if (bufsz != filesz)
+      {
+        throw std::runtime_error("Input Size does not match: " + std::to_string(bufsz) +
+                                 " expected, but " + std::to_string(filesz) + " provided.");
+      }
+      file.seekg(0, std::ios::beg);
+      file.read(reinterpret_cast<char *>(inputs[i].data()), filesz);
+      file.close();
+
+      NNPR_ENSURE_STATUS(nnfw_set_input(session_, i, ti.dtype, inputs[i].data(), bufsz));
+      NNPR_ENSURE_STATUS(nnfw_set_input_layout(session_, i, NNFW_LAYOUT_CHANNELS_LAST));
+    }
+  }
+  catch (const std::exception &e)
+  {
+    std::cerr << e.what() << std::endl;
+    std::exit(-1);
+  }
+};
+
+void RawFormatter::dumpOutputs(const std::string &filename, std::vector<Allocation> &outputs)
+{
+  uint32_t num_outputs;
+  NNPR_ENSURE_STATUS(nnfw_output_size(session_, &num_outputs));
+  // TODO: Support multiple outputs
+  // Available options are same.
+  if (num_outputs != 1)
+  {
+    throw std::runtime_error("Only 1 output is supported for raw input");
+  }
+  try
+  {
+    for (uint32_t i = 0; i < num_outputs; i++)
+    {
+      nnfw_tensorinfo ti;
+      NNPR_ENSURE_STATUS(nnfw_output_tensorinfo(session_, i, &ti));
+      auto bufsz = bufsize_for(&ti);
+
+      std::ofstream file(filename + "." + std::to_string(i), std::ios::out | std::ios::binary);
+      file.write(reinterpret_cast<const char *>(outputs[i].data()), bufsz);
+      file.close();
+      std::cerr << filename + "." + std::to_string(i) + " is generated.\n";
+    }
+  }
+  catch (const std::runtime_error &e)
+  {
+    std::cerr << "Error during dumpOutputs on nnpackage_run : " << e.what() << std::endl;
+    std::exit(-1);
+  }
+}
+} // end of namespace nnpkg_run

--- a/tests/tools/nnpackage_run/src/rawformatter.h
+++ b/tests/tools/nnpackage_run/src/rawformatter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef __NNPACKAGE_RUN_H5FORMATTER_H__
-#define __NNPACKAGE_RUN_H5FORMATTER_H__
+#ifndef __NNPACKAGE_RUN_RAWFORMATTER_H__
+#define __NNPACKAGE_RUN_RAWFORMATTER_H__
 
 #include "allocation.h"
 #include "formatter.h"
@@ -28,14 +28,13 @@ struct nnfw_session;
 
 namespace nnpkg_run
 {
-class H5Formatter : public Formatter
+class RawFormatter : public Formatter
 {
 public:
-  H5Formatter(nnfw_session *sess) : Formatter(sess) {}
-  std::vector<TensorShape> readTensorShapes(const std::string &filename) override;
+  RawFormatter(nnfw_session *sess) : Formatter(sess) {}
   void loadInputs(const std::string &filename, std::vector<Allocation> &inputs) override;
   void dumpOutputs(const std::string &filename, std::vector<Allocation> &outputs) override;
 };
 } // namespace nnpkg_run
 
-#endif // __NNPACKAGE_RUN_H5FORMATTER_H__
+#endif // __NNPACKAGE_RUN_RAWFORMATTER_H__


### PR DESCRIPTION
It introduces reading and writing raw data for input and output respectively.

Two options are added:
--load:raw your_input_to_load_in_raw
--dump:raw your_output_dump_in_raw

RawFormatter is introduced
Formatter will also introduced as base class for H5Formatter and RawFormatter.

TODO: Support multiple raw inputs/outputs

Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

Related: #8820