### PR TITLE
[onert] Add Greater Tests in one_op_tests

### DIFF
--- a/tests/nnfw_api/src/CircleGen.cc
+++ b/tests/nnfw_api/src/CircleGen.cc
@@ -269,6 +269,13 @@ uint32_t CircleGen::addOperatorFloorDiv(const OperatorParams &params)
                                 circle::BuiltinOptions_NONE, 0);
 }
 
+uint32_t CircleGen::addOperatorGreater(const OperatorParams &params)
+{
+  auto options = circle::CreateLessOptions(_fbb).Union();
+  return addOperatorWithOptions(params, circle::BuiltinOperator_GREATER,
+                                circle::BuiltinOptions_GreaterOptions, options);
+}
+
 uint32_t CircleGen::addOperatorL2Normalization(const OperatorParams &params)
 {
   auto options = circle::CreateL2NormOptions(_fbb).Union();

--- a/tests/nnfw_api/src/CircleGen.h
+++ b/tests/nnfw_api/src/CircleGen.h
@@ -174,6 +174,7 @@ public:
   uint32_t addOperatorFullyConnected(const OperatorParams &params,
                                      circle::FullyConnectedOptionsWeightsFormat weights_format =
                                        circle::FullyConnectedOptionsWeightsFormat_DEFAULT);
+  uint32_t addOperatorGreater(const OperatorParams &params);
   uint32_t addOperatorIf(const OperatorParams &params, uint32_t then_subg, uint32_t else_subg);
   uint32_t addOperatorInstanceNorm(const OperatorParams &params, float epsilon,
                                    circle::ActivationFunctionType actfn);

--- a/tests/nnfw_api/src/one_op_tests/Greater.cc
+++ b/tests/nnfw_api/src/one_op_tests/Greater.cc
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "GenModelTest.h"
+
+struct GreaterVariationParam
+{
+  TestCaseData tcd;
+  circle::TensorType input_type = circle::TensorType::TensorType_FLOAT32;
+  const std::vector<std::string> backends = {"acl_cl", "acl_neon", "cpu"};
+};
+
+class GreaterVariation : public GenModelTest,
+                         public ::testing::WithParamInterface<GreaterVariationParam>
+{
+};
+
+// Input shape:
+//   Base: {1, 2, 2, 1}
+//   Brodcast: {1} on of two input
+// Output shape: {1, 2, 2, 1}
+// Input type: Non-quantization type
+// Output type: BOOL
+// Test with different input type and value
+INSTANTIATE_TEST_SUITE_P(GenModelTest, GreaterVariation,
+                         ::testing::Values(
+                           // Float type
+                           GreaterVariationParam{TestCaseData{}
+                                                   .addInput<float>({0.1, 0.3, 0.2, 0.7})
+                                                   .addInput<float>({0.1, 0.2, 0.3, 0.4})
+                                                   .addOutput<bool>({false, true, false, true})},
+                           // Float type - broadcast
+                           GreaterVariationParam{TestCaseData{}
+                                                   .addInput<float>({0.1, 0.3, 0.2, 0.7})
+                                                   .addInput<float>({0.3})
+                                                   .addOutput<bool>({false, false, false, true})},
+                           // Int32 type
+                           GreaterVariationParam{TestCaseData{}
+                                                   .addInput<int32_t>({1, 3, 2, 7})
+                                                   .addInput<int32_t>({1, 2, 3, 4})
+                                                   .addOutput<bool>({false, true, false, true}),
+                                                 circle::TensorType::TensorType_INT32},
+                           // Int32 type - broadcast
+                           GreaterVariationParam{TestCaseData{}
+                                                   .addInput<int32_t>({1, 3, 2, 7})
+                                                   .addInput<int32_t>({5})
+                                                   .addOutput<bool>({false, false, false, true}),
+                                                 circle::TensorType::TensorType_INT32},
+                           // Int64 type
+                           // NYI: acl backend
+                           GreaterVariationParam{TestCaseData{}
+                                                   .addInput<int64_t>({1, 3, -2, 7})
+                                                   .addInput<int64_t>({1, 2, 3, 4})
+                                                   .addOutput<bool>({false, true, false, true}),
+                                                 circle::TensorType::TensorType_INT64,
+                                                 {"cpu"}},
+                           // Int64 type - broadcast
+                           // NYI: acl backend
+                           GreaterVariationParam{TestCaseData{}
+                                                   .addInput<int64_t>({1, 3, -2, 7})
+                                                   .addInput<int64_t>({1})
+                                                   .addOutput<bool>({false, true, false, true}),
+                                                 circle::TensorType::TensorType_INT64,
+                                                 {"cpu"}}));
+
+TEST_P(GreaterVariation, Test)
+{
+  auto &param = GetParam();
+
+  auto lhs_data = param.tcd.inputs.at(0);
+  auto rhs_data = param.tcd.inputs.at(1);
+
+  bool broadcast_lhs = false;
+  bool broadcast_rhs = false;
+  if (lhs_data.size() != rhs_data.size())
+  {
+    if (lhs_data.size() < rhs_data.size())
+      broadcast_lhs = true;
+    else
+      broadcast_rhs = true;
+  }
+
+  CircleGen cgen;
+  const auto output_type = circle::TensorType::TensorType_BOOL;
+
+  int lhs = broadcast_lhs ? cgen.addTensor({{1}, param.input_type})
+                          : cgen.addTensor({{1, 2, 2, 1}, param.input_type});
+  int rhs = broadcast_rhs ? cgen.addTensor({{1}, param.input_type})
+                          : cgen.addTensor({{1, 2, 2, 1}, param.input_type});
+  int out = cgen.addTensor({{1, 2, 2, 1}, output_type});
+  cgen.addOperatorGreater({{lhs, rhs}, {out}});
+  cgen.setInputsAndOutputs({lhs, rhs}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->addTestCase(param.tcd);
+  _context->setBackends(param.backends);
+
+  SUCCEED();
+}
+
+TEST_F(GenModelTest, neg_OneOp_Greater_DifferentType)
+{
+  CircleGen cgen;
+  int lhs = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_FLOAT32});
+  int rhs = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_INT32});
+  int out = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_BOOL});
+  cgen.addOperatorGreater({{lhs, rhs}, {out}});
+  cgen.setInputsAndOutputs({lhs, rhs}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->setBackends({"acl_cl", "acl_neon", "cpu"});
+  _context->expectFailModelLoad();
+
+  SUCCEED();
+}
+
+TEST_F(GenModelTest, neg_OneOp_Greater_InvalidType)
+{
+  CircleGen cgen;
+  int lhs = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_FLOAT32});
+  int rhs = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_FLOAT32});
+  int out = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_INT32});
+  cgen.addOperatorGreater({{lhs, rhs}, {out}});
+  cgen.setInputsAndOutputs({lhs, rhs}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->setBackends({"acl_cl", "acl_neon", "cpu"});
+  _context->expectFailModelLoad();
+
+  SUCCEED();
+}


### PR DESCRIPTION
It adds tests for Greater by negating LessEqual's expected output.

Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

Related: #8935