### PR TITLE
[circle-mpqsolver] Add comment to PatternSolver

### DIFF
--- a/compiler/circle-mpqsolver/src/pattern/PatternSolver.h
+++ b/compiler/circle-mpqsolver/src/pattern/PatternSolver.h
@@ -48,6 +48,9 @@ struct FrozenNodes
 class PatternSolver final : public MPQSolver
 {
 public:
+  /**
+   * @brief construct PatternSolver using qunatization context and patterns to apply
+   */
   PatternSolver(const mpqsolver::core::Quantizer::Context &ctx,
                 const std::vector<QuantizationPattern> &patterns);
 


### PR DESCRIPTION
This commit adds comment to PatternSolver constructor.

ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>