### PR TITLE
[onert] Change unnecessary copies to use references

### DIFF
--- a/runtime/onert/core/src/compiler/ExecutorFactory.cc
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.cc
@@ -321,7 +321,7 @@ exec::IExecutor *ExecutorFactory::createLinearExecutor(
   std::unique_ptr<compiler::LoweredGraph> lowered_graph, const util::TracingCtx *tracing_ctx,
   const compiler::CompilerOptions &options, const std::shared_ptr<exec::ExecutorMap> &executor_map)
 {
-  auto graph = lowered_graph->graph();
+  auto &graph = lowered_graph->graph();
 
   backend::BackendContexts backend_contexts =
     createBackendContexts(*lowered_graph, options.executor == "Linear");

--- a/runtime/onert/core/src/compiler/Fp32ToFp16Converter.cc
+++ b/runtime/onert/core/src/compiler/Fp32ToFp16Converter.cc
@@ -180,7 +180,7 @@ void Fp32ToFp16Converter::appendOpSequences()
 {
   _lowered_graph.op_seqs().iterate(
     [&](const ir::OpSequenceIndex &op_seq_ind, ir::OpSequence &op_seq) {
-      const auto lower_info = _lowered_graph.getLowerInfo(op_seq_ind);
+      const auto &lower_info = _lowered_graph.getLowerInfo(op_seq_ind);
       assert(lower_info != nullptr);
 
       // For now, the only acl_cl supports fully fp16 type
@@ -375,7 +375,7 @@ void Fp32ToFp16Converter::convertOperands()
 {
   _lowered_graph.op_seqs().iterate(
     [&](const ir::OpSequenceIndex &op_seq_ind, ir::OpSequence &op_seq) {
-      const auto lower_info = _lowered_graph.getLowerInfo(op_seq_ind);
+      const auto &lower_info = _lowered_graph.getLowerInfo(op_seq_ind);
       assert(lower_info != nullptr);
       // For now, the only acl_cl supports fully fp16
       if (lower_info->backend()->config()->id() != kAclClBackendConfigId)
@@ -515,7 +515,7 @@ ir::OperandIndex Fp32ToFp16Converter::newCopiedOperand(const ir::OperandIndex &o
 void Fp32ToFp16Converter::setNewOperandLowerInfo(const ir::OpSequenceIndex &op_seq_ind,
                                                  const ir::OperandIndex &new_op_ind)
 {
-  const auto lower_info = _lowered_graph.getLowerInfo(op_seq_ind);
+  const auto &lower_info = _lowered_graph.getLowerInfo(op_seq_ind);
   assert(lower_info != nullptr);
   auto new_lower_info = std::make_unique<compiler::OperandLowerInfo>();
   auto permute_factor = compiler::PermuteFactor(lower_info->backend(), lower_info->layout());
@@ -527,7 +527,7 @@ void Fp32ToFp16Converter::setNewOperandLowerInfo(const ir::OpSequenceIndex &op_s
 void Fp32ToFp16Converter::setNewOperationLowerInfo(const ir::OpSequenceIndex &op_seq_ind,
                                                    const ir::OpSequenceIndex &new_op_seq_ind)
 {
-  const auto lower_info = _lowered_graph.getLowerInfo(op_seq_ind);
+  const auto &lower_info = _lowered_graph.getLowerInfo(op_seq_ind);
   assert(lower_info != nullptr);
 
   auto new_lower_info =
@@ -635,7 +635,7 @@ ir::OpSequenceIndex Fp32ToFp16Converter::newOpSequence(const ir::OpSequenceIndex
                                                        const ir::OperationIndex &node_index)
 {
   auto &node = _lowered_graph.graph().operations().at(node_index);
-  const auto lower_info = _lowered_graph.getLowerInfo(op_seq_ind);
+  const auto &lower_info = _lowered_graph.getLowerInfo(op_seq_ind);
   assert(lower_info != nullptr);
   auto layout = lower_info->layout();
 


### PR DESCRIPTION
This commit changes unnecessary copies to use references.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>