### PR TITLE
[onert/api] create CompilerOptions in try block

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -220,14 +220,14 @@ NNFW_STATUS nnfw_session::load_circle_from_buffer(uint8_t *buffer, size_t size)
   try
   {
     _model = onert::circle_loader::loadModel(buffer, size);
+    _coptions = onert::compiler::CompilerOptions::fromGlobalConfig();
+    _state = State::MODEL_LOADED;
   }
   catch (const std::exception &e)
   {
     std::cerr << "Error during model loading : " << e.what() << std::endl;
     return NNFW_STATUS_ERROR;
   }
-  _coptions = onert::compiler::CompilerOptions::fromGlobalConfig();
-  _state = State::MODEL_LOADED;
   return NNFW_STATUS_NO_ERROR;
 }
 
@@ -270,14 +270,14 @@ NNFW_STATUS nnfw_session::load_model_from_modelfile(const char *model_file_path)
       std::cerr << "Unsupported model type" << std::endl;
       return NNFW_STATUS_ERROR;
     }
+    _coptions = onert::compiler::CompilerOptions::fromGlobalConfig();
+    _state = State::MODEL_LOADED;
   }
   catch (const std::exception &e)
   {
     std::cerr << "Error during model loading : " << e.what() << std::endl;
     return NNFW_STATUS_ERROR;
   }
-  _coptions = onert::compiler::CompilerOptions::fromGlobalConfig();
-  _state = State::MODEL_LOADED;
   return NNFW_STATUS_NO_ERROR;
 }
 
@@ -353,14 +353,14 @@ NNFW_STATUS nnfw_session::load_model_from_nnpackage(const char *package_dir)
       return NNFW_STATUS_ERROR;
     }
     _model->primary_subgraph()->bindKernelBuilder(_kernel_registry->getBuilder());
+    _coptions = onert::compiler::CompilerOptions::fromGlobalConfig();
+    _state = State::MODEL_LOADED;
   }
   catch (const std::exception &e)
   {
     std::cerr << "Error during model loading : " << e.what() << std::endl;
     return NNFW_STATUS_ERROR;
   }
-  _coptions = onert::compiler::CompilerOptions::fromGlobalConfig();
-  _state = State::MODEL_LOADED;
   return NNFW_STATUS_NO_ERROR;
 }
 


### PR DESCRIPTION
CompilerOptions construction may throw exceptions (bad_alloc, out_of_range, ...).
Let's move all load statements into try block.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

Related: #9328, https://github.com/Samsung/ONE/pull/9334/files#r905917895