### PR TITLE
[one-cmds] Enable remove_unnecessary_transpose

### DIFF
--- a/compiler/one-cmds/how-to-use-one-commands.txt
+++ b/compiler/one-cmds/how-to-use-one-commands.txt
@@ -194,6 +194,7 @@ Current transformation options are
 - remove_unnecessary_slice : This removes unnecessary slice operators.
 - remove_unnecessary_strided_slice : This removes unnecessary strided slice operators.
 - remove_unnecessary_split : This removes unnecessary split operators.
+- remove_unnecessary_transpose: This removes unnecessary transpose operators.
 - replace_cw_mul_add_with_depthwise_conv: This will replace channel-wise Mul/Add with DepthwiseConv2D.
 - resolve_customop_add: This will convert Custom(Add) to normal Add operator
 - resolve_customop_batchmatmul: This will convert Custom(BatchMatMul) to

--- a/compiler/one-cmds/onelib/constant.py
+++ b/compiler/one-cmds/onelib/constant.py
@@ -132,6 +132,7 @@ class CONSTANT:
         ('remove_unnecessary_slice', 'remove unnecessary slice ops'),
         ('remove_unnecessary_strided_slice', 'remove unnecessary strided slice ops'),
         ('remove_unnecessary_split', 'remove unnecessary split ops'),
+        ('remove_unnecessary_transpose', 'remove unnecessary transpose ops'),
         ('replace_non_const_fc_with_batch_matmul',
          'replace FullyConnected op with non-const weights to BatchMatMul op'),
         ('replace_sub_with_add', 'replace Sub op with Add op'),

--- a/compiler/one-cmds/onelib/constant.py
+++ b/compiler/one-cmds/onelib/constant.py
@@ -56,6 +56,7 @@ class CONSTANT:
         'remove_unnecessary_slice',
         'remove_unnecessary_strided_slice',
         'remove_unnecessary_split',
+        'remove_unnecessary_transpose',
         'common_subexpression_elimination',
 
         # Canonicalization


### PR DESCRIPTION
This PR enables remove_unnecessary_transpose for one-cmds.

* to resovle : https://github.com/Samsung/ONE/issues/11654 
* from draft : #11891  

ONE-DCO-1.0-Signed-off-by: SeungHui Youn <sseung.youn@samsung.com>