### PR TITLE
[luci-pass-value-test] Add CSE_Quantize_000

### DIFF
--- a/compiler/luci-pass-value-test/test.lst
+++ b/compiler/luci-pass-value-test/test.lst
@@ -61,3 +61,6 @@ addeval(Net_Densify_Dequantize_Add_000 fold_dequantize fold_densify)
 # test SignatureDef, with any optimization
 #addeval(SignatureDef_MultiOut_000 fuse_instnorm)
 #addeval(SignatureDef_MultiOut_001 fuse_instnorm)
+
+# test for common subexpression elimination
+addeval(CSE_Quantize_000 common_subexpression_elimination)


### PR DESCRIPTION
This adds test for CSE_Quantize_000.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/11704
Draft PR: https://github.com/Samsung/ONE/pull/11824