### PR TITLE
[luci/pass] Fix Op test to have valid shape status

### DIFF
--- a/compiler/luci/pass/src/FoldDepthwiseConv2DPass.test.cpp
+++ b/compiler/luci/pass/src/FoldDepthwiseConv2DPass.test.cpp
@@ -56,6 +56,7 @@ public:
     _dconv->filter(_dconv_filter);
     _dconv->bias(_dconv_bias);
     _dconv->shape({1, 4, 4, 1});
+    _dconv->shape_status(luci::ShapeStatus::VALID);
     _dconv->stride()->h(1);
     _dconv->stride()->w(1);
     _dconv->depthMultiplier(1);

--- a/compiler/luci/pass/src/FoldFullyConnectedPass.test.cpp
+++ b/compiler/luci/pass/src/FoldFullyConnectedPass.test.cpp
@@ -58,6 +58,7 @@ public:
     _fc->weights(_fc_weights);
     _fc->bias(_fc_bias);
     _fc->shape({NUM_UNITS});
+    _fc->shape_status(luci::ShapeStatus::VALID);
     _fc->weights_format(luci::CircleFullyConnected::WeightsFormat::DEFAULT);
     _fc->keep_num_dims(true);
 


### PR DESCRIPTION
This will revise test model to have valid shape status.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>