### PR TITLE
[onert] Change ir::Shape::MAX_RANK to ir::Shape::ONERT_MAX_RANK

### DIFF
--- a/runtime/onert/backend/acl_common/AclTensorBuilder.h
+++ b/runtime/onert/backend/acl_common/AclTensorBuilder.h
@@ -162,7 +162,7 @@ void AclTensorBuilder<T_ITensor, T_Tensor, T_SubTensor>::registerTensorInfo(
     auto &offset = parent_info.coordinates;
     auto frontend_layout = parent_info.frontend_layout;
 
-    assert(obj.shape().rank() <= ir::Shape::MAX_RANK);
+    assert(obj.shape().rank() <= ir::Shape::kMaxRank);
     auto shape = obj.shape();
     if (_operands.at(parent_index).shape().rank() >= 4 && frontend_layout == ir::Layout::NHWC &&
         backend_layout == ir::Layout::NCHW)

--- a/runtime/onert/core/include/ir/Shape.h
+++ b/runtime/onert/core/include/ir/Shape.h
@@ -70,8 +70,8 @@ struct FeatureShape
 struct Shape
 {
 public:
-  static int32_t const UNSPECIFIED_DIM;
-  static int32_t const MAX_RANK;
+  static int32_t const kUnspecifiedDim;
+  static int32_t const kMaxRank;
 
   Shape() = default;
 
@@ -126,7 +126,7 @@ public:
    */
   bool hasUnspecifiedDims() const
   {
-    return (std::find(_dimensions.begin(), _dimensions.end(), UNSPECIFIED_DIM) !=
+    return (std::find(_dimensions.begin(), _dimensions.end(), kUnspecifiedDim) !=
             _dimensions.end());
   }
 

--- a/runtime/onert/core/src/ir/Shape.cc
+++ b/runtime/onert/core/src/ir/Shape.cc
@@ -26,10 +26,10 @@ namespace onert
 namespace ir
 {
 
-int32_t const Shape::UNSPECIFIED_DIM = -1;
+int32_t const Shape::kUnspecifiedDim = -1;
 
 // NNFW_MAX_RANK is 6
-int32_t const Shape::MAX_RANK = 6;
+int32_t const Shape::kMaxRank = 6;
 
 FeatureShape Shape::asFeature(Layout layout) const
 {
@@ -80,7 +80,7 @@ uint64_t Shape::num_elements() const
 {
   // if dimension is 0, it means unspecified and cannot calculate the total number of elements
   if (std::any_of(_dimensions.begin(), _dimensions.end(),
-                  [](const int32_t &v) { return v == UNSPECIFIED_DIM; }))
+                  [](const int32_t &v) { return v == kUnspecifiedDim; }))
     throw std::runtime_error("num_elements() cannot calculate when any dimension is unspecified");
 
   return std::accumulate(_dimensions.cbegin(), _dimensions.cend(), UINT64_C(1),
@@ -89,7 +89,7 @@ uint64_t Shape::num_elements() const
 
 Shape permuteShape(const Shape &shape, Layout from, Layout to)
 {
-  assert(shape.rank() <= Shape::MAX_RANK);
+  assert(shape.rank() <= Shape::kMaxRank);
   Shape ret{shape};
   if (from == to)
     return ret;

--- a/runtime/onert/core/src/ir/Shape.test.cc
+++ b/runtime/onert/core/src/ir/Shape.test.cc
@@ -48,7 +48,7 @@ TEST(ShapeTest, neg_basic_test)
     onert::ir::Shape shape(2);
 
     shape.dim(0) = 1;
-    shape.dim(1) = onert::ir::Shape::UNSPECIFIED_DIM;
+    shape.dim(1) = onert::ir::Shape::kUnspecifiedDim;
 
     ASSERT_EQ(shape.rank(), 2);
     ASSERT_EQ(onert::ir::rankMaybeUnspecified(shape), false);

--- a/runtime/onert/core/src/util/ShapeInference.cc
+++ b/runtime/onert/core/src/util/ShapeInference.cc
@@ -608,12 +608,12 @@ ir::Shape inferReshapeShape(const int32_t *shape_buf, const int32_t shape_num_el
                             const size_t total_num_elements)
 {
   ir::Shape ret(shape_num_elements);
-  int32_t flatten_dim = ir::Shape::UNSPECIFIED_DIM;
+  int32_t flatten_dim = ir::Shape::kUnspecifiedDim;
   for (int32_t i = 0; i < shape_num_elements; ++i)
   {
     if (shape_buf[i] < 0)
     {
-      if (flatten_dim != ir::Shape::UNSPECIFIED_DIM)
+      if (flatten_dim != ir::Shape::kUnspecifiedDim)
         throw std::runtime_error("Reshape: 2nd param has special dim(for flatten) more than twice");
       flatten_dim = i;
       ret.dim(i) = 1;
@@ -623,7 +623,7 @@ ir::Shape inferReshapeShape(const int32_t *shape_buf, const int32_t shape_num_el
       ret.dim(i) = shape_buf[i];
     }
   }
-  if (flatten_dim != ir::Shape::UNSPECIFIED_DIM)
+  if (flatten_dim != ir::Shape::kUnspecifiedDim)
     ret.dim(flatten_dim) = total_num_elements / ret.num_elements();
 
   // Check reshapable


### PR DESCRIPTION
This commit changes ir::Shape::MAX_RANK to ir::Shape::ONERT_MAX_RANK to avoid duplicated declaration.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>