### PR TITLE
[onert/test] Rename TEST_CASE to TEST_SUITE

### DIFF
--- a/runtime/onert/core/src/compiler/HEScheduler.test.cc
+++ b/runtime/onert/core/src/compiler/HEScheduler.test.cc
@@ -361,8 +361,8 @@ class HESchedulerTestWithExecutorParam : public HESchedulerTest,
 
 // SchedulerTestWithExecutorParam tests are parameterized with executor name and runs three times -
 // one time for each executor
-INSTANTIATE_TEST_CASE_P(AllExecutors, HESchedulerTestWithExecutorParam,
-                        testing::Values(LINEAR, DATAFLOW, PARALLEL));
+INSTANTIATE_TEST_SUITE_P(AllExecutors, HESchedulerTestWithExecutorParam,
+                         testing::Values(LINEAR, DATAFLOW, PARALLEL));
 
 // Test scheduler behavior for straight graph with known execution time of all nodes and permutes.
 TEST_P(HESchedulerTestWithExecutorParam, straight_graph_known_exec_time)

--- a/tests/nnfw_api/src/one_op_tests/ArgMinMax.test.cc
+++ b/tests/nnfw_api/src/one_op_tests/ArgMinMax.test.cc
@@ -37,7 +37,7 @@ class ArgMinMaxVariation : public GenModelTest,
 // Output shape: {1, 2, 1}
 // Output type: Int32
 // Test with different input type and value
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
   GenModelTest, ArgMinMaxVariation,
   ::testing::Values(
     // ArgMax, float input

--- a/tests/nnfw_api/src/one_op_tests/AveragePool2D.test.cc
+++ b/tests/nnfw_api/src/one_op_tests/AveragePool2D.test.cc
@@ -43,7 +43,7 @@ class AveragePool2DVariation : public GenModelTest,
 };
 
 // Test with different input type and value
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
   GenModelTest, AveragePool2DVariation,
   ::testing::Values(
     // float data

--- a/tests/nnfw_api/src/one_op_tests/Concat.test.cc
+++ b/tests/nnfw_api/src/one_op_tests/Concat.test.cc
@@ -59,7 +59,7 @@ class ConcatVariation : public GenModelTest,
 
 // Input shape: {2, 3} / {2, 3}
 // Output shape: {4, 3}
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
   GenModelTest, ConcatVariation,
   ::testing::Values(
     // Float

--- a/tests/nnfw_api/src/one_op_tests/DepthToSpace.test.cc
+++ b/tests/nnfw_api/src/one_op_tests/DepthToSpace.test.cc
@@ -32,7 +32,7 @@ class DepthToSpaceVariation : public GenModelTest,
 // Input shape: {1, 1, 2, 4}
 // Block size: 2
 // Output shape: {1, 2, 4, 1}
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
   GenModelTest, DepthToSpaceVariation,
   ::testing::Values(
     // Float

--- a/tests/nnfw_api/src/one_op_tests/DepthwiseConv2D.test.cc
+++ b/tests/nnfw_api/src/one_op_tests/DepthwiseConv2D.test.cc
@@ -259,7 +259,7 @@ using DepthwiseConv2DQuantTestU8 = DepthwiseConv2DQuantTest<uint8_t>;
 
 // Test with different InputDepth and DepthMultiplier. The values are intended to test optimized CPU
 // kernels.
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
   GenModelTest, DepthwiseConv2DQuantTestU8,
   ::testing::Values(
     // Stride == 1
@@ -342,7 +342,7 @@ using DepthwiseConv2DQuantTestI8 = DepthwiseConv2DQuantTest<int8_t>;
 
 // Test with different InputDepth and DepthMultiplier. The values are intended to test optimized CPU
 // kernels.
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
   GenModelTest, DepthwiseConv2DQuantTestI8,
   ::testing::Values(
     // Stride == 1

--- a/tests/nnfw_api/src/one_op_tests/Fill.test.cc
+++ b/tests/nnfw_api/src/one_op_tests/Fill.test.cc
@@ -56,7 +56,7 @@ const int64_t test_int64 = 1052;
 const float test_float = 5.2;
 
 // Test with different value type
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
   GenModelTest, FillVariation,
   ::testing::Values(
     // float value

--- a/tests/nnfw_api/src/one_op_tests/If.test.cc
+++ b/tests/nnfw_api/src/one_op_tests/If.test.cc
@@ -126,7 +126,7 @@ TEST_P(IfWrongSubgraphIndex, neg_Test)
   SUCCEED();
 }
 
-INSTANTIATE_TEST_CASE_P(GenModelTest, IfWrongSubgraphIndex,
-                        ::testing::Values(std::make_pair(99, 2), std::make_pair(-1, 2),
-                                          std::make_pair(1, 99), std::make_pair(1, -99),
-                                          std::make_pair(-99, 99)));
+INSTANTIATE_TEST_SUITE_P(GenModelTest, IfWrongSubgraphIndex,
+                         ::testing::Values(std::make_pair(99, 2), std::make_pair(-1, 2),
+                                           std::make_pair(1, 99), std::make_pair(1, -99),
+                                           std::make_pair(-99, 99)));

--- a/tests/nnfw_api/src/one_op_tests/Pad.test.cc
+++ b/tests/nnfw_api/src/one_op_tests/Pad.test.cc
@@ -32,7 +32,7 @@ class PadVariation : public GenModelTest, public ::testing::WithParamInterface<P
 };
 
 // Test with different value type
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
   GenModelTest, PadVariation,
   ::testing::Values(
     // float value

--- a/tests/nnfw_api/src/one_op_tests/Reduce.test.cc
+++ b/tests/nnfw_api/src/one_op_tests/Reduce.test.cc
@@ -63,8 +63,8 @@ TEST_P(ReduceMaxBadIndex, neg_Test)
   SUCCEED();
 }
 
-INSTANTIATE_TEST_CASE_P(GenModelTest, ReduceMaxBadIndex,
-                        ::testing::Values(std::vector<int32_t>{0, 1, 2, 4},
-                                          std::vector<int32_t>{0, -5, 2, 3},
-                                          std::vector<int32_t>{-88, 1, 2, 3},
-                                          std::vector<int32_t>{0, 1, 88, 3}));
+INSTANTIATE_TEST_SUITE_P(GenModelTest, ReduceMaxBadIndex,
+                         ::testing::Values(std::vector<int32_t>{0, 1, 2, 4},
+                                           std::vector<int32_t>{0, -5, 2, 3},
+                                           std::vector<int32_t>{-88, 1, 2, 3},
+                                           std::vector<int32_t>{0, 1, 88, 3}));

--- a/tests/nnfw_api/src/one_op_tests/ResizeBilinear.test.cc
+++ b/tests/nnfw_api/src/one_op_tests/ResizeBilinear.test.cc
@@ -51,7 +51,7 @@ TEST_P(ResizeBilinearVariation, Test)
   SUCCEED();
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
   GenModelTest, ResizeBilinearVariation,
   ::testing::Values(
     // float value

--- a/tests/nnfw_api/src/one_op_tests/Slice.test.cc
+++ b/tests/nnfw_api/src/one_op_tests/Slice.test.cc
@@ -34,7 +34,7 @@ class SliceVariation : public GenModelTest,
 {
 };
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
   GenModelTest, SliceVariation,
   ::testing::Values(
     SliceVariationParam{

--- a/tests/nnfw_api/src/one_op_tests/Softmax.test.cc
+++ b/tests/nnfw_api/src/one_op_tests/Softmax.test.cc
@@ -31,7 +31,7 @@ class SoftmaxVariation : public GenModelTest, public ::testing::WithParamInterfa
 };
 
 // Test with different value type
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
   GenModelTest, SoftmaxVariation,
   ::testing::Values(
     // float value

--- a/tests/nnfw_api/src/one_op_tests/While.test.cc
+++ b/tests/nnfw_api/src/one_op_tests/While.test.cc
@@ -213,10 +213,10 @@ TEST_P(WhileWrongSubgraphIndex, neg_Test)
   SUCCEED();
 }
 
-INSTANTIATE_TEST_CASE_P(GenModelTest, WhileWrongSubgraphIndex,
-                        ::testing::Values(std::make_pair(99, 2), std::make_pair(-1, 2),
-                                          std::make_pair(1, 99), std::make_pair(1, -99),
-                                          std::make_pair(-99, 99)));
+INSTANTIATE_TEST_SUITE_P(GenModelTest, WhileWrongSubgraphIndex,
+                         ::testing::Values(std::make_pair(99, 2), std::make_pair(-1, 2),
+                                           std::make_pair(1, 99), std::make_pair(1, -99),
+                                           std::make_pair(-99, 99)));
 
 // In this test, output of WHILE and body subgraph have different data types
 TEST_F(GenModelTest, neg_while_wrong_dtype)


### PR DESCRIPTION
This commit changes googletest TEST_CASE to TEST_SUITE.
TEST_CASE is deprecated to avoid confusing.

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related: http://google.github.io/googletest/primer.html#beware-of-the-nomenclature