### PR TITLE
[circle2circle] Add common subexpression elimination option

### DIFF
--- a/compiler/circle2circle/src/Circle2Circle.cpp
+++ b/compiler/circle2circle/src/Circle2Circle.cpp
@@ -181,6 +181,8 @@ int entry(int argc, char **argv)
              "Decompose HardSwish operator to Add, Mul and Relu6 operators");
   add_switch(arser, "--decompose_softmax",
              "Decompose Softmax operator into multiple operators for special backends");
+  add_switch(arser, "--common_subexpression_elimination",
+             "Perform common subexpression elimination");
   add_switch(arser, "--mute_warnings", "This will turn off warning messages");
   add_switch(arser, "--disable_validation",
              "This will turn off operator validations. May help input model investigation.");
@@ -349,6 +351,8 @@ int entry(int argc, char **argv)
     options->enable(Algorithms::TransformMinMaxToRelu6Pass);
   if (arser.get<bool>("--transform_min_relu_to_relu6"))
     options->enable(Algorithms::TransformMinReluToRelu6Pass);
+  if (arser.get<bool>("--common_subexpression_elimination"))
+    options->enable(Algorithms::CommonSubExpressionElimination);
   if (arser.get<bool>("--decompose_hardswish"))
     options->enable(Algorithms::DecomposeHardSwishPass);
   if (arser.get<bool>("--decompose_softmax"))


### PR DESCRIPTION
This adds common subexpression elimination option.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/11704
Draft PR: https://github.com/Samsung/ONE/pull/11824