### PR TITLE
Fix false no asserion in TCA

### DIFF
--- a/compiler/arser/tests/arser.test.cpp
+++ b/compiler/arser/tests/arser.test.cpp
@@ -257,6 +257,7 @@ TEST(BasicTest, ExitWithFunctionCallWithLamda)
   test::Prompt prompt("./computer --shutdown");
   /* act */ /* assert */
   EXPECT_EXIT(arser.parse(prompt.argc(), prompt.argv()), testing::ExitedWithCode(0), "Good bye..");
+  SUCCEED();
 }
 
 TEST(BasicTest, DefaultValue)


### PR DESCRIPTION
by adding redundant SUCCEED

ONE-DCO-1.0-Signed-off-by: Chunseok Lee <chunseok.lee@samsung.com>