### PR TITLE
[npud] Implement create and destroy network in core class

### DIFF
--- a/runtime/service/npud/core/Core.cc
+++ b/runtime/service/npud/core/Core.cc
@@ -73,5 +73,50 @@ int Core::destroyContext(ContextID contextId) const
   return 0;
 }
 
+int Core::createNetwork(ContextID contextId, const std::string &modelPath, ModelID *modelId) const
+{
+  VERBOSE(Core) << "createNetwork with " << contextId << ", " << modelPath << std::endl;
+  NpuContext *npuContext = _contextManager->getNpuContext(contextId);
+  if (!npuContext)
+  {
+    VERBOSE(Core) << "Invalid context id" << std::endl;
+    // TODO Define CoreStatus
+    return 1;
+  }
+
+  ModelID id;
+  int ret = _devManager->registerModel(npuContext, modelPath, &id);
+  if (ret != NPU_STATUS_SUCCESS)
+  {
+    VERBOSE(Core) << "Failed to register model: " << ret << std::endl;
+    return 1;
+  }
+
+  *modelId = id;
+  return 0;
+}
+
+int Core::destroyNetwork(ContextID contextId, ModelID modelId) const
+{
+  VERBOSE(Core) << "destroyNetwork with " << contextId << std::endl;
+  NpuContext *npuContext = _contextManager->getNpuContext(contextId);
+  if (!npuContext)
+  {
+    VERBOSE(Core) << "Invalid context id" << std::endl;
+    // TODO Define CoreStatus
+    return 1;
+  }
+
+  int ret = _devManager->unregisterModel(npuContext, modelId);
+  if (ret != NPU_STATUS_SUCCESS)
+  {
+    VERBOSE(Core) << "Failed to unregister model: " << ret << std::endl;
+    // TODO Define CoreStatus
+    return 1;
+  }
+
+  return 0;
+}
+
 } // namespace core
 } // namespace npud

--- a/runtime/service/npud/core/Core.h
+++ b/runtime/service/npud/core/Core.h
@@ -45,6 +45,8 @@ public:
   int getAvailableDeviceList(std::vector<std::string> &list) const;
   int createContext(int deviceId, int priority, ContextID *contextId) const;
   int destroyContext(ContextID contextId) const;
+  int createNetwork(ContextID contextId, const std::string &modelPath, ModelID *modelId) const;
+  int destroyNetwork(ContextID contextId, ModelID modelId) const;
 
 private:
   std::unique_ptr<DevManager> _devManager;

--- a/runtime/service/npud/core/DBus.cc
+++ b/runtime/service/npud/core/DBus.cc
@@ -117,8 +117,7 @@ gboolean DBus::on_handle_network_create(NpudCore *object, GDBusMethodInvocation 
   VERBOSE(DBus) << "on_handle_network_create with " << arg_ctx << ", " << arg_model_path
                 << std::endl;
   ModelID modelId = 0;
-  int ret = -1;
-  // TODO Invoke Core function.
+  int ret = Server::instance().core().createNetwork(arg_ctx, arg_model_path, &modelId);
   npud_core_complete_network_create(object, invocation, guint(modelId), ret);
   return TRUE;
 }
@@ -128,8 +127,7 @@ gboolean DBus::on_handle_network_destroy(NpudCore *object, GDBusMethodInvocation
 {
   VERBOSE(DBus) << "on_handle_network_destroy with " << arg_ctx << ", " << arg_nw_handle
                 << std::endl;
-  int ret = -1;
-  // TODO Invoke Core function.
+  int ret = Server::instance().core().destroyNetwork(arg_ctx, arg_nw_handle);
   npud_core_complete_network_destroy(object, invocation, ret);
   return TRUE;
 }


### PR DESCRIPTION
The Core function checks whether the given context id is valid or not and get the npu context. Then it invokes the dev manager to register and unregister the given model using the npu context.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Draft PR: #9989