### PR TITLE
[circlechef] Remove extype used for custom op

### DIFF
--- a/compiler/circlechef/core/src/ModelChef.cpp
+++ b/compiler/circlechef/core/src/ModelChef.cpp
@@ -135,7 +135,7 @@ gather_builtincode_map(const ::circlechef::ModelRecipe &model_recipe)
 
   for (const auto &operation : model_recipe.operation())
   {
-    if (operation.type() == "Custom" || (operation.has_extype() && operation.extype() == "Custom"))
+    if (operation.type() == "Custom")
       continue;
 
     auto op_chef = op_chef_registry().lookup(operation.type()).create(&operation);
@@ -151,8 +151,7 @@ gather_builtincode_map(const ::circlechef::ModelRecipe &model_recipe)
     const auto &graph = model_recipe.graph(g);
     for (const auto &operation : graph.operation())
     {
-      if (operation.type() == "Custom" ||
-          (operation.has_extype() && operation.extype() == "Custom"))
+      if (operation.type() == "Custom")
         continue;
 
       auto op_chef = op_chef_registry().lookup(operation.type()).create(&operation);
@@ -172,7 +171,7 @@ std::set<std::string> gather_customcode_set(const ::circlechef::ModelRecipe &mod
   std::set<std::string> customcode_set;
   for (const auto &operation : model_recipe.operation())
   {
-    if (operation.type() == "Custom" || (operation.has_extype() && operation.extype() == "Custom"))
+    if (operation.type() == "Custom")
     {
       assert(not operation.custom_code().empty());
       customcode_set.insert(operation.custom_code());
@@ -185,8 +184,7 @@ std::set<std::string> gather_customcode_set(const ::circlechef::ModelRecipe &mod
     const auto &graph = model_recipe.graph(g);
     for (const auto &operation : graph.operation())
     {
-      if (operation.type() == "Custom" ||
-          (operation.has_extype() && operation.extype() == "Custom"))
+      if (operation.type() == "Custom")
       {
         assert(not operation.custom_code().empty());
         customcode_set.insert(operation.custom_code());

--- a/compiler/circlechef/proto/circlechef.proto
+++ b/compiler/circlechef/proto/circlechef.proto
@@ -93,7 +93,6 @@ message Operation {
   optional int32 version = 4 [default = 1];
   optional string custom_code = 5;
 
-  optional string extype = 99;
   optional BatchMatMulOptions batch_matmul_options = 100;
   optional InstanceNormOptions instance_norm_options = 101;
   optional BCQFullyConnectedOptions bcq_fully_connected_options = 102;


### PR DESCRIPTION
This commit includes removing extype used for custom op because it is no longer necessary.

ONE-DCO-1.0-Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>

---
Related Issue: https://github.com/Samsung/ONE/issues/11741
Draft PR: https://github.com/Samsung/ONE/pull/11750