### PR TITLE
[circle-opselector] Fix log misspelling

### DIFF
--- a/compiler/circle-opselector/src/OpSelector.cpp
+++ b/compiler/circle-opselector/src/OpSelector.cpp
@@ -132,7 +132,7 @@ std::unique_ptr<loco::Graph> make_graph(const std::vector<const luci::CircleNode
         input_node = dynamic_cast<luci::CircleNode *>(arg);
         if (not input_node)
         {
-          throw std::runtime_error{"ERROR: Invliad graph"};
+          throw std::runtime_error{"ERROR: Invalid graph"};
         }
         luci::copy_common_attributes(input_node, circle_input);
         ctx.emplace(input_node, circle_input);


### PR DESCRIPTION
This commit fixes a misspelling of the error message.

ONE-DCO-1.0-Signed-off-by: Seungha Son linuxias@gmail.com