### PR TITLE
[circle-quantizer] Read alternate layer params

### DIFF
--- a/compiler/circle-quantizer/src/CircleQuantizer.cpp
+++ b/compiler/circle-quantizer/src/CircleQuantizer.cpp
@@ -118,7 +118,7 @@ LayerParams read_layer_params(std::string &filename)
   return p;
 }
 
-LayerParamsSet read_layer_params_set(const std::string &filename)
+LayerParamsSet read_layer_params_set(std::string &filename)
 {
   LayerParamsSet lpss;
 

--- a/compiler/circle-quantizer/src/CircleQuantizer.cpp
+++ b/compiler/circle-quantizer/src/CircleQuantizer.cpp
@@ -118,7 +118,7 @@ LayerParams read_layer_params(std::string &filename)
   return p;
 }
 
-LayerParamsSet read_layer_params_set(std::string &filename)
+LayerParamsSet read_layer_params_set(const std::string &filename)
 {
   LayerParamsSet lpss;
 


### PR DESCRIPTION
This will enable to read alternate layer params.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>