### PR TITLE
[one-cmds] Support HardSwish decomposing option

### DIFF
--- a/compiler/one-cmds/how-to-use-one-commands.txt
+++ b/compiler/one-cmds/how-to-use-one-commands.txt
@@ -149,6 +149,7 @@ one-optimize
 one-optimize provides network or operator transformation shown below.
 
 Current transformation options are
+- decompose_hardswish : This will decompose hardswish operator to Add, Mul and Relu6 operators.
 - decompose_softmax : This will decompose softmax into multiple operators for special backends.
 - disable_validation : This will turn off operator validations.
 - expand_broadcast_const : This will expand broadcastable constant node inputs


### PR DESCRIPTION
This commit adds the missing description of the previously implemented `decompose_hardswish` option.

ONE-DCO-1.0-Signed-off-by: Seungho Henry Park <shs.park@samsung.com>

---

Related to: #10930 
