### PR TITLE
[res] Add recipe for ArgMax with negative axis

### DIFF
--- a/res/TensorFlowLiteRecipes/ArgMax_004/test.recipe
+++ b/res/TensorFlowLiteRecipes/ArgMax_004/test.recipe
@@ -1,0 +1,30 @@
+operand {
+  name: "ifm"
+  type: FLOAT32
+  shape { dim: 1 dim: 4 dim: 2 }
+}
+operand {
+  name: "ofm"
+  type: INT64
+  shape { dim: 1 dim: 4 }
+}
+operand {
+  name: "argmax/dim"
+  type: INT32
+  shape { }
+  filler {
+    tag: "explicit"
+    arg: "-1"
+  }
+}
+operation {
+  type: "ArgMax"
+  argmax_options {
+    output_type: INT64
+  }
+  input: "ifm"
+  input: "argmax/dim"
+  output: "ofm"
+}
+input: "ifm"
+output: "ofm"


### PR DESCRIPTION
This adds recipe for ArgMax with negative axis.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/pull/9515