### PR TITLE
[infra] Exclude intermediate workspace on SAM exclude file

### DIFF
--- a/.ahub/sam/exclude.txt
+++ b/.ahub/sam/exclude.txt
@@ -47,3 +47,6 @@
 
 # Downloaded externals
 /ONE/externals
+
+# Intermediate code for runtime build (refer nnfw.spec file's nncc_workspace)
+/ONE/build/nncc/


### PR DESCRIPTION
This commit updates exclude.txt for SAM to exclude the build intermediate files.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>