### PR TITLE
[tools/onert_train] Add validation_split argument

### DIFF
--- a/tests/tools/onert_train/src/args.cc
+++ b/tests/tools/onert_train/src/args.cc
@@ -166,6 +166,15 @@ void Args::Initialize(void)
     checkModelfile(_load_raw_expected_filename);
   };
 
+  auto process_validation_split = [&](const float v) {
+    if (v < 0.f || v > 1.f)
+    {
+      std::cerr << "Invalid validation_split. Float between 0 and 1." << std::endl;
+      exit(1);
+    }
+    _validation_split = v;
+  };
+
   auto process_output_sizes = [&](const std::string &output_sizes_json_str) {
     Json::Value root;
     Json::Reader reader;
@@ -231,6 +240,8 @@ void Args::Initialize(void)
     ("metric", po::value<int>()->default_value(-1)->notifier([&] (const auto &v) { _metric_type = v; }),
       "Metricy type\n"
       "  Simply calculates the metric value using the variables (default: none)\n")
+    ("validation_split", po::value<float>()->default_value(0.0f)->notifier(process_validation_split),
+         "Float between 0 and 1. Fraction of the training data to be used as validation data.")
     ("verbose_level,v", po::value<int>()->default_value(0)->notifier([&](const auto &v) { _verbose_level = v; }),
          "Verbose level\n"
          "0: prints the only result. Messages btw run don't print\n"

--- a/tests/tools/onert_train/src/args.h
+++ b/tests/tools/onert_train/src/args.h
@@ -60,6 +60,7 @@ public:
   const int getLossReductionType(void) const { return _loss_reduction_type; }
   const int getOptimizerType(void) const { return _optimizer_type; }
   const int getMetricType(void) const { return _metric_type; }
+  const float getValidationSplit(void) const { return _validation_split; }
   const bool printVersion(void) const { return _print_version; }
   const int getVerboseLevel(void) const { return _verbose_level; }
   std::unordered_map<uint32_t, uint32_t> getOutputSizes(void) const { return _output_sizes; }
@@ -86,6 +87,7 @@ private:
   int _loss_reduction_type;
   int _optimizer_type;
   int _metric_type;
+  float _validation_split;
   bool _print_version = false;
   int _verbose_level;
   std::unordered_map<uint32_t, uint32_t> _output_sizes;


### PR DESCRIPTION
This commit adds a validation_split argument.
This argument refers to the fraction of the training data to be used as validation data.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Draft: #12265
