### PR TITLE
[onert-micro] Fix TrainableWeightStorage path

### DIFF
--- a/onert-micro/luci-interpreter/src/core/TrainableWeightStorage.cpp
+++ b/onert-micro/luci-interpreter/src/core/TrainableWeightStorage.cpp
@@ -16,7 +16,7 @@
 
 #ifdef ENABLE_TRAINING
 
-#include "luci_interpreter/core/TrainableWeightStorage.h"
+#include "luci_interpreter/TrainableWeightStorage.h"
 
 namespace luci_interpreter
 {

--- a/onert-micro/luci-interpreter/src/core/TrainingGraph.h
+++ b/onert-micro/luci-interpreter/src/core/TrainingGraph.h
@@ -20,7 +20,7 @@
 #define LUCI_INTERPRETER_SRC_CORE_TRAINING_GRAPH_H
 
 #include "luci_interpreter/TrainingSettings.h"
-#include "luci_interpreter/core/TrainableWeightStorage.h"
+#include "luci_interpreter/TrainableWeightStorage.h"
 #include "luci_interpreter/core/reader/CircleMicroReader.h"
 #include "memory_managers/SimpleMemoryManager.h"
 

--- a/onert-micro/luci-interpreter/src/core/TrainingModule.h
+++ b/onert-micro/luci-interpreter/src/core/TrainingModule.h
@@ -21,7 +21,7 @@
 
 #include "core/RuntimeModule.h"
 
-#include "luci_interpreter/core/TrainableWeightStorage.h"
+#include "luci_interpreter/TrainableWeightStorage.h"
 #include "TrainingGraph.h"
 
 namespace luci_interpreter


### PR DESCRIPTION
This commit fixes TrainableWeightStorage path in onert-micro.

for #11264

ONE-DCO-1.0-Signed-off-by: Artem Balyshev <a.balyshev@samsung.com>