### PR TITLE
[mio-circle04] Operator outputs

### DIFF
--- a/compiler/mio-circle04/include/mio_circle/Reader.h
+++ b/compiler/mio-circle04/include/mio_circle/Reader.h
@@ -68,6 +68,7 @@ public:
   size_t buffer_info(uint32_t buf_idx, const uint8_t **buff_data);
   ::circle::BuiltinOperator builtin_code(const ::circle::Operator *op) const;
   std::string opcode_name(const ::circle::Operator *op) const;
+  std::vector<int32_t> outputs(const ::circle::Operator *op) const;
   std::string tensor_name(const ::circle::Tensor *tensor) const;
   std::string tensor_dtype(const ::circle::Tensor *tensor) const;
 

--- a/compiler/mio-circle04/src/Reader.cpp
+++ b/compiler/mio-circle04/src/Reader.cpp
@@ -98,6 +98,11 @@ std::string Reader::opcode_name(const ::circle::Operator *op) const
   return mio::circle::opcode_name(opcode);
 }
 
+std::vector<int32_t> Reader::outputs(const ::circle::Operator *op) const
+{
+  return as_index_vector(op->outputs());
+}
+
 std::string Reader::tensor_name(const ::circle::Tensor *tensor) const
 {
   return mio::circle::tensor_name(tensor);


### PR DESCRIPTION
This will introduce method to get tensor index of Operator outputs.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>