### PR TITLE
[onert] Convert Pool2D Op to trainable

### DIFF
--- a/runtime/onert/core/src/compiler/train/TrainableOperationConverter.cc
+++ b/runtime/onert/core/src/compiler/train/TrainableOperationConverter.cc
@@ -61,6 +61,11 @@ void TrainableOperationConverter::visit(const ir::operation::Permute &node)
   _return_op = std::make_unique<ir::train::operation::Permute>(node);
 }
 
+void TrainableOperationConverter::visit(const ir::operation::Pool2D &node)
+{
+  _return_op = std::make_unique<ir::train::operation::Pool2D>(node);
+}
+
 void TrainableOperationConverter::visit(const ir::operation::Reshape &node)
 {
   _return_op = std::make_unique<ir::train::operation::Reshape>(node);

--- a/runtime/onert/core/src/compiler/train/TrainableOperationConverter.h
+++ b/runtime/onert/core/src/compiler/train/TrainableOperationConverter.h
@@ -41,6 +41,7 @@ private:
   void visit(const ir::operation::ElementwiseActivation &) override;
   void visit(const ir::operation::Loss &node) override;
   void visit(const ir::operation::Permute &node) override;
+  void visit(const ir::operation::Pool2D &node) override;
   void visit(const ir::operation::Reshape &) override;
   void visit(const ir::operation::Softmax &) override;
 


### PR DESCRIPTION
This commit converts Pool2D Op to trainable.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Related comment: https://github.com/Samsung/ONE/pull/11003#issuecomment-1623588185