### PR TITLE
[infra] Use 20221125 preset in debian

### DIFF
--- a/infra/debian/compiler/rules
+++ b/infra/debian/compiler/rules
@@ -1,7 +1,7 @@
 #!/usr/bin/make -f
 export DH_VERBOSE = 1
 export NNAS_BUILD_PREFIX = build
-export PRESET = 20220323
+export PRESET = 20221125
 export _DESTDIR = debian/tmp/usr
 
 %:


### PR DESCRIPTION
This will revise debian rules file to use 20221125 preset.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>