### PR TITLE
[one-cmds] Get right optimization list

### DIFF
--- a/compiler/one-cmds/onelib/utils.py
+++ b/compiler/one-cmds/onelib/utils.py
@@ -228,7 +228,9 @@ def get_optimization_list(get_name=False):
     dir_path = os.path.dirname(os.path.realpath(__file__))
 
     # optimization folder
-    files = [f for f in glob.glob(dir_path + '/../optimization/O*.cfg', recursive=True)]
+    files = [
+        f for f in glob.glob(dir_path + '/../../optimization/O*.cfg', recursive=True)
+    ]
     # exclude if the name has space
     files = [s for s in files if not ' ' in s]
 


### PR DESCRIPTION
This commit fixes the function to get the opt list correctly.

Related: https://github.com/Samsung/ONE/issues/10323#issuecomment-1381113666
Signed-off-by: seongwoo <mhs4670go@naver.com>