### PR TITLE
[luci] Assert check for Activation None

### DIFF
--- a/compiler/luci/pass/src/FuseBatchNormWithTConvPass.cpp
+++ b/compiler/luci/pass/src/FuseBatchNormWithTConvPass.cpp
@@ -225,6 +225,7 @@ bool fused_batch_norm_with_tconv(luci::CircleAdd *add)
   }
   else
   {
+    assert(add->fusedActivationFunction() == luci::FusedActFunc::NONE);
     replace(add).with(fused_tconv);
   }
 


### PR DESCRIPTION
This will add assert check in FuseBatchNormWithTConvPass for Activation is None.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>