### PR TITLE
[one-cmds] Add replace_sub_with_add into constant.py

### DIFF
--- a/compiler/one-cmds/onelib/constant.py
+++ b/compiler/one-cmds/onelib/constant.py
@@ -64,6 +64,7 @@ class CONSTANT:
         ('remove_unnecessary_split', 'remove unnecessary split ops'),
         ('replace_non_const_fc_with_batch_matmul',
          'replace FullyConnected op with non-const weights to BatchMatMul op'),
+        ('replace_sub_with_add', 'replace Sub op with Add op'),
         ('resolve_customop_add', 'convert Custom(Add) op to Add op'),
         ('resolve_customop_batchmatmul',
          'convert Custom(BatchMatmul) op to BatchMatmul op'),


### PR DESCRIPTION
This adds replace_sub_with_add into constant.py,
which was omitted by mistake when creating constant.py.

ONE-DCO-1.0-Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>