### PR TITLE
[circle-mpqsolver] Fix BisectionSolver

### DIFF
--- a/compiler/circle-mpqsolver/src/bisection/BisectionSolver.cpp
+++ b/compiler/circle-mpqsolver/src/bisection/BisectionSolver.cpp
@@ -231,16 +231,16 @@ std::unique_ptr<luci::Module> BisectionSolver::run(const std::string &module_pat
 
   while (true)
   {
-    if (_hooks)
-    {
-      _hooks->onBeginIteration();
-    }
-
     int cut_depth = static_cast<int>(std::floor(0.5f * (min_depth + max_depth)));
 
     if (last_depth == cut_depth)
     {
       break;
+    }
+
+    if (_hooks)
+    {
+      _hooks->onBeginIteration();
     }
 
     SolverOutput::get() << "Looking for the optimal configuration in [" << min_depth << " , "


### PR DESCRIPTION
This commit moves onBeginIteration to keep it
synchronized with onEndIteration.

Draft: #12042
Related: #12020
ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>