### PR TITLE
[infra] Remove deprecated model2nnpkg.sh

### DIFF
--- a/infra/debian/compiler/one-compiler.install
+++ b/infra/debian/compiler/one-compiler.install
@@ -10,7 +10,6 @@ usr/bin/dalgona usr/share/one/bin/
 usr/bin/generate_bcq_metadata.py usr/share/one/bin/
 usr/bin/generate_bcq_output_arrays.py usr/share/one/bin/
 usr/bin/model2nnpkg usr/share/one/bin/
-usr/bin/model2nnpkg.sh usr/share/one/bin/
 usr/bin/onecc usr/share/one/bin/
 usr/bin/onecc.template.cfg usr/share/one/bin/
 usr/bin/one-build usr/share/one/bin/

--- a/infra/debian/compiler/rules
+++ b/infra/debian/compiler/rules
@@ -14,7 +14,6 @@ override_dh_auto_install:
 	cmake --build "$(NNAS_BUILD_PREFIX)/nncc" -- install
 
 override_dh_install:
-	install -t "$(_DESTDIR)/bin" -D "tools/nnpackage_tool/model2nnpkg/model2nnpkg.sh"
 	install -T -m 755 -D "infra/packaging/res/tf2nnpkg.${PRESET}" "$(_DESTDIR)/bin/tf2nnpkg"
 	dh_install
 

--- a/infra/packaging/preset/20221125
+++ b/infra/packaging/preset/20221125
@@ -58,9 +58,6 @@ function preset_configure()
 
 function preset_install()
 {
-  install -t "${NNPKG_INSTALL_PREFIX}/bin" -D \
-    "${NNAS_PROJECT_PATH}/tools/nnpackage_tool/model2nnpkg/model2nnpkg.sh"
-
   # Install tf2nnpkg
   install -T -m 755 -D "${SCRIPT_PATH}/res/tf2nnpkg.${PRESET}" "${NNAS_INSTALL_PREFIX}/bin/tf2nnpkg"
 }

--- a/infra/packaging/preset/20221125_windows
+++ b/infra/packaging/preset/20221125_windows
@@ -68,9 +68,6 @@ function preset_install()
   mv ${NNCC_INSTALL_PREFIX}/lib/*.dll ${NNCC_INSTALL_PREFIX}/bin
   rm -rf ${NNCC_INSTALL_PREFIX}/lib
 
-  install -t "${NNPKG_INSTALL_PREFIX}/bin" -D \
-    "${NNAS_PROJECT_PATH}/tools/nnpackage_tool/model2nnpkg/model2nnpkg.sh"
-
   # Install tf2nnpkg
   install -T -m 755 -D "${SCRIPT_PATH}/res/tf2nnpkg.${PRESET}" "${NNAS_INSTALL_PREFIX}/bin/tf2nnpkg"
 


### PR DESCRIPTION
This commit removes deprecated model2nnpkg.sh to packaging.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: #10235