### PR TITLE
[luci/pass] Extend ForwardReshapeToUnaryOpPass with Mean op

### DIFF
--- a/compiler/luci/pass/src/ForwardReshapeToUnaryOpPass.cpp
+++ b/compiler/luci/pass/src/ForwardReshapeToUnaryOpPass.cpp
@@ -96,6 +96,7 @@ bool forward_reshape(luci::CircleReshape *reshape, luci::CircleMean *mean, uint3
   auto *shape_reshape = loco::must_cast<luci::CircleConst *>(new_reshape->shape());
   assert(shape_reshape->dtype() == loco::DataType::S32);     // FIX_CALLER_UNLESS
   assert(axis < shape_reshape->size<loco::DataType::S32>()); // FIX_CALLER_UNLESS
+  // Mean reduction will make value to '1'
   shape_reshape->at<loco::DataType::S32>(axis) = 1;
 
   // Do shape inference for this node again.

--- a/compiler/luci/pass/src/ForwardReshapeToUnaryOpPass.cpp
+++ b/compiler/luci/pass/src/ForwardReshapeToUnaryOpPass.cpp
@@ -285,7 +285,7 @@ protected:
 
     for (int32_t i = 0; i <= axis_value; ++i)
     {
-      if (reshape_input->dim(i).value() != reshape->dim(i).value())
+      if (not reshape_input->dim(i).known() or reshape_input->dim(i).value() != reshape->dim(i).value())
         return false;
     }
 

--- a/compiler/luci/pass/src/ForwardReshapeToUnaryOpPass.cpp
+++ b/compiler/luci/pass/src/ForwardReshapeToUnaryOpPass.cpp
@@ -243,6 +243,34 @@ protected:
     return false;
   }
 
+  /**
+   * Graph example:
+   *
+   *  BEFORE
+   *               [Input]
+   *              (3, 4, 4)                 [Shape_Const = (1, -1, 4)]
+   *                  |                     |
+   *              [Reshape] ----------------
+   *              (1, 12, 4)
+   *                  |
+   *        [Mean, keep_dims = true]
+   *              (1, 12, 1)
+   *                  |
+   *               [Output]
+   *
+   *  AFTER
+   *               [Input]
+   *              (3, 4, 4)
+   *                  |
+   *         [Mean, keep_dims = true]
+   *              (3, 4, 1)                 [Shape_Const = (1, -1, 1)]
+   *                  |                     |
+   *              [Reshape]-----------------
+   *              (1, 12, 1)
+   *                  |
+   *              [Output]
+   *
+   */
   bool visit(luci::CircleMean *node)
   {
     luci::CircleReshape *reshape = nullptr;

--- a/compiler/luci/pass/src/ForwardReshapeToUnaryOpPass.cpp
+++ b/compiler/luci/pass/src/ForwardReshapeToUnaryOpPass.cpp
@@ -262,8 +262,7 @@ protected:
       return false;
 
     // axis value
-    int32_t axis_value;
-    axis_value = axis->at<loco::DataType::S32>(0);
+    auto axis_value = axis->at<loco::DataType::S32>(0);
 
     if (axis_value < 0)
       axis_value += static_cast<int32_t>(reshape->rank());
@@ -273,9 +272,7 @@ protected:
     if (node->keep_dims() != true)
       return false;
 
-    auto *reshape_input = dynamic_cast<luci::CircleNode *>(reshape->tensor());
-    if (reshape_input == nullptr)
-      return false;
+    auto reshape_input = loco::must_cast<luci::CircleNode *>(reshape->tensor());
 
     // reshape shouldn't change rank
     if (reshape_input->rank() != reshape->rank())
@@ -285,7 +282,8 @@ protected:
 
     for (int32_t i = 0; i <= axis_value; ++i)
     {
-      if (not reshape_input->dim(i).known() or reshape_input->dim(i).value() != reshape->dim(i).value())
+      if (not reshape_input->dim(i).known() or
+          reshape_input->dim(i).value() != reshape->dim(i).value())
         return false;
     }
 

--- a/compiler/luci/pass/src/ForwardReshapeToUnaryOpPass.test.cpp
+++ b/compiler/luci/pass/src/ForwardReshapeToUnaryOpPass.test.cpp
@@ -277,6 +277,8 @@ public:
 
     output()->from(_mean);
   }
+
+  void invalid_type() { _mean_const->dtype(loco::DataType::FLOAT32); }
 };
 
 } // namespace
@@ -324,4 +326,16 @@ TEST(FuseMulWithDivPassTest, forward_reshape_to_mean_pattern)
   g.init();
 
   EXPECT_TRUE(pass.run(g.g()));
+}
+
+TEST(FuseMulWithDivPassTest, forward_reshape_to_mean_pattern_NEG)
+{
+  ForwardReshapeToMeanPatternTestGraph g;
+  luci::ForwardReshapeToUnaryOpPass pass;
+
+  g.init();
+
+  g.invalid_type();
+
+  EXPECT_FALSE(pass.run(g.g()));
 }


### PR DESCRIPTION
This commit extends ForwardReshapeToUnaryOpPass with Mean op.

for issue: https://github.com/Samsung/ONE/issues/11956
from draft https://github.com/Samsung/ONE/pull/12124

ONE-DCO-1.0-Signed-off-by: Artem Balyshev <a.balyshev@samsung.com>