### PR TITLE
[circle-quantizer-dredd] Add S2D, D2S fake quant tests

### DIFF
--- a/compiler/circle-quantizer-dredd-recipe-test/test.lst
+++ b/compiler/circle-quantizer-dredd-recipe-test/test.lst
@@ -70,6 +70,8 @@ Add(Quant_Conv_001 DTYPE uint8 GRANULARITY channel OUTPUT_DTYPE float32)
 Add(Quant_Conv_002 DTYPE uint8 GRANULARITY channel INPUT_DTYPE float32 OUTPUT_DTYPE float32)
 
 AddFakeQuant(Quant_Add_000)
+AddFakeQuant(Quant_DepthToSpace_000)
+AddFakeQuant(Quant_SpaceToDepth_000)
 
 ## CIRCLE RECIPE
 


### PR DESCRIPTION
This adds SpaceToDepth, DepthToSpace fake quantization tests.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/9881
Draft PR: https://github.com/Samsung/ONE/pull/9896