### PR TITLE
[luci] Quantize inactive inputs

### DIFF
--- a/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
+++ b/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
@@ -558,7 +558,10 @@ bool QuantizeWithMinMaxPass::run(loco::Graph *g)
   };
 
   // Quantize activation
-  for (auto node : loco::active_nodes(loco::output_nodes(g)))
+  // Why all_nodes?
+  // Models can have inactive (unused) inputs.
+  // We do not reject such models, but quantize them too
+  for (auto node : loco::all_nodes(g))
   {
     auto circle_node = loco::must_cast<luci::CircleNode *>(node);
     QuantizeActivation qa(_ctx->input_model_dtype, quantize_dtype(circle_node));

--- a/compiler/luci/pass/src/QuantizeWithMinMaxPass.test.cpp
+++ b/compiler/luci/pass/src/QuantizeWithMinMaxPass.test.cpp
@@ -74,3 +74,16 @@ TEST(QuantizeWithMinMaxPassTest, int_concat)
   EXPECT_EQ(nullptr, g.input_1->quantparam());
   EXPECT_EQ(nullptr, g.input_2->quantparam());
 }
+
+TEST(QuantizeWithMinMaxPassTest, inactive_input)
+{
+  SimpleConcatGraph g(loco::DataType::FLOAT32);
+
+  // Unused input
+  g.g.nodes()->create<luci::CircleInput>();
+
+  luci::QuantizeWithMinMaxPass qwmm(loco::DataType::FLOAT32, loco::DataType::U8,
+                                    luci::QuantizationGranularity::LayerWise);
+
+  EXPECT_NO_THROW(qwmm.run(&g.g));
+}


### PR DESCRIPTION
This allows to quantize inactive (unused) inputs.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>