### PR TITLE
[luci] Use vector type input/output_type in QuantizedModelVerifier

### DIFF
--- a/compiler/luci/pass/src/CircleQuantizer.cpp
+++ b/compiler/luci/pass/src/CircleQuantizer.cpp
@@ -514,9 +514,8 @@ void CircleQuantizer::quantize(loco::Graph *g) const
     {
       verify_ctx->output_model_dtype = str_to_dtype(output_model_dtype);
       verify_ctx->granularity = str_to_granularity(granularity);
-      // TODO Change input/output_type to vector
-      verify_ctx->input_type = input_types[0];
-      verify_ctx->output_type = output_types[0];
+      verify_ctx->input_types = input_types;
+      verify_ctx->output_types = output_types;
       verify_ctx->TF_style_maxpool = TF_style_maxpool;
 
       for (auto layer_param : layer_params)

--- a/compiler/luci/pass/src/QuantizedModelVerifier.h
+++ b/compiler/luci/pass/src/QuantizedModelVerifier.h
@@ -38,8 +38,8 @@ public:
   {
     loco::DataType output_model_dtype = loco::DataType::Unknown;
     QuantizationGranularity granularity = QuantizationGranularity::ChannelWise;
-    loco::DataType input_type = loco::DataType::Unknown;
-    loco::DataType output_type = loco::DataType::Unknown;
+    std::vector<loco::DataType> input_types;
+    std::vector<loco::DataType> output_types;
     bool TF_style_maxpool = false;
     std::vector<LayerInfo> layers_info;
   };

--- a/compiler/luci/pass/src/QuantizedModelVerifier.test.cpp
+++ b/compiler/luci/pass/src/QuantizedModelVerifier.test.cpp
@@ -151,8 +151,8 @@ void quantize_and_verify(loco::Graph *g, Type quantized_dtype, Granularity granu
     ctx->output_model_dtype = quantized_dtype;
     ctx->granularity = granularity;
     // Test graph has only one input/output
-    ctx->input_type = {quantized_dtype};
-    ctx->output_type = {quantized_dtype};
+    ctx->input_types = {quantized_dtype};
+    ctx->output_types = {quantized_dtype};
   }
 
   luci::QuantizedModelVerifier verifier(std::move(ctx));
@@ -194,8 +194,8 @@ void quantize_and_verify_with_layer_info(loco::Graph *g, Type quantized_dtype,
     {
       ctx->output_model_dtype = quantized_dtype;
       ctx->granularity = granularity;
-      ctx->input_type = quantized_dtype;
-      ctx->output_type = quantized_dtype;
+      ctx->input_types = {quantized_dtype};
+      ctx->output_types = {quantized_dtype};
       ctx->TF_style_maxpool = false;
       ctx->layers_info.push_back(info);
     }
@@ -220,8 +220,8 @@ void quantize_and_verify_with_wrong_type(luci::test::TestIOGraph *g, Type quanti
     ctx->output_model_dtype = quantized_dtype;
     ctx->granularity = granularity;
     // Test graph has only one input/output
-    ctx->input_type = {quantized_dtype};
-    ctx->output_type = {quantized_dtype};
+    ctx->input_types = {quantized_dtype};
+    ctx->output_types = {quantized_dtype};
   }
 
   luci::QuantizedModelVerifier verifier(std::move(ctx));
@@ -243,8 +243,8 @@ void quantize_and_verify_with_wrong_granularity(luci::test::TestIOGraph *g, Type
     ctx->output_model_dtype = quantized_dtype;
     ctx->granularity = granularity;
     // Test graph has only one input/output
-    ctx->input_type = {quantized_dtype};
-    ctx->output_type = {quantized_dtype};
+    ctx->input_types = {quantized_dtype};
+    ctx->output_types = {quantized_dtype};
   }
 
   luci::QuantizedModelVerifier verifier(std::move(ctx));
@@ -1415,8 +1415,8 @@ private:
     {                                                                               \
       ctx->output_model_dtype = type;                                               \
       ctx->granularity = granularity_;                                              \
-      ctx->input_type = {type};                                                     \
-      ctx->output_type = {type};                                                    \
+      ctx->input_types = {type};                                                    \
+      ctx->output_types = {type};                                                   \
     }                                                                               \
     luci::QuantizedModelVerifier verifier(std::move(ctx));                          \
     EXPECT_ANY_THROW(verifier.verify(g.g()));                                       \
@@ -1437,8 +1437,8 @@ private:
     {                                                                         \
       ctx->output_model_dtype = type;                                         \
       ctx->granularity = granularity_;                                        \
-      ctx->input_type = {type};                                               \
-      ctx->output_type = {type};                                              \
+      ctx->input_types = {type};                                              \
+      ctx->output_types = {type};                                             \
     }                                                                         \
     luci::QuantizedModelVerifier verifier(std::move(ctx));                    \
     EXPECT_ANY_THROW(verifier.verify(g.g()));                                 \


### PR DESCRIPTION
This uses vector type input/output_type in QuantizedModelVerifier.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/10493
Draft PR: https://github.com/Samsung/ONE/pull/10518