### PR TITLE
[luci] Add check before QuantizeSpecialActivation

### DIFF
--- a/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
+++ b/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
@@ -630,6 +630,13 @@ bool QuantizeWithMinMaxPass::run(loco::Graph *g)
   for (auto node : loco::active_nodes(loco::output_nodes(g)))
   {
     auto circle_node = loco::must_cast<luci::CircleNode *>(node);
+
+    // At this point, all activations have to be quantized.
+    // Un-quantized nodes are not the quantization target (ex: int32 tensor),
+    // so we skip them
+    if (circle_node->quantparam() == nullptr)
+      continue;
+
     QuantizeSpecialActivation qsa(_ctx->input_model_dtype, quantize_dtype(circle_node));
     circle_node->accept(&qsa);
   }


### PR DESCRIPTION
This checks if node is a quantization target.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>