### PR TITLE
[onert] Revisit TensorInfo API implementation

### DIFF
--- a/runtime/onert/core/include/ir/NNPkg.h
+++ b/runtime/onert/core/include/ir/NNPkg.h
@@ -181,6 +181,9 @@ public:
    */
   const ModelEdges &model_edges() { return _edges; }
 
+  // TODO Find better way to handle single model NNPackage and multi model NNPackage on inputSize(),
+  //      outputSize(), inputInfo(), outputInfo()
+
   /**
    * @brief   Get model input size
    */
@@ -197,6 +200,42 @@ public:
   {
     return _models.size() == 1 ? primary_model()->primary_subgraph()->getOutputs().size()
                                : _edges.pkg_outputs.size();
+  }
+
+  /**
+   * @brief   Get model input info
+   */
+  OperandInfo &inputInfo(uint32_t index) const
+  {
+    if (_models.size() == 1)
+    {
+      auto const graph = primary_model()->primary_subgraph();
+      auto const operand_index = graph->getInputs().at(index);
+      return graph->operands().at(operand_index).info();
+    }
+
+    auto const &desc = input(index);
+    auto const graph = model(std::get<ModelIndex>(desc))->primary_subgraph();
+    auto const operand_index = graph->getInputs().at(std::get<IOIndex>(desc).value());
+    return graph->operands().at(operand_index).info();
+  }
+
+  /**
+   * @brief   Get model output info
+   */
+  OperandInfo &outputInfo(uint32_t index) const
+  {
+    if (_models.size() == 1)
+    {
+      auto const graph = primary_model()->primary_subgraph();
+      auto const operand_index = graph->getOutputs().at(index);
+      return graph->operands().at(operand_index).info();
+    }
+
+    auto const &desc = output(index);
+    auto const graph = model(std::get<ModelIndex>(desc))->primary_subgraph();
+    auto const operand_index = graph->getOutputs().at(std::get<IOIndex>(desc).value());
+    return graph->operands().at(operand_index).info();
   }
 
   // TODO: Add iterate() or getter for edges

--- a/runtime/onert/core/src/exec/Execution.cc
+++ b/runtime/onert/core/src/exec/Execution.cc
@@ -251,10 +251,16 @@ ir::Shape Execution::getInputShape(ir::IOIndex ind) const
   }
 }
 
+// NNAPI return fail if ANeuralNetworksExecution_getOutputOperandRank or
+// ANeuralNetworksExecution_getOutputOperandDimensions is called before execution.
+// On the other hand, NNFW API return static shape inference result if nnfw_output_tensorinfo is
+// called before execution.
+// To handle both case, this method retun static shape inference result and fail will be handled on
+// NNAPI frontend.
 ir::Shape Execution::getOutputShape(ir::IOIndex ind) const
 {
   if (!isFinished())
-    throw std::runtime_error("Cannot get output shape before execution is finished");
+    return _executors->outputInfo(ind).shape();
 
   const auto &output_desc = _io_desc.outputs.at(ind.value());
 


### PR DESCRIPTION
This commit update TensorInfo API implementations. 
Before execution, API will use method in NNPkg class. 
After execution, API will use method in Execution class.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: #9809