### PR TITLE
[one-cmds] Enable fuse_horizontal_fc_layers

### DIFF
--- a/compiler/one-cmds/how-to-use-one-commands.txt
+++ b/compiler/one-cmds/how-to-use-one-commands.txt
@@ -177,6 +177,7 @@ Current transformation options are
 - fuse_activation_function: This fuses Activation function to a preceding operator.
 - fuse_mean_with_mean: This fuses two consecutive ReduceMean operations into one.
 - fuse_transpose_with_mean: This fuses ReduceMean with a preceding Transpose under certain conditions.
+- fuse_horizontal_fc_layers: This fuses horizontal FullyConnected layers under certain conditions.
 - make_batchnorm_gamma_positive: This makes negative gamma of batch normalization into a small positive value (1e-10).
   Note that this pass can change the execution result of the model.
   So, use it only when the impact is known to be acceptable.

--- a/compiler/one-cmds/onelib/constant.py
+++ b/compiler/one-cmds/onelib/constant.py
@@ -107,6 +107,8 @@ class CONSTANT:
         ('fuse_mean_with_mean', 'fuse two consecutive Mean ops'),
         ('fuse_transpose_with_mean',
          'fuse Mean with a preceding Transpose under certain conditions'),
+        ('fuse_horizontal_fc_layers',
+         'fuse horizontal FullyConnected layers under certain conditions'),
         ('make_batchnorm_gamma_positive',
          'make negative gamma of BatchNorm to a small positive value (1e-10).'
          ' Note that this pass can change the execution result of the model.'


### PR DESCRIPTION
This commit enables fuse_horizontal_fc_layers option for one-cmds optimize.

for issue: https://github.com/Samsung/ONE/issues/11705
from draft: https://github.com/Samsung/ONE/pull/11739

ONE-DCO-1.0-Signed-off-by: Artem Balyshev <a.balyshev@samsung.com>