### PR TITLE
[onert] Use copy of graph in interpreter

### DIFF
--- a/runtime/onert/core/src/interp/InterpExecutor.h
+++ b/runtime/onert/core/src/interp/InterpExecutor.h
@@ -74,7 +74,12 @@ public:
   }
 
 private:
-  const ir::Graph &_graph;
+  /**
+   * @brief Copy of target graph for lowering
+   * @note  It uses copy of graph, not reference.
+   *        Original graph may be deallocated by frontend.
+   */
+  const ir::Graph _graph;
   ir::OperandIndexMap<std::shared_ptr<ITensor>> _tensor_map;
 };
 


### PR DESCRIPTION
This commit updates interpreter to use copy of graph, not original graph reference.
Sometimes interpreter executor cannot refer original graph.

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

This PR is previous commit for #9308 