### PR TITLE
[onert/api] Add TrainingInfo into nnfw_session

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -27,6 +27,7 @@
 #include "json/json.h"
 #include "ir/NNPkg.h"
 #include "ir/OpCode.h"
+#include "ir/train/TrainingInfo.h"
 #include "util/TracingCtx.h"
 #include "odc/QuantizeManager.h"
 #include "circle_schema_generated.h"
@@ -226,7 +227,7 @@ uint64_t getBufSize(const nnfw_tensorinfo *info)
 
 nnfw_session::nnfw_session()
   : _nnpkg{nullptr}, _coptions{}, _compiler_artifact{nullptr}, _execution{nullptr},
-    _kernel_registry{nullptr}, _quant_manager{nullptr}
+    _kernel_registry{nullptr}, _train_info{nullptr}, _quant_manager{nullptr}
 {
   // DO NOTHING
 }
@@ -316,6 +317,8 @@ NNFW_STATUS nnfw_session::load_model_from_modelfile(const char *model_file_path)
     _model_path = std::string(model_file_path);
     _nnpkg = std::make_shared<onert::ir::NNPkg>(std::move(model));
     _coptions.push_back(onert::compiler::CompilerOptions::fromGlobalConfig());
+    // TODO load TrainingInfo from model, using TraininfoLoader
+    _train_info = std::make_unique<onert::ir::train::TrainingInfo>();
     _state = State::MODEL_LOADED;
   }
   catch (const std::exception &e)
@@ -401,6 +404,9 @@ NNFW_STATUS nnfw_session::load_model_from_nnpackage(const char *package_dir)
       _nnpkg->push(onert::ir::ModelIndex{i}, std::move(model));
       _coptions.push_back(onert::compiler::CompilerOptions::fromGlobalConfig());
     }
+
+    // TODO load TrainingInfo from model, using TraininfoLoader
+    _train_info = std::make_unique<onert::ir::train::TrainingInfo>();
 
     auto toIODesc = [](std::string str) {
       auto indices = nnfw::misc::split(str, ':');

--- a/runtime/onert/api/src/nnfw_api_internal.h
+++ b/runtime/onert/api/src/nnfw_api_internal.h
@@ -42,6 +42,10 @@ namespace ir
 struct IGraph;
 class Model;
 class NNPkg;
+namespace train
+{
+class TrainingInfo;
+}
 } // namespace ir
 namespace compiler
 {
@@ -206,6 +210,7 @@ private:
   std::shared_ptr<onert::api::CustomKernelRegistry> _kernel_registry;
   std::vector<std::thread> _threads;
   uint32_t _training_step{0};
+  std::unique_ptr<onert::ir::train::TrainingInfo> _train_info;
   std::unique_ptr<onert::odc::QuantizeManager> _quant_manager;
   // Remember path to loaded original model
   // It may be used for on-device compiler / on-device training.


### PR DESCRIPTION
This PR adds TrainingInfo into nnfw_session.
It also initalize nnfw_session._train_info in 'load_model_from_modelfile' and 'load_model_from_nnpackage'.

ONE-DCO-1.0-Signed-off-by: SeungHui Youn <sseung.youn@samsung.com>

issue : https://github.com/Samsung/ONE/issues/11692
draft : https://github.com/Samsung/ONE/pull/12152.  