### PR TITLE
[circle-eval-diff] Add missing parentheses

### DIFF
--- a/compiler/circle-eval-diff/src/InputDataLoader.cpp
+++ b/compiler/circle-eval-diff/src/InputDataLoader.cpp
@@ -166,7 +166,7 @@ DirectoryLoader::DirectoryLoader(const std::string &dir_path,
 
   struct dirent *entry = nullptr;
   const auto input_total_bytes = getTotalByteSizeOf(input_nodes);
-  while (entry = readdir(dir))
+  while ((entry = readdir(dir)))
   {
     // Skip if the entry is not a regular file
     if (entry->d_type != DT_REG)


### PR DESCRIPTION
The compiler warns using the result of an assignment as a condition without parentheses. Let's add additional parentheses to make sure the condition is intended.

ONE-DCO-1.0-Signed-off-by: Jonghwa Lee <jonghwa3.lee@samsung.com>