### PR TITLE
[infra/nncc] Relocate tree-vectorize

### DIFF
--- a/infra/nncc/cmake/buildtool/config/config_armv7l-linux.cmake
+++ b/infra/nncc/cmake/buildtool/config/config_armv7l-linux.cmake
@@ -11,13 +11,13 @@ include("${CMAKE_CURRENT_LIST_DIR}/config_linux.cmake")
 set(FLAGS_COMMON ${FLAGS_COMMON}
     "-mcpu=cortex-a7"
     "-mfloat-abi=hard"
-    "-ftree-vectorize"
     "-mfp16-format=ieee"
     )
 
 if(BUILD_ARM32_NEON)
   set(FLAGS_COMMON ${FLAGS_COMMON}
       "-mfpu=neon-vfpv4"
+      "-ftree-vectorize"
       )
 else(BUILD_ARM32_NEON)
   message(STATUS "ARMv7l: NEON is disabled")


### PR DESCRIPTION
This will move '-ftree-vectorize' option into NEON block.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>