### PR TITLE
[infra] Use one-version

### DIFF
--- a/infra/scripts/docker_build_nncc.sh
+++ b/infra/scripts/docker_build_nncc.sh
@@ -67,7 +67,7 @@ tar -zcf ${ARCHIVE_PATH}/nncc-test-package.tar.gz -C ${NNCC_INSTALL_PREFIX} ./te
 
 if [ -z ${RELEASE_VERSION} ] || [ ${RELEASE_VERSION} == "nightly" ]; then
   ./nncc docker-run /bin/bash -c \
-	  'dch -v $($(pwd)/tools/release_tool/onert_version.sh)~$(date "+%y%m%d%H") "nightly release" -D $(lsb_release --short --codename)'
+	  'dch -v $(${PWD}/${NNCC_INSTALL_PREFIX}/bin/one-version)~$(date "+%y%m%d%H") "nightly release" -D $(lsb_release --short --codename)'
   ./nncc docker-run dch -r ''
 fi
 


### PR DESCRIPTION
This commit revisits docker_build_nncc script to use one-version.

Related: #10853 
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>