### PR TITLE
[luci/import] Reshape S64 for Reshape shape

### DIFF
--- a/compiler/luci/import/src/Nodes/CircleReshape.cpp
+++ b/compiler/luci/import/src/Nodes/CircleReshape.cpp
@@ -30,7 +30,7 @@ bool CircleReshapeGraphBuilder::validate(const ValidateArgs &args) const
   if (args.op.outputs.size() != 1)
     return false;
 
-  // for two inputs, check if type is S32
+  // for two inputs, check if type is S32 or S64
   if (args.op.inputs.size() == 2)
   {
     const auto &inputs = args.op.inputs;
@@ -38,9 +38,8 @@ bool CircleReshapeGraphBuilder::validate(const ValidateArgs &args) const
     const auto tensor_in = tensors.at(inputs.at(1));
     assert(tensor_in != nullptr);
 
-    // NOTE fix this if there is any other case
-    // TensorFlow lite and circle only supports S32
-    if (tensor_in->type() != circle::TensorType::TensorType_INT32)
+    if (tensor_in->type() != circle::TensorType::TensorType_INT32 &&
+        tensor_in->type() != circle::TensorType::TensorType_INT64)
       return false;
   }
 


### PR DESCRIPTION
This will enable to support S65 for Resape shape input.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>