### PR TITLE
[luci/pass] QuantizeWeightsOnly supports DepthwiseConv2D

### DIFF
--- a/compiler/luci/pass/src/QuantizeWeightsOnly.cpp
+++ b/compiler/luci/pass/src/QuantizeWeightsOnly.cpp
@@ -205,6 +205,20 @@ void QuantizeWeightsOnly::visit(luci::CircleConv2D *node)
   }
 }
 
+void QuantizeWeightsOnly::visit(luci::CircleDepthwiseConv2D *node)
+{
+  LOGGER(l);
+  INFO(l) << "QuantizeWeightsOnly visits node: " << node->name() << std::endl;
+
+  auto weights = loco::must_cast<luci::CircleConst *>(node->filter());
+  if (!is_quantized(weights))
+  {
+    auto new_weights = luci::clone(weights);
+    node->filter(new_weights);
+    quantize_weights(new_weights);
+  }
+}
+
 void QuantizeWeightsOnly::visit(luci::CircleNode *) {}
 
 } // namespace luci

--- a/compiler/luci/pass/src/QuantizeWeightsOnly.h
+++ b/compiler/luci/pass/src/QuantizeWeightsOnly.h
@@ -42,6 +42,7 @@ private:
   void quantize_weights(luci::CircleConst *weights);
 
   void visit(luci::CircleConv2D *node);
+  void visit(luci::CircleDepthwiseConv2D *node);
   void visit(luci::CircleNode *);
 };
 


### PR DESCRIPTION
It add visit function for DepthwiseConv2D in QuantizeWeightsOnly.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

Related: #11057