### PR TITLE
[tools/onert_train] Support multiple input in rawdataloader test

### DIFF
--- a/tests/tools/onert_train/test/rawdataloader.test.cc
+++ b/tests/tools/onert_train/test/rawdataloader.test.cc
@@ -53,29 +53,35 @@ public:
     }
   }
 
-  template <typename T> const std::string &generateInputData(const std::vector<T> &data)
+  template <typename T>
+  const std::string &generateInputData(const std::vector<std::vector<T>> &data)
   {
     generateData(_input_file, data);
     return _input_file;
   }
 
-  template <typename T> const std::string &generateExpectedData(const std::vector<T> &data)
+  template <typename T>
+  const std::string &generateExpectedData(const std::vector<std::vector<T>> &data)
   {
     generateData(_expected_file, data);
     return _expected_file;
   }
 
 private:
-  template <typename T> void generateData(const std::string &name, const std::vector<T> &data)
+  template <typename T>
+  void generateData(const std::string &name, const std::vector<std::vector<T>> &data)
   {
     try
     {
       std::ofstream file(name, std::ios::binary);
-      for (uint32_t i = 0; i < _data_length; ++i)
+      for (uint32_t i = 0; i < data.size(); ++i)
       {
-        for (uint32_t j = 0; j < data.size(); ++j)
+        for (uint32_t j = 0; j < _data_length; ++j)
         {
-          file.write(reinterpret_cast<const char *>(&data[j]), sizeof(data[j]));
+          for (uint32_t k = 0; k < data[i].size(); ++k)
+          {
+            file.write(reinterpret_cast<const char *>(&data[i][k]), sizeof(data[i][k]));
+          }
         }
       }
     }
@@ -124,16 +130,25 @@ TEST_F(RawDataLoaderTest, loadDatas_1)
   std::vector<nnfw_tensorinfo> expected_infos{expected_info};
 
   // Generate test data
-  std::vector<uint32_t> in(num_input * num_elems(&in_info));
-  std::generate(in.begin(), in.end(), [] {
-    static uint32_t i = 0;
-    return i++;
-  });
-  std::vector<uint32_t> expected(num_expected * num_elems(&expected_info));
-  std::generate(expected.begin(), expected.end(), [in] {
-    auto sum = std::accumulate(in.begin(), in.end(), 0);
-    return sum;
-  });
+  std::vector<std::vector<uint32_t>> in(num_input);
+  for (uint32_t i = 0; i < num_input; ++i)
+  {
+    in[i].resize(num_elems(&in_infos[i]));
+    std::generate(in[i].begin(), in[i].end(), [this] {
+      static uint32_t i = 0;
+      return i++;
+    });
+  }
+
+  std::vector<std::vector<uint32_t>> expected(num_expected);
+  for (uint32_t i = 0; i < num_expected; ++i)
+  {
+    expected[i].resize(num_elems(&expected_infos[i]));
+    std::generate(expected[i].begin(), expected[i].end(), [in, i] {
+      auto sum = std::accumulate(in[i].begin(), in[i].end(), 0);
+      return sum;
+    });
+  }
 
   // Generate test data file
   DataFileGenerator file_gen(data_length);
@@ -147,14 +162,14 @@ TEST_F(RawDataLoaderTest, loadDatas_1)
   {
     for (uint32_t j = 0; j < batch_size; ++j)
     {
-      expected_in[i].insert(expected_in[i].end(), in.begin(), in.end());
+      expected_in[i].insert(expected_in[i].end(), in[i].begin(), in[i].end());
     }
   }
   for (uint32_t i = 0; i < num_expected; ++i)
   {
     for (uint32_t j = 0; j < batch_size; ++j)
     {
-      expected_ex[i].insert(expected_ex[i].end(), expected.begin(), expected.end());
+      expected_ex[i].insert(expected_ex[i].end(), expected[i].begin(), expected[i].end());
     }
   }
 
@@ -196,7 +211,7 @@ TEST_F(RawDataLoaderTest, loadDatas_1)
       {
         for (uint32_t k = 0; k < num_elem; ++k)
         {
-          auto inbufs = reinterpret_cast<uint32_t *>(inputs[j].data()) + k;
+          auto inbufs = reinterpret_cast<uint32_t *>(inputs[h * batch_size + j].data()) + k;
           gen_in[h].emplace_back(*inbufs);
         }
       }
@@ -209,7 +224,7 @@ TEST_F(RawDataLoaderTest, loadDatas_1)
       {
         for (uint32_t k = 0; k < num_elem; ++k)
         {
-          auto exbufs = reinterpret_cast<uint32_t *>(expecteds[j].data()) + k;
+          auto exbufs = reinterpret_cast<uint32_t *>(expecteds[h * batch_size + j].data()) + k;
           gen_ex[h].emplace_back(*exbufs);
         }
       }


### PR DESCRIPTION
This commit supports multiple input and expected output in rawdataloader test. This change connets sample data by input as much as data length to temporary file.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Draft : #11027 