### PR TITLE
[onert] Fix tizen x86_64 build fail

### DIFF
--- a/infra/nnfw/cmake/options/options_x86_64-tizen.cmake
+++ b/infra/nnfw/cmake/options/options_x86_64-tizen.cmake
@@ -2,6 +2,7 @@
 # x86_64 linux cmake options
 #
 option(BUILD_ARMCOMPUTE "Build ARM Compute from the downloaded source" OFF)
+option(BUILD_TENSORFLOW_LITE "Build TensorFlow Lite from the downloaded source" OFF)
 option(DOWNLOAD_ARMCOMPUTE "Download ARM Compute source" OFF)
 option(DOWNLOAD_GTEST "Download Google Test source and build Google Test" OFF)
 


### PR DESCRIPTION
- Disable tensorflow-lite build on tizen x86_64

ONE-DCO-1.0-Signed-off-by: Chunseok Lee <chunseok.lee@samsung.com>