### PR TITLE
[onert] Move custom kernel builders into Model

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -359,7 +359,7 @@ NNFW_STATUS nnfw_session::load_model_from_nnpackage(const char *package_dir)
       auto model = loadModel(model_file_path, model_type);
       if (model == nullptr)
         return NNFW_STATUS_ERROR;
-      model->primary_subgraph()->bindKernelBuilder(_kernel_registry->getBuilder());
+      model->bindKernelBuilder(_kernel_registry->getBuilder());
       _nnpkg->push(onert::ir::ModelIndex{i}, std::move(model));
       _coptions.push_back(onert::compiler::CompilerOptions::fromGlobalConfig());
     }

--- a/runtime/onert/core/include/ir/Graph.h
+++ b/runtime/onert/core/include/ir/Graph.h
@@ -27,17 +27,6 @@
 
 namespace onert
 {
-namespace backend
-{
-namespace custom
-{
-class IKernelBuilder;
-} // namespace custom
-} // namespace backend
-} // namespace onert
-
-namespace onert
-{
 namespace ir
 {
 
@@ -112,22 +101,6 @@ private:
   // TODO Rename to `sweepUnusedOperands`
   // TODO Make this public
   void sweepGarbageOperands();
-
-  // Custom operations support
-public:
-  void
-  bindKernelBuilder(const std::shared_ptr<onert::backend::custom::IKernelBuilder> &kernel_builder)
-  {
-    _kernel_builder = kernel_builder;
-  }
-
-  const std::shared_ptr<backend::custom::IKernelBuilder> &getKernelBuilder() const
-  {
-    return _kernel_builder;
-  }
-
-private:
-  std::shared_ptr<backend::custom::IKernelBuilder> _kernel_builder;
 
   // Accessors
 public:

--- a/runtime/onert/core/include/ir/Model.h
+++ b/runtime/onert/core/include/ir/Model.h
@@ -25,6 +25,17 @@
 
 namespace onert
 {
+namespace backend
+{
+namespace custom
+{
+class IKernelBuilder;
+} // namespace custom
+} // namespace backend
+} // namespace onert
+
+namespace onert
+{
 namespace ir
 {
 
@@ -131,6 +142,22 @@ public:
 
 private:
   std::unordered_map<SubgraphIndex, std::shared_ptr<Graph>> _subgraphs;
+
+  // Custom operations support
+public:
+  void
+  bindKernelBuilder(const std::shared_ptr<onert::backend::custom::IKernelBuilder> &kernel_builder)
+  {
+    _kernel_builder = kernel_builder;
+  }
+
+  const std::shared_ptr<backend::custom::IKernelBuilder> &getKernelBuilder() const
+  {
+    return _kernel_builder;
+  }
+
+private:
+  std::shared_ptr<backend::custom::IKernelBuilder> _kernel_builder;
 };
 
 } // namespace ir

--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -78,6 +78,8 @@ std::shared_ptr<CompilerArtifact> Compiler::compile(void)
   _options->forceInternalOptions();
   _options->verboseOptions();
 
+  auto custom_kernel_builder = _model->getKernelBuilder();
+
   _model->iterate([&](const ir::SubgraphIndex &, ir::Graph &subg) {
     // Mandatory passes
     pass::PassRunner{}
@@ -170,6 +172,7 @@ std::shared_ptr<CompilerArtifact> Compiler::compile(void)
     args.tracing_ctx = tracing_ctx.get();
     args.options = _options;
     args.model_index = model_index;
+    args.custom_kernel_builder = custom_kernel_builder;
     auto executor = std::unique_ptr<exec::IExecutor>{
       ExecutorFactory::get().create(std::move(lowered_subg), executors, args)};
     executor->setIndexedRanks(indexed_ranks);

--- a/runtime/onert/core/src/compiler/ExecutorFactory.h
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.h
@@ -37,6 +37,7 @@ struct ExecutorFactoryArgs
   const util::TracingCtx *tracing_ctx;
   const compiler::CompilerOptions *options;
   ir::ModelIndex model_index;
+  std::shared_ptr<backend::custom::IKernelBuilder> custom_kernel_builder;
 };
 
 class ExecutorFactory


### PR DESCRIPTION
This commit moves custom kernel builders from Graph into Model.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>