### PR TITLE
[Draft][tflchef/circlechef] Use a dedicated type for custom operators

### DIFF
--- a/compiler/circlechef/proto/circlechef.proto
+++ b/compiler/circlechef/proto/circlechef.proto
@@ -91,7 +91,9 @@ message Operation {
   repeated string input = 2;
   repeated string output = 3;
   optional int32 version = 4 [default = 1];
+  optional string custom_code = 5;
 
+  optional string extype = 99;
   optional BatchMatMulOptions batch_matmul_options = 100;
   optional InstanceNormOptions instance_norm_options = 101;
   optional BCQFullyConnectedOptions bcq_fully_connected_options = 102;

--- a/compiler/tflchef/core/src/CustomOp/AddV2.cpp
+++ b/compiler/tflchef/core/src/CustomOp/AddV2.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "AddV2.h"
+#include "OpUtils.h"
 
 #include <flatbuffers/flexbuffers.h>
 
@@ -28,8 +29,7 @@ flatbuffers::Offset<flatbuffers::Vector<uint8_t>>
 AddV2Chef::custom_value(flatbuffers::FlatBufferBuilder &fbb) const
 {
   auto &operation = (*_operation);
-
-  assert(operation.type() == "AddV2");
+  check_custom_op_value(operation, "AddV2");
 
   /**
    * REGISTER_OP("AddV2")

--- a/compiler/tflchef/core/src/CustomOp/All.cpp
+++ b/compiler/tflchef/core/src/CustomOp/All.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "All.h"
+#include "OpUtils.h"
 
 #include <flatbuffers/flexbuffers.h>
 
@@ -28,8 +29,7 @@ flatbuffers::Offset<flatbuffers::Vector<uint8_t>>
 AllChef::custom_value(flatbuffers::FlatBufferBuilder &fbb) const
 {
   auto &operation = (*_operation);
-
-  assert(operation.type() == "All");
+  check_custom_op_value(operation, "All");
 
   /**
    * REGISTER_OP("All")

--- a/compiler/tflchef/core/src/CustomOp/BatchMatMulV2.cpp
+++ b/compiler/tflchef/core/src/CustomOp/BatchMatMulV2.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "BatchMatMulV2.h"
+#include "OpUtils.h"
 
 #include <flatbuffers/flexbuffers.h>
 
@@ -28,8 +29,7 @@ flatbuffers::Offset<flatbuffers::Vector<uint8_t>>
 BatchMatMulV2Chef::custom_value(flatbuffers::FlatBufferBuilder &fbb) const
 {
   auto &operation = (*_operation);
-
-  assert(operation.type() == "BatchMatMulV2");
+  check_custom_op_value(operation, "BatchMatMulV2");
 
   /**
    * REGISTER_OP("BatchMatMulV2")

--- a/compiler/tflchef/core/src/CustomOp/BroadcastTo.cpp
+++ b/compiler/tflchef/core/src/CustomOp/BroadcastTo.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "BroadcastTo.h"
+#include "OpUtils.h"
 
 #include <flatbuffers/flexbuffers.h>
 
@@ -28,8 +29,7 @@ flatbuffers::Offset<flatbuffers::Vector<uint8_t>>
 BroadcastToChef::custom_value(flatbuffers::FlatBufferBuilder &fbb) const
 {
   auto &operation = (*_operation);
-
-  assert(operation.type() == "BroadcastTo");
+  check_custom_op_value(operation, "BroadcastTo");
 
   /**
    * REGISTER_OP("BroadcastTo")

--- a/compiler/tflchef/core/src/CustomOp/Erf.cpp
+++ b/compiler/tflchef/core/src/CustomOp/Erf.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "Erf.h"
+#include "OpUtils.h"
 
 #include <flatbuffers/flexbuffers.h>
 
@@ -28,8 +29,7 @@ flatbuffers::Offset<flatbuffers::Vector<uint8_t>>
 ErfChef::custom_value(flatbuffers::FlatBufferBuilder &fbb) const
 {
   auto &operation = (*_operation);
-
-  assert(operation.type() == "Erf");
+  check_custom_op_value(operation, "Erf");
 
   /**
    * REGISTER_OP("Erf")

--- a/compiler/tflchef/core/src/CustomOp/MatMul.cpp
+++ b/compiler/tflchef/core/src/CustomOp/MatMul.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "MatMul.h"
+#include "OpUtils.h"
 
 #include <flatbuffers/flexbuffers.h>
 
@@ -28,8 +29,7 @@ flatbuffers::Offset<flatbuffers::Vector<uint8_t>>
 MatMulChef::custom_value(flatbuffers::FlatBufferBuilder &fbb) const
 {
   auto &operation = (*_operation);
-
-  assert(operation.type() == "MatMul");
+  check_custom_op_value(operation, "MatMul");
 
   /**
    * REGISTER_OP("MatMul")

--- a/compiler/tflchef/core/src/CustomOp/MatrixBandPart.cpp
+++ b/compiler/tflchef/core/src/CustomOp/MatrixBandPart.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "MatrixBandPart.h"
+#include "OpUtils.h"
 
 #include <flatbuffers/flexbuffers.h>
 
@@ -28,8 +29,7 @@ flatbuffers::Offset<flatbuffers::Vector<uint8_t>>
 MatrixBandPartChef::custom_value(flatbuffers::FlatBufferBuilder &fbb) const
 {
   auto &operation = (*_operation);
-
-  assert(operation.type() == "MatrixBandPart");
+  check_custom_op_value(operation, "MatrixBandPart");
 
   /**
    * REGISTER_OP("MatrixBandPart")

--- a/compiler/tflchef/core/src/CustomOp/MaxPoolWithArgmax.cpp
+++ b/compiler/tflchef/core/src/CustomOp/MaxPoolWithArgmax.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "MaxPoolWithArgmax.h"
+#include "OpUtils.h"
 
 #include <flatbuffers/flexbuffers.h>
 
@@ -28,8 +29,7 @@ flatbuffers::Offset<flatbuffers::Vector<uint8_t>>
 MaxPoolWithArgmaxChef::custom_value(flatbuffers::FlatBufferBuilder &fbb) const
 {
   auto &operation = (*_operation);
-
-  assert(operation.type() == "MaxPoolWithArgmax");
+  check_custom_op_value(operation, "MaxPoolWithArgmax");
 
   /**
    * REGISTER_OP("MaxPoolWithArgmax")

--- a/compiler/tflchef/core/src/ModelChef.cpp
+++ b/compiler/tflchef/core/src/ModelChef.cpp
@@ -141,10 +141,11 @@ gather_builtincode_map(const ::tflchef::ModelRecipe &model_recipe)
 
   for (const auto &operation : model_recipe.operation())
   {
-    auto op_chef = op_chef_registry().lookup(operation.type()).create(&operation);
-    if (op_chef->code() == tflite::BuiltinOperator_CUSTOM)
+    if ((operation.has_extype() && operation.extype() == "Custom") ||
+        (operation.has_type() && operation.type() == "Custom"))
       continue;
 
+    auto op_chef = op_chef_registry().lookup(operation.type()).create(&operation);
     // Various operation version is unified as the highest version among them
     if (builtin_map.find(op_chef->code()) == builtin_map.end() ||
         builtin_map[op_chef->code()] < operation.version())
@@ -157,10 +158,11 @@ gather_builtincode_map(const ::tflchef::ModelRecipe &model_recipe)
     const auto &graph = model_recipe.graph(g);
     for (const auto &operation : graph.operation())
     {
-      auto op_chef = op_chef_registry().lookup(operation.type()).create(&operation);
-      if (op_chef->code() == tflite::BuiltinOperator_CUSTOM)
+      if ((operation.has_extype() && operation.extype() == "Custom") ||
+          (operation.has_type() && operation.type() == "Custom"))
         continue;
 
+      auto op_chef = op_chef_registry().lookup(operation.type()).create(&operation);
       // Various operation version is unified as the highest version among them
       if (builtin_map.find(op_chef->code()) == builtin_map.end() ||
           builtin_map[op_chef->code()] < operation.version())
@@ -177,9 +179,12 @@ std::set<std::string> gather_customcode_set(const ::tflchef::ModelRecipe &model_
   std::set<std::string> customcode_set;
   for (const auto &operation : model_recipe.operation())
   {
-    auto op_chef = op_chef_registry().lookup(operation.type()).create(&operation);
-    if (op_chef->code() == tflite::BuiltinOperator_CUSTOM)
-      customcode_set.insert(operation.type());
+    if ((operation.has_extype() && operation.extype() == "Custom") ||
+        (operation.has_type() && operation.type() == "Custom"))
+    {
+      assert(operation.has_custom_code());
+      customcode_set.insert(operation.custom_code());
+    }
   }
 
   // Add ops used in Graphs(subgraphs)
@@ -188,9 +193,12 @@ std::set<std::string> gather_customcode_set(const ::tflchef::ModelRecipe &model_
     const auto &graph = model_recipe.graph(g);
     for (const auto &operation : graph.operation())
     {
-      auto op_chef = op_chef_registry().lookup(operation.type()).create(&operation);
-      if (op_chef->code() == tflite::BuiltinOperator_CUSTOM)
-        customcode_set.insert(operation.type());
+      if ((operation.has_extype() && operation.extype() == "Custom") ||
+          (operation.has_type() && operation.type() == "Custom"))
+      {
+        assert(operation.has_custom_code());
+        customcode_set.insert(operation.custom_code());
+      }
     }
   }
 
@@ -619,7 +627,11 @@ template <typename T> std::map<std::string, int32_t> cook_graph(const T &graph, 
   {
     assert(operation.has_type());
 
-    auto op_chef = op_chef_registry().lookup(operation.type()).create(&operation);
+    std::string op_type = operation.type();
+    if (operation.has_custom_code())
+      op_type = operation.custom_code();
+
+    auto op_chef = op_chef_registry().lookup(op_type).create(&operation);
 
     // Create 'inputs'
     std::vector<int32_t> input_vec = as_dataset(operation.input()).map(lookup).vectorize();
@@ -650,7 +662,8 @@ template <typename T> std::map<std::string, int32_t> cook_graph(const T &graph, 
     // custom operator
     else
     {
-      auto op_it = std::find(custom_code_vec.begin(), custom_code_vec.end(), operation.type());
+      auto op_it =
+        std::find(custom_code_vec.begin(), custom_code_vec.end(), operation.custom_code());
       assert(op_it != custom_code_vec.end());
       opcode_index = builtin_code_map.size();
       opcode_index += std::distance(custom_code_vec.begin(), op_it);

--- a/compiler/tflchef/core/src/OpUtils.cpp
+++ b/compiler/tflchef/core/src/OpUtils.cpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "OpUtils.h"
+
+#include <stdexcept>
+
+void check_custom_op_value(const tflchef::Operation operation, std::string op_type)
+{
+  if ((operation.has_extype() && operation.extype() == "Custom") ||
+      (operation.has_type() && operation.type() == "Custom"))
+  {
+    assert(operation.has_custom_code());
+    assert(operation.custom_code() == op_type);
+  }
+}

--- a/compiler/tflchef/core/src/OpUtils.h
+++ b/compiler/tflchef/core/src/OpUtils.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file  OpUtils.h
+ * @brief This header declares various op_utils functions
+ */
+#ifndef __OPUTILS_H__
+#define __OPUTILS_H__
+
+#include <tflchef.pb.h>
+
+void check_custom_op_value(const tflchef::Operation operation, std::string op_type);
+
+#endif // __OPUTILS_H__

--- a/compiler/tflchef/proto/tflchef.proto
+++ b/compiler/tflchef/proto/tflchef.proto
@@ -556,7 +556,9 @@ message Operation {
   repeated string input = 2;
   repeated string output = 3;
   optional int32 version = 4 [default = 1];
+  optional string custom_code = 5;
 
+  optional string extype = 99;
   optional Conv2DOptions conv2d_options = 100;
   optional Pool2DOptions averagepool2d_options = 101;
   optional ConcatenationOptions concatenation_options = 102;

--- a/compiler/tflchef/tests/custom_erf/test.recipe
+++ b/compiler/tflchef/tests/custom_erf/test.recipe
@@ -12,6 +12,8 @@ operation {
   type: "Erf"
   input: "ifm"
   output: "ofm"
+  custom_code: "Erf"
+  extype: "Custom"
 }
 input: "ifm"
 output: "ofm"

--- a/res/TensorFlowLiteRecipes/All_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/All_000/test.recipe
@@ -25,6 +25,8 @@ operation {
   input: "ifm"
   input: "All/reduction_indices"
   output: "ofm"
+  custom_code: "All"
+  extype: "Custom"
 }
 input: "ifm"
 output: "ofm"

--- a/res/TensorFlowLiteRecipes/BatchMatMulV2_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/BatchMatMulV2_000/test.recipe
@@ -18,6 +18,8 @@ operation {
   input: "ifm1"
   input: "ifm2"
   output: "ofm"
+  custom_code: "BatchMatMulV2"
+  extype: "Custom"
 }
 input: "ifm1"
 input: "ifm2"

--- a/res/TensorFlowLiteRecipes/BatchMatMulV2_001/test.recipe
+++ b/res/TensorFlowLiteRecipes/BatchMatMulV2_001/test.recipe
@@ -21,6 +21,8 @@ operation {
   input: "ifm1"
   input: "ifm2"
   output: "ofm"
+  custom_code: "BatchMatMulV2"
+  extype: "Custom"
 }
 input: "ifm1"
 input: "ifm2"

--- a/res/TensorFlowLiteRecipes/BroadcastTo_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/BroadcastTo_000/test.recipe
@@ -19,6 +19,8 @@ operation {
   input: "bc_input"
   input: "bc_shape"
   output: "bc_ofm"
+  custom_code: "BroadcastTo"
+  extype: "Custom"
 }
 input: "bc_input"
 output: "bc_ofm"

--- a/res/TensorFlowLiteRecipes/MatMul_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/MatMul_000/test.recipe
@@ -22,6 +22,8 @@ operation {
     transpose_a: true
     transpose_b: false
   }
+  custom_code: "MatMul"
+  extype: "Custom"
 }
 input: "ifm1"
 input: "ifm2"

--- a/res/TensorFlowLiteRecipes/MatrixBandPart_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/MatrixBandPart_000/test.recipe
@@ -32,6 +32,8 @@ operation {
   input: "MatrixBandPart/num_lower"
   input: "MatrixBandPart/num_upper"
   output: "ofm"
+  custom_code: "MatrixBandPart"
+  extype: "Custom"
 }
 input: "ifm"
 output: "ofm"

--- a/res/TensorFlowLiteRecipes/MaxPoolWithArgmax_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/MaxPoolWithArgmax_000/test.recipe
@@ -27,6 +27,8 @@ operation {
     output_type: INT64
     include_batch_in_index: false
   }
+  custom_code: "MaxPoolWithArgmax"
+  extype: "Custom"
 }
 input: "ifm"
 output: "ofm"

--- a/res/TensorFlowLiteRecipes/MaxPoolWithArgmax_001/test.recipe
+++ b/res/TensorFlowLiteRecipes/MaxPoolWithArgmax_001/test.recipe
@@ -27,6 +27,8 @@ operation {
     output_type: INT32
     include_batch_in_index: false
   }
+  custom_code: "MaxPoolWithArgmax"
+  extype: "Custom"
 }
 input: "ifm"
 output: "ofm"

--- a/res/TensorFlowLiteRecipes/MaxPoolWithArgmax_002/test.recipe
+++ b/res/TensorFlowLiteRecipes/MaxPoolWithArgmax_002/test.recipe
@@ -27,6 +27,8 @@ operation {
     output_type: INT64
     include_batch_in_index: false
   }
+  custom_code: "MaxPoolWithArgmax"
+  extype: "Custom"
 }
 input: "ifm"
 output: "ofm"

--- a/res/TensorFlowLiteRecipes/Net_BroadcastTo_AddV2_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/Net_BroadcastTo_AddV2_000/test.recipe
@@ -19,6 +19,8 @@ operation {
   input: "bc_input"
   input: "bc_shape"
   output: "bc_ofm"
+  custom_code: "BroadcastTo"
+  extype: "Custom"
 }
 operand {
   name: "reshape_data"
@@ -57,6 +59,8 @@ operation {
   input: "bc_ofm"
   input: "reshape_ofm"
   output: "ofm"
+  custom_code: "AddV2"
+  extype: "Custom"
 }
 input: "bc_input"
 input: "reshape_data"

--- a/res/TensorFlowLiteRecipes/Net_BroadcastTo_AddV2_001/test.recipe
+++ b/res/TensorFlowLiteRecipes/Net_BroadcastTo_AddV2_001/test.recipe
@@ -19,6 +19,8 @@ operation {
   input: "bc_input"
   input: "bc_shape"
   output: "bc_ofm"
+  custom_code: "BroadcastTo"
+  extype: "Custom"
 }
 operand {
   name: "reshape_data"
@@ -53,10 +55,12 @@ operand {
   shape { dim: 1 dim: 2 dim: 3 }
 }
 operation {
-  type: "AddV2"
+  type: "BroadcastTo"
   input: "bc_ofm"
   input: "reshape_ofm"
   output: "ofm"
+  custom_code: "AddV2"
+  extype: "Custom"
 }
 input: "bc_input"
 input: "reshape_data"

--- a/res/TensorFlowLiteRecipes/Net_FC_Gelu_FC_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/Net_FC_Gelu_FC_000/test.recipe
@@ -104,6 +104,8 @@ operation {
   type: "Erf"
   input: "fc2"
   output: "erf"
+  custom_code: "Erf"
+  extype: "Custom"
 }
 operation {
   type: "Add"

--- a/res/TensorFlowLiteRecipes/Net_Gather_SparseToDense_AddV2_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/Net_Gather_SparseToDense_AddV2_000/test.recipe
@@ -103,6 +103,8 @@ operation {
   input: "ofm_sparse"
   input: "add_v2_2"
   output: "ofm_add_v2"
+  custom_code: "AddV2"
+  extype: "Custom"
 }
 operation {
   type: "Cast"

--- a/res/TensorFlowLiteRecipes/Net_Gelu_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/Net_Gelu_000/test.recipe
@@ -68,6 +68,8 @@ operation {
   type: "Erf"
   input: "mul_sqrt"
   output: "erf"
+  custom_code: "Erf"
+  extype: "Custom"
 }
 operation {
   type: "Add"

--- a/res/TensorFlowLiteRecipes/Net_Gelu_001/test.recipe
+++ b/res/TensorFlowLiteRecipes/Net_Gelu_001/test.recipe
@@ -68,6 +68,8 @@ operation {
   type: "Erf"
   input: "mul_sqrt"
   output: "erf"
+  custom_code: "Erf"
+  extype: "Custom"
 }
 operation {
   type: "Add"


### PR DESCRIPTION
On going draft to use a dedicated type for custom operators in the recipe.

ONE-DCO-1.0-Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>

---
Related Issue : https://github.com/Samsung/ONE/issues/11741