### PR TITLE
[infra/onert] Introduce model download dev command

### DIFF
--- a/infra/nnfw/command/prepare-model
+++ b/infra/nnfw/command/prepare-model
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+import "build.configuration"
+
+# This command is used to download test materials on host environment
+# by using test command on host
+
+# Common variables
+DRIVER_PATH=$NNFW_PROJECT_PATH/tests/scripts
+CACHE_PATH=${CACHE_PATH:-$WORKSPACE_PATH/out/test/cache}
+
+COMMAND_FILE=$DRIVER_PATH/command/prepare-model
+if [[ ! -f $COMMAND_FILE ]]; then
+  echo "ERROR: '$COMMAND' is not supported"
+  exit 255
+fi
+
+source $COMMAND_FILE $@

--- a/infra/scripts/tizen_xu4_test.sh
+++ b/infra/scripts/tizen_xu4_test.sh
@@ -25,15 +25,18 @@ function install_model()
 {
     # download tflite model files
     pushd $HOST_HOME
-    tests/scripts/models/run_test.sh --download=on --run=off
+    TEMP_PATH=$(mktemp -d)
+    CACHE_PATH=$TEMP_PATH/cache
+    mkdir -p $CACHE_PATH
+    ./nnfw prepare-model --cachedir=$CACHE_PATH
     # TODO Since this command removes model file(.zip),
     # We must always download the file unlike model file(.tflite).
     # Because caching applies only to tflite file.
-    find tests -name "*.zip" -exec rm {} \;
-    tar -zcf cache.tar.gz -C tests/scripts/models cache
-    $SDB_CMD push cache.tar.gz $TEST_ROOT/.
-    rm -rf cache.tar.gz
-    $SDB_CMD shell tar -zxf $TEST_ROOT/cache.tar.gz -C $TEST_ROOT/Product/out/test/models
+    find $CACHE_PATH -name "*.zip" -exec rm {} \;
+    tar -zcf $TEMP_PATH/cache.tar.gz -C $TEMP_PATH cache
+    $SDB_CMD push $TEMP_PATH/cache.tar.gz $TEST_ROOT/
+    rm -rf $TEMP_PATH
+    $SDB_CMD shell tar -zxf $TEST_ROOT/cache.tar.gz -C $TEST_ROOT/Product/out/test
     popd
 }
 


### PR DESCRIPTION
This commit introduces model download command on host machine.
It can be used to download models without build & install process.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: https://github.com/Samsung/ONE/pull/10496
Related issue: https://github.com/Samsung/ONE/issues/9877