### PR TITLE
[luci-value-test] Enable skip test

### DIFF
--- a/compiler/luci-value-test/CMakeLists.txt
+++ b/compiler/luci-value-test/CMakeLists.txt
@@ -1,3 +1,7 @@
+if(NOT ENABLE_TEST)
+  return()
+endif(NOT ENABLE_TEST)
+
 unset(LUCI_VALUE_TESTS)
 unset(LUCI_VALUE_TESTS_TOL)
 


### PR DESCRIPTION
This will revise to skip test when ENABLE_TEST is not defined.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>