### PR TITLE
[infra] Enable nnpackage_run build on x64 runtime build

### DIFF
--- a/infra/scripts/docker_build_test_x64.sh
+++ b/infra/scripts/docker_build_test_x64.sh
@@ -32,9 +32,8 @@ pushd $ROOT_PATH > /dev/null
 export DOCKER_ENV_VARS
 export DOCKER_VOLUMES
 export BUILD_OPTIONS
-# Disable nnpackage_run build: mismatch between buildtool for CI and installed hdf5
-CMD="export OPTIONS='-DBUILD_NNPACKAGE_RUN=OFF $BUILD_OPTIONS' && \
-     export BUILD_TYPE=Release && \
+
+CMD="export BUILD_TYPE=Release && \
      cp -nv Makefile.template Makefile && \
      make all install build_test_suite"
 ./nnfw docker-run bash -c "$CMD"


### PR DESCRIPTION
This commit enables nnpackage_run on x64 runtime build test script.

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>