### PR TITLE
[one-cmds] Change warning format

### DIFF
--- a/compiler/one-cmds/onecc
+++ b/compiler/one-cmds/onecc
@@ -148,9 +148,14 @@ def _is_available_driver(config, driver_name):
         'one-build', driver_name))
 
 
+def _simple_warning(message, category, filename, lineno, file=None, line=None):
+    return f'{category.__name__}: {message}\n'
+
+
 def _verify_cfg(import_driver_list, config):
     if not config.has_section('onecc'):
         if config.has_section('one-build'):
+            warnings.formatwarning = _simple_warning
             warnings.warn("[one-build] section will be deprecated. Please use [onecc] section.")
         else:
             raise ImportError('[onecc] section is required in configuration file')


### PR DESCRIPTION
This commit changes warning format in onecc.

Related: https://github.com/Samsung/ONE/issues/9125#issuecomment-1132583726
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>