### PR TITLE
[circle-mpqsolver] Add PassSolver unittests

### DIFF
--- a/compiler/circle-mpqsolver/CMakeLists.txt
+++ b/compiler/circle-mpqsolver/CMakeLists.txt
@@ -38,6 +38,7 @@ set(TEST_SOURCES
     "src/bisection/VISQErrorApproximator.cpp"
     "src/core/ErrorMetric.cpp"
     "src/pattern/PatternResolver.cpp"
+    "src/pattern/PatternSolver.cpp"
     "src/core/Dumper.cpp"
     "src/core/DumpingHooks.cpp"
     "src/core/Evaluator.cpp"

--- a/compiler/circle-mpqsolver/src/core/TestHelper.h
+++ b/compiler/circle-mpqsolver/src/core/TestHelper.h
@@ -19,6 +19,7 @@
 
 #include <luci/IR/CircleNodes.h>
 #include <luci/IR/Module.h>
+#include <luci/test/TestIOGraph.h>
 
 namespace mpqsolver
 {
@@ -70,6 +71,37 @@ public:
   float _a_max = 1.f;
   luci::CircleAdd *_add = nullptr;
   luci::CircleConst *_beta = nullptr;
+};
+
+class SoftmaxGraphlet
+{
+public:
+  SoftmaxGraphlet() = default;
+  virtual ~SoftmaxGraphlet() = default;
+
+  void init(loco::Graph *g);
+
+protected:
+  void initMinMax(luci::CircleNode *node, float min, float max);
+
+public:
+  luci::CircleAbs *_ifm = nullptr;
+  luci::CircleReduceMax *_max = nullptr;
+  luci::CircleSub *_sub = nullptr;
+  luci::CircleExp *_exp = nullptr;
+  luci::CircleSum *_sum = nullptr;
+  luci::CircleDiv *_div = nullptr;
+
+protected:
+  luci::CircleConst *_softmax_indices = nullptr;
+};
+
+class SoftmaxTestGraph : public luci::test::TestIOGraph, public SoftmaxGraphlet
+{
+public:
+  SoftmaxTestGraph() = default;
+
+  void init(void);
 };
 
 } // namespace models

--- a/compiler/circle-mpqsolver/src/pattern/PatternResolver.test.cpp
+++ b/compiler/circle-mpqsolver/src/pattern/PatternResolver.test.cpp
@@ -16,6 +16,8 @@
 
 #include "PatternResolver.h"
 
+#include "core/TestHelper.h"
+
 #include <luci/CircleQuantizer.h>
 #include <luci/IR/CircleNodes.h>
 
@@ -129,80 +131,6 @@ public:
   }
 };
 
-class SoftmaxGraphlet
-{
-public:
-  SoftmaxGraphlet() = default;
-  virtual ~SoftmaxGraphlet() = default;
-
-  void init(loco::Graph *g)
-  {
-    ifm = nullptr;
-
-    ifm = g->nodes()->create<luci::CircleAbs>();
-    max = g->nodes()->create<luci::CircleReduceMax>();
-    sub = g->nodes()->create<luci::CircleSub>();
-    exp = g->nodes()->create<luci::CircleExp>();
-    sum = g->nodes()->create<luci::CircleSum>();
-    div = g->nodes()->create<luci::CircleDiv>();
-    _softmax_indices = g->nodes()->create<luci::CircleConst>();
-
-    ifm->name("ifm");
-    max->name("maximum_of_ifm");
-    sub->name("sub");
-    exp->name("exp");
-    sum->name("sum");
-    div->name("div");
-    _softmax_indices->name("reduction_indices");
-
-    _softmax_indices->dtype(loco::DataType::S32);
-    _softmax_indices->size<loco::DataType::S32>(1);
-    _softmax_indices->shape({1});
-    _softmax_indices->at<loco::DataType::S32>(0) = -1;
-    _softmax_indices->shape_status(luci::ShapeStatus::VALID);
-
-    max->keep_dims(true);
-    sum->keep_dims(true);
-  }
-
-public:
-  luci::CircleAbs *ifm = nullptr;
-  luci::CircleReduceMax *max = nullptr;
-  luci::CircleSub *sub = nullptr;
-  luci::CircleExp *exp = nullptr;
-  luci::CircleSum *sum = nullptr;
-  luci::CircleDiv *div = nullptr;
-
-protected:
-  luci::CircleConst *_softmax_indices = nullptr;
-};
-
-class SoftmaxTestGraph : public TestIOGraph, public SoftmaxGraphlet
-{
-public:
-  SoftmaxTestGraph() = default;
-
-  void init(void)
-  {
-    TestIOGraph::init({1, 12, 11, 15}, {1, 12, 11, 15});
-    SoftmaxGraphlet::init(g());
-
-    ifm->x(input());
-    max->input(ifm);
-    max->reduction_indices(_softmax_indices);
-
-    sub->x(ifm);
-    sub->y(max);
-    exp->x(sub);
-    sum->input(exp);
-    sum->reduction_indices(_softmax_indices);
-    div->x(exp);
-    div->y(sum);
-
-    output()->from(div);
-  }
-};
-
 } // namespace
 
 TEST(LayerNormPatternResolverTest, resolve_pattern)
@@ -246,7 +174,7 @@ TEST(LayerNormPatternResolverTest, resolve_pattern_NEG)
 TEST(SoftmaxResolverTest, resolve_pattern)
 {
   auto m = luci::make_module();
-  SoftmaxTestGraph g;
+  mpqsolver::test::models::SoftmaxTestGraph g;
   g.init();
   g.transfer_to(m.get());
 
@@ -254,8 +182,8 @@ TEST(SoftmaxResolverTest, resolve_pattern)
   mpqsolver::pattern::Q8SoftmaxWithQ16SubExpResolver resolver;
   EXPECT_NO_THROW({ params = resolver.resolve(m.get()); });
 
-  std::set<luci::CircleNode *> q16_nodes = {g.sub, g.exp};
-  std::set<luci::CircleNode *> q8_nodes = {g.ifm, g.max, g.sum, g.div};
+  std::set<luci::CircleNode *> q16_nodes = {g._sub, g._exp};
+  std::set<luci::CircleNode *> q8_nodes = {g._ifm, g._max, g._sum, g._div};
 
   // params of all valid layers are set
   EXPECT_EQ(params.size(), q16_nodes.size() + q8_nodes.size());

--- a/compiler/circle-mpqsolver/src/pattern/PatternSolver.test.cpp
+++ b/compiler/circle-mpqsolver/src/pattern/PatternSolver.test.cpp
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "PatternSolver.h"
+
+#include "core/TestHelper.h"
+
+#include <luci/CircleExporter.h>
+#include <luci/CircleFileExpContract.h>
+
+using namespace mpqsolver::pattern;
+
+namespace
+{
+
+class CircleMPQSolverPatternSolverTest : public ::testing::Test
+{
+public:
+  CircleMPQSolverPatternSolverTest()
+  {
+    char module_template[] = "CircleMPQSolverPatternSolverTest-CIRCLE-XXXXXX";
+    mpqsolver::test::io_utils::makeTemporaryFile(module_template);
+    _module_path = module_template;
+  }
+
+  ~CircleMPQSolverPatternSolverTest() { unlink(_module_path.c_str()); }
+
+protected:
+  mpqsolver::test::models::SoftmaxTestGraph _g;
+  std::string _module_path;
+};
+
+} // namespace
+
+TEST_F(CircleMPQSolverPatternSolverTest, verify_results)
+{
+  auto m = luci::make_module();
+  _g.init();
+  _g.transfer_to(m.get());
+
+  // export to _module_path
+  luci::CircleExporter exporter;
+  luci::CircleFileExpContract contract(m.get(), _module_path);
+  EXPECT_TRUE(exporter.invoke(&contract));
+
+  // create solver
+  mpqsolver::pattern::PatternSolver solver(
+    "uint8", "uint8",
+    std::vector<QuantizationPattern>(1, QuantizationPattern::Q8SoftmaxWithQ16SubExp));
+
+  // run solver
+  auto const res = solver.run(_module_path);
+  EXPECT_TRUE(res.get() != nullptr);
+  ASSERT_EQ(1, res.get()->size());
+
+  auto const graph = res.get()->graph();
+  ASSERT_NE(nullptr, graph);
+
+  uint32_t exp_count = 0;
+  for (auto node : loco::postorder_traversal(loco::output_nodes(graph)))
+  {
+    auto const exp = dynamic_cast<luci::CircleExp *>(node);
+    if (exp != nullptr)
+    {
+      exp_count += 1;
+      auto const dtype = exp->dtype();
+      // pattern was applied
+      ASSERT_EQ(loco::DataType::S16, dtype);
+    }
+  }
+
+  // the model has a single exp node
+  ASSERT_EQ(1, exp_count);
+}
+
+TEST_F(CircleMPQSolverPatternSolverTest, empty_patterns_NEG)
+{
+  auto m = luci::make_module();
+  _g.init();
+  _g.transfer_to(m.get());
+
+  // export to _module_path
+  luci::CircleExporter exporter;
+  luci::CircleFileExpContract contract(m.get(), _module_path);
+  EXPECT_TRUE(exporter.invoke(&contract));
+
+  // create solver
+  mpqsolver::pattern::PatternSolver solver("uint8", "uint8", std::vector<QuantizationPattern>());
+
+  // run solver
+  auto const res = solver.run(_module_path);
+  EXPECT_TRUE(res.get() != nullptr);
+  ASSERT_EQ(1, res.get()->size());
+
+  auto const graph = res.get()->graph();
+  ASSERT_NE(nullptr, graph);
+
+  uint32_t exp_count = 0;
+  for (auto node : loco::postorder_traversal(loco::output_nodes(graph)))
+  {
+    auto const exp = dynamic_cast<luci::CircleExp *>(node);
+    if (exp != nullptr)
+    {
+      exp_count += 1;
+      auto const dtype = exp->dtype();
+      // pattern was not applied
+      ASSERT_EQ(loco::DataType::U8, dtype);
+    }
+  }
+
+  // the model has a single exp node
+  ASSERT_EQ(1, exp_count);
+}
+
+TEST_F(CircleMPQSolverPatternSolverTest, empty_path_NEG)
+{
+  mpqsolver::pattern::PatternSolver solver(
+    "uint8", "uint8",
+    std::vector<QuantizationPattern>(1, QuantizationPattern::Q8LayerNormWithQ16Variance));
+
+  EXPECT_ANY_THROW(solver.run(""));
+}


### PR DESCRIPTION
This commit adds unitests for PassSolver and
moves SoftmaxTestGraph to TestHelper.

Related: https://github.com/Samsung/ONE/issues/11374
ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>