### PR TITLE
[visq-unittest] Enable test jammy/venv_2_10_1

### DIFF
--- a/compiler/visq-unittest/CMakeLists.txt
+++ b/compiler/visq-unittest/CMakeLists.txt
@@ -56,3 +56,11 @@ add_test(
   COMMAND ${NNCC_OVERLAY_DIR}/venv_2_8_0/bin/python -m unittest
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
+
+if(ONE_UBUNTU_CODENAME_JAMMY)
+  add_test(
+    NAME visq_210_unittest
+    COMMAND ${NNCC_OVERLAY_DIR}/venv_2_10_1/bin/python -m unittest
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  )
+endif(ONE_UBUNTU_CODENAME_JAMMY)


### PR DESCRIPTION
This will enable test for jammy within venv_2_10_1.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>