### PR TITLE
[onert] Add negative TC for BatchToSpaceND

### DIFF
--- a/tests/nnfw_api/src/one_op_tests/BatchToSpaceND.test.cc
+++ b/tests/nnfw_api/src/one_op_tests/BatchToSpaceND.test.cc
@@ -70,3 +70,20 @@ TEST_F(GenModelTest, OneOp_BatchToSpaceND_Crop)
   _context->setBackends({"cpu"});
   SUCCEED();
 }
+
+TEST_F(GenModelTest, neg_OneOp_BatchToSpaceND_DifferentType)
+{
+  CircleGen cgen;
+  int in = cgen.addTensor({{4, 1, 1, 1}, circle::TensorType::TensorType_FLOAT32});
+  int out = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_INT32});
+  int block = cgen.addTensor({{2}, circle::TensorType::TensorType_INT32});
+  cgen.addOperatorBatchToSpaceND({{in, block}, {out}});
+  cgen.setInputsAndOutputs({in, block}, {out});
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->addTestCase(TestCaseData{}
+                          .addInput<float>({1, 2, 3, 4})
+                          .addInput<int32_t>({2, 2})
+                          .addOutput<int>({1, 2, 3, 4}));
+  _context->expectFailModelLoad();
+  SUCCEED();
+}


### PR DESCRIPTION
It adds different type of input and output as negative tc.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

Related: #10616 

```
[ RUN      ] GenModelTest.neg_OneOp_BatchToSpaceND_DifferentType
Error during model loading : OperationValidator failed at line 138
Failed model loading as expected.
[       OK ] GenModelTest.neg_OneOp_BatchToSpaceND_DifferentType (0 ms)
```