### PR TITLE
[onecc-docker] Add test directory

### DIFF
--- a/compiler/onecc-docker/CMakeLists.txt
+++ b/compiler/onecc-docker/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(tests)

--- a/compiler/onecc-docker/tests/CMakeLists.txt
+++ b/compiler/onecc-docker/tests/CMakeLists.txt
@@ -1,0 +1,67 @@
+# Install onecc-docker test scripts
+
+# Gather test scripts
+file(GLOB TESTITEMS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "./*.test")
+file(GLOB CONFIGITEMS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "./*.cfg")
+
+# Create a script to run the tests at installation folder
+set(DRIVER_SCRIPT "${CMAKE_CURRENT_BINARY_DIR}/runtestall.sh")
+
+file(WRITE  "${DRIVER_SCRIPT}" "#!/bin/bash\n\n")
+file(APPEND "${DRIVER_SCRIPT}" "SCRIPT_PATH=$(cd $(dirname $\{BASH_SOURCE\[0\]\}) && pwd)\n")
+file(APPEND "${DRIVER_SCRIPT}" "pushd $SCRIPT_PATH > /dev/null\n")
+file(APPEND "${DRIVER_SCRIPT}" "rm -rf runtestall.log\n")
+file(APPEND "${DRIVER_SCRIPT}" "export PATH=$SCRIPT_PATH/../bin:$PATH\n")
+file(APPEND "${DRIVER_SCRIPT}" "if [[ $# -ge 1 ]]; then\n")
+file(APPEND "${DRIVER_SCRIPT}" "  USER_PATH=$1\n")
+file(APPEND "${DRIVER_SCRIPT}" "  export PATH=$USER_PATH:$PATH\n")
+file(APPEND "${DRIVER_SCRIPT}" "fi\n")
+file(APPEND "${DRIVER_SCRIPT}" "\n")
+file(APPEND "${DRIVER_SCRIPT}" "# refer https://github.com/Samsung/ONE/issues/6286\n")
+file(APPEND "${DRIVER_SCRIPT}" "set -o pipefail\n\n")
+file(APPEND "${DRIVER_SCRIPT}" "fail_count=0\n")
+file(APPEND "${DRIVER_SCRIPT}" "trap \"(( fail_count++ ))\" ERR\n\n")
+
+foreach(TESTITEM IN ITEMS ${TESTITEMS})
+  get_filename_component(ITEM_PREFIX ${TESTITEM} NAME_WE)
+
+  set(TESTITEM_SCRIPT_FILE "${ITEM_PREFIX}.test")
+  set(TESTITEM_SCRIPT_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/${TESTITEM_SCRIPT_FILE}")
+
+  file(APPEND "${DRIVER_SCRIPT}" "/bin/bash ${TESTITEM_SCRIPT_FILE} | tee -a runtestall.log\n")
+
+  install(FILES ${TESTITEM} DESTINATION test)
+endforeach(TESTITEM)
+
+foreach(CONFIGITEM IN ITEMS ${CONFIGITEMS})
+  get_filename_component(ITEM_PREFIX ${CONFIGITEM} NAME_WE)
+  install(FILES ${CONFIGITEM} DESTINATION test)
+endforeach(CONFIGITEM)
+
+file(APPEND "${DRIVER_SCRIPT}" "popd > /dev/null\n\n")
+
+file(APPEND "${DRIVER_SCRIPT}"
+"if [[ $fail_count != 0 ]]; then
+  echo \"$fail_count TESTS FAILED\"
+  exit 255
+else
+  echo \"ALL TESTS PASSED!\"
+fi\n
+")
+
+set(PREPARE_TEST_MATERIALS_SH "${CMAKE_CURRENT_SOURCE_DIR}/prepare_test_materials.sh")
+
+install(FILES ${DRIVER_SCRIPT}
+        PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE
+                    GROUP_READ GROUP_EXECUTE
+                    WORLD_READ WORLD_EXECUTE
+        DESTINATION test)
+
+install(FILES ${PREPARE_TEST_MATERIALS_SH}
+        PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE
+                    GROUP_READ GROUP_EXECUTE
+                    WORLD_READ WORLD_EXECUTE
+        DESTINATION test)
+
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/README.txt
+        DESTINATION test)

--- a/compiler/onecc-docker/tests/README.txt
+++ b/compiler/onecc-docker/tests/README.txt
@@ -1,0 +1,19 @@
+# onecc-docker test
+
+## How to
+
+Run `runinstall.sh` script to test onecc-docker command line tool.
+
+### Preparation
+
+Run `prepare_test_materials.sh` script to download test models into test directory.
+
+```
+test$ bash prepare_test_materials.sh
+```
+
+### Run test
+
+```
+test$ bash runtestall.sh
+```

--- a/compiler/onecc-docker/tests/prepare_test_materials.sh
+++ b/compiler/onecc-docker/tests/prepare_test_materials.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# See https://github.com/Samsung/ONE/issues/4155 for information
+
+SCRIPT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+pushd $SCRIPT_PATH > /dev/null
+
+if [[ ! -s "inception_v3.pb" ]]; then
+    rm -rf inception_v3_2018_04_27.tgz
+    wget https://storage.googleapis.com/download.tensorflow.org/models/tflite/model_zoo/upload_20180427/inception_v3_2018_04_27.tgz
+    tar zxvf inception_v3_2018_04_27.tgz
+fi
+
+popd > /dev/null


### PR DESCRIPTION
This commit adds test directory.
The test directory helps to test `onecc-docker` command line tool by installing prepare_test_materials.sh script and generating runtestall.sh script automatically.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>