### PR TITLE
[onert] Rename DERIVATIVE to BACK_PROP in marco definition

### DIFF
--- a/runtime/onert/core/src/compiler/train/StaticBackPropShapeInferer.h
+++ b/runtime/onert/core/src/compiler/train/StaticBackPropShapeInferer.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef __ONERT_COMPILER_STATIC_DERIVATIVE_SHAPE_INFERER_H__
-#define __ONERT_COMPILER_STATIC_DERIVATIVE_SHAPE_INFERER_H__
+#ifndef __ONERT_COMPILER_TRAIN_STATIC_BACK_PROP_SHAPE_INFERER_H__
+#define __ONERT_COMPILER_TRAIN_STATIC_BACK_PROP_SHAPE_INFERER_H__
 
 #include "ir/train/TrainableOperationVisitor.h"
 
@@ -77,4 +77,4 @@ private:
 } // namespace compiler
 } // namespace onert
 
-#endif // __ONERT_COMPILER_STATIC_DERIVATIVE_SHAPE_INFERER_H__
+#endif // __ONERT_COMPILER_TRAIN_STATIC_BACK_PROP_SHAPE_INFERER_H__


### PR DESCRIPTION
This commit renames DERIVATIVE to BACK_PROP in a file name definition.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>