### PR TITLE
[one-cmds] Add forward_transpose_op optimization option

### DIFF
--- a/compiler/one-cmds/onelib/constant.py
+++ b/compiler/one-cmds/onelib/constant.py
@@ -35,6 +35,7 @@ class CONSTANT:
         ('fold_gather', 'fold Gather op'),
         ('fold_sparse_to_dense', 'fold SparseToDense op'),
         ('forward_reshape_to_unaryop', 'Forward Reshape op'),
+        ('forward_transpose_op', 'Forward Transpose op'),
         ('fuse_add_with_tconv', 'fuse Add op to Transposed'),
         ('fuse_add_with_fully_connected', 'fuse Add op to FullyConnected op'),
         ('fuse_batchnorm_with_conv', 'fuse BatchNorm op to Convolution op'),


### PR DESCRIPTION
This adds forward_transpose_op optimization option.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/9872
Draft PR: https://github.com/Samsung/ONE/pull/9873