### PR TITLE
[onert] Support Q16 SYMM model on TRIX Backend

### DIFF
--- a/runtime/onert/backend/trix/DevContext.h
+++ b/runtime/onert/backend/trix/DevContext.h
@@ -98,6 +98,8 @@ private:
     {
       case ir::DataType::QUANT_UINT8_ASYMM:
         return DATA_TYPE_QASYMM8;
+      case ir::DataType::QUANT_INT16_SYMM:
+        return DATA_TYPE_QSYMM16;
       default:
         throw std::runtime_error("Unsupported data type");
     }

--- a/runtime/onert/core/src/exec/IPermuteFunction.h
+++ b/runtime/onert/core/src/exec/IPermuteFunction.h
@@ -145,6 +145,9 @@ protected:
       case ir::DataType::INT64:
         permute<int64_t>(src_tensor, dst_tensor, rank, src_offsets, dst_offsets);
         break;
+      case ir::DataType::QUANT_INT16_SYMM:
+        permute<int16_t>(src_tensor, dst_tensor, rank, src_offsets, dst_offsets);
+        break;
       default:
         throw std::runtime_error("IPermuteFunction: Not supported data type");
         break;
@@ -338,6 +341,8 @@ protected:
       case ir::DataType::QUANT_INT8_ASYMM:
       case ir::DataType::QUANT_INT8_SYMM:
         return typeid(int8_t);
+      case ir::DataType::QUANT_INT16_SYMM:
+        return typeid(int16_t);
       default:
         throw std::runtime_error("IPermuteFunction: Not supported data type");
     }

--- a/runtime/onert/frontend/trix/src/trix_loader.cc
+++ b/runtime/onert/frontend/trix/src/trix_loader.cc
@@ -123,6 +123,8 @@ ir::DataType TrixLoader::toDataType(const data_type type) const
   {
     case DATA_TYPE_QASYMM8:
       return ir::DataType::QUANT_UINT8_ASYMM;
+    case DATA_TYPE_QSYMM16:
+      return ir::DataType::QUANT_INT16_SYMM;
     default:
       throw std::runtime_error("Unsupported data type from trix model");
   }


### PR DESCRIPTION
This commit supports Q16 symmetric model on TRIX Backend.

Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

draft pr: #8888

_Note_
_This patch does not have build dependency with #8905.
However, this is not executed Q16 model alone. #8905 PR is essential to perform Q16 model on TRIX device._