### PR TITLE
[kuma] Make gcc-11 happy

### DIFF
--- a/compiler/kuma/src/IntervalSet.h
+++ b/compiler/kuma/src/IntervalSet.h
@@ -17,6 +17,7 @@
 #ifndef __KUMA_DETAILS_LIVE_INTERVAL_SET_H__
 #define __KUMA_DETAILS_LIVE_INTERVAL_SET_H__
 
+#include <cstdint>
 #include <map>
 
 namespace kuma


### PR DESCRIPTION
From https://github.com/Samsung/ONE/issues/9432

This commit makes gcc-11 happy.
  - Fix an error that ‘uint32_t’ is defined in header

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>