### PR TITLE
[onert] Introduce LossReductionType

### DIFF
--- a/runtime/onert/api/include/nnfw_experimental.h
+++ b/runtime/onert/api/include/nnfw_experimental.h
@@ -182,9 +182,25 @@ typedef enum
 
 typedef enum
 {
+  /** Invalid */
+  NNFW_TRAIN_LOSS_REDUCTION_INVALID = 0,
+  /** Scalar sum divided by number of elements in losses */
+  NNFW_TRAIN_LOSS_REDUCTION_SUM_OVER_BATCH_SIZE = 1,
+  /** Scalar sum of weighted losses */
+  NNFW_TRAIN_LOSS_REDUCTION_SUM = 2,
+} NNFW_TRAIN_LOSS_REDUCTION;
+
+typedef enum
+{
   NNFW_TRAIN_OPTIMIZER_SGD = 0,
   NNFW_TRAIN_OPTIMIZER_ADAM = 1,
 } NNFW_TRAIN_OPTIMIZER;
+
+typedef struct nnfw_loss_info
+{
+  NNFW_TRAIN_LOSS loss;
+  NNFW_TRAIN_LOSS_REDUCTION reduction_type;
+} nnfw_loss_info;
 
 /**
  * @brief Training information to prepare training
@@ -197,8 +213,9 @@ typedef struct nnfw_train_info
   float learning_rate = 0.001f;
   /** Batch size */
   uint32_t batch_size = 1;
-  /** loss type */
-  NNFW_TRAIN_LOSS loss = NNFW_TRAIN_LOSS_MEAN_SQUARED_ERROR;
+  /** loss info */
+  nnfw_loss_info loss_info{.loss = NNFW_TRAIN_LOSS_MEAN_SQUARED_ERROR,
+                           .reduction_type = NNFW_TRAIN_LOSS_REDUCTION_INVALID};
   /** optimizer type */
   NNFW_TRAIN_OPTIMIZER opt = NNFW_TRAIN_OPTIMIZER_SGD;
 } nnfw_train_info;

--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -1192,8 +1192,18 @@ NNFW_STATUS nnfw_session::train_prepare(const nnfw_train_info *info)
       else
         throw std::runtime_error("not supported loss type");
     };
+    auto convertLossReductionType = [](const int &type) {
+      if (type == NNFW_TRAIN_LOSS_REDUCTION_INVALID)
+        return onert::ir::train::LossReductionType::Invalid;
+      else if (type == NNFW_TRAIN_LOSS_REDUCTION_SUM_OVER_BATCH_SIZE)
+        return onert::ir::train::LossReductionType::SumOverBatchSize;
+      else
+        throw std::runtime_error("not supported loss reduction type");
+    };
     onert::ir::train::LossInfo loss_info;
-    loss_info.loss_code = convertLossType(tinfo.loss);
+    loss_info.loss_code = convertLossType(tinfo.loss_info.loss);
+    // TODO Consider the reduction type of model file
+    loss_info.reduction_type = convertLossReductionType(tinfo.loss_info.reduction_type);
 
     auto convertOptType = [](const int &type) {
       if (type == NNFW_TRAIN_OPTIMIZER_SGD)

--- a/runtime/onert/core/include/compiler/train/TrainingInfo.h
+++ b/runtime/onert/core/include/compiler/train/TrainingInfo.h
@@ -42,7 +42,14 @@ public:
   uint32_t batchSize() const { return _batch_size; }
   void setBatchSize(const uint32_t batch_size) { _batch_size = batch_size; }
   const ir::train::LossInfo &lossInfo() const { return _loss_info; }
-  void setLossInfo(const ir::train::LossInfo &loss_info) { _loss_info = loss_info; }
+  void setLossInfo(const ir::train::LossInfo &loss_info)
+  {
+    _loss_info = loss_info;
+
+    // If the reduction type is not specified, it uses SumOverBatchSize.
+    if (_loss_info.reduction_type == ir::train::LossReductionType::Invalid)
+      _loss_info.reduction_type = ir::train::LossReductionType::SumOverBatchSize;
+  }
   const ir::train::OptimizerInfo &optimizerInfo() const { return _optimizer_info; }
   void setOptimizerInfo(const ir::train::OptimizerInfo &optimizer_info)
   {
@@ -50,7 +57,7 @@ public:
   }
 
 private:
-  ir::train::LossInfo _loss_info{ir::train::LossCode::Invalid};
+  ir::train::LossInfo _loss_info;
   ir::train::OptimizerInfo _optimizer_info{ir::train::OptimizerCode::Invalid, 0};
   uint32_t _batch_size = 0;
 };

--- a/runtime/onert/core/include/ir/train/LossInfo.h
+++ b/runtime/onert/core/include/ir/train/LossInfo.h
@@ -26,10 +26,19 @@ namespace ir
 namespace train
 {
 
+enum class LossReductionType
+{
+  Invalid,          //< Invalid
+  SumOverBatchSize, //< SumOverBatchSize loss reduction type
+  Sum,              //< Sum loss reduction type
+};
+
 struct LossInfo
 {
   LossCode loss_code;
+  LossReductionType reduction_type;
   // TODO Add properties
+  LossInfo() : loss_code{LossCode::Invalid}, reduction_type{LossReductionType::Invalid} {}
 };
 
 } // namespace train

--- a/tests/tools/onert_train/src/onert_train.cc
+++ b/tests/tools/onert_train/src/onert_train.cc
@@ -149,7 +149,7 @@ int main(const int argc, char **argv)
     nnfw_train_info tri;
     tri.batch_size = args.getBatchSize();
     tri.learning_rate = args.getLearningRate();
-    tri.loss = convertLossType(args.getLossType());
+    tri.loss_info.loss = convertLossType(args.getLossType());
     tri.opt = convertOptType(args.getOptimizerType());
 
     // prepare execution


### PR DESCRIPTION
This commit introduces LossReductionType for training feature. It will use SumOverBatchSize reduction type, if the reduction type is not specified.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>