### PR TITLE
Add cmake options for macOS aarch64 build

### DIFF
--- a/infra/nncc/cmake/options/options_aarch64-darwin.cmake
+++ b/infra/nncc/cmake/options/options_aarch64-darwin.cmake
@@ -1,0 +1,4 @@
+#
+# aarch64 darwin cmake options
+#
+


### PR DESCRIPTION
- For `aarch64-darwin`.

ONE-DCO-1.0-Signed-off-by: Sung-Jae Lee <sj925.lee@samsung.com>