### PR TITLE
[circledump] Use mio::circle::builtin_code_neutral

### DIFF
--- a/compiler/circledump/src/Read.cpp
+++ b/compiler/circledump/src/Read.cpp
@@ -67,7 +67,7 @@ circle::BuiltinOperator Reader::builtin_code(const circle::Operator *op) const
   assert(index < _op_codes.size());
   const circle::OperatorCode *opcode = _op_codes.at(index);
 
-  return opcode->builtin_code();
+  return mio::circle::builtin_code_neutral(opcode);
 }
 
 std::string Reader::opcode_name(const circle::Operator *op) const


### PR DESCRIPTION
This will revise to use mio::circle::builtin_code_neutral for correct
builtin_code.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>