### PR TITLE
[circle-mpqsolver] Revisit DumpingHooks

### DIFF
--- a/compiler/circle-mpqsolver/src/bisection/BisectionSolver.cpp
+++ b/compiler/circle-mpqsolver/src/bisection/BisectionSolver.cpp
@@ -140,7 +140,7 @@ std::unique_ptr<luci::Module> BisectionSolver::run(const std::string &module_pat
   _quantizer->set_hook(_hooks.get());
   if (_hooks)
   {
-    _hooks->on_begin_solver(module_path, uint8_qerror, int16_qerror);
+    _hooks->onBeginSolver(module_path, uint8_qerror, int16_qerror);
   }
 
   if (int16_qerror > uint8_qerror)
@@ -163,7 +163,7 @@ std::unique_ptr<luci::Module> BisectionSolver::run(const std::string &module_pat
 
     if (_hooks)
     {
-      _hooks->on_end_solver(layer_params, "int16", int16_qerror);
+      _hooks->onEndSolver(layer_params, "int16", int16_qerror);
     }
 
     SolverOutput::get() << "The best configuration is int16 configuration\n";
@@ -180,7 +180,7 @@ std::unique_ptr<luci::Module> BisectionSolver::run(const std::string &module_pat
 
     if (_hooks)
     {
-      _hooks->on_end_solver(layer_params, "uint8", uint8_qerror);
+      _hooks->onEndSolver(layer_params, "uint8", uint8_qerror);
     }
 
     SolverOutput::get() << "The best configuration is uint8 configuration\n";
@@ -233,7 +233,7 @@ std::unique_ptr<luci::Module> BisectionSolver::run(const std::string &module_pat
   {
     if (_hooks)
     {
-      _hooks->on_begin_iteration();
+      _hooks->onBeginIteration();
     }
 
     int cut_depth = static_cast<int>(std::floor(0.5f * (min_depth + max_depth)));
@@ -277,7 +277,7 @@ std::unique_ptr<luci::Module> BisectionSolver::run(const std::string &module_pat
 
     if (_hooks)
     {
-      _hooks->on_end_iteration(layer_params, "uint8", cur_error);
+      _hooks->onEndIteration(layer_params, "uint8", cur_error);
     }
 
     if (cur_error < _qerror)
@@ -300,7 +300,7 @@ std::unique_ptr<luci::Module> BisectionSolver::run(const std::string &module_pat
 
   if (_hooks)
   {
-    _hooks->on_end_solver(best_params, "uint8", best_error);
+    _hooks->onEndSolver(best_params, "uint8", best_error);
   }
 
   SolverOutput::get() << "Found the best configuration at depth " << best_depth << "\n";

--- a/compiler/circle-mpqsolver/src/core/DumpingHooks.cpp
+++ b/compiler/circle-mpqsolver/src/core/DumpingHooks.cpp
@@ -23,7 +23,7 @@ DumpingHooks::DumpingHooks(const std::string &save_path)
 {
 }
 
-void DumpingHooks::on_begin_solver(const std::string &model_path, float q8error, float q16error)
+void DumpingHooks::onBeginSolver(const std::string &model_path, float q8error, float q16error)
 {
   _model_path = model_path;
   _dumper.setModelPath(_model_path);
@@ -32,28 +32,28 @@ void DumpingHooks::on_begin_solver(const std::string &model_path, float q8error,
   _dumper.dumpQ16Error(q16error);
 }
 
-void DumpingHooks::on_begin_iteration()
+void DumpingHooks::onBeginIteration()
 {
   _in_iterations = true;
   _num_of_iterations += 1;
 }
 
-void DumpingHooks::on_end_iteration(const LayerParams &layers, const std::string &def_type,
-                                    float error) const
+void DumpingHooks::onEndIteration(const LayerParams &layers, const std::string &def_type,
+                                  float error) const
 {
   _dumper.dumpMPQConfiguration(layers, def_type, _num_of_iterations);
   _dumper.dumpMPQError(error, _num_of_iterations);
 }
 
-void DumpingHooks::on_end_solver(const LayerParams &layers, const std::string &def_dtype,
-                                 float qerror)
+void DumpingHooks::onEndSolver(const LayerParams &layers, const std::string &def_dtype,
+                               float qerror)
 {
   _dumper.dumpFinalMPQ(layers, def_dtype);
   _dumper.dumpMPQError(qerror);
   _in_iterations = false;
 }
 
-void DumpingHooks::on_quantized(luci::Module *module) const
+void DumpingHooks::onQuantized(luci::Module *module) const
 {
   if (_in_iterations)
   {

--- a/compiler/circle-mpqsolver/src/core/DumpingHooks.h
+++ b/compiler/circle-mpqsolver/src/core/DumpingHooks.h
@@ -45,30 +45,29 @@ public:
   /**
    * @brief called on successfull quantization
    */
-  virtual void on_quantized(luci::Module *module) const override;
+  virtual void onQuantized(luci::Module *module) const override;
 
   /**
    * @brief called on the start of iterative search
    */
-  virtual void on_begin_solver(const std::string &model_path, float q8error,
-                               float q16error) override;
+  virtual void onBeginSolver(const std::string &model_path, float q8error, float q16error) override;
 
   /**
    * @brief called on the start of current iteration
    */
-  virtual void on_begin_iteration() override;
+  virtual void onBeginIteration() override;
 
   /**
    * @brief called at the end of current iteration
    */
-  virtual void on_end_iteration(const LayerParams &layers, const std::string &def_dtype,
-                                float error) const override;
+  virtual void onEndIteration(const LayerParams &layers, const std::string &def_dtype,
+                              float error) const override;
 
   /**
    * @brief called at the end of iterative search
    */
-  virtual void on_end_solver(const LayerParams &layers, const std::string &def_dtype,
-                             float qerror) override;
+  virtual void onEndSolver(const LayerParams &layers, const std::string &def_dtype,
+                           float qerror) override;
 
 protected:
   std::string _model_path;

--- a/compiler/circle-mpqsolver/src/core/DumpingHooks.test.cpp
+++ b/compiler/circle-mpqsolver/src/core/DumpingHooks.test.cpp
@@ -52,17 +52,17 @@ protected:
 TEST_F(CircleMPQSolverDumpingHooksTest, verifyResultsTest)
 {
   mpqsolver::core::DumpingHooks hooks(_folder);
-  EXPECT_NO_THROW(hooks.on_begin_solver("model_path.circle", 0.0, 1.0));
+  EXPECT_NO_THROW(hooks.onBeginSolver("model_path.circle", 0.0, 1.0));
   std::string errors_path = _folder + "/errors" + ".mpq.txt";
   EXPECT_TRUE(mpqsolver::test::io_utils::isFileExists(errors_path));
 
-  hooks.on_begin_iteration();
+  hooks.onBeginIteration();
 
-  EXPECT_NO_THROW(hooks.on_end_iteration(mpqsolver::core::LayerParams(), "uint8", 0.0));
+  EXPECT_NO_THROW(hooks.onEndIteration(mpqsolver::core::LayerParams(), "uint8", 0.0));
   std::string current_mpq_path = _folder + "/Configuration_" + std::to_string(1) + ".mpq.json";
   EXPECT_TRUE(mpqsolver::test::io_utils::isFileExists(current_mpq_path));
 
-  EXPECT_NO_THROW(hooks.on_end_solver(mpqsolver::core::LayerParams(), "uint8", 0.5));
+  EXPECT_NO_THROW(hooks.onEndSolver(mpqsolver::core::LayerParams(), "uint8", 0.5));
   std::string final_mpq_path = _folder + "/FinalConfiguration" + ".mpq.json";
   EXPECT_TRUE(mpqsolver::test::io_utils::isFileExists(final_mpq_path));
 }
@@ -70,9 +70,9 @@ TEST_F(CircleMPQSolverDumpingHooksTest, verifyResultsTest)
 TEST_F(CircleMPQSolverDumpingHooksTest, empty_path_NEG)
 {
   mpqsolver::core::DumpingHooks hooks("");
-  EXPECT_ANY_THROW(hooks.on_begin_solver("", -1, -1));
-  hooks.on_begin_iteration();
-  EXPECT_ANY_THROW(hooks.on_quantized(nullptr));
-  EXPECT_ANY_THROW(hooks.on_end_iteration(mpqsolver::core::LayerParams(), "uint8", -1));
-  EXPECT_ANY_THROW(hooks.on_end_solver(mpqsolver::core::LayerParams(), "uint8", -1));
+  EXPECT_ANY_THROW(hooks.onBeginSolver("", -1, -1));
+  hooks.onBeginIteration();
+  EXPECT_ANY_THROW(hooks.onQuantized(nullptr));
+  EXPECT_ANY_THROW(hooks.onEndIteration(mpqsolver::core::LayerParams(), "uint8", -1));
+  EXPECT_ANY_THROW(hooks.onEndSolver(mpqsolver::core::LayerParams(), "uint8", -1));
 }

--- a/compiler/circle-mpqsolver/src/core/Quantizer.cpp
+++ b/compiler/circle-mpqsolver/src/core/Quantizer.cpp
@@ -110,7 +110,7 @@ bool Quantizer::quantize(luci::Module *module, const std::string &quant_dtype,
 
   if (_hook)
   {
-    _hook->on_quantized(module);
+    _hook->onQuantized(module);
   }
 
   return true;

--- a/compiler/circle-mpqsolver/src/core/Quantizer.h
+++ b/compiler/circle-mpqsolver/src/core/Quantizer.h
@@ -38,7 +38,7 @@ struct QuantizerHook
    * @brief called on successfull quantization
    * @param module quantized module
    */
-  virtual void on_quantized(luci::Module *module) const = 0;
+  virtual void onQuantized(luci::Module *module) const = 0;
 };
 
 class Quantizer

--- a/compiler/circle-mpqsolver/src/core/SolverHooks.h
+++ b/compiler/circle-mpqsolver/src/core/SolverHooks.h
@@ -37,12 +37,12 @@ public:
    * @param q8error error of Q8 quantization
    * @param q16error error of Q16 quantization
    */
-  virtual void on_begin_solver(const std::string &model_path, float q8error, float q16error) = 0;
+  virtual void onBeginSolver(const std::string &model_path, float q8error, float q16error) = 0;
 
   /**
    * @brief called on the start of current iteration
    */
-  virtual void on_begin_iteration() = 0;
+  virtual void onBeginIteration() = 0;
 
   /**
    * @brief called at the end of current iteration
@@ -50,8 +50,8 @@ public:
    * @param def_dtype default quantization dtype
    * @param error error of quantization for current iteration
    */
-  virtual void on_end_iteration(const LayerParams &layers, const std::string &def_dtype,
-                                float error) const = 0;
+  virtual void onEndIteration(const LayerParams &layers, const std::string &def_dtype,
+                              float error) const = 0;
 
   /**
    * @brief called at the end of iterative search
@@ -59,8 +59,8 @@ public:
    * @param def_dtype default quantization dtype
    * @param qerror final error of quantization
    */
-  virtual void on_end_solver(const LayerParams &layers, const std::string &def_dtype,
-                             float qerror) = 0;
+  virtual void onEndSolver(const LayerParams &layers, const std::string &def_dtype,
+                           float qerror) = 0;
 };
 
 } // namespace core


### PR DESCRIPTION
This commit normalizes DumpingHooks methods to camel notation and adjusts dependencies accordingly.

Related: https://github.com/Samsung/ONE/issues/12156
ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>