### PR TITLE
[circle-mpqsolver] Revise getSingleDataProvider name

### DIFF
--- a/compiler/circle-mpqsolver/src/bisection/BisectionSolver.test.cpp
+++ b/compiler/circle-mpqsolver/src/bisection/BisectionSolver.test.cpp
@@ -61,7 +61,7 @@ TEST_F(CircleMPQSolverBisectionSolverTestF, verifyResultsTest)
   // create solver
   mpqsolver::core::Quantizer::Context ctx;
   mpqsolver::bisection::BisectionSolver solver(ctx, 0.5);
-  auto data = mpqsolver::test::data_utils::getSingleDataProvider();
+  auto data = mpqsolver::test::data_utils::getAllZeroSingleDataProvider();
   solver.setInputData(std::move(data));
   solver.algorithm(mpqsolver::bisection::BisectionSolver::Algorithm::ForceQ16Back);
   SolverOutput::get().TurnOn(false);

--- a/compiler/circle-mpqsolver/src/core/Evaluator.test.cpp
+++ b/compiler/circle-mpqsolver/src/core/Evaluator.test.cpp
@@ -30,7 +30,7 @@ TEST(CircleMPQSolverEvaluatorTest, verifyResultsTest)
   g.transfer_to(m.get());
 
   mpqsolver::core::MAEMetric metric;
-  auto data = mpqsolver::test::data_utils::getSingleDataProvider();
+  auto data = mpqsolver::test::data_utils::getAllZeroSingleDataProvider();
   mpqsolver::core::DatasetEvaluator evaluator(m.get(), *data.get(), metric);
   float value = evaluator.evaluate(m.get());
   EXPECT_FLOAT_EQ(value, 0.f);

--- a/compiler/circle-mpqsolver/src/core/TestHelper.h
+++ b/compiler/circle-mpqsolver/src/core/TestHelper.h
@@ -136,7 +136,7 @@ bool isFileExists(const std::string &file_path);
 namespace data_utils
 {
 
-std::unique_ptr<mpqsolver::core::DataProvider> getSingleDataProvider();
+std::unique_ptr<mpqsolver::core::DataProvider> getAllZeroSingleDataProvider();
 
 } // namespace data_utils
 

--- a/compiler/circle-mpqsolver/src/core/TestHelper.test.cpp
+++ b/compiler/circle-mpqsolver/src/core/TestHelper.test.cpp
@@ -229,7 +229,7 @@ public:
   }
 };
 
-std::unique_ptr<mpqsolver::core::DataProvider> getSingleDataProvider()
+std::unique_ptr<mpqsolver::core::DataProvider> getAllZeroSingleDataProvider()
 {
   return std::make_unique<SingleDataProvider>();
 }


### PR DESCRIPTION
This commit renames getSingleDataProvider as
getAllZeroSingleDataProvider for clarity.

ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>

---
Original: https://github.com/Samsung/ONE/pull/12117#discussion_r1405731891