### PR TITLE
[onert] Separate IOperation from the Operation header

### DIFF
--- a/runtime/onert/core/include/backend/IConfig.h
+++ b/runtime/onert/core/include/backend/IConfig.h
@@ -18,7 +18,7 @@
 #define __ONERT_BACKEND_ICONFIG_H__
 
 #include "ir/Layout.h"
-#include "ir/Operation.h"
+#include "ir/IOperation.h"
 #include "util/ITimer.h"
 
 #include <memory>

--- a/runtime/onert/core/include/backend/basic/DynamicTensorManager.h
+++ b/runtime/onert/core/include/backend/basic/DynamicTensorManager.h
@@ -21,8 +21,10 @@
 #include "TensorRegistry.h"
 
 #include <ir/OperandInfo.h>
-#include <ir/Operation.h>
+#include <ir/IOperation.h>
 #include <ir/Index.h>
+
+#include <unordered_set>
 
 namespace onert
 {

--- a/runtime/onert/core/include/compiler/CodeMap.h
+++ b/runtime/onert/core/include/compiler/CodeMap.h
@@ -19,7 +19,7 @@
 
 #include <unordered_map>
 #include "ir/Index.h"
-#include "ir/Operation.h"
+#include "ir/IOperation.h"
 #include "exec/FunctionSequence.h"
 #include "OperationLowerInfo.h"
 

--- a/runtime/onert/core/include/ir/IOperation.h
+++ b/runtime/onert/core/include/ir/IOperation.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_IR_IOPERATION_H__
+#define __ONERT_IR_IOPERATION_H__
+
+#include <memory>
+
+#include "ir/Index.h"
+#include "ir/OpCode.h"
+#include "ir/OperandIndexSequence.h"
+
+namespace onert
+{
+namespace ir
+{
+
+struct OperationVisitor;
+
+struct IOperation
+{
+  virtual ~IOperation() = default;
+
+  virtual void accept(OperationVisitor &v) const = 0;
+  virtual std::string name() const { return std::string{toString(opcode())}; }
+  virtual OpCode opcode() const = 0;
+
+  virtual void replaceInputs(const OperandIndex &from, const OperandIndex &to) = 0;
+  virtual void replaceOutputs(const OperandIndex &from, const OperandIndex &to) = 0;
+  virtual const OperandIndexSequence &getInputs() const = 0;
+  virtual const OperandIndexSequence &getOutputs() const = 0;
+};
+
+} // namespace ir
+} // namespace onert
+
+#endif // __ONERT_IR_IOPERATION_H__

--- a/runtime/onert/core/include/ir/Operation.h
+++ b/runtime/onert/core/include/ir/Operation.h
@@ -19,31 +19,14 @@
 
 #include <memory>
 
-#include "ir/OpCode.h"
+#include "ir/IOperation.h"
 #include "ir/Operand.h"
-#include "ir/OperandIndexSequence.h"
 #include "ir/OperandConstraint.h"
 
 namespace onert
 {
 namespace ir
 {
-
-struct OperationVisitor;
-
-struct IOperation
-{
-  virtual ~IOperation() = default;
-
-  virtual void accept(OperationVisitor &v) const = 0;
-  virtual std::string name() const { return std::string{toString(opcode())}; }
-  virtual OpCode opcode() const = 0;
-
-  virtual void replaceInputs(const OperandIndex &from, const OperandIndex &to) = 0;
-  virtual void replaceOutputs(const OperandIndex &from, const OperandIndex &to) = 0;
-  virtual const OperandIndexSequence &getInputs() const = 0;
-  virtual const OperandIndexSequence &getOutputs() const = 0;
-};
 
 class Operation : public IOperation
 {

--- a/runtime/onert/core/include/ir/Operations.h
+++ b/runtime/onert/core/include/ir/Operations.h
@@ -18,7 +18,7 @@
 #define __ONERT_IR_OPERATIONS_H__
 
 #include "ir/Index.h"
-#include "ir/Operation.h"
+#include "ir/IOperation.h"
 #include "util/ObjectManager.h"
 
 namespace onert

--- a/runtime/onert/core/include/ir/train/ITrainableOperation.h
+++ b/runtime/onert/core/include/ir/train/ITrainableOperation.h
@@ -17,15 +17,12 @@
 #ifndef __ONERT_IR_TRAIN_ITRAINABLE_OPERATION_H__
 #define __ONERT_IR_TRAIN_ITRAINABLE_OPERATION_H__
 
-#include "ir/Operation.h"
+#include "ir/IOperation.h"
 
 namespace onert
 {
 namespace ir
 {
-
-struct OperationVisitor;
-
 namespace train
 {
 

--- a/runtime/onert/core/src/backend/BackendContext.cc
+++ b/runtime/onert/core/src/backend/BackendContext.cc
@@ -16,8 +16,6 @@
 
 #include "backend/BackendContext.h"
 
-#include "ir/Operation.h"
-
 namespace onert
 {
 namespace backend

--- a/runtime/onert/core/src/compiler/pass/OperationPass.cc
+++ b/runtime/onert/core/src/compiler/pass/OperationPass.cc
@@ -17,7 +17,7 @@
 #include "OperationPass.h"
 
 #include "ir/Index.h"
-#include "ir/Operation.h"
+#include "ir/IOperation.h"
 #include "ir/Graph.h"
 
 namespace onert

--- a/runtime/onert/core/src/dumper/dot/OperationNode.h
+++ b/runtime/onert/core/src/dumper/dot/OperationNode.h
@@ -25,7 +25,7 @@
 #define __ONERT_DUMPER_DOT_DOT_NODE_INFO_H__
 
 #include "Node.h"
-#include "ir/Operation.h"
+#include "ir/IOperation.h"
 #include "ir/Index.h"
 
 namespace onert

--- a/runtime/onert/core/src/exec/ExecutionObservers.h
+++ b/runtime/onert/core/src/exec/ExecutionObservers.h
@@ -24,7 +24,7 @@
 
 #include "exec/IExecutor.h"
 #include "ir/Index.h"
-#include "ir/Operation.h"
+#include "ir/IOperation.h"
 #include "util/ITimer.h"
 #include "util/TracingCtx.h"
 

--- a/runtime/onert/core/src/exec/FunctionSequence.cc
+++ b/runtime/onert/core/src/exec/FunctionSequence.cc
@@ -16,7 +16,6 @@
 
 #include "exec/FunctionSequence.h"
 
-#include "ir/Operation.h"
 #include "backend/ITensorRegistry.h"
 #include "util/logging.h"
 


### PR DESCRIPTION
This commit separates IOperation from the Operation header.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>