### PR TITLE
[Draft][ONE-Dockerizing] Introduce onecc dockerizing

### DIFF
--- a/compiler/onecc-docker/Dockerfile
+++ b/compiler/onecc-docker/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:18.04 
+
+RUN apt-get update 
+
+RUN apt-get install -y wget 
+
+RUN wget https://github.com/Samsung/ONE/releases/download/1.21.0/one-compiler_1.21.0_amd64.deb 
+
+RUN apt install -y ./one-compiler_1.21.0_amd64.deb 
+
+WORKDIR /home/ 
+
+RUN mkdir test 
+
+WORKDIR /home/test 
+
+CMD ["onecc", "-C", "onecc.template.cfg"]

--- a/compiler/onecc-docker/onecc-docker.py
+++ b/compiler/onecc-docker/onecc-docker.py
@@ -1,0 +1,64 @@
+import sys
+import subprocess
+from distutils.version import StrictVersion
+import json
+
+def _is_image(version) : 
+    cmd = ['docker', 'images', f'onecc:{version}']
+    p = subprocess.Popen(cmd,  stdout=subprocess.PIPE, stderr=subprocess.STDOUT) 
+    out, err = p.communicate()
+    dic = {}
+
+    decoded_out = [i.split() for i in out.decode().split("\n") if len(i)]
+
+    if len(decoded_out) <2 :
+        return False
+
+    dic[decoded_out[0][0]] = decoded_out[1][0]
+    dic[decoded_out[0][1]] = decoded_out[1][1]
+
+    tag_name = cmd[2].split(':')
+
+    if dic['REPOSITORY'] == tag_name[0] and dic['TAG'] == tag_name[1]  :
+        return True 
+    else :
+        return False
+
+
+def main():
+    installed_onecc_version = sys.argv[1]
+    versions_str = subprocess.check_output("curl -s https://api.github.com/repos/Samsung/ONE/tags", shell=True ,encoding='utf-8')
+    versions_json = json.loads(versions_str)
+    versions = []
+    for i in versions_json:
+        versions.append(i["name"])
+
+    versions.sort(key=StrictVersion)
+    chosen_version = ""
+    while 1:
+        for i in range(18, len(versions)):
+            print(versions[i])
+        chosen_version = input("choose version: ")
+        flag = False
+        for i in range(18, len(versions)):
+            if chosen_version == versions[i]:
+                flag = True
+                break
+        if(flag):
+            break
+        else:
+            print("choose right version")
+    if chosen_version == installed_onecc_version:
+        print("onecc is installed in computer")
+        onecc_cmd = ["onecc"] + sys.argv[2:]
+        subprocess.call(onecc_cmd)
+        exit(0)
+
+    if not _is_image(chosen_version):
+        build_cmd = ["docker", "build", "-t", f"onecc:{chosen_version}", "."]
+        subprocess.call(build_cmd)
+    run_cmd = ["docker", "run", "--rm", "--name", "onecc", "-v", "/home/:/home/", f"onecc:{chosen_version}"]
+    subprocess.call(run_cmd)
+
+if __name__ == "__main__":
+	main()

--- a/compiler/onecc-docker/onecc-docker.sh
+++ b/compiler/onecc-docker/onecc-docker.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+if ! command -v docker > /dev/null
+        then
+        echo "docker must be installed"
+        exit 0
+fi
+
+if ! command -v python3 > /dev/null
+        then
+        echo "python3 must be installed"
+        exit 0
+fi
+
+if command -v onecc > /dev/null 
+        then
+        version=( $(onecc --version) )
+        exec "python3" "onecc-docker.py" "${version[2]}" "$@" 
+        exit 0
+else
+        exec "python3" "onecc-docker.py" "0" "$@" 
+        exit 0
+fi
+


### PR DESCRIPTION
This commit introduces Dockerizing for onecc.
Regarding [#8232](https://github.com/Samsung/ONE/issues/8232) issue, we are going to do Dockerizing so that more users can easily use onecc.
I wrote onecc version selection code part for dockerizing with python and bash shell script. in the draft code for now.
However, if DraftCode is checked, we plan to first post an implementation code in PR with the latest version of onecc dockerizing as the default operation.

Related Issue : [#9712](https://github.com/Samsung/ONE/issues/9712)

## Work Flow
- If the selected version of onecc is pre-installed, the input onecc-cmd is executed. 
- And if the selected onecc version is not installed, check if there is a docker image of the selected version. 
   - If the selected version of onecc docker image is not present, the selected onecc docker image is built. 
   - The selected version of the onecc docker container is then run.


## How to test

I currently proceeded with Dockerizing in the following way.

### summary

1. Import TensorFlow Model for Dockerizing and write Configure File.
2. Write a Dockerfile to create a Docker image and run the container.
    - When `onecc` is finished running, the container is terminated and deleted.
3. Check that circle file and nnpackage have been created.



### Import Tensorflow model for testing

First, I created the path '/home/test/' for Linux (wsl) and downloaded the model file to test. After downloading [inception_v3](https://storage.googleapis.com/download.tensorflow.org/models/tflite/model_zoo/upload_20180427/inception_v3_2018_04_27.tgz), the Configure file was created.

```
# /home/test/
/home/test$ wget https://storage.googleapis.com/download.tensorflow.org/models/tflite/model_zoo/upload_20180427/inception_v3_2018_04_27.tgz

/home/test$ tar -xvf inception_v3_2018_04_27.tgz

/home/test$ vi onecc.template.cfg

/home/test$ tree
.
├── inception_v3.pb
├── inception_v3.tflite
├── inception_v3_2018_04_27.tgz
├── labels.txt
└── onecc.template.cfg
```

- onecc.template.cfg

    ```
    [onecc]
    one-import-tf=True
    one-import-tflite=False
    one-import-bcq=False
    one-import-onnx=False
    one-optimize=True
    one-quantize=False
    one-parition=False
    one-pack=True
    one-codegen=False
    
    [one-import-tf]
    input_path=inception_v3.pb
    output_path=inception_v3.circle
    input_arrays=input
    input_shapes=1,299,299,3
    output_arrays=InceptionV3/Predictions/Reshape_1
    converter_version=v1
    model_format=graph_def
    
    [one-optimize]
    input_path=inception_v3.circle
    output_path=inception_v3.opt.circle
    generate_profile_data=False
    
    [one-pack]
    input_path=inception_v3.opt.circle
    output_path=inception_v3_pack
    ```

### run onecc-docker.sh
```
$ cd ONE/compiler/onecc-docker/
$ bash ./onecc-docker.sh
``` 

   
### Execution Results 

This is my execution result. The circle file and nnpackage have been created well, and I don't think there is any problem with my method so far. 

Docker container was also successfully removed. 


- Test results
```
/home/test$ tree
.
├── inception_v3.circle
├── inception_v3.circle.log
├── inception_v3.opt.circle
├── inception_v3.opt.circle.log
├── inception_v3.pb
├── inception_v3.tflite
├── inception_v3_2018_04_27.tgz
├── inception_v3_pack
│   └── inception_v3.opt
│       ├── inception_v3.opt.circle
│       └── metadata
│           └── MANIFEST
├── inception_v3_pack.log
├── labels.txt
└── onecc.template.cfg

3 directories, 12 files
```
/cc [@Samsung/ootpg](https://github.com/orgs/Samsung/teams/ootpg)
Signed-off-by: seunghui-lee <hithere1012@naver.com>