### PR TITLE
[luci-compute] Fix case for output_shape method

### DIFF
--- a/compiler/luci-compute/include/luci_compute/DepthwiseConv2D.h
+++ b/compiler/luci-compute/include/luci_compute/DepthwiseConv2D.h
@@ -56,7 +56,7 @@ public:
 
 public:
   bool prepare(void);
-  const loco::TensorShape &outputShape(void) const { return _output_shape; }
+  const loco::TensorShape &output_shape(void) const { return _output_shape; }
   void compute(void);
 
 private:

--- a/compiler/luci-compute/include/luci_compute/FullyConnected.h
+++ b/compiler/luci-compute/include/luci_compute/FullyConnected.h
@@ -59,7 +59,7 @@ public:
 
 public:
   bool prepare(void);
-  const loco::TensorShape &outputShape(void) const { return _output_shape; }
+  const loco::TensorShape &output_shape(void) const { return _output_shape; }
   void compute(void);
 
 private:


### PR DESCRIPTION
This will fix to snake_case for output_shape method.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>