### PR TITLE
[one-cmds] Invoke preprocessing script for numpy files 

### DIFF
--- a/compiler/one-cmds/tests/prepare_test_materials.sh
+++ b/compiler/one-cmds/tests/prepare_test_materials.sh
@@ -61,6 +61,10 @@ if [ ! -d "raw_files" ] || [ ! -s "datalist.txt" ]; then
     ../bin/venv/bin/python preprocess_images.py
 fi
 
+if [ ! -d "numpy_files" ] || [ ! -s "datalist_numpy.txt" ]; then
+    ../bin/venv/bin/python preprocess_images_numpy.py
+fi
+
 if [[ ! -s "inception_v3_test_data.h5" ]]; then
   ../bin/venv/bin/python ../bin/rawdata2hdf5 \
   --data_list datalist.txt \


### PR DESCRIPTION
This invokes preprocessing script for numpy files in prepare_test_materials.sh.

ONE-DCO-1.0-Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>

---
Related Issue: https://github.com/Samsung/ONE/issues/12053
Draft PR: https://github.com/Samsung/ONE/pull/12186