### PR TITLE
[onecc-docker] onecc-docker permission error fix

### DIFF
--- a/compiler/onecc-docker/debian/rules
+++ b/compiler/onecc-docker/debian/rules
@@ -3,3 +3,6 @@
 %:
 	dh $@
 
+override_dh_fixperms:
+	dh_fixperms
+	chmod +x debian/onecc-docker/usr/share/one/bin/onecc-docker


### PR DESCRIPTION
This PR corrects a permission error when using onecc-docker after installing onecc-docker debian package.

ONE-DCO-1.0.-Signed-off-by: seunghui-lee hithere1012@naver.com

Related Issue : [#9750]