### PR TITLE
[record-minmax] Create record-minmax-for-thread-test target

### DIFF
--- a/compiler/record-minmax/CMakeLists.txt
+++ b/compiler/record-minmax/CMakeLists.txt
@@ -23,6 +23,24 @@ if(NOT ENABLE_TEST)
   return()
 endif(NOT ENABLE_TEST)
 
+# create record-minmax-for-thread-test target
+add_executable(record-minmax-for-thread-test ${DRIVER} ${SOURCES})
+target_include_directories(record-minmax-for-thread-test PRIVATE include)
+
+target_link_libraries(record-minmax-for-thread-test arser)
+target_link_libraries(record-minmax-for-thread-test safemain)
+target_link_libraries(record-minmax-for-thread-test luci_import)
+target_link_libraries(record-minmax-for-thread-test luci_env)
+target_link_libraries(record-minmax-for-thread-test luci_export)
+target_link_libraries(record-minmax-for-thread-test luci_interpreter)
+target_link_libraries(record-minmax-for-thread-test dio_hdf5)
+target_link_libraries(record-minmax-for-thread-test vconone)
+target_link_libraries(record-minmax-for-thread-test nncc_coverage)
+
+install(TARGETS record-minmax-for-thread-test DESTINATION bin)
+target_compile_options(record-minmax-for-thread-test PUBLIC -fsanitize=thread)
+target_link_libraries(record-minmax-for-thread-test -fsanitize=thread)
+
 file(GLOB_RECURSE TESTS "tests/*.test.cpp")
 
 nnas_find_package(GTest REQUIRED)

--- a/compiler/record-minmax/CMakeLists.txt
+++ b/compiler/record-minmax/CMakeLists.txt
@@ -24,6 +24,8 @@ if(NOT ENABLE_TEST)
 endif(NOT ENABLE_TEST)
 
 # create record-minmax-for-thread-test target
+# Note: record-minmax-for-thread-test is built with -fsanitize=thread so that thread sanitizer can check memory bugs,
+# record-minmax is built without the option for performance.
 add_executable(record-minmax-for-thread-test ${DRIVER} ${SOURCES})
 target_include_directories(record-minmax-for-thread-test PRIVATE include)
 
@@ -36,6 +38,7 @@ target_link_libraries(record-minmax-for-thread-test luci_interpreter)
 target_link_libraries(record-minmax-for-thread-test dio_hdf5)
 target_link_libraries(record-minmax-for-thread-test vconone)
 target_link_libraries(record-minmax-for-thread-test nncc_coverage)
+target_link_libraries(record-minmax-for-thread-test luci_log)
 
 install(TARGETS record-minmax-for-thread-test DESTINATION bin)
 target_compile_options(record-minmax-for-thread-test PUBLIC -fsanitize=thread)

--- a/compiler/record-minmax/CMakeLists.txt
+++ b/compiler/record-minmax/CMakeLists.txt
@@ -40,7 +40,6 @@ target_link_libraries(record-minmax-for-thread-test vconone)
 target_link_libraries(record-minmax-for-thread-test nncc_coverage)
 target_link_libraries(record-minmax-for-thread-test luci_log)
 
-install(TARGETS record-minmax-for-thread-test DESTINATION bin)
 target_compile_options(record-minmax-for-thread-test PUBLIC -fsanitize=thread)
 target_link_libraries(record-minmax-for-thread-test -fsanitize=thread)
 


### PR DESCRIPTION
This PR creates record-minmax-for-thread-test target.

for issue https://github.com/Samsung/ONE/issues/10133
from draft: https://github.com/Samsung/ONE/pull/10132

ONE-DCO-1.0-Signed-off-by: Artem Balyshev <a.balyshev@samsung.com>