### PR TITLE
[circle2circle] Add fuse_mul_with_div option

### DIFF
--- a/compiler/circle2circle/src/Circle2Circle.cpp
+++ b/compiler/circle2circle/src/Circle2Circle.cpp
@@ -107,6 +107,8 @@ int entry(int argc, char **argv)
              "into one operation and merge reduction indices.");
   add_switch(arser, "--fuse_mul_with_conv",
              "This will fuse Mul operation with a preceding Conv if possible.");
+  add_switch(arser, "--fuse_mul_with_div",
+             "This will fuse Mul operation with a Div operation whose numerator is const.");
   add_switch(arser, "--fuse_slice_with_tconv",
              "This will fuse Slice operation with a preceding TConv if possible.");
   add_switch(arser, "--fuse_transpose_with_mean",
@@ -289,6 +291,8 @@ int entry(int argc, char **argv)
     options->enable(Algorithms::FuseMeanWithMean);
   if (arser.get<bool>("--fuse_mul_with_conv"))
     options->enable(Algorithms::FuseMulWithConv);
+  if (arser.get<bool>("--fuse_mul_with_div"))
+    options->enable(Algorithms::FuseMulWithDiv);
   if (arser.get<bool>("--make_batchnorm_gamma_positive"))
     options->enable(Algorithms::MakeBatchNormGammaPositive);
   if (arser.get<bool>("--fuse_preactivation_batchnorm"))


### PR DESCRIPTION
This commit adds fuse_mul_with_div option to circle2circle.

for issue: https://github.com/Samsung/ONE/issues/11956
from draft https://github.com/Samsung/ONE/pull/12124

ONE-DCO-1.0-Signed-off-by: Artem Balyshev <a.balyshev@samsung.com>