### PR TITLE
[Draft][one-cmds] Introduce `tflite-infer` for `one-infer`

### DIFF
--- a/NOTE.md
+++ b/NOTE.md
@@ -1,0 +1,95 @@
+### Introduce `tflite-infer` tool
+
+It's used to infer tflite model and get the result data.
+`tflite-infer` code itself is included in [#9122](https://github.com/Samsung/ONE/pull/9122) too. This pr includes tests, manpage, cmake codes.
+
+
+### `tflite-infer` I/O file strategy
+
+Working on `tflite-infer`, options for loading and dumping I/O data are the most difficult part to design. Here are the restrictions and requirements that I thinking about.
+
+1. Each I/O data needs to support every `npy`, `h5` and `bin` format. 
+2. After dumping randomly generated data as a file, it should be able to be loaded without any additional process. 
+3. Dumping data should not mess up the working directory with many independent files.
+4. (Optional) Data file should be expandable for multiple data inference, for example, infer multiple images in one `tflite-infer` command.
+
+Here are two command line examples which show the changes between before and after `tflite-infer` called. 
+
+<details><summary>Case of loading npy input data</summary>
+
+```console
+$ tree .
+.
+├── model.tflite
+└── simple_data
+    ├── simple_data.input.0.npy
+    └── simple_data.input.1.npy
+
+$ tflite-infer --loadable model.tflite \
+    --input-spec  npy:simple_data \
+    --dump-input-npy  simple_new \
+    --dump-input-h5   simple_new \
+    --dump-output-npy simple_new \
+    --dump-output-h5  simple_new
+
+$ tree .
+.
+├── model.tflite
+│── simple_data
+│   ├── simple_data.input.0.npy
+│   └── simple_data.input.1.npy
+├── simple_new
+│   ├── simple_new.input.0.npy
+│   ├── simple_new.input.1.npy
+│   └── simple_new.output.0.npy
+├── simple_new.input.h5
+└── simple_new.output.h5
+```
+
+</details>
+</br>
+<details><summary>Case of loading h5 input data</summary>
+
+```console
+$ tree .
+.
+├── model.tflite
+└── simple_data.input.h5
+
+$ tflite-infer --loadable model.tflite \
+    --input-spec  h5:simple_data \
+    --dump-input-npy  simple_new \
+    --dump-input-h5   simple_new \
+    --dump-output-npy simple_new \
+    --dump-output-h5  simple_new
+
+$ tree .
+.
+├── model.tflite
+└── simple_data.input.h5
+├── simple_new
+│   ├── simple_new.input.0.npy
+│   ├── simple_new.input.1.npy
+│   └── simple_new.output.0.npy
+├── simple_new.input.h5
+└── simple_new.output.h5
+```
+
+</details>
+</br>
+
+### test design description
+
+Category | Test # | Description
+:--: | :--: | :--
+positive test | P-01 | -h printing test
+positive test |	P-02	|-l --input-spec npy:\<filename> execution & output npy dump
+positive test |	P-03	|-l --input-spec h5:\<filename> execution & output h5 dump
+positive test |	P-04	|-l --input-spec any input npy&h5 shape/dtype test
+positive test|	P-05	|-l --input-spec non-zero input npy&h5 value, shape/dtype test
+positive test|	P-06	|-l --input-spec positive input npy&h5 value, shape/dtype test
+negative test |	N-01 |	-l option is missing
+negative test |	N-02 | 	--input-spec is missing
+negative test |	N-03 |	--input-spec \<option> is invalid
+negative test |	N-04 |	-l model is not found
+negative test |	N-05 |	--input-spec npy:\<filename> file is not found

--- a/compiler/one-cmds/CMakeLists.txt
+++ b/compiler/one-cmds/CMakeLists.txt
@@ -44,6 +44,33 @@ foreach(ONE_COMMAND IN ITEMS ${ONE_COMMAND_FILES})
           
 endforeach(ONE_COMMAND)
 
+set(INFER_FILES
+    tflite-infer
+)
+
+foreach(INFER_ITEM IN ITEMS ${INFER_FILES})
+
+  set(INFER_FILE ${INFER_ITEM})
+  set(INFER_SRC "${CMAKE_CURRENT_SOURCE_DIR}/${INFER_FILE}")
+  set(INFER_BIN "${CMAKE_CURRENT_BINARY_DIR}/${INFER_FILE}")
+  set(INFER_TARGET "${ONE_COMMAND}_target")
+
+  add_custom_command(OUTPUT ${INFER_BIN}
+    COMMAND ${CMAKE_COMMAND} -E copy "${INFER_SRC}" "${INFER_BIN}"
+    DEPENDS ${INFER_SRC}
+    COMMENT "Generate ${INFER_BIN}"
+  )
+
+  add_custom_target(${INFER_TARGET} ALL DEPENDS ${INFER_BIN})
+
+  install(FILES ${INFER_ITEM}
+          PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE
+                      GROUP_READ GROUP_EXECUTE
+                      WORLD_READ WORLD_EXECUTE
+          DESTINATION bin)
+          
+endforeach(INFER_ITEM)
+
 set(ONE_UTILITY_FILES
     one-build.template.cfg
     onecc.template.cfg

--- a/compiler/one-cmds/tests/tflite-infer_001.test
+++ b/compiler/one-cmds/tests/tflite-infer_001.test
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# print tflite-infer's help message
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  echo "${filename_ext} FAILED"
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+# run test
+tflite-infer -h > ${filename}.log 2>&1
+
+# TODO: Check this help message is still valid after draft
+if grep -q "Command line tool for infering tflite model" "${filename}.log"; then
+  echo "${filename_ext} SUCCESS"
+  exit 0
+fi
+
+trap_err_onexit

--- a/compiler/one-cmds/tests/tflite-infer_002.test.disabled
+++ b/compiler/one-cmds/tests/tflite-infer_002.test.disabled
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# load input npy data and dump output as npy file
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  echo "${filename_ext} FAILED"
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+input_model='./simple_add.tflite'
+input_npy='simple'
+output_npy='simple_out'
+
+rm -rf ${output_npy}
+
+# run test
+tflite-infer -l ${input_model} --input-spec npy:${input_npy} --dump-output-npy ${output_npy} > ${filename}.log 2>&1
+
+if [[ ! -s "${output_npy}/output.0.npy" ]]; then
+  trap_err_onexit
+fi
+
+rm -rf ${output_npy}
+
+echo "${filename_ext} SUCCESS"

--- a/compiler/one-cmds/tests/tflite-infer_003.test.disabled
+++ b/compiler/one-cmds/tests/tflite-infer_003.test.disabled
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# load input h5 data and dump output as h5 file
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  echo "${filename_ext} FAILED"
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+input_model='./simple_add.tflite'
+input_h5='simple'
+output_h5='simple_out'
+
+rm -rf ${output_npy}
+
+# run test
+tflite-infer -l ${input_model} --input-spec h5:${input_npy} --dump-output-npy ${output_npy} > ${filename}.log 2>&1
+
+if [[ ! -s "${output_npy}/output.0.npy" ]]; then
+  trap_err_onexit
+fi
+
+rm -rf ${output_npy}
+
+echo "${filename_ext} SUCCESS"

--- a/compiler/one-cmds/tests/tflite-infer_004.test.disabled
+++ b/compiler/one-cmds/tests/tflite-infer_004.test.disabled
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# print one-codegen's help message
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  echo "${filename_ext} FAILED"
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+# run test
+one-codegen -h > ${filename}.log 2>&1
+
+if grep -q "command line tool for code generation" "${filename}.log"; then
+  echo "${filename_ext} SUCCESS"
+  exit 0
+fi
+
+trap_err_onexit

--- a/compiler/one-cmds/tests/tflite-infer_neg_001.test
+++ b/compiler/one-cmds/tests/tflite-infer_neg_001.test
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# negative usage with no input model
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  if grep -q "error: the following arguments are required" "${filename}.log"; then
+    echo "${filename_ext} SUCCESS"
+    exit 0
+  fi
+
+  echo "${filename_ext} FAILED"
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+# run test
+one-codegen --input-spec any > ${filename}.log 2>&1
+
+echo "${filename_ext} FAILED"
+exit 255

--- a/compiler/one-cmds/tests/tflite-infer_neg_002.test
+++ b/compiler/one-cmds/tests/tflite-infer_neg_002.test
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# negative usage with no input-spec
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  if grep -q "error: the following arguments are required" "${filename}.log"; then
+    echo "${filename_ext} SUCCESS"
+    exit 0
+  fi
+
+  echo "${filename_ext} FAILED"
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+# run test
+one-codegen -l inception_v3.tflite > ${filename}.log 2>&1
+
+echo "${filename_ext} FAILED"
+exit 255

--- a/compiler/one-cmds/tflite-infer
+++ b/compiler/one-cmds/tflite-infer
@@ -1,0 +1,283 @@
+#!/usr/bin/env bash
+''''export SCRIPT_PATH="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)" # '''
+''''export PY_PATH=${SCRIPT_PATH}/venv/bin/python                                       # '''
+''''test -f ${PY_PATH} && exec ${PY_PATH} "$0" "$@"                                     # '''
+''''echo "Error: Virtual environment not found. Please run 'one-prepare-venv' command." # '''
+''''exit 255                                                                            # '''
+
+# Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import h5py as h5
+import numpy as np
+from pkg_resources import split_sections
+import tensorflow as tf
+import sys
+
+from pathlib import Path
+
+import utils as _utils
+
+
+def _get_parser():
+    desc = '''
+    Command line tool for inferring tflite model.
+
+    Input data for given model can be randomly generated, or given by options.
+    IN/OUT data format and spec are described in man page.
+'''
+    usage_string = '''
+    tflite-infer [-l/--loadable] [--input-spec=<any|positive|non-zero|npy:{filename}|h5:{filename}>]
+    [--dump-input-npy] [--dump-input-h5] [--dump-output-npy] [--dump-output-h5]
+'''
+    parser = argparse.ArgumentParser(description= desc, usage = usage_string, formatter_class = argparse.RawTextHelpFormatter)
+
+    input_model_msg = 'tflite model path to infer'
+    parser.add_argument('-l', '--loadable', type=str, required=True, help=input_model_msg)
+
+    input_spec_msg = '''option for input tensor data (generate or import)
+[Example]
+    To run model.tflite with some random input data with condition,
+    $ tflite-infer -l model.tflite --input-spec {any | positive | non-zero} [OPTIONS]
+    
+    To run model.tflite with .npy files, (which is saved as {filename}/{filename}.input.{data_num}.{tensor_idx}.npy)
+    $ tflite-infer -l model.tflite --input-spec {npy:<filename> | h5:<filename>}
+'''
+    parser.add_argument('--input-spec', type=str, required=True, help=input_spec_msg)
+
+    dump_input_npy_msg = 'dump input buffer as file name format of {FILE_NAME}/{FILE_NAME}.input.{INPUT_IDX}.npy'
+    parser.add_argument('--dump-input-npy', help=dump_input_npy_msg)
+
+    dump_input_h5_msg = 'dump input buffer as file name format of {FILE_NAME}.h5'
+    parser.add_argument('--dump-input-h5', help=dump_input_h5_msg)
+
+    dump_output_npy_msg = 'dump output as file name format of {FILE_NAME}/{FILE_NAME}.output.{OUTPUT_IDX}.npy'
+    parser.add_argument('--dump-output-npy', help=dump_output_npy_msg)
+
+    dump_output_h5_msg = 'dump output as file name format of {FILE_NAME}.output.h5'
+    parser.add_argument('--dump-output-h5', help=dump_output_h5_msg)
+
+    return parser
+
+
+def _verify_args(parser, args):
+    """verify given arguments"""
+    # check if required arguments is given
+    missing = []
+    required = {'loadable': '-l/--loadable', 'input_spec': '--input-spec'}
+    for req_key in required.keys():
+        if not _utils._is_valid_attr(args, req_key):
+            missing.append(required[req_key])
+    if len(missing):
+        parser.error('the following arguments are required: ' + ' '.join(missing))
+        return
+
+    # --input-spec option has its restriction. 
+    # It should be one of
+    #   [1] any / non-zero / positive
+    #   [2] npy:{FILE_NAME} / h5:{FILENAME}
+    # [1] for random input data with such condition
+    # [2] to load input data from specific file
+    if _utils._is_valid_attr(args, 'input_spec'):
+        tokens = getattr(args, 'input_spec').split(':')
+        random_conds =['any', 'non-zero', 'positive']
+        valid_filetypes = ['npy', 'h5']
+        # CASE [1]
+        if len(tokens) == 1 and tokens[0] in random_conds:
+            return
+        # CASE [2]
+        elif len(tokens) == 2 and tokens[0] in valid_filetypes:
+            return
+        else:
+            parser.error('  ERROR! input-spec option is invalid')
+
+
+def _parse_args(parser):
+    args, _ = parser.parse_known_args(sys.argv)
+    return args
+
+
+def _get_arg_list(args):
+    # List of Parsed Arguments
+    ret = []
+
+    # Required Arguments
+    modelPath = getattr(args, 'loadable')
+    specTokens = getattr(args, 'input_spec').split(':')
+    (cond, loadInputFile) = (specTokens[0], None) if len(specTokens) == 1\
+                            else specTokens[0:2]
+
+    ret.extend([modelPath, cond, loadInputFile])
+
+    # Optional Arguments
+    dumpInputNPY = getattr(args, 'dump_input_npy')
+    dumpInputH5 = getattr(args, 'dump_input_h5')
+    dumpOutputNPY = getattr(args, 'dump_output_npy')
+    dumpOutputH5 = getattr(args, 'dump_output_h5')
+    ret.extend([dumpInputNPY, dumpInputH5, dumpOutputNPY, dumpOutputH5])
+
+    return ret
+
+
+def get_random_data(shape, dtype, cond='any'):
+    cond_list = ['any', 'non-zero', 'positive']
+    if cond not in cond_list:
+        raise Exception(f'  ERROR! Input spec should be one of {cond_list}')
+
+    if dtype == np.float32:
+        # TODO: apply cond to float32 tensor
+        data = np.random.random(shape).astype(dtype)
+    elif dtype == np.int8:
+        if cond == 'any':
+            data = np.random.randint(0, 256, size=shape).astype(dtype)
+        elif cond == 'non-zero':
+            data = np.random.randint(1, 256, size=shape).astype(dtype)
+        elif cond == 'positive':
+            data = np.random.randint(1, 127, size=shape).astype(dtype)
+    elif dtype == np.bool:
+        data = np.random.choice(a=[True, False], size=shape).astype(dtype)
+    else:
+        raise SystemExit("  ERROR! Unsupported input dtype")
+
+    return data
+
+
+def get_data_from_file(filename, tensor_idx, filetype='npy'):
+    # TODO: support h5
+    filetypes = ['npy', 'h5']
+    if filetype not in filetypes:
+        raise SystemExit(f'  ERROR! {filetype} is not supported for data loading')
+
+    path = Path(filename)
+    if not path.exists():
+        raise SystemExit(f'  ERROR! {filename} is not found.')
+    if filetype == 'npy':
+        filepath = path / f'{path.name}.input.{tensor_idx}.{filetype}'
+
+        if not filepath.is_file():
+            raise SystemExit(f"{str(filepath)} doesn't exist")
+
+        data = np.load(str(filepath))
+    elif filetype == 'h5':
+        filepath = Path(str(path) + ".h5")
+
+        if not filepath.is_file():
+            raise SystemExit(f"{str(filepath)} doesn't exist")
+
+        h5File = h5.File(str(filepath))
+        data = h5File[f'input/{str(tensor_idx)}'][()]
+    else:
+        # Q) this condition is already checked at the start of this function
+        #    Is this necessary? or the filetype checker can be abandoned?
+        raise SystemExit(f'  ERROR! {filetype} is not supported for data loading')
+
+    return data
+
+
+# TODO: support multiple runs with multiple data
+def save_input_as_npy(filename, input_data):
+    Path(filename).mkdir(parents=True, exist_ok=True)
+    prefix = filename + '/' + Path(filename).name
+    for idx, data in enumerate(input_data):
+        full_filename = f'{prefix}.input.{str(idx)}.npy'
+        np.save(full_filename, data)
+
+
+def save_output_as_npy(filename, input_data):
+    Path(filename).mkdir(parents=True, exist_ok=True)
+    prefix = filename + '/' + Path(filename).name
+    for idx, data in enumerate(input_data):
+        full_filename = f'{prefix}.output.{str(idx)}.npy'
+        np.save(full_filename, data)
+
+
+def save_input_as_h5(filename, input_data):
+    filename = f'{filename}.input.h5'
+    f = h5.File(filename, 'w')
+    for idx, data in enumerate(input_data):
+        f.create_dataset(f'{str(idx)}', data=data)
+    f.close()
+
+
+def save_output_as_h5(filename, output_data):
+    filename = f'{filename}.output.h5'
+    f = h5.File(filename, 'w')
+    for idx, data in enumerate(output_data):
+        f.create_dataset(f'{str(idx)}', data=data)
+    f.close()
+
+
+def exec_model():
+    parser = _get_parser()
+    args = _parse_args(parser)
+    _verify_args(parser, args)
+    modelPath, inputCond, inputFileName, dumpInputNPY, dumpInputH5,\
+        dumpOutputNPY, dumpOutputH5 = _get_arg_list(args)
+
+    cond_list = ['any', 'non-zero', 'positive']
+    filetype_list = ['npy', 'h5']
+
+    interpreter = tf.lite.Interpreter(modelPath)
+    interpreter.allocate_tensors()
+
+    input_details = interpreter.get_input_details()
+    input_data = []
+    for idx, input in enumerate(input_details):
+        input_type = input['dtype']
+        input_shape = input['shape']
+
+        if inputCond in cond_list:
+            data = get_random_data(input_shape, input_type, inputCond)
+        elif inputCond in filetype_list:
+            data = get_data_from_file(inputFileName, idx, inputCond)
+        else:
+            raise SystemExit("  Error! Invalid input-spec")
+
+        input_idx = input['index']
+        input_data.append(data)
+
+        # Q. Is this safe approach? Won't input_idx be mixed?
+        interpreter.set_tensor(input_idx, input_data[idx])
+
+    # Run the model
+    interpreter.invoke()
+
+    tensor_details = interpreter.get_tensor_details()
+    output_details = interpreter.get_output_details()
+    output_data = []
+    for idx, output in enumerate(output_details):
+        output_tensor_idx = output['index']
+
+        # `one-optimize` supports to change the input/output tensors. It could make impossible
+        # to compare the inference result between the source model and the compiled result.
+        # TODO: support output tensor selection
+
+        data = interpreter.get_tensor(output_tensor_idx)
+        output_data.append(data)
+
+    # Save I/O data to file
+    if dumpInputNPY:
+        save_input_as_npy(dumpInputNPY, input_data)
+    if dumpInputH5:
+        save_input_as_h5(dumpInputH5, input_data)
+    if dumpOutputNPY:
+        save_output_as_npy(dumpOutputNPY, output_data)
+    if dumpOutputH5:
+        save_output_as_h5(dumpOutputH5, output_data)
+
+
+if __name__ == "__main__":
+    # TODO: Add any log about the generated file
+    exec_model()

--- a/infra/debian/compiler/docs/tflite-infer.1
+++ b/infra/debian/compiler/docs/tflite-infer.1
@@ -1,0 +1,32 @@
+.TH TFLITE-INFER "1" "August 2022" "tflite-profile version 1.17.0" "User Commands"
+.SH NAME
+tflite-infer \- infer tflite model file
+.SH DESCRIPTION
+usage: tflite\-infer [\-h] [\-l TFLITE MODEL] [\-\-input\-spec INPUT SPEC]
+.PP
+[\-\-dump\-input\-npy INPUT NPY NAME] [\-\-dump\-input\-h5 INPUT H5 NAME]
+.PP
+[\-\-dump\-output\-npy OUTPUT NPY NAME] [\-\-dump\-output\-h5 OUTPUT H5 NAME]
+.PP
+\fBtflite\-infer\fR is a command line tool to infer tflite model.
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+show this help message and exit
+.TP
+.SH COPYRIGHT
+Copyright \(co 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+Licensed under the Apache License, Version 2.0
+https://github.com/Samsung/ONE
+.SH "SEE ALSO"
+The full documentation for
+.B tflite-profile
+is maintained as a Texinfo manual.  If the
+.B info
+and
+.B tflite-profile
+programs are properly installed at your site, the command
+.IP
+.B info tflite-profile
+.PP
+should give you access to the complete manual.


### PR DESCRIPTION
This commit introduces `tlifte-infer` tool which helps to infer
tflite model and get the result data. It can be used by `one-infer`
in `one-cmds`.

Signed-off-by: yunjay-hong <yunjay.hong@samsung.com>