### PR TITLE
[mpqsolver] Introduce ModuleCloner

### DIFF
--- a/compiler/circle-mpqsolver/CMakeLists.txt
+++ b/compiler/circle-mpqsolver/CMakeLists.txt
@@ -1,8 +1,26 @@
 file(GLOB_RECURSE SOURCES "src/*.cpp")
+file(GLOB_RECURSE TESTS "src/*.test.cpp")
+list(REMOVE_ITEM SOURCES ${TESTS})
 
 add_executable(circle-mpqsolver "${SOURCES}")
+target_link_libraries(circle-mpqsolver luci_service)
+target_link_libraries(circle-mpqsolver luci_partition)
 target_link_libraries(circle-mpqsolver arser)
 target_link_libraries(circle-mpqsolver vconone)
 target_link_libraries(circle-mpqsolver safemain)
 
 install(TARGETS circle-mpqsolver DESTINATION bin)
+
+if(NOT ENABLE_TEST)
+  return()
+endif(NOT ENABLE_TEST)
+
+# circle-mpqsolver is executable, so we do not link it to the test.
+# Instead, we use TEST_SOURCES to specify sources uesd for tests.
+set(TEST_SOURCES
+    "src/ModuleCloner.cpp")
+
+nnas_find_package(GTest REQUIRED)
+GTest_AddTest(circle_mpqsolver_test ${TESTS} ${TEST_SOURCES})
+target_link_libraries(circle_mpqsolver_test luci_service)
+target_link_libraries(circle_mpqsolver_test luci_partition)

--- a/compiler/circle-mpqsolver/requires.cmake
+++ b/compiler/circle-mpqsolver/requires.cmake
@@ -1,3 +1,4 @@
 require("safemain")
 require("arser")
 require("vconone")
+require("luci")

--- a/compiler/circle-mpqsolver/src/ModuleCloner.cpp
+++ b/compiler/circle-mpqsolver/src/ModuleCloner.cpp
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "ModuleCloner.h"
+
+#include <luci/ConnectNode.h>
+#include <luci/Service/CircleNodeClone.h>
+
+namespace
+{
+
+void add_graph_input(loco::Graph *graph, luci::CircleInput *input_node)
+{
+  assert(graph != nullptr);
+  assert(input_node != nullptr);
+
+  auto graph_input = graph->inputs()->create();
+  graph_input->name(input_node->name());
+
+  // Set GraphInputOutputIndex for graph
+  input_node->index(graph_input->index());
+
+  // Data type
+  graph_input->dtype(input_node->dtype());
+
+  // Shape of GraphInput
+  auto input_shape = std::make_unique<loco::TensorShape>();
+  input_shape->rank(input_node->rank());
+  for (uint32_t r = 0; r < input_node->rank(); ++r)
+  {
+    if (input_node->dim(r).known())
+      input_shape->dim(r).set(input_node->dim(r).value());
+  }
+  graph_input->shape(std::move(input_shape));
+}
+
+void add_graph_output(loco::Graph *graph, luci::CircleOutput *output_node)
+{
+  assert(graph != nullptr);
+  assert(output_node != nullptr);
+
+  auto graph_output = graph->outputs()->create();
+  graph_output->name(output_node->name());
+
+  // Set GraphInputOutputIndex for graph
+  output_node->index(graph_output->index());
+
+  // Data type
+  graph_output->dtype(output_node->dtype());
+
+  // Shape of GraphOutput
+  auto output_shape = std::make_unique<loco::TensorShape>();
+  output_shape->rank(output_node->rank());
+  for (uint32_t r = 0; r < output_node->rank(); ++r)
+  {
+    if (output_node->dim(r).known())
+      output_shape->dim(r).set(output_node->dim(r).value());
+  }
+  graph_output->shape(std::move(output_shape));
+}
+
+std::unique_ptr<loco::Graph> clone_graph(loco::Graph *graph_org)
+{
+  if (not graph_org)
+    return nullptr;
+  luci::CloneContext clonectx;
+
+  auto graph = loco::make_graph();
+  auto graph_clone = graph.get();
+  auto &graph_name = graph_org->name();
+
+  graph_clone->name(graph_name);
+
+  // clone inputs
+  auto inputs = graph_org->inputs();
+  assert(inputs);
+  for (const auto &node : loco::input_nodes(graph_org))
+  {
+    auto input_node = loco::must_cast<const luci::CircleNode *>(node);
+
+    auto *input_clone = graph_clone->nodes()->create<luci::CircleInput>();
+    luci::copy_common_attributes(input_node, input_clone);
+
+    add_graph_input(graph_clone, input_clone);
+    clonectx.emplace(input_node, input_clone);
+  }
+
+  // clone nodes
+  auto nodes = loco::all_nodes(graph_org);
+  for (const auto &node : nodes)
+  {
+    auto cnode = loco::must_cast<const luci::CircleNode *>(node);
+
+    // skip for CircleInput, CircleOutput
+    if (dynamic_cast<luci::CircleInput *>(node) != nullptr)
+      continue;
+    if (dynamic_cast<luci::CircleOutput *>(node) != nullptr)
+      continue;
+
+    auto node_org = loco::must_cast<luci::CircleNode *>(node);
+    assert(clonectx.find(node_org) == clonectx.end());
+
+    auto *node_clone = clone_node(node_org, graph_clone);
+    clonectx.emplace(node_org, node_clone);
+  }
+
+  // connect nodes
+  for (auto node : nodes)
+  {
+    // skip for CircleInput, CircleOutput
+    if (dynamic_cast<luci::CircleInput *>(node) != nullptr)
+      continue;
+    if (dynamic_cast<luci::CircleOutput *>(node) != nullptr)
+      continue;
+
+    auto node_org = loco::must_cast<luci::CircleNode *>(node);
+    clone_connect(node_org, clonectx);
+  }
+
+  // clone outputs
+  for (uint32_t n = 0; n < graph_org->outputs()->size(); ++n)
+  {
+    auto output_org = luci::output_node(graph_org, n);
+    assert(output_org != nullptr);
+
+    auto *output_clone = graph_clone->nodes()->create<luci::CircleOutput>();
+    luci::copy_common_attributes(output_org, output_clone);
+    // note: we don't add output_clone to clonectx.
+    // logically, output is not used as an input to any other nodes.
+    auto output_from = loco::must_cast<luci::CircleNode *>(output_org->from());
+    auto it = clonectx.find(output_from);
+    assert(it != clonectx.end());
+    output_clone->from(it->second);
+
+    add_graph_output(graph_clone, output_clone);
+  }
+
+  return graph;
+}
+
+} // namespace
+
+namespace mpqsolver
+{
+
+std::unique_ptr<luci::Module> clone(const luci::Module *module)
+{
+  std::unique_ptr<luci::Module> new_module = luci::make_module();
+  for (size_t idx = 0; idx < module->size(); ++idx)
+  {
+    auto graph = module->graph(idx);
+    if (!graph)
+    {
+      return nullptr;
+    }
+    auto new_graph = clone_graph(graph);
+    new_module->add(std::move(new_graph));
+  }
+
+  return new_module;
+}
+
+} // namespace mpqsolver

--- a/compiler/circle-mpqsolver/src/ModuleCloner.h
+++ b/compiler/circle-mpqsolver/src/ModuleCloner.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef __MPQSOLVER_MODULE_CLONER_H__
+#define __MPQSOLVER_MODULE_CLONER_H__
+
+#include <luci/IR/Module.h>
+
+namespace mpqsolver
+{
+
+std::unique_ptr<luci::Module> clone(const luci::Module *module);
+
+} // namespace mpqsolver
+
+#endif //__MPQSOLVER_MODULE_CLONER_H__

--- a/compiler/circle-mpqsolver/src/ModuleCloner.test.cpp
+++ b/compiler/circle-mpqsolver/src/ModuleCloner.test.cpp
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "TestHelper.h"
+#include "ModuleCloner.h"
+
+#include <luci/IR/CircleNodeDecl.h>
+
+namespace
+{
+
+class AddGraph final : public SimpleGraph
+{
+protected:
+  loco::Node *insertGraphBody(loco::Node *input) override
+  {
+    _add = _g->nodes()->create<luci::CircleAdd>();
+    auto beta = _g->nodes()->create<luci::CircleConst>();
+
+    _add->dtype(loco::DataType::FLOAT32);
+    beta->dtype(loco::DataType::FLOAT32);
+
+    _add->shape({1, _channel_size, _width, _height});
+    beta->shape({1, _channel_size, _width, _height});
+
+    _add->fusedActivationFunction(luci::FusedActFunc::NONE);
+
+    _add->x(input);
+    _add->y(beta);
+
+    _add->name("add");
+    beta->name("beta");
+
+    return _add;
+  }
+
+public:
+  luci::CircleAdd *_add = nullptr;
+};
+
+} // namespace
+
+TEST(CircleMPQSolverModuleClonerTest, verifyResultsTest)
+{
+  auto m = luci::make_module();
+  AddGraph g;
+  g.init();
+  auto all_nodes = loco::all_nodes(g._g.get());
+  auto add = g._add;
+  g.transfer_to(m.get());
+
+  auto cloned = mpqsolver::clone(m.get());
+  EXPECT_TRUE(cloned->size() == 1);
+  auto cloned_graph = cloned->graph(0);
+  auto all_cloned_nodes = loco::all_nodes(cloned_graph);
+  EXPECT_TRUE(all_nodes.size() == all_cloned_nodes.size());
+  bool found = false;
+  for (auto node : all_cloned_nodes)
+  {
+    auto ci_node = dynamic_cast<luci::CircleNode *>(node);
+    EXPECT_TRUE(ci_node != nullptr);
+    if (ci_node->name() == add->name())
+    {
+      auto cloned_add = dynamic_cast<luci::CircleAdd *>(ci_node);
+      EXPECT_TRUE(cloned_add != nullptr);
+      EXPECT_TRUE(add->fusedActivationFunction() == cloned_add->fusedActivationFunction());
+      EXPECT_TRUE(cloned_add->rank() == add->rank());
+      for (uint32_t dim = 0; dim < add->rank(); ++dim)
+      {
+        auto cloned_dimension = cloned_add->dim(dim);
+        auto dimension = add->dim(dim);
+        EXPECT_TRUE(cloned_dimension.known() == dimension.known());
+        EXPECT_TRUE(cloned_dimension.value() == dimension.value());
+      }
+      found = true;
+      break;
+    }
+  }
+  EXPECT_TRUE(found);
+}
+
+TEST(CircleMPQSolverModuleClonerTest, verifyResultsTest_NEG)
+{
+  auto m = luci::make_module();
+  auto cloned = mpqsolver::clone(m.get());
+  EXPECT_TRUE(cloned->size() == 0);
+}

--- a/compiler/circle-mpqsolver/src/TestHelper.h
+++ b/compiler/circle-mpqsolver/src/TestHelper.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef __CIRCLE_MPQSEOLVER_TEST_HELPER_H__
+#define __CIRCLE_MPQSEOLVER_TEST_HELPER_H__
+
+#include <luci/IR/CircleNodes.h>
+#include <luci/IR/Module.h>
+
+class SimpleGraph
+{
+public:
+  SimpleGraph() : _g(loco::make_graph()) {}
+
+public:
+  void init()
+  {
+    _input = _g->nodes()->create<luci::CircleInput>();
+    _output = _g->nodes()->create<luci::CircleOutput>();
+    _input->name("input");
+    _output->name("output");
+
+    auto graph_input = _g->inputs()->create();
+    _input->index(graph_input->index());
+    auto graph_output = _g->outputs()->create();
+    _output->index(graph_output->index());
+
+    graph_input->dtype(loco::DataType::FLOAT32);
+    _input->dtype(loco::DataType::FLOAT32);
+    _output->dtype(loco::DataType::FLOAT32);
+    graph_output->dtype(loco::DataType::FLOAT32);
+
+    graph_input->shape({1, _channel_size, _width, _height});
+    _input->shape({1, _channel_size, _width, _height});
+    _output->shape({1, _channel_size, _width, _height});
+    graph_output->shape({1, _channel_size, _width, _height});
+
+    auto graph_body = insertGraphBody(_input);
+    _output->from(graph_body);
+
+    initInput(_input);
+  }
+
+  virtual ~SimpleGraph() = default;
+  void transfer_to(luci::Module *module)
+  {
+    // WARNING: after g is transfered, _graph_inputs, _inputs
+    //          and _graph_outputs, _outputs in TestOsGraphlet will be invalid.
+    //          arrays are not cleared as this is just helpers to unit tests
+    module->add(std::move(_g));
+  }
+
+protected:
+  virtual loco::Node *insertGraphBody(loco::Node *input) = 0;
+  virtual void initInput(loco::Node *input){};
+
+public:
+  std::unique_ptr<loco::Graph> _g;
+  luci::CircleInput *_input = nullptr;
+  luci::CircleOutput *_output = nullptr;
+  uint32_t _channel_size = 16;
+  uint32_t _width = 4;
+  uint32_t _height = 4;
+};
+
+#endif //__CIRCLE_MPQSEOLVER_TEST_HELPER_H__


### PR DESCRIPTION
This commit introduces ModuleCloner for the task of automatic mixed precision quantization.

Draft: https://github.com/Samsung/ONE/pull/10191
Related to: https://github.com/Samsung/ONE/issues/10154

Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>