### PR TITLE
[circle-mpqsolver] Revisit Quantizer

### DIFF
--- a/compiler/circle-mpqsolver/src/core/Quantizer.h
+++ b/compiler/circle-mpqsolver/src/core/Quantizer.h
@@ -82,6 +82,8 @@ public:
   bool fakeQuantize(luci::Module *module, const std::string &quant_dtype,
                     LayerParams &layer_params);
 
+  const Context &getContext() const { return _ctx; }
+
 private:
   Context _ctx;
   const QuantizerHook *_hook = nullptr;


### PR DESCRIPTION
This commit adds getContext method to get saved Quantizer::Context.

Draft: https://github.com/Samsung/ONE/pull/12042
Related: https://github.com/Samsung/ONE/issues/12020

ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>