### PR TITLE
[circle-inspect] Dump constant names

### DIFF
--- a/compiler/circle-inspect/driver/Driver.cpp
+++ b/compiler/circle-inspect/driver/Driver.cpp
@@ -34,6 +34,7 @@ int entry(int argc, char **argv)
   arser.add_argument("--conv2d_weight")
     .nargs(0)
     .help("Dump Conv2D series weight operators in circle file");
+  arser.add_argument("--constants").nargs(0).help("Dump constant tensors name");
   arser.add_argument("--op_version").nargs(0).help("Dump versions of the operators in circle file");
   arser.add_argument("--tensor_dtype").nargs(0).help("Dump dtype of tensors");
   arser.add_argument("circle").help("Circle file to inspect");
@@ -50,7 +51,7 @@ int entry(int argc, char **argv)
   }
 
   if (!arser["--operators"] && !arser["--conv2d_weight"] && !arser["--op_version"] &&
-      !arser["--tensor_dtype"])
+      !arser["--tensor_dtype"] && !arser["--constants"])
   {
     std::cout << "At least one option must be specified" << std::endl;
     std::cout << arser;
@@ -67,6 +68,8 @@ int entry(int argc, char **argv)
     dumps.push_back(std::make_unique<circleinspect::DumpOperatorVersion>());
   if (arser["--tensor_dtype"])
     dumps.push_back(std::make_unique<circleinspect::DumpTensorDType>());
+  if (arser["--constants"])
+    dumps.push_back(std::make_unique<circleinspect::DumpConstants>());
 
   std::string model_file = arser.get<std::string>("circle");
 

--- a/compiler/circle-inspect/src/Dump.cpp
+++ b/compiler/circle-inspect/src/Dump.cpp
@@ -202,3 +202,36 @@ void DumpTensorDType::run(std::ostream &os, const circle::Model *model)
 }
 
 } // namespace circleinspect
+
+namespace circleinspect
+{
+
+void DumpConstants::run(std::ostream &os, const circle::Model *model)
+{
+  mio::circle::Reader reader(model);
+
+  const uint32_t subgraph_size = reader.num_subgraph();
+
+  for (uint32_t g = 0; g < subgraph_size; g++)
+  {
+    reader.select_subgraph(g);
+    auto tensors = reader.tensors();
+
+    for (uint32_t i = 0; i < tensors->Length(); ++i)
+    {
+      const auto tensor = tensors->Get(i);
+      if (tensor->is_variable())
+        continue;
+
+      auto const buffer_id = tensor->buffer();
+
+      auto const buffer_size = reader.buffer_info(buffer_id, nullptr);
+      if (buffer_size == 0)
+        continue;
+
+      os << reader.tensor_name(tensor) << std::endl;
+    }
+  }
+}
+
+} // namespace circleinspect

--- a/compiler/circle-inspect/src/Dump.h
+++ b/compiler/circle-inspect/src/Dump.h
@@ -69,6 +69,15 @@ public:
   void run(std::ostream &os, const circle::Model *model);
 };
 
+class DumpConstants final : public DumpInterface
+{
+public:
+  DumpConstants() = default;
+
+public:
+  void run(std::ostream &os, const circle::Model *model);
+};
+
 } // namespace circleinspect
 
 #endif // __DUMP_H__


### PR DESCRIPTION
This PR adds option to dump names of constant tensors.

for issue: #10014
draft: #10008

ONE-DCO-1.0-Signed-off-by: Artem Balyshev <a.balyshev@samsung.com>