### PR TITLE
[one-cmds] Revise prepare_test_materials.sh

### DIFF
--- a/compiler/one-cmds/tests/prepare_test_materials.sh
+++ b/compiler/one-cmds/tests/prepare_test_materials.sh
@@ -124,6 +124,13 @@ if [[ ! -s "UnidirSeqLSTM.tflite" ]]; then
     # https://github.com/Samsung/ONE/issues/9940#issuecomment-1293282484
 fi
 
+if [[ ! -s "onnx_conv2d_conv2d_split.onnx" ]]; then
+    rm -rf onnx_conv2d_conv2d_split.zip
+    wget -nv https://github.com/Samsung/ONE/files/12711381/onnx_conv2d_conv2d_split.zip
+    unzip onnx_conv2d_conv2d_split.zip
+    # https://github.com/Samsung/ONE/issues/11280#issuecomment-1732852295
+fi
+
 function files_missing() {
     condition="test "
 


### PR DESCRIPTION
This will revise prepare_test_materials.sh to download test model for enabling alternate names for quntization.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>