### PR TITLE
[onert] Tidy DynamicTensorCtx

### DIFF
--- a/runtime/onert/backend/cpu/KernelGenerator.cc
+++ b/runtime/onert/backend/cpu/KernelGenerator.cc
@@ -244,17 +244,13 @@ std::unique_ptr<exec::FunctionSequence> KernelGenerator::generate(ir::OperationI
   assert(_tensor_builder->dynamicTensorManager());
   assert(_tensor_reg);
 
-  auto dyn_shape_inferer = std::make_shared<exec::DynamicShapeInferer>(_ctx, _tensor_reg);
-
   // Prepare to handle dynamic tensors later
   auto dyn_ctx = std::make_shared<exec::FunctionSequence::DynamicTensorCtx>();
   {
-    dyn_ctx->op_ind = ind;
-    dyn_ctx->operations = &_operations_ctx;
-    dyn_ctx->dynamic_shape_inferer = std::move(dyn_shape_inferer);
-
-    ret->dynamic_tensor_ctx(dyn_ctx);
+    dyn_ctx->op = &_operations_ctx.at(ind);
+    dyn_ctx->dynamic_shape_inferer = std::make_shared<exec::DynamicShapeInferer>(_ctx, _tensor_reg);
   }
+  ret->dynamic_tensor_ctx(dyn_ctx);
 
   auto &op = _graph.operations().at(ind);
   op.accept(*this);

--- a/runtime/onert/backend/ruy/KernelGenerator.cc
+++ b/runtime/onert/backend/ruy/KernelGenerator.cc
@@ -42,17 +42,13 @@ std::unique_ptr<exec::FunctionSequence> KernelGenerator::generate(ir::OperationI
   assert(_tensor_builder->dynamicTensorManager());
   assert(_tensor_reg);
 
-  auto dyn_shape_inferer = std::make_shared<exec::DynamicShapeInferer>(_ctx, _tensor_reg);
-
   // Prepare to handle dynamic tensors later
   auto dyn_ctx = std::make_shared<exec::FunctionSequence::DynamicTensorCtx>();
   {
-    dyn_ctx->op_ind = ind;
-    dyn_ctx->operations = &_operations_ctx;
-    dyn_ctx->dynamic_shape_inferer = std::move(dyn_shape_inferer);
-
-    ret->dynamic_tensor_ctx(dyn_ctx);
+    dyn_ctx->op = &_operations_ctx.at(ind);
+    dyn_ctx->dynamic_shape_inferer = std::make_shared<exec::DynamicShapeInferer>(_ctx, _tensor_reg);
   }
+  ret->dynamic_tensor_ctx(dyn_ctx);
 
   auto &op = _graph.operations().at(ind);
   op.accept(*this);

--- a/runtime/onert/backend/xnnpack/KernelGenerator.cc
+++ b/runtime/onert/backend/xnnpack/KernelGenerator.cc
@@ -56,17 +56,13 @@ std::unique_ptr<exec::FunctionSequence> KernelGenerator::generate(ir::OperationI
   assert(_tensor_builder->dynamicTensorManager());
   assert(_tensor_reg);
 
-  auto dyn_shape_inferer = std::make_shared<exec::DynamicShapeInferer>(_ctx, _tensor_reg);
-
   // Prepare to handle dynamic tensors later
   auto dyn_ctx = std::make_shared<exec::FunctionSequence::DynamicTensorCtx>();
   {
-    dyn_ctx->op_ind = ind;
-    dyn_ctx->operations = &_operations_ctx;
-    dyn_ctx->dynamic_shape_inferer = std::move(dyn_shape_inferer);
-
-    ret->dynamic_tensor_ctx(dyn_ctx);
+    dyn_ctx->op = &_operations_ctx.at(ind);
+    dyn_ctx->dynamic_shape_inferer = std::make_shared<exec::DynamicShapeInferer>(_ctx, _tensor_reg);
   }
+  ret->dynamic_tensor_ctx(dyn_ctx);
 
   auto &op = _graph.operations().at(ind);
   op.accept(*this);

--- a/runtime/onert/core/include/exec/FunctionSequence.h
+++ b/runtime/onert/core/include/exec/FunctionSequence.h
@@ -75,8 +75,7 @@ public:
 public: // methods related to dynamic tensor
   struct DynamicTensorCtx
   {
-    ir::OperationIndex op_ind;
-    const ir::Operations *operations = nullptr;
+    const ir::Operation *op = nullptr;
     std::shared_ptr<exec::DynamicShapeInferer> dynamic_shape_inferer = nullptr;
   };
 

--- a/runtime/onert/core/src/backend/builtin/KernelGenerator.cc
+++ b/runtime/onert/core/src/backend/builtin/KernelGenerator.cc
@@ -46,20 +46,16 @@ std::unique_ptr<exec::FunctionSequence> KernelGenerator::generate(ir::OperationI
   assert(_dyn_tensor_manager);
   assert(_tensor_reg);
 
-  auto dyn_shape_inferer =
-    std::make_unique<exec::DynamicShapeInferer>(_graph.operands(), _tensor_reg);
-
   auto ret = std::make_unique<exec::FunctionSequence>();
 
   // Prepare to handle dynamic tensors later
   auto dyn_ctx = std::make_shared<exec::FunctionSequence::DynamicTensorCtx>();
   {
-    dyn_ctx->op_ind = ind;
-    dyn_ctx->operations = &_graph.operations();
-    dyn_ctx->dynamic_shape_inferer = std::move(dyn_shape_inferer);
-
-    ret->dynamic_tensor_ctx(dyn_ctx);
+    dyn_ctx->op = &_graph.operations().at(ind);
+    dyn_ctx->dynamic_shape_inferer =
+      std::make_unique<exec::DynamicShapeInferer>(_graph.operands(), _tensor_reg);
   }
+  ret->dynamic_tensor_ctx(dyn_ctx);
 
   auto &op = _graph.operations().at(ind);
   op.accept(*this);

--- a/runtime/onert/core/src/exec/FunctionSequence.cc
+++ b/runtime/onert/core/src/exec/FunctionSequence.cc
@@ -34,9 +34,7 @@ void FunctionSequence::run()
     // Thus, those two bakends cannot reach here.
 
     // Do dynamic shape inference
-    auto op_ind = _dynamic_tensor_ctx->op_ind;
-    auto &op = _dynamic_tensor_ctx->operations->at(op_ind);
-    op.accept(*_dynamic_tensor_ctx->dynamic_shape_inferer);
+    _dynamic_tensor_ctx->op->accept(*_dynamic_tensor_ctx->dynamic_shape_inferer);
 
     for (const auto &function : _functions)
     {


### PR DESCRIPTION
DynamicTensorCtx doesn't need operations and op_idx.
An operator itself is enough.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>