### PR TITLE
[onert] Implement getLoss in TrainableExecutors

### DIFF
--- a/runtime/onert/core/src/exec/train/TrainableExecutors.cc
+++ b/runtime/onert/core/src/exec/train/TrainableExecutors.cc
@@ -77,6 +77,13 @@ void TrainableExecutors::train(const IODescription &desc, uint32_t training_step
   // TODO Support multple executors
 }
 
+float TrainableExecutors::getLoss(const ir::IOIndex &index) const
+{
+  if (_executors.size() > 1)
+    throw std::runtime_error("TrainableExecutors does not support multiple executors yet");
+  return entryExecutor()->getLoss(index);
+}
+
 } // namespace train
 } // namespace exec
 } // namespace onert

--- a/runtime/onert/core/src/exec/train/TrainableExecutors.h
+++ b/runtime/onert/core/src/exec/train/TrainableExecutors.h
@@ -78,6 +78,8 @@ public:
    */
   void train(const IODescription &desc, uint32_t training_step);
 
+  float getLoss(const ir::IOIndex &index) const;
+
 private:
   // TODO Append model index to ModelIndex
   std::unordered_map<ir::SubgraphIndex, std::unique_ptr<TrainableExecutor>> _executors;


### PR DESCRIPTION
This commit implements getLoss function in TrainableExecutors. The nnfw api will call this function to get loss value using pred output index.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Draft: #11035