### PR TITLE
[onert] Introduce ExecutorIndex

### DIFF
--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -608,10 +608,11 @@ std::shared_ptr<CompilerArtifact> Compiler::compile(void)
    *  Backend independent analysis & optimization phase finished
    *************************************************************/
   auto executors = std::make_shared<exec::Executors>(std::move(model_edges));
-  for (auto &pair : lowered_subgs)
+  // Executor generation requires ordering
+  for (uint32_t i = 0; i < lowered_subgs.size(); i++)
   {
-    const auto &subg_index = pair.first;
-    auto &lowered_subg = pair.second;
+    auto const subg_index = ir::SubgraphIndex{i};
+    auto &lowered_subg = lowered_subgs.at(subg_index);
     auto indexed_ranks = lowered_subg->indexed_ranks();
 
     ir::OperationDumper dumper("Executor generation of Subgraph " +

--- a/runtime/onert/core/src/exec/Executors.cc
+++ b/runtime/onert/core/src/exec/Executors.cc
@@ -21,16 +21,39 @@ namespace onert
 namespace exec
 {
 
+void Executors::emplace(const ir::SubgraphIndex &idx, std::unique_ptr<IExecutor> exec)
+{
+  const auto index = generateIndex();
+  if (!index.valid())
+    return;
+
+  _executors.emplace(index, std::move(exec));
+  _index_map.emplace(index, idx);
+}
+
+IExecutor *Executors::at(const ir::SubgraphIndex &idx) const
+{
+  // Find index
+  // TODO Find better way for fast search
+  for (auto pair : _index_map)
+  {
+    if (idx == pair.second)
+      return at(pair.first);
+  }
+
+  return nullptr;
+}
+
 uint32_t Executors::inputSize() const
 {
   return _model_edges ? _model_edges->pkg_inputs.size()
-                      : _executors.at(ir::SubgraphIndex{0})->graph().getInputs().size();
+                      : _executors.at(ExecutorIndex{0})->graph().getInputs().size();
 }
 
 uint32_t Executors::outputSize() const
 {
   return _model_edges ? _model_edges->pkg_outputs.size()
-                      : _executors.at(ir::SubgraphIndex{0})->graph().getOutputs().size();
+                      : _executors.at(ExecutorIndex{0})->graph().getOutputs().size();
 }
 
 const ir::OperandInfo Executors::inputInfo(const ir::IOIndex &index)
@@ -41,13 +64,13 @@ const ir::OperandInfo Executors::inputInfo(const ir::IOIndex &index)
     // TODO handle general case
     const auto desc = _model_edges->pkg_inputs[index.value()];
     const auto model_idx = std::get<0>(desc);
-    const auto executor_idx = ir::SubgraphIndex{model_idx.value()};
+    const auto executor_idx = ExecutorIndex{model_idx.value()};
     const auto input_index = _executors.at(executor_idx)->graph().getInputs().at(std::get<2>(desc));
     return _executors.at(executor_idx)->graph().operands().at(input_index).info();
   }
 
-  const auto input_index = _executors.at(ir::SubgraphIndex{0})->graph().getInputs().at(index);
-  return _executors.at(ir::SubgraphIndex{0})->graph().operands().at(input_index).info();
+  const auto input_index = _executors.at(ExecutorIndex{0})->graph().getInputs().at(index);
+  return _executors.at(ExecutorIndex{0})->graph().operands().at(input_index).info();
 }
 
 const ir::OperandInfo Executors::outputInfo(const ir::IOIndex &index)
@@ -58,13 +81,13 @@ const ir::OperandInfo Executors::outputInfo(const ir::IOIndex &index)
     // TODO handle general case
     auto desc = _model_edges->pkg_outputs[index.value()];
     auto model_idx = std::get<0>(desc);
-    auto executor_idx = ir::SubgraphIndex{model_idx.value()};
+    auto executor_idx = ExecutorIndex{model_idx.value()};
     auto output_index = _executors.at(executor_idx)->graph().getOutputs().at(std::get<2>(desc));
     return _executors.at(executor_idx)->graph().operands().at(output_index).info();
   }
 
-  auto output_index = _executors.at(ir::SubgraphIndex{0})->graph().getOutputs().at(index);
-  return _executors.at(ir::SubgraphIndex{0})->graph().operands().at(output_index).info();
+  auto output_index = _executors.at(ExecutorIndex{0})->graph().getOutputs().at(index);
+  return _executors.at(ExecutorIndex{0})->graph().operands().at(output_index).info();
 }
 
 void Executors::execute(const IODescription &desc)
@@ -72,7 +95,7 @@ void Executors::execute(const IODescription &desc)
   if (_model_edges)
     return executeEntries(desc);
 
-  _executors.at(ir::SubgraphIndex{0})->execute(desc);
+  _executors.at(ExecutorIndex{0})->execute(desc);
 }
 
 void Executors::executeEntries(const IODescription &desc)
@@ -118,9 +141,9 @@ void Executors::executeEntries(const IODescription &desc)
     }
   }
 
-  const auto &executor1 = _executors.at(ir::SubgraphIndex{0});
+  const auto &executor1 = _executors.at(ExecutorIndex{0});
   const auto &graph1 = executor1->graph();
-  const auto &executor2 = _executors.at(ir::SubgraphIndex{1});
+  const auto &executor2 = _executors.at(ExecutorIndex{1});
   const auto &graph2 = executor2->graph();
 
   if ((graph1.getInputs().size() != _model_edges->pkg_inputs.size()) ||
@@ -139,9 +162,8 @@ void Executors::executeEntries(const IODescription &desc)
 
   for (uint32_t i = 0; i < graph1.getOutputs().size(); i++)
   {
-    const auto buf_index =
-      _executors.at(ir::SubgraphIndex{0})->graph().getOutputs().at(ir::IOIndex{i});
-    buf_infos[i] = &_executors.at(ir::SubgraphIndex{0})->graph().operands().at(buf_index).info();
+    const auto buf_index = _executors.at(ExecutorIndex{0})->graph().getOutputs().at(ir::IOIndex{i});
+    buf_infos[i] = &_executors.at(ExecutorIndex{0})->graph().operands().at(buf_index).info();
     const auto buf_size = buf_infos[i]->total_size();
     bufs[i] = std::make_unique<uint8_t[]>(buf_size);
   }


### PR DESCRIPTION
This commit introduces ExecutorIndex in Executors.h and use as key on Executor's map. 
To maintain mapping between model's subgraph index and executor index, introduce index map. 
Index map will use model index with subgraph index later.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: #9713
Draft: https://github.com/Samsung/ONE/pull/9716