### PR TITLE
[onert-micro] Introduce UnidirectionalSequenceLSTMParams

### DIFF
--- a/onert-micro/luci-interpreter/src/core/KernelParams.h
+++ b/onert-micro/luci-interpreter/src/core/KernelParams.h
@@ -213,6 +213,15 @@ struct TransposeConvParams
   int32_t stride_width;
 };
 
+struct UnidirectionalSequenceLSTMParams
+{
+  Activation activation;
+  float cell_clip;
+  float proj_clip;
+  bool time_major;
+  bool asymmetric_quantize_inputs;
+};
+
 struct UnpackParams
 {
   int axis;


### PR DESCRIPTION
This commit introduces UnidirectionalSequenceLSTMParams structure.

for issue https://github.com/Samsung/ONE/issues/10375
from draft https://github.com/Samsung/ONE/pull/10376

ONE-DCO-1.0-Signed-off-by: Vyacheslav Bazhenov <slavikmipt@gmail.com>