### PR TITLE
[circle-operator] Revise multi output tensor

### DIFF
--- a/compiler/circle-operator/src/Dump.cpp
+++ b/compiler/circle-operator/src/Dump.cpp
@@ -47,20 +47,19 @@ void dump_ops(std::ostream &os, mio::circle::Reader &reader, const cirops::DumpO
     }
     else if (option.names)
     {
+      // TODO multiple outputs?
       const auto tensors = reader.tensors();
       const auto output_tensors = reader.outputs(op);
-      for (const auto output : output_tensors)
+      const auto output = output_tensors.at(0);
+      const auto tensor = tensors->Get(output);
+      const std::string name = mio::circle::tensor_name(tensor);
+      if (option.all_graphs)
       {
-        const auto tensor = tensors->Get(output);
-        const std::string name = mio::circle::tensor_name(tensor);
-        if (option.all_graphs)
-        {
-          os << i << "$" << name << std::endl;
-        }
-        else
-        {
-          os << name << std::endl;
-        }
+        os << i << "$" << name << std::endl;
+      }
+      else
+      {
+        os << name << std::endl;
       }
     }
   }


### PR DESCRIPTION
This will revise multi output tensor to dump first output.
- this is to fix as node is single object
- add todo for if there is other cases

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>