### PR TITLE
[one-cmds] Install pydot on onecc venv

### DIFF
--- a/compiler/one-cmds/one-prepare-venv
+++ b/compiler/one-cmds/one-prepare-venv
@@ -37,6 +37,7 @@ VER_TENSORFLOW=2.8.0
 VER_ONNX=1.11.0
 VER_ONNXRUNTIME=1.11.0
 VER_ONNX_TF=1.10.0
+VER_PYDOT=1.4.2
 
 # Install tensorflow
 
@@ -92,3 +93,6 @@ fi
 # NOTE refer https://github.com/protocolbuffers/protobuf/issues/10051
 # TODO remove this when issue is resolved
 ${VENV_PYTHON} -m pip ${PIP_OPTIONS} install --upgrade protobuf==3.20.1
+
+# Install pydot for visq
+${VENV_PYTHON} -m pip ${PIP_OPTIONS} install pydot==${VER_PYDOT}


### PR DESCRIPTION
This installs pydot on venv for visq.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/10277
Draft PR: https://github.com/Samsung/ONE/pull/10291