### PR TITLE
[onert] Implement Loss visitor function in StaticShapeInferer

### DIFF
--- a/runtime/onert/core/include/compiler/StaticShapeInferer.h
+++ b/runtime/onert/core/include/compiler/StaticShapeInferer.h
@@ -136,6 +136,7 @@ private:
   void visit(const ir::operation::Gather &op) override;
   void visit(const ir::operation::If &op) override;
   void visit(const ir::operation::L2Normalization &op) override;
+  void visit(const ir::operation::Loss &op) override;
   void visit(const ir::operation::LSTM &op) override;
   void visit(const ir::operation::MatrixBandPart &op) override;
   void visit(const ir::operation::OneHot &op) override;

--- a/runtime/onert/core/src/compiler/StaticShapeInferer.cc
+++ b/runtime/onert/core/src/compiler/StaticShapeInferer.cc
@@ -605,6 +605,23 @@ void StaticShapeInferer::visit(const ir::operation::L2Normalization &op)
   handleSimpleUnaryOp(op, op.getInputs().at(ir::operation::L2Normalization::Input::INPUT));
 }
 
+void StaticShapeInferer::visit(const ir::operation::Loss &op)
+{
+  auto &operands = _lowered_subg->graph().operands();
+
+  const auto y_pred_idx{op.getInputs().at(ir::operation::Loss::Input::Y_PRED)};
+  const auto &y_pred = operands.at(y_pred_idx);
+
+  const auto y_true_idx{op.getInputs().at(ir::operation::Loss::Input::Y_TRUE)};
+  auto &y_true = operands.at(y_true_idx);
+
+  // TODO Consider SparseCategoricalCrossentropy case
+
+  y_true.info().shape(y_pred.info().shape());
+
+  // TODO Consider output shape in case of reduction option
+}
+
 void StaticShapeInferer::visit(const ir::operation::LSTM &op)
 {
   auto &operands = _lowered_subg->graph().operands();


### PR DESCRIPTION
This commit implements Loss visitor function in StaticShapeInferer.
The Y_TRUE input should be the same shape as Y_PRED.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Draft: #11035 