### PR TITLE
[npud] Fix segfault issue related to _backend shared pointer

### DIFF
--- a/runtime/service/npud/core/DynamicLoader.cc
+++ b/runtime/service/npud/core/DynamicLoader.cc
@@ -47,7 +47,14 @@ DynamicLoader::DynamicLoader(const char *file, int flags)
   _backend = std::shared_ptr<Backend>(alloc(), [dealloc](Backend *b) { dealloc(b); });
 }
 
-DynamicLoader::~DynamicLoader() { dlclose(_handle); }
+DynamicLoader::~DynamicLoader()
+{
+  // NOTE
+  // The _backend shared_ptr must be explicitly deleted before
+  // the dynamic library handle is released.
+  _backend.reset();
+  dlclose(_handle);
+}
 
 std::shared_ptr<Backend> DynamicLoader::getInstance() { return _backend; }
 


### PR DESCRIPTION
This commit fixes a segfault issue related to the _backend shared_ptr. The _backend shared_ptr must be explicitly deleted before the dynamic library handle is released.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>