### PR TITLE
[onert] Move ModelEdges

### DIFF
--- a/runtime/onert/core/include/exec/Executors.h
+++ b/runtime/onert/core/include/exec/Executors.h
@@ -26,26 +26,13 @@ namespace exec
 {
 
 /**
- * @brief Struct to gather model I/O information in multimodel NN package
- *        Model I/O will have role one of below
- *        - Package input/output
- *        - Edge's start/finish point between model
- */
-struct ModelEdges
-{
-  std::vector<ir::IODesc> pkg_inputs;
-  std::vector<ir::IODesc> pkg_outputs;
-  std::unordered_set<ir::ModelEdge, ir::ModelEdgeHash, ir::ModelEdgeEqual> edges;
-};
-
-/**
  * @brief Class to gather executors
  */
 class Executors
 {
 public:
   Executors(void) = default;
-  Executors(std::unique_ptr<ModelEdges> model_edges) { _model_edges = std::move(model_edges); }
+  Executors(std::unique_ptr<ir::ModelEdges> model_edges) { _model_edges = std::move(model_edges); }
   Executors(const Executors &) = delete;
   Executors(Executors &&) = default;
 
@@ -71,7 +58,8 @@ private:
   // TODO Use Executor index
   //      Changing index will effect if/while compile and kernel implementation
   std::unordered_map<ir::SubgraphIndex, std::unique_ptr<IExecutor>> _executors;
-  std::unique_ptr<ModelEdges> _model_edges;
+  // NOTE _model_edges may use different struct type for executor implementation
+  std::unique_ptr<ir::ModelEdges> _model_edges;
 };
 
 } // namespace exec

--- a/runtime/onert/core/include/ir/NNPkg.h
+++ b/runtime/onert/core/include/ir/NNPkg.h
@@ -63,6 +63,21 @@ inline std::ostream &operator<<(std::ostream &o, const IODesc &od)
   return o;
 }
 
+using ModelEdgeSet = std::unordered_set<ir::ModelEdge, ir::ModelEdgeHash, ir::ModelEdgeEqual>;
+
+/**
+ * @brief Struct to gather model I/O information in multimodel NN package
+ *        Model I/O will have role one of below
+ *        - Package input/output
+ *        - Edge's start/finish point between model
+ */
+struct ModelEdges
+{
+  std::vector<ir::IODesc> pkg_inputs;
+  std::vector<ir::IODesc> pkg_outputs;
+  ModelEdgeSet edges;
+};
+
 class NNPkg
 {
 public:
@@ -112,25 +127,20 @@ public:
    * @param[in] index Index of pkg_input to be returned
    * @return IODesc at index
    */
-  const IODesc &input(uint32_t index) const { return _pkg_inputs[index]; }
+  const IODesc &input(uint32_t index) const { return _edges.pkg_inputs[index]; }
   /**
    * @brief Get pkg_input at index
    *
    * @param[in] index Index of pkg_input to be returned
    * @return IODesc at index
    */
-  IODesc &input(uint32_t index) { return _pkg_inputs[index]; }
-  /**
-   * @brief   Get pkg_input vector
-   * @return  IODesc vector reference
-   */
-  const std::vector<IODesc> &inputs() { return _pkg_inputs; }
+  IODesc &input(uint32_t index) { return _edges.pkg_inputs[index]; }
   /**
    * @brief Add input at the end
    *
    * @param[in] input Input IODesc to be pushed
    */
-  void addInput(const IODesc &input) { _pkg_inputs.push_back(input); }
+  void addInput(const IODesc &input) { _edges.pkg_inputs.push_back(input); }
 
   /**
    * @brief Get pkg_output at index
@@ -138,25 +148,20 @@ public:
    * @param[in] index Index of pkg_output to be returned
    * @return IODesc at index
    */
-  const IODesc &output(uint32_t index) const { return _pkg_outputs[index]; }
+  const IODesc &output(uint32_t index) const { return _edges.pkg_outputs[index]; }
   /**
    * @brief Get pkg_output at index
    *
    * @param[in] index Index of pkg_output to be returned
    * @return IODesc at index
    */
-  IODesc &output(uint32_t index) { return _pkg_outputs[index]; }
-  /**
-   * @brief   Get pkg_output vector
-   * @return  IODesc vector reference
-   */
-  const std::vector<IODesc> &outputs() { return _pkg_outputs; }
+  IODesc &output(uint32_t index) { return _edges.pkg_outputs[index]; }
   /**
    * @brief Add output at the end
    *
    * @param[in] output Output IODesc to be pushed
    */
-  void addOutput(const IODesc &output) { _pkg_outputs.push_back(output); }
+  void addOutput(const IODesc &output) { _edges.pkg_outputs.push_back(output); }
 
   /**
    * @brief Add edge between models at the end
@@ -167,24 +172,19 @@ public:
   void addEdge(const IODesc &from, const IODesc &to)
   {
     std::cout << from << " -> " << to << std::endl;
-    _model_edges.insert(ModelEdge{from, to});
+    _edges.edges.insert(ModelEdge{from, to});
   }
   /**
-   * @brief   Get edge set
+   * @brief   Get model edge set
    * @return  Edge set reference
    */
-  const std::unordered_set<ModelEdge, ModelEdgeHash, ModelEdgeEqual> &edges()
-  {
-    return _model_edges;
-  }
+  const ModelEdges &model_edges() { return _edges; }
 
   // TODO: Add iterate() or getter for edges
 
 private:
   std::unordered_map<ModelIndex, std::shared_ptr<Model>> _models;
-  std::vector<IODesc> _pkg_inputs;
-  std::vector<IODesc> _pkg_outputs;
-  std::unordered_set<ModelEdge, ModelEdgeHash, ModelEdgeEqual> _model_edges;
+  ModelEdges _edges;
 };
 
 } // namespace ir

--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -513,7 +513,7 @@ std::shared_ptr<CompilerArtifact> Compiler::compile(void)
   auto tracing_ctx = std::make_unique<util::TracingCtx>();
 
   // Model edge context
-  std::unique_ptr<exec::ModelEdges> model_edges = nullptr;
+  std::unique_ptr<ir::ModelEdges> model_edges = nullptr;
 
   // Lower: Assign backend
   std::unordered_map<ir::SubgraphIndex, std::unique_ptr<compiler::LoweredGraph>> lowered_subgs;
@@ -533,13 +533,8 @@ std::shared_ptr<CompilerArtifact> Compiler::compile(void)
     // TODO Support tracing_ctx for multiple model
     tracing_ctx = nullptr;
 
-    // Fill model edge context
-    model_edges = std::make_unique<exec::ModelEdges>();
-    {
-      model_edges->pkg_inputs = _nnpkg->inputs();
-      model_edges->pkg_outputs = _nnpkg->outputs();
-      model_edges->edges = _nnpkg->edges();
-    }
+    // Copy model edge context
+    model_edges = std::make_unique<ir::ModelEdges>(_nnpkg->model_edges());
 
     for (uint32_t i = 0; i < model_count; i++)
     {


### PR DESCRIPTION
This commit moves ModelEdges struct into ir/NNPkg.h and share struct.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: https://github.com/Samsung/ONE/pull/9636#discussion_r957018961