### PR TITLE
[circle-eval-diff] Add creating empty tensor method

### DIFF
--- a/compiler/circle-eval-diff/src/Tensor.h
+++ b/compiler/circle-eval-diff/src/Tensor.h
@@ -18,6 +18,7 @@
 #define __CIRCLE_EVAL_DIFF_TENSOR_H__
 
 #include <loco.h>
+#include <luci/IR/CircleNodeDecl.h>
 
 #include <vector>
 
@@ -75,6 +76,8 @@ public:
 private:
   std::vector<uint8_t> _data;
 };
+
+std::shared_ptr<Tensor> createEmptyTensor(const luci::CircleNode *node);
 
 } // namespace circle_eval_diff
 

--- a/compiler/circle-eval-diff/src/Tensor.test.cpp
+++ b/compiler/circle-eval-diff/src/Tensor.test.cpp
@@ -18,6 +18,8 @@
 
 #include <gtest/gtest.h>
 
+#include <luci/IR/CircleNodes.h>
+
 using Tensor = circle_eval_diff::Tensor;
 
 namespace
@@ -98,4 +100,30 @@ TEST(CircleEvalDiffTensorTest, out_of_buffer_range_NEG)
   test_out_of_buffer_range<loco::DataType::FLOAT32>();
 
   SUCCEED();
+}
+
+TEST(CircleEvalDiffTensorTest, createEmptyTensorTest)
+{
+  luci::CircleInput input;
+  input.dtype(loco::DataType::FLOAT32);
+  input.rank(4);
+  input.dim(0).set(1);
+  input.dim(1).set(3);
+  input.dim(2).set(3);
+  input.dim(3).set(2);
+
+  loco::DataType right_data_type{loco::DataType::FLOAT32};
+  std::vector<loco::Dimension> right_shape;
+  right_shape.emplace_back(1);
+  right_shape.emplace_back(3);
+  right_shape.emplace_back(3);
+  right_shape.emplace_back(2);
+
+  auto tensor = circle_eval_diff::createEmptyTensor(&input);
+  EXPECT_EQ(loco::DataType::FLOAT32, tensor->dtype());
+  EXPECT_EQ(4, tensor->rank());
+  EXPECT_EQ(1, tensor->dim(0));
+  EXPECT_EQ(3, tensor->dim(1));
+  EXPECT_EQ(3, tensor->dim(2));
+  EXPECT_EQ(2, tensor->dim(3));
 }


### PR DESCRIPTION
This commit adds createEmptyTensor method that literally creates empty tensor from existing CircleNode.

This function is from `compiler/circle-eval-diff/src/CircleEvalDiff.cpp` that will be removed soon.

Draft: https://github.com/Samsung/ONE/pull/8830
Related: https://github.com/Samsung/ONE/issues/8829
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>