### PR TITLE
[infra/nnfw] Disable default path when finding luci lib

### DIFF
--- a/infra/nnfw/cmake/packages/LuciConfig.cmake
+++ b/infra/nnfw/cmake/packages/LuciConfig.cmake
@@ -8,7 +8,7 @@ find_path(LUCI_HEADERS
 
 macro(_load_library LUCI_NAME)
     add_library(luci::${LUCI_NAME} SHARED IMPORTED)
-    find_library(LUCI_LIB_PATH_${LUCI_NAME} NAMES luci_${LUCI_NAME} PATHS ${EXT_OVERLAY_DIR}/lib)
+    find_library(LUCI_LIB_PATH_${LUCI_NAME} NAMES luci_${LUCI_NAME} PATHS ${EXT_OVERLAY_DIR}/lib NO_DEFAULT_PATH)
     if (NOT LUCI_LIB_PATH_${LUCI_NAME})
         return()
     endif()


### PR DESCRIPTION
This commit disables default path when finding luci libraries.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>