### PR TITLE
[luci/lang] Introduce output_state for LSTM

### DIFF
--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleUnidirectionalSequenceLSTM.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleUnidirectionalSequenceLSTM.h
@@ -76,6 +76,10 @@ public:
   loco::Node *projection_bias(void) const { return at(17)->node(); }
   void projection_bias(loco::Node *node) { at(17)->node(node); }
 
+  // NOTE activation_state is renamed to output_state
+  loco::Node *output_state(void) const { return at(18)->node(); }
+  void output_state(loco::Node *node) { at(18)->node(node); }
+  // TODO remove activation_state
   loco::Node *activation_state(void) const { return at(18)->node(); }
   void activation_state(loco::Node *node) { at(18)->node(node); }
   loco::Node *cell_state(void) const { return at(19)->node(); }

--- a/compiler/luci/lang/src/Nodes/CircleUnidirectionalSequenceLSTM.test.cpp
+++ b/compiler/luci/lang/src/Nodes/CircleUnidirectionalSequenceLSTM.test.cpp
@@ -52,7 +52,7 @@ TEST(CircleUnidirectionalSequenceLSTMTest, constructor_P)
   ASSERT_EQ(nullptr, trc_node.projection_weights());
   ASSERT_EQ(nullptr, trc_node.projection_bias());
 
-  ASSERT_EQ(nullptr, trc_node.activation_state());
+  ASSERT_EQ(nullptr, trc_node.output_state());
   ASSERT_EQ(nullptr, trc_node.cell_state());
 
   ASSERT_EQ(nullptr, trc_node.input_layer_norm_coefficients());


### PR DESCRIPTION
This will introduce output_state attribute in CircleUnidirectionalSequenceLSTM to replace activation_state attribute.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>