### PR TITLE
[one-cmds] Add common_subexpression_elimination option

### DIFF
--- a/compiler/one-cmds/how-to-use-one-commands.txt
+++ b/compiler/one-cmds/how-to-use-one-commands.txt
@@ -149,6 +149,7 @@ one-optimize
 one-optimize provides network or operator transformation shown below.
 
 Current transformation options are
+- common_subexpression_elimination : This will perform common subexpression elimination.
 - decompose_hardswish : This will decompose hardswish operator to Add, Mul and Relu6 operators.
 - decompose_softmax : This will decompose softmax into multiple operators for special backends.
 - disable_validation : This will turn off operator validations.

--- a/compiler/one-cmds/onelib/constant.py
+++ b/compiler/one-cmds/onelib/constant.py
@@ -55,6 +55,7 @@ class CONSTANT:
         'remove_unnecessary_slice',
         'remove_unnecessary_strided_slice',
         'remove_unnecessary_split',
+        'common_subexpression_elimination',
 
         # Canonicalization
         # (passes to help further optimization)
@@ -80,6 +81,7 @@ class CONSTANT:
         ('convert_nchw_to_nhwc',
          'Experimental: This will convert NCHW operators to NHWC under the assumption that input model is NCHW.'
          ),
+        ('common_subexpression_elimination', 'perform common subexpression elimination'),
         ('expand_broadcast_const', 'expand broadcastable constant node inputs'),
         ('nchw_to_nhwc_input_shape',
          'convert the input shape of the model (argument for convert_nchw_to_nhwc)'),


### PR DESCRIPTION
This adds cse option to one-optimize.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/11704
Draft PR: https://github.com/Samsung/ONE/pull/11824