### PR TITLE
[tools/onert_train] Change Loss function type

### DIFF
--- a/tests/tools/onert_train/src/args.cc
+++ b/tests/tools/onert_train/src/args.cc
@@ -212,7 +212,10 @@ void Args::Initialize(void)
     ("epoch", po::value<int>()->default_value(5)->notifier([&](const auto &v) { _epoch = v; }), "Epoch number (default: 5)")
     ("batch_size", po::value<int>()->default_value(32)->notifier([&](const auto &v) { _batch_size = v; }), "Batch size (default: 32)")
     ("learning_rate", po::value<float>()->default_value(1.0e-4)->notifier([&](const auto &v) { _learning_rate = v; }), "Learning rate (default: 1.0e-4)")
-    ("loss", po::value<std::string>()->default_value("mse")->notifier([&] (const auto &v) { _loss_function = v; }), "Loss function name (default: mse)")
+    ("loss", po::value<int>()->default_value(0)->notifier([&] (const auto &v) { _loss_type = v; }),
+        "Loss type\n"
+        "0: MEAN_SQUARED_ERROR (default)\n"
+        "1: CATEGORICAL_CROSSENTROPY\n")
     ("optimizer", po::value<std::string>()->default_value("sgd")->notifier([&] (const auto &v) { _optimizer = v; }), "Optimizer name (default: sgd)")
     ("verbose_level,v", po::value<int>()->default_value(0)->notifier([&](const auto &v) { _verbose_level = v; }),
          "Verbose level\n"

--- a/tests/tools/onert_train/src/args.h
+++ b/tests/tools/onert_train/src/args.h
@@ -55,7 +55,7 @@ public:
   const int getEpoch(void) const { return _epoch; }
   const int getBatchSize(void) const { return _batch_size; }
   const float getLearningRate(void) const { return _learning_rate; }
-  const std::string &getLossFunction(void) const { return _loss_function; }
+  const int getLossType(void) const { return _loss_type; }
   const std::string &getOptimizer(void) const { return _optimizer; }
   const bool printVersion(void) const { return _print_version; }
   const int getVerboseLevel(void) const { return _verbose_level; }
@@ -78,7 +78,7 @@ private:
   int _epoch;
   int _batch_size;
   float _learning_rate;
-  std::string _loss_function;
+  int _loss_type;
   std::string _optimizer;
   bool _print_version = false;
   int _verbose_level;


### PR DESCRIPTION
This commit changes loss function argument type from string to int.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

draft: #11035