### PR TITLE
[infra] Add RISC-V tizen cmake build config and options

### DIFF
--- a/infra/nncc/cmake/options/options_riscv64-tizen.cmake
+++ b/infra/nncc/cmake/options/options_riscv64-tizen.cmake
@@ -1,0 +1,3 @@
+#
+# riscv64 tizen cmake options
+#

--- a/infra/nnfw/cmake/buildtool/config/config_riscv64-tizen.cmake
+++ b/infra/nnfw/cmake/buildtool/config/config_riscv64-tizen.cmake
@@ -1,0 +1,17 @@
+#
+# riscv64 tizen compile options
+#
+
+message(STATUS "Building for RISC-V Tizen")
+
+# Build flag for tizen
+set(CMAKE_C_FLAGS_DEBUG     "-O -g -DDEBUG")
+set(CMAKE_CXX_FLAGS_DEBUG   "-O -g -DDEBUG")
+
+# TODO : add and use option_tizen if something uncommon comes up
+# include linux common
+include("cmake/buildtool/config/config_linux.cmake")
+
+# addition for riscv64-tizen
+set(FLAGS_COMMON ${FLAGS_COMMON}
+    )

--- a/infra/nnfw/cmake/options/options_riscv64-tizen.cmake
+++ b/infra/nnfw/cmake/options/options_riscv64-tizen.cmake
@@ -1,0 +1,20 @@
+#
+# riscv64 tizen cmake options
+#
+option(BUILD_ARMCOMPUTE "Build ARM Compute from the downloaded source" OFF)
+option(BUILD_TENSORFLOW_LITE "Build TensorFlow Lite from the downloaded source" OFF)
+option(DOWNLOAD_ARMCOMPUTE "Download ARM Compute source" OFF)
+option(DOWNLOAD_GTEST "Download Google Test source and build Google Test" OFF)
+
+option(BUILD_LOGGING "Build logging runtime" OFF)
+option(GENERATE_RUNTIME_NNAPI_TESTS "Generate NNAPI operation gtest" OFF)
+option(ENVVAR_ONERT_CONFIG "Use environment variable for onert configuration" OFF)
+
+option(BUILD_XNNPACK "Build XNNPACK" OFF)
+option(DOWNLOAD_OPENCL_HEADERS "Download opencl headers" OFF)
+
+option(BUILD_NPUD "Build NPU daemon" OFF)
+# Do not allow to use CONFIG option on Tizen
+option(ENVVAR_NPUD_CONFIG "Use environment variable for npud configuration" OFF)
+
+option(BUILD_MINMAX_H5DUMPER "Build minmax h5dumper" OFF)


### PR DESCRIPTION
This commit adds RISC-V tizen cmake build config and options.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft:  #12343