### PR TITLE
[onert] Revisit TracingCtx constructor

### DIFF
--- a/runtime/onert/core/include/util/TracingCtx.h
+++ b/runtime/onert/core/include/util/TracingCtx.h
@@ -37,29 +37,9 @@ class TracingCtx
 public:
   /**
    * @brief Create and store unique session id managed by this class
-   *        Note that this constructor can be called by multiple sessions running in parallely.
-   *        Use this constructor only when there is only one subgraph in a model.
+   * @note  This constructor can be called by multiple session running in parallely.
    */
-  TracingCtx(const ir::Graph *primary_subgraph)
-  {
-    decideSessionID();
-    _subgraph_indices.emplace(primary_subgraph, 0);
-  }
-
-  /**
-   * @brief Create and store unique session id managed by this class
-   *        Note that this constructor can be called by multiple sessions running in parallely.
-   */
-  TracingCtx(const onert::ir::Model *model)
-  {
-    assert(model);
-
-    decideSessionID();
-
-    auto count = model->subgraphs_count();
-    for (size_t i = 0; i < count; i++)
-      _subgraph_indices.emplace(model->at(onert::ir::SubgraphIndex(i)).get(), i);
-  }
+  TracingCtx(void) { decideSessionID(); }
 
   uint32_t getSessionId() const { return _session_id; }
 

--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -379,13 +379,13 @@ std::shared_ptr<CompilerArtifact> Compiler::compile(void)
   if (_options.he_profiling_mode)
     checkProfilerConditions();
 
-  // Tracing context
-  auto tracing_ctx = std::make_unique<util::TracingCtx>(_model.get());
-
   /***************************************************
    * Backend independent analysis & optimization phase
    ***************************************************/
   auto dump_level = static_cast<dumper::dot::DotDumper::Level>(_options.graph_dump_level);
+
+  // Tracing context
+  auto tracing_ctx = std::make_unique<util::TracingCtx>();
 
   // Lower: Assign backend
   std::unordered_map<ir::SubgraphIndex, std::unique_ptr<compiler::LoweredGraph>> lowered_subgs;


### PR DESCRIPTION
This commit updates TracingCtx constructor.
It removes graph set parameter, and create empty graph to index map.

Current constructor get original graph set as constructor's parameter.
But original graph is not used for tracing because executor can't refer original graph.
Tracing observer uses copied graph on lowering.

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>