### PR TITLE
[onert] Introduce CompilerArtifact

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.h
+++ b/runtime/onert/api/src/nnfw_api_internal.h
@@ -45,7 +45,7 @@ class Subgraphs;
 } // namespace ir
 namespace compiler
 {
-class Compiler;
+struct CompilerArtifact;
 class CompilerOptions;
 } // namespace compiler
 } // namespace onert
@@ -168,12 +168,14 @@ private:
   State _state{State::INITIALIZED};
   std::shared_ptr<onert::ir::Subgraphs> _subgraphs;
   std::unique_ptr<onert::compiler::CompilerOptions> _coptions;
+  std::shared_ptr<onert::compiler::CompilerArtifact> _compiler_artifact;
   std::unique_ptr<onert::exec::Execution> _execution;
   std::shared_ptr<onert::api::CustomKernelRegistry> _kernel_registry;
   std::vector<std::thread> _threads;
   std::vector<std::shared_ptr<onert::exec::Execution>> _executions;
   std::string _package_file_path;
 
+  // TODO Remove _tracing_ctx
   std::unique_ptr<onert::util::TracingCtx> _tracing_ctx;
 };
 

--- a/runtime/onert/core/include/compiler/Compiler.h
+++ b/runtime/onert/core/include/compiler/Compiler.h
@@ -113,14 +113,14 @@ public:
   /**
    * @brief   Do compilation with the options
    *
-   * @return std::shared_ptr<CompilationResult> Executors as a result of compilation
+   * @return std::shared_ptr<CompilerArtifact> Executors as a result of compilation
    */
   std::shared_ptr<CompilerArtifact> compile(void);
 
   /**
    * @brief   Do compilation with the options
    *
-   * @return std::vector<std::shared_ptr<CompilationResult>> Executors as a result of compilation
+   * @return std::vector<std::shared_ptr<CompilerArtifact>> Executors as a result of compilation
    * for pipeline
    */
   std::vector<std::shared_ptr<CompilerArtifact>> compile(const char *package_file_path,

--- a/runtime/onert/core/include/compiler/Compiler.h
+++ b/runtime/onert/core/include/compiler/Compiler.h
@@ -79,7 +79,19 @@ public:
   bool fp16_enable;       //< Whether fp16 mode ON/OFF
   PartialGraphOptions partial_graph_options;
 
+  // TODO Remove tracing_ctx
   util::TracingCtx *tracing_ctx; //< Profiling information
+};
+
+struct CompilerArtifact
+{
+  CompilerArtifact(void) = delete;
+  CompilerArtifact(std::shared_ptr<exec::ExecutorMap> executors,
+                   std::unique_ptr<const util::TracingCtx> tracing_ctx)
+    : _executors{executors}, _tracing_ctx{std::move(tracing_ctx)} {};
+
+  std::shared_ptr<exec::ExecutorMap> _executors;
+  std::unique_ptr<const util::TracingCtx> _tracing_ctx;
 };
 
 /**
@@ -101,18 +113,18 @@ public:
   /**
    * @brief   Do compilation with the options
    *
-   * @return std::shared_ptr<exec::ExecutorMap> Executors as a result of compilation
+   * @return std::shared_ptr<CompilationResult> Executors as a result of compilation
    */
-  std::shared_ptr<exec::ExecutorMap> compile(void);
+  std::shared_ptr<CompilerArtifact> compile(void);
 
   /**
    * @brief   Do compilation with the options
    *
-   * @return std::vector<std::shared_ptr<exec::ExecutorMap>> Executors as a result of compilation
+   * @return std::vector<std::shared_ptr<CompilationResult>> Executors as a result of compilation
    * for pipeline
    */
-  std::vector<std::shared_ptr<exec::ExecutorMap>> compile(const char *package_file_path,
-                                                          const char *map_file_path);
+  std::vector<std::shared_ptr<CompilerArtifact>> compile(const char *package_file_path,
+                                                         const char *map_file_path);
 
   State state(void) const { return _state; }
 

--- a/runtime/onert/core/src/exec/Execution.test.cc
+++ b/runtime/onert/core/src/exec/Execution.test.cc
@@ -82,7 +82,7 @@ public:
     tracing_ctx = std::make_unique<onert::util::TracingCtx>(subgs.get());
     coptions = std::make_unique<onert::compiler::CompilerOptions>(*subgs);
     onert::compiler::Compiler compiler{subgs, tracing_ctx.get(), *coptions};
-    executors = compiler.compile();
+    executors = compiler.compile()->_executors;
   }
 
 public:
@@ -146,7 +146,7 @@ TEST(ExecInstance, twoCompile)
   auto tracing_ctx = std::make_unique<onert::util::TracingCtx>(subgs.get());
   auto coptions = std::make_unique<onert::compiler::CompilerOptions>(*subgs);
   onert::compiler::Compiler compiler{subgs, tracing_ctx.get(), *coptions};
-  std::shared_ptr<onert::exec::ExecutorMap> executors2 = compiler.compile();
+  std::shared_ptr<onert::exec::ExecutorMap> executors2 = compiler.compile()->_executors;
   onert::exec::Execution execution2{executors2};
 
   const float exe2_input1_buffer[4] = {2, 1, -2, 0};

--- a/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksCompilation.cc
+++ b/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksCompilation.cc
@@ -38,7 +38,7 @@ bool ANeuralNetworksCompilation::finish() noexcept
 {
   try
   {
-    _executors = _compiler->compile();
+    _artifact = _compiler->compile();
   }
   catch (const std::exception &e)
   {

--- a/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksCompilation.h
+++ b/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksCompilation.h
@@ -36,7 +36,13 @@ public:
   onert::compiler::State state(void) noexcept { return _compiler->state(); }
   void publish(std::shared_ptr<onert::exec::ExecutorMap> &executors) noexcept
   {
-    executors = _executors;
+    if (_artifact == nullptr)
+    {
+      executors = nullptr;
+      return;
+    }
+
+    executors = _artifact->_executors;
   }
 
 private:
@@ -51,7 +57,7 @@ private:
 
   std::unique_ptr<onert::compiler::CompilerOptions> _coptions;
   std::shared_ptr<onert::compiler::Compiler> _compiler;
-  std::shared_ptr<onert::exec::ExecutorMap> _executors;
+  std::shared_ptr<onert::compiler::CompilerArtifact> _artifact;
 };
 
 #endif

--- a/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksCompilation.h
+++ b/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksCompilation.h
@@ -36,13 +36,7 @@ public:
   onert::compiler::State state(void) noexcept { return _compiler->state(); }
   void publish(std::shared_ptr<onert::exec::ExecutorMap> &executors) noexcept
   {
-    if (_artifact == nullptr)
-    {
-      executors = nullptr;
-      return;
-    }
-
-    executors = _artifact->_executors;
+    executors = _artifact ? _artifact->_executors : nullptr;
   }
 
 private:


### PR DESCRIPTION
This commit introduceCompilerArtifact class.
Compiler returns CompilerArtifact which includes ExecutorMap and TracingCtx.

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: #9281
Draft: #9280 