### PR TITLE
[pics] Upgrade circle schema to 0.5

### DIFF
--- a/compiler/pics/CMakeLists.txt
+++ b/compiler/pics/CMakeLists.txt
@@ -11,7 +11,7 @@ unset(PICS_DEPS)
 ###
 set(CIRCLE_SCHEMA_PYTHON_DIR "${CMAKE_CURRENT_BINARY_DIR}/circle")
 
-get_target_property(SCHEMA_BIN_PATH mio_circle04 BINARY_DIR)
+get_target_property(SCHEMA_BIN_PATH mio_circle05 BINARY_DIR)
 
 add_custom_command(
   OUTPUT ${CIRCLE_SCHEMA_PYTHON_DIR}


### PR DESCRIPTION
This upgrades circle schema to 0.5.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/10629
Draft PR: https://github.com/Samsung/ONE/pull/10643