### PR TITLE
[onert_run] Use weight-only quantization type

### DIFF
--- a/tests/tools/onert_run/src/onert_run.cc
+++ b/tests/tools/onert_run/src/onert_run.cc
@@ -122,6 +122,10 @@ int main(const int argc, char **argv)
         quantize_type = NNFW_QUANTIZE_TYPE_U8_ASYM;
       if (quantize == "int16")
         quantize_type = NNFW_QUANTIZE_TYPE_I16_SYM;
+      if (quantize == "wo_int8")
+        quantize_type = NNFW_QUANTIZE_TYPE_WO_I8_SYM;
+      if (quantize == "wo_int16")
+        quantize_type = NNFW_QUANTIZE_TYPE_WO_I16_SYM;
       NNPR_ENSURE_STATUS(nnfw_set_quantization_type(session, quantize_type));
 
       if (args.getQuantizedModelPath() != "")


### PR DESCRIPTION
It will use "wo_" to distinguish weight-only and full quantization.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

#11497 must be landed before this PR.