### PR TITLE
[onert] Fix use of partial graph's outputs

### DIFF
--- a/runtime/onert/core/src/backend/builtin/train/KernelGenerator.cc
+++ b/runtime/onert/core/src/backend/builtin/train/KernelGenerator.cc
@@ -69,7 +69,7 @@ void KernelGenerator::visit(const ir::train::operation::Permute &node)
 
   // NOTE IOTensors of graph outputs for passing data to users must be ignored in training
   //      because the buffers of those IOTensors are unnecessary and nullptr
-  bool ignore_forward_in_training = _tgraph.getOutputs().contains(output_index);
+  bool ignore_forward_in_training = _whole_graph_outputs.contains(output_index);
   auto fn = std::make_unique<kernel::PermuteLayer>(input_tensors, output_tensors,
                                                    input_deriv_tensors, output_deriv_tensors,
                                                    ignore_forward_in_training, _external_context);

--- a/runtime/onert/core/src/backend/builtin/train/KernelGenerator.h
+++ b/runtime/onert/core/src/backend/builtin/train/KernelGenerator.h
@@ -48,6 +48,11 @@ public:
     _tensor_registries = tensor_registries;
   }
 
+  void setWholeGraphOutputs(const ir::OperandIndexSequence &outputs)
+  {
+    _whole_graph_outputs = outputs;
+  }
+
 private:
   void visit(const ir::train::operation::Permute &) override;
 
@@ -59,6 +64,7 @@ private:
   std::shared_ptr<TensorRegistry> _tensor_reg;
   compiler::train::TensorRegistries _tensor_registries;
   const std::shared_ptr<ExternalContext> _external_context;
+  ir::OperandIndexSequence _whole_graph_outputs;
 };
 
 } // namespace train

--- a/runtime/onert/core/src/compiler/ExecutorFactory.cc
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.cc
@@ -762,6 +762,7 @@ exec::IExecutor *ExecutorFactory::createTrainableExecutor(
     {
       auto builtin_kernel_gen = builtin_context->kernel_gen;
       builtin_kernel_gen->setTensorRegistries(tensor_regs);
+      builtin_kernel_gen->setWholeGraphOutputs(lowered_graph->trainable_graph().getOutputs());
     }
   }
 


### PR DESCRIPTION
This commit fixes use of partial graph to use outputs of whole graph.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>