### PR TITLE
[one-cmds] Support ResolveCustomOpSplitV option

### DIFF
--- a/compiler/one-cmds/onelib/constant.py
+++ b/compiler/one-cmds/onelib/constant.py
@@ -71,6 +71,7 @@ class CONSTANT:
         ('resolve_customop_matmul', 'convert Custom(Matmul) op to Matmul op'),
         ('resolve_customop_max_pool_with_argmax',
          'convert Custom(MaxPoolWithArgmax) to net of builtin operators'),
+        ('resolve_customop_splitv', 'convert Custom(SplitV) op to SplitV op'),
         ('shuffle_weight_to_16x1float32',
          'convert weight format of FullyConnected op to SHUFFLED16x1FLOAT32.'
          ' Note that it only converts weights whose row is a multiple of 16'),


### PR DESCRIPTION
This enables a ResolveCustomOpSplitV option.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/9400
Draft PR: https://github.com/Samsung/ONE/pull/9408