### PR TITLE
[circle2circle] Add fuse_gelu option

### DIFF
--- a/compiler/circle2circle/src/Circle2Circle.cpp
+++ b/compiler/circle2circle/src/Circle2Circle.cpp
@@ -111,6 +111,7 @@ int entry(int argc, char **argv)
   add_switch(arser, "--fuse_preactivation_batchnorm",
              "This will fuse BatchNorm operators of pre-activations to Convolution operator");
   add_switch(arser, "--fuse_prelu", "This will fuse operators to PReLU operator");
+  add_switch(arser, "--fuse_gelu", "This will fuse operators to GeLU operator");
   add_switch(arser, "--remove_duplicate_const", "This will remove all duplicate constant nodes");
   add_switch(arser, "--remove_fakequant", "This will remove FakeQuant operators");
   add_switch(arser, "--remove_quantdequant", "This will remove Quantize-Dequantize sequence");
@@ -257,6 +258,8 @@ int entry(int argc, char **argv)
     options->enable(Algorithms::FusePreActivationBatchNorm);
   if (arser.get<bool>("--fuse_prelu"))
     options->enable(Algorithms::FusePRelu);
+  if (arser.get<bool>("--fuse_gelu"))
+    options->enable(Algorithms::FuseGelu);
   if (arser.get<bool>("--fuse_transpose_with_mean"))
     options->enable(Algorithms::FuseTransposeWithMean);
   if (arser.get<bool>("--remove_duplicate_const"))


### PR DESCRIPTION
This adds fuse_gelu optimization option.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/10692
Draft PR: https://github.com/Samsung/ONE/pull/10748