### PR TITLE
[onert] Fix typo in Add negative test

### DIFF
--- a/tests/nnfw_api/src/one_op_tests/Add.cc
+++ b/tests/nnfw_api/src/one_op_tests/Add.cc
@@ -283,7 +283,7 @@ TEST_F(GenModelTest, neg_OneOp_Add_VarToVarSize0_InvalidShape)
   SUCCEED();
 }
 
-TEST_F(GenModelTest, net_OneOp_Add_VarToVarInt16)
+TEST_F(GenModelTest, neg_OneOp_Add_VarToVarInt16)
 {
   CircleGen cgen;
   int lhs = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_INT16}, 1., 2);


### PR DESCRIPTION
It replaces typo net with neg in negative test name.

Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

I found a typo while referencing negative test code.