### PR TITLE
[luci-pass-value-test] Add Softmax decompose test

### DIFF
--- a/compiler/luci-pass-value-test/test.lst
+++ b/compiler/luci-pass-value-test/test.lst
@@ -40,6 +40,8 @@ addeval(Net_StridedSlice_StridedSlice_000 remove_unnecessary_strided_slice)
 addeval(FullyConnected_007 replace_non_const_fc_with_batch_matmul)
 addeval(Net_Transpose_Add_000 forward_transpose_op)
 addeval(Net_Transpose_Abs_000 forward_transpose_op)
+addeval(Softmax_001 decompose_softmax)
+addeval(Softmax_002 decompose_softmax)
 addeval(UnidirectionalSequenceLSTM_003 unroll_unidirseqlstm)
 addeval(UnidirectionalSequenceLSTM_004 unroll_unidirseqlstm)
 


### PR DESCRIPTION
This commit adds value tests for Softmax decomposition.

Its correctness is tested at https://github.com/Samsung/ONE/pull/11687.

Draft: https://github.com/Samsung/ONE/pull/11687
Related: https://github.com/Samsung/ONE/issues/11492
ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>