### PR TITLE
[one-cmds] Add mixed_layernorm option to one-quantize

### DIFF
--- a/compiler/one-cmds/one-quantize
+++ b/compiler/one-cmds/one-quantize
@@ -250,10 +250,15 @@ def _get_parser():
 
     # ampq_algorithm
     ampq_quant_group.add_argument(
-        '--ampq_algorithm', type=str, help='type of algorithm (bisection)')
+        '--ampq_algorithm', type=str, help='type of algorithm (bisection, pattern)')
 
     ampq_quant_group.add_argument(
         '--bisection_type', type=str, help="one of 'auto', 'i16_front', 'i16_back'")
+
+    ampq_quant_group.add_argument(
+        '--mixed_layernorm',
+        action='store_true',
+        help='whether to apply LayerNorm pattern in pattern algorithm')
 
     # ampq_bisection_visq
     ampq_quant_group.add_argument(
@@ -783,6 +788,10 @@ def _ampq_solve(args):
                         ampq_quantize_cmd.extend(['--bisection', 'true'])
                     elif bisection_type == 'i16_back':
                         ampq_quantize_cmd.extend(['--bisection', 'false'])
+            elif algorithm == 'pattern':
+                ampq_quantize_cmd.append('--patterns')
+                if oneutils.is_valid_attr(args, 'mixed_layernorm'):
+                    ampq_quantize_cmd.append('--u8_layernorm_with_s16_variance')
 
         # recorded model as input
         ampq_quantize_cmd.extend(['--input_model', tmp_minmax_recorded_path])

--- a/compiler/one-cmds/one-quantize
+++ b/compiler/one-cmds/one-quantize
@@ -258,7 +258,7 @@ def _get_parser():
     ampq_quant_group.add_argument(
         '--u8_layernorm_with_s16_variance',
         action='store_true',
-        help='whether to apply LayerNorm pattern in pattern algorithm')
+        help='Use int16 for computing variance in uint8 layer normalization')
 
     # ampq_bisection_visq
     ampq_quant_group.add_argument(

--- a/compiler/one-cmds/one-quantize
+++ b/compiler/one-cmds/one-quantize
@@ -256,7 +256,7 @@ def _get_parser():
         '--bisection_type', type=str, help="one of 'auto', 'i16_front', 'i16_back'")
 
     ampq_quant_group.add_argument(
-        '--mixed_layernorm',
+        '--u8_layernorm_with_s16_variance',
         action='store_true',
         help='whether to apply LayerNorm pattern in pattern algorithm')
 
@@ -790,7 +790,7 @@ def _ampq_solve(args):
                         ampq_quantize_cmd.extend(['--bisection', 'false'])
             elif algorithm == 'pattern':
                 ampq_quantize_cmd.append('--patterns')
-                if oneutils.is_valid_attr(args, 'mixed_layernorm'):
+                if oneutils.is_valid_attr(args, 'u8_layernorm_with_s16_variance'):
                     ampq_quantize_cmd.append('--u8_layernorm_with_s16_variance')
 
         # recorded model as input


### PR DESCRIPTION
This commit addd mixed_layernorm option to one-quantize.

Running locally the following config:
```
[onecc]
one-import-tflite=False
one-import-tf=False
one-import-bcq=False
one-import-onnx=False
one-optimize=False
one-quantize=True
one-codegen=False
one-profile=False

[one-quantize]
input_path=/home/stanislav/repos/WorkSpaces/LAYER_NORM/model.circle
output_path=/home/stanislav/repos/WorkSpaces/LAYER_NORM/model.q_opt.circle
ampq=True
ampq_algorithm=pattern
u8_layernorm_with_s16_variance=True
```
produced attached model:
[model.q_opt.zip](https://github.com/Samsung/ONE/files/12891362/model.q_opt.zip)

which seems to be a valid result.

ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>