### PR TITLE
[onert] Introduce MinMaxMap

### DIFF
--- a/runtime/onert/core/include/exec/MinMaxMap.h
+++ b/runtime/onert/core/include/exec/MinMaxMap.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_EXEC_MINMAX_MAP_H__
+#define __ONERT_EXEC_MINMAX_MAP_H__
+
+#include "ir/Index.h"
+#include "util/MinMaxMap.h"
+
+namespace onert
+{
+namespace exec
+{
+struct SMHash
+{
+  size_t operator()(const std::pair<ir::SubgraphIndex, ir::OperationIndex> &k) const noexcept
+  {
+    return std::hash<ir::SubgraphIndex>()(k.first) ^ std::hash<ir::OperationIndex>()(k.second);
+  }
+};
+// SM means single model
+using SMMinMaxMap = util::MinMaxMap<std::pair<ir::SubgraphIndex, ir::OperationIndex>, SMHash>;
+} // namespace exec
+} // namespace onert
+
+#endif // __ONERT_EXEC_MINMAX_MAP_H__

--- a/runtime/onert/core/include/util/MinMaxMap.h
+++ b/runtime/onert/core/include/util/MinMaxMap.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_UTIL_MINMAX_MAP_H_
+#define __ONERT_UTIL_MINMAX_MAP_H_
+
+#include <unordered_map>
+#include <utility>
+
+namespace onert
+{
+namespace util
+{
+
+template <typename N, typename Hash = std::hash<N>> class MinMaxMap
+{
+  struct MinMaxPair
+  {
+    float data[2]; // [0] = min, [1] = max
+  };
+
+public:
+  void append(N node, float min, float max) { _minmax_map[node] = {min, max}; }
+  auto begin() const { return _minmax_map.begin(); }
+  auto end() const { return _minmax_map.end(); }
+
+private:
+  std::unordered_map<N, MinMaxPair, Hash> _minmax_map;
+};
+
+} // namespace util
+} // namespace onert
+
+#endif // __ONERT_UTIL_MINMAX_MAP_H_


### PR DESCRIPTION
It introduces MinMaxMap for recording maxmax.
It maps {subg_idx,op_idx} to {min,max}.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

Related to #10604