### PR TITLE
[circle-quantizer] Add save_min_max option

### DIFF
--- a/compiler/circle-quantizer/src/CircleQuantizer.cpp
+++ b/compiler/circle-quantizer/src/CircleQuantizer.cpp
@@ -179,6 +179,8 @@ int entry(int argc, char **argv)
 
   const std::string gpd = "--generate_profile_data";
 
+  const std::string save_min_max = "--save_min_max";
+
   arser::Arser arser("circle-quantizer provides circle model quantization");
 
   arser::Helper::add_version(arser, print_version);
@@ -203,6 +205,11 @@ int entry(int argc, char **argv)
     .default_value(false)
     .help("Force MaxPool Op to have the same input/output quantparams. NOTE: This feature can "
           "degrade accuracy of some models");
+
+  arser.add_argument(save_min_max)
+    .nargs(0)
+    .default_value(false)
+    .help("Save recorded min/max values.");
 
   arser.add_argument(fake_quant)
     .nargs(0)
@@ -350,6 +357,9 @@ int entry(int argc, char **argv)
 
     if (arser[tf_maxpool] and arser.get<bool>(tf_maxpool))
       options->param(AlgorithmParameters::Quantize_TF_style_maxpool, "True");
+
+    if (arser[save_min_max] and arser.get<bool>(save_min_max))
+      options->param(AlgorithmParameters::Quantize_save_min_max, "True");
 
     if (arser[cfg])
     {


### PR DESCRIPTION
This commit adds an option to enable saving min and max values

for issue: https://github.com/Samsung/ONE/issues/11717
from draft: https://github.com/Samsung/ONE/pull/11730

ONE-DCO-1.0-Signed-off-by: Artem Balyshev <a.balyshev@samsung.com>