### PR TITLE
[one-cmds] Introduce dummy-onnx-ext

### DIFF
--- a/compiler/one-cmds/dummy-driver/CMakeLists.txt
+++ b/compiler/one-cmds/dummy-driver/CMakeLists.txt
@@ -8,6 +8,7 @@ set(HELP_INFER_SRC src/help-infer.cpp)
 set(DUMMY_PROFILE_SRC src/dummy-profile.cpp)
 set(HELP_PROFILE_SRC src/help-profile.cpp)
 set(DUMMY_ENV_SRC src/dummyEnv-compile.cpp)
+set(DUMMY_ONNX_EXT src/dummy-onnx-ext.cpp)
 
 add_executable(dummy-compile ${DUMMY_DRIVER_SRC})
 add_executable(dummyV2-compile ${DUMMY_V2_DRIVER_SRC})
@@ -18,6 +19,7 @@ add_executable(help-infer ${HELP_INFER_SRC})
 add_executable(dummy-profile ${DUMMY_PROFILE_SRC})
 add_executable(help-profile ${HELP_PROFILE_SRC})
 add_executable(dummyEnv-compile ${DUMMY_ENV_SRC})
+add_executable(dummy-onnx-ext ${DUMMY_ONNX_EXT})
 
 set(DUMMY_DRIVER "${CMAKE_CURRENT_BINARY_DIR}/dummy-compile")
 set(DUMMY_V2_DRIVER "${CMAKE_CURRENT_BINARY_DIR}/dummyV2-compile")
@@ -28,6 +30,7 @@ set(HELP_INFER "${CMAKE_CURRENT_BINARY_DIR}/help-infer")
 set(DUMMY_PROFILE "${CMAKE_CURRENT_BINARY_DIR}/dummy-profile")
 set(HELP_PROFILE "${CMAKE_CURRENT_BINARY_DIR}/help-profile")
 set(DUMMY_ENV "${CMAKE_CURRENT_BINARY_DIR}/dummyEnv-compile")
+set(DUMMY_ONNX_EXT "${CMAKE_CURRENT_BINARY_DIR}/dummy-onnx-ext")
 
 install(FILES ${DUMMY_DRIVER}
         PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE
@@ -78,6 +81,12 @@ install(FILES ${HELP_PROFILE}
         DESTINATION test)
 
 install(FILES ${DUMMY_ENV}
+        PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE
+                    GROUP_READ GROUP_EXECUTE
+                    WORLD_READ WORLD_EXECUTE
+        DESTINATION test)
+
+install(FILES ${DUMMY_ONNX_EXT}
         PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE
                     GROUP_READ GROUP_EXECUTE
                     WORLD_READ WORLD_EXECUTE

--- a/compiler/one-cmds/dummy-driver/src/dummy-onnx-ext.cpp
+++ b/compiler/one-cmds/dummy-driver/src/dummy-onnx-ext.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * dummy-onnx-ext only tests its interface rather than its functionality.
+ *
+ * ./dummy-onnx-ext [options]
+ * one-import-onnx-ext dummy output!!!
+ */
+
+#include <iostream>
+#include <fstream>
+#include <string>
+
+int main(int argc, char **argv)
+{
+  (void)argc;
+  (void)argv;
+
+  std::cout << "one-import-onnx-ext dummy output!!!" << std::endl;
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
This will introduce dummy-onnx-ext for testing one-import-onnx extension.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>