### PR TITLE
[circle-mpqsolver] Use DataProvider

### DIFF
--- a/compiler/circle-mpqsolver/CMakeLists.txt
+++ b/compiler/circle-mpqsolver/CMakeLists.txt
@@ -45,6 +45,7 @@ set(TEST_SOURCES
     "src/MPQSolver.cpp"
     "src/core/SolverOutput.cpp"
     "src/bisection/BisectionSolver.cpp"
+    "src/core/DataProvider.cpp"
 )
 
 nnas_find_package(GTest REQUIRED)

--- a/compiler/circle-mpqsolver/src/CircleMPQSolver.cpp
+++ b/compiler/circle-mpqsolver/src/CircleMPQSolver.cpp
@@ -20,6 +20,8 @@
 #include <luci/CircleFileExpContract.h>
 
 #include "bisection/BisectionSolver.h"
+#include "core/DataProvider.h"
+#include "core/SolverOutput.h"
 #include "pattern/PatternSolver.h"
 #include "core/SolverOutput.h"
 #include "core/Quantizer.h"
@@ -213,7 +215,11 @@ int entry(int argc, char **argv)
 
     using namespace mpqsolver::bisection;
 
-    auto bi_solver = std::make_unique<BisectionSolver>(ctx, data_path, qerror_ratio);
+    auto bi_solver = std::make_unique<BisectionSolver>(ctx, qerror_ratio);
+    auto input_data =
+      std::make_unique<mpqsolver::core::H5FileDataProvider>(data_path, input_model_path);
+    bi_solver->setInputData(std::move(input_data));
+
     {
       auto value = arser.get<std::string>(bisection_str);
       if (value == "auto")

--- a/compiler/circle-mpqsolver/src/bisection/BisectionSolver.h
+++ b/compiler/circle-mpqsolver/src/bisection/BisectionSolver.h
@@ -48,17 +48,21 @@ public:
    * @brief Construct a new Bisection Solver object
    *
    * @param ctx - quantizer context
-   * @param input_data_path - input path of h5 file
    * @param qerror_ratio - target error ratio
    */
-  BisectionSolver(const mpqsolver::core::Quantizer::Context &ctx,
-                  const std::string &input_data_path, float qerror_ratio);
+  BisectionSolver(const mpqsolver::core::Quantizer::Context &ctx, float qerror_ratio);
+
   BisectionSolver() = delete;
 
   /**
    * @brief run bisection for recorded float module at module_path
    */
   std::unique_ptr<luci::Module> run(const std::string &module_path) override;
+
+  /**
+   * @brief set data provider
+   */
+  void setInputData(std::unique_ptr<mpqsolver::core::DataProvider> &&data);
 
   /**
    * @brief set used algorithm
@@ -81,7 +85,7 @@ private:
   float _qerror = 0.f;             // quantization error
   Algorithm _algorithm = Algorithm::ForceQ16Front;
   std::string _visq_data_path;
-  std::string _input_data_path;
+  std::unique_ptr<mpqsolver::core::DataProvider> _input_data;
 };
 
 } // namespace bisection

--- a/compiler/circle-mpqsolver/src/bisection/BisectionSolver.test.cpp
+++ b/compiler/circle-mpqsolver/src/bisection/BisectionSolver.test.cpp
@@ -23,7 +23,7 @@ TEST(CircleMPQSolverBisectionSolverTest, empty_path_NEG)
   mpqsolver::core::Quantizer::Context ctx;
   ctx.input_type = "uint8";
   ctx.output_type = "uint8";
-  mpqsolver::bisection::BisectionSolver solver(ctx, "", 0.0);
+  mpqsolver::bisection::BisectionSolver solver(ctx, 0.0);
   solver.algorithm(mpqsolver::bisection::BisectionSolver::Algorithm::ForceQ16Back);
   EXPECT_ANY_THROW(solver.run(""));
 }

--- a/compiler/circle-mpqsolver/src/core/Evaluator.h
+++ b/compiler/circle-mpqsolver/src/core/Evaluator.h
@@ -19,6 +19,8 @@
 
 #include "ErrorMetric.h"
 
+#include "DataProvider.h"
+
 #include <luci/IR/Module.h>
 #include <luci/CircleQuantizer.h>
 
@@ -34,9 +36,9 @@ class DatasetEvaluator final
 {
 public:
   /**
-   * @brief create Evaluator for comparing output of ref_module on h5file
+   * @brief create Evaluator for comparing output of ref_module on provider
    */
-  DatasetEvaluator(const luci::Module *ref_module, const std::string &h5file,
+  DatasetEvaluator(const luci::Module *ref_module, const DataProvider &provider,
                    const ErrorMetric &metric);
   DatasetEvaluator() = delete;
   ~DatasetEvaluator() = default;
@@ -55,7 +57,7 @@ private:
 
 private:
   const luci::Module *_ref_module = nullptr;
-  std::string _h5file;
+  const DataProvider *_provider = nullptr;
   WholeOutput _ref_output;
   const ErrorMetric *_metric = nullptr;
 };

--- a/compiler/circle-mpqsolver/src/core/Evaluator.test.cpp
+++ b/compiler/circle-mpqsolver/src/core/Evaluator.test.cpp
@@ -21,5 +21,6 @@
 TEST(CircleMPQSolverEvaluatorTest, empty_path_NEG)
 {
   mpqsolver::core::MAEMetric metric;
-  EXPECT_ANY_THROW(mpqsolver::core::DatasetEvaluator evaluator(nullptr, "", metric));
+  EXPECT_ANY_THROW(mpqsolver::core::H5FileDataProvider data("", "");
+                   mpqsolver::core::DatasetEvaluator evaluator(nullptr, data, metric));
 }


### PR DESCRIPTION
This commit replaces direct use of HDF5File by DataProvider in BisectionSolver and adjusts Evaluator accordingly.
This commit was tested in #11849

Draft: https://github.com/Samsung/ONE/pull/11849
Related: https://github.com/Samsung/ONE/issues/11374

ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>