### PR TITLE
[infra/nncc] Remove unnecessary cmake option

### DIFF
--- a/infra/nncc/cmake/options/options_aarch64-linux.cmake
+++ b/infra/nncc/cmake/options/options_aarch64-linux.cmake
@@ -2,4 +2,3 @@
 # aarch64 linux cmake options
 #
 
-option(BUILD_ARM64_NEON "Use NEON for ARM64 build" ON)


### PR DESCRIPTION
- Remove BUILD_ARM64_NEON option for aarch64.

ONE-DCO-1.0-Signed-off-by: Sung-Jae Lee <sj925.lee@samsung.com>