### PR TITLE
[luci/pass] Introduce fuse_slice_with_tconv

### DIFF
--- a/compiler/one-cmds/how-to-use-one-commands.txt
+++ b/compiler/one-cmds/how-to-use-one-commands.txt
@@ -166,6 +166,7 @@ Current transformation options are
 - fuse_batchnorm_with_conv : This fuses BatchNorm operator to convolution operator
 - fuse_batchnorm_with_dwconv : This fuses BatchNorm operator to depthwise convolution operator
 - fuse_batchnorm_with_tconv : This fuses BatchNorm operator to transpose convolution operator
+- fuse_slice_with_tconv: This fuses Slice with a preceding TConv if possible.
 - fuse_bcq: This enables Binary-Coded-bases Quantized DNNs
    - read https://arxiv.org/abs/2005.09904 for detailed information
 - fuse_instnorm: This will convert instance normalization related operators to
@@ -175,7 +176,7 @@ Current transformation options are
 - fuse_preactivation_batchnorm: This fuses batch normalization operators of pre-activations to Conv operators.
 - fuse_activation_function: This fuses Activation function to a preceding operator.
 - fuse_mean_with_mean: This fuses two consecutive ReduceMean operations into one.
-- fuse_transpose_with_mean: This fuses ReduceMean with a preceding Transpose under certain conditions.
+- fuse_transpose_with_mean: This fuses ReduceMean with a preceding Transpose under certain conditions
 - make_batchnorm_gamma_positive: This makes negative gamma of batch normalization into a small positive value (1e-10).
   Note that this pass can change the execution result of the model.
   So, use it only when the impact is known to be acceptable.

--- a/compiler/one-cmds/onelib/constant.py
+++ b/compiler/one-cmds/onelib/constant.py
@@ -98,6 +98,7 @@ class CONSTANT:
         ('fuse_batchnorm_with_conv', 'fuse BatchNorm op to Convolution op'),
         ('fuse_batchnorm_with_dwconv', 'fuse BatchNorm op to Depthwise Convolution op'),
         ('fuse_batchnorm_with_tconv', 'fuse BatchNorm op to Transposed Convolution op'),
+        ('fuse_slice_with_tconv', 'fuse Slice op to Transposed Convolution op'),
         ('fuse_bcq', 'apply Binary Coded Quantization'),
         ('fuse_preactivation_batchnorm',
          'fuse BatchNorm operators of pre-activations to Convolution op'),


### PR DESCRIPTION
This draft introduces fuse_slice_with_tconv pass.

Running `onecc` 
```
[onecc]
one-import-tflite=False
one-import-tf=False
one-import-bcq=False
one-import-onnx=False
one-optimize=True
one-quantize=False
one-codegen=False
one-profile=False

[one-optimize]
input_path=/home/stanislav/repos/WorkSpaces/fuse_tconv_slice/model_original.circle
output_path=/home/stanislav/repos/WorkSpaces/fuse_tconv_slice/model_fused.opt.circle
fuse_slice_with_tconv=True
````
successfully produced  result (see attachment).
[fuse_tconv_slice.zip](https://github.com/Samsung/ONE/files/12930049/fuse_tconv_slice.zip)

Related: #10960
ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>