### PR TITLE
[luci/logex] Revise CircleConst

### DIFF
--- a/compiler/luci/logex/src/CircleNodeSummaryBuilders.cpp
+++ b/compiler/luci/logex/src/CircleNodeSummaryBuilders.cpp
@@ -374,6 +374,22 @@ void CircleConcatenationSummaryBuilder::build_attributes(const luci::CircleNode 
   s.args().append("fused_activation_function", to_str(concat->fusedActivationFunction()));
 }
 
+void CircleConstSummaryBuilder::build_attributes(const luci::CircleNode *node,
+                                                 locop::NodeSummary &s)
+{
+  auto circonst = loco::must_cast<const luci::CircleConst *>(node);
+  s.args().append("dtype", to_str(circonst->dtype()));
+  s.args().append("rank", std::to_string(circonst->rank()));
+  std::string shape;
+  for (uint32_t r = 0; r < circonst->rank(); ++r)
+  {
+    if (!shape.empty())
+      shape += " ";
+    shape += std::to_string(circonst->dim(r).value());
+  }
+  s.args().append("shape", "[" + shape + "]");
+}
+
 void CircleConstSummaryBuilder::update_status(locop::NodeSummary &s)
 {
   s.state(locop::NodeDesc::State::PartiallyKnown);

--- a/compiler/luci/logex/src/CircleNodeSummaryBuilders.h
+++ b/compiler/luci/logex/src/CircleNodeSummaryBuilders.h
@@ -167,6 +167,7 @@ private:
 class CircleConstSummaryBuilder final : public CircleNodeSummaryBuilder
 {
 private:
+  void build_attributes(const luci::CircleNode *node, locop::NodeSummary &s);
   void update_status(locop::NodeSummary &s);
 };
 


### PR DESCRIPTION
This will revise CircleConstSummaryBuilder to show dtype and shape for
CircleConst node.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>