### PR TITLE
[onert] Introduce nnfw_train_set_output api

### DIFF
--- a/runtime/onert/api/include/nnfw_experimental.h
+++ b/runtime/onert/api/include/nnfw_experimental.h
@@ -264,9 +264,31 @@ NNFW_STATUS nnfw_train_set_expected(nnfw_session *session, uint32_t index, const
                                     const nnfw_tensorinfo *expected_info);
 
 /**
+ * @brief Set training output buffer
+ *
+ * This function must be called after {@link nnfw_train_prepare}, \p buffer given to this function
+ * can be reused for training. \p length must be greater or equal than the operand requires.
+ * An output operand can have unspecified shape and deduced dynamically during the execution. You
+ * must provide \p buffer large enough.
+ *
+ * @param[in]   session Session from inference output is to be extracted
+ * @param[in]   index   Index of output to be set (0-indexed)
+ * @param[in]   type    Type of the output
+ * @param[out]  buffer  Raw buffer for output
+ * @param[in]   length  Size of bytes of output buffer
+ *
+ * @return      @c NNFW_STATUS_NO_ERROR if successful
+ */
+NNFW_STATUS nnfw_train_set_output(nnfw_session *session, uint32_t index, NNFW_TYPE type,
+                                  void *buffer, size_t length);
+
+/**
  * @brief Train the model
  * @note  This function should be called after {@link nnfw_train_set_input} and
  *        {@link nnfw_train_set_expected} for each input and expected output
+ *
+ *        In order to use \p update_weights as false, it should be called after
+ *        {@link nnfw_train_set_output}.
  *
  * @param[in] session The session to be trained
  * @param[in] update_weights If true, update weights of the model

--- a/runtime/onert/api/src/nnfw_api.cc
+++ b/runtime/onert/api/src/nnfw_api.cc
@@ -424,6 +424,13 @@ NNFW_STATUS nnfw_train_set_expected(nnfw_session *session, uint32_t index, const
   return session->train_set_expected(index, expected, expected_info);
 }
 
+NNFW_STATUS nnfw_train_set_output(nnfw_session *session, uint32_t index, NNFW_TYPE type,
+                                  void *buffer, size_t length)
+{
+  NNFW_RETURN_ERROR_IF_NULL(session);
+  return session->train_set_output(index, type, buffer, length);
+}
+
 NNFW_STATUS nnfw_train(nnfw_session *session, bool update_weights)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);

--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -1368,6 +1368,35 @@ NNFW_STATUS nnfw_session::train_set_expected(uint32_t index, const void *expecte
   return NNFW_STATUS_NO_ERROR;
 }
 
+NNFW_STATUS nnfw_session::train_set_output(uint32_t index, NNFW_TYPE /*type*/, void *buffer,
+                                           size_t length)
+{
+  if (!isStatePreparedOrFinishedTraining())
+  {
+    std::cerr << "Error during nnfw_session::train_set_output : invalid state" << std::endl;
+    return NNFW_STATUS_INVALID_STATE;
+  }
+
+  if (!buffer && length != 0)
+  {
+    std::cerr << "Error during nnfw_session::train_set_output : given buffer is NULL but the "
+                 "length is not 0"
+              << std::endl;
+    return NNFW_STATUS_ERROR;
+  }
+
+  try
+  {
+    _execution->setOutput(onert::ir::IOIndex(index), buffer, length);
+  }
+  catch (const std::exception &e)
+  {
+    std::cerr << "Error during nnfw_session::train_set_output : " << e.what() << std::endl;
+    return NNFW_STATUS_ERROR;
+  }
+  return NNFW_STATUS_NO_ERROR;
+}
+
 NNFW_STATUS nnfw_session::train_run(bool update_weights)
 {
   if (!isStatePreparedOrFinishedTraining())

--- a/runtime/onert/api/src/nnfw_api_internal.h
+++ b/runtime/onert/api/src/nnfw_api_internal.h
@@ -174,6 +174,7 @@ public:
                               const nnfw_tensorinfo *input_tensorinfo);
   NNFW_STATUS train_set_expected(uint32_t index, const void *expected,
                                  const nnfw_tensorinfo *expected_tensorinfo);
+  NNFW_STATUS train_set_output(uint32_t index, NNFW_TYPE type, void *buffer, size_t length);
   NNFW_STATUS train_run(bool update_weights);
   NNFW_STATUS train_get_loss(uint32_t index, float *loss);
   NNFW_STATUS train_export_circle(const char *path);


### PR DESCRIPTION
This commit introduces nnfw_train_set_output api.
If user sets the output buffer using this function, user can obtain the output result executed with trained weight.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>