### PR TITLE
[circle-mpqsolver] Introduce pattern for softmax

### DIFF
--- a/compiler/one-cmds/one-quantize
+++ b/compiler/one-cmds/one-quantize
@@ -260,6 +260,11 @@ def _get_parser():
         action='store_true',
         help='Use int16 for computing variance in uint8 layer normalization')
 
+    ampq_quant_group.add_argument(
+        '--u8_softmax_with_s16_sub_exp',
+        action='store_true',
+        help='Use int16 for computing Sub and Exp nodes in uint8 softmax')
+
     # ampq_bisection_visq
     ampq_quant_group.add_argument(
         '--ampq_bisection_visq',
@@ -792,6 +797,8 @@ def _ampq_solve(args):
                 ampq_quantize_cmd.append('--patterns')
                 if oneutils.is_valid_attr(args, 'u8_layernorm_with_s16_variance'):
                     ampq_quantize_cmd.append('--u8_layernorm_with_s16_variance')
+                if oneutils.is_valid_attr(args, 'u8_softmax_with_s16_sub_exp'):
+                    ampq_quantize_cmd.append('--u8_softmax_with_s16_sub_exp')
 
         # recorded model as input
         ampq_quantize_cmd.extend(['--input_model', tmp_minmax_recorded_path])


### PR DESCRIPTION
This PR introduces u8_softmax_with_s16_sub_exp
option for optimal softmax mixed precision quantization.
Running the following configuration
```
[onecc]
one-import-tflite=False
one-import-tf=False
one-import-bcq=False
one-import-onnx=False
one-optimize=False
one-quantize=True
one-codegen=False
one-profile=False

[one-quantize]
input_path=/home/stanislav/repos/WorkSpaces/softmax_ampq/model_softmax.opt.circle
output_path=/home/stanislav/repos/WorkSpaces/softmax_ampq/model_softmax.q_opt.circle
ampq=True
ampq_algorithm=pattern
u8_softmax_with_s16_sub_exp=True
```
produced attached `model_softmax.q_opt.circle` (see attachment).
[softmax_ampq.zip](https://github.com/Samsung/ONE/files/13024862/softmax_ampq.zip)

Related: #11543
ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>