### PR TITLE
[onert] Add comment about graph copy on lowering

### DIFF
--- a/runtime/onert/core/include/compiler/LoweredGraph.h
+++ b/runtime/onert/core/include/compiler/LoweredGraph.h
@@ -65,7 +65,7 @@ private:
 private:
   /**
    *  @brief  Copy of target graph for lowering
-   *  @note   It use copy of graph, not reference.
+   *  @note   It uses copy of graph, not reference.
    *          It allows the original graph can be compiled multiple times.
    */
   ir::Graph _graph;

--- a/runtime/onert/core/include/compiler/LoweredGraph.h
+++ b/runtime/onert/core/include/compiler/LoweredGraph.h
@@ -63,6 +63,11 @@ private:
   void lowerGraph(const ir::Graph &graph, const compiler::CompilerOptions &options);
 
 private:
+  /**
+   *  @brief  Copy of target graph for lowering
+   *  @note   It use copy of graph, not reference.
+   *          It allows the original graph can be compiled multiple times.
+   */
   ir::Graph _graph;
   ir::Graph _parent_graph;
   std::shared_ptr<ir::OperationIndexMap<int64_t>> _indexed_ranks;


### PR DESCRIPTION
This commit adds comment why lowering uses graph copy.

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>