### PR TITLE
[luci] Revist ConvertToFakeQuantizedModelPass.h

### DIFF
--- a/compiler/luci/pass/include/luci/Pass/ConvertToFakeQuantizedModel.h
+++ b/compiler/luci/pass/include/luci/Pass/ConvertToFakeQuantizedModel.h
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-#ifndef __LUCI_CONVERT_TO_FAKE_QUANTIZED_MODEL_PASS_H__
-#define __LUCI_CONVERT_TO_FAKE_QUANTIZED_MODEL_PASS_H__
+#ifndef __LUCI_CONVERT_TO_FAKE_QUANTIZED_MODEL_H__
+#define __LUCI_CONVERT_TO_FAKE_QUANTIZED_MODEL_H__
 
-#include <logo/Pass.h>
+#include <loco.h>
 
 namespace luci
 {
@@ -25,15 +25,11 @@ namespace luci
 /**
  * @brief  Class to convert a quantized model to a fake-quantized fp32 model.
  */
-struct ConvertToFakeQuantizedModelPass final : public logo::Pass
+struct ConvertToFakeQuantizedModel final
 {
-  ConvertToFakeQuantizedModelPass() {}
-
-  const char *name(void) const final { return "luci::ConvertToFakeQuantizedModelPass"; }
-
-  bool run(loco::Graph *g) final;
+  void run(loco::Graph *g);
 };
 
 } // namespace luci
 
-#endif // __LUCI_CONVERT_TO_FAKE_QUANTIZED_MODEL_PASS_H__
+#endif // __LUCI_CONVERT_TO_FAKE_QUANTIZED_MODEL_H__

--- a/compiler/luci/pass/src/CircleQuantizer.cpp
+++ b/compiler/luci/pass/src/CircleQuantizer.cpp
@@ -20,7 +20,7 @@
 #include "luci/Pass/ForceQuantParamPass.h"
 #include "luci/Pass/PropagateQParamForwardPass.h"
 #include "luci/Pass/RequantizePass.h"
-#include "luci/Pass/ConvertToFakeQuantizedModelPass.h"
+#include "luci/Pass/ConvertToFakeQuantizedModel.h"
 #include "luci/Pass/FoldDequantizePass.h"
 #include "luci/Pass/RemoveRedundantDequantizePass.h"
 #include "luci/Pass/QuantizePreCheckerPass.h"
@@ -425,7 +425,7 @@ void CircleQuantizer::quantize(loco::Graph *g) const
   // Convert quantized model to fake-quantized model
   if (_options->query(Options::Algorithm::ConvertToFakeQuantizedModel))
   {
-    luci::ConvertToFakeQuantizedModelPass fake_quantizer;
+    luci::ConvertToFakeQuantizedModel fake_quantizer;
     fake_quantizer.run(g);
 
     logo::Phase phase;

--- a/compiler/luci/pass/src/ConvertToFakeQuantizedModel.cpp
+++ b/compiler/luci/pass/src/ConvertToFakeQuantizedModel.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "luci/Pass/ConvertToFakeQuantizedModelPass.h"
+#include "luci/Pass/ConvertToFakeQuantizedModel.h"
 #include "luci/Pass/QuantizationParameters.h"
 
 #include "QuantizationUtils.h"
@@ -237,20 +237,17 @@ struct FakeQuantize final : public luci::CircleNodeMutableVisitor<void>
 namespace luci
 {
 
-bool ConvertToFakeQuantizedModelPass::run(loco::Graph *g)
+void ConvertToFakeQuantizedModel::run(loco::Graph *g)
 {
   LOGGER(l);
   for (auto node : loco::active_nodes(loco::output_nodes(g)))
   {
     auto circle_node = loco::must_cast<luci::CircleNode *>(node);
-    INFO(l) << "ConvertToFakeQuantizedModelPass visit node: " << circle_node->name() << std::endl;
+    INFO(l) << "ConvertToFakeQuantizedModel visit node: " << circle_node->name() << std::endl;
 
     FakeQuantize fq;
     circle_node->accept(&fq);
   }
-
-  // One time run
-  return false;
 }
 
 } // namespace luci

--- a/compiler/luci/pass/src/ConvertToFakeQuantizedModel.test.cpp
+++ b/compiler/luci/pass/src/ConvertToFakeQuantizedModel.test.cpp
@@ -16,7 +16,7 @@
 
 #include <logo/Phase.h>
 
-#include "luci/Pass/ConvertToFakeQuantizedModelPass.h"
+#include "luci/Pass/ConvertToFakeQuantizedModel.h"
 #include <luci/IR/CircleNodes.h>
 
 #include <gtest/gtest.h>
@@ -232,7 +232,7 @@ TEST(ConvertToFakeQuantizedModelTest, U8Conv2D)
   U8ConvGraph g;
   g.init();
 
-  luci::ConvertToFakeQuantizedModelPass fq;
+  luci::ConvertToFakeQuantizedModel fq;
   fq.run(&g.g);
 
   // Check ifm
@@ -255,7 +255,7 @@ TEST(ConvertToFakeQuantizedModelTest, F32Conv2D_NEG)
   FP32ConvGraph g;
   g.init();
 
-  luci::ConvertToFakeQuantizedModelPass fq;
+  luci::ConvertToFakeQuantizedModel fq;
   fq.run(&g.g);
 
   uint32_t dequant_count = 0;


### PR DESCRIPTION
This makes ConvertToFakeQuantizedModelPass do not inherit Pass.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/9356