### PR TITLE
[onert] Convert Permute op to trainable operation

### DIFF
--- a/runtime/onert/core/src/compiler/train/LoweredTrainableGraph.cc
+++ b/runtime/onert/core/src/compiler/train/LoweredTrainableGraph.cc
@@ -26,8 +26,7 @@
 #include "../../backend/builtin/Config.h"
 #include "../../dumper/text/GraphDumper.h"
 #include "../../ir/verifier/Verifier.h"
-// TODO Enable after merging TrainableOperationConverter
-// #include "TrainableOperationConverter.h"
+#include "TrainableOperationConverter.h"
 
 #include "backend/Backend.h"
 #include "backend/train/ITrainableBackend.h"
@@ -105,19 +104,18 @@ void LoweredTrainableGraph::lowerGraph(const CompilerOptions &options)
     .append(std::make_unique<compiler::pass::PermutationInsertionPass>(*this))
     .run();
 
-  // TODO Enable after merging TrainableOperationConverter
-  // // TODO Move converting Permute op into PermutationInsertionPass
-  // auto op_converter = TrainableOperationConverter{_trainable_graph, nullptr};
-  // _trainable_graph.operations().iterate(
-  //   [&](const onert::ir::OperationIndex &index, const onert::ir::IOperation &op) {
-  //     if (op.opcode() == ir::OpCode::Permute)
-  //     {
-  //       auto top = op_converter(index);
-  //       auto gen_index = _trainable_graph.replaceOperation(index, std::move(top));
-  //       UNUSED_RELEASE(gen_index);
-  //       assert(gen_index == index);
-  //     }
-  //   });
+  // TODO Move converting Permute op into PermutationInsertionPass
+  auto op_converter = TrainableOperationConverter{_trainable_graph, nullptr};
+  _trainable_graph.operations().iterate(
+    [&](const onert::ir::OperationIndex &index, const onert::ir::IOperation &op) {
+      if (op.opcode() == ir::OpCode::Permute)
+      {
+        auto top = op_converter(index);
+        auto gen_index = _trainable_graph.replaceOperation(index, std::move(top));
+        UNUSED_RELEASE(gen_index);
+        assert(gen_index == index);
+      }
+    });
 
   dumpLowerInfo();
 


### PR DESCRIPTION
This commit applies converting Permute operation to trainable Permute operation.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>