### PR TITLE
[onert] Remove unused member in nnfw_session

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.h
+++ b/runtime/onert/api/src/nnfw_api_internal.h
@@ -174,9 +174,6 @@ private:
   std::vector<std::thread> _threads;
   std::vector<std::shared_ptr<onert::exec::Execution>> _executions;
   std::string _package_file_path;
-
-  // TODO Remove _tracing_ctx
-  std::unique_ptr<onert::util::TracingCtx> _tracing_ctx;
 };
 
 #endif // __API_NNFW_API_INTERNAL_H__


### PR DESCRIPTION
This commit removes tracing_ctx member in nnfw_session.

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: https://github.com/Samsung/ONE/issues/9281
Draft: https://github.com/Samsung/ONE/pull/9280