### PR TITLE
[hermes-std] Check getenv once per instance

### DIFF
--- a/compiler/hermes-std/include/hermes/ConsoleReporter.h
+++ b/compiler/hermes-std/include/hermes/ConsoleReporter.h
@@ -32,6 +32,7 @@ struct ConsoleReporter final : public hermes::Sink
 
 private:
   bool _is_colored = false;
+  bool _env_checked = false;
 };
 
 } // namespace hermes

--- a/compiler/hermes-std/src/ConsoleReporter.cpp
+++ b/compiler/hermes-std/src/ConsoleReporter.cpp
@@ -42,12 +42,16 @@ static constexpr const char *kTermColorResetAllCode = "\033[0m";
 
 void ConsoleReporter::notify(const hermes::Message *m)
 {
-  const char *env_color_p = std::getenv("ONE_HERMES_COLOR");
-  if (env_color_p)
+  if (not _env_checked)
   {
-    auto env_color_str = std::string(env_color_p);
-    if ((env_color_str == "1") or (env_color_str == "ON"))
-      _is_colored = true;
+    const char *env_color_p = std::getenv("ONE_HERMES_COLOR");
+    if (env_color_p)
+    {
+      auto env_color_str = std::string(env_color_p);
+      if ((env_color_str == "1") or (env_color_str == "ON"))
+        _is_colored = true;
+    }
+    _env_checked = true;
   }
 
   if (_is_colored)


### PR DESCRIPTION
This will revise to check environment variable only once per instance of ConsoleReporter.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>