### PR TITLE
[circle-eval-diff] Support directory input

### DIFF
--- a/compiler/circle-eval-diff/driver/Driver.cpp
+++ b/compiler/circle-eval-diff/driver/Driver.cpp
@@ -32,8 +32,12 @@ std::string to_lower_case(std::string s)
 
 InputFormat to_input_format(const std::string &str)
 {
-  if (to_lower_case(str).compare("h5") == 0)
+  auto small_str = to_lower_case(str);
+  if (small_str.compare("h5") == 0)
     return InputFormat::H5;
+
+  if (small_str.compare("directory") == 0 || small_str.compare("dir") == 0)
+    return InputFormat::DIR;
 
   throw std::runtime_error("Unsupported input format.");
 }

--- a/compiler/circle-eval-diff/src/InputDataLoader.cpp
+++ b/compiler/circle-eval-diff/src/InputDataLoader.cpp
@@ -20,6 +20,11 @@
 #include <loco/IR/Graph.h>
 #include <luci/IR/CircleNodes.h>
 
+#include <cstring>
+#include <dirent.h>
+#include <fstream>
+#include <vector>
+
 using DataType = loco::DataType;
 using Shape = std::vector<loco::Dimension>;
 
@@ -41,6 +46,46 @@ void verifyTypeShape(const luci::CircleInput *input_node, const DataType &dtype,
     if (not(shape.at(i) == input_node->dim(i)))
       throw std::runtime_error("Input shape mismatch.");
   }
+}
+
+std::vector<size_t> getEachByteSizeOf(const std::vector<loco::Node *> &nodes)
+{
+  std::vector<size_t> vec;
+
+  for (const auto node : nodes)
+  {
+    const auto input_node = loco::must_cast<const luci::CircleInput *>(node);
+    size_t element_size = 1;
+
+    for (uint32_t index = 0; index < input_node->rank(); index++)
+    {
+      element_size *= input_node->dim(index).value();
+    }
+
+    vec.push_back(element_size);
+  }
+
+  return vec;
+}
+
+size_t getTotalByteSizeOf(const std::vector<loco::Node *> &nodes)
+{
+  size_t total_byte_size = 0;
+
+  for (const auto node : nodes)
+  {
+    const auto input_node = loco::must_cast<const luci::CircleInput *>(node);
+    size_t byte_size = loco::size(input_node->dtype());
+
+    for (uint32_t index = 0; index < input_node->rank(); index++)
+    {
+      byte_size *= input_node->dim(index).value();
+    }
+
+    total_byte_size += byte_size;
+  }
+
+  return total_byte_size;
 }
 
 } // namespace circle_eval_diff
@@ -90,6 +135,65 @@ InputDataLoader::Data HDF5Loader::get(uint32_t data_idx) const
   return data;
 }
 
+DirectoryLoader::DirectoryLoader(const std::string &dir_path,
+                                 const std::vector<loco::Node *> &input_nodes)
+  : _input_nodes{input_nodes}
+{
+  DIR *dir = opendir(dir_path.c_str());
+  if (not dir)
+  {
+    throw std::runtime_error("Cannot open directory \"" + dir_path + "\".");
+  }
+
+  struct dirent *entry = nullptr;
+  std::vector<size_t> input_bytes = getEachByteSizeOf(input_nodes);
+  const auto input_total_bytes = getTotalByteSizeOf(input_nodes);
+  while (entry = readdir(dir))
+  {
+    // Skip if the entry is not a regular file
+    if (entry->d_type != DT_REG)
+      continue;
+
+    // Read raw data
+    std::vector<char> input_data(input_total_bytes);
+    const std::string raw_data_path = dir_path + "/" + entry->d_name;
+    std::ifstream fs(raw_data_path, std::ifstream::binary);
+    if (fs.fail())
+    {
+      throw std::runtime_error("Cannot open file \"" + raw_data_path + "\".");
+    }
+    if (fs.read(input_data.data(), input_total_bytes).fail())
+    {
+      throw std::runtime_error("Failed to read raw data from file \"" + raw_data_path + "\".");
+    }
+
+    // Make Tensor from raw data
+    auto input_data_cur = input_data.data();
+
+    _data_set.emplace_back();
+    auto tensors = _data_set.back();
+    tensors.resize(input_nodes.size());
+    for (uint32_t index = 0; index < input_nodes.size(); index++)
+    {
+      const auto input_node = loco::must_cast<const luci::CircleInput *>(input_nodes.at(index));
+      auto &tensor = tensors.at(index);
+      tensor = *createEmptyTensor(input_node).get();
+      auto buffer = tensor.buffer();
+      std::memcpy(buffer, input_data_cur, input_bytes.at(index));
+      input_data_cur += input_bytes.at(index);
+    }
+  }
+
+  closedir(dir);
+}
+
+uint32_t DirectoryLoader::size(void) const { return _data_set.size(); }
+
+InputDataLoader::Data DirectoryLoader::get(uint32_t data_idx) const
+{
+  return _data_set.at(data_idx);
+}
+
 std::unique_ptr<InputDataLoader> makeDataLoader(const std::string &file_path,
                                                 const InputFormat &format,
                                                 const std::vector<loco::Node *> &input_nodes)
@@ -99,6 +203,10 @@ std::unique_ptr<InputDataLoader> makeDataLoader(const std::string &file_path,
     case InputFormat::H5:
     {
       return std::make_unique<HDF5Loader>(file_path, input_nodes);
+    }
+    case InputFormat::DIR:
+    {
+      return std::make_unique<DirectoryLoader>(file_path, input_nodes);
     }
     default:
       throw std::runtime_error{"Unsupported input format."};

--- a/compiler/circle-eval-diff/src/InputDataLoader.h
+++ b/compiler/circle-eval-diff/src/InputDataLoader.h
@@ -86,7 +86,7 @@ public:
 
 private:
   const std::vector<loco::Node *> _input_nodes;
-  std::vector<Data> _data_set;
+  std::vector<std::string> _data_paths;
 };
 
 std::unique_ptr<InputDataLoader> makeDataLoader(const std::string &file_path,

--- a/compiler/circle-eval-diff/src/InputDataLoader.h
+++ b/compiler/circle-eval-diff/src/InputDataLoader.h
@@ -41,6 +41,7 @@ enum class InputFormat
 {
   Undefined, // For debugging
   H5,
+  DIR, // directory
   // TODO Implement Random, Directory
 };
 
@@ -71,6 +72,21 @@ public:
 private:
   const std::vector<loco::Node *> _input_nodes;
   std::unique_ptr<dio::hdf5::HDF5Importer> _hdf5;
+};
+
+// This class loads the directory that has raw data binary files.
+class DirectoryLoader final : public InputDataLoader
+{
+public:
+  DirectoryLoader(const std::string &dir_path, const std::vector<loco::Node *> &input_nodes);
+
+public:
+  uint32_t size(void) const final;
+  Data get(uint32_t data_idx) const final;
+
+private:
+  const std::vector<loco::Node *> _input_nodes;
+  std::vector<Data> _data_set;
 };
 
 std::unique_ptr<InputDataLoader> makeDataLoader(const std::string &file_path,


### PR DESCRIPTION
This commit makes `circle-eval-diff` support directory input.

Related test is gonna be posted after this pr is merged.
Related: #9224 
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>