### PR TITLE
[one-cmds] Use python model2nnpkg in one-pack

### DIFF
--- a/compiler/one-cmds/one-pack
+++ b/compiler/one-cmds/one-pack
@@ -84,7 +84,7 @@ def _pack(args):
 
     with open(logfile_path, 'wb') as f:
         # make a command to package circle model and metadata into nnpackage
-        model2nnpkg_path = os.path.join(dir_path, 'model2nnpkg.sh')
+        model2nnpkg_path = os.path.join(dir_path, 'model2nnpkg')
         model2nnpkg_cmd = _make_model2nnpkg_cmd(model2nnpkg_path,
                                                 getattr(args, 'input_path'),
                                                 getattr(args, 'output_path'))
@@ -92,7 +92,7 @@ def _pack(args):
         f.write((' '.join(model2nnpkg_cmd) + '\n').encode())
 
         # convert tflite to circle
-        _utils._run(model2nnpkg_cmd, err_prefix="model2nnpkg.sh", logfile=f)
+        _utils._run(model2nnpkg_cmd, err_prefix="model2nnpkg", logfile=f)
 
 
 def main():


### PR DESCRIPTION
This commit updates one-pack to use python model2nnpkg.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: https://github.com/Samsung/ONE/pull/10235