### PR TITLE
[onert] Change SubgraphIndex value type

### DIFF
--- a/runtime/onert/core/include/ir/Index.h
+++ b/runtime/onert/core/include/ir/Index.h
@@ -36,7 +36,7 @@ struct IOIndexTag;
 using IOIndex = ::onert::util::Index<uint32_t, IOIndexTag>;
 
 struct SubgraphIndexTag;
-using SubgraphIndex = ::onert::util::Index<uint32_t, SubgraphIndexTag>;
+using SubgraphIndex = ::onert::util::Index<uint16_t, SubgraphIndexTag>;
 
 struct ModelIndexTag;
 using ModelIndex = ::onert::util::Index<uint16_t, ModelIndexTag>;

--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -287,7 +287,7 @@ bool Compiler::buildPartialGraph(uint32_t num_graphs)
 
   auto partialgraphs = std::make_shared<ir::Model>();
 
-  for (uint32_t idx = 0; idx < num_graphs; idx++)
+  for (uint16_t idx = 0; idx < num_graphs; idx++)
   {
     auto partialgraph = std::make_unique<ir::Graph>();
     partialgraphs->push(ir::SubgraphIndex{idx}, std::move(partialgraph));
@@ -353,7 +353,7 @@ bool Compiler::buildPartialGraph(uint32_t num_graphs)
       assert(new_operation_index == operation_index);
     });
 
-  for (uint32_t idx = 0; idx < partial_graph->subgraphs_count(); idx++)
+  for (uint16_t idx = 0; idx < partial_graph->subgraphs_count(); idx++)
   {
     auto partition = partial_graph->at(ir::SubgraphIndex{idx});
 
@@ -664,23 +664,21 @@ std::vector<std::shared_ptr<CompilerArtifact>> Compiler::compile(const char *pac
   const Json::Value &map = root["partition_map"];
   const Json::Value &np = root["num_partitions"];
 
-  uint32_t num_graphs = 1;
-
-  if (pmfs.is_open())
-  {
-    num_graphs = np.asUInt();
-    for (uint32_t i = 0; i < (uint32_t)map.size(); ++i)
-    {
-      options.partial_graph_options.index_to_graph[ir::OperationIndex{i}] =
-        ir::SubgraphIndex{map[i].asUInt()};
-    }
-  }
-  else
-  {
+  if (!pmfs.is_open())
     throw std::runtime_error("There is no partition map file");
-  }
 
-  if (!buildPartialGraph(num_graphs))
+  for (uint32_t i = 0; i < map.size(); ++i)
+  {
+    auto subg_idx = map[i].asUInt();
+    if (subg_idx > ir::SubgraphIndex::max())
+      throw std::runtime_error("The number of partition cannot exceed " +
+                               std::to_string(ir::SubgraphIndex::max() + 1));
+    else
+      options.partial_graph_options.index_to_graph[ir::OperationIndex{i}] =
+        ir::SubgraphIndex(subg_idx);
+  }
+  uint32_t num_partial_graphs = np.asUInt();
+  if (!buildPartialGraph(num_partial_graphs))
   {
     throw std::runtime_error("It doesn't support in case there are subgraphs");
   }


### PR DESCRIPTION
It changes type for value from uint32 to uint16.
    
tflite and circle schema define Subgraphs as following:
```
  subgraphs:[SubGraph];
```
It can have 2^32 Subgraphs.
But onert assumes the number of subgraph does not exceed 2^16.
We will remove the assumption when we encounter such case.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>