### PR TITLE
[npud] Add buffers_create and buffers_destroy dbus method

### DIFF
--- a/runtime/service/npud/core/DBus.h
+++ b/runtime/service/npud/core/DBus.h
@@ -48,6 +48,10 @@ public:
                                            gint arg_device_id, gint arg_priority);
   static gboolean on_handle_context_destroy(NpudCore *object, GDBusMethodInvocation *invocation,
                                             guint64 arg_ctx);
+  static gboolean on_handle_buffers_create(NpudCore *object, GDBusMethodInvocation *invocation,
+                                           guint64 arg_ctx, GVariant *arg_buffers);
+  static gboolean on_handle_buffers_destroy(NpudCore *object, GDBusMethodInvocation *invocation,
+                                            guint64 arg_ctx, GVariant *arg_buffers);
   static gboolean on_handle_network_create(NpudCore *object, GDBusMethodInvocation *invocation,
                                            guint64 arg_ctx, const gchar *arg_model_path);
   static gboolean on_handle_network_destroy(NpudCore *object, GDBusMethodInvocation *invocation,

--- a/runtime/service/npud/org.tizen.npud.xml
+++ b/runtime/service/npud/org.tizen.npud.xml
@@ -43,6 +43,34 @@
 	    <arg name="error" type="i" direction="out"  />
     </method>
     <!--
+      buffers_create:
+      @ctx: The Context handle.
+      @buffers: The array of buffer structure. (i:type, t:address, u:size)
+      @out_buffers: The array of buffer sturcture containing created buffer address.
+      @error: The error status of the function.
+
+      Create buffer array.
+    -->
+    <method name="buffers_create">
+      <arg name="ctx" type="t" direction="in" />
+      <arg name="buffers" type="a(itu)" direction="in" />
+      <arg name="out_buffers" type="a(itu)" direction="out" />
+      <arg name="error" type="i" direction="out" />
+    </method>
+    <!--
+      buffers_destroy:
+      @ctx: The Context handle.
+      @buffers: The array of buffer structure. (i:type, t:address, u:size)
+      @error: The error status of the function.
+
+      Destroy buffer array.
+    -->
+    <method name="buffers_destroy">
+      <arg name="ctx" type="t" direction="in" />
+      <arg name="buffers" type="a(itu)" direction="in" />
+      <arg name="error" type="i" direction="out" />
+    </method>
+    <!--
       network_create:
       @ctx: The context handle.
       @model_path: The model path to run.


### PR DESCRIPTION
This commit adds buffers_create and buffers_destroy dbus method. This buffer will be used in set_request_data dbus method.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>