### PR TITLE
[onert] Change OperationDumper's FullyConnected

### DIFF
--- a/runtime/onert/core/src/ir/OperationDumper.cc
+++ b/runtime/onert/core/src/ir/OperationDumper.cc
@@ -166,10 +166,11 @@ void OperationDumper::visit(const Fill &node)
 
 void OperationDumper::visit(const FullyConnected &node)
 {
-  std::string inputs =
-    "Weight(" + std::to_string(node.getInputs().at(FullyConnected::Input::WEIGHT).value()) +
-    ") Bias(" + std::to_string(node.getInputs().at(FullyConnected::Input::BIAS).value()) + ")";
-  dumpUnaryInputOp(node, inputs);
+  VERBOSE(LIR) << "* " << node.name() << std::endl;
+  VERBOSE(LIR) << "  - Inputs : Input(" << node.getInputs().at(ArgMinMax::INPUT) << ") Weight("
+               << node.getInputs().at(FullyConnected::Input::WEIGHT) << ") Bias("
+               << node.getInputs().at(FullyConnected::Input::BIAS) << ")" << std::endl;
+  VERBOSE(LIR) << "  - Output : Output(" << node.getOutputs().at(0) << ")" << std::endl;
 }
 
 void OperationDumper::visit(const Gather &node)


### PR DESCRIPTION
It prints Operands using operator<<, it shows `undefined` with decorated form instead of uint_max.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

.......................................................................................

For Reviewers,

```
$ BACKENDS=cpu ONERT_LOG_ENABLE=1 Product/x86_64-linux.debug/out/bin/onert_run mnist.circle
```

### BEFORE
```
[       LIR      ] Executor generation of Subgraph 0
[       LIR      ] * FullyConnected
[       LIR      ]   - Inputs : Input(%0) Weight(7) Bias(4294967295)
[       LIR      ]   - Output : Output(%4)
[       LIR      ] * FullyConnected
[       LIR      ]   - Inputs : Input(%4) Weight(8) Bias(4294967295)
[       LIR      ]   - Output : Output(%5)
[       LIR      ] * FullyConnected
[       LIR      ]   - Inputs : Input(%5) Weight(9) Bias(4294967295)
[       LIR      ]   - Output : Output(%11)
```

### AFTER
```
[       LIR      ] Executor generation of Subgraph 0
[       LIR      ] * FullyConnected
[       LIR      ]   - Inputs : Input(%0) Weight(%7) Bias(%?)
[       LIR      ]   - Output : Output(%4)
[       LIR      ] * FullyConnected
[       LIR      ]   - Inputs : Input(%4) Weight(%8) Bias(%?)
[       LIR      ]   - Output : Output(%5)
[       LIR      ] * FullyConnected
[       LIR      ]   - Inputs : Input(%5) Weight(%9) Bias(%?)
[       LIR      ]   - Output : Output(%11)
```