### PR TITLE
[circle-mpqsolver] Add evaluator unittest

### DIFF
--- a/compiler/circle-mpqsolver/src/core/Evaluator.test.cpp
+++ b/compiler/circle-mpqsolver/src/core/Evaluator.test.cpp
@@ -18,6 +18,24 @@
 
 #include "Evaluator.h"
 
+#include "DataProvider.h"
+#include "TestHelper.h"
+
+TEST(CircleMPQSolverEvaluatorTest, verifyResultsTest)
+{
+  // create nn module
+  auto m = luci::make_module();
+  mpqsolver::test::models::AddGraph g;
+  g.init();
+  g.transfer_to(m.get());
+
+  mpqsolver::core::MAEMetric metric;
+  auto data = mpqsolver::test::data_utils::getSingleDataProvider();
+  mpqsolver::core::DatasetEvaluator evaluator(m.get(), *data.get(), metric);
+  float value = evaluator.evaluate(m.get());
+  EXPECT_FLOAT_EQ(value, 0.f);
+}
+
 TEST(CircleMPQSolverEvaluatorTest, empty_path_NEG)
 {
   mpqsolver::core::MAEMetric metric;


### PR DESCRIPTION
This commit adds one more unittest for Evaluator
to increase test coverage.

This commit was tested in https://github.com/Samsung/ONE/pull/11849

Draft: https://github.com/Samsung/ONE/pull/11849
Related: https://github.com/Samsung/ONE/issues/11374

ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>