### PR TITLE
[nnpkg_run] Suppress raw exception message on missing --nnpackage

### DIFF
--- a/tests/tools/nnpackage_run/src/nnpackage_run.cc
+++ b/tests/tools/nnpackage_run/src/nnpackage_run.cc
@@ -29,6 +29,7 @@
 #include "ruy/profiler/profiler.h"
 #endif
 
+#include <boost/program_options.hpp>
 #include <cassert>
 #include <chrono>
 #include <cstdlib>
@@ -312,6 +313,11 @@ int main(const int argc, char **argv)
     benchmark::writeResult(result, exec_basename, nnpkg_basename, backend_name);
 
     return 0;
+  }
+  catch (boost::program_options::error &e)
+  {
+    std::cerr << "E: " << e.what() << std::endl;
+    exit(-1);
   }
   catch (std::runtime_error &e)
   {


### PR DESCRIPTION
It will show the error message only without boost exception message
when --nnpackage is missing.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

### BEFORE
```
$ Product/out/bin/nnpackage_run
terminate called after throwing an instance of 'boost::exception_detail::clone_impl<boost::exception_detail::error_info_injector<boost::program_options::required_option> >'
  what():  the option '--nnpackage' is required but missing
Aborted (core dumped)
```

### AFTER
```
$ Product/out/bin/nnpackage_run
E: the option '--nnpackage' is required but missing
```