### PR TITLE
[tflchef] Use extype and custom_code type for custom operators

### DIFF
--- a/compiler/tflchef/core/src/ModelChef.cpp
+++ b/compiler/tflchef/core/src/ModelChef.cpp
@@ -141,10 +141,10 @@ gather_builtincode_map(const ::tflchef::ModelRecipe &model_recipe)
 
   for (const auto &operation : model_recipe.operation())
   {
-    auto op_chef = op_chef_registry().lookup(operation.type()).create(&operation);
-    if (op_chef->code() == tflite::BuiltinOperator_CUSTOM)
+    if ((operation.has_extype() && operation.extype() == "Custom") || operation.type() == "Custom")
       continue;
 
+    auto op_chef = op_chef_registry().lookup(operation.type()).create(&operation);
     // Various operation version is unified as the highest version among them
     if (builtin_map.find(op_chef->code()) == builtin_map.end() ||
         builtin_map[op_chef->code()] < operation.version())
@@ -157,10 +157,11 @@ gather_builtincode_map(const ::tflchef::ModelRecipe &model_recipe)
     const auto &graph = model_recipe.graph(g);
     for (const auto &operation : graph.operation())
     {
-      auto op_chef = op_chef_registry().lookup(operation.type()).create(&operation);
-      if (op_chef->code() == tflite::BuiltinOperator_CUSTOM)
+      if ((operation.has_extype() && operation.extype() == "Custom") ||
+          operation.type() == "Custom")
         continue;
 
+      auto op_chef = op_chef_registry().lookup(operation.type()).create(&operation);
       // Various operation version is unified as the highest version among them
       if (builtin_map.find(op_chef->code()) == builtin_map.end() ||
           builtin_map[op_chef->code()] < operation.version())
@@ -177,9 +178,11 @@ std::set<std::string> gather_customcode_set(const ::tflchef::ModelRecipe &model_
   std::set<std::string> customcode_set;
   for (const auto &operation : model_recipe.operation())
   {
-    auto op_chef = op_chef_registry().lookup(operation.type()).create(&operation);
-    if (op_chef->code() == tflite::BuiltinOperator_CUSTOM)
-      customcode_set.insert(operation.type());
+    if ((operation.has_extype() && operation.extype() == "Custom") || operation.type() == "Custom")
+    {
+      assert(operation.has_custom_code());
+      customcode_set.insert(operation.custom_code());
+    }
   }
 
   // Add ops used in Graphs(subgraphs)
@@ -188,9 +191,12 @@ std::set<std::string> gather_customcode_set(const ::tflchef::ModelRecipe &model_
     const auto &graph = model_recipe.graph(g);
     for (const auto &operation : graph.operation())
     {
-      auto op_chef = op_chef_registry().lookup(operation.type()).create(&operation);
-      if (op_chef->code() == tflite::BuiltinOperator_CUSTOM)
-        customcode_set.insert(operation.type());
+      if ((operation.has_extype() && operation.extype() == "Custom") ||
+          operation.type() == "Custom")
+      {
+        assert(operation.has_custom_code());
+        customcode_set.insert(operation.custom_code());
+      }
     }
   }
 
@@ -619,7 +625,11 @@ template <typename T> std::map<std::string, int32_t> cook_graph(const T &graph, 
   {
     assert(operation.has_type());
 
-    auto op_chef = op_chef_registry().lookup(operation.type()).create(&operation);
+    std::string op_type = operation.type();
+    if (operation.has_custom_code())
+      op_type = operation.custom_code();
+
+    auto op_chef = op_chef_registry().lookup(op_type).create(&operation);
 
     // Create 'inputs'
     std::vector<int32_t> input_vec = as_dataset(operation.input()).map(lookup).vectorize();
@@ -650,7 +660,9 @@ template <typename T> std::map<std::string, int32_t> cook_graph(const T &graph, 
     // custom operator
     else
     {
-      auto op_it = std::find(custom_code_vec.begin(), custom_code_vec.end(), operation.type());
+      assert(operation.has_custom_code());
+      auto op_it =
+        std::find(custom_code_vec.begin(), custom_code_vec.end(), operation.custom_code());
       assert(op_it != custom_code_vec.end());
       opcode_index = builtin_code_map.size();
       opcode_index += std::distance(custom_code_vec.begin(), op_it);

--- a/compiler/tflchef/core/src/ModelChef.cpp
+++ b/compiler/tflchef/core/src/ModelChef.cpp
@@ -141,7 +141,7 @@ gather_builtincode_map(const ::tflchef::ModelRecipe &model_recipe)
 
   for (const auto &operation : model_recipe.operation())
   {
-    if ((operation.has_extype() && operation.extype() == "Custom") || operation.type() == "Custom")
+    if (operation.type() == "Custom" || (operation.has_extype() && operation.extype() == "Custom"))
       continue;
 
     auto op_chef = op_chef_registry().lookup(operation.type()).create(&operation);
@@ -157,8 +157,8 @@ gather_builtincode_map(const ::tflchef::ModelRecipe &model_recipe)
     const auto &graph = model_recipe.graph(g);
     for (const auto &operation : graph.operation())
     {
-      if ((operation.has_extype() && operation.extype() == "Custom") ||
-          operation.type() == "Custom")
+      if (operation.type() == "Custom" ||
+          (operation.has_extype() && operation.extype() == "Custom"))
         continue;
 
       auto op_chef = op_chef_registry().lookup(operation.type()).create(&operation);
@@ -178,9 +178,9 @@ std::set<std::string> gather_customcode_set(const ::tflchef::ModelRecipe &model_
   std::set<std::string> customcode_set;
   for (const auto &operation : model_recipe.operation())
   {
-    if ((operation.has_extype() && operation.extype() == "Custom") || operation.type() == "Custom")
+    if (operation.type() == "Custom" || (operation.has_extype() && operation.extype() == "Custom"))
     {
-      assert(operation.has_custom_code());
+      assert(not operation.custom_code().empty());
       customcode_set.insert(operation.custom_code());
     }
   }
@@ -191,10 +191,10 @@ std::set<std::string> gather_customcode_set(const ::tflchef::ModelRecipe &model_
     const auto &graph = model_recipe.graph(g);
     for (const auto &operation : graph.operation())
     {
-      if ((operation.has_extype() && operation.extype() == "Custom") ||
-          operation.type() == "Custom")
+      if (operation.type() == "Custom" ||
+          (operation.has_extype() && operation.extype() == "Custom"))
       {
-        assert(operation.has_custom_code());
+        assert(not operation.custom_code().empty());
         customcode_set.insert(operation.custom_code());
       }
     }
@@ -626,7 +626,7 @@ template <typename T> std::map<std::string, int32_t> cook_graph(const T &graph, 
     assert(operation.has_type());
 
     std::string op_type = operation.type();
-    if (operation.has_custom_code())
+    if (not operation.custom_code().empty())
       op_type = operation.custom_code();
 
     auto op_chef = op_chef_registry().lookup(op_type).create(&operation);
@@ -660,9 +660,9 @@ template <typename T> std::map<std::string, int32_t> cook_graph(const T &graph, 
     // custom operator
     else
     {
-      assert(operation.has_custom_code());
-      auto op_it =
-        std::find(custom_code_vec.begin(), custom_code_vec.end(), operation.custom_code());
+      assert(not operation.custom_code().empty());
+      auto custom_code = operation.custom_code();
+      auto op_it = std::find(custom_code_vec.begin(), custom_code_vec.end(), custom_code);
       assert(op_it != custom_code_vec.end());
       opcode_index = builtin_code_map.size();
       opcode_index += std::distance(custom_code_vec.begin(), op_it);

--- a/compiler/tflchef/tests/custom_erf/test.recipe
+++ b/compiler/tflchef/tests/custom_erf/test.recipe
@@ -12,6 +12,8 @@ operation {
   type: "Erf"
   input: "ifm"
   output: "ofm"
+  custom_code: "Erf"
+  extype: "Custom"
 }
 input: "ifm"
 output: "ofm"


### PR DESCRIPTION
This introduces extype and custom_code for custom operators.

ONE-DCO-1.0-Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>

---
Related Issue: https://github.com/Samsung/ONE/issues/11741
Draft PR: https://github.com/Samsung/ONE/pull/11750