### PR TITLE
[npud] Remove segfault test case

### DIFF
--- a/runtime/service/npud/tests/core/Signal.test.cc
+++ b/runtime/service/npud/tests/core/Signal.test.cc
@@ -69,14 +69,6 @@ TEST_F(SignalTest, raise_SIGTERM)
   ASSERT_EQ(server.isRunning(), false);
 }
 
-TEST_F(SignalTest, raise_SIGSEGV)
-{
-  auto &server = Server::instance();
-  ASSERT_EQ(server.isRunning(), true);
-  std::raise(SIGSEGV);
-  ASSERT_EQ(server.isRunning(), false);
-}
-
 TEST_F(SignalTest, raise_SIGINT)
 {
   auto &server = Server::instance();


### PR DESCRIPTION
This commit removes segfault test case.
Npud removes the segfault signal handler few days ago. Thus, this test case will cause a real segfault error while running unittest.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Related PR: https://github.com/Samsung/ONE/pull/10107