### PR TITLE
[loco] Refactor output_nodes in IR Graph

### DIFF
--- a/compiler/loco/include/loco/IR/Graph.h
+++ b/compiler/loco/include/loco/IR/Graph.h
@@ -264,7 +264,6 @@ struct GraphOutputIndexQueryService : public DialectService
   virtual GraphOutputIndex index(const Node *node) const = 0;
 };
 
-// TODO Use "const Graph *"
 std::vector<Node *> output_nodes(Graph *);
 
 /**


### PR DESCRIPTION
Make output_nodes helper accept const loco::Graph* instead of loco::Graph*.

Signed-off-by: a.shedko <a.shedko@samsung.com>