### PR TITLE
Fix format checker for python

### DIFF
--- a/infra/command/format
+++ b/infra/command/format
@@ -154,11 +154,9 @@ function check_python_files() {
   fi
 
   # Check python files
-  FILES_TO_CHECK_PYTHON=`echo "$FILES_TO_CHECK" | tr ' ' '\n' | egrep '\.py$'`
+  FILES_TO_CHECK_PYTHON=(`echo "$FILES_TO_CHECK" | tr ' ' '\n' | egrep '\.py$'`)
   # Exceptional case: one-cmds don't have '.py' extension: ignore non-python source (cmake, etc) and ignore shell script: one-prepare-venv
-  FILES_TO_CHECK_PYTHON=`echo "$FILES_TO_CHECK_PYTHON" | egrep -v '^compiler/one-cmds/.*\..*$' | egrep -v '^compiler/one-cmds/one-prepare-venv$'`
-  # Transform to array
-  FILES_TO_CHECK_PYTHON=($FILES_TO_CHECK_PYTHON)
+  FILES_TO_CHECK_PYTHON+=(`echo "$FILES_TO_CHECK" | tr ' ' '\n' | egrep '^compiler/one-cmds/[^(\./)]*$' | egrep -v '^compiler/one-cmds/one-prepare-venv$'`)
 
   for s in ${DIRECTORIES_NOT_TO_BE_TESTED[@]}; do
     skip=${s#'.'/}/


### PR DESCRIPTION
This commit fixes format checker to include `*.py` files in `one-cmds`
directory and few `one-cmds` scripts which are based on python.

Signed-off-by: yunjay-hong <yunjay.hong@samsung.com>

---

This pr changes formatter script, and it might break CI until #9353 is merged. 

for: #9351 
draft: #9352 