### PR TITLE
[circle-quantizer] Support float32 input/output type

### DIFF
--- a/compiler/circle-quantizer/src/CircleQuantizer.cpp
+++ b/compiler/circle-quantizer/src/CircleQuantizer.cpp
@@ -158,9 +158,11 @@ int entry(int argc, char **argv)
           "Two arguments required: source_tensor_name(string), "
           "destination_tensor_name(string)");
 
-  arser.add_argument("--input_type").help("Input type of quantized model (uint8 or int16)");
+  arser.add_argument("--input_type")
+    .help("Input type of quantized model (uint8, int16, or float32)");
 
-  arser.add_argument("--output_type").help("Output type of quantized model (uint8 or int16)");
+  arser.add_argument("--output_type")
+    .help("Output type of quantized model (uint8, int16, or float32)");
 
   arser.add_argument(cfg).help("Path to the quantization configuration file");
 


### PR DESCRIPTION
This updates help message for float32 input/output type.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/8753
Draft PR: https://github.com/Samsung/ONE/pull/9030