### PR TITLE
[onert] Bring FullyConnected kernel from tensorflow v2.12.1.

### DIFF
--- a/compute/cker/CMakeLists.txt
+++ b/compute/cker/CMakeLists.txt
@@ -12,6 +12,10 @@ if(PROFILE_RUY)
   target_link_libraries(nnfw_lib_cker INTERFACE ruy_profiler)
 endif(PROFILE_RUY)
 
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "(x86)|(X86)|(amd64)|(AMD64)")
+  target_compile_definitions(nnfw_lib_cker INTERFACE CKER_X86_PLATFORM)
+endif(CMAKE_SYSTEM_PROCESSOR MATCHES "(x86)|(X86)|(amd64)|(AMD64)")
+
 target_include_directories(nnfw_lib_cker INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 # Workaround to avoid warning

--- a/compute/cker/include/cker/Types.h
+++ b/compute/cker/include/cker/Types.h
@@ -258,9 +258,12 @@ struct FullyConnectedParams
   // uint8, etc, activation params.
   int32_t quantized_activation_min;
   int32_t quantized_activation_max;
-  // float activation params - no one use this params, but ruy might use them later.
-  // float float_activation_min;
-  // float float_activation_max;
+  // float activation params
+  float float_activation_min;
+  float float_activation_max;
+  // Mark the operands as cacheable if they are unchanging, e.g. weights.
+  bool lhs_cacheable;
+  bool rhs_cacheable;
   // FullyConnectedWeightsFormat weights_format;
 };
 

--- a/compute/cker/include/cker/eigen/eigen_gemm_eigen.h
+++ b/compute/cker/include/cker/eigen/eigen_gemm_eigen.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __NNFW_CKER_EGIEN_EIGEN_GEMM_EIGEN_H__
+#define __NNFW_CKER_EGIEN_EIGEN_GEMM_EIGEN_H__
+
+// See b/131835803: in TFLite code, because eigen_spatial_convolutions.h does
+// #define Eigen EigenForTFLite, it is difficult to have any #include of Eigen
+// headers in a header file, as that results in name classes (compilation
+// errors) depending on the order in which these headers are #included.
+// So we have moved the #include of Eigen here, in a .cc file, where we have
+// control over the header #include sequence.
+// #include "third_party/eigen3/Eigen/Core"
+// #include "tensorflow/lite/kernels/cpu_backend_context.h"
+// #include "tensorflow/lite/kernels/cpu_backend_gemm_params.h"
+// #include "tensorflow/lite/kernels/internal/common.h"
+// #include "cker/eigen/eigen_convolution_helpers.h"
+#include "cker/operation/Common.h"
+#include "cker/Types.h"
+
+#include <Eigen/Core>
+
+namespace nnfw
+{
+namespace cker
+{
+namespace detail
+{
+
+// tensorflow/tensorflow/lite/kernels/cpu_backend_gemm_eigen.h and cpu_backend_gemm_eigen.cc
+struct GemmImplUsingEigen
+{
+  static void Run(const MatrixParams<float> &lhs_params, const float *lhs_data,
+                  const MatrixParams<float> &rhs_params, const float *rhs_data,
+                  const MatrixParams<float> &dst_params, float *dst_data,
+                  const GemmParams<float, float> &params)
+  {
+    // This code assumes specific storage orders, encoded in these Eigen types.
+    // These assumptions have been checked by TF_LITE_ASSERT's in the public
+    // Gemm entry point already, before the implementation gets to this point.
+    using EigenMatrixMapRowMajorConst =
+      Eigen::Map<const Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>;
+    using EigenMatrixMapColMajorConst =
+      Eigen::Map<const Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::ColMajor>>;
+    using EigenMatrixMapColMajorMutable =
+      Eigen::Map<Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::ColMajor>>;
+
+    EigenMatrixMapRowMajorConst eigen_lhs(lhs_data, lhs_params.rows, lhs_params.cols);
+    EigenMatrixMapColMajorConst eigen_rhs(rhs_data, rhs_params.rows, rhs_params.cols);
+    EigenMatrixMapColMajorMutable eigen_dst(dst_data, dst_params.rows, dst_params.cols);
+
+    if (rhs_params.cols == 1)
+    {
+      eigen_dst.col(0).noalias() = eigen_lhs * eigen_rhs.col(0);
+    }
+    else if (lhs_params.rows == 1)
+    {
+      eigen_dst.row(0).noalias() = eigen_lhs.row(0) * eigen_rhs;
+    }
+    else
+    {
+      eigen_dst.noalias() = eigen_lhs * eigen_rhs;
+    }
+
+    if (params.bias)
+    {
+      BiasAndClamp(params.clamp_min, params.clamp_max, dst_params.rows, params.bias,
+                   dst_params.rows * dst_params.cols, dst_data);
+    }
+    else
+    {
+      eigen_dst = eigen_dst.cwiseMin(params.clamp_max).cwiseMax(params.clamp_min);
+    }
+  }
+};
+
+} // namespace detail
+} // namespace cker
+} // namespace nnfw
+
+#endif // __NNFW_CKER_EGIEN_EIGEN_GEMM_EIGEN_H__

--- a/compute/cker/include/cker/operation/FullyConnected.h
+++ b/compute/cker/include/cker/operation/FullyConnected.h
@@ -21,6 +21,7 @@
 #include <ruy/context.h>
 #include "cker/operation/FullyConnectedDense16x1.h"
 #include "cker/operation/FullyConnectedSparse16x1.h"
+#include "cker/operation/optimized/Gemm.h"
 #include "cker/Shape.h"
 #include "cker/Types.h"
 #include "cker/Utils.h"
@@ -58,6 +59,42 @@ public:
   std::vector<int32_t> accum_scratch;
 };
 
+#if defined(CKER_X86_PLATFORM)
+
+// From tensorflow/tensorflow/lite/kernels/internal/optimized/optimized_ops.h
+inline void FullyConnected(const FullyConnectedParams &params, const Shape &input_shape,
+                           const float *input_data, const Shape &weights_shape,
+                           const float *weights_data, const Shape &,
+                           const float *optional_bias_data, const Shape &output_shape,
+                           float *output_data)
+{
+  const int dims_count = weights_shape.DimensionsCount();
+  const int input_rows = weights_shape.Dims(dims_count - 1);
+  MatrixParams<float> rhs_params;
+  rhs_params.order = Order::kColMajor;
+  rhs_params.rows = input_rows;
+  rhs_params.cols = input_shape.FlatSize() / input_rows;
+  rhs_params.cache_policy = optimized::DefaultCachePolicy(params.rhs_cacheable);
+
+  MatrixParams<float> lhs_params;
+  lhs_params.order = Order::kRowMajor;
+  lhs_params.cols = weights_shape.Dims(dims_count - 1);
+  lhs_params.rows = FlatSizeSkipDim(weights_shape, dims_count - 1);
+  lhs_params.cache_policy = optimized::DefaultCachePolicy(params.lhs_cacheable);
+  MatrixParams<float> dst_params;
+  dst_params.order = Order::kColMajor;
+  dst_params.rows = output_shape.Dims(output_shape.DimensionsCount() - 1);
+  dst_params.cols = FlatSizeSkipDim(output_shape, output_shape.DimensionsCount() - 1);
+  GemmParams<float, float> gemm_params;
+  gemm_params.bias = optional_bias_data;
+  gemm_params.clamp_min = params.float_activation_min;
+  gemm_params.clamp_max = params.float_activation_max;
+  optimized::Gemm(lhs_params, weights_data, rhs_params, input_data, dst_params, output_data,
+                  gemm_params);
+}
+
+#else // CKER_X86_PLATFORM
+
 inline void FullyConnected(const FullyConnectedParams &params, const Shape &input_shape,
                            const float *input_data, const Shape &weights_shape,
                            const float *weights_data, const Shape &, const float *bias_data,
@@ -88,6 +125,8 @@ inline void FullyConnected(const FullyConnectedParams &params, const Shape &inpu
     ApplyActivationToVector(output_data, batch_size * num_units, params.activation, output_data);
   }
 }
+
+#endif // CKER_X86_PLATFORM
 
 inline void FullyConnected(const FullyConnectedParams &params, const Shape &input_shape,
                            const uint8_t *input_data, const Shape &filter_shape,

--- a/compute/cker/include/cker/operation/optimized/Gemm.h
+++ b/compute/cker/include/cker/operation/optimized/Gemm.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __NNFW_CKER_OPTIMIZED_GEMM_H__
+#define __NNFW_CKER_OPTIMIZED_GEMM_H__
+
+#include "cker/eigen/eigen_gemm_eigen.h"
+#include "cker/Shape.h"
+#include "cker/Types.h"
+
+#include <ruy/context.h>
+
+namespace nnfw
+{
+namespace cker
+{
+namespace optimized
+{
+
+#if defined(CKER_X86_PLATFORM)
+
+/* From tensorflow/tensorflow/lite/kernels/cpu_backend_gemm_x86.h */
+template <typename LhsScalar, typename RhsScalar, typename AccumScalar, typename DstScalar,
+          QuantizationFlavor quantization_flavor>
+struct GemmImplX86
+{
+  static void Run(const MatrixParams<LhsScalar> &, const LhsScalar *,
+                  const MatrixParams<RhsScalar> &, const RhsScalar *,
+                  const MatrixParams<DstScalar> &, DstScalar *,
+                  const GemmParams<AccumScalar, DstScalar, quantization_flavor> &)
+  {
+    static_assert(
+      std::is_floating_point<LhsScalar>::value && std::is_floating_point<RhsScalar>::value &&
+        std::is_floating_point<AccumScalar>::value && std::is_floating_point<DstScalar>::value &&
+        quantization_flavor != QuantizationFlavor::kFloatingPoint,
+      "GemmImplX86 does not supported types other than float yet.");
+  }
+};
+
+// For float, defer to eigen for now.
+template <> struct GemmImplX86<float, float, float, float, QuantizationFlavor::kFloatingPoint>
+{
+  static void Run(const MatrixParams<float> &lhs_params, const float *lhs_data,
+                  const MatrixParams<float> &rhs_params, const float *rhs_data,
+                  const MatrixParams<float> &dst_params, float *dst_data,
+                  const GemmParams<float, float, QuantizationFlavor::kFloatingPoint> &params)
+  {
+    detail::GemmImplUsingEigen::Run(lhs_params, lhs_data, rhs_params, rhs_data, dst_params,
+                                    dst_data, params);
+  }
+};
+
+/* From tensorflow/tensorflow/lite/kernels/cpu_backend_gemm.h */
+/* GEMM dispatch implementation for x86.
+ */
+template <typename LhsScalar, typename RhsScalar, typename AccumScalar, typename DstScalar,
+          QuantizationFlavor quantization_flavor>
+struct GemmImpl : GemmImplX86<LhsScalar, RhsScalar, AccumScalar, DstScalar, quantization_flavor>
+{
+};
+
+/* From tensorflow/tensorflow/lite/kernels/cpu_backend_gemm.h */
+template <typename LhsScalar, typename RhsScalar, typename AccumScalar, typename DstScalar,
+          QuantizationFlavor quantization_flavor>
+void Gemm(const MatrixParams<LhsScalar> &lhs_params, const LhsScalar *lhs_data,
+          const MatrixParams<RhsScalar> &rhs_params, const RhsScalar *rhs_data,
+          const MatrixParams<DstScalar> &dst_params, DstScalar *dst_data,
+          const GemmParams<AccumScalar, DstScalar, quantization_flavor> &params)
+{
+  // Generic case: dispatch to any backend as a general GEMM.
+  GemmImpl<LhsScalar, RhsScalar, AccumScalar, DstScalar, quantization_flavor>::Run(
+    lhs_params, lhs_data, rhs_params, rhs_data, dst_params, dst_data, params);
+}
+
+// From tensorflow/tensorflow/lite/kernels/cpu_backend_gemm_params.h
+inline CachePolicy DefaultCachePolicy(bool is_constant_data)
+{
+  return is_constant_data ? CachePolicy::kCacheIfLargeSpeedup : CachePolicy::kNeverCache;
+}
+#endif // CKER_X86_PLATFORM
+
+} // namespace optimized
+} // namespace cker
+} // namespace nnfw
+
+#endif // __NNFW_CKER_OPTIMIZED_GEMM_H__

--- a/runtime/onert/backend/cpu/ops/FullyConnectedLayer.cc
+++ b/runtime/onert/backend/cpu/ops/FullyConnectedLayer.cc
@@ -43,7 +43,16 @@ FullyConnectedLayer::~FullyConnectedLayer() = default;
 void FullyConnectedLayer::fullyConnectedFloat32()
 {
   nnfw::cker::FullyConnectedParams op_params;
+  float output_activation_min = 0;
+  float output_activation_max = 0;
+  CalculateActivationRange(_activation, &output_activation_min, &output_activation_max);
+
   op_params.activation = convertActivationType(_activation);
+  op_params.float_activation_min = output_activation_min;
+  op_params.float_activation_max = output_activation_max;
+  // TODO Set both cachables as false when training
+  op_params.lhs_cacheable = _weights->is_constant();
+  op_params.rhs_cacheable = _input->is_constant();
 
   nnfw::cker::FullyConnected(op_params, getShape(_input), getBuffer<float>(_input),
                              getShape(_weights), getBuffer<float>(_weights), getShape(_bias),

--- a/runtime/onert/backend/train/ops/FullyConnectedLayer.cc
+++ b/runtime/onert/backend/train/ops/FullyConnectedLayer.cc
@@ -154,7 +154,14 @@ void FullyConnectedLayer::backwardFloat32()
 
   // Initialize FullyConnectedParams
   nnfw::cker::FullyConnectedParams op_params;
+  float output_activation_min = 0;
+  float output_activation_max = 0;
+  CalculateActivationRange(ir::Activation::NONE, &output_activation_min, &output_activation_max);
   op_params.activation = nnfw::cker::FusedActivationFunctionType::kNone;
+  op_params.float_activation_min = output_activation_min;
+  op_params.float_activation_max = output_activation_max;
+  op_params.lhs_cacheable = false;
+  op_params.rhs_cacheable = false;
 
   // Transpose and compute gradient for input
   // ∂L/∂X = fc(Incoming gradient, transposed W)


### PR DESCRIPTION
This commit brings a FullyConnected kernel from tensorflow v2.12.1.
  - The kernel is an eigen kernel for FullyConnected operation.
  - The kernel supports only for float and x86.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>