### PR TITLE
[one-cmds] Fix one-import-onnx_002.test failure

### DIFF
--- a/compiler/one-cmds/tests/one-import-onnx_002.test
+++ b/compiler/one-cmds/tests/one-import-onnx_002.test
@@ -42,7 +42,7 @@ if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit
 fi
 
-circle-inspect --operators reshape_matmul.circle > ${outputfile}.log 2>&1
+circle-operator --code reshape_matmul.circle > ${outputfile}.log 2>&1
 
 if ! grep -q "FULLY_CONNECTED" "${outputfile}.log"; then
   trap_err_onexit
@@ -61,7 +61,7 @@ if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit
 fi
 
-circle-inspect --operators reshape_matmul.circle > ${outputfile}.log 2>&1
+circle-operator --code reshape_matmul.circle > ${outputfile}.log 2>&1
 
 if ! grep -q "BATCH_MATMUL" "${outputfile}.log"; then
   trap_err_onexit


### PR DESCRIPTION
This will fix one-import-onnx_002.test to use circle-operator.
- circle-inspect tool is not a installed tool thus cannot use here

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>