### PR TITLE
[record-minmax] Build thread test in 64bit arch

### DIFF
--- a/compiler/record-minmax/CMakeLists.txt
+++ b/compiler/record-minmax/CMakeLists.txt
@@ -23,25 +23,30 @@ if(NOT ENABLE_TEST)
   return()
 endif(NOT ENABLE_TEST)
 
-# create record-minmax-for-thread-test target
-# Note: record-minmax-for-thread-test is built with -fsanitize=thread so that thread sanitizer can check memory bugs,
-# record-minmax is built without the option for performance.
-add_executable(record-minmax-for-thread-test ${DRIVER} ${SOURCES})
-target_include_directories(record-minmax-for-thread-test PRIVATE include)
+# Build record-minmax-for-thread-test if target arch is 64bit
+# Thread sanitizer is only available on 64bit machine
+# (https://github.com/google/sanitizers/wiki/ThreadSanitizerCppManual#supported-platforms)
+if("${CMAKE_SIZEOF_VOID_P}" STREQUAL "8")
+  # create record-minmax-for-thread-test target
+  # Note: record-minmax-for-thread-test is built with -fsanitize=thread so that thread sanitizer can check memory bugs,
+  # record-minmax is built without the option for performance.
+  add_executable(record-minmax-for-thread-test ${DRIVER} ${SOURCES})
+  target_include_directories(record-minmax-for-thread-test PRIVATE include)
 
-target_link_libraries(record-minmax-for-thread-test arser)
-target_link_libraries(record-minmax-for-thread-test safemain)
-target_link_libraries(record-minmax-for-thread-test luci_import)
-target_link_libraries(record-minmax-for-thread-test luci_env)
-target_link_libraries(record-minmax-for-thread-test luci_export)
-target_link_libraries(record-minmax-for-thread-test luci_interpreter)
-target_link_libraries(record-minmax-for-thread-test dio_hdf5)
-target_link_libraries(record-minmax-for-thread-test vconone)
-target_link_libraries(record-minmax-for-thread-test nncc_coverage)
-target_link_libraries(record-minmax-for-thread-test luci_log)
+  target_link_libraries(record-minmax-for-thread-test arser)
+  target_link_libraries(record-minmax-for-thread-test safemain)
+  target_link_libraries(record-minmax-for-thread-test luci_import)
+  target_link_libraries(record-minmax-for-thread-test luci_env)
+  target_link_libraries(record-minmax-for-thread-test luci_export)
+  target_link_libraries(record-minmax-for-thread-test luci_interpreter)
+  target_link_libraries(record-minmax-for-thread-test dio_hdf5)
+  target_link_libraries(record-minmax-for-thread-test vconone)
+  target_link_libraries(record-minmax-for-thread-test nncc_coverage)
+  target_link_libraries(record-minmax-for-thread-test luci_log)
 
-target_compile_options(record-minmax-for-thread-test PUBLIC -fsanitize=thread)
-target_link_libraries(record-minmax-for-thread-test -fsanitize=thread)
+  target_compile_options(record-minmax-for-thread-test PUBLIC -fsanitize=thread)
+  target_link_libraries(record-minmax-for-thread-test -fsanitize=thread)
+endif("${CMAKE_SIZEOF_VOID_P}" STREQUAL "8")
 
 file(GLOB_RECURSE TESTS "tests/*.test.cpp")
 


### PR DESCRIPTION
This builds thread test only in 64bit arch.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related https://github.com/Samsung/ONE/issues/10313