### PR TITLE
[onert] Introduce Compiler contructor for NNPkg

### DIFF
--- a/runtime/onert/core/include/ir/NNPkg.h
+++ b/runtime/onert/core/include/ir/NNPkg.h
@@ -19,6 +19,7 @@
 
 #include <memory>
 #include <unordered_set>
+#include <vector>
 
 #include "ir/Index.h"
 #include "ir/Model.h"


### PR DESCRIPTION
This commit introduces Compiler constructor for NNPkg and option vector.
For NNPkg compilation, model field is changed to nnpkg field, and option reference field is changed to option pointer vector field.
This commit includes bug fix on NNPkg.h header file.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: https://github.com/Samsung/ONE/pull/9616
Related issue: #9610