### PR TITLE
[ArmComputeEx] Use python3 explicitly

### DIFF
--- a/compute/ARMComputeEx/CMakeLists.txt
+++ b/compute/ARMComputeEx/CMakeLists.txt
@@ -14,7 +14,7 @@ file(GLOB_RECURSE ACL_EX_SRCS "${ACL_EX_BASE}/*.cpp")
 # generate embeded cl_kernel
 execute_process (
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-    COMMAND bash -c "python resolve_includes.py"
+    COMMAND bash -c "python3 resolve_includes.py"
 )
 
 add_library(arm_compute_ex SHARED ${ACL_EX_SRCS})

--- a/packaging/nnfw.spec
+++ b/packaging/nnfw.spec
@@ -42,7 +42,7 @@ BuildRequires:  pkgconfig(flatbuffers)
 
 %ifarch %{arm} aarch64
 # Require python for acl-ex library build pre-process
-BuildRequires:  python
+BuildRequires:  python3
 BuildRequires:  libarmcl-devel >= v21.02
 %endif
 


### PR DESCRIPTION
Let's use python3 explicitly on ArmComputeEx build process.

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>