### PR TITLE
[pota-quantization-value-test] Add weights_only_quantization

### DIFF
--- a/compiler/pota-quantization-value-test/compare_tensors.py
+++ b/compiler/pota-quantization-value-test/compare_tensors.py
@@ -19,7 +19,9 @@ parser.add_argument('--expect_dir', type=str, required=True)
 parser.add_argument('--mode', type=str, required=True)
 args = parser.parse_args()
 
-supported_modes = ["fake_quantization", "record_minmax", "quantization"]
+supported_modes = [
+    "fake_quantization", "record_minmax", "quantization", "weights_only_quantization"
+]
 
 model = args.input_h5
 expect_dir = args.expect_dir
@@ -111,6 +113,9 @@ with h5.File(model, "r") as input:
                 compare_record_minmax(input[tensor_name], tensor_name, expect_dir)
             elif mode == "quantization":
                 compare_quantization(input[tensor_name], tensor_name, expect_dir)
+            elif mode == "weights_only_quantization":
+                if tensor_name == "ker":
+                    compare_quantization(input[tensor_name], tensor_name, expect_dir)
             else:
                 raise SystemExit("Unsupproted mode.")
 

--- a/compiler/pota-quantization-value-test/compare_tensors.py
+++ b/compiler/pota-quantization-value-test/compare_tensors.py
@@ -114,6 +114,7 @@ with h5.File(model, "r") as input:
             elif mode == "quantization":
                 compare_quantization(input[tensor_name], tensor_name, expect_dir)
             elif mode == "weights_only_quantization":
+                # Assume weights have name "ker"
                 if tensor_name == "ker":
                     compare_quantization(input[tensor_name], tensor_name, expect_dir)
             else:


### PR DESCRIPTION
It add weights_only_quantization mode in compare_tensors.py. It only quantize weights. Thus, bias and so on are not checked.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

Related: https://github.com/Samsung/ONE/pull/11073, https://github.com/Samsung/ONE/issues/11122, #11057