### PR TITLE
[onert/ndarray] Add more NDArray tests

### DIFF
--- a/runtime/libs/ndarray/test/ndarray_test.cpp
+++ b/runtime/libs/ndarray/test/ndarray_test.cpp
@@ -24,8 +24,10 @@ TEST(NDArray_tests, basic_data_test)
 {
 
   float raw_data[] = {1, 2, 3, 4};
+  int32_t raw_data_int[] = {1, 2, 3, 4};
 
   Array<float> data22{raw_data, {2, 2}};
+  Array<int32_t> data22_int{raw_data_int, {2, 2}};
 
   ASSERT_FLOAT_EQ(data22.at(0, 0), 1);
   ASSERT_FLOAT_EQ(data22.at(0, 1), 2);
@@ -44,9 +46,26 @@ TEST(NDArray_tests, basic_data_test)
   ASSERT_EQ(data14.shape().dim(0), 1);
   ASSERT_EQ(data14.shape().dim(1), 4);
 
-  ContiguousSpan<float> cs = data22.flat();
-  ASSERT_EQ(cs.size(), 4);
-  ASSERT_FLOAT_EQ(cs.at(3), 4);
+  // <float, false>
+  {
+    ContiguousSpan<float> cs = data22.flat();
+    ASSERT_EQ(cs.size(), 4);
+    ASSERT_FLOAT_EQ(cs.at(3), 4);
+  }
+
+  // <float, true>
+  {
+    ContiguousSpan<float, true> cs_const = data22.flat();
+    ASSERT_EQ(cs_const.size(), 4);
+    ASSERT_FLOAT_EQ(cs_const.at(3), 4);
+  }
+
+  // <int32_t, false>
+  {
+    ContiguousSpan<int32_t> cs_int = data22_int.flat();
+    ASSERT_EQ(cs_int.size(), 4);
+    ASSERT_FLOAT_EQ(cs_int.at(3), 4);
+  }
 
   Array<float> lv = std::move(data14);
   ASSERT_FLOAT_EQ(lv.at(0, 0), 1);
@@ -57,16 +76,32 @@ TEST(NDArray_tests, basic_data_test)
 
 TEST(NDArray_tests, slice_write_test)
 {
-  float raw_data[4] = {0};
+  // float
+  {
+    float raw_data[4] = {0};
 
-  Array<float> data22{raw_data, {2, 2}};
+    Array<float> data22{raw_data, {2, 2}};
 
-  data22.slice(1) = {1, 2};
+    data22.slice(1) = {1, 2};
 
-  ASSERT_FLOAT_EQ(data22.at(0, 0), 0);
-  ASSERT_FLOAT_EQ(data22.at(0, 1), 0);
-  ASSERT_FLOAT_EQ(data22.at(1, 0), 1);
-  ASSERT_FLOAT_EQ(data22.at(1, 1), 2);
+    ASSERT_FLOAT_EQ(data22.at(0, 0), 0);
+    ASSERT_FLOAT_EQ(data22.at(0, 1), 0);
+    ASSERT_FLOAT_EQ(data22.at(1, 0), 1);
+    ASSERT_FLOAT_EQ(data22.at(1, 1), 2);
+  }
+
+  // int32_t
+  {
+    int32_t raw_data_int[4] = {0};
+    Array<int32_t> data22{raw_data_int, {2, 2}};
+
+    data22.slice(1) = {1, 2};
+
+    ASSERT_FLOAT_EQ(data22.at(0, 0), 0);
+    ASSERT_FLOAT_EQ(data22.at(0, 1), 0);
+    ASSERT_FLOAT_EQ(data22.at(1, 0), 1);
+    ASSERT_FLOAT_EQ(data22.at(1, 1), 2);
+  }
 }
 
 TEST(NDArray_tests, slice_read_test)
@@ -96,27 +131,65 @@ TEST(NDArray_tests, multidim_test)
 
 TEST(NDArray_tests, slice_assign_test)
 {
-  std::vector<float> v1{1, 2, 3, 4, 5};
-  std::vector<float> v2(5);
+  // float
+  {
+    std::vector<float> v1{1, 2, 3, 4, 5};
+    std::vector<float> v2(5);
 
-  ContiguousSpan<float> span1(v1.begin(), v1.end());
-  ContiguousSpan<float> span2(v2.begin(), v2.end());
+    ContiguousSpan<float> span1(v1.begin(), v1.end());
+    ContiguousSpan<float> span2(v2.begin(), v2.end());
 
-  span2.assign(span1);
+    span2.assign(span1);
 
-  ASSERT_EQ(v1, v2);
-  ASSERT_EQ(span1.size(), 5);
-  ASSERT_EQ(span2.size(), 5);
+    ASSERT_EQ(v1, v2);
+    ASSERT_EQ(span1.size(), 5);
+    ASSERT_EQ(span2.size(), 5);
 
-  ASSERT_EQ(span2.at(2), 3);
-  ASSERT_EQ(span2.at(4), 5);
+    ASSERT_EQ(span2.at(2), 3);
+    ASSERT_EQ(span2.at(4), 5);
 
-  ASSERT_EQ(*(span1.data() + 2), *(span1.data() + 2));
+    ASSERT_EQ(*(span1.data() + 2), *(span1.data() + 2));
 
-  ContiguousSpan<float> span3(span2.offset(1));
-  ASSERT_EQ(span3.size(), 4);
-  ASSERT_EQ(span3.at(0), 2);
-  ASSERT_EQ(span3.at(1), 3);
-  ASSERT_EQ(span3.at(2), 4);
-  ASSERT_EQ(span3.at(3), 5);
+    ContiguousSpan<float> span3(span2.offset(1));
+    ASSERT_EQ(span3.size(), 4);
+    ASSERT_EQ(span3.at(0), 2);
+    ASSERT_EQ(span3.at(1), 3);
+    ASSERT_EQ(span3.at(2), 4);
+    ASSERT_EQ(span3.at(3), 5);
+
+    // const
+    ContiguousSpan<float, true> span3_const(span2.offset(1));
+    ASSERT_EQ(span3_const.size(), 4);
+    ASSERT_EQ(span3_const.at(0), 2);
+    ASSERT_EQ(span3_const.at(1), 3);
+    ASSERT_EQ(span3_const.at(2), 4);
+    ASSERT_EQ(span3_const.at(3), 5);
+  }
+
+  // int32_t
+  {
+    std::vector<int32_t> v4{1, 2, 3, 4, 5};
+    std::vector<int32_t> v5(5);
+
+    ContiguousSpan<int32_t> span4(v4.begin(), v4.end());
+    ContiguousSpan<int32_t> span5(v5.begin(), v5.end());
+
+    span5.assign(span4);
+
+    ASSERT_EQ(v4, v5);
+    ASSERT_EQ(span4.size(), 5);
+    ASSERT_EQ(span5.size(), 5);
+
+    ASSERT_EQ(span5.at(2), 3);
+    ASSERT_EQ(span5.at(4), 5);
+
+    ASSERT_EQ(*(span4.data() + 2), *(span5.data() + 2));
+
+    ContiguousSpan<int32_t> span6(span5.offset(1));
+    ASSERT_EQ(span6.size(), 4);
+    ASSERT_EQ(span6.at(0), 2);
+    ASSERT_EQ(span6.at(1), 3);
+    ASSERT_EQ(span6.at(2), 4);
+    ASSERT_EQ(span6.at(3), 5);
+  }
 }


### PR DESCRIPTION
This commit adds more different type NDArray tests.

`ContiguousSpan<float, true>` and `ContiguousSpan<int32_t, false>` are used in DetectionPostProcessLayer.

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: #8935