### PR TITLE
[onert-micro] Add missing kernels in GenerateKernelsListHelper

### DIFF
--- a/onert-micro/helpers/GenerateKernelsListHelper.cpp
+++ b/onert-micro/helpers/GenerateKernelsListHelper.cpp
@@ -108,10 +108,14 @@ std::string get_register_kernel_str(const circle::BuiltinOperator builtin_operat
       return "REGISTER_KERNEL(PAD, Pad)";
     case circle::BuiltinOperator_PADV2:
       return "REGISTER_KERNEL(PADV2, PadV2)";
+    case circle::BuiltinOperator_PACK:
+      return "REGISTER_KERNEL(PACK, Pack)";
     case circle::BuiltinOperator_PRELU:
       return "REGISTER_KERNEL(PRELU, PRelu)";
     case circle::BuiltinOperator_QUANTIZE:
       return "REGISTER_KERNEL(QUANTIZE, Quantize)";
+    case circle::BuiltinOperator_REDUCE_PROD:
+      return "REGISTER_KERNEL(REDUCE_PROD, ReduceCommon)";
     case circle::BuiltinOperator_RESHAPE:
       return "REGISTER_KERNEL(RESHAPE, Reshape)";
     case circle::BuiltinOperator_RESIZE_BILINEAR:


### PR DESCRIPTION
This pr adds missing kernels in GenerateKernelsListHelper.

related to issue: #10651

ONE-DCO-1.0-Signed-off-by: Artem Balyshev <a.balyshev@samsung.com>