### PR TITLE
[circle-mpqsolver] Revisit Quantizer

### DIFF
--- a/compiler/circle-mpqsolver/src/bisection/BisectionSolver.cpp
+++ b/compiler/circle-mpqsolver/src/bisection/BisectionSolver.cpp
@@ -88,7 +88,7 @@ float BisectionSolver::evaluate(const core::DatasetEvaluator &evaluator,
   assert(model != nullptr);
 
   // get fake quantized model for evaluation
-  if (!_quantizer->fake_quantize(model.get(), def_quant, layers))
+  if (!_quantizer->fakeQuantize(model.get(), def_quant, layers))
   {
     throw std::runtime_error("Failed to produce fake-quantized model.");
   }
@@ -137,7 +137,7 @@ std::unique_ptr<luci::Module> BisectionSolver::run(const std::string &module_pat
   float uint8_qerror =
     evaluate(evaluator, module_path, "uint8" /* default quant_dtype */, layer_params);
   SolverOutput::get() << "Full uint8 model qerror: " << uint8_qerror << "\n";
-  _quantizer->set_hook(_hooks.get());
+  _quantizer->setHook(_hooks.get());
   if (_hooks)
   {
     _hooks->onBeginSolver(module_path, uint8_qerror, int16_qerror);

--- a/compiler/circle-mpqsolver/src/core/Quantizer.cpp
+++ b/compiler/circle-mpqsolver/src/core/Quantizer.cpp
@@ -49,7 +49,7 @@ bool make_model_fake_quantized(luci::Module *module)
 
 } // namespace
 
-void Quantizer::set_hook(const QuantizerHook *hook) { _hook = hook; }
+void Quantizer::setHook(const QuantizerHook *hook) { _hook = hook; }
 
 /**
  * @brief quantize recorded module (min/max initialized) with specified parameters
@@ -129,8 +129,8 @@ bool Quantizer::quantize(luci::Module *module, LayerParams &layer_params)
  * @brief fake_quantize recorded module (min/max initialized) with specified parameters
  * returns true on success
  */
-bool Quantizer::fake_quantize(luci::Module *module, const std::string &quant_dtype,
-                              LayerParams &layer_params)
+bool Quantizer::fakeQuantize(luci::Module *module, const std::string &quant_dtype,
+                             LayerParams &layer_params)
 {
   if (!quantize(module, quant_dtype, layer_params))
     return false;

--- a/compiler/circle-mpqsolver/src/core/Quantizer.h
+++ b/compiler/circle-mpqsolver/src/core/Quantizer.h
@@ -61,7 +61,7 @@ public:
   /**
    * @brief set hook on the end of quantization event
    */
-  void set_hook(const QuantizerHook *callback);
+  void setHook(const QuantizerHook *callback);
 
   /**
    * @brief quantize recorded module (min/max initialized) with specified parameters
@@ -79,8 +79,8 @@ public:
    * @brief fake_quantize recorded module (min/max initialized) with specified parameters
    * returns true on success
    */
-  bool fake_quantize(luci::Module *module, const std::string &quant_dtype,
-                     LayerParams &layer_params);
+  bool fakeQuantize(luci::Module *module, const std::string &quant_dtype,
+                    LayerParams &layer_params);
 
 private:
   Context _ctx;


### PR DESCRIPTION
This commit normalizes Quantizer methods to camel notation and adjusts dependencies accordingly.

Related: #12156
ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>