### PR TITLE
[visq-unittest] Enable tests

### DIFF
--- a/compiler/visq-unittest/CMakeLists.txt
+++ b/compiler/visq-unittest/CMakeLists.txt
@@ -1,6 +1,3 @@
-# TODO Remove this line
-return()
-
 if(NOT ENABLE_TEST)
   return()
 endif(NOT ENABLE_TEST)


### PR DESCRIPTION
This enables visq-unittest after landing #10950.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/10949
Draft PR: https://github.com/Samsung/ONE/pull/10950