### PR TITLE
[luci/pass] Add RemoveDuplicateConstPass to luci/pass

### DIFF
--- a/compiler/luci/pass/include/luci/CircleOptimizer.h
+++ b/compiler/luci/pass/include/luci/CircleOptimizer.h
@@ -84,6 +84,7 @@ public:
       RemoveRedundantReshape,
       RemoveFakeQuant,
       RemoveQuantDequantSeq,
+      RemoveDuplicateConst,
     };
 
     enum AlgorithmParameters

--- a/compiler/luci/pass/include/luci/Pass/RemoveDuplicateConstPass.h
+++ b/compiler/luci/pass/include/luci/Pass/RemoveDuplicateConstPass.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __LUCI_REMOVE_DUPLICATE_CONST_PASS_H__
+#define __LUCI_REMOVE_DUPLICATE_CONST_PASS_H__
+
+#include <luci/IR/CircleNodes.h>
+#include <logo/Pass.h>
+
+namespace luci
+{
+
+/**
+ * @brief  Class to remove duplicate Const nodes.
+ */
+struct RemoveDuplicateConstPass final : public logo::Pass
+{
+  const char *name(void) const final { return "luci::RemoveDuplicateConstPass"; }
+
+  bool run(loco::Graph *g) final;
+
+private:
+  bool remove_duplicate_const();
+
+  template <loco::DataType DT> void add_to_map(luci::CircleConst *const_node);
+
+  std::map<float, std::vector<CircleConst *>> _sum_to_const;
+};
+
+} // namespace luci
+
+#endif // __LUCI_REMOVE_DUPLICATE_CONST_PASS_H__

--- a/compiler/luci/pass/src/CircleOptimizer.cpp
+++ b/compiler/luci/pass/src/CircleOptimizer.cpp
@@ -39,6 +39,7 @@
 #include "luci/Pass/FusePreActivationBatchNormPass.h"
 #include "luci/Pass/FuseTransposeWithMeanPass.h"
 #include "luci/Pass/MakeBatchNormGammaPositivePass.h"
+#include "luci/Pass/RemoveDuplicateConstPass.h"
 #include "luci/Pass/RemoveFakeQuantPass.h"
 #include "luci/Pass/RemoveQuantDequantSeqPass.h"
 #include "luci/Pass/RemoveRedundantReshapePass.h"
@@ -330,6 +331,10 @@ void CircleOptimizer::optimize(loco::Graph *g) const
   if (_options->query(Options::Algorithm::ExpandBroadcastConst))
   {
     phase.emplace_back(std::make_unique<luci::ExpandBroadcastConstPass>());
+  }
+  if (_options->query(Options::Algorithm::RemoveDuplicateConst))
+  {
+    phase.emplace_back(std::make_unique<luci::RemoveDuplicateConstPass>());
   }
   if (_options->query(Options::Algorithm::RemoveFakeQuant))
   {

--- a/compiler/luci/pass/src/RemoveDuplicateConstPass.cpp
+++ b/compiler/luci/pass/src/RemoveDuplicateConstPass.cpp
@@ -126,7 +126,7 @@ bool RemoveDuplicateConstPass::remove_duplicate_const()
             is_equal = is_equal_consts<loco::DataType::U8>(reference_const, cur_const);
             break;
           default:
-            throw std::runtime_error("Not supported type\n");
+            continue;
         }
 
         if (not is_equal)
@@ -166,8 +166,28 @@ void RemoveDuplicateConstPass::add_to_map(luci::CircleConst *const_node)
   }
 }
 
-/*
+/**
  * Remove duplicate Const nodes.
+ *
+ * BEFORE
+ *    [CircleNode]   [CircleConst]
+ *          |        /
+ *          |      /
+ *    [CircleNode]    [CircleConst]
+ *          |        /
+ *          |      /
+ *    [CircleNode]
+ *
+ * AFTER
+ *
+ *    [CircleNode]   [CircleConst]
+ *          |        /     /
+ *          |      /     /
+ *    [CircleNode]     /
+ *          |        /
+ *          |      /
+ *    [CircleNode]
+ *
  */
 bool RemoveDuplicateConstPass::run(loco::Graph *g)
 {

--- a/compiler/luci/pass/src/RemoveDuplicateConstPass.cpp
+++ b/compiler/luci/pass/src/RemoveDuplicateConstPass.cpp
@@ -26,18 +26,21 @@ bool compare_quant_params(luci::CircleConst *left, luci::CircleConst *right)
   const auto left_quant_param = left->quantparam();
   const auto right_quant_param = right->quantparam();
 
+  if (left_quant_param == right_quant_param)
+    return true;
+
   if (left_quant_param != nullptr and right_quant_param != nullptr)
   {
-    if (left_quant_param->scale != right_quant_param->scale or
-        left_quant_param->quantized_dimension != right_quant_param->quantized_dimension or
-        left_quant_param->zerop != right_quant_param->zerop or
-        left_quant_param->min != right_quant_param->min or
-        left_quant_param->max != right_quant_param->max)
+    if (left_quant_param->scale == right_quant_param->scale and
+        left_quant_param->quantized_dimension == right_quant_param->quantized_dimension and
+        left_quant_param->zerop == right_quant_param->zerop and
+        left_quant_param->min == right_quant_param->min and
+        left_quant_param->max == right_quant_param->max)
     {
-      return false;
+      return true;
     }
   }
-  return true;
+  return false;
 }
 
 bool compare_dim_values(luci::CircleConst *left, luci::CircleConst *right)

--- a/compiler/luci/pass/src/RemoveDuplicateConstPass.cpp
+++ b/compiler/luci/pass/src/RemoveDuplicateConstPass.cpp
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Pass/RemoveDuplicateConstPass.h"
+
+#include <luci/Log.h>
+
+namespace
+{
+
+template <loco::DataType DT> bool is_equal_consts(luci::CircleConst *left, luci::CircleConst *right)
+{
+  const auto left_rank = left->rank();
+  const auto right_rank = right->rank();
+
+  const auto left_quant_param = left->quantparam();
+  const auto right_quant_param = right->quantparam();
+
+  if (left_quant_param != nullptr and right_quant_param != nullptr)
+  {
+    if (left_quant_param->scale != right_quant_param->scale or
+        left_quant_param->quantized_dimension != right_quant_param->quantized_dimension)
+      return false;
+
+    if ((left->dtype() == loco::DataType::U8 or left->dtype() == loco::DataType::S8) and
+        left_quant_param->zerop != right_quant_param->zerop)
+      return false;
+  }
+
+  if (left_rank != right_rank)
+    return false;
+
+  for (uint32_t i = 0; i < left_rank; ++i)
+  {
+    if (left->dim(i).value() != right->dim(i).value())
+      return false;
+  }
+
+  for (uint32_t i = 0; i < left->size<DT>(); ++i)
+  {
+    if (left->at<DT>(i) != right->at<DT>(i))
+      return false;
+  }
+
+  return true;
+}
+
+} // namespace
+
+namespace luci
+{
+
+bool RemoveDuplicateConstPass::remove_duplicate_const()
+{
+  bool changed = false;
+
+  for (auto &cur_pair : _sum_to_const)
+  {
+    // if single const - continue
+    if (cur_pair.second.size() == 1)
+      continue;
+
+    for (auto reference_const : cur_pair.second)
+    {
+      if (reference_const == nullptr)
+        continue;
+
+      for (uint32_t i = 0; i < cur_pair.second.size(); ++i)
+      {
+        auto cur_const = cur_pair.second.at(i);
+        if (cur_const == nullptr or cur_const == reference_const)
+          continue;
+
+        if (cur_const->dtype() != reference_const->dtype())
+          continue;
+
+        bool is_equal;
+
+        switch (cur_const->dtype())
+        {
+          case loco::DataType::FLOAT32:
+            is_equal = is_equal_consts<loco::DataType::FLOAT32>(reference_const, cur_const);
+            break;
+          case loco::DataType::S32:
+            is_equal = is_equal_consts<loco::DataType::S32>(reference_const, cur_const);
+            break;
+          case loco::DataType::S16:
+            is_equal = is_equal_consts<loco::DataType::S16>(reference_const, cur_const);
+            break;
+          case loco::DataType::S8:
+            is_equal = is_equal_consts<loco::DataType::S8>(reference_const, cur_const);
+            break;
+          case loco::DataType::U8:
+            is_equal = is_equal_consts<loco::DataType::U8>(reference_const, cur_const);
+            break;
+          default:
+            is_equal = false;
+        }
+
+        if (not is_equal)
+          continue;
+
+        loco::replace(cur_const).with(reference_const);
+
+        // Remove from next checking
+        cur_pair.second[i] = nullptr;
+
+        changed = true;
+      }
+    }
+  }
+
+  return changed;
+}
+
+template <loco::DataType DT>
+void RemoveDuplicateConstPass::add_to_map(luci::CircleConst *const_node)
+{
+  const auto const_size = const_node->size<DT>();
+  float sum = 0.0;
+
+  for (uint32_t i = 0; i < const_size; ++i)
+  {
+    sum += const_node->at<DT>(i);
+  }
+
+  if (_sum_to_const.find(sum) == _sum_to_const.end())
+  {
+    _sum_to_const[sum] = {const_node};
+  }
+  else
+  {
+    _sum_to_const.at(sum).push_back(const_node);
+  }
+}
+
+/*
+ * Remove duplicate Const nodes.
+ */
+bool RemoveDuplicateConstPass::run(loco::Graph *g)
+{
+  for (auto node : loco::active_nodes(loco::output_nodes(g)))
+  {
+    auto const_node = dynamic_cast<luci::CircleConst *>(node);
+    if (const_node == nullptr)
+      continue;
+
+    switch (const_node->dtype())
+    {
+      case loco::DataType::FLOAT32:
+        add_to_map<loco::DataType::FLOAT32>(const_node);
+        break;
+      case loco::DataType::S32:
+        add_to_map<loco::DataType::S32>(const_node);
+        break;
+      case loco::DataType::S16:
+        add_to_map<loco::DataType::S16>(const_node);
+        break;
+      case loco::DataType::S8:
+        add_to_map<loco::DataType::S8>(const_node);
+        break;
+      case loco::DataType::U8:
+        add_to_map<loco::DataType::U8>(const_node);
+        break;
+      default:
+        continue;
+    }
+  }
+
+  return remove_duplicate_const();
+}
+
+} // namespace luci

--- a/compiler/luci/pass/src/RemoveDuplicateConstPass.test.cpp
+++ b/compiler/luci/pass/src/RemoveDuplicateConstPass.test.cpp
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Pass/RemoveDuplicateConstPass.h"
+
+#include <luci/IR/CircleNodes.h>
+#include <luci/test/TestIOGraph.h>
+#include <gtest/gtest.h>
+
+namespace
+{
+using namespace luci::test;
+
+class DuplicateConstsGraphlet
+{
+public:
+  DuplicateConstsGraphlet() = default;
+
+public:
+  void init(loco::Graph *g, bool is_duplicate)
+  {
+    _reshape_shape = g->nodes()->create<luci::CircleConst>();
+    _reshape_shape->rank(1);
+    _reshape_shape->dim(0).set(1);
+    _reshape_shape->shape_status(luci::ShapeStatus::VALID);
+    _reshape_shape->dtype(loco::DataType::S32);
+
+    _reshape_shape->size<loco::DataType::S32>(1);
+    _reshape_shape->at<loco::DataType::S32>(0) = 5;
+    _reshape_shape->name("reshape_shape_1");
+
+    _reshape_shape_duplicate = g->nodes()->create<luci::CircleConst>();
+    _reshape_shape_duplicate->rank(1);
+    _reshape_shape_duplicate->dim(0).set(1);
+    _reshape_shape_duplicate->shape_status(luci::ShapeStatus::VALID);
+    _reshape_shape_duplicate->dtype(loco::DataType::S32);
+    if (is_duplicate)
+    {
+      _reshape_shape_duplicate->size<loco::DataType::S32>(1);
+      _reshape_shape_duplicate->at<loco::DataType::S32>(0) = 5;
+    }
+    else
+    {
+      _reshape_shape_duplicate->size<loco::DataType::S32>(2);
+      _reshape_shape_duplicate->at<loco::DataType::S32>(0) = 1;
+      _reshape_shape_duplicate->at<loco::DataType::S32>(1) = 5;
+    }
+    _reshape_shape_duplicate->name("reshape_shape_2");
+
+    _reshape_f = g->nodes()->create<luci::CircleReshape>();
+    _reshape_f->newShape()->rank(1);
+    _reshape_f->newShape()->dim(0) = 5;
+    _reshape_f->name("reshape_f");
+
+    _reshape_s = g->nodes()->create<luci::CircleReshape>();
+    if (is_duplicate)
+    {
+      _reshape_s->newShape()->rank(1);
+      _reshape_s->newShape()->dim(0) = 5;
+    }
+    else
+    {
+      _reshape_s->newShape()->rank(2);
+      _reshape_s->newShape()->dim(0) = 1;
+      _reshape_s->newShape()->dim(1) = 5;
+    }
+    _reshape_s->name("reshape_s");
+  }
+
+protected:
+  luci::CircleReshape *_reshape_f = nullptr;
+  luci::CircleReshape *_reshape_s = nullptr;
+  luci::CircleConst *_reshape_shape = nullptr;
+  luci::CircleConst *_reshape_shape_duplicate = nullptr;
+};
+
+class DuplicateConstsGraph : public TestIOGraph, public DuplicateConstsGraphlet
+{
+public:
+  DuplicateConstsGraph() = default;
+
+public:
+  void init(const ShapeU32 in_shape, const ShapeU32 out_shape, bool is_duplicate)
+  {
+    TestIOGraph::init(in_shape, out_shape);
+
+    DuplicateConstsGraphlet::init(g(), is_duplicate);
+
+    // connect graph
+    _reshape_f->tensor(input());
+    _reshape_f->shape(_reshape_shape);
+
+    _reshape_s->tensor(_reshape_f);
+    _reshape_s->shape(_reshape_shape_duplicate);
+
+    output()->from(_reshape_s);
+  }
+};
+} // namespace
+
+TEST(RemoveDuplicateConstPass, name)
+{
+  luci::RemoveDuplicateConstPass pass;
+  auto const name = pass.name();
+  ASSERT_NE(nullptr, name);
+}
+
+TEST(RemoveDuplicateConstPass, remove_duplicate)
+{
+  DuplicateConstsGraph g;
+  g.init({1, 5}, {5}, true);
+
+  luci::RemoveDuplicateConstPass pass;
+  while (pass.run(g.g()))
+    ;
+
+  uint32_t const_num = 0;
+  for (auto node : loco::active_nodes(loco::output_nodes(g.g())))
+  {
+    auto target_node = dynamic_cast<luci::CircleConst *>(node);
+    if (target_node != nullptr)
+      const_num++;
+  }
+
+  ASSERT_EQ(const_num, 1);
+}
+
+TEST(RemoveDuplicateConstPass, remove_duplicate_NEG)
+{
+  DuplicateConstsGraph g;
+  g.init({1, 5}, {1, 5}, false);
+
+  luci::RemoveDuplicateConstPass pass;
+  while (pass.run(g.g()))
+    ;
+
+  uint32_t const_num = 0;
+  for (auto node : loco::active_nodes(loco::output_nodes(g.g())))
+  {
+    auto target_node = dynamic_cast<luci::CircleConst *>(node);
+    if (target_node != nullptr)
+      const_num++;
+  }
+
+  ASSERT_EQ(const_num, 2);
+}


### PR DESCRIPTION
This PR adds pass to remove duplicate consts node from model to luci.

for issue: https://github.com/Samsung/ONE/issues/10009
draft: #10008

ONE-DCO-1.0-Signed-off-by: Artem Balyshev <a.balyshev@samsung.com>