### PR TITLE
[circlechef] Introduce extype and custom_code for custom operators

### DIFF
--- a/compiler/circlechef/proto/circlechef.proto
+++ b/compiler/circlechef/proto/circlechef.proto
@@ -91,6 +91,8 @@ message Operation {
   repeated string input = 2;
   repeated string output = 3;
   optional int32 version = 4 [default = 1];
+  optional string extype = 5;
+  optional string custom_code = 6;
 
   optional BatchMatMulOptions batch_matmul_options = 100;
   optional InstanceNormOptions instance_norm_options = 101;

--- a/compiler/circlechef/proto/circlechef.proto
+++ b/compiler/circlechef/proto/circlechef.proto
@@ -91,9 +91,9 @@ message Operation {
   repeated string input = 2;
   repeated string output = 3;
   optional int32 version = 4 [default = 1];
-  optional string extype = 5;
-  optional string custom_code = 6;
+  optional string custom_code = 5;
 
+  optional string extype = 99;
   optional BatchMatMulOptions batch_matmul_options = 100;
   optional InstanceNormOptions instance_norm_options = 101;
   optional BCQFullyConnectedOptions bcq_fully_connected_options = 102;


### PR DESCRIPTION
This introduces extype and custom_code for custom operators.

ONE-DCO-1.0-Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>

---
Related Issue: https://github.com/Samsung/ONE/issues/11741
Draft PR: https://github.com/Samsung/ONE/pull/11750