### PR TITLE
[mio-tflite260] Update readme with obsolete

### DIFF
--- a/compiler/mio-tflite260/README.md
+++ b/compiler/mio-tflite260/README.md
@@ -1,3 +1,5 @@
 # mio-tflite260
 
 _mio-tflite260_ provides a library to access TensorFlow lite model files with V2.6.0.
+
+NOTE: _mio-tflite260_ is currently obsolete


### PR DESCRIPTION
This will update readme with note with this module is obsolete.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>