### PR TITLE
[onert] Support simply partitioned multimodel execution

### DIFF
--- a/runtime/onert/core/src/exec/Executors.cc
+++ b/runtime/onert/core/src/exec/Executors.cc
@@ -79,77 +79,99 @@ void Executors::executeEntries(const IODescription &desc)
 {
   // Assume 2 executors only
   // Assume that each model may have only one subgraph
-  // Assume that each model may have only one input/output
   // TODO Support general case
-  if (_executors.size() != 2 || _model_edges->pkg_inputs.size() != 1 ||
-      _model_edges->pkg_outputs.size() != 1 || _model_edges->edges.size() != 1)
+  if (_executors.size() != 2)
     throw std::runtime_error{"NYI: Multi model execution for this package is not supported yet"};
 
-  // Assume edge is 0:0:0 -> 1:0:0
-  auto &edge = *_model_edges->edges.begin();
-  if ((std::get<0>(edge.from) != ir::ModelIndex{0}) ||
-      (std::get<1>(edge.from) != ir::SubgraphIndex{0}) ||
-      (std::get<2>(edge.from) != ir::IOIndex{0}))
-    throw std::runtime_error{"NYI: Multi model execution for this edge(from) is not supported yet"};
+  // Assume all edges are 0:0:x -> 1:0:x
+  for (auto edge : _model_edges->edges)
+  {
+    if ((std::get<0>(edge.from) != ir::ModelIndex{0}) ||
+        (std::get<0>(edge.to) != ir::ModelIndex{1}) ||
+        (std::get<1>(edge.from) != std::get<1>(edge.to)) ||
+        (std::get<2>(edge.from) != std::get<2>(edge.to)))
+      throw std::runtime_error{"NYI: Multi model execution for this edge is not supported yet"};
+  }
 
-  if ((std::get<0>(edge.to) != ir::ModelIndex{1}) ||
-      (std::get<1>(edge.to) != ir::SubgraphIndex{0}) || (std::get<2>(edge.to) != ir::IOIndex{0}))
-    throw std::runtime_error{"NYI: Multi model execution for this edge(to) is not supported yet"};
+  // Assume all package inputs are 0:0:x
+  for (uint32_t i = 0; i < _model_edges->pkg_inputs.size(); i++)
+  {
+    auto input = _model_edges->pkg_inputs[i];
+    if ((std::get<0>(input) != ir::ModelIndex{0}) || (std::get<1>(input) != ir::SubgraphIndex{0}) ||
+        (std::get<2>(input) != ir::IOIndex{i}))
+    {
+      throw std::runtime_error{"NYI: Support package input to 1st model with same order"};
+    }
+  }
+
+  // Assume all package outputs are 1:0:x
+  for (uint32_t i = 0; i < _model_edges->pkg_outputs.size(); i++)
+  {
+    auto output = _model_edges->pkg_outputs[i];
+    if ((std::get<0>(output) != ir::ModelIndex{1}) ||
+        (std::get<1>(output) != ir::SubgraphIndex{0}) || (std::get<2>(output) != ir::IOIndex{i}))
+    {
+      throw std::runtime_error{"NYI: Support package output from 2nd model with same order"};
+    }
+  }
+
+  const auto &executor1 = _executors.at(ir::SubgraphIndex{0});
+  const auto &graph1 = executor1->graph();
+  const auto &executor2 = _executors.at(ir::SubgraphIndex{1});
+  const auto &graph2 = executor2->graph();
+
+  if ((graph1.getInputs().size() != _model_edges->pkg_inputs.size()) ||
+      (graph2.getOutputs().size() != _model_edges->pkg_outputs.size()) ||
+      (graph1.getOutputs().size() != graph2.getInputs().size()) ||
+      (graph1.getOutputs().size() != _model_edges->edges.size()))
+  {
+    throw std::runtime_error{"NYI: Unsupported model edge pattern"};
+  }
 
   // Prepare buffer
   // Assume buffer layout is NHWC
+  std::vector<std::unique_ptr<uint8_t[]>> bufs(_model_edges->edges.size());
+  std::vector<const ir::OperandInfo *> buf_infos(_model_edges->edges.size());
   const auto layout = ir::Layout::NHWC;
-  const auto buf_index =
-    _executors.at(ir::SubgraphIndex{0})->graph().getOutputs().at(ir::IOIndex{0});
-  const auto buf_info =
-    _executors.at(ir::SubgraphIndex{0})->graph().operands().at(buf_index).info();
-  const auto buf_size = buf_info.total_size();
-  auto connect_buf = std::make_unique<uint8_t[]>(buf_size);
-  auto buf_ptr = connect_buf.get();
+
+  for (uint32_t i = 0; i < graph1.getOutputs().size(); i++)
+  {
+    const auto buf_index =
+      _executors.at(ir::SubgraphIndex{0})->graph().getOutputs().at(ir::IOIndex{i});
+    buf_infos[i] = &_executors.at(ir::SubgraphIndex{0})->graph().operands().at(buf_index).info();
+    const auto buf_size = buf_infos[i]->total_size();
+    bufs[i] = std::make_unique<uint8_t[]>(buf_size);
+  }
 
   // 1st executor
   {
-    auto &executor1 = _executors.at(ir::SubgraphIndex{0});
-    auto &graph1 = executor1->graph();
-    if (graph1.getInputs().size() != 1 || graph1.getOutputs().size() != 1)
-      throw std::runtime_error{
-        "NYI: Multi model execution for this 1st model is not supported yet"};
-
-    const auto input_desc = _model_edges->pkg_inputs[0];
-    if ((std::get<0>(input_desc) != ir::ModelIndex{0}) ||
-        (std::get<1>(input_desc) != ir::SubgraphIndex{0}) ||
-        (std::get<2>(input_desc) != ir::IOIndex{0}))
-      throw std::runtime_error{
-        "NYI: Multi model execution for this 1st model is not supported yet"};
-
     IODescription desc1;
-    desc1.inputs.resize(1);
-    desc1.inputs[0] = std::make_unique<InputDesc>(*desc.inputs[0].get());
-    desc1.outputs.resize(1);
-    desc1.outputs[0] = std::make_unique<OutputDesc>(buf_info, buf_ptr, buf_size, layout);
+    const auto input_size = graph1.getInputs().size();
+    const auto output_size = graph1.getOutputs().size();
+    desc1.inputs.resize(input_size);
+    desc1.outputs.resize(output_size);
+    for (uint32_t i = 0; i < input_size; i++)
+      desc1.inputs[i] = std::make_unique<InputDesc>(*desc.inputs[i].get());
+    for (uint32_t i = 0; i < output_size; i++)
+      desc1.outputs[i] = std::make_unique<OutputDesc>(*buf_infos[i], bufs[i].get(),
+                                                      buf_infos[i]->total_size(), layout);
+
     executor1->execute(desc1);
   }
 
   // 2nd executor
   {
-    auto &executor2 = _executors.at(ir::SubgraphIndex{1});
-    auto &graph2 = executor2->graph();
-    if (graph2.getInputs().size() != 1 || graph2.getOutputs().size() != 1)
-      throw std::runtime_error{
-        "NYI: Multi model execution for this 2nd model is not supported yet"};
-
-    const auto output_desc = _model_edges->pkg_outputs[0];
-    if ((std::get<0>(output_desc) != ir::ModelIndex{1}) ||
-        (std::get<1>(output_desc) != ir::SubgraphIndex{0}) ||
-        (std::get<2>(output_desc) != ir::IOIndex{0}))
-      throw std::runtime_error{
-        "NYI: Multi model execution for this 2nd model is not supported yet"};
-
     IODescription desc2;
-    desc2.inputs.resize(1);
-    desc2.inputs[0] = std::make_unique<InputDesc>(buf_info, buf_ptr, buf_size, layout);
-    desc2.outputs.resize(1);
-    desc2.outputs[0] = std::make_unique<OutputDesc>(*desc.outputs[0].get());
+    const auto input_size = graph2.getInputs().size();
+    const auto output_size = graph2.getOutputs().size();
+    desc2.inputs.resize(input_size);
+    desc2.outputs.resize(output_size);
+    for (uint32_t i = 0; i < input_size; i++)
+      desc2.inputs[i] = std::make_unique<InputDesc>(*buf_infos[i], bufs[i].get(),
+                                                    buf_infos[i]->total_size(), layout);
+    for (uint32_t i = 0; i < output_size; i++)
+      desc2.outputs[i] = std::make_unique<OutputDesc>(*desc.outputs[i].get());
+
     executor2->execute(desc2);
   }
 }

--- a/runtime/onert/core/src/exec/Executors.cc
+++ b/runtime/onert/core/src/exec/Executors.cc
@@ -86,10 +86,11 @@ void Executors::executeEntries(const IODescription &desc)
   // Assume all edges are 0:0:x -> 1:0:x
   for (auto edge : _model_edges->edges)
   {
-    if ((std::get<0>(edge.from) != ir::ModelIndex{0}) ||
-        (std::get<0>(edge.to) != ir::ModelIndex{1}) ||
-        (std::get<1>(edge.from) != std::get<1>(edge.to)) ||
-        (std::get<2>(edge.from) != std::get<2>(edge.to)))
+    if ((std::get<ir::ModelIndex>(edge.from) != ir::ModelIndex{0}) ||
+        (std::get<ir::ModelIndex>(edge.to) != ir::ModelIndex{1}) ||
+        (std::get<ir::SubgraphIndex>(edge.from) != ir::SubgraphIndex{0}) ||
+        (std::get<ir::SubgraphIndex>(edge.to) != ir::SubgraphIndex{0}) ||
+        (std::get<ir::IOIndex>(edge.from) != std::get<ir::IOIndex>(edge.to)))
       throw std::runtime_error{"NYI: Multi model execution for this edge is not supported yet"};
   }
 
@@ -97,8 +98,9 @@ void Executors::executeEntries(const IODescription &desc)
   for (uint32_t i = 0; i < _model_edges->pkg_inputs.size(); i++)
   {
     auto input = _model_edges->pkg_inputs[i];
-    if ((std::get<0>(input) != ir::ModelIndex{0}) || (std::get<1>(input) != ir::SubgraphIndex{0}) ||
-        (std::get<2>(input) != ir::IOIndex{i}))
+    if ((std::get<ir::ModelIndex>(input) != ir::ModelIndex{0}) ||
+        (std::get<ir::SubgraphIndex>(input) != ir::SubgraphIndex{0}) ||
+        (std::get<ir::IOIndex>(input) != ir::IOIndex{i}))
     {
       throw std::runtime_error{"NYI: Support package input to 1st model with same order"};
     }
@@ -108,8 +110,9 @@ void Executors::executeEntries(const IODescription &desc)
   for (uint32_t i = 0; i < _model_edges->pkg_outputs.size(); i++)
   {
     auto output = _model_edges->pkg_outputs[i];
-    if ((std::get<0>(output) != ir::ModelIndex{1}) ||
-        (std::get<1>(output) != ir::SubgraphIndex{0}) || (std::get<2>(output) != ir::IOIndex{i}))
+    if ((std::get<ir::ModelIndex>(output) != ir::ModelIndex{1}) ||
+        (std::get<ir::SubgraphIndex>(output) != ir::SubgraphIndex{0}) ||
+        (std::get<ir::IOIndex>(output) != ir::IOIndex{i}))
     {
       throw std::runtime_error{"NYI: Support package output from 2nd model with same order"};
     }


### PR DESCRIPTION
This commit updates Executors::executeEntries to support simply partitioned multimodel package execution.

Simply partitioned multimodel package
- Package has two model
- Package's all inputs = 1st model's all inputs (same order)
- Package's all outputs = 2nd model's all outputs (same order)
- 1st model's all outputs = 2nd model's all inputs (same order)

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: #9646