### PR TITLE
[onert] Support Lookup operator loading

### DIFF
--- a/runtime/onert/frontend/base_loader/include/base_loader.h
+++ b/runtime/onert/frontend/base_loader/include/base_loader.h
@@ -1663,6 +1663,12 @@ void BaseLoader<LoaderDomain>::loadOperation(const Operator *op, ir::Graph &subg
     case BuiltinOperator::BuiltinOperator_DEPTH_TO_SPACE:
       loadDepthToSpace(op, subg);
       return;
+    case BuiltinOperator::BuiltinOperator_EMBEDDING_LOOKUP:
+      loadOperationTo<ir::operation::EmbeddingLookup>(op, subg);
+      return;
+    case BuiltinOperator::BuiltinOperator_HASHTABLE_LOOKUP:
+      loadOperationTo<ir::operation::HashtableLookup>(op, subg);
+      return;
     default:
       throw std::runtime_error(
         std::string("Unsupported operation: ").append(EnumNameBuiltinOperator(builtin_op)));

--- a/tests/scripts/list/tflite_comparator.aarch64.acl_cl.list
+++ b/tests/scripts/list/tflite_comparator.aarch64.acl_cl.list
@@ -8,10 +8,12 @@ concat
 conv_2d
 depthwise_conv_2d
 div
+embedding_lookup
 exp
 floor
 fullyconnected
 gather
+hashtable_lookup
 l2_normalization
 max
 max_pool_2d

--- a/tests/scripts/list/tflite_comparator.aarch64.acl_neon.list
+++ b/tests/scripts/list/tflite_comparator.aarch64.acl_neon.list
@@ -7,8 +7,10 @@ concat
 conv_2d
 depthwise_conv_2d
 div
+embedding_lookup
 floor
 gather
+hashtable_lookup
 l2_normalization
 logistic
 max

--- a/tests/scripts/list/tflite_comparator.armv7l.acl_cl.list
+++ b/tests/scripts/list/tflite_comparator.armv7l.acl_cl.list
@@ -8,10 +8,12 @@ concat
 conv_2d
 depthwise_conv_2d
 div
+embedding_lookup
 exp
 floor
 fullyconnected
 gather
+hashtable_lookup
 l2_normalization
 max
 max_pool_2d

--- a/tests/scripts/list/tflite_comparator.armv7l.acl_neon.list
+++ b/tests/scripts/list/tflite_comparator.armv7l.acl_neon.list
@@ -7,9 +7,11 @@ concat
 conv_2d
 depthwise_conv_2d
 div
+embedding_lookup
 floor
 fullyconnected
 gather
+hashtable_lookup
 l2_normalization
 logistic
 max


### PR DESCRIPTION
This commit updates base loader to support lookup operators (embedding lookup, hashtable lookup). These operators are supported on NNAPI.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: #9724