### PR TITLE
[onert] Remove creating IOTensors of outputs

### DIFF
--- a/runtime/onert/core/src/compiler/ExecutorFactory.cc
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.cc
@@ -728,10 +728,10 @@ exec::IExecutor *ExecutorFactory::createTrainableExecutor(
 
   train::TensorRegistries tensor_regs{tbackend_contexts, false};
 
-  initializeSubgraphIOTensors(
-    *lowered_graph, tbackend_contexts,
-    (lowered_graph->graph().getInputs() + lowered_graph->graph().getOutputs()) |
-      ir::Remove::DUPLICATED | ir::Remove::UNDEFINED);
+  // NOTE Outputs of trainable graph cannot be IOTensor. They will be built by the owned backend.
+  initializeSubgraphIOTensors(*lowered_graph, tbackend_contexts,
+                              lowered_graph->graph().getInputs() | ir::Remove::DUPLICATED |
+                                ir::Remove::UNDEFINED);
 
   // linearize
   auto order = Linear::linearize(*lowered_graph);


### PR DESCRIPTION
This commit removes creating IOTensors of outputs.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>