### PR TITLE
[one-cmds] Use different output name

### DIFF
--- a/compiler/one-cmds/tests/one-quantize_018.test
+++ b/compiler/one-cmds/tests/one-quantize_018.test
@@ -27,7 +27,7 @@ trap_err_onexit()
 trap trap_err_onexit ERR
 
 inputfile="./inception_v3.circle"
-outputfile="./inception_v3.q_opt.circle"
+outputfile="./inception_v3.q_opt.one-quantize_018.circle"
 datafile="./inception_v3_test_data.h5"
 bisection_type="i16_front"
 

--- a/compiler/one-cmds/tests/one-quantize_019.test
+++ b/compiler/one-cmds/tests/one-quantize_019.test
@@ -27,7 +27,7 @@ trap_err_onexit()
 trap trap_err_onexit ERR
 
 inputfile="./inception_v3.circle"
-outputfile="./inception_v3.q_opt.circle"
+outputfile="./inception_v3.q_opt.one-quantize_019.circle"
 datafile="./inception_v3_test_data.h5"
 bisection_type="i16_back"
 

--- a/compiler/one-cmds/tests/one-quantize_020.test
+++ b/compiler/one-cmds/tests/one-quantize_020.test
@@ -27,7 +27,7 @@ trap_err_onexit()
 trap trap_err_onexit ERR
 
 inputfile="./inception_v3.circle"
-outputfile="./inception_v3.q_opt.circle"
+outputfile="./inception_v3.q_opt.one-quantize_020.circle"
 datafile="./inception_v3_test_data.h5"
 bisection_type="auto"
 


### PR DESCRIPTION
This makes tests use different output name to avoid name conflicts.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>