### PR TITLE
[infra] Fix compiler coverage report

### DIFF
--- a/infra/scripts/unittest_compiler_xml.sh
+++ b/infra/scripts/unittest_compiler_xml.sh
@@ -7,7 +7,9 @@ set -eo pipefail
 CURRENT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_PATH="$CURRENT_PATH/../../"
 NNCC_WORKSPACE=${NNCC_WORKSPACE:-${ROOT_PATH}build}
-UNITTEST_REPORT_DIR=${NNCC_WORKSPACE}/unittest_compiler_xml
+
+# Use fixed absolute report dir for CI
+UNITTEST_REPORT_DIR=${ROOT_PATH}build/unittest_compiler_xml
 
 for i in "$@"
 do
@@ -25,5 +27,10 @@ fi
 
 for TEST_BIN in `find ${NNCC_WORKSPACE}/compiler -type f -executable -name *_test`; do
   TEST_NAME="$(basename -- $TEST_BIN)"
-  LUGI_LOG=999 $TEST_BIN --gtest_output="xml:$UNITTEST_REPORT_DIR/$TEST_NAME.xml"
+  TEST_DIR="$(dirname $TEST_BIN)"
+
+  # Execute on test directory to find related file
+  pushd $TEST_DIR > /dev/null
+  LUGI_LOG=999 $TEST_NAME --gtest_output="xml:$UNITTEST_REPORT_DIR/$TEST_NAME.xml"
+  popd > /dev/null
 done


### PR DESCRIPTION
This commit resolves coverage test fail by using absolute report path and executing test binary on each test directory.

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>