### PR TITLE
[npud] Create and destroy NpuContext in Trix backend

### DIFF
--- a/runtime/service/npud/backend/trix/TrixBackend.cc
+++ b/runtime/service/npud/backend/trix/TrixBackend.cc
@@ -79,14 +79,26 @@ NpuStatus TrixBackend::getVersion(std::string &version)
 
 NpuStatus TrixBackend::createContext(int deviceId, int priority, NpuContext **ctx)
 {
-  // TODO Implement details
-  return NPU_STATUS_ERROR_NOT_SUPPORTED;
+  NpuContext *context = new NpuContext();
+  if (deviceId >= _dev->handles.size())
+  {
+    return NPU_STATUS_ERROR_INVALID_ARGUMENT;
+  }
+  context->defaultCore = deviceId;
+  // TODO Consider priority.
+  *ctx = context;
+  return NPU_STATUS_SUCCESS;
 }
 
 NpuStatus TrixBackend::destroyContext(NpuContext *ctx)
 {
-  // TODO Implement details
-  return NPU_STATUS_ERROR_NOT_SUPPORTED;
+  if (ctx == nullptr)
+  {
+    return NPU_STATUS_ERROR_INVALID_ARGUMENT;
+  }
+
+  delete ctx;
+  return NPU_STATUS_SUCCESS;
 }
 
 NpuStatus TrixBackend::createBuffer(NpuContext *ctx, GenericBuffer *buffer)

--- a/runtime/service/npud/core/DevManager.cc
+++ b/runtime/service/npud/core/DevManager.cc
@@ -19,7 +19,6 @@
 
 #include <dirent.h>
 
-#define CHECK_BACKEND(b) ((b == nullptr) ? return NPU_STATUS_ERROR_OPERATION_FAILED;: ;)
 namespace npud
 {
 namespace core
@@ -92,32 +91,35 @@ std::shared_ptr<Backend> DevManager::getBackend()
 {
   if (!_dev)
   {
-    return nullptr;
+    throw std::runtime_error("No backend device.");
   }
-
   return _dev->loader->getInstance();
 }
 
 int DevManager::createContext(int deviceId, int priority, NpuContext **npuContext)
 {
-  auto backend = getBackend();
-  if (!backend)
+  try
   {
+    return getBackend()->createContext(deviceId, priority, npuContext);
+  }
+  catch (const std::exception &e)
+  {
+    VERBOSE(DevManager) << e.what() << std::endl;
     return NPU_STATUS_ERROR_OPERATION_FAILED;
   }
-
-  return backend->createContext(deviceId, priority, npuContext);
 }
 
 int DevManager::destroyContext(NpuContext *npuContext)
 {
-  auto backend = getBackend();
-  if (!backend)
+  try
   {
+    return getBackend()->destroyContext(npuContext);
+  }
+  catch (const std::exception &e)
+  {
+    VERBOSE(DevManager) << e.what() << std::endl;
     return NPU_STATUS_ERROR_OPERATION_FAILED;
   }
-
-  return backend->destroyContext(npuContext);
 }
 
 } // namespace core

--- a/runtime/service/npud/core/DevManager.cc
+++ b/runtime/service/npud/core/DevManager.cc
@@ -19,6 +19,7 @@
 
 #include <dirent.h>
 
+#define CHECK_BACKEND(b) ((b == nullptr) ? return NPU_STATUS_ERROR_OPERATION_FAILED;: ;)
 namespace npud
 {
 namespace core
@@ -95,6 +96,28 @@ std::shared_ptr<Backend> DevManager::getBackend()
   }
 
   return _dev->loader->getInstance();
+}
+
+int DevManager::createContext(int deviceId, int priority, NpuContext **npuContext)
+{
+  auto backend = getBackend();
+  if (!backend)
+  {
+    return NPU_STATUS_ERROR_OPERATION_FAILED;
+  }
+
+  return backend->createContext(deviceId, priority, npuContext);
+}
+
+int DevManager::destroyContext(NpuContext *npuContext)
+{
+  auto backend = getBackend();
+  if (!backend)
+  {
+    return NPU_STATUS_ERROR_OPERATION_FAILED;
+  }
+
+  return backend->destroyContext(npuContext);
 }
 
 } // namespace core

--- a/runtime/service/npud/core/DevManager.h
+++ b/runtime/service/npud/core/DevManager.h
@@ -45,6 +45,9 @@ public:
   void releaseModules();
   std::shared_ptr<Backend> getBackend();
 
+  int createContext(int deviceId, int priority, NpuContext **npuContext);
+  int destroyContext(NpuContext *npuContext);
+
 private:
   std::unique_ptr<Device> _dev;
   std::string _module_dir;


### PR DESCRIPTION
This commit creates and destroys NpuContext in Trix backend.
The DevManager invokes these functions.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Related PR: #10021 
Draft PR: #9989