### PR TITLE
[circle-mpqsolver] Revisit Dumper

### DIFF
--- a/compiler/circle-mpqsolver/src/core/Dumper.cpp
+++ b/compiler/circle-mpqsolver/src/core/Dumper.cpp
@@ -43,11 +43,11 @@ Dumper::Dumper(const std::string &dir_path) : _dir_path(dir_path) {}
 void Dumper::setModelPath(const std::string &model_path) { _model_path = model_path; }
 
 void Dumper::dumpMPQConfiguration(const LayerParams &layers, const std::string &def_dtype,
-                                  const std::string &path) const
+                                  const std::string &def_granularity, const std::string &path) const
 {
   Json::Value mpq_data;
   mpq_data[default_dtype_key] = def_dtype;
-  mpq_data[default_granularity_key] = "channel";
+  mpq_data[default_granularity_key] = def_granularity;
   mpq_data[model_key] = _model_path;
 
   Json::Value layers_data;
@@ -80,18 +80,19 @@ void Dumper::prepareDirectory(const std::string &dir_path) const
 }
 
 void Dumper::dumpMPQConfiguration(const LayerParams &layers, const std::string &def_dtype,
-                                  int step) const
+                                  const std::string &def_granularity, int step) const
 {
   prepareDirectory(_dir_path);
   std::string path = _dir_path + "/Configuration_" + std::to_string(step) + ".mpq.json";
-  dumpMPQConfiguration(layers, def_dtype, path);
+  dumpMPQConfiguration(layers, def_dtype, def_granularity, path);
 }
 
-void Dumper::dumpFinalMPQ(const LayerParams &layers, const std::string &def_dtype) const
+void Dumper::dumpFinalMPQ(const LayerParams &layers, const std::string &def_dtype,
+                          const std::string &def_granularity) const
 {
   prepareDirectory(_dir_path);
   std::string path = _dir_path + "/FinalConfiguration" + ".mpq.json";
-  dumpMPQConfiguration(layers, def_dtype, path);
+  dumpMPQConfiguration(layers, def_dtype, def_granularity, path);
 }
 
 void Dumper::writeDataToFile(const std::string &path, const std::string &data) const

--- a/compiler/circle-mpqsolver/src/core/Dumper.h
+++ b/compiler/circle-mpqsolver/src/core/Dumper.h
@@ -45,17 +45,20 @@ public:
    * @brief dumps mpq configuration
    * @param layers specific quantization parameters
    * @param def_dtype default quantization data type
+   * @param def_granularity default granularity
    * @param step id of mpq configuration
    */
   void dumpMPQConfiguration(const LayerParams &layers, const std::string &def_dtype,
-                            int step) const;
+                            const std::string &def_granularity, int step) const;
 
   /**
    * @brief dumps final mpq configuration
    * @param layers specific quantization parameters
    * @param def_dtype default quantization data type
+   * @param def_granularity default granularity
    */
-  void dumpFinalMPQ(const LayerParams &layers, const std::string &def_dtype) const;
+  void dumpFinalMPQ(const LayerParams &layers, const std::string &def_dtype,
+                    const std::string &def_granularity) const;
 
   /**
    * @brief dumps quantized module
@@ -95,7 +98,7 @@ public:
 private:
   void writeDataToFile(const std::string &path, const std::string &data) const;
   void dumpMPQConfiguration(const LayerParams &layers, const std::string &def_dtype,
-                            const std::string &path) const;
+                            const std::string &def_granularity, const std::string &path) const;
   void prepareDirectory(const std::string &dir_path) const;
   void saveCircle(luci::Module *module, std::string &path) const;
   void dumpError(float error, const std::string &tag, const std::string &path) const;

--- a/compiler/circle-mpqsolver/src/core/Dumper.test.cpp
+++ b/compiler/circle-mpqsolver/src/core/Dumper.test.cpp
@@ -56,12 +56,12 @@ TEST_F(CircleMPQSolverDumperTest, verifyResultsTest)
   dumper.setModelPath("");
   mpqsolver::core::LayerParams params;
   auto const step = 0;
-  dumper.dumpMPQConfiguration(params, "uint8", step);
+  dumper.dumpMPQConfiguration(params, "uint8", "channel", step);
 
   std::string step_path = _folder + "/Configuration_" + std::to_string(step) + ".mpq.json";
   EXPECT_TRUE(mpqsolver::test::io_utils::isFileExists(step_path));
 
-  dumper.dumpFinalMPQ(params, "uint8");
+  dumper.dumpFinalMPQ(params, "uint8", "channel");
   std::string fin_path = _folder + "/FinalConfiguration" + ".mpq.json";
   EXPECT_TRUE(mpqsolver::test::io_utils::isFileExists(fin_path));
 
@@ -77,7 +77,7 @@ TEST_F(CircleMPQSolverDumperTest, empty_path_NEG)
 
   mpqsolver::core::LayerParams params;
   auto const step = 0;
-  EXPECT_THROW(dumper.dumpMPQConfiguration(params, "uint8", step), std::runtime_error);
-  EXPECT_THROW(dumper.dumpFinalMPQ(params, "uint8"), std::runtime_error);
+  EXPECT_THROW(dumper.dumpMPQConfiguration(params, "uint8", "channel", step), std::runtime_error);
+  EXPECT_THROW(dumper.dumpFinalMPQ(params, "uint8", "channel"), std::runtime_error);
   EXPECT_THROW(dumper.prepareForErrorDumping(), std::runtime_error);
 }

--- a/compiler/circle-mpqsolver/src/core/DumpingHooks.cpp
+++ b/compiler/circle-mpqsolver/src/core/DumpingHooks.cpp
@@ -41,14 +41,14 @@ void DumpingHooks::onBeginIteration()
 void DumpingHooks::onEndIteration(const LayerParams &layers, const std::string &def_type,
                                   float error) const
 {
-  _dumper.dumpMPQConfiguration(layers, def_type, _num_of_iterations);
+  _dumper.dumpMPQConfiguration(layers, def_type, "channel", _num_of_iterations);
   _dumper.dumpMPQError(error, _num_of_iterations);
 }
 
 void DumpingHooks::onEndSolver(const LayerParams &layers, const std::string &def_dtype,
                                float qerror)
 {
-  _dumper.dumpFinalMPQ(layers, def_dtype);
+  _dumper.dumpFinalMPQ(layers, def_dtype, "channel");
   _dumper.dumpMPQError(qerror);
   _in_iterations = false;
 }


### PR DESCRIPTION
This commit removes hardcoded granularity from Dumper and adjusts dependencies accordingly.

Draft: https://github.com/Samsung/ONE/pull/12042
Related: https://github.com/Samsung/ONE/issues/12020

ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>