### PR TITLE
[onert] Unify TensorRegistry for training

### DIFF
--- a/runtime/onert/backend/train/Backend.h
+++ b/runtime/onert/backend/train/Backend.h
@@ -53,14 +53,11 @@ public:
     const auto &tgraph = *tdata.tgraph;
     auto tr = std::make_shared<TensorRegistry>();
     auto tb = std::make_shared<TensorBuilder>(tr, "Bump");
-    auto deriv_tr = std::make_shared<TensorRegistry>();
-    auto deriv_tb = std::make_shared<TensorBuilder>(deriv_tr, "Bump");
     auto tdata_ptr = std::make_unique<backend::train::TrainableContextData>(std::move(tdata));
-    auto context = std::make_unique<train::BackendContext>(this, std::move(tdata_ptr), tr, tb,
-                                                           deriv_tr, deriv_tb);
+    auto context = std::make_unique<train::BackendContext>(this, std::move(tdata_ptr), tr, tb);
 
     context->kernel_gen =
-      std::make_shared<train::KernelGenerator>(tgraph, tr, deriv_tr, context->external_context());
+      std::make_shared<train::KernelGenerator>(tgraph, tr, context->external_context());
     return context;
   }
 

--- a/runtime/onert/backend/train/BackendContext.h
+++ b/runtime/onert/backend/train/BackendContext.h
@@ -52,23 +52,17 @@ class BackendContext : public onert::backend::train::TrainableBackendContext
 {
 public:
   BackendContext(const ITrainableBackend *backend, std::unique_ptr<TrainableContextData> &&tdata,
-                 std::shared_ptr<backend::ITensorRegistry> tensor_registry = nullptr,
+                 std::shared_ptr<backend::train::ITensorRegistry> tensor_registry = nullptr,
                  std::shared_ptr<TensorBuilder> tensor_builder = nullptr,
-                 std::shared_ptr<backend::ITensorRegistry> deriv_tensor_registry = nullptr,
-                 std::shared_ptr<TensorBuilder> deriv_tensor_builder = nullptr,
                  std::shared_ptr<KernelGenerator> kernel_gen = nullptr)
-    : onert::backend::train::TrainableBackendContext(backend, std::move(tdata), tensor_registry,
-                                                     deriv_tensor_registry),
-      kernel_gen{kernel_gen}, _external_context(new ExternalContext),
-      _tensor_builder{tensor_builder}, _deriv_tensor_builder{deriv_tensor_builder}
+    : onert::backend::train::TrainableBackendContext(backend, std::move(tdata), tensor_registry),
+      kernel_gen{kernel_gen},
+      _external_context(new ExternalContext), _tensor_builder{tensor_builder}
   {
   }
 
   backend::ITensorRegistry *genTensors() override;
-  backend::ITensorRegistry *genTrainingTensors() override;
-
-private:
-  void genDerivativeTensors();
+  backend::train::ITensorRegistry *genTrainingTensors() override;
 
 public:
   FunctionMap genKernels() override;
@@ -87,7 +81,6 @@ private:
 
 private:
   std::shared_ptr<TensorBuilder> _tensor_builder;
-  std::shared_ptr<TensorBuilder> _deriv_tensor_builder;
 };
 
 } // namespace train

--- a/runtime/onert/backend/train/KernelGenerator.cc
+++ b/runtime/onert/backend/train/KernelGenerator.cc
@@ -78,11 +78,9 @@ std::unique_ptr<exec::train::TrainableFnSequence> KernelGenerator::generate(ir::
 
 KernelGenerator::KernelGenerator(const ir::train::TrainableGraph &tgraph,
                                  const std::shared_ptr<TensorRegistry> &tensor_reg,
-                                 const std::shared_ptr<TensorRegistry> &deriv_tensor_reg,
                                  const std::shared_ptr<ExternalContext> &external_context)
   : backend::train::KernelGeneratorBase{tgraph}, _current_layout{tgraph.layout()},
-    _tensor_reg{tensor_reg}, _deriv_tensor_reg{deriv_tensor_reg},
-    _external_context(external_context)
+    _tensor_reg{tensor_reg}, _external_context(external_context)
 {
   // DO NOTHING
 }

--- a/runtime/onert/backend/train/KernelGenerator.h
+++ b/runtime/onert/backend/train/KernelGenerator.h
@@ -39,7 +39,6 @@ class KernelGenerator : public backend::train::KernelGeneratorBase
 public:
   KernelGenerator(const ir::train::TrainableGraph &tgraph,
                   const std::shared_ptr<TensorRegistry> &tensor_reg,
-                  const std::shared_ptr<TensorRegistry> &deriv_tensor_reg,
                   const std::shared_ptr<ExternalContext> &external_context);
 
   std::unique_ptr<exec::train::TrainableFnSequence> generate(ir::OperationIndex op_ind) override;
@@ -49,7 +48,6 @@ public:
 private:
   ir::Layout _current_layout;
   std::shared_ptr<TensorRegistry> _tensor_reg;
-  std::shared_ptr<TensorRegistry> _deriv_tensor_reg;
   const std::shared_ptr<ExternalContext> _external_context;
 };
 

--- a/runtime/onert/backend/train/TensorBuilder.cc
+++ b/runtime/onert/backend/train/TensorBuilder.cc
@@ -125,6 +125,10 @@ void TensorBuilder::allocate(void)
 {
   _tensor_mgr->allocateNonConstTensors();
   _tensor_mgr->allocateTrainableTensors();
+}
+
+void TensorBuilder::allocateBackward(void)
+{
   _tensor_mgr->allocateDerivativeTensors();
   _tensor_mgr->allocateGradientTensors();
 }

--- a/runtime/onert/backend/train/TensorBuilder.h
+++ b/runtime/onert/backend/train/TensorBuilder.h
@@ -60,6 +60,7 @@ public:
   bool isRegisteredBackward(const ir::OperandIndex &) const;
 
   void allocate(void);
+  void allocateBackward(void);
 
 private:
   const std::shared_ptr<TensorRegistry> _tensor_reg;

--- a/runtime/onert/core/include/backend/train/TrainableBackendContext.h
+++ b/runtime/onert/core/include/backend/train/TrainableBackendContext.h
@@ -18,7 +18,7 @@
 #define __ONERT_BACKEND_BACKEND_TRAIN_TRAINABLE_CONTEXT_H__
 
 #include "backend/Backend.h"
-#include "backend/ITensorRegistry.h"
+#include "backend/train/ITensorRegistry.h"
 #include "backend/train/ITrainableBackend.h"
 #include "exec/train/TrainableFnSequence.h"
 #include "ir/OperandIndexMap.h"
@@ -56,10 +56,8 @@ class TrainableBackendContext
 public:
   TrainableBackendContext(const ITrainableBackend *backend,
                           std::unique_ptr<TrainableContextData> &&tdata,
-                          std::shared_ptr<backend::ITensorRegistry> tensor_registry = nullptr,
-                          std::shared_ptr<backend::ITensorRegistry> deriv_tensor_registry = nullptr)
-    : _backend{backend}, _tdata{std::move(tdata)}, _tensor_registry{tensor_registry},
-      _deriv_tensor_registry{deriv_tensor_registry}
+                          std::shared_ptr<ITensorRegistry> tensor_registry = nullptr)
+    : _backend{backend}, _tdata{std::move(tdata)}, _tensor_registry{tensor_registry}
   {
     assert(_tdata);
   }
@@ -73,14 +71,10 @@ public:
   const util::Set<ir::OperandIndex> &external_operands() const { return _tdata->external_operands; }
   const ir::OperandIndexMap<ir::Layout> &operand_layouts() const { return _tdata->operand_layouts; }
 
-  std::shared_ptr<backend::ITensorRegistry> tensor_registry() { return _tensor_registry; }
-  std::shared_ptr<backend::ITensorRegistry> deriv_tensor_registry()
-  {
-    return _deriv_tensor_registry;
-  }
+  std::shared_ptr<ITensorRegistry> tensor_registry() { return _tensor_registry; }
 
   virtual ITensorRegistry *genTrainingTensors() = 0;
-  virtual ITensorRegistry *genTensors() = 0;
+  virtual backend::ITensorRegistry *genTensors() = 0;
   virtual FunctionMap genKernels() = 0;
 
 private:
@@ -90,8 +84,7 @@ protected:
   std::unique_ptr<TrainableContextData> _tdata;
 
 protected:
-  std::shared_ptr<backend::ITensorRegistry> _tensor_registry;
-  std::shared_ptr<backend::ITensorRegistry> _deriv_tensor_registry;
+  std::shared_ptr<ITensorRegistry> _tensor_registry;
 };
 
 using TrainableBackendContexts =

--- a/runtime/onert/core/src/backend/builtin/train/BackendContext.cc
+++ b/runtime/onert/core/src/backend/builtin/train/BackendContext.cc
@@ -28,25 +28,22 @@ namespace builtin
 namespace train
 {
 
-ITensorRegistry *BackendContext::genTensors()
+backend::ITensorRegistry *BackendContext::genTensors()
 {
   return basic::train::genTensors(*this, _tensor_builder);
 }
 
-ITensorRegistry *BackendContext::genTrainingTensors()
+backend::train::ITensorRegistry *BackendContext::genTrainingTensors()
 {
-  genDerivativeTensors();
-
-  // TODO Generate training-related tensors except for derivative
-
-  return deriv_tensor_registry().get();
+  // For now, there is no need to generate tensors for backwarding.
+  return tensor_registry().get();
 }
 
 void BackendContext::genDerivativeTensors()
 {
   const ir::train::TrainableGraph &tgraph = *trainable_graph();
-  auto tensor_builder = _deriv_tensor_builder;
-  auto tensor_reg = deriv_tensor_registry();
+  auto tensor_builder = _tensor_builder;
+  auto tensor_reg = tensor_registry();
 
   tgraph.operands().iterate([&](const ir::OperandIndex &ind, const ir::Operand &) {
     if (external_operands().contains(ind))

--- a/runtime/onert/core/src/backend/builtin/train/BackendContext.h
+++ b/runtime/onert/core/src/backend/builtin/train/BackendContext.h
@@ -37,20 +37,17 @@ class BackendContext : public backend::train::TrainableBackendContext
 public:
   BackendContext(const backend::train::ITrainableBackend *backend,
                  std::unique_ptr<backend::train::TrainableContextData> &&data,
-                 std::shared_ptr<ITensorRegistry> tensor_registry = nullptr,
+                 std::shared_ptr<backend::train::ITensorRegistry> tensor_registry = nullptr,
                  std::shared_ptr<TensorBuilder> tensor_builder = nullptr,
-                 std::shared_ptr<ITensorRegistry> deriv_tensor_registry = nullptr,
-                 std::shared_ptr<TensorBuilder> deriv_tensor_builder = nullptr,
                  std::shared_ptr<KernelGenerator> kernel_gen = nullptr)
-    : backend::train::TrainableBackendContext(backend, std::move(data), tensor_registry,
-                                              deriv_tensor_registry),
-      kernel_gen{kernel_gen}, _external_context(new ExternalContext),
-      _tensor_builder{tensor_builder}, _deriv_tensor_builder{deriv_tensor_builder}
+    : backend::train::TrainableBackendContext(backend, std::move(data), tensor_registry),
+      kernel_gen{kernel_gen},
+      _external_context(new ExternalContext), _tensor_builder{tensor_builder}
   {
   }
 
-  ITensorRegistry *genTensors() override;
-  ITensorRegistry *genTrainingTensors() override;
+  backend::ITensorRegistry *genTensors() override;
+  backend::train::ITensorRegistry *genTrainingTensors() override;
 
 private:
   void genDerivativeTensors();
@@ -72,7 +69,6 @@ private:
 
 private:
   std::shared_ptr<TensorBuilder> _tensor_builder;
-  std::shared_ptr<TensorBuilder> _deriv_tensor_builder;
 };
 
 } // namespace train

--- a/runtime/onert/core/src/backend/builtin/train/KernelGenerator.cc
+++ b/runtime/onert/core/src/backend/builtin/train/KernelGenerator.cc
@@ -79,7 +79,7 @@ backend::ITensor *KernelGenerator::getTensor(const ir::OperandIndex &index)
 backend::ITensor *KernelGenerator::getDerivativeTensor(const ir::OperandIndex &index)
 {
   // Get derivative Tensor from all tensor registries (for Permute op)
-  auto ret = _deriv_tensor_registries.getITensor(index);
+  auto ret = _tensor_registries.getDerivativeITensor(index);
   assert(ret != nullptr);
   return ret;
 }

--- a/runtime/onert/core/src/backend/builtin/train/KernelGenerator.h
+++ b/runtime/onert/core/src/backend/builtin/train/KernelGenerator.h
@@ -19,7 +19,7 @@
 
 #include "../ExternalContext.h"
 #include "../train/TensorRegistry.h"
-#include "../../../compiler/TensorRegistries.h"
+#include "../../../compiler/train/TensorRegistries.h"
 
 #include <backend/train/KernelGeneratorBase.h>
 #include <exec/train/TrainableFnSequence.h>
@@ -43,14 +43,9 @@ public:
 
   std::unique_ptr<exec::train::TrainableFnSequence> generate(ir::OperationIndex ind) override;
 
-  void setTensorRegistries(const compiler::TensorRegistries &tensor_registries)
+  void setTensorRegistries(const compiler::train::TensorRegistries &tensor_registries)
   {
     _tensor_registries = tensor_registries;
-  }
-
-  void setDerivativeTensorRegistries(const compiler::TensorRegistries &tensor_registries)
-  {
-    _deriv_tensor_registries = tensor_registries;
   }
 
 private:
@@ -62,8 +57,7 @@ private:
 
 private:
   std::shared_ptr<TensorRegistry> _tensor_reg;
-  compiler::TensorRegistries _tensor_registries;
-  compiler::TensorRegistries _deriv_tensor_registries;
+  compiler::train::TensorRegistries _tensor_registries;
   const std::shared_ptr<ExternalContext> _external_context;
 };
 

--- a/runtime/onert/core/src/backend/builtin/train/TensorRegistry.h
+++ b/runtime/onert/core/src/backend/builtin/train/TensorRegistry.h
@@ -39,6 +39,8 @@ using BaseTensorRegistry =
 class TensorRegistry : public backend::train::ITensorRegistry
 {
 public:
+  TensorRegistry() : _base_reg{new BaseTensorRegistry} {}
+
   ITensor *getITensor(const ir::OperandIndex &index) override
   {
     auto base_tensor = _base_reg->getITensor(index);

--- a/runtime/onert/core/src/compiler/ExecutorFactory.cc
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.cc
@@ -134,15 +134,15 @@ void initializeSubgraphIOTensors(compiler::ILoweredGraph &lowered_graph,
                                  const backend::train::TrainableBackendContexts &backend_contexts,
                                  const ir::OperandIndexSequence &indices)
 {
-  std::shared_ptr<backend::builtin::TensorRegistry> builtin_tensor_reg;
+  std::shared_ptr<backend::builtin::train::TensorRegistry> builtin_tensor_reg;
   for (const auto &e : backend_contexts)
   {
     auto backend = e.first;
     auto &context = e.second;
     if (backend->config()->id() == backend::builtin::Config::ID)
     {
-      builtin_tensor_reg =
-        std::dynamic_pointer_cast<backend::builtin::TensorRegistry>(context->tensor_registry());
+      builtin_tensor_reg = std::dynamic_pointer_cast<backend::builtin::train::TensorRegistry>(
+        context->tensor_registry());
     }
   }
   assert(builtin_tensor_reg);
@@ -626,8 +626,7 @@ void ExecutorFactory::prepareMigrantTensors(
   compiler::ILoweredGraph &lowered_graph,
   const backend::train::TrainableBackendContexts &backend_contexts)
 {
-  const auto is_derivative = false;
-  TensorRegistries tensor_regs{backend_contexts, is_derivative};
+  train::TensorRegistries tensor_regs{backend_contexts, true};
 
   lowered_graph.graph().operations().iterate(
     [&](const ir::OperationIndex &op_ind, const ir::IOperation &op) {
@@ -719,8 +718,7 @@ exec::IExecutor *ExecutorFactory::createTrainableExecutor(
   }
   base_backend_contexts.clear();
 
-  TensorRegistries derivative_tensor_regs{tbackend_contexts, true};
-  TensorRegistries tensor_regs{tbackend_contexts, false};
+  train::TensorRegistries tensor_regs{tbackend_contexts, false};
 
   initializeSubgraphIOTensors(
     *lowered_graph, tbackend_contexts,
@@ -752,7 +750,6 @@ exec::IExecutor *ExecutorFactory::createTrainableExecutor(
     if (builtin_context != nullptr)
     {
       auto builtin_kernel_gen = builtin_context->kernel_gen;
-      builtin_kernel_gen->setTensorRegistries(derivative_tensor_regs);
       builtin_kernel_gen->setTensorRegistries(tensor_regs);
     }
   }

--- a/runtime/onert/core/src/compiler/TensorRegistries.h
+++ b/runtime/onert/core/src/compiler/TensorRegistries.h
@@ -22,9 +22,6 @@
 
 #include "backend/Backend.h"
 #include "backend/BackendContext.h"
-#ifdef ONERT_TRAIN
-#include "backend/train/TrainableBackendContext.h"
-#endif // ONERT_TRAIN
 
 #include <memory>
 #include <unordered_set>
@@ -57,24 +54,6 @@ public:
       }
     }
   }
-
-#ifdef ONERT_TRAIN
-  TensorRegistries(const backend::train::TrainableBackendContexts &backend_contexts,
-                   bool is_derivative)
-  {
-    for (const auto &e : backend_contexts)
-    {
-      auto tensor_reg =
-        is_derivative ? e.second->deriv_tensor_registry() : e.second->tensor_registry();
-      if (e.first->config()->id() == backend::builtin::Config::ID)
-      {
-        _builtin_tensor_reg =
-          std::dynamic_pointer_cast<backend::builtin::TensorRegistry>(tensor_reg);
-      }
-      _tensor_regs.insert(tensor_reg);
-    }
-  }
-#endif // ONERT_TRAIN
 
   std::unordered_set<std::shared_ptr<onert::backend::ITensorRegistry>>::const_iterator begin() const
   {

--- a/runtime/onert/core/src/exec/train/TrainableExecutor.cc
+++ b/runtime/onert/core/src/exec/train/TrainableExecutor.cc
@@ -31,8 +31,9 @@ namespace train
 TrainableExecutor::TrainableExecutor(
   std::unique_ptr<compiler::train::LoweredTrainableGraph> lowered_graph,
   backend::train::TrainableBackendContexts &&backend_contexts,
-  const compiler::TensorRegistries &tensor_regs, compiler::train::TrainableCodeMap &&code_map,
-  const std::vector<ir::OperationIndex> &order, const util::TracingCtx *tracing_ctx)
+  const compiler::train::TensorRegistries &tensor_regs,
+  compiler::train::TrainableCodeMap &&code_map, const std::vector<ir::OperationIndex> &order,
+  const util::TracingCtx *tracing_ctx)
   : _lowered_graph{std::move(lowered_graph)}, _backend_contexts{std::move(backend_contexts)},
     _trainable_graph{_lowered_graph->trainable_graph()}, _mutex(), _tracing_ctx(tracing_ctx)
 {

--- a/runtime/onert/core/src/exec/train/TrainableExecutor.h
+++ b/runtime/onert/core/src/exec/train/TrainableExecutor.h
@@ -20,7 +20,7 @@
 #include "exec/IExecutor.h"
 
 #include "../ExecutionObservee.h"
-#include "../../compiler/TensorRegistries.h"
+#include "../../compiler/train/TensorRegistries.h"
 
 #include "backend/train/TrainableBackendContext.h"
 #include "compiler/train/TrainableCodeMap.h"
@@ -46,7 +46,7 @@ public:
    */
   TrainableExecutor(std::unique_ptr<compiler::train::LoweredTrainableGraph> lowered_graph,
                     backend::train::TrainableBackendContexts &&backend_contexts,
-                    const compiler::TensorRegistries &tensor_regs,
+                    const compiler::train::TensorRegistries &tensor_regs,
                     compiler::train::TrainableCodeMap &&code_map,
                     const std::vector<ir::OperationIndex> &order,
                     const util::TracingCtx *tracing_ctx);


### PR DESCRIPTION
This commit unifies TensorRegistry for training.
  - Unify TensorRegistry in train backend
  - Unify TensorRegistry for training in builtin backend
  - Use TensorRegistries for training for each backend context

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>