### PR TITLE
[one-cmds] Add tests for ampq

### DIFF
--- a/compiler/one-cmds/tests/one-quantize_018.test
+++ b/compiler/one-cmds/tests/one-quantize_018.test
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ampq test for bisection_type = 'i16_front' (front nodes will be quantized to int16)
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  echo "${filename_ext} FAILED"
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+inputfile="./inception_v3.circle"
+outputfile="./inception_v3.q_opt.circle"
+datafile="./inception_v3_test_data.h5"
+bisection_type="i16_front"
+
+rm -f ${filename}.log
+rm -f ${outputfile}
+
+# run test
+one-quantize \
+--input_data ${datafile} \
+--input_path ${inputfile} \
+--ampq \
+--ampq_qerror_ratio "0.5" \
+--ampq_algorithm "bisection" \
+--bisection_type ${bisection_type} \
+--output_path ${outputfile} > ${filename}.log 2>&1
+
+if [[ ! -s "${outputfile}" ]]; then
+  trap_err_onexit
+fi
+
+echo "${filename_ext} SUCCESS"

--- a/compiler/one-cmds/tests/one-quantize_019.test
+++ b/compiler/one-cmds/tests/one-quantize_019.test
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ampq test for bisection_type = 'i16_back' (output nodes will be quantized to int16)
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  echo "${filename_ext} FAILED"
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+inputfile="./inception_v3.circle"
+outputfile="./inception_v3.q_opt.circle"
+datafile="./inception_v3_test_data.h5"
+bisection_type="i16_back"
+
+rm -f ${filename}.log
+rm -f ${outputfile}
+
+# run test
+one-quantize \
+--input_data ${datafile} \
+--input_path ${inputfile} \
+--ampq \
+--ampq_qerror_ratio "0.5" \
+--ampq_algorithm "bisection" \
+--bisection_type ${bisection_type} \
+--output_path ${outputfile} > ${filename}.log 2>&1
+
+if [[ ! -s "${outputfile}" ]]; then
+  trap_err_onexit
+fi
+
+echo "${filename_ext} SUCCESS"

--- a/compiler/one-cmds/tests/one-quantize_020.test
+++ b/compiler/one-cmds/tests/one-quantize_020.test
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ampq test with bisection_type set to auto
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  echo "${filename_ext} FAILED"
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+inputfile="./inception_v3.circle"
+outputfile="./inception_v3.q_opt.circle"
+datafile="./inception_v3_test_data.h5"
+bisection_type="auto"
+
+rm -f ${filename}.log
+rm -f ${outputfile}
+
+# run test
+one-quantize \
+--input_data ${datafile} \
+--input_path ${inputfile} \
+--ampq \
+--ampq_qerror_ratio "0.5" \
+--ampq_algorithm "bisection" \
+--bisection_type ${bisection_type} \
+--output_path ${outputfile} > ${filename}.log 2>&1
+
+if [[ ! -s "${outputfile}" ]]; then
+  trap_err_onexit
+fi
+
+echo "${filename_ext} SUCCESS"


### PR DESCRIPTION
This commit adds tests for ampq option of one-quantize cmd.

Its correctness is tested at https://github.com/Samsung/ONE/pull/11179.

Draft: https://github.com/Samsung/ONE/pull/11179
Related: https://github.com/Samsung/ONE/issues/11146

ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>