### PR TITLE
[circle-mpqsolver] Revisit MAEMetric

### DIFF
--- a/compiler/circle-mpqsolver/src/core/ErrorMetric.cpp
+++ b/compiler/circle-mpqsolver/src/core/ErrorMetric.cpp
@@ -56,5 +56,10 @@ float MAEMetric::compute(const WholeOutput &first, const WholeOutput &second) co
     }
   }
 
+  if (output_size == 0)
+  {
+    throw std::runtime_error("nothing to compare");
+  }
+
   return error / output_size;
 }


### PR DESCRIPTION
This commit throws an exception at an attempt to divide by zero.

Draft: #11452
Related: #11374

ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>