### PR TITLE
[res] Introduce LSTM_unroll for TF examples

### DIFF
--- a/res/TensorFlowPythonExamples/examples/LSTM_unroll/__init__.py
+++ b/res/TensorFlowPythonExamples/examples/LSTM_unroll/__init__.py
@@ -1,0 +1,11 @@
+# NOTE tested with TF 2.8.0
+import tensorflow as tf
+import numpy as np
+
+from tensorflow import keras
+
+model = keras.Sequential()
+shape = (4, 4)
+
+model.add(keras.layers.InputLayer(input_shape=shape, batch_size=1))
+model.add(keras.layers.LSTM(2, input_shape=shape, unroll=True))


### PR DESCRIPTION
This will introduce LSTM_unroll in TensorFlowPythonExamples
- LSTM with unroll
- use known(1) batch size

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>