### PR TITLE
[doc] Update how-to-build-runtime.md

### DIFF
--- a/docs/howto/how-to-build-runtime.md
+++ b/docs/howto/how-to-build-runtime.md
@@ -8,11 +8,12 @@ If you are going to build this project, the following modules must be installed 
 
 - CMake
 - Boost C++ libraries
+- GLib library of C routines
 
 In the Ubuntu, you can easily install it with the following command.
 
 ```
-$ sudo apt-get install cmake libboost-all-dev
+$ sudo apt-get install cmake libboost-all-dev libglib2.0-dev
 ```
 
 If your linux system does not have the basic development configuration, you will need to install more packages. A list of all packages needed to configure the development environment can be found in https://github.com/Samsung/ONE/blob/master/infra/docker/bionic/Dockerfile.
@@ -32,6 +33,7 @@ lcov \
 libatlas-base-dev \
 libboost-all-dev \
 libgflags-dev \
+libglib2.0-dev \
 libgoogle-glog-dev \
 libgtest-dev \
 libhdf5-dev \


### PR DESCRIPTION
This commit updates how-to-build-runtime.md.
  - Add installing libglib2.0-dev for x64 build

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>