### PR TITLE
[res] TensorFlowLiteRecipes for Conv->Mul fusion

### DIFF
--- a/res/TensorFlowLiteRecipes/Net_Conv_Mul_000/test.recipe
+++ b/res/TensorFlowLiteRecipes/Net_Conv_Mul_000/test.recipe
@@ -1,0 +1,71 @@
+# test for Conv(pad=valid, krnl(2, 3, 2, 3), stride=(2, 1))->Mul_with_rank-4_channelwise_constant
+
+operand {
+  name: "ifm_conv"
+  type: FLOAT32
+  shape { dim: 1 dim: 4 dim: 2 dim: 3 }
+}
+operand {
+  name: "filter"
+  type: FLOAT32
+  shape { dim: 2 dim: 3 dim: 2 dim: 3 }
+  filler {
+    tag: "gaussian"
+    arg: "-1.0"
+    arg: "1.0"
+  }
+}
+operand {
+  name: "bias"
+  type: FLOAT32
+  shape { dim: 2 }
+  filler {
+    tag: "gaussian"
+    arg: "0.0"
+    arg: "1.0"
+  }
+}
+operand {
+  name: "ofm_conv"
+  type: FLOAT32
+  shape { dim: 1 dim: 1 dim: 1 dim: 2 }
+}
+operand {
+  name: "mul_const"
+  type: FLOAT32
+  shape { dim: 1 dim: 1 dim: 1 dim: 2 }
+  filler {
+    tag: "gaussian"
+    arg: "-1.0"
+    arg: "1.0"
+  }
+}
+operand { 
+  name: "ofm_mul"
+  type: FLOAT32
+  shape { dim: 1 dim: 1 dim: 1 dim: 2 }
+}
+operation {
+  type: "Conv2D"
+  conv2d_options {
+    padding: VALID
+    stride_h: 2
+    stride_w: 1
+    activation: NONE
+  }
+  input: "ifm_conv"
+  input: "filter"
+  input: "bias"
+  output: "ofm_conv"
+}
+operation {
+  type: "Mul"
+  input: "ofm_conv"
+  input: "mul_const"
+  output: "ofm_mul"
+  mul_options {
+    activation: RELU
+  }
+}
+input: "ifm_conv"
+output: "ofm_mul"

--- a/res/TensorFlowLiteRecipes/Net_Conv_Mul_000/test.rule
+++ b/res/TensorFlowLiteRecipes/Net_Conv_Mul_000/test.rule
@@ -1,0 +1,6 @@
+# To check if Mul is fused to Conv
+
+RULE    "VERIFY_FILE_FORMAT"    $(verify_file_format) '=' 1
+
+RULE    "CONV_EXIST"            $(op_count CONV_2D) '=' 1
+RULE    "MUL_NOT_EXIST"         $(op_count MUL) '=' 0

--- a/res/TensorFlowLiteRecipes/Net_Conv_Mul_001/test.recipe
+++ b/res/TensorFlowLiteRecipes/Net_Conv_Mul_001/test.recipe
@@ -1,0 +1,71 @@
+# test for Conv(pad=valid, krnl(2, 3, 2, 3), stride=(2, 1))->Mul_with_rank-1_channelwise_constant
+
+operand {
+  name: "ifm_conv"
+  type: FLOAT32
+  shape { dim: 1 dim: 4 dim: 2 dim: 3 }
+}
+operand {
+  name: "filter"
+  type: FLOAT32
+  shape { dim: 2 dim: 3 dim: 2 dim: 3 }
+  filler {
+    tag: "gaussian"
+    arg: "-1.0"
+    arg: "1.0"
+  }
+}
+operand {
+  name: "bias"
+  type: FLOAT32
+  shape { dim: 2 }
+  filler {
+    tag: "gaussian"
+    arg: "0.0"
+    arg: "1.0"
+  }
+}
+operand {
+  name: "ofm_conv"
+  type: FLOAT32
+  shape { dim: 1 dim: 1 dim: 1 dim: 2 }
+}
+operand {
+  name: "mul_const"
+  type: FLOAT32
+  shape { dim: 2 }
+  filler {
+    tag: "gaussian"
+    arg: "-1.0"
+    arg: "1.0"
+  }
+}
+operand { 
+  name: "ofm_mul"
+  type: FLOAT32
+  shape { dim: 1 dim: 1 dim: 1 dim: 2 }
+}
+operation {
+  type: "Conv2D"
+  conv2d_options {
+    padding: VALID
+    stride_h: 2
+    stride_w: 1
+    activation: NONE
+  }
+  input: "ifm_conv"
+  input: "filter"
+  input: "bias"
+  output: "ofm_conv"
+}
+operation {
+  type: "Mul"
+  input: "ofm_conv"
+  input: "mul_const"
+  output: "ofm_mul"
+  mul_options {
+    activation: RELU
+  }
+}
+input: "ifm_conv"
+output: "ofm_mul"

--- a/res/TensorFlowLiteRecipes/Net_Conv_Mul_001/test.rule
+++ b/res/TensorFlowLiteRecipes/Net_Conv_Mul_001/test.rule
@@ -1,0 +1,6 @@
+# To check if Mul is fused to Conv
+
+RULE    "VERIFY_FILE_FORMAT"    $(verify_file_format) '=' 1
+
+RULE    "CONV_EXIST"            $(op_count CONV_2D) '=' 1
+RULE    "MUL_NOT_EXIST"         $(op_count MUL) '=' 0

--- a/res/TensorFlowLiteRecipes/Net_Conv_Mul_002/test.recipe
+++ b/res/TensorFlowLiteRecipes/Net_Conv_Mul_002/test.recipe
@@ -1,0 +1,71 @@
+# test for Conv(pad=valid, krnl(2, 3, 2, 3), stride=(2, 1))->Mul_with_rank-1_constant
+
+operand {
+  name: "ifm_conv"
+  type: FLOAT32
+  shape { dim: 1 dim: 4 dim: 2 dim: 3 }
+}
+operand {
+  name: "filter"
+  type: FLOAT32
+  shape { dim: 2 dim: 3 dim: 2 dim: 3 }
+  filler {
+    tag: "gaussian"
+    arg: "-1.0"
+    arg: "1.0"
+  }
+}
+operand {
+  name: "bias"
+  type: FLOAT32
+  shape { dim: 2 }
+  filler {
+    tag: "gaussian"
+    arg: "0.0"
+    arg: "1.0"
+  }
+}
+operand {
+  name: "ofm_conv"
+  type: FLOAT32
+  shape { dim: 1 dim: 1 dim: 1 dim: 2 }
+}
+operand {
+  name: "mul_const"
+  type: FLOAT32
+  shape { dim: 1 }
+  filler {
+    tag: "gaussian"
+    arg: "-1.0"
+    arg: "1.0"
+  }
+}
+operand { 
+  name: "ofm_mul"
+  type: FLOAT32
+  shape { dim: 1 dim: 1 dim: 1 dim: 2 }
+}
+operation {
+  type: "Conv2D"
+  conv2d_options {
+    padding: VALID
+    stride_h: 2
+    stride_w: 1
+    activation: NONE
+  }
+  input: "ifm_conv"
+  input: "filter"
+  input: "bias"
+  output: "ofm_conv"
+}
+operation {
+  type: "Mul"
+  input: "ofm_conv"
+  input: "mul_const"
+  output: "ofm_mul"
+  mul_options {
+    activation: RELU
+  }
+}
+input: "ifm_conv"
+output: "ofm_mul"

--- a/res/TensorFlowLiteRecipes/Net_Conv_Mul_002/test.rule
+++ b/res/TensorFlowLiteRecipes/Net_Conv_Mul_002/test.rule
@@ -1,0 +1,6 @@
+# To check if Mul is fused to Conv
+
+RULE    "VERIFY_FILE_FORMAT"    $(verify_file_format) '=' 1
+
+RULE    "CONV_EXIST"            $(op_count CONV_2D) '=' 1
+RULE    "MUL_NOT_EXIST"         $(op_count MUL) '=' 0

--- a/res/TensorFlowLiteRecipes/Net_Conv_Mul_003/test.recipe
+++ b/res/TensorFlowLiteRecipes/Net_Conv_Mul_003/test.recipe
@@ -1,0 +1,70 @@
+# test for Conv(pad=valid, krnl(2, 3, 2, 3), stride=(2, 1))->Mul_with_rank_0_constant
+
+operand {
+  name: "ifm_conv"
+  type: FLOAT32
+  shape { dim: 1 dim: 4 dim: 2 dim: 3 }
+}
+operand {
+  name: "filter"
+  type: FLOAT32
+  shape { dim: 2 dim: 3 dim: 2 dim: 3 }
+  filler {
+    tag: "gaussian"
+    arg: "-1.0"
+    arg: "1.0"
+  }
+}
+operand {
+  name: "bias"
+  type: FLOAT32
+  shape { dim: 2 }
+  filler {
+    tag: "gaussian"
+    arg: "0.0"
+    arg: "1.0"
+  }
+}
+operand {
+  name: "ofm_conv"
+  type: FLOAT32
+  shape { dim: 1 dim: 1 dim: 1 dim: 2 }
+}
+operand {
+  name: "mul_const"
+  type: FLOAT32
+  filler {
+    tag: "gaussian"
+    arg: "-1.0"
+    arg: "1.0"
+  }
+}
+operand { 
+  name: "ofm_mul"
+  type: FLOAT32
+  shape { dim: 1 dim: 1 dim: 1 dim: 2 }
+}
+operation {
+  type: "Conv2D"
+  conv2d_options {
+    padding: VALID
+    stride_h: 2
+    stride_w: 1
+    activation: NONE
+  }
+  input: "ifm_conv"
+  input: "filter"
+  input: "bias"
+  output: "ofm_conv"
+}
+operation {
+  type: "Mul"
+  input: "ofm_conv"
+  input: "mul_const"
+  output: "ofm_mul"
+  mul_options {
+    activation: RELU
+  }
+}
+input: "ifm_conv"
+output: "ofm_mul"

--- a/res/TensorFlowLiteRecipes/Net_Conv_Mul_003/test.rule
+++ b/res/TensorFlowLiteRecipes/Net_Conv_Mul_003/test.rule
@@ -1,0 +1,6 @@
+# To check if Mul is fused to Conv
+
+RULE    "VERIFY_FILE_FORMAT"    $(verify_file_format) '=' 1
+
+RULE    "CONV_EXIST"            $(op_count CONV_2D) '=' 1
+RULE    "MUL_NOT_EXIST"         $(op_count MUL) '=' 0


### PR DESCRIPTION
This commit adds models for testing Conv->Mul fusion with various parameters.

Its correctness is tested in https://github.com/Samsung/ONE/pull/11991.

Draft: https://github.com/Samsung/ONE/pull/11991
Related: https://github.com/Samsung/ONE/issues/11897

ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>