### PR TITLE
[onert] Adjust whether to cache cpu conv weights

### DIFF
--- a/runtime/onert/backend/cpu/KernelGenerator.cc
+++ b/runtime/onert/backend/cpu/KernelGenerator.cc
@@ -309,6 +309,9 @@ void KernelGenerator::visit(const ir::operation::Conv2D &node)
   const auto activation = node.param().activation;
   const auto param_padding = node.param().padding;
   const auto dilation = node.param().dilation;
+
+  const bool is_cacheable_weights = ker_tensor->is_constant();
+
   auto fn = std::make_unique<ops::ConvolutionLayer>();
 
   if (_ctx.at(ifm_index).info().isDynamic() || _ctx.at(ker_index).info().isDynamic())
@@ -316,7 +319,7 @@ void KernelGenerator::visit(const ir::operation::Conv2D &node)
     fn->configure(ifm_tensor, ker_tensor, bias_tensor, param_padding.type, param_padding.param.left,
                   param_padding.param.right, param_padding.param.top, param_padding.param.bottom,
                   stride.horizontal, stride.vertical, dilation.width_factor, dilation.height_factor,
-                  activation, ofm_tensor);
+                  activation, ofm_tensor, is_cacheable_weights);
 
     _return_fn = std::move(fn);
     return;
@@ -334,7 +337,8 @@ void KernelGenerator::visit(const ir::operation::Conv2D &node)
 
   fn->configure(ifm_tensor, ker_tensor, bias_tensor, param_padding.type, padding.left,
                 padding.right, padding.top, padding.bottom, stride.horizontal, stride.vertical,
-                dilation.width_factor, dilation.height_factor, activation, ofm_tensor);
+                dilation.width_factor, dilation.height_factor, activation, ofm_tensor,
+                is_cacheable_weights);
 
   _return_fn = std::move(fn);
 }

--- a/runtime/onert/backend/cpu/ops/ConvolutionLayer.h
+++ b/runtime/onert/backend/cpu/ops/ConvolutionLayer.h
@@ -56,7 +56,7 @@ public:
                  const uint32_t paddingBottom, const uint32_t strideWidth,
                  const uint32_t strideHeight, const uint32_t dilationWidthFactor,
                  const uint32_t dilationHeightFactor, const ir::Activation activation,
-                 IPortableTensor *output);
+                 IPortableTensor *output, bool is_cachable_weights);
   void prepare() override;
   void run() override;
 
@@ -67,7 +67,7 @@ private:
   void convQ8i();
   void convQ8iHybridPerChannel();
 
-private:
+protected:
   const IPortableTensor *_input;
   const IPortableTensor *_kernel;
   const IPortableTensor *_bias;
@@ -90,6 +90,7 @@ private:
   std::unique_ptr<nnfw::cker::ConvHybridTempArena> _hybrid_arena;
 
   bool _prepare;
+  bool _is_cachable_weights;
   bool _is_hybrid;
 };
 

--- a/runtime/onert/backend/train/ops/ConvolutionLayer.cc
+++ b/runtime/onert/backend/train/ops/ConvolutionLayer.cc
@@ -40,9 +40,11 @@ void ConvolutionLayer::configure(const IPortableTensor *input, const IPortableTe
                                  const uint32_t dilationHeightFactor,
                                  const ir::Activation activation, IPortableTensor *output)
 {
-  cpu::ops::ConvolutionLayer::configure(
-    input, kernel, bias, paddingType, paddingLeft, paddingRight, paddingTop, paddingBottom,
-    strideWidth, strideHeight, dilationWidthFactor, dilationHeightFactor, activation, output);
+  const bool is_cacheable_weights = false;
+  cpu::ops::ConvolutionLayer::configure(input, kernel, bias, paddingType, paddingLeft, paddingRight,
+                                        paddingTop, paddingBottom, strideWidth, strideHeight,
+                                        dilationWidthFactor, dilationHeightFactor, activation,
+                                        output, is_cacheable_weights);
 }
 
 void ConvolutionLayer::forward(bool) { cpu::ops::ConvolutionLayer::run(); }


### PR DESCRIPTION
This commit introduces a boolean param whether to check whether to cache weights for ConvolutionLayer of cpu backend.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>