### PR TITLE
[onert] Revisit session creation

### DIFF
--- a/runtime/onert/api/src/nnfw_api.cc
+++ b/runtime/onert/api/src/nnfw_api.cc
@@ -58,15 +58,7 @@ STATIC_ASSERT_ENUM_CHECK(NNFW_INFO_ID_VERSION, 0);
  * @param session the session to be created
  * @return NNFW_STATUS_NO_ERROR if successful
  */
-NNFW_STATUS nnfw_create_session(nnfw_session **session)
-{
-  NNFW_RETURN_ERROR_IF_NULL(session);
-
-  *session = new (std::nothrow) nnfw_session();
-  if (*session == nullptr)
-    return NNFW_STATUS_OUT_OF_MEMORY;
-  return NNFW_STATUS_NO_ERROR;
-}
+NNFW_STATUS nnfw_create_session(nnfw_session **session) { return nnfw_session::create(session); }
 
 /*
  * Close a session instance

--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -210,15 +210,10 @@ NNFW_STATUS nnfw_session::create(nnfw_session **session)
     return NNFW_STATUS_UNEXPECTED_NULL;
 
   // Create session
-  try
+  *session = new (std::nothrow) nnfw_session();
+  if (*session == nullptr)
   {
-    *session = new nnfw_session();
-  }
-  catch (const std::exception &e)
-  {
-    std::cerr << "Error during session creation : " << e.what() << std::endl;
-    *session = nullptr;
-
+    std::cerr << "Error during session creation" << std::endl;
     return NNFW_STATUS_OUT_OF_MEMORY;
   }
 
@@ -231,6 +226,7 @@ NNFW_STATUS nnfw_session::create(nnfw_session **session)
   catch (const std::exception &e)
   {
     std::cerr << "Error during session initialization : " << e.what() << std::endl;
+    delete *session;
     *session = nullptr;
 
     return NNFW_STATUS_ERROR;

--- a/runtime/onert/api/src/nnfw_api_internal.h
+++ b/runtime/onert/api/src/nnfw_api_internal.h
@@ -98,9 +98,18 @@ private:
   };
 
 public:
-  nnfw_session();
-  ~nnfw_session();
+  /**
+   * @brief Factory method. It creates and initialize nnfw_session
+   *
+   * @note  Use factory instead of constructor to get status
+   */
+  static NNFW_STATUS create(nnfw_session **session);
 
+private:
+  nnfw_session();
+
+public:
+  ~nnfw_session();
   NNFW_STATUS load_model_from_nnpackage(const char *package_file_path);
   NNFW_STATUS prepare();
   NNFW_STATUS prepare_pipeline(const char *map_file_path);


### PR DESCRIPTION
This commit revisits session creation.
It introduces factory method for `nnfw_session`. Factory method handles different exception type and return different status.
To prevent using constructor directly, `nnfw_session`'s constructor is changed to private.
To initialize on session creation, `_coption` and `_kernel_registry` initialization is moved into factory method.

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: https://github.com/Samsung/ONE/pull/9335#discussion_r906899854