### PR TITLE
[Draft][tools] Introduce generate_datafiles for onert_train

### DIFF
--- a/tests/tools/onert_run/src/args.cc
+++ b/tests/tools/onert_run/src/args.cc
@@ -265,6 +265,7 @@ void Args::Initialize(void)
     ("load,l", po::value<std::string>()->default_value("")->notifier([&](const auto &v) { _load_filename = v; }), "Input filename")
 #endif
     ("dump:raw", po::value<std::string>()->default_value("")->notifier([&](const auto &v) { _dump_raw_filename = v; }), "Raw Output filename")
+    ("dump_input:raw", po::value<std::string>()->default_value("")->notifier([&](const auto &v) { _dump_raw_input_filename = v; }), "Raw Input filename")
     ("load:raw", po::value<std::string>()->default_value("")->notifier([&](const auto &v) { _load_raw_filename = v; }), "Raw Input filename")
     ("output_sizes", po::value<std::string>()->notifier(process_output_sizes),
         "The output buffer size in JSON 1D array\n"

--- a/tests/tools/onert_run/src/args.h
+++ b/tests/tools/onert_run/src/args.h
@@ -55,6 +55,7 @@ public:
   WhenToUseH5Shape getWhenToUseH5Shape(void) const { return _when_to_use_h5_shape; }
 #endif
   const std::string &getDumpRawFilename(void) const { return _dump_raw_filename; }
+  const std::string &getDumpRawInputFilename(void) const { return _dump_raw_input_filename; }
   const std::string &getLoadRawFilename(void) const { return _load_raw_filename; }
   const int getNumRuns(void) const { return _num_runs; }
   const int getWarmupRuns(void) const { return _warmup_runs; }
@@ -86,6 +87,7 @@ private:
   WhenToUseH5Shape _when_to_use_h5_shape = WhenToUseH5Shape::NOT_PROVIDED;
 #endif
   std::string _dump_raw_filename;
+  std::string _dump_raw_input_filename;
   std::string _load_raw_filename;
   TensorShapeMap _shape_prepare;
   TensorShapeMap _shape_run;

--- a/tests/tools/onert_run/src/onert_run.cc
+++ b/tests/tools/onert_run/src/onert_run.cc
@@ -277,6 +277,8 @@ int main(const int argc, char **argv)
     if (!args.getDumpFilename().empty())
       H5Formatter(session).dumpOutputs(args.getDumpFilename(), outputs);
 #endif
+    if (!args.getDumpRawInputFilename().empty())
+      RawFormatter(session).dumpInputs(args.getDumpRawInputFilename(), inputs);
     if (!args.getDumpRawFilename().empty())
       RawFormatter(session).dumpOutputs(args.getDumpRawFilename(), outputs);
 

--- a/tests/tools/onert_run/src/rawformatter.cc
+++ b/tests/tools/onert_run/src/rawformatter.cc
@@ -94,4 +94,29 @@ void RawFormatter::dumpOutputs(const std::string &filename, std::vector<Allocati
     std::exit(-1);
   }
 }
+
+void RawFormatter::dumpInputs(const std::string &filename, std::vector<Allocation> &inputs)
+{
+  uint32_t num_inputs;
+  NNPR_ENSURE_STATUS(nnfw_input_size(session_, &num_inputs));
+  try
+  {
+    for (uint32_t i = 0; i < num_inputs; i++)
+    {
+      nnfw_tensorinfo ti;
+      NNPR_ENSURE_STATUS(nnfw_input_tensorinfo(session_, i, &ti));
+      auto bufsz = bufsize_for(&ti);
+
+      std::ofstream file(filename + "." + std::to_string(i), std::ios::out | std::ios::binary);
+      file.write(reinterpret_cast<const char *>(inputs[i].data()), bufsz);
+      file.close();
+      std::cerr << filename + "." + std::to_string(i) + " is generated.\n";
+    }
+  }
+  catch (const std::runtime_error &e)
+  {
+    std::cerr << "Error during dumpRandomInputs on onert_run : " << e.what() << std::endl;
+    std::exit(-1);
+  }
+}
 } // end of namespace onert_run

--- a/tests/tools/onert_run/src/rawformatter.h
+++ b/tests/tools/onert_run/src/rawformatter.h
@@ -34,6 +34,7 @@ public:
   RawFormatter(nnfw_session *sess) : Formatter(sess) {}
   void loadInputs(const std::string &filename, std::vector<Allocation> &inputs) override;
   void dumpOutputs(const std::string &filename, std::vector<Allocation> &outputs) override;
+  void dumpInputs(const std::string &filename, std::vector<Allocation> &inputs);
 };
 } // namespace onert_run
 

--- a/tools/generate_datafile/README.md
+++ b/tools/generate_datafile/README.md
@@ -1,0 +1,86 @@
+# Generate Datafile
+
+This script aims to generate data files for onert_train tool.
+
+This tool creates random input data automatically and it executes
+onert_run tool to create output result data using the generated random input data.
+It saves the input and output data as binary file format.
+
+You can use `--num-runs` option to generate multiple data. This option combines
+multiple input and output data and save them as a single input and output file.
+
+You can also specify the input and output file name using `--input` and `--output`
+options.
+
+## How to use
+
+### Prerequirement
+
+- modelfile
+- onert_run tool
+
+### Basic usecase
+
+Create one input and output datafile.
+
+```
+python3 ./tools/generate_datafile/generate_datafile.py \
+  [onert_run tool path] \
+  [modelfile path]
+```
+
+### Specify input and output file name
+
+Create one input and output datafile with given name.
+
+```
+python3 ./tools/generate_datafile/generate_datafile.py \
+  [onert_run tool path] \
+  [modelfile path] \
+  --input input \
+  --output output
+```
+
+### Generate multiple data
+
+Combine multiple test results and create one input and output datafile.
+
+```
+python3 ./tools/generate_datafile/generate_datafile.py \
+  [onert_run tool path] \
+  [modelfile path] \
+  --num-runs [number]
+```
+
+## Example
+
+### Create 50 data files using a.model
+
+```
+$ python3 ./tools/generate_datafile/generate_datafile.py \
+  ./Product/out/bin/onert_run \
+  ./test-models/a.model \
+  --num-runs 50 \
+  --input input.50 \
+  --output output.50
+
+Model Filename ./test-models/a.model
+./test-models/a.input.10.0 is generated.
+./test-models/a.output.10.0 is generated.
+===================================
+MODEL_LOAD   takes 1.914 ms
+PREPARE      takes 5.744 ms
+EXECUTE      takes 16.765 ms
+- MEAN     :  16.765 ms
+- MAX      :  16.765 ms
+- MIN      :  16.765 ms
+- GEOMEAN  :  16.765 ms
+===================================
+...
+Generated input and output files
+Done
+
+$ ls -al ./test-models/a.*.bin
+-rw-rw-r-- 1 jyoung jyoung  156800  6월 21 15:55 ./test-models/a.input.50.bin
+-rw-rw-r-- 1 jyoung jyoung    2000  6월 21 15:55 ./test-models/a.output.50.bin
+```

--- a/tools/generate_datafile/generate_datafile.py
+++ b/tools/generate_datafile/generate_datafile.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+
+#
+# generate_datafile.py
+# - Generate Model input and expected datas for onert_train
+#
+
+import argparse
+import os
+import subprocess
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description='Generate Model input and expected datas for onert_train')
+    parser.add_argument('tool')
+    parser.add_argument('model')
+    parser.add_argument('--input_name', '-i', default='input')
+    parser.add_argument('--output_name', '-o', default='output')
+    parser.add_argument('--num_runs', '-n', default=1, type=int)
+
+    args = parser.parse_args()
+
+    if os.path.exists(args.tool) == False:
+        print("Tool file not found: " + args.tool)
+        exit(1)
+
+    if os.path.exists(args.model) == False:
+        print("Model file not found: " + args.model)
+        exit(1)
+
+    base_name = os.path.splitext(args.model)[0]
+    input_file = base_name + "." + args.input_name + '.bin'
+    output_file = base_name + "." + args.output_name + '.bin'
+
+    inf = open(input_file, 'wb')
+    outf = open(output_file, 'wb')
+
+    for idx in range(args.num_runs):
+        input_idx_file = base_name + "." + args.input_name
+        output_idx_file = base_name + "." + args.output_name
+
+        subprocess.run([
+            args.tool, '--modelfile', args.model, '--dump_input:raw', input_idx_file,
+            '--dump:raw', output_idx_file
+        ])
+
+        input_idx_file += '.0'
+        output_idx_file += '.0'
+
+        if os.path.exists(input_idx_file) == False or os.path.exists(
+                output_idx_file) == False:
+            print("Failed to generate nth input and output files")
+            exit(1)
+
+        with open(input_idx_file, 'rb') as f:
+            inf.write(f.read())
+        with open(output_idx_file, 'rb') as f:
+            outf.write(f.read())
+
+    print("Generated input and output files")
+    print("Done")
+    exit(0)


### PR DESCRIPTION
This commit introduces generate_datafile.py script to create multiple input and expected data files for onert_train. It includes some modification to onert_run tool to save the input data file.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Related PR: #10900