### PR TITLE
[circle-tensordump] Upgrade circle schema to 0.5

### DIFF
--- a/compiler/circle-tensordump/CMakeLists.txt
+++ b/compiler/circle-tensordump/CMakeLists.txt
@@ -1,6 +1,6 @@
-if(NOT TARGET mio_circle04)
+if(NOT TARGET mio_circle05)
   return()
-endif(NOT TARGET mio_circle04)
+endif(NOT TARGET mio_circle05)
 
 nnas_find_package(HDF5 COMPONENTS STATIC QUIET)
 
@@ -19,8 +19,8 @@ target_include_directories(circle-tensordump PRIVATE ${HDF5_INCLUDE_DIRS})
 target_link_libraries(circle-tensordump PRIVATE ${HDF5_CXX_LIBRARIES})
 target_link_libraries(circle-tensordump PRIVATE arser)
 target_link_libraries(circle-tensordump PRIVATE foder)
-target_link_libraries(circle-tensordump PRIVATE mio_circle04)
-target_link_libraries(circle-tensordump PRIVATE mio_circle04_helper)
+target_link_libraries(circle-tensordump PRIVATE mio_circle05)
+target_link_libraries(circle-tensordump PRIVATE mio_circle05_helper)
 target_link_libraries(circle-tensordump PRIVATE safemain)
 
 install(TARGETS circle-tensordump DESTINATION bin)

--- a/compiler/circle-tensordump/requires.cmake
+++ b/compiler/circle-tensordump/requires.cmake
@@ -1,4 +1,4 @@
 require("arser")
 require("foder")
-require("mio-circle04")
+require("mio-circle05")
 require("safemain")


### PR DESCRIPTION
This upgrades circle schema to 0.5.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/10629
Draft PR: https://github.com/Samsung/ONE/pull/10643