### PR TITLE
[DRAFT] [mpqsolver] Introduce bisection method

### DIFF
--- a/compiler/circle-mpqsolver/CMakeLists.txt
+++ b/compiler/circle-mpqsolver/CMakeLists.txt
@@ -1,0 +1,15 @@
+file(GLOB_RECURSE SOURCES "src/*.cpp")
+
+add_executable(circle-mpqsolver "${SOURCES}")
+target_link_libraries(circle-mpqsolver luci_import)
+target_link_libraries(circle-mpqsolver luci_export)
+target_link_libraries(circle-mpqsolver luci_pass)
+target_link_libraries(circle-mpqsolver luci_service)
+target_link_libraries(circle-mpqsolver luci_interpreter)
+target_link_libraries(circle-mpqsolver luci_partition)
+target_link_libraries(circle-mpqsolver dio_hdf5)
+target_link_libraries(circle-mpqsolver arser)
+target_link_libraries(circle-mpqsolver vconone)
+target_link_libraries(circle-mpqsolver safemain)
+
+install(TARGETS circle-mpqsolver DESTINATION bin)

--- a/compiler/circle-mpqsolver/README.md
+++ b/compiler/circle-mpqsolver/README.md
@@ -1,0 +1,3 @@
+# circle-mpqsolver
+
+_circle-mpqsolver_ provides light-weight methods for finding Mixed Precision Quantization model.

--- a/compiler/circle-mpqsolver/requires.cmake
+++ b/compiler/circle-mpqsolver/requires.cmake
@@ -1,0 +1,6 @@
+require("arser")
+require("luci")
+require("luci-interpreter")
+require("dio-hdf5")
+require("safemain")
+require("vconone")

--- a/compiler/circle-mpqsolver/src/BisectionSolver.cpp
+++ b/compiler/circle-mpqsolver/src/BisectionSolver.cpp
@@ -1,0 +1,287 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "BisectionSolver.h"
+#include "ErrorApproximator.h"
+#include "ModuleCloner.h"
+#include "Evaluator.h"
+
+#include <cmath>
+#include <iostream>
+
+using namespace mpqsolver;
+
+using NodeDepthType = std::map<luci::CircleNode *, float>;
+
+namespace
+{
+
+int compute_depth(const luci::Module *module, NodeDepthType &nodes_depth, float &min_depth,
+                  float &max_depth)
+{
+  if (module == nullptr)
+    return EXIT_FAILURE;
+
+  if (module->size() != 1)
+    return EXIT_FAILURE;
+
+  auto graph = module->graph(0);
+  if (!graph)
+    return EXIT_FAILURE;
+
+  auto nodes = graph->nodes();
+  uint32_t nodes_size = nodes->size();
+  std::set<std::string> input_names;
+  {
+    auto inp_nodes = graph->inputs();
+    for (uint32_t i = 0; i < inp_nodes->size(); ++i)
+    {
+      auto inp_node = inp_nodes->at(i);
+      auto inp_name = inp_node->name();
+      input_names.insert(inp_name);
+    }
+  }
+
+  // initializing
+  std::vector<luci::CircleNode *> to_process;
+  std::map<std::string, float> named_depth;
+  {
+    auto inputs = loco::input_nodes(graph);
+    for (auto &node : inputs)
+    {
+      auto cnode = loco::must_cast<luci::CircleNode *>(node);
+      to_process.emplace_back(cnode);
+      nodes_depth[cnode] = 0.f;
+      named_depth[cnode->name()] = 0.f;
+    }
+  }
+
+  // enumerating
+  while (!to_process.empty())
+  {
+    auto cur_node = to_process.back();
+    to_process.pop_back();
+    auto iter = nodes_depth.find(cur_node);
+    if (iter == nodes_depth.end())
+    {
+      return EXIT_FAILURE; // unexpected
+    }
+    float cur_depth = iter->second + 1;
+    // processing children
+    auto children = loco::succs(cur_node);
+    for (auto &child : children)
+    {
+      auto cichild = loco::must_cast<luci::CircleNode *>(child);
+      auto node_depth = nodes_depth.find(cichild);
+      if (node_depth == nodes_depth.end() || node_depth->second < cur_depth)
+      {
+        // initialize depth
+        nodes_depth[cichild] = cur_depth;
+        to_process.push_back(cichild);
+        named_depth[cichild->name()] = cur_depth;
+      }
+    }
+  }
+
+  auto minmax = std::minmax_element(
+    nodes_depth.begin(), nodes_depth.end(),
+    [=](const std::pair<luci::CircleNode *, float> &el1,
+        const std::pair<luci::CircleNode *, float> &el2) { return el1.second < el2.second; });
+
+  min_depth = minmax.first->second;
+  max_depth = minmax.second->second;
+
+  return EXIT_SUCCESS;
+}
+
+bool error_at_input_is_larger_than_at_output(const NodeDepthType &nodes_depth, float cut_depth)
+{
+  float error_at_input = 0;
+  float error_at_output = 0;
+  for (auto &iter : nodes_depth)
+  {
+    float cur_error = ErrorApproximator::approximate(iter.first);
+    if (iter.second < cut_depth)
+    {
+      error_at_input += cur_error;
+    }
+    else
+    {
+      error_at_output += cur_error;
+    }
+  }
+
+  if (error_at_input > error_at_output)
+  {
+    std::cerr << "Q16 will be set at input due to ";
+  }
+  else
+  {
+    std::cerr << "Q8 will be set at input due to ";
+  }
+  std::cerr << error_at_input << " error at input vs ";
+  std::cerr << error_at_output << " error at output." << std::endl;
+
+  return error_at_input > error_at_output;
+}
+
+class BisectionOptionsImpl final : public BisectionSolver::Options
+{
+public:
+  virtual void enable(Q16AtInput) final;
+  virtual bool query(Q16AtInput) final;
+
+private:
+  Q16AtInput _q16AtInput = Q16AtInput::Auto;
+};
+
+void BisectionOptionsImpl::enable(Q16AtInput q16AtInput) { _q16AtInput = q16AtInput; }
+bool BisectionOptionsImpl::query(Q16AtInput q16AtInput) { return _q16AtInput == q16AtInput; }
+
+} // namespace
+
+BisectionSolver::BisectionSolver(const std::string &input_data_path, float qerror_ratio)
+  : _input_data_path(input_data_path), _qerror_ratio(qerror_ratio), _qerror(0.f)
+{
+}
+
+BisectionSolver::Options *BisectionSolver::options(void)
+{
+  if (_options == nullptr)
+  {
+    _options = std::make_unique<BisectionOptionsImpl>();
+  }
+
+  return _options.get();
+}
+
+std::unique_ptr<luci::Module> BisectionSolver::run(const luci::Module *in_module)
+{
+  float min_depth = 0.f;
+  float max_depth = 0.f;
+  NodeDepthType nodes_depth;
+  if (compute_depth(in_module, nodes_depth, min_depth, max_depth) != EXIT_SUCCESS)
+  {
+    std::cerr << "Invalid graph for bisectioning" << std::endl;
+    return nullptr;
+  }
+
+  DatasetEvaluator evaluator(in_module, _input_data_path);
+  // const auto &ref_output = compute_outputs(module.get(), _input_data_path);
+  LayerParams layer_params;
+  float int16_qerror = evaluator.evaluate("int16", layer_params);
+  std::cerr << "int16_quantization_error " << int16_qerror << std::endl;
+
+  float int8_qerror = evaluator.evaluate("uint8", layer_params);
+  std::cerr << "int8_quantization_error " << int8_qerror << std::endl;
+
+  _qerror = int16_qerror + _qerror_ratio * std::fabs(int8_qerror - int16_qerror);
+  std::cerr << "target quantization error " << _qerror << std::endl;
+
+  int last_depth = -1;
+  float best_depth = -1;
+  LayerParams best_params;
+  auto graph = in_module->graph(0);
+  auto active_nodes = loco::active_nodes(loco::output_nodes(graph));
+  // input and output nodes are not valid for quantization, so let's remove them
+  for (auto node : loco::input_nodes(graph))
+  {
+    active_nodes.erase(node);
+  }
+  for (auto node : loco::output_nodes(graph))
+  {
+    active_nodes.erase(node);
+  }
+
+  // let's decide whether nodes at input are more suspectible to be quantized into Q16, than at
+  // output
+  bool int16_at_input = true;
+  if (auto option = options())
+  {
+    if (option->query(Options::Q16AtInput::Auto))
+    {
+      int16_at_input =
+        error_at_input_is_larger_than_at_output(nodes_depth, 0.5f * (max_depth + min_depth));
+    }
+    else if (option->query(Options::Q16AtInput::True))
+    {
+      int16_at_input = true;
+    }
+    else if (option->query(Options::Q16AtInput::False))
+    {
+      int16_at_input = false;
+    }
+  }
+
+  while (true)
+  {
+    float cut_depth = 0.5f * (min_depth + max_depth);
+
+    if (last_depth == int(cut_depth))
+    {
+      break;
+    }
+    last_depth = int(cut_depth);
+
+    auto nodes = graph->nodes();
+    LayerParams layer_params;
+    for (auto &node : active_nodes)
+    {
+      auto cur_node = loco::must_cast<luci::CircleNode *>(node);
+      auto iter = nodes_depth.find(cur_node);
+      if (iter == nodes_depth.end())
+      {
+        continue;
+      }
+
+      float depth = iter->second;
+      if ((depth <= cut_depth && int16_at_input) || (depth >= cut_depth && !int16_at_input))
+      {
+        auto layer_param = std::make_shared<LayerParam>();
+        {
+          layer_param->name = cur_node->name();
+          layer_param->dtype = "int16";
+          layer_param->granularity = "channel";
+        }
+
+        layer_params.emplace_back(layer_param);
+      }
+    }
+
+    float cur_accuracy = evaluator.evaluate("uint8", layer_params);
+    std::cerr << cut_depth << " : " << cur_accuracy << std::endl;
+
+    if (cur_accuracy < _qerror)
+    {
+      int16_at_input ? (max_depth = cut_depth) : (min_depth = cut_depth);
+      best_params = layer_params;
+      best_depth = cut_depth;
+    }
+    else
+    {
+      int16_at_input ? (min_depth = cut_depth) : (max_depth = cut_depth);
+    }
+  }
+
+  if (best_params.empty())
+  {
+    std::cerr << "Failed to optimal configuration" << std::endl;
+    return nullptr;
+  }
+
+  std::cerr << "Found optimal configuration at " << best_depth << " depth." << std::endl;
+  return evaluator.quantize("uint8", best_params);
+}

--- a/compiler/circle-mpqsolver/src/BisectionSolver.h
+++ b/compiler/circle-mpqsolver/src/BisectionSolver.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __MPQSOLVER_BISECTION_SOLVER_H__
+#define __MPQSOLVER_BISECTION_SOLVER_H__
+
+#include <luci/IR/Module.h>
+
+#include <memory>
+#include <string>
+
+namespace mpqsolver
+{
+
+class BisectionSolver final
+{
+
+public:
+  struct Options
+  {
+    enum class Q16AtInput
+    {
+      Auto,
+      True,
+      False,
+    };
+    virtual ~Options() = default;
+
+    virtual void enable(Q16AtInput) = 0;
+    virtual bool query(Q16AtInput) = 0;
+  };
+
+public:
+  Options *options(void);
+
+public:
+  BisectionSolver(const std::string &input_data_path, float qerror_ratio);
+  ~BisectionSolver() = default;
+
+  std::unique_ptr<luci::Module> run(const luci::Module *in_module);
+
+private:
+  std::string _input_data_path;
+  float _qerror = 0.f;       // quantization error
+  float _qerror_ratio = 0.f; // quantization error ratio
+  std::unique_ptr<Options> _options;
+};
+
+} // namespace mpqsolver
+
+#endif //__MPQSOLVER_BISECTION_SOLVER_H__

--- a/compiler/circle-mpqsolver/src/CircleMPQSolver.cpp
+++ b/compiler/circle-mpqsolver/src/CircleMPQSolver.cpp
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "BisectionSolver.h"
+
+#include <arser/arser.h>
+#include <vconone/vconone.h>
+
+#include <luci/ImporterEx.h>
+#include <luci/Importer.h>
+#include <luci/CircleExporter.h>
+#include <luci/CircleFileExpContract.h>
+
+#include <iostream>
+#include <iomanip>
+#include <chrono>
+
+void print_version(void)
+{
+  std::cout << "circle-mpqsolver version " << vconone::get_string() << std::endl;
+  std::cout << vconone::get_copyright() << std::endl;
+}
+
+int entry(int argc, char **argv)
+{
+  const std::string bisection_str = "--bisection";
+
+  arser::Arser arser("circle-mpqsolver provides circle_model mixed precision quantization");
+
+  arser::Helper::add_version(arser, print_version);
+  arser::Helper::add_verbose(arser);
+
+  arser.add_argument("--data").required(true).help(".h5 file with test data");
+  arser.add_argument("--qerror_ratio")
+    .type(arser::DataType::FLOAT)
+    .default_value(0.5f)
+    .help("quantization error ratio");
+
+  arser.add_argument(bisection_str)
+    .nargs(1)
+    .default_value("auto")
+    .type(arser::DataType::STR)
+    .help("Bisection method Q16 at input nodes"
+          "Default is 'auto'."
+          "Single optional argument: whether Q16 qunatization should be at input nodes "
+          "'auto', 'true', 'false'.");
+
+  arser.add_argument("--input_model")
+    .required(true)
+    .help("Input float model with min max initialized");
+
+  arser.add_argument("--output_model").required(true).help("Output quantized model");
+
+  try
+  {
+    arser.parse(argc, argv);
+  }
+  catch (const std::runtime_error &err)
+  {
+    std::cerr << err.what() << std::endl;
+    std::cout << arser;
+    return EXIT_FAILURE;
+  }
+
+  if (arser.get<bool>("--verbose"))
+  {
+    // The third parameter of setenv means REPLACE.
+    // If REPLACE is zero, it does not overwrite an existing value.
+    setenv("LUCI_LOG", "100", 0);
+  }
+
+  auto data_path = arser.get<std::string>("--data");
+  auto input_model_path = arser.get<std::string>("--input_model");
+  auto output_model_path = arser.get<std::string>("--output_model");
+
+  float qerror_ratio = arser.get<float>("--qerror_ratio");
+
+  auto start = std::chrono::high_resolution_clock::now();
+
+  // Load input model
+  luci::ImporterEx importerex;
+  auto module = importerex.importVerifyModule(input_model_path);
+  if (module.get() == nullptr)
+  {
+    std::cerr << "Failed to load " << input_model_path << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  // optimize
+  mpqsolver::BisectionSolver solver(data_path, qerror_ratio);
+  {
+    auto value = arser.get<std::string>(bisection_str);
+    if (value == "auto")
+    {
+      solver.options()->enable(mpqsolver::BisectionSolver::Options::Q16AtInput::Auto);
+    }
+    else if (value == "true")
+    {
+      solver.options()->enable(mpqsolver::BisectionSolver::Options::Q16AtInput::True);
+    }
+    else if (value == "false")
+    {
+      solver.options()->enable(mpqsolver::BisectionSolver::Options::Q16AtInput::False);
+    }
+    else
+    {
+      std::cerr << "Unrecognized option for bisection algortithm" << input_model_path << std::endl;
+      return EXIT_FAILURE;
+    }
+  }
+
+  auto optimized = solver.run(module.get());
+  if (optimized == nullptr)
+  {
+    std::cerr << "Failed to build mixed precision model" << input_model_path << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  // save optimized
+  {
+    luci::CircleExporter exporter;
+    luci::CircleFileExpContract contract(optimized.get(), output_model_path);
+    if (!exporter.invoke(&contract))
+    {
+      std::cerr << "Failed to build mixed precision model" << input_model_path << std::endl;
+      return EXIT_FAILURE;
+    }
+  }
+
+  auto duration = std::chrono::duration_cast<std::chrono::seconds>(
+    std::chrono::high_resolution_clock::now() - start);
+  std::cerr << "Time elapsed is " << std::setprecision(5) << duration.count() / 60.f << " minutes."
+            << std::endl;
+
+  return EXIT_SUCCESS;
+}

--- a/compiler/circle-mpqsolver/src/ErrorApproximator.cpp
+++ b/compiler/circle-mpqsolver/src/ErrorApproximator.cpp
@@ -1,0 +1,352 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ErrorApproximator.h"
+
+#include <cmath>
+#include <limits>
+#include <vector>
+#include <functional>
+#include <luci/IR/Nodes/CircleConst.h>
+#include <luci/IR/Nodes/CircleConv2D.h>
+#include <luci/IR/Nodes/CircleTransposeConv.h>
+#include <luci/IR/Nodes/CircleFullyConnected.h>
+#include <luci/IR/Nodes/CircleDepthwiseConv2D.h>
+
+using namespace mpqsolver;
+
+namespace
+{
+
+using namespace luci;
+using IterFunc = std::function<void(uint32_t *, loco::TensorShape &, int32_t)>;
+
+inline bool has_min_max(const CircleNode *node)
+{
+  return node->quantparam() && !node->quantparam()->min.empty() && !node->quantparam()->max.empty();
+}
+
+inline uint32_t cal_offset(const loco::TensorShape &dimension, uint32_t *indices)
+{
+  return indices[0] * dimension.dim(1).value() * dimension.dim(2).value() *
+           dimension.dim(3).value() +
+         indices[1] * dimension.dim(2).value() * dimension.dim(3).value() +
+         indices[2] * dimension.dim(3).value() + indices[3];
+}
+
+uint32_t get_channel_dim_index(const CircleNode *node)
+{
+  uint32_t index = 0;
+  auto opcode = node->opcode();
+  switch (opcode)
+  {
+    case CircleOpcode::CONV_2D:
+    case CircleOpcode::TRANSPOSE_CONV:
+    case CircleOpcode::FULLY_CONNECTED:
+    {
+      index = 0;
+    }
+    break;
+    case CircleOpcode::DEPTHWISE_CONV_2D:
+    {
+      index = 3;
+    }
+    break;
+    default:
+      throw std::runtime_error("Failed to find channel index in " + node->name());
+  }
+
+  return index;
+}
+
+bool set_weight_dim(const CircleNode *node, const CircleConst *weights,
+                    loco::TensorShape &dimension)
+{
+  auto opcode = node->opcode();
+  switch (opcode)
+  {
+    case CircleOpcode::CONV_2D:
+    case CircleOpcode::TRANSPOSE_CONV:
+    case CircleOpcode::DEPTHWISE_CONV_2D:
+    {
+      assert(node->rank() == 4);
+      dimension.rank(node->rank());
+      dimension.dim(0).set(weights->dim(0).value());
+      dimension.dim(1).set(weights->dim(1).value());
+      dimension.dim(2).set(weights->dim(2).value());
+      dimension.dim(3).set(weights->dim(3).value());
+    }
+    break;
+    case CircleOpcode::FULLY_CONNECTED:
+    {
+      assert(node->rank() == 2);
+      dimension.rank(4);
+      dimension.dim(0).set(weights->dim(0).value());
+      dimension.dim(1).set(1); // Set FC layer like CONV
+      dimension.dim(2).set(1);
+      dimension.dim(3).set(weights->dim(1).value());
+    }
+    break;
+    default:
+      return false;
+  }
+
+  return true;
+}
+
+loco::Node *get_weight(const CircleNode *node)
+{
+  loco::Node *weight = nullptr;
+  auto opcode = node->opcode();
+  switch (opcode)
+  {
+    case CircleOpcode::CONV_2D:
+    {
+      auto conv = loco::must_cast<const CircleConv2D *>(node);
+      weight = conv->filter();
+    }
+    break;
+    case CircleOpcode::DEPTHWISE_CONV_2D:
+    {
+      auto dconv = loco::must_cast<const CircleDepthwiseConv2D *>(node);
+      weight = dconv->filter();
+    }
+    break;
+    case CircleOpcode::TRANSPOSE_CONV:
+    {
+      auto tconv = loco::must_cast<const CircleTransposeConv *>(node);
+      weight = tconv->filter();
+    }
+    break;
+    case CircleOpcode::FULLY_CONNECTED:
+    {
+      auto fc = loco::must_cast<const CircleFullyConnected *>(node);
+      weight = fc->weights();
+    }
+    break;
+    default:
+      break;
+  }
+
+  return weight;
+}
+
+void iterate_per_channel(const CircleNode *node, IterFunc func)
+{
+  CircleConst *weight = loco::must_cast<CircleConst *>(get_weight(node));
+  loco::TensorShape dimension;
+  set_weight_dim(node, weight, dimension);
+  uint32_t indices[4] = {
+    0,
+  };
+
+  auto channel_dim_index = get_channel_dim_index(node);
+
+  for (indices[0] = 0; indices[0] < dimension.dim(0).value(); indices[0]++)
+  {
+    for (indices[1] = 0; indices[1] < dimension.dim(1).value(); indices[1]++)
+    {
+      for (indices[2] = 0; indices[2] < dimension.dim(2).value(); indices[2]++)
+      {
+        for (indices[3] = 0; indices[3] < dimension.dim(3).value(); indices[3]++)
+        {
+          func(indices, dimension, channel_dim_index);
+        }
+      }
+    }
+  }
+}
+
+void cal_minmax_per_channel(const CircleNode *node, std::vector<float> &min,
+                            std::vector<float> &max)
+{
+  CircleConst *weight = loco::must_cast<CircleConst *>(get_weight(node));
+  loco::TensorShape dimension;
+  set_weight_dim(node, weight, dimension);
+
+  auto channel_dim_index = get_channel_dim_index(node);
+  auto size = dimension.dim(channel_dim_index).value();
+
+  std::vector<bool> has_min_max_value(size, false);
+  min.resize(size);
+  max.resize(size);
+
+  auto cal_minmax = [&](uint32_t *indices, loco::TensorShape &dimension, int channel_dim_index) {
+    int channel_idx = indices[channel_dim_index];
+    auto data = weight->at<loco::DataType::FLOAT32>(cal_offset(dimension, indices));
+    if (has_min_max_value[channel_idx])
+    {
+      min[channel_idx] = data < min[channel_idx] ? data : min[channel_idx];
+      max[channel_idx] = data > max[channel_idx] ? data : max[channel_idx];
+    }
+    else
+    {
+      min[channel_idx] = data;
+      max[channel_idx] = data;
+      has_min_max_value[channel_idx] = true;
+    }
+  };
+
+  iterate_per_channel(node, cal_minmax);
+}
+
+bool get_shape(const CircleNode *circle_node, std::vector<uint32_t> &shape)
+{
+  if (circle_node->shape_status() == ShapeStatus::VALID)
+  {
+    auto rank = circle_node->rank();
+    if (rank != 4)
+      return false;
+
+    shape.resize(rank);
+    for (int i = 0; i < rank; i++)
+    {
+      shape[i] = circle_node->dim(i).value();
+    }
+    return true;
+  }
+
+  return false;
+}
+
+uint32_t get_computations_per_channel(const CircleNode *node)
+{
+  uint32_t computations_per_channel = 1;
+  std::vector<uint32_t> cir_shape;
+  // size of activation map
+  if (get_shape(node, cir_shape))
+  {
+    for (uint32_t index = 0; index < cir_shape.size(); index++)
+    {
+      computations_per_channel *= cir_shape[index];
+    }
+  }
+
+  // for depthwise convolution computation of output layer needs just single input layer
+  if (node->opcode() == CircleOpcode::DEPTHWISE_CONV_2D)
+  {
+    computations_per_channel /= cir_shape.back();
+  }
+
+  if (auto weights = loco::must_cast<CircleNode *>(get_weight(node)))
+  {
+    std::vector<uint32_t> w_shape;
+    if (get_shape(weights, w_shape))
+    {
+      computations_per_channel *= (w_shape[1] * w_shape[2]); //[channels_out, k_x, k_y, channels_in]
+    }
+  }
+
+  return computations_per_channel;
+}
+
+void get_min_max_activation_values(const CircleNode *node, float &ci_min, float &ci_max)
+{
+  auto preds = loco::preds(node);
+  for (const auto &pred : preds)
+  {
+    auto parent_node = loco::must_cast<const luci::CircleNode *>(pred);
+    if (has_min_max(parent_node))
+    {
+      auto quantparam = parent_node->quantparam();
+      if (quantparam->min.size() > 0)
+      {
+        ci_min = quantparam->min[0];
+        ci_max = quantparam->max[0];
+      }
+    }
+  }
+}
+
+} // namespace
+
+/**
+ * How Approximate works?
+ *
+ * Currently it works just for convolution layers, but may be generalized for other types as well.
+ * See discussion at https://github.com/Samsung/ONE/pull/10170#discussion_r1042246598
+ * Convolution is just a matrix multiplication.
+ * While quantizing we introduce quantization error into convolution operand (activations) as well
+ * as into convolution weights. A_q * W_q = (A + q_err(A)) * (W + q_err(W)) = A * W + A * q_err(W) +
+ * W * q_err(A), q_err - quantization error, W - weight matrix, A - activations from previous layer,
+ * so quantization error of matrix multiplication is A * q_err(W) + W * q_err(A).
+ * Estimating its largest value we get
+ * ~ number_of_additions * (A_max * (W_max - W_min) / 255 + W_max * (A_max - A_min) / 255)
+ * The following code tries to get total error for quantizing convolution node into Q8.
+ * It's just an heuristic (Metric sensitivity depends highly on derivatives as well).
+ */
+float ErrorApproximator::approximate(const CircleNode *node)
+{
+  auto opcode = node->opcode();
+  if (opcode != CircleOpcode::CONV_2D && opcode != CircleOpcode::TRANSPOSE_CONV &&
+      opcode != CircleOpcode::DEPTHWISE_CONV_2D)
+  {
+    return 0.0; // TODO
+  }
+
+  float volume_W_A_err = 0.f;
+  {
+    // activation min-max values
+    float ci_min = 0.f;
+    float ci_max = 0.f;
+    get_min_max_activation_values(node, ci_min, ci_max);
+
+    // channel-wise min, max
+    std::vector<float> min_values;
+    std::vector<float> max_values;
+    cal_minmax_per_channel(node, min_values, max_values);
+
+    // ranges  = (max_values - min_values)
+    std::vector<float> ranges = max_values;
+    for (uint32_t i = 0; i < min_values.size(); ++i)
+    {
+      ranges[i] -= min_values[i];
+    }
+
+    // maximal weight value across all channels
+    float w_max = 0;
+    {
+      for (int i = 0; i < (int)max_values.size(); ++i)
+      {
+        w_max = std::max(w_max, (float)::fabs(max_values[i]));
+        w_max = std::max(w_max, (float)::fabs(min_values[i]));
+      }
+    }
+
+    // total weight quantization error across all channels
+    // so maximal error of quantization is ~ (max_value - min_value) / 255
+    // omitting 255 term we get that maximal error of quantization is just its range
+    float sum_err = 0.f;
+    for (auto cur_err : ranges)
+    {
+      sum_err += cur_err;
+    }
+
+    uint32_t computations_per_channel = get_computations_per_channel(node);
+    uint32_t num_of_channels = ranges.size();
+
+    // maximal error introduced by weights quantization (for all channels)
+    volume_W_A_err = sum_err * std::max(::fabs(ci_max), ::fabs(ci_min));
+    // plus total error introduced by activation quantization (for all channels)
+    volume_W_A_err += w_max * num_of_channels * ::fabs(ci_max - ci_min);
+    // scale by volume of computations per channel
+    volume_W_A_err *= computations_per_channel;
+    // scale to get more readable output values
+    volume_W_A_err /= 1.e+6f;
+  }
+
+  return volume_W_A_err;
+}

--- a/compiler/circle-mpqsolver/src/ErrorApproximator.h
+++ b/compiler/circle-mpqsolver/src/ErrorApproximator.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef __MPQSOLVER_ERROR_APPROXIMATOR_H__
+#define __MPQSOLVER_ERROR_APPROXIMATOR_H__
+
+#include <loco.h>
+
+#include <luci/IR/CircleNodeDecl.h>
+
+namespace mpqsolver
+{
+
+class ErrorApproximator final
+{
+public:
+  static float approximate(const luci::CircleNode *node);
+};
+
+} // namespace mpqsolver
+
+#endif // __MPQSOLVER_ERROR_APPROXIMATOR_H__

--- a/compiler/circle-mpqsolver/src/Evaluator.cpp
+++ b/compiler/circle-mpqsolver/src/Evaluator.cpp
@@ -1,0 +1,245 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "Evaluator.h"
+#include "ModuleCloner.h"
+
+#include <luci_interpreter/Interpreter.h>
+#include <luci/Service/Validate.h>
+
+#include <dio_hdf5/HDF5Importer.h>
+
+#include <cmath>
+#include <iostream>
+
+using namespace mpqsolver;
+
+using Shape = std::vector<loco::Dimension>;
+using AlgorithmParameters = luci::CircleQuantizer::Options::AlgorithmParameters;
+using Algorithms = luci::CircleQuantizer::Options::Algorithm;
+
+namespace
+{
+using namespace luci;
+
+template <typename NodeT> size_t get_tensor_size(const NodeT *node)
+{
+  uint32_t tensor_size = loco::size(node->dtype());
+  for (uint32_t i = 0; i < node->rank(); ++i)
+    tensor_size *= node->dim(i).value();
+  return tensor_size;
+}
+
+std::unique_ptr<luci::Module> fake_quantize(const luci::Module *in_module)
+{
+  luci::CircleQuantizer quantizer;
+
+  auto options = quantizer.options();
+  options->enable(Algorithms::ConvertToFakeQuantizedModel);
+  std::unique_ptr<luci::Module> module = ModuleCloner::clone(in_module);
+  if (!module)
+  {
+    return nullptr;
+  }
+
+  for (size_t idx = 0; idx < module->size(); ++idx)
+  {
+    auto graph = module->graph(idx);
+    // quantize the graph
+    quantizer.quantize(graph);
+    if (!luci::validate(graph))
+    {
+      // std::cerr << "ERROR: Quantized graph is invalid" << std::endl;
+      return nullptr;
+    }
+  }
+
+  return module;
+}
+
+} // namespace
+
+DatasetOutput compute_outputs(const luci::Module *module, const std::string &h5file)
+{
+  dio::hdf5::HDF5Importer importer{h5file};
+  importer.importGroup("value");
+
+  bool is_raw_data = importer.isRawData();
+
+  const auto num_records = importer.numData();
+  if (num_records == 0)
+    throw std::runtime_error("The input data file does not contain any record.");
+  const auto input_nodes = loco::input_nodes(module->graph());
+  const auto num_inputs = input_nodes.size();
+
+  DatasetOutput dataset_output;
+
+  // Create interpreter.
+  luci_interpreter::Interpreter interpreter(module);
+  for (int32_t record_idx = 0; record_idx < num_records; record_idx++)
+  {
+    if (num_inputs != importer.numInputs(record_idx))
+      throw std::runtime_error("Wrong number of inputs.");
+    for (int32_t input_idx = 0; input_idx < num_inputs; input_idx++)
+    {
+      const auto *input_node = loco::must_cast<const luci::CircleInput *>(input_nodes[input_idx]);
+      assert(input_node->index() == input_idx);
+
+      std::vector<char> input_data(get_tensor_size(input_node));
+
+      if (!is_raw_data)
+      {
+        loco::DataType dtype;
+        Shape shape;
+        importer.readTensor(record_idx, input_idx, &dtype, &shape, input_data.data());
+      }
+      else
+      {
+        // Skip type/shape check for raw data
+        importer.readTensor(record_idx, input_idx, input_data.data());
+      }
+
+      interpreter.writeInputTensor(input_node, input_data.data(), input_data.size());
+    }
+
+    interpreter.interpret();
+
+    NNOutput nn_output;
+
+    // Get output.
+    const auto output_nodes = loco::output_nodes(module->graph());
+    for (int i = 0; i < module->graph()->outputs()->size(); i++)
+    {
+      const auto *output_node = loco::must_cast<const luci::CircleOutput *>(output_nodes[i]);
+      ElementaryOutput output_data(get_tensor_size(output_node));
+      interpreter.readOutputTensor(output_node, output_data.data(), output_data.size());
+      // output
+      nn_output.push_back(output_data);
+    }
+    dataset_output.push_back(nn_output);
+  }
+
+  return dataset_output;
+}
+
+DatasetEvaluator::DatasetEvaluator(const luci::Module *ref_module, const std::string &h5file)
+  : _ref_module(ref_module), _h5file(h5file)
+{
+  _ref_output = compute_outputs(_ref_module, _h5file);
+}
+
+float DatasetEvaluator::evaluate(const std::string &def_quant, LayerParams &layer_params)
+{
+  auto quantized = quantize(def_quant, layer_params);
+  auto fake_quantized = fake_quantize(quantized.get());
+  return evaluate(fake_quantized.get());
+}
+
+std::unique_ptr<luci::Module> DatasetEvaluator::quantize(const std::string &def_quant,
+                                                         LayerParams &layer_params)
+{
+  static const std::string default_dtype = "float32";
+  static const std::string input_dtype = "uint8";
+  static const std::string output_dtype = "uint8";
+  static const std::string granularity_type = "channel";
+
+  luci::CircleQuantizer quantizer;
+
+  auto options = quantizer.options();
+  options->enable(Algorithms::QuantizeWithMinMax);
+
+  options->param(AlgorithmParameters::Quantize_input_model_dtype, default_dtype);
+  options->param(AlgorithmParameters::Quantize_output_model_dtype, def_quant);
+  options->param(AlgorithmParameters::Quantize_granularity, granularity_type);
+  options->param(AlgorithmParameters::Quantize_input_type, input_dtype);
+  options->param(AlgorithmParameters::Quantize_output_type, output_dtype);
+  options->param(AlgorithmParameters::Quantize_TF_style_maxpool, "True");
+
+  if (!layer_params.empty())
+  {
+    try
+    {
+      options->layer_params(AlgorithmParameters::Quantize_layer_params, layer_params);
+    }
+    catch (const std::runtime_error &e)
+    {
+      std::cerr << e.what() << '\n';
+      return nullptr;
+    }
+  }
+
+  std::unique_ptr<luci::Module> module = ModuleCloner::clone(_ref_module);
+  if (!module)
+  {
+    std::cerr << "ERROR: Failed to clone module" << std::endl;
+    return nullptr;
+  }
+
+  for (size_t idx = 0; idx < module->size(); ++idx)
+  {
+    auto graph = module->graph(idx);
+    // quantize the graph
+    quantizer.quantize(graph);
+    if (!luci::validate(graph))
+    {
+      std::cerr << "ERROR: Quantized graph is invalid" << std::endl;
+      return nullptr;
+    }
+  }
+
+  return module;
+}
+
+float DatasetEvaluator::evaluate(const luci::Module *module)
+{
+  float accuracy = 0.f;
+  size_t output_size = 0;
+  const DatasetOutput &cur_output = compute_outputs(module, _h5file);
+  for (size_t sample_index = 0; sample_index < _ref_output.size(); ++sample_index)
+  {
+    // Get output.
+    const auto output_nodes = loco::output_nodes(module->graph());
+    for (size_t out_index = 0; out_index < _ref_output[sample_index].size(); ++out_index)
+    {
+      const auto *output_node =
+        loco::must_cast<const luci::CircleOutput *>(output_nodes[out_index]);
+      loco::DataType out_type = output_node->dtype();
+      const ElementaryOutput &ref_elementary = _ref_output[sample_index][out_index];
+      const ElementaryOutput &cur_elementary = cur_output[sample_index][out_index];
+      size_t cur_size = ref_elementary.size() / loco::size(out_type);
+
+      switch (out_type)
+      {
+        case loco::DataType::FLOAT32:
+        {
+          const float *ref_floats = reinterpret_cast<const float *>(ref_elementary.data());
+          const float *cur_floats = reinterpret_cast<const float *>(cur_elementary.data());
+          for (size_t index = 0; index < cur_size; index++)
+          {
+            float ref_value = *(ref_floats + index);
+            float cur_value = *(cur_floats + index);
+            accuracy += std::fabs(ref_value - cur_value);
+          }
+          output_size += cur_size;
+        }
+        break;
+        default:
+          throw std::runtime_error("Unknown out_type");
+      }
+    }
+  }
+  accuracy /= output_size;
+  return accuracy;
+}

--- a/compiler/circle-mpqsolver/src/Evaluator.h
+++ b/compiler/circle-mpqsolver/src/Evaluator.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef __MPQSOLVER_EVALUATOR_H__
+#define __MPQSOLVER_EVALUATOR_H__
+
+#include <luci/IR/Module.h>
+#include <luci/CircleQuantizer.h>
+
+#include <string>
+#include <vector>
+
+namespace mpqsolver
+{
+using ElementaryOutput = std::vector<char>;
+using NNOutput = std::vector<ElementaryOutput>;
+using DatasetOutput = std::vector<NNOutput>;
+using LayerParam = luci::CircleQuantizer::Options::LayerParam;
+using LayerParams = std::vector<std::shared_ptr<LayerParam>>;
+
+class DatasetEvaluator
+{
+public:
+  DatasetEvaluator(const luci::Module *ref_module, const std::string &h5file);
+  ~DatasetEvaluator() = default;
+  float evaluate(const std::string &def_quant, LayerParams &layer_params);
+  std::unique_ptr<luci::Module> quantize(const std::string &def_quant, LayerParams &layer_params);
+
+private:
+  float evaluate(const luci::Module *module);
+
+private:
+  const luci::Module *_ref_module = nullptr;
+  std::string _h5file;
+  DatasetOutput _ref_output;
+};
+
+} // namespace mpqsolver
+
+#endif //__MPQSOLVER_EVALUATOR_H__

--- a/compiler/circle-mpqsolver/src/ModuleCloner.cpp
+++ b/compiler/circle-mpqsolver/src/ModuleCloner.cpp
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "ModuleCloner.h"
+
+#include <luci/ConnectNode.h>
+#include <luci/Service/CircleNodeClone.h>
+
+using namespace mpqsolver;
+
+namespace
+{
+void add_graph_input(loco::Graph *graph, luci::CircleInput *input_node)
+{
+  assert(graph != nullptr);
+  assert(input_node != nullptr);
+
+  auto graph_input = graph->inputs()->create();
+  graph_input->name(input_node->name());
+
+  // Set GraphInputOutputIndex for graph
+  input_node->index(graph_input->index());
+
+  // Data type
+  graph_input->dtype(input_node->dtype());
+
+  // Shape of GraphInput
+  auto input_shape = std::make_unique<loco::TensorShape>();
+  input_shape->rank(input_node->rank());
+  for (uint32_t r = 0; r < input_node->rank(); ++r)
+  {
+    if (input_node->dim(r).known())
+      input_shape->dim(r).set(input_node->dim(r).value());
+  }
+  graph_input->shape(std::move(input_shape));
+}
+
+void add_graph_output(loco::Graph *graph, luci::CircleOutput *output_node)
+{
+  assert(graph != nullptr);
+  assert(output_node != nullptr);
+
+  auto graph_output = graph->outputs()->create();
+  graph_output->name(output_node->name());
+
+  // Set GraphInputOutputIndex for graph
+  output_node->index(graph_output->index());
+
+  // Data type
+  graph_output->dtype(output_node->dtype());
+
+  // Shape of GraphOutput
+  auto output_shape = std::make_unique<loco::TensorShape>();
+  output_shape->rank(output_node->rank());
+  for (uint32_t r = 0; r < output_node->rank(); ++r)
+  {
+    if (output_node->dim(r).known())
+      output_shape->dim(r).set(output_node->dim(r).value());
+  }
+  graph_output->shape(std::move(output_shape));
+}
+
+std::unique_ptr<loco::Graph> clone_graph(loco::Graph *graph_org)
+{
+  if (not graph_org)
+    return nullptr;
+  luci::CloneContext clonectx;
+
+  auto graph = loco::make_graph();
+  auto graph_clone = graph.get();
+  auto &graph_name = graph_org->name();
+
+  graph_clone->name(graph_name);
+
+  // clone inputs
+  auto inputs = graph_org->inputs();
+  assert(inputs);
+  for (const auto &node : loco::input_nodes(graph_org))
+  {
+    auto input_node = loco::must_cast<const luci::CircleNode *>(node);
+
+    auto *input_clone = graph_clone->nodes()->create<luci::CircleInput>();
+    luci::copy_common_attributes(input_node, input_clone);
+
+    add_graph_input(graph_clone, input_clone);
+    clonectx.emplace(input_node, input_clone);
+  }
+
+  // clone nodes
+  auto nodes = loco::all_nodes(graph_org);
+  for (const auto &node : nodes)
+  {
+    auto cnode = loco::must_cast<const luci::CircleNode *>(node);
+
+    // skip for CircleInput, CircleOutput
+    if (dynamic_cast<luci::CircleInput *>(node) != nullptr)
+      continue;
+    if (dynamic_cast<luci::CircleOutput *>(node) != nullptr)
+      continue;
+
+    auto node_org = loco::must_cast<luci::CircleNode *>(node);
+    assert(clonectx.find(node_org) == clonectx.end());
+
+    auto *node_clone = clone_node(node_org, graph_clone);
+    clonectx.emplace(node_org, node_clone);
+  }
+
+  // connect nodes
+  for (auto node : nodes)
+  {
+    // skip for CircleInput, CircleOutput
+    if (dynamic_cast<luci::CircleInput *>(node) != nullptr)
+      continue;
+    if (dynamic_cast<luci::CircleOutput *>(node) != nullptr)
+      continue;
+
+    auto node_org = loco::must_cast<luci::CircleNode *>(node);
+    clone_connect(node_org, clonectx);
+  }
+
+  // clone outputs
+  for (uint32_t n = 0; n < graph_org->outputs()->size(); ++n)
+  {
+    auto output_org = luci::output_node(graph_org, n);
+    assert(output_org != nullptr);
+
+    auto *output_clone = graph_clone->nodes()->create<luci::CircleOutput>();
+    luci::copy_common_attributes(output_org, output_clone);
+    // note: we don't add output_clone to clonectx.
+    // logically, output is not used as an input to any other nodes.
+    auto output_from = loco::must_cast<luci::CircleNode *>(output_org->from());
+    auto it = clonectx.find(output_from);
+    assert(it != clonectx.end());
+    output_clone->from(it->second);
+
+    add_graph_output(graph_clone, output_clone);
+  }
+
+  return graph;
+}
+
+} // namespace
+
+std::unique_ptr<luci::Module> ModuleCloner::clone(const luci::Module *module)
+{
+  std::unique_ptr<luci::Module> new_module = luci::make_module();
+  for (size_t idx = 0; idx < module->size(); ++idx)
+  {
+    auto graph = module->graph(idx);
+    if (!graph)
+    {
+      return nullptr;
+    }
+    auto new_graph = clone_graph(graph);
+    new_module->add(std::move(new_graph));
+  }
+
+  return new_module;
+}

--- a/compiler/circle-mpqsolver/src/ModuleCloner.h
+++ b/compiler/circle-mpqsolver/src/ModuleCloner.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef __MPQSOLVER_MODULE_CLONER_H__
+#define __MPQSOLVER_MODULE_CLONER_H__
+
+#include <luci/IR/Module.h>
+
+namespace mpqsolver
+{
+
+class ModuleCloner final
+{
+public:
+  static std::unique_ptr<luci::Module> clone(const luci::Module *module);
+};
+
+} // namespace mpqsolver
+
+#endif //__MPQSOLVER_MODULE_CLONER_H__


### PR DESCRIPTION
This commit introduces bisection method for the task of automatic mixed precision quantization.
Related to: #10154

The cornerstone of the currently implemented method is:
```
the whole network is assumed to be split into two adjacent parts (Q8 part and Q16 part) 
```
Algorithm proceeds as follows:
1) Determine which part is Q16 and which is Q8 (Q16 at _input_related_nodes_ or Q16 at _output_related_nodes_)
2) Compute 'depth' parameterization for input model (which is supposed to be '_recorded_')
3) Use '_bisectioning_' of 'depth' parameter to find _Accuracy(final_depth) == Target_

'_Mobile_net_v1_' output for 100 images:
```
int16_accuracy 0.000108095
int8_accuracy 0.000296601
target accuracy 0.000202348
290.08 vs 25.9079
16 : 0.000161125
8 : 0.00018704
4 : 0.000204438
6 : 0.000187962
5 : 0.000194962
4.5 : 0.000204438
Found optimal configuration at 5 depth.
Time elapsed is 7.3167 minutes.
```
'_Mobile_net_v2_' output for 100 images:
```
int16_accuracy 0.0161741
int8_accuracy 0.297486
target accuracy 0.128699
491.042 vs 50.6277
35 : 0.0927452
17.5 : 0.114215
8.75 : 0.138438
13.125 : 0.116353
10.9375 : 0.125074
9.84375 : 0.134745
10.3906 : 0.125074
Found optimal configuration at 10.3906 depth.
Time elapsed is 4.7333 minutes.
```
'_cartoon_' output for 100 images:
```
int16_accuracy 0.0072662
int8_accuracy 0.0943325
target accuracy 0.0420927
109.214 vs 178.843
31.5 : 0.0174134
47.25 : 0.0220028
55.125 : 0.0352334
59.0625 : 0.094363
57.0938 : 0.0675179
56.1094 : 0.0675179
55.6172 : 0.0352334
Found optimal configuration at 55.6172 depth.
Time elapsed is 16.583 minutes.
```
Note:
There is a lot of room for improvements, e.g. OpenMP parallelization in inference part.

Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>