### PR TITLE
[record-minmax] Fix cmake warning

### DIFF
--- a/compiler/record-minmax/CMakeLists.txt
+++ b/compiler/record-minmax/CMakeLists.txt
@@ -52,7 +52,7 @@ if("${CMAKE_SIZEOF_VOID_P}" STREQUAL "8" AND FALSE)
 
   target_compile_options(record-minmax-for-thread-test PUBLIC -fsanitize=thread)
   target_link_libraries(record-minmax-for-thread-test -fsanitize=thread)
-endif("${CMAKE_SIZEOF_VOID_P}" STREQUAL "8")
+endif("${CMAKE_SIZEOF_VOID_P}" STREQUAL "8" AND FALSE)
 
 file(GLOB_RECURSE TESTS "tests/*.test.cpp")
 


### PR DESCRIPTION
This will fix cmake warning about if block mis-matching.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>