### PR TITLE
[circle-partitioner] Fix README

### DIFF
--- a/compiler/circle-partitioner/README.md
+++ b/compiler/circle-partitioner/README.md
@@ -171,7 +171,7 @@ Consider partitioning with backends of OneRT
 
 Let's try with this command:
 ```
-circle_partitioner \
+circle-partitioner \
    --partition Net_InstanceNorm_003.part \
    --backends cpu,acl_cl \
    --default cpu \


### PR DESCRIPTION
This will fix README file with circle-partitioner name.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>