### PR TITLE
[circle-mpqsolver] Tidy BisectionSolver test

### DIFF
--- a/compiler/circle-mpqsolver/src/bisection/BisectionSolver.test.cpp
+++ b/compiler/circle-mpqsolver/src/bisection/BisectionSolver.test.cpp
@@ -21,8 +21,6 @@
 TEST(CircleMPQSolverBisectionSolverTest, empty_path_NEG)
 {
   mpqsolver::core::Quantizer::Context ctx;
-  ctx.input_type = "uint8";
-  ctx.output_type = "uint8";
   mpqsolver::bisection::BisectionSolver solver(ctx, 0.0);
   solver.algorithm(mpqsolver::bisection::BisectionSolver::Algorithm::ForceQ16Back);
   EXPECT_ANY_THROW(solver.run(""));


### PR DESCRIPTION
This commit removes unnecessary assignment of input/output type.

This commit was tested in https://github.com/Samsung/ONE/pull/11849

Draft: https://github.com/Samsung/ONE/pull/11849
Related: https://github.com/Samsung/ONE/issues/11374

ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>