### PR TITLE
[onert] Get CompilerOptions out of Compiler

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -198,7 +198,7 @@ void fillTensorInfo(nnfw_tensorinfo *ti, const onert::ir::Shape &shape,
 } // namespace
 
 nnfw_session::nnfw_session()
-  : _subgraphs{nullptr}, _compiler{nullptr}, _execution{nullptr},
+  : _subgraphs{nullptr}, _coptions{nullptr}, _compiler{nullptr}, _execution{nullptr},
     _kernel_registry{std::make_shared<onert::api::CustomKernelRegistry>()}, _tracing_ctx{nullptr}
 {
   // DO NOTHING
@@ -228,8 +228,9 @@ NNFW_STATUS nnfw_session::load_circle_from_buffer(uint8_t *buffer, size_t size)
   }
 
   _tracing_ctx = std::make_unique<onert::util::TracingCtx>(_subgraphs.get());
-
-  _compiler = std::make_unique<onert::compiler::Compiler>(_subgraphs, _tracing_ctx.get());
+  _coptions = std::make_unique<onert::compiler::CompilerOptions>(*_subgraphs);
+  _compiler =
+    std::make_unique<onert::compiler::Compiler>(_subgraphs, _tracing_ctx.get(), *_coptions);
 
   _state = State::MODEL_LOADED;
   return NNFW_STATUS_NO_ERROR;
@@ -280,11 +281,10 @@ NNFW_STATUS nnfw_session::load_model_from_modelfile(const char *model_file_path)
     std::cerr << "Error during model loading : " << e.what() << std::endl;
     return NNFW_STATUS_ERROR;
   }
-
   _tracing_ctx = std::make_unique<onert::util::TracingCtx>(_subgraphs.get());
-
-  _compiler = std::make_unique<onert::compiler::Compiler>(_subgraphs, _tracing_ctx.get());
-
+  _coptions = std::make_unique<onert::compiler::CompilerOptions>(*_subgraphs);
+  _compiler =
+    std::make_unique<onert::compiler::Compiler>(_subgraphs, _tracing_ctx.get(), *_coptions);
   _state = State::MODEL_LOADED;
   return NNFW_STATUS_NO_ERROR;
 }
@@ -367,11 +367,10 @@ NNFW_STATUS nnfw_session::load_model_from_nnpackage(const char *package_dir)
     std::cerr << "Error during model loading : " << e.what() << std::endl;
     return NNFW_STATUS_ERROR;
   }
-
   _tracing_ctx = std::make_unique<onert::util::TracingCtx>(_subgraphs.get());
-
-  _compiler = std::make_unique<onert::compiler::Compiler>(_subgraphs, _tracing_ctx.get());
-
+  _coptions = std::make_unique<onert::compiler::CompilerOptions>(*_subgraphs);
+  _compiler =
+    std::make_unique<onert::compiler::Compiler>(_subgraphs, _tracing_ctx.get(), *_coptions);
   _state = State::MODEL_LOADED;
   return NNFW_STATUS_NO_ERROR;
 }
@@ -430,6 +429,9 @@ NNFW_STATUS nnfw_session::prepare_pipeline(const char *map_file_path)
 
   try
   {
+    _tracing_ctx = std::make_unique<onert::util::TracingCtx>(_subgraphs.get());
+    _compiler =
+      std::make_unique<onert::compiler::Compiler>(_subgraphs, _tracing_ctx.get(), *_coptions);
     _subgraphs.reset();
     std::vector<std::shared_ptr<onert::exec::ExecutorMap>> executor_maps =
       _compiler->compile(_package_file_path.c_str(), map_file_path);
@@ -971,7 +973,7 @@ NNFW_STATUS nnfw_session::set_available_backends(const char *backends)
     if (null_terminating(backends, MAX_BACKEND_NAME_LENGTH) == false)
       return NNFW_STATUS_ERROR;
 
-    auto &options = _compiler->options();
+    auto &options = *_coptions;
 
     using namespace onert::util;
 
@@ -1005,7 +1007,7 @@ NNFW_STATUS nnfw_session::set_op_backend(const char *op, const char *backend)
       return NNFW_STATUS_ERROR;
     }
 
-    auto &opcode_to_backend = _compiler->options().manual_scheduler_options.opcode_to_backend;
+    auto &opcode_to_backend = _coptions->manual_scheduler_options.opcode_to_backend;
     opcode_to_backend.emplace(onert::ir::toOpCode(key), backend);
   }
   catch (const std::exception &e)
@@ -1024,7 +1026,7 @@ NNFW_STATUS nnfw_session::set_config(const char *key, const char *value)
   if (!key || !value)
     return NNFW_STATUS_UNEXPECTED_NULL;
 
-  auto &options = _compiler->options();
+  auto &options = *_coptions;
 
   using namespace onert::util;
 
@@ -1094,7 +1096,7 @@ NNFW_STATUS nnfw_session::get_config(const char *key, char *value, size_t value_
   if (!key || !value)
     return NNFW_STATUS_UNEXPECTED_NULL;
 
-  auto &options = _compiler->options();
+  auto &options = *_coptions;
 
   auto check_boundary = [](size_t dest_size, std::string &src) {
     if (dest_size < src.length() + 1 /* for '\0' */)

--- a/runtime/onert/api/src/nnfw_api_internal.h
+++ b/runtime/onert/api/src/nnfw_api_internal.h
@@ -46,6 +46,7 @@ class Subgraphs;
 namespace compiler
 {
 class Compiler;
+class CompilerOptions;
 } // namespace compiler
 } // namespace onert
 
@@ -162,6 +163,7 @@ private:
 private:
   State _state{State::INITIALIZED};
   std::shared_ptr<onert::ir::Subgraphs> _subgraphs;
+  std::unique_ptr<onert::compiler::CompilerOptions> _coptions;
   std::unique_ptr<onert::compiler::Compiler> _compiler;
   std::unique_ptr<onert::exec::Execution> _execution;
   std::shared_ptr<onert::api::CustomKernelRegistry> _kernel_registry;

--- a/runtime/onert/core/include/compiler/Compiler.h
+++ b/runtime/onert/core/include/compiler/Compiler.h
@@ -50,8 +50,17 @@ struct PartialGraphOptions
   std::unordered_map<ir::OperationIndex, ir::SubgraphIndex> index_to_graph;
 };
 
-struct CompilerOptions
+class CompilerOptions
 {
+public:
+  CompilerOptions(const ir::Subgraphs &subgs) { fetchCompilerOptionsFromGlobalConfig(subgs); }
+
+private:
+  // Set default values for CompilerOptions
+  // All these default values should not be fetched from Env, when we stop supporting Android NNAPI.
+  void fetchCompilerOptionsFromGlobalConfig(const ir::Subgraphs &subgs);
+
+public:
   // GENERAL OPTIONS
   std::vector<std::string> backend_list;
 
@@ -69,8 +78,6 @@ struct CompilerOptions
   util::TracingCtx *tracing_ctx; //< Profiling information
 };
 
-CompilerOptions fetchCompilerOptionsFromGlobalConfig(const ir::Subgraphs &subgs);
-
 /**
  * @brief Class to compile graph model
  */
@@ -81,8 +88,10 @@ public:
    * @brief     Construct a new Compiler object
    * @param[in] subgs All subgraphs of a model
    * @param[in] tracing_ctx Profiling information
+   * @param[in] coptions Compiler Options
    */
-  Compiler(const std::shared_ptr<ir::Subgraphs> &subgs, util::TracingCtx *tracing_ctx);
+  Compiler(const std::shared_ptr<ir::Subgraphs> &subgs, util::TracingCtx *tracing_ctx,
+           CompilerOptions &copt);
 
 public:
   /**
@@ -133,7 +142,7 @@ private:
   // have to add allocate non-constant tensor memory of executors in execution time when each
   // subgraph is called.
   State _state;
-  CompilerOptions _options;
+  CompilerOptions &_options;
 };
 
 } // namespace compiler

--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -115,21 +115,19 @@ namespace onert
 namespace compiler
 {
 
-CompilerOptions fetchCompilerOptionsFromGlobalConfig(const ir::Subgraphs &subgs)
+void CompilerOptions::fetchCompilerOptionsFromGlobalConfig(const ir::Subgraphs &subgs)
 {
-  CompilerOptions options;
-  options.backend_list = nnfw::misc::split(util::getConfigString(util::config::BACKENDS), ';');
-  options.trace_filepath = util::getConfigString(util::config::TRACE_FILEPATH);
-  options.graph_dump_level = util::getConfigInt(util::config::GRAPH_DOT_DUMP);
-  options.executor = util::getConfigString(util::config::EXECUTOR);
-  options.he_scheduler = util::getConfigBool(util::config::USE_SCHEDULER);
-  options.he_profiling_mode = util::getConfigBool(util::config::PROFILING_MODE);
-  options.disable_compile = util::getConfigBool(util::config::DISABLE_COMPILE);
-  options.fp16_enable = util::getConfigBool(util::config::FP16_ENABLE);
-
+  backend_list = nnfw::misc::split(util::getConfigString(util::config::BACKENDS), ';');
+  trace_filepath = util::getConfigString(util::config::TRACE_FILEPATH);
+  graph_dump_level = util::getConfigInt(util::config::GRAPH_DOT_DUMP);
+  executor = util::getConfigString(util::config::EXECUTOR);
+  he_scheduler = util::getConfigBool(util::config::USE_SCHEDULER);
+  he_profiling_mode = util::getConfigBool(util::config::PROFILING_MODE);
+  disable_compile = util::getConfigBool(util::config::DISABLE_COMPILE);
+  fp16_enable = util::getConfigBool(util::config::FP16_ENABLE);
   {
     // Backend for all
-    auto &ms_options = options.manual_scheduler_options;
+    auto &ms_options = manual_scheduler_options;
 
     // Default value for op_backend_all is first element in the backend list
     ms_options.backend_for_all = util::getConfigString(util::config::OP_BACKEND_ALLOPS);
@@ -150,17 +148,12 @@ CompilerOptions fetchCompilerOptionsFromGlobalConfig(const ir::Subgraphs &subgs)
     auto map_str = util::getConfigString(util::config::OP_BACKEND_MAP);
     setBackendMap(ms_options, subgs, map_str);
   }
-  return options;
 }
 
-Compiler::Compiler(const std::shared_ptr<ir::Subgraphs> &subgs, util::TracingCtx *tracing_ctx)
-  : _subgraphs{subgs}, _state{State::CREATED}
+Compiler::Compiler(const std::shared_ptr<ir::Subgraphs> &subgs, util::TracingCtx *tracing_ctx,
+                   CompilerOptions &copt)
+  : _subgraphs{subgs}, _state{State::CREATED}, _options(copt)
 {
-  // Set default values for CompilerOptions
-  // All these default values should not be fetched from Env, when we stop supporting Android NN
-  // API.
-  _options = fetchCompilerOptionsFromGlobalConfig(*subgs);
-
   _options.tracing_ctx = tracing_ctx;
 }
 

--- a/runtime/onert/core/src/compiler/HEScheduler.test.cc
+++ b/runtime/onert/core/src/compiler/HEScheduler.test.cc
@@ -391,8 +391,8 @@ TEST_P(HESchedulerTestWithExecutorParam, straight_graph_known_exec_time)
     et.storeOperationsExecTime();
 
     // Test scheduler
-    auto scheduler =
-      compiler::HEScheduler(_mock_backends, compiler::fetchCompilerOptionsFromGlobalConfig(subgs));
+    onert::compiler::CompilerOptions coptions(subgs);
+    auto scheduler = compiler::HEScheduler(_mock_backends, coptions);
     const auto br = scheduler.schedule(*graph);
     ASSERT_EQ(br->getBackend(add_op_idx)->config()->id(), "cpu");
     ASSERT_EQ(br->getBackend(sub_op_idx)->config()->id(), "gpu");
@@ -406,8 +406,8 @@ TEST_P(HESchedulerTestWithExecutorParam, straight_graph_known_exec_time)
     setPermutationsExecutionTime(_mock_backends, OPERAND_SIZE, 1e5);
 
     // Test scheduler
-    auto scheduler =
-      compiler::HEScheduler(_mock_backends, compiler::fetchCompilerOptionsFromGlobalConfig(subgs));
+    onert::compiler::CompilerOptions coptions(subgs);
+    auto scheduler = compiler::HEScheduler(_mock_backends, coptions);
     const auto br = scheduler.schedule(*graph);
     ASSERT_EQ(br->getBackend(add_op_idx)->config()->id(), "cpu");
     ASSERT_EQ(br->getBackend(sub_op_idx)->config()->id(), "cpu");
@@ -448,8 +448,8 @@ TEST_P(HESchedulerTestWithExecutorParam, branched_graph_known_exec_time)
     et.storeOperationsExecTime();
 
     // Test scheduler
-    auto scheduler =
-      compiler::HEScheduler(_mock_backends, compiler::fetchCompilerOptionsFromGlobalConfig(subgs));
+    onert::compiler::CompilerOptions coptions(subgs);
+    auto scheduler = compiler::HEScheduler(_mock_backends, coptions);
     const auto br = scheduler.schedule(*graph);
 
     std::string branch1_expected_backend("npu"), branch2_expected_backend("npu");
@@ -482,8 +482,8 @@ TEST_P(HESchedulerTestWithExecutorParam, branched_graph_known_exec_time)
     et.storeOperationsExecTime();
 
     // Test scheduler
-    auto scheduler =
-      compiler::HEScheduler(_mock_backends, compiler::fetchCompilerOptionsFromGlobalConfig(subgs));
+    onert::compiler::CompilerOptions coptions(subgs);
+    auto scheduler = compiler::HEScheduler(_mock_backends, coptions);
     const auto br = scheduler.schedule(*graph);
     ASSERT_EQ(br->getBackend(add_op_idx)->config()->id(), "npu");
     ASSERT_EQ(br->getBackend(mul1_op_idx)->config()->id(), "npu");
@@ -527,8 +527,8 @@ TEST_F(HESchedulerTest, branched_graph_profiling_mode)
     et.storeOperationsExecTime();
 
     // Test scheduler
-    auto scheduler =
-      compiler::HEScheduler(_mock_backends, compiler::fetchCompilerOptionsFromGlobalConfig(subgs));
+    onert::compiler::CompilerOptions coptions(subgs);
+    auto scheduler = compiler::HEScheduler(_mock_backends, coptions);
     const auto br = scheduler.schedule(*graph);
     ASSERT_EQ(br->getBackend(mul1_op_idx)->config()->id(), "npu");
     ASSERT_EQ(br->getBackend(mul2_op_idx)->config()->id(), "npu");
@@ -549,8 +549,8 @@ TEST_F(HESchedulerTest, branched_graph_profiling_mode)
     et.storeOperationsExecTime();
 
     // Test scheduler
-    auto scheduler =
-      compiler::HEScheduler(_mock_backends, compiler::fetchCompilerOptionsFromGlobalConfig(subgs));
+    onert::compiler::CompilerOptions coptions(subgs);
+    auto scheduler = compiler::HEScheduler(_mock_backends, coptions);
     const auto br = scheduler.schedule(*graph);
     ASSERT_NE(br->getBackend(add_op_idx)->config()->id(),
               br->getBackend(mul1_op_idx)->config()->id());

--- a/runtime/onert/core/src/exec/Execution.test.cc
+++ b/runtime/onert/core/src/exec/Execution.test.cc
@@ -80,7 +80,8 @@ public:
     auto subgs = std::make_shared<onert::ir::Subgraphs>();
     subgs->push(onert::ir::SubgraphIndex{0}, graph);
     tracing_ctx = std::make_unique<onert::util::TracingCtx>(subgs.get());
-    onert::compiler::Compiler compiler{subgs, tracing_ctx.get()};
+    coptions = std::make_unique<onert::compiler::CompilerOptions>(*subgs);
+    onert::compiler::Compiler compiler{subgs, tracing_ctx.get(), *coptions};
     executors = compiler.compile();
   }
 
@@ -88,6 +89,7 @@ public:
   std::shared_ptr<Graph> graph;
   std::shared_ptr<onert::exec::ExecutorMap> executors;
   std::unique_ptr<onert::util::TracingCtx> tracing_ctx;
+  std::unique_ptr<onert::compiler::CompilerOptions> coptions;
 };
 
 TEST(ExecInstance, simple)
@@ -142,7 +144,8 @@ TEST(ExecInstance, twoCompile)
   auto subgs = std::make_shared<onert::ir::Subgraphs>();
   subgs->push(onert::ir::SubgraphIndex{0}, graph);
   auto tracing_ctx = std::make_unique<onert::util::TracingCtx>(subgs.get());
-  onert::compiler::Compiler compiler{subgs, tracing_ctx.get()};
+  auto coptions = std::make_unique<onert::compiler::CompilerOptions>(*subgs);
+  onert::compiler::Compiler compiler{subgs, tracing_ctx.get(), *coptions};
   std::shared_ptr<onert::exec::ExecutorMap> executors2 = compiler.compile();
   onert::exec::Execution execution2{executors2};
 

--- a/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksCompilation.cc
+++ b/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksCompilation.cc
@@ -18,11 +18,15 @@
 
 #include "util/logging.h"
 
+using namespace onert;
+
 // TODO Support multiple subgraphs
 ANeuralNetworksCompilation::ANeuralNetworksCompilation(const ANeuralNetworksModel *model) noexcept
-  : _subgraphs{model->getSubGraphs()}, _tracing_ctx{std::make_unique<onert::util::TracingCtx>(
+  : _subgraphs{model->getSubGraphs()}, _tracing_ctx{std::make_unique<util::TracingCtx>(
                                          _subgraphs.get())},
-    _compiler{new onert::compiler::Compiler{_subgraphs, _tracing_ctx.get()}}
+    _coptions{std::make_unique<compiler::CompilerOptions>(*_subgraphs)},
+    _compiler{std::make_shared<compiler::Compiler>(_subgraphs, _tracing_ctx.get(), *_coptions)}
+
 {
   if (model->allowedToFp16())
   {

--- a/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksCompilation.h
+++ b/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksCompilation.h
@@ -49,6 +49,7 @@ private:
   // and let's make it work with one model for now.
   std::unique_ptr<onert::util::TracingCtx> _tracing_ctx;
 
+  std::unique_ptr<onert::compiler::CompilerOptions> _coptions;
   std::shared_ptr<onert::compiler::Compiler> _compiler;
   std::shared_ptr<onert::exec::ExecutorMap> _executors;
 };


### PR DESCRIPTION
CompilerOptions outlives Compiler.
CompilerOptions are prepared before Compiler::compile()
  - nnfw_set_available_backecnds(), nnfw_set/get_config().

Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

Related: https://github.com/Samsung/ONE/pull/9271#issuecomment-1158387870