### PR TITLE
[nnpackage_run] Support multiple raw output dump

### DIFF
--- a/tests/tools/nnpackage_run/src/rawformatter.cc
+++ b/tests/tools/nnpackage_run/src/rawformatter.cc
@@ -29,11 +29,13 @@ void RawFormatter::loadInputs(const std::string &filename, std::vector<Allocatio
   uint32_t num_inputs;
   NNPR_ENSURE_STATUS(nnfw_input_size(session_, &num_inputs));
 
-  // TODO: Support multiple inputs
+  // Support multiple inputs
   // Option 1: Get comman-separated input file list like --load:raw a,b,c
   // Option 2: Get prefix --load:raw in
   //           Internally access in.0, in.1, in.2, ... in.{N-1} where N is determined by nnfw info
   //           query api.
+  //
+  // Currently Option 2 is implemented.
   try
   {
     for (uint32_t i = 0; i < num_inputs; ++i)
@@ -72,12 +74,6 @@ void RawFormatter::dumpOutputs(const std::string &filename, std::vector<Allocati
 {
   uint32_t num_outputs;
   NNPR_ENSURE_STATUS(nnfw_output_size(session_, &num_outputs));
-  // TODO: Support multiple outputs
-  // Available options are same.
-  if (num_outputs != 1)
-  {
-    throw std::runtime_error("Only 1 output is supported for raw input");
-  }
   try
   {
     for (uint32_t i = 0; i < num_outputs; i++)


### PR DESCRIPTION
Multiple raw output dump is allowed.

Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

### For Reviewers

`multiout.q8` is an nnpackage with 2 outputs model.

```
$ tree multiout.q8
multiout.q8
├── metadata
│   └── MANIFEST
├── multiout.q8.circle
├── multiout.q8.expected.0
├── multiout.q8.expected.1
├── multiout.q8.in.0
└── multiout.q8.tvn
```

#### Before
```
$ BACKENDS="trix;cpu" ./Product/x86_64-linux.debug/out/bin/nnpackage_run \
--load:raw multiout.q8/multiout.q8.in \
--dump:raw multiout.q8/multiout.q8.out \
multiout.q8
...
E: Fail to run by runtime error:Only 1 output is supported for raw input
```

#### After
```
$ BACKENDS="trix;cpu" ./Product/x86_64-linux.debug/out/bin/nnpackage_run \
--load:raw multiout.q8/multiout.q8.in \
--dump:raw multiout.q8/multiout.q8.out \
multiout.q8
$ diff multiout.q8/multiout.q8.{out,expected}.0
$ echo $?
0
$ diff multiout.q8/multiout.q8{out,expected}.1
$ echo $?
0
```