### PR TITLE
[infra] Update binary gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,10 +7,11 @@ res/** linguist-detectable=false
 * text eol=lf
 
 # Binary - ignore text file setting
-*.caffemodel -text
-*.png -text
-*.pdf -text
-*.h5 -text
-*.tar.gz -text
-*.tflite -text
-*.bmp -text
+*.bmp binary
+*.caffemodel binary
+*.h5 binary
+*.jar binary
+*.pdf binary
+*.png binary
+*.tar.gz binary
+*.tflite binary


### PR DESCRIPTION
This commit updates .gitattributes file.
- Use binary macro instead of "-text"
- Add jar extension
- Sort binary extension

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>