### PR TITLE
[luci] Support CommonSubExpressionElimination option

### DIFF
--- a/compiler/luci/pass/include/luci/CircleOptimizer.h
+++ b/compiler/luci/pass/include/luci/CircleOptimizer.h
@@ -78,6 +78,7 @@ public:
       SubstituteSqueezeToReshape,
       ExpandBroadcastConst,
       ConvertNCHWToNHWC,
+      CommonSubExpressionElimination,
       RemoveUnnecessaryAdd,
       RemoveUnnecessarySlice,
       RemoveUnnecessaryStridedSlice,

--- a/compiler/luci/pass/src/CircleOptimizer.cpp
+++ b/compiler/luci/pass/src/CircleOptimizer.cpp
@@ -17,6 +17,7 @@
 #include "luci/CircleOptimizer.h"
 
 #include "luci/Pass/ConvertNCHWToNHWCPass.h"
+#include "luci/Pass/CommonSubExpressionEliminationPass.h"
 #include "luci/Pass/ExpandBroadcastConstPass.h"
 #include "luci/Pass/FoldAddV2Pass.h"
 #include "luci/Pass/FoldCastPass.h"
@@ -243,6 +244,10 @@ void CircleOptimizer::optimize(loco::Graph *g) const
   phase.emplace_back(std::make_unique<luci::CircleShapeInferencePass>());
   phase.emplace_back(std::make_unique<luci::CircleTypeInferencePass>());
 
+  if (_options->query(Options::Algorithm::CommonSubExpressionElimination))
+  {
+    phase.emplace_back(std::make_unique<luci::CommonSubExpressionEliminationPass>());
+  }
   if (_options->query(Options::Algorithm::ResolveCustomOpAdd))
   {
     phase.emplace_back(std::make_unique<luci::ResolveCustomOpAddPass>());


### PR DESCRIPTION
This supports CSE option to circle optimizer.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/11704
Draft PR: https://github.com/Samsung/ONE/pull/11824