### PR TITLE
[tflchef] explicit float16 data chef

### DIFF
--- a/compiler/tflchef/core/src/DataChef.def
+++ b/compiler/tflchef/core/src/DataChef.def
@@ -22,5 +22,6 @@ DATA_CHEF(INT32, gaussian, GaussianInt32DataChefFactory)
 DATA_CHEF(INT16, gaussian, GaussianInt16DataChefFactory)
 DATA_CHEF(UINT8, gaussian, GaussianUint8DataChefFactory)
 
-// FLOAT16 support for only gaussian for now
+// FLOAT16 support for only gaussian, explicit for now
+DATA_CHEF(FLOAT16, explicit, ExplicitFloat16DataChefFactory)
 DATA_CHEF(FLOAT16, gaussian, GaussianFloat16DataChefFactory)


### PR DESCRIPTION
This will enable explicit data chef for float16 type.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>