### PR TITLE
[circle2circle-dredd] Add REGRESS_ONNX_Mul_Mul test

### DIFF
--- a/compiler/circle2circle-dredd-recipe-test/test.lst
+++ b/compiler/circle2circle-dredd-recipe-test/test.lst
@@ -89,3 +89,6 @@ Add(REGRESS_ONNX_Conv_BN_MeanMean_001 PASS
       fuse_activation_function
       fuse_mean_with_mean
       fuse_transpose_with_mean)
+
+Add(REGRESS_ONNX_Mul_Mul_000 PASS
+      convert_nchw_to_nhwc)


### PR DESCRIPTION
This adds a regression test for ONNX_Mul_Mul.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/pull/10611#issuecomment-1500083991