### PR TITLE
[onert] Move core/util unittest

### DIFF
--- a/runtime/onert/core/CMakeLists.txt
+++ b/runtime/onert/core/CMakeLists.txt
@@ -48,6 +48,8 @@ set(TEST_ONERT_CORE test_onert_core)
 add_executable(${TEST_ONERT_CORE} ${TESTS})
 
 target_link_libraries(${TEST_ONERT_CORE} onert_core)
+# Requires linking nnfw_coverage: check header coverage
+target_link_libraries(${TEST_ONERT_CORE} nnfw_coverage)
 target_link_libraries(${TEST_ONERT_CORE} gtest gtest_main dl ${LIB_PTHREAD})
 
 add_test(${TEST_ONERT_CORE} ${TEST_ONERT_CORE})

--- a/runtime/onert/core/include/util/ObjectManager.h
+++ b/runtime/onert/core/include/util/ObjectManager.h
@@ -17,14 +17,13 @@
 #ifndef __ONERT_UTIL_OBJECT_MANAGER_H__
 #define __ONERT_UTIL_OBJECT_MANAGER_H__
 
-#include <unordered_map>
-#include <memory>
-#include <list>
-#include <functional>
-
-#include <memory>
-
 #include "util/logging.h"
+
+#include <cassert>
+#include <functional>
+#include <list>
+#include <memory>
+#include <unordered_map>
 
 namespace onert
 {

--- a/runtime/onert/core/src/util/Index.test.cc
+++ b/runtime/onert/core/src/util/Index.test.cc
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#include <gtest/gtest.h>
-
 #include "util/Index.h"
+
+#include <gtest/gtest.h>
 
 using Index = ::onert::util::Index<uint32_t, struct TestTag>;
 

--- a/runtime/onert/core/src/util/ObjectManager.test.cc
+++ b/runtime/onert/core/src/util/ObjectManager.test.cc
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-#include <gtest/gtest.h>
-
-#include "util/ObjectManager.h"
 #include "util/Index.h"
+#include "util/ObjectManager.h"
+
+#include <gtest/gtest.h>
 
 using namespace onert;
 

--- a/runtime/onert/core/src/util/ShapeInference.test.cc
+++ b/runtime/onert/core/src/util/ShapeInference.test.cc
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-#include <gtest/gtest.h>
-
-#include "ir/Layout.h"
 #include "util/ShapeInference.h"
+
+#include <gtest/gtest.h>
 
 using namespace onert::ir;
 


### PR DESCRIPTION
This commit moves core/util unittest into "core/src/util".

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue; #9063