### PR TITLE
[tools/onert_train] Add loss_reduction_type option

### DIFF
--- a/tests/tools/onert_train/src/args.cc
+++ b/tests/tools/onert_train/src/args.cc
@@ -216,6 +216,11 @@ void Args::Initialize(void)
         "Loss type\n"
         "0: MEAN_SQUARED_ERROR (default)\n"
         "1: CATEGORICAL_CROSSENTROPY\n")
+    ("loss_reduction_type", po::value<int>()->default_value(0)->notifier([&] (const auto &v) { _loss_reduction_type = v; }),
+        "Loss Reduction type\n"
+        "0: Use default setting (Model parameter or ONERT train setting)\n"
+        "1: SUM_OVER_BATCH_SIZE\n"
+        "2: SUM\n")
     ("optimizer", po::value<int>()->default_value(0)->notifier([&] (const auto &v) { _optimizer_type = v; }),
       "Optimizer type\n"
       "0: SGD (default)\n"

--- a/tests/tools/onert_train/src/args.h
+++ b/tests/tools/onert_train/src/args.h
@@ -56,6 +56,7 @@ public:
   const int getBatchSize(void) const { return _batch_size; }
   const float getLearningRate(void) const { return _learning_rate; }
   const int getLossType(void) const { return _loss_type; }
+  const int getLossReductionType(void) const { return _loss_reduction_type; }
   const int getOptimizerType(void) const { return _optimizer_type; }
   const bool printVersion(void) const { return _print_version; }
   const int getVerboseLevel(void) const { return _verbose_level; }
@@ -79,6 +80,7 @@ private:
   int _batch_size;
   float _learning_rate;
   int _loss_type;
+  int _loss_reduction_type;
   int _optimizer_type;
   bool _print_version = false;
   int _verbose_level;

--- a/tests/tools/onert_train/src/onert_train.cc
+++ b/tests/tools/onert_train/src/onert_train.cc
@@ -132,6 +132,21 @@ int main(const int argc, char **argv)
       }
     };
 
+    auto convertLossReductionType = [](int type) {
+      switch (type)
+      {
+        case 0:
+          return NNFW_TRAIN_LOSS_REDUCTION_INVALID;
+        case 1:
+          return NNFW_TRAIN_LOSS_REDUCTION_SUM_OVER_BATCH_SIZE;
+        case 2:
+          return NNFW_TRAIN_LOSS_REDUCTION_SUM;
+        default:
+          std::cerr << "E: not supported loss reduction type" << std::endl;
+          exit(-1);
+      }
+    };
+
     auto convertOptType = [](int type) {
       switch (type)
       {
@@ -150,6 +165,7 @@ int main(const int argc, char **argv)
     tri.batch_size = args.getBatchSize();
     tri.learning_rate = args.getLearningRate();
     tri.loss_info.loss = convertLossType(args.getLossType());
+    tri.loss_info.reduction_type = convertLossReductionType(args.getLossReductionType());
     tri.opt = convertOptType(args.getOptimizerType());
 
     // prepare execution


### PR DESCRIPTION
This commit adds `--loss_reduction_type` option.
The default value is 0, which means to follow the model setting or
onert train setting.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

~~waiting for #12105~~