### PR TITLE
[onert] Fix using after forward

### DIFF
--- a/runtime/onert/core/include/util/Utils.h
+++ b/runtime/onert/core/include/util/Utils.h
@@ -40,8 +40,7 @@ template <size_t from, size_t to, typename Enable = void> struct ForEachDimensio
     for (auto v = 0; v < d; v++)
     {
       coords.set(from, v);
-      ForEachDimension<from + 1, to>::unroll(shape, coords, std::forward<L>(lambda_function),
-                                             std::forward<Args>(args)...);
+      ForEachDimension<from + 1, to>::unroll(shape, coords, lambda_function, args...);
     }
   }
 };


### PR DESCRIPTION
This commit resolves warning: using after std::forward.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>