### PR TITLE
[luci] Introduce FuseMulWithConv

### DIFF
--- a/compiler/luci/pass/include/luci/CircleOptimizer.h
+++ b/compiler/luci/pass/include/luci/CircleOptimizer.h
@@ -44,6 +44,7 @@ public:
       FuseHorizontalFullyConnected,
       FuseInstanceNorm,
       FuseMeanWithMean,
+      FuseMulWithConv,
       FuseTransposeWithMean,
       ResolveCustomOpAdd,
       ResolveCustomOpBatchMatMul,

--- a/compiler/luci/pass/src/CircleOptimizer.cpp
+++ b/compiler/luci/pass/src/CircleOptimizer.cpp
@@ -38,6 +38,7 @@
 #include "luci/Pass/FuseBCQPass.h"
 #include "luci/Pass/FuseInstanceNormPass.h"
 #include "luci/Pass/FuseMeanWithMeanPass.h"
+#include "luci/Pass/FuseMulWithConvPass.h"
 #include "luci/Pass/FusePreActivationBatchNormPass.h"
 #include "luci/Pass/FusePReluPass.h"
 #include "luci/Pass/FuseGeluPass.h"
@@ -264,6 +265,10 @@ void CircleOptimizer::optimize(loco::Graph *g) const
   if (_options->query(Options::Algorithm::FuseMeanWithMean))
   {
     phase.emplace_back(std::make_unique<FuseMeanWithMeanPass>());
+  }
+  if (_options->query(Options::Algorithm::FuseMulWithConv))
+  {
+    phase.emplace_back(std::make_unique<FuseMulWithConvPass>());
   }
   if (_options->query(Options::Algorithm::ResolveCustomOpMaxPoolWithArgmax))
   {


### PR DESCRIPTION
This commit introduces FuseMulWithConv option.

Its correctness is tested in https://github.com/Samsung/ONE/pull/11991.

Draft: https://github.com/Samsung/ONE/pull/11991
Related: https://github.com/Samsung/ONE/issues/11897

ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>