### PR TITLE
[onecc-docker] Change docker file path

### DIFF
--- a/compiler/onecc-docker/debian/onecc-docker.install
+++ b/compiler/onecc-docker/debian/onecc-docker.install
@@ -1,2 +1,2 @@
 compiler/onecc-docker/onecc-docker /usr/share/one/bin/
-compiler/onecc-docker/docker/Dockerfile /usr/share/one/docker/
+compiler/onecc-docker/docker/Dockerfile /usr/share/one/bin/docker/


### PR DESCRIPTION
This commit changes the docker file path.
The dockerfile will be placed in the bin directory.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>