### PR TITLE
[nnc] Use delete w/ bracket for array type

### DIFF
--- a/compiler/nnc/backends/soft_backend/code_snippets/cpp_header_types.def
+++ b/compiler/nnc/backends/soft_backend/code_snippets/cpp_header_types.def
@@ -147,7 +147,7 @@ public:
 
     if (!t._managed) {
       if (_managed)
-        delete _data;
+        delete [] _data;
 
       _managed = false;
       _data = t._data;


### PR DESCRIPTION
Use 'delete []' for freeing a array type variable.

ONE-DCO-1.0-Signed-off-by: Jonghwa Lee <jonghwa3.lee@samsung.com>