### PR TITLE
[circle-mpqsolver] Fix size of operand

### DIFF
--- a/compiler/circle-mpqsolver/src/core/Quantizer.test.cpp
+++ b/compiler/circle-mpqsolver/src/core/Quantizer.test.cpp
@@ -50,11 +50,10 @@ protected:
     _add->dtype(loco::DataType::FLOAT32);
     _beta->dtype(loco::DataType::FLOAT32);
 
-    uint32_t channel_size = 16;
     _add->shape({1, _channel_size, _width, _height});
     _beta->shape({1, _channel_size, _width, _height});
 
-    _beta->size<loco::DataType::FLOAT32>(channel_size);
+    _beta->size<loco::DataType::FLOAT32>(_channel_size * _width * _height);
     _add->x(input);
     _add->y(_beta);
     _add->fusedActivationFunction(luci::FusedActFunc::NONE);


### PR DESCRIPTION
This commit fixes size of constant operand.

Draft: https://github.com/Samsung/ONE/pull/11452
Related: https://github.com/Samsung/ONE/issues/11374

ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>