### PR TITLE
[onert] Access gradient tensors in builtin KernelGenerator

### DIFF
--- a/runtime/onert/core/src/backend/builtin/train/KernelGenerator.cc
+++ b/runtime/onert/core/src/backend/builtin/train/KernelGenerator.cc
@@ -32,7 +32,7 @@ KernelGenerator::KernelGenerator(const ir::train::TrainableGraph &tgraph,
                                  const std::shared_ptr<TensorRegistry> &grad_tensor_reg,
                                  const std::shared_ptr<ExternalContext> &external_context)
   : KernelGeneratorBase{tgraph}, _tensor_reg{tensor_reg}, _grad_tensor_reg{grad_tensor_reg},
-    _tensor_registries{}, _grad_tensor_registries{}, _external_context{external_context}
+    _external_context(external_context)
 {
 }
 

--- a/runtime/onert/core/src/backend/builtin/train/KernelGenerator.cc
+++ b/runtime/onert/core/src/backend/builtin/train/KernelGenerator.cc
@@ -32,7 +32,7 @@ KernelGenerator::KernelGenerator(const ir::train::TrainableGraph &tgraph,
                                  const std::shared_ptr<TensorRegistry> &grad_tensor_reg,
                                  const std::shared_ptr<ExternalContext> &external_context)
   : KernelGeneratorBase{tgraph}, _tensor_reg{tensor_reg}, _grad_tensor_reg{grad_tensor_reg},
-    _external_context(external_context)
+    _tensor_registries{}, _grad_tensor_registries{}, _external_context{external_context}
 {
 }
 
@@ -71,6 +71,14 @@ backend::ITensor *KernelGenerator::getTensor(const ir::OperandIndex &index)
 {
   // get Tensor from all tensor registries (for Permute op)
   auto ret = _tensor_registries.getITensor(index);
+  assert(ret != nullptr);
+  return ret;
+}
+
+backend::ITensor *KernelGenerator::getGradTensor(const ir::OperandIndex &index)
+{
+  // get gradient Tensor from all tensor registries (for Permute op)
+  auto ret = _grad_tensor_registries.getITensor(index);
   assert(ret != nullptr);
   return ret;
 }

--- a/runtime/onert/core/src/backend/builtin/train/KernelGenerator.h
+++ b/runtime/onert/core/src/backend/builtin/train/KernelGenerator.h
@@ -49,16 +49,23 @@ public:
     _tensor_registries = tensor_registries;
   }
 
+  void setGradTensorRegistries(const compiler::TensorRegistries &tensor_registries)
+  {
+    _grad_tensor_registries = tensor_registries;
+  }
+
 private:
   void visit(const ir::train::operation::Permute &) override;
 
 private:
   backend::ITensor *getTensor(const ir::OperandIndex &index);
+  backend::ITensor *getGradTensor(const ir::OperandIndex &index);
 
 private:
   std::shared_ptr<TensorRegistry> _tensor_reg;
   std::shared_ptr<TensorRegistry> _grad_tensor_reg;
   compiler::TensorRegistries _tensor_registries;
+  compiler::TensorRegistries _grad_tensor_registries;
   const std::shared_ptr<ExternalContext> _external_context;
 };
 


### PR DESCRIPTION
This commit make `builtin`'s KernelGenerator can access tensors for gradient.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>