### PR TITLE
[circle2circle] Add remove_unnecessary_add option

### DIFF
--- a/compiler/circle2circle/src/Circle2Circle.cpp
+++ b/compiler/circle2circle/src/Circle2Circle.cpp
@@ -123,6 +123,8 @@ int entry(int argc, char **argv)
              "This will fuse or remove subsequent Reshape operators");
   add_switch(arser, "--remove_redundant_transpose",
              "This will fuse or remove subsequent Transpose operators");
+  add_switch(arser, "--remove_unnecessary_add",
+             "This will remove unnecessary add of zero constant");
   add_switch(arser, "--remove_unnecessary_reshape",
              "This will remove unnecessary reshape operators");
   add_switch(arser, "--remove_unnecessary_slice", "This will remove unnecessary slice operators");
@@ -297,6 +299,8 @@ int entry(int argc, char **argv)
     options->enable(Algorithms::RemoveRedundantReshape);
   if (arser.get<bool>("--remove_redundant_transpose"))
     options->enable(Algorithms::RemoveRedundantTranspose);
+  if (arser.get<bool>("--remove_unnecessary_add"))
+    options->enable(Algorithms::RemoveUnnecessaryAdd);
   if (arser.get<bool>("--remove_unnecessary_reshape"))
     options->enable(Algorithms::RemoveUnnecessaryReshape);
   if (arser.get<bool>("--remove_unnecessary_slice"))


### PR DESCRIPTION
This commit adds an option to enable removal of
unnecessary add of zero constant.

Its correctness is tested at https://github.com/Samsung/ONE/pull/11770.
Draft: https://github.com/Samsung/ONE/pull/11770
Related: https://github.com/Samsung/ONE/issues/10358

ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>