### PR TITLE
[pics] Add requires.cmake file

### DIFF
--- a/compiler/pics/requires.cmake
+++ b/compiler/pics/requires.cmake
@@ -1,0 +1,2 @@
+require("mio-circle05")
+


### PR DESCRIPTION
This adds requires cmake file.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/pull/10672#issuecomment-1512516362