### PR TITLE
[onert] Use trainable graph as a class member variable in lowered trainable graph

### DIFF
--- a/runtime/onert/core/include/compiler/train/LoweredTrainableGraph.h
+++ b/runtime/onert/core/include/compiler/train/LoweredTrainableGraph.h
@@ -68,7 +68,7 @@ private:
    *  @note   It uses copy of graph, not reference.
    *          It allows the original graph can be compiled multiple times.
    */
-  ir::train::TrainableGraph &_trainable_graph;
+  ir::train::TrainableGraph _trainable_graph;
   std::shared_ptr<ir::OperationIndexMap<int64_t>> _indexed_ranks;
   compiler::GraphLowerInfo _lower_info_map;
 };


### PR DESCRIPTION
This commit uses trainable graph as a class member variable instead of reference in lowered trainable graph.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>