### PR TITLE
[luci] Support shape inference of ArgMin/Max with negative axis

### DIFF
--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -280,6 +280,8 @@ template <class CIRCLENODE> loco::NodeShape infer_arg_maxmin(const CIRCLENODE *n
     select_axis = const_shape_node->template scalar<loco::DataType::S32>();
   }
 
+  assert(select_axis < input_shape.rank());
+
   if (select_axis < 0)
     select_axis += input_shape.rank();
 

--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -279,8 +279,9 @@ template <class CIRCLENODE> loco::NodeShape infer_arg_maxmin(const CIRCLENODE *n
 
     select_axis = const_shape_node->template scalar<loco::DataType::S32>();
   }
-  assert(select_axis < input_shape.rank());
-  assert(select_axis >= 0); // TODO support minus of this breaks
+
+  if (select_axis < 0)
+    select_axis += input_shape.rank();
 
   // NOTE select_axis is removed
   loco::TensorShape shape_output;


### PR DESCRIPTION
This supports shape inference of ArgMin/Max with negative axis.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>