### PR TITLE
[one-cmds] Update input name for reshape_matmul

### DIFF
--- a/compiler/one-cmds/tests/one-quantize_016.test
+++ b/compiler/one-cmds/tests/one-quantize_016.test
@@ -54,8 +54,8 @@ if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit
 fi
 
-circledump ${outputfile} | grep serving_default_l.1:0$ > ${filename}.first.cdump
-circledump ${outputfile} | grep serving_default_r.1:0$ > ${filename}.second.cdump
+circledump ${outputfile} | grep "T(0:0)" > ${filename}.first.cdump
+circledump ${outputfile} | grep "T(0:1)" > ${filename}.second.cdump
 
 # check dtype of the first input (uint8)
 if ! grep -q "UINT8" "${filename}.first.cdump"; then

--- a/compiler/one-cmds/tests/onecc_045.test
+++ b/compiler/one-cmds/tests/onecc_045.test
@@ -49,8 +49,8 @@ if [[ ! -s "${outputfile}" ]]; then
   trap_err_onexit
 fi
 
-circledump ${outputfile} | grep serving_default_l.1:0$ > ${filename}.first.cdump
-circledump ${outputfile} | grep serving_default_r.1:0$ > ${filename}.second.cdump
+circledump ${outputfile} | grep "T(0:0)" > ${filename}.first.cdump
+circledump ${outputfile} | grep "T(0:1)" > ${filename}.second.cdump
 
 # check dtype of the first input (uint8)
 if ! grep -q "UINT8" "${filename}.first.cdump"; then


### PR DESCRIPTION
This will update input name for using recent updated reshape_matmul. Using T(0:0), T(0:1) is to make independent from naming convention of TF upgrade.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>