### PR TITLE
[onert] Initialize variable model_id

### DIFF
--- a/runtime/onert/backend/trix/DevContext.cc
+++ b/runtime/onert/backend/trix/DevContext.cc
@@ -89,7 +89,7 @@ ModelID DevContext::registerModel(const std::string &model_file_path)
   file_info.filepath = model_file_path.c_str();
   file_info.size = meta->size;
 
-  ModelID model_id;
+  ModelID model_id = 0;
 
   for (uint32_t dev_num = 0; dev_num < _dev_handles.size(); ++dev_num)
   {


### PR DESCRIPTION
This commit initializes model_id variable in DevContext.cc. 
It can be returned without initialization, so gcc 13 warns this.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>