### PR TITLE
[luci/service] Use explicit int64_t type zero

### DIFF
--- a/compiler/luci/service/src/ShapeInfer_StridedSlice.cpp
+++ b/compiler/luci/service/src/ShapeInfer_StridedSlice.cpp
@@ -301,7 +301,7 @@ StridedSliceParams BuildStridedSliceParams(StridedSliceContext *op_context)
     if ((1 << i) & effective_ellipsis_mask)
     {
       // If ellipsis_mask, set the begin_mask and end_mask at that index.
-      added_ellipsis = std::max(0l, i - ellipsis_start_idx);
+      added_ellipsis = std::max(int64_t(0), i - ellipsis_start_idx);
       assert(i < 16);
       op_params.begin_mask |= (1 << i);
       op_params.end_mask |= (1 << i);


### PR DESCRIPTION
This commit updates constant zero to int64_t type explicitly on std::max. 
It will resolve build fail for 32bit target.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>