### PR TITLE
[onert] Replace constant when its use count >= 2

### DIFF
--- a/runtime/onert/core/src/compiler/pass/ConstantInsertionPass.cc
+++ b/runtime/onert/core/src/compiler/pass/ConstantInsertionPass.cc
@@ -39,7 +39,7 @@ void ConstantInsertionPass::callback(const ir::OperationIndex &node_index, ir::I
   {
     auto &object = _graph.operands().at(input);
 
-    if (object.isConstant())
+    if (object.isConstant() && object.getUses().size() >= 2)
     {
       const auto key = ReplaceKey{input, factor};
       if (_replace_operands_map.count(key) == 0)


### PR DESCRIPTION
It does not replace constant operands if it has single use or no use.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

.......................................................................

For Reviewers,

```
$ BACKENDS=cpu ONERT_LOG_ENABLE=1 Product/x86_64-linux.debug/out/bin/onert_run mnist.circle
```

`%1,%2,%3` are corresponding to FullyConnected's weights.
They don't need to be replaced to `%7,%8,%9`.

### BEFORE
```
[  LoweredGraph  ] dump before mandatory passes
[   GraphDumper  ] {
[   GraphDumper  ]   %4 = @0_FullyConnected(%0, %1, %?)
[   GraphDumper  ]   %5 = @1_FullyConnected(%4, %2, %?)
[   GraphDumper  ]   %6 = @2_FullyConnected(%5, %3, %?)
[   GraphDumper  ] }
[   PassRunner   ] Start running 'ConstantInsertionPass'
[ ConstInsertPass] New operand %7 added(copy of %1) for (cpu/NHWC)
[ ConstInsertPass] Original operand %1 removed - no uses
[ ConstInsertPass] New operand %8 added(copy of %2) for (cpu/NHWC)
[ ConstInsertPass] Original operand %2 removed - no uses
[ ConstInsertPass] New operand %9 added(copy of %3) for (cpu/NHWC)
[ ConstInsertPass] Original operand %3 removed - no uses
...
[  LoweredGraph  ] Dump after all the passes
[  LoweredGraph  ] Graph Input : %0
[  LoweredGraph  ] Graph Output : %11
[   GraphDumper  ] {
[   GraphDumper  ]   %4 = @0_FullyConnected(%0, %7, %?)
[   GraphDumper  ]   %5 = @1_FullyConnected(%4, %8, %?)
[   GraphDumper  ]   %11 = @2_FullyConnected(%5, %9, %?)
[   GraphDumper  ] }
```

### AFTER
```
[  LoweredGraph  ] dump before mandatory passes
[   GraphDumper  ] {
[   GraphDumper  ]   %4 = @0_FullyConnected(%0, %1, %?)
[   GraphDumper  ]   %5 = @1_FullyConnected(%4, %2, %?)
[   GraphDumper  ]   %6 = @2_FullyConnected(%5, %3, %?)
[   GraphDumper  ] }
[   PassRunner   ] Start running 'ConstantInsertionPass'
[   PassRunner   ] Finished running 'ConstantInsertionPass'
...
[  LoweredGraph  ] Dump after all the passes
[  LoweredGraph  ] Graph Input : %0
[  LoweredGraph  ] Graph Output : %8
[   GraphDumper  ] {
[   GraphDumper  ]   %4 = @0_FullyConnected(%0, %1, %?)
[   GraphDumper  ]   %5 = @1_FullyConnected(%4, %2, %?)
[   GraphDumper  ]   %8 = @2_FullyConnected(%5, %3, %?)
[   GraphDumper  ] }
```