### PR TITLE
[one-cmds] Fix one-infer help message

### DIFF
--- a/compiler/one-cmds/one-infer
+++ b/compiler/one-cmds/one-infer
@@ -109,7 +109,7 @@ def _search_backend_driver(driver):
 
 
 def _get_parser(backends_list):
-    infer_usage = 'one-infer [-h] [-v] [-C CONFIG] [-d DRIVER] [-b BACKEND] [--post-process POST_PROCESS] [--] [COMMANDS FOR BACKEND DRIVER]'
+    infer_usage = 'one-infer [-h] [-v] [-C CONFIG] [-d DRIVER | -b BACKEND] [--post-process POST_PROCESS] [--] [COMMANDS FOR BACKEND DRIVER]'
     parser = argparse.ArgumentParser(
         description='command line tool to infer model', usage=infer_usage)
 


### PR DESCRIPTION
This commit fixes one-infer help message to clarify
its mutually exclusive options.

Signed-off-by: yunjay-hong <yunjay.hong@samsung.com>