### PR TITLE
[onert] Use const & for saving training info in TrainingCompiler

### DIFF
--- a/runtime/onert/core/src/compiler/CompilerFactory.cc
+++ b/runtime/onert/core/src/compiler/CompilerFactory.cc
@@ -42,7 +42,7 @@ CompilerFactory::create(const std::shared_ptr<ir::NNPkg> &nnpkg,
 #ifdef ONERT_TRAIN
   // Returing compiler for training
   if (training_info)
-    return std::make_unique<train::TrainingCompiler>(nnpkg, copts, training_info);
+    return std::make_unique<train::TrainingCompiler>(nnpkg, copts, *training_info);
 #else  // ONERT_TRAIN
   (void)training_info;
 #endif // ONERT_TRAIN

--- a/runtime/onert/core/src/compiler/train/TrainingCompiler.cc
+++ b/runtime/onert/core/src/compiler/train/TrainingCompiler.cc
@@ -47,7 +47,7 @@ namespace train
 
 TrainingCompiler::TrainingCompiler(const std::shared_ptr<ir::NNPkg> &nnpkg,
                                    std::vector<std::unique_ptr<CompilerOptions>> &copts,
-                                   const TrainingInfo *training_info)
+                                   const TrainingInfo &training_info)
   : _model{nnpkg->primary_model()}, _options{copts[0].get()}, _training_info{training_info}
 {
   if (nnpkg->model_count() > 1)
@@ -113,7 +113,7 @@ std::shared_ptr<CompilerArtifact> TrainingCompiler::compile(void)
       auto trainable_subg = std::make_shared<ir::train::TrainableGraph>(subg);
 
       // Convert operations to trainable operations
-      auto converter = TrainableOperationConverter{*trainable_subg, _training_info};
+      auto converter = TrainableOperationConverter{*trainable_subg, &_training_info};
       subg.operations().iterate(
         [&](const onert::ir::OperationIndex &op_index, const onert::ir::IOperation &op) {
           auto trainable_op = converter(op);

--- a/runtime/onert/core/src/compiler/train/TrainingCompiler.h
+++ b/runtime/onert/core/src/compiler/train/TrainingCompiler.h
@@ -49,7 +49,7 @@ public:
    */
   explicit TrainingCompiler(const std::shared_ptr<ir::NNPkg> &nnpkg,
                             std::vector<std::unique_ptr<CompilerOptions>> &copts,
-                            const TrainingInfo *training_info);
+                            const TrainingInfo &training_info);
 
   /**
    * @brief Default Construct
@@ -73,7 +73,7 @@ public:
 private:
   std::shared_ptr<ir::Model> _model;
   CompilerOptions *_options;
-  const TrainingInfo *_training_info;
+  const TrainingInfo _training_info;
 };
 
 } // namespace train


### PR DESCRIPTION
This commit uses const & keyword for saving training info in TrainingCompiler.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>