### PR TITLE
[luci/svc] Max() with unsigned zero will always be ignored

### DIFF
--- a/compiler/luci/service/src/ShapeInfer_StridedSlice.cpp
+++ b/compiler/luci/service/src/ShapeInfer_StridedSlice.cpp
@@ -305,7 +305,7 @@ StridedSliceParams BuildStridedSliceParams(StridedSliceContext *op_context)
     if ((1 << i) & effective_ellipsis_mask)
     {
       // If ellipsis_mask, set the begin_mask and end_mask at that index.
-      added_ellipsis = std::max(0u, i - ellipsis_start_idx);
+      added_ellipsis = std::max(0, (int32_t)(i - ellipsis_start_idx));
       assert(i < 16);
       op_params.begin_mask |= (1 << i);
       op_params.end_mask |= (1 << i);


### PR DESCRIPTION
Using std::max() with unsigned type value and unsigned zero(0u) always return a value greater than 0. 
It fixes the use of std::max() to work as intended.

ONE-DCO-1.0-Signed-off-by: Jonghwa Lee <jonghwa3.lee@samsung.com>