### PR TITLE
[onert] Introduce AUTO loss reduction type

### DIFF
--- a/runtime/onert/api/include/nnfw_experimental.h
+++ b/runtime/onert/api/include/nnfw_experimental.h
@@ -182,8 +182,8 @@ typedef enum
 
 typedef enum
 {
-  /** Invalid */
-  NNFW_TRAIN_LOSS_REDUCTION_INVALID = 0,
+  /** Auto */
+  NNFW_TRAIN_LOSS_REDUCTION_AUTO = 0,
   /** Scalar sum divided by number of elements in losses */
   NNFW_TRAIN_LOSS_REDUCTION_SUM_OVER_BATCH_SIZE = 1,
   /** Scalar sum of weighted losses */
@@ -215,7 +215,7 @@ typedef struct nnfw_train_info
   uint32_t batch_size = 1;
   /** loss info */
   nnfw_loss_info loss_info{.loss = NNFW_TRAIN_LOSS_MEAN_SQUARED_ERROR,
-                           .reduction_type = NNFW_TRAIN_LOSS_REDUCTION_INVALID};
+                           .reduction_type = NNFW_TRAIN_LOSS_REDUCTION_AUTO};
   /** optimizer type */
   NNFW_TRAIN_OPTIMIZER opt = NNFW_TRAIN_OPTIMIZER_SGD;
 } nnfw_train_info;

--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -1198,8 +1198,8 @@ NNFW_STATUS nnfw_session::train_prepare(const nnfw_train_info *info)
         throw std::runtime_error("not supported loss type");
     };
     auto convertLossReductionType = [](const int &type) {
-      if (type == NNFW_TRAIN_LOSS_REDUCTION_INVALID)
-        return onert::ir::train::LossReductionType::Invalid;
+      if (type == NNFW_TRAIN_LOSS_REDUCTION_AUTO)
+        return onert::ir::train::LossReductionType::Auto;
       else if (type == NNFW_TRAIN_LOSS_REDUCTION_SUM_OVER_BATCH_SIZE)
         return onert::ir::train::LossReductionType::SumOverBatchSize;
       else if (type == NNFW_TRAIN_LOSS_REDUCTION_SUM)

--- a/runtime/onert/core/include/compiler/train/TrainingInfo.h
+++ b/runtime/onert/core/include/compiler/train/TrainingInfo.h
@@ -47,8 +47,9 @@ public:
   {
     _loss_info = loss_info;
 
-    // If the reduction type is not specified, it uses SumOverBatchSize.
-    if (_loss_info.reduction_type == ir::train::LossReductionType::Invalid)
+    // Always use SumOverBatchSize type
+    // TODO Support different type
+    if (_loss_info.reduction_type == ir::train::LossReductionType::Auto)
       _loss_info.reduction_type = ir::train::LossReductionType::SumOverBatchSize;
   }
   const ir::train::OptimizerInfo &optimizerInfo() const { return _optimizer_info; }

--- a/runtime/onert/core/include/ir/train/LossInfo.h
+++ b/runtime/onert/core/include/ir/train/LossInfo.h
@@ -29,6 +29,7 @@ namespace train
 enum class LossReductionType
 {
   Invalid,          //< Invalid
+  Auto,             //< Auto
   SumOverBatchSize, //< SumOverBatchSize loss reduction type
   Sum,              //< Sum loss reduction type
 };

--- a/tests/tools/onert_train/src/args.cc
+++ b/tests/tools/onert_train/src/args.cc
@@ -230,7 +230,7 @@ void Args::Initialize(void)
         "1: CATEGORICAL_CROSSENTROPY\n")
     ("loss_reduction_type", po::value<int>()->default_value(0)->notifier([&] (const auto &v) { _loss_reduction_type = v; }),
         "Loss Reduction type\n"
-        "0: Use default setting (Model parameter or ONERT train setting)\n"
+        "0: AUTO (default)\n"
         "1: SUM_OVER_BATCH_SIZE\n"
         "2: SUM\n")
     ("optimizer", po::value<int>()->default_value(0)->notifier([&] (const auto &v) { _optimizer_type = v; }),

--- a/tests/tools/onert_train/src/nnfw_util.cc
+++ b/tests/tools/onert_train/src/nnfw_util.cc
@@ -87,8 +87,8 @@ std::ostream &operator<<(std::ostream &os, const NNFW_TRAIN_LOSS_REDUCTION &loss
 {
   switch (loss_reduction)
   {
-    case NNFW_TRAIN_LOSS_REDUCTION_INVALID:
-      os << "use default setting";
+    case NNFW_TRAIN_LOSS_REDUCTION_AUTO:
+      os << "use automatic reduction type";
       break;
     case NNFW_TRAIN_LOSS_REDUCTION_SUM_OVER_BATCH_SIZE:
       os << "sum over batch size";

--- a/tests/tools/onert_train/src/onert_train.cc
+++ b/tests/tools/onert_train/src/onert_train.cc
@@ -137,7 +137,7 @@ int main(const int argc, char **argv)
       switch (type)
       {
         case 0:
-          return NNFW_TRAIN_LOSS_REDUCTION_INVALID;
+          return NNFW_TRAIN_LOSS_REDUCTION_AUTO;
         case 1:
           return NNFW_TRAIN_LOSS_REDUCTION_SUM_OVER_BATCH_SIZE;
         case 2:


### PR DESCRIPTION
This commit introduces AUTO loss reduction type. The experimental API does not have Invalid loss reduction type because the user does not have to select the INVALID type. Instead, INVALID type is changed to AUTO type. AUTO type means that the reduction option will be determined by the context. In contrast, onert ir supports both Invalid and Auto types. The default value of loss info in onert ir is Invalid type to determine whether the value has been received from the user.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>