### PR TITLE
[res] Add recipes for CSE on Quantize Ops

### DIFF
--- a/res/TensorFlowLiteRecipes/CSE_Quantize_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/CSE_Quantize_000/test.recipe
@@ -1,0 +1,31 @@
+operand {
+  name: "ifm"
+  type: UINT8
+  shape { dim: 1 dim: 3 dim: 3 dim: 4 }
+  quant { min: 0 max: 255 scale: 1.0 zero_point: 0 }
+}
+operand {
+  name: "ofm1"
+  type: UINT8
+  shape { dim: 1 dim: 3 dim: 3 dim: 4 }
+  quant { min: 0 max: 510 scale: 2.0 zero_point: 0 }
+}
+operand {
+  name: "ofm2"
+  type: UINT8
+  shape { dim: 1 dim: 3 dim: 3 dim: 4 }
+  quant { min: 0 max: 510 scale: 2.0 zero_point: 0 }
+}
+operation {
+  type: "Quantize"
+  input: "ifm"
+  output: "ofm1"
+}
+operation {
+  type: "Quantize"
+  input: "ifm"
+  output: "ofm2"
+}
+input: "ifm"
+output: "ofm1"
+output: "ofm2"

--- a/res/TensorFlowLiteRecipes/CSE_Quantize_000/test.rule
+++ b/res/TensorFlowLiteRecipes/CSE_Quantize_000/test.rule
@@ -1,0 +1,5 @@
+# To check if common Quantize Op is eliminated
+
+RULE    "VERIFY_FILE_FORMAT"      $(verify_file_format) '=' 1
+
+RULE    "DUP_QUANTIZE_REMOVED"    $(op_count QUANTIZE) '=' 1

--- a/res/TensorFlowLiteRecipes/CSE_Quantize_001/test.recipe
+++ b/res/TensorFlowLiteRecipes/CSE_Quantize_001/test.recipe
@@ -1,0 +1,31 @@
+operand {
+  name: "ifm"
+  type: UINT8
+  shape { dim: 1 dim: 3 dim: 3 dim: 4 }
+  quant { min: 0 max: 255 scale: 1.0 zero_point: 0 }
+}
+operand {
+  name: "ofm1"
+  type: UINT8
+  shape { dim: 1 dim: 3 dim: 3 dim: 4 }
+  quant { min: 0 max: 510 scale: 2.0 zero_point: 0 }
+}
+operand {
+  name: "ofm2"
+  type: UINT8
+  shape { dim: 1 dim: 3 dim: 3 dim: 4 }
+  quant { min: 0 max: 765 scale: 3.0 zero_point: 0 }
+}
+operation {
+  type: "Quantize"
+  input: "ifm"
+  output: "ofm1"
+}
+operation {
+  type: "Quantize"
+  input: "ifm"
+  output: "ofm2"
+}
+input: "ifm"
+output: "ofm1"
+output: "ofm2"

--- a/res/TensorFlowLiteRecipes/CSE_Quantize_001/test.rule
+++ b/res/TensorFlowLiteRecipes/CSE_Quantize_001/test.rule
@@ -1,0 +1,5 @@
+# To check if different Quantize Ops remain
+
+RULE    "VERIFY_FILE_FORMAT"      $(verify_file_format) '=' 1
+
+RULE    "QUANTIZE_NOT_REMOVED"    $(op_count QUANTIZE) '=' 2


### PR DESCRIPTION
This adds recipes for CSE one Quantize Ops.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/11704
Draft PR: https://github.com/Samsung/ONE/pull/11824