### PR TITLE
[onert] Introduce QuantizerLoader

### DIFF
--- a/runtime/onert/core/src/odc/QuantizerLoader.cc
+++ b/runtime/onert/core/src/odc/QuantizerLoader.cc
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "QuantizerLoader.h"
+
+#include <dlfcn.h>
+#include <iostream>
+#include <string>
+
+static const char *SHARED_LIB_EXT =
+#if defined(__APPLE__) && defined(__MACH__)
+  ".dylib";
+#else
+  ".so";
+#endif
+
+namespace onert
+{
+namespace odc
+{
+
+QuantizerLoader &QuantizerLoader::instance()
+{
+  static QuantizerLoader singleton;
+  return singleton;
+}
+
+int32_t QuantizerLoader::loadLibrary()
+{
+  if (get() != nullptr)
+    return 0;
+
+  const std::string quantize_so = std::string("libonert_odc") + SHARED_LIB_EXT;
+  void *handle = dlopen(quantize_so.c_str(), RTLD_LAZY | RTLD_LOCAL);
+  auto dlerror_msg = dlerror();
+
+  if (handle == nullptr)
+  {
+    std::cerr << "Failed to load " << quantize_so << std::endl;
+    std::cerr << dlerror_msg << std::endl;
+    return 1;
+  }
+
+  {
+    const char *factory_name = "create_quantizer";
+    auto factory = (factory_t)dlsym(handle, factory_name);
+    dlerror_msg = dlerror();
+
+    if (factory == nullptr)
+    {
+      std::cerr << "QuantizerLoader: unable to find function " << factory_name << dlerror_msg
+                << std::endl;
+      dlclose(handle);
+      return 1;
+    }
+
+    auto destroyer = (quantizer_destory_t)dlsym(handle, "destroy_quantizer");
+    _quantizer = std::unique_ptr<IQuantizer, quantizer_destory_t>(factory(), destroyer);
+
+    if (_quantizer == nullptr)
+    {
+      std::cerr << "QuantizerLoader: unable to create quantizer" << std::endl;
+      return 1;
+    }
+  }
+
+  // Save quantize library handle (avoid warning by handle lost without dlclose())
+  // clang-format off
+  _dlhandle = std::unique_ptr<void, dlhandle_destroy_t>{handle, [filename = quantize_so](void *h) {
+    if (dlclose(h) != 0)
+      std::cerr << "Failed to unload backend " << filename << std::endl;
+  }};
+  // clang-format on
+
+  return 0;
+}
+
+int32_t QuantizerLoader::unloadLibrary()
+{
+  if (get() == nullptr)
+    return 0;
+
+  _quantizer.reset(nullptr);
+  _dlhandle.reset(nullptr);
+
+  return 0;
+}
+
+} // namespace odc
+} // namespace onert

--- a/runtime/onert/core/src/odc/QuantizerLoader.h
+++ b/runtime/onert/core/src/odc/QuantizerLoader.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_ODC_QUANTIZER_LOADER_H__
+#define __ONERT_ODC_QUANTIZER_LOADER_H__
+
+#include "odc/IQuantizer.h"
+
+#include <functional>
+#include <memory>
+
+namespace onert
+{
+namespace odc
+{
+
+/**
+ * @brief Class to manage loading and unloading of dynamic library containing
+ *        implementation of IQuantizer interface
+ */
+class QuantizerLoader
+{
+public:
+  /**
+   * @brief Typedef for function pointer to destroy loaded library handle
+   */
+  using dlhandle_destroy_t = std::function<void(void *)>;
+  /**
+   * @brief Typedef for function pointer to create instance of IQuantizer
+   */
+  using factory_t = IQuantizer *(*)();
+  /**
+   * @brief Typedef for function pointer to destroy instance of IQuantizer
+   */
+  using quantizer_destory_t = void (*)(IQuantizer *);
+
+  /**
+   * @brief   Get singleton instance of QuantizerLoader
+   * @return  Reference to singleton instance of QuantizerLoader
+   */
+  static QuantizerLoader &instance();
+
+private:
+  // Cannot create instance of QuantizerLoader outside of this class
+  QuantizerLoader() = default;
+  QuantizerLoader(QuantizerLoader const &) = delete;
+  QuantizerLoader &operator=(QuantizerLoader const &) = delete;
+  ~QuantizerLoader() = default;
+
+public:
+  /**
+   * @brief   Load dynamic library containing implementation of IQuantizer
+   * @return  0 if success, otherwise errno value
+   */
+  int32_t loadLibrary();
+  /**
+   * @brief  Unload dynamic library containing implementation of IQuantizer
+   * @return 0 if success, otherwise errno value
+   */
+  int32_t unloadLibrary();
+  /**
+   * @brief   Get instance of IQuantizer created through factory method
+   * @return  Pointer to instance of IQuantizer
+   */
+  IQuantizer *get() const { return _quantizer.get(); }
+
+private:
+  // Note: Keep handle to avoid svace warning of "handle lost without dlclose()"
+  std::unique_ptr<void, dlhandle_destroy_t> _dlhandle;
+  std::unique_ptr<IQuantizer, quantizer_destory_t> _quantizer{nullptr, nullptr};
+};
+
+} // namespace odc
+} // namespace onert
+
+#endif // __ONERT_ODC_QUANTIZER_LOADER_H__

--- a/runtime/onert/core/src/odc/QuantizerLoader.test.cc
+++ b/runtime/onert/core/src/odc/QuantizerLoader.test.cc
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "QuantizerLoader.h"
+
+#include <gtest/gtest.h>
+
+using namespace onert::odc;
+
+// Test QuantizerLoader singleton
+TEST(odc_QuantizerLoader, singleton)
+{
+  QuantizerLoader &loader1 = QuantizerLoader::instance();
+  QuantizerLoader &loader2 = QuantizerLoader::instance();
+  ASSERT_EQ(&loader1, &loader2);
+}
+
+// Test load quantizer library
+TEST(odc_QuantizerLoader, load)
+{
+  QuantizerLoader &loader = QuantizerLoader::instance();
+  // Unload because it may be loaded on previous tests
+  ASSERT_EQ(loader.unloadLibrary(), 0);
+
+  if (loader.loadLibrary() == 0)
+  {
+    // Load twice to check if it is thread-safe
+    ASSERT_EQ(loader.loadLibrary(), 0);
+  }
+}
+
+// Get quantizer function without loading quantizer library
+TEST(odc_QuantizerLoader, neg_get)
+{
+  QuantizerLoader &loader = QuantizerLoader::instance();
+  // Unload because it may be loaded on previous tests
+  ASSERT_EQ(loader.unloadLibrary(), 0);
+  ASSERT_EQ(loader.get(), nullptr);
+}
+
+// Check quantizer function pointer when QuantizerLoader is unloaded
+TEST(odc_QuantizerLoader, neg_unload)
+{
+  QuantizerLoader &loader = QuantizerLoader::instance();
+  if (loader.loadLibrary() == 0)
+    ASSERT_NE(loader.get(), nullptr);
+
+  ASSERT_EQ(loader.unloadLibrary(), 0);
+  ASSERT_EQ(loader.get(), nullptr);
+}


### PR DESCRIPTION
This commit intrduces QuantizerLoader to bind odc module quantizer to onert core.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: https://github.com/Samsung/ONE/issues/11391
Draft: https://github.com/Samsung/ONE/pull/11298