### PR TITLE
[debian] Revisit rules

### DIFF
--- a/infra/debian/compiler/rules
+++ b/infra/debian/compiler/rules
@@ -17,5 +17,3 @@ override_dh_install:
 	install -T -m 755 -D "infra/packaging/res/tf2nnpkg.${PRESET}" "$(_DESTDIR)/bin/tf2nnpkg"
 	dh_install
 
-override_dh_builddeb:
-	dh_builddeb --destdir=$(NNAS_BUILD_PREFIX)


### PR DESCRIPTION
This commit revisits rules to change the destdir.

This change follows the CI change. At first, `destdir` should be given because default `destdir` - parent directory of working directory - cannot be accessed by docker container for permission issue. But for now, the restriction has been resolved so we don't have to override `destdir` anymore.

NOTE. This commit should be merged at the same time with the [CI change](https://github.sec.samsung.net/RS7-RuntimeNTools/nnfw_ci/pull/595).

Related: https://github.com/Samsung/ONE/issues/10425#issuecomment-1415340488

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>