### PR TITLE
[mio-circle04] Add helper methods for tensor

### DIFF
--- a/compiler/mio-circle04/include/mio_circle/Reader.h
+++ b/compiler/mio-circle04/include/mio_circle/Reader.h
@@ -68,6 +68,8 @@ public:
   size_t buffer_info(uint32_t buf_idx, const uint8_t **buff_data);
   ::circle::BuiltinOperator builtin_code(const ::circle::Operator *op) const;
   std::string opcode_name(const ::circle::Operator *op) const;
+  std::string tensor_name(const ::circle::Tensor *tensor) const;
+  std::string tensor_dtype(const ::circle::Tensor *tensor) const;
 
 public:
   bool select_subgraph(uint32_t subgraph);

--- a/compiler/mio-circle04/src/Reader.cpp
+++ b/compiler/mio-circle04/src/Reader.cpp
@@ -98,6 +98,16 @@ std::string Reader::opcode_name(const ::circle::Operator *op) const
   return mio::circle::opcode_name(opcode);
 }
 
+std::string Reader::tensor_name(const ::circle::Tensor *tensor) const
+{
+  return mio::circle::tensor_name(tensor);
+}
+
+std::string Reader::tensor_dtype(const ::circle::Tensor *tensor) const
+{
+  return mio::circle::tensor_type(tensor);
+}
+
 bool Reader::select_subgraph(uint32_t sgindex)
 {
   _subgraph_index = sgindex;


### PR DESCRIPTION
This will add helper methods to get tensor name and dtype.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>