### PR TITLE
[onert] Implement train_set_expected in nnfw api

### DIFF
--- a/runtime/onert/core/include/exec/Execution.h
+++ b/runtime/onert/core/include/exec/Execution.h
@@ -155,6 +155,7 @@ public:
   ir::Shape getInputShape(ir::IOIndex ind) const;
   ir::Shape getOutputShape(ir::IOIndex ind) const;
   size_t getInputTotalSize(ir::IOIndex ind) const;
+  size_t getOutputTotalSize(ir::IOIndex ind) const;
 
 private:
   const IExecutor *entryExecutor() const { return _executors->entryExecutor(); };

--- a/runtime/onert/core/src/exec/Execution.cc
+++ b/runtime/onert/core/src/exec/Execution.cc
@@ -206,5 +206,10 @@ size_t Execution::getInputTotalSize(ir::IOIndex ind) const
   return _executors->inputInfo(ind).total_size();
 }
 
+size_t Execution::getOutputTotalSize(ir::IOIndex ind) const
+{
+  return _executors->outputInfo(ind).total_size();
+}
+
 } // namespace exec
 } // namespace onert


### PR DESCRIPTION
This commit implements train_set_expected in nnfw api. IT sets the expected input to loss input tensor.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Draft: #11035 