### PR TITLE
[one-cmds] Fix import onnx I/O names with numeric

### DIFF
--- a/compiler/one-cmds/one-import-onnx
+++ b/compiler/one-cmds/one-import-onnx
@@ -70,17 +70,21 @@ class TidyIONames:
         for idx in range(0, len(self.onnx_model.graph.input)):
             name = self.onnx_model.graph.input[idx].name
             if not name in self.initializers:
-                if '.' in name or ':' in name:
+                if '.' in name or ':' in name or name[:1].isdigit():
                     self.input_nodes.append(name)
                     name_alt = name.replace('.', '_')
                     name_alt = name_alt.replace(':', '_')
+                    if name_alt[:1].isdigit():
+                        name_alt = 'a_' + name_alt
                     self.remap_inputs.append(name_alt)
         for idx in range(0, len(self.onnx_model.graph.output)):
             name = self.onnx_model.graph.output[idx].name
-            if '.' in name or ':' in name:
+            if '.' in name or ':' in name or name[:1].isdigit():
                 self.output_nodes.append(name)
                 name_alt = name.replace('.', '_')
                 name_alt = name_alt.replace(':', '_')
+                if name_alt[:1].isdigit():
+                    name_alt = 'a_' + name_alt
                 self.remap_outputs.append(name_alt)
 
     def update(self):


### PR DESCRIPTION
This will fix one-import-onnx I/O names starting with numeric.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>