### PR TITLE
[luci-interpreter] Fix int32 overflow in large Conv2D

### DIFF
--- a/compiler/luci-interpreter/include/luci_interpreter/core/Tensor.h
+++ b/compiler/luci-interpreter/include/luci_interpreter/core/Tensor.h
@@ -60,6 +60,17 @@ public:
     return result;
   }
 
+  // TODO Replace num_elements
+  int64_t large_num_elements() const
+  {
+    int64_t result = 1;
+    for (const int32_t dim : _dims)
+    {
+      result *= dim;
+    }
+    return result;
+  }
+
   bool operator==(const Shape &other) const { return _dims == other._dims; }
 
   bool operator!=(const Shape &other) const { return !operator==(other); }

--- a/compiler/luci-interpreter/pal/linux/PALConv2d.h
+++ b/compiler/luci-interpreter/pal/linux/PALConv2d.h
@@ -111,9 +111,11 @@ static inline void SetupScratchpadTensor(luci_interpreter::Tensor *scratchpad,
     const int32_t output_width = output_shape.Dims(2);
 
     auto data_type_size = static_cast<int32_t>(luci_interpreter::getDataTypeSize(input_data_type));
-    int32_t scratchpad_size = batches * output_width * output_height * input_depth * filter_height *
-                              filter_width * data_type_size;
-    luci_interpreter::Shape scratchpad_shape{scratchpad_size};
+    // im2col_shape
+    // data_type_size is added because we use U8 for scratchpad buffer dtype
+    luci_interpreter::Shape scratchpad_shape{batches, output_height, output_width,
+                                             input_depth * filter_height * filter_width,
+                                             data_type_size};
     scratchpad->resize(scratchpad_shape);
   }
   else

--- a/compiler/luci-interpreter/src/SimpleMemoryManager.cpp
+++ b/compiler/luci-interpreter/src/SimpleMemoryManager.cpp
@@ -30,7 +30,9 @@ void SimpleMemoryManager::allocate_memory(luci_interpreter::Tensor &tensor)
     release_memory(tensor);
   }
   const auto element_size = getDataTypeSize(tensor.element_type());
-  const auto num_elements = tensor.shape().num_elements();
+
+  // Use large_num_elements to avoid overflow
+  const auto num_elements = tensor.shape().large_num_elements();
 
   auto *data = new uint8_t[num_elements * element_size];
   tensor.set_data_buffer(data);


### PR DESCRIPTION
This fixes int32 overflow in large Conv2D.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: #11582 
Draft PR: #11583