### PR TITLE
[luci/pass] Introduce LayerParamsSet, layer_params_set getter/setter

### DIFF
--- a/compiler/luci/pass/include/luci/CircleQuantizer.h
+++ b/compiler/luci/pass/include/luci/CircleQuantizer.h
@@ -19,6 +19,7 @@
 
 #include <loco.h>
 
+#include <iterator>
 #include <string>
 #include <vector>
 
@@ -38,6 +39,22 @@ public:
     };
 
     using LayerParams = std::vector<std::shared_ptr<LayerParam>>;
+
+    // NOTE ...Set is not related with std::set but used as to denote
+    //      multple 'set' of LayerParams.
+    class LayerParamsSet
+    {
+    public:
+      // some helper methods
+      size_t size(void) const { return items.size(); }
+      template <class... Args> void emplace_back(Args &&... args) { items.emplace_back(args...); }
+      std::vector<LayerParams>::iterator begin() { return items.begin(); };
+      std::vector<LayerParams>::iterator end() { return items.end(); };
+
+    private:
+      // store multiple set of LayerParams
+      std::vector<LayerParams> items;
+    };
 
     enum Algorithm
     {
@@ -82,6 +99,8 @@ public:
     // Quantization parameters for multiple layers
     virtual void layer_params(AlgorithmParameters, LayerParams &) = 0;
     virtual LayerParams layer_params(AlgorithmParameters) const = 0;
+    virtual void layer_params_set(LayerParamsSet &) = 0;
+    virtual LayerParamsSet layer_params_set(void) const = 0;
   };
 
 public:

--- a/compiler/luci/pass/src/CircleQuantizer.cpp
+++ b/compiler/luci/pass/src/CircleQuantizer.cpp
@@ -53,6 +53,7 @@ namespace
 using namespace luci;
 using LayerParam = luci::CircleQuantizer::Options::LayerParam;
 using LayerParams = luci::CircleQuantizer::Options::LayerParams;
+using LayerParamsSet = luci::CircleQuantizer::Options::LayerParamsSet;
 
 // This function updates user-given input_type to match with the input signature of graph
 // If user gives only one input_type, it will be expanded to the number of graph inputs
@@ -229,6 +230,8 @@ public:
   std::vector<std::string> params(AlgorithmParameters) const final;
   void layer_params(AlgorithmParameters, LayerParams &) final;
   LayerParams layer_params(AlgorithmParameters) const final;
+  void layer_params_set(LayerParamsSet &) final;
+  LayerParamsSet layer_params_set(void) const final;
   bool query(Algorithm) final;
 
 private:
@@ -236,6 +239,7 @@ private:
   std::map<AlgorithmParameters, const std::string> _algorithm_params;
   std::map<AlgorithmParameters, std::vector<std::string>> _multiple_params;
   std::map<AlgorithmParameters, LayerParams> _layer_params;
+  LayerParamsSet _layer_params_set;
 };
 
 void QuantizeOptionsImpl::enable(Algorithm algo) { _algorithms.push_back(algo); }
@@ -293,6 +297,10 @@ LayerParams QuantizeOptionsImpl::layer_params(AlgorithmParameters param) const
     return LayerParams();
   }
 }
+
+void QuantizeOptionsImpl::layer_params_set(LayerParamsSet &vec) { _layer_params_set = vec; }
+
+LayerParamsSet QuantizeOptionsImpl::layer_params_set(void) const { return _layer_params_set; }
 
 bool QuantizeOptionsImpl::query(Algorithm algo)
 {


### PR DESCRIPTION
This will introduce LayerParamsSet type and layer_params_set getter/setter in CircleQuantizer::Options.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>