### PR TITLE
[onert] Revisit IExecutors and derivered

### DIFF
--- a/runtime/onert/core/include/exec/IExecutors.h
+++ b/runtime/onert/core/include/exec/IExecutors.h
@@ -50,9 +50,9 @@ public:
 
   virtual uint32_t outputSize() const = 0;
 
-  virtual const ir::OperandInfo inputInfo(const ir::IOIndex &index) = 0;
+  virtual const ir::OperandInfo &inputInfo(const ir::IOIndex &index) const = 0;
 
-  virtual const ir::OperandInfo outputInfo(const ir::IOIndex &index) = 0;
+  virtual const ir::OperandInfo &outputInfo(const ir::IOIndex &index) const = 0;
 
   virtual void execute(const IODescription &desc) = 0;
 };

--- a/runtime/onert/core/src/exec/Executors.cc
+++ b/runtime/onert/core/src/exec/Executors.cc
@@ -45,13 +45,13 @@ uint32_t SingleModelExecutors::outputSize() const
   return entryExecutor()->graph().getOutputs().size();
 }
 
-const ir::OperandInfo SingleModelExecutors::inputInfo(const ir::IOIndex &index)
+const ir::OperandInfo &SingleModelExecutors::inputInfo(const ir::IOIndex &index) const
 {
   const auto input_index = entryExecutor()->graph().getInputs().at(index);
   return entryExecutor()->graph().operands().at(input_index).info();
 }
 
-const ir::OperandInfo SingleModelExecutors::outputInfo(const ir::IOIndex &index)
+const ir::OperandInfo &SingleModelExecutors::outputInfo(const ir::IOIndex &index) const
 {
   auto output_index = entryExecutor()->graph().getOutputs().at(index);
   return entryExecutor()->graph().operands().at(output_index).info();
@@ -75,7 +75,7 @@ uint32_t Executors::inputSize() const { return _model_edges->pkg_inputs.size(); 
 
 uint32_t Executors::outputSize() const { return _model_edges->pkg_outputs.size(); }
 
-const ir::OperandInfo Executors::inputInfo(const ir::IOIndex &index)
+const ir::OperandInfo &Executors::inputInfo(const ir::IOIndex &index) const
 {
   auto const desc = _model_edges->pkg_inputs[index.value()];
   auto const model_index = std::get<0>(desc);
@@ -85,7 +85,7 @@ const ir::OperandInfo Executors::inputInfo(const ir::IOIndex &index)
   return executor->graph().operands().at(input_index).info();
 }
 
-const ir::OperandInfo Executors::outputInfo(const ir::IOIndex &index)
+const ir::OperandInfo &Executors::outputInfo(const ir::IOIndex &index) const
 {
   auto const desc = _model_edges->pkg_outputs[index.value()];
   auto const model_index = std::get<0>(desc);

--- a/runtime/onert/core/src/exec/Executors.h
+++ b/runtime/onert/core/src/exec/Executors.h
@@ -53,19 +53,20 @@ public:
 
   // TODO Use Executor index
   void emplace(const ir::ModelIndex &model_index, const ir::SubgraphIndex &subg_index,
-               std::unique_ptr<IExecutor> exec);
+               std::unique_ptr<IExecutor> exec) override;
 
-  IExecutor *at(const ir::ModelIndex &model_index, const ir::SubgraphIndex &subg_index) const;
+  IExecutor *at(const ir::ModelIndex &model_index,
+                const ir::SubgraphIndex &subg_index) const override;
 
-  uint32_t inputSize() const;
+  uint32_t inputSize() const override;
 
-  uint32_t outputSize() const;
+  uint32_t outputSize() const override;
 
-  const ir::OperandInfo inputInfo(const ir::IOIndex &index);
+  const ir::OperandInfo &inputInfo(const ir::IOIndex &index) const override;
 
-  const ir::OperandInfo outputInfo(const ir::IOIndex &index);
+  const ir::OperandInfo &outputInfo(const ir::IOIndex &index) const override;
 
-  void execute(const IODescription &desc);
+  void execute(const IODescription &desc) override;
 
 private:
   std::unordered_map<ir::SubgraphIndex, std::unique_ptr<IExecutor>> _executors;
@@ -85,19 +86,20 @@ public:
 
   // TODO Use Executor index
   void emplace(const ir::ModelIndex &model_index, const ir::SubgraphIndex &subg_index,
-               std::unique_ptr<IExecutor> exec);
+               std::unique_ptr<IExecutor> exec) override;
 
-  IExecutor *at(const ir::ModelIndex &model_index, const ir::SubgraphIndex &subg_index) const;
+  IExecutor *at(const ir::ModelIndex &model_index,
+                const ir::SubgraphIndex &subg_index) const override;
 
-  uint32_t inputSize() const;
+  uint32_t inputSize() const override;
 
-  uint32_t outputSize() const;
+  uint32_t outputSize() const override;
 
-  const ir::OperandInfo inputInfo(const ir::IOIndex &index);
+  const ir::OperandInfo &inputInfo(const ir::IOIndex &index) const override;
 
-  const ir::OperandInfo outputInfo(const ir::IOIndex &index);
+  const ir::OperandInfo &outputInfo(const ir::IOIndex &index) const override;
 
-  void execute(const IODescription &desc);
+  void execute(const IODescription &desc) override;
 
 private:
   void checkSupportedMultimodel() const;


### PR DESCRIPTION
This commit updates IExecutors and derivered classes.
- Add override keyword
- Update inputInfo/outputInfo to return reference with method const keyword

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>