### PR TITLE
[onert] Change TensorRegistry in builtin backend

### DIFF
--- a/runtime/onert/core/src/backend/builtin/Backend.h
+++ b/runtime/onert/core/src/backend/builtin/Backend.h
@@ -25,6 +25,7 @@
 #ifdef ONERT_TRAIN
 #include "train/BackendContext.h"
 #include "train/KernelGenerator.h"
+#include "train/TensorRegistry.h"
 #endif // ONERT_TRAIN
 
 #include <backend/Backend.h>
@@ -86,16 +87,13 @@ public:
   newContext(backend::train::TrainableContextData &&tdata) const override
   {
     const auto &tgraph = *tdata.tgraph;
-    auto tr = std::make_shared<TensorRegistry>();
-    auto tb = std::make_shared<TensorBuilder>(tr, "Bump");
-    auto deriv_tr = std::make_shared<TensorRegistry>();
-    auto deriv_tb = std::make_shared<TensorBuilder>(deriv_tr, "Bump");
+    auto tr = std::make_shared<train::TensorRegistry>();
+    // TODO Create TensorBuilder if necessary
     auto tdata_ptr = std::make_unique<backend::train::TrainableContextData>(std::move(tdata));
-    auto context = std::make_unique<train::BackendContext>(this, std::move(tdata_ptr), tr, tb,
-                                                           deriv_tr, deriv_tb);
+    auto context = std::make_unique<train::BackendContext>(this, std::move(tdata_ptr), tr);
 
     context->kernel_gen =
-      std::make_shared<train::KernelGenerator>(tgraph, tr, deriv_tr, context->external_context());
+      std::make_shared<train::KernelGenerator>(tgraph, tr, context->external_context());
     return context;
   }
 #endif // ONERT_TRAIN

--- a/runtime/onert/core/src/backend/builtin/TensorBuilder.cc
+++ b/runtime/onert/core/src/backend/builtin/TensorBuilder.cc
@@ -35,15 +35,6 @@ TensorBuilder::TensorBuilder(const std::shared_ptr<TensorRegistry> &tensor_reg)
   /* empty */
 }
 
-TensorBuilder::TensorBuilder(const std::shared_ptr<TensorRegistry> &tensor_reg,
-                             const std::string planner_id)
-  : _tensor_reg{tensor_reg}, _dynamic_tensor_mgr{new DynamicTensorManager(_tensor_reg->base_reg())},
-    _static_tensor_mgr{new basic::StaticTensorManager(_tensor_reg->base_reg(), planner_id,
-                                                      _dynamic_tensor_mgr.get())}
-{
-  /* empty */
-}
-
 void TensorBuilder::registerTensorInfo(const ir::OperandIndex &ind, const ir::OperandInfo &info,
                                        ir::Layout backend_layout)
 {

--- a/runtime/onert/core/src/backend/builtin/TensorBuilder.h
+++ b/runtime/onert/core/src/backend/builtin/TensorBuilder.h
@@ -38,7 +38,6 @@ class TensorBuilder
 {
 public:
   TensorBuilder(const std::shared_ptr<TensorRegistry> &tensor_reg);
-  TensorBuilder(const std::shared_ptr<TensorRegistry> &tensor_reg, const std::string planner_id);
 
   /**
    * @brief     Register tensor information to allocate on CPU backend

--- a/runtime/onert/core/src/backend/builtin/train/KernelGenerator.cc
+++ b/runtime/onert/core/src/backend/builtin/train/KernelGenerator.cc
@@ -29,10 +29,8 @@ namespace train
 
 KernelGenerator::KernelGenerator(const ir::train::TrainableGraph &tgraph,
                                  const std::shared_ptr<TensorRegistry> &tensor_reg,
-                                 const std::shared_ptr<TensorRegistry> &deriv_tensor_reg,
                                  const std::shared_ptr<ExternalContext> &external_context)
-  : KernelGeneratorBase{tgraph}, _tensor_reg{tensor_reg}, _deriv_tensor_reg{deriv_tensor_reg},
-    _external_context(external_context)
+  : KernelGeneratorBase{tgraph}, _tensor_reg{tensor_reg}, _external_context(external_context)
 {
 }
 

--- a/runtime/onert/core/src/backend/builtin/train/KernelGenerator.h
+++ b/runtime/onert/core/src/backend/builtin/train/KernelGenerator.h
@@ -18,7 +18,7 @@
 #define __ONERT_BACKEND_BUTIN_TRAIN_KERNEL_GENERATOR_H__
 
 #include "../ExternalContext.h"
-#include "../TensorRegistry.h"
+#include "../train/TensorRegistry.h"
 #include "../../../compiler/TensorRegistries.h"
 
 #include <backend/train/KernelGeneratorBase.h>
@@ -39,7 +39,6 @@ class KernelGenerator : public backend::train::KernelGeneratorBase
 public:
   KernelGenerator(const ir::train::TrainableGraph &tgraph,
                   const std::shared_ptr<TensorRegistry> &tensor_reg,
-                  const std::shared_ptr<TensorRegistry> &deriv_tensor_reg,
                   const std::shared_ptr<ExternalContext> &external_context);
 
   std::unique_ptr<exec::train::TrainableFnSequence> generate(ir::OperationIndex ind) override;
@@ -63,7 +62,6 @@ private:
 
 private:
   std::shared_ptr<TensorRegistry> _tensor_reg;
-  std::shared_ptr<TensorRegistry> _deriv_tensor_reg;
   compiler::TensorRegistries _tensor_registries;
   compiler::TensorRegistries _deriv_tensor_registries;
   const std::shared_ptr<ExternalContext> _external_context;


### PR DESCRIPTION
This commit changes TensorRegistry in builtin backend.
  - Remove TensorBuilders for training from builtin backend
  - Replace TensorRegistry with train::TensorRegistry

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>