### PR TITLE
[infra/onert] Remove training feature option

### DIFF
--- a/infra/nnfw/cmake/CfgOptionFlags.cmake
+++ b/infra/nnfw/cmake/CfgOptionFlags.cmake
@@ -33,7 +33,6 @@ option(BUILD_GPU_CL "Build gpu_cl backend" OFF)
 option(BUILD_NPUD "Build NPU daemon" OFF)
 option(ENVVAR_NPUD_CONFIG "Use environment variable for npud configuration" OFF)
 option(BUILD_MINMAX_H5DUMPER "Build minmax h5dumper" ON)
-option(ENABLE_ONERT_TRAIN "Enable onert training feature" ON)
 #
 # Default build configuration for contrib
 #


### PR DESCRIPTION
This commit removes ENABLE_ONERT_TRAIN option.
It is not used any more.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>