### PR TITLE
[onert-micro] Change TARGET_CPU and TARGET_ARCH options

### DIFF
--- a/onert-micro/CMakeLists.txt
+++ b/onert-micro/CMakeLists.txt
@@ -45,8 +45,8 @@ set(CMAKE_ARM_OPTIONS
   -DLUCI_INTERPRETER_STATIC=ON
   -DLUCI_STATIC=ON
   -DBUILD_CMSIS_NN_FUNCTIONS=ON
-  -DTARGET_CPU=cortex-m7
-  -DTARGET_ARCH=armv7em
+  -DTARGET_CPU=${TARGET_CPU}
+  -DTARGET_ARCH=${TARGET_ARCH}
   "-DEXT_OVERLAY_DIR=${CMAKE_CURRENT_BINARY_DIR}/../../overlay"
   "-DFlatbuffers_DIR=${CMAKE_CURRENT_BINARY_DIR}/../../overlay/lib/cmake/flatbuffers"
   "-DCMAKE_TOOLCHAIN_FILE=${NNAS_PROJECT_SOURCE_DIR}/infra/nncc/cmake/buildtool/config/arm-none-eabi-gcc.cmake"


### PR DESCRIPTION
This PR defines TARGET_ARCH, TARGET_CPU options for onert-micro.

ONE-DCO-1.0-Signed-off-by: Artem Balyshev a.balyshev@partner.samsung.com