### PR TITLE
[npud] Add DynamicLoader to load a backend library

### DIFF
--- a/runtime/service/npud/core/CMakeLists.txt
+++ b/runtime/service/npud/core/CMakeLists.txt
@@ -13,6 +13,7 @@ target_include_directories(npud_core PUBLIC ${DBUS_INCLUDE_DIRS})
 target_link_libraries(npud_core PRIVATE nnfw_lib_misc)
 target_link_libraries(npud_core PRIVATE ${GLIB2.0_LIBRARIES})
 target_link_libraries(npud_core PRIVATE ${LIB_PTHREAD})
+target_link_libraries(npud_core PRIVATE dl)
 target_link_libraries(npud_core PRIVATE npud_dbus)
 
 if(ENVVAR_NPUD_CONFIG)

--- a/runtime/service/npud/core/Core.cc
+++ b/runtime/service/npud/core/Core.cc
@@ -23,15 +23,9 @@ namespace core
 
 Core::Core() noexcept : _devManager(std::make_unique<DevManager>()) {}
 
-void Core::init()
-{
-  // TODO Implement details
-}
+void Core::init() { _devManager->loadModules(); }
 
-void Core::deinit()
-{
-  // TODO Implement details
-}
+void Core::deinit() { _devManager->releaseModules(); }
 
 int Core::getAvailableDeviceList(std::vector<std::string> &list) const { return 0; }
 

--- a/runtime/service/npud/core/DynamicLoader.cc
+++ b/runtime/service/npud/core/DynamicLoader.cc
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "DynamicLoader.h"
+
+#include "util/Logging.h"
+
+namespace npud
+{
+namespace core
+{
+
+DynamicLoader::DynamicLoader(const char *file, int flags)
+  : _handle(nullptr), _filepath(file), _allocSymbol("allocate"), _deallocSymbol("deallocate")
+{
+  if (!(_handle = dlopen(_filepath.c_str(), flags)))
+  {
+    VERBOSE(DynamicLoader) << "Fail to load " << _filepath << " module: " << dlerror() << std::endl;
+    throw std::runtime_error("Fail to load " + _filepath + " module");
+  }
+
+  NpuAlloc alloc;
+  NpuDealloc dealloc;
+
+  alloc = reinterpret_cast<NpuAlloc>(dlsym(_handle, _allocSymbol.c_str()));
+  dealloc = reinterpret_cast<NpuDealloc>(dlsym(_handle, _deallocSymbol.c_str()));
+  if (!alloc || !dealloc)
+  {
+    VERBOSE(DynamicLoader) << "Fail to load " << _filepath << " symbol: " << dlerror() << std::endl;
+    dlclose(_handle);
+    throw std::runtime_error("Fail to load " + _filepath + " module");
+  }
+
+  _backend = std::shared_ptr<Backend>(alloc(), [dealloc](Backend *b) { dealloc(b); });
+}
+
+DynamicLoader::~DynamicLoader() { dlclose(_handle); }
+
+std::shared_ptr<Backend> DynamicLoader::getInstance() { return _backend; }
+
+} // namespace core
+} // namespace npud

--- a/runtime/service/npud/core/DynamicLoader.h
+++ b/runtime/service/npud/core/DynamicLoader.h
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
-#ifndef __ONE_SERVICE_NPUD_CORE_DEV_MANAGER_H__
-#define __ONE_SERVICE_NPUD_CORE_DEV_MANAGER_H__
+#ifndef __ONE_SERVICE_NPUD_CORE_DYNAMIC_LOADER_H__
+#define __ONE_SERVICE_NPUD_CORE_DYNAMIC_LOADER_H__
 
-#include "DynamicLoader.h"
+#include "Backend.h"
 
+#include <dlfcn.h>
+#include <string>
 #include <memory>
 
 namespace npud
@@ -26,31 +28,27 @@ namespace npud
 namespace core
 {
 
-struct Device
-{
-  std::string modulePath;
-  std::unique_ptr<DynamicLoader> loader;
-};
+using DLHandle = void *;
 
-class DevManager
+class DynamicLoader
 {
 public:
-  DevManager();
-  ~DevManager() = default;
+  DynamicLoader(const char *file, int flags = RTLD_LAZY);
+  ~DynamicLoader();
 
-  DevManager(const DevManager &) = delete;
-  DevManager &operator=(const DevManager &) = delete;
+  DynamicLoader(const DynamicLoader &) = delete;
 
-  void loadModules();
-  void releaseModules();
-  std::shared_ptr<Backend> getBackend();
+  std::shared_ptr<Backend> getInstance();
 
 private:
-  std::unique_ptr<Device> _dev;
-  std::string _module_dir;
+  DLHandle _handle;
+  std::string _filepath;
+  std::string _allocSymbol;
+  std::string _deallocSymbol;
+  std::shared_ptr<Backend> _backend;
 };
 
 } // namespace core
 } // namespace npud
 
-#endif // __ONE_SERVICE_NPUD_CORE_DEV_MANAGER_H__
+#endif // __ONE_SERVICE_NPUD_CORE_DYNAMIC_LOADER_H__


### PR DESCRIPTION
This commit adds DynamicLoader class.
This class loads a backend library and provides a function to get Backend class in shared library.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Related issue: #12583