### PR TITLE
[record-minmax-thread-safety-test] Upgrade TF to 2.12.1

### DIFF
--- a/compiler/record-minmax-thread-safety-test/CMakeLists.txt
+++ b/compiler/record-minmax-thread-safety-test/CMakeLists.txt
@@ -63,7 +63,7 @@ add_test(
         COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/testall.sh"
         "${TEST_CONFIG}"
         "${ARTIFACTS_BIN_PATH}"
-        "${NNCC_OVERLAY_DIR}/venv_2_8_0"
+        "${NNCC_OVERLAY_DIR}/venv_2_12_1"
         ${RECORD_MINMAX_THREAD_SAFETY_TEST}
 )
 


### PR DESCRIPTION
This will upgrade test environment TF to 2.12.1.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>