### PR TITLE
[onert/cker] Add conv2d hybrid reference kernel

### DIFF
--- a/compute/cker/include/cker/operation/reference/Conv.h
+++ b/compute/cker/include/cker/operation/reference/Conv.h
@@ -311,11 +311,14 @@ inline void Conv(const ConvParams &params, const int32_t *output_multiplier,
   }
 }
 
-// Copied from tflite 2.13.0
-inline void Conv(const ConvParams &params, float *scaling_factors_ptr, const Shape &input_shape,
-                 const int8_t *input_data, const Shape &filter_shape, const int8_t *filter_data,
-                 const Shape &bias_shape, const float *bias_data, const Shape &output_shape,
-                 float *output_data, const float *per_channel_scale, const int32_t *input_offset)
+// Slightly modified from tflite 2.13.0 HybridConvPerChannel
+// im2col and im2col_shape are removed since it is not used in reference kernel.
+inline void HybridConvPerChannel(const ConvParams &params, float *scaling_factors_ptr,
+                                 const Shape &input_shape, const int8_t *input_data,
+                                 const Shape &filter_shape, const int8_t *filter_data,
+                                 const Shape &bias_shape, const float *bias_data,
+                                 const Shape &output_shape, float *output_data,
+                                 const float *per_channel_scale, const int32_t *input_offset)
 
 {
   const int stride_width = params.stride_width;
@@ -335,6 +338,7 @@ inline void Conv(const ConvParams &params, float *scaling_factors_ptr, const Sha
   if (bias_data)
   {
     assert(bias_shape.FlatSize() == output_depth);
+    UNUSED_RELEASE(bias_shape);
   }
   const int input_height = input_shape.Dims(1);
   const int input_width = input_shape.Dims(2);

--- a/compute/cker/include/cker/operation/reference/Conv.h
+++ b/compute/cker/include/cker/operation/reference/Conv.h
@@ -311,6 +311,87 @@ inline void Conv(const ConvParams &params, const int32_t *output_multiplier,
   }
 }
 
+// Copied from tflite 2.13.0
+inline void Conv(const ConvParams &params, float *scaling_factors_ptr, const Shape &input_shape,
+                 const int8_t *input_data, const Shape &filter_shape, const int8_t *filter_data,
+                 const Shape &bias_shape, const float *bias_data, const Shape &output_shape,
+                 float *output_data, const float *per_channel_scale, const int32_t *input_offset)
+
+{
+  const int stride_width = params.stride_width;
+  const int stride_height = params.stride_height;
+  const int dilation_width_factor = params.dilation_width_factor;
+  const int dilation_height_factor = params.dilation_height_factor;
+  const int pad_width = params.padding_values.width;
+  const int pad_height = params.padding_values.height;
+  const float output_activation_min = params.float_activation_min;
+  const float output_activation_max = params.float_activation_max;
+  assert(input_shape.DimensionsCount() == 4);
+  assert(filter_shape.DimensionsCount() == 4);
+  assert(output_shape.DimensionsCount() == 4);
+  const int batches = MatchingDim(input_shape, 0, output_shape, 0);
+  const int input_depth = input_shape.Dims(3);
+  const int output_depth = MatchingDim(filter_shape, 0, output_shape, 3);
+  if (bias_data)
+  {
+    assert(bias_shape.FlatSize() == output_depth);
+  }
+  const int input_height = input_shape.Dims(1);
+  const int input_width = input_shape.Dims(2);
+  const int filter_height = filter_shape.Dims(1);
+  const int filter_width = filter_shape.Dims(2);
+  const int filter_input_depth = filter_shape.Dims(3);
+  const int groups = input_depth / filter_input_depth;
+  assert(input_depth % filter_input_depth == 0);
+  const int filters_per_group = output_depth / groups;
+  const int output_height = output_shape.Dims(1);
+  const int output_width = output_shape.Dims(2);
+  for (int batch = 0; batch < batches; ++batch)
+  {
+    for (int out_y = 0; out_y < output_height; ++out_y)
+    {
+      for (int out_x = 0; out_x < output_width; ++out_x)
+      {
+        for (int out_channel = 0; out_channel < output_depth; ++out_channel)
+        {
+          auto group = out_channel / filters_per_group;
+          const int in_x_origin = (out_x * stride_width) - pad_width;
+          const int in_y_origin = (out_y * stride_height) - pad_height;
+          int32_t acc = 0;
+          for (int filter_y = 0; filter_y < filter_height; ++filter_y)
+          {
+            for (int filter_x = 0; filter_x < filter_width; ++filter_x)
+            {
+              for (int in_channel = 0; in_channel < filter_input_depth; ++in_channel)
+              {
+                const int in_x = in_x_origin + dilation_width_factor * filter_x;
+                const int in_y = in_y_origin + dilation_height_factor * filter_y;
+                // If the location is outside the bounds of the input image,
+                // use zero as a default value.
+                if ((in_x >= 0) && (in_x < input_width) && (in_y >= 0) && (in_y < input_height))
+                {
+                  int32_t input_val = input_data[Offset(input_shape, batch, in_y, in_x,
+                                                        in_channel + group * filter_input_depth)];
+                  int32_t filter_val =
+                    filter_data[Offset(filter_shape, out_channel, filter_y, filter_x, in_channel)];
+                  acc += filter_val * (input_val - input_offset[batch]);
+                }
+              }
+            }
+          }
+          float acc_float = acc * per_channel_scale[out_channel] * scaling_factors_ptr[batch];
+          if (bias_data)
+          {
+            acc_float += bias_data[out_channel];
+          }
+          output_data[Offset(output_shape, batch, out_y, out_x, out_channel)] =
+            ActivationFunctionWithMinMax(acc_float, output_activation_min, output_activation_max);
+        }
+      }
+    }
+  }
+}
+
 } // namespace reference
 } // namespace cker
 } // namespace nnfw


### PR DESCRIPTION
It adds conv2d hybrid (weight: int8 symm, in/out: f32) reference kernel.
Implementation is copied from tflite 2.13.0.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>