### PR TITLE
[one-cmds] Experimental disable_batchmatmul_unfold option

### DIFF
--- a/compiler/one-cmds/one-import-onnx
+++ b/compiler/one-cmds/one-import-onnx
@@ -86,6 +86,12 @@ def _get_parser():
         action='store_true',
         help='Save intermediate files to output folder')
 
+    # experimental options
+    parser.add_argument(
+        '--disable_batchmatmul_unfold',
+        action='store_true',
+        help='Experimental disable BatMatMul unfold')
+
     return parser
 
 

--- a/compiler/one-cmds/one-import-onnx
+++ b/compiler/one-cmds/one-import-onnx
@@ -90,7 +90,7 @@ def _get_parser():
     parser.add_argument(
         '--disable_batchmatmul_unfold',
         action='store_true',
-        help='Experimental disable BatMatMul unfold')
+        help='Experimental disable BatchMatMul unfold')
 
     return parser
 

--- a/compiler/one-cmds/one-import-onnx
+++ b/compiler/one-cmds/one-import-onnx
@@ -88,7 +88,7 @@ def _get_parser():
 
     # experimental options
     parser.add_argument(
-        '--disable_batchmatmul_unfold',
+        '--experimental_disable_batchmatmul_unfold',
         action='store_true',
         help='Experimental disable BatchMatMul unfold')
 

--- a/compiler/one-cmds/onelib/make_cmd.py
+++ b/compiler/one-cmds/onelib/make_cmd.py
@@ -65,6 +65,10 @@ def make_tf2tfliteV2_cmd(args, driver_path, input_path, output_path):
         cmd.append('--output_arrays')
         cmd.append(getattr(args, 'output_arrays'))
 
+    # experimental options
+    if _is_valid_attr(args, 'disable_batchmatmul_unfold'):
+        cmd.append('--disable_batchmatmul_unfold')
+
     return cmd
 
 

--- a/compiler/one-cmds/onelib/make_cmd.py
+++ b/compiler/one-cmds/onelib/make_cmd.py
@@ -66,8 +66,8 @@ def make_tf2tfliteV2_cmd(args, driver_path, input_path, output_path):
         cmd.append(getattr(args, 'output_arrays'))
 
     # experimental options
-    if _is_valid_attr(args, 'disable_batchmatmul_unfold'):
-        cmd.append('--disable_batchmatmul_unfold')
+    if _is_valid_attr(args, 'experimental_disable_batchmatmul_unfold'):
+        cmd.append('--experimental_disable_batchmatmul_unfold')
 
     return cmd
 

--- a/compiler/tf2tfliteV2/tf2tfliteV2.py
+++ b/compiler/tf2tfliteV2/tf2tfliteV2.py
@@ -114,7 +114,7 @@ def _get_parser():
     parser.add_argument(
         "--disable_batchmatmul_unfold",
         action="store_true",
-        help="Experimental disable BatMatMul unfold")
+        help="Experimental disable BatchMatMul unfold")
 
     # Set default value
     parser.set_defaults(model_format="graph_def")

--- a/compiler/tf2tfliteV2/tf2tfliteV2.py
+++ b/compiler/tf2tfliteV2/tf2tfliteV2.py
@@ -112,7 +112,7 @@ def _get_parser():
 
     # experimental options
     parser.add_argument(
-        "--disable_batchmatmul_unfold",
+        "--experimental_disable_batchmatmul_unfold",
         action="store_true",
         help="Experimental disable BatchMatMul unfold")
 
@@ -234,7 +234,7 @@ def _v2_convert(flags):
         keras_model = tf.keras.models.load_model(flags.input_path)
         converter = tf.lite.TFLiteConverter.from_keras_model(keras_model)
 
-    if flags.disable_batchmatmul_unfold:
+    if flags.experimental_disable_batchmatmul_unfold:
         converter._experimental_disable_batchmatmul_unfold = True
 
     converter.allow_custom_ops = True

--- a/compiler/tf2tfliteV2/tf2tfliteV2.py
+++ b/compiler/tf2tfliteV2/tf2tfliteV2.py
@@ -110,6 +110,12 @@ def _get_parser():
         type=str,
         help="Names of the output arrays, comma-separated.")
 
+    # experimental options
+    parser.add_argument(
+        "--disable_batchmatmul_unfold",
+        action="store_true",
+        help="Experimental disable BatMatMul unfold")
+
     # Set default value
     parser.set_defaults(model_format="graph_def")
     return parser
@@ -227,6 +233,9 @@ def _v2_convert(flags):
     if flags.model_format == "keras_model":
         keras_model = tf.keras.models.load_model(flags.input_path)
         converter = tf.lite.TFLiteConverter.from_keras_model(keras_model)
+
+    if flags.disable_batchmatmul_unfold:
+        converter._experimental_disable_batchmatmul_unfold = True
 
     converter.allow_custom_ops = True
     converter.experimental_new_converter = True


### PR DESCRIPTION
This will add experimental disable_batchmatmul_unfold option to
tf2tfliteV2 and one-import-onnx to support ONNX models having BatMatMul Ops.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>