### PR TITLE
[onert] Revisit CompilerOptions

### DIFF
--- a/runtime/onert/core/include/compiler/Compiler.h
+++ b/runtime/onert/core/include/compiler/Compiler.h
@@ -22,6 +22,7 @@
 #ifndef __ONERT_COMPILER_COMPILE_H_
 #define __ONERT_COMPILER_COMPILE_H_
 
+#include "CompilerOptions.h"
 #include "ir/NNPkg.h"
 #include "exec/Executors.h"
 #include "util/TracingCtx.h"
@@ -31,39 +32,6 @@ namespace onert
 
 namespace compiler
 {
-
-struct ManualSchedulerOptions
-{
-public:
-  void setBackendMap(const std::string &str);
-
-public:
-  std::string backend_for_all;
-  std::unordered_map<ir::OpCode, std::string> opcode_to_backend;
-  std::unordered_map<ir::OperationIndex, std::string> index_to_backend;
-};
-
-class CompilerOptions
-{
-public:
-  // Set default values for CompilerOptions
-  // All these default values should not be fetched from Env, when we stop supporting Android NNAPI.
-  static std::unique_ptr<CompilerOptions> fromGlobalConfig();
-
-public:
-  // GENERAL OPTIONS
-  std::vector<std::string> backend_list;
-
-  // OPTIONS ONLY FOR DEBUGGING/PROFILING
-  std::string trace_filepath; //< File path to save trace records
-  int graph_dump_level;       //< Graph dump level, values between 0 and 2 are valid
-  std::string executor;       //< Executor name to use
-  ManualSchedulerOptions manual_scheduler_options; //< Options for ManualScheduler
-  bool he_scheduler;      //< HEScheduler if true, ManualScheduler otherwise
-  bool he_profiling_mode; //< Whether HEScheduler profiling mode ON/OFF
-  bool disable_compile;   //< Run with Interpreter if true, try compilation otherwise
-  bool fp16_enable;       //< Whether fp16 mode ON/OFF
-};
 
 struct CompilerArtifact
 {
@@ -104,11 +72,6 @@ public:
    * @return std::shared_ptr<CompilerArtifact> Executors as a result of compilation
    */
   std::shared_ptr<CompilerArtifact> compile(void);
-
-  /**
-   * @brief   Allow to compute float32 using float16 data type
-   */
-  void enableToFp16();
 
 private:
   void checkProfilerConditions();

--- a/runtime/onert/core/include/compiler/CompilerOptions.h
+++ b/runtime/onert/core/include/compiler/CompilerOptions.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_COMPILER_COMPILER_OPTIONS_H_
+#define __ONERT_COMPILER_COMPILER_OPTIONS_H_
+
+#include "ir/OpCode.h"
+#include "ir/Index.h"
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace onert
+{
+namespace compiler
+{
+
+struct ManualSchedulerOptions
+{
+public:
+  void setBackendMap(const std::string &str);
+
+public:
+  std::string backend_for_all;
+  std::unordered_map<ir::OpCode, std::string> opcode_to_backend;
+  std::unordered_map<ir::OperationIndex, std::string> index_to_backend;
+};
+
+class CompilerOptions
+{
+public:
+  /**
+   * @brief   Set default values for CompilerOptions
+   * @return  Generated CompileOption
+   *
+   * @note    All these default values should not be fetched from Env
+   *          when we stop supporting Android NNAPI.
+   */
+  static std::unique_ptr<CompilerOptions> fromGlobalConfig();
+
+  /**
+   * @brief Allow to compute float32 using float16 data type
+   */
+  void enableToFp16() { fp16_enable = true; }
+
+  /**
+   * @brief Force default values of CompilerOptions for correct compilations
+   *
+   * @note  This should be called after CompilerOptions setting is finished
+   *        to prevent value overwriting
+   */
+  void forceInternalOptions();
+
+  /**
+   * @brief Print option value
+   */
+  void verboseOptions();
+
+public:
+  // GENERAL OPTIONS
+  std::vector<std::string> backend_list;
+
+  // OPTIONS ONLY FOR DEBUGGING/PROFILING
+  std::string trace_filepath; //< File path to save trace records
+  int graph_dump_level;       //< Graph dump level, values between 0 and 2 are valid
+  std::string executor;       //< Executor name to use
+  ManualSchedulerOptions manual_scheduler_options; //< Options for ManualScheduler
+  bool he_scheduler;      //< HEScheduler if true, ManualScheduler otherwise
+  bool he_profiling_mode; //< Whether HEScheduler profiling mode ON/OFF
+  bool disable_compile;   //< Run with Interpreter if true, try compilation otherwise
+  bool fp16_enable;       //< Whether fp16 mode ON/OFF
+};
+
+} // namespace compiler
+} // namespace onert
+
+#endif // __ONERT_COMPILER_COMPILER_OPTIONS_H_

--- a/runtime/onert/core/src/compiler/CompilerOptions.cc
+++ b/runtime/onert/core/src/compiler/CompilerOptions.cc
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "compiler/CompilerOptions.h"
+
+#include "../backend/builtin/Backend.h"
+
+#include "util/ConfigSource.h"
+#include "util/logging.h"
+
+#include <misc/string_helpers.h>
+
+namespace
+{
+
+using namespace onert;
+
+std::string getOpBackends(std::unordered_map<ir::OpCode, std::string> &opcode_to_backend)
+{
+  std::unordered_map<ir::OpCode, std::string>::iterator it;
+  std::string opbackends;
+
+  for (it = opcode_to_backend.begin(); it != opcode_to_backend.end(); ++it)
+  {
+    if (!opbackends.empty())
+      opbackends = opbackends + ", ";
+
+    auto opcode = it->first;
+    const std::string opname = ir::toString(opcode);
+    opbackends += opname + "=" + it->second;
+  }
+  return opbackends;
+}
+
+} // namespace
+
+namespace onert
+{
+namespace compiler
+{
+
+void ManualSchedulerOptions::setBackendMap(const std::string &str)
+{
+  // TODO Support multiple subgraphs for manual scheduling
+  auto key_val_list = nnfw::misc::split(str, ';');
+  for (const auto &key_val_str : key_val_list)
+  {
+    if (key_val_str.empty())
+    {
+      continue;
+    }
+
+    auto key_val = nnfw::misc::split(key_val_str, '=');
+    const auto &key_str = key_val.at(0);
+    const auto &val = key_val.at(1);
+    auto key = static_cast<uint32_t>(std::stoi(key_str));
+    this->index_to_backend.emplace(ir::OperationIndex{key}, val);
+  }
+}
+
+std::unique_ptr<CompilerOptions> CompilerOptions::fromGlobalConfig()
+{
+  auto o = std::make_unique<CompilerOptions>();
+  o->backend_list = nnfw::misc::split(util::getConfigString(util::config::BACKENDS), ';');
+  o->trace_filepath = util::getConfigString(util::config::TRACE_FILEPATH);
+  o->graph_dump_level = util::getConfigInt(util::config::GRAPH_DOT_DUMP);
+  o->executor = util::getConfigString(util::config::EXECUTOR);
+  o->he_scheduler = util::getConfigBool(util::config::USE_SCHEDULER);
+  o->he_profiling_mode = util::getConfigBool(util::config::PROFILING_MODE);
+  o->disable_compile = util::getConfigBool(util::config::DISABLE_COMPILE);
+  o->fp16_enable = util::getConfigBool(util::config::FP16_ENABLE);
+  {
+    // Backend for all
+    auto &ms_options = o->manual_scheduler_options;
+
+    // Default value for op_backend_all is first element in the backend list
+    ms_options.backend_for_all = util::getConfigString(util::config::OP_BACKEND_ALLOPS);
+
+// Opcode to Backend
+#define OP(OpName)                                                                      \
+  {                                                                                     \
+    const auto &backend_str = util::getConfigString(util::config::OP_BACKEND_##OpName); \
+    if (!backend_str.empty())                                                           \
+    {                                                                                   \
+      ms_options.opcode_to_backend[ir::OpCode::OpName] = backend_str;                   \
+    }                                                                                   \
+  }
+#include "ir/Operations.lst"
+#undef OP
+
+    // Index to Backend
+    auto map_str = util::getConfigString(util::config::OP_BACKEND_MAP);
+    ms_options.setBackendMap(map_str);
+  }
+  return o;
+}
+
+void CompilerOptions::forceInternalOptions()
+{
+  // Set control flow backend for control flow operators
+  auto &builtin_id = backend::builtin::Config::ID;
+  manual_scheduler_options.opcode_to_backend[ir::OpCode::If] = builtin_id;
+  manual_scheduler_options.opcode_to_backend[ir::OpCode::While] = builtin_id;
+  manual_scheduler_options.opcode_to_backend[ir::OpCode::Permute] = builtin_id;
+
+  // FIXME This is a workaround for bcq operations, should remove it
+  manual_scheduler_options.opcode_to_backend[ir::OpCode::BCQFullyConnected] = "bcq";
+  manual_scheduler_options.opcode_to_backend[ir::OpCode::BCQGather] = "bcq";
+
+  // FIXME This is a workaround for bulk operations, should remove it
+  manual_scheduler_options.opcode_to_backend[ir::OpCode::Bulk] = "trix";
+}
+
+void CompilerOptions::verboseOptions()
+{
+  VERBOSE(Compiler) << std::boolalpha << "==== Compiler Options ====" << std::endl;
+  VERBOSE(Compiler) << "backend_list             : "
+                    << nnfw::misc::join(backend_list.begin(), backend_list.end(), "/") << std::endl;
+  VERBOSE(Compiler) << "trace_filepath           : " << trace_filepath << std::endl;
+  VERBOSE(Compiler) << "graph_dump_level         : " << graph_dump_level << std::endl;
+  VERBOSE(Compiler) << "executor                 : " << executor << std::endl;
+  VERBOSE(Compiler) << "manual backend_for_all   : " << manual_scheduler_options.backend_for_all
+                    << std::endl;
+  VERBOSE(Compiler) << "manual_scheduler_options : "
+                    << getOpBackends(manual_scheduler_options.opcode_to_backend) << std::endl;
+  VERBOSE(Compiler) << "he_scheduler             : " << he_scheduler << std::endl;
+  VERBOSE(Compiler) << "he_profiling_mode        : " << he_profiling_mode << std::endl;
+  VERBOSE(Compiler) << "disable_compile          : " << disable_compile << std::endl;
+  VERBOSE(Compiler) << "fp16_enable              : " << fp16_enable << std::endl
+                    << std::noboolalpha;
+}
+
+} // namespace compiler
+} // namespace onert

--- a/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksCompilation.cc
+++ b/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksCompilation.cc
@@ -26,9 +26,7 @@ ANeuralNetworksCompilation::ANeuralNetworksCompilation(const ANeuralNetworksMode
     _compiler{std::make_shared<compiler::Compiler>(_model, *_coptions)}
 {
   if (model->allowedToFp16())
-  {
-    _compiler->enableToFp16();
-  }
+    _coptions->enableToFp16();
 }
 
 bool ANeuralNetworksCompilation::finish() noexcept


### PR DESCRIPTION
This commit revisits CompilerOptions.
- Move class implementation to CompilerOptions.h/cpp
- Move option seting methods into CompilerOptions
  - Move enableToFp16 into CompilerOptions
  - Introduce forceInternalOptions method
- Move verboseOptions into CompilerOptions

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>