### PR TITLE
[npud] Restart dbus service before running gtest

### DIFF
--- a/infra/scripts/test_ubuntu_npud.sh
+++ b/infra/scripts/test_ubuntu_npud.sh
@@ -13,6 +13,8 @@ DBUS_CONF="${INSTALL_PATH}/share/org.tizen.npud.conf"
 mkdir -p /usr/share/dbus-1/system.d/
 cp ${DBUS_CONF} /usr/share/dbus-1/system.d/
 
+service dbus restart
+
 function NpudTest()
 {
   pushd ${ROOT_PATH} > /dev/null


### PR DESCRIPTION
This commit restarts dbus service to apply npud dbus configuration file before running gtest.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>