### PR TITLE
[tools/tflitefile_tool] Remove duplicated buffer indices

### DIFF
--- a/tools/tflitefile_tool/select_operator.py
+++ b/tools/tflitefile_tool/select_operator.py
@@ -1332,6 +1332,7 @@ def main(args):
             if tensor.Buffer() != 0:
                 used_buffers.append(tensor.Buffer())
 
+    used_buffers = list(set(used_buffers))
     used_buffers.sort()
 
     # Assign new index for operator


### PR DESCRIPTION
Related issue : #8747

This commit removes duplicated buffer indices to avoid allocating incorrect buffer indices.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>