### PR TITLE
[one-cmds] Handle PIL.Image.ANTIALIAS deprecation

### DIFF
--- a/compiler/one-cmds/tests/preprocess_images.py
+++ b/compiler/one-cmds/tests/preprocess_images.py
@@ -26,8 +26,11 @@ for (root, _, files) in os.walk(input_dir):
     datalist = open(list_file, 'w')
     for f in files:
         with PIL.Image.open(root + '/' + f) as image:
-            img = np.array(image.resize((299, 299),
-                                        PIL.Image.ANTIALIAS)).astype(np.float32)
+            # To handle ANTIALIAS deprecation
+            ANTIALIAS = PIL.Image.Resampling.LANCZOS if hasattr(
+                PIL.Image, "Resampling") else PIL.Image.ANTIALIAS
+
+            img = np.array(image.resize((299, 299), ANTIALIAS)).astype(np.float32)
             img = ((img / 255) - 0.5) * 2.0
             output_file = output_dir + '/' + f.replace('jpg', 'data')
             img.tofile(output_file)


### PR DESCRIPTION
This handles deprecation of PIL.Image.ANTIALIAS attribute.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/10966