### PR TITLE
[infra/gbs] Remove userinfo

### DIFF
--- a/infra/nnfw/config/gbs.conf
+++ b/infra/nnfw/config/gbs.conf
@@ -3,8 +3,8 @@
 profile = profile.tizen
 
 [profile.tizen]
-user=obs_viewer
-obs = obs.tizen
+#user=obs_viewer
+#obs = obs.tizen
 repos = repo.tizen_one,repo.tizen_base,repo.tizen_mobile
 buildroot = /home/GBS-ROOT/
 
@@ -19,4 +19,3 @@ url = http://download.tizen.org/snapshots/tizen/base/latest/repos/standard/packa
 
 [repo.tizen_one]
 url = http://13.125.34.93/archive/tizen/
-


### PR DESCRIPTION
This commit removes userinfo from gbs.conf.
Userinfo in config file makes fail on proxy environment.

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>