### PR TITLE
[one-cmds] Add infer option to onecc

### DIFF
--- a/compiler/one-cmds/onecc
+++ b/compiler/one-cmds/onecc
@@ -43,6 +43,7 @@ subtool_list = {
     'backend': {
         'codegen': 'Code generation tool',
         'profile': 'Profile backend model file',
+        'infer': 'Infer Backend model file'
     },
 }
 
@@ -128,7 +129,8 @@ def _get_driver_name(driver_name):
         'one-partition': 'one-partition',
         'one-pack': 'one-pack',
         'one-codegen': 'one-codegen',
-        'one-profile': 'one-profile'
+        'one-profile': 'one-profile',
+        'one-infer': 'one-infer'
     }[driver_name]
 
 
@@ -217,7 +219,7 @@ def main():
     bin_dir = os.path.dirname(os.path.realpath(__file__))
     import_drivers_dict = _utils._detect_one_import_drivers(bin_dir)
     transform_drivers = [
-        'one-optimize', 'one-quantize', 'one-pack', 'one-codegen', 'one-profile', 'one-partition'
+        'one-optimize', 'one-quantize', 'one-pack', 'one-codegen', 'one-profile', 'one-partition', 'one-infer'
     ]
     _verify_cfg(import_drivers_dict, config)
 

--- a/compiler/one-cmds/onecc
+++ b/compiler/one-cmds/onecc
@@ -43,7 +43,7 @@ subtool_list = {
     'backend': {
         'codegen': 'Code generation tool',
         'profile': 'Profile backend model file',
-        'infer': 'Infer Backend model file'
+        'infer': 'Infer backend model file'
     },
 }
 

--- a/compiler/one-cmds/onecc.template.cfg
+++ b/compiler/one-cmds/onecc.template.cfg
@@ -18,6 +18,8 @@ one-pack=False
 one-codegen=False
 ; profile
 one-profile=False
+; infer
+one-infer=False
 
 [one-import-tf]
 # mandatory
@@ -131,4 +133,12 @@ command=
 # mandatory
 ; backend name
 backend=
+# //TODO: Add available options
+
+[one-infer]
+# mandatory (mutually exclusive)
+; backend name
+backend=
+; driver name
+driver=
 # //TODO: Add available options

--- a/compiler/one-cmds/tests/onecc_027.cfg
+++ b/compiler/one-cmds/tests/onecc_027.cfg
@@ -1,0 +1,15 @@
+[onecc]
+one-import-tf=False
+one-import-tflite=False
+one-import-bcq=False
+one-import-onnx=False
+one-optimize=False
+one-quantize=False
+one-pack=False
+one-codegen=False
+one-profile=False
+one-infer=True
+
+[one-infer]
+backend=dummy
+command=test_onnx_model.bin

--- a/compiler/one-cmds/tests/onecc_027.test
+++ b/compiler/one-cmds/tests/onecc_027.test
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# one-infer
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  echo "${filename_ext} FAILED"
+  rm -rf ../bin/dummy-profile
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+configfile="onecc_027.cfg"
+
+# copy dummy-infer to bin folder
+cp dummy-infer ../bin/dummy-infer
+
+# run test
+onecc -C ${configfile} > ${filename}.log
+
+rm -rf ../bin/dummy-infer
+
+if grep -q "dummy-infer dummy output!!!" "${filename}.log"; then
+  echo "${filename_ext} SUCCESS"
+  exit 0
+fi
+
+trap_err_onexit


### PR DESCRIPTION
This commit adds infer option to onecc.
Add, it contains test cases of onecc.

Signed-off-by: yunjay-hong <yunjay.hong@samsung.com>