### PR TITLE
[luci/svc] Validate for multi-output nodes

### DIFF
--- a/compiler/luci/service/src/Validate.cpp
+++ b/compiler/luci/service/src/Validate.cpp
@@ -148,6 +148,23 @@ bool validate_shape_dtype(loco::Graph *g)
   return true;
 }
 
+/**
+ * @brief Validate sequence of multi-output nodes are followed for specific
+ *        IRs such as CircleIfOut.
+ */
+bool validate_multi_outs(loco::Graph *g)
+{
+  for (auto node : loco::active_nodes(loco::output_nodes(g)))
+  {
+    auto const cnode = loco::must_cast<luci::CircleNode *>(node);
+
+    // TODO implement validate per cnode
+    (void)cnode;
+  }
+
+  return true;
+}
+
 class VirtualNodeDetector final : public luci::CircleNodeVisitor<bool>
 {
 public:
@@ -183,6 +200,9 @@ bool validate(loco::Graph *g)
     return false;
 
   if (!validate_shape_dtype(g))
+    return false;
+
+  if (!validate_multi_outs(g))
     return false;
 
   // TODO add more validation


### PR DESCRIPTION
This will introduce validate_multi_outs method to validate for multi-output nodes.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>