### PR TITLE
[one-cmds] Fix error message

### DIFF
--- a/compiler/one-cmds/tests/one-quantize_neg_003.test
+++ b/compiler/one-cmds/tests/one-quantize_neg_003.test
@@ -21,7 +21,7 @@ filename="${filename_ext%.*}"
 
 trap_err_onexit()
 {
-  if grep -q "Input shape mismatch" "${filename}.log"; then
+  if grep -q "Buffer size does not match" "${filename}.log"; then
     echo "${filename_ext} SUCCESS"
     exit 0
   fi


### PR DESCRIPTION
This fixes error message in one-quantize_neg_003.test

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/10555#issuecomment-1488184775