### PR TITLE
[onert-micro] Support variable and intermediate tensors

### DIFF
--- a/onert-micro/luci-interpreter/src/core/RuntimeGraph.cpp
+++ b/onert-micro/luci-interpreter/src/core/RuntimeGraph.cpp
@@ -49,6 +49,12 @@ void IBaseRuntimeGraph::addInputTensor(Tensor *input_tensor)
   _input_tensors.push_back(input_tensor);
 }
 
+void IBaseRuntimeGraph::addIntermediateTensorAffineQuantization(
+  AffineQuantization *intermediate_tensor_affine_quant)
+{
+  _intermediate_tensors_affine_quantizations.push_back(intermediate_tensor_affine_quant);
+}
+
 void IBaseRuntimeGraph::addOutputTensor(Tensor *output_tensor)
 {
   _output_tensors.push_back(output_tensor);

--- a/onert-micro/luci-interpreter/src/core/RuntimeGraph.h
+++ b/onert-micro/luci-interpreter/src/core/RuntimeGraph.h
@@ -38,11 +38,16 @@ public:
   Tensor *addTensor(std::unique_ptr<Tensor> &&tensor);
   AffineQuantization *addAffineQuantization(std::unique_ptr<AffineQuantization> &&quantization);
 
+  void addIntermediateTensorAffineQuantization(AffineQuantization *intermediate_tensor);
   void addInputTensor(Tensor *input_tensor);
   void addOutputTensor(Tensor *output_tensor);
 
   void configureAllocations(Tensor *tensor);
 
+  const std::vector<AffineQuantization *> &getIntermediateAffineQuantizations() const
+  {
+    return _intermediate_tensors_affine_quantizations;
+  }
   const std::vector<Tensor *> &getInputTensors() const { return _input_tensors; }
   const std::vector<Tensor *> &getOutputTensors() const { return _output_tensors; }
 
@@ -61,6 +66,7 @@ protected:
   std::vector<std::unique_ptr<Tensor>> _tensors;
   std::vector<std::unique_ptr<AffineQuantization>> _affine_quantizations;
   std::vector<Tensor *> _input_tensors;
+  std::vector<AffineQuantization *> _intermediate_tensors_affine_quantizations;
   std::vector<Tensor *> _output_tensors;
 
   bool _is_valid = false;

--- a/onert-micro/luci-interpreter/src/loader/GraphLoader.cpp
+++ b/onert-micro/luci-interpreter/src/loader/GraphLoader.cpp
@@ -71,15 +71,15 @@ bool GraphLoader::isCouldBeEmplaceTensor(const int32_t tensor_index)
   return true;
 }
 
-void GraphLoader::loadTensors()
+void GraphLoader::loadTensors(bool use_static_memory_manager)
 {
   for (uint32_t i = 0; i < _reader->tensors().size(); ++i)
   {
     const auto const_tensor = _reader->tensors().at(i);
 
-    // TODO: handle with variable tensors
-    if (const_tensor->is_variable())
-      continue;
+    // TODO: handle variable tensors with static memory manager
+    if (const_tensor->is_variable() and use_static_memory_manager)
+      assert(false && "Not supported now");
 
     auto const buffer = wrap(_reader->buffers()[const_tensor->buffer()]->data());
     auto const const_dims = wrap(const_tensor->shape()); // in NHWC
@@ -95,7 +95,7 @@ void GraphLoader::loadTensors()
       size *= const_dim;
     }
 
-    if (buffer.empty() && size > 0)
+    if (buffer.empty() && size > 0 && not const_tensor->is_variable())
     {
       // normal empty tensor
       continue;
@@ -111,10 +111,10 @@ void GraphLoader::loadTensors()
     const auto dtype = luci_datatype(const_tensor->type());
 
     AffineQuantization *quantization = nullptr;
-    if (dtype == DataType::U8 or dtype == DataType::S8 or dtype == DataType::S16)
+    const auto quant_params = const_tensor->quantization();
+    if (quant_params)
     {
       auto unique_ptr_quantization = std::make_unique<AffineQuantization>();
-      const auto quant_params = const_tensor->quantization();
       assert(quant_params->zero_point()->size() == quant_params->scale()->size());
       unique_ptr_quantization->scale.assign(quant_params->scale()->cbegin(),
                                             quant_params->scale()->cend());
@@ -125,12 +125,25 @@ void GraphLoader::loadTensors()
       quantization = _runtime_graph->addAffineQuantization(std::move(unique_ptr_quantization));
     }
 
+    // Let's check if tensor with zero size have quantization params
+    if (size == 0)
+    {
+      if (quantization != nullptr)
+        _runtime_graph->addIntermediateTensorAffineQuantization(quantization);
+
+      continue;
+    }
+
     // Get pointer to data from buffer
     auto data_ptr = const_cast<unsigned char *>(buffer.data());
 
     auto tensor = std::make_unique<Tensor>(dtype, std::move(shape), quantization);
+
+    assert(data_ptr != nullptr or const_tensor->is_variable());
+
     // Save pointer to const data
-    tensor->writeDataWithoutCopy(static_cast<void *>(data_ptr));
+    if (data_ptr)
+      tensor->writeDataWithoutCopy(static_cast<void *>(data_ptr));
 
     _index_to_tensor->emplace(i, tensor.get());
     _runtime_graph->addTensor(std::move(tensor));
@@ -152,10 +165,10 @@ void GraphLoader::initInputTensors(bool use_static_memory_manager) const
     }
 
     AffineQuantization *quantization = nullptr;
-    if (dtype == DataType::U8 or dtype == DataType::S8 or dtype == DataType::S16)
+    const auto quant_params = tensor->quantization();
+    if (quant_params)
     {
       auto unique_ptr_quantization = std::make_unique<AffineQuantization>();
-      const auto quant_params = tensor->quantization();
       assert(quant_params->zero_point()->size() == quant_params->scale()->size());
       unique_ptr_quantization->scale.assign(quant_params->scale()->cbegin(),
                                             quant_params->scale()->cend());
@@ -279,10 +292,10 @@ void GraphLoader::loadOperators(bool use_static_memory_manager)
       }
 
       AffineQuantization *quantization = nullptr;
-      if (dtype == DataType::U8 or dtype == DataType::S8 or dtype == DataType::S16)
+      const auto quant_params = tensor->quantization();
+      if (quant_params)
       {
         auto unique_ptr_quantization = std::make_unique<AffineQuantization>();
-        const auto quant_params = tensor->quantization();
         assert(quant_params->zero_point()->size() == quant_params->scale()->size());
         unique_ptr_quantization->scale.assign(quant_params->scale()->cbegin(),
                                               quant_params->scale()->cend());

--- a/onert-micro/luci-interpreter/src/loader/GraphLoader.h
+++ b/onert-micro/luci-interpreter/src/loader/GraphLoader.h
@@ -33,7 +33,7 @@ public:
               IMemoryManager *memory_manager,
               std::unordered_map<int32_t, Tensor *> *index_to_tensor);
 
-  void loadTensors();
+  void loadTensors(bool use_static_memory_manager);
   void initInputTensors(bool use_static_memory_manager) const;
   void loadOperators(bool use_static_memory_manager);
 

--- a/onert-micro/luci-interpreter/src/loader/ModuleLoader.cpp
+++ b/onert-micro/luci-interpreter/src/loader/ModuleLoader.cpp
@@ -49,7 +49,7 @@ void ModuleLoader::load(bool use_static_memory_manager)
     GraphLoader loader(&reader, runtime_graph, _memory_manager, &_index_to_tensor);
 
     loader.initInputTensors(use_static_memory_manager);
-    loader.loadTensors();
+    loader.loadTensors(use_static_memory_manager);
     loader.loadOperators(use_static_memory_manager);
   }
 


### PR DESCRIPTION
This PR adds support of variable and intermediate tensors in onert-micro.

for issue: https://github.com/Samsung/ONE/issues/10375
from draft #10376

ONE-DCO-1.0-Signed-off-by: Artem Balyshev <a.balyshev@samsung.com>