### PR TITLE
[onert-micro] Change allocateAndWriteInputTensor's data type

### DIFF
--- a/onert-micro/luci-interpreter/include/luci_interpreter/Interpreter.h
+++ b/onert-micro/luci-interpreter/include/luci_interpreter/Interpreter.h
@@ -45,7 +45,8 @@ public:
 
   ~Interpreter();
 
-  void allocateAndWriteInputTensor(int32_t input_tensor_index, const void *data, size_t data_size);
+  void allocateAndWriteInputTensor(int32_t input_tensor_index, const uint8_t *data,
+                                   size_t data_size);
   uint8_t *allocateInputTensor(int32_t input_tensor_index);
 
   uint8_t *readOutputTensor(int32_t output_tensor_index);

--- a/onert-micro/luci-interpreter/src/Interpreter.cpp
+++ b/onert-micro/luci-interpreter/src/Interpreter.cpp
@@ -77,7 +77,7 @@ int32_t Interpreter::getOutputDataSizeByIndex(int32_t output_tensor_index)
   return runtime_graph->getOutputDataSizeByIndex(output_tensor_index);
 }
 
-void Interpreter::allocateAndWriteInputTensor(int32_t input_tensor_index, const void *data,
+void Interpreter::allocateAndWriteInputTensor(int32_t input_tensor_index, const uint8_t *data,
                                               size_t data_size)
 {
   assert(data_size > 0);


### PR DESCRIPTION
This commit changes allocateAndWriteInputTensor's data type.

for https://github.com/Samsung/ONE/pull/11264

ONE-DCO-1.0-Signed-off-by: Artem Balyshev <a.balyshev@samsung.com>