### PR TITLE
[onert] Introduce metadata to model and loader

### DIFF
--- a/runtime/onert/core/include/ir/Model.h
+++ b/runtime/onert/core/include/ir/Model.h
@@ -177,9 +177,9 @@ private:
   std::shared_ptr<backend::custom::IKernelBuilder> _kernel_builder;
 
 public:
-  void add_metadata(const std::string &name, std::shared_ptr<const ir::Data> data)
+  void add_metadata(const std::string &name, std::unique_ptr<const ir::Data> data)
   {
-    _metadatas.emplace(name, data);
+    _metadatas.emplace(name, std::move(data));
   }
 
   bool is_metadata_exist(const std::string &name) const
@@ -187,13 +187,20 @@ public:
     return _metadatas.find(name) != _metadatas.end();
   }
 
-  std::shared_ptr<const ir::Data> get_metadata(const std::string name) const
+  std::unique_ptr<const ir::Data> get_metadata(const std::string name)
   {
-    return _metadatas.at(name);
+    auto m = _metadatas.find(name);
+
+    if (m == _metadatas.end())
+      throw std::out_of_range{"no meatdata named " + name};
+
+    auto data = std::move(m->second);
+    _metadatas.erase(m);
+    return data;
   }
 
 private:
-  std::unordered_map<std::string, std::shared_ptr<const ir::Data>> _metadatas;
+  std::unordered_map<std::string, std::unique_ptr<const ir::Data>> _metadatas;
 };
 } // namespace ir
 } // namespace onert

--- a/runtime/onert/core/include/ir/Model.h
+++ b/runtime/onert/core/include/ir/Model.h
@@ -187,7 +187,8 @@ public:
     return _metadatas.find(name) != _metadatas.end();
   }
 
-  std::unique_ptr<const ir::Data> get_metadata(const std::string name)
+  // NOTE The corresponding metadata is deleted from the model and returned
+  std::unique_ptr<const ir::Data> extract_metadata(const std::string name)
   {
     auto m = _metadatas.find(name);
 

--- a/runtime/onert/core/include/ir/Model.h
+++ b/runtime/onert/core/include/ir/Model.h
@@ -175,8 +175,26 @@ public:
 
 private:
   std::shared_ptr<backend::custom::IKernelBuilder> _kernel_builder;
-};
 
+public:
+  void add_metadata(const std::string &name, std::shared_ptr<const ir::Data> data)
+  {
+    _metadatas.emplace(name, data);
+  }
+
+  bool is_metadata_exist(const std::string &name) const
+  {
+    return _metadatas.find(name) != _metadatas.end();
+  }
+
+  std::shared_ptr<const ir::Data> get_metadata(const std::string name) const
+  {
+    return _metadatas.at(name);
+  }
+
+private:
+  std::unordered_map<std::string, std::shared_ptr<const ir::Data>> _metadatas;
+};
 } // namespace ir
 } // namespace onert
 

--- a/runtime/onert/core/include/ir/Model.h
+++ b/runtime/onert/core/include/ir/Model.h
@@ -182,7 +182,7 @@ public:
     _metadatas.emplace(name, std::move(data));
   }
 
-  bool is_metadata_exist(const std::string &name) const
+  bool exists_metadata(const std::string &name) const
   {
     return _metadatas.find(name) != _metadatas.end();
   }

--- a/runtime/onert/frontend/base_loader/include/base_loader.h
+++ b/runtime/onert/frontend/base_loader/include/base_loader.h
@@ -249,11 +249,7 @@ template <typename LoaderDomain>
 std::unique_ptr<ir::Data>
 BaseLoader<LoaderDomain>::BaseLoader::loadMetadata(const uint32_t buffer_idx)
 {
-  if (_domain_model == nullptr)
-  {
-    throw std::runtime_error{"fail to access _domain_model"};
-  }
-
+  assert(_domain_model != nullptr);
   const auto *data = _domain_model->buffers()->Get(buffer_idx)->data();
   if (_fd == -1) // Model is from memory
   {

--- a/runtime/onert/frontend/base_loader/include/base_loader.h
+++ b/runtime/onert/frontend/base_loader/include/base_loader.h
@@ -1754,8 +1754,8 @@ template <typename LoaderDomain> void BaseLoader<LoaderDomain>::loadModel()
       if (metadata->name() == nullptr)
         continue; // metadata should have name
 
-      std::shared_ptr<const ir::Data> data = loadMetadata(metadata->buffer());
-      model->add_metadata(metadata->name()->str(), data);
+      std::unique_ptr<const ir::Data> data = loadMetadata(metadata->buffer());
+      model->add_metadata(metadata->name()->str(), std::move(data));
     }
   }
 

--- a/runtime/onert/frontend/circle/src/circle_loader.cc
+++ b/runtime/onert/frontend/circle/src/circle_loader.cc
@@ -33,6 +33,7 @@ struct LoaderDomain
   using Buffer = circle::Buffer;
   using BuiltinOperator = circle::BuiltinOperator;
   using CustomOptionsFormat = circle::CustomOptionsFormat;
+  using Metadata = circle::Metadata;
   using Model = circle::Model;
   using Operator = circle::Operator;
   using Padding = circle::Padding;

--- a/runtime/onert/frontend/tflite/src/tflite_loader.cc
+++ b/runtime/onert/frontend/tflite/src/tflite_loader.cc
@@ -34,6 +34,7 @@ struct LoaderDomain
   using BuiltinOperator = onert_tflite::BuiltinOperator;
   using CustomOptionsFormat = onert_tflite::CustomOptionsFormat;
   using Model = onert_tflite::Model;
+  using Metadata = onert_tflite::Metadata;
   using Operator = onert_tflite::Operator;
   using Padding = onert_tflite::Padding;
   using Pool2DOptions = onert_tflite::Pool2DOptions;


### PR DESCRIPTION
This PR introduces a metadata field to ir::Model and related loading logic.

draft : https://github.com/Samsung/ONE/pull/12152 
issue : https://github.com/Samsung/ONE/issues/11692

ONE-DCO-1.0-Signed-off-by: SeungHui Youn <sseung.youn@samsung.com>