### PR TITLE
[Draft] Fix build warnings over various modules

### DIFF
--- a/compiler/circle-eval-diff/src/InputDataLoader.cpp
+++ b/compiler/circle-eval-diff/src/InputDataLoader.cpp
@@ -166,7 +166,7 @@ DirectoryLoader::DirectoryLoader(const std::string &dir_path,
 
   struct dirent *entry = nullptr;
   const auto input_total_bytes = getTotalByteSizeOf(input_nodes);
-  while (entry = readdir(dir))
+  while ((entry = readdir(dir)) != NULL)
   {
     // Skip if the entry is not a regular file
     if (entry->d_type != DT_REG)

--- a/compiler/circledump/src/MetadataPrinter.h
+++ b/compiler/circledump/src/MetadataPrinter.h
@@ -29,6 +29,7 @@ class MetadataPrinter
 {
 public:
   virtual void print(const uint8_t * /* buffer */, std::ostream &) const = 0;
+  virtual ~MetadataPrinter() = default;
 };
 
 class MetadataPrinterRegistry

--- a/compiler/luci/import/include/luci/Import/NodeBuilder.h
+++ b/compiler/luci/import/include/luci/Import/NodeBuilder.h
@@ -42,6 +42,7 @@ class NodeBuilderBase
 public:
   virtual CircleNode *build(TensorIndex tensor_idx, GraphBuilderContext *context) const = 0;
   virtual NodeBuilderType builder_type() const = 0;
+  virtual ~NodeBuilderBase() = default;
 };
 
 /**

--- a/compiler/luci/logex/src/CircleNodeSummaryBuilder.cpp
+++ b/compiler/luci/logex/src/CircleNodeSummaryBuilder.cpp
@@ -68,7 +68,7 @@ bool CircleNodeSummaryBuilder::build(const loco::Node *node, const locop::Symbol
     {
       if (i)
         ss << ",";
-      ss << node->dim(i).known() ? node->dim(i).value() : -1;
+      ss << (node->dim(i).known() ? node->dim(i).value() : -1);
     }
     ss << ">";
     return ss.str();

--- a/compiler/luci/pass/src/ConvertNCHWToNHWCPass.test.cpp
+++ b/compiler/luci/pass/src/ConvertNCHWToNHWCPass.test.cpp
@@ -535,6 +535,8 @@ public:
   luci::CircleMaximum *max = nullptr;
 };
 
+static constexpr std::initializer_list<uint32_t> kDefaultShape = {1, 16, 1, 1};
+
 class MeanGraph final : public SimpleGraph
 {
 protected:
@@ -577,7 +579,7 @@ public:
 private:
   bool _keep_dims = true;
   std::vector<int32_t> _axes = {2, 3};
-  std::initializer_list<uint32_t> _shape = {1, 16, 1, 1};
+  std::initializer_list<uint32_t> _shape = kDefaultShape;
 };
 
 class MinimumGraph final : public SimpleGraph
@@ -876,7 +878,7 @@ public:
 private:
   bool _keep_dims = true;
   std::vector<int32_t> _axes = {2, 3};
-  std::initializer_list<uint32_t> _shape = {1, 16, 1, 1};
+  std::initializer_list<uint32_t> _shape = kDefaultShape;
 };
 
 class ReduceMinGraph final : public SimpleGraph
@@ -921,7 +923,7 @@ public:
 private:
   bool _keep_dims = true;
   std::vector<int32_t> _axes = {2, 3};
-  std::initializer_list<uint32_t> _shape = {1, 16, 1, 1};
+  std::initializer_list<uint32_t> _shape = kDefaultShape;
 };
 
 class ReluGraph final : public SimpleGraph

--- a/compiler/luci/pass/src/FoldAddV2Pass.test.cpp
+++ b/compiler/luci/pass/src/FoldAddV2Pass.test.cpp
@@ -44,10 +44,10 @@ template <loco::DataType T> class FoldAddV2Test : public luci::ConstantFoldingAd
 public:
   FoldAddV2Test(std::initializer_list<uint32_t> shape) : luci::ConstantFoldingAddTestGraph(shape, T)
   {
-    _addV2 = _g.nodes()->create<luci::CircleCustom>(2, 1);
-    _x = _g.nodes()->create<luci::CircleConst>();
-    _y = _g.nodes()->create<luci::CircleConst>();
-    _addV2_out = _g.nodes()->create<luci::CircleCustomOut>();
+    _addV2 = _g.nodes()->template create<luci::CircleCustom>(2, 1);
+    _x = _g.nodes()->template create<luci::CircleConst>();
+    _y = _g.nodes()->template create<luci::CircleConst>();
+    _addV2_out = _g.nodes()->template create<luci::CircleCustomOut>();
 
     _addV2->dtype(T);
     _x->dtype(T);

--- a/compiler/luci/pass/src/FoldCastPass.test.cpp
+++ b/compiler/luci/pass/src/FoldCastPass.test.cpp
@@ -31,8 +31,8 @@ public:
   FoldCastTest(std::initializer_list<uint32_t> shape)
     : luci::ConstantFoldingAddTestGraph(shape, ToT)
   {
-    _cast = _g.nodes()->create<luci::CircleCast>();
-    _x = _g.nodes()->create<luci::CircleConst>();
+    _cast = _g.nodes()->template create<luci::CircleCast>();
+    _x = _g.nodes()->template create<luci::CircleConst>();
 
     _cast->dtype(ToT);
     _x->dtype(FromT);

--- a/compiler/luci/pass/src/FoldDequantizePass.test.cpp
+++ b/compiler/luci/pass/src/FoldDequantizePass.test.cpp
@@ -28,7 +28,7 @@ class FoldDequantizeTest : public luci::ConstantFoldingAddTestGraph, public ::te
 public:
   FoldDequantizeTest() : luci::ConstantFoldingAddTestGraph({2, 2, 2}, DT) {}
 
-  virtual void SetUp() { init(); }
+  void SetUp() override { init(); }
 
   loco::Node *createFoldedPattern() override
   {
@@ -111,7 +111,7 @@ class F16FoldDequantizeTest : public luci::ConstantFoldingTestGraph, public ::te
 public:
   F16FoldDequantizeTest() : ConstantFoldingTestGraph({2, 2}, loco::DataType::FLOAT16) {}
 
-  virtual void SetUp() { init(); }
+  void SetUp() override { init(); }
 
   loco::Node *createFoldedPattern() override
   {

--- a/compiler/luci/pass/src/FoldDequantizePass.test.cpp
+++ b/compiler/luci/pass/src/FoldDequantizePass.test.cpp
@@ -32,8 +32,8 @@ public:
 
   loco::Node *createFoldedPattern() override
   {
-    _dequantize = _g.nodes()->create<luci::CircleDequantize>();
-    _input = _g.nodes()->create<luci::CircleConst>();
+    _dequantize = _g.nodes()->template create<luci::CircleDequantize>();
+    _input = _g.nodes()->template create<luci::CircleConst>();
 
     _dequantize->dtype(loco::DataType::FLOAT32);
     _input->dtype(DT);

--- a/compiler/luci/pass/src/FoldGatherPass.test.cpp
+++ b/compiler/luci/pass/src/FoldGatherPass.test.cpp
@@ -45,7 +45,7 @@ class S64FoldGatherSimpleTest : public luci::ConstantFoldingAddTestGraph, public
 public:
   S64FoldGatherSimpleTest() : luci::ConstantFoldingAddTestGraph({1}, loco::DataType::S64) {}
 
-  virtual void SetUp() { init(); }
+  void SetUp() override { init(); }
 
   loco::Node *createFoldedPattern() override
   {
@@ -106,7 +106,7 @@ class S32FoldGatherTwoDimsTest : public luci::ConstantFoldingAddTestGraph, publi
 public:
   S32FoldGatherTwoDimsTest() : luci::ConstantFoldingAddTestGraph({4, 2}, loco::DataType::S32) {}
 
-  virtual void SetUp() { init(); }
+  void SetUp() override { init(); }
 
   loco::Node *createFoldedPattern() override
   {

--- a/compiler/luci/pass/src/FoldSparseToDensePass.test.cpp
+++ b/compiler/luci/pass/src/FoldSparseToDensePass.test.cpp
@@ -47,7 +47,7 @@ class S64SparseToDenseZeroIndicesTest : public luci::ConstantFoldingAddTestGraph
 public:
   S64SparseToDenseZeroIndicesTest() : luci::ConstantFoldingAddTestGraph({3}, loco::DataType::S64) {}
 
-  virtual void SetUp() { init(); }
+  void SetUp() override { init(); }
 
   loco::Node *createFoldedPattern() override
   {

--- a/compiler/luci/pass/src/QuantizedModelVerifier.test.cpp
+++ b/compiler/luci/pass/src/QuantizedModelVerifier.test.cpp
@@ -66,6 +66,8 @@ template <Type T> luci::CircleConst *create_dummy_const(loco::Graph *g, luci::te
           // Fill with index
           node->at<T>(i) = static_cast<int16_t>(i);
           break;
+        default:
+          break;
       }
     }
   }

--- a/compiler/luci/pass/src/QuantizedModelVerifier.test.cpp
+++ b/compiler/luci/pass/src/QuantizedModelVerifier.test.cpp
@@ -470,15 +470,15 @@ public:
   void init(void) override
   {
     TestIOGraph::init({32}, {32});
-    _begin = g()->nodes()->create<luci::CircleConst>();
+    _begin = g()->nodes()->template create<luci::CircleConst>();
     {
       _begin->dtype(indexT);
     }
-    _size = g()->nodes()->create<luci::CircleConst>();
+    _size = g()->nodes()->template create<luci::CircleConst>();
     {
       _size->dtype(indexT);
     }
-    _slice = g()->nodes()->create<luci::CircleSlice>();
+    _slice = g()->nodes()->template create<luci::CircleSlice>();
     {
       _slice->input(input());
       _slice->begin(_begin);
@@ -694,11 +694,11 @@ public:
     TestIOGraph::init({32}, {1});
     // output dtype is float by default, but ArgMax should have indexType (s32/s64)
     output()->dtype(indexT);
-    _dimension = g()->nodes()->create<luci::CircleConst>();
+    _dimension = g()->nodes()->template create<luci::CircleConst>();
     {
       _dimension->dtype(indexT);
     }
-    _argmax = g()->nodes()->create<luci::CircleArgMax>();
+    _argmax = g()->nodes()->template create<luci::CircleArgMax>();
     {
       _argmax->input(input());
       _argmax->dimension(_dimension);
@@ -1003,7 +1003,7 @@ public:
     TestIOGraph::init({32}, {32});
     output()->dtype(loco::DataType::BOOL);
     _y = create_dummy_const<Type::FLOAT32>(g(), {32});
-    _op = g()->nodes()->create<Op>();
+    _op = g()->nodes()->template create<Op>();
     {
       _op->x(input());
       _op->y(_y);
@@ -1036,7 +1036,7 @@ public:
     input()->dtype(loco::DataType::BOOL);
     output()->dtype(loco::DataType::BOOL);
     _y = create_dummy_const<Type::BOOL>(g(), {32});
-    _op = g()->nodes()->create<Op>();
+    _op = g()->nodes()->template create<Op>();
     {
       _op->x(input());
       _op->y(_y);
@@ -1340,7 +1340,7 @@ public:
     TypedTestGraph::init(T, {32}, {32});
 
     _const = create_dummy_const<T>(g(), {32});
-    _mul = g()->nodes()->create<luci::CircleMul>();
+    _mul = g()->nodes()->template create<luci::CircleMul>();
     {
       _mul->x(input());
       _mul->y(_const);
@@ -1395,7 +1395,7 @@ public:
     TypedTestGraph::init(T, {32}, {32});
 
     _const = create_dummy_const<T>(g(), {32});
-    _add = g()->nodes()->create<luci::CircleAdd>();
+    _add = g()->nodes()->template create<luci::CircleAdd>();
     {
       _add->x(input());
       _add->y(_const);

--- a/compiler/luci/pass/src/VerifyQuantizedBiasScale.cpp
+++ b/compiler/luci/pass/src/VerifyQuantizedBiasScale.cpp
@@ -31,7 +31,7 @@ namespace
 bool same(float a, float b)
 {
   constexpr float epsilon = 1e-10;
-  return abs(a - b) < epsilon;
+  return std::abs(a - b) < epsilon;
 }
 
 // Check bias scale = input scale * weight scale

--- a/compiler/luci/service/src/ShapeInfer_StridedSlice.cpp
+++ b/compiler/luci/service/src/ShapeInfer_StridedSlice.cpp
@@ -305,7 +305,7 @@ StridedSliceParams BuildStridedSliceParams(StridedSliceContext *op_context)
     if ((1 << i) & effective_ellipsis_mask)
     {
       // If ellipsis_mask, set the begin_mask and end_mask at that index.
-      added_ellipsis = std::max(0u, i - ellipsis_start_idx);
+      added_ellipsis = std::max(0, (int32_t)(i - ellipsis_start_idx));
       assert(i < 16);
       op_params.begin_mask |= (1 << i);
       op_params.end_mask |= (1 << i);

--- a/compiler/mir/unittests/ShapeRange.cpp
+++ b/compiler/mir/unittests/ShapeRange.cpp
@@ -56,7 +56,7 @@ TEST_P(ShapeIteratorTest, ElementCount)
 std::vector<ParamType> test_data{ParamType{6, 1, 2, 3}, ParamType{16, 2, 2, 4},
                                  ParamType{1, 1, 1, 1, 1, 1}, ParamType{5, 5, 1, 1, 1, 1, 1}};
 
-INSTANTIATE_TEST_CASE_P(SimpleInput, ShapeIteratorTest, ::testing::ValuesIn(test_data));
+INSTANTIATE_TEST_SUITE_P(SimpleInput, ShapeIteratorTest, ::testing::ValuesIn(test_data));
 
 TEST(ShapeRange, Contains)
 {

--- a/compiler/moco-tf/src/Canonicalization/SoftmaxCanonicalizer.h
+++ b/compiler/moco-tf/src/Canonicalization/SoftmaxCanonicalizer.h
@@ -15,7 +15,7 @@
  */
 
 #ifndef __MOCO_TF_SOFTMAX_CANONICALIZER_H__
-#define __MOCO_TF_SOFTMAx_CANONICALIZER_H__
+#define __MOCO_TF_SOFTMAX_CANONICALIZER_H__
 
 #include "Transform.h"
 #include "SimpleNodeTransform.h"

--- a/compiler/nnc/backends/soft_backend/code_snippets/cpp_header_types.def
+++ b/compiler/nnc/backends/soft_backend/code_snippets/cpp_header_types.def
@@ -147,7 +147,7 @@ public:
 
     if (!t._managed) {
       if (_managed)
-        delete _data;
+        delete [] _data;
 
       _managed = false;
       _data = t._data;

--- a/compiler/nnkit-mocotf/support/include/nnkit/support/moco/tf/Backend.h
+++ b/compiler/nnkit-mocotf/support/include/nnkit/support/moco/tf/Backend.h
@@ -50,7 +50,7 @@ public:
 
   void run(void) override;
 
-  void teardown(const std::function<void(nnkit::TensorContext &)> &f);
+  void teardown(const std::function<void(nnkit::TensorContext &)> &f) override;
 
 private:
   std::unique_ptr<loco::Graph> _loco_graph;

--- a/compiler/nnkit-mocotf/support/src/TensorContext.h
+++ b/compiler/nnkit-mocotf/support/src/TensorContext.h
@@ -69,10 +69,10 @@ public:
   // Float (fp32) tensor support
   bool isFloatTensor(uint32_t n) const override { return _tensors.at(n)->isFloatTensor(); }
 
-  virtual void getMutableFloatTensor(uint32_t n,
-                                     const nnkit::TensorContext::TypedAccessor<float> &f) = 0;
-  virtual void getConstFloatTensor(uint32_t n,
-                                   const nnkit::TensorContext::TypedReader<float> &f) const = 0;
+  void getMutableFloatTensor(uint32_t n,
+                             const nnkit::TensorContext::TypedAccessor<float> &f) override;
+  void getConstFloatTensor(uint32_t n,
+                           const nnkit::TensorContext::TypedReader<float> &f) const override;
 
 private:
   const ParsedTensors &_tensors;


### PR DESCRIPTION
As result of build with Clang compiler, there were several build warnings that GCC might missed.
Some of them are obvious bugs which can occur 'memory leaks', 'undefined behavior', and others are related with code readability which can prevent a human error.
