### PR TITLE
[luci/pass] Add saving recorded min-max

### DIFF
--- a/compiler/luci/pass/include/luci/CircleQuantizer.h
+++ b/compiler/luci/pass/include/luci/CircleQuantizer.h
@@ -85,6 +85,7 @@ public:
       Quantize_input_type,
       Quantize_output_type,
       Quantize_TF_style_maxpool,
+      Quantize_save_min_max,
     };
 
     virtual ~Options() = default;

--- a/compiler/luci/pass/include/luci/Pass/QuantizeWithMinMaxPass.h
+++ b/compiler/luci/pass/include/luci/Pass/QuantizeWithMinMaxPass.h
@@ -42,6 +42,7 @@ public:
     std::vector<loco::DataType> input_types;
     std::vector<loco::DataType> output_types;
     bool TF_style_maxpool = false;
+    bool save_min_max = false;
     std::vector<LayerInfo> layers_info;
   };
 

--- a/compiler/luci/pass/src/CircleQuantizer.cpp
+++ b/compiler/luci/pass/src/CircleQuantizer.cpp
@@ -502,6 +502,9 @@ void CircleQuantizer::quantize(loco::Graph *g) const
     bool TF_style_maxpool =
       _options->param(Options::AlgorithmParameters::Quantize_TF_style_maxpool) == "True";
 
+    bool save_min_max =
+      _options->param(Options::AlgorithmParameters::Quantize_save_min_max) == "True";
+
     auto layer_params = _options->layer_params(Options::AlgorithmParameters::Quantize_layer_params);
     auto layer_params_set = _options->layer_params_set();
 
@@ -576,6 +579,7 @@ void CircleQuantizer::quantize(loco::Graph *g) const
       ctx->input_types = input_types;
       ctx->output_types = output_types;
       ctx->TF_style_maxpool = TF_style_maxpool;
+      ctx->save_min_max = save_min_max;
 
       for (auto layer_param : layer_params)
       {

--- a/compiler/luci/pass/src/PropagateQParamForwardPass.cpp
+++ b/compiler/luci/pass/src/PropagateQParamForwardPass.cpp
@@ -141,7 +141,7 @@ struct PropagateQParamForward final : public luci::CircleNodeMutableVisitor<bool
       case luci::ActivationQType::PreDefinedLogistic:
       case luci::ActivationQType::PreDefinedTanh:
       case luci::ActivationQType::PreDefinedSoftmax:
-        node->quantparam(luci::make_predefined_qparam(qtype, node->dtype()));
+        node->quantparam(luci::make_predefined_qparam(qtype, node->dtype(), node->quantparam()));
         break;
       case luci::ActivationQType::IntScale:
         luci::set_int_scale(node);

--- a/compiler/luci/pass/src/QuantizationUtils.h
+++ b/compiler/luci/pass/src/QuantizationUtils.h
@@ -77,7 +77,8 @@ ActivationQType activation_qtype(const CircleNode *node);
 // Create qparam with pre-defined values for speical operators
 std::unique_ptr<CircleQuantParam> make_predefined_qparam(CircleNode *node, loco::DataType dtype);
 std::unique_ptr<CircleQuantParam> make_predefined_qparam(ActivationQType qtype,
-                                                         loco::DataType dtype);
+                                                         loco::DataType dtype,
+                                                         CircleQuantParam *old_quant_param);
 
 // Update node's scale to a positive integer (for special Ops e.g., Floor, Ceil)
 void set_int_scale(luci::CircleNode *node);

--- a/compiler/luci/pass/src/QuantizeActivation.cpp
+++ b/compiler/luci/pass/src/QuantizeActivation.cpp
@@ -110,26 +110,30 @@ void QuantizeSpecialActivation::visit(luci::CircleNode *node)
   auto fused_act_node = dynamic_cast<CircleNodeMixin<CircleNodeTrait::FusedActFunc> *>(node);
   if (fused_act_node != nullptr && fused_act_node->fusedActivationFunction() == FusedActFunc::TANH)
   {
-    auto qparam = make_predefined_qparam(luci::ActivationQType::PreDefinedTanh, output_type);
+    auto qparam = make_predefined_qparam(luci::ActivationQType::PreDefinedTanh, output_type,
+                                         node->quantparam());
     node->quantparam(std::move(qparam));
   }
 }
 
 void QuantizeSpecialActivation::visit(luci::CircleLogistic *node)
 {
-  auto qparam = make_predefined_qparam(luci::ActivationQType::PreDefinedLogistic, output_type);
+  auto qparam = make_predefined_qparam(luci::ActivationQType::PreDefinedLogistic, output_type,
+                                       node->quantparam());
   node->quantparam(std::move(qparam));
 }
 
 void QuantizeSpecialActivation::visit(luci::CircleTanh *node)
 {
-  auto qparam = make_predefined_qparam(luci::ActivationQType::PreDefinedTanh, output_type);
+  auto qparam =
+    make_predefined_qparam(luci::ActivationQType::PreDefinedTanh, output_type, node->quantparam());
   node->quantparam(std::move(qparam));
 }
 
 void QuantizeSpecialActivation::visit(luci::CircleSoftmax *node)
 {
-  auto qparam = make_predefined_qparam(luci::ActivationQType::PreDefinedSoftmax, output_type);
+  auto qparam = make_predefined_qparam(luci::ActivationQType::PreDefinedSoftmax, output_type,
+                                       node->quantparam());
   node->quantparam(std::move(qparam));
 }
 

--- a/compiler/luci/pass/src/QuantizeWeights.cpp
+++ b/compiler/luci/pass/src/QuantizeWeights.cpp
@@ -407,8 +407,6 @@ void QuantizeWeights::quantize_weights(luci::CircleConst *weights)
     {
       sym_wquant_per_channel(weights, scaling_factor, channel_dim_index);
     }
-    quantparam->min.clear();
-    quantparam->max.clear();
     quantparam->quantized_dimension = channel_dim_index;
   }
   // Find min/max per layer-wise
@@ -449,8 +447,6 @@ void QuantizeWeights::quantize_weights(luci::CircleConst *weights)
     auto min = quantparam->min[0];
     auto scaling_factor = quantparam->scale[0];
     asym_wquant_per_layer(weights, min, scaling_factor);
-    quantparam->min.clear();
-    quantparam->max.clear();
   }
 }
 void QuantizeWeights::visit(luci::CircleConv2D *node)


### PR DESCRIPTION
This commit adds saving recorded min-max values.

for issue: https://github.com/Samsung/ONE/issues/11717
from draft: #11730

ONE-DCO-1.0-Signed-off-by: Artem Balyshev <a.balyshev@samsung.com>