### PR TITLE
[circle-mpqsolver] Revisit Dumper

### DIFF
--- a/compiler/circle-mpqsolver/src/core/Dumper.cpp
+++ b/compiler/circle-mpqsolver/src/core/Dumper.cpp
@@ -40,10 +40,10 @@ const std::string layer_granularity_key = "granularity";
 
 Dumper::Dumper(const std::string &dir_path) : _dir_path(dir_path) {}
 
-void Dumper::set_model_path(const std::string &model_path) { _model_path = model_path; }
+void Dumper::setModelPath(const std::string &model_path) { _model_path = model_path; }
 
-void Dumper::dump_MPQ_configuration(const LayerParams &layers, const std::string &def_dtype,
-                                    const std::string &path) const
+void Dumper::dumpMPQConfiguration(const LayerParams &layers, const std::string &def_dtype,
+                                  const std::string &path) const
 {
   Json::Value mpq_data;
   mpq_data[default_dtype_key] = def_dtype;
@@ -64,10 +64,10 @@ void Dumper::dump_MPQ_configuration(const LayerParams &layers, const std::string
   Json::StreamWriterBuilder builder;
   auto data = Json::writeString(builder, mpq_data);
 
-  write_data_to_file(path, data);
+  writeDataToFile(path, data);
 }
 
-void Dumper::prepare_directory(const std::string &dir_path) const
+void Dumper::prepareDirectory(const std::string &dir_path) const
 {
   struct stat sb;
   if (stat(dir_path.c_str(), &sb) != 0 || !S_ISDIR(sb.st_mode))
@@ -79,22 +79,22 @@ void Dumper::prepare_directory(const std::string &dir_path) const
   }
 }
 
-void Dumper::dump_MPQ_configuration(const LayerParams &layers, const std::string &def_dtype,
-                                    int step) const
+void Dumper::dumpMPQConfiguration(const LayerParams &layers, const std::string &def_dtype,
+                                  int step) const
 {
-  prepare_directory(_dir_path);
+  prepareDirectory(_dir_path);
   std::string path = _dir_path + "/Configuration_" + std::to_string(step) + ".mpq.json";
-  dump_MPQ_configuration(layers, def_dtype, path);
+  dumpMPQConfiguration(layers, def_dtype, path);
 }
 
-void Dumper::dump_final_MPQ(const LayerParams &layers, const std::string &def_dtype) const
+void Dumper::dumpFinalMPQ(const LayerParams &layers, const std::string &def_dtype) const
 {
-  prepare_directory(_dir_path);
+  prepareDirectory(_dir_path);
   std::string path = _dir_path + "/FinalConfiguration" + ".mpq.json";
-  dump_MPQ_configuration(layers, def_dtype, path);
+  dumpMPQConfiguration(layers, def_dtype, path);
 }
 
-void Dumper::write_data_to_file(const std::string &path, const std::string &data) const
+void Dumper::writeDataToFile(const std::string &path, const std::string &data) const
 {
   std::ofstream file;
   file.open(path);
@@ -102,7 +102,7 @@ void Dumper::write_data_to_file(const std::string &path, const std::string &data
   file.close();
 }
 
-void Dumper::save_circle(luci::Module *module, std::string &path) const
+void Dumper::saveCircle(luci::Module *module, std::string &path) const
 {
   luci::CircleExporter exporter;
   luci::CircleFileExpContract contract(module, path);
@@ -112,13 +112,13 @@ void Dumper::save_circle(luci::Module *module, std::string &path) const
   }
 }
 
-void Dumper::dump_quantized(luci::Module *module, uint32_t step) const
+void Dumper::dumpQuantized(luci::Module *module, uint32_t step) const
 {
   std::string path = _dir_path + "/quantized_" + std::to_string(step) + ".mpq.circle";
-  save_circle(module, path);
+  saveCircle(module, path);
 }
 
-void Dumper::dump_error(float error, const std::string &tag, const std::string &path) const
+void Dumper::dumpError(float error, const std::string &tag, const std::string &path) const
 {
   std::ofstream file;
   file.open(path, std::ios_base::app);
@@ -126,35 +126,35 @@ void Dumper::dump_error(float error, const std::string &tag, const std::string &
   file.close();
 }
 
-void Dumper::prepare_for_error_dumping() const
+void Dumper::prepareForErrorDumping() const
 {
-  prepare_directory(_dir_path);
-  std::string path = get_error_path();
+  prepareDirectory(_dir_path);
+  std::string path = getErrorPath();
   std::ofstream file;
   file.open(path); // create empty
   file.close();
 }
 
-void Dumper::dump_Q8_error(float error) const
+void Dumper::dumpQ8Error(float error) const
 {
-  std::string path = get_error_path();
-  dump_error(error, "Q8", path);
+  std::string path = getErrorPath();
+  dumpError(error, "Q8", path);
 }
 
-void Dumper::dump_Q16_error(float error) const
+void Dumper::dumpQ16Error(float error) const
 {
-  std::string path = get_error_path();
-  dump_error(error, "Q16", path);
+  std::string path = getErrorPath();
+  dumpError(error, "Q16", path);
 }
 
-void Dumper::dump_MPQ_error(float error, uint32_t step) const
+void Dumper::dumpMPQError(float error, uint32_t step) const
 {
-  std::string path = get_error_path();
-  dump_error(error, std::to_string(step), path);
+  std::string path = getErrorPath();
+  dumpError(error, std::to_string(step), path);
 }
 
-void Dumper::dump_MPQ_error(float error) const
+void Dumper::dumpMPQError(float error) const
 {
-  std::string path = get_error_path();
-  dump_error(error, "FINAL", path);
+  std::string path = getErrorPath();
+  dumpError(error, "FINAL", path);
 }

--- a/compiler/circle-mpqsolver/src/core/Dumper.h
+++ b/compiler/circle-mpqsolver/src/core/Dumper.h
@@ -39,7 +39,7 @@ public:
   /**
    * @brief sets model path for further usage
    */
-  void set_model_path(const std::string &model_path);
+  void setModelPath(const std::string &model_path);
 
   /**
    * @brief dumps mpq configuration
@@ -47,59 +47,59 @@ public:
    * @param def_dtype default quantization data type
    * @param step id of mpq configuration
    */
-  void dump_MPQ_configuration(const LayerParams &layers, const std::string &def_dtype,
-                              int step) const;
+  void dumpMPQConfiguration(const LayerParams &layers, const std::string &def_dtype,
+                            int step) const;
 
   /**
    * @brief dumps final mpq configuration
    * @param layers specific quantization parameters
    * @param def_dtype default quantization data type
    */
-  void dump_final_MPQ(const LayerParams &layers, const std::string &def_dtype) const;
+  void dumpFinalMPQ(const LayerParams &layers, const std::string &def_dtype) const;
 
   /**
    * @brief dumps quantized module
    * @param layers specific quantization parameters
    * @param step id of quantized module
    */
-  void dump_quantized(luci::Module *module, uint32_t step) const;
+  void dumpQuantized(luci::Module *module, uint32_t step) const;
 
   /**
    * @brief create file for error dumping
    */
-  void prepare_for_error_dumping() const;
+  void prepareForErrorDumping() const;
 
   /**
    * @brief append error of Q8 quantization
    */
-  void dump_Q8_error(float error) const;
+  void dumpQ8Error(float error) const;
 
   /**
    * @brief append error of Q16 quantization
    */
-  void dump_Q16_error(float error) const;
+  void dumpQ16Error(float error) const;
 
   /**
    * @brief append error of mpq quantization
    * @param error error of quantization
    * @param step id of error
    */
-  void dump_MPQ_error(float error, uint32_t step) const;
+  void dumpMPQError(float error, uint32_t step) const;
 
   /**
    * @brief dump final error
    * @param error final error of quantization
    */
-  void dump_MPQ_error(float error) const;
+  void dumpMPQError(float error) const;
 
 private:
-  void write_data_to_file(const std::string &path, const std::string &data) const;
-  void dump_MPQ_configuration(const LayerParams &layers, const std::string &def_dtype,
-                              const std::string &path) const;
-  void prepare_directory(const std::string &dir_path) const;
-  void save_circle(luci::Module *module, std::string &path) const;
-  void dump_error(float error, const std::string &tag, const std::string &path) const;
-  std::string get_error_path() const { return _dir_path + "/errors" + ".mpq.txt"; }
+  void writeDataToFile(const std::string &path, const std::string &data) const;
+  void dumpMPQConfiguration(const LayerParams &layers, const std::string &def_dtype,
+                            const std::string &path) const;
+  void prepareDirectory(const std::string &dir_path) const;
+  void saveCircle(luci::Module *module, std::string &path) const;
+  void dumpError(float error, const std::string &tag, const std::string &path) const;
+  std::string getErrorPath() const { return _dir_path + "/errors" + ".mpq.txt"; }
 
 private:
   std::string _dir_path;

--- a/compiler/circle-mpqsolver/src/core/Dumper.test.cpp
+++ b/compiler/circle-mpqsolver/src/core/Dumper.test.cpp
@@ -53,19 +53,19 @@ protected:
 TEST_F(CircleMPQSolverDumperTest, verifyResultsTest)
 {
   mpqsolver::core::Dumper dumper(_folder);
-  dumper.set_model_path("");
+  dumper.setModelPath("");
   mpqsolver::core::LayerParams params;
   auto const step = 0;
-  dumper.dump_MPQ_configuration(params, "uint8", step);
+  dumper.dumpMPQConfiguration(params, "uint8", step);
 
   std::string step_path = _folder + "/Configuration_" + std::to_string(step) + ".mpq.json";
   EXPECT_TRUE(mpqsolver::test::io_utils::isFileExists(step_path));
 
-  dumper.dump_final_MPQ(params, "uint8");
+  dumper.dumpFinalMPQ(params, "uint8");
   std::string fin_path = _folder + "/FinalConfiguration" + ".mpq.json";
   EXPECT_TRUE(mpqsolver::test::io_utils::isFileExists(fin_path));
 
-  dumper.prepare_for_error_dumping();
+  dumper.prepareForErrorDumping();
   std::string errors_path = _folder + "/errors" + ".mpq.txt";
   EXPECT_TRUE(mpqsolver::test::io_utils::isFileExists(errors_path));
 }
@@ -73,11 +73,11 @@ TEST_F(CircleMPQSolverDumperTest, verifyResultsTest)
 TEST_F(CircleMPQSolverDumperTest, empty_path_NEG)
 {
   mpqsolver::core::Dumper dumper("");
-  dumper.set_model_path("");
+  dumper.setModelPath("");
 
   mpqsolver::core::LayerParams params;
   auto const step = 0;
-  EXPECT_THROW(dumper.dump_MPQ_configuration(params, "uint8", step), std::runtime_error);
-  EXPECT_THROW(dumper.dump_final_MPQ(params, "uint8"), std::runtime_error);
-  EXPECT_THROW(dumper.prepare_for_error_dumping(), std::runtime_error);
+  EXPECT_THROW(dumper.dumpMPQConfiguration(params, "uint8", step), std::runtime_error);
+  EXPECT_THROW(dumper.dumpFinalMPQ(params, "uint8"), std::runtime_error);
+  EXPECT_THROW(dumper.prepareForErrorDumping(), std::runtime_error);
 }

--- a/compiler/circle-mpqsolver/src/core/DumpingHooks.cpp
+++ b/compiler/circle-mpqsolver/src/core/DumpingHooks.cpp
@@ -26,10 +26,10 @@ DumpingHooks::DumpingHooks(const std::string &save_path)
 void DumpingHooks::on_begin_solver(const std::string &model_path, float q8error, float q16error)
 {
   _model_path = model_path;
-  _dumper.set_model_path(_model_path);
-  _dumper.prepare_for_error_dumping();
-  _dumper.dump_Q8_error(q8error);
-  _dumper.dump_Q16_error(q16error);
+  _dumper.setModelPath(_model_path);
+  _dumper.prepareForErrorDumping();
+  _dumper.dumpQ8Error(q8error);
+  _dumper.dumpQ16Error(q16error);
 }
 
 void DumpingHooks::on_begin_iteration()
@@ -41,15 +41,15 @@ void DumpingHooks::on_begin_iteration()
 void DumpingHooks::on_end_iteration(const LayerParams &layers, const std::string &def_type,
                                     float error) const
 {
-  _dumper.dump_MPQ_configuration(layers, def_type, _num_of_iterations);
-  _dumper.dump_MPQ_error(error, _num_of_iterations);
+  _dumper.dumpMPQConfiguration(layers, def_type, _num_of_iterations);
+  _dumper.dumpMPQError(error, _num_of_iterations);
 }
 
 void DumpingHooks::on_end_solver(const LayerParams &layers, const std::string &def_dtype,
                                  float qerror)
 {
-  _dumper.dump_final_MPQ(layers, def_dtype);
-  _dumper.dump_MPQ_error(qerror);
+  _dumper.dumpFinalMPQ(layers, def_dtype);
+  _dumper.dumpMPQError(qerror);
   _in_iterations = false;
 }
 
@@ -57,6 +57,6 @@ void DumpingHooks::on_quantized(luci::Module *module) const
 {
   if (_in_iterations)
   {
-    _dumper.dump_quantized(module, _num_of_iterations);
+    _dumper.dumpQuantized(module, _num_of_iterations);
   }
 }


### PR DESCRIPTION
This commit normalizes Dumper methods to camel notation and adjusts dependencies accordingly.

Related: #12156
ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>