### PR TITLE
[one-cmds-test] Rename output circle use for input

### DIFF
--- a/compiler/one-cmds/tests/one-import_neg_005.test
+++ b/compiler/one-cmds/tests/one-import_neg_005.test
@@ -33,10 +33,9 @@ trap_err_onexit()
 trap trap_err_onexit ERR
 
 inputfile="./inception_v3.pb"
-outputfile="./inception_v3.circle"
+outputfile="./inception_v3.imp_neg_005.circle"
 
-# do not remove output file
-# rm -rf ${outputfile}
+rm -rf ${outputfile}
 rm -rf ${filename}.log
 
 # run test

--- a/compiler/one-cmds/tests/one-import_neg_006.test
+++ b/compiler/one-cmds/tests/one-import_neg_006.test
@@ -33,10 +33,9 @@ trap_err_onexit()
 trap trap_err_onexit ERR
 
 inputfile="./inception_v3.pb"
-outputfile="./inception_v3.circle"
+outputfile="./inception_v3.imp_neg_006.circle"
 
-# do not remove output file
-# rm -rf ${outputfile}
+rm -rf ${outputfile}
 rm -rf ${filename}.log
 
 # run test

--- a/compiler/one-cmds/tests/one-import_neg_007.test
+++ b/compiler/one-cmds/tests/one-import_neg_007.test
@@ -33,10 +33,9 @@ trap_err_onexit()
 trap trap_err_onexit ERR
 
 inputfile="./inception_v3.pb"
-outputfile="./inception_v3.circle"
+outputfile="./inception_v3.imp_neg_007.circle"
 
-# do not remove output file
-# rm -rf ${outputfile}
+rm -rf ${outputfile}
 rm -rf ${filename}.log
 
 # run test

--- a/compiler/one-cmds/tests/one-import_neg_008.test
+++ b/compiler/one-cmds/tests/one-import_neg_008.test
@@ -33,10 +33,9 @@ trap_err_onexit()
 trap trap_err_onexit ERR
 
 inputfile="./inception_v3.pb"
-outputfile="./inception_v3.circle"
+outputfile="./inception_v3.imp_neg_008.circle"
 
-# do not remove output file
-# rm -rf ${outputfile}
+rm -rf ${outputfile}
 rm -rf ${filename}.log
 
 # run test

--- a/compiler/one-cmds/tests/one-import_neg_010.test
+++ b/compiler/one-cmds/tests/one-import_neg_010.test
@@ -33,10 +33,9 @@ trap_err_onexit()
 trap trap_err_onexit ERR
 
 inputfile="./inception_v3.pb"
-outputfile="./inception_v3.circle"
+outputfile="./inception_v3.imp_neg_010.circle"
 
-# do not remove output file
-# rm -rf ${outputfile}
+rm -rf ${outputfile}
 rm -rf ${filename}.log
 
 # run test

--- a/compiler/one-cmds/tests/onecc_001.cfg
+++ b/compiler/one-cmds/tests/onecc_001.cfg
@@ -9,12 +9,12 @@ one-codegen=False
 
 [one-import-tf]
 input_path=inception_v3.pb
-output_path=inception_v3.circle
+output_path=inception_v3.onecc_001.circle
 input_arrays=input
 input_shapes=1,299,299,3
 output_arrays=InceptionV3/Predictions/Reshape_1
 converter_version=v2
 
 [one-optimize]
-input_path=inception_v3.circle
+input_path=inception_v3.onecc_001.circle
 output_path=inception_v3.opt.circle

--- a/compiler/one-cmds/tests/onecc_002.cfg
+++ b/compiler/one-cmds/tests/onecc_002.cfg
@@ -9,14 +9,14 @@ one-codegen=False
 
 [one-import-tf]
 input_path=inception_v3.pb
-output_path=inception_v3.circle
+output_path=inception_v3.onecc_002.circle
 input_arrays=input
 input_shapes=1,299,299,3
 output_arrays=InceptionV3/Predictions/Reshape_1
 converter_version=v2
 
 [one-optimize]
-input_path=inception_v3.circle
+input_path=inception_v3.onecc_002.circle
 output_path=inception_v3.opt.circle
 
 [one-pack]

--- a/compiler/one-cmds/tests/onecc_003.cfg
+++ b/compiler/one-cmds/tests/onecc_003.cfg
@@ -9,13 +9,13 @@ one-codegen=False
 
 [one-import-tf]
 input_path=inception_v3.pb
-output_path=inception_v3.circle
+output_path=inception_v3.onecc_003.circle
 input_arrays=input
 input_shapes=1,299,299,3
 output_arrays=InceptionV3/Predictions/Reshape_1
 converter_version=v1
 
 [one-quantize]
-input_path=inception_v3.circle
+input_path=inception_v3.onecc_003.circle
 output_path=inception_v3.quantized.circle
 input_data=inception_v3_test_data.h5

--- a/compiler/one-cmds/tests/onecc_004.cfg
+++ b/compiler/one-cmds/tests/onecc_004.cfg
@@ -9,7 +9,7 @@ one-codegen=True
 
 [one-import-tf]
 input_path=inception_v3.pb
-output_path=inception_v3.circle
+output_path=inception_v3.onecc_004.circle
 input_arrays=input
 input_shapes=1,299,299,3
 output_arrays=InceptionV3/Predictions/Reshape_1
@@ -17,4 +17,4 @@ converter_version=v1
 
 [one-codegen]
 backend=dummy
-command=-o sample.tvn inception_v3.circle
+command=-o sample.tvn inception_v3.onecc_004.circle

--- a/compiler/one-cmds/tests/onecc_005.cfg
+++ b/compiler/one-cmds/tests/onecc_005.cfg
@@ -9,10 +9,10 @@ one-codegen=True
 
 [one-import-tflite]
 input_path=inception_v3.tflite
-output_path=inception_v3.circle
+output_path=inception_v3.onecc_005.circle
 
 [one-optimize]
-input_path=inception_v3.circle
+input_path=inception_v3.onecc_005.circle
 output_path=inception_v3.opt.circle
 
 [one-codegen]

--- a/compiler/one-cmds/tests/onecc_006.cfg
+++ b/compiler/one-cmds/tests/onecc_006.cfg
@@ -9,14 +9,14 @@ one-codegen=True
 
 [one-import-tf]
 input_path=inception_v3.pb
-output_path=inception_v3.circle
+output_path=inception_v3.onecc_006.circle
 input_arrays=input
 input_shapes=1,299,299,3
 output_arrays=InceptionV3/Predictions/Reshape_1
 converter_version=v1
 
 [one-optimize]
-input_path=inception_v3.circle
+input_path=inception_v3.onecc_006.circle
 output_path=inception_v3.opt.circle
 
 [one-quantize]

--- a/compiler/one-cmds/tests/onecc_007.cfg
+++ b/compiler/one-cmds/tests/onecc_007.cfg
@@ -9,14 +9,14 @@ one-codegen=False
 
 [one-import-tf]
 input_path=inception_v3.pb
-output_path=inception_v3.circle
+output_path=inception_v3.onecc_007.circle
 input_arrays=input
 input_shapes=1,299,299,3
 output_arrays=InceptionV3/Predictions/Reshape_1
 converter_version=v1
 
 [one-optimize]
-input_path=inception_v3.circle
+input_path=inception_v3.onecc_007.circle
 output_path=inception_v3.opt.circle
 
 [one-quantize]

--- a/compiler/one-cmds/tests/onecc_012.cfg
+++ b/compiler/one-cmds/tests/onecc_012.cfg
@@ -9,14 +9,14 @@ one-codegen=False
 
 [one-import-tf]
 input_path=inception_v3.pb
-output_path=inception_v3.circle
+output_path=inception_v3.onecc_012.circle
 input_arrays=input
 input_shapes=1,299,299,3
 output_arrays=InceptionV3/Predictions/Reshape_1
 converter_version=v1
 
 [one-quantize]
-input_path=inception_v3.circle
+input_path=inception_v3.onecc_012.circle
 output_path=inception_v3.list.quantized.circle
 input_data=datalist.txt
 input_data_format=list

--- a/compiler/one-cmds/tests/onecc_024.cfg
+++ b/compiler/one-cmds/tests/onecc_024.cfg
@@ -10,13 +10,13 @@ one-codegen=False
 
 [one-import-tf]
 input_path=inception_v3.pb
-output_path=inception_v3.circle
+output_path=inception_v3.onecc_024.circle
 input_arrays=input
 input_shapes=1,299,299,3
 output_arrays=InceptionV3/Predictions/Reshape_1
 converter_version=v1
 
 [one-optimize]
-input_path=inception_v3.circle
+input_path=inception_v3.onecc_024.circle
 output_path=inception_v3.opt.circle
 make_batchnorm_gamma_positive=False

--- a/compiler/one-cmds/tests/onecc_025.cfg
+++ b/compiler/one-cmds/tests/onecc_025.cfg
@@ -9,12 +9,12 @@ one-codegen=False
 
 [one-import-tf]
 input_path=inception_v3.pb
-output_path=inception_v3.circle
+output_path=inception_v3.onecc_025.circle
 input_arrays=input
 input_shapes=1,299,299,3
 output_arrays=InceptionV3/Predictions/Reshape_1
 converter_version=v2
 
 [one-optimize]
-input_path=inception_v3.circle
+input_path=inception_v3.onecc_025.circle
 output_path=inception_v3.opt.circle

--- a/compiler/one-cmds/tests/onecc_028.workflow.json
+++ b/compiler/one-cmds/tests/onecc_028.workflow.json
@@ -12,7 +12,7 @@
             "one-cmd": "one-import-tf",
             "commands": {
                 "input_path": "inception_v3.pb",
-                "output_path": "inception_v3.circle",
+                "output_path": "inception_v3.onecc_028.circle",
                 "input_arrays": "input",
                 "input_shapes": "1,299,299,3",
                 "output_arrays": "InceptionV3/Predictions/Reshape_1",
@@ -22,7 +22,7 @@
         "OPTIMIZE": {
             "one-cmd": "one-optimize",
             "commands": {
-                "input_path": "inception_v3.circle",
+                "input_path": "inception_v3.onecc_028.circle",
                 "output_path": "inception_v3.opt.circle"
             }
         },

--- a/compiler/one-cmds/tests/onecc_029.workflow.json
+++ b/compiler/one-cmds/tests/onecc_029.workflow.json
@@ -11,7 +11,7 @@
             "one-cmd": "one-import-tf",
             "commands": {
                 "input_path": "inception_v3.pb",
-                "output_path": "inception_v3.circle",
+                "output_path": "inception_v3.onecc_029.circle",
                 "input_arrays": "input",
                 "input_shapes": "1,299,299,3",
                 "output_arrays": "InceptionV3/Predictions/Reshape_1",
@@ -21,7 +21,7 @@
         "QUANTIZE": {
             "one-cmd": "one-quantize",
             "commands": {
-                "input_path": "inception_v3.circle",
+                "input_path": "inception_v3.onecc_029.circle",
                 "output_path": "inception_v3.quantized.circle",
                 "input_data": "inception_v3_test_data.h5"
             }

--- a/compiler/one-cmds/tests/onecc_030.workflow.json
+++ b/compiler/one-cmds/tests/onecc_030.workflow.json
@@ -11,7 +11,7 @@
             "one-cmd": "one-import-tf",
             "commands": {
                 "input_path": "inception_v3.pb",
-                "output_path": "inception_v3.circle",
+                "output_path": "inception_v3.onecc_030.circle",
                 "input_arrays": "input",
                 "input_shapes": "1,299,299,3",
                 "output_arrays": "InceptionV3/Predictions/Reshape_1",
@@ -22,7 +22,7 @@
             "one-cmd": "one-codegen",
             "commands": {
                 "backend": "dummy",
-                "command": "-o sample.tvn inception_v3.circle"
+                "command": "-o sample.tvn inception_v3.onecc_030.circle"
             }
         }
     }

--- a/compiler/one-cmds/tests/onecc_031.workflow.json
+++ b/compiler/one-cmds/tests/onecc_031.workflow.json
@@ -12,13 +12,13 @@
             "one-cmd": "one-import-tflite",
             "commands": {
                 "input_path": "inception_v3.tflite",
-                "output_path": "inception_v3.circle"
+                "output_path": "inception_v3.onecc_031.circle"
             }
         },
         "optimize": {
             "one-cmd": "one-optimize",
             "commands": {
-                "input_path": "inception_v3.circle",
+                "input_path": "inception_v3.onecc_031.circle",
                 "output_path": "inception_v3.opt.circle"
             }
         },

--- a/compiler/one-cmds/tests/onecc_032.workflow.json
+++ b/compiler/one-cmds/tests/onecc_032.workflow.json
@@ -13,20 +13,20 @@
             "one-cmd": "one-import-tflite",
             "commands": {
                 "input_path": "inception_v3.tflite",
-                "output_path": "inception_v3.circle"
+                "output_path": "inception_v3.onecc_032.circle"
             }
         },
         "optimize": {
             "one-cmd": "one-optimize",
             "commands": {
-                "input_path": "inception_v3.circle",
+                "input_path": "inception_v3.onecc_032.circle",
                 "output_path": "inception_v3.opt.circle"
             }
         },
         "quantize": {
             "one-cmd": "one-quantize",
             "commands": {
-                "input_path": "inception_v3.circle",
+                "input_path": "inception_v3.onecc_032.circle",
                 "output_path": "inception_v3.quantized.circle",
                 "input_data": "inception_v3_test_data.h5"
             }

--- a/compiler/one-cmds/tests/onecc_033.workflow.json
+++ b/compiler/one-cmds/tests/onecc_033.workflow.json
@@ -13,20 +13,20 @@
             "one-cmd": "one-import-tflite",
             "commands": {
                 "input_path": "inception_v3.tflite",
-                "output_path": "inception_v3.circle"
+                "output_path": "inception_v3.onecc_033.circle"
             }
         },
         "optimize": {
             "one-cmd": "one-optimize",
             "commands": {
-                "input_path": "inception_v3.circle",
+                "input_path": "inception_v3.onecc_033.circle",
                 "output_path": "inception_v3.opt.circle"
             }
         },
         "quantize": {
             "one-cmd": "one-quantize",
             "commands": {
-                "input_path": "inception_v3.circle",
+                "input_path": "inception_v3.onecc_033.circle",
                 "output_path": "inception_v3.quantized.circle",
                 "input_data": "inception_v3_test_data.h5"
             }

--- a/compiler/one-cmds/tests/onecc_037.workflow.json
+++ b/compiler/one-cmds/tests/onecc_037.workflow.json
@@ -11,7 +11,7 @@
             "one-cmd": "one-import-tf",
             "commands": {
                 "input_path": "inception_v3.pb",
-                "output_path": "inception_v3.circle",
+                "output_path": "inception_v3.onecc_037.circle",
                 "input_arrays": "input",
                 "input_shapes": "1,299,299,3",
                 "output_arrays": "InceptionV3/Predictions/Reshape_1",
@@ -21,7 +21,7 @@
         "OPTIMIZE": {
             "one-cmd": "one-optimize",
             "commands": {
-                "input_path": "inception_v3.circle",
+                "input_path": "inception_v3.onecc_037.circle",
                 "output_path": "inception_v3.opt.circle"
             }
         }

--- a/compiler/one-cmds/tests/onecc_038.workflow.json
+++ b/compiler/one-cmds/tests/onecc_038.workflow.json
@@ -11,7 +11,7 @@
             "one-cmd": "one-import-tf",
             "commands": {
                 "input_path": "inception_v3.pb",
-                "output_path": "inception_v3.circle",
+                "output_path": "inception_v3.onecc_038.circle",
                 "input_arrays": "input",
                 "input_shapes": "1,299,299,3",
                 "output_arrays": "InceptionV3/Predictions/Reshape_1",
@@ -21,7 +21,7 @@
         "QUANTIZE": {
             "one-cmd": "one-quantize",
             "commands": {
-                "input_path": "inception_v3.circle",
+                "input_path": "inception_v3.onecc_038.circle",
                 "output_path": "inception_v3.list.quantized.circle",
                 "input_data": "datalist.txt",
                 "input_data_format": "list"

--- a/compiler/one-cmds/tests/onecc_040.cfg
+++ b/compiler/one-cmds/tests/onecc_040.cfg
@@ -9,12 +9,12 @@ one-codegen=False
 
 [one-import-tf]
 input_path=inception_v3.pb
-output_path=inception_v3.circle
+output_path=inception_v3.onecc_040.circle
 input_arrays=input
 input_shapes=1,299,299,3
 output_arrays=InceptionV3/Predictions/Reshape_1
 converter_version=v2
 
 [one-optimize]
-input_path=inception_v3.circle
+input_path=inception_v3.onecc_040.circle
 output_path=inception_v3.opt.circle

--- a/compiler/one-cmds/tests/onecc_041.workflow.json
+++ b/compiler/one-cmds/tests/onecc_041.workflow.json
@@ -42,7 +42,7 @@
             "one-cmd": "one-import-tf",
             "commands": {
                 "input_path": "inception_v3.pb",
-                "output_path": "inception_v3.circle",
+                "output_path": "inception_v3.onecc_041.circle",
                 "input_arrays": "input",
                 "input_shapes": "1,299,299,3",
                 "output_arrays": "InceptionV3/Predictions/Reshape_1",
@@ -52,7 +52,7 @@
         "OPTIMIZE": {
             "one-cmd": "one-optimize",
             "commands": {
-                "input_path": "inception_v3.circle",
+                "input_path": "inception_v3.onecc_041.circle",
                 "output_path": "inception_v3.opt.circle"
             }
         }

--- a/compiler/one-cmds/tests/onecc_neg_002.cfg
+++ b/compiler/one-cmds/tests/onecc_neg_002.cfg
@@ -9,12 +9,12 @@ one-codegen=False
 
 [one-import-tf]
 input_path=inception_v3.pb
-output_path=inception_v3.circle
+output_path=inception_v3.onecc_neg_002.circle
 input_arrays=input
 input_shapes=1,299,299,3
 output_arrays=InceptionV3/Predictions/Reshape_1
 converter_version=v2
 
 [one-optimize]
-input_path=inception_v3.circle
+input_path=inception_v3.onecc_neg_002.circle
 output_path=inception_v3.opt.circle

--- a/compiler/one-cmds/tests/onecc_neg_003.cfg
+++ b/compiler/one-cmds/tests/onecc_neg_003.cfg
@@ -1,13 +1,13 @@
 [one-import-tf]
 input_path=inception_v3.pb
-output_path=inception_v3.circle
+output_path=inception_v3.onecc_neg_003.circle
 input_arrays=input
 input_shapes=1,299,299,3
 output_arrays=InceptionV3/Predictions/Reshape_1
 converter_version=v2
 
 [one-optimize]
-input_path=inception_v3.circle
+input_path=inception_v3.onecc_neg_003.circle
 output_path=inception_v3.opt.circle
 
 [one-pack]

--- a/compiler/one-cmds/tests/onecc_neg_004.cfg
+++ b/compiler/one-cmds/tests/onecc_neg_004.cfg
@@ -9,14 +9,14 @@ one-codegen=False
 
 [one-import-tf]
 input_path=inception_v3.pb
-output_path=inception_v3.circle
+output_path=inception_v3.onecc_neg_004.circle
 input_arrays=input
 input_shapes=1,299,299,3
 output_arrays=InceptionV3/Predictions/Reshape_1
 converter_version=v2
 
 [one-optimize]
-input_path=inception_v3.circle
+input_path=inception_v3.onecc_neg_004.circle
 output_path=inception_v3.opt.circle
 
 [one-optimize]

--- a/compiler/one-cmds/tests/onecc_neg_018.workflow.json
+++ b/compiler/one-cmds/tests/onecc_neg_018.workflow.json
@@ -13,7 +13,7 @@
             "one-cmd": "one-import-tf",
             "commands": {
                 "input_path": "inception_v3.pb",
-                "output_path": "inception_v3.circle",
+                "output_path": "inception_v3.onecc_neg_018.circle",
                 "input_arrays": "input",
                 "input_shapes": "1,299,299,3",
                 "output_arrays": "InceptionV3/Predictions/Reshape_1",

--- a/compiler/one-cmds/tests/onecc_neg_019.workflow.json
+++ b/compiler/one-cmds/tests/onecc_neg_019.workflow.json
@@ -10,7 +10,7 @@
             "one-cmddddddddd": "one-import-tf",
             "commands": {
                 "input_path": "inception_v3.pb",
-                "output_path": "inception_v3.circle",
+                "output_path": "inception_v3.onecc_neg_019.circle",
                 "input_arrays": "input",
                 "input_shapes": "1,299,299,3",
                 "output_arrays": "InceptionV3/Predictions/Reshape_1",

--- a/compiler/one-cmds/tests/onecc_neg_020.workflow.json
+++ b/compiler/one-cmds/tests/onecc_neg_020.workflow.json
@@ -10,7 +10,7 @@
             "one-cmd": "one-import-tf",
             "commandssssssssss": {
                 "input_path": "inception_v3.pb",
-                "output_path": "inception_v3.circle",
+                "output_path": "inception_v3.onecc_neg_020.circle",
                 "input_arrays": "input",
                 "input_shapes": "1,299,299,3",
                 "output_arrays": "InceptionV3/Predictions/Reshape_1",

--- a/compiler/one-cmds/tests/onecc_neg_021.workflow.json
+++ b/compiler/one-cmds/tests/onecc_neg_021.workflow.json
@@ -14,7 +14,7 @@
             "one-cmd": "one-import-tf",
             "commands": {
                 "input_path": "inception_v3.pb",
-                "output_path": "inception_v3.circle",
+                "output_path": "inception_v3.onecc_neg_021.circle",
                 "input_arrays": "input",
                 "input_shapes": "1,299,299,3",
                 "output_arrays": "InceptionV3/Predictions/Reshape_1",
@@ -33,7 +33,7 @@
             "one-cmd": "one-import-tf",
             "commands": {
                 "input_path": "inception_v3.pb",
-                "output_path": "inception_v3.circle",
+                "output_path": "inception_v3.onecc_neg_021.circle",
                 "input_arrays": "input",
                 "input_shapes": "1,299,299,3",
                 "output_arrays": "InceptionV3/Predictions/Reshape_1",

--- a/compiler/one-cmds/tests/onecc_neg_022.workflow.json
+++ b/compiler/one-cmds/tests/onecc_neg_022.workflow.json
@@ -45,7 +45,7 @@
             "one-cmd": "one-import-tf",
             "commands": {
                 "input_path": "inception_v3.pb",
-                "output_path": "inception_v3.circle",
+                "output_path": "inception_v3.onecc_neg_022.circle",
                 "input_arrays": "input",
                 "input_shapes": "1,299,299,3",
                 "output_arrays": "InceptionV3/Predictions/Reshape_1",
@@ -55,7 +55,7 @@
         "OPTIMIZE": {
             "one-cmd": "one-optimize",
             "commands": {
-                "input_path": "inception_v3.circle",
+                "input_path": "inception_v3.onecc_neg_022.circle",
                 "output_path": "inception_v3.opt.circle"
             }
         }

--- a/compiler/one-cmds/tests/onecc_neg_023.workflow.json
+++ b/compiler/one-cmds/tests/onecc_neg_023.workflow.json
@@ -11,7 +11,7 @@
             "one-cmd": "one-import-tf",
             "commands": {
                 "input_path": "inception_v3.pb",
-                "output_path": "inception_v3.circle",
+                "output_path": "inception_v3.onecc_neg_023.circle",
                 "input_arrays": "input",
                 "input_shapes": "1,299,299,3",
                 "output_arrays": "InceptionV3/Predictions/Reshape_1",
@@ -21,7 +21,7 @@
         "OPTIMIZE": {
             "one-cmd": "one-optimize",
             "commands": {
-                "input_path": "inception_v3.circle",
+                "input_path": "inception_v3.onecc_neg_023.circle",
                 "output_path": "inception_v3.opt.circle",
                 "change_outputs": "non_existing_node_name"
             }


### PR DESCRIPTION
This will rename output circle name that is used as input for other tests.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>