### PR TITLE
[onert] Support type-aware quantization for multi-model

### DIFF
--- a/runtime/onert/core/include/exec/IExecutor.h
+++ b/runtime/onert/core/include/exec/IExecutor.h
@@ -92,6 +92,13 @@ struct IExecutor
                        const std::vector<backend::IPortableTensor *> &outputs) = 0;
 
   /**
+   * @brief Get input tensor objects
+   *
+   * @return Vector of @c IOTensor
+   */
+  virtual const std::vector<backend::builtin::IOTensor *> &getInputTensors() const = 0;
+
+  /**
    * @brief Get output tensor objects
    *
    * @return Vector of @c IOTensor

--- a/runtime/onert/core/src/backend/builtin/IOTensor.h
+++ b/runtime/onert/core/src/backend/builtin/IOTensor.h
@@ -47,7 +47,7 @@ public:
 public:
   void setTensor(IPortableTensor *tensor);
   void setUserTensor(uint8_t *buffer, size_t size);
-  ir::OperandInfo orig_info() const { return _orig_info; }
+  const ir::OperandInfo &orig_info() const { return _orig_info; }
   ir::Layout orig_layout() const { return _orig_layout; }
 
 public:

--- a/runtime/onert/core/src/exec/ExecutorBase.h
+++ b/runtime/onert/core/src/exec/ExecutorBase.h
@@ -68,6 +68,11 @@ public:
 
   void addObserver(std::unique_ptr<IExecutionObserver> ref) { _subject.add(std::move(ref)); };
 
+  const std::vector<backend::builtin::IOTensor *> &getInputTensors() const override
+  {
+    return _input_tensors;
+  }
+
   const std::vector<backend::builtin::IOTensor *> &getOutputTensors() const override
   {
     return _output_tensors;

--- a/runtime/onert/core/src/interp/InterpExecutor.h
+++ b/runtime/onert/core/src/interp/InterpExecutor.h
@@ -64,6 +64,10 @@ public:
   {
     throw new std::runtime_error{"Interpreter does not support subgraph calls(control flow ops)"};
   }
+  const std::vector<backend::builtin::IOTensor *> &getInputTensors() const final
+  {
+    throw new std::runtime_error{"Interpreter does not support this function."};
+  }
   const std::vector<backend::builtin::IOTensor *> &getOutputTensors() const final
   {
     throw new std::runtime_error{"Interpreter does not support this function."};


### PR DESCRIPTION
This commit applies type-aware quantization to multi-model.
  - Support type-aware quantization for multi-model
  - Add unittest for multi-model

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>

---
For #10002
Draft #10329