### PR TITLE
StaticShapeInferer for Bulk

### DIFF
--- a/runtime/onert/core/include/compiler/StaticShapeInferer.h
+++ b/runtime/onert/core/include/compiler/StaticShapeInferer.h
@@ -153,6 +153,7 @@ private:
   void visit(const ir::operation::Unpack &op) override;
   void visit(const ir::operation::While &op) override;
   void visit(const ir::operation::DetectionPostProcess &op) override;
+  void visit(const ir::operation::Bulk &op) override;
 
 private:
   /**


### PR DESCRIPTION
Note that Bulk's Static Shape Inferer assumes :
- new input shape has new batch size if it is different from model's
original input shape. Other dimension is not allowed to be changed.
- All new input shapes have the same batch. Thus, it is sufficient to
check 1st input's batch dim.

Signed-off-by: Chunseok Lee <chunseok.lee@samsung.com>