### PR TITLE
[onert] Disallow dynamic shape of tensors in train backend.

### DIFF
--- a/runtime/onert/backend/train/Tensor.h
+++ b/runtime/onert/backend/train/Tensor.h
@@ -26,7 +26,23 @@ namespace backend
 namespace train
 {
 
-using Tensor = basic::Tensor;
+// NOTE This class can be replaced with basic::Tensor if this backend supports dynamic tensors.
+class Tensor : public basic::Tensor
+{
+public:
+  Tensor() = delete;
+
+public:
+  Tensor(const ir::OperandInfo &info, const ir::Layout layout)
+    : basic::Tensor{info, layout, nullptr}
+  {
+    // DO NOTHING
+  }
+
+public:
+  bool applyShape(const ir::Shape &) override { return false; }
+};
+
 using ExternalTensor = basic::ExternalTensor;
 
 } // namespace train


### PR DESCRIPTION
This commit makes tensors in train backend not allow dynamic shape.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>