### PR TITLE
[tf2cir-dredd-pbtxt-test] Enable skip test

### DIFF
--- a/compiler/tf2circle-dredd-pbtxt-test/CMakeLists.txt
+++ b/compiler/tf2circle-dredd-pbtxt-test/CMakeLists.txt
@@ -175,6 +175,10 @@ list(APPEND DEPS "${TARGET_RULE_LIB}")
 # Generate dependencies
 add_custom_target(tf2circle_dredd_pbtxt_deps ALL DEPENDS ${DEPS})
 
+if(NOT ENABLE_TEST)
+  return()
+endif(NOT ENABLE_TEST)
+
 add_test(
   NAME tf2circle_dredd_pbtxt_test
   COMMAND


### PR DESCRIPTION
This will revise to skip test when ENABLE_TEST is not defined.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>