### PR TITLE
[one-cmds] Overwriting commands over given configuration on one-codegen

### DIFF
--- a/compiler/one-cmds/dummy-driver/src/dummyV2-compile.cpp
+++ b/compiler/one-cmds/dummy-driver/src/dummyV2-compile.cpp
@@ -35,7 +35,10 @@ int main(int argc, char **argv)
   std::string argv_1{argv[1]};
 
   if (opt_o != argv_1)
+  {
+    std::cout << "dummyV2-compile: Invalid option" << std::endl;
     return EXIT_FAILURE;
+  }
 
   std::string output_name{argv[2]};
   std::ofstream outfile(output_name);

--- a/compiler/one-cmds/one-codegen
+++ b/compiler/one-cmds/one-codegen
@@ -56,11 +56,23 @@ def _get_parser(backends_list):
     return parser
 
 
-def _verify_arg(parser, args, cfg_args):
+def _verify_arg(parser, args, cfg_args, backend_args, unknown_args):
     """verify given arguments"""
     cmd_backend_exist = oneutils.is_valid_attr(args, 'backend')
     cfg_backend_exist = oneutils.is_valid_attr(cfg_args, 'backend')
     cfg_backends_exist = oneutils.is_valid_attr(cfg_args, 'backends')
+
+    # check if required arguments is given
+    missing = []
+    if not cmd_backend_exist and not cfg_backend_exist and not cfg_backends_exist:
+        missing.append('-b/--backend')
+    if len(missing):
+        parser.error('the following arguments are required: ' + ' '.join(missing))
+
+    if not oneutils.is_valid_attr(args, 'config'):
+        if not backend_args and not unknown_args:
+            parser.error('commands for the backend is missing.')
+
     if cfg_backend_exist and cfg_backends_exist:
         parser.error(
             '\'backend\' option and \'backends\' option cannot be used simultaneously.')
@@ -70,12 +82,8 @@ def _verify_arg(parser, args, cfg_args):
         if args.backend != cfg_args.backend:
             parser.error('Not found the command of given backend')
 
-    # check if required arguments is given
-    missing = []
-    if not cmd_backend_exist and not cfg_backend_exist and not cfg_backends_exist:
-        missing.append('-b/--backend')
-    if len(missing):
-        parser.error('the following arguments are required: ' + ' '.join(missing))
+    if cfg_backend_exist and not oneutils.is_valid_attr(cfg_args, 'command'):
+        parser.error('\'command\' key is missing in the configuration file.')
 
     if cfg_backends_exist:
         cfg_backends = getattr(cfg_args, 'backends').split(',')
@@ -134,7 +142,7 @@ def main():
     # oneutils.parse_cfg(args.config, 'one-codegen', args)
 
     # verify arguments
-    _verify_arg(parser, args, cfg_args)
+    _verify_arg(parser, args, cfg_args, backend_args, unknown_args)
     '''
     one-codegen defines its behavior for below cases.
 
@@ -147,26 +155,34 @@ def main():
     [7] one-codegen -b ${backend} -C {cfg} (backend, command key in cfg)
     [8] one-codegen -b ${backend} -C {cfg} (backends key in cfg) (Only 'backend' is invoked, 
          even though cfg file has multiple backends)
+    [9] one-codegen -b ${backend} -C ${cfg} -- ${command} (backend, command key in cfg) 
+    [10] one-codegen -b ${backend} -C ${cfg} -- ${command} (backends key in cfg) (Only 'backend' is invoked, 
+         even though cfg file has multiple backends)
 
     All other cases are not allowed or an undefined behavior.
     '''
+    cmd_overwrite = False
     if oneutils.is_valid_attr(args, 'config'):
-        assert (not backend_args or not unknown_args)
-        # [7], [8]
-        if oneutils.is_valid_attr(args, 'backend'):
+        # [9], [10]
+        if backend_args and not unknown_args:
             given_backends = [args.backend]
-            if oneutils.is_valid_attr(cfg_args, 'backend'):
-                assert (oneutils.is_valid_attr(cfg_args, 'command'))
-                setattr(cfg_args, args.backend, cfg_args.command)
+            cmd_overwrite = True
         else:
-            # [3]
-            if oneutils.is_valid_attr(cfg_args, 'backend'):
-                assert (oneutils.is_valid_attr(cfg_args, 'command'))
-                given_backends = [cfg_args.backend]
-                setattr(cfg_args, cfg_args.backend, cfg_args.command)
-            # [4]
-            if oneutils.is_valid_attr(cfg_args, 'backends'):
-                given_backends = cfg_args.backends.split(',')
+            # [7], [8]
+            if oneutils.is_valid_attr(args, 'backend'):
+                given_backends = [args.backend]
+                if oneutils.is_valid_attr(cfg_args, 'backend'):
+                    assert (oneutils.is_valid_attr(cfg_args, 'command'))
+                    setattr(cfg_args, args.backend, cfg_args.command)
+            else:
+                # [3]
+                if oneutils.is_valid_attr(cfg_args, 'backend'):
+                    assert (oneutils.is_valid_attr(cfg_args, 'command'))
+                    given_backends = [cfg_args.backend]
+                    setattr(cfg_args, cfg_args.backend, cfg_args.command)
+                # [4]
+                if oneutils.is_valid_attr(cfg_args, 'backends'):
+                    given_backends = cfg_args.backends.split(',')
     # [5], [6]
     else:
         assert (backend_args or unknown_args)
@@ -185,9 +201,13 @@ def main():
 
         if not codegen_path:
             raise FileNotFoundError(backend_base + ' not found')
-        codegen_cmd = [codegen_path] + backend_args + unknown_args
-        if oneutils.is_valid_attr(cfg_args, given_backend):
+
+        codegen_cmd = [codegen_path]
+        if not cmd_overwrite and oneutils.is_valid_attr(cfg_args, given_backend):
             codegen_cmd += getattr(cfg_args, given_backend).split()
+        else:
+            codegen_cmd += backend_args
+            codegen_cmd += unknown_args
 
         # run backend driver
         oneutils.run(codegen_cmd, err_prefix=backend_base)

--- a/compiler/one-cmds/tests/one-codegen_neg_002.test
+++ b/compiler/one-cmds/tests/one-codegen_neg_002.test
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+# Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# negative usage with no input
+# one-codegen ${command} without backend option
 
 filename_ext="$(basename -- $0)"
 filename="${filename_ext%.*}"
@@ -35,7 +35,7 @@ trap trap_err_onexit ERR
 rm -f ${filename}.log
 
 # run test
-one-codegen > ${filename}.log 2>&1
+one-codegen -o test.tvn test.circle > ${filename}.log 2>&1
 
 echo "${filename_ext} FAILED"
 exit 255

--- a/compiler/one-cmds/tests/one-codegen_neg_003.test
+++ b/compiler/one-cmds/tests/one-codegen_neg_003.test
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+# Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# negative usage with no input
+# one-codegen -- ${command} without backend option
 
 filename_ext="$(basename -- $0)"
 filename="${filename_ext%.*}"
@@ -35,7 +35,7 @@ trap trap_err_onexit ERR
 rm -f ${filename}.log
 
 # run test
-one-codegen > ${filename}.log 2>&1
+one-codegen -- -o test.tvn test.circle > ${filename}.log 2>&1
 
 echo "${filename_ext} FAILED"
 exit 255

--- a/compiler/one-cmds/tests/one-codegen_neg_004.cfg
+++ b/compiler/one-cmds/tests/one-codegen_neg_004.cfg
@@ -1,0 +1,6 @@
+[onecc]
+one-codegen=True
+
+[one-codegen]
+backend=dummy
+# command=..

--- a/compiler/one-cmds/tests/one-codegen_neg_004.test
+++ b/compiler/one-cmds/tests/one-codegen_neg_004.test
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+# Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,14 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# negative usage with no input
+# command key is missing
 
 filename_ext="$(basename -- $0)"
 filename="${filename_ext%.*}"
 
 trap_err_onexit()
 {
-  if grep -q "error: the following arguments are required: -b/--backend" "${filename}.log"; then
+  if grep -q "error: 'command' key is missing in the configuration file" "${filename}.log"; then
     echo "${filename_ext} SUCCESS"
     exit 0
   fi
@@ -32,10 +32,12 @@ trap_err_onexit()
 
 trap trap_err_onexit ERR
 
+configfile="one-codegen_neg_004.cfg"
+
 rm -f ${filename}.log
 
 # run test
-one-codegen > ${filename}.log 2>&1
+one-codegen -b dummy -C ${configfile} > ${filename}.log 2>&1
 
 echo "${filename_ext} FAILED"
 exit 255

--- a/compiler/one-cmds/tests/one-codegen_neg_005.test
+++ b/compiler/one-cmds/tests/one-codegen_neg_005.test
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+# Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,14 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# negative usage with no input
+# commands for the backend is missing
 
 filename_ext="$(basename -- $0)"
 filename="${filename_ext%.*}"
 
 trap_err_onexit()
 {
-  if grep -q "error: the following arguments are required: -b/--backend" "${filename}.log"; then
+  if grep -q "error: commands for the backend is missing" "${filename}.log"; then
     echo "${filename_ext} SUCCESS"
     exit 0
   fi
@@ -35,7 +35,7 @@ trap trap_err_onexit ERR
 rm -f ${filename}.log
 
 # run test
-one-codegen > ${filename}.log 2>&1
+one-codegen -b dummy > ${filename}.log 2>&1
 
 echo "${filename_ext} FAILED"
 exit 255

--- a/compiler/one-cmds/tests/onecc_054.cfg
+++ b/compiler/one-cmds/tests/onecc_054.cfg
@@ -1,0 +1,7 @@
+[onecc]
+one-codegen=True
+
+[one-codegen]
+backends=dummy,dummyV2
+dummy=-o onecc_054.tvn inception_v3.onecc_054.circle
+dummyV2=-O onecc_054.2.tvn inception_v3.onecc_054.2.circle

--- a/compiler/one-cmds/tests/onecc_054.test
+++ b/compiler/one-cmds/tests/onecc_054.test
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# overwrite one-codegen command with `backends` key
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  echo "${filename_ext} FAILED"
+  rm -rf ../bin/dummy-compile
+  rm -rf ../bin/dummyV2-compile
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+configfile="onecc_054.cfg"
+outputfile0="onecc_054_overwrite.tvn"
+outputfile1="onecc_054.tvn"
+outputfile2="onecc_054.2.tvn"
+
+rm -f ${filename}.log
+rm -rf ${outputfile0}
+rm -rf ${outputfile1}
+rm -rf ${outputfile2}
+
+# copy dummy tools to bin folder
+cp dummy-compile ../bin/dummy-compile
+cp dummyV2-compile ../bin/dummyV2-compile
+
+# run test
+onecc codegen -C ${configfile} -b dummyV2 -- \
+  -O onecc_054_overwrite.tvn onecc.circle > ${filename}.log 2>&1
+
+if [[ ! -s "${outputfile0}" ]]; then
+  trap_err_onexit
+fi
+
+# shouldn't be generated
+if [[ -s "${outputfile1}" ]]; then
+  trap_err_onexit
+fi
+if [[ -s "${outputfile2}" ]]; then
+  trap_err_onexit
+fi
+
+rm -rf ../bin/dummy-compile
+rm -rf ../bin/dummyV2-compile
+
+echo "${filename_ext} SUCCESS"

--- a/compiler/one-cmds/tests/onecc_055.cfg
+++ b/compiler/one-cmds/tests/onecc_055.cfg
@@ -1,0 +1,6 @@
+[onecc]
+one-codegen=True
+
+[one-codegen]
+backend=dummyV2
+command=-O onecc_048.tvn inception_v3.onecc_048.circle

--- a/compiler/one-cmds/tests/onecc_055.test
+++ b/compiler/one-cmds/tests/onecc_055.test
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2021 Samsung Electronics Co., Ltd. All Rights Reserved
+# Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,28 +14,44 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# negative usage with no input
+# overwrite one-codegen command with `backend` and `command` key
 
 filename_ext="$(basename -- $0)"
 filename="${filename_ext%.*}"
 
 trap_err_onexit()
 {
-  if grep -q "error: the following arguments are required: -b/--backend" "${filename}.log"; then
-    echo "${filename_ext} SUCCESS"
-    exit 0
-  fi
-
   echo "${filename_ext} FAILED"
+  rm -rf ../bin/dummyV2-compile
   exit 255
 }
 
 trap trap_err_onexit ERR
 
+configfile="onecc_055.cfg"
+outputfile0="onecc_055.tvn"
+outputfile1="onecc_055_overwrite.tvn"
+
 rm -f ${filename}.log
+rm -rf ${outputfile0}
+rm -rf ${outputfile1}
+
+# copy dummy tools to bin folder
+cp dummyV2-compile ../bin/dummyV2-compile
 
 # run test
-one-codegen > ${filename}.log 2>&1
+onecc codegen -C ${configfile} -b dummyV2 -- \
+  -O onecc_055_overwrite.tvn onecc.circle > ${filename}.log 2>&1
 
-echo "${filename_ext} FAILED"
-exit 255
+if [[ ! -s "${outputfile1}" ]]; then
+  trap_err_onexit
+fi
+
+# shouldn't be generated
+if [[ -s "${outputfile0}" ]]; then
+  trap_err_onexit
+fi
+
+rm -rf ../bin/dummyV2-compile
+
+echo "${filename_ext} SUCCESS"


### PR DESCRIPTION
This commit supports overwriting commands over given configuration file on one-codegen.

Related: #10994 
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>