### PR TITLE
Ignore missing ARM Compiler

### DIFF
--- a/onert-micro/CMakeLists.txt
+++ b/onert-micro/CMakeLists.txt
@@ -7,7 +7,6 @@ find_program(ARM_C_COMPILER_PATH ${ARM_C_COMPILER})
 
 if (NOT ARM_C_COMPILER_PATH)
     message(STATUS "Build luci-micro: FALSE(ARM compiler is NOT FOUND)")
-    return()
 endif ()
 
 if (NOT_BUILD_EXTERNALS)


### PR DESCRIPTION
- Do not exit with missing arm compiler for x64 configure

ONE-DCO-1.0-Signed-off-by: Chunseok Lee <chunseok.lee@samsung.com>