### PR TITLE
[dalgona] Install executable to bin

### DIFF
--- a/compiler/dalgona/CMakeLists.txt
+++ b/compiler/dalgona/CMakeLists.txt
@@ -40,6 +40,8 @@ target_link_libraries(dalgona PRIVATE luci_interpreter)
 target_link_libraries(dalgona PRIVATE dio_hdf5)
 target_link_libraries(dalgona PRIVATE nncc_common)
 
+install(TARGETS dalgona DESTINATION bin)
+
 if(NOT ENABLE_TEST)
   return()
 endif(NOT ENABLE_TEST)


### PR DESCRIPTION
This installs executable to bin.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Draft: https://github.com/Samsung/ONE/pull/9819