### PR TITLE
[circle-mpqsolver] Revise BisectionSolver

### DIFF
--- a/compiler/circle-mpqsolver/src/bisection/BisectionSolver.cpp
+++ b/compiler/circle-mpqsolver/src/bisection/BisectionSolver.cpp
@@ -74,11 +74,9 @@ bool front_has_higher_error(const NodeDepthType &nodes_depth, const std::string 
 
 } // namespace
 
-BisectionSolver::BisectionSolver(const std::string &input_data_path, float qerror_ratio,
-                                 const std::string &input_quantization,
-                                 const std::string &output_quantization)
-  : MPQSolver(input_quantization, output_quantization), _qerror_ratio(qerror_ratio),
-    _input_data_path(input_data_path)
+BisectionSolver::BisectionSolver(const mpqsolver::core::Quantizer::Context &ctx,
+                                 const std::string &input_data_path, float qerror_ratio)
+  : MPQSolver(ctx), _qerror_ratio(qerror_ratio), _input_data_path(input_data_path)
 {
 }
 

--- a/compiler/circle-mpqsolver/src/bisection/BisectionSolver.h
+++ b/compiler/circle-mpqsolver/src/bisection/BisectionSolver.h
@@ -45,12 +45,14 @@ public:
 
 public:
   /**
-   * @brief construct Solver using input_data_path for .h5 file,
-   * qerror_ratio to set target qerror, and input_quantization/output_quantization to set
-   * quantization type at input/output respectively
+   * @brief Construct a new Bisection Solver object
+   *
+   * @param ctx - quantizer context
+   * @param input_data_path - input path of h5 file
+   * @param qerror_ratio - target error ratio
    */
-  BisectionSolver(const std::string &input_data_path, float qerror_ratio,
-                  const std::string &input_quantization, const std::string &output_quantization);
+  BisectionSolver(const mpqsolver::core::Quantizer::Context &ctx,
+                  const std::string &input_data_path, float qerror_ratio);
   BisectionSolver() = delete;
 
   /**

--- a/compiler/circle-mpqsolver/src/bisection/BisectionSolver.test.cpp
+++ b/compiler/circle-mpqsolver/src/bisection/BisectionSolver.test.cpp
@@ -20,7 +20,10 @@
 
 TEST(CircleMPQSolverBisectionSolverTest, empty_path_NEG)
 {
-  mpqsolver::bisection::BisectionSolver solver("", 0.0, "uint8", "uint8");
+  mpqsolver::core::Quantizer::Context ctx;
+  ctx.input_type = "uint8";
+  ctx.output_type = "uint8";
+  mpqsolver::bisection::BisectionSolver solver(ctx, "", 0.0);
   solver.algorithm(mpqsolver::bisection::BisectionSolver::Algorithm::ForceQ16Back);
   EXPECT_ANY_THROW(solver.run(""));
 }


### PR DESCRIPTION
This commit uses quantizer context in constructor of BisectionSolver instead of  passing them directly.

Draft: https://github.com/Samsung/ONE/pull/11849
Related: https://github.com/Samsung/ONE/issues/11374

ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>