### PR TITLE
[onecc-docker] Add no-check-certificate option

### DIFF
--- a/compiler/onecc-docker/docker/Dockerfile
+++ b/compiler/onecc-docker/docker/Dockerfile
@@ -19,7 +19,7 @@ ARG VERSION
 RUN apt-get update && apt-get install -qqy --no-install-recommends \ 
     wget \
     ca-certificates \ 
-    && wget https://github.com/Samsung/ONE/releases/download/${VERSION}/one-compiler-bionic_${VERSION}_amd64.deb \ 
+    && wget --no-check-certificate https://github.com/Samsung/ONE/releases/download/${VERSION}/one-compiler-bionic_${VERSION}_amd64.deb \ 
     && apt-get install -y ./one-compiler-bionic_${VERSION}_amd64.deb \ 
     && rm -rf /var/lib/apt/lists/* 
  


### PR DESCRIPTION
This commit uses `--no-check-certificate` option when it downloads one-compiler package from GitHub Release page.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>