### PR TITLE
[onert] Change Executors::at() return type

### DIFF
--- a/runtime/onert/core/include/exec/Execution.h
+++ b/runtime/onert/core/include/exec/Execution.h
@@ -243,11 +243,8 @@ public:
   void sholudStop();
 
 private:
-  const std::unique_ptr<IExecutor> &primary_executor() const
-  {
-    return _executors->at(ir::SubgraphIndex{0});
-  };
-  std::unique_ptr<IExecutor> &primary_executor() { return _executors->at(ir::SubgraphIndex{0}); };
+  const IExecutor *primary_executor() const { return _executors->at(ir::SubgraphIndex{0}); };
+  IExecutor *primary_executor() { return _executors->at(ir::SubgraphIndex{0}); };
 
 private:
   const std::shared_ptr<Executors> _executors;

--- a/runtime/onert/core/include/exec/Executors.h
+++ b/runtime/onert/core/include/exec/Executors.h
@@ -42,7 +42,7 @@ public:
     _executors.emplace(idx, std::move(exec));
   }
 
-  std::unique_ptr<IExecutor> &at(ir::SubgraphIndex idx) { return _executors.at(idx); }
+  IExecutor *at(ir::SubgraphIndex idx) const { return _executors.at(idx).get(); }
 
   uint32_t inputSize() const;
 

--- a/runtime/onert/core/include/exec/IExecutor.h
+++ b/runtime/onert/core/include/exec/IExecutor.h
@@ -66,14 +66,14 @@ struct IExecutor
    *
    * @return Graph object
    */
-  virtual const ir::Graph &graph() = 0;
+  virtual const ir::Graph &graph() const = 0;
 
   /**
    * @brief Returns parent graph object
    *
    * @return Graph object
    */
-  virtual const ir::Graph &parent_graph() = 0;
+  virtual const ir::Graph &parent_graph() const = 0;
 
   /**
    * @brief     Set an ordering on operations

--- a/runtime/onert/core/src/backend/builtin/kernel/IfLayer.cc
+++ b/runtime/onert/core/src/backend/builtin/kernel/IfLayer.cc
@@ -61,12 +61,12 @@ void IfLayer::run()
   if (cond_result)
   {
     VERBOSE(If) << "Call to $" << _then_subg_index << " (then)" << std::endl;
-    subg_exec = _executors->at(_then_subg_index).get();
+    subg_exec = _executors->at(_then_subg_index);
   }
   else
   {
     VERBOSE(If) << "Call to $" << _else_subg_index << " (else)" << std::endl;
-    subg_exec = _executors->at(_else_subg_index).get();
+    subg_exec = _executors->at(_else_subg_index);
   }
 
   subg_exec->execute(_input_tensors, _output_tensors);

--- a/runtime/onert/core/src/backend/builtin/kernel/WhileLayer.cc
+++ b/runtime/onert/core/src/backend/builtin/kernel/WhileLayer.cc
@@ -57,8 +57,8 @@ void WhileLayer::run()
   // // Run cond subg
   // If there is no loop copy "_input_tensors" -> "_dst_tensors", else copy "cond subg inputs" ->
   // "_dst_tensors"
-  auto cond_exec = _executors->at(_cond_subg_index).get();
-  auto body_exec = _executors->at(_body_subg_index).get();
+  auto cond_exec = _executors->at(_cond_subg_index);
+  auto body_exec = _executors->at(_body_subg_index);
 
   // Need a temp tensor to hold the cond subgraph output
   assert(cond_exec->getOutputTensors().size() == 1);

--- a/runtime/onert/core/src/exec/ExecutorBase.h
+++ b/runtime/onert/core/src/exec/ExecutorBase.h
@@ -51,9 +51,9 @@ public:
 
   virtual ~ExecutorBase() = default;
 
-  const ir::Graph &graph() final { return _graph; }
+  const ir::Graph &graph() const final { return _graph; }
 
-  const ir::Graph &parent_graph() final { return _parent_graph; }
+  const ir::Graph &parent_graph() const final { return _parent_graph; }
 
   void execute(const IODescription &desc) final;
 

--- a/runtime/onert/core/src/interp/InterpExecutor.h
+++ b/runtime/onert/core/src/interp/InterpExecutor.h
@@ -49,9 +49,9 @@ public:
    * @brief   Return graph object
    * @return  Graph object
    */
-  const ir::Graph &graph() final { return _graph; }
+  const ir::Graph &graph() const final { return _graph; }
 
-  const ir::Graph &parent_graph() final
+  const ir::Graph &parent_graph() const final
   {
     throw new std::runtime_error{"Interpreter does not support this function."};
   }


### PR DESCRIPTION
This commit changes Executors::at() return type to simplify usage and avoid missreading about ownership.

This commit includes additional const keyword to resolve compile issue.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: #9716