### PR TITLE
[infra/runtime] Set flag for NEON2SSE debug build

### DIFF
--- a/infra/cmake/packages/NEON2SSESourceConfig.cmake
+++ b/infra/cmake/packages/NEON2SSESourceConfig.cmake
@@ -8,9 +8,8 @@ function(_NEON2SSESource_import)
   nnas_include(OptionTools)
 
   # NOTE TensorFlow 1.13.1 downloads NEON2SSE from the following URL
-  # NOTE TensorFlow 2.1 downloads NEON2SSE from the following URL
-  # NOTE TensorFlow 2.2 downloads NEON2SSE from the following URL
-  # NOTE TensorFlow 2.3 downloads NEON2SSE from the following URL
+  # NOTE TensorFlow 2.8.0 downloads NEON2SSE from the following URL
+  # NOTE commit c12f8932c3be5aebaf35562d699f645686c4e2c3 will resolve build fail on debug build
   envoption(EXTERNAL_DOWNLOAD_SERVER "https://github.com")
   envoption(NEON2SSE_URL ${EXTERNAL_DOWNLOAD_SERVER}/intel/ARM_NEON_2_x86_SSE/archive/1200fe90bb174a6224a525ee60148671a786a71f.tar.gz)
 

--- a/infra/nnfw/cmake/packages/TensorFlowLite-1.13.1/TensorFlowLite/CMakeLists.txt
+++ b/infra/nnfw/cmake/packages/TensorFlowLite-1.13.1/TensorFlowLite/CMakeLists.txt
@@ -52,13 +52,11 @@ target_compile_definitions(tensorflow-lite PUBLIC "GEMMLOWP_ALLOW_SLOW_SCALAR_FA
 set_property(TARGET tensorflow-lite PROPERTY POSITION_INDEPENDENT_CODE ON)
 target_link_libraries(tensorflow-lite eigen-tf-1.13.1 flatbuffers::flatbuffers ${LIB_PTHREAD} dl)
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_BUILD_TYPE_LC STREQUAL "debug")
-  if(NEON2SSESource_FOUND AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9)
-    message(WARNING "GNU Compiler version under 9 is not supporting NEON2SSE debug build. "
-                    "Compiler will use O3 (release) build option as a workaround.")
-    target_compile_options(tensorflow-lite PRIVATE -O3 -DNDEBUG)
-  endif()
-endif()
+# Define TF_LITE_DISABLE_X86_NEON for debug build
+# If we upgrade NEON2SSE version, we can remove below line
+if(NEON2SSESource_FOUND)
+  target_compile_definitions(tensorflow-lite PRIVATE $<$<CONFIG:Debug>:TF_LITE_DISABLE_X86_NEON>)
+endif(NEON2SSESource_FOUND)
 
 if(ANDROID)
   target_link_libraries(tensorflow-lite log)

--- a/infra/nnfw/cmake/packages/TensorFlowLite-2.3.0/TensorFlowLite/CMakeLists.txt
+++ b/infra/nnfw/cmake/packages/TensorFlowLite-2.3.0/TensorFlowLite/CMakeLists.txt
@@ -90,6 +90,12 @@ if(NOT ANDROID AND ${BUILD_WITH_NNAPI})
   target_link_libraries(tensorflow-lite-2.3.0 rt)
 endif()
 
+# Define TF_LITE_DISABLE_X86_NEON for debug build
+# If we upgrade NEON2SSE version, we can remove below line
+if(NEON2SSESource_FOUND)
+  target_compile_definitions(tensorflow-lite-2.3.0 PRIVATE $<$<CONFIG:Debug>:TF_LITE_DISABLE_X86_NEON>)
+endif(NEON2SSESource_FOUND)
+
 if(ANDROID)
   target_link_libraries(tensorflow-lite-2.3.0 log)
   target_include_directories(tensorflow-lite-2.3.0 PUBLIC "${NDK_DIR}/..")


### PR DESCRIPTION
This commit updates TensorFlowLite cmake for x64 build to resolve debug build fail by setting flag TF_LITE_DISABLE_X86_NEON.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>