### PR TITLE
[circle-mpqsolver] Fix DumpingHooks

### DIFF
--- a/compiler/circle-mpqsolver/src/core/DumpingHooks.cpp
+++ b/compiler/circle-mpqsolver/src/core/DumpingHooks.cpp
@@ -39,10 +39,11 @@ void DumpingHooks::onBeginIteration()
 }
 
 void DumpingHooks::onEndIteration(const LayerParams &layers, const std::string &def_type,
-                                  float error) const
+                                  float error)
 {
   _dumper.dumpMPQConfiguration(layers, def_type, _num_of_iterations);
   _dumper.dumpMPQError(error, _num_of_iterations);
+  _in_iterations = false;
 }
 
 void DumpingHooks::onEndSolver(const LayerParams &layers, const std::string &def_dtype,
@@ -50,7 +51,6 @@ void DumpingHooks::onEndSolver(const LayerParams &layers, const std::string &def
 {
   _dumper.dumpFinalMPQ(layers, def_dtype);
   _dumper.dumpMPQError(qerror);
-  _in_iterations = false;
 }
 
 void DumpingHooks::onQuantized(luci::Module *module) const

--- a/compiler/circle-mpqsolver/src/core/DumpingHooks.h
+++ b/compiler/circle-mpqsolver/src/core/DumpingHooks.h
@@ -61,7 +61,7 @@ public:
    * @brief called at the end of current iteration
    */
   virtual void onEndIteration(const LayerParams &layers, const std::string &def_dtype,
-                              float error) const override;
+                              float error) override;
 
   /**
    * @brief called at the end of iterative search

--- a/compiler/circle-mpqsolver/src/core/SolverHooks.h
+++ b/compiler/circle-mpqsolver/src/core/SolverHooks.h
@@ -51,7 +51,7 @@ public:
    * @param error error of quantization for current iteration
    */
   virtual void onEndIteration(const LayerParams &layers, const std::string &def_dtype,
-                              float error) const = 0;
+                              float error) = 0;
 
   /**
    * @brief called at the end of iterative search


### PR DESCRIPTION
This commit  moves setting _in_iterations to false to onEndIteration
and makes onEndIteration nonconst to keep onEndIteration synchronized
with onBeginIteration.

Draft: https://github.com/Samsung/ONE/pull/12042
Related: https://github.com/Samsung/ONE/issues/12020

ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>