### PR TITLE
[debian] Fix changelog trailer line

### DIFF
--- a/infra/debian/compiler/changelog
+++ b/infra/debian/compiler/changelog
@@ -19,7 +19,7 @@ one (1.20.0) bionic; urgency=medium
   * Drop support for TensorFlow 1.x
   * Fix for several bugs, performance enhancements, and typos
 
- -- seongwoo <mhs4670go@naver.com> Tue, 26 Apr 2022 12:00:00 +0900
+ -- seongwoo <mhs4670go@naver.com>  Tue, 26 Apr 2022 12:00:00 +0900
 
 one (1.19.0) bionic; urgency=medium
 


### PR DESCRIPTION
This commit fixes changelog trailer line.

```bash
dch: warning:     debian/changelog(l22): badly formatted trailer line
19:44:25  LINE:  -- seongwoo <mhs4670go@naver.com> Tue, 26 Apr 2022 12:00:00 +0900
```
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>