### PR TITLE
[circledump] Support int8 datatype

### DIFF
--- a/compiler/circle-tensordump/src/Dump.cpp
+++ b/compiler/circle-tensordump/src/Dump.cpp
@@ -185,6 +185,10 @@ H5::PredType hdf5_dtype_cast(const circle::TensorType &circle_type)
     {
       return H5::PredType::NATIVE_UINT8;
     }
+    case circle::TensorType_INT8:
+    {
+      return H5::PredType::NATIVE_INT8;
+    }
     case circle::TensorType_INT16:
     {
       return H5::PredType::NATIVE_INT16;


### PR DESCRIPTION
It makes circle-tensordump support `int8` datatype.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

Related: https://github.com/Samsung/ONE/pull/11073, https://github.com/Samsung/ONE/issues/11122, #11057