### PR TITLE
[one-cmds] Skip some tests for a while

### DIFF
--- a/compiler/one-cmds/tests/one-quantize_016.test
+++ b/compiler/one-cmds/tests/one-quantize_016.test
@@ -17,6 +17,14 @@
 filename_ext="$(basename -- $0)"
 filename="${filename_ext%.*}"
 
+# TODO Resolve circledump not found
+# https://github.com/Samsung/ONE/issues/10550
+if ! command -v circledump &> /dev/null
+then
+  echo "${filename_ext} SKIPPED"
+  exit 0
+fi
+
 trap_err_onexit()
 {
   echo "${filename_ext} FAILED"

--- a/compiler/one-cmds/tests/onecc_045.test
+++ b/compiler/one-cmds/tests/onecc_045.test
@@ -17,6 +17,14 @@
 filename_ext="$(basename -- $0)"
 filename="${filename_ext%.*}"
 
+# TODO Resolve circledump not found
+# https://github.com/Samsung/ONE/issues/10550
+if ! command -v circledump &> /dev/null
+then
+  echo "${filename_ext} SKIPPED"
+  exit 0
+fi
+
 trap_err_onexit()
 {
   echo "${filename_ext} FAILED"


### PR DESCRIPTION
This commit skips the tests that use circledump.

Related: #10550 
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>