### PR TITLE
[one-cmds] Do not use --O1 for one-optimize test

### DIFF
--- a/compiler/one-cmds/tests/one-optimize_001.test
+++ b/compiler/one-cmds/tests/one-optimize_001.test
@@ -40,7 +40,7 @@ if [[ ! -s ${inputfile} ]]; then
 fi
 
 # run test
-one-optimize --O1 \
+one-optimize --resolve_customop_add \
 --input_path ${inputfile} \
 --output_path ${outputfile} > /dev/null 2>&1
 

--- a/compiler/one-cmds/tests/one-optimize_002.test
+++ b/compiler/one-cmds/tests/one-optimize_002.test
@@ -40,7 +40,7 @@ if [[ ! -s ${inputfile} ]]; then
 fi
 
 # run test
-one-optimize --O1 \
+one-optimize --resolve_customop_add \
 --change_outputs InceptionV3/Logits/SpatialSqueeze1 \
 --input_path ${inputfile} \
 --output_path ${outputfile} > /dev/null 2>&1

--- a/compiler/one-cmds/tests/one-optimize_neg_001.test
+++ b/compiler/one-cmds/tests/one-optimize_neg_001.test
@@ -39,7 +39,7 @@ rm -rf ${outputfile}
 rm -rf ${outputfile}.log
 
 # run test
-one-optimize --O1 \
+one-optimize --resolve_customop_add \
 --input_path ${inputfile} \
 --output_path ${outputfile} > ${filename}.log 2>&1
 

--- a/compiler/one-cmds/tests/one-optimize_neg_002.test
+++ b/compiler/one-cmds/tests/one-optimize_neg_002.test
@@ -39,7 +39,7 @@ rm -rf ${outputfile}
 rm -rf ${outputfile}.log
 
 # run test
-one-optimize --O1 \
+one-optimize --resolve_customop_add \
 --input_path ${inputfile} \
 --output_path ${outputfile} > ${filename}.log 2>&1
 

--- a/compiler/one-cmds/tests/one-optimize_neg_003.test
+++ b/compiler/one-cmds/tests/one-optimize_neg_003.test
@@ -44,7 +44,7 @@ if [[ ! -s ${inputfile} ]]; then
 fi
 
 # run test
-one-optimize --O1 \
+one-optimize --resolve_customop_add \
 --input_path "${inputfile}" > "${filename}.log" 2>&1
 
 echo "${filename_ext} FAILED"

--- a/compiler/one-cmds/tests/one-optimize_neg_004.test
+++ b/compiler/one-cmds/tests/one-optimize_neg_004.test
@@ -39,7 +39,7 @@ rm -rf ${outputfile}
 rm -rf ${filename}.log
 
 # run test
-one-optimize --O1 \
+one-optimize --resolve_customop_add \
 --change_outputs non_existing_node_name \
 --input_path ${inputfile} \
 --output_path ${outputfile} > ${filename}.log 2>&1


### PR DESCRIPTION
This will revise not to use --O1 option and instead use --resolve_customop_add
for one-optimize test.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>