### PR TITLE
[luci-interpreter] Add Op type for "Unsupported type" msg

### DIFF
--- a/compiler/luci-interpreter/src/kernels/Abs.cpp
+++ b/compiler/luci-interpreter/src/kernels/Abs.cpp
@@ -42,7 +42,7 @@ void Abs::execute() const
       eval<float>();
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp Abs Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/Add.cpp
+++ b/compiler/luci-interpreter/src/kernels/Add.cpp
@@ -70,7 +70,7 @@ void Add::execute() const
       evalQuantizedS16();
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp Add Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/AveragePool2D.cpp
+++ b/compiler/luci-interpreter/src/kernels/AveragePool2D.cpp
@@ -99,7 +99,7 @@ void AveragePool2D::execute() const
       evalSInt8();
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp AveragePool2D Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/BatchMatMul.cpp
+++ b/compiler/luci-interpreter/src/kernels/BatchMatMul.cpp
@@ -58,7 +58,7 @@ void BatchMatMul::configure()
 
   // TODO Support non-float types
   if (lhs->element_type() != DataType::FLOAT32 || rhs->element_type() != DataType::FLOAT32)
-    throw std::runtime_error("Unsupported type.");
+    throw std::runtime_error("luci-intp BatchMatMul(1) Unsupported type.");
 
   LUCI_INTERPRETER_CHECK(lhs->element_type() == rhs->element_type());
 
@@ -180,7 +180,7 @@ void BatchMatMul::execute() const
                                         getTensorData<float>(output()));
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp BatchMatMul(2) Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/BatchToSpaceND.cpp
+++ b/compiler/luci-interpreter/src/kernels/BatchToSpaceND.cpp
@@ -96,7 +96,7 @@ void BatchToSpaceND::execute() const
         getTensorData<uint8_t>(output()));
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp BatchToSpaceND Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/Concatenation.cpp
+++ b/compiler/luci-interpreter/src/kernels/Concatenation.cpp
@@ -107,7 +107,7 @@ void Concatenation::execute() const
       evalGeneric<int64_t>();
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp Concatenation Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/Conv2D.cpp
+++ b/compiler/luci-interpreter/src/kernels/Conv2D.cpp
@@ -75,7 +75,7 @@ void Conv2D::configure()
   }
   else
   {
-    throw std::runtime_error("Unsupported type.");
+    throw std::runtime_error("luci-intp Conv2D(1) Unsupported type.");
   }
   LUCI_INTERPRETER_CHECK(output()->element_type() == input()->element_type());
 
@@ -143,7 +143,7 @@ void Conv2D::execute() const
         evalFloat();
         break;
       }
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp Conv2D(2) Unsupported type.");
     case DataType::U8:
       if (filter()->scales().size() == 1)
       {
@@ -164,7 +164,7 @@ void Conv2D::execute() const
       evalQuantizedS16();
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp Conv2D(3) Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/Cos.cpp
+++ b/compiler/luci-interpreter/src/kernels/Cos.cpp
@@ -57,7 +57,7 @@ void Cos::execute() const
       evalFloat();
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp Cos Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/CumSum.cpp
+++ b/compiler/luci-interpreter/src/kernels/CumSum.cpp
@@ -51,7 +51,7 @@ void CumSum::execute() const
                                     params().reverse, getTensorData<float>(output()));
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp CumSum Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/DepthToSpace.cpp
+++ b/compiler/luci-interpreter/src/kernels/DepthToSpace.cpp
@@ -72,7 +72,7 @@ void DepthToSpace::execute() const
                                          getTensorData<uint8_t>(output()));
       break;
     default:
-      throw std::runtime_error("Unsupported Type.");
+      throw std::runtime_error("luci-intp DepthToSpace Unsupported Type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/DepthwiseConv2D.cpp
+++ b/compiler/luci-interpreter/src/kernels/DepthwiseConv2D.cpp
@@ -75,7 +75,7 @@ void DepthwiseConv2D::configure()
   }
   else
   {
-    throw std::runtime_error("Unsupported type.");
+    throw std::runtime_error("luci-intp DepthwiseConv2D(1) Unsupported type.");
   }
   LUCI_INTERPRETER_CHECK(output()->element_type() == input()->element_type());
 
@@ -130,7 +130,7 @@ void DepthwiseConv2D::execute() const
         evalFloat();
         break;
       }
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp DepthwiseConv2D(2) Unsupported type.");
     case DataType::U8:
       if (filter()->scales().size() == 1)
       {
@@ -151,7 +151,7 @@ void DepthwiseConv2D::execute() const
       evalQuantizedS16();
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp DepthwiseConv2D(3) Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/Dequantize.cpp
+++ b/compiler/luci-interpreter/src/kernels/Dequantize.cpp
@@ -71,7 +71,7 @@ void Dequantize::execute() const
       break;
     }
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp Dequantize Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/Div.cpp
+++ b/compiler/luci-interpreter/src/kernels/Div.cpp
@@ -56,7 +56,7 @@ void Div::execute() const
       evalQuantized();
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp Div Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/Elu.cpp
+++ b/compiler/luci-interpreter/src/kernels/Elu.cpp
@@ -44,7 +44,7 @@ void Elu::execute() const
                                 getTensorShape(output()), getTensorData<float>(output()));
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp Elu Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/Equal.cpp
+++ b/compiler/luci-interpreter/src/kernels/Equal.cpp
@@ -59,7 +59,7 @@ void Equal::execute() const
       evalQuantized();
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp Equal Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/Exp.cpp
+++ b/compiler/luci-interpreter/src/kernels/Exp.cpp
@@ -42,7 +42,7 @@ void Exp::execute() const
       evalFloat();
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp Exp Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/ExpandDims.cpp
+++ b/compiler/luci-interpreter/src/kernels/ExpandDims.cpp
@@ -40,7 +40,7 @@ void ExpandDims::configure()
       axis_value = static_cast<int32_t>(*getTensorData<int64_t>(axis()));
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp ExpandDims Unsupported type.");
   }
 
   const auto input_shape = input()->shape();

--- a/compiler/luci-interpreter/src/kernels/Fill.cpp
+++ b/compiler/luci-interpreter/src/kernels/Fill.cpp
@@ -80,7 +80,7 @@ void Fill::configure()
       configureShape<int64_t>();
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp Fill(1) Unsupported type.");
   }
 }
 
@@ -109,7 +109,7 @@ void Fill::execute() const
                                   getTensorShape(output()), getTensorData<float>(output()));
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp Fill(2) Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/Floor.cpp
+++ b/compiler/luci-interpreter/src/kernels/Floor.cpp
@@ -43,7 +43,7 @@ void Floor::execute() const
       break;
 
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp Floor Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/FloorDiv.cpp
+++ b/compiler/luci-interpreter/src/kernels/FloorDiv.cpp
@@ -48,7 +48,7 @@ void FloorDiv::execute() const
       evalFloat();
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp FloorDiv Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/FloorMod.cpp
+++ b/compiler/luci-interpreter/src/kernels/FloorMod.cpp
@@ -75,7 +75,7 @@ void FloorMod::execute() const
       evalInteger<int64_t>();
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp FloorMod Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/FullyConnected.cpp
+++ b/compiler/luci-interpreter/src/kernels/FullyConnected.cpp
@@ -56,7 +56,7 @@ void FullyConnected::configure()
   }
   else
   {
-    throw std::runtime_error("Unsupported type.");
+    throw std::runtime_error("luci-intp FullyConnected(1) Unsupported type.");
   }
 
   const Shape &input_shape = input()->shape();
@@ -101,7 +101,7 @@ void FullyConnected::execute() const
       evalFloat();
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp FullyConnected(2) Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/Gather.cpp
+++ b/compiler/luci-interpreter/src/kernels/Gather.cpp
@@ -42,7 +42,7 @@ void Gather::configure()
   }
   else
   {
-    throw std::runtime_error("Unsupported type.");
+    throw std::runtime_error("luci-intp Gather(1) Unsupported type.");
   }
 
   LUCI_INTERPRETER_CHECK(indices()->element_type() == DataType::S32 ||
@@ -102,7 +102,7 @@ void Gather::execute() const
       evalFloat();
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp Gather(2) Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/Gelu.cpp
+++ b/compiler/luci-interpreter/src/kernels/Gelu.cpp
@@ -48,7 +48,7 @@ void Gelu::execute() const
       evalFloat();
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp Gelu Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/Greater.cpp
+++ b/compiler/luci-interpreter/src/kernels/Greater.cpp
@@ -59,7 +59,7 @@ void Greater::execute() const
       evalQuantized();
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp Greather Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/GreaterEqual.cpp
+++ b/compiler/luci-interpreter/src/kernels/GreaterEqual.cpp
@@ -62,7 +62,7 @@ void GreaterEqual::execute() const
       evalQuantized();
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp GreaterEqual Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/HardSwish.cpp
+++ b/compiler/luci-interpreter/src/kernels/HardSwish.cpp
@@ -44,7 +44,7 @@ void HardSwish::execute() const
                                       getTensorShape(output()), getTensorData<float>(output()));
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp HardSwish Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/InstanceNorm.cpp
+++ b/compiler/luci-interpreter/src/kernels/InstanceNorm.cpp
@@ -55,7 +55,7 @@ void InstanceNorm::execute() const
       evalFloat();
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp InstanceNorm Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/L2Normalize.cpp
+++ b/compiler/luci-interpreter/src/kernels/L2Normalize.cpp
@@ -58,7 +58,7 @@ void L2Normalize::execute() const
       eval<uint8_t>(input()->zero_point());
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp L2Normalize Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/L2Pool2D.cpp
+++ b/compiler/luci-interpreter/src/kernels/L2Pool2D.cpp
@@ -80,7 +80,7 @@ void L2Pool2D::execute() const
                                    getTensorData<float>(output()));
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp L2Pool2D Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/LeakyRelu.cpp
+++ b/compiler/luci-interpreter/src/kernels/LeakyRelu.cpp
@@ -59,7 +59,7 @@ void LeakyRelu::execute() const
       evalQuantized();
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp LeakyRelu Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/Less.cpp
+++ b/compiler/luci-interpreter/src/kernels/Less.cpp
@@ -59,7 +59,7 @@ void Less::execute() const
       evalQuantized();
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp Less Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/LessEqual.cpp
+++ b/compiler/luci-interpreter/src/kernels/LessEqual.cpp
@@ -59,7 +59,7 @@ void LessEqual::execute() const
       evalQuantized();
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp LessEqual Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/LocalResponseNormalization.cpp
+++ b/compiler/luci-interpreter/src/kernels/LocalResponseNormalization.cpp
@@ -57,7 +57,7 @@ void LocalResponseNormalization::execute() const
         getTensorData<float>(output()));
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp LocalResponseNormalizartion Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/Log.cpp
+++ b/compiler/luci-interpreter/src/kernels/Log.cpp
@@ -37,7 +37,7 @@ void Log::execute() const
       evalFloat();
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp Log Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/LogSoftmax.cpp
+++ b/compiler/luci-interpreter/src/kernels/LogSoftmax.cpp
@@ -57,7 +57,7 @@ void LogSoftmax::execute() const
       evalQuantized();
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp LogSoftmax Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/LogicalAnd.cpp
+++ b/compiler/luci-interpreter/src/kernels/LogicalAnd.cpp
@@ -46,7 +46,7 @@ void LogicalAnd::execute() const
       evalLogicalAnd();
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp LogicalAnd Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/LogicalNot.cpp
+++ b/compiler/luci-interpreter/src/kernels/LogicalNot.cpp
@@ -41,7 +41,7 @@ void LogicalNot::execute() const
       evalLogicalNot();
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp LogicalNot Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/Logistic.cpp
+++ b/compiler/luci-interpreter/src/kernels/Logistic.cpp
@@ -49,7 +49,7 @@ void Logistic::execute() const
       evalQuantized();
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp Logistic Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/MaxPool2D.cpp
+++ b/compiler/luci-interpreter/src/kernels/MaxPool2D.cpp
@@ -81,7 +81,7 @@ void MaxPool2D::execute() const
       evalSInt16();
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp MaxPool2D Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/Maximum.cpp
+++ b/compiler/luci-interpreter/src/kernels/Maximum.cpp
@@ -49,7 +49,7 @@ void Maximum::execute() const
       evalMaximum<uint8_t>();
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp Maximum Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/Mean.cpp
+++ b/compiler/luci-interpreter/src/kernels/Mean.cpp
@@ -190,7 +190,7 @@ void Mean::execute() const
       evalQuantizedS16();
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp Mean Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/Minimum.cpp
+++ b/compiler/luci-interpreter/src/kernels/Minimum.cpp
@@ -49,7 +49,7 @@ void Minimum::execute() const
       evalMinimum<uint8_t>();
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp Minimum Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/MirrorPad.cpp
+++ b/compiler/luci-interpreter/src/kernels/MirrorPad.cpp
@@ -82,7 +82,7 @@ void MirrorPad::execute() const
       break;
     }
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp MirrorPad Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/Mul.cpp
+++ b/compiler/luci-interpreter/src/kernels/Mul.cpp
@@ -68,7 +68,7 @@ void Mul::execute() const
       evalQuantizedS16();
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp Mul Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/Neg.cpp
+++ b/compiler/luci-interpreter/src/kernels/Neg.cpp
@@ -44,7 +44,7 @@ void Neg::execute() const
       evalFloat();
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp Neg Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/NotEqual.cpp
+++ b/compiler/luci-interpreter/src/kernels/NotEqual.cpp
@@ -59,7 +59,7 @@ void NotEqual::execute() const
       evalQuantized();
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp NotEqual Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/PRelu.cpp
+++ b/compiler/luci-interpreter/src/kernels/PRelu.cpp
@@ -103,7 +103,7 @@ void PRelu::execute() const
       evalQuantizedS16();
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp PRelu Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/Pack.cpp
+++ b/compiler/luci-interpreter/src/kernels/Pack.cpp
@@ -48,7 +48,7 @@ void Pack::configure()
       t0->element_type() != DataType::U8 && t0->element_type() != DataType::S8 &&
       t0->element_type() != DataType::S16 && t0->element_type() != DataType::S64)
   {
-    throw std::runtime_error("Unsupported type.");
+    throw std::runtime_error("luci-intp Pack(1) Unsupported type.");
   }
 
   for (uint32_t i = 1; i < _inputs.size(); ++i)
@@ -116,7 +116,7 @@ void Pack::execute() const
       evalGeneric<int64_t>();
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp Pack(2) Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/Pad.cpp
+++ b/compiler/luci-interpreter/src/kernels/Pad.cpp
@@ -106,7 +106,7 @@ void Pad::execute() const
       break;
     }
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp Pad Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/PadV2.cpp
+++ b/compiler/luci-interpreter/src/kernels/PadV2.cpp
@@ -100,7 +100,7 @@ void PadV2::execute() const
       break;
     }
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp PadV2 Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/Pow.cpp
+++ b/compiler/luci-interpreter/src/kernels/Pow.cpp
@@ -50,7 +50,7 @@ void Pow::execute() const
       eval<int32_t>();
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp Pow Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/Quantize.cpp
+++ b/compiler/luci-interpreter/src/kernels/Quantize.cpp
@@ -132,7 +132,7 @@ void Quantize::execute() const
           break;
         }
         default:
-          throw std::runtime_error("Unsupported type.");
+          throw std::runtime_error("luci-intp Quantize(1) Unsupported type.");
       }
       break;
     }
@@ -152,7 +152,7 @@ void Quantize::execute() const
       break;
     }
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp Quantize(2) Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/ReduceMax.cpp
+++ b/compiler/luci-interpreter/src/kernels/ReduceMax.cpp
@@ -151,7 +151,7 @@ void ReduceMax::execute() const
       break;
     // TODO Support quantized kernels
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp ReduceMax Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/ReduceProd.cpp
+++ b/compiler/luci-interpreter/src/kernels/ReduceProd.cpp
@@ -150,7 +150,7 @@ void ReduceProd::execute() const
       break;
     // TODO Support quantized kernels
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp ReduceProd Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/Relu.cpp
+++ b/compiler/luci-interpreter/src/kernels/Relu.cpp
@@ -59,7 +59,7 @@ void Relu::execute() const
       evalQuantizedS16();
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp Relu Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/Relu6.cpp
+++ b/compiler/luci-interpreter/src/kernels/Relu6.cpp
@@ -52,7 +52,7 @@ void Relu6::execute() const
       evalQuantized();
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp Relu6 Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/ResizeBilinear.cpp
+++ b/compiler/luci-interpreter/src/kernels/ResizeBilinear.cpp
@@ -66,7 +66,7 @@ void ResizeBilinear::execute() const
         getTensorData<int32_t>(size()), getTensorShape(output()), getTensorData<uint8_t>(output()));
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp ResizeBilinear Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/ResizeNearestNeighbor.cpp
+++ b/compiler/luci-interpreter/src/kernels/ResizeNearestNeighbor.cpp
@@ -66,7 +66,7 @@ void ResizeNearestNeighbor::execute() const
         getTensorData<int32_t>(size()), getTensorShape(output()), getTensorData<uint8_t>(output()));
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp ResizeNearestNeighbor Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/Rsqrt.cpp
+++ b/compiler/luci-interpreter/src/kernels/Rsqrt.cpp
@@ -46,7 +46,7 @@ void Rsqrt::execute() const
       break;
 
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp Rsqrt Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/SVDF.cpp
+++ b/compiler/luci-interpreter/src/kernels/SVDF.cpp
@@ -84,7 +84,7 @@ void SVDF::configure()
   }
   else
   {
-    throw std::runtime_error("Unsupported type.");
+    throw std::runtime_error("luci-intp SVDF Unsupported type.");
   }
 
   // Check all the parameters of tensor match within themselves and match the

--- a/compiler/luci-interpreter/src/kernels/Select.cpp
+++ b/compiler/luci-interpreter/src/kernels/Select.cpp
@@ -64,7 +64,7 @@ void Select::execute() const
       evalFloat();
       break;
     default:
-      throw std::runtime_error("Select: unsupported type.");
+      throw std::runtime_error("luci-intp Select unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/Shape.cpp
+++ b/compiler/luci-interpreter/src/kernels/Shape.cpp
@@ -50,7 +50,7 @@ void ShapeKernel::execute() const
       evalInt<int64_t>();
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp Shape Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/Sin.cpp
+++ b/compiler/luci-interpreter/src/kernels/Sin.cpp
@@ -57,7 +57,7 @@ void Sin::execute() const
       evalFloat();
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp Sin Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/Slice.cpp
+++ b/compiler/luci-interpreter/src/kernels/Slice.cpp
@@ -90,7 +90,7 @@ void Slice::configure()
   }
   else
   {
-    throw std::runtime_error("Unsupported type.");
+    throw std::runtime_error("luci-intp Slice Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/Softmax.cpp
+++ b/compiler/luci-interpreter/src/kernels/Softmax.cpp
@@ -64,7 +64,7 @@ void Softmax::execute() const
       evalQuantized<uint8_t>();
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp Softmax Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/SpaceToBatchND.cpp
+++ b/compiler/luci-interpreter/src/kernels/SpaceToBatchND.cpp
@@ -95,7 +95,7 @@ void SpaceToBatchND::execute() const
         getTensorData<uint8_t>(output()));
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp ShapeToBatchND Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/SpaceToDepth.cpp
+++ b/compiler/luci-interpreter/src/kernels/SpaceToDepth.cpp
@@ -71,7 +71,7 @@ void SpaceToDepth::execute() const
                                          getTensorData<uint8_t>(output()));
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp SpaceToDepth Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/Split.cpp
+++ b/compiler/luci-interpreter/src/kernels/Split.cpp
@@ -72,7 +72,7 @@ void Split::execute() const
       TF_LITE_SPLIT(uint8_t);
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp Split Unsupported type.");
   }
 #undef TF_LITE_SPLIT
 }

--- a/compiler/luci-interpreter/src/kernels/SplitV.cpp
+++ b/compiler/luci-interpreter/src/kernels/SplitV.cpp
@@ -102,7 +102,7 @@ void SplitV::execute() const
       TF_LITE_SPLIT(int16_t);
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp SplitV Unsupported type.");
   }
 #undef TF_LITE_SPLIT
 }

--- a/compiler/luci-interpreter/src/kernels/Sqrt.cpp
+++ b/compiler/luci-interpreter/src/kernels/Sqrt.cpp
@@ -46,7 +46,7 @@ void Sqrt::execute() const
       break;
 
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp Sqrt Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/Square.cpp
+++ b/compiler/luci-interpreter/src/kernels/Square.cpp
@@ -46,7 +46,7 @@ void Square::execute() const
       break;
 
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp Square Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/SquaredDifference.cpp
+++ b/compiler/luci-interpreter/src/kernels/SquaredDifference.cpp
@@ -46,7 +46,7 @@ void SquaredDifference::execute() const
       evalSquaredDifference<float>();
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp SquaredDifference Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/StridedSlice.cpp
+++ b/compiler/luci-interpreter/src/kernels/StridedSlice.cpp
@@ -142,7 +142,7 @@ void StridedSlice::execute() const
                                           getTensorData<int32_t>(output()));
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp StridedSlice Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/Sub.cpp
+++ b/compiler/luci-interpreter/src/kernels/Sub.cpp
@@ -58,7 +58,7 @@ void Sub::execute() const
       evalQuantized();
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp Sub Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/Sum.cpp
+++ b/compiler/luci-interpreter/src/kernels/Sum.cpp
@@ -149,7 +149,7 @@ void Sum::execute() const
       evalFloat();
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp Sum Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/Tanh.cpp
+++ b/compiler/luci-interpreter/src/kernels/Tanh.cpp
@@ -49,7 +49,7 @@ void Tanh::execute() const
       evalQuantized();
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp Tanh Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/Tile.cpp
+++ b/compiler/luci-interpreter/src/kernels/Tile.cpp
@@ -54,7 +54,7 @@ void Tile::execute() const
       evalFloat();
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp Tile Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/Transpose.cpp
+++ b/compiler/luci-interpreter/src/kernels/Transpose.cpp
@@ -76,7 +76,7 @@ void Transpose::execute() const
                                        getTensorData<uint8_t>(output()));
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp Transpose Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/TransposeConv.cpp
+++ b/compiler/luci-interpreter/src/kernels/TransposeConv.cpp
@@ -115,7 +115,7 @@ void TransposeConv::execute() const
       evalQuantizedS16();
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp TransposeConv Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/Unpack.cpp
+++ b/compiler/luci-interpreter/src/kernels/Unpack.cpp
@@ -76,7 +76,7 @@ void Unpack::execute() const
     case DataType::U8:
       return executeImpl<uint8_t>();
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp Unpack Unsupported type.");
   }
 }
 

--- a/compiler/luci-interpreter/src/kernels/Utils.cpp
+++ b/compiler/luci-interpreter/src/kernels/Utils.cpp
@@ -139,7 +139,7 @@ void calculateActivationRangeQuantized(Activation activation, const Tensor *outp
       qmax = std::numeric_limits<int16_t>::max();
       break;
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp (calculateActivationRangeQuantized) Unsupported type.");
   }
 
   calculateActivationRangeQuantizedImpl(activation, qmin, qmax, output, activation_min,

--- a/compiler/luci-interpreter/src/loader/GraphLoader.cpp
+++ b/compiler/luci-interpreter/src/loader/GraphLoader.cpp
@@ -69,7 +69,7 @@ const void *getNodeData(const luci::CircleConst *node, size_t *data_size)
     case DataType::BOOL:
       return getNodeDataImpl<DataType::BOOL>(node, data_size);
     default:
-      throw std::runtime_error("Unsupported type.");
+      throw std::runtime_error("luci-intp (getNodeData) Unsupported type.");
   }
 }
 


### PR DESCRIPTION
This will revise to show it is from luci-interpreter with Op type for "Unsupported type." error message.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>