### PR TITLE
[tools/model2nnpkg] Add new line at end of output json files

### DIFF
--- a/tools/nnpackage_tool/model2nnpkg/model2nnpkg.py
+++ b/tools/nnpackage_tool/model2nnpkg/model2nnpkg.py
@@ -130,7 +130,7 @@ def main():
     manifest = _generate_manifest(args)
     manifest_path = os.path.join(nnpkg_path, 'metadata', 'MANIFEST')
     with open(manifest_path, "w") as json_file:
-        json.dump(manifest, json_file, indent=2)
+        json_file.write(f'{json.dumps(manifest, indent=2)}\n')
 
     # copy models and configurations
     for i in range(len(args.models)):


### PR DESCRIPTION
This commit adds new line at end of output json files.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>

---

Related issue: https://github.com/Samsung/ONE/issues/10240#issue-1510528294