### PR TITLE
[infra] Fix build option on x64 runtime build

### DIFF
--- a/infra/scripts/docker_build_test_x64.sh
+++ b/infra/scripts/docker_build_test_x64.sh
@@ -33,7 +33,8 @@ export DOCKER_ENV_VARS
 export DOCKER_VOLUMES
 export BUILD_OPTIONS
 
-CMD="export BUILD_TYPE=Release && \
+CMD="export OPTIONS='$BUILD_OPTIONS' && \
+     export BUILD_TYPE=Release && \
      cp -nv Makefile.template Makefile && \
      make all install build_test_suite"
 ./nnfw docker-run bash -c "$CMD"


### PR DESCRIPTION
This commit updates x64 runtime build script to pass build option on CI.

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

This option was introduced by #8845 but removed by #9022 by mistake.