### PR TITLE
[one-cmds] Fix input path for one-import-onnx-ext

### DIFF
--- a/compiler/one-cmds/one-import-onnx
+++ b/compiler/one-cmds/one-import-onnx
@@ -230,6 +230,12 @@ def _convert(args):
                 onnx.save(onnx_model, fixed_path)
 
         if ext_path:
+            # save onnx_model to temporary alt file
+            basename = os.path.basename(getattr(args, 'input_path'))
+            alt_path = os.path.join(tmpdir, os.path.splitext(basename)[0] + '-alt.onnx')
+            onnx.save(onnx_model, alt_path)
+
+            # call extension with options
             ext_cmd = [ext_path]
             if oneutils.is_valid_attr(args, 'unroll_rnn'):
                 ext_cmd.append('--unroll_rnn')
@@ -241,7 +247,7 @@ def _convert(args):
                 ext_cmd.append('--save_intermediate')
             if oneutils.is_valid_attr(args, 'keep_io_order'):
                 ext_cmd.append('--keep_io_order')
-            ext_cmd.append(getattr(args, 'input_path'))
+            ext_cmd.append(alt_path)
             ext_cmd.append(getattr(args, 'output_path'))
             oneutils.run(ext_cmd, logfile=f)
             return


### PR DESCRIPTION
This will fix input model path for calling one-import-onnx-ext.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>