### PR TITLE
[luci] Support Sum in fake quantization

### DIFF
--- a/compiler/luci/pass/src/ConvertToFakeQuantizedModelPass.cpp
+++ b/compiler/luci/pass/src/ConvertToFakeQuantizedModelPass.cpp
@@ -217,6 +217,7 @@ struct FakeQuantize final : public luci::CircleNodeMutableVisitor<void>
   void visit(luci::CircleRsqrt *node) { fq_activation(node); }
   void visit(luci::CircleSoftmax *node) { fq_activation(node); }
   void visit(luci::CircleSqrt *node) { fq_activation(node); }
+  void visit(luci::CircleSum *node) { fq_activation(node); }
   void visit(luci::CircleTanh *node) { fq_activation(node); }
   void visit(luci::CircleTransposeConv *node) { fq_activation(node); }
 


### PR DESCRIPTION
This supports Sum Op in fake quantization.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/10531