### PR TITLE
[one-cmds] Add quantiation tests for input/output_type

### DIFF
--- a/compiler/one-cmds/tests/one-quantize_016.test
+++ b/compiler/one-cmds/tests/one-quantize_016.test
@@ -33,6 +33,7 @@ rm -f ${filename}.first.cdump
 rm -f ${filename}.second.cdump
 rm -f ${outputfile}
 
+# TODO Generate input file in prepare_test_materials.sh
 if [[ ! -s "${inputfile}" ]]; then
   one-import onnx -i reshape_matmul.onnx -o ${inputfile}
 fi

--- a/compiler/one-cmds/tests/one-quantize_016.test
+++ b/compiler/one-cmds/tests/one-quantize_016.test
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  echo "${filename_ext} FAILED"
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+inputfile="./reshape_matmul.circle"
+outputfile="./reshape_matmul.one-quantize_016.circle"
+
+rm -f ${filename}.log
+rm -f ${filename}.first.cdump
+rm -f ${filename}.second.cdump
+rm -f ${outputfile}
+
+if [[ ! -s "${inputfile}" ]]; then
+  one-import onnx -i reshape_matmul.onnx -o ${inputfile}
+fi
+
+# run test with different input_type
+one-quantize \
+--input_dtype float32 \
+--quantized_dtype uint8 \
+--granularity channel \
+--input_type uint8,int16 \
+--input_path ${inputfile} \
+--output_path ${outputfile} > ${filename}.log 2>&1
+
+if [[ ! -s "${outputfile}" ]]; then
+  trap_err_onexit
+fi
+
+circledump ${outputfile} | grep serving_default_l.1:0$ > ${filename}.first.cdump
+circledump ${outputfile} | grep serving_default_r.1:0$ > ${filename}.second.cdump
+
+# check dtype of the first input (uint8)
+if ! grep -q "UINT8" "${filename}.first.cdump"; then
+  trap_err_onexit
+fi
+
+# check dtype of the second input (int16)
+if ! grep -q "INT16" "${filename}.second.cdump"; then
+  trap_err_onexit
+fi
+
+echo "${filename_ext} SUCCESS"

--- a/compiler/one-cmds/tests/one-quantize_neg_021.test
+++ b/compiler/one-cmds/tests/one-quantize_neg_021.test
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# check error message is printed when qconfig file is not json
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  if grep -q "Invalid number of input dtype" "${filename}.log"; then
+    echo "${filename_ext} SUCCESS"
+    exit 0
+  fi
+
+  echo "${filename_ext} FAILED"
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+inputfile="./reshape_matmul.circle"
+outputfile="./reshape_matmul.quantized.neg_021.circle"
+
+rm -f ${filename}.log
+
+if [[ ! -s "${inputfile}" ]]; then
+  one-import onnx -i reshape_matmul.onnx -o ${inputfile}
+fi
+
+# run test with wrong number of input_type
+one-quantize \
+--input_dtype float32 \
+--quantized_dtype uint8 \
+--granularity channel \
+--input_type uint8,int16,uint8 \
+--input_path ${inputfile} \
+--output_path ${outputfile} > ${filename}.log 2>&1
+
+echo "${filename_ext} FAILED"
+exit 255

--- a/compiler/one-cmds/tests/one-quantize_neg_021.test
+++ b/compiler/one-cmds/tests/one-quantize_neg_021.test
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# check error message is printed when qconfig file is not json
+# Wrong number of input_type in one-quantize
 
 filename_ext="$(basename -- $0)"
 filename="${filename_ext%.*}"
@@ -37,6 +37,7 @@ outputfile="./reshape_matmul.quantized.neg_021.circle"
 
 rm -f ${filename}.log
 
+# TODO Generate input file in prepare_test_materials.sh
 if [[ ! -s "${inputfile}" ]]; then
   one-import onnx -i reshape_matmul.onnx -o ${inputfile}
 fi

--- a/compiler/one-cmds/tests/onecc_045.cfg
+++ b/compiler/one-cmds/tests/onecc_045.cfg
@@ -1,0 +1,13 @@
+[onecc]
+one-import-tf=False
+one-import-tflite=False
+one-import-bcq=False
+one-optimize=False
+one-quantize=True
+one-pack=False
+one-codegen=False
+
+[one-quantize]
+input_path=reshape_matmul.circle
+output_path=reshape_matmul.onecc_045.q.circle
+input_type=uint8,int16

--- a/compiler/one-cmds/tests/onecc_045.test
+++ b/compiler/one-cmds/tests/onecc_045.test
@@ -34,6 +34,7 @@ rm -f ${filename}.first.cdump
 rm -f ${filename}.second.cdump
 rm -f ${outputfile}
 
+# TODO Generate input file in prepare_test_materials.sh
 if [[ ! -s "${inputfile}" ]]; then
   one-import onnx -i reshape_matmul.onnx -o ${inputfile}
 fi

--- a/compiler/one-cmds/tests/onecc_045.test
+++ b/compiler/one-cmds/tests/onecc_045.test
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  echo "${filename_ext} FAILED"
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+inputfile="./reshape_matmul.circle"
+configfile="onecc_045.cfg"
+outputfile="reshape_matmul.onecc_045.q.circle"
+
+rm -f ${filename}.log
+rm -f ${filename}.first.cdump
+rm -f ${filename}.second.cdump
+rm -f ${outputfile}
+
+if [[ ! -s "${inputfile}" ]]; then
+  one-import onnx -i reshape_matmul.onnx -o ${inputfile}
+fi
+
+# run test
+onecc -C ${configfile} > ${filename}.log 2>&1
+
+if [[ ! -s "${outputfile}" ]]; then
+  trap_err_onexit
+fi
+
+circledump ${outputfile} | grep serving_default_l.1:0$ > ${filename}.first.cdump
+circledump ${outputfile} | grep serving_default_r.1:0$ > ${filename}.second.cdump
+
+# check dtype of the first input (uint8)
+if ! grep -q "UINT8" "${filename}.first.cdump"; then
+  trap_err_onexit
+fi
+
+# check dtype of the second input (int16)
+if ! grep -q "INT16" "${filename}.second.cdump"; then
+  trap_err_onexit
+fi
+
+echo "${filename_ext} SUCCESS"

--- a/compiler/one-cmds/tests/onecc_neg_026.cfg
+++ b/compiler/one-cmds/tests/onecc_neg_026.cfg
@@ -1,0 +1,13 @@
+[onecc]
+one-import-tf=False
+one-import-tflite=False
+one-import-bcq=False
+one-optimize=False
+one-quantize=True
+one-pack=False
+one-codegen=False
+
+[one-quantize]
+input_path=reshape_matmul.circle
+output_path=reshape_matmul.onecc_045.q.circle
+input_type=uint8,int16,uint8

--- a/compiler/one-cmds/tests/onecc_neg_026.test
+++ b/compiler/one-cmds/tests/onecc_neg_026.test
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Wrong number of input_type in one-quantize
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  if grep -q "Invalid number of input dtype" "${filename}.log"; then
+    echo "${filename_ext} SUCCESS"
+    exit 0
+  fi
+
+  echo "${filename_ext} FAILED"
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+inputfile="./reshape_matmul.circle"
+configfile="onecc_neg_026.cfg"
+
+rm -f ${filename}.log
+
+if [[ ! -s "${inputfile}" ]]; then
+  one-import onnx -i reshape_matmul.onnx -o ${inputfile}
+fi
+
+# run test
+onecc -C ${configfile} > ${filename}.log 2>&1
+
+echo "${filename_ext} FAILED"
+exit 255

--- a/compiler/one-cmds/tests/onecc_neg_026.test
+++ b/compiler/one-cmds/tests/onecc_neg_026.test
@@ -37,6 +37,7 @@ configfile="onecc_neg_026.cfg"
 
 rm -f ${filename}.log
 
+# TODO Generate input file in prepare_test_materials.sh
 if [[ ! -s "${inputfile}" ]]; then
   one-import onnx -i reshape_matmul.onnx -o ${inputfile}
 fi


### PR DESCRIPTION
This adds tests for multiple input/output_type in quantization.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/10493
Draft PR: https://github.com/Samsung/ONE/pull/10518