### PR TITLE
[visq-unittest] Turn off for a while

### DIFF
--- a/compiler/visq-unittest/CMakeLists.txt
+++ b/compiler/visq-unittest/CMakeLists.txt
@@ -1,3 +1,6 @@
+# TODO Remove this line
+return()
+
 if(NOT ENABLE_TEST)
   return()
 endif(NOT ENABLE_TEST)


### PR DESCRIPTION
This turns off visq-unittest during landing #10950.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: #10949
Draft PR: https://github.com/Samsung/ONE/pull/10950