### PR TITLE
[luci-interpreter] Enable S64 shape for Reshape

### DIFF
--- a/compiler/luci-interpreter/src/kernels/Reshape.cpp
+++ b/compiler/luci-interpreter/src/kernels/Reshape.cpp
@@ -17,6 +17,8 @@
 
 #include "kernels/Reshape.h"
 
+#include "kernels/Utils.h"
+
 #include <cassert>
 #include <cstring>
 
@@ -28,12 +30,26 @@ namespace kernels
 
 static Shape extractShapeFromTensor(const Tensor *tensor)
 {
-  assert(tensor->element_type() == DataType::S32);
   Shape shape(tensor->shape().num_elements());
-  const auto *shape_data = tensor->data<int32_t>();
-  for (int i = 0; i < tensor->shape().num_elements(); ++i)
+  if (tensor->element_type() == DataType::S32)
   {
-    shape.dim(i) = shape_data[i];
+    const auto *shape_data = tensor->data<int32_t>();
+    for (int i = 0; i < tensor->shape().num_elements(); ++i)
+    {
+      shape.dim(i) = shape_data[i];
+    }
+  }
+  else if (tensor->element_type() == DataType::S64)
+  {
+    const auto *shape_data = tensor->data<int64_t>();
+    for (int i = 0; i < tensor->shape().num_elements(); ++i)
+    {
+      shape.dim(i) = static_cast<int32_t>(shape_data[i]);
+    }
+  }
+  else
+  {
+    LUCI_INTERPRETER_CHECK(false);
   }
   return shape;
 }

--- a/compiler/luci-interpreter/src/kernels/Reshape.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/Reshape.test.cpp
@@ -77,6 +77,42 @@ TEST_F(ReshapeTest, UnknownDimension)
   EXPECT_THAT(extractTensorData<float>(output_tensor), FloatArrayNear(input_data));
 }
 
+TEST_F(ReshapeTest, SupportS64)
+{
+  Shape input_shape{2, 1, 2, 3};
+  std::vector<float> input_data{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+  Shape shape_shape{3};
+  std::vector<int64_t> shape_data{2, -1, 2};
+  Tensor input_tensor =
+    makeInputTensor<DataType::FLOAT32>(input_shape, input_data, _memory_manager.get());
+  Tensor shape_tensor =
+    makeInputTensor<DataType::S64>(shape_shape, shape_data, _memory_manager.get());
+  Tensor output_tensor = makeOutputTensor(DataType::FLOAT32);
+
+  Reshape kernel(&input_tensor, &shape_tensor, &output_tensor);
+  kernel.configure();
+  _memory_manager->allocate_memory(output_tensor);
+  kernel.execute();
+
+  EXPECT_THAT(extractTensorData<float>(output_tensor), FloatArrayNear(input_data));
+}
+
+TEST_F(ReshapeTest, SupportS16_NEG)
+{
+  Shape input_shape{2, 1, 2, 3};
+  std::vector<float> input_data{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+  Shape shape_shape{3};
+  std::vector<int16_t> shape_data{2, -1, 2};
+  Tensor input_tensor =
+    makeInputTensor<DataType::FLOAT32>(input_shape, input_data, _memory_manager.get());
+  Tensor shape_tensor =
+    makeInputTensor<DataType::S16>(shape_shape, shape_data, _memory_manager.get());
+  Tensor output_tensor = makeOutputTensor(DataType::FLOAT32);
+
+  Reshape kernel(&input_tensor, &shape_tensor, &output_tensor);
+  EXPECT_ANY_THROW(kernel.configure());
+}
+
 } // namespace
 } // namespace kernels
 } // namespace luci_interpreter


### PR DESCRIPTION
This will enable S64 dtype from shape.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>