### PR TITLE
[onecc-docker] Change the release name of one-compiler in docker file

### DIFF
--- a/compiler/onecc-docker/docker/Dockerfile
+++ b/compiler/onecc-docker/docker/Dockerfile
@@ -19,8 +19,8 @@ ARG VERSION
 RUN apt-get update && apt-get install -qqy --no-install-recommends \ 
     wget \
     ca-certificates \ 
-    && wget https://github.com/Samsung/ONE/releases/download/${VERSION}/one-compiler_${VERSION}_amd64.deb \ 
-    && apt-get install -y ./one-compiler_${VERSION}_amd64.deb \ 
+    && wget https://github.com/Samsung/ONE/releases/download/${VERSION}/one-compiler-bionic_${VERSION}_amd64.deb \ 
+    && apt-get install -y ./one-compiler-bionic_${VERSION}_amd64.deb \ 
     && rm -rf /var/lib/apt/lists/* 
  
 ENTRYPOINT ["onecc"]


### PR DESCRIPTION
This commit changes the release name of one-compiler in docker file. 
The name will be changed to match the url of one-compiler release name asset.

ONE-DCO-1.0.-Signed-off-by: Seunghui Lee <shsh1004.lee@samsung.com>

Related Issue : [#10773]