### PR TITLE
[docs] Add Python 3.8 into build requirement.

### DIFF
--- a/docs/howto/how-to-build-compiler.md
+++ b/docs/howto/how-to-build-compiler.md
@@ -45,6 +45,8 @@ pylint \
 python3 \
 python3-pip \
 python3-venv \
+python3.8 \
+python3.8-dev \
 scons \
 software-properties-common \
 unzip \


### PR DESCRIPTION
This adds Python 3.8 into build requirement.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>