### PR TITLE
[onert/api] Get file extension by searching ., not by fixed length

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -243,13 +243,14 @@ NNFW_STATUS nnfw_session::load_model_from_modelfile(const char *model_file_path)
   }
 
   std::string filename{model_file_path};
-  if (filename.size() < 8) // .tflite or .circle
+  // TODO: Use std::filesystem::path when we can use c++17.
+  auto dotidx = filename.find_last_of('.');
+  if (dotidx == std::string::npos)
   {
-    std::cerr << "Invalid model file path." << std::endl;
+    std::cerr << "Invalid model file path. Please use file with extension." << std::endl;
     return NNFW_STATUS_ERROR;
   }
-
-  std::string model_type = filename.substr(filename.size() - 7, 7);
+  std::string model_type = filename.substr(dotidx);
 
   try
   {


### PR DESCRIPTION
load_model_from_modelfile() assumes that its model file will end with
either `.circle` or `.tflite`. It get its extension by getting last 7
characters. But it would be more generatl to find extension by last dot.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

Related: https://github.com/Samsung/ONE/pull/9244#discussion_r896447982

I tested this change by running `tflite_comparator 1.tvn`.
Sure, it only succeeds to run `1.tvn`, and fails whille trying `1.tvn` with tflite interpreter. : )
But I confirmed this change works by seeing trix emulator's run log.