### PR TITLE
[one-cmds] Fix file name typo

### DIFF
--- a/compiler/one-cmds/dummy-driver/CMakeLists.txt
+++ b/compiler/one-cmds/dummy-driver/CMakeLists.txt
@@ -2,7 +2,7 @@
 set(DUMMY_DRIVER_SRC src/dummy-compile.cpp)
 set(HELP_DRIVER_SRC src/help-compile.cpp)
 set(DUMMY_INFER_SRC src/dummy-infer.cpp)
-set(DUMMY_INFER_V2_SRC src/dummy-inferV2)
+set(DUMMY_INFER_V2_SRC src/dummy-inferV2.cpp)
 set(HELP_INFER_SRC src/help-infer.cpp)
 set(DUMMY_PROFILE_SRC src/dummy-profile.cpp)
 set(HELP_PROFILE_SRC src/help-profile.cpp)


### PR DESCRIPTION
This commit adds lost file extension `cpp`.

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>