### PR TITLE
[CFE/minmax-embedder] Remove unwanted empty line

### DIFF
--- a/compiler/minmax-embedder/src/h5/Reader.h
+++ b/compiler/minmax-embedder/src/h5/Reader.h
@@ -47,7 +47,6 @@ namespace h5
 //                       ├── ATTRIBUTE op_{idx}
 //                       │      DATATYPE String
 //                       │      DATA { "op/name"}
-
 //                       └── ATTRIBUTE input_{idx}
 //                              DATATYPE String
 //                              DATA { "input/name"}


### PR DESCRIPTION
An unintended empty line is added. It removes the line.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>