### PR TITLE
[onert] Fix a missed nullptr check

### DIFF
--- a/runtime/onert/backend/train/ops/FullyConnectedLayer.cc
+++ b/runtime/onert/backend/train/ops/FullyConnectedLayer.cc
@@ -117,7 +117,7 @@ void FullyConnectedLayer::backward()
     case OperandType::FLOAT32:
     {
       assert(data_type == _grad_weights->data_type());
-      assert(data_type == _grad_bias->data_type());
+      assert(_grad_bias == nullptr || data_type == _grad_bias->data_type());
       backwardFloat32();
       break;
     }


### PR DESCRIPTION
This commit fixes the missed nullptr check in train::FullConnectedLayer

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>