### PR TITLE
[rec-minmax-t-safety-test] Enable test jammy/venv_2_10_1

### DIFF
--- a/compiler/record-minmax-thread-safety-test/CMakeLists.txt
+++ b/compiler/record-minmax-thread-safety-test/CMakeLists.txt
@@ -60,3 +60,14 @@ add_test(
         "${NNCC_OVERLAY_DIR}/venv_2_8_0"
         ${RECORD_MINMAX_THREAD_SAFETY_TEST}
 )
+
+if(ONE_UBUNTU_CODENAME_JAMMY)
+    add_test(
+            NAME record_minmax_thread_safety_210_test
+            COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/testall.sh"
+            "${TEST_CONFIG}"
+            "${ARTIFACTS_BIN_PATH}"
+            "${NNCC_OVERLAY_DIR}/venv_2_10_1"
+            ${RECORD_MINMAX_THREAD_SAFETY_TEST}
+    )
+endif(ONE_UBUNTU_CODENAME_JAMMY)


### PR DESCRIPTION
This will enable test for jammy within venv_2_10_1.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>