### PR TITLE
[one-cmds] Add requantize tests

### DIFF
--- a/compiler/one-cmds/tests/one-quantize_017.test
+++ b/compiler/one-cmds/tests/one-quantize_017.test
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  echo "${filename_ext} FAILED"
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+inputfile="./mobilenet_edgetpu_224_1.0_int8.circle"
+outputfile="./mobilenet_edgetpu_224_1.0_int8.one-quantize_017.circle"
+
+rm -f ${filename}.log
+rm -f ${outputfile}
+
+# run test
+one-quantize \
+--requantize \
+--input_model_dtype int8 \
+--quantized_dtype uint8 \
+--input_path ${inputfile} \
+--output_path ${outputfile} > ${filename}.log 2>&1
+
+if [[ ! -s "${outputfile}" ]]; then
+  trap_err_onexit
+fi
+
+echo "${filename_ext} SUCCESS"

--- a/compiler/one-cmds/tests/one-quantize_neg_022.test
+++ b/compiler/one-cmds/tests/one-quantize_neg_022.test
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Wrong number of input_type in one-quantize
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  if grep -q "following arguments are required: --input_model_dtype" "${filename}.log"; then
+    echo "${filename_ext} SUCCESS"
+    exit 0
+  fi
+
+  echo "${filename_ext} FAILED"
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+inputfile="./mobilenet_edgetpu_224_1.0_int8.circle"
+outputfile="./mobilenet_edgetpu_224_1.0_int8.one-quantize_neg_022.circle"
+
+rm -f ${filename}.log
+
+# run test with wrong input model dtype
+one-quantize \
+--requantize \
+--quantized_dtype uint8 \
+--input_path ${inputfile} \
+--output_path ${outputfile} > ${filename}.log 2>&1
+
+echo "${filename_ext} FAILED"
+exit 255

--- a/compiler/one-cmds/tests/onecc_058.cfg
+++ b/compiler/one-cmds/tests/onecc_058.cfg
@@ -1,0 +1,9 @@
+[onecc]
+one-quantize=True
+
+[one-quantize]
+requantize=True
+input_path=mobilenet_edgetpu_224_1.0_int8.circle
+output_path=mobilenet_edgetpu_224_1.0_int8.onecc_058.circle
+input_model_dtype=int8
+quantized_dtype=uint8

--- a/compiler/one-cmds/tests/onecc_058.test
+++ b/compiler/one-cmds/tests/onecc_058.test
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  echo "${filename_ext} FAILED"
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+configfile="onecc_058.cfg"
+outputfile="mobilenet_edgetpu_224_1.0_int8.onecc_058.circle"
+
+rm -f ${filename}.log
+rm -rf ${outputfile}
+
+# run test
+onecc -C ${configfile} > ${filename}.log 2>&1
+
+if [[ ! -s "${outputfile}" ]]; then
+  trap_err_onexit
+fi
+
+echo "${filename_ext} SUCCESS"

--- a/compiler/one-cmds/tests/prepare_test_materials.sh
+++ b/compiler/one-cmds/tests/prepare_test_materials.sh
@@ -25,6 +25,10 @@ if [[ ! -s "inception_v3.pb" ]]; then
     tar zxvf inception_v3_2018_04_27.tgz
 fi
 
+if [[ ! -s "mobilenet_edgetpu_224_1.0_int8.tflite" ]]; then
+    wget -nv https://github.com/mlcommons/mobile_models/raw/main/v0_7/tflite/mobilenet_edgetpu_224_1.0_int8.tflite
+fi
+
 if [[ ! -s "while_3.pbtxt" ]]; then
     rm -rf while_3.zip
     wget -nv https://github.com/Samsung/ONE/files/5095630/while_3.zip
@@ -171,6 +175,16 @@ outputfile="./inception_v3.mat.q8.circle"
 
 if [[ ! -s ${outputfile} ]]; then
   ../bin/one-quantize \
+  --input_path ${inputfile} \
+  --output_path ${outputfile}
+fi
+
+# prepare 'mobilenet_edgetpu_224_1.0_int8.circle' file used for requantization test
+inputfile="./mobilenet_edgetpu_224_1.0_int8.tflite"
+outputfile="./mobilenet_edgetpu_224_1.0_int8.circle"
+
+if [[ ! -s ${outputfile} ]]; then
+  ../bin/one-import-tflite \
   --input_path ${inputfile} \
   --output_path ${outputfile}
 fi


### PR DESCRIPTION
This adds tests for requantize option of one-quantize.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/11109
Draft PR: https://github.com/Samsung/ONE/pull/11155