### PR TITLE
[luci] Support fake quantization of ReduceMax Op

### DIFF
--- a/compiler/luci/pass/src/ConvertToFakeQuantizedModelPass.cpp
+++ b/compiler/luci/pass/src/ConvertToFakeQuantizedModelPass.cpp
@@ -199,6 +199,7 @@ struct FakeQuantize final : public luci::CircleNodeMutableVisitor<void>
   void visit(luci::CirclePad *node) { fq_activation(node); }
   void visit(luci::CirclePRelu *node) { fq_activation(node); }
   void visit(luci::CircleMean *node) { fq_activation(node); }
+  void visit(luci::CircleReduceMax *node) { fq_activation(node); }
   void visit(luci::CircleRelu *node) { fq_activation(node); }
   void visit(luci::CircleRelu6 *node) { fq_activation(node); }
   void visit(luci::CircleResizeBilinear *node) { fq_activation(node); }


### PR DESCRIPTION
This supports fake quantization of ReduceMax.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/9458