### PR TITLE
[luci/pass] Introduce ResovleFormerCustomOpPass 

### DIFF
--- a/compiler/luci/pass/include/luci/CircleOptimizer.h
+++ b/compiler/luci/pass/include/luci/CircleOptimizer.h
@@ -52,6 +52,7 @@ public:
       ResolveCustomOpMatMul,
       ResolveCustomOpMaxPoolWithArgmax,
       ResolveCustomOpSplitV,
+      ResolveFormerCustomOp,
       FoldAddV2,
       FoldCast,
       FoldDensify,

--- a/compiler/luci/pass/include/luci/Pass/ResolveFormerCustomOpPass.h
+++ b/compiler/luci/pass/include/luci/Pass/ResolveFormerCustomOpPass.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __LUCI_RESOLVE_FORMER_CUSTOM_OP_PASS_H__
+#define __LUCI_RESOLVE_FORMER_CUSTOM_OP_PASS_H__
+
+#include <logo/Pass.h>
+
+namespace luci
+{
+
+/**
+ * @brief Class to convert a custom operator to a built-in operator.
+ *
+ * @details This pass changes a op formerly used as a custom op to builtin op
+ *          from schema version upgrade.
+ */
+struct ResolveFormerCustomOpPass final : public logo::Pass
+{
+  const char *name(void) const final { return "luci::ResolveFormerCustomOpPass"; }
+
+  bool run(loco::Graph *g) final;
+};
+
+} // namespace luci
+
+#endif // __LUCI_RESOLVE_FORMER_CUSTOM_OP_PASS_H__

--- a/compiler/luci/pass/src/CircleOptimizer.cpp
+++ b/compiler/luci/pass/src/CircleOptimizer.cpp
@@ -69,6 +69,7 @@
 #include "luci/Pass/ResolveCustomOpMatMulPass.h"
 #include "luci/Pass/ResolveCustomOpMaxPoolWithArgmaxPass.h"
 #include "luci/Pass/ResolveCustomOpSplitVPass.h"
+#include "luci/Pass/ResolveFormerCustomOpPass.h"
 #include "luci/Pass/SparsifyTensorPass.h"
 #include "luci/Pass/ShuffleWeightTo16x1Float32Pass.h"
 #include "luci/Pass/SubstitutePackToReshapePass.h"
@@ -164,6 +165,7 @@ void convert_nchw_to_nhwc(loco::Graph *g, bool preserve_input, bool preserve_out
   phase.emplace_back(std::make_unique<luci::ResolveCustomOpMatMulPass>());
   phase.emplace_back(std::make_unique<luci::ResolveCustomOpMaxPoolWithArgmaxPass>());
   phase.emplace_back(std::make_unique<luci::ResolveCustomOpSplitVPass>());
+  phase.emplace_back(std::make_unique<luci::ResolveFormerCustomOpPass>());
 
   // Fuse FullyConnected with Add
   // Why we perform FuseAddWithFullyConnectedPass before ConvertNCHWToNHWCPass?
@@ -262,6 +264,10 @@ void CircleOptimizer::optimize(loco::Graph *g) const
   if (_options->query(Options::Algorithm::ResolveCustomOpMatMul))
   {
     phase.emplace_back(std::make_unique<luci::ResolveCustomOpMatMulPass>());
+  }
+  if (_options->query(Options::Algorithm::ResolveFormerCustomOp))
+  {
+    phase.emplace_back(std::make_unique<luci::ResolveFormerCustomOpPass>());
   }
   if (_options->query(Options::Algorithm::FuseMeanWithMean))
   {

--- a/compiler/luci/pass/src/ResolveFormerCustomOpPass.cpp
+++ b/compiler/luci/pass/src/ResolveFormerCustomOpPass.cpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Pass/ResolveFormerCustomOpPass.h"
+
+#include <luci/IR/CircleNodes.h>
+#include <luci/IR/AttrFusedActFunc.h>
+#include <luci/Profile/CircleNodeOrigin.h>
+
+#include <flatbuffers/flexbuffers.h>
+
+namespace
+{
+
+bool resolve_with_BroadcastTo(luci::CircleCustom *node)
+{
+  // check if the number of inputs is 2.
+  if (node->numInputs() != 2)
+    return false;
+
+  auto input = loco::must_cast<luci::CircleNode *>(node->inputs(0));
+
+  // check if shape are support data types
+  auto shape = loco::must_cast<luci::CircleNode *>(node->inputs(1));
+  if (shape->dtype() != loco::DataType::S32 && shape->dtype() != loco::DataType::S64)
+    return false;
+
+  auto name = node->name();
+  assert(name.length() > 0);
+
+  auto broadcastTo = node->graph()->nodes()->create<luci::CircleBroadcastTo>();
+  broadcastTo->input(input);
+  broadcastTo->shape(shape);
+  broadcastTo->name(name);
+  luci::add_origin(broadcastTo, luci::get_origin(node));
+
+  auto customOut = loco::succs(node);
+
+  assert(customOut.size() == 1);
+
+  // check if the data type of output is same with the one of the input feature map.
+  auto output = loco::must_cast<luci::CircleNode *>(*customOut.begin());
+  if (input->dtype() != output->dtype())
+    return false;
+
+  replace(*customOut.begin()).with(broadcastTo);
+
+  return true;
+}
+
+bool resolve_custom_op(luci::CircleCustom *node)
+{
+  const std::string custom_code = node->custom_code();
+
+  if (custom_code == "BroadcastTo")
+  {
+    return resolve_with_BroadcastTo(node);
+  }
+  // TODO add more custom codes
+
+  return false;
+}
+
+} // namespace
+
+namespace luci
+{
+
+bool ResolveFormerCustomOpPass::run(loco::Graph *g)
+{
+  bool changed = false;
+
+  for (auto node : loco::active_nodes(loco::output_nodes(g)))
+  {
+    auto cop = dynamic_cast<luci::CircleCustom *>(node);
+    if (not cop)
+      continue;
+
+    if (resolve_custom_op(cop))
+      changed = true;
+  }
+
+  return changed;
+}
+
+} // namespace luci

--- a/compiler/luci/pass/src/ResolveFormerCustomOpPass.test.cpp
+++ b/compiler/luci/pass/src/ResolveFormerCustomOpPass.test.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Pass/ResolveFormerCustomOpPass.h"
+
+#include <gtest/gtest.h>
+
+TEST(ResolveFormerCustomOpPassTest, name)
+{
+  luci::ResolveFormerCustomOpPass pass;
+  auto const name = pass.name();
+  ASSERT_NE(nullptr, name);
+}


### PR DESCRIPTION
This commit introduces ResolveFormerCustomOpPass to luci.
ResolveFormerCustomOpPass changes a specific custom op into a builtin op from schema version upgrade.

ONE-DCO-1.0-Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>

---
Related to Issue: https://github.com/Samsung/ONE/issues/10784
Draft PR: [#10737](https://github.com/Samsung/ONE/pull/11701)