### PR TITLE
[onert_train] Make data_length option mandatory

### DIFF
--- a/tests/tools/onert_train/src/args.cc
+++ b/tests/tools/onert_train/src/args.cc
@@ -198,7 +198,7 @@ void Args::Initialize(void)
     ("nnpackage", po::value<std::string>()->notifier(process_nnpackage), "NN Package file(directory) name")
     ("modelfile", po::value<std::string>()->notifier(process_modelfile), "NN Model filename")
     ("path", po::value<std::string>()->notifier(process_path), "NN Package or NN Modelfile path")
-    ("data_length", po::value<int>()->default_value(-1)->notifier([&](const auto &v) { _data_length = v; }), "Data length number")
+    ("data_length", po::value<int>()->notifier([&](const auto &v) { _data_length = v; }), "Data length number")
     ("load_input:raw", po::value<std::string>()->notifier(process_load_raw_inputfile),
          "NN Model Raw Input data file\n"
          "The datafile must have data for each input number.\n"
@@ -275,6 +275,9 @@ void Args::Parse(const int argc, char **argv)
     if (!vm.count("modelfile") && !vm.count("nnpackage") && !vm.count("path"))
       throw boost::program_options::error(
         std::string("Require one of options modelfile, nnpackage, or path."));
+
+    if (!vm.count("data_length"))
+      throw boost::program_options::error(std::string("data_length option is mandatory."));
   }
 
   try


### PR DESCRIPTION
It makes data_length option mandatory not to make the user suprised.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

Related: https://github.com/Samsung/ONE/issues/11892#issuecomment-1797888717