### PR TITLE
[infra] Fix compile CPU type option

### DIFF
--- a/infra/nnfw/cmake/buildtool/config/config_armv7hl-tizen.cmake
+++ b/infra/nnfw/cmake/buildtool/config/config_armv7hl-tizen.cmake
@@ -14,7 +14,8 @@ include("cmake/buildtool/config/config_linux.cmake")
 
 # addition for arm-linux
 set(FLAGS_COMMON ${FLAGS_COMMON}
-    "-mtune=cortex-a8"
+    "-march=armv7-a"
+    "-mtune=cortex-a15.cortex-a7"
     "-mfloat-abi=hard"
     "-mfpu=neon-vfpv4"
     "-funsafe-math-optimizations"

--- a/infra/nnfw/cmake/buildtool/config/config_armv7l-linux.cmake
+++ b/infra/nnfw/cmake/buildtool/config/config_armv7l-linux.cmake
@@ -9,7 +9,8 @@ include("${CMAKE_CURRENT_LIST_DIR}/config_linux.cmake")
 
 # addition for arm-linux
 set(FLAGS_COMMON ${FLAGS_COMMON}
-    "-mcpu=cortex-a7"
+    "-march=armv7-a"
+    "-mtune=cortex-a15.cortex-a7"
     "-mfloat-abi=hard"
     "-mfpu=neon-vfpv4"
     "-ftree-vectorize"

--- a/infra/nnfw/cmake/buildtool/config/config_armv7l-tizen.cmake
+++ b/infra/nnfw/cmake/buildtool/config/config_armv7l-tizen.cmake
@@ -14,7 +14,8 @@ include("cmake/buildtool/config/config_linux.cmake")
 
 # addition for arm-linux
 set(FLAGS_COMMON ${FLAGS_COMMON}
-    "-mtune=cortex-a8"
+    "-march=armv7-a"
+    "-mtune=cortex-a15.cortex-a7"
     "-mfloat-abi=softfp"
     "-mfpu=neon-vfpv4"
     "-funsafe-math-optimizations"


### PR DESCRIPTION
This commit fixes armv7 CPU type option to set `march` and `mtune` and remove `mcpu`.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>