### PR TITLE
[preset] Add circle-opselector to preset 20221125

### DIFF
--- a/infra/packaging/preset/20221125
+++ b/infra/packaging/preset/20221125
@@ -41,6 +41,7 @@ function preset_configure()
   REQUIRED_UNITS+=("bcq-tools")
   REQUIRED_UNITS+=("dalgona")
   REQUIRED_UNITS+=("visq")
+  REQUIRED_UNITS+=("circle-opselector")
 
   # Dependent modules needed for build
   REQUIRED_UNITS+=("circlechef")


### PR DESCRIPTION
This commit adds _circle-opselector_ to preset 20221125.

Related: #10420 
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>