### PR TITLE
[luci-interpreter] Relocate getTfLiteActivation

### DIFF
--- a/compiler/luci-interpreter/src/kernels/SVDF.cpp
+++ b/compiler/luci-interpreter/src/kernels/SVDF.cpp
@@ -26,30 +26,6 @@ namespace luci_interpreter
 namespace kernels
 {
 
-namespace
-{
-TfLiteFusedActivation get_tflite_activation(Activation activation)
-{
-  switch (activation)
-  {
-    case luci::FusedActFunc::RELU:
-      return kTfLiteActRelu;
-    case luci::FusedActFunc::RELU6:
-      return kTfLiteActRelu6;
-    case luci::FusedActFunc::RELU_N1_TO_1:
-      return kTfLiteActReluN1To1;
-    case luci::FusedActFunc::TANH:
-      return kTfLiteActTanh;
-    case luci::FusedActFunc::SIGN_BIT:
-      return kTfLiteActSignBit;
-    case luci::FusedActFunc::NONE:
-      return kTfLiteActNone;
-    default:
-      throw std::runtime_error("Unsupported activation type");
-  }
-}
-} // namespace
-
 SVDF::SVDF(const Tensor *input, const Tensor *weight_feature, const Tensor *weight_time,
            const Tensor *bias, const Tensor *input_activation_state, Tensor *output,
            Tensor *scratchpad_activation_state, Tensor *scratchpad_1, Tensor *scratchpad_2,
@@ -191,7 +167,7 @@ void SVDF::evalInteger() const
   TfLiteSVDFParams params_svdf{};
   params_svdf.asymmetric_quantize_inputs = params().asymmetric_quantize_inputs;
   params_svdf.rank = params().svdf_rank;
-  params_svdf.activation = get_tflite_activation(params().activation);
+  params_svdf.activation = getTfLiteActivation(params().activation);
 
   auto scratchpad_activation_state = getOutputTensors()[1];
   // Note: it is expected that activation_state input variable tensor reset to zero,
@@ -219,7 +195,7 @@ void SVDF::evalFloat() const
   TfLiteSVDFParams params_svdf{};
   params_svdf.asymmetric_quantize_inputs = params().asymmetric_quantize_inputs;
   params_svdf.rank = params().svdf_rank;
-  params_svdf.activation = get_tflite_activation(params().activation);
+  params_svdf.activation = getTfLiteActivation(params().activation);
 
   auto scratchpad_activation_state = getOutputTensors()[1];
   // Note: it is expected that activation_state input variable tensor reset to zero,

--- a/compiler/luci-interpreter/src/kernels/Utils.cpp
+++ b/compiler/luci-interpreter/src/kernels/Utils.cpp
@@ -27,6 +27,27 @@ namespace luci_interpreter
 namespace kernels
 {
 
+TfLiteFusedActivation getTfLiteActivation(Activation activation)
+{
+  switch (activation)
+  {
+    case luci::FusedActFunc::RELU:
+      return kTfLiteActRelu;
+    case luci::FusedActFunc::RELU6:
+      return kTfLiteActRelu6;
+    case luci::FusedActFunc::RELU_N1_TO_1:
+      return kTfLiteActReluN1To1;
+    case luci::FusedActFunc::TANH:
+      return kTfLiteActTanh;
+    case luci::FusedActFunc::SIGN_BIT:
+      return kTfLiteActSignBit;
+    case luci::FusedActFunc::NONE:
+      return kTfLiteActNone;
+    default:
+      throw std::runtime_error("Unsupported activation type");
+  }
+}
+
 template <typename T>
 void calculateActivationRange(Activation activation, T *activation_min, T *activation_max)
 {

--- a/compiler/luci-interpreter/src/kernels/Utils.h
+++ b/compiler/luci-interpreter/src/kernels/Utils.h
@@ -21,6 +21,7 @@
 #include "core/KernelParams.h"
 #include "luci_interpreter/core/Tensor.h"
 
+#include <tensorflow/lite/kernels/internal/tensor_utils.h>
 #include <tensorflow/lite/kernels/internal/types.h>
 
 #include <cassert>
@@ -75,6 +76,8 @@ inline int32_t calcOffset(const Shape &shape, int32_t d0, int32_t d1, int32_t d2
 {
   return ((d0 * shape.dim(1) + d1) * shape.dim(2) + d2) * shape.dim(3) + d3;
 }
+
+TfLiteFusedActivation getTfLiteActivation(Activation activation);
 
 template <typename T>
 void calculateActivationRange(Activation activation, T *activation_min, T *activation_max);


### PR DESCRIPTION
This will relocate get_tflite_activation method as getTfLiteActivation from SVDF kernel to Utils. Method name is changed to match naming convention of Utils.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>