### PR TITLE
[luci/svc] Implement validate_multi_outs

### DIFF
--- a/compiler/luci/service/src/Validate.cpp
+++ b/compiler/luci/service/src/Validate.cpp
@@ -148,18 +148,73 @@ bool validate_shape_dtype(loco::Graph *g)
   return true;
 }
 
+class MultiOutNodeValidate final : public luci::CircleNodeVisitor<bool>
+{
+public:
+  MultiOutNodeValidate() {}
+
+private:
+  template <class T> bool check(const luci::CircleNode *node)
+  {
+    auto succs = loco::succs(node);
+    if (succs.size() < 1)
+      return false;
+    for (const auto &cnode : succs)
+    {
+      auto const child = dynamic_cast<const T *>(cnode);
+      if (child == nullptr)
+        return false;
+    }
+    return true;
+  }
+
+public:
+  bool visit(const luci::CircleBidirectionalSequenceLSTM *node) final
+  {
+    return check<luci::CircleBidirectionalSequenceLSTMOut>(node);
+  }
+  bool visit(const luci::CircleCustom *node) final { return check<luci::CircleCustomOut>(node); }
+  bool visit(const luci::CircleIf *node) final { return check<luci::CircleIfOut>(node); }
+  bool visit(const luci::CircleNonMaxSuppressionV4 *node) final
+  {
+    return check<luci::CircleNonMaxSuppressionV4Out>(node);
+  }
+  bool visit(const luci::CircleNonMaxSuppressionV5 *node) final
+  {
+    return check<luci::CircleNonMaxSuppressionV5Out>(node);
+  }
+  bool visit(const luci::CircleSplit *node) final { return check<luci::CircleSplitOut>(node); }
+  bool visit(const luci::CircleSplitV *node) final { return check<luci::CircleSplitVOut>(node); }
+  bool visit(const luci::CircleTopKV2 *node) final { return check<luci::CircleTopKV2Out>(node); }
+  bool visit(const luci::CircleUnique *node) final { return check<luci::CircleUniqueOut>(node); }
+  bool visit(const luci::CircleUnpack *node) final { return check<luci::CircleUnpackOut>(node); }
+  bool visit(const luci::CircleWhile *node) final { return check<luci::CircleWhileOut>(node); }
+
+  // default true for other nodes
+  bool visit(const luci::CircleNode *) final { return true; }
+};
+
 /**
  * @brief Validate sequence of multi-output nodes are followed for specific
  *        IRs such as CircleIfOut.
  */
 bool validate_multi_outs(loco::Graph *g)
 {
+  LOGGER(l);
+
   for (auto node : loco::active_nodes(loco::output_nodes(g)))
   {
     auto const cnode = loco::must_cast<luci::CircleNode *>(node);
 
-    // TODO implement validate per cnode
-    (void)cnode;
+    MultiOutNodeValidate d;
+    if (cnode->accept(&d))
+      continue;
+
+    auto const name = cnode->name();
+    INFO(l) << "Node: " << name << ", " << (uint32_t)(cnode->opcode()) << " has invalid successor."
+            << std::endl;
+
+    return false;
   }
 
   return true;


### PR DESCRIPTION
This will implement validate_multi_outs method to check multiple output IRs has valid successor type.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>