### PR TITLE
[debian] Install circle-opselector

### DIFF
--- a/infra/debian/compiler/one-compiler-dev.install
+++ b/infra/debian/compiler/one-compiler-dev.install
@@ -1,6 +1,7 @@
 # {FILES_TO_INSTALL} {DEST_DIR}
 # bin
 usr/bin/circledump usr/share/one/bin/
+usr/bin/circle-opselector usr/share/one/bin/
 usr/bin/circle-tensordump usr/share/one/bin/
 usr/bin/tflchef usr/share/one/bin/
 usr/bin/tflchef-file usr/share/one/bin/


### PR DESCRIPTION
This commit installs _circle-opselector_ on one-compiler-dev package.

Related: #10420 
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>