### PR TITLE
[onert] Refine DotDumper

### DIFF
--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -382,6 +382,7 @@ std::shared_ptr<CompilerArtifact> Compiler::compile(void)
    * Backend independent analysis & optimization phase
    ***************************************************/
   auto dump_level = static_cast<dumper::dot::DotDumper::Level>(_options.graph_dump_level);
+  onert::dumper::dot::DotDumper dot_dumper(dump_level);
 
   // Tracing context
   auto tracing_ctx = std::make_unique<util::TracingCtx>();
@@ -389,8 +390,7 @@ std::shared_ptr<CompilerArtifact> Compiler::compile(void)
   // Lower: Assign backend
   std::unordered_map<ir::SubgraphIndex, std::unique_ptr<compiler::LoweredGraph>> lowered_subgs;
   _model->iterate([&](const ir::SubgraphIndex &index, ir::Graph &subg) {
-    onert::dumper::dot::DotDumper dot_dumper(subg, dump_level);
-    dot_dumper.dump(nnfw::misc::str("before_lower_subg-", index.value()));
+    dot_dumper.dump(subg, nnfw::misc::str("before_lower_subg-", index.value()));
 
     // Lower: Assign backend
     lowered_subgs[index] = std::make_unique<compiler::LoweredGraph>(subg, _options);
@@ -405,8 +405,7 @@ std::shared_ptr<CompilerArtifact> Compiler::compile(void)
   {
     const auto &subg_index = pair.first;
     auto &lowered_subg = pair.second;
-    onert::dumper::dot::DotDumper dot_dumper_lowered(lowered_subg.get(), dump_level);
-    dot_dumper_lowered.dump("after_lower_subg-" + std::to_string(subg_index.value()));
+    dot_dumper.dump(*lowered_subg, "after_lower_subg-" + std::to_string(subg_index.value()));
   }
 
   // Shape inference.
@@ -572,6 +571,7 @@ std::vector<std::shared_ptr<CompilerArtifact>> Compiler::compile(const char *pac
    * Backend independent analysis & optimization phase
    ***************************************************/
   auto dump_level = static_cast<dumper::dot::DotDumper::Level>(_options.graph_dump_level);
+  onert::dumper::dot::DotDumper dot_dumper_part(dump_level);
 
   // Lower: Assign backend
   std::unordered_map<ir::SubgraphIndex, std::unique_ptr<compiler::LoweredGraph>>
@@ -579,8 +579,8 @@ std::vector<std::shared_ptr<CompilerArtifact>> Compiler::compile(const char *pac
   _model->iterate([&](const ir::SubgraphIndex &, ir::Graph &subg) {
     auto part = subg.partialgraphs();
     part->iterate([&](const ir::SubgraphIndex &pindex, ir::Graph &partialgraph) {
-      onert::dumper::dot::DotDumper dot_dumper_part(partialgraph, dump_level);
-      dot_dumper_part.dump(nnfw::misc::str("before_lower_subg_partialgraph-", pindex.value()));
+      dot_dumper_part.dump(partialgraph,
+                           nnfw::misc::str("before_lower_subg_partialgraph-", pindex.value()));
 
       // // Lower: Assign backend
       lowered_partialgraphs[pindex] =
@@ -593,9 +593,8 @@ std::vector<std::shared_ptr<CompilerArtifact>> Compiler::compile(const char *pac
 
     const auto &partialgraph_index = pair.first;
     auto &lowered_partialgraph = pair.second;
-    onert::dumper::dot::DotDumper dot_dumper_lowered_part(lowered_partialgraph.get(), dump_level);
-    dot_dumper_lowered_part.dump("after_lower_subg_partialgraph-" +
-                                 std::to_string(partialgraph_index.value()));
+    dot_dumper_part.dump(*lowered_partialgraph, "after_lower_subg_partialgraph-" +
+                                                  std::to_string(partialgraph_index.value()));
   }
 
   // Partial Graph shape inference

--- a/runtime/onert/core/src/dumper/dot/DotDumper.cc
+++ b/runtime/onert/core/src/dumper/dot/DotDumper.cc
@@ -19,6 +19,7 @@
 
 #include "DotDumper.h"
 #include "DotBuilder.h"
+#include "ir/OperandIndexMap.h"
 #include "ir/OperationIndexMap.h"
 #include "backend/Backend.h"
 #include "backend/IConfig.h"
@@ -31,97 +32,77 @@ namespace dumper
 namespace dot
 {
 
-void DotDumper::dump(const std::string &tag)
+namespace
 {
-  if (_level == Level::OFF)
+std::string backend_to_fillcolor(const backend::Backend *backend)
+{
+  static const auto map = []() {
+    std::unordered_map<const backend::Backend *, std::string> ret;
+    uint32_t index = 1; // Start from 1 to avoid 0(red) which is too dark :(
+    for (const auto backend : compiler::BackendManager::get().getAll())
+    {
+      ret.emplace(backend, Node::BG_COLORS[index]);
+      index = (index + 1) % (sizeof(Node::BG_COLORS) / sizeof(Node::BG_COLORS[0]));
+    }
+    return ret;
+  }();
+  auto itr = map.find(backend);
+  if (itr == map.end())
   {
-    return;
+    return Node::DEFAULT_FILLCOLOR;
   }
+  else
+  {
+    return itr->second;
+  }
+}
 
-  onert::dumper::dot::DotBuilder dot_builder;
-
-  auto &operations = _graph.operations();
-  auto &operands = _graph.operands();
-
-  ir::OperationIndexMap<std::unique_ptr<Operation>> operation_nodes;
-  std::unordered_map<ir::OperandIndex, std::unique_ptr<Operand>> operand_nodes;
-
-  auto backend_to_fillcolor = [](const backend::Backend *backend) {
-    static const auto map = []() {
-      std::unordered_map<const backend::Backend *, std::string> ret;
-      uint32_t index = 1; // Start from 1 to avoid 0(red) which is too dark :(
-      for (const auto backend : compiler::BackendManager::get().getAll())
-      {
-        ret.emplace(backend, Node::BG_COLORS[index]);
-        index = (index + 1) % (sizeof(Node::BG_COLORS) / sizeof(Node::BG_COLORS[0]));
-      }
-      return ret;
-    }();
-
-    auto itr = map.find(backend);
-    if (itr == map.end())
-    {
-      return Node::DEFAULT_FILLCOLOR;
-    }
-    else
-    {
-      return itr->second;
-    }
-  };
-
+std::unordered_map<ir::OperandIndex, std::unique_ptr<Operand>>
+generate_dot_operands(const ir::Graph &graph, const DotDumper::Level level)
+{
+  std::unordered_map<ir::OperandIndex, std::unique_ptr<Operand>> dot_operands;
   util::Set<ir::OperandIndex> shown_operand_set;
 
+  const auto &operands = graph.operands();
   operands.iterate([&](const ir::OperandIndex &index, const ir::Operand &object) {
-    bool showing_cond = false;
-    if (_level == Level::ALL)
-    {
-      showing_cond = true;
-    }
-    else
-    {
-      showing_cond =
-        !object.isConstant() || (_graph.getInputs() + _graph.getOutputs()).contains(index);
-    }
+    bool showing_cond =
+      level == DotDumper::Level::ALL
+        ? true
+        : !object.isConstant() || (graph.getInputs() + graph.getOutputs()).contains(index);
     if (showing_cond)
     {
+      // This set is not used anywhere.
+      // TODO: Remove this set
       shown_operand_set.add(index);
 
       auto type = [&]() {
         using onert::dumper::dot::Operand;
-        if (_graph.getInputs().contains(index))
+        if (graph.getInputs().contains(index))
           return Operand::Type::MODEL_INPUT;
-        if (_graph.getOutputs().contains(index))
+        if (graph.getOutputs().contains(index))
           return Operand::Type::MODEL_OUTPUT;
         return Operand::Type::INTERNAL;
       }();
 
       auto node = std::make_unique<Operand>(index, type);
+      std::string label = std::to_string(index.value());
+      std::string fillcolor = "";
+      node->setAttribute("label", label);
+      node->setAttribute("fillcolor", fillcolor);
 
-      {
-        // Display LowerInfo attributes
-        std::string label = std::to_string(index.value());
-        std::string fillcolor = "";
-        if (_lowered_graph)
-        {
-          auto lower_info = _lowered_graph->lower_info().operand.getRawPtr(index);
-          const auto &def_factors = lower_info->def_factors();
-          if (def_factors.size() > 0)
-          {
-            label += "\\n[";
-            label += def_factors.getOnlyElement().backend()->config()->id();
-            label += "]";
-
-            fillcolor = backend_to_fillcolor(lower_info->def_factors().getOnlyElement().backend());
-          }
-        }
-        node->setAttribute("label", label);
-        node->setAttribute("fillcolor", fillcolor);
-      }
-
-      operand_nodes.emplace(index, std::move(node));
+      dot_operands.emplace(index, std::move(node));
     }
   });
 
+  return dot_operands;
+}
+
+ir::OperationIndexMap<std::unique_ptr<Operation>>
+generate_dot_operations(const ir::Graph &graph,
+                        const ir::OperandIndexMap<std::unique_ptr<Operand>> &dot_operands)
+{
+  ir::OperationIndexMap<std::unique_ptr<Operation>> dot_operations;
+  const auto &operations = graph.operations();
   operations.iterate([&](const ir::OperationIndex &index, const ir::Operation &op) {
     auto node = std::make_unique<Operation>(index, op);
 
@@ -130,42 +111,79 @@ void DotDumper::dump(const std::string &tag)
       using onert::dumper::dot::Operand;
 
       // Constant input and dump level is ALL_BUT_CONSTANTS
-      if (operand_nodes.find(input) == operand_nodes.end())
+      if (dot_operands.find(input) == dot_operands.end())
         continue;
 
-      auto &input_node = operand_nodes.at(input);
+      auto &input_node = dot_operands.at(input);
       input_node->addOutEdge(node.get());
     }
 
     for (auto output : op.getOutputs() | ir::Remove::UNDEFINED)
     {
       using onert::dumper::dot::Operand;
-      auto &output_node = operand_nodes.at(output);
+      auto &output_node = dot_operands.at(output);
       node->addOutEdge(output_node.get());
     }
 
-    operation_nodes.emplace(index, std::move(node));
+    dot_operations.emplace(index, std::move(node));
   });
 
-  if (_lowered_graph)
-  {
-    _graph.operations().iterate([&](const ir::OperationIndex &index, const ir::Operation &) {
-      const auto lower_info = _lowered_graph->lower_info().operation.getRawPtr(index);
-      if (lower_info)
-      {
-        auto fillcolor = backend_to_fillcolor(lower_info->backend());
-        std::string backend_label = "[" + lower_info->backend()->config()->id() + "]";
-        auto itr = operation_nodes.find(index);
-        if (itr != operation_nodes.end())
-        {
-          auto &node = itr->second;
-          node->setAttribute("label", node->getAttribute("label") + "\n" + backend_label);
-          node->setAttribute("fillcolor", fillcolor);
-        }
-      }
-    });
-  }
+  return dot_operations;
+}
 
+void update_lower_info(const compiler::LoweredGraph &lowered_graph,
+                       ir::OperandIndexMap<std::unique_ptr<Operand>> *dot_operands)
+{
+  const auto &operands = lowered_graph.graph().operands();
+  operands.iterate([&](const ir::OperandIndex &index, const ir::Operand &) {
+    auto itr = dot_operands->find(index);
+    if (itr != dot_operands->end())
+    {
+      auto &node = itr->second;
+      // Display LowerInfo attributes
+      std::string label = node->getAttribute("label");
+      std::string fillcolor = node->getAttribute("fillcolor");
+      auto lower_info = lowered_graph.lower_info().operand.getRawPtr(index);
+      const auto &def_factors = lower_info->def_factors();
+      if (def_factors.size() > 0)
+      {
+        label += "\\n[";
+        label += def_factors.getOnlyElement().backend()->config()->id();
+        label += "]";
+        fillcolor = backend_to_fillcolor(lower_info->def_factors().getOnlyElement().backend());
+      }
+      node->setAttribute("label", label);
+      node->setAttribute("fillcolor", fillcolor);
+    }
+  });
+}
+
+void update_lower_info(const compiler::LoweredGraph &lowered_graph,
+                       ir::OperationIndexMap<std::unique_ptr<Operation>> *dot_operations)
+{
+  const auto &operations = lowered_graph.graph().operations();
+  operations.iterate([&](const ir::OperationIndex &index, const ir::Operation &) {
+    const auto lower_info = lowered_graph.lower_info().operation.getRawPtr(index);
+    if (lower_info)
+    {
+      auto fillcolor = backend_to_fillcolor(lower_info->backend());
+      std::string backend_label = "[" + lower_info->backend()->config()->id() + "]";
+      auto itr = dot_operations->find(index);
+      if (itr != dot_operations->end())
+      {
+        auto &node = itr->second;
+        node->setAttribute("label", node->getAttribute("label") + "\n" + backend_label);
+        node->setAttribute("fillcolor", fillcolor);
+      }
+    }
+  });
+}
+
+void dump_to_file(const ir::OperandIndexMap<std::unique_ptr<Operand>> &operand_nodes,
+                  const ir::OperationIndexMap<std::unique_ptr<Operation>> &operation_nodes,
+                  const std::string &tag)
+{
+  onert::dumper::dot::DotBuilder dot_builder;
   for (const auto &e : operation_nodes)
     dot_builder.update(*e.second);
   for (const auto &e : operand_nodes)
@@ -185,6 +203,33 @@ void DotDumper::dump(const std::string &tag)
 
     fb.close();
   }
+}
+} // namespace
+
+void DotDumper::dump(const ir::Graph &graph, const std::string &tag)
+{
+  if (_level == Level::OFF)
+  {
+    return;
+  }
+
+  const auto dot_operands = generate_dot_operands(graph, _level);
+  const auto dot_operations = generate_dot_operations(graph, dot_operands);
+  dump_to_file(dot_operands, dot_operations, tag);
+}
+
+void DotDumper::dump(const compiler::LoweredGraph &lowered_graph, const std::string &tag)
+{
+  if (_level == Level::OFF)
+  {
+    return;
+  }
+
+  auto dot_operands = generate_dot_operands(lowered_graph.graph(), _level);
+  auto dot_operations = generate_dot_operations(lowered_graph.graph(), dot_operands);
+  update_lower_info(lowered_graph, &dot_operands);
+  update_lower_info(lowered_graph, &dot_operations);
+  dump_to_file(dot_operands, dot_operations, tag);
 }
 
 } // namespace dot

--- a/runtime/onert/core/src/dumper/dot/DotDumper.h
+++ b/runtime/onert/core/src/dumper/dot/DotDumper.h
@@ -38,27 +38,28 @@ public:
   };
 
 public:
-  DotDumper(const ir::Graph &graph, Level level)
-    : _lowered_graph{nullptr}, _graph(graph), _level{level}
-  {
-  }
-  DotDumper(const compiler::LoweredGraph *lowered_graph, Level level)
-    : _lowered_graph{lowered_graph}, _graph(_lowered_graph->graph()), _level{level}
-  {
-  }
+  DotDumper(Level level) : _level{level} {}
 
 public:
   /**
-   * @brief Dump to dot file as tag name if "GRAPH_DOT_DUMP" is set
+   * @brief Dump graph information to dot file as tag name if "GRAPH_DOT_DUMP" is set
    *
+   * @param[in] graph  The graph that would be used to get operations and operands
    * @param[in] tag    The name of dot file that would be created
    * @return N/A
    */
-  void dump(const std::string &tag);
+  void dump(const ir::Graph &graph, const std::string &tag);
+
+  /**
+   * @brief Dump lowered graph information to dot file as tag name if "GRAPH_DOT_DUMP" is set
+   *
+   * @param[in] graph  The graph that would be used to get operations and operands
+   * @param[in] tag    The name of dot file that would be created
+   * @return N/A
+   */
+  void dump(const compiler::LoweredGraph &lowered_graph, const std::string &tag);
 
 private:
-  const compiler::LoweredGraph *_lowered_graph;
-  const ir::Graph &_graph;
   Level _level;
 };
 


### PR DESCRIPTION
This commit refines DotDumper.
  - Seperate the method `dump()` of `DotDumper`
  - Remove class members that might cause the problems with c++ lifetime

Signed-off-by: ragmani <ragmani0216@gmail.com>