### PR TITLE
[onert] Move setConfigKeyValues

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -111,9 +111,7 @@ std::string trim(const std::string &value)
   return value.substr(begin, range);
 }
 
-using CfgKeyValues = std::unordered_map<std::string, std::string>;
-
-bool loadConfigure(const std::string cfgfile, CfgKeyValues &keyValues)
+bool loadConfigure(const std::string cfgfile, onert::util::CfgKeyValues &keyValues)
 {
   std::ifstream ifs(cfgfile);
   if (ifs.is_open())
@@ -142,19 +140,6 @@ bool loadConfigure(const std::string cfgfile, CfgKeyValues &keyValues)
     return true;
   }
   return false;
-}
-
-void setConfigKeyValues(const CfgKeyValues &keyValues)
-{
-  auto configsrc = std::make_unique<onert::util::GeneralConfigSource>();
-
-  for (auto it = keyValues.begin(); it != keyValues.end(); ++it)
-  {
-    VERBOSE(NNPKG_CONFIGS) << "(" << it->first << ") = (" << it->second << ")" << std::endl;
-    configsrc->set(it->first, it->second);
-  }
-
-  onert::util::config_source_ext(std::move(configsrc));
 }
 
 NNFW_TYPE datatype_to_nnfw_dtype(onert::ir::DataType dt)
@@ -359,10 +344,10 @@ NNFW_STATUS nnfw_session::load_model_from_nnpackage(const char *package_dir)
     {
       auto filepath = package_path + std::string("/metadata/") + configs[0].asString();
 
-      CfgKeyValues keyValues;
+      onert::util::CfgKeyValues keyValues;
       if (loadConfigure(filepath, keyValues))
       {
-        setConfigKeyValues(keyValues);
+        onert::util::setConfigKeyValues(keyValues);
       }
     }
     _nnpkg = std::make_shared<onert::ir::NNPkg>();

--- a/runtime/onert/backend/cpu/ExternalContext.h
+++ b/runtime/onert/backend/cpu/ExternalContext.h
@@ -20,6 +20,8 @@
 #include <util/ConfigSource.h>
 #include <ruy/context.h>
 
+#include <memory>
+
 namespace onert
 {
 namespace backend

--- a/runtime/onert/backend/ruy/ExternalContext.h
+++ b/runtime/onert/backend/ruy/ExternalContext.h
@@ -20,6 +20,8 @@
 #include <util/ConfigSource.h>
 #include <ruy/context.h>
 
+#include <memory>
+
 namespace onert
 {
 namespace backend

--- a/runtime/onert/core/include/util/ConfigSource.h
+++ b/runtime/onert/core/include/util/ConfigSource.h
@@ -17,17 +17,17 @@
 #ifndef __ONERT_UTIL_CONFIG_SOURCE_H__
 #define __ONERT_UTIL_CONFIG_SOURCE_H__
 
-#include <memory>
-
-#include "IConfigSource.h"
+#include <string>
+#include <unordered_map>
 
 namespace onert
 {
 namespace util
 {
 
-void config_source(std::unique_ptr<IConfigSource> &&source);
-void config_source_ext(std::unique_ptr<IConfigSource> &&source);
+using CfgKeyValues = std::unordered_map<std::string, std::string>;
+
+void setConfigKeyValues(const CfgKeyValues &keyValues);
 
 bool toBool(const std::string &val);
 int toInt(const std::string &val);

--- a/runtime/onert/core/src/backend/builtin/ExternalContext.h
+++ b/runtime/onert/core/src/backend/builtin/ExternalContext.h
@@ -24,6 +24,8 @@
 #include <ruy/ctx.h>
 #include <ruy/tune.h>
 
+#include <memory>
+
 namespace onert
 {
 namespace backend

--- a/runtime/onert/core/src/util/ConfigSource.cc
+++ b/runtime/onert/core/src/util/ConfigSource.cc
@@ -15,13 +15,14 @@
  */
 
 #include "util/ConfigSource.h"
-#include "util/GeneralConfigSource.h"
 #include "util/EnvConfigSource.h"
+#include "util/GeneralConfigSource.h"
+#include "util/IConfigSource.h"
+#include "util/logging.h"
 
-#include <array>
 #include <algorithm>
+#include <array>
 #include <cassert>
-
 #include <memory>
 
 namespace onert
@@ -34,6 +35,19 @@ static std::unique_ptr<IConfigSource> _source_ext;
 
 void config_source(std::unique_ptr<IConfigSource> &&source) { _source = std::move(source); }
 void config_source_ext(std::unique_ptr<IConfigSource> &&source) { _source_ext = std::move(source); }
+
+void setConfigKeyValues(const CfgKeyValues &keyValues)
+{
+  auto configsrc = std::make_unique<GeneralConfigSource>();
+
+  for (auto it = keyValues.begin(); it != keyValues.end(); ++it)
+  {
+    VERBOSE(NNPKG_CONFIGS) << "(" << it->first << ") = (" << it->second << ")" << std::endl;
+    configsrc->set(it->first, it->second);
+  }
+
+  onert::util::config_source_ext(std::move(configsrc));
+}
 
 static IConfigSource *config_source()
 {


### PR DESCRIPTION
This commit moves setConfigKeyValues function from frontend nnfw_api_internal.cc to core ConfigSource.h/cc.
By this, we can hide `config_source` and `config_source_ext` function and header include, so reduce header depdency.

Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: https://github.com/Samsung/ONE/pull/9571
Related issue: https://github.com/Samsung/ONE/issues/9576