### PR TITLE
[luci-pass-value-test] Add ForwardTransposeOpPass test

### DIFF
--- a/compiler/luci-pass-value-test/test.lst
+++ b/compiler/luci-pass-value-test/test.lst
@@ -34,6 +34,7 @@ addeval(Net_InstanceNorm_002 fuse_instnorm)
 addeval(Net_InstanceNorm_003 fuse_instnorm)
 addeval(Net_StridedSlice_StridedSlice_000 remove_unnecessary_strided_slice)
 addeval(FullyConnected_007 replace_non_const_fc_with_batch_matmul)
+addeval(Net_Transpose_Add_000 forward_transpose_op)
 
 # test for limited support for FLOAT16
 addeval(Net_Dequantize_Add_000 fold_dequantize)


### PR DESCRIPTION
This adds a test for ForwardTransposeOpPass.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/9872
Draft PR: https://github.com/Samsung/ONE/pull/9873