### PR TITLE
[loco] Install CanonicalNodes.lst file

### DIFF
--- a/compiler/loco/CMakeLists.txt
+++ b/compiler/loco/CMakeLists.txt
@@ -15,7 +15,7 @@ target_link_libraries(loco PUBLIC nncc_coverage)
 # Q. HOW TO MAKE DEV PACKAGE(?)
 install(TARGETS loco DESTINATION lib)
 install(DIRECTORY include/ DESTINATION include
-        FILES_MATCHING PATTERN "*.h")
+        FILES_MATCHING PATTERN "*.h" PATTERN "*.lst")
 
 if(NOT ENABLE_TEST)
   return()


### PR DESCRIPTION
Let's install CanonicalNodes.lst file.

"CanonicalNodes.lst" is used in installed loco header files. 
So if we include installed loco header file, it can make build fail.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>