### PR TITLE
[onert] Introduce IExecutors

### DIFF
--- a/runtime/onert/core/include/compiler/ICompiler.h
+++ b/runtime/onert/core/include/compiler/ICompiler.h
@@ -22,7 +22,7 @@
 #ifndef __ONERT_COMPILER_I_COMPILER_H_
 #define __ONERT_COMPILER_I_COMPILER_H_
 
-#include "exec/Executors.h"
+#include "exec/IExecutors.h"
 #include "util/TracingCtx.h"
 
 namespace onert
@@ -33,11 +33,11 @@ namespace compiler
 struct CompilerArtifact
 {
   CompilerArtifact(void) = delete;
-  CompilerArtifact(std::shared_ptr<exec::Executors> executors,
+  CompilerArtifact(std::shared_ptr<exec::IExecutors> executors,
                    std::unique_ptr<const util::TracingCtx> tracing_ctx)
     : _executors{executors}, _tracing_ctx{std::move(tracing_ctx)} {};
 
-  std::shared_ptr<exec::Executors> _executors;
+  std::shared_ptr<exec::IExecutors> _executors;
   std::unique_ptr<const util::TracingCtx> _tracing_ctx;
 };
 

--- a/runtime/onert/core/include/exec/Execution.h
+++ b/runtime/onert/core/include/exec/Execution.h
@@ -22,7 +22,7 @@
 #define __ONERT_EXEC_EXECUTION_H__
 
 #include "ir/Layout.h"
-#include "exec/Executors.h"
+#include "exec/IExecutors.h"
 #include "IODescription.h"
 
 #include <thread>
@@ -46,7 +46,7 @@ public:
    * @brief     Construct a new Execution object
    * @param[in] executor  Model executor
    */
-  Execution(const std::shared_ptr<Executors> &executors);
+  Execution(const std::shared_ptr<IExecutors> &executors);
 
 public:
   /**
@@ -150,7 +150,7 @@ private:
   IExecutor *entryExecutor() { return _executors->entryExecutor(); };
 
 private:
-  const std::shared_ptr<Executors> _executors;
+  const std::shared_ptr<IExecutors> _executors;
   IODescription _io_desc;
   std::unique_ptr<std::thread> _exec_thread;
   bool finished{false};

--- a/runtime/onert/core/include/exec/IExecutors.h
+++ b/runtime/onert/core/include/exec/IExecutors.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_EXEC_I_EXECUTORS_H__
+#define __ONERT_EXEC_I_EXECUTORS_H__
+
+#include "IExecutor.h"
+
+namespace onert
+{
+namespace exec
+{
+
+/**
+ * @brief Class to gather executors
+ */
+class IExecutors
+{
+public:
+  /**
+   * @brief Virtual IExecutors destructor
+   * @note  Require derived class destructor
+   */
+  virtual ~IExecutors() = default;
+
+public:
+  // TODO Use Executor index
+  virtual void emplace(const ir::ModelIndex &model_index, const ir::SubgraphIndex &subg_index,
+                       std::unique_ptr<IExecutor> exec) = 0;
+
+  virtual IExecutor *at(const ir::ModelIndex &model_index,
+                        const ir::SubgraphIndex &subg_index) const = 0;
+
+  IExecutor *entryExecutor() const { return at(ir::ModelIndex{0}, ir::SubgraphIndex{0}); }
+
+  virtual uint32_t inputSize() const = 0;
+
+  virtual uint32_t outputSize() const = 0;
+
+  virtual const ir::OperandInfo inputInfo(const ir::IOIndex &index) = 0;
+
+  virtual const ir::OperandInfo outputInfo(const ir::IOIndex &index) = 0;
+
+  virtual void execute(const IODescription &desc) = 0;
+};
+
+} // namespace exec
+} // namespace onert
+
+#endif // __ONERT_EXEC_I_EXECUTORS_H__

--- a/runtime/onert/core/src/backend/builtin/KernelGenerator.h
+++ b/runtime/onert/core/src/backend/builtin/KernelGenerator.h
@@ -23,7 +23,7 @@
 #include "../../compiler/TensorRegistries.h"
 
 #include "backend/basic/KernelGeneratorBase.h"
-#include "exec/Executors.h"
+#include "exec/IExecutors.h"
 #include "ir/Graph.h"
 
 namespace onert
@@ -44,7 +44,7 @@ public:
   {
     _tensor_registries = tensor_registries;
   }
-  void setExecutors(const std::shared_ptr<exec::Executors> &executors)
+  void setExecutors(const std::shared_ptr<exec::IExecutors> &executors)
   {
     // FIXME Using shared_ptr's raw pointer!
     _executors = executors.get();
@@ -67,7 +67,7 @@ private:
   DynamicTensorManager *_dyn_tensor_manager;
   std::shared_ptr<TensorRegistry> _tensor_reg;
   compiler::TensorRegistries _tensor_registries;
-  exec::Executors *_executors;
+  exec::IExecutors *_executors;
   ir::ModelIndex _model_index;
   const std::shared_ptr<ExternalContext> _external_context;
 };

--- a/runtime/onert/core/src/backend/builtin/kernel/IfLayer.cc
+++ b/runtime/onert/core/src/backend/builtin/kernel/IfLayer.cc
@@ -29,7 +29,7 @@ IfLayer::IfLayer(backend::IPortableTensor *cond_tensor,
                  const std::vector<backend::IPortableTensor *> input_tensors,
                  const std::vector<backend::IPortableTensor *> output_tensors,
                  const ir::SubgraphIndex &then_subg_index, const ir::SubgraphIndex &else_subg_index,
-                 exec::Executors *executors, const ir::ModelIndex &model_index,
+                 exec::IExecutors *executors, const ir::ModelIndex &model_index,
                  const std::shared_ptr<ExternalContext> &external_context)
   : _cond_tensor{cond_tensor}, _input_tensors{input_tensors}, _output_tensors{output_tensors},
     _then_subg_index{then_subg_index}, _else_subg_index{else_subg_index}, _executors{executors},

--- a/runtime/onert/core/src/backend/builtin/kernel/IfLayer.h
+++ b/runtime/onert/core/src/backend/builtin/kernel/IfLayer.h
@@ -18,7 +18,7 @@
 #define __ONERT_BACKEND_BUILTIN_KERNEL_IF_LAYER_H__
 
 #include <backend/IPortableTensor.h>
-#include <exec/Executors.h>
+#include <exec/IExecutors.h>
 #include "../ExternalContext.h"
 
 namespace onert
@@ -37,7 +37,7 @@ public:
           const std::vector<backend::IPortableTensor *> input_tensors,
           const std::vector<backend::IPortableTensor *> output_tensors,
           const ir::SubgraphIndex &then_subg_index, const ir::SubgraphIndex &else_subg_index,
-          exec::Executors *executors, const ir::ModelIndex &model_index,
+          exec::IExecutors *executors, const ir::ModelIndex &model_index,
           const std::shared_ptr<ExternalContext> &external_context);
 
 public:
@@ -49,7 +49,7 @@ private:
   const std::vector<backend::IPortableTensor *> _output_tensors;
   const ir::SubgraphIndex _then_subg_index;
   const ir::SubgraphIndex _else_subg_index;
-  exec::Executors *_executors;
+  exec::IExecutors *_executors;
   ir::ModelIndex _model_index;
   const std::shared_ptr<ExternalContext> _external_context;
 };

--- a/runtime/onert/core/src/backend/builtin/kernel/WhileLayer.cc
+++ b/runtime/onert/core/src/backend/builtin/kernel/WhileLayer.cc
@@ -35,7 +35,7 @@ namespace kernel
 WhileLayer::WhileLayer(const std::vector<backend::IPortableTensor *> input_tensors,
                        const std::vector<backend::IPortableTensor *> output_tensors,
                        const ir::SubgraphIndex &cond_subg_index,
-                       const ir::SubgraphIndex &body_subg_index, exec::Executors *executors,
+                       const ir::SubgraphIndex &body_subg_index, exec::IExecutors *executors,
                        const ir::ModelIndex &model_index,
                        basic::DynamicMemoryManager *dyn_memory_manager,
                        const std::shared_ptr<ExternalContext> &external_context)

--- a/runtime/onert/core/src/backend/builtin/kernel/WhileLayer.h
+++ b/runtime/onert/core/src/backend/builtin/kernel/WhileLayer.h
@@ -18,7 +18,7 @@
 #define __ONERT_BACKEND_BUILTIN_KERNEL_WHILE_LAYER_H__
 
 #include <backend/IPortableTensor.h>
-#include <exec/Executors.h>
+#include <exec/IExecutors.h>
 #include <exec/IFunction.h>
 #include <ir/OperandIndexSequence.h>
 #include <ir/Graph.h>
@@ -41,7 +41,7 @@ public:
   WhileLayer(const std::vector<backend::IPortableTensor *> input_tensors,
              const std::vector<backend::IPortableTensor *> output_tensors,
              const ir::SubgraphIndex &cond_subg_index, const ir::SubgraphIndex &body_subg_index,
-             exec::Executors *executors, const ir::ModelIndex &model_index,
+             exec::IExecutors *executors, const ir::ModelIndex &model_index,
              basic::DynamicMemoryManager *dyn_memory_manager,
              const std::shared_ptr<ExternalContext> &external_context);
 
@@ -53,7 +53,7 @@ private:
   const ir::SubgraphIndex _body_subg_index;
   const std::vector<backend::IPortableTensor *> _input_tensors;
   const std::vector<backend::IPortableTensor *> _output_tensors;
-  exec::Executors *_executors;
+  exec::IExecutors *_executors;
   const ir::ModelIndex _model_index;
   basic::DynamicMemoryManager *_dyn_memory_manager; // For generating temp tensors
   const std::shared_ptr<ExternalContext> _external_context;

--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -23,6 +23,7 @@
 #include "pass/PassRunner.h"
 #include "pass/UnusedOperandEliminationPass.h"
 #include "../dumper/dot/DotDumper.h"
+#include "../exec/Executors.h"
 #include "../interp/InterpExecutor.h"
 #include "../ir/OperationDumper.h"
 #include "../ir/verifier/Verifier.h"

--- a/runtime/onert/core/src/compiler/ExecutorFactory.cc
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.cc
@@ -251,7 +251,7 @@ ExecutorFactory::ExecutorFactory()
 exec::IExecutor *ExecutorFactory::create(std::unique_ptr<compiler::LoweredGraph> lowered_graph,
                                          const util::TracingCtx *tracing_ctx,
                                          const compiler::CompilerOptions &options,
-                                         const std::shared_ptr<exec::Executors> &executors,
+                                         const std::shared_ptr<exec::IExecutors> &executors,
                                          const ir::ModelIndex &index)
 {
   return _map.at(options.executor)(std::move(lowered_graph), tracing_ctx, options, executors,
@@ -286,7 +286,7 @@ void ExecutorFactory::prepareMigrantTensors(compiler::LoweredGraph &lowered_grap
 }
 
 void ExecutorFactory::prepareBuiltinBackend(const TensorRegistries &tensor_regs,
-                                            const std::shared_ptr<exec::Executors> &executors,
+                                            const std::shared_ptr<exec::IExecutors> &executors,
                                             const backend::BackendContexts &backend_contexts,
                                             const ir::ModelIndex &index)
 {
@@ -325,7 +325,7 @@ ExecutorFactory::orderBackendContext(const backend::BackendContexts &backend_con
 
 exec::IExecutor *ExecutorFactory::createLinearExecutor(
   std::unique_ptr<compiler::LoweredGraph> lowered_graph, const util::TracingCtx *tracing_ctx,
-  const compiler::CompilerOptions &options, const std::shared_ptr<exec::Executors> &executors,
+  const compiler::CompilerOptions &options, const std::shared_ptr<exec::IExecutors> &executors,
   const ir::ModelIndex &index)
 {
   auto &graph = lowered_graph->graph();
@@ -451,7 +451,7 @@ exec::IExecutor *ExecutorFactory::createLinearExecutor(
 
 exec::IExecutor *ExecutorFactory::createDataflowExecutor(
   std::unique_ptr<compiler::LoweredGraph> lowered_graph, const util::TracingCtx *tracing_ctx,
-  const compiler::CompilerOptions &options, const std::shared_ptr<exec::Executors> &executors,
+  const compiler::CompilerOptions &options, const std::shared_ptr<exec::IExecutors> &executors,
   const ir::ModelIndex &index, bool parallel)
 {
   backend::BackendContexts backend_contexts =

--- a/runtime/onert/core/src/compiler/ExecutorFactory.h
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.h
@@ -21,7 +21,7 @@
 
 #include "backend/ITensor.h"
 #include "compiler/LoweredGraph.h"
-#include "exec/Executors.h"
+#include "exec/IExecutors.h"
 
 #include <deque>
 #include <unordered_map>
@@ -40,7 +40,7 @@ public:
   exec::IExecutor *create(std::unique_ptr<compiler::LoweredGraph> lowered_graph,
                           const util::TracingCtx *tracing_ctx,
                           const compiler::CompilerOptions &options,
-                          const std::shared_ptr<exec::Executors> &executors,
+                          const std::shared_ptr<exec::IExecutors> &executors,
                           const ir::ModelIndex &index);
 
 private:
@@ -50,7 +50,7 @@ private:
   static void prepareMigrantTensors(compiler::LoweredGraph &lowered_graph,
                                     const backend::BackendContexts &backend_contexts);
   static void prepareBuiltinBackend(const TensorRegistries &tensor_regs,
-                                    const std::shared_ptr<exec::Executors> &executors,
+                                    const std::shared_ptr<exec::IExecutors> &executors,
                                     const backend::BackendContexts &backend_contexts,
                                     const ir::ModelIndex &index);
   static std::deque<std::pair<const backend::Backend *, backend::BackendContext *>>
@@ -58,19 +58,20 @@ private:
 
   static exec::IExecutor *createLinearExecutor(
     std::unique_ptr<compiler::LoweredGraph> lowered_graph, const util::TracingCtx *tracing_ctx,
-    const compiler::CompilerOptions &options, const std::shared_ptr<exec::Executors> &executors,
+    const compiler::CompilerOptions &options, const std::shared_ptr<exec::IExecutors> &executors,
     const ir::ModelIndex &index);
   static exec::IExecutor *createDataflowExecutor(
     std::unique_ptr<compiler::LoweredGraph> lowered_graph, const util::TracingCtx *tracing_ctx,
-    const compiler::CompilerOptions &options, const std::shared_ptr<exec::Executors> &executors,
+    const compiler::CompilerOptions &options, const std::shared_ptr<exec::IExecutors> &executors,
     const ir::ModelIndex &index, bool parallel);
 
 private:
   std::unordered_map<
-    std::string, std::function<exec::IExecutor *(
-                   std::unique_ptr<compiler::LoweredGraph>, const util::TracingCtx *tracing_ctx,
-                   const compiler::CompilerOptions &options,
-                   const std::shared_ptr<exec::Executors> &executors, const ir::ModelIndex &index)>>
+    std::string,
+    std::function<exec::IExecutor *(
+      std::unique_ptr<compiler::LoweredGraph>, const util::TracingCtx *tracing_ctx,
+      const compiler::CompilerOptions &options, const std::shared_ptr<exec::IExecutors> &executors,
+      const ir::ModelIndex &index)>>
     _map;
 };
 

--- a/runtime/onert/core/src/compiler/MultiModelCompiler.cc
+++ b/runtime/onert/core/src/compiler/MultiModelCompiler.cc
@@ -23,6 +23,7 @@
 #include "pass/PassRunner.h"
 #include "pass/UnusedOperandEliminationPass.h"
 #include "../dumper/dot/DotDumper.h"
+#include "../exec/Executors.h"
 #include "../ir/OperationDumper.h"
 #include "../ir/verifier/Verifier.h"
 

--- a/runtime/onert/core/src/exec/Execution.cc
+++ b/runtime/onert/core/src/exec/Execution.cc
@@ -23,7 +23,7 @@ namespace onert
 namespace exec
 {
 
-Execution::Execution(const std::shared_ptr<Executors> &executors) : _executors{executors}
+Execution::Execution(const std::shared_ptr<IExecutors> &executors) : _executors{executors}
 {
   assert(executors != nullptr);
   assert(executors->entryExecutor() != nullptr);

--- a/runtime/onert/core/src/exec/Execution.test.cc
+++ b/runtime/onert/core/src/exec/Execution.test.cc
@@ -209,7 +209,7 @@ class Inference
 {
 public:
   Inference(const float (&input1)[4], const float (&input2)[4], float (&output)[4],
-            std::shared_ptr<onert::exec::Executors> &executors)
+            std::shared_ptr<onert::exec::IExecutors> &executors)
     : _input1{input1}, _input2{input2}, _output{output}, _executors{executors}
   {
     // DO NOTHING
@@ -233,7 +233,7 @@ private:
   const float (&_input1)[4];
   const float (&_input2)[4];
   float (&_output)[4];
-  std::shared_ptr<onert::exec::Executors> &_executors;
+  std::shared_ptr<onert::exec::IExecutors> &_executors;
 };
 
 // Support multi-thread execution

--- a/runtime/onert/core/src/exec/ExecutionObservers.h
+++ b/runtime/onert/core/src/exec/ExecutionObservers.h
@@ -22,7 +22,7 @@
 #include "../util/EventRecorder.h"
 #include "../util/EventWriter.h"
 
-#include "exec/Executors.h"
+#include "exec/IExecutor.h"
 #include "ir/Index.h"
 #include "ir/Operation.h"
 #include "util/ITimer.h"

--- a/runtime/onert/core/src/exec/Executors.cc
+++ b/runtime/onert/core/src/exec/Executors.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "exec/Executors.h"
+#include "Executors.h"
 
 namespace onert
 {

--- a/runtime/onert/core/src/exec/Executors.h
+++ b/runtime/onert/core/src/exec/Executors.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_EXEC_EXECUTORS_H__
 #define __ONERT_EXEC_EXECUTORS_H__
 
-#include "IExecutor.h"
+#include "exec/IExecutors.h"
 #include "ir/NNPkg.h"
 
 namespace std
@@ -43,21 +43,20 @@ namespace exec
 /**
  * @brief Class to gather executors
  */
-class Executors
+class Executors : public IExecutors
 {
 public:
   Executors(void) = default;
   Executors(std::unique_ptr<ir::ModelEdges> model_edges) { _model_edges = std::move(model_edges); }
   Executors(const Executors &) = delete;
   Executors(Executors &&) = default;
+  ~Executors() = default;
 
   // TODO Use Executor index
   void emplace(const ir::ModelIndex &model_index, const ir::SubgraphIndex &subg_index,
                std::unique_ptr<IExecutor> exec);
 
   IExecutor *at(const ir::ModelIndex &model_index, const ir::SubgraphIndex &subg_index) const;
-
-  IExecutor *entryExecutor() const { return at(ir::ModelIndex{0}, ir::SubgraphIndex{0}); }
 
   uint32_t inputSize() const;
 

--- a/runtime/onert/core/src/interp/InterpExecutor.test.cc
+++ b/runtime/onert/core/src/interp/InterpExecutor.test.cc
@@ -15,6 +15,7 @@
  */
 
 #include "InterpExecutor.h"
+#include "../exec/Executors.h"
 
 #include "exec/Execution.h"
 #include "ir/Graph.h"

--- a/runtime/onert/frontend/nnapi/execution.cc
+++ b/runtime/onert/frontend/nnapi/execution.cc
@@ -37,7 +37,7 @@ int ANeuralNetworksExecution_create(ANeuralNetworksCompilation *compilation,
     return ANEURALNETWORKS_UNEXPECTED_NULL;
   }
 
-  std::shared_ptr<onert::exec::Executors> executors;
+  std::shared_ptr<onert::exec::IExecutors> executors;
 
   compilation->publish(executors);
 

--- a/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksCompilation.h
+++ b/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksCompilation.h
@@ -22,7 +22,7 @@
 #include "compiler/Compiler.h"
 #include "ir/Graph.h"
 #include "ir/Model.h"
-#include "exec/Executors.h"
+#include "exec/IExecutors.h"
 #include "util/TracingCtx.h"
 
 struct ANeuralNetworksCompilation
@@ -34,7 +34,7 @@ public:
   bool finish() noexcept;
   bool isFinished() noexcept { return _compiler == nullptr; }
 
-  void publish(std::shared_ptr<onert::exec::Executors> &executors) noexcept
+  void publish(std::shared_ptr<onert::exec::IExecutors> &executors) noexcept
   {
     executors = _artifact ? _artifact->_executors : nullptr;
   }

--- a/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksExecution.h
+++ b/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksExecution.h
@@ -26,7 +26,7 @@
 struct ANeuralNetworksExecution
 {
 public:
-  ANeuralNetworksExecution(const std::shared_ptr<onert::exec::Executors> &executors)
+  ANeuralNetworksExecution(const std::shared_ptr<onert::exec::IExecutors> &executors)
     : _execution{std::make_shared<onert::exec::Execution>(executors)}
   {
     // DO NOTHING


### PR DESCRIPTION
This commit introduces IExecutors.
`Executors.h` is moved into `src/` directory, so it is not public header.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: #10004