### PR TITLE
[onert] Remove an unnecessary member from TrainingCompiler

### DIFF
--- a/runtime/onert/core/src/compiler/train/TrainingCompiler.cc
+++ b/runtime/onert/core/src/compiler/train/TrainingCompiler.cc
@@ -43,7 +43,6 @@ std::shared_ptr<CompilerArtifact> TrainingCompiler::compile(void)
 
   // Avoid unused-private-field error
   UNUSED_RELEASE(_model);
-  UNUSED_RELEASE(_inference_compiler);
   UNUSED_RELEASE(_options);
   UNUSED_RELEASE(_training_info);
 

--- a/runtime/onert/core/src/compiler/train/TrainingCompiler.h
+++ b/runtime/onert/core/src/compiler/train/TrainingCompiler.h
@@ -72,7 +72,6 @@ public:
 
 private:
   std::shared_ptr<ir::Model> _model;
-  std::unique_ptr<ICompiler> _inference_compiler;
   CompilerOptions *_options;
   const TrainingInfo *_training_info;
 };


### PR DESCRIPTION
This commit removes an unnecessary member from TrainingCompiler.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>