### PR TITLE
[luci-compute] Revise to set min/max from activation

### DIFF
--- a/compiler/luci-compute/src/ConvertValues.cpp
+++ b/compiler/luci-compute/src/ConvertValues.cpp
@@ -1,0 +1,53 @@
+/* Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ConvertValues.h"
+
+#include <limits> // std::numeric_limits
+#include <stdexcept>
+
+namespace luci
+{
+namespace compute
+{
+
+void get_act_minmax(const FusedActFunc act, float &act_min, float &act_max)
+{
+  switch (act)
+  {
+    case FusedActFunc::NONE:
+    case FusedActFunc::TANH:
+      act_min = std::numeric_limits<float>::lowest();
+      act_max = std::numeric_limits<float>::max();
+      break;
+    case FusedActFunc::RELU:
+      act_min = 0;
+      act_max = std::numeric_limits<float>::max();
+      break;
+    case FusedActFunc::RELU_N1_TO_1:
+      act_min = -1;
+      act_max = 1;
+      break;
+    case FusedActFunc::RELU6:
+      act_min = 0;
+      act_max = 6;
+      break;
+    default:
+      throw std::runtime_error("luci-comp get_act_minmax unsupported type.");
+  }
+}
+
+} // namespace compute
+} // namespace luci

--- a/compiler/luci-compute/src/ConvertValues.h
+++ b/compiler/luci-compute/src/ConvertValues.h
@@ -1,0 +1,31 @@
+/* Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __LUCI_COMPUTE_CONVERT_VALUES_H__
+#define __LUCI_COMPUTE_CONVERT_VALUES_H__
+
+#include "luci_compute/Types.h"
+
+namespace luci
+{
+namespace compute
+{
+
+void get_act_minmax(const FusedActFunc act, float &act_min, float &act_max);
+
+} // namespace compute
+} // namespace luci
+
+#endif // __LUCI_COMPUTE_CONVERT_VALUES_H__

--- a/compiler/luci-compute/src/DepthwiseConv2D.cpp
+++ b/compiler/luci-compute/src/DepthwiseConv2D.cpp
@@ -17,6 +17,7 @@
 #include "luci_compute/DepthwiseConv2D.h"
 
 #include "ConvertTypes.h"
+#include "ConvertValues.h"
 
 #include <tensorflow/lite/kernels/internal/reference/depthwiseconv_float.h>
 
@@ -104,6 +105,8 @@ bool DepthwiseConv2D::prepare(void)
                                      _params.stride_width, _params.dilation_width_factor);
   if (output_width < 0)
     return false;
+
+  get_act_minmax(_fused_act_func, _params.float_activation_min, _params.float_activation_max);
 
   _output_shape.rank(4);
   _output_shape.dim(0) = input_batches;

--- a/compiler/luci-compute/src/FullyConnected.cpp
+++ b/compiler/luci-compute/src/FullyConnected.cpp
@@ -17,6 +17,7 @@
 #include "luci_compute/FullyConnected.h"
 
 #include "ConvertTypes.h"
+#include "ConvertValues.h"
 
 #include <tensorflow/lite/kernels/internal/reference/fully_connected.h>
 
@@ -52,6 +53,8 @@ bool FullyConnected::prepare(void)
     if (element_count(&_bias_shape) != num_units)
       return false;
   }
+
+  get_act_minmax(_fused_act_func, _params.float_activation_min, _params.float_activation_max);
 
   if (_keep_num_dims)
   {


### PR DESCRIPTION
This will revise DepthwiseConv2D, FullyConnected to set activation min/max from activation function.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>