### PR TITLE
[docs] Revise how-to-build-compiler

### DIFF
--- a/docs/howto/how-to-build-compiler.md
+++ b/docs/howto/how-to-build-compiler.md
@@ -47,6 +47,7 @@ python3-pip \
 python3-venv \
 python3.8 \
 python3.8-dev \
+python3.8-venv \
 scons \
 software-properties-common \
 unzip \


### PR DESCRIPTION
This will revise how-to-build-compiler document with package python3.8-venv to install.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>