### PR TITLE
[res] TensorFlowLiteRecipes for TConv->Slice fusion

### DIFF
--- a/res/TensorFlowLiteRecipes/Net_TConv_Slice_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/Net_TConv_Slice_000/test.recipe
@@ -1,0 +1,99 @@
+# test for zero spatial offset but spatial reduction in size
+# TConv(pad=valid, krnl=(32, 4, 4, 32))->Slice(offset = (0, 0, 0, 0), size = (0, 15, 15, 32))=TConv
+
+operand {
+  name: "tconv_shape"
+  type: INT32
+  shape {
+    dim: 4
+  }
+  filler {
+    tag: "explicit"
+    arg: "1"
+    arg: "18"
+    arg: "18"
+    arg: "32"
+  }
+}
+operand {
+  name: "filter"
+  type: FLOAT32
+  shape { dim: 32 dim: 4 dim: 4 dim: 32 }
+  filler {
+    tag: "gaussian"
+    arg: "0.0"
+    arg: "1.0"
+  }
+}
+operand {
+  name: "ifm"
+  type: FLOAT32
+  shape { dim: 1 dim: 8 dim: 8 dim: 32 }
+}
+operand {
+  name: "bias"
+  type: FLOAT32
+  shape { dim: 32 }
+  filler {
+    tag: "gaussian"
+    arg: "0.0"
+    arg: "1.0"
+  }
+}
+operand {
+  name: "ofm_tconv"
+  type: FLOAT32
+  shape { dim: 1 dim: 18 dim: 18 dim: 32 }
+}
+operation {
+  type: "TransposeConv"
+  input: "tconv_shape"
+  input: "filter"
+  input: "ifm"
+  input: "bias"
+  output: "ofm_tconv"
+  transpose_conv_options {
+    padding: VALID
+    stride_w: 2
+    stride_h: 2
+    activation: RELU
+  }
+}
+operand {
+  name: "offset"
+  type: INT32
+  shape { dim: 4 }
+  filler {
+    tag: "explicit"
+    arg: "0"
+    arg: "0"
+    arg: "0"
+    arg: "0"
+  }
+}
+operand {
+  name: "size"
+  type: INT32
+  shape { dim: 4 }
+  filler {
+    tag: "explicit"
+    arg: "1" 
+    arg: "15" 
+    arg: "15"
+    arg: "32"
+  }
+}
+operand {
+  name: "ofm"
+  type: FLOAT32
+  shape { dim: 1 dim: 15 dim: 15 dim: 32 }
+}
+operation {
+  type: "Slice"
+  input: "ofm_tconv"
+  input: "offset"
+  input: "size"
+  output: "ofm"
+}
+input: "ifm"
+output: "ofm"

--- a/res/TensorFlowLiteRecipes/Net_TConv_Slice_000/test.rule
+++ b/res/TensorFlowLiteRecipes/Net_TConv_Slice_000/test.rule
@@ -1,0 +1,6 @@
+# To check if TConv->Slice is converted to TConv operation
+
+RULE    "VERIFY_FILE_FORMAT"      $(verify_file_format) '=' 1
+
+RULE    "TCONV_EXIST"             $(op_count TRANSPOSE_CONV) '=' 1
+RULE    "SLICE_NOT_EXIST"         $(op_count SLICE) '=' 0

--- a/res/TensorFlowLiteRecipes/Net_TConv_Slice_001/test.recipe
+++ b/res/TensorFlowLiteRecipes/Net_TConv_Slice_001/test.recipe
@@ -1,0 +1,99 @@
+# test for non-zero spatial offset
+# TConv(pad=valid, krnl=(32, 4, 4, 32))->Slice(offset = (0, 1, 1, 0), size = (0, 14, 14, 32))=TConv
+
+operand {
+  name: "tconv_shape"
+  type: INT32
+  shape {
+    dim: 4
+  }
+  filler {
+    tag: "explicit"
+    arg: "1"
+    arg: "18"
+    arg: "18"
+    arg: "32"
+  }
+}
+operand {
+  name: "filter"
+  type: FLOAT32
+  shape { dim: 32 dim: 4 dim: 4 dim: 32 }
+  filler {
+    tag: "gaussian"
+    arg: "0.0"
+    arg: "1.0"
+  }
+}
+operand {
+  name: "ifm"
+  type: FLOAT32
+  shape { dim: 1 dim: 8 dim: 8 dim: 32 }
+}
+operand {
+  name: "bias"
+  type: FLOAT32
+  shape { dim: 32 }
+  filler {
+    tag: "gaussian"
+    arg: "0.0"
+    arg: "1.0"
+  }
+}
+operand {
+  name: "ofm_tconv"
+  type: FLOAT32
+  shape { dim: 1 dim: 18 dim: 18 dim: 32 }
+}
+operation {
+  type: "TransposeConv"
+  input: "tconv_shape"
+  input: "filter"
+  input: "ifm"
+  input: "bias"
+  output: "ofm_tconv"
+  transpose_conv_options {
+    padding: VALID
+    stride_w: 2
+    stride_h: 2
+    activation: RELU
+  }
+}
+operand {
+  name: "offset"
+  type: INT32
+  shape { dim: 4 }
+  filler {
+    tag: "explicit"
+    arg: "0"
+    arg: "1"
+    arg: "1"
+    arg: "0"
+  }
+}
+operand {
+  name: "size"
+  type: INT32
+  shape { dim: 4 }
+  filler {
+    tag: "explicit"
+    arg: "1" 
+    arg: "14" 
+    arg: "14"
+    arg: "32"
+  }
+}
+operand {
+  name: "ofm"
+  type: FLOAT32
+  shape { dim: 1 dim: 14 dim: 14 dim: 32 }
+}
+operation {
+  type: "Slice"
+  input: "ofm_tconv"
+  input: "offset"
+  input: "size"
+  output: "ofm"
+}
+input: "ifm"
+output: "ofm"

--- a/res/TensorFlowLiteRecipes/Net_TConv_Slice_001/test.rule
+++ b/res/TensorFlowLiteRecipes/Net_TConv_Slice_001/test.rule
@@ -1,0 +1,6 @@
+# To check if TConv->Slice is converted to TConv operation
+
+RULE    "VERIFY_FILE_FORMAT"      $(verify_file_format) '=' 1
+
+RULE    "TCONV_EXIST"             $(op_count TRANSPOSE_CONV) '=' 1
+RULE    "SLICE_NOT_EXIST"         $(op_count SLICE) '=' 0

--- a/res/TensorFlowLiteRecipes/Net_TConv_Slice_002/test.recipe
+++ b/res/TensorFlowLiteRecipes/Net_TConv_Slice_002/test.recipe
@@ -1,0 +1,99 @@
+# test for channel-direction slice
+# TConv(pad=valid, krnl=(32, 4, 4, 32))->Slice(begin = (0, 0, 0, 10), size = (0, 15, 15, 10))=TConv
+
+operand {
+  name: "tconv_shape"
+  type: INT32
+  shape {
+    dim: 4
+  }
+  filler {
+    tag: "explicit"
+    arg: "1"
+    arg: "18"
+    arg: "18"
+    arg: "32"
+  }
+}
+operand {
+  name: "filter"
+  type: FLOAT32
+  shape { dim: 32 dim: 4 dim: 4 dim: 32 }
+  filler {
+    tag: "gaussian"
+    arg: "0.0"
+    arg: "1.0"
+  }
+}
+operand {
+  name: "ifm"
+  type: FLOAT32
+  shape { dim: 1 dim: 8 dim: 8 dim: 32 }
+}
+operand {
+  name: "bias"
+  type: FLOAT32
+  shape { dim: 32 }
+  filler {
+    tag: "gaussian"
+    arg: "0.0"
+    arg: "1.0"
+  }
+}
+operand {
+  name: "ofm_tconv"
+  type: FLOAT32
+  shape { dim: 1 dim: 18 dim: 18 dim: 32 }
+}
+operation {
+  type: "TransposeConv"
+  input: "tconv_shape"
+  input: "filter"
+  input: "ifm"
+  input: "bias"
+  output: "ofm_tconv"
+  transpose_conv_options {
+    padding: VALID
+    stride_w: 2
+    stride_h: 2
+    activation: RELU
+  }
+}
+operand {
+  name: "offset"
+  type: INT32
+  shape { dim: 4 }
+  filler {
+    tag: "explicit"
+    arg: "0"
+    arg: "0"
+    arg: "0"
+    arg: "10"
+  }
+}
+operand {
+  name: "size"
+  type: INT32
+  shape { dim: 4 }
+  filler {
+    tag: "explicit"
+    arg: "1" 
+    arg: "18" 
+    arg: "18"
+    arg: "10"
+  }
+}
+operand {
+  name: "ofm"
+  type: FLOAT32
+  shape { dim: 1 dim: 18 dim: 18 dim: 10 }
+}
+operation {
+  type: "Slice"
+  input: "ofm_tconv"
+  input: "offset"
+  input: "size"
+  output: "ofm"
+}
+input: "ifm"
+output: "ofm"

--- a/res/TensorFlowLiteRecipes/Net_TConv_Slice_002/test.rule
+++ b/res/TensorFlowLiteRecipes/Net_TConv_Slice_002/test.rule
@@ -1,0 +1,6 @@
+# To check if TConv->Slice is converted to TConv operation
+
+RULE    "VERIFY_FILE_FORMAT"      $(verify_file_format) '=' 1
+
+RULE    "TCONV_EXIST"             $(op_count TRANSPOSE_CONV) '=' 1
+RULE    "SLICE_NOT_EXIST"         $(op_count SLICE) '=' 0

--- a/res/TensorFlowLiteRecipes/Net_TConv_Slice_003/test.recipe
+++ b/res/TensorFlowLiteRecipes/Net_TConv_Slice_003/test.recipe
@@ -1,0 +1,99 @@
+# test for original `same` padding and non-zero offset
+# TConv(pad=same, krnl=(32, 3, 3, 32))->Slice(begin = (0, 1, 1, 0), size = (0, 15, 15, 32))=TConv
+
+operand {
+  name: "tconv_shape"
+  type: INT32
+  shape {
+    dim: 4
+  }
+  filler {
+    tag: "explicit"
+    arg: "1"
+    arg: "16"
+    arg: "16"
+    arg: "32"
+  }
+}
+operand {
+  name: "filter"
+  type: FLOAT32
+  shape { dim: 32 dim: 3 dim: 3 dim: 32 }
+  filler {
+    tag: "gaussian"
+    arg: "0.0"
+    arg: "1.0"
+  }
+}
+operand {
+  name: "ifm"
+  type: FLOAT32
+  shape { dim: 1 dim: 8 dim: 8 dim: 32 }
+}
+operand {
+  name: "bias"
+  type: FLOAT32
+  shape { dim: 32 }
+  filler {
+    tag: "gaussian"
+    arg: "0.0"
+    arg: "1.0"
+  }
+}
+operand {
+  name: "ofm_tconv"
+  type: FLOAT32
+  shape { dim: 1 dim: 16 dim: 16 dim: 32 }
+}
+operation {
+  type: "TransposeConv"
+  input: "tconv_shape"
+  input: "filter"
+  input: "ifm"
+  input: "bias"
+  output: "ofm_tconv"
+  transpose_conv_options {
+    padding: SAME
+    stride_w: 2
+    stride_h: 2
+    activation: RELU
+  }
+}
+operand {
+  name: "offset"
+  type: INT32
+  shape { dim: 4 }
+  filler {
+    tag: "explicit"
+    arg: "0"
+    arg: "1"
+    arg: "1"
+    arg: "0"
+  }
+}
+operand {
+  name: "size"
+  type: INT32
+  shape { dim: 4 }
+  filler {
+    tag: "explicit"
+    arg: "1" 
+    arg: "15" 
+    arg: "15"
+    arg: "32"
+  }
+}
+operand {
+  name: "ofm"
+  type: FLOAT32
+  shape { dim: 1 dim: 15 dim: 15 dim: 32 }
+}
+operation {
+  type: "Slice"
+  input: "ofm_tconv"
+  input: "offset"
+  input: "size"
+  output: "ofm"
+}
+input: "ifm"
+output: "ofm"

--- a/res/TensorFlowLiteRecipes/Net_TConv_Slice_003/test.rule
+++ b/res/TensorFlowLiteRecipes/Net_TConv_Slice_003/test.rule
@@ -1,0 +1,6 @@
+# To check if TConv->Slice is converted to TConv operation
+
+RULE    "VERIFY_FILE_FORMAT"      $(verify_file_format) '=' 1
+
+RULE    "TCONV_EXIST"             $(op_count TRANSPOSE_CONV) '=' 1
+RULE    "SLICE_NOT_EXIST"         $(op_count SLICE) '=' 0


### PR DESCRIPTION
This commit adds models for testing TConv->Slice fusion with various parameters.

Its correctness is tested at https://github.com/Samsung/ONE/pull/11725.
Draft: https://github.com/Samsung/ONE/pull/11725
Related: https://github.com/Samsung/ONE/issues/10960

ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>