### PR TITLE
[infra] Remove interpreter nnpackage test

### DIFF
--- a/infra/scripts/test_arm_nnpkg.sh
+++ b/infra/scripts/test_arm_nnpkg.sh
@@ -10,7 +10,4 @@ do
   NNPackageTest ${BACKEND} "Product/out/test/list/nnpkg_test_list.armv7l-linux.${BACKEND}"
 done
 
-# Interpreter test
-export DISABLE_COMPILE=1
-NNPackageTest "interp" "Product/out/test/list/nnpkg_test_list.noarch.interp"
 unset DISABLE_COMPILE


### PR DESCRIPTION
This commit removes runtime's interpreter nnpackage test.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>