### PR TITLE
[luci-pass-value-test] Add CSE_Transpose test

### DIFF
--- a/compiler/luci-pass-value-test/test.lst
+++ b/compiler/luci-pass-value-test/test.lst
@@ -64,3 +64,4 @@ addeval(Net_Densify_Dequantize_Add_000 fold_dequantize fold_densify)
 
 # test for common subexpression elimination
 addeval(CSE_Quantize_000 common_subexpression_elimination)
+addeval(CSE_Transpose_000 common_subexpression_elimination)


### PR DESCRIPTION
This adds a test for CSE_Transpose.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/11726
Draft PR: https://github.com/Samsung/ONE/pull/11869