### PR TITLE
[infra] Change using pthread option

### DIFF
--- a/infra/nnfw/cmake/ApplyCompileFlags.cmake
+++ b/infra/nnfw/cmake/ApplyCompileFlags.cmake
@@ -31,3 +31,13 @@ endforeach()
 foreach(FLAG ${FLAGS_CXXONLY})
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FLAG}")
 endforeach()
+
+# lib pthread as a variable (finding pthread build option must be disabled on android)
+# Define here to use on external lib build
+set(LIB_PTHREAD lib_pthread)
+add_library(${LIB_PTHREAD} INTERFACE)
+if(NOT TARGET_OS STREQUAL "android")
+  # Get compile option (ex. "-pthread" on linux GNU build tool)
+  find_package(Threads)
+  target_link_libraries(${LIB_PTHREAD} INTERFACE Threads::Threads)
+endif()

--- a/infra/nnfw/cmake/buildtool/config/config_aarch64-android.cmake
+++ b/infra/nnfw/cmake/buildtool/config/config_aarch64-android.cmake
@@ -1,8 +1,5 @@
 include("cmake/buildtool/config/config_linux.cmake")
 
-# On Android, pthread is contained in bionic(libc)
-set(LIB_PTHREAD "")
-
 # SIMD for aarch64
 set(FLAGS_COMMON ${FLAGS_COMMON}
     "-ftree-vectorize"

--- a/infra/nnfw/cmake/buildtool/config/config_linux.cmake
+++ b/infra/nnfw/cmake/buildtool/config/config_linux.cmake
@@ -10,6 +10,3 @@ set(FLAGS_CXXONLY ${FLAGS_CXXONLY} "-Wno-ignored-attributes")
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.0)
   list(APPEND FLAGS_CXXONLY "-Wno-psabi")
 endif()
-
-# lib pthread as a variable (pthread must be disabled on android)
-set(LIB_PTHREAD pthread)

--- a/infra/nnfw/cmake/buildtool/config/config_x86_64-darwin.cmake
+++ b/infra/nnfw/cmake/buildtool/config/config_x86_64-darwin.cmake
@@ -7,6 +7,3 @@ message(STATUS "Building for x86-64 Darwin")
 set(FLAGS_COMMON ${FLAGS_COMMON}
     "-msse4"
     )
-
-# lib pthread as a variable (pthread must be disabled on android)
-set(LIB_PTHREAD pthread)


### PR DESCRIPTION
Instead of using old convention - linking pthread (`-lpthread`), let's use compiler build option (`-pthread`) by using cmake FindThread.

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>