### PR TITLE
[circle2circle] Add RemoveDuplicateConstPass

### DIFF
--- a/compiler/circle2circle/src/Circle2Circle.cpp
+++ b/compiler/circle2circle/src/Circle2Circle.cpp
@@ -108,6 +108,7 @@ int entry(int argc, char **argv)
              "when the impact is known to be acceptable.");
   add_switch(arser, "--fuse_preactivation_batchnorm",
              "This will fuse BatchNorm operators of pre-activations to Convolution operator");
+  add_switch(arser, "--remove_duplicate_const", "This will remove all duplicate constant nodes");
   add_switch(arser, "--remove_fakequant", "This will remove FakeQuant operators");
   add_switch(arser, "--remove_quantdequant", "This will remove Quantize-Dequantize sequence");
   add_switch(arser, "--remove_redundant_quantize", "This will remove redundant Quantize operators");
@@ -250,6 +251,8 @@ int entry(int argc, char **argv)
     options->enable(Algorithms::FusePreActivationBatchNorm);
   if (arser.get<bool>("--fuse_transpose_with_mean"))
     options->enable(Algorithms::FuseTransposeWithMean);
+  if (arser.get<bool>("--remove_duplicate_const"))
+    options->enable(Algorithms::RemoveDuplicateConst);
   if (arser.get<bool>("--remove_fakequant"))
     options->enable(Algorithms::RemoveFakeQuant);
   if (arser.get<bool>("--remove_quantdequant"))


### PR DESCRIPTION
This PR adds circle2circle pass to remove duplicate consts node from model.

draft: #10008
for issue: https://github.com/Samsung/ONE/issues/10009

ONE-DCO-1.0-Signed-off-by: Artem Balyshev <a.balyshev@samsung.com>