### PR TITLE
[circledump] Add a virtual destructor for Base class

### DIFF
--- a/compiler/circledump/src/MetadataPrinter.h
+++ b/compiler/circledump/src/MetadataPrinter.h
@@ -29,6 +29,7 @@ class MetadataPrinter
 {
 public:
   virtual void print(const uint8_t * /* buffer */, std::ostream &) const = 0;
+  virtual ~MetadataPrinter() = default;
 };
 
 class MetadataPrinterRegistry


### PR DESCRIPTION
The MetadataPrinter abstract class has a non-virtual destructor implicitly. If a virtual destructor is not defined in the base class, a derived class's destructor won't be called when it's deleted with the pointer to its base class type.

ONE-DCO-1.0-Signed-off-by: Jonghwa Lee <jonghwa3.lee@samsung.com>