### PR TITLE
[tflchef] Introduce a op util function to check custom codes

### DIFF
--- a/compiler/tflchef/core/src/CustomOp/AddV2.cpp
+++ b/compiler/tflchef/core/src/CustomOp/AddV2.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "AddV2.h"
+#include "OpUtils.h"
 
 #include <flatbuffers/flexbuffers.h>
 
@@ -29,7 +30,7 @@ AddV2Chef::custom_value(flatbuffers::FlatBufferBuilder &fbb) const
 {
   auto &operation = (*_operation);
 
-  assert(operation.type() == "AddV2");
+  check_custom_op_value(operation, "AddV2");
 
   /**
    * REGISTER_OP("AddV2")

--- a/compiler/tflchef/core/src/CustomOp/All.cpp
+++ b/compiler/tflchef/core/src/CustomOp/All.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "All.h"
+#include "OpUtils.h"
 
 #include <flatbuffers/flexbuffers.h>
 
@@ -29,7 +30,7 @@ AllChef::custom_value(flatbuffers::FlatBufferBuilder &fbb) const
 {
   auto &operation = (*_operation);
 
-  assert(operation.type() == "All");
+  check_custom_op_value(operation, "All");
 
   /**
    * REGISTER_OP("All")

--- a/compiler/tflchef/core/src/CustomOp/BatchMatMulV2.cpp
+++ b/compiler/tflchef/core/src/CustomOp/BatchMatMulV2.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "BatchMatMulV2.h"
+#include "OpUtils.h"
 
 #include <flatbuffers/flexbuffers.h>
 
@@ -29,7 +30,7 @@ BatchMatMulV2Chef::custom_value(flatbuffers::FlatBufferBuilder &fbb) const
 {
   auto &operation = (*_operation);
 
-  assert(operation.type() == "BatchMatMulV2");
+  check_custom_op_value(operation, "BatchMatMulV2");
 
   /**
    * REGISTER_OP("BatchMatMulV2")

--- a/compiler/tflchef/core/src/CustomOp/BroadcastTo.cpp
+++ b/compiler/tflchef/core/src/CustomOp/BroadcastTo.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "BroadcastTo.h"
+#include "OpUtils.h"
 
 #include <flatbuffers/flexbuffers.h>
 
@@ -29,7 +30,7 @@ BroadcastToChef::custom_value(flatbuffers::FlatBufferBuilder &fbb) const
 {
   auto &operation = (*_operation);
 
-  assert(operation.type() == "BroadcastTo");
+  check_custom_op_value(operation, "BroadcastTo");
 
   /**
    * REGISTER_OP("BroadcastTo")

--- a/compiler/tflchef/core/src/CustomOp/Erf.cpp
+++ b/compiler/tflchef/core/src/CustomOp/Erf.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "Erf.h"
+#include "OpUtils.h"
 
 #include <flatbuffers/flexbuffers.h>
 
@@ -29,7 +30,7 @@ ErfChef::custom_value(flatbuffers::FlatBufferBuilder &fbb) const
 {
   auto &operation = (*_operation);
 
-  assert(operation.type() == "Erf");
+  check_custom_op_value(operation, "Erf");
 
   /**
    * REGISTER_OP("Erf")

--- a/compiler/tflchef/core/src/CustomOp/MatMul.cpp
+++ b/compiler/tflchef/core/src/CustomOp/MatMul.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "MatMul.h"
+#include "OpUtils.h"
 
 #include <flatbuffers/flexbuffers.h>
 
@@ -29,7 +30,7 @@ MatMulChef::custom_value(flatbuffers::FlatBufferBuilder &fbb) const
 {
   auto &operation = (*_operation);
 
-  assert(operation.type() == "MatMul");
+  check_custom_op_value(operation, "MatMul");
 
   /**
    * REGISTER_OP("MatMul")

--- a/compiler/tflchef/core/src/CustomOp/MatrixBandPart.cpp
+++ b/compiler/tflchef/core/src/CustomOp/MatrixBandPart.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "MatrixBandPart.h"
+#include "OpUtils.h"
 
 #include <flatbuffers/flexbuffers.h>
 
@@ -29,7 +30,7 @@ MatrixBandPartChef::custom_value(flatbuffers::FlatBufferBuilder &fbb) const
 {
   auto &operation = (*_operation);
 
-  assert(operation.type() == "MatrixBandPart");
+  check_custom_op_value(operation, "MatrixBandPart");
 
   /**
    * REGISTER_OP("MatrixBandPart")

--- a/compiler/tflchef/core/src/CustomOp/MaxPoolWithArgmax.cpp
+++ b/compiler/tflchef/core/src/CustomOp/MaxPoolWithArgmax.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "MaxPoolWithArgmax.h"
+#include "OpUtils.h"
 
 #include <flatbuffers/flexbuffers.h>
 
@@ -29,7 +30,7 @@ MaxPoolWithArgmaxChef::custom_value(flatbuffers::FlatBufferBuilder &fbb) const
 {
   auto &operation = (*_operation);
 
-  assert(operation.type() == "MaxPoolWithArgmax");
+  check_custom_op_value(operation, "MaxPoolWithArgmax");
 
   /**
    * REGISTER_OP("MaxPoolWithArgmax")

--- a/compiler/tflchef/core/src/OpUtils.cpp
+++ b/compiler/tflchef/core/src/OpUtils.cpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "OpUtils.h"
+
+#include <stdexcept>
+
+void check_custom_op_value(const tflchef::Operation operation, std::string op_type)
+{
+  if ((operation.has_extype() && operation.extype() == "Custom") || operation.type() == "Custom")
+  {
+    assert(operation.has_custom_code());
+    assert(operation.custom_code() == op_type);
+  }
+}

--- a/compiler/tflchef/core/src/OpUtils.h
+++ b/compiler/tflchef/core/src/OpUtils.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file  OpUtils.h
+ * @brief This header declares various op_utils functions
+ */
+#ifndef __OPUTILS_H__
+#define __OPUTILS_H__
+
+#include <tflchef.pb.h>
+
+void check_custom_op_value(const tflchef::Operation operation, std::string op_type);
+
+#endif // __OPUTILS_H__


### PR DESCRIPTION
This introduces a function that check codes of CustomOp to avoid duplication.

ONE-DCO-1.0-Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>

---
Related Issue: https://github.com/Samsung/ONE/issues/11741
Draft PR: https://github.com/Samsung/ONE/pull/11750