### PR TITLE
[tools/tflitefile_tool] Fix numpy bool type

### DIFF
--- a/tools/tflitefile_tool/parser/tflite/tflite_tensor.py
+++ b/tools/tflitefile_tool/parser/tflite/tflite_tensor.py
@@ -54,7 +54,7 @@ def GetTypeSize(type_name):
 
 
 TYPE_TO_NPTYPE = {
-    'BOOL': np.bool,
+    'BOOL': np.bool_,
     'COMPLEX64': np.cdouble,
     'FLOAT16': np.float16,
     'FLOAT32': np.float32,


### PR DESCRIPTION
This commit changes numpy `bool` type to `bool_` type. 
`bool` type is deprecated.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>