### PR TITLE
[onert] Introduce exec/MinMaxRecorder

### DIFF
--- a/runtime/onert/core/CMakeLists.txt
+++ b/runtime/onert/core/CMakeLists.txt
@@ -3,8 +3,10 @@ file(GLOB_RECURSE TESTS "*.test.cc")
 list(REMOVE_ITEM SOURCES ${TESTS})
 
 if(NOT BUILD_MINMAX_H5DUMPER)
-  file(GLOB_RECURSE H5DUMPER_SRC "src/dumper/h5/*.cc")
-  list(REMOVE_ITEM SOURCES ${H5DUMPER_SRC})
+  file(GLOB_RECURSE SRC_TO_REMOVE "src/dumper/h5/*.cc")
+  list(REMOVE_ITEM SOURCES ${SRC_TO_REMOVE})
+  file(GLOB_RECURSE SRC_TO_REMOVE "src/exec/MinMaxRecorder.cc")
+  list(REMOVE_ITEM SOURCES ${SRC_TO_REMOVE})
 endif(NOT BUILD_MINMAX_H5DUMPER)
 
 add_library(onert_core SHARED ${SOURCES})

--- a/runtime/onert/core/src/exec/MinMaxRecorder.cc
+++ b/runtime/onert/core/src/exec/MinMaxRecorder.cc
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "MinMaxRecorder.h"
+
+#include "backend/ITensor.h"
+
+#include <cassert>
+#include <cmath>
+
+namespace onert
+{
+namespace exec
+{
+
+MinMaxRecorder::MinMaxRecorder(const std::string &minmax_filepath, const ir::Graph &graph,
+                               const backend::BackendContexts &backend_contexts)
+  : _graph{graph}, _backend_contexts{backend_contexts}, _h5dumper(minmax_filepath)
+{
+}
+
+void MinMaxRecorder::handleJobEnd(IExecutor *, ir::SubgraphIndex subg_idx,
+                                  ir::OperationIndex op_idx, const backend::Backend *backend)
+{
+  const auto &tensor_reg = _backend_contexts.at(backend)->tensor_registry;
+  const auto &op = _graph.operations().at(op_idx);
+  const auto &outputs = op.getOutputs();
+  // TODO: Support multiple output
+  if (outputs.size() != 1)
+    throw std::runtime_error("Only 1 output operator is supported for recording minmax.");
+
+  auto tensor = tensor_reg->getITensor(outputs.at(0));
+
+  // Logic copied from MinMaxObserver.cpp.
+
+  // Filter Ops
+  if (tensor->is_constant())
+    return;
+
+  if (tensor->data_type() != ir::DataType::FLOAT32)
+    return;
+
+  switch (op.opcode())
+  {
+    // Operators with multiple outputs
+    case ir::OpCode::If:
+    case ir::OpCode::Split:
+    case ir::OpCode::SplitV:
+    case ir::OpCode::TopKV2:
+    case ir::OpCode::Unpack:
+    case ir::OpCode::While:
+      return;
+    // NOTE: Sin, Cos, Tanh's output is in [-1, 1]
+    // We may not need to dump those operators.
+    default:; // Do Nothing
+  }
+
+  // Otherwise, dump!
+  assert(tensor->data_type() == ir::DataType::FLOAT32);
+  const auto data = reinterpret_cast<float *>(tensor->buffer());
+  const auto num_elements = tensor->total_size() / sizeof(float);
+
+  float max = std::numeric_limits<float>::lowest();
+  float min = std::numeric_limits<float>::max();
+
+  bool all_nan = true;
+  for (size_t i = 0; i < num_elements; ++i)
+  {
+    const float number = data[i];
+    if (std::isnan(number))
+      continue;
+
+    if (number == std::numeric_limits<float>::lowest())
+      continue;
+
+    all_nan = false;
+
+    if (number > max)
+      max = number;
+
+    if (number < min)
+      min = number;
+  }
+
+  if (all_nan)
+    throw std::runtime_error("All values are NaN(Not a Number)");
+
+  _minmax_map.append({subg_idx, op_idx}, min, max);
+}
+
+void MinMaxRecorder::handleSubgraphEnd(ir::SubgraphIndex)
+{
+  // It would be better to dump at the end of model execution, not subgraph
+  // But it requires more changes than subgraph.
+  _h5dumper.dump(_minmax_map);
+}
+
+} // namespace exec
+} // namespace onert

--- a/runtime/onert/core/src/exec/MinMaxRecorder.h
+++ b/runtime/onert/core/src/exec/MinMaxRecorder.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_EXEC_MINMAX_RECORDER__
+#define __ONERT_EXEC_MINMAX_RECORDER__
+
+#include "ExecutionObservers.h"
+#include "ir/Index.h"
+#include "exec/MinMaxMap.h"
+#include "../dumper/h5/MinMaxDumper.h"
+
+#include <memory>
+
+namespace onert
+{
+namespace exec
+{
+
+class MinMaxRecorder : public IExecutionObserver
+{
+public:
+  MinMaxRecorder(const std::string &minmax_filepath, const ir::Graph &graph,
+                 const backend::BackendContexts &backend_contexts);
+  void handleJobBegin(IExecutor *, ir::SubgraphIndex, ir::OperationIndex,
+                      const backend::Backend *) override
+  {
+    return;
+  }
+  void handleJobEnd(IExecutor *, ir::SubgraphIndex, ir::OperationIndex,
+                    const backend::Backend *) override;
+  void handleSubgraphEnd(ir::SubgraphIndex) override;
+
+private:
+  const ir::Graph &_graph;
+  const backend::BackendContexts &_backend_contexts;
+  dumper::h5::MinMaxDumper _h5dumper;
+  SMMinMaxMap _minmax_map;
+};
+
+} // namespace exec
+} // namespace onert
+
+#endif // __ONERT_EXEC_MINMAX_RECORDER__


### PR DESCRIPTION
It introduces MinMaxRecorder
It will not be built for Tizen and Android (not hdf5-ready).

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

Related: https://github.com/Samsung/ONE/issues/10604

@hseok-oh This PR contains the changes you've suggested in internal repo.
`MinMaxRecorder` inherits `ExecutionObserver`.