### PR TITLE
[DRAFT] Support multiple subgraphs in circle-opselector

### DIFF
--- a/compiler/circle-opselector/src/OpSelector.h
+++ b/compiler/circle-opselector/src/OpSelector.h
@@ -38,16 +38,18 @@ public:
 
 private:
   template <SelectType SELECT_TYPE>
-  std::vector<const luci::CircleNode *> select_by(const std::vector<std::string> &tokens);
+  std::vector<const luci::CircleNode *> select_nodes_by(const std::vector<std::string> &tokens,
+                                                        const uint32_t graph_idx);
 
 public:
-  template <SelectType SELECT_TYPE> std::unique_ptr<luci::Module> select_by(const std::string &str);
+  template <SelectType SELECT_TYPE>
+  std::unique_ptr<luci::Module> select_by(const std::vector<std::string> &inputs);
 };
 
 extern template std::unique_ptr<luci::Module>
-OpSelector::select_by<SelectType::ID>(const std::string &str);
+OpSelector::select_by<SelectType::ID>(const std::vector<std::string> &inputs);
 extern template std::unique_ptr<luci::Module>
-OpSelector::select_by<SelectType::NAME>(const std::string &str);
+OpSelector::select_by<SelectType::NAME>(const std::vector<std::string> &inputs);
 
 } // namespace opselector
 

--- a/compiler/circle-opselector/src/OpSelector.test.cpp
+++ b/compiler/circle-opselector/src/OpSelector.test.cpp
@@ -114,7 +114,8 @@ TEST(OpSelectorTest, select_by_name)
   opselector::OpSelector op_selector{m.get()};
 
   // Select conv only
-  auto conv_module = op_selector.select_by<opselector::SelectType::NAME>("conv");
+  auto conv_module =
+    op_selector.select_by<opselector::SelectType::NAME>(std::vector<std::string>{"conv"});
   ASSERT_EQ(1, conv_module->size());
 
   auto conv_graph = conv_module->graph(0);
@@ -129,7 +130,8 @@ TEST(OpSelectorTest, select_by_name)
   EXPECT_STREQ("conv_bias", conv_bias->name().c_str());
 
   // Select dconv only
-  auto dconv_module = op_selector.select_by<opselector::SelectType::NAME>("dconv");
+  auto dconv_module =
+    op_selector.select_by<opselector::SelectType::NAME>(std::vector<std::string>{"dconv"});
   ASSERT_EQ(1, dconv_module->size());
 
   auto dconv_graph = dconv_module->graph(0);
@@ -153,5 +155,6 @@ TEST(OpSelectorTest, select_by_name_NEG)
 
   opselector::OpSelector op_selector{m.get()};
 
-  EXPECT_ANY_THROW(op_selector.select_by<opselector::SelectType::NAME>(","));
+  EXPECT_ANY_THROW(
+    op_selector.select_by<opselector::SelectType::NAME>(std::vector<std::string>{","}));
 }

--- a/compiler/luci/service/src/Nodes/CircleWhile.cpp
+++ b/compiler/luci/service/src/Nodes/CircleWhile.cpp
@@ -24,7 +24,11 @@ luci::CircleNode *CloneNodeLet<CN::WXYZ>::visit(const luci::CircleWhile *node)
   auto ic = node->input_count();
   auto oc = node->output_count();
 
-  return _graph->nodes()->create<luci::CircleWhile>(ic, oc);
+  auto cloned = _graph->nodes()->create<luci::CircleWhile>(ic, oc);
+  cloned->cond_branch(node->cond_branch());
+  cloned->body_branch(node->body_branch());
+
+  return cloned;
 }
 
 } // namespace luci


### PR DESCRIPTION
This draft is to support multiple sub-graphs in circle-opselector.

Related: #9953 
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>