### PR TITLE
[onert] Support tracing context for multiple models

### DIFF
--- a/runtime/onert/core/include/util/TracingCtx.h
+++ b/runtime/onert/core/include/util/TracingCtx.h
@@ -29,6 +29,8 @@ namespace onert
 namespace util
 {
 
+using Origin = ir::SubgraphIndex;
+
 /**
  * @brief Class to maintain information about profiling per session
  */
@@ -51,14 +53,14 @@ public:
   bool hasMultipleSessions() const { return _next_session_id > 1; }
 
   /**
-   * @brief Set subgraph index of a graph
+   * @brief Set origin of a graph
    */
-  void setSubgraphIndex(const ir::Graph *g, uint32_t index) { _subgraph_indices.emplace(g, index); }
+  void setOrigin(const ir::Graph *g, uint32_t index) { _origin_map.emplace(g, index); }
 
   /**
-   * @brief Get subgraph index of a graph.
+   * @brief Get origin of a graph.
    */
-  ir::SubgraphIndex getSubgraphIndex(const ir::Graph *g) const { return _subgraph_indices.at(g); }
+  Origin getOrigin(const ir::Graph *g) const { return _origin_map.at(g); }
 
 private:
   void decideSessionID()
@@ -69,7 +71,7 @@ private:
   }
 
 private:
-  std::unordered_map<const ir::Graph *, ir::SubgraphIndex> _subgraph_indices;
+  std::unordered_map<const ir::Graph *, Origin> _origin_map;
   uint32_t _session_id;
   static std::mutex _session_id_mutex;
   static uint32_t _next_session_id;

--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -542,8 +542,8 @@ std::shared_ptr<CompilerArtifact> Compiler::compile(void)
         std::make_unique<compiler::LoweredGraph>(subg, *_voptions[i]);
       // Set tracing_ctx for copied graph
       if (tracing_ctx != nullptr)
-        tracing_ctx->setSubgraphIndex(&(lowered_subgs[model_index][subg_index]->graph()),
-                                      subg_index.value());
+        tracing_ctx->setOrigin(&(lowered_subgs[model_index][subg_index]->graph()),
+                               subg_index.value());
     });
   }
 

--- a/runtime/onert/core/src/exec/DataflowExecutor.cc
+++ b/runtime/onert/core/src/exec/DataflowExecutor.cc
@@ -141,7 +141,7 @@ void DataflowExecutor::executeImpl()
   }
   assert(!_ready_jobs.empty()); // Cannot begin if there is no initial jobs
 
-  auto profiling_subg_index = _tracing_ctx->getSubgraphIndex(&_graph);
+  auto profiling_subg_index = _tracing_ctx->getOrigin(&_graph);
 
   _subject.notifySubgraphBegin(profiling_subg_index);
 

--- a/runtime/onert/core/src/exec/LinearExecutor.cc
+++ b/runtime/onert/core/src/exec/LinearExecutor.cc
@@ -28,7 +28,7 @@ void LinearExecutor::executeImpl()
 {
   if (_tracing_ctx)
   {
-    auto profiling_subg_index = _tracing_ctx->getSubgraphIndex(&_graph);
+    auto profiling_subg_index = _tracing_ctx->getOrigin(&_graph);
 
     _subject.notifySubgraphBegin(profiling_subg_index);
     for (auto &&code : _code)

--- a/runtime/onert/core/src/exec/ParallelExecutor.cc
+++ b/runtime/onert/core/src/exec/ParallelExecutor.cc
@@ -100,7 +100,7 @@ void ParallelExecutor::executeImpl()
 
   VERBOSE(ParallelExecutor) << "INITIAL JOBS : " << _ready_jobs.size() << std::endl;
 
-  auto profiling_subg_index = _tracing_ctx->getSubgraphIndex(&_graph);
+  auto profiling_subg_index = _tracing_ctx->getOrigin(&_graph);
 
   _subject.notifySubgraphBegin(profiling_subg_index);
 


### PR DESCRIPTION
It support tracing for multiple models.
Origin is introduced to encapsulate the origin information. It is currently ir::SubgrphIndex.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>