### PR TITLE
[circle-eval-diff] Fix input data size

### DIFF
--- a/compiler/circle-eval-diff/src/InputDataLoader.cpp
+++ b/compiler/circle-eval-diff/src/InputDataLoader.cpp
@@ -55,7 +55,7 @@ std::vector<size_t> getEachByteSizeOf(const std::vector<loco::Node *> &nodes)
   for (const auto node : nodes)
   {
     const auto input_node = loco::must_cast<const luci::CircleInput *>(node);
-    size_t element_size = 1;
+    size_t element_size = loco::size(input_node->dtype());
 
     for (uint32_t index = 0; index < input_node->rank(); index++)
     {

--- a/compiler/circle-eval-diff/src/InputDataLoader.cpp
+++ b/compiler/circle-eval-diff/src/InputDataLoader.cpp
@@ -55,14 +55,15 @@ std::vector<size_t> getEachByteSizeOf(const std::vector<loco::Node *> &nodes)
   for (const auto node : nodes)
   {
     const auto input_node = loco::must_cast<const luci::CircleInput *>(node);
-    size_t element_size = loco::size(input_node->dtype());
+    const auto dtype_size = loco::size(input_node->dtype());
+    size_t element_size = 1;
 
     for (uint32_t index = 0; index < input_node->rank(); index++)
     {
       element_size *= input_node->dim(index).value();
     }
 
-    vec.push_back(element_size);
+    vec.push_back(element_size * dtype_size);
   }
 
   return vec;


### PR DESCRIPTION
This fixes byte size of directory input.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>