### PR TITLE
[mio-tflite280] Support ruy library

### DIFF
--- a/compiler/mio-tflite280/CMakeLists.txt
+++ b/compiler/mio-tflite280/CMakeLists.txt
@@ -44,9 +44,16 @@ if(NOT TensorFlowGEMMLowpSource_FOUND)
   return()
 endif(NOT TensorFlowGEMMLowpSource_FOUND)
 
+nnas_find_package(TensorFlowRuySource EXACT 2.8.0 QUIET)
+
+if(NOT TensorFlowRuySource_FOUND)
+  return()
+endif(NOT TensorFlowRuySource_FOUND)
+
 add_library(mio_tflite280_inc INTERFACE)
 target_include_directories(mio_tflite280_inc SYSTEM INTERFACE "${TensorFlowSource_DIR}")
 target_include_directories(mio_tflite280_inc SYSTEM INTERFACE "${TensorFlowGEMMLowpSource_DIR}")
+target_include_directories(mio_tflite280_inc SYSTEM INTERFACE "${TensorFlowRuySource_DIR}")
 
 file(GLOB_RECURSE SOURCES "src/*.cpp")
 file(GLOB_RECURSE TESTS "src/*.test.cpp")


### PR DESCRIPTION
This supports ruy in mio-tflite280.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/10066
Draft PR: #10081