### PR TITLE
[infra/gbs] Fix test install path typo

### DIFF
--- a/packaging/nnfw.spec
+++ b/packaging/nnfw.spec
@@ -134,7 +134,7 @@ NPU daemon for optimal management of NPU hardware
 # TODO Share path with release package
 %define test_install_home /opt/usr/nnfw-test
 %define test_install_dir %{test_install_home}/Product/out
-%define test_install_path %{buildroot}%{test_install_dir}
+%define test_install_path %{buildroot}/%{test_install_dir}
 
 # Set option for test build (and coverage test build)
 %define option_test -DENABLE_TEST=OFF


### PR DESCRIPTION
This commit fixes test install path typo:
`%{buildroot}%{test_install_dir}` -> `%{buildroot}/%{test_install_dir}`

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>