### PR TITLE
[onert] nnfw_session::create covers more allocation failures

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -208,29 +208,23 @@ NNFW_STATUS nnfw_session::create(nnfw_session **session)
 {
   if (session == nullptr)
     return NNFW_STATUS_UNEXPECTED_NULL;
-
-  // Create session
-  *session = new (std::nothrow) nnfw_session();
-  if (*session == nullptr)
+  try
+  {
+    auto new_session = std::unique_ptr<nnfw_session>(new nnfw_session());
+    new_session->_kernel_registry = std::make_shared<onert::api::CustomKernelRegistry>();
+    *session = new_session.release();
+  }
+  catch (const std::bad_alloc &e)
   {
     std::cerr << "Error during session creation" << std::endl;
     return NNFW_STATUS_OUT_OF_MEMORY;
   }
-
-  // Initialize fields
-  try
-  {
-    (*session)->_kernel_registry = std::make_shared<onert::api::CustomKernelRegistry>();
-  }
   catch (const std::exception &e)
   {
     std::cerr << "Error during session initialization : " << e.what() << std::endl;
-    delete *session;
-    *session = nullptr;
-
+    *session = nullptr; // Set nullptr to keep the old behavior
     return NNFW_STATUS_ERROR;
   }
-
   return NNFW_STATUS_NO_ERROR;
 }
 

--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -217,12 +217,13 @@ NNFW_STATUS nnfw_session::create(nnfw_session **session)
   catch (const std::bad_alloc &e)
   {
     std::cerr << "Error during session creation" << std::endl;
+    *session = nullptr; // Set nullptr on error to keep the old behavior
     return NNFW_STATUS_OUT_OF_MEMORY;
   }
   catch (const std::exception &e)
   {
     std::cerr << "Error during session initialization : " << e.what() << std::endl;
-    *session = nullptr; // Set nullptr to keep the old behavior
+    *session = nullptr; // Set nullptr on error to keep the old behavior
     return NNFW_STATUS_ERROR;
   }
   return NNFW_STATUS_NO_ERROR;


### PR DESCRIPTION
Previously, nnfw_session::create checks only from new nnfw_session(). Now, it covers CustomKernelRegistry and more.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>