### PR TITLE
[circle-mpqsolver] Add more unitests for MAEMetric

### DIFF
--- a/compiler/circle-mpqsolver/src/core/ErrorMetric.cpp
+++ b/compiler/circle-mpqsolver/src/core/ErrorMetric.cpp
@@ -29,7 +29,10 @@ using namespace mpqsolver::core;
  */
 float MAEMetric::compute(const WholeOutput &first, const WholeOutput &second) const
 {
-  assert(first.size() == second.size());
+  if (first.size() != second.size())
+  {
+    throw std::runtime_error("Can not compare vectors of different sizes");
+  }
 
   double output_errors = 0.; // mean over mean outputs errors
   size_t num_output_errors = 0;

--- a/compiler/circle-mpqsolver/src/core/ErrorMetric.test.cpp
+++ b/compiler/circle-mpqsolver/src/core/ErrorMetric.test.cpp
@@ -48,6 +48,84 @@ TEST(CircleMPQSolverMAEMetricTest, verifyResultsTest)
   EXPECT_FLOAT_EQ(value, 1.f);
 }
 
+TEST(CircleMPQSolverMAEMetricTest, verifyComplexResultsTest)
+{
+  // test for model with a pair of outputs
+
+  size_t num_elements = 512;
+  mpqsolver::core::WholeOutput target, source;
+  // construct target
+  {
+    // let first target output be 0.0
+    std::vector<float> float_buffer(num_elements, 0.f);
+    auto const char_buffer = reinterpret_cast<char *>(float_buffer.data());
+    auto const char_buffer_size = num_elements * sizeof(float) / sizeof(char);
+    std::vector<char> buffer(char_buffer, char_buffer + char_buffer_size);
+
+    // first target output
+    mpqsolver::core::Output out = mpqsolver::core::Output(1, buffer);
+    {
+      // let second target output be 0.25
+      std::vector<float> float_buffer(num_elements / 2, 0.25f);
+      auto const char_buffer = reinterpret_cast<char *>(float_buffer.data());
+      auto const char_buffer_size = num_elements / 2 * sizeof(float) / sizeof(char);
+      std::vector<char> buffer(char_buffer, char_buffer + char_buffer_size);
+      // second target output
+      out.emplace_back(buffer);
+    }
+
+    // target consists of single sample (each sample consists of two outputs)
+    target = mpqsolver::core::WholeOutput(1, out);
+  }
+
+  // construct target
+  {
+    // let first source output be 1.f
+    std::vector<float> float_buffer(num_elements, 1.f);
+    auto const char_buffer = reinterpret_cast<char *>(float_buffer.data());
+    auto const char_buffer_size = num_elements * sizeof(float) / sizeof(char);
+    std::vector<char> buffer(char_buffer, char_buffer + char_buffer_size);
+    // first source output
+    mpqsolver::core::Output out = mpqsolver::core::Output(1, buffer);
+    {
+      // let second source output be 1.f
+      std::vector<float> float_buffer(num_elements / 2, 1.0f);
+      auto const char_buffer = reinterpret_cast<char *>(float_buffer.data());
+      auto const char_buffer_size = num_elements / 2 * sizeof(float) / sizeof(char);
+      std::vector<char> buffer(char_buffer, char_buffer + char_buffer_size);
+      // second source output
+      out.emplace_back(buffer);
+    }
+
+    // source consists of single sample (each sample consists of two outputs)
+    source = mpqsolver::core::WholeOutput(1, out);
+  }
+
+  mpqsolver::core::MAEMetric metric;
+  float value = metric.compute(target, source);
+  EXPECT_FLOAT_EQ(value, 0.875f); // (|0 - 1| + |0.25 - 1|) / 2 = 1.75 / 2 = 0.875
+}
+
+TEST(CircleMPQSolverMAEMetricTest, different_samples_NEG)
+{
+  mpqsolver::core::MAEMetric metric;
+
+  size_t num_elements = 512;
+  std::vector<float> float_buffer(num_elements, 0.f);
+  auto const char_buffer = reinterpret_cast<char *>(float_buffer.data());
+  auto const char_buffer_size = num_elements * sizeof(float) / sizeof(char);
+  std::vector<char> buffer(char_buffer, char_buffer + char_buffer_size);
+  mpqsolver::core::Output out = mpqsolver::core::Output(1, buffer);
+
+  // let target be zero of two samples
+  mpqsolver::core::WholeOutput target = mpqsolver::core::WholeOutput(2, out);
+
+  // let source be zero of single sample
+  mpqsolver::core::WholeOutput source;
+
+  EXPECT_ANY_THROW(metric.compute(target, source));
+}
+
 TEST(CircleMPQSolverMAEMetricTest, verifyResultsTest_NEG)
 {
   mpqsolver::core::MAEMetric metric;


### PR DESCRIPTION
This commit introduces two more unitests for MAEMetric.

Related: #11374
ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>