### PR TITLE
[circle-mpqsolver] Introduce PatternResolver

### DIFF
--- a/compiler/circle-mpqsolver/CMakeLists.txt
+++ b/compiler/circle-mpqsolver/CMakeLists.txt
@@ -37,6 +37,7 @@ set(TEST_SOURCES
     "src/core/Quantizer.cpp"
     "src/bisection/VISQErrorApproximator.cpp"
     "src/core/ErrorMetric.cpp"
+    "src/pattern/PatternResolver.cpp"
 )
 
 nnas_find_package(GTest REQUIRED)
@@ -46,3 +47,4 @@ target_include_directories(circle_mpqsolver_test PRIVATE ${Jsoncpp_INCLUDE_DIRS}
 target_link_libraries(circle_mpqsolver_test ${Jsoncpp_STATIC_LIB})
 target_link_libraries(circle_mpqsolver_test luci_service)
 target_link_libraries(circle_mpqsolver_test luci_pass)
+target_link_libraries(circle_mpqsolver_test luci_testhelper)

--- a/compiler/circle-mpqsolver/src/pattern/PatternResolver.cpp
+++ b/compiler/circle-mpqsolver/src/pattern/PatternResolver.cpp
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "PatternResolver.h"
+
+using namespace mpqsolver::pattern;
+
+using LayerParam = luci::CircleQuantizer::Options::LayerParam;
+
+namespace
+{
+
+/**
+ * SUBGRAPH PATTERN
+ *  LayerNorm := (ifm - |ifm|) / sqrt(|(ifm - |ifm|)^2| + eps)
+ *    - |x|: mean of x
+ *    - Below diagram shows LayerNorm pattern to quantize.
+ *
+ *                 [In]
+ *                   |
+ *                   V
+ *                  ifm -----+   (reduction indicies)
+ *                   |       |       |
+ *                   |       V       V
+ *                   |      mean_of_ifm
+ *                   V       |
+ *     +------------sub <----+
+ *     |             |
+ *     |             V           (reduction indicies)
+ *     |          sub_squared           |
+ *     |             |                  |
+ *     |             V                  |
+ *     |       mean_as_variance <-------+    (const_as_eps)
+ *     |             |                          |
+ *     |             V                          |
+ *     |          add_eps<----------------------+
+ *     |             |
+ *     |             V
+ *     |           rsqrt
+ *     |             |
+ *     |             V
+ *     +------>mul_as_terminal
+ *                   |
+ *                   V
+ *                 [Out]
+ *
+ */
+class LayerNormPattern final
+{
+public:
+  LayerNormPattern(luci::CircleMul *candidate)
+  {
+    assert(candidate);
+    mul_as_terminal = candidate;
+  }
+
+public:
+  bool matched();
+
+  std::vector<luci::CircleNode *> get_q16_nodes()
+  {
+    return {sub_squared, mean_as_variance, add_eps, rsqrt};
+  }
+
+  std::vector<luci::CircleNode *> get_q8_nodes() { return {mean_of_ifm, sub, mul_as_terminal}; }
+
+public:
+  loco::Node *ifm = nullptr;
+  luci::CircleMean *mean_of_ifm = nullptr;      // = |ifm|
+  luci::CircleSub *sub = nullptr;               // = ifm - |ifm|
+  luci::CircleMul *sub_squared = nullptr;       // = (ifm - |ifm|)^2
+  luci::CircleMean *mean_as_variance = nullptr; // = |(ifm - |ifm|)^2|
+  luci::CircleAdd *add_eps = nullptr;           // = |(ifm - |ifm|)^2| + eps
+  luci::CircleRsqrt *rsqrt = nullptr;           // = 1.0 / sqrt(|(ifm - |ifm|)^2| + eps)
+  luci::CircleMul *mul_as_terminal = nullptr;   // = (ifm - |ifm|) / sqrt(|(ifm - |ifm|)^2| + eps)
+};
+
+#define CHECK_OR_FALSE(condition) \
+  if (not(condition))             \
+    return false;
+
+bool LayerNormPattern::matched()
+{
+  sub = dynamic_cast<luci::CircleSub *>(mul_as_terminal->x());
+  rsqrt = dynamic_cast<luci::CircleRsqrt *>(mul_as_terminal->y());
+  if (!sub || !rsqrt)
+  {
+    sub = dynamic_cast<luci::CircleSub *>(mul_as_terminal->y());
+    rsqrt = dynamic_cast<luci::CircleRsqrt *>(mul_as_terminal->x());
+  }
+  CHECK_OR_FALSE(rsqrt != nullptr && sub != nullptr);
+
+  ifm = dynamic_cast<luci::CircleNode *>(sub->x());
+  mean_of_ifm = dynamic_cast<luci::CircleMean *>(sub->y());
+  CHECK_OR_FALSE(ifm != nullptr && mean_of_ifm != nullptr);
+
+  add_eps = dynamic_cast<luci::CircleAdd *>(rsqrt->x());
+  CHECK_OR_FALSE(add_eps != nullptr);
+
+  auto const *eps = dynamic_cast<luci::CircleConst *>(add_eps->x());
+  mean_as_variance = dynamic_cast<luci::CircleMean *>(add_eps->y());
+  if (!eps || !mean_as_variance)
+  {
+    eps = dynamic_cast<luci::CircleConst *>(add_eps->y());
+    mean_as_variance = dynamic_cast<luci::CircleMean *>(add_eps->x());
+  }
+
+  CHECK_OR_FALSE(eps != nullptr && mean_as_variance != nullptr);
+
+  // eps should be scalar value
+  CHECK_OR_FALSE(eps->size<loco::DataType::FLOAT32>() == 1);
+
+  sub_squared = dynamic_cast<luci::CircleMul *>(mean_as_variance->input());
+  CHECK_OR_FALSE(sub_squared != nullptr);
+
+  // check that sub_squared = sub * sub
+  CHECK_OR_FALSE(sub_squared->x() == sub_squared->y() && sub_squared->x() == sub);
+
+  auto const mean_as_variance_indices =
+    dynamic_cast<luci::CircleConst *>(mean_as_variance->reduction_indices());
+  auto const mean_of_ifm_indices =
+    dynamic_cast<luci::CircleConst *>(mean_of_ifm->reduction_indices());
+
+  // check validity of reduction indices
+  CHECK_OR_FALSE(mean_of_ifm_indices != nullptr && mean_as_variance_indices != nullptr);
+
+  // check dtype of reduction indices
+  CHECK_OR_FALSE(mean_of_ifm_indices->dtype() == loco::DataType::S32 &&
+                 mean_as_variance_indices->dtype() == loco::DataType::S32);
+
+  // reduction indices of both mean operations must be the same
+  CHECK_OR_FALSE(mean_as_variance_indices->size<loco::DataType::S32>() ==
+                 mean_of_ifm_indices->size<loco::DataType::S32>());
+
+  std::set<int32_t> set_of_mean_as_variance_indices;
+  std::set<int32_t> set_of_mean_of_ifm_indices;
+  for (uint32_t index = 0; index < mean_as_variance_indices->size<loco::DataType::S32>(); index++)
+  {
+    set_of_mean_as_variance_indices.insert(
+      mean_as_variance_indices->at<loco::DataType::S32>(index));
+    set_of_mean_of_ifm_indices.insert(mean_of_ifm_indices->at<loco::DataType::S32>(index));
+  }
+  // now make sure that reduction indices of mean_as_variance are the same as mean_of_ifm
+  CHECK_OR_FALSE(set_of_mean_as_variance_indices == set_of_mean_of_ifm_indices);
+
+  return true;
+}
+
+#undef CHECK_OR_FALSE
+
+} // namespace
+
+std::map<luci::CircleNode *, LayerParam>
+Q8LayerNormWithQ16VarianceResolver::resolve(const luci::Module *module)
+{
+  if (!module)
+  {
+    throw std::runtime_error("no module for pattern resolving");
+  }
+
+  std::map<luci::CircleNode *, LayerParam> nodes_params;
+  for (size_t idx = 0; idx < module->size(); ++idx)
+  {
+    auto graph = module->graph(idx);
+
+    for (auto node : loco::active_nodes(loco::output_nodes(graph)))
+    {
+      auto const mul = dynamic_cast<luci::CircleMul *>(node);
+      if (!mul)
+        continue;
+
+      LayerNormPattern pattern(mul);
+      if (!pattern.matched())
+        continue;
+
+      // set quantization parameters of recognized pattern
+      for (auto q16_node : pattern.get_q16_nodes())
+      {
+        LayerParam param = {q16_node->name(), "int16", "channel"};
+        nodes_params[q16_node] = param;
+      }
+
+      for (auto q8_node : pattern.get_q8_nodes())
+      {
+        LayerParam param = {q8_node->name(), "uint8", "channel"};
+        nodes_params[q8_node] = param;
+      }
+    }
+  }
+
+  return nodes_params;
+}

--- a/compiler/circle-mpqsolver/src/pattern/PatternResolver.cpp
+++ b/compiler/circle-mpqsolver/src/pattern/PatternResolver.cpp
@@ -16,6 +16,10 @@
 
 #include "PatternResolver.h"
 
+#include <map>
+#include <set>
+#include <vector>
+
 using namespace mpqsolver::pattern;
 
 using LayerParam = luci::CircleQuantizer::Options::LayerParam;

--- a/compiler/circle-mpqsolver/src/pattern/PatternResolver.h
+++ b/compiler/circle-mpqsolver/src/pattern/PatternResolver.h
@@ -21,6 +21,8 @@
 #include <luci/IR/Module.h>
 #include <luci/IR/CircleNodes.h>
 
+#include <map>
+
 namespace mpqsolver
 {
 namespace pattern

--- a/compiler/circle-mpqsolver/src/pattern/PatternResolver.h
+++ b/compiler/circle-mpqsolver/src/pattern/PatternResolver.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __MPQSOLVER_PATTERN_RESOLVER_H__
+#define __MPQSOLVER_PATTERN_RESOLVER_H__
+
+#include <luci/CircleQuantizer.h>
+#include <luci/IR/Module.h>
+#include <luci/IR/CircleNodes.h>
+
+namespace mpqsolver
+{
+namespace pattern
+{
+
+class PatternResolver
+{
+public:
+  virtual ~PatternResolver() = default;
+  virtual std::map<luci::CircleNode *, luci::CircleQuantizer::Options::LayerParam>
+  resolve(const luci::Module *module) = 0;
+};
+
+class Q8LayerNormWithQ16VarianceResolver : public PatternResolver
+{
+public:
+  /**
+   * @brief resolve all nodes of LayerNorm pattern as prescribed
+   */
+  std::map<luci::CircleNode *, luci::CircleQuantizer::Options::LayerParam>
+  resolve(const luci::Module *module) override;
+};
+
+} // namespace pattern
+} // namespace mpqsolver
+
+#endif //__MPQSOLVER_PATTERN_RESOLVER_H__

--- a/compiler/circle-mpqsolver/src/pattern/PatternResolver.test.cpp
+++ b/compiler/circle-mpqsolver/src/pattern/PatternResolver.test.cpp
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "PatternResolver.h"
+
+#include <luci/CircleQuantizer.h>
+#include <luci/IR/CircleNodes.h>
+
+#include <luci/test/TestIOGraph.h>
+
+#include <cmath>
+#include <gtest/gtest.h>
+
+using LayerParam = luci::CircleQuantizer::Options::LayerParam;
+
+namespace
+{
+
+using namespace luci::test;
+
+class LayerNormGraphlet
+{
+public:
+  LayerNormGraphlet() = default;
+  virtual ~LayerNormGraphlet() = default;
+
+  void init(loco::Graph *g)
+  {
+    ifm = nullptr;
+
+    ifm = g->nodes()->create<luci::CircleAbs>();
+    mean_of_ifm = g->nodes()->create<luci::CircleMean>();
+    sub = g->nodes()->create<luci::CircleSub>();
+    sub_squared = g->nodes()->create<luci::CircleMul>();
+    mean_as_variance = g->nodes()->create<luci::CircleMean>();
+    add_eps = g->nodes()->create<luci::CircleAdd>();
+    rsqrt = g->nodes()->create<luci::CircleRsqrt>();
+    mul = g->nodes()->create<luci::CircleMul>();
+    _eps = g->nodes()->create<luci::CircleConst>();
+    _mean_of_ifm_indices = g->nodes()->create<luci::CircleConst>();
+    _mean_as_variance_indices = g->nodes()->create<luci::CircleConst>();
+
+    ifm->name("ifm");
+    mean_of_ifm->name("mean_of_ifm");
+    sub->name("sub");
+    sub_squared->name("sub_squared");
+    mean_as_variance->name("mean_as_variance");
+    add_eps->name("add_eps");
+    rsqrt->name("rsqrt");
+    mul->name("mul");
+    _eps->name("eps");
+    _mean_of_ifm_indices->name("mean_of_ifm_indices");
+    _mean_as_variance_indices->name("mean_as_variance_indices");
+
+    _eps->dtype(loco::DataType::FLOAT32);
+    _eps->size<loco::DataType::FLOAT32>(1);
+    _eps->shape({1});
+    _eps->at<loco::DataType::FLOAT32>(0) = 1.e-05f;
+    _eps->shape_status(luci::ShapeStatus::VALID);
+
+    _mean_of_ifm_indices->dtype(loco::DataType::S32);
+    _mean_of_ifm_indices->size<loco::DataType::S32>(1);
+    _mean_of_ifm_indices->shape({1});
+    _mean_of_ifm_indices->at<loco::DataType::S32>(0) = -1;
+    _mean_of_ifm_indices->shape_status(luci::ShapeStatus::VALID);
+
+    _mean_as_variance_indices->dtype(loco::DataType::S32);
+    _mean_as_variance_indices->size<loco::DataType::S32>(1);
+    _mean_as_variance_indices->shape({1});
+    _mean_as_variance_indices->at<loco::DataType::S32>(0) = -1;
+    _mean_as_variance_indices->shape_status(luci::ShapeStatus::VALID);
+  }
+
+public:
+  luci::CircleAbs *ifm = nullptr;
+  luci::CircleMean *mean_of_ifm = nullptr;
+  luci::CircleSub *sub = nullptr;
+  luci::CircleMul *sub_squared = nullptr;
+  luci::CircleMean *mean_as_variance = nullptr;
+  luci::CircleAdd *add_eps = nullptr;
+  luci::CircleRsqrt *rsqrt = nullptr;
+  luci::CircleMul *mul = nullptr;
+
+protected:
+  luci::CircleConst *_eps = nullptr;
+  luci::CircleConst *_mean_of_ifm_indices = nullptr;
+  luci::CircleConst *_mean_as_variance_indices = nullptr;
+};
+
+class LayerNormTestGraph : public TestIOGraph, public LayerNormGraphlet
+{
+public:
+  LayerNormTestGraph() = default;
+
+  void init(void)
+  {
+    TestIOGraph::init({1, 12, 11, 15}, {1, 12, 11, 15});
+    LayerNormGraphlet::init(g());
+
+    ifm->x(input());
+    mean_of_ifm->input(ifm);
+    mean_of_ifm->reduction_indices(_mean_of_ifm_indices);
+    sub->x(ifm);
+    sub->y(mean_of_ifm);
+    sub_squared->x(sub);
+    sub_squared->y(sub);
+    mean_as_variance->input(sub_squared);
+    mean_as_variance->reduction_indices(_mean_as_variance_indices);
+    add_eps->x(mean_as_variance);
+    add_eps->y(_eps);
+    rsqrt->x(add_eps);
+    mul->x(sub);
+    mul->y(rsqrt);
+
+    output()->from(mul);
+  }
+};
+
+} // namespace
+
+TEST(LayerNormPatternResolverTest, resolve_pattern)
+{
+  auto m = luci::make_module();
+  LayerNormTestGraph g;
+  g.init();
+  g.transfer_to(m.get());
+
+  std::map<luci::CircleNode *, LayerParam> params;
+  mpqsolver::pattern::Q8LayerNormWithQ16VarianceResolver resolver;
+  EXPECT_NO_THROW({ params = resolver.resolve(m.get()); });
+
+  std::set<luci::CircleNode *> q16_nodes = {g.sub_squared, g.mean_as_variance, g.add_eps, g.rsqrt};
+  std::set<luci::CircleNode *> q8_nodes = {g.mean_of_ifm, g.sub, g.mul};
+
+  // params of all valid layers are set
+  EXPECT_EQ(params.size(), q16_nodes.size() + q8_nodes.size());
+
+  for (auto param : params)
+  {
+    // params of all layers are set as prescribed
+    if (q16_nodes.find(param.first) != q16_nodes.end())
+    {
+      EXPECT_STREQ(param.second.dtype.c_str(), "int16");
+    }
+    else if (q8_nodes.find(param.first) != q8_nodes.end())
+    {
+      EXPECT_STREQ(param.second.dtype.c_str(), "uint8");
+    }
+  }
+}
+
+TEST(LayerNormPatternResolverTest, resolve_pattern_NEG)
+{
+  std::map<luci::CircleNode *, LayerParam> params;
+  mpqsolver::pattern::Q8LayerNormWithQ16VarianceResolver resolver;
+  EXPECT_ANY_THROW(resolver.resolve(nullptr));
+}


### PR DESCRIPTION
This commit introduces PatternResolver aiming to convert all recognized LayerNorm patterns to prescribed quantization patterns.

Its correctness is tested at #11560.

Draft: #11560
Related: https://github.com/Samsung/ONE/issues/11543

ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>