### PR TITLE
[one-cmds] Add fuse_slice_with_tconv to O1 group

### DIFF
--- a/compiler/one-cmds/onelib/constant.py
+++ b/compiler/one-cmds/onelib/constant.py
@@ -43,6 +43,7 @@ class CONSTANT:
         'fuse_gelu',
         'fuse_mean_with_mean',
         'fuse_transpose_with_mean',
+        'fuse_slice_with_tconv',
         'transform_min_max_to_relu6',
         'transform_min_relu_to_relu6',
 


### PR DESCRIPTION
This commit adds fuse_slice_with_tconv option to O1 group.

Running the following `.cfg`:
```
[onecc]
one-optimize=True
include=O1

[one-optimize]
input_path=/home/stanislav/repos/WorkSpaces/fuse_tconv_slice/model_original.circle
output_path=/home/stanislav/repos/WorkSpaces/fuse_tconv_slice/model_fused_6.opt.circle
```
successfully produced `model_fused_6.opt.circle` model without Slice.
Please see attachment:
[test_pass.zip](https://github.com/Samsung/ONE/files/13187379/test_pass.zip)


Related: #10960
ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>