### PR TITLE
[onert] Implement train_set_input in nnfw api

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -1231,15 +1231,32 @@ NNFW_STATUS nnfw_session::train_set_input(uint32_t index, const void *input,
     return NNFW_STATUS_INVALID_STATE;
   }
 
-  // Check index is valid: [0, getInputSize())
+  if (index >= getInputSize())
+  {
+    std::cerr << "Error during nnfw_session::train_set_input : index is out of range" << std::endl;
+    return NNFW_STATUS_ERROR;
+  }
 
-  // Maybe it cannot use general execute->setInput()
-  // because it needs to set batch input
-  (void)index;
-  (void)input_tensorinfo;
+  if (input_tensorinfo != nullptr)
+  {
+    std::cerr << "Error during nnfw_session::train_set_input : not supporeted to change tensorinfo"
+              << std::endl;
+    return NNFW_STATUS_ERROR;
+  }
 
-  // NYI
-  return NNFW_STATUS_ERROR;
+  try
+  {
+    auto ind = onert::ir::IOIndex(index);
+    auto size = _execution->getInputTotalSize(ind);
+    _execution->setInput(ind, input, size);
+  }
+  catch (const std::exception &e)
+  {
+    std::cerr << "Error during nnfw_session::train_set_input : " << e.what() << std::endl;
+    return NNFW_STATUS_ERROR;
+  }
+
+  return NNFW_STATUS_NO_ERROR;
 }
 
 NNFW_STATUS nnfw_session::train_set_expected(uint32_t index, const void *expected,


### PR DESCRIPTION
This commit implements train_set_input in nnfw api.
It sets train input to input tensor.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

draft: #11035
~~waiting #11077~~