### PR TITLE
[mir] Replace deprecated macro with recommended

### DIFF
--- a/compiler/mir/unittests/ShapeRange.cpp
+++ b/compiler/mir/unittests/ShapeRange.cpp
@@ -56,7 +56,7 @@ TEST_P(ShapeIteratorTest, ElementCount)
 std::vector<ParamType> test_data{ParamType{6, 1, 2, 3}, ParamType{16, 2, 2, 4},
                                  ParamType{1, 1, 1, 1, 1, 1}, ParamType{5, 5, 1, 1, 1, 1, 1}};
 
-INSTANTIATE_TEST_CASE_P(SimpleInput, ShapeIteratorTest, ::testing::ValuesIn(test_data));
+INSTANTIATE_TEST_SUITE_P(SimpleInput, ShapeIteratorTest, ::testing::ValuesIn(test_data));
 
 TEST(ShapeRange, Contains)
 {


### PR DESCRIPTION
The macro 'INSTANTIATE_TEST_CASE_P' from GTest is deprecated.
It is recommended to use 'INSTANTIATE_TEST_SUITE_P' instead.

---
FYI, you can check the history of renaming of the macro in below link.

* Issue from GoogleTest
https://github.com/google/googletest/issues/1085

* Summary of the above issue
https://github.com/Samsung/ONE/pull/11190#issuecomment-1661274707

Related: #11177 