### PR TITLE
[circle-mpqsolver] Revisit MPQSolver

### DIFF
--- a/compiler/circle-mpqsolver/src/CircleMPQSolver.cpp
+++ b/compiler/circle-mpqsolver/src/CircleMPQSolver.cpp
@@ -254,7 +254,7 @@ int entry(int argc, char **argv)
       auto data_path = arser.get<std::string>(save_intermediate_str);
       if (!data_path.empty())
       {
-        bi_solver->set_save_intermediate(data_path);
+        bi_solver->setSaveIntermediate(data_path);
       }
     }
 

--- a/compiler/circle-mpqsolver/src/MPQSolver.cpp
+++ b/compiler/circle-mpqsolver/src/MPQSolver.cpp
@@ -26,12 +26,12 @@ MPQSolver::MPQSolver(const core::Quantizer::Context &ctx)
   _quantizer = std::make_unique<core::Quantizer>(ctx);
 }
 
-void MPQSolver::set_save_intermediate(const std::string &save_path)
+void MPQSolver::setSaveIntermediate(const std::string &save_path)
 {
   _hooks = std::make_unique<core::DumpingHooks>(save_path);
 }
 
-std::unique_ptr<luci::Module> MPQSolver::read_module(const std::string &path)
+std::unique_ptr<luci::Module> MPQSolver::readModule(const std::string &path)
 {
   luci::ImporterEx importerex;
   auto module = importerex.importVerifyModule(path);

--- a/compiler/circle-mpqsolver/src/MPQSolver.h
+++ b/compiler/circle-mpqsolver/src/MPQSolver.h
@@ -43,10 +43,10 @@ public:
   /**
    * @brief set all intermediate artifacts to be saved
    */
-  void set_save_intermediate(const std::string &save_path);
+  void setSaveIntermediate(const std::string &save_path);
 
 protected:
-  std::unique_ptr<luci::Module> read_module(const std::string &path);
+  std::unique_ptr<luci::Module> readModule(const std::string &path);
 
 protected:
   std::string _input_quantization;

--- a/compiler/circle-mpqsolver/src/bisection/BisectionSolver.cpp
+++ b/compiler/circle-mpqsolver/src/bisection/BisectionSolver.cpp
@@ -84,7 +84,7 @@ float BisectionSolver::evaluate(const core::DatasetEvaluator &evaluator,
                                 const std::string &flt_path, const std::string &def_quant,
                                 core::LayerParams &layers)
 {
-  auto model = read_module(flt_path);
+  auto model = readModule(flt_path);
   assert(model != nullptr);
 
   // get fake quantized model for evaluation
@@ -107,7 +107,7 @@ void BisectionSolver::setInputData(std::unique_ptr<mpqsolver::core::DataProvider
 
 std::unique_ptr<luci::Module> BisectionSolver::run(const std::string &module_path)
 {
-  auto module = read_module(module_path);
+  auto module = readModule(module_path);
   assert(module != nullptr);
 
   float min_depth = 0.f;

--- a/compiler/circle-mpqsolver/src/pattern/PatternSolver.cpp
+++ b/compiler/circle-mpqsolver/src/pattern/PatternSolver.cpp
@@ -35,7 +35,7 @@ PatternSolver::PatternSolver(const mpqsolver::core::Quantizer::Context &ctx,
 
 std::unique_ptr<luci::Module> PatternSolver::run(const std::string &module_path)
 {
-  auto module = read_module(module_path);
+  auto module = readModule(module_path);
   assert(module != nullptr);
 
   resolve_patterns(module.get());


### PR DESCRIPTION
This commit normalizes MPQSolver methods to camel notation and adjusts dependencies accordingly.

Related: https://github.com/Samsung/ONE/issues/12156
ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>