### PR TITLE
[luci/pass] Reset shape status for SplitVOut

### DIFF
--- a/compiler/luci/pass/src/ConvertNCHWToNHWCPass.cpp
+++ b/compiler/luci/pass/src/ConvertNCHWToNHWCPass.cpp
@@ -1273,6 +1273,9 @@ class ConvertNCHWToNHWC final : public luci::CircleNodeMutableVisitor<bool>
       auto post_trans = create_post_transpose(svo);
       loco::replace(svo).with(post_trans);
       post_trans->a(svo);
+
+      // Do shape inference for this node again.
+      svo->shape_status(luci::ShapeStatus::UNDEFINED);
     }
 
     return true;


### PR DESCRIPTION
This will reset shape status for CircleSplitVOut too for NCHW to NHWC conversion.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>