### PR TITLE
[one-cmds] Enable fuse_prelu

### DIFF
--- a/compiler/one-cmds/how-to-use-one-commands.txt
+++ b/compiler/one-cmds/how-to-use-one-commands.txt
@@ -169,6 +169,7 @@ Current transformation options are
 - fuse_instnorm: This will convert instance normalization related operators to
   one InstanceNormalization operator that our onert provides for faster
   execution.
+- fuse_prelu: This will fuse operators to PReLU operator
 - fuse_preactivation_batchnorm: This fuses batch normalization operators of pre-activations to Conv operators.
 - fuse_activation_function: This fuses Activation function to a preceding operator.
 - fuse_mean_with_mean: This fuses two consecutive ReduceMean operations into one.

--- a/compiler/one-cmds/onelib/constant.py
+++ b/compiler/one-cmds/onelib/constant.py
@@ -54,6 +54,7 @@ class CONSTANT:
          ' So, use it only when the impact is known to be acceptable.'),
         ('fuse_activation_function', 'fuse Activation function to a preceding operator'),
         ('fuse_instnorm', 'fuse ops to InstanceNorm operator'),
+        ('fuse_prelu', 'fuse ops to PReLU operator'),
         ('replace_cw_mul_add_with_depthwise_conv',
          'replace channel-wise Mul/Add with DepthwiseConv2D'),
         ('remove_fakequant', 'remove FakeQuant ops'),


### PR DESCRIPTION
This will enable fuse_prelu option to one-cmds optimize.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>