### PR TITLE
[tflchef] Revise check_custom_op_value parameters

### DIFF
--- a/compiler/tflchef/core/src/OpUtils.cpp
+++ b/compiler/tflchef/core/src/OpUtils.cpp
@@ -18,7 +18,7 @@
 
 #include <stdexcept>
 
-void check_custom_op_value(const tflchef::Operation operation, std::string op_type)
+void check_custom_op_value(const tflchef::Operation &operation, const std::string &op_type)
 {
   if (operation.type() == "Custom")
   {

--- a/compiler/tflchef/core/src/OpUtils.h
+++ b/compiler/tflchef/core/src/OpUtils.h
@@ -23,6 +23,6 @@
 
 #include <tflchef.pb.h>
 
-void check_custom_op_value(const tflchef::Operation operation, std::string op_type);
+void check_custom_op_value(const tflchef::Operation &operation, const std::string &op_type);
 
 #endif // __OPUTILS_H__


### PR DESCRIPTION
This will revise check_custom_op_value with reference parameters to reduce stack memory.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>