### PR TITLE
[circle-mpqsolver] Revise MPQSolver

### DIFF
--- a/compiler/circle-mpqsolver/src/MPQSolver.cpp
+++ b/compiler/circle-mpqsolver/src/MPQSolver.cpp
@@ -21,17 +21,13 @@
 
 using namespace mpqsolver;
 
-MPQSolver::MPQSolver(const core::Quantizer::Context &ctx, const std::string &input_data_path,
-                     float qerror_ratio)
-  : _input_data_path(input_data_path), _qerror_ratio(qerror_ratio)
+MPQSolver::MPQSolver(const core::Quantizer::Context &ctx)
 {
   _quantizer = std::make_unique<core::Quantizer>(ctx);
 }
 
-MPQSolver::MPQSolver(const std::string &input_data_path, float qerror_ratio,
-                     const std::string &input_quantization, const std::string &output_quantization)
-  : _input_data_path(input_data_path), _qerror_ratio(qerror_ratio),
-    _input_quantization(input_quantization), _output_quantization(output_quantization)
+MPQSolver::MPQSolver(const std::string &input_quantization, const std::string &output_quantization)
+  : _input_quantization(input_quantization), _output_quantization(output_quantization)
 {
   _quantizer = std::make_unique<core::Quantizer>(_input_quantization, _output_quantization);
 }

--- a/compiler/circle-mpqsolver/src/MPQSolver.h
+++ b/compiler/circle-mpqsolver/src/MPQSolver.h
@@ -31,17 +31,14 @@ namespace mpqsolver
 class MPQSolver
 {
 public:
-  MPQSolver(const core::Quantizer::Context &ctx, const std::string &input_data_path,
-            float qerror_ratio);
+  MPQSolver(const core::Quantizer::Context &ctx);
 
 public:
   /**
-   * @brief construct Solver using input_data_path for .h5 file,
-   * qerror_ratio to set target qerror, and input_quantization/output_quantization to set
-   * quantization type at input/output respectively
+   * @brief construct Solver using input_quantization/output_quantization to set quantization type
+   * at input/output respectively
    */
-  MPQSolver(const std::string &input_data_path, float qerror_ratio,
-            const std::string &input_quantization, const std::string &output_quantization);
+  MPQSolver(const std::string &input_quantization, const std::string &output_quantization);
   virtual ~MPQSolver() = default;
 
   /**
@@ -58,11 +55,9 @@ protected:
   std::unique_ptr<luci::Module> read_module(const std::string &path);
 
 protected:
-  std::string _input_data_path;
   std::string _input_quantization;
   std::string _output_quantization;
   std::unique_ptr<core::Quantizer> _quantizer;
-  float _qerror_ratio = 0.f; // quantization error ratio
   std::unique_ptr<core::DumpingHooks> _hooks;
 };
 

--- a/compiler/circle-mpqsolver/src/bisection/BisectionSolver.cpp
+++ b/compiler/circle-mpqsolver/src/bisection/BisectionSolver.cpp
@@ -77,7 +77,8 @@ bool front_has_higher_error(const NodeDepthType &nodes_depth, const std::string 
 BisectionSolver::BisectionSolver(const std::string &input_data_path, float qerror_ratio,
                                  const std::string &input_quantization,
                                  const std::string &output_quantization)
-  : MPQSolver(input_data_path, qerror_ratio, input_quantization, output_quantization)
+  : MPQSolver(input_quantization, output_quantization), _qerror_ratio(qerror_ratio),
+    _input_data_path(input_data_path)
 {
 }
 

--- a/compiler/circle-mpqsolver/src/bisection/BisectionSolver.h
+++ b/compiler/circle-mpqsolver/src/bisection/BisectionSolver.h
@@ -75,9 +75,11 @@ private:
                  const std::string &def_quant, core::LayerParams &layers);
 
 private:
-  float _qerror = 0.f; // quantization error
+  const float _qerror_ratio = 0.f; // quantization error ratio
+  float _qerror = 0.f;             // quantization error
   Algorithm _algorithm = Algorithm::ForceQ16Front;
   std::string _visq_data_path;
+  std::string _input_data_path;
 };
 
 } // namespace bisection

--- a/compiler/circle-mpqsolver/src/pattern/PatternSolver.cpp
+++ b/compiler/circle-mpqsolver/src/pattern/PatternSolver.cpp
@@ -27,7 +27,7 @@ using LayerParams = luci::CircleQuantizer::Options::LayerParams;
 
 PatternSolver::PatternSolver(const mpqsolver::core::Quantizer::Context &ctx,
                              const std::vector<QuantizationPattern> &patterns)
-  : MPQSolver(ctx, "", 1.f)
+  : MPQSolver(ctx)
 {
   MPQOptions options{patterns};
   set_mpq_options(options);
@@ -36,7 +36,7 @@ PatternSolver::PatternSolver(const mpqsolver::core::Quantizer::Context &ctx,
 PatternSolver::PatternSolver(const std::string &input_quantization,
                              const std::string &output_quantization,
                              const std::vector<QuantizationPattern> &patterns)
-  : MPQSolver("", 1.f, input_quantization, output_quantization)
+  : MPQSolver(input_quantization, output_quantization)
 {
   MPQOptions options{patterns};
   set_mpq_options(options);


### PR DESCRIPTION
This commit moves _qerror_ratio and _input_data_path
from MPQSolver to BisectionSolver, as it's the only
consumer of these fields.

Draft: https://github.com/Samsung/ONE/pull/11849
Related: https://github.com/Samsung/ONE/issues/11374

ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>