### PR TITLE
[onert] Introduce QUANT_INT16_SYMM type

### DIFF
--- a/runtime/onert/core/include/ir/DataType.h
+++ b/runtime/onert/core/include/ir/DataType.h
@@ -38,6 +38,7 @@ enum class DataType
   QUANT_INT8_ASYMM = 9,
   QUANT_INT16_ASYMM = 10,
   QUANT_INT8_SYMM_PER_CHANNEL = 11,
+  QUANT_INT16_SYMM = 12,
 };
 
 size_t sizeOfDataType(DataType data_type);

--- a/runtime/onert/core/src/ir/DataType.cc
+++ b/runtime/onert/core/src/ir/DataType.cc
@@ -50,6 +50,8 @@ size_t sizeOfDataType(DataType data_type)
       return sizeof(int64_t);
     case DataType::QUANT_INT16_ASYMM:
       return sizeof(int16_t);
+    case DataType::QUANT_INT16_SYMM:
+      return sizeof(int16_t);
     default:
       throw std::runtime_error{"Unsupported type size"};
   }


### PR DESCRIPTION
Introduce QUANT_INT16_SYMM type
- QUANT_INT16_SYMM: int16 quantization operation input/output tensor data type

Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

draft pr: #8888 