### PR TITLE
[infra] Revisit runtime build compiler version check

### DIFF
--- a/infra/nnfw/CMakeLists.txt
+++ b/infra/nnfw/CMakeLists.txt
@@ -55,6 +55,12 @@ macro(nnas_find_package PREFIX)
   )
 endmacro(nnas_find_package)
 
+# C++14 feature requires 5 or later
+# Using std::unordered_map shows build fail under 6.2
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 6.2)
+  message(FATAL "Runtime build requires GNU Compiler version 6.2 or later.")
+endif()
+
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_EXTENSIONS OFF)
 

--- a/infra/nnfw/cmake/buildtool/config/config_linux.cmake
+++ b/infra/nnfw/cmake/buildtool/config/config_linux.cmake
@@ -2,15 +2,9 @@
 # linux common compile options
 #
 
-# remove warning from arm cl
+# Remove warning: ignoring attributes on template argument (ACL, Eigen, etc)
 # https://github.com/ARM-software/ComputeLibrary/issues/330
-set(GCC_VERSION_DISABLE_WARNING 6.0)
-if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER GCC_VERSION_DISABLE_WARNING)
-  message(STATUS "GCC version higher than ${GCC_VERSION_DISABLE_WARNING}")
-  set(FLAGS_CXXONLY ${FLAGS_CXXONLY}
-      "-Wno-ignored-attributes"
-      )
-endif()
+set(FLAGS_CXXONLY ${FLAGS_CXXONLY} "-Wno-ignored-attributes")
 
 # Disable annoying ABI compatibility warning.
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.0)

--- a/infra/nnfw/cmake/packages/TensorFlowLite-1.13.1/TensorFlowLite/CMakeLists.txt
+++ b/infra/nnfw/cmake/packages/TensorFlowLite-1.13.1/TensorFlowLite/CMakeLists.txt
@@ -52,6 +52,14 @@ target_compile_definitions(tensorflow-lite PUBLIC "GEMMLOWP_ALLOW_SLOW_SCALAR_FA
 set_property(TARGET tensorflow-lite PROPERTY POSITION_INDEPENDENT_CODE ON)
 target_link_libraries(tensorflow-lite eigen-tf-1.13.1 flatbuffers::flatbuffers ${LIB_PTHREAD} dl)
 
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_BUILD_TYPE_LC STREQUAL "debug")
+  if(NEON2SSESource_FOUND AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9)
+    message(WARNING "GNU Compiler version under 9 is not supporting NEON2SSE debug build. "
+                    "Compiler will use O3 (release) build option as a workaround.")
+    target_compile_options(tensorflow-lite PRIVATE -O3 -DNDEBUG)
+  endif()
+endif()
+
 if(ANDROID)
   target_link_libraries(tensorflow-lite log)
   target_include_directories(tensorflow-lite PUBLIC "${NDK_DIR}/..")

--- a/tests/nnapi/CMakeLists.txt
+++ b/tests/nnapi/CMakeLists.txt
@@ -7,11 +7,6 @@ if (NOT BUILD_ONERT)
   return()
 endif(NOT BUILD_ONERT)
 
-# GCC Compiler under 6.2 is not support this test build
-if (CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 6.2)
-  return()
-endif()
-
 if (ANDROID_BOOST_ROOT)
   set(BOOST_ROOT ${ANDROID_BOOST_ROOT})
 endif (ANDROID_BOOST_ROOT)


### PR DESCRIPTION
This commit moves GNU compiler version check to root cmake
and remove redundant version checking on runtime build.

If NEON2SSE is used and GNU compiler version is under 9,
tensorflow lite build uses release build option (-O3).

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>