### PR TITLE
[onert] Remove tracing_ctx check from LinearExecutor::executeImpl

### DIFF
--- a/runtime/onert/core/src/exec/LinearExecutor.cc
+++ b/runtime/onert/core/src/exec/LinearExecutor.cc
@@ -26,52 +26,30 @@ namespace exec
 
 void LinearExecutor::executeImpl()
 {
-  if (_tracing_ctx)
-  {
-    auto profiling_subg_index = _tracing_ctx->getSubgraphIndex(&_graph);
+  auto profiling_subg_index = _tracing_ctx->getSubgraphIndex(&_graph);
 
-    _subject.notifySubgraphBegin(profiling_subg_index);
-    for (auto &&code : _code)
-    {
-      const auto backend = code.lower_info->backend();
+  _subject.notifySubgraphBegin(profiling_subg_index);
+  for (auto &&code : _code)
+  {
+    const auto backend = code.lower_info->backend();
 // TODO : Move ruy profiler into ExecutionObserver
 #ifdef RUY_PROFILER
-      ruy::profiler::ScopeLabel label(code.op->name());
+    ruy::profiler::ScopeLabel label(code.op->name());
 #endif
-      _subject.notifyJobBegin(this, profiling_subg_index, code.op_ind, backend);
+    _subject.notifyJobBegin(this, profiling_subg_index, code.op_ind, backend);
 
-      auto &fn_seq = code.fn_seq;
+    auto &fn_seq = code.fn_seq;
 
-      fn_seq->initRunning();
+    fn_seq->initRunning();
 
-      bool handle_dynamic_tensor =
-        _lowered_graph->getHasDynamicTensor(code.op_ind) || hasDynamicInput();
-      fn_seq->enableDynamicShapeInferer(handle_dynamic_tensor);
-      fn_seq->run();
+    bool handle_dynamic_tensor =
+      _lowered_graph->getHasDynamicTensor(code.op_ind) || hasDynamicInput();
+    fn_seq->enableDynamicShapeInferer(handle_dynamic_tensor);
+    fn_seq->run();
 
-      _subject.notifyJobEnd(this, profiling_subg_index, code.op_ind, backend);
-    }
-    _subject.notifySubgraphEnd(profiling_subg_index);
+    _subject.notifyJobEnd(this, profiling_subg_index, code.op_ind, backend);
   }
-  else
-  {
-    for (auto &&code : _code)
-    {
-// TODO : Move ruy profiler into ExecutionObserver
-#ifdef RUY_PROFILER
-      ruy::profiler::ScopeLabel label(code.op->name());
-#endif
-
-      auto &fn_seq = code.fn_seq;
-
-      fn_seq->initRunning();
-
-      bool handle_dynamic_tensor =
-        _lowered_graph->getHasDynamicTensor(code.op_ind) || hasDynamicInput();
-      fn_seq->enableDynamicShapeInferer(handle_dynamic_tensor);
-      fn_seq->run();
-    }
-  }
+  _subject.notifySubgraphEnd(profiling_subg_index);
 }
 
 } // namespace exec


### PR DESCRIPTION
tracing_ctx is always created.
if condition is always true.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

Related: #9834