### PR TITLE
[onert] Remove handleDynamicInputTensor

### DIFF
--- a/runtime/onert/core/src/exec/ExecutorBase.h
+++ b/runtime/onert/core/src/exec/ExecutorBase.h
@@ -92,9 +92,6 @@ protected:
   std::vector<backend::builtin::IOTensor *> _output_tensors;
   std::mutex _mutex;
   const util::TracingCtx *_tracing_ctx;
-
-private:
-  void handleDynamicInputTensor(ir::IOIndex input_index, const IODescription &desc);
 };
 
 } // namespace exec


### PR DESCRIPTION
Now, `handleDynamicInputTensor` is used only one place, and it can be done by invoking applyShape directly.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

Related: #1714