### PR TITLE
[infra] Add npud test in TCM configuration

### DIFF
--- a/.ahub/tcchecker-tca/config.yaml
+++ b/.ahub/tcchecker-tca/config.yaml
@@ -8,6 +8,7 @@ test:
       - /runtime/libs/misc
       - /runtime/libs/ndarray
       - /runtime/onert
+      - /runtime/service/npud/tests
       - /tests/nnfw_api
 
     testFile:


### PR DESCRIPTION
This commit adds npu test directory in TCM runtime configuration.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>