### PR TITLE
[circle-mpqsolver] Introduce Q8SoftmaxWithQ16SubExp

### DIFF
--- a/compiler/circle-mpqsolver/src/pattern/PatternSolver.cpp
+++ b/compiler/circle-mpqsolver/src/pattern/PatternSolver.cpp
@@ -79,6 +79,9 @@ void PatternSolver::resolve_patterns(luci::Module *module)
       case QuantizationPattern::Q8LayerNormWithQ16Variance:
         resolver = std::make_unique<pattern::Q8LayerNormWithQ16VarianceResolver>();
         break;
+      case QuantizationPattern::Q8SoftmaxWithQ16SubExp:
+        resolver = std::make_unique<pattern::Q8SoftmaxWithQ16SubExpResolver>();
+        break;
       default:
         throw std::runtime_error("Unsupported pattern to resolve");
     }

--- a/compiler/circle-mpqsolver/src/pattern/PatternSolver.h
+++ b/compiler/circle-mpqsolver/src/pattern/PatternSolver.h
@@ -31,7 +31,8 @@ namespace pattern
 
 enum class QuantizationPattern
 {
-  Q8LayerNormWithQ16Variance
+  Q8LayerNormWithQ16Variance,
+  Q8SoftmaxWithQ16SubExp,
 };
 
 struct MPQOptions


### PR DESCRIPTION
This commit introduces Q8SoftmaxWithQ16SubExp option to resolve all nodes of Softmax pattern as prescribed.

Its correctness is tested #11737.

Draft: https://github.com/Samsung/ONE/pull/11737
Related: https://github.com/Samsung/ONE/issues/11543

ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>