### PR TITLE
[luci/pass] Introduce XpSepActFromTransposeConv

### DIFF
--- a/compiler/luci/pass/include/luci/CircleOptimizer.h
+++ b/compiler/luci/pass/include/luci/CircleOptimizer.h
@@ -90,6 +90,7 @@ public:
       RemoveQuantDequantSeq,
       RemoveDuplicateConst,
       UnrollUnidirSeqLSTM,
+      XpSepActFromTransposeConv,
     };
 
     enum AlgorithmParameters

--- a/compiler/luci/pass/src/CircleOptimizer.cpp
+++ b/compiler/luci/pass/src/CircleOptimizer.cpp
@@ -73,6 +73,7 @@
 #include "luci/Pass/TransformMinReluToRelu6Pass.h"
 #include "luci/Pass/DecomposeHardSwishPass.h"
 #include "luci/Pass/UnrollUnidirectionalSequenceLSTMPass.h"
+#include "luci/Pass/XpSepActFromTransposeConvPass.h"
 // TODO add more passes
 
 #include "luci/Pass/CircleShapeInferencePass.h"
@@ -442,6 +443,14 @@ void CircleOptimizer::optimize(loco::Graph *g) const
   {
     phase.emplace_back(std::make_unique<luci::UnrollUnidirectionalSequenceLSTMPass>());
   }
+
+  // NOTE Experimental options; these will be removed someday
+  //      Add experimental options here
+  if (_options->query(Options::Algorithm::XpSepActFromTransposeConv))
+  {
+    phase.emplace_back(std::make_unique<luci::XpSepActFromTransposeConvPass>());
+  }
+
   // Forward Reshape/Transpose is done after
   // 1. SubstituteXXXToReshape
   // 2. RemoveRedundantReshape/Transpose


### PR DESCRIPTION
This will introduce XpSepActFromTransposeConv flag to enable XpSepActFromTransposeConvPass.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>