### PR TITLE
[tools/onert_train] Do not multiply batch_size to tensor info

### DIFF
--- a/tests/tools/onert_train/src/onert_train.cc
+++ b/tests/tools/onert_train/src/onert_train.cc
@@ -147,19 +147,14 @@ int main(const int argc, char **argv)
     std::vector<nnfw_tensorinfo> expected_infos;
 
     // prepare data buffers
-    std::vector<Allocation> input_data(num_inputs * tri.batch_size);
-    std::vector<Allocation> expected_data(num_expecteds * tri.batch_size);
+    std::vector<Allocation> input_data(num_inputs);
+    std::vector<Allocation> expected_data(num_expecteds);
 
     for (uint32_t i = 0; i < num_inputs; ++i)
     {
       nnfw_tensorinfo ti;
       NNPR_ENSURE_STATUS(nnfw_input_tensorinfo(session, i, &ti));
-
-      auto bufsz = bufsize_for(&ti);
-      for (uint32_t n = 0; n < tri.batch_size; ++n)
-      {
-        input_data[i * tri.batch_size + n].alloc(bufsz);
-      }
+      input_data[i].alloc(bufsize_for(&ti));
       input_infos.emplace_back(std::move(ti));
     }
 
@@ -167,12 +162,7 @@ int main(const int argc, char **argv)
     {
       nnfw_tensorinfo ti;
       NNPR_ENSURE_STATUS(nnfw_output_tensorinfo(session, i, &ti));
-
-      auto bufsz = bufsize_for(&ti);
-      for (uint32_t n = 0; n < tri.batch_size; ++n)
-      {
-        expected_data[i * tri.batch_size + n].alloc(bufsz);
-      }
+      expected_data[i].alloc(bufsize_for(&ti));
       expected_infos.emplace_back(std::move(ti));
     }
 


### PR DESCRIPTION
The tensor info of trainable graph changes the tensor info according to the batch_size during `train_prepare` function.
The onert_train tool does not need to consider the batch_size for tensorinfo. This commit therefore does not multiply batch_size to the tensor info.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

~~waiting : #11112~~
Draft : #11035
Related code:
https://github.com/Samsung/ONE/blob/276bd85d67bd274b55c767612669a24eb1ca43da/runtime/onert/api/src/nnfw_api_internal.cc#L1165-L1174