### PR TITLE
[luci-interpreter] Clear also sp_scratch_buffer

### DIFF
--- a/compiler/luci-interpreter/src/kernels/UnidirectionalSequenceLSTM.cpp
+++ b/compiler/luci-interpreter/src/kernels/UnidirectionalSequenceLSTM.cpp
@@ -857,6 +857,8 @@ void UnidirectionalSequenceLSTM::evalFloat() const
   std::fill_n(scratchpad_data, sp_output_state->shape().num_elements(), 0);
   scratchpad_data = getTensorData<float>(sp_cell_state);
   std::fill_n(scratchpad_data, sp_cell_state->shape().num_elements(), 0);
+  scratchpad_data = getTensorData<float>(sp_scratch_buffer);
+  std::fill_n(scratchpad_data, sp_scratch_buffer->shape().num_elements(), 0);
 
   TfLiteLSTMParams lstm_params{};
   lstm_params.activation = getTfLiteActivation(params().activation);


### PR DESCRIPTION
This will clear also sp_scratch_buffer values to zero.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>