### PR TITLE
[luci/logex] Add missing parentheses

### DIFF
--- a/compiler/luci/logex/src/CircleNodeSummaryBuilder.cpp
+++ b/compiler/luci/logex/src/CircleNodeSummaryBuilder.cpp
@@ -68,7 +68,7 @@ bool CircleNodeSummaryBuilder::build(const loco::Node *node, const locop::Symbol
     {
       if (i)
         ss << ",";
-      ss << node->dim(i).known() ? node->dim(i).value() : -1;
+      ss << (node->dim(i).known() ? node->dim(i).value() : -1);
     }
     ss << ">";
     return ss.str();


### PR DESCRIPTION
The insertion operator ('<<') has higher precedence than conditional
operator ('?'). It adds a parentheses to keep the order of operators.

ONE-DCO-1.0-Signed-off-by: Jonghwa Lee <jonghwa3.lee@samsung.com>