### PR TITLE
[onert] mmap circle file for exporting circle

### DIFF
--- a/runtime/onert/api/include/nnfw.h
+++ b/runtime/onert/api/include/nnfw.h
@@ -123,6 +123,8 @@ typedef enum
   NNFW_STATUS_OUT_OF_MEMORY = 4,
   /** When it was given an insufficient output buffer */
   NNFW_STATUS_INSUFFICIENT_OUTPUT_SIZE = 5,
+  /** When it was given an invalid file */
+  NNFW_STATUS_INVALID_FILE = 6,
 } NNFW_STATUS;
 
 /**

--- a/runtime/onert/api/include/nnfw.h
+++ b/runtime/onert/api/include/nnfw.h
@@ -123,8 +123,6 @@ typedef enum
   NNFW_STATUS_OUT_OF_MEMORY = 4,
   /** When it was given an insufficient output buffer */
   NNFW_STATUS_INSUFFICIENT_OUTPUT_SIZE = 5,
-  /** When it was given an invalid file */
-  NNFW_STATUS_INVALID_FILE = 6,
 } NNFW_STATUS;
 
 /**

--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -1467,7 +1467,8 @@ NNFW_STATUS nnfw_session::train_export_circle(const char *path)
       // file_stat.st_size is `off_t` while msync, munmap requires `size_t`
       // `off_t` may be long or long long.
       // `size_t` may be uint32 or uint64.
-      static_assert(sizeof(off_t) == sizeof(size_t), "sizeof(off_t) != sizeof(size_t)");
+      static_assert(sizeof(off_t) <= sizeof(size_t),
+                    "size_t should be bigger than off_t in positive range");
       _buf_sz = static_cast<size_t>(file_stat.st_size);
       _buf = mmap(NULL, _buf_sz, PROT_READ | PROT_WRITE, MAP_SHARED, _fd, 0);
       return _buf != MAP_FAILED;

--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -1462,13 +1462,10 @@ NNFW_STATUS nnfw_session::train_export_circle(const char *path)
     bool ensure_mmap()
     {
       struct stat file_stat;
-      if (fstat(_fd, &file_stat) != 0)
+      if (fstat(_fd, &file_stat) != 0 || file_stat.st_size < 0 ||
+          static_cast<size_t>(file_stat.st_size) > SIZE_MAX)
         return false;
-      // file_stat.st_size is `off_t` while msync, munmap requires `size_t`
-      // `off_t` may be long or long long.
-      // `size_t` may be uint32 or uint64.
-      static_assert(sizeof(off_t) <= sizeof(size_t),
-                    "size_t should be bigger than off_t in positive range");
+
       _buf_sz = static_cast<size_t>(file_stat.st_size);
       _buf = mmap(NULL, _buf_sz, PROT_READ | PROT_WRITE, MAP_SHARED, _fd, 0);
       return _buf != MAP_FAILED;

--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -1467,7 +1467,7 @@ NNFW_STATUS nnfw_session::train_export_circle(const char *path)
       // file_stat.st_size is `off_t` while msync, munmap requires `size_t`
       // `off_t` may be long or long long.
       // `size_t` may be uint32 or uint64.
-      assert(sizeof(off_t) == sizeof(size_t));
+      static_assert(sizeof(off_t) == sizeof(size_t));
       _buf_sz = static_cast<size_t>(file_stat.st_size);
       _buf =
         static_cast<uint8_t *>(mmap(NULL, _buf_sz, PROT_READ | PROT_WRITE, MAP_SHARED, _fd, 0));

--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -1469,9 +1469,7 @@ NNFW_STATUS nnfw_session::train_export_circle(const char *path)
       // `size_t` may be uint32 or uint64.
       static_assert(sizeof(off_t) == sizeof(size_t), "sizeof(off_t) != sizeof(size_t)");
       _buf_sz = static_cast<size_t>(file_stat.st_size);
-      _buf =
-        static_cast<uint8_t *>(mmap(NULL, _buf_sz, PROT_READ | PROT_WRITE, MAP_SHARED, _fd, 0));
-
+      _buf = mmap(NULL, _buf_sz, PROT_READ | PROT_WRITE, MAP_SHARED, _fd, 0);
       return _buf != MAP_FAILED;
     }
 

--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -1467,7 +1467,7 @@ NNFW_STATUS nnfw_session::train_export_circle(const char *path)
       // file_stat.st_size is `off_t` while msync, munmap requires `size_t`
       // `off_t` may be long or long long.
       // `size_t` may be uint32 or uint64.
-      static_assert(sizeof(off_t) == sizeof(size_t));
+      static_assert(sizeof(off_t) == sizeof(size_t), "sizeof(off_t) != sizeof(size_t)");
       _buf_sz = static_cast<size_t>(file_stat.st_size);
       _buf =
         static_cast<uint8_t *>(mmap(NULL, _buf_sz, PROT_READ | PROT_WRITE, MAP_SHARED, _fd, 0));

--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -1463,7 +1463,7 @@ NNFW_STATUS nnfw_session::train_export_circle(const char *path)
     {
       struct stat file_stat;
       if (fstat(_fd, &file_stat) != 0 || file_stat.st_size < 0 ||
-          static_cast<size_t>(file_stat.st_size) > SIZE_MAX)
+          static_cast<uint64_t>(file_stat.st_size) > SIZE_MAX)
         return false;
 
       _buf_sz = static_cast<size_t>(file_stat.st_size);


### PR DESCRIPTION
It ensure to mmap circle file with getting file size.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

Draft: https://github.com/Samsung/ONE/pull/12246