### PR TITLE
[one-cmds] Remove unnecessary O1 logic

### DIFF
--- a/compiler/one-cmds/one-optimize
+++ b/compiler/one-cmds/one-optimize
@@ -97,12 +97,6 @@ def _parse_arg(parser):
     if args.version:
         oneutils.print_version_and_exit(__file__)
 
-    # handle default options given by cmdline
-    if oneutils.is_valid_attr(args, 'O1'):
-        for opt in _constant.CONSTANT.O1:
-            setattr(args, opt, True)
-        setattr(args, 'O1', False)
-
     return args
 
 

--- a/compiler/one-cmds/onelib/constant.py
+++ b/compiler/one-cmds/onelib/constant.py
@@ -73,8 +73,6 @@ class CONSTANT:
 
     OPTIMIZATION_OPTS = (
         # (OPTION_NAME, HELP_MESSAGE)
-        ('O1', 'A basic set of optimization options. This will not change the ' +
-         'execution result of the model and finish within a resonable time.'),
         ('convert_nchw_to_nhwc',
          'Experimental: This will convert NCHW operators to NHWC under the assumption that input model is NCHW.'
          ),

--- a/compiler/one-cmds/onelib/utils.py
+++ b/compiler/one-cmds/onelib/utils.py
@@ -122,17 +122,6 @@ def parse_cfg(args, driver_name):
             raise AssertionError('configuration file must have \'' + section_to_run +
                                  '\' section')
 
-        if section_to_run == 'one-optimize':
-            # Q. Why we handle default options first?
-            # A. We allow users to overwrite individual options. For example,
-            #    if O1=True and FoldDequantize=False, FoldDequantize is set to False.
-            if 'O1' in config[section_to_run]:
-                for opt in _constant.CONSTANT.O1:
-                    if opt in config[section_to_run]:
-                        continue
-                    setattr(args, opt, True)
-                del config[section_to_run]['O1']
-
         for key in config[section_to_run]:
             if is_accumulated_arg(key, driver_name):
                 if not is_valid_attr(args, key):


### PR DESCRIPTION
This commit removes unnecessary O1 logics. They've become unnecessary for resolving below "Related" issue.

Draft: https://github.com/Samsung/ONE/pull/10478
Related: https://github.com/Samsung/ONE/pull/10474#discussion_r1113763693
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>