### PR TITLE
[luci-value-test] Temporary disable YUV_TO_RGB_U8_000

### DIFF
--- a/compiler/luci-value-test/test.lst
+++ b/compiler/luci-value-test/test.lst
@@ -188,7 +188,8 @@ addeval(UnidirectionalSequenceLSTM_002)
 #addeval(While_001)
 #addeval(While_002)
 #addeval(While_003)
-addeval(YUV_TO_RGB_U8_000)
+# NOTE temporary disable to make CI happy, https://github.com/Samsung/ONE/issues/10438
+# addeval(YUV_TO_RGB_U8_000)
 #addeval(ZerosLike_000)
 
 # Simple Network test


### PR DESCRIPTION
This will temporary disable YUV_TO_RGB_U8_000 as sometimes fails in jammy and this makes CI unhappy.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>