### PR TITLE
[one-cmds] Use default dtype/granularity in qconfig

### DIFF
--- a/compiler/one-cmds/one-quantize
+++ b/compiler/one-cmds/one-quantize
@@ -23,6 +23,7 @@ import argparse
 import os
 import sys
 import tempfile
+import json
 
 import utils as _utils
 from utils import Command
@@ -218,9 +219,29 @@ def _set_default_values(args):
             args, 'input_dtype'):
         setattr(args, 'input_model_dtype', 'float32')
     if not _utils._is_valid_attr(args, 'quantized_dtype'):
-        setattr(args, 'quantized_dtype', 'uint8')
+        if _utils._is_valid_attr(args, 'quant_config'):
+            # Get quantized_dtype from qconfig file
+            try:
+                with open(getattr(args, 'quant_config')) as f:
+                    qconf = json.load(f)
+                    if 'default_quantization_dtype' in qconf:
+                        setattr(args, 'quantized_dtype', qconf['default_quantization_dtype'])
+            except json.decoder.JSONDecodeError:
+                print('Failed to decode ' + getattr(args, 'quant_config') + '. Please check it is a json file.')
+        else:
+            setattr(args, 'quantized_dtype', 'uint8')
     if not _utils._is_valid_attr(args, 'granularity'):
-        setattr(args, 'granularity', 'layer')
+        if _utils._is_valid_attr(args, 'quant_config'):
+            # Get granularity from qconfig file
+            try:
+                with open(getattr(args, 'quant_config')) as f:
+                    qconf = json.load(f)
+                    if 'default_granularity' in qconf:
+                        setattr(args, 'granularity', qconf['default_granularity'])
+            except json.decoder.JSONDecodeError:
+                print('Failed to decode ' + getattr(args, 'quant_config') + '. Please check it is a json file.')
+        else:
+            setattr(args, 'granularity', 'layer')
     if not _utils._is_valid_attr(args, 'mode'):
         setattr(args, 'mode', 'percentile')
     if not _utils._is_valid_attr(args, 'min_percentile'):

--- a/compiler/one-cmds/one-quantize
+++ b/compiler/one-cmds/one-quantize
@@ -219,6 +219,7 @@ def _set_default_values(args):
             args, 'input_dtype'):
         setattr(args, 'input_model_dtype', 'float32')
     if not _utils._is_valid_attr(args, 'quantized_dtype'):
+        setattr(args, 'quantized_dtype', 'uint8')
         if _utils._is_valid_attr(args, 'quant_config'):
             # Get quantized_dtype from qconfig file
             try:
@@ -226,13 +227,10 @@ def _set_default_values(args):
                     qconf = json.load(f)
                     if 'default_quantization_dtype' in qconf:
                         setattr(args, 'quantized_dtype', qconf['default_quantization_dtype'])
-                    else:
-                        setattr(args, 'quantized_dtype', 'uint8')
             except json.decoder.JSONDecodeError:
                 print('Failed to decode ' + getattr(args, 'quant_config') + '. Please check it is a json file.')
-        else:
-            setattr(args, 'quantized_dtype', 'uint8')
     if not _utils._is_valid_attr(args, 'granularity'):
+        setattr(args, 'granularity', 'layer')
         if _utils._is_valid_attr(args, 'quant_config'):
             # Get granularity from qconfig file
             try:
@@ -240,12 +238,8 @@ def _set_default_values(args):
                     qconf = json.load(f)
                     if 'default_granularity' in qconf:
                         setattr(args, 'granularity', qconf['default_granularity'])
-                    else:
-                        setattr(args, 'granularity', 'layer')
             except json.decoder.JSONDecodeError:
                 print('Failed to decode ' + getattr(args, 'quant_config') + '. Please check it is a json file.')
-        else:
-            setattr(args, 'granularity', 'layer')
     if not _utils._is_valid_attr(args, 'mode'):
         setattr(args, 'mode', 'percentile')
     if not _utils._is_valid_attr(args, 'min_percentile'):

--- a/compiler/one-cmds/one-quantize
+++ b/compiler/one-cmds/one-quantize
@@ -226,6 +226,8 @@ def _set_default_values(args):
                     qconf = json.load(f)
                     if 'default_quantization_dtype' in qconf:
                         setattr(args, 'quantized_dtype', qconf['default_quantization_dtype'])
+                    else:
+                        setattr(args, 'quantized_dtype', 'uint8')
             except json.decoder.JSONDecodeError:
                 print('Failed to decode ' + getattr(args, 'quant_config') + '. Please check it is a json file.')
         else:
@@ -238,6 +240,8 @@ def _set_default_values(args):
                     qconf = json.load(f)
                     if 'default_granularity' in qconf:
                         setattr(args, 'granularity', qconf['default_granularity'])
+                    else:
+                        setattr(args, 'granularity', 'layer')
             except json.decoder.JSONDecodeError:
                 print('Failed to decode ' + getattr(args, 'quant_config') + '. Please check it is a json file.')
         else:

--- a/compiler/one-cmds/tests/one-quantize_013.qconf.json
+++ b/compiler/one-cmds/tests/one-quantize_013.qconf.json
@@ -1,0 +1,16 @@
+{
+    "default_quantization_dtype" : "uint8",
+    "default_granularity" : "channel",
+    "layers" : [
+        {
+            "names" : ["InceptionV3/InceptionV3/Conv2d_2b_3x3/Relu;InceptionV3/InceptionV3/Conv2d_2b_3x3/BatchNorm/FusedBatchNorm;InceptionV3/InceptionV3/Mixed_6a/Branch_1/Conv2d_0a_1x1/Conv2D;InceptionV3/InceptionV3/Conv2d_2b_3x3/Conv2D",
+            "InceptionV3/InceptionV3/MaxPool_5a_3x3/MaxPool",
+            "InceptionV3/InceptionV3/Mixed_5b/concat",
+            "InceptionV3/InceptionV3/Mixed_5b/Branch_3/AvgPool_0a_3x3/AvgPool",
+            "InceptionV3/InceptionV3/Mixed_7c/concat",
+            "InceptionV3/Predictions/Reshape_1"],
+            "dtype" : "int16",
+            "granularity" : "channel"
+        }
+    ]
+}

--- a/compiler/one-cmds/tests/one-quantize_013.test
+++ b/compiler/one-cmds/tests/one-quantize_013.test
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# quantized_dtype and granularity are given by qconfig file
+# (not by command line interface)
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  echo "${filename_ext} FAILED"
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+inputfile="./inception_v3.circle"
+outputfile="./inception_v3.one-quantize_013.q.circle"
+
+rm -rf ${outputfile}
+
+# run test without input data
+# quantized_dtype and granularity are not given here
+one-quantize \
+--input_dtype float32 \
+--quant_config one-quantize_013.qconf.json \
+--input_path ${inputfile} \
+--output_path ${outputfile} > /dev/null 2>&1
+
+if [[ ! -s "${outputfile}" ]]; then
+  trap_err_onexit
+fi
+
+echo "${filename_ext} SUCCESS"

--- a/compiler/one-cmds/tests/one-quantize_neg_020.test
+++ b/compiler/one-cmds/tests/one-quantize_neg_020.test
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# check error message is printed when qconfig file is not json
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  if grep -q "Failed to decode" "${filename}.log"; then
+    echo "${filename_ext} SUCCESS"
+    exit 0
+  fi
+
+  echo "${filename_ext} FAILED"
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+inputfile="./inception_v3.circle"
+outputfile="./inception_v3.quantized.neg_020.circle"
+
+rm -rf ${outputfile}.log
+
+# run test
+one-quantize \
+--input_dtype float32 \
+--quant_config one-quantize_neg_020.test \
+--input_path ${inputfile} \
+--output_path ${outputfile} > ${filename}.log 2>&1
+
+echo "${filename_ext} FAILED"
+exit 255


### PR DESCRIPTION
This uses default dtype/granularity in qconfig file.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>