### PR TITLE
[luci-micro] Remove arser and foder from GenerateKernelsListHelper

### DIFF
--- a/compiler/luci-micro/CMakeLists.txt
+++ b/compiler/luci-micro/CMakeLists.txt
@@ -63,8 +63,7 @@ if (GENERATE_KERNELS_LIST_FROM)
   endif(NOT TARGET mio_circle04)
 
   add_executable(generator_kernels_list_exec helpers/GenerateKernelsListHelper.cpp)
-  target_link_libraries(generator_kernels_list_exec arser)
-  target_link_libraries(generator_kernels_list_exec foder)
+  # TODO: remove mio_circle04 dependency
   target_link_libraries(generator_kernels_list_exec mio_circle04)
   target_link_libraries(generator_kernels_list_exec mio_circle04_helper)
 
@@ -78,7 +77,7 @@ if (GENERATE_KERNELS_LIST_FROM)
 endif()
 
 # To remove GENERATE_KERNELS_LIST_FROM variable from cmake cache
-set(GENERATE_KERNELS_LIST_FROM "" CACHE STRING "" FORCE)
+unset(GENERATE_KERNELS_LIST_FROM CACHE)
 
 set(MICRO_ARM_BINARY "${MICRO_ARM_BUILD_DIR}/compiler/luci-micro/luci-interpreter/src/libluci_interpreter.a")
 

--- a/compiler/luci-micro/helpers/GenerateKernelsListHelper.cpp
+++ b/compiler/luci-micro/helpers/GenerateKernelsListHelper.cpp
@@ -216,9 +216,6 @@ int main(int argc, char **argv)
   std::string model_file(argv[1]);
   std::string generated_file_path(argv[2]);
 
-  std::cout << "model: " << model_file << std::endl;
-  std::cout << "file: " << generated_file_path << std::endl;
-
   std::vector<char> model_data = loadFile(model_file);
   const circle::Model *circle_model = circle::GetModel(model_data.data());
 


### PR DESCRIPTION
This PR removes arser and foder dependencies from GenerateKernelsListHelper, also makes small refactors.

according to https://github.com/Samsung/ONE/pull/9702#pullrequestreview-1110506802

Note: mio_circle04 dependency will be removed in separate PR

ONE-DCO-1.0-Signed-off-by: Artem Balyshev a.balyshev@partner.samsung.com