### PR TITLE
[one-cmds] Rename output file

### DIFF
--- a/compiler/one-cmds/tests/one-import-onnx_002.test
+++ b/compiler/one-cmds/tests/one-import-onnx_002.test
@@ -28,7 +28,7 @@ trap_err_onexit()
 trap trap_err_onexit ERR
 
 inputfile="./reshape_matmul.onnx"
-outputfile="./reshape_matmul.circle"
+outputfile="./reshape_matmul.one-import-onnx_002.circle"
 
 rm -rf ${outputfile}
 rm -rf ${outputfile}.log
@@ -42,7 +42,7 @@ if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit
 fi
 
-circle-operator --code reshape_matmul.circle > ${outputfile}.log 2>&1
+circle-operator --code ${outputfile} > ${outputfile}.log 2>&1
 
 if ! grep -q "FULLY_CONNECTED" "${outputfile}.log"; then
   trap_err_onexit
@@ -61,7 +61,7 @@ if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit
 fi
 
-circle-operator --code reshape_matmul.circle > ${outputfile}.log 2>&1
+circle-operator --code ${outputfile} > ${outputfile}.log 2>&1
 
 if ! grep -q "BATCH_MATMUL" "${outputfile}.log"; then
   trap_err_onexit


### PR DESCRIPTION
This makes one-import-onnx_002.test create a unique output name.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/pull/10538#discussion_r1146956103