### PR TITLE
[infra/nncc] Revise Makefile.arm32

### DIFF
--- a/infra/nncc/Makefile.arm32
+++ b/infra/nncc/Makefile.arm32
@@ -35,7 +35,7 @@ ARM32_BUILD_ITEMS+=;luci-interpreter
 ARM32_BUILD_ITEMS+=;tflite2circle
 ARM32_BUILD_ITEMS+=;tflchef;circlechef
 ARM32_BUILD_ITEMS+=;circle2circle;record-minmax;circle-quantizer
-ARM32_BUILD_ITEMS+=;luci-eval-driver;luci-value-test
+ARM32_BUILD_ITEMS+=;luci-eval-driver;luci-value-py-test
 
 ARM32_TOOLCHAIN_FILE=cmake/buildtool/cross/toolchain_armv7l-linux.cmake
 
@@ -54,7 +54,7 @@ ARM32_HOST_ITEMS+=;tflchef;circlechef
 ARM32_HOST_ITEMS+=;circle-tensordump
 ARM32_HOST_ITEMS+=;circle2circle
 ARM32_HOST_ITEMS+=;common-artifacts
-ARM32_HOST_ITEMS+=;luci-eval-driver;luci-value-test
+ARM32_HOST_ITEMS+=;luci-eval-driver;luci-value-py-test
 
 
 _EMPTY_:=


### PR DESCRIPTION
This will revise Makefile.arm32 to replace with luci-value-py-test.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>