### PR TITLE
[onert] Introduce LossMSEGrad function in train backend

### DIFF
--- a/compute/cker/include/cker/train/operation/Loss.h
+++ b/compute/cker/include/cker/train/operation/Loss.h
@@ -54,6 +54,22 @@ inline void MSE(const Shape &y_pred_shape, const T *y_pred_data, const Shape &y_
   output_data[0] = (T)(squared_sum / size);
 }
 
+template <typename T>
+inline void MSEGrad(const Shape &y_pred_shape, const T *y_pred_data, const Shape &y_true_shape,
+                    const T *y_true_data, const Shape &grad_shape, T *grad_data)
+{
+  if (y_pred_shape != y_true_shape)
+    throw std::runtime_error("cker::MSEGrad: y_pred_shape != y_true_shape");
+  if (y_pred_shape != grad_shape)
+    throw std::runtime_error("cker::MSEGrad: y_pred_shape != grad_shape");
+
+  const int size = grad_shape.FlatSize();
+  for (int i = 0; i < size; ++i)
+  {
+    grad_data[i] = static_cast<T>(-2 * (y_true_data[i] - y_pred_data[i]) / size);
+  }
+}
+
 } // namespace train
 } // namespace cker
 } // namespace nnfw

--- a/compute/cker/src/train/Loss.test.cc
+++ b/compute/cker/src/train/Loss.test.cc
@@ -115,3 +115,87 @@ TEST(CKer_Operation, neg_LossMSE)
                                             nnfw::cker::Shape{1}, output.data()));
   }
 }
+
+TEST(CKer_Operation, LossMSEGrad)
+{
+  {
+    // Shape: {1, 10} -> m_rows:10, m_cols:1
+    std::vector<int> y_pred = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+    std::vector<int> y_true = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+    std::vector<int> deriv_y_pred(10);
+    std::vector<int> expected = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+
+    nnfw::cker::train::MSEGrad(nnfw::cker::Shape{1, 10}, y_pred.data(), nnfw::cker::Shape{1, 10},
+                               y_true.data(), nnfw::cker::Shape{1, 10}, deriv_y_pred.data());
+
+    for (size_t i = 0; i < deriv_y_pred.size(); ++i)
+      ASSERT_EQ(deriv_y_pred[i], expected[i]);
+  }
+
+  {
+    // Shape: {1, 10} -> m_rows:10, m_cols:1
+    std::vector<float> y_pred = {1., 2., 3., 4., 5., 6., 7., 8., 9., 10.};
+    std::vector<float> y_true = {0., 1., 2., 3., 4., 5., 6., 7., 8., 9.};
+    std::vector<float> deriv_y_pred(10);
+    std::vector<float> expected = {0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2};
+
+    nnfw::cker::train::MSEGrad(nnfw::cker::Shape{1, 10}, y_pred.data(), nnfw::cker::Shape{1, 10},
+                               y_true.data(), nnfw::cker::Shape{1, 10}, deriv_y_pred.data());
+
+    for (size_t i = 0; i < deriv_y_pred.size(); ++i)
+      ASSERT_FLOAT_EQ(deriv_y_pred[i], expected[i]);
+  }
+
+  {
+    // Shape: {2, 3} -> m_rows:3, m_cols:2
+    std::vector<float> y_pred = {27.2, 31.8, 51.9, 10.2, 34.2, 12.4};
+    std::vector<float> y_true = {31.3, 40.3, 29.7, 12.9, 25.8, 11.9};
+    std::vector<float> deriv_y_pred(6);
+    std::vector<float> expected = {-1.3666667, -2.8333333, 7.4, -0.9, 2.8, 0.1666667};
+
+    nnfw::cker::train::MSEGrad(nnfw::cker::Shape{2, 3}, y_pred.data(), nnfw::cker::Shape{2, 3},
+                               y_true.data(), nnfw::cker::Shape{2, 3}, deriv_y_pred.data());
+
+    for (size_t i = 0; i < deriv_y_pred.size(); ++i)
+      ASSERT_FLOAT_EQ(deriv_y_pred[i], expected[i]);
+  }
+}
+
+TEST(CKer_Operation, neg_LossMSEGrad)
+{
+  {
+    // Invalid expected value
+    std::vector<float> y_pred = {27.2, 31.8, 51.9, 10.2, 34.2, 12.4};
+    std::vector<float> y_true = {31.3, 40.3, 29.7, 12.9, 25.8, 11.9};
+    std::vector<float> deriv_y_pred(6);
+    std::vector<float> expected = {1., 1., 1., 1., 1., 1.};
+
+    nnfw::cker::train::MSEGrad(nnfw::cker::Shape{2, 3}, y_pred.data(), nnfw::cker::Shape{2, 3},
+                               y_true.data(), nnfw::cker::Shape{2, 3}, deriv_y_pred.data());
+
+    for (size_t i = 0; i < deriv_y_pred.size(); ++i)
+      ASSERT_NE(deriv_y_pred[i], expected[i]);
+  }
+
+  {
+    // Different y_pred and y_true shape
+    std::vector<float> y_pred = {1., 2., 3., 4., 5., 6., 7., 8., 9., 10.};
+    std::vector<float> y_true = {0., 1., 2., 3., 4., 5.};
+    std::vector<float> deriv_y_pred(10);
+
+    EXPECT_ANY_THROW(nnfw::cker::train::MSEGrad(nnfw::cker::Shape{1, 10}, y_pred.data(),
+                                                nnfw::cker::Shape{2, 3}, y_true.data(),
+                                                nnfw::cker::Shape{1, 10}, deriv_y_pred.data()));
+  }
+
+  {
+    // Different y_pred and deriv_y_pred shape
+    std::vector<float> y_pred = {1., 2., 3., 4., 5., 6., 7., 8., 9., 10.};
+    std::vector<float> y_true = {0., 1., 2., 3., 4., 5., 6., 7., 8., 9.};
+    std::vector<float> deriv_y_pred(6);
+
+    EXPECT_ANY_THROW(nnfw::cker::train::MSEGrad(nnfw::cker::Shape{1, 10}, y_pred.data(),
+                                                nnfw::cker::Shape{1, 10}, y_true.data(),
+                                                nnfw::cker::Shape{2, 3}, deriv_y_pred.data()));
+  }
+}

--- a/runtime/onert/backend/train/KernelGenerator.cc
+++ b/runtime/onert/backend/train/KernelGenerator.cc
@@ -216,14 +216,11 @@ void KernelGenerator::visit(const ir::train::operation::Loss &node)
   auto y_pred_tensor = _tensor_reg->getPortableTensor(y_pred_index);
   auto y_true_tensor = _tensor_reg->getPortableTensor(y_true_index);
 
-  auto deriv_output_tensor = _tensor_reg->getDerivativeTensor(output_index);
   auto deriv_y_pred_tensor = _tensor_reg->getDerivativeTensor(y_pred_index);
-  auto deriv_y_true_tensor = _tensor_reg->getDerivativeTensor(y_true_index);
-
   auto fn = std::make_unique<ops::LossLayer>();
 
   fn->configure(y_pred_tensor, y_true_tensor, output_tensor, deriv_y_pred_tensor,
-                deriv_y_true_tensor, deriv_output_tensor, convertLossType(node.param().op_type));
+                convertLossType(node.param().op_type));
 
   _return_fn = std::move(fn);
 

--- a/runtime/onert/backend/train/ops/LossLayer.h
+++ b/runtime/onert/backend/train/ops/LossLayer.h
@@ -42,9 +42,7 @@ public:
   LossLayer();
 
   void configure(const IPortableTensor *y_pred, const IPortableTensor *y_true,
-                 IPortableTensor *output, IPortableTensor *deriv_y_pred,
-                 IPortableTensor *deriv_y_true, const IPortableTensor *deriv_output,
-                 LossType loss_type);
+                 IPortableTensor *output, IPortableTensor *deriv_y_pred, LossType loss_type);
   void forward(bool training) override;
   void backward(uint32_t) override;
 
@@ -53,9 +51,6 @@ private:
   const IPortableTensor *_y_true;
   IPortableTensor *_output;
   IPortableTensor *_deriv_y_pred;
-  IPortableTensor *_deriv_y_true;
-  const IPortableTensor *_deriv_output;
-
   LossType _loss_type;
 };
 


### PR DESCRIPTION
This commit introduces LossMSEGrad function in train backend.
    - Implements LossMSEGrad in cker
    - Removed usused derivative tensors

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Draft: #11035
Refer formula: https://github.com/Samsung/ONE/issues/11248#issuecomment-1674169085