### PR TITLE
[onert] Copy the whole OperandInfo on TrainableTensor creation

### DIFF
--- a/runtime/onert/core/include/backend/basic/BackendContextHelpers.h
+++ b/runtime/onert/core/include/backend/basic/BackendContextHelpers.h
@@ -201,9 +201,7 @@ template <typename T_BackendContext> ITensorRegistry *genTensors(T_BackendContex
       return;
     // NOTE Assuming there is no layout changes (Always assume NHWC or UNKNOWN)
     assert(graph.layout() != ir::Layout::NCHW);
-    ir::OperandInfo backend_info{obj.shape(), obj.typeInfo(), obj.info().memAllocType(),
-                                 obj.isConstant()};
-    tensor_builder->registerTensorInfo(ind, backend_info, ir::Layout::NHWC);
+    tensor_builder->registerTensorInfo(ind, obj.info(), ir::Layout::NHWC);
   });
 
   // TODO Get compiler options from compiler, and use it rather than getting it from Env

--- a/runtime/onert/core/include/backend/basic/train/TrainableBackendContextHelpers.h
+++ b/runtime/onert/core/include/backend/basic/train/TrainableBackendContextHelpers.h
@@ -43,9 +43,7 @@ ITensorRegistry *genTensors(backend::train::TrainableBackendContext &ctx,
       return;
     // NOTE Assuming there is no layout changes (Always assume NHWC or UNKNOWN)
     assert(tgraph.layout() != ir::Layout::NCHW);
-    ir::OperandInfo backend_info{obj.shape(), obj.typeInfo(), obj.info().memAllocType(),
-                                 obj.isConstant()};
-    tensor_builder->registerTensorInfo(ind, backend_info, ir::Layout::NHWC);
+    tensor_builder->registerTensorInfo(ind, obj.info(), ir::Layout::NHWC);
   });
 
   // For the executors that does not have fixed linear execution order:


### PR DESCRIPTION
On constructing TrainableTensor, OperandInfo will be used from the whole copy of original OperandInfo, not by copying listing each members.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

Draft: https://github.com/Samsung/ONE/pull/12246