### PR TITLE
[one-cmds] Introduce `one-infer` to `one-cmds`

### DIFF
--- a/compiler/one-cmds/CMakeLists.txt
+++ b/compiler/one-cmds/CMakeLists.txt
@@ -10,6 +10,7 @@ set(ONE_COMMAND_FILES
     one-pack
     one-partition
     one-profile
+    one-infer
     one-codegen
     one-prepare-venv
     onecc

--- a/compiler/one-cmds/one-infer
+++ b/compiler/one-cmds/one-infer
@@ -34,10 +34,6 @@ sys.tracebacklimit = 0
 
 
 def _get_backends_list():
-    # This approach is too much backend-depended, 
-    # since if the backend driver doesn't use {backend}-infer as its driver,
-    # then `one-infer` cannot run the driver. 
-    # TODO: introduce new layer which maps backend infer driver to one-infer
     """
     [one hierarchy]
     one
@@ -76,12 +72,55 @@ def _get_backends_list():
     return backends_list
 
 
+def _search_backend_driver(driver):
+    """
+    [one hierarchy]
+    one
+    ├── backends
+    ├── bin
+    ├── doc
+    ├── include
+    ├── lib
+    └── test
+
+    The list where `one-infer` finds its backend driver
+    - `bin` folder where `one-infer` exists
+    - `backends/**/bin/` folder
+
+    NOTE If there are drivers of the same name in different places,
+     the closer to the top in the list, the higher the priority.
+    """
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+
+    # CASE 0: check drvier name validation
+    if not driver:
+        return None
+
+    # CASE 1: one/bin/{driver} is found
+    driver_path = dir_path + '/' + driver
+    if os.path.isfile(driver_path) and os.access(driver_path, os.X_OK):
+        return driver_path
+
+    # CASE 2: one/backends/**/bin/{driver} is found
+    for driver_path in glob.glob(dir_path + '/../backends/**/bin/' + driver, recursive=True):
+        print(driver_path)
+        if os.path.isfile(driver_path) and os.access(driver_path, os.X_OK):
+            return driver_path
+
+    # CASE 3: {driver} is found in nowhere
+    return None
+
+
 def _get_parser(backends_list):
-    infer_usage = 'one-infer [-h] [-v] [-C CONFIG] [-b BACKEND] [--] [COMMANDS FOR BACKEND]'
+    infer_usage = 'one-infer [-h] [-v] [-C CONFIG] [-d DRIVER] [-b BACKEND] [--] [COMMANDS FOR BACKEND DRIVER]'
     parser = argparse.ArgumentParser(
         description='command line tool to infer model', usage=infer_usage)
 
     _utils._add_default_arg(parser)
+
+    # TODO: add tflite/onnx-infer driver to helper message when it is implemented
+    driver_help_message = 'backend inference driver name to execute'
+    parser.add_argument('-d', '--driver', type=str, help=driver_help_message)
 
     # get backend list in the directory
     backends_name = [ntpath.basename(f) for f in backends_list]
@@ -100,8 +139,8 @@ def _verify_arg(parser, args):
     """verify given arguments"""
     # check if required arguments is given
     missing = []
-    if not _utils._is_valid_attr(args, 'backend'):
-        missing.append('-b/--backend')
+    if not _utils._is_valid_attr(args, 'backend') and not _utils._is_valid_attr(args, 'driver'):
+        missing.append('-d/--driver or -b/--backend')
     if len(missing):
         parser.error('the following arguments are required: ' + ' '.join(missing))
 
@@ -109,27 +148,45 @@ def _verify_arg(parser, args):
 def _parse_arg(parser):
     infer_args = []
     backend_args = []
-    unknown_args = []
     argv = copy.deepcopy(sys.argv)
     # delete file name
     del argv[0]
     # split by '--'
     args = [list(y) for x, y in itertools.groupby(argv, lambda z: z == '--') if not x]
-    # one-infer has two interfaces
-    # 1. one-infer [-h] [-v] [-C CONFIG] [-b BACKEND] [COMMANDS FOR BACKEND]
-    if len(args) == 1:
+    
+    # one-infer [-h] [-v] [-C CONFIG] [-d DRIVER] [-b BACKEND] -- [COMMANDS FOR BACKEND DRIVER]
+    if len(args):
         infer_args = args[0]
-        infer_args, unknown_args = parser.parse_known_args(infer_args)
-    # 2. one-infer [-h] [-v] [-C CONFIG] [-b BACKEND] -- [COMMANDS FOR BACKEND]
-    if len(args) == 2:
-        infer_args = args[0]
-        backend_args = args[1]
         infer_args = parser.parse_args(infer_args)
+        backend_args = backend_args if len(args) < 2 else args[1]
     # print version
     if len(args) and infer_args.version:
         _utils._print_version_and_exit(__file__)
 
-    return infer_args, backend_args, unknown_args
+    return infer_args, backend_args
+
+
+def _get_executable(args, backends_list):
+    executable = None
+    missing = []
+
+    driver = getattr(args, 'driver')
+    if driver:
+        executable = _search_backend_driver(driver)
+        if executable:
+                return executable
+        missing.append(driver)
+
+    if getattr(args, 'backend'):
+        backend_base = getattr(args, 'backend') + '-infer'
+        for cand in backends_list:
+            if ntpath.basename(cand) == backend_base:
+                executable = cand
+                return executable
+        missing.append(backend_base)
+
+    if not executable:
+        raise FileNotFoundError(' or '.join(missing) + ' not found')
 
 
 def main():
@@ -138,7 +195,7 @@ def main():
 
     # parse arguments
     parser = _get_parser(backends_list)
-    args, backend_args, unknown_args = _parse_arg(parser)
+    args, backend_args = _parse_arg(parser)
 
     # parse configuration file
     _utils._parse_cfg(args, 'one-infer')
@@ -147,20 +204,14 @@ def main():
     _verify_arg(parser, args)
 
     # make a command to run given backend driver
-    infer_path = None
-    backend_base = getattr(args, 'backend') + '-infer'
-    for cand in backends_list:
-        if ntpath.basename(cand) == backend_base:
-            infer_path = cand
-    if not infer_path:
-        raise FileNotFoundError(backend_base + ' not found')
-    infer_cmd = [infer_path] + backend_args + unknown_args
+    driver_path = _get_executable(args, backends_list)
+    infer_cmd = [driver_path] + backend_args
     if _utils._is_valid_attr(args, 'command'):
         infer_cmd += getattr(args, 'command').split()
 
     # run backend driver
-    _utils._run(infer_cmd, err_prefix=backend_base)
+    _utils._run(infer_cmd, err_prefix=ntpath.basename(driver_path))
 
 
 if __name__ == '__main__':
-    main()
+    _utils._safemain(main, __file__)

--- a/compiler/one-cmds/one-infer
+++ b/compiler/one-cmds/one-infer
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+''''export SCRIPT_PATH="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)" # '''
+''''export PY_PATH=${SCRIPT_PATH}/venv/bin/python                                       # '''
+''''test -f ${PY_PATH} && exec ${PY_PATH} "$0" "$@"                                     # '''
+''''echo "Error: Virtual environment not found. Please run 'one-prepare-venv' command." # '''
+''''exit 255                                                                            # '''
+
+# Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import copy
+import glob
+import itertools
+import ntpath
+import os
+import sys
+
+import utils as _utils
+
+# TODO Find better way to suppress trackback on error
+sys.tracebacklimit = 0
+
+
+def _get_backends_list():
+    # This approach is too much backend-depended, 
+    # since if the backend driver doesn't use {backend}-infer as its driver,
+    # then `one-infer` cannot run the driver. 
+    # TODO: introduce new layer which maps backend infer driver to one-infer
+    """
+    [one hierarchy]
+    one
+    ├── backends
+    ├── bin
+    ├── doc
+    ├── include
+    ├── lib
+    └── test
+
+    The list where `one-infer` finds its backends
+    - `bin` folder where `one-infer` exists
+    - `backends` folder
+
+    NOTE If there are backends of the same name in different places,
+     the closer to the top in the list, the higher the priority.
+    """
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+    backend_set = set()
+
+    # bin folder
+    files = [f for f in glob.glob(dir_path + '/*-infer')]
+    # backends folder
+    files += [
+        f for f in glob.glob(dir_path + '/../backends/**/*-infer', recursive=True)
+    ]
+    # TODO find backends in `$PATH`
+
+    backends_list = []
+    for cand in files:
+        base = ntpath.basename(cand)
+        if (not base in backend_set) and os.path.isfile(cand) and os.access(cand, os.X_OK):
+            backend_set.add(base)
+            backends_list.append(cand)
+
+    return backends_list
+
+
+def _get_parser(backends_list):
+    infer_usage = 'one-infer [-h] [-v] [-C CONFIG] [-b BACKEND] [--] [COMMANDS FOR BACKEND]'
+    parser = argparse.ArgumentParser(
+        description='command line tool to infer model', usage=infer_usage)
+
+    _utils._add_default_arg(parser)
+
+    # get backend list in the directory
+    backends_name = [ntpath.basename(f) for f in backends_list]
+    if not backends_name:
+        backends_name_message = '(There is no available backend drivers)'
+    else:
+        backends_name_message = '(available backend drivers: ' + ', '.join(
+            backends_name) + ')'
+    backend_help_message = 'backend name to use ' + backends_name_message
+    parser.add_argument('-b', '--backend', type=str, help=backend_help_message)
+
+    return parser
+
+
+def _verify_arg(parser, args):
+    """verify given arguments"""
+    # check if required arguments is given
+    missing = []
+    if not _utils._is_valid_attr(args, 'backend'):
+        missing.append('-b/--backend')
+    if len(missing):
+        parser.error('the following arguments are required: ' + ' '.join(missing))
+
+
+def _parse_arg(parser):
+    infer_args = []
+    backend_args = []
+    unknown_args = []
+    argv = copy.deepcopy(sys.argv)
+    # delete file name
+    del argv[0]
+    # split by '--'
+    args = [list(y) for x, y in itertools.groupby(argv, lambda z: z == '--') if not x]
+    # one-infer has two interfaces
+    # 1. one-infer [-h] [-v] [-C CONFIG] [-b BACKEND] [COMMANDS FOR BACKEND]
+    if len(args) == 1:
+        infer_args = args[0]
+        infer_args, unknown_args = parser.parse_known_args(infer_args)
+    # 2. one-infer [-h] [-v] [-C CONFIG] [-b BACKEND] -- [COMMANDS FOR BACKEND]
+    if len(args) == 2:
+        infer_args = args[0]
+        backend_args = args[1]
+        infer_args = parser.parse_args(infer_args)
+    # print version
+    if len(args) and infer_args.version:
+        _utils._print_version_and_exit(__file__)
+
+    return infer_args, backend_args, unknown_args
+
+
+def main():
+    # get backend list
+    backends_list = _get_backends_list()
+
+    # parse arguments
+    parser = _get_parser(backends_list)
+    args, backend_args, unknown_args = _parse_arg(parser)
+
+    # parse configuration file
+    _utils._parse_cfg(args, 'one-infer')
+
+    # verify arguments
+    _verify_arg(parser, args)
+
+    # make a command to run given backend driver
+    infer_path = None
+    backend_base = getattr(args, 'backend') + '-infer'
+    for cand in backends_list:
+        if ntpath.basename(cand) == backend_base:
+            infer_path = cand
+    if not infer_path:
+        raise FileNotFoundError(backend_base + ' not found')
+    infer_cmd = [infer_path] + backend_args + unknown_args
+    if _utils._is_valid_attr(args, 'command'):
+        infer_cmd += getattr(args, 'command').split()
+
+    # run backend driver
+    _utils._run(infer_cmd, err_prefix=backend_base)
+
+
+if __name__ == '__main__':
+    main()

--- a/compiler/one-cmds/one-infer
+++ b/compiler/one-cmds/one-infer
@@ -42,6 +42,7 @@ def _get_backends_list():
     ├── doc
     ├── include
     ├── lib
+    ├── optimization
     └── test
 
     The list where `one-infer` finds its backends
@@ -81,6 +82,7 @@ def _search_backend_driver(driver):
     ├── doc
     ├── include
     ├── lib
+    ├── optimization
     └── test
 
     The list where `one-infer` finds its backend driver
@@ -134,7 +136,7 @@ def _verify_arg(parser, args):
     """verify given arguments"""
     # `-d/--driver` and `-b/--backend` are mutually exclusive arguments.
     if _utils._is_valid_attr(args, 'driver') and _utils._is_valid_attr(args, 'backend'):
-        parser.error('-d and -b options are mutually exclusive. Please use only one of them.')
+        parser.error('-d and -b options are mutually exclusive. Please use only one of them')
 
     missing = []
     if not _utils._is_valid_attr(args, 'driver') and not _utils._is_valid_attr(args, 'backend'):
@@ -165,26 +167,20 @@ def _parse_arg(parser):
 
 
 def _get_executable(args, backends_list):
-    executable = None
-    missing = []
-
-    driver = getattr(args, 'driver')
+    driver = _utils._is_valid_attr(args, 'driver')
     if driver:
         executable = _search_backend_driver(driver)
         if executable:
             return executable
-        missing.append(driver)
+        else:
+            raise FileNotFoundError(driver + ' not found')
 
-    if getattr(args, 'backend'):
+    if _utils._is_valid_attr(args, 'backend'):
         backend_base = getattr(args, 'backend') + '-infer'
         for cand in backends_list:
             if ntpath.basename(cand) == backend_base:
-                executable = cand
-                return executable
-        missing.append(backend_base)
-
-    if not executable:
-        raise FileNotFoundError(' or '.join(missing) + ' not found')
+                return cand
+        raise FileNotFoundError(backend_base + ' not found')
 
 
 def main():

--- a/compiler/one-cmds/one-infer
+++ b/compiler/one-cmds/one-infer
@@ -92,10 +92,6 @@ def _search_backend_driver(driver):
     """
     dir_path = os.path.dirname(os.path.realpath(__file__))
 
-    # CASE 0: check drvier name validation
-    if not driver:
-        return None
-
     # CASE 1: one/bin/{driver} is found
     driver_path = dir_path + '/' + driver
     if os.path.isfile(driver_path) and os.access(driver_path, os.X_OK):
@@ -103,7 +99,6 @@ def _search_backend_driver(driver):
 
     # CASE 2: one/backends/**/bin/{driver} is found
     for driver_path in glob.glob(dir_path + '/../backends/**/bin/' + driver, recursive=True):
-        print(driver_path)
         if os.path.isfile(driver_path) and os.access(driver_path, os.X_OK):
             return driver_path
 
@@ -137,10 +132,13 @@ def _get_parser(backends_list):
 
 def _verify_arg(parser, args):
     """verify given arguments"""
-    # check if required arguments is given
+    # `-d/--driver` and `-b/--backend` are mutually exclusive arguments.
+    if _utils._is_valid_attr(args, 'driver') and _utils._is_valid_attr(args, 'backend'):
+        parser.error('-d and -b options are mutually exclusive. Please use only one of them.')
+
     missing = []
-    if not _utils._is_valid_attr(args, 'backend') and not _utils._is_valid_attr(args, 'driver'):
-        missing.append('-d/--driver or -b/--backend')
+    if not _utils._is_valid_attr(args, 'driver') and not _utils._is_valid_attr(args, 'backend'):
+        missing.append('{-d/--driver | -b/--backend}')
     if len(missing):
         parser.error('the following arguments are required: ' + ' '.join(missing))
 
@@ -174,7 +172,7 @@ def _get_executable(args, backends_list):
     if driver:
         executable = _search_backend_driver(driver)
         if executable:
-                return executable
+            return executable
         missing.append(driver)
 
     if getattr(args, 'backend'):


### PR DESCRIPTION
This commit introduces `one-infer` which executes backend inference tool.

Signed-off-by: yunjay-hong <yunjay.hong@samsung.com>

---

for: #8970 
draft: #9122 