### PR TITLE
[one-cmds] Remove --O1 option

### DIFF
--- a/compiler/one-cmds/how-to-use-one-commands.txt
+++ b/compiler/one-cmds/how-to-use-one-commands.txt
@@ -205,10 +205,6 @@ Current transformation options are
 - transform_min_max_to_relu6: This will transform Minimum-Maximum pattern to Relu6 operator.
 - transform_min_relu_to_relu6: This will transform Minimum(6)-Relu pattern to Relu6 operator.
 
-There are options to enable multiple options at once for convenience.
-- O1: fuse_bcq, fuse_instnorm, resolve_customop_add, resolve_customop_batchmatmul,
-  resolve_customop_matmul, remove_redundant_transpose, substitute_pack_to_reshape
-
 
 one-quantize
 ------------

--- a/compiler/one-cmds/onelib/constant.py
+++ b/compiler/one-cmds/onelib/constant.py
@@ -19,7 +19,6 @@ class CONSTANT:
     __slots__ = ()  # This prevents access via __dict__.
     OPTIMIZATION_OPTS = (
         # (OPTION_NAME, HELP_MESSAGE)
-        ('O1', 'enable O1 optimization pass'),
         ('convert_nchw_to_nhwc',
          'Experimental: This will convert NCHW operators to NHWC under the assumption that input model is NCHW.'
          ),


### PR DESCRIPTION
This will remove --O1 option from optimization list.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>