### PR TITLE
[one-cmds] Improve help message of one-quantize granularity

### DIFF
--- a/compiler/one-cmds/one-quantize
+++ b/compiler/one-cmds/one-quantize
@@ -94,7 +94,7 @@ def _get_parser():
     quantization_group.add_argument(
         '--granularity',
         type=str,
-        help='quantization granularity (supported: layer, channel, default=layer)')
+        help='weight quantization granularity (supported: layer, channel, default=layer)')
     quantization_group.add_argument(
         '--input_type',
         type=str,

--- a/compiler/one-cmds/one-quantize
+++ b/compiler/one-cmds/one-quantize
@@ -94,7 +94,8 @@ def _get_parser():
     quantization_group.add_argument(
         '--granularity',
         type=str,
-        help='weight quantization granularity (supported: layer, channel, default=layer)')
+        help="""weight quantization granularity (supported: layer, channel, default=layer).
+        Activation is quantized per layer.""")
     quantization_group.add_argument(
         '--input_type',
         type=str,


### PR DESCRIPTION
This PR improve one-quantize granularity options, by adding a word 'weight'.

ONE-DCO-1.0-Signed-off-by: SeungHui Youn <sseung.youn@samsung.com>

related issue : https://github.com/Samsung/ONE/issues/12081 