### PR TITLE
[onert] Introduce entryExecutor

### DIFF
--- a/runtime/onert/core/include/exec/Execution.h
+++ b/runtime/onert/core/include/exec/Execution.h
@@ -53,9 +53,9 @@ public:
    * @brief   Returns primary graph object
    * @return  Graph object
    */
-  const ir::Graph &primary_subgraph() const { return primary_executor()->graph(); }
+  const ir::Graph &primary_subgraph() const { return entryExecutor()->graph(); }
 
-  const ir::Graph &primary_parentgraph() const { return primary_executor()->parent_graph(); }
+  const ir::Graph &primary_parentgraph() const { return entryExecutor()->parent_graph(); }
   /**
    * @brief     Change input shape
    * @param[in] index   Input index
@@ -243,8 +243,8 @@ public:
   void sholudStop();
 
 private:
-  const IExecutor *primary_executor() const { return _executors->at(ir::SubgraphIndex{0}); };
-  IExecutor *primary_executor() { return _executors->at(ir::SubgraphIndex{0}); };
+  const IExecutor *entryExecutor() const { return _executors->entryExecutor(); };
+  IExecutor *entryExecutor() { return _executors->entryExecutor(); };
 
 private:
   const std::shared_ptr<Executors> _executors;

--- a/runtime/onert/core/include/exec/Executors.h
+++ b/runtime/onert/core/include/exec/Executors.h
@@ -44,6 +44,8 @@ public:
 
   IExecutor *at(ir::SubgraphIndex idx) const { return _executors.at(idx).get(); }
 
+  IExecutor *entryExecutor() const { return at(ir::SubgraphIndex{0}); }
+
   uint32_t inputSize() const;
 
   uint32_t outputSize() const;
@@ -55,7 +57,7 @@ public:
   void execute(const IODescription &desc);
 
 private:
-  void executeEntries(const IODescription &desc);
+  void executeModels(const IODescription &desc);
 
 private:
   // TODO Use Executor index

--- a/runtime/onert/core/src/exec/Execution.cc
+++ b/runtime/onert/core/src/exec/Execution.cc
@@ -26,7 +26,7 @@ namespace exec
 Execution::Execution(const std::shared_ptr<Executors> &executors) : _executors{executors}
 {
   assert(executors != nullptr);
-  assert(executors->at(ir::SubgraphIndex{0}) != nullptr);
+  assert(executors->entryExecutor() != nullptr);
   _io_desc.inputs.resize(_executors->inputSize());
   _io_desc.outputs.resize(_executors->outputSize());
   sem_init(&_async_io_descs_sem, 0, 1);
@@ -218,7 +218,7 @@ void Execution::AsyncExecute()
     return;
   }
 
-  primary_executor()->execute(*_async_io_descs.front().first);
+  entryExecutor()->execute(*_async_io_descs.front().first);
 }
 
 void Execution::startExecute()

--- a/runtime/onert/core/src/exec/Executors.cc
+++ b/runtime/onert/core/src/exec/Executors.cc
@@ -24,13 +24,13 @@ namespace exec
 uint32_t Executors::inputSize() const
 {
   return _model_edges ? _model_edges->pkg_inputs.size()
-                      : _executors.at(ir::SubgraphIndex{0})->graph().getInputs().size();
+                      : entryExecutor()->graph().getInputs().size();
 }
 
 uint32_t Executors::outputSize() const
 {
   return _model_edges ? _model_edges->pkg_outputs.size()
-                      : _executors.at(ir::SubgraphIndex{0})->graph().getOutputs().size();
+                      : entryExecutor()->graph().getOutputs().size();
 }
 
 const ir::OperandInfo Executors::inputInfo(const ir::IOIndex &index)
@@ -46,8 +46,8 @@ const ir::OperandInfo Executors::inputInfo(const ir::IOIndex &index)
     return _executors.at(executor_idx)->graph().operands().at(input_index).info();
   }
 
-  const auto input_index = _executors.at(ir::SubgraphIndex{0})->graph().getInputs().at(index);
-  return _executors.at(ir::SubgraphIndex{0})->graph().operands().at(input_index).info();
+  const auto input_index = entryExecutor()->graph().getInputs().at(index);
+  return entryExecutor()->graph().operands().at(input_index).info();
 }
 
 const ir::OperandInfo Executors::outputInfo(const ir::IOIndex &index)
@@ -63,19 +63,19 @@ const ir::OperandInfo Executors::outputInfo(const ir::IOIndex &index)
     return _executors.at(executor_idx)->graph().operands().at(output_index).info();
   }
 
-  auto output_index = _executors.at(ir::SubgraphIndex{0})->graph().getOutputs().at(index);
-  return _executors.at(ir::SubgraphIndex{0})->graph().operands().at(output_index).info();
+  auto output_index = entryExecutor()->graph().getOutputs().at(index);
+  return entryExecutor()->graph().operands().at(output_index).info();
 }
 
 void Executors::execute(const IODescription &desc)
 {
   if (_model_edges)
-    return executeEntries(desc);
+    return executeModels(desc);
 
-  _executors.at(ir::SubgraphIndex{0})->execute(desc);
+  entryExecutor()->execute(desc);
 }
 
-void Executors::executeEntries(const IODescription &desc)
+void Executors::executeModels(const IODescription &desc)
 {
   // Assume 2 executors only
   // Assume that each model may have only one subgraph

--- a/runtime/onert/core/src/interp/InterpExecutor.test.cc
+++ b/runtime/onert/core/src/interp/InterpExecutor.test.cc
@@ -217,7 +217,7 @@ TEST_F(InterpExecutorTest, create_simple)
 {
   CreateSimpleModel();
   ASSERT_NE(_executors, nullptr);
-  ASSERT_NE(_executors->at(onert::ir::SubgraphIndex{0}), nullptr);
+  ASSERT_NE(_executors->entryExecutor(), nullptr);
 }
 
 TEST_F(InterpExecutorTest, neg_setInput)


### PR DESCRIPTION
This commit introduce entryExecutor to abstract 1st running executor.
Method executeEntries is renamed to executeModels to avoid confusion.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: #9716