### PR TITLE
[onert] Remove compiler state variable

### DIFF
--- a/runtime/onert/core/include/compiler/Compiler.h
+++ b/runtime/onert/core/include/compiler/Compiler.h
@@ -32,12 +32,6 @@ namespace onert
 namespace compiler
 {
 
-enum class State
-{
-  CREATED, // Before compilation
-  COMPILED // Success compilation
-};
-
 struct ManualSchedulerOptions
 {
 public:
@@ -126,8 +120,6 @@ public:
   std::vector<std::shared_ptr<CompilerArtifact>> compile(const char *package_file_path,
                                                          const char *map_file_path);
 
-  State state(void) const { return _state; }
-
   /**
    * @brief   Allow to compute float32 using float16 data type
    */
@@ -147,12 +139,6 @@ private:
 
 private:
   std::shared_ptr<ir::NNPkg> _nnpkg;
-  // NOTE These executors does not have duplicated subgraph. This mean they do not allow support
-  // subgraphs being called recursively because data of non-constant tensor of parent executor will
-  // be updated by child executor. If you want to support subgraphs being called recursively, you
-  // have to add allocate non-constant tensor memory of executors in execution time when each
-  // subgraph is called.
-  State _state;
   std::vector<CompilerOptions *> _voptions;
 };
 

--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -238,14 +238,14 @@ std::unique_ptr<CompilerOptions> CompilerOptions::fromGlobalConfig()
 }
 
 Compiler::Compiler(const std::shared_ptr<ir::Model> &model, CompilerOptions &copt)
-  : _nnpkg{std::make_shared<ir::NNPkg>(model)}, _state{State::CREATED}, _voptions{&copt}
+  : _nnpkg{std::make_shared<ir::NNPkg>(model)}, _voptions{&copt}
 {
   // DO NOTHING
 }
 
 Compiler::Compiler(const std::shared_ptr<ir::NNPkg> &nnpkg,
                    std::vector<std::unique_ptr<CompilerOptions>> &copts)
-  : _nnpkg{nnpkg}, _state{State::CREATED}, _voptions{}
+  : _nnpkg{nnpkg}, _voptions{}
 {
   for (uint32_t i = 0; i < copts.size(); i++)
   {
@@ -493,7 +493,6 @@ std::shared_ptr<CompilerArtifact> Compiler::compile(void)
     _nnpkg->primary_model()->iterate([&](const ir::SubgraphIndex &index, ir::Graph &subg) {
       executors->emplace(ir::ModelIndex{0}, index, std::make_unique<interp::InterpExecutor>(subg));
     });
-    _state = State::COMPILED;
     return std::make_shared<CompilerArtifact>(executors, nullptr);
   }
 
@@ -631,7 +630,6 @@ std::shared_ptr<CompilerArtifact> Compiler::compile(void)
   /********************************
    * Code generation phase finished
    ********************************/
-  _state = State::COMPILED;
   return std::make_shared<CompilerArtifact>(executors, std::move(tracing_ctx));
 }
 
@@ -743,7 +741,6 @@ std::vector<std::shared_ptr<CompilerArtifact>> Compiler::compile(const char *pac
       executors->emplace(ir::ModelIndex{0}, index, std::make_unique<interp::InterpExecutor>(subg));
     });
     results.push_back(std::make_shared<CompilerArtifact>(executors, nullptr));
-    _state = State::COMPILED;
     return results;
   }
 
@@ -843,7 +840,6 @@ std::vector<std::shared_ptr<CompilerArtifact>> Compiler::compile(const char *pac
   /********************************
    * Code generation phase finished
    ********************************/
-  _state = State::COMPILED;
 
   return results;
 }

--- a/runtime/onert/frontend/nnapi/compilation.cc
+++ b/runtime/onert/frontend/nnapi/compilation.cc
@@ -58,7 +58,7 @@ int ANeuralNetworksCompilation_finish(ANeuralNetworksCompilation *compilation)
     return ANEURALNETWORKS_UNEXPECTED_NULL;
   }
 
-  if (compilation->state() != ::onert::compiler::State::CREATED)
+  if (compilation->isFinished())
   {
     VERBOSE(NNAPI::Compilation) << "finish: Already finished" << std::endl;
     return ANEURALNETWORKS_BAD_STATE;
@@ -87,7 +87,7 @@ int ANeuralNetworksCompilation_setPreference(ANeuralNetworksCompilation *compila
     return ANEURALNETWORKS_UNEXPECTED_NULL;
   }
 
-  if (compilation->state() != ::onert::compiler::State::CREATED)
+  if (compilation->isFinished())
   {
     VERBOSE(NNAPI::Compilation) << "setPreference: Already finished" << std::endl;
     return ANEURALNETWORKS_BAD_STATE;

--- a/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksCompilation.cc
+++ b/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksCompilation.cc
@@ -36,6 +36,7 @@ bool ANeuralNetworksCompilation::finish() noexcept
   try
   {
     _artifact = _compiler->compile();
+    _compiler = nullptr;
   }
   catch (const std::exception &e)
   {

--- a/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksCompilation.h
+++ b/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksCompilation.h
@@ -32,8 +32,8 @@ public:
 
 public:
   bool finish() noexcept;
+  bool isFinished() noexcept { return _compiler == nullptr; }
 
-  onert::compiler::State state(void) noexcept { return _compiler->state(); }
   void publish(std::shared_ptr<onert::exec::Executors> &executors) noexcept
   {
     executors = _artifact ? _artifact->_executors : nullptr;


### PR DESCRIPTION
This commit removes compiler state variable setting on Compiler. It is used on NNAPI only, and it can be maintained on frontend.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>