### PR TITLE
[quantizer-dredd] Add mixed-quant test for ADD

### DIFF
--- a/compiler/circle-quantizer-dredd-recipe-test/test.lst
+++ b/compiler/circle-quantizer-dredd-recipe-test/test.lst
@@ -6,6 +6,8 @@
 
 ## TFLITE RECIPE
 
+Add(Quant_Add_001 DTYPE uint8 GRANULARITY channel USE_QCONFIG)
+Add(Quant_Add_002 DTYPE int16 GRANULARITY channel USE_QCONFIG)
 Add(Quant_Conv_Mul_Add_000 DTYPE uint8 GRANULARITY channel USE_QCONFIG)
 Add(Quant_Conv_Mul_Add_001 DTYPE uint8 GRANULARITY channel USE_QCONFIG)
 Add(Quant_Conv_Mul_Add_002 DTYPE uint8 GRANULARITY channel USE_QCONFIG)


### PR DESCRIPTION
This adds mixed-quant tests for ADD Op.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/9056
Draft PR: https://github.com/Samsung/ONE/pull/9057