### PR TITLE
[onert] Add derivative info to TrainableGraph

### DIFF
--- a/runtime/onert/core/include/ir/train/TrainableGraph.h
+++ b/runtime/onert/core/include/ir/train/TrainableGraph.h
@@ -83,8 +83,22 @@ public:
   OperationIndex replaceOperation(OperationIndex index,
                                   std::unique_ptr<ITrainableOperation> &&operation);
 
+  /**
+   * @brief Add a derivative to the graph with the given index and object
+   *
+   * If the given index is available, it succeeds. And @c derivative is moved which invalidates the
+   * caller's pointer. If the given index is already taken, it fails. And @c derivative will not be
+   * moved so the caller's pointer will be still valid.
+   *
+   * @param[in] index      Index to be added
+   * @param[in] derivative Derivative operand to be added
+   * @return OperandIndex @c index if successful, UNDEFINED otherwise
+   */
+  OperandIndex addDerivative(OperandIndex index, std::unique_ptr<Operand> &&derivative);
+
 public:
   void changeShape(const OperandIndex &ind, const ir::Shape &new_shape) override;
+  void changeDerivativeShape(const OperandIndex &ind, const ir::Shape &new_shape);
   void addInput(const OperandIndex &ind, const std::string &name = "");
   void addOutput(const OperandIndex &ind, const std::string &name = "");
   void verify() const;
@@ -104,6 +118,7 @@ public:
   const Operands &operands() const override { return _graph.operands(); }
   Operands &operands() { return _graph.operands(); } // TODO Remove this non-const accessor
   const Operations &operations() const override { return _graph.operations(); }
+  const Operands &derivatives() const { return _derivatives; }
   Layout layout() const { return _graph.layout(); }
   const Graph &graph() const { return _graph; }
 
@@ -116,6 +131,7 @@ public:
 
 private:
   Graph _graph;
+  Operands _derivatives;
 };
 
 } // namespace train

--- a/runtime/onert/core/src/compiler/train/StaticDerivativeShapeInferer.cc
+++ b/runtime/onert/core/src/compiler/train/StaticDerivativeShapeInferer.cc
@@ -69,6 +69,20 @@ bool StaticDerivativeShapeInferer::checkDynamicInput(const ir::IOperation &op)
   return false;
 }
 
+void StaticDerivativeShapeInferer::setShape(const ir::OperandIndex &index, const ir::Shape &shape)
+{
+  auto &tgraph = _lowered_subg->trainable_graph();
+
+  if (tgraph.derivatives().exist(index))
+    tgraph.changeDerivativeShape(index, shape);
+  else
+  {
+    // NOTE This code assumes the types are always the same, but I'm not sure.
+    const auto &type = tgraph.operands().at(index).typeInfo();
+    tgraph.addDerivative(index, std::make_unique<ir::Operand>(shape, type));
+  }
+}
+
 void StaticDerivativeShapeInferer::visit(const ir::train::operation::Conv2D &)
 {
   // NYI

--- a/runtime/onert/core/src/compiler/train/StaticDerivativeShapeInferer.h
+++ b/runtime/onert/core/src/compiler/train/StaticDerivativeShapeInferer.h
@@ -57,6 +57,7 @@ public:
 
 private:
   bool checkDynamicInput(const ir::IOperation &op);
+  void setShape(const ir::OperandIndex &index, const ir::Shape &shape);
 
 private:
   void visit(const ir::train::operation::Conv2D &op) override;

--- a/runtime/onert/core/src/ir/train/TrainableGraph.cc
+++ b/runtime/onert/core/src/ir/train/TrainableGraph.cc
@@ -54,6 +54,12 @@ OperationIndex TrainableGraph::replaceOperation(OperationIndex index,
   return _graph.replaceOperation(index, std::move(operation));
 }
 
+OperandIndex TrainableGraph::addDerivative(OperandIndex index,
+                                           std::unique_ptr<Operand> &&derivative)
+{
+  return _derivatives.push(std::move(derivative), index);
+}
+
 IOIndex TrainableGraph::getInputIndex(const std::string &name) const
 {
   return _graph.getInputIndex(name);
@@ -67,6 +73,12 @@ IOIndex TrainableGraph::getOutputIndex(const std::string &name) const
 void TrainableGraph::changeShape(const OperandIndex &index, const ir::Shape &new_shape)
 {
   _graph.changeShape(index, new_shape);
+}
+
+void TrainableGraph::changeDerivativeShape(const OperandIndex &index, const ir::Shape &new_shape)
+{
+  assert(_derivatives.exist(index));
+  _derivatives.at(index).info().shape(new_shape);
 }
 
 void TrainableGraph::addInput(const OperandIndex &ind, const std::string &name)


### PR DESCRIPTION
This commit allows to append derivative information in TrainableGraph.
  - Introduce derivative operands into TrainableGraph
  - Add setting shape of derivative in ShapeDerivativeShapeInferer

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>