### PR TITLE
[infra] Exclude more test code on coverage

### DIFF
--- a/infra/command/gen-coverage-report
+++ b/infra/command/gen-coverage-report
@@ -69,10 +69,10 @@ done
 
 opencl_files=($(find ./runtime/onert/backend/gpu_cl/open_cl/ \( -name "*.cc" -o -name "*.h" \) -exec realpath {} \; ))
 
-# Exclude *.test.cpp files from coverage report
+# Exclude test files from coverage report
 # Exclude flatbuffer generated files from coverage report
 "${LCOV_PATH}" -r "${EXTRACTED_COVERAGE_INFO_PATH}" -o "${EXCLUDED_COVERAGE_INFO_PATH}" \
-  '*.test.cpp' '*/test/*' '*_schema_generated.h' "${opencl_files[@]}"
+  '*.test.cpp' '*.test.cc' '*/test/*' '*/tests/*' '*_schema_generated.h' "${opencl_files[@]}"
 
 # Final coverage data
 cp -v ${EXCLUDED_COVERAGE_INFO_PATH} ${COVERAGE_INFO_PATH}


### PR DESCRIPTION
This commit removes test files *.test.cc and files in directory tess/ from coverage report.

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>