### PR TITLE
[luci/pass] Extend ForwardReshapeToUnaryOpPass with Mul and Div ops

### DIFF
--- a/compiler/luci/pass/src/ForwardReshapeToUnaryOpPass.cpp
+++ b/compiler/luci/pass/src/ForwardReshapeToUnaryOpPass.cpp
@@ -299,7 +299,7 @@ namespace luci
  *
  *   UnaryOp: CircleNeg, ...
  *   Note: Binary Op (Div, Mul) can also be considered as a unary operation
- *   if one of its inputs is a constant.
+ *         if one of its inputs is a constant.
  *
  * AFTER
  *                       |


### PR DESCRIPTION
This commit extends ForwardReshapeToUnaryOpPass with Mul and Div ops.

for issue: https://github.com/Samsung/ONE/issues/11956
from draft https://github.com/Samsung/ONE/pull/12124

ONE-DCO-1.0-Signed-off-by: Artem Balyshev <a.balyshev@samsung.com>