### PR TITLE
[circle-eval-diff] Install circle-eval-diff binary

### DIFF
--- a/compiler/circle-eval-diff/CMakeLists.txt
+++ b/compiler/circle-eval-diff/CMakeLists.txt
@@ -18,6 +18,8 @@ target_link_libraries(circle-eval-diff luci_interpreter)
 target_link_libraries(circle-eval-diff dio_hdf5)
 target_link_libraries(circle-eval-diff vconone)
 
+install(TARGETS circle-eval-diff DESTINATION bin)
+
 if(NOT ENABLE_TEST)
   return()
 endif(NOT ENABLE_TEST)


### PR DESCRIPTION
This installs circle-eval-diff binary in the bin directory.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/9124
Draft PR: https://github.com/Samsung/ONE/pull/9141