### PR TITLE
[res] TensorFlowLiteRecipes for Softmax decomposition

### DIFF
--- a/res/TensorFlowLiteRecipes/Softmax_001/test.recipe
+++ b/res/TensorFlowLiteRecipes/Softmax_001/test.recipe
@@ -1,0 +1,20 @@
+operand {
+  name: "ifm"
+  type: FLOAT32
+  shape { dim: 1 dim: 16 dim: 16 dim: 128 }
+}
+operand {
+  name: "ofm"
+  type: FLOAT32
+  shape { dim: 1 dim: 16 dim: 16 dim: 128 }
+}
+operation {
+  type: "Softmax"
+  softmax_options {
+    beta: 1.0
+  }
+  input: "ifm"
+  output: "ofm"
+}
+input: "ifm"
+output: "ofm"

--- a/res/TensorFlowLiteRecipes/Softmax_001/test.rule
+++ b/res/TensorFlowLiteRecipes/Softmax_001/test.rule
@@ -1,0 +1,11 @@
+# To check if Softmax is converted to Max, Sub, Exp, Sum and Div operations
+
+RULE    "VERIFY_FILE_FORMAT"      $(verify_file_format) '=' 1
+
+RULE    "REDUCE_MAX_EXIST"        $(op_count REDUCE_MAX) '=' 1
+RULE    "SUB_EXIST"               $(op_count SUB) '=' 1
+RULE    "MUL_NOT_EXIST"           $(op_count MUL) '=' 0
+RULE    "EXP_EXIST"               $(op_count EXP) '=' 1
+RULE    "SUM_EXIST"               $(op_count SUM) '=' 1
+RULE    "DIV_EXIST"               $(op_count DIV) '=' 1
+RULE    "SOFTMAX_NOT_EXIST"       $(op_count SOFTMAX) '=' 0

--- a/res/TensorFlowLiteRecipes/Softmax_002/test.recipe
+++ b/res/TensorFlowLiteRecipes/Softmax_002/test.recipe
@@ -1,0 +1,20 @@
+operand {
+  name: "ifm"
+  type: FLOAT32
+  shape { dim: 1 dim: 16 dim: 16 dim: 128 }
+}
+operand {
+  name: "ofm"
+  type: FLOAT32
+  shape { dim: 1 dim: 16 dim: 16 dim: 128 }
+}
+operation {
+  type: "Softmax"
+  softmax_options {
+    beta: 0.5
+  }
+  input: "ifm"
+  output: "ofm"
+}
+input: "ifm"
+output: "ofm"

--- a/res/TensorFlowLiteRecipes/Softmax_002/test.rule
+++ b/res/TensorFlowLiteRecipes/Softmax_002/test.rule
@@ -1,0 +1,11 @@
+# To check if Softmax is converted to Max, Sub, Exp, Sum and Div operations
+
+RULE    "VERIFY_FILE_FORMAT"      $(verify_file_format) '=' 1
+
+RULE    "REDUCE_MAX_EXIST"        $(op_count REDUCE_MAX) '=' 1
+RULE    "SUB_EXIST"               $(op_count SUB) '=' 1
+RULE    "MUL_EXIST"               $(op_count MUL) '=' 1
+RULE    "EXP_EXIST"               $(op_count EXP) '=' 1
+RULE    "SUM_EXIST"               $(op_count SUM) '=' 1
+RULE    "DIV_EXIST"               $(op_count DIV) '=' 1
+RULE    "SOFTMAX_NOT_EXIST"       $(op_count SOFTMAX) '=' 0


### PR DESCRIPTION
This commit adds two models for Softmax with unit/nonunit beta.
Its correctness is tested at #11687.

Draft: #11687
Related: #11492
ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>