### PR TITLE
[onert/train] Fix reference after move

### DIFF
--- a/runtime/onert/core/src/exec/train/TrainableExecutor.cc
+++ b/runtime/onert/core/src/exec/train/TrainableExecutor.cc
@@ -42,7 +42,7 @@ TrainableExecutor::TrainableExecutor(
     assert(tensors.empty());
     for (auto &&ind : ind_seq)
     {
-      backend::ITensor *tensor = tensor_regs.getITensor(ind);
+      backend::ITensor *tensor = _tensor_regs.getITensor(ind);
       assert(tensor != nullptr);
       auto io_tensor = nnfw::misc::polymorphic_downcast<backend::builtin::IOTensor *>(tensor);
       tensors.push_back(io_tensor);


### PR DESCRIPTION
This commit fixes bug in TrainableExecutor constructor referencing `tensor_regs` after move.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: #12013