### PR TITLE
[onert] Introduce `builtin` backend's KernelGenerator for training

### DIFF
--- a/runtime/onert/core/include/backend/train/KernelGeneratorBase.h
+++ b/runtime/onert/core/include/backend/train/KernelGeneratorBase.h
@@ -40,8 +40,6 @@ public:
   virtual std::unique_ptr<exec::train::TrainableFnSequence> generate(ir::OperationIndex ind) = 0;
 
 protected:
-  using TrainableOperationVisitor::visit;
-
 #define OP(InternalName)                                                                \
   void visit(const ir::train::operation::InternalName &) override                       \
   {                                                                                     \

--- a/runtime/onert/core/src/backend/builtin/train/KernelGenerator.cc
+++ b/runtime/onert/core/src/backend/builtin/train/KernelGenerator.cc
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "KernelGenerator.h"
+
+#include "ir/train/Operations.Include.h"
+
+namespace onert
+{
+namespace backend
+{
+namespace builtin
+{
+namespace train
+{
+
+KernelGenerator::KernelGenerator(const ir::train::TrainableGraph &tgraph,
+                                 const std::shared_ptr<TensorRegistry> &tensor_reg,
+                                 const std::shared_ptr<TensorRegistry> &grad_tensor_reg,
+                                 const std::shared_ptr<ExternalContext> &external_context)
+  : KernelGeneratorBase{tgraph}, _tensor_reg{tensor_reg}, _grad_tensor_reg{grad_tensor_reg},
+    _external_context(external_context)
+{
+}
+
+std::unique_ptr<exec::train::TrainableFnSequence> KernelGenerator::generate(ir::OperationIndex ind)
+{
+  auto ret = std::make_unique<exec::train::TrainableFnSequence>();
+  const auto &op = _tgraph.operation(ind);
+  op.accept(*this);
+  // _return_fn must have been generated
+  if (_return_fn == nullptr)
+  {
+    throw std::runtime_error(op.name() + " op does not supported trainable kernel yet");
+  }
+
+  ret->_functions.emplace_back(std::move(_return_fn));
+
+  return ret;
+}
+
+// TODO Append visit functions
+
+backend::ITensor *KernelGenerator::getTensor(const ir::OperandIndex &index)
+{
+  // get Tensor from all tensor registries (for Permute op)
+  auto ret = _tensor_registries.getITensor(index);
+  assert(ret != nullptr);
+  return ret;
+}
+
+} // namespace train
+} // namespace builtin
+} // namespace backend
+} // namespace onert

--- a/runtime/onert/core/src/backend/builtin/train/KernelGenerator.h
+++ b/runtime/onert/core/src/backend/builtin/train/KernelGenerator.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_BACKEND_BUTIN_TRAIN_KERNEL_GENERATOR_H__
+#define __ONERT_BACKEND_BUTIN_TRAIN_KERNEL_GENERATOR_H__
+
+#include "../ExternalContext.h"
+#include "../TensorRegistry.h"
+#include "../../../compiler/TensorRegistries.h"
+
+#include <backend/train/KernelGeneratorBase.h>
+#include <exec/train/TrainableFnSequence.h>
+#include <ir/train/TrainableGraph.h>
+
+namespace onert
+{
+namespace backend
+{
+namespace builtin
+{
+namespace train
+{
+
+class KernelGenerator : public backend::train::KernelGeneratorBase
+{
+public:
+  KernelGenerator(const ir::train::TrainableGraph &tgraph,
+                  const std::shared_ptr<TensorRegistry> &tensor_reg,
+                  const std::shared_ptr<TensorRegistry> &grad_tensor_reg,
+                  const std::shared_ptr<ExternalContext> &external_context);
+
+  std::unique_ptr<exec::train::TrainableFnSequence> generate(ir::OperationIndex ind) override;
+
+  void setTensorRegistries(const compiler::TensorRegistries &tensor_registries)
+  {
+    _tensor_registries = tensor_registries;
+  }
+
+private:
+  // TODO Append visit functions
+
+private:
+  backend::ITensor *getTensor(const ir::OperandIndex &index);
+
+private:
+  std::shared_ptr<TensorRegistry> _tensor_reg;
+  std::shared_ptr<TensorRegistry> _grad_tensor_reg;
+  compiler::TensorRegistries _tensor_registries;
+  const std::shared_ptr<ExternalContext> _external_context;
+};
+
+} // namespace train
+} // namespace builtin
+} // namespace backend
+} // namespace onert
+
+#endif // __ONERT_BACKEND_BUTIN_TRAIN_KERNEL_GENERATOR_H__


### PR DESCRIPTION
This commit introduces `builtin` backend's KernelGenerator for training.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>