### PR TITLE
[loco] Fix test not to double destroy with node

### DIFF
--- a/compiler/loco/src/IR/Graph.test.cpp
+++ b/compiler/loco/src/IR/Graph.test.cpp
@@ -79,6 +79,18 @@ TEST(GraphTest, create_and_destroy_node)
   auto pull = g->nodes()->create<loco::Pull>();
 
   ASSERT_NO_THROW(g->nodes()->destroy(pull));
+}
+
+TEST(GraphTest, DISABLED_create_and_destroy_node_again)
+{
+  auto g = loco::make_graph();
+
+  auto pull = g->nodes()->create<loco::Pull>();
+
+  ASSERT_NO_THROW(g->nodes()->destroy(pull));
+  // NOTE calling destroy again raises Segmentation fault
+  //      refer https://github.com/Samsung/ONE/issues/9968
+  // TODO fix this
   ASSERT_THROW(g->nodes()->destroy(pull), std::invalid_argument);
 }
 
@@ -139,7 +151,6 @@ TEST(GraphTest, consturctor_with_param_node)
   ASSERT_FLOAT_EQ(test_node->f(), 11.11);
 
   ASSERT_NO_THROW(g->nodes()->destroy(test_node));
-  ASSERT_THROW(g->nodes()->destroy(test_node), std::invalid_argument);
 }
 
 TEST(GraphTest, getters_over_const_instance)


### PR DESCRIPTION
This will fix unit test not to double destory with a single node object.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>