### PR TITLE
[onert] Split supported multimodel check

### DIFF
--- a/runtime/onert/core/include/exec/Executors.h
+++ b/runtime/onert/core/include/exec/Executors.h
@@ -70,6 +70,7 @@ public:
   void execute(const IODescription &desc);
 
 private:
+  void checkSupportedMultimodel() const;
   void executeModels(const IODescription &desc);
 
 private:

--- a/runtime/onert/core/src/exec/Executors.cc
+++ b/runtime/onert/core/src/exec/Executors.cc
@@ -85,7 +85,7 @@ void Executors::execute(const IODescription &desc)
   entryExecutor()->execute(desc);
 }
 
-void Executors::executeModels(const IODescription &desc)
+void Executors::checkSupportedMultimodel() const
 {
   // Assume 2 executors only
   // Assume that each model may have only one subgraph
@@ -140,6 +140,17 @@ void Executors::executeModels(const IODescription &desc)
   {
     throw std::runtime_error{"NYI: Unsupported model edge pattern"};
   }
+}
+
+void Executors::executeModels(const IODescription &desc)
+{
+  // Check supported multi model package
+  checkSupportedMultimodel();
+
+  const auto &executor1 = at(ir::ModelIndex{0}, ir::SubgraphIndex{0});
+  const auto &graph1 = executor1->graph();
+  const auto &executor2 = at(ir::ModelIndex{1}, ir::SubgraphIndex{0});
+  const auto &graph2 = executor2->graph();
 
   // Prepare buffer
   // Assume buffer layout is NHWC


### PR DESCRIPTION
This commit introduces checkSupportedMultimodel() method to split supported multi model check.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>