### PR TITLE
[circle-mpqsolver] Add BisectionSolver unitest

### DIFF
--- a/compiler/circle-mpqsolver/src/bisection/BisectionSolver.test.cpp
+++ b/compiler/circle-mpqsolver/src/bisection/BisectionSolver.test.cpp
@@ -18,6 +18,59 @@
 
 #include "BisectionSolver.h"
 
+#include "core/SolverOutput.h"
+#include "core/TestHelper.h"
+
+#include <luci/CircleExporter.h>
+#include <luci/CircleFileExpContract.h>
+
+namespace
+{
+
+class CircleMPQSolverBisectionSolverTestF : public ::testing::Test
+{
+public:
+  CircleMPQSolverBisectionSolverTestF()
+  {
+    char module_template[] = "CircleMPQSolverBisectionSolverTest-CIRCLE-XXXXXX";
+    mpqsolver::test::io_utils::makeTemporaryFile(module_template);
+    _module_path = module_template;
+  }
+
+  ~CircleMPQSolverBisectionSolverTestF() { unlink(_module_path.c_str()); }
+
+protected:
+  mpqsolver::test::models::AddGraph _g;
+  std::string _module_path;
+};
+
+} // namespace
+
+TEST_F(CircleMPQSolverBisectionSolverTestF, verifyResultsTest)
+{
+  // create network
+  auto m = luci::make_module();
+  _g.init();
+  _g.transfer_to(m.get());
+
+  // export to _module_path
+  luci::CircleExporter exporter;
+  luci::CircleFileExpContract contract(m.get(), _module_path);
+  EXPECT_TRUE(exporter.invoke(&contract));
+
+  // create solver
+  mpqsolver::core::Quantizer::Context ctx;
+  mpqsolver::bisection::BisectionSolver solver(ctx, 0.5);
+  auto data = mpqsolver::test::data_utils::getSingleDataProvider();
+  solver.setInputData(std::move(data));
+  solver.algorithm(mpqsolver::bisection::BisectionSolver::Algorithm::ForceQ16Back);
+  SolverOutput::get().TurnOn(false);
+
+  // run solver
+  auto res = solver.run(_module_path);
+  EXPECT_TRUE(res.get() != nullptr);
+}
+
 TEST(CircleMPQSolverBisectionSolverTest, empty_path_NEG)
 {
   mpqsolver::core::Quantizer::Context ctx;


### PR DESCRIPTION
This commit adds one more unittest for BisectionSolver to increase test coverage.

This commit was tested in https://github.com/Samsung/ONE/pull/11849

Draft: https://github.com/Samsung/ONE/pull/11849
Related: https://github.com/Samsung/ONE/issues/11374

ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>