### PR TITLE
[tflchef] Refactor check_custom_op_value in OpUtils

### DIFF
--- a/compiler/tflchef/core/src/OpUtils.cpp
+++ b/compiler/tflchef/core/src/OpUtils.cpp
@@ -20,9 +20,8 @@
 
 void check_custom_op_value(const tflchef::Operation operation, std::string op_type)
 {
-  if ((operation.has_extype() && operation.extype() == "Custom") || operation.type() == "Custom")
+  if (operation.type() == "Custom" || (operation.has_extype() && operation.extype() == "Custom"))
   {
-    assert(operation.has_custom_code());
     assert(operation.custom_code() == op_type);
   }
 }


### PR DESCRIPTION
This commit is for refactoring check_custom_op_value function in OpUtils. 
First, the extype is used for a while and will be removed later. 
Second, it is unnecessary to check the state of custom_code because the default value always exists.

ONE-DCO-1.0-Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>

---
Related Issue: https://github.com/Samsung/ONE/issues/11741
Draft PR: https://github.com/Samsung/ONE/pull/11750