### PR TITLE
[onert/api] Introduce _model_path in nnfw_session

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -269,6 +269,7 @@ NNFW_STATUS nnfw_session::load_circle_from_buffer(uint8_t *buffer, size_t size)
   try
   {
     auto model = onert::circle_loader::loadModel(buffer, size);
+    // TODO: Update _model_path if necessary
     _nnpkg = std::make_shared<onert::ir::NNPkg>(std::move(model));
     _coptions.push_back(onert::compiler::CompilerOptions::fromGlobalConfig());
     _state = State::MODEL_LOADED;
@@ -309,6 +310,7 @@ NNFW_STATUS nnfw_session::load_model_from_modelfile(const char *model_file_path)
     auto model = loadModel(filename, model_type);
     if (model == nullptr)
       return NNFW_STATUS_ERROR;
+    _model_path = std::string(model_file_path);
     _nnpkg = std::make_shared<onert::ir::NNPkg>(std::move(model));
     _coptions.push_back(onert::compiler::CompilerOptions::fromGlobalConfig());
     _state = State::MODEL_LOADED;
@@ -391,6 +393,7 @@ NNFW_STATUS nnfw_session::load_model_from_nnpackage(const char *package_dir)
       auto model = loadModel(model_file_path, model_type);
       if (model == nullptr)
         return NNFW_STATUS_ERROR;
+      _model_path = std::string(model_file_path);
       model->bindKernelBuilder(_kernel_registry->getBuilder());
       _nnpkg->push(onert::ir::ModelIndex{i}, std::move(model));
       _coptions.push_back(onert::compiler::CompilerOptions::fromGlobalConfig());
@@ -1559,6 +1562,7 @@ NNFW_STATUS nnfw_session::quantize()
     auto model = loadModel(_quant_manager->exportModelPath(), "circle");
     if (model == nullptr)
       return NNFW_STATUS_ERROR;
+    // TODO: Update _model_path if necessary
     _nnpkg->replaceModel(std::move(model));
   }
   catch (const std::exception &e)

--- a/runtime/onert/api/src/nnfw_api_internal.h
+++ b/runtime/onert/api/src/nnfw_api_internal.h
@@ -212,6 +212,16 @@ private:
   uint32_t _training_step{0};
 #endif // ONERT_TRAIN
   std::unique_ptr<onert::odc::QuantizeManager> _quant_manager;
+  // Remember path to loaded original model
+  // It may be used for on-device compiler / on-device training.
+  //
+  // If necessary, we may replace _model_path to _model_origin like:
+  //
+  //   union _model_origin {
+  //     const char* path;
+  //     const const uint8* buf
+  //   }
+  std::string _model_path;
 };
 
 #endif // __API_NNFW_API_INTERNAL_H__


### PR DESCRIPTION
It adds _model_path in nnfw_session.
_model_path is the path to original model.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

Draft: https://github.com/Samsung/ONE/pull/12246