### PR TITLE
[circle-mpqsolver] Implement 'save_intermediate' option

### DIFF
--- a/compiler/circle-mpqsolver/src/CircleMPQSolver.cpp
+++ b/compiler/circle-mpqsolver/src/CircleMPQSolver.cpp
@@ -169,6 +169,15 @@ int entry(int argc, char **argv)
       }
     }
 
+    if (arser[save_intermediate_str])
+    {
+      auto data_path = arser.get<std::string>(save_intermediate_str);
+      if (!data_path.empty())
+      {
+        solver.set_save_intermediate(data_path);
+      }
+    }
+
     VERBOSE(l, 0) << "qerror metric: MSE" << std::endl
                   << "target qerror ratio: " << qerror_ratio << std::endl;
 


### PR DESCRIPTION
This commit implements 'save_intermediate' option at entry level.

Its correctness is tested in https://github.com/Samsung/ONE/pull/10655

Draft: https://github.com/Samsung/ONE/pull/10655
Related: https://github.com/Samsung/ONE/issues/10634

ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>