### PR TITLE
[luci] Reorder optimization passes

### DIFF
--- a/compiler/luci/pass/src/CircleOptimizer.cpp
+++ b/compiler/luci/pass/src/CircleOptimizer.cpp
@@ -319,14 +319,6 @@ void CircleOptimizer::optimize(loco::Graph *g) const
   {
     phase.emplace_back(std::make_unique<luci::FoldSparseToDensePass>());
   }
-  if (_options->query(Options::Algorithm::ForwardReshapeToUnaryOp))
-  {
-    phase.emplace_back(std::make_unique<luci::ForwardReshapeToUnaryOpPass>());
-  }
-  if (_options->query(Options::Algorithm::ForwardTransposeOp))
-  {
-    phase.emplace_back(std::make_unique<luci::ForwardTransposeOpPass>());
-  }
   if (_options->query(Options::Algorithm::FusePreActivationBatchNorm))
   {
     phase.emplace_back(std::make_unique<luci::FusePreActivationBatchNormPass>());
@@ -431,6 +423,15 @@ void CircleOptimizer::optimize(loco::Graph *g) const
   if (_options->query(Options::Algorithm::UnrollUnidirSeqLSTM))
   {
     phase.emplace_back(std::make_unique<luci::UnrollUnidirectionalSequenceLSTMPass>());
+  }
+  // Forward Reshape/Transpose after trying to remove redundant Reshape/Transpose
+  if (_options->query(Options::Algorithm::ForwardReshapeToUnaryOp))
+  {
+    phase.emplace_back(std::make_unique<luci::ForwardReshapeToUnaryOpPass>());
+  }
+  if (_options->query(Options::Algorithm::ForwardTransposeOp))
+  {
+    phase.emplace_back(std::make_unique<luci::ForwardTransposeOpPass>());
   }
 
   /* TRANSFORM DECLARATION END */

--- a/compiler/luci/pass/src/CircleOptimizer.cpp
+++ b/compiler/luci/pass/src/CircleOptimizer.cpp
@@ -424,7 +424,10 @@ void CircleOptimizer::optimize(loco::Graph *g) const
   {
     phase.emplace_back(std::make_unique<luci::UnrollUnidirectionalSequenceLSTMPass>());
   }
-  // Forward Reshape/Transpose after trying to remove redundant Reshape/Transpose
+  // Forward Reshape/Transpose is done after
+  // 1. SubstituteXXXToReshape
+  // 2. RemoveRedundantReshape/Transpose
+  // See https://github.com/Samsung/ONE/pull/10596 for more details
   if (_options->query(Options::Algorithm::ForwardReshapeToUnaryOp))
   {
     phase.emplace_back(std::make_unique<luci::ForwardReshapeToUnaryOpPass>());


### PR DESCRIPTION
This performs forwarding after removing redundant ops.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---

Previous ordering
`ForwardReshapeToUnaryOp -> ForwardTransposeOp -> RemoveRedundantReshape -> RemoveRedundantTranspose -> SubstituteTransposeToReshape`

This caused a problem in the below case.

Step 0 (original): Reshape -> Transpose -> Add
Step 1 (after ForwardTransposeOp): Reshape -> Add -> Transpose
Step 2 (after SubstituteTransposeToReshape): **Reshape -> Add -> Reshape**

If we reorder optimization passes as below (move Forward passes to the end),
`RemoveRedundantReshape -> RemoveRedundantTranspose -> SubstituteTransposeToReshape -> ForwardReshapeToUnaryOp -> ForwardTransposeOp`

Step 0 (original): Reshape -> Transpose -> Add
Step 1 (after SubstituteTransposeToReshape): Reshape -> Reshape -> Add
Step 1 (after RemoveRedundantReshape): **Add**