### PR TITLE
[circle-operator] Upgrade circle schema to 0.5

### DIFF
--- a/compiler/circle-operator/CMakeLists.txt
+++ b/compiler/circle-operator/CMakeLists.txt
@@ -1,6 +1,6 @@
-if(NOT TARGET mio_circle04)
+if(NOT TARGET mio_circle05)
   return()
-endif(NOT TARGET mio_circle04)
+endif(NOT TARGET mio_circle05)
 
 set(DRIVER "driver/Driver.cpp")
 
@@ -10,8 +10,8 @@ add_executable(circle-operator ${DRIVER} ${SOURCES})
 target_include_directories(circle-operator PRIVATE src)
 target_link_libraries(circle-operator arser)
 target_link_libraries(circle-operator foder)
-target_link_libraries(circle-operator mio_circle04)
-target_link_libraries(circle-operator mio_circle04_helper)
+target_link_libraries(circle-operator mio_circle05)
+target_link_libraries(circle-operator mio_circle05_helper)
 target_link_libraries(circle-operator safemain)
 
 install(TARGETS circle-operator DESTINATION bin)

--- a/compiler/circle-operator/requires.cmake
+++ b/compiler/circle-operator/requires.cmake
@@ -1,4 +1,4 @@
 require("arser")
 require("foder")
-require("mio-circle04")
+require("mio-circle05")
 require("safemain")


### PR DESCRIPTION
This upgrades circle schema to 0.5.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/10629
Draft PR: https://github.com/Samsung/ONE/pull/10643