### PR TITLE
[onert] Introduce OriginIndex in IR

### DIFF
--- a/runtime/onert/core/include/ir/Index.h
+++ b/runtime/onert/core/include/ir/Index.h
@@ -41,6 +41,9 @@ using SubgraphIndex = ::onert::util::Index<uint16_t, SubgraphIndexTag>;
 struct ModelIndexTag;
 using ModelIndex = ::onert::util::Index<uint16_t, ModelIndexTag>;
 
+struct OriginIndexTag;
+using OriginIndex = ::onert::util::Index<uint32_t, OriginIndexTag>;
+
 template <typename IndexType>
 std::ostream &_index_print_impl(std::ostream &o, const std::string &prefix, IndexType index)
 {
@@ -75,6 +78,10 @@ inline std::ostream &operator<<(std::ostream &o, const ModelIndex &i)
   return _index_print_impl(o, "MODEL", i);
 }
 
+inline std::ostream &operator<<(std::ostream &o, const OriginIndex &i)
+{
+  return _index_print_impl(o, "", i);
+}
 } // namespace ir
 } // namespace onert
 

--- a/runtime/onert/core/include/ir/Operand.h
+++ b/runtime/onert/core/include/ir/Operand.h
@@ -104,6 +104,9 @@ public:
     return std::vector<T>(base, base + size);
   }
 
+  void setOriginIndex(OriginIndex origin) { _info.setOriginIndex(origin); }
+  OriginIndex originIndex() const { return _info.originIndex(); }
+
 private:
   OperandInfo _info;
   std::shared_ptr<Data> _data;

--- a/runtime/onert/core/include/ir/OperandInfo.h
+++ b/runtime/onert/core/include/ir/OperandInfo.h
@@ -21,9 +21,10 @@
 #ifndef __ONERT_IR_OPERAND_INFO_H__
 #define __ONERT_IR_OPERAND_INFO_H__
 
+#include "ir/Index.h"
+#include "ir/Layout.h"
 #include "ir/Shape.h"
 #include "ir/TypeInfo.h"
-#include "ir/Layout.h"
 
 namespace onert
 {
@@ -66,9 +67,9 @@ public:
    * @param[in] alloc_type  When the thesor needs memory allocation
    */
   OperandInfo(const Shape &shape, const TypeInfo &typeInfo, MemAllocType alloc_type,
-              bool is_const = false, bool is_variable = false)
+              bool is_const = false, bool is_variable = false, OriginIndex origin = OriginIndex())
     : _shape(shape), _typeInfo(typeInfo), _alloc_type(alloc_type), _const(is_const),
-      _variable(is_variable)
+      _variable(is_variable), _origin(origin)
   {
     // DO NOTHING
   }
@@ -135,14 +136,16 @@ public:
   bool isVariable() const { return _variable; }
   bool isDynamic() const { return _alloc_type == MemAllocType::DYNAMIC; }
   void setDynamic() { _alloc_type = MemAllocType::DYNAMIC; }
+  OriginIndex originIndex() const { return _origin; }
+  void setOriginIndex(OriginIndex origin) { _origin = origin; }
 
 private:
   Shape _shape;
   TypeInfo _typeInfo;
-
   MemAllocType _alloc_type;
   bool _const;
   bool _variable;
+  OriginIndex _origin;
 };
 
 } // namespace ir


### PR DESCRIPTION
It introduces OriginIndex in IR.
It will be used for exporting circle after training.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

Draft: #12246