### PR TITLE
[infra/runtime] Update cmake minimum requirement

### DIFF
--- a/infra/nnfw/CMakeLists.txt
+++ b/infra/nnfw/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16.3)
 
 project(nnfw)
 


### PR DESCRIPTION
Let's update cmake minimum requirement to 3.16.3: ubuntu 20.04 default.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: #11229