### PR TITLE
Draft: prepare clang-format version up

### DIFF
--- a/.clang-format.16
+++ b/.clang-format.16
@@ -1,0 +1,93 @@
+Language:        Cpp
+BasedOnStyle: Google
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignEscapedNewlinesLeft: true
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: false
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterClass:             true
+  AfterCaseLabel:         true
+  AfterControlStatement:  true
+  AfterEnum:              true
+  AfterFunction:          true
+  AfterNamespace:         true
+  AfterObjCDeclaration:   false
+  AfterStruct:            true
+  AfterUnion:             false
+  AfterExternBlock:       false
+  BeforeCatch:            true
+  BeforeElse:             true
+  IndentBraces:           false
+BreakBeforeBraces: Custom
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     100
+CommentPragmas:  '^ IWYU pragma:'
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 2
+ContinuationIndentWidth: 2
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+  - Regex:           '^(<|"(gtest|isl|json)/)'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        1
+IndentCaseLabels: true
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Right
+ReflowComments:  true
+SortIncludes:    false
+SortUsingDeclarations: false
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+TabWidth:        2
+UseTab:          Never

--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -28,16 +28,22 @@ jobs:
         with:
           python-version: '3.x'
 
-      # C format: clang-format-8
+      # C format: clang-format-8 & clang-format-16
       # Python format: yapf==0.22.0
       - name: Install packages
         run: |
-          sudo apt-get install -y clang-format-8
+          sudo apt-get install -y gnupg2 software-properties-common
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          sudo add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-16 main"
+          sudo apt-get update
+          sudo apt-get install -y clang-format-8 clang-format-16
           python -m pip install --upgrade pip
           pip install yapf==0.22.0
 
       - name: Check
-        run: ./nnas format
+        run: |
+          ./nnas format --exclude runtime
+          ./nnas format --clang-format-version 16 runtime
 
       # Upload patch file if failed
       - name: Store archive

--- a/infra/command/format
+++ b/infra/command/format
@@ -4,11 +4,12 @@ INVALID_EXIT=0
 FILES_TO_CHECK=()
 DIRECTORIES_TO_BE_TESTED=()
 DIRECTORIES_NOT_TO_BE_TESTED=()
-DEFAULT_CLANG_FORMAT="clang-format-8"
-CLANG_FORMAT_CANDIDATES=()
+DEFAULT_CLANG_VERSION="8"
+CLANG_FORMAT_CANDIDATE=clang-format-$DEFAULT_CLANG_VERSION
 PATCH_FILE=format.patch
 CHECK_DIFF_ONLY="0"
 CHECK_STAGED_ONLY="0"
+CLANG_STYLE_FILE=
 
 function Usage()
 {
@@ -17,9 +18,10 @@ function Usage()
   echo "If <file>s are given, it reformats the files"
   echo ""
   echo "Options:"
-  echo "      --clang-format <TOOL>     clang format bin (default: $DEFAULT_CLANG_FORMAT)"
-  echo "      --diff-only               check diff files with master"
-  echo "      --staged-only             check git staged files"
+  echo "      --clang-format-version <version>  clang format version (default: ${DEFAULT_CLANG_VERSION})"
+  echo "      --diff-only                       check diff files with master"
+  echo "      --staged-only                     check git staged files"
+  echo "      --exclude <path>                  exclude format check"
 }
 
 while [[ $# -gt 0 ]]
@@ -30,13 +32,10 @@ do
       Usage
       exit 0
       ;;
-    --clang-format)
-      CLANG_FORMAT_CANDIDATES=($2)
+    --clang-format-version)
+      CLANG_FORMAT_CANDIDATE=clang-format-$2
+      CLANG_STYLE_FILE=.clang-format.$2
       shift 2
-      ;;
-    --clang-format=*)
-      CLANG_FORMAT_CANDIDATES=(${1#*=})
-      shift
       ;;
     --staged-only)
       CHECK_STAGED_ONLY="1"
@@ -46,6 +45,10 @@ do
     --diff-only)
       CHECK_DIFF_ONLY="1"
       shift
+      ;;
+    --exclude)
+      DIRECTORIES_NOT_TO_BE_TESTED+=($2)
+      shift 2
       ;;
     *)
       DIRECTORIES_TO_BE_TESTED+=($1)
@@ -104,18 +107,19 @@ function check_cpp_files() {
     return
   fi
 
-  CLANG_FORMAT_CANDIDATES+=($DEFAULT_CLANG_FORMAT)
-  for CLANG_FORMAT_CANDIDATE in ${CLANG_FORMAT_CANDIDATES[@]}; do
-    if command_exists ${CLANG_FORMAT_CANDIDATE} ; then
-      CLANG_FORMAT="${CLANG_FORMAT_CANDIDATE}"
-      break
-    fi
-  done
+  if command_exists $CLANG_FORMAT_CANDIDATE ; then
+    CLANG_FORMAT=$CLANG_FORMAT_CANDIDATE
+  fi
 
-  if [[ -z ${CLANG_FORMAT}  ]]; then
-    echo "[ERROR] $CLANG_FORMAT is unavailable"
+  if [[ -z "${CLANG_FORMAT}"  ]]; then
+    echo "[ERROR] $CLANG_FORMAT_CANDIDATE is unavailable"
     echo
-    echo "        Please install $DEFAULT_CLANG_FORMAT before running format check"
+    echo "        Please install $CLANG_FORMAT_CANDIDATE before running format check"
+    exit 1
+  fi
+
+  if  [[ -n "${CLANG_STYLE_FILE}" ]] && [[ ! -e ${CLANG_STYLE_FILE} ]]; then
+    echo "[ERROR] Cannot find clang style file: ${CLANG_STYLE_FILE}"
     exit 1
   fi
 
@@ -128,12 +132,20 @@ function check_cpp_files() {
 
   # Skip by '.FORMATDENY' file
   for s in ${DIRECTORIES_NOT_TO_BE_TESTED[@]}; do
-    FILES_TO_CHECK_CPP=(${FILES_TO_CHECK_CPP[*]/$s*/})
-    FILES_TO_CHECK_CPP_BY_CLANG_FORMAT_8=(${FILES_TO_CHECK_CPP_BY_CLANG_FORMAT_8[*]/$s*/})
+    for i in "${!FILES_TO_CHECK_CPP[@]}"; do
+      if [[ "${FILES_TO_CHECK_CPP[$i]}" == "$s"* ]]; then
+        unset FILES_TO_CHECK_CPP[$i]
+      fi
+    done
   done
 
   if [[ ${#FILES_TO_CHECK_CPP} -ne 0 ]]; then
-    ${CLANG_FORMAT} -i ${FILES_TO_CHECK_CPP[@]}
+    if [[ -z "${CLANG_STYLE_FILE}" ]]; then
+      ${CLANG_FORMAT} -i ${FILES_TO_CHECK_CPP[@]}
+    else
+      # It support clang-format version 14 and upper
+      ${CLANG_FORMAT} -i --style=file:$CLANG_STYLE_FILE ${FILES_TO_CHECK_CPP[@]}
+    fi
     EXIT_CODE=$?
     if [[ ${EXIT_CODE} -ne 0 ]]; then
       INVALID_EXIT=${EXIT_CODE}
@@ -248,7 +260,7 @@ if [[ -s ${PATCH_FILE} ]]; then
 fi
 
 if [[ ${INVALID_EXIT} -ne 0 ]]; then
-  echo "[[FAILED] Invalid format checker exit."
+  echo "[FAILED] Invalid format checker exit."
 fi
 
 exit 1

--- a/infra/docker/focal/Dockerfile
+++ b/infra/docker/focal/Dockerfile
@@ -38,6 +38,12 @@ RUN apt-get update && \
 RUN python3 -m pip install --upgrade pip
 RUN python3 -m pip install yapf==0.22.0 numpy flatbuffers
 
+# clang-format
+RUN apt-get install -qqy gnupg2
+RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+RUN add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-16 main"
+RUN apt-get update && apt-get -qqy install clang-format-16
+
 # Install google test (source)
 RUN apt-get update && apt-get -qqy install libgtest-dev
 

--- a/infra/git-hooks/pre-push.sh
+++ b/infra/git-hooks/pre-push.sh
@@ -27,6 +27,7 @@ url="$2"
 REPO_PATH=$(git rev-parse --show-toplevel)
 cd $REPO_PATH
 
-./nnas format --diff-only
+./nnas format --diff-only --exclude runtime
+./nnas format --diff-only --clang-format-version 16 runtime
 
 exit $?

--- a/runtime/contrib/TFLiteSharp/TFLiteNative/include/tflite_log.h
+++ b/runtime/contrib/TFLiteSharp/TFLiteNative/include/tflite_log.h
@@ -47,11 +47,12 @@ extern "C" {
     }                                                 \
   } while (0)
 #else // __TIZEN__
-#define LEVEL_TO_STR(level)                  \
-  (((level) == ERROR) ? "ERROR"              \
-                      : ((level) == WARNING) \
-                          ? "WARNING"        \
-                          : ((level) == INFO) ? "INFO" : ((level) == DEBUG) ? "DEBUG" : "DEFAULT")
+#define LEVEL_TO_STR(level)           \
+  (((level) == ERROR)     ? "ERROR"   \
+   : ((level) == WARNING) ? "WARNING" \
+   : ((level) == INFO)    ? "INFO"    \
+   : ((level) == DEBUG)   ? "DEBUG"   \
+                          : "DEFAULT")
 #define TFLITE_NATIVE_LOG(log_level, format, args...)      \
   do                                                       \
   {                                                        \

--- a/runtime/libs/misc/include/misc/string_helpers.h
+++ b/runtime/libs/misc/include/misc/string_helpers.h
@@ -30,7 +30,7 @@ namespace
 
 template <typename Arg> void _str(std::ostream &os, Arg &&arg) { os << std::forward<Arg>(arg); }
 
-template <typename Arg, typename... Args> void _str(std::ostream &os, Arg &&arg, Args &&... args)
+template <typename Arg, typename... Args> void _str(std::ostream &os, Arg &&arg, Args &&...args)
 {
   _str(os, std::forward<Arg>(arg));
   _str(os, std::forward<Args>(args)...);
@@ -55,7 +55,7 @@ inline std::vector<std::string> split(const std::string &s, char delim)
   return elems;
 }
 
-template <typename... Args> std::string str(Args &&... args)
+template <typename... Args> std::string str(Args &&...args)
 {
   std::stringstream ss;
   _str(ss, std::forward<Args>(args)...);

--- a/runtime/onert/backend/acl_cl/KernelGenerator.cc
+++ b/runtime/onert/backend/acl_cl/KernelGenerator.cc
@@ -47,9 +47,8 @@ using ActivationBuilder = ::onert::backend::acl_common::AclActivationBuilder<
 KernelGenerator::KernelGenerator(
   const ir::Graph &graph, const std::shared_ptr<TensorBuilder> &tensor_builder,
   const std::shared_ptr<acl_common::AclTensorRegistry<TensorManager>> &tensor_reg)
-  : basic::KernelGeneratorBase{graph}, _ctx(graph.operands()),
-    _operations_ctx(graph.operations()), _current_layout{graph.layout()},
-    _tensor_builder(tensor_builder), _tensor_reg(tensor_reg)
+  : basic::KernelGeneratorBase{graph}, _ctx(graph.operands()), _operations_ctx(graph.operations()),
+    _current_layout{graph.layout()}, _tensor_builder(tensor_builder), _tensor_reg(tensor_reg)
 {
   // DO NOTHING
 }

--- a/runtime/onert/backend/acl_cl/Optimizer.cc
+++ b/runtime/onert/backend/acl_cl/Optimizer.cc
@@ -31,8 +31,8 @@ namespace acl_cl
 {
 
 Optimizer::Optimizer(BackendContext *context)
-  : _context{context}, _tensor_builder{
-                         std::dynamic_pointer_cast<TensorBuilder>(context->tensor_builder)}
+  : _context{context},
+    _tensor_builder{std::dynamic_pointer_cast<TensorBuilder>(context->tensor_builder)}
 {
   assert(context);
 }

--- a/runtime/onert/backend/acl_common/AclKernelGen.h
+++ b/runtime/onert/backend/acl_common/AclKernelGen.h
@@ -45,7 +45,7 @@ void disableDimCorrection(IACLTensor *tensor)
 }
 
 template <typename Layer, typename... Args>
-std::unique_ptr<arm_compute::IFunction> generateLayer(Args &&... args)
+std::unique_ptr<arm_compute::IFunction> generateLayer(Args &&...args)
 {
   auto l = std::make_unique<Layer>();
 
@@ -56,7 +56,7 @@ std::unique_ptr<arm_compute::IFunction> generateLayer(Args &&... args)
 
 template <typename Layer, typename... Args>
 std::unique_ptr<arm_compute::IFunction>
-generateLayer(std::shared_ptr<arm_compute::IMemoryManager> memory_manager, Args &&... args)
+generateLayer(std::shared_ptr<arm_compute::IMemoryManager> memory_manager, Args &&...args)
 {
   auto l = std::make_unique<Layer>(memory_manager);
 

--- a/runtime/onert/backend/acl_neon/KernelGenerator.cc
+++ b/runtime/onert/backend/acl_neon/KernelGenerator.cc
@@ -46,9 +46,8 @@ using ActivationBuilder = ::onert::backend::acl_common::AclActivationBuilder<
 KernelGenerator::KernelGenerator(
   const ir::Graph &graph, const std::shared_ptr<TensorBuilder> &tensor_builder,
   const std::shared_ptr<acl_common::AclTensorRegistry<TensorManager>> &tensor_reg)
-  : basic::KernelGeneratorBase{graph}, _ctx(graph.operands()),
-    _operations_ctx(graph.operations()), _current_layout{graph.layout()},
-    _tensor_builder(tensor_builder), _tensor_reg(tensor_reg)
+  : basic::KernelGeneratorBase{graph}, _ctx(graph.operands()), _operations_ctx(graph.operations()),
+    _current_layout{graph.layout()}, _tensor_builder(tensor_builder), _tensor_reg(tensor_reg)
 {
   // DO NOTHING
 }

--- a/runtime/onert/backend/acl_neon/Optimizer.cc
+++ b/runtime/onert/backend/acl_neon/Optimizer.cc
@@ -31,8 +31,8 @@ namespace acl_neon
 {
 
 Optimizer::Optimizer(BackendContext *context)
-  : _context{context}, _tensor_builder{
-                         std::dynamic_pointer_cast<TensorBuilder>(context->tensor_builder)}
+  : _context{context},
+    _tensor_builder{std::dynamic_pointer_cast<TensorBuilder>(context->tensor_builder)}
 {
   assert(context);
 }

--- a/runtime/onert/backend/cl_common/include/cl_common/BackendContext.h
+++ b/runtime/onert/backend/cl_common/include/cl_common/BackendContext.h
@@ -41,8 +41,8 @@ public:
                  std::shared_ptr<T_ConstantInitializer> constant_initializer = nullptr,
                  std::shared_ptr<T_KernelGenerator> kernel_gen = nullptr)
     : onert::backend::BackendContext(backend, std::move(data), tensor_registry),
-      tensor_builder{tensor_builder}, constant_initializer{constant_initializer}, kernel_gen{
-                                                                                    kernel_gen}
+      tensor_builder{tensor_builder}, constant_initializer{constant_initializer},
+      kernel_gen{kernel_gen}
   {
   }
 

--- a/runtime/onert/backend/cpu/KernelGenerator.cc
+++ b/runtime/onert/backend/cpu/KernelGenerator.cc
@@ -229,10 +229,9 @@ KernelGenerator::KernelGenerator(
   const std::shared_ptr<basic::TensorRegistry> &tensor_reg,
   const std::shared_ptr<backend::custom::IKernelBuilder> &kernel_builder,
   const std::shared_ptr<ExternalContext> &external_context)
-  : basic::KernelGeneratorBase{graph},
-    _ctx(graph.operands()), _operations_ctx{graph.operations()}, _current_layout{graph.layout()},
-    _tensor_builder(tensor_builder), _tensor_reg{tensor_reg}, _kernel_builder(kernel_builder),
-    _external_context(external_context)
+  : basic::KernelGeneratorBase{graph}, _ctx(graph.operands()), _operations_ctx{graph.operations()},
+    _current_layout{graph.layout()}, _tensor_builder(tensor_builder), _tensor_reg{tensor_reg},
+    _kernel_builder(kernel_builder), _external_context(external_context)
 {
   // DO NOTHING
 }

--- a/runtime/onert/backend/cpu/ops/CompareLayer.cc
+++ b/runtime/onert/backend/cpu/ops/CompareLayer.cc
@@ -62,7 +62,7 @@ void compareQuant8(const IPortableTensor *lhs, const IPortableTensor *rhs, IPort
   params.is_broadcast = !HaveSameShapes(lhs, rhs);
 
   using CompareFunction = void (*)(
-    ComparisonParams & params, const Shape &input1_shape, const T *input1_data,
+    ComparisonParams &params, const Shape &input1_shape, const T *input1_data,
     const Shape &input2_shape, const T *input2_data, const Shape &output_shape, bool *output_data);
 
   static const CompareFunction broadcast_fns[] = {

--- a/runtime/onert/backend/gpu_cl/KernelGenerator.cc
+++ b/runtime/onert/backend/gpu_cl/KernelGenerator.cc
@@ -210,9 +210,9 @@ KernelGenerator::KernelGenerator(
   const ir::Graph &graph, const std::shared_ptr<TensorBuilder> &tensor_builder,
   const std::shared_ptr<TensorRegistry> &tensor_reg,
   const std::shared_ptr<tflite::gpu::cl::CreationContext> &creation_context)
-  : basic::KernelGeneratorBase{graph}, _ctx(graph.operands()),
-    _operations_ctx(graph.operations()), _current_layout{graph.layout()},
-    _tensor_builder(tensor_builder), _tensor_reg(tensor_reg), _creation_context(creation_context)
+  : basic::KernelGeneratorBase{graph}, _ctx(graph.operands()), _operations_ctx(graph.operations()),
+    _current_layout{graph.layout()}, _tensor_builder(tensor_builder), _tensor_reg(tensor_reg),
+    _creation_context(creation_context)
 {
 }
 

--- a/runtime/onert/backend/ruy/KernelGenerator.cc
+++ b/runtime/onert/backend/ruy/KernelGenerator.cc
@@ -77,10 +77,9 @@ KernelGenerator::KernelGenerator(
   const std::shared_ptr<basic::TensorRegistry> &tensor_reg,
   const std::shared_ptr<backend::custom::IKernelBuilder> &kernel_builder,
   const std::shared_ptr<ExternalContext> &external_context)
-  : basic::KernelGeneratorBase{graph},
-    _ctx(graph.operands()), _operations_ctx{graph.operations()}, _current_layout{graph.layout()},
-    _tensor_builder(tensor_builder), _tensor_reg{tensor_reg}, _kernel_builder(kernel_builder),
-    _external_context(external_context)
+  : basic::KernelGeneratorBase{graph}, _ctx(graph.operands()), _operations_ctx{graph.operations()},
+    _current_layout{graph.layout()}, _tensor_builder(tensor_builder), _tensor_reg{tensor_reg},
+    _kernel_builder(kernel_builder), _external_context(external_context)
 {
   // DO NOTHING
 }

--- a/runtime/onert/backend/train/BackendContext.h
+++ b/runtime/onert/backend/train/BackendContext.h
@@ -57,9 +57,8 @@ public:
                  std::unique_ptr<exec::train::optimizer::Optimizer> optimizer = nullptr,
                  std::shared_ptr<KernelGenerator> kernel_gen = nullptr)
     : onert::backend::train::TrainableBackendContext(backend, std::move(tdata), tensor_registry),
-      kernel_gen{kernel_gen},
-      _external_context(new ExternalContext), _tensor_builder{tensor_builder}, _optimizer{std::move(
-                                                                                 optimizer)}
+      kernel_gen{kernel_gen}, _external_context(new ExternalContext),
+      _tensor_builder{tensor_builder}, _optimizer{std::move(optimizer)}
   {
   }
   BackendContext(const BackendContext &) = delete;

--- a/runtime/onert/backend/train/KernelGenerator.cc
+++ b/runtime/onert/backend/train/KernelGenerator.cc
@@ -121,8 +121,8 @@ KernelGenerator::KernelGenerator(const ir::train::TrainableGraph &tgraph,
                                  const std::shared_ptr<ExternalContext> &external_context,
                                  const exec::train::optimizer::Optimizer *optimizer)
   : backend::train::KernelGeneratorBase{tgraph}, _current_layout{tgraph.layout()},
-    _tensor_reg{tensor_reg},
-    _external_context(external_context), _optimizer{optimizer}, _update_funcs{}
+    _tensor_reg{tensor_reg}, _external_context(external_context), _optimizer{optimizer},
+    _update_funcs{}
 {
   // DO NOTHING
 }

--- a/runtime/onert/backend/train/TensorBuilder.cc
+++ b/runtime/onert/backend/train/TensorBuilder.cc
@@ -28,8 +28,8 @@ namespace train
 TensorBuilder::TensorBuilder(const std::shared_ptr<TensorRegistry> &tensor_reg,
                              const exec::train::optimizer::Optimizer *optimizer,
                              const std::string planner_id)
-  : _tensor_reg{tensor_reg}, _tensor_mgr{new TensorManager(tensor_reg, planner_id)}, _optimizer{
-                                                                                       optimizer}
+  : _tensor_reg{tensor_reg}, _tensor_mgr{new TensorManager(tensor_reg, planner_id)},
+    _optimizer{optimizer}
 {
   /* empty */
 }

--- a/runtime/onert/backend/train/TensorManager.cc
+++ b/runtime/onert/backend/train/TensorManager.cc
@@ -55,8 +55,8 @@ namespace train
 TensorManager::TensorManager(const std::shared_ptr<TensorRegistry> &reg,
                              const std::string planner_id)
   : _nonconst_mgr{new MemoryManager(planner_id)}, _trainable_mgr{new MemoryManager(planner_id)},
-    _derivative_mgr{new MemoryManager(planner_id)},
-    _gradient_mgr{new MemoryManager(planner_id)}, _tensors{reg}
+    _derivative_mgr{new MemoryManager(planner_id)}, _gradient_mgr{new MemoryManager(planner_id)},
+    _tensors{reg}
 {
   // DO NOTHING
 }

--- a/runtime/onert/backend/train/ops/ReshapeLayer.cc
+++ b/runtime/onert/backend/train/ops/ReshapeLayer.cc
@@ -26,8 +26,8 @@ namespace ops
 {
 
 ReshapeLayer::ReshapeLayer()
-  : _input{nullptr}, _shape{nullptr}, _output{nullptr}, _deriv_input{nullptr}, _deriv_output{
-                                                                                 nullptr}
+  : _input{nullptr}, _shape{nullptr}, _output{nullptr}, _deriv_input{nullptr},
+    _deriv_output{nullptr}
 {
   // DO NOTHING
 }

--- a/runtime/onert/backend/trix/BatchThreadPool.h
+++ b/runtime/onert/backend/trix/BatchThreadPool.h
@@ -53,8 +53,7 @@ public:
    * @return std::future<typename std::result_of<F(uint32_t, Args...)>::type>
    */
   template <class F, class... Args>
-  std::future<typename std::result_of<F(uint32_t, Args...)>::type> enqueueJob(F &&f,
-                                                                              Args &&... args)
+  std::future<typename std::result_of<F(uint32_t, Args...)>::type> enqueueJob(F &&f, Args &&...args)
   {
     if (_stop_all)
     {

--- a/runtime/onert/backend/trix/KernelGenerator.cc
+++ b/runtime/onert/backend/trix/KernelGenerator.cc
@@ -38,9 +38,9 @@ KernelGenerator::KernelGenerator(const ir::Graph &graph,
                                  const std::shared_ptr<TensorBuilder> &tensor_builder,
                                  const std::shared_ptr<basic::TensorRegistry> &tensor_reg,
                                  const std::shared_ptr<DevContext> &dev_context)
-  : basic::KernelGeneratorBase{graph},
-    _ctx(graph.operands()), _operations_ctx{graph.operations()}, _current_layout{graph.layout()},
-    _tensor_builder(tensor_builder), _tensor_reg{tensor_reg}, _dev_context{dev_context}
+  : basic::KernelGeneratorBase{graph}, _ctx(graph.operands()), _operations_ctx{graph.operations()},
+    _current_layout{graph.layout()}, _tensor_builder(tensor_builder), _tensor_reg{tensor_reg},
+    _dev_context{dev_context}
 {
   // DO NOTHING
 }

--- a/runtime/onert/backend/xnnpack/KernelGenerator.cc
+++ b/runtime/onert/backend/xnnpack/KernelGenerator.cc
@@ -41,10 +41,9 @@ KernelGenerator::KernelGenerator(
   const std::shared_ptr<basic::TensorRegistry> &tensor_reg,
   const std::shared_ptr<backend::custom::IKernelBuilder> &kernel_builder,
   const std::shared_ptr<ExternalContext> &external_context)
-  : basic::KernelGeneratorBase{graph},
-    _ctx(graph.operands()), _operations_ctx{graph.operations()}, _current_layout{graph.layout()},
-    _tensor_builder(tensor_builder), _tensor_reg{tensor_reg}, _kernel_builder(kernel_builder),
-    _external_context(external_context)
+  : basic::KernelGeneratorBase{graph}, _ctx(graph.operands()), _operations_ctx{graph.operations()},
+    _current_layout{graph.layout()}, _tensor_builder(tensor_builder), _tensor_reg{tensor_reg},
+    _kernel_builder(kernel_builder), _external_context(external_context)
 {
   // DO NOTHING
 }

--- a/runtime/onert/core/include/exec/FunctionSequence.h
+++ b/runtime/onert/core/include/exec/FunctionSequence.h
@@ -35,7 +35,7 @@ namespace exec
 class FunctionSequence : public IFunction
 {
 public:
-  template <typename... Args> FunctionSequence(Args &&... args) { initialize(std::move(args)...); }
+  template <typename... Args> FunctionSequence(Args &&...args) { initialize(std::move(args)...); }
 
 private:
   void initialize()
@@ -43,7 +43,7 @@ private:
     // Template base case : do nothing
   }
 
-  template <typename T, typename... Args> void initialize(std::unique_ptr<T> &&fn, Args &&... args)
+  template <typename T, typename... Args> void initialize(std::unique_ptr<T> &&fn, Args &&...args)
   {
     _functions.emplace_back(std::move(fn));
     initialize(std::move(args)...);
@@ -64,7 +64,7 @@ public:
 
   void iterate(const std::function<void(IFunction &)> &fn);
 
-  template <typename T, typename... Args> void wrap(Args &&... args)
+  template <typename T, typename... Args> void wrap(Args &&...args)
   {
     for (auto &&function : _functions)
     {

--- a/runtime/onert/core/include/ir/Operand.h
+++ b/runtime/onert/core/include/ir/Operand.h
@@ -79,7 +79,7 @@ public:
   bool isConstant(void) const { return _info.isConstant(); }
 
 public:
-  template <typename T, typename... Args> void data(Args &&... args)
+  template <typename T, typename... Args> void data(Args &&...args)
   {
     data(std::make_unique<T>(std::forward<Args>(args)...));
   }

--- a/runtime/onert/core/include/util/ObjectManager.h
+++ b/runtime/onert/core/include/util/ObjectManager.h
@@ -46,7 +46,7 @@ public:
    * @param[in] args Arguments for creating Operand object
    * @return Created index that is associated to the object if successful, Undefined index otherwise
    */
-  template <class... Args> Index emplace(Args &&... args)
+  template <class... Args> Index emplace(Args &&...args)
   {
     auto index = generateIndex();
     if (!index.valid())

--- a/runtime/onert/core/src/backend/basic/StaticTensorManager.cc
+++ b/runtime/onert/core/src/backend/basic/StaticTensorManager.cc
@@ -29,8 +29,8 @@ namespace basic
 
 StaticTensorManager::StaticTensorManager(const std::shared_ptr<TensorRegistry> &reg,
                                          DynamicTensorManager *dynamic_tensor_manager)
-  : _nonconst_mgr{new MemoryManager()}, _tensors{reg}, _dynamic_tensor_manager{
-                                                         dynamic_tensor_manager}
+  : _nonconst_mgr{new MemoryManager()}, _tensors{reg},
+    _dynamic_tensor_manager{dynamic_tensor_manager}
 {
   // DO NOTHING
 }
@@ -38,8 +38,8 @@ StaticTensorManager::StaticTensorManager(const std::shared_ptr<TensorRegistry> &
 StaticTensorManager::StaticTensorManager(const std::shared_ptr<TensorRegistry> &reg,
                                          const std::string planner_id,
                                          DynamicTensorManager *dynamic_tensor_manager)
-  : _nonconst_mgr{new MemoryManager(planner_id)}, _tensors{reg}, _dynamic_tensor_manager{
-                                                                   dynamic_tensor_manager}
+  : _nonconst_mgr{new MemoryManager(planner_id)}, _tensors{reg},
+    _dynamic_tensor_manager{dynamic_tensor_manager}
 {
   // DO NOTHING
 }

--- a/runtime/onert/core/src/backend/builtin/kernel/PermuteLayer.h
+++ b/runtime/onert/core/src/backend/builtin/kernel/PermuteLayer.h
@@ -72,8 +72,8 @@ private:
     PermuteWorkerTask(const uint8_t *src_buffer, uint8_t *dst_buffer, uint32_t src_start_offset,
                       uint32_t dst_start_offset, size_t size)
       : _src_buffer{src_buffer}, _dst_buffer{dst_buffer}, _src_start_offset{src_start_offset},
-        _dst_start_offset{dst_start_offset}, _src_strides{0}, _dst_strides{0},
-        _loop_shape{1}, _size{size}, _src_layout{}, _dst_layout{}, _is_permutation{false}
+        _dst_start_offset{dst_start_offset}, _src_strides{0}, _dst_strides{0}, _loop_shape{1},
+        _size{size}, _src_layout{}, _dst_layout{}, _is_permutation{false}
     {
       // DO NOTHING
     }

--- a/runtime/onert/core/src/backend/builtin/kernel/WhileLayer.cc
+++ b/runtime/onert/core/src/backend/builtin/kernel/WhileLayer.cc
@@ -41,8 +41,8 @@ WhileLayer::WhileLayer(const std::vector<backend::IPortableTensor *> input_tenso
                        const std::shared_ptr<ExternalContext> &external_context)
   : _cond_subg_index{cond_subg_index}, _body_subg_index{body_subg_index},
     _input_tensors{input_tensors}, _output_tensors{output_tensors}, _executors{executors},
-    _model_index{model_index}, _dyn_memory_manager{dyn_memory_manager}, _external_context{
-                                                                          external_context}
+    _model_index{model_index}, _dyn_memory_manager{dyn_memory_manager},
+    _external_context{external_context}
 {
   // At this point, executors may not have executors of cond subg and body subg
 }

--- a/runtime/onert/core/src/backend/builtin/train/BackendContext.h
+++ b/runtime/onert/core/src/backend/builtin/train/BackendContext.h
@@ -41,8 +41,8 @@ public:
                  std::shared_ptr<TensorBuilder> tensor_builder = nullptr,
                  std::shared_ptr<KernelGenerator> kernel_gen = nullptr)
     : backend::train::TrainableBackendContext(backend, std::move(data), tensor_registry),
-      kernel_gen{kernel_gen},
-      _external_context(new ExternalContext), _tensor_builder{tensor_builder}
+      kernel_gen{kernel_gen}, _external_context(new ExternalContext),
+      _tensor_builder{tensor_builder}
   {
   }
 

--- a/runtime/onert/core/src/compiler/HEScheduler.test.cc
+++ b/runtime/onert/core/src/compiler/HEScheduler.test.cc
@@ -206,7 +206,7 @@ void setPermutationsExecutionTime(const std::vector<const Backend *> &backends,
 using OIS = OperandIndexSequence;
 
 template <typename NodeT, typename... Types>
-OperationIndex create(std::shared_ptr<Graph> graph, Types &&... args)
+OperationIndex create(std::shared_ptr<Graph> graph, Types &&...args)
 {
   auto op = std::make_unique<NodeT>(std::forward<Types>(args)...);
   auto op_idx = graph->addOperation(std::move(op));

--- a/runtime/onert/core/src/compiler/train/UntrainableOperationConverter.cc
+++ b/runtime/onert/core/src/compiler/train/UntrainableOperationConverter.cc
@@ -30,8 +30,8 @@ UntrainableOperationConverter::UntrainableOperationConverter(ir::train::Trainabl
 {
 }
 
-std::unique_ptr<ir::train::ITrainableOperation> UntrainableOperationConverter::
-operator()(const ir::IOperation &op)
+std::unique_ptr<ir::train::ITrainableOperation>
+UntrainableOperationConverter::operator()(const ir::IOperation &op)
 {
   op.accept(*this);
 

--- a/runtime/onert/core/src/exec/ExecutorBase.cc
+++ b/runtime/onert/core/src/exec/ExecutorBase.cc
@@ -29,9 +29,8 @@ ExecutorBase::ExecutorBase(std::unique_ptr<compiler::LoweredGraph> &&lowered_gra
                            backend::BackendContexts &&backend_contexts,
                            const compiler::TensorRegistries &tensor_regs,
                            const util::TracingCtx *tracing_ctx)
-  : _lowered_graph{std::move(lowered_graph)},
-    _backend_contexts{std::move(backend_contexts)}, _graph{_lowered_graph->graph()}, _mutex(),
-    _tracing_ctx(tracing_ctx)
+  : _lowered_graph{std::move(lowered_graph)}, _backend_contexts{std::move(backend_contexts)},
+    _graph{_lowered_graph->graph()}, _mutex(), _tracing_ctx(tracing_ctx)
 {
   auto build_tensor_list = [&](const auto &ind_seq, auto &tensors) {
     assert(tensors.empty());

--- a/runtime/onert/core/src/exec/Executors.h
+++ b/runtime/onert/core/src/exec/Executors.h
@@ -26,9 +26,8 @@ namespace std
 
 template <> struct hash<std::pair<::onert::ir::ModelIndex, ::onert::ir::SubgraphIndex>>
 {
-  size_t
-  operator()(const std::pair<::onert::ir::ModelIndex, ::onert::ir::SubgraphIndex> &pair) const
-    noexcept
+  size_t operator()(
+    const std::pair<::onert::ir::ModelIndex, ::onert::ir::SubgraphIndex> &pair) const noexcept
   {
     return (hash<uint32_t>()(pair.first.value()) << 16) ^ hash<uint32_t>()(pair.second.value());
   }

--- a/runtime/onert/core/src/exec/feature/nchw/Reader.h
+++ b/runtime/onert/core/src/exec/feature/nchw/Reader.h
@@ -42,11 +42,10 @@ public:
     : _shape{shape}, _strides{strides}, _ptr{reinterpret_cast<const uint8_t *>(ptr)}, _len{len}
   {
     UNUSED_RELEASE(len); // Workaround for unused variable in release mode
-    assert(len == static_cast<size_t>(strides.N != 0
-                                        ? shape.N * strides.N
-                                        : strides.C != 0 ? shape.C * strides.C
-                                                         : strides.H != 0 ? shape.H * strides.H
-                                                                          : shape.W * strides.W));
+    assert(len == static_cast<size_t>(strides.N != 0   ? shape.N * strides.N
+                                      : strides.C != 0 ? shape.C * strides.C
+                                      : strides.H != 0 ? shape.H * strides.H
+                                                       : shape.W * strides.W));
   }
 
   // Construct for backend tensor

--- a/runtime/onert/core/src/exec/feature/nhwc/Reader.h
+++ b/runtime/onert/core/src/exec/feature/nhwc/Reader.h
@@ -43,11 +43,10 @@ public:
     : _shape{shape}, _strides{strides}, _ptr{reinterpret_cast<const uint8_t *>(ptr)}, _len{len}
   {
     UNUSED_RELEASE(len); // Workaround for unused variable in release mode
-    assert(len == static_cast<size_t>(strides.N != 0
-                                        ? shape.N * strides.N
-                                        : strides.H != 0 ? shape.H * strides.H
-                                                         : strides.W != 0 ? shape.W * strides.W
-                                                                          : shape.C * strides.C));
+    assert(len == static_cast<size_t>(strides.N != 0   ? shape.N * strides.N
+                                      : strides.H != 0 ? shape.H * strides.H
+                                      : strides.W != 0 ? shape.W * strides.W
+                                                       : shape.C * strides.C));
   }
 
   // Construct for backend tensor

--- a/runtime/onert/frontend/base_loader/include/base_loader.h
+++ b/runtime/onert/frontend/base_loader/include/base_loader.h
@@ -125,7 +125,7 @@ private:
   virtual std::unique_ptr<ir::Graph> loadSubgraph(const SubGraph *subg) = 0;
   // Operations
   template <typename OpIR, typename... Args>
-  const OpIR *loadOperationTo(const Operator *op, ir::Graph &subg, Args &&... args);
+  const OpIR *loadOperationTo(const Operator *op, ir::Graph &subg, Args &&...args);
 
   void loadAddV2(const Operator *op, ir::Graph &subg);
   void loadArgMinMax(const Operator *op, ir::Graph &subg, bool is_argmax);
@@ -626,7 +626,7 @@ void BaseLoader<LoaderDomain>::loadPool2DOptions(Param &param, const Pool2DOptio
 template <typename LoaderDomain>
 template <typename OpIR, typename... Args>
 const OpIR *BaseLoader<LoaderDomain>::loadOperationTo(const Operator *op, ir::Graph &subg,
-                                                      Args &&... args)
+                                                      Args &&...args)
 {
   static_assert(sizeof...(args) <= 1, "You can't have more than 1 arguments!");
   ir::OperandIndexSequence inputs;

--- a/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksModel.cc
+++ b/runtime/onert/frontend/nnapi/wrapper/ANeuralNetworksModel.cc
@@ -27,8 +27,8 @@
 // ANeuralNetworksModel
 //
 ANeuralNetworksModel::ANeuralNetworksModel() noexcept
-  : _finished_building{false}, _optional_operands{}, _operand_usages{}, _allowFloat32toFloat16{
-                                                                          false}
+  : _finished_building{false}, _optional_operands{}, _operand_usages{},
+    _allowFloat32toFloat16{false}
 {
   _graph = std::make_shared<onert::ir::Graph>();
 }


### PR DESCRIPTION
Use clang-format upper version: 16 (runtime only)
clang-format-8 is not supported on ubuntu 22.04.
clang-format-8 is not supported on apt.llvm.org/focal repo. 
Update format command for step-by-step upgrade.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>