### PR TITLE
[luci] Remove return with std::move

### DIFF
--- a/compiler/luci/partition/src/PartitionIR.cpp
+++ b/compiler/luci/partition/src/PartitionIR.cpp
@@ -64,7 +64,7 @@ std::unique_ptr<PGroups> PGroups::make_copy(void) const
     // note: d_pgroup is now nullptr as it's moved
   }
 
-  return std::move(d_pgroups);
+  return d_pgroups;
 }
 
 GroupKey PGroups::group_of(luci::CircleNode *node) const

--- a/compiler/luci/partition/src/PartitionMerge.cpp
+++ b/compiler/luci/partition/src/PartitionMerge.cpp
@@ -255,7 +255,7 @@ std::unique_ptr<luci::PGroups> merge_pgroups(const luci::PGroups *s_pgroups)
     }
   } while (changed);
 
-  return std::move(d_pgroups);
+  return d_pgroups;
 }
 
 } // namespace luci

--- a/compiler/luci/partition/src/PartitionPGroups.cpp
+++ b/compiler/luci/partition/src/PartitionPGroups.cpp
@@ -257,7 +257,7 @@ std::unique_ptr<luci::PGroups> produce_pgroups(const luci::Module *source,
     }
   }
 
-  return std::move(pgroups);
+  return pgroups;
 }
 
 } // namespace luci

--- a/compiler/luci/partition/src/PartitionPModules.cpp
+++ b/compiler/luci/partition/src/PartitionPModules.cpp
@@ -156,7 +156,7 @@ std::unique_ptr<loco::Graph> clone_graph(loco::Graph *graph_org, luci::CloneCont
     add_graph_output(graph_clone, output_clone);
   }
 
-  return std::move(graph);
+  return graph;
 }
 
 void clone_recursive_subgraphs(luci::PartedModule &pm, loco::Graph *graph,

--- a/compiler/luci/pass/src/QuantizationUtils.cpp
+++ b/compiler/luci/pass/src/QuantizationUtils.cpp
@@ -380,7 +380,7 @@ std::unique_ptr<CircleQuantParam> make_predefined_qparam(ActivationQType qtype,
     default:
       throw std::runtime_error("Unsupported opcode with pre-defined qparam");
   }
-  return std::move(qparam);
+  return qparam;
 }
 
 // For nodes with integer output, we use integer scale


### PR DESCRIPTION
This removes return with std::move(...) for local unique pointer.
It needs on old compiler version, but we don't use old compiler any more.

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Same with https://github.com/Samsung/ONE/pull/9329
Draft: https://github.com/Samsung/ONE/pull/9245