### PR TITLE
[cker] Bring Conv2D kernels from tensorflow v2.12.1

### DIFF
--- a/compute/cker/include/cker/eigen/eigen_backward_spatial_convolutions.h
+++ b/compute/cker/include/cker/eigen/eigen_backward_spatial_convolutions.h
@@ -1,0 +1,571 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __NNFW_CKER_EGIEN_EIGEN_BACKWARD_SPATIAL_CONVOLUTIONS_H__
+#define __NNFW_CKER_EGIEN_EIGEN_BACKWARD_SPATIAL_CONVOLUTIONS_H__
+
+#include "unsupported/Eigen/CXX11/Tensor"
+#include "eigen_spatial_convolutions.h"
+
+namespace Eigen
+{
+
+/** SpatialConvolutionBackwardInput
+ * \ingroup CXX11_NeuralNetworks_Module
+ *
+ * \brief Computes the backprop for the input of a 2D convolution.
+ *
+ * The output_backward parameter is expected to be a tensor with a rank of 3 or
+ * more (channels, height, width, and optionally others)
+ * The kernel parameter is expected to be a 4D tensor (filters, channels,
+ * kernel_height, kernel_width)
+ * The output_backward and the kernel must both be in col-major layout. The
+ * result will also be in col-major layout.
+ *
+ * If row_in_stride, col_in_stride > 1, then applies convolution with holes
+ * (aka atrous convolution), sampling every row_in_stride, col_in_stride input
+ * pixels.
+ *
+ * The result can be assigned to a tensor of rank equal to the rank of the
+ * output_backward. The dimensions of the result will be filters, height, width
+ * (and others if applicable).
+ *
+ * It is possible to swap the order of the width and height dimensions provided
+ * that the same order is used in the input, the kernel, and the output.
+ *
+ */
+typedef IndexList<type2index<0>, type2index<0>, type2index<1>, type2index<1>> ReverseColMajor;
+typedef IndexList<type2index<1>, type2index<1>, type2index<0>, type2index<0>> ReverseRowMajor;
+
+template <typename OutputBackward, typename Kernel>
+EIGEN_ALWAYS_INLINE static const std::conditional_t<
+  internal::traits<OutputBackward>::Layout == ColMajor,
+  TensorReshapingOp<
+    const DSizes<typename internal::traits<OutputBackward>::Index,
+                 internal::traits<OutputBackward>::NumDimensions>,
+    const TensorContractionOp<
+      const array<IndexPair<typename internal::traits<OutputBackward>::Index>, 1>,
+      const TensorReshapingOp<const DSizes<typename internal::traits<OutputBackward>::Index, 2>,
+                              const Eigen::TensorForcedEvalOp<const TensorShufflingOp<
+                                const array<typename internal::traits<OutputBackward>::Index, 4>,
+                                const Eigen::TensorForcedEvalOp<
+                                  const TensorReverseOp<const ReverseColMajor, const Kernel>>>>>,
+      const TensorReshapingOp<const DSizes<typename internal::traits<OutputBackward>::Index, 2>,
+                              const TensorImagePatchOp<Dynamic, Dynamic, const OutputBackward>>>>,
+  TensorReshapingOp<
+
+    const DSizes<typename internal::traits<OutputBackward>::Index,
+                 internal::traits<OutputBackward>::NumDimensions>,
+    const TensorContractionOp<
+      const array<IndexPair<typename internal::traits<OutputBackward>::Index>, 1>,
+      const TensorReshapingOp<const DSizes<typename internal::traits<OutputBackward>::Index, 2>,
+                              const TensorImagePatchOp<Dynamic, Dynamic, const OutputBackward>>,
+      const TensorReshapingOp<const DSizes<typename internal::traits<OutputBackward>::Index, 2>,
+                              const Eigen::TensorForcedEvalOp<const TensorShufflingOp<
+                                const array<typename internal::traits<OutputBackward>::Index, 4>,
+                                const Eigen::TensorForcedEvalOp<
+                                  const TensorReverseOp<const ReverseRowMajor, const Kernel>>>>>>>>
+SpatialConvolutionBackwardInput(const Kernel &kernel, const OutputBackward &output_backward,
+                                typename internal::traits<OutputBackward>::Index inputRows,
+                                typename internal::traits<OutputBackward>::Index inputCols,
+                                const DenseIndex row_stride = 1, const DenseIndex col_stride = 1,
+                                const DenseIndex row_in_stride = 1,
+                                const DenseIndex col_in_stride = 1)
+{
+  typedef typename internal::traits<OutputBackward>::Index TensorIndex;
+  typedef typename internal::traits<OutputBackward>::Scalar OutScalar;
+  TensorRef<
+    Tensor<typename internal::traits<Kernel>::Scalar, internal::traits<Kernel>::NumDimensions,
+           internal::traits<Kernel>::Layout, TensorIndex>>
+    kern(kernel);
+  TensorRef<Tensor<OutScalar, internal::traits<OutputBackward>::NumDimensions,
+                   internal::traits<OutputBackward>::Layout, TensorIndex>>
+    out(output_backward);
+
+  EIGEN_STATIC_ASSERT(internal::traits<Kernel>::Layout == internal::traits<OutputBackward>::Layout,
+                      YOU_MADE_A_PROGRAMMING_MISTAKE);
+
+  static const bool isColMajor = (internal::traits<OutputBackward>::Layout == ColMajor);
+
+  static const int NumDims = internal::traits<OutputBackward>::NumDimensions;
+
+  // Number of filters to apply. This is the same as the output depth of the
+  // result
+  const TensorIndex kernelFilters = isColMajor ? kern.dimensions()[0] : kern.dimensions()[3];
+  // Number of channels. This is the same as the input depth.
+  const TensorIndex kernelChannels = isColMajor ? kern.dimensions()[1] : kern.dimensions()[2];
+  const TensorIndex kernelRows = isColMajor ? kern.dimensions()[2] : kern.dimensions()[1];
+  const TensorIndex kernelCols = isColMajor ? kern.dimensions()[3] : kern.dimensions()[0];
+
+  // This is the effective kernel size, taking into account the (*_in_stride -
+  // 1) zero-values
+  // inserted between consecutive kernel elements in atrous convolution
+  const TensorIndex kernelRowsEff = kernelRows + (kernelRows - 1) * (row_in_stride - 1);
+  const TensorIndex kernelColsEff = kernelCols + (kernelCols - 1) * (col_in_stride - 1);
+
+  const TensorIndex outputRows =
+    isColMajor ? output_backward.dimension(1) : output_backward.dimension(NumDims - 2);
+  const TensorIndex outputCols =
+    isColMajor ? output_backward.dimension(2) : output_backward.dimension(NumDims - 3);
+
+  // Computing the forward padding
+  const TensorIndex forward_pad_top =
+    numext::maxi<Index>(0, ((outputRows - 1) * row_stride + kernelRowsEff - inputRows) / 2);
+  const TensorIndex forward_pad_left =
+    numext::maxi<Index>(0, ((outputCols - 1) * col_stride + kernelColsEff - inputCols) / 2);
+  const TensorIndex padding_top = kernelRowsEff - 1 - forward_pad_top;
+  const TensorIndex padding_left = kernelColsEff - 1 - forward_pad_left;
+
+  const TensorIndex padding_bottom =
+    inputRows - (outputRows - 1) * row_stride - 2 - padding_top + kernelRowsEff;
+  const TensorIndex padding_right =
+    inputCols - (outputCols - 1) * col_stride - 2 - padding_left + kernelColsEff;
+
+  eigen_assert(padding_top >= 0);
+  eigen_assert(padding_left >= 0);
+  eigen_assert(padding_bottom >= 0);
+  eigen_assert(padding_right >= 0);
+
+  // The kernel has dimensions filters X channels X patch_rows X patch_cols
+  // We need to reverse the kernel along dimensions corresponding to rows and
+  // cols.
+  // TODO(yangke): we can make things slightly faster by collapsing the
+  // dimensions
+  // where we don't reverse. Try that once we have a faster compiler.
+  typedef std::conditional_t<isColMajor, ReverseColMajor, ReverseRowMajor> Reverse;
+  Reverse kernel_reverse;
+  // Reorder the dimensions to:
+  //   filters x patch_rows x patch_cols x channels
+  array<TensorIndex, 4> kernel_shuffle;
+  if (isColMajor)
+  {
+    //  From: filters x channels x rows x cols
+    //  To:   filters x rows x cols x channels
+    kernel_shuffle[0] = 0;
+    kernel_shuffle[1] = 2;
+    kernel_shuffle[2] = 3;
+    kernel_shuffle[3] = 1;
+  }
+  else
+  {
+    //  From: cols x rows x channels x filters
+    //  To:   channels x cols x rows x filters
+    kernel_shuffle[0] = 2;
+    kernel_shuffle[1] = 0;
+    kernel_shuffle[2] = 1;
+    kernel_shuffle[3] = 3;
+  }
+
+  // Collapse the dims
+  DSizes<TensorIndex, 2> kernel_dims;
+  if (isColMajor)
+  {
+    kernel_dims[0] = kernelFilters * kernelRows * kernelCols;
+    kernel_dims[1] = kernelChannels;
+  }
+  else
+  {
+    kernel_dims[1] = kernelFilters * kernelRows * kernelCols;
+    kernel_dims[0] = kernelChannels;
+  }
+
+  // The output_backward has dimensions out_depth X out_rows X out_cols X OTHERS
+  // When we extract the image patches from output_backward, it will have
+  // dimensions
+  //   out_depth X (patch_rows * patch_cols) X (input_rows * input_cols *
+  //   OTHERS)
+  DSizes<TensorIndex, 2> pre_contract_dims;
+  if (isColMajor)
+  {
+    pre_contract_dims[0] = kernelFilters * kernelRows * kernelCols;
+    pre_contract_dims[1] = inputRows * inputCols;
+    for (int i = 3; i < NumDims; ++i)
+    {
+      pre_contract_dims[1] *= out.dimension(i);
+    }
+  }
+  else
+  {
+    pre_contract_dims[1] = kernelFilters * kernelRows * kernelCols;
+    pre_contract_dims[0] = inputRows * inputCols;
+    for (int i = 0; i < NumDims - 3; ++i)
+    {
+      pre_contract_dims[0] *= out.dimension(i);
+    }
+  }
+
+  // We will contract along the collapsed dimension that contains the
+  // kernelFilters, the kernelRows and the kernelCols.
+  array<IndexPair<TensorIndex>, 1> contract_dims;
+  if (isColMajor)
+  {
+    // col-major: kernel.contract(output.patches)
+    contract_dims[0] = IndexPair<TensorIndex>(0, 0);
+  }
+  else
+  {
+    // row-major: output.patches.contract(kernel)
+    contract_dims[0] = IndexPair<TensorIndex>(1, 1);
+  }
+
+  // Post contraction, the dimensions of the input_backprop is
+  //  channels X input_rows X input_cols X OTHERS
+  DSizes<TensorIndex, NumDims> post_contract_dims;
+  if (isColMajor)
+  {
+    post_contract_dims[0] = kernelChannels;
+    post_contract_dims[1] = inputRows;
+    post_contract_dims[2] = inputCols;
+    for (int i = 3; i < NumDims; ++i)
+    {
+      post_contract_dims[i] = out.dimension(i);
+    }
+  }
+  else
+  {
+    post_contract_dims[NumDims - 1] = kernelChannels;
+    post_contract_dims[NumDims - 2] = inputRows;
+    post_contract_dims[NumDims - 3] = inputCols;
+    for (int i = 0; i < NumDims - 3; ++i)
+    {
+      post_contract_dims[i] = out.dimension(i);
+    }
+  }
+
+  // NOTE(ezhulenev): We do eval after reverse and shuffle, because tiled
+  // evaluation of these ops does not compose. Doing explicit eval is ~8x
+  // faster in micro benchmarks.
+
+  return choose(
+    Cond<internal::traits<OutputBackward>::Layout == ColMajor>(),
+    kernel.reverse(kernel_reverse)
+      .eval()
+      .shuffle(kernel_shuffle)
+      .eval()
+      .reshape(kernel_dims)
+      .contract(output_backward
+                  .extract_image_patches(kernelRows, kernelCols, 1, 1, row_in_stride, col_in_stride,
+                                         row_stride, col_stride, padding_top, padding_bottom,
+                                         padding_left, padding_right, OutScalar(0))
+                  .reshape(pre_contract_dims),
+                contract_dims)
+      .reshape(post_contract_dims),
+    output_backward
+      .extract_image_patches(kernelRows, kernelCols, 1, 1, row_in_stride, col_in_stride, row_stride,
+                             col_stride, padding_top, padding_bottom, padding_left, padding_right,
+                             OutScalar(0))
+      .reshape(pre_contract_dims)
+      .contract(
+        kernel.reverse(kernel_reverse).eval().shuffle(kernel_shuffle).eval().reshape(kernel_dims),
+        contract_dims)
+      .reshape(post_contract_dims));
+}
+
+/** SpatialConvolutionBackwardKernel
+ * \ingroup CXX11_NeuralNetworks_Module
+ *
+ * \brief Computes the backprop for the filter of a 2D convolution.
+ *
+ * The output_backward parameter is expected to be a tensor with a rank of 3 or
+ * more (channels, height, width, and optionally others)
+ * The kernel parameter is expected to be a 4D tensor (filters, channels,
+ * kernel_height, kernel_width)
+ * The output_backward and the kernel must both be in col-major layout. The
+ * result will also be in col-major layout.
+ *
+ * If row_in_stride, col_stride > 1, then applies convolution with holes (aka
+ * atrous convolution), sampling every row_in_stride, col_in_stride input
+ * pixels.
+ *
+ * The result can be assigned to a tensor of rank equal to the rank of the
+ * output_backward. The dimensions of the result will be filters, height, width
+ * (and others if applicable).
+ *
+ * It is possible to swap the order of the width and height dimensions provided
+ * that the same order is used in the input, the kernel, and the output.
+ *
+ */
+
+template <typename OutputBackward, typename Input>
+EIGEN_ALWAYS_INLINE static const std::conditional_t<
+  internal::traits<Input>::Layout == ColMajor,
+  const TensorReverseOp<
+    const Eigen::array<typename internal::traits<Input>::Index,
+                       internal::traits<Input>::NumDimensions>,
+    const Eigen::TensorForcedEvalOp<const Eigen::TensorShufflingOp<
+      const Eigen::array<typename internal::traits<Input>::Index,
+                         internal::traits<Input>::NumDimensions>,
+      const Eigen::TensorReshapingOp<
+        const Eigen::DSizes<typename internal::traits<Input>::Index,
+                            internal::traits<Input>::NumDimensions>,
+        const TensorContractionOp<
+          const array<IndexPair<typename internal::traits<Input>::Index>, 1>,
+          const TensorReshapingOp<const DSizes<typename internal::traits<Input>::Index, 2>,
+                                  const Eigen::TensorForcedEvalOp<const Eigen::TensorShufflingOp<
+                                    const Eigen::array<typename internal::traits<Input>::Index,
+                                                       internal::traits<Input>::NumDimensions>,
+                                    const Input>>>,
+          const TensorReshapingOp<
+            const DSizes<typename internal::traits<Input>::Index, 2>,
+            const TensorImagePatchOp<Dynamic, Dynamic,
+                                     const Eigen::TensorForcedEvalOp<const Eigen::TensorShufflingOp<
+                                       const Eigen::array<typename internal::traits<Input>::Index,
+                                                          internal::traits<Input>::NumDimensions>,
+                                       const OutputBackward>>>>>>>>>,
+  const TensorReverseOp<
+    const Eigen::array<typename internal::traits<Input>::Index,
+                       internal::traits<Input>::NumDimensions>,
+    const Eigen::TensorForcedEvalOp<const Eigen::TensorShufflingOp<
+      const Eigen::array<typename internal::traits<Input>::Index,
+                         internal::traits<Input>::NumDimensions>,
+      const Eigen::TensorReshapingOp<
+        const Eigen::DSizes<typename internal::traits<Input>::Index,
+                            internal::traits<Input>::NumDimensions>,
+        const TensorContractionOp<
+          const array<IndexPair<typename internal::traits<Input>::Index>, 1>,
+          const TensorReshapingOp<
+            const DSizes<typename internal::traits<Input>::Index, 2>,
+            const TensorImagePatchOp<Dynamic, Dynamic,
+                                     const Eigen::TensorForcedEvalOp<const Eigen::TensorShufflingOp<
+                                       const Eigen::array<typename internal::traits<Input>::Index,
+                                                          internal::traits<Input>::NumDimensions>,
+                                       const OutputBackward>>>>,
+          const TensorReshapingOp<const DSizes<typename internal::traits<Input>::Index, 2>,
+                                  const Eigen::TensorForcedEvalOp<const Eigen::TensorShufflingOp<
+                                    const Eigen::array<typename internal::traits<Input>::Index,
+                                                       internal::traits<Input>::NumDimensions>,
+                                    const Input>>>>>>>>>
+SpatialConvolutionBackwardKernel(const Input &input, const OutputBackward &output_backward,
+                                 typename internal::traits<Input>::Index kernelRows,
+                                 typename internal::traits<Input>::Index kernelCols,
+                                 const DenseIndex row_stride = 1, const DenseIndex col_stride = 1,
+                                 const DenseIndex row_in_stride = 1,
+                                 const DenseIndex col_in_stride = 1)
+{
+  typedef typename internal::traits<Input>::Index TensorIndex;
+  typedef typename internal::traits<OutputBackward>::Scalar OutScalar;
+  TensorRef<Tensor<typename internal::traits<Input>::Scalar, internal::traits<Input>::NumDimensions,
+                   internal::traits<Input>::Layout, TensorIndex>>
+    in(input);
+  TensorRef<Tensor<OutScalar, internal::traits<OutputBackward>::NumDimensions,
+                   internal::traits<OutputBackward>::Layout, TensorIndex>>
+    out(output_backward);
+
+  EIGEN_STATIC_ASSERT(internal::traits<Input>::Layout == internal::traits<OutputBackward>::Layout,
+                      YOU_MADE_A_PROGRAMMING_MISTAKE);
+
+  // stride and in_stride cannot both be larger than 1
+  eigen_assert(!(row_stride > 1 && row_in_stride > 1));
+  eigen_assert(!(col_stride > 1 && col_in_stride > 1));
+
+  static const bool isColMajor = (internal::traits<Input>::Layout == ColMajor);
+
+  static const int NumDims = internal::traits<Input>::NumDimensions;
+  EIGEN_STATIC_ASSERT(internal::traits<Input>::NumDimensions ==
+                        internal::traits<OutputBackward>::NumDimensions,
+                      YOU_MADE_A_PROGRAMMING_MISTAKE);
+  EIGEN_STATIC_ASSERT(NumDims == 4, YOU_MADE_A_PROGRAMMING_MISTAKE);
+
+  const TensorIndex inputRows = isColMajor ? in.dimension(1) : in.dimension(NumDims - 2);
+  const TensorIndex inputCols = isColMajor ? in.dimension(2) : in.dimension(NumDims - 3);
+
+  const TensorIndex outputRows =
+    isColMajor ? output_backward.dimension(1) : output_backward.dimension(NumDims - 2);
+  const TensorIndex outputCols =
+    isColMajor ? output_backward.dimension(2) : output_backward.dimension(NumDims - 3);
+
+  // Number of filters to apply. This is the same as the output depth of the
+  // result
+  const TensorIndex kernelFilters =
+    isColMajor ? out.dimensions()[0] : out.dimensions()[NumDims - 1];
+
+  // Number of channels. This is the same as the input depth.
+  const TensorIndex kernelChannels = isColMajor ? in.dimensions()[0] : in.dimensions()[NumDims - 1];
+
+  // This is the effective kernel size, taking into account the
+  // (*_in_stride - 1) zero-values inserted between consecutive kernel
+  // elements in atrous convolution
+  const TensorIndex kernelRowsEff = kernelRows + (kernelRows - 1) * (row_in_stride - 1);
+  const TensorIndex kernelColsEff = kernelCols + (kernelCols - 1) * (col_in_stride - 1);
+
+  // Number of batches (and other dimensions) in the input tensor.
+  TensorIndex batch = 1;
+  for (int d = 3; d < NumDims; ++d)
+  {
+    batch *= isColMajor ? in.dimension(d) : in.dimension(NumDims - d - 1);
+  }
+
+  // Computing the forward padding
+  const TensorIndex padRows =
+    numext::maxi<Index>(0, (outputRows - 1) * row_stride + kernelRowsEff - inputRows);
+  const TensorIndex padCols =
+    numext::maxi<Index>(0, (outputCols - 1) * col_stride + kernelColsEff - inputCols);
+
+  TensorIndex padding_top = padRows / 2;
+  TensorIndex padding_left = padCols / 2;
+
+  // Compute paddings for output_backward before extracting patches.
+  const TensorIndex expanded_out_rows = (outputRows - 1) * row_stride + 1;
+  const TensorIndex expanded_out_cols = (outputCols - 1) * col_stride + 1;
+
+  const TensorIndex padded_out_rows = inputRows + kernelRowsEff - 1;
+  const TensorIndex padded_out_cols = inputCols + kernelColsEff - 1;
+
+  const TensorIndex top_pad_rows = kernelRowsEff - 1 - padding_top;
+  const TensorIndex left_pad_cols = kernelColsEff - 1 - padding_left;
+
+  const TensorIndex bottom_pad_rows = padded_out_rows - expanded_out_rows - top_pad_rows;
+  const TensorIndex right_pad_cols = padded_out_cols - expanded_out_cols - left_pad_cols;
+
+  // Reorder output_backward dimensions.
+  array<TensorIndex, 4> output_backward_shuffle;
+  if (isColMajor)
+  {
+    // From: [out_depth, out_rows, out_cols, batch]
+    // To:   [batch, out_rows, out_cols, out_depth]
+    output_backward_shuffle = {3, 1, 2, 0};
+  }
+  else
+  {
+    // From: [batch, out_cols, out_rows, out_depth]
+    // To:   [out_depth, out_cols, out_rows, batch]
+    output_backward_shuffle = {3, 1, 2, 0};
+  }
+
+  // Reorder input dimensions.
+  array<TensorIndex, 4> input_shuffle;
+  if (isColMajor)
+  {
+    // From: [in_depth, in_rows, in_cols, batch]
+    // To:   [in_depth, batch, in_rows, in_cols]
+    input_shuffle = {0, 3, 1, 2};
+  }
+  else
+  {
+    // From: [batch, in_cols, in_rows, in_depth]
+    // To:   [in_cols, in_rows, batch, in_depth]
+    input_shuffle = {1, 2, 0, 3};
+  }
+
+  // Input is playing the role of a "kernel" in this convolution.
+  DSizes<TensorIndex, 2> input_dims;
+  if (isColMajor)
+  {
+    input_dims[0] = kernelChannels;
+    input_dims[1] = batch * inputRows * inputCols;
+  }
+  else
+  {
+    input_dims[1] = kernelChannels;
+    input_dims[0] = inputCols * inputRows * batch;
+  }
+
+  // Molds the output of the patch extraction result into a 2D tensor:
+  // - the first dimension (dims[0]): the patch values to be multiplied with the
+  // kernels
+  // - the second dimension (dims[1]): everything else
+  DSizes<TensorIndex, 2> pre_contract_dims;
+  if (isColMajor)
+  {
+    pre_contract_dims[0] = batch * inputRows * inputCols;
+    pre_contract_dims[1] = kernelRows * kernelCols * kernelFilters;
+  }
+  else
+  {
+    pre_contract_dims[1] = inputCols * inputRows * batch;
+    pre_contract_dims[0] = kernelFilters * kernelCols * kernelRows;
+  }
+
+  // We will contract along the collapsed dimension that contains the
+  // batch, inputRows and inputCols.
+  array<IndexPair<TensorIndex>, 1> contract_dims;
+  contract_dims[0] = IndexPair<TensorIndex>(1, 0);
+
+  // Dimensions after contraction.
+  DSizes<TensorIndex, NumDims> post_contract_dims;
+  if (isColMajor)
+  {
+    post_contract_dims[0] = kernelChannels;
+    post_contract_dims[1] = kernelRows;
+    post_contract_dims[2] = kernelCols;
+    post_contract_dims[3] = kernelFilters;
+  }
+  else
+  {
+    post_contract_dims[0] = kernelFilters;
+    post_contract_dims[1] = kernelCols;
+    post_contract_dims[2] = kernelRows;
+    post_contract_dims[3] = kernelChannels;
+  }
+
+  // Reorder output of contraction to a valid filter shape.
+  array<TensorIndex, 4> kernel_shuffle;
+  if (isColMajor)
+  {
+    // From: [in_depth, kernel_rows, kernel_cols, out_depth]
+    // To:   [out_depth, in_depth, kernel_rows, kernel_cols]
+    kernel_shuffle = {3, 0, 1, 2};
+  }
+  else
+  {
+    // From: [out_depth, kernel_cols, kernel_rows, in_depth]
+    // To:   [kernel_cols, kernel_rows, in_depth, out_depth]
+    kernel_shuffle = {1, 2, 3, 0};
+  }
+
+  // Reverse kernel backprop dimensions.
+  array<TensorIndex, 4> kernel_reverse;
+  if (isColMajor)
+  {
+    kernel_reverse = {false, false, true, true};
+  }
+  else
+  {
+    kernel_reverse = {true, true, false, false};
+  }
+
+  // Create convolution input (aka source of patches) from output backward
+  // tensor by shuffling dimensions.
+  const auto output_backward_shuffled = output_backward.shuffle(output_backward_shuffle).eval();
+
+  // Create convolution kernel (aka filter) from input by shuffling and
+  // reshaping.
+  const auto input_shuffled = input.shuffle(input_shuffle).eval().reshape(input_dims);
+
+  return choose(Cond<internal::traits<OutputBackward>::Layout == ColMajor>(),
+                input_shuffled.contract(
+                  output_backward_shuffled
+                    .extract_image_patches(inputRows, inputCols, row_in_stride, col_in_stride, 1, 1,
+                                           row_stride, col_stride, top_pad_rows, bottom_pad_rows,
+                                           left_pad_cols, right_pad_cols, OutScalar(0))
+                    .reshape(pre_contract_dims),
+                  contract_dims),
+                output_backward_shuffled
+                  .extract_image_patches(inputRows, inputCols, row_in_stride, col_in_stride, 1, 1,
+                                         row_stride, col_stride, top_pad_rows, bottom_pad_rows,
+                                         left_pad_cols, right_pad_cols, OutScalar(0))
+                  .reshape(pre_contract_dims)
+                  .contract(input_shuffled, contract_dims))
+    .reshape(post_contract_dims)
+    .shuffle(kernel_shuffle)
+    .eval()
+    .reverse(kernel_reverse);
+}
+
+} // end namespace Eigen
+
+#endif // __NNFW_CKER_EGIEN_EIGEN_BACKWARD_SPATIAL_CONVOLUTIONS_H__

--- a/compute/cker/include/cker/train/operation/Conv.h
+++ b/compute/cker/include/cker/train/operation/Conv.h
@@ -1,0 +1,267 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __NNFW_CKER_TRAIN_OPERATION_CONV_H__
+#define __NNFW_CKER_TRAIN_OPERATION_CONV_H__
+
+#include "cker/operation/Helper/Tensor.h"
+#include "cker/eigen/eigen_backward_spatial_convolutions.h"
+#include "cker/eigen/EigenSupport.h"
+#include "cker/eigen/Utils.h"
+#include "cker/Shape.h"
+#include "cker/Types.h"
+
+namespace nnfw
+{
+namespace cker
+{
+namespace train
+{
+
+// From tensorflow/core/kernels/conv_2d.h
+namespace functor
+{
+
+template <typename Device, typename T> struct SpatialConvolutionBackwardInputFunc
+{
+  void operator()(const Device &d, typename TTypes<T, 4>::Tensor input_backward,
+                  typename TTypes<T, 4>::ConstTensor filter,
+                  typename TTypes<T, 4>::ConstTensor output_backward, Eigen::DenseIndex col_stride,
+                  Eigen::DenseIndex row_stride, Eigen::DenseIndex col_dilation,
+                  Eigen::DenseIndex row_dilation)
+  {
+    input_backward.device(d) = Eigen::SpatialConvolutionBackwardInput(
+      filter, output_backward, input_backward.dimension(2), input_backward.dimension(1), col_stride,
+      row_stride, col_dilation, row_dilation);
+  }
+};
+
+template <typename Device, typename T> struct SpatialConvolutionBackwardInputWithExplicitPaddingFunc
+{
+  void operator()(const Device &d, typename TTypes<T, 4>::Tensor input_backward,
+                  typename TTypes<T, 4>::ConstTensor filter,
+                  typename TTypes<T, 4>::ConstTensor output_backward, Eigen::DenseIndex padded_cols,
+                  Eigen::DenseIndex padded_rows, Eigen::DenseIndex col_stride,
+                  Eigen::DenseIndex row_stride, Eigen::DenseIndex col_dilation,
+                  Eigen::DenseIndex row_dilation, Eigen::DenseIndex pad_left,
+                  Eigen::DenseIndex pad_top)
+  {
+    // We have to slice the result of a spatial convolution backward
+    // input, before assigning it to the `input_backward` to remove padding.
+    //
+    // TODO(ezhulenev): Pass explicit paddings to Eigen and do not materialize
+    // intermediate result in memory before slicing.
+    input_backward.device(d) =
+      Eigen::SpatialConvolutionBackwardInput(filter, output_backward, padded_cols, padded_rows,
+                                             col_stride, row_stride, col_dilation, row_dilation)
+        .eval()
+        .slice(Eigen::DSizes<Eigen::DenseIndex, 4>{0, pad_left, pad_top, 0},
+               input_backward.dimensions());
+  }
+};
+
+} // namespace functor
+
+// From tensorflow/core/kernels/conv_grad_input_ops.h
+// Computes backprop input using Eigen::SpatialConvolutionBackwardInput on CPU
+// and GPU (for int32 only).
+template <typename Device, typename T> struct LaunchConv2DBackpropInputOpImpl
+{
+  void operator()(const Device &d, const T *out_backprop_data, int batches, int out_backprop_height,
+                  int out_backprop_width, int output_depth, const T *filter_data, int filter_height,
+                  int filter_width, int row_dilation, int col_dilation, int row_stride /* H */,
+                  int col_stride /* W */, const PaddingType &padding_type, int padding_top,
+                  int padding_bottom, int padding_left, int padding_right, T *in_backprop_data,
+                  int in_backprop_height, int in_backprop_width, int input_depth)
+  {
+    // WARNING: Need to swap row/col, padding_top/padding_left, and
+    // padding_bottom/padding_right when calling Eigen. Eigen expects tensors
+    // in NWHC format, but Tensorflow uses NHWC.
+
+    eigen_support::EigenTensor in_backprop_t(in_backprop_data, batches, in_backprop_height,
+                                             in_backprop_width, input_depth);
+    eigen_support::ConstEigenTensor filter_t(filter_data, filter_height, filter_width, input_depth,
+                                             output_depth);
+    eigen_support::ConstEigenTensor out_backprop_t(out_backprop_data, batches, out_backprop_height,
+                                                   out_backprop_width, output_depth);
+
+    if (padding_type != PaddingType::kNone /* EXPLICIT */)
+    {
+      // If padding was not explicitly defined, Eigen spatial convolution
+      // backward input will infer correct forward paddings from input tensors.
+      functor::SpatialConvolutionBackwardInputFunc<Device, T>()(
+        d, in_backprop_t, filter_t, out_backprop_t, col_stride, row_stride, col_dilation,
+        row_dilation);
+    }
+    else
+    {
+      functor::SpatialConvolutionBackwardInputWithExplicitPaddingFunc<Device, T>()(
+        d, in_backprop_t, filter_t, out_backprop_t,
+        in_backprop_t.dimension(2) + (padding_left + padding_right),
+        in_backprop_t.dimension(1) + (padding_top + padding_bottom), col_stride, row_stride,
+        col_dilation, row_dilation, padding_top, padding_left);
+    }
+  }
+};
+
+// Computes backprop input using Eigen::SpatialConvolutionBackwardInput on CPU.
+template <typename T> struct LaunchConv2DBackpropInputOp
+{
+  void operator()(const T *out_backprop_data, int batches, int out_backprop_height,
+                  int out_backprop_width, int output_depth, const T *filter_data, int filter_height,
+                  int filter_width, int row_dilation, int col_dilation, int row_stride /* H */,
+                  int col_stride /* W */, const PaddingType &padding_type, int padding_top,
+                  int padding_bottom, int padding_left, int padding_right, T *in_backprop_data,
+                  int in_backprop_height, int in_backprop_width, int input_depth)
+  {
+    LaunchConv2DBackpropInputOpImpl<Eigen::ThreadPoolDevice, T> launcher;
+    launcher(*eigen_support::GetThreadPoolDevice(), out_backprop_data, batches, out_backprop_height,
+             out_backprop_width, output_depth, filter_data, filter_height, filter_width,
+             row_dilation, col_dilation, row_stride, col_stride, padding_type, padding_top,
+             padding_bottom, padding_left, padding_right, in_backprop_data, in_backprop_height,
+             in_backprop_width, input_depth);
+  }
+};
+
+// From tensorflow/core/kernels/conv_grad_filter_ops.cc
+template <typename T> struct LaunchConv2DBackpropFilterOp
+{
+  void operator()(const T *out_backprop_data, int batches, int out_backprop_height,
+                  int out_backprop_width, int output_depth, const T *input_data, int input_height,
+                  int input_width, int input_depth, int row_dilation, int col_dilation,
+                  int row_stride /* H */, int col_stride /* W */, const PaddingType &padding_type,
+                  int padding_top, int padding_bottom, int padding_left, int padding_right,
+                  T *filter_backprop_data, int filter_backprop_height, int filter_backprop_width)
+  {
+    eigen_support::EigenTensor filter_backprop_t(filter_backprop_data, filter_backprop_height,
+                                                 filter_backprop_width, input_depth, output_depth);
+    eigen_support::ConstEigenTensor input_t(input_data, batches, input_height, input_width,
+                                            input_depth);
+    eigen_support::ConstEigenTensor out_backprop_t(out_backprop_data, batches, out_backprop_height,
+                                                   out_backprop_width, output_depth);
+
+    const Eigen::ThreadPoolDevice &d = *eigen_support::GetThreadPoolDevice();
+
+    if (padding_type != PaddingType::kNone /* EXPLICIT */)
+    {
+      // If padding was not explicitly defined, Eigen spatial convolution
+      // backward filter will infer correct forward paddings from input tensors.
+      filter_backprop_t.device(d) = Eigen::SpatialConvolutionBackwardKernel(
+        input_t, out_backprop_t, filter_backprop_t.dimension(1), filter_backprop_t.dimension(0),
+        col_stride, row_stride, col_dilation, row_dilation);
+    }
+    else
+    {
+      // Otherwise we have to explicitly pad the input, before passing it to
+      // spatial convolution backward filter.
+      Eigen::array<std::pair<int, int>, 4> paddings;
+      paddings[0] = {0, 0};
+      paddings[1] = {padding_top, padding_bottom};
+      paddings[2] = {padding_left, padding_right};
+      paddings[3] = {0, 0};
+
+      auto padded_t = input_t.pad(paddings, T(0));
+
+      // TODO(ezhulenev): Pass explicit paddings to Eigen spatial backward
+      // convolution and do not rely on tensor padding expression.
+      filter_backprop_t.device(d) = Eigen::SpatialConvolutionBackwardKernel(
+        padded_t, out_backprop_t, filter_backprop_t.dimension(1), filter_backprop_t.dimension(0),
+        col_stride, row_stride, col_dilation, row_dilation);
+    }
+  }
+};
+
+inline void ConvInputGrad(const ConvParams &params, const Shape &incoming_shape,
+                          const float *incoming_data, const Shape &filter_shape,
+                          const float *filter_data, const int padding_bottom,
+                          const int padding_right, const Shape &grad_shape, float *grad_data)
+{
+  const int stride_rows = params.stride_height;
+  const int stride_cols = params.stride_width;
+  const PaddingType padding = params.padding_type;
+  const int padding_top = params.padding_values.height;
+  const int padding_left = params.padding_values.width;
+  assert(padding_top >= 0);
+  assert(padding_bottom >= 0);
+  assert(padding_left >= 0);
+  assert(padding_right >= 0);
+  const int dilation_rows = params.dilation_height_factor;
+  const int dilation_cols = params.dilation_width_factor;
+
+  const int batches = MatchingDim(grad_shape, 0, incoming_shape, 0);
+  const int input_depth = MatchingDim(filter_shape, 2, grad_shape, 3);
+  const int output_depth = MatchingDim(filter_shape, 3, incoming_shape, 3);
+  const int grad_height = grad_shape.Dims(1);
+  const int grad_width = grad_shape.Dims(2);
+  const int filter_height = filter_shape.Dims(0);
+  const int filter_width = filter_shape.Dims(1);
+  const int incoming_height = incoming_shape.Dims(1);
+  const int incoming_width = incoming_shape.Dims(2);
+
+  if (dilation_rows != 1 || dilation_cols != 1)
+    throw std::runtime_error("cker::ConvFilterGrad: not yet support dilation rates larger than 1.");
+
+  LaunchConv2DBackpropInputOp<float>()(
+    incoming_data, batches, incoming_height, incoming_width, output_depth, filter_data,
+    filter_height, filter_width, dilation_rows, dilation_cols, stride_rows, stride_cols, padding,
+    padding_top, padding_bottom, padding_left, padding_right, grad_data, grad_height, grad_width,
+    input_depth);
+}
+
+inline void ConvFilterGrad(const ConvParams &params, const Shape &incoming_shape,
+                           const float *incoming_data, const Shape &input_shape,
+                           const float *input_data, const int padding_bottom,
+                           const int padding_right, const Shape &filter_backprop_shape,
+                           float *filter_backprop_data)
+{
+  const int stride_rows = params.stride_height;
+  const int stride_cols = params.stride_width;
+  const PaddingType padding = params.padding_type;
+  const int padding_top = params.padding_values.height;
+  const int padding_left = params.padding_values.width;
+  assert(padding_top >= 0);
+  assert(padding_bottom >= 0);
+  assert(padding_left >= 0);
+  assert(padding_right >= 0);
+  const int dilation_rows = params.dilation_height_factor;
+  const int dilation_cols = params.dilation_width_factor;
+
+  const int batches = MatchingDim(input_shape, 0, incoming_shape, 0);
+  const int input_depth = MatchingDim(filter_backprop_shape, 2, input_shape, 3);
+  const int output_depth = MatchingDim(filter_backprop_shape, 3, incoming_shape, 3);
+  const int input_height = input_shape.Dims(1);
+  const int input_width = input_shape.Dims(2);
+  const int filter_backprop_height = filter_backprop_shape.Dims(0);
+  const int filter_backprop_width = filter_backprop_shape.Dims(1);
+  const int incoming_height = incoming_shape.Dims(1);
+  const int incoming_width = incoming_shape.Dims(2);
+
+  if (dilation_rows != 1 || dilation_cols != 1)
+    throw std::runtime_error("cker::ConvFilterGrad: not yet support dilation rates larger than 1.");
+
+  LaunchConv2DBackpropFilterOp<float>()(
+    incoming_data, batches, incoming_height, incoming_width, output_depth, input_data, input_height,
+    input_width, input_depth, dilation_rows, dilation_cols, stride_rows, stride_cols, padding,
+    padding_top, padding_bottom, padding_left, padding_right, filter_backprop_data,
+    filter_backprop_height, filter_backprop_width);
+}
+
+} // namespace train
+} // namespace cker
+} // namespace nnfw
+
+#endif // __NNFW_CKER_TRAIN_OPERATION_RELU_H__

--- a/compute/cker/src/train/Conv.test.cc
+++ b/compute/cker/src/train/Conv.test.cc
@@ -1,0 +1,421 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cker/train/operation/Conv.h>
+
+#include <gtest/gtest.h>
+#include <vector>
+
+namespace
+{
+
+template <typename T> class ConvVerifier
+{
+public:
+  static void verifyFilterGradExpected(const nnfw::cker::ConvParams &params,
+                                       const nnfw::cker::Shape &incoming_shape,
+                                       const T *incoming_data, const nnfw::cker::Shape &input_shape,
+                                       const T *input_data, int padding_bottom, int padding_right,
+                                       const nnfw::cker::Shape &filter_shape)
+  {
+    std::vector<T> gradient(filter_shape.FlatSize(), static_cast<T>(0));
+    std::vector<T> expected(filter_shape.FlatSize(), static_cast<T>(0));
+
+    calculateFilterGradExpected(params, incoming_shape, incoming_data, input_shape, input_data,
+                                filter_shape, expected.data());
+
+    nnfw::cker::train::ConvFilterGrad(params, incoming_shape, incoming_data, input_shape,
+                                      input_data, padding_bottom, padding_right, filter_shape,
+                                      gradient.data());
+
+    for (size_t i = 0; i < gradient.size(); ++i)
+      EXPECT_NEAR(gradient[i], expected[i], 1e-4f);
+  }
+
+  static void verifyInputGradExpected(const nnfw::cker::ConvParams &params,
+                                      const nnfw::cker::Shape &incoming_shape,
+                                      const T *incoming_data, const nnfw::cker::Shape &filter_shape,
+                                      const T *filter_data, int padding_bottom, int padding_right,
+                                      const nnfw::cker::Shape &input_shape)
+  {
+    std::vector<T> gradient(input_shape.FlatSize(), static_cast<T>(0));
+    std::vector<T> expected(input_shape.FlatSize(), static_cast<T>(0));
+
+    calculateInputGradExpected(params, incoming_shape, incoming_data, filter_shape, filter_data,
+                               input_shape, expected.data());
+
+    nnfw::cker::train::ConvInputGrad(params, incoming_shape, incoming_data, filter_shape,
+                                     filter_data, padding_bottom, padding_right, input_shape,
+                                     gradient.data());
+
+    for (size_t i = 0; i < gradient.size(); ++i)
+      EXPECT_NEAR(gradient[i], expected[i], 1e-4f);
+  }
+
+private:
+  static void calculateFilterGradExpected(const nnfw::cker::ConvParams &params,
+                                          const nnfw::cker::Shape &incoming_shape,
+                                          const T *incoming_data,
+                                          const nnfw::cker::Shape &input_shape, const T *input_data,
+                                          const nnfw::cker::Shape &filter_shape, T *expected)
+  {
+    assert(incoming_shape.DimensionsCount() == 4);
+    assert(input_shape.DimensionsCount() == 4);
+    assert(filter_shape.DimensionsCount() == 4);
+
+    const int batches = MatchingDim(incoming_shape, 0, input_shape, 0);
+    const int input_channel = MatchingDim(filter_shape, 2, input_shape, 3);
+    const int output_channel = MatchingDim(filter_shape, 3, incoming_shape, 3);
+    const int input_height = input_shape.Dims(1);
+    const int input_width = input_shape.Dims(2);
+    const int filter_height = filter_shape.Dims(0);
+    const int filter_width = filter_shape.Dims(1);
+    const int incoming_height = incoming_shape.Dims(1);
+    const int incoming_width = incoming_shape.Dims(2);
+
+    int pad_top = params.padding_values.height;
+    int pad_left = params.padding_values.width;
+    const int stride_height = params.stride_height;
+    const int stride_width = params.stride_width;
+
+    if (params.padding_type == nnfw::cker::PaddingType::kValid)
+    {
+      pad_top = 0;
+      pad_left = 0;
+    }
+    else if (params.padding_type == nnfw::cker::PaddingType::kSame)
+    {
+      pad_top = ((incoming_height - 1) * stride_height + filter_height - input_height) / 2;
+      pad_left = ((incoming_width - 1) * stride_width + filter_width - input_width) / 2;
+    }
+
+    assert(pad_top >= 0);
+    assert(pad_left >= 0);
+    assert(stride_height > 0);
+    assert(stride_width > 0);
+
+    for (int m = 0; m < batches; ++m)
+    {
+      for (int i = 0; i < incoming_height; ++i)
+      {
+        for (int j = 0; j < incoming_width; ++j)
+        {
+          for (int a = 0; a < filter_height; ++a)
+          {
+            for (int b = 0; b < filter_width; ++b)
+            {
+              for (int c = 0; c < input_channel; ++c)
+              {
+                for (int k = 0; k < output_channel; ++k)
+                {
+                  const auto input_i = stride_height * i + a - pad_top;
+                  const auto input_j = stride_width * j + b - pad_left;
+                  if (input_i < 0 || input_i >= input_height || input_j < 0 ||
+                      input_j >= input_width)
+                    continue;
+
+                  const auto filter_offset = Offset(filter_shape, a, b, c, k);
+                  const auto incoming_offset = Offset(incoming_shape, m, i, j, k);
+                  const auto input_offset = Offset(input_shape, m, input_i, input_j, c);
+
+                  expected[filter_offset] +=
+                    incoming_data[incoming_offset] * input_data[input_offset];
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  static void calculateInputGradExpected(const nnfw::cker::ConvParams &params,
+                                         const nnfw::cker::Shape &incoming_shape,
+                                         const T *incoming_data,
+                                         const nnfw::cker::Shape &filter_shape,
+                                         const T *filter_data, const nnfw::cker::Shape &input_shape,
+                                         T *expected)
+  {
+    assert(incoming_shape.DimensionsCount() == 4);
+    assert(filter_shape.DimensionsCount() == 4);
+    assert(input_shape.DimensionsCount() == 4);
+
+    const int batches = MatchingDim(incoming_shape, 0, input_shape, 0);
+    const int input_channel = MatchingDim(filter_shape, 2, input_shape, 3);
+    const int output_channel = MatchingDim(filter_shape, 3, incoming_shape, 3);
+    const int input_height = input_shape.Dims(1);
+    const int input_width = input_shape.Dims(2);
+    const int filter_height = filter_shape.Dims(0);
+    const int filter_width = filter_shape.Dims(1);
+    const int incoming_height = incoming_shape.Dims(1);
+    const int incoming_width = incoming_shape.Dims(2);
+
+    int pad_top = params.padding_values.height;
+    int pad_left = params.padding_values.width;
+    const int stride_height = params.stride_height;
+    const int stride_width = params.stride_width;
+
+    if (params.padding_type == nnfw::cker::PaddingType::kValid)
+    {
+      pad_top = 0;
+      pad_left = 0;
+    }
+    else if (params.padding_type == nnfw::cker::PaddingType::kSame)
+    {
+      pad_top = ((incoming_height - 1) * stride_height + filter_height - input_height) / 2;
+      pad_left = ((incoming_width - 1) * stride_width + filter_width - input_width) / 2;
+    }
+
+    assert(pad_top >= 0);
+    assert(pad_left >= 0);
+    assert(stride_height > 0);
+    assert(stride_width > 0);
+
+    for (int m = 0; m < batches; ++m)
+    {
+      for (int i = 0; i < incoming_height; ++i)
+      {
+        for (int j = 0; j < incoming_width; ++j)
+        {
+          for (int a = 0; a < filter_height; ++a)
+          {
+            for (int b = 0; b < filter_width; ++b)
+            {
+              for (int c = 0; c < input_channel; ++c)
+              {
+                for (int k = 0; k < output_channel; ++k)
+                {
+                  const auto input_i = stride_height * i + a - pad_top;
+                  const auto input_j = stride_width * j + b - pad_left;
+                  if (input_i < 0 || input_i >= input_height || input_j < 0 ||
+                      input_j >= input_width)
+                    continue;
+
+                  const auto filter_offset = Offset(filter_shape, a, b, c, k);
+                  const auto incoming_offset = Offset(incoming_shape, m, i, j, k);
+                  const auto input_offset = Offset(input_shape, m, input_i, input_j, c);
+
+                  expected[input_offset] +=
+                    incoming_data[incoming_offset] * filter_data[filter_offset];
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+};
+
+} // namespace
+
+TEST(CKer_Operation, ConvGrad)
+{
+  // No pad, No stride
+  {
+    nnfw::cker::ConvParams params;
+    params.padding_type = nnfw::cker::PaddingType::kNone;
+    params.padding_values.width = 0;
+    params.padding_values.height = 0;
+    params.stride_width = 1;
+    params.stride_height = 1;
+    params.dilation_width_factor = 1;
+    params.dilation_height_factor = 1;
+
+    nnfw::cker::Shape incoming_shape{1, 2, 2, 3}; // n, h, w, c
+    std::vector<float> incoming = {-0.1, 0.2, -0.3, 0.4,  0.5, -0.6,
+                                   -0.7, 0.8, 0.9,  -1.0, 1.1, -1.2};
+    nnfw::cker::Shape filter_shape{2, 2, 2, 3}; // h, w, i, o
+    std::vector<float> filter = {-1,  2,  -3,  4,  5,  -6,  -7,  8,  9,   -10, -11, 12,
+                                 -13, 14, -15, 16, 17, -18, -19, 20, -21, 22,  23,  -24};
+    nnfw::cker::Shape input_shape{1, 3, 3, 2}; // n, h, w, c
+    std::vector<float> input = {-1,  2,  -3,  4,  5,   -6, -7,  8,   -9,
+                                -10, 11, -12, 13, -14, 15, -16, -17, 18};
+
+    const auto padding_bottom = 0;
+    const auto padding_right = 0;
+
+    ConvVerifier<float>::verifyFilterGradExpected(params, incoming_shape, incoming.data(),
+                                                  input_shape, input.data(), padding_bottom,
+                                                  padding_right, filter_shape);
+    ConvVerifier<float>::verifyInputGradExpected(params, incoming_shape, incoming.data(),
+                                                 filter_shape, filter.data(), padding_bottom,
+                                                 padding_right, input_shape);
+  }
+
+  // pad top 1, pad left 1, No stride
+  {
+    nnfw::cker::ConvParams params;
+    params.padding_type = nnfw::cker::PaddingType::kNone;
+    params.padding_values.width = 1;
+    params.padding_values.height = 1;
+    params.stride_width = 1;
+    params.stride_height = 1;
+    params.dilation_width_factor = 1;
+    params.dilation_height_factor = 1;
+
+    nnfw::cker::Shape incoming_shape{1, 3, 3, 3}; // n, h, w, c
+    std::vector<float> incoming = {-0.1, 0.2, -0.3, 0.4, 0.5,  -0.6, -0.7, 0.8,  0.9,
+                                   -1.0, 1.1, -1.2, 1.3, -1.4, 1.5,  -1.6, 1.7,  -1.8,
+                                   -1.9, 2.0, -2.1, 2.2, 2.3,  -2.4, 2.5,  -2.6, -2.7};
+    nnfw::cker::Shape filter_shape{2, 2, 2, 3}; // h, w, i, o
+    std::vector<float> filter = {-1,  2,  -3,  4,  5,  -6,  -7,  8,  9,   -10, -11, 12,
+                                 -13, 14, -15, 16, 17, -18, -19, 20, -21, 22,  23,  -24};
+    nnfw::cker::Shape input_shape{1, 3, 3, 2}; // n, h, w, c
+    std::vector<float> input = {-1,  2,  -3,  4,  5,   -6, -7,  8,   -9,
+                                -10, 11, -12, 13, -14, 15, -16, -17, 18};
+
+    const auto padding_bottom = 0;
+    const auto padding_right = 0;
+
+    ConvVerifier<float>::verifyFilterGradExpected(params, incoming_shape, incoming.data(),
+                                                  input_shape, input.data(), padding_bottom,
+                                                  padding_right, filter_shape);
+    ConvVerifier<float>::verifyInputGradExpected(params, incoming_shape, incoming.data(),
+                                                 filter_shape, filter.data(), padding_bottom,
+                                                 padding_right, input_shape);
+  }
+
+  // pad top 1, pad left 1, pad bottom 2, pad right 2, stride 2
+  {
+    nnfw::cker::ConvParams params;
+    params.padding_type = nnfw::cker::PaddingType::kNone;
+    params.padding_values.width = 1;
+    params.padding_values.height = 1;
+    params.stride_width = 2;
+    params.stride_height = 2;
+    params.dilation_width_factor = 1;
+    params.dilation_height_factor = 1;
+
+    nnfw::cker::Shape incoming_shape{1, 3, 3, 3}; // n, h, w, c
+    std::vector<float> incoming = {-0.1, 0.2, -0.3, 0.4, 0.5,  -0.6, -0.7, 0.8,  0.9,
+                                   -1.0, 1.1, -1.2, 1.3, -1.4, -1.5, 1.6,  1.7,  -1.8,
+                                   1.9,  2.0, -2.1, 2.2, -2.3, 2.4,  2.5,  -2.6, -2.7};
+    nnfw::cker::Shape filter_shape{3, 3, 2, 3}; // h, w, i, o
+    std::vector<float> filter = {
+      -1,  2,   -3,  4,   5,  -6,  -7,  8,   9,  -10, -11, 12,  -13, 14,  -15, 16,  17,  -18,
+      -19, 20,  -21, 22,  23, -24, -25, 26,  27, -28, -29, -30, 31,  -32, 33,  -34, 35,  36,
+      -37, -38, 39,  -40, 41, 42,  43,  -44, 45, -46, 47,  48,  -49, -50, -51, 52,  -53, 54};
+    nnfw::cker::Shape input_shape{1, 3, 3, 2}; // n, h, w, c
+    std::vector<float> input = {-1,  2,  -3,  4,  5,   -6, -7,  8,   -9,
+                                -10, 11, -12, 13, -14, 15, -16, -17, 18};
+
+    const auto padding_bottom = 2;
+    const auto padding_right = 2;
+
+    ConvVerifier<float>::verifyFilterGradExpected(params, incoming_shape, incoming.data(),
+                                                  input_shape, input.data(), padding_bottom,
+                                                  padding_right, filter_shape);
+    ConvVerifier<float>::verifyInputGradExpected(params, incoming_shape, incoming.data(),
+                                                 filter_shape, filter.data(), padding_bottom,
+                                                 padding_right, input_shape);
+  }
+
+  // pad same, stride 2
+  {
+    nnfw::cker::ConvParams params;
+    params.padding_type = nnfw::cker::PaddingType::kSame;
+    params.stride_width = 2;
+    params.stride_height = 2;
+    params.dilation_width_factor = 1;
+    params.dilation_height_factor = 1;
+
+    nnfw::cker::Shape incoming_shape{1, 3, 3, 3}; // n, h, w, c
+    std::vector<float> incoming = {-0.1, 0.2, -0.3, 0.4, 0.5,  -0.6, -0.7, 0.8,  0.9,
+                                   -1.0, 1.1, -1.2, 1.3, -1.4, -1.5, 1.6,  1.7,  -1.8,
+                                   1.9,  2.0, -2.1, 2.2, -2.3, 2.4,  2.5,  -2.6, -2.7};
+    nnfw::cker::Shape filter_shape{3, 3, 2, 3}; // h, w, i, o
+    std::vector<float> filter = {
+      -1,  2,   -3,  4,   5,  -6,  -7,  8,   9,  -10, -11, 12,  -13, 14,  -15, 16,  17,  -18,
+      -19, 20,  -21, 22,  23, -24, -25, 26,  27, -28, -29, -30, 31,  -32, 33,  -34, 35,  36,
+      -37, -38, 39,  -40, 41, 42,  43,  -44, 45, -46, 47,  48,  -49, -50, -51, 52,  -53, 54};
+    nnfw::cker::Shape input_shape{1, 3, 3, 2}; // n, h, w, c
+    std::vector<float> input = {-1,  2,  -3,  4,  5,   -6, -7,  8,   -9,
+                                -10, 11, -12, 13, -14, 15, -16, -17, 18};
+
+    const auto padding_bottom = 0;
+    const auto padding_right = 0;
+
+    ConvVerifier<float>::verifyFilterGradExpected(params, incoming_shape, incoming.data(),
+                                                  input_shape, input.data(), padding_bottom,
+                                                  padding_right, filter_shape);
+    ConvVerifier<float>::verifyInputGradExpected(params, incoming_shape, incoming.data(),
+                                                 filter_shape, filter.data(), padding_bottom,
+                                                 padding_right, input_shape);
+  }
+
+  // pad valid, stride 2
+  {
+    nnfw::cker::ConvParams params;
+    params.padding_type = nnfw::cker::PaddingType::kValid;
+    params.stride_width = 2;
+    params.stride_height = 2;
+    params.dilation_width_factor = 1;
+    params.dilation_height_factor = 1;
+
+    nnfw::cker::Shape incoming_shape{1, 1, 1, 3}; // n, h, w, c
+    std::vector<float> incoming = {-0.1, 0.2, -0.3};
+    nnfw::cker::Shape filter_shape{2, 2, 2, 3}; // h, w, i, o
+    std::vector<float> filter = {-1,  2,  -3,  4,  5,  -6,  -7,  8,  9,   -10, -11, 12,
+                                 -13, 14, -15, 16, 17, -18, -19, 20, -21, 22,  23,  -24};
+    nnfw::cker::Shape input_shape{1, 3, 3, 2}; // n, h, w, c
+    std::vector<float> input = {-1,  2,  -3,  4,  5,   -6, -7,  8,   -9,
+                                -10, 11, -12, 13, -14, 15, -16, -17, 18};
+
+    const auto padding_bottom = 0;
+    const auto padding_right = 0;
+
+    ConvVerifier<float>::verifyFilterGradExpected(params, incoming_shape, incoming.data(),
+                                                  input_shape, input.data(), padding_bottom,
+                                                  padding_right, filter_shape);
+    ConvVerifier<float>::verifyInputGradExpected(params, incoming_shape, incoming.data(),
+                                                 filter_shape, filter.data(), padding_bottom,
+                                                 padding_right, input_shape);
+  }
+}
+
+TEST(CKer_Operation, neg_ConvGradUnsupportedDilation)
+{
+  // Unsupported dilation
+  {
+    nnfw::cker::ConvParams params;
+    params.padding_type = nnfw::cker::PaddingType::kNone;
+    params.padding_values.width = 0;
+    params.padding_values.height = 0;
+    params.stride_width = 1;
+    params.stride_height = 1;
+    params.dilation_width_factor = 2;
+    params.dilation_height_factor = 2;
+
+    nnfw::cker::Shape incoming_shape{1, 2, 2, 3}; // n, h, w, c
+    std::vector<float> incoming = {-0.1, 0.2, -0.3, 0.4,  0.5, -0.6,
+                                   -0.7, 0.8, 0.9,  -1.0, 1.1, -1.2};
+    nnfw::cker::Shape filter_shape{2, 2, 2, 3}; // h, w, i, o
+    std::vector<float> filter = {-1,  2,  -3,  4,  5,  -6,  -7,  8,  9,   -10, -11, 12,
+                                 -13, 14, -15, 16, 17, -18, -19, 20, -21, 22,  23,  -24};
+    nnfw::cker::Shape input_shape{1, 3, 3, 2}; // n, h, w, c
+    std::vector<float> input = {-1,  2,  -3,  4,  5,   -6, -7,  8,   -9,
+                                -10, 11, -12, 13, -14, 15, -16, -17, 18};
+
+    EXPECT_ANY_THROW(nnfw::cker::train::ConvFilterGrad(params, incoming_shape, incoming.data(),
+                                                       input_shape, input.data(), 0, 0,
+                                                       filter_shape, filter.data()));
+
+    EXPECT_ANY_THROW(nnfw::cker::train::ConvInputGrad(params, incoming_shape, incoming.data(),
+                                                      filter_shape, filter.data(), 0, 0,
+                                                      input_shape, input.data()));
+  }
+}


### PR DESCRIPTION
This commit brings Conv2D kernels from tensorflow v2.12.1.
  - Bring Conv2D kernels
  - Add unit tests

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>