### PR TITLE
[moco-tf] Fix typo in header macro

### DIFF
--- a/compiler/moco-tf/src/Canonicalization/SoftmaxCanonicalizer.h
+++ b/compiler/moco-tf/src/Canonicalization/SoftmaxCanonicalizer.h
@@ -15,7 +15,7 @@
  */
 
 #ifndef __MOCO_TF_SOFTMAX_CANONICALIZER_H__
-#define __MOCO_TF_SOFTMAx_CANONICALIZER_H__
+#define __MOCO_TF_SOFTMAX_CANONICALIZER_H__
 
 #include "Transform.h"
 #include "SimpleNodeTransform.h"


### PR DESCRIPTION
This PR fixes typo in HEADER guard.

Related: #11177 

ONE-DCO-1.0-Signed-off-by: Jonghwa Lee <jonghwa3.lee@samsung.com>