### PR TITLE
[tf2tfliteV2-conversion-test] Upgrade TF to 2.12.1

### DIFF
--- a/compiler/tf2tfliteV2-conversion-test/CMakeLists.txt
+++ b/compiler/tf2tfliteV2-conversion-test/CMakeLists.txt
@@ -76,12 +76,7 @@ list(APPEND TEST_DEPS "${TEST_RUNNER}")
 
 get_target_property(ARTIFACTS_BIN_PATH testDataGenerator BINARY_DIR)
 
-# TODO Run both 2.8.0 and 2.10.1 test for jammy
-if(ONE_UBUNTU_CODENAME_JAMMY)
-  set(VIRTUALENV "${NNCC_OVERLAY_DIR}/venv_2_10_1")
-else()
-  set(VIRTUALENV "${NNCC_OVERLAY_DIR}/venv_2_8_0")
-endif()
+set(VIRTUALENV "${NNCC_OVERLAY_DIR}/venv_2_12_1")
 
 ###
 ### Generate test.config


### PR DESCRIPTION
iThis will upgrade test environment TF to 2.12.1.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>