### PR TITLE
[npud] Do not handle SIGSEGV signal

### DIFF
--- a/runtime/service/npud/core/Signal.cc
+++ b/runtime/service/npud/core/Signal.cc
@@ -31,14 +31,12 @@ void Signal::init(void)
 {
   // NOTE Types of signals
   // SIGTERM: termination request, sent to the program
-  // SIGSEGV: invalid memory access (segmentation fault)
   // SIGINT:  external interrupt, usually initiated by the user
   // SIGILL:	invalid program image, such as invalid instruction
   // SIGABRT:	abnormal termination condition, as is e.g. initiated by std::abort()
   // SIGFPE: 	erroneous arithmetic operation such as divide by zero
   // from https://en.cppreference.com/w/cpp/utility/program/SIG_types
   std::signal(SIGTERM, handleSignal);
-  std::signal(SIGSEGV, handleSignal);
   std::signal(SIGINT, handleSignal);
   std::signal(SIGILL, handleSignal);
   std::signal(SIGABRT, handleSignal);


### PR DESCRIPTION
This commit removes the SIGSEGV signal handler.
When program segfaults, the Linux kernel will sometimes write a core dump to disk. To use this operation, it does not handle SIGSEGV signal.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>