### PR TITLE
[luci] Skip replace_non_const_fc_with_batch_matmul for const inputs

### DIFF
--- a/compiler/luci/pass/src/ReplaceNonConstFCWithBatchMatMulPass.cpp
+++ b/compiler/luci/pass/src/ReplaceNonConstFCWithBatchMatMulPass.cpp
@@ -138,6 +138,12 @@ bool replace_fc_with_matmul(luci::CircleFullyConnected *fc)
   if (dynamic_cast<luci::CircleConst *>(fc->weights()))
     return false; // NonConst
 
+  // For const inputs, we don't do this conversion, because we can improve
+  // accuracy of quantized models by making transposed FC.
+  // See https://github.com/Samsung/ONE/discussions/11941 for more details.
+  if (dynamic_cast<luci::CircleConst *>(fc->input()) != nullptr)
+    return false;
+
   if ((ty = dynamic_cast<luci::CircleTranspose *>(fc->weights()))) // is y a transpose?
   {
     adj_y = false;

--- a/compiler/luci/pass/src/ReplaceNonConstFCWithBatchMatMulPass.test.cpp
+++ b/compiler/luci/pass/src/ReplaceNonConstFCWithBatchMatMulPass.test.cpp
@@ -143,3 +143,17 @@ TEST_F(ReplaceNonConstFCWithBatchMatMulPassTest, wrong_op_NEG)
 
   EXPECT_EQ(false, changed);
 }
+
+TEST_F(ReplaceNonConstFCWithBatchMatMulPassTest, const_input_NEG)
+{
+  g.init({2, 3}, {2, 3}, {2, 2}, 1.0f);
+
+  auto const_input = g.g()->nodes()->create<luci::CircleConst>();
+  const_input->shape({2, 3});
+  const_input->dtype(loco::DataType::FLOAT32);
+
+  g.fc()->input(const_input);
+
+  auto ret = pass.run(g.g());
+  EXPECT_EQ(false, ret);
+}


### PR DESCRIPTION
This skips replace_non_const_fc_with_batch_matmul for const inputs.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/discussions/11941