### PR TITLE
[infra/debian] Make link for libluci_compute

### DIFF
--- a/infra/debian/compiler/one-compiler.links
+++ b/infra/debian/compiler/one-compiler.links
@@ -3,6 +3,7 @@ usr/share/one/bin/one-build usr/bin/one-build
 usr/share/one/bin/onecc usr/bin/onecc
 # lib
 usr/share/one/lib/libloco.so usr/lib/libloco.so
+usr/share/one/lib/libluci_compute.so usr/lib/libluci_compute.so
 usr/share/one/lib/libluci_env.so usr/lib/libluci_env.so
 usr/share/one/lib/libluci_export.so usr/lib/libluci_export.so
 usr/share/one/lib/libluci_import.so usr/lib/libluci_import.so


### PR DESCRIPTION
This will add lib link for libluci_compute.so file.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>