### PR TITLE
[nnpkg_tools/gen_golden] Use same range for float random

### DIFF
--- a/tools/nnpackage_tool/gen_golden/gen_golden.py
+++ b/tools/nnpackage_tool/gen_golden/gen_golden.py
@@ -96,7 +96,7 @@ if __name__ == '__main__':
                     np.random.randint(-127, 127, this_shape).astype(np.int8))
             elif this_dtype == tf.float32:
                 input_values.append(
-                    np.random.random_sample(this_shape).astype(np.float32))
+                    (10 * np.random.random_sample(this_shape) - 5).astype(np.float32))
             elif this_dtype == tf.bool:
                 # generate random integer from [0, 2)
                 input_values.append(
@@ -142,7 +142,7 @@ if __name__ == '__main__':
                     np.random.randint(-127, 127, this_shape).astype(np.int8))
             elif this_dtype == np.float32:
                 input_values.append(
-                    np.random.random_sample(this_shape).astype(np.float32))
+                    (10 * np.random.random_sample(this_shape) - 5).astype(np.float32))
             elif this_dtype == np.bool_:
                 # generate random integer from [0, 2)
                 input_values.append(


### PR DESCRIPTION
It changse the default range for float random input.
Previosly, [0, 1) to [-5, 5), which is the same to RecordMinMax.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

Related: https://github.com/Samsung/ONE/issues/9609#issuecomment-1227983715

The range for random input depends on each model. As I remember, some model expected the input [0, 1.0).
In spite of this fact, I am trying to use the same one to `RecordMinMax` which is the tool we use to quantize tflite float to circle because I am guessing it is more likely to meet a value test error, and it may be hard to find the reason who is not familiar with our internal tools.