### PR TITLE
[infra/onert] Update debian build

### DIFF
--- a/infra/debian/runtime/control
+++ b/infra/debian/runtime/control
@@ -2,7 +2,7 @@ Source: one
 Section: devel
 Priority: extra
 Maintainer: Neural Network Acceleration Solution Developers <nnfw@samsung.com>
-Build-Depends: cmake, debhelper (>=9), dh-python, python3-all
+Build-Depends: cmake, debhelper (>=9), dh-python, python3-all, libboost-all-dev, libhdf5-dev
 Standards-Version: 3.9.8
 Homepage: https://github.com/Samsung/ONE
 
@@ -16,4 +16,10 @@ Package: nnfw-dev
 Architecture: amd64
 Multi-Arch: same
 Depends: nnfw, ${shlibs:Depends}, ${misc:Depends}
+Description: one-runtime development package
+
+Package: nnfw-plugin-dev
+Architecture: amd64
+Multi-Arch: same
+Depends: nnfw, nnfw-dev, ${shlibs:Depends}, ${misc:Depends}
 Description: one-runtime development package

--- a/infra/debian/runtime/nnfw-plugin-dev.install
+++ b/infra/debian/runtime/nnfw-plugin-dev.install
@@ -1,0 +1,3 @@
+# {FILES_TO_INSTALL} {DEST_DIR}
+usr/include/onert usr/include/
+usr/lib/pkgconfig/nnfw-plugin.pc usr/lib/pkgconfig/

--- a/infra/debian/runtime/rules
+++ b/infra/debian/runtime/rules
@@ -6,7 +6,7 @@ DEBVER := $(shell dpkg-parsechangelog -SVersion)
 NPROC ?= $(shell nproc)
 
 export DH_VERBOSE = 1
-export NNFW_WORKSPACE = build
+export NNFW_WORKSPACE = build/onert
 export NNFW_INSTALL_PREFIX = $(CURDIR)/debian/tmp/usr/
 
 %:
@@ -17,8 +17,8 @@ override_dh_auto_build:
 	find packaging/ -type f -name "*.tar.gz" | xargs -i tar xf {} -C externals
 	mkdir -p $(NNFW_WORKSPACE)
 	./nnfw configure -DCMAKE_BUILD_TYPE=Release -DEXTERNALS_BUILD_THREADS=$(NPROC) \
-		-DBUILD_LOGGING=OFF -DDOWNLOAD_GTEST=OFF -DENABLE_TEST=OFF \
-		-DBUILD_TENSORFLOW_LITE=OFF -DBUILD_PYTHON_BINDING=OFF -DBUILD_MINMAX_H5DUMPER=OFF
+	  -DBUILD_LOGGING=OFF -DDOWNLOAD_GTEST=OFF -DENABLE_TEST=OFF \
+		-DBUILD_PYTHON_BINDING=OFF
 	./nnfw build -j$(NPROC)
 override_dh_auto_install:
 	./nnfw install --prefix $(NNFW_INSTALL_PREFIX)
@@ -27,5 +27,10 @@ override_dh_install:
 	sed -i 's:@libdir@:\/usr\/lib:g' ./packaging/nnfw.pc.in
 	sed -i 's:@includedir@:\/usr\/include:g' ./packaging/nnfw.pc.in
 	sed -i 's:@version@:${DEBVER}:g' ./packaging/nnfw.pc.in
+	sed -i 's:@libdir@:\/usr\/lib:g' ./packaging/nnfw-plugin.pc.in
+	sed -i 's:@includedir@:\/usr\/include:g' ./packaging/nnfw-plugin.pc.in
+	sed -i 's:@version@:${DEBVER}:g' ./packaging/nnfw-plugin.pc.in
+
 	install -m 0644 packaging/nnfw.pc.in -T $(NNFW_INSTALL_PREFIX)/lib/pkgconfig/nnfw.pc
+	install -m 0644 packaging/nnfw-plugin.pc.in -T $(NNFW_INSTALL_PREFIX)/lib/pkgconfig/nnfw-plugin.pc
 	dh_install


### PR DESCRIPTION
This commit updates debian build.
- Enable using hdf5
- Packaging nnfw-plugin-dev (matching tizen nnfw-plugin-devel.rpm)

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>