### PR TITLE
[infra] Introduce test_venv in Makefile.arm32

### DIFF
--- a/infra/nncc/Makefile.arm32
+++ b/infra/nncc/Makefile.arm32
@@ -132,6 +132,16 @@ int_test_arm32_host:
 	NNCC_WORKSPACE=$(BUILD_ARM32_HOST) ./nncc test
 
 #
+# prepare python venv in target for testing
+# NOTE sync package versions with compiler/common-artifacts
+#
+int_prep_venv_arm32:
+	python3 -m venv $(BUILD_ARM32_FOLDER)/overlay/venv_2_12_1
+	$(BUILD_ARM32_FOLDER)/overlay/venv_2_12_1/bin/python3 -m pip install --upgrade pip setuptools
+	$(BUILD_ARM32_FOLDER)/overlay/venv_2_12_1/bin/python3 -m pip install --upgrade tensorflow==2.12.1 \
+		flatbuffers==23.5.26 protobuf==4.23.3 pydot==1.4.2 pytest==7.4.3
+
+#
 # tests: run in ARM32 Ubuntu 18.04 device
 #
 int_test:
@@ -147,6 +157,9 @@ debug: int_build_arm32
 
 # NOTE before run test in ARM32, run test in host is required to prepare test data
 test_prep: int_test_arm32_host
+
+# NOTE before run test in ARM32, prepare python venv in ARM32
+test_venv: int_prep_venv_arm32
 
 # NOTE run test in ARM32 Ubuntu 18.04 device
 test: int_test


### PR DESCRIPTION
This will introduce test_venv for ARM32 target device in Makefile.arm32 to prepare python venv which needs python environment.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>