### PR TITLE
[onert] Add negative TC for StridedSlice

### DIFF
--- a/tests/nnfw_api/src/one_op_tests/StridedSlice.test.cc
+++ b/tests/nnfw_api/src/one_op_tests/StridedSlice.test.cc
@@ -41,3 +41,28 @@ TEST_F(GenModelTest, OneOp_StridedSlice_LastDim)
 
   SUCCEED();
 }
+
+TEST_F(GenModelTest, neg_OneOp_StridedSlice_DifferentType)
+{
+  CircleGen cgen;
+  std::vector<int32_t> begin_data{0, 3};
+  std::vector<int32_t> end_data{0, 6};
+  std::vector<int32_t> strides_data{1, 1};
+  uint32_t begin_buf = cgen.addBuffer(begin_data);
+  uint32_t end_buf = cgen.addBuffer(end_data);
+  uint32_t strides_buf = cgen.addBuffer(strides_data);
+  int input = cgen.addTensor({{1, 6}, circle::TensorType::TensorType_FLOAT32});
+  int begin = cgen.addTensor({{2}, circle::TensorType::TensorType_INT32, begin_buf});
+  int end = cgen.addTensor({{2}, circle::TensorType::TensorType_INT32, end_buf});
+  int strides = cgen.addTensor({{2}, circle::TensorType::TensorType_INT32, strides_buf});
+  int out = cgen.addTensor({{1, 3}, circle::TensorType::TensorType_INT32});
+  cgen.addOperatorStridedSlice({{input, begin, end, strides}, {out}}, 1, 1);
+  cgen.setInputsAndOutputs({input}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->addTestCase(uniformTCD<float>({{1, 2, 3, 4, 5, 6}}, {{4, 5, 6}}));
+  _context->setBackends({"acl_cl", "acl_neon", "cpu"});
+  _context->expectFailModelLoad();
+
+  SUCCEED();
+}


### PR DESCRIPTION
It adds different type of input and output as negative tc.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

Related: #10616

```
[ RUN      ] GenModelTest.neg_OneOp_StridedSlice_DifferentType
Error during model loading : OperationValidator failed at line 524
Failed model loading as expected.
[       OK ] GenModelTest.neg_OneOp_StridedSlice_DifferentType (0 ms)
```
