### PR TITLE
[npud] Implement register and unregister model in Trix backend

### DIFF
--- a/runtime/service/npud/backend/trix/TrixBackend.h
+++ b/runtime/service/npud/backend/trix/TrixBackend.h
@@ -36,6 +36,14 @@ using Handle = void *;
 struct TrixDevice
 {
   std::vector<Handle> handles;
+  // Note
+  // Q. Why does it use `weak_ptr` here?
+  // A. The `TrixDevice` manages all model files. Each `NpuContext` shares model
+  //    information data with `TrixDevice`. Using `shared_ptr`, the model data is
+  //    not destroyed because `TrixDevice` always has a model data. Using `weak_ptr`
+  //    it can recognize that all `NpuContext` has unregistered the model and
+  //    delete the model data.
+  std::vector<std::weak_ptr<NpuModelInfo>> models;
 };
 
 class TrixBackend : public Backend


### PR DESCRIPTION
This commit registers a given model. If the same model is already registered, it shares the model information data.
Each NpuContext has own model list.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Draft PR: #9989