### PR TITLE
[circle-mpqsolver] Add Bisection Unitests

### DIFF
--- a/compiler/circle-mpqsolver/src/core/Quantizer.cpp
+++ b/compiler/circle-mpqsolver/src/core/Quantizer.cpp
@@ -120,7 +120,6 @@ bool Quantizer::quantize(luci::Module *module, const std::string &quant_dtype,
  * @brief quantize recorded module (min/max initialized) with specified parameters
  * returns true on success
  */
-
 bool Quantizer::quantize(luci::Module *module, LayerParams &layer_params)
 {
   return quantize(module, _ctx.output_model_dtype, layer_params);

--- a/compiler/circle-mpqsolver/src/pattern/PatternSolver.h
+++ b/compiler/circle-mpqsolver/src/pattern/PatternSolver.h
@@ -48,6 +48,9 @@ struct FrozenNodes
 class PatternSolver final : public MPQSolver
 {
 public:
+  /**
+   * @brief construct PatternSolver using qunatization context and patterns to apply
+   */
   PatternSolver(const mpqsolver::core::Quantizer::Context &ctx,
                 const std::vector<QuantizationPattern> &patterns);
 


### PR DESCRIPTION
This draft refactors bisection to enable in-memory data input for Evaluator and BisectionSolver.

Previous draft: #11452
Related: #11374 
ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>