### PR TITLE
[one-cmds] Overwriting commands over given configuration on one-profile

### DIFF
--- a/compiler/one-cmds/dummy-driver/CMakeLists.txt
+++ b/compiler/one-cmds/dummy-driver/CMakeLists.txt
@@ -7,6 +7,7 @@ set(DUMMY_INFER_V2_SRC src/dummy-inferV2.cpp)
 set(HELP_INFER_SRC src/help-infer.cpp)
 set(DUMMY_PROFILE_SRC src/dummy-profile.cpp)
 set(DUMMY_V2_PROFILE_SRC src/dummyV2-profile.cpp)
+set(DUMMY_V3_PROFILE_SRC src/dummyV3-profile.cpp)
 set(HELP_PROFILE_SRC src/help-profile.cpp)
 set(DUMMY_ENV_SRC src/dummyEnv-compile.cpp)
 set(DUMMY_ONNX_EXT src/dummy-onnx-ext.cpp)
@@ -19,6 +20,7 @@ add_executable(dummy-inferV2 ${DUMMY_INFER_V2_SRC})
 add_executable(help-infer ${HELP_INFER_SRC})
 add_executable(dummy-profile ${DUMMY_PROFILE_SRC})
 add_executable(dummyV2-profile ${DUMMY_V2_PROFILE_SRC})
+add_executable(dummyV3-profile ${DUMMY_V3_PROFILE_SRC})
 add_executable(help-profile ${HELP_PROFILE_SRC})
 add_executable(dummyEnv-compile ${DUMMY_ENV_SRC})
 add_executable(dummy-onnx-ext ${DUMMY_ONNX_EXT})
@@ -31,6 +33,7 @@ set(DUMMY_INFER_V2 "${CMAKE_CURRENT_BINARY_DIR}/dummy-inferV2")
 set(HELP_INFER "${CMAKE_CURRENT_BINARY_DIR}/help-infer")
 set(DUMMY_PROFILE "${CMAKE_CURRENT_BINARY_DIR}/dummy-profile")
 set(DUMMY_V2_PROFILE "${CMAKE_CURRENT_BINARY_DIR}/dummyV2-profile")
+set(DUMMY_V3_PROFILE "${CMAKE_CURRENT_BINARY_DIR}/dummyV3-profile")
 set(HELP_PROFILE "${CMAKE_CURRENT_BINARY_DIR}/help-profile")
 set(DUMMY_ENV "${CMAKE_CURRENT_BINARY_DIR}/dummyEnv-compile")
 set(DUMMY_ONNX_EXT "${CMAKE_CURRENT_BINARY_DIR}/dummy-onnx-ext")
@@ -78,6 +81,12 @@ install(FILES ${DUMMY_PROFILE}
         DESTINATION test)
 
 install(FILES ${DUMMY_V2_PROFILE}
+        PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE
+                    GROUP_READ GROUP_EXECUTE
+                    WORLD_READ WORLD_EXECUTE
+        DESTINATION test)
+
+install(FILES ${DUMMY_V3_PROFILE}
         PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE
                     GROUP_READ GROUP_EXECUTE
                     WORLD_READ WORLD_EXECUTE

--- a/compiler/one-cmds/dummy-driver/src/dummyV3-profile.cpp
+++ b/compiler/one-cmds/dummy-driver/src/dummyV3-profile.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * dummyV3-profile only tests its interface rather than its functionality.
+ *
+ * ./dummyV3-profile ${INPUT_TO_PRINT}
+ * dummyV3-profile with ${INPUT_TO_PRINT}
+ */
+
+#include <iostream>
+#include <fstream>
+#include <string>
+
+int main(int argc, char **argv)
+{
+  if (argc != 2)
+    return EXIT_FAILURE;
+
+  std::string input_to_print{argv[1]};
+
+  std::cout << "dummyV3-profile with " << input_to_print << std::endl;
+
+  return EXIT_SUCCESS;
+}

--- a/compiler/one-cmds/one-profile
+++ b/compiler/one-cmds/one-profile
@@ -93,18 +93,11 @@ def _get_parser(backends_list):
     return parser
 
 
-def _verify_arg(parser, args, cfg_args):
+def _verify_arg(parser, args, cfg_args, backend_args, unknown_args):
     """verify given arguments"""
     cmd_backend_exist = oneutils.is_valid_attr(args, 'backend')
     cfg_backend_exist = oneutils.is_valid_attr(cfg_args, 'backend')
     cfg_backends_exist = oneutils.is_valid_attr(cfg_args, 'backends')
-    if cfg_backend_exist and cfg_backends_exist:
-        parser.error(
-            '\'backend\' option and \'backends\' option cannot be used simultaneously.')
-    # Check if given backend from command line exists in the configuration file
-    if cmd_backend_exist and cfg_backend_exist:
-        if args.backend != cfg_args.backend:
-            parser.error('Not found the command of given backend')
 
     # check if required arguments is given
     missing = []
@@ -112,6 +105,22 @@ def _verify_arg(parser, args, cfg_args):
         missing.append('-b/--backend')
     if len(missing):
         parser.error('the following arguments are required: ' + ' '.join(missing))
+
+    if not oneutils.is_valid_attr(args, 'config'):
+        if not backend_args and not unknown_args:
+            parser.error('commands for the backend is missing.')
+
+    if cfg_backend_exist and cfg_backends_exist:
+        parser.error(
+            '\'backend\' option and \'backends\' option cannot be used simultaneously.')
+
+    # Check if given backend from command line exists in the configuration file
+    if cmd_backend_exist and cfg_backend_exist:
+        if args.backend != cfg_args.backend:
+            parser.error('Not found the command of given backend')
+
+    if cfg_backend_exist and not oneutils.is_valid_attr(cfg_args, 'command'):
+        parser.error('\'command\' key is missing in the configuration file.')
 
     if cfg_backends_exist:
         cfg_backends = getattr(cfg_args, 'backends').split(',')
@@ -166,7 +175,7 @@ def main():
     oneutils.parse_cfg(args.config, 'one-profile', cfg_args)
 
     # verify arguments
-    _verify_arg(parser, args, cfg_args)
+    _verify_arg(parser, args, cfg_args, backend_args, unknown_args)
     '''
     one-profile defines its behavior for below cases.
 
@@ -179,30 +188,39 @@ def main():
     [7] one-profile -b ${backend} -C {cfg} (backend, command key in cfg)
     [8] one-profile -b ${backend} -C {cfg} (backends key in cfg) (Only 'backend' is invoked, 
          even though cfg file has multiple backends)
+    [9] one-profile -b ${backend} -C ${cfg} -- ${command} (backend, command key in cfg) 
+    [10] one-profile -b ${backend} -C ${cfg} -- ${command} (backends key in cfg) (Only 'backend' is invoked, 
+         even though cfg file has multiple backends)
 
     All other cases are not allowed or an undefined behavior.
     '''
+    cmd_overwrite = False
     if oneutils.is_valid_attr(args, 'config'):
-        assert (not backend_args or not unknown_args)
-        # [7], [8]
-        if oneutils.is_valid_attr(args, 'backend'):
+        # [9], [10]
+        if backend_args and not unknown_args:
             given_backends = [args.backend]
-            if oneutils.is_valid_attr(cfg_args, 'backend'):
-                assert (oneutils.is_valid_attr(cfg_args, 'command'))
-                setattr(cfg_args, args.backend, cfg_args.command)
+            cmd_overwrite = True
         else:
-            # [3]
-            if oneutils.is_valid_attr(cfg_args, 'backend'):
-                assert (oneutils.is_valid_attr(cfg_args, 'command'))
-                given_backends = [cfg_args.backend]
-                setattr(cfg_args, cfg_args.backend, cfg_args.command)
-            # [4]
-            if oneutils.is_valid_attr(cfg_args, 'backends'):
-                given_backends = cfg_args.backends.split(',')
+            # [7], [8]
+            if oneutils.is_valid_attr(args, 'backend'):
+                given_backends = [args.backend]
+                if oneutils.is_valid_attr(cfg_args, 'backend'):
+                    assert (oneutils.is_valid_attr(cfg_args, 'command'))
+                    setattr(cfg_args, args.backend, cfg_args.command)
+            else:
+                # [3]
+                if oneutils.is_valid_attr(cfg_args, 'backend'):
+                    assert (oneutils.is_valid_attr(cfg_args, 'command'))
+                    given_backends = [cfg_args.backend]
+                    setattr(cfg_args, cfg_args.backend, cfg_args.command)
+                # [4]
+                if oneutils.is_valid_attr(cfg_args, 'backends'):
+                    given_backends = cfg_args.backends.split(',')
     # [5], [6]
     else:
         assert (backend_args or unknown_args)
         given_backends = [args.backend]
+
     for given_backend in given_backends:
         # make a command to run given backend driver
         profile_path = None
@@ -212,9 +230,14 @@ def main():
                 profile_path = cand
         if not profile_path:
             raise FileNotFoundError(backend_base + ' not found')
-        profile_cmd = [profile_path] + backend_args + unknown_args
-        if oneutils.is_valid_attr(cfg_args, given_backend):
+
+        profile_cmd = [profile_path]
+        if not cmd_overwrite and oneutils.is_valid_attr(cfg_args, given_backend):
             profile_cmd += getattr(cfg_args, given_backend).split()
+        else:
+            profile_cmd += backend_args
+            profile_cmd += unknown_args
+
         # run backend driver
         oneutils.run(profile_cmd, err_prefix=backend_base)
 

--- a/compiler/one-cmds/tests/one-profile_neg_002.test
+++ b/compiler/one-cmds/tests/one-profile_neg_002.test
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# one-profile ${command} without backend option
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  if grep -q "error: the following arguments are required: -b/--backend" "${filename}.log"; then
+    echo "${filename_ext} SUCCESS"
+    exit 0
+  fi
+
+  echo "${filename_ext} FAILED"
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+rm -f ${filename}.log
+
+# run test
+one-profile test.tvn > ${filename}.log 2>&1
+
+echo "${filename_ext} FAILED"
+exit 255

--- a/compiler/one-cmds/tests/one-profile_neg_003.test
+++ b/compiler/one-cmds/tests/one-profile_neg_003.test
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# one-profile -- ${command} without backend option
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  if grep -q "error: the following arguments are required: -b/--backend" "${filename}.log"; then
+    echo "${filename_ext} SUCCESS"
+    exit 0
+  fi
+
+  echo "${filename_ext} FAILED"
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+rm -f ${filename}.log
+
+# run test
+one-profile -- test.tvn > ${filename}.log 2>&1
+
+echo "${filename_ext} FAILED"
+exit 255

--- a/compiler/one-cmds/tests/one-profile_neg_004.cfg
+++ b/compiler/one-cmds/tests/one-profile_neg_004.cfg
@@ -1,0 +1,6 @@
+[onecc]
+one-profile=True
+
+[one-profile]
+backend=dummy
+# command=..

--- a/compiler/one-cmds/tests/one-profile_neg_004.test
+++ b/compiler/one-cmds/tests/one-profile_neg_004.test
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# command key is missing
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  if grep -q "error: 'command' key is missing in the configuration file" "${filename}.log"; then
+    echo "${filename_ext} SUCCESS"
+    exit 0
+  fi
+
+  echo "${filename_ext} FAILED"
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+configfile="one-profile_neg_004.cfg"
+
+rm -f ${filename}.log
+
+# run test
+one-profile -b dummy -C ${configfile} > ${filename}.log 2>&1
+
+echo "${filename_ext} FAILED"
+exit 255

--- a/compiler/one-cmds/tests/one-profile_neg_005.test
+++ b/compiler/one-cmds/tests/one-profile_neg_005.test
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# commands for the backend is missing
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  if grep -q "error: commands for the backend is missing" "${filename}.log"; then
+    echo "${filename_ext} SUCCESS"
+    exit 0
+  fi
+
+  echo "${filename_ext} FAILED"
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+rm -f ${filename}.log
+
+# run test
+one-profile -b dummy > ${filename}.log 2>&1
+
+echo "${filename_ext} FAILED"
+exit 255

--- a/compiler/one-cmds/tests/onecc_056.cfg
+++ b/compiler/one-cmds/tests/onecc_056.cfg
@@ -1,0 +1,6 @@
+[onecc]
+one-profile=True
+
+[one-profile]
+backend=dummyV3
+command=onecc_056

--- a/compiler/one-cmds/tests/onecc_056.test
+++ b/compiler/one-cmds/tests/onecc_056.test
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# overwrite one-profile command with 'backend' key
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  echo "${filename_ext} FAILED"
+  rm -rf ../bin/dummyV3-profile
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+configfile="onecc_056.cfg"
+
+rm -f ${filename}.log
+
+# copy dummy tools to bin folder
+cp dummyV3-profile ../bin/dummyV3-profile
+
+# run test
+onecc profile -C ${configfile} -b dummyV3 -- \
+  onecc_056_overwrite > ${filename}.log 2>&1
+
+if ! grep -q "dummyV3-profile with onecc_056_overwrite" "${filename}.log"; then
+  trap_err_onexit
+fi
+
+rm -rf ../bin/dummyV3-profile
+
+echo "${filename_ext} SUCCESS"

--- a/compiler/one-cmds/tests/onecc_057.cfg
+++ b/compiler/one-cmds/tests/onecc_057.cfg
@@ -1,0 +1,7 @@
+[onecc]
+one-profile=True
+
+[one-profile]
+backends=dummyV2,dummyV3
+dummyV2=dummyV2.bin
+dummyV3=onecc_057

--- a/compiler/one-cmds/tests/onecc_057.test
+++ b/compiler/one-cmds/tests/onecc_057.test
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# overwrite one-profile command with `backends` key
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  echo "${filename_ext} FAILED"
+  rm -rf ../bin/dummyV2-profile
+  rm -rf ../bin/dummyV3-profile
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+configfile="onecc_057.cfg"
+
+rm -f ${filename}.log
+
+# copy dummy tools to bin folder
+cp dummyV2-profile ../bin/dummyV2-profile
+cp dummyV3-profile ../bin/dummyV3-profile
+
+# run test
+onecc profile -C ${configfile} -b dummyV3 -- \
+  onecc_057_overwrite > ${filename}.log 2>&1
+
+if ! grep -q "dummyV3-profile with onecc_057_overwrite" "${filename}.log"; then
+  trap_err_onexit
+fi
+
+rm -rf ../bin/dummyV2-profile
+rm -rf ../bin/dummyV3-profile
+
+echo "${filename_ext} SUCCESS"


### PR DESCRIPTION
This commit supports overwriting commands over given configuration file on one-profile.

Related: #10994 
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>