### PR TITLE
[circle-mpqsolver] Add fusedActivationFunction

### DIFF
--- a/compiler/circle-mpqsolver/src/bisection/Quantizer.test.cpp
+++ b/compiler/circle-mpqsolver/src/bisection/Quantizer.test.cpp
@@ -57,6 +57,7 @@ protected:
     _beta->size<loco::DataType::FLOAT32>(channel_size);
     _add->x(input);
     _add->y(_beta);
+    _add->fusedActivationFunction(luci::FusedActFunc::NONE);
 
     _add->name("add");
     _beta->name("beta");


### PR DESCRIPTION
This adds fusedActivationFunction to resolve #10270.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/10270