### PR TITLE
[tools/onert_train] Use loss type argument

### DIFF
--- a/tests/tools/onert_train/src/onert_train.cc
+++ b/tests/tools/onert_train/src/onert_train.cc
@@ -116,10 +116,24 @@ int main(const int argc, char **argv)
     verifyInputTypes();
     verifyOutputTypes();
 
+    auto convertLossType = [](int type) {
+      switch (type)
+      {
+        case 0:
+          return NNFW_TRAIN_LOSS_MEAN_SQUARED_ERROR;
+        case 1:
+          return NNFW_TRAIN_LOSS_CATEGORICAL_CROSSENTROPY;
+        default:
+          std::cerr << "E: not supported loss type" << std::endl;
+          exit(-1);
+      }
+    };
+
     // prepare training info
     nnfw_train_info tri;
     tri.batch_size = args.getBatchSize();
     tri.learning_rate = args.getLearningRate();
+    tri.loss = convertLossType(args.getLossType());
 
     // prepare execution
 


### PR DESCRIPTION
This commit uses loss type argument and passes it to nnfw_train_info.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

~~waiting: #11112~~
Draft: #11035 