### PR TITLE
[luci] Support S2D, D2S in fake quantization

### DIFF
--- a/compiler/luci/pass/src/ConvertToFakeQuantizedModelPass.cpp
+++ b/compiler/luci/pass/src/ConvertToFakeQuantizedModelPass.cpp
@@ -222,10 +222,12 @@ struct FakeQuantize final : public luci::CircleNodeMutableVisitor<void>
   // (dtype will be automatically updated by type inference)
   void visit(luci::CircleCast *) {}
   void visit(luci::CircleConcatenation *) {}
+  void visit(luci::CircleDepthToSpace *) {}
   void visit(luci::CircleGather *) {}
   void visit(luci::CircleSlice *) {}
   void visit(luci::CircleStridedSlice *) {}
   void visit(luci::CircleReshape *) {}
+  void visit(luci::CircleSpaceToDepth *) {}
   void visit(luci::CircleSplit *) {}
   void visit(luci::CircleSplitOut *) {}
   void visit(luci::CircleSplitV *) {}


### PR DESCRIPTION
This supports SpaceToDepth, DepthToSpace Ops in fake quantization.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---

Related to: https://github.com/Samsung/ONE/issues/9881
Draft PR: https://github.com/Samsung/ONE/pull/9896