### PR TITLE
[onert] Close file handle before return

### DIFF
--- a/runtime/onert/core/src/odc/QuantizerLoader.cc
+++ b/runtime/onert/core/src/odc/QuantizerLoader.cc
@@ -73,6 +73,7 @@ int32_t QuantizerLoader::loadLibrary()
     if (_quantizer == nullptr)
     {
       std::cerr << "QuantizerLoader: unable to create quantizer" << std::endl;
+      dlclose(handle);
       return 1;
     }
   }


### PR DESCRIPTION
This commit updates QuantizerLoader::loadLibrary to close file handle before return.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>