### PR TITLE
[onert] Update Categorical crossentropy implementation

### DIFF
--- a/compute/cker/include/cker/train/operation/Loss.h
+++ b/compute/cker/include/cker/train/operation/Loss.h
@@ -30,6 +30,7 @@ namespace train
 {
 
 template <typename T> inline T square(T value) { return value * value; }
+template <typename T> inline T log_threshold() { return static_cast<T>(1e-20); }
 
 template <typename T>
 inline void MSE(const Shape &y_pred_shape, const T *y_pred_data, const Shape &y_true_shape,
@@ -72,62 +73,44 @@ inline void MSEGrad(const Shape &y_pred_shape, const T *y_pred_data, const Shape
   }
 }
 
-template <typename T> bool checkValue(const T *data, int size, T min, T max)
+template <typename T>
+inline void CategoricalCrossEntropy(const Shape &y_pred_shape, const T *y_pred_data,
+                                    const Shape &y_true_shape, const T *y_true_data,
+                                    const Shape &output_shape, T *output_data)
 {
-  for (int i = 0; i < size; ++i)
-  {
-    if (data[i] > max || data[i] < min)
-      return false;
-  }
-  return true;
+  if (output_shape.DimensionsCount() != 1)
+    throw std::runtime_error("cker::CategoricalCrossEntropy: output dimension count should be 1");
+  if (y_pred_shape != y_true_shape)
+    throw std::runtime_error(
+      "cker::CategoricalCrossEntropy: y_pred and y_true do not have the same shape");
+  if (output_shape.Dims(0) != y_pred_shape.Dims(0))
+    throw std::runtime_error(
+      "cker::CategoricalCrossEntropy: output and y_pred do not have the same batch");
+
+  const auto y_pred = MapAsMatrixWithLastDimAsRows(y_pred_data, y_pred_shape);
+  const auto y_true = MapAsMatrixWithLastDimAsRows(y_true_data, y_true_shape);
+  auto output = MapAsVector(output_data, output_shape);
+
+  output = -(y_true.array() * y_pred.array().cwiseMax(log_threshold<T>()).log()).colwise().sum();
 }
 
 template <typename T>
-inline void CategoricalCrossEntropy(const T *y_pred_data, const T *y_true_data, T *output_data,
-                                    const int batch_size, const int input_size)
+inline void CategoricalCrossEntropyGrad(const Shape &y_pred_shape, const T *y_pred_data,
+                                        const Shape &y_true_shape, const T *y_true_data,
+                                        const Shape &grad_shape, T *grad_data)
 {
-  const T *y_prob_data = y_pred_data;
+  if (y_pred_shape != y_true_shape)
+    throw std::runtime_error(
+      "cker::CategoricalCrossEntropyGrad: y_pred and y_true do not have the same shape");
+  if (y_pred_shape != grad_shape)
+    throw std::runtime_error(
+      "cker::CategoricalCrossEntropyGrad: y_pred and grad do not have the same shape");
 
-  if (!checkValue(y_pred_data, input_size * batch_size, static_cast<T>(0), static_cast<T>(1)))
-  {
-    throw std::runtime_error("cker::CategoricalCrossEntropy: y_pred data is not logit data.");
-  }
+  const auto y_pred = MapAsMatrixWithLastDimAsRows(y_pred_data, y_pred_shape);
+  const auto y_true = MapAsMatrixWithLastDimAsRows(y_true_data, y_true_shape);
+  auto grad = MapAsMatrixWithLastDimAsRows(grad_data, grad_shape);
 
-  std::vector<T> sum(batch_size, 0.f);
-  for (int b = 0; b < batch_size; ++b)
-  {
-    int b_offset = b * input_size;
-    for (int i = 0; i < input_size; ++i)
-    {
-      if (y_true_data[b_offset + i] != 0)
-      {
-        sum[b] += -std::log(std::max(y_prob_data[b_offset + i], static_cast<float>(1.0e-20))) *
-                  y_true_data[b_offset + i];
-      }
-    }
-  }
-
-  output_data[0] = std::accumulate(sum.begin(), sum.end(), 0.f) / static_cast<float>(batch_size);
-}
-
-template <typename T>
-inline void CategoricalCrossEntropyGrad(const T *y_pred_data, const T *y_true_data, T *grad_data,
-                                        const int batch_size, const int input_size)
-{
-  if (!checkValue(y_pred_data, input_size * batch_size, static_cast<T>(0), static_cast<T>(1)))
-  {
-    throw std::runtime_error("cker::CategoricalCrossEntropyGrad: y_pred data is not logit data.");
-  }
-
-  for (int b = 0; b < batch_size; ++b)
-  {
-    int b_offset = b * input_size;
-    for (int i = 0; i < input_size; ++i)
-    {
-      grad_data[b_offset + i] = -(y_true_data[b_offset + i] /
-                                  std::max(y_pred_data[b_offset + i], static_cast<float>(1e-20)));
-    }
-  }
+  grad = -(y_true.array() / y_pred.array().cwiseMax(log_threshold<T>()));
 }
 
 } // namespace train

--- a/compute/cker/src/train/Loss.test.cc
+++ b/compute/cker/src/train/Loss.test.cc
@@ -40,14 +40,15 @@ public:
     const int N = _in_shape.Dims(0);
     const int D = _in_shape.FlatSize() / N;
 
-    nnfw::cker::train::CategoricalCrossEntropy(y_pred.data(), y_true.data(), output.data(), N, D);
+    nnfw::cker::train::CategoricalCrossEntropy(_in_shape, y_pred.data(), _in_shape, y_true.data(),
+                                               _out_shape, output.data());
 
     // Don't be panic when it fails after kernel implementation or input is changed.
     // CrossEntropy formula can be calculated slightly differently depending on the environment
     // because it involes calculations such as log or exp.
     for (int i = 0; i < output.size(); ++i)
     {
-      EXPECT_FLOAT_EQ(output[i], expected[i]);
+      EXPECT_NEAR(output[i], expected[i], 1e-3f);
     }
   }
 
@@ -60,8 +61,8 @@ public:
     const int N = _in_shape.Dims(0);
     const int D = _in_shape.FlatSize() / N;
 
-    EXPECT_ANY_THROW(nnfw::cker::train::CategoricalCrossEntropy(y_pred.data(), y_true.data(),
-                                                                output.data(), N, D));
+    EXPECT_ANY_THROW(nnfw::cker::train::CategoricalCrossEntropy(
+      _in_shape, y_pred.data(), _in_shape, y_true.data(), _out_shape, output.data()));
   }
 
   void verifyBackward(const std::vector<T> &y_pred, const std::vector<T> &y_true,
@@ -73,15 +74,15 @@ public:
     const int N = _in_shape.Dims(0);
     const int D = _in_shape.FlatSize() / N;
 
-    nnfw::cker::train::CategoricalCrossEntropyGrad(y_pred.data(), y_true.data(), output.data(), N,
-                                                   D);
+    nnfw::cker::train::CategoricalCrossEntropyGrad(_in_shape, y_pred.data(), _in_shape,
+                                                   y_true.data(), _out_shape, output.data());
 
     // Don't be panic when it fails after kernel implementation or input is changed.
     // CrossEntropy Gradient formula can be calculated slightly differently depending on the
     // environment because it involes calculations such as log or exp.
     for (int i = 0; i < output.size(); ++i)
     {
-      EXPECT_FLOAT_EQ(output[i], expected[i]);
+      EXPECT_NEAR(output[i], expected[i], 1e-3f);
     }
   }
 
@@ -94,8 +95,8 @@ public:
     const int N = _in_shape.Dims(0);
     const int D = _in_shape.FlatSize() / N;
 
-    EXPECT_ANY_THROW(nnfw::cker::train::CategoricalCrossEntropyGrad(y_pred.data(), y_true.data(),
-                                                                    output.data(), N, D));
+    EXPECT_ANY_THROW(nnfw::cker::train::CategoricalCrossEntropyGrad(
+      _in_shape, y_pred.data(), _in_shape, y_true.data(), _out_shape, output.data()));
   }
 
 private:
@@ -296,9 +297,10 @@ TEST(CKer_Operation, neg_LossMSEGrad)
 
 TEST(CKer_Operation, LossCategoricalCrossEntropy)
 {
+  // single batch
   {
     nnfw::cker::Shape in_shape{1, 10};
-    nnfw::cker::Shape out_shape{1, 1};
+    nnfw::cker::Shape out_shape{1};
 
     std::vector<float> y_pred = {2.86E-12, 2.82E-13, 0.99999845, 2.36E-07, 2.91E-16,
                                  2.10E-07, 1.69E-14, 1.21E-17,   1.08E-06, 6.23E-18};
@@ -309,52 +311,15 @@ TEST(CKer_Operation, LossCategoricalCrossEntropy)
     verifier.verifyForward(y_pred, y_true, expected);
   }
 
+  // multiple batch
   {
     nnfw::cker::Shape in_shape{2, 10};
-    nnfw::cker::Shape out_shape{1, 1};
+    nnfw::cker::Shape out_shape{2};
 
-    std::vector<float> y_pred = {2.86E-12, 2.82E-13, 0.99999845,  2.36E-07, 2.91E-16,
-                                 2.10E-07, 1.69E-14, 1.21E-17,    1.08E-06, 6.23E-18,
-                                 2.75E-12, 2.71E-13, 0.999998569, 2.35E-07, 2.77E-16,
-                                 2.02E-07, 1.54E-14, 1.17E-17,    1.01E-06, 5.97E-18};
-    std::vector<float> y_true = {0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1};
-    std::vector<float> expected = {39.638470};
-
-    LossCCEVerifier<float> verifier(in_shape, out_shape);
-    verifier.verifyForward(y_pred, y_true, expected);
-  }
-
-  {
-    nnfw::cker::Shape in_shape{10, 10};
-    nnfw::cker::Shape out_shape{1, 1};
-
-    std::vector<float> y_pred = {
-      2.86196349e-12, 2.81945149e-13, 0.99999845,     2.35860654e-07, 2.9058794e-16,
-      2.09894068e-07, 1.6895507e-14,  1.21488099e-17, 1.0800934e-06,  6.22995669e-18,
-      6.80839918e-08, 2.31582132e-11, 5.66484014e-05, 0.450473011,    7.77803386e-13,
-      0.000452301028, 0.541836798,    1.54490024e-07, 0.00718099857,  4.84658429e-08,
-      0.00148730644,  0.000732639397, 0.0529860929,   0.104999296,    6.03449457e-10,
-      0.000499041693, 0.834561646,    2.97201696e-05, 0.0041414029,   0.000562905625,
-      7.88594662e-06, 1.72171513e-05, 0.00883230194,  0.493081957,    7.07157586e-13,
-      0.0145716211,   0.482783914,    2.76635546e-07, 0.00042539509,  0.000279496337,
-      1.0276257e-07,  3.83042126e-10, 0.0112575656,   0.983353972,    2.16322504e-17,
-      3.18806633e-06, 3.15719735e-05, 1.65277847e-10, 0.00535304006,  5.68216365e-07,
-      4.83230951e-06, 1.0492589e-09,  0.000612914097, 0.00494865049,  1.38217895e-10,
-      0.00836936105,  0.336497307,    8.71851896e-12, 0.649567008,    2.37553195e-08,
-      7.90850857e-11, 2.31540633e-12, 0.999991655,    1.34670612e-08, 6.38619986e-06,
-      1.88032658e-07, 1.6713152e-06,  1.14870158e-09, 8.11773879e-13, 4.81475465e-15,
-      4.71250632e-06, 4.9459074e-12,  0.915183961,    0.0051834262,   2.34058541e-12,
-      0.00018049599,  0.0348859429,   2.23697881e-16, 0.0445616208,   2.25251653e-12,
-      0.00105480896,  1.76535832e-06, 0.00727920234,  0.036443647,    1.75241883e-06,
-      0.954570055,    1.01299993e-05, 0.000419652439, 0.000141307348, 7.75765366e-05,
-      0.000144087317, 4.25886909e-10, 0.127607137,    0.87181282,     1.07257775e-14,
-      0.000421706965, 2.60532915e-12, 7.31942293e-08, 1.40476577e-05, 9.71598766e-08};
-    std::vector<float> y_true = {0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0,
-                                 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,
-                                 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,
-                                 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0};
-    std::vector<float> expected = {11.531664};
+    std::vector<float> y_pred = {0.01, 0.03, 0.05, 0.35,  0.04,  0.05,  0.28,  0.09,  0.04,  0.06,
+                                 0.89, 0.03, 0.04, 0.005, 0.023, 0.001, 0.004, 0.005, 0.001, 0.001};
+    std::vector<float> y_true = {0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    std::vector<float> expected = {2.813410, 0.116533};
 
     LossCCEVerifier<float> verifier(in_shape, out_shape);
     verifier.verifyForward(y_pred, y_true, expected);
@@ -363,6 +328,7 @@ TEST(CKer_Operation, LossCategoricalCrossEntropy)
 
 TEST(CKer_Operation, neg_LossCategoricalCrossEntropy)
 {
+  // Invalid output shape
   {
     nnfw::cker::Shape in_shape{1, 10};
     nnfw::cker::Shape out_shape{1, 1};
@@ -381,92 +347,43 @@ TEST(CKer_Operation, LossCategoricalCrossEntropyGrad)
 {
   {
     nnfw::cker::Shape in_shape{1, 10};
-    nnfw::cker::Shape out_shape{1, 1};
+    nnfw::cker::Shape grad_shape{1, 10};
 
-    std::vector<float> y_pred = {2.86E-12, 2.82E-13, 0.99999845, 2.36E-07, 2.91E-16,
-                                 2.10E-07, 1.69E-14, 1.21E-17,   1.08E-06, 6.23E-18};
+    std::vector<float> y_pred = {0.01, 0.03, 0.05, 0.35, 0.04, 0.05, 0.28, 0.09, 0.04, 0.06};
     std::vector<float> y_true = {0, 0, 0, 0, 0, 0, 0, 0, 0, 1};
-    std::vector<float> expected = {0, 0, 0, 0, 0, 0, 0, 0, 0, -1.60513648e+17};
+    std::vector<float> expected = {0, 0, 0, 0, 0, 0, 0, 0, 0, -16.66666667};
 
-    LossCCEVerifier<float> verifier(in_shape, out_shape);
+    LossCCEVerifier<float> verifier(in_shape, grad_shape);
     verifier.verifyBackward(y_pred, y_true, expected);
   }
 
   {
     nnfw::cker::Shape in_shape{2, 10};
-    nnfw::cker::Shape out_shape{1, 1};
+    nnfw::cker::Shape grad_shape{2, 10};
 
-    std::vector<float> y_pred = {2.86E-12, 2.82E-13, 0.99999845,  2.36E-07, 2.91E-16,
-                                 2.10E-07, 1.69E-14, 1.21E-17,    1.08E-06, 6.23E-18,
-                                 2.75E-12, 2.71E-13, 0.999998569, 2.35E-07, 2.77E-16,
-                                 2.02E-07, 1.54E-14, 1.17E-17,    1.01E-06, 5.97E-18};
-    std::vector<float> y_true = {0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1};
-    std::vector<float> expected = {0, 0, 0, 0, 0, 0, 0, 0, 0, -1.60513648e+17,
-                                   0, 0, 0, 0, 0, 0, 0, 0, 0, -1.67504188e+17};
+    std::vector<float> y_pred = {0.01, 0.03, 0.05, 0.35,  0.04,  0.05,  0.28,  0.09,  0.04,  0.06,
+                                 0.89, 0.03, 0.04, 0.005, 0.023, 0.001, 0.004, 0.005, 0.001, 0.001};
+    std::vector<float> y_true = {0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    std::vector<float> expected = {0, 0, 0, 0, 0, 0, 0, 0, 0, -16.66666667, -1.123595506,
+                                   0, 0, 0, 0, 0, 0, 0, 0, 0};
 
-    LossCCEVerifier<float> verifier(in_shape, out_shape);
-    verifier.verifyBackward(y_pred, y_true, expected);
-  }
-
-  {
-    nnfw::cker::Shape in_shape{10, 10};
-    nnfw::cker::Shape out_shape{1, 1};
-
-    std::vector<float> y_pred = {
-      2.86196349e-12, 2.81945149e-13, 0.99999845,     2.35860654e-07, 2.9058794e-16,
-      2.09894068e-07, 1.6895507e-14,  1.21488099e-17, 1.0800934e-06,  6.22995669e-18,
-      6.80839918e-08, 2.31582132e-11, 5.66484014e-05, 0.450473011,    7.77803386e-13,
-      0.000452301028, 0.541836798,    1.54490024e-07, 0.00718099857,  4.84658429e-08,
-      0.00148730644,  0.000732639397, 0.0529860929,   0.104999296,    6.03449457e-10,
-      0.000499041693, 0.834561646,    2.97201696e-05, 0.0041414029,   0.000562905625,
-      7.88594662e-06, 1.72171513e-05, 0.00883230194,  0.493081957,    7.07157586e-13,
-      0.0145716211,   0.482783914,    2.76635546e-07, 0.00042539509,  0.000279496337,
-      1.0276257e-07,  3.83042126e-10, 0.0112575656,   0.983353972,    2.16322504e-17,
-      3.18806633e-06, 3.15719735e-05, 1.65277847e-10, 0.00535304006,  5.68216365e-07,
-      4.83230951e-06, 1.0492589e-09,  0.000612914097, 0.00494865049,  1.38217895e-10,
-      0.00836936105,  0.336497307,    8.71851896e-12, 0.649567008,    2.37553195e-08,
-      7.90850857e-11, 2.31540633e-12, 0.999991655,    1.34670612e-08, 6.38619986e-06,
-      1.88032658e-07, 1.6713152e-06,  1.14870158e-09, 8.11773879e-13, 4.81475465e-15,
-      4.71250632e-06, 4.9459074e-12,  0.915183961,    0.0051834262,   2.34058541e-12,
-      0.00018049599,  0.0348859429,   2.23697881e-16, 0.0445616208,   2.25251653e-12,
-      0.00105480896,  1.76535832e-06, 0.00727920234,  0.036443647,    1.75241883e-06,
-      0.954570055,    1.01299993e-05, 0.000419652439, 0.000141307348, 7.75765366e-05,
-      0.000144087317, 4.25886909e-10, 0.127607137,    0.87181282,     1.07257775e-14,
-      0.000421706965, 2.60532915e-12, 7.31942293e-08, 1.40476577e-05, 9.71598766e-08};
-    std::vector<float> y_true = {0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0,
-                                 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,
-                                 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,
-                                 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0};
-    std::vector<float> expected = {
-      0,           0, 0,           0,           0, 0,           0, 0,          0, -1.60514765e+17,
-      -14687740,   0, 0,           0,           0, 0,           0, 0,          0, 0,
-      -672.356384, 0, 0,           0,           0, 0,           0, 0,          0, 0,
-      0,           0, 0,           -2.02806044, 0, 0,           0, 0,          0, 0,
-      -9731170,    0, 0,           0,           0, 0,           0, 0,          0, 0,
-      0,           0, -1631.55005, 0,           0, 0,           0, 0,          0, 0,
-      0,           0, 0,           0,           0, 0,           0, -870548096, 0, 0,
-      0,           0, -1.09267652, 0,           0, 0,           0, 0,          0, 0,
-      0,           0, 0,           0,           0, -1.04759204, 0, 0,          0, 0,
-      0,           0, 0,           0,           0, -2371.31494, 0, 0,          0, 0};
-
-    LossCCEVerifier<float> verifier(in_shape, out_shape);
+    LossCCEVerifier<float> verifier(in_shape, grad_shape);
     verifier.verifyBackward(y_pred, y_true, expected);
   }
 }
 
 TEST(CKer_Operation, neg_LossCategoricalCrossEntropyGrad)
 {
+  // Invalid grad shape
   {
     nnfw::cker::Shape in_shape{1, 10};
-    nnfw::cker::Shape out_shape{1, 1};
+    nnfw::cker::Shape grad_shape{1, 1};
 
-    std::vector<float> y_pred = {-2.86E-12, 2.82E-13, 0.99999845, 2.36E-07, 2.91E-16,
-                                 2.10E-07,  1.69E-14, 1.21E-17,   1.08E-06, 6.23E-18};
+    std::vector<float> y_pred = {0.01, 0.03, 0.05, 0.35, 0.04, 0.05, 0.28, 0.09, 0.04, 0.06};
     std::vector<float> y_true = {0, 0, 0, 0, 0, 0, 0, 0, 0, 1};
-    std::vector<float> expected = {0, 0, 0, 0, 0, 0, 0, 0, 0, -1.60513648e+17};
+    std::vector<float> expected = {0, 0, 0, 0, 0, 0, 0, 0, 0, -16.66666667};
 
-    LossCCEVerifier<float> verifier(in_shape, out_shape);
+    LossCCEVerifier<float> verifier(in_shape, grad_shape);
     verifier.throwBackward(y_pred, y_true, expected);
   }
 }

--- a/runtime/onert/backend/train/ops/LossCategoricalCrossentropyLayer.cc
+++ b/runtime/onert/backend/train/ops/LossCategoricalCrossentropyLayer.cc
@@ -40,61 +40,13 @@ void LossCategoricalCrossentropyLayer::configure(const IPortableTensor *y_pred,
   _label_smoothing = label_smoothing;
 }
 
-void LossCategoricalCrossentropyLayer::categoricalCrossEntropyFloat32()
-{
-  if (getNumberOfDimensions(_y_pred) == 1)
-  {
-    uint32_t input_size = getNumberOfElements(_y_pred);
-    nnfw::cker::train::CategoricalCrossEntropy(getBuffer<float>(_y_pred), getBuffer<float>(_y_true),
-                                               getBuffer<float>(_output), 1, input_size);
-  }
-  else if (getNumberOfDimensions(_y_pred) == 2)
-  {
-    uint32_t batch_size = getSizeOfDimension(_y_pred, 0);
-    if (batch_size == 0)
-      throw std::runtime_error("batch_size should not be 0");
-
-    uint32_t input_size = getNumberOfElements(_y_pred) / batch_size;
-    nnfw::cker::train::CategoricalCrossEntropy(getBuffer<float>(_y_pred), getBuffer<float>(_y_true),
-                                               getBuffer<float>(_output), batch_size, input_size);
-  }
-  else
-  {
-    throw std::runtime_error("LossLayer: unsupported Dimensions");
-  }
-}
-
-void LossCategoricalCrossentropyLayer::categoricalCrossEntropyGradFloat32()
-{
-  if (getNumberOfDimensions(_y_pred) == 1)
-  {
-    uint32_t input_size = getNumberOfElements(_y_pred);
-    nnfw::cker::train::CategoricalCrossEntropyGrad(
-      getBuffer<float>(_y_pred), getBuffer<float>(_y_true), getBuffer<float>(_back_prop_y_pred), 1,
-      input_size);
-  }
-  else if (getNumberOfDimensions(_y_pred) == 2)
-  {
-    uint32_t batch_size = getSizeOfDimension(_y_pred, 0);
-    if (batch_size == 0)
-      throw std::runtime_error("batch_size should not be 0");
-
-    uint32_t input_size = getNumberOfElements(_y_pred) / batch_size;
-    nnfw::cker::train::CategoricalCrossEntropyGrad(
-      getBuffer<float>(_y_pred), getBuffer<float>(_y_true), getBuffer<float>(_back_prop_y_pred),
-      batch_size, input_size);
-  }
-  else
-  {
-    throw std::runtime_error("LossLayer: unsupported Dimensions");
-  }
-}
-
 void LossCategoricalCrossentropyLayer::forward(bool)
 {
   if (_y_pred->data_type() == OperandType::FLOAT32)
   {
-    categoricalCrossEntropyFloat32();
+    nnfw::cker::train::CategoricalCrossEntropy(getShape(_y_pred), getBuffer<float>(_y_pred),
+                                               getShape(_y_true), getBuffer<float>(_y_true),
+                                               getShape(_output), getBuffer<float>(_output));
   }
   else
   {
@@ -106,7 +58,9 @@ void LossCategoricalCrossentropyLayer::backward()
 {
   if (_y_pred->data_type() == OperandType::FLOAT32)
   {
-    categoricalCrossEntropyGradFloat32();
+    nnfw::cker::train::CategoricalCrossEntropyGrad(
+      getShape(_y_pred), getBuffer<float>(_y_pred), getShape(_y_true), getBuffer<float>(_y_true),
+      getShape(_back_prop_y_pred), getBuffer<float>(_back_prop_y_pred));
   }
   else
   {

--- a/runtime/onert/backend/train/ops/LossCategoricalCrossentropyLayer.h
+++ b/runtime/onert/backend/train/ops/LossCategoricalCrossentropyLayer.h
@@ -41,10 +41,6 @@ public:
   void backward() override;
 
 private:
-  void categoricalCrossEntropyFloat32();
-  void categoricalCrossEntropyGradFloat32();
-
-private:
   int32_t _axis{-1};
   float _label_smoothing{0.0f};
 };


### PR DESCRIPTION
This commit updates Categorical crossentropy implementation to apply changed output shape. The output shape is changed from [1] to [batch_size].

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>