### PR TITLE
[mir] Skip mir_onnx_importer build if no interpreter

### DIFF
--- a/compiler/mir/src/mir_onnx_importer/CMakeLists.txt
+++ b/compiler/mir/src/mir_onnx_importer/CMakeLists.txt
@@ -9,6 +9,10 @@ if (NOT Protobuf_FOUND)
     return()
 endif ()
 
+if (NOT TARGET mir_interpreter)
+    return()
+endif ()
+
 Protobuf_Generate(MIR_ONNX_PROTO
         ${CMAKE_CURRENT_BINARY_DIR}/generated
         ${ONNXSource_DIR}


### PR DESCRIPTION
This will revise to skip mir_onnx_importer build if interpreter is absent.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>