### PR TITLE
[circle-mpqsolver] Refactor BisectionSolver

### DIFF
--- a/compiler/circle-mpqsolver/src/MPQSolver.cpp
+++ b/compiler/circle-mpqsolver/src/MPQSolver.cpp
@@ -16,6 +16,9 @@
 
 #include "MPQSolver.h"
 
+#include <luci/ImporterEx.h>
+#include <iostream>
+
 using namespace mpqsolver;
 
 MPQSolver::MPQSolver(const std::string &input_data_path, float qerror_ratio,
@@ -23,9 +26,23 @@ MPQSolver::MPQSolver(const std::string &input_data_path, float qerror_ratio,
   : _input_data_path(input_data_path), _qerror_ratio(qerror_ratio),
     _input_quantization(input_quantization), _output_quantization(output_quantization)
 {
+  _quantizer = std::make_unique<core::Quantizer>(_input_quantization, _output_quantization);
 }
 
 void MPQSolver::set_save_intermediate(const std::string &save_path)
 {
   _hooks = std::make_unique<core::DumpingHooks>(save_path);
+}
+
+std::unique_ptr<luci::Module> MPQSolver::read_module(const std::string &path)
+{
+  luci::ImporterEx importerex;
+  auto module = importerex.importVerifyModule(path);
+  if (module.get() == nullptr)
+  {
+    std::cerr << "ERROR: Failed to load " << path << std::endl;
+    return nullptr;
+  }
+
+  return module;
 }

--- a/compiler/circle-mpqsolver/src/MPQSolver.h
+++ b/compiler/circle-mpqsolver/src/MPQSolver.h
@@ -17,7 +17,10 @@
 #ifndef __MPQSOLVER_MPQSOLEVR_SOLVER_H__
 #define __MPQSOLVER_MPQSOLEVR_SOLVER_H__
 
+#include "core/Quantizer.h"
 #include <core/DumpingHooks.h>
+
+#include <luci/IR/CircleNodes.h>
 
 #include <memory>
 #include <string>
@@ -48,9 +51,13 @@ public:
   void set_save_intermediate(const std::string &save_path);
 
 protected:
+  std::unique_ptr<luci::Module> read_module(const std::string &path);
+
+protected:
   std::string _input_data_path;
   std::string _input_quantization;
   std::string _output_quantization;
+  std::unique_ptr<core::Quantizer> _quantizer;
   float _qerror_ratio = 0.f; // quantization error ratio
   std::unique_ptr<core::DumpingHooks> _hooks;
 };

--- a/compiler/circle-mpqsolver/src/bisection/BisectionSolver.cpp
+++ b/compiler/circle-mpqsolver/src/bisection/BisectionSolver.cpp
@@ -72,19 +72,6 @@ bool front_has_higher_error(const NodeDepthType &nodes_depth, const std::string 
   return error_at_input > error_at_output;
 }
 
-std::unique_ptr<luci::Module> read_module(const std::string &path)
-{
-  luci::ImporterEx importerex;
-  auto module = importerex.importVerifyModule(path);
-  if (module.get() == nullptr)
-  {
-    std::cerr << "ERROR: Failed to load " << path << std::endl;
-    return nullptr;
-  }
-
-  return module;
-}
-
 } // namespace
 
 BisectionSolver::BisectionSolver(const std::string &input_data_path, float qerror_ratio,
@@ -92,7 +79,6 @@ BisectionSolver::BisectionSolver(const std::string &input_data_path, float qerro
                                  const std::string &output_quantization)
   : MPQSolver(input_data_path, qerror_ratio, input_quantization, output_quantization)
 {
-  _quantizer = std::make_unique<core::Quantizer>(_input_quantization, _output_quantization);
 }
 
 float BisectionSolver::evaluate(const core::DatasetEvaluator &evaluator,

--- a/compiler/circle-mpqsolver/src/bisection/BisectionSolver.h
+++ b/compiler/circle-mpqsolver/src/bisection/BisectionSolver.h
@@ -17,7 +17,6 @@
 #ifndef __MPQSOLVER_BISECTION_SOLVER_H__
 #define __MPQSOLVER_BISECTION_SOLVER_H__
 
-#include <core/Quantizer.h>
 #include <core/Evaluator.h>
 #include <MPQSolver.h>
 
@@ -78,7 +77,6 @@ private:
 private:
   float _qerror = 0.f; // quantization error
   Algorithm _algorithm = Algorithm::ForceQ16Front;
-  std::unique_ptr<core::Quantizer> _quantizer;
   std::string _visq_data_path;
 };
 


### PR DESCRIPTION
This commit moves _quantizer and read_module to parent class.

Its correctness is tested at https://github.com/Samsung/ONE/pull/11560.

Draft: https://github.com/Samsung/ONE/pull/11560
Related: https://github.com/Samsung/ONE/issues/11543

ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>