### PR TITLE
[onecc-docker] Fix request recent version error

### DIFF
--- a/compiler/onecc-docker/onecc-docker
+++ b/compiler/onecc-docker/onecc-docker
@@ -49,7 +49,9 @@ def _request_recent_version(token=None):
         # Return the latest version containing one-compiler-bionic_{version}_amd64.deb in assets
         version = release_item["tag_name"]
         for asset in release_item["assets"]:
-            if bool(re.match(r'one-compiler-bionic_\d+\.\d+\.\d_amd64.deb', asset["name"])):
+            if bool(
+                    re.match(r'one-compiler-bionic_\d+\.\d+\.\d_amd64.deb',
+                             asset["name"])):
                 return version
 
     raise SystemExit('[onecc-docker] Failed to get latest onecc version')

--- a/compiler/onecc-docker/onecc-docker
+++ b/compiler/onecc-docker/onecc-docker
@@ -44,14 +44,13 @@ def _request_recent_version(token=None):
     response = RequestHandler(
         token,
         timeout=5).make_request(url="https://api.github.com/repos/Samsung/ONE/releases")
-    versions = [release_item["tag_name"] for release_item in response.json()]
 
-    for version in versions:
-        # Return the latest version with the given format
-        # to filter out such as 'onert-micro-0.1.0' release
-        # which doesn't contain onecc package.
-        if bool(re.match(r'^\d+\.\d+\.\d+$', version)):
-            return version
+    for release_item in response.json():
+        # Return the latest version containing one-compiler-bionic_{version}_amd64.deb in assets
+        version = release_item["tag_name"]
+        for asset in release_item["assets"]:
+            if bool(re.match(r'one-compiler-bionic_\d+\.\d+\.\d_amd64.deb', asset["name"])):
+                return version
 
     raise SystemExit('[onecc-docker] Failed to get latest onecc version')
 


### PR DESCRIPTION
This commit fix request recent version error
Changed to return the latest version containing `one-compiler-bionic_{version}_amd64.deb` in assets

ONE-DCO-1.0-Signed-off-by: profornnan <profornnan@naver.com>

Related: #11539