### PR TITLE
[onert] Check conv2d hybrid validity

### DIFF
--- a/runtime/onert/core/src/ir/OperationValidator.cc
+++ b/runtime/onert/core/src/ir/OperationValidator.cc
@@ -195,6 +195,13 @@ void OperationValidator::visit(const operation::Conv2D &node)
     for (const auto zeropoint : _operands.at(kernel_index).typeInfo().zero_points())
       OP_REQUIRES(zeropoint == 0);
   }
+  if (isConstant(kernel_index) && operandType(kernel_index) == DataType::QUANT_INT8_SYMM)
+  {
+    int32_t kernel_input_channel = _operands.at(kernel_index).shape().dim(3);
+    // zero_points comes from flatbuffer vector. Its size is guaranteed within uint32_t.
+    size_t kernel_zerop_cnt = _operands.at(kernel_index).typeInfo().zero_points().size();
+    OP_REQUIRES((int64_t)kernel_input_channel == (int64_t)kernel_zerop_cnt);
+  }
 }
 
 void OperationValidator::visit(const operation::DepthToSpace &node)

--- a/tests/nnfw_api/src/one_op_tests/Conv2D.test.cc
+++ b/tests/nnfw_api/src/one_op_tests/Conv2D.test.cc
@@ -276,3 +276,29 @@ TEST_F(GenModelTest, neg_OneOp_Conv2D_I8_NonZero_ZeroPoints)
 
   SUCCEED();
 }
+
+TEST_F(GenModelTest, neg_OneOp_Conv2D_I8_Hybrid_PerLayer)
+{
+  CircleGen cgen;
+  std::vector<int8_t> weight_data{1, 2, 3, 4, 5, 6, 7, 8, 9};
+  uint32_t weight_buf = cgen.addBuffer(weight_data);
+  std::vector<float> bias_data{0, 2, 4};
+  uint32_t bias_buf = cgen.addBuffer(bias_data);
+  int in = cgen.addTensor({{1, 1, 1, 3}, circle::TensorType::TensorType_FLOAT32});
+  // Hybrid does not support per-layer.
+  std::vector<float> weight_scales = {0.5};
+  std::vector<int64_t> weight_zeropoints = {0};
+  int weight = cgen.addTensor({{3, 1, 1, 3}, circle::TensorType::TensorType_INT8, weight_buf},
+                              weight_scales, weight_zeropoints);
+  int bias = cgen.addTensor({{1, 1, 1, 3}, circle::TensorType::TensorType_FLOAT32, bias_buf});
+  int out = cgen.addTensor({{1, 1, 1, 3}, circle::TensorType::TensorType_FLOAT32});
+  cgen.addOperatorConv2D({{in, weight, bias}, {out}}, circle::Padding_VALID, 1, 1,
+                         circle::ActivationFunctionType_NONE);
+  cgen.setInputsAndOutputs({in}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->setBackends({"cpu"});
+  _context->expectFailModelLoad();
+
+  SUCCEED();
+}

--- a/tests/nnfw_api/src/one_op_tests/Conv2D.test.cc
+++ b/tests/nnfw_api/src/one_op_tests/Conv2D.test.cc
@@ -277,7 +277,7 @@ TEST_F(GenModelTest, neg_OneOp_Conv2D_I8_NonZero_ZeroPoints)
   SUCCEED();
 }
 
-TEST_F(GenModelTest, neg_OneOp_Conv2D_I8_Hybrid_PerLayer)
+TEST_F(GenModelTest, neg_OneOp_Conv2D_I8_Hybrid_PerTensor)
 {
   CircleGen cgen;
   std::vector<int8_t> weight_data{1, 2, 3, 4, 5, 6, 7, 8, 9};
@@ -285,7 +285,7 @@ TEST_F(GenModelTest, neg_OneOp_Conv2D_I8_Hybrid_PerLayer)
   std::vector<float> bias_data{0, 2, 4};
   uint32_t bias_buf = cgen.addBuffer(bias_data);
   int in = cgen.addTensor({{1, 1, 1, 3}, circle::TensorType::TensorType_FLOAT32});
-  // Hybrid does not support per-layer.
+  // Hybrid does not support per-tensor.
   std::vector<float> weight_scales = {0.5};
   std::vector<int64_t> weight_zeropoints = {0};
   int weight = cgen.addTensor({{3, 1, 1, 3}, circle::TensorType::TensorType_INT8, weight_buf},


### PR DESCRIPTION
It adds validation for conv2d hybrid op.
It ensure conv2d weight is per-channel quantized.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

Related: #11454, #11318

I added negative test.

```
$ Product/x86_64-linux.debug/out/unittest/nnfw_api_gtest --gtest_filter=GenModelTest.neg_OneOp_Conv2D_I8_Hybrid*
Note: Google Test filter = GenModelTest.neg_OneOp_Conv2D_I8_Hybrid*
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from GenModelTest
[ RUN      ] GenModelTest.neg_OneOp_Conv2D_I8_Hybrid_PerLayer
Error during model loading : OperationValidator failed at line 203
Failed model loading as expected.
[       OK ] GenModelTest.neg_OneOp_Conv2D_I8_Hybrid_PerLayer (3 ms)
[----------] 1 test from GenModelTest (3 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (4 ms total)
[  PASSED  ] 1 test.
```