### PR TITLE
[DRAFT] Fix build error on gcc13

### DIFF
--- a/compiler/pp/include/pp/IndentedStringBuilder.h
+++ b/compiler/pp/include/pp/IndentedStringBuilder.h
@@ -18,6 +18,7 @@
 #define __PP_INDENTED_STRING_BUILDER_H__
 
 #include "pp/Format.h"
+#include <cstdint>
 
 namespace pp
 {

--- a/infra/cmake/modules/ExternalBuildTools.cmake
+++ b/infra/cmake/modules/ExternalBuildTools.cmake
@@ -54,7 +54,7 @@ function(ExternalBuild_CMake)
                             -G "${CMAKE_GENERATOR}"
                             -DCMAKE_INSTALL_PREFIX=${ARG_INSTALL_DIR}
                             -DCMAKE_BUILD_TYPE=Release
-                            -DCMAKE_CXX_FLAGS=${ARG_BUILD_FLAGS}
+                            -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS} ${ARG_BUILD_FLAGS}
                             ${ARG_EXTRA_OPTS}
                             ${ARG_CMAKE_DIR}
                   OUTPUT_FILE ${BUILD_LOG_PATH}

--- a/infra/nncc/cmake/buildtool/config/config_linux.cmake
+++ b/infra/nncc/cmake/buildtool/config/config_linux.cmake
@@ -7,5 +7,10 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_G
   list(APPEND FLAGS_CXXONLY "-Wno-psabi")
 endif()
 
+# Build fail on memcpy (ex. compute/cker/include/cker/Shape.h:211:16)
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 12.0)
+  list(APPEND FLAGS_CXXONLY "-Wno-error=stringop-overflow -Wno-error=array-bounds")
+endif()
+
 # lib pthread as a variable (pthread must be disabled on android)
 set(LIB_PTHREAD pthread)


### PR DESCRIPTION
This patch comes from the change in review.tizen.org :

```
From d44185dba35beb4f2dbb9fcf91513e48bac1108c Mon Sep 17 00:00:00 2001
From: wchang kim <wchang.kim@samsung.com>
Date: Wed, 20 Dec 2023 13:33:20 +0900
Subject: [PATCH] Fixed the build error on gcc13.

Change-Id: I96706f553a0349c4c5cde903510fa97cc7316dfe
```