### PR TITLE
[onert/ir] Remove a typo in comment

### DIFF
--- a/runtime/onert/core/include/ir/Index.h
+++ b/runtime/onert/core/include/ir/Index.h
@@ -64,7 +64,7 @@ inline std::ostream &operator<<(std::ostream &o, const IOIndex &i)
 
 inline std::ostream &operator<<(std::ostream &o, const SubgraphIndex &i)
 {
-  return _index_print_impl(o, "SUBGRAPH", i); // $ubgraph
+  return _index_print_impl(o, "SUBGRAPH", i);
 }
 
 } // namespace ir


### PR DESCRIPTION
- $ubgraph should be Subgraph.
- It seems not much meaningful comment. Let's remove it.

Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>