### PR TITLE
[tf2tflitev2-conv-test] Enable test jammy/venv_2_10_1

### DIFF
--- a/compiler/tf2tfliteV2-conversion-test/CMakeLists.txt
+++ b/compiler/tf2tfliteV2-conversion-test/CMakeLists.txt
@@ -76,7 +76,12 @@ list(APPEND TEST_DEPS "${TEST_RUNNER}")
 
 get_target_property(ARTIFACTS_BIN_PATH testDataGenerator BINARY_DIR)
 
-set(VIRTUALENV "${NNCC_OVERLAY_DIR}/venv_2_8_0")
+# TODO Run both 2.8.0 and 2.10.1 test for jammy
+if(ONE_UBUNTU_CODENAME_JAMMY)
+  set(VIRTUALENV "${NNCC_OVERLAY_DIR}/venv_2_10_1")
+else()
+  set(VIRTUALENV "${NNCC_OVERLAY_DIR}/venv_2_8_0")
+endif()
 
 ###
 ### Generate test.config


### PR DESCRIPTION
This will enable test for jammy within venv_2_10_1.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>