### PR TITLE
[luci-interpreter] Add SimpleMemoryManager test

### DIFF
--- a/compiler/luci-interpreter/src/CMakeLists.txt
+++ b/compiler/luci-interpreter/src/CMakeLists.txt
@@ -39,7 +39,7 @@ else ()
   add_library(${LUCI_INTERPRETER_BINARY} STATIC ${SOURCES})
 endif ()
 
-set(TEST_SOURCES BuddyMemoryManager.test.cpp)
+set(TEST_SOURCES SimpleMemoryManager.test.cpp BuddyMemoryManager.test.cpp)
 
 target_include_directories(${LUCI_INTERPRETER_BINARY} PUBLIC "${LUCI_INTERPRETER_INCLUDE_DIR}")
 target_include_directories(${LUCI_INTERPRETER_BINARY} PRIVATE "${LUCI_INTERPRETER_SOURCE_DIR}")
@@ -57,5 +57,5 @@ endif(NOT ENABLE_TEST)
 
 nnas_find_package(GTest REQUIRED)
 
-GTest_AddTest(buddy_manager_test ${TEST_SOURCES})
-target_link_libraries(buddy_manager_test ${LUCI_INTERPRETER_BINARY})
+GTest_AddTest(luci_interpreter_memory_manager_test ${TEST_SOURCES})
+target_link_libraries(luci_interpreter_memory_manager_test ${LUCI_INTERPRETER_BINARY})

--- a/compiler/luci-interpreter/src/SimpleMemoryManager.test.cpp
+++ b/compiler/luci-interpreter/src/SimpleMemoryManager.test.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci_interpreter/SimpleMemoryManager.h"
+#include <gtest/gtest.h>
+
+using namespace luci_interpreter;
+using namespace testing;
+
+TEST(SimpleMemoryManager, basic)
+{
+  SimpleMemoryManager smm;
+  Tensor t(DataType::U8, Shape({1, 16, 16, 256}), AffineQuantization{}, "t");
+
+  EXPECT_NO_THROW(smm.allocate_memory(t));
+  EXPECT_NO_THROW(smm.release_memory(t));
+}
+
+TEST(SimpleMemoryManager, huge)
+{
+  SimpleMemoryManager smm;
+  Tensor t(DataType::U8, Shape({1, 512, 512, 256 * 3 * 3 * 4}), AffineQuantization{}, "t");
+
+  EXPECT_NO_THROW(smm.allocate_memory(t));
+  EXPECT_NO_THROW(smm.release_memory(t));
+}
+
+TEST(SimpleMemoryManager, string_dtype_NEG)
+{
+  SimpleMemoryManager smm;
+  Tensor t(DataType::STRING, Shape({1, 16, 16, 4}), AffineQuantization{}, "t");
+
+  EXPECT_ANY_THROW(smm.allocate_memory(t));
+}
+
+TEST(SimpleMemoryManager, negative_shape_NEG)
+{
+  SimpleMemoryManager smm;
+  Tensor t(DataType::U8, Shape({1, 16, 16, -4}), AffineQuantization{}, "t");
+
+  EXPECT_ANY_THROW(smm.allocate_memory(t));
+}


### PR DESCRIPTION
This adds tests for SimpleMemoryManager.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/11582
Draft PR: https://github.com/Samsung/ONE/pull/11583