### PR TITLE
[onert] Remove Permute op from outputs of trainable graph

### DIFF
--- a/runtime/onert/core/src/compiler/train/LoweredTrainableGraph.cc
+++ b/runtime/onert/core/src/compiler/train/LoweredTrainableGraph.cc
@@ -21,11 +21,11 @@
 #include "../pass/ConstantLoweringPass.h"
 #include "../pass/PassRunner.h"
 #include "../pass/PermutationEliminationPass.h"
-#include "../pass/PermutationInsertionPass.h"
 #include "../pass/PermutationOperationPass.h"
 #include "../../backend/builtin/Config.h"
 #include "../../dumper/text/GraphDumper.h"
 #include "../../ir/verifier/Verifier.h"
+#include "pass/PermutationInsertionPass.h"
 #include "TrainableOperationConverter.h"
 
 #include "backend/Backend.h"
@@ -101,7 +101,7 @@ void LoweredTrainableGraph::lowerGraph(const CompilerOptions &options)
     .append(std::make_unique<compiler::pass::ConstantInsertionPass>(*this))
     .append(std::make_unique<compiler::pass::ConstantLoweringPass>(*this))
     .append(std::make_unique<compiler::pass::PermutationOperationPass>(*this))
-    .append(std::make_unique<compiler::pass::PermutationInsertionPass>(*this))
+    .append(std::make_unique<compiler::train::pass::PermutationInsertionPass>(*this))
     .run();
 
   // TODO Move converting Permute op into PermutationInsertionPass

--- a/runtime/onert/core/src/compiler/train/pass/PermutationInsertionPass.cc
+++ b/runtime/onert/core/src/compiler/train/pass/PermutationInsertionPass.cc
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "PermutationInsertionPass.h"
+
+namespace onert
+{
+namespace compiler
+{
+namespace train
+{
+namespace pass
+{
+
+void PermutationInsertionPass::callback(const ir::OperandIndex &index, ir::Operand &object)
+{
+  // NOTE Permutation is not inserted for outputs of trainable graph unless user requests result of
+  //      output.
+  if (_graph.getOutputs().contains(index))
+    return;
+
+  compiler::pass::PermutationInsertionPass::callback(index, object);
+}
+
+} // namespace pass
+} // namespace train
+} // namespace compiler
+} // namespace onert

--- a/runtime/onert/core/src/compiler/train/pass/PermutationInsertionPass.h
+++ b/runtime/onert/core/src/compiler/train/pass/PermutationInsertionPass.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_COMPILER_TRAIN_PASS_PERMUTATION_INSERTION_PASS_H__
+#define __ONERT_COMPILER_TRAIN_PASS_PERMUTATION_INSERTION_PASS_H__
+
+#include "../../pass/PermutationInsertionPass.h"
+
+namespace onert
+{
+namespace compiler
+{
+namespace train
+{
+namespace pass
+{
+
+class PermutationInsertionPass : public compiler::pass::PermutationInsertionPass
+{
+public:
+  using compiler::pass::PermutationInsertionPass::PermutationInsertionPass;
+
+public:
+  void callback(const ir::OperandIndex &index, ir::Operand &object) final;
+};
+
+} // namespace pass
+} // namespace train
+} // namespace compiler
+} // namespace onert
+
+#endif // __ONERT_COMPILER_TRAIN_PASS_PERMUTATION_INSERTION_PASS_H__


### PR DESCRIPTION
This commit makes Permute operation not to be inserted for outputs of trainable graph.
  - Introduce PermutationInsertionPass for training and apply it

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>