### PR TITLE
[circle-mpqsolver] Dump config

### DIFF
--- a/compiler/circle-mpqsolver/src/core/DumpingHooks.h
+++ b/compiler/circle-mpqsolver/src/core/DumpingHooks.h
@@ -48,7 +48,7 @@ public:
   virtual void onQuantized(luci::Module *module) const override;
 
   /**
-   * @brief called on the start of iterative search
+   * @brief called on the start of mpq search
    */
   virtual void onBeginSolver(const std::string &model_path, float q8error, float q16error) override;
 
@@ -64,7 +64,7 @@ public:
                               float error) override;
 
   /**
-   * @brief called at the end of iterative search
+   * @brief called at the end of mpq search
    */
   virtual void onEndSolver(const LayerParams &layers, const std::string &def_dtype,
                            float qerror) override;


### PR DESCRIPTION
This commit dumps final qconfig if save_intermediate option is on.

Running `patternsolver` with `--save_intermediate` option turned to `on`, successfully produced `FinalConfiguration.mpq.json` with correct parameters. 
Please see attachement for result:
[out_3.zip](https://github.com/Samsung/ONE/files/13349884/out_3.zip)



Related: #12020
ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>