### PR TITLE
[infra] Check pre-installed TFLite 2.8.0

### DIFF
--- a/infra/nnfw/cmake/packages/TensorFlowLite-2.8.0/TensorFlowLiteConfig.cmake
+++ b/infra/nnfw/cmake/packages/TensorFlowLite-2.8.0/TensorFlowLiteConfig.cmake
@@ -48,3 +48,43 @@ if(BUILD_TENSORFLOW_LITE_2_8_0)
   set(TensorFlowLite_2_8_0_FOUND TRUE)
   return()
 endif()
+
+# Use pre-built TensorFlow Lite
+find_path(TFLITE_INCLUDE_DIR NAMES  tensorflow/lite/c/c_api.h)
+find_library(TFLITE_LIB NAMES       tensorflow2-lite)
+
+if(NOT TFLITE_INCLUDE_DIR)
+  # Tizen install TensorFlow Lite 2.8 headers in /usr/include/tensorflow2
+  find_path(TFLITE_INCLUDE_DIR NAMES tensorflow/lite/c/c_api.h PATHS "/usr/include/tensorflow2")
+  if(NOT TFLITE_INCLUDE_DIR)
+    set(TensorFlowLite_2_8_0_FOUND FALSE)
+    return()
+  endif(NOT TFLITE_INCLUDE_DIR)
+endif(NOT TFLITE_INCLUDE_DIR)
+
+if(NOT TFLITE_LIB)
+  set(TensorFlowLite_2_8_0_FOUND FALSE)
+  return()
+endif(NOT TFLITE_LIB)
+
+message(STATUS "Found TensorFlow Lite 2.8 : TRUE (include: ${TFLITE_INCLUDE_DIR}, lib: ${TFLITE_LIB}")
+
+# TODO Use IMPORTED target
+add_library(tensorflow-lite-2.8.0 INTERFACE)
+target_include_directories(tensorflow-lite-2.8.0 SYSTEM INTERFACE ${TFLITE_INCLUDE_DIR})
+target_link_libraries(tensorflow-lite-2.8.0 INTERFACE ${TFLITE_LIB})
+find_package(Flatbuffers)
+if(Flatbuffers_FOUND)
+  target_link_libraries(tensorflow-lite-2.8.0 INTERFACE flatbuffers::flatbuffers)
+endif(Flatbuffers_FOUND)
+
+# Prefer -pthread to -lpthread
+set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+find_package(Threads QUIET)
+
+if(Threads_FOUND)
+  target_link_libraries(tensorflow-lite-2.8.0 INTERFACE ${CMAKE_THREAD_LIBS_INIT})
+endif(Threads_FOUND)
+
+set(TensorFlowLite_2_8_0_FOUND TRUE)


### PR DESCRIPTION
This commit updates TensorFlowLiteConfig.cmake to use pre-installed TFLite 2.8.0 on Tizen.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: #9671 