### PR TITLE
[onert] Introduce LossInsertionPass

### DIFF
--- a/runtime/onert/core/src/compiler/train/pass/LossInsertionPass.cc
+++ b/runtime/onert/core/src/compiler/train/pass/LossInsertionPass.cc
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "LossInsertionPass.h"
+
+namespace onert
+{
+namespace compiler
+{
+namespace train
+{
+namespace pass
+{
+
+void LossInsertionPass::run()
+{
+  // TODO Check if it is necessary to add Loss op to this graph
+
+  // TODO Find the loss information of this graph
+
+  // TODO Find the correct pred_index and add the y_true operand into this graph if necessary
+
+  // TODO Set inputs of loss op
+
+  // TODO Find the correct Shape and TypeInfo of the output of loss op
+  // TODO Add the output operand into this graph
+
+  // TODO Set outputs
+
+  // TODO Add ir::train::operation::Loss with the correct inputs, outputs, and param
+
+  // TODO Change outputs of graph if necessary
+}
+
+} // namespace pass
+} // namespace train
+} // namespace compiler
+} // namespace onert

--- a/runtime/onert/core/src/compiler/train/pass/LossInsertionPass.h
+++ b/runtime/onert/core/src/compiler/train/pass/LossInsertionPass.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_COMPILER_TRAIN_PASS_LOSS_INSERTION_PASS_H__
+#define __ONERT_COMPILER_TRAIN_PASS_LOSS_INSERTION_PASS_H__
+
+#include "Pass.h"
+
+#include "compiler/train/TrainingInfo.h"
+
+namespace onert
+{
+namespace compiler
+{
+namespace train
+{
+namespace pass
+{
+
+class LossInsertionPass : public Pass
+{
+public:
+  LossInsertionPass(ir::train::TrainableGraph &trainable_graph,
+                    const ir::train::TrainingInfo *training_info,
+                    const ir::SubgraphIndex &subg_index)
+    : Pass{trainable_graph, training_info}, _subg_index{subg_index}
+  {
+  }
+
+public:
+  std::string id() final { return "LossInsertionPass"; }
+  void run() final;
+
+private:
+  ir::SubgraphIndex _subg_index;
+};
+
+} // namespace pass
+} // namespace train
+} // namespace compiler
+} // namespace onert
+
+#endif // __ONERT_COMPILER_TRAIN_PASS_LOSS_INSERTION_PASS_H__


### PR DESCRIPTION
This commit introduces LossInsertionPass that can insert Loss operation into a subgraph.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>