### PR TITLE
[common-artifacts] Enable UnidirectionalSequenceLSTM_001

### DIFF
--- a/compiler/common-artifacts/exclude.lst
+++ b/compiler/common-artifacts/exclude.lst
@@ -5,7 +5,6 @@
 
 #[[ optimize : Exclude from circle optimization(circle2circle) ]]
 ## TensorFlowLiteRecipes
-optimize(UnidirectionalSequenceLSTM_001) # This recipe contains is_variable Tensor
 
 ## CircleRecipes
 
@@ -137,7 +136,6 @@ tcgenerate(Tile_U8_000)
 tcgenerate(TopKV2_000)
 tcgenerate(TopKV2_001)
 tcgenerate(UnidirectionalSequenceLSTM_000) # runtime and luci-interpreter doesn't support UnidirectionalSequenceLSTM op yet
-tcgenerate(UnidirectionalSequenceLSTM_001) # runtime and luci-interpreter doesn't support UnidirectionalSequenceLSTM op yet
 tcgenerate(Unique_000)
 tcgenerate(Unique_001)
 tcgenerate(Unique_002)


### PR DESCRIPTION
This will enable test for UnidirectionalSequenceLSTM_001 as it is now possible to run UnidirectionalSequenceLSTM Op.
- UnidirectionalSequenceLSTM_000 is not enabled this is just for creation of this Op

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>