### PR TITLE
[one-cmds] Fix `one-infer` man page

### DIFF
--- a/infra/debian/compiler/docs/one-infer.1
+++ b/infra/debian/compiler/docs/one-infer.1
@@ -1,10 +1,12 @@
-.TH ONE-INFER "1" "June 2022" "one-profile version 1.21.0" "User Commands"
+.TH ONE-INFER "1" "June 2022" "one-infer version 1.21.0" "User Commands"
 .SH NAME
 \fBone-infer\fR \- infer model file
 .SH DESCRIPTION
-usage: one\-infer [\-h] [\-v] [\-V] [\-C CONFIG] [\-b BACKEND] [\-d DRIVER] [\-\-] [COMMANDS FOR BACKEND]
+usage: one\-infer [\-h] [\-v] [\-V] [\-C CONFIG] [\-b BACKEND | \-d DRIVER] [\-\-] [COMMANDS FOR BACKEND]
 .PP
 \fBone\-infer\fR is a command line tool to infer model.
+.PP
+[\-b BACKEND] and [\-d DRIVER] are mutually exclusive options.
 .SH OPTIONS
 .TP
 \fB\-h\fR, \fB\-\-help\fR
@@ -20,7 +22,7 @@ output additional information to stdout or stderr
 run with configuation file
 .TP
 \fB\-b\fR BACKEND, \fB\-\-backend\fR BACKEND
-backend name to use
+backend name to find \fIBACKEND\fR\-infer driver
 .TP
 \fB\-d\fR DRIVER, \fB\-\-driver\fR DRIVER
 backend inference driver name to execute


### PR DESCRIPTION
This commit fixes `one-infer` man page to include
enough information about the command itself.

Signed-off-by: yunjay-hong <yunjay.hong@samsung.com>

---

Left is master and right is this pr's

![image](https://user-images.githubusercontent.com/50489513/173043349-a00776b2-6450-4ae8-b3f1-3dfb35b8c8e2.png)

I think one approval is enough :)