### PR TITLE
[luci] Add guard code to FuseAddWithFullyConnectedPass

### DIFF
--- a/compiler/luci/pass/src/FuseAddWithFullyConnectedPass.cpp
+++ b/compiler/luci/pass/src/FuseAddWithFullyConnectedPass.cpp
@@ -86,6 +86,14 @@ bool fuse_add_with_fc(luci::CircleFullyConnected *fc)
   if (not(addition->dim(rank - 1) == weights->dim(0)))
     return false;
 
+  auto bias = loco::must_cast<luci::CircleNode *>(fc->bias());
+
+  // We only support (1) constant bias (2) no bias
+  // If bias is neither (1) nor (2), it would be a feature map
+  if (bias->opcode() != luci::CircleOpcode::CIRCLECONST and
+      bias->opcode() != luci::CircleOpcode::CIRCLEOUTPUTEXCLUDE)
+    return false;
+
   auto fused_bias = luci::clone(addition);
 
   // Add existing bias values

--- a/compiler/luci/pass/src/FuseAddWithFullyConnectedPass.test.cpp
+++ b/compiler/luci/pass/src/FuseAddWithFullyConnectedPass.test.cpp
@@ -125,6 +125,15 @@ public:
 public:
   luci::CircleFullyConnected *fc() { return _fc; }
 
+public:
+  void to_fm_bias(void)
+  {
+    assert(_fc != nullptr); // FIX_ME_UNLESS
+
+    auto new_fc = _fc->graph()->nodes()->create<luci::CircleFullyConnected>();
+    _fc->bias(new_fc);
+  }
+
 protected:
   luci::CircleFullyConnected *_fc = nullptr;
   luci::CircleAdd *_add = nullptr;
@@ -173,4 +182,15 @@ TEST_F(FuseAddWithFullyConnectedPassTest, simple_test)
   {
     EXPECT_EQ(i, bias->at<loco::DataType::FLOAT32>(i));
   }
+}
+
+TEST_F(FuseAddWithFullyConnectedPassTest, fm_bias_NEG)
+{
+  g.init();
+
+  // Bias is a feature map. Add is not fused.
+  g.to_fm_bias();
+
+  auto ret = pass.run(g.g());
+  EXPECT_EQ(false, ret);
 }


### PR DESCRIPTION
This prevents Add from being fused with FC with non-const bias.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>