### PR TITLE
[infra/npud] Disable default build on ubuntu x64

### DIFF
--- a/infra/nnfw/cmake/options/options_x86_64-linux.cmake
+++ b/infra/nnfw/cmake/options/options_x86_64-linux.cmake
@@ -4,6 +4,3 @@
 option(BUILD_ARMCOMPUTE "Build ARM Compute from the downloaded source" OFF)
 option(BUILD_XNNPACK "Build XNNPACK" OFF)
 option(DOWNLOAD_ARMCOMPUTE "Download ARM Compute source" OFF)
-
-option(BUILD_NPUD "Build NPU daemon" ON)
-option(ENVVAR_NPUD_CONFIG "Use environment variable for npud configuration" ON)


### PR DESCRIPTION
This commit disables `npud` build on ubuntu x64 default setting.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: #10161 