### PR TITLE
[one-cmds] Preprocess the image in numpy format to test numpy2hdf5

### DIFF
--- a/compiler/one-cmds/tests/CMakeLists.txt
+++ b/compiler/one-cmds/tests/CMakeLists.txt
@@ -70,6 +70,7 @@ fi\n
 
 set(PREPARE_TEST_MATERIALS_SH "${CMAKE_CURRENT_SOURCE_DIR}/prepare_test_materials.sh")
 set(PREPROCESS_IMAGES_PY "${CMAKE_CURRENT_SOURCE_DIR}/preprocess_images.py")
+set(PREPROCESS_IMAGES_NUMPY_PY "${CMAKE_CURRENT_SOURCE_DIR}/preprocess_images_numpy.py")
 set(ONNX_LEGALIZE_RUN_COMPARE "${CMAKE_CURRENT_SOURCE_DIR}/onnx_legalize_run_compare.py")
 set(PRINT_ONNX_MODEL "${CMAKE_CURRENT_SOURCE_DIR}/print_onnx_model.py")
 
@@ -91,6 +92,12 @@ install(FILES ${PREPROCESS_IMAGES_PY}
                     WORLD_READ
         DESTINATION test)
 
+install(FILES ${PREPROCESS_IMAGES_NUMPY_PY}
+        PERMISSIONS OWNER_WRITE OWNER_READ
+                    GROUP_READ
+                    WORLD_READ
+        DESTINATION test)
+        
 install(FILES ${ONNX_LEGALIZE_RUN_COMPARE}
         PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE
         GROUP_READ GROUP_EXECUTE

--- a/compiler/one-cmds/tests/preprocess_images_numpy.py
+++ b/compiler/one-cmds/tests/preprocess_images_numpy.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os, shutil, PIL.Image, numpy as np
+
+input_dir = 'img_files'
+output_dir = 'numpy_files'
+list_file = 'datalist_numpy.txt'
+
+if os.path.exists(output_dir):
+    shutil.rmtree(output_dir, ignore_errors=True)
+os.makedirs(output_dir)
+
+for (root, _, files) in os.walk(input_dir):
+    datalist = open(list_file, 'w')
+    for f in files:
+        with PIL.Image.open(root + '/' + f) as image:
+            # To handle ANTIALIAS deprecation
+            ANTIALIAS = PIL.Image.Resampling.LANCZOS if hasattr(
+                PIL.Image, "Resampling") else PIL.Image.ANTIALIAS
+
+            # To save in numpy format
+            img = np.array(image.resize((299, 299), ANTIALIAS)).astype(np.float32)
+            img = ((img / 255) - 0.5) * 2.0
+            output_file = output_dir + '/' + f.replace('jpg', 'npy')
+            np.save('./' + output_file, img)
+            datalist.writelines(os.path.abspath(output_file) + '\n')
+    datalist.close()


### PR DESCRIPTION
This introduces preprocessing the image in numpy format to test numpy2hdf5 of one-create-quant-dataset.

ONE-DCO-1.0-Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>

---
Related Issue: https://github.com/Samsung/ONE/issues/12053
Draft PR: https://github.com/Samsung/ONE/pull/12186