### PR TITLE
[dalgona-test] Enable test jammy/venv_2_10_1

### DIFF
--- a/compiler/dalgona-test/CMakeLists.txt
+++ b/compiler/dalgona-test/CMakeLists.txt
@@ -56,3 +56,14 @@ add_test(
           "${NNCC_OVERLAY_DIR}/venv_2_8_0"
           ${DALGONA_SINGLE_OP_TEST}
 )
+
+if(ONE_UBUNTU_CODENAME_JAMMY)
+  add_test(
+    NAME dalgona_single_op_210_test
+    COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/TestSingleOp.sh"
+            "${TEST_CONFIG}"
+            "${ARTIFACTS_BIN_PATH}"
+            "${NNCC_OVERLAY_DIR}/venv_2_10_1"
+            ${DALGONA_SINGLE_OP_TEST}
+  )
+endif(ONE_UBUNTU_CODENAME_JAMMY)


### PR DESCRIPTION
This will enable test for jammy within venv_2_10_1.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>