### PR TITLE
[infra/nncc] Disable NEON

### DIFF
--- a/infra/nncc/Makefile.arm32
+++ b/infra/nncc/Makefile.arm32
@@ -106,8 +106,12 @@ int_configure_arm32:
 		$(NNCC_ARM32_DEBUG) $(NNCC_CFG_STRICT) \
 		-DCMAKE_TOOLCHAIN_FILE=$(ARM32_TOOLCHAIN_FILE) \
 		-DCMAKE_INSTALL_PREFIX="$(ARM32_INSTALL_FOLDER)" \
+		-DBUILD_ARM32_NEON=OFF \
 		-DENABLE_TEST=ON
 
+# NOTE BUILD_ARM32_NEON=OFF was given cause of RUY ARM32 compile error
+#      refer https://github.com/Samsung/ONE/issues/10050
+# TODO remove BUILD_ARM32_NEON=OFF
 
 #
 # builds


### PR DESCRIPTION
This will disable NEON not to use RUY with ARM32 cross build.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>