### PR TITLE
[onert-micro] Revisit standalone CMakeLists.txt

### DIFF
--- a/onert-micro/standalone/CMakeLists.txt
+++ b/onert-micro/standalone/CMakeLists.txt
@@ -1,10 +1,7 @@
 cmake_minimum_required(VERSION 3.10)
 project(luci_interpreter_micro_standalone)
 
-# Add fake target, so nothing is build
-set(BUILD_WHITELIST "dummy")
-
-add_subdirectory(${NNAS_ROOT}/infra/nncc ${CMAKE_CURRENT_BINARY_DIR}/nncc)
+include(${NNAS_ROOT}/infra/onert-micro/utils.cmake)
 
 nnas_find_package(FlatBuffersSource EXACT 2.0 QUIET)
 include_directories(${FlatBuffersSource_DIR}/include)


### PR DESCRIPTION
This PR revisits standalone CMakeLists.txt.

from draft: https://github.com/Samsung/ONE/pull/9836

ONE-DCO-1.0-Signed-off-by: Artem Balyshev a.balyshev@partner.samsung.com