### PR TITLE
[circle-interpreter-test] Add proper dependency

### DIFF
--- a/compiler/circle-interpreter-test/CMakeLists.txt
+++ b/compiler/circle-interpreter-test/CMakeLists.txt
@@ -11,7 +11,17 @@ nnas_find_package(GTest REQUIRED)
 file(GLOB_RECURSE TESTS "src/*.test.cpp")
 GTest_AddTest(circle-interpreter-test ${TESTS})
 
-set_tests_properties(circle-interpreter-test
-                     PROPERTIES
-                     ENVIRONMENT "ARTIFACTS_PATH=${ARTIFACTS_PATH};CIRCLE_INTERPRETER_PATH=${CIRCLE_INTERPRETER_PATH}"
-                     )
+# circle-interpreter-test uses input data generated during luci_value_test
+if(NOT CMAKE_CROSSCOMPILING)
+  set_tests_properties(circle-interpreter-test
+                      PROPERTIES
+                      DEPENDS luci_value_test
+                      ENVIRONMENT "ARTIFACTS_PATH=${ARTIFACTS_PATH};CIRCLE_INTERPRETER_PATH=${CIRCLE_INTERPRETER_PATH}"
+                      )
+else(NOT CMAKE_CROSSCOMPILING)
+  set_tests_properties(circle-interpreter-test
+                      PROPERTIES
+                      DEPENDS luci_value_cross_test
+                      ENVIRONMENT "ARTIFACTS_PATH=${ARTIFACTS_PATH};CIRCLE_INTERPRETER_PATH=${CIRCLE_INTERPRETER_PATH}"
+                      )
+endif(NOT CMAKE_CROSSCOMPILING)

--- a/compiler/circle-interpreter-test/requires.cmake
+++ b/compiler/circle-interpreter-test/requires.cmake
@@ -1,2 +1,3 @@
 require("common-artifacts")
 require("circle-interpreter")
+require("luci-value-test")


### PR DESCRIPTION
This adds dependency on luci_value_test.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
`circle-interpreter-test` intermittently fails as input data (generated by `luci_value_test`) does not exist. This PR resolves the issue.