### PR TITLE
[one-cmds] Add args list for one-init

### DIFF
--- a/compiler/one-cmds/one-init
+++ b/compiler/one-cmds/one-init
@@ -71,25 +71,36 @@ def _get_backends_list():
 
     return backends_list
 
+
 # TODO Add support for TF graphdef and bcq
 def _get_parser(backends_list):
-    init_usage = ('one-init [-h] [-v] [-V] '
-                  '[-i INPUT_PATH] '
-                  '[-o OUTPUT_PATH] '
-                  '[-m MODEL_TYPE] '
-                  '[-b BACKEND] '
-                  # args for onnx model
-                  '[--input_img_layout LAYOUT] '
-                  '[--output_img_layout LAYOUT] '
-                  # args for backend driver
-                  '[--] [COMMANDS FOR BACKEND DRIVER]')
+    init_usage = (
+        'one-init [-h] [-v] [-V] '
+        '[-i INPUT_PATH] '
+        '[-o OUTPUT_PATH] '
+        '[-m MODEL_TYPE] '
+        '[-b BACKEND] '
+        # args for onnx model
+        '[--convert_nchw_to_nhwc] '
+        '[--nchw_to_nhwc_input_shape] '
+        '[--nchw_to_nhwc_output_shape] '
+        # args for backend driver
+        '[--] [COMMANDS FOR BACKEND DRIVER]')
+    """
+    NOTE
+    layout options for onnx model could be difficult to users.
+    In one-init, we could consider easier args for the the above three:
+    For example, we could have another option, e.g., --input_img_layout LAYOUT
+      - When LAYOUT is NHWC, apply 'nchw_to_nhwc_input_shape=True' into cfg
+      - When LAYOUT is NCHW, apply 'nchw_to_nhwc_input_shape=False' into cfg
+    """
 
     parser = argparse.ArgumentParser(
         description='Command line tool to generate initial cfg file. '
-        'Currently tflite and onnx models are supported.',
+        'Currently tflite and onnx models are supported',
         usage=init_usage)
 
-    _utils._add_default_arg(parser, include_config_file=False)
+    _utils._add_default_arg_no_CS(parser)
 
     parser.add_argument(
         '-i', '--input_path', type=str, help='full filepath of the input model file')
@@ -105,17 +116,18 @@ def _get_parser(backends_list):
 
     onnx_group = parser.add_argument_group('arguments when model type is onnx')
     onnx_group.add_argument(
-        '--input_img_layout',
-        type=str,
+        '--convert_nchw_to_nhwc',
+        action='store_true',
         help=
-        'input data layout when input data format is image. Allowed list is "NHWC", "NCHW".'
-    )
+        'Convert NCHW operators to NHWC under the assumption that input model is NCHW.')
     onnx_group.add_argument(
-        '--output_img_layout',
-        type=str,
-        help=
-        'output data layout when output date format is image. Allowed list is "NHWC", "NCHW".'
-    )
+        '--nchw_to_nhwc_input_shape',
+        action='store_true',
+        help='Convert the input shape of the model (argument for convert_nchw_to_nhwc)')
+    onnx_group.add_argument(
+        '--nchw_to_nhwc_output_shape',
+        action='store_true',
+        help='Convert the output shape of the model (argument for convert_nchw_to_nhwc)')
 
     # get backend list in the directory
     backends_name = [ntpath.basename(f) for f in backends_list]

--- a/compiler/one-cmds/one-init
+++ b/compiler/one-cmds/one-init
@@ -71,14 +71,51 @@ def _get_backends_list():
 
     return backends_list
 
-
+# TODO Add support for TF graphdef and bcq
 def _get_parser(backends_list):
+    init_usage = ('one-init [-h] [-v] [-V] '
+                  '[-i INPUT_PATH] '
+                  '[-o OUTPUT_PATH] '
+                  '[-m MODEL_TYPE] '
+                  '[-b BACKEND] '
+                  # args for onnx model
+                  '[--input_img_layout LAYOUT] '
+                  '[--output_img_layout LAYOUT] '
+                  # args for backend driver
+                  '[--] [COMMANDS FOR BACKEND DRIVER]')
 
-    init_usage = 'NYI'
     parser = argparse.ArgumentParser(
-        description='Command line tool to generate initial cfg file.', usage=init_usage)
+        description='Command line tool to generate initial cfg file. '
+        'Currently tflite and onnx models are supported.',
+        usage=init_usage)
 
-    # TODO Add args into parser
+    _utils._add_default_arg(parser, include_config_file=False)
+
+    parser.add_argument(
+        '-i', '--input_path', type=str, help='full filepath of the input model file')
+    parser.add_argument(
+        '-o', '--output_path', type=str, help='full filepath of the output cfg file')
+    parser.add_argument(
+        '-m',
+        '--model_type',
+        type=str,
+        help=('type of input model: "onnx", "tflite". '
+              'If the file extension passed to --input_path is '
+              '".tflite" or ".onnx", this arg can be omitted.'))
+
+    onnx_group = parser.add_argument_group('arguments when model type is onnx')
+    onnx_group.add_argument(
+        '--input_img_layout',
+        type=str,
+        help=
+        'input data layout when input data format is image. Allowed list is "NHWC", "NCHW".'
+    )
+    onnx_group.add_argument(
+        '--output_img_layout',
+        type=str,
+        help=
+        'output data layout when output date format is image. Allowed list is "NHWC", "NCHW".'
+    )
 
     # get backend list in the directory
     backends_name = [ntpath.basename(f) for f in backends_list]

--- a/compiler/one-cmds/utils.py
+++ b/compiler/one-cmds/utils.py
@@ -26,7 +26,7 @@ import sys
 import onelib.constant as _constant
 
 
-def _add_default_arg(parser):
+def _add_default_arg(parser, include_config_file=True):
     # version
     parser.add_argument(
         '-v',
@@ -41,10 +41,11 @@ def _add_default_arg(parser):
         action='store_true',
         help='output additional information to stdout or stderr')
 
-    # configuration file
-    parser.add_argument('-C', '--config', type=str, help='run with configuation file')
-    # section name that you want to run in configuration file
-    parser.add_argument('-S', '--section', type=str, help=argparse.SUPPRESS)
+    if include_config_file:
+        # configuration file
+        parser.add_argument('-C', '--config', type=str, help='run with configuation file')
+        # section name that you want to run in configuration file
+        parser.add_argument('-S', '--section', type=str, help=argparse.SUPPRESS)
 
 
 def is_accumulated_arg(arg, driver):

--- a/compiler/one-cmds/utils.py
+++ b/compiler/one-cmds/utils.py
@@ -26,7 +26,7 @@ import sys
 import onelib.constant as _constant
 
 
-def _add_default_arg(parser, include_config_file=True):
+def _add_default_arg(parser):
     # version
     parser.add_argument(
         '-v',
@@ -41,11 +41,29 @@ def _add_default_arg(parser, include_config_file=True):
         action='store_true',
         help='output additional information to stdout or stderr')
 
-    if include_config_file:
-        # configuration file
-        parser.add_argument('-C', '--config', type=str, help='run with configuation file')
-        # section name that you want to run in configuration file
-        parser.add_argument('-S', '--section', type=str, help=argparse.SUPPRESS)
+    # configuration file
+    parser.add_argument('-C', '--config', type=str, help='run with configuation file')
+    # section name that you want to run in configuration file
+    parser.add_argument('-S', '--section', type=str, help=argparse.SUPPRESS)
+
+
+def _add_default_arg_no_CS(parser):
+    """
+    This adds -v -V args only (no -C nor -S)
+    """
+    # version
+    parser.add_argument(
+        '-v',
+        '--version',
+        action='store_true',
+        help='show program\'s version number and exit')
+
+    # verbose
+    parser.add_argument(
+        '-V',
+        '--verbose',
+        action='store_true',
+        help='output additional information to stdout or stderr')
 
 
 def is_accumulated_arg(arg, driver):


### PR DESCRIPTION
This adds args list for one-init.
- Currently tflite and onnx models are supported.
- `-C config_file` and `-S section` are not args for one-init. So, they are excluded.

parent issue: https://github.com/Samsung/ONE/issues/9450
draft: https://github.com/Samsung/ONE/pull/9421

ONE-DCO-1.0-Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>
