### PR TITLE
[one-cmds] Add save_min_max option to one-quantize

### DIFF
--- a/compiler/one-cmds/one-quantize
+++ b/compiler/one-cmds/one-quantize
@@ -145,6 +145,12 @@ def _get_parser():
         "Force MaxPool Op to have the same input/output quantparams. NOTE: This option can degrade accuracy of some models.)"
     )
     quantization_group.add_argument(
+        '--save_min_max',
+        action='store_true',
+        help=
+        "Save min/max of each tensor. NOTE: Min/max valuse are clipped according to calibration algorithms, such as percentile or moving average. Nudge adjustment is not applied."
+    )
+    quantization_group.add_argument(
         '--quant_config', type=str, help="Path to the quantization configuration file.")
     quantization_group.add_argument(
         '--evaluate_result',
@@ -518,6 +524,8 @@ def _quantize(args):
             circle_quantizer_cmd.append(getattr(args, 'granularity'))
         if oneutils.is_valid_attr(args, 'TF-style_maxpool'):
             circle_quantizer_cmd.append('--TF-style_maxpool')
+        if oneutils.is_valid_attr(args, 'save_min_max'):
+            circle_quantizer_cmd.append('--save_min_max')
         if oneutils.is_valid_attr(args, 'input_type'):
             circle_quantizer_cmd.append('--input_type')
             circle_quantizer_cmd.append(getattr(args, 'input_type'))

--- a/compiler/one-cmds/tests/one-quantize_024.test
+++ b/compiler/one-cmds/tests/one-quantize_024.test
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  echo "${filename_ext} FAILED"
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+inputfile="./inception_v3.circle"
+outputfile="./inception_v3.one-quantize_024.circle"
+
+rm -f ${filename}.log
+rm -rf ${outputfile}
+
+# run test without input data
+one-quantize \
+--quantized_dtype uint8 \
+--granularity channel \
+--save_min_max \
+--input_path ${inputfile} \
+--output_path ${outputfile} > ${filename}.log 2>&1
+
+if [[ ! -s "${outputfile}" ]]; then
+  trap_err_onexit
+fi
+
+echo "${filename_ext} SUCCESS"


### PR DESCRIPTION
This adds save_min_max option to one-quantize.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/11717