### PR TITLE
[model2nnpkg] Fix diff between bash and python script

### DIFF
--- a/tools/nnpackage_tool/model2nnpkg/model2nnpkg.py
+++ b/tools/nnpackage_tool/model2nnpkg/model2nnpkg.py
@@ -100,7 +100,7 @@ def _get_args():
 
 
 def _generate_manifest(args):
-    config_list = ''
+    config_list = [""]
     if args.config:
         config_list = [os.path.basename(e) for e in args.config]
     models_list = [os.path.basename(e) for e in args.models]


### PR DESCRIPTION
This commit fixes metadata on python script to generate config json array.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: https://github.com/Samsung/ONE/issues/10240#issue-1510528294