### PR TITLE
[one-cmds] Add multi-input quantization dataset test

### DIFF
--- a/compiler/one-cmds/tests/one-quantize_023.test
+++ b/compiler/one-cmds/tests/one-quantize_023.test
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  echo "${filename_ext} FAILED"
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+inputfile="./Add_000.circle"
+outputfile="./Add_000.one-quantize_023.circle"
+
+rm -f ${filename}.log
+rm -rf ${outputfile}
+
+# Test space-delimitered list format (Add_000.inputs.txt)
+# Content of Add_000.inputs.txt is as follows.
+# Add_000.circle.input0 Add_000.circle.input1
+one-quantize \
+--input_dtype float32 \
+--quantized_dtype uint8 \
+--input_path ${inputfile} \
+--input_data ./Add_000.inputs.txt \
+--input_data_format list \
+--output_path ${outputfile} > ${filename}.log 2>&1
+
+if [[ ! -s "${outputfile}" ]]; then
+  trap_err_onexit
+fi
+
+echo "${filename_ext} SUCCESS"

--- a/compiler/one-cmds/tests/one-quantize_neg_024.test
+++ b/compiler/one-cmds/tests/one-quantize_neg_024.test
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  if grep -q "Wrong number of inputs" "${filename}.log"; then
+    echo "${filename_ext} SUCCESS"
+    exit 0
+  fi
+
+  echo "${filename_ext} FAILED"
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+inputfile="./Add_000.circle"
+outputfile="./Add_000.one-quantize_neg_024.circle"
+
+rm -f ${filename}.log
+
+# Test with wrong number of intputs in list file
+# Model has two inputs, but list file has three inputs
+# Add_000.circle.input0 Add_000.circle.input1 Add_000.circle.input2
+one-quantize \
+--input_dtype float32 \
+--quantized_dtype uint8 \
+--input_path ${inputfile} \
+--input_data ./Add_000.wrong_inputs.txt \
+--input_data_format list \
+--output_path ${outputfile} > ${filename}.log 2>&1
+
+if [[ ! -s "${outputfile}" ]]; then
+  trap_err_onexit
+fi
+
+echo "${filename_ext} SUCCESS"

--- a/compiler/one-cmds/tests/prepare_test_materials.sh
+++ b/compiler/one-cmds/tests/prepare_test_materials.sh
@@ -131,6 +131,17 @@ if [[ ! -s "onnx_conv2d_conv2d_split.onnx" ]]; then
     # https://github.com/Samsung/ONE/issues/11280#issuecomment-1732852295
 fi
 
+if [[ ! -s "Add_000.inputs.txt" ]]; then
+    rm -rf Add_000.inputs.txt
+    echo "Add_000.circle.input0 Add_000.circle.input1" >> Add_000.inputs.txt
+fi
+
+# List file with wrong number of inputs (for negative test)
+if [[ ! -s "Add_000.wrong_inputs.txt" ]]; then
+    rm -rf Add_000.wrong_inputs.txt
+    echo "Add_000.circle.input0 Add_000.circle.input1 Add_000.circle.input2" >> Add_000.wrong_inputs.txt
+fi
+
 function files_missing() {
     condition="test "
 
@@ -162,6 +173,15 @@ if files_missing "${NEG_TEST_RECCURENT_MODELS[@]}"; then
     wget -nv https://github.com/Samsung/ONE/files/8137183/neg_test_onnx_recurrent_models.zip
     unzip neg_test_onnx_recurrent_models.zip
     # https://github.com/Samsung/ONE/issues/8395#issuecomment-1050364375
+fi
+
+declare -a ADD_000_MODEL_AND_INPUTS=("Add_000.circle" "Add_000.circle.input0" "Add_000.circle.input1")
+
+if files_missing "${ADD_000_MODEL_AND_INPUTS}"; then
+    rm -rf Add_000.zip
+    wget -nv https://github.com/Samsung/ONE/files/13211993/Add_000.zip
+    unzip Add_000.zip
+    # https://github.com/Samsung/ONE/issues/11724#issuecomment-1786420834
 fi
 
 # prepare 'inception_v3.circle' file used for quantization test

--- a/compiler/one-cmds/tests/rawdata2hdf5_002.test
+++ b/compiler/one-cmds/tests/rawdata2hdf5_002.test
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  echo "${filename_ext} FAILED"
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+outputfile="./rawdata2hdf5_002.h5"
+
+rm -f ${filename}.log
+rm -rf ${outputfile}
+
+# run test
+rawdata2hdf5 \
+--data_list Add_000.inputs.txt \
+--output_path ${outputfile} > ${filename}.log 2>&1
+
+if [[ ! -s "${outputfile}" ]]; then
+  trap_err_onexit
+fi
+
+echo "${filename_ext} SUCCESS"


### PR DESCRIPTION
This adds tests for multi-input quantization dataset.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/11724
Draft PR: https://github.com/Samsung/ONE/pull/11831