### PR TITLE
[infra] Add armv8-m TARGET_ARCH

### DIFF
--- a/infra/cmake/modules/IdentifyPlatform.cmake
+++ b/infra/cmake/modules/IdentifyPlatform.cmake
@@ -51,6 +51,8 @@ endif()
 
 if("${TARGET_ARCH}" STREQUAL "x86_64")
   set(TARGET_ARCH_BASE ${TARGET_ARCH})
+elseif("${TARGET_ARCH}" STREQUAL "armv8-m")
+  set(TARGET_ARCH_BASE "arm")
 elseif("${TARGET_ARCH}" STREQUAL "armv7-r")
   set(TARGET_ARCH_BASE "arm")
 elseif("${TARGET_ARCH}" STREQUAL "armv7em")


### PR DESCRIPTION
This PR adds armv8-m TARGET_ARCH to build to support rtl8721csm board for onert-micro.

ONE-DCO-1.0-Signed-off-by: Artem Balyshev a.balyshev@partner.samsung.com