### PR TITLE
[luci/pass] Revise GeluPattern1 to inherit from GeluPatternBase

### DIFF
--- a/compiler/luci/pass/src/FuseGeluPass.cpp
+++ b/compiler/luci/pass/src/FuseGeluPass.cpp
@@ -95,8 +95,6 @@ public:
     _mul_half = candidate;
   }
 
-  ~GeluPattern1() override = default;
-
 public:
   bool matched() override;
 };

--- a/compiler/luci/pass/src/FuseGeluPass.cpp
+++ b/compiler/luci/pass/src/FuseGeluPass.cpp
@@ -95,20 +95,10 @@ public:
     _mul_half = candidate;
   }
 
-public:
-  bool matched();
+  ~GeluPattern1() override = default;
 
 public:
-  luci::CircleNode *_ifm = nullptr;
-  luci::CircleMul *_mul_sqrt = nullptr;
-  luci::CircleCustom *_erf = nullptr;
-  luci::CircleCustomOut *_erf_out = nullptr;
-  luci::CircleAdd *_add_one = nullptr;
-  luci::CircleMul *_mul = nullptr;
-  luci::CircleMul *_mul_half = nullptr;
-  luci::CircleConst *_const_sqrt = nullptr;
-  luci::CircleConst *_const_one = nullptr;
-  luci::CircleConst *_const_half = nullptr;
+  bool matched() override;
 };
 
 #define CHECK_OR_FALSE(condition) \


### PR DESCRIPTION
This PR Revise GeluPattern1 to inherit from GeluPatternBase.

for issue: https://github.com/Samsung/ONE/issues/11002
from draft: https://github.com/Samsung/ONE/pull/11016

Note: this PR contains changes from #11060 and should be rebased after #11060 will be merged

ONE-DCO-1.0-Signed-off-by: Artem Balyshev <a.balyshev@samsung.com>