### PR TITLE
[luci/pass] Update negative test for QuantizeWeightsPass

### DIFF
--- a/compiler/luci/pass/src/QuantizeWeightsPass.cpp
+++ b/compiler/luci/pass/src/QuantizeWeightsPass.cpp
@@ -28,6 +28,9 @@ bool QuantizeWeightsPass::run(loco::Graph *g)
   LOGGER(l);
   INFO(l) << "QuantizeWeightsPass Start" << std::endl;
 
+  if (_ctx->input_model_dtype != loco::DataType::FLOAT32)
+    throw std::runtime_error("Weights-only quantization supports float32 input only");
+
   // Quantize weights
   for (auto node : loco::active_nodes(loco::output_nodes(g)))
   {


### PR DESCRIPTION
It alters 1st negative test to check input dtype.
It also updates test graph's conv params so that it is valid.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

https://github.com/Samsung/ONE/pull/11340#pullrequestreview-1597521620