### PR TITLE
[npud] Change install directory of npud gtest

### DIFF
--- a/packaging/nnfw.spec
+++ b/packaging/nnfw.spec
@@ -262,7 +262,13 @@ install -m 0644 ./tests/scripts/build_path.txt %{buildroot}%{test_install_dir}/t
 
 %if %{npud_build} == 1
 install -m 755 build/out/bin/npud %{buildroot}%{_bindir}
-%endif
+
+%if %{test_build} == 1
+mkdir -p %{test_install_path}/npud-gtest
+install -m 755 build/out/npud-gtest/* %{test_install_path}/npud-gtest
+%endif # test_build
+
+%endif # npud_build
 
 %endif
 

--- a/runtime/service/npud/tests/CMakeLists.txt
+++ b/runtime/service/npud/tests/CMakeLists.txt
@@ -4,14 +4,14 @@ endif(NOT ENABLE_TEST)
 
 file(GLOB_RECURSE TESTS "*.cc")
 
-add_executable(npud_test ${TESTS})
+add_executable(npud_gtest ${TESTS})
 
-set_target_properties(npud_test PROPERTIES LINKER_LANGUAGE CXX)
-target_include_directories(npud_test PUBLIC ${NPUD_INCLUDE_DIRS})
-target_include_directories(npud_test PUBLIC ${GLIB2.0_INCLUDE_DIRS})
-target_link_libraries(npud_test PRIVATE ${GLIB2.0_LIBRARIES})
-target_link_libraries(npud_test PRIVATE ${LIB_PTHREAD})
-target_link_libraries(npud_test PRIVATE npud_core)
-target_link_libraries(npud_test PRIVATE gtest_main dl)
+set_target_properties(npud_gtest PROPERTIES LINKER_LANGUAGE CXX)
+target_include_directories(npud_gtest PUBLIC ${NPUD_INCLUDE_DIRS})
+target_include_directories(npud_gtest PUBLIC ${GLIB2.0_INCLUDE_DIRS})
+target_link_libraries(npud_gtest PRIVATE ${GLIB2.0_LIBRARIES})
+target_link_libraries(npud_gtest PRIVATE ${LIB_PTHREAD})
+target_link_libraries(npud_gtest PRIVATE npud_core)
+target_link_libraries(npud_gtest PRIVATE gtest_main dl)
 
-install(TARGETS npud_test DESTINATION unittest)
+install(TARGETS npud_gtest DESTINATION npud-gtest)


### PR DESCRIPTION
This commit changes the name and install path of npud gtest.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Related comments: https://github.com/Samsung/ONE/pull/10179#discussion_r1044058190