### PR TITLE
[common-artifacts] Enable optimization test for CumSum operation

### DIFF
--- a/compiler/common-artifacts/exclude.lst
+++ b/compiler/common-artifacts/exclude.lst
@@ -7,7 +7,6 @@
 ## TensorFlowLiteRecipes
 optimize(BroadcastTo_000)
 optimize(BroadcastTo_001)
-optimize(CumSum_000)
 
 ## CircleRecipes
 


### PR DESCRIPTION
This enables the test of cirlce optimization generation for CumSum op.

ONE-DCO-1.0-Signed-off-by: Jonghwa Lee <jonghwa3.lee@samsung.com>

---
Realated w/ : #11842 