### PR TITLE
[one-cmds] Add exit code to test

### DIFF
--- a/compiler/one-cmds/tests/onecc_neg_011.test
+++ b/compiler/one-cmds/tests/onecc_neg_011.test
@@ -38,3 +38,4 @@ configfile="onecc_neg_011.cfg"
 onecc -C ${configfile} > ${filename}.log 2>&1
 
 echo "${filename_ext} FAILED"
+exit 255


### PR DESCRIPTION
This commit adds exit code 255 to negative test.

Signed-off-by: yunjay-hong <yunjay.hong@samsung.com>

---

from: 
I think `onecc_neg_011.test` needs also fix. if possible can you fix `onecc_neg_011.test` too ? (in another PR)

_Originally posted by @seanshpark in https://github.com/Samsung/ONE/pull/9324#discussion_r904671191_