### PR TITLE
[onert] Introduce loss map for training

### DIFF
--- a/runtime/onert/core/include/ir/train/TrainableGraph.h
+++ b/runtime/onert/core/include/ir/train/TrainableGraph.h
@@ -101,6 +101,7 @@ public:
   void changeDerivativeShape(const OperandIndex &ind, const ir::Shape &new_shape);
   void addInput(const OperandIndex &ind, const std::string &name = "");
   void addOutput(const OperandIndex &ind, const std::string &name = "");
+  void addLoss(const OperandIndex &loss_ind, const IOIndex &pred_io_ind);
   void verify() const;
   void removeOperand(const OperandIndex &ind);
   void setLayout(Layout layout);
@@ -119,6 +120,7 @@ public:
   Operands &operands() { return _graph.operands(); } // TODO Remove this non-const accessor
   const Operations &operations() const override { return _graph.operations(); }
   const Operands &derivatives() const { return _derivatives; }
+  OperandIndex getLossIndex(const IOIndex &pred_io_ind) const;
   Layout layout() const { return _graph.layout(); }
   const Graph &graph() const { return _graph; }
 
@@ -132,6 +134,8 @@ public:
 private:
   Graph _graph;
   Operands _derivatives;
+
+  std::unordered_map<IOIndex, OperandIndex> _losses;
 };
 
 } // namespace train

--- a/runtime/onert/core/src/ir/train/TrainableGraph.cc
+++ b/runtime/onert/core/src/ir/train/TrainableGraph.cc
@@ -30,7 +30,7 @@ namespace train
 TrainableGraph::TrainableGraph() : _graph{} {}
 
 TrainableGraph::TrainableGraph(const TrainableGraph &tgraph)
-  : _graph{tgraph._graph}, _derivatives{tgraph._derivatives}
+  : _graph{tgraph._graph}, _derivatives{tgraph._derivatives}, _losses{tgraph._losses}
 {
   tgraph.operations().iterate(
     [&](const onert::ir::OperationIndex &index, const onert::ir::IOperation &op) {
@@ -127,6 +127,17 @@ const ITrainableOperation &TrainableGraph::operation(OperationIndex index) const
 std::vector<ir::OperationIndex> TrainableGraph::topolSortOperations() const
 {
   return _graph.topolSortOperations();
+}
+
+void TrainableGraph::addLoss(const OperandIndex &loss_ind, const IOIndex &pred_ioind)
+{
+  _losses.emplace(pred_ioind, loss_ind);
+}
+
+OperandIndex TrainableGraph::getLossIndex(const IOIndex &pred_ioind) const
+{
+  auto itr = _losses.find(pred_ioind);
+  return (itr == _losses.end()) ? OperandIndex{} : itr->second;
 }
 
 } // namespace train


### PR DESCRIPTION
This commit introduces loss map for accessing training loss value from nnfw internal api.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Draft: #11035 