### PR TITLE
[luci/pass] Fix build warnings

### DIFF
--- a/compiler/luci/pass/src/ConvertNCHWToNHWCPass.test.cpp
+++ b/compiler/luci/pass/src/ConvertNCHWToNHWCPass.test.cpp
@@ -535,6 +535,8 @@ public:
   luci::CircleMaximum *max = nullptr;
 };
 
+static constexpr std::initializer_list<uint32_t> kDefaultShape = {1, 16, 1, 1};
+
 class MeanGraph final : public SimpleGraph
 {
 protected:
@@ -577,7 +579,7 @@ public:
 private:
   bool _keep_dims = true;
   std::vector<int32_t> _axes = {2, 3};
-  std::initializer_list<uint32_t> _shape = {1, 16, 1, 1};
+  std::initializer_list<uint32_t> _shape = kDefaultShape;
 };
 
 class MinimumGraph final : public SimpleGraph
@@ -876,7 +878,7 @@ public:
 private:
   bool _keep_dims = true;
   std::vector<int32_t> _axes = {2, 3};
-  std::initializer_list<uint32_t> _shape = {1, 16, 1, 1};
+  std::initializer_list<uint32_t> _shape = kDefaultShape;
 };
 
 class ReduceMinGraph final : public SimpleGraph
@@ -921,7 +923,7 @@ public:
 private:
   bool _keep_dims = true;
   std::vector<int32_t> _axes = {2, 3};
-  std::initializer_list<uint32_t> _shape = {1, 16, 1, 1};
+  std::initializer_list<uint32_t> _shape = kDefaultShape;
 };
 
 class ReluGraph final : public SimpleGraph

--- a/compiler/luci/pass/src/FoldAddV2Pass.test.cpp
+++ b/compiler/luci/pass/src/FoldAddV2Pass.test.cpp
@@ -44,10 +44,10 @@ template <loco::DataType T> class FoldAddV2Test : public luci::ConstantFoldingAd
 public:
   FoldAddV2Test(std::initializer_list<uint32_t> shape) : luci::ConstantFoldingAddTestGraph(shape, T)
   {
-    _addV2 = _g.nodes()->create<luci::CircleCustom>(2, 1);
-    _x = _g.nodes()->create<luci::CircleConst>();
-    _y = _g.nodes()->create<luci::CircleConst>();
-    _addV2_out = _g.nodes()->create<luci::CircleCustomOut>();
+    _addV2 = _g.nodes()->template create<luci::CircleCustom>(2, 1);
+    _x = _g.nodes()->template create<luci::CircleConst>();
+    _y = _g.nodes()->template create<luci::CircleConst>();
+    _addV2_out = _g.nodes()->template create<luci::CircleCustomOut>();
 
     _addV2->dtype(T);
     _x->dtype(T);

--- a/compiler/luci/pass/src/FoldCastPass.test.cpp
+++ b/compiler/luci/pass/src/FoldCastPass.test.cpp
@@ -31,8 +31,8 @@ public:
   FoldCastTest(std::initializer_list<uint32_t> shape)
     : luci::ConstantFoldingAddTestGraph(shape, ToT)
   {
-    _cast = _g.nodes()->create<luci::CircleCast>();
-    _x = _g.nodes()->create<luci::CircleConst>();
+    _cast = _g.nodes()->template create<luci::CircleCast>();
+    _x = _g.nodes()->template create<luci::CircleConst>();
 
     _cast->dtype(ToT);
     _x->dtype(FromT);

--- a/compiler/luci/pass/src/FoldDequantizePass.test.cpp
+++ b/compiler/luci/pass/src/FoldDequantizePass.test.cpp
@@ -32,8 +32,8 @@ public:
 
   loco::Node *createFoldedPattern() override
   {
-    _dequantize = _g.nodes()->create<luci::CircleDequantize>();
-    _input = _g.nodes()->create<luci::CircleConst>();
+    _dequantize = _g.nodes()->template create<luci::CircleDequantize>();
+    _input = _g.nodes()->template create<luci::CircleConst>();
 
     _dequantize->dtype(loco::DataType::FLOAT32);
     _input->dtype(DT);

--- a/compiler/luci/pass/src/QuantizedModelVerifier.test.cpp
+++ b/compiler/luci/pass/src/QuantizedModelVerifier.test.cpp
@@ -66,6 +66,8 @@ template <Type T> luci::CircleConst *create_dummy_const(loco::Graph *g, luci::te
           // Fill with index
           node->at<T>(i) = static_cast<int16_t>(i);
           break;
+        default:
+          break;
       }
     }
   }

--- a/compiler/luci/pass/src/QuantizedModelVerifier.test.cpp
+++ b/compiler/luci/pass/src/QuantizedModelVerifier.test.cpp
@@ -470,15 +470,15 @@ public:
   void init(void) override
   {
     TestIOGraph::init({32}, {32});
-    _begin = g()->nodes()->create<luci::CircleConst>();
+    _begin = g()->nodes()->template create<luci::CircleConst>();
     {
       _begin->dtype(indexT);
     }
-    _size = g()->nodes()->create<luci::CircleConst>();
+    _size = g()->nodes()->template create<luci::CircleConst>();
     {
       _size->dtype(indexT);
     }
-    _slice = g()->nodes()->create<luci::CircleSlice>();
+    _slice = g()->nodes()->template create<luci::CircleSlice>();
     {
       _slice->input(input());
       _slice->begin(_begin);
@@ -694,11 +694,11 @@ public:
     TestIOGraph::init({32}, {1});
     // output dtype is float by default, but ArgMax should have indexType (s32/s64)
     output()->dtype(indexT);
-    _dimension = g()->nodes()->create<luci::CircleConst>();
+    _dimension = g()->nodes()->template create<luci::CircleConst>();
     {
       _dimension->dtype(indexT);
     }
-    _argmax = g()->nodes()->create<luci::CircleArgMax>();
+    _argmax = g()->nodes()->template create<luci::CircleArgMax>();
     {
       _argmax->input(input());
       _argmax->dimension(_dimension);
@@ -1003,7 +1003,7 @@ public:
     TestIOGraph::init({32}, {32});
     output()->dtype(loco::DataType::BOOL);
     _y = create_dummy_const<Type::FLOAT32>(g(), {32});
-    _op = g()->nodes()->create<Op>();
+    _op = g()->nodes()->template create<Op>();
     {
       _op->x(input());
       _op->y(_y);
@@ -1036,7 +1036,7 @@ public:
     input()->dtype(loco::DataType::BOOL);
     output()->dtype(loco::DataType::BOOL);
     _y = create_dummy_const<Type::BOOL>(g(), {32});
-    _op = g()->nodes()->create<Op>();
+    _op = g()->nodes()->template create<Op>();
     {
       _op->x(input());
       _op->y(_y);
@@ -1340,7 +1340,7 @@ public:
     TypedTestGraph::init(T, {32}, {32});
 
     _const = create_dummy_const<T>(g(), {32});
-    _mul = g()->nodes()->create<luci::CircleMul>();
+    _mul = g()->nodes()->template create<luci::CircleMul>();
     {
       _mul->x(input());
       _mul->y(_const);
@@ -1395,7 +1395,7 @@ public:
     TypedTestGraph::init(T, {32}, {32});
 
     _const = create_dummy_const<T>(g(), {32});
-    _add = g()->nodes()->create<luci::CircleAdd>();
+    _add = g()->nodes()->template create<luci::CircleAdd>();
     {
       _add->x(input());
       _add->y(_const);

--- a/compiler/luci/pass/src/VerifyQuantizedBiasScale.cpp
+++ b/compiler/luci/pass/src/VerifyQuantizedBiasScale.cpp
@@ -31,7 +31,7 @@ namespace
 bool same(float a, float b)
 {
   constexpr float epsilon = 1e-10;
-  return abs(a - b) < epsilon;
+  return std::abs(a - b) < epsilon;
 }
 
 // Check bias scale = input scale * weight scale


### PR DESCRIPTION
This PR fixes buid warnings from luci/pass module.

 ONE-DCO-1.0-Signed-off-by: Jonghwa Lee <jonghwa3.lee@samsung.com>

---
### Descriptions

The build warnigs were obtained while it compiles the one compiler with Clang 14.0.
The more information about each fixes are in below.

| Commits | Description | Severity(*) |
|---|---|---|
|[[luci/pass] Use std::abs() for float type instead of abs()](https://github.com/Samsung/ONE/commit/b97844c19e987bb5f3baf2544b1d136b4ff31e62) | * The abs() in libc only gets integer parameters.<br> * It should uses std::abs() for float type. | High |
|[[luci/pass] Initialize std::initializer_list with static variable](https://github.com/Samsung/ONE/commit/e8336cfaf203b0b99c018e34329556a31fdd2660)| * Using std::initializer_list with brace-init-list via default member intializer is not safe. <br> * The underlying array will be released as contructor is returning. <br>  * As a workaround, it tries to use a static array to extend life time of underying array. <br>* (Reference) <br> http://eel.is/c++draft/dcl.init.list#6 | High |
|[[luci/pass] Add 'template' keyword](https://github.com/Samsung/ONE/commit/5e9f3c4f8e8c74c5e41eb5042de8d32f081b6a3a)| * Because of the C++ grammar ambiguity, '<' token can be interpreted both of the start of template argument list or a less than operator. <br> * And also, if the type of base class is dependent (e.g. template), then the compiler can't know about the member function. <br> * (Reference) <br> http://www.aerialmantis.co.uk/blog/2017/03/17/template-keywords/ | Low |
|[[luci/pass] Missing default handle for switch statement](https://github.com/Samsung/ONE/commit/36a3dfffbedef483be4f21a277d6233d46d49990)| * The default case is not mandatory in switch statement, but it is necessary to handle the unxexpected cases. | Low |

(*) The severity level is based on personal opinion. Higher level is more harmful :(