### PR TITLE
[circle-mpqsolver] Implement DumpingHooks

### DIFF
--- a/compiler/circle-mpqsolver/src/core/DumpingHooks.cpp
+++ b/compiler/circle-mpqsolver/src/core/DumpingHooks.cpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "DumpingHooks.h"
+
+using namespace mpqsolver::core;
+
+DumpingHooks::DumpingHooks(const std::string &save_path)
+  : _save_path(save_path), _dumper(_save_path)
+{
+}
+
+void DumpingHooks::on_begin_solver(const std::string &model_path, float q8error, float q16error)
+{
+  _model_path = model_path;
+  _dumper.set_model_path(_model_path);
+  _dumper.prepare_for_error_dumping();
+  _dumper.dump_Q8_error(q8error);
+  _dumper.dump_Q16_error(q16error);
+}
+
+void DumpingHooks::on_begin_iteration()
+{
+  _in_iterations = true;
+  _num_of_iterations += 1;
+}
+
+void DumpingHooks::on_end_iteration(const LayerParams &layers, const std::string &def_type,
+                                    float error) const
+{
+  _dumper.dump_MPQ_configuration(layers, def_type, _num_of_iterations);
+  _dumper.dump_MPQ_error(error, _num_of_iterations);
+}
+
+void DumpingHooks::on_end_solver(const LayerParams &layers, const std::string &def_dtype)
+{
+  _dumper.dump_final_MPQ(layers, def_dtype);
+  _in_iterations = false;
+}
+
+void DumpingHooks::on_quantized(luci::Module *module) const
+{
+  if (_in_iterations)
+  {
+    _dumper.dump_quantized(module, _num_of_iterations);
+  }
+}

--- a/compiler/circle-mpqsolver/src/core/DumpingHooks.h
+++ b/compiler/circle-mpqsolver/src/core/DumpingHooks.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __MPQSOLVER_DUMPING_HOOKS_H__
+#define __MPQSOLVER_DUMPING_HOOKS_H__
+
+#include <luci/IR/Module.h>
+
+#include <core/Quantizer.h>
+#include <core/SolverHooks.h>
+#include <core/Dumper.h>
+
+#include <string>
+
+namespace mpqsolver
+{
+namespace core
+{
+
+/**
+ * @brief DumpingHooks is intended to save intermediate results
+ */
+class DumpingHooks final : public QuantizerHook, public SolverHooks
+{
+public:
+  /**
+   * @brief DumpingHooks constructor
+   * @param save_path directory where all intermediate data will be saved
+   */
+  DumpingHooks(const std::string &save_path);
+
+  /**
+   * @brief called on successfull quantization
+   */
+  virtual void on_quantized(luci::Module *module) const override;
+
+  /**
+   * @brief called on the start of iterative search
+   */
+  virtual void on_begin_solver(const std::string &model_path, float q8error,
+                               float q16error) override;
+
+  /**
+   * @brief called on the start of current iteration
+   */
+  virtual void on_begin_iteration() override;
+
+  /**
+   * @brief called at the end of current iteration
+   */
+  virtual void on_end_iteration(const LayerParams &layers, const std::string &def_dtype,
+                                float error) const override;
+
+  /**
+   * @brief called at the end of iterative search
+   */
+  virtual void on_end_solver(const LayerParams &layers, const std::string &def_dtype) override;
+
+protected:
+  std::string _model_path;
+  std::string _save_path;
+  Dumper _dumper;
+  uint32_t _num_of_iterations = 0;
+  bool _in_iterations = false;
+};
+
+} // namespace core
+} // namespace mpqsolver
+
+#endif //__MPQSOLVER_DUMPING_HOOKS_H__


### PR DESCRIPTION
This commit implements DumpingHooks for saving intermediate results.

Its correctness is tested in https://github.com/Samsung/ONE/pull/10655

Draft: https://github.com/Samsung/ONE/pull/10655
Related: https://github.com/Samsung/ONE/issues/10634

ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>