### PR TITLE
[onecc-docker] Use onecc version with a certain format

### DIFF
--- a/compiler/onecc-docker/onecc-docker
+++ b/compiler/onecc-docker/onecc-docker
@@ -56,10 +56,8 @@ def _request_recent_version(token=None):
 
 
 def _run(cmd, is_shell=False):
-    result = subprocess.Popen(cmd,
-                              shell=is_shell,
-                              stdout=subprocess.PIPE,
-                              stderr=subprocess.PIPE)
+    result = subprocess.Popen(
+        cmd, shell=is_shell, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
     stdout, stderr = result.communicate()
     stdout = stdout.decode('utf-8')
@@ -84,8 +82,8 @@ def main():
 
     onecc_docker_usage = 'onecc-docker [-h] [-t TOKEN] [COMMAND <args>]'
     onecc_docker_desc = 'Run onecc via docker'
-    parser = argparse.ArgumentParser(usage=onecc_docker_usage,
-                                     description=onecc_docker_desc)
+    parser = argparse.ArgumentParser(
+        usage=onecc_docker_usage, description=onecc_docker_desc)
     parser.add_argument(
         "-t",
         "--token",

--- a/compiler/onecc-docker/onecc-docker
+++ b/compiler/onecc-docker/onecc-docker
@@ -42,8 +42,9 @@ class RequestHandler:
 
 
 def _request_recent_version(token=None):
-    response = RequestHandler(token, timeout=100).make_request(
-        url="https://api.github.com/repos/Samsung/ONE/releases")
+    response = RequestHandler(
+        token,
+        timeout=100).make_request(url="https://api.github.com/repos/Samsung/ONE/releases")
     versions = [release_item["tag_name"] for release_item in response.json()]
 
     for version in versions:
@@ -55,8 +56,10 @@ def _request_recent_version(token=None):
 
 
 def _run(cmd, is_shell=False):
-    result = subprocess.Popen(
-        cmd, shell=is_shell, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    result = subprocess.Popen(cmd,
+                              shell=is_shell,
+                              stdout=subprocess.PIPE,
+                              stderr=subprocess.PIPE)
 
     stdout, stderr = result.communicate()
     stdout = stdout.decode('utf-8')
@@ -81,8 +84,8 @@ def main():
 
     onecc_docker_usage = 'onecc-docker [-h] [-t TOKEN] [COMMAND <args>]'
     onecc_docker_desc = 'Run onecc via docker'
-    parser = argparse.ArgumentParser(
-        usage=onecc_docker_usage, description=onecc_docker_desc)
+    parser = argparse.ArgumentParser(usage=onecc_docker_usage,
+                                     description=onecc_docker_desc)
     parser.add_argument(
         "-t",
         "--token",

--- a/compiler/onecc-docker/onecc-docker
+++ b/compiler/onecc-docker/onecc-docker
@@ -34,11 +34,9 @@ class RequestHandler:
         try:
             response = requests.get(url, headers=self.headers)
             response.raise_for_status()
-            print("[onecc-docker] Request succeeded: {}".format(response.status_code))
             return response
         except requests.RequestException as e:
-            print("[onecc-docker] Request failed: ", e)
-            return None
+            raise SystemExit('[onecc-docker] error: {}'.format(e))
 
 
 def _request_recent_version(token=None):
@@ -53,6 +51,8 @@ def _request_recent_version(token=None):
         # which doesn't contain onecc package.
         if bool(re.match(r'^\d+\.\d+\.\d+$', version)):
             return version
+
+    raise SystemExit('[onecc-docker] Failed to get latest onecc version')
 
 
 def _run(cmd, is_shell=False):
@@ -102,9 +102,9 @@ def main():
         build_cmd = [
             "docker", "build", "-t", image_name, "--build-arg", build_arg, dockerfile_path
         ]
-        print('build Docker image ...')
+        print('[onecc-docker] Build docker image ...')
         _run(build_cmd)
-        print('Dockerfile successfully built.')
+        print('[onecc-docker] Docker image is built successfully.')
 
     contianer_name = f"onecc_{recent_version.replace('.','_')}"
     user_cmd = ' '.join(onecc_arguments)

--- a/compiler/onecc-docker/onecc-docker
+++ b/compiler/onecc-docker/onecc-docker
@@ -16,10 +16,42 @@
 
 import sys
 import subprocess
-import json
 import requests
 import os
 import argparse
+import re
+
+
+class RequestHandler:
+    def __init__(self, token=None, timeout=None):
+        if token:
+            self.headers = {"Authorization": "Bearer {}".format(token)}
+        else:
+            self.headers = {}
+        self.timeout = timeout or 5
+
+    def make_request(self, url):
+        try:
+            response = requests.get(url, headers=self.headers)
+            response.raise_for_status()
+            print("[onecc-docker] Request succeeded: {}".format(response.status_code))
+            return response
+        except requests.RequestException as e:
+            print("[onecc-docker] Request failed: ", e)
+            return None
+
+
+def _request_recent_version(token=None):
+    response = RequestHandler(token, timeout=100).make_request(
+        url="https://api.github.com/repos/Samsung/ONE/releases")
+    versions = [release_item["tag_name"] for release_item in response.json()]
+
+    for version in versions:
+        # Return the latest version with the given format
+        # to filter out such as 'onert-micro-0.1.0' release
+        # which doesn't contain onecc package.
+        if bool(re.match(r'^\d+\.\d+\.\d+$', version)):
+            return version
 
 
 def _run(cmd, is_shell=False):
@@ -61,20 +93,7 @@ def main():
     args, onecc_arguments = parser.parse_known_args()
     authorization_token = args.token
 
-    LATEST_URL = "https://api.github.com/repos/Samsung/ONE/releases/latest"
-    headers = {}
-    if authorization_token:
-        headers = {"Authorization": "Bearer {}".format(authorization_token)}
-    try:
-        response = requests.get(LATEST_URL, headers=headers)
-        response.raise_for_status()
-    except requests.exceptions.RequestException as e:
-        raise SystemExit('onecc-docker: error: {}'.format(e))
-
-    versions_str = response.content
-    versions_json = json.loads(versions_str)
-    recent_version = versions_json["tag_name"]
-
+    recent_version = _request_recent_version(authorization_token)
     image_name = f"onecc:{recent_version}"
     build_arg = f"VERSION={recent_version}"
 


### PR DESCRIPTION
This commit requests github several latest version information and filter out versions like onert-micro-0.1.0
which doesn't include onecc package.

ONE-DCO-1.0.-Signed-off-by: Dayoung Lee <dayoung.lee@samsung.com>