### PR TITLE
[common-artifacts] Enable optimization test for BroadcastTo op

### DIFF
--- a/compiler/common-artifacts/exclude.lst
+++ b/compiler/common-artifacts/exclude.lst
@@ -5,9 +5,6 @@
 
 #[[ optimize : Exclude from circle optimization(circle2circle) ]]
 ## TensorFlowLiteRecipes
-optimize(BroadcastTo_000)
-optimize(BroadcastTo_001)
-optimize(BroadcastTo_002)
 
 ## CircleRecipes
 


### PR DESCRIPTION
This enables the test of circle optimization generation for BroadcastTo op.

ONE-DCO-1.0-Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>

---
Related to Issue: https://github.com/Samsung/ONE/issues/10784
Draft PR: [#10737](https://github.com/Samsung/ONE/pull/11701)