### PR TITLE
[circle-eval-diff] Use Input data loader

### DIFF
--- a/compiler/circle-eval-diff/driver/Driver.cpp
+++ b/compiler/circle-eval-diff/driver/Driver.cpp
@@ -15,7 +15,6 @@
  */
 
 #include "CircleEvalDiff.h"
-#include "InputDataLoader.h"
 
 #include <arser/arser.h>
 #include <vconone/vconone.h>
@@ -141,6 +140,8 @@ int entry(const int argc, char **argv)
   {
     ctx->first_model_path = first_model_path;
     ctx->second_model_path = second_model_path;
+    ctx->first_input_data_path = first_input_data_path;
+    ctx->second_input_data_path = second_input_data_path;
     ctx->metric = metrics;
     ctx->input_format = to_input_format(input_data_format);
     ctx->output_prefix = output_prefix;
@@ -150,12 +151,7 @@ int entry(const int argc, char **argv)
 
   ced.init();
 
-  auto first_input_loader = circle_eval_diff::makeDataLoader(
-    first_input_data_path, to_input_format(input_data_format), ced.first_module_inputs());
-  auto second_input_loader = circle_eval_diff::makeDataLoader(
-    second_input_data_path, to_input_format(input_data_format), ced.second_module_inputs());
-
-  ced.evalDiff(first_input_loader.get(), second_input_loader.get());
+  ced.evalDiff();
 
   return EXIT_SUCCESS;
 }

--- a/compiler/circle-eval-diff/driver/Driver.cpp
+++ b/compiler/circle-eval-diff/driver/Driver.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "CircleEvalDiff.h"
+#include "InputDataLoader.h"
 
 #include <arser/arser.h>
 #include <vconone/vconone.h>
@@ -149,7 +150,12 @@ int entry(const int argc, char **argv)
 
   ced.init();
 
-  ced.evalDiff(first_input_data_path, second_input_data_path);
+  auto first_input_loader = circle_eval_diff::makeDataLoader(
+    first_input_data_path, to_input_format(input_data_format), ced.first_module_inputs());
+  auto second_input_loader = circle_eval_diff::makeDataLoader(
+    second_input_data_path, to_input_format(input_data_format), ced.second_module_inputs());
+
+  ced.evalDiff(first_input_loader.get(), second_input_loader.get());
 
   return EXIT_SUCCESS;
 }

--- a/compiler/circle-eval-diff/include/CircleEvalDiff.h
+++ b/compiler/circle-eval-diff/include/CircleEvalDiff.h
@@ -20,8 +20,12 @@
 #include <luci/IR/Module.h>
 #include <luci_interpreter/Interpreter.h>
 
+#include "InputDataLoader.h"
+#include "MetricPrinter.h"
+
 #include <string>
 #include <memory>
+#include <vector>
 
 namespace circle_eval_diff
 {
@@ -35,13 +39,6 @@ enum class Metric
   MAE,       // Mean Absolute Error
   MAPE,      // Mean Percentage Absolute Error
   MPEIR,     // Mean Peak Error to Interval Ratio
-};
-
-enum class InputFormat
-{
-  Undefined, // For debugging
-  H5,
-  // TODO Implement Random, Directory
 };
 
 class CircleEvalDiff final
@@ -64,12 +61,17 @@ public:
   void init();
 
   // Evaluate two circle models for the given input data and compare the results
-  void evalDiff(const std::string &first_input_data_path,
-                const std::string &second_input_data_path) const;
+  void evalDiff(const InputDataLoader *first, const InputDataLoader *second) const;
+
+public:
+  const std::vector<loco::Node *> first_module_inputs(void) const;
+  const std::vector<loco::Node *> second_module_inputs(void) const;
 
 private:
   std::unique_ptr<Context> _ctx;
-  std::unique_ptr<ModuleEvalDiff> _runner;
+  std::unique_ptr<luci::Module> _first_module;
+  std::unique_ptr<luci::Module> _second_module;
+  std::vector<std::unique_ptr<MetricPrinter>> _metrics;
 };
 
 } // namespace circle_eval_diff

--- a/compiler/circle-eval-diff/include/CircleEvalDiff.h
+++ b/compiler/circle-eval-diff/include/CircleEvalDiff.h
@@ -48,6 +48,8 @@ public:
   {
     std::string first_model_path;
     std::string second_model_path;
+    std::string first_input_data_path;
+    std::string second_input_data_path;
     std::vector<Metric> metric;
     InputFormat input_format = InputFormat::Undefined;
     std::string output_prefix;
@@ -61,11 +63,7 @@ public:
   void init();
 
   // Evaluate two circle models for the given input data and compare the results
-  void evalDiff(const InputDataLoader *first, const InputDataLoader *second) const;
-
-public:
-  const std::vector<loco::Node *> first_module_inputs(void) const;
-  const std::vector<loco::Node *> second_module_inputs(void) const;
+  void evalDiff(void) const;
 
 private:
   std::unique_ptr<Context> _ctx;

--- a/compiler/circle-eval-diff/src/CircleEvalDiff.cpp
+++ b/compiler/circle-eval-diff/src/CircleEvalDiff.cpp
@@ -15,8 +15,8 @@
  */
 
 #include "CircleEvalDiff.h"
-#include "ModuleEvalDiff.h"
 #include "MetricPrinter.h"
+#include "Tensor.h"
 
 #include <foder/FileLoader.h>
 #include <luci/Importer.h>
@@ -48,33 +48,76 @@ std::unique_ptr<luci::Module> import(const std::string &model_path)
   return module;
 }
 
+const std::vector<loco::Node *> inputs_of(const luci::Module *module)
+{
+  return loco::input_nodes(module->graph());
+}
+
+const std::vector<loco::Node *> outputs_of(const luci::Module *module)
+{
+  return loco::output_nodes(module->graph());
+}
+
+void writeDataToFile(const std::string &filename, const char *data, size_t data_size)
+{
+  std::ofstream fs(filename, std::ofstream::binary);
+  if (fs.fail())
+    throw std::runtime_error("Cannot open file \"" + filename + "\".\n");
+  if (fs.write(data, data_size).fail())
+  {
+    throw std::runtime_error("Failed to write data to file \"" + filename + "\".\n");
+  }
+}
+
 } // namespace
 
 namespace circle_eval_diff
 {
 
-CircleEvalDiff::CircleEvalDiff(std::unique_ptr<Context> &&ctx)
-  : _ctx(std::move(ctx)), _runner(nullptr)
+std::vector<std::shared_ptr<Tensor>> interpret(const luci::Module *module,
+                                               const InputDataLoader::Data &data)
 {
+  auto interpreter = std::make_unique<luci_interpreter::Interpreter>(module);
+
+  auto input_nodes = ::inputs_of(module);
+  auto output_nodes = ::outputs_of(module);
+
+  for (uint32_t input_idx = 0; input_idx < data.size(); input_idx++)
+  {
+    auto input_node = loco::must_cast<const luci::CircleInput *>(input_nodes[input_idx]);
+    assert(input_node->index() == input_idx);
+
+    auto input_data = data.at(input_idx);
+    interpreter->writeInputTensor(input_node, input_data.buffer(), input_data.byte_size());
+  }
+
+  interpreter->interpret();
+
+  std::vector<std::shared_ptr<Tensor>> outputs;
+  for (uint32_t output_idx = 0; output_idx < output_nodes.size(); output_idx++)
+  {
+    auto output_node = loco::must_cast<const luci::CircleOutput *>(output_nodes[output_idx]);
+    assert(output_node->index() == output_idx);
+
+    auto tensor = createEmptyTensor(output_node);
+    interpreter->readOutputTensor(output_node, tensor->buffer(), tensor->byte_size());
+    outputs.emplace_back(tensor);
+  }
+
+  return outputs;
+}
+
+CircleEvalDiff::CircleEvalDiff(std::unique_ptr<Context> &&ctx) : _ctx(std::move(ctx))
+{
+  // DO NOTHING
 }
 
 CircleEvalDiff::~CircleEvalDiff() = default;
 
 void CircleEvalDiff::init()
 {
-  auto first_module = import(_ctx->first_model_path);
-  auto second_module = import(_ctx->second_model_path);
-
-  // Set runner
-  switch (_ctx->input_format)
-  {
-    case InputFormat::H5:
-      _runner =
-        std::make_unique<H5InputEvalDiff>(std::move(first_module), std::move(second_module));
-      break;
-    default:
-      throw std::runtime_error("Unsupported input format.");
-  }
+  _first_module = import(_ctx->first_model_path);
+  _second_module = import(_ctx->second_model_path);
 
   // Set metric
   std::unique_ptr<MetricPrinter> metric;
@@ -83,24 +126,77 @@ void CircleEvalDiff::init()
     switch (metric)
     {
       case Metric::MAE:
-        _runner->registerMetric(std::make_unique<MAEPrinter>());
+      {
+        _metrics.emplace_back(std::make_unique<MAEPrinter>());
         break;
+      }
       case Metric::MAPE:
-        _runner->registerMetric(std::make_unique<MAPEPrinter>());
+      {
+        _metrics.emplace_back(std::make_unique<MAPEPrinter>());
         break;
+      }
       case Metric::MPEIR:
-        _runner->registerMetric(std::make_unique<MPEIRPrinter>());
+      {
+        _metrics.emplace_back(std::make_unique<MPEIRPrinter>());
         break;
+      }
       default:
         throw std::runtime_error("Unsupported metric.");
     }
+    _metrics.back()->init(_first_module.get(), _second_module.get());
   }
 }
 
-void CircleEvalDiff::evalDiff(const std::string &first_input_data_path,
-                              const std::string &second_input_data_path) const
+void CircleEvalDiff::evalDiff(const InputDataLoader *first, const InputDataLoader *second) const
 {
-  _runner->evalDiff(first_input_data_path, second_input_data_path, _ctx->output_prefix);
+  for (uint32_t data_idx = 0; data_idx < first->size(); data_idx++)
+  {
+    std::cout << "Evaluating " << data_idx << "'th data" << std::endl;
+
+    auto first_data = first->get(data_idx);
+    auto second_data = second->get(data_idx);
+
+    auto first_output = interpret(_first_module.get(), first_data);
+    auto second_output = interpret(_second_module.get(), second_data);
+
+    for (auto &metric : _metrics)
+    {
+      metric->accumulate(first_output, second_output);
+    }
+
+    if (_ctx.get()->output_prefix.empty())
+      continue;
+
+    for (uint32_t i = 0; i < first_output.size(); i++)
+    {
+      auto out = first_output[i];
+      writeDataToFile(_ctx.get()->output_prefix + "." + std::to_string(data_idx) + ".first.output" +
+                        std::to_string(i),
+                      (char *)(out->buffer()), out->byte_size());
+    }
+    for (uint32_t i = 0; i < second_output.size(); i++)
+    {
+      auto out = second_output[i];
+      writeDataToFile(_ctx.get()->output_prefix + "." + std::to_string(data_idx) +
+                        ".second.output" + std::to_string(i),
+                      (char *)(out->buffer()), out->byte_size());
+    }
+  }
+
+  for (auto &metric : _metrics)
+  {
+    std::cout << metric.get() << std::endl;
+  }
+}
+
+const std::vector<loco::Node *> CircleEvalDiff::first_module_inputs(void) const
+{
+  return loco::input_nodes(_first_module->graph());
+}
+
+const std::vector<loco::Node *> CircleEvalDiff::second_module_inputs(void) const
+{
+  return loco::input_nodes(_second_module->graph());
 }
 
 } // namespace circle_eval_diff


### PR DESCRIPTION
This commit makes driver use input data loader.

Draft: https://github.com/Samsung/ONE/pull/8830
Related: https://github.com/Samsung/ONE/issues/8829
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>