### PR TITLE
[one-cmds] Add model input argument

### DIFF
--- a/compiler/one-cmds/one-pack
+++ b/compiler/one-cmds/one-pack
@@ -73,6 +73,7 @@ def _make_model2nnpkg_cmd(driver_path, input_path, output_path):
     cmd = [os.path.expanduser(driver_path)]
     cmd.append('-o')
     cmd.append(os.path.expanduser(output_path))
+    cmd.append('-m')
     cmd.append(os.path.expanduser(input_path))
     return cmd
 


### PR DESCRIPTION
Python version model2nnpkg requires model input argument "-m".

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>