### PR TITLE
[embedded-imp-val-test] Enable skip test

### DIFF
--- a/compiler/embedded-import-value-test/CMakeLists.txt
+++ b/compiler/embedded-import-value-test/CMakeLists.txt
@@ -1,3 +1,7 @@
+if(NOT ENABLE_TEST)
+  return()
+endif(NOT ENABLE_TEST)
+
 set(SRCS_TEST_DRIVER src/TestDriver.cpp)
 
 # create driver


### PR DESCRIPTION
This will revise to skip test when ENABLE_TEST is not defined.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>