### PR TITLE
[onert] Introduce UntrainableOperationConverter

### DIFF
--- a/runtime/onert/core/include/ir/operation/BinaryArithmetic.h
+++ b/runtime/onert/core/include/ir/operation/BinaryArithmetic.h
@@ -27,7 +27,7 @@ namespace ir
 namespace operation
 {
 
-class BinaryArithmetic final : public Operation
+class BinaryArithmetic : public Operation
 {
 public:
   enum Input

--- a/runtime/onert/core/src/compiler/train/UntrainableOperationConverter.cc
+++ b/runtime/onert/core/src/compiler/train/UntrainableOperationConverter.cc
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "UntrainableOperationConverter.h"
+
+#include "ir/train/operation/UntrainableOperation.h"
+
+namespace onert
+{
+namespace compiler
+{
+namespace train
+{
+
+UntrainableOperationConverter::UntrainableOperationConverter(ir::train::TrainableGraph &tgraph)
+  : _tgraph{tgraph}, _return_op{nullptr}
+{
+}
+
+std::unique_ptr<ir::train::ITrainableOperation> UntrainableOperationConverter::
+operator()(const ir::OperationIndex &index)
+{
+  const auto &op = _tgraph.operations().at(index);
+  op.accept(*this);
+
+  return std::move(_return_op);
+}
+
+#define OP(InternalName)                                                                         \
+  void UntrainableOperationConverter::visit(const ir::operation::InternalName &node)             \
+  {                                                                                              \
+    _return_op =                                                                                 \
+      std::make_unique<ir::train::operation::UntrainableOperation<ir::operation::InternalName>>( \
+        node);                                                                                   \
+  }
+#include "ir/Operations.lst"
+#undef OP
+
+} // namespace train
+} // namespace compiler
+} // namespace onert

--- a/runtime/onert/core/src/compiler/train/UntrainableOperationConverter.h
+++ b/runtime/onert/core/src/compiler/train/UntrainableOperationConverter.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_COMPILER_TRAIN_UNTRAINABLE_OPERATION_CONVERTER_H__
+#define __ONERT_COMPILER_TRAIN_UNTRAINABLE_OPERATION_CONVERTER_H__
+
+#include "ir/Operations.Include.h"
+#include "ir/OperationVisitor.h"
+#include "ir/train/TrainableGraph.h"
+
+#include <memory>
+
+namespace onert
+{
+namespace compiler
+{
+namespace train
+{
+
+class UntrainableOperationConverter : public ir::OperationVisitor
+{
+public:
+  UntrainableOperationConverter(ir::train::TrainableGraph &tgraph);
+  std::unique_ptr<ir::train::ITrainableOperation> operator()(const ir::OperationIndex &index);
+
+#define OP(InternalName) void visit(const ir::operation::InternalName &node);
+#include "ir/Operations.lst"
+#undef OP
+
+protected:
+  ir::train::TrainableGraph &_tgraph;
+  std::unique_ptr<ir::train::ITrainableOperation> _return_op;
+};
+
+} // namespace train
+} // namespace compiler
+} // namespace onert
+
+#endif // __ONERT_COMPILER_TRAIN_UNTRAINABLE_OPERATION_CONVERTER_H__


### PR DESCRIPTION
This commit introduces UntrainableOperationConverter that converts operations to UntrainableOperation.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>