### PR TITLE
[onert] Include builtin train tensor registry in trainable executor

### DIFF
--- a/runtime/onert/core/src/compiler/ExecutorFactory.cc
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.cc
@@ -726,7 +726,7 @@ exec::IExecutor *ExecutorFactory::createTrainableExecutor(
   }
   base_backend_contexts.clear();
 
-  train::TensorRegistries tensor_regs{tbackend_contexts, false};
+  train::TensorRegistries tensor_regs{tbackend_contexts, true};
 
   initializeSubgraphIOTensors(
     *lowered_graph, tbackend_contexts,


### PR DESCRIPTION
This commit includes builtin train tensor registry in trainable executor.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>