### PR TITLE
[circle-mpqsolver] Improve help message of circle-mpqsolver granularity

### DIFF
--- a/compiler/circle-mpqsolver/src/CircleMPQSolver.cpp
+++ b/compiler/circle-mpqsolver/src/CircleMPQSolver.cpp
@@ -113,7 +113,8 @@ int entry(int argc, char **argv)
   arser.add_argument("--granularity")
     .type(arser::DataType::STR)
     .default_value("channel")
-    .help("Granularity of quantization scheme (supported: layer, channel (default))");
+    .help("Granularity of quantization scheme on weight (supported: layer, channel (default)). "
+          "Activation is quantized per layer.");
 
   arser.add_argument("--TF-style_maxpool")
     .nargs(0)


### PR DESCRIPTION
This PR adds a word 'weight-quanitzation' to circle-mpqsolver granularity to improve help message.

ONE-DCO-1.0-Signed-off-by: SeungHui Youn <sseung.youn@samsung.com>

related issue : https://github.com/Samsung/ONE/issues/12081 