### PR TITLE
[onert] Change Bulk shape inference batch check

### DIFF
--- a/runtime/onert/core/src/compiler/StaticShapeInferer.cc
+++ b/runtime/onert/core/src/compiler/StaticShapeInferer.cc
@@ -1306,8 +1306,11 @@ void StaticShapeInferer::visit(const ir::operation::Bulk &op)
   auto origin_output_shape = op.param().origin_output_shapes[0];
 
   // TODO: more check for valid batch request
-  assert(cur_input_shape.dim(0) >= origin_output_shape.dim(0));
-  assert(cur_input_shape.dim(0) % origin_output_shape.dim(0) == 0);
+  if ((cur_input_shape.dim(0) < origin_output_shape.dim(0)) ||
+      (cur_input_shape.dim(0) % origin_output_shape.dim(0) != 0))
+  {
+    throw std::runtime_error("StaticShapeInferer " + op.name() + ": Not supported batch size");
+  }
   size_t batch_multiplier = cur_input_shape.dim(0) / origin_output_shape.dim(0);
 
   ir::Shape new_shape;


### PR DESCRIPTION
This commit changes valid batch size check for bulk operation on static shape inference.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

For #9670