### PR TITLE
[onert] Remove TracingCtx in CompilerOption

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -385,8 +385,7 @@ NNFW_STATUS nnfw_session::prepare()
   try
   {
     _tracing_ctx = std::make_unique<onert::util::TracingCtx>(_subgraphs.get());
-    auto compiler =
-      std::make_unique<onert::compiler::Compiler>(_subgraphs, _tracing_ctx.get(), *_coptions);
+    auto compiler = std::make_unique<onert::compiler::Compiler>(_subgraphs, *_coptions);
     _subgraphs.reset();
     _compiler_artifact = compiler->compile();
     _execution = std::make_unique<onert::exec::Execution>(_compiler_artifact->_executors);
@@ -422,8 +421,7 @@ NNFW_STATUS nnfw_session::prepare_pipeline(const char *map_file_path)
   try
   {
     _tracing_ctx = std::make_unique<onert::util::TracingCtx>(_subgraphs.get());
-    auto compiler =
-      std::make_unique<onert::compiler::Compiler>(_subgraphs, _tracing_ctx.get(), *_coptions);
+    auto compiler = std::make_unique<onert::compiler::Compiler>(_subgraphs, *_coptions);
     _subgraphs.reset();
     auto artifacts = compiler->compile(_package_file_path.c_str(), map_file_path);
 

--- a/runtime/onert/core/include/compiler/Compiler.h
+++ b/runtime/onert/core/include/compiler/Compiler.h
@@ -78,9 +78,6 @@ public:
   bool disable_compile;   //< Run with Interpreter if true, try compilation otherwise
   bool fp16_enable;       //< Whether fp16 mode ON/OFF
   PartialGraphOptions partial_graph_options;
-
-  // TODO Remove tracing_ctx
-  util::TracingCtx *tracing_ctx; //< Profiling information
 };
 
 struct CompilerArtifact
@@ -103,11 +100,9 @@ public:
   /**
    * @brief     Construct a new Compiler object
    * @param[in] subgs All subgraphs of a model
-   * @param[in] tracing_ctx Profiling information
    * @param[in] coptions Compiler Options
    */
-  Compiler(const std::shared_ptr<ir::Subgraphs> &subgs, util::TracingCtx *tracing_ctx,
-           CompilerOptions &copt);
+  Compiler(const std::shared_ptr<ir::Subgraphs> &subgs, CompilerOptions &copt);
 
 public:
   /**

--- a/runtime/onert/core/include/compiler/LoweredGraph.h
+++ b/runtime/onert/core/include/compiler/LoweredGraph.h
@@ -60,7 +60,7 @@ public:
 private:
   void makeLowerInfo(const compiler::BackendResolver &backend_resolver);
   void dumpLowerInfo();
-  void lowerGraph(const ir::Graph &graph, const compiler::CompilerOptions &options);
+  void lowerGraph(const compiler::CompilerOptions &options);
 
 private:
   ir::Graph _graph;

--- a/runtime/onert/core/src/compiler/ExecutorFactory.h
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.h
@@ -38,6 +38,7 @@ public:
 
 public:
   exec::IExecutor *create(std::unique_ptr<compiler::LoweredGraph> lowered_graph,
+                          const util::TracingCtx *tracing_ctx,
                           const compiler::CompilerOptions &options,
                           const std::shared_ptr<exec::ExecutorMap> &executor_map);
 
@@ -55,18 +56,21 @@ private:
 
   static exec::IExecutor *
   createLinearExecutor(std::unique_ptr<compiler::LoweredGraph> lowered_graph,
+                       const util::TracingCtx *tracing_ctx,
                        const compiler::CompilerOptions &options,
                        const std::shared_ptr<exec::ExecutorMap> &executor_map);
   static exec::IExecutor *
   createDataflowExecutor(std::unique_ptr<compiler::LoweredGraph> lowered_graph,
+                         const util::TracingCtx *tracing_ctx,
                          const compiler::CompilerOptions &options,
                          const std::shared_ptr<exec::ExecutorMap> &executor_map, bool parallel);
 
 private:
-  std::unordered_map<std::string, std::function<exec::IExecutor *(
-                                    std::unique_ptr<compiler::LoweredGraph>,
-                                    const compiler::CompilerOptions &options,
-                                    const std::shared_ptr<exec::ExecutorMap> &executor_map)>>
+  std::unordered_map<std::string,
+                     std::function<exec::IExecutor *(
+                       std::unique_ptr<compiler::LoweredGraph>, const util::TracingCtx *tracing_ctx,
+                       const compiler::CompilerOptions &options,
+                       const std::shared_ptr<exec::ExecutorMap> &executor_map)>>
     _map;
 };
 

--- a/runtime/onert/core/src/compiler/LoweredGraph.cc
+++ b/runtime/onert/core/src/compiler/LoweredGraph.cc
@@ -41,7 +41,7 @@ namespace compiler
 
 LoweredGraph::LoweredGraph(const ir::Graph &graph, const CompilerOptions &options) : _graph{graph}
 {
-  lowerGraph(graph, options);
+  lowerGraph(options);
 }
 
 // TODO Design better class and constructor to represent parent_graph
@@ -49,18 +49,11 @@ LoweredGraph::LoweredGraph(const ir::Graph &parent_graph, const ir::Graph &graph
                            const CompilerOptions &options)
   : _graph{graph}, _parent_graph{parent_graph}
 {
-  lowerGraph(graph, options);
+  lowerGraph(options);
 }
 
-void LoweredGraph::lowerGraph(const ir::Graph &graph, const CompilerOptions &options)
+void LoweredGraph::lowerGraph(const CompilerOptions &options)
 {
-  // set tracing_ctx for copied graph
-  if (options.tracing_ctx)
-  {
-    auto subgraph_index = options.tracing_ctx->getSubgraphIndex(&graph);
-    options.tracing_ctx->setSubgraphIndex(&_graph, subgraph_index.value());
-  }
-
   // Build backend contexts
   auto &backend_manager = BackendManager::get();
   // Create contexts for other backends

--- a/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksCompilation.cc
+++ b/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksCompilation.cc
@@ -25,7 +25,7 @@ ANeuralNetworksCompilation::ANeuralNetworksCompilation(const ANeuralNetworksMode
   : _subgraphs{model->getSubGraphs()}, _tracing_ctx{std::make_unique<util::TracingCtx>(
                                          _subgraphs.get())},
     _coptions{std::make_unique<compiler::CompilerOptions>(*_subgraphs)},
-    _compiler{std::make_shared<compiler::Compiler>(_subgraphs, _tracing_ctx.get(), *_coptions)}
+    _compiler{std::make_shared<compiler::Compiler>(_subgraphs, *_coptions)}
 
 {
   if (model->allowedToFp16())


### PR DESCRIPTION
This commit removes TracingCtx in CompilerOption.

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: https://github.com/Samsung/ONE/issues/9281
Draft: https://github.com/Samsung/ONE/pull/9280