### PR TITLE
[onert] Support FloorMod

### DIFF
--- a/compute/cker/include/cker/operation/FloorMod.h
+++ b/compute/cker/include/cker/operation/FloorMod.h
@@ -23,6 +23,7 @@
 
 #include <functional>
 #include <stdexcept>
+#include <string>
 
 namespace nnfw
 {
@@ -42,15 +43,9 @@ inline void FloorModBroadcast(const Shape &unextended_input1_shape, const T *inp
   using ModFunc =
     typename std::conditional<std::is_integral<T>::value, std::modulus<T>, FloatMod>::type;
 
-  if (unextended_input1_shape.DimensionsCount() > 4)
-    throw std::runtime_error("cker::FloorModBroadcast: Unsupported rank size : " +
-                             unextended_input1_shape.DimensionsCount());
-  if (unextended_input2_shape.DimensionsCount() > 4)
-    throw std::runtime_error("cker::FloorModBroadcast: Unsupported rank size : " +
-                             unextended_input2_shape.DimensionsCount());
   if (unextended_output_shape.DimensionsCount() > 4)
-    throw std::runtime_error("cker::FloorModBroadcast: Unsupported rank size : " +
-                             unextended_output_shape.DimensionsCount());
+    throw std::runtime_error(std::string("cker::FloorModBroadcast: Unsupported rank size : ") +
+                             std::to_string(unextended_output_shape.DimensionsCount()));
   const Shape output_shape = Shape::ExtendedShape(4, unextended_output_shape);
 
   NdArrayDesc<4> desc1;

--- a/runtime/onert/backend/cpu/KernelGenerator.cc
+++ b/runtime/onert/backend/cpu/KernelGenerator.cc
@@ -133,6 +133,8 @@ convertElementwiseBinaryType(ir::operation::ElementwiseBinary::ElementwiseBinary
   {
     case ir::operation::ElementwiseBinary::ElementwiseBinaryType::FLOOR_DIV:
       return ops::ElementwiseBinaryType::kFloorDiv;
+    case ir::operation::ElementwiseBinary::ElementwiseBinaryType::FLOOR_MOD:
+      return ops::ElementwiseBinaryType::kFloorMod;
     case ir::operation::ElementwiseBinary::ElementwiseBinaryType::LOGICAL_AND:
       return ops::ElementwiseBinaryType::kLogicalAnd;
     case ir::operation::ElementwiseBinary::ElementwiseBinaryType::LOGICAL_OR:

--- a/runtime/onert/backend/cpu/ops/ElementwiseBinaryLayer.cc
+++ b/runtime/onert/backend/cpu/ops/ElementwiseBinaryLayer.cc
@@ -19,6 +19,7 @@
 #include "OperationUtils.h"
 
 #include <cker/operation/FloorDiv.h>
+#include <cker/operation/FloorMod.h>
 #include <cker/operation/LogicalAnd.h>
 #include <cker/operation/LogicalOr.h>
 #include <cker/operation/MaxMin.h>
@@ -46,6 +47,22 @@ void FloorDivGeneric(const IPortableTensor *lhs, const IPortableTensor *rhs,
   else
   {
     nnfw::cker::FloorDivElementwise<T>(getShape(lhs), getBuffer<T>(lhs), getBuffer<T>(rhs),
+                                       getBuffer<T>(output));
+  }
+}
+
+template <typename T>
+void FloorModGeneric(const IPortableTensor *lhs, const IPortableTensor *rhs,
+                     IPortableTensor *output)
+{
+  if (!HaveSameShapes(lhs, rhs))
+  {
+    nnfw::cker::FloorModBroadcast<T>(getShape(lhs), getBuffer<T>(lhs), getShape(rhs),
+                                     getBuffer<T>(rhs), getShape(output), getBuffer<T>(output));
+  }
+  else
+  {
+    nnfw::cker::FloorModElementwise<T>(getShape(lhs), getBuffer<T>(lhs), getBuffer<T>(rhs),
                                        getBuffer<T>(output));
   }
 }
@@ -130,6 +147,20 @@ void ElementwiseBinaryLayer::configure(const IPortableTensor *lhs, const IPortab
       else
       {
         throw std::runtime_error{"Max: unsupported data type"};
+      }
+      break;
+    case ElementwiseBinaryType::kFloorMod:
+      if (_lhs->data_type() == OperandType::FLOAT32)
+      {
+        _kernel = FloorModGeneric<float>;
+      }
+      else if (_lhs->data_type() == OperandType::INT64)
+      {
+        _kernel = FloorModGeneric<int64_t>;
+      }
+      else
+      {
+        throw std::runtime_error{"FloorMod: unsupported data type"};
       }
       break;
     case ElementwiseBinaryType::kLogicalAnd:

--- a/runtime/onert/backend/cpu/ops/ElementwiseBinaryLayer.h
+++ b/runtime/onert/backend/cpu/ops/ElementwiseBinaryLayer.h
@@ -33,6 +33,7 @@ namespace ops
 enum class ElementwiseBinaryType
 {
   kFloorDiv,
+  kFloorMod,
   kLogicalAnd,
   kLogicalOr,
   kMax,

--- a/tests/nnfw_api/src/CircleGen.cc
+++ b/tests/nnfw_api/src/CircleGen.cc
@@ -269,6 +269,12 @@ uint32_t CircleGen::addOperatorFloorDiv(const OperatorParams &params)
                                 circle::BuiltinOptions_NONE, 0);
 }
 
+uint32_t CircleGen::addOperatorFloorMod(const OperatorParams &params)
+{
+  return addOperatorWithOptions(params, circle::BuiltinOperator_FLOOR_MOD,
+                                circle::BuiltinOptions_NONE, 0);
+}
+
 uint32_t CircleGen::addOperatorGreater(const OperatorParams &params)
 {
   auto options = circle::CreateLessOptions(_fbb).Union();

--- a/tests/nnfw_api/src/CircleGen.h
+++ b/tests/nnfw_api/src/CircleGen.h
@@ -171,6 +171,7 @@ public:
   uint32_t addOperatorFill(const OperatorParams &params);
   uint32_t addOperatorFloor(const OperatorParams &params);
   uint32_t addOperatorFloorDiv(const OperatorParams &params);
+  uint32_t addOperatorFloorMod(const OperatorParams &params);
   uint32_t addOperatorFullyConnected(const OperatorParams &params,
                                      circle::FullyConnectedOptionsWeightsFormat weights_format =
                                        circle::FullyConnectedOptionsWeightsFormat_DEFAULT);

--- a/tests/nnfw_api/src/one_op_tests/FloorMod.test.cc
+++ b/tests/nnfw_api/src/one_op_tests/FloorMod.test.cc
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "GenModelTest.h"
+
+#include <memory>
+
+TEST_F(GenModelTest, OneOp_FloorMod_VarToVar_Float)
+{
+  CircleGen cgen;
+  int lhs = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_FLOAT32});
+  int rhs = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_FLOAT32});
+  int out = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_FLOAT32});
+  cgen.addOperatorFloorMod({{lhs, rhs}, {out}});
+  cgen.setInputsAndOutputs({lhs, rhs}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->addTestCase(
+    uniformTCD<float>({{4.0, -3.0, -7.8, 26.2}, {2.0, 2.0, -3.0, -4.0}}, {{0.0, 1.0, -1.8, -1.8}}));
+  _context->setBackends({"cpu"});
+
+  SUCCEED();
+}
+
+TEST_F(GenModelTest, OneOp_FloorMod_VarToVar_Float_Broadcast)
+{
+  CircleGen cgen;
+  int lhs = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_FLOAT32});
+  int rhs = cgen.addTensor({{1}, circle::TensorType::TensorType_FLOAT32});
+  int out = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_FLOAT32});
+  cgen.addOperatorFloorMod({{lhs, rhs}, {out}});
+  cgen.setInputsAndOutputs({lhs, rhs}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->addTestCase(
+    uniformTCD<float>({{4.0, -3.0, -6.8, 24.2}, {-3.0}}, {{-2.0, 0.0, -0.8, -2.8}}));
+  _context->setBackends({"cpu"});
+
+  SUCCEED();
+}
+
+TEST_F(GenModelTest, neg_OneOp_FloorMod_VarToVar_InvalidType1)
+{
+  CircleGen cgen;
+  int lhs = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_FLOAT32});
+  int rhs = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_INT32});
+  int out = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_FLOAT32});
+  cgen.addOperatorFloorMod({{lhs, rhs}, {out}});
+  cgen.setInputsAndOutputs({lhs, rhs}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->setBackends({"cpu"});
+  _context->expectFailModelLoad();
+
+  SUCCEED();
+}
+
+TEST_F(GenModelTest, neg_OneOp_FloorMod_Broadcast_InvalidType1)
+{
+  CircleGen cgen;
+  int lhs = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_FLOAT32});
+  int rhs = cgen.addTensor({{1}, circle::TensorType::TensorType_INT32});
+  int out = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_FLOAT32});
+  cgen.addOperatorFloorMod({{lhs, rhs}, {out}});
+  cgen.setInputsAndOutputs({lhs, rhs}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->setBackends({"cpu"});
+  _context->expectFailModelLoad();
+
+  SUCCEED();
+}
+
+TEST_F(GenModelTest, OneOp_FloorMod_VarToVar_Int64)
+{
+  CircleGen cgen;
+  int lhs = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_INT64});
+  int rhs = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_INT64});
+  int out = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_INT64});
+  cgen.addOperatorFloorMod({{lhs, rhs}, {out}});
+  cgen.setInputsAndOutputs({lhs, rhs}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->addTestCase(
+    uniformTCD<int64_t>({{10, 21, -68, 242}, {1, 2, -3, -4}}, {{0, 1, -2, -2}}));
+  _context->setBackends({"cpu"});
+
+  SUCCEED();
+}
+
+TEST_F(GenModelTest, OneOp_FloorMod_VarToVar_Int64_Broadcast)
+{
+  CircleGen cgen;
+  int lhs = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_INT64});
+  int rhs = cgen.addTensor({{1}, circle::TensorType::TensorType_INT64});
+  int out = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_INT64});
+  cgen.addOperatorFloorMod({{lhs, rhs}, {out}});
+  cgen.setInputsAndOutputs({lhs, rhs}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->addTestCase(uniformTCD<int64_t>({{10, 21, -67, 242}, {-3}}, {{-2, 0, -1, -1}}));
+  _context->setBackends({"cpu"});
+
+  SUCCEED();
+}
+
+TEST_F(GenModelTest, neg_OneOp_FloorMod_VarToVar_InvalidType2)
+{
+  CircleGen cgen;
+  int lhs = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_INT32});
+  int rhs = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_FLOAT32});
+  int out = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_INT32});
+  cgen.addOperatorFloorMod({{lhs, rhs}, {out}});
+  cgen.setInputsAndOutputs({lhs, rhs}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->setBackends({"cpu"});
+  _context->expectFailModelLoad();
+
+  SUCCEED();
+}
+
+TEST_F(GenModelTest, neg_OneOp_FloorMod_Broadcast_InvalidType2)
+{
+  CircleGen cgen;
+  int lhs = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_INT32});
+  int rhs = cgen.addTensor({{1}, circle::TensorType::TensorType_FLOAT32});
+  int out = cgen.addTensor({{1, 2, 2, 1}, circle::TensorType::TensorType_INT32});
+  cgen.addOperatorFloorMod({{lhs, rhs}, {out}});
+  cgen.setInputsAndOutputs({lhs, rhs}, {out});
+
+  _context = std::make_unique<GenModelTestContext>(cgen.finish());
+  _context->setBackends({"cpu"});
+  _context->expectFailModelLoad();
+
+  SUCCEED();
+}


### PR DESCRIPTION
This commit makes onert support FloorMod op.
  - Add FloorMod unit tests to one_op_tests
  - Support float and int64
  - Apply FloorMod cpu kernel

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>