### PR TITLE
[luci] Quantize fp32 nodes only

### DIFF
--- a/compiler/luci/pass/src/QuantizationUtils.cpp
+++ b/compiler/luci/pass/src/QuantizationUtils.cpp
@@ -34,6 +34,8 @@ bool is_quantized(const CircleNode *node)
           node->dtype() == loco::DataType::S64);  // bias (int16 quant)
 }
 
+bool is_fp32(const CircleNode *node) { return node->dtype() == loco::DataType::FLOAT32; }
+
 uint8_t fp32_to_uint8_cast(float f)
 {
   assert(std::numeric_limits<uint8_t>::min() <= f);

--- a/compiler/luci/pass/src/QuantizationUtils.h
+++ b/compiler/luci/pass/src/QuantizationUtils.h
@@ -60,6 +60,9 @@ void propagate_pad_v2_quantparam(luci::CirclePadV2 *pad_v2);
 // Return true if the node is quantized
 bool is_quantized(const CircleNode *node);
 
+// Return true if the node is fp32
+bool is_fp32(const CircleNode *node);
+
 enum ActivationQType
 {
   MinMax,             // Quantize using recorded min/max

--- a/compiler/luci/pass/src/QuantizeActivation.cpp
+++ b/compiler/luci/pass/src/QuantizeActivation.cpp
@@ -44,12 +44,8 @@ void QuantizeActivation::visit(luci::CircleNode *node)
   LOGGER(l);
   INFO(l) << "QuantizeActivation visit node: " << node->name() << std::endl;
 
-  // Check if this is already quantized
-  if (is_quantized(node))
-    return;
-
-  // Check if this is bool type (bool type is not quantized)
-  if (node->dtype() == loco::DataType::BOOL)
+  // Check if node is fp32
+  if (not is_fp32(node))
     return;
 
   // Check if this is const (const activation is handled by QuantizeConstInputActivation)
@@ -185,7 +181,7 @@ void QuantizeConstInputActivation::visit(luci::CircleNode *node)
   {                                                             \
     auto input = node->INPUT_NAME();                            \
     auto const_node = dynamic_cast<luci::CircleConst *>(input); \
-    if (const_node && !is_quantized(const_node))                \
+    if (const_node && is_fp32(const_node))                      \
     {                                                           \
       auto new_const = luci::clone(const_node);                 \
       quant_const(new_const, _output_type);                     \
@@ -199,7 +195,7 @@ void QuantizeConstInputActivation::visit(luci::CircleNode *node)
   {                                                               \
     auto input1 = node->INPUT_NAME1();                            \
     auto const_node1 = dynamic_cast<luci::CircleConst *>(input1); \
-    if (const_node1 && !is_quantized(const_node1))                \
+    if (const_node1 && is_fp32(const_node1))                      \
     {                                                             \
       auto new_const1 = luci::clone(const_node1);                 \
       quant_const(new_const1, _output_type);                      \
@@ -207,7 +203,7 @@ void QuantizeConstInputActivation::visit(luci::CircleNode *node)
     }                                                             \
     auto input2 = node->INPUT_NAME2();                            \
     auto const_node2 = dynamic_cast<luci::CircleConst *>(input2); \
-    if (const_node2 && !is_quantized(const_node2))                \
+    if (const_node2 && is_fp32(const_node2))                      \
     {                                                             \
       auto new_const2 = luci::clone(const_node2);                 \
       quant_const(new_const2, _output_type);                      \
@@ -278,7 +274,7 @@ void QuantizeConstInputActivation::visit(luci::CircleAddN *node)
   {
     auto input_node = node->inputs(i);
     auto const_node = dynamic_cast<luci::CircleConst *>(input_node);
-    if (const_node && !is_quantized(const_node))
+    if (const_node && is_fp32(const_node))
     {
       auto new_const = luci::clone(const_node);
       quant_const(new_const, _output_type);


### PR DESCRIPTION
This quantizes fp32 nodes only.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>