### PR TITLE
[onert] Change parameter of TrainableOperationConverter

### DIFF
--- a/runtime/onert/core/src/compiler/train/LoweredTrainableGraph.cc
+++ b/runtime/onert/core/src/compiler/train/LoweredTrainableGraph.cc
@@ -110,8 +110,8 @@ void LoweredTrainableGraph::lowerGraph(const CompilerOptions &options)
     [&](const onert::ir::OperationIndex &index, const onert::ir::IOperation &op) {
       if (op.opcode() == ir::OpCode::Permute)
       {
-        auto top = op_converter(index);
-        auto gen_index = _trainable_graph.replaceOperation(index, std::move(top));
+        auto trainable_op = op_converter(op);
+        auto gen_index = _trainable_graph.replaceOperation(index, std::move(trainable_op));
         UNUSED_RELEASE(gen_index);
         assert(gen_index == index);
       }

--- a/runtime/onert/core/src/compiler/train/TrainingCompiler.cc
+++ b/runtime/onert/core/src/compiler/train/TrainingCompiler.cc
@@ -113,8 +113,8 @@ std::shared_ptr<CompilerArtifact> TrainingCompiler::compile(void)
       // Convert operations to trainable operations
       auto converter = TrainableOperationConverter{*trainable_subg, _training_info};
       subg.operations().iterate(
-        [&](const onert::ir::OperationIndex &op_index, const onert::ir::IOperation &) {
-          auto trainable_op = converter(op_index);
+        [&](const onert::ir::OperationIndex &op_index, const onert::ir::IOperation &op) {
+          auto trainable_op = converter(op);
           auto gen_index = trainable_subg->replaceOperation(op_index, std::move(trainable_op));
           UNUSED_RELEASE(gen_index);
           assert(gen_index == op_index);

--- a/runtime/onert/core/src/compiler/train/UntrainableOperationConverter.cc
+++ b/runtime/onert/core/src/compiler/train/UntrainableOperationConverter.cc
@@ -31,9 +31,8 @@ UntrainableOperationConverter::UntrainableOperationConverter(ir::train::Trainabl
 }
 
 std::unique_ptr<ir::train::ITrainableOperation> UntrainableOperationConverter::
-operator()(const ir::OperationIndex &index)
+operator()(const ir::IOperation &op)
 {
-  const auto &op = _tgraph.operations().at(index);
   op.accept(*this);
 
   return std::move(_return_op);

--- a/runtime/onert/core/src/compiler/train/UntrainableOperationConverter.h
+++ b/runtime/onert/core/src/compiler/train/UntrainableOperationConverter.h
@@ -34,7 +34,7 @@ class UntrainableOperationConverter : public ir::OperationVisitor
 {
 public:
   UntrainableOperationConverter(ir::train::TrainableGraph &tgraph);
-  std::unique_ptr<ir::train::ITrainableOperation> operator()(const ir::OperationIndex &index);
+  std::unique_ptr<ir::train::ITrainableOperation> operator()(const ir::IOperation &op);
 
 #define OP(InternalName) void visit(const ir::operation::InternalName &node);
 #include "ir/Operations.lst"


### PR DESCRIPTION
This commit makes TrainablerOperationConvert convert op instead of index.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>