### PR TITLE
[luci] Revisit QuantizedModelVerifier

### DIFF
--- a/compiler/luci/pass/src/QuantizedModelVerifier.h
+++ b/compiler/luci/pass/src/QuantizedModelVerifier.h
@@ -45,19 +45,6 @@ public:
   };
 
 public:
-  QuantizedModelVerifier(loco::DataType quantized_dtype, QuantizationGranularity granularity)
-  {
-    _ctx = std::make_unique<Context>();
-    {
-      _ctx->output_model_dtype = quantized_dtype;
-      _ctx->granularity = granularity;
-      _ctx->input_type = quantized_dtype;
-      _ctx->output_type = quantized_dtype;
-      _ctx->TF_style_maxpool = false;
-    }
-  }
-
-public:
   QuantizedModelVerifier(std::unique_ptr<Context> &&ctx) : _ctx{std::move(ctx)}
   {
     // DO NOTHING


### PR DESCRIPTION
This removes deprecated constructor of QuantizedModelVerifier.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>
