### PR TITLE
[oops] Add requires.cmake

### DIFF
--- a/compiler/oops/requires.cmake
+++ b/compiler/oops/requires.cmake
@@ -1,0 +1,1 @@
+require("pepper-str")


### PR DESCRIPTION
It introduces requires.cmake because "oops" links "pepper-str".

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>