### PR TITLE
[q-implant] Quantization Parameter forward propagation

### DIFF
--- a/compiler/q-implant/include/QImplant.h
+++ b/compiler/q-implant/include/QImplant.h
@@ -28,7 +28,7 @@ class QImplant final
 {
 public:
   QImplant(const std::string &path) : _path(path) {}
-  
+
   void write(loco::Graph *g);
 
 private:

--- a/compiler/q-implant/include/QImplant.h
+++ b/compiler/q-implant/include/QImplant.h
@@ -28,13 +28,13 @@ class QImplant final
 {
 public:
   QImplant(const std::string &path) : _path(path) {}
-
   void write(loco::Graph *g);
 
 private:
-  const std::string &_path;
-
   void forward_qparam(loco::Graph *g);
+
+private:
+  const std::string &_path;
 };
 
 } // namespace q_implant

--- a/compiler/q-implant/include/QImplant.h
+++ b/compiler/q-implant/include/QImplant.h
@@ -28,6 +28,7 @@ class QImplant final
 {
 public:
   QImplant(const std::string &path) : _path(path) {}
+  
   void write(loco::Graph *g);
 
 private:

--- a/compiler/q-implant/include/QImplant.h
+++ b/compiler/q-implant/include/QImplant.h
@@ -33,6 +33,8 @@ public:
 
 private:
   const std::string &_path;
+
+  void forward_qparam(loco::Graph *g);
 };
 
 } // namespace q_implant

--- a/compiler/q-implant/src/QImplant.cpp
+++ b/compiler/q-implant/src/QImplant.cpp
@@ -32,6 +32,10 @@ using namespace q_implant;
 
 namespace
 {
+// TODO: Find opcodes which can be appended in conversion
+std::set<luci::CircleOpcode> appendable_operator_opcode{
+  luci::CircleOpcode::CONCATENATION, luci::CircleOpcode::RESHAPE, luci::CircleOpcode::SPLIT,
+  luci::CircleOpcode::TRANSPOSE};
 
 // Return directory path of given file path
 // TODO Find a platform-independent way to do this
@@ -103,6 +107,8 @@ Json::Value load_json(const std::string &path)
 
 void set_dtype(luci::CircleNode *node, loco::DataType dtype) { node->dtype(dtype); }
 
+void set_dtype(luci::CircleNode *origin, luci::CircleNode *dest) { dest->dtype(origin->dtype()); }
+
 void set_scale(luci::CircleNode *node, const std::string &scale_path)
 {
   assert(node);               // FIX CALLER UNLESS
@@ -141,6 +147,20 @@ void set_quantized_dimension(luci::CircleNode *node, const uint32_t quantized_di
   assert(node->quantparam()); // FIX CALLER UNLESS
 
   node->quantparam()->quantized_dimension = quantized_dimension;
+}
+
+void set_quantparam(luci::CircleNode *origin, luci::CircleNode *dest)
+{
+  assert(origin);
+  auto origin_quantparam = origin->quantparam();
+  assert(origin_quantparam);
+
+  assert(dest);
+  auto dest_quantparam = dest->quantparam();
+  assert(dest_quantparam);
+  dest_quantparam->zerop = origin_quantparam->zerop;
+  dest_quantparam->scale = origin_quantparam->scale;
+  dest_quantparam->quantized_dimension = origin_quantparam->quantized_dimension;
 }
 
 template <loco::DataType DT> void set_value(luci::CircleConst *node, const std::string &value_path)
@@ -248,6 +268,50 @@ void QImplant::write(loco::Graph *g)
       const auto value_path = dir_path + '/' + tensor["value"].asString();
 
       set_value(const_node, value_path, dtype);
+    }
+  }
+
+  std::set<luci::CircleNode *> visit;
+  std::deque<luci::CircleNode *> que;
+  for (auto input_node : loco::input_nodes(g))
+  {
+    auto node = loco::must_cast<luci::CircleNode *>(input_node);
+    que.emplace_back(node);
+  }
+
+  // check whether node can share its successor node quantization parameter
+  while (!que.empty())
+  {
+    auto node = que.front();
+    que.pop_front();
+
+    // skip when node is output
+    if (node->opcode() == luci::CircleOpcode::CIRCLEOUTPUT)
+    {
+      continue;
+    }
+
+    auto quantparam = node->quantparam();
+    THROW_UNLESS(quantparam);
+
+    for (auto child : loco::succs(node))
+    {
+      auto child_node = loco::must_cast<luci::CircleNode *>(child);
+      if (visit.find(child_node) != visit.end())
+        continue;
+      visit.emplace(child_node);
+      que.emplace_back(child_node);
+
+      if (child_node->quantparam() == nullptr)
+      {
+        if (appendable_operator_opcode.find(child_node->opcode()) ==
+            appendable_operator_opcode.end())
+          continue;
+
+        set_dtype(node, child_node);
+        child_node->quantparam(std::make_unique<luci::CircleQuantParam>());
+        set_quantparam(node, child_node);
+      }
     }
   }
 

--- a/compiler/q-implant/src/QImplant.cpp
+++ b/compiler/q-implant/src/QImplant.cpp
@@ -298,6 +298,7 @@ void QImplant::forward_qparam(loco::Graph *g)
   std::set<luci::CircleOpcode> forwardable_opcode;
   forwardable_opcode.emplace(luci::CircleOpcode::RESHAPE);
   forwardable_opcode.emplace(luci::CircleOpcode::SPLIT);
+  forwardable_opcode.emplace(luci::CircleOpcode::CIRCLESPLITOUT);
   forwardable_opcode.emplace(luci::CircleOpcode::TRANSPOSE);
   // TODO add more Ops
 


### PR DESCRIPTION
Operators(such as transpose, reshape and etc.) can be added while model conversion. Those operators are not present at original model, so corresponding quantization parameter could not exist on `qparam.json`. For those operators, forward quantization parameter to make appropriate graph.

ONE-DCO-1.0-Signed-off-by: WooJeong Jeong <wj6349@gmail.com>