### PR TITLE
[one-cmds] Revise one-prepare-venv for AArch64

### DIFF
--- a/compiler/one-cmds/CMakeLists.txt
+++ b/compiler/one-cmds/CMakeLists.txt
@@ -37,9 +37,9 @@ set(ONE_COMMAND_FILES
 
 # TODO find better way for per-platform files
 if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "aarch64")
-  # NOTE copy one-prepare-venv.u1804.aarch64 as build/../one-prepare-venv
+  # NOTE copy one-prepare-venv.aarch64 as build/../one-prepare-venv
   #      and install build/../one-prepare-venv file
-  list(APPEND ONE_COMMAND_FILES one-prepare-venv.u1804.aarch64)
+  list(APPEND ONE_COMMAND_FILES one-prepare-venv.aarch64)
 else(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "aarch64")
   if(ONE_UBUNTU_CODENAME_BIONIC)
     # NOTE copy one-prepare-venv.u1804 as build/../one-prepare-venv

--- a/compiler/one-cmds/one-prepare-venv.aarch64
+++ b/compiler/one-cmds/one-prepare-venv.aarch64
@@ -33,10 +33,10 @@ fi
 # - https://github.com/onnx/onnx/blob/master/docs/Versioning.md
 # - https://github.com/onnx/onnx-tensorflow/blob/master/Versioning.md
 
-VER_TENSORFLOW=2.10.1
-VER_ONNX=1.12.0
-VER_ONNXRUNTIME=1.12.1
-VER_ONNX_TF=1.6.0
+VER_TENSORFLOW=2.12.1
+VER_ONNX=1.14.0
+VER_ONNXRUNTIME=1.15.0
+VER_ONNX_TF=1.10.0
 VER_PYDOT=1.4.2
 
 # Install tensorflow
@@ -89,9 +89,8 @@ else
   ${VENV_PYTHON} -m pip ${PIP_OPTIONS} install onnx-tf==${VER_ONNX_TF}
 fi
 
-# NOTE refer https://github.com/protocolbuffers/protobuf/issues/10051
-# TODO remove this when issue is resolved
-${VENV_PYTHON} -m pip ${PIP_OPTIONS} install --upgrade protobuf==3.19.6
+# Fix version to that of TF release date
+${VENV_PYTHON} -m pip ${PIP_OPTIONS} install --upgrade protobuf==4.23.3
 
 # Install pydot for visq
 ${VENV_PYTHON} -m pip ${PIP_OPTIONS} install pydot==${VER_PYDOT}


### PR DESCRIPTION
This will revise one-prepare-venv for AArch64
- remove Ubuntu version fron name
- update TF and related packages versions

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>