### PR TITLE
[one-cmds] Freeze tensorflow_addons version

### DIFF
--- a/compiler/one-cmds/one-prepare-venv
+++ b/compiler/one-cmds/one-prepare-venv
@@ -66,6 +66,8 @@ fi
 ${VENV_PYTHON} -m pip ${PIP_OPTIONS} install Pillow
 # TODO remove version fix, https://github.com/Samsung/ONE/issues/9240
 ${VENV_PYTHON} -m pip ${PIP_OPTIONS} install tensorflow_probability==0.16.0
+# TODO remove version fix, https://github.com/Samsung/ONE/issues/10481
+${VENV_PYTHON} -m pip ${PIP_OPTIONS} install tensorflow_addons==0.16.1
 
 # Install PyTorch and ONNX related
 # NOTE set ONE_PREPVENV_TORCH_STABLE to override 'torch_stable.html' URL.


### PR DESCRIPTION
This will freeze tensorflow_addons not to show TF version warnings.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>