### PR TITLE
[luci] Tidy OutputExclude dtype settings

### DIFF
--- a/compiler/luci/import/src/GraphBuilder.cpp
+++ b/compiler/luci/import/src/GraphBuilder.cpp
@@ -47,9 +47,6 @@ CircleNode *GraphBuilder::build(const circle::OperatorT &op, GraphBuilderContext
     {
       // If there is no tensor, insert CircleOutputExclude.
       auto *node = context->graph()->nodes()->create<luci::CircleOutputExclude>();
-      // CircleOutputExclude doesn't need a type, but since all nodes must have a type,
-      // a dummy type is inserted.
-      node->dtype(loco::DataType::FLOAT32);
       input_nodes.push_back(node);
     }
   }

--- a/compiler/luci/import/src/GraphBuilderMultiOutput.cpp
+++ b/compiler/luci/import/src/GraphBuilderMultiOutput.cpp
@@ -48,9 +48,6 @@ CircleNode *GraphBuilderMultiOutput::build(const circle::OperatorT &op,
     {
       // If there is no tensor, insert CircleOutputExclude.
       auto *node = context->graph()->nodes()->create<luci::CircleOutputExclude>();
-      // CircleOutputExclude doesn't need a type, but since all nodes must have a type,
-      // a dummy type is inserted.
-      node->dtype(loco::DataType::FLOAT32);
       input_nodes.push_back(node);
     }
   }

--- a/compiler/luci/import/src/Nodes/CircleSVDF.cpp
+++ b/compiler/luci/import/src/Nodes/CircleSVDF.cpp
@@ -43,9 +43,6 @@ CircleNode *CircleSVDFBuilder::build_node(const circle::OperatorT &op,
   if (inputs.size() == 4)
   {
     auto *bias = graph->nodes()->create<CircleOutputExclude>();
-    // CircleOutputExclude doesn't need a type, but since all nodes must have a type,
-    // a dummy type is inserted.
-    bias->dtype(inputs.at(0)->dtype());
     node->bias(bias);
 
     node->input_activation_state(inputs.at(3));

--- a/compiler/luci/import/src/Nodes/CircleTransposeConv.cpp
+++ b/compiler/luci/import/src/Nodes/CircleTransposeConv.cpp
@@ -65,9 +65,6 @@ CircleNode *CircleTransposeConvGraphBuilder::build_node(const circle::OperatorT 
   if (inputs.size() == 3)
   {
     auto *bias = graph->nodes()->create<CircleOutputExclude>();
-    // CircleOutputExclude doesn't need a type, but since all nodes must have a type,
-    // a dummy type is inserted.
-    bias->dtype(loco::DataType::FLOAT32);
     node->bias(bias);
   }
   else

--- a/compiler/luci/pass/src/FuseBCQPass.cpp
+++ b/compiler/luci/pass/src/FuseBCQPass.cpp
@@ -679,7 +679,6 @@ bool FuseBCQPass::run(luci::Module *m)
         if (output_node->index() == 0 || (int)output_node->index() > original_output_cnt)
         {
           auto noOp = main_graph->nodes()->create<luci::CircleOutputExclude>();
-          noOp->dtype(loco::DataType::FLOAT32); // TODO Remove this setting
           output_node->from(noOp);
           changed = true;
         }

--- a/compiler/luci/pass/src/ResolveCustomOpMatMulPass.cpp
+++ b/compiler/luci/pass/src/ResolveCustomOpMatMulPass.cpp
@@ -153,7 +153,6 @@ bool resolve_matmul(luci::CircleCustom *cop)
   }
 
   auto empty_bias = graph->nodes()->create<luci::CircleOutputExclude>();
-  empty_bias->dtype(loco::DataType::FLOAT32); // Needed for type inference
 
   auto fc_node = graph->nodes()->create<luci::CircleFullyConnected>();
   fc_node->input(lhs);

--- a/compiler/luci/pass/src/UnrollUnidirectionalSequenceLSTMPass.cpp
+++ b/compiler/luci/pass/src/UnrollUnidirectionalSequenceLSTMPass.cpp
@@ -299,7 +299,6 @@ luci::CircleAdd *UnrollLSTM::create_input_matmul(luci::CircleNode *input, luci::
   luci::add_origin(fcw, luci::get_origin(_lstm));
 
   auto fcb = _nctx->create<luci::CircleOutputExclude>();
-  fcb->dtype(loco::DataType::FLOAT32); // Needed for type inference
 
   auto fc = _nctx->create<luci::CircleFullyConnected>();
   fc->input(input);
@@ -320,7 +319,6 @@ luci::CircleAdd *UnrollLSTM::create_input_matmul(luci::CircleNode *input, luci::
   luci::add_origin(fcrw, luci::get_origin(_lstm));
 
   auto fcrb = _nctx->create<luci::CircleOutputExclude>();
-  fcrb->dtype(loco::DataType::FLOAT32); // Needed for type inference
 
   auto fcr = _nctx->create<luci::CircleFullyConnected>();
   fcr->input(mul);

--- a/compiler/luci/pass/src/UnrollUnidirectionalSequenceLSTMPass.test.cpp
+++ b/compiler/luci/pass/src/UnrollUnidirectionalSequenceLSTMPass.test.cpp
@@ -49,7 +49,6 @@ public:
     _rw = weight_1x1(g);
     _gb = weight_1(g);
     _ex = g->nodes()->create<luci::CircleOutputExclude>();
-    _ex->dtype(loco::DataType::FLOAT32);
   }
 
 protected:


### PR DESCRIPTION
This will tidy dummy dtype settings for OutputExclude nodes.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>