### PR TITLE
[luci-pass-value-test] Upgrade TF to 2.12.1

### DIFF
--- a/compiler/luci-pass-value-test/CMakeLists.txt
+++ b/compiler/luci-pass-value-test/CMakeLists.txt
@@ -49,7 +49,7 @@ add_test(NAME luci_pass_value_test
   COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/eval_driver.sh"
           "${CMAKE_CURRENT_BINARY_DIR}"
           "${ARTIFACTS_BIN_PATH}"
-          "${NNCC_OVERLAY_DIR}/venv_2_8_0"
+          "${NNCC_OVERLAY_DIR}/venv_2_12_1"
           "$<TARGET_FILE:luci_eval_driver>"
           ${LUCI_PASS_VALUE_TESTS}
 )


### PR DESCRIPTION
This will upgrade test environment TF to 2.12.1

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>