### PR TITLE
[moco] Remove return with std::move

### DIFF
--- a/compiler/moco/import/src/Importer.cpp
+++ b/compiler/moco/import/src/Importer.cpp
@@ -190,7 +190,7 @@ std::unique_ptr<loco::Graph> Importer::import(const ModelSignature &signature,
 
   convert_graph(*source_ptr, signature, tf_graph_def, graph.get());
 
-  return std::move(graph);
+  return graph;
 }
 
 } // namespace moco


### PR DESCRIPTION
This removes return with std::move(...) for local unique pointer.
It needs on old compiler version, but we don't use old compiler any more.

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Same with https://github.com/Samsung/ONE/pull/9329
Draft: https://github.com/Samsung/ONE/pull/9245