### PR TITLE
[one-cmds] Add negative test for onecc

### DIFF
--- a/compiler/one-cmds/tests/onecc_neg_012.cfg
+++ b/compiler/one-cmds/tests/onecc_neg_012.cfg
@@ -1,0 +1,15 @@
+[onecc]
+one-import-tf=False
+one-import-tflite=False
+one-import-bcq=False
+one-optimize=False
+one-quantize=False
+one-pack=False
+one-codegen=False
+one-profile=False
+one-infer=True
+
+[one-infer]
+driver=dummy-infer
+backend=dummy
+command="dummy arguments"

--- a/compiler/one-cmds/tests/onecc_neg_012.test
+++ b/compiler/one-cmds/tests/onecc_neg_012.test
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# generate error for unrecognized opitmization option
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  if grep -q "\-d and -b options are mutually exclusive" "${filename}.log"; then
+    echo "${filename_ext} SUCCESS"
+    exit 0
+  fi
+
+  echo "${filename_ext} FAILED"
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+configfile="onecc_neg_012.cfg"
+
+# run test
+onecc -C ${configfile} > ${filename}.log 2>&1
+
+echo "${filename_ext} FAILED"

--- a/compiler/one-cmds/tests/onecc_neg_012.test
+++ b/compiler/one-cmds/tests/onecc_neg_012.test
@@ -38,3 +38,4 @@ configfile="onecc_neg_012.cfg"
 onecc -C ${configfile} > ${filename}.log 2>&1
 
 echo "${filename_ext} FAILED"
+exit 255

--- a/compiler/one-cmds/tests/onecc_neg_012.test
+++ b/compiler/one-cmds/tests/onecc_neg_012.test
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# generate error for unrecognized opitmization option
+# Check driver and backend option is mutually exclusive
 
 filename_ext="$(basename -- $0)"
 filename="${filename_ext%.*}"


### PR DESCRIPTION
This commit adds negative test for one-infer option in onecc

Signed-off-by: yunjay-hong <yunjay.hong@samsung.com>

---

from: 

@yunjayh , in anotehr PR, please add negative test to check mutual exclusiveness is working as expected.

_Originally posted by @seanshpark in https://github.com/Samsung/ONE/pull/9321#issuecomment-1163886035_