### PR TITLE
[npud] Implement create and destroy request in core class

### DIFF
--- a/runtime/service/npud/core/Core.cc
+++ b/runtime/service/npud/core/Core.cc
@@ -118,5 +118,51 @@ int Core::destroyNetwork(ContextID contextId, ModelID modelId) const
   return 0;
 }
 
+int Core::createRequest(ContextID contextId, ModelID modelId, RequestID *requestId) const
+{
+  VERBOSE(Core) << "createRequest with " << contextId << ", " << modelId << std::endl;
+  NpuContext *npuContext = _contextManager->getNpuContext(contextId);
+  if (!npuContext)
+  {
+    VERBOSE(Core) << "Invalid context id" << std::endl;
+    // TODO Define CoreStatus
+    return 1;
+  }
+
+  RequestID id;
+  int ret = _devManager->createRequest(npuContext, modelId, &id);
+  if (ret != NPU_STATUS_SUCCESS)
+  {
+    VERBOSE(Core) << "Failed to create request of model: " << ret << std::endl;
+    // TODO Define CoreStatus
+    return 1;
+  }
+
+  *requestId = id;
+  return 0;
+}
+
+int Core::destroyRequest(ContextID contextId, RequestID requestId) const
+{
+  VERBOSE(Core) << "destroyRequest with " << contextId << ", " << requestId << std::endl;
+  NpuContext *npuContext = _contextManager->getNpuContext(contextId);
+  if (!npuContext)
+  {
+    VERBOSE(Core) << "Invalid context id" << std::endl;
+    // TODO Define CoreStatus
+    return 1;
+  }
+
+  int ret = _devManager->destroyRequest(npuContext, requestId);
+  if (ret != NPU_STATUS_SUCCESS)
+  {
+    VERBOSE(Core) << "Failed to destroy request: " << ret << std::endl;
+    // TODO Define CoreStatus
+    return 1;
+  }
+
+  return 0;
+}
+
 } // namespace core
 } // namespace npud

--- a/runtime/service/npud/core/Core.h
+++ b/runtime/service/npud/core/Core.h
@@ -47,6 +47,8 @@ public:
   int destroyContext(ContextID contextId) const;
   int createNetwork(ContextID contextId, const std::string &modelPath, ModelID *modelId) const;
   int destroyNetwork(ContextID contextId, ModelID modelId) const;
+  int createRequest(ContextID contextId, ModelID modelId, RequestID *requestId) const;
+  int destroyRequest(ContextID contextId, RequestID requestId) const;
 
 private:
   std::unique_ptr<DevManager> _devManager;

--- a/runtime/service/npud/core/DBus.cc
+++ b/runtime/service/npud/core/DBus.cc
@@ -140,8 +140,7 @@ gboolean DBus::on_handle_request_create(NpudCore *object, GDBusMethodInvocation 
   VERBOSE(DBus) << "on_handle_request_create with " << arg_ctx << ", " << arg_nw_handle
                 << std::endl;
   RequestID requestID = 0;
-  int ret = -1;
-  // TODO Invoke core function.
+  int ret = Server::instance().core().createRequest(arg_ctx, arg_nw_handle, &requestID);
   npud_core_complete_request_create(object, invocation, guint(requestID), ret);
   return TRUE;
 }
@@ -151,8 +150,7 @@ gboolean DBus::on_handle_request_destroy(NpudCore *object, GDBusMethodInvocation
 {
   VERBOSE(DBus) << "on_handle_request_destroy with " << arg_ctx << ", " << arg_rq_handle
                 << std::endl;
-  int ret = -1;
-  // TODO Invoke core function.
+  int ret = Server::instance().core().destroyRequest(arg_ctx, arg_rq_handle);
   npud_core_complete_request_destroy(object, invocation, ret);
   return TRUE;
 }


### PR DESCRIPTION
The Core function invokes the dev manager to create and destroy request. The npu daemon will do the job with a given model id using backend library.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Draft PR: #9989 