### PR TITLE
[dio-hdf5] Check buffer size in readTensor

### DIFF
--- a/compiler/dio-hdf5/include/dio_hdf5/HDF5Importer.h
+++ b/compiler/dio-hdf5/include/dio_hdf5/HDF5Importer.h
@@ -59,11 +59,29 @@ public:
    * @param shape : pointer to write the tensor's shape
    * @param buffer : pointer to write the tensor's data
    */
+  // TODO Deprecate this API (use the one with buffer_bytes)
   void readTensor(int32_t data_idx, int32_t input_idx, loco::DataType *dtype,
                   std::vector<loco::Dimension> *shape, void *buffer);
 
   // Read a raw tensor (no type/shape is specified)
+  // TODO Deprecate this API (use the one with buffer_bytes)
   void readTensor(int32_t data_idx, int32_t input_idx, void *buffer);
+
+  /**
+   * @brief Read tensor data from file and store it into buffer
+   * @details A tensor in the file can be retrieved with (data_idx, input_idx)
+   * @param data_idx : index of the data
+   * @param input_idx : index of the input
+   * @param dtype : pointer to write the tensor's data type
+   * @param shape : pointer to write the tensor's shape
+   * @param buffer : pointer to write the tensor's data
+   * @param buffer_bytes : byte size of the buffer
+   */
+  void readTensor(int32_t data_idx, int32_t input_idx, loco::DataType *dtype,
+                  std::vector<loco::Dimension> *shape, void *buffer, size_t buffer_bytes);
+
+  // Read a raw tensor (no type/shape is specified)
+  void readTensor(int32_t data_idx, int32_t input_idx, void *buffer, size_t buffer_bytes);
 
   bool isRawData() { return _group.attrExists("rawData"); }
 

--- a/compiler/dio-hdf5/src/HDF5Importer.cpp
+++ b/compiler/dio-hdf5/src/HDF5Importer.cpp
@@ -167,5 +167,51 @@ void HDF5Importer::readTensor(int32_t record_idx, int32_t input_idx, DataType *d
   }
 }
 
+void HDF5Importer::readTensor(int32_t record_idx, int32_t input_idx, void *buffer,
+                              size_t buffer_bytes)
+{
+  auto record = _group.openGroup(std::to_string(record_idx));
+  auto tensor = record.openDataSet(std::to_string(input_idx));
+
+  if (tensor.getInMemDataSize() != buffer_bytes)
+    throw std::runtime_error("Buffer size does not match with the size of tensor data");
+
+  readTensorData(tensor, static_cast<uint8_t *>(buffer));
+}
+
+void HDF5Importer::readTensor(int32_t record_idx, int32_t input_idx, DataType *dtype, Shape *shape,
+                              void *buffer, size_t buffer_bytes)
+{
+  auto record = _group.openGroup(std::to_string(record_idx));
+  auto tensor = record.openDataSet(std::to_string(input_idx));
+
+  auto tensor_dtype = tensor.getDataType();
+  *dtype = toInternalDtype(tensor_dtype);
+
+  auto tensor_shape = tensor.getSpace();
+  *shape = toInternalShape(tensor_shape);
+
+  if (tensor.getInMemDataSize() != buffer_bytes)
+    throw std::runtime_error("Buffer size does not match with the size of tensor data");
+
+  switch (*dtype)
+  {
+    case DataType::FLOAT32:
+      readTensorData(tensor, static_cast<float *>(buffer));
+      break;
+    case DataType::S32:
+      readTensorData(tensor, static_cast<int32_t *>(buffer));
+      break;
+    case DataType::S64:
+      readTensorData(tensor, static_cast<int64_t *>(buffer));
+      break;
+    case DataType::BOOL:
+      readTensorData(tensor, static_cast<uint8_t *>(buffer));
+      break;
+    default:
+      throw std::runtime_error{"Unsupported data type for input data (.h5)"};
+  }
+}
+
 } // namespace hdf5
 } // namespace dio

--- a/compiler/dio-hdf5/src/HDF5Importer.test.cpp
+++ b/compiler/dio-hdf5/src/HDF5Importer.test.cpp
@@ -132,3 +132,18 @@ TEST(dio_hdf5_test, input_out_of_index_NEG)
   // Read non-existing input (input_idx = 1)
   EXPECT_ANY_THROW(h5.readTensor(0, 1, &dtype, &shape, buffer.data()));
 }
+
+TEST(dio_hdf5_test, wrong_buffer_size_NEG)
+{
+  createFile();
+
+  HDF5Importer h5(::file_name);
+
+  h5.importGroup("value");
+
+  std::vector<float> buffer(6);
+
+  DataType dtype;
+  Shape shape;
+  EXPECT_ANY_THROW(h5.readTensor(0, 0, &dtype, &shape, buffer.data(), 1 /* wrong buffer size */));
+}


### PR DESCRIPTION
This adds new interface that checks buffer size when reading tensor data.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/pull/10567
Draft PR: https://github.com/Samsung/ONE/pull/10568