### PR TITLE
[luci-compute] Enable FullyConnected weights_format conversion

### DIFF
--- a/compiler/luci-compute/src/ConvertTypes.cpp
+++ b/compiler/luci-compute/src/ConvertTypes.cpp
@@ -16,6 +16,7 @@
 #include "ConvertTypes.h"
 
 #include <cassert>
+#include <stdexcept>
 
 namespace luci
 {
@@ -44,6 +45,20 @@ tflite::PaddingType tflite_padding(const PaddingType type)
   }
   assert(false);
   return tflite::PaddingType::kNone;
+}
+
+tflite::FullyConnectedWeightsFormat tflite_weights_format(const FullyConnectedWeightsFormat type)
+{
+  switch (type)
+  {
+    case FullyConnectedWeightsFormat::kDefault:
+      return tflite::FullyConnectedWeightsFormat::kDefault;
+    case FullyConnectedWeightsFormat::kShuffled4x16Int8:
+      return tflite::FullyConnectedWeightsFormat::kShuffled4x16Int8;
+    default:
+      break;
+  }
+  throw std::runtime_error("luci-comp tflite_weights_format unsupported type.");
 }
 
 } // namespace compute

--- a/compiler/luci-compute/src/ConvertTypes.h
+++ b/compiler/luci-compute/src/ConvertTypes.h
@@ -31,6 +31,8 @@ tflite::RuntimeShape tflite_shape(const loco::TensorShape &shape);
 
 tflite::PaddingType tflite_padding(const PaddingType type);
 
+tflite::FullyConnectedWeightsFormat tflite_weights_format(const FullyConnectedWeightsFormat type);
+
 } // namespace compute
 } // namespace luci
 

--- a/compiler/luci-compute/src/FullyConnected.cpp
+++ b/compiler/luci-compute/src/FullyConnected.cpp
@@ -94,8 +94,7 @@ void FullyConnected::compute(void)
   params.float_activation_max     = _params.float_activation_max;
   params.lhs_cacheable            = _params.lhs_cacheable;
   params.rhs_cacheable            = _params.rhs_cacheable;
-  // TODO converty format
-  params.weights_format           = tflite::FullyConnectedWeightsFormat::kDefault;
+  params.weights_format           = tflite_weights_format(_params.weights_format);
   // clang-format on
 
   tflite::reference_ops::FullyConnected(


### PR DESCRIPTION
This will enable FullyConnected weights_format conversion.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>