### PR TITLE
[luci-interpreter] Add StridedSlice execute for S32 input

### DIFF
--- a/compiler/luci-interpreter/src/kernels/StridedSlice.cpp
+++ b/compiler/luci-interpreter/src/kernels/StridedSlice.cpp
@@ -136,6 +136,11 @@ void StridedSlice::execute() const
                                           getTensorData<uint8_t>(input()), getTensorShape(output()),
                                           getTensorData<uint8_t>(output()));
       break;
+    case DataType::S32:
+      tflite::reference_ops::StridedSlice(op_params, getTensorShape(input()),
+                                          getTensorData<int32_t>(input()), getTensorShape(output()),
+                                          getTensorData<int32_t>(output()));
+      break;
     default:
       throw std::runtime_error("Unsupported type.");
   }


### PR DESCRIPTION
This PR adds StridedSlice execute for S32 input in luci-interpreter.

from draft: https://github.com/Samsung/ONE/pull/9253
for issue https://github.com/Samsung/ONE/issues/9225

ONE-DCO-1.0-Signed-off-by: Artem Balyshev a.balyshev@partner.samsung.com