### PR TITLE
[infra/cmake] Remove GTest cmake warning

### DIFF
--- a/infra/nnfw/cmake/packages/GTestConfig.cmake
+++ b/infra/nnfw/cmake/packages/GTestConfig.cmake
@@ -44,7 +44,7 @@ if(${GTEST_FOUND} AND TARGET Threads::Threads)
       add_library(gmock INTERFACE)
       target_include_directories(gmock INTERFACE ${GMOCK_INCLUDE_DIR})
       target_link_libraries(gmock INTERFACE ${GMOCK_LIBRARIES} Threads::Threads)
-    endif(GMOCK_LIBRARIES)
+    endif(GMOCK_LIBRARIES AND GMOCK_INCLUDE_DIR)
   endif(NOT TARGET gmock)
 
   if(NOT TARGET gmock_main)


### PR DESCRIPTION
This commit removes warning message by if-endif mismatching in GTest cmake.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>