### PR TITLE
[onecc-docker] Change debian file locations

### DIFF
--- a/compiler/onecc-docker/debian/onecc-docker.install
+++ b/compiler/onecc-docker/debian/onecc-docker.install
@@ -1,3 +1,2 @@
-# TODO Change the file location
-/onecc-docker /usr/share/one/bin/
-/docker/Dockerfile /usr/share/one/docker/
+compiler/onecc-docker/onecc-docker /usr/share/one/bin/
+compiler/onecc-docker/docker/Dockerfile /usr/share/one/docker/


### PR DESCRIPTION
This commit changes debian file locations to build in root directory.

Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

/cc @Samsung/ootpg_docker 