### PR TITLE
[onert/test] Add quantization option in onert_run

### DIFF
--- a/runtime/onert/api/src/nnfw_api.cc
+++ b/runtime/onert/api/src/nnfw_api.cc
@@ -494,6 +494,8 @@ NNFW_STATUS nnfw_train_export_circle(nnfw_session *session, const char *)
   return NNFW_STATUS_ERROR;
 }
 
+#endif // ONERT_TRAIN
+
 // Quantization
 
 NNFW_STATUS nnfw_set_quantization_type(nnfw_session *session, NNFW_QUANTIZE_TYPE qtype)
@@ -513,5 +515,3 @@ NNFW_STATUS nnfw_quantize(nnfw_session *session)
   NNFW_RETURN_ERROR_IF_NULL(session);
   return session->quantize();
 }
-
-#endif // ONERT_TRAIN

--- a/tests/tools/onert_run/src/args.cc
+++ b/tests/tools/onert_run/src/args.cc
@@ -299,6 +299,10 @@ void Args::Initialize(void)
          "0: prints the only result. Messages btw run don't print\n"
          "1: prints result and message btw run\n"
          "2: prints all of messages to print\n")
+    ("quantize,q", po::value<std::string>()->default_value("")->notifier([&](const auto &v) { _quantize = v; }), "Request quantization with type (int8 or int16)")
+    ("qpath", po::value<std::string>()->default_value("")->notifier([&](const auto &v) { _quantized_model_path = v; }),
+         "Path to export quantized model.\n"
+         "If it is not set, the quantized model will be exported to the same directory of the original model/package with q8/q16 suffix.")
     ;
   // clang-format on
 

--- a/tests/tools/onert_run/src/args.h
+++ b/tests/tools/onert_run/src/args.h
@@ -69,6 +69,8 @@ public:
   /// @brief Return true if "--shape_run" or "--shape_prepare" is provided
   bool shapeParamProvided();
   const int getVerboseLevel(void) const { return _verbose_level; }
+  const std::string &getQuantize(void) const { return _quantize; }
+  const std::string &getQuantizedModelPath(void) const { return _quantized_model_path; }
 
 private:
   void Initialize();
@@ -99,6 +101,8 @@ private:
   bool _print_version = false;
   int _verbose_level;
   bool _use_single_model = false;
+  std::string _quantize;
+  std::string _quantized_model_path;
 };
 
 } // end of namespace onert_run


### PR DESCRIPTION
This commit adds quantization option in onert_run for online quantization test.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: https://github.com/Samsung/ONE/issues/11391
Draft: https://github.com/Samsung/ONE/pull/11298