### PR TITLE
[common-artifacts] Exclude BroadcastTo_002

### DIFF
--- a/compiler/common-artifacts/exclude.lst
+++ b/compiler/common-artifacts/exclude.lst
@@ -7,6 +7,7 @@
 ## TensorFlowLiteRecipes
 optimize(BroadcastTo_000)
 optimize(BroadcastTo_001)
+optimize(BroadcastTo_002)
 
 ## CircleRecipes
 
@@ -31,6 +32,7 @@ tcgenerate(BatchMatMulV2_001)
 tcgenerate(BatchToSpaceND_000)
 tcgenerate(BroadcastTo_000) # luci-interpreter doesn't support custom operator
 tcgenerate(BroadcastTo_001)
+tcgenerate(BroadcastTo_002)
 tcgenerate(Ceil_000)
 tcgenerate(Conv2D_003) # runtime doesn't support dilation
 tcgenerate(Densify_000) # luci-interpreter doesn't support


### PR DESCRIPTION
This adds BroadcastTo_002 to exclude.lst.

ONE-DCO-1.0-Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>

---
Related to Issue: https://github.com/Samsung/ONE/issues/10784
Draft PR: [#10737](https://github.com/Samsung/ONE/pull/11701)