### PR TITLE
[one-cmds] Fix onecc infer tests

### DIFF
--- a/compiler/one-cmds/tests/onecc_027.cfg
+++ b/compiler/one-cmds/tests/onecc_027.cfg
@@ -11,5 +11,5 @@ one-profile=False
 one-infer=True
 
 [one-infer]
-backend=dummy
+driver=dummy-infer
 command=test_onnx_model.bin

--- a/compiler/one-cmds/tests/onecc_neg_012.cfg
+++ b/compiler/one-cmds/tests/onecc_neg_012.cfg
@@ -11,5 +11,4 @@ one-infer=True
 
 [one-infer]
 driver=dummy-infer
-backend=dummy
 command="dummy arguments"

--- a/compiler/one-cmds/tests/onecc_neg_012.test
+++ b/compiler/one-cmds/tests/onecc_neg_012.test
@@ -14,14 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Check driver and backend option is mutually exclusive
+# Check the case when driver does not exist
 
 filename_ext="$(basename -- $0)"
 filename="${filename_ext%.*}"
 
 trap_err_onexit()
 {
-  if grep -q "\-d and -b options are mutually exclusive" "${filename}.log"; then
+  if grep -q "dummy-infer not found" "${filename}.log"; then
     echo "${filename_ext} SUCCESS"
     exit 0
   fi


### PR DESCRIPTION
This fixes onecc infer tests as -b option is removed.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/9710