### PR TITLE
[onert] Add more test for Cast

### DIFF
--- a/runtime/onert/frontend/base_loader/include/base_loader.h
+++ b/runtime/onert/frontend/base_loader/include/base_loader.h
@@ -290,6 +290,8 @@ ir::DataType BaseLoader<LoaderDomain>::BaseLoader::tensorTypeToDataType(const Te
     case TensorType::TensorType_INT8:
       return ir::DataType::QUANT_INT8_ASYMM;
     // case TensorType::TensorType_FLOAT64
+    case TensorType::TensorType_UINT32:
+      return ir::DataType::UINT32;
     default:
       throw std::runtime_error(
         std::string("Unsupported tensor type: ").append(EnumNameTensorType(type)));

--- a/tests/nnfw_api/src/one_op_tests/Cast.cc
+++ b/tests/nnfw_api/src/one_op_tests/Cast.cc
@@ -110,8 +110,8 @@ TEST_F(GenModelTest, OneOp_Cast_Int64ToFloat32)
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
   _context->addTestCase(TestCaseData{}
-                          .addInput<int64_t>({-12345, 0, 100, 2147483648})
-                          .addOutput<float>({-12345., 3., 100., 2147483647.}));
+                          .addInput<int64_t>({-12345, 3, 100, 2147483648})
+                          .addOutput<float>({-12345., 3., 100., 2147483648.}));
   _context->setBackends({"acl_cl", "acl_neon", "cpu"});
 
   SUCCEED();

--- a/tests/nnfw_api/src/one_op_tests/Cast.cc
+++ b/tests/nnfw_api/src/one_op_tests/Cast.cc
@@ -89,21 +89,6 @@ TEST_F(GenModelTest, OneOp_Cast_BoolToInt32)
   SUCCEED();
 }
 
-TEST_F(GenModelTest, OneOp_Cast_Uint32ToFloat32)
-{
-  CircleGen cgen = genSimpleCastModel(circle::TensorType_UINT32, circle::TensorType_FLOAT32);
-
-  _context = std::make_unique<GenModelTestContext>(cgen.finish());
-  // clang-format off
-  _context->addTestCase(
-    TestCaseData{}.addInput<uint32_t>({0, 3, 100, 31415})
-                  .addOutput<float>({0., 3., 100., 31415.}));
-  // clang-format on
-  _context->setBackends({"acl_cl", "acl_neon", "cpu"});
-
-  SUCCEED();
-}
-
 TEST_F(GenModelTest, OneOp_Cast_Uint8ToFloat32)
 {
   CircleGen cgen = genSimpleCastModel(circle::TensorType_UINT8, circle::TensorType_FLOAT32);

--- a/tests/nnfw_api/src/one_op_tests/Cast.cc
+++ b/tests/nnfw_api/src/one_op_tests/Cast.cc
@@ -112,7 +112,7 @@ TEST_F(GenModelTest, OneOp_Cast_Int64ToFloat32)
   _context->addTestCase(TestCaseData{}
                           .addInput<int64_t>({-12345, 3, 100, 2147483648})
                           .addOutput<float>({-12345., 3., 100., 2147483648.}));
-  _context->setBackends({"acl_cl", "acl_neon", "cpu"});
+  _context->setBackends({"acl_cl", "cpu"});
 
   SUCCEED();
 }

--- a/tests/nnfw_api/src/one_op_tests/Cast.cc
+++ b/tests/nnfw_api/src/one_op_tests/Cast.cc
@@ -112,7 +112,7 @@ TEST_F(GenModelTest, OneOp_Cast_Int64ToFloat32)
   _context->addTestCase(TestCaseData{}
                           .addInput<int64_t>({-12345, 3, 100, 2147483648})
                           .addOutput<float>({-12345., 3., 100., 2147483648.}));
-  _context->setBackends({"acl_cl", "cpu"});
+  _context->setBackends({"cpu"});
 
   SUCCEED();
 }

--- a/tests/nnfw_api/src/one_op_tests/Cast.cc
+++ b/tests/nnfw_api/src/one_op_tests/Cast.cc
@@ -89,6 +89,49 @@ TEST_F(GenModelTest, OneOp_Cast_BoolToInt32)
   SUCCEED();
 }
 
+TEST_F(GenModelTest, OneOp_Cast_Uint32ToFloat32)
+{
+  CircleGen cgen = genSimpleCastModel(circle::TensorType_UINT32, circle::TensorType_FLOAT32);
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  // clang-format off
+  _context->addTestCase(
+    TestCaseData{}.addInput<uint32_t>({0, 3, 100, 31415})
+                  .addOutput<float>({0., 3., 100., 31415.}));
+  // clang-format on
+  _context->setBackends({"acl_cl", "acl_neon", "cpu"});
+
+  SUCCEED();
+}
+
+TEST_F(GenModelTest, OneOp_Cast_Uint8ToFloat32)
+{
+  CircleGen cgen = genSimpleCastModel(circle::TensorType_UINT8, circle::TensorType_FLOAT32);
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  // clang-format off
+  _context->addTestCase(
+    TestCaseData{}.addInput<uint8_t>({0, 100, 200, 255})
+                  .addOutput<float>({0., 100., 200., 255.}));
+  // clang-format on
+  _context->setBackends({"acl_cl", "acl_neon", "cpu"});
+
+  SUCCEED();
+}
+
+TEST_F(GenModelTest, OneOp_Cast_Int64ToFloat32)
+{
+  CircleGen cgen = genSimpleCastModel(circle::TensorType_INT64, circle::TensorType_FLOAT32);
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->addTestCase(TestCaseData{}
+                          .addInput<int64_t>({-12345, 0, 100, 2147483648})
+                          .addOutput<float>({-12345., 3., 100., 2147483647.}));
+  _context->setBackends({"acl_cl", "acl_neon", "cpu"});
+
+  SUCCEED();
+}
+
 TEST_F(GenModelTest, OneOp_Cast_AfterEqual)
 {
   CircleGen cgen;


### PR DESCRIPTION
It adds more tests for uncovered input types (e.g. int64_t, uint32_t,
...) in Cast operator.

Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

Related: #8935