### PR TITLE
[luci] Enable FuseGelu algorithm

### DIFF
--- a/compiler/luci/pass/include/luci/CircleOptimizer.h
+++ b/compiler/luci/pass/include/luci/CircleOptimizer.h
@@ -63,6 +63,7 @@ public:
       MakeBatchNormGammaPositive,
       FuseActivationFunction,
       FusePRelu,
+      FuseGelu,
       ShuffleWeightTo16x1Float32,
       RemoveRedundantTranspose,
       ReplaceMulAddWithDepthwiseConv,

--- a/compiler/luci/pass/src/CircleOptimizer.cpp
+++ b/compiler/luci/pass/src/CircleOptimizer.cpp
@@ -39,6 +39,7 @@
 #include "luci/Pass/FuseMeanWithMeanPass.h"
 #include "luci/Pass/FusePreActivationBatchNormPass.h"
 #include "luci/Pass/FusePReluPass.h"
+#include "luci/Pass/FuseGeluPass.h"
 #include "luci/Pass/FuseTransposeWithMeanPass.h"
 #include "luci/Pass/MakeBatchNormGammaPositivePass.h"
 #include "luci/Pass/RemoveDuplicateConstPass.h"
@@ -282,6 +283,10 @@ void CircleOptimizer::optimize(loco::Graph *g) const
   if (_options->query(Options::Algorithm::FusePRelu))
   {
     phase.emplace_back(std::make_unique<FusePReluPass>());
+  }
+  if (_options->query(Options::Algorithm::FuseGelu))
+  {
+    phase.emplace_back(std::make_unique<FuseGeluPass>());
   }
   if (_options->query(Options::Algorithm::FuseTransposeWithMean))
   {


### PR DESCRIPTION
This enables FuseGelu algorithm in luci.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/10692
Draft PR: https://github.com/Samsung/ONE/pull/10748