### PR TITLE
[one-cmds] Add 'save-allocations' codegen option

### DIFF
--- a/compiler/one-cmds/one-codegen
+++ b/compiler/one-cmds/one-codegen
@@ -90,6 +90,8 @@ def _get_parser(backends_list):
             backends_name) + ')'
     backend_help_message = 'backend name to use ' + backends_name_message
     parser.add_argument('-b', '--backend', type=str, help=backend_help_message)
+    parser.add_argument('--save-allocations', action='store_true',
+        help='save memory allocations trace for supported backends')
 
     return parser
 
@@ -126,6 +128,9 @@ def _parse_arg(parser):
     # print version
     if len(args) and codegen_args.version:
         _utils._print_version_and_exit(__file__)
+
+    if codegen_args.save_allocations:
+        backend_args.append('--save-allocations')
 
     return codegen_args, backend_args, unknown_args
 


### PR DESCRIPTION
This commit adds 'save-allocations' optional codegen argument which passes this option into codegen backends with allocation trace export support.

Issue: #8723 
ONE-vscode issue: https://github.com/Samsung/ONE-vscode/issues/395 (viewer implementation for allocation trace files)

NOTE: During discussion in #8723 it was stated that 'visualization' solution for memory allocation is outside of ONE's scope, so visualizer implementation task was moved into ONE-vscode (active PR: https://github.com/Samsung/ONE-vscode/pull/483).

Support in ONE is currently limited to `save-allocations` option support (which can be either passed as an argument or config entry) which is implemented in this PR.