### PR TITLE
[onert] Remove forward declaration IExecutionObserver

### DIFF
--- a/runtime/onert/core/include/exec/IExecutor.h
+++ b/runtime/onert/core/include/exec/IExecutor.h
@@ -46,7 +46,6 @@ namespace onert
 {
 namespace exec
 {
-class IExecutionObserver;
 /**
  * @brief Struct to define interface of Executor
  */


### PR DESCRIPTION
IExecutor doesn't need IExecutionObserver in its header.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>