### PR TITLE
[luci/svc] Shape/dtype inference for Densify

### DIFF
--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -204,6 +204,7 @@ template <class CIRCLENODE> loco::NodeShape broadcast_xy(const CIRCLENODE *node)
     return loco::NodeShape{inputs_shape};                                               \
   }
 
+DECLARE_USE_SINGLE(input);
 DECLARE_USE_SINGLE(inputs);
 DECLARE_USE_SINGLE(x);
 DECLARE_USE_SINGLE(logits);
@@ -2054,6 +2055,8 @@ public:
   loco::NodeShape visit(const luci::CircleCos *node) final { return use_x(node); }
 
   loco::NodeShape visit(const luci::CircleCustom *node) final { return use_own(node); }
+
+  loco::NodeShape visit(const luci::CircleDensify *node) final { return use_input(node); }
 
   loco::NodeShape visit(const luci::CircleDepthToSpace *node) final
   {

--- a/compiler/luci/service/src/CircleTypeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleTypeInferenceRule.cpp
@@ -102,6 +102,11 @@ struct TypeInferenceAlgorithm final : public luci::CircleNodeVisitor<loco::DataT
     return node->dtype();
   }
 
+  loco::DataType visit(const luci::CircleDensify *node) final
+  {
+    return luci::dtype_get(node->input());
+  }
+
   loco::DataType visit(const luci::CircleDepthToSpace *node) final
   {
     return luci::dtype_get(node->input());


### PR DESCRIPTION
This will enable shape/dtype inferenece for CircleDensify IR.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>