### PR TITLE
[tools/onert_train] Remove data_length parameter from onert_train tool

### DIFF
--- a/tests/tools/onert_train/src/args.cc
+++ b/tests/tools/onert_train/src/args.cc
@@ -198,7 +198,6 @@ void Args::Initialize(void)
     ("nnpackage", po::value<std::string>()->notifier(process_nnpackage), "NN Package file(directory) name")
     ("modelfile", po::value<std::string>()->notifier(process_modelfile), "NN Model filename")
     ("path", po::value<std::string>()->notifier(process_path), "NN Package or NN Modelfile path")
-    ("data_length", po::value<int>()->notifier([&](const auto &v) { _data_length = v; }), "Data length number")
     ("load_input:raw", po::value<std::string>()->notifier(process_load_raw_inputfile),
          "NN Model Raw Input data file\n"
          "The datafile must have data for each input number.\n"
@@ -275,9 +274,6 @@ void Args::Parse(const int argc, char **argv)
     if (!vm.count("modelfile") && !vm.count("nnpackage") && !vm.count("path"))
       throw boost::program_options::error(
         std::string("Require one of options modelfile, nnpackage, or path."));
-
-    if (!vm.count("data_length"))
-      throw boost::program_options::error(std::string("data_length option is mandatory."));
   }
 
   try

--- a/tests/tools/onert_train/src/args.h
+++ b/tests/tools/onert_train/src/args.h
@@ -49,7 +49,6 @@ public:
   const std::string &getPackageFilename(void) const { return _package_filename; }
   const std::string &getModelFilename(void) const { return _model_filename; }
   const bool useSingleModel(void) const { return _use_single_model; }
-  const int getDataLength(void) const { return _data_length; }
   const std::string &getLoadRawInputFilename(void) const { return _load_raw_input_filename; }
   const std::string &getLoadRawExpectedFilename(void) const { return _load_raw_expected_filename; }
   const bool getMemoryPoll(void) const { return _mem_poll; }
@@ -73,7 +72,6 @@ private:
   std::string _package_filename;
   std::string _model_filename;
   bool _use_single_model = false;
-  int _data_length;
   std::string _load_raw_input_filename;
   std::string _load_raw_expected_filename;
   bool _mem_poll;

--- a/tests/tools/onert_train/src/onert_train.cc
+++ b/tests/tools/onert_train/src/onert_train.cc
@@ -182,16 +182,16 @@ int main(const int argc, char **argv)
       expected_infos.emplace_back(std::move(ti));
     }
 
-    auto data_length = args.getDataLength();
+    uint32_t data_length;
 
     Generator generator;
     RawDataLoader rawDataLoader;
 
     if (!args.getLoadRawInputFilename().empty() && !args.getLoadRawExpectedFilename().empty())
     {
-      generator =
+      std::tie(generator, data_length) =
         rawDataLoader.loadData(args.getLoadRawInputFilename(), args.getLoadRawExpectedFilename(),
-                               input_infos, expected_infos, data_length, tri.batch_size);
+                               input_infos, expected_infos, tri.batch_size);
     }
     else
     {

--- a/tests/tools/onert_train/src/rawdataloader.cc
+++ b/tests/tools/onert_train/src/rawdataloader.cc
@@ -23,12 +23,46 @@
 
 namespace onert_train
 {
-
-Generator RawDataLoader::loadData(const std::string &input_file, const std::string &expected_file,
-                                  const std::vector<nnfw_tensorinfo> &input_infos,
-                                  const std::vector<nnfw_tensorinfo> &expected_infos,
-                                  const uint32_t data_length, const uint32_t batch_size)
+uint64_t getRawTensorSize(const std::vector<nnfw_tensorinfo> &infos)
 {
+  // NOTE The input_infos has already applied the batch_size.
+  //      In order to know the size of the tensor stored in the actual file,
+  //      the batch_size information must be excluded.
+  uint64_t total = 0;
+  for (uint32_t i = 0; i < infos.size(); ++i)
+  {
+    total += (bufsize_for(&infos[i]) / infos[i].dims[0]);
+  }
+  return total;
+}
+} // namespace onert_train
+
+namespace onert_train
+{
+std::tuple<Generator, uint32_t>
+RawDataLoader::loadData(const std::string &input_file, const std::string &expected_file,
+                        const std::vector<nnfw_tensorinfo> &input_infos,
+                        const std::vector<nnfw_tensorinfo> &expected_infos,
+                        const uint32_t batch_size)
+{
+  _input_file = std::ifstream(input_file, std::ios::binary);
+  _expected_file = std::ifstream(expected_file, std::ios::binary);
+
+  _input_file.seekg(0, std::ios::end);
+  uint32_t input_file_size = _input_file.tellg();
+  uint32_t input_data_length = input_file_size / getRawTensorSize(input_infos);
+
+  _expected_file.seekg(0, std::ios::end);
+  uint32_t expected_file_size = _expected_file.tellg();
+  uint32_t expected_data_length = expected_file_size / getRawTensorSize(expected_infos);
+
+  if (input_data_length != expected_data_length)
+  {
+    throw std::runtime_error("The length of input data and expected data does not match.");
+  }
+
+  uint32_t data_length = input_data_length;
+
   std::vector<uint32_t> input_origins(input_infos.size());
   uint32_t start = 0;
   for (uint32_t i = 0; i < input_infos.size(); ++i)
@@ -45,33 +79,24 @@ Generator RawDataLoader::loadData(const std::string &input_file, const std::stri
     start += (bufsize_for(&expected_infos[i]) / batch_size * data_length);
   }
 
-  try
-  {
-    _input_file = std::ifstream(input_file, std::ios::ate | std::ios::binary);
-    _expected_file = std::ifstream(expected_file, std::ios::ate | std::ios::binary);
-  }
-  catch (const std::exception &e)
-  {
-    std::cerr << e.what() << std::endl;
-    std::exit(-1);
-  }
-
-  return [input_origins, expected_origins, &input_infos, &expected_infos,
-          this](uint32_t idx, std::vector<Allocation> &inputs, std::vector<Allocation> &expecteds) {
-    for (uint32_t i = 0; i < input_infos.size(); ++i)
-    {
-      auto bufsz = bufsize_for(&input_infos[i]);
-      _input_file.seekg(input_origins[i] + idx * bufsz, std::ios::beg);
-      _input_file.read(reinterpret_cast<char *>(inputs[i].data()), bufsz);
-    }
-    for (uint32_t i = 0; i < expected_infos.size(); ++i)
-    {
-      auto bufsz = bufsize_for(&expected_infos[i]);
-      _expected_file.seekg(expected_origins[i] + idx * bufsz, std::ios::beg);
-      _expected_file.read(reinterpret_cast<char *>(expecteds[i].data()), bufsz);
-    }
-    return true;
-  };
+  return std::make_tuple(
+    [input_origins, expected_origins, &input_infos, &expected_infos,
+     this](uint32_t idx, std::vector<Allocation> &inputs, std::vector<Allocation> &expecteds) {
+      for (uint32_t i = 0; i < input_infos.size(); ++i)
+      {
+        auto bufsz = bufsize_for(&input_infos[i]);
+        _input_file.seekg(input_origins[i] + idx * bufsz, std::ios::beg);
+        _input_file.read(reinterpret_cast<char *>(inputs[i].data()), bufsz);
+      }
+      for (uint32_t i = 0; i < expected_infos.size(); ++i)
+      {
+        auto bufsz = bufsize_for(&expected_infos[i]);
+        _expected_file.seekg(expected_origins[i] + idx * bufsz, std::ios::beg);
+        _expected_file.read(reinterpret_cast<char *>(expecteds[i].data()), bufsz);
+      }
+      return true;
+    },
+    data_length);
 }
 
 } // namespace onert_train

--- a/tests/tools/onert_train/src/rawdataloader.h
+++ b/tests/tools/onert_train/src/rawdataloader.h
@@ -23,6 +23,7 @@
 #include <functional>
 #include <string>
 #include <vector>
+#include <tuple>
 #include <fstream>
 
 namespace onert_train
@@ -36,10 +37,11 @@ class RawDataLoader
 {
 public:
   RawDataLoader() = default;
-  Generator loadData(const std::string &input_file, const std::string &expected_file,
-                     const std::vector<nnfw_tensorinfo> &input_infos,
-                     const std::vector<nnfw_tensorinfo> &output_infos, const uint32_t data_length,
-                     const uint32_t batch_size);
+  std::tuple<Generator, uint32_t> loadData(const std::string &input_file,
+                                           const std::string &expected_file,
+                                           const std::vector<nnfw_tensorinfo> &input_infos,
+                                           const std::vector<nnfw_tensorinfo> &expected_infos,
+                                           const uint32_t batch_size);
 
 private:
   std::ifstream _input_file;

--- a/tests/tools/onert_train/test/rawdataloader.test.cc
+++ b/tests/tools/onert_train/test/rawdataloader.test.cc
@@ -175,8 +175,12 @@ TEST_F(RawDataLoaderTest, loadDatas_1)
 
   // Load test datas
   RawDataLoader loader;
-  Generator generator =
-    loader.loadData(input_file, expected_file, in_infos, expected_infos, data_length, batch_size);
+  Generator generator;
+  uint32_t test_data_length;
+  std::tie(generator, test_data_length) =
+    loader.loadData(input_file, expected_file, in_infos, expected_infos, batch_size);
+
+  EXPECT_EQ(data_length, test_data_length);
 
   // Allocate inputs and expecteds data memory
   std::vector<Allocation> inputs(num_input);


### PR DESCRIPTION
This commit removes data_length input parameter. It calcaulates the data length value using the input and expected data files.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Related comment: https://github.com/Samsung/ONE/issues/11892#issuecomment-1797888717