### PR TITLE
[onert] Define LossCode and LossInfo as separated files

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -1186,14 +1186,14 @@ NNFW_STATUS nnfw_session::train_prepare(const nnfw_train_info *info)
 
     auto convertLossType = [](const int &type) {
       if (type == NNFW_TRAIN_LOSS_MEAN_SQUARED_ERROR)
-        return onert::ir::operation::Loss::Type::MEAN_SQUARED_ERROR;
+        return onert::ir::train::LossCode::MeanSquaredError;
       if (type == NNFW_TRAIN_LOSS_CATEGORICAL_CROSSENTROPY)
-        return onert::ir::operation::Loss::Type::CATEGORICAL_CROSSENTROPY;
+        return onert::ir::train::LossCode::CategoricalCrossentropy;
       else
         throw std::runtime_error("not supported loss type");
     };
-    onert::compiler::train::LossInfo loss_info;
-    loss_info.type = convertLossType(tinfo.loss);
+    onert::ir::train::LossInfo loss_info;
+    loss_info.loss_code = convertLossType(tinfo.loss);
 
     auto convertOptType = [](const int &type) {
       if (type == NNFW_TRAIN_OPTIMIZER_SGD)

--- a/runtime/onert/backend/train/KernelGenerator.cc
+++ b/runtime/onert/backend/train/KernelGenerator.cc
@@ -242,18 +242,18 @@ void KernelGenerator::visit(const ir::train::operation::Loss &node)
 
   auto back_prop_y_pred_tensor = _tensor_reg->getBackPropTensor(y_pred_index);
 
-  auto op_type = node.param().op_type;
+  auto loss_code = node.param().loss_code;
 
-  switch (op_type)
+  switch (loss_code)
   {
-    case ir::operation::Loss::Type::MEAN_SQUARED_ERROR:
+    case ir::train::LossCode::MeanSquaredError:
     {
       auto fn = std::make_unique<ops::LossMeanSquaredErrorLayer>();
       fn->configure(y_pred_tensor, y_true_tensor, output_tensor, back_prop_y_pred_tensor);
       _return_fn = std::move(fn);
       break;
     }
-    case ir::operation::Loss::Type::CATEGORICAL_CROSSENTROPY:
+    case ir::train::LossCode::CategoricalCrossentropy:
     default:
       throw std::runtime_error("LossLayer: unsupported loss type");
       break;

--- a/runtime/onert/core/include/compiler/train/TrainingInfo.h
+++ b/runtime/onert/core/include/compiler/train/TrainingInfo.h
@@ -18,7 +18,7 @@
 #define __ONERT_COMPILER_TRAIN_TRAINING_INFO_H__
 
 #include "ir/Index.h"
-#include "ir/operation/Loss.h"
+#include "ir/train/LossInfo.h"
 #include "ir/train/OptimizerCode.h"
 #include "ir/train/OptimizerInfo.h"
 
@@ -28,12 +28,6 @@ namespace compiler
 {
 namespace train
 {
-
-struct LossInfo
-{
-  ir::operation::Loss::Type type;
-  // TODO Add members for loss
-};
 
 class TrainingInfo
 {
@@ -47,8 +41,8 @@ public:
 
   uint32_t batchSize() const { return _batch_size; }
   void setBatchSize(const uint32_t batch_size) { _batch_size = batch_size; }
-  const LossInfo &lossInfo() const { return _loss_info; }
-  void setLossInfo(const LossInfo &loss_info) { _loss_info = loss_info; }
+  const ir::train::LossInfo &lossInfo() const { return _loss_info; }
+  void setLossInfo(const ir::train::LossInfo &loss_info) { _loss_info = loss_info; }
   const ir::train::OptimizerInfo &optimizerInfo() const { return _optimizer_info; }
   void setOptimizerInfo(const ir::train::OptimizerInfo &optimizer_info)
   {
@@ -56,7 +50,7 @@ public:
   }
 
 private:
-  LossInfo _loss_info{ir::operation::Loss::Type::MEAN_SQUARED_ERROR};
+  ir::train::LossInfo _loss_info{ir::train::LossCode::Invalid};
   ir::train::OptimizerInfo _optimizer_info{ir::train::OptimizerCode::Invalid, 0};
   uint32_t _batch_size = 0;
 };

--- a/runtime/onert/core/include/ir/operation/Loss.h
+++ b/runtime/onert/core/include/ir/operation/Loss.h
@@ -36,35 +36,12 @@ public:
     // TODO Add more inputs if necessary
   };
 
-  // NOTE It is not yet determined how to get the information of the previous activation when
-  //      generating kernels of Loss operation for each backend. If it is determined to get it
-  //      from the object of this class, we have to consider whether to change this enum class.
-  enum class Type
-  {
-    MEAN_SQUARED_ERROR,
-    CATEGORICAL_CROSSENTROPY
-  };
-
-  struct Param
-  {
-    Type op_type;
-    // TODO Add more params if necessary
-    Param() : op_type(Type::MEAN_SQUARED_ERROR) {}
-  };
-
 public:
-  Loss(const OperandIndexSequence &inputs, const OperandIndexSequence &outputs, const Param &param);
+  Loss(const OperandIndexSequence &inputs, const OperandIndexSequence &outputs);
 
 public:
   void accept(OperationVisitor &v) const override;
-  std::string name() const override;
   OpCode opcode() const final { return OpCode::Loss; }
-
-public:
-  const Param &param() const { return _param; }
-
-private:
-  Param _param;
 };
 
 } // namespace operation

--- a/runtime/onert/core/include/ir/train/LossCode.h
+++ b/runtime/onert/core/include/ir/train/LossCode.h
@@ -14,26 +14,35 @@
  * limitations under the License.
  */
 
-#include "ir/operation/Loss.h"
-#include "ir/OperationVisitor.h"
+#ifndef __ONERT_IR_TRAIN_LOSS_CODE_H__
+#define __ONERT_IR_TRAIN_LOSS_CODE_H__
 
-#include <unordered_map>
+#include <string>
 
 namespace onert
 {
 namespace ir
 {
-namespace operation
+namespace train
 {
 
-void Loss::accept(OperationVisitor &v) const { v.visit(*this); }
-
-Loss::Loss(const OperandIndexSequence &inputs, const OperandIndexSequence &outputs)
-  : Operation{OperandConstraint::createAtLeast(2u), inputs, outputs}
+enum class LossCode
 {
-  assert(inputs.size() == 2);
-}
+  Invalid,                //< Invalid
+  MeanSquaredError,       //< MeanSquaredError optimizer
+  CategoricalCrossentropy //< CategoricalCrossentropy optimizer
+};
 
-} // namespace operation
+/**
+ * @brief Convert the optimizer code to the name
+ *
+ * @param opcode The optimizer code
+ * @return The name of the optimizer
+ */
+std::string toString(LossCode opcode);
+
+} // namespace train
 } // namespace ir
 } // namespace onert
+
+#endif // __ONERT_IR_TRAIN_LOSS_CODE_H__

--- a/runtime/onert/core/include/ir/train/LossInfo.h
+++ b/runtime/onert/core/include/ir/train/LossInfo.h
@@ -14,26 +14,26 @@
  * limitations under the License.
  */
 
-#include "ir/operation/Loss.h"
-#include "ir/OperationVisitor.h"
+#ifndef __ONERT_IR_TRAIN_LOSS_INFO_H__
+#define __ONERT_IR_TRAIN_LOSS_INFO_H__
 
-#include <unordered_map>
+#include "LossCode.h"
 
 namespace onert
 {
 namespace ir
 {
-namespace operation
+namespace train
 {
 
-void Loss::accept(OperationVisitor &v) const { v.visit(*this); }
-
-Loss::Loss(const OperandIndexSequence &inputs, const OperandIndexSequence &outputs)
-  : Operation{OperandConstraint::createAtLeast(2u), inputs, outputs}
+struct LossInfo
 {
-  assert(inputs.size() == 2);
-}
+  LossCode loss_code;
+  // TODO Add properties
+};
 
-} // namespace operation
+} // namespace train
 } // namespace ir
 } // namespace onert
+
+#endif // __ONERT_IR_TRAIN_LOSS_INFO_H__

--- a/runtime/onert/core/include/ir/train/operation/Loss.h
+++ b/runtime/onert/core/include/ir/train/operation/Loss.h
@@ -20,6 +20,9 @@
 #include "ir/operation/Loss.h"
 #include "ir/train/ITrainableOperation.h"
 
+#include "ir/train/LossCode.h"
+#include "ir/train/LossInfo.h"
+
 namespace onert
 {
 namespace ir
@@ -35,12 +38,19 @@ private:
   using OperationType = ir::operation::Loss;
 
 public:
-  Loss(const OperationType &operation);
+  Loss(const OperationType &operation, const LossInfo &info);
 
 public:
   std::unique_ptr<ITrainableOperation> clone() const override;
   void accept(OperationVisitor &v) const override;
   void accept(TrainableOperationVisitor &v) const override;
+  std::string name() const override { return toString(_param.loss_code) + toString(opcode()); };
+
+public:
+  const LossInfo &param() const { return _param; }
+
+private:
+  LossInfo _param;
 };
 
 } // namespace operation

--- a/runtime/onert/core/src/compiler/train/TrainableOperationConverter.cc
+++ b/runtime/onert/core/src/compiler/train/TrainableOperationConverter.cc
@@ -58,7 +58,7 @@ void TrainableOperationConverter::visit(const ir::operation::FullyConnected &nod
 
 void TrainableOperationConverter::visit(const ir::operation::Loss &node)
 {
-  _return_op = std::make_unique<ir::train::operation::Loss>(node);
+  _return_op = std::make_unique<ir::train::operation::Loss>(node, _training_info->lossInfo());
 }
 
 void TrainableOperationConverter::visit(const ir::operation::Permute &node)

--- a/runtime/onert/core/src/compiler/train/pass/LossInsertionPass.cc
+++ b/runtime/onert/core/src/compiler/train/pass/LossInsertionPass.cc
@@ -32,9 +32,6 @@ void LossInsertionPass::run()
 {
   const auto &loss_info = _training_info->lossInfo();
 
-  ir::operation::Loss::Param param;
-  param.op_type = loss_info.type;
-
   if (_trainable_graph.getOutputs().size() != 1)
   {
     throw std::runtime_error("LossInsertionPass: Not supported multiple outputs");
@@ -60,8 +57,8 @@ void LossInsertionPass::run()
   auto output_index = _trainable_graph.addOperand(ir::Shape{1}, float_op);
   ir::OperandIndexSequence outputs{output_index};
 
-  auto loss_op = std::make_unique<ir::operation::Loss>(inputs, outputs, param);
-  auto trainable_loss_op = std::make_unique<ir::train::operation::Loss>(*loss_op);
+  auto loss_op = std::make_unique<ir::operation::Loss>(inputs, outputs);
+  auto trainable_loss_op = std::make_unique<ir::train::operation::Loss>(*loss_op, loss_info);
 
   _trainable_graph.addOperation(std::move(trainable_loss_op));
 

--- a/runtime/onert/core/src/ir/train/LossCode.cc
+++ b/runtime/onert/core/src/ir/train/LossCode.cc
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#include "ir/operation/Loss.h"
-#include "ir/OperationVisitor.h"
+#include "ir/train/LossCode.h"
 
 #include <unordered_map>
 
@@ -23,17 +22,18 @@ namespace onert
 {
 namespace ir
 {
-namespace operation
+namespace train
 {
 
-void Loss::accept(OperationVisitor &v) const { v.visit(*this); }
-
-Loss::Loss(const OperandIndexSequence &inputs, const OperandIndexSequence &outputs)
-  : Operation{OperandConstraint::createAtLeast(2u), inputs, outputs}
+std::string toString(LossCode code)
 {
-  assert(inputs.size() == 2);
+  static const std::unordered_map<LossCode, const char *> map{
+    {LossCode::Invalid, "Invalid"},
+    {LossCode::MeanSquaredError, "MeanSquaredError"},
+    {LossCode::CategoricalCrossentropy, "CategoricalCrossentropy"}};
+  return map.at(code);
 }
 
-} // namespace operation
+} // namespace train
 } // namespace ir
 } // namespace onert

--- a/runtime/onert/core/src/ir/train/operation/Loss.cc
+++ b/runtime/onert/core/src/ir/train/operation/Loss.cc
@@ -36,8 +36,8 @@ void Loss::accept(OperationVisitor &v) const { v.visit(*this); }
 
 void Loss::accept(TrainableOperationVisitor &v) const { v.visit(*this); }
 
-Loss::Loss(const OperationType &operation)
-  : OperationType{operation.getInputs(), operation.getOutputs(), operation.param()}
+Loss::Loss(const OperationType &operation, const LossInfo &param)
+  : OperationType{operation.getInputs(), operation.getOutputs()}, _param{param}
 {
   // DO NOTHING
 }


### PR DESCRIPTION
This commit implements LossCode and LossInfo as separated files and use the same structure in Compiler, TrainingInfo and Loss IR.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>