### PR TITLE
[onert/api] Remove _compiler from nnfw_session

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -198,7 +198,7 @@ void fillTensorInfo(nnfw_tensorinfo *ti, const onert::ir::Shape &shape,
 } // namespace
 
 nnfw_session::nnfw_session()
-  : _subgraphs{nullptr}, _coptions{nullptr}, _compiler{nullptr}, _execution{nullptr},
+  : _subgraphs{nullptr}, _coptions{nullptr}, _execution{nullptr},
     _kernel_registry{std::make_shared<onert::api::CustomKernelRegistry>()}, _tracing_ctx{nullptr}
 {
   // DO NOTHING
@@ -385,10 +385,10 @@ NNFW_STATUS nnfw_session::prepare()
   try
   {
     _tracing_ctx = std::make_unique<onert::util::TracingCtx>(_subgraphs.get());
-    _compiler =
+    auto compiler =
       std::make_unique<onert::compiler::Compiler>(_subgraphs, _tracing_ctx.get(), *_coptions);
     _subgraphs.reset();
-    std::shared_ptr<onert::exec::ExecutorMap> executors = _compiler->compile();
+    std::shared_ptr<onert::exec::ExecutorMap> executors = compiler->compile();
     _execution = std::make_unique<onert::exec::Execution>(executors);
   }
   catch (const std::exception &e)
@@ -422,11 +422,11 @@ NNFW_STATUS nnfw_session::prepare_pipeline(const char *map_file_path)
   try
   {
     _tracing_ctx = std::make_unique<onert::util::TracingCtx>(_subgraphs.get());
-    _compiler =
+    auto compiler =
       std::make_unique<onert::compiler::Compiler>(_subgraphs, _tracing_ctx.get(), *_coptions);
     _subgraphs.reset();
     std::vector<std::shared_ptr<onert::exec::ExecutorMap>> executor_maps =
-      _compiler->compile(_package_file_path.c_str(), map_file_path);
+      compiler->compile(_package_file_path.c_str(), map_file_path);
 
     for (auto it = executor_maps.begin(); it != executor_maps.end(); ++it)
     {
@@ -1133,7 +1133,7 @@ bool nnfw_session::isStateInitialized()
   if (_state == State::INITIALIZED)
   {
     assert(_subgraphs == nullptr);
-    assert(_compiler == nullptr);
+    assert(_coptions == nullptr);
     assert(_execution == nullptr && _executions.empty());
     return true;
   }
@@ -1148,7 +1148,7 @@ bool nnfw_session::isStateModelLoaded()
   if (_state == State::MODEL_LOADED)
   {
     assert(_subgraphs != nullptr);
-    assert(_compiler == nullptr);
+    assert(_coptions != nullptr);
     assert(_execution == nullptr && _executions.empty());
     return true;
   }
@@ -1163,7 +1163,7 @@ bool nnfw_session::isStatePrepared()
   if (_state == State::PREPARED)
   {
     assert(_subgraphs == nullptr);
-    assert(_compiler != nullptr);
+    assert(_coptions != nullptr);
     assert(_execution != nullptr || !_executions.empty());
     return true;
   }
@@ -1178,7 +1178,7 @@ bool nnfw_session::isStateRunning()
   if (_state == State::RUNNING)
   {
     assert(_subgraphs == nullptr);
-    assert(_compiler != nullptr);
+    assert(_coptions != nullptr);
     assert(_execution != nullptr || !_executions.empty());
     return true;
   }
@@ -1190,7 +1190,7 @@ bool nnfw_session::isStateFinishedRun()
   if (_state == State::FINISHED_RUN)
   {
     assert(_subgraphs == nullptr);
-    assert(_compiler != nullptr);
+    assert(_coptions != nullptr);
     assert(_execution != nullptr || !_executions.empty());
     return true;
   }

--- a/runtime/onert/api/src/nnfw_api_internal.h
+++ b/runtime/onert/api/src/nnfw_api_internal.h
@@ -168,7 +168,6 @@ private:
   State _state{State::INITIALIZED};
   std::shared_ptr<onert::ir::Subgraphs> _subgraphs;
   std::unique_ptr<onert::compiler::CompilerOptions> _coptions;
-  std::unique_ptr<onert::compiler::Compiler> _compiler;
   std::unique_ptr<onert::exec::Execution> _execution;
   std::shared_ptr<onert::api::CustomKernelRegistry> _kernel_registry;
   std::vector<std::thread> _threads;

--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -370,6 +370,7 @@ std::shared_ptr<exec::ExecutorMap> Compiler::compile(void)
   {
     _subgraphs->iterate([&](const ir::SubgraphIndex &index, ir::Graph &subg) {
       executors->emplace(index, std::make_unique<interp::InterpExecutor>(subg));
+      subg.setSubgraphs(_subgraphs);
     });
     _state = State::COMPILED;
     return executors;


### PR DESCRIPTION
_compiler is used during compile().
Let's kick off _compiler out of nnfw_session.

Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

From #9279