### PR TITLE
[circle-mpqsolver] Dump config

### DIFF
--- a/compiler/circle-mpqsolver/src/pattern/PatternSolver.cpp
+++ b/compiler/circle-mpqsolver/src/pattern/PatternSolver.cpp
@@ -19,6 +19,7 @@
 #include "PatternResolver.h"
 
 #include <iostream>
+#include <cmath>
 
 using namespace mpqsolver::pattern;
 
@@ -38,9 +39,20 @@ std::unique_ptr<luci::Module> PatternSolver::run(const std::string &module_path)
   auto module = readModule(module_path);
   assert(module != nullptr);
 
+  _quantizer->setHook(_hooks.get());
+  if (_hooks)
+  {
+    _hooks->onBeginSolver(module_path, NAN, NAN);
+  }
+
   resolvePatterns(module.get());
 
   auto layer_params = getFrozenParams();
+
+  if (_hooks)
+  {
+    _hooks->onEndSolver(layer_params, _quantizer->getContext().output_model_dtype, NAN);
+  }
 
   if (!_quantizer->quantize(module.get(), layer_params))
   {


### PR DESCRIPTION
This commit dumps final qconfig in PatternSolver
if save_intermediate option is on.

For `layer_norm` it produced the following qconfig :
[FinalConfiguration.mpq.zip](https://github.com/Samsung/ONE/files/13659239/FinalConfiguration.mpq.zip)



Draft: https://github.com/Samsung/ONE/pull/12042
Related: https://github.com/Samsung/ONE/issues/12020

ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>