### PR TITLE
[onert] Replace declaring operations with including operations

### DIFF
--- a/runtime/onert/core/include/ir/train/Operations.Include.h
+++ b/runtime/onert/core/include/ir/train/Operations.Include.h
@@ -14,30 +14,9 @@
  * limitations under the License.
  */
 
-#ifndef __ONERT_IR_TRAIN_TRAINABLE_OPERATION_VISITOR_H__
-#define __ONERT_IR_TRAIN_TRAINABLE_OPERATION_VISITOR_H__
+#ifndef __ONERT_IR_TRAIN_OPERATIONS_OPERATION_INCLUDE_H__
+#define __ONERT_IR_TRAIN_OPERATIONS_OPERATION_INCLUDE_H__
 
-#include "ir/train/Operations.Include.h"
+// TODO Append including trainable operation
 
-namespace onert
-{
-namespace ir
-{
-namespace train
-{
-
-struct TrainableOperationVisitor
-{
-  virtual ~TrainableOperationVisitor() = default;
-
-#define OP(InternalName) \
-  virtual void visit(const operation::InternalName &) {}
-#include "ir/train/Operations.lst"
-#undef OP
-};
-
-} // namespace train
-} // namespace ir
-} // namespace onert
-
-#endif // __ONERT_IR_TRAIN_TRAINABLE_OPERATION_VISITOR_H__
+#endif // __ONERT_IR_TRAIN_OPERATIONS_OPERATION_INCLUDE_H__

--- a/runtime/onert/core/include/ir/train/Operations.lst
+++ b/runtime/onert/core/include/ir/train/Operations.lst
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef OP
+#error Define OP before including this file
+#endif
+
+// TODO Add trainable operation list


### PR DESCRIPTION
This commit replaces declaring trainable operations with including trainable operations.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>