### PR TITLE
[one-cmds] Add moving_average parameters

### DIFF
--- a/compiler/one-cmds/one-quantize
+++ b/compiler/one-cmds/one-quantize
@@ -121,6 +121,18 @@ def _get_parser():
         'maximum percentile (0.0~100.0, default=99.0). Algorithm parameter for calibration. This is valid when calibration algorithm is percentile.'
     )
     quantization_group.add_argument(
+        '--moving_avg_batch',
+        type=str,
+        help=
+        'batch size of moving average (default=16). This is valid when calibration algorithm is moving_average.'
+    )
+    quantization_group.add_argument(
+        '--moving_avg_const',
+        type=str,
+        help=
+        'hyperparameter (C) to compute moving average (default=0.1). Update equation: avg <- avg + C * (curr_batch_avg - avg). This is valid when calibration algorithm is moving_average.'
+    )
+    quantization_group.add_argument(
         '--mode',
         type=str,
         help=
@@ -288,6 +300,10 @@ def _set_default_values(args):
         setattr(args, 'min_percentile', '1.0')
     if not oneutils.is_valid_attr(args, 'max_percentile'):
         setattr(args, 'max_percentile', '99.0')
+    if not oneutils.is_valid_attr(args, 'moving_avg_batch'):
+        setattr(args, 'moving_avg_batch', '16')
+    if not oneutils.is_valid_attr(args, 'moving_avg_const'):
+        setattr(args, 'moving_avg_const', '0.1')
     if not oneutils.is_valid_attr(args, 'ampq_algorithm'):
         setattr(args, 'ampq_algorithm', 'bisection')
     if not oneutils.is_valid_attr(args, 'bisection_type'):
@@ -344,6 +360,31 @@ def _verify_arg(parser, args):
         if len(src_tensors) != len(dst_tensors):
             parser.error(
                 'The same number of src_tensor_name and dst_tensor_name should be given.')
+
+    # Check calibration parameters
+    if oneutils.is_valid_attr(args, 'mode'):
+        if getattr(args, 'mode') == 'percentile':
+            # Check dtype
+            try:
+                min_percentile = float(getattr(args, 'min_percentile'))
+            except ValueError:
+                parser.error('min_percentile must be float')
+            try:
+                max_percentile = float(getattr(args, 'max_percentile'))
+            except ValueError:
+                parser.error('max_percentile must be float')
+        elif getattr(args, 'mode') == 'moving_average':
+            # Check dtype
+            try:
+                moving_avg_batch = int(getattr(args, 'moving_avg_batch'))
+            except ValueError:
+                parser.error('moving_avg_batch must be integer')
+            try:
+                moving_avg_const = float(getattr(args, 'moving_avg_const'))
+            except ValueError:
+                parser.error('moving_avg_const must be float')
+        else:
+            parser.error('Unsupported mode')
 
 
 def _parse_arg(parser):
@@ -443,6 +484,8 @@ def _quantize(args):
             .add_option_with_valid_args('--input_data_format', ['input_data_format']) \
             .add_option_with_valid_args('--min_percentile', ['min_percentile']) \
             .add_option_with_valid_args('--max_percentile', ['max_percentile']) \
+            .add_option_with_valid_args('--moving_avg_batch', ['moving_avg_batch']) \
+            .add_option_with_valid_args('--moving_avg_const', ['moving_avg_const']) \
             .add_option_with_valid_args('--mode', ['mode']) \
             .add_noarg_option_if_valid_arg('--generate_profile_data', 'generate_profile_data') \
             .run()
@@ -637,6 +680,8 @@ def _ampq_solve(args):
             .add_option_with_valid_args('--input_data_format', ['input_data_format']) \
             .add_option_with_valid_args('--min_percentile', ['min_percentile']) \
             .add_option_with_valid_args('--max_percentile', ['max_percentile']) \
+            .add_option_with_valid_args('--moving_avg_batch', ['moving_avg_batch']) \
+            .add_option_with_valid_args('--moving_avg_const', ['moving_avg_const']) \
             .add_option_with_valid_args('--mode', ['mode']) \
             .add_noarg_option_if_valid_arg('--generate_profile_data', 'generate_profile_data') \
             .run()

--- a/compiler/one-cmds/tests/one-quantize_021.test
+++ b/compiler/one-cmds/tests/one-quantize_021.test
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Test moving average parameters (moving average per Image)
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  echo "${filename_ext} FAILED"
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+inputfile="./inception_v3.circle"
+outputfile="./inception_v3.one-quantize_021.circle"
+
+rm -f ${filename}.log
+rm -f ${outputfile}
+
+# run test
+one-quantize \
+--input_path ${inputfile} \
+--mode moving_average \
+--moving_avg_batch 1 \
+--moving_avg_const 0.01 \
+--output_path ${outputfile} > ${filename}.log 2>&1
+
+if [[ ! -s "${outputfile}" ]]; then
+  trap_err_onexit
+fi
+
+echo "${filename_ext} SUCCESS"

--- a/compiler/one-cmds/tests/one-quantize_neg_023.test
+++ b/compiler/one-cmds/tests/one-quantize_neg_023.test
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Wrong type of calibration parameter
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  if grep -q "moving_avg_batch must be integer" "${filename}.log"; then
+    echo "${filename_ext} SUCCESS"
+    exit 0
+  fi
+
+  echo "${filename_ext} FAILED"
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+inputfile="./inception_v3.circle"
+outputfile="./inception_v3.one-quantize_neg_023.circle"
+
+rm -f ${filename}.log
+
+# run test with wrong parameter dtype
+# moving_avg_batch must be integer
+one-quantize \
+--input_path ${inputfile} \
+--mode moving_average \
+--moving_avg_batch 0.1 \
+--output_path ${outputfile} > ${filename}.log 2>&1
+
+echo "${filename_ext} FAILED"
+exit 255


### PR DESCRIPTION
This adds parameters for moving_average in one-quantize.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/11269
Draft PR: https://github.com/Samsung/ONE/pull/11409