### PR TITLE
[onert] Introduce I/O size getter for package

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -1135,9 +1135,11 @@ uint32_t nnfw_session::getInputSize()
   if (isStateModelLoaded())
     return _nnpkg->inputSize();
 
+  // Session is prepared (general inference)
   if (_executions.empty())
     return _compiler_artifact->_executors->inputSize();
 
+  // Session is prepared (pipeline inference)
   return _executions[0]->primary_parentgraph().getInputs().size();
 }
 
@@ -1149,9 +1151,11 @@ uint32_t nnfw_session::getOutputSize()
   if (isStateModelLoaded())
     return _nnpkg->outputSize();
 
+  // Session is prepared (general inference)
   if (_executions.empty())
     return _compiler_artifact->_executors->outputSize();
 
+  // Session is prepared (pipeline inference)
   return _executions[0]->primary_parentgraph().getOutputs().size();
 }
 

--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -657,7 +657,7 @@ NNFW_STATUS nnfw_session::input_size(uint32_t *number)
       std::cerr << "Error during nnfw_session::input_size, number is null pointer." << std::endl;
       return NNFW_STATUS_UNEXPECTED_NULL;
     }
-    *number = primary_subgraph()->getInputs().size();
+    *number = getInputSize();
   }
   catch (const std::exception &e)
   {
@@ -679,7 +679,7 @@ NNFW_STATUS nnfw_session::output_size(uint32_t *number)
       std::cerr << "Error during nnfw_session::output_size, number is null pointer." << std::endl;
       return NNFW_STATUS_UNEXPECTED_NULL;
     }
-    *number = primary_subgraph()->getOutputs().size();
+    *number = getOutputSize();
   }
   catch (const std::exception &e)
   {
@@ -822,7 +822,7 @@ NNFW_STATUS nnfw_session::input_tensorinfo(uint32_t index, nnfw_tensorinfo *ti)
                 << std::endl;
       return NNFW_STATUS_UNEXPECTED_NULL;
     }
-    if (index >= primary_subgraph()->getInputs().size())
+    if (index >= getInputSize())
     {
       std::cerr << "Error during nnfw_session::input_tensorinfo, index is out of range."
                 << std::endl;
@@ -858,15 +858,15 @@ NNFW_STATUS nnfw_session::output_tensorinfo(uint32_t index, nnfw_tensorinfo *ti)
     return NNFW_STATUS_UNEXPECTED_NULL;
   }
 
-  if (index >= primary_subgraph()->getOutputs().size())
-  {
-    std::cerr << "Error during nnfw_session::output_tensorinfo, index is out of range."
-              << std::endl;
-    return NNFW_STATUS_ERROR;
-  }
-
   try
   {
+    if (index >= getOutputSize())
+    {
+      std::cerr << "Error during nnfw_session::output_tensorinfo, index is out of range."
+                << std::endl;
+      return NNFW_STATUS_ERROR;
+    }
+
     auto opidx = primary_subgraph()->getOutputs().at(index);
     auto shape = primary_subgraph()->operands().at(opidx).shape();
     // If it is called after `nnfw_run` then get the shape from Execution, not from the graph
@@ -1125,6 +1125,34 @@ const onert::ir::Graph *nnfw_session::primary_subgraph()
 
     return &_execution->primary_subgraph();
   }
+}
+
+uint32_t nnfw_session::getInputSize()
+{
+  if (isStateInitialized())
+    throw std::runtime_error{"Model is not loaded yet"};
+
+  if (isStateModelLoaded())
+    return _nnpkg->inputSize();
+
+  if (_executions.empty())
+    return _compiler_artifact->_executors->inputSize();
+
+  return _executions[0]->primary_parentgraph().getInputs().size();
+}
+
+uint32_t nnfw_session::getOutputSize()
+{
+  if (isStateInitialized())
+    throw std::runtime_error{"Model is not loaded yet"};
+
+  if (isStateModelLoaded())
+    return _nnpkg->outputSize();
+
+  if (_executions.empty())
+    return _compiler_artifact->_executors->outputSize();
+
+  return _executions[0]->primary_parentgraph().getOutputs().size();
 }
 
 NNFW_STATUS nnfw_session::get_config(const char *key, char *value, size_t value_size)

--- a/runtime/onert/api/src/nnfw_api_internal.h
+++ b/runtime/onert/api/src/nnfw_api_internal.h
@@ -166,6 +166,9 @@ public:
 
 private:
   const onert::ir::Graph *primary_subgraph();
+  uint32_t getInputSize();
+  uint32_t getOutputSize();
+
   bool isStateInitialized();
   bool isStateModelLoaded();
   bool isStatePrepared();

--- a/runtime/onert/core/include/ir/NNPkg.h
+++ b/runtime/onert/core/include/ir/NNPkg.h
@@ -21,6 +21,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "ir/Graph.h"
 #include "ir/Index.h"
 #include "ir/Model.h"
 
@@ -89,7 +90,7 @@ public:
   ~NNPkg() = default;
 
   NNPkg(std::shared_ptr<Model> model) { _models[ModelIndex{0}] = model; }
-  std::shared_ptr<Model> primary_model() { return _models.at(onert::ir::ModelIndex{0}); }
+  std::shared_ptr<Model> primary_model() const { return _models.at(onert::ir::ModelIndex{0}); }
 
   /**
    * @brief Put model at index
@@ -179,6 +180,24 @@ public:
    * @return  Edge set reference
    */
   const ModelEdges &model_edges() { return _edges; }
+
+  /**
+   * @brief   Get model input size
+   */
+  uint32_t inputSize() const
+  {
+    return _models.size() == 1 ? primary_model()->primary_subgraph()->getInputs().size()
+                               : _edges.pkg_inputs.size();
+  }
+
+  /**
+   * @brief   Get model output size
+   */
+  uint32_t outputSize() const
+  {
+    return _models.size() == 1 ? primary_model()->primary_subgraph()->getOutputs().size()
+                               : _edges.pkg_outputs.size();
+  }
 
   // TODO: Add iterate() or getter for edges
 


### PR DESCRIPTION
This commit introduces I/O size getter in nnfw_api_internal.cc and NNPkg.h to reduce code duplication. 
New getters support multimodel and pipeline.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>