### PR TITLE
[one-cmds] Remove unrecognized option

### DIFF
--- a/compiler/one-cmds/tests/one-build_008.cfg
+++ b/compiler/one-cmds/tests/one-build_008.cfg
@@ -15,7 +15,6 @@ output_path=test_onnx_model.circle
 [one-optimize]
 input_path=test_onnx_model.circle
 output_path=test_onnx_model.opt.circle
-all=True
 remove_redundant_transpose=True
 
 [one-codegen]

--- a/compiler/one-cmds/tests/one-build_009.cfg
+++ b/compiler/one-cmds/tests/one-build_009.cfg
@@ -15,7 +15,6 @@ output_path=onnx_conv2d_conv2d.circle
 [one-optimize]
 input_path=onnx_conv2d_conv2d.circle
 output_path=onnx_conv2d_conv2d.opt.circle
-all=True
 remove_redundant_transpose=True
 convert_nchw_to_nhwc=True
 

--- a/compiler/one-cmds/tests/onecc_008.cfg
+++ b/compiler/one-cmds/tests/onecc_008.cfg
@@ -15,7 +15,6 @@ output_path=test_onnx_model.circle
 [one-optimize]
 input_path=test_onnx_model.circle
 output_path=test_onnx_model.opt.circle
-all=True
 remove_redundant_transpose=True
 
 [one-codegen]

--- a/compiler/one-cmds/tests/onecc_009.cfg
+++ b/compiler/one-cmds/tests/onecc_009.cfg
@@ -15,7 +15,6 @@ output_path=onnx_conv2d_conv2d.circle
 [one-optimize]
 input_path=onnx_conv2d_conv2d.circle
 output_path=onnx_conv2d_conv2d.opt.circle
-all=True
 remove_redundant_transpose=True
 convert_nchw_to_nhwc=True
 


### PR DESCRIPTION
This removes unrecognized opt option.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/9154