### PR TITLE
[one-cmd] Remove useless code from one-init

### DIFF
--- a/compiler/one-cmds/one-init
+++ b/compiler/one-cmds/one-init
@@ -226,14 +226,6 @@ def _generate():
     def _add_onecc_sections():
         pass  # NYI
 
-    def _add_from_backend_cfg():
-        '''
-        This copies key & value in sections of backend cfg into one cfg.
-        Call this after setting default values for circle since there might be values overrided
-        by backend.
-        '''
-        pass  # NYI
-
     def _gen_import():
         pass  # NYI
 
@@ -256,9 +248,6 @@ def _generate():
     _gen_optimize()
     _gen_quantize()
     _gen_codegen()
-    _gen_profile()
-
-    _add_from_backend_cfg()
 
     with open(args.output_path, 'w') as f:
         config.write(f)
@@ -278,8 +267,6 @@ def main():
     # make a command to run given backend driver
     driver_path = _get_executable(args, backends_list)
     init_cmd = [driver_path] + backend_args
-    if _utils._is_valid_attr(args, 'command'):
-        init_cmd += getattr(args, 'command').split()
 
     # run backend driver
     _utils._run(init_cmd, err_prefix=ntpath.basename(driver_path))


### PR DESCRIPTION
This removes useless code:
1. remove `_add_from_backend_cfg()`
- Previously, there were two cfg output files:
  One was output of one-init, and another was output of backend-init.
  In this approach, after bckend-init creates its own cfg,
  one-init reads the cfg file of backend-init and write them into the output of one-init. --- (A)
  `_add_from_backend_cfg()` was created for (A) and it is now useless.

  Now, the changed way works like this:
  output cfg of one-init is used as input of backend-init,
  and backend-init generates the final output cfg.

2. remove `_gen_profile()`
  Let's not handle this at the current version.
  Comment at L242 already mentioned this.

3. handling 'command' arg was copied from other file
   and not used in one-init.

for https://github.com/Samsung/ONE/issues/9450
draft https://github.com/Samsung/ONE/pull/9514

ONE-DCO-1.0-Signed-off-by: Hyun Sik Yoon <hyunsik.yoon.1024@gmail.com>