### PR TITLE
[onert] Introduce iterateTrainableTensors

### DIFF
--- a/runtime/onert/core/include/backend/train/ITensorRegistry.h
+++ b/runtime/onert/core/include/backend/train/ITensorRegistry.h
@@ -18,6 +18,7 @@
 #define __ONERT_BACKEND_TRAIN_ITENSOR_REGISTRY_H__
 
 #include "backend/ITensorRegistry.h"
+#include "backend/train/ITrainableTensor.h"
 
 namespace onert
 {
@@ -55,6 +56,13 @@ public:
    * @note  Returned tensor cannot be used longer than dynamic tensor manager
    */
   virtual ITensor *getGradientITensor(const ir::OperandIndex &) = 0;
+
+  /**
+   * @brief Iterate ITrainableTensors with fn
+   * @param fn function to be called with OperandIndex and a pointer to ITrainableTensor
+   */
+  virtual void iterateTrainableTensors(
+    const std::function<void(const ir::OperandIndex &, train::ITrainableTensor *)> &) const = 0;
 };
 
 } // namespace train
@@ -100,6 +108,16 @@ public:
   ITensor *getGradientITensor(const ir::OperandIndex &index) override
   {
     return getGradientTensor(index);
+  }
+
+  void iterateTrainableTensors(
+    const std::function<void(const ir::OperandIndex &, train::ITrainableTensor *)> &fn)
+    const override
+  {
+    for (const auto &e : _trainable)
+    {
+      fn(e.first, e.second.get());
+    }
   }
 
   IPortableTensor *getPortableTensor(const ir::OperandIndex &index)

--- a/runtime/onert/core/include/backend/train/ITensorRegistry.h
+++ b/runtime/onert/core/include/backend/train/ITensorRegistry.h
@@ -62,7 +62,8 @@ public:
    * @param fn function to be called with OperandIndex and a pointer to ITrainableTensor
    */
   virtual void iterateTrainableTensors(
-    const std::function<void(const ir::OperandIndex &, train::ITrainableTensor *)> &) const = 0;
+    const std::function<void(const ir::OperandIndex &, const train::ITrainableTensor *)> &)
+    const = 0;
 };
 
 } // namespace train
@@ -111,7 +112,7 @@ public:
   }
 
   void iterateTrainableTensors(
-    const std::function<void(const ir::OperandIndex &, train::ITrainableTensor *)> &fn)
+    const std::function<void(const ir::OperandIndex &, const train::ITrainableTensor *)> &fn)
     const override
   {
     for (const auto &e : _trainable)

--- a/runtime/onert/core/include/backend/train/ITensorRegistry.h
+++ b/runtime/onert/core/include/backend/train/ITensorRegistry.h
@@ -116,9 +116,7 @@ public:
     const override
   {
     for (const auto &e : _trainable)
-    {
       fn(e.first, e.second.get());
-    }
   }
 
   IPortableTensor *getPortableTensor(const ir::OperandIndex &index)

--- a/runtime/onert/core/src/backend/builtin/train/TensorRegistry.h
+++ b/runtime/onert/core/src/backend/builtin/train/TensorRegistry.h
@@ -98,7 +98,7 @@ public:
   }
 
   void iterateTrainableTensors(
-    const std::function<void(const ir::OperandIndex &, backend::train::ITrainableTensor *)> &)
+    const std::function<void(const ir::OperandIndex &, const backend::train::ITrainableTensor *)> &)
     const override
   {
     // DO NOTHING

--- a/runtime/onert/core/src/backend/builtin/train/TensorRegistry.h
+++ b/runtime/onert/core/src/backend/builtin/train/TensorRegistry.h
@@ -18,6 +18,7 @@
 #define __ONERT_BACKEND_BUILTIN_TRAIN_TENSOR_REGISTRY_H__
 
 #include <backend/train/ITensorRegistry.h>
+#include <backend/train/ITrainableTensor.h>
 
 #include "../IOTensor.h"
 #include "../Tensor.h"
@@ -94,6 +95,14 @@ public:
     assert(!getITensor(index)); // For the index, tensor is not registered yet
     _base_reg->setMigrantTensor(index, tensor);
     return true;
+  }
+
+  void iterateTrainableTensors(
+    const std::function<void(const ir::OperandIndex &, backend::train::ITrainableTensor *)> &)
+    const override
+  {
+    // DO NOTHING
+    // Builtin tensor registry does not have trainable tensor.
   }
 
   void setBackPropTensor(const ir::OperandIndex &index, std::unique_ptr<BackPropTensor> tensor)

--- a/runtime/onert/core/src/backend/builtin/train/TensorRegistry.h
+++ b/runtime/onert/core/src/backend/builtin/train/TensorRegistry.h
@@ -18,7 +18,6 @@
 #define __ONERT_BACKEND_BUILTIN_TRAIN_TENSOR_REGISTRY_H__
 
 #include <backend/train/ITensorRegistry.h>
-#include <backend/train/ITrainableTensor.h>
 
 #include "../IOTensor.h"
 #include "../Tensor.h"

--- a/runtime/onert/core/src/compiler/train/TensorRegistries.h
+++ b/runtime/onert/core/src/compiler/train/TensorRegistries.h
@@ -20,6 +20,8 @@
 #include "../../backend/builtin/Config.h"
 #include "../../backend/builtin/train/TensorRegistry.h"
 
+#include <backend/train/ITensorRegistry.h>
+#include <backend/train/ITrainableTensor.h>
 #include <backend/train/TrainableBackendContext.h>
 
 #include <memory>
@@ -91,6 +93,15 @@ public:
         return tensor;
     }
     return nullptr;
+  }
+
+  void iterateTrainableTensors(
+    const std::function<void(const ir::OperandIndex &, backend::train::ITrainableTensor *)> &fn)
+    const
+  {
+    assert(_tensor_regs.size() == 2); // training backend and built-in backcend
+    for (auto &&tensor_reg : _tensor_regs)
+      tensor_reg->iterateTrainableTensors(fn);
   }
 
 private:

--- a/runtime/onert/core/src/compiler/train/TensorRegistries.h
+++ b/runtime/onert/core/src/compiler/train/TensorRegistries.h
@@ -96,11 +96,11 @@ public:
   }
 
   void iterateTrainableTensors(
-    const std::function<void(const ir::OperandIndex &, backend::train::ITrainableTensor *)> &fn)
-    const
+    const std::function<void(const ir::OperandIndex &, const backend::train::ITrainableTensor *)>
+      &fn) const
   {
-    assert(_tensor_regs.size() == 2); // training backend and built-in backcend
-    for (auto &&tensor_reg : _tensor_regs)
+    assert(_tensor_regs.size() == 2); // training backend and built-in backend
+    for (const auto &tensor_reg : _tensor_regs)
       tensor_reg->iterateTrainableTensors(fn);
   }
 

--- a/runtime/onert/core/src/compiler/train/TensorRegistries.h
+++ b/runtime/onert/core/src/compiler/train/TensorRegistries.h
@@ -21,7 +21,6 @@
 #include "../../backend/builtin/train/TensorRegistry.h"
 
 #include <backend/train/ITensorRegistry.h>
-#include <backend/train/ITrainableTensor.h>
 #include <backend/train/TrainableBackendContext.h>
 
 #include <memory>

--- a/runtime/onert/core/src/compiler/train/TensorRegistries.h
+++ b/runtime/onert/core/src/compiler/train/TensorRegistries.h
@@ -99,7 +99,6 @@ public:
     const std::function<void(const ir::OperandIndex &, const backend::train::ITrainableTensor *)>
       &fn) const
   {
-    assert(_tensor_regs.size() == 2); // training backend and built-in backend
     for (const auto &tensor_reg : _tensor_regs)
       tensor_reg->iterateTrainableTensors(fn);
   }


### PR DESCRIPTION
It introduces iterateTrainableTensors in train::ITensorRegistry and TensorRegistries.
It is added for exporting circle with trained weights.
    
ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

Draft: https://github.com/Samsung/ONE/pull/12246