### PR TITLE
[onert] Add backward to ITrainableFunction

### DIFF
--- a/runtime/onert/backend/train/ops/ConvolutionLayer.cc
+++ b/runtime/onert/backend/train/ops/ConvolutionLayer.cc
@@ -46,6 +46,10 @@ void ConvolutionLayer::configure(const IPortableTensor *input, const IPortableTe
 }
 
 void ConvolutionLayer::forward(bool) { cpu::ops::ConvolutionLayer::run(); }
+void ConvolutionLayer::backward()
+{
+  // TODO Implement detail
+}
 
 } // namespace ops
 } // namespace train

--- a/runtime/onert/backend/train/ops/ConvolutionLayer.h
+++ b/runtime/onert/backend/train/ops/ConvolutionLayer.h
@@ -44,6 +44,7 @@ public:
                  const uint32_t dilationHeightFactor, const ir::Activation activation,
                  IPortableTensor *output);
   void forward(bool training) override;
+  void backward() override;
 };
 
 } // namespace ops

--- a/runtime/onert/backend/train/ops/PoolLayer.cc
+++ b/runtime/onert/backend/train/ops/PoolLayer.cc
@@ -61,6 +61,11 @@ void PoolLayer::forward(bool training)
   }
 }
 
+void PoolLayer::backward()
+{
+  // TODO Implement detail
+}
+
 } // namespace ops
 } // namespace train
 } // namespace backend

--- a/runtime/onert/backend/train/ops/PoolLayer.h
+++ b/runtime/onert/backend/train/ops/PoolLayer.h
@@ -48,6 +48,7 @@ public:
                  const uint32_t kernelHeight, const ir::Activation activation,
                  IPortableTensor *output, const PoolType op_type);
   void forward(bool training) override;
+  void backward() override;
 };
 
 } // namespace ops

--- a/runtime/onert/core/include/exec/ITrainableFunction.h
+++ b/runtime/onert/core/include/exec/ITrainableFunction.h
@@ -27,6 +27,7 @@ class ITrainableFunction
 public:
   virtual ~ITrainableFunction() = default;
   virtual void forward(bool training) = 0;
+  virtual void backward() = 0;
 };
 
 } // namespace exec

--- a/runtime/onert/core/src/backend/builtin/train/kernel/PermuteLayer.cc
+++ b/runtime/onert/core/src/backend/builtin/train/kernel/PermuteLayer.cc
@@ -38,6 +38,11 @@ PermuteLayer::PermuteLayer(const std::vector<ITensor *> &src_tensors,
 
 void PermuteLayer::forward(bool) { builtin::kernel::PermuteLayer::run(); }
 
+void PermuteLayer::backward()
+{
+  // TODO Implement detail
+}
+
 } // namespace kernel
 } // namespace train
 } // namespace builtin

--- a/runtime/onert/core/src/backend/builtin/train/kernel/PermuteLayer.h
+++ b/runtime/onert/core/src/backend/builtin/train/kernel/PermuteLayer.h
@@ -39,8 +39,7 @@ public:
                const std::shared_ptr<ExternalContext> &external_context);
 
   void forward(bool training) override;
-
-  // TODO Add methods for training
+  void backward() override;
 };
 
 } // namespace kernel


### PR DESCRIPTION
This commit adds backward function to ITrainableFunction class.
TrainableExecutors will invoke backward function when it trains model.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>