### PR TITLE
[onert] Use ASSERT_NE for negative test

### DIFF
--- a/runtime/onert/odc/Quantizer.test.cc
+++ b/runtime/onert/odc/Quantizer.test.cc
@@ -31,12 +31,12 @@ TEST(odc_Quantizer, neg_model_input_path)
 TEST(odc_Quantizer, neg_model_output_path)
 {
   Quantizer quantizer;
-  ASSERT_EQ(quantizer.quantize("in", nullptr, false), 1);
+  ASSERT_NE(quantizer.quantize("in", nullptr, false), 0);
 }
 
 // Test invalid model input path
 TEST(odc_Quantizer, neg_invalid_model_input_path)
 {
   Quantizer quantizer;
-  ASSERT_EQ(quantizer.quantize("invalid_model_input_path.circle", "out", false), 1);
+  ASSERT_NE(quantizer.quantize("invalid_model_input_path.circle", "out", false), 0);
 }


### PR DESCRIPTION
This commit updates odc quantizer negative unittest to use ASSERT_NE.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related review: https://github.com/Samsung/ONE/pull/11414#discussion_r1311371592