### PR TITLE
[circle-mpqsolver] Introduce PatternSolver

### DIFF
--- a/compiler/circle-mpqsolver/src/MPQSolver.cpp
+++ b/compiler/circle-mpqsolver/src/MPQSolver.cpp
@@ -16,15 +16,10 @@
 
 #include "MPQSolver.h"
 
-#include "pattern/PatternResolver.h"
-
 #include <luci/ImporterEx.h>
 #include <iostream>
 
 using namespace mpqsolver;
-
-using LayerParam = luci::CircleQuantizer::Options::LayerParam;
-using LayerParams = luci::CircleQuantizer::Options::LayerParams;
 
 MPQSolver::MPQSolver(const std::string &input_data_path, float qerror_ratio,
                      const std::string &input_quantization, const std::string &output_quantization)
@@ -37,53 +32,6 @@ MPQSolver::MPQSolver(const std::string &input_data_path, float qerror_ratio,
 void MPQSolver::set_save_intermediate(const std::string &save_path)
 {
   _hooks = std::make_unique<core::DumpingHooks>(save_path);
-}
-
-void MPQSolver::set_mpq_options(MPQOptions &options) { _options = options; }
-
-LayerParams MPQSolver::get_frozen_params() const
-{
-  LayerParams params;
-  for (auto node_to_param : _frozen._node_to_param)
-  {
-    params.push_back(std::make_shared<LayerParam>(node_to_param.second));
-  }
-
-  return params;
-}
-
-void MPQSolver::resolve_patterns(luci::Module *module)
-{
-  _frozen._node_to_param.clear();
-
-  for (auto pattern : _options._patterns)
-  {
-    std::unique_ptr<pattern::PatternResolver> resolver;
-    switch (pattern)
-    {
-      case QuantizationPattern::Q8LayerNormWithQ16Variance:
-        resolver = std::make_unique<pattern::Q8LayerNormWithQ16VarianceResolver>();
-        break;
-      default:
-        throw std::runtime_error("Unsupported pattern to resolve");
-    }
-
-    auto const resolved = resolver->resolve(module);
-    for (auto node_param : resolved)
-    {
-      auto const frozen = _frozen._node_to_param.find(node_param.first);
-      if (frozen == _frozen._node_to_param.end())
-      {
-        // node was not previously defined - just set it (no ambiguity)
-        _frozen._node_to_param[node_param.first] = node_param.second;
-      }
-      else if (frozen->second.dtype != node_param.second.dtype)
-      {
-        // ambiguity (incoming description conflicts with current)
-        throw std::runtime_error("Resolved patterns contradict each other");
-      }
-    }
-  }
 }
 
 std::unique_ptr<luci::Module> MPQSolver::read_module(const std::string &path)

--- a/compiler/circle-mpqsolver/src/MPQSolver.h
+++ b/compiler/circle-mpqsolver/src/MPQSolver.h
@@ -22,28 +22,11 @@
 
 #include <luci/IR/CircleNodes.h>
 
-#include <map>
 #include <memory>
 #include <string>
-#include <vector>
 
 namespace mpqsolver
 {
-
-enum class QuantizationPattern
-{
-  Q8LayerNormWithQ16Variance
-};
-
-struct MPQOptions
-{
-  std::vector<QuantizationPattern> _patterns;
-};
-
-struct FrozenNodes
-{
-  std::map<luci::CircleNode *, luci::CircleQuantizer::Options::LayerParam> _node_to_param;
-};
 
 class MPQSolver
 {
@@ -70,33 +53,11 @@ public:
 protected:
   std::unique_ptr<luci::Module> read_module(const std::string &path);
 
-  /**
-   * @brief set quantization options
-   */
-  void set_mpq_options(MPQOptions &options);
-
-  /**
-   * @brief fill _frozen with prescribed quantization parameters of resolved nodes
-   */
-  void resolve_patterns(luci::Module *module);
-
-  /**
-   * @brief resolve Q8LayerNormWithQ16Variance pattern
-   */
-  void resolve_layer_norm_pattern(luci::Module *module);
-
-  /**
-   * @brief transform _frozen nodes to Quantizer friendly form
-   */
-  luci::CircleQuantizer::Options::LayerParams get_frozen_params() const;
-
 protected:
   std::string _input_data_path;
   std::string _input_quantization;
   std::string _output_quantization;
   std::unique_ptr<core::Quantizer> _quantizer;
-  MPQOptions _options;       // options for mpq quantization
-  FrozenNodes _frozen;       // nodes with prescribed quantization parameters
   float _qerror_ratio = 0.f; // quantization error ratio
   std::unique_ptr<core::DumpingHooks> _hooks;
 };

--- a/compiler/circle-mpqsolver/src/pattern/PatternSolver.cpp
+++ b/compiler/circle-mpqsolver/src/pattern/PatternSolver.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "PatternSolver.h"
+
+#include <iostream>
+
+using namespace mpqsolver::pattern;
+
+PatternSolver::PatternSolver(const std::string &input_quantization,
+                             const std::string &output_quantization,
+                             const std::vector<QuantizationPattern> &patterns)
+  : MPQSolver("", 1.f, input_quantization, output_quantization)
+{
+  MPQOptions options{patterns};
+  set_mpq_options(options);
+}
+
+std::unique_ptr<luci::Module> PatternSolver::run(const std::string &module_path)
+{
+  auto module = read_module(module_path);
+
+  resolve_patterns(module.get());
+
+  auto layer_params = get_frozen_params();
+
+  if (!_quantizer->quantize(module.get(), "uint8", layer_params))
+  {
+    std::cerr << "ERROR: Failed to quantize model" << std::endl;
+    return nullptr;
+  }
+
+  return module;
+}

--- a/compiler/circle-mpqsolver/src/pattern/PatternSolver.cpp
+++ b/compiler/circle-mpqsolver/src/pattern/PatternSolver.cpp
@@ -37,6 +37,10 @@ PatternSolver::PatternSolver(const std::string &input_quantization,
 std::unique_ptr<luci::Module> PatternSolver::run(const std::string &module_path)
 {
   auto module = read_module(module_path);
+  if (!module)
+  {
+    throw std::runtime_error("Failed to load model");
+  }
 
   resolve_patterns(module.get());
 
@@ -44,8 +48,7 @@ std::unique_ptr<luci::Module> PatternSolver::run(const std::string &module_path)
 
   if (!_quantizer->quantize(module.get(), "uint8", layer_params))
   {
-    std::cerr << "ERROR: Failed to quantize model" << std::endl;
-    return nullptr;
+    throw std::runtime_error("Failed to quantize model");
   }
 
   return module;

--- a/compiler/circle-mpqsolver/src/pattern/PatternSolver.h
+++ b/compiler/circle-mpqsolver/src/pattern/PatternSolver.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __MPQSOLVER_PATTERN_SOLVER_H__
+#define __MPQSOLVER_PATTERN_SOLVER_H__
+
+#include "MPQSolver.h"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace mpqsolver
+{
+namespace pattern
+{
+
+class PatternSolver final : public MPQSolver
+{
+public:
+  /**
+   * @brief construct PatternSolver using input_quantization/output_quantization to set
+   * quantization type at input/output respectively and patterns to apply
+   */
+  PatternSolver(const std::string &input_quantization, const std::string &output_quantization,
+                const std::vector<QuantizationPattern> &patterns);
+
+  /**
+   * @brief run solver for recorded float module at module_path
+   */
+  std::unique_ptr<luci::Module> run(const std::string &module_path) override;
+};
+
+} // namespace pattern
+} // namespace mpqsolver
+
+#endif //__MPQSOLVER_PATTERN_SOLVER_H__


### PR DESCRIPTION
This commit introduces PatternSolver
to get optimal mixed precision model.

Its correctness is tested at https://github.com/Samsung/ONE/pull/11560.

Draft: https://github.com/Samsung/ONE/pull/11560
Related: https://github.com/Samsung/ONE/issues/11543

ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>