### PR TITLE
[onert] Rename model connect description struct

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -363,33 +363,32 @@ NNFW_STATUS nnfw_session::load_model_from_nnpackage(const char *package_dir)
       _coptions.push_back(onert::compiler::CompilerOptions::fromGlobalConfig());
     }
 
-    auto toOperandDesc = [](std::string str) {
+    auto toIODesc = [](std::string str) {
       auto indices = nnfw::misc::split(str, ':');
       if (indices.size() != 3)
       {
         std::cerr << "OperandDesc should be 3-tuple." << std::endl;
-        return onert::ir::OperandDesc{};
+        return onert::ir::IODesc{};
       }
       auto model_idx = static_cast<uint32_t>(std::stoi(indices.at(0)));
       auto subgraph_idx = static_cast<uint32_t>(std::stoi(indices.at(1)));
       auto operand_idx = static_cast<uint32_t>(std::stoi(indices.at(2)));
-      return onert::ir::OperandDesc{model_idx, subgraph_idx, operand_idx};
+      return onert::ir::IODesc{model_idx, subgraph_idx, operand_idx};
     };
     // read pkg-inputs and pkg-outputs
     const Json::Value &pkg_inputs = root["pkg-inputs"];
     for (uint32_t i = 0; i < pkg_inputs.size(); ++i)
-      _nnpkg->addInput(toOperandDesc(pkg_inputs[i].asString()));
+      _nnpkg->addInput(toIODesc(pkg_inputs[i].asString()));
     const Json::Value &pkg_outputs = root["pkg-outputs"];
     for (uint32_t i = 0; i < pkg_outputs.size(); ++i)
-      _nnpkg->addOutput(toOperandDesc(pkg_outputs[i].asString()));
+      _nnpkg->addOutput(toIODesc(pkg_outputs[i].asString()));
     // read model-connect
     const Json::Value &fromtos = root["model-connect"];
     for (uint32_t i = 0; i < fromtos.size(); ++i)
     {
       const Json::Value &tos = fromtos[i]["to"];
       for (uint32_t j = 0; j < tos.size(); ++j)
-        _nnpkg->addEdge(toOperandDesc(fromtos[i]["from"].asString()),
-                        toOperandDesc(tos[j].asString()));
+        _nnpkg->addEdge(toIODesc(fromtos[i]["from"].asString()), toIODesc(tos[j].asString()));
     }
     _state = State::MODEL_LOADED;
   }

--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -367,7 +367,7 @@ NNFW_STATUS nnfw_session::load_model_from_nnpackage(const char *package_dir)
       auto indices = nnfw::misc::split(str, ':');
       if (indices.size() != 3)
       {
-        std::cerr << "OperandDesc should be 3-tuple." << std::endl;
+        std::cerr << "IODesc should be 3-tuple." << std::endl;
         return onert::ir::IODesc{};
       }
       auto model_idx = static_cast<uint32_t>(std::stoi(indices.at(0)));

--- a/runtime/onert/core/include/ir/NNPkg.h
+++ b/runtime/onert/core/include/ir/NNPkg.h
@@ -28,12 +28,12 @@ namespace onert
 namespace ir
 {
 
-using OperandDesc = std::tuple<ModelIndex, SubgraphIndex, OperandIndex>;
+using IODesc = std::tuple<ModelIndex, SubgraphIndex, IOIndex>;
 
 struct ModelEdge
 {
-  OperandDesc from;
-  OperandDesc to;
+  IODesc from;
+  IODesc to;
 };
 
 struct ModelEdgeEqual
@@ -56,7 +56,7 @@ struct ModelEdgeHash
   }
 };
 
-inline std::ostream &operator<<(std::ostream &o, const OperandDesc &od)
+inline std::ostream &operator<<(std::ostream &o, const IODesc &od)
 {
   o << std::get<0>(od).value() << ":" << std::get<1>(od).value() << ":" << std::get<2>(od).value();
   return o;
@@ -109,51 +109,51 @@ public:
    * @brief Get pkg_input at index
    *
    * @param[in] index Index of pkg_input to be returned
-   * @return OperandDesc at index
+   * @return IODesc at index
    */
-  const OperandDesc &input(uint32_t index) const { return _pkg_inputs[index]; }
+  const IODesc &input(uint32_t index) const { return _pkg_inputs[index]; }
   /**
    * @brief Get pkg_input at index
    *
    * @param[in] index Index of pkg_input to be returned
-   * @return OperandDesc at index
+   * @return IODesc at index
    */
-  OperandDesc &input(uint32_t index) { return _pkg_inputs[index]; }
+  IODesc &input(uint32_t index) { return _pkg_inputs[index]; }
   /**
    * @brief Add input at the end
    *
-   * @param[in] input Input OperandDesc to be pushed
+   * @param[in] input Input IODesc to be pushed
    */
-  void addInput(const OperandDesc &input) { _pkg_inputs.push_back(input); }
+  void addInput(const IODesc &input) { _pkg_inputs.push_back(input); }
 
   /**
    * @brief Get pkg_output at index
    *
    * @param[in] index Index of pkg_output to be returned
-   * @return OperandDesc at index
+   * @return IODesc at index
    */
-  const OperandDesc &output(uint32_t index) const { return _pkg_outputs[index]; }
+  const IODesc &output(uint32_t index) const { return _pkg_outputs[index]; }
   /**
    * @brief Get pkg_output at index
    *
    * @param[in] index Index of pkg_output to be returned
-   * @return OperandDesc at index
+   * @return IODesc at index
    */
-  OperandDesc &output(uint32_t index) { return _pkg_outputs[index]; }
+  IODesc &output(uint32_t index) { return _pkg_outputs[index]; }
   /**
    * @brief Add output at the end
    *
-   * @param[in] output Output OperandDesc to be pushed
+   * @param[in] output Output IODesc to be pushed
    */
-  void addOutput(const OperandDesc &output) { _pkg_outputs.push_back(output); }
+  void addOutput(const IODesc &output) { _pkg_outputs.push_back(output); }
 
   /**
    * @brief Add edge between models at the end
    *
-   * @param[in] from from OperandDesc
-   * @param[in] to   to OperandDesc
+   * @param[in] from from IODesc
+   * @param[in] to   to IODesc
    */
-  void addEdge(const OperandDesc &from, const OperandDesc &to)
+  void addEdge(const IODesc &from, const IODesc &to)
   {
     std::cout << from << " -> " << to << std::endl;
     _model_edges.insert(ModelEdge{from, to});
@@ -163,8 +163,8 @@ public:
 
 private:
   std::unordered_map<ModelIndex, std::shared_ptr<Model>> _models;
-  std::vector<OperandDesc> _pkg_inputs;
-  std::vector<OperandDesc> _pkg_outputs;
+  std::vector<IODesc> _pkg_inputs;
+  std::vector<IODesc> _pkg_outputs;
   std::unordered_set<ModelEdge, ModelEdgeHash, ModelEdgeEqual> _model_edges;
 };
 


### PR DESCRIPTION
This commit renames model I/O operand description struct OperandDesc to IODesc because it includes IOIndex.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>