### PR TITLE
[onert] Rename Loss operation's printed name.

### DIFF
--- a/runtime/onert/core/src/ir/operation/Loss.cc
+++ b/runtime/onert/core/src/ir/operation/Loss.cc
@@ -42,8 +42,8 @@ std::string Loss::name() const
 {
   using LossType = onert::ir::operation::Loss::Type;
   static const std::unordered_map<Type, std::string> name_map{
-    {LossType::MEAN_SQUARED_ERROR, "MeanSquaredError Loss"},
-    {LossType::CATEGORICAL_CROSSENTROPY, "CategoricalCrossentropy Loss"}};
+    {LossType::MEAN_SQUARED_ERROR, "MeanSquaredError"},
+    {LossType::CATEGORICAL_CROSSENTROPY, "CategoricalCrossentropy"}};
   return name_map.at(_param.op_type);
 }
 


### PR DESCRIPTION
Loss is a kind of operation. It has name() member funciton which is used to print in log. It has space (e.g. "MeanSquaredError Loss", ...). When it is printed in IR, it looks like two words: e.g.

```
[   GraphDumper  ] {
[   GraphDumper  ]   %4 = @0_FullyConnected(%0, %1, %?)
[   GraphDumper  ]   %5 = @1_FullyConnected(%4, %2, %?)
[   GraphDumper  ]   %6 = @2_FullyConnected(%5, %3, %?)
[   GraphDumper  ]   %8 = @3_MeanSquaredError Loss(%6, %7)
[   GraphDumper  ] {
```

It would be good to remove space in operation name.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

.......................................................

```
$ ONERT_LOG_ENABLE=1 \
Product/x86_64-linux.debug/out/bin/onert_train mnist.circle \
--load_input:raw mnist_train.i160.bin \
--load_expected:raw mnist_train.o160.bin
```

### BEFORE

```
[   GraphDumper  ] {
[   GraphDumper  ]   %4 = @0_FullyConnected(%0, %1, %?)
[   GraphDumper  ]   %5 = @1_FullyConnected(%4, %2, %?)
[   GraphDumper  ]   %6 = @2_FullyConnected(%5, %3, %?)
[   GraphDumper  ]   %8 = @3_MeanSquaredError Loss(%6, %7)
```

### AFTER
```
[   GraphDumper  ] {
[   GraphDumper  ]   %4 = @0_FullyConnected(%0, %1, %?)
[   GraphDumper  ]   %5 = @1_FullyConnected(%4, %2, %?)
[   GraphDumper  ]   %6 = @2_FullyConnected(%5, %3, %?)
[   GraphDumper  ]   %8 = @3_MeanSquaredError(%6, %7)
```