### PR TITLE
[infra/onert] Set default ACL build type to release

### DIFF
--- a/infra/nnfw/cmake/CfgOptionFlags.cmake
+++ b/infra/nnfw/cmake/CfgOptionFlags.cmake
@@ -75,6 +75,7 @@ option(BUILD_TENSORFLOW_LITE "Build TensorFlow Lite from the downloaded source" 
 option(BUILD_TENSORFLOW_LITE_2_3_0 "Build TensorFlow Lite 2.3.0 from the downloaded source" OFF)
 option(BUILD_TENSORFLOW_LITE_GPU "Build TensorFlow Lite GPU delegate from the downloaded source" OFF)
 option(BUILD_ARMCOMPUTE "Build ARM Compute from the downloaded source" ON)
+option(DEBUG_ARMCOMPUTE "Build ARM Compute as release type" OFF)
 option(BUILD_RUY "Build ruy library from the downloaded source" ON)
 option(BUILD_CPUINFO "Build cpuinfo library from the downloaded source" ON)
 option(PROFILE_RUY "Enable ruy library profiling" OFF)

--- a/infra/nnfw/cmake/CfgOptionFlags.cmake
+++ b/infra/nnfw/cmake/CfgOptionFlags.cmake
@@ -75,7 +75,7 @@ option(BUILD_TENSORFLOW_LITE "Build TensorFlow Lite from the downloaded source" 
 option(BUILD_TENSORFLOW_LITE_2_3_0 "Build TensorFlow Lite 2.3.0 from the downloaded source" OFF)
 option(BUILD_TENSORFLOW_LITE_GPU "Build TensorFlow Lite GPU delegate from the downloaded source" OFF)
 option(BUILD_ARMCOMPUTE "Build ARM Compute from the downloaded source" ON)
-option(DEBUG_ARMCOMPUTE "Build ARM Compute as release type" OFF)
+option(DEBUG_ARMCOMPUTE "Build ARM Compute as debug type" OFF)
 option(BUILD_RUY "Build ruy library from the downloaded source" ON)
 option(BUILD_CPUINFO "Build cpuinfo library from the downloaded source" ON)
 option(PROFILE_RUY "Enable ruy library profiling" OFF)

--- a/infra/nnfw/cmake/packages/ARMComputeConfig.cmake
+++ b/infra/nnfw/cmake/packages/ARMComputeConfig.cmake
@@ -90,11 +90,11 @@ function(_ARMCompute_Build ARMComputeInstall_DIR)
     return()
   endif(NOT SCONS_PATH)
 
-  if(CMAKE_BUILD_TYPE)
-    string(TOLOWER "${CMAKE_BUILD_TYPE}" SCON_BUILD_TYPE)
-  else(CMAKE_BUILD_TYPE)
+  if(DEBUG_ARMCOMPUTE)
+    set(SCON_BUILD_TYPE "debug")
+  else(DEBUG_ARMCOMPUTE)
     set(SCON_BUILD_TYPE "release")
-  endif(CMAKE_BUILD_TYPE)
+  endif(DEBUG_ARMCOMPUTE)
 
   #### Architecture-specific configurations
 


### PR DESCRIPTION
This commit changes default ACL build type to release. If developer want to build debug type, set `DEBUG_ARMCOMPUTE=ON` on configure.

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue:  #9085