### PR TITLE
[onert] Fix nnfw_api CircleGen condition

### DIFF
--- a/tests/nnfw_api/src/CircleGen.cc
+++ b/tests/nnfw_api/src/CircleGen.cc
@@ -624,7 +624,7 @@ uint32_t CircleGen::addCustomOperatorCode(std::string custom_code)
 
 flatbuffers::Offset<circle::Buffer> CircleGen::buildBuffer(const uint8_t *buf, size_t size)
 {
-  if (buf == nullptr && size == 0)
+  if (buf == nullptr || size == 0)
     return circle::CreateBuffer(_fbb);
   auto buffer = _fbb.CreateVector(buf, size);
   return circle::CreateBuffer(_fbb, buffer);


### PR DESCRIPTION
It changes && to || for empty vector check

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

Related: https://github.com/Samsung/ONE/issues/11454, https://github.com/Samsung/ONE/pull/11318