### PR TITLE
[onert] Refine StaticShapeinferer

### DIFF
--- a/tests/nnfw_api/src/one_op_tests/While.test.cc
+++ b/tests/nnfw_api/src/one_op_tests/While.test.cc
@@ -261,10 +261,10 @@ TEST_F(GenModelTest, neg_while_wrong_dtype)
   }
 
   _context = std::make_unique<GenModelTestContext>(cgen.finish());
-  auto tc = uniformTCD<float>({{0}}, {{100}});
-  tc.expectFailRun();
-  _context->addTestCase(tc);
   _context->setBackends({"cpu"});
+  // It is correct to call `_context->expectFailModelLoad();`, but OperationValidator does not deal
+  // with subgraphs. So it is verified by `_context->expectFailCompile(); as a workaround`
+  _context->expectFailCompile();
 
   SUCCEED();
 }


### PR DESCRIPTION
This commit refines StaticShapeInferer.
  - Change StaticShapeInferer so that a StaticShapeInferer is assigned to each subgraph
  - Add observers to call StaticShapeInferers recursively