### PR TITLE
[onert] GraphDumper prints origin index

### DIFF
--- a/runtime/onert/core/src/dumper/text/GraphDumper.cc
+++ b/runtime/onert/core/src/dumper/text/GraphDumper.cc
@@ -87,8 +87,10 @@ void dumpGraph(const ir::Graph &graph)
     const auto &op = graph.operations().at(op_ind);
     VERBOSE(GraphDumper) << "  " << formatOperation(op, op_ind) << "\n";
   }
+  graph.operands().iterate([&](const ir::OperandIndex &idx, const ir::Operand &oprd) {
+    VERBOSE(GraphDumper) << "  Origin(" << idx << "): " << oprd.originIndex() << std::endl;
+  });
   VERBOSE(GraphDumper) << "}\n";
-  VERBOSE(GraphDumper) << std::endl;
 }
 
 void dumpLoweredGraph(const compiler::LoweredGraph &lgraph)


### PR DESCRIPTION
When dumping graph, it prints origin index also.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

Draft: https://github.com/Samsung/ONE/pull/12246

--------------

Did you intend to have no prefix?

_Originally posted by @ragmani in https://github.com/Samsung/ONE/pull/12267#discussion_r1423575165_

Yes. Origin is not printed during iterating operators, it is printed during iterating operands. No prefix looks better. I will push another PR for dumping graph. We can enhance log printing if necessary in forecoming PR.

_Originally posted by @glistening in https://github.com/Samsung/ONE/pull/12267#discussion_r1423592211_           