### PR TITLE
[circle-eval-diff] Support Top-1 and Top-5 match ratio

### DIFF
--- a/compiler/circle-eval-diff/driver/Driver.cpp
+++ b/compiler/circle-eval-diff/driver/Driver.cpp
@@ -81,6 +81,16 @@ int entry(const int argc, char **argv)
     .default_value(false)
     .help("Print Mean Peak Error to Interval Ratio");
 
+  arser.add_argument("--print_top1_match")
+    .nargs(0)
+    .default_value(false)
+    .help("Print Mean Top-1 Match Ratio");
+
+  arser.add_argument("--print_top5_match")
+    .nargs(0)
+    .default_value(false)
+    .help("Print Mean Top-5 Match Ratio");
+
   arser.add_argument("--input_data_format")
     .default_value("h5")
     .help("Input data format. h5/hdf5 (default) or directory");
@@ -132,6 +142,14 @@ int entry(const int argc, char **argv)
   if (arser["--print_mpeir"] and arser.get<bool>("--print_mpeir"))
   {
     metrics.emplace_back(Metric::MPEIR);
+  }
+  if (arser["--print_top1_match"] and arser.get<bool>("--print_top1_match"))
+  {
+    metrics.emplace_back(Metric::MTOP1);
+  }
+  if (arser["--print_top5_match"] and arser.get<bool>("--print_top5_match"))
+  {
+    metrics.emplace_back(Metric::MTOP5);
   }
 
   input_data_format = arser.get<std::string>("--input_data_format");

--- a/compiler/circle-eval-diff/include/CircleEvalDiff.h
+++ b/compiler/circle-eval-diff/include/CircleEvalDiff.h
@@ -39,6 +39,8 @@ enum class Metric
   MAE,       // Mean Absolute Error
   MAPE,      // Mean Percentage Absolute Error
   MPEIR,     // Mean Peak Error to Interval Ratio
+  MTOP1,     // Mean Top-1 Match Ratio
+  MTOP5,     // Mean Top-5 Match Ratio
 };
 
 class CircleEvalDiff final

--- a/compiler/circle-eval-diff/src/CircleEvalDiff.cpp
+++ b/compiler/circle-eval-diff/src/CircleEvalDiff.cpp
@@ -141,6 +141,16 @@ void CircleEvalDiff::init()
         _metrics.emplace_back(std::make_unique<MPEIRPrinter>());
         break;
       }
+      case Metric::MTOP1:
+      {
+        _metrics.emplace_back(std::make_unique<TopKMatchPrinter>(1));
+        break;
+      }
+      case Metric::MTOP5:
+      {
+        _metrics.emplace_back(std::make_unique<TopKMatchPrinter>(5));
+        break;
+      }
       default:
         throw std::runtime_error("Unsupported metric.");
     }


### PR DESCRIPTION
This supports Top-1 and Top-5 match ratio.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/9124
Draft PR: https://github.com/Samsung/ONE/pull/9141