### PR TITLE
[onert] Introduce ReshapeLayer in train backend

### DIFF
--- a/runtime/onert/backend/train/KernelGenerator.h
+++ b/runtime/onert/backend/train/KernelGenerator.h
@@ -49,6 +49,7 @@ public:
   void visit(const ir::train::operation::ElementwiseActivation &) override;
   void visit(const ir::train::operation::FullyConnected &) override;
   void visit(const ir::train::operation::Loss &) override;
+  void visit(const ir::train::operation::Reshape &node) override;
 
 private:
   ir::Layout _current_layout;

--- a/runtime/onert/backend/train/ops/ReshapeLayer.cc
+++ b/runtime/onert/backend/train/ops/ReshapeLayer.cc
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ReshapeLayer.h"
+
+namespace onert
+{
+namespace backend
+{
+namespace train
+{
+namespace ops
+{
+
+ReshapeLayer::ReshapeLayer()
+  : _input{nullptr}, _shape{nullptr}, _output{nullptr}, _deriv_input{nullptr}, _deriv_output{
+                                                                                 nullptr}
+{
+  // DO NOTHING
+}
+
+void ReshapeLayer::reshapeGeneric(const IPortableTensor *input, IPortableTensor *output)
+{
+  size_t count = input->total_size();
+  memcpy(output->buffer(), input->buffer(), count);
+}
+
+void ReshapeLayer::configure(const IPortableTensor *input, const IPortableTensor *shape,
+                             IPortableTensor *output, IPortableTensor *deriv_input,
+                             const IPortableTensor *deriv_output)
+{
+  _input = input;
+  /* note : shape is optional. If not provided from model, _shape is nullptr. */
+  _shape = shape;
+  _output = output;
+
+  _deriv_input = deriv_input;
+  _deriv_output = deriv_output;
+}
+
+void ReshapeLayer::forward(bool) { reshapeGeneric(_input, _output); }
+
+void ReshapeLayer::backward(uint32_t) { reshapeGeneric(_deriv_output, _deriv_input); }
+
+} // namespace ops
+} // namespace train
+} // namespace backend
+} // namespace onert

--- a/runtime/onert/backend/train/ops/ReshapeLayer.h
+++ b/runtime/onert/backend/train/ops/ReshapeLayer.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_BACKEND_TRAIN_OPS_RESHAPELAYER_H__
+#define __ONERT_BACKEND_TRAIN_OPS_RESHAPELAYER_H__
+
+#include <backend/IPortableTensor.h>
+
+#include <exec/train/ITrainableFunction.h>
+
+namespace onert
+{
+namespace backend
+{
+namespace train
+{
+namespace ops
+{
+
+class ReshapeLayer : public ::onert::exec::train::ITrainableFunction
+{
+public:
+  ReshapeLayer();
+
+public:
+  void configure(const IPortableTensor *input, const IPortableTensor *shape,
+                 IPortableTensor *output, IPortableTensor *deriv_input,
+                 const IPortableTensor *deriv_output);
+  void forward(bool training) override;
+  void backward(uint32_t training_step) override;
+
+private:
+  void reshapeGeneric(const IPortableTensor *input, IPortableTensor *output);
+
+private:
+  const IPortableTensor *_input;
+  const IPortableTensor *_shape;
+  IPortableTensor *_output;
+
+  IPortableTensor *_deriv_input;
+  const IPortableTensor *_deriv_output;
+};
+
+} // namespace ops
+} // namespace train
+} // namespace backend
+} // namespace onert
+
+#endif // __ONERT_BACKEND_TRAIN_OPS_RESHAPELAYER_H__


### PR DESCRIPTION
This commit introduces ReshapeLayer in train backend.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Draft: #11035 