### PR TITLE
[onert] Introduce TrainableOperationConverter

### DIFF
--- a/runtime/onert/core/src/compiler/train/TrainableOperationConverter.cc
+++ b/runtime/onert/core/src/compiler/train/TrainableOperationConverter.cc
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "TrainableOperationConverter.h"
+
+#include "ir/train/Operations.Include.h"
+#include "util/Utils.h"
+
+namespace onert
+{
+namespace compiler
+{
+namespace train
+{
+
+TrainableOperationConverter::TrainableOperationConverter(
+  ir::train::TrainableGraph &tgraph, const compiler::train::TrainingInfo *training_info)
+  : UntrainableOperationConverter{tgraph}, _training_info{training_info}
+{
+  // Avoid unused-private-field error
+  UNUSED_RELEASE(_training_info);
+}
+
+void TrainableOperationConverter::visit(const ir::operation::ElementwiseActivation &node)
+{
+  if (node.param().op_type == ir::operation::ElementwiseActivation::Type::RELU)
+  {
+    _return_op = std::make_unique<ir::train::operation::ElementwiseActivation>(node);
+  }
+  else
+  {
+    UntrainableOperationConverter::visit(node);
+  }
+}
+
+void TrainableOperationConverter::visit(const ir::operation::Loss &node)
+{
+  _return_op = std::make_unique<ir::train::operation::Loss>(node);
+}
+
+void TrainableOperationConverter::visit(const ir::operation::Permute &node)
+{
+  _return_op = std::make_unique<ir::train::operation::Permute>(node);
+}
+
+} // namespace train
+} // namespace compiler
+} // namespace onert

--- a/runtime/onert/core/src/compiler/train/TrainableOperationConverter.h
+++ b/runtime/onert/core/src/compiler/train/TrainableOperationConverter.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_COMPILER_TRAIN_TRAINABLE_OPERATION_CONVERTER_H__
+#define __ONERT_COMPILER_TRAIN_TRAINABLE_OPERATION_CONVERTER_H__
+
+#include "UntrainableOperationConverter.h"
+
+#include "compiler/train/TrainingInfo.h"
+
+namespace onert
+{
+namespace compiler
+{
+namespace train
+{
+
+class TrainableOperationConverter : public UntrainableOperationConverter
+{
+public:
+  TrainableOperationConverter(ir::train::TrainableGraph &trainable_graph,
+                              const compiler::train::TrainingInfo *training_info);
+
+  using UntrainableOperationConverter::operator();
+
+private:
+  void visit(const ir::operation::ElementwiseActivation &) override;
+  void visit(const ir::operation::Loss &node) override;
+  void visit(const ir::operation::Permute &node) override;
+
+private:
+  const compiler::train::TrainingInfo *_training_info;
+};
+
+} // namespace train
+} // namespace compiler
+} // namespace onert
+
+#endif // __ONERT_COMPILER_TRAIN_TRAINABLE_OPERATION_CONVERTER_H__


### PR DESCRIPTION
This commit introduces TrainableOperationConverter that can convert operations to trainable operations.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>