### PR TITLE
Disable record-minmax-thread-safety-test

### DIFF
--- a/compiler/record-minmax-thread-safety-test/CMakeLists.txt
+++ b/compiler/record-minmax-thread-safety-test/CMakeLists.txt
@@ -2,6 +2,11 @@ if(NOT ENABLE_TEST)
     return()
 endif(NOT ENABLE_TEST)
 
+# Disable the test if record-minmax-for-thread-test does not exist
+if (NOT TARGET record-minmax-for-thread-test)
+    return()
+endif(NOT TARGET record-minmax-for-thread-test)
+
 # Build record-minmax-for-thread-test if target arch is 64bit
 # Thread sanitizer is only available on 64bit machine
 # (https://github.com/google/sanitizers/wiki/ThreadSanitizerCppManual#supported-platforms)

--- a/compiler/record-minmax/CMakeLists.txt
+++ b/compiler/record-minmax/CMakeLists.txt
@@ -23,30 +23,35 @@ if(NOT ENABLE_TEST)
   return()
 endif(NOT ENABLE_TEST)
 
+### 
+### record-minmax-for-thread-test is disabled, because gcc package has a bug.
+### (https://bugs.launchpad.net/ubuntu/+source/gcc-10/+bug/2029910)
+### Let's enable the target after the bug is fixed.
+###
 # Build record-minmax-for-thread-test if target arch is 64bit
 # Thread sanitizer is only available on 64bit machine
 # (https://github.com/google/sanitizers/wiki/ThreadSanitizerCppManual#supported-platforms)
-if("${CMAKE_SIZEOF_VOID_P}" STREQUAL "8")
-  # create record-minmax-for-thread-test target
-  # Note: record-minmax-for-thread-test is built with -fsanitize=thread so that thread sanitizer can check memory bugs,
-  # record-minmax is built without the option for performance.
-  add_executable(record-minmax-for-thread-test ${DRIVER} ${SOURCES})
-  target_include_directories(record-minmax-for-thread-test PRIVATE include)
+# if("${CMAKE_SIZEOF_VOID_P}" STREQUAL "8")
+#   # create record-minmax-for-thread-test target
+#   # Note: record-minmax-for-thread-test is built with -fsanitize=thread so that thread sanitizer can check memory bugs,
+#   # record-minmax is built without the option for performance.
+#   add_executable(record-minmax-for-thread-test ${DRIVER} ${SOURCES})
+#   target_include_directories(record-minmax-for-thread-test PRIVATE include)
 
-  target_link_libraries(record-minmax-for-thread-test arser)
-  target_link_libraries(record-minmax-for-thread-test safemain)
-  target_link_libraries(record-minmax-for-thread-test luci_import)
-  target_link_libraries(record-minmax-for-thread-test luci_env)
-  target_link_libraries(record-minmax-for-thread-test luci_export)
-  target_link_libraries(record-minmax-for-thread-test luci_interpreter)
-  target_link_libraries(record-minmax-for-thread-test dio_hdf5)
-  target_link_libraries(record-minmax-for-thread-test vconone)
-  target_link_libraries(record-minmax-for-thread-test nncc_coverage)
-  target_link_libraries(record-minmax-for-thread-test luci_log)
+#   target_link_libraries(record-minmax-for-thread-test arser)
+#   target_link_libraries(record-minmax-for-thread-test safemain)
+#   target_link_libraries(record-minmax-for-thread-test luci_import)
+#   target_link_libraries(record-minmax-for-thread-test luci_env)
+#   target_link_libraries(record-minmax-for-thread-test luci_export)
+#   target_link_libraries(record-minmax-for-thread-test luci_interpreter)
+#   target_link_libraries(record-minmax-for-thread-test dio_hdf5)
+#   target_link_libraries(record-minmax-for-thread-test vconone)
+#   target_link_libraries(record-minmax-for-thread-test nncc_coverage)
+#   target_link_libraries(record-minmax-for-thread-test luci_log)
 
-  target_compile_options(record-minmax-for-thread-test PUBLIC -fsanitize=thread)
-  target_link_libraries(record-minmax-for-thread-test -fsanitize=thread)
-endif("${CMAKE_SIZEOF_VOID_P}" STREQUAL "8")
+#   target_compile_options(record-minmax-for-thread-test PUBLIC -fsanitize=thread)
+#   target_link_libraries(record-minmax-for-thread-test -fsanitize=thread)
+# endif("${CMAKE_SIZEOF_VOID_P}" STREQUAL "8")
 
 file(GLOB_RECURSE TESTS "tests/*.test.cpp")
 


### PR DESCRIPTION
This PR disables record-minmax-thread-safety test to avoid gcc package bug.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/11202