### PR TITLE
[luci/pass] Remove unused fp16 library

### DIFF
--- a/compiler/luci/pass/src/FoldDensifyPass.cpp
+++ b/compiler/luci/pass/src/FoldDensifyPass.cpp
@@ -24,8 +24,6 @@
 #include <cassert>
 #include <vector>
 
-#include "helpers/FP16.h"
-
 namespace
 {
 


### PR DESCRIPTION
This will remove unused fp16 library include in FoldDensifyPass.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>