### PR TITLE
[onert] Rename Executors to MultiModelExecutors

### DIFF
--- a/runtime/onert/core/src/compiler/MultiModelCompiler.cc
+++ b/runtime/onert/core/src/compiler/MultiModelCompiler.cc
@@ -24,7 +24,7 @@
 #include "pass/PassRunner.h"
 #include "pass/UnusedOperandEliminationPass.h"
 #include "../dumper/dot/DotDumper.h"
-#include "../exec/Executors.h"
+#include "../exec/MultiModelExecutors.h"
 #include "../ir/OperationDumper.h"
 #include "../ir/verifier/Verifier.h"
 
@@ -203,7 +203,7 @@ std::shared_ptr<CompilerArtifact> MultiModelCompiler::compile(void)
   /*************************************************************
    *  Backend independent analysis & optimization phase finished
    *************************************************************/
-  auto executors = std::make_shared<exec::Executors>(std::move(model_edges));
+  auto executors = std::make_shared<exec::MultiModelExecutors>(std::move(model_edges));
   for (auto &&pair : lowered_subgs)
   {
     auto const &model_index = pair.first;

--- a/runtime/onert/core/src/compiler/MultiModelCompiler.h
+++ b/runtime/onert/core/src/compiler/MultiModelCompiler.h
@@ -54,7 +54,7 @@ public:
   /**
    * @brief   Do compilation with the options
    *
-   * @return std::shared_ptr<CompilerArtifact> Executors as a result of compilation
+   * @return std::shared_ptr<CompilerArtifact> MultiModelExecutors as a result of compilation
    */
   std::shared_ptr<CompilerArtifact> compile(void);
 

--- a/runtime/onert/core/src/exec/MultiModelExecutors.h
+++ b/runtime/onert/core/src/exec/MultiModelExecutors.h
@@ -44,11 +44,11 @@ namespace exec
 /**
  * @brief Class to gather executors
  */
-class Executors : public IExecutors
+class MultiModelExecutors : public IExecutors
 {
 public:
-  Executors(void) = delete;
-  Executors(std::unique_ptr<ir::ModelEdges> model_edges)
+  MultiModelExecutors(void) = delete;
+  MultiModelExecutors(std::unique_ptr<ir::ModelEdges> model_edges)
     : _executors{}, _model_edges{std::move(model_edges)}, _edge_quant_layers{},
       _edge_quant_tensors{}, _edge_tensors{}, _is_created_edge_quant_layers{false},
       _pkg_input_quant_layers{}, _pkg_output_quant_layers{}, _pkg_input_quant_tensors{},
@@ -59,9 +59,9 @@ public:
       _edge_map[edge.from].emplace_back(edge.to);
     }
   }
-  Executors(const Executors &) = delete;
-  Executors(Executors &&) = default;
-  ~Executors() = default;
+  MultiModelExecutors(const MultiModelExecutors &) = delete;
+  MultiModelExecutors(MultiModelExecutors &&) = default;
+  ~MultiModelExecutors() = default;
 
   // TODO Use Executor index
   void emplace(const ir::ModelIndex &model_index, const ir::SubgraphIndex &subg_index,


### PR DESCRIPTION
It renames Executors to MultiModelExecutors. (class/file name).

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>