### PR TITLE
[infra/debian] Add onnx_legalizer to compiler

### DIFF
--- a/infra/debian/compiler/one-compiler.install
+++ b/infra/debian/compiler/one-compiler.install
@@ -24,6 +24,7 @@ usr/bin/one-quantize usr/share/one/bin/
 usr/bin/one-version usr/share/one/bin/
 usr/bin/onelib/constant.py usr/share/one/bin/onelib/
 usr/bin/onelib/make_cmd.py usr/share/one/bin/onelib/
+usr/bin/onnx_legalizer.py usr/share/one/bin/
 usr/bin/rawdata2hdf5 usr/share/one/bin/
 usr/bin/record-minmax usr/share/one/bin/
 usr/bin/tf2nnpkg usr/share/one/bin/


### PR DESCRIPTION
This will add onnx_legalizer script to compiler debian package list.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>