### PR TITLE
[onert] Revisit `SingleModelExecutors`

### DIFF
--- a/runtime/onert/core/src/exec/SingleModelExecutors.cc
+++ b/runtime/onert/core/src/exec/SingleModelExecutors.cc
@@ -16,6 +16,8 @@
 
 #include "SingleModelExecutors.h"
 
+#include "../backend/builtin/IOTensor.h"
+
 namespace onert
 {
 namespace exec
@@ -35,24 +37,22 @@ IExecutor *SingleModelExecutors::at(const ir::ModelIndex &,
 
 uint32_t SingleModelExecutors::inputSize() const
 {
-  return entryExecutor()->graph().getInputs().size();
+  return entryExecutor()->getInputTensors().size();
 }
 
 uint32_t SingleModelExecutors::outputSize() const
 {
-  return entryExecutor()->graph().getOutputs().size();
+  return entryExecutor()->getOutputTensors().size();
 }
 
 const ir::OperandInfo &SingleModelExecutors::inputInfo(const ir::IOIndex &index) const
 {
-  const auto input_index = entryExecutor()->graph().getInputs().at(index);
-  return entryExecutor()->graph().operands().at(input_index).info();
+  return entryExecutor()->getInputTensors().at(index.value())->orig_info();
 }
 
 const ir::OperandInfo &SingleModelExecutors::outputInfo(const ir::IOIndex &index) const
 {
-  auto output_index = entryExecutor()->graph().getOutputs().at(index);
-  return entryExecutor()->graph().operands().at(output_index).info();
+  return entryExecutor()->getOutputTensors().at(index.value())->orig_info();
 }
 
 void SingleModelExecutors::execute(const IODescription &desc) { entryExecutor()->execute(desc); }

--- a/runtime/onert/core/src/interp/InterpExecutor.h
+++ b/runtime/onert/core/src/interp/InterpExecutor.h
@@ -39,10 +39,7 @@ class ITensor;
 class InterpExecutor final : public exec::IExecutor
 {
 public:
-  explicit InterpExecutor(const ir::Graph &graph) : _graph(graph)
-  {
-    // DO NOTHING
-  }
+  explicit InterpExecutor(const ir::Graph &graph);
 
 public:
   /**
@@ -66,11 +63,11 @@ public:
   }
   const std::vector<backend::builtin::IOTensor *> &getInputTensors() const final
   {
-    throw new std::runtime_error{"Interpreter does not support this function."};
+    return _input_tensors;
   }
   const std::vector<backend::builtin::IOTensor *> &getOutputTensors() const final
   {
-    throw new std::runtime_error{"Interpreter does not support this function."};
+    return _output_tensors;
   }
 
 private:
@@ -81,6 +78,9 @@ private:
    */
   const ir::Graph _graph;
   ir::OperandIndexMap<std::shared_ptr<ITensor>> _tensor_map;
+  std::vector<backend::builtin::IOTensor *> _input_tensors;
+  std::vector<backend::builtin::IOTensor *> _output_tensors;
+  ir::OperandIndexMap<std::shared_ptr<backend::builtin::IOTensor>> _io_tensors;
 };
 
 } // namespace interp


### PR DESCRIPTION
This commit changes getting IO information to get it from io tensors instead of Graph.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>

---
For #10002
Draft #10329