### PR TITLE
[circle2circle-dredd-test] Add CSE_Transpose test

### DIFF
--- a/compiler/circle2circle-dredd-recipe-test/test.lst
+++ b/compiler/circle2circle-dredd-recipe-test/test.lst
@@ -74,6 +74,8 @@ Add(Softmax_002 PASS decompose_softmax)
 
 Add(CSE_Quantize_000 PASS common_subexpression_elimination)
 Add(CSE_Quantize_001 PASS common_subexpression_elimination)
+Add(CSE_Transpose_000 PASS common_subexpression_elimination)
+Add(CSE_Transpose_001 PASS common_subexpression_elimination)
 
 ## CIRCLE RECIPE
 


### PR DESCRIPTION
This adds tests for CSE Transpose.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/11726
Draft PR: https://github.com/Samsung/ONE/pull/11869