### PR TITLE
[one-cmds-tests] Remove unnecessary preparation

### DIFF
--- a/compiler/one-cmds/tests/one-optimize_001.test
+++ b/compiler/one-cmds/tests/one-optimize_001.test
@@ -30,15 +30,6 @@ outputfile="./inception_v3-opt.circle"
 
 rm -rf ${outputfile}
 
-# to create inception_v3.circle
-if [[ ! -s ${inputfile} ]]; then
-  /bin/bash one-import_001.test > /dev/null 2>&1
-  return_code=$?
-  if [[ ${return_code} != 0 ]]; then
-    trap_err_onexit
-  fi
-fi
-
 # run test
 one-optimize --resolve_customop_add \
 --input_path ${inputfile} \

--- a/compiler/one-cmds/tests/one-optimize_002.test
+++ b/compiler/one-cmds/tests/one-optimize_002.test
@@ -30,15 +30,6 @@ outputfile="./inception_v3-opt.circle"
 
 rm -rf ${outputfile}
 
-# to create inception_v3.circle
-if [[ ! -s ${inputfile} ]]; then
-  /bin/bash one-import_001.test > /dev/null 2>&1
-  return_code=$?
-  if [[ ${return_code} != 0 ]]; then
-    trap_err_onexit
-  fi
-fi
-
 # run test
 one-optimize --resolve_customop_add \
 --change_outputs InceptionV3/Logits/SpatialSqueeze1 \

--- a/compiler/one-cmds/tests/one-optimize_neg_003.test
+++ b/compiler/one-cmds/tests/one-optimize_neg_003.test
@@ -34,15 +34,6 @@ trap trap_err_onexit ERR
 
 inputfile="./inception_v3.circle"
 
-# to create inception_v3.circle
-if [[ ! -s ${inputfile} ]]; then
-  /bin/bash one-import_001.test >> /dev/null
-  return_code=$?
-  if [[ ${return_code} != 0 ]]; then
-    trap_err_onexit
-  fi
-fi
-
 # run test
 one-optimize --resolve_customop_add \
 --input_path "${inputfile}" > "${filename}.log" 2>&1

--- a/compiler/one-cmds/tests/one-pack_001.test
+++ b/compiler/one-cmds/tests/one-pack_001.test
@@ -30,15 +30,6 @@ outputfolder="nnpack"
 
 rm -rf ${outputfolder}
 
-# to create inception_v3.circle
-if [[ ! -s ${inputfile} ]]; then
-  /bin/bash one-import_001.test > /dev/null 2>&1
-  return_code=$?
-  if [[ ${return_code} != 0 ]]; then
-    trap_err_onexit
-  fi
-fi
-
 # run test
 one-pack \
 -i ${inputfile} \

--- a/compiler/one-cmds/tests/one-quantize_001.test
+++ b/compiler/one-cmds/tests/one-quantize_001.test
@@ -30,15 +30,6 @@ outputfile="./inception_v3.quantized.circle"
 
 rm -rf ${outputfile}
 
-# to create inception_v3.circle
-if [[ ! -s ${inputfile} ]]; then
-  /bin/bash one-import_001.test > /dev/null 2>&1
-  return_code=$?
-  if [[ ${return_code} != 0 ]]; then
-    trap_err_onexit
-  fi
-fi
-
 # run test
 one-quantize \
 --input_dtype float32 \

--- a/compiler/one-cmds/tests/one-quantize_002.test
+++ b/compiler/one-cmds/tests/one-quantize_002.test
@@ -30,15 +30,6 @@ outputfile="./inception_v3.random.quantized.circle"
 
 rm -rf ${outputfile}
 
-# to create inception_v3.circle
-if [[ ! -s ${inputfile} ]]; then
-  /bin/bash one-import_001.test > /dev/null 2>&1
-  return_code=$?
-  if [[ ${return_code} != 0 ]]; then
-    trap_err_onexit
-  fi
-fi
-
 # run test without input data
 one-quantize \
 --input_dtype float32 \

--- a/compiler/one-cmds/tests/one-quantize_007.test
+++ b/compiler/one-cmds/tests/one-quantize_007.test
@@ -30,15 +30,6 @@ outputfile="./inception_v3.random.quantized.q16.iq8.circle"
 
 rm -rf ${outputfile}
 
-# to create inception_v3.circle
-if [[ ! -s ${inputfile} ]]; then
-  /bin/bash one-import_001.test > /dev/null 2>&1
-  return_code=$?
-  if [[ ${return_code} != 0 ]]; then
-    trap_err_onexit
-  fi
-fi
-
 # run test without input data
 one-quantize \
 --input_dtype float32 \

--- a/compiler/one-cmds/tests/one-quantize_008.test
+++ b/compiler/one-cmds/tests/one-quantize_008.test
@@ -30,15 +30,6 @@ outputfile="./inception_v3.random.quantized.q16.oq8.circle"
 
 rm -rf ${outputfile}
 
-# to create inception_v3.circle
-if [[ ! -s ${inputfile} ]]; then
-  /bin/bash one-import_001.test > /dev/null 2>&1
-  return_code=$?
-  if [[ ${return_code} != 0 ]]; then
-    trap_err_onexit
-  fi
-fi
-
 # run test without input data
 one-quantize \
 --input_dtype float32 \

--- a/compiler/one-cmds/tests/one-quantize_009.test
+++ b/compiler/one-cmds/tests/one-quantize_009.test
@@ -30,15 +30,6 @@ outputfile="./inception_v3.random.quantized.mixed.circle"
 
 rm -rf ${outputfile}
 
-# to create inception_v3.circle
-if [[ ! -s ${inputfile} ]]; then
-  /bin/bash one-import_001.test > /dev/null 2>&1
-  return_code=$?
-  if [[ ${return_code} != 0 ]]; then
-    trap_err_onexit
-  fi
-fi
-
 # run test without input data
 one-quantize \
 --input_dtype float32 \

--- a/compiler/one-cmds/tests/one-quantize_010.test
+++ b/compiler/one-cmds/tests/one-quantize_010.test
@@ -41,15 +41,6 @@ datafile="./inception_v3_test_data.h5"
 
 rm -rf ${outputfile}
 
-# to create inception_v3.circle
-if [[ ! -s ${inputfile} ]]; then
-  /bin/bash one-import_001.test > /dev/null 2>&1
-  return_code=$?
-  if [[ ${return_code} != 0 ]]; then
-    trap_err_onexit
-  fi
-fi
-
 # run test
 one-quantize \
 --input_dtype float32 \

--- a/compiler/one-cmds/tests/one-quantize_neg_001.test
+++ b/compiler/one-cmds/tests/one-quantize_neg_001.test
@@ -41,15 +41,6 @@ rm -rf ${outputfile}.log
 
 # test begin
 
-# to create inception_v3.circle
-if [[ ! -s ${inputfile} ]]; then
-  /bin/bash one-import_001.test >> /dev/null
-  return_code=$?
-  if [[ ${return_code} != 0 ]]; then
-    trap_err_onexit
-  fi
-fi
-
 one-quantize \
 --input_dtype float64 \
 --quantized_dtype uint8 \

--- a/compiler/one-cmds/tests/one-quantize_neg_002.test
+++ b/compiler/one-cmds/tests/one-quantize_neg_002.test
@@ -39,15 +39,6 @@ outputfile="./inception_v3.quantized.circle"
 rm -rf ${outputfile}
 rm -rf ${outputfile}.log
 
-# to create inception_v3.circle
-if [[ ! -s ${inputfile} ]]; then
-  /bin/bash one-import_001.test >> /dev/null
-  return_code=$?
-  if [[ ${return_code} != 0 ]]; then
-    trap_err_onexit
-  fi
-fi
-
 # run test
 one-quantize \
 --input_dtype float32 \

--- a/compiler/one-cmds/tests/one-quantize_neg_003.test
+++ b/compiler/one-cmds/tests/one-quantize_neg_003.test
@@ -38,15 +38,6 @@ outputfile="./inception_v3.quantized.circle"
 rm -rf ${outputfile}
 rm -rf ${outputfile}.log
 
-# to create inception_v3.circle
-if [[ ! -s ${inputfile} ]]; then
-  /bin/bash one-import_001.test >> /dev/null
-  return_code=$?
-  if [[ ${return_code} != 0 ]]; then
-    trap_err_onexit
-  fi
-fi
-
 # run test
 one-quantize \
 --input_dtype float32 \

--- a/compiler/one-cmds/tests/one-quantize_neg_004.test
+++ b/compiler/one-cmds/tests/one-quantize_neg_004.test
@@ -38,15 +38,6 @@ outputfile="."
 
 rm -rf ${outputfile}.log
 
-# to create inception_v3.circle
-if [[ ! -s ${inputfile} ]]; then
-  /bin/bash one-import_001.test >> /dev/null
-  return_code=$?
-  if [[ ${return_code} != 0 ]]; then
-    trap_err_onexit
-  fi
-fi
-
 # run test
 one-quantize \
 --input_dtype float32 \

--- a/compiler/one-cmds/tests/one-quantize_neg_007.test
+++ b/compiler/one-cmds/tests/one-quantize_neg_007.test
@@ -38,15 +38,6 @@ outputfile="./inception_v3.quantized.circle"
 
 rm -rf ${outputfile}.log
 
-# to create inception_v3.circle
-if [[ ! -s ${inputfile} ]]; then
-  /bin/bash one-import_001.test >> /dev/null
-  return_code=$?
-  if [[ ${return_code} != 0 ]]; then
-    trap_err_onexit
-  fi
-fi
-
 # run test
 one-quantize \
 --input_dtype float32 \

--- a/compiler/one-cmds/tests/one-quantize_neg_008.test
+++ b/compiler/one-cmds/tests/one-quantize_neg_008.test
@@ -38,15 +38,6 @@ outputfile="./inception_v3.quantized.circle"
 
 rm -rf ${outputfile}.log
 
-# to create inception_v3.circle
-if [[ ! -s ${inputfile} ]]; then
-  /bin/bash one-import_001.test >> /dev/null
-  return_code=$?
-  if [[ ${return_code} != 0 ]]; then
-    trap_err_onexit
-  fi
-fi
-
 # run test
 one-quantize \
 --input_dtype float32 \

--- a/compiler/one-cmds/tests/one-quantize_neg_009.test
+++ b/compiler/one-cmds/tests/one-quantize_neg_009.test
@@ -38,15 +38,6 @@ outputfile="./inception_v3.quantized.circle"
 
 rm -rf ${outputfile}.log
 
-# to create inception_v3.circle
-if [[ ! -s ${inputfile} ]]; then
-  /bin/bash one-import_001.test >> /dev/null
-  return_code=$?
-  if [[ ${return_code} != 0 ]]; then
-    trap_err_onexit
-  fi
-fi
-
 # run test
 one-quantize \
 --input_dtype float32 \

--- a/compiler/one-cmds/tests/one-quantize_neg_010.test
+++ b/compiler/one-cmds/tests/one-quantize_neg_010.test
@@ -38,15 +38,6 @@ outputfile="./inception_v3.quantized.circle"
 
 rm -rf ${outputfile}.log
 
-# to create inception_v3.circle
-if [[ ! -s ${inputfile} ]]; then
-  /bin/bash one-import_001.test >> /dev/null
-  return_code=$?
-  if [[ ${return_code} != 0 ]]; then
-    trap_err_onexit
-  fi
-fi
-
 # run test
 one-quantize \
 --input_dtype float32 \

--- a/compiler/one-cmds/tests/one-quantize_neg_011.test
+++ b/compiler/one-cmds/tests/one-quantize_neg_011.test
@@ -38,15 +38,6 @@ outputfile="./inception_v3.quantized.circle"
 
 rm -rf ${outputfile}.log
 
-# to create inception_v3.circle
-if [[ ! -s ${inputfile} ]]; then
-  /bin/bash one-import_001.test >> /dev/null
-  return_code=$?
-  if [[ ${return_code} != 0 ]]; then
-    trap_err_onexit
-  fi
-fi
-
 # run test
 one-quantize \
 --input_dtype float32 \

--- a/compiler/one-cmds/tests/one-quantize_neg_012.test
+++ b/compiler/one-cmds/tests/one-quantize_neg_012.test
@@ -38,15 +38,6 @@ outputfile="./inception_v3.quantized.circle"
 
 rm -rf ${outputfile}.log
 
-# to create inception_v3.circle
-if [[ ! -s ${inputfile} ]]; then
-  /bin/bash one-import_001.test >> /dev/null
-  return_code=$?
-  if [[ ${return_code} != 0 ]]; then
-    trap_err_onexit
-  fi
-fi
-
 # run test
 one-quantize \
 --input_dtype float32 \

--- a/compiler/one-cmds/tests/one-quantize_neg_013.test
+++ b/compiler/one-cmds/tests/one-quantize_neg_013.test
@@ -38,15 +38,6 @@ outputfile="./inception_v3.quantized.circle"
 
 rm -rf ${outputfile}.log
 
-# to create inception_v3.circle
-if [[ ! -s ${inputfile} ]]; then
-  /bin/bash one-import_001.test >> /dev/null
-  return_code=$?
-  if [[ ${return_code} != 0 ]]; then
-    trap_err_onexit
-  fi
-fi
-
 # run test
 one-quantize \
 --input_dtype float32 \


### PR DESCRIPTION
This will remove unnecessary preparation of inception_v3.circle file as this file is prepared in prepare_test_materials script.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>