### PR TITLE
[rmm-thread-safety-test] Check target before test

### DIFF
--- a/compiler/record-minmax-thread-safety-test/CMakeLists.txt
+++ b/compiler/record-minmax-thread-safety-test/CMakeLists.txt
@@ -2,6 +2,12 @@ if(NOT ENABLE_TEST)
     return()
 endif(NOT ENABLE_TEST)
 
+# Disable the test if record-minmax-for-thread-test does not exist
+if (NOT TARGET record-minmax-for-thread-test)
+    message(STATUS "record-minmax-thread-safety-test is disabled as record-minmax-for-thread-test was not built.")
+    return()
+endif(NOT TARGET record-minmax-for-thread-test)
+
 # Build record-minmax-for-thread-test if target arch is 64bit
 # Thread sanitizer is only available on 64bit machine
 # (https://github.com/google/sanitizers/wiki/ThreadSanitizerCppManual#supported-platforms)


### PR DESCRIPTION
This checks record-minmax-for-thread-test before test.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Draft: https://github.com/Samsung/ONE/pull/11268
Related to: #11202