### PR TITLE
[tfldump] Support GeLU Op

### DIFF
--- a/compiler/tfldump/src/OpPrinter.cpp
+++ b/compiler/tfldump/src/OpPrinter.cpp
@@ -359,6 +359,19 @@ public:
   }
 };
 
+class GeluPrinter : public OpPrinter
+{
+public:
+  void options(const tflite::Operator *op, std::ostream &os) const override
+  {
+    if (auto *params = op->builtin_options_as_GeluOptions())
+    {
+      os << "    ";
+      os << "approximate(" << params->approximate() << ") ";
+    }
+  }
+};
+
 class IfPrinter : public OpPrinter
 {
 public:
@@ -746,6 +759,7 @@ OpPrinterRegistry::OpPrinterRegistry()
   // There is no Option for FLOOR_MOD
   _op_map[tflite::BuiltinOperator_FULLY_CONNECTED] = make_unique<FullyConnectedPrinter>();
   _op_map[tflite::BuiltinOperator_GATHER] = make_unique<GatherPrinter>();
+  _op_map[tflite::BuiltinOperator_GELU] = make_unique<GeluPrinter>();
   _op_map[tflite::BuiltinOperator_IF] = make_unique<IfPrinter>();
   _op_map[tflite::BuiltinOperator_L2_POOL_2D] = make_unique<Pool2DPrinter>();
   _op_map[tflite::BuiltinOperator_L2_NORMALIZATION] = make_unique<L2NormPrinter>();


### PR DESCRIPTION
This supports GeLU Op printer.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/10692
Draft PR: https://github.com/Samsung/ONE/pull/10737