### PR TITLE
[onert] Implement nnfw_train_export_circle 

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -1450,7 +1450,7 @@ NNFW_STATUS nnfw_session::train_export_circle(const char *path)
     return NNFW_STATUS_INVALID_STATE;
   }
 
-  // NYI
+  _execution->export_circle(std::string(path));
   return NNFW_STATUS_ERROR;
 }
 

--- a/runtime/onert/core/include/backend/basic/train/TrainableBackendContextHelpers.h
+++ b/runtime/onert/core/include/backend/basic/train/TrainableBackendContextHelpers.h
@@ -43,9 +43,7 @@ ITensorRegistry *genTensors(backend::train::TrainableBackendContext &ctx,
       return;
     // NOTE Assuming there is no layout changes (Always assume NHWC or UNKNOWN)
     assert(tgraph.layout() != ir::Layout::NCHW);
-    ir::OperandInfo backend_info{obj.shape(), obj.typeInfo(), obj.info().memAllocType(),
-                                 obj.isConstant()};
-    tensor_builder->registerTensorInfo(ind, backend_info, ir::Layout::NHWC);
+    tensor_builder->registerTensorInfo(ind, obj.info(), ir::Layout::NHWC);
   });
 
   // For the executors that does not have fixed linear execution order:

--- a/runtime/onert/core/include/backend/train/ITensorRegistry.h
+++ b/runtime/onert/core/include/backend/train/ITensorRegistry.h
@@ -18,6 +18,7 @@
 #define __ONERT_BACKEND_TRAIN_ITENSOR_REGISTRY_H__
 
 #include "backend/ITensorRegistry.h"
+#include "backend/train/ITrainableTensor.h"
 
 namespace onert
 {
@@ -55,6 +56,13 @@ public:
    * @note  Returned tensor cannot be used longer than dynamic tensor manager
    */
   virtual ITensor *getGradientITensor(const ir::OperandIndex &) = 0;
+
+  /**
+   * @brief Iterate ITrainableTensors with fn
+   * @param fn function to be called with OperandIndex and a pointer to ITrainableTensor
+   */
+  virtual void iterateTrainableTensors(
+    const std::function<void(const ir::OperandIndex &, train::ITrainableTensor *)> &) const = 0;
 };
 
 } // namespace train
@@ -100,6 +108,16 @@ public:
   ITensor *getGradientITensor(const ir::OperandIndex &index) override
   {
     return getGradientTensor(index);
+  }
+
+  void iterateTrainableTensors(
+    const std::function<void(const ir::OperandIndex &, train::ITrainableTensor *)> &fn)
+    const override
+  {
+    for (const auto &e : _trainable)
+    {
+      fn(e.first, e.second.get());
+    }
   }
 
   IPortableTensor *getPortableTensor(const ir::OperandIndex &index)

--- a/runtime/onert/core/include/exec/Execution.h
+++ b/runtime/onert/core/include/exec/Execution.h
@@ -158,6 +158,14 @@ public:
    * @return @c float Loss value
    */
   float getLoss(const ir::IOIndex &ind);
+
+  /**
+   * @brief     Export circle
+   * @note      It should be called after training
+   * @param[in] path   Output path
+   * @throw     runtime_error on wrong path or permission denied
+   */
+  void export_circle(const std::string &path) const;
 #endif // ONERT_TRAIN
 
   ir::Shape getInputShape(ir::IOIndex ind) const;

--- a/runtime/onert/core/include/ir/Index.h
+++ b/runtime/onert/core/include/ir/Index.h
@@ -41,6 +41,9 @@ using SubgraphIndex = ::onert::util::Index<uint16_t, SubgraphIndexTag>;
 struct ModelIndexTag;
 using ModelIndex = ::onert::util::Index<uint16_t, ModelIndexTag>;
 
+struct OriginIndexTag;
+using OriginIndex = ::onert::util::Index<uint32_t, OriginIndexTag>;
+
 template <typename IndexType>
 std::ostream &_index_print_impl(std::ostream &o, const std::string &prefix, IndexType index)
 {
@@ -75,6 +78,10 @@ inline std::ostream &operator<<(std::ostream &o, const ModelIndex &i)
   return _index_print_impl(o, "MODEL", i);
 }
 
+inline std::ostream &operator<<(std::ostream &o, const OriginIndex &i)
+{
+  return _index_print_impl(o, "", i);
+}
 } // namespace ir
 } // namespace onert
 

--- a/runtime/onert/core/include/ir/Operand.h
+++ b/runtime/onert/core/include/ir/Operand.h
@@ -104,6 +104,9 @@ public:
     return std::vector<T>(base, base + size);
   }
 
+  void setOriginIndex(OriginIndex origin) { _info.setOriginIndex(origin); }
+  OriginIndex originIndex() const { return _info.originIndex(); }
+
 private:
   OperandInfo _info;
   std::shared_ptr<Data> _data;

--- a/runtime/onert/core/include/ir/OperandInfo.h
+++ b/runtime/onert/core/include/ir/OperandInfo.h
@@ -21,9 +21,10 @@
 #ifndef __ONERT_IR_OPERAND_INFO_H__
 #define __ONERT_IR_OPERAND_INFO_H__
 
+#include "ir/Index.h"
+#include "ir/Layout.h"
 #include "ir/Shape.h"
 #include "ir/TypeInfo.h"
-#include "ir/Layout.h"
 
 namespace onert
 {
@@ -66,9 +67,9 @@ public:
    * @param[in] alloc_type  When the thesor needs memory allocation
    */
   OperandInfo(const Shape &shape, const TypeInfo &typeInfo, MemAllocType alloc_type,
-              bool is_const = false, bool is_variable = false)
+              bool is_const = false, bool is_variable = false, OriginIndex origin = OriginIndex())
     : _shape(shape), _typeInfo(typeInfo), _alloc_type(alloc_type), _const(is_const),
-      _variable(is_variable)
+      _variable(is_variable), _origin(origin)
   {
     // DO NOTHING
   }
@@ -135,14 +136,16 @@ public:
   bool isVariable() const { return _variable; }
   bool isDynamic() const { return _alloc_type == MemAllocType::DYNAMIC; }
   void setDynamic() { _alloc_type = MemAllocType::DYNAMIC; }
+  OriginIndex originIndex() const { return _origin; }
+  void setOriginIndex(OriginIndex origin) { _origin = origin; }
 
 private:
   Shape _shape;
   TypeInfo _typeInfo;
-
   MemAllocType _alloc_type;
   bool _const;
   bool _variable;
+  OriginIndex _origin;
 };
 
 } // namespace ir

--- a/runtime/onert/core/src/backend/builtin/train/TensorRegistry.h
+++ b/runtime/onert/core/src/backend/builtin/train/TensorRegistry.h
@@ -18,6 +18,7 @@
 #define __ONERT_BACKEND_BUILTIN_TRAIN_TENSOR_REGISTRY_H__
 
 #include <backend/train/ITensorRegistry.h>
+#include <backend/train/ITrainableTensor.h>
 
 #include "../IOTensor.h"
 #include "../Tensor.h"
@@ -94,6 +95,14 @@ public:
     assert(!getITensor(index)); // For the index, tensor is not registered yet
     _base_reg->setMigrantTensor(index, tensor);
     return true;
+  }
+
+  void iterateTrainableTensors(
+    const std::function<void(const ir::OperandIndex &, backend::train::ITrainableTensor *)> &)
+    const override
+  {
+    // DO NOTHING
+    // Builtin tensor registry does not have trainable tensor.
   }
 
   void setBackPropTensor(const ir::OperandIndex &index, std::unique_ptr<BackPropTensor> tensor)

--- a/runtime/onert/core/src/compiler/train/TensorRegistries.h
+++ b/runtime/onert/core/src/compiler/train/TensorRegistries.h
@@ -20,6 +20,8 @@
 #include "../../backend/builtin/Config.h"
 #include "../../backend/builtin/train/TensorRegistry.h"
 
+#include <backend/train/ITensorRegistry.h>
+#include <backend/train/ITrainableTensor.h>
 #include <backend/train/TrainableBackendContext.h>
 
 #include <memory>
@@ -91,6 +93,15 @@ public:
         return tensor;
     }
     return nullptr;
+  }
+
+  void iterateTrainableTensors(
+    const std::function<void(const ir::OperandIndex &, backend::train::ITrainableTensor *)> &fn)
+    const
+  {
+    assert(_tensor_regs.size() == 2); // training backend and built-in backcend
+    for (auto &&tensor_reg : _tensor_regs)
+      tensor_reg->iterateTrainableTensors(fn);
   }
 
 private:

--- a/runtime/onert/core/src/dumper/text/GraphDumper.cc
+++ b/runtime/onert/core/src/dumper/text/GraphDumper.cc
@@ -87,8 +87,10 @@ void dumpGraph(const ir::Graph &graph)
     const auto &op = graph.operations().at(op_ind);
     VERBOSE(GraphDumper) << "  " << formatOperation(op, op_ind) << "\n";
   }
+  graph.operands().iterate([&](const ir::OperandIndex &idx, const ir::Operand &oprd) {
+    VERBOSE(GraphDumper) << "  Origin(" << idx << "): " << oprd.originIndex() << std::endl;
+  });
   VERBOSE(GraphDumper) << "}\n";
-  VERBOSE(GraphDumper) << std::endl;
 }
 
 void dumpLoweredGraph(const compiler::LoweredGraph &lgraph)

--- a/runtime/onert/core/src/exec/Execution.cc
+++ b/runtime/onert/core/src/exec/Execution.cc
@@ -180,6 +180,12 @@ float Execution::getLoss(const ir::IOIndex &ind)
 
   return execs->getLoss(ind);
 }
+
+void Execution::export_circle(const std::string &path) const
+{
+  auto tr_executors = dynamic_cast<exec::train::TrainableExecutors *>(_executors.get());
+  tr_executors->export_circle(path);
+}
 #endif // ONERT_TRAIN
 
 ir::Shape Execution::getInputShape(ir::IOIndex ind) const

--- a/runtime/onert/core/src/exec/train/TrainableExecutor.cc
+++ b/runtime/onert/core/src/exec/train/TrainableExecutor.cc
@@ -210,6 +210,14 @@ float TrainableExecutor::getLoss(const ir::IOIndex &pred_io_ind) const
 void TrainableExecutor::export_circle(const std::string &path) const
 {
   (void)path;
+  _tensor_regs.iterateTrainableTensors(
+    [&](const ir::OperandIndex &idx, backend::train::ITrainableTensor *tensor) {
+      printf("[G] Tensor %u: origin = %u, buffer (addr, size) = (%p, %zu)\n", idx.value(),
+             tensor->get_info().originIndex().value(), tensor->buffer(), tensor->total_size());
+      // I did not check buffer size or type. It is just quick check for temporary
+      float *fbuf = (float *)tensor->buffer();
+      printf("              buffer = %f, %f, %f, %f,...\n", fbuf[0], fbuf[1], fbuf[2], fbuf[3]);
+    });
 }
 
 } // namespace train

--- a/runtime/onert/core/src/exec/train/TrainableExecutor.cc
+++ b/runtime/onert/core/src/exec/train/TrainableExecutor.cc
@@ -207,6 +207,11 @@ float TrainableExecutor::getLoss(const ir::IOIndex &pred_io_ind) const
   return static_cast<float>(sum);
 }
 
+void TrainableExecutor::export_circle(const std::string &path) const
+{
+  (void)path;
+}
+
 } // namespace train
 } // namespace exec
 } // namespace onert

--- a/runtime/onert/core/src/exec/train/TrainableExecutor.h
+++ b/runtime/onert/core/src/exec/train/TrainableExecutor.h
@@ -83,6 +83,7 @@ public:
   }
 
   float getLoss(const ir::IOIndex &pred_io_ind) const;
+  void export_circle(const std::string &path) const;
 
   backend::train::TrainableBackendContexts &getBackendContexts() { return _backend_contexts; }
 

--- a/runtime/onert/core/src/exec/train/TrainableExecutors.cc
+++ b/runtime/onert/core/src/exec/train/TrainableExecutors.cc
@@ -84,6 +84,13 @@ float TrainableExecutors::getLoss(const ir::IOIndex &index) const
   return entryExecutor()->getLoss(index);
 }
 
+void TrainableExecutors::export_circle(const std::string &path) const
+{
+  if (_executors.size() > 1)
+    throw std::runtime_error("TrainableExecutors does not support multiple executors yet");
+  return entryExecutor()->export_circle(path);
+}
+
 } // namespace train
 } // namespace exec
 } // namespace onert

--- a/runtime/onert/core/src/exec/train/TrainableExecutors.h
+++ b/runtime/onert/core/src/exec/train/TrainableExecutors.h
@@ -21,6 +21,8 @@
 #include "exec/IExecutors.h"
 #include "ir/NNPkg.h"
 
+#include <string>
+
 namespace onert
 {
 namespace exec
@@ -79,6 +81,8 @@ public:
   void train(const IODescription &desc, uint32_t training_step);
 
   float getLoss(const ir::IOIndex &index) const;
+
+  void export_circle(const std::string &path) const;
 
 private:
   // TODO Append model index to ModelIndex

--- a/runtime/onert/frontend/circle/src/circle_loader.cc
+++ b/runtime/onert/frontend/circle/src/circle_loader.cc
@@ -94,6 +94,7 @@ private:
     for (flatbuffers::uoffset_t i = 0; i < circle_subg->tensors()->size(); ++i)
     {
       _tensor_to_operand[i] = loadOperand(circle_subg->tensors()->Get(i), *subg);
+      subg->operands().at(_tensor_to_operand[i]).setOriginIndex(ir::OriginIndex(i));
     }
     // Set inputs
     for (const std::int32_t input_ind : *circle_subg->inputs())

--- a/tests/tools/onert_train/src/onert_train.cc
+++ b/tests/tools/onert_train/src/onert_train.cc
@@ -270,6 +270,10 @@ int main(const int argc, char **argv)
       }
     });
 
+    // TODO: Add command-line option
+    if (true)
+      NNPR_ENSURE_STATUS(nnfw_train_export_circle(session, "tr.circle"));
+
     NNPR_ENSURE_STATUS(nnfw_close_session(session));
 
     measure.printResult();


### PR DESCRIPTION
- Introduce OriginIndex in Operand
- Introduce export_circle to classes from api to core
- Fix to copy the whole operand info during training phase
- To show, how to use
  - onert_train, circle_dump (just for buffer printing) are added temporarily

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>