### PR TITLE
[onert] Enable max2d PoolLayer for training

### DIFF
--- a/compute/cker/include/cker/train/operation/MaxPool.h
+++ b/compute/cker/include/cker/train/operation/MaxPool.h
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __NNFW_CKER_TRAIN_OPERATION_MAXPOOL_H__
+#define __NNFW_CKER_TRAIN_OPERATION_MAXPOOL_H__
+
+#include "cker/Shape.h"
+#include "cker/Utils.h"
+#include "cker/eigen/Utils.h"
+
+#include <Eigen/Core>
+
+namespace nnfw
+{
+namespace cker
+{
+namespace train
+{
+
+// Most of the logic except 'arg_max_index' related is copy-paste from
+// https://github.com/Samsung/ONE/blob/a380292/compute/cker/include/cker/operation/MaxPool.h#L42-L88
+// 'arg_max_index' is to record max-arguments' index to apply gradient later.
+inline void MaxPool2D(const PoolParams &params, const Shape &input_shape, const float *input_data,
+                      const Shape &output_shape, float *output_data, int *arg_max_index)
+{
+  assert(input_shape.DimensionsCount() == 4);
+  assert(output_shape.DimensionsCount() == 4);
+  assert(input_shape.Dims(0) == output_shape.Dims(0)); // MaxPool2D doesn't change batch
+  assert(input_shape.Dims(3) == output_shape.Dims(3)); // MaxPool2D doesn't change depth
+
+  const int batches = MatchingDim(input_shape, 0, output_shape, 0);
+  const int input_height = input_shape.Dims(1);
+  const int input_width = input_shape.Dims(2);
+  const int output_height = output_shape.Dims(1);
+  const int output_width = output_shape.Dims(2);
+  const int filter_height = params.filter_height;
+  const int filter_width = params.filter_width;
+  const int pad_height = params.padding_values.height;
+  const int pad_width = params.padding_values.width;
+  const int stride_height = params.stride_height;
+  const int stride_width = params.stride_width;
+
+  const auto in_mat = MapAsMatrixWithLastDimAsRows(input_data, input_shape);
+  auto out_mat = MapAsMatrixWithLastDimAsRows(output_data, output_shape);
+  auto arg_max_index_mat = MapAsMatrixWithLastDimAsRows(arg_max_index, output_shape);
+
+  // initialize output area
+  std::fill(output_data, output_data + output_shape.FlatSize(), 0.0);
+  std::fill(arg_max_index, arg_max_index + output_shape.FlatSize(), -1);
+
+  // initialize projected area with lowest float
+  const int h_start =
+    (pad_height < filter_height) ? 0 : (pad_height - filter_height) / stride_height + 1;
+  const int h_end = std::min((input_height + pad_height - 1) / stride_height + 1, output_height);
+
+  const int w_start =
+    (pad_width < filter_width) ? 0 : (pad_width - filter_width) / stride_width + 1;
+  const int w_end = std::min((input_width + pad_width - 1) / stride_width + 1, output_width);
+
+  for (int b = 0; b < batches; ++b)
+  {
+    for (int h_idx = h_start; h_idx < h_end; h_idx++)
+    {
+      for (int w_idx = w_start; w_idx < w_end; w_idx++)
+      {
+        const int offset = NodeOffset(b, h_idx, w_idx, output_height, output_width);
+        out_mat.col(offset).setConstant(std::numeric_limits<float>::lowest());
+      }
+    }
+  }
+
+  for (int b = 0; b < batches; ++b)
+  {
+    for (int h = 0; h < input_height; ++h)
+    {
+      for (int w = 0; w < input_width; ++w)
+      {
+        // (h_start, h_end) * (w_start, w_end) is the range that the input
+        // vector projects to.
+        int hpad = h + pad_height;
+        int wpad = w + pad_width;
+
+        int h_start = (hpad < filter_height) ? 0 : (hpad - filter_height) / stride_height + 1;
+        int h_end = std::min(hpad / stride_height + 1, output_height);
+
+        int w_start = (wpad < filter_width) ? 0 : (wpad - filter_width) / stride_width + 1;
+        int w_end = std::min(wpad / stride_width + 1, output_width);
+
+        // compute elementwise sum
+        for (int ph = h_start; ph < h_end; ++ph)
+        {
+          for (int pw = w_start; pw < w_end; ++pw)
+          {
+            const int out_offset = NodeOffset(b, ph, pw, output_height, output_width);
+            const int in_offset = NodeOffset(b, h, w, input_height, input_width);
+
+            const auto out_vector = out_mat.col(out_offset);
+            const auto in_vector = in_mat.col(in_offset);
+
+            // update arg_max_index_mat
+            arg_max_index_mat.col(out_offset) =
+              (out_vector.array() < in_vector.array())
+                .select(in_offset, arg_max_index_mat.col(out_offset));
+
+            // update out_mat
+            out_mat.col(out_offset) = out_vector.cwiseMax(in_vector);
+          }
+        }
+      }
+    }
+  }
+
+  out_mat.cwiseMin(params.float_activation_min).cwiseMax(params.float_activation_max);
+}
+
+inline void MaxPool2DGrad(const Shape &deriv_output_shape, const float *deriv_output_data,
+                          const int *arg_max_index, const Shape &deriv_input_shape,
+                          float *deriv_input_data)
+{
+  assert(deriv_input_shape.DimensionsCount() == 4);
+  assert(deriv_output_shape.DimensionsCount() == 4);
+
+  // initialize deriv_input_data
+  std::fill(deriv_input_data, deriv_input_data + deriv_input_shape.FlatSize(), 0.0);
+
+  const int depth = MatchingDim(deriv_input_shape, 3, deriv_output_shape, 3);
+  const auto deriv_out_mat = MapAsMatrixWithLastDimAsRows(deriv_output_data, deriv_output_shape);
+  auto arg_max_index_mat = MapAsMatrixWithLastDimAsRows(arg_max_index, deriv_output_shape);
+  auto deriv_in_mat = MapAsMatrixWithLastDimAsRows(deriv_input_data, deriv_input_shape);
+
+  for (int col_index = 0; col_index < deriv_out_mat.cols(); col_index++)
+  {
+    auto arg_indices = arg_max_index_mat.col(col_index);
+    for (int d = 0; d < depth; d++)
+    {
+      // output value is from padding, so nothing to propagate
+      if (arg_indices(d) == -1)
+        continue;
+
+      deriv_in_mat(d, arg_indices(d)) += deriv_out_mat(d, col_index);
+    }
+  }
+}
+
+} // namespace train
+} // namespace cker
+} // namespace nnfw
+
+#endif // __NNFW_CKER_TRAIN_OPERATION_MAXPOOL_H__

--- a/compute/cker/src/train/MaxPool.test.cc
+++ b/compute/cker/src/train/MaxPool.test.cc
@@ -1,0 +1,279 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cker/eigen/Utils.h>
+#include <cker/operation/MaxPool.h>
+#include <cker/train/operation/MaxPool.h>
+#include <cker/Shape.h>
+
+#include <gtest/gtest.h>
+#include <vector>
+
+namespace
+{
+using namespace nnfw::cker;
+
+template <typename T> class MaxPoolOpVerifier
+{
+private:
+  const PoolParams _op_params;
+  const Shape _in_shape;
+  const Shape _out_shape;
+  std::vector<int> _arg_max_index;
+
+public:
+  MaxPoolOpVerifier(const nnfw::cker::PoolParams &op_params, const Shape &in_shape,
+                    const Shape &out_shape)
+    : _op_params(op_params), _in_shape(in_shape), _out_shape(out_shape)
+  {
+    _arg_max_index.reserve(_out_shape.FlatSize());
+  }
+
+public:
+  void verifyForward(const std::vector<T> input, const std::vector<T> expected_output,
+                     bool expect_eq = true)
+  {
+    assert(input.size() == _in_shape.FlatSize());
+    assert(expected_output.size() == _out_shape.FlatSize());
+
+    std::vector<T> cacluated_output(_out_shape.FlatSize());
+    nnfw::cker::train::MaxPool2D(_op_params, _in_shape, input.data(), _out_shape,
+                                 cacluated_output.data(), _arg_max_index.data());
+
+    if (expect_eq)
+      EXPECT_EQ(expected_output, cacluated_output);
+    else
+      EXPECT_NE(expected_output, cacluated_output);
+  }
+
+  void verifyBackward(const std::vector<T> deriv_output, const std::vector<T> expected_deriv_input,
+                      bool expect_eq = true)
+  {
+    assert(deriv_output.size() == _out_shape.FlatSize());
+    assert(expected_deriv_input.size() == _in_shape.FlatSize());
+
+    std::vector<T> calcuated_deriv(_in_shape.FlatSize());
+    nnfw::cker::train::MaxPool2DGrad(_out_shape, deriv_output.data(), _arg_max_index.data(),
+                                     _in_shape, calcuated_deriv.data());
+
+    if (expect_eq)
+      EXPECT_EQ(expected_deriv_input, calcuated_deriv);
+    else
+      EXPECT_NE(expected_deriv_input, calcuated_deriv);
+  }
+};
+
+} // namespace
+
+TEST(CKer_Operation, MaxPool2D)
+{
+  // Depth 1 case
+  {
+    nnfw::cker::PoolParams op_param;
+    {
+      op_param.stride_height = 1;
+      op_param.stride_width = 1;
+      op_param.filter_height = 2;
+      op_param.filter_width = 2;
+      op_param.padding_values.height = 0;
+      op_param.padding_values.width = 0;
+    }
+    nnfw::cker::Shape in = {1, 3, 3, 1};
+    nnfw::cker::Shape out = {1, 2, 2, 1};
+
+    MaxPoolOpVerifier<float> verifier(op_param, in, out);
+
+    /**
+     *  input(index) :                         output(arg-index):
+     *
+     *  10(0)  15(1)   2(2)
+     *   7(3)   8(4)   9(5)   - (forward) ->   15(1)  15(1)
+     *  10(6)   1(7)   0(8)                    10(6)   9(5)
+     */
+
+    std::vector<float> input = {10, 15, 2, 7, 8, 9, 10, 1, 0};
+    std::vector<float> expected_output = {15, 15, 10, 9};
+    verifier.verifyForward(input, expected_output);
+
+    /**
+     *  output_deriv:                     input_deriv:
+     * (randomly filled)
+     *
+     *   0.1   0.2                        0     0.3   0
+     *   0.3   0.4     - (backward) ->    0     0     0.4
+     *                                    0.3   0     0
+     */
+
+    std::vector<float> output_deriv = {0.1, 0.2, 0.3, 0.4};
+    std::vector<float> expected_input_deriv = {0, 0.3, 0, 0, 0, 0.4, 0.3, 0, 0};
+    verifier.verifyBackward(output_deriv, expected_input_deriv);
+  }
+
+  // Depth 2 case
+  {
+    nnfw::cker::PoolParams op_param;
+    {
+      op_param.stride_height = 1;
+      op_param.stride_width = 1;
+      op_param.filter_height = 3;
+      op_param.filter_width = 3;
+      op_param.padding_values.height = 0;
+      op_param.padding_values.width = 0;
+    }
+    nnfw::cker::Shape in = {1, 3, 3, 2};
+    nnfw::cker::Shape out = {1, 1, 1, 2};
+
+    MaxPoolOpVerifier<float> verifier(op_param, in, out);
+
+    /**
+     *  depth[0]
+     *  input(index) :                     output(arg-index):
+     *
+     *  10(0)  15(1)  2(2)
+     *  10(3)  12(4)  17(5)   -(forward)->     50(6)
+     *  50(6)  34(7)  -2(8)
+     *
+     *
+     *  depth[1]
+     *  input(index):                      output(arg-index):
+     *
+     *  -1(0)  2(1)  3(2)
+     *  8(3)   9(4)  2(5)    -(forward)->       9(4)
+     *  4(6)   2(7)  1(8)
+     */
+
+    std::vector<float> input(in.FlatSize());
+    auto input_mat = MapAsMatrixWithLastDimAsRows(input.data(), in);
+    input_mat << /* depth0 */ 10, 15, 2, 10, 12, 17, 50, 34, -2,
+      /* depth1 */ -1, 2, 3, 8, 9, 2, 4, 2, 1;
+    std::vector<float> expected_output = {50, 9};
+    verifier.verifyForward(input, expected_output);
+
+    /**
+     * depth[0]
+     * ouput_deriv:                 input_deriv:
+     *
+     *                              0   0   0
+     *    0.5     -(backward)->     0   0   0
+     *                             0.5  0   0
+     *
+     *
+     * depth[1]
+     * output_deriv:                input_deriv:
+     *                              0   0   0
+     *    0.9     -(backward)->     0  0.9  0
+     *                              0   0   0
+     */
+
+    std::vector<float> output_deriv = {0.5, 0.9};
+    std::vector<float> expected_input_deriv(in.FlatSize());
+    auto input_deriv_mat = MapAsMatrixWithLastDimAsRows(expected_input_deriv.data(), in);
+    input_deriv_mat << /* depth0 */ 0, 0, 0, 0, 0, 0, 0.5, 0, 0,
+      /* depth1 */ 0, 0, 0, 0, 0.9, 0, 0, 0, 0;
+    verifier.verifyBackward(output_deriv, expected_input_deriv);
+  }
+
+  // with padding case
+  {
+    nnfw::cker::PoolParams op_param;
+    {
+      op_param.stride_height = 2;
+      op_param.stride_width = 2;
+      op_param.filter_height = 2;
+      op_param.filter_width = 2;
+      op_param.padding_values.height = 2;
+      op_param.padding_values.width = 2;
+    }
+    nnfw::cker::Shape in = {1, 2, 2, 1};
+    nnfw::cker::Shape out = {1, 3, 3, 1};
+
+    MaxPoolOpVerifier<float> verifier(op_param, in, out);
+
+    /**
+     * input_with_padding:             expected_output:
+     *
+     *    4   8                              0  0  0
+     *    9   2            -(forward)->      0  9  0
+     *                                       0  0  0
+     */
+
+    std::vector<float> input = {4, 8, 9, 2};
+    std::vector<float> expected_output = {0, 0, 0, 0, 9, 0, 0, 0, 0};
+    verifier.verifyForward(input, expected_output);
+
+    /**
+     * output_deriv:                    input_deriv:
+     *
+     *  0.1   0.1   0.1                     0     0
+     *  0.1   0.2   0.3   -(backward)->     0.2   0
+     *  0.5   0.1   0.1
+     */
+    std::vector<float> output_deriv = {0.1, 0.1, 0.1, 0.1, 0.2, 0.3, 0.5, 0.1, 0.1};
+    std::vector<float> expected_input_deriv = {0, 0, 0.2, 0};
+    verifier.verifyBackward(output_deriv, expected_input_deriv);
+  }
+}
+
+TEST(CKer_Operation, neg_MaxPool)
+{
+  // Invalid expected value
+  {
+    nnfw::cker::PoolParams op_param;
+    {
+      op_param.stride_height = 1;
+      op_param.stride_width = 1;
+      op_param.filter_height = 2;
+      op_param.filter_width = 2;
+      op_param.padding_values.height = 0;
+      op_param.padding_values.width = 0;
+    }
+    nnfw::cker::Shape in = {1, 2, 2, 1};
+    nnfw::cker::Shape out = {1, 1, 1, 1};
+
+    MaxPoolOpVerifier<float> verifier(op_param, in, out);
+
+    std::vector<float> input = {0, 0, 0, 0};
+    std::vector<float> expected_output = {-1};
+
+    verifier.verifyForward(input, expected_output, false);
+  }
+
+  // Invalid expected value
+  {
+    nnfw::cker::PoolParams op_param;
+    {
+      op_param.stride_height = 2;
+      op_param.stride_width = 2;
+      op_param.filter_height = 2;
+      op_param.filter_width = 2;
+      op_param.padding_values.height = 1;
+      op_param.padding_values.width = 1;
+    }
+
+    nnfw::cker::Shape in = {1, 2, 2, 1};
+    nnfw::cker::Shape out = {1, 2, 2, 1};
+
+    MaxPoolOpVerifier<float> verifier(op_param, in, out);
+
+    std::vector<float> input = {0, 0, 0, 0};
+    std::vector<float> expected_output = {0, 0, 0, 0};
+    verifier.verifyForward(input, expected_output);
+
+    std::vector<float> output_deriv = {0.1, 0.1, 0.1, 0.2};
+    std::vector<float> expected_input_deriv = {0.1, 0.1, 0.1, 0.1};
+    verifier.verifyBackward(output_deriv, expected_input_deriv, false);
+  }
+}

--- a/runtime/onert/backend/cpu/ops/PoolLayer.h
+++ b/runtime/onert/backend/cpu/ops/PoolLayer.h
@@ -53,10 +53,11 @@ public:
 
   void run() override;
 
-private:
+protected:
   const IPortableTensor *_input;
   IPortableTensor *_output;
 
+private:
   std::function<void(const IPortableTensor *, IPortableTensor *)> _kernel;
 };
 

--- a/runtime/onert/backend/train/KernelGenerator.h
+++ b/runtime/onert/backend/train/KernelGenerator.h
@@ -50,6 +50,7 @@ public:
   void visit(const ir::train::operation::ElementwiseActivation &) override;
   void visit(const ir::train::operation::FullyConnected &) override;
   void visit(const ir::train::operation::Loss &) override;
+  void visit(const ir::train::operation::Pool2D &) override;
   void visit(const ir::train::operation::Reshape &node) override;
 
 private:

--- a/runtime/onert/backend/train/ops/PoolLayer.cc
+++ b/runtime/onert/backend/train/ops/PoolLayer.cc
@@ -15,6 +15,12 @@
  */
 
 #include "PoolLayer.h"
+#include "OperationUtils.h"
+#include "../Tensor.h"
+
+#include <cker/Utils.h>
+#include <cker/train/operation/MaxPool.h>
+#include <cker/train/operation/ReLU.h>
 
 namespace onert
 {
@@ -25,7 +31,106 @@ namespace train
 namespace ops
 {
 
-PoolLayer::PoolLayer() : cpu::ops::PoolLayer()
+namespace
+{
+
+cpu::ops::PoolType convertToInfer(const train::ops::PoolType &pool_type)
+{
+  switch (pool_type)
+  {
+    case train::ops::PoolType::kMax:
+      return cpu::ops::PoolType::kMax;
+    default:
+      throw std::runtime_error("PoolLayer: Unsupported pool type yet");
+  }
+}
+
+class MaxPool2D final : public TrainingKernelRegistry
+{
+private:
+  const ir::Activation _activation;
+  const IPortableTensor *_output;
+  nnfw::cker::PoolParams _op_params;
+
+  std::unique_ptr<Tensor> _act_deriv_output;
+  std::unique_ptr<Tensor> _arg_max_index;
+
+public:
+  MaxPool2D(const uint32_t paddingLeft, const uint32_t, const uint32_t, const uint32_t paddingTop,
+            const uint32_t strideWidth, const uint32_t strideHeight, const uint32_t kernelWidth,
+            const uint32_t kernelHeight, const ir::Activation activation,
+            const IPortableTensor *output)
+    : _activation(activation), _output(output)
+  {
+    {
+      _op_params.stride_height = strideHeight;
+      _op_params.stride_width = strideWidth;
+      _op_params.filter_height = kernelHeight;
+      _op_params.filter_width = kernelWidth;
+      _op_params.padding_values.height = (int8_t)paddingTop;
+      _op_params.padding_values.width = (int8_t)paddingLeft;
+      CalculateActivationRange<float>(activation, &_op_params.float_activation_min,
+                                      &_op_params.float_activation_max);
+    }
+
+    _arg_max_index = std::make_unique<Tensor>(_output->get_info(), _output->layout());
+    _arg_max_index->setBuffer(std::make_shared<basic::Allocator>(_output->total_size()));
+
+    if (activation != ir::Activation::NONE)
+    {
+      _act_deriv_output = std::make_unique<Tensor>(_output->get_info(), _output->layout());
+      _act_deriv_output->setBuffer(std::make_shared<basic::Allocator>(_output->total_size()));
+    }
+  };
+
+  ~MaxPool2D() {}
+
+public:
+  void forward(const IPortableTensor *in, IPortableTensor *out)
+  {
+    assert(in->layout() == ir::Layout::NHWC);
+
+    auto out_shape = getShape(out);
+    auto out_data = getBuffer<float>(out);
+    auto arg_max_index = _arg_max_index.get();
+
+    // maxpool forward
+    nnfw::cker::train::MaxPool2D(_op_params, getShape(in), getBuffer<float>(in), out_shape,
+                                 out_data, getBuffer<int>(arg_max_index));
+  }
+
+  void backward(const IPortableTensor *deriv_out, IPortableTensor *deriv_in)
+  {
+    assert(deriv_out->layout() == ir::Layout::NHWC);
+
+    // activation bacward
+    switch (_activation)
+    {
+      case ir::Activation::NONE:
+        break;
+      case ir::Activation::RELU:
+        nnfw::cker::train::ReLUGrad(getShape(_output), getBuffer<float>(_output),
+                                    getShape(deriv_out), getBuffer<float>(deriv_out),
+                                    getShape(_act_deriv_output.get()),
+                                    getBuffer<float>(_act_deriv_output.get()));
+        deriv_out = _act_deriv_output.get();
+        break;
+      default:
+        throw std::runtime_error("PoolLayer: Unsupported activation type yet");
+    }
+
+    // maxpool baackward
+    auto arg_max_index = _arg_max_index.get();
+    nnfw::cker::train::MaxPool2DGrad(getShape(deriv_out), getBuffer<float>(deriv_out),
+                                     getBuffer<int>(arg_max_index), getShape(deriv_in),
+                                     getBuffer<float>(deriv_in));
+  }
+};
+
+} // namespace
+
+PoolLayer::PoolLayer()
+  : cpu::ops::PoolLayer(), _deriv_input(nullptr), _deriv_output(nullptr), _kernel(nullptr)
 {
   // DO NOTHING
 }
@@ -35,14 +140,32 @@ void PoolLayer::configure(const IPortableTensor *input, const uint32_t paddingLe
                           const uint32_t paddingBottom, const uint32_t strideWidth,
                           const uint32_t strideHeight, const uint32_t kernelWidth,
                           const uint32_t kernelHeight, const ir::Activation activation,
-                          IPortableTensor *output, const PoolType op_type)
+                          IPortableTensor *output, const PoolType op_type,
+                          IPortableTensor *deriv_input, const IPortableTensor *deriv_output)
 {
+  _input = input;
+  _output = output;
+
+  _deriv_output = deriv_output;
+  _deriv_input = deriv_input;
+
+  // ready inference kernel
+  cpu::ops::PoolLayer::configure(input, paddingLeft, paddingRight, paddingTop, paddingBottom,
+                                 strideWidth, strideHeight, kernelWidth, kernelHeight, activation,
+                                 output, convertToInfer(op_type));
+
+  if (output->data_type() != OperandType::FLOAT32)
+  {
+    throw std::runtime_error("PoolLayer : Unsupported data type for training");
+  }
+
+  // ready training kernel
   switch (op_type)
   {
     case PoolType::kMax:
-      cpu::ops::PoolLayer::configure(input, paddingLeft, paddingRight, paddingTop, paddingBottom,
-                                     strideWidth, strideHeight, kernelWidth, kernelHeight,
-                                     activation, output, cpu::ops::PoolType::kMax);
+      _kernel = std::make_unique<MaxPool2D>(paddingLeft, paddingRight, paddingTop, paddingBottom,
+                                            strideWidth, strideHeight, kernelWidth, kernelHeight,
+                                            activation, output);
       break;
     default:
       throw std::runtime_error("PoolLayer: Unsupported pool type");
@@ -53,7 +176,7 @@ void PoolLayer::forward(bool training)
 {
   if (training)
   {
-    // TODO Implement training pool layer
+    _kernel->forward(_input, _output);
   }
   else
   {
@@ -61,10 +184,7 @@ void PoolLayer::forward(bool training)
   }
 }
 
-void PoolLayer::backward()
-{
-  // TODO Implement detail
-}
+void PoolLayer::backward() { _kernel->backward(_deriv_output, _deriv_input); }
 
 } // namespace ops
 } // namespace train

--- a/runtime/onert/backend/train/ops/PoolLayer.h
+++ b/runtime/onert/backend/train/ops/PoolLayer.h
@@ -30,6 +30,18 @@ namespace train
 namespace ops
 {
 
+/**
+ * This is to register the pair of (forward, backward) training kernel.
+ */
+class TrainingKernelRegistry
+{
+public:
+  virtual void forward(const IPortableTensor *in, IPortableTensor *out) = 0;
+  virtual void backward(const IPortableTensor *deriv_out, IPortableTensor *deriv_in) = 0;
+  TrainingKernelRegistry() = default;
+  virtual ~TrainingKernelRegistry() = default;
+};
+
 enum class PoolType
 {
   kMax,
@@ -46,9 +58,17 @@ public:
                  const uint32_t paddingBottom, const uint32_t strideWidth,
                  const uint32_t strideHeight, const uint32_t kernelWidth,
                  const uint32_t kernelHeight, const ir::Activation activation,
-                 IPortableTensor *output, const PoolType op_type);
+                 IPortableTensor *output, const PoolType op_type, IPortableTensor *deriv_input,
+                 const IPortableTensor *deriv_output);
+
   void forward(bool training) override;
   void backward() override;
+
+private:
+  IPortableTensor *_deriv_input;
+  const IPortableTensor *_deriv_output;
+
+  std::unique_ptr<TrainingKernelRegistry> _kernel;
 };
 
 } // namespace ops

--- a/runtime/onert/core/include/compiler/StaticShapeInferer.h
+++ b/runtime/onert/core/include/compiler/StaticShapeInferer.h
@@ -143,6 +143,7 @@ private:
   void visit(const ir::operation::Pack &op) override;
   void visit(const ir::operation::Pad &op) override;
   void visit(const ir::operation::Permute &op) override;
+  void visit(const ir::operation::Pool2D &op) override;
   void visit(const ir::operation::Pow &op) override;
   void visit(const ir::operation::Range &op) override;
   void visit(const ir::operation::Reduce &op) override;

--- a/runtime/onert/core/src/compiler/StaticShapeInferer.cc
+++ b/runtime/onert/core/src/compiler/StaticShapeInferer.cc
@@ -807,6 +807,26 @@ void StaticShapeInferer::visit(const ir::operation::Permute &op)
   output.info().shape(new_shape);
 }
 
+void StaticShapeInferer::visit(const ir::operation::Pool2D &op)
+{
+  auto &operands = _lowered_subg->graph().operands();
+
+  const auto layout = _lowered_subg->graph().layout();
+
+  const auto input_idx{op.getInputs().at(ir::operation::Pool2D::Input::INPUT)};
+  const auto &input = operands.at(input_idx);
+  if (input.info().shape().rank() != 4)
+  {
+    throw std::runtime_error(op.name() + ": supports only 4D tensor as input");
+  }
+
+  const auto output_idx = op.getOutputs().at(0);
+  ir::Operand &output = operands.at(output_idx);
+
+  ir::Shape new_shape = shape_inference::inferPoolShape(input.info().shape(), op.param(), layout);
+  output.info().shape(new_shape);
+}
+
 void StaticShapeInferer::visit(const ir::operation::Pow &op)
 {
   handleBinaryArithmeticOp(op, op.getInputs().at(ir::operation::Pow::Input::LHS),


### PR DESCRIPTION
This PR is to enable max2d PoolLayer for training.

This PR fills unimplemented part of PoolLayer: 

  * implements shape-inference visit() for pool2d
  * implelments kernel-generator visit() for pool2d
  * Implements train PoolLayer op's forward, backward functions and ckernel
  
ONE-DCO-1.0-Signed-off-by: SeungHui Youn <sseung.youn@samsung.com> 

---------------------------------------------------


related issue : https://github.com/Samsung/ONE/issues/11427 
from draft : https://github.com/Samsung/ONE/pull/11480  