### PR TITLE
[luci] Check if nullptr after dynamic casting

### DIFF
--- a/compiler/luci/pass/src/ConvertNCHWToNHWCPass.test.cpp
+++ b/compiler/luci/pass/src/ConvertNCHWToNHWCPass.test.cpp
@@ -1999,6 +1999,7 @@ TEST(ConvertNCHWToNHWC, SplitV)
 
   // Check axis
   auto axis = dynamic_cast<luci::CircleConst *>(g.splitv()->split_dim());
+  EXPECT_NE(nullptr, axis);
   EXPECT_EQ(1, axis->size<loco::DataType::S32>());
   EXPECT_EQ(2, axis->at<loco::DataType::S32>(0));
 }


### PR DESCRIPTION
This commit checks if casted ptr is nullptr.

This is for resolving static analysis tool issue.
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>