### PR TITLE
Add aarch64 support to common-artifacts build

### DIFF
--- a/compiler/common-artifacts/CMakeLists.txt
+++ b/compiler/common-artifacts/CMakeLists.txt
@@ -53,21 +53,43 @@ if(DEFINED ENV{ONE_PIP_OPTION_TRUST_HOST})
   set(PIP_OPTION_TRUSTED_HOST --trusted-host pypi.python.org --trusted-host files.pythonhosted.org --trusted-host pypi.org)
 endif()
 
-# NOTE refer https://github.com/protocolbuffers/protobuf/issues/10051
-# TODO remove protobuf==3.20.1 when issue is resolved
-add_custom_command(
-  OUTPUT ${REQUIREMENTS_OVERLAY_PATH_TF_2_8_0}
-  COMMAND ${CMAKE_COMMAND} -E remove -f ${REQUIREMENTS_OVERLAY_PATH_TF_2_8_0}
-  COMMAND ${CMAKE_COMMAND} -E echo "tensorflow-cpu==2.8.0" >> ${REQUIREMENTS_OVERLAY_PATH_TF_2_8_0}
-  COMMAND ${CMAKE_COMMAND} -E echo "flatbuffers==1.12" >> ${REQUIREMENTS_OVERLAY_PATH_TF_2_8_0}
-  COMMAND ${CMAKE_COMMAND} -E echo "protobuf==3.20.1" >> ${REQUIREMENTS_OVERLAY_PATH_TF_2_8_0}
-  COMMAND ${CMAKE_COMMAND} -E echo "pydot==1.4.2" >> ${REQUIREMENTS_OVERLAY_PATH_TF_2_8_0}
-  COMMAND ${VIRTUALENV_OVERLAY_TF_2_8_0}/bin/${PYTHON_OVERLAY} -m pip --default-timeout=1000
-          ${PIP_OPTION_TRUSTED_HOST} install --upgrade pip setuptools
-  COMMAND ${VIRTUALENV_OVERLAY_TF_2_8_0}/bin/${PYTHON_OVERLAY} -m pip --default-timeout=1000
-          ${PIP_OPTION_TRUSTED_HOST} install -r ${REQUIREMENTS_OVERLAY_PATH_TF_2_8_0} --upgrade
-  DEPENDS ${VIRTUALENV_OVERLAY_TF_2_8_0}
-)
+if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "aarch64")
+  # NOTE installing tensorflow 2.10.1 in OVERLAY_PATH_TF_2_8_0 is strange, but keeping different
+  # versions of tensorflow is temporary and it is a way to support aarch64 native build while
+  # minimizing the impact on the entire build system, so we choose this way.
+  # NOTE `tensorflow-cpu` package is not available for aarch64, so we use `tensorflow` package.
+  # TODO renaming OVERLAY_PATH_TF_2_8_0 and OVERLAY_PATH_TF_2_10_1 to version neutral names would
+  # be appropriate.
+  add_custom_command(
+    OUTPUT ${REQUIREMENTS_OVERLAY_PATH_TF_2_8_0}
+    COMMAND ${CMAKE_COMMAND} -E remove -f ${REQUIREMENTS_OVERLAY_PATH_TF_2_8_0}
+    COMMAND ${CMAKE_COMMAND} -E echo "tensorflow==2.10.1" >> ${REQUIREMENTS_OVERLAY_PATH_TF_2_8_0}
+    COMMAND ${CMAKE_COMMAND} -E echo "flatbuffers==23.1.21" >> ${REQUIREMENTS_OVERLAY_PATH_TF_2_8_0}
+    COMMAND ${CMAKE_COMMAND} -E echo "protobuf==3.19.6" >> ${REQUIREMENTS_OVERLAY_PATH_TF_2_8_0}
+    COMMAND ${CMAKE_COMMAND} -E echo "pydot==1.4.2" >> ${REQUIREMENTS_OVERLAY_PATH_TF_2_8_0}
+    COMMAND ${VIRTUALENV_OVERLAY_TF_2_8_0}/bin/${PYTHON_OVERLAY} -m pip --default-timeout=1000
+            ${PIP_OPTION_TRUSTED_HOST} install --upgrade pip setuptools
+    COMMAND ${VIRTUALENV_OVERLAY_TF_2_8_0}/bin/${PYTHON_OVERLAY} -m pip --default-timeout=1000
+            ${PIP_OPTION_TRUSTED_HOST} install -r ${REQUIREMENTS_OVERLAY_PATH_TF_2_8_0} --upgrade
+    DEPENDS ${VIRTUALENV_OVERLAY_TF_2_8_0}
+  )
+else(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "aarch64")
+  # NOTE refer https://github.com/protocolbuffers/protobuf/issues/10051
+  # TODO remove protobuf==3.20.1 when issue is resolved
+  add_custom_command(
+    OUTPUT ${REQUIREMENTS_OVERLAY_PATH_TF_2_8_0}
+    COMMAND ${CMAKE_COMMAND} -E remove -f ${REQUIREMENTS_OVERLAY_PATH_TF_2_8_0}
+    COMMAND ${CMAKE_COMMAND} -E echo "tensorflow-cpu==2.8.0" >> ${REQUIREMENTS_OVERLAY_PATH_TF_2_8_0}
+    COMMAND ${CMAKE_COMMAND} -E echo "flatbuffers==1.12" >> ${REQUIREMENTS_OVERLAY_PATH_TF_2_8_0}
+    COMMAND ${CMAKE_COMMAND} -E echo "protobuf==3.20.1" >> ${REQUIREMENTS_OVERLAY_PATH_TF_2_8_0}
+    COMMAND ${CMAKE_COMMAND} -E echo "pydot==1.4.2" >> ${REQUIREMENTS_OVERLAY_PATH_TF_2_8_0}
+    COMMAND ${VIRTUALENV_OVERLAY_TF_2_8_0}/bin/${PYTHON_OVERLAY} -m pip --default-timeout=1000
+            ${PIP_OPTION_TRUSTED_HOST} install --upgrade pip setuptools
+    COMMAND ${VIRTUALENV_OVERLAY_TF_2_8_0}/bin/${PYTHON_OVERLAY} -m pip --default-timeout=1000
+            ${PIP_OPTION_TRUSTED_HOST} install -r ${REQUIREMENTS_OVERLAY_PATH_TF_2_8_0} --upgrade
+    DEPENDS ${VIRTUALENV_OVERLAY_TF_2_8_0}
+  )
+endif(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "aarch64")
 
 add_custom_target(common_artifacts_python_deps ALL
   DEPENDS ${VIRTUALENV_OVERLAY_TF_2_8_0}


### PR DESCRIPTION
- Identifies aarch64 and configures it to use the appropriate python package.

ONE-DCO-1.0-Signed-off-by: Sung-Jae Lee <sj925.lee@samsung.com>

for: #11036 
draft: #10564 