### PR TITLE
[onert] Introduce ExecutionEvent{Emitter,Listener}

### DIFF
--- a/runtime/onert/core/src/exec/ExecutionEventEmitter.cc
+++ b/runtime/onert/core/src/exec/ExecutionEventEmitter.cc
@@ -27,11 +27,12 @@ void ExecutionEventEmitter::addListener(std::unique_ptr<IExecutionEventListener>
 }
 
 void ExecutionEventEmitter::notifyExecuteOpEnd(ir::SubgraphIndex s, ir::OperationIndex o,
-                                               ir::OpCode opcode, backend::ITensor *tensor)
+                                               ir::OpCode opcode, backend::ITensor **tensors,
+                                               uint32_t ntensors)
 {
   for (auto &l : _listeners)
   {
-    l->handleExecuteOpEnd(s, o, opcode, tensor);
+    l->handleExecuteOpEnd(s, o, opcode, tensors, ntensors);
   }
 }
 

--- a/runtime/onert/core/src/exec/ExecutionEventEmitter.cc
+++ b/runtime/onert/core/src/exec/ExecutionEventEmitter.cc
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ExecutionEventEmitter.h"
+
+namespace onert
+{
+namespace exec
+{
+
+void ExecutionEventEmitter::addListener(std::unique_ptr<IExecutionEventListener> listener)
+{
+  _listeners.emplace_back(std::move(listener));
+}
+
+void ExecutionEventEmitter::notifyExecuteOpEnd(ir::SubgraphIndex s, ir::OperationIndex o,
+                                               ir::OpCode opcode, backend::ITensor *tensor)
+{
+  for (auto &l : _listeners)
+  {
+    l->handleExecuteOpEnd(s, o, opcode, tensor);
+  }
+}
+
+void ExecutionEventEmitter::notifyExecuteSubgEnd(ir::SubgraphIndex s)
+{
+  for (auto &l : _listeners)
+  {
+    l->handleExecuteSubgEnd(s);
+  }
+}
+
+} // namespace exec
+} // namespace onert

--- a/runtime/onert/core/src/exec/ExecutionEventEmitter.h
+++ b/runtime/onert/core/src/exec/ExecutionEventEmitter.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_EXEC_EXECUTION_EVENT_EMITTER__
+#define __ONERT_EXEC_EXECUTION_EVENT_EMITTER__
+
+#include "IExecutionEventEmitter.h"
+#include "IExecutionEventListener.h"
+
+#include <list>
+#include <memory>
+
+namespace onert
+{
+namespace exec
+{
+
+/* ExecutionEventEmitter (hereafter, EEE) is different from ExecutionObserver (hereafter EO) in:
+ *
+ * 1. EEE is used in release code, not only for debug
+ * 2. EEE is interested in the output tensor value. It has different paramters.
+ * 3. EEE will consider multiple model, subgraph later.
+ */
+class ExecutionEventEmitter : public IExecutionEventEmitter
+{
+public:
+  void addListener(std::unique_ptr<IExecutionEventListener> listener) override;
+  void notifyExecuteOpEnd(ir::SubgraphIndex, ir::OperationIndex, ir::OpCode,
+                          backend::ITensor *) override;
+  void notifyExecuteSubgEnd(ir::SubgraphIndex) override;
+
+private:
+  std::list<std::unique_ptr<IExecutionEventListener>> _listeners;
+};
+
+} // namespace exec
+} // namespace onert
+
+#endif // __ONERT_EXEC_EXECUTION_EVENT_EMITTER__

--- a/runtime/onert/core/src/exec/ExecutionEventEmitter.h
+++ b/runtime/onert/core/src/exec/ExecutionEventEmitter.h
@@ -38,8 +38,8 @@ class ExecutionEventEmitter : public IExecutionEventEmitter
 {
 public:
   void addListener(std::unique_ptr<IExecutionEventListener> listener) override;
-  void notifyExecuteOpEnd(ir::SubgraphIndex, ir::OperationIndex, ir::OpCode,
-                          backend::ITensor *) override;
+  void notifyExecuteOpEnd(ir::SubgraphIndex, ir::OperationIndex, ir::OpCode, backend::ITensor **,
+                          uint32_t) override;
   void notifyExecuteSubgEnd(ir::SubgraphIndex) override;
 
 private:

--- a/runtime/onert/core/src/exec/IExecutionEventEmitter.h
+++ b/runtime/onert/core/src/exec/IExecutionEventEmitter.h
@@ -34,7 +34,7 @@ namespace onert
 {
 namespace exec
 {
-class IExecutionEventListener;
+struct IExecutionEventListener;
 struct IExecutionEventEmitter
 {
   /**

--- a/runtime/onert/core/src/exec/IExecutionEventEmitter.h
+++ b/runtime/onert/core/src/exec/IExecutionEventEmitter.h
@@ -46,6 +46,7 @@ struct IExecutionEventEmitter
   virtual void notifyExecuteOpEnd(ir::SubgraphIndex, ir::OperationIndex, ir::OpCode,
                                   backend::ITensor **, uint32_t) = 0;
   virtual void notifyExecuteSubgEnd(ir::SubgraphIndex) = 0;
+  virtual ~IExecutionEventEmitter() = default;
 };
 } // namespace exec
 } // namespace onert

--- a/runtime/onert/core/src/exec/IExecutionEventEmitter.h
+++ b/runtime/onert/core/src/exec/IExecutionEventEmitter.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_EXEC_IEXECUTION_EVENT_EMITTER__
+#define __ONERT_EXEC_IEXECUTION_EVENT_EMITTER__
+
+#include "ir/Index.h"
+#include "ir/OpCode.h"
+
+#include <memory>
+
+namespace onert
+{
+namespace backend
+{
+class ITensor;
+}
+} // namespace onert
+
+namespace onert
+{
+namespace exec
+{
+class IExecutionEventListener;
+struct IExecutionEventEmitter
+{
+  /**
+   * @brief Add a listener
+   *
+   * @param listener Listener to be added
+   */
+  virtual void addListener(std::unique_ptr<IExecutionEventListener> listener) = 0;
+  virtual void notifyExecuteOpEnd(ir::SubgraphIndex, ir::OperationIndex, ir::OpCode,
+                                  backend::ITensor *) = 0;
+  virtual void notifyExecuteSubgEnd(ir::SubgraphIndex) = 0;
+};
+} // namespace exec
+} // namespace onert
+
+#endif // __ONERT_EXEC_IEXECUTION_EVENT_EMITTER__

--- a/runtime/onert/core/src/exec/IExecutionEventEmitter.h
+++ b/runtime/onert/core/src/exec/IExecutionEventEmitter.h
@@ -44,7 +44,7 @@ struct IExecutionEventEmitter
    */
   virtual void addListener(std::unique_ptr<IExecutionEventListener> listener) = 0;
   virtual void notifyExecuteOpEnd(ir::SubgraphIndex, ir::OperationIndex, ir::OpCode,
-                                  backend::ITensor *) = 0;
+                                  backend::ITensor **, uint32_t) = 0;
   virtual void notifyExecuteSubgEnd(ir::SubgraphIndex) = 0;
 };
 } // namespace exec

--- a/runtime/onert/core/src/exec/IExecutionEventListener.h
+++ b/runtime/onert/core/src/exec/IExecutionEventListener.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_EXEC_IEXECUTION_EVENT_LISTENER__
+#define __ONERT_EXEC_IEXECUTION_EVENT_LISTENER__
+
+#include "ir/Index.h"
+#include "ir/OpCode.h"
+
+namespace onert
+{
+namespace backend
+{
+class ITensor;
+}
+} // namespace onert
+
+namespace onert
+{
+namespace exec
+{
+
+struct IExecutionEventListener
+{
+  virtual void handleExecuteOpEnd(ir::SubgraphIndex, ir::OperationIndex, ir::OpCode,
+                                  backend::ITensor *) = 0;
+  virtual void handleExecuteSubgEnd(ir::SubgraphIndex) = 0;
+};
+
+} // namespace exec
+} // namespace onert
+
+#endif // __ONERT_EXEC_IEXECUTION_EVENT_LISTENER__

--- a/runtime/onert/core/src/exec/IExecutionEventListener.h
+++ b/runtime/onert/core/src/exec/IExecutionEventListener.h
@@ -36,7 +36,7 @@ namespace exec
 struct IExecutionEventListener
 {
   virtual void handleExecuteOpEnd(ir::SubgraphIndex, ir::OperationIndex, ir::OpCode,
-                                  backend::ITensor *) = 0;
+                                  backend::ITensor **, uint32_t) = 0;
   virtual void handleExecuteSubgEnd(ir::SubgraphIndex) = 0;
 };
 

--- a/runtime/onert/core/src/exec/IExecutionEventListener.h
+++ b/runtime/onert/core/src/exec/IExecutionEventListener.h
@@ -38,6 +38,7 @@ struct IExecutionEventListener
   virtual void handleExecuteOpEnd(ir::SubgraphIndex, ir::OperationIndex, ir::OpCode,
                                   backend::ITensor **, uint32_t) = 0;
   virtual void handleExecuteSubgEnd(ir::SubgraphIndex) = 0;
+  virtual ~IExecutionEventListener() = default;
 };
 
 } // namespace exec


### PR DESCRIPTION
Let's introduce ExecutionListener/Emitter for recording minmax.
They are named as Listener/Emitter because ExecutorObserve{r,e} are in use.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

Related: https://github.com/Samsung/ONE/issues/10604

2nd commit from Inner Repo's Draft PR