### PR TITLE
[infra] Install CfgRunner.py

### DIFF
--- a/infra/debian/compiler/one-compiler.install
+++ b/infra/debian/compiler/one-compiler.install
@@ -28,6 +28,7 @@ usr/bin/one-quantize usr/share/one/bin/
 usr/bin/one-version usr/share/one/bin/
 usr/bin/onelib/constant.py usr/share/one/bin/onelib/
 usr/bin/onelib/make_cmd.py usr/share/one/bin/onelib/
+usr/bin/onelib/CfgRunner.py usr/share/one/bin/onelib/
 usr/bin/onnx_legalizer.py usr/share/one/bin/
 usr/bin/rawdata2hdf5 usr/share/one/bin/
 usr/bin/record-minmax usr/share/one/bin/


### PR DESCRIPTION
This commit installs CfgRunner.py to onelib.

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>