### PR TITLE
[record-minmax] Introduce --minmax_data_path

### DIFF
--- a/compiler/record-minmax/include/RecordMinMax.h
+++ b/compiler/record-minmax/include/RecordMinMax.h
@@ -60,6 +60,8 @@ public:
 
   void saveModel(const std::string &output_model_path);
 
+  void loadMinMax(const std::string &output_model_path);
+
 private:
   luci_interpreter::Interpreter *getInterpreter() const { return _interpreters[0].get(); }
 

--- a/compiler/record-minmax/src/RecordMinMax.cpp
+++ b/compiler/record-minmax/src/RecordMinMax.cpp
@@ -617,4 +617,9 @@ void RecordMinMax::saveModel(const std::string &output_model_path)
   }
 }
 
+void RecordMinMax::loadMinMax(const std::string &output_model_path)
+{
+  throw std::runtime_error("loadMinMax is not supported yet.");
+}
+
 } // namespace record_minmax


### PR DESCRIPTION
It introduces --minmax_data_path, which loads the profiled-data from given --minmax_data_path, then generate new model with min/max from given input model.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

Draft for #11644