### PR TITLE
[luci] Skip checks for S32/S64 Add

### DIFF
--- a/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
+++ b/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
@@ -181,6 +181,10 @@ private:
     if (input->opcode() == luci::CircleOpcode::CIRCLECONST)
       return nullptr;
 
+    // input is not quantizable (ex: index)
+    if (input->quantparam() == nullptr)
+      return nullptr;
+
     auto input_quant = create_quantize_op(input, _op_dtype);
     input_quant->input(input);
     auto origin_node = loco::must_cast<luci::CircleNode *>(origin);
@@ -192,6 +196,11 @@ private:
   {
     auto output = loco::must_cast<luci::CircleNode *>(node);
     assert(output->opcode() != luci::CircleOpcode::CIRCLECONST); // FIX_CALLER_UNLESS
+
+    // output is not quantizable (ex: index)
+    if (output->quantparam() == nullptr)
+      return;
+
     auto output_quant = create_quantize_op(output, _default_dtype);
 
     luci::add_origin(output_quant, luci::get_origin(output));

--- a/compiler/luci/pass/src/VerifyQuantizedNodeGranularity.h
+++ b/compiler/luci/pass/src/VerifyQuantizedNodeGranularity.h
@@ -133,6 +133,10 @@ private:
 
   bool visit(const luci::CircleAdd *node)
   {
+    // Skip granularity check for indices
+    if (node->dtype() == loco::DataType::S32 or node->dtype() == loco::DataType::S64)
+      return true;
+
     RETURN_FALSE_UNLESS(is_lwq(node));
     RETURN_FALSE_UNLESS(is_lwq(node->x()));
     RETURN_FALSE_UNLESS(is_lwq(node->y()));

--- a/compiler/luci/pass/src/VerifyQuantizedNodeType.cpp
+++ b/compiler/luci/pass/src/VerifyQuantizedNodeType.cpp
@@ -47,6 +47,10 @@ namespace luci
 template <loco::DataType Qtype, loco::DataType Btype>
 bool VerifyQuantizedNodeTypeBase<Qtype, Btype>::visit(const luci::CircleAdd *node)
 {
+  // Allow add of indices
+  if (group_has_type(node, loco::DataType::S32) or group_has_type(node, loco::DataType::S64))
+    return true;
+
   return group_has_type(node, Qtype);
 }
 


### PR DESCRIPTION
This skips type/granularity checks for index-typed Add.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/9798