### PR TITLE
[luci/pass] Implement Softmax decomposing pass

### DIFF
--- a/compiler/luci/pass/include/luci/CircleOptimizer.h
+++ b/compiler/luci/pass/include/luci/CircleOptimizer.h
@@ -83,6 +83,7 @@ public:
       TransformMinMaxToRelu6Pass,
       TransformMinReluToRelu6Pass,
       DecomposeHardSwishPass,
+      DecomposeSoftmaxPass,
       SubstituteStridedSliceToReshape,
       SubstituteTransposeToReshape,
       RemoveRedundantQuantize,

--- a/compiler/luci/pass/include/luci/Pass/DecomposeSoftmaxPass.h
+++ b/compiler/luci/pass/include/luci/Pass/DecomposeSoftmaxPass.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __LUCI_DECOMPOSE_SOFTMAX_PASS_H__
+#define __LUCI_DECOMPOSE_SOFTMAX_PASS_H__
+
+#include <logo/Pass.h>
+
+namespace luci
+{
+
+/**
+ * @brief  Class to decompose Softmax into backend friendly structures
+ */
+struct DecomposeSoftmaxPass final : public logo::Pass
+{
+  const char *name(void) const final { return "luci::DecomposeSoftmaxPass"; }
+
+  bool run(loco::Graph *g) final;
+};
+
+} // namespace luci
+
+#endif // __LUCI_DECOMPOSE_SOFTMAX_PASS_H__

--- a/compiler/luci/pass/src/CircleOptimizer.cpp
+++ b/compiler/luci/pass/src/CircleOptimizer.cpp
@@ -73,6 +73,7 @@
 #include "luci/Pass/TransformMinMaxToRelu6Pass.h"
 #include "luci/Pass/TransformMinReluToRelu6Pass.h"
 #include "luci/Pass/DecomposeHardSwishPass.h"
+#include "luci/Pass/DecomposeSoftmaxPass.h"
 #include "luci/Pass/UnrollUnidirectionalSequenceLSTMPass.h"
 #include "luci/Pass/XpSepActFromTransposeConvPass.h"
 // TODO add more passes
@@ -443,6 +444,10 @@ void CircleOptimizer::optimize(loco::Graph *g) const
   if (_options->query(Options::Algorithm::DecomposeHardSwishPass))
   {
     phase.emplace_back(std::make_unique<luci::DecomposeHardSwishPass>());
+  }
+  if (_options->query(Options::Algorithm::DecomposeSoftmaxPass))
+  {
+    phase.emplace_back(std::make_unique<luci::DecomposeSoftmaxPass>());
   }
   if (_options->query(Options::Algorithm::UnrollUnidirSeqLSTM))
   {

--- a/compiler/luci/pass/src/DecomposeSoftmaxPass.cpp
+++ b/compiler/luci/pass/src/DecomposeSoftmaxPass.cpp
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Pass/DecomposeSoftmaxPass.h"
+
+#include <luci/IR/CircleNodes.h>
+#include <luci/Profile/CircleNodeOrigin.h>
+
+namespace
+{
+/**
+ *  BEFORE
+ *        [CircleNode]
+ *              |
+ *              |
+ *      [CircleSoftmax]
+ *              |
+ *              |
+ *        [CircleNode]
+ *
+ *
+ *  AFTER
+ *
+ *      [CircleNode]   [CircleConst(=-1)]
+ *          |    \       /           |
+ *          |     \     /            |
+ *          | [CircleReduceMax]      |
+ *          |    /                   |
+ *          |   /                    |
+ *          |  /                     |
+ *        [Sub]                      |
+ *          |                        |
+ *          | [CircleConst(=beta)]   |
+ *          |   /                    |
+ *          |  /                     |
+ *        [Mul] (if beta != 1)       |
+ *          |                        |
+ *        [Exp]                      |
+ *          | \                      |
+ *          |  \                     |
+ *          |  [CircleSum]-----------+
+ *          |  /
+ *          | /
+ *        [Div]
+ *          |
+ *          |
+ *      [CircleNode]
+ */
+bool decompose_softmax(luci::CircleSoftmax *softmax)
+{
+  if (!softmax)
+    return false;
+
+  if (softmax->dtype() != loco::DataType::FLOAT32)
+    return false;
+
+  auto const input = loco::must_cast<luci::CircleNode *>(softmax->logits());
+  auto g = softmax->graph();
+
+  auto const beta = softmax->beta();
+  auto const name = softmax->name();
+  assert(name.length() > 0);
+
+  // fill reduction index (-1) for CircleReduceMax and CircleSum
+  auto index_const = g->nodes()->create<luci::CircleConst>();
+  index_const->shape({}); // scalar
+  index_const->dtype(loco::DataType::S32);
+  index_const->rank(0);
+  index_const->size<loco::DataType::S32>(1);
+  index_const->at<loco::DataType::S32>(0) = -1;
+  index_const->name(name + "/Softmax/reduction_index");
+  luci::add_origin(index_const, luci::get_origin(softmax));
+
+  // Create CircleReduceMax operation
+  auto max = g->nodes()->create<luci::CircleReduceMax>();
+  max->input(input);
+  max->reduction_indices(index_const);
+  max->keep_dims(true);
+  max->name(name + "/Softmax/max");
+  luci::add_origin(max, luci::get_origin(softmax));
+
+  // Create CircleSub operation
+  auto sub = g->nodes()->create<luci::CircleSub>();
+  sub->x(input);
+  sub->y(max);
+  sub->fusedActivationFunction(luci::FusedActFunc::NONE);
+  sub->name(name + "/Softmax/sub");
+  luci::add_origin(sub, luci::get_origin(softmax));
+
+  // input for exp can be either sub or mul (in case beta != 1)
+  loco::Node *exp_input = sub;
+
+  // multiply sub by beta in case it is nonunit
+  if (std::abs(beta - 1.f) > 1.e-05f)
+  {
+    // Create constant for beta
+    auto beta_const = g->nodes()->create<luci::CircleConst>();
+    beta_const->shape({}); // scalar
+    beta_const->dtype(loco::DataType::FLOAT32);
+    beta_const->rank(0);
+    beta_const->size<loco::DataType::FLOAT32>(1);
+    beta_const->at<loco::DataType::FLOAT32>(0) = beta;
+    beta_const->name(name + "/Softmax/beta_const");
+    luci::add_origin(beta_const, luci::get_origin(softmax));
+
+    // Create CircleMul
+    auto mul = g->nodes()->create<luci::CircleMul>();
+    mul->x(sub);
+    mul->y(beta_const);
+    mul->fusedActivationFunction(luci::FusedActFunc::NONE);
+    mul->name(name + "/Softmax/beta_mul");
+    luci::add_origin(mul, luci::get_origin(softmax));
+
+    exp_input = mul;
+  }
+
+  // Create CircleExp operation
+  auto exp = g->nodes()->create<luci::CircleExp>();
+  exp->x(exp_input);
+  exp->name(name + "/Softmax/exp");
+  luci::add_origin(exp, luci::get_origin(softmax));
+
+  // Create CircleSum operation
+  auto sum = g->nodes()->create<luci::CircleSum>();
+  sum->input(exp);
+  sum->reduction_indices(index_const);
+  sum->keep_dims(true);
+  sum->name(name + "/Softmax/sum");
+  luci::add_origin(sum, luci::get_origin(softmax));
+
+  // Create CircleDiv operation
+  auto div = g->nodes()->create<luci::CircleDiv>();
+  div->x(exp);
+  div->y(sum);
+  div->fusedActivationFunction(luci::FusedActFunc::NONE);
+  div->name(name + "/Softmax/div");
+  luci::add_origin(div, luci::get_origin(softmax));
+
+  replace(softmax).with(div);
+
+  return true;
+}
+
+} // namespace
+
+namespace luci
+{
+
+bool DecomposeSoftmaxPass::run(loco::Graph *g)
+{
+  bool changed = false;
+
+  for (auto node : loco::active_nodes(loco::output_nodes(g)))
+  {
+    if (auto softmax = dynamic_cast<luci::CircleSoftmax *>(node))
+    {
+      if (decompose_softmax(softmax))
+        changed = true;
+    }
+  }
+
+  return changed;
+}
+
+} // namespace luci

--- a/compiler/luci/pass/src/DecomposeSoftmaxPass.test.cpp
+++ b/compiler/luci/pass/src/DecomposeSoftmaxPass.test.cpp
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Pass/DecomposeSoftmaxPass.h"
+
+#include <luci/IR/CircleNodes.h>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+
+/**
+ *  Softmax graph
+ *
+ *        [CircleInput]
+ *              |
+ *              |
+ *       [CircleSoftMax]
+ *              |
+ *              |
+ *        [CircleOutput]
+ */
+template <loco::DataType T> struct SoftmaxGraph
+{
+  loco::Graph _g;
+  luci::CircleInput *_input = nullptr;
+  luci::CircleSoftmax *_softmax = nullptr;
+  luci::CircleOutput *_output = nullptr;
+
+  SoftmaxGraph()
+  {
+    const int N = 1;
+    const int H = 4;
+    const int W = 4;
+    const int C = 3;
+
+    // graph input and output
+    auto graph_input = _g.inputs()->create();
+    auto graph_output = _g.outputs()->create();
+
+    // CircleInput
+    _input = _g.nodes()->create<luci::CircleInput>();
+    _input->index(graph_input->index());
+    _input->shape({N, H, W, C});
+    _input->dtype(T);
+    _input->name("input");
+
+    // CircleSoftmax
+    _softmax = _g.nodes()->create<luci::CircleSoftmax>();
+    _softmax->logits(_input);
+    _softmax->shape({N, H, W, C});
+    _softmax->dtype(T);
+    _softmax->name("softmax");
+    _softmax->beta(0.5f);
+
+    // CircleOutput
+    _output = _g.nodes()->create<luci::CircleOutput>();
+    _output->index(graph_output->index());
+    _output->from(_softmax);
+    _output->shape({N, H, W, C});
+    _output->dtype(T);
+    _output->name("output");
+  }
+};
+
+} // namespace
+
+TEST(DecomposeSoftmaxPass, simple_test)
+{
+  /**
+   *  tests:
+   *    1) decomposition pass has nonnull name
+   *    2) decomposition runs successfully for float32 softmax graph
+   *    3) resulting graph has the following structure:
+   *
+   *      [CircleNode]   [CircleConst(=-1)]
+   *          |    \       /           |
+   *          |     \     /            |
+   *          | [CircleReduceMax]      |
+   *          |    /                   |
+   *          |   /                    |
+   *          |  /                     |
+   *        [Sub]                      |
+   *          |                        |
+   *          | [CircleConst(=0.5)]    |
+   *          |   /                    |
+   *          |  /                     |
+   *        [Mul]                      |
+   *          |                        |
+   *        [Exp]                      |
+   *          | \                      |
+   *          |  \                     |
+   *          |  [CircleSum]-----------+
+   *          |  /
+   *          | /
+   *        [Div]
+   *          |
+   *          |
+   *      [CircleNode]
+   */
+  luci::DecomposeSoftmaxPass pass;
+  SoftmaxGraph<loco::DataType::FLOAT32> softmax_g;
+
+  auto const name = pass.name();
+  ASSERT_NE(nullptr, name);
+
+  auto ret = pass.run(&softmax_g._g);
+  EXPECT_TRUE(ret);
+
+  auto div = dynamic_cast<luci::CircleDiv *>(softmax_g._output->from());
+  EXPECT_NE(nullptr, div);
+
+  auto exp = dynamic_cast<luci::CircleExp *>(div->x());
+  EXPECT_NE(nullptr, exp);
+
+  auto sum = dynamic_cast<luci::CircleSum *>(div->y());
+  EXPECT_NE(nullptr, sum);
+
+  auto exp_1 = dynamic_cast<luci::CircleExp *>(sum->input());
+  EXPECT_EQ(exp, exp_1);
+
+  auto indices = dynamic_cast<luci::CircleConst *>(sum->reduction_indices());
+  EXPECT_NE(nullptr, indices);
+  EXPECT_EQ(indices->dtype(), loco::DataType::S32);
+  EXPECT_EQ(indices->size<loco::DataType::S32>(), 1);
+  EXPECT_EQ(indices->scalar<loco::DataType::S32>(), -1);
+
+  auto mul = dynamic_cast<luci::CircleMul *>(exp->x());
+  EXPECT_NE(nullptr, mul);
+
+  auto sub = dynamic_cast<luci::CircleSub *>(mul->x());
+  EXPECT_NE(nullptr, sub);
+
+  auto beta = dynamic_cast<luci::CircleConst *>(mul->y());
+  EXPECT_NE(nullptr, beta);
+  EXPECT_EQ(beta->dtype(), loco::DataType::FLOAT32);
+  EXPECT_EQ(beta->size<loco::DataType::FLOAT32>(), 1);
+  EXPECT_FLOAT_EQ(beta->scalar<loco::DataType::FLOAT32>(), 0.5f);
+
+  auto input = dynamic_cast<luci::CircleInput *>(sub->x());
+  EXPECT_NE(nullptr, input);
+
+  auto max = dynamic_cast<luci::CircleReduceMax *>(sub->y());
+  EXPECT_NE(nullptr, max);
+
+  auto indices_1 = dynamic_cast<luci::CircleConst *>(max->reduction_indices());
+  EXPECT_NE(nullptr, indices_1);
+  EXPECT_EQ(indices, indices_1);
+
+  auto input_1 = dynamic_cast<luci::CircleInput *>(max->input());
+  EXPECT_NE(nullptr, input_1);
+  EXPECT_EQ(input, input_1);
+}
+
+TEST(DecomposeSoftmaxPass, wrong_condition_NEG)
+{
+  luci::DecomposeSoftmaxPass pass;
+  SoftmaxGraph<loco::DataType::S32> softmax_g;
+
+  auto ret = pass.run(&softmax_g._g);
+  EXPECT_FALSE(ret);
+
+  auto softmax = dynamic_cast<luci::CircleSoftmax *>(softmax_g._output->from());
+  EXPECT_NE(nullptr, softmax);
+}


### PR DESCRIPTION
This commit implements decomposition of the Softmax operation to Max, Sub, Exp, Sum, Div and possibly Mul  operations.

Its correctness is tested at #11687.

Draft: #11687
Related: #11492
ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>