### PR TITLE
[onert] Separate IExecutors derive classes

### DIFF
--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -23,7 +23,7 @@
 #include "pass/PassRunner.h"
 #include "pass/UnusedOperandEliminationPass.h"
 #include "../dumper/dot/DotDumper.h"
-#include "../exec/Executors.h"
+#include "../exec/SingleModelExecutors.h"
 #include "../interp/InterpExecutor.h"
 #include "../ir/OperationDumper.h"
 #include "../ir/verifier/Verifier.h"

--- a/runtime/onert/core/src/exec/Executors.cc
+++ b/runtime/onert/core/src/exec/Executors.cc
@@ -23,42 +23,6 @@ namespace onert
 namespace exec
 {
 
-void SingleModelExecutors::emplace(const ir::ModelIndex &, const ir::SubgraphIndex &subg_index,
-                                   std::unique_ptr<IExecutor> exec)
-{
-  _executors.emplace(subg_index, std::move(exec));
-}
-
-IExecutor *SingleModelExecutors::at(const ir::ModelIndex &,
-                                    const ir::SubgraphIndex &subg_index) const
-{
-  return _executors.at(subg_index).get();
-}
-
-uint32_t SingleModelExecutors::inputSize() const
-{
-  return entryExecutor()->graph().getInputs().size();
-}
-
-uint32_t SingleModelExecutors::outputSize() const
-{
-  return entryExecutor()->graph().getOutputs().size();
-}
-
-const ir::OperandInfo &SingleModelExecutors::inputInfo(const ir::IOIndex &index) const
-{
-  const auto input_index = entryExecutor()->graph().getInputs().at(index);
-  return entryExecutor()->graph().operands().at(input_index).info();
-}
-
-const ir::OperandInfo &SingleModelExecutors::outputInfo(const ir::IOIndex &index) const
-{
-  auto output_index = entryExecutor()->graph().getOutputs().at(index);
-  return entryExecutor()->graph().operands().at(output_index).info();
-}
-
-void SingleModelExecutors::execute(const IODescription &desc) { entryExecutor()->execute(desc); }
-
 void Executors::emplace(const ir::ModelIndex &model_index, const ir::SubgraphIndex &subg_index,
                         std::unique_ptr<IExecutor> exec)
 {

--- a/runtime/onert/core/src/exec/SingleModelExecutors.cc
+++ b/runtime/onert/core/src/exec/SingleModelExecutors.cc
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "SingleModelExecutors.h"
+
+namespace onert
+{
+namespace exec
+{
+
+void SingleModelExecutors::emplace(const ir::ModelIndex &, const ir::SubgraphIndex &subg_index,
+                                   std::unique_ptr<IExecutor> exec)
+{
+  _executors.emplace(subg_index, std::move(exec));
+}
+
+IExecutor *SingleModelExecutors::at(const ir::ModelIndex &,
+                                    const ir::SubgraphIndex &subg_index) const
+{
+  return _executors.at(subg_index).get();
+}
+
+uint32_t SingleModelExecutors::inputSize() const
+{
+  return entryExecutor()->graph().getInputs().size();
+}
+
+uint32_t SingleModelExecutors::outputSize() const
+{
+  return entryExecutor()->graph().getOutputs().size();
+}
+
+const ir::OperandInfo &SingleModelExecutors::inputInfo(const ir::IOIndex &index) const
+{
+  const auto input_index = entryExecutor()->graph().getInputs().at(index);
+  return entryExecutor()->graph().operands().at(input_index).info();
+}
+
+const ir::OperandInfo &SingleModelExecutors::outputInfo(const ir::IOIndex &index) const
+{
+  auto output_index = entryExecutor()->graph().getOutputs().at(index);
+  return entryExecutor()->graph().operands().at(output_index).info();
+}
+
+void SingleModelExecutors::execute(const IODescription &desc) { entryExecutor()->execute(desc); }
+
+} // namespace exec
+} // namespace onert

--- a/runtime/onert/core/src/exec/SingleModelExecutors.h
+++ b/runtime/onert/core/src/exec/SingleModelExecutors.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,26 +14,11 @@
  * limitations under the License.
  */
 
-#ifndef __ONERT_EXEC_EXECUTORS_H__
-#define __ONERT_EXEC_EXECUTORS_H__
+#ifndef __ONERT_EXEC_SINGLE_MODEL_EXECUTORS_H__
+#define __ONERT_EXEC_SINGLE_MODEL_EXECUTORS_H__
 
 #include "exec/IExecutors.h"
 #include "ir/NNPkg.h"
-
-namespace std
-{
-
-template <> struct hash<std::pair<::onert::ir::ModelIndex, ::onert::ir::SubgraphIndex>>
-{
-  size_t
-  operator()(const std::pair<::onert::ir::ModelIndex, ::onert::ir::SubgraphIndex> &pair) const
-    noexcept
-  {
-    return (hash<uint32_t>()(pair.first.value()) << 16) ^ hash<uint32_t>()(pair.second.value());
-  }
-};
-
-} // namespace std
 
 namespace onert
 {
@@ -41,18 +26,24 @@ namespace exec
 {
 
 /**
- * @brief Class to gather executors
+ * @brief Class to gather executor set for single model NN package
  */
-class Executors : public IExecutors
+class SingleModelExecutors : public IExecutors
 {
 public:
-  Executors(void) = delete;
-  Executors(std::unique_ptr<ir::ModelEdges> model_edges) { _model_edges = std::move(model_edges); }
-  Executors(const Executors &) = delete;
-  Executors(Executors &&) = default;
-  ~Executors() = default;
+  /**
+   * @brief Construct a new SingleModelExecutors object
+   */
+  SingleModelExecutors(void) = default;
+  SingleModelExecutors(const SingleModelExecutors &) = delete;
+  SingleModelExecutors(SingleModelExecutors &&) = default;
 
-  // TODO Use Executor index
+  /**
+   * @brief Destroy the SingleModelExecutors object
+   */
+  ~SingleModelExecutors() = default;
+
+public:
   void emplace(const ir::ModelIndex &model_index, const ir::SubgraphIndex &subg_index,
                std::unique_ptr<IExecutor> exec) override;
 
@@ -70,17 +61,10 @@ public:
   void execute(const IODescription &desc) override;
 
 private:
-  void checkSupportedMultimodel() const;
-  uint16_t modelCount() const;
-
-private:
-  std::unordered_map<std::pair<ir::ModelIndex, ir::SubgraphIndex>, std::unique_ptr<IExecutor>>
-    _executors;
-  // NOTE _model_edges may use different struct type for executor implementation
-  std::unique_ptr<ir::ModelEdges> _model_edges;
+  std::unordered_map<ir::SubgraphIndex, std::unique_ptr<IExecutor>> _executors;
 };
 
 } // namespace exec
 } // namespace onert
 
-#endif // __ONERT_EXEC_EXECUTORS_H__
+#endif // __ONERT_EXEC_SINGLE_MODEL_EXECUTORS_H__

--- a/runtime/onert/core/src/interp/InterpExecutor.test.cc
+++ b/runtime/onert/core/src/interp/InterpExecutor.test.cc
@@ -15,7 +15,7 @@
  */
 
 #include "InterpExecutor.h"
-#include "../exec/Executors.h"
+#include "../exec/SingleModelExecutors.h"
 
 #include "exec/Execution.h"
 #include "ir/Graph.h"


### PR DESCRIPTION
This commit separates implementation file for Executors and SingleModelExecutors.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>