### PR TITLE
[visq-unittest] Remove unused module

### DIFF
--- a/compiler/visq-unittest/test/testDotBuilder.py
+++ b/compiler/visq-unittest/test/testDotBuilder.py
@@ -15,7 +15,6 @@
 
 import unittest
 import pydot
-from pathlib import Path
 
 from visqlib.DotBuilder import DotBuilder
 from test.Resources import fp32_model_dir


### PR DESCRIPTION
This removes unused Python module.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>