### PR TITLE
[res] Remove extype and Change type value to Custom for custom operators

### DIFF
--- a/res/TensorFlowLiteRecipes/All_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/All_000/test.recipe
@@ -18,7 +18,7 @@ operand {
   }
 }
 operation {
-  type: "All"
+  type: "Custom"
   all_options {
     keep_dims: false
   }
@@ -26,7 +26,6 @@ operation {
   input: "All/reduction_indices"
   output: "ofm"
   custom_code: "All"
-  extype: "Custom"
 }
 input: "ifm"
 output: "ofm"

--- a/res/TensorFlowLiteRecipes/BatchMatMulV2_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/BatchMatMulV2_000/test.recipe
@@ -14,12 +14,11 @@ operand {
   shape { dim: 1 dim: 2 dim: 4 dim: 4 }
 }
 operation {
-  type: "BatchMatMulV2"
+  type: "Custom"
   input: "ifm1"
   input: "ifm2"
   output: "ofm"
   custom_code: "BatchMatMulV2"
-  extype: "Custom"
 }
 input: "ifm1"
 input: "ifm2"

--- a/res/TensorFlowLiteRecipes/BatchMatMulV2_001/test.recipe
+++ b/res/TensorFlowLiteRecipes/BatchMatMulV2_001/test.recipe
@@ -14,7 +14,7 @@ operand {
   shape { dim: 2 dim: 2 dim: 2 dim: 4 }
 }
 operation {
-  type: "BatchMatMulV2"
+  type: "Custom"
   batch_matmul_options {
       adj_x : true
   }
@@ -22,7 +22,6 @@ operation {
   input: "ifm2"
   output: "ofm"
   custom_code: "BatchMatMulV2"
-  extype: "Custom"
 }
 input: "ifm1"
 input: "ifm2"

--- a/res/TensorFlowLiteRecipes/BroadcastTo_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/BroadcastTo_000/test.recipe
@@ -15,12 +15,11 @@ operand {
   shape { dim: 1 dim: 2 dim: 3 }
 }
 operation {
-  type: "BroadcastTo"
+  type: "Custom"
   input: "bc_input"
   input: "bc_shape"
   output: "bc_ofm"
   custom_code: "BroadcastTo"
-  extype: "Custom"
 }
 input: "bc_input"
 output: "bc_ofm"

--- a/res/TensorFlowLiteRecipes/MatMul_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/MatMul_000/test.recipe
@@ -14,7 +14,7 @@ operand {
   shape { dim: 3 dim: 3 }
 }
 operation {
-  type: "MatMul"
+  type: "Custom"
   input: "ifm1"
   input: "ifm2"
   output: "ofm"
@@ -23,7 +23,6 @@ operation {
     transpose_b: false
   }
   custom_code: "MatMul"
-  extype: "Custom"
 }
 input: "ifm1"
 input: "ifm2"

--- a/res/TensorFlowLiteRecipes/MatrixBandPart_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/MatrixBandPart_000/test.recipe
@@ -27,13 +27,12 @@ operand {
   shape { dim: 4 dim: 4 }
 }
 operation {
-  type: "MatrixBandPart"
+  type: "Custom"
   input: "ifm"
   input: "MatrixBandPart/num_lower"
   input: "MatrixBandPart/num_upper"
   output: "ofm"
   custom_code: "MatrixBandPart"
-  extype: "Custom"
 }
 input: "ifm"
 output: "ofm"

--- a/res/TensorFlowLiteRecipes/MaxPoolWithArgmax_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/MaxPoolWithArgmax_000/test.recipe
@@ -14,7 +14,7 @@ operand {
   shape { dim: 1 dim: 9 dim: 9 dim: 1 }
 }
 operation {
-  type: "MaxPoolWithArgmax"
+  type: "Custom"
   input: "ifm"
   output: "ofm"
   output: "argmax"
@@ -28,7 +28,6 @@ operation {
     include_batch_in_index: false
   }
   custom_code: "MaxPoolWithArgmax"
-  extype: "Custom"
 }
 input: "ifm"
 output: "ofm"

--- a/res/TensorFlowLiteRecipes/MaxPoolWithArgmax_001/test.recipe
+++ b/res/TensorFlowLiteRecipes/MaxPoolWithArgmax_001/test.recipe
@@ -14,7 +14,7 @@ operand {
   shape { dim: 1 dim: 9 dim: 9 dim: 1 }
 }
 operation {
-  type: "MaxPoolWithArgmax"
+  type: "Custom"
   input: "ifm"
   output: "ofm"
   output: "argmax"
@@ -28,7 +28,6 @@ operation {
     include_batch_in_index: false
   }
   custom_code: "MaxPoolWithArgmax"
-  extype: "Custom"
 }
 input: "ifm"
 output: "ofm"

--- a/res/TensorFlowLiteRecipes/MaxPoolWithArgmax_002/test.recipe
+++ b/res/TensorFlowLiteRecipes/MaxPoolWithArgmax_002/test.recipe
@@ -14,7 +14,7 @@ operand {
   shape { dim: 1 dim: 8 dim: 8 dim: 2 }
 }
 operation {
-  type: "MaxPoolWithArgmax"
+  type: "Custom"
   input: "ifm"
   output: "ofm"
   output: "argmax"
@@ -28,7 +28,6 @@ operation {
     include_batch_in_index: false
   }
   custom_code: "MaxPoolWithArgmax"
-  extype: "Custom"
 }
 input: "ifm"
 output: "ofm"

--- a/res/TensorFlowLiteRecipes/Net_BroadcastTo_AddV2_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/Net_BroadcastTo_AddV2_000/test.recipe
@@ -15,12 +15,11 @@ operand {
   shape { dim: 1 dim: 2 dim: 3 }
 }
 operation {
-  type: "BroadcastTo"
+  type: "Custom"
   input: "bc_input"
   input: "bc_shape"
   output: "bc_ofm"
   custom_code: "BroadcastTo"
-  extype: "Custom"
 }
 operand {
   name: "reshape_data"
@@ -55,12 +54,11 @@ operand {
   shape { dim: 1 dim: 2 dim: 3 }
 }
 operation {
-  type: "AddV2"
+  type: "Custom"
   input: "bc_ofm"
   input: "reshape_ofm"
   output: "ofm"
   custom_code: "AddV2"
-  extype: "Custom"
 }
 input: "bc_input"
 input: "reshape_data"

--- a/res/TensorFlowLiteRecipes/Net_BroadcastTo_AddV2_001/test.recipe
+++ b/res/TensorFlowLiteRecipes/Net_BroadcastTo_AddV2_001/test.recipe
@@ -15,12 +15,11 @@ operand {
   shape { dim: 1 dim: 2 dim: 3 }
 }
 operation {
-  type: "BroadcastTo"
+  type: "Custom"
   input: "bc_input"
   input: "bc_shape"
   output: "bc_ofm"
   custom_code: "BroadcastTo"
-  extype: "Custom"
 }
 operand {
   name: "reshape_data"
@@ -55,12 +54,11 @@ operand {
   shape { dim: 1 dim: 2 dim: 3 }
 }
 operation {
-  type: "AddV2"
+  type: "Custom"
   input: "bc_ofm"
   input: "reshape_ofm"
   output: "ofm"
   custom_code: "AddV2"
-  extype: "Custom"
 }
 input: "bc_input"
 input: "reshape_data"

--- a/res/TensorFlowLiteRecipes/Net_FC_Gelu_FC_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/Net_FC_Gelu_FC_000/test.recipe
@@ -101,11 +101,10 @@ operation {
   output: "fc2"
 }
 operation {
-  type: "Erf"
+  type: "Custom"
   input: "fc2"
   output: "erf"
   custom_code: "Erf"
-  extype: "Custom"
 }
 operation {
   type: "Add"

--- a/res/TensorFlowLiteRecipes/Net_Gather_SparseToDense_AddV2_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/Net_Gather_SparseToDense_AddV2_000/test.recipe
@@ -99,12 +99,11 @@ operation {
   output: "ofm_sparse"
 }
 operation {
-  type: "AddV2"
+  type: "Custom"
   input: "ofm_sparse"
   input: "add_v2_2"
   output: "ofm_add_v2"
   custom_code: "AddV2"
-  extype: "Custom"
 }
 operation {
   type: "Cast"

--- a/res/TensorFlowLiteRecipes/Net_Gelu_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/Net_Gelu_000/test.recipe
@@ -65,11 +65,10 @@ operation {
   }
 }
 operation {
-  type: "Erf"
+  type: "Custom"
   input: "mul_sqrt"
   output: "erf"
   custom_code: "Erf"
-  extype: "Custom"
 }
 operation {
   type: "Add"

--- a/res/TensorFlowLiteRecipes/Net_Gelu_001/test.recipe
+++ b/res/TensorFlowLiteRecipes/Net_Gelu_001/test.recipe
@@ -65,11 +65,10 @@ operation {
   }
 }
 operation {
-  type: "Erf"
+  type: "Custom"
   input: "mul_sqrt"
   output: "erf"
   custom_code: "Erf"
-  extype: "Custom"
 }
 operation {
   type: "Add"


### PR DESCRIPTION
This commit includes removing extype and changing type to Custom if op type is a custom op.

ONE-DCO-1.0-Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>

---
Related Issue: https://github.com/Samsung/ONE/issues/11741
Draft PR: https://github.com/Samsung/ONE/pull/11750