### PR TITLE
[circle-part-value-py-test] Introduce py test

### DIFF
--- a/compiler/circle-part-value-py-test/CMakeLists.txt
+++ b/compiler/circle-part-value-py-test/CMakeLists.txt
@@ -1,0 +1,110 @@
+if(NOT ENABLE_TEST)
+  return()
+endif(NOT ENABLE_TEST)
+
+get_target_property(ARTIFACTS_BIN_PATH testDataGenerator BINARY_DIR)
+
+unset(RECIPE_LIST)
+unset(PARTITION_LIST)
+unset(OUTPUT_COUNT_LIST)
+unset(TEST_DEPS)
+
+macro(add RECIPE_NAME PARTITION_NAME OUTPUT_COUNT)
+  list(APPEND RECIPE_LIST ${RECIPE_NAME})
+  list(APPEND PARTITION_LIST ${PARTITION_NAME})
+  list(APPEND OUTPUT_COUNT_LIST ${OUTPUT_COUNT})
+endmacro(add)
+
+# Read "test.lst"
+include("test.lst")
+
+list(LENGTH RECIPE_LIST RECIPE_LENGTH)
+math(EXPR RECIPE_LENGTH_M1 "${RECIPE_LENGTH} - 1")
+
+foreach(IDX RANGE ${RECIPE_LENGTH_M1})
+  list(GET RECIPE_LIST ${IDX} RECIPE_NAME)
+  list(GET PARTITION_LIST ${IDX} PARTITION_NAME)
+  list(GET OUTPUT_COUNT_LIST ${IDX} OUTPUT_COUNT)
+
+  # NOTE about the name:
+  # Use '.recipe' name for source tflite and circle files
+  # Use '.part' name for actual test folder and test files
+
+  # Output to a folder
+  set(PARTITIONER_OUTPUT_PATH "${CMAKE_CURRENT_BINARY_DIR}/${PARTITION_NAME}")
+
+  add_custom_command(OUTPUT ${PARTITIONER_OUTPUT_PATH}
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${PARTITIONER_OUTPUT_PATH}"
+    COMMENT "Make directory ${PARTITIONER_OUTPUT_PATH}"
+  )
+
+  # Copy tflite
+  set(TFLITE_SRC_PATH "${ARTIFACTS_BIN_PATH}/${RECIPE_NAME}.tflite")
+  set(TFLITE_DST_PATH "${PARTITIONER_OUTPUT_PATH}/${PARTITION_NAME}.tflite")
+
+  add_custom_command(OUTPUT ${TFLITE_DST_PATH}
+    COMMAND ${CMAKE_COMMAND} -E copy "${TFLITE_SRC_PATH}" "${TFLITE_DST_PATH}"
+    DEPENDS ${TFLITE_SRC_PATH}
+    COMMENT "Copy ${RECIPE_NAME}.tflite"
+  )
+  list(APPEND TEST_DEPS ${TFLITE_DST_PATH})
+
+  # Copy circle
+  set(CIRCLE_SRC_PATH "${ARTIFACTS_BIN_PATH}/${RECIPE_NAME}.circle")
+  set(CIRCLE_DST_PATH "${PARTITIONER_OUTPUT_PATH}/${PARTITION_NAME}.circle")
+
+  add_custom_command(OUTPUT ${CIRCLE_DST_PATH}
+    COMMAND ${CMAKE_COMMAND} -E copy "${CIRCLE_SRC_PATH}" "${CIRCLE_DST_PATH}"
+    DEPENDS ${CIRCLE_SRC_PATH}
+    COMMENT "Copy ${RECIPE_NAME}.circle"
+  )
+  list(APPEND TEST_DEPS ${CIRCLE_DST_PATH})
+
+  # Copy .part
+  set(PART_FILE "${PARTITION_NAME}.part")
+  set(PART_SRC_PATH "${CMAKE_CURRENT_SOURCE_DIR}/parts/${PART_FILE}")
+  set(PART_DST_PATH "${PARTITIONER_OUTPUT_PATH}/${PART_FILE}")
+
+  add_custom_command(OUTPUT ${PART_DST_PATH}
+    COMMAND ${CMAKE_COMMAND} -E copy "${PART_SRC_PATH}" "${PART_DST_PATH}"
+    DEPENDS ${PART_SRC_PATH}
+    COMMENT "Copy ${PART_FILE}"
+  )
+  list(APPEND TEST_DEPS ${PART_DST_PATH})
+
+  # Partition connection file to generate
+  set(PARTITIONER_CONN_JSON "${PARTITIONER_OUTPUT_PATH}/${PARTITION_NAME}.conn.json")
+
+  # Run partitioner
+  add_custom_command(OUTPUT ${PARTITIONER_CONN_JSON}
+    COMMAND circle-partitioner "--part_file" "${PART_FILE}" "--input_file"
+            "${PARTITION_NAME}.circle" "--work_path" "${PARTITIONER_OUTPUT_PATH}"
+    DEPENDS circle-partitioner ${PART_DST_PATH} ${CIRCLE_DST_PATH}
+    COMMENT "Parition ${RECIPE_NAME}.circle with ${PART_FILE}"
+  )
+  list(APPEND TEST_DEPS ${PARTITIONER_CONN_JSON})
+
+  # Write .excnt file; expected count of output models
+  set(COUNT_FILE "${PARTITION_NAME}.excnt")
+  set(COUNT_FILE_PATH "${PARTITIONER_OUTPUT_PATH}/${COUNT_FILE}")
+  add_custom_command(OUTPUT ${COUNT_FILE_PATH}
+    COMMAND echo ${OUTPUT_COUNT} > ${COUNT_FILE_PATH}
+    DEPENDS ${PART_SRC_PATH} ${PARTITIONER_OUTPUT_PATH}
+    COMMENT "Write ${COUNT_FILE} with ${OUTPUT_COUNT}"
+  )
+  list(APPEND TEST_DEPS ${COUNT_FILE_PATH})
+endforeach(IDX)
+
+add_custom_target(circle_part_value_py_test_prepare ALL DEPENDS ${TEST_DEPS})
+add_dependencies(circle_part_value_py_test_prepare common_artifacts_deps)
+
+set(VIRTUALENV "${NNCC_OVERLAY_DIR}/venv_2_12_1")
+set(TEST_LIST_FILE "test.lst")
+
+add_test(NAME circle_part_value_py_test
+  COMMAND ${VIRTUALENV}/bin/python -m pytest -sv test_circle_part_value.py
+        --test_list ${TEST_LIST_FILE}
+        --bin_dir ${CMAKE_CURRENT_BINARY_DIR}
+        --circle_part_driver $<TARGET_FILE:circle_part_driver>
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)

--- a/compiler/circle-part-value-py-test/README.md
+++ b/compiler/circle-part-value-py-test/README.md
@@ -1,0 +1,15 @@
+# circle-part-value-py-test
+
+_circle-part-value-py-test_ evaluates partitioned models produced by circle-partitioner.
+
+### Process of evaluation
+
+Evaluation process is like how _luci-value-test_ does.
+
+1) generates random input and stores to reference input file(s)
+2) executes tflite file from common-artifacts for reference output
+3) partitions circle file with .part file and produces into output folder
+4) executes produced partitioned circle models with reference input file(s)
+5) saves output(s) of circle models to file(s)
+6) compares reference output with saved output file(s)
+7) fail test if values differ

--- a/compiler/circle-part-value-py-test/conftest.py
+++ b/compiler/circle-part-value-py-test/conftest.py
@@ -1,0 +1,32 @@
+import re
+
+
+def extract_test_args(s):
+    p = re.compile('add\\((.*)\\)')
+    result = p.search(s)
+    return result.group(1)
+
+
+def pytest_addoption(parser):
+    parser.addoption("--test_list", action="store", help="Path to test list")
+    parser.addoption("--bin_dir", action="store", help="Directory including artifacts")
+    parser.addoption(
+        "--circle_part_driver", action="store", help="Path to circle part driver")
+
+
+def pytest_generate_tests(metafunc):
+    list_path = metafunc.config.getoption('test_list')
+    bin_dir = metafunc.config.getoption('bin_dir')
+    circle_part_driver = metafunc.config.getoption('circle_part_driver')
+
+    with open(list_path) as f:
+        contents = [line.rstrip() for line in f]
+
+    comment_removed = [line for line in contents if not line.startswith('#')]
+    newline_removed = [line for line in comment_removed if line.startswith('add(')]
+    test_args = [extract_test_args(line) for line in newline_removed]
+    # add(RECIPE_NAME PARTITION_NAME EXPECTED_OUTPUT_COUNT)
+    partition_list = [(arg.split()[1], bin_dir, circle_part_driver) for arg in test_args]
+
+    if 'test_name' in metafunc.fixturenames:
+        metafunc.parametrize('test_name,bin_dir,part_driver_path', partition_list)

--- a/compiler/circle-part-value-py-test/parts/Net_InstanceNorm_003.001.part
+++ b/compiler/circle-part-value-py-test/parts/Net_InstanceNorm_003.001.part
@@ -1,0 +1,7 @@
+[partition]
+backends=cpu,acl_cl
+default=cpu
+comply=opcode
+
+[OPCODE]
+ADD=acl_cl

--- a/compiler/circle-part-value-py-test/parts/Net_InstanceNorm_003.002.part
+++ b/compiler/circle-part-value-py-test/parts/Net_InstanceNorm_003.002.part
@@ -1,0 +1,8 @@
+[partition]
+backends=cpu,acl_cl
+default=cpu
+comply=opcode
+
+[OPCODE]
+SUB=acl_cl
+DIV=acl_cl

--- a/compiler/circle-part-value-py-test/parts/Net_InstanceNorm_003.003.part
+++ b/compiler/circle-part-value-py-test/parts/Net_InstanceNorm_003.003.part
@@ -1,0 +1,9 @@
+[partition]
+backends=cpu,acl_cl
+default=cpu
+comply=opname
+
+[OPNAME]
+Mean_as_variance=acl_cl
+Add_as_variance=acl_cl
+Pow=acl_cl

--- a/compiler/circle-part-value-py-test/parts/Net_InstanceNorm_003.part
+++ b/compiler/circle-part-value-py-test/parts/Net_InstanceNorm_003.part
@@ -1,0 +1,7 @@
+[partition]
+backends=cpu,acl_cl
+default=cpu
+comply=opcode
+
+[OPCODE]
+DIV=acl_cl

--- a/compiler/circle-part-value-py-test/parts/Net_UnpackAdd_001.001.part
+++ b/compiler/circle-part-value-py-test/parts/Net_UnpackAdd_001.001.part
@@ -1,0 +1,7 @@
+[partition]
+backends=cpu,npu
+default=cpu
+comply=opcode
+
+[OPCODE]
+ADD=npu

--- a/compiler/circle-part-value-py-test/parts/Net_UnpackAdd_001.002.part
+++ b/compiler/circle-part-value-py-test/parts/Net_UnpackAdd_001.002.part
@@ -1,0 +1,7 @@
+[partition]
+backends=cpu,npu
+default=cpu
+comply=opcode
+
+[OPCODE]
+UNPACK=npu

--- a/compiler/circle-part-value-py-test/parts/Net_UnpackAdd_001.part
+++ b/compiler/circle-part-value-py-test/parts/Net_UnpackAdd_001.part
@@ -1,0 +1,7 @@
+[partition]
+backends=cpu,npu
+default=npu
+comply=opcode
+
+[OPCODE]
+UNPACK=cpu

--- a/compiler/circle-part-value-py-test/parts/Part_Add_Sqrt_000.part
+++ b/compiler/circle-part-value-py-test/parts/Part_Add_Sqrt_000.part
@@ -1,0 +1,7 @@
+[partition]
+backends=cpu,acl_cl
+default=cpu
+comply=opcode
+
+[OPCODE]
+SQRT=acl_cl

--- a/compiler/circle-part-value-py-test/parts/Part_Add_Sqrt_Rsqrt_000.part
+++ b/compiler/circle-part-value-py-test/parts/Part_Add_Sqrt_Rsqrt_000.part
@@ -1,0 +1,7 @@
+[partition]
+backends=cpu,acl_cl
+default=cpu
+comply=opcode
+
+[OPCODE]
+RSQRT=acl_cl

--- a/compiler/circle-part-value-py-test/parts/Part_Add_Sub_000.001.part
+++ b/compiler/circle-part-value-py-test/parts/Part_Add_Sub_000.001.part
@@ -1,0 +1,7 @@
+[partition]
+backends=cpu,acl_cl
+default=cpu
+comply=opname
+
+[OPNAME]
+add1=acl_cl

--- a/compiler/circle-part-value-py-test/parts/Part_Add_Sub_000.part
+++ b/compiler/circle-part-value-py-test/parts/Part_Add_Sub_000.part
@@ -1,0 +1,7 @@
+[partition]
+backends=cpu,acl_cl
+default=cpu
+comply=opcode
+
+[OPCODE]
+SUB=acl_cl

--- a/compiler/circle-part-value-py-test/parts/Part_Add_Sub_001.part
+++ b/compiler/circle-part-value-py-test/parts/Part_Add_Sub_001.part
@@ -1,0 +1,7 @@
+[partition]
+backends=cpu,acl_cl
+default=cpu
+comply=opname
+
+[OPNAME]
+some/node/add2;and/another=acl_cl

--- a/compiler/circle-part-value-py-test/parts/Part_Add_Sub_002.001.part
+++ b/compiler/circle-part-value-py-test/parts/Part_Add_Sub_002.001.part
@@ -1,0 +1,9 @@
+[partition]
+backends=cpu,acl_cl
+default=cpu
+comply=opname
+
+[OPNAME]
+add1=cpu
+add2=acl_cl
+ofm=acl_cl

--- a/compiler/circle-part-value-py-test/parts/Part_Add_Sub_002.002.part
+++ b/compiler/circle-part-value-py-test/parts/Part_Add_Sub_002.002.part
@@ -1,0 +1,9 @@
+[partition]
+backends=cpu,acl_cl
+default=cpu
+comply=opname
+
+[OPNAME]
+add1=acl_cl
+add2=acl_cl
+ofm=cpu

--- a/compiler/circle-part-value-py-test/parts/Part_If_Add_Sub_000.001.part
+++ b/compiler/circle-part-value-py-test/parts/Part_If_Add_Sub_000.001.part
@@ -1,0 +1,7 @@
+[partition]
+backends=cpu,acl_cl
+default=cpu
+comply=opcode
+
+[OPCODE]
+ADD=acl_cl

--- a/compiler/circle-part-value-py-test/parts/Part_If_Add_Sub_001.001.part
+++ b/compiler/circle-part-value-py-test/parts/Part_If_Add_Sub_001.001.part
@@ -1,0 +1,7 @@
+[partition]
+backends=cpu,acl_cl
+default=cpu
+comply=opcode
+
+[OPCODE]
+ADD=acl_cl

--- a/compiler/circle-part-value-py-test/parts/Part_Mul_Sqrt_FC_nobias_000_000.part
+++ b/compiler/circle-part-value-py-test/parts/Part_Mul_Sqrt_FC_nobias_000_000.part
@@ -1,0 +1,7 @@
+[partition]
+backends=cpu,npu
+default=npu
+comply=opcode
+
+[OPCODE]
+MUL=npu

--- a/compiler/circle-part-value-py-test/parts/Part_Mul_Sqrt_FC_nobias_000_001.part
+++ b/compiler/circle-part-value-py-test/parts/Part_Mul_Sqrt_FC_nobias_000_001.part
@@ -1,0 +1,7 @@
+[partition]
+backends=cpu,npu
+default=npu
+comply=opcode
+
+[OPCODE]
+SQRT=cpu

--- a/compiler/circle-part-value-py-test/parts/Part_Mul_Sqrt_FC_nobias_000_002.part
+++ b/compiler/circle-part-value-py-test/parts/Part_Mul_Sqrt_FC_nobias_000_002.part
@@ -1,0 +1,7 @@
+[partition]
+backends=cpu,npu
+default=npu
+comply=opcode
+
+[OPCODE]
+FULLY_CONNECTED=cpu

--- a/compiler/circle-part-value-py-test/parts/Part_Split_Add_000.part
+++ b/compiler/circle-part-value-py-test/parts/Part_Split_Add_000.part
@@ -1,0 +1,7 @@
+[partition]
+backends=cpu,npu
+default=npu
+comply=opcode
+
+[OPCODE]
+SPLIT=cpu

--- a/compiler/circle-part-value-py-test/parts/Part_Sqrt_Rsqrt_000.part
+++ b/compiler/circle-part-value-py-test/parts/Part_Sqrt_Rsqrt_000.part
@@ -1,0 +1,7 @@
+[partition]
+backends=cpu,acl_cl
+default=cpu
+comply=opcode
+
+[OPCODE]
+SQRT=acl_cl

--- a/compiler/circle-part-value-py-test/parts/Part_Sqrt_Rsqrt_001.part
+++ b/compiler/circle-part-value-py-test/parts/Part_Sqrt_Rsqrt_001.part
@@ -1,0 +1,7 @@
+[partition]
+backends=cpu,acl_cl
+default=cpu
+comply=opcode
+
+[OPCODE]
+SQRT=acl_cl

--- a/compiler/circle-part-value-py-test/parts/Part_Sqrt_Rsqrt_002.part
+++ b/compiler/circle-part-value-py-test/parts/Part_Sqrt_Rsqrt_002.part
@@ -1,0 +1,7 @@
+[partition]
+backends=cpu,acl_cl
+default=cpu
+comply=opcode
+
+[OPCODE]
+SQRT=acl_cl

--- a/compiler/circle-part-value-py-test/parts/Part_Sqrt_Rsqrt_003.part
+++ b/compiler/circle-part-value-py-test/parts/Part_Sqrt_Rsqrt_003.part
@@ -1,0 +1,7 @@
+[partition]
+backends=cpu,acl_cl
+default=cpu
+comply=opcode
+
+[OPCODE]
+SQRT=acl_cl

--- a/compiler/circle-part-value-py-test/parts/Part_Sqrt_Rsqrt_Add_000.part
+++ b/compiler/circle-part-value-py-test/parts/Part_Sqrt_Rsqrt_Add_000.part
@@ -1,0 +1,7 @@
+[partition]
+backends=cpu,acl_cl
+default=cpu
+comply=opcode
+
+[OPCODE]
+SQRT=acl_cl

--- a/compiler/circle-part-value-py-test/parts/Part_Sqrt_Rsqrt_Add_001.part
+++ b/compiler/circle-part-value-py-test/parts/Part_Sqrt_Rsqrt_Add_001.part
@@ -1,0 +1,7 @@
+[partition]
+backends=cpu,acl_cl
+default=cpu
+comply=opcode
+
+[OPCODE]
+SQRT=acl_cl

--- a/compiler/circle-part-value-py-test/parts/Part_Sqrt_Rsqrt_Add_002.part
+++ b/compiler/circle-part-value-py-test/parts/Part_Sqrt_Rsqrt_Add_002.part
@@ -1,0 +1,7 @@
+[partition]
+backends=cpu,acl_cl
+default=cpu
+comply=opcode
+
+[OPCODE]
+SQRT=acl_cl

--- a/compiler/circle-part-value-py-test/parts/Part_Sqrt_Rsqrt_Add_003.part
+++ b/compiler/circle-part-value-py-test/parts/Part_Sqrt_Rsqrt_Add_003.part
@@ -1,0 +1,7 @@
+[partition]
+backends=cpu,acl_cl
+default=cpu
+comply=opcode
+
+[OPCODE]
+WWW=acl_cl

--- a/compiler/circle-part-value-py-test/parts/Part_Sqrt_Rsqrt_Add_004.part
+++ b/compiler/circle-part-value-py-test/parts/Part_Sqrt_Rsqrt_Add_004.part
@@ -1,0 +1,6 @@
+[partition]
+backends=cpu,acl_cl
+default=cpu
+comply=opcode
+
+[OPCODE]

--- a/compiler/circle-part-value-py-test/parts/Part_Tanh_FC_nobias.part
+++ b/compiler/circle-part-value-py-test/parts/Part_Tanh_FC_nobias.part
@@ -1,0 +1,7 @@
+[partition]
+backends=cpu,acl_cl
+default=cpu
+comply=opcode
+
+[OPCODE]
+DIV=acl_cl

--- a/compiler/circle-part-value-py-test/parts/Part_Tanh_FC_nobias_001.part
+++ b/compiler/circle-part-value-py-test/parts/Part_Tanh_FC_nobias_001.part
@@ -1,0 +1,7 @@
+[partition]
+backends=cpu,npu
+default=npu
+comply=opcode
+
+[OPCODE]
+TANH=cpu

--- a/compiler/circle-part-value-py-test/parts/Part_Tanh_FC_nobias_002.part
+++ b/compiler/circle-part-value-py-test/parts/Part_Tanh_FC_nobias_002.part
@@ -1,0 +1,7 @@
+[partition]
+backends=cpu,npu
+default=cpu
+comply=opcode
+
+[OPCODE]
+FULLY_CONNECTED=npu

--- a/compiler/circle-part-value-py-test/parts/Part_Tanh_FC_nobias_003.part
+++ b/compiler/circle-part-value-py-test/parts/Part_Tanh_FC_nobias_003.part
@@ -1,0 +1,7 @@
+[partition]
+backends=cpu,npu
+default=npu
+comply=opcode
+
+[OPCODE]
+FULLY_CONNECTED=cpu

--- a/compiler/circle-part-value-py-test/parts/Part_While_000.part
+++ b/compiler/circle-part-value-py-test/parts/Part_While_000.part
@@ -1,0 +1,7 @@
+[partition]
+backends=cpu,acl_cl
+default=cpu
+comply=opcode
+
+[OPCODE]
+MAXIMUM=acl_cl

--- a/compiler/circle-part-value-py-test/parts/Part_While_001.part
+++ b/compiler/circle-part-value-py-test/parts/Part_While_001.part
@@ -1,0 +1,7 @@
+[partition]
+backends=cpu,acl_cl
+default=cpu
+comply=opcode
+
+[OPCODE]
+MAXIMUM=acl_cl

--- a/compiler/circle-part-value-py-test/parts/SignatureDef_MultiOut_000.part
+++ b/compiler/circle-part-value-py-test/parts/SignatureDef_MultiOut_000.part
@@ -1,0 +1,7 @@
+[partition]
+backends=cpu,acl_cl
+default=cpu
+comply=opcode
+
+[OPCODE]
+MAXIMUM=acl_cl

--- a/compiler/circle-part-value-py-test/parts/SignatureDef_MultiOut_001.part
+++ b/compiler/circle-part-value-py-test/parts/SignatureDef_MultiOut_001.part
@@ -1,0 +1,7 @@
+[partition]
+backends=cpu,acl_cl
+default=cpu
+comply=opcode
+
+[OPCODE]
+MAXIMUM=acl_cl

--- a/compiler/circle-part-value-py-test/requires.cmake
+++ b/compiler/circle-part-value-py-test/requires.cmake
@@ -1,0 +1,3 @@
+require("common-artifacts")
+require("circle-partitioner")
+require("circle-part-driver")

--- a/compiler/circle-part-value-py-test/test.lst
+++ b/compiler/circle-part-value-py-test/test.lst
@@ -1,0 +1,58 @@
+# Add recipe names from /res/TensorFlowLiteRecipes to test.
+# Only add items exist in common-artifacts test: tflite/circle files are copied as source.
+#
+# add(RECIPE_NAME PARTITION_NAME EXPECTED_OUTPUT_COUNT)
+#     EXPECTED_OUTPUT_COUNT: 0 for skip expected count test
+
+add(Part_Add_Sub_000 Part_Add_Sub_000 2)
+add(Part_Sqrt_Rsqrt_000 Part_Sqrt_Rsqrt_000 2)
+add(Part_Sqrt_Rsqrt_001 Part_Sqrt_Rsqrt_001 2)
+add(Part_Sqrt_Rsqrt_002 Part_Sqrt_Rsqrt_002 4)
+add(Part_Sqrt_Rsqrt_003 Part_Sqrt_Rsqrt_003 3)
+add(Part_Sqrt_Rsqrt_Add_000 Part_Sqrt_Rsqrt_Add_000 3)
+add(Part_Sqrt_Rsqrt_Add_001 Part_Sqrt_Rsqrt_Add_001 3)
+add(Part_Sqrt_Rsqrt_Add_002 Part_Sqrt_Rsqrt_Add_002 4)
+add(Part_Sqrt_Rsqrt_Add_003 Part_Sqrt_Rsqrt_Add_003 1)
+add(Part_Sqrt_Rsqrt_Add_004 Part_Sqrt_Rsqrt_Add_004 1)
+add(Part_Add_Sqrt_000 Part_Add_Sqrt_000 3)
+add(Part_Add_Sqrt_Rsqrt_000 Part_Add_Sqrt_Rsqrt_000 3)
+add(Net_InstanceNorm_003 Net_InstanceNorm_003 3)
+add(Net_InstanceNorm_003 Net_InstanceNorm_003.001 5)
+# skip expected count for now
+add(Net_InstanceNorm_003 Net_InstanceNorm_003.002 0)
+
+# comply=opname
+add(Part_Add_Sub_000 Part_Add_Sub_000.001 3)
+add(Part_Add_Sub_001 Part_Add_Sub_001 3)
+add(Part_Add_Sub_002 Part_Add_Sub_002.001 2)
+add(Part_Add_Sub_002 Part_Add_Sub_002.002 2)
+add(Net_InstanceNorm_003 Net_InstanceNorm_003.003 3)
+
+# IF with subgraphs
+add(Part_If_Add_Sub_000 Part_If_Add_Sub_000.001 3)
+add(Part_If_Add_Sub_001 Part_If_Add_Sub_001.001 3)
+
+# WHILE with subgraphs
+add(Part_While_000 Part_While_000 3)
+add(Part_While_001 Part_While_001 3)
+
+# UNPACK with multiple outputs
+add(Net_UnpackAdd_001 Net_UnpackAdd_001 2)
+add(Net_UnpackAdd_001 Net_UnpackAdd_001.001 2)
+add(Net_UnpackAdd_001 Net_UnpackAdd_001.002 2)
+
+# Other multiple outputs
+add(Part_Split_Add_000 Part_Split_Add_000 2)
+
+# test SignatureDef, with any OPCODE
+add(SignatureDef_MultiOut_000 SignatureDef_MultiOut_000 0)
+add(SignatureDef_MultiOut_001 SignatureDef_MultiOut_001 0)
+
+# FC with nobias
+add(Part_Tanh_FC_nobias Part_Tanh_FC_nobias 1)
+add(Part_Tanh_FC_nobias Part_Tanh_FC_nobias_001 2)
+add(Part_Tanh_FC_nobias Part_Tanh_FC_nobias_002 2)
+add(Part_Tanh_FC_nobias Part_Tanh_FC_nobias_003 2)
+add(Part_Mul_Sqrt_FC_nobias_000 Part_Mul_Sqrt_FC_nobias_000_000 0)
+add(Part_Mul_Sqrt_FC_nobias_000 Part_Mul_Sqrt_FC_nobias_000_001 0)
+add(Part_Mul_Sqrt_FC_nobias_000 Part_Mul_Sqrt_FC_nobias_000_002 0)

--- a/compiler/circle-part-value-py-test/test_circle_part_value.py
+++ b/compiler/circle-part-value-py-test/test_circle_part_value.py
@@ -1,0 +1,147 @@
+import numpy as np
+import tensorflow as tf
+import subprocess
+import os
+import json
+
+
+# Compares the execution result of TFLite interpreter and partitioned model(s) from a circle model.
+def part_eval(test_name, bin_dir, circle_part_driver):
+    artifacts_dir = os.path.join(bin_dir, test_name)
+    tflite_model = os.path.join(artifacts_dir, test_name + ".tflite")
+    circle_model = os.path.join(artifacts_dir, test_name + ".circle")
+    partition_conn_ini = os.path.join(artifacts_dir, test_name + ".conn.ini")
+    partition_conn_json = os.path.join(artifacts_dir, test_name + ".conn.json")
+    expected_count = os.path.join(artifacts_dir, test_name + ".excnt")
+
+    # Check expected count of models from partitioning
+    try:
+        with open(expected_count, "r") as expected_count_file:
+            expected_count_line = expected_count_file.readline()
+
+        expected_count_line = int(expected_count_line)
+        if expected_count_line:
+            with open(partition_conn_json) as json_file:
+                json_data = json.load(json_file)
+                parts_value = json_data["parts"]
+                if len(parts_value) != expected_count_line:
+                    print("Partitioned model count differs from expected:",
+                          expected_count_line)
+                    assert False
+
+                print("Partitioned model count expected: ", expected_count_line)
+        else:
+            print("Skip expected partitioned model count check: 0")
+
+    except:
+        print("Skip expected partitioned model count check: error")
+
+    # Build TFLite interpreter.
+    interpreter = tf.lite.Interpreter(tflite_model)
+    interpreter.allocate_tensors()
+
+    # Read SignatureDef and get output tensor id orders for remapping
+    full_signatures = interpreter._get_full_signature_list()
+    full_signatures_outputs_remap = None
+    if full_signatures != None:
+        signature_serving_default = full_signatures.get('serving_default', None)
+        if signature_serving_default != None:
+            signature_outputs = signature_serving_default['outputs']
+
+            full_signatures_outputs_remap = []
+            for index, (key, value) in enumerate(signature_outputs.items()):
+                full_signatures_outputs_remap.append(value)
+
+    # Generate random input data.
+    num_inputs = len(interpreter.get_input_details())
+    for i in range(num_inputs):
+        input_details = interpreter.get_input_details()[i]
+        if input_details["dtype"] == np.float32:
+            input_data = np.array(
+                np.random.random_sample(input_details["shape"]), input_details["dtype"])
+        elif input_details["dtype"] == np.uint8:
+            input_data = np.array(
+                np.random.randint(0, 256, size=input_details["shape"]),
+                input_details["dtype"])
+        elif input_details["dtype"] == np.int16:
+            input_data = np.array(
+                np.random.randint(0, 100, size=input_details["shape"]),
+                input_details["dtype"])
+        elif input_details["dtype"] == np.int32:
+            input_data = np.array(
+                np.random.randint(0, 100, size=input_details["shape"]),
+                input_details["dtype"])
+        elif input_details["dtype"] == np.int64:
+            input_data = np.array(
+                np.random.randint(0, 100, size=input_details["shape"]),
+                input_details["dtype"])
+        elif input_details["dtype"] == np.bool_:
+            input_data = np.array(
+                np.random.choice(a=[True, False], size=input_details["shape"]),
+                input_details["dtype"])
+        else:
+            assert False, "Unsupported input dtype"
+
+        interpreter.set_tensor(input_details["index"], input_data)
+        input_data.tofile(circle_model + ".input" + str(i))
+
+    # Do inference
+    interpreter.invoke()
+
+    # Execute circle-part-driver.
+    partition_command = [
+        circle_part_driver, partition_conn_ini,
+        str(num_inputs), circle_model + ".input", circle_model + ".output"
+    ]
+    print("Run: ")
+    for arg in partition_command:
+        print("    ", arg, "\\")
+    print("", flush=True)
+
+    # working directory into the folder as ini has relative filename of the model
+    subprocess.run(partition_command, check=True, cwd=artifacts_dir)
+
+    # Compare the results.
+    inpt_output_details = interpreter.get_output_details()
+    for idx in range(len(inpt_output_details)):
+        output_details = inpt_output_details[idx]
+        output_data = np.fromfile(circle_model + ".output" + str(idx),
+                                  output_details["dtype"])
+        shape_file = open(circle_model + ".output" + str(idx) + ".shape", 'r')
+        output_shape = [int(i) for i in shape_file.read().split(',')]
+        luci_output_data = np.reshape(output_data, output_shape)
+        output_tensor = output_details["index"]
+        if full_signatures_outputs_remap != None:
+            output_tensor = full_signatures_outputs_remap[idx]
+        intp_output_data = interpreter.get_tensor(output_tensor)
+        if output_details["dtype"] == np.uint8:
+            assert np.allclose(
+                luci_output_data, intp_output_data, rtol=0, atol=0
+            ), "Execution result of " + tflite_model + " does not match with " + circle_model
+        elif output_details["dtype"] == np.float32:
+            assert np.allclose(
+                luci_output_data, intp_output_data, rtol=1.e-5, atol=1.e-5
+            ), "Execution result of " + tflite_model + " does not match with " + circle_model
+        elif output_details["dtype"] == np.int64:
+            assert np.allclose(
+                luci_output_data, intp_output_data, rtol=0, atol=0
+            ), "Execution result of " + tflite_model + " does not match with " + circle_model
+        elif output_details["dtype"] == np.int32:
+            assert np.allclose(
+                luci_output_data, intp_output_data, rtol=0, atol=0
+            ), "Execution result of " + tflite_model + " does not match with " + circle_model
+        elif output_details["dtype"] == np.int16:
+            assert np.allclose(
+                luci_output_data, intp_output_data, rtol=0, atol=0
+            ), "Execution result of " + tflite_model + " does not match with " + circle_model
+        elif output_details["dtype"] == np.bool_:
+            assert np.allclose(
+                luci_output_data, intp_output_data, rtol=0, atol=0
+            ), "Execution result of " + tflite_model + " does not match with " + circle_model
+        else:
+            assert False, "Unsupported data type: " + output_details["dtype"]
+
+
+# arguments must be in sync with `conftest.py`
+def test_circle_part_value(test_name: str, bin_dir: str, part_driver_path: str):
+    part_eval(test_name, bin_dir, part_driver_path)


### PR DESCRIPTION
This commit introduces circle-part-value-py-test to resolve long test duration.

Related: #12071 

### Before
```
Start 72: circle_part_value_test
72/76 Test #72: circle_part_value_test .................   Passed   41.85 sec
```
### After
```
Test project /home/seongwoo/ONE/build
    Start 74: circle_part_value_py_test
1/1 Test #74: circle_part_value_py_test ........   Passed    1.72 sec

100% tests passed, 0 tests failed out of 1

Total Test time (real) =   1.73 sec
```
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>