### PR TITLE
[circlechef] Tidy nnkit from requires.cmake

### DIFF
--- a/compiler/circlechef/requires.cmake
+++ b/compiler/circlechef/requires.cmake
@@ -1,5 +1,4 @@
 require("arser")
-require("nnkit")
 require("cwrap")
 require("mio-circle06")
 require("safemain")


### PR DESCRIPTION
This will tidy nnkit from requires.cmake.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>