### PR TITLE
[luci/lang] Remove activation_state

### DIFF
--- a/compiler/luci/lang/include/luci/IR/Nodes/CircleUnidirectionalSequenceLSTM.h
+++ b/compiler/luci/lang/include/luci/IR/Nodes/CircleUnidirectionalSequenceLSTM.h
@@ -76,12 +76,8 @@ public:
   loco::Node *projection_bias(void) const { return at(17)->node(); }
   void projection_bias(loco::Node *node) { at(17)->node(node); }
 
-  // NOTE activation_state is renamed to output_state
   loco::Node *output_state(void) const { return at(18)->node(); }
   void output_state(loco::Node *node) { at(18)->node(node); }
-  // TODO remove activation_state
-  loco::Node *activation_state(void) const { return at(18)->node(); }
-  void activation_state(loco::Node *node) { at(18)->node(node); }
   loco::Node *cell_state(void) const { return at(19)->node(); }
   void cell_state(loco::Node *node) { at(19)->node(node); }
 


### PR DESCRIPTION
This will remove not used anymore activation_state attribute from CircleUnidirectionalSequenceLSTM.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>