### PR TITLE
[circle-mpqsolver] Implement intermediate dumping

### DIFF
--- a/compiler/circle-mpqsolver/src/CircleMPQSolver.cpp
+++ b/compiler/circle-mpqsolver/src/CircleMPQSolver.cpp
@@ -169,6 +169,15 @@ int entry(int argc, char **argv)
       }
     }
 
+    if (arser[save_intermediate_str])
+    {
+      auto data_path = arser.get<std::string>(save_intermediate_str);
+      if (!data_path.empty())
+      {
+        solver.set_save_intermediate(data_path);
+      }
+    }
+
     VERBOSE(l, 0) << "qerror metric: MSE" << std::endl
                   << "target qerror ratio: " << qerror_ratio << std::endl;
 


### PR DESCRIPTION
This commit implements intermediate dumping.
It produces following files:

![image](https://user-images.githubusercontent.com/112689352/232058237-2764d4d9-d8b2-4d4e-a4d8-9e131c6381c5.png)

for every iteration it provides `mpq` configuration(`*.mpq.json`) and quantized circle model (`*.mpq.circle`) 
along with base errors and errors at every iteration (`errors.mpq.txt`)


Sample output is attached:
[sample_output.zip](https://github.com/Samsung/ONE/files/11233315/sample_output.zip)

Related: #10634
ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>