### PR TITLE
[circle-inspect] Upgrade circle schema to 0.5

### DIFF
--- a/compiler/circle-inspect/CMakeLists.txt
+++ b/compiler/circle-inspect/CMakeLists.txt
@@ -1,6 +1,6 @@
-if(NOT TARGET mio_circle04)
+if(NOT TARGET mio_circle05)
   return()
-endif(NOT TARGET mio_circle04)
+endif(NOT TARGET mio_circle05)
 
 set(DRIVER "driver/Driver.cpp")
 
@@ -10,6 +10,6 @@ add_executable(circle-inspect ${DRIVER} ${SOURCES})
 target_include_directories(circle-inspect PRIVATE src)
 target_link_libraries(circle-inspect arser)
 target_link_libraries(circle-inspect foder)
-target_link_libraries(circle-inspect mio_circle04)
-target_link_libraries(circle-inspect mio_circle04_helper)
+target_link_libraries(circle-inspect mio_circle05)
+target_link_libraries(circle-inspect mio_circle05_helper)
 target_link_libraries(circle-inspect safemain)

--- a/compiler/circle-inspect/requires.cmake
+++ b/compiler/circle-inspect/requires.cmake
@@ -1,4 +1,4 @@
 require("arser")
 require("foder")
-require("mio-circle04")
+require("mio-circle05")
 require("safemain")


### PR DESCRIPTION
This upgrades circle schema to 0.5.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/10629
Draft PR: https://github.com/Samsung/ONE/pull/10643