### PR TITLE
[onert] Introduce NNFW_TRAIN_OPTIMIZER enum to nnfw experimental api

### DIFF
--- a/runtime/onert/api/include/nnfw_experimental.h
+++ b/runtime/onert/api/include/nnfw_experimental.h
@@ -180,6 +180,12 @@ typedef enum
   NNFW_TRAIN_LOSS_CATEGORICAL_CROSSENTROPY = 1,
 } NNFW_TRAIN_LOSS;
 
+typedef enum
+{
+  NNFW_TRAIN_OPTIMIZER_SGD = 0,
+  NNFW_TRAIN_OPTIMIZER_ADAM = 1,
+} NNFW_TRAIN_OPTIMIZER;
+
 /**
  * @brief Training information to prepare training
  * @todo  Add more training information
@@ -193,6 +199,8 @@ typedef struct nnfw_train_info
   uint32_t batch_size = 1;
   /** loss type */
   NNFW_TRAIN_LOSS loss = NNFW_TRAIN_LOSS_MEAN_SQUARED_ERROR;
+  /** optimizer type */
+  NNFW_TRAIN_OPTIMIZER opt = NNFW_TRAIN_OPTIMIZER_SGD;
 } nnfw_train_info;
 
 /**


### PR DESCRIPTION
This commit introduces NNFW_TRAIN_OPTIMIZER enum to nnfw experimental api. nnfw_train_info structure has a opt type as a member variable.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Draft : #11035 