### PR TITLE
[npud] Do not throw errors when server is already running or stopped

### DIFF
--- a/runtime/service/npud/core/Server.cc
+++ b/runtime/service/npud/core/Server.cc
@@ -37,7 +37,7 @@ void Server::run(void)
 
   if (_isRunning.exchange(true))
   {
-    throw std::runtime_error("Mainloop is already running.");
+    return;
   }
 
   g_main_loop_run(_mainloop.get());
@@ -49,7 +49,7 @@ void Server::stop(void)
 
   if (!_isRunning.load())
   {
-    throw std::runtime_error("Mainloop is not running");
+    return;
   }
 
   while (!g_main_loop_is_running(_mainloop.get()))


### PR DESCRIPTION
This commit remove exception when server is already running or stopped. It returns quietly.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>