### PR TITLE
[onert] Store origin tensor index in ir::Operand during loading circle

### DIFF
--- a/runtime/onert/frontend/circle/src/circle_loader.cc
+++ b/runtime/onert/frontend/circle/src/circle_loader.cc
@@ -94,6 +94,7 @@ private:
     for (flatbuffers::uoffset_t i = 0; i < circle_subg->tensors()->size(); ++i)
     {
       _tensor_to_operand[i] = loadOperand(circle_subg->tensors()->Get(i), *subg);
+      subg->operands().at(_tensor_to_operand[i]).setOriginIndex(ir::OriginIndex(i));
     }
     // Set inputs
     for (const std::int32_t input_ind : *circle_subg->inputs())


### PR DESCRIPTION
It stores circle tensor index in ir::Operand during loading circle.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

Draft: https://github.com/Samsung/ONE/pull/12246

It is modification under `frontend`. (not under `ir`, `api`, ...)
Thus, I separated this PR. 