### PR TITLE
[onert] Change ModelIndex value type

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -352,7 +352,7 @@ NNFW_STATUS nnfw_session::load_model_from_nnpackage(const char *package_dir)
     }
     _nnpkg = std::make_shared<onert::ir::NNPkg>();
     auto num_models = models.size();
-    if (num_models >= static_cast<uint16_t>(num_models))
+    if (num_models == 0 || (num_models - 1) > onert::ir::ModelIndex::max())
     {
       std::cerr << "Invalid model size - " << std::to_string(num_models) << std::endl;
       return NNFW_STATUS_ERROR;

--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -351,7 +351,14 @@ NNFW_STATUS nnfw_session::load_model_from_nnpackage(const char *package_dir)
       }
     }
     _nnpkg = std::make_shared<onert::ir::NNPkg>();
-    for (uint32_t i = 0; i < models.size(); ++i)
+    auto num_models = models.size();
+    if (num_models >= static_cast<uint16_t>(num_models))
+    {
+      std::cerr << "Invalid model size - " << std::to_string(num_models) << std::endl;
+      return NNFW_STATUS_ERROR;
+    }
+
+    for (uint16_t i = 0; i < num_models; ++i)
     {
       auto model_file_path = package_path + std::string("/") + models[i].asString();
       auto model_type = model_types[i].asString();

--- a/runtime/onert/core/include/exec/Executors.h
+++ b/runtime/onert/core/include/exec/Executors.h
@@ -29,7 +29,7 @@ template <> struct hash<std::pair<::onert::ir::ModelIndex, ::onert::ir::Subgraph
   operator()(const std::pair<::onert::ir::ModelIndex, ::onert::ir::SubgraphIndex> &pair) const
     noexcept
   {
-    return hash<uint64_t>()((uint64_t(pair.first.value()) << 32) | uint64_t(pair.second.value()));
+    return (hash<uint32_t>()(pair.first.value()) << 16) ^ hash<uint32_t>()(pair.second.value());
   }
 };
 

--- a/runtime/onert/core/include/ir/Index.h
+++ b/runtime/onert/core/include/ir/Index.h
@@ -39,7 +39,7 @@ struct SubgraphIndexTag;
 using SubgraphIndex = ::onert::util::Index<uint32_t, SubgraphIndexTag>;
 
 struct ModelIndexTag;
-using ModelIndex = ::onert::util::Index<uint32_t, ModelIndexTag>;
+using ModelIndex = ::onert::util::Index<uint16_t, ModelIndexTag>;
 
 template <typename IndexType>
 std::ostream &_index_print_impl(std::ostream &o, const std::string &prefix, IndexType index)

--- a/runtime/onert/core/include/util/Index.h
+++ b/runtime/onert/core/include/util/Index.h
@@ -138,6 +138,13 @@ public:
    */
   T value() const { return _index; }
 
+  /**
+   * @brief Return max index value
+   *
+   * @return Maximum valid index value
+   */
+  static T max() { return UNDEFINED - 1; }
+
 private:
   T _index;
 };

--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -463,7 +463,7 @@ std::shared_ptr<CompilerArtifact> Compiler::compile(void)
   if (model_count != _voptions.size())
     throw std::runtime_error{"Model count and option vector size mismatch"};
 
-  for (uint32_t i = 0; i < model_count; i++)
+  for (uint16_t i = 0; i < model_count; i++)
   {
     _nnpkg->model(ir::ModelIndex{i})->iterate([&](const ir::SubgraphIndex &, ir::Graph &subg) {
       // Mandatory passes
@@ -529,7 +529,7 @@ std::shared_ptr<CompilerArtifact> Compiler::compile(void)
     model_edges = std::make_unique<ir::ModelEdges>(_nnpkg->model_edges());
   }
 
-  for (uint32_t i = 0; i < model_count; i++)
+  for (uint16_t i = 0; i < model_count; i++)
   {
     auto const model_index = ir::ModelIndex{i};
     auto model = _nnpkg->model(model_index);


### PR DESCRIPTION
This commit changes ModelIndex value type from uint32_t to uint16_t.

This commit includes updating hash function for ModelIndex-SubgraphIndex pair.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: https://github.com/Samsung/ONE/pull/9791#discussion_r979557008