### PR TITLE
[npud] Disable copy constructor and assignment operator

### DIFF
--- a/runtime/service/npud/core/Server.h
+++ b/runtime/service/npud/core/Server.h
@@ -32,6 +32,9 @@ namespace core
 class Server
 {
 public:
+  Server(const Server &) = delete;
+  Server &operator=(const Server &) = delete;
+
   void run(void);
   void stop(void);
 


### PR DESCRIPTION
This commit disables copy constructors and assignment operator.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>