### PR TITLE
[infra/acl] Fix build fail on clang

### DIFF
--- a/infra/nnfw/cmake/packages/ARMComputeConfig.cmake
+++ b/infra/nnfw/cmake/packages/ARMComputeConfig.cmake
@@ -172,6 +172,10 @@ function(_ARMCompute_Build ARMComputeInstall_DIR)
     set(SCONS_CXX "clang++")
   endif(ANDROID)
 
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 10)
+    list(APPEND SCONS_OPTIONS "extra_cxx_flags=-Wno-deprecated-copy")
+  endif()
+
   message(STATUS "Build ARMCompute with ${SCONS_PATH} ('${SCONS_OPTIONS}'")
 
   # Build ARMCompute libraries with SCONS


### PR DESCRIPTION
This commit fixes build fail by deprecated-copy warning on clang > 10 (ex. ndk > 21)

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>