### PR TITLE
[onert/train] Fix build fail

### DIFF
--- a/tests/tools/onert_train/src/nnfw_util.h
+++ b/tests/tools/onert_train/src/nnfw_util.h
@@ -20,6 +20,8 @@
 #include "nnfw.h"
 #include "nnfw_experimental.h"
 
+#include <ostream>
+
 #define NNPR_ENSURE_STATUS(a)        \
   do                                 \
   {                                  \


### PR DESCRIPTION
This commit resolves build fail by ostream without header include.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>