### PR TITLE
Add missing license statement into onert-micro

### DIFF
--- a/onert-micro/luci-interpreter/pal/cmsisnn/PALArgMax.h
+++ b/onert-micro/luci-interpreter/pal/cmsisnn/PALArgMax.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/cmsisnn/PALAveragePool2d.h
+++ b/onert-micro/luci-interpreter/pal/cmsisnn/PALAveragePool2d.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/cmsisnn/PALBatchToSpaceND.h
+++ b/onert-micro/luci-interpreter/pal/cmsisnn/PALBatchToSpaceND.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/cmsisnn/PALConv2d.h
+++ b/onert-micro/luci-interpreter/pal/cmsisnn/PALConv2d.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/cmsisnn/PALDepthToSpace.h
+++ b/onert-micro/luci-interpreter/pal/cmsisnn/PALDepthToSpace.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/cmsisnn/PALDepthwiseConv2d.h
+++ b/onert-micro/luci-interpreter/pal/cmsisnn/PALDepthwiseConv2d.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/cmsisnn/PALDequantize.h
+++ b/onert-micro/luci-interpreter/pal/cmsisnn/PALDequantize.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/cmsisnn/PALElu.h
+++ b/onert-micro/luci-interpreter/pal/cmsisnn/PALElu.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/cmsisnn/PALFill.h
+++ b/onert-micro/luci-interpreter/pal/cmsisnn/PALFill.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/cmsisnn/PALFullyConnected.h
+++ b/onert-micro/luci-interpreter/pal/cmsisnn/PALFullyConnected.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/cmsisnn/PALL2Normalize.h
+++ b/onert-micro/luci-interpreter/pal/cmsisnn/PALL2Normalize.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/cmsisnn/PALL2Pool2D.h
+++ b/onert-micro/luci-interpreter/pal/cmsisnn/PALL2Pool2D.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/cmsisnn/PALLeakyRelu.h
+++ b/onert-micro/luci-interpreter/pal/cmsisnn/PALLeakyRelu.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/cmsisnn/PALMul.h
+++ b/onert-micro/luci-interpreter/pal/cmsisnn/PALMul.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/cmsisnn/PALNeg.h
+++ b/onert-micro/luci-interpreter/pal/cmsisnn/PALNeg.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/cmsisnn/PALQuantize.h
+++ b/onert-micro/luci-interpreter/pal/cmsisnn/PALQuantize.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/cmsisnn/PALResizeBilinear.h
+++ b/onert-micro/luci-interpreter/pal/cmsisnn/PALResizeBilinear.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/cmsisnn/PALResizeNearestNeighbor.h
+++ b/onert-micro/luci-interpreter/pal/cmsisnn/PALResizeNearestNeighbor.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/cmsisnn/PALSoftmax.h
+++ b/onert-micro/luci-interpreter/pal/cmsisnn/PALSoftmax.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/cmsisnn/PALSpaceToBatchND.h
+++ b/onert-micro/luci-interpreter/pal/cmsisnn/PALSpaceToBatchND.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/cmsisnn/PALSpaceToDepth.h
+++ b/onert-micro/luci-interpreter/pal/cmsisnn/PALSpaceToDepth.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/cmsisnn/PALSub.h
+++ b/onert-micro/luci-interpreter/pal/cmsisnn/PALSub.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/linux/PALArgMax.h
+++ b/onert-micro/luci-interpreter/pal/linux/PALArgMax.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/linux/PALAveragePool2d.h
+++ b/onert-micro/luci-interpreter/pal/linux/PALAveragePool2d.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/linux/PALBatchMatMul.h
+++ b/onert-micro/luci-interpreter/pal/linux/PALBatchMatMul.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/linux/PALBatchToSpaceND.h
+++ b/onert-micro/luci-interpreter/pal/linux/PALBatchToSpaceND.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/linux/PALConv2d.h
+++ b/onert-micro/luci-interpreter/pal/linux/PALConv2d.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/linux/PALDepthToSpace.h
+++ b/onert-micro/luci-interpreter/pal/linux/PALDepthToSpace.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/linux/PALDepthwiseConv2d.h
+++ b/onert-micro/luci-interpreter/pal/linux/PALDepthwiseConv2d.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/linux/PALDequantize.h
+++ b/onert-micro/luci-interpreter/pal/linux/PALDequantize.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/linux/PALElu.h
+++ b/onert-micro/luci-interpreter/pal/linux/PALElu.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/linux/PALFill.h
+++ b/onert-micro/luci-interpreter/pal/linux/PALFill.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/linux/PALFullyConnected.h
+++ b/onert-micro/luci-interpreter/pal/linux/PALFullyConnected.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/linux/PALGather.h
+++ b/onert-micro/luci-interpreter/pal/linux/PALGather.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/linux/PALL2Normalize.h
+++ b/onert-micro/luci-interpreter/pal/linux/PALL2Normalize.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/linux/PALL2Pool2D.h
+++ b/onert-micro/luci-interpreter/pal/linux/PALL2Pool2D.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/linux/PALLeakyRelu.h
+++ b/onert-micro/luci-interpreter/pal/linux/PALLeakyRelu.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/linux/PALLocalResponseNormalization.h
+++ b/onert-micro/luci-interpreter/pal/linux/PALLocalResponseNormalization.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/linux/PALLogSoftmax.h
+++ b/onert-micro/luci-interpreter/pal/linux/PALLogSoftmax.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/linux/PALMul.h
+++ b/onert-micro/luci-interpreter/pal/linux/PALMul.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/linux/PALNeg.h
+++ b/onert-micro/luci-interpreter/pal/linux/PALNeg.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/linux/PALQuantize.h
+++ b/onert-micro/luci-interpreter/pal/linux/PALQuantize.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/linux/PALRelu.h
+++ b/onert-micro/luci-interpreter/pal/linux/PALRelu.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/linux/PALRelu6.h
+++ b/onert-micro/luci-interpreter/pal/linux/PALRelu6.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/linux/PALResizeBilinear.h
+++ b/onert-micro/luci-interpreter/pal/linux/PALResizeBilinear.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/linux/PALResizeNearestNeighbor.h
+++ b/onert-micro/luci-interpreter/pal/linux/PALResizeNearestNeighbor.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/linux/PALSVDF.h
+++ b/onert-micro/luci-interpreter/pal/linux/PALSVDF.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/linux/PALSlice.h
+++ b/onert-micro/luci-interpreter/pal/linux/PALSlice.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/linux/PALSoftmax.h
+++ b/onert-micro/luci-interpreter/pal/linux/PALSoftmax.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/linux/PALSpaceToBatchND.h
+++ b/onert-micro/luci-interpreter/pal/linux/PALSpaceToBatchND.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/linux/PALSpaceToDepth.h
+++ b/onert-micro/luci-interpreter/pal/linux/PALSpaceToDepth.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/linux/PALSplit.h
+++ b/onert-micro/luci-interpreter/pal/linux/PALSplit.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/linux/PALSub.h
+++ b/onert-micro/luci-interpreter/pal/linux/PALSub.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/mcu/PALArgMax.h
+++ b/onert-micro/luci-interpreter/pal/mcu/PALArgMax.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/mcu/PALAveragePool2d.h
+++ b/onert-micro/luci-interpreter/pal/mcu/PALAveragePool2d.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/mcu/PALBatchToSpaceND.h
+++ b/onert-micro/luci-interpreter/pal/mcu/PALBatchToSpaceND.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/mcu/PALConv2d.h
+++ b/onert-micro/luci-interpreter/pal/mcu/PALConv2d.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/mcu/PALDepthToSpace.h
+++ b/onert-micro/luci-interpreter/pal/mcu/PALDepthToSpace.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/mcu/PALDepthwiseConv2d.h
+++ b/onert-micro/luci-interpreter/pal/mcu/PALDepthwiseConv2d.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/mcu/PALDequantize.h
+++ b/onert-micro/luci-interpreter/pal/mcu/PALDequantize.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/mcu/PALElu.h
+++ b/onert-micro/luci-interpreter/pal/mcu/PALElu.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/mcu/PALFill.h
+++ b/onert-micro/luci-interpreter/pal/mcu/PALFill.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/mcu/PALFullyConnected.h
+++ b/onert-micro/luci-interpreter/pal/mcu/PALFullyConnected.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/mcu/PALL2Normalize.h
+++ b/onert-micro/luci-interpreter/pal/mcu/PALL2Normalize.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/mcu/PALL2Pool2D.h
+++ b/onert-micro/luci-interpreter/pal/mcu/PALL2Pool2D.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/mcu/PALLeakyRelu.h
+++ b/onert-micro/luci-interpreter/pal/mcu/PALLeakyRelu.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/mcu/PALMul.h
+++ b/onert-micro/luci-interpreter/pal/mcu/PALMul.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/mcu/PALNeg.h
+++ b/onert-micro/luci-interpreter/pal/mcu/PALNeg.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/mcu/PALQuantize.h
+++ b/onert-micro/luci-interpreter/pal/mcu/PALQuantize.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/mcu/PALResizeBilinear.h
+++ b/onert-micro/luci-interpreter/pal/mcu/PALResizeBilinear.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/mcu/PALResizeNearestNeighbor.h
+++ b/onert-micro/luci-interpreter/pal/mcu/PALResizeNearestNeighbor.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/mcu/PALSoftmax.h
+++ b/onert-micro/luci-interpreter/pal/mcu/PALSoftmax.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/mcu/PALSpaceToBatchND.h
+++ b/onert-micro/luci-interpreter/pal/mcu/PALSpaceToBatchND.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/mcu/PALSpaceToDepth.h
+++ b/onert-micro/luci-interpreter/pal/mcu/PALSpaceToDepth.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/pal/mcu/PALSub.h
+++ b/onert-micro/luci-interpreter/pal/mcu/PALSub.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Add.h
+++ b/onert-micro/luci-interpreter/src/kernels/Add.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/ArgMax.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/ArgMax.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/ArgMax.h
+++ b/onert-micro/luci-interpreter/src/kernels/ArgMax.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/ArgMax.test.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/ArgMax.test.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/AveragePool2D.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/AveragePool2D.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/AveragePool2D.h
+++ b/onert-micro/luci-interpreter/src/kernels/AveragePool2D.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/AveragePool2D.test.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/AveragePool2D.test.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/BatchMatMul.h
+++ b/onert-micro/luci-interpreter/src/kernels/BatchMatMul.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/BatchMatMul.test.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/BatchMatMul.test.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/BatchToSpaceND.h
+++ b/onert-micro/luci-interpreter/src/kernels/BatchToSpaceND.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/BatchToSpaceND.test.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/BatchToSpaceND.test.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Builders.h
+++ b/onert-micro/luci-interpreter/src/kernels/Builders.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/CMakeLists.txt
+++ b/onert-micro/luci-interpreter/src/kernels/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(SOURCES
         BinaryOpCommon.h
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
         Utils.h
         Utils.cpp
         Builders.h

--- a/onert-micro/luci-interpreter/src/kernels/Cast.h
+++ b/onert-micro/luci-interpreter/src/kernels/Cast.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Cast.test.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/Cast.test.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Concatenation.test.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/Concatenation.test.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Conv2D.test.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/Conv2D.test.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/DepthToSpace.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/DepthToSpace.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/DepthToSpace.h
+++ b/onert-micro/luci-interpreter/src/kernels/DepthToSpace.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/DepthToSpace.test.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/DepthToSpace.test.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/DepthwiseConv2D.h
+++ b/onert-micro/luci-interpreter/src/kernels/DepthwiseConv2D.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/DepthwiseConv2D.test.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/DepthwiseConv2D.test.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Dequantize.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/Dequantize.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Dequantize.h
+++ b/onert-micro/luci-interpreter/src/kernels/Dequantize.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Div.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/Div.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Div.h
+++ b/onert-micro/luci-interpreter/src/kernels/Div.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Elu.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/Elu.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Elu.h
+++ b/onert-micro/luci-interpreter/src/kernels/Elu.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Elu.test.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/Elu.test.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Equal.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/Equal.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Equal.h
+++ b/onert-micro/luci-interpreter/src/kernels/Equal.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Exp.h
+++ b/onert-micro/luci-interpreter/src/kernels/Exp.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/ExpandDims.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/ExpandDims.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Fill.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/Fill.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Fill.h
+++ b/onert-micro/luci-interpreter/src/kernels/Fill.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Fill.test.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/Fill.test.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Floor.h
+++ b/onert-micro/luci-interpreter/src/kernels/Floor.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Floor.test.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/Floor.test.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/FloorDiv.h
+++ b/onert-micro/luci-interpreter/src/kernels/FloorDiv.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/FullyConnected.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/FullyConnected.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/FullyConnected.test.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/FullyConnected.test.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Gather.h
+++ b/onert-micro/luci-interpreter/src/kernels/Gather.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Gather.test.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/Gather.test.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Greater.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/Greater.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Greater.h
+++ b/onert-micro/luci-interpreter/src/kernels/Greater.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/GreaterEqual.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/GreaterEqual.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/GreaterEqual.h
+++ b/onert-micro/luci-interpreter/src/kernels/GreaterEqual.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/If.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/If.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/If.h
+++ b/onert-micro/luci-interpreter/src/kernels/If.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/InstanceNorm.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/InstanceNorm.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/InstanceNorm.h
+++ b/onert-micro/luci-interpreter/src/kernels/InstanceNorm.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/InstanceNorm.test.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/InstanceNorm.test.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/KernelBuilder.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/KernelBuilder.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/KernelBuilder.h
+++ b/onert-micro/luci-interpreter/src/kernels/KernelBuilder.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/L2Normalize.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/L2Normalize.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/L2Normalize.h
+++ b/onert-micro/luci-interpreter/src/kernels/L2Normalize.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/L2Pool2D.h
+++ b/onert-micro/luci-interpreter/src/kernels/L2Pool2D.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/LeakyRelu.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/LeakyRelu.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/LeakyRelu.h
+++ b/onert-micro/luci-interpreter/src/kernels/LeakyRelu.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/LeakyRelu.test.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/LeakyRelu.test.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Less.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/Less.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Less.h
+++ b/onert-micro/luci-interpreter/src/kernels/Less.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/LessEqual.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/LessEqual.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/LessEqual.h
+++ b/onert-micro/luci-interpreter/src/kernels/LessEqual.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/LocalResponseNormalization.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/LocalResponseNormalization.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/LocalResponseNormalization.h
+++ b/onert-micro/luci-interpreter/src/kernels/LocalResponseNormalization.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/LogSoftmax.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/LogSoftmax.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/LogSoftmax.h
+++ b/onert-micro/luci-interpreter/src/kernels/LogSoftmax.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/LogicalAnd.h
+++ b/onert-micro/luci-interpreter/src/kernels/LogicalAnd.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/LogicalNot.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/LogicalNot.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/LogicalNot.h
+++ b/onert-micro/luci-interpreter/src/kernels/LogicalNot.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Logistic.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/Logistic.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Logistic.test.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/Logistic.test.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/MaxPool2D.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/MaxPool2D.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/MaxPool2D.test.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/MaxPool2D.test.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Maximum.h
+++ b/onert-micro/luci-interpreter/src/kernels/Maximum.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Mean.h
+++ b/onert-micro/luci-interpreter/src/kernels/Mean.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Minimum.h
+++ b/onert-micro/luci-interpreter/src/kernels/Minimum.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/MirrorPad.h
+++ b/onert-micro/luci-interpreter/src/kernels/MirrorPad.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/MirrorPad.test.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/MirrorPad.test.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Mul.h
+++ b/onert-micro/luci-interpreter/src/kernels/Mul.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Neg.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/Neg.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Neg.h
+++ b/onert-micro/luci-interpreter/src/kernels/Neg.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/NotEqual.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/NotEqual.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/NotEqual.h
+++ b/onert-micro/luci-interpreter/src/kernels/NotEqual.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/OneHot.h
+++ b/onert-micro/luci-interpreter/src/kernels/OneHot.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/OneHot.test.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/OneHot.test.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/PRelu.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/PRelu.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/PRelu.h
+++ b/onert-micro/luci-interpreter/src/kernels/PRelu.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Pack.h
+++ b/onert-micro/luci-interpreter/src/kernels/Pack.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Pack.test.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/Pack.test.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Pad.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/Pad.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Pad.h
+++ b/onert-micro/luci-interpreter/src/kernels/Pad.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Pad.test.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/Pad.test.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/PadV2.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/PadV2.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/PadV2.h
+++ b/onert-micro/luci-interpreter/src/kernels/PadV2.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/PadV2.test.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/PadV2.test.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Pow.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/Pow.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Pow.h
+++ b/onert-micro/luci-interpreter/src/kernels/Pow.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Pow.test.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/Pow.test.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Quantize.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/Quantize.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Quantize.h
+++ b/onert-micro/luci-interpreter/src/kernels/Quantize.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Relu.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/Relu.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Relu.h
+++ b/onert-micro/luci-interpreter/src/kernels/Relu.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Relu6.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/Relu6.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Relu6.h
+++ b/onert-micro/luci-interpreter/src/kernels/Relu6.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Reshape.test.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/Reshape.test.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/ResizeBilinear.h
+++ b/onert-micro/luci-interpreter/src/kernels/ResizeBilinear.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/ResizeNearestNeighbor.h
+++ b/onert-micro/luci-interpreter/src/kernels/ResizeNearestNeighbor.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/ReverseV2.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/ReverseV2.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/ReverseV2.h
+++ b/onert-micro/luci-interpreter/src/kernels/ReverseV2.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Rsqrt.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/Rsqrt.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Rsqrt.h
+++ b/onert-micro/luci-interpreter/src/kernels/Rsqrt.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Rsqrt.test.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/Rsqrt.test.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/SVDF.h
+++ b/onert-micro/luci-interpreter/src/kernels/SVDF.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/SVDF.test.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/SVDF.test.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Shape.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/Shape.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Shape.h
+++ b/onert-micro/luci-interpreter/src/kernels/Shape.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Shape.test.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/Shape.test.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Slice.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/Slice.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Slice.h
+++ b/onert-micro/luci-interpreter/src/kernels/Slice.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Slice.test.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/Slice.test.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Softmax.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/Softmax.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Softmax.test.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/Softmax.test.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/SpaceToBatchND.h
+++ b/onert-micro/luci-interpreter/src/kernels/SpaceToBatchND.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/SpaceToBatchND.test.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/SpaceToBatchND.test.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/SpaceToDepth.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/SpaceToDepth.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/SpaceToDepth.h
+++ b/onert-micro/luci-interpreter/src/kernels/SpaceToDepth.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/SpaceToDepth.test.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/SpaceToDepth.test.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Split.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/Split.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Split.h
+++ b/onert-micro/luci-interpreter/src/kernels/Split.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/SplitV.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/SplitV.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/SplitV.h
+++ b/onert-micro/luci-interpreter/src/kernels/SplitV.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Sqrt.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/Sqrt.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Sqrt.h
+++ b/onert-micro/luci-interpreter/src/kernels/Sqrt.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Sqrt.test.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/Sqrt.test.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Square.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/Square.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Square.h
+++ b/onert-micro/luci-interpreter/src/kernels/Square.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/SquaredDifference.h
+++ b/onert-micro/luci-interpreter/src/kernels/SquaredDifference.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Squeeze.test.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/Squeeze.test.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/StridedSlice.h
+++ b/onert-micro/luci-interpreter/src/kernels/StridedSlice.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/StridedSlice.test.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/StridedSlice.test.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Sub.h
+++ b/onert-micro/luci-interpreter/src/kernels/Sub.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Tanh.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/Tanh.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Tanh.h
+++ b/onert-micro/luci-interpreter/src/kernels/Tanh.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Transpose.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/Transpose.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Transpose.h
+++ b/onert-micro/luci-interpreter/src/kernels/Transpose.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Transpose.test.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/Transpose.test.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/TransposeConv.h
+++ b/onert-micro/luci-interpreter/src/kernels/TransposeConv.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/TransposeConv.test.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/TransposeConv.test.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/UnidirectionalSequenceLSTM.h
+++ b/onert-micro/luci-interpreter/src/kernels/UnidirectionalSequenceLSTM.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Unpack.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/Unpack.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/Unpack.h
+++ b/onert-micro/luci-interpreter/src/kernels/Unpack.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/onert-micro/luci-interpreter/src/kernels/While.h
+++ b/onert-micro/luci-interpreter/src/kernels/While.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
- TensorFlow's license statement is missing in a lot for files
- To remedy this, the statement added into the most files

ONE-DCO-1.0-Signed-off-by: Chunseok Lee <chunseok.lee@samsung.com>