### PR TITLE
Remove bad escape

### DIFF
--- a/compiler/nnc/backends/soft_backend/code_snippets/eigen.def
+++ b/compiler/nnc/backends/soft_backend/code_snippets/eigen.def
@@ -13381,7 +13381,7 @@ struct palign_impl<Offset,Type>\
         if (Offset!=0)\
             first = Command(first, second, Offset);\
     }\
-};\
+};
 PALIGN_NEON(0,Packet2d,vextq_f64)
 PALIGN_NEON(1,Packet2d,vextq_f64)
 #undef PALIGN_NEON


### PR DESCRIPTION
- Remove bad tailing escapes from macro definition that cause semantic errors.

ONE-DCO-1.0-Signed-off-by: Sung-Jae Lee <sj925.lee@samsung.com>