### PR TITLE
[one-cmds] Revisit function naming in utils.py

### DIFF
--- a/compiler/one-cmds/one-build
+++ b/compiler/one-cmds/one-build
@@ -35,9 +35,9 @@ def _get_parser():
     parser = argparse.ArgumentParser(
         description='command line tool to run ONE drivers in customized order')
 
-    _utils._add_default_arg(parser)
+    _utils.add_default_arg(parser)
 
-    opt_name_list = _utils._get_optimization_list(get_name=True)
+    opt_name_list = _utils.get_optimization_list(get_name=True)
     opt_name_list = ['-' + s for s in opt_name_list]
     if not opt_name_list:
         opt_help_message = '(No available optimization options)'
@@ -54,7 +54,7 @@ def _parse_arg(parser):
     args = parser.parse_args()
     # print version
     if args.version:
-        _utils._print_version_and_exit(__file__)
+        _utils.print_version_and_exit(__file__)
 
     return args
 
@@ -62,12 +62,12 @@ def _parse_arg(parser):
 def _verify_arg(parser, args):
     """verify given arguments"""
     # check if required arguments is given
-    if not _utils._is_valid_attr(args, 'config'):
+    if not _utils.is_valid_attr(args, 'config'):
         parser.error('-C/--config argument is required')
     # check if given optimization option exists
-    opt_name_list = _utils._get_optimization_list(get_name=True)
-    opt_name_list = [_utils._remove_prefix(s, 'O') for s in opt_name_list]
-    if _utils._is_valid_attr(args, 'O'):
+    opt_name_list = _utils.get_optimization_list(get_name=True)
+    opt_name_list = [_utils.remove_prefix(s, 'O') for s in opt_name_list]
+    if _utils.is_valid_attr(args, 'O'):
         if ' ' in getattr(args, 'O'):
             parser.error('Not allowed to have space in the optimization name')
         if not getattr(args, 'O') in opt_name_list:
@@ -88,7 +88,7 @@ def _get_driver_name(driver_name):
     }[driver_name]
 
 
-def _parse_cfg(args):
+def parse_cfg(args):
     config = configparser.ConfigParser()
     config.optionxform = str
     parsed = config.read(os.path.expanduser(getattr(args, 'config')))
@@ -121,12 +121,12 @@ def _verify_cfg(driver_list, config):
 
 # verify given optimization option file
 def _verify_opt(args):
-    if _utils._is_valid_attr(args, 'O'):
+    if _utils.is_valid_attr(args, 'O'):
         config = configparser.ConfigParser()
         config.optionxform = str
         opt_name_path_dic = dict(
-            zip(_utils._get_optimization_list(get_name=True),
-                _utils._get_optimization_list()))
+            zip(_utils.get_optimization_list(get_name=True),
+                _utils.get_optimization_list()))
         parsed = config.read(opt_name_path_dic['O' + getattr(args, 'O')])
         # check if given optimization option file exists
         if not parsed:
@@ -151,11 +151,11 @@ def main():
     _verify_arg(parser, args)
 
     # parse configuration file
-    config = _parse_cfg(args)
+    config = parse_cfg(args)
 
     # verify configuration file
     bin_dir = os.path.dirname(os.path.realpath(__file__))
-    import_drivers_dict = _utils._detect_one_import_drivers(bin_dir)
+    import_drivers_dict = _utils.detect_one_import_drivers(bin_dir)
     transform_drivers = [
         'one-optimize', 'one-quantize', 'one-pack', 'one-codegen', 'one-profile',
         'one-partition'
@@ -181,10 +181,10 @@ def main():
             driver_name = _get_driver_name(section)
         driver_path = os.path.join(dir_path, driver_name)
         cmd = [driver_path, '--config', getattr(args, 'config'), '--section', section]
-        if section == 'one-optimize' and _utils._is_valid_attr(args, 'O'):
+        if section == 'one-optimize' and _utils.is_valid_attr(args, 'O'):
             cmd += ['-O', getattr(args, 'O')]
-        _utils._run(cmd)
+        _utils.run(cmd)
 
 
 if __name__ == '__main__':
-    _utils._safemain(main, __file__)
+    _utils.safemain(main, __file__)

--- a/compiler/one-cmds/one-codegen
+++ b/compiler/one-cmds/one-codegen
@@ -79,7 +79,7 @@ def _get_parser(backends_list):
     parser = argparse.ArgumentParser(
         description='command line tool for code generation', usage=codegen_usage)
 
-    _utils._add_default_arg(parser)
+    _utils.add_default_arg(parser)
 
     # get backend list in the directory
     backends_name = [ntpath.basename(f) for f in backends_list]
@@ -98,7 +98,7 @@ def _verify_arg(parser, args):
     """verify given arguments"""
     # check if required arguments is given
     missing = []
-    if not _utils._is_valid_attr(args, 'backend'):
+    if not _utils.is_valid_attr(args, 'backend'):
         missing.append('-b/--backend')
     if len(missing):
         parser.error('the following arguments are required: ' + ' '.join(missing))
@@ -125,7 +125,7 @@ def _parse_arg(parser):
         codegen_args = parser.parse_args(codegen_args)
     # print version
     if len(args) and codegen_args.version:
-        _utils._print_version_and_exit(__file__)
+        _utils.print_version_and_exit(__file__)
 
     return codegen_args, backend_args, unknown_args
 
@@ -139,7 +139,7 @@ def main():
     args, backend_args, unknown_args = _parse_arg(parser)
 
     # parse configuration file
-    _utils._parse_cfg(args, 'one-codegen')
+    _utils.parse_cfg(args, 'one-codegen')
 
     # verify arguments
     _verify_arg(parser, args)
@@ -157,12 +157,12 @@ def main():
     if not codegen_path:
         raise FileNotFoundError(backend_base + ' not found')
     codegen_cmd = [codegen_path] + backend_args + unknown_args
-    if _utils._is_valid_attr(args, 'command'):
+    if _utils.is_valid_attr(args, 'command'):
         codegen_cmd += getattr(args, 'command').split()
 
     # run backend driver
-    _utils._run(codegen_cmd, err_prefix=backend_base)
+    _utils.run(codegen_cmd, err_prefix=backend_base)
 
 
 if __name__ == '__main__':
-    _utils._safemain(main, __file__)
+    _utils.safemain(main, __file__)

--- a/compiler/one-cmds/one-import
+++ b/compiler/one-cmds/one-import
@@ -79,7 +79,7 @@ def _convert(args, unknown_args):
     dir_path = os.path.dirname(os.path.realpath(__file__))
     # make cmd
     cmd = [sys.executable, os.path.join(dir_path, _get_driver_name(args.driver))]
-    if _utils._is_valid_attr(args, 'config'):
+    if _utils.is_valid_attr(args, 'config'):
         cmd.append('--config')
         cmd.append(os.path.expanduser(args.config))
     return_code = subprocess.call(cmd + unknown_args)
@@ -100,4 +100,4 @@ def main():
 
 
 if __name__ == '__main__':
-    _utils._safemain(main, __file__)
+    _utils.safemain(main, __file__)

--- a/compiler/one-cmds/one-import-bcq
+++ b/compiler/one-cmds/one-import-bcq
@@ -40,7 +40,7 @@ def _get_parser():
     parser = argparse.ArgumentParser(
         description='command line tool to convert TensorFlow with BCQ to circle')
 
-    _utils._add_default_arg(parser)
+    _utils.add_default_arg(parser)
 
     ## tf2tfliteV2 arguments
     tf2tfliteV2_group = parser.add_argument_group('converter arguments')
@@ -94,9 +94,9 @@ def _verify_arg(parser, args):
     """verify given arguments"""
     # check if required arguments is given
     missing = []
-    if not _utils._is_valid_attr(args, 'input_path'):
+    if not _utils.is_valid_attr(args, 'input_path'):
         missing.append('-i/--input_path')
-    if not _utils._is_valid_attr(args, 'output_path'):
+    if not _utils.is_valid_attr(args, 'output_path'):
         missing.append('-o/--output_path')
     if len(missing):
         parser.error('the following arguments are required: ' + ' '.join(missing))
@@ -106,7 +106,7 @@ def _parse_arg(parser):
     args = parser.parse_args()
     # print version
     if args.version:
-        _utils._print_version_and_exit(__file__)
+        _utils.print_version_and_exit(__file__)
 
     return args
 
@@ -115,15 +115,15 @@ def _make_generate_bcq_metadata_cmd(args, driver_path, output_path):
     """make a command for running generate_bcq_metadata"""
     cmd = [sys.executable, driver_path]
     # input_path
-    if _utils._is_valid_attr(args, 'input_path'):
+    if _utils.is_valid_attr(args, 'input_path'):
         cmd.append('--input_path')
         cmd.append(os.path.expanduser(getattr(args, 'input_path')))
     # output_path
-    if _utils._is_valid_attr(args, 'output_path'):
+    if _utils.is_valid_attr(args, 'output_path'):
         cmd.append('--output_path')
         cmd.append(os.path.expanduser(output_path))
     # output_arrays
-    if _utils._is_valid_attr(args, 'output_arrays'):
+    if _utils.is_valid_attr(args, 'output_arrays'):
         cmd.append('--output_arrays')
         cmd.append(getattr(args, 'output_arrays'))
 
@@ -147,7 +147,7 @@ def _convert(args):
         f.write((' '.join(generate_bcq_metadata_cmd) + '\n').encode())
 
         # generate BCQ information metadata
-        _utils._run(generate_bcq_metadata_cmd, logfile=f)
+        _utils.run(generate_bcq_metadata_cmd, logfile=f)
 
         # get output_arrays with BCQ
         bcq_output_arrays = _bcq_info_gen.get_bcq_output_arrays(
@@ -171,7 +171,7 @@ def _convert(args):
         f.write((' '.join(tf2tfliteV2_cmd) + '\n').encode())
 
         # convert tf to tflite
-        _utils._run(tf2tfliteV2_cmd, logfile=f)
+        _utils.run(tf2tfliteV2_cmd, logfile=f)
 
         # make a command to convert from tflite to circle
         tflite2circle_path = os.path.join(dir_path, 'tflite2circle')
@@ -182,7 +182,7 @@ def _convert(args):
         f.write((' '.join(tflite2circle_cmd) + '\n').encode())
 
         # convert tflite to circle
-        _utils._run(tflite2circle_cmd, logfile=f)
+        _utils.run(tflite2circle_cmd, logfile=f)
 
 
 def main():
@@ -191,7 +191,7 @@ def main():
     args = _parse_arg(parser)
 
     # parse configuration file
-    _utils._parse_cfg(args, 'one-import-bcq')
+    _utils.parse_cfg(args, 'one-import-bcq')
 
     # verify arguments
     _verify_arg(parser, args)
@@ -201,4 +201,4 @@ def main():
 
 
 if __name__ == '__main__':
-    _utils._safemain(main, __file__)
+    _utils.safemain(main, __file__)

--- a/compiler/one-cmds/one-import-onnx
+++ b/compiler/one-cmds/one-import-onnx
@@ -49,7 +49,7 @@ def _get_parser():
     parser = argparse.ArgumentParser(
         description='command line tool to convert ONNX to circle')
 
-    _utils._add_default_arg(parser)
+    _utils.add_default_arg(parser)
 
     ## tf2tfliteV2 arguments
     tf2tfliteV2_group = parser.add_argument_group('converter arguments')
@@ -105,9 +105,9 @@ def _verify_arg(parser, args):
     """verify given arguments"""
     # check if required arguments is given
     missing = []
-    if not _utils._is_valid_attr(args, 'input_path'):
+    if not _utils.is_valid_attr(args, 'input_path'):
         missing.append('-i/--input_path')
-    if not _utils._is_valid_attr(args, 'output_path'):
+    if not _utils.is_valid_attr(args, 'output_path'):
         missing.append('-o/--output_path')
     if len(missing):
         parser.error('the following arguments are required: ' + ' '.join(missing))
@@ -117,7 +117,7 @@ def _parse_arg(parser):
     args = parser.parse_args()
     # print version
     if args.version:
-        _utils._print_version_and_exit(__file__)
+        _utils.print_version_and_exit(__file__)
 
     return args
 
@@ -203,18 +203,18 @@ def _convert(args):
 
     with open(logfile_path, 'wb') as f, tempfile.TemporaryDirectory() as tmpdir:
         # save intermediate
-        if _utils._is_valid_attr(args, 'save_intermediate'):
+        if _utils.is_valid_attr(args, 'save_intermediate'):
             tmpdir = os.path.dirname(logfile_path)
         # convert onnx to tf saved model
         onnx_model = onnx.load(getattr(args, 'input_path'))
         if _onnx_legalizer_enabled:
             options = onnx_legalizer.LegalizeOptions
-            options.unroll_rnn = _utils._is_valid_attr(args, 'unroll_rnn')
-            options.unroll_lstm = _utils._is_valid_attr(args, 'unroll_lstm')
+            options.unroll_rnn = _utils.is_valid_attr(args, 'unroll_rnn')
+            options.unroll_lstm = _utils.is_valid_attr(args, 'unroll_lstm')
             onnx_legalizer.legalize(onnx_model, options)
-        if _utils._is_valid_attr(args, 'keep_io_order'):
+        if _utils.is_valid_attr(args, 'keep_io_order'):
             _remap_io_names(onnx_model)
-            if _utils._is_valid_attr(args, 'save_intermediate'):
+            if _utils.is_valid_attr(args, 'save_intermediate'):
                 basename = os.path.basename(getattr(args, 'input_path'))
                 fixed_path = os.path.join(tmpdir,
                                           os.path.splitext(basename)[0] + '~.onnx')
@@ -238,7 +238,7 @@ def _convert(args):
         f.write((' '.join(tf2tfliteV2_cmd) + '\n').encode())
 
         # convert tf to tflite
-        _utils._run(tf2tfliteV2_cmd, logfile=f)
+        _utils.run(tf2tfliteV2_cmd, logfile=f)
 
         # make a command to convert from tflite to circle
         tflite2circle_path = os.path.join(dir_path, 'tflite2circle')
@@ -249,7 +249,7 @@ def _convert(args):
         f.write((' '.join(tflite2circle_cmd) + '\n').encode())
 
         # convert tflite to circle
-        _utils._run(tflite2circle_cmd, err_prefix="tflite2circle", logfile=f)
+        _utils.run(tflite2circle_cmd, err_prefix="tflite2circle", logfile=f)
 
 
 def main():
@@ -258,7 +258,7 @@ def main():
     args = _parse_arg(parser)
 
     # parse configuration file
-    _utils._parse_cfg(args, 'one-import-onnx')
+    _utils.parse_cfg(args, 'one-import-onnx')
 
     # verify arguments
     _verify_arg(parser, args)
@@ -268,4 +268,4 @@ def main():
 
 
 if __name__ == '__main__':
-    _utils._safemain(main, __file__)
+    _utils.safemain(main, __file__)

--- a/compiler/one-cmds/one-import-pytorch
+++ b/compiler/one-cmds/one-import-pytorch
@@ -47,7 +47,7 @@ def _get_parser():
     parser = argparse.ArgumentParser(
         description='command line tool to convert PyTorch to Circle')
 
-    _utils._add_default_arg(parser)
+    _utils.add_default_arg(parser)
 
     ## converter arguments
     converter_group = parser.add_argument_group('converter arguments')
@@ -96,13 +96,13 @@ def _verify_arg(parser, args):
     """verify given arguments"""
     # check if required arguments is given
     missing = []
-    if not _utils._is_valid_attr(args, 'input_path'):
+    if not _utils.is_valid_attr(args, 'input_path'):
         missing.append('-i/--input_path')
-    if not _utils._is_valid_attr(args, 'output_path'):
+    if not _utils.is_valid_attr(args, 'output_path'):
         missing.append('-o/--output_path')
-    if not _utils._is_valid_attr(args, 'input_shapes'):
+    if not _utils.is_valid_attr(args, 'input_shapes'):
         missing.append('-s/--input_shapes')
-    if not _utils._is_valid_attr(args, 'input_types'):
+    if not _utils.is_valid_attr(args, 'input_types'):
         missing.append('-t/--input_types')
 
     if len(missing):
@@ -113,7 +113,7 @@ def _parse_arg(parser):
     args = parser.parse_args()
     # print version
     if args.version:
-        _utils._print_version_and_exit(__file__)
+        _utils.print_version_and_exit(__file__)
 
     return args
 
@@ -255,7 +255,7 @@ def _convert(args):
     logfile_path = os.path.realpath(args.output_path) + '.log'
     with open(logfile_path, 'wb') as f, tempfile.TemporaryDirectory() as tmpdir:
         # save intermediate
-        if _utils._is_valid_attr(args, 'save_intermediate'):
+        if _utils.is_valid_attr(args, 'save_intermediate'):
             tmpdir = os.path.dirname(logfile_path)
         # convert pytorch to onnx model
         input_path = getattr(args, 'input_path')
@@ -310,8 +310,8 @@ def _convert(args):
         onnx_model = onnx.load(onnx_output_path)
 
         options = onnx_legalizer.LegalizeOptions()
-        options.unroll_rnn = _utils._is_valid_attr(args, 'unroll_rnn')
-        options.unroll_lstm = _utils._is_valid_attr(args, 'unroll_lstm')
+        options.unroll_rnn = _utils.is_valid_attr(args, 'unroll_rnn')
+        options.unroll_lstm = _utils.is_valid_attr(args, 'unroll_lstm')
         onnx_legalizer.legalize(onnx_model, options)
 
         tf_savedmodel = onnx_tf.backend.prepare(onnx_model)
@@ -334,7 +334,7 @@ def _convert(args):
         f.write((' '.join(tf2tfliteV2_cmd) + '\n').encode())
 
         # convert tf to tflite
-        _utils._run(tf2tfliteV2_cmd, logfile=f)
+        _utils.run(tf2tfliteV2_cmd, logfile=f)
 
         # make a command to convert from tflite to circle
         tflite2circle_path = os.path.join(dir_path, 'tflite2circle')
@@ -345,7 +345,7 @@ def _convert(args):
         f.write((' '.join(tflite2circle_cmd) + '\n').encode())
 
         # convert tflite to circle
-        _utils._run(tflite2circle_cmd, err_prefix="tflite2circle", logfile=f)
+        _utils.run(tflite2circle_cmd, err_prefix="tflite2circle", logfile=f)
 
 
 def main():
@@ -354,7 +354,7 @@ def main():
     args = _parse_arg(parser)
 
     # parse configuration file
-    _utils._parse_cfg(args, 'one-import-pytorch')
+    _utils.parse_cfg(args, 'one-import-pytorch')
 
     # verify arguments
     _verify_arg(parser, args)
@@ -364,4 +364,4 @@ def main():
 
 
 if __name__ == '__main__':
-    _utils._safemain(main, __file__)
+    _utils.safemain(main, __file__)

--- a/compiler/one-cmds/one-import-tf
+++ b/compiler/one-cmds/one-import-tf
@@ -35,7 +35,7 @@ def _get_parser():
     parser = argparse.ArgumentParser(
         description='command line tool to convert TensorFlow to circle')
 
-    _utils._add_default_arg(parser)
+    _utils.add_default_arg(parser)
 
     ## tf2tfliteV2 arguments
     tf2tfliteV2_group = parser.add_argument_group('converter arguments')
@@ -118,9 +118,9 @@ def _verify_arg(parser, args):
     """verify given arguments"""
     # check if required arguments is given
     missing = []
-    if not _utils._is_valid_attr(args, 'input_path'):
+    if not _utils.is_valid_attr(args, 'input_path'):
         missing.append('-i/--input_path')
-    if not _utils._is_valid_attr(args, 'output_path'):
+    if not _utils.is_valid_attr(args, 'output_path'):
         missing.append('-o/--output_path')
     if len(missing):
         parser.error('the following arguments are required: ' + ' '.join(missing))
@@ -130,7 +130,7 @@ def _parse_arg(parser):
     args = parser.parse_args()
     # print version
     if args.version:
-        _utils._print_version_and_exit(__file__)
+        _utils.print_version_and_exit(__file__)
 
     return args
 
@@ -142,7 +142,7 @@ def _convert(args):
 
     with open(logfile_path, 'wb') as f, tempfile.TemporaryDirectory() as tmpdir:
         # save intermediate
-        if _utils._is_valid_attr(args, 'save_intermediate'):
+        if _utils.is_valid_attr(args, 'save_intermediate'):
             tmpdir = os.path.dirname(logfile_path)
         # make a command to convert from tf to tflite
         tf2tfliteV2_path = os.path.join(dir_path, 'tf2tfliteV2.py')
@@ -156,7 +156,7 @@ def _convert(args):
         f.write((' '.join(tf2tfliteV2_cmd) + '\n').encode())
 
         # convert tf to tflite
-        _utils._run(tf2tfliteV2_cmd, logfile=f)
+        _utils.run(tf2tfliteV2_cmd, logfile=f)
 
         # make a command to convert from tflite to circle
         tflite2circle_path = os.path.join(dir_path, 'tflite2circle')
@@ -167,7 +167,7 @@ def _convert(args):
         f.write((' '.join(tflite2circle_cmd) + '\n').encode())
 
         # convert tflite to circle
-        _utils._run(tflite2circle_cmd, err_prefix="tflite2circle", logfile=f)
+        _utils.run(tflite2circle_cmd, err_prefix="tflite2circle", logfile=f)
 
 
 def main():
@@ -176,7 +176,7 @@ def main():
     args = _parse_arg(parser)
 
     # parse configuration file
-    _utils._parse_cfg(args, 'one-import-tf')
+    _utils.parse_cfg(args, 'one-import-tf')
 
     # verify arguments
     _verify_arg(parser, args)
@@ -186,4 +186,4 @@ def main():
 
 
 if __name__ == '__main__':
-    _utils._safemain(main, __file__)
+    _utils.safemain(main, __file__)

--- a/compiler/one-cmds/one-import-tflite
+++ b/compiler/one-cmds/one-import-tflite
@@ -38,7 +38,7 @@ def _get_parser():
     parser = argparse.ArgumentParser(
         description='command line tool to convert TensorFlow lite to circle')
 
-    _utils._add_default_arg(parser)
+    _utils.add_default_arg(parser)
 
     ## tflite2circle arguments
     tflite2circle_group = parser.add_argument_group('converter arguments')
@@ -56,9 +56,9 @@ def _verify_arg(parser, args):
     """verify given arguments"""
     # check if required arguments is given
     missing = []
-    if not _utils._is_valid_attr(args, 'input_path'):
+    if not _utils.is_valid_attr(args, 'input_path'):
         missing.append('-i/--input_path')
-    if not _utils._is_valid_attr(args, 'output_path'):
+    if not _utils.is_valid_attr(args, 'output_path'):
         missing.append('-o/--output_path')
     if len(missing):
         parser.error('the following arguments are required: ' + ' '.join(missing))
@@ -68,7 +68,7 @@ def _parse_arg(parser):
     args = parser.parse_args()
     # print version
     if args.version:
-        _utils._print_version_and_exit(__file__)
+        _utils.print_version_and_exit(__file__)
 
     return args
 
@@ -88,7 +88,7 @@ def _convert(args):
         f.write((' '.join(tflite2circle_cmd) + '\n').encode())
 
         # convert tflite to circle
-        _utils._run(tflite2circle_cmd, err_prefix="tflite2circle", logfile=f)
+        _utils.run(tflite2circle_cmd, err_prefix="tflite2circle", logfile=f)
 
 
 def main():
@@ -97,7 +97,7 @@ def main():
     args = _parse_arg(parser)
 
     # parse configuration file
-    _utils._parse_cfg(args, 'one-import-tflite')
+    _utils.parse_cfg(args, 'one-import-tflite')
 
     # verify arguments
     _verify_arg(parser, args)
@@ -107,4 +107,4 @@ def main():
 
 
 if __name__ == '__main__':
-    _utils._safemain(main, __file__)
+    _utils.safemain(main, __file__)

--- a/compiler/one-cmds/one-infer
+++ b/compiler/one-cmds/one-infer
@@ -82,7 +82,7 @@ one-infer -d dummy-infer --post-process "script.py arg1 arg2" -- [arguments for 
         epilog=infer_detail,
         formatter_class=argparse.RawTextHelpFormatter)
 
-    _utils._add_default_arg(parser)
+    _utils.add_default_arg(parser)
 
     driver_help_message = 'backend inference driver name to execute'
     parser.add_argument('-d', '--driver', type=str, help=driver_help_message)
@@ -96,7 +96,7 @@ one-infer -d dummy-infer --post-process "script.py arg1 arg2" -- [arguments for 
 def _verify_arg(parser, args):
     """verify given arguments"""
     missing = []
-    if not _utils._is_valid_attr(args, 'driver'):
+    if not _utils.is_valid_attr(args, 'driver'):
         missing.append('-d/--driver')
     if len(missing):
         parser.error('the following arguments are required: ' + ' '.join(missing))
@@ -118,13 +118,13 @@ def _parse_arg(parser):
         backend_args = backend_args if len(args) < 2 else args[1]
     # print version
     if len(args) and infer_args.version:
-        _utils._print_version_and_exit(__file__)
+        _utils.print_version_and_exit(__file__)
 
     return infer_args, backend_args
 
 
 def _get_executable(args):
-    driver = _utils._is_valid_attr(args, 'driver')
+    driver = _utils.is_valid_attr(args, 'driver')
 
     executable = _search_backend_driver(driver)
     if executable:
@@ -139,7 +139,7 @@ def main():
     args, backend_args = _parse_arg(parser)
 
     # parse configuration file
-    _utils._parse_cfg(args, 'one-infer')
+    _utils.parse_cfg(args, 'one-infer')
 
     # verify arguments
     _verify_arg(parser, args)
@@ -147,20 +147,20 @@ def main():
     # make a command to run given backend driver
     driver_path = _get_executable(args)
     infer_cmd = [driver_path] + backend_args
-    if _utils._is_valid_attr(args, 'command'):
+    if _utils.is_valid_attr(args, 'command'):
         infer_cmd += getattr(args, 'command').split()
 
     # run backend driver
-    _utils._run(infer_cmd, err_prefix=ntpath.basename(driver_path))
+    _utils.run(infer_cmd, err_prefix=ntpath.basename(driver_path))
 
     # run post process script if it's given
-    if _utils._is_valid_attr(args, 'post_process'):
+    if _utils.is_valid_attr(args, 'post_process'):
         # NOTE: the given python script will be executed by venv of ONE
         python_path = sys.executable
         post_process_command = [python_path] + getattr(args,
                                                        'post_process').strip().split(' ')
-        _utils._run(post_process_command, err_prefix='one-infer')
+        _utils.run(post_process_command, err_prefix='one-infer')
 
 
 if __name__ == '__main__':
-    _utils._safemain(main, __file__)
+    _utils.safemain(main, __file__)

--- a/compiler/one-cmds/one-init
+++ b/compiler/one-cmds/one-init
@@ -152,7 +152,7 @@ def _get_parser(backends_list):
         'Currently tflite and onnx models are supported',
         usage=init_usage)
 
-    _utils._add_default_arg_no_CS(parser)
+    _utils.add_default_arg_no_CS(parser)
 
     parser.add_argument(
         '-i', '--input_path', type=str, help='full filepath of the input model file')
@@ -197,23 +197,23 @@ def _get_parser(backends_list):
 def _verify_arg(parser, args):
     # check if required arguments is given
     missing = []
-    if not _utils._is_valid_attr(args, 'input_path'):
+    if not _utils.is_valid_attr(args, 'input_path'):
         missing.append('-i/--input_path')
-    if not _utils._is_valid_attr(args, 'output_path'):
+    if not _utils.is_valid_attr(args, 'output_path'):
         missing.append('-o/--output_path')
-    if not _utils._is_valid_attr(args, 'backend'):
+    if not _utils.is_valid_attr(args, 'backend'):
         missing.append('-b/--backend')
 
-    if _utils._is_valid_attr(args, 'model_type'):
+    if _utils.is_valid_attr(args, 'model_type'):
         # TODO Support model types other than onnx and tflite (e.g., TF)
         if getattr(args, 'model_type') not in ['onnx', 'tflite']:
             parser.error('Allowed value for --model_type: "onnx" or "tflite"')
 
-    if _utils._is_valid_attr(args, 'nchw_to_nhwc_input_shape'):
-        if not _utils._is_valid_attr(args, 'convert_nchw_to_nhwc'):
+    if _utils.is_valid_attr(args, 'nchw_to_nhwc_input_shape'):
+        if not _utils.is_valid_attr(args, 'convert_nchw_to_nhwc'):
             missing.append('--convert_nchw_to_nhwc')
-    if _utils._is_valid_attr(args, 'nchw_to_nhwc_output_shape'):
-        if not _utils._is_valid_attr(args, 'convert_nchw_to_nhwc'):
+    if _utils.is_valid_attr(args, 'nchw_to_nhwc_output_shape'):
+        if not _utils.is_valid_attr(args, 'convert_nchw_to_nhwc'):
             missing.append('--convert_nchw_to_nhwc')
 
     if len(missing):
@@ -236,13 +236,13 @@ def _parse_arg(parser):
         backend_args = backend_args if len(args) < 2 else args[1]
     # print version
     if len(args) and init_args.version:
-        _utils._print_version_and_exit(__file__)
+        _utils.print_version_and_exit(__file__)
 
     return init_args, backend_args
 
 
 def _get_executable(args, backends_list):
-    if _utils._is_valid_attr(args, 'backend'):
+    if _utils.is_valid_attr(args, 'backend'):
         backend_base = getattr(args, 'backend') + '-init'
         for cand in backends_list:
             if ntpath.basename(cand) == backend_base:
@@ -327,10 +327,10 @@ def _generate(args, model_type: str, inout_path: InputOutputPath):
 
 
 def _get_model_type(parser, args):
-    if _utils._is_valid_attr(args, 'model_type'):
+    if _utils.is_valid_attr(args, 'model_type'):
         return args.model_type
 
-    if _utils._is_valid_attr(args, 'input_path'):
+    if _utils.is_valid_attr(args, 'input_path'):
         _, ext = os.path.splitext(args.input_path)
 
         # ext would be, e.g., '.tflite' or '.onnx'.
@@ -366,10 +366,10 @@ def main():
     init_cmd = [driver_path] + backend_args
 
     # run backend driver
-    _utils._run(init_cmd, err_prefix=ntpath.basename(driver_path))
+    _utils.run(init_cmd, err_prefix=ntpath.basename(driver_path))
 
     raise NotImplementedError("NYI")
 
 
 if __name__ == '__main__':
-    _utils._safemain(main, __file__)
+    _utils.safemain(main, __file__)

--- a/compiler/one-cmds/one-optimize
+++ b/compiler/one-cmds/one-optimize
@@ -35,7 +35,7 @@ def _get_parser():
     parser = argparse.ArgumentParser(
         description='command line tool to optimize circle model')
 
-    _utils._add_default_arg(parser)
+    _utils.add_default_arg(parser)
 
     ## utility arguments
     utility_group = parser.add_argument_group('arguments for utility')
@@ -75,9 +75,9 @@ def _verify_arg(parser, args):
     """verify given arguments"""
     # check if required arguments is given
     missing = []
-    if not _utils._is_valid_attr(args, 'input_path'):
+    if not _utils.is_valid_attr(args, 'input_path'):
         missing.append('-i/--input_path')
-    if not _utils._is_valid_attr(args, 'output_path'):
+    if not _utils.is_valid_attr(args, 'output_path'):
         missing.append('-o/--output_path')
     if len(missing):
         parser.error('the following arguments are required: ' + ' '.join(missing))
@@ -95,7 +95,7 @@ def _parse_arg(parser):
     args = parser.parse_args()
     # print version
     if args.version:
-        _utils._print_version_and_exit(__file__)
+        _utils.print_version_and_exit(__file__)
 
     return args
 
@@ -113,25 +113,25 @@ def _optimize(args):
                                                              getattr(args, 'output_path'))
 
         # verbose
-        if _utils._is_valid_attr(args, 'verbose'):
+        if _utils.is_valid_attr(args, 'verbose'):
             circle2circle_cmd.append('--verbose')
-        if _utils._is_valid_attr(args, 'change_outputs'):
+        if _utils.is_valid_attr(args, 'change_outputs'):
             circle2circle_cmd.append('--change_outputs')
             circle2circle_cmd.append(getattr(args, 'change_outputs'))
 
         f.write((' '.join(circle2circle_cmd) + '\n').encode())
 
         # optimize
-        _utils._run(circle2circle_cmd, err_prefix="circle2circle", logfile=f)
+        _utils.run(circle2circle_cmd, err_prefix="circle2circle", logfile=f)
 
 
 def _parse_opt(args):
-    if _utils._is_valid_attr(args, 'O'):
+    if _utils.is_valid_attr(args, 'O'):
         opt_name_path_dic = dict(
-            zip(_utils._get_optimization_list(get_name=True),
-                _utils._get_optimization_list()))
+            zip(_utils.get_optimization_list(get_name=True),
+                _utils.get_optimization_list()))
         config_path = opt_name_path_dic['O' + getattr(args, 'O')]
-        _utils._parse_cfg_and_overwrite(config_path, 'one-optimize', args)
+        _utils.parse_cfg_and_overwrite(config_path, 'one-optimize', args)
 
 
 def main():
@@ -140,7 +140,7 @@ def main():
     args = _parse_arg(parser)
 
     # parse configuration file
-    _utils._parse_cfg(args, 'one-optimize')
+    _utils.parse_cfg(args, 'one-optimize')
 
     # parse optimization file
     # NOTE if there is a `one-optimize` section in above configuration file as well,
@@ -155,4 +155,4 @@ def main():
 
 
 if __name__ == '__main__':
-    _utils._safemain(main, __file__)
+    _utils.safemain(main, __file__)

--- a/compiler/one-cmds/one-pack
+++ b/compiler/one-cmds/one-pack
@@ -33,7 +33,7 @@ def _get_parser():
     parser = argparse.ArgumentParser(
         description='command line tool to package circle and metadata into nnpackage')
 
-    _utils._add_default_arg(parser)
+    _utils.add_default_arg(parser)
 
     ## model2nnpkg arguments
     model2nnpkg_group = parser.add_argument_group('arguments for packaging')
@@ -51,9 +51,9 @@ def _verify_arg(parser, args):
     """verify given arguments"""
     # check if required arguments is given
     missing = []
-    if not _utils._is_valid_attr(args, 'input_path'):
+    if not _utils.is_valid_attr(args, 'input_path'):
         missing.append('-i/--input_path')
-    if not _utils._is_valid_attr(args, 'output_path'):
+    if not _utils.is_valid_attr(args, 'output_path'):
         missing.append('-o/--output_path')
     if len(missing):
         parser.error('the following arguments are required: ' + ' '.join(missing))
@@ -63,7 +63,7 @@ def _parse_arg(parser):
     args = parser.parse_args()
     # print version
     if args.version:
-        _utils._print_version_and_exit(__file__)
+        _utils.print_version_and_exit(__file__)
 
     return args
 
@@ -93,7 +93,7 @@ def _pack(args):
         f.write((' '.join(model2nnpkg_cmd) + '\n').encode())
 
         # convert tflite to circle
-        _utils._run(model2nnpkg_cmd, err_prefix="model2nnpkg", logfile=f)
+        _utils.run(model2nnpkg_cmd, err_prefix="model2nnpkg", logfile=f)
 
 
 def main():
@@ -102,7 +102,7 @@ def main():
     args = _parse_arg(parser)
 
     # parse configuration file
-    _utils._parse_cfg(args, 'one-pack')
+    _utils.parse_cfg(args, 'one-pack')
 
     # verify arguments
     _verify_arg(parser, args)
@@ -112,4 +112,4 @@ def main():
 
 
 if __name__ == '__main__':
-    _utils._safemain(main, __file__)
+    _utils.safemain(main, __file__)

--- a/compiler/one-cmds/one-partition
+++ b/compiler/one-cmds/one-partition
@@ -34,7 +34,7 @@ def _get_parser():
     parser = argparse.ArgumentParser(
         description='command line tool to partition circle model by multiple backends')
 
-    _utils._add_default_arg(parser)
+    _utils.add_default_arg(parser)
 
     parser.add_argument(
         '--backends', type=str, help='backends in CSV to use for partitioning')
@@ -55,7 +55,7 @@ def _parse_arg(parser):
     args = parser.parse_args()
     # print version
     if args.version:
-        _utils._print_version_and_exit(__file__)
+        _utils.print_version_and_exit(__file__)
 
     return args
 
@@ -64,9 +64,9 @@ def _verify_arg(parser, args):
     """verify given arguments"""
     # check if required arguments is given
     missing = []
-    if not _utils._is_valid_attr(args, 'part_file'):
+    if not _utils.is_valid_attr(args, 'part_file'):
         missing.append('part_file')
-    if not _utils._is_valid_attr(args, 'input_file'):
+    if not _utils.is_valid_attr(args, 'input_file'):
         missing.append('input_file')
     if len(missing):
         parser.error('the following arguments are required: ' + ' '.join(missing))
@@ -86,13 +86,13 @@ def _partition(args):
 
         cmd = [os.path.expanduser(circle_partitioner_path)]
 
-        if _utils._is_valid_attr(args, 'backends'):
+        if _utils.is_valid_attr(args, 'backends'):
             cmd.append('--backends')
             cmd.append(getattr(args, 'backends'))
-        if _utils._is_valid_attr(args, 'default'):
+        if _utils.is_valid_attr(args, 'default'):
             cmd.append('--default')
             cmd.append(getattr(args, 'default'))
-        if _utils._is_valid_attr(args, 'work_path'):
+        if _utils.is_valid_attr(args, 'work_path'):
             cmd.append('--work_path')
             cmd.append(getattr(args, 'work_path'))
 
@@ -104,7 +104,7 @@ def _partition(args):
         f.write((' '.join(cmd) + '\n').encode())
 
         # run circle-partitoner
-        _utils._run(cmd, err_prefix='circle-partitioner', logfile=f)
+        _utils.run(cmd, err_prefix='circle-partitioner', logfile=f)
 
 
 def main():
@@ -113,11 +113,11 @@ def main():
     args = _parse_arg(parser)
 
     # parse configuration file
-    _utils._parse_cfg(args, 'one-partition')
+    _utils.parse_cfg(args, 'one-partition')
 
-    if _utils._is_valid_attr(args, 'config'):
+    if _utils.is_valid_attr(args, 'config'):
         config_path = getattr(args, 'config')
-        _utils._parse_cfg_and_overwrite(config_path, 'one-partition', args)
+        _utils.parse_cfg_and_overwrite(config_path, 'one-partition', args)
 
     # verify arguments
     _verify_arg(parser, args)
@@ -127,4 +127,4 @@ def main():
 
 
 if __name__ == '__main__':
-    _utils._safemain(main, __file__)
+    _utils.safemain(main, __file__)

--- a/compiler/one-cmds/one-profile
+++ b/compiler/one-cmds/one-profile
@@ -77,7 +77,7 @@ def _get_parser(backends_list):
     parser = argparse.ArgumentParser(
         description='command line tool for profiling backend model', usage=profile_usage)
 
-    _utils._add_default_arg(parser)
+    _utils.add_default_arg(parser)
 
     # get backend list in the directory
     backends_name = [ntpath.basename(f) for f in backends_list]
@@ -96,7 +96,7 @@ def _verify_arg(parser, args):
     """verify given arguments"""
     # check if required arguments is given
     missing = []
-    if not _utils._is_valid_attr(args, 'backend'):
+    if not _utils.is_valid_attr(args, 'backend'):
         missing.append('-b/--backend')
     if len(missing):
         parser.error('the following arguments are required: ' + ' '.join(missing))
@@ -123,7 +123,7 @@ def _parse_arg(parser):
         profile_args = parser.parse_args(profile_args)
     # print version
     if len(args) and profile_args.version:
-        _utils._print_version_and_exit(__file__)
+        _utils.print_version_and_exit(__file__)
 
     return profile_args, backend_args, unknown_args
 
@@ -137,7 +137,7 @@ def main():
     args, backend_args, unknown_args = _parse_arg(parser)
 
     # parse configuration file
-    _utils._parse_cfg(args, 'one-profile')
+    _utils.parse_cfg(args, 'one-profile')
 
     # verify arguments
     _verify_arg(parser, args)
@@ -151,11 +151,11 @@ def main():
     if not profile_path:
         raise FileNotFoundError(backend_base + ' not found')
     profile_cmd = [profile_path] + backend_args + unknown_args
-    if _utils._is_valid_attr(args, 'command'):
+    if _utils.is_valid_attr(args, 'command'):
         profile_cmd += getattr(args, 'command').split()
 
     # run backend driver
-    _utils._run(profile_cmd, err_prefix=backend_base)
+    _utils.run(profile_cmd, err_prefix=backend_base)
 
 
 if __name__ == '__main__':

--- a/compiler/one-cmds/one-quantize
+++ b/compiler/one-cmds/one-quantize
@@ -36,7 +36,7 @@ def _get_parser():
     parser = argparse.ArgumentParser(
         description='command line tool to quantize circle model')
 
-    _utils._add_default_arg(parser)
+    _utils.add_default_arg(parser)
 
     # input and output path.
     parser.add_argument(
@@ -221,12 +221,12 @@ def _get_parser():
 
 
 def _set_default_values(args):
-    if not _utils._is_valid_attr(args, 'input_model_dtype') and not _utils._is_valid_attr(
+    if not _utils.is_valid_attr(args, 'input_model_dtype') and not _utils.is_valid_attr(
             args, 'input_dtype'):
         setattr(args, 'input_model_dtype', 'float32')
-    if not _utils._is_valid_attr(args, 'quantized_dtype'):
+    if not _utils.is_valid_attr(args, 'quantized_dtype'):
         setattr(args, 'quantized_dtype', 'uint8')
-        if _utils._is_valid_attr(args, 'quant_config'):
+        if _utils.is_valid_attr(args, 'quant_config'):
             # Get quantized_dtype from qconfig file
             try:
                 with open(getattr(args, 'quant_config')) as f:
@@ -237,9 +237,9 @@ def _set_default_values(args):
             except json.decoder.JSONDecodeError:
                 print('Failed to decode ' + getattr(args, 'quant_config') +
                       '. Please check it is a json file.')
-    if not _utils._is_valid_attr(args, 'granularity'):
+    if not _utils.is_valid_attr(args, 'granularity'):
         setattr(args, 'granularity', 'layer')
-        if _utils._is_valid_attr(args, 'quant_config'):
+        if _utils.is_valid_attr(args, 'quant_config'):
             # Get granularity from qconfig file
             try:
                 with open(getattr(args, 'quant_config')) as f:
@@ -249,11 +249,11 @@ def _set_default_values(args):
             except json.decoder.JSONDecodeError:
                 print('Failed to decode ' + getattr(args, 'quant_config') +
                       '. Please check it is a json file.')
-    if not _utils._is_valid_attr(args, 'mode'):
+    if not _utils.is_valid_attr(args, 'mode'):
         setattr(args, 'mode', 'percentile')
-    if not _utils._is_valid_attr(args, 'min_percentile'):
+    if not _utils.is_valid_attr(args, 'min_percentile'):
         setattr(args, 'min_percentile', '1.0')
-    if not _utils._is_valid_attr(args, 'max_percentile'):
+    if not _utils.is_valid_attr(args, 'max_percentile'):
         setattr(args, 'max_percentile', '99.0')
 
 
@@ -261,32 +261,32 @@ def _verify_arg(parser, args):
     """verify given arguments"""
     # check if required arguments is given
     missing = []
-    if not _utils._is_valid_attr(args, 'input_path'):
+    if not _utils.is_valid_attr(args, 'input_path'):
         missing.append('-i/--input_path')
-    if not _utils._is_valid_attr(args, 'output_path'):
+    if not _utils.is_valid_attr(args, 'output_path'):
         missing.append('-o/--output_path')
-    if _utils._is_valid_attr(args, 'force_quantparam'):
-        if not _utils._is_valid_attr(args, 'tensor_name'):
+    if _utils.is_valid_attr(args, 'force_quantparam'):
+        if not _utils.is_valid_attr(args, 'tensor_name'):
             missing.append('--tensor_name')
-        if not _utils._is_valid_attr(args, 'scale'):
+        if not _utils.is_valid_attr(args, 'scale'):
             missing.append('--scale')
-        if not _utils._is_valid_attr(args, 'zero_point'):
+        if not _utils.is_valid_attr(args, 'zero_point'):
             missing.append('--zero_point')
-    if _utils._is_valid_attr(args, 'copy_quantparam'):
-        if not _utils._is_valid_attr(args, 'src_tensor_name'):
+    if _utils.is_valid_attr(args, 'copy_quantparam'):
+        if not _utils.is_valid_attr(args, 'src_tensor_name'):
             missing.append('--src_tensor_name')
-        if not _utils._is_valid_attr(args, 'dst_tensor_name'):
+        if not _utils.is_valid_attr(args, 'dst_tensor_name'):
             missing.append('--dst_tensor_name')
     if len(missing):
         parser.error('the following arguments are required: ' + ' '.join(missing))
-    if _utils._is_valid_attr(args, 'force_quantparam'):
+    if _utils.is_valid_attr(args, 'force_quantparam'):
         tensors = getattr(args, 'tensor_name')
         scales = getattr(args, 'scale')
         zerops = getattr(args, 'zero_point')
         if len(tensors) != len(scales) or len(tensors) != len(zerops):
             parser.error(
                 'The same number of tensor_name, scale, and zero_point should be given.')
-    if _utils._is_valid_attr(args, 'copy_quantparam'):
+    if _utils.is_valid_attr(args, 'copy_quantparam'):
         src_tensors = getattr(args, 'src_tensor_name')
         dst_tensors = getattr(args, 'dst_tensor_name')
         if len(src_tensors) != len(dst_tensors):
@@ -298,23 +298,23 @@ def _parse_arg(parser):
     args = parser.parse_args()
     # print version
     if args.version:
-        _utils._print_version_and_exit(__file__)
+        _utils.print_version_and_exit(__file__)
 
     return args
 
 
 def _quantize(args):
-    if _utils._is_valid_attr(args, 'force_quantparam'):
+    if _utils.is_valid_attr(args, 'force_quantparam'):
         # write quantization parameters
         _write_qparam(args)
         return
 
-    if _utils._is_valid_attr(args, 'copy_quantparam'):
+    if _utils.is_valid_attr(args, 'copy_quantparam'):
         # copy quantization parameters
         _copy_qparam(args)
         return
 
-    if _utils._is_valid_attr(args, 'fake_quantize'):
+    if _utils.is_valid_attr(args, 'fake_quantize'):
         # fake-quantize model
         _fake_quantize(args)
         return
@@ -324,7 +324,7 @@ def _quantize(args):
     logfile_path = os.path.realpath(args.output_path) + '.log'
 
     with open(logfile_path, 'wb') as f, tempfile.TemporaryDirectory() as tmpdir:
-        if _utils._is_valid_attr(args, 'save_intermediate'):
+        if _utils.is_valid_attr(args, 'save_intermediate'):
             tmpdir = os.path.dirname(logfile_path)
         # get driver path
         circle_quantizer_path = os.path.join(dir_path, 'circle-quantizer')
@@ -333,26 +333,26 @@ def _quantize(args):
         ## make a command to quantize and dequantize the weights of the model
         circle_quantizer_cmd = [circle_quantizer_path]
         # verbose
-        if _utils._is_valid_attr(args, 'verbose'):
+        if _utils.is_valid_attr(args, 'verbose'):
             circle_quantizer_cmd.append('--verbose')
         # quantize_dequantize_weights
         circle_quantizer_cmd.append('--quantize_dequantize_weights')
         # Use input_model_dtype if it exists. Use input_dtype otherwise.
-        if _utils._is_valid_attr(args, 'input_model_dtype'):
+        if _utils.is_valid_attr(args, 'input_model_dtype'):
             circle_quantizer_cmd.append(getattr(args, 'input_model_dtype'))
-        elif _utils._is_valid_attr(args, 'input_dtype'):
+        elif _utils.is_valid_attr(args, 'input_dtype'):
             circle_quantizer_cmd.append(getattr(args, 'input_dtype'))
-        if _utils._is_valid_attr(args, 'quantized_dtype'):
+        if _utils.is_valid_attr(args, 'quantized_dtype'):
             circle_quantizer_cmd.append(getattr(args, 'quantized_dtype'))
-        if _utils._is_valid_attr(args, 'granularity'):
+        if _utils.is_valid_attr(args, 'granularity'):
             circle_quantizer_cmd.append(getattr(args, 'granularity'))
-        if _utils._is_valid_attr(args, 'quant_config'):
+        if _utils.is_valid_attr(args, 'quant_config'):
             # NOTE --config conflicts with --config option in onecc, so
             # we use quant_config for one-quantize
             circle_quantizer_cmd.append('--config')
             circle_quantizer_cmd.append(getattr(args, 'quant_config'))
         # input and output path
-        if _utils._is_valid_attr(args, 'input_path'):
+        if _utils.is_valid_attr(args, 'input_path'):
             circle_quantizer_cmd.append(getattr(args, 'input_path'))
         tmp_weights_fake_quant_path = os.path.join(
             tmpdir,
@@ -360,13 +360,13 @@ def _quantize(args):
                 args.input_path))[0]) + '.weights_fake_quant.circle'
         circle_quantizer_cmd.append(tmp_weights_fake_quant_path)
         # profiling
-        if _utils._is_valid_attr(args, 'generate_profile_data'):
+        if _utils.is_valid_attr(args, 'generate_profile_data'):
             circle_quantizer_cmd.append('--generate_profile_data')
 
         f.write((' '.join(circle_quantizer_cmd) + '\n').encode())
 
         # run circle-quantizer
-        _utils._run(circle_quantizer_cmd, err_prefix="circle_quantizer", logfile=f)
+        _utils.run(circle_quantizer_cmd, err_prefix="circle_quantizer", logfile=f)
 
         tmp_minmax_recorded_path = os.path.join(
             tmpdir,
@@ -389,50 +389,50 @@ def _quantize(args):
         ## make a second command to quantize the model using the embedded information
         circle_quantizer_cmd = [circle_quantizer_path]
         # verbose
-        if _utils._is_valid_attr(args, 'verbose'):
+        if _utils.is_valid_attr(args, 'verbose'):
             circle_quantizer_cmd.append('--verbose')
         # quantize_dequantize_weights
         circle_quantizer_cmd.append('--quantize_with_minmax')
         # Use input_model_dtype if it exists. Use input_dtype otherwise.
-        if _utils._is_valid_attr(args, 'input_model_dtype'):
+        if _utils.is_valid_attr(args, 'input_model_dtype'):
             circle_quantizer_cmd.append(getattr(args, 'input_model_dtype'))
-        elif _utils._is_valid_attr(args, 'input_dtype'):
+        elif _utils.is_valid_attr(args, 'input_dtype'):
             circle_quantizer_cmd.append(getattr(args, 'input_dtype'))
-        if _utils._is_valid_attr(args, 'quantized_dtype'):
+        if _utils.is_valid_attr(args, 'quantized_dtype'):
             circle_quantizer_cmd.append(getattr(args, 'quantized_dtype'))
-        if _utils._is_valid_attr(args, 'granularity'):
+        if _utils.is_valid_attr(args, 'granularity'):
             circle_quantizer_cmd.append(getattr(args, 'granularity'))
-        if _utils._is_valid_attr(args, 'TF-style_maxpool'):
+        if _utils.is_valid_attr(args, 'TF-style_maxpool'):
             circle_quantizer_cmd.append('--TF-style_maxpool')
-        if _utils._is_valid_attr(args, 'input_type'):
+        if _utils.is_valid_attr(args, 'input_type'):
             circle_quantizer_cmd.append('--input_type')
             circle_quantizer_cmd.append(getattr(args, 'input_type'))
-        if _utils._is_valid_attr(args, 'output_type'):
+        if _utils.is_valid_attr(args, 'output_type'):
             circle_quantizer_cmd.append('--output_type')
             circle_quantizer_cmd.append(getattr(args, 'output_type'))
-        if _utils._is_valid_attr(args, 'quant_config'):
+        if _utils.is_valid_attr(args, 'quant_config'):
             # NOTE --config conflicts with --config option in onecc, so
             # we use quant_config for one-quantize
             circle_quantizer_cmd.append('--config')
             circle_quantizer_cmd.append(getattr(args, 'quant_config'))
         # input and output path
         circle_quantizer_cmd.append(tmp_minmax_recorded_path)
-        if _utils._is_valid_attr(args, 'output_path'):
+        if _utils.is_valid_attr(args, 'output_path'):
             circle_quantizer_cmd.append(getattr(args, 'output_path'))
         # profiling
-        if _utils._is_valid_attr(args, 'generate_profile_data'):
+        if _utils.is_valid_attr(args, 'generate_profile_data'):
             circle_quantizer_cmd.append('--generate_profile_data')
 
         f.write((' '.join(circle_quantizer_cmd) + '\n').encode())
 
         # run circle-quantizer
-        _utils._run(circle_quantizer_cmd, err_prefix="circle_quantizer", logfile=f)
+        _utils.run(circle_quantizer_cmd, err_prefix="circle_quantizer", logfile=f)
 
         # evaluate
-        if _utils._is_valid_attr(args, 'evaluate_result'):
+        if _utils.is_valid_attr(args, 'evaluate_result'):
             circle_eval_diff_path = os.path.join(dir_path, 'circle-eval-diff')
             quant_model = ""
-            if _utils._is_valid_attr(args, 'output_path'):
+            if _utils.is_valid_attr(args, 'output_path'):
                 quant_model = getattr(args, 'output_path')
             tmp_fake_quant_model = os.path.join(
                 tmpdir,
@@ -473,13 +473,13 @@ def _write_qparam(args):
         # make a command to write qparams to the tensors
         circle_quantizer_cmd = [circle_quantizer_path]
         # verbose
-        if _utils._is_valid_attr(args, 'verbose'):
+        if _utils.is_valid_attr(args, 'verbose'):
             circle_quantizer_cmd.append('--verbose')
-        if _utils._is_valid_attr(args, 'tensor_name'):
+        if _utils.is_valid_attr(args, 'tensor_name'):
             tensor_name = getattr(args, 'tensor_name')
-        if _utils._is_valid_attr(args, 'scale'):
+        if _utils.is_valid_attr(args, 'scale'):
             scale = getattr(args, 'scale')
-        if _utils._is_valid_attr(args, 'zero_point'):
+        if _utils.is_valid_attr(args, 'zero_point'):
             zero_point = getattr(args, 'zero_point')
         for (t, s, zp) in zip(tensor_name, scale, zero_point):
             circle_quantizer_cmd.append('--force_quantparam')
@@ -487,15 +487,15 @@ def _write_qparam(args):
             circle_quantizer_cmd.append(str(s))
             circle_quantizer_cmd.append(str(zp))
         # input and output path
-        if _utils._is_valid_attr(args, 'input_path'):
+        if _utils.is_valid_attr(args, 'input_path'):
             circle_quantizer_cmd.append(getattr(args, 'input_path'))
-        if _utils._is_valid_attr(args, 'output_path'):
+        if _utils.is_valid_attr(args, 'output_path'):
             circle_quantizer_cmd.append(getattr(args, 'output_path'))
 
         f.write((' '.join(circle_quantizer_cmd) + '\n').encode())
 
         # run circle-quantizer
-        _utils._run(circle_quantizer_cmd, err_prefix="circle_quantizer", logfile=f)
+        _utils.run(circle_quantizer_cmd, err_prefix="circle_quantizer", logfile=f)
 
 
 def _copy_qparam(args):
@@ -510,26 +510,26 @@ def _copy_qparam(args):
         # make a command to write qparams to the tensors
         circle_quantizer_cmd = [circle_quantizer_path]
         # verbose
-        if _utils._is_valid_attr(args, 'verbose'):
+        if _utils.is_valid_attr(args, 'verbose'):
             circle_quantizer_cmd.append('--verbose')
-        if _utils._is_valid_attr(args, 'src_tensor_name'):
+        if _utils.is_valid_attr(args, 'src_tensor_name'):
             src_tensor_name = getattr(args, 'src_tensor_name')
-        if _utils._is_valid_attr(args, 'dst_tensor_name'):
+        if _utils.is_valid_attr(args, 'dst_tensor_name'):
             dst_tensor_name = getattr(args, 'dst_tensor_name')
         for (src, dst) in zip(src_tensor_name, dst_tensor_name):
             circle_quantizer_cmd.append('--copy_quantparam')
             circle_quantizer_cmd.append(src)
             circle_quantizer_cmd.append(dst)
         # input and output path
-        if _utils._is_valid_attr(args, 'input_path'):
+        if _utils.is_valid_attr(args, 'input_path'):
             circle_quantizer_cmd.append(getattr(args, 'input_path'))
-        if _utils._is_valid_attr(args, 'output_path'):
+        if _utils.is_valid_attr(args, 'output_path'):
             circle_quantizer_cmd.append(getattr(args, 'output_path'))
 
         f.write((' '.join(circle_quantizer_cmd) + '\n').encode())
 
         # run circle-quantizer
-        _utils._run(circle_quantizer_cmd, err_prefix="circle_quantizer", logfile=f)
+        _utils.run(circle_quantizer_cmd, err_prefix="circle_quantizer", logfile=f)
 
 
 def _fake_quantize(args):
@@ -556,7 +556,7 @@ def main():
     args = _parse_arg(parser)
 
     # parse configuration file
-    _utils._parse_cfg(args, 'one-quantize')
+    _utils.parse_cfg(args, 'one-quantize')
 
     # set default values
     _set_default_values(args)
@@ -569,4 +569,4 @@ def main():
 
 
 if __name__ == '__main__':
-    _utils._safemain(main, __file__)
+    _utils.safemain(main, __file__)

--- a/compiler/one-cmds/onecc
+++ b/compiler/one-cmds/onecc
@@ -53,7 +53,7 @@ def _call_driver(driver_name, options):
     dir_path = os.path.dirname(os.path.realpath(__file__))
     driver_path = os.path.join(dir_path, driver_name)
     cmd = [driver_path] + options
-    _utils._run(cmd)
+    _utils.run(cmd)
 
 
 def _check_subtool_exists():
@@ -71,9 +71,9 @@ def _get_parser():
     onecc_desc = 'Run ONE driver via several commands or configuration file'
     parser = argparse.ArgumentParser(description=onecc_desc, usage=onecc_usage)
 
-    _utils._add_default_arg(parser)
+    _utils.add_default_arg(parser)
 
-    opt_name_list = _utils._get_optimization_list(get_name=True)
+    opt_name_list = _utils.get_optimization_list(get_name=True)
     opt_name_list = ['-' + s for s in opt_name_list]
     if not opt_name_list:
         opt_help_message = '(No available optimization options)'
@@ -106,7 +106,7 @@ def _parse_arg(parser):
     args = parser.parse_args()
     # print version
     if args.version:
-        _utils._print_version_and_exit(__file__)
+        _utils.print_version_and_exit(__file__)
 
     return args
 
@@ -114,13 +114,13 @@ def _parse_arg(parser):
 def _verify_arg(parser, args):
     """verify given arguments"""
     # check if required arguments is given
-    if not _utils._is_valid_attr(args, 'config') and not _utils._is_valid_attr(
+    if not _utils.is_valid_attr(args, 'config') and not _utils.is_valid_attr(
             args, 'workflow'):
         parser.error('-C/--config or -W/--workflow argument is required')
     # check if given optimization option exists
-    opt_name_list = _utils._get_optimization_list(get_name=True)
-    opt_name_list = [_utils._remove_prefix(s, 'O') for s in opt_name_list]
-    if _utils._is_valid_attr(args, 'O'):
+    opt_name_list = _utils.get_optimization_list(get_name=True)
+    opt_name_list = [_utils.remove_prefix(s, 'O') for s in opt_name_list]
+    if _utils.is_valid_attr(args, 'O'):
         if ' ' in getattr(args, 'O'):
             parser.error('Not allowed to have space in the optimization name')
         if not getattr(args, 'O') in opt_name_list:
@@ -147,16 +147,16 @@ def main():
     _verify_arg(parser, args)
 
     bin_dir = os.path.dirname(os.path.realpath(__file__))
-    if _utils._is_valid_attr(args, 'config'):
+    if _utils.is_valid_attr(args, 'config'):
         runner = CfgRunner(args.config)
         runner.detect_import_drivers(bin_dir)
-        if _utils._is_valid_attr(args, 'O'):
+        if _utils.is_valid_attr(args, 'O'):
             runner.add_opt(getattr(args, 'O'))
         runner.run(bin_dir)
-    elif _utils._is_valid_attr(args, 'workflow'):
+    elif _utils.is_valid_attr(args, 'workflow'):
         runner = WorkflowRunner(args.workflow)
         runner.run(bin_dir)
 
 
 if __name__ == '__main__':
-    _utils._safemain(main, __file__)
+    _utils.safemain(main, __file__)

--- a/compiler/one-cmds/onelib/CfgRunner.py
+++ b/compiler/one-cmds/onelib/CfgRunner.py
@@ -67,8 +67,8 @@ class CfgRunner:
         # make option names case sensitive
         self.optparser.optionxform = str
         opt_book = dict(
-            zip(oneutils._get_optimization_list(get_name=True),
-                oneutils._get_optimization_list()))
+            zip(oneutils.get_optimization_list(get_name=True),
+                oneutils.get_optimization_list()))
         parsed = self.optparser.read(opt_book['O' + opt])
         if not parsed:
             raise FileNotFoundError('Not found given optimization configuration file')
@@ -80,7 +80,7 @@ class CfgRunner:
         self.opt = opt
 
     def detect_import_drivers(self, dir):
-        self.import_drivers = list(oneutils._detect_one_import_drivers(dir).keys())
+        self.import_drivers = list(oneutils.detect_one_import_drivers(dir).keys())
 
     def run(self, working_dir, verbose=False):
         # set environment
@@ -102,4 +102,4 @@ class CfgRunner:
                 options.append('--verbose')
             driver_path = os.path.join(working_dir, section)
             cmd = [driver_path] + options
-            oneutils._run(cmd)
+            oneutils.run(cmd)

--- a/compiler/one-cmds/onelib/Command.py
+++ b/compiler/one-cmds/onelib/Command.py
@@ -28,7 +28,7 @@ class Command:
     # Option values are collected from self.args
     def add_option_with_valid_args(self, option, attrs):
         for attr in attrs:
-            if not oneutils._is_valid_attr(self.args, attr):
+            if not oneutils.is_valid_attr(self.args, attr):
                 return self
         self.cmd.append(option)
         for attr in attrs:
@@ -44,11 +44,11 @@ class Command:
 
     # Add option with no argument (ex: --verbose) if attr is valid
     def add_noarg_option_if_valid_arg(self, option, attr):
-        if oneutils._is_valid_attr(self.args, attr):
+        if oneutils.is_valid_attr(self.args, attr):
             self.cmd.append(option)
         return self
 
     # Run cmd and save logs
     def run(self):
         self.log_file.write((' '.join(self.cmd) + '\n').encode())
-        oneutils._run(self.cmd, err_prefix=self.driver, logfile=self.log_file)
+        oneutils.run(self.cmd, err_prefix=self.driver, logfile=self.log_file)

--- a/compiler/one-cmds/onelib/WorkflowRunner.py
+++ b/compiler/one-cmds/onelib/WorkflowRunner.py
@@ -124,7 +124,7 @@ class WorkflowRunner:
                     # get the absolute path of the caller
                     driver_path = os.path.join(working_dir, driver_name)
                     cmd = [driver_path] + options
-                    oneutils._run(cmd)
+                    oneutils.run(cmd)
             elif self.CFG_REFERENCE_K in workflow:
                 cfg_path = workflow[self.CFG_REFERENCE_K]['path']
                 runner = CfgRunner(cfg_path)

--- a/compiler/one-cmds/onelib/make_cmd.py
+++ b/compiler/one-cmds/onelib/make_cmd.py
@@ -20,7 +20,7 @@ import sys
 import onelib.constant as _constant
 
 
-def _is_valid_attr(args, attr):
+def is_valid_attr(args, attr):
     return hasattr(args, attr) and getattr(args, attr)
 
 
@@ -28,45 +28,45 @@ def make_tf2tfliteV2_cmd(args, driver_path, input_path, output_path):
     """make a command for running tf2tfliteV2.py"""
     cmd = [sys.executable, os.path.expanduser(driver_path)]
     # verbose
-    if _is_valid_attr(args, 'verbose'):
+    if is_valid_attr(args, 'verbose'):
         cmd.append('--verbose')
     # model_format
-    if _is_valid_attr(args, 'model_format_cmd'):
+    if is_valid_attr(args, 'model_format_cmd'):
         cmd.append(getattr(args, 'model_format_cmd'))
-    elif _is_valid_attr(args, 'model_format'):
+    elif is_valid_attr(args, 'model_format'):
         cmd.append('--' + getattr(args, 'model_format'))
     else:
         cmd.append('--graph_def')  # default value
     # converter version
-    if _is_valid_attr(args, 'converter_version_cmd'):
+    if is_valid_attr(args, 'converter_version_cmd'):
         cmd.append(getattr(args, 'converter_version_cmd'))
-    elif _is_valid_attr(args, 'converter_version'):
+    elif is_valid_attr(args, 'converter_version'):
         cmd.append('--' + getattr(args, 'converter_version'))
     else:
         cmd.append('--v1')  # default value
     # input_path
-    if _is_valid_attr(args, 'input_path'):
+    if is_valid_attr(args, 'input_path'):
         cmd.append('--input_path')
         cmd.append(os.path.expanduser(input_path))
     # output_path
-    if _is_valid_attr(args, 'output_path'):
+    if is_valid_attr(args, 'output_path'):
         cmd.append('--output_path')
         cmd.append(os.path.expanduser(output_path))
     # input_arrays
-    if _is_valid_attr(args, 'input_arrays'):
+    if is_valid_attr(args, 'input_arrays'):
         cmd.append('--input_arrays')
         cmd.append(getattr(args, 'input_arrays'))
     # input_shapes
-    if _is_valid_attr(args, 'input_shapes'):
+    if is_valid_attr(args, 'input_shapes'):
         cmd.append('--input_shapes')
         cmd.append(getattr(args, 'input_shapes'))
     # output_arrays
-    if _is_valid_attr(args, 'output_arrays'):
+    if is_valid_attr(args, 'output_arrays'):
         cmd.append('--output_arrays')
         cmd.append(getattr(args, 'output_arrays'))
 
     # experimental options
-    if _is_valid_attr(args, 'experimental_disable_batchmatmul_unfold'):
+    if is_valid_attr(args, 'experimental_disable_batchmatmul_unfold'):
         cmd.append('--experimental_disable_batchmatmul_unfold')
 
     return cmd
@@ -82,12 +82,12 @@ def make_circle2circle_cmd(args, driver_path, input_path, output_path):
     """make a command for running circle2circle"""
     cmd = [os.path.expanduser(c) for c in [driver_path, input_path, output_path]]
     # profiling
-    if _is_valid_attr(args, 'generate_profile_data'):
+    if is_valid_attr(args, 'generate_profile_data'):
         cmd.append('--generate_profile_data')
     # optimization pass(only true/false options)
     # TODO support options whose number of arguments is more than zero
     for opt in _constant.CONSTANT.OPTIMIZATION_OPTS:
-        if _is_valid_attr(args, opt[0]):
+        if is_valid_attr(args, opt[0]):
             # ./driver --opt[0]
             if type(getattr(args, opt[0])) is bool:
                 cmd.append('--' + opt[0])

--- a/compiler/one-cmds/utils.py
+++ b/compiler/one-cmds/utils.py
@@ -26,7 +26,7 @@ import sys
 import onelib.constant as _constant
 
 
-def _add_default_arg(parser):
+def add_default_arg(parser):
     # version
     parser.add_argument(
         '-v',
@@ -47,7 +47,7 @@ def _add_default_arg(parser):
     parser.add_argument('-S', '--section', type=str, help=argparse.SUPPRESS)
 
 
-def _add_default_arg_no_CS(parser):
+def add_default_arg_no_CS(parser):
     """
     This adds -v -V args only (no -C nor -S)
     """
@@ -77,11 +77,11 @@ def is_accumulated_arg(arg, driver):
     return False
 
 
-def _is_valid_attr(args, attr):
+def is_valid_attr(args, attr):
     return hasattr(args, attr) and getattr(args, attr)
 
 
-def _parse_cfg_and_overwrite(config_path, section, args):
+def parse_cfg_and_overwrite(config_path, section, args):
     """
     parse given section of configuration file and set the values of args.
     Even if the values parsed from the configuration file already exist in args,
@@ -104,28 +104,28 @@ def _parse_cfg_and_overwrite(config_path, section, args):
     # TODO support accumulated arguments
 
 
-def _parse_cfg(args, driver_name):
+def parse_cfg(args, driver_name):
     """parse configuration file. If the option is directly given to the command line,
        the option is processed prior to the configuration file.
        That is, if the values parsed from the configuration file already exist in args,
        the values are ignored."""
-    if _is_valid_attr(args, 'config'):
+    if is_valid_attr(args, 'config'):
         config = configparser.ConfigParser()
         config.optionxform = str
         config.read(args.config)
         # if section is given, verify given section
-        if _is_valid_attr(args, 'section'):
+        if is_valid_attr(args, 'section'):
             if not config.has_section(args.section):
                 raise AssertionError('configuration file must have \'' + driver_name +
                                      '\' section')
             for key in config[args.section]:
                 if is_accumulated_arg(key, driver_name):
-                    if not _is_valid_attr(args, key):
+                    if not is_valid_attr(args, key):
                         setattr(args, key, [config[args.section][key]])
                     else:
                         getattr(args, key).append(config[args.section][key])
                     continue
-                if not _is_valid_attr(args, key):
+                if not is_valid_attr(args, key):
                     setattr(args, key, config[args.section][key])
         # if section is not given, section name is same with its driver name
         else:
@@ -135,16 +135,16 @@ def _parse_cfg(args, driver_name):
             secton_to_run = driver_name
             for key in config[secton_to_run]:
                 if is_accumulated_arg(key, driver_name):
-                    if not _is_valid_attr(args, key):
+                    if not is_valid_attr(args, key):
                         setattr(args, key, [config[secton_to_run][key]])
                     else:
                         getattr(args, key).append(config[secton_to_run][key])
                     continue
-                if not _is_valid_attr(args, key):
+                if not is_valid_attr(args, key):
                     setattr(args, key, config[secton_to_run][key])
 
 
-def _print_version_and_exit(file_path):
+def print_version_and_exit(file_path):
     """print version of the file located in the file_path"""
     script_path = os.path.realpath(file_path)
     dir_path = os.path.dirname(script_path)
@@ -154,7 +154,7 @@ def _print_version_and_exit(file_path):
     sys.exit()
 
 
-def _safemain(main, mainpath):
+def safemain(main, mainpath):
     """execute given method and print with program name for all uncaught exceptions"""
     try:
         main()
@@ -164,7 +164,7 @@ def _safemain(main, mainpath):
         sys.exit(255)
 
 
-def _run(cmd, err_prefix=None, logfile=None):
+def run(cmd, err_prefix=None, logfile=None):
     """Execute command in subprocess
 
     Args:
@@ -196,19 +196,19 @@ def _run(cmd, err_prefix=None, logfile=None):
         sys.exit(p.returncode)
 
 
-def _remove_prefix(str, prefix):
+def remove_prefix(str, prefix):
     if str.startswith(prefix):
         return str[len(prefix):]
     return str
 
 
-def _remove_suffix(str, suffix):
+def remove_suffix(str, suffix):
     if str.endswith(suffix):
         return str[:-len(suffix)]
     return str
 
 
-def _get_optimization_list(get_name=False):
+def get_optimization_list(get_name=False):
     """
     returns a list of optimization. If `get_name` is True,
     only basename without extension is returned rather than full file path.
@@ -242,12 +242,12 @@ def _get_optimization_list(get_name=False):
         # NOTE the name includes prefix 'O'
         # e.g. O1, O2, ONCHW not just 1, 2, NCHW
         opt_list = [ntpath.basename(f) for f in opt_list]
-        opt_list = [_remove_suffix(s, '.cfg') for s in opt_list]
+        opt_list = [remove_suffix(s, '.cfg') for s in opt_list]
 
     return opt_list
 
 
-def _detect_one_import_drivers(search_path):
+def detect_one_import_drivers(search_path):
     """Looks for import drivers in given directory
 
     Args:


### PR DESCRIPTION
This commit removes first underscore of each functions in utils.py.

Single underscore starting from functions means internal use indicator. But, utils.py's funcitons are not internal use. It better be removed.

Related: #9359
Signed-off-by: seongwoo <mhs4670go@naver.com>