### PR TITLE
[luci/pass] Add UnrollUnidirSeqLSTM option

### DIFF
--- a/compiler/luci/pass/include/luci/CircleOptimizer.h
+++ b/compiler/luci/pass/include/luci/CircleOptimizer.h
@@ -85,6 +85,7 @@ public:
       RemoveFakeQuant,
       RemoveQuantDequantSeq,
       RemoveDuplicateConst,
+      UnrollUnidirSeqLSTM,
     };
 
     enum AlgorithmParameters

--- a/compiler/luci/pass/src/CircleOptimizer.cpp
+++ b/compiler/luci/pass/src/CircleOptimizer.cpp
@@ -68,6 +68,7 @@
 #include "luci/Pass/SubstituteTransposeToReshapePass.h"
 #include "luci/Pass/TransformMinMaxToRelu6Pass.h"
 #include "luci/Pass/TransformMinReluToRelu6Pass.h"
+#include "luci/Pass/UnrollUnidirectionalSequenceLSTMPass.h"
 // TODO add more passes
 
 #include "luci/Pass/CircleShapeInferencePass.h"
@@ -416,6 +417,10 @@ void CircleOptimizer::optimize(loco::Graph *g) const
   if (_options->query(Options::Algorithm::TransformMinReluToRelu6Pass))
   {
     phase.emplace_back(std::make_unique<luci::TransformMinReluToRelu6Pass>());
+  }
+  if (_options->query(Options::Algorithm::UnrollUnidirSeqLSTM))
+  {
+    phase.emplace_back(std::make_unique<luci::UnrollUnidirectionalSequenceLSTMPass>());
   }
 
   /* TRANSFORM DECLARATION END */


### PR DESCRIPTION
This will add UnrollUnidirSeqLSTM option to enable UnrollUnidirectionalSequenceLSTMPass.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>