### PR TITLE
[circle2circle] Add ResolveCustomOpSplitV option

### DIFF
--- a/compiler/circle2circle/src/Circle2Circle.cpp
+++ b/compiler/circle2circle/src/Circle2Circle.cpp
@@ -130,6 +130,8 @@ int entry(int argc, char **argv)
              "This will convert Custom(Matmul) to Matmul operator");
   add_switch(arser, "--resolve_customop_max_pool_with_argmax",
              "This will convert Custom(MaxPoolWithArgmax) to equivalent set of operators");
+  add_switch(arser, "--resolve_customop_splitv",
+             "This will convert Custom(SplitV) to SplitV operator");
   add_switch(arser, "--shuffle_weight_to_16x1float32",
              "This will convert weight format of FullyConnected to SHUFFLED16x1FLOAT32. Note that "
              "it only converts weights whose row is a multiple of 16");
@@ -283,6 +285,8 @@ int entry(int argc, char **argv)
     options->enable(Algorithms::ResolveCustomOpMatMul);
   if (arser.get<bool>("--resolve_customop_max_pool_with_argmax"))
     options->enable(Algorithms::ResolveCustomOpMaxPoolWithArgmax);
+  if (arser.get<bool>("--resolve_customop_splitv"))
+    options->enable(Algorithms::ResolveCustomOpSplitV);
   if (arser.get<bool>("--shuffle_weight_to_16x1float32"))
     options->enable(Algorithms::ShuffleWeightTo16x1Float32);
   if (arser.get<bool>("--replace_non_const_fc_with_batch_matmul"))


### PR DESCRIPTION
This adds a ResolveCustomOpSplitV option.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/9400
Draft PR: https://github.com/Samsung/ONE/pull/9408