### PR TITLE
[circle-mpqsolver] Revisit  MPQSolver

### DIFF
--- a/compiler/circle-mpqsolver/src/MPQSolver.cpp
+++ b/compiler/circle-mpqsolver/src/MPQSolver.cpp
@@ -24,7 +24,7 @@
 using namespace mpqsolver;
 
 using LayerParam = luci::CircleQuantizer::Options::LayerParam;
-using LayerParams = std::vector<std::shared_ptr<LayerParam>>;
+using LayerParams = luci::CircleQuantizer::Options::LayerParams;
 
 MPQSolver::MPQSolver(const std::string &input_data_path, float qerror_ratio,
                      const std::string &input_quantization, const std::string &output_quantization)
@@ -62,12 +62,10 @@ void MPQSolver::resolve_patterns(luci::Module *module)
     switch (pattern)
     {
       case QuantizationPattern::Q8LayerNormWithQ16Variance:
-      {
         resolver = std::make_unique<pattern::Q8LayerNormWithQ16VarianceResolver>();
-      }
-      break;
+        break;
       default:
-        throw std::runtime_error("ERROR: unsupported pattern to resolve");
+        throw std::runtime_error("Unsupported pattern to resolve");
     }
 
     auto const resolved = resolver->resolve(module);
@@ -82,7 +80,7 @@ void MPQSolver::resolve_patterns(luci::Module *module)
       else if (frozen->second.dtype != node_param.second.dtype)
       {
         // ambiguity (incoming description conflicts with current)
-        throw std::runtime_error("ERROR: resolved patterns contradict each other");
+        throw std::runtime_error("Resolved patterns contradict each other");
       }
     }
   }

--- a/compiler/circle-mpqsolver/src/MPQSolver.cpp
+++ b/compiler/circle-mpqsolver/src/MPQSolver.cpp
@@ -16,10 +16,15 @@
 
 #include "MPQSolver.h"
 
+#include "pattern/PatternResolver.h"
+
 #include <luci/ImporterEx.h>
 #include <iostream>
 
 using namespace mpqsolver;
+
+using LayerParam = luci::CircleQuantizer::Options::LayerParam;
+using LayerParams = std::vector<std::shared_ptr<LayerParam>>;
 
 MPQSolver::MPQSolver(const std::string &input_data_path, float qerror_ratio,
                      const std::string &input_quantization, const std::string &output_quantization)
@@ -32,6 +37,55 @@ MPQSolver::MPQSolver(const std::string &input_data_path, float qerror_ratio,
 void MPQSolver::set_save_intermediate(const std::string &save_path)
 {
   _hooks = std::make_unique<core::DumpingHooks>(save_path);
+}
+
+void MPQSolver::set_mpq_options(MPQOptions &options) { _options = options; }
+
+LayerParams MPQSolver::get_frozen_params() const
+{
+  LayerParams params;
+  for (auto node_to_param : _frozen._node_to_param)
+  {
+    params.push_back(std::make_shared<LayerParam>(node_to_param.second));
+  }
+
+  return params;
+}
+
+void MPQSolver::resolve_patterns(luci::Module *module)
+{
+  _frozen._node_to_param.clear();
+
+  for (auto pattern : _options._patterns)
+  {
+    std::unique_ptr<pattern::PatternResolver> resolver;
+    switch (pattern)
+    {
+      case QuantizationPattern::Q8LayerNormWithQ16Variance:
+      {
+        resolver = std::make_unique<pattern::Q8LayerNormWithQ16VarianceResolver>();
+      }
+      break;
+      default:
+        throw std::runtime_error("ERROR: unsupported pattern to resolve");
+    }
+
+    auto const resolved = resolver->resolve(module);
+    for (auto node_param : resolved)
+    {
+      auto const frozen = _frozen._node_to_param.find(node_param.first);
+      if (frozen == _frozen._node_to_param.end())
+      {
+        // node was not previously defined - just set it (no ambiguity)
+        _frozen._node_to_param[node_param.first] = node_param.second;
+      }
+      else if (frozen->second.dtype != node_param.second.dtype)
+      {
+        // ambiguity (incoming description conflicts with current)
+        throw std::runtime_error("ERROR: resolved patterns contradict each other");
+      }
+    }
+  }
 }
 
 std::unique_ptr<luci::Module> MPQSolver::read_module(const std::string &path)

--- a/compiler/circle-mpqsolver/src/MPQSolver.h
+++ b/compiler/circle-mpqsolver/src/MPQSolver.h
@@ -22,8 +22,10 @@
 
 #include <luci/IR/CircleNodes.h>
 
+#include <map>
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace mpqsolver
 {
@@ -86,8 +88,7 @@ protected:
   /**
    * @brief transform _frozen nodes to Quantizer friendly form
    */
-  std::vector<std::shared_ptr<luci::CircleQuantizer::Options::LayerParam>>
-  get_frozen_params() const;
+  luci::CircleQuantizer::Options::LayerParams get_frozen_params() const;
 
 protected:
   std::string _input_data_path;

--- a/compiler/circle-mpqsolver/src/MPQSolver.h
+++ b/compiler/circle-mpqsolver/src/MPQSolver.h
@@ -28,6 +28,21 @@
 namespace mpqsolver
 {
 
+enum class QuantizationPattern
+{
+  Q8LayerNormWithQ16Variance
+};
+
+struct MPQOptions
+{
+  std::vector<QuantizationPattern> _patterns;
+};
+
+struct FrozenNodes
+{
+  std::map<luci::CircleNode *, luci::CircleQuantizer::Options::LayerParam> _node_to_param;
+};
+
 class MPQSolver
 {
 public:
@@ -53,11 +68,34 @@ public:
 protected:
   std::unique_ptr<luci::Module> read_module(const std::string &path);
 
+  /**
+   * @brief set quantization options
+   */
+  void set_mpq_options(MPQOptions &options);
+
+  /**
+   * @brief fill _frozen with prescribed quantization parameters of resolved nodes
+   */
+  void resolve_patterns(luci::Module *module);
+
+  /**
+   * @brief resolve Q8LayerNormWithQ16Variance pattern
+   */
+  void resolve_layer_norm_pattern(luci::Module *module);
+
+  /**
+   * @brief transform _frozen nodes to Quantizer friendly form
+   */
+  std::vector<std::shared_ptr<luci::CircleQuantizer::Options::LayerParam>>
+  get_frozen_params() const;
+
 protected:
   std::string _input_data_path;
   std::string _input_quantization;
   std::string _output_quantization;
   std::unique_ptr<core::Quantizer> _quantizer;
+  MPQOptions _options;       // options for mpq quantization
+  FrozenNodes _frozen;       // nodes with prescribed quantization parameters
   float _qerror_ratio = 0.f; // quantization error ratio
   std::unique_ptr<core::DumpingHooks> _hooks;
 };


### PR DESCRIPTION
This commit introduces functionality needed for `pattern` quantization.

Its correctness is tested at https://github.com/Samsung/ONE/pull/11560.

Draft: https://github.com/Samsung/ONE/pull/11560
Related: https://github.com/Samsung/ONE/issues/11543
ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>