### PR TITLE
[tflchef] Remove extype used for custom op

### DIFF
--- a/compiler/tflchef/core/src/ModelChef.cpp
+++ b/compiler/tflchef/core/src/ModelChef.cpp
@@ -141,7 +141,7 @@ gather_builtincode_map(const ::tflchef::ModelRecipe &model_recipe)
 
   for (const auto &operation : model_recipe.operation())
   {
-    if (operation.type() == "Custom" || (operation.has_extype() && operation.extype() == "Custom"))
+    if (operation.type() == "Custom")
       continue;
 
     auto op_chef = op_chef_registry().lookup(operation.type()).create(&operation);
@@ -157,8 +157,7 @@ gather_builtincode_map(const ::tflchef::ModelRecipe &model_recipe)
     const auto &graph = model_recipe.graph(g);
     for (const auto &operation : graph.operation())
     {
-      if (operation.type() == "Custom" ||
-          (operation.has_extype() && operation.extype() == "Custom"))
+      if (operation.type() == "Custom")
         continue;
 
       auto op_chef = op_chef_registry().lookup(operation.type()).create(&operation);
@@ -178,7 +177,7 @@ std::set<std::string> gather_customcode_set(const ::tflchef::ModelRecipe &model_
   std::set<std::string> customcode_set;
   for (const auto &operation : model_recipe.operation())
   {
-    if (operation.type() == "Custom" || (operation.has_extype() && operation.extype() == "Custom"))
+    if (operation.type() == "Custom")
     {
       assert(not operation.custom_code().empty());
       customcode_set.insert(operation.custom_code());
@@ -191,8 +190,7 @@ std::set<std::string> gather_customcode_set(const ::tflchef::ModelRecipe &model_
     const auto &graph = model_recipe.graph(g);
     for (const auto &operation : graph.operation())
     {
-      if (operation.type() == "Custom" ||
-          (operation.has_extype() && operation.extype() == "Custom"))
+      if (operation.type() == "Custom")
       {
         assert(not operation.custom_code().empty());
         customcode_set.insert(operation.custom_code());

--- a/compiler/tflchef/core/src/OpUtils.cpp
+++ b/compiler/tflchef/core/src/OpUtils.cpp
@@ -20,7 +20,7 @@
 
 void check_custom_op_value(const tflchef::Operation operation, std::string op_type)
 {
-  if (operation.type() == "Custom" || (operation.has_extype() && operation.extype() == "Custom"))
+  if (operation.type() == "Custom")
   {
     assert(operation.custom_code() == op_type);
   }

--- a/compiler/tflchef/proto/tflchef.proto
+++ b/compiler/tflchef/proto/tflchef.proto
@@ -558,7 +558,6 @@ message Operation {
   optional int32 version = 4 [default = 1];
   optional string custom_code = 5;
 
-  optional string extype = 99;
   optional Conv2DOptions conv2d_options = 100;
   optional Pool2DOptions averagepool2d_options = 101;
   optional ConcatenationOptions concatenation_options = 102;

--- a/compiler/tflchef/tests/custom_erf/test.recipe
+++ b/compiler/tflchef/tests/custom_erf/test.recipe
@@ -9,11 +9,10 @@ operand {
   shape { dim: 1 dim: 3 dim: 3 dim: 2 }
 }
 operation {
-  type: "Erf"
+  type: "Custom"
   input: "ifm"
   output: "ofm"
   custom_code: "Erf"
-  extype: "Custom"
 }
 input: "ifm"
 output: "ofm"


### PR DESCRIPTION
This commit includes removing extype used for custom op because it is no longer necessary.

ONE-DCO-1.0-Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>

---
Related Issue: https://github.com/Samsung/ONE/issues/11741
Draft PR: https://github.com/Samsung/ONE/pull/11750