### PR TITLE
[infra] Add retry loop to build-onert-micro-arm

### DIFF
--- a/.github/workflows/build-onert-micro-arm.yml
+++ b/.github/workflows/build-onert-micro-arm.yml
@@ -43,4 +43,8 @@ jobs:
           mkdir build
           cd build
           cmake ../infra/onert-micro/
-          make -j$(nproc) luci_interpreter_micro_arm
+          for i in $(seq 1 5); do \
+            [ $i -gt 1 ] && sleep 5; \
+            make -j1 luci_interpreter_micro_arm && s=0 && break || s=$?; \
+          done; \
+          (exit $s)


### PR DESCRIPTION
This commit adds retry loop to build-onert-micro-arm (workaround for build fails due to lack of memory).

ONE-DCO-1.0-Signed-off-by: Vyacheslav Bazhenov <slavikmipt@gmail.com>