### PR TITLE
[onert] Change input shape after loss insertion pass

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -1162,17 +1162,6 @@ NNFW_STATUS nnfw_session::train_prepare(const nnfw_train_info *info)
 
   try
   {
-    for (uint32_t i = 0; i < getInputSize(); ++i)
-    {
-      auto info = _nnpkg->inputInfo(i);
-      onert::ir::Shape new_shape(info.shape());
-      // TODO Consider batch size index
-      if (new_shape.dim(0) != 1)
-        throw std::runtime_error("the first dim is not 1. It is not supported yet.");
-      new_shape.dim(0) = training_info.batchSize();
-      _nnpkg->changeInputShape(i, new_shape);
-    }
-
     auto compiler =
       onert::compiler::CompilerFactory::get().create(_nnpkg, _coptions, &training_info);
     _nnpkg.reset();

--- a/runtime/onert/core/src/compiler/StaticShapeInferer.cc
+++ b/runtime/onert/core/src/compiler/StaticShapeInferer.cc
@@ -605,19 +605,9 @@ void StaticShapeInferer::visit(const ir::operation::L2Normalization &op)
   handleSimpleUnaryOp(op, op.getInputs().at(ir::operation::L2Normalization::Input::INPUT));
 }
 
-void StaticShapeInferer::visit(const ir::operation::Loss &op)
+void StaticShapeInferer::visit(const ir::operation::Loss &)
 {
-  auto &operands = _lowered_subg->graph().operands();
-
-  const auto y_pred_idx{op.getInputs().at(ir::operation::Loss::Input::Y_PRED)};
-  const auto &y_pred = operands.at(y_pred_idx);
-
-  const auto y_true_idx{op.getInputs().at(ir::operation::Loss::Input::Y_TRUE)};
-  auto &y_true = operands.at(y_true_idx);
-
   // TODO Consider SparseCategoricalCrossentropy case
-
-  y_true.info().shape(y_pred.info().shape());
 
   // TODO Consider output shape in case of reduction option
 }

--- a/runtime/onert/core/src/compiler/train/TrainingCompiler.cc
+++ b/runtime/onert/core/src/compiler/train/TrainingCompiler.cc
@@ -147,6 +147,23 @@ std::shared_ptr<CompilerArtifact> TrainingCompiler::compile(void)
       .run();
   }
 
+  // Change input shape according to batch_size
+  for (auto &&pair : trainable_subgraphs)
+  {
+    auto trainable_subg = pair.second;
+
+    for (const auto &ind : trainable_subg->getInputs())
+    {
+      auto &input = trainable_subg->operands().at(ind);
+      auto new_shape = input.info().shape();
+      // TODO Consider batch size index
+      if (new_shape.dim(0) != 1)
+        throw std::runtime_error("the first dim is not 1. It is not supported yet.");
+      new_shape.dim(0) = _training_info.batchSize();
+      input.info().shape(new_shape);
+    }
+  }
+
   /***************************************************
    * Backend independent analysis & optimization phase
    ***************************************************/


### PR DESCRIPTION
This commit changes input shape according to batch_size after loss insertion pass finished. The loss insertion pass adds new input for ground truth and it should be applied with the batch_size.

- Move batch applying code from train_prepare to TrainingCompiler
- Remove the static shape inferer for loss

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>
