### PR TITLE
[one-cmds] Add fuse_horizontal_fc_layers to O1

### DIFF
--- a/compiler/one-cmds/onelib/constant.py
+++ b/compiler/one-cmds/onelib/constant.py
@@ -44,6 +44,7 @@ class CONSTANT:
         'fuse_mean_with_mean',
         'fuse_transpose_with_mean',
         'fuse_slice_with_tconv',
+        'fuse_horizontal_fc_layers'
         'transform_min_max_to_relu6',
         'transform_min_relu_to_relu6',
 


### PR DESCRIPTION
This commit adds fuse_horizontal_fc_layers to O1 group.

for issue: https://github.com/Samsung/ONE/issues/11705

ONE-DCO-1.0-Signed-off-by: Artem Balyshev <a.balyshev@samsung.com>