### PR TITLE
DRAFT: Sync circle-mpqsolver with one-quantize

### DIFF
--- a/compiler/circle-mpqsolver/src/CircleMPQSolver.cpp
+++ b/compiler/circle-mpqsolver/src/CircleMPQSolver.cpp
@@ -22,6 +22,7 @@
 #include "bisection/BisectionSolver.h"
 #include "pattern/PatternSolver.h"
 #include "core/SolverOutput.h"
+#include "core/Quantizer.h"
 
 #include <iostream>
 #include <iomanip>
@@ -104,6 +105,29 @@ int entry(int argc, char **argv)
     .default_value("uint8")
     .help("Data type of quantized model's outputs (default: uint8)");
 
+  arser.add_argument("--quantized_dtype")
+    .type(arser::DataType::STR)
+    .default_value("uint8")
+    .help("Data type of quantized model (supported: uint8 (default), int16)");
+
+  arser.add_argument("--granularity")
+    .type(arser::DataType::STR)
+    .default_value("channel")
+    .help("Granularity of quantization scheme (supported: layer, channel (default))");
+
+  arser.add_argument("--TF-style_maxpool")
+    .nargs(0)
+    .default_value(false)
+    .help("Force MaxPool Op to have the same input/output quantparams. NOTE: This feature can "
+          "degrade accuracy of some models");
+
+  arser.add_argument("--save_min_max")
+    .nargs(0)
+    .default_value(false)
+    .help("Save recorded min/max values.");
+
+  arser.add_argument("--config").help("Path to the quantization configuration file");
+
   arser.add_argument("--output_model").required(true).help("Output quantized model");
 
   arser.add_argument("--visq_file")
@@ -140,6 +164,10 @@ int entry(int argc, char **argv)
   auto output_model_path = arser.get<std::string>("--output_model");
   auto input_dtype = arser.get<std::string>("--input_dtype");
   auto output_dtype = arser.get<std::string>("--output_dtype");
+  auto quantized_dtype = arser.get<std::string>("--quantized_dtype");
+  auto granularity = arser.get<std::string>("--granularity");
+  auto TF_style_maxpool = arser["--TF-style_maxpool"] and arser.get<bool>("--TF-style_maxpool");
+  auto save_min_max = arser["--save_min_max"] and arser.get<bool>("--save_min_max");
 
   float qerror_ratio = arser.get<float>("--qerror_ratio");
   if (qerror_ratio < 0.0 || qerror_ratio > 1.f)
@@ -158,8 +186,12 @@ int entry(int argc, char **argv)
   SolverOutput::get() << ">> Searching mixed precision configuration \n"
                       << "model:" << input_model_path << "\n"
                       << "dataset: " << data_path << "\n"
+                      << "quantized dtype: " << quantized_dtype << "\n"
+                      << "granularity: " << granularity << "\n"
                       << "input dtype: " << input_dtype << "\n"
-                      << "output dtype: " << output_dtype << "\n";
+                      << "output dtype: " << output_dtype << "\n"
+                      << "TF_style_maxpool: " << (TF_style_maxpool ? "True" : "False") << "\n"
+                      << "save_min_max: " << (save_min_max ? "True" : "False") << "\n";
 
   std::unique_ptr<mpqsolver::MPQSolver> solver;
   if (arser[bisection_str])
@@ -226,8 +258,19 @@ int entry(int argc, char **argv)
     {
       patterns.push_back(mpqsolver::pattern::QuantizationPattern::Q8SoftmaxWithQ16SubExp);
     }
-    solver =
-      std::make_unique<mpqsolver::pattern::PatternSolver>(input_dtype, output_dtype, patterns);
+
+    // Create quantizer parameters
+    mpqsolver::core::Quantizer::Context ctx;
+    {
+      ctx.output_model_dtype = quantized_dtype;
+      ctx.granularity = granularity;
+      ctx.input_type = input_dtype;
+      ctx.output_type = output_dtype;
+      ctx.save_min_max = save_min_max;
+      ctx.TF_style_maxpool = TF_style_maxpool;
+    }
+
+    solver = std::make_unique<mpqsolver::pattern::PatternSolver>(ctx, patterns);
   }
   else
   {

--- a/compiler/circle-mpqsolver/src/MPQSolver.cpp
+++ b/compiler/circle-mpqsolver/src/MPQSolver.cpp
@@ -21,6 +21,13 @@
 
 using namespace mpqsolver;
 
+MPQSolver::MPQSolver(const core::Quantizer::Context &ctx, const std::string &input_data_path,
+                     float qerror_ratio)
+  : _input_data_path(input_data_path), _qerror_ratio(qerror_ratio)
+{
+  _quantizer = std::make_unique<core::Quantizer>(ctx);
+}
+
 MPQSolver::MPQSolver(const std::string &input_data_path, float qerror_ratio,
                      const std::string &input_quantization, const std::string &output_quantization)
   : _input_data_path(input_data_path), _qerror_ratio(qerror_ratio),

--- a/compiler/circle-mpqsolver/src/MPQSolver.h
+++ b/compiler/circle-mpqsolver/src/MPQSolver.h
@@ -31,6 +31,10 @@ namespace mpqsolver
 class MPQSolver
 {
 public:
+  MPQSolver(const core::Quantizer::Context &ctx, const std::string &input_data_path,
+            float qerror_ratio);
+
+public:
   /**
    * @brief construct Solver using input_data_path for .h5 file,
    * qerror_ratio to set target qerror, and input_quantization/output_quantization to set

--- a/compiler/circle-mpqsolver/src/core/Quantizer.cpp
+++ b/compiler/circle-mpqsolver/src/core/Quantizer.cpp
@@ -115,6 +115,65 @@ bool Quantizer::quantize(luci::Module *module, const std::string &quant_dtype,
 }
 
 /**
+ * @brief quantize recorded module (min/max initialized) with specified parameters
+ * returns true on success
+ */
+
+bool Quantizer::quantize(luci::Module *module, LayerParams &layer_params)
+{
+  if (!module)
+    return false;
+
+  static const std::string default_dtype = "float32";
+
+  luci::CircleQuantizer quantizer;
+
+  auto options = quantizer.options();
+  options->enable(Algorithms::QuantizeWithMinMax);
+
+  options->param(AlgorithmParameters::Quantize_input_model_dtype, default_dtype);
+  options->param(AlgorithmParameters::Quantize_output_model_dtype, _ctx.output_model_dtype);
+  options->param(AlgorithmParameters::Quantize_granularity, _ctx.granularity);
+  options->param(AlgorithmParameters::Quantize_input_type, _ctx.input_type);
+  options->param(AlgorithmParameters::Quantize_output_type, _ctx.output_type);
+  options->param(AlgorithmParameters::Quantize_TF_style_maxpool,
+                 _ctx.TF_style_maxpool ? "True" : "False");
+  options->param(AlgorithmParameters::Quantize_save_min_max, _ctx.save_min_max ? "True" : "False");
+
+  if (!layer_params.empty())
+  {
+    try
+    {
+      options->layer_params(AlgorithmParameters::Quantize_layer_params, layer_params);
+    }
+    catch (const std::runtime_error &e)
+    {
+      std::cerr << e.what() << '\n';
+      return false;
+    }
+  }
+
+  for (size_t idx = 0; idx < module->size(); ++idx)
+  {
+    auto graph = module->graph(idx);
+    // quantize the graph
+    quantizer.quantize(graph);
+    if (!luci::validate(graph))
+    {
+      std::cerr << "ERROR: Quantized graph is invalid" << std::endl;
+      return false;
+    }
+  }
+
+  if (_hook)
+  {
+    _hook->on_quantized(module);
+  }
+
+  return true;
+}
+
+/**
  * @brief fake_quantize recorded module (min/max initialized) with specified parameters
  * returns true on success
  */

--- a/compiler/circle-mpqsolver/src/core/Quantizer.h
+++ b/compiler/circle-mpqsolver/src/core/Quantizer.h
@@ -44,6 +44,22 @@ struct QuantizerHook
 class Quantizer
 {
 public:
+  struct Context
+  {
+    std::string output_model_dtype;
+    std::string granularity;
+    std::string input_type;
+    std::string output_type;
+    bool TF_style_maxpool = false;
+    bool save_min_max = false;
+    // TODO Support layer info
+  };
+
+public:
+  Quantizer(const Context &ctx) : _ctx(ctx) {}
+
+  // TODO Remove this
+public:
   Quantizer(const std::string &input_dtype, const std::string &output_type);
 
   /**
@@ -58,6 +74,12 @@ public:
   bool quantize(luci::Module *module, const std::string &quant_dtype, LayerParams &layer_params);
 
   /**
+   * @brief quantize recorded module (min/max initialized) with specified parameters
+   * returns true on success
+   */
+  bool quantize(luci::Module *module, LayerParams &layer_params);
+
+  /**
    * @brief fake_quantize recorded module (min/max initialized) with specified parameters
    * returns true on success
    */
@@ -65,6 +87,8 @@ public:
                      LayerParams &layer_params);
 
 private:
+  Context _ctx;
+  // TODO Remove _input_dtype and output_dtype
   std::string _input_dtype = "uint8";
   std::string _output_dtype = "uint8";
   const QuantizerHook *_hook = nullptr;

--- a/compiler/circle-mpqsolver/src/pattern/PatternSolver.cpp
+++ b/compiler/circle-mpqsolver/src/pattern/PatternSolver.cpp
@@ -25,6 +25,14 @@ using namespace mpqsolver::pattern;
 using LayerParam = luci::CircleQuantizer::Options::LayerParam;
 using LayerParams = luci::CircleQuantizer::Options::LayerParams;
 
+PatternSolver::PatternSolver(const mpqsolver::core::Quantizer::Context &ctx,
+                             const std::vector<QuantizationPattern> &patterns)
+  : MPQSolver(ctx, "", 1.f)
+{
+  MPQOptions options{patterns};
+  set_mpq_options(options);
+}
+
 PatternSolver::PatternSolver(const std::string &input_quantization,
                              const std::string &output_quantization,
                              const std::vector<QuantizationPattern> &patterns)
@@ -43,7 +51,7 @@ std::unique_ptr<luci::Module> PatternSolver::run(const std::string &module_path)
 
   auto layer_params = get_frozen_params();
 
-  if (!_quantizer->quantize(module.get(), "uint8", layer_params))
+  if (!_quantizer->quantize(module.get(), layer_params))
   {
     throw std::runtime_error("Failed to quantize model");
   }

--- a/compiler/circle-mpqsolver/src/pattern/PatternSolver.h
+++ b/compiler/circle-mpqsolver/src/pattern/PatternSolver.h
@@ -48,6 +48,10 @@ struct FrozenNodes
 class PatternSolver final : public MPQSolver
 {
 public:
+  PatternSolver(const mpqsolver::core::Quantizer::Context &ctx,
+                const std::vector<QuantizationPattern> &patterns);
+  // TODO Remove this
+public:
   /**
    * @brief construct PatternSolver using input_quantization/output_quantization to set
    * quantization type at input/output respectively and patterns to apply

--- a/compiler/circle-mpqsolver/src/pattern/PatternSolver.test.cpp
+++ b/compiler/circle-mpqsolver/src/pattern/PatternSolver.test.cpp
@@ -58,10 +58,20 @@ TEST_F(CircleMPQSolverPatternSolverTest, verify_results)
   luci::CircleFileExpContract contract(m.get(), _module_path);
   EXPECT_TRUE(exporter.invoke(&contract));
 
+  // Create quantizer parameters
+  mpqsolver::core::Quantizer::Context ctx;
+  {
+    ctx.output_model_dtype = "uint8";
+    ctx.granularity = "channel";
+    ctx.input_type = "uint8";
+    ctx.output_type = "uint8";
+    ctx.save_min_max = false;
+    ctx.TF_style_maxpool = false;
+  }
+
   // create solver
   mpqsolver::pattern::PatternSolver solver(
-    "uint8", "uint8",
-    std::vector<QuantizationPattern>(1, QuantizationPattern::Q8SoftmaxWithQ16SubExp));
+    ctx, std::vector<QuantizationPattern>(1, QuantizationPattern::Q8SoftmaxWithQ16SubExp));
 
   // run solver
   auto const res = solver.run(_module_path);
@@ -99,8 +109,19 @@ TEST_F(CircleMPQSolverPatternSolverTest, empty_patterns_NEG)
   luci::CircleFileExpContract contract(m.get(), _module_path);
   EXPECT_TRUE(exporter.invoke(&contract));
 
+  // Create quantizer parameters
+  mpqsolver::core::Quantizer::Context ctx;
+  {
+    ctx.output_model_dtype = "uint8";
+    ctx.granularity = "channel";
+    ctx.input_type = "uint8";
+    ctx.output_type = "uint8";
+    ctx.save_min_max = false;
+    ctx.TF_style_maxpool = false;
+  }
+
   // create solver
-  mpqsolver::pattern::PatternSolver solver("uint8", "uint8", std::vector<QuantizationPattern>());
+  mpqsolver::pattern::PatternSolver solver(ctx, std::vector<QuantizationPattern>());
 
   // run solver
   auto const res = solver.run(_module_path);
@@ -129,9 +150,20 @@ TEST_F(CircleMPQSolverPatternSolverTest, empty_patterns_NEG)
 
 TEST_F(CircleMPQSolverPatternSolverTest, empty_path_NEG)
 {
+  // Create quantizer parameters
+  mpqsolver::core::Quantizer::Context ctx;
+  {
+    ctx.output_model_dtype = "uint8";
+    ctx.granularity = "channel";
+    ctx.input_type = "uint8";
+    ctx.output_type = "uint8";
+    ctx.save_min_max = false;
+    ctx.TF_style_maxpool = false;
+  }
+
+  // create solver
   mpqsolver::pattern::PatternSolver solver(
-    "uint8", "uint8",
-    std::vector<QuantizationPattern>(1, QuantizationPattern::Q8LayerNormWithQ16Variance));
+    ctx, std::vector<QuantizationPattern>(1, QuantizationPattern::Q8LayerNormWithQ16Variance));
 
   EXPECT_ANY_THROW(solver.run(""));
 }

--- a/compiler/one-cmds/one-quantize
+++ b/compiler/one-cmds/one-quantize
@@ -823,6 +823,26 @@ def _ampq_solve(args):
         if oneutils.is_valid_attr(args, 'output_path'):
             ampq_quantize_cmd.extend(['--output_model', getattr(args, 'output_path')])
 
+        # quantized model dtype
+        if oneutils.is_valid_attr(args, 'quantized_dtype'):
+            ampq_quantize_cmd.extend(
+                ['--quantized_dtype',
+                 getattr(args, 'quantized_dtype')])
+
+        # granularity
+        if oneutils.is_valid_attr(args, 'granularity'):
+            ampq_quantize_cmd.extend(['--granularity', getattr(args, 'granularity')])
+
+        # TF-style_maxpool
+        if oneutils.is_valid_attr(args, 'TF-style_maxpool'):
+            ampq_quantize_cmd.append('--TF-style_maxpool')
+
+        # save_min_max
+        if oneutils.is_valid_attr(args, 'save_min_max'):
+            ampq_quantize_cmd.append('--save_min_max')
+
+        # TODO Add config
+
         # visq_file
         if not (visq_file is None):
             ampq_quantize_cmd.extend(['--visq_file', visq_file])


### PR DESCRIPTION
On going draft to sync circle-mpqsolver options with one-quantize.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/11943