### PR TITLE
[luci/pass] Support Abs quantization

### DIFF
--- a/compiler/luci/pass/src/QuantizeActivation.cpp
+++ b/compiler/luci/pass/src/QuantizeActivation.cpp
@@ -212,6 +212,7 @@ void QuantizeConstInputActivation::visit(luci::CircleNode *node)
   }
 
 // Ops that receive a single activation as an input
+QUANTIZE_SINGLE_CONST_INPUT(luci::CircleAbs, x)
 QUANTIZE_SINGLE_CONST_INPUT(luci::CircleArgMax, input)
 QUANTIZE_SINGLE_CONST_INPUT(luci::CircleArgMin, input)
 QUANTIZE_SINGLE_CONST_INPUT(luci::CircleBatchToSpaceND, input)

--- a/compiler/luci/pass/src/QuantizeActivation.h
+++ b/compiler/luci/pass/src/QuantizeActivation.h
@@ -102,6 +102,7 @@ private:
   void visit(luci::CircleNode *node);
 
   // Ops that receive a single activation as an input
+  void visit(luci::CircleAbs *node);
   void visit(luci::CircleArgMax *node);
   void visit(luci::CircleArgMin *node);
   void visit(luci::CircleBatchToSpaceND *node);

--- a/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
+++ b/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
@@ -260,6 +260,7 @@ private:
   void visit(luci::CircleUnpackOut *) {}
 
   // Ops that receive a single activation as an input
+  INSERT_QUANTIZE_TO_UNARY_OP(luci::CircleAbs, x)
   INSERT_QUANTIZE_TO_UNARY_OP(luci::CircleAveragePool2D, value)
   INSERT_QUANTIZE_TO_UNARY_OP(luci::CircleBatchToSpaceND, input)
   INSERT_QUANTIZE_TO_UNARY_OP(luci::CircleConv2D, input)


### PR DESCRIPTION
This pr adds support Abs quantization: add QuantizeConstInputActivation and InsertQuantizeOp(for mpq)

for issue: #10185

ONE-DCO-1.0-Signed-off-by: Artem Balyshev <a.balyshev@samsung.com>