### PR TITLE
[onert] Enable Sum LossReductionType

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -1197,6 +1197,8 @@ NNFW_STATUS nnfw_session::train_prepare(const nnfw_train_info *info)
         return onert::ir::train::LossReductionType::Invalid;
       else if (type == NNFW_TRAIN_LOSS_REDUCTION_SUM_OVER_BATCH_SIZE)
         return onert::ir::train::LossReductionType::SumOverBatchSize;
+      else if (type == NNFW_TRAIN_LOSS_REDUCTION_SUM)
+        return onert::ir::train::LossReductionType::Sum;
       else
         throw std::runtime_error("not supported loss reduction type");
     };


### PR DESCRIPTION
This commit enables Sum LossReductionType.
This reduction type returns the sum value of the losses per batch.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>