### PR TITLE
[dredd-rule-lib] Add rule to check constant tensor count

### DIFF
--- a/compiler/dredd-rule-lib/rule-lib.sh
+++ b/compiler/dredd-rule-lib/rule-lib.sh
@@ -234,4 +234,22 @@ tensor_dtype()
   echo ${ACTUAL}
 }
 
+const_count()
+{
+  argc_check $# 1
+  file_path_check ${COMPILED_FILE}
+  file_path_check ${INSPECT_PROG_PATH}
+
+  set -o pipefail
+
+  RESULT=`init_error_log ; ${INSPECT_PROG_PATH} --constants ${COMPILED_FILE}`
+  check_success_exit_code $? 0
+
+  # note : grep's exit code is 2 in case of error.
+  ACTUAL=`init_error_log ; echo "${RESULT}" | grep -wc "$1"`
+  check_error_exit_code $? 2
+
+  echo ${ACTUAL}
+}
+
 # TODO define more qullity test function


### PR DESCRIPTION
This PR adds rule to check constant tensor count.

for issue: https://github.com/Samsung/ONE/issues/10014
draft: https://github.com/Samsung/ONE/pull/10008

ONE-DCO-1.0-Signed-off-by: Artem Balyshev <a.balyshev@samsung.com>