### PR TITLE
[luci] Support mixed-precision quantization of Gelu

### DIFF
--- a/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
+++ b/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
@@ -271,6 +271,7 @@ private:
   INSERT_QUANTIZE_TO_UNARY_OP(luci::CircleFloor, x)
   INSERT_QUANTIZE_TO_UNARY_OP(luci::CircleFullyConnected, input)
   INSERT_QUANTIZE_TO_UNARY_OP(luci::CircleGather, params)
+  INSERT_QUANTIZE_TO_UNARY_OP(luci::CircleGelu, features)
   INSERT_QUANTIZE_TO_UNARY_OP(luci::CircleInstanceNorm, input)
   INSERT_QUANTIZE_TO_UNARY_OP(luci::CircleLeakyRelu, features)
   INSERT_QUANTIZE_TO_UNARY_OP(luci::CircleLocalResponseNormalization, input)


### PR DESCRIPTION
This supports mixed-precision quantization of Gelu.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/10692