### PR TITLE
[dalgona-test] Use pics module

### DIFF
--- a/compiler/dalgona-test/CMakeLists.txt
+++ b/compiler/dalgona-test/CMakeLists.txt
@@ -4,12 +4,6 @@ endif(NOT ENABLE_TEST)
 
 unset(DALGONA_SINGLE_OP_TEST)
 
-nnas_find_package(FlatBuffers EXACT 2.0 QUIET)
-if(NOT FlatBuffers_FOUND)
-  message(STATUS "Test dalgona: FAILED (missing FlatBuffers)")
-  return()
-endif(NOT FlatBuffers_FOUND)
-
 macro(singleOpTest NAME)
   list(APPEND DALGONA_SINGLE_OP_TEST ${NAME})
 endmacro(singleOpTest)
@@ -22,7 +16,6 @@ include("test.local.lst" OPTIONAL)
 unset(TEST_DEPS)
 
 get_target_property(ARTIFACTS_BIN_PATH testDataGenerator BINARY_DIR)
-get_target_property(SCHEMA_BIN_PATH mio_circle04 BINARY_DIR)
 
 # Place test scripts in one place
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/GenH5RandomInputs.py" "${CMAKE_CURRENT_BINARY_DIR}/GenH5RandomInputs.py" COPYONLY)
@@ -43,21 +36,13 @@ add_custom_command(
   COMMENT "Generate test configuration"
 )
 
-###
-### Generate python interface for circle schema
-###
-set(CIRCLE_SCHEMA_PYTHON_DIR "${CMAKE_CURRENT_BINARY_DIR}/circle")
+# Import pics module
+get_target_property(PICS_BIN_PATH pics BINARY_DIR)
+add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/circle
+                   COMMAND ${CMAKE_COMMAND} -E create_symlink
+                   ${PICS_BIN_PATH}/circle ${CMAKE_CURRENT_BINARY_DIR}/circle)
 
-add_custom_command(
-  OUTPUT ${CIRCLE_SCHEMA_PYTHON_DIR}
-  COMMAND ${CMAKE_COMMAND} -E remove_directory "${CIRCLE_SCHEMA_PYTHON_DIR}"
-  COMMAND "$<TARGET_FILE:flatbuffers::flatc>" --python
-          -o "${CMAKE_CURRENT_BINARY_DIR}" "${SCHEMA_BIN_PATH}/schema.fbs"
-  DEPENDS flatbuffers::flatc
-  COMMENT "Generate python interface for circle schema"
-)
-
-list(APPEND TEST_DEPS "${TEST_CONFIG}" "${CIRCLE_SCHEMA_PYTHON_DIR}")
+list(APPEND TEST_DEPS "${TEST_CONFIG}" "${CMAKE_CURRENT_BINARY_DIR}/circle")
 
 # This enforces CMake to generate all the dependencies during "build" phase
 add_custom_target(dalgona_test_deps ALL DEPENDS ${TEST_DEPS})

--- a/compiler/dalgona-test/requires.cmake
+++ b/compiler/dalgona-test/requires.cmake
@@ -1,2 +1,3 @@
 require("dalgona")
 require("common-artifacts")
+require("pics")


### PR DESCRIPTION
This uses pics instead of flatc.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Draft PR: https://github.com/Samsung/ONE/pull/10283
Related to: https://github.com/Samsung/ONE/issues/10281