### PR TITLE
[res] Fix Path is not defined

### DIFF
--- a/res/TensorFlowPythonExamples/tfpem.py
+++ b/res/TensorFlowPythonExamples/tfpem.py
@@ -6,6 +6,8 @@ import tensorflow as tf
 import importlib
 import argparse
 
+from pathlib import Path
+
 parser = argparse.ArgumentParser(description='Process TensorFlow Python Examples')
 
 parser.add_argument('--mode', metavar='MODE', choices=['pbtxt'], default='pbtxt')


### PR DESCRIPTION
This will fix Path is not defined error in TensorFlowPythonExamples.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>