### PR TITLE
[mio-tflite280] Remove mio_tflite280_inc

### DIFF
--- a/compiler/mio-tflite280/CMakeLists.txt
+++ b/compiler/mio-tflite280/CMakeLists.txt
@@ -38,23 +38,6 @@ target_link_libraries(mio_tflite280_example mio_tflite280)
 add_executable(mio_tflite280_validate example.cpp)
 target_link_libraries(mio_tflite280_validate mio_tflite280)
 
-nnas_find_package(TensorFlowGEMMLowpSource EXACT 2.8.0 QUIET)
-
-if(NOT TensorFlowGEMMLowpSource_FOUND)
-  return()
-endif(NOT TensorFlowGEMMLowpSource_FOUND)
-
-nnas_find_package(TensorFlowRuySource EXACT 2.8.0 QUIET)
-
-if(NOT TensorFlowRuySource_FOUND)
-  return()
-endif(NOT TensorFlowRuySource_FOUND)
-
-add_library(mio_tflite280_inc INTERFACE)
-target_include_directories(mio_tflite280_inc SYSTEM INTERFACE "${TensorFlowSource_DIR}")
-target_include_directories(mio_tflite280_inc SYSTEM INTERFACE "${TensorFlowGEMMLowpSource_DIR}")
-target_include_directories(mio_tflite280_inc SYSTEM INTERFACE "${TensorFlowRuySource_DIR}")
-
 file(GLOB_RECURSE SOURCES "src/*.cpp")
 file(GLOB_RECURSE TESTS "src/*.test.cpp")
 list(REMOVE_ITEM SOURCES ${TESTS})


### PR DESCRIPTION
This will remove mio_tflite280_inc target that has been moved to luci-compute.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>