### PR TITLE
[one-cmds] Add missing comma

### DIFF
--- a/compiler/one-cmds/onelib/constant.py
+++ b/compiler/one-cmds/onelib/constant.py
@@ -44,7 +44,7 @@ class CONSTANT:
         'fuse_mean_with_mean',
         'fuse_transpose_with_mean',
         'fuse_slice_with_tconv',
-        'fuse_horizontal_fc_layers'
+        'fuse_horizontal_fc_layers',
         'transform_min_max_to_relu6',
         'transform_min_relu_to_relu6',
 


### PR DESCRIPTION
This adds missing comma in constant.py.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/11777#issuecomment-1794041987