### PR TITLE
[infra] Ignore commit message check on draft

### DIFF
--- a/.github/workflows/check-pr-commit.yml
+++ b/.github/workflows/check-pr-commit.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - master
       - release/*
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
 
 defaults:
   run:
@@ -14,6 +19,8 @@ jobs:
   check-commit-message:
     name: Check commit message
     runs-on: ubuntu-20.04
+    # Skip on draft, check on draft -> ready
+    if: github.event.pull_request.draft == false
 
     steps:
       - name: Checkout


### PR DESCRIPTION
This commit changes policy for draft.
- If PR is draft, skip commit message check
- If PR is changed from draft to ready-for-review, check commit message

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>