### PR TITLE
[circle-part-value-test] Upgrade TF to 2.12.1

### DIFF
--- a/compiler/circle-part-value-test/CMakeLists.txt
+++ b/compiler/circle-part-value-test/CMakeLists.txt
@@ -107,7 +107,7 @@ add_dependencies(circle_part_value_test_prepare common_artifacts_deps)
 add_test(NAME circle_part_value_test
   COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/part_eval_all.sh"
           "${CMAKE_CURRENT_BINARY_DIR}"
-          "${NNCC_OVERLAY_DIR}/venv_2_8_0"
+          "${NNCC_OVERLAY_DIR}/venv_2_12_1"
           "$<TARGET_FILE:circle_part_driver>"
           ${PARTITION_LIST}
 )


### PR DESCRIPTION
This will upgrade test environment TF to 2.12.1

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>