### PR TITLE
[circle-mpqsolver] Introduce 'save_intermediate'

### DIFF
--- a/compiler/circle-mpqsolver/README.md
+++ b/compiler/circle-mpqsolver/README.md
@@ -40,6 +40,7 @@ Run _circle-mpqsolver_ with the following arguments.
 
 --bisection _mode_: input nodes should be at Q16 precision ['auto', 'true', 'false']
 --visq_file: .visq.json file to be used in 'auto' mode
+--save_intermediate: path to the directory where all intermediate results will be saved
 
 ```
 $ ./circle-mpqsolver
@@ -49,6 +50,7 @@ $ ./circle-mpqsolver
   --qerror_ratio <optional value for reproducing target _qerror_ default is 0.5>
   --bisection <whether input nodes should be quantized into Q16 default is 'auto'>
   --visq_file <*.visq.json file with quantization errors>
+  --save_intermediate <intermediate_results_path>
 ```
 
 For example:

--- a/compiler/circle-mpqsolver/src/CircleMPQSolver.cpp
+++ b/compiler/circle-mpqsolver/src/CircleMPQSolver.cpp
@@ -49,6 +49,7 @@ int entry(int argc, char **argv)
   LOGGER(l);
 
   const std::string bisection_str = "--bisection";
+  const std::string save_intermediate_str = "--save_intermediate";
 
   arser::Arser arser("circle-mpqsolver provides light-weight methods for finding a high-quality "
                      "mixed-precision model within a reasonable time.");
@@ -91,6 +92,11 @@ int entry(int argc, char **argv)
     .default_value("")
     .required(false)
     .help("*.visq.json file with quantization errors");
+
+  arser.add_argument(save_intermediate_str)
+    .type(arser::DataType::STR)
+    .required(false)
+    .help("path to save intermediate results");
 
   try
   {


### PR DESCRIPTION
This commit introduces 'save_intermediate parameter' and updates readme accrodingly.

Its correctness is tested in https://github.com/Samsung/ONE/pull/10655

Draft: https://github.com/Samsung/ONE/pull/10655
Related: https://github.com/Samsung/ONE/issues/10634

ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>