### PR TITLE
[onert] Remove copy from auto keyword

### DIFF
--- a/runtime/onert/backend/cl_common/include/cl_common/BackendContext.h
+++ b/runtime/onert/backend/cl_common/include/cl_common/BackendContext.h
@@ -144,7 +144,7 @@ protected:
     // 1. Scan DEF of outputs. If the DEF, allocate it
     // 2. Scan DEF of inputs. If variable tensor, allocate it
     // 3. Scan USE of inputs. Decrease the USE and deallocate if the USE is 0
-    for (const auto op_ind : _data.op_order)
+    for (const auto &op_ind : _data.op_order)
     {
       const auto &op = graph()->operations().at(op_ind);
       auto op_inputs = op.getInputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED;

--- a/runtime/onert/backend/cpu/BackendContext.cc
+++ b/runtime/onert/backend/cpu/BackendContext.cc
@@ -37,7 +37,7 @@ FunctionMap BackendContext::genKernels()
 {
   FunctionMap ret;
 
-  for (auto op_ind : _data.op_order)
+  for (auto &op_ind : _data.op_order)
   {
     auto fn_seq = kernel_gen->generate(op_ind);
     ret.emplace_back(op_ind, std::move(fn_seq));

--- a/runtime/onert/backend/cpu/KernelGenerator.cc
+++ b/runtime/onert/backend/cpu/KernelGenerator.cc
@@ -257,7 +257,7 @@ std::unique_ptr<exec::FunctionSequence> KernelGenerator::generate(ir::OperationI
   assert(_return_fn); // _return_fn must have been generated
   ret->append(std::move(_return_fn));
 
-  for (auto ind : (op.getInputs() | ir::Remove::UNDEFINED) + op.getOutputs())
+  for (auto &ind : (op.getInputs() | ir::Remove::UNDEFINED) + op.getOutputs())
   {
     auto portable_tensor = _tensor_reg->getPortableTensor(ind);
     if (portable_tensor)

--- a/runtime/onert/backend/gpu_cl/BackendContext.cc
+++ b/runtime/onert/backend/gpu_cl/BackendContext.cc
@@ -90,7 +90,7 @@ FunctionMap BackendContext::genKernels()
 {
   FunctionMap fn_map;
 
-  for (auto op_ind : _data.op_order)
+  for (auto &op_ind : _data.op_order)
   {
     auto fn_seq = kernel_gen->generate(op_ind);
     fn_map.emplace_back(op_ind, std::move(fn_seq));

--- a/runtime/onert/backend/gpu_cl/TensorManager.cc
+++ b/runtime/onert/backend/gpu_cl/TensorManager.cc
@@ -103,10 +103,10 @@ ir::OperandIndexMap<std::shared_ptr<operand::CLTensor>> &TensorManager::nonconst
 
 void TensorManager::iterate(const std::function<void(const ir::OperandIndex &)> &fn)
 {
-  for (auto it : _nonconst_mgr->tensors())
+  for (auto &it : _nonconst_mgr->tensors())
     fn(it.first);
 
-  for (auto it : _const_mgr->tensors())
+  for (auto &it : _const_mgr->tensors())
     fn(it.first);
 }
 

--- a/runtime/onert/backend/ruy/BackendContext.cc
+++ b/runtime/onert/backend/ruy/BackendContext.cc
@@ -37,7 +37,7 @@ FunctionMap BackendContext::genKernels()
 {
   FunctionMap ret;
 
-  for (auto op_ind : _data.op_order)
+  for (auto &op_ind : _data.op_order)
   {
     auto fn_seq = kernel_gen->generate(op_ind);
     ret.emplace_back(op_ind, std::move(fn_seq));

--- a/runtime/onert/backend/ruy/KernelGenerator.cc
+++ b/runtime/onert/backend/ruy/KernelGenerator.cc
@@ -55,7 +55,7 @@ std::unique_ptr<exec::FunctionSequence> KernelGenerator::generate(ir::OperationI
   assert(_return_fn); // _return_fn must have been generated
   ret->append(std::move(_return_fn));
 
-  for (auto ind : (op.getInputs() | ir::Remove::UNDEFINED) + op.getOutputs())
+  for (auto &ind : (op.getInputs() | ir::Remove::UNDEFINED) + op.getOutputs())
   {
     auto portable_tensor = _tensor_reg->getPortableTensor(ind);
     if (portable_tensor)

--- a/runtime/onert/backend/trix/BackendContext.cc
+++ b/runtime/onert/backend/trix/BackendContext.cc
@@ -37,7 +37,7 @@ FunctionMap BackendContext::genKernels()
 {
   FunctionMap ret;
 
-  for (auto op_ind : _data.op_order)
+  for (auto &op_ind : _data.op_order)
   {
     auto fn_seq = kernel_gen->generate(op_ind);
     ret.emplace_back(op_ind, std::move(fn_seq));

--- a/runtime/onert/backend/xnnpack/BackendContext.cc
+++ b/runtime/onert/backend/xnnpack/BackendContext.cc
@@ -37,7 +37,7 @@ FunctionMap BackendContext::genKernels()
 {
   FunctionMap ret;
 
-  for (auto op_ind : _data.op_order)
+  for (auto &op_ind : _data.op_order)
   {
     auto fn_seq = kernel_gen->generate(op_ind);
     ret.emplace_back(op_ind, std::move(fn_seq));

--- a/runtime/onert/backend/xnnpack/KernelGenerator.cc
+++ b/runtime/onert/backend/xnnpack/KernelGenerator.cc
@@ -69,7 +69,7 @@ std::unique_ptr<exec::FunctionSequence> KernelGenerator::generate(ir::OperationI
   assert(_return_fn); // _return_fn must have been generated
   ret->append(std::move(_return_fn));
 
-  for (auto ind : (op.getInputs() | ir::Remove::UNDEFINED) + op.getOutputs())
+  for (auto &ind : (op.getInputs() | ir::Remove::UNDEFINED) + op.getOutputs())
   {
     auto portable_tensor = _tensor_reg->getPortableTensor(ind);
     if (portable_tensor)

--- a/runtime/onert/core/include/util/Set.h
+++ b/runtime/onert/core/include/util/Set.h
@@ -145,7 +145,7 @@ public:
   Set<Element> operator-(const Set<Element> &other) const // Minus
   {
     auto ret = *this;
-    for (auto e : other)
+    for (auto &e : other)
     {
       ret.remove(e);
     }

--- a/runtime/onert/core/src/backend/builtin/BackendContext.cc
+++ b/runtime/onert/core/src/backend/builtin/BackendContext.cc
@@ -32,7 +32,7 @@ FunctionMap BackendContext::genKernels()
 {
   FunctionMap ret;
 
-  for (auto op_ind : _data.op_order)
+  for (auto &op_ind : _data.op_order)
   {
     auto fn_seq = kernel_gen->generate(op_ind);
     ret.emplace_back(op_ind, std::move(fn_seq));

--- a/runtime/onert/core/src/backend/builtin/KernelGenerator.cc
+++ b/runtime/onert/core/src/backend/builtin/KernelGenerator.cc
@@ -71,14 +71,14 @@ void KernelGenerator::visit(const ir::operation::If &node)
   const auto else_subg_index = node.param().else_subg_index;
 
   std::vector<backend::IPortableTensor *> input_tensors;
-  for (const auto input_index : node.getInputs())
+  for (const auto &input_index : node.getInputs())
   {
     auto input_tensor = getPortableTensor(input_index);
     input_tensors.emplace_back(input_tensor);
   }
 
   std::vector<backend::IPortableTensor *> output_tensors;
-  for (const auto output_index : node.getOutputs())
+  for (const auto &output_index : node.getOutputs())
   {
     auto output_tensor = getPortableTensor(output_index);
     output_tensors.emplace_back(output_tensor);
@@ -117,14 +117,14 @@ void KernelGenerator::visit(const ir::operation::While &node)
   // This op does not support input as a constant, because builtin backend does not have
   // TensorBuilder
   std::vector<backend::IPortableTensor *> input_tensors;
-  for (const auto input_index : node.getInputs())
+  for (const auto &input_index : node.getInputs())
   {
     auto input_tensor = getPortableTensor(input_index);
     input_tensors.emplace_back(input_tensor);
   }
 
   std::vector<backend::IPortableTensor *> output_tensors;
-  for (const auto output_index : node.getOutputs())
+  for (const auto &output_index : node.getOutputs())
   {
     auto output_tensor = getPortableTensor(output_index);
     output_tensors.emplace_back(output_tensor);

--- a/runtime/onert/core/src/compiler/ExecutorFactory.cc
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.cc
@@ -116,7 +116,7 @@ void initializeSubgraphIOTensors(compiler::ILoweredGraph &lowered_graph,
   }
   assert(builtin_tensor_reg);
 
-  for (auto ind : indices)
+  for (auto &ind : indices)
   {
     const auto &operand = lowered_graph.graph().operands().at(ind);
     auto tensor = std::make_unique<backend::builtin::IOTensor>(
@@ -214,7 +214,7 @@ createBackendContexts(compiler::ILoweredGraph &lgraph, bool linear_executor,
         // Add missing operands (externals)
         auto io_list = (operation.getInputs() + operation.getOutputs()) | ir::Remove::DUPLICATED |
                        ir::Remove::UNDEFINED;
-        for (auto operand_ind : io_list)
+        for (auto &operand_ind : io_list)
         {
           if (partial_graph.operands().exist(operand_ind))
             continue;
@@ -330,7 +330,7 @@ void ExecutorFactory::prepareMigrantTensors(compiler::ILoweredGraph &lowered_gra
     [&](const ir::OperationIndex &op_ind, const ir::IOperation &op) {
       auto lower_info = lowered_graph.lower_info().operation.getRawPtr(op_ind);
       auto &backend_ctx = backend_contexts.at(lower_info->backend());
-      for (auto ind :
+      for (auto &ind :
            (op.getInputs() + op.getOutputs()) | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED)
       {
         // If an Operation's input/output tensor does not have an own tensor object,
@@ -447,7 +447,7 @@ ExecutorFactory::createLinearExecutor(std::unique_ptr<compiler::LoweredGraph> lo
       uses_map[ind]++;
     }
 
-    for (const auto op_ind : order)
+    for (const auto &op_ind : order)
     {
       const auto &op = graph.operations().at(op_ind);
       auto op_inputs = op.getInputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED;

--- a/runtime/onert/core/src/compiler/Linear.cc
+++ b/runtime/onert/core/src/compiler/Linear.cc
@@ -37,7 +37,7 @@ std::vector<ir::OperationIndex> Linear::linearize(const compiler::ILoweredGraph 
 void Linear::dump(const compiler::ILoweredGraph &lowered_graph,
                   const std::vector<ir::OperationIndex> &order)
 {
-  for (const auto ind : order)
+  for (const auto &ind : order)
   {
     // TODO Could logging system can handle this? (Inserting prefix for each line)
     std::istringstream iss{dumper::text::formatOperation(lowered_graph.graph(), ind)};

--- a/runtime/onert/core/src/compiler/LoweredGraph.cc
+++ b/runtime/onert/core/src/compiler/LoweredGraph.cc
@@ -49,7 +49,7 @@ void LoweredGraph::lowerGraph(const CompilerOptions &options)
   // Build backend contexts
   auto &backend_manager = BackendManager::get();
   // Create contexts for other backends
-  for (auto backend_str : options.backend_list)
+  for (auto &backend_str : options.backend_list)
   {
     backend_manager.loadBackend(backend_str);
     auto backend = backend_manager.get(backend_str);
@@ -100,9 +100,9 @@ void LoweredGraph::lowerGraph(const CompilerOptions &options)
   pass::PassRunner{}.append(std::make_unique<pass::PermutationEliminationPass>(*this)).run();
 
   VERBOSE(LoweredGraph) << "Dump after all the passes" << std::endl;
-  for (auto operand : _graph.getInputs())
+  for (auto &operand : _graph.getInputs())
     VERBOSE(LoweredGraph) << "Graph Input : " << operand << std::endl;
-  for (auto operand : _graph.getOutputs())
+  for (auto &operand : _graph.getOutputs())
     VERBOSE(LoweredGraph) << "Graph Output : " << operand << std::endl;
   dumper::text::dumpLoweredGraph(*this);
 
@@ -135,12 +135,12 @@ void LoweredGraph::makeLowerInfo(const compiler::BackendResolver &backend_resolv
     // TODO Change setting layout of each backend at another place
     auto backend_layout = backend->config()->supportLayout(op, frontend_layout);
 
-    for (auto ind : op.getInputs() | ir::Remove::UNDEFINED)
+    for (auto &ind : op.getInputs() | ir::Remove::UNDEFINED)
     {
       auto &operand_li = lower_info().operand.at(ind);
       operand_li.addUsePermuteFactor(PermuteFactor{backend, backend_layout});
     }
-    for (auto ind : op.getOutputs() | ir::Remove::UNDEFINED)
+    for (auto &ind : op.getOutputs() | ir::Remove::UNDEFINED)
     {
       auto &operand_li = lower_info().operand.at(ind);
       operand_li.addDefPermuteFactor(PermuteFactor{backend, backend_layout});
@@ -152,13 +152,13 @@ void LoweredGraph::makeLowerInfo(const compiler::BackendResolver &backend_resolv
   // Handle graph inputs and outputs
   const auto builtin_backend = BackendManager::get().getBuiltin();
   auto factor = PermuteFactor{builtin_backend, _graph.layout()};
-  for (auto index : _graph.getInputs() | ir::Remove::UNDEFINED)
+  for (auto &index : _graph.getInputs() | ir::Remove::UNDEFINED)
   {
     auto &operand_li = lower_info().operand.at(index);
     assert(operand_li.def_factors().empty());
     operand_li.addDefPermuteFactor(factor);
   }
-  for (auto index : _graph.getOutputs() | ir::Remove::UNDEFINED)
+  for (auto &index : _graph.getOutputs() | ir::Remove::UNDEFINED)
   {
     auto &operand_li = lower_info().operand.at(index);
     operand_li.addUsePermuteFactor(factor);
@@ -204,7 +204,7 @@ void LoweredGraph::dumpLowerInfo()
 
       auto factors_to_string = [](const PermuteFactorSet &factors) {
         std::string str;
-        for (auto factor : factors)
+        for (auto &factor : factors)
         {
           str += factor.backend()->config()->id();
           str += "(" + to_string(factor.layout()) + ")";
@@ -216,7 +216,7 @@ void LoweredGraph::dumpLowerInfo()
       auto operation_index_set_to_string = [](const ir::OperationIndexSet &operations) {
         std::stringstream sstream;
         sstream << "{ ";
-        for (auto op : operations)
+        for (auto &op : operations)
           sstream << op << " ";
         sstream << "}";
         return sstream.str();

--- a/runtime/onert/core/src/compiler/ManualScheduler.cc
+++ b/runtime/onert/core/src/compiler/ManualScheduler.cc
@@ -42,7 +42,7 @@ std::unique_ptr<BackendResolver> ManualScheduler::schedule(const ir::Graph &grap
 
   // This fallback will be used in case that `backend_for_all` is unavailable
   auto fallback = [&]() -> const backend::Backend * {
-    for (auto backend_id : _options.backend_list)
+    for (auto &backend_id : _options.backend_list)
     {
       auto backend = resolveBackend(backend_id);
       if (backend)

--- a/runtime/onert/core/src/compiler/StaticShapeInferer.cc
+++ b/runtime/onert/core/src/compiler/StaticShapeInferer.cc
@@ -102,7 +102,7 @@ void StaticShapeInferer::infer()
 bool StaticShapeInferer::checkDynamicInput(const ir::IOperation &op)
 {
   const auto &operands = _lowered_subg->graph().operands();
-  for (auto input_idx : op.getInputs() | ir::Remove::UNDEFINED | ir::Remove::DUPLICATED)
+  for (auto &input_idx : op.getInputs() | ir::Remove::UNDEFINED | ir::Remove::DUPLICATED)
   {
     if (operands.at(input_idx).info().isDynamic())
     {
@@ -116,7 +116,7 @@ bool StaticShapeInferer::checkDynamicInput(const ir::IOperation &op)
 bool StaticShapeInferer::checkDynamicOutput(const ir::IOperation &op)
 {
   auto &operands = _lowered_subg->graph().operands();
-  for (auto output_idx : op.getOutputs() | ir::Remove::UNDEFINED)
+  for (auto &output_idx : op.getOutputs() | ir::Remove::UNDEFINED)
   {
     if (operands.at(output_idx).info().isDynamic())
     {
@@ -129,7 +129,7 @@ bool StaticShapeInferer::checkDynamicOutput(const ir::IOperation &op)
 void StaticShapeInferer::setDynamicOutput(const ir::IOperation &op)
 {
   auto &operands = _lowered_subg->graph().operands();
-  for (auto output_idx : op.getOutputs() | ir::Remove::UNDEFINED)
+  for (auto &output_idx : op.getOutputs() | ir::Remove::UNDEFINED)
   {
     operands.at(output_idx).info().setDynamic();
   }
@@ -1122,7 +1122,7 @@ void StaticShapeInferer::visit(const ir::operation::Split &op)
   auto outputs = op.getOutputs();
   if (!axis.isConstant())
   {
-    for (auto output_idx : outputs)
+    for (auto &output_idx : outputs)
     {
       ir::Operand &output = operands.at(output_idx);
       output.info().setDynamic();

--- a/runtime/onert/core/src/compiler/pass/ConstantInsertionPass.cc
+++ b/runtime/onert/core/src/compiler/pass/ConstantInsertionPass.cc
@@ -35,7 +35,7 @@ void ConstantInsertionPass::callback(const ir::OperationIndex &node_index, ir::I
   const auto layout = op_lower_info->layout();
   const auto factor = PermuteFactor{backend, layout};
 
-  for (const auto input : node.getInputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED)
+  for (const auto &input : node.getInputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED)
   {
     auto &object = _graph.operands().at(input);
 

--- a/runtime/onert/core/src/compiler/pass/ConstantLoweringPass.cc
+++ b/runtime/onert/core/src/compiler/pass/ConstantLoweringPass.cc
@@ -37,7 +37,7 @@ void ConstantLoweringPass::callback(const ir::OperationIndex &node_index, ir::IO
   const auto factor = PermuteFactor{backend, layout};
 
   // Now this runtime does not support the node making output of operation as constant
-  for (const auto input : node.getInputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED)
+  for (const auto &input : node.getInputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED)
   {
     auto &object = _graph.operands().at(input);
     if (object.isConstant())

--- a/runtime/onert/core/src/compiler/pass/ConstantOutputPass.cc
+++ b/runtime/onert/core/src/compiler/pass/ConstantOutputPass.cc
@@ -49,7 +49,7 @@ void ConstantOutputPass::callback(const ir::OperandIndex &ind, ir::Operand &obj)
 
   // Make the operations that uses this operand to use the generated operand
   auto orig_uses = obj.getUses();
-  for (auto use : orig_uses)
+  for (auto &use : orig_uses)
   {
     permute_input_obj.insertUse(use);
     obj.removeUse(use);

--- a/runtime/onert/core/src/compiler/pass/PermutationInsertionPass.cc
+++ b/runtime/onert/core/src/compiler/pass/PermutationInsertionPass.cc
@@ -54,13 +54,13 @@ void PermutationInsertionPass::callback(const ir::OperandIndex &index, ir::Opera
   std::unordered_map<PermuteFactor, ir::OperandIndex> factor_to_index;
   {
     assert(operand_li->def_factors().size() == 1);
-    for (auto factor : operand_li->def_factors())
+    for (auto &factor : operand_li->def_factors())
     {
       factor_to_index.emplace(factor, index);
     }
 
     auto insert_set = operand_li->use_factors() - operand_li->def_factors();
-    for (auto factor : insert_set)
+    for (auto &factor : insert_set)
     {
       const auto permute_operation_index = insertPermute(index, factor);
       permute_indexes.push_back(permute_operation_index);
@@ -75,7 +75,7 @@ void PermutationInsertionPass::callback(const ir::OperandIndex &index, ir::Opera
     std::list<ir::OperationIndex> remove_list;
 
     auto uses = object.getUses();
-    for (auto use : uses)
+    for (auto &use : uses)
     {
       // If permute operation, ignore it
       if (std::find(permute_indexes.begin(), permute_indexes.end(), use) != permute_indexes.end())

--- a/runtime/onert/core/src/compiler/pass/UnusedOperandEliminationPass.cc
+++ b/runtime/onert/core/src/compiler/pass/UnusedOperandEliminationPass.cc
@@ -38,14 +38,14 @@ void UnusedOperandEliminationPass::run()
   util::Set<ir::OperandIndex> used;
 
   _graph.operations().iterate([&](const ir::OperationIndex &, const ir::IOperation &node) {
-    for (auto ind : (node.getInputs() + node.getOutputs()) | ir::Remove::UNDEFINED)
+    for (auto &ind : (node.getInputs() + node.getOutputs()) | ir::Remove::UNDEFINED)
     {
       used.add(ind);
     }
   });
 
   // Graph's inputs/outputs are always considered as used
-  for (auto ind : (_graph.getInputs() + _graph.getOutputs()) | ir::Remove::UNDEFINED)
+  for (auto &ind : (_graph.getInputs() + _graph.getOutputs()) | ir::Remove::UNDEFINED)
   {
     used.add(ind);
   }

--- a/runtime/onert/core/src/dumper/dot/DotBuilder.cc
+++ b/runtime/onert/core/src/dumper/dot/DotBuilder.cc
@@ -47,7 +47,7 @@ void DotBuilder::add(const Node &node)
   _dot << node.id();
   std::stringstream ss;
   _dot << "[";
-  for (auto attr : node.attributes())
+  for (auto &attr : node.attributes())
   {
     _dot << attr.first << "=\"" << attr.second << "\" ";
   }

--- a/runtime/onert/core/src/dumper/dot/DotDumper.cc
+++ b/runtime/onert/core/src/dumper/dot/DotDumper.cc
@@ -101,7 +101,7 @@ generate_dot_operations(const ir::Graph &graph,
   operations.iterate([&](const ir::OperationIndex &index, const ir::IOperation &op) {
     auto node = std::make_unique<Operation>(index, op);
 
-    for (auto input : op.getInputs())
+    for (auto &input : op.getInputs())
     {
       using onert::dumper::dot::Operand;
 
@@ -113,7 +113,7 @@ generate_dot_operations(const ir::Graph &graph,
       input_node->addOutEdge(node.get());
     }
 
-    for (auto output : op.getOutputs() | ir::Remove::UNDEFINED)
+    for (auto &output : op.getOutputs() | ir::Remove::UNDEFINED)
     {
       using onert::dumper::dot::Operand;
       auto &output_node = dot_operands.at(output);

--- a/runtime/onert/core/src/dumper/text/GraphDumper.cc
+++ b/runtime/onert/core/src/dumper/text/GraphDumper.cc
@@ -37,7 +37,7 @@ namespace
 std::string formatOperandIndexSequence(const ir::OperandIndexSequence &seq)
 {
   std::vector<std::string> strs;
-  for (auto ind : seq)
+  for (auto &ind : seq)
     strs.push_back(dumper::text::formatOperandBrief(ind));
   return nnfw::misc::join(strs.begin(), strs.end(), ", ");
 }
@@ -82,7 +82,7 @@ void dumpGraph(const ir::Graph &graph)
 {
   VERBOSE(GraphDumper) << "{\n";
   auto ops_topol = graph.topolSortOperations();
-  for (auto op_ind : ops_topol)
+  for (auto &op_ind : ops_topol)
   {
     const auto &op = graph.operations().at(op_ind);
     VERBOSE(GraphDumper) << "  " << formatOperation(op, op_ind) << "\n";

--- a/runtime/onert/core/src/exec/DataflowExecutor.cc
+++ b/runtime/onert/core/src/exec/DataflowExecutor.cc
@@ -104,7 +104,7 @@ DataflowExecutor::DataflowExecutor(std::unique_ptr<compiler::LoweredGraph> lower
 
   operations.iterate([&](const ir::OperationIndex &op_ind, const ir::IOperation &op) {
     auto job_index = op_to_job[op_ind];
-    for (auto output : op.getOutputs())
+    for (auto &output : op.getOutputs())
     {
       // Update output and input info
       operations.iterate([&](const ir::OperationIndex &op_cur_ind, const ir::IOperation &op_cur) {

--- a/runtime/onert/core/src/exec/DynamicShapeInferer.cc
+++ b/runtime/onert/core/src/exec/DynamicShapeInferer.cc
@@ -300,7 +300,7 @@ void DynamicShapeInferer::visit(const ir::operation::Concat &op)
 
   // getting output shape
   onert::shape_inference::Shapes in_shapes;
-  for (auto input_ind : op.getInputs())
+  for (auto &input_ind : op.getInputs())
   {
     auto input = _tensor_registry->getITensor(input_ind);
     ir::Shape shape = input->getShape();
@@ -1042,7 +1042,7 @@ void DynamicShapeInferer::visit(const ir::operation::Split &op)
 
   // Return if all tensors are not dynamic
   bool has_dynamic = false;
-  for (const auto output_idx : op.getOutputs())
+  for (const auto &output_idx : op.getOutputs())
   {
     auto output = _tensor_registry->getITensor(output_idx);
     has_dynamic |= output->is_dynamic();

--- a/runtime/onert/core/src/exec/ExecutorBase.cc
+++ b/runtime/onert/core/src/exec/ExecutorBase.cc
@@ -35,7 +35,7 @@ ExecutorBase::ExecutorBase(std::unique_ptr<compiler::LoweredGraph> &&lowered_gra
 {
   auto build_tensor_list = [&](const auto &ind_seq, auto &tensors) {
     assert(tensors.empty());
-    for (auto ind : ind_seq)
+    for (auto &ind : ind_seq)
     {
       backend::ITensor *tensor = tensor_regs.getITensor(ind);
       assert(tensor != nullptr);

--- a/runtime/onert/core/src/exec/Executors.cc
+++ b/runtime/onert/core/src/exec/Executors.cc
@@ -147,7 +147,7 @@ void Executors::checkSupportedMultimodel() const
 
   // Assumption: edges
   // m1 < m2, s1 == 0 and s2 == 0 if edge 'm1:s1:o1 -> m2:s2:o2'
-  for (auto edge : _model_edges->edges)
+  for (auto &edge : _model_edges->edges)
   {
     auto const model_from = std::get<ir::ModelIndex>(edge.from);
     auto const model_to = std::get<ir::ModelIndex>(edge.to);

--- a/runtime/onert/core/src/exec/LinearExecutor.h
+++ b/runtime/onert/core/src/exec/LinearExecutor.h
@@ -52,7 +52,7 @@ public:
                  const std::vector<ir::OperationIndex> &order, const util::TracingCtx *tracing_ctx)
     : ExecutorBase{std::move(lowered_graph), std::move(backend_contexts), tensor_regs, tracing_ctx}
   {
-    for (auto index : order)
+    for (auto &index : order)
     {
       _code.emplace_back(std::move(code_map.at(index)));
     }

--- a/runtime/onert/core/src/ir/Graph.cc
+++ b/runtime/onert/core/src/ir/Graph.cc
@@ -46,10 +46,10 @@ bool Graph::checkOperandsForOperation(const IOperation &operation)
 {
   auto inputs = operation.getInputs() | ir::Remove::UNDEFINED | ir::Remove::DUPLICATED;
   auto outputs = operation.getOutputs() | ir::Remove::UNDEFINED | ir::Remove::DUPLICATED;
-  for (auto input : inputs)
+  for (auto &input : inputs)
     if (!operands().exist(input))
       return false;
-  for (auto input : outputs)
+  for (auto &input : outputs)
     if (!operands().exist(input))
       return false;
   return true;
@@ -60,9 +60,9 @@ void Graph::linkOperandToOperation(OperationIndex index, const IOperation &opera
   auto inputs = operation.getInputs() | ir::Remove::UNDEFINED | ir::Remove::DUPLICATED;
   auto outputs = operation.getOutputs() | ir::Remove::UNDEFINED | ir::Remove::DUPLICATED;
 
-  for (auto input : inputs)
+  for (auto &input : inputs)
     operands().at(input).insertUse(index);
-  for (auto output : outputs)
+  for (auto &output : outputs)
     operands().at(output).setDef(index);
 }
 
@@ -169,12 +169,12 @@ void Graph::initializeUseDef()
 {
   operations().iterate([&](const OperationIndex &index, const IOperation &node) -> void {
     auto outputs = node.getOutputs();
-    for (auto output : outputs | ir::Remove::UNDEFINED)
+    for (auto &output : outputs | ir::Remove::UNDEFINED)
     {
       operands().at(output).setDef(index);
     }
 
-    for (auto input : node.getInputs() | ir::Remove::UNDEFINED)
+    for (auto &input : node.getInputs() | ir::Remove::UNDEFINED)
     {
       operands().at(input).insertUse(index);
     }
@@ -194,7 +194,7 @@ std::vector<ir::OperationIndex> Graph::topolSortOperations() const
       return;
     unvisited.remove(index);
 
-    for (const auto output : op.getOutputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED)
+    for (const auto &output : op.getOutputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED)
     {
       const auto &operand = operands().at(output);
       for (const auto &use : operand.getUses())

--- a/runtime/onert/core/src/ir/OperationValidator.cc
+++ b/runtime/onert/core/src/ir/OperationValidator.cc
@@ -163,7 +163,7 @@ void OperationValidator::visit(const operation::Concat &node)
 {
   const auto output_index{node.getOutputs().at(0)};
 
-  for (auto input_index : node.getInputs())
+  for (auto &input_index : node.getInputs())
   {
     OP_REQUIRES(isSameType(input_index, output_index));
 

--- a/runtime/onert/core/src/ir/verifier/Verifier.cc
+++ b/runtime/onert/core/src/ir/verifier/Verifier.cc
@@ -77,7 +77,7 @@ bool EdgeChecker::verify(const Graph &graph) const noexcept
   auto &operations = graph.operations();
   uint32_t errors = 0;
   operations.iterate([&](const OperationIndex &index, const IOperation &node) {
-    for (auto operand_index : node.getInputs() | ir::Remove::UNDEFINED)
+    for (auto &operand_index : node.getInputs() | ir::Remove::UNDEFINED)
     {
       try
       {
@@ -98,7 +98,7 @@ bool EdgeChecker::verify(const Graph &graph) const noexcept
         errors += 1;
       }
     }
-    for (auto operand_index : node.getOutputs() | ir::Remove::UNDEFINED)
+    for (auto &operand_index : node.getOutputs() | ir::Remove::UNDEFINED)
     {
       try
       {
@@ -127,7 +127,7 @@ bool EdgeChecker::verify(const Graph &graph) const noexcept
 
 bool InputOutputChecker::verify(const Graph &graph) const noexcept
 {
-  for (auto operand_ind :
+  for (auto &operand_ind :
        (graph.getInputs() + graph.getOutputs()) | Remove::DUPLICATED | Remove::UNDEFINED)
   {
     if (!graph.operands().exist(operand_ind))

--- a/runtime/onert/core/src/util/MDTableEventWriter.cc
+++ b/runtime/onert/core/src/util/MDTableEventWriter.cc
@@ -124,7 +124,7 @@ struct Graph : public MDContent
   void setOperations(const std::map<std::string, Operation> &name_to_op)
   {
     uint64_t graph_latency = end_ts - begin_ts;
-    for (auto it : name_to_op)
+    for (auto &it : name_to_op)
     {
       auto op = it.second;
       op.graph_latency = graph_latency;
@@ -172,7 +172,7 @@ struct Graph : public MDContent
     writeMDTableRow(os, op_headers_line);
 
     // Operation's contents
-    for (auto op : ops)
+    for (auto &op : ops)
     {
       op.write(os);
     }

--- a/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksModel.cc
+++ b/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksModel.cc
@@ -262,7 +262,7 @@ void ANeuralNetworksModel::setOptionalOperand(const onert::ir::OperandIndex idx)
 void ANeuralNetworksModel::fillOptionalOperand(void)
 {
   _graph->operations().iterate([&](const onert::ir::OperationIndex &, onert::ir::IOperation &node) {
-    for (auto input : node.getInputs())
+    for (auto &input : node.getInputs())
     {
       // TODO fill default value for optional operands
       if (_optional_operands.find(input) != _optional_operands.end())


### PR DESCRIPTION
This commit removes compiler and analysis warning from copying on auto keyword by adding &.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>