### PR TITLE
[onert] Change the time measurement method

### DIFF
--- a/runtime/libs/benchmark/src/Phases.cpp
+++ b/runtime/libs/benchmark/src/Phases.cpp
@@ -22,16 +22,16 @@
 #include <cassert>
 #include <chrono>
 #include <iostream>
-#include <sys/time.h>
+#include <time.h>
 
 namespace
 {
 
 uint64_t nowMicros()
 {
-  struct timeval tv;
-  gettimeofday(&tv, nullptr);
-  return static_cast<uint64_t>(tv.tv_sec) * 1e6 + tv.tv_usec;
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return static_cast<uint64_t>(ts.tv_nsec) / 1e3 + static_cast<uint64_t>(ts.tv_sec) * 1e6;
 }
 
 void SleepForMicros(uint64_t micros)

--- a/runtime/libs/profiling/src/profiling/time.cpp
+++ b/runtime/libs/profiling/src/profiling/time.cpp
@@ -25,7 +25,7 @@
 #if defined(_MSC_VER)
 #include <chrono>  // NOLINT(build/c++11)
 #else
-#include <sys/time.h>
+#include <time.h>
 #endif
 
 namespace tflite {
@@ -43,9 +43,9 @@ uint64_t NowMicros() {
 #else
 
 uint64_t NowMicros() {
-  struct timeval tv;
-  gettimeofday(&tv, nullptr);
-  return static_cast<uint64_t>(tv.tv_sec) * 1000000 + tv.tv_usec;
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return static_cast<uint64_t>(ts.tv_nsec) / 1e3 + static_cast<uint64_t>(ts.tv_sec) * 1e6;
 }
 
 #endif  // defined(_MSC_VER)


### PR DESCRIPTION
This commit uses `clock_gettime` instead of `gettimeofday`. POSIX.1-2008 marks gettimeofday() as obsolete,
and recommending the use of `clock_gettime` instead. https://man7.org/linux/man-pages/man2/settimeofday.2.html

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>