### PR TITLE
[infra] Revise nnpackage collection script

### DIFF
--- a/infra/scripts/compiler_modules.sh
+++ b/infra/scripts/compiler_modules.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 # NOTE this file is sourced from, for the purpose of
-# - configure_compiler_coverage.sh: to get test coverage for release criteria
+# - configure_compiler_coverage.sh (DEBUG_BUILD_ITEMS): to get test coverage for release criteria
+# - configure_collect_nnpkgs.sh (NNPKG_RES_ITEMS): to collect nnpkg resources for nnpackage test
 
 # Don't run this script
 [[ "${BASH_SOURCE[0]}" == "${0}" ]] && echo "Please don't execute ${BASH_SOURCE[0]}, source it" && return
@@ -36,3 +37,22 @@ DEBUG_BUILD_ITEMS+=";circle-interpreter;circle-interpreter-test"
 DEBUG_BUILD_ITEMS+=";dalgona;dalgona-test"
 DEBUG_BUILD_ITEMS+=";visq"
 DEBUG_BUILD_ITEMS+=";circle-mpqsolver"
+
+NNPKG_RES_ITEMS="angkor;cwrap;pepper-str;pepper-strcast;pp"
+NNPKG_RES_ITEMS+=";pepper-csv2vec"
+NNPKG_RES_ITEMS+=";oops;safemain;foder;crew;arser;vconone"
+# Hermes Logging Framework
+NNPKG_RES_ITEMS+=";hermes;hermes-std"
+# loco IR and related utilities
+NNPKG_RES_ITEMS+=";loco;locop;locomotiv;logo-core;logo"
+# Compute
+NNPKG_RES_ITEMS+=";luci-compute"
+# Circle compiler library (.circle -> .circle)
+NNPKG_RES_ITEMS+=";luci"
+# Flatbuffer I/O
+NNPKG_RES_ITEMS+=";mio-tflite2121;mio-circle06"
+# Tools
+NNPKG_RES_ITEMS+=";tflite2circle;circle2circle;luci-interpreter"
+NNPKG_RES_ITEMS+=";souschef;tflchef;circlechef;circle-verify"
+# common-artifacts
+NNPKG_RES_ITEMS+=";common-artifacts"

--- a/infra/scripts/configure_collect_nnpkgs.sh
+++ b/infra/scripts/configure_collect_nnpkgs.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+[[ "${BASH_SOURCE[0]}" != "${0}" ]] && echo "Please don't source ${BASH_SOURCE[0]}, execute it" && return
+
+set -eo pipefail
+
+CURRENT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_PATH="$CURRENT_PATH/../../"
+
+source ${CURRENT_PATH}/compiler_modules.sh
+
+NNCC_CFG_OPTION=" -DCMAKE_BUILD_TYPE=Release"
+NNCC_CFG_STRICT=" -DENABLE_STRICT_BUILD=ON"
+NNCC_COV_DEBUG=" -DBUILD_WHITELIST=$NNPKG_RES_ITEMS"
+
+if [ $# -ne 0 ]; then
+	echo "Additional cmake configuration: $@"
+fi
+
+# Reset whitelist to build all
+./nncc configure \
+	$NNCC_CFG_OPTION $NNCC_COV_DEBUG $NNCC_CFG_STRICT \
+	"$@"

--- a/infra/scripts/docker_collect_nnpkg_resources.sh
+++ b/infra/scripts/docker_collect_nnpkg_resources.sh
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-function join_by
-{
-  local IFS="$1"; shift; echo "$*"
-}
-
 [[ "${BASH_SOURCE[0]}" != "${0}" ]] && echo "Please don't source ${BASH_SOURCE[0]}, execute it" && return
 
 CURRENT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -81,9 +76,7 @@ REQUIRED_UNITS+=("souschef" "tflchef" "circlechef" "circle-verify")
 REQUIRED_UNITS+=("common-artifacts")
 
 # Reset whitelist to build all
-./nnas docker-run ./nncc configure -DENABLE_STRICT_BUILD=ON -DCMAKE_BUILD_TYPE=release \
-  -DBUILD_WHITELIST=$(join_by ";" "${REQUIRED_UNITS[@]}") \
-  $CONFIG_OPTIONS
+./nnas docker-run ./infra/scripts/configure_collect_nnpkgs.sh -DEXTERNALS_BUILD_THREADS=4
 ./nnas docker-run ./nncc build -j4
 
 mkdir -p ${ARCHIVE_PATH}


### PR DESCRIPTION
This commit updates "docker_collect_nnpkg_resources.sh" to split nncc configure. 
New configure script "configure_collect_nnpkgs.sh" has similar style with "configure_compiler_coverage.sh". 
"docker_collect_nnpkg_resources.sh" will be removed.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>