### PR TITLE
[res] TensorFlowLiteRecipes for horizontal FC pattern fusion

### DIFF
--- a/res/TensorFlowLiteRecipes/Net_Horizontal_FullyConnected_Add_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/Net_Horizontal_FullyConnected_Add_000/test.recipe
@@ -1,0 +1,91 @@
+operand {
+  name: "ifm"
+  type: FLOAT32
+  shape { dim: 1 dim: 120 }
+}
+operand {
+  name: "fc_wgt_1"
+  type: FLOAT32
+  shape { dim: 29 dim: 120 }
+  filler {
+    tag: "gaussian"
+    arg: "0.0"
+    arg: "1.0"
+  }
+}
+operand {
+  name: "fc_bias_1"
+  type: FLOAT32
+  shape { dim: 29 }
+  filler {
+    tag: "gaussian"
+    arg: "0.0"
+    arg: "1.0"
+  }
+}
+operand {
+  name: "fc_1"
+  type: FLOAT32
+  shape { dim: 1 dim: 29 }
+}
+operation {
+  type: "FullyConnected"
+  fullyconnected_options {
+    activation: NONE
+  }
+  input: "ifm"
+  input: "fc_wgt_1"
+  input: "fc_bias_1"
+  output: "fc_1"
+}
+operand {
+  name: "fc_wgt_2"
+  type: FLOAT32
+  shape { dim: 29 dim: 120 }
+  filler {
+    tag: "gaussian"
+    arg: "0.0"
+    arg: "1.0"
+  }
+}
+operand {
+  name: "fc_bias_2"
+  type: FLOAT32
+  shape { dim: 29 }
+  filler {
+    tag: "gaussian"
+    arg: "0.0"
+    arg: "1.0"
+  }
+}
+operand {
+  name: "fc_2"
+  type: FLOAT32
+  shape { dim: 1 dim: 29 }
+}
+operation {
+  type: "FullyConnected"
+  fullyconnected_options {
+    activation: NONE
+  }
+  input: "ifm"
+  input: "fc_wgt_2"
+  input: "fc_bias_2"
+  output: "fc_2"
+}
+operand {
+  name: "ofm"
+  type: FLOAT32
+  shape { dim: 1 dim: 29 }
+}
+operation {
+  type: "Add"
+  input: "fc_1"
+  input: "fc_2"
+  output: "ofm"
+  add_options {
+    activation: NONE
+  }
+}
+input: "ifm"
+output: "ofm"

--- a/res/TensorFlowLiteRecipes/Net_Horizontal_FullyConnected_Add_000/test.rule
+++ b/res/TensorFlowLiteRecipes/Net_Horizontal_FullyConnected_Add_000/test.rule
@@ -2,5 +2,5 @@
 
 RULE    "VERIFY_FILE_FORMAT"      $(verify_file_format) '=' 1
 
-RULE    "ADD_REMOVED"               $(op_count ADD) '=' 0
+RULE    "ADD_REMOVED"             $(op_count ADD) '=' 0
 RULE    "FC_FUSED"                $(op_count FULLY_CONNECTED) '=' 1

--- a/res/TensorFlowLiteRecipes/Net_Horizontal_FullyConnected_Add_000/test.rule
+++ b/res/TensorFlowLiteRecipes/Net_Horizontal_FullyConnected_Add_000/test.rule
@@ -2,5 +2,5 @@
 
 RULE    "VERIFY_FILE_FORMAT"      $(verify_file_format) '=' 1
 
-RULE    "ADD_FUSED"               $(op_count ADD) '=' 0
+RULE    "ADD_REMOVED"               $(op_count ADD) '=' 0
 RULE    "FC_FUSED"                $(op_count FULLY_CONNECTED) '=' 1

--- a/res/TensorFlowLiteRecipes/Net_Horizontal_FullyConnected_Add_000/test.rule
+++ b/res/TensorFlowLiteRecipes/Net_Horizontal_FullyConnected_Add_000/test.rule
@@ -1,0 +1,6 @@
+# To check if horizontal FullyConnected and Add kernels are fused
+
+RULE    "VERIFY_FILE_FORMAT"      $(verify_file_format) '=' 1
+
+RULE    "ADD_FUSED"               $(op_count ADD) '=' 0
+RULE    "FC_FUSED"                $(op_count FULLY_CONNECTED) '=' 1


### PR DESCRIPTION
This commit adds models for testing horizontal FC pattern fusion.

for issue: https://github.com/Samsung/ONE/issues/11705
from draft: https://github.com/Samsung/ONE/pull/11739

ONE-DCO-1.0-Signed-off-by: Artem Balyshev <a.balyshev@samsung.com>