### PR TITLE
[onert] Implement shape inferer of Loss Op

### DIFF
--- a/compute/cker/include/cker/train/operation/Loss.h
+++ b/compute/cker/include/cker/train/operation/Loss.h
@@ -31,27 +31,23 @@ template <typename T>
 inline void MSE(const Shape &y_pred_shape, const T *y_pred_data, const Shape &y_true_shape,
                 const T *y_true_data, const Shape &output_shape, T *output_data)
 {
-  // TODO Consider Reduction
-  if (output_shape != Shape{1})
-    throw std::runtime_error("cker::MSE: output_shape != Shape{1}");
   if (y_pred_shape != y_true_shape)
     throw std::runtime_error("cker::MSE: y_pred_shape != y_true_shape");
+  if (y_pred_shape.Dims(0) != output_shape.Dims(0))
+    throw std::runtime_error("cker::MSE: y_pred_shape.Dims(0) != output_shape.Dims(0)");
 
   const auto y_pred = MapAsMatrixWithLastDimAsRows(y_pred_data, y_pred_shape);
   const auto y_true = MapAsMatrixWithLastDimAsRows(y_true_data, y_true_shape);
 
-  double squared_sum = 0.0f;
   for (size_t c = 0; c < (size_t)y_pred.cols(); ++c)
   {
+    double squared_sum = 0.0f;
     for (size_t r = 0; r < (size_t)y_pred.rows(); ++r)
     {
-      double error = y_pred.coeff(r, c) - y_true.coeff(r, c);
-      squared_sum += (error * error);
+      squared_sum += std::pow(y_true.coeff(r, c) - y_pred.coeff(r, c), 2);
     }
+    output_data[c] = static_cast<T>(squared_sum / y_pred.rows());
   }
-
-  auto size = y_pred.cols() * y_pred.rows();
-  output_data[0] = (T)(squared_sum / size);
 }
 
 template <typename T>

--- a/runtime/onert/core/src/compiler/StaticShapeInferer.cc
+++ b/runtime/onert/core/src/compiler/StaticShapeInferer.cc
@@ -605,11 +605,20 @@ void StaticShapeInferer::visit(const ir::operation::L2Normalization &op)
   handleSimpleUnaryOp(op, op.getInputs().at(ir::operation::L2Normalization::Input::INPUT));
 }
 
-void StaticShapeInferer::visit(const ir::operation::Loss &)
+void StaticShapeInferer::visit(const ir::operation::Loss &op)
 {
-  // TODO Consider SparseCategoricalCrossentropy case
+  auto &operands = _lowered_subg->graph().operands();
+  const auto y_pred_index{op.getInputs().at(ir::operation::Loss::Input::Y_PRED)};
+  const auto output_index{op.getOutputs().at(0)};
 
-  // TODO Consider output shape in case of reduction option
+  const auto &y_pred = operands.at(y_pred_index);
+  auto &output = operands.at(output_index);
+
+  // NOTE
+  // output shape of Loss op is {batch_size}
+  // y_pred & y_true shape : {16, 2, 3, 2} -> output shape : {16}
+  ir::Shape new_shape = ir::Shape{y_pred.shape().dim(0)};
+  output.info().shape(new_shape);
 }
 
 void StaticShapeInferer::visit(const ir::operation::LSTM &op)

--- a/runtime/onert/core/src/compiler/train/pass/LossInsertionPass.cc
+++ b/runtime/onert/core/src/compiler/train/pass/LossInsertionPass.cc
@@ -49,12 +49,15 @@ void LossInsertionPass::run()
   const auto &y_pred_index = _trainable_graph.getOutputs().at(index);
   const auto &y_pred = _trainable_graph.operands().at(y_pred_index);
   const auto &shape = y_pred.shape();
+
+  if (shape.dim(0) != 1)
+  {
+    throw std::runtime_error("LossInsertionPass: Not supported multiple batch_size inputs");
+  }
+
   const auto &type_info = y_pred.typeInfo();
   auto y_true_index = _trainable_graph.addOperand(shape, type_info);
   ir::OperandIndexSequence inputs{y_pred_index, y_true_index};
-
-  // TODO Consider Reduction
-  //      Some types of Reduction have the same shape y_true and output.
 
   const ir::TypeInfo float_op(ir::DataType::FLOAT32);
   auto output_index = _trainable_graph.addOperand(ir::Shape{1}, float_op);

--- a/runtime/onert/core/src/exec/train/TrainableExecutor.cc
+++ b/runtime/onert/core/src/exec/train/TrainableExecutor.cc
@@ -196,7 +196,16 @@ float TrainableExecutor::getLoss(const ir::IOIndex &pred_io_ind) const
     throw std::runtime_error{"Loss " + std::to_string(loss_ind.value()) + " is not defined."};
   backend::ITensor *tensor = _tensor_regs.getITensor(loss_ind);
   auto loss_buf = reinterpret_cast<float *>(tensor->buffer());
-  return *loss_buf;
+
+  // NOTE Only support SUM_OVER_BATCH_SIZE
+  // TODO Consider other cases
+  auto batch_size = tensor->getShape().dim(0);
+  double sum = 0.f;
+  for (int i = 0; i < batch_size; ++i)
+  {
+    sum += loss_buf[i];
+  }
+  return sum / batch_size;
 }
 
 } // namespace train


### PR DESCRIPTION
This commit implements shape inferer of Loss op.
This change is related to the Reduction case. Loss output has a shape equal to the input batch_size. The loss kernel calculates the loss value for each batch data. And the get_loss function returns the average of each batch loss.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Draft: #11035 