### PR TITLE
[one-cmds] Add onnxruntime InferenceSession options

### DIFF
--- a/compiler/one-cmds/tests/onnx_legalize_run_compare.py
+++ b/compiler/one-cmds/tests/onnx_legalize_run_compare.py
@@ -52,7 +52,14 @@ def _run_model(model, inputs):
         list of numpy.ndarray: inference outputs
     """
     output_names = list(map(lambda output: output.name, model.graph.output))
-    session = rt.InferenceSession(model.SerializeToString())
+    options = rt.SessionOptions()
+    # NOTE this is needed for U18.04
+    # referenced: https://github.com/microsoft/onnxruntime/issues/10113
+    options.intra_op_num_threads = 4
+    # NOTE set `providers` for https://github.com/microsoft/onnxruntime/issues/17631
+    providers = rt.get_available_providers()
+    session = rt.InferenceSession(
+        model.SerializeToString(), sess_options=options, providers=providers)
     outputs = session.run(output_names, inputs)
     return outputs
 

--- a/compiler/one-cmds/validate-onnx2circle/validate_onnx2circle.py
+++ b/compiler/one-cmds/validate-onnx2circle/validate_onnx2circle.py
@@ -64,7 +64,14 @@ class OnnxRunner:
     def load(self):
         model = onnx.load(self.filepath)
         onnx.checker.check_model(model)
-        self.session = ort.InferenceSession(self.filepath)
+        options = ort.SessionOptions()
+        # NOTE this is needed for U18.04
+        # referenced: https://github.com/microsoft/onnxruntime/issues/10113
+        options.intra_op_num_threads = 4
+        # NOTE set `providers` for https://github.com/microsoft/onnxruntime/issues/17631
+        providers = ort.get_available_providers()
+        self.session = ort.InferenceSession(
+            self.filepath, sess_options=options, providers=providers)
 
     def feed_random_inputs(self):
         self.inputs = self.session.get_inputs()


### PR DESCRIPTION
Thils will revise to add some options to prevent issues running onnxruntime.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>