### PR TITLE
[luci/pass] Introduce QuantizeWeightsPass

### DIFF
--- a/compiler/luci/pass/include/luci/Pass/QuantizeWeightsPass.h
+++ b/compiler/luci/pass/include/luci/Pass/QuantizeWeightsPass.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __LUCI_QUANTIZE_WEIGHTS_PASS_H__
+#define __LUCI_QUANTIZE_WEIGHTS_PASS_H__
+
+#include <loco.h>
+
+#include <logo/Pass.h>
+
+#include <luci/Pass/QuantizationParameters.h>
+
+namespace luci
+{
+
+/**
+ * @brief Pass to quantize weights
+ */
+class QuantizeWeightsPass : public logo::Pass
+{
+public:
+  struct Context
+  {
+    loco::DataType input_model_dtype = loco::DataType::Unknown;
+    loco::DataType output_model_dtype = loco::DataType::Unknown;
+    QuantizationGranularity granularity = QuantizationGranularity::ChannelWise;
+  };
+
+public:
+  QuantizeWeightsPass(std::unique_ptr<Context> &&ctx) : _ctx{std::move(ctx)}
+  {
+    // DO NOTHING
+  }
+
+public:
+  QuantizeWeightsPass(loco::DataType input_model_dtype, loco::DataType output_model_dtype,
+                      QuantizationGranularity granularity)
+  {
+    _ctx = std::make_unique<Context>();
+    {
+      _ctx->input_model_dtype = input_model_dtype;
+      _ctx->output_model_dtype = output_model_dtype;
+      _ctx->granularity = granularity;
+    }
+  }
+  virtual const char *name(void) const { return "luci::QuantizeWeightsPass"; }
+
+public:
+  bool run(loco::Graph *graph);
+
+private:
+  std::unique_ptr<Context> _ctx;
+};
+
+} // namespace luci
+
+#endif //__LUCI_QUANTIZE_WEIGHTS_PASS_H__

--- a/compiler/luci/pass/src/CircleQuantizer.cpp
+++ b/compiler/luci/pass/src/CircleQuantizer.cpp
@@ -26,6 +26,7 @@
 #include "luci/Pass/QuantizePreCheckerPass.h"
 #include "luci/Pass/QuantizeWithMinMaxPass.h"
 #include "luci/Pass/QuantizeDequantizeWeightsPass.h"
+#include "luci/Pass/QuantizeWeightsPass.h"
 
 #include "luci/Pass/CircleShapeInferencePass.h"
 #include "luci/Pass/CircleTypeInferencePass.h"
@@ -559,8 +560,15 @@ void CircleQuantizer::quantize(loco::Graph *g) const
     if (!in_array(to_lower_case(granularity), qw_supported_granularity))
       throw std::runtime_error("Unsupported granularity. List of supported granularity: " +
                                to_string(qw_supported_granularity));
+    auto ctx = std::make_unique<luci::QuantizeWeightsPass::Context>();
+    {
+      ctx->input_model_dtype = str_to_dtype(input_model_dtype);
+      ctx->output_model_dtype = str_to_dtype(output_model_dtype);
+      ctx->granularity = str_to_granularity(granularity);
+    }
+    luci::QuantizeWeightsPass weights_quantizer(std::move(ctx));
 
-    throw std::runtime_error("QuantizeWeights is not supported yet");
+    weights_quantizer.run(g);
   }
 
   // Requantize

--- a/compiler/luci/pass/src/QuantizeWeightsPass.cpp
+++ b/compiler/luci/pass/src/QuantizeWeightsPass.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Pass/QuantizeWeightsPass.h"
+#include "QuantizeWeightsOnly.h"
+#include "QuantizationUtils.h"
+
+#include <luci/IR/CircleNodes.h>
+#include <luci/IR/CircleNodeVisitor.h>
+#include <luci/Service/Nodes/CircleConst.h>
+#include <luci/Log.h>
+#include <loco/IR/TensorShape.h>
+
+#include <iostream>
+#include <cmath>
+#include <functional>
+#include <limits>
+
+namespace luci
+{
+
+bool QuantizeWeightsPass::run(loco::Graph *g)
+{
+  LOGGER(l);
+  INFO(l) << "QuantizeWeightsPass Start" << std::endl;
+
+  // Quantize weights
+  for (auto node : loco::active_nodes(loco::output_nodes(g)))
+  {
+    auto circle_node = loco::must_cast<luci::CircleNode *>(node);
+    QuantizeWeightsOnly qw(_ctx->input_model_dtype, _ctx->output_model_dtype, _ctx->granularity);
+    circle_node->accept(&qw);
+  }
+
+  INFO(l) << "QuantizeWeightsPass End" << std::endl;
+  return false; // one time run
+}
+
+} // namespace luci

--- a/compiler/luci/pass/src/QuantizeWeightsPass.cpp
+++ b/compiler/luci/pass/src/QuantizeWeightsPass.cpp
@@ -18,16 +18,7 @@
 #include "QuantizeWeightsOnly.h"
 #include "QuantizationUtils.h"
 
-#include <luci/IR/CircleNodes.h>
-#include <luci/IR/CircleNodeVisitor.h>
-#include <luci/Service/Nodes/CircleConst.h>
 #include <luci/Log.h>
-#include <loco/IR/TensorShape.h>
-
-#include <iostream>
-#include <cmath>
-#include <functional>
-#include <limits>
 
 namespace luci
 {

--- a/compiler/luci/pass/src/QuantizeWeightsPass.test.cpp
+++ b/compiler/luci/pass/src/QuantizeWeightsPass.test.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Pass/QuantizeWeightsPass.h"
+#include <gtest/gtest.h>
+
+TEST(QuantizeWeightsPassTest, name)
+{
+  luci::QuantizeWeightsPass pass(loco::DataType::FLOAT32, loco::DataType::S8,
+                                 luci::QuantizationGranularity::ChannelWise);
+  auto const name = pass.name();
+  ASSERT_NE(nullptr, name);
+}
+
+TEST(QuantizeWeightsPassTest, name_ctx)
+{
+  auto ctx = std::make_unique<luci::QuantizeWeightsPass::Context>();
+  {
+    ctx->input_model_dtype = loco::DataType::FLOAT32;
+    ctx->output_model_dtype = loco::DataType::S8;
+    ctx->granularity = luci::QuantizationGranularity::ChannelWise;
+  }
+
+  luci::QuantizeWeightsPass pass(std::move(ctx));
+  auto const name = pass.name();
+  ASSERT_NE(nullptr, name);
+}
+
+// TODO: Update negative test
+// Refer to DecomposeHardSwishPass.test.cpp
+// inherit test
+// have graph, input, output as member
+// Use graph in 2 negative tests
+
+TEST(QuantizeWeightsPassTest, run_NEG)
+{
+  loco::Graph g;
+  luci::QuantizeWeightsPass pass(loco::DataType::FLOAT32, loco::DataType::U8,
+                                 luci::QuantizationGranularity::ChannelWise);
+
+  // EXPECT_THROW(throw std::runtime_error{"run_NEG"}, std::runtime_error);
+  ASSERT_FALSE(pass.run(&g));
+}
+
+TEST(QuantizeWeightsPassTest, run_u8_NEG)
+{
+  loco::Graph g;
+  luci::QuantizeWeightsPass pass(loco::DataType::FLOAT32, loco::DataType::U8,
+                                 luci::QuantizationGranularity::ChannelWise);
+  ASSERT_FALSE(pass.run(&g));
+}


### PR DESCRIPTION
It introduces QuantizeWeightsPass, which calls WeigghtsOnly visitor.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

Related: https://github.com/Samsung/ONE/pull/11073, https://github.com/Samsung/ONE/issues/11057