### PR TITLE
[circle2circle-dredd] Add CSE_Quantize tests

### DIFF
--- a/compiler/circle2circle-dredd-recipe-test/test.lst
+++ b/compiler/circle2circle-dredd-recipe-test/test.lst
@@ -69,6 +69,9 @@ Add(Net_Gelu_001 PASS fuse_gelu)
 Add(HardSwish_001 PASS decompose_hardswish)
 Add(Softmax_001 PASS decompose_softmax)
 Add(Softmax_002 PASS decompose_softmax)
+
+# CSE test
+
 Add(CSE_Quantize_000 PASS common_subexpression_elimination)
 Add(CSE_Quantize_001 PASS common_subexpression_elimination)
 

--- a/compiler/circle2circle-dredd-recipe-test/test.lst
+++ b/compiler/circle2circle-dredd-recipe-test/test.lst
@@ -69,6 +69,8 @@ Add(Net_Gelu_001 PASS fuse_gelu)
 Add(HardSwish_001 PASS decompose_hardswish)
 Add(Softmax_001 PASS decompose_softmax)
 Add(Softmax_002 PASS decompose_softmax)
+Add(CSE_Quantize_000 PASS common_subexpression_elimination)
+Add(CSE_Quantize_001 PASS common_subexpression_elimination)
 
 ## CIRCLE RECIPE
 


### PR DESCRIPTION
This adds CSE tests for Quantize Op.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/11704
Draft PR: https://github.com/Samsung/ONE/pull/11824