### PR TITLE
[one-cmds] Revise one-partition_neg_001.test

### DIFF
--- a/compiler/one-cmds/tests/one-partition_neg_001.test
+++ b/compiler/one-cmds/tests/one-partition_neg_001.test
@@ -26,6 +26,11 @@ trap_err_onexit()
     echo "${filename_ext} SUCCESS"
     exit 0
   fi
+  # for debug build test
+  if grep -1 "std::runtime_error" "${filename}.log"; then
+    echo "${filename_ext} SUCCESS"
+    exit 0
+  fi
 
   echo "${filename_ext} FAILED"
   exit 255


### PR DESCRIPTION
This will revise one-partition_neg_001.test to check for Debug build.
- debug will throw runtime_error

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>