### PR TITLE
[luci] Revisit QuantizeWithMinMaxPass

### DIFF
--- a/compiler/luci/pass/include/luci/Pass/QuantizeWithMinMaxPass.h
+++ b/compiler/luci/pass/include/luci/Pass/QuantizeWithMinMaxPass.h
@@ -45,23 +45,6 @@ public:
     std::vector<LayerInfo> layers_info;
   };
 
-  // For backward-compatibility
-  // TODO Remove this constructor
-public:
-  QuantizeWithMinMaxPass(loco::DataType input_model_dtype, loco::DataType output_model_dtype,
-                         QuantizationGranularity granularity)
-  {
-    _ctx = std::make_unique<Context>();
-    {
-      _ctx->input_model_dtype = input_model_dtype;
-      _ctx->output_model_dtype = output_model_dtype;
-      _ctx->granularity = granularity;
-      _ctx->input_type = output_model_dtype;
-      _ctx->output_type = output_model_dtype;
-      _ctx->TF_style_maxpool = false;
-    }
-  }
-
 public:
   QuantizeWithMinMaxPass(std::unique_ptr<Context> &&ctx) : _ctx{std::move(ctx)}
   {

--- a/compiler/luci/pass/src/QuantizeWithMinMaxPass.test.cpp
+++ b/compiler/luci/pass/src/QuantizeWithMinMaxPass.test.cpp
@@ -53,8 +53,14 @@ public:
 
 TEST(QuantizeWithMinMaxPassTest, name)
 {
-  luci::QuantizeWithMinMaxPass pass(loco::DataType::FLOAT32, loco::DataType::U8,
-                                    luci::QuantizationGranularity::LayerWise);
+  auto ctx = std::make_unique<luci::QuantizeWithMinMaxPass::Context>();
+  {
+    ctx->input_model_dtype = loco::DataType::FLOAT32;
+    ctx->output_model_dtype = loco::DataType::U8;
+    ctx->granularity = luci::QuantizationGranularity::LayerWise;
+  }
+
+  luci::QuantizeWithMinMaxPass pass(std::move(ctx));
   auto const name = pass.name();
   ASSERT_NE(nullptr, name);
 }
@@ -65,8 +71,14 @@ TEST(QuantizeWithMinMaxPassTest, int_concat)
 {
   SimpleConcatGraph g(loco::DataType::S32);
 
-  luci::QuantizeWithMinMaxPass qwmm(loco::DataType::FLOAT32, loco::DataType::U8,
-                                    luci::QuantizationGranularity::LayerWise);
+  auto ctx = std::make_unique<luci::QuantizeWithMinMaxPass::Context>();
+  {
+    ctx->input_model_dtype = loco::DataType::FLOAT32;
+    ctx->output_model_dtype = loco::DataType::U8;
+    ctx->granularity = luci::QuantizationGranularity::LayerWise;
+  }
+
+  luci::QuantizeWithMinMaxPass qwmm(std::move(ctx));
 
   qwmm.run(&g.g);
 
@@ -82,8 +94,14 @@ TEST(QuantizeWithMinMaxPassTest, inactive_input)
   // Unused input
   g.g.nodes()->create<luci::CircleInput>();
 
-  luci::QuantizeWithMinMaxPass qwmm(loco::DataType::FLOAT32, loco::DataType::U8,
-                                    luci::QuantizationGranularity::LayerWise);
+  auto ctx = std::make_unique<luci::QuantizeWithMinMaxPass::Context>();
+  {
+    ctx->input_model_dtype = loco::DataType::FLOAT32;
+    ctx->output_model_dtype = loco::DataType::U8;
+    ctx->granularity = luci::QuantizationGranularity::LayerWise;
+  }
+
+  luci::QuantizeWithMinMaxPass qwmm(std::move(ctx));
 
   EXPECT_NO_THROW(qwmm.run(&g.g));
 }

--- a/compiler/luci/pass/src/QuantizedModelVerifier.test.cpp
+++ b/compiler/luci/pass/src/QuantizedModelVerifier.test.cpp
@@ -113,8 +113,16 @@ void run_phase(loco::Graph *g, Type quantized_dtype, Granularity granularity)
   // Default passes.
   phase.emplace_back(std::make_unique<luci::CircleTypeInferencePass>());
 
-  phase.emplace_back(
-    std::make_unique<luci::QuantizeWithMinMaxPass>(Type::FLOAT32, quantized_dtype, granularity));
+  auto ctx = std::make_unique<luci::QuantizeWithMinMaxPass::Context>();
+  {
+    ctx->input_model_dtype = loco::DataType::FLOAT32;
+    ctx->output_model_dtype = quantized_dtype;
+    ctx->granularity = granularity;
+    ctx->input_type = quantized_dtype;
+    ctx->output_type = quantized_dtype;
+  }
+
+  phase.emplace_back(std::make_unique<luci::QuantizeWithMinMaxPass>(std::move(ctx)));
 
   logo::PhaseRunner<logo::PhaseStrategy::Restart> phase_runner{g};
   phase_runner.run(phase);


### PR DESCRIPTION
This removes deprecated constructor of QuantizeWithMinMaxPass.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>