### PR TITLE
[luci] Add ReplaceWithFCGeluFC algorithm

### DIFF
--- a/compiler/luci/pass/include/luci/CircleOptimizer.h
+++ b/compiler/luci/pass/include/luci/CircleOptimizer.h
@@ -69,6 +69,7 @@ public:
       ReplaceMulAddWithDepthwiseConv,
       ReplaceNonConstFCWithBatchMatMul,
       ReplaceSubWithAdd,
+      ReplaceWithFCGeluFC,
       SubstitutePackToReshape,
       SubstitutePadV2ToPad,
       SubstituteSplitVToSplit,

--- a/compiler/luci/pass/src/CircleOptimizer.cpp
+++ b/compiler/luci/pass/src/CircleOptimizer.cpp
@@ -56,6 +56,7 @@
 #include "luci/Pass/ReplaceNonConstFCWithBatchMatMulPass.h"
 #include "luci/Pass/ReplaceMulAddWithDepthwiseConvPass.h"
 #include "luci/Pass/ReplaceSubWithAddPass.h"
+#include "luci/Pass/ReplaceWithFCGeluFCPass.h"
 #include "luci/Pass/ResolveCustomOpAddPass.h"
 #include "luci/Pass/ResolveCustomOpBatchMatMulPass.h"
 #include "luci/Pass/ResolveCustomOpMatMulPass.h"
@@ -402,6 +403,10 @@ void CircleOptimizer::optimize(loco::Graph *g) const
   if (_options->query(Options::Algorithm::ReplaceSubWithAdd))
   {
     phase.emplace_back(std::make_unique<luci::ReplaceSubWithAddPass>());
+  }
+  if (_options->query(Options::Algorithm::ReplaceWithFCGeluFC))
+  {
+    phase.emplace_back(std::make_unique<luci::ReplaceWithFCGeluFCPass>());
   }
   if (_options->query(Options::Algorithm::SubstitutePackToReshape))
   {


### PR DESCRIPTION
This adds ReplaceWithFCGeluFC algorithm to CircleOptimizer.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/11542
Draft PR: https://github.com/Samsung/ONE/pull/11604