### PR TITLE
[luci/pass] UnrollLSTM first_transpose assert input

### DIFF
--- a/compiler/luci/pass/src/UnrollUnidirectionalSequenceLSTMPass.cpp
+++ b/compiler/luci/pass/src/UnrollUnidirectionalSequenceLSTMPass.cpp
@@ -150,6 +150,8 @@ luci::CircleConst *UnrollLSTM::transpose_perm(void)
 
 luci::CircleTranspose *UnrollLSTM::first_transpose(luci::CircleNode *input)
 {
+  assert(input != nullptr);
+
   auto perm = transpose_perm();
   perm->name(_name + "_perm1");
   luci::add_origin(perm, luci::get_origin(_lstm));


### PR DESCRIPTION
This will add assert for input parameter of first_transpose.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>