### PR TITLE
[onert/nnapi] Remove tracing_ctx from ANeuralNetworkCompilation

### DIFF
--- a/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksCompilation.cc
+++ b/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksCompilation.cc
@@ -22,11 +22,9 @@ using namespace onert;
 
 // TODO Support multiple subgraphs
 ANeuralNetworksCompilation::ANeuralNetworksCompilation(const ANeuralNetworksModel *model) noexcept
-  : _subgraphs{model->getSubGraphs()}, _tracing_ctx{std::make_unique<util::TracingCtx>(
-                                         _subgraphs.get())},
-    _coptions{std::make_unique<compiler::CompilerOptions>(*_subgraphs)},
+  : _subgraphs{model->getSubGraphs()}, _coptions{std::make_unique<compiler::CompilerOptions>(
+                                         *_subgraphs)},
     _compiler{std::make_shared<compiler::Compiler>(_subgraphs, *_coptions)}
-
 {
   if (model->allowedToFp16())
   {

--- a/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksCompilation.h
+++ b/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksCompilation.h
@@ -41,14 +41,6 @@ public:
 
 private:
   std::shared_ptr<onert::ir::Subgraphs> _subgraphs;
-  // TODO Refine the ownership of TracingCtx
-  // In case of nnfw API, nnfw_session has ownership of TracingCtx.
-  // In case of nnapi, there is no concept of session and primary model might have the ownership
-  // of TracingCtx.
-  // Since we don't support multiple models yet with nnapi in ONE, let's implement this later
-  // and let's make it work with one model for now.
-  std::unique_ptr<onert::util::TracingCtx> _tracing_ctx;
-
   std::unique_ptr<onert::compiler::CompilerOptions> _coptions;
   std::shared_ptr<onert::compiler::Compiler> _compiler;
   std::shared_ptr<onert::compiler::CompilerArtifact> _artifact;


### PR DESCRIPTION
tracing_ctx is not created and managed by out-of-compiler.
It is created by compile(). Thus, it is not necessary.

Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

Related #9281