### PR TITLE
[tools/onert_train] Add mem_poll argument

### DIFF
--- a/tests/tools/onert_train/src/args.cc
+++ b/tests/tools/onert_train/src/args.cc
@@ -209,6 +209,7 @@ void Args::Initialize(void)
          "NN Model Raw Expected data file\n"
          "(Same data policy with load_input:raw)\n"
     )
+    ("mem_poll,m", po::value<bool>()->default_value(false)->notifier([&](const auto &v) { _mem_poll = v; }), "Check memory polling")
     ("epoch", po::value<int>()->default_value(5)->notifier([&](const auto &v) { _epoch = v; }), "Epoch number (default: 5)")
     ("batch_size", po::value<int>()->default_value(32)->notifier([&](const auto &v) { _batch_size = v; }), "Batch size (default: 32)")
     ("learning_rate", po::value<float>()->default_value(1.0e-4)->notifier([&](const auto &v) { _learning_rate = v; }), "Learning rate (default: 1.0e-4)")

--- a/tests/tools/onert_train/src/args.h
+++ b/tests/tools/onert_train/src/args.h
@@ -52,6 +52,7 @@ public:
   const int getDataLength(void) const { return _data_length; }
   const std::string &getLoadRawInputFilename(void) const { return _load_raw_input_filename; }
   const std::string &getLoadRawExpectedFilename(void) const { return _load_raw_expected_filename; }
+  const bool getMemoryPoll(void) const { return _mem_poll; }
   const int getEpoch(void) const { return _epoch; }
   const int getBatchSize(void) const { return _batch_size; }
   const float getLearningRate(void) const { return _learning_rate; }
@@ -75,6 +76,7 @@ private:
   int _data_length;
   std::string _load_raw_input_filename;
   std::string _load_raw_expected_filename;
+  bool _mem_poll;
   int _epoch;
   int _batch_size;
   float _learning_rate;


### PR DESCRIPTION
This commit adds mem_poll argument to enable memory polling.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Draft: #11035 