### PR TITLE
[circle-execution-plan] Add luci-interpreter runtime

### DIFF
--- a/compiler/circle-execution-plan/pal/TargetPlatform.h
+++ b/compiler/circle-execution-plan/pal/TargetPlatform.h
@@ -29,7 +29,8 @@ enum SupportedPlatformType
 
 enum RuntimeType
 {
-  ONERT_MICRO
+  ONERT_MICRO,
+  LUCI_INTERPRETER
 };
 
 enum AllocatingMode

--- a/compiler/circle-execution-plan/src/CircleExecutionPlan.cpp
+++ b/compiler/circle-execution-plan/src/CircleExecutionPlan.cpp
@@ -140,9 +140,20 @@ int entry(int argc, char **argv)
   {
     runtime_type = circle_planner::RuntimeType::ONERT_MICRO;
   }
+  else if (runtime_name == "luci-interpreter")
+  {
+    runtime_type = circle_planner::RuntimeType::LUCI_INTERPRETER;
+  }
   else
   {
     std::cerr << "ERROR: Invalid runtime name '" << runtime_name << "'" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  if (allocating_mode == circle_planner::AllocatingMode::SPLIT and
+      runtime_type == circle_planner::RuntimeType::LUCI_INTERPRETER)
+  {
+    std::cerr << "Split buffer type can only be used with onert-micro runtime" << std::endl;
     return EXIT_FAILURE;
   }
 

--- a/compiler/circle-execution-plan/src/ExecutionPlanner.cpp
+++ b/compiler/circle-execution-plan/src/ExecutionPlanner.cpp
@@ -241,12 +241,32 @@ void ExecutionPlanner::make_execution_plan_onert_micro_common_buffer()
   VERBOSE(l, 0) << "Buffer required memory = " << _required_size << std::endl;
 }
 
+void ExecutionPlanner::make_execution_plan_luci_interpreter()
+{
+  LOGGER(l);
+
+  get_default_execution_order_plan();
+  _required_size = get_offsets_with_greedy_by_size();
+  for (uint32_t i = 0; i < _ordered_nodes.size(); i++)
+  {
+    luci::CircleNodeExecutionPlan execution_plan(i, _offsets[i]);
+    luci::add_execution_plan(loco::must_cast<luci::CircleNode *>(_ordered_nodes[i]),
+                             execution_plan);
+  }
+
+  VERBOSE(l, 0) << "Buffer required memory = " << _required_size << std::endl;
+  dump_inform();
+}
+
 void ExecutionPlanner::make_execution_plan()
 {
   switch (_runtime_type)
   {
     case ONERT_MICRO:
       make_execution_plan_onert_micro_base();
+      break;
+    case LUCI_INTERPRETER:
+      make_execution_plan_luci_interpreter();
       break;
     default:
       throw std::runtime_error("Unsupported runtime platform\n");

--- a/compiler/circle-execution-plan/src/ExecutionPlanner.h
+++ b/compiler/circle-execution-plan/src/ExecutionPlanner.h
@@ -117,6 +117,9 @@ private:
   // Constants are not written.
   void make_execution_plan_onert_micro_base();
 
+  // Save execution plan for luci-interpreter runtime base function.
+  void make_execution_plan_luci_interpreter();
+
   // Save execution plan for onert-micro runtime for common buffer type.
   void make_execution_plan_onert_micro_common_buffer();
 


### PR DESCRIPTION
This PR adds luci-interpreter runtime.

for issue: https://github.com/Samsung/ONE/issues/9849

draft: https://github.com/Samsung/ONE/pull/9893

ONE-DCO-1.0-Signed-off-by: Artem Balyshev <a.balyshev@samsung.com>