### PR TITLE
[onert] Introduce LossMeanSquaredErrorLayer in train backend

### DIFF
--- a/runtime/onert/backend/train/ops/LossLayer.cc
+++ b/runtime/onert/backend/train/ops/LossLayer.cc
@@ -15,9 +15,6 @@
  */
 
 #include "LossLayer.h"
-#include "OperationUtils.h"
-
-#include <cker/train/operation/Loss.h>
 
 namespace onert
 {
@@ -29,68 +26,23 @@ namespace ops
 {
 
 LossLayer::LossLayer()
-  : _y_pred(nullptr), _y_true(nullptr), _output(nullptr), _back_prop_y_pred(nullptr),
-    _loss_type(LossType::kMSE)
+  : _y_pred(nullptr), _y_true(nullptr), _output(nullptr), _back_prop_y_pred(nullptr)
 {
   // DO NOTHING
 }
 
 void LossLayer::configure(const IPortableTensor *y_pred, const IPortableTensor *y_true,
-                          IPortableTensor *output, IPortableTensor *back_prop_y_pred,
-                          LossType loss_type)
+                          IPortableTensor *output, IPortableTensor *back_prop_y_pred)
 {
   assert(y_pred != nullptr);
   assert(y_true != nullptr);
   assert(output != nullptr);
   assert(back_prop_y_pred != nullptr);
-  switch (loss_type)
-  {
-    case LossType::kMSE:
-      break;
-    default:
-      throw std::runtime_error("LossLayer: unsupported loss type");
-  }
 
   _y_pred = y_pred;
   _y_true = y_true;
   _output = output;
   _back_prop_y_pred = back_prop_y_pred;
-  _loss_type = loss_type;
-}
-
-void LossLayer::forward(bool)
-{
-  // TODO Implement this
-  switch (_loss_type)
-  {
-    case LossType::kMSE:
-      if (_y_pred->data_type() == OperandType::FLOAT32)
-      {
-        nnfw::cker::train::MSE(getShape(_y_pred), getBuffer<float>(_y_pred), getShape(_y_true),
-                               getBuffer<float>(_y_true), getShape(_output),
-                               getBuffer<float>(_output));
-      }
-      break;
-    default:
-      throw std::runtime_error("LossLayer: unsupported loss type");
-  }
-}
-
-void LossLayer::backward()
-{
-  switch (_loss_type)
-  {
-    case LossType::kMSE:
-      if (_y_pred->data_type() == OperandType::FLOAT32)
-      {
-        nnfw::cker::train::MSEGrad(getShape(_y_pred), getBuffer<float>(_y_pred), getShape(_y_true),
-                                   getBuffer<float>(_y_true), getShape(_back_prop_y_pred),
-                                   getBuffer<float>(_back_prop_y_pred));
-      }
-      break;
-    default:
-      throw std::runtime_error("LossLayer: unsupported loss type");
-  }
 }
 
 } // namespace ops

--- a/runtime/onert/backend/train/ops/LossMeanSquaredErrorLayer.cc
+++ b/runtime/onert/backend/train/ops/LossMeanSquaredErrorLayer.cc
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "LossMeanSquaredErrorLayer.h"
+#include "OperationUtils.h"
+
+#include <cker/train/operation/Loss.h>
+
+namespace onert
+{
+namespace backend
+{
+namespace train
+{
+namespace ops
+{
+
+void LossMeanSquaredErrorLayer::configure(const IPortableTensor *y_pred,
+                                          const IPortableTensor *y_true, IPortableTensor *output,
+                                          IPortableTensor *back_prop_y_pred)
+{
+  LossLayer::configure(y_pred, y_true, output, back_prop_y_pred);
+}
+
+void LossMeanSquaredErrorLayer::forward(bool)
+{
+  // TODO Implement this
+  if (_y_pred->data_type() == OperandType::FLOAT32)
+  {
+    nnfw::cker::train::MSE(getShape(_y_pred), getBuffer<float>(_y_pred), getShape(_y_true),
+                           getBuffer<float>(_y_true), getShape(_output), getBuffer<float>(_output));
+  }
+  else
+  {
+    throw std::runtime_error("LossMeanSquaredErrorLayer: unsupported data type");
+  }
+}
+
+void LossMeanSquaredErrorLayer::backward()
+{
+  if (_y_pred->data_type() == OperandType::FLOAT32)
+  {
+    nnfw::cker::train::MSEGrad(getShape(_y_pred), getBuffer<float>(_y_pred), getShape(_y_true),
+                               getBuffer<float>(_y_true), getShape(_back_prop_y_pred),
+                               getBuffer<float>(_back_prop_y_pred));
+  }
+  else
+  {
+    throw std::runtime_error("LossMeanSquaredErrorLayer: unsupported data type");
+  }
+}
+
+} // namespace ops
+} // namespace train
+} // namespace backend
+} // namespace onert

--- a/runtime/onert/backend/train/ops/LossMeanSquaredErrorLayer.h
+++ b/runtime/onert/backend/train/ops/LossMeanSquaredErrorLayer.h
@@ -14,13 +14,10 @@
  * limitations under the License.
  */
 
-#ifndef __ONERT_BACKEND_TRAIN_OPS_LOSSLAYER_H__
-#define __ONERT_BACKEND_TRAIN_OPS_LOSSLAYER_H__
+#ifndef __ONERT_BACKEND_TRAIN_OPS_LOSS_MEANSQUAREDERROR_LAYER_H__
+#define __ONERT_BACKEND_TRAIN_OPS_LOSS_MEANSQUAREDERROR_LAYER_H__
 
-#include <backend/IPortableTensor.h>
-#include <ops/ElementwiseActivationLayer.h>
-
-#include <exec/train/ITrainableFunction.h>
+#include "LossLayer.h"
 
 namespace onert
 {
@@ -31,24 +28,15 @@ namespace train
 namespace ops
 {
 
-enum class LossType
-{
-  kMSE,
-};
-
-class LossLayer : public ::onert::exec::train::ITrainableFunction
+class LossMeanSquaredErrorLayer : public LossLayer
 {
 public:
-  LossLayer();
+  LossMeanSquaredErrorLayer() = default;
 
   void configure(const IPortableTensor *y_pred, const IPortableTensor *y_true,
                  IPortableTensor *output, IPortableTensor *back_prop_y_pred);
-
-protected:
-  const IPortableTensor *_y_pred;
-  const IPortableTensor *_y_true;
-  IPortableTensor *_output;
-  IPortableTensor *_back_prop_y_pred;
+  void forward(bool training) override;
+  void backward() override;
 };
 
 } // namespace ops
@@ -56,4 +44,4 @@ protected:
 } // namespace backend
 } // namespace onert
 
-#endif // __ONERT_BACKEND_TRAIN_OPS_LOSSLAYER_H__
+#endif // __ONERT_BACKEND_TRAIN_OPS_LOSS_MEANSQUAREDERROR_LAYER_H__


### PR DESCRIPTION
This commit introduces LossMeanSqauredErrorLayer in train backend. This code is from LossLayer. LossLayer becomes a base class and other loss types inherit LossLayer to implement each loss layer.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>