### PR TITLE
[circle-eval-diff] Do null check for circle

### DIFF
--- a/compiler/circle-eval-diff/src/CircleEvalDiff.cpp
+++ b/compiler/circle-eval-diff/src/CircleEvalDiff.cpp
@@ -60,7 +60,12 @@ std::unique_ptr<luci::Module> import(const std::string &model_path)
     throw std::runtime_error("Failed to verify circle '" + model_path + "'");
   }
 
-  auto module = luci::Importer().importModule(circle::GetModel(model_data.data()));
+  auto circle_model = circle::GetModel(model_data.data());
+
+  if (not circle_model)
+    throw std::runtime_error("Failed to load '" + model_path + "'");
+
+  auto module = luci::Importer().importModule(circle_model);
 
   if (not module)
     throw std::runtime_error("Failed to load '" + model_path + "'");


### PR DESCRIPTION
This performs null check for circle model.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/9195