### PR TITLE
[circle2circle-dredd-recipe-test] Add Softmax decompose tests

### DIFF
--- a/compiler/circle2circle-dredd-recipe-test/test.lst
+++ b/compiler/circle2circle-dredd-recipe-test/test.lst
@@ -58,6 +58,8 @@ Add(FullyConnected_008 PASS replace_non_const_fc_with_batch_matmul)
 Add(Net_Gelu_000 PASS fuse_gelu)
 Add(Net_Gelu_001 PASS fuse_gelu)
 Add(HardSwish_001 PASS decompose_hardswish)
+Add(Softmax_001 PASS decompose_softmax)
+Add(Softmax_002 PASS decompose_softmax)
 
 ## CIRCLE RECIPE
 


### PR DESCRIPTION
This commit adds dredd tests for Softmax decomposition.

Its correctness is tested at https://github.com/Samsung/ONE/pull/11687.

Draft: https://github.com/Samsung/ONE/pull/11687
Related: https://github.com/Samsung/ONE/issues/11492

ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>