### PR TITLE
[circle-mpqsolver] Revisit DumpingHooks

### DIFF
--- a/compiler/circle-mpqsolver/src/MPQSolver.cpp
+++ b/compiler/circle-mpqsolver/src/MPQSolver.cpp
@@ -28,7 +28,7 @@ MPQSolver::MPQSolver(const core::Quantizer::Context &ctx)
 
 void MPQSolver::setSaveIntermediate(const std::string &save_path)
 {
-  _hooks = std::make_unique<core::DumpingHooks>(save_path);
+  _hooks = std::make_unique<core::DumpingHooks>(save_path, _quantizer->getContext());
 }
 
 std::unique_ptr<luci::Module> MPQSolver::readModule(const std::string &path)

--- a/compiler/circle-mpqsolver/src/core/DumpingHooks.cpp
+++ b/compiler/circle-mpqsolver/src/core/DumpingHooks.cpp
@@ -19,8 +19,8 @@
 
 using namespace mpqsolver::core;
 
-DumpingHooks::DumpingHooks(const std::string &save_path)
-  : _save_path(save_path), _dumper(_save_path)
+DumpingHooks::DumpingHooks(const std::string &save_path, const Quantizer::Context &ctx)
+  : _save_path(save_path), _dumper(_save_path), _ctx(ctx)
 {
 }
 
@@ -51,7 +51,7 @@ void DumpingHooks::onBeginIteration()
 void DumpingHooks::onEndIteration(const LayerParams &layers, const std::string &def_type,
                                   float error)
 {
-  _dumper.dumpMPQConfiguration(layers, def_type, "channel", _num_of_iterations);
+  _dumper.dumpMPQConfiguration(layers, def_type, _ctx.granularity, _num_of_iterations);
   _dumper.dumpMPQError(error, _num_of_iterations);
   _in_iterations = false;
 }
@@ -59,7 +59,7 @@ void DumpingHooks::onEndIteration(const LayerParams &layers, const std::string &
 void DumpingHooks::onEndSolver(const LayerParams &layers, const std::string &def_dtype,
                                float qerror)
 {
-  _dumper.dumpFinalMPQ(layers, def_dtype, "channel");
+  _dumper.dumpFinalMPQ(layers, def_dtype, _ctx.granularity);
   if (!std::isnan(qerror))
   {
     _dumper.dumpMPQError(qerror);

--- a/compiler/circle-mpqsolver/src/core/DumpingHooks.h
+++ b/compiler/circle-mpqsolver/src/core/DumpingHooks.h
@@ -40,7 +40,7 @@ public:
    * @brief DumpingHooks constructor
    * @param save_path directory where all intermediate data will be saved
    */
-  DumpingHooks(const std::string &save_path);
+  DumpingHooks(const std::string &save_path, const Quantizer::Context &ctx);
 
   /**
    * @brief called on successfull quantization
@@ -75,6 +75,7 @@ private:
   Dumper _dumper;
   uint32_t _num_of_iterations = 0;
   bool _in_iterations = false;
+  Quantizer::Context _ctx;
 };
 
 } // namespace core

--- a/compiler/circle-mpqsolver/src/core/DumpingHooks.test.cpp
+++ b/compiler/circle-mpqsolver/src/core/DumpingHooks.test.cpp
@@ -52,47 +52,53 @@ protected:
 
 TEST_F(CircleMPQSolverDumpingHooksTest, verifyResultsTest)
 {
-  mpqsolver::core::DumpingHooks hooks(_folder);
+  mpqsolver::core::Quantizer::Context ctx;
+  mpqsolver::core::DumpingHooks hooks(_folder, ctx);
   EXPECT_NO_THROW(hooks.onBeginSolver("model_path.circle", 0.0, 1.0));
   std::string errors_path = _folder + "/errors" + ".mpq.txt";
   EXPECT_TRUE(mpqsolver::test::io_utils::isFileExists(errors_path));
 
   hooks.onBeginIteration();
 
-  EXPECT_NO_THROW(hooks.onEndIteration(mpqsolver::core::LayerParams(), "uint8", 0.0));
+  EXPECT_NO_THROW(
+    hooks.onEndIteration(mpqsolver::core::LayerParams(), ctx.output_model_dtype, 0.0));
   std::string current_mpq_path = _folder + "/Configuration_" + std::to_string(1) + ".mpq.json";
   EXPECT_TRUE(mpqsolver::test::io_utils::isFileExists(current_mpq_path));
 
-  EXPECT_NO_THROW(hooks.onEndSolver(mpqsolver::core::LayerParams(), "uint8", 0.5));
+  EXPECT_NO_THROW(hooks.onEndSolver(mpqsolver::core::LayerParams(), ctx.output_model_dtype, 0.5));
   std::string final_mpq_path = _folder + "/FinalConfiguration" + ".mpq.json";
   EXPECT_TRUE(mpqsolver::test::io_utils::isFileExists(final_mpq_path));
 }
 
 TEST_F(CircleMPQSolverDumpingHooksTest, verify_NAN_results_test)
 {
-  mpqsolver::core::DumpingHooks hooks(_folder);
+  mpqsolver::core::Quantizer::Context ctx;
+  mpqsolver::core::DumpingHooks hooks(_folder, ctx);
   EXPECT_NO_THROW(hooks.onBeginSolver("model_path.circle", NAN, NAN));
   std::string errors_path = _folder + "/errors" + ".mpq.txt";
   EXPECT_TRUE(not mpqsolver::test::io_utils::isFileExists(errors_path));
 
-  EXPECT_NO_THROW(hooks.onEndSolver(mpqsolver::core::LayerParams(), "uint8", NAN));
+  EXPECT_NO_THROW(hooks.onEndSolver(mpqsolver::core::LayerParams(), ctx.output_model_dtype, NAN));
   std::string final_mpq_path = _folder + "/FinalConfiguration" + ".mpq.json";
   EXPECT_TRUE(mpqsolver::test::io_utils::isFileExists(final_mpq_path));
 }
 
 TEST_F(CircleMPQSolverDumpingHooksTest, empty_path_NEG)
 {
-  mpqsolver::core::DumpingHooks hooks("");
+  mpqsolver::core::Quantizer::Context ctx;
+  mpqsolver::core::DumpingHooks hooks("", ctx);
   EXPECT_ANY_THROW(hooks.onBeginSolver("", -1, -1));
   hooks.onBeginIteration();
   EXPECT_ANY_THROW(hooks.onQuantized(nullptr));
-  EXPECT_ANY_THROW(hooks.onEndIteration(mpqsolver::core::LayerParams(), "uint8", -1));
-  EXPECT_ANY_THROW(hooks.onEndSolver(mpqsolver::core::LayerParams(), "uint8", -1));
+  EXPECT_ANY_THROW(
+    hooks.onEndIteration(mpqsolver::core::LayerParams(), ctx.output_model_dtype, -1));
+  EXPECT_ANY_THROW(hooks.onEndSolver(mpqsolver::core::LayerParams(), ctx.output_model_dtype, -1));
 }
 
 TEST_F(CircleMPQSolverDumpingHooksTest, empty_NAN_path_NEG)
 {
-  mpqsolver::core::DumpingHooks hooks("");
+  mpqsolver::core::Quantizer::Context ctx;
+  mpqsolver::core::DumpingHooks hooks("", ctx);
   EXPECT_NO_THROW(hooks.onBeginSolver("", NAN, NAN));
-  EXPECT_ANY_THROW(hooks.onEndSolver(mpqsolver::core::LayerParams(), "uint8", NAN));
+  EXPECT_ANY_THROW(hooks.onEndSolver(mpqsolver::core::LayerParams(), ctx.output_model_dtype, NAN));
 }


### PR DESCRIPTION
This commit introduces Quantizer::Context to DumpingHooks to get rid of hardcoded granularity and adjusts dependencies accordingly.

Draft: https://github.com/Samsung/ONE/pull/12042
Related: https://github.com/Samsung/ONE/issues/12020

ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>