### PR TITLE
[infra/runtime] Prevent multiple build TFLite 2.8

### DIFF
--- a/infra/nnfw/cmake/packages/TensorFlowLite-2.8.0/TensorFlowLiteConfig.cmake
+++ b/infra/nnfw/cmake/packages/TensorFlowLite-2.8.0/TensorFlowLiteConfig.cmake
@@ -1,3 +1,9 @@
+# NOTE This line prevents multiple definitions of tensorflow-lite target
+if(TARGET tensorflow-lite-2.8.0)
+  set(TensorFlowLite_FOUND TRUE)
+  return()
+endif(TARGET tensorflow-lite-2.8.0)
+
 if(BUILD_TENSORFLOW_LITE)
   macro(return_unless VAR)
   if(NOT ${VAR})


### PR DESCRIPTION
This commit updates TensorFlowLiteConfig.cmake for TFLite 2.8 to prevent multiple definition.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>