### PR TITLE
[onert] Fix optimizer being nullptr

### DIFF
--- a/runtime/onert/backend/train/Backend.h
+++ b/runtime/onert/backend/train/Backend.h
@@ -57,7 +57,7 @@ public:
     auto context = std::make_unique<train::BackendContext>(this, std::move(tdata_ptr), tr, tb);
 
     context->kernel_gen = std::make_shared<train::KernelGenerator>(
-      tgraph, tr, context->external_context(), tdata.optimizer);
+      tgraph, tr, context->external_context(), context->data()->optimizer);
     return context;
   }
 


### PR DESCRIPTION
This commit fixes optimizer being nullptr in the KernelGenerator of train backend.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>