### PR TITLE
[tflchef] Introduce extype and custom_code for custom operators

### DIFF
--- a/compiler/tflchef/proto/tflchef.proto
+++ b/compiler/tflchef/proto/tflchef.proto
@@ -556,9 +556,9 @@ message Operation {
   repeated string input = 2;
   repeated string output = 3;
   optional int32 version = 4 [default = 1];
-  optional string extype = 5;
-  optional string custom_code = 6;
+  optional string custom_code = 5;
 
+  optional string extype = 99;
   optional Conv2DOptions conv2d_options = 100;
   optional Pool2DOptions averagepool2d_options = 101;
   optional ConcatenationOptions concatenation_options = 102;

--- a/compiler/tflchef/proto/tflchef.proto
+++ b/compiler/tflchef/proto/tflchef.proto
@@ -556,6 +556,8 @@ message Operation {
   repeated string input = 2;
   repeated string output = 3;
   optional int32 version = 4 [default = 1];
+  optional string extype = 5;
+  optional string custom_code = 6;
 
   optional Conv2DOptions conv2d_options = 100;
   optional Pool2DOptions averagepool2d_options = 101;


### PR DESCRIPTION
This introduces extype and custom_code for custom operators.

ONE-DCO-1.0-Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>

---
Related Issue: https://github.com/Samsung/ONE/issues/11741
Draft PR: https://github.com/Samsung/ONE/pull/11750