### PR TITLE
[onert/cker] Check ruy::Context pointer to make gcc11 happy

### DIFF
--- a/compute/cker/include/cker/CpuBackendThreadpool.h
+++ b/compute/cker/include/cker/CpuBackendThreadpool.h
@@ -21,6 +21,8 @@
 #include <ruy/context.h>     // from @ruy
 #include <ruy/thread_pool.h> // from @ruy
 
+#include <stdexcept>
+
 namespace nnfw
 {
 namespace cker
@@ -33,7 +35,12 @@ using Task = ruy::Task;
 template <typename TaskType>
 void Execute(int tasks_count, TaskType *tasks, ruy::Context *ruy_context)
 {
+  assert(ruy_context != nullptr);
   assert(tasks_count <= ruy_context->max_num_threads());
+  if (ruy_context == nullptr)
+  {
+    throw std::runtime_error("CpuBackendThreadpool.h: ruy::Context is null");
+  }
   ruy_context->mutable_thread_pool()->Execute(tasks_count, tasks);
 }
 


### PR DESCRIPTION
Related to #9265

This commit adds checking ruy::Context pointer to make gcc11 happy.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>