### PR TITLE
[dalgona] Add Pre/Post-Operator Hooks

### DIFF
--- a/compiler/dalgona/CMakeLists.txt
+++ b/compiler/dalgona/CMakeLists.txt
@@ -20,6 +20,8 @@ endif(NOT Pybind11_FOUND)
 set(DRIVER "driver/Driver.cpp")
 
 file(GLOB_RECURSE SOURCES "src/*.cpp")
+file(GLOB_RECURSE TESTS "src/*.test.cpp")
+list(REMOVE_ITEM SOURCES ${TESTS})
 
 add_executable(dalgona ${DRIVER} ${SOURCES})
 target_include_directories(dalgona PRIVATE include)
@@ -34,3 +36,17 @@ target_link_libraries(dalgona PRIVATE foder)
 target_link_libraries(dalgona PRIVATE luci_import)
 target_link_libraries(dalgona PRIVATE luci_interpreter)
 target_link_libraries(dalgona PRIVATE dio_hdf5)
+
+if(NOT ENABLE_TEST)
+  return()
+endif(NOT ENABLE_TEST)
+
+# dalgona is executable, so we do not link it to the test.
+# Instead, we use TEST_SOURCES to specify sources used for tests.
+set(TEST_SOURCES
+    "src/StringUtils.cpp")
+
+nnas_find_package(GTest REQUIRED)
+GTest_AddTest(dalgona_unit_test ${TESTS} ${TEST_SOURCES})
+target_include_directories(dalgona_unit_test PRIVATE src)
+target_link_libraries(dalgona_unit_test luci_lang)

--- a/compiler/dalgona/include/PythonHooks.h
+++ b/compiler/dalgona/include/PythonHooks.h
@@ -50,7 +50,11 @@ public:
   // Called after a network is executed
   void endNetworkExecution(loco::Graph *graph);
 
-  // TODO Add opeartor hooks
+  // Called before an operator is executed
+  void preOperatorExecute(const luci::CircleNode *node) override;
+
+  // Called after an operator is executed
+  void postOperatorExecute(const luci::CircleNode *node) override;
 
 private:
   luci_interpreter::Interpreter *_interpreter = nullptr;

--- a/compiler/dalgona/src/PostOperatorHook.h
+++ b/compiler/dalgona/src/PostOperatorHook.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __DALGONA_POST_OPERATOR_HOOK_H__
+#define __DALGONA_POST_OPERATOR_HOOK_H__
+
+#include "Utils.h"
+#include "StringUtils.h"
+
+#include <loco/IR/Node.h>
+#include <luci_interpreter/Interpreter.h>
+#include <luci/IR/CircleNodeVisitor.h>
+
+#include <pybind11/embed.h>
+#include <vector>
+
+namespace py = pybind11;
+using namespace py::literals;
+
+namespace dalgona
+{
+
+// Invoke a user-written Python hook after an operator is executed
+class PostOperatorHook final : public luci::CircleNodeVisitor<void>
+{
+
+private:
+  py::object _analysis;
+  luci_interpreter::Interpreter *_interpreter{nullptr};
+
+public:
+  explicit PostOperatorHook(py::object analysis, luci_interpreter::Interpreter *interpreter)
+    : _analysis(analysis), _interpreter(interpreter)
+  {
+    // Do nothing
+  }
+
+  // default
+  void visit(const luci::CircleNode *node)
+  {
+    if (not py::hasattr(_analysis, "DefaultOpPost"))
+      return;
+
+    py::object hook = _analysis.attr("DefaultOpPost");
+    auto inputs = inputsPyArray(node, _interpreter);
+    auto output = outputPyArray(node, _interpreter);
+
+    py::list input_list;
+    for (int i = 0; i < inputs.size(); i++)
+    {
+      input_list.append(inputs[i]);
+    }
+
+    pySafeCall(hook,
+               node->name(),             // name
+               toString(node->opcode()), // opcode
+               input_list,               // list of inputs
+               output                    // output
+    );
+  }
+};
+
+} // namespace dalgona
+
+#endif // __DALGONA_POST_OPERATOR_HOOK_H__

--- a/compiler/dalgona/src/PreOperatorHook.h
+++ b/compiler/dalgona/src/PreOperatorHook.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __DALGONA_PRE_OPERATOR_HOOK_H__
+#define __DALGONA_PRE_OPERATOR_HOOK_H__
+
+#include "Utils.h"
+#include "StringUtils.h"
+
+#include <loco/IR/Node.h>
+#include <luci_interpreter/Interpreter.h>
+#include <luci/IR/CircleNodeVisitor.h>
+
+#include <pybind11/embed.h>
+#include <vector>
+
+namespace py = pybind11;
+using namespace py::literals;
+
+namespace dalgona
+{
+
+// Invoke a user-written Python hook before an operator is executed
+class PreOperatorHook final : public luci::CircleNodeVisitor<void>
+{
+private:
+  py::object _analysis;
+  luci_interpreter::Interpreter *_interpreter{nullptr};
+
+public:
+  explicit PreOperatorHook(py::object analysis, luci_interpreter::Interpreter *interpreter)
+    : _analysis(analysis), _interpreter(interpreter)
+  {
+    // Do nothing
+  }
+
+  // default
+  void visit(const luci::CircleNode *node)
+  {
+    if (not py::hasattr(_analysis, "DefaultOpPre"))
+      return;
+
+    py::object hook = _analysis.attr("DefaultOpPre");
+    auto inputs = inputsPyArray(node, _interpreter);
+
+    py::list input_list;
+    for (int i = 0; i < inputs.size(); i++)
+    {
+      input_list.append(inputs[i]);
+    }
+
+    pySafeCall(hook,
+               node->name(),             // name
+               toString(node->opcode()), // opcode
+               input_list                // list of inputs
+    );
+  }
+};
+
+} // namespace dalgona
+
+#endif // __DALGONA_PRE_OPERATOR_HOOK_H__

--- a/compiler/dalgona/src/PythonHooks.cpp
+++ b/compiler/dalgona/src/PythonHooks.cpp
@@ -15,12 +15,26 @@
  */
 
 #include "PythonHooks.h"
+#include "PostOperatorHook.h"
+#include "PreOperatorHook.h"
 #include "Utils.h"
 
 #include <loco/IR/Graph.h>
 
 namespace dalgona
 {
+
+void PythonHooks::preOperatorExecute(const luci::CircleNode *node)
+{
+  PreOperatorHook hook(_analysis, _interpreter);
+  node->accept(&hook);
+}
+
+void PythonHooks::postOperatorExecute(const luci::CircleNode *node)
+{
+  PostOperatorHook hook(_analysis, _interpreter);
+  node->accept(&hook);
+}
 
 void PythonHooks::importAnalysis(const std::string &analysis_path, py::object &globals,
                                  const std::string &analysis_args)

--- a/compiler/dalgona/src/StringUtils.cpp
+++ b/compiler/dalgona/src/StringUtils.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "StringUtils.h"
+
+#include <luci/IR/CircleNodeDecl.h>
+
+#include <cassert>
+
+namespace dalgona
+{
+
+const std::string toString(luci::CircleOpcode opcode)
+{
+  static const char *names[] = {
+#define CIRCLE_NODE(OPCODE, CIRCLE_CLASS) #CIRCLE_CLASS,
+#define CIRCLE_VNODE(OPCODE, CIRCLE_CLASS) #CIRCLE_CLASS,
+#include <luci/IR/CircleNodes.lst>
+#undef CIRCLE_NODE
+#undef CIRCLE_VNODE
+  };
+
+  auto const node_name = names[static_cast<int>(opcode)];
+
+  assert(std::string(node_name).substr(0, 6) == "Circle"); // FIX_ME_UNLESS
+
+  // Return substring of class name ("Circle" is sliced out)
+  // Ex: Return "Conv2D" for "CircleConv2D" node
+  return std::string(node_name).substr(6);
+}
+
+} // namespace dalgona

--- a/compiler/dalgona/src/StringUtils.h
+++ b/compiler/dalgona/src/StringUtils.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __DALGONA_STRING_UTILS_H__
+#define __DALGONA_STRING_UTILS_H__
+
+#include <luci/IR/CircleOpcode.h>
+
+#include <string>
+
+namespace dalgona
+{
+
+const std::string toString(luci::CircleOpcode opcode);
+
+} // namespace dalgona
+
+#endif // __DALGONA_STRING_UTILS_H__

--- a/compiler/dalgona/src/StringUtils.test.cpp
+++ b/compiler/dalgona/src/StringUtils.test.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "StringUtils.h"
+
+#include <luci/IR/CircleNodes.h>
+
+#include <gtest/gtest.h>
+
+using namespace dalgona;
+
+TEST(DalgonaUtilTest, toString_basic)
+{
+  luci::CircleConv2D node;
+
+  EXPECT_EQ("Conv2D", toString(node.opcode()));
+}

--- a/compiler/dalgona/src/Utils.h
+++ b/compiler/dalgona/src/Utils.h
@@ -40,6 +40,9 @@ template <typename... Args> void pySafeCall(py::object func, Args... args)
 
 py::dict outputPyArray(const luci::CircleNode *node, luci_interpreter::Interpreter *interpreter);
 
+// Return a vector of Tensors(py::dict) which correspond to node's inputs
+std::vector<py::dict> inputsPyArray(const luci::CircleNode *node,
+                                    luci_interpreter::Interpreter *interpreter);
 } // namespace dalgona
 
 #endif // __DALGONA_UTILS_H__


### PR DESCRIPTION
This adds pre/post-operator hooks on interpreter.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/pull/3501