### PR TITLE
[infra/onert] Fix cmake overlay searching

### DIFF
--- a/infra/nnfw/CMakeLists.txt
+++ b/infra/nnfw/CMakeLists.txt
@@ -26,8 +26,9 @@ set(NNFW_OVERLAY_DIR "${CMAKE_BINARY_DIR}/overlay" CACHE
 # Share package build script with compiler
 set(EXT_OVERLAY_DIR ${NNFW_OVERLAY_DIR})
 
-# This allows find_package to access configurations installed inside overlay
-list(APPEND CMAKE_PREFIX_PATH "${EXT_OVERLAY_DIR}")
+# This allows find_package configurations, find_library, and find_path to access installed inside overlay
+# EXT_OVERLAY_DIR is higher priority than ROOTFS_DIR on cross build
+list(INSERT CMAKE_FIND_ROOT_PATH 0 "${EXT_OVERLAY_DIR}")
 
 macro(nnas_include PREFIX)
   include("${NNAS_PROJECT_SOURCE_DIR}/infra/cmake/modules/${PREFIX}.cmake")

--- a/infra/nnfw/cmake/packages/ARMComputeConfig.cmake
+++ b/infra/nnfw/cmake/packages/ARMComputeConfig.cmake
@@ -3,19 +3,17 @@ function(_ARMCompute_Import)
 
   list(APPEND ARMCompute_LIB_SEARCH_PATHS ${ARMCompute_PREFIX}/lib)
 
-  find_path(INCLUDE_DIR NAMES arm_compute/core/ITensor.h PATHS ${ARMCompute_INCLUDE_SEARCH_PATHS})
+  find_path(INCLUDE_DIR NAMES arm_compute/core/ITensor.h)
 
-  find_library(CORE_LIBRARY NAMES  	 arm_compute_core  PATHS ${ARMCompute_LIB_SEARCH_PATHS} CMAKE_FIND_ROOT_PATH_BOTH)
-  find_library(RUNTIME_LIBRARY NAMES arm_compute       PATHS ${ARMCompute_LIB_SEARCH_PATHS} CMAKE_FIND_ROOT_PATH_BOTH)
-  find_library(GRAPH_LIBRARY NAMES   arm_compute_graph PATHS ${ARMCompute_LIB_SEARCH_PATHS} CMAKE_FIND_ROOT_PATH_BOTH)
-
-  message(STATUS "Search acl in ${ARMCompute_LIB_SEARCH_PATHS}")
+  find_library(CORE_LIBRARY NAMES  	 arm_compute_core)
+  find_library(RUNTIME_LIBRARY NAMES arm_compute)
+  find_library(GRAPH_LIBRARY NAMES   arm_compute_graph)
 
   # ARMCompute v21.02 moves some headers into "src/".
   # And we cannot build armcompute-ex library without these headers.
   # So we need to download and use source code if our build root doesn't have headers in "src/" (tizen's devel package includes these headers).
   # TODO Don't use headers in "src/"
-  find_path(HEADER_SRC_DIR NAMES src/core/CL/ICLKernel.h PATHS ${ARMCompute_INCLUDE_SEARCH_PATHS})
+  find_path(HEADER_SRC_DIR NAMES src/core/CL/ICLKernel.h)
   if(NOT INCLUDE_DIR OR NOT HEADER_SRC_DIR)
     nnas_find_package(ARMComputeSource QUIET)
     if (NOT ARMComputeSource_FOUND)

--- a/infra/nnfw/cmake/packages/LuciConfig.cmake
+++ b/infra/nnfw/cmake/packages/LuciConfig.cmake
@@ -2,13 +2,11 @@
 
 set(Luci_FOUND FALSE)
 
-find_path(LUCI_HEADERS
-    NAMES loco.h luci/IR/CircleNode.h
-    PATHS ${EXT_OVERLAY_DIR}/include)
+find_path(LUCI_HEADERS NAMES loco.h luci/IR/CircleNode.h)
 
 macro(_load_library LUCI_NAME)
     add_library(luci::${LUCI_NAME} SHARED IMPORTED)
-    find_library(LUCI_LIB_PATH_${LUCI_NAME} NAMES luci_${LUCI_NAME} PATHS ${EXT_OVERLAY_DIR}/lib NO_DEFAULT_PATH)
+    find_library(LUCI_LIB_PATH_${LUCI_NAME} NAMES luci_${LUCI_NAME})
     if (NOT LUCI_LIB_PATH_${LUCI_NAME})
         return()
     endif()
@@ -32,7 +30,7 @@ _load_library(service)
 # Need luci::loco to avoid "DSO missing from command line" link error
 # TODO Find better way to do this
 add_library(luci::loco SHARED IMPORTED)
-find_library(LOCO_LIB_PATH NAMES loco PATHS ${EXT_OVERLAY_DIR}/lib)
+find_library(LOCO_LIB_PATH NAMES loco)
 if (NOT LOCO_LIB_PATH)
     return()
 endif()


### PR DESCRIPTION
This commit changes overlay searching by using CMAKE_FIND_ROOT_PATH. 
It will simplify searching overlay and fix bug on luci library searching.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>