### PR TITLE
[circle-mpqsolver] Dump final qerror

### DIFF
--- a/compiler/circle-mpqsolver/src/bisection/BisectionSolver.cpp
+++ b/compiler/circle-mpqsolver/src/bisection/BisectionSolver.cpp
@@ -170,6 +170,7 @@ std::unique_ptr<luci::Module> BisectionSolver::run(const std::string &module_pat
 
   int last_depth = -1;
   float best_depth = -1;
+  float best_accuracy = -1;
   core::LayerParams best_params;
   if (module->size() != 1)
   {
@@ -266,6 +267,7 @@ std::unique_ptr<luci::Module> BisectionSolver::run(const std::string &module_pat
       int16_front ? (max_depth = cut_depth) : (min_depth = cut_depth);
       best_params = layer_params;
       best_depth = cut_depth;
+      best_accuracy = cur_accuracy;
     }
     else
     {
@@ -278,7 +280,7 @@ std::unique_ptr<luci::Module> BisectionSolver::run(const std::string &module_pat
 
   if (_hooks)
   {
-    _hooks->on_end_solver(best_params, "uint8");
+    _hooks->on_end_solver(best_params, "uint8", best_accuracy);
   }
 
   VERBOSE(l, 0) << "Found the best configuration at depth " << best_depth << std::endl;

--- a/compiler/circle-mpqsolver/src/core/Dumper.cpp
+++ b/compiler/circle-mpqsolver/src/core/Dumper.cpp
@@ -152,3 +152,9 @@ void Dumper::dump_MPQ_error(float error, uint32_t step) const
   std::string path = get_error_path();
   dump_error(error, std::to_string(step), path);
 }
+
+void Dumper::dump_MPQ_error(float error) const
+{
+  std::string path = get_error_path();
+  dump_error(error, "FINAL", path);
+}

--- a/compiler/circle-mpqsolver/src/core/Dumper.h
+++ b/compiler/circle-mpqsolver/src/core/Dumper.h
@@ -86,6 +86,12 @@ public:
    */
   void dump_MPQ_error(float error, uint32_t step) const;
 
+  /**
+   * @brief dump final error
+   * @param error final error of quantization
+   */
+  void dump_MPQ_error(float error) const;
+
 private:
   void write_data_to_file(const std::string &path, const std::string &data) const;
   void dump_MPQ_configuration(const LayerParams &layers, const std::string &def_dtype,

--- a/compiler/circle-mpqsolver/src/core/DumpingHooks.cpp
+++ b/compiler/circle-mpqsolver/src/core/DumpingHooks.cpp
@@ -45,9 +45,11 @@ void DumpingHooks::on_end_iteration(const LayerParams &layers, const std::string
   _dumper.dump_MPQ_error(error, _num_of_iterations);
 }
 
-void DumpingHooks::on_end_solver(const LayerParams &layers, const std::string &def_dtype)
+void DumpingHooks::on_end_solver(const LayerParams &layers, const std::string &def_dtype,
+                                 float qerror)
 {
   _dumper.dump_final_MPQ(layers, def_dtype);
+  _dumper.dump_MPQ_error(qerror);
   _in_iterations = false;
 }
 

--- a/compiler/circle-mpqsolver/src/core/DumpingHooks.h
+++ b/compiler/circle-mpqsolver/src/core/DumpingHooks.h
@@ -67,7 +67,8 @@ public:
   /**
    * @brief called at the end of iterative search
    */
-  virtual void on_end_solver(const LayerParams &layers, const std::string &def_dtype) override;
+  virtual void on_end_solver(const LayerParams &layers, const std::string &def_dtype,
+                             float qerror) override;
 
 protected:
   std::string _model_path;

--- a/compiler/circle-mpqsolver/src/core/SolverHooks.h
+++ b/compiler/circle-mpqsolver/src/core/SolverHooks.h
@@ -57,8 +57,10 @@ public:
    * @brief called at the end of iterative search
    * @param layers model nodes with specific quantization parameters
    * @param def_dtype default quantization dtype
+   * @param qerror final error of quantization
    */
-  virtual void on_end_solver(const LayerParams &layers, const std::string &def_dtype) = 0;
+  virtual void on_end_solver(const LayerParams &layers, const std::string &def_dtype,
+                             float qerror) = 0;
 };
 
 } // namespace core


### PR DESCRIPTION
This commit dumps final error of quantization.

This will ease analysis of `circle-mpqsolver` run.

Related: #11146
ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>