### PR TITLE
[onert] Implement getLoss in TrainableExecutor

### DIFF
--- a/runtime/onert/core/src/exec/train/TrainableExecutor.h
+++ b/runtime/onert/core/src/exec/train/TrainableExecutor.h
@@ -80,6 +80,8 @@ public:
     return _output_tensors;
   }
 
+  float getLoss(const ir::IOIndex &pred_io_ind) const;
+
   backend::train::TrainableBackendContexts &getBackendContexts() { return _backend_contexts; }
 
 private:
@@ -93,6 +95,7 @@ private:
   std::unique_ptr<compiler::train::LoweredTrainableGraph> _lowered_graph;
   backend::train::TrainableBackendContexts _backend_contexts;
   const ir::train::TrainableGraph &_trainable_graph;
+  compiler::train::TensorRegistries _tensor_regs;
   std::vector<backend::builtin::IOTensor *> _input_tensors;
   std::vector<backend::builtin::IOTensor *> _output_tensors;
   std::mutex _mutex;


### PR DESCRIPTION
This commit implements getLoss function in TrainableExecutor. It finds loss output index using pred index and returns the loss value.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Draft: #11035 