### PR TITLE
[circle-quantizer] Remove unused argparse

### DIFF
--- a/compiler/circle-quantizer/src/CircleQuantizer.cpp
+++ b/compiler/circle-quantizer/src/CircleQuantizer.cpp
@@ -104,8 +104,6 @@ void print_version(void)
 
 int entry(int argc, char **argv)
 {
-  // Simple argument parser (based on map)
-  std::map<std::string, OptionHook> argparse;
   luci::CircleQuantizer quantizer;
 
   auto options = quantizer.options();


### PR DESCRIPTION
argparse is not used anywhere and misleading.
It removes argparse and related comment.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>