### PR TITLE
[luci-interpreter] throw error when the memory limit exceeded

### DIFF
--- a/compiler/luci-interpreter/src/BuddyMemoryManager.cpp
+++ b/compiler/luci-interpreter/src/BuddyMemoryManager.cpp
@@ -53,7 +53,10 @@ void BuddyMemoryManager::allocate_memory(luci_interpreter::Tensor &tensor)
   while (l < 32 && !_free_blocks[l])
     l++;
 
-  assert(l < 32);
+  if (l >= 32)
+  {
+    throw std::runtime_error{"Memory limit exceeded"};
+  }
 
   Block *tmp;
   tmp = _free_blocks[l];


### PR DESCRIPTION
This commit adds an exception of memroy limit exceeded.

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>