### PR TITLE
[tools/onert_train] Add metric argument

### DIFF
--- a/tests/tools/onert_train/src/args.cc
+++ b/tests/tools/onert_train/src/args.cc
@@ -228,6 +228,9 @@ void Args::Initialize(void)
       "Optimizer type\n"
       "0: SGD (default)\n"
       "1: Adam\n")
+    ("metric", po::value<int>()->default_value(-1)->notifier([&] (const auto &v) { _metric_type = v; }),
+      "Metricy type\n"
+      "  Simply calculates the metric value using the variables (default: none)\n")
     ("verbose_level,v", po::value<int>()->default_value(0)->notifier([&](const auto &v) { _verbose_level = v; }),
          "Verbose level\n"
          "0: prints the only result. Messages btw run don't print\n"

--- a/tests/tools/onert_train/src/args.h
+++ b/tests/tools/onert_train/src/args.h
@@ -59,6 +59,7 @@ public:
   const int getLossType(void) const { return _loss_type; }
   const int getLossReductionType(void) const { return _loss_reduction_type; }
   const int getOptimizerType(void) const { return _optimizer_type; }
+  const int getMetricType(void) const { return _metric_type; }
   const bool printVersion(void) const { return _print_version; }
   const int getVerboseLevel(void) const { return _verbose_level; }
   std::unordered_map<uint32_t, uint32_t> getOutputSizes(void) const { return _output_sizes; }
@@ -84,6 +85,7 @@ private:
   int _loss_type;
   int _loss_reduction_type;
   int _optimizer_type;
+  int _metric_type;
   bool _print_version = false;
   int _verbose_level;
   std::unordered_map<uint32_t, uint32_t> _output_sizes;


### PR DESCRIPTION
This commit adds metric argument.
It simply calculates the metric value using the variables.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>