### PR TITLE
[tfldump] OpPrinter should print enum name for Padding

### DIFF
--- a/compiler/tfldump/src/OpPrinter.cpp
+++ b/compiler/tfldump/src/OpPrinter.cpp
@@ -117,7 +117,7 @@ public:
     if (auto conv_params = op->builtin_options_as_Conv2DOptions())
     {
       os << "    ";
-      os << "Padding(" << conv_params->padding() << ") ";
+      os << "Padding(" << EnumNamePadding(conv_params->padding()) << ") ";
       os << "Stride.W(" << conv_params->stride_w() << ") ";
       os << "Stride.H(" << conv_params->stride_h() << ") ";
       os << "Dilation.W(" << conv_params->dilation_w_factor() << ") ";
@@ -152,7 +152,7 @@ public:
     if (auto pool_params = op->builtin_options_as_Pool2DOptions())
     {
       os << "    ";
-      os << "Padding(" << pool_params->padding() << ") ";
+      os << "Padding(" << EnumNamePadding(pool_params->padding()) << ") ";
       os << "Stride.W(" << pool_params->stride_w() << ") ";
       os << "Stride.H(" << pool_params->stride_h() << ") ";
       os << "Filter.W(" << pool_params->filter_width() << ") ";
@@ -294,7 +294,7 @@ public:
     if (auto conv_params = op->builtin_options_as_DepthwiseConv2DOptions())
     {
       os << "    ";
-      os << "Padding(" << conv_params->padding() << ") ";
+      os << "Padding(" << EnumNamePadding(conv_params->padding()) << ") ";
       os << "Stride.W(" << conv_params->stride_w() << ") ";
       os << "Stride.H(" << conv_params->stride_h() << ") ";
       os << "DepthMultiplier(" << conv_params->depth_multiplier() << ") ";
@@ -640,7 +640,7 @@ public:
     if (auto *params = op->builtin_options_as_TransposeConvOptions())
     {
       os << "    ";
-      os << "Padding(" << params->padding() << ") ";
+      os << "Padding(" << EnumNamePadding(params->padding()) << ") ";
       os << "Stride.W(" << params->stride_w() << ") ";
       os << "Stride.H(" << params->stride_h() << ") ";
       os << "Activation(" << EnumNameActivationFunctionType(params->fused_activation_function())


### PR DESCRIPTION
OpPrinter printed enum value, not enum name for Padding. It caused tfldump's output as binary.
Now, it will print enum Padding name.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

It is a twin PR for `tfldump`.

Related: #11749