### PR TITLE
[circle-mqpsolver] Prevent copy of an object

### DIFF
--- a/compiler/circle-mpqsolver/src/bisection/VISQErrorApproximator.cpp
+++ b/compiler/circle-mpqsolver/src/bisection/VISQErrorApproximator.cpp
@@ -44,7 +44,7 @@ void VISQErrorApproximator::init(std::istream &visq_data)
 
   auto layers = completeJsonData["error"][0];
   auto names = layers.getMemberNames();
-  for (auto name : names)
+  for (const auto &name : names)
   {
     auto value = layers[name].asFloat();
     _layer_errors[name] = value;

--- a/compiler/circle-mpqsolver/src/pattern/PatternSolver.cpp
+++ b/compiler/circle-mpqsolver/src/pattern/PatternSolver.cpp
@@ -67,7 +67,7 @@ void PatternSolver::setMPQOptions(MPQOptions &options) { _options = options; }
 LayerParams PatternSolver::getFrozenParams() const
 {
   LayerParams params;
-  for (auto node_to_param : _frozen._node_to_param)
+  for (const auto &node_to_param : _frozen._node_to_param)
   {
     params.push_back(std::make_shared<LayerParam>(node_to_param.second));
   }
@@ -95,7 +95,7 @@ void PatternSolver::resolvePatterns(luci::Module *module)
     }
 
     auto const resolved = resolver->resolve(module);
-    for (auto node_param : resolved)
+    for (const auto &node_param : resolved)
     {
       auto const frozen = _frozen._node_to_param.find(node_param.first);
       if (frozen == _frozen._node_to_param.end())


### PR DESCRIPTION
This commit prevents from copying of an object when using auto keyword.

This warning is from our static analysis tool.
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>