### PR TITLE
[onert] Use template to reduce duplicated in Conv2d

### DIFF
--- a/compute/cker/include/cker/operation/Conv.h
+++ b/compute/cker/include/cker/operation/Conv.h
@@ -138,13 +138,25 @@ public:
     }
   }
 
+  void operator()(const ConvParams &params, const Shape &input_shape, const uint8_t *input_data,
+                  const Shape &filter_shape, const uint8_t *filter_data,
+                  const int32_t *filter_zero_point, const Shape &bias_shape,
+                  const int32_t *bias_data, const Shape &output_shape, uint8_t *output_data)
+  {
+    reference::Conv<uint8_t, true>(params, _per_channel_output_multiplier.data(),
+                                   _per_channel_output_shift.data(), input_shape, input_data,
+                                   filter_shape, filter_data, filter_zero_point, bias_shape,
+                                   bias_data, output_shape, output_data);
+  }
+
   void operator()(const ConvParams &params, const Shape &input_shape, const int8_t *input_data,
                   const Shape &filter_shape, const int8_t *filter_data, const Shape &bias_shape,
                   const int32_t *bias_data, const Shape &output_shape, int8_t *output_data)
   {
-    reference::Conv(params, _per_channel_output_multiplier.data(), _per_channel_output_shift.data(),
-                    input_shape, input_data, filter_shape, filter_data, bias_shape, bias_data,
-                    output_shape, output_data);
+    reference::Conv<int8_t, false>(params, _per_channel_output_multiplier.data(),
+                                   _per_channel_output_shift.data(), input_shape, input_data,
+                                   filter_shape, filter_data, nullptr /* filter_zero_point */,
+                                   bias_shape, bias_data, output_shape, output_data);
   }
   std::vector<int32_t> &per_channel_output_multiplier() { return _per_channel_output_multiplier; }
   std::vector<int> &per_channel_output_shift() { return _per_channel_output_shift; }

--- a/compute/cker/include/cker/operation/reference/Conv.h
+++ b/compute/cker/include/cker/operation/reference/Conv.h
@@ -190,11 +190,12 @@ inline void Conv(const ConvParams &params, const Shape &input_shape, const uint8
   }
 }
 
+template <typename T, bool is_asymmetric>
 inline void Conv(const ConvParams &params, const int32_t *output_multiplier,
-                 const int32_t *output_shift, const Shape &input_shape, const uint8_t *input_data,
-                 const Shape &filter_shape, const uint8_t *filter_data,
-                 const int32_t *filter_zeropoint, const Shape &bias_shape, const int32_t *bias_data,
-                 const Shape &output_shape, uint8_t *output_data)
+                 const int32_t *output_shift, const Shape &input_shape, const T *input_data,
+                 const Shape &filter_shape, const T *filter_data, const int32_t *filter_zeropoint,
+                 const Shape &bias_shape, const int32_t *bias_data, const Shape &output_shape,
+                 T *output_data)
 
 {
   UNUSED_RELEASE(bias_shape);
@@ -261,12 +262,35 @@ inline void Conv(const ConvParams &params, const int32_t *output_multiplier,
 
               for (int in_channel = 0; in_channel < input_depth; ++in_channel)
               {
-                const uint8_t input_val =
-                  input_data[Offset(input_shape, batch, in_y, in_x, in_channel)];
-                const uint8_t filter_val =
+                const T input_val = input_data[Offset(input_shape, batch, in_y, in_x, in_channel)];
+                const T filter_val =
                   filter_data[Offset(filter_shape, out_channel, filter_y, filter_x, in_channel)];
-                const int32_t filter_offset = -filter_zeropoint[out_channel];
-                acc += (filter_val + filter_offset) * (input_val + input_offset);
+                if (is_asymmetric)
+                {
+                  const int32_t filter_offset = -filter_zeropoint[out_channel];
+                  acc += (filter_val + filter_offset) * (input_val + input_offset);
+                }
+                else
+                {
+                  // Accumulate with 32 bits accumulator.
+                  // In the nudging process during model quantization, we force
+                  // real value of 0.0 be represented by a quantized value. This
+                  // guarantees that the input_offset is a int8_t, even though
+                  // it is represented using int32_t. int32_t += int8_t *
+                  // (int8_t - int8_t) so the highest value we can get from each
+                  // accumulation is [-127, 127] * ([-128, 127] -
+                  // [-128, 127]), which is [-32512, 32512]. log2(32512)
+                  // = 14.98, which means we can accumulate at least 2^16
+                  // multiplications without overflow. The accumulator is
+                  // applied to a filter so the accumulation logic will hold as
+                  // long as the filter size (filter_y * filter_x * in_channel)
+                  // does not exceed 2^16, which is the case in all the models
+                  // we have seen so far.
+                  // TODO(jianlijianli): Add a check to make sure the
+                  // accumulator depth is smaller than 2^16.
+                  acc += filter_val * (input_val + input_offset);
+                  UNUSED_RELEASE(filter_zeropoint);
+                }
               }
             }
           }
@@ -280,118 +304,7 @@ inline void Conv(const ConvParams &params, const int32_t *output_multiplier,
           acc += output_offset;
           acc = std::max(acc, output_activation_min);
           acc = std::min(acc, output_activation_max);
-          output_data[Offset(output_shape, batch, out_y, out_x, out_channel)] =
-            static_cast<uint8_t>(acc);
-        }
-      }
-    }
-  }
-}
-
-inline void Conv(const ConvParams &params, const int32_t *output_multiplier,
-                 const int32_t *output_shift, const Shape &input_shape, const int8_t *input_data,
-                 const Shape &filter_shape, const int8_t *filter_data, const Shape &bias_shape,
-                 const int32_t *bias_data, const Shape &output_shape, int8_t *output_data)
-{
-  UNUSED_RELEASE(bias_shape);
-  // Get parameters.
-  const int32_t input_offset = params.input_offset; // r = s(q - Z)
-  const int stride_width = params.stride_width;
-  const int stride_height = params.stride_height;
-  const int dilation_width_factor = params.dilation_width_factor;
-  const int dilation_height_factor = params.dilation_height_factor;
-  const int pad_width = params.padding_values.width;
-  const int pad_height = params.padding_values.height;
-  const int32_t output_offset = params.output_offset;
-
-  // Set min and max value of the output.
-  const int32_t output_activation_min = params.quantized_activation_min;
-  const int32_t output_activation_max = params.quantized_activation_max;
-
-  // Consistency check.
-  assert(output_activation_min < output_activation_max);
-  assert(input_shape.DimensionsCount() == 4);
-  assert(filter_shape.DimensionsCount() == 4);
-  assert(output_shape.DimensionsCount() == 4);
-  const int batches = MatchingDim(input_shape, 0, output_shape, 0);
-  const int input_depth = MatchingDim(input_shape, 3, filter_shape, 3);
-  const int output_depth = MatchingDim(filter_shape, 0, output_shape, 3);
-  if (bias_data)
-  {
-    assert(bias_shape.FlatSize() == output_depth);
-  }
-
-  // Check dimensions of the tensors.
-  const int input_height = input_shape.Dims(1);
-  const int input_width = input_shape.Dims(2);
-  const int filter_height = filter_shape.Dims(1);
-  const int filter_width = filter_shape.Dims(2);
-  const int output_height = output_shape.Dims(1);
-  const int output_width = output_shape.Dims(2);
-  for (int batch = 0; batch < batches; ++batch)
-  {
-    for (int out_y = 0; out_y < output_height; ++out_y)
-    {
-      const int in_y_origin = (out_y * stride_height) - pad_height;
-      for (int out_x = 0; out_x < output_width; ++out_x)
-      {
-        const int in_x_origin = (out_x * stride_width) - pad_width;
-        for (int out_channel = 0; out_channel < output_depth; ++out_channel)
-        {
-          int32_t acc = 0;
-          for (int filter_y = 0; filter_y < filter_height; ++filter_y)
-          {
-            const int in_y = in_y_origin + dilation_height_factor * filter_y;
-            for (int filter_x = 0; filter_x < filter_width; ++filter_x)
-            {
-              const int in_x = in_x_origin + dilation_width_factor * filter_x;
-
-              // Zero padding by omitting the areas outside the image.
-              const bool is_point_inside_image =
-                (in_x >= 0) && (in_x < input_width) && (in_y >= 0) && (in_y < input_height);
-
-              if (!is_point_inside_image)
-              {
-                continue;
-              }
-
-              for (int in_channel = 0; in_channel < input_depth; ++in_channel)
-              {
-                int32_t input_val = input_data[Offset(input_shape, batch, in_y, in_x, in_channel)];
-                int32_t filter_val =
-                  filter_data[Offset(filter_shape, out_channel, filter_y, filter_x, in_channel)];
-                // Accumulate with 32 bits accumulator.
-                // In the nudging process during model quantization, we force
-                // real value of 0.0 be represented by a quantized value. This
-                // guarantees that the input_offset is a int8_t, even though
-                // it is represented using int32_t. int32_t += int8_t *
-                // (int8_t - int8_t) so the highest value we can get from each
-                // accumulation is [-127, 127] * ([-128, 127] -
-                // [-128, 127]), which is [-32512, 32512]. log2(32512)
-                // = 14.98, which means we can accumulate at least 2^16
-                // multiplications without overflow. The accumulator is
-                // applied to a filter so the accumulation logic will hold as
-                // long as the filter size (filter_y * filter_x * in_channel)
-                // does not exceed 2^16, which is the case in all the models
-                // we have seen so far.
-                // TODO(jianlijianli): Add a check to make sure the
-                // accumulator depth is smaller than 2^16.
-                acc += filter_val * (input_val + input_offset);
-              }
-            }
-          }
-
-          if (bias_data)
-          {
-            acc += bias_data[out_channel];
-          }
-          acc = MultiplyByQuantizedMultiplier(acc, output_multiplier[out_channel],
-                                              output_shift[out_channel]);
-          acc += output_offset;
-          acc = std::max(acc, output_activation_min);
-          acc = std::min(acc, output_activation_max);
-          output_data[Offset(output_shape, batch, out_y, out_x, out_channel)] =
-            static_cast<int8_t>(acc);
+          output_data[Offset(output_shape, batch, out_y, out_x, out_channel)] = static_cast<T>(acc);
         }
       }
     }


### PR DESCRIPTION
There are only a few different lines between uint8 and int8.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

### For Reviewers

- Related Issue: #9609
- extra (optional?) PR of after #9613
- Tested on #9613 

Most codes are identical between uint8 and int8 except for the following:

```diff
@@ -1,7 +1,9 @@
 inline void Conv(const ConvParams &params, const int32_t *output_multiplier,
-                 const int32_t *output_shift, const Shape &input_shape, const int8_t *input_data,
-                 const Shape &filter_shape, const int8_t *filter_data, const Shape &bias_shape,
-                 const int32_t *bias_data, const Shape &output_shape, int8_t *output_data)
+                 const int32_t *output_shift, const Shape &input_shape, const uint8_t *input_data,
+                 const Shape &filter_shape, const uint8_t *filter_data,
+                 const int32_t *filter_zeropoint, const Shape &bias_shape, const int32_t *bias_data,
+                 const Shape &output_shape, uint8_t *output_data)
+
 {
   UNUSED_RELEASE(bias_shape);
   // Get parameters.
@@ -67,26 +69,12 @@
 
               for (int in_channel = 0; in_channel < input_depth; ++in_channel)
               {
-                int32_t input_val = input_data[Offset(input_shape, batch, in_y, in_x, in_channel)];
-                int32_t filter_val =
+                const uint8_t input_val =
+                  input_data[Offset(input_shape, batch, in_y, in_x, in_channel)];
+                const uint8_t filter_val =
                   filter_data[Offset(filter_shape, out_channel, filter_y, filter_x, in_channel)];
-                // Accumulate with 32 bits accumulator.
-                // In the nudging process during model quantization, we force
-                // real value of 0.0 be represented by a quantized value. This
-                // guarantees that the input_offset is a int8_t, even though
-                // it is represented using int32_t. int32_t += int8_t *
-                // (int8_t - int8_t) so the highest value we can get from each
-                // accumulation is [-127, 127] * ([-128, 127] -
-                // [-128, 127]), which is [-32512, 32512]. log2(32512)
-                // = 14.98, which means we can accumulate at least 2^16
-                // multiplications without overflow. The accumulator is
-                // applied to a filter so the accumulation logic will hold as
-                // long as the filter size (filter_y * filter_x * in_channel)
-                // does not exceed 2^16, which is the case in all the models
-                // we have seen so far.
-                // TODO(jianlijianli): Add a check to make sure the
-                // accumulator depth is smaller than 2^16.
-                acc += filter_val * (input_val + input_offset);
+                const int32_t filter_offset = -filter_zeropoint[out_channel];
+                acc += (filter_val + filter_offset) * (input_val + input_offset);
               }
             }
           }
@@ -101,7 +89,7 @@
           acc = std::max(acc, output_activation_min);
           acc = std::min(acc, output_activation_max);
           output_data[Offset(output_shape, batch, out_y, out_x, out_channel)] =
-            static_cast<int8_t>(acc);
+            static_cast<uint8_t>(acc);
         }
       }
     }
```

I would like to remove duplicated code using template.