### PR TITLE
[onert] Introduce SingleModelExecutors

### DIFF
--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -89,7 +89,7 @@ std::shared_ptr<CompilerArtifact> Compiler::compile(void)
   //       execution between interpreter and compiled executor (including control flow)
   if (_options->disable_compile)
   {
-    auto executors = std::make_shared<exec::Executors>();
+    auto executors = std::make_shared<exec::SingleModelExecutors>();
 
     _model->iterate([&](const ir::SubgraphIndex &index, ir::Graph &subg) {
       executors->emplace(ir::ModelIndex{0}, index, std::make_unique<interp::InterpExecutor>(subg));
@@ -106,9 +106,6 @@ std::shared_ptr<CompilerArtifact> Compiler::compile(void)
 
   // Tracing context
   auto tracing_ctx = std::make_unique<util::TracingCtx>();
-
-  // Model edge context
-  std::unique_ptr<ir::ModelEdges> model_edges = nullptr;
 
   // Lower: Assign backend
   std::unordered_map<ir::SubgraphIndex, std::unique_ptr<compiler::LoweredGraph>> lowered_subgs;
@@ -164,7 +161,7 @@ std::shared_ptr<CompilerArtifact> Compiler::compile(void)
   /*************************************************************
    *  Backend independent analysis & optimization phase finished
    *************************************************************/
-  auto executors = std::make_shared<exec::Executors>(std::move(model_edges));
+  auto executors = std::make_shared<exec::SingleModelExecutors>();
   for (auto &pair : lowered_subgs)
   {
     auto const model_index = ir::ModelIndex{0};

--- a/runtime/onert/core/src/exec/Executors.h
+++ b/runtime/onert/core/src/exec/Executors.h
@@ -41,12 +41,43 @@ namespace exec
 {
 
 /**
+ * @brief Class to gather single model's executors
+ */
+class SingleModelExecutors : public IExecutors
+{
+public:
+  SingleModelExecutors(void) = default;
+  SingleModelExecutors(const SingleModelExecutors &) = delete;
+  SingleModelExecutors(SingleModelExecutors &&) = default;
+  ~SingleModelExecutors() = default;
+
+  // TODO Use Executor index
+  void emplace(const ir::ModelIndex &model_index, const ir::SubgraphIndex &subg_index,
+               std::unique_ptr<IExecutor> exec);
+
+  IExecutor *at(const ir::ModelIndex &model_index, const ir::SubgraphIndex &subg_index) const;
+
+  uint32_t inputSize() const;
+
+  uint32_t outputSize() const;
+
+  const ir::OperandInfo inputInfo(const ir::IOIndex &index);
+
+  const ir::OperandInfo outputInfo(const ir::IOIndex &index);
+
+  void execute(const IODescription &desc);
+
+private:
+  std::unordered_map<ir::SubgraphIndex, std::unique_ptr<IExecutor>> _executors;
+};
+
+/**
  * @brief Class to gather executors
  */
 class Executors : public IExecutors
 {
 public:
-  Executors(void) = default;
+  Executors(void) = delete;
   Executors(std::unique_ptr<ir::ModelEdges> model_edges) { _model_edges = std::move(model_edges); }
   Executors(const Executors &) = delete;
   Executors(Executors &&) = default;
@@ -70,7 +101,6 @@ public:
 
 private:
   void checkSupportedMultimodel() const;
-  void executeModels(const IODescription &desc);
   uint16_t modelCount() const;
 
 private:

--- a/runtime/onert/core/src/interp/InterpExecutor.test.cc
+++ b/runtime/onert/core/src/interp/InterpExecutor.test.cc
@@ -31,7 +31,7 @@ namespace
 using namespace onert::ir;
 using InterpExecutor = onert::interp::InterpExecutor;
 using Execution = onert::exec::Execution;
-using Executors = onert::exec::Executors;
+using Executors = onert::exec::SingleModelExecutors;
 
 class InterpExecutorTest : public ::testing::Test
 {


### PR DESCRIPTION
This commit introduces `SingleModelExecutors` to separate single and multi model's executors implementation.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: #10004