### PR TITLE
[circle-mpqsolver] Tidy comments

### DIFF
--- a/compiler/circle-mpqsolver/src/core/DumpingHooks.h
+++ b/compiler/circle-mpqsolver/src/core/DumpingHooks.h
@@ -48,7 +48,7 @@ public:
   virtual void onQuantized(luci::Module *module) const override;
 
   /**
-   * @brief called on the start of iterative search
+   * @brief called on the start of mpq search
    */
   virtual void onBeginSolver(const std::string &model_path, float q8error, float q16error) override;
 
@@ -64,7 +64,7 @@ public:
                               float error) override;
 
   /**
-   * @brief called at the end of iterative search
+   * @brief called at the end of mpq search
    */
   virtual void onEndSolver(const LayerParams &layers, const std::string &def_dtype,
                            float qerror) override;

--- a/compiler/circle-mpqsolver/src/core/SolverHooks.h
+++ b/compiler/circle-mpqsolver/src/core/SolverHooks.h
@@ -32,7 +32,7 @@ class SolverHooks
 {
 public:
   /**
-   * @brief called on the start of iterative search
+   * @brief called on the start of mpq search
    * @param model_path path of original float model to quantize
    * @param q8error error of Q8 quantization (if NAN, then not applicable)
    * @param q16error error of Q16 quantization (if NAN, then not applicable)
@@ -54,7 +54,7 @@ public:
                               float error) = 0;
 
   /**
-   * @brief called at the end of iterative search
+   * @brief called at the end of mpq search
    * @param layers model nodes with specific quantization parameters
    * @param def_dtype default quantization dtype
    * @param qerror final error of quantization (if NAN, then not applicable)


### PR DESCRIPTION
Thos commit changes description of onBeginSolver/onEndSolver because now these methods can be called even from non-iterative solver.

Draft: https://github.com/Samsung/ONE/pull/12042
Related: https://github.com/Samsung/ONE/issues/12020

ONE-DCO-1.0-Signed-off-by: s.malakhov <s.malakhov@partner.samsung.com>