### PR TITLE
[infra] Fix external download tool bug

### DIFF
--- a/infra/cmake/modules/ExternalSourceTools.cmake
+++ b/infra/cmake/modules/ExternalSourceTools.cmake
@@ -53,17 +53,10 @@ function(ExternalSource_Download PREFIX)
 
       # For external mirror server
       envoption(EXTERNAL_SERVER_USERPWD "")
-
-      if("${EXTERNAL_SERVER_USERPWD}" STREQUAL "")
-        file(DOWNLOAD ${URL} "${DOWNLOAD_PATH}"
-                      STATUS status
-                      USERPWD "${ARG_USERPWD}"
-                      LOG log)
-      else("${EXTERNAL_SERVER_USERPWD}" STREQUAL "")
-        file(DOWNLOAD ${URL} "${DOWNLOAD_PATH}"
-                      STATUS status
-                      LOG log)
-      endif("${EXTERNAL_SERVER_USERPWD}" STREQUAL "")
+      file(DOWNLOAD ${URL} "${DOWNLOAD_PATH}"
+                    STATUS status
+                    USERPWD "${EXTERNAL_SERVER_USERPWD}"
+                    LOG log)
 
       list(GET status 0 status_code)
       list(GET status 1 status_string)


### PR DESCRIPTION
This commit fixes invalid variable name in ExternalSourceTools. 
It includes reducing file download implementation.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>