### PR TITLE
[one-quantize] Support QuantizeWeightsOnly for FullyConnected

### DIFF
--- a/compiler/luci/pass/src/QuantizeWeightsOnly.cpp
+++ b/compiler/luci/pass/src/QuantizeWeightsOnly.cpp
@@ -205,6 +205,20 @@ void QuantizeWeightsOnly::visit(luci::CircleConv2D *node)
   }
 }
 
+void QuantizeWeightsOnly::visit(luci::CircleFullyConnected *node)
+{
+  LOGGER(l);
+  INFO(l) << "QuantizeWeightsOnly visit node: " << node->name() << std::endl;
+
+  auto weights = loco::must_cast<luci::CircleConst *>(node->weights());
+  if (!is_quantized(weights))
+  {
+    auto new_weights = luci::clone(weights);
+    node->weights(new_weights);
+    quantize_weights(new_weights);
+  }
+}
+
 void QuantizeWeightsOnly::visit(luci::CircleDepthwiseConv2D *node)
 {
   LOGGER(l);

--- a/compiler/luci/pass/src/QuantizeWeightsOnly.h
+++ b/compiler/luci/pass/src/QuantizeWeightsOnly.h
@@ -42,6 +42,7 @@ private:
   void quantize_weights(luci::CircleConst *weights);
 
   void visit(luci::CircleConv2D *node);
+  void visit(luci::CircleFullyConnected *node);
   void visit(luci::CircleDepthwiseConv2D *node);
   void visit(luci::CircleNode *);
 };

--- a/compiler/luci/pass/src/QuantizeWeightsOnly.h
+++ b/compiler/luci/pass/src/QuantizeWeightsOnly.h
@@ -42,8 +42,8 @@ private:
   void quantize_weights(luci::CircleConst *weights);
 
   void visit(luci::CircleConv2D *node);
-  void visit(luci::CircleFullyConnected *node);
   void visit(luci::CircleDepthwiseConv2D *node);
+  void visit(luci::CircleFullyConnected *node);
   void visit(luci::CircleNode *);
 };
 


### PR DESCRIPTION
This commit supports QuantizeWeightsOnly for FullyConnected.

for issue:  #11772

ONE-DCO-1.0-Signed-off-by: Artem Balyshev <a.balyshev@samsung.com>