### PR TITLE
[circle-mpqsolver] Tidy includes

### DIFF
--- a/compiler/circle-mpqsolver/src/CircleMPQSolver.cpp
+++ b/compiler/circle-mpqsolver/src/CircleMPQSolver.cpp
@@ -21,7 +21,7 @@
 
 #include "bisection/BisectionSolver.h"
 #include "pattern/PatternSolver.h"
-#include <core/SolverOutput.h>
+#include "core/SolverOutput.h"
 
 #include <iostream>
 #include <iomanip>

--- a/compiler/circle-mpqsolver/src/MPQSolver.h
+++ b/compiler/circle-mpqsolver/src/MPQSolver.h
@@ -18,7 +18,7 @@
 #define __MPQSOLVER_MPQSOLVER_SOLVER_H__
 
 #include "core/Quantizer.h"
-#include <core/DumpingHooks.h>
+#include "core/DumpingHooks.h"
 
 #include <luci/IR/CircleNodes.h>
 

--- a/compiler/circle-mpqsolver/src/bisection/BisectionSolver.cpp
+++ b/compiler/circle-mpqsolver/src/bisection/BisectionSolver.cpp
@@ -18,8 +18,8 @@
 #include "DepthParameterizer.h"
 #include "VISQErrorApproximator.h"
 
-#include <core/ErrorMetric.h>
-#include <core/SolverOutput.h>
+#include "core/ErrorMetric.h"
+#include "core/SolverOutput.h"
 
 #include <luci/ImporterEx.h>
 

--- a/compiler/circle-mpqsolver/src/bisection/BisectionSolver.h
+++ b/compiler/circle-mpqsolver/src/bisection/BisectionSolver.h
@@ -17,8 +17,8 @@
 #ifndef __MPQSOLVER_BISECTION_SOLVER_H__
 #define __MPQSOLVER_BISECTION_SOLVER_H__
 
-#include <core/Evaluator.h>
-#include <MPQSolver.h>
+#include "core/Evaluator.h"
+#include "MPQSolver.h"
 
 #include <luci/IR/Module.h>
 

--- a/compiler/circle-mpqsolver/src/bisection/DepthParameterizer.test.cpp
+++ b/compiler/circle-mpqsolver/src/bisection/DepthParameterizer.test.cpp
@@ -17,7 +17,7 @@
 #include <gtest/gtest.h>
 
 #include "DepthParameterizer.h"
-#include <core/TestHelper.h>
+#include "core/TestHelper.h"
 
 #include <luci/IR/CircleNodes.h>
 

--- a/compiler/circle-mpqsolver/src/core/DumpingHooks.h
+++ b/compiler/circle-mpqsolver/src/core/DumpingHooks.h
@@ -19,9 +19,9 @@
 
 #include <luci/IR/Module.h>
 
-#include <core/Quantizer.h>
-#include <core/SolverHooks.h>
-#include <core/Dumper.h>
+#include "core/Quantizer.h"
+#include "core/SolverHooks.h"
+#include "core/Dumper.h"
 
 #include <string>
 

--- a/compiler/circle-mpqsolver/src/core/SolverHooks.h
+++ b/compiler/circle-mpqsolver/src/core/SolverHooks.h
@@ -19,7 +19,7 @@
 
 #include <luci/IR/Module.h>
 
-#include <core/Quantizer.h>
+#include "core/Quantizer.h"
 
 #include <string>
 


### PR DESCRIPTION
This commit replaces <...> includes by "..." includes for 'circle-mpqsolver' included modules.

ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>