### PR TITLE
[circle-mpqsolver] Introduce Q8SoftmaxWithQ16SubExpResolver

### DIFF
--- a/compiler/circle-mpqsolver/src/pattern/PatternResolver.h
+++ b/compiler/circle-mpqsolver/src/pattern/PatternResolver.h
@@ -46,6 +46,16 @@ public:
   resolve(const luci::Module *module) override;
 };
 
+class Q8SoftmaxWithQ16SubExpResolver : public PatternResolver
+{
+public:
+  /**
+   * @brief resolve all nodes of Softmax pattern as prescribed
+   */
+  std::map<luci::CircleNode *, luci::CircleQuantizer::Options::LayerParam>
+  resolve(const luci::Module *module) override;
+};
+
 } // namespace pattern
 } // namespace mpqsolver
 


### PR DESCRIPTION
This commit introduces Q8SoftmaxWithQ16SubExpResolver aiming to convert recognized SoftMax patterns to prescribed quantization patterns and adds tests for it.

Draft: #11737
Related: #11543

ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>