### PR TITLE
[onert] Create Executors for multimodel

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -421,14 +421,13 @@ NNFW_STATUS nnfw_session::prepare()
   try
   {
     // TODO: Compile all models in case of multiple models
-    if (_nnpkg->model_count() > 1)
+    if (_nnpkg->model_count() > 2)
     {
-      std::cerr << "Error during model prepare : multiple models are not supported yet."
+      std::cerr << "Error during model prepare : more than 3 multiple models are not supported yet."
                 << std::endl;
       return NNFW_STATUS_ERROR;
     }
-    auto model = _nnpkg->primary_model();
-    auto compiler = std::make_unique<onert::compiler::Compiler>(model, *_coptions[0]);
+    auto compiler = std::make_unique<onert::compiler::Compiler>(_nnpkg, _coptions);
     _nnpkg.reset();
     _compiler_artifact = compiler->compile();
     _execution = std::make_unique<onert::exec::Execution>(_compiler_artifact->_executors);

--- a/runtime/onert/core/include/exec/Executors.h
+++ b/runtime/onert/core/include/exec/Executors.h
@@ -18,11 +18,25 @@
 #define __ONERT_EXEC_EXECUTORS_H__
 
 #include "IExecutor.h"
+#include "ir/NNPkg.h"
 
 namespace onert
 {
 namespace exec
 {
+
+/**
+ * @brief Struct to gather model I/O information in multimodel NN package
+ *        Model I/O will have role one of below
+ *        - Package input/output
+ *        - Edge's start/finish point between model
+ */
+struct ModelEdges
+{
+  std::vector<ir::IODesc> pkg_inputs;
+  std::vector<ir::IODesc> pkg_outputs;
+  std::unordered_set<ir::ModelEdge, ir::ModelEdgeHash, ir::ModelEdgeEqual> edges;
+};
 
 /**
  * @brief Class to gather executors
@@ -31,6 +45,7 @@ class Executors
 {
 public:
   Executors(void) = default;
+  Executors(std::unique_ptr<ModelEdges> model_edges) { _model_edges = std::move(model_edges); }
   Executors(const Executors &) = delete;
   Executors(Executors &&) = default;
 
@@ -56,6 +71,7 @@ private:
   // TODO Use Executor index
   //      Changing index will effect if/while compile and kernel implementation
   std::unordered_map<ir::SubgraphIndex, std::unique_ptr<IExecutor>> _executors;
+  std::unique_ptr<ModelEdges> _model_edges;
 };
 
 } // namespace exec

--- a/runtime/onert/core/include/ir/NNPkg.h
+++ b/runtime/onert/core/include/ir/NNPkg.h
@@ -121,6 +121,11 @@ public:
    */
   IODesc &input(uint32_t index) { return _pkg_inputs[index]; }
   /**
+   * @brief   Get pkg_input vector
+   * @return  IODesc vector reference
+   */
+  const std::vector<IODesc> &inputs() { return _pkg_inputs; }
+  /**
    * @brief Add input at the end
    *
    * @param[in] input Input IODesc to be pushed
@@ -142,6 +147,11 @@ public:
    */
   IODesc &output(uint32_t index) { return _pkg_outputs[index]; }
   /**
+   * @brief   Get pkg_output vector
+   * @return  IODesc vector reference
+   */
+  const std::vector<IODesc> &outputs() { return _pkg_outputs; }
+  /**
    * @brief Add output at the end
    *
    * @param[in] output Output IODesc to be pushed
@@ -158,6 +168,14 @@ public:
   {
     std::cout << from << " -> " << to << std::endl;
     _model_edges.insert(ModelEdge{from, to});
+  }
+  /**
+   * @brief   Get edge set
+   * @return  Edge set reference
+   */
+  const std::unordered_set<ModelEdge, ModelEdgeHash, ModelEdgeEqual> &edges()
+  {
+    return _model_edges;
   }
 
   // TODO: Add iterate() or getter for edges

--- a/runtime/onert/core/src/exec/Executors.cc
+++ b/runtime/onert/core/src/exec/Executors.cc
@@ -23,28 +23,43 @@ namespace exec
 
 uint32_t Executors::inputSize() const
 {
+  if (_model_edges)
+    throw std::runtime_error{"NYI: Multi model execution is not supported yet"};
+
   return _executors.at(ir::SubgraphIndex{0})->graph().getInputs().size();
 }
 
 uint32_t Executors::outputSize() const
 {
+  if (_model_edges)
+    throw std::runtime_error{"NYI: Multi model execution is not supported yet"};
+
   return _executors.at(ir::SubgraphIndex{0})->graph().getOutputs().size();
 }
 
 const ir::OperandInfo Executors::inputInfo(const ir::IOIndex &index)
 {
+  if (_model_edges)
+    throw std::runtime_error{"NYI: Multi model execution is not supported yet"};
+
   const auto input_index = _executors.at(ir::SubgraphIndex{0})->graph().getInputs().at(index);
   return _executors.at(ir::SubgraphIndex{0})->graph().operands().at(input_index).info();
 }
 
 const ir::OperandInfo Executors::outputInfo(const ir::IOIndex &index)
 {
+  if (_model_edges)
+    throw std::runtime_error{"NYI: Multi model execution is not supported yet"};
+
   auto output_index = _executors.at(ir::SubgraphIndex{0})->graph().getOutputs().at(index);
   return _executors.at(ir::SubgraphIndex{0})->graph().operands().at(output_index).info();
 }
 
 void Executors::execute(const IODescription &desc)
 {
+  if (_model_edges)
+    throw std::runtime_error{"NYI: Multi model execution is not supported yet"};
+
   _executors.at(ir::SubgraphIndex{0})->execute(desc);
 }
 


### PR DESCRIPTION
This commit introduces Executors constructor for multimodel.
To get edge information, this commit introduces ModelEdge struct and generate and pass on Compiler::compile method.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: https://github.com/Samsung/ONE/pull/9616
Related issue: https://github.com/Samsung/ONE/issues/9610