### PR TITLE
[one-cmds] Enable fuse_mul_div

### DIFF
--- a/compiler/one-cmds/how-to-use-one-commands.txt
+++ b/compiler/one-cmds/how-to-use-one-commands.txt
@@ -168,6 +168,7 @@ Current transformation options are
 - fuse_batchnorm_with_dwconv : This fuses BatchNorm operator to depthwise convolution operator
 - fuse_batchnorm_with_tconv : This fuses BatchNorm operator to transpose convolution operator
 - fuse_mul_with_conv: This fuses Mul with a preceding Convolution op if possible.
+- fuse_mul_div: This fuses Mul and Div op as Div.
 - fuse_slice_with_tconv: This fuses Slice with a preceding TConv if possible.
 - fuse_bcq: This enables Binary-Coded-bases Quantized DNNs
    - read https://arxiv.org/abs/2005.09904 for detailed information

--- a/compiler/one-cmds/onelib/constant.py
+++ b/compiler/one-cmds/onelib/constant.py
@@ -111,6 +111,7 @@ class CONSTANT:
          'fuse BatchNorm operators of pre-activations to Convolution op'),
         ('fuse_mean_with_mean', 'fuse two consecutive Mean ops'),
         ('fuse_mul_with_conv', 'fuse Mul op to Convolution op'),
+        ('fuse_mul_div', 'fuse Mul with Div as Div'),
         ('fuse_transpose_with_mean',
          'fuse Mean with a preceding Transpose under certain conditions'),
         ('fuse_horizontal_fc_layers',

--- a/compiler/one-cmds/onelib/constant.py
+++ b/compiler/one-cmds/onelib/constant.py
@@ -43,6 +43,7 @@ class CONSTANT:
         'fuse_gelu',
         'fuse_mean_with_mean',
         'fuse_mul_with_conv',
+        'fuse_mul_div',
         'fuse_transpose_with_mean',
         'fuse_slice_with_tconv',
         'fuse_horizontal_fc_layers',


### PR DESCRIPTION
This commit enables fuse_mul_div option for one-cmds optimize.

for issue: https://github.com/Samsung/ONE/issues/11956
from draft https://github.com/Samsung/ONE/pull/12124

ONE-DCO-1.0-Signed-off-by: Artem Balyshev <a.balyshev@samsung.com>