### PR TITLE
[circle2circle] Add ReplaceNonConstFCWithBatchMatMul option

### DIFF
--- a/compiler/circle2circle/src/Circle2Circle.cpp
+++ b/compiler/circle2circle/src/Circle2Circle.cpp
@@ -250,7 +250,7 @@ int entry(int argc, char **argv)
   arser.add_argument("--replace_non_const_fc_with_batch_matmul")
     .nargs(0)
     .default_value(false)
-    .help("Replace Fully Connected with Batch Mat Mul when its weight is non-constant");
+    .help("Replace Fully Connected with BatchMatMul when its weight is non-constant");
 
   arser.add_argument("--substitute_pack_to_reshape")
     .nargs(0)

--- a/compiler/circle2circle/src/Circle2Circle.cpp
+++ b/compiler/circle2circle/src/Circle2Circle.cpp
@@ -250,7 +250,7 @@ int entry(int argc, char **argv)
   arser.add_argument("--replace_non_const_fc_with_batch_matmul")
     .nargs(0)
     .default_value(false)
-    .help("Replace Fully Connected with BatchMatMul when its weight is non-constant");
+    .help("Replace FullyConnected with BatchMatMul when its weight is non-constant");
 
   arser.add_argument("--substitute_pack_to_reshape")
     .nargs(0)

--- a/compiler/circle2circle/src/Circle2Circle.cpp
+++ b/compiler/circle2circle/src/Circle2Circle.cpp
@@ -247,6 +247,11 @@ int entry(int argc, char **argv)
     .help("This will convert weight format of FullyConnected to SHUFFLED16x1FLOAT32. Note that "
           "it only converts weights whose row is a multiple of 16");
 
+  arser.add_argument("--replace_non_const_fc_with_batch_matmul")
+    .nargs(0)
+    .default_value(false)
+    .help("Replace Fully Connected with Batch Mat Mul when its weight is non-constant");
+
   arser.add_argument("--substitute_pack_to_reshape")
     .nargs(0)
     .default_value(false)
@@ -444,6 +449,8 @@ int entry(int argc, char **argv)
     options->enable(Algorithms::ResolveCustomOpMaxPoolWithArgmax);
   if (arser.get<bool>("--shuffle_weight_to_16x1float32"))
     options->enable(Algorithms::ShuffleWeightTo16x1Float32);
+  if (arser.get<bool>("--replace_non_const_fc_with_batch_matmul"))
+    options->enable(Algorithms::ReplaceNonConstFCWithBatchMatMul);
   if (arser.get<bool>("--substitute_pack_to_reshape"))
     options->enable(Algorithms::SubstitutePackToReshape);
   if (arser.get<bool>("--substitute_padv2_to_pad"))


### PR DESCRIPTION
This PR adds ReplaceNonConstFCWithBatchMatMul option to circle2circle.
The pass allows us to compile FC with non-const weight to Batch MatMul.

Signed-off-by: a.shedko <a.shedko@samsung.com>