### PR TITLE
[one-import-onnx] Deprecate fix_io_order

### DIFF
--- a/compiler/one-cmds/one-import-onnx
+++ b/compiler/one-cmds/one-import-onnx
@@ -80,12 +80,6 @@ def _get_parser():
     parser.add_argument(
         '--unroll_lstm', action='store_true', help='Unroll LSTM operators')
     parser.add_argument(
-        '--fix_io_order',
-        action='store_true',
-        help=
-        'Ensure generated circle model preserves the I/O order of the original onnx model.'
-    )
-    parser.add_argument(
         '--keep_io_order',
         action='store_true',
         help=
@@ -218,8 +212,7 @@ def _convert(args):
             options.unroll_rnn = _utils._is_valid_attr(args, 'unroll_rnn')
             options.unroll_lstm = _utils._is_valid_attr(args, 'unroll_lstm')
             onnx_legalizer.legalize(onnx_model, options)
-        if _utils._is_valid_attr(args, 'fix_io_order') or _utils._is_valid_attr(
-                args, 'keep_io_order'):
+        if _utils._is_valid_attr(args, 'keep_io_order'):
             _remap_io_names(onnx_model)
             if _utils._is_valid_attr(args, 'save_intermediate'):
                 basename = os.path.basename(getattr(args, 'input_path'))


### PR DESCRIPTION
This will remove fix_io_order that was replaced with keep_io_order.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>