### PR TITLE
[one-cmds] Enable decompose_softmax

### DIFF
--- a/compiler/one-cmds/how-to-use-one-commands.txt
+++ b/compiler/one-cmds/how-to-use-one-commands.txt
@@ -149,6 +149,7 @@ one-optimize
 one-optimize provides network or operator transformation shown below.
 
 Current transformation options are
+- decompose_softmax : This will decompose softmax into multiple operators for special backends.
 - disable_validation : This will turn off operator validations.
 - expand_broadcast_const : This will expand broadcastable constant node inputs
 - fold_add_v2 : This removes AddV2 operation which can be folded

--- a/compiler/one-cmds/onelib/constant.py
+++ b/compiler/one-cmds/onelib/constant.py
@@ -148,6 +148,8 @@ class CONSTANT:
         ('transform_min_max_to_relu6', 'transform Minimum-Maximum pattern to Relu6 op'),
         ('transform_min_relu_to_relu6', 'transform Minimum(6)-Relu pattern to Relu6 op'),
         ('decompose_hardswish', 'decompose the HardSwish op to Add, Mul and Relu6 ops'),
+        ('decompose_softmax',
+         'decompose the Softmax op to Max, Sub, Exp, Sum, Div and optionally Mul ops'),
         ('unroll_unidirseqlstm', 'unroll UnidirectionalSequenceLSTM op'),
         ('dynamic_batch_to_single_batch',
          'convert dynamic batch size (first dimension) of inputs to 1'))


### PR DESCRIPTION
This commit enables decompose_softmax option for one-cmds optimize.

Locally after running build onecc:
```
[onecc]
one-import-tflite=False
one-import-tf=False
one-import-bcq=False
one-import-onnx=False
one-optimize=True
one-quantize=False
one-codegen=False
one-profile=False

[one-optimize]
input_path=/home/stanislav/repos/WorkSpaces/softmax/model_original.circle
output_path=/home/stanislav/repos/WorkSpaces/softmax/model_softmax.opt.circle
decompose_softmax=True
```
produced valid attached model:
[model_softmax.opt.zip](https://github.com/Samsung/ONE/files/12890814/model_softmax.opt.zip)


Draft: https://github.com/Samsung/ONE/pull/11687
Related: https://github.com/Samsung/ONE/issues/11492

ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>