### PR TITLE
[infra] Add circle-operator to debian install

### DIFF
--- a/infra/debian/compiler/one-compiler.install
+++ b/infra/debian/compiler/one-compiler.install
@@ -2,6 +2,7 @@
 # bin
 usr/bin/circle2circle usr/share/one/bin/
 usr/bin/circle-eval-diff usr/share/one/bin/
+usr/bin/circle-operator usr/share/one/bin/
 usr/bin/circle-partitioner usr/share/one/bin/
 usr/bin/circle-quantizer usr/share/one/bin/
 usr/bin/generate_bcq_metadata.py usr/share/one/bin/


### PR DESCRIPTION
This will revise debian install list to include circle-operator tool.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>