### PR TITLE
[onert] Fix wrong TrainingInfo namespace in pass

### DIFF
--- a/runtime/onert/core/src/compiler/train/pass/LossInsertionPass.h
+++ b/runtime/onert/core/src/compiler/train/pass/LossInsertionPass.h
@@ -33,8 +33,7 @@ namespace pass
 class LossInsertionPass : public Pass
 {
 public:
-  LossInsertionPass(ir::train::TrainableGraph &trainable_graph,
-                    const ir::train::TrainingInfo *training_info,
+  LossInsertionPass(ir::train::TrainableGraph &trainable_graph, const TrainingInfo *training_info,
                     const ir::SubgraphIndex &subg_index)
     : Pass{trainable_graph, training_info}, _subg_index{subg_index}
   {

--- a/runtime/onert/core/src/compiler/train/pass/Pass.h
+++ b/runtime/onert/core/src/compiler/train/pass/Pass.h
@@ -26,7 +26,6 @@ namespace ir
 namespace train
 {
 class TrainableGraph;
-class TrainingInfo;
 } // namespace train
 } // namespace ir
 } // namespace onert
@@ -37,13 +36,16 @@ namespace compiler
 {
 namespace train
 {
+
+class TrainingInfo;
+
 namespace pass
 {
 
 class Pass : public compiler::pass::IPass
 {
 public:
-  Pass(ir::train::TrainableGraph &trainable_graph, const ir::train::TrainingInfo *training_info)
+  Pass(ir::train::TrainableGraph &trainable_graph, const TrainingInfo *training_info)
     : _trainable_graph{trainable_graph}, _training_info{training_info}
   {
   }
@@ -51,7 +53,7 @@ public:
 
 protected:
   ir::train::TrainableGraph &_trainable_graph;
-  const ir::train::TrainingInfo *_training_info;
+  const TrainingInfo *_training_info;
 };
 
 } // namespace pass


### PR DESCRIPTION
This commit fixes wrong TrainingInfo namespace in Pass class.
The TrainingInfo class has been moved from ir/train to compiler/train namespace.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>