### PR TITLE
[onert] Add explicit keyword to Graph constructor

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -902,12 +902,12 @@ void nnfw_session::make_dependency()
 {
   for (uint32_t out_exe = 0; out_exe < _executions.size(); out_exe++)
   {
-    auto out_graph = _executions[out_exe]->primary_subgraph();
+    auto &out_graph = _executions[out_exe]->primary_subgraph();
     for (uint32_t in_exe = 0; in_exe < _executions.size(); in_exe++)
     {
       if (out_exe == in_exe)
         continue;
-      auto in_graph = _executions[in_exe]->primary_subgraph();
+      auto &in_graph = _executions[in_exe]->primary_subgraph();
       for (auto out = out_graph._name_to_output_begin(); out != out_graph._name_to_output_end();
            out++)
       {

--- a/runtime/onert/core/include/ir/Graph.h
+++ b/runtime/onert/core/include/ir/Graph.h
@@ -50,7 +50,9 @@ private:
   };
 
 public:
-  Graph(void);
+  explicit Graph(void);
+  explicit Graph(const Graph &);
+
   ~Graph(void);
 
   // Graph Building
@@ -139,19 +141,19 @@ public:
   {
     return _tensor_names;
   }
-  std::unordered_map<std::string, IOIndex>::iterator _name_to_input_begin()
+  std::unordered_map<std::string, IOIndex>::const_iterator _name_to_input_begin() const
   {
     return _name_to_input.begin();
   }
-  std::unordered_map<std::string, IOIndex>::iterator _name_to_input_end()
+  std::unordered_map<std::string, IOIndex>::const_iterator _name_to_input_end() const
   {
     return _name_to_input.end();
   }
-  std::unordered_map<std::string, IOIndex>::iterator _name_to_output_begin()
+  std::unordered_map<std::string, IOIndex>::const_iterator _name_to_output_begin() const
   {
     return _name_to_output.begin();
   }
-  std::unordered_map<std::string, IOIndex>::iterator _name_to_output_end()
+  std::unordered_map<std::string, IOIndex>::const_iterator _name_to_output_end() const
   {
     return _name_to_output.end();
   }

--- a/runtime/onert/core/src/ir/Graph.cc
+++ b/runtime/onert/core/src/ir/Graph.cc
@@ -28,6 +28,8 @@ namespace ir
 
 Graph::Graph() = default;
 
+Graph::Graph(const Graph &) = default;
+
 Graph::~Graph(void) = default;
 
 OperandIndex Graph::addOperand(const Shape &shape, const TypeInfo &type)


### PR DESCRIPTION
This commit adds explicit keyword to Graph default constructor and copy constructor to prevent unexpected copy.

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>