### PR TITLE
[circle-quantizer] Tidy unused OptionHook

### DIFF
--- a/compiler/circle-quantizer/src/CircleQuantizer.cpp
+++ b/compiler/circle-quantizer/src/CircleQuantizer.cpp
@@ -26,12 +26,9 @@
 #include <vconone/vconone.h>
 #include <json.h>
 
-#include <functional>
 #include <iostream>
 #include <map>
 #include <string>
-
-using OptionHook = std::function<int(const char **)>;
 
 using LayerParam = luci::CircleQuantizer::Options::LayerParam;
 using LayerParams = luci::CircleQuantizer::Options::LayerParams;


### PR DESCRIPTION
This will tidy unused OptionHook alias.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>