### PR TITLE
[infra/dockerfile] Install sudo in ubuntu 22.04

### DIFF
--- a/infra/docker/jammy/Dockerfile
+++ b/infra/docker/jammy/Dockerfile
@@ -48,6 +48,7 @@ RUN apt-get update && apt-get -qqy install libgtest-dev
 # Setup user to match host user, and give superuser permissions
 ARG USER_ID=1000
 ARG GROUP_ID=${USER_ID}
+RUN apt-get update && apt-get -qqy install sudo
 RUN addgroup --gid ${GROUP_ID} ubuntu && adduser --disabled-password --gecos '' --uid ${USER_ID} --gid ${GROUP_ID} ubuntu && usermod -aG sudo ubuntu
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 


### PR DESCRIPTION
This commit adds sudo package installation.
Ubuntu 22.04 default image doesn't have sudo package.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>