### PR TITLE
[infra/gbs] Add tizen 8.0 profile

### DIFF
--- a/infra/nnfw/config/gbs.conf
+++ b/infra/nnfw/config/gbs.conf
@@ -5,8 +5,17 @@ profile = profile.tizen
 [profile.tizen]
 repos = repo.base, repo.unified
 
+[profile.tizen_8]
+repos = repo.base_8, repo.unified_8
+
 [repo.unified]
 url = http://download.tizen.org/snapshots/TIZEN/Tizen-7.0/Tizen-7.0-Unified/latest/repos/standard/packages/
 
 [repo.base]
 url = http://download.tizen.org/snapshots/TIZEN/Tizen-7.0/Tizen-7.0-Base/latest/repos/standard/packages/
+
+[repo.unified_8]
+url = http://download.tizen.org/snapshots/TIZEN/Tizen-8.0/Tizen-8.0-Unified/latest/repos/standard/packages/
+
+[repo.base_8]
+url = http://download.tizen.org/snapshots/TIZEN/Tizen-8.0/Tizen-8.0-Base/latest/repos/standard/packages/


### PR DESCRIPTION
This commit adds tizen 8.0 profile to gbs.conf.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>