### PR TITLE
[onert] Add iterateTrainableTensors under exec

### DIFF
--- a/runtime/onert/core/include/exec/Execution.h
+++ b/runtime/onert/core/include/exec/Execution.h
@@ -21,6 +21,7 @@
 #ifndef __ONERT_EXEC_EXECUTION_H__
 #define __ONERT_EXEC_EXECUTION_H__
 
+#include "backend/train/ITrainableTensor.h"
 #include "ir/Layout.h"
 #include "exec/IExecutors.h"
 #include "IODescription.h"
@@ -157,6 +158,15 @@ public:
    * @return @c float Loss value
    */
   float getLoss(const ir::IOIndex &ind);
+
+  /**
+   * @brief     Iterate trainable tensors
+   * @note      It should be called after training
+   * @param[in] fn  function to be called with OperandIndex and a pointer to ITrainableTensor
+   */
+  void iterateTrainableTensors(
+    const std::function<void(const ir::OperandIndex &, const backend::train::ITrainableTensor *)>
+      &fn) const;
 
   ir::Shape getInputShape(ir::IOIndex ind) const;
   ir::Shape getOutputShape(ir::IOIndex ind) const;

--- a/runtime/onert/core/src/exec/Execution.cc
+++ b/runtime/onert/core/src/exec/Execution.cc
@@ -180,6 +180,18 @@ float Execution::getLoss(const ir::IOIndex &ind)
   return execs->getLoss(ind);
 }
 
+void Execution::iterateTrainableTensors(
+  const std::function<void(const ir::OperandIndex &, const backend::train::ITrainableTensor *)> &fn)
+  const
+{
+  auto execs = dynamic_cast<exec::train::TrainableExecutors *>(_executors.get());
+  if (!execs)
+  {
+    throw std::runtime_error{"Supported only TrainableExecutors"};
+  }
+  execs->iterateTrainableTensors(fn);
+}
+
 ir::Shape Execution::getInputShape(ir::IOIndex ind) const
 {
   auto itr = _io_desc.dynamic_input_shapes.find(ind);

--- a/runtime/onert/core/src/exec/train/TrainableExecutor.cc
+++ b/runtime/onert/core/src/exec/train/TrainableExecutor.cc
@@ -207,6 +207,13 @@ float TrainableExecutor::getLoss(const ir::IOIndex &pred_io_ind) const
   return static_cast<float>(sum);
 }
 
+void TrainableExecutor::iterateTrainableTensors(
+  const std::function<void(const ir::OperandIndex &, const backend::train::ITrainableTensor *)> &fn)
+  const
+{
+  _tensor_regs.iterateTrainableTensors(fn);
+}
+
 } // namespace train
 } // namespace exec
 } // namespace onert

--- a/runtime/onert/core/src/exec/train/TrainableExecutor.h
+++ b/runtime/onert/core/src/exec/train/TrainableExecutor.h
@@ -84,6 +84,10 @@ public:
 
   float getLoss(const ir::IOIndex &pred_io_ind) const;
 
+  void iterateTrainableTensors(
+    const std::function<void(const ir::OperandIndex &, const backend::train::ITrainableTensor *)>
+      &fn) const;
+
   backend::train::TrainableBackendContexts &getBackendContexts() { return _backend_contexts; }
 
 private:

--- a/runtime/onert/core/src/exec/train/TrainableExecutors.cc
+++ b/runtime/onert/core/src/exec/train/TrainableExecutors.cc
@@ -84,6 +84,13 @@ float TrainableExecutors::getLoss(const ir::IOIndex &index) const
   return entryExecutor()->getLoss(index);
 }
 
+void TrainableExecutors::iterateTrainableTensors(
+  const std::function<void(const ir::OperandIndex &, const backend::train::ITrainableTensor *)> &fn)
+  const
+{
+  return entryExecutor()->iterateTrainableTensors(fn);
+}
+
 } // namespace train
 } // namespace exec
 } // namespace onert

--- a/runtime/onert/core/src/exec/train/TrainableExecutors.h
+++ b/runtime/onert/core/src/exec/train/TrainableExecutors.h
@@ -80,6 +80,10 @@ public:
 
   float getLoss(const ir::IOIndex &index) const;
 
+  void iterateTrainableTensors(
+    const std::function<void(const ir::OperandIndex &, const backend::train::ITrainableTensor *)>
+      &fn) const;
+
 private:
   // TODO Append model index to ModelIndex
   std::unordered_map<ir::SubgraphIndex, std::unique_ptr<TrainableExecutor>> _executors;


### PR DESCRIPTION
It adds iterateTrainableTensors in Execution and TrainableExecutor(s).

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

Draft: https://github.com/Samsung/ONE/pull/12246