### PR TITLE
[luci-pass-value-test] UnrollLSTM

### DIFF
--- a/compiler/luci-pass-value-test/test.lst
+++ b/compiler/luci-pass-value-test/test.lst
@@ -35,6 +35,8 @@ addeval(Net_InstanceNorm_003 fuse_instnorm)
 addeval(Net_StridedSlice_StridedSlice_000 remove_unnecessary_strided_slice)
 addeval(FullyConnected_007 replace_non_const_fc_with_batch_matmul)
 addeval(Net_Transpose_Add_000 forward_transpose_op)
+addeval(UnidirectionalSequenceLSTM_003 unroll_unidirseqlstm)
+addeval(UnidirectionalSequenceLSTM_004 unroll_unidirseqlstm)
 
 # test for limited support for FLOAT16
 addeval(Net_Dequantize_Add_000 fold_dequantize)


### PR DESCRIPTION
This will add value tests for unroll_unidirseqlstm option.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>