### PR TITLE
[circle2circle/test] Dredd test for fuse_gelu

### DIFF
--- a/compiler/circle2circle-dredd-recipe-test/test.lst
+++ b/compiler/circle2circle-dredd-recipe-test/test.lst
@@ -54,6 +54,7 @@ Add(MaxPoolWithArgmax_001 PASS resolve_customop_max_pool_with_argmax)
 Add(MaxPoolWithArgmax_002 PASS resolve_customop_max_pool_with_argmax)
 Add(FullyConnected_007 PASS replace_non_const_fc_with_batch_matmul)
 Add(FullyConnected_008 PASS replace_non_const_fc_with_batch_matmul)
+Add(Net_Gelu_000 PASS fuse_gelu)
 
 ## CIRCLE RECIPE
 


### PR DESCRIPTION
This will enable circle2circle fuse_gelu dredd test with Net_Gelu_000 model.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>