### PR TITLE
[record-minmax] Make gcc-11 happy

### DIFF
--- a/compiler/record-minmax/include/RecordFunction.h
+++ b/compiler/record-minmax/include/RecordFunction.h
@@ -18,7 +18,7 @@
 #include <cassert>
 #include <algorithm>
 #include <cmath>
-#include <numeric>
+#include <limits>
 #include <stdexcept>
 
 namespace record_minmax

--- a/compiler/record-minmax/src/MinMaxObserver.cpp
+++ b/compiler/record-minmax/src/MinMaxObserver.cpp
@@ -18,6 +18,7 @@
 
 #include <luci/IR/CircleOpcode.h>
 
+#include <limits>
 #include <math.h>
 
 using DataType = luci_interpreter::DataType;


### PR DESCRIPTION
From https://github.com/Samsung/ONE/issues/9432

This commit makes gcc-11 happy.
  - Fix an error that ‘numeric_limits’ is not a member of ‘std’

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>