### PR TITLE
[circle-mpqsolver] Revisit  BisectionSolver

### DIFF
--- a/compiler/circle-mpqsolver/src/bisection/BisectionSolver.cpp
+++ b/compiler/circle-mpqsolver/src/bisection/BisectionSolver.cpp
@@ -155,8 +155,7 @@ std::unique_ptr<luci::Module> BisectionSolver::run(const std::string &module_pat
       _hooks->on_end_solver(layer_params, "int16", int16_qerror);
     }
 
-    SolverOutput::get() << "The best configuration is int16 configuration "
-                        << "\n";
+    SolverOutput::get() << "The best configuration is int16 configuration\n";
     return module;
   }
   else if (uint8_qerror <= _qerror)
@@ -173,8 +172,7 @@ std::unique_ptr<luci::Module> BisectionSolver::run(const std::string &module_pat
       _hooks->on_end_solver(layer_params, "uint8", uint8_qerror);
     }
 
-    SolverOutput::get() << "The best configuration is uint8 configuration "
-                        << "\n";
+    SolverOutput::get() << "The best configuration is uint8 configuration\n";
     return module;
   }
 


### PR DESCRIPTION
This commit excludes unnecessary search process when target error is out of reasonable bounds.

Its output for `qerror_ratio = 0.0` (q16) is:
```
...
>> Computing baseline qerrors
Full int16 model qerror: 9.25156e-05
Full uint8 model qerror: 0.000252629
Target qerror: 9.25156e-05
The best configuration is int16 configuration 
```
Its output for `qerror_ratio = 1.0` (q8) is:
```
...
>> Computing baseline qerrors
Full int16 model qerror: 9.25156e-05
Full uint8 model qerror: 0.000252629
Target qerror: 0.000252629
The best configuration is uint8 configuration 
```
ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>