### PR TITLE
[one-cmds] Fix trusted host name

### DIFF
--- a/compiler/one-cmds/one-prepare-venv
+++ b/compiler/one-cmds/one-prepare-venv
@@ -42,7 +42,7 @@ VER_ONNX_TF=1.10.0
 
 PIP_TRUSTED_HOST="--trusted-host pypi.org "
 PIP_TRUSTED_HOST+="--trusted-host pypi.python.org "
-PIP_TRUSTED_HOST+="--trusted-host files.pythonhost.org "
+PIP_TRUSTED_HOST+="--trusted-host files.pythonhosted.org "
 PIP_TRUSTED_HOST+="--trusted-host download.pytorch.org "
 
 PIP_TIMEOUT="--default-timeout=1000 "


### PR DESCRIPTION
This will fix trusted host name for files.pythonhosted.org

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>