### PR TITLE
[circle-mpqsolver] Implement 'set_save_intermediate'

### DIFF
--- a/compiler/circle-mpqsolver/src/MPQSolver.cpp
+++ b/compiler/circle-mpqsolver/src/MPQSolver.cpp
@@ -24,3 +24,15 @@ MPQSolver::MPQSolver(const std::string &input_data_path, float qerror_ratio,
     _input_quantization(input_quantization), _output_quantization(output_quantization)
 {
 }
+
+void MPQSolver::set_save_intermediate(bool save, const std::string &save_path)
+{
+  if (save)
+  {
+    _hooks = std::make_unique<core::DumpingHooks>(save_path);
+  }
+  else
+  {
+    _hooks.reset(nullptr);
+  }
+}

--- a/compiler/circle-mpqsolver/src/MPQSolver.cpp
+++ b/compiler/circle-mpqsolver/src/MPQSolver.cpp
@@ -25,14 +25,7 @@ MPQSolver::MPQSolver(const std::string &input_data_path, float qerror_ratio,
 {
 }
 
-void MPQSolver::set_save_intermediate(bool save, const std::string &save_path)
+void MPQSolver::set_save_intermediate(const std::string &save_path)
 {
-  if (save)
-  {
-    _hooks = std::make_unique<core::DumpingHooks>(save_path);
-  }
-  else
-  {
-    _hooks.reset(nullptr);
-  }
+  _hooks = std::make_unique<core::DumpingHooks>(save_path);
 }

--- a/compiler/circle-mpqsolver/src/MPQSolver.h
+++ b/compiler/circle-mpqsolver/src/MPQSolver.h
@@ -17,7 +17,7 @@
 #ifndef __MPQSOLVER_MPQSOLEVR_SOLVER_H__
 #define __MPQSOLVER_MPQSOLEVR_SOLVER_H__
 
-#include <luci/IR/Module.h>
+#include <core/DumpingHooks.h>
 
 #include <memory>
 #include <string>
@@ -42,11 +42,17 @@ public:
    */
   virtual std::unique_ptr<luci::Module> run(const std::string &module_path) = 0;
 
+  /**
+   * @brief whether all intermediate artifacts should be saved
+   */
+  void set_save_intermediate(bool save, const std::string &save_path);
+
 protected:
   std::string _input_data_path;
   std::string _input_quantization;
   std::string _output_quantization;
   float _qerror_ratio = 0.f; // quantization error ratio
+  std::unique_ptr<core::DumpingHooks> _hooks;
 };
 
 } // namespace mpqsolver

--- a/compiler/circle-mpqsolver/src/MPQSolver.h
+++ b/compiler/circle-mpqsolver/src/MPQSolver.h
@@ -43,9 +43,9 @@ public:
   virtual std::unique_ptr<luci::Module> run(const std::string &module_path) = 0;
 
   /**
-   * @brief whether all intermediate artifacts should be saved
+   * @brief set all intermediate artifacts to be saved
    */
-  void set_save_intermediate(bool save, const std::string &save_path);
+  void set_save_intermediate(const std::string &save_path);
 
 protected:
   std::string _input_data_path;


### PR DESCRIPTION
This commit implements 'set_save_intermediate' for the AMPQ task.

Its correctness is tested in https://github.com/Samsung/ONE/pull/10655

Draft: https://github.com/Samsung/ONE/pull/10655
Related: https://github.com/Samsung/ONE/issues/10634

ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>