### PR TITLE
[onert] Support conv2d per-channel uint8 quantization

### DIFF
--- a/compute/cker/include/cker/operation/Conv.h
+++ b/compute/cker/include/cker/operation/Conv.h
@@ -71,9 +71,9 @@ public:
     }
   }
 
-  void prepareQ8u(const Shape &input_shape, const Shape &kernel_shape, const Shape &output_shape,
-                  uint32_t stride_width, uint32_t stride_height, uint32_t dilation_width_factor,
-                  uint32_t dilation_height_factor)
+  void prepareQ8uPerTensor(const Shape &input_shape, const Shape &kernel_shape,
+                           const Shape &output_shape, uint32_t stride_width, uint32_t stride_height,
+                           uint32_t dilation_width_factor, uint32_t dilation_height_factor)
   {
     if (!_prepared)
     {

--- a/runtime/onert/backend/cpu/ops/ConvolutionLayer.h
+++ b/runtime/onert/backend/cpu/ops/ConvolutionLayer.h
@@ -50,7 +50,8 @@ public:
 public:
   void convFloat32();
 
-  void convQ8u();
+  void convQ8uPerTensor();
+  void convQ8uPerChannel();
 
   void convQ8i();
 

--- a/runtime/onert/core/include/ir/TypeInfo.h
+++ b/runtime/onert/core/include/ir/TypeInfo.h
@@ -50,11 +50,7 @@ public:
 
 public:
   DataType type() const { return _type; }
-  float scale() const
-  {
-    assert(_quant.scales.size() == 1);
-    return _quant.scales[0];
-  }
+  float scale() const { return _quant.scales[0]; }
   const std::vector<float> &scales() const { return _quant.scales; }
   int32_t zero_point() const
   {


### PR DESCRIPTION
- Remove invalid assert of quantization is always per-layer.
- Support Q8 per-channel

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

- Related Issue: #9609
- 2st PR of 3 from #9613
- Tested on #9613 