### PR TITLE
[circledump] Upgrade circle schema to 0.5

### DIFF
--- a/compiler/circledump/CMakeLists.txt
+++ b/compiler/circledump/CMakeLists.txt
@@ -1,7 +1,7 @@
-if(NOT TARGET mio_circle04)
-  message(STATUS "Skip circledump: mio_circle04 not found")
+if(NOT TARGET mio_circle05)
+  message(STATUS "Skip circledump: mio_circle05 not found")
   return()
-endif(NOT TARGET mio_circle04)
+endif(NOT TARGET mio_circle05)
 
 set(DRIVER "driver/Driver.cpp")
 
@@ -11,8 +11,8 @@ add_executable(circledump ${DRIVER} ${SOURCES})
 target_include_directories(circledump PRIVATE include)
 target_link_libraries(circledump arser)
 target_link_libraries(circledump foder)
-target_link_libraries(circledump mio_circle04)
-target_link_libraries(circledump mio_circle04_helper)
+target_link_libraries(circledump mio_circle05)
+target_link_libraries(circledump mio_circle05_helper)
 target_link_libraries(circledump safemain)
 
 install(TARGETS circledump DESTINATION bin)

--- a/compiler/circledump/README.md
+++ b/compiler/circledump/README.md
@@ -65,6 +65,6 @@ O T(3) ofm
 
 ### Dependency
 
-- mio-circle04
+- mio-circle05
 - safemain
 - FlatBuffers

--- a/compiler/circledump/requires.cmake
+++ b/compiler/circledump/requires.cmake
@@ -1,4 +1,4 @@
 require("arser")
 require("foder")
-require("mio-circle04")
+require("mio-circle05")
 require("safemain")


### PR DESCRIPTION
This upgrades circle schema to 0.5.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/10629
Draft PR: https://github.com/Samsung/ONE/pull/10643