### PR TITLE
[circle-mpqsolver] Revise Quantizer

### DIFF
--- a/compiler/circle-mpqsolver/src/MPQSolver.cpp
+++ b/compiler/circle-mpqsolver/src/MPQSolver.cpp
@@ -26,12 +26,6 @@ MPQSolver::MPQSolver(const core::Quantizer::Context &ctx)
   _quantizer = std::make_unique<core::Quantizer>(ctx);
 }
 
-MPQSolver::MPQSolver(const std::string &input_quantization, const std::string &output_quantization)
-  : _input_quantization(input_quantization), _output_quantization(output_quantization)
-{
-  _quantizer = std::make_unique<core::Quantizer>(_input_quantization, _output_quantization);
-}
-
 void MPQSolver::set_save_intermediate(const std::string &save_path)
 {
   _hooks = std::make_unique<core::DumpingHooks>(save_path);

--- a/compiler/circle-mpqsolver/src/MPQSolver.h
+++ b/compiler/circle-mpqsolver/src/MPQSolver.h
@@ -33,12 +33,6 @@ class MPQSolver
 public:
   MPQSolver(const core::Quantizer::Context &ctx);
 
-public:
-  /**
-   * @brief construct Solver using input_quantization/output_quantization to set quantization type
-   * at input/output respectively
-   */
-  MPQSolver(const std::string &input_quantization, const std::string &output_quantization);
   virtual ~MPQSolver() = default;
 
   /**

--- a/compiler/circle-mpqsolver/src/core/Quantizer.cpp
+++ b/compiler/circle-mpqsolver/src/core/Quantizer.cpp
@@ -49,11 +49,6 @@ bool make_model_fake_quantized(luci::Module *module)
 
 } // namespace
 
-Quantizer::Quantizer(const std::string &input_dtype, const std::string &output_dtype)
-  : _input_dtype(input_dtype), _output_dtype(output_dtype)
-{
-}
-
 void Quantizer::set_hook(const QuantizerHook *hook) { _hook = hook; }
 
 /**
@@ -67,7 +62,6 @@ bool Quantizer::quantize(luci::Module *module, const std::string &quant_dtype,
     return false;
 
   static const std::string default_dtype = "float32";
-  static const std::string granularity_type = "channel";
 
   luci::CircleQuantizer quantizer;
 
@@ -76,10 +70,12 @@ bool Quantizer::quantize(luci::Module *module, const std::string &quant_dtype,
 
   options->param(AlgorithmParameters::Quantize_input_model_dtype, default_dtype);
   options->param(AlgorithmParameters::Quantize_output_model_dtype, quant_dtype);
-  options->param(AlgorithmParameters::Quantize_granularity, granularity_type);
-  options->param(AlgorithmParameters::Quantize_input_type, _input_dtype);
-  options->param(AlgorithmParameters::Quantize_output_type, _output_dtype);
-  options->param(AlgorithmParameters::Quantize_TF_style_maxpool, "False");
+  options->param(AlgorithmParameters::Quantize_granularity, _ctx.granularity);
+  options->param(AlgorithmParameters::Quantize_input_type, _ctx.input_type);
+  options->param(AlgorithmParameters::Quantize_output_type, _ctx.output_type);
+  options->param(AlgorithmParameters::Quantize_TF_style_maxpool,
+                 _ctx.TF_style_maxpool ? "True" : "False");
+  options->param(AlgorithmParameters::Quantize_save_min_max, _ctx.save_min_max ? "True" : "False");
 
   if (!layer_params.empty())
   {

--- a/compiler/circle-mpqsolver/src/core/Quantizer.h
+++ b/compiler/circle-mpqsolver/src/core/Quantizer.h
@@ -46,10 +46,10 @@ class Quantizer
 public:
   struct Context
   {
-    std::string output_model_dtype;
-    std::string granularity;
-    std::string input_type;
-    std::string output_type;
+    std::string output_model_dtype = "uint8";
+    std::string granularity = "channel";
+    std::string input_type = "uint8";
+    std::string output_type = "uint8";
     bool TF_style_maxpool = false;
     bool save_min_max = false;
     // TODO Support layer info
@@ -57,10 +57,6 @@ public:
 
 public:
   Quantizer(const Context &ctx) : _ctx(ctx) {}
-
-  // TODO Remove this
-public:
-  Quantizer(const std::string &input_dtype, const std::string &output_type);
 
   /**
    * @brief set hook on the end of quantization event
@@ -88,9 +84,6 @@ public:
 
 private:
   Context _ctx;
-  // TODO Remove _input_dtype and output_dtype
-  std::string _input_dtype = "uint8";
-  std::string _output_dtype = "uint8";
   const QuantizerHook *_hook = nullptr;
 };
 

--- a/compiler/circle-mpqsolver/src/core/Quantizer.test.cpp
+++ b/compiler/circle-mpqsolver/src/core/Quantizer.test.cpp
@@ -31,10 +31,10 @@ TEST(CircleMPQSolverQuantizerTest, verifyResultsTest)
   float range = g._a_max - g._a_min;
   g.transfer_to(m.get());
 
-  std::string def_quant = "uint8";
-  mpqsolver::core::Quantizer quantizer(def_quant, def_quant);
+  mpqsolver::core::Quantizer::Context context;
+  mpqsolver::core::Quantizer quantizer(context);
   mpqsolver::core::LayerParams params;
-  auto res = quantizer.quantize(m.get(), def_quant, params);
+  auto res = quantizer.quantize(m.get(), context.output_model_dtype, params);
   EXPECT_TRUE(res);
   auto quant_param = add->quantparam();
   EXPECT_TRUE(quant_param != nullptr);
@@ -46,9 +46,9 @@ TEST(CircleMPQSolverQuantizerTest, verifyResultsTest)
 
 TEST(CircleMPQSolverQuantizerTest, verifyResultsTest_NEG)
 {
-  std::string def_quant = "uint8";
-  mpqsolver::core::Quantizer quantizer(def_quant, def_quant);
+  mpqsolver::core::Quantizer::Context context;
+  mpqsolver::core::Quantizer quantizer(context);
   mpqsolver::core::LayerParams params;
-  auto res = quantizer.quantize(nullptr, def_quant, params);
+  auto res = quantizer.quantize(nullptr, context.output_model_dtype, params);
   EXPECT_TRUE(!res);
 }


### PR DESCRIPTION
This commit sets default values in Context, removes deprecated Quantizer constructor, adjusts tests and MPQSolver.

Draft: https://github.com/Samsung/ONE/pull/11849
Related: https://github.com/Samsung/ONE/issues/11374

ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>