### PR TITLE
[onert] Support Q8 Hybrid Quantization for Conv2D

### DIFF
--- a/compute/cker/include/cker/operation/Conv.h
+++ b/compute/cker/include/cker/operation/Conv.h
@@ -207,6 +207,21 @@ private:
   std::vector<int32_t> _per_channel_output_multiplier;
   std::vector<int> _per_channel_output_shift;
 };
+
+struct ConvHybridTempArena
+{
+  ConvHybridTempArena(int input_size, int batch_size)
+  {
+    input_quantized.resize(input_size);
+    // TODO: Optimize the case of batch_size = 1
+    input_scaling_factors.resize(batch_size);
+    input_offsets.resize(batch_size);
+  }
+  std::vector<int8_t> input_quantized;
+  std::vector<float> input_scaling_factors;
+  std::vector<int32_t> input_offsets;
+};
+
 } // namespace cker
 } // namespace nnfw
 

--- a/runtime/onert/backend/cpu/ops/ConvolutionLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ConvolutionLayer.cc
@@ -285,6 +285,14 @@ void ConvolutionLayer::prepare()
 
   if (_is_hybrid)
   {
+    // ensure weight is per-channel quantized.
+    int32_t kernel_input_channel = getShape(_kernel).Dims(3);
+    // zero_points comes from flatbuffer vector. Its size is within uint32_t range.
+    size_t kernel_zerop_cnt = _kernel->data_scales().size();
+    // promote to int64_t to compare int32_t and uint32_t
+    if ((int64_t)kernel_input_channel != (int64_t)kernel_zerop_cnt)
+      throw std::runtime_error{"DConv2D hybrid supports only per-channel quantized weight."};
+
     // allocate memory for activation quantization.
     // - quantized values (int8_t type and same shape of original input)
     // - quantization params (= scale/zeropoint for each input)

--- a/runtime/onert/backend/cpu/ops/ConvolutionLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ConvolutionLayer.cc
@@ -16,6 +16,7 @@
 
 #include "ConvolutionLayer.h"
 #include "OperationUtils.h"
+#include "cker/PortableTensorUtils.h"
 
 #include "../Tensor.h"
 #include "ir/Padding.h"
@@ -151,6 +152,47 @@ void ConvolutionLayer::convQ8i()
          reinterpret_cast<int8_t *>(_output->buffer()));
 }
 
+void ConvolutionLayer::convQ8iHybridPerChannel()
+{
+  float output_activation_min = 0;
+  float output_activation_max = 0;
+  CalculateActivationRange(_activation, &output_activation_min, &output_activation_max);
+
+  const int batch_size = getShape(_input).Dims(0);
+  if (batch_size == 0)
+    throw std::runtime_error{"Convolution input batch_size = 0"};
+  auto input_shape = getShape(_input);
+  const int input_size = input_shape.FlatSize() / batch_size;
+
+  auto input_quantized_ptr = _hybrid_arena->input_quantized.data();
+  auto input_scaling_factors_ptr = _hybrid_arena->input_scaling_factors.data();
+  auto input_offsets_ptr = _hybrid_arena->input_offsets.data();
+  for (int b = 0; b < batch_size; ++b)
+  {
+    const int offset = b * input_size;
+    nnfw::cker::PortableAsymmetricQuantizeFloats(
+      reinterpret_cast<const float *>(_input->buffer()) + offset, input_size,
+      input_quantized_ptr + offset, &input_scaling_factors_ptr[b], &input_offsets_ptr[b]);
+  }
+  nnfw::cker::ConvParams op_params;
+  op_params.padding_type = getPaddingType(_paddingType);
+  op_params.padding_values.width = _paddingLeft;
+  op_params.padding_values.height = _paddingTop;
+  op_params.stride_width = _strideWidth;
+  op_params.stride_height = _strideHeight;
+  op_params.dilation_width_factor = _dilationWidthFactor;
+  op_params.dilation_height_factor = _dilationHeightFactor;
+  op_params.float_activation_min = output_activation_min;
+  op_params.float_activation_max = output_activation_max;
+
+  const auto *filter_per_channel_scales = _kernel->data_scales().data();
+  nnfw::cker::reference::HybridConvPerChannel(
+    op_params, input_scaling_factors_ptr, getShape(_input), input_quantized_ptr, getShape(_kernel),
+    reinterpret_cast<const int8_t *>(_kernel->buffer()), getShape(_bias),
+    reinterpret_cast<const float *>(_bias->buffer()), getShape(_output),
+    reinterpret_cast<float *>(_output->buffer()), filter_per_channel_scales, input_offsets_ptr);
+}
+
 void ConvolutionLayer::configure(const IPortableTensor *input, const IPortableTensor *kernel,
                                  const IPortableTensor *bias, const ir::PaddingType paddingType,
                                  const uint32_t paddingLeft, const uint32_t paddingRight,
@@ -174,12 +216,13 @@ void ConvolutionLayer::configure(const IPortableTensor *input, const IPortableTe
   _dilationHeightFactor = dilationHeightFactor;
   _activation = activation;
   _output = output;
+  _is_hybrid = _input->data_type() == OperandType::FLOAT32 &&
+               _kernel->data_type() == OperandType::QUANT_INT8_SYMM;
 }
 
 void ConvolutionLayer::run()
 {
   prepare();
-
   if (_input->is_dynamic() || _kernel->is_dynamic())
   {
     const auto ifm_shape = _input->getShape().asFeature(_input->layout());
@@ -209,7 +252,11 @@ void ConvolutionLayer::run()
     _paddingTop = padding.top;
     _paddingBottom = padding.bottom;
   }
-  if (_input->data_type() == OperandType::FLOAT32)
+  if (_is_hybrid)
+  {
+    convQ8iHybridPerChannel();
+  }
+  else if (_input->data_type() == OperandType::FLOAT32)
   {
     convFloat32();
   }
@@ -235,6 +282,19 @@ void ConvolutionLayer::prepare()
 {
   if (_prepare)
     return;
+
+  if (_is_hybrid)
+  {
+    // allocate memory for activation quantization.
+    // - quantized values (int8_t type and same shape of original input)
+    // - quantization params (= scale/zeropoint for each input)
+    auto input_shape = getShape(_input);
+    const int batch_size = input_shape.Dims(0);
+    const int input_size = input_shape.FlatSize() / batch_size;
+    _hybrid_arena = std::make_unique<nnfw::cker::ConvHybridTempArena>(batch_size, input_size);
+    _prepare = true;
+    return;
+  }
 
   nnfw::cker::Conv &kernel = *_conv_kernel;
   if (_input->data_type() == OperandType::FLOAT32 && _kernel->is_constant())

--- a/runtime/onert/backend/cpu/ops/ConvolutionLayer.h
+++ b/runtime/onert/backend/cpu/ops/ConvolutionLayer.h
@@ -29,7 +29,7 @@ namespace nnfw
 namespace cker
 {
 class Conv;
-class ConvHybridTempArena;
+struct ConvHybridTempArena;
 class Shape;
 } // namespace cker
 } // namespace nnfw

--- a/runtime/onert/backend/cpu/ops/ConvolutionLayer.h
+++ b/runtime/onert/backend/cpu/ops/ConvolutionLayer.h
@@ -29,7 +29,9 @@ namespace nnfw
 namespace cker
 {
 class Conv;
-}
+class ConvHybridTempArena;
+class Shape;
+} // namespace cker
 } // namespace nnfw
 
 namespace onert
@@ -63,6 +65,7 @@ private:
   void convQ8uPerTensor();
   void convQ8uPerChannel();
   void convQ8i();
+  void convQ8iHybridPerChannel();
 
 private:
   const IPortableTensor *_input;
@@ -84,8 +87,10 @@ private:
   ir::Activation _activation;
 
   std::unique_ptr<nnfw::cker::Conv> _conv_kernel;
+  std::unique_ptr<nnfw::cker::ConvHybridTempArena> _hybrid_arena;
 
   bool _prepare;
+  bool _is_hybrid;
 };
 
 } // namespace ops

--- a/runtime/onert/core/src/ir/OperationValidator.cc
+++ b/runtime/onert/core/src/ir/OperationValidator.cc
@@ -195,6 +195,13 @@ void OperationValidator::visit(const operation::Conv2D &node)
     for (const auto zeropoint : _operands.at(kernel_index).typeInfo().zero_points())
       OP_REQUIRES(zeropoint == 0);
   }
+  if (isConstant(kernel_index) && operandType(kernel_index) == DataType::QUANT_INT8_SYMM)
+  {
+    int32_t kernel_input_channel = _operands.at(kernel_index).shape().dim(3);
+    // zero_points comes from flatbuffer vector. Its size is guaranteed within uint32_t.
+    size_t kernel_zerop_cnt = _operands.at(kernel_index).typeInfo().zero_points().size();
+    OP_REQUIRES((int64_t)kernel_input_channel == (int64_t)kernel_zerop_cnt);
+  }
 }
 
 void OperationValidator::visit(const operation::DepthToSpace &node)

--- a/runtime/onert/core/src/ir/OperationValidator.cc
+++ b/runtime/onert/core/src/ir/OperationValidator.cc
@@ -195,13 +195,6 @@ void OperationValidator::visit(const operation::Conv2D &node)
     for (const auto zeropoint : _operands.at(kernel_index).typeInfo().zero_points())
       OP_REQUIRES(zeropoint == 0);
   }
-  if (isConstant(kernel_index) && operandType(kernel_index) == DataType::QUANT_INT8_SYMM)
-  {
-    int32_t kernel_input_channel = _operands.at(kernel_index).shape().dim(3);
-    // zero_points comes from flatbuffer vector. Its size is guaranteed within uint32_t.
-    size_t kernel_zerop_cnt = _operands.at(kernel_index).typeInfo().zero_points().size();
-    OP_REQUIRES((int64_t)kernel_input_channel == (int64_t)kernel_zerop_cnt);
-  }
 }
 
 void OperationValidator::visit(const operation::DepthToSpace &node)

--- a/tests/nnfw_api/src/one_op_tests/Conv2D.test.cc
+++ b/tests/nnfw_api/src/one_op_tests/Conv2D.test.cc
@@ -301,29 +301,3 @@ TEST_F(GenModelTest, neg_OneOp_Conv2D_I8_NonZero_ZeroPoints)
 
   SUCCEED();
 }
-
-TEST_F(GenModelTest, neg_OneOp_Conv2D_I8_Hybrid_PerTensor)
-{
-  CircleGen cgen;
-  std::vector<int8_t> weight_data{1, 2, 3, 4, 5, 6, 7, 8, 9};
-  uint32_t weight_buf = cgen.addBuffer(weight_data);
-  std::vector<float> bias_data{0, 2, 4};
-  uint32_t bias_buf = cgen.addBuffer(bias_data);
-  int in = cgen.addTensor({{1, 1, 1, 3}, circle::TensorType::TensorType_FLOAT32});
-  // Hybrid does not support per-tensor.
-  std::vector<float> weight_scales = {0.5};
-  std::vector<int64_t> weight_zeropoints = {0};
-  int weight = cgen.addTensor({{3, 1, 1, 3}, circle::TensorType::TensorType_INT8, weight_buf},
-                              weight_scales, weight_zeropoints);
-  int bias = cgen.addTensor({{1, 1, 1, 3}, circle::TensorType::TensorType_FLOAT32, bias_buf});
-  int out = cgen.addTensor({{1, 1, 1, 3}, circle::TensorType::TensorType_FLOAT32});
-  cgen.addOperatorConv2D({{in, weight, bias}, {out}}, circle::Padding_VALID, 1, 1,
-                         circle::ActivationFunctionType_NONE);
-  cgen.setInputsAndOutputs({in}, {out});
-
-  _context = std::make_unique<GenModelTestContext>(cgen.finish());
-  _context->setBackends({"cpu"});
-  _context->expectFailModelLoad();
-
-  SUCCEED();
-}

--- a/tests/nnfw_api/src/one_op_tests/Conv2D.test.cc
+++ b/tests/nnfw_api/src/one_op_tests/Conv2D.test.cc
@@ -276,3 +276,29 @@ TEST_F(GenModelTest, neg_OneOp_Conv2D_I8_NonZero_ZeroPoints)
 
   SUCCEED();
 }
+
+TEST_F(GenModelTest, neg_OneOp_Conv2D_I8_Hybrid_PerTensor)
+{
+  CircleGen cgen;
+  std::vector<int8_t> weight_data{1, 2, 3, 4, 5, 6, 7, 8, 9};
+  uint32_t weight_buf = cgen.addBuffer(weight_data);
+  std::vector<float> bias_data{0, 2, 4};
+  uint32_t bias_buf = cgen.addBuffer(bias_data);
+  int in = cgen.addTensor({{1, 1, 1, 3}, circle::TensorType::TensorType_FLOAT32});
+  // Hybrid does not support per-tensor.
+  std::vector<float> weight_scales = {0.5};
+  std::vector<int64_t> weight_zeropoints = {0};
+  int weight = cgen.addTensor({{3, 1, 1, 3}, circle::TensorType::TensorType_INT8, weight_buf},
+                              weight_scales, weight_zeropoints);
+  int bias = cgen.addTensor({{1, 1, 1, 3}, circle::TensorType::TensorType_FLOAT32, bias_buf});
+  int out = cgen.addTensor({{1, 1, 1, 3}, circle::TensorType::TensorType_FLOAT32});
+  cgen.addOperatorConv2D({{in, weight, bias}, {out}}, circle::Padding_VALID, 1, 1,
+                         circle::ActivationFunctionType_NONE);
+  cgen.setInputsAndOutputs({in}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->setBackends({"cpu"});
+  _context->expectFailModelLoad();
+
+  SUCCEED();
+}

--- a/tests/nnfw_api/src/one_op_tests/Conv2D.test.cc
+++ b/tests/nnfw_api/src/one_op_tests/Conv2D.test.cc
@@ -301,3 +301,29 @@ TEST_F(GenModelTest, neg_OneOp_Conv2D_I8_NonZero_ZeroPoints)
 
   SUCCEED();
 }
+
+TEST_F(GenModelTest, neg_OneOp_Conv2D_I8_Hybrid_PerTensor)
+{
+  CircleGen cgen;
+  std::vector<int8_t> weight_data{1, 2, 3, 4, 5, 6, 7, 8, 9};
+  uint32_t weight_buf = cgen.addBuffer(weight_data);
+  std::vector<float> bias_data{0, 2, 4};
+  uint32_t bias_buf = cgen.addBuffer(bias_data);
+  int in = cgen.addTensor({{1, 1, 1, 3}, circle::TensorType::TensorType_FLOAT32});
+  // Hybrid does not support per-tensor.
+  std::vector<float> weight_scales = {0.5};
+  std::vector<int64_t> weight_zeropoints = {0};
+  int weight = cgen.addTensor({{3, 1, 1, 3}, circle::TensorType::TensorType_INT8, weight_buf},
+                              weight_scales, weight_zeropoints);
+  int bias = cgen.addTensor({{1, 1, 1, 3}, circle::TensorType::TensorType_FLOAT32, bias_buf});
+  int out = cgen.addTensor({{1, 1, 1, 3}, circle::TensorType::TensorType_FLOAT32});
+  cgen.addOperatorConv2D({{in, weight, bias}, {out}}, circle::Padding_VALID, 1, 1,
+                         circle::ActivationFunctionType_NONE);
+  cgen.setInputsAndOutputs({in}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->setBackends({"cpu"});
+  _context->expectFailCompile();
+
+  SUCCEED();
+}


### PR DESCRIPTION
Conv2D supports int8 symmetric weights-only quantization.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

Related: #11047