### PR TITLE
[onert-micro] Add training into RuntimeModule

### DIFF
--- a/onert-micro/luci-interpreter/src/core/RuntimeModule.h
+++ b/onert-micro/luci-interpreter/src/core/RuntimeModule.h
@@ -20,6 +20,12 @@
 #include "core/RuntimeGraph.h"
 #include "luci_interpreter/core/reader/CircleMicroReader.h"
 
+#ifdef ENABLE_TRAINING
+#include "luci_interpreter/TrainableWeightStorage.h"
+#include "TrainingGraph.h"
+#include "core/RuntimeGraph.h"
+#endif // ENABLE_TRAINING
+
 #include <memory>
 #include <vector>
 
@@ -34,10 +40,23 @@ using BaseRuntimeGraph = RuntimeGraph;
 using MemoryManager = SimpleMemoryManager;
 #endif // USE_STATIC_ALLOC
 
+#ifdef ENABLE_TRAINING
+namespace training
+{
+
+class TrainingModule;
+
+} // namespace training
+#endif // ENABLE_TRAINING
+
 class RuntimeModule
 {
 public:
   RuntimeModule() = default;
+
+#ifdef ENABLE_TRAINING
+  friend class training::TrainingModule;
+#endif // ENABLE_TRAINING
 
   void addGraph(MemoryManager *memory_manager)
   {
@@ -59,6 +78,10 @@ private:
   std::vector<BaseRuntimeGraph> _graphs;
 
   CircleReader _circle_reader;
+
+#ifdef ENABLE_TRAINING
+  std::unique_ptr<training::TrainableWeightStorage> _storage;
+#endif // ENABLE_TRAINING
 };
 
 } // namespace luci_interpreter


### PR DESCRIPTION
This commit adds training into RuntimeModule in onert-micro.

for https://github.com/Samsung/ONE/pull/11264

ONE-DCO-1.0-Signed-off-by: Artem Balyshev <a.balyshev@samsung.com>