### PR TITLE
[dio-hdf5] Revisit HDF5Importer

### DIFF
--- a/compiler/dio-hdf5/include/dio_hdf5/HDF5Importer.h
+++ b/compiler/dio-hdf5/include/dio_hdf5/HDF5Importer.h
@@ -61,16 +61,16 @@ public:
    * @param buffer_bytes : byte size of the buffer
    */
   void readTensor(int32_t data_idx, int32_t input_idx, loco::DataType *dtype,
-                  std::vector<loco::Dimension> *shape, void *buffer, size_t buffer_bytes);
+                  std::vector<loco::Dimension> *shape, void *buffer, size_t buffer_bytes) const;
 
   // Read a raw tensor (no type/shape is specified)
-  void readTensor(int32_t data_idx, int32_t input_idx, void *buffer, size_t buffer_bytes);
+  void readTensor(int32_t data_idx, int32_t input_idx, void *buffer, size_t buffer_bytes) const;
 
-  bool isRawData() { return _group.attrExists("rawData"); }
+  bool isRawData() const { return _group.attrExists("rawData"); }
 
-  int32_t numData() { return _group.getNumObjs(); }
+  int32_t numData() const { return _group.getNumObjs(); }
 
-  int32_t numInputs(int32_t data_idx);
+  int32_t numInputs(int32_t data_idx) const;
 
 private:
   H5::H5File _file;

--- a/compiler/dio-hdf5/src/HDF5Importer.cpp
+++ b/compiler/dio-hdf5/src/HDF5Importer.cpp
@@ -122,14 +122,14 @@ HDF5Importer::HDF5Importer(const std::string &path)
   _file = H5::H5File(path, H5F_ACC_RDONLY);
 }
 
-int32_t HDF5Importer::numInputs(int32_t record_idx)
+int32_t HDF5Importer::numInputs(int32_t record_idx) const
 {
   auto records = _group.openGroup(std::to_string(record_idx));
   return records.getNumObjs();
 }
 
 void HDF5Importer::readTensor(int32_t record_idx, int32_t input_idx, void *buffer,
-                              size_t buffer_bytes)
+                              size_t buffer_bytes) const
 {
   auto record = _group.openGroup(std::to_string(record_idx));
   auto tensor = record.openDataSet(std::to_string(input_idx));
@@ -141,7 +141,7 @@ void HDF5Importer::readTensor(int32_t record_idx, int32_t input_idx, void *buffe
 }
 
 void HDF5Importer::readTensor(int32_t record_idx, int32_t input_idx, DataType *dtype, Shape *shape,
-                              void *buffer, size_t buffer_bytes)
+                              void *buffer, size_t buffer_bytes) const
 {
   auto record = _group.openGroup(std::to_string(record_idx));
   auto tensor = record.openDataSet(std::to_string(input_idx));


### PR DESCRIPTION
This commit declares methods of HDF5Importer as const where it's possible.

Draft: #11849
Related: #11374 

ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>