### PR TITLE
[dio-hdf5] Remove deprecated readTensor

### DIFF
--- a/compiler/dio-hdf5/include/dio_hdf5/HDF5Importer.h
+++ b/compiler/dio-hdf5/include/dio_hdf5/HDF5Importer.h
@@ -58,23 +58,6 @@ public:
    * @param dtype : pointer to write the tensor's data type
    * @param shape : pointer to write the tensor's shape
    * @param buffer : pointer to write the tensor's data
-   */
-  // TODO Deprecate this API (use the one with buffer_bytes)
-  void readTensor(int32_t data_idx, int32_t input_idx, loco::DataType *dtype,
-                  std::vector<loco::Dimension> *shape, void *buffer);
-
-  // Read a raw tensor (no type/shape is specified)
-  // TODO Deprecate this API (use the one with buffer_bytes)
-  void readTensor(int32_t data_idx, int32_t input_idx, void *buffer);
-
-  /**
-   * @brief Read tensor data from file and store it into buffer
-   * @details A tensor in the file can be retrieved with (data_idx, input_idx)
-   * @param data_idx : index of the data
-   * @param input_idx : index of the input
-   * @param dtype : pointer to write the tensor's data type
-   * @param shape : pointer to write the tensor's shape
-   * @param buffer : pointer to write the tensor's data
    * @param buffer_bytes : byte size of the buffer
    */
   void readTensor(int32_t data_idx, int32_t input_idx, loco::DataType *dtype,

--- a/compiler/dio-hdf5/src/HDF5Importer.cpp
+++ b/compiler/dio-hdf5/src/HDF5Importer.cpp
@@ -128,45 +128,6 @@ int32_t HDF5Importer::numInputs(int32_t record_idx)
   return records.getNumObjs();
 }
 
-void HDF5Importer::readTensor(int32_t record_idx, int32_t input_idx, void *buffer)
-{
-  auto record = _group.openGroup(std::to_string(record_idx));
-  auto tensor = record.openDataSet(std::to_string(input_idx));
-
-  readTensorData(tensor, static_cast<uint8_t *>(buffer));
-}
-
-void HDF5Importer::readTensor(int32_t record_idx, int32_t input_idx, DataType *dtype, Shape *shape,
-                              void *buffer)
-{
-  auto record = _group.openGroup(std::to_string(record_idx));
-  auto tensor = record.openDataSet(std::to_string(input_idx));
-
-  auto tensor_dtype = tensor.getDataType();
-  *dtype = toInternalDtype(tensor_dtype);
-
-  auto tensor_shape = tensor.getSpace();
-  *shape = toInternalShape(tensor_shape);
-
-  switch (*dtype)
-  {
-    case DataType::FLOAT32:
-      readTensorData(tensor, static_cast<float *>(buffer));
-      break;
-    case DataType::S32:
-      readTensorData(tensor, static_cast<int32_t *>(buffer));
-      break;
-    case DataType::S64:
-      readTensorData(tensor, static_cast<int64_t *>(buffer));
-      break;
-    case DataType::BOOL:
-      readTensorData(tensor, static_cast<uint8_t *>(buffer));
-      break;
-    default:
-      throw std::runtime_error{"Unsupported data type for input data (.h5)"};
-  }
-}
-
 void HDF5Importer::readTensor(int32_t record_idx, int32_t input_idx, void *buffer,
                               size_t buffer_bytes)
 {

--- a/compiler/dio-hdf5/src/HDF5Importer.test.cpp
+++ b/compiler/dio-hdf5/src/HDF5Importer.test.cpp
@@ -73,7 +73,7 @@ TEST(dio_hdf5_test, read_with_type_shape)
 
   DataType dtype;
   Shape shape;
-  h5.readTensor(0, 0, &dtype, &shape, buffer.data());
+  h5.readTensor(0, 0, &dtype, &shape, buffer.data(), buffer.size() * sizeof(float));
 
   for (uint32_t i = 0; i < 6; i++)
     EXPECT_EQ(i, buffer[i]);
@@ -114,7 +114,8 @@ TEST(dio_hdf5_test, data_out_of_index_NEG)
   DataType dtype;
   Shape shape;
   // Read non-existing data (data_idx = 1)
-  EXPECT_ANY_THROW(h5.readTensor(1, 0, &dtype, &shape, buffer.data()));
+  EXPECT_ANY_THROW(
+    h5.readTensor(1, 0, &dtype, &shape, buffer.data(), buffer.size() * sizeof(float)));
 }
 
 TEST(dio_hdf5_test, input_out_of_index_NEG)
@@ -130,7 +131,8 @@ TEST(dio_hdf5_test, input_out_of_index_NEG)
   DataType dtype;
   Shape shape;
   // Read non-existing input (input_idx = 1)
-  EXPECT_ANY_THROW(h5.readTensor(0, 1, &dtype, &shape, buffer.data()));
+  EXPECT_ANY_THROW(
+    h5.readTensor(0, 1, &dtype, &shape, buffer.data(), buffer.size() * sizeof(float)));
 }
 
 TEST(dio_hdf5_test, wrong_buffer_size_NEG)


### PR DESCRIPTION
This removes deprecated readTensor and updates existing tests.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/10567
Draft PR: https://github.com/Samsung/ONE/pull/10568