### PR TITLE
[luci/pass] Support Logistic in ForwardTransposeOpPass

### DIFF
--- a/compiler/luci/pass/src/ForwardTransposeOpPass.cpp
+++ b/compiler/luci/pass/src/ForwardTransposeOpPass.cpp
@@ -289,6 +289,8 @@ public:
   bool visit(luci::CircleNode *) { return false; }
 
   bool visit(luci::CircleAbs *node) { return has_pattern_x(node); }
+
+  bool visit(luci::CircleLogistic *node) { return has_pattern_x(node); }
 };
 
 } // namespace


### PR DESCRIPTION
This will enable ForwardTransposeOpPass to support CircleLogistic Op.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>