### PR TITLE
[onert] Change train_get_loss function signature

### DIFF
--- a/runtime/onert/api/src/nnfw_api.cc
+++ b/runtime/onert/api/src/nnfw_api.cc
@@ -433,17 +433,7 @@ NNFW_STATUS nnfw_train(nnfw_session *session, bool update_weights)
 NNFW_STATUS nnfw_train_get_loss(nnfw_session *session, uint32_t index, float *loss)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-
-  try
-  {
-    *loss = session->train_get_loss(index);
-  }
-  catch (std::exception &e)
-  {
-    return NNFW_STATUS_ERROR;
-  }
-
-  return NNFW_STATUS_NO_ERROR;
+  return session->train_get_loss(index, loss);
 }
 
 NNFW_STATUS nnfw_train_export_circle(nnfw_session *session, const char *path)

--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -1356,8 +1356,14 @@ NNFW_STATUS nnfw_session::train_run(bool update_weights)
   return NNFW_STATUS_NO_ERROR;
 }
 
-float nnfw_session::train_get_loss(uint32_t index)
+NNFW_STATUS nnfw_session::train_get_loss(uint32_t index, float *loss)
 {
+  if (loss == nullptr)
+  {
+    std::cerr << "Error during nnfw_session::train_get_loss : loss is null" << std::endl;
+    return NNFW_STATUS_UNEXPECTED_NULL;
+  }
+
   if (!isStateFinishedTraining())
   {
     std::cerr << "Error during nnfw_session::train_get_loss : invalid state" << std::endl;
@@ -1369,7 +1375,7 @@ float nnfw_session::train_get_loss(uint32_t index)
   (void)index;
 
   // NYI
-  throw std::runtime_error{"Return loss: Not implemented yet"};
+  return NNFW_STATUS_ERROR;
 }
 
 NNFW_STATUS nnfw_session::train_export_circle(const char *path)

--- a/runtime/onert/api/src/nnfw_api_internal.h
+++ b/runtime/onert/api/src/nnfw_api_internal.h
@@ -171,7 +171,7 @@ public:
   NNFW_STATUS train_set_expected(uint32_t index, const void *expected,
                                  const nnfw_tensorinfo *expected_tensorinfo);
   NNFW_STATUS train_run(bool update_weights);
-  float train_get_loss(uint32_t index);
+  NNFW_STATUS train_get_loss(uint32_t index, float *loss);
   NNFW_STATUS train_export_circle(const char *path);
 #endif // ONERT_TRAIN
 


### PR DESCRIPTION
This commit changes the train_get_loss function signature to return error status in internal api. It also unifies the function implementation of train_get_loss the same as other functions.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Draft: #11035