### PR TITLE
Fix cmake warnings.

### DIFF
--- a/infra/cmake/packages/ProtobufConfig.cmake
+++ b/infra/cmake/packages/ProtobufConfig.cmake
@@ -24,12 +24,12 @@ endfunction(_Protobuf_module_import)
 function(_Protobuf_import)
   # Let's use find_package here not to export unnecessary definitions
   # NOTE Here we use "exact" match to avoid possible infinite loop
-  find_package(protobuf EXACT 3.5.2 QUIET)
+  find_package(Protobuf EXACT 3.5.2 QUIET)
 
-  if(NOT protobuf_FOUND)
+  if(NOT Protobuf_FOUND)
     set(Protobuf_FOUND FALSE PARENT_SCOPE)
     return()
-  endif(NOT protobuf_FOUND)
+  endif(NOT Protobuf_FOUND)
 
   if(NOT TARGET libprotobuf)
     add_library(libprotobuf INTERFACE)


### PR DESCRIPTION
- Match case of module names and function call parameters.
- To remove warnings from cmake version 3.27.2.

ONE-DCO-1.0-Signed-off-by: Sung-Jae Lee <sj925.lee@samsung.com>
