### PR TITLE
[onert/test] Use curl for test model download

### DIFF
--- a/tests/scripts/models/run_test.sh
+++ b/tests/scripts/models/run_test.sh
@@ -233,7 +233,7 @@ download_tests()
 
             rm -f $MODELFILE # Remove invalid file if exists
             pushd $CACHE_ROOT_PATH
-            wget --tries=3 --retry-connrefused --waitretry=2 -nv $MODELFILE_URL
+            curl --netrc-optional -kLsSO $MODELFILE_URL
             if [ "${MODELFILE_NAME##*.}" == "zip" ]; then
                 unzip -o $MODELFILE_NAME -d ${MODELFILE_NAME%.zip}
             fi


### PR DESCRIPTION
This commit updates test model download script to use `curl` instaed of `wget`.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>