### PR TITLE
[infra/gbs] Remove gbs.conf internal repo

### DIFF
--- a/infra/nnfw/config/gbs.conf
+++ b/infra/nnfw/config/gbs.conf
@@ -3,19 +3,11 @@
 profile = profile.tizen
 
 [profile.tizen]
-#user=obs_viewer
-#obs = obs.tizen
-repos = repo.tizen_one,repo.tizen_base,repo.tizen_mobile
+repos = repo.tizen_base,repo.tizen_mobile
 buildroot = /home/GBS-ROOT/
-
-[obs.tizen]
-url = http://api.tizen.org
 
 [repo.tizen_mobile]
 url = http://download.tizen.org/snapshots/tizen/unified/latest/repos/standard/packages/
 
 [repo.tizen_base]
 url = http://download.tizen.org/snapshots/tizen/base/latest/repos/standard/packages/
-
-[repo.tizen_one]
-url = http://13.125.34.93/archive/tizen/


### PR DESCRIPTION
This commit removes internal repo definition in gbs.conf.
We will find different way for package sync when version up.

This commit includes clean up gbs.conf file.

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>