### PR TITLE
[onert] Introduce ITrainableOperation

### DIFF
--- a/runtime/onert/core/include/ir/Operation.h
+++ b/runtime/onert/core/include/ir/Operation.h
@@ -31,7 +31,21 @@ namespace ir
 
 struct OperationVisitor;
 
-class Operation
+struct IOperation
+{
+  virtual ~IOperation() = default;
+
+  virtual void accept(OperationVisitor &v) const = 0;
+  virtual std::string name() const { return std::string{toString(opcode())}; }
+  virtual OpCode opcode() const = 0;
+
+  virtual void replaceInputs(const OperandIndex &from, const OperandIndex &to) = 0;
+  virtual void replaceOutputs(const OperandIndex &from, const OperandIndex &to) = 0;
+  virtual const OperandIndexSequence &getInputs() const = 0;
+  virtual const OperandIndexSequence &getOutputs() const = 0;
+};
+
+class Operation : public IOperation
 {
 public:
   // TODO Remove default parameter
@@ -49,16 +63,11 @@ public:
   virtual ~Operation();
 
 public:
-  virtual void accept(OperationVisitor &v) const = 0;
-  virtual std::string name() const { return std::string{toString(opcode())}; }
-  virtual OpCode opcode() const = 0;
-
-public:
-  void replaceInputs(const OperandIndex &from, const OperandIndex &to);
-  void replaceOutputs(const OperandIndex &from, const OperandIndex &to);
+  void replaceInputs(const OperandIndex &from, const OperandIndex &to) override;
+  void replaceOutputs(const OperandIndex &from, const OperandIndex &to) override;
   OperandIndexSequence &getInputs() { return _inputs; }
-  const OperandIndexSequence &getInputs() const { return _inputs; }
-  const OperandIndexSequence &getOutputs() const { return _outputs; }
+  const OperandIndexSequence &getInputs() const override { return _inputs; }
+  const OperandIndexSequence &getOutputs() const override { return _outputs; }
   // It's for only input/output tensors but const data.
   void setInputs(const OperandIndexSequence &indexes);
   void setOutputs(const OperandIndexSequence &indexes);

--- a/runtime/onert/core/include/ir/train/ITrainableOperation.h
+++ b/runtime/onert/core/include/ir/train/ITrainableOperation.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_IR_TRAIN_ITRAINABLE_OPERATION_H__
+#define __ONERT_IR_TRAIN_ITRAINABLE_OPERATION_H__
+
+#include "ir/Operation.h"
+
+namespace onert
+{
+namespace ir
+{
+
+struct OperationVisitor;
+
+namespace train
+{
+
+struct TrainableOperationVisitor;
+
+class ITrainableOperation : public IOperation
+{
+public:
+  virtual ~ITrainableOperation() = default;
+
+public:
+  virtual std::unique_ptr<ITrainableOperation> clone(Operation &) const = 0;
+  virtual void accept(OperationVisitor &v) const override = 0;
+  virtual void accept(TrainableOperationVisitor &v) const = 0;
+  // TODO Add virtual methods related to training
+
+public:
+  void replaceInputs(const OperandIndex &from, const OperandIndex &to) override
+  {
+    operation().replaceInputs(from, to);
+  }
+  void replaceOutputs(const OperandIndex &from, const OperandIndex &to) override
+  {
+    operation().replaceOutputs(from, to);
+  }
+  const OperandIndexSequence &getInputs() const override { return operation().getInputs(); }
+  const OperandIndexSequence &getOutputs() const override { return operation().getOutputs(); }
+
+public:
+  virtual const Operation &operation() const = 0;
+
+protected:
+  virtual Operation &operation() = 0;
+};
+
+} // namespace train
+} // namespace ir
+} // namespace onert
+
+#endif // __ONERT_IR_TRAIN_ITRAINABLE_OPERATION_H__

--- a/runtime/onert/core/include/ir/train/TrainableOperations.h
+++ b/runtime/onert/core/include/ir/train/TrainableOperations.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_IR_TRAIN_TRAINABLE_OPERATIONS_H__
+#define __ONERT_IR_TRAIN_TRAINABLE_OPERATIONS_H__
+
+#include "ir/Index.h"
+#include "ir/train/ITrainableOperation.h"
+#include "util/ObjectManager.h"
+
+namespace onert
+{
+namespace ir
+{
+namespace train
+{
+
+class TrainableOperations : public util::ObjectManager<OperationIndex, ITrainableOperation>
+{
+public:
+  TrainableOperations() = default;
+  TrainableOperations(const TrainableOperations &obj);
+  TrainableOperations(TrainableOperations &&) = default;
+  TrainableOperations &operator=(const TrainableOperations &) = delete;
+  TrainableOperations &operator=(TrainableOperations &&) = default;
+  ~TrainableOperations() = default;
+};
+
+} // namespace train
+} // namespace ir
+} // namespace onert
+
+#endif // __ONERT_IR_TRAIN_TRAINABLE_OPERATIONS_H__


### PR DESCRIPTION
This commit introduces ITrainableOperation that can contain training-related operation information.
  - Introduce IOperation
  - Introduce ITrainableOperation
  - Introduce TrainableOperations

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>