### PR TITLE
[onert] Refine TrainableBackendContext in builtin backend

### DIFF
--- a/runtime/onert/core/src/backend/builtin/train/BackendContext.h
+++ b/runtime/onert/core/src/backend/builtin/train/BackendContext.h
@@ -49,9 +49,6 @@ public:
   backend::ITensorRegistry *genTensors() override;
   backend::train::ITensorRegistry *genTrainingTensors() override;
 
-private:
-  void genDerivativeTensors();
-
 public:
   backend::train::FunctionMap genKernels() override;
 


### PR DESCRIPTION
This commit refines TrainableBackendContext in builtin backend.
  - Remove generating tensors
  - Remove initializing constant operands

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>