### PR TITLE
[record-minmax] Revise record-minmax

### DIFF
--- a/compiler/record-minmax/include/MinMaxComputer.h
+++ b/compiler/record-minmax/include/MinMaxComputer.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __RECORD_MINMAX_MINMAXCOMPUTER_H__
+#define __RECORD_MINMAX_MINMAXCOMPUTER_H__
+
+#include "MinMaxObserver.h"
+
+namespace record_minmax
+{
+
+class MinMaxComputer
+{
+public:
+  MinMaxComputer()
+  {
+    // Do nothing
+  }
+
+  virtual ~MinMaxComputer() = default;
+
+  // Child class must implement this
+  // TODO Use proper input signature
+  virtual void update_qparam(MinMaxObserver *observer) = 0;
+};
+
+class PercentileComputer : public MinMaxComputer
+{
+public:
+  PercentileComputer(float min_percentile, float max_percentile)
+    : _min_percentile(min_percentile), _max_percentile(max_percentile)
+  {
+  }
+
+  virtual void update_qparam(MinMaxObserver *observer);
+
+private:
+  float _min_percentile = 0.0;
+  float _max_percentile = 0.0;
+};
+
+class MovingAvgComputer : public MinMaxComputer
+{
+public:
+  MovingAvgComputer(uint32_t batch_size, float update_const)
+    : _batch_size(batch_size), _update_const(update_const)
+  {
+  }
+
+  virtual void update_qparam(MinMaxObserver *observer);
+
+private:
+  uint32_t _batch_size = 0;
+  float _update_const = 0.0;
+};
+
+std::unique_ptr<MinMaxComputer> make_percentile_computer(float min_percentile,
+                                                         float max_percentile);
+
+std::unique_ptr<MinMaxComputer> make_moving_avg_computer(uint32_t batch_size,
+                                                         float moving_avg_const);
+
+} // namespace record_minmax
+
+#endif // __RECORD_MINMAX_MINMAXCOMPUTER_H__

--- a/compiler/record-minmax/include/RecordMinMax.h
+++ b/compiler/record-minmax/include/RecordMinMax.h
@@ -21,6 +21,7 @@
 #include <luci_interpreter/Interpreter.h>
 
 #include "MinMaxObserver.h"
+#include "MinMaxComputer.h"
 
 #include <memory>
 #include <thread>
@@ -35,9 +36,11 @@ using WholeOutput = std::vector<Output>;
 class RecordMinMax
 {
 public:
-  explicit RecordMinMax(uint32_t num_threads) : _threads_size(num_threads)
+  explicit RecordMinMax(uint32_t num_threads, std::unique_ptr<MinMaxComputer> &&minmax_computer)
+    : _threads_size(num_threads), _minmax_computer(std::move(minmax_computer))
   {
     assert(_threads_size > 0);
+    assert(_minmax_computer != nullptr);
   }
 
   ~RecordMinMax() = default;
@@ -74,6 +77,7 @@ private:
   std::vector<std::unique_ptr<MinMaxObserver>> _observers;
 
   uint32_t _threads_size = 0;
+  std::unique_ptr<MinMaxComputer> _minmax_computer;
 };
 
 } // namespace record_minmax

--- a/compiler/record-minmax/src/MinMaxComputer.cpp
+++ b/compiler/record-minmax/src/MinMaxComputer.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "MinMaxComputer.h"
+#include "RecordFunction.h"
+
+#include <luci/IR/CircleQuantParam.h>
+
+namespace record_minmax
+{
+
+void PercentileComputer::update_qparam(MinMaxObserver *observer)
+{
+  auto minmax_map = observer->minMaxData()->getMap();
+  for (auto iter = minmax_map->begin(); iter != minmax_map->end(); ++iter)
+  {
+    auto node = iter->first;
+    auto minmax = iter->second;
+
+    auto min = getNthPercentile(minmax.min_vector, _min_percentile);
+    auto max = getNthPercentile(minmax.max_vector, _max_percentile);
+
+    auto quantparam = std::make_unique<luci::CircleQuantParam>();
+    quantparam->min.push_back(min);
+    quantparam->max.push_back(max);
+
+    assert(node->quantparam() == nullptr);
+
+    auto mutable_node = const_cast<luci::CircleNode *>(node);
+    mutable_node->quantparam(std::move(quantparam));
+  }
+}
+
+void MovingAvgComputer::update_qparam(MinMaxObserver *observer)
+{
+  auto minmax_map = observer->minMaxData()->getMap();
+  for (auto iter = minmax_map->begin(); iter != minmax_map->end(); ++iter)
+  {
+    auto node = iter->first;
+    auto minmax = iter->second;
+
+    auto min = getMovingAverage(minmax.min_vector, 1 - _update_const, _batch_size, true);
+    auto max = getMovingAverage(minmax.max_vector, 1 - _update_const, _batch_size, false);
+
+    auto quantparam = std::make_unique<luci::CircleQuantParam>();
+    quantparam->min.push_back(min);
+    quantparam->max.push_back(max);
+
+    assert(node->quantparam() == nullptr);
+
+    auto mutable_node = const_cast<luci::CircleNode *>(node);
+    mutable_node->quantparam(std::move(quantparam));
+  }
+}
+
+std::unique_ptr<MinMaxComputer> make_percentile_computer(float min_percentile, float max_percentile)
+{
+  return std::make_unique<PercentileComputer>(min_percentile, max_percentile);
+}
+
+std::unique_ptr<MinMaxComputer> make_moving_avg_computer(uint32_t batch_size,
+                                                         float moving_avg_const)
+{
+  return std::make_unique<MovingAvgComputer>(batch_size, moving_avg_const);
+}
+
+} // namespace record_minmax

--- a/compiler/record-minmax/src/RecordMinMax.cpp
+++ b/compiler/record-minmax/src/RecordMinMax.cpp
@@ -15,7 +15,6 @@
  */
 
 #include "RecordMinMax.h"
-#include "RecordFunction.h"
 #include "MinMaxObserver.h"
 
 #include <luci/Importer.h>
@@ -144,6 +143,8 @@ void verifyTypeShape(const luci::CircleInput *input_node, const DataType &dtype,
   }
 }
 
+// TODO Remove unused code
+#if 0
 void update_quantparam(record_minmax::MinMaxObserver *observer, const std::string &mode,
                        float min_percentile, float max_percentile)
 {
@@ -175,6 +176,7 @@ void update_quantparam(record_minmax::MinMaxObserver *observer, const std::strin
     mutable_node->quantparam(std::move(quantparam));
   }
 }
+#endif
 
 } // namespace
 
@@ -297,7 +299,11 @@ void RecordMinMax::profileRawDataDirectory(const std::string &mode,
 
   std::cout << "Recording finished. Number of recorded data: " << num_records << std::endl;
 
-  update_quantparam(getObserver(), mode, min_percentile, max_percentile);
+  _minmax_computer->update_qparam(getObserver());
+  // TODO Remove redundant arguments
+  (void)mode;
+  (void)min_percentile;
+  (void)max_percentile;
 }
 
 // input_data_path is a text file which specifies the representative data
@@ -357,7 +363,11 @@ void RecordMinMax::profileRawData(const std::string &mode, const std::string &in
 
   std::cout << "Recording finished. Number of recorded data: " << num_records << std::endl;
 
-  update_quantparam(getObserver(), mode, min_percentile, max_percentile);
+  _minmax_computer->update_qparam(getObserver());
+  // TODO Remove redundant arguments
+  (void)mode;
+  (void)min_percentile;
+  (void)max_percentile;
 }
 
 WholeOutput RecordMinMax::importH5Data(const std::string &input_data_path)
@@ -481,7 +491,11 @@ void RecordMinMax::profileData(const std::string &mode, const std::string &input
     throw std::runtime_error("HDF5 error occurred.");
   }
 
-  update_quantparam(getObserver(), mode, min_percentile, max_percentile);
+  _minmax_computer->update_qparam(getObserver());
+  // TODO Remove redundant arguments
+  (void)mode;
+  (void)min_percentile;
+  (void)max_percentile;
 }
 
 void RecordMinMax::profileDataInParallel(const std::string &mode,
@@ -570,7 +584,11 @@ void RecordMinMax::profileDataInParallel(const std::string &mode,
 
   std::cout << "Recording finished. Number of recorded data: " << num_records << std::endl;
 
-  update_quantparam(observer.get(), mode, min_percentile, max_percentile);
+  _minmax_computer->update_qparam(observer.get());
+  // TODO Remove redundant arguments
+  (void)mode;
+  (void)min_percentile;
+  (void)max_percentile;
 }
 
 void RecordMinMax::profileDataWithRandomInputs(const std::string &mode, float min_percentile,
@@ -642,7 +660,11 @@ void RecordMinMax::profileDataWithRandomInputs(const std::string &mode, float mi
 
   std::cout << "Recording finished. Number of recorded data: " << num_records << std::endl;
 
-  update_quantparam(getObserver(), mode, min_percentile, max_percentile);
+  _minmax_computer->update_qparam(getObserver());
+  // TODO Remove redundant arguments
+  (void)mode;
+  (void)min_percentile;
+  (void)max_percentile;
 }
 
 void RecordMinMax::saveModel(const std::string &output_model_path)


### PR DESCRIPTION
This introduces MinMaxComputer to easily update calibration logic.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: #11269 
Draft PR: https://github.com/Samsung/ONE/pull/11409