### PR TITLE
[luci/import] Add a virtual destructor for Base class

### DIFF
--- a/compiler/luci/import/include/luci/Import/NodeBuilder.h
+++ b/compiler/luci/import/include/luci/Import/NodeBuilder.h
@@ -42,6 +42,7 @@ class NodeBuilderBase
 public:
   virtual CircleNode *build(TensorIndex tensor_idx, GraphBuilderContext *context) const = 0;
   virtual NodeBuilderType builder_type() const = 0;
+  virtual ~NodeBuilderBase() = default;
 };
 
 /**


### PR DESCRIPTION
The NodeBuilderBase abstract class has a non-virtual destructor implicitly. If a virtual destructor is not defined in the base class, a derived class's destructor won't be called when it's deleted with the pointer to its base class type.

ONE-DCO-1.0-Signed-off-by: Jonghwa Lee <jonghwa3.lee@samsung.com>