### PR TITLE
[circle-eval-diff] Support MSE printer

### DIFF
--- a/compiler/circle-eval-diff/driver/Driver.cpp
+++ b/compiler/circle-eval-diff/driver/Driver.cpp
@@ -95,6 +95,8 @@ int entry(const int argc, char **argv)
     .default_value(false)
     .help("Print Mean Top-5 Match Ratio");
 
+  arser.add_argument("--print_mse").nargs(0).default_value(false).help("Print Mean Squared Error");
+
   arser.add_argument("--input_data_format")
     .default_value("h5")
     .help("Input data format. h5/hdf5 (default) or directory");
@@ -154,6 +156,10 @@ int entry(const int argc, char **argv)
   if (arser["--print_top5_match"] and arser.get<bool>("--print_top5_match"))
   {
     metrics.emplace_back(Metric::MTOP5);
+  }
+  if (arser["--print_mse"] and arser.get<bool>("--print_mse"))
+  {
+    metrics.emplace_back(Metric::MSE);
   }
 
   input_data_format = arser.get<std::string>("--input_data_format");

--- a/compiler/circle-eval-diff/include/CircleEvalDiff.h
+++ b/compiler/circle-eval-diff/include/CircleEvalDiff.h
@@ -41,6 +41,7 @@ enum class Metric
   MPEIR,     // Mean Peak Error to Interval Ratio
   MTOP1,     // Mean Top-1 Match Ratio
   MTOP5,     // Mean Top-5 Match Ratio
+  MSE,       // Mean Squared Error
 };
 
 class CircleEvalDiff final

--- a/compiler/circle-eval-diff/src/CircleEvalDiff.cpp
+++ b/compiler/circle-eval-diff/src/CircleEvalDiff.cpp
@@ -202,6 +202,11 @@ void CircleEvalDiff::init()
         _metrics.emplace_back(std::make_unique<TopKMatchPrinter>(5));
         break;
       }
+      case Metric::MSE:
+      {
+        _metrics.emplace_back(std::make_unique<MSEPrinter>());
+        break;
+      }
       default:
         throw std::runtime_error("Unsupported metric.");
     }

--- a/compiler/circle-eval-diff/src/MetricPrinter.h
+++ b/compiler/circle-eval-diff/src/MetricPrinter.h
@@ -85,6 +85,28 @@ private:
   uint32_t _num_data = 0;
 };
 
+// Mean Squared Error
+class MSEPrinter final : public MetricPrinter
+{
+public:
+  void init(const luci::Module *first, const luci::Module *second);
+
+  void accumulate(const std::vector<std::shared_ptr<Tensor>> &first,
+                  const std::vector<std::shared_ptr<Tensor>> &second);
+
+  void dump(std::ostream &os) const;
+
+private:
+  void accum_squared_error(uint32_t index, const std::shared_ptr<Tensor> &a,
+                           const std::shared_ptr<Tensor> &b);
+
+private:
+  // Store accumulated sum of absolute error for each output
+  std::vector<Tensor> _intermediate;
+  std::vector<std::string> _output_names;
+  uint32_t _num_data = 0;
+};
+
 // Mean Absolute Percentage Error
 class MAPEPrinter final : public MetricPrinter
 {


### PR DESCRIPTION
This supports MSE printer in circle-eval-diff.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/9528