### PR TITLE
[one-cmds] Install model2nnpkg

### DIFF
--- a/compiler/one-cmds/CMakeLists.txt
+++ b/compiler/one-cmds/CMakeLists.txt
@@ -74,6 +74,15 @@ foreach(ONE_UTILITY IN ITEMS ${ONE_UTILITY_FILES})
 
 endforeach(ONE_UTILITY)
 
+# one-pack internally uses model2nnpkg tool
+set(MODEL2NNPKG "${NNAS_PROJECT_SOURCE_DIR}/tools/nnpackage_tool/model2nnpkg/model2nnpkg.sh")
+install(FILES ${MODEL2NNPKG}
+              PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE
+                          GROUP_READ GROUP_EXECUTE
+                          WORLD_READ WORLD_EXECUTE
+              DESTINATION bin
+              RENAME "model2nnpkg")
+
 # make python directory
 set(ONE_PYTHON_FILES constant.py
                      make_cmd.py


### PR DESCRIPTION
Let's install model2nnpkg script in one-cmds cmake.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: #10235 