### PR TITLE
[cli] Fix typo in CMakeLists

### DIFF
--- a/compiler/cli/CMakeLists.txt
+++ b/compiler/cli/CMakeLists.txt
@@ -10,5 +10,5 @@ endif(NOT ENABLE_TEST)
 
 nnas_find_package(GTest QUIET)
 
-GTest_AddTEst(cli_test ${TESTS})
+GTest_AddTest(cli_test ${TESTS})
 target_link_libraries(cli_test cli)


### PR DESCRIPTION
This will fix GTest_AddTest typo.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>