### PR TITLE
[onert] Change the batch_size of input tensor in train_prepare

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -1156,6 +1156,17 @@ NNFW_STATUS nnfw_session::train_prepare(const nnfw_train_info *info)
 
   try
   {
+    for (uint32_t i = 0; i < getInputSize(); ++i)
+    {
+      auto info = _nnpkg->inputInfo(i);
+      onert::ir::Shape new_shape(info.shape());
+      // TODO Consider batch size index
+      if (new_shape.dim(0) != 1)
+        throw std::runtime_error("the first dim is not 1. It is not supported yet.");
+      new_shape.dim(0) = training_info.batchSize();
+      _nnpkg->changeInputShape(i, new_shape);
+    }
+
     auto compiler =
       onert::compiler::CompilerFactory::get().create(_nnpkg, _coptions, &training_info);
     _nnpkg.reset();


### PR DESCRIPTION
This commit changes the batch_size of input tensor in train_prepare
nnfw internal api. Other operation will be changed the tensor info
through Static shape inference function.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>