### PR TITLE
[onert] Apply IGradientApplier

### DIFF
--- a/runtime/onert/backend/train/KernelGenerator.h
+++ b/runtime/onert/backend/train/KernelGenerator.h
@@ -23,6 +23,7 @@
 #include "Tensor.h"
 
 #include <backend/train/KernelGeneratorBase.h>
+#include <exec/train/IGradientApplier.h>
 #include <exec/train/optimizer/Optimizer.h>
 #include <ir/Operands.h>
 #include <ir/Operations.h>
@@ -56,7 +57,7 @@ private:
   std::shared_ptr<TensorRegistry> _tensor_reg;
   const std::shared_ptr<ExternalContext> _external_context;
   std::shared_ptr<exec::train::optimizer::Optimizer> _optimizer;
-  std::vector<std::unique_ptr<exec::train::ITrainableFunction>> _update_funcs;
+  std::vector<std::unique_ptr<exec::train::IGradientApplier>> _update_funcs;
 };
 
 } // namespace train

--- a/runtime/onert/backend/train/ops/GradientApplier.cc
+++ b/runtime/onert/backend/train/ops/GradientApplier.cc
@@ -40,7 +40,7 @@ void GradientApplier::configure(std::shared_ptr<exec::train::optimizer::Optimize
   _trainable_tensor = trainable;
 }
 
-void GradientApplier::backward(uint32_t training_step)
+void GradientApplier::applyGradient(uint32_t training_step)
 {
   _optimizer->applyGradient(
     std::forward_as_tuple(*_gradient_tensor, *_trainable_tensor, training_step));

--- a/runtime/onert/backend/train/ops/GradientApplier.h
+++ b/runtime/onert/backend/train/ops/GradientApplier.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_BACKEND_TRAIN_OPS_GRADIENT_APPLIER_H__
 #define __ONERT_BACKEND_TRAIN_OPS_GRADIENT_APPLIER_H__
 
-#include <exec/train/ITrainableFunction.h>
+#include <exec/train/IGradientApplier.h>
 
 #include <exec/train/optimizer/Optimizer.h>
 
@@ -30,7 +30,7 @@ namespace train
 namespace ops
 {
 
-class GradientApplier : public ::onert::exec::train::ITrainableFunction
+class GradientApplier : public ::onert::exec::train::IGradientApplier
 {
 public:
   GradientApplier();
@@ -38,8 +38,7 @@ public:
 
   void configure(std::shared_ptr<exec::train::optimizer::Optimizer> optimizer,
                  const IPortableTensor *gradient, ITrainableTensor *trainable);
-  void forward(bool) override {}
-  void backward(uint32_t training_step) override;
+  void applyGradient(uint32_t training_step) override;
 
 private:
   std::shared_ptr<exec::train::optimizer::Optimizer> _optimizer;

--- a/runtime/onert/core/include/exec/train/ITrainableFunction.h
+++ b/runtime/onert/core/include/exec/train/ITrainableFunction.h
@@ -31,6 +31,7 @@ class ITrainableFunction
 public:
   virtual ~ITrainableFunction() = default;
   virtual void forward(bool training) = 0;
+  // TODO Remove training_step
   virtual void backward(uint32_t training_step) = 0;
 };
 

--- a/runtime/onert/core/include/exec/train/TrainableFnSequence.h
+++ b/runtime/onert/core/include/exec/train/TrainableFnSequence.h
@@ -18,6 +18,7 @@
 #define __ONERT_EXEC_TRAIN_TRAINABLE_FN_SEQUENCE_H__
 
 #include "exec/train/ITrainableFunction.h"
+#include "exec/train/IGradientApplier.h"
 
 #include <memory>
 #include <vector>
@@ -36,11 +37,13 @@ public:
   void backward(uint32_t training_step) override;
 
   void append(std::unique_ptr<ITrainableFunction> &&fn);
+  void append(std::unique_ptr<IGradientApplier> &&applier);
   void iterate(const std::function<void(ITrainableFunction &)> &fn);
 
 public:
   // TODO Change members
   std::vector<std::unique_ptr<ITrainableFunction>> _functions;
+  std::vector<std::unique_ptr<IGradientApplier>> _appliers;
 };
 } // namespace train
 } // namespace exec

--- a/runtime/onert/core/src/exec/train/TrainableFnSequence.cc
+++ b/runtime/onert/core/src/exec/train/TrainableFnSequence.cc
@@ -37,11 +37,21 @@ void TrainableFnSequence::backward(uint32_t training_step)
   {
     (*it)->backward(training_step);
   }
+
+  for (const auto &applier : _appliers)
+  {
+    applier->applyGradient(training_step);
+  }
 }
 
 void TrainableFnSequence::append(std::unique_ptr<ITrainableFunction> &&function)
 {
   _functions.push_back(std::move(function));
+}
+
+void TrainableFnSequence::append(std::unique_ptr<IGradientApplier> &&applier)
+{
+  _appliers.push_back(std::move(applier));
 }
 
 void TrainableFnSequence::iterate(const std::function<void(ITrainableFunction &)> &fn)


### PR DESCRIPTION
This commit applies IGradientApplier.
  - Change GradientAppiler from inherting ITranableFunction to inherting IGradientApplier.
  - Add IGradientApplier vector in TrainableFnSequence.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>