### PR TITLE
[infra/compiler] Update cmake minimum requirement version to 3.3

### DIFF
--- a/infra/nncc/CMakeLists.txt
+++ b/infra/nncc/CMakeLists.txt
@@ -1,4 +1,7 @@
-cmake_minimum_required(VERSION 3.1)
+# The libboost 1.74 uses IN_LIST operator, which requires the policy CMP0057, in a CMake file.
+# This policy requires ``cmake_minimum_required(VERSION 3.3)``.
+# Run "cmake --help-policy CMP0057" for policy details.
+cmake_minimum_required(VERSION 3.3)
 
 project(nncc)
 


### PR DESCRIPTION
From https://github.com/Samsung/ONE/issues/9432#issuecomment-1184412692

This commit updates cmake minimum requirement version to 3.3.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>