### PR TITLE
[onert] Remove core private include

### DIFF
--- a/runtime/onert/core/CMakeLists.txt
+++ b/runtime/onert/core/CMakeLists.txt
@@ -6,8 +6,13 @@ nnfw_find_package(Ruy REQUIRED)
 
 add_library(onert_core SHARED ${SOURCES})
 set_target_properties(onert_core PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+# NOTE
+# We publish public headers into developer package.
+# To avoid mistake using private header in public header, do not define
+# private target_include_directories scope for src/ directory.
 target_include_directories(onert_core PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
-target_include_directories(onert_core PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
+
 target_link_libraries(onert_core PUBLIC nnfw_lib_misc half)
 target_link_libraries(onert_core PRIVATE nnfw_lib_cker)
 target_link_libraries(onert_core PRIVATE nnfw_common)

--- a/runtime/onert/core/src/backend/builtin/KernelGenerator.cc
+++ b/runtime/onert/core/src/backend/builtin/KernelGenerator.cc
@@ -16,12 +16,10 @@
 
 #include "KernelGenerator.h"
 
-#include <backend/BackendContext.h>
-#include <util/Utils.h>
 #include "kernel/IfLayer.h"
-#include "kernel/WhileLayer.h"
 #include "kernel/PermuteLayer.h"
-#include "exec/ExecutorBase.h"
+#include "kernel/WhileLayer.h"
+
 #include "exec/FunctionSequence.h"
 
 namespace onert

--- a/runtime/onert/core/src/backend/builtin/KernelGenerator.h
+++ b/runtime/onert/core/src/backend/builtin/KernelGenerator.h
@@ -17,13 +17,14 @@
 #ifndef __ONERT_BACKEND_BUILTIN_KERNEL_GENERATOR_H__
 #define __ONERT_BACKEND_BUILTIN_KERNEL_GENERATOR_H__
 
-#include "exec/IExecutor.h"
+#include "DynamicTensorManager.h"
 #include "ExternalContext.h"
-#include "ir/Graph.h"
-#include "TensorBuilder.h"
-#include "compiler/TensorRegistries.h"
-#include "backend/basic/KernelGeneratorBase.h"
 #include "TensorRegistry.h"
+#include "../../compiler/TensorRegistries.h"
+
+#include "backend/basic/KernelGeneratorBase.h"
+#include "exec/IExecutor.h"
+#include "ir/Graph.h"
 
 namespace onert
 {

--- a/runtime/onert/core/src/backend/builtin/kernel/IfLayer.cc
+++ b/runtime/onert/core/src/backend/builtin/kernel/IfLayer.cc
@@ -16,10 +16,6 @@
 
 #include "IfLayer.h"
 
-#include <backend/ITensor.h>
-#include "exec/ExecutorBase.h"
-#include "PermuteLayer.h"
-
 namespace onert
 {
 namespace backend

--- a/runtime/onert/core/src/backend/builtin/kernel/PermuteLayer.cc
+++ b/runtime/onert/core/src/backend/builtin/kernel/PermuteLayer.cc
@@ -16,9 +16,9 @@
 
 #include "PermuteLayer.h"
 
-#include "exec/ShapeConverter.h"
+#include "../../../exec/ShapeConverter.h"
 
-#include "ruy/context.h" // from @ruy
+#include <ruy/context.h> // from @ruy
 
 namespace onert
 {

--- a/runtime/onert/core/src/backend/builtin/kernel/PermuteLayer.h
+++ b/runtime/onert/core/src/backend/builtin/kernel/PermuteLayer.h
@@ -17,10 +17,10 @@
 #ifndef __ONERT_BACKEND_BUILTIN_KERNEL_PERMUTELAYER_H__
 #define __ONERT_BACKEND_BUILTIN_KERNEL_PERMUTELAYER_H__
 
-#include "exec/IPermuteFunction.h"
-#include "exec/IExecutor.h"
 #include "../ExternalContext.h"
-#include "ruy/thread_pool.h" // from @ruy
+#include "../../../exec/IPermuteFunction.h"
+
+#include <ruy/thread_pool.h> // from @ruy
 
 namespace onert
 {

--- a/runtime/onert/core/src/backend/builtin/kernel/WhileLayer.cc
+++ b/runtime/onert/core/src/backend/builtin/kernel/WhileLayer.cc
@@ -16,11 +16,12 @@
 
 #include "WhileLayer.h"
 
-#include <algorithm>
-#include <backend/ITensor.h>
-#include "exec/ExecutorBase.h"
-#include <misc/polymorphic_downcast.h>
 #include "PermuteLayer.h"
+#include "../../../exec/ExecutorBase.h"
+
+#include <misc/polymorphic_downcast.h>
+
+#include <algorithm>
 
 namespace onert
 {

--- a/runtime/onert/core/src/compiler/BackendManager.cc
+++ b/runtime/onert/core/src/compiler/BackendManager.cc
@@ -16,16 +16,11 @@
 
 #include "compiler/BackendManager.h"
 
-#include <memory>
-#include <dlfcn.h>
+#include "../backend/builtin/Backend.h"
+#include "../backend/builtin/Config.h"
 
-#include "backend/Backend.h"
-#include "backend/builtin/Backend.h"
-#include "backend/builtin/Config.h"
-#include "backend/IConfig.h"
-#include "util/logging.h"
-#include "util/ConfigSource.h"
-#include "misc/string_helpers.h"
+#include <dlfcn.h>
+#include <memory>
 
 static const char *SHARED_LIB_EXT =
 #if defined(__APPLE__) && defined(__MACH__)

--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -18,29 +18,26 @@
 
 #include "ExecutorFactory.h"
 #include "ShapeValidator.h"
+#include "pass/ConstantOutputPass.h"
+#include "pass/OddOutputPass.h"
+#include "pass/PassRunner.h"
+#include "pass/UnusedOperandEliminationPass.h"
+#include "../backend/builtin/Config.h"
+#include "../dumper/dot/DotDumper.h"
+#include "../interp/InterpExecutor.h"
+#include "../ir/OperationCloner.h"
+#include "../ir/OperationDumper.h"
+#include "../ir/verifier/Verifier.h"
 
-#include <backend/builtin/Config.h>
-#include "compiler/BackendManager.h"
-#include "compiler/IScheduler.h"
-#include "compiler/ManualScheduler.h"
-#include "compiler/HEScheduler.h"
 #include "compiler/StaticShapeInferer.h"
-#include "compiler/OperationLowerInfo.h"
-#include "compiler/pass/ConstantOutputPass.h"
-#include "compiler/pass/OddOutputPass.h"
-#include "compiler/pass/PassRunner.h"
-#include "compiler/pass/UnusedOperandEliminationPass.h"
-#include "exec/ExecTime.h"
-#include "ir/verifier/Verifier.h"
-#include "dumper/dot/DotDumper.h"
-#include "compiler/Linear.h"
-#include "interp/InterpExecutor.h"
 #include "util/ConfigSource.h"
 #include "util/logging.h"
-#include "ir/OperationDumper.h"
-#include "ir/OperationCloner.h"
-#include "misc/string_helpers.h"
-#include "json/json.h"
+
+#include <misc/string_helpers.h>
+#include <json/json.h>
+
+// TODO Remove using fstream header
+#include <fstream>
 
 namespace
 {

--- a/runtime/onert/core/src/compiler/HEScheduler.cc
+++ b/runtime/onert/core/src/compiler/HEScheduler.cc
@@ -14,17 +14,14 @@
  * limitations under the License.
  */
 
-#include "ir/Operand.h"
-#include "compiler/HEScheduler.h"
-#include "ir/Graph.h"
-#include "util/ConfigSource.h"
+#include "HEScheduler.h"
+
 #include "compiler/BackendResolver.h"
+#include "ir/Graph.h"
 #include "util/logging.h"
-#include "util/Utils.h"
-#include "exec/FunctionSequence.h"
+
 #include <cassert>
 #include <cmath>
-#include <chrono>
 
 namespace
 {

--- a/runtime/onert/core/src/compiler/Linear.cc
+++ b/runtime/onert/core/src/compiler/Linear.cc
@@ -14,15 +14,13 @@
  * limitations under the License.
  */
 
-#include <algorithm>
-#include <sstream>
-
 #include "Linear.h"
 
-#include "backend/IConfig.h"
-#include "backend/Backend.h"
+#include "../dumper/text/GraphDumper.h"
+
 #include "util/logging.h"
-#include "dumper/text/GraphDumper.h"
+
+#include <sstream>
 
 namespace onert
 {

--- a/runtime/onert/core/src/compiler/LoweredGraph.cc
+++ b/runtime/onert/core/src/compiler/LoweredGraph.cc
@@ -16,24 +16,23 @@
 
 #include "compiler/LoweredGraph.h"
 
-#include <assert.h>
-#include <algorithm>
-#include <sstream>
-#include "util/logging.h"
-#include "compiler/pass/ConstantInsertionPass.h"
-#include "compiler/pass/ConstantLoweringPass.h"
-#include "compiler/pass/PassRunner.h"
-#include "compiler/pass/PermutationOperationPass.h"
-#include "compiler/pass/PermutationInsertionPass.h"
-#include "compiler/pass/PermutationEliminationPass.h"
-#include "dumper/text/GraphDumper.h"
-#include "ir/verifier/Verifier.h"
+#include "HEScheduler.h"
+#include "ManualScheduler.h"
+#include "pass/ConstantInsertionPass.h"
+#include "pass/ConstantLoweringPass.h"
+#include "pass/PassRunner.h"
+#include "pass/PermutationEliminationPass.h"
+#include "pass/PermutationInsertionPass.h"
+#include "pass/PermutationOperationPass.h"
+#include "../dumper/text/GraphDumper.h"
+#include "../ir/verifier/Verifier.h"
+
 #include "backend/Backend.h"
-#include "backend/IConfig.h"
 #include "compiler/BackendResolver.h"
-#include "compiler/ManualScheduler.h"
-#include "compiler/HEScheduler.h"
-#include "util/TracingCtx.h"
+#include "util/logging.h"
+
+#include <cassert>
+#include <sstream>
 
 namespace onert
 {

--- a/runtime/onert/core/src/compiler/TensorRegistries.h
+++ b/runtime/onert/core/src/compiler/TensorRegistries.h
@@ -17,13 +17,14 @@
 #ifndef __ONERT_COMPILER_TENSOR_REGISTRIES_H__
 #define __ONERT_COMPILER_TENSOR_REGISTRIES_H__
 
-#include <unordered_set>
-#include <memory>
-#include "backend/BackendContext.h"
+#include "../backend/builtin/Config.h"
+#include "../backend/builtin/TensorRegistry.h"
+
 #include "backend/Backend.h"
-#include "backend/builtin/Config.h"
-#include "backend/builtin/TensorBuilder.h"
-#include "backend/builtin/TensorRegistry.h"
+#include "backend/BackendContext.h"
+
+#include <memory>
+#include <unordered_set>
 
 namespace onert
 {

--- a/runtime/onert/core/src/compiler/pass/PermutationEliminationPass.cc
+++ b/runtime/onert/core/src/compiler/pass/PermutationEliminationPass.cc
@@ -15,7 +15,6 @@
  */
 
 #include "PermutationEliminationPass.h"
-#include "backend/builtin/Config.h"
 
 #include "util/logging.h"
 

--- a/runtime/onert/core/src/compiler/pass/PermutationInsertionPass.cc
+++ b/runtime/onert/core/src/compiler/pass/PermutationInsertionPass.cc
@@ -17,18 +17,16 @@
 
 #include "PermutationInsertionPass.h"
 
-#include <cassert>
-#include <utility>
-#include <unordered_map>
+#include "../../backend/builtin/Config.h"
 
-#include "backend/builtin/Config.h"
-#include "ir/Operand.h"
 #include "compiler/OperationLowerInfo.h"
-#include "ir/Graph.h"
-#include "backend/IConfig.h"
-#include "util/logging.h"
-#include <memory>
 #include "ir/operation/Permute.h"
+#include "util/logging.h"
+
+#include <cassert>
+#include <memory>
+#include <unordered_map>
+#include <utility>
 
 namespace onert
 {

--- a/runtime/onert/core/src/exec/DataflowExecutor.h
+++ b/runtime/onert/core/src/exec/DataflowExecutor.h
@@ -17,18 +17,17 @@
 #ifndef __ONERT_EXEC_DATAFLOW_EXECUTOR_H__
 #define __ONERT_EXEC_DATAFLOW_EXECUTOR_H__
 
+#include "ExecutorBase.h"
+#include "Job.h"
+
+#include "compiler/CodeMap.h"
+#include "ir/OperandIndexSequence.h"
+#include "util/TracingCtx.h"
+
 #include <list>
 #include <map>
-#include <unordered_map>
-
-#include "exec/FunctionSequence.h"
-#include "Job.h"
-#include "ir/OperandIndexSequence.h"
-#include "ir/Index.h"
 #include <memory>
-#include "exec/ExecutorBase.h"
-#include "compiler/CodeMap.h"
-#include "util/TracingCtx.h"
+#include <unordered_map>
 
 namespace onert
 {

--- a/runtime/onert/core/src/exec/ExecTime.cc
+++ b/runtime/onert/core/src/exec/ExecTime.cc
@@ -14,12 +14,10 @@
  * limitations under the License.
  */
 
-#include "exec/ExecTime.h"
+#include "ExecTime.h"
 
-#include <fstream>
-#include <cassert>
-#include <limits>
 #include <algorithm>
+#include <cassert>
 
 namespace onert
 {

--- a/runtime/onert/core/src/exec/ExecutionObservee.h
+++ b/runtime/onert/core/src/exec/ExecutionObservee.h
@@ -17,10 +17,11 @@
 #ifndef __ONERT_EXEC_EXECUTION_OBSERVEE_H__
 #define __ONERT_EXEC_EXECUTION_OBSERVEE_H__
 
-#include <list>
+#include "ExecutionObservers.h"
 
-#include "exec/ExecutionObservers.h"
 #include "ir/Index.h"
+
+#include <list>
 
 namespace onert
 {

--- a/runtime/onert/core/src/exec/ExecutionObservers.cc
+++ b/runtime/onert/core/src/exec/ExecutionObservers.cc
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
-#include "exec/ExecutionObservers.h"
+#include "ExecutionObservers.h"
+
+#include "../util/EventWriter.h"
+
+#include "util/logging.h"
+
+#include <misc/polymorphic_downcast.h>
 
 #include <string>
 #include <sstream>
-
-#include "util/logging.h"
-#include "exec/IExecutor.h"
-#include "misc/polymorphic_downcast.h"
-#include "ir/Operation.h"
-#include "util/EventWriter.h"
 
 namespace
 {

--- a/runtime/onert/core/src/exec/ExecutionObservers.h
+++ b/runtime/onert/core/src/exec/ExecutionObservers.h
@@ -17,17 +17,16 @@
 #ifndef __ONERT_EXEC_OBSREVERS_H__
 #define __ONERT_EXEC_OBSREVERS_H__
 
-#include "exec/IFunction.h"
+#include "ExecTime.h"
+#include "../util/EventCollector.h"
+#include "../util/EventRecorder.h"
+#include "../util/EventWriter.h"
+
+#include "exec/IExecutor.h"
 #include "ir/Index.h"
 #include "ir/Operation.h"
-#include "ExecTime.h"
 #include "util/ITimer.h"
-#include "exec/IExecutor.h"
-#include "util/EventCollector.h"
-#include "util/EventRecorder.h"
-#include "util/EventWriter.h"
 #include "util/TracingCtx.h"
-#include "util/EventWriter.h"
 
 namespace onert
 {

--- a/runtime/onert/core/src/exec/ExecutorBase.cc
+++ b/runtime/onert/core/src/exec/ExecutorBase.cc
@@ -15,11 +15,10 @@
  */
 
 #include "ExecutorBase.h"
+
 #include "ShapeConverter.h"
 
-#include "backend/builtin/UserTensor.h"
-#include "util/logging.h"
-#include "misc/polymorphic_downcast.h"
+#include <misc/polymorphic_downcast.h>
 
 namespace onert
 {

--- a/runtime/onert/core/src/exec/ExecutorBase.h
+++ b/runtime/onert/core/src/exec/ExecutorBase.h
@@ -17,22 +17,17 @@
 #ifndef __ONERT_EXEC_EXECUTOR_BASE_H__
 #define __ONERT_EXEC_EXECUTOR_BASE_H__
 
-#include "IPermuteFunction.h"
+#include "ExecutionObservee.h"
+#include "../backend/builtin/IOTensor.h"
+#include "../compiler/TensorRegistries.h"
+
+#include "compiler/LoweredGraph.h"
 #include "exec/IExecutor.h"
-#include "exec/ExecTime.h"
-#include "exec/ExecutionObservee.h"
-#include "exec/IFunction.h"
 #include "exec/IODescription.h"
 #include "ir/Graph.h"
-#include "ir/Index.h"
-#include "compiler/GraphLowerInfo.h"
 #include "ir/OperationIndexMap.h"
-#include "compiler/LoweredGraph.h"
-#include "compiler/TensorRegistries.h"
-#include "backend/builtin/IOTensor.h"
 #include "util/TracingCtx.h"
 
-#include <cstdint>
 #include <memory>
 #include <mutex>
 #include <vector>

--- a/runtime/onert/core/src/exec/JSONExecTime.cc
+++ b/runtime/onert/core/src/exec/JSONExecTime.cc
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#include "exec/JSONExecTime.h"
-#include "backend/IConfig.h"
+#include "JSONExecTime.h"
+
 #include <fstream>
 
 namespace onert

--- a/runtime/onert/core/src/exec/LinearExecutor.h
+++ b/runtime/onert/core/src/exec/LinearExecutor.h
@@ -22,11 +22,10 @@
 #ifndef __ONERT_EXEC_EXECUTOR_H_
 #define __ONERT_EXEC_EXECUTOR_H_
 
-#include "ir/Index.h"
 #include "ExecutorBase.h"
-#include "compiler/Linear.h"
-#include "exec/FunctionSequence.h"
+
 #include "compiler/CodeMap.h"
+#include "ir/Index.h"
 #include "util/TracingCtx.h"
 
 namespace onert

--- a/runtime/onert/core/src/exec/ParallelExecutor.h
+++ b/runtime/onert/core/src/exec/ParallelExecutor.h
@@ -17,18 +17,12 @@
 #ifndef __ONERT_EXEC_PARALLEL_EXECUTOR_H__
 #define __ONERT_EXEC_PARALLEL_EXECUTOR_H__
 
-#include <list>
-#include <queue>
-#include <unordered_map>
-
-#include "exec/FunctionSequence.h"
-#include "Job.h"
-#include "ir/OperandIndexSequence.h"
-#include "ir/Index.h"
-#include <memory>
-#include "exec/DataflowExecutor.h"
+#include "DataflowExecutor.h"
 #include "ParallelScheduler.h"
+
 #include "util/TracingCtx.h"
+
+#include <memory>
 
 namespace onert
 {

--- a/runtime/onert/core/src/interp/InterpExecutor.cc
+++ b/runtime/onert/core/src/interp/InterpExecutor.cc
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-#include "interp/InterpExecutor.h"
-#include "interp/ExecEnv.h"
-#include "interp/Interpreter.h"
+#include "InterpExecutor.h"
+
+#include "ExecEnv.h"
+#include "Interpreter.h"
 
 #include "util/logging.h"
 

--- a/runtime/onert/core/src/interp/operations/BinaryArithmeticOps.cc
+++ b/runtime/onert/core/src/interp/operations/BinaryArithmeticOps.cc
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-#include <cker/operation/BinaryArithmeticOps.h>
-
 #include "OperationUtil.h"
+#include "../Registration.h"
 
-#include "interp/Registration.h"
 #include "ir/operation/BinaryArithmetic.h"
-#include "misc/polymorphic_downcast.h"
-#include "cker/Types.h"
+
+#include <cker/operation/BinaryArithmeticOps.h>
+#include <cker/Types.h>
+#include <misc/polymorphic_downcast.h>
 
 namespace onert
 {

--- a/runtime/onert/core/src/interp/operations/Concat.cc
+++ b/runtime/onert/core/src/interp/operations/Concat.cc
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-#include <cker/operation/Concatenation.h>
-
 #include "OperationUtil.h"
+#include "../Registration.h"
 
-#include "interp/Registration.h"
 #include "ir/operation/Concat.h"
-#include "misc/polymorphic_downcast.h"
+
+#include <cker/operation/Concatenation.h>
+#include <misc/polymorphic_downcast.h>
 
 namespace onert
 {

--- a/runtime/onert/core/src/interp/operations/Conv2D.cc
+++ b/runtime/onert/core/src/interp/operations/Conv2D.cc
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-#include <cker/operation/Conv.h>
-
 #include "OperationUtil.h"
+#include "../Registration.h"
 
-#include "interp/Registration.h"
 #include "ir/operation/Conv2D.h"
-#include "util/Utils.h"
 #include "util/ShapeInference.h"
-#include "misc/polymorphic_downcast.h"
+#include "util/Utils.h"
+
+#include <cker/operation/Conv.h>
+#include <misc/polymorphic_downcast.h>
 
 namespace onert
 {

--- a/runtime/onert/core/src/interp/operations/DepthwiseConv2D.cc
+++ b/runtime/onert/core/src/interp/operations/DepthwiseConv2D.cc
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
+#include "OperationUtil.h"
+#include "../Registration.h"
+
+#include "ir/operation/DepthwiseConv2D.h"
+#include "util/ShapeInference.h"
+#include "util/Utils.h"
+
 #include <cker/operation/DepthwiseConv.h>
 #include <misc/polymorphic_downcast.h>
-
-#include "OperationUtil.h"
-
-#include "interp/Registration.h"
-#include "ir/operation/DepthwiseConv2D.h"
-#include "util/Utils.h"
-#include "util/ShapeInference.h"
 
 namespace onert
 {

--- a/runtime/onert/core/src/interp/operations/ElementwiseActivations.cc
+++ b/runtime/onert/core/src/interp/operations/ElementwiseActivations.cc
@@ -14,17 +14,16 @@
  * limitations under the License.
  */
 
-#include <cmath>
-
 #include "OperationUtil.h"
-
-#include "interp/Registration.h"
+#include "../Registration.h"
 
 #include "ir/operation/ElementwiseActivation.h"
 
-#include <misc/polymorphic_downcast.h>
 #include <cker/operation/Logistic.h>
 #include <cker/operation/Tanh.h>
+#include <misc/polymorphic_downcast.h>
+
+#include <cmath>
 
 namespace onert
 {

--- a/runtime/onert/core/src/interp/operations/FullyConnected.cc
+++ b/runtime/onert/core/src/interp/operations/FullyConnected.cc
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-#include <cker/operation/FullyConnected.h>
-
 #include "OperationUtil.h"
+#include "../Registration.h"
 
-#include "interp/Registration.h"
 #include "ir/operation/FullyConnected.h"
-#include "misc/polymorphic_downcast.h"
+
+#include <cker/operation/FullyConnected.h>
+#include <misc/polymorphic_downcast.h>
 
 namespace onert
 {

--- a/runtime/onert/core/src/interp/operations/Gather.cc
+++ b/runtime/onert/core/src/interp/operations/Gather.cc
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-#include <cker/operation/Gather.h>
-
 #include "OperationUtil.h"
+#include "../Registration.h"
 
-#include "interp/Registration.h"
 #include "ir/operation/Gather.h"
-#include "misc/polymorphic_downcast.h"
+
+#include <cker/operation/Gather.h>
+#include <misc/polymorphic_downcast.h>
 
 namespace onert
 {

--- a/runtime/onert/core/src/interp/operations/InstanceNorm.cc
+++ b/runtime/onert/core/src/interp/operations/InstanceNorm.cc
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-#include <cker/operation/InstanceNorm.h>
-
 #include "OperationUtil.h"
+#include "../Registration.h"
 
-#include "interp/Registration.h"
 #include "ir/operation/InstanceNorm.h"
-#include "misc/polymorphic_downcast.h"
+
+#include <cker/operation/InstanceNorm.h>
+#include <misc/polymorphic_downcast.h>
 
 namespace onert
 {

--- a/runtime/onert/core/src/interp/operations/Pad.cc
+++ b/runtime/onert/core/src/interp/operations/Pad.cc
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-#include <cker/operation/Pad.h>
-
 #include "OperationUtil.h"
+#include "../Registration.h"
 
-#include "interp/Registration.h"
 #include "ir/operation/Pad.h"
+
+#include <cker/operation/Pad.h>
 
 namespace onert
 {

--- a/runtime/onert/core/src/interp/operations/Pool2D.cc
+++ b/runtime/onert/core/src/interp/operations/Pool2D.cc
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
+#include "OperationUtil.h"
+#include "../Registration.h"
+
+#include "ir/operation/Pool2D.h"
+#include "util/ShapeInference.h"
+#include "util/Utils.h"
+
 #include <cker/operation/AveragePool.h>
 #include <cker/operation/MaxPool.h>
-
-#include "OperationUtil.h"
-
-#include "interp/Registration.h"
-#include "ir/operation/Pool2D.h"
-#include "util/Utils.h"
-#include "util/ShapeInference.h"
-#include "misc/polymorphic_downcast.h"
+#include <misc/polymorphic_downcast.h>
 
 namespace onert
 {

--- a/runtime/onert/core/src/interp/operations/Reshape.cc
+++ b/runtime/onert/core/src/interp/operations/Reshape.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "interp/Registration.h"
+#include "../Registration.h"
 
 namespace onert
 {

--- a/runtime/onert/core/src/interp/operations/Softmax.cc
+++ b/runtime/onert/core/src/interp/operations/Softmax.cc
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-#include <cker/operation/SoftMax.h>
-
 #include "OperationUtil.h"
+#include "../Registration.h"
 
-#include "interp/Registration.h"
 #include "ir/operation/Softmax.h"
-#include "misc/polymorphic_downcast.h"
+
+#include <cker/operation/SoftMax.h>
+#include <misc/polymorphic_downcast.h>
 
 namespace onert
 {

--- a/runtime/onert/core/src/interp/operations/TransposeConv.cc
+++ b/runtime/onert/core/src/interp/operations/TransposeConv.cc
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
+#include "OperationUtil.h"
+#include "../Registration.h"
+
+#include "ir/operation/TransposeConv.h"
+
 #include <cker/operation/TransposeConv.h>
 #include <misc/polymorphic_downcast.h>
-
-#include "OperationUtil.h"
-
-#include "interp/Registration.h"
-#include "ir/operation/TransposeConv.h"
 
 namespace onert
 {

--- a/runtime/onert/core/src/ir/Graph.cc
+++ b/runtime/onert/core/src/ir/Graph.cc
@@ -17,19 +17,9 @@
 #include "ir/Graph.h"
 
 #include "OperationValidator.h"
-
-#include <algorithm>
-
-#include <bitset>
-#include <sstream>
-
-#include "util/logging.h"
-#include "util/Set.h"
 #include "verifier/Verifier.h"
-#include "ir/OperandIndexMap.h"
-#include "ir/OperationIndexMap.h"
-#include "dumper/text/GraphDumper.h"
-#include "backend/IConfig.h"
+
+#include "util/Set.h"
 
 namespace onert
 {

--- a/runtime/onert/core/src/util/ChromeTracingEventWriter.cc
+++ b/runtime/onert/core/src/util/ChromeTracingEventWriter.cc
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-#include "util/EventWriter.h"
+#include "EventWriter.h"
 
-#include <sstream>
-#include <vector>
 #include <cassert>
+#include <sstream>
 #include <utility>
+#include <vector>
 
 // json type for ChromeTracingWriter
 namespace

--- a/runtime/onert/core/src/util/EventCollector.cc
+++ b/runtime/onert/core/src/util/EventCollector.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "util/EventCollector.h"
+#include "EventCollector.h"
 
 // C++ standard libraries
 #include <chrono>

--- a/runtime/onert/core/src/util/EventCollector.h
+++ b/runtime/onert/core/src/util/EventCollector.h
@@ -17,12 +17,13 @@
 #ifndef __ONERT_UTIL_EVENT_COLLECTOR_H__
 #define __ONERT_UTIL_EVENT_COLLECTOR_H__
 
-#include "util/EventRecorder.h"
+#include "EventRecorder.h"
+
 #include "util/TracingCtx.h"
 
-#include <vector>
-#include <utility>
 #include <string>
+#include <utility>
+#include <vector>
 
 class EventCollector
 {

--- a/runtime/onert/core/src/util/EventRecorder.cc
+++ b/runtime/onert/core/src/util/EventRecorder.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "util/EventRecorder.h"
+#include "EventRecorder.h"
 
 void EventRecorder::emit(std::unique_ptr<DurationEvent> &&evt)
 {

--- a/runtime/onert/core/src/util/EventWriter.cc
+++ b/runtime/onert/core/src/util/EventWriter.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "util/EventWriter.h"
+#include "EventWriter.h"
 
 #include <cassert>
 

--- a/runtime/onert/core/src/util/MDTableEventWriter.cc
+++ b/runtime/onert/core/src/util/MDTableEventWriter.cc
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
-#include "util/EventWriter.h"
+#include "EventWriter.h"
 
-#include <sstream>
-#include <vector>
-#include <unordered_map>
 #include <cassert>
-#include <utility>
 #include <map>
 #include <set>
+#include <sstream>
 #include <stdint.h>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 // md table type
 namespace

--- a/runtime/onert/core/src/util/SNPEEventWriter.cc
+++ b/runtime/onert/core/src/util/SNPEEventWriter.cc
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-#include "util/EventWriter.h"
+#include "EventWriter.h"
 
-#include <unordered_map>
 #include <json/json.h>
+
 #include <cassert>
+#include <unordered_map>
 #include <utility>
 
 /**


### PR DESCRIPTION
This commit removes private type target_include_directories in core.
It prevents to include private header in public header.

This commit includes header include reordering and removing redundant include.

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>