### PR TITLE
[infra/command] Update docker-run and config

### DIFF
--- a/infra/command/docker-run
+++ b/infra/command/docker-run
@@ -1,19 +1,15 @@
 #!/bin/bash
 
 import "docker.configuration"
-USER_MODE=0
 
+# Use host user ID if --user option is given
+# It is useful if host userID is different from docker userID 1000
 if [[ $1 == '--user' ]]; then
   DOCKER_RUN_OPTS+=" -u $(stat -c "%u" $NNAS_PROJECT_PATH):$(stat -c "%g" $NNAS_PROJECT_PATH)"
-  USER_MODE=1
   shift
 fi
 
 docker run ${DOCKER_RUN_OPTS} ${DOCKER_ENV_VARS} ${DOCKER_VOLUMES} ${DOCKER_IMAGE_NAME} "$@"
 EXITCODE=$?
-
-if [ $USER_MODE -eq 0 ]; then
-  docker_cleanup
-fi
 
 exit ${EXITCODE}

--- a/infra/config/docker.configuration
+++ b/infra/config/docker.configuration
@@ -3,7 +3,7 @@
 # Don't run this script
 [[ "${BASH_SOURCE[0]}" == "${0}" ]] && echo "Please don't execute ${BASH_SOURCE[0]}" && exit 1
 
-DOCKER_IMAGE_NAME=${DOCKER_IMAGE_NAME:-nnfw/one-devtools}
+DOCKER_IMAGE_NAME=${DOCKER_IMAGE_NAME:-nnfw/one-devtools:focal}
 echo "Using docker image ${DOCKER_IMAGE_NAME}"
 
 if [ -z "`docker images ${DOCKER_IMAGE_NAME}`" ]; then
@@ -32,21 +32,10 @@ DOCKER_ENV_VARS+=" -e GIT_SSL_NO_VERIFY"
 DOCKER_ENV_VARS+=" -e NNAS_WORKSPACE"
 DOCKER_ENV_VARS+=" -e NNCC_WORKSPACE"
 DOCKER_ENV_VARS+=" -e NNFW_WORKSPACE"
+DOCKER_ENV_VARS+=" -e EXTERNAL_DOWNLOAD_SERVER"
+DOCKER_ENV_VARS+=" -e EXTERNAL_SERVER_USERPWD"
+DOCKER_ENV_VARS+=" -e MODELFILE_SERVER"
 
 DOCKER_RUN_OPTS="${DOCKER_OPTS}"
 DOCKER_RUN_OPTS+=" --rm"
 DOCKER_RUN_OPTS+=" -w ${DOCKER_PATH}"
-
-function docker_cleanup()
-{
-  # Newly created files during during docker run can have different ownership.
-  # This may cause some problems, for example, some jenkins slaves or developers
-  # can't remove built files due to lack of permission.
-  # To address this issue, let's change owner of all files
-  # in nncc to owner of nncc.
-  NNFW_OWNER_UID=$(stat -c "%u" ${HOST_PATH})
-  NNFW_OWNER_GID=$(stat -c "%g" ${HOST_PATH})
-
-  CMD="chown -R ${NNFW_OWNER_UID}:${NNFW_OWNER_GID} ${DOCKER_PATH}"
-  docker run ${DOCKER_RUN_OPTS} ${DOCKER_ENV_VARS} ${DOCKER_VOLUMES} ${DOCKER_IMAGE_NAME} ${CMD}
-}


### PR DESCRIPTION
This commit updates docker-run command.
- Remove cleanup function: docker image is using userID
- Set default docker image's ubuntu version
- Get more env variable from host
  - EXTERNAL_DOWNLOAD_SERVER
  - EXTERNAL_SERVER_USERPWD
  - MODELFILE_SERVER

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>