### PR TITLE
[onert] Make log aligned using fixed width of index

### DIFF
--- a/runtime/onert/core/include/ir/Index.h
+++ b/runtime/onert/core/include/ir/Index.h
@@ -19,7 +19,9 @@
 
 #include "util/Index.h"
 
+#include <iomanip>
 #include <ostream>
+#include <sstream>
 
 namespace onert
 {
@@ -47,10 +49,12 @@ using OriginIndex = ::onert::util::Index<uint32_t, OriginIndexTag>;
 template <typename IndexType>
 std::ostream &_index_print_impl(std::ostream &o, const std::string &prefix, IndexType index)
 {
+  std::ostringstream oss;
   if (index.undefined())
-    return o << prefix << std::string("?");
+    oss << prefix << std::string("?");
   else
-    return o << prefix << index.value();
+    oss << prefix << index.value();
+  return o << std::right << std::setw(4) << oss.str();
 }
 
 inline std::ostream &operator<<(std::ostream &o, const OperationIndex &i)

--- a/runtime/onert/core/src/dumper/text/GraphDumper.cc
+++ b/runtime/onert/core/src/dumper/text/GraphDumper.cc
@@ -39,7 +39,7 @@ std::string formatOperandIndexSequence(const ir::OperandIndexSequence &seq)
   std::vector<std::string> strs;
   for (auto &&ind : seq)
     strs.push_back(dumper::text::formatOperandBrief(ind));
-  return nnfw::misc::join(strs.begin(), strs.end(), ", ");
+  return nnfw::misc::join(strs.begin(), strs.end(), ",");
 }
 
 } // namespace
@@ -88,7 +88,6 @@ void dumpGraph(const ir::Graph &graph)
     VERBOSE(GraphDumper) << "  " << formatOperation(op, op_ind) << "\n";
   }
   VERBOSE(GraphDumper) << "}\n";
-  VERBOSE(GraphDumper) << std::endl;
 }
 
 void dumpLoweredGraph(const compiler::LoweredGraph &lgraph)


### PR DESCRIPTION
It uses width=3 for better alignment in log.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>