### PR TITLE
[circle-mpqsolver] Fix typo in metric

### DIFF
--- a/compiler/circle-mpqsolver/src/CircleMPQSolver.cpp
+++ b/compiler/circle-mpqsolver/src/CircleMPQSolver.cpp
@@ -178,7 +178,7 @@ int entry(int argc, char **argv)
       }
     }
 
-    VERBOSE(l, 0) << "qerror metric: MSE" << std::endl
+    VERBOSE(l, 0) << "qerror metric: MAE" << std::endl
                   << "target qerror ratio: " << qerror_ratio << std::endl;
 
     auto optimized = solver.run(input_model_path);


### PR DESCRIPTION
This commit fixes type in metric name.

Actually it's MAE (Mean Absolute Error). Please see https://github.com/Samsung/ONE/blob/bb30405d3ed25d457af427dbd8319af4e722c1ea/compiler/circle-mpqsolver/src/core/ErrorMetric.h#L42
ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>