### PR TITLE
[record-minmax] Extract MinMaxVectors

### DIFF
--- a/compiler/record-minmax/include/MinMaxObserver.h
+++ b/compiler/record-minmax/include/MinMaxObserver.h
@@ -20,17 +20,13 @@
 #include <luci_interpreter/Interpreter.h>
 #include <luci_interpreter/core/Tensor.h>
 
+#include "MinMaxVectors.h"
+
 #include <vector>
 #include <unordered_map>
 
 namespace record_minmax
 {
-
-struct MinMaxVectors
-{
-  std::vector<float> min_vector;
-  std::vector<float> max_vector;
-};
 
 class MinMaxMap
 {

--- a/compiler/record-minmax/include/MinMaxVectors.h
+++ b/compiler/record-minmax/include/MinMaxVectors.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __RECORD_MINMAX_MINMAXVECTORS_H__
+#define __RECORD_MINMAX_MINMAXVECTORS_H__
+
+#include <vector>
+
+namespace record_minmax
+{
+
+struct MinMaxVectors
+{
+  std::vector<float> min_vector;
+  std::vector<float> max_vector;
+};
+
+} // namespace record_minmax
+
+#endif // __RECORD_MINMAX_MINMAXVECTORS_H__


### PR DESCRIPTION
This extracts MinMaxVectors from MinMaxObserver.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/pull/11410#issuecomment-1700518870