### PR TITLE
[luci] Introduce RemoveUnnecessaryAdd

### DIFF
--- a/compiler/luci/pass/include/luci/CircleOptimizer.h
+++ b/compiler/luci/pass/include/luci/CircleOptimizer.h
@@ -77,6 +77,7 @@ public:
       SubstituteSqueezeToReshape,
       ExpandBroadcastConst,
       ConvertNCHWToNHWC,
+      RemoveUnnecessaryAdd,
       RemoveUnnecessarySlice,
       RemoveUnnecessaryStridedSlice,
       RemoveUnnecessarySplit,

--- a/compiler/luci/pass/src/CircleOptimizer.cpp
+++ b/compiler/luci/pass/src/CircleOptimizer.cpp
@@ -49,6 +49,7 @@
 #include "luci/Pass/RemoveRedundantReshapePass.h"
 #include "luci/Pass/RemoveRedundantTransposePass.h"
 #include "luci/Pass/RemoveRedundantQuantizePass.h"
+#include "luci/Pass/RemoveUnnecessaryAddPass.h"
 #include "luci/Pass/RemoveUnnecessaryReshapePass.h"
 #include "luci/Pass/RemoveUnnecessaryReshapeNetPass.h"
 #include "luci/Pass/RemoveUnnecessarySlicePass.h"
@@ -368,6 +369,10 @@ void CircleOptimizer::optimize(loco::Graph *g) const
   if (_options->query(Options::Algorithm::RemoveQuantDequantSeq))
   {
     phase.emplace_back(std::make_unique<luci::RemoveQuantDequantSeqPass>());
+  }
+  if (_options->query(Options::Algorithm::RemoveUnnecessaryAdd))
+  {
+    phase.emplace_back(std::make_unique<luci::RemoveUnnecessaryAddPass>());
   }
   if (_options->query(Options::Algorithm::RemoveUnnecessaryReshape))
   {


### PR DESCRIPTION
This commit introduces RemoveUnnecessaryAdd option.

Its correctness is tested at https://github.com/Samsung/ONE/pull/11770.
Draft: https://github.com/Samsung/ONE/pull/11770
Related: https://github.com/Samsung/ONE/issues/10358

ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>