### PR TITLE
[onert] Implement LossInsertionPass

### DIFF
--- a/runtime/onert/core/include/compiler/train/TrainingInfo.h
+++ b/runtime/onert/core/include/compiler/train/TrainingInfo.h
@@ -19,6 +19,7 @@
 
 #include "ir/Index.h"
 #include "exec/train/optimizer/OptimizerCode.h"
+#include "ir/operation/Loss.h"
 
 namespace onert
 {
@@ -29,6 +30,7 @@ namespace train
 
 struct LossInfo
 {
+  ir::operation::Loss::Type type;
   // TODO Add members for loss
 };
 

--- a/runtime/onert/core/src/compiler/train/TrainingCompiler.cc
+++ b/runtime/onert/core/src/compiler/train/TrainingCompiler.cc
@@ -139,8 +139,12 @@ std::shared_ptr<CompilerArtifact> TrainingCompiler::compile(void)
   for (auto &&pair : trainable_subgraphs)
   {
     auto trainable_subg = pair.second;
+    auto subg_index = pair.first;
 
-    // TODO Apply LossInsertionPass
+    compiler::pass::PassRunner{}
+      .append(std::make_unique<train::pass::LossInsertionPass>(*trainable_subg, &_training_info,
+                                                               subg_index))
+      .run();
   }
 
   /***************************************************


### PR DESCRIPTION
This commit implements LossInsertionPass.
This function runs in the middle of constructing the trainable graph. Loss uses the original graph output as y_pred input. And it creates y_true input in the same shape and type as y_pred input. The output is Scalar tensor by default.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Draft: #11035 