### PR TITLE
[circle-mpqsolver] Revisit logging

### DIFF
--- a/compiler/circle-mpqsolver/src/CircleMPQSolver.cpp
+++ b/compiler/circle-mpqsolver/src/CircleMPQSolver.cpp
@@ -18,9 +18,9 @@
 #include <vconone/vconone.h>
 #include <luci/CircleExporter.h>
 #include <luci/CircleFileExpContract.h>
-#include <luci/Log.h>
 
 #include "bisection/BisectionSolver.h"
+#include <core/SolverOutput.h>
 
 #include <iostream>
 #include <iomanip>
@@ -114,8 +114,6 @@ int entry(int argc, char **argv)
     setenv("LUCI_LOG", "100", 0);
   }
 
-  LOGGER(l);
-
   auto data_path = arser.get<std::string>("--data");
   auto input_model_path = arser.get<std::string>("--input_model");
   auto output_model_path = arser.get<std::string>("--output_model");
@@ -129,11 +127,11 @@ int entry(int argc, char **argv)
     return EXIT_FAILURE;
   }
 
-  VERBOSE(l, 0) << ">> Searching mixed precision configuration " << std::endl
-                << "model:" << input_model_path << std::endl
-                << "dataset: " << data_path << std::endl
-                << "input dtype: " << input_dtype << std::endl
-                << "output dtype: " << output_dtype << std::endl;
+  SolverOutput::get() << ">> Searching mixed precision configuration \n"
+                      << "model:" << input_model_path << "\n"
+                      << "dataset: " << data_path << "\n"
+                      << "input dtype: " << input_dtype << "\n"
+                      << "output dtype: " << output_dtype << "\n";
 
   if (arser[bisection_str])
   {
@@ -145,7 +143,7 @@ int entry(int argc, char **argv)
       auto value = arser.get<std::string>(bisection_str);
       if (value == "auto")
       {
-        VERBOSE(l, 0) << "algorithm: bisection (auto)" << std::endl;
+        SolverOutput::get() << "algorithm: bisection (auto)\n";
         if (!handleAutoAlgorithm(arser, solver))
         {
           return EXIT_FAILURE;
@@ -153,12 +151,12 @@ int entry(int argc, char **argv)
       }
       else if (value == "true")
       {
-        VERBOSE(l, 0) << "algorithm: bisection (Q16AtFront)";
+        SolverOutput::get() << "algorithm: bisection (Q16AtFront)";
         solver.algorithm(BisectionSolver::Algorithm::ForceQ16Front);
       }
       else if (value == "false")
       {
-        VERBOSE(l, 0) << "algorithm: bisection (Q8AtFront)";
+        SolverOutput::get() << "algorithm: bisection (Q8AtFront)";
         solver.algorithm(BisectionSolver::Algorithm::ForceQ16Back);
       }
       else
@@ -178,8 +176,8 @@ int entry(int argc, char **argv)
       }
     }
 
-    VERBOSE(l, 0) << "qerror metric: MAE" << std::endl
-                  << "target qerror ratio: " << qerror_ratio << std::endl;
+    SolverOutput::get() << "qerror metric: MAE\n"
+                        << "target qerror ratio: " << qerror_ratio << "\n";
 
     auto optimized = solver.run(input_model_path);
     if (optimized == nullptr)
@@ -190,7 +188,7 @@ int entry(int argc, char **argv)
 
     // save optimized
     {
-      VERBOSE(l, 0) << "Saving output model to " << output_model_path << std::endl;
+      SolverOutput::get() << "Saving output model to " << output_model_path << "\n";
       luci::CircleExporter exporter;
       luci::CircleFileExpContract contract(optimized.get(), output_model_path);
       if (!exporter.invoke(&contract))

--- a/compiler/circle-mpqsolver/src/core/SolverOutput.cpp
+++ b/compiler/circle-mpqsolver/src/core/SolverOutput.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "SolverOutput.h"
+
+#include <iostream>
+
+SolverOutput &SolverOutput::get(void)
+{
+  static SolverOutput d;
+  return d;
+}
+
+const SolverOutput &SolverOutput::operator<<(const std::string &message) const
+{
+  if (_turn_on)
+  {
+    std::cout << message;
+  }
+
+  return *this;
+}
+
+const SolverOutput &SolverOutput::operator<<(float value) const
+{
+  if (_turn_on)
+  {
+    std::cout << value;
+  }
+
+  return *this;
+}
+
+void SolverOutput::TurnOn(bool on) { _turn_on = on; }

--- a/compiler/circle-mpqsolver/src/core/SolverOutput.h
+++ b/compiler/circle-mpqsolver/src/core/SolverOutput.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __MPQSOLVER_SOLVER_OUTPUT_H__
+#define __MPQSOLVER_SOLVER_OUTPUT_H__
+
+#include <string>
+
+/**
+ * @brief SolverOutput prints important performance information
+ */
+class SolverOutput
+{
+private:
+  /**
+   * @brief construct SolverOutput
+   */
+  SolverOutput() = default;
+
+public:
+  /**
+   * @brief get singleton object
+   */
+  static SolverOutput &get(void);
+
+  /**
+   * @brief print string message
+   */
+  const SolverOutput &operator<<(const std::string &message) const;
+
+  /**
+   * @brief print float value
+   */
+  const SolverOutput &operator<<(float value) const;
+
+  /**
+   * @brief turn on/off actual output
+   */
+  void TurnOn(bool on);
+
+private:
+  bool _turn_on = true;
+};
+
+#endif // __MPQSOLVER_SOLVER_OUTPUT_H__


### PR DESCRIPTION
This commit replaces zero level logging with always printed messages.

It implements suggestion from https://github.com/Samsung/ONE/pull/11216#discussion_r1285390062.

Running `circle-mpqsolver` without 'LUCI_LOG' being defined produced the following output:
```
>> Searching mixed precision configuration 
model:/home/stanislav/repos/WorkSpaces/mobile_net_v1/model.recorded.circle
dataset: /mnt/storage/datasets/ms_coco/dataset_MB_v1_3.h5
input dtype: uint8
output dtype: uint8
algorithm: bisection (auto)
qerror metric: MAE
target qerror ratio: 0.1

>> Computing baseline qerrors
Full int16 model qerror: 7.68947e-05
Full uint8 model qerror: 0.000288324
Target qerror: 9.80376e-05

>> Running bisection(auto) algorithm
Qerror of front half: 152628
Qerror of rear half: 50324.6
Front part will be Q16, while the rear will be Q8

Looking for the optimal configuration in [0 , 32] depth segment
Qerror at depth 16 is 9.03983e-05 < target qerror (9.80376e-05)
Looking for the optimal configuration in [0 , 16] depth segment
Qerror at depth 8 is 0.000123055 > target qerror (9.80376e-05)
Looking for the optimal configuration in [8 , 16] depth segment
Qerror at depth 12 is 0.000103797 > target qerror (9.80376e-05)
Looking for the optimal configuration in [12 , 16] depth segment
Qerror at depth 14 is 0.000102298 > target qerror (9.80376e-05)
Looking for the optimal configuration in [14 , 16] depth segment
Qerror at depth 15 is 9.56676e-05 < target qerror (9.80376e-05)
Looking for the optimal configuration in [14 , 15] depth segment
Qerror at depth 14 is 0.000102298 > target qerror (9.80376e-05)
Found the best configuration at depth 15
Saving output model to /home/stanislav/repos/WorkSpaces/mobile_net_v1/model.q_opt.circle
```

Draft: https://github.com/Samsung/ONE/pull/11179
Related: https://github.com/Samsung/ONE/issues/11146

ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>