### PR TITLE
[onert] Apply reduction type to Loss

### DIFF
--- a/compute/cker/include/cker/train/operation/Loss.h
+++ b/compute/cker/include/cker/train/operation/Loss.h
@@ -29,31 +29,31 @@ namespace cker
 namespace train
 {
 
+template <typename T> inline T square(T value) { return value * value; }
+
 template <typename T>
 inline void MSE(const Shape &y_pred_shape, const T *y_pred_data, const Shape &y_true_shape,
                 const T *y_true_data, const Shape &output_shape, T *output_data)
 {
-  // TODO Consider Reduction
-  if (output_shape != Shape{1})
-    throw std::runtime_error("cker::MSE: output_shape != Shape{1}");
+  if (output_shape.DimensionsCount() != 1)
+    throw std::runtime_error("cker::MSE: output dimension count should be 1");
+  if (output_shape.Dims(0) != y_pred_shape.Dims(0))
+    throw std::runtime_error("cker::MSE: output and y_pred do not have the same batch");
   if (y_pred_shape != y_true_shape)
     throw std::runtime_error("cker::MSE: y_pred_shape != y_true_shape");
 
-  const auto y_pred = MapAsMatrixWithLastDimAsRows(y_pred_data, y_pred_shape);
-  const auto y_true = MapAsMatrixWithLastDimAsRows(y_true_data, y_true_shape);
+  const auto batch = y_pred_shape.Dims(0);
+  const auto size = FlatSizeSkipDim(y_pred_shape, 0);
 
-  double squared_sum = 0.0f;
-  for (size_t c = 0; c < (size_t)y_pred.cols(); ++c)
+  for (int b = 0; b < batch; ++b)
   {
-    for (size_t r = 0; r < (size_t)y_pred.rows(); ++r)
+    float sum = 0.f;
+    for (int i = 0; i < size; ++i)
     {
-      double error = y_pred.coeff(r, c) - y_true.coeff(r, c);
-      squared_sum += (error * error);
+      sum += square(y_pred_data[b * size + i] - y_true_data[b * size + i]);
     }
+    output_data[b] = static_cast<T>(sum / size);
   }
-
-  auto size = y_pred.cols() * y_pred.rows();
-  output_data[0] = (T)(squared_sum / size);
 }
 
 template <typename T>

--- a/compute/cker/src/train/Loss.test.cc
+++ b/compute/cker/src/train/Loss.test.cc
@@ -136,13 +136,16 @@ TEST(CKer_Operation, LossMSE)
     // Shape: {2, 3} -> m_rows:3, m_cols:2
     std::vector<float> y_pred = {27.2, 31.8, 51.9, 10.2, 34.2, 12.4};
     std::vector<float> y_true = {31.3, 40.3, 29.7, 12.9, 25.8, 11.9};
-    std::vector<float> output(1);
-    std::vector<float> expected = {110.0};
+    std::vector<float> output(2);
+    std::vector<float> expected = {193.9667, 26.033342};
 
     nnfw::cker::train::MSE(nnfw::cker::Shape{2, 3}, y_pred.data(), nnfw::cker::Shape{2, 3},
-                           y_true.data(), nnfw::cker::Shape{1}, output.data());
+                           y_true.data(), nnfw::cker::Shape{2}, output.data());
 
-    EXPECT_FLOAT_EQ(output[0], expected[0]);
+    for (int i = 0; i < output.size(); ++i)
+    {
+      EXPECT_FLOAT_EQ(output[i], expected[i]);
+    }
   }
 
   {
@@ -151,13 +154,16 @@ TEST(CKer_Operation, LossMSE)
                                  1., 2., 3., 4., 1., 2., 3., 4., 1., 2., 3., 4.};
     std::vector<float> y_true = {1., 1., 1., 1., 2., 2., 2., 2., 3., 3., 3., 3.,
                                  1., 1., 1., 1., 2., 2., 2., 2., 3., 3., 3., 3.};
-    std::vector<float> output(1);
-    std::vector<float> expected = {2.1666667};
+    std::vector<float> output(2);
+    std::vector<float> expected = {2.1666667, 2.1666667};
 
     nnfw::cker::train::MSE(nnfw::cker::Shape{2, 3, 4}, y_pred.data(), nnfw::cker::Shape{2, 3, 4},
-                           y_true.data(), nnfw::cker::Shape{1}, output.data());
+                           y_true.data(), nnfw::cker::Shape{2}, output.data());
 
-    EXPECT_FLOAT_EQ(output[0], expected[0]);
+    for (int i = 0; i < output.size(); ++i)
+    {
+      EXPECT_FLOAT_EQ(output[i], expected[i]);
+    }
   }
 }
 
@@ -167,13 +173,16 @@ TEST(CKer_Operation, neg_LossMSE)
     // Invalid expected value
     std::vector<float> y_pred = {1., 2., 3., 4., 5., 6., 7., 8., 9., 10.};
     std::vector<float> y_true = {0., 1., 2., 3., 4., 5., 6., 7., 8., 9.};
-    std::vector<float> output(1);
-    std::vector<float> expected = {-1.0};
+    std::vector<float> output(2);
+    std::vector<float> expected = {0.0, 0.0};
 
-    nnfw::cker::train::MSE(nnfw::cker::Shape{2, 3, 4}, y_pred.data(), nnfw::cker::Shape{2, 3, 4},
-                           y_true.data(), nnfw::cker::Shape{1}, output.data());
+    nnfw::cker::train::MSE(nnfw::cker::Shape{2, 5}, y_pred.data(), nnfw::cker::Shape{2, 5},
+                           y_true.data(), nnfw::cker::Shape{2}, output.data());
 
-    EXPECT_NE(output[0], expected[0]);
+    for (int i = 0; i < output.size(); ++i)
+    {
+      EXPECT_NE(output[i], expected[i]);
+    }
   }
 
   {
@@ -181,10 +190,10 @@ TEST(CKer_Operation, neg_LossMSE)
     std::vector<float> y_pred = {1., 2., 3., 4., 5., 6., 7., 8., 9., 10.};
     std::vector<float> y_true = {0., 1., 2., 3., 4., 5., 6., 7., 8., 9.};
     std::vector<float> output(3);
-    std::vector<float> expected = {1.0};
+    std::vector<float> expected = {1.0, 1.0};
 
-    EXPECT_ANY_THROW(nnfw::cker::train::MSE(nnfw::cker::Shape{2, 3, 4}, y_pred.data(),
-                                            nnfw::cker::Shape{2, 3, 4}, y_true.data(),
+    EXPECT_ANY_THROW(nnfw::cker::train::MSE(nnfw::cker::Shape{2, 5}, y_pred.data(),
+                                            nnfw::cker::Shape{2, 5}, y_true.data(),
                                             nnfw::cker::Shape{3}, output.data()));
   }
 
@@ -192,12 +201,12 @@ TEST(CKer_Operation, neg_LossMSE)
     // Different y_pread and y_true shape
     std::vector<float> y_pred = {1., 2., 3., 4., 5., 6., 7., 8., 9., 10.};
     std::vector<float> y_true = {0., 1., 2., 3., 4., 5.};
-    std::vector<float> output(1);
-    std::vector<float> expected = {1.0};
+    std::vector<float> output(2);
+    std::vector<float> expected = {1.0, 1.0};
 
-    EXPECT_ANY_THROW(nnfw::cker::train::MSE(nnfw::cker::Shape{2, 3, 4}, y_pred.data(),
+    EXPECT_ANY_THROW(nnfw::cker::train::MSE(nnfw::cker::Shape{2, 5}, y_pred.data(),
                                             nnfw::cker::Shape{2, 3}, y_true.data(),
-                                            nnfw::cker::Shape{1}, output.data()));
+                                            nnfw::cker::Shape{2}, output.data()));
   }
 }
 

--- a/runtime/onert/core/src/compiler/ExecutorFactory.cc
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.cc
@@ -885,7 +885,8 @@ exec::IExecutor *ExecutorFactory::createTrainableExecutor(
                                                  tensor_regs,
                                                  std::move(code_map),
                                                  order,
-                                                 tracing_ctx};
+                                                 tracing_ctx,
+                                                 training_info.lossInfo()};
 
   if (!options->trace_filepath.empty())
   {

--- a/runtime/onert/core/src/compiler/StaticShapeInferer.cc
+++ b/runtime/onert/core/src/compiler/StaticShapeInferer.cc
@@ -605,11 +605,22 @@ void StaticShapeInferer::visit(const ir::operation::L2Normalization &op)
   handleSimpleUnaryOp(op, op.getInputs().at(ir::operation::L2Normalization::Input::INPUT));
 }
 
-void StaticShapeInferer::visit(const ir::operation::Loss &)
+void StaticShapeInferer::visit(const ir::operation::Loss &op)
 {
   // TODO Consider SparseCategoricalCrossentropy case
 
-  // TODO Consider output shape in case of reduction option
+  auto &operands = _lowered_subg->graph().operands();
+
+  const auto input_index{op.getInputs().at(ir::operation::Loss::Input::Y_PRED)};
+  auto &input = operands.at(input_index);
+
+  const auto output_index{op.getOutputs().at(0)};
+  auto &output = operands.at(output_index);
+
+  ir::Shape new_shape = output.info().shape();
+  new_shape.dim(0) = input.info().shape().dim(0);
+
+  output.info().shape(new_shape);
 }
 
 void StaticShapeInferer::visit(const ir::operation::LSTM &op)

--- a/runtime/onert/core/src/exec/train/TrainableExecutor.cc
+++ b/runtime/onert/core/src/exec/train/TrainableExecutor.cc
@@ -33,10 +33,10 @@ TrainableExecutor::TrainableExecutor(
   backend::train::TrainableBackendContexts &&backend_contexts,
   const compiler::train::TensorRegistries &tensor_regs,
   compiler::train::TrainableCodeMap &&code_map, const std::vector<ir::OperationIndex> &order,
-  const util::TracingCtx *tracing_ctx)
+  const util::TracingCtx *tracing_ctx, const ir::train::LossInfo &loss_info)
   : _lowered_graph{std::move(lowered_graph)}, _backend_contexts{std::move(backend_contexts)},
     _trainable_graph{_lowered_graph->trainable_graph()}, _tensor_regs{std::move(tensor_regs)},
-    _mutex(), _tracing_ctx(tracing_ctx)
+    _mutex(), _tracing_ctx(tracing_ctx), _loss_info(loss_info)
 {
   auto build_tensor_list = [&](const auto &ind_seq, auto &tensors) {
     assert(tensors.empty());
@@ -195,8 +195,16 @@ float TrainableExecutor::getLoss(const ir::IOIndex &pred_io_ind) const
   if (loss_ind.undefined())
     throw std::runtime_error{"Loss " + std::to_string(loss_ind.value()) + " is not defined."};
   backend::ITensor *tensor = _tensor_regs.getITensor(loss_ind);
-  auto loss_buf = reinterpret_cast<float *>(tensor->buffer());
-  return *loss_buf;
+  long double sum = 0;
+  for (uint64_t i = 0; i < tensor->getShape().num_elements(); ++i)
+  {
+    sum += reinterpret_cast<float *>(tensor->buffer())[i];
+  }
+  if (_loss_info.reduction_type == ir::train::LossReductionType::SumOverBatchSize)
+  {
+    sum /= tensor->getShape().num_elements();
+  }
+  return static_cast<float>(sum);
 }
 
 } // namespace train

--- a/runtime/onert/core/src/exec/train/TrainableExecutor.h
+++ b/runtime/onert/core/src/exec/train/TrainableExecutor.h
@@ -25,6 +25,7 @@
 #include "backend/train/TrainableBackendContext.h"
 #include "compiler/train/TrainableCodeMap.h"
 #include "compiler/train/LoweredTrainableGraph.h"
+#include "ir/train/LossInfo.h"
 #include "ir/Index.h"
 #include "util/TracingCtx.h"
 
@@ -49,7 +50,7 @@ public:
                     const compiler::train::TensorRegistries &tensor_regs,
                     compiler::train::TrainableCodeMap &&code_map,
                     const std::vector<ir::OperationIndex> &order,
-                    const util::TracingCtx *tracing_ctx);
+                    const util::TracingCtx *tracing_ctx, const ir::train::LossInfo &training_info);
 
 public:
   const ir::Graph &graph() const final { return _trainable_graph.graph(); }
@@ -100,6 +101,7 @@ private:
   std::vector<backend::builtin::IOTensor *> _output_tensors;
   std::mutex _mutex;
   const util::TracingCtx *_tracing_ctx;
+  const ir::train::LossInfo _loss_info;
 };
 
 } // namespace train


### PR DESCRIPTION
This commit applies a reduction type to the Loss operation. It changes the loss output shape to match the batch size using a static shape inferer. The loss information is stored in the TrainingExecutor and the loss value is returned according to the reduction type.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>