### PR TITLE
[onert] Support NCHW layout for type-aware quantization

### DIFF
--- a/runtime/onert/core/src/exec/IPermuteFunction.cc
+++ b/runtime/onert/core/src/exec/IPermuteFunction.cc
@@ -60,13 +60,19 @@ void elementwiseQuantize(const backend::ITensor *src_tensor, backend::ITensor *d
   int max_val = std::numeric_limits<OutputT>::max();
 
   auto loop_shape = src_tensor->getShape();
+  const auto src_layout = src_tensor->layout();
+  const auto dst_layout = dst_tensor->layout();
+  const bool is_permutation = src_layout != dst_layout && loop_shape.rank() == 4;
   ShapeLoop(loop_shape, [&](const onert::ir::Coordinates &coords) {
     const InputT *input_data =
       reinterpret_cast<const InputT *>(src_tensor->buffer() + src_tensor->calcOffset(coords));
     int32_t unclamped = static_cast<int32_t>(round(*input_data / scale)) + zero_point;
     int32_t clamped = std::min(std::max(unclamped, min_val), max_val);
+
+    ir::Coordinates dst_coords =
+      is_permutation ? ir::convertCoordinates(coords, src_layout, dst_layout) : coords;
     OutputT *output_data =
-      reinterpret_cast<OutputT *>(dst_tensor->buffer() + dst_tensor->calcOffset(coords));
+      reinterpret_cast<OutputT *>(dst_tensor->buffer() + dst_tensor->calcOffset(dst_coords));
     *output_data = clamped;
   });
 }
@@ -100,12 +106,18 @@ void elementwiseDequantize(const backend::ITensor *src_tensor, backend::ITensor 
   const auto zero_point = src_tensor->data_zero_point();
 
   auto loop_shape = src_tensor->getShape();
+  const auto src_layout = src_tensor->layout();
+  const auto dst_layout = dst_tensor->layout();
+  const bool is_permutation = src_layout != dst_layout && loop_shape.rank() == 4;
   ShapeLoop(loop_shape, [&](const onert::ir::Coordinates &coords) {
     const InputT *input_data =
       reinterpret_cast<const InputT *>(src_tensor->buffer() + src_tensor->calcOffset(coords));
     const OutputT result = static_cast<OutputT>(scale * (*input_data - zero_point));
+
+    ir::Coordinates dst_coords =
+      is_permutation ? ir::convertCoordinates(coords, src_layout, dst_layout) : coords;
     OutputT *output_data =
-      reinterpret_cast<OutputT *>(dst_tensor->buffer() + dst_tensor->calcOffset(coords));
+      reinterpret_cast<OutputT *>(dst_tensor->buffer() + dst_tensor->calcOffset(dst_coords));
     *output_data = result;
   });
 }
@@ -137,12 +149,6 @@ template <typename SRC_T, typename DST_T,
                            bool> = true>
 void typeAwareQuantize(const SRC_T *src_tensor, DST_T *dst_tensor)
 {
-  // TODO Support different layouts
-  if (src_tensor->layout() != ir::Layout::NHWC || dst_tensor->layout() != ir::Layout::NHWC)
-  {
-    throw std::runtime_error("Currently, type-aware quantization supports only potable tensors");
-  }
-
   // TODO Support other types
   if (src_tensor->data_type() == ir::DataType::FLOAT32)
   {


### PR DESCRIPTION
This commit enables IPermuteFunction to support nchw layout in type-aware quantization.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>

---
For #10002
Draft #10329