### PR TITLE
[tools/onert_train] Add input and expected datafile arguments

### DIFF
--- a/tests/tools/onert_train/src/args.cc
+++ b/tests/tools/onert_train/src/args.cc
@@ -150,6 +150,20 @@ void Args::Initialize(void)
     }
   };
 
+  auto process_load_raw_inputfile = [&](const std::string &input_filename) {
+    _load_raw_input_filename = input_filename;
+
+    std::cerr << "Model Input Filename " << _load_raw_input_filename << std::endl;
+    checkModelfile(_load_raw_input_filename);
+  };
+
+  auto process_load_raw_expectedfile = [&](const std::string &expected_filename) {
+    _load_raw_expected_filename = expected_filename;
+
+    std::cerr << "Model Expected Filename " << _load_raw_expected_filename << std::endl;
+    checkModelfile(_load_raw_expected_filename);
+  };
+
   auto process_output_sizes = [&](const std::string &output_sizes_json_str) {
     Json::Value root;
     Json::Reader reader;
@@ -184,6 +198,17 @@ void Args::Initialize(void)
     ("nnpackage", po::value<std::string>()->notifier(process_nnpackage), "NN Package file(directory) name")
     ("modelfile", po::value<std::string>()->notifier(process_modelfile), "NN Model filename")
     ("path", po::value<std::string>()->notifier(process_path), "NN Package or NN Modelfile path")
+    ("data_length", po::value<int>()->default_value(-1)->notifier([&](const auto &v) { _data_length = v; }), "Data length number")
+    ("load_input:raw", po::value<std::string>()->notifier(process_load_raw_inputfile),
+         "NN Model Raw Input data file\n"
+         "The datafile must have data for each input number.\n"
+         "If there are 3 inputs, the data of input0 must exist as much as data_length, "
+         "and the data for input1 and input2 must be held sequentially as data_length.\n"
+    )
+    ("load_expected:raw", po::value<std::string>()->notifier(process_load_raw_expectedfile),
+         "NN Model Raw Expected data file\n"
+         "(Same data policy with load_input:raw)\n"
+    )
     ("epoch", po::value<int>()->default_value(5)->notifier([&](const auto &v) { _epoch = v; }), "Epoch number (default: 5)")
     ("batch_size", po::value<int>()->default_value(32)->notifier([&](const auto &v) { _batch_size = v; }), "Batch size (default: 32)")
     ("learning_rate", po::value<float>()->default_value(1.0e-4)->notifier([&](const auto &v) { _learning_rate = v; }), "Learning rate (default: 1.0e-4)")

--- a/tests/tools/onert_train/src/args.h
+++ b/tests/tools/onert_train/src/args.h
@@ -49,6 +49,9 @@ public:
   const std::string &getPackageFilename(void) const { return _package_filename; }
   const std::string &getModelFilename(void) const { return _model_filename; }
   const bool useSingleModel(void) const { return _use_single_model; }
+  const int getDataLength(void) const { return _data_length; }
+  const std::string &getLoadRawInputFilename(void) const { return _load_raw_input_filename; }
+  const std::string &getLoadRawExpectedFilename(void) const { return _load_raw_expected_filename; }
   const int getEpoch(void) const { return _epoch; }
   const int getBatchSize(void) const { return _batch_size; }
   const float getLearningRate(void) const { return _learning_rate; }
@@ -69,6 +72,9 @@ private:
   std::string _package_filename;
   std::string _model_filename;
   bool _use_single_model = false;
+  int _data_length;
+  std::string _load_raw_input_filename;
+  std::string _load_raw_expected_filename;
   int _epoch;
   int _batch_size;
   float _learning_rate;


### PR DESCRIPTION
This commit adds input and expected datafile arguments and data_length. The onert_train will train a given model using input and expected datafile.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Draft PR: #10900 