### PR TITLE
[one-cmds] Revisit one-cmds test

### DIFF
--- a/compiler/one-cmds/tests/one-build_001.test
+++ b/compiler/one-cmds/tests/one-build_001.test
@@ -30,8 +30,11 @@ trap trap_err_onexit ERR
 configfile="one-build_001.cfg"
 outputfile="inception_v3.opt.circle"
 
+rm -f ${filename}.log
+rm -f ${outputfile}
+
 # run test
-one-build -C ${configfile} > /dev/null 2>&1
+one-build -C ${configfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-build_002.test
+++ b/compiler/one-cmds/tests/one-build_002.test
@@ -30,8 +30,11 @@ trap trap_err_onexit ERR
 configfile="one-build_002.cfg"
 outputfile="inception_v3_pkg"
 
+rm -f ${filename}.log
+rm -rf ${outputfile}
+
 # run test
-one-build -C ${configfile} > /dev/null 2>&1
+one-build -C ${configfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-build_003.test
+++ b/compiler/one-cmds/tests/one-build_003.test
@@ -30,10 +30,11 @@ trap trap_err_onexit ERR
 configfile="one-build_003.cfg"
 outputfile="inception_v3.quantized.circle"
 
-rm -rf ${outputfile}
+rm -f ${filename}.log
+rm -f ${outputfile}
 
 # run test
-one-build -C ${configfile} > /dev/null 2>&1
+one-build -C ${configfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-build_004.test
+++ b/compiler/one-cmds/tests/one-build_004.test
@@ -31,13 +31,14 @@ trap trap_err_onexit ERR
 configfile="one-build_004.cfg"
 outputfile="sample.tvn"
 
-rm -rf ${outputfile}
+rm -f ${filename}.log
+rm -f ${outputfile}
 
 # copy dummy-compile to bin folder
 cp dummy-compile ../bin/dummy-compile
 
 # run test
-one-build -C ${configfile} > /dev/null 2>&1
+one-build -C ${configfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-build_005.test
+++ b/compiler/one-cmds/tests/one-build_005.test
@@ -31,13 +31,14 @@ trap trap_err_onexit ERR
 configfile="one-build_005.cfg"
 outputfile="sample.tvn"
 
-rm -rf ${outputfile}
+rm -f ${filename}.log
+rm -f ${outputfile}
 
 # copy dummy-compile to bin folder
 cp dummy-compile ../bin/dummy-compile
 
 # run test
-one-build -C ${configfile} > /dev/null 2>&1
+one-build -C ${configfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-build_006.test
+++ b/compiler/one-cmds/tests/one-build_006.test
@@ -31,13 +31,14 @@ trap trap_err_onexit ERR
 configfile="one-build_006.cfg"
 outputfile="sample.tvn"
 
-rm -rf ${outputfile}
+rm -f ${filename}.log
+rm -f ${outputfile}
 
 # copy dummy-compile to bin folder
 cp dummy-compile ../bin/dummy-compile
 
 # run test
-one-build -C ${configfile} > /dev/null 2>&1
+one-build -C ${configfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-build_007.test
+++ b/compiler/one-cmds/tests/one-build_007.test
@@ -30,10 +30,11 @@ trap trap_err_onexit ERR
 configfile="one-build_007.cfg"
 outputfile="inception_v3_pkg"
 
+rm -f ${filename}.log
 rm -rf ${outputfile}
 
 # run test
-one-build -C ${configfile} > /dev/null 2>&1
+one-build -C ${configfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-build_008.test
+++ b/compiler/one-cmds/tests/one-build_008.test
@@ -31,13 +31,14 @@ trap trap_err_onexit ERR
 configfile="one-build_008.cfg"
 outputfile="test_onnx_model.bin"
 
-rm -rf ${outputfile}
+rm -f ${filename}.log
+rm -f ${outputfile}
 
 # copy dummy-compile to bin folder
 cp dummy-compile ../bin/dummy-compile
 
 # run test
-one-build -C ${configfile} > /dev/null 2>&1
+one-build -C ${configfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-build_009.test
+++ b/compiler/one-cmds/tests/one-build_009.test
@@ -31,13 +31,14 @@ trap trap_err_onexit ERR
 configfile="one-build_009.cfg"
 outputfile="onnx_conv2d_conv2d.bin"
 
-rm -rf ${outputfile}
+rm -f ${filename}.log
+rm -f ${outputfile}
 
 # copy dummy-compile to bin folder
 cp dummy-compile ../bin/dummy-compile
 
 # run test
-one-build -C ${configfile} > /dev/null 2>&1
+one-build -C ${configfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-build_010.test
+++ b/compiler/one-cmds/tests/one-build_010.test
@@ -31,11 +31,12 @@ configfile="one-build_010.cfg"
 outputfile="inception_v3.alt.circle"
 intermfile="inception_v3.alt.tflite"
 
-rm -rf ${outputfile}
-rm -rf ${intermfile}
+rm -f ${filename}.log
+rm -f ${outputfile}
+rm -f ${intermfile}
 
 # run test
-one-build -C ${configfile} > /dev/null 2>&1
+one-build -C ${configfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-build_011.test
+++ b/compiler/one-cmds/tests/one-build_011.test
@@ -31,11 +31,12 @@ configfile="one-build_011.cfg"
 outputfile="test_onnx_model.circle"
 intermfile="test_onnx_model.tflite"
 
-rm -rf ${outputfile}
-rm -rf ${intermfile}
+rm -f ${filename}.log
+rm -f ${outputfile}
+rm -f ${intermfile}
 
 # run test
-one-build -C ${configfile} > /dev/null 2>&1
+one-build -C ${configfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-build_012.test
+++ b/compiler/one-cmds/tests/one-build_012.test
@@ -30,10 +30,11 @@ trap trap_err_onexit ERR
 configfile="one-build_012.cfg"
 outputfile="inception_v3.list.quantized.circle"
 
-rm -rf ${outputfile}
+rm -f ${filename}.log
+rm -f ${outputfile}
 
 # run test
-one-build -C ${configfile} > /dev/null 2>&1
+one-build -C ${configfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-build_013.test
+++ b/compiler/one-cmds/tests/one-build_013.test
@@ -30,10 +30,11 @@ trap trap_err_onexit ERR
 configfile="one-build_013.cfg"
 outputfile="inception_v3.dir.quantized.circle"
 
-rm -rf ${outputfile}
+rm -f ${filename}.log
+rm -f ${outputfile}
 
 # run test
-one-build -C ${configfile} > /dev/null 2>&1
+one-build -C ${configfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-build_014.test
+++ b/compiler/one-cmds/tests/one-build_014.test
@@ -55,8 +55,8 @@ trap trap_err_onexit ERR
 configfile="one-build_014.cfg"
 outputfile="inception_v3.opt.circle"
 
-rm -rf ${outputfile}
 rm -f ${filename}.log
+rm -f ${outputfile}
 
 if [ ! -d "../optimization" ]; then
   mkdir -p ../optimization

--- a/compiler/one-cmds/tests/one-import-bcq_001.test
+++ b/compiler/one-cmds/tests/one-import-bcq_001.test
@@ -28,6 +28,7 @@ trap trap_err_onexit ERR
 inputfile="./bcq.pb"
 outputfile="./bcq.circle"
 
+rm -f ${filename}.log
 rm -rf $outputfile
 
 # run test
@@ -35,7 +36,7 @@ one-import-bcq \
 --input_path ${inputfile} \
 --output_path ${outputfile} \
 --input_arrays Placeholder \
---output_arrays MatMul > /dev/null 2>&1
+--output_arrays MatMul > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-import_001.test
+++ b/compiler/one-cmds/tests/one-import_001.test
@@ -29,13 +29,14 @@ inputfile="./inception_v3.pb"
 outputfile="./inception_v3.circle"
 
 # Note: Do not remove output circle file as it's used for quantize tests
+rm -f ${filename}.log
 
 # run test
 one-import tf \
 --input_path ${inputfile} \
 --output_path ${outputfile} \
 --input_arrays input --input_shapes "1,299,299,3" \
---output_arrays InceptionV3/Predictions/Reshape_1 > /dev/null 2>&1
+--output_arrays InceptionV3/Predictions/Reshape_1 > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-import_002.test
+++ b/compiler/one-cmds/tests/one-import_002.test
@@ -30,9 +30,12 @@ trap trap_err_onexit ERR
 configfile="one-import_002.cfg"
 outputfile="inception_v3_cmd.circle"
 
+rm -f ${filename}.log
+rm -f ${outputfile}
+
 # run test
 one-import tf -C ${configfile} \
---output_path=${outputfile} > /dev/null 2>&1
+--output_path=${outputfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-import_003.test
+++ b/compiler/one-cmds/tests/one-import_003.test
@@ -30,10 +30,11 @@ trap trap_err_onexit ERR
 configfile="one-import_003.cfg"
 outputfile="test_saved_model.circle"
 
+rm -f ${filename}.log
 rm -f ${outputfile}
 
 # run test
-one-import tf -C ${configfile} > /dev/null 2>&1
+one-import tf -C ${configfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-import_004.test
+++ b/compiler/one-cmds/tests/one-import_004.test
@@ -30,10 +30,11 @@ trap trap_err_onexit ERR
 configfile="one-import_004.cfg"
 outputfile="test_keras_model.circle"
 
+rm -f ${filename}.log
 rm -f ${outputfile}
 
 # run test
-one-import tf -C ${configfile} > /dev/null 2>&1
+one-import tf -C ${configfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-infer_001.test
+++ b/compiler/one-cmds/tests/one-infer_001.test
@@ -29,6 +29,8 @@ trap trap_err_onexit ERR
 # copy help-infer to bin folder
 cp help-infer ../bin/help-infer
 
+rm -f ${filename}.log
+
 # run test
 one-infer -d help-infer -- -h > ${filename}.log
 

--- a/compiler/one-cmds/tests/one-infer_002.test
+++ b/compiler/one-cmds/tests/one-infer_002.test
@@ -35,6 +35,8 @@ fi
 # copy dummy-infer to bin folder
 cp dummy-infer ../bin/dummy-infer
 
+rm -f ${filename}.log
+
 # run test
 one-infer -d dummy-infer -- ${inputfile} > ${filename}.log
 

--- a/compiler/one-cmds/tests/one-infer_003.test
+++ b/compiler/one-cmds/tests/one-infer_003.test
@@ -27,6 +27,8 @@ trap_err_onexit()
 
 trap trap_err_onexit ERR
 
+rm -f ${filename}.log
+
 # run test
 one-infer -h > ${filename}.log
 

--- a/compiler/one-cmds/tests/one-infer_004.test
+++ b/compiler/one-cmds/tests/one-infer_004.test
@@ -38,6 +38,8 @@ fi
 # copy dummy-infer to bin folder
 cp dummy-infer ../bin/dummy-infer
 
+rm -f ${filename}.log
+
 # run test
 one-infer -C ${configfile} > ${filename}.log
 

--- a/compiler/one-cmds/tests/one-infer_005.test
+++ b/compiler/one-cmds/tests/one-infer_005.test
@@ -37,6 +37,8 @@ fi
 # copy dummy-infer to bin folder
 cp dummy-infer ../bin/dummy-infer
 
+rm -f ${filename}.log
+
 # run test
 one-infer -d dummy-infer --post-process "./one-infer-test-post-process.py TOKEN" -- ${inputfile} > ${filename}.log 2>&1
 return_code=$?

--- a/compiler/one-cmds/tests/one-infer_neg_001.test
+++ b/compiler/one-cmds/tests/one-infer_neg_001.test
@@ -32,6 +32,8 @@ trap_err_onexit()
 
 trap trap_err_onexit ERR
 
+rm -f ${filename}.log
+
 # run test
 one-infer > ${filename}.log 2>&1
 

--- a/compiler/one-cmds/tests/one-infer_neg_002.test
+++ b/compiler/one-cmds/tests/one-infer_neg_002.test
@@ -33,8 +33,10 @@ trap_err_onexit()
 
 trap trap_err_onexit ERR
 
+rm -f ${filename}.log
+
 # run test
-one-infer -d ${driver_name} -- -h> ${filename}.log 2>&1
+one-infer -d ${driver_name} -- -h > ${filename}.log 2>&1
 
 echo "${filename_ext} FAILED"
 exit 255

--- a/compiler/one-cmds/tests/one-infer_neg_003.test
+++ b/compiler/one-cmds/tests/one-infer_neg_003.test
@@ -46,6 +46,8 @@ fi
 # copy dummy-infer to bin folder
 cp dummy-infer ../bin/dummy-infer
 
+rm -f ${filename}.log
+
 # run test
 one-infer -d dummy-infer --post-process "./one-infer-test-post-process.py" -- ${inputfile} > ${filename}.log 2>&1
 

--- a/compiler/one-cmds/tests/one-optimize_001.test
+++ b/compiler/one-cmds/tests/one-optimize_001.test
@@ -28,12 +28,13 @@ trap trap_err_onexit ERR
 inputfile="./inception_v3.circle"
 outputfile="./inception_v3-opt.circle"
 
+rm -f ${filename}.log
 rm -rf ${outputfile}
 
 # run test
 one-optimize --resolve_customop_add \
 --input_path ${inputfile} \
---output_path ${outputfile} > /dev/null 2>&1
+--output_path ${outputfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-optimize_002.test
+++ b/compiler/one-cmds/tests/one-optimize_002.test
@@ -28,13 +28,14 @@ trap trap_err_onexit ERR
 inputfile="./inception_v3.circle"
 outputfile="./inception_v3-opt.circle"
 
+rm -f ${filename}.log
 rm -rf ${outputfile}
 
 # run test
 one-optimize --resolve_customop_add \
 --change_outputs InceptionV3/Logits/SpatialSqueeze1 \
 --input_path ${inputfile} \
---output_path ${outputfile} > /dev/null 2>&1
+--output_path ${outputfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-optimize_neg_003.test
+++ b/compiler/one-cmds/tests/one-optimize_neg_003.test
@@ -34,6 +34,8 @@ trap trap_err_onexit ERR
 
 inputfile="./inception_v3.circle"
 
+rm -f ${filename}.log
+
 # run test
 one-optimize --resolve_customop_add \
 --input_path "${inputfile}" > "${filename}.log" 2>&1

--- a/compiler/one-cmds/tests/one-pack_001.test
+++ b/compiler/one-cmds/tests/one-pack_001.test
@@ -28,12 +28,13 @@ trap trap_err_onexit ERR
 inputfile="./inception_v3.circle"
 outputfolder="nnpack"
 
+rm -f ${filename}.log
 rm -rf ${outputfolder}
 
 # run test
 one-pack \
 -i ${inputfile} \
--o ${outputfolder} > /dev/null 2>&1
+-o ${outputfolder} > ${filename}.log 2>&1
 
 if [[ ! -d "${outputfolder}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-partition_001.test
+++ b/compiler/one-cmds/tests/one-partition_001.test
@@ -30,6 +30,7 @@ inputfile="${testmodel}.circle"
 partfile="${testmodel}.part"
 outputfile="${testmodel}.conn.json"
 
+rm -f ${filename}.log
 rm -rf  ${testmodel}.000*
 rm -rf  ${testmodel}.conn.*
 rm -rf  ${testmodel}.*.log
@@ -37,7 +38,7 @@ rm -rf  ${testmodel}.*.log
 # run test
 one-partition \
 --input_file ${inputfile} \
---part_file ${partfile} > /dev/null 2>&1
+--part_file ${partfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-profile_001.test
+++ b/compiler/one-cmds/tests/one-profile_001.test
@@ -29,6 +29,8 @@ trap trap_err_onexit ERR
 # copy help-profile to bin folder
 cp help-profile ../bin/help-profile
 
+rm -f ${filename}.log
+
 # run test
 one-profile -b help -- -h > ${filename}.log
 

--- a/compiler/one-cmds/tests/one-profile_002.test
+++ b/compiler/one-cmds/tests/one-profile_002.test
@@ -37,6 +37,8 @@ fi
 # copy dummy-profile to bin folder
 cp dummy-profile ../bin/dummy-profile
 
+rm -f ${filename}.log
+
 # run test
 one-profile -b dummy ${inputfile} > ${filename}.log
 

--- a/compiler/one-cmds/tests/one-profile_003.test
+++ b/compiler/one-cmds/tests/one-profile_003.test
@@ -27,6 +27,8 @@ trap_err_onexit()
 
 trap trap_err_onexit ERR
 
+rm -f ${filename}.log
+
 # run test
 one-profile -h > ${filename}.log
 

--- a/compiler/one-cmds/tests/one-profile_004.test
+++ b/compiler/one-cmds/tests/one-profile_004.test
@@ -38,6 +38,8 @@ fi
 # copy dummy-profile to bin folder
 cp dummy-profile ../bin/dummy-profile
 
+rm -f ${filename}.log
+
 # run test
 one-profile -C ${configfile} > ${filename}.log
 

--- a/compiler/one-cmds/tests/one-profile_neg_001.test
+++ b/compiler/one-cmds/tests/one-profile_neg_001.test
@@ -32,6 +32,8 @@ trap_err_onexit()
 
 trap trap_err_onexit ERR
 
+rm -f ${filename}.log
+
 # run test
 one-profile > ${filename}.log 2>&1
 

--- a/compiler/one-cmds/tests/one-quantize_001.test
+++ b/compiler/one-cmds/tests/one-quantize_001.test
@@ -28,6 +28,7 @@ trap trap_err_onexit ERR
 inputfile="./inception_v3.circle"
 outputfile="./inception_v3.quantized.circle"
 
+rm -f ${filename}.log
 rm -rf ${outputfile}
 
 # run test
@@ -36,7 +37,7 @@ one-quantize \
 --quantized_dtype uint8 \
 --input_path ./inception_v3.circle \
 --input_data ./inception_v3_test_data.h5 \
---output_path ./inception_v3.quantized.circle > /dev/null 2>&1
+--output_path ./inception_v3.quantized.circle > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-quantize_002.test
+++ b/compiler/one-cmds/tests/one-quantize_002.test
@@ -28,6 +28,7 @@ trap trap_err_onexit ERR
 inputfile="./inception_v3.circle"
 outputfile="./inception_v3.random.quantized.circle"
 
+rm -f ${filename}.log
 rm -rf ${outputfile}
 
 # run test without input data
@@ -35,7 +36,7 @@ one-quantize \
 --input_dtype float32 \
 --quantized_dtype uint8 \
 --input_path ${inputfile} \
---output_path ${outputfile} > /dev/null 2>&1
+--output_path ${outputfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-quantize_003.test
+++ b/compiler/one-cmds/tests/one-quantize_003.test
@@ -28,6 +28,7 @@ trap trap_err_onexit ERR
 inputfile="./inception_v3.circle"
 outputfile="./inception_v3.list.quantized.circle"
 
+rm -f ${filename}.log
 rm -rf ${outputfile}
 
 # run test with list-format input data (datalist.txt)
@@ -37,7 +38,7 @@ one-quantize \
 --input_path ${inputfile} \
 --input_data ./datalist.txt \
 --input_data_format list \
---output_path ${outputfile} > /dev/null 2>&1
+--output_path ${outputfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-quantize_004.test
+++ b/compiler/one-cmds/tests/one-quantize_004.test
@@ -28,6 +28,7 @@ trap trap_err_onexit ERR
 inputfile="./inception_v3.circle"
 outputfile="./inception_v3.directory.quantized.circle"
 
+rm -f ${filename}.log
 rm -rf ${outputfile}
 
 # run test with directory-format input data (raw_files)
@@ -37,7 +38,7 @@ one-quantize \
 --input_path ${inputfile} \
 --input_data ./raw_files \
 --input_data_format directory \
---output_path ${outputfile} > /dev/null 2>&1
+--output_path ${outputfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-quantize_005.test
+++ b/compiler/one-cmds/tests/one-quantize_005.test
@@ -28,6 +28,7 @@ trap trap_err_onexit ERR
 inputfile="./inception_v3.mat.q8.circle"
 outputfile="./inception_v3.one-quantize_005.q8.circle"
 
+rm -f ${filename}.log
 rm -rf ${outputfile}
 
 # run test with force_quantparam option
@@ -37,7 +38,7 @@ one-quantize \
 --scale 2.3 \
 --zero_point 33 \
 --input_path ${inputfile} \
---output_path ${outputfile} > /dev/null 2>&1
+--output_path ${outputfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-quantize_006.test
+++ b/compiler/one-cmds/tests/one-quantize_006.test
@@ -28,6 +28,7 @@ trap trap_err_onexit ERR
 inputfile="./inception_v3.mat.q8.circle"
 outputfile="./inception_v3.one-quantize_006.q8.circle"
 
+rm -f ${filename}.log
 rm -rf ${outputfile}
 
 # run test with force_quantparam option (multi tensors)
@@ -40,7 +41,7 @@ one-quantize \
 --scale 2.3 \
 --zero_point 33 \
 --input_path ${inputfile} \
---output_path ${outputfile} > /dev/null 2>&1
+--output_path ${outputfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-quantize_007.test
+++ b/compiler/one-cmds/tests/one-quantize_007.test
@@ -28,6 +28,7 @@ trap trap_err_onexit ERR
 inputfile="./inception_v3.circle"
 outputfile="./inception_v3.random.quantized.q16.iq8.circle"
 
+rm -f ${filename}.log
 rm -rf ${outputfile}
 
 # run test without input data
@@ -37,7 +38,7 @@ one-quantize \
 --granularity channel \
 --input_type uint8 \
 --input_path ${inputfile} \
---output_path ${outputfile} > /dev/null 2>&1
+--output_path ${outputfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-quantize_008.test
+++ b/compiler/one-cmds/tests/one-quantize_008.test
@@ -28,6 +28,7 @@ trap trap_err_onexit ERR
 inputfile="./inception_v3.circle"
 outputfile="./inception_v3.random.quantized.q16.oq8.circle"
 
+rm -f ${filename}.log
 rm -rf ${outputfile}
 
 # run test without input data
@@ -37,7 +38,7 @@ one-quantize \
 --granularity channel \
 --output_type uint8 \
 --input_path ${inputfile} \
---output_path ${outputfile} > /dev/null 2>&1
+--output_path ${outputfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-quantize_009.test
+++ b/compiler/one-cmds/tests/one-quantize_009.test
@@ -28,6 +28,7 @@ trap trap_err_onexit ERR
 inputfile="./inception_v3.circle"
 outputfile="./inception_v3.random.quantized.mixed.circle"
 
+rm -f ${filename}.log
 rm -rf ${outputfile}
 
 # run test without input data
@@ -37,7 +38,7 @@ one-quantize \
 --granularity channel \
 --quant_config one-quantize_009.qconf.json \
 --input_path ${inputfile} \
---output_path ${outputfile} > /dev/null 2>&1
+--output_path ${outputfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-quantize_010.test
+++ b/compiler/one-cmds/tests/one-quantize_010.test
@@ -39,6 +39,7 @@ inputfile="./inception_v3.circle"
 outputfile="./inception_v3.one-quantize_010.q.circle"
 datafile="./inception_v3_test_data.h5"
 
+rm -f ${filename}.log
 rm -rf ${outputfile}
 
 # run test

--- a/compiler/one-cmds/tests/one-quantize_011.test
+++ b/compiler/one-cmds/tests/one-quantize_011.test
@@ -39,6 +39,7 @@ inputfile="./inception_v3.circle"
 outputfile="./inception_v3.one-quantize_011.q.circle"
 datafile="./inception_v3_test_data.h5"
 
+rm -f ${filename}.log
 rm -rf ${outputfile}
 
 # run test

--- a/compiler/one-cmds/tests/one-quantize_012.test
+++ b/compiler/one-cmds/tests/one-quantize_012.test
@@ -28,6 +28,7 @@ trap trap_err_onexit ERR
 inputfile="./inception_v3.circle"
 outputfile="./inception_v3.one-quantize_012.q.circle"
 
+rm -f ${filename}.log
 rm -rf ${outputfile}
 
 # run test without input data
@@ -37,7 +38,7 @@ one-quantize \
 --granularity channel \
 --quant_config one-quantize_012.qconf.json \
 --input_path ${inputfile} \
---output_path ${outputfile} > /dev/null 2>&1
+--output_path ${outputfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-quantize_013.test
+++ b/compiler/one-cmds/tests/one-quantize_013.test
@@ -31,6 +31,7 @@ trap trap_err_onexit ERR
 inputfile="./inception_v3.circle"
 outputfile="./inception_v3.one-quantize_013.q.circle"
 
+rm -f ${filename}.log
 rm -rf ${outputfile}
 
 # run test without input data
@@ -39,7 +40,7 @@ one-quantize \
 --input_dtype float32 \
 --quant_config one-quantize_013.qconf.json \
 --input_path ${inputfile} \
---output_path ${outputfile} > /dev/null 2>&1
+--output_path ${outputfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/one-quantize_014.test
+++ b/compiler/one-cmds/tests/one-quantize_014.test
@@ -41,6 +41,7 @@ inputfile="./inception_v3.circle"
 outputfile="./inception_v3.one-quantize_014.q.circle"
 datadir="./raw_files/"
 
+rm -f ${filename}.log
 rm -rf ${outputfile}
 
 # run test

--- a/compiler/one-cmds/tests/one-quantize_015.test
+++ b/compiler/one-cmds/tests/one-quantize_015.test
@@ -30,6 +30,7 @@ trap trap_err_onexit ERR
 inputfile="./inception_v3.mat.q8.circle"
 outputfile="./inception_v3.one-quantize_015.fq.circle"
 
+rm -f ${filename}.log
 rm -rf ${outputfile}
 
 # run test

--- a/compiler/one-cmds/tests/onecc_001.test
+++ b/compiler/one-cmds/tests/onecc_001.test
@@ -30,8 +30,11 @@ trap trap_err_onexit ERR
 configfile="onecc_001.cfg"
 outputfile="inception_v3.opt.circle"
 
+rm -f ${filename}.log
+rm -f ${outputfile}
+
 # run test
-onecc -C ${configfile} > /dev/null 2>&1
+onecc -C ${configfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/onecc_002.test
+++ b/compiler/one-cmds/tests/onecc_002.test
@@ -30,8 +30,11 @@ trap trap_err_onexit ERR
 configfile="onecc_002.cfg"
 outputfile="inception_v3_pkg"
 
+rm -f ${filename}.log
+rm -rf ${outputfile}
+
 # run test
-onecc -C ${configfile} > /dev/null 2>&1
+onecc -C ${configfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/onecc_003.test
+++ b/compiler/one-cmds/tests/onecc_003.test
@@ -30,10 +30,11 @@ trap trap_err_onexit ERR
 configfile="onecc_003.cfg"
 outputfile="inception_v3.quantized.circle"
 
+rm -f ${filename}.log
 rm -rf ${outputfile}
 
 # run test
-onecc -C ${configfile} > /dev/null 2>&1
+onecc -C ${configfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/onecc_004.test
+++ b/compiler/one-cmds/tests/onecc_004.test
@@ -31,13 +31,14 @@ trap trap_err_onexit ERR
 configfile="onecc_004.cfg"
 outputfile="sample.tvn"
 
+rm -f ${filename}.log
 rm -rf ${outputfile}
 
 # copy dummy-compile to bin folder
 cp dummy-compile ../bin/dummy-compile
 
 # run test
-onecc -C ${configfile} > /dev/null 2>&1
+onecc -C ${configfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/onecc_005.test
+++ b/compiler/one-cmds/tests/onecc_005.test
@@ -31,13 +31,14 @@ trap trap_err_onexit ERR
 configfile="onecc_005.cfg"
 outputfile="sample.tvn"
 
+rm -f ${filename}.log
 rm -rf ${outputfile}
 
 # copy dummy-compile to bin folder
 cp dummy-compile ../bin/dummy-compile
 
 # run test
-onecc -C ${configfile} > /dev/null 2>&1
+onecc -C ${configfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/onecc_006.test
+++ b/compiler/one-cmds/tests/onecc_006.test
@@ -31,13 +31,14 @@ trap trap_err_onexit ERR
 configfile="onecc_006.cfg"
 outputfile="sample.tvn"
 
+rm -f ${filename}.log
 rm -rf ${outputfile}
 
 # copy dummy-compile to bin folder
 cp dummy-compile ../bin/dummy-compile
 
 # run test
-onecc -C ${configfile} > /dev/null 2>&1
+onecc -C ${configfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/onecc_007.test
+++ b/compiler/one-cmds/tests/onecc_007.test
@@ -30,10 +30,11 @@ trap trap_err_onexit ERR
 configfile="onecc_007.cfg"
 outputfile="inception_v3_pkg"
 
+rm -f ${filename}.log
 rm -rf ${outputfile}
 
 # run test
-onecc -C ${configfile} > /dev/null 2>&1
+onecc -C ${configfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/onecc_008.test
+++ b/compiler/one-cmds/tests/onecc_008.test
@@ -31,13 +31,14 @@ trap trap_err_onexit ERR
 configfile="onecc_008.cfg"
 outputfile="test_onnx_model.bin"
 
+rm -f ${filename}.log
 rm -rf ${outputfile}
 
 # copy dummy-compile to bin folder
 cp dummy-compile ../bin/dummy-compile
 
 # run test
-onecc -C ${configfile} > /dev/null 2>&1
+onecc -C ${configfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/onecc_009.test
+++ b/compiler/one-cmds/tests/onecc_009.test
@@ -31,13 +31,14 @@ trap trap_err_onexit ERR
 configfile="onecc_009.cfg"
 outputfile="onnx_conv2d_conv2d.bin"
 
+rm -f ${filename}.log
 rm -rf ${outputfile}
 
 # copy dummy-compile to bin folder
 cp dummy-compile ../bin/dummy-compile
 
 # run test
-onecc -C ${configfile} > /dev/null 2>&1
+onecc -C ${configfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/onecc_010.test
+++ b/compiler/one-cmds/tests/onecc_010.test
@@ -31,11 +31,12 @@ configfile="onecc_010.cfg"
 outputfile="inception_v3.alt.circle"
 intermfile="inception_v3.alt.tflite"
 
+rm -f ${filename}.log
 rm -rf ${outputfile}
 rm -rf ${intermfile}
 
 # run test
-onecc -C ${configfile} > /dev/null 2>&1
+onecc -C ${configfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/onecc_011.test
+++ b/compiler/one-cmds/tests/onecc_011.test
@@ -31,11 +31,12 @@ configfile="onecc_011.cfg"
 outputfile="test_onnx_model.circle"
 intermfile="test_onnx_model.tflite"
 
+rm -f ${filename}.log
 rm -rf ${outputfile}
 rm -rf ${intermfile}
 
 # run test
-onecc -C ${configfile} > /dev/null 2>&1
+onecc -C ${configfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/onecc_012.test
+++ b/compiler/one-cmds/tests/onecc_012.test
@@ -30,10 +30,11 @@ trap trap_err_onexit ERR
 configfile="onecc_012.cfg"
 outputfile="inception_v3.list.quantized.circle"
 
+rm -f ${filename}.log
 rm -rf ${outputfile}
 
 # run test
-onecc -C ${configfile} > /dev/null 2>&1
+onecc -C ${configfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/onecc_013.test
+++ b/compiler/one-cmds/tests/onecc_013.test
@@ -30,10 +30,11 @@ trap trap_err_onexit ERR
 configfile="onecc_013.cfg"
 outputfile="inception_v3.onecc_13.circle"
 
+rm -f ${filename}.log
 rm -rf ${outputfile}
 
 # run test
-onecc import tf -C ${configfile} > /dev/null 2>&1
+onecc import tf -C ${configfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/onecc_014.test
+++ b/compiler/one-cmds/tests/onecc_014.test
@@ -30,10 +30,11 @@ trap trap_err_onexit ERR
 configfile="onecc_014.cfg"
 outputfile="inception_v3.onecc_014.circle"
 
+rm -f ${filename}.log
 rm -rf ${outputfile}
 
 # run test
-onecc import tflite -C ${configfile} > /dev/null 2>&1
+onecc import tflite -C ${configfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/onecc_015.test
+++ b/compiler/one-cmds/tests/onecc_015.test
@@ -30,10 +30,11 @@ trap trap_err_onexit ERR
 configfile="onecc_015.cfg"
 outputfile="bcq.circle"
 
+rm -f ${filename}.log
 rm -rf ${outputfile}
 
 # run test
-onecc import bcq -C ${configfile} > /dev/null 2>&1
+onecc import bcq -C ${configfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/onecc_016.test
+++ b/compiler/one-cmds/tests/onecc_016.test
@@ -30,10 +30,11 @@ trap trap_err_onexit ERR
 configfile="onecc_016.cfg"
 outputfile="test_onnx_model.circle"
 
+rm -f ${filename}.log
 rm -rf ${outputfile}
 
 # run test
-onecc import onnx -C ${configfile} > /dev/null 2>&1
+onecc import onnx -C ${configfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/onecc_017.test
+++ b/compiler/one-cmds/tests/onecc_017.test
@@ -35,10 +35,11 @@ if [[ ! -s "${inputfile}" ]]; then
   trap_err_onexit
 fi
 
+rm -f ${filename}.log
 rm -rf ${outputfile}
 
 # run test
-onecc optimize -i ${inputfile} -o ${outputfile} > /dev/null 2>&1
+onecc optimize -i ${inputfile} -o ${outputfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/onecc_018.test
+++ b/compiler/one-cmds/tests/onecc_018.test
@@ -36,10 +36,11 @@ if [[ ! -s "${inputfile}" && ! -s "${inputdata}" ]]; then
   trap_err_onexit
 fi
 
+rm -f ${filename}.log
 rm -rf ${outputfile}
 
 # run test
-onecc quantize -i ${inputfile} -o ${outputfile} -d ${inputdata} > /dev/null 2>&1
+onecc quantize -i ${inputfile} -o ${outputfile} -d ${inputdata} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/onecc_019.test
+++ b/compiler/one-cmds/tests/onecc_019.test
@@ -35,10 +35,11 @@ if [[ ! -s "${inputfile}" ]]; then
   trap_err_onexit
 fi
 
+rm -f ${filename}.log
 rm -rf ${outputfile}
 
 # run test
-onecc pack -i ${inputfile} -o ${outputfile} > /dev/null 2>&1
+onecc pack -i ${inputfile} -o ${outputfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/onecc_020.test
+++ b/compiler/one-cmds/tests/onecc_020.test
@@ -38,13 +38,14 @@ if [[ ! -f "${inputfile}" ]]; then
   trap_err_onexit
 fi
 
+rm -f ${filename}.log
 rm -rf ${outputfile}
 
 # copy dummy-compile to bin folder
 cp dummy-compile ../bin/dummy-compile
 
 # run test
-onecc codegen -b dummy -o ${outputfile} ${inputfile} > /dev/null 2>&1
+onecc codegen -b dummy -o ${outputfile} ${inputfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/onecc_021.test
+++ b/compiler/one-cmds/tests/onecc_021.test
@@ -33,8 +33,10 @@ configfile="onecc_021.cfg"
 # copy dummy-profile to bin folder
 cp dummy-profile ../bin/dummy-profile
 
+rm -f ${filename}.log
+
 # run test
-onecc -C ${configfile} > ${filename}.log
+onecc -C ${configfile} > ${filename}.log 2>&1
 
 rm -rf ../bin/dummy-profile
 

--- a/compiler/one-cmds/tests/onecc_022.test
+++ b/compiler/one-cmds/tests/onecc_022.test
@@ -30,10 +30,11 @@ trap trap_err_onexit ERR
 configfile="onecc_022.cfg"
 outputfile="inception_v3.onecc_022.q8.circle"
 
+rm -f ${filename}.log
 rm -rf ${outputfile}
 
 # run test
-onecc -C ${configfile} > /dev/null 2>&1
+onecc -C ${configfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/onecc_023.test
+++ b/compiler/one-cmds/tests/onecc_023.test
@@ -30,10 +30,11 @@ trap trap_err_onexit ERR
 configfile="onecc_023.cfg"
 outputfile="inception_v3.onecc_023.q16.iq8.circle"
 
+rm -f ${filename}.log
 rm -rf ${outputfile}
 
 # run test
-onecc -C ${configfile} > /dev/null 2>&1
+onecc -C ${configfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/onecc_024.test
+++ b/compiler/one-cmds/tests/onecc_024.test
@@ -55,6 +55,7 @@ trap trap_err_onexit ERR
 configfile="onecc_024.cfg"
 outputfile="inception_v3.opt.circle"
 
+rm -f ${filename}.log
 rm -rf ${outputfile}
 
 if [ ! -d "../optimization" ]; then

--- a/compiler/one-cmds/tests/onecc_025.test
+++ b/compiler/one-cmds/tests/onecc_025.test
@@ -30,8 +30,11 @@ trap trap_err_onexit ERR
 configfile="onecc_001.cfg"
 outputfile="inception_v3.opt.circle"
 
+rm -f ${filename}.log
+rm -f ${outputfile}
+
 # run test
-onecc -C ${configfile} > /dev/null 2>&1
+onecc -C ${configfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/onecc_026.test
+++ b/compiler/one-cmds/tests/onecc_026.test
@@ -38,6 +38,7 @@ trap trap_err_onexit ERR
 configfile="onecc_026.cfg"
 outputfile="inception_v3.onecc_026.q.circle"
 
+rm -f ${filename}.log
 rm -rf ${outputfile}
 
 # run test

--- a/compiler/one-cmds/tests/onecc_027.test
+++ b/compiler/one-cmds/tests/onecc_027.test
@@ -33,8 +33,10 @@ configfile="onecc_027.cfg"
 # copy dummy-infer to bin folder
 cp dummy-infer ../bin/dummy-infer
 
+rm -f ${filename}.log
+
 # run test
-onecc -C ${configfile} > ${filename}.log
+onecc -C ${configfile} > ${filename}.log 2>&1
 
 rm -rf ../bin/dummy-infer
 

--- a/compiler/one-cmds/tests/onecc_028.test
+++ b/compiler/one-cmds/tests/onecc_028.test
@@ -30,6 +30,7 @@ trap trap_err_onexit ERR
 workflowfile="onecc_028.workflow.json"
 outputfile="inception_v3_pkg"
 
+rm -f ${filename}.log
 rm -rf ${outputfile}
 
 # run test

--- a/compiler/one-cmds/tests/onecc_042.test
+++ b/compiler/one-cmds/tests/onecc_042.test
@@ -31,16 +31,15 @@ trap_err_onexit()
 trap trap_err_onexit ERR
 
 configfile="onecc_042.cfg"
-logfile="onecc_042.log"
 
 rm -rf ${outputfile}
-rm -rf ${logfile}
+rm -rf ${filename}.log
 
 # copy dummyEnv-compile to bin folder
 cp dummyEnv-compile ../bin/dummyEnv-compile
 
 # run test
-onecc -C ${configfile} > ${logfile} 2>&1
+onecc -C ${configfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit

--- a/compiler/one-cmds/tests/rawdata2hdf5_001.test
+++ b/compiler/one-cmds/tests/rawdata2hdf5_001.test
@@ -27,12 +27,13 @@ trap trap_err_onexit ERR
 
 outputfile="./output_testdata.h5"
 
+rm -f ${filename}.log
 rm -rf ${outputfile}
 
 # run test
 rawdata2hdf5 \
 --data_list datalist.txt \
---output_path ${outputfile} >> /dev/null
+--output_path ${outputfile} > ${filename}.log 2>&1
 
 if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit


### PR DESCRIPTION
This commit revisits one-cmds test as follows.
- make it generate log file
- remove previous output and log file before the test

Related: #10344 
Signed-off-by: seongwoo <mhs4670go@naver.com>