### PR TITLE
[res] Add TensorFlowLiteRecipes for TransposeReshapeTranspose pattern

### DIFF
--- a/res/TensorFlowLiteRecipes/Net_Trans_Reshape_Trans_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/Net_Trans_Reshape_Trans_000/test.recipe
@@ -1,0 +1,67 @@
+operand 
+{
+  name : "ifm"
+  type : FLOAT32
+  shape {dim: 1, dim: 7, dim: 7, dim : 20}
+}
+operand 
+{
+  name : "front_perm"
+  type : INT32
+  shape {dim : 4}
+  filler {tag: "explicit" arg: "0", arg: "3", arg:"1", arg: "2"}
+}
+operand
+{
+  name : "front_transpose_out"
+  type : FLOAT32
+  shape {dim: 1, dim: 20, dim:7, dim:7} 
+}
+operand
+{
+  name : "shape"
+  type : INT32
+  shape {dim: 3}
+  filler {tag: "explicit", arg: "1", arg: "20", arg: "49"}
+}
+operand
+{
+  name : "reshape_out"
+  type : FLOAT32
+  shape : {dim: 1, dim:20, dim:49}
+}
+operand 
+{
+  name : "back_perm"
+  type : INT32
+  shape {dim : 3}
+  filler {tag: "explicit" arg: "0", arg: "2", arg:"1"}
+}
+operand
+{
+  name : "ofm"
+  type : FLOAT32
+  shape {dim: 1, dim: 49, dim:20} 
+}
+operation {
+  type: "Transpose"
+  input: "ifm"
+  input: "front_perm"
+  output: "front_transpose_out"
+}
+operation {
+  type: "Reshape"
+  input: "front_transpose_out"
+  input: "shape"
+  output: "reshape_out"
+}
+operation
+{
+  type: "Transpose"
+  input: "reshape_out"
+  input: "back_perm"
+  output: "ofm"
+} 
+
+input: "ifm"
+output: "ofm"

--- a/res/TensorFlowLiteRecipes/Net_Trans_Reshape_Trans_000/test.rule
+++ b/res/TensorFlowLiteRecipes/Net_Trans_Reshape_Trans_000/test.rule
@@ -1,0 +1,6 @@
+# To check if unnecessary Transposes are removed in Transpose-Reshape-Transpose
+
+RULE    "VERIFY_FILE_FORMAT"      $(verify_file_format) '=' 1
+
+RULE    "TRANSPOSE_NOT_EXIST"     $(op_count TRANSPOSE) '=' 0
+RULE    "RESHAPE_EXIST"           $(op_count RESHAPE) '=' 1


### PR DESCRIPTION
This PR adds models for testing RemoveUnnecessaryTransposeNetPass.

* to resovle : https://github.com/Samsung/ONE/issues/11654 
* from draft : #11891 

ONE-DCO-1.0-Signed-off-by: SeungHui Youn <sseung.youn@samsung.com>