### PR TITLE
[one-cmds] Revise to use python3 for one-prepare-venv

### DIFF
--- a/compiler/one-cmds/one-prepare-venv
+++ b/compiler/one-cmds/one-prepare-venv
@@ -26,7 +26,7 @@ VENV_PYTHON=${DRIVER_PATH}/venv/bin/python
 
 if [ ! -f ${VENV_ACTIVATE} ]; then
   # Create python virtual enviornment
-  python3.8 -m venv "${DRIVER_PATH}/venv"
+  python3 -m venv "${DRIVER_PATH}/venv"
 fi
 
 # NOTE version


### PR DESCRIPTION
This will revise one-prepare-venv to use python3.
- one-prepare-venv is for U20.04 and U22.04

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>