### PR TITLE
[npud] Add NpuContext vector in Trix device

### DIFF
--- a/runtime/service/npud/backend/trix/TrixBackend.h
+++ b/runtime/service/npud/backend/trix/TrixBackend.h
@@ -44,6 +44,7 @@ struct TrixDevice
   //    it can recognize that all `NpuContext` has unregistered the model and
   //    delete the model data.
   std::vector<std::weak_ptr<NpuModelInfo>> models;
+  std::vector<std::unique_ptr<NpuContext>> ctxs;
 };
 
 class TrixBackend : public Backend


### PR DESCRIPTION
This commit adds NpuContext vector in Trix device. Trix device manages NpuContext when it is created and destroyed.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>