### PR TITLE
[npud] Implement create and destroy context in core class

### DIFF
--- a/runtime/service/npud/core/Core.cc
+++ b/runtime/service/npud/core/Core.cc
@@ -15,6 +15,7 @@
  */
 
 #include "Core.h"
+#include "util/Logging.h"
 
 namespace npud
 {
@@ -31,6 +32,46 @@ void Core::init() { _devManager->loadModules(); }
 void Core::deinit() { _devManager->releaseModules(); }
 
 int Core::getAvailableDeviceList(std::vector<std::string> &list) const { return 0; }
+
+int Core::createContext(int deviceId, int priority, ContextID *contextId) const
+{
+  VERBOSE(Core) << "createContext with " << deviceId << ", " << priority << std::endl;
+  NpuContext *npuContext;
+  int ret = _devManager->createContext(deviceId, priority, &npuContext);
+  if (ret != NPU_STATUS_SUCCESS)
+  {
+    VERBOSE(Core) << "Fail to create dev context" << std::endl;
+    // TODO Define CoreStatus
+    return 1;
+  }
+
+  ContextID _contextId;
+  _contextManager->newContext(npuContext, &_contextId);
+  *contextId = _contextId;
+  return 0;
+}
+
+int Core::destroyContext(ContextID contextId) const
+{
+  VERBOSE(Core) << "destroyContext with " << contextId << std::endl;
+  NpuContext *npuContext = _contextManager->getNpuContext(contextId);
+  if (!npuContext)
+  {
+    VERBOSE(Core) << "Invalid context id" << std::endl;
+    // TODO Define CoreStatus
+    return 1;
+  }
+
+  int ret = _devManager->destroyContext(npuContext);
+  if (ret != NPU_STATUS_SUCCESS)
+  {
+    VERBOSE(Core) << "Failed to destroy npu context: " << ret << std::endl;
+    return 1;
+  }
+
+  _contextManager->deleteContext(contextId);
+  return 0;
+}
 
 } // namespace core
 } // namespace npud

--- a/runtime/service/npud/core/Core.h
+++ b/runtime/service/npud/core/Core.h
@@ -43,6 +43,8 @@ public:
   void deinit();
 
   int getAvailableDeviceList(std::vector<std::string> &list) const;
+  int createContext(int deviceId, int priority, ContextID *contextId) const;
+  int destroyContext(ContextID contextId) const;
 
 private:
   std::unique_ptr<DevManager> _devManager;

--- a/runtime/service/npud/core/DBus.cc
+++ b/runtime/service/npud/core/DBus.cc
@@ -95,9 +95,9 @@ gboolean DBus::on_handle_context_create(NpudCore *object, GDBusMethodInvocation 
 {
   VERBOSE(DBus) << "on_handle_context_create with " << arg_device_id << ", " << arg_priority
                 << std::endl;
+
   guint64 out_ctx = 0;
-  int ret = -1;
-  // TODO Invoke Core function.
+  int ret = Server::instance().core().createContext(arg_device_id, arg_priority, &out_ctx);
   npud_core_complete_context_create(object, invocation, out_ctx, ret);
   return TRUE;
 }
@@ -106,8 +106,7 @@ gboolean DBus::on_handle_context_destroy(NpudCore *object, GDBusMethodInvocation
                                          guint64 arg_ctx)
 {
   VERBOSE(DBus) << "on_handle_context_destroy with " << arg_ctx << std::endl;
-  int ret = -1;
-  // TODO Invoke Core function.
+  int ret = Server::instance().core().destroyContext(arg_ctx);
   npud_core_complete_context_destroy(object, invocation, ret);
   return TRUE;
 }


### PR DESCRIPTION
The Core function invokes the dev manager to get npu context and invokes the context manager to create npu daemon context. The npu daemon context internally contains npu context.

Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Draft PR: #9989