### PR TITLE
[one-cmds] Add one-infer to debian package

### DIFF
--- a/infra/debian/compiler/one-compiler.install
+++ b/infra/debian/compiler/one-compiler.install
@@ -17,6 +17,7 @@ usr/bin/one-import-bcq usr/share/one/bin/
 usr/bin/one-import-onnx usr/share/one/bin/
 usr/bin/one-import-tf usr/share/one/bin/
 usr/bin/one-import-tflite usr/share/one/bin/
+usr/bin/one-infer usr/share/one/bin/
 usr/bin/one-optimize usr/share/one/bin/
 usr/bin/one-pack usr/share/one/bin/
 usr/bin/one-partition usr/share/one/bin/


### PR DESCRIPTION
This commit adds one-infer to debian package

Signed-off-by: yunjay-hong <yunjay.hong@samsung.com>

---

for: https://github.com/Samsung/ONE/issues/8970
draft: https://github.com/Samsung/ONE/pull/9122
