### PR TITLE
[infra] Change deprecated --O1 option

### DIFF
--- a/infra/packaging/res/tf2nnpkg.20220323
+++ b/infra/packaging/res/tf2nnpkg.20220323
@@ -104,6 +104,6 @@ fi
 ${ONE_IMPORT_BCQ_SCRIPT}
 
 # optimize
-"${ROOT}/bin/circle2circle" --O1 "${TMPDIR}/${MODEL_NAME}.tmp.circle" "${TMPDIR}/${MODEL_NAME}.circle"
+"${ROOT}/bin/circle2circle" --resolve_customop_add "${TMPDIR}/${MODEL_NAME}.tmp.circle" "${TMPDIR}/${MODEL_NAME}.circle"
 
 "${ROOT}/bin/model2nnpkg.sh" -o "${OUTPUT_DIR}" "${TMPDIR}/${MODEL_NAME}.circle"


### PR DESCRIPTION
This commit changes usage of deprecated circle2circle --O1 option to --resolve_customop_add in tf2nnpkg.

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>