### PR TITLE
[luci/DRAFT] Issue warning when quantized weight is poorly representable

### DIFF
--- a/compiler/circle-quantizer/src/CircleQuantizer.cpp
+++ b/compiler/circle-quantizer/src/CircleQuantizer.cpp
@@ -189,6 +189,13 @@ int entry(int argc, char **argv)
     .required(false)
     .help("Output type of quantized model (uint8 or int16)");
 
+  arser.add_argument("--warn_weights")
+    .nargs(0)
+    .required(false)
+    .default_value(true)
+    .help(
+      "Issue warnings if the quantized model would be inaccurate due to unrepresentable weights");
+
   arser.add_argument(cfg)
     .nargs(1)
     .type(arser::DataType::STR)
@@ -410,8 +417,14 @@ int entry(int argc, char **argv)
   {
     auto graph = module->graph(idx);
 
-    // quantize the graph
-    quantizer.quantize(graph);
+    if (arser["--warn_weights"])
+    {
+      quantizer.check(graph);
+    }
+    else
+    { // quantize the graph
+      quantizer.quantize(graph);
+    }
 
     if (!luci::validate(graph))
     {

--- a/compiler/luci/pass/include/luci/CircleQuantizer.h
+++ b/compiler/luci/pass/include/luci/CircleQuantizer.h
@@ -88,6 +88,9 @@ public:
 public:
   void quantize(loco::Graph *) const;
 
+public:
+  void check(loco::Graph *) const;
+
 private:
   std::unique_ptr<Options> _options;
 };

--- a/compiler/luci/pass/include/luci/Pass/UnrepresentableWarningIssuerPass.h
+++ b/compiler/luci/pass/include/luci/Pass/UnrepresentableWarningIssuerPass.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __LUCI_UNREPRESENTABLE_WARNING_ISSUER_PASS_H__
+#define __LUCI_UNREPRESENTABLE_WARNING_ISSUER_PASS_H__
+
+#include <logo/Pass.h>
+
+#include <utility>
+#include <luci/IR/CircleNode.h>
+#include <helpers/LayerInfoMap.h>
+#include "QuantizationParameters.h"
+
+namespace luci
+{
+
+/**
+ * @brief  Class to convert a quantized model to a fake-quantized fp32 model.
+ */
+struct UnrepresentableWarningIssuerPass final : public logo::Pass
+{
+  struct Context
+  {
+    loco::DataType input_model_dtype = loco::DataType::Unknown;
+    loco::DataType output_model_dtype = loco::DataType::Unknown;
+    QuantizationGranularity granularity = QuantizationGranularity::ChannelWise;
+    std::vector<LayerInfo> layers_info;
+  };
+
+  std::unique_ptr<Context> _ctx;
+  explicit UnrepresentableWarningIssuerPass(std::unique_ptr<Context> c) : _ctx(std::move(c)) {}
+
+  const char *name(void) const final { return "luci::UnrepresentableWarningIssuerPass"; }
+
+  bool run(loco::Graph *g) final;
+
+protected:
+
+  // For testing
+  bool is_unrepr(luci::CircleConst* pConst,
+                 loco::DataType input_t,loco::DataType output_t,QuantizationGranularity qgran);
+
+private:
+  void warn_if_unrepr(CircleConst *, loco::Graph *);
+
+  LayerInfoMap info_by_name;
+
+  loco::DataType quantize_dtype(const luci::CircleNode *node) {
+    auto iter = info_by_name.find(node->name());
+
+    // Return designated quantization dtype
+    if (iter != info_by_name.end())
+      return iter->second.dtype;
+
+    // Return default quantization dtype
+    return _ctx->output_model_dtype;
+  };
+
+  QuantizationGranularity quantize_granularity(const luci::CircleNode *node) {
+    auto iter = info_by_name.find(node->name());
+
+    // Return designated quantization granularity
+    if (iter != info_by_name.end())
+      return iter->second.granularity;
+
+    // Return default quantization granularity
+    return _ctx->granularity;
+  };
+
+};
+
+} // namespace luci
+
+#endif // __LUCI_UNREPRESENTABLE_WARNING_ISSUER_H__

--- a/compiler/luci/pass/include/luci/Pass/UnrepresentableWarningIssuerPass.h
+++ b/compiler/luci/pass/include/luci/Pass/UnrepresentableWarningIssuerPass.h
@@ -53,7 +53,7 @@ protected:
                  QuantizationGranularity qgran);
 
 private:
-  void warn_if_unrepr(CircleConst *, loco::Graph *);
+  void warn_if_unrepr(CircleConst *);
 
   LayerInfoMap info_by_name;
 

--- a/compiler/luci/pass/include/luci/Pass/UnrepresentableWarningIssuerPass.h
+++ b/compiler/luci/pass/include/luci/Pass/UnrepresentableWarningIssuerPass.h
@@ -48,17 +48,17 @@ struct UnrepresentableWarningIssuerPass final : public logo::Pass
   bool run(loco::Graph *g) final;
 
 protected:
-
   // For testing
-  bool is_unrepr(luci::CircleConst* pConst,
-                 loco::DataType input_t,loco::DataType output_t,QuantizationGranularity qgran);
+  bool is_unrepr(luci::CircleConst *pConst, loco::DataType input_t, loco::DataType output_t,
+                 QuantizationGranularity qgran);
 
 private:
   void warn_if_unrepr(CircleConst *, loco::Graph *);
 
   LayerInfoMap info_by_name;
 
-  loco::DataType quantize_dtype(const luci::CircleNode *node) {
+  loco::DataType quantize_dtype(const luci::CircleNode *node)
+  {
     auto iter = info_by_name.find(node->name());
 
     // Return designated quantization dtype
@@ -69,7 +69,8 @@ private:
     return _ctx->output_model_dtype;
   };
 
-  QuantizationGranularity quantize_granularity(const luci::CircleNode *node) {
+  QuantizationGranularity quantize_granularity(const luci::CircleNode *node)
+  {
     auto iter = info_by_name.find(node->name());
 
     // Return designated quantization granularity
@@ -79,7 +80,6 @@ private:
     // Return default quantization granularity
     return _ctx->granularity;
   };
-
 };
 
 } // namespace luci

--- a/compiler/luci/pass/src/UnrepresentableWarningIssuerPass.cpp
+++ b/compiler/luci/pass/src/UnrepresentableWarningIssuerPass.cpp
@@ -25,7 +25,7 @@
 namespace luci
 {
 
-void UnrepresentableWarningIssuerPass::warn_if_unrepr(CircleConst *pConst, loco::Graph *g)
+void UnrepresentableWarningIssuerPass::warn_if_unrepr(CircleConst *pConst)
 {
   LOGGER(l);
 
@@ -39,8 +39,6 @@ void UnrepresentableWarningIssuerPass::warn_if_unrepr(CircleConst *pConst, loco:
   {
     WARN(l) << "Weight " << pConst->name()
             << " is poorly representable given quantization parameters: " << std::endl;
-
-    ;
   }
 }
 
@@ -55,7 +53,7 @@ bool luci::UnrepresentableWarningIssuerPass::run(loco::Graph *g)
     if (not circle_const)
       continue;
     INFO(l) << "UnrepresentableWarningIssuerPass visit node: " << circle_const->name() << std::endl;
-    warn_if_unrepr(circle_const, g);
+    warn_if_unrepr(circle_const);
   }
 
   // One time run

--- a/compiler/luci/pass/src/UnrepresentableWarningIssuerPass.cpp
+++ b/compiler/luci/pass/src/UnrepresentableWarningIssuerPass.cpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Pass/UnrepresentableWarningIssuerPass.h"
+#include "luci/Pass/QuantizationParameters.h"
+#include "helpers/LayerInfoMap.h"
+
+#include <cmath>
+#include <luci/IR/CircleNodes.h>
+#include <luci/Log.h>
+
+namespace luci
+{
+
+void UnrepresentableWarningIssuerPass::warn_if_unrepr(CircleConst *pConst, loco::Graph *g)
+{
+  LOGGER(l);
+
+  QuantizationGranularity gran = ChannelWise;
+  for (auto suc : loco::succs(pConst))
+  {
+    gran = quantize_granularity(loco::must_cast<const luci::CircleNode *>(suc));
+  }
+
+  if (is_unrepr(pConst, _ctx->input_model_dtype, quantize_dtype(pConst), gran))
+  {
+    WARN(l) << "Weight " << pConst->name()
+            << " is poorly representable given quantization parameters: " << std::endl;
+
+    ;
+  }
+}
+
+bool luci::UnrepresentableWarningIssuerPass::run(loco::Graph *g)
+{
+  LOGGER(l);
+  info_by_name = layer_info_map(g, _ctx->layers_info);
+
+  for (auto node : loco::active_nodes(loco::output_nodes(g)))
+  {
+    auto circle_const = dynamic_cast<luci::CircleConst *>(node);
+    if (not circle_const)
+      continue;
+    INFO(l) << "UnrepresentableWarningIssuerPass visit node: " << circle_const->name() << std::endl;
+    warn_if_unrepr(circle_const, g);
+  }
+
+  // One time run
+  return false;
+}
+
+int nbits(loco::DataType output_t) noexcept
+{
+  switch (output_t)
+  {
+    case loco::DataType::S8:
+    case loco::DataType::U8:
+      return 8;
+    case loco::DataType::S16:
+    case loco::DataType::U16:
+    case loco::DataType::FLOAT16:
+      return 16;
+    case loco::DataType::S32:
+    case loco::DataType::U32:
+    case loco::DataType::FLOAT32:
+      return 32;
+    case loco::DataType::S64:
+      return 64;
+    default:
+      return 64;
+  }
+}
+
+bool UnrepresentableWarningIssuerPass::is_unrepr(luci::CircleConst *pConst, loco::DataType input_t,
+                                                 loco::DataType output_t, QuantizationGranularity)
+{
+  float min = 1e30f, max = +1e30f;
+  float d = 1.5f;
+  pConst->rank();
+  // TODO only collect min/max across channel for QuantizationGranularity::Channel
+  assert(input_t == loco::DataType::FLOAT32);
+  assert(pConst->dtype() == loco::DataType::FLOAT32);
+  for (uint32_t i = 0; i < pConst->size<loco::DataType::FLOAT32>(); i++)
+  {
+    auto v = pConst->at<loco::DataType::FLOAT32>(i);
+    min = std::min(min, v);
+    max = std::max(max, v);
+  }
+  return log2f(max) - log2f(min) > nbits(output_t) * d;
+}
+
+} // namespace luci


### PR DESCRIPTION
This Draft shows an approach to dumping warnings for poorly representable (given quantization params) nodes.
See #8889.

ONE-DCO-1.0-Signed-off-by: a.shedko <a.shedko@samsung.com>