### PR TITLE
[luci] Introduce FuseSliceWithTConv

### DIFF
--- a/compiler/luci/pass/include/luci/CircleOptimizer.h
+++ b/compiler/luci/pass/include/luci/CircleOptimizer.h
@@ -39,6 +39,7 @@ public:
       FuseBatchNormWithConv,
       FuseBatchNormWithDwConv,
       FuseBatchNormWithTConv,
+      FuseSliceWithTConv,
       FuseBCQ,
       FuseInstanceNorm,
       FuseMeanWithMean,

--- a/compiler/luci/pass/src/CircleOptimizer.cpp
+++ b/compiler/luci/pass/src/CircleOptimizer.cpp
@@ -40,6 +40,7 @@
 #include "luci/Pass/FusePreActivationBatchNormPass.h"
 #include "luci/Pass/FusePReluPass.h"
 #include "luci/Pass/FuseGeluPass.h"
+#include "luci/Pass/FuseSliceWithTConvPass.h"
 #include "luci/Pass/FuseTransposeWithMeanPass.h"
 #include "luci/Pass/MakeBatchNormGammaPositivePass.h"
 #include "luci/Pass/RemoveDuplicateConstPass.h"
@@ -279,6 +280,10 @@ void CircleOptimizer::optimize(loco::Graph *g) const
   if (_options->query(Options::Algorithm::FuseBatchNormWithTConv))
   {
     phase.emplace_back(std::make_unique<FuseBatchNormWithTConvPass>());
+  }
+  if (_options->query(Options::Algorithm::FuseSliceWithTConv))
+  {
+    phase.emplace_back(std::make_unique<FuseSliceWithTConvPass>());
   }
   if (_options->query(Options::Algorithm::FuseAddWithFullyConnected))
   {


### PR DESCRIPTION
This commit introduces FuseSliceWithTConv option.

Its correctness is tested at https://github.com/Samsung/ONE/pull/11725.
Draft: https://github.com/Samsung/ONE/pull/11725
Related: https://github.com/Samsung/ONE/issues/10960

ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>