### PR TITLE
[record-minmax] Improve error message

### DIFF
--- a/compiler/record-minmax/src/MinMaxObserver.cpp
+++ b/compiler/record-minmax/src/MinMaxObserver.cpp
@@ -76,7 +76,7 @@ void MinMaxObserver::postTensorWrite(const luci::CircleNode *node,
         // Reshape changes only shape of input tensor, efficiently is it a no-op.
         return;
       default:
-        throw std::runtime_error("Tensor's data type is not float");
+        throw std::runtime_error("Tensor's data type is not float. " + node->name());
     }
   }
 


### PR DESCRIPTION
This prints node name if tensor dtype is not float.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>