### PR TITLE
[luci/pass] Introduce FuseSliceWithTConvPass

### DIFF
--- a/compiler/luci/pass/include/luci/Pass/FuseSliceWithTConvPass.h
+++ b/compiler/luci/pass/include/luci/Pass/FuseSliceWithTConvPass.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __LUCI_FUSE_SLICE_WITH_TCONV_PASS_H__
+#define __LUCI_FUSE_SLICE_WITH_TCONV_PASS_H__
+
+#include <logo/Pass.h>
+
+namespace luci
+{
+
+/**
+ * @brief  Class to fuse Slice operation with a preceding TConv
+ */
+struct FuseSliceWithTConvPass final : public logo::Pass
+{
+  const char *name(void) const final { return "luci::FuseSliceWithTConvPass"; }
+
+  bool run(loco::Graph *g) final;
+};
+
+} // namespace luci
+
+#endif // __LUCI_FUSE_SLICE_WITH_TCONV_PASS_H__

--- a/compiler/luci/pass/src/FuseSliceWithTConvPass.cpp
+++ b/compiler/luci/pass/src/FuseSliceWithTConvPass.cpp
@@ -1,0 +1,288 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Pass/FuseSliceWithTConvPass.h"
+
+#include <luci/IR/CircleNodes.h>
+#include <luci/Profile/CircleNodeOrigin.h>
+#include <luci/Service/CircleNodeClone.h>
+#include <luci/Service/Nodes/CircleConst.h>
+
+namespace
+{
+
+#define RETURN_FALSE_UNLESS(cond) \
+  if (not(cond))                  \
+    return false;
+
+inline int32_t compute_input_size(luci::Padding padding, int32_t image_size, int32_t filter_size,
+                                  int32_t stride)
+{
+  switch (padding)
+  {
+    case luci::Padding::SAME:
+      return (image_size + stride - 1) / stride;
+    case luci::Padding::VALID:
+      return (image_size + stride - filter_size) / stride;
+    default:
+      throw std::runtime_error("Unsupported padding");
+  }
+}
+
+inline int32_t extract_pad_value(int32_t stride, int32_t in_size, int32_t filter_size,
+                                 int32_t out_size)
+{
+  const int32_t padding = ((in_size - 1) * stride + filter_size - out_size) / 2;
+  return padding > 0 ? padding : 0;
+}
+
+inline uint32_t cal_offset(const luci::CircleConst *node, const uint32_t *indices)
+{
+  return indices[0] * node->dim(1).value() * node->dim(2).value() * node->dim(3).value() +
+         indices[1] * node->dim(2).value() * node->dim(3).value() +
+         indices[2] * node->dim(3).value() + indices[3];
+}
+
+luci::Padding compute_padding(const luci::CircleTransposeConv *tconv, int32_t out_height,
+                              int32_t out_width, int32_t pad_top, int32_t pad_left)
+{
+  auto const filter = dynamic_cast<luci::CircleConst *>(tconv->filter());
+  if (!filter)
+    return luci::Padding::UNDEFINED;
+
+  auto tconv_shape = dynamic_cast<luci::CircleConst *>(tconv->inputSizes());
+  if (!tconv_shape)
+    return luci::Padding::UNDEFINED;
+
+  luci::Padding padding = luci::Padding::UNDEFINED;
+  std::initializer_list<luci::Padding> paddings_to_check = {luci::Padding::VALID,
+                                                            luci::Padding::SAME};
+
+  auto const filter_height = filter->dim(1).value();
+  auto const filter_width = filter->dim(2).value();
+  auto const stride_height = tconv->stride()->h();
+  auto const stride_width = tconv->stride()->w();
+
+  for (auto padding_to_check : paddings_to_check)
+  {
+    auto const in_height =
+      compute_input_size(padding_to_check, out_height, filter_height, stride_height);
+    auto const pad_top_virtual =
+      extract_pad_value(stride_height, in_height, filter_height, out_height);
+    if (pad_top_virtual != pad_top)
+      continue;
+
+    auto const in_width =
+      compute_input_size(padding_to_check, out_width, filter_width, stride_width);
+    auto const pad_left_virtual =
+      extract_pad_value(stride_width, in_width, filter_width, out_width);
+    if (pad_left_virtual == pad_left)
+    {
+      padding = padding_to_check; // correct padding is found
+      break;
+    }
+  }
+
+  return padding;
+}
+
+/**
+ *  Fuse Slice with CircleTransposeConv if possible
+ *
+ *  NOTE: In case predecessor of slice is tconv, we can try to merge slice with tconv,
+ *  because spatial slice is reduction so as padding for tconv,
+ *  while channels slice reduction can be directly modeled in tconv.
+ *  For now there is no option to set explicitely pad values for
+ *  CircleTransposeConv. Only using VALID/SAME and output shape is the only way
+ *  to set pad values. That is why not all numerical values of pad are legal for such
+ *  transform.
+ *
+ *  BEFORE
+ *                    |
+ *           [CircleTransposeConv]
+ *                    |
+ *               [CircleSlice]
+ *                    |
+ *
+ *  AFTER
+ *                    |
+ *            [CircleTransposeConv] (with m.b. changed padding, output shape, and filter/bias)
+ *                    |
+ *
+ */
+
+bool fuse_slice_with_tconv(luci::CircleSlice *slice)
+{
+  // NOTE: assume NHWC layout
+  auto tconv = dynamic_cast<luci::CircleTransposeConv *>(slice->input());
+  RETURN_FALSE_UNLESS(tconv != nullptr);
+
+  // offset
+  auto begin = dynamic_cast<luci::CircleConst *>(slice->begin());
+  // sanity check
+  RETURN_FALSE_UNLESS(begin != nullptr && begin->dtype() == loco::DataType::S32 &&
+                      begin->rank() == 1);
+
+  // output shape
+  auto out_shape = dynamic_cast<luci::CircleConst *>(slice->size());
+  // sanity check
+  RETURN_FALSE_UNLESS(out_shape != nullptr && out_shape->dtype() == loco::DataType::S32 &&
+                      out_shape->rank() == 1);
+
+  // output shape of tconv
+  auto tconv_shape = dynamic_cast<luci::CircleConst *>(tconv->inputSizes());
+  // sanity check
+  RETURN_FALSE_UNLESS(tconv_shape != nullptr && tconv_shape->dtype() == loco::DataType::S32 &&
+                      tconv_shape->rank() == 1);
+
+  // no update if batch dimension is processed in slice
+  RETURN_FALSE_UNLESS(begin->at<loco::DataType::S32>(0) == 0 &&
+                      out_shape->at<loco::DataType::S32>(0) ==
+                        tconv_shape->at<loco::DataType::S32>(0));
+
+  // filter
+  auto const tconv_filter = dynamic_cast<luci::CircleConst *>(tconv->filter());
+  // sanity check
+  RETURN_FALSE_UNLESS(tconv_filter != nullptr && tconv_filter->rank() == 4 &&
+                      tconv_filter->dtype() == loco::DataType::FLOAT32);
+
+  // bias
+  auto const tconv_bias = dynamic_cast<luci::CircleConst *>(tconv->bias());
+  // Only support const bias
+  // TODO Support non-const bias
+  RETURN_FALSE_UNLESS(tconv_bias != nullptr && tconv_bias->rank() == 1 &&
+                      tconv_bias->dtype() == loco::DataType::FLOAT32);
+
+  auto const out_height = out_shape->at<loco::DataType::S32>(1);
+  auto const out_width = out_shape->at<loco::DataType::S32>(2);
+
+  auto const pad_top = begin->at<loco::DataType::S32>(1);
+  auto const pad_left = begin->at<loco::DataType::S32>(2);
+
+  // As there is no option to set numerical values of pad explicitly for CircleTransposeConv
+  // we need to be sure that interpretation of PADDING + OUTPUT_SHAPE will produce
+  // the pad values, defined by slice. If possible compute_padding will return correct
+  // padding value, otherwise it will return UNDEFINED
+  auto const padding = compute_padding(tconv, out_height, out_width, pad_top, pad_left);
+  if (padding == luci::Padding::UNDEFINED)
+    return false; // impossible to fuse
+
+  auto const out_channels = out_shape->at<loco::DataType::S32>(3);
+  // update filter and bias in case it's needed
+  loco::Node *fused_filter = tconv->filter();
+  loco::Node *fused_bias = tconv->bias();
+  // Channel-direction slice
+  // Corresponding weights/bias of TConv is sliced.
+  if (begin->at<loco::DataType::S32>(3) != 0 ||
+      out_channels != tconv_shape->at<loco::DataType::S32>(3))
+  {
+    // fused filter
+    auto const in_channels = tconv_filter->dim(3).value();
+
+    luci::CircleConst *fused_tconv_filter = luci::clone(tconv_filter);
+    fused_tconv_filter->dim(0).set(out_channels); // out_channels
+    // update size due to channels change
+    fused_tconv_filter->size<loco::DataType::FLOAT32>(out_channels * tconv_filter->dim(1).value() *
+                                                      tconv_filter->dim(2).value() * in_channels);
+    auto const ch_offset = begin->at<loco::DataType::S32>(3);
+    // set reduced filter values
+    for (uint32_t out_chan = 0; out_chan < fused_tconv_filter->dim(0).value(); out_chan++)
+    {
+      for (uint32_t out_height = 0; out_height < fused_tconv_filter->dim(1).value(); out_height++)
+      {
+        for (uint32_t out_width = 0; out_width < fused_tconv_filter->dim(2).value(); out_width++)
+        {
+          for (uint32_t in_chan = 0; in_chan < fused_tconv_filter->dim(3).value(); in_chan++)
+          {
+            uint32_t indices[4] = {out_chan, out_height, out_width, in_chan};
+            uint32_t old_indices[4] = {out_chan + ch_offset, out_height, out_width, in_chan};
+            auto const data =
+              tconv_filter->at<loco::DataType::FLOAT32>(cal_offset(tconv_filter, old_indices));
+            fused_tconv_filter->at<loco::DataType::FLOAT32>(
+              cal_offset(fused_tconv_filter, indices)) = data;
+          }
+        }
+      }
+    }
+    fused_tconv_filter->name(tconv_filter->name() + "/FusedSlice");
+    luci::add_origin(fused_tconv_filter, luci::get_origin(tconv_shape));
+    fused_filter = fused_tconv_filter;
+
+    // fused bias
+    luci::CircleConst *fused_tconv_bias = luci::clone(tconv_bias);
+    fused_tconv_bias->size<loco::DataType::FLOAT32>(out_channels);
+    fused_tconv_bias->dim(0).set(out_channels); // out_channels
+    // set reduced bias values
+    for (int32_t c = 0; c < out_channels; c++)
+    {
+      auto const data = tconv_bias->at<loco::DataType::FLOAT32>(c + ch_offset);
+      fused_tconv_bias->at<loco::DataType::FLOAT32>(c) = data;
+    }
+
+    fused_tconv_bias->name(tconv_bias->name() + "/FusedSlice");
+    luci::add_origin(fused_tconv_bias, luci::get_origin(tconv_bias));
+    fused_bias = fused_tconv_bias;
+  }
+
+  auto *fused_tconv_shape = luci::clone(tconv_shape);
+  // spatial dimensions
+  fused_tconv_shape->at<loco::DataType::S32>(1) = out_height;
+  fused_tconv_shape->at<loco::DataType::S32>(2) = out_width;
+  // channels
+  fused_tconv_shape->at<loco::DataType::S32>(3) = out_channels;
+  fused_tconv_shape->name(tconv_shape->name() + "/FusedSlice");
+  luci::add_origin(fused_tconv_shape, luci::get_origin(tconv_shape));
+
+  // Configure new CircleTransposeConv operation.
+  auto *fused_tconv =
+    loco::must_cast<luci::CircleTransposeConv *>(luci::clone_node(tconv, slice->graph()));
+  fused_tconv->inputSizes(fused_tconv_shape);
+  fused_tconv->outBackprop(tconv->outBackprop());
+  fused_tconv->filter(fused_filter);
+  fused_tconv->bias(fused_bias);
+  fused_tconv->padding(padding);
+  fused_tconv->name(tconv->name() + "/FusedSlice");
+  luci::add_origin(fused_tconv,
+                   luci::composite_origin({luci::get_origin(tconv), luci::get_origin(slice)}));
+
+  // Replace old slice operation with new fused_tconv with merged pad values
+  replace(slice).with(fused_tconv);
+
+  return true;
+}
+
+} // namespace
+
+namespace luci
+{
+
+bool FuseSliceWithTConvPass::run(loco::Graph *g)
+{
+  bool changed = false;
+  for (auto node : loco::active_nodes(loco::output_nodes(g)))
+  {
+    auto slice = dynamic_cast<luci::CircleSlice *>(node);
+    if (not slice)
+      continue;
+
+    if (fuse_slice_with_tconv(slice))
+      changed = true;
+  }
+
+  return changed;
+}
+
+} // namespace luci

--- a/compiler/luci/pass/src/FuseSliceWithTConvPass.test.cpp
+++ b/compiler/luci/pass/src/FuseSliceWithTConvPass.test.cpp
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Pass/FuseSliceWithTConvPass.h"
+
+#include <luci/IR/CircleNodes.h>
+
+#include <luci/test/TestIOGraph.h>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+
+/**
+ *  TConv->Slice graph for test
+ *
+ *        [CircleInput]
+ *              |
+ *              |
+ *     [CircleTransposeConv]
+ *              |
+ *              |
+ *        [CircleSlice]
+ *              |
+ *              |
+ *        [CircleOutput]
+ */
+struct TConvSliceGraph : public luci::test::TestIOGraph
+{
+  luci::CircleTransposeConv *_tconv = nullptr;
+  luci::CircleSlice *_slice = nullptr;
+  luci::CircleConst *_filter = nullptr;
+  luci::CircleConst *_bias = nullptr;
+  luci::CircleConst *_tconv_shape = nullptr;
+  luci::CircleConst *_slice_offset = nullptr;
+  luci::CircleConst *_slice_size = nullptr;
+
+  TConvSliceGraph(uint32_t h, uint32_t w, uint32_t pads[4])
+  {
+    // pads={pad_top, pad_bottom, pad_left, pad_right}
+    uint32_t channels = 32;
+    uint32_t k_h = 3, k_w = 3;
+    auto const tconv_h = (h - 1) * 2 + k_h;
+    auto const tconv_w = (w - 1) * 2 + k_w;
+    auto const out_h = tconv_h - pads[0] - pads[1];
+    auto const out_w = tconv_w - pads[2] - pads[3];
+
+    // graph input and output
+    TestIOGraph::init({1, h, w, channels}, {1, out_h, out_w, channels});
+
+    _filter = g()->nodes()->create<luci::CircleConst>();
+    _filter->dtype(loco::DataType::FLOAT32);
+    _filter->rank(4);
+    _filter->shape({channels, k_h, k_w, channels});
+    _filter->shape_status(luci::ShapeStatus::VALID);
+    _filter->size<loco::DataType::FLOAT32>(channels * k_h * k_w * channels);
+    _filter->name("filter");
+
+    _bias = g()->nodes()->create<luci::CircleConst>();
+    _bias->dtype(loco::DataType::FLOAT32);
+    _bias->rank(1);
+    _bias->shape({channels});
+    _bias->shape_status(luci::ShapeStatus::VALID);
+    _bias->size<loco::DataType::FLOAT32>(channels);
+    _bias->name("bias");
+
+    _tconv_shape = g()->nodes()->create<luci::CircleConst>();
+    _tconv_shape->dtype(loco::DataType::S32);
+    _tconv_shape->rank(1);
+    _tconv_shape->shape({4});
+    _tconv_shape->shape_status(luci::ShapeStatus::VALID);
+    _tconv_shape->size<loco::DataType::S32>(4);
+    _tconv_shape->at<loco::DataType::S32>(0) = 1;
+    _tconv_shape->at<loco::DataType::S32>(3) = channels;
+    _tconv_shape->at<loco::DataType::S32>(1) = tconv_h;
+    _tconv_shape->at<loco::DataType::S32>(2) = tconv_w;
+    _tconv_shape->name("tconv_shape");
+
+    _tconv = g()->nodes()->create<luci::CircleTransposeConv>();
+    _tconv->filter(_filter);
+    _tconv->bias(_bias);
+    _tconv->inputSizes(_tconv_shape);
+    _tconv->outBackprop(input());
+    _tconv->fusedActivationFunction(luci::FusedActFunc::NONE);
+    _tconv->dtype(loco::DataType::FLOAT32);
+    _tconv->padding(luci::Padding::VALID);
+    _tconv->stride()->h(2);
+    _tconv->stride()->w(2);
+    _tconv->name("tconv");
+
+    // offset to be used in slice
+    _slice_offset = g()->nodes()->create<luci::CircleConst>();
+    _slice_offset->dtype(loco::DataType::S32);
+    _slice_offset->rank(1);
+    _slice_offset->shape({4});
+    _slice_offset->shape_status(luci::ShapeStatus::VALID);
+    _slice_offset->size<loco::DataType::S32>(4);
+    _slice_offset->at<loco::DataType::S32>(0) = 0;
+    _slice_offset->at<loco::DataType::S32>(3) = 0;
+    _slice_offset->at<loco::DataType::S32>(1) = pads[0];
+    _slice_offset->at<loco::DataType::S32>(2) = pads[2];
+    _slice_offset->name("slice_offset");
+
+    _slice_size = g()->nodes()->create<luci::CircleConst>();
+    _slice_size->dtype(loco::DataType::S32);
+    _slice_size->rank(1);
+    _slice_size->shape({4});
+    _slice_size->shape_status(luci::ShapeStatus::VALID);
+    _slice_size->size<loco::DataType::S32>(4);
+    _slice_size->at<loco::DataType::S32>(0) = 1;
+    _slice_size->at<loco::DataType::S32>(3) = channels;
+    _slice_size->at<loco::DataType::S32>(1) = out_h;
+    _slice_size->at<loco::DataType::S32>(2) = out_w;
+    _slice_size->name("slice_size");
+
+    _slice = g()->nodes()->create<luci::CircleSlice>();
+    _slice->begin(_slice_offset);
+    _slice->size(_slice_size);
+    _slice->input(_tconv);
+    _slice->name("slice");
+
+    output()->from(_slice);
+  }
+};
+
+} // namespace
+
+TEST(FuseSliceWithTConvPassTest, simple_test)
+{
+  /**
+   *  tests:
+   *    1) fusion pass has nonnull name
+   *    2) fusion runs successfully for float32 TConvSlice graph
+   *    3) resulting graph has the following structure:
+   *
+   *      [CircleTransposeConv] (with output_shape = shape_of_the_slice)
+   *              |
+   *              |
+   *           [Output]
+   */
+  luci::FuseSliceWithTConvPass pass;
+  uint32_t pads[4] = {0, 2, 0, 2};
+  uint32_t h = 8, w = 8;
+  TConvSliceGraph graph(h, w, pads);
+  auto const out_h = graph._slice_size->at<loco::DataType::S32>(1);
+  auto const out_w = graph._slice_size->at<loco::DataType::S32>(2);
+
+  auto const name = pass.name();
+  ASSERT_NE(nullptr, name);
+
+  auto ret = pass.run(graph.g());
+  EXPECT_TRUE(ret);
+
+  auto const fused_tconv = dynamic_cast<luci::CircleTransposeConv *>(graph.output()->from());
+  EXPECT_NE(nullptr, fused_tconv);
+
+  EXPECT_EQ(luci::Padding::VALID, fused_tconv->padding());
+
+  auto const out_size = dynamic_cast<luci::CircleConst *>(fused_tconv->inputSizes());
+  EXPECT_NE(nullptr, out_size);
+  EXPECT_EQ(out_h, out_size->at<loco::DataType::S32>(1)); // h
+  EXPECT_EQ(out_w, out_size->at<loco::DataType::S32>(2)); // 2
+}
+
+TEST(FuseSliceWithTConvPassTest, wrong_condition_NEG)
+{
+  luci::FuseSliceWithTConvPass pass;
+  uint32_t pads[4] = {3, 3, 3, 3}; // no fusion is possible with these pads
+  TConvSliceGraph graph(8, 8, pads);
+
+  auto ret = pass.run(graph.g());
+  EXPECT_FALSE(ret);
+}


### PR DESCRIPTION
This commit introduces FuseSliceWithTConvPass
for fusing slice with tconv if possible.

Its correctness is tested at #11725.
Draft: #11725
Related: https://github.com/Samsung/ONE/issues/10960

ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>