### PR TITLE
[luci-interpreter] Remove wrong check in Pack kernel configure

### DIFF
--- a/compiler/luci-interpreter/src/kernels/Pack.cpp
+++ b/compiler/luci-interpreter/src/kernels/Pack.cpp
@@ -76,9 +76,8 @@ void Pack::configure()
     }
   }
 
-  if (t0->element_type() == DataType::S32 || t0->element_type() == DataType::U8 ||
-      t0->element_type() == DataType::S8 || t0->element_type() == DataType::S16 ||
-      t0->element_type() == DataType::S64)
+  if (t0->element_type() == DataType::U8 || t0->element_type() == DataType::S8 ||
+      t0->element_type() == DataType::S16)
   {
     LUCI_INTERPRETER_CHECK(output()->zero_point() == t0->zero_point());
     LUCI_INTERPRETER_CHECK(output()->scale() == t0->scale());


### PR DESCRIPTION
This PR removes wrong check for S32 and S64 input type in Pack kernel configure.

from draft: https://github.com/Samsung/ONE/pull/9253
for issue https://github.com/Samsung/ONE/issues/9225

ONE-DCO-1.0-Signed-off-by: Artem Balyshev a.balyshev@partner.samsung.com