### PR TITLE
[luci/pass] Use std::abs() for float type instead of abs()

### DIFF
--- a/compiler/luci/pass/src/VerifyQuantizedBiasScale.cpp
+++ b/compiler/luci/pass/src/VerifyQuantizedBiasScale.cpp
@@ -31,7 +31,7 @@ namespace
 bool same(float a, float b)
 {
   constexpr float epsilon = 1e-10;
-  return abs(a - b) < epsilon;
+  return std::abs(a - b) < epsilon;
 }
 
 // Check bias scale = input scale * weight scale


### PR DESCRIPTION
The abs() will typecasts float type into integer implictly.
Better to use std::abs() for float type variable.

ONE-DCO-1.0-Signed-off-by: Jonghwa Lee <jonghwa3.lee@samsung.com>

---

Related with #11343 