### PR TITLE
[circle-mpqsolver] Revise PatternSolver

### DIFF
--- a/compiler/circle-mpqsolver/src/pattern/PatternSolver.cpp
+++ b/compiler/circle-mpqsolver/src/pattern/PatternSolver.cpp
@@ -33,15 +33,6 @@ PatternSolver::PatternSolver(const mpqsolver::core::Quantizer::Context &ctx,
   set_mpq_options(options);
 }
 
-PatternSolver::PatternSolver(const std::string &input_quantization,
-                             const std::string &output_quantization,
-                             const std::vector<QuantizationPattern> &patterns)
-  : MPQSolver(input_quantization, output_quantization)
-{
-  MPQOptions options{patterns};
-  set_mpq_options(options);
-}
-
 std::unique_ptr<luci::Module> PatternSolver::run(const std::string &module_path)
 {
   auto module = read_module(module_path);

--- a/compiler/circle-mpqsolver/src/pattern/PatternSolver.h
+++ b/compiler/circle-mpqsolver/src/pattern/PatternSolver.h
@@ -50,14 +50,6 @@ class PatternSolver final : public MPQSolver
 public:
   PatternSolver(const mpqsolver::core::Quantizer::Context &ctx,
                 const std::vector<QuantizationPattern> &patterns);
-  // TODO Remove this
-public:
-  /**
-   * @brief construct PatternSolver using input_quantization/output_quantization to set
-   * quantization type at input/output respectively and patterns to apply
-   */
-  PatternSolver(const std::string &input_quantization, const std::string &output_quantization,
-                const std::vector<QuantizationPattern> &patterns);
 
   /**
    * @brief run solver for recorded float module at module_path


### PR DESCRIPTION
This commit removes unused constructor from PatternSolver.

Draft: https://github.com/Samsung/ONE/pull/11849
Related: https://github.com/Samsung/ONE/issues/11374

ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>