### PR TITLE
[one-cmds] Enable remove_unnecessary_add

### DIFF
--- a/compiler/one-cmds/how-to-use-one-commands.txt
+++ b/compiler/one-cmds/how-to-use-one-commands.txt
@@ -187,6 +187,7 @@ Current transformation options are
 - remove_redundant_quantize : This removes redundant quantize operators.
 - remove_redundant_reshape : This fuses or removes redundant reshape operators.
 - remove_redundant_transpose : This fuses or removes redundant transpose operators.
+- remove_unnecessary_add : This removes unnecessary add operators.
 - remove_unnecessary_reshape : This removes unnecessary reshape operators.
 - remove_unnecessary_slice : This removes unnecessary slice operators.
 - remove_unnecessary_strided_slice : This removes unnecessary strided slice operators.

--- a/compiler/one-cmds/onelib/constant.py
+++ b/compiler/one-cmds/onelib/constant.py
@@ -49,6 +49,7 @@ class CONSTANT:
         # Remove redundant operators
         'remove_redundant_reshape',
         'remove_redundant_transpose',
+        'remove_unnecessary_add',
         'remove_unnecessary_reshape',
         'remove_unnecessary_slice',
         'remove_unnecessary_strided_slice',
@@ -120,6 +121,7 @@ class CONSTANT:
         ('remove_redundant_quantize', 'remove redundant Quantize ops'),
         ('remove_redundant_reshape', 'fuse or remove subsequent Reshape ops'),
         ('remove_redundant_transpose', 'fuse or remove subsequent Transpose ops'),
+        ('remove_unnecessary_add', 'remove unnecessary add ops'),
         ('remove_unnecessary_reshape', 'remove unnecessary reshape ops'),
         ('remove_unnecessary_slice', 'remove unnecessary slice ops'),
         ('remove_unnecessary_strided_slice', 'remove unnecessary strided slice ops'),


### PR DESCRIPTION
This commit enables remove_unnecessary_add option for one-cmds optimize.

Its correctness is tested at https://github.com/Samsung/ONE/pull/11770.
Draft: https://github.com/Samsung/ONE/pull/11770
Related: https://github.com/Samsung/ONE/issues/10358

ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>