### PR TITLE
Draft: Support  SpaceToDepth, DepthToSpace in fake quantization.

### DIFF
--- a/compiler/circle-quantizer-dredd-recipe-test/test.lst
+++ b/compiler/circle-quantizer-dredd-recipe-test/test.lst
@@ -70,6 +70,8 @@ Add(Quant_Conv_001 DTYPE uint8 GRANULARITY channel OUTPUT_DTYPE float32)
 Add(Quant_Conv_002 DTYPE uint8 GRANULARITY channel INPUT_DTYPE float32 OUTPUT_DTYPE float32)
 
 AddFakeQuant(Quant_Add_000)
+AddFakeQuant(Quant_DepthToSpace_000)
+AddFakeQuant(Quant_SpaceToDepth_000)
 
 ## CIRCLE RECIPE
 

--- a/compiler/luci/pass/src/ConvertToFakeQuantizedModelPass.cpp
+++ b/compiler/luci/pass/src/ConvertToFakeQuantizedModelPass.cpp
@@ -222,10 +222,12 @@ struct FakeQuantize final : public luci::CircleNodeMutableVisitor<void>
   // (dtype will be automatically updated by type inference)
   void visit(luci::CircleCast *) {}
   void visit(luci::CircleConcatenation *) {}
+  void visit(luci::CircleDepthToSpace *) {}
   void visit(luci::CircleGather *) {}
   void visit(luci::CircleSlice *) {}
   void visit(luci::CircleStridedSlice *) {}
   void visit(luci::CircleReshape *) {}
+  void visit(luci::CircleSpaceToDepth *) {}
   void visit(luci::CircleSplit *) {}
   void visit(luci::CircleSplitOut *) {}
   void visit(luci::CircleSplitV *) {}

--- a/res/TensorFlowLiteRecipes/Quant_DepthToSpace_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/Quant_DepthToSpace_000/test.recipe
@@ -1,0 +1,22 @@
+operand {
+  name: "ifm"
+  type: UINT8
+  shape { dim: 1 dim: 2 dim: 2 dim: 4 }
+  quant { min: 0 max: 255 scale: 1.0 zero_point: 0 }
+}
+operand {
+  name: "ofm"
+  type: UINT8
+  shape { dim: 1 dim: 4 dim: 4 dim: 1 }
+  quant { min: 0 max: 255 scale: 1.0 zero_point: 0 }
+}
+operation {
+  type: "DepthToSpace"
+  depth_to_space_options {
+    block_size: 2
+  }
+  input: "ifm"
+  output: "ofm"
+}
+input: "ifm"
+output: "ofm"

--- a/res/TensorFlowLiteRecipes/Quant_DepthToSpace_000/test.rule
+++ b/res/TensorFlowLiteRecipes/Quant_DepthToSpace_000/test.rule
@@ -1,0 +1,12 @@
+# To check fake quantization of DepthToSpace (D2S).
+# 1. ifm is float32.
+# 2. D2S is float32.
+# 3. Q/DQ is inserted at the beginning of the model (from ifm).
+# 4. Q/DQ is not inserted after D2S, because D2S does not change values of input.
+
+RULE    "VERIFY_FILE_FORMAT"      $(verify_file_format) '=' 1
+
+RULE    "IFM_FP32"              $(tensor_dtype ifm) '=' FLOAT32
+RULE    "D2S_FP32"              $(tensor_dtype ofm) '=' FLOAT32
+RULE    "QUANTIZE_OP"           $(op_count QUANTIZE) '=' 1
+RULE    "DEQUANTIZE_OP"         $(op_count DEQUANTIZE) '=' 1

--- a/res/TensorFlowLiteRecipes/Quant_SpaceToDepth_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/Quant_SpaceToDepth_000/test.recipe
@@ -1,0 +1,22 @@
+operand {
+  name: "ifm"
+  type: UINT8
+  shape { dim: 1 dim: 4 dim: 4 dim: 3 }
+  quant { min: 0 max: 255 scale: 1.0 zero_point: 0 }
+}
+operand {
+  name: "ofm"
+  type: UINT8
+  shape { dim: 1 dim: 2 dim: 2 dim: 12 }
+  quant { min: 0 max: 255 scale: 1.0 zero_point: 0 }
+}
+operation {
+  type: "SpaceToDepth"
+  space_to_depth_options {
+    block_size: 2
+  }
+  input: "ifm"
+  output: "ofm"
+}
+input: "ifm"
+output: "ofm"

--- a/res/TensorFlowLiteRecipes/Quant_SpaceToDepth_000/test.rule
+++ b/res/TensorFlowLiteRecipes/Quant_SpaceToDepth_000/test.rule
@@ -1,0 +1,12 @@
+# To check fake quantization of SpaceToDepth (S2D).
+# 1. ifm is float32.
+# 2. S2D is float32.
+# 3. Q/DQ is inserted at the beginning of the model (from ifm).
+# 4. Q/DQ is not inserted after S2D, because S2D does not change values of input.
+
+RULE    "VERIFY_FILE_FORMAT"      $(verify_file_format) '=' 1
+
+RULE    "IFM_FP32"              $(tensor_dtype ifm) '=' FLOAT32
+RULE    "S2D_FP32"              $(tensor_dtype ofm) '=' FLOAT32
+RULE    "QUANTIZE_OP"           $(op_count QUANTIZE) '=' 1
+RULE    "DEQUANTIZE_OP"         $(op_count DEQUANTIZE) '=' 1


### PR DESCRIPTION
On going draft to support SpaceToDepth, DepthToSpace in fake quantization.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/9881