### PR TITLE
[luci-pass-value-test] Enable Densify and Dequantize

### DIFF
--- a/compiler/luci-pass-value-test/test.lst
+++ b/compiler/luci-pass-value-test/test.lst
@@ -14,6 +14,8 @@ addeval(Net_Conv_Add_Mul_002 fuse_batchnorm_with_conv)
 addeval(Net_Conv_Min_Max_000 transform_min_max_to_relu6)
 addeval(Net_Conv_Min_Relu_000 transform_min_relu_to_relu6)
 addeval(Net_Conv_Relu6_000 fuse_activation_function)
+addeval(Net_Densify_Add_000 fold_densify)
+addeval(Net_Dequantize_Add_000 fold_dequantize)
 addeval(Net_DwConv_BN_000 fuse_batchnorm_with_dwconv)
 addeval(Net_DwConv_BN_001 fuse_batchnorm_with_dwconv)
 addeval(Net_Reshape_Neg_000 forward_reshape_to_unaryop)
@@ -35,6 +37,7 @@ addeval(FullyConnected_007 replace_non_const_fc_with_batch_matmul)
 
 # test for limited support for FLOAT16
 addeval(Net_Dequantize_Add_000 fold_dequantize)
+addeval(Net_Densify_Dequantize_Add_000 fold_dequantize fold_densify)
 
 # test SignatureDef, with any optimization
 #addeval(SignatureDef_MultiOut_000 fuse_instnorm)


### PR DESCRIPTION
This will enable Densify and Dequantize tests.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>