### PR TITLE
[onert-micro] Add REGISTER_TRAIN_KERNEL interface

### DIFF
--- a/onert-micro/luci-interpreter/src/kernels/Builders.h
+++ b/onert-micro/luci-interpreter/src/kernels/Builders.h
@@ -46,6 +46,18 @@ using BaseRuntimeGraph = RuntimeGraph;
 
 #undef REGISTER_KERNEL
 
+namespace training
+{
+#define REGISTER_TRAIN_KERNEL(builtin_operator, name)                                           \
+  Status train_kernel_Circle##name(                                                             \
+    const circle::Operator *op, CircleReader *reader,                                           \
+    GradientCalculationStorage *gradient_calculation_storage, const TrainingSettings &settings, \
+    TrainableWeightStorage *weight_storage, bool is_compute_gradient);
+
+#include "KernelsToTrain.lst"
+
+#undef REGISTER_TRAIN_KERNEL
+} // namespace training
 } // namespace luci_interpreter
 
 #endif // LUCI_INTERPRETER_KERNELS_NODES_BUILDERS_H

--- a/onert-micro/luci-interpreter/src/kernels/CMakeLists.txt
+++ b/onert-micro/luci-interpreter/src/kernels/CMakeLists.txt
@@ -37,7 +37,13 @@ macro(REGISTER_KERNEL OPERATOR, NODE)
   list(APPEND TEST_SOURCES "${NODE}.test.cpp")
 endmacro(REGISTER_KERNEL)
 
+macro(REGISTER_TRAIN_KERNEL OPERATOR, NODE)
+  list(APPEND SOURCES "${NODE}.train.cpp")
+endmacro(REGISTER_TRAIN_KERNEL)
+
 include(${KERNEL_REGISTER_FILE})
+
+include("${LUCI_INTERPRETER_PAL_DIR}/KernelsToTrain.lst")
 
 list(APPEND TEST_SOURCES TestUtils.h TestUtils.cpp)
 

--- a/onert-micro/luci-interpreter/src/kernels/KernelBuilder.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/KernelBuilder.cpp
@@ -41,4 +41,21 @@ void KernelExecuteRegistry::execute_kernel(const circle::Operator *cur_op,
   specific_execute_func(cur_op, runtime_graph);
 }
 
+#ifdef ENABLE_TRAINING
+
+training::Status training::KernelTrainRegistry::train_kernel(
+  const circle::Operator *cur_op, circle::BuiltinOperator opcode, CircleReader *reader,
+  GradientCalculationStorage *gradient_calculation_storage, const TrainingSettings &settings,
+  TrainableWeightStorage *weight_storage, bool is_compute_gradient) const
+{
+  auto specific_train_func = get_kernel_train_func(opcode);
+  if (specific_train_func == nullptr)
+    assert(false && "Unsupported operator");
+
+  return specific_train_func(cur_op, reader, gradient_calculation_storage, settings, weight_storage,
+                             is_compute_gradient);
+}
+
+#endif // ENABLE_TRAINING
+
 } // namespace luci_interpreter

--- a/onert-micro/luci-interpreter/src/kernels/KernelBuilder.h
+++ b/onert-micro/luci-interpreter/src/kernels/KernelBuilder.h
@@ -142,6 +142,59 @@ private:
   KernelExecuteFunc *_operator_execute[size_t(BuilderID::Size)];
 };
 
+#ifdef ENABLE_TRAINING
+
+namespace training
+{
+class KernelTrainRegistry
+{
+public:
+  using KernelTrainFunc = Status(const circle::Operator *, CircleReader *,
+                                 GradientCalculationStorage *, const TrainingSettings &,
+                                 TrainableWeightStorage *, bool);
+
+  constexpr KernelTrainRegistry() : _operator_train()
+  {
+#define REGISTER_TRAIN_KERNEL(builtin_operator, name) \
+  register_kernel_train(BuilderID::BuiltinOperator_##builtin_operator, train_kernel_Circle##name);
+
+#if USE_GENERATED_LIST
+#include "GeneratedKernelsToBuild.lst"
+#else
+#include "KernelsToTrain.lst"
+#endif
+
+#undef REGISTER_TRAIN_KERNEL
+  }
+
+  Status train_kernel(const circle::Operator *cur_op, circle::BuiltinOperator opcode,
+                      CircleReader *reader,
+                      GradientCalculationStorage *gradient_calculation_storage,
+                      const TrainingSettings &settings, TrainableWeightStorage *weight_storage,
+                      bool is_compute_gradient) const;
+
+private:
+  constexpr KernelTrainFunc *get_kernel_train_func(circle::BuiltinOperator opcode) const
+  {
+    const auto tmp = size_t(get_builder_id(opcode));
+    assert(tmp < size_t(BuilderID::Size));
+    return _operator_train[tmp];
+  }
+
+  constexpr void register_kernel_train(BuilderID id, KernelTrainFunc *func)
+  {
+    assert(size_t(id) < size_t(BuilderID::Size));
+    _operator_train[size_t(id)] = func;
+  }
+
+private:
+  KernelTrainFunc *_operator_train[size_t(BuilderID::Size)];
+};
+
+constexpr KernelTrainRegistry kernel_train;
+} // namespace training
+#endif // ENABLE_TRAINING
+
 // Global constexpr kernel configure and kernel executor
 constexpr KernelConfigureRegistry kernel_configure;
 constexpr KernelExecuteRegistry kernel_executor;


### PR DESCRIPTION
This commit adds REGISTER_TRAIN_KERNEL interface in onert-micro.

for https://github.com/Samsung/ONE/pull/11264

ONE-DCO-1.0-Signed-off-by: Artem Balyshev <a.balyshev@samsung.com>