### PR TITLE
[res] Add a TensorFlowLiteRecipes for CumSum

### DIFF
--- a/res/TensorFlowLiteRecipes/CumSum_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/CumSum_000/test.recipe
@@ -1,0 +1,45 @@
+operand {
+  name: "ifm"
+  type: FLOAT32
+  shape {
+    dim: 1
+    dim: 1
+    dim: 10
+    dim: 10
+  }
+}
+
+operand {
+  name: "axis"
+  type: INT32
+  shape {}
+  filler {
+    tag: "explicit"
+    arg: "2"
+  }
+}
+
+operand {
+  name: "ofm"
+  type: FLOAT32
+  shape {
+    dim: 1
+    dim: 1
+    dim: 10
+    dim: 10
+  }
+}
+
+operation {
+  type: "CumSum"
+  input: "ifm"
+  input: "axis"
+  output: "ofm"
+  cumsum_options {
+    exclusive: false
+    reverse: false
+  }
+}
+
+input: "ifm"
+output: "ofm"


### PR DESCRIPTION
This adds a TensorFlowLiteRecipes for CumSum operation.

ONE-DCO-1.0-Signed-off-by: Jonghwa Lee <jonghwa3.lee@samsung.com>

---
Realated w/ : https://github.com/Samsung/ONE/issues/11842
Draft PR : https://github.com/Samsung/ONE/pull/11810