### PR TITLE
[onert/test] Use common variable DRIVER_PATH on command

### DIFF
--- a/tests/scripts/command/prepare-model
+++ b/tests/scripts/command/prepare-model
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-MODEL_ROOT_DIR=$INSTALL_PATH/test/models
+MODEL_ROOT_DIR=$DRIVER_PATH/models
 MD5_CHECK="on"
 
 function Usage()

--- a/tests/scripts/onert-test
+++ b/tests/scripts/onert-test
@@ -16,11 +16,11 @@
 
 [[ "${BASH_SOURCE[0]}" != "${0}" ]] && echo "Please don't source ${BASH_SOURCE[0]}, execute it" && return
 
-DRIVER_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-
 # Common variables which are used on test commands
+# DRIVER_PATH: test driver and related resources forder
 # INSTALL_PATH: test package installed folder
 # CACHE_PATH: cache folder for test resource download
+DRIVER_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 INSTALL_PATH="$(dirname $DRIVER_PATH)"
 CACHE_PATH=$DRIVER_PATH/cache
 


### PR DESCRIPTION
This commit changes DRIVER_PATH as test command common variable. 
By this, We can use prepare-model host command `./nnfw prepare-model`.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: https://github.com/Samsung/ONE/pull/10496
Related issue: https://github.com/Samsung/ONE/issues/9877