### PR TITLE
[one-cmds] Profile multiple backends with a single cfg file

### DIFF
--- a/compiler/one-cmds/dummy-driver/CMakeLists.txt
+++ b/compiler/one-cmds/dummy-driver/CMakeLists.txt
@@ -6,6 +6,7 @@ set(DUMMY_INFER_SRC src/dummy-infer.cpp)
 set(DUMMY_INFER_V2_SRC src/dummy-inferV2.cpp)
 set(HELP_INFER_SRC src/help-infer.cpp)
 set(DUMMY_PROFILE_SRC src/dummy-profile.cpp)
+set(DUMMY_V2_PROFILE_SRC src/dummyV2-profile.cpp)
 set(HELP_PROFILE_SRC src/help-profile.cpp)
 set(DUMMY_ENV_SRC src/dummyEnv-compile.cpp)
 set(DUMMY_ONNX_EXT src/dummy-onnx-ext.cpp)
@@ -17,6 +18,7 @@ add_executable(dummy-infer ${DUMMY_INFER_SRC})
 add_executable(dummy-inferV2 ${DUMMY_INFER_V2_SRC})
 add_executable(help-infer ${HELP_INFER_SRC})
 add_executable(dummy-profile ${DUMMY_PROFILE_SRC})
+add_executable(dummyV2-profile ${DUMMY_V2_PROFILE_SRC})
 add_executable(help-profile ${HELP_PROFILE_SRC})
 add_executable(dummyEnv-compile ${DUMMY_ENV_SRC})
 add_executable(dummy-onnx-ext ${DUMMY_ONNX_EXT})
@@ -28,6 +30,7 @@ set(DUMMY_INFER "${CMAKE_CURRENT_BINARY_DIR}/dummy-infer")
 set(DUMMY_INFER_V2 "${CMAKE_CURRENT_BINARY_DIR}/dummy-inferV2")
 set(HELP_INFER "${CMAKE_CURRENT_BINARY_DIR}/help-infer")
 set(DUMMY_PROFILE "${CMAKE_CURRENT_BINARY_DIR}/dummy-profile")
+set(DUMMY_V2_PROFILE "${CMAKE_CURRENT_BINARY_DIR}/dummyV2-profile")
 set(HELP_PROFILE "${CMAKE_CURRENT_BINARY_DIR}/help-profile")
 set(DUMMY_ENV "${CMAKE_CURRENT_BINARY_DIR}/dummyEnv-compile")
 set(DUMMY_ONNX_EXT "${CMAKE_CURRENT_BINARY_DIR}/dummy-onnx-ext")
@@ -69,6 +72,12 @@ install(FILES ${HELP_INFER}
         DESTINATION test)
 
 install(FILES ${DUMMY_PROFILE}
+        PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE
+                    GROUP_READ GROUP_EXECUTE
+                    WORLD_READ WORLD_EXECUTE
+        DESTINATION test)
+
+install(FILES ${DUMMY_V2_PROFILE}
         PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE
                     GROUP_READ GROUP_EXECUTE
                     WORLD_READ WORLD_EXECUTE

--- a/compiler/one-cmds/dummy-driver/src/dummyV2-profile.cpp
+++ b/compiler/one-cmds/dummy-driver/src/dummyV2-profile.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * dummyV2-profile only tests its interface rather than its functionality.
+ *
+ * ./dummyV2-profile ${INPUT_NAME}
+ * dummyV2-profile dummy output!!!
+ */
+
+#include <iostream>
+#include <fstream>
+#include <string>
+
+int main(int argc, char **argv)
+{
+  if (argc != 2)
+    return EXIT_FAILURE;
+
+  std::cout << "dummyV2-profile dummy output!!!" << std::endl;
+
+  return EXIT_SUCCESS;
+}

--- a/compiler/one-cmds/one-profile
+++ b/compiler/one-cmds/one-profile
@@ -26,6 +26,7 @@ import itertools
 import ntpath
 import os
 import sys
+from types import SimpleNamespace
 
 import onelib.utils as oneutils
 
@@ -92,14 +93,36 @@ def _get_parser(backends_list):
     return parser
 
 
-def _verify_arg(parser, args):
+def _verify_arg(parser, args, cfg_args):
     """verify given arguments"""
+    cmd_backend_exist = oneutils.is_valid_attr(args, 'backend')
+    cfg_backend_exist = oneutils.is_valid_attr(cfg_args, 'backend')
+    cfg_backends_exist = oneutils.is_valid_attr(cfg_args, 'backends')
+    if cfg_backend_exist and cfg_backends_exist:
+        parser.error(
+            '\'backend\' option and \'backends\' option cannot be used simultaneously.')
+    # Check if given backend from command line exists in the configuration file
+    if cmd_backend_exist and cfg_backend_exist:
+        if args.backend != cfg_args.backend:
+            parser.error('Not found the command of given backend')
+
     # check if required arguments is given
     missing = []
-    if not oneutils.is_valid_attr(args, 'backend'):
+    if not cmd_backend_exist and not cfg_backend_exist and not cfg_backends_exist:
         missing.append('-b/--backend')
     if len(missing):
         parser.error('the following arguments are required: ' + ' '.join(missing))
+
+    if cfg_backends_exist:
+        cfg_backends = getattr(cfg_args, 'backends').split(',')
+        # check if commands of given backends exist
+        for b in cfg_backends:
+            if not oneutils.is_valid_attr(cfg_args, b):
+                parser.error('Not found the command for ' + b)
+        # Check if given backend from command line exists in the configuration file
+        if cmd_backend_exist:
+            if args.backend not in cfg_backends:
+                parser.error('Not found the command of given backend')
 
 
 def _parse_arg(parser):
@@ -139,25 +162,61 @@ def main():
     args, backend_args, unknown_args = _parse_arg(parser)
 
     # parse configuration file
-    oneutils.parse_cfg(args.config, 'one-profile', args)
+    cfg_args = SimpleNamespace()
+    oneutils.parse_cfg(args.config, 'one-profile', cfg_args)
 
     # verify arguments
-    _verify_arg(parser, args)
+    _verify_arg(parser, args, cfg_args)
+    '''
+    one-profile defines its behavior for below cases.
 
-    # make a command to run given backend driver
-    profile_path = None
-    backend_base = getattr(args, 'backend') + '-profile'
-    for cand in backends_list:
-        if ntpath.basename(cand) == backend_base:
-            profile_path = cand
-    if not profile_path:
-        raise FileNotFoundError(backend_base + ' not found')
-    profile_cmd = [profile_path] + backend_args + unknown_args
-    if oneutils.is_valid_attr(args, 'command'):
-        profile_cmd += getattr(args, 'command').split()
+    [1] one-profile -h
+    [2] one-profile -v
+    [3] one-profile -C ${cfg} (backend, command key in cfg)
+    [4] one-profile -C ${cfg} (backends key in cfg)
+    [5] one-profile -b ${backend} ${command}
+    [6] one-profile -b ${backend} -- ${command}
+    [7] one-profile -b ${backend} -C {cfg} (backend, command key in cfg)
+    [8] one-profile -b ${backend} -C {cfg} (backends key in cfg) (Only 'backend' is invoked, 
+         even though cfg file has multiple backends)
 
-    # run backend driver
-    oneutils.run(profile_cmd, err_prefix=backend_base)
+    All other cases are not allowed or an undefined behavior.
+    '''
+    if oneutils.is_valid_attr(args, 'config'):
+        assert (not backend_args or not unknown_args)
+        # [7], [8]
+        if oneutils.is_valid_attr(args, 'backend'):
+            given_backends = [args.backend]
+            if oneutils.is_valid_attr(cfg_args, 'backend'):
+                assert (oneutils.is_valid_attr(cfg_args, 'command'))
+                setattr(cfg_args, args.backend, cfg_args.command)
+        else:
+            # [3]
+            if oneutils.is_valid_attr(cfg_args, 'backend'):
+                assert (oneutils.is_valid_attr(cfg_args, 'command'))
+                given_backends = [cfg_args.backend]
+                setattr(cfg_args, cfg_args.backend, cfg_args.command)
+            # [4]
+            if oneutils.is_valid_attr(cfg_args, 'backends'):
+                given_backends = cfg_args.backends.split(',')
+    # [5], [6]
+    else:
+        assert (backend_args or unknown_args)
+        given_backends = [args.backend]
+    for given_backend in given_backends:
+        # make a command to run given backend driver
+        profile_path = None
+        backend_base = given_backend + '-profile'
+        for cand in backends_list:
+            if ntpath.basename(cand) == backend_base:
+                profile_path = cand
+        if not profile_path:
+            raise FileNotFoundError(backend_base + ' not found')
+        profile_cmd = [profile_path] + backend_args + unknown_args
+        if oneutils.is_valid_attr(cfg_args, given_backend):
+            profile_cmd += getattr(cfg_args, given_backend).split()
+        # run backend driver
+        oneutils.run(profile_cmd, err_prefix=backend_base)
 
 
 if __name__ == '__main__':

--- a/compiler/one-cmds/onecc
+++ b/compiler/one-cmds/onecc
@@ -115,38 +115,46 @@ def _parse_arg(parser):
     return args
 
 
-def _verify_codegen(parser, args):
+def _verify_backend_args(parser, args):
     """
-    verify one-codegen arguments
+    verify one-profile, one-codegen arguments
 
-    This verification logic comes from 'one-codegen' codes.
+    This verification logic comes from each drivers' codes.
     """
-    cfg_args = SimpleNamespace()
-    oneutils.parse_cfg(args.config, 'one-codegen', cfg_args)
-    cmd_backend_exist = oneutils.is_valid_attr(args, 'backend')
-    cfg_backend_exist = oneutils.is_valid_attr(cfg_args, 'backend')
-    cfg_backends_exist = oneutils.is_valid_attr(cfg_args, 'backends')
+    cfgparser = configparser.ConfigParser()
+    cfgparser.optionxform = str
+    cfgparser.read(args.config)
 
-    if cfg_backend_exist and cfg_backends_exist:
-        parser.error(
-            "'backend' option and 'backends' option cannot be used simultaneously.")
+    for driver in ['one-profile', 'one-codegen']:
+        if not driver in cfgparser:
+            continue
 
-    # Check if given backend from command line exists in the configuration file
-    if cmd_backend_exist and cfg_backend_exist:
-        if args.backend != cfg_args.backend:
-            parser.error('Not found the command of given backend')
+        cfg_args = SimpleNamespace()
+        oneutils.parse_cfg(args.config, driver, cfg_args)
+        cmd_backend_exist = oneutils.is_valid_attr(args, 'backend')
+        cfg_backend_exist = oneutils.is_valid_attr(cfg_args, 'backend')
+        cfg_backends_exist = oneutils.is_valid_attr(cfg_args, 'backends')
 
-    if cfg_backends_exist:
-        cfg_backends = getattr(cfg_args, 'backends').split(',')
-        # check if commands of given backends exist
-        for b in cfg_backends:
-            if not oneutils.is_valid_attr(cfg_args, b):
-                parser.error('Not found the command for ' + b)
+        if cfg_backend_exist and cfg_backends_exist:
+            parser.error(
+                "'backend' option and 'backends' option cannot be used simultaneously.")
 
         # Check if given backend from command line exists in the configuration file
-        if cmd_backend_exist:
-            if args.backend not in cfg_backends:
+        if cmd_backend_exist and cfg_backend_exist:
+            if args.backend != cfg_args.backend:
                 parser.error('Not found the command of given backend')
+
+        if cfg_backends_exist:
+            cfg_backends = getattr(cfg_args, 'backends').split(',')
+            # check if commands of given backends exist
+            for b in cfg_backends:
+                if not oneutils.is_valid_attr(cfg_args, b):
+                    parser.error('Not found the command for ' + b)
+
+            # Check if given backend from command line exists in the configuration file
+            if cmd_backend_exist:
+                if args.backend not in cfg_backends:
+                    parser.error('Not found the command of given backend')
 
 
 def _verify_arg(parser, args):
@@ -169,7 +177,7 @@ def _verify_arg(parser, args):
         parser.error('\'backend\' option can be used only with \'config\' option')
 
     if oneutils.is_valid_attr(args, 'backend'):
-        _verify_codegen(parser, args)
+        _verify_backend_args(parser, args)
 
 
 def main():

--- a/compiler/one-cmds/onelib/CfgRunner.py
+++ b/compiler/one-cmds/onelib/CfgRunner.py
@@ -114,7 +114,7 @@ class CfgRunner:
                 options += ['-O', self.opt]
             if verbose:
                 options.append('--verbose')
-            if section == 'one-codegen' and self.backend:
+            if (section == 'one-codegen' or section == 'one-profile') and self.backend:
                 options += ['-b', self.backend]
             driver_path = os.path.join(working_dir, section)
             cmd = [driver_path] + options

--- a/compiler/one-cmds/tests/onecc_049.cfg
+++ b/compiler/one-cmds/tests/onecc_049.cfg
@@ -1,0 +1,7 @@
+[onecc]
+one-profile=True
+
+[one-profile]
+backends=dummy,dummyV2
+dummy=dummy.bin
+dummyV2=dummyV2.bin

--- a/compiler/one-cmds/tests/onecc_049.test
+++ b/compiler/one-cmds/tests/onecc_049.test
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# 'backends' key in one-profile section
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  echo "${filename_ext} FAILED"
+  rm -rf ../bin/dummy-profile
+  rm -rf ../bin/dummyV2-profile
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+configfile="onecc_049.cfg"
+
+rm -f ${filename}.log
+
+# copy dummy tools to bin folder
+cp dummy-profile ../bin/dummy-profile
+cp dummyV2-profile ../bin/dummyV2-profile
+
+# run test
+onecc -C ${configfile} > ${filename}.log 2>&1
+
+if ! grep -q "dummy-profile dummy output!!!" "${filename}.log"; then
+  trap_err_onexit
+fi
+
+if ! grep -q "dummyV2-profile dummy output!!!" "${filename}.log"; then
+  trap_err_onexit
+fi
+
+rm -rf ../bin/dummy-profile
+rm -rf ../bin/dummyV2-profile
+
+echo "${filename_ext} SUCCESS"

--- a/compiler/one-cmds/tests/onecc_050.cfg
+++ b/compiler/one-cmds/tests/onecc_050.cfg
@@ -1,0 +1,7 @@
+[onecc]
+one-profile=True
+
+[one-profile]
+backends=dummy,dummyV2
+dummy=dummy.bin
+dummyV2=dummyV2.bin

--- a/compiler/one-cmds/tests/onecc_050.test
+++ b/compiler/one-cmds/tests/onecc_050.test
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# 'backends' key in configuration file but run one-profile for only one backend
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  echo "${filename_ext} FAILED"
+  rm -rf ../bin/dummy-profile
+  rm -rf ../bin/dummyV2-profile
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+configfile="onecc_050.cfg"
+
+rm -f ${filename}.log
+
+# copy dummy tools to bin folder
+cp dummy-profile ../bin/dummy-profile
+cp dummyV2-profile ../bin/dummyV2-profile
+
+# run test
+onecc -C ${configfile} -b dummyV2 > ${filename}.log 2>&1
+
+if grep -q "dummy-profile dummy output!!!" "${filename}.log"; then
+  trap_err_onexit
+fi
+
+if ! grep -q "dummyV2-profile dummy output!!!" "${filename}.log"; then
+  trap_err_onexit
+fi
+
+rm -rf ../bin/dummy-profile
+rm -rf ../bin/dummyV2-profile
+
+echo "${filename_ext} SUCCESS"

--- a/compiler/one-cmds/tests/onecc_051.cfg
+++ b/compiler/one-cmds/tests/onecc_051.cfg
@@ -1,0 +1,6 @@
+[onecc]
+one-profile=True
+
+[one-profile]
+backend=dummyV2
+command=dummyV2.bin

--- a/compiler/one-cmds/tests/onecc_051.test
+++ b/compiler/one-cmds/tests/onecc_051.test
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# 'backend' option from command line with 'backend' key in configuration file
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  echo "${filename_ext} FAILED"
+  rm -rf ../bin/dummy-profile
+  rm -rf ../bin/dummyV2-profile
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+configfile="onecc_051.cfg"
+
+rm -f ${filename}.log
+
+# copy dummy tools to bin folder
+cp dummyV2-profile ../bin/dummyV2-profile
+
+# run test
+onecc -C ${configfile} -b dummyV2 > ${filename}.log 2>&1
+
+if ! grep -q "dummyV2-profile dummy output!!!" "${filename}.log"; then
+  trap_err_onexit
+fi
+
+rm -rf ../bin/dummyV2-profile
+
+echo "${filename_ext} SUCCESS"

--- a/compiler/one-cmds/tests/onecc_052.cfg
+++ b/compiler/one-cmds/tests/onecc_052.cfg
@@ -1,0 +1,13 @@
+[onecc]
+one-codegen=True
+one-profile=True
+
+[one-codegen]
+backends=dummy,dummyV2
+dummy=-o onecc_052.tvn inception_v3.onecc_052.circle
+dummyV2=-O onecc_052.2.tvn inception_v3.onecc_052.2.circle
+
+[one-profile]
+backends=dummy,dummyV2
+dummy=dummy.bin
+dummyV2=dummyV2.bin

--- a/compiler/one-cmds/tests/onecc_052.test
+++ b/compiler/one-cmds/tests/onecc_052.test
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+# Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# 'backends' key with one-profile and one-codgen section
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  echo "${filename_ext} FAILED"
+  rm -rf ../bin/dummy-profile
+  rm -rf ../bin/dummyV2-profile
+  rm -rf ../bin/dummy-compile
+  rm -rf ../bin/dummyV2-compile
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+configfile="onecc_052.cfg"
+outputfile="onecc_052.tvn"
+outputfile2="onecc_052.2.tvn"
+
+rm -f ${filename}.log
+rm -rf ${outputfile}
+rm -rf ${outputfile2}
+
+# copy dummy tools to bin folder
+cp dummy-profile ../bin/dummy-profile
+cp dummyV2-profile ../bin/dummyV2-profile
+cp dummy-compile ../bin/dummy-compile
+cp dummyV2-compile ../bin/dummyV2-compile
+
+# run test
+onecc -C ${configfile} > ${filename}.log 2>&1
+
+if ! grep -q "dummy-profile dummy output!!!" "${filename}.log"; then
+  trap_err_onexit
+fi
+
+if ! grep -q "dummyV2-profile dummy output!!!" "${filename}.log"; then
+  trap_err_onexit
+fi
+
+if [[ ! -s "${outputfile}" ]]; then
+  echo "ERROR: Not found ${outputfile}" >> ${filename}.log
+  trap_err_onexit
+fi
+
+if [[ ! -s "${outputfile2}" ]]; then
+echo "ERROR: Not found ${outputfile2}" >> ${filename}.log
+  trap_err_onexit
+fi
+
+rm -rf ../bin/dummy-profile
+rm -rf ../bin/dummyV2-profile
+rm -rf ../bin/dummy-compile
+rm -rf ../bin/dummyV2-compile
+
+echo "${filename_ext} SUCCESS"

--- a/compiler/one-cmds/tests/onecc_053.cfg
+++ b/compiler/one-cmds/tests/onecc_053.cfg
@@ -1,0 +1,13 @@
+[onecc]
+one-codegen=True
+one-profile=True
+
+[one-codegen]
+backends=dummy,dummyV2
+dummy=-o onecc_053.tvn inception_v3.onecc_053.circle
+dummyV2=-O onecc_053.2.tvn inception_v3.onecc_053.2.circle
+
+[one-profile]
+backends=dummy,dummyV2
+dummy=dummy.bin
+dummyV2=dummyV2.bin

--- a/compiler/one-cmds/tests/onecc_053.test
+++ b/compiler/one-cmds/tests/onecc_053.test
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+# Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# 'backend' option with one-profile and one-codgen section
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  echo "${filename_ext} FAILED"
+  rm -rf ../bin/dummy-profile
+  rm -rf ../bin/dummyV2-profile
+  rm -rf ../bin/dummy-compile
+  rm -rf ../bin/dummyV2-compile
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+configfile="onecc_053.cfg"
+outputfile="onecc_053.tvn"
+outputfile2="onecc_053.2.tvn"
+
+rm -f ${filename}.log
+rm -rf ${outputfile}
+rm -rf ${outputfile2}
+
+# copy dummy tools to bin folder
+cp dummy-profile ../bin/dummy-profile
+cp dummyV2-profile ../bin/dummyV2-profile
+cp dummy-compile ../bin/dummy-compile
+cp dummyV2-compile ../bin/dummyV2-compile
+
+# run test
+onecc -C ${configfile} -b dummyV2 > ${filename}.log 2>&1
+
+if grep -q "dummy-profile dummy output!!!" "${filename}.log"; then
+  trap_err_onexit
+fi
+
+if ! grep -q "dummyV2-profile dummy output!!!" "${filename}.log"; then
+  trap_err_onexit
+fi
+
+if [[ -s "${outputfile}" ]]; then
+  echo "ERROR: Found ${outputfile}" >> ${filename}.log
+  trap_err_onexit
+fi
+
+if [[ ! -s "${outputfile2}" ]]; then
+echo "ERROR: Not found ${outputfile2}" >> ${filename}.log
+  trap_err_onexit
+fi
+
+rm -rf ../bin/dummy-profile
+rm -rf ../bin/dummyV2-profile
+rm -rf ../bin/dummy-compile
+rm -rf ../bin/dummyV2-compile
+
+echo "${filename_ext} SUCCESS"

--- a/compiler/one-cmds/tests/onecc_neg_032.cfg
+++ b/compiler/one-cmds/tests/onecc_neg_032.cfg
@@ -1,0 +1,7 @@
+[onecc]
+one-profile=True
+
+[one-profile]
+backends=dummy,dummyV2
+dummy=dummy.bin
+# dummyV2=dummyV2.bin

--- a/compiler/one-cmds/tests/onecc_neg_032.test
+++ b/compiler/one-cmds/tests/onecc_neg_032.test
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# not found the command for given backend
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  if grep -q "Not found the command for dummyV2" "${filename}.log"; then
+    echo "${filename_ext} SUCCESS"
+    exit 0
+  fi
+
+  echo "${filename_ext} FAILED"
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+configfile="onecc_neg_032.cfg"
+
+rm -f ${filename}.log
+
+# run test
+onecc -C ${configfile} > ${filename}.log 2>&1
+
+echo "${filename_ext} FAILED"
+exit 255

--- a/compiler/one-cmds/tests/onecc_neg_033.cfg
+++ b/compiler/one-cmds/tests/onecc_neg_033.cfg
@@ -1,0 +1,9 @@
+[onecc]
+one-profile=True
+
+[one-profile]
+backend=dummyV3
+command=dummyV3.bin
+backends=dummy,dummyV2
+dummy=dummy.bin
+dummyV2=dummyB2.bin

--- a/compiler/one-cmds/tests/onecc_neg_033.test
+++ b/compiler/one-cmds/tests/onecc_neg_033.test
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# use 'backend' and 'backends' option simultaneously
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  if grep -q "option cannot be used simultaneously" "${filename}.log"; then
+    echo "${filename_ext} SUCCESS"
+    exit 0
+  fi
+
+  echo "${filename_ext} FAILED"
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+configfile="onecc_neg_033.cfg"
+
+rm -f ${filename}.log
+
+# run test
+onecc -C ${configfile} > ${filename}.log 2>&1
+
+echo "${filename_ext} FAILED"
+exit 255

--- a/compiler/one-cmds/tests/onecc_neg_034.cfg
+++ b/compiler/one-cmds/tests/onecc_neg_034.cfg
@@ -1,0 +1,6 @@
+[onecc]
+one-profile=True
+
+[one-profile]
+backend=dummy
+command=dummy.bin

--- a/compiler/one-cmds/tests/onecc_neg_034.test
+++ b/compiler/one-cmds/tests/onecc_neg_034.test
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# not found the command of given backend
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  if grep -q "Not found the command of given backend" "${filename}.log"; then
+    echo "${filename_ext} SUCCESS"
+    exit 0
+  fi
+
+  echo "${filename_ext} FAILED"
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+configfile="onecc_neg_034.cfg"
+
+rm -f ${filename}.log
+
+# run test
+onecc -C ${configfile} --backend dummyV2 > ${filename}.log 2>&1
+
+echo "${filename_ext} FAILED"
+exit 255

--- a/compiler/one-cmds/tests/onecc_neg_035.cfg
+++ b/compiler/one-cmds/tests/onecc_neg_035.cfg
@@ -1,0 +1,6 @@
+[onecc]
+one-profile=True
+
+[one-profile]
+backends=dummyV2
+dummyV2=dummyV2.bin

--- a/compiler/one-cmds/tests/onecc_neg_035.test
+++ b/compiler/one-cmds/tests/onecc_neg_035.test
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# not found the command of given backend
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  if grep -q "Not found the command of given backend" "${filename}.log"; then
+    echo "${filename_ext} SUCCESS"
+    exit 0
+  fi
+
+  echo "${filename_ext} FAILED"
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+configfile="onecc_neg_035.cfg"
+
+rm -f ${filename}.log
+
+# run test
+onecc -C ${configfile} --backend dummy > ${filename}.log 2>&1
+
+echo "${filename_ext} FAILED"
+exit 255

--- a/compiler/one-cmds/tests/onecc_neg_036.test
+++ b/compiler/one-cmds/tests/onecc_neg_036.test
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# use 'backend' option with 'workflow' option
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  if grep -q "'backend' option can be used only with 'config' option" "${filename}.log"; then
+    echo "${filename_ext} SUCCESS"
+    exit 0
+  fi
+
+  echo "${filename_ext} FAILED"
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+workflowfile="onecc_neg_036.workflow.json"
+
+rm -f ${filename}.log
+
+# run test
+onecc -W ${workflowfile} --backend dummy > ${filename}.log 2>&1
+
+echo "${filename_ext} FAILED"
+exit 255

--- a/compiler/one-cmds/tests/onecc_neg_036.workflow.json
+++ b/compiler/one-cmds/tests/onecc_neg_036.workflow.json
@@ -1,0 +1,29 @@
+{
+    "workflows": [
+        "profile_wf"
+    ],
+    "profile_wf": {
+        "steps": [
+            "import_tf",
+            "profile"
+        ],
+        "import_tf": {
+            "one-cmd": "one-import-tf",
+            "commands": {
+                "input_path": "inception_v3.pb",
+                "output_path": "inception_v3.onecc_neg_036.circle",
+                "input_arrays": "input",
+                "input_shapes": "1,299,299,3",
+                "output_arrays": "InceptionV3/Predictions/Reshape_1",
+                "converter_version": "v2"
+            }
+        },
+        "profile": {
+            "one-cmd": "one-profile",
+            "commands": {
+                "backend": "dummy",
+                "command": "dummy.bin"
+            }
+        }
+    }
+}


### PR DESCRIPTION
This commit supports multiple backends with a single cfg file on profiling.

Related: #10848 
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>