### PR TITLE
[one-cmds] Rename wrong variables

### DIFF
--- a/compiler/one-cmds/tests/CMakeLists.txt
+++ b/compiler/one-cmds/tests/CMakeLists.txt
@@ -3,8 +3,8 @@
 # Gather test scripts
 file(GLOB TESTITEMS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "./*.test")
 file(GLOB CONFIGITEMS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "./*.cfg")
-file(GLOB CONFIGITEMS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "./*.py")
 file(GLOB QCONFIGITEMS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "./*.qconf.json")
+file(GLOB PYSCRIPTS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "./*.py")
 
 # Create a script to run the tests at installation folder
 set(DRIVER_SCRIPT "${CMAKE_CURRENT_BINARY_DIR}/runtestall.sh")
@@ -45,6 +45,11 @@ foreach(QCONFIGITEM IN ITEMS ${QCONFIGITEMS})
   get_filename_component(ITEM_PREFIX ${QCONFIGITEM} NAME_WE)
   install(FILES ${QCONFIGITEM} DESTINATION test)
 endforeach(QCONFIGITEM)
+
+foreach(PYSCRIPT IN ITEMS ${PYSCRIPTS})
+  get_filename_component(ITEM_PREFIX ${PYSCRIPT} NAME_WE)
+  install(FILES ${PYSCRIPT} DESTINATION test)
+endforeach(PYSCRIPT)
 
 file(APPEND "${DRIVER_SCRIPT}" "popd > /dev/null\n\n")
 


### PR DESCRIPTION
This commit renames wrong variables.

Related: https://github.com/Samsung/ONE/issues/9370#issuecomment-1171937926
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>