### PR TITLE
[luci] Remove zeropoint from symmetric quantization

### DIFF
--- a/compiler/luci/pass/src/QuantizationUtils.cpp
+++ b/compiler/luci/pass/src/QuantizationUtils.cpp
@@ -73,14 +73,14 @@ void asymmetric_wquant_with_minmax_per_layer(CircleConst *node, float min, float
 }
 
 void symmetric_wquant_with_minmax_per_layer(CircleConst *node, float min, float max,
-                                            float &scaling_factor, int64_t &zp, float &nudged_min,
+                                            float &scaling_factor, float &nudged_min,
                                             float &nudged_max)
 {
   const int32_t kMaxScale = std::numeric_limits<int16_t>::max();
   const int32_t kMinScale = -kMaxScale;
 
   uint32_t size = node->size<loco::DataType::FLOAT32>();
-  compute_sym_scale_zp(min, max, scaling_factor, zp, nudged_min, nudged_max);
+  compute_sym_scale(min, max, scaling_factor, nudged_min, nudged_max);
   const float scaling_factor_inv = 1.0 / scaling_factor;
   std::vector<int32_t> quantized_values(size);
   for (uint32_t i = 0; i < size; ++i)
@@ -101,8 +101,8 @@ void symmetric_wquant_with_minmax_per_layer(CircleConst *node, float min, float 
   }
 }
 
-void compute_sym_scale_zp(float min, float max, float &scaling_factor, int64_t &zp,
-                          float &nudged_min, float &nudged_max)
+void compute_sym_scale(float min, float max, float &scaling_factor, float &nudged_min,
+                       float &nudged_max)
 {
   assert(min <= max);
 
@@ -129,7 +129,6 @@ void compute_sym_scale_zp(float min, float max, float &scaling_factor, int64_t &
   if (scaling_factor < 1e-8)
     scaling_factor = 1e-8;
 
-  zp = 0;
   nudged_min = static_cast<float>(qmin_double * scaling_factor);
   nudged_max = static_cast<float>(qmax_double * scaling_factor);
 }
@@ -424,7 +423,7 @@ void quant_const(luci::CircleConst *node, loco::DataType quant_type)
                                               nudged_max);
       break;
     case loco::DataType::S16:
-      symmetric_wquant_with_minmax_per_layer(node, min, max, scaling_factor, zp, nudged_min,
+      symmetric_wquant_with_minmax_per_layer(node, min, max, scaling_factor, nudged_min,
                                              nudged_max);
       break;
     default:

--- a/compiler/luci/pass/src/QuantizationUtils.h
+++ b/compiler/luci/pass/src/QuantizationUtils.h
@@ -23,9 +23,9 @@
 namespace luci
 {
 
-// Compute scale/zp using given min/max for symmetric quantization (int16)
-void compute_sym_scale_zp(float min, float max, float &scaling_factor, int64_t &zp,
-                          float &nudged_min, float &nudged_max);
+// Compute scale using given min/max for symmetric quantization (int16)
+void compute_sym_scale(float min, float max, float &scaling_factor, float &nudged_min,
+                       float &nudged_max);
 
 // Compute scale/zp using given min/max for asymmetric quantization (uint8)
 void compute_asym_scale_zp(float min, float max, float &scaling_factor, int64_t &zp,
@@ -40,7 +40,7 @@ void asymmetric_wquant_with_minmax_per_layer(CircleConst *node, float min, float
 // Symmetric per-layer quantization of weights (const tensor) using given min/max values
 // NOTE: in-place update of node data
 void symmetric_wquant_with_minmax_per_layer(CircleConst *node, float min, float max,
-                                            float &scaling_factor, int64_t &zp, float &nudged_min,
+                                            float &scaling_factor, float &nudged_min,
                                             float &nudged_max);
 
 // Helper function to get channel dimension

--- a/compiler/luci/pass/src/QuantizeActivation.cpp
+++ b/compiler/luci/pass/src/QuantizeActivation.cpp
@@ -78,7 +78,7 @@ void QuantizeActivation::visit(luci::CircleNode *node)
     }
     else
     {
-      compute_sym_scale_zp(min, max, scaling_factor, zp, nudged_min, nudged_max);
+      compute_sym_scale(min, max, scaling_factor, nudged_min, nudged_max);
       node->dtype(loco::DataType::S16);
     }
 

--- a/compiler/luci/pass/src/QuantizeDequantizeWeightsPass.cpp
+++ b/compiler/luci/pass/src/QuantizeDequantizeWeightsPass.cpp
@@ -110,8 +110,8 @@ void cal_minmax_per_channel(CircleConst *node, std::vector<float> &min, std::vec
 }
 
 void sym_wquant_per_channel(CircleConst *node, std::vector<float> &min, std::vector<float> &max,
-                            std::vector<float> &scaling_factor, std::vector<int64_t> &zp,
-                            std::vector<float> &nudged_min, std::vector<float> &nudged_max)
+                            std::vector<float> &scaling_factor, std::vector<float> &nudged_min,
+                            std::vector<float> &nudged_max)
 {
   assert(node->dtype() == loco::DataType::FLOAT32);
   const int32_t kMaxScale = std::numeric_limits<int16_t>::max();
@@ -122,7 +122,7 @@ void sym_wquant_per_channel(CircleConst *node, std::vector<float> &min, std::vec
 
   for (size_t i = 0; i < min.size(); ++i)
   {
-    compute_sym_scale_zp(min[i], max[i], scaling_factor[i], zp[i], nudged_min[i], nudged_max[i]);
+    compute_sym_scale(min[i], max[i], scaling_factor[i], nudged_min[i], nudged_max[i]);
   }
 
   auto quantize = [&](uint32_t *indices, loco::TensorShape &dimension, int channel_dim_index) {
@@ -322,7 +322,7 @@ private:
     }
     else
     {
-      sym_wquant_per_channel(weights, min, max, scaling_factor, zp, nudged_min, nudged_max);
+      sym_wquant_per_channel(weights, min, max, scaling_factor, nudged_min, nudged_max);
       sym_wdequant_per_channel(weights, scaling_factor);
     }
 

--- a/compiler/luci/pass/src/QuantizeWeights.cpp
+++ b/compiler/luci/pass/src/QuantizeWeights.cpp
@@ -92,9 +92,8 @@ void asym_wquant_per_channel(CircleConst *node, std::vector<float> &min,
 
 // TODO Reduce duplicate code with QuantizeDequantizeWeights
 void sym_wquant_per_channel(CircleConst *node, std::vector<float> &min, std::vector<float> &max,
-                            std::vector<float> &scaling_factor, std::vector<int64_t> &zp,
-                            std::vector<float> &nudged_min, std::vector<float> &nudged_max,
-                            int32_t &channel_dim_index)
+                            std::vector<float> &scaling_factor, std::vector<float> &nudged_min,
+                            std::vector<float> &nudged_max, int32_t &channel_dim_index)
 {
   assert(node->dtype() == loco::DataType::FLOAT32);
   const int32_t kMaxScale = std::numeric_limits<int16_t>::max();
@@ -105,7 +104,7 @@ void sym_wquant_per_channel(CircleConst *node, std::vector<float> &min, std::vec
 
   for (size_t i = 0; i < min.size(); ++i)
   {
-    compute_sym_scale_zp(min[i], max[i], scaling_factor[i], zp[i], nudged_min[i], nudged_max[i]);
+    compute_sym_scale(min[i], max[i], scaling_factor[i], nudged_min[i], nudged_max[i]);
   }
 
   auto quantize = [&](uint32_t *indices, loco::TensorShape &dimension, int channel_dim_index) {
@@ -383,7 +382,7 @@ void QuantizeWeights::quantize_weights(luci::CircleConst *weights)
       }
       else
       {
-        sym_wquant_per_channel(weights, min, max, scaling_factor, zp, nudged_min, nudged_max,
+        sym_wquant_per_channel(weights, min, max, scaling_factor, nudged_min, nudged_max,
                                channel_dim_index);
       }
 

--- a/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
+++ b/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
@@ -101,7 +101,7 @@ luci::CircleQuantize *create_quantize_op(luci::CircleNode *node, loco::DataType 
   else
   {
     assert(out_type == loco::DataType::S16);
-    compute_sym_scale_zp(min, max, scaling_factor, zp, nudged_min, nudged_max);
+    compute_sym_scale(min, max, scaling_factor, nudged_min, nudged_max);
   }
 
   auto quantparam = std::make_unique<CircleQuantParam>();
@@ -434,7 +434,7 @@ void QuantizeWithMinMaxPass::set_input_type(loco::Graph *g) const
       else
       {
         assert(user_given_dtype == loco::DataType::S16);
-        compute_sym_scale_zp(min, max, scaling_factor, zp, nudged_min, nudged_max);
+        compute_sym_scale(min, max, scaling_factor, nudged_min, nudged_max);
       }
       input->quantparam()->scale[0] = scaling_factor;
       input->quantparam()->zerop[0] = zp;


### PR DESCRIPTION
It removes zeropoint parameters from symmetric quantization.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>