### PR TITLE
[one-cmds] Install python model2nnpkg

### DIFF
--- a/compiler/one-cmds/CMakeLists.txt
+++ b/compiler/one-cmds/CMakeLists.txt
@@ -75,7 +75,7 @@ foreach(ONE_UTILITY IN ITEMS ${ONE_UTILITY_FILES})
 endforeach(ONE_UTILITY)
 
 # one-pack internally uses model2nnpkg tool
-set(MODEL2NNPKG "${NNAS_PROJECT_SOURCE_DIR}/tools/nnpackage_tool/model2nnpkg/model2nnpkg.sh")
+set(MODEL2NNPKG "${NNAS_PROJECT_SOURCE_DIR}/tools/nnpackage_tool/model2nnpkg/model2nnpkg.py")
 install(FILES ${MODEL2NNPKG}
               PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE
                           GROUP_READ GROUP_EXECUTE


### PR DESCRIPTION
Let's install python model2nnpkg script instead of deprecated bash script for one-pack.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>