### PR TITLE
[onecc-docker] onecc-docker permissions error fix

### DIFF
--- a/compiler/onecc-docker/debian/postinst
+++ b/compiler/onecc-docker/debian/postinst
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# https://www.debian.org/doc/debian-policy/ch-maintainerscripts.html
+# Boradly speaking, the `postinst` is called after a package is unpacked.
+
+set -e
+
+sudo chmod +x /usr/share/one/bin/onecc-docker


### PR DESCRIPTION
This PR corrects a permission error when using onecc-docker after installing onecc-docker debian package.

ONE-DCO-1.0.-Signed-off-by: seunghui-lee hithere1012@naver.com