### PR TITLE
[circledump] OpPrinter should print enum name for Padding

### DIFF
--- a/compiler/circledump/src/OpPrinter.cpp
+++ b/compiler/circledump/src/OpPrinter.cpp
@@ -135,7 +135,7 @@ public:
     if (auto conv_params = op->builtin_options_as_Conv2DOptions())
     {
       os << "    ";
-      os << "Padding(" << conv_params->padding() << ") ";
+      os << "Padding(" << EnumNamePadding(conv_params->padding()) << ") ";
       os << "Stride.W(" << conv_params->stride_w() << ") ";
       os << "Stride.H(" << conv_params->stride_h() << ") ";
       os << "Dilation.W(" << conv_params->dilation_w_factor() << ") ";
@@ -184,7 +184,7 @@ public:
     if (auto pool_params = op->builtin_options_as_Pool2DOptions())
     {
       os << "    ";
-      os << "Padding(" << pool_params->padding() << ") ";
+      os << "Padding(" << EnumNamePadding(pool_params->padding()) << ") ";
       os << "Stride.W(" << pool_params->stride_w() << ") ";
       os << "Stride.H(" << pool_params->stride_h() << ") ";
       os << "Filter.W(" << pool_params->filter_width() << ") ";
@@ -298,7 +298,7 @@ public:
     if (auto conv_params = op->builtin_options_as_DepthwiseConv2DOptions())
     {
       os << "    ";
-      os << "Padding(" << conv_params->padding() << ") ";
+      os << "Padding(" << EnumNamePadding(conv_params->padding()) << ") ";
       os << "Stride.W(" << conv_params->stride_w() << ") ";
       os << "Stride.H(" << conv_params->stride_h() << ") ";
       os << "DepthMultiplier(" << conv_params->depth_multiplier() << ") ";
@@ -662,7 +662,7 @@ public:
     if (auto params = op->builtin_options_as_TransposeConvOptions())
     {
       os << "    ";
-      os << "Padding(" << params->padding() << ") ";
+      os << "Padding(" << EnumNamePadding(params->padding()) << ") ";
       os << "Stride.W(" << params->stride_w() << ") ";
       os << "Stride.H(" << params->stride_h() << ") ";
       os << "Activation(" << EnumNameActivationFunctionType(params->fused_activation_function())


### PR DESCRIPTION
OpPrinter printed enum value, not enum name for Padding.
It caused circledump's output as binary.
Now, it will print enum Padding name.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

Related: https://github.com/Samsung/ONE/pull/11699#issuecomment-1772717795

With this PR, padding is printed correctly.

### BEFORE
```
$ circledump Net_Conv_Relu6_000.circle
...
O(0:0) CONV_2D 
    Padding(^@) Stride.W(1) Stride.H(1) Dilation.W(1) Dilation.H(1) Activation(NONE)
    I T(0:0) Placeholder
    I T(0:1) Conv2D_1
    I T(0:2) Conv2D_2
    O T(0:4) Conv2D_11
O(0:1) RELU6 
    I T(0:4) Conv2D_11
    O T(0:5) ReLU6
O(0:2) CONV_2D 
    Padding(^@) Stride.W(1) Stride.H(1) Dilation.W(1) Dilation.H(1) Activation(NONE)
    I T(0:5) ReLU6
    I T(0:3) Conv2D_21
    I T(0:2) Conv2D_2
    O T(0:6) Conv2D_22
O(0:3) RELU6 
    I T(0:6) Conv2D_22
    O T(0:7) ReLU6_1

Inputs/Outputs: I(input)/O(output) T(tensor index) OperandName
I T(0:0) Placeholder
O T(0:7) ReLU6_1
```

### AFTER
```
$ circledump Net_Conv_Relu6_000.circle
...
O(0:0) CONV_2D 
    Padding(SAME) Stride.W(1) Stride.H(1) Dilation.W(1) Dilation.H(1) Activation(NONE)
    I T(0:0) Placeholder
    I T(0:1) Conv2D_1
    I T(0:2) Conv2D_2
    O T(0:4) Conv2D_11
O(0:1) RELU6 
    I T(0:4) Conv2D_11
    O T(0:5) ReLU6
O(0:2) CONV_2D 
    Padding(SAME) Stride.W(1) Stride.H(1) Dilation.W(1) Dilation.H(1) Activation(NONE)
    I T(0:5) ReLU6
    I T(0:3) Conv2D_21
    I T(0:2) Conv2D_2
    O T(0:6) Conv2D_22
O(0:3) RELU6 
    I T(0:6) Conv2D_22
    O T(0:7) ReLU6_1

Inputs/Outputs: I(input)/O(output) T(tensor index) OperandName
I T(0:0) Placeholder
O T(0:7) ReLU6_1
```

I will update `tflchef` after this is reviewed and merged.