### PR TITLE
[res] TensorFlowLiteRecipes for unnecessary Add removal

### DIFF
--- a/res/TensorFlowLiteRecipes/Net_Mul_Add_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/Net_Mul_Add_000/test.recipe
@@ -1,0 +1,52 @@
+# test for Add(Mul, zero) is converted to Mul
+
+operand {
+    name: "ifm1"
+    type: FLOAT32
+    shape { dim: 1 dim: 15 dim: 16 dim: 17 }
+}
+operand {
+  name: "ifm2"
+  type: FLOAT32
+  shape { dim: 1 dim: 15 dim: 16 dim: 17 }
+}
+operand {
+  name: "mul_ofm"
+  type: FLOAT32
+  shape { dim: 1 dim: 15 dim: 16 dim: 17 }
+}
+operation {
+    type: "Mul"
+    input: "ifm1"
+    input: "ifm2"
+    output: "mul_ofm"
+    mul_options {
+      activation: RELU
+    }
+}
+operand {
+  name: "zero"
+  type: FLOAT32
+  shape { dim: 1 dim: 15 dim: 16 dim: 17 }
+  filler {
+    tag: "explicit"
+    arg: "0"
+  }
+}
+operand {
+  name: "ofm"
+  type: FLOAT32
+  shape { dim: 1 dim: 15 dim: 16 dim: 17 }
+}
+operation {
+    type: "Add"
+    input: "mul_ofm"
+    input: "zero"
+    output: "ofm"
+    add_options {
+      activation: NONE
+    }
+}
+input: "ifm1"
+input: "ifm2"
+output: "ofm"

--- a/res/TensorFlowLiteRecipes/Net_Mul_Add_000/test.rule
+++ b/res/TensorFlowLiteRecipes/Net_Mul_Add_000/test.rule
@@ -1,6 +1,6 @@
 # To check if unnecessary Add is removed from sample graph
 
-RULE    "VERIFY_FILE_FORMAT"      $(verify_file_format) '=' 1
+RULE    "VERIFY_FILE_FORMAT"    $(verify_file_format) '=' 1
 
 RULE    "MUL_EXIST"             $(op_count MUL) '=' 1
 RULE    "ADD_NOT_EXIST"         $(op_count ADD) '=' 0

--- a/res/TensorFlowLiteRecipes/Net_Mul_Add_000/test.rule
+++ b/res/TensorFlowLiteRecipes/Net_Mul_Add_000/test.rule
@@ -1,0 +1,6 @@
+# To check if unnecessary Add is removed from sample graph
+
+RULE    "VERIFY_FILE_FORMAT"      $(verify_file_format) '=' 1
+
+RULE    "MUL_EXIST"             $(op_count MUL) '=' 1
+RULE    "ADD_NOT_EXIST"         $(op_count ADD) '=' 0

--- a/res/TensorFlowLiteRecipes/Net_Mul_Add_001/test.recipe
+++ b/res/TensorFlowLiteRecipes/Net_Mul_Add_001/test.recipe
@@ -1,0 +1,52 @@
+# test for Add(Mul, zero_broadcasted) is converted to Mul
+
+operand {
+    name: "ifm1"
+    type: FLOAT32
+    shape { dim: 1 dim: 15 dim: 16 dim: 17 }
+}
+operand {
+  name: "ifm2"
+  type: FLOAT32
+  shape { dim: 1 dim: 15 dim: 16 dim: 17 }
+}
+operand {
+  name: "mul_ofm"
+  type: FLOAT32
+  shape { dim: 1 dim: 15 dim: 16 dim: 17 }
+}
+operation {
+    type: "Mul"
+    input: "ifm1"
+    input: "ifm2"
+    output: "mul_ofm"
+    mul_options {
+      activation: RELU
+    }
+}
+operand {
+  name: "zero_broadcasted"
+  type: FLOAT32
+  shape { dim: 1 }
+  filler {
+    tag: "explicit"
+    arg: "0"
+  }
+}
+operand {
+  name: "ofm"
+  type: FLOAT32
+  shape { dim: 1 dim: 15 dim: 16 dim: 17 }
+}
+operation {
+    type: "Add"
+    input: "mul_ofm"
+    input: "zero_broadcasted"
+    output: "ofm"
+    add_options {
+      activation: NONE
+    }
+}
+input: "ifm1"
+input: "ifm2"
+output: "ofm"

--- a/res/TensorFlowLiteRecipes/Net_Mul_Add_001/test.rule
+++ b/res/TensorFlowLiteRecipes/Net_Mul_Add_001/test.rule
@@ -1,6 +1,6 @@
 # To check if unnecessary Add is removed from sample graph
 
-RULE    "VERIFY_FILE_FORMAT"      $(verify_file_format) '=' 1
+RULE    "VERIFY_FILE_FORMAT"    $(verify_file_format) '=' 1
 
 RULE    "MUL_EXIST"             $(op_count MUL) '=' 1
 RULE    "ADD_NOT_EXIST"         $(op_count ADD) '=' 0

--- a/res/TensorFlowLiteRecipes/Net_Mul_Add_001/test.rule
+++ b/res/TensorFlowLiteRecipes/Net_Mul_Add_001/test.rule
@@ -1,0 +1,6 @@
+# To check if unnecessary Add is removed from sample graph
+
+RULE    "VERIFY_FILE_FORMAT"      $(verify_file_format) '=' 1
+
+RULE    "MUL_EXIST"             $(op_count MUL) '=' 1
+RULE    "ADD_NOT_EXIST"         $(op_count ADD) '=' 0

--- a/res/TensorFlowLiteRecipes/Net_Mul_Add_002/test.recipe
+++ b/res/TensorFlowLiteRecipes/Net_Mul_Add_002/test.recipe
@@ -1,0 +1,52 @@
+# test for Add(Mul, zero_broadcasted) is converted to Mul
+
+operand {
+    name: "ifm1"
+    type: FLOAT32
+    shape { dim: 1 dim: 15 dim: 16 dim: 17 }
+}
+operand {
+  name: "ifm2"
+  type: FLOAT32
+  shape { dim: 1 dim: 15 dim: 16 dim: 17 }
+}
+operand {
+  name: "mul_ofm"
+  type: FLOAT32
+  shape { dim: 1 dim: 15 dim: 16 dim: 17 }
+}
+operation {
+    type: "Mul"
+    input: "ifm1"
+    input: "ifm2"
+    output: "mul_ofm"
+    mul_options {
+      activation: RELU
+    }
+}
+operand {
+  name: "zero_broadcasted"
+  type: FLOAT32
+  shape { dim: 1 dim: 1 dim: 16 dim: 17 }
+  filler {
+    tag: "explicit"
+    arg: "0"
+  }
+}
+operand {
+  name: "ofm"
+  type: FLOAT32
+  shape { dim: 1 dim: 15 dim: 16 dim: 17 }
+}
+operation {
+    type: "Add"
+    input: "mul_ofm"
+    input: "zero_broadcasted"
+    output: "ofm"
+    add_options {
+      activation: NONE
+    }
+}
+input: "ifm1"
+input: "ifm2"
+output: "ofm"

--- a/res/TensorFlowLiteRecipes/Net_Mul_Add_002/test.rule
+++ b/res/TensorFlowLiteRecipes/Net_Mul_Add_002/test.rule
@@ -1,6 +1,6 @@
 # To check if unnecessary Add is removed from sample graph
 
-RULE    "VERIFY_FILE_FORMAT"      $(verify_file_format) '=' 1
+RULE    "VERIFY_FILE_FORMAT"    $(verify_file_format) '=' 1
 
 RULE    "MUL_EXIST"             $(op_count MUL) '=' 1
 RULE    "ADD_NOT_EXIST"         $(op_count ADD) '=' 0

--- a/res/TensorFlowLiteRecipes/Net_Mul_Add_002/test.rule
+++ b/res/TensorFlowLiteRecipes/Net_Mul_Add_002/test.rule
@@ -1,0 +1,6 @@
+# To check if unnecessary Add is removed from sample graph
+
+RULE    "VERIFY_FILE_FORMAT"      $(verify_file_format) '=' 1
+
+RULE    "MUL_EXIST"             $(op_count MUL) '=' 1
+RULE    "ADD_NOT_EXIST"         $(op_count ADD) '=' 0

--- a/res/TensorFlowLiteRecipes/Net_Mul_Add_003/test.recipe
+++ b/res/TensorFlowLiteRecipes/Net_Mul_Add_003/test.recipe
@@ -1,0 +1,52 @@
+# test for Add(zero_broadcasted, Mul) is converted to Mul
+
+operand {
+    name: "ifm1"
+    type: FLOAT32
+    shape { dim: 1 dim: 15 dim: 16 dim: 17 }
+}
+operand {
+  name: "ifm2"
+  type: FLOAT32
+  shape { dim: 1 dim: 15 dim: 16 dim: 17 }
+}
+operand {
+  name: "mul_ofm"
+  type: FLOAT32
+  shape { dim: 1 dim: 15 dim: 16 dim: 17 }
+}
+operation {
+    type: "Mul"
+    input: "ifm1"
+    input: "ifm2"
+    output: "mul_ofm"
+    mul_options {
+      activation: NONE
+    }
+}
+operand {
+  name: "zero_broadcasted"
+  type: FLOAT32
+  shape { dim: 1 dim: 1 dim: 16 dim: 17 }
+  filler {
+    tag: "explicit"
+    arg: "0"
+  }
+}
+operand {
+  name: "ofm"
+  type: FLOAT32
+  shape { dim: 1 dim: 15 dim: 16 dim: 17 }
+}
+operation {
+    type: "Add"
+    input: "zero_broadcasted"
+    input: "mul_ofm"
+    output: "ofm"
+    add_options {
+      activation: NONE
+    }
+}
+input: "ifm1"
+input: "ifm2"
+output: "ofm"

--- a/res/TensorFlowLiteRecipes/Net_Mul_Add_003/test.rule
+++ b/res/TensorFlowLiteRecipes/Net_Mul_Add_003/test.rule
@@ -1,6 +1,6 @@
 # To check if unnecessary Add is removed from sample graph
 
-RULE    "VERIFY_FILE_FORMAT"      $(verify_file_format) '=' 1
+RULE    "VERIFY_FILE_FORMAT"    $(verify_file_format) '=' 1
 
 RULE    "MUL_EXIST"             $(op_count MUL) '=' 1
 RULE    "ADD_NOT_EXIST"         $(op_count ADD) '=' 0

--- a/res/TensorFlowLiteRecipes/Net_Mul_Add_003/test.rule
+++ b/res/TensorFlowLiteRecipes/Net_Mul_Add_003/test.rule
@@ -1,0 +1,6 @@
+# To check if unnecessary Add is removed from sample graph
+
+RULE    "VERIFY_FILE_FORMAT"      $(verify_file_format) '=' 1
+
+RULE    "MUL_EXIST"             $(op_count MUL) '=' 1
+RULE    "ADD_NOT_EXIST"         $(op_count ADD) '=' 0


### PR DESCRIPTION
This commit adds models for testing unnecessary Add removal with various parameters.

Its correctness is tested at https://github.com/Samsung/ONE/pull/11770.
Draft: https://github.com/Samsung/ONE/pull/11770
Related: https://github.com/Samsung/ONE/issues/10358

ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>