### PR TITLE
Release note 1.26.0

### DIFF
--- a/docs/release/1.26/index.rst
+++ b/docs/release/1.26/index.rst
@@ -1,0 +1,13 @@
+.. ONE documentation master file, created by
+   sphinx-quickstart on Thu Dec 19 14:10:15 2023.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+1.26
+====
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+  ./release-note-1.26.0.md

--- a/docs/release/1.26/release-note-1.26.0.md
+++ b/docs/release/1.26/release-note-1.26.0.md
@@ -1,0 +1,15 @@
+# Release Note 1.26.0
+
+## ONE Compiler
+
+- Support more Op(s): HardSwish, CumSum, BroadcastTo
+- Support more optimization option(s): `decompose_softmax`, `decompose_hardswish`, `fuse_slice_with_tconv`,
+    `fuse_mul_with_conv`, `remove_unnecessary_add`, `fuse_horizontal_fc_layers`, `common_subexpression_elimination`,
+    `remove_unnecessary_transpose`
+- _one-quantize_ supports more option
+  - Requantization option to convert TF2-quantized int8 model to uint8 model (--requantize)
+  - A new option to automatically find mixed-precision configuration (--ampq)
+  - A new option to save calibrated min/max values (--save_min_max)
+  - Add new parameters for moving average calibration (--moving_avg_batch, --moving_avg_const)
+- Introduce _q-implant_ that writes quantization parameters and weights into the circle model
+- Introduce _minmax-embedder_ that embeds min/max values into the circle model


### PR DESCRIPTION
This commit is a release note for 1.26.0.

Related: #12299 
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>