### PR TITLE
[visq-unittest] Remove redundant log

### DIFF
--- a/compiler/visq-unittest/test/testUtil.py
+++ b/compiler/visq-unittest/test/testUtil.py
@@ -42,7 +42,6 @@ class VisqUtilTest(unittest.TestCase):
         three_digits_ans = [0.123, 12.346, [0.123], {'test': [0.123]}]
         for test_data, ans in zip(test_configs, three_digits_ans):
             res = pretty_float(test_data, ndigits=3)
-            print(res)
             self.assertEqual(res, ans)
 
         test_configs = [0.123456, 12.3456, [0.123456], {'test': [0.123456]}]


### PR DESCRIPTION
This removes redundant print in the test code.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>