### PR TITLE
Disable ACL Backend from tizen build

### DIFF
--- a/infra/nnfw/cmake/options/options_aarch64-tizen.cmake
+++ b/infra/nnfw/cmake/options/options_aarch64-tizen.cmake
@@ -1,6 +1,7 @@
 #
 # aarch64 tizen cmake options
 #
+option(DOWNLOAD_ARMCOMPUTE "Download ARM Compute source" OFF)
 option(BUILD_ARMCOMPUTE "Build ARM Compute from the downloaded source" OFF)
 option(BUILD_TENSORFLOW_LITE "Build TensorFlow Lite from the downloaded source" OFF)
 option(DOWNLOAD_NEON2SSE "Download NEON2SSE library source" OFF)

--- a/infra/nnfw/cmake/options/options_armv7hl-tizen.cmake
+++ b/infra/nnfw/cmake/options/options_armv7hl-tizen.cmake
@@ -1,6 +1,7 @@
 #
 # armv7hl tizen cmake options
 #
+option(DOWNLOAD_ARMCOMPUTE "Download ARM Compute source" OFF)
 option(BUILD_ARMCOMPUTE "Build ARM Compute from the downloaded source" OFF)
 option(BUILD_TENSORFLOW_LITE "Build TensorFlow Lite from the downloaded source" OFF)
 option(DOWNLOAD_NEON2SSE "Download NEON2SSE library source" OFF)

--- a/infra/nnfw/cmake/options/options_armv7l-tizen.cmake
+++ b/infra/nnfw/cmake/options/options_armv7l-tizen.cmake
@@ -1,6 +1,7 @@
 #
 # armv7l tizen cmake options
 #
+option(DOWNLOAD_ARMCOMPUTE "Download ARM Compute source" OFF)
 option(BUILD_ARMCOMPUTE "Build ARM Compute from the downloaded source" OFF)
 option(BUILD_TENSORFLOW_LITE "Build TensorFlow Lite from the downloaded source" OFF)
 option(DOWNLOAD_NEON2SSE "Download NEON2SSE library source" OFF)

--- a/packaging/nnfw.spec
+++ b/packaging/nnfw.spec
@@ -49,7 +49,6 @@ BuildRequires:  cmake
 %ifarch %{arm} aarch64
 # Require python for acl-ex library build pre-process
 BuildRequires:  python3
-BuildRequires:  libarmcl-devel >= v21.02
 %endif
 
 Requires(post): /sbin/ldconfig


### PR DESCRIPTION
- Disable download, build of armcl library
- Remove BuildReqiure of libarmcl from nnfw.spec

ONE-DCO-1.0-Signed-off-by: Chunseok Lee <chunseok.lee@samsung.com>