### PR TITLE
[record-minmax] Fix multi-input data handling

### DIFF
--- a/compiler/record-minmax/src/RecordMinMax.cpp
+++ b/compiler/record-minmax/src/RecordMinMax.cpp
@@ -342,7 +342,7 @@ void RecordMinMax::profileRawData(const std::string &input_data_path)
         readDataFromFile(file_name, input_data[i], input_size);
 
         // Write data from buffer to interpreter
-        getInterpreter()->writeInputTensor(input_node, input_data.data(), input_size);
+        getInterpreter()->writeInputTensor(input_node, input_data[i].data(), input_size);
       }
 
       getInterpreter()->interpret();


### PR DESCRIPTION
This fixes a bug in handling multi-input data.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/11777#issuecomment-1788530346