### PR TITLE
[onert] Implement Loss visitor function in OperationDumper

### DIFF
--- a/runtime/onert/core/src/ir/OperationDumper.cc
+++ b/runtime/onert/core/src/ir/OperationDumper.cc
@@ -202,6 +202,14 @@ void OperationDumper::visit(const L2Normalization &node) { dumpOpGeneric(node); 
 
 void OperationDumper::visit(const LocalResponseNormalization &node) { dumpOpGeneric(node); }
 
+void OperationDumper::visit(const Loss &node)
+{
+  VERBOSE(LIR) << "* " << node.name() << std::endl;
+  VERBOSE(LIR) << " - Inputs : Prediction(" << node.getInputs().at(Loss::Input::Y_PRED) << ") True("
+               << node.getInputs().at(Loss::Input::Y_TRUE) << ")" << std::endl;
+  VERBOSE(LIR) << " - Outputs : Output(" << node.getOutputs().at(0) << ")" << std::endl;
+}
+
 void OperationDumper::visit(const LSTM &node)
 {
   VERBOSE(LIR) << "* " << node.name() << std::endl;

--- a/runtime/onert/core/src/ir/OperationDumper.h
+++ b/runtime/onert/core/src/ir/OperationDumper.h
@@ -55,6 +55,7 @@ public:
   void visit(const operation::InstanceNorm &) override;
   void visit(const operation::L2Normalization &) override;
   void visit(const operation::LocalResponseNormalization &) override;
+  void visit(const operation::Loss &node) override;
   void visit(const operation::LSTM &) override;
   void visit(const operation::Pack &) override;
   void visit(const operation::Pad &) override;


### PR DESCRIPTION
This commit implements Loss visitor function in OperationDumper.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

draft: #11035 