### PR TITLE
[onert] Remove training start and finish log

### DIFF
--- a/runtime/onert/core/src/exec/Execution.cc
+++ b/runtime/onert/core/src/exec/Execution.cc
@@ -161,12 +161,8 @@ void Execution::train(uint32_t training_step)
     throw std::runtime_error{"Supported only TrainableExecutors"};
   }
 
-  VERBOSE(Execution) << "Start training" << std::endl;
-
   execs->train(_io_desc, training_step);
   finished = true;
-
-  VERBOSE(Execution) << "training finished" << std::endl;
 }
 
 float Execution::getLoss(const ir::IOIndex &ind)


### PR DESCRIPTION
This commit removes training start and finish log. While training is running several times, the meaningless logs are repeatedly printed.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>