### PR TITLE
[luci/pass] compute_sym_scale supports int8

### DIFF
--- a/compiler/luci/pass/src/QuantizationUtils.h
+++ b/compiler/luci/pass/src/QuantizationUtils.h
@@ -23,9 +23,9 @@
 namespace luci
 {
 
-// Compute scale using given min/max for symmetric quantization (int16)
+// Compute scale using given min/max for symmetric quantization (int8/int16)
 void compute_sym_scale(float min, float max, float &scaling_factor, float &nudged_min,
-                       float &nudged_max);
+                       float &nudged_max, loco::DataType out_type = loco::DataType::S16);
 
 // Compute scale/zp using given min/max for asymmetric quantization (uint8)
 void compute_asym_scale_zp(float min, float max, float &scaling_factor, int64_t &zp,


### PR DESCRIPTION
Add out_type parameter to compute_sym_scale in order to support int8.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

Related: https://github.com/Samsung/ONE/pull/11073, #11057