### PR TITLE
[circle-mpqsolver] Add evaluator unittest

### DIFF
--- a/compiler/circle-mpqsolver/CMakeLists.txt
+++ b/compiler/circle-mpqsolver/CMakeLists.txt
@@ -40,6 +40,7 @@ set(TEST_SOURCES
     "src/pattern/PatternResolver.cpp"
     "src/core/Dumper.cpp"
     "src/core/DumpingHooks.cpp"
+    "src/core/Evaluator.cpp"
 )
 
 nnas_find_package(GTest REQUIRED)
@@ -51,3 +52,5 @@ target_link_libraries(circle_mpqsolver_test luci_service)
 target_link_libraries(circle_mpqsolver_test luci_pass)
 target_link_libraries(circle_mpqsolver_test luci_testhelper)
 target_link_libraries(circle_mpqsolver_test luci_export)
+target_link_libraries(circle_mpqsolver_test luci_interpreter)
+target_link_libraries(circle_mpqsolver_test dio_hdf5)

--- a/compiler/circle-mpqsolver/src/core/Evaluator.test.cpp
+++ b/compiler/circle-mpqsolver/src/core/Evaluator.test.cpp
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "Evaluator.h"
+
+TEST(CircleMPQSolverEvaluatorTest, empty_path_NEG)
+{
+  mpqsolver::core::MAEMetric metric;
+  EXPECT_ANY_THROW(mpqsolver::core::DatasetEvaluator evaluator(nullptr, "", metric));
+}


### PR DESCRIPTION
This commit adds negative unit test for Evaluator
to increase test converage.

ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>