### PR TITLE
[tf2tflite-dredd-pb-test] Enable skip test

### DIFF
--- a/compiler/tf2tflite-dredd-pb-test/CMakeLists.txt
+++ b/compiler/tf2tflite-dredd-pb-test/CMakeLists.txt
@@ -1,3 +1,7 @@
+if(NOT ENABLE_TEST)
+  return()
+endif(NOT ENABLE_TEST)
+
 nnas_include(TargetRequire)
 
 unset(REQUIRED_TARGETS)


### PR DESCRIPTION
This will revise to skip test when ENABLE_TEST is not defined.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>