### PR TITLE
[onert] Introduce weight-only quantize types

### DIFF
--- a/runtime/onert/api/nnfw/include/nnfw_experimental.h
+++ b/runtime/onert/api/nnfw/include/nnfw_experimental.h
@@ -412,6 +412,11 @@ typedef enum
   NNFW_QUANTIZE_TYPE_U8_ASYM,
   /** symmetric quantization with a scale only */
   NNFW_QUANTIZE_TYPE_I16_SYM,
+  /** weight-only int8 symmetric quantization */
+  NNFW_QUANTIZE_TYPE_WO_I8_SYM,
+  /** weight-only int16 symmetric quantization */
+  NNFW_QUANTIZE_TYPE_WO_I16_SYM,
+
 } NNFW_QUANTIZE_TYPE;
 
 /**


### PR DESCRIPTION
It introduces NNFW_QUANTIZE_TYPE_WO_I{8,16}_SYM .

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>