### PR TITLE
[onert] Implement train_get_loss in nnfw api

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -1394,12 +1394,24 @@ NNFW_STATUS nnfw_session::train_get_loss(uint32_t index, float *loss)
     return NNFW_STATUS_INVALID_STATE;
   }
 
-  // Check index is valid: [0, getExpectedSize())
+  if (index >= getOutputSize())
+  {
+    std::cerr << "Error during nnfw_session::train_get_loss : index is out of range" << std::endl;
+    return NNFW_STATUS_ERROR;
+  }
 
-  (void)index;
+  try
+  {
+    auto ind = onert::ir::IOIndex(index);
+    *loss = _execution->getLoss(ind);
+  }
+  catch (const std::exception &e)
+  {
+    std::cerr << "Error during nnfw_session::train_get_loss : " << e.what() << std::endl;
+    return NNFW_STATUS_ERROR;
+  }
 
-  // NYI
-  return NNFW_STATUS_ERROR;
+  return NNFW_STATUS_NO_ERROR;
 }
 
 NNFW_STATUS nnfw_session::train_export_circle(const char *path)


### PR DESCRIPTION
This commit implements train_get_loss in nnfw api. It gets the loss value from the loss tensor corresponding to output index.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Draft: #11035 