### PR TITLE
[draft][onert] Revisit CompilerOptions and ManualSchedulerOptions

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -226,7 +226,7 @@ NNFW_STATUS nnfw_session::load_circle_from_buffer(uint8_t *buffer, size_t size)
     std::cerr << "Error during model loading : " << e.what() << std::endl;
     return NNFW_STATUS_ERROR;
   }
-  _coptions = std::make_unique<onert::compiler::CompilerOptions>(*_model);
+  _coptions = onert::compiler::CompilerOptions::fromGlobalConfig(*_model);
   _state = State::MODEL_LOADED;
   return NNFW_STATUS_NO_ERROR;
 }
@@ -276,7 +276,7 @@ NNFW_STATUS nnfw_session::load_model_from_modelfile(const char *model_file_path)
     std::cerr << "Error during model loading : " << e.what() << std::endl;
     return NNFW_STATUS_ERROR;
   }
-  _coptions = std::make_unique<onert::compiler::CompilerOptions>(*_model);
+  _coptions = onert::compiler::CompilerOptions::fromGlobalConfig(*_model);
   _state = State::MODEL_LOADED;
   return NNFW_STATUS_NO_ERROR;
 }
@@ -359,7 +359,7 @@ NNFW_STATUS nnfw_session::load_model_from_nnpackage(const char *package_dir)
     std::cerr << "Error during model loading : " << e.what() << std::endl;
     return NNFW_STATUS_ERROR;
   }
-  _coptions = std::make_unique<onert::compiler::CompilerOptions>(*_model);
+  _coptions = onert::compiler::CompilerOptions::fromGlobalConfig(*_model);
   _state = State::MODEL_LOADED;
   return NNFW_STATUS_NO_ERROR;
 }

--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -226,7 +226,7 @@ NNFW_STATUS nnfw_session::load_circle_from_buffer(uint8_t *buffer, size_t size)
     std::cerr << "Error during model loading : " << e.what() << std::endl;
     return NNFW_STATUS_ERROR;
   }
-  _coptions = onert::compiler::CompilerOptions::fromGlobalConfig(*_model);
+  _coptions = onert::compiler::CompilerOptions::fromGlobalConfig();
   _state = State::MODEL_LOADED;
   return NNFW_STATUS_NO_ERROR;
 }
@@ -276,7 +276,7 @@ NNFW_STATUS nnfw_session::load_model_from_modelfile(const char *model_file_path)
     std::cerr << "Error during model loading : " << e.what() << std::endl;
     return NNFW_STATUS_ERROR;
   }
-  _coptions = onert::compiler::CompilerOptions::fromGlobalConfig(*_model);
+  _coptions = onert::compiler::CompilerOptions::fromGlobalConfig();
   _state = State::MODEL_LOADED;
   return NNFW_STATUS_NO_ERROR;
 }
@@ -359,7 +359,7 @@ NNFW_STATUS nnfw_session::load_model_from_nnpackage(const char *package_dir)
     std::cerr << "Error during model loading : " << e.what() << std::endl;
     return NNFW_STATUS_ERROR;
   }
-  _coptions = onert::compiler::CompilerOptions::fromGlobalConfig(*_model);
+  _coptions = onert::compiler::CompilerOptions::fromGlobalConfig();
   _state = State::MODEL_LOADED;
   return NNFW_STATUS_NO_ERROR;
 }
@@ -1220,7 +1220,7 @@ NNFW_STATUS nnfw_session::set_backends_per_operation(const char *backend_setting
 
   // Backend for all
   auto &ms_options = _coptions->manual_scheduler_options;
-  ms_options.setBackendMap(*_model, std::string{backend_settings});
+  ms_options.setBackendMap(std::string{backend_settings});
 
   return NNFW_STATUS_NO_ERROR;
 }

--- a/runtime/onert/core/include/compiler/Compiler.h
+++ b/runtime/onert/core/include/compiler/Compiler.h
@@ -57,12 +57,9 @@ struct PartialGraphOptions
 class CompilerOptions
 {
 public:
-  CompilerOptions(const ir::Model &model) { fetchCompilerOptionsFromGlobalConfig(model); }
-
-private:
   // Set default values for CompilerOptions
   // All these default values should not be fetched from Env, when we stop supporting Android NNAPI.
-  void fetchCompilerOptionsFromGlobalConfig(const ir::Model &model);
+  static std::unique_ptr<CompilerOptions> fromGlobalConfig(const ir::Model &model);
 
 public:
   // GENERAL OPTIONS

--- a/runtime/onert/core/include/compiler/Compiler.h
+++ b/runtime/onert/core/include/compiler/Compiler.h
@@ -41,7 +41,7 @@ enum class State
 struct ManualSchedulerOptions
 {
 public:
-  void setBackendMap(const ir::Model &model, const std::string &str);
+  void setBackendMap(const std::string &str);
 
 public:
   std::string backend_for_all;
@@ -59,7 +59,7 @@ class CompilerOptions
 public:
   // Set default values for CompilerOptions
   // All these default values should not be fetched from Env, when we stop supporting Android NNAPI.
-  static std::unique_ptr<CompilerOptions> fromGlobalConfig(const ir::Model &model);
+  static std::unique_ptr<CompilerOptions> fromGlobalConfig();
 
 public:
   // GENERAL OPTIONS

--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -90,7 +90,7 @@ namespace onert
 
 namespace compiler
 {
-void ManualSchedulerOptions::setBackendMap(const ir::Model &model, const std::string &str)
+void ManualSchedulerOptions::setBackendMap(const std::string &str)
 {
   // TODO Support multiple subgraphs for manual scheduling
   auto key_val_list = nnfw::misc::split(str, ';');
@@ -105,15 +105,18 @@ void ManualSchedulerOptions::setBackendMap(const ir::Model &model, const std::st
     const auto &key_str = key_val.at(0);
     const auto &val = key_val.at(1);
     auto key = static_cast<uint32_t>(std::stoi(key_str));
-
+#if 0
+    // Let setBackemdMap to parse str and put key, value pair to map.
+    // Check is done during execution.
     model.at(ir::SubgraphIndex{0})
       ->operations()
       .at(ir::OperationIndex{key}); // Check if exist, or this wil throw
+#endif
     this->index_to_backend.emplace(ir::OperationIndex{key}, val);
   }
 }
 
-std::unique_ptr<CompilerOptions> CompilerOptions::fromGlobalConfig(const ir::Model &model)
+std::unique_ptr<CompilerOptions> CompilerOptions::fromGlobalConfig()
 {
   auto o = std::make_unique<CompilerOptions>();
   o->backend_list = nnfw::misc::split(util::getConfigString(util::config::BACKENDS), ';');
@@ -145,7 +148,7 @@ std::unique_ptr<CompilerOptions> CompilerOptions::fromGlobalConfig(const ir::Mod
 
     // Index to Backend
     auto map_str = util::getConfigString(util::config::OP_BACKEND_MAP);
-    ms_options.setBackendMap(model, map_str);
+    ms_options.setBackendMap(map_str);
   }
   return o;
 }

--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -113,19 +113,20 @@ void ManualSchedulerOptions::setBackendMap(const ir::Model &model, const std::st
   }
 }
 
-void CompilerOptions::fetchCompilerOptionsFromGlobalConfig(const ir::Model &model)
+std::unique_ptr<CompilerOptions> CompilerOptions::fromGlobalConfig(const ir::Model &model)
 {
-  backend_list = nnfw::misc::split(util::getConfigString(util::config::BACKENDS), ';');
-  trace_filepath = util::getConfigString(util::config::TRACE_FILEPATH);
-  graph_dump_level = util::getConfigInt(util::config::GRAPH_DOT_DUMP);
-  executor = util::getConfigString(util::config::EXECUTOR);
-  he_scheduler = util::getConfigBool(util::config::USE_SCHEDULER);
-  he_profiling_mode = util::getConfigBool(util::config::PROFILING_MODE);
-  disable_compile = util::getConfigBool(util::config::DISABLE_COMPILE);
-  fp16_enable = util::getConfigBool(util::config::FP16_ENABLE);
+  auto o = std::make_unique<CompilerOptions>();
+  o->backend_list = nnfw::misc::split(util::getConfigString(util::config::BACKENDS), ';');
+  o->trace_filepath = util::getConfigString(util::config::TRACE_FILEPATH);
+  o->graph_dump_level = util::getConfigInt(util::config::GRAPH_DOT_DUMP);
+  o->executor = util::getConfigString(util::config::EXECUTOR);
+  o->he_scheduler = util::getConfigBool(util::config::USE_SCHEDULER);
+  o->he_profiling_mode = util::getConfigBool(util::config::PROFILING_MODE);
+  o->disable_compile = util::getConfigBool(util::config::DISABLE_COMPILE);
+  o->fp16_enable = util::getConfigBool(util::config::FP16_ENABLE);
   {
     // Backend for all
-    auto &ms_options = manual_scheduler_options;
+    auto &ms_options = o->manual_scheduler_options;
 
     // Default value for op_backend_all is first element in the backend list
     ms_options.backend_for_all = util::getConfigString(util::config::OP_BACKEND_ALLOPS);
@@ -146,6 +147,7 @@ void CompilerOptions::fetchCompilerOptionsFromGlobalConfig(const ir::Model &mode
     auto map_str = util::getConfigString(util::config::OP_BACKEND_MAP);
     ms_options.setBackendMap(model, map_str);
   }
+  return o;
 }
 
 Compiler::Compiler(const std::shared_ptr<ir::Model> &model, CompilerOptions &copt)

--- a/runtime/onert/core/src/compiler/HEScheduler.test.cc
+++ b/runtime/onert/core/src/compiler/HEScheduler.test.cc
@@ -391,7 +391,7 @@ TEST_P(HESchedulerTestWithExecutorParam, straight_graph_known_exec_time)
     et.storeOperationsExecTime();
 
     // Test scheduler
-    auto coptions = *onert::compiler::CompilerOptions::fromGlobalConfig(model);
+    auto coptions = *onert::compiler::CompilerOptions::fromGlobalConfig();
     auto scheduler = compiler::HEScheduler(_mock_backends, coptions);
     const auto br = scheduler.schedule(*graph);
     ASSERT_EQ(br->getBackend(add_op_idx)->config()->id(), "cpu");
@@ -406,7 +406,7 @@ TEST_P(HESchedulerTestWithExecutorParam, straight_graph_known_exec_time)
     setPermutationsExecutionTime(_mock_backends, OPERAND_SIZE, 1e5);
 
     // Test scheduler
-    auto coptions = *onert::compiler::CompilerOptions::fromGlobalConfig(model);
+    auto coptions = *onert::compiler::CompilerOptions::fromGlobalConfig();
     auto scheduler = compiler::HEScheduler(_mock_backends, coptions);
     const auto br = scheduler.schedule(*graph);
     ASSERT_EQ(br->getBackend(add_op_idx)->config()->id(), "cpu");
@@ -448,7 +448,7 @@ TEST_P(HESchedulerTestWithExecutorParam, branched_graph_known_exec_time)
     et.storeOperationsExecTime();
 
     // Test scheduler
-    auto coptions = *onert::compiler::CompilerOptions::fromGlobalConfig(model);
+    auto coptions = *onert::compiler::CompilerOptions::fromGlobalConfig();
     auto scheduler = compiler::HEScheduler(_mock_backends, coptions);
     const auto br = scheduler.schedule(*graph);
 
@@ -482,7 +482,7 @@ TEST_P(HESchedulerTestWithExecutorParam, branched_graph_known_exec_time)
     et.storeOperationsExecTime();
 
     // Test scheduler
-    auto coptions = *onert::compiler::CompilerOptions::fromGlobalConfig(model);
+    auto coptions = *onert::compiler::CompilerOptions::fromGlobalConfig();
     auto scheduler = compiler::HEScheduler(_mock_backends, coptions);
     const auto br = scheduler.schedule(*graph);
     ASSERT_EQ(br->getBackend(add_op_idx)->config()->id(), "npu");
@@ -527,7 +527,7 @@ TEST_F(HESchedulerTest, branched_graph_profiling_mode)
     et.storeOperationsExecTime();
 
     // Test scheduler
-    auto coptions = *onert::compiler::CompilerOptions::fromGlobalConfig(model);
+    auto coptions = *onert::compiler::CompilerOptions::fromGlobalConfig();
     auto scheduler = compiler::HEScheduler(_mock_backends, coptions);
     const auto br = scheduler.schedule(*graph);
     ASSERT_EQ(br->getBackend(mul1_op_idx)->config()->id(), "npu");
@@ -549,7 +549,7 @@ TEST_F(HESchedulerTest, branched_graph_profiling_mode)
     et.storeOperationsExecTime();
 
     // Test scheduler
-    auto coptions = *onert::compiler::CompilerOptions::fromGlobalConfig(model);
+    auto coptions = *onert::compiler::CompilerOptions::fromGlobalConfig();
     auto scheduler = compiler::HEScheduler(_mock_backends, coptions);
     const auto br = scheduler.schedule(*graph);
     ASSERT_NE(br->getBackend(add_op_idx)->config()->id(),

--- a/runtime/onert/core/src/compiler/HEScheduler.test.cc
+++ b/runtime/onert/core/src/compiler/HEScheduler.test.cc
@@ -391,7 +391,7 @@ TEST_P(HESchedulerTestWithExecutorParam, straight_graph_known_exec_time)
     et.storeOperationsExecTime();
 
     // Test scheduler
-    onert::compiler::CompilerOptions coptions(model);
+    auto coptions = *onert::compiler::CompilerOptions::fromGlobalConfig(model);
     auto scheduler = compiler::HEScheduler(_mock_backends, coptions);
     const auto br = scheduler.schedule(*graph);
     ASSERT_EQ(br->getBackend(add_op_idx)->config()->id(), "cpu");
@@ -406,7 +406,7 @@ TEST_P(HESchedulerTestWithExecutorParam, straight_graph_known_exec_time)
     setPermutationsExecutionTime(_mock_backends, OPERAND_SIZE, 1e5);
 
     // Test scheduler
-    onert::compiler::CompilerOptions coptions(model);
+    auto coptions = *onert::compiler::CompilerOptions::fromGlobalConfig(model);
     auto scheduler = compiler::HEScheduler(_mock_backends, coptions);
     const auto br = scheduler.schedule(*graph);
     ASSERT_EQ(br->getBackend(add_op_idx)->config()->id(), "cpu");
@@ -448,7 +448,7 @@ TEST_P(HESchedulerTestWithExecutorParam, branched_graph_known_exec_time)
     et.storeOperationsExecTime();
 
     // Test scheduler
-    onert::compiler::CompilerOptions coptions(model);
+    auto coptions = *onert::compiler::CompilerOptions::fromGlobalConfig(model);
     auto scheduler = compiler::HEScheduler(_mock_backends, coptions);
     const auto br = scheduler.schedule(*graph);
 
@@ -482,7 +482,7 @@ TEST_P(HESchedulerTestWithExecutorParam, branched_graph_known_exec_time)
     et.storeOperationsExecTime();
 
     // Test scheduler
-    onert::compiler::CompilerOptions coptions(model);
+    auto coptions = *onert::compiler::CompilerOptions::fromGlobalConfig(model);
     auto scheduler = compiler::HEScheduler(_mock_backends, coptions);
     const auto br = scheduler.schedule(*graph);
     ASSERT_EQ(br->getBackend(add_op_idx)->config()->id(), "npu");
@@ -527,7 +527,7 @@ TEST_F(HESchedulerTest, branched_graph_profiling_mode)
     et.storeOperationsExecTime();
 
     // Test scheduler
-    onert::compiler::CompilerOptions coptions(model);
+    auto coptions = *onert::compiler::CompilerOptions::fromGlobalConfig(model);
     auto scheduler = compiler::HEScheduler(_mock_backends, coptions);
     const auto br = scheduler.schedule(*graph);
     ASSERT_EQ(br->getBackend(mul1_op_idx)->config()->id(), "npu");
@@ -549,7 +549,7 @@ TEST_F(HESchedulerTest, branched_graph_profiling_mode)
     et.storeOperationsExecTime();
 
     // Test scheduler
-    onert::compiler::CompilerOptions coptions(model);
+    auto coptions = *onert::compiler::CompilerOptions::fromGlobalConfig(model);
     auto scheduler = compiler::HEScheduler(_mock_backends, coptions);
     const auto br = scheduler.schedule(*graph);
     ASSERT_NE(br->getBackend(add_op_idx)->config()->id(),

--- a/runtime/onert/core/src/exec/Execution.test.cc
+++ b/runtime/onert/core/src/exec/Execution.test.cc
@@ -79,7 +79,7 @@ public:
     // Compile
     auto model = std::make_shared<onert::ir::Model>();
     model->push(onert::ir::SubgraphIndex{0}, graph);
-    coptions = std::make_unique<onert::compiler::CompilerOptions>(*model);
+    coptions = onert::compiler::CompilerOptions::fromGlobalConfig(*model);
     onert::compiler::Compiler compiler{model, *coptions};
     artifact = compiler.compile();
   }
@@ -141,7 +141,7 @@ TEST(ExecInstance, twoCompile)
   // Make new executor: compile again
   auto model = std::make_shared<onert::ir::Model>();
   model->push(onert::ir::SubgraphIndex{0}, graph);
-  auto coptions = std::make_unique<onert::compiler::CompilerOptions>(*model);
+  auto coptions = onert::compiler::CompilerOptions::fromGlobalConfig(*model);
   onert::compiler::Compiler compiler{model, *coptions};
   std::shared_ptr<onert::compiler::CompilerArtifact> artifact = compiler.compile();
   onert::exec::Execution execution2{artifact->_executors};

--- a/runtime/onert/core/src/exec/Execution.test.cc
+++ b/runtime/onert/core/src/exec/Execution.test.cc
@@ -79,7 +79,7 @@ public:
     // Compile
     auto model = std::make_shared<onert::ir::Model>();
     model->push(onert::ir::SubgraphIndex{0}, graph);
-    coptions = onert::compiler::CompilerOptions::fromGlobalConfig(*model);
+    coptions = onert::compiler::CompilerOptions::fromGlobalConfig();
     onert::compiler::Compiler compiler{model, *coptions};
     artifact = compiler.compile();
   }
@@ -141,7 +141,7 @@ TEST(ExecInstance, twoCompile)
   // Make new executor: compile again
   auto model = std::make_shared<onert::ir::Model>();
   model->push(onert::ir::SubgraphIndex{0}, graph);
-  auto coptions = onert::compiler::CompilerOptions::fromGlobalConfig(*model);
+  auto coptions = onert::compiler::CompilerOptions::fromGlobalConfig();
   onert::compiler::Compiler compiler{model, *coptions};
   std::shared_ptr<onert::compiler::CompilerArtifact> artifact = compiler.compile();
   onert::exec::Execution execution2{artifact->_executors};

--- a/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksCompilation.cc
+++ b/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksCompilation.cc
@@ -22,7 +22,7 @@ using namespace onert;
 
 // TODO Support multiple subgraphs
 ANeuralNetworksCompilation::ANeuralNetworksCompilation(const ANeuralNetworksModel *model) noexcept
-  : _model{model->getModel()}, _coptions{compiler::CompilerOptions::fromGlobalConfig(*_model)},
+  : _model{model->getModel()}, _coptions{compiler::CompilerOptions::fromGlobalConfig()},
     _compiler{std::make_shared<compiler::Compiler>(_model, *_coptions)}
 {
   if (model->allowedToFp16())

--- a/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksCompilation.cc
+++ b/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksCompilation.cc
@@ -22,7 +22,7 @@ using namespace onert;
 
 // TODO Support multiple subgraphs
 ANeuralNetworksCompilation::ANeuralNetworksCompilation(const ANeuralNetworksModel *model) noexcept
-  : _model{model->getModel()}, _coptions{std::make_unique<compiler::CompilerOptions>(*_model)},
+  : _model{model->getModel()}, _coptions{compiler::CompilerOptions::fromGlobalConfig(*_model)},
     _compiler{std::make_shared<compiler::Compiler>(_model, *_coptions)}
 {
   if (model->allowedToFp16())


### PR DESCRIPTION
There has been only 1 `CompilerOptions` in `nnfw_session`. But there may be multiple `CompilerOptions` for multiple models.

Related #9328

It simplifies `CompilerOptions` by:

- Introducing `fromGlobalConfig` to show explicitly the values come from GlobalConfig
- Removing `Model` param from CompilerOptions constructor and ManualSchedulerOptions::setBackend.

