### PR TITLE
[luci/pass] Add value test for forward_transpose_op

### DIFF
--- a/compiler/luci-pass-value-test/test.lst
+++ b/compiler/luci-pass-value-test/test.lst
@@ -38,6 +38,7 @@ addeval(Net_InstanceNorm_003 fuse_instnorm)
 addeval(Net_StridedSlice_StridedSlice_000 remove_unnecessary_strided_slice)
 addeval(FullyConnected_007 replace_non_const_fc_with_batch_matmul)
 addeval(Net_Transpose_Add_000 forward_transpose_op)
+addeval(Net_Transpose_Abs_000 forward_transpose_op)
 addeval(UnidirectionalSequenceLSTM_003 unroll_unidirseqlstm)
 addeval(UnidirectionalSequenceLSTM_004 unroll_unidirseqlstm)
 


### PR DESCRIPTION
This will add value test for forward_transpose_op with Net_Transpose_Abs_000.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>