### PR TITLE
[luci] Set keep_num_dims of CircleFullyConnected when cloning

### DIFF
--- a/compiler/luci/service/src/Nodes/CircleFullyConnected.cpp
+++ b/compiler/luci/service/src/Nodes/CircleFullyConnected.cpp
@@ -31,6 +31,7 @@ luci::CircleNode *CloneNodeLet<CN::DEF>::visit(const luci::CircleFullyConnected 
   {
     cloned->fusedActivationFunction(node->fusedActivationFunction());
     cloned->weights_format(node->weights_format());
+    cloned->keep_num_dims(node->keep_num_dims());
   }
   return cloned;
 }


### PR DESCRIPTION
This commit sets keep_num_dims attribute of CircleFullyConnected when cloning the node.

Related: #10450 
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>