### PR TITLE
[onert] Support TrainableGraph dump in dot

### DIFF
--- a/runtime/onert/core/src/dumper/dot/DotDumper.cc
+++ b/runtime/onert/core/src/dumper/dot/DotDumper.cc
@@ -228,6 +228,11 @@ void DotDumper::dump(const compiler::ILoweredGraph &lowered_graph, const std::st
   dump_to_file(dot_operands, dot_operations, tag);
 }
 
+void DotDumper::dump(const ir::train::TrainableGraph &graph, const std::string &tag)
+{
+  dump(graph.graph(), tag);
+}
+
 } // namespace dot
 } // namespace dumper
 } // namespace onert

--- a/runtime/onert/core/src/dumper/dot/DotDumper.h
+++ b/runtime/onert/core/src/dumper/dot/DotDumper.h
@@ -15,6 +15,7 @@
  */
 
 #include "ir/Graph.h"
+#include "ir/train/TrainableGraph.h"
 #include "compiler/ILoweredGraph.h"
 
 #ifndef __ONERT_DUMPER_DOT_DOT_DUMPER_H__
@@ -58,6 +59,15 @@ public:
    * @return N/A
    */
   void dump(const compiler::ILoweredGraph &lowered_graph, const std::string &tag);
+
+  /**
+   * @brief Dump graph information to dot file as tag name if "GRAPH_DOT_DUMP" is set
+   *
+   * @param[in] graph  TrainableGraph to be dumped
+   * @param[in] tag    The name of dot file to be dumped
+   * @return N/A
+   */
+  void dump(const ir::train::TrainableGraph &graph, const std::string &tag);
 
 private:
   Level _level;


### PR DESCRIPTION
It supports dot dumping for TrainableGraph during TrainingCompiler's compilation.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

```
$ GRAPH_DOT_DUMP=1 \
Product/x86_64-linux.debug/out/bin/onert_train \
mnist.circle \
--load_input:raw mnist_train.i160.bin \
--load_expected:raw mnist_train.o160.bin \
--optimizer 1 \
--data_length 160 \
--epoch 1

$ ls *.dot
-rw-rw-r-- 1 gyu gyu  578 Nov 14 10:57 after_loss_insertion-0.dot
-rw-rw-r-- 1 gyu gyu 2061 Nov 14 10:52 after_lower_subg-0.dot
-rw-rw-r-- 1 gyu gyu  843 Nov 14 10:52 before_loss_insertion-0.dot
```

(I will upload the screenshot after I got to home.)

You can see the graph in dumped dot by downloading `.dot` and opening with `xdot` or something.

[training_dots.tar.gz](https://github.com/Samsung/ONE/files/13343736/training_dots.tar.gz)