### PR TITLE
[onert] Introduce MEAN_SQUARED_ERROR to Loss operation

### DIFF
--- a/runtime/onert/core/include/ir/operation/Loss.h
+++ b/runtime/onert/core/include/ir/operation/Loss.h
@@ -41,6 +41,7 @@ public:
   //      from the object of this class, we have to consider whether to change this enum class.
   enum class Type
   {
+    MEAN_SQUARED_ERROR,
     CATEGORICAL_CROSSENTROPY
   };
 
@@ -48,7 +49,7 @@ public:
   {
     Type op_type;
     // TODO Add more params if necessary
-    Param() : op_type(Type::CATEGORICAL_CROSSENTROPY) {}
+    Param() : op_type(Type::MEAN_SQUARED_ERROR) {}
   };
 
 public:

--- a/runtime/onert/core/src/ir/operation/Loss.cc
+++ b/runtime/onert/core/src/ir/operation/Loss.cc
@@ -42,6 +42,7 @@ std::string Loss::name() const
 {
   using LossType = onert::ir::operation::Loss::Type;
   static const std::unordered_map<Type, std::string> name_map{
+    {LossType::MEAN_SQUARED_ERROR, "MeanSquaredError Loss"},
     {LossType::CATEGORICAL_CROSSENTROPY, "CategoricalCrossentropy Loss"}};
   return name_map.at(_param.op_type);
 }


### PR DESCRIPTION
This commit introduces MEAN_SQUARED_ERROR to Loss operation. Since CATEGORICAL_CROSSENTROPY may not operate according to the model structure, the default type of loss op has also been changed to MEAN_SQUARED_ERROR.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Draft : #11035 