### PR TITLE
[circle-interpreter] Show error message if input tensor size mismatches

### DIFF
--- a/compiler/circle-interpreter/src/CircleInterpreter.cpp
+++ b/compiler/circle-interpreter/src/CircleInterpreter.cpp
@@ -33,7 +33,9 @@ void readDataFromFile(const std::string &filename, char *data, size_t data_size)
   if (fs.fail())
     throw std::runtime_error("Cannot open file \"" + filename + "\".\n");
   if (fs.read(data, data_size).fail())
-    throw std::runtime_error("Failed to read data from file \"" + filename + "\".\n");
+    throw std::runtime_error("Input tensor size mismatches with \"" + filename + "\".\n");
+  if (fs.peek() != EOF)
+    throw std::runtime_error("Input tensor size mismatches with \"" + filename + "\".\n");
 }
 
 void writeDataToFile(const std::string &filename, const char *data, size_t data_size)


### PR DESCRIPTION
This commit changes shown error message if given data's size doesn't meet with model's input tensor size.

Signed-off-by: yunjay-hong <yunjay.hong@samsung.com>

---

for https://github.com/Samsung/ONE/issues/9634#issuecomment-1248914693