### PR TITLE
[circle-mpqsolver] Fix 'README.md' for qerror_ratio parameter

### DIFF
--- a/compiler/circle-mpqsolver/README.md
+++ b/compiler/circle-mpqsolver/README.md
@@ -36,7 +36,7 @@ Run _circle-mpqsolver_ with the following arguments.
 
 --output_model: Output qunatized mode
 
---qerror_ratio: Target quantization error ratio. It should be in [0, 1]. 0 indicates qerror of full uint8 model, 1 indicates qerror of full int16 model.
+--qerror_ratio: Target quantization error ratio. It should be in [0, 1]. 0 indicates qerror of full uint16 model, 1 indicates qerror of full int8 model. The lower `qerror_ratio` the more accurate the solution.
 
 --bisection _mode_: input nodes should be at Q16 precision ['auto', 'true', 'false']
 

--- a/compiler/circle-mpqsolver/README.md
+++ b/compiler/circle-mpqsolver/README.md
@@ -36,7 +36,7 @@ Run _circle-mpqsolver_ with the following arguments.
 
 --output_model: Output qunatized mode
 
---qerror_ratio: Target quantization error ratio. It should be in [0, 1]. 0 indicates qerror of full uint16 model, 1 indicates qerror of full int8 model. The lower `qerror_ratio` the more accurate the solution.
+--qerror_ratio: Target quantization error ratio. It should be in [0, 1]. 0 indicates qerror of full int16 model, 1 indicates qerror of full uint8 model. The lower `qerror_ratio` indicates the more accurate solution.
 
 --bisection _mode_: input nodes should be at Q16 precision ['auto', 'true', 'false']
 


### PR DESCRIPTION
This commit fixes details of qerror_ratio parameter in 'README.md'.

Issue: #10387

ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>