### PR TITLE
[tools/onert_run] Add the function to dump input raw data

### DIFF
--- a/tests/tools/onert_run/src/args.cc
+++ b/tests/tools/onert_run/src/args.cc
@@ -265,6 +265,7 @@ void Args::Initialize(void)
     ("load,l", po::value<std::string>()->default_value("")->notifier([&](const auto &v) { _load_filename = v; }), "Input filename")
 #endif
     ("dump:raw", po::value<std::string>()->default_value("")->notifier([&](const auto &v) { _dump_raw_filename = v; }), "Raw Output filename")
+    ("dump_input:raw", po::value<std::string>()->default_value("")->notifier([&](const auto &v) { _dump_raw_input_filename = v; }), "Raw Input filename for dump")
     ("load:raw", po::value<std::string>()->default_value("")->notifier([&](const auto &v) { _load_raw_filename = v; }), "Raw Input filename")
     ("output_sizes", po::value<std::string>()->notifier(process_output_sizes),
         "The output buffer size in JSON 1D array\n"

--- a/tests/tools/onert_run/src/args.h
+++ b/tests/tools/onert_run/src/args.h
@@ -55,6 +55,7 @@ public:
   WhenToUseH5Shape getWhenToUseH5Shape(void) const { return _when_to_use_h5_shape; }
 #endif
   const std::string &getDumpRawFilename(void) const { return _dump_raw_filename; }
+  const std::string &getDumpRawInputFilename(void) const { return _dump_raw_input_filename; }
   const std::string &getLoadRawFilename(void) const { return _load_raw_filename; }
   const int getNumRuns(void) const { return _num_runs; }
   const int getWarmupRuns(void) const { return _warmup_runs; }
@@ -88,6 +89,7 @@ private:
   WhenToUseH5Shape _when_to_use_h5_shape = WhenToUseH5Shape::NOT_PROVIDED;
 #endif
   std::string _dump_raw_filename;
+  std::string _dump_raw_input_filename;
   std::string _load_raw_filename;
   TensorShapeMap _shape_prepare;
   TensorShapeMap _shape_run;

--- a/tests/tools/onert_run/src/onert_run.cc
+++ b/tests/tools/onert_run/src/onert_run.cc
@@ -336,6 +336,8 @@ int main(const int argc, char **argv)
     if (!args.getDumpFilename().empty())
       H5Formatter(session).dumpOutputs(args.getDumpFilename(), outputs);
 #endif
+    if (!args.getDumpRawInputFilename().empty())
+      RawFormatter(session).dumpInputs(args.getDumpRawInputFilename(), inputs);
     if (!args.getDumpRawFilename().empty())
       RawFormatter(session).dumpOutputs(args.getDumpRawFilename(), outputs);
 

--- a/tests/tools/onert_run/src/rawformatter.cc
+++ b/tests/tools/onert_run/src/rawformatter.cc
@@ -94,4 +94,29 @@ void RawFormatter::dumpOutputs(const std::string &filename, std::vector<Allocati
     std::exit(-1);
   }
 }
+
+void RawFormatter::dumpInputs(const std::string &filename, std::vector<Allocation> &inputs)
+{
+  uint32_t num_inputs;
+  NNPR_ENSURE_STATUS(nnfw_input_size(session_, &num_inputs));
+  try
+  {
+    for (uint32_t i = 0; i < num_inputs; i++)
+    {
+      nnfw_tensorinfo ti;
+      NNPR_ENSURE_STATUS(nnfw_input_tensorinfo(session_, i, &ti));
+      auto bufsz = bufsize_for(&ti);
+
+      std::ofstream file(filename + "." + std::to_string(i), std::ios::out | std::ios::binary);
+      file.write(reinterpret_cast<const char *>(inputs[i].data()), bufsz);
+      file.close();
+      std::cerr << filename + "." + std::to_string(i) + " is generated.\n";
+    }
+  }
+  catch (const std::runtime_error &e)
+  {
+    std::cerr << "Error during dumpRandomInputs on onert_run : " << e.what() << std::endl;
+    std::exit(-1);
+  }
+}
 } // end of namespace onert_run

--- a/tests/tools/onert_run/src/rawformatter.h
+++ b/tests/tools/onert_run/src/rawformatter.h
@@ -34,6 +34,7 @@ public:
   RawFormatter(nnfw_session *sess) : Formatter(sess) {}
   void loadInputs(const std::string &filename, std::vector<Allocation> &inputs) override;
   void dumpOutputs(const std::string &filename, std::vector<Allocation> &outputs) override;
+  void dumpInputs(const std::string &filename, std::vector<Allocation> &inputs);
 };
 } // namespace onert_run
 


### PR DESCRIPTION
This commit adds the function to dump input raw dafa. It stores automatically generated input data.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

draft: #10901