### PR TITLE
[onecc] Change the way removing whitespace in Makefile.arm32

### DIFF
--- a/infra/nncc/Makefile.arm32
+++ b/infra/nncc/Makefile.arm32
@@ -55,8 +55,8 @@ ARM32_HOST_ITEMS+=;common-artifacts
 ARM32_HOST_ITEMS+=;luci-eval-driver;luci-value-test
 
 
-_SPACE_:=
-_SPACE_+=
+_EMPTY_:=
+_SPACE_:=$(_EMPTY_) $(_EMPTY_)
 ARM32_BUILD_WHITELIST=$(subst $(_SPACE_),,$(ARM32_BUILD_ITEMS))
 ARM32_HOST_WHITELIST=$(subst $(_SPACE_),,$(ARM32_HOST_ITEMS))
 


### PR DESCRIPTION
This commit changes the way removing whispace in Makefile.arm32.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>