### PR TITLE
[circle-mpqsolver] Tidy Quantizer

### DIFF
--- a/compiler/circle-mpqsolver/src/core/Quantizer.cpp
+++ b/compiler/circle-mpqsolver/src/core/Quantizer.cpp
@@ -120,7 +120,6 @@ bool Quantizer::quantize(luci::Module *module, const std::string &quant_dtype,
  * @brief quantize recorded module (min/max initialized) with specified parameters
  * returns true on success
  */
-
 bool Quantizer::quantize(luci::Module *module, LayerParams &layer_params)
 {
   return quantize(module, _ctx.output_model_dtype, layer_params);


### PR DESCRIPTION
This commit removes unnecessary line between comment and implementation of quantize.

ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>