### PR TITLE
[onert/test] Remove boost dependency on NNAPI gtest

### DIFF
--- a/tests/nnapi/CMakeLists.txt
+++ b/tests/nnapi/CMakeLists.txt
@@ -7,13 +7,10 @@ if (NOT BUILD_ONERT)
   return()
 endif(NOT BUILD_ONERT)
 
-if (ANDROID_BOOST_ROOT)
-  set(BOOST_ROOT ${ANDROID_BOOST_ROOT})
-endif (ANDROID_BOOST_ROOT)
-
-nnfw_find_package(Boost REQUIRED)
 nnfw_find_package(GTest)
 
+# NNAPI gtest requires c++17
+set(CMAKE_CXX_STANDARD 17)
 
 set(GENERATED_CPPS "${CMAKE_CURRENT_SOURCE_DIR}/src/generated/all_generated_V1_2_cts_tests.cpp"
                    "${CMAKE_CURRENT_SOURCE_DIR}/src/generated/all_generated_V1_1_cts_tests.cpp"
@@ -51,7 +48,6 @@ endif(GENERATE_RUNTIME_NNAPI_TESTS)
 set(RUNTIME_NNAPI_TEST_SRC_INC ${CMAKE_CURRENT_SOURCE_DIR}/include
                                ${CMAKE_CURRENT_SOURCE_DIR}/src)
 target_include_directories(${RUNTIME_NNAPI_TEST} PRIVATE ${RUNTIME_NNAPI_TEST_SRC_INC})
-target_include_directories(${RUNTIME_NNAPI_TEST} PRIVATE ${Boost_INCLUDE_DIRS})
 
 # Define NNTEST_ONLY_PUBLIC_API to avoid android dependency
 target_compile_definitions(${RUNTIME_NNAPI_TEST} PRIVATE NNTEST_ONLY_PUBLIC_API)

--- a/tests/nnapi/include/NeuralNetworksWrapper.h
+++ b/tests/nnapi/include/NeuralNetworksWrapper.h
@@ -27,9 +27,7 @@
 #include "NeuralNetworksExShim.h"
 
 #include <math.h>
-// Fix for onert: use boost::optional instead of std::optional
-// TODO in onert: introduce and use internal optional library
-#include <boost/optional.hpp>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -104,10 +102,7 @@ struct SymmPerChannelQuantParams {
 struct OperandType {
     ANeuralNetworksOperandType operandType;
     std::vector<uint32_t> dimensions;
-    // Fix for onert:
-    //  Use boost::optional instead of std::optional
-    //  Default value: std::nullopt -> boost::none
-    boost::optional<SymmPerChannelQuantParams> channelQuant;
+    std::optional<SymmPerChannelQuantParams> channelQuant;
 
     OperandType(const OperandType& other)
         : operandType(other.operandType),
@@ -127,7 +122,7 @@ struct OperandType {
     }
 
     OperandType(Type type, std::vector<uint32_t> d, float scale = 0.0f, int32_t zeroPoint = 0)
-        : dimensions(std::move(d)), channelQuant(boost::none) {
+        : dimensions(std::move(d)), channelQuant(std::nullopt) {
         operandType = {
                 .type = static_cast<int32_t>(type),
                 .dimensionCount = static_cast<uint32_t>(dimensions.size()),

--- a/tests/nnapi/src/TestNeuralNetworksWrapper.h
+++ b/tests/nnapi/src/TestNeuralNetworksWrapper.h
@@ -27,9 +27,7 @@
 //#include "NeuralNetworksWrapperExtensions.h"
 
 #include <math.h>
-// Fix for onert: use boost::optional instead of std::optional
-// TODO in onert: introduce and use internal optional library
-#include <boost/optional.hpp>
+#include <optional>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
This commit removes depdency with boost on NNAPI gtest. To remove depdency, NNAPI gtest build uses c++17.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>