### PR TITLE
[onert-micro] Fix kernels CMake file

### DIFF
--- a/onert-micro/luci-interpreter/src/kernels/CMakeLists.txt
+++ b/onert-micro/luci-interpreter/src/kernels/CMakeLists.txt
@@ -14,6 +14,12 @@ macro(REGISTER_KERNEL OPERATOR, NODE)
   list(APPEND SOURCES "${NODE}.cpp")
 endmacro(REGISTER_KERNEL)
 
+macro(REGISTER_TRAIN_KERNEL OPERATOR, NODE)
+  list(APPEND SOURCES "${NODE}.train.cpp")
+endmacro(REGISTER_TRAIN_KERNEL)
+
+include("${LUCI_INTERPRETER_PAL_DIR}/KernelsToTrain.lst")
+
 include(${KERNEL_REGISTER_FILE})
 
 add_library(${LUCI_INTERPRETER_KERNELS} STATIC ${SOURCES})
@@ -37,13 +43,7 @@ macro(REGISTER_KERNEL OPERATOR, NODE)
   list(APPEND TEST_SOURCES "${NODE}.test.cpp")
 endmacro(REGISTER_KERNEL)
 
-macro(REGISTER_TRAIN_KERNEL OPERATOR, NODE)
-  list(APPEND SOURCES "${NODE}.train.cpp")
-endmacro(REGISTER_TRAIN_KERNEL)
-
 include(${KERNEL_REGISTER_FILE})
-
-include("${LUCI_INTERPRETER_PAL_DIR}/KernelsToTrain.lst")
 
 list(APPEND TEST_SOURCES TestUtils.h TestUtils.cpp)
 


### PR DESCRIPTION
This commit fixes kernels CMakeLists file for onert-micro to move above `if ENABLE_TEST` statement 

for #11264

ONE-DCO-1.0-Signed-off-by: Artem Balyshev <a.balyshev@samsung.com>