### PR TITLE
[circle-mpqsolver] Normalize exceptions

### DIFF
--- a/compiler/circle-mpqsolver/src/core/ErrorMetric.cpp
+++ b/compiler/circle-mpqsolver/src/core/ErrorMetric.cpp
@@ -64,7 +64,7 @@ float MAEMetric::compute(const WholeOutput &first, const WholeOutput &second) co
 
   if (num_output_errors == 0)
   {
-    throw std::runtime_error("nothing to compare");
+    throw std::runtime_error("Nothing to compare");
   }
 
   return static_cast<float>(output_errors / num_output_errors);

--- a/compiler/circle-mpqsolver/src/pattern/PatternResolver.cpp
+++ b/compiler/circle-mpqsolver/src/pattern/PatternResolver.cpp
@@ -172,7 +172,7 @@ Q8LayerNormWithQ16VarianceResolver::resolve(const luci::Module *module)
 {
   if (!module)
   {
-    throw std::runtime_error("no module for pattern resolving");
+    throw std::runtime_error("No module for pattern resolving");
   }
 
   std::map<luci::CircleNode *, LayerParam> nodes_params;


### PR DESCRIPTION
This commit uses capital letters in exception messages where applicable.

ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>

---
original: https://github.com/Samsung/ONE/pull/11805#discussion_r1374243457