### PR TITLE
[onert] Don't show intended cp fail

### DIFF
--- a/Makefile.template
+++ b/Makefile.template
@@ -188,7 +188,7 @@ acl_tar_internal: configure_internal
 
 install_acl_internal:
 # Workaround to install acl for test (ignore error when there is no file to copy)
-	cp $(OVERLAY_FOLDER)/lib/libarm_compute*.so $(INSTALL_ALIAS)/lib || true
+	@cp $(OVERLAY_FOLDER)/lib/libarm_compute*.so $(INSTALL_ALIAS)/lib 2>/dev/null || true
 
 install_luci_internal:
 	@mkdir -p $(INSTALL_ALIAS)/lib/nnfw/odc


### PR DESCRIPTION
This commit updates makefile to not show intended copy fail message on x64.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: #11405