### PR TITLE
[onert/test] Move download script function

### DIFF
--- a/tests/scripts/command/prepare-model
+++ b/tests/scripts/command/prepare-model
@@ -48,6 +48,107 @@ do
     shift
 done
 
+function find_tests()
+{
+    local TEST_DIRS="$@"
+    local TESTS_TO_DOWNLOAD=""
+
+    if [[ $# -eq 0 ]]; then
+        TEST_DIRS="."
+    fi
+
+    shift $#
+
+    pushd $MODEL_ROOT_DIR > /dev/null
+    for DIR in $TEST_DIRS; do
+        if [ -d "$DIR" ]; then
+            TESTS_FOUND=$(find "$DIR" -type f -name 'config.sh' -exec dirname {} \;| sed 's|^./||' | sort)
+            TESTS_TO_DOWNLOAD="$TESTS_TO_DOWNLOAD $TESTS_FOUND"
+        else
+            echo "Test $DIR was not found. This test is not added." 1>&2
+        fi
+    done
+    popd > /dev/null
+
+    echo $TESTS_TO_DOWNLOAD
+}
+
+function need_download()
+{
+    LOCAL_PATH=$1
+    REMOTE_URL=$2
+    if [ ! -e $LOCAL_PATH ]; then
+        return 0;
+    fi
+    # Ignore checking md5 in cache
+    # TODO Use "--md5" option only and remove IGNORE_MD5 environment variable
+    if [ ! -z $IGNORE_MD5 ] && [ "$IGNORE_MD5" == "1" ]; then
+        return 1
+    fi
+    if [ "$MD5_CHECK" = "off" ]; then
+        return 1
+    fi
+
+    LOCAL_HASH=$(md5sum $LOCAL_PATH | awk '{ print $1 }')
+    REMOTE_HASH=$(curl --netrc-optional -kLsS $REMOTE_URL | md5sum  | awk '{ print $1 }')
+    # TODO Emit an error when Content-MD5 field was not found. (Server configuration issue)
+    if [ "$LOCAL_HASH" != "$REMOTE_HASH" ]; then
+        echo "Downloaded file is outdated or incomplete."
+        return 0
+    fi
+    return 1
+}
+
+function download_tests()
+{
+    SELECTED_TESTS=$@
+
+    echo ""
+    echo "Downloading tests:"
+    echo "======================"
+    for TEST_NAME in $SELECTED_TESTS; do
+        echo $TEST_NAME
+    done
+    echo "======================"
+
+    if [ ! -e $CACHE_PATH ]; then
+        mkdir -p $CACHE_PATH
+    fi
+
+    i=0
+    for TEST_NAME in $SELECTED_TESTS; do
+        # Test configure initialization
+        ((i++))
+        MODELFILE_URL_BASE=""
+        MODELFILE_NAME=""
+        source $MODEL_ROOT_DIR/$TEST_NAME/config.sh
+
+        MODELFILE=$CACHE_PATH/$MODELFILE_NAME
+        MODELFILE_URL="$MODELFILE_URL_BASE/$MODELFILE_NAME"
+        if [ -n  "$MODELFILE_SERVER" ]; then
+            MODELFILE_URL="$MODELFILE_SERVER/$MODELFILE_NAME"
+        fi
+
+        # Download model file
+        # Download unless we have it in cache (Also check md5sum)
+        if need_download "$MODELFILE" "$MODELFILE_URL"; then
+            echo ""
+            echo "Download test file for $TEST_NAME"
+            echo "======================"
+
+            rm -f $MODELFILE # Remove invalid file if exists
+            pushd $CACHE_PATH > /dev/null
+            echo "Download $MODELFILE_URL"
+            curl --netrc-optional -kLOsS $MODELFILE_URL
+            if [ "${MODELFILE_NAME##*.}" == "zip" ]; then
+                unzip -o $MODELFILE_NAME -d ${MODELFILE_NAME%.zip}
+            fi
+            popd > /dev/null
+        fi
+
+    done
+}
+
 # Check MODELFILE_SERVER
 if [[ -z "$MODELFILE_SERVER" ]]; then
     echo "Fail to download models: Please set MODELFILE_SERVER to download model"
@@ -55,4 +156,6 @@ if [[ -z "$MODELFILE_SERVER" ]]; then
 fi
 echo "Download from $MODELFILE_SERVER"
 
-$INSTALL_PATH/test/models/run_test.sh --download=on --run=off --md5=$MD5_CHECK --cachedir=$CACHE_PATH
+# Download tflite model
+TESTS_TO_DOWNLOAD=$(find_tests tflite)
+download_tests $TESTS_TO_DOWNLOAD

--- a/tests/scripts/command/verify-tflite
+++ b/tests/scripts/command/verify-tflite
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-MD5_CHECK="on"
-TFLITE_LOADER="loader"
 REPORT_DIR="report"
 TEST_LIST_FILE=
 
@@ -24,7 +22,6 @@ function Usage()
     echo "Usage: $0 $(basename ${BASH_SOURCE[0]}) [OPTIONS]"
     echo ""
     echo "Options:"
-    echo "      --ignoremd5             Ignore MD5 check when download model files"
     echo "      --reportdir=PATH        Path to write report (default=$REPORT_DIR)"
     echo "      --list=FILE             List file to test. Test all if list option is not passed"
     echo "      --cachedir=PATH         Set downloaded resouces cache directory (default: $CACHE_PATH)"
@@ -36,9 +33,6 @@ do
         -h|--help|help)
             Usage
             exit 1
-            ;;
-        --ignoremd5)
-            MD5_CHECK="off"
             ;;
         --reportdir=*)
             REPORT_DIR=${i#*=}
@@ -71,7 +65,6 @@ TEST_NAME="Loader Verification"
 TEST_DRIVER=tflite_comparator
 
 $INSTALL_PATH/test/models/run_test.sh --driverbin=$TEST_DRIVER \
-    --download=off --run=on \
     --reportdir=$REPORT_DIR \
     --tapname=$TAP_NAME \
     --cachedir=$CACHE_PATH \


### PR DESCRIPTION
This commit moves model download script function from `run_test.sh` to `prepare-model` command.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: #10496
Related issue: #9877 