### PR TITLE
[luci] Skip unnecessary traversal in ConvertNCHWToNHWCPass

### DIFF
--- a/compiler/luci/pass/src/ConvertNCHWToNHWCPass.cpp
+++ b/compiler/luci/pass/src/ConvertNCHWToNHWCPass.cpp
@@ -1454,6 +1454,10 @@ bool ConvertNCHWToNHWCPass::run(loco::Graph *g)
       collect_intermediate = [&](loco::Node *n) {
         for (auto succ : loco::succs(n))
         {
+          // Skip unnecessary traversal
+          if (intermediate.find(succ) != intermediate.end())
+            continue;
+
           // Exit condition
           if (is_post_transpose(succ) || is_post_reshape(succ))
             continue;


### PR DESCRIPTION
This skips unnecessary traversal in ConvertNCHWToNHWCPass.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>