### PR TITLE
[luci/pass] Show node name for unknown node

### DIFF
--- a/compiler/luci/pass/src/QuantizeActivation.cpp
+++ b/compiler/luci/pass/src/QuantizeActivation.cpp
@@ -171,7 +171,10 @@ void QuantizeConstInputActivation::visit(luci::CircleNode *node)
     auto input_node = node->arg(i);
     auto const_node = dynamic_cast<luci::CircleConst *>(input_node);
     if (const_node != nullptr)
-      throw std::runtime_error("Unsupported Op for const inputs");
+    {
+      std::string msg = "Unsupported Op for const inputs: " + node->name();
+      throw std::runtime_error(msg);
+    }
   }
 }
 


### PR DESCRIPTION
This will revise runtime_error message to show node name for better debugging.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>