### PR TITLE
[npud] Add dbus test case of npud functions

### DIFF
--- a/infra/scripts/test_ubuntu_npud.sh
+++ b/infra/scripts/test_ubuntu_npud.sh
@@ -54,6 +54,6 @@ function NpudTest()
 
 TestPrepared
 
-DEVICE_MODULE_PATH=${INSTALL_PATH}/lib NpudTest
+DEVICE_MODULE_PATH=${INSTALL_PATH}/lib GTEST_MODEL_PATH=${MODEL_PATH} NpudTest
 
 TestCleanUp

--- a/runtime/service/npud/tests/core/DBus.test.cc
+++ b/runtime/service/npud/tests/core/DBus.test.cc
@@ -69,6 +69,23 @@ protected:
     }
     return proxy;
   }
+
+  const std::string &getModel()
+  {
+    if (model.empty())
+    {
+      auto model_path = std::getenv("GTEST_MODEL_PATH");
+      model = model_path + std::string("/mv1.q8/mv1.q8.tvn");
+    }
+    if (access(model.c_str(), F_OK) != 0)
+    {
+      model.clear();
+    }
+    return model;
+  }
+
+private:
+  std::string model;
 };
 
 //
@@ -93,6 +110,499 @@ TEST_F(DBusTest, device_get_available_list)
     g_error_free(error);
   }
   ASSERT_EQ(out_error, 0);
+}
+
+TEST_F(DBusTest, context_create)
+{
+  NpudCore *proxy = this->getProxy();
+  ASSERT_NE(proxy, nullptr);
+
+  GError *error = NULL;
+  gint out_error = -1;
+  gint arg_device_id = 0;
+  gint arg_priority = 0;
+  guint64 out_ctx;
+  npud_core_call_context_create_sync(proxy, arg_device_id, arg_priority, &out_ctx, &out_error, NULL,
+                                     &error);
+  if (error)
+  {
+    g_error_free(error);
+  }
+  ASSERT_EQ(out_error, 0);
+}
+
+TEST_F(DBusTest, context_destroy)
+{
+  NpudCore *proxy = this->getProxy();
+  ASSERT_NE(proxy, nullptr);
+
+  GError *error = NULL;
+  gint out_error = -1;
+  gint arg_device_id = 0;
+  gint arg_priority = 0;
+  guint64 out_ctx = 0;
+  npud_core_call_context_create_sync(proxy, arg_device_id, arg_priority, &out_ctx, &out_error, NULL,
+                                     &error);
+  if (error)
+  {
+    g_error_free(error);
+  }
+  ASSERT_EQ(out_error, 0);
+
+  npud_core_call_context_destroy_sync(proxy, out_ctx, &out_error, NULL, &error);
+  if (error)
+  {
+    g_error_free(error);
+  }
+  ASSERT_EQ(out_error, 0);
+}
+
+TEST_F(DBusTest, neg_context_destroy_invalid_ctx)
+{
+  NpudCore *proxy = this->getProxy();
+  ASSERT_NE(proxy, nullptr);
+
+  GError *error = NULL;
+  gint out_error = -1;
+  guint64 out_ctx = 0;
+  npud_core_call_context_destroy_sync(proxy, out_ctx, &out_error, NULL, &error);
+  if (error)
+  {
+    g_error_free(error);
+  }
+  ASSERT_NE(out_error, 0);
+}
+
+TEST_F(DBusTest, network_create)
+{
+  NpudCore *proxy = this->getProxy();
+  ASSERT_NE(proxy, nullptr);
+
+  GError *error = NULL;
+  gint out_error = -1;
+  gint arg_device_id = 0;
+  gint arg_priority = 0;
+  guint64 out_ctx = 0;
+  npud_core_call_context_create_sync(proxy, arg_device_id, arg_priority, &out_ctx, &out_error, NULL,
+                                     &error);
+  if (error)
+  {
+    g_error_free(error);
+    error = NULL;
+  }
+  ASSERT_EQ(out_error, 0);
+
+  out_error = -1;
+  const gchar *model_path = this->getModel().c_str();
+  guint out_nw_handle = 0;
+  npud_core_call_network_create_sync(proxy, out_ctx, model_path, &out_nw_handle, &out_error, NULL,
+                                     &error);
+  if (error)
+  {
+    g_error_free(error);
+  }
+  ASSERT_EQ(out_error, 0);
+}
+
+TEST_F(DBusTest, neg_network_create_invalid_ctx)
+{
+  NpudCore *proxy = this->getProxy();
+  ASSERT_NE(proxy, nullptr);
+
+  GError *error = NULL;
+  gint out_error = -1;
+  guint64 out_ctx = -1;
+  const gchar *model_path = this->getModel().c_str();
+  guint out_nw_handle = 0;
+  npud_core_call_network_create_sync(proxy, out_ctx, model_path, &out_nw_handle, &out_error, NULL,
+                                     &error);
+  if (error)
+  {
+    g_error_free(error);
+  }
+  ASSERT_NE(out_error, 0);
+}
+
+TEST_F(DBusTest, neg_network_create_invalid_model)
+{
+  NpudCore *proxy = this->getProxy();
+  ASSERT_NE(proxy, nullptr);
+
+  GError *error = NULL;
+  gint out_error = -1;
+  gint arg_device_id = 0;
+  gint arg_priority = 0;
+  guint64 out_ctx = 0;
+  npud_core_call_context_create_sync(proxy, arg_device_id, arg_priority, &out_ctx, &out_error, NULL,
+                                     &error);
+  if (error)
+  {
+    g_error_free(error);
+    error = NULL;
+  }
+  ASSERT_EQ(out_error, 0);
+
+  out_error = -1;
+  // Invalid model
+  const gchar *model_path = "invalid.tvn";
+  guint out_nw_handle = 0;
+  npud_core_call_network_create_sync(proxy, out_ctx, model_path, &out_nw_handle, &out_error, NULL,
+                                     &error);
+  if (error)
+  {
+    g_error_free(error);
+  }
+  ASSERT_NE(out_error, 0);
+}
+
+TEST_F(DBusTest, network_destroy)
+{
+  NpudCore *proxy = this->getProxy();
+  ASSERT_NE(proxy, nullptr);
+
+  GError *error = NULL;
+  gint out_error = -1;
+  gint arg_device_id = 0;
+  gint arg_priority = 0;
+  guint64 out_ctx = 0;
+  npud_core_call_context_create_sync(proxy, arg_device_id, arg_priority, &out_ctx, &out_error, NULL,
+                                     &error);
+  if (error)
+  {
+    g_error_free(error);
+    error = NULL;
+  }
+  ASSERT_EQ(out_error, 0);
+
+  out_error = -1;
+  const gchar *model_path = this->getModel().c_str();
+  guint out_nw_handle = 0;
+  npud_core_call_network_create_sync(proxy, out_ctx, model_path, &out_nw_handle, &out_error, NULL,
+                                     &error);
+  if (error)
+  {
+    g_error_free(error);
+  }
+  ASSERT_EQ(out_error, 0);
+
+  out_error = -1;
+  npud_core_call_network_destroy_sync(proxy, out_ctx, out_nw_handle, &out_error, NULL, &error);
+  if (error)
+  {
+    g_error_free(error);
+  }
+  ASSERT_EQ(out_error, 0);
+}
+
+TEST_F(DBusTest, neg_network_destroy_invalid_ctx)
+{
+  NpudCore *proxy = this->getProxy();
+  ASSERT_NE(proxy, nullptr);
+
+  GError *error = NULL;
+  gint out_error = -1;
+  gint arg_device_id = 0;
+  gint arg_priority = 0;
+  guint64 out_ctx = 0;
+  npud_core_call_context_create_sync(proxy, arg_device_id, arg_priority, &out_ctx, &out_error, NULL,
+                                     &error);
+  if (error)
+  {
+    g_error_free(error);
+    error = NULL;
+  }
+  ASSERT_EQ(out_error, 0);
+
+  out_error = -1;
+  const gchar *model_path = this->getModel().c_str();
+  guint out_nw_handle = 0;
+  npud_core_call_network_create_sync(proxy, out_ctx, model_path, &out_nw_handle, &out_error, NULL,
+                                     &error);
+  if (error)
+  {
+    g_error_free(error);
+  }
+  ASSERT_EQ(out_error, 0);
+
+  out_error = -1;
+  // Invalid ctx
+  out_ctx = -1;
+  npud_core_call_network_destroy_sync(proxy, out_ctx, out_nw_handle, &out_error, NULL, &error);
+  if (error)
+  {
+    g_error_free(error);
+  }
+  ASSERT_NE(out_error, 0);
+}
+
+TEST_F(DBusTest, neg_network_destroy_invalid_nw_handle)
+{
+  NpudCore *proxy = this->getProxy();
+  ASSERT_NE(proxy, nullptr);
+
+  GError *error = NULL;
+  gint out_error = -1;
+  gint arg_device_id = 0;
+  gint arg_priority = 0;
+  guint64 out_ctx = 0;
+  npud_core_call_context_create_sync(proxy, arg_device_id, arg_priority, &out_ctx, &out_error, NULL,
+                                     &error);
+  if (error)
+  {
+    g_error_free(error);
+    error = NULL;
+  }
+  ASSERT_EQ(out_error, 0);
+
+  out_error = -1;
+  guint out_nw_handle = -1;
+  npud_core_call_network_destroy_sync(proxy, out_ctx, out_nw_handle, &out_error, NULL, &error);
+  if (error)
+  {
+    g_error_free(error);
+  }
+  ASSERT_NE(out_error, 0);
+}
+
+TEST_F(DBusTest, request_create)
+{
+  NpudCore *proxy = this->getProxy();
+  ASSERT_NE(proxy, nullptr);
+
+  GError *error = NULL;
+  gint out_error = -1;
+  gint arg_device_id = 0;
+  gint arg_priority = 0;
+  guint64 out_ctx = 0;
+  npud_core_call_context_create_sync(proxy, arg_device_id, arg_priority, &out_ctx, &out_error, NULL,
+                                     &error);
+  if (error)
+  {
+    g_error_free(error);
+    error = NULL;
+  }
+  ASSERT_EQ(out_error, 0);
+
+  out_error = -1;
+  const gchar *model_path = this->getModel().c_str();
+  guint out_nw_handle = 0;
+  npud_core_call_network_create_sync(proxy, out_ctx, model_path, &out_nw_handle, &out_error, NULL,
+                                     &error);
+  if (error)
+  {
+    g_error_free(error);
+    error = NULL;
+  }
+  ASSERT_EQ(out_error, 0);
+
+  out_error = -1;
+  guint out_rq_handle = 0;
+  npud_core_call_request_create_sync(proxy, out_ctx, out_nw_handle, &out_rq_handle, &out_error,
+                                     NULL, &error);
+  if (error)
+  {
+    g_error_free(error);
+  }
+  ASSERT_EQ(out_error, 0);
+}
+
+TEST_F(DBusTest, neg_request_create_invalid_ctx)
+{
+  NpudCore *proxy = this->getProxy();
+  ASSERT_NE(proxy, nullptr);
+
+  GError *error = NULL;
+  gint out_error = -1;
+  gint arg_device_id = 0;
+  gint arg_priority = 0;
+  guint64 out_ctx = 0;
+  npud_core_call_context_create_sync(proxy, arg_device_id, arg_priority, &out_ctx, &out_error, NULL,
+                                     &error);
+  if (error)
+  {
+    g_error_free(error);
+    error = NULL;
+  }
+  ASSERT_EQ(out_error, 0);
+
+  out_error = -1;
+  const gchar *model_path = this->getModel().c_str();
+  guint out_nw_handle = 0;
+  npud_core_call_network_create_sync(proxy, out_ctx, model_path, &out_nw_handle, &out_error, NULL,
+                                     &error);
+  if (error)
+  {
+    g_error_free(error);
+    error = NULL;
+  }
+  ASSERT_EQ(out_error, 0);
+
+  out_error = -1;
+  guint out_rq_handle = 0;
+  npud_core_call_request_create_sync(proxy, 0, out_nw_handle, &out_rq_handle, &out_error, NULL,
+                                     &error);
+  if (error)
+  {
+    g_error_free(error);
+  }
+  ASSERT_NE(out_error, 0);
+}
+
+TEST_F(DBusTest, neg_request_create_invalid_nw)
+{
+  NpudCore *proxy = this->getProxy();
+  ASSERT_NE(proxy, nullptr);
+
+  GError *error = NULL;
+  gint out_error = -1;
+  gint arg_device_id = 0;
+  gint arg_priority = 0;
+  guint64 out_ctx = 0;
+  npud_core_call_context_create_sync(proxy, arg_device_id, arg_priority, &out_ctx, &out_error, NULL,
+                                     &error);
+  if (error)
+  {
+    g_error_free(error);
+    error = NULL;
+  }
+  ASSERT_EQ(out_error, 0);
+
+  out_error = -1;
+  guint out_rq_handle = 0;
+  npud_core_call_request_create_sync(proxy, out_ctx, 0, &out_rq_handle, &out_error, NULL, &error);
+  if (error)
+  {
+    g_error_free(error);
+  }
+  ASSERT_NE(out_error, 0);
+}
+
+TEST_F(DBusTest, request_destroy)
+{
+  NpudCore *proxy = this->getProxy();
+  ASSERT_NE(proxy, nullptr);
+
+  GError *error = NULL;
+  gint out_error = -1;
+  gint arg_device_id = 0;
+  gint arg_priority = 0;
+  guint64 out_ctx = 0;
+  npud_core_call_context_create_sync(proxy, arg_device_id, arg_priority, &out_ctx, &out_error, NULL,
+                                     &error);
+  if (error)
+  {
+    g_error_free(error);
+    error = NULL;
+  }
+  ASSERT_EQ(out_error, 0);
+
+  out_error = -1;
+  const gchar *model_path = this->getModel().c_str();
+  guint out_nw_handle = 0;
+  npud_core_call_network_create_sync(proxy, out_ctx, model_path, &out_nw_handle, &out_error, NULL,
+                                     &error);
+  if (error)
+  {
+    g_error_free(error);
+    error = NULL;
+  }
+  ASSERT_EQ(out_error, 0);
+
+  out_error = -1;
+  guint out_rq_handle = 0;
+  npud_core_call_request_create_sync(proxy, out_ctx, out_nw_handle, &out_rq_handle, &out_error,
+                                     NULL, &error);
+  if (error)
+  {
+    g_error_free(error);
+  }
+  ASSERT_EQ(out_error, 0);
+
+  out_error = -1;
+  npud_core_call_request_destroy_sync(proxy, out_ctx, out_rq_handle, &out_error, NULL, &error);
+  if (error)
+  {
+    g_error_free(error);
+  }
+  ASSERT_EQ(out_error, 0);
+}
+
+TEST_F(DBusTest, neg_request_destroy_invalid_ctx)
+{
+  NpudCore *proxy = this->getProxy();
+  ASSERT_NE(proxy, nullptr);
+
+  GError *error = NULL;
+  gint out_error = -1;
+  gint arg_device_id = 0;
+  gint arg_priority = 0;
+  guint64 out_ctx = 0;
+  npud_core_call_context_create_sync(proxy, arg_device_id, arg_priority, &out_ctx, &out_error, NULL,
+                                     &error);
+  if (error)
+  {
+    g_error_free(error);
+    error = NULL;
+  }
+  ASSERT_EQ(out_error, 0);
+
+  out_error = -1;
+  const gchar *model_path = this->getModel().c_str();
+  guint out_nw_handle = 0;
+  npud_core_call_network_create_sync(proxy, out_ctx, model_path, &out_nw_handle, &out_error, NULL,
+                                     &error);
+  if (error)
+  {
+    g_error_free(error);
+    error = NULL;
+  }
+  ASSERT_EQ(out_error, 0);
+
+  out_error = -1;
+  guint out_rq_handle = 0;
+  npud_core_call_request_create_sync(proxy, out_ctx, out_nw_handle, &out_rq_handle, &out_error,
+                                     NULL, &error);
+  if (error)
+  {
+    g_error_free(error);
+  }
+  ASSERT_EQ(out_error, 0);
+
+  out_error = -1;
+  npud_core_call_request_destroy_sync(proxy, 0, out_rq_handle, &out_error, NULL, &error);
+  if (error)
+  {
+    g_error_free(error);
+  }
+  ASSERT_NE(out_error, 0);
+}
+
+TEST_F(DBusTest, neg_request_destroy_invalid_rq)
+{
+  NpudCore *proxy = this->getProxy();
+  ASSERT_NE(proxy, nullptr);
+
+  GError *error = NULL;
+  gint out_error = -1;
+  gint arg_device_id = 0;
+  gint arg_priority = 0;
+  guint64 out_ctx = 0;
+  npud_core_call_context_create_sync(proxy, arg_device_id, arg_priority, &out_ctx, &out_error, NULL,
+                                     &error);
+  if (error)
+  {
+    g_error_free(error);
+    error = NULL;
+  }
+  ASSERT_EQ(out_error, 0);
+
+  out_error = -1;
+  npud_core_call_request_destroy_sync(proxy, out_ctx, 0, &out_error, NULL, &error);
+  if (error)
+  {
+    g_error_free(error);
+  }
+  ASSERT_NE(out_error, 0);
 }
 
 } // unnamed namespace


### PR DESCRIPTION
This commit adds the test cases below.
- add dbus test case of `context_create` and `context_destroy`.
- add dbus test case of `network_create` and `network_destroy`.
- add dbus test case of `request_create` and `request_destroy`.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

This PR requires #10199 PR.
Trix engine does not release the request id. So the user must request to remove the request before terminating. Otherwise, the program will be stuck.
The #10199 PR resolved this issue.