### PR TITLE
[circle-mpqsolver] Add BisectionSolver unittest

### DIFF
--- a/compiler/circle-mpqsolver/CMakeLists.txt
+++ b/compiler/circle-mpqsolver/CMakeLists.txt
@@ -41,6 +41,9 @@ set(TEST_SOURCES
     "src/core/Dumper.cpp"
     "src/core/DumpingHooks.cpp"
     "src/core/Evaluator.cpp"
+    "src/MPQSolver.cpp"
+    "src/core/SolverOutput.cpp"
+    "src/bisection/BisectionSolver.cpp"
 )
 
 nnas_find_package(GTest REQUIRED)
@@ -51,6 +54,7 @@ target_link_libraries(circle_mpqsolver_test ${Jsoncpp_STATIC_LIB})
 target_link_libraries(circle_mpqsolver_test luci_service)
 target_link_libraries(circle_mpqsolver_test luci_pass)
 target_link_libraries(circle_mpqsolver_test luci_testhelper)
+target_link_libraries(circle_mpqsolver_test luci_import)
 target_link_libraries(circle_mpqsolver_test luci_export)
 target_link_libraries(circle_mpqsolver_test luci_interpreter)
 target_link_libraries(circle_mpqsolver_test dio_hdf5)

--- a/compiler/circle-mpqsolver/src/bisection/BisectionSolver.test.cpp
+++ b/compiler/circle-mpqsolver/src/bisection/BisectionSolver.test.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "BisectionSolver.h"
+
+TEST(CircleMPQSolverBisectionSolverTest, empty_path_NEG)
+{
+  mpqsolver::bisection::BisectionSolver solver("", 0.0, "uint8", "uint8");
+  solver.algorithm(mpqsolver::bisection::BisectionSolver::Algorithm::ForceQ16Back);
+  auto const res = solver.run("");
+  EXPECT_TRUE(res.get() == nullptr);
+}


### PR DESCRIPTION
This commit adds negative unit test for BisectionSolver to increase test coverage.

ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>