### PR TITLE
[onert] Change auto && to const auto &

### DIFF
--- a/runtime/onert/core/src/compiler/TensorRegistries.h
+++ b/runtime/onert/core/src/compiler/TensorRegistries.h
@@ -71,7 +71,7 @@ public:
 
   backend::ITensor *getITensor(ir::OperandIndex ind) const
   {
-    for (auto &&tensor_reg : _tensor_regs)
+    for (const auto &tensor_reg : _tensor_regs)
     {
       auto tensor = tensor_reg->getITensor(ind);
       if (tensor)

--- a/runtime/onert/core/src/compiler/train/TensorRegistries.h
+++ b/runtime/onert/core/src/compiler/train/TensorRegistries.h
@@ -74,7 +74,7 @@ public:
 
   backend::ITensor *getITensor(ir::OperandIndex index) const
   {
-    for (auto &&tensor_reg : _tensor_regs)
+    for (const auto &tensor_reg : _tensor_regs)
     {
       auto tensor = tensor_reg->getITensor(index);
       if (tensor)
@@ -85,7 +85,7 @@ public:
 
   backend::ITensor *getBackPropITensor(ir::OperandIndex index) const
   {
-    for (auto &&tensor_reg : _tensor_regs)
+    for (const auto &tensor_reg : _tensor_regs)
     {
       auto tensor = tensor_reg->getBackPropITensor(index);
       if (tensor)


### PR DESCRIPTION
It changes auto && to const auto during iterating TensorRegistries using
for-range loop.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

(Optional)
```suggestion
    for (const auto &tensor_reg : _tensor_regs)
```
_Originally posted by @ragmani in https://github.com/Samsung/ONE/pull/12269#discussion_r1423615248_
            