### PR TITLE
[tools] Update android SDK & NDK install script

### DIFF
--- a/docs/nnfw/howto/CrossBuildForAndroid.md
+++ b/docs/nnfw/howto/CrossBuildForAndroid.md
@@ -7,34 +7,24 @@ Supported Architecture : AARCH64 only (ARM32 is not supported yet)
 ## Prepare Android NDK
 
 Use `tools/cross/install_android_ndk.sh` script to prepare Android NDK. This is recommended way to build Android NDK.
-You may download it yourself from the offical Android NDK website, but the script does a little more than just downloading and unzipping.
+
+Or you can use `tools/cross/install_android_sdk.sh` script to prepare Android SDK including NDK. You can find NDK in `{android-sdk-dir}/ndk/{ndk-version}` directory.
 
 ## Build
 
 ### Host Environment Requirements
 
-With Ubuntu 16.04, everything is fine except one. CMake 3.6.0 or later is required for Android NDK CMake support.
-So if you want to use Docker, please use `infra/docker/Dockerfile.1804` which is based on Ubuntu 18.04. It has CMake 3.10.2.
-
-```bash
-docker build --network host -t nnas1804 -f infra/docker/Dockerfile.1804 infra/docker
-```
-
-### Get prebuilt ARM Compute Library
-
-Download prebuilt binary from [github](https://github.com/ARM-software/ComputeLibrary/releases). Check the version we support and platform(Android).
-
-Then extract the tarball to the folder indicated as EXT_ACL_FOLDER in the example below. We will use the following file in `lib/android-arm64-v8a-neon-cl`.
+CMake 3.6.0 or later is required for Android NDK r20 CMake support.
+So if you want to use Docker, please use `infra/docker/focal/Dockerfile` which is based on Ubuntu 20.04. It has CMake 3.16.3.
 
 ```
-libarm_compute_core.so
-libarm_compute_graph.so
-libarm_compute.so
+$ ./nnas build-docker-image -t nnfw/one-devtools:focal
 ```
+
 
 ### Build and install the runtime
 
-Some tools/libs are still not supported and those are not built by default - mostly due to dependency on Boost library.
+Some tools/libs are still not supported and those are not built by default - mostly due to dependency on HDF5 library.
 Please refer to `infra/nnfw/cmake/options/options_aarch64-android.cmake` for details.
 
 Different from cross build for linux,
@@ -46,7 +36,6 @@ Here is an example of using Makefile.
 ```bash
 TARGET_OS=android \
 CROSS_BUILD=1 \
-NDK_DIR=/path/android-tools/r20/ndk \
-EXT_ACL_FOLDER=/path/arm_compute-v19.11.1-bin-android/lib/android-arm64-v8a-neon-cl \
+NDK_DIR=/path/android-sdk/ndk/{ndk-version}/ \
 make -f Makefile.template install
 ```

--- a/tools/cross/install_android_ndk.sh
+++ b/tools/cross/install_android_ndk.sh
@@ -59,7 +59,7 @@ do
     shift
 done
 
-__InstallDir=${__InstallDir:-"${__CrossDir}/ndk/${__NDKVersion}"}
+__InstallDir=${__InstallDir:-"${__CrossDir}/ndk"}
 
 NDK_DIR=android-ndk-${__NDKVersion}
 NDK_ZIP=${NDK_DIR}-linux-x86_64.zip
@@ -82,4 +82,3 @@ fi
 echo "Unzipping Android NDK"
 unzip -qq -o $__InstallDir/$NDK_ZIP -d $__InstallDir
 rm $__InstallDir/$NDK_ZIP
-mv  $__InstallDir/${NDK_DIR} "$__InstallDir/ndk" # This is necessary since Tensorflow Lite does include like `#include "ndk/sources/..."`

--- a/tools/cross/install_android_sdk.sh
+++ b/tools/cross/install_android_sdk.sh
@@ -17,9 +17,11 @@
 # Setup Android Cross-Build Environment (ANDROID SDK)
 SCRIPT_HOME=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd ) # absolute path to directory where script is
 INSTALL_PATH=$SCRIPT_HOME/android_sdk # path to directory where android sdk will be installed
-PLATFORMS_PACKAGE_VERSION="28" # version of platfroms package which will be installed
-BUILD_TOOLS_PACKAGE_VERSION="28.0.0" # version of build-tools package which will be installed
-COMMAND_LINE_TOOLS_ARCHIVE="commandlinetools-linux-6200805_latest.zip" # command line tools archive name from site https://developer.android.com/studio/#downloads
+PLATFORMS_PACKAGE_VERSION="29" # version of platfroms package which will be installed
+BUILD_TOOLS_PACKAGE_VERSION="29.0.3" # version of build-tools package which will be installed
+NDK_VERSION="20.0.5594570" # version of ndk which will be installed
+COMMAND_LINE_TOOLS_ARCHIVE="commandlinetools-linux-6514223_latest.zip" # command line tools archive name from site https://developer.android.com/studio/#downloads for bootstrap
+COMMAND_LINE_TOOLS_VERSION="10.0" # version of command line tools which will be installed
 
 
 usage() {
@@ -27,6 +29,7 @@ usage() {
  printf "  --install-dir                 - absolute path to directory where android sdk will be installed, by default: $INSTALL_PATH\n"
  printf "  --platforms-package-version   - version of platforms package which will be installed, by default: $PLATFORMS_PACKAGE_VERSION\n"
  printf "  --build-tools-package-version - version of build-tools package which will be installed, by default: $BUILD_TOOLS_PACKAGE_VERSION\n"
+ printf "  --command-line-tools-version  - version of cmdline-tools package which will be installed, by default: $COMMAND_LINE_TOOLS_VERSION\n"
  printf "  --command-line-tools-archive  - name of command line tools archive from site https://developer.android.com/studio/#downloads, by default: $COMMAND_LINE_TOOLS_ARCHIVE\n"
  printf "  --help                        - show this text\n"
 }
@@ -35,8 +38,8 @@ check_that_available() {
   local util_name=${1}
   local possible_util_alias=${2}
   if ! [ -x "$(command -v $util_name)" ]; then
-    printf "ERROR: this script uses $util_name utility, "
-    printf "please install it and repeat try (e.g. for ubuntu execute command: sudo apt install $possible_util_alias)"
+    printf "ERROR: this script uses $util_name utility, \n"
+    printf "please install it and repeat try (e.g. for ubuntu execute command: sudo apt install $possible_util_alias)\n"
     exit 1
   fi
 }
@@ -44,7 +47,7 @@ check_that_available() {
 check_preconditions() {
   check_that_available wget wget
   check_that_available unzip unzip
-  check_that_available java default-jdk
+  check_that_available java 'default-jdk or openjdk-{version}-jdk. SDK command line tools require proper openjdk version'
 }
 
 check_that_android_sdk_have_not_been_installed_yet() {
@@ -61,19 +64,19 @@ make_environment() {
   check_that_android_sdk_have_not_been_installed_yet $root
   mkdir -p $root
 
-  pushd $root
+  pushd $root > /dev/null
   export ANDROID_HOME=$root
-  export PATH=$PATH:/$ANDROID_HOME/tools/bin
-  export PATH=$PATH:/$ANDROID_HOME/platform-tools
+  export PATH=$PATH:$ANDROID_HOME/cmdline-tools/${COMMAND_LINE_TOOLS_VERSION}/bin
+  export PATH=$PATH:$ANDROID_HOME/platform-tools
   export JAVA_OPTS='-XX:+IgnoreUnrecognizedVMOptions'
-  popd
+  popd > /dev/null
 }
 
-download_command_line_tools() {
+install_command_line_tools() {
   local root=${1}
   local download_url=https://dl.google.com/android/repository
-
-  pushd $root
+  temp_dir=$(mktemp -d)
+  pushd $temp_dir > /dev/null
   wget $download_url/$COMMAND_LINE_TOOLS_ARCHIVE
   if [ ${?} -ne 0 ]; then
     echo "seems like '$COMMAND_LINE_TOOLS_ARCHIVE' not found. Please, go to https://developer.android.com/studio/#downloads "
@@ -81,23 +84,15 @@ download_command_line_tools() {
     echo "and put it as --command-line-tools-archive-name parameter value"
     exit 1
   fi
-  popd
-}
 
-extract_command_line_tools() {
-  local root=${1}
-
-  pushd $root
   unzip $COMMAND_LINE_TOOLS_ARCHIVE
   rm $COMMAND_LINE_TOOLS_ARCHIVE
-  popd
-}
 
-install_command_line_tools() {
-  local root=${1}
+  yes | tools/bin/sdkmanager --sdk_root=${root} --licenses
+  tools/bin/sdkmanager --sdk_root=${root} "cmdline-tools;${COMMAND_LINE_TOOLS_VERSION}"
+  popd > /dev/null
 
-  download_command_line_tools $root
-  extract_command_line_tools $root
+  rm -rf $temp_dir
 }
 
 check_that_given_version_of_package_available() {
@@ -115,16 +110,23 @@ check_that_given_version_of_package_available() {
 install_android_sdk() {
   local root=${1}
 
-  pushd $root
-  yes | sdkmanager --sdk_root=${ANDROID_HOME} --licenses > /dev/null
+  pushd $root > /dev/null
   check_that_given_version_of_package_available "platforms;android-" ${PLATFORMS_PACKAGE_VERSION}
   check_that_given_version_of_package_available "build-tools;" ${BUILD_TOOLS_PACKAGE_VERSION}
-  sdkmanager --sdk_root=${ANDROID_HOME} "platform-tools"
-  sdkmanager --sdk_root=${ANDROID_HOME} "platforms;android-$PLATFORMS_PACKAGE_VERSION"
-  sdkmanager --sdk_root=${ANDROID_HOME} "build-tools;$BUILD_TOOLS_PACKAGE_VERSION"
-  popd
+  sdkmanager --sdk_root=${root} "platform-tools" "emulator"
+  sdkmanager --sdk_root=${root} "platforms;android-$PLATFORMS_PACKAGE_VERSION"
+  sdkmanager --sdk_root=${root} "build-tools;$BUILD_TOOLS_PACKAGE_VERSION"
+  popd > /dev/null
 }
 
+install_android_ndk() {
+  local root=${1}
+
+  pushd $root > /dev/null
+  sdkmanager --sdk_root=${root} "ndk;$NDK_VERSION"
+  echo "Android NDK is installed on $root"/ndk/$NDK_VERSION" directory"
+  popd > /dev/null
+}
 
 while [[ $# -gt 0 ]]; do
   key="$(echo $1 | awk '{print tolower($0)}')"
@@ -148,6 +150,11 @@ while [[ $# -gt 0 ]]; do
       BUILD_TOOLS_PACKAGE_VERSION=${1}
       shift
       ;;
+    --ndk-version)
+      shift
+      NDK_VERSION=${1}
+      shift
+      ;;
     --command-line-tools-archive)
       shift
       COMMAND_LINE_TOOLS_ARCHIVE=${1}
@@ -164,4 +171,5 @@ done
 check_preconditions
 make_environment $INSTALL_PATH
 install_command_line_tools $INSTALL_PATH
+install_android_ndk $INSTALL_PATH
 install_android_sdk $INSTALL_PATH


### PR DESCRIPTION
This commit updates android SDK & NDK install script
- Remove NDK install path workaround for TFLite 1.13.1
- Update SDK initial commandline tool version to same version with dockerfile
- Update SDK commandline tool install process for easy version up
- Update runtime android build documentation

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>