### PR TITLE
[onert] Add IR structures for multiple model nnpkg

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -410,7 +410,7 @@ NNFW_STATUS nnfw_session::prepare()
     _tracing_ctx = std::make_unique<onert::util::TracingCtx>(subgraphs.get());
     auto compiler =
       std::make_unique<onert::compiler::Compiler>(subgraphs, _tracing_ctx.get(), *_coptions);
-    subgraphs.reset();
+    _model_graph.reset();
     std::shared_ptr<onert::exec::ExecutorMap> executors = compiler->compile();
     _execution = std::make_unique<onert::exec::Execution>(executors);
   }

--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -221,7 +221,7 @@ NNFW_STATUS nnfw_session::load_circle_from_buffer(uint8_t *buffer, size_t size)
   try
   {
     auto subgraphs = onert::circle_loader::loadModel(buffer, size);
-    auto model = std::make_unique<onert::ir::Model>(subgraphs.get());
+    auto model = std::make_unique<onert::ir::Model>(std::move(subgraphs));
     // It loads a single circle model from buffer.
     // nnfw_session will have only one Model in ModelGraph.
     // nnfw_session now can have more than one models.
@@ -285,7 +285,7 @@ NNFW_STATUS nnfw_session::load_model_from_modelfile(const char *model_file_path)
     //
     // Q. Where the loaded graph should be put? 0th model? or Append the model?
     // A. It will put the loaded model in 0th model because it's used only for test.
-    auto model = std::make_unique<onert::ir::Model>(subgraphs.get());
+    auto model = std::make_unique<onert::ir::Model>(subgraphs);
     _model_graph = std::make_shared<onert::ir::ModelGraph>();
     _model_graph->models().push(std::move(model), onert::ir::ModelIndex{0});
   }
@@ -372,7 +372,7 @@ NNFW_STATUS nnfw_session::load_model_from_nnpackage(const char *package_dir)
       return NNFW_STATUS_ERROR;
     }
     subgraphs->primary()->bindKernelBuilder(_kernel_registry->getBuilder());
-    auto model = std::make_unique<onert::ir::Model>(subgraphs.get());
+    auto model = std::make_unique<onert::ir::Model>(subgraphs);
     _model_graph = std::make_shared<onert::ir::ModelGraph>();
     _model_graph->models().push(std::move(model), onert::ir::ModelIndex{0});
   }

--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -1086,11 +1086,10 @@ NNFW_STATUS nnfw_session::set_config(const char *key, const char *value)
 
 const onert::ir::Graph *nnfw_session::primary_subgraph()
 {
-  auto subgraphs = _model_graph->entry();
-  if (subgraphs)
+  if (_state == State::MODEL_LOADED)
   {
     assert(_execution == nullptr && _executions.empty());
-    return subgraphs->primary().get();
+    return _model_graph->entry()->primary().get();
   }
   else
   {

--- a/runtime/onert/api/src/nnfw_api_internal.h
+++ b/runtime/onert/api/src/nnfw_api_internal.h
@@ -42,6 +42,7 @@ namespace ir
 {
 class Graph;
 class Subgraphs;
+class ModelGraph;
 } // namespace ir
 namespace compiler
 {
@@ -166,7 +167,7 @@ private:
 
 private:
   State _state{State::INITIALIZED};
-  std::shared_ptr<onert::ir::Subgraphs> _subgraphs;
+  std::shared_ptr<onert::ir::ModelGraph> _model_graph;
   std::unique_ptr<onert::compiler::CompilerOptions> _coptions;
   std::unique_ptr<onert::exec::Execution> _execution;
   std::shared_ptr<onert::api::CustomKernelRegistry> _kernel_registry;

--- a/runtime/onert/core/include/ir/Index.h
+++ b/runtime/onert/core/include/ir/Index.h
@@ -38,6 +38,12 @@ using IOIndex = ::onert::util::Index<uint32_t, IOIndexTag>;
 struct SubgraphIndexTag;
 using SubgraphIndex = ::onert::util::Index<uint32_t, SubgraphIndexTag>;
 
+struct ModelIndexTag;
+using ModelIndex = ::onert::util::Index<uint32_t, ModelIndexTag>;
+
+struct ModelOperandIndexTag;
+using ModelOperandIndex = ::onert::util::Index<uint32_t, ModelOperandIndexTag>;
+
 template <typename IndexType>
 std::ostream &_index_print_impl(std::ostream &o, const std::string &prefix, IndexType index)
 {
@@ -64,7 +70,12 @@ inline std::ostream &operator<<(std::ostream &o, const IOIndex &i)
 
 inline std::ostream &operator<<(std::ostream &o, const SubgraphIndex &i)
 {
-  return _index_print_impl(o, "SUBGRAPH", i); // $ubgraph
+  return _index_print_impl(o, "SUBGRAPH", i);
+}
+
+inline std::ostream &operator<<(std::ostream &o, const ModelIndex &i)
+{
+  return _index_print_impl(o, "MODEL", i);
 }
 
 } // namespace ir

--- a/runtime/onert/core/include/ir/Model.h
+++ b/runtime/onert/core/include/ir/Model.h
@@ -27,7 +27,7 @@ namespace ir
 
 struct Model
 {
-  Model(Subgraphs *s) : _subgraphs(s) {}
+  Model(const std::shared_ptr<Subgraphs> &subgs) : _subgraphs(subgs) {}
 
   std::shared_ptr<Subgraphs> _subgraphs;
   ModelOperandIndexSequence _inputs;

--- a/runtime/onert/core/include/ir/Model.h
+++ b/runtime/onert/core/include/ir/Model.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_IR_MODEL_H__
+#define __ONERT_IR_MODEL_H__
+
+#include "ir/ModelOperandIndexSequence.h"
+#include "ir/Subgraphs.h"
+
+namespace onert
+{
+namespace ir
+{
+
+struct Model
+{
+  ModelOperandIndexSequence _inputs;
+  ModelOperandIndexSequence _outputs;
+  std::shared_ptr<Subgraphs> _subgraphs;
+};
+
+} // namespace ir
+} // namespace onert
+
+#endif // __ONERT_IR_MODEL_H__

--- a/runtime/onert/core/include/ir/Model.h
+++ b/runtime/onert/core/include/ir/Model.h
@@ -27,7 +27,7 @@ namespace ir
 
 struct Model
 {
-  Model(Subgraphs *s) : _subgraphs(s) { }
+  Model(Subgraphs *s) : _subgraphs(s) {}
 
   std::shared_ptr<Subgraphs> _subgraphs;
   ModelOperandIndexSequence _inputs;

--- a/runtime/onert/core/include/ir/ModelGraph.h
+++ b/runtime/onert/core/include/ir/ModelGraph.h
@@ -40,7 +40,7 @@ public:
 
   const Models &models() const { return _models; }
   Models &models() { return _models; }
-  std::shared_ptr<Subgraphs> &entry() { return _models.at(onert::ir::ModelIndex{0})._subgraphs; }
+  std::shared_ptr<Subgraphs> entry() { return _models.at(onert::ir::ModelIndex{0})._subgraphs; }
 
 private:
   Models _models;

--- a/runtime/onert/core/include/ir/ModelGraph.h
+++ b/runtime/onert/core/include/ir/ModelGraph.h
@@ -14,10 +14,13 @@
  * limitations under the License.
  */
 
-#ifndef __ONERT_IR_MODEL_H__
-#define __ONERT_IR_MODEL_H__
+#ifndef __ONERT_IR_MODEL_GRAPH_H__
+#define __ONERT_IR_MODEL_GRAPH_H__
 
-#include "ir/ModelOperandIndexSequence.h"
+#include <memory>
+
+#include "ir/Index.h"
+#include "ir/Models.h"
 #include "ir/Subgraphs.h"
 
 namespace onert
@@ -25,16 +28,26 @@ namespace onert
 namespace ir
 {
 
-struct Model
+class ModelGraph
 {
-  Model(Subgraphs *s) : _subgraphs(s) { }
+public:
+  ModelGraph() = default;
+  ModelGraph(const ModelGraph &obj) = default;
+  ModelGraph(ModelGraph &&) = default;
+  ModelGraph &operator=(const ModelGraph &) = default;
+  ModelGraph &operator=(ModelGraph &&) = default;
+  ~ModelGraph() = default;
 
-  std::shared_ptr<Subgraphs> _subgraphs;
-  ModelOperandIndexSequence _inputs;
-  ModelOperandIndexSequence _outputs;
+  const Models &models() const { return _models; }
+  Models &models() { return _models; }
+  std::shared_ptr<Subgraphs> &entry() { return _models.at(onert::ir::ModelIndex{0})._subgraphs; }
+
+private:
+  Models _models;
+  // TODO: Add connection between models
 };
 
 } // namespace ir
 } // namespace onert
 
-#endif // __ONERT_IR_MODEL_H__
+#endif // __ONERT_IR_MODEL_GRAPH_H__

--- a/runtime/onert/core/include/ir/ModelGraph.h
+++ b/runtime/onert/core/include/ir/ModelGraph.h
@@ -32,9 +32,9 @@ class ModelGraph
 {
 public:
   ModelGraph() = default;
-  ModelGraph(const ModelGraph &obj) = default;
-  ModelGraph(ModelGraph &&) = default;
-  ModelGraph &operator=(const ModelGraph &) = default;
+  ModelGraph(const ModelGraph &obj) = delete;
+  ModelGraph(ModelGraph &&) = delete;
+  ModelGraph &operator=(const ModelGraph &) = delete;
   ModelGraph &operator=(ModelGraph &&) = default;
   ~ModelGraph() = default;
 

--- a/runtime/onert/core/include/ir/ModelOperandIndexSequence.h
+++ b/runtime/onert/core/include/ir/ModelOperandIndexSequence.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_IR_MODEL_OPERAND_INDEX_SEQUENCE_H__
+#define __ONERT_IR_MODEL_OPERAND_INDEX_SEQUENCE_H__
+
+#include "ir/Index.h"
+
+#include <initializer_list>
+#include <vector>
+
+namespace onert
+{
+namespace ir
+{
+
+class ModelOperandIndexSequence
+{
+public:
+  ModelOperandIndexSequence(void) = default;
+  ModelOperandIndexSequence(std::initializer_list<ModelOperandIndex> list);
+  ModelOperandIndexSequence(std::initializer_list<int32_t> list);
+  ModelOperandIndexSequence(std::initializer_list<uint32_t> list);
+
+public:
+  void append(const ModelOperandIndex &index) { _vec.emplace_back(index); }
+  void append(const ModelOperandIndexSequence &l) { _vec.insert(_vec.end(), l.begin(), l.end()); }
+
+public:
+  uint32_t size() const { return static_cast<uint32_t>(_vec.size()); }
+  const ModelOperandIndex &at(IOIndex set_index) const { return _vec.at(set_index.value()); }
+  const ModelOperandIndex &at(uint32_t index) const { return _vec.at(index); }
+  bool contains(const ModelOperandIndex &index) const;
+  void replace(const ModelOperandIndex &from, const ModelOperandIndex &to);
+
+public:
+  ModelOperandIndexSequence operator+(const ModelOperandIndexSequence &other) const;
+
+public:
+  std::vector<ModelOperandIndex>::const_iterator begin(void) const { return _vec.begin(); }
+  std::vector<ModelOperandIndex>::const_iterator end(void) const { return _vec.end(); }
+  std::vector<ModelOperandIndex>::iterator begin(void) { return _vec.begin(); }
+  std::vector<ModelOperandIndex>::iterator end(void) { return _vec.end(); }
+
+private:
+  std::vector<ModelOperandIndex> _vec;
+};
+
+} // namespace ir
+} // namespace onert
+
+#endif // __ONERT_IR_MODEL_OPERAND_INDEX_SEQUENCE_H__

--- a/runtime/onert/core/include/ir/Models.h
+++ b/runtime/onert/core/include/ir/Models.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_IR_MODELS_H__
+#define __ONERT_IR_MODELS_H__
+
+#include "ir/Index.h"
+#include "ir/Model.h"
+#include "util/ObjectManager.h"
+
+namespace onert
+{
+namespace ir
+{
+
+class Models : public util::ObjectManager<ModelIndex, Model>
+{
+public:
+  Models() = default;
+  Models(const Models &obj) = delete;
+  Models(Models &&) = delete;
+  Models &operator=(const Models &) = delete;
+  Models &operator=(Models &&) = default;
+  ~Models() = default;
+};
+
+} // namespace ir
+} // namespace onert
+
+#endif // __ONERT_IR_MODELS_H__

--- a/runtime/onert/core/src/ir/ModelOperandIndexSequence.cc
+++ b/runtime/onert/core/src/ir/ModelOperandIndexSequence.cc
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ir/ModelOperandIndexSequence.h"
+
+#include <algorithm>
+
+namespace onert
+{
+namespace ir
+{
+
+ModelOperandIndexSequence::ModelOperandIndexSequence(std::initializer_list<ModelOperandIndex> list)
+  : _vec(list)
+{
+  // DO NOTHING
+}
+
+ModelOperandIndexSequence::ModelOperandIndexSequence(std::initializer_list<int32_t> list)
+{
+  for (auto val : list)
+  {
+    _vec.emplace_back(static_cast<uint32_t>(val));
+  }
+}
+
+ModelOperandIndexSequence::ModelOperandIndexSequence(std::initializer_list<uint32_t> list)
+{
+  for (auto val : list)
+  {
+    _vec.emplace_back(val);
+  }
+}
+
+bool ModelOperandIndexSequence::contains(const ModelOperandIndex &index) const
+{
+  return std::find(_vec.begin(), _vec.end(), index) != _vec.end();
+}
+
+void ModelOperandIndexSequence::replace(const ModelOperandIndex &from, const ModelOperandIndex &to)
+{
+  std::replace(_vec.begin(), _vec.end(), from, to);
+}
+
+ModelOperandIndexSequence ModelOperandIndexSequence::
+operator+(const ModelOperandIndexSequence &other) const
+{
+  ModelOperandIndexSequence ret = *this;
+  ret.append(other);
+  return ret;
+}
+
+} // namespace ir
+} // namespace onert

--- a/tests/tools/tflite_comparator/src/tflite_comparator.cc
+++ b/tests/tools/tflite_comparator/src/tflite_comparator.cc
@@ -184,7 +184,6 @@ int main(const int argc, char **argv)
 
   NNFW_ASSERT_FAIL(nnfw_load_model_from_modelfile(onert_session, tflite_file.c_str()),
                    "[ ERROR ] Failure during model load");
-
   uint32_t num_inputs;
   uint32_t num_outputs;
   NNFW_ASSERT_FAIL(nnfw_input_size(onert_session, &num_inputs),
@@ -193,10 +192,8 @@ int main(const int argc, char **argv)
                    "[ ERROR ] Failure during get model outputs");
 
   std::cout << "[Execution] Model is deserialized!" << std::endl;
-
   // Compile
   nnfw_prepare(onert_session);
-
   std::cout << "[Execution] Model compiled!" << std::endl;
 
   // Prepare input/output data
@@ -262,7 +259,6 @@ int main(const int argc, char **argv)
     NNFW_ASSERT_FAIL(nnfw_set_input(onert_session, i, ti_input.dtype, inputs[i].data(), input_size),
                      "[ ERROR ] Failure to set input tensor buffer");
   }
-
   std::cout << "[Execution] Input data is defined!" << std::endl;
 
   for (uint32_t i = 0; i < num_outputs; i++)


### PR DESCRIPTION
It adds Model, Models, ModelOperandIndex, and ModelOperandIndexSequence.

Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

Related: #9206 


### For Reviewers
It is draft PR for supporting multiple model nnpkg, based on the draft in #6274.

The difference to #6274:
- This PR does not cover api_internal.
- This PR will change `ModelGraphs` since there were changes after #6274.

- 1st commit in this PR is exactly copy-and-paste of #6274 except for copyright year change 2021 → 2022.