### PR TITLE
[circle-mpqsolver] Introduce setVisqPath

### DIFF
--- a/compiler/circle-mpqsolver/src/bisection/BisectionSolver.cpp
+++ b/compiler/circle-mpqsolver/src/bisection/BisectionSolver.cpp
@@ -101,6 +101,8 @@ float BisectionSolver::evaluate(const DatasetEvaluator &evaluator, const std::st
 
 void BisectionSolver::algorithm(Algorithm algorithm) { _algorithm = algorithm; }
 
+void BisectionSolver::setVisqPath(const std::string &visq_path) { _visq_data_path = visq_path; }
+
 std::unique_ptr<luci::Module> BisectionSolver::run(const std::string &module_path)
 {
   LOGGER(l);

--- a/compiler/circle-mpqsolver/src/bisection/BisectionSolver.h
+++ b/compiler/circle-mpqsolver/src/bisection/BisectionSolver.h
@@ -64,6 +64,13 @@ public:
    */
   void algorithm(Algorithm algorithm);
 
+  /**
+   * @brief   set visq_file path to be used in 'auto' mode
+   * @details this is used to handle which way (8 or 16bit) of
+   *          splitting the neural network will be the best for accuracy.
+   */
+  void setVisqPath(const std::string &visq_path);
+
 private:
   float evaluate(const DatasetEvaluator &evaluator, const std::string &module_path,
                  const std::string &def_quant, LayerParams &layers);
@@ -72,6 +79,7 @@ private:
   float _qerror = 0.f; // quantization error
   Algorithm _algorithm = Algorithm::ForceQ16Front;
   std::unique_ptr<Quantizer> _quantizer;
+  std::string _visq_data_path;
 };
 
 } // namespace bisection


### PR DESCRIPTION
This commit introduce setVisqPath into BisectionSolver.

Draft: https://github.com/Samsung/ONE/pull/10432
Related: https://github.com/Samsung/ONE/issues/10393

ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>