### PR TITLE
[onert/cker] Update ReduceMeanGrad to consider floating point error

### DIFF
--- a/compute/cker/src/train/ReduceMean.test.cc
+++ b/compute/cker/src/train/ReduceMean.test.cc
@@ -67,7 +67,13 @@ public:
     nnfw::cker::train::MeanGrad(_out_shape, incoming.data(), _in_shape, grad.data());
 
     if (expect_eq)
-      EXPECT_EQ(grad, expected);
+    {
+      // consider the floating point error
+      for (int i = 0; i < grad.size(); ++i)
+      {
+        EXPECT_NEAR(grad[i], expected[i], 1e-3f);
+      }
+    }
     else
       EXPECT_NE(grad, expected);
   }


### PR DESCRIPTION
This PR updates ReduceMeanGrad tests to consider floating point error.

ONE-DCO-1.0-Signed-off-by: SeungHui Youn <sseung.youn@samsung.com>

related : https://github.com/Samsung/ONE/issues/12371, https://github.com/Samsung/ONE/issues/12370 