### PR TITLE
[one-cmds] Use prepared file

### DIFF
--- a/compiler/one-cmds/tests/one-quantize_016.test
+++ b/compiler/one-cmds/tests/one-quantize_016.test
@@ -41,11 +41,6 @@ rm -f ${filename}.first.cdump
 rm -f ${filename}.second.cdump
 rm -f ${outputfile}
 
-# TODO Generate input file in prepare_test_materials.sh
-if [[ ! -s "${inputfile}" ]]; then
-  one-import onnx -i reshape_matmul.onnx -o ${inputfile}
-fi
-
 # run test with different input_type
 one-quantize \
 --input_dtype float32 \

--- a/compiler/one-cmds/tests/one-quantize_neg_021.test
+++ b/compiler/one-cmds/tests/one-quantize_neg_021.test
@@ -37,11 +37,6 @@ outputfile="./reshape_matmul.quantized.neg_021.circle"
 
 rm -f ${filename}.log
 
-# TODO Generate input file in prepare_test_materials.sh
-if [[ ! -s "${inputfile}" ]]; then
-  one-import onnx -i reshape_matmul.onnx -o ${inputfile}
-fi
-
 # run test with wrong number of input_type
 one-quantize \
 --input_dtype float32 \

--- a/compiler/one-cmds/tests/onecc_045.test
+++ b/compiler/one-cmds/tests/onecc_045.test
@@ -42,11 +42,6 @@ rm -f ${filename}.first.cdump
 rm -f ${filename}.second.cdump
 rm -f ${outputfile}
 
-# TODO Generate input file in prepare_test_materials.sh
-if [[ ! -s "${inputfile}" ]]; then
-  one-import onnx -i reshape_matmul.onnx -o ${inputfile}
-fi
-
 # run test
 onecc -C ${configfile} > ${filename}.log 2>&1
 

--- a/compiler/one-cmds/tests/onecc_neg_026.test
+++ b/compiler/one-cmds/tests/onecc_neg_026.test
@@ -37,11 +37,6 @@ configfile="onecc_neg_026.cfg"
 
 rm -f ${filename}.log
 
-# TODO Generate input file in prepare_test_materials.sh
-if [[ ! -s "${inputfile}" ]]; then
-  one-import onnx -i reshape_matmul.onnx -o ${inputfile}
-fi
-
 # run test
 onecc -C ${configfile} > ${filename}.log 2>&1
 

--- a/compiler/one-cmds/tests/prepare_test_materials.sh
+++ b/compiler/one-cmds/tests/prepare_test_materials.sh
@@ -98,6 +98,13 @@ if [[ ! -s "reshape_matmul.onnx" ]]; then
     # https://github.com/Samsung/ONE/issues/9405#issuecomment-1180198137
 fi
 
+# prepare 'reshape_matmul.circle' file used for tests
+if [[ ! -s "reshape_matmul.circle" ]]; then
+    ../bin/one-import onnx \
+    -i reshape_matmul.onnx \
+    -o reshape_matmul.circle
+fi
+
 if [[ ! -s "Net_InstanceNorm_003.part" ]]; then
     rm -rf Net_InstanceNorm_003.zip
     wget -nv https://github.com/Samsung/ONE/files/8608844/Net_InstanceNorm_003.zip


### PR DESCRIPTION
This makes tests use reshape_matmul.circle to avoid repetitive overhead.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/pull/10538#discussion_r1146956103