### PR TITLE
[infra] Fix tf2nnpkg.20221125

### DIFF
--- a/infra/packaging/res/tf2nnpkg.20221125
+++ b/infra/packaging/res/tf2nnpkg.20221125
@@ -106,4 +106,4 @@ ${ONE_IMPORT_BCQ_SCRIPT}
 # optimize
 "${ROOT}/bin/circle2circle" --resolve_customop_add "${TMPDIR}/${MODEL_NAME}.tmp.circle" "${TMPDIR}/${MODEL_NAME}.circle"
 
-"${ROOT}/bin/model2nnpkg" -o "${OUTPUT_DIR}" "${TMPDIR}/${MODEL_NAME}.circle"
+"${ROOT}/bin/model2nnpkg" -o "${OUTPUT_DIR}" -m "${TMPDIR}/${MODEL_NAME}.circle"


### PR DESCRIPTION
Python version model2nnpkg requires model input argument "-m".

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>