### PR TITLE
[onert] Remove model reference in graph

### DIFF
--- a/runtime/onert/core/include/ir/Graph.h
+++ b/runtime/onert/core/include/ir/Graph.h
@@ -87,7 +87,6 @@ public:
   void verify(void);
   void removeOperand(const OperandIndex &ind) { _operands.remove(ind); }
   void setLayout(Layout layout) { _layout = layout; }
-  void setModel(const std::shared_ptr<Model> &model) { _model = model; }
   void setPartialModel(const std::shared_ptr<Model> &partial_model)
   {
     _partialgraphs = partial_model;
@@ -134,8 +133,6 @@ public:
   Operands &operands() { return _operands; } // TODO Remove this non-const accessor
   const Operations &operations() const { return _operations; }
   Operations &operations() { return _operations; }
-  const std::shared_ptr<Model> &model() const { return _model; }
-  std::shared_ptr<Model> &model() { return _model; }
   Layout layout() const { return _layout; }
   std::shared_ptr<Model> &partialgraphs() { return _partialgraphs; }
   std::shared_ptr<std::unordered_map<ir::OperandIndex, std::string>> &tensor_names()
@@ -172,8 +169,6 @@ private:
   OperandIndexSequence _outputs;
   std::unordered_map<std::string, IOIndex> _name_to_input;
   std::unordered_map<std::string, IOIndex> _name_to_output;
-  // model for child subgraphs
-  std::shared_ptr<Model> _model;
   // TFLite and circle's default layout is NHWC;
   Layout _layout{Layout::NHWC};
 

--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -369,7 +369,6 @@ std::shared_ptr<CompilerArtifact> Compiler::compile(void)
 
     _model->iterate([&](const ir::SubgraphIndex &index, ir::Graph &subg) {
       executors->emplace(index, std::make_unique<interp::InterpExecutor>(subg));
-      subg.setModel(_model);
     });
     _state = State::COMPILED;
     return std::make_shared<CompilerArtifact>(executors, nullptr);
@@ -398,8 +397,6 @@ std::shared_ptr<CompilerArtifact> Compiler::compile(void)
 
     // Set tracing_ctx for copied graph
     tracing_ctx->setSubgraphIndex(&(lowered_subgs[index]->graph()), index.value());
-
-    subg.setModel(nullptr);
   });
 
   _model.reset();
@@ -588,7 +585,6 @@ std::vector<std::shared_ptr<CompilerArtifact>> Compiler::compile(const char *pac
       // // Lower: Assign backend
       lowered_partialgraphs[pindex] =
         std::make_unique<compiler::LoweredGraph>(subg, partialgraph, _options);
-      partialgraph.setModel(nullptr);
     });
   });
 

--- a/runtime/onert/core/src/compiler/ShapeValidator.cc
+++ b/runtime/onert/core/src/compiler/ShapeValidator.cc
@@ -53,10 +53,6 @@ void ShapeValidator::checkUnaryOp(const ir::Operation &node)
 
 void ShapeValidator::operator()()
 {
-  // There is no reason for each subgraph to have subgraphs since compiler has subgraphs when
-  // creating Compiler
-  assert(_graph.model() == nullptr);
-
   _current_layout = _graph.layout();
 
   _graph.operations().iterate(

--- a/runtime/onert/core/src/interp/InterpExecutor.test.cc
+++ b/runtime/onert/core/src/interp/InterpExecutor.test.cc
@@ -76,7 +76,6 @@ protected:
 
     auto model = std::make_shared<onert::ir::Model>();
     model->push(onert::ir::SubgraphIndex{0}, _graph);
-    _graph->setModel(model);
 
     _executors = std::make_shared<ExecutorMap>();
     _executors->insert(
@@ -141,7 +140,6 @@ protected:
 
     auto model = std::make_shared<onert::ir::Model>();
     model->push(onert::ir::SubgraphIndex{0}, _graph);
-    _graph->setModel(model);
 
     _executors = std::make_shared<ExecutorMap>();
     _executors->insert(
@@ -194,7 +192,6 @@ protected:
 
     auto model = std::make_shared<onert::ir::Model>();
     model->push(onert::ir::SubgraphIndex{0}, _graph);
-    _graph->setModel(model);
 
     _executors = std::make_shared<ExecutorMap>();
     _executors->insert(


### PR DESCRIPTION
This commit removes model reference field in graph.

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>