### PR TITLE
[onert] Remove _has_info variable from TrainingInfo

### DIFF
--- a/runtime/onert/core/include/compiler/train/TrainingInfo.h
+++ b/runtime/onert/core/include/compiler/train/TrainingInfo.h
@@ -34,25 +34,19 @@ struct LossInfo
 class TrainingInfo
 {
 public:
-  TrainingInfo() : _has_info{false} {}
+  TrainingInfo() {}
   TrainingInfo(const TrainingInfo &obj) = default;
   TrainingInfo(TrainingInfo &&) = default;
   TrainingInfo &operator=(const TrainingInfo &) = default;
   TrainingInfo &operator=(TrainingInfo &&) = default;
   ~TrainingInfo() = default;
 
-  bool shouldTrain() const { return _has_info; }
   uint32_t batchSize() const { return _batch_size; }
   void setBatchSize(const uint32_t batch_size) { _batch_size = batch_size; }
   const LossInfo &lossInfo() const { return _loss_info; }
-  void setLossInfo(const LossInfo &loss_info)
-  {
-    _loss_info = loss_info;
-    _has_info = true;
-  }
+  void setLossInfo(const LossInfo &loss_info) { _loss_info = loss_info; }
 
 private:
-  bool _has_info;
   LossInfo _loss_info;
   uint32_t _batch_size;
 };

--- a/runtime/onert/core/src/compiler/CompilerFactory.cc
+++ b/runtime/onert/core/src/compiler/CompilerFactory.cc
@@ -41,7 +41,7 @@ CompilerFactory::create(const std::shared_ptr<ir::NNPkg> &nnpkg,
 {
 #ifdef ONERT_TRAIN
   // Returing compiler for training
-  if (training_info && training_info->shouldTrain())
+  if (training_info)
     return std::make_unique<train::TrainingCompiler>(nnpkg, copts, training_info);
 #else  // ONERT_TRAIN
   (void)training_info;


### PR DESCRIPTION
This commit removes the has_info variable from TrainingInfo.
The default value of trainnig_info in CompilerFactory.create() is nullptr.
Therefore, if create() is not called with TrainingInfo, it is the same with shouldTrain() == false.
Conversely, if create() is called with TrainingInfo, it is the same with shouldTrain() == true.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>