### PR TITLE
[one-cmds] Compile multiple backends with a single cfg file

### DIFF
--- a/compiler/one-cmds/dummy-driver/CMakeLists.txt
+++ b/compiler/one-cmds/dummy-driver/CMakeLists.txt
@@ -1,5 +1,6 @@
 # dummy driver for interface test
 set(DUMMY_DRIVER_SRC src/dummy-compile.cpp)
+set(DUMMY_V2_DRIVER_SRC src/dummyV2-compile.cpp)
 set(HELP_DRIVER_SRC src/help-compile.cpp)
 set(DUMMY_INFER_SRC src/dummy-infer.cpp)
 set(DUMMY_INFER_V2_SRC src/dummy-inferV2.cpp)
@@ -9,6 +10,7 @@ set(HELP_PROFILE_SRC src/help-profile.cpp)
 set(DUMMY_ENV_SRC src/dummyEnv-compile.cpp)
 
 add_executable(dummy-compile ${DUMMY_DRIVER_SRC})
+add_executable(dummyV2-compile ${DUMMY_V2_DRIVER_SRC})
 add_executable(help-compile ${HELP_DRIVER_SRC})
 add_executable(dummy-infer ${DUMMY_INFER_SRC})
 add_executable(dummy-inferV2 ${DUMMY_INFER_V2_SRC})
@@ -18,6 +20,7 @@ add_executable(help-profile ${HELP_PROFILE_SRC})
 add_executable(dummyEnv-compile ${DUMMY_ENV_SRC})
 
 set(DUMMY_DRIVER "${CMAKE_CURRENT_BINARY_DIR}/dummy-compile")
+set(DUMMY_V2_DRIVER "${CMAKE_CURRENT_BINARY_DIR}/dummyV2-compile")
 set(HELP_DRIVER "${CMAKE_CURRENT_BINARY_DIR}/help-compile")
 set(DUMMY_INFER "${CMAKE_CURRENT_BINARY_DIR}/dummy-infer")
 set(DUMMY_INFER_V2 "${CMAKE_CURRENT_BINARY_DIR}/dummy-inferV2")
@@ -27,6 +30,12 @@ set(HELP_PROFILE "${CMAKE_CURRENT_BINARY_DIR}/help-profile")
 set(DUMMY_ENV "${CMAKE_CURRENT_BINARY_DIR}/dummyEnv-compile")
 
 install(FILES ${DUMMY_DRIVER}
+        PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE
+                    GROUP_READ GROUP_EXECUTE
+                    WORLD_READ WORLD_EXECUTE
+        DESTINATION test)
+
+install(FILES ${DUMMY_V2_DRIVER}
         PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE
                     GROUP_READ GROUP_EXECUTE
                     WORLD_READ WORLD_EXECUTE

--- a/compiler/one-cmds/dummy-driver/src/dummyV2-compile.cpp
+++ b/compiler/one-cmds/dummy-driver/src/dummyV2-compile.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * dummyV2-compile only tests its interface rather than its functionality.
+ *
+ * ./dummyV2-compile -o ${OUTPUT_NAME} ${INPUT_NAME}
+ *
+ * NOTE argv[3](INPUT_NAME) is not used here.
+ */
+
+#include <iostream>
+#include <fstream>
+#include <string>
+
+int main(int argc, char **argv)
+{
+  if (argc != 4)
+    return EXIT_FAILURE;
+
+  std::string opt_o{"-O"};
+  std::string argv_1{argv[1]};
+
+  if (opt_o != argv_1)
+    return EXIT_FAILURE;
+
+  std::string output_name{argv[2]};
+  std::ofstream outfile(output_name);
+
+  outfile << "dummyV2-compile dummy output!!" << std::endl;
+
+  outfile.close();
+
+  return EXIT_SUCCESS;
+}

--- a/compiler/one-cmds/one-codegen
+++ b/compiler/one-cmds/one-codegen
@@ -97,42 +97,35 @@ def _get_parser(backends_list):
 
 def _verify_arg(parser, args, cfg_args):
     """verify given arguments"""
-    if oneutils.is_valid_attr(cfg_args, 'backend') and oneutils.is_valid_attr(
-            cfg_args, 'backends') and oneutils.is_valid_attr(cfg_args, 'command'):
+    cmd_backend_exist = oneutils.is_valid_attr(args, 'backend')
+    cfg_backend_exist = oneutils.is_valid_attr(cfg_args, 'backend')
+    cfg_backends_exist = oneutils.is_valid_attr(cfg_args, 'backends')
+    if cfg_backend_exist and cfg_backends_exist:
         parser.error(
             '\'backend\' option and \'backends\' option cannot be used simultaneously.')
 
     # Check if given backend from command line exists in the configuration file
-    if oneutils.is_valid_attr(args, 'backend') and oneutils.is_valid_attr(
-            cfg_args, 'backend'):
+    if cmd_backend_exist and cfg_backend_exist:
         if args.backend != cfg_args.backend:
             parser.error('Not found the command of given backend')
 
     # check if required arguments is given
     missing = []
-    if not oneutils.is_valid_attr(args, 'backend') and not oneutils.is_valid_attr(
-            args, 'backends') and not oneutils.is_valid_attr(
-                cfg_args, 'backend') and not oneutils.is_valid_attr(cfg_args, 'backends'):
+    if not cmd_backend_exist and not cfg_backend_exist and not cfg_backends_exist:
         missing.append('-b/--backend')
     if len(missing):
         parser.error('the following arguments are required: ' + ' '.join(missing))
 
-    if oneutils.is_valid_attr(cfg_args, 'backends'):
-        backends = getattr(cfg_args, 'backends').split(',')
+    if cfg_backends_exist:
+        cfg_backends = getattr(cfg_args, 'backends').split(',')
         # check if commands of given backends exist
-        for b in backends:
+        for b in cfg_backends:
             if not oneutils.is_valid_attr(cfg_args, b):
                 parser.error('Not found the command for ' + b)
 
         # Check if given backend from command line exists in the configuration file
-        if oneutils.is_valid_attr(args, 'backend') and oneutils.is_valid_attr(
-                cfg_args, 'backends'):
-            exists = False
-            for b in backends:
-                if b == args.backend:
-                    exists = True
-                    break
-            if not exists:
+        if cmd_backend_exist:
+            if args.backend not in cfg_backends:
                 parser.error('Not found the command of given backend')
 
 
@@ -164,22 +157,6 @@ def _parse_arg(parser):
     return codegen_args, backend_args, unknown_args
 
 
-'''
-one-codegen defines its behavior for below cases.
-
-[1] one-codegen -h
-[2] one-codegen -v
-[3] one-codegen -C ${cfg} (backend, command key in cfg)
-[4] one-codegen -C ${cfg} (backends key in cfg)
-[5] one-codegen -b ${backend} ${command}
-[6] one-codegen -b ${backend} -- ${command}
-[7] one-codegen -b ${backend} -C {cfg} (backend, command key in cfg)
-[8] one-codegen -b ${backend} -C {cfg} (backends key in cfg)
-
-All other cases are not allowed or an undefined behavior.
-'''
-
-
 def main():
     # get backend list
     backends_list = _get_backends_list()
@@ -197,7 +174,21 @@ def main():
 
     # verify arguments
     _verify_arg(parser, args, cfg_args)
+    '''
+    one-codegen defines its behavior for below cases.
 
+    [1] one-codegen -h
+    [2] one-codegen -v
+    [3] one-codegen -C ${cfg} (backend, command key in cfg)
+    [4] one-codegen -C ${cfg} (backends key in cfg)
+    [5] one-codegen -b ${backend} ${command}
+    [6] one-codegen -b ${backend} -- ${command}
+    [7] one-codegen -b ${backend} -C {cfg} (backend, command key in cfg)
+    [8] one-codegen -b ${backend} -C {cfg} (backends key in cfg) (Only 'backend' is invoked, 
+         even though cfg file has multiple backends)
+
+    All other cases are not allowed or an undefined behavior.
+    '''
     if oneutils.is_valid_attr(args, 'config'):
         assert (not backend_args or not unknown_args)
         # [7], [8]

--- a/compiler/one-cmds/one-codegen
+++ b/compiler/one-cmds/one-codegen
@@ -27,6 +27,7 @@ import ntpath
 import os
 import sys
 import shutil
+from types import SimpleNamespace
 
 import onelib.utils as oneutils
 
@@ -94,14 +95,45 @@ def _get_parser(backends_list):
     return parser
 
 
-def _verify_arg(parser, args):
+def _verify_arg(parser, args, cfg_args):
     """verify given arguments"""
+    if oneutils.is_valid_attr(cfg_args, 'backend') and oneutils.is_valid_attr(
+            cfg_args, 'backends') and oneutils.is_valid_attr(cfg_args, 'command'):
+        parser.error(
+            '\'backend\' option and \'backends\' option cannot be used simultaneously.')
+
+    # Check if given backend from command line exists in the configuration file
+    if oneutils.is_valid_attr(args, 'backend') and oneutils.is_valid_attr(
+            cfg_args, 'backend'):
+        if args.backend != cfg_args.backend:
+            parser.error('Not found the command of given backend')
+
     # check if required arguments is given
     missing = []
-    if not oneutils.is_valid_attr(args, 'backend'):
+    if not oneutils.is_valid_attr(args, 'backend') and not oneutils.is_valid_attr(
+            args, 'backends') and not oneutils.is_valid_attr(
+                cfg_args, 'backend') and not oneutils.is_valid_attr(cfg_args, 'backends'):
         missing.append('-b/--backend')
     if len(missing):
         parser.error('the following arguments are required: ' + ' '.join(missing))
+
+    if oneutils.is_valid_attr(cfg_args, 'backends'):
+        backends = getattr(cfg_args, 'backends').split(',')
+        # check if commands of given backends exist
+        for b in backends:
+            if not oneutils.is_valid_attr(cfg_args, b):
+                parser.error('Not found the command for ' + b)
+
+        # Check if given backend from command line exists in the configuration file
+        if oneutils.is_valid_attr(args, 'backend') and oneutils.is_valid_attr(
+                cfg_args, 'backends'):
+            exists = False
+            for b in backends:
+                if b == args.backend:
+                    exists = True
+                    break
+            if not exists:
+                parser.error('Not found the command of given backend')
 
 
 def _parse_arg(parser):
@@ -132,6 +164,22 @@ def _parse_arg(parser):
     return codegen_args, backend_args, unknown_args
 
 
+'''
+one-codegen defines its behavior for below cases.
+
+[1] one-codegen -h
+[2] one-codegen -v
+[3] one-codegen -C ${cfg} (backend, command key in cfg)
+[4] one-codegen -C ${cfg} (backends key in cfg)
+[5] one-codegen -b ${backend} ${command}
+[6] one-codegen -b ${backend} -- ${command}
+[7] one-codegen -b ${backend} -C {cfg} (backend, command key in cfg)
+[8] one-codegen -b ${backend} -C {cfg} (backends key in cfg)
+
+All other cases are not allowed or an undefined behavior.
+'''
+
+
 def main():
     # get backend list
     backends_list = _get_backends_list()
@@ -141,29 +189,56 @@ def main():
     args, backend_args, unknown_args = _parse_arg(parser)
 
     # parse configuration file
-    oneutils.parse_cfg(args.config, 'one-codegen', args)
+    cfg_args = SimpleNamespace()
+    oneutils.parse_cfg(args.config, 'one-codegen', cfg_args)
+
+    # parse configuration file (args has arguments parsed from command line + cfg)
+    # oneutils.parse_cfg(args.config, 'one-codegen', args)
 
     # verify arguments
-    _verify_arg(parser, args)
+    _verify_arg(parser, args, cfg_args)
 
-    # make a command to run given backend driver
-    codegen_path = None
-    backend_base = getattr(args, 'backend') + '-compile'
-    for cand in backends_list:
-        if ntpath.basename(cand) == backend_base:
-            codegen_path = cand
-    if not codegen_path:
-        # Find backend from system path
-        codegen_path = shutil.which(backend_base)
+    if oneutils.is_valid_attr(args, 'config'):
+        assert (not backend_args or not unknown_args)
+        # [7], [8]
+        if oneutils.is_valid_attr(args, 'backend'):
+            given_backends = [args.backend]
+            if oneutils.is_valid_attr(cfg_args, 'backend'):
+                assert (oneutils.is_valid_attr(cfg_args, 'command'))
+                setattr(cfg_args, args.backend, cfg_args.command)
+        else:
+            # [3]
+            if oneutils.is_valid_attr(cfg_args, 'backend'):
+                assert (oneutils.is_valid_attr(cfg_args, 'command'))
+                given_backends = [cfg_args.backend]
+                setattr(cfg_args, cfg_args.backend, cfg_args.command)
+            # [4]
+            if oneutils.is_valid_attr(cfg_args, 'backends'):
+                given_backends = cfg_args.backends.split(',')
+    # [5], [6]
+    else:
+        assert (backend_args or unknown_args)
+        given_backends = [args.backend]
 
-    if not codegen_path:
-        raise FileNotFoundError(backend_base + ' not found')
-    codegen_cmd = [codegen_path] + backend_args + unknown_args
-    if oneutils.is_valid_attr(args, 'command'):
-        codegen_cmd += getattr(args, 'command').split()
+    for given_backend in given_backends:
+        # make a command to run given backend driver
+        codegen_path = None
+        backend_base = given_backend + '-compile'
+        for cand in backends_list:
+            if ntpath.basename(cand) == backend_base:
+                codegen_path = cand
+        if not codegen_path:
+            # Find backend from system path
+            codegen_path = shutil.which(backend_base)
 
-    # run backend driver
-    oneutils.run(codegen_cmd, err_prefix=backend_base)
+        if not codegen_path:
+            raise FileNotFoundError(backend_base + ' not found')
+        codegen_cmd = [codegen_path] + backend_args + unknown_args
+        if oneutils.is_valid_attr(cfg_args, given_backend):
+            codegen_cmd += getattr(cfg_args, given_backend).split()
+
+        # run backend driver
+        oneutils.run(codegen_cmd, err_prefix=backend_base)
 
 
 if __name__ == '__main__':

--- a/compiler/one-cmds/onecc
+++ b/compiler/one-cmds/onecc
@@ -67,7 +67,7 @@ def _check_subtool_exists():
 
 
 def _get_parser():
-    onecc_usage = 'onecc [-h] [-v] [-C CONFIG] [-W WORKFLOW] [-O OPTIMIZATION] [COMMAND <args>]'
+    onecc_usage = 'onecc [-h] [-v] [-C CONFIG] [-b BACKEND] [-W WORKFLOW] [-O OPTIMIZATION] [COMMAND <args>]'
     onecc_desc = 'Run ONE driver via several commands or configuration file'
     parser = argparse.ArgumentParser(description=onecc_desc, usage=onecc_usage)
 
@@ -85,6 +85,9 @@ def _get_parser():
 
     parser.add_argument(
         '-W', '--workflow', type=str, metavar='WORKFLOW', help='run with workflow file')
+
+    parser.add_argument(
+        '-b', '--backend', type=str, help='generate code for given backend')
 
     # just for help message
     compile_group = parser.add_argument_group('compile to circle model')
@@ -126,6 +129,10 @@ def _verify_arg(parser, args):
         if not getattr(args, 'O') in opt_name_list:
             parser.error('Invalid optimization option')
 
+    if oneutils.is_valid_attr(args, 'backend') and oneutils.is_valid_attr(
+            args, 'workflow'):
+        parser.error('\'backend\' option can be used only with \'config\' option')
+
 
 def main():
     # check if there is subtool argument
@@ -152,6 +159,8 @@ def main():
         runner.detect_import_drivers(bin_dir)
         if oneutils.is_valid_attr(args, 'O'):
             runner.add_opt(getattr(args, 'O'))
+        if oneutils.is_valid_attr(args, 'backend'):
+            runner.set_backend(args.backend)
         runner.run(bin_dir)
     elif oneutils.is_valid_attr(args, 'workflow'):
         runner = WorkflowRunner(args.workflow)

--- a/compiler/one-cmds/onelib/CfgRunner.py
+++ b/compiler/one-cmds/onelib/CfgRunner.py
@@ -56,6 +56,8 @@ class CfgRunner:
                 # add_opt receives group name except first 'O'
                 self.add_opt(o[1:])
 
+        self.backend = None
+
     def _verify_cfg(self, cfgparser):
         if not cfgparser.has_section('onecc'):
             if cfgparser.has_section('one-build'):
@@ -88,6 +90,9 @@ class CfgRunner:
             )
         self.opt = opt
 
+    def set_backend(self, backend: str):
+        self.backend = backend
+
     def detect_import_drivers(self, dir):
         self.import_drivers = list(oneutils.detect_one_import_drivers(dir).keys())
 
@@ -109,6 +114,8 @@ class CfgRunner:
                 options += ['-O', self.opt]
             if verbose:
                 options.append('--verbose')
+            if section == 'one-codegen' and self.backend:
+                options += ['-b', self.backend]
             driver_path = os.path.join(working_dir, section)
             cmd = [driver_path] + options
             oneutils.run(cmd)

--- a/compiler/one-cmds/tests/onecc_046.cfg
+++ b/compiler/one-cmds/tests/onecc_046.cfg
@@ -1,0 +1,7 @@
+[onecc]
+one-codegen=True
+
+[one-codegen]
+backends=dummy,dummyV2
+dummy=-o sample.tvn inception_v3.onecc_046.circle
+dummyV2=-O sample2.tvn inception_v3.onecc_046.circle

--- a/compiler/one-cmds/tests/onecc_046.cfg
+++ b/compiler/one-cmds/tests/onecc_046.cfg
@@ -3,5 +3,5 @@ one-codegen=True
 
 [one-codegen]
 backends=dummy,dummyV2
-dummy=-o sample.tvn inception_v3.onecc_046.circle
-dummyV2=-O sample2.tvn inception_v3.onecc_046.circle
+dummy=-o onecc_046.tvn inception_v3.onecc_046.circle
+dummyV2=-O onecc_046.2.tvn inception_v3.onecc_046.2.circle

--- a/compiler/one-cmds/tests/onecc_046.test
+++ b/compiler/one-cmds/tests/onecc_046.test
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+# Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,8 +29,8 @@ trap_err_onexit()
 trap trap_err_onexit ERR
 
 configfile="onecc_046.cfg"
-outputfile="sample.tvn"
-outputfile2="sample2.tvn"
+outputfile="onecc_046.tvn"
+outputfile2="onecc_046.2.tvn"
 
 rm -f ${filename}.log
 rm -rf ${outputfile}

--- a/compiler/one-cmds/tests/onecc_046.test
+++ b/compiler/one-cmds/tests/onecc_046.test
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# 'backends' key in configuration file
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  echo "${filename_ext} FAILED"
+  rm -rf ../bin/dummy-compile
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+configfile="onecc_046.cfg"
+outputfile="sample.tvn"
+outputfile2="sample2.tvn"
+
+rm -f ${filename}.log
+rm -rf ${outputfile}
+rm -rf ${outputfile2}
+
+# copy dummy tools to bin folder
+cp dummy-compile ../bin/dummy-compile
+cp dummyV2-compile ../bin/dummyV2-compile
+
+# run test
+onecc -C ${configfile} > ${filename}.log 2>&1
+
+if [[ ! -s "${outputfile}" ]]; then
+  trap_err_onexit
+fi
+
+if [[ ! -s "${outputfile2}" ]]; then
+  trap_err_onexit
+fi
+
+rm -rf ../bin/dummy-compile
+rm -rf ../bin/dummyV2-compile
+
+echo "${filename_ext} SUCCESS"

--- a/compiler/one-cmds/tests/onecc_047.cfg
+++ b/compiler/one-cmds/tests/onecc_047.cfg
@@ -1,0 +1,7 @@
+[onecc]
+one-codegen=True
+
+[one-codegen]
+backends=dummy,dummyV2
+dummy=-o sample.tvn inception_v3.onecc_047.circle
+dummyV2=-O sample2.tvn inception_v3.onecc_047.circle

--- a/compiler/one-cmds/tests/onecc_047.cfg
+++ b/compiler/one-cmds/tests/onecc_047.cfg
@@ -3,5 +3,5 @@ one-codegen=True
 
 [one-codegen]
 backends=dummy,dummyV2
-dummy=-o sample.tvn inception_v3.onecc_047.circle
-dummyV2=-O sample2.tvn inception_v3.onecc_047.circle
+dummy=-o onecc_047.tvn inception_v3.onecc_047.circle
+dummyV2=-O onecc_047.2.tvn inception_v3.onecc_047.2.circle

--- a/compiler/one-cmds/tests/onecc_047.test
+++ b/compiler/one-cmds/tests/onecc_047.test
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+# Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -30,8 +30,8 @@ trap_err_onexit()
 trap trap_err_onexit ERR
 
 configfile="onecc_047.cfg"
-outputfile="sample.tvn"
-outputfile2="sample2.tvn"
+outputfile="onecc_047.tvn"
+outputfile2="onecc_047.2.tvn"
 
 rm -f ${filename}.log
 rm -rf ${outputfile}

--- a/compiler/one-cmds/tests/onecc_047.test
+++ b/compiler/one-cmds/tests/onecc_047.test
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# 'backends' key in configuration file but run codegen for only one backend
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  echo "${filename_ext} FAILED"
+  rm -rf ../bin/dummy-compile
+  rm -rf ../bin/dummyV2-compile
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+configfile="onecc_047.cfg"
+outputfile="sample.tvn"
+outputfile2="sample2.tvn"
+
+rm -f ${filename}.log
+rm -rf ${outputfile}
+rm -rf ${outputfile2}
+
+# copy dummy tools to bin folder
+cp dummy-compile ../bin/dummy-compile
+cp dummyV2-compile ../bin/dummyV2-compile
+
+# run test
+onecc -C ${configfile} -b dummyV2 > ${filename}.log 2>&1
+
+# shouldn't be generated
+if [[ -s "${outputfile}" ]]; then
+  trap_err_onexit
+fi
+
+if [[ ! -s "${outputfile2}" ]]; then
+  trap_err_onexit
+fi
+
+rm -rf ../bin/dummy-compile
+rm -rf ../bin/dummyV2-compile
+
+echo "${filename_ext} SUCCESS"

--- a/compiler/one-cmds/tests/onecc_048.cfg
+++ b/compiler/one-cmds/tests/onecc_048.cfg
@@ -1,0 +1,6 @@
+[onecc]
+one-codegen=True
+
+[one-codegen]
+backend=dummyV2
+command=-O sample2.tvn inception_v3.onecc_048.circle

--- a/compiler/one-cmds/tests/onecc_048.cfg
+++ b/compiler/one-cmds/tests/onecc_048.cfg
@@ -3,4 +3,4 @@ one-codegen=True
 
 [one-codegen]
 backend=dummyV2
-command=-O sample2.tvn inception_v3.onecc_048.circle
+command=-O onecc_048.tvn inception_v3.onecc_048.circle

--- a/compiler/one-cmds/tests/onecc_048.test
+++ b/compiler/one-cmds/tests/onecc_048.test
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# 'backend' option from command line with 'backend' key in configuration file
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  echo "${filename_ext} FAILED"
+  rm -rf ../bin/dummyV2-compile
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+configfile="onecc_048.cfg"
+outputfile="sample2.tvn"
+
+rm -f ${filename}.log
+rm -rf ${outputfile}
+
+# copy dummy tools to bin folder
+cp dummyV2-compile ../bin/dummyV2-compile
+
+# run test
+onecc -C ${configfile} -b dummyV2 > ${filename}.log 2>&1
+
+if [[ ! -s "${outputfile}" ]]; then
+  trap_err_onexit
+fi
+
+rm -rf ../bin/dummyV2-compile
+
+echo "${filename_ext} SUCCESS"

--- a/compiler/one-cmds/tests/onecc_048.test
+++ b/compiler/one-cmds/tests/onecc_048.test
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+# Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ trap_err_onexit()
 trap trap_err_onexit ERR
 
 configfile="onecc_048.cfg"
-outputfile="sample2.tvn"
+outputfile="onecc_048.tvn"
 
 rm -f ${filename}.log
 rm -rf ${outputfile}

--- a/compiler/one-cmds/tests/onecc_neg_027.cfg
+++ b/compiler/one-cmds/tests/onecc_neg_027.cfg
@@ -1,0 +1,7 @@
+[onecc]
+one-codegen=True
+
+[one-codegen]
+backends=dummy,dummyV2
+dummy=-o sample.tvn inception_v3.onecc_neg_027.circle
+# dummyV2=-O sample2.tvn inception_v3.onecc_neg_027.circle

--- a/compiler/one-cmds/tests/onecc_neg_027.test
+++ b/compiler/one-cmds/tests/onecc_neg_027.test
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# not found the command for given backend
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  if grep -q "Not found the command for dummyV2" "${filename}.log"; then
+    echo "${filename_ext} SUCCESS"
+    exit 0
+  fi
+
+  echo "${filename_ext} FAILED"
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+configfile="onecc_neg_027.cfg"
+
+rm -f ${filename}.log
+
+# run test
+onecc -C ${configfile} > ${filename}.log 2>&1
+
+echo "${filename_ext} FAILED"
+exit 255

--- a/compiler/one-cmds/tests/onecc_neg_028.cfg
+++ b/compiler/one-cmds/tests/onecc_neg_028.cfg
@@ -1,0 +1,9 @@
+[onecc]
+one-codegen=True
+
+[one-codegen]
+backend=dummy3
+command=-o sample.tvn inception_v3.onecc_neg_028.circle
+backends=dummy,dummy2
+dummy=-o sample.tvn inception_v3.onecc_neg_028.circle
+dummyV2=-O sample2.tvn inception_v3.onecc_neg_028.circle

--- a/compiler/one-cmds/tests/onecc_neg_028.test
+++ b/compiler/one-cmds/tests/onecc_neg_028.test
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# use 'backend' and 'backends' option simultaneously
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  if grep -q "option cannot be used simultaneously" "${filename}.log"; then
+    echo "${filename_ext} SUCCESS"
+    exit 0
+  fi
+
+  echo "${filename_ext} FAILED"
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+configfile="onecc_neg_028.cfg"
+
+rm -f ${filename}.log
+
+# run test
+onecc -C ${configfile} > ${filename}.log 2>&1
+
+echo "${filename_ext} FAILED"
+exit 255

--- a/compiler/one-cmds/tests/onecc_neg_029.cfg
+++ b/compiler/one-cmds/tests/onecc_neg_029.cfg
@@ -1,0 +1,6 @@
+[onecc]
+one-codegen=True
+
+[one-codegen]
+backend=dummy3
+command=-o sample.tvn inception_v3.onecc_neg_029.circle

--- a/compiler/one-cmds/tests/onecc_neg_029.test
+++ b/compiler/one-cmds/tests/onecc_neg_029.test
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# not found the command of given backend
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  if grep -q "Not found the command of given backend" "${filename}.log"; then
+    echo "${filename_ext} SUCCESS"
+    exit 0
+  fi
+
+  echo "${filename_ext} FAILED"
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+configfile="onecc_neg_029.cfg"
+
+rm -f ${filename}.log
+
+# run test
+onecc -C ${configfile} --backend dummy2 > ${filename}.log 2>&1
+
+echo "${filename_ext} FAILED"
+exit 255

--- a/compiler/one-cmds/tests/onecc_neg_030.cfg
+++ b/compiler/one-cmds/tests/onecc_neg_030.cfg
@@ -1,0 +1,6 @@
+[onecc]
+one-codegen=True
+
+[one-codegen]
+backends=dummy3
+dummy3=-o sample.tvn inception_v3.onecc_neg_030.circle

--- a/compiler/one-cmds/tests/onecc_neg_030.test
+++ b/compiler/one-cmds/tests/onecc_neg_030.test
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# not found the command of given backend
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  if grep -q "Not found the command of given backend" "${filename}.log"; then
+    echo "${filename_ext} SUCCESS"
+    exit 0
+  fi
+
+  echo "${filename_ext} FAILED"
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+configfile="onecc_neg_030.cfg"
+
+rm -f ${filename}.log
+
+# run test
+onecc -C ${configfile} --backend dummy2 > ${filename}.log 2>&1
+
+echo "${filename_ext} FAILED"
+exit 255

--- a/compiler/one-cmds/tests/onecc_neg_031.test
+++ b/compiler/one-cmds/tests/onecc_neg_031.test
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# use 'backend' option with 'workflow' option
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  if grep -q "'backend' option can be used only with 'config' option" "${filename}.log"; then
+    echo "${filename_ext} SUCCESS"
+    exit 0
+  fi
+
+  echo "${filename_ext} FAILED"
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+workflowfile="onecc_neg_031.workflow.json"
+
+rm -f ${filename}.log
+
+# run test
+onecc -W ${workflowfile} --backend dummy > ${filename}.log 2>&1
+
+echo "${filename_ext} FAILED"
+exit 255

--- a/compiler/one-cmds/tests/onecc_neg_031.workflow.json
+++ b/compiler/one-cmds/tests/onecc_neg_031.workflow.json
@@ -1,0 +1,29 @@
+{
+    "workflows": [
+        "codegen_wf"
+    ],
+    "codegen_wf": {
+        "steps": [
+            "import_tf",
+            "codegen"
+        ],
+        "import_tf": {
+            "one-cmd": "one-import-tf",
+            "commands": {
+                "input_path": "inception_v3.pb",
+                "output_path": "inception_v3.onecc_031.circle",
+                "input_arrays": "input",
+                "input_shapes": "1,299,299,3",
+                "output_arrays": "InceptionV3/Predictions/Reshape_1",
+                "converter_version": "v2"
+            }
+        },
+        "codegen": {
+            "one-cmd": "one-codegen",
+            "commands": {
+                "backend": "dummy",
+                "command": "-o sample.tvn inception_v3.onecc_031.circle"
+            }
+        }
+    }
+}

--- a/compiler/one-cmds/tests/onecc_neg_031.workflow.json
+++ b/compiler/one-cmds/tests/onecc_neg_031.workflow.json
@@ -11,7 +11,7 @@
             "one-cmd": "one-import-tf",
             "commands": {
                 "input_path": "inception_v3.pb",
-                "output_path": "inception_v3.onecc_031.circle",
+                "output_path": "inception_v3.onecc_neg_031.circle",
                 "input_arrays": "input",
                 "input_shapes": "1,299,299,3",
                 "output_arrays": "InceptionV3/Predictions/Reshape_1",
@@ -22,7 +22,7 @@
             "one-cmd": "one-codegen",
             "commands": {
                 "backend": "dummy",
-                "command": "-o sample.tvn inception_v3.onecc_031.circle"
+                "command": "-o sample.tvn inception_v3.onecc_neg_031.circle"
             }
         }
     }


### PR DESCRIPTION
This commit introduces 'backends' option into one-codegen section.

Related: #10537 
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>