### PR TITLE
[npud] Simplify config implementation

### DIFF
--- a/runtime/service/npud/util/ConfigSource.cc
+++ b/runtime/service/npud/util/ConfigSource.cc
@@ -15,11 +15,12 @@
  */
 
 #include "ConfigSource.h"
-#include "GeneralConfigSource.h"
 #include "EnvConfigSource.h"
+#include "GeneralConfigSource.h"
+#include "IConfigSource.h"
 
-#include <array>
 #include <algorithm>
+#include <array>
 #include <cassert>
 #include <memory>
 
@@ -29,10 +30,8 @@ namespace util
 {
 
 static std::unique_ptr<IConfigSource> _source;
-static std::unique_ptr<IConfigSource> _source_ext;
 
 void config_source(std::unique_ptr<IConfigSource> &&source) { _source = std::move(source); }
-void config_source_ext(std::unique_ptr<IConfigSource> &&source) { _source_ext = std::move(source); }
 
 static IConfigSource *config_source()
 {
@@ -66,14 +65,6 @@ static std::string getConfigOrDefault(const std::string &key)
 
   // Treat empty string and absence of the value to be the same
   auto ret = config_source()->get(key);
-  if (ret.empty())
-  {
-    // if env is not set, search from external
-    if (_source_ext.get())
-    {
-      ret = _source_ext.get()->get(key);
-    }
-  }
   // if not found search from defaults
   if (ret.empty())
   {

--- a/runtime/service/npud/util/ConfigSource.h
+++ b/runtime/service/npud/util/ConfigSource.h
@@ -17,20 +17,12 @@
 #ifndef __ONE_SERVICE_NPUD_UTIL_CONFIG_SOURCE_H__
 #define __ONE_SERVICE_NPUD_UTIL_CONFIG_SOURCE_H__
 
-#include <memory>
-
-#include "IConfigSource.h"
+#include <string>
 
 namespace npud
 {
 namespace util
 {
-
-void config_source(std::unique_ptr<IConfigSource> &&source);
-void config_source_ext(std::unique_ptr<IConfigSource> &&source);
-
-bool toBool(const std::string &val);
-int toInt(const std::string &val);
 
 bool getConfigBool(const std::string &key);
 int getConfigInt(const std::string &key);


### PR DESCRIPTION
This commit removes `_source_ext` and related implementation.
Runtime requires this feature to initialize config in nnpackage, but npud doesn't need this.

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: #9571
Related issue: #9576