### PR TITLE
[infra/onert] Update luci build to use mio-circle06 only

### DIFF
--- a/Makefile.template
+++ b/Makefile.template
@@ -147,7 +147,7 @@ prepare_nncc_internal: $(WORKSPACE)
 ifneq ($(CROSS_BUILD),1)
 	./nncc configure -DBUILD_GTEST=OFF -DENABLE_TEST=OFF -DEXTERNALS_BUILD_THREADS=$(NPROCS) -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) \
 		-DCMAKE_INSTALL_PREFIX=$(OVERLAY_FOLDER) \
-		-DBUILD_WHITELIST="luci;foder;pepper-csv2vec;loco;locop;logo;logo-core;mio-circle05;luci-compute;oops;hermes;hermes-std;angkor;pp;pepper-strcast;pepper-str"
+		-DBUILD_WHITELIST="luci;foder;pepper-csv2vec;loco;locop;logo;logo-core;mio-circle06;luci-compute;oops;hermes;hermes-std;angkor;pp;pepper-strcast;pepper-str"
 	./nncc build -j$(NPROCS)
 	cmake --install $(NNCC_FOLDER)
 # install angkor TensorIndex and oops InternalExn header (TODO: Remove this)

--- a/packaging/nnfw.spec
+++ b/packaging/nnfw.spec
@@ -209,7 +209,7 @@ tar -xf %{SOURCE3019} -C ./externals
 %if %{odc_build} == 1
 %{nncc_env} ./nncc configure -DBUILD_GTEST=OFF -DENABLE_TEST=OFF -DEXTERNALS_BUILD_THREADS=%{nproc} -DCMAKE_BUILD_TYPE=%{build_type} -DTARGET_OS=tizen \
         -DCMAKE_INSTALL_PREFIX=$(pwd)/%{overlay_path} \
-	-DBUILD_WHITELIST="luci;foder;pepper-csv2vec;loco;locop;logo;logo-core;mio-circle05;mio-circle06;luci-compute;oops;hermes;hermes-std;angkor;pp;pepper-strcast;pepper-str"
+	-DBUILD_WHITELIST="luci;foder;pepper-csv2vec;loco;locop;logo;logo-core;mio-circle06;luci-compute;oops;hermes;hermes-std;angkor;pp;pepper-strcast;pepper-str"
 %{nncc_env} ./nncc build %{build_jobs}
 cmake --install %{nncc_workspace}
 %endif # odc_build


### PR DESCRIPTION
This commit adds luci build config mio-circle06 and removes mio-circle05.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>