### PR TITLE
[circle2circle] Add fuse_prelu option

### DIFF
--- a/compiler/circle2circle/src/Circle2Circle.cpp
+++ b/compiler/circle2circle/src/Circle2Circle.cpp
@@ -110,7 +110,7 @@ int entry(int argc, char **argv)
              "when the impact is known to be acceptable.");
   add_switch(arser, "--fuse_preactivation_batchnorm",
              "This will fuse BatchNorm operators of pre-activations to Convolution operator");
-  add_switch(arser, "--fuse_prelu", "This will fuse sub-graph to PReLU that is equivalent");
+  add_switch(arser, "--fuse_prelu", "This will fuse operators to PReLU operator");
   add_switch(arser, "--remove_duplicate_const", "This will remove all duplicate constant nodes");
   add_switch(arser, "--remove_fakequant", "This will remove FakeQuant operators");
   add_switch(arser, "--remove_quantdequant", "This will remove Quantize-Dequantize sequence");

--- a/compiler/circle2circle/src/Circle2Circle.cpp
+++ b/compiler/circle2circle/src/Circle2Circle.cpp
@@ -110,6 +110,7 @@ int entry(int argc, char **argv)
              "when the impact is known to be acceptable.");
   add_switch(arser, "--fuse_preactivation_batchnorm",
              "This will fuse BatchNorm operators of pre-activations to Convolution operator");
+  add_switch(arser, "--fuse_prelu", "This will fuse sub-graph to PReLU that is equivalent");
   add_switch(arser, "--remove_duplicate_const", "This will remove all duplicate constant nodes");
   add_switch(arser, "--remove_fakequant", "This will remove FakeQuant operators");
   add_switch(arser, "--remove_quantdequant", "This will remove Quantize-Dequantize sequence");
@@ -254,6 +255,8 @@ int entry(int argc, char **argv)
     options->enable(Algorithms::MakeBatchNormGammaPositive);
   if (arser.get<bool>("--fuse_preactivation_batchnorm"))
     options->enable(Algorithms::FusePreActivationBatchNorm);
+  if (arser.get<bool>("--fuse_prelu"))
+    options->enable(Algorithms::FusePRelu);
   if (arser.get<bool>("--fuse_transpose_with_mean"))
     options->enable(Algorithms::FuseTransposeWithMean);
   if (arser.get<bool>("--remove_duplicate_const"))


### PR DESCRIPTION
This will add fuse_prelu option to fuse some sort of subgraph to CirclePRelu Op.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>