### PR TITLE
[circle-operator] Fix README typo

### DIFF
--- a/compiler/circle-operator/README.md
+++ b/compiler/circle-operator/README.md
@@ -27,7 +27,7 @@ Operators codes with `--code`
 
 Example
 ```
-$ circle-operator --name model.circle
+$ circle-operator --code model.circle
 ```
 
 Result


### PR DESCRIPTION
This will fix README typo with argument.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>