### PR TITLE
[tools/onert_train] Do not change input and expected tensorinfo

### DIFF
--- a/tests/tools/onert_train/src/onert_train.cc
+++ b/tests/tools/onert_train/src/onert_train.cc
@@ -193,15 +193,13 @@ int main(const int argc, char **argv)
         // prepare input
         for (uint32_t i = 0; i < num_inputs; ++i)
         {
-          NNPR_ENSURE_STATUS(
-            nnfw_train_set_input(session, i, input_data[i].data(), &input_infos[i]));
+          NNPR_ENSURE_STATUS(nnfw_train_set_input(session, i, input_data[i].data(), nullptr));
         }
 
         // prepare output
         for (uint32_t i = 0; i < num_expecteds; ++i)
         {
-          NNPR_ENSURE_STATUS(
-            nnfw_train_set_expected(session, i, expected_data[i].data(), &expected_infos[i]));
+          NNPR_ENSURE_STATUS(nnfw_train_set_expected(session, i, expected_data[i].data(), nullptr));
         }
 
         // train


### PR DESCRIPTION
This commit prevents input and expected tensorinfo from changing. If the last parameter of set_input and set_expected function is not nullptr, the runtime changes the tensorinfo. This tool uses nullptr because it does not change tensorinfo.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Draft : #11035

Related code: https://github.com/Samsung/ONE/blob/276bd85d67bd274b55c767612669a24eb1ca43da/runtime/onert/api/src/nnfw_api_internal.cc#L1246-L1251