### PR TITLE
[one-init] Add missing import

### DIFF
--- a/compiler/one-cmds/one-init
+++ b/compiler/one-cmds/one-init
@@ -27,6 +27,7 @@ import ntpath
 import os
 import sys
 
+import configparser
 import utils as _utils
 
 # TODO Find better way to suppress trackback on error


### PR DESCRIPTION
This adds missing import statement.

parent issue: https://github.com/Samsung/ONE/issues/9450
draft: https://github.com/Samsung/ONE/pull/9421

ONE-DCO-1.0-Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>
