### PR TITLE
[luci/import] Revise validate_minmax with int16

### DIFF
--- a/compiler/luci/import/src/ValidateHelpers.cpp
+++ b/compiler/luci/import/src/ValidateHelpers.cpp
@@ -79,6 +79,7 @@ bool validate_minmax(const GraphBuilderBase::ValidateArgs &args)
     case circle::TensorType_FLOAT16:
     case circle::TensorType_FLOAT32:
     case circle::TensorType_FLOAT64:
+    case circle::TensorType_INT16:
     case circle::TensorType_INT32:
     case circle::TensorType_INT64:
     case circle::TensorType_UINT8:


### PR DESCRIPTION
This will revise validate_minmax method to support INT16 quantized model.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>