### PR TITLE
[luci/pass] Change names in FuseGeluPass.test

### DIFF
--- a/compiler/luci/pass/src/FuseGeluPass.test.cpp
+++ b/compiler/luci/pass/src/FuseGeluPass.test.cpp
@@ -99,10 +99,10 @@ protected:
   luci::CircleConst *_const_half = nullptr;
 };
 
-class FuseGeluTestGraph : public TestIOGraph, public GeluGraphlet
+class FuseGeluTestGraph1 : public TestIOGraph, public GeluGraphlet
 {
 public:
-  FuseGeluTestGraph() = default;
+  FuseGeluTestGraph1() = default;
 
   void init(void)
   {
@@ -161,9 +161,9 @@ TEST(FuseGeluPassTest, name)
   ASSERT_NE(nullptr, name);
 }
 
-TEST(FuseGeluPassTest, fuse)
+TEST(FuseGeluPassTest, fuse_pattern1)
 {
-  FuseGeluTestGraph g;
+  FuseGeluTestGraph1 g;
   luci::FuseGeluPass pass;
 
   g.init();


### PR DESCRIPTION
This PR refactors FuseGeluPass.test to add more patterns at future.

for issue: https://github.com/Samsung/ONE/issues/11002
from draft: https://github.com/Samsung/ONE/pull/11016

ONE-DCO-1.0-Signed-off-by: Artem Balyshev <a.balyshev@samsung.com>