### PR TITLE
[gbs] Disable armcl backend on tizen

### DIFF
--- a/infra/nnfw/cmake/options/options_aarch64-tizen.cmake
+++ b/infra/nnfw/cmake/options/options_aarch64-tizen.cmake
@@ -3,6 +3,7 @@
 #
 option(BUILD_ARMCOMPUTE "Build ARM Compute from the downloaded source" OFF)
 option(BUILD_TENSORFLOW_LITE "Build TensorFlow Lite from the downloaded source" OFF)
+option(DOWNLOAD_ARMCOMPUTE "Build ARM Compute from the downloaded source" OFF)
 option(DOWNLOAD_NEON2SSE "Download NEON2SSE library source" OFF)
 option(DOWNLOAD_GTEST "Download Google Test source and build Google Test" OFF)
 

--- a/infra/nnfw/cmake/options/options_armv7hl-tizen.cmake
+++ b/infra/nnfw/cmake/options/options_armv7hl-tizen.cmake
@@ -3,6 +3,7 @@
 #
 option(BUILD_ARMCOMPUTE "Build ARM Compute from the downloaded source" OFF)
 option(BUILD_TENSORFLOW_LITE "Build TensorFlow Lite from the downloaded source" OFF)
+option(DOWNLOAD_ARMCOMPUTE "Build ARM Compute from the downloaded source" OFF)
 option(DOWNLOAD_NEON2SSE "Download NEON2SSE library source" OFF)
 option(DOWNLOAD_GTEST "Download Google Test source and build Google Test" OFF)
 

--- a/infra/nnfw/cmake/options/options_armv7l-tizen.cmake
+++ b/infra/nnfw/cmake/options/options_armv7l-tizen.cmake
@@ -3,6 +3,7 @@
 #
 option(BUILD_ARMCOMPUTE "Build ARM Compute from the downloaded source" OFF)
 option(BUILD_TENSORFLOW_LITE "Build TensorFlow Lite from the downloaded source" OFF)
+option(DOWNLOAD_ARMCOMPUTE "Build ARM Compute from the downloaded source" OFF)
 option(DOWNLOAD_NEON2SSE "Download NEON2SSE library source" OFF)
 option(DOWNLOAD_GTEST "Download Google Test source and build Google Test" OFF)
 

--- a/packaging/nnfw.spec
+++ b/packaging/nnfw.spec
@@ -46,12 +46,6 @@ Source3019: FLATBUFFERS-2.0.tar.gz
 
 BuildRequires:  cmake
 
-%ifarch %{arm} aarch64
-# Require python for acl-ex library build pre-process
-BuildRequires:  python3
-BuildRequires:  libarmcl-devel >= v21.02
-%endif
-
 Requires(post): /sbin/ldconfig
 Requires(postun): /sbin/ldconfig
 


### PR DESCRIPTION
This commit disables armcl (neon, cl) backend on tizen.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>