### PR TITLE
[visq] Use tensor ID as a filename

### DIFF
--- a/compiler/visq-unittest/test/testQErrorComputer.py
+++ b/compiler/visq-unittest/test/testQErrorComputer.py
@@ -37,10 +37,12 @@ class VisqQErrorComputerTest(unittest.TestCase):
         self.fq_dir.cleanup()
 
     def _setUpSingleTensorData(self):
-        with open(self.fp32_dir.name + '/tensors.txt', 'w') as f:
-            f.write('test')
-        with open(self.fq_dir.name + '/tensors.txt', 'w') as f:
-            f.write('test')
+        tensor_id = {}
+        tensor_id['test'] = 0
+        with open(self.fp32_dir.name + '/tensors.json', 'w') as f:
+            json.dump(tensor_id, f)
+        with open(self.fq_dir.name + '/tensors.json', 'w') as f:
+            json.dump(tensor_id, f)
         scales = {}
         scales['test'] = 2.0
         with open(self.fq_dir.name + '/scales.txt', 'w') as f:
@@ -48,14 +50,16 @@ class VisqQErrorComputerTest(unittest.TestCase):
         os.mkdir(self.fp32_dir.name + '/0')
         os.mkdir(self.fq_dir.name + '/0')
         test_data = np.zeros(16)
-        np.save(self.fp32_dir.name + '/0/test.npy', test_data)
-        np.save(self.fq_dir.name + '/0/test.npy', test_data)
+        np.save(self.fp32_dir.name + '/0/0.npy', test_data)
+        np.save(self.fq_dir.name + '/0/0.npy', test_data)
 
     def _setUpTwoTensorData(self):
-        with open(self.fp32_dir.name + '/tensors.txt', 'w') as f:
-            f.write('test')
-        with open(self.fq_dir.name + '/tensors.txt', 'w') as f:
-            f.write('test')
+        tensor_id = {}
+        tensor_id['test'] = 0
+        with open(self.fp32_dir.name + '/tensors.json', 'w') as f:
+            json.dump(tensor_id, f)
+        with open(self.fq_dir.name + '/tensors.json', 'w') as f:
+            json.dump(tensor_id, f)
         scales = {}
         scales['test'] = 2.0
         with open(self.fq_dir.name + '/scales.txt', 'w') as f:
@@ -66,10 +70,10 @@ class VisqQErrorComputerTest(unittest.TestCase):
         os.mkdir(self.fq_dir.name + '/1')
         test_data_one = np.ones(16)
         test_data_zero = np.zeros(16)
-        np.save(self.fp32_dir.name + '/0/test.npy', test_data_one)
-        np.save(self.fp32_dir.name + '/1/test.npy', test_data_zero)
-        np.save(self.fq_dir.name + '/0/test.npy', test_data_zero)
-        np.save(self.fq_dir.name + '/1/test.npy', test_data_zero)
+        np.save(self.fp32_dir.name + '/0/0.npy', test_data_one)
+        np.save(self.fp32_dir.name + '/1/0.npy', test_data_zero)
+        np.save(self.fq_dir.name + '/0/0.npy', test_data_zero)
+        np.save(self.fq_dir.name + '/1/0.npy', test_data_zero)
         # Golden: (1 + 0) / 2 = 0.5 for MSE
 
     def _setUpDifferentTensorData(self):
@@ -78,11 +82,14 @@ class VisqQErrorComputerTest(unittest.TestCase):
         # NOTE When does this happen?
         # This case can happen because visq ignores nodes that do not affect qerrors.
         # For example, RESHAPE Op does not affect qerrors, so its fq data is not dumped,
-        # although it is listed in 'tensors.txt'.
-        with open(self.fp32_dir.name + '/tensors.txt', 'w') as f:
-            f.writelines(['test\n', 'test2'])
-        with open(self.fq_dir.name + '/tensors.txt', 'w') as f:
-            f.writelines(['test\n', 'test2'])
+        # although it is listed in 'tensors.json'.
+        tensor_id = {}
+        tensor_id['test'] = 0
+        tensor_id['test2'] = 1
+        with open(self.fp32_dir.name + '/tensors.json', 'w') as f:
+            json.dump(tensor_id, f)
+        with open(self.fq_dir.name + '/tensors.json', 'w') as f:
+            json.dump(tensor_id, f)
         scales = {}
         scales['test'] = 2.0
         scales['test2'] = 1.0
@@ -91,9 +98,9 @@ class VisqQErrorComputerTest(unittest.TestCase):
         os.mkdir(self.fp32_dir.name + '/0')
         os.mkdir(self.fq_dir.name + '/0')
         test_data = np.zeros(16)
-        np.save(self.fp32_dir.name + '/0/test.npy', test_data)
-        np.save(self.fp32_dir.name + '/0/test2.npy', test_data)
-        np.save(self.fq_dir.name + '/0/test.npy', test_data)
+        np.save(self.fp32_dir.name + '/0/0.npy', test_data)
+        np.save(self.fp32_dir.name + '/0/1.npy', test_data)
+        np.save(self.fq_dir.name + '/0/0.npy', test_data)
 
     def test_MPEIR(self):
         self._setUpSingleTensorData()

--- a/compiler/visq/visq
+++ b/compiler/visq/visq
@@ -156,7 +156,7 @@ def advance_on_data(fp32_model, fq_model, data, computers):
          tempfile.TemporaryDirectory() as fq_dir:
 
         _run_dalgona(fp32_model, data, dump_fp32_py, fp32_dir)
-        copyfile(fp32_dir + '/tensors.txt', fq_dir + '/tensors.txt')
+        copyfile(fp32_dir + '/tensors.json', fq_dir + '/tensors.json')
         _run_dalgona(fq_model, data, dump_fq_py, fq_dir)
 
         for metric_key in computers:
@@ -304,7 +304,7 @@ def run_on_data(fp32_model, q_model, data, dump_dot_graph, computers):
         _run_dalgona(fp32_model, data, dump_fp32_py, fp32_dir)
 
         # Copy list of dumped tensors
-        copyfile(fp32_dir + '/tensors.txt', fq_dir + '/tensors.txt')
+        copyfile(fp32_dir + '/tensors.json', fq_dir + '/tensors.json')
 
         # Step 3. Run dalgona to dump intermediate FMs in fq model
         _run_dalgona(fq_model, data, dump_fq_py, fq_dir)


### PR DESCRIPTION
This uses tensor ID as a filename to avoid too long filename error.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/10941