### PR TITLE
[dalgona] Suppress warning message

### DIFF
--- a/compiler/dalgona/CMakeLists.txt
+++ b/compiler/dalgona/CMakeLists.txt
@@ -23,6 +23,8 @@ file(GLOB_RECURSE SOURCES "src/*.cpp")
 file(GLOB_RECURSE TESTS "src/*.test.cpp")
 list(REMOVE_ITEM SOURCES ${TESTS})
 
+add_compile_options(-fvisibility=hidden)
+
 add_executable(dalgona ${DRIVER} ${SOURCES})
 target_include_directories(dalgona PRIVATE include)
 target_include_directories(dalgona PRIVATE ${PYTHON_INCLUDE_DIRS})


### PR DESCRIPTION
This sets visibility option to hidden.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---

Related to: https://github.com/Samsung/ONE/issues/9777