### PR TITLE
[one-cmds] Revise preprocess_images.py to process also numpy files

### DIFF
--- a/compiler/one-cmds/tests/prepare_test_materials.sh
+++ b/compiler/one-cmds/tests/prepare_test_materials.sh
@@ -57,7 +57,7 @@ if [[ ! -s "img_files" ]]; then
     # https://github.com/Samsung/ONE/issues/3213#issuecomment-722757499
 fi
 
-if [ ! -d "raw_files" ] || [ ! -s "datalist.txt" ]; then
+if [ ! -d "raw_files" ] || [ ! -s "datalist.txt" ] || [ ! -d "numpy_files" ] || [ ! -s "datalist_numpy.txt" ]; then
     ../bin/venv/bin/python preprocess_images.py
 fi
 

--- a/compiler/one-cmds/tests/preprocess_images.py
+++ b/compiler/one-cmds/tests/preprocess_images.py
@@ -15,15 +15,22 @@
 import os, shutil, PIL.Image, numpy as np
 
 input_dir = 'img_files'
-output_dir = 'raw_files'
-list_file = 'datalist.txt'
+raw_output_dir = 'raw_files'
+raw_list_file = 'datalist.txt'
+numpy_output_dir = 'numpy_files'
+numpy_list_file = 'datalist_numpy.txt'
 
-if os.path.exists(output_dir):
-    shutil.rmtree(output_dir, ignore_errors=True)
-os.makedirs(output_dir)
+if os.path.exists(raw_output_dir):
+    shutil.rmtree(raw_output_dir, ignore_errors=True)
+os.makedirs(raw_output_dir)
+
+if os.path.exists(numpy_output_dir):
+    shutil.rmtree(numpy_output_dir, ignore_errors=True)
+os.makedirs(numpy_output_dir)
 
 for (root, _, files) in os.walk(input_dir):
-    datalist = open(list_file, 'w')
+    raw_datalist = open(raw_list_file, 'w')
+    numpy_datalist = open(numpy_list_file, 'w')
     for f in files:
         with PIL.Image.open(root + '/' + f) as image:
             # To handle ANTIALIAS deprecation
@@ -32,7 +39,15 @@ for (root, _, files) in os.walk(input_dir):
 
             img = np.array(image.resize((299, 299), ANTIALIAS)).astype(np.float32)
             img = ((img / 255) - 0.5) * 2.0
-            output_file = output_dir + '/' + f.replace('jpg', 'data')
-            img.tofile(output_file)
-            datalist.writelines(os.path.abspath(output_file) + '\n')
-    datalist.close()
+            # To save in numpy format
+            output_numpy_file = numpy_output_dir + '/' + f.replace('jpg', 'npy')
+            np.save('./' + output_numpy_file, img)
+            numpy_datalist.writelines(os.path.abspath(output_numpy_file) + '\n')
+
+            # To save in raw data format
+            output_raw_file = raw_output_dir + '/' + f.replace('jpg', 'data')
+            img.tofile(output_raw_file)
+            raw_datalist.writelines(os.path.abspath(output_raw_file) + '\n')
+
+    raw_datalist.close()
+    numpy_datalist.close()


### PR DESCRIPTION
This commit revises preprocess_images.py to process also numpy files.
- preprocess_images_numpy.py is very similar to preprocess_images.py. so, merge them to reduce duplicate codes.

ONE-DCO-1.0-Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>

---
Related Issue: https://github.com/Samsung/ONE/issues/12053
Draft PR: https://github.com/Samsung/ONE/pull/12186