### PR TITLE
[onert] Use ModelIndex on executor map

### DIFF
--- a/runtime/onert/core/include/exec/Executors.h
+++ b/runtime/onert/core/include/exec/Executors.h
@@ -20,6 +20,21 @@
 #include "IExecutor.h"
 #include "ir/NNPkg.h"
 
+namespace std
+{
+
+template <> struct hash<std::pair<::onert::ir::ModelIndex, ::onert::ir::SubgraphIndex>>
+{
+  size_t
+  operator()(const std::pair<::onert::ir::ModelIndex, ::onert::ir::SubgraphIndex> &pair) const
+    noexcept
+  {
+    return hash<uint64_t>()((uint64_t(pair.first.value()) << 32) | uint64_t(pair.second.value()));
+  }
+};
+
+} // namespace std
+
 namespace onert
 {
 namespace exec
@@ -37,14 +52,16 @@ public:
   Executors(Executors &&) = default;
 
   // TODO Use Executor index
-  void emplace(ir::SubgraphIndex idx, std::unique_ptr<IExecutor> exec)
-  {
-    _executors.emplace(idx, std::move(exec));
-  }
+  void emplace(const ir::ModelIndex &model_index, const ir::SubgraphIndex &subg_index,
+               std::unique_ptr<IExecutor> exec);
 
-  IExecutor *at(ir::SubgraphIndex idx) const { return _executors.at(idx).get(); }
+  // Temporary method for builtin backend migration
+  // TODO Remove this method
+  IExecutor *at(ir::SubgraphIndex idx) const { return at(ir::ModelIndex{0}, idx); }
 
-  IExecutor *entryExecutor() const { return at(ir::SubgraphIndex{0}); }
+  IExecutor *at(const ir::ModelIndex &model_index, const ir::SubgraphIndex &subg_index) const;
+
+  IExecutor *entryExecutor() const { return at(ir::ModelIndex{0}, ir::SubgraphIndex{0}); }
 
   uint32_t inputSize() const;
 
@@ -60,9 +77,8 @@ private:
   void executeModels(const IODescription &desc);
 
 private:
-  // TODO Use Executor index
-  //      Changing index will effect if/while compile and kernel implementation
-  std::unordered_map<ir::SubgraphIndex, std::unique_ptr<IExecutor>> _executors;
+  std::unordered_map<std::pair<ir::ModelIndex, ir::SubgraphIndex>, std::unique_ptr<IExecutor>>
+    _executors;
   // NOTE _model_edges may use different struct type for executor implementation
   std::unique_ptr<ir::ModelEdges> _model_edges;
 };

--- a/runtime/onert/core/src/interp/InterpExecutor.test.cc
+++ b/runtime/onert/core/src/interp/InterpExecutor.test.cc
@@ -78,7 +78,8 @@ protected:
     model->push(onert::ir::SubgraphIndex{0}, _graph);
 
     _executors = std::make_shared<Executors>();
-    _executors->emplace(onert::ir::SubgraphIndex{0}, std::make_unique<InterpExecutor>(*_graph));
+    _executors->emplace(onert::ir::ModelIndex{0}, onert::ir::SubgraphIndex{0},
+                        std::make_unique<InterpExecutor>(*_graph));
   }
 
   void CreateTwoStepModel()
@@ -141,7 +142,8 @@ protected:
     model->push(onert::ir::SubgraphIndex{0}, _graph);
 
     _executors = std::make_shared<Executors>();
-    _executors->emplace(onert::ir::SubgraphIndex{0}, std::make_unique<InterpExecutor>(*_graph));
+    _executors->emplace(onert::ir::ModelIndex{0}, onert::ir::SubgraphIndex{0},
+                        std::make_unique<InterpExecutor>(*_graph));
   }
 
   void CreateUnspecifiedDimensionsModel()
@@ -192,7 +194,8 @@ protected:
     model->push(onert::ir::SubgraphIndex{0}, _graph);
 
     _executors = std::make_shared<Executors>();
-    _executors->emplace(onert::ir::SubgraphIndex{0}, std::make_unique<InterpExecutor>(*_graph));
+    _executors->emplace(onert::ir::ModelIndex{0}, onert::ir::SubgraphIndex{0},
+                        std::make_unique<InterpExecutor>(*_graph));
   }
 
   void createExecution() { _execution = std::make_unique<Execution>(_executors); }


### PR DESCRIPTION
This commit updates executor map in Executors to use ModelIndex and SubgraphIndex pair as key.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: https://github.com/Samsung/ONE/issues/9713
Draft: https://github.com/Samsung/ONE/pull/9716