### PR TITLE
[luci/import] Support BroadcastTo operation

### DIFF
--- a/compiler/luci/import/include/luci/Import/Nodes.h
+++ b/compiler/luci/import/include/luci/Import/Nodes.h
@@ -28,6 +28,7 @@
 #include "Nodes/CircleBCQFullyConnected.h"
 #include "Nodes/CircleBCQGather.h"
 #include "Nodes/CircleBidirectionalSequenceLSTM.h"
+#include "Nodes/CircleBroadcastTo.h"
 #include "Nodes/CircleCast.h"
 #include "Nodes/CircleCeil.h"
 #include "Nodes/CircleConcatenation.h"

--- a/compiler/luci/import/include/luci/Import/Nodes/CircleBroadcastTo.h
+++ b/compiler/luci/import/include/luci/Import/Nodes/CircleBroadcastTo.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __LUCI_IMPORT_OP_CIRCLE_BROADCAST_TO_H__
+#define __LUCI_IMPORT_OP_CIRCLE_BROADCAST_TO_H__
+
+#include "luci/Import/GraphBuilder.h"
+
+namespace luci
+{
+
+class CircleBroadcastToGraphBuilder : public GraphBuilder
+{
+public:
+  bool validate(const ValidateArgs &args) const final;
+
+private:
+  CircleNode *build_node(const circle::OperatorT &op, const std::vector<CircleNode *> &inputs,
+                         loco::Graph *graph) const final;
+};
+
+} // namespace luci
+
+#endif // __LUCI_IMPORT_OP_CIRCLE_BROADCAST_TO_H__

--- a/compiler/luci/import/src/GraphBuilderRegistry.cpp
+++ b/compiler/luci/import/src/GraphBuilderRegistry.cpp
@@ -38,6 +38,7 @@ GraphBuilderRegistry::GraphBuilderRegistry()
   CIRCLE_NODE(BCQ_FULLY_CONNECTED, CircleBCQFullyConnectedGraphBuilder);                   // 253
   CIRCLE_NODE(BCQ_GATHER, CircleBCQGatherGraphBuilder);                                    // 252
   CIRCLE_NODE(BIDIRECTIONAL_SEQUENCE_LSTM, CircleBidirectionalSequenceLSTMGraphBuilder);   // 52
+  CIRCLE_NODE(BROADCAST_TO, CircleBroadcastToGraphBuilder);                                // 130
   CIRCLE_NODE(CAST, CircleCastGraphBuilder);                                               // 53
   CIRCLE_NODE(CEIL, CircleCeilGraphBuilder);                                               // 104
   CIRCLE_NODE(CUSTOM, CircleCustomGraphBuilder);                                           // 32

--- a/compiler/luci/import/src/Nodes/CircleBroadcastTo.cpp
+++ b/compiler/luci/import/src/Nodes/CircleBroadcastTo.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Import/Nodes/CircleBroadcastTo.h"
+
+#include <luci/IR/Nodes/CircleBroadcastTo.h>
+
+#include <loco.h>
+
+namespace luci
+{
+
+bool CircleBroadcastToGraphBuilder::validate(const ValidateArgs &args) const
+{
+  // TODO Support type check
+  return GraphBuilder::validate(args, 2);
+}
+
+CircleNode *CircleBroadcastToGraphBuilder::build_node(const circle::OperatorT &,
+                                                      const std::vector<CircleNode *> &inputs,
+                                                      loco::Graph *graph) const
+{
+  auto *node = graph->nodes()->create<CircleBroadcastTo>();
+  node->input(inputs.at(0));
+  node->shape(inputs.at(1));
+
+  return node;
+}
+
+} // namespace luci


### PR DESCRIPTION
This supports import of BroadcastTo Op.

ONE-DCO-1.0-Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>

---
Related to Issue: https://github.com/Samsung/ONE/issues/10784
Draft PR: [#10737](https://github.com/Samsung/ONE/pull/11701)