### PR TITLE
[luci] Use vector type input/output_type in QuantizeWithMinMaxPass

### DIFF
--- a/compiler/luci/pass/include/luci/Pass/QuantizeWithMinMaxPass.h
+++ b/compiler/luci/pass/include/luci/Pass/QuantizeWithMinMaxPass.h
@@ -39,8 +39,8 @@ public:
     loco::DataType input_model_dtype = loco::DataType::Unknown;
     loco::DataType output_model_dtype = loco::DataType::Unknown;
     QuantizationGranularity granularity = QuantizationGranularity::ChannelWise;
-    std::vector<loco::DataType> input_type;
-    std::vector<loco::DataType> output_type;
+    std::vector<loco::DataType> input_types;
+    std::vector<loco::DataType> output_types;
     bool TF_style_maxpool = false;
     std::vector<LayerInfo> layers_info;
   };

--- a/compiler/luci/pass/include/luci/Pass/QuantizeWithMinMaxPass.h
+++ b/compiler/luci/pass/include/luci/Pass/QuantizeWithMinMaxPass.h
@@ -39,8 +39,8 @@ public:
     loco::DataType input_model_dtype = loco::DataType::Unknown;
     loco::DataType output_model_dtype = loco::DataType::Unknown;
     QuantizationGranularity granularity = QuantizationGranularity::ChannelWise;
-    loco::DataType input_type = loco::DataType::Unknown;
-    loco::DataType output_type = loco::DataType::Unknown;
+    std::vector<loco::DataType> input_type;
+    std::vector<loco::DataType> output_type;
     bool TF_style_maxpool = false;
     std::vector<LayerInfo> layers_info;
   };

--- a/compiler/luci/pass/src/CircleQuantizer.cpp
+++ b/compiler/luci/pass/src/CircleQuantizer.cpp
@@ -490,9 +490,8 @@ void CircleQuantizer::quantize(loco::Graph *g) const
       ctx->input_model_dtype = str_to_dtype(input_model_dtype);
       ctx->output_model_dtype = str_to_dtype(output_model_dtype);
       ctx->granularity = str_to_granularity(granularity);
-      // TODO Change input/output_type to vector
-      ctx->input_type = input_types[0];
-      ctx->output_type = output_types[0];
+      ctx->input_type = input_types;
+      ctx->output_type = output_types;
       ctx->TF_style_maxpool = TF_style_maxpool;
 
       for (auto layer_param : layer_params)

--- a/compiler/luci/pass/src/CircleQuantizer.cpp
+++ b/compiler/luci/pass/src/CircleQuantizer.cpp
@@ -490,8 +490,8 @@ void CircleQuantizer::quantize(loco::Graph *g) const
       ctx->input_model_dtype = str_to_dtype(input_model_dtype);
       ctx->output_model_dtype = str_to_dtype(output_model_dtype);
       ctx->granularity = str_to_granularity(granularity);
-      ctx->input_type = input_types;
-      ctx->output_type = output_types;
+      ctx->input_types = input_types;
+      ctx->output_types = output_types;
       ctx->TF_style_maxpool = TF_style_maxpool;
 
       for (auto layer_param : layer_params)

--- a/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
+++ b/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
@@ -372,11 +372,10 @@ private:
 
 void QuantizeWithMinMaxPass::set_input_type(loco::Graph *g) const
 {
-  assert(g); // FIX_CALLER_UNLESS
   auto inputs = g->inputs();
 
-  assert(inputs);                                    // FIX_CALLER_UNLESS
-  assert(inputs->size() == _ctx->input_type.size()); // FIX_CALLER_UNLESS
+  assert(inputs);                                     // FIX_CALLER_UNLESS
+  assert(inputs->size() == _ctx->input_types.size()); // FIX_CALLER_UNLESS
 
   // NOTE loco::input_nodes returns input nodes following the order of InputIndex
   auto input_nodes = loco::input_nodes(g);
@@ -385,7 +384,7 @@ void QuantizeWithMinMaxPass::set_input_type(loco::Graph *g) const
     auto input = loco::must_cast<luci::CircleInput *>(input_nodes[i]);
     assert(i == input->index()); // Fix input_type logic
 
-    const auto user_given_dtype = _ctx->input_type[i];
+    const auto user_given_dtype = _ctx->input_types[i];
 
     if (input->dtype() == user_given_dtype)
       continue;
@@ -450,11 +449,9 @@ void QuantizeWithMinMaxPass::set_input_type(loco::Graph *g) const
 
 void QuantizeWithMinMaxPass::set_output_type(loco::Graph *g) const
 {
-  assert(g); // FIX_CALLER_UNLESS
-
   auto outputs = g->outputs();
-  assert(outputs);                                     // FIX_CALLER_UNLESS
-  assert(outputs->size() == _ctx->output_type.size()); // Fix CircleQuantizer unless
+  assert(outputs);                                      // FIX_CALLER_UNLESS
+  assert(outputs->size() == _ctx->output_types.size()); // Fix CircleQuantizer unless
 
   // NOTE loco::output_nodes returns output nodes following the order of OutputIndex
   auto output_nodes = loco::output_nodes(g);
@@ -463,7 +460,7 @@ void QuantizeWithMinMaxPass::set_output_type(loco::Graph *g) const
     auto output = loco::must_cast<luci::CircleOutput *>(output_nodes[i]);
     assert(i == output->index()); // Fix output_type logic
 
-    const auto user_given_dtype = _ctx->output_type[i];
+    const auto user_given_dtype = _ctx->output_types[i];
 
     if (output->dtype() == user_given_dtype)
       continue;

--- a/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
+++ b/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
@@ -372,11 +372,22 @@ private:
 
 void QuantizeWithMinMaxPass::set_input_type(loco::Graph *g) const
 {
+  assert(g); // FIX_CALLER_UNLESS
   auto inputs = g->inputs();
-  for (auto node : loco::input_nodes(g))
+
+  assert(inputs);                                    // FIX_CALLER_UNLESS
+  assert(inputs->size() == _ctx->input_type.size()); // FIX_CALLER_UNLESS
+
+  // NOTE loco::input_nodes returns input nodes following the order of InputIndex
+  auto input_nodes = loco::input_nodes(g);
+  for (uint32_t i = 0; i < input_nodes.size(); i++)
   {
-    auto input = loco::must_cast<luci::CircleInput *>(node);
-    if (input->dtype() == _ctx->input_type)
+    auto input = loco::must_cast<luci::CircleInput *>(input_nodes[i]);
+    assert(i == input->index()); // Fix input_type logic
+
+    const auto user_given_dtype = _ctx->input_type[i];
+
+    if (input->dtype() == user_given_dtype)
       continue;
 
     // Bool type is not quantizable
@@ -402,7 +413,7 @@ void QuantizeWithMinMaxPass::set_input_type(loco::Graph *g) const
 
     // Update qparam of input
     // This step is skipped if input_type is float32
-    if (_ctx->input_type != loco::DataType::FLOAT32)
+    if (user_given_dtype != loco::DataType::FLOAT32)
     {
       auto quantparam = input->quantparam();
       assert(quantparam);
@@ -416,13 +427,13 @@ void QuantizeWithMinMaxPass::set_input_type(loco::Graph *g) const
       float nudged_min{0};
       float nudged_max{0};
 
-      if (_ctx->input_type == loco::DataType::U8)
+      if (user_given_dtype == loco::DataType::U8)
       {
         compute_asym_scale_zp(min, max, scaling_factor, zp, nudged_min, nudged_max);
       }
       else
       {
-        assert(_ctx->input_type == loco::DataType::S16);
+        assert(user_given_dtype == loco::DataType::S16);
         compute_sym_scale_zp(min, max, scaling_factor, zp, nudged_min, nudged_max);
       }
       input->quantparam()->scale[0] = scaling_factor;
@@ -430,20 +441,31 @@ void QuantizeWithMinMaxPass::set_input_type(loco::Graph *g) const
     }
 
     // Update dtype of input
-    input->dtype(_ctx->input_type);
+    input->dtype(user_given_dtype);
 
     auto graph_input = inputs->at(input->index());
-    graph_input->dtype(_ctx->input_type);
+    graph_input->dtype(user_given_dtype);
   }
 }
 
 void QuantizeWithMinMaxPass::set_output_type(loco::Graph *g) const
 {
+  assert(g); // FIX_CALLER_UNLESS
+
   auto outputs = g->outputs();
-  for (auto node : loco::output_nodes(g))
+  assert(outputs);                                     // FIX_CALLER_UNLESS
+  assert(outputs->size() == _ctx->output_type.size()); // Fix CircleQuantizer unless
+
+  // NOTE loco::output_nodes returns output nodes following the order of OutputIndex
+  auto output_nodes = loco::output_nodes(g);
+  for (uint32_t i = 0; i < output_nodes.size(); i++)
   {
-    auto output = loco::must_cast<luci::CircleOutput *>(node);
-    if (output->dtype() == _ctx->output_type)
+    auto output = loco::must_cast<luci::CircleOutput *>(output_nodes[i]);
+    assert(i == output->index()); // Fix output_type logic
+
+    const auto user_given_dtype = _ctx->output_type[i];
+
+    if (output->dtype() == user_given_dtype)
       continue;
 
     // Bool type is not quantizable
@@ -457,7 +479,7 @@ void QuantizeWithMinMaxPass::set_output_type(loco::Graph *g) const
       continue;
 
     // Insert Dequantize Op for float32 output_type
-    if (_ctx->output_type == loco::DataType::FLOAT32)
+    if (user_given_dtype == loco::DataType::FLOAT32)
     {
       auto dequant_op = create_dequantize(from);
       loco::replace(from).with(dequant_op);
@@ -466,7 +488,7 @@ void QuantizeWithMinMaxPass::set_output_type(loco::Graph *g) const
     else
     {
       // Insert Quantize Op for non-float32 output_type
-      auto quant_op = create_quantize_op(from, _ctx->output_type);
+      auto quant_op = create_quantize_op(from, user_given_dtype);
       loco::replace(from).with(quant_op);
       quant_op->input(from);
 
@@ -475,10 +497,10 @@ void QuantizeWithMinMaxPass::set_output_type(loco::Graph *g) const
     }
 
     // Update dtype of output
-    output->dtype(_ctx->output_type);
+    output->dtype(user_given_dtype);
 
     auto graph_output = outputs->at(output->index());
-    graph_output->dtype(_ctx->output_type);
+    graph_output->dtype(user_given_dtype);
   }
 }
 

--- a/compiler/luci/pass/src/QuantizedModelVerifier.test.cpp
+++ b/compiler/luci/pass/src/QuantizedModelVerifier.test.cpp
@@ -118,8 +118,9 @@ void run_phase(loco::Graph *g, Type quantized_dtype, Granularity granularity)
     ctx->input_model_dtype = loco::DataType::FLOAT32;
     ctx->output_model_dtype = quantized_dtype;
     ctx->granularity = granularity;
-    ctx->input_type = quantized_dtype;
-    ctx->output_type = quantized_dtype;
+    // Test graph has only one input/output
+    ctx->input_type = {quantized_dtype};
+    ctx->output_type = {quantized_dtype};
   }
 
   phase.emplace_back(std::make_unique<luci::QuantizeWithMinMaxPass>(std::move(ctx)));
@@ -177,8 +178,9 @@ void quantize_and_verify_with_layer_info(loco::Graph *g, Type quantized_dtype,
       ctx->input_model_dtype = Type::FLOAT32;
       ctx->output_model_dtype = quantized_dtype;
       ctx->granularity = granularity;
-      ctx->input_type = quantized_dtype;
-      ctx->output_type = quantized_dtype;
+      // Test graph has only one input/output
+      ctx->input_type = {quantized_dtype};
+      ctx->output_type = {quantized_dtype};
       ctx->TF_style_maxpool = false;
       ctx->layers_info.push_back(info);
     }

--- a/compiler/luci/pass/src/QuantizedModelVerifier.test.cpp
+++ b/compiler/luci/pass/src/QuantizedModelVerifier.test.cpp
@@ -119,8 +119,8 @@ void run_phase(loco::Graph *g, Type quantized_dtype, Granularity granularity)
     ctx->output_model_dtype = quantized_dtype;
     ctx->granularity = granularity;
     // Test graph has only one input/output
-    ctx->input_type = {quantized_dtype};
-    ctx->output_type = {quantized_dtype};
+    ctx->input_types = {quantized_dtype};
+    ctx->output_types = {quantized_dtype};
   }
 
   phase.emplace_back(std::make_unique<luci::QuantizeWithMinMaxPass>(std::move(ctx)));
@@ -179,8 +179,8 @@ void quantize_and_verify_with_layer_info(loco::Graph *g, Type quantized_dtype,
       ctx->output_model_dtype = quantized_dtype;
       ctx->granularity = granularity;
       // Test graph has only one input/output
-      ctx->input_type = {quantized_dtype};
-      ctx->output_type = {quantized_dtype};
+      ctx->input_types = {quantized_dtype};
+      ctx->output_types = {quantized_dtype};
       ctx->TF_style_maxpool = false;
       ctx->layers_info.push_back(info);
     }


### PR DESCRIPTION
This uses vectoer type input/output_type in QuantizeWithMinMaxPass.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/10493
Draft PR: https://github.com/Samsung/ONE/pull/10518