### PR TITLE
[onert] Do not use uninitialized variable in train ElementwiseActivat…

### DIFF
--- a/runtime/onert/backend/train/ops/ElementwiseActivationLayer.cc
+++ b/runtime/onert/backend/train/ops/ElementwiseActivationLayer.cc
@@ -52,7 +52,7 @@ void ElementwiseActivationLayer::configure(const IPortableTensor *input, IPortab
   switch (op_type)
   {
     case ElementwiseActivationType::kReLU:
-      if (_input->data_type() == OperandType::FLOAT32)
+      if (input->data_type() == OperandType::FLOAT32)
       {
         if (alpha == std::numeric_limits<float>::infinity() && beta == 0.f)
         {


### PR DESCRIPTION
…ionLayer

This commit does not use uninitialized input variable in train ElementwiseActivationLayer.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>