### PR TITLE
[onert] Rename backward operands from BackProp to Backward

### DIFF
--- a/runtime/onert/core/include/ir/train/TrainableGraph.h
+++ b/runtime/onert/core/include/ir/train/TrainableGraph.h
@@ -84,21 +84,21 @@ public:
                                   std::unique_ptr<ITrainableOperation> &&operation);
 
   /**
-   * @brief Add a operand for back propagation to the graph with the given index and object
+   * @brief Add a operand for backwarding to the graph with the given index and object
    *
-   * If the given index is available, it succeeds. And @c back_prop is moved which invalidates the
-   * caller's pointer. If the given index is already taken, it fails. And @c back_prop will not be
-   * moved so the caller's pointer will be still valid.
+   * If the given index is available, it succeeds. And @c bwd_operand is moved which invalidates
+   * the caller's pointer. If the given index is already taken, it fails. And @c bwd_operand will
+   * not be moved so the caller's pointer will be still valid.
    *
-   * @param[in] index     Index to be added
-   * @param[in] back_prop Back propagation operand to be added
+   * @param[in] index       Index to be added
+   * @param[in] bwd_operand Backward operand to be added
    * @return OperandIndex @c index if successful, UNDEFINED otherwise
    */
-  OperandIndex addBackProp(OperandIndex index, std::unique_ptr<Operand> &&back_prop);
+  OperandIndex addBackwardOperand(OperandIndex index, std::unique_ptr<Operand> &&bwd_operand);
 
 public:
   void changeShape(const OperandIndex &ind, const ir::Shape &new_shape) override;
-  void changeBackPropShape(const OperandIndex &ind, const ir::Shape &new_shape);
+  void changeBackwardShape(const OperandIndex &ind, const ir::Shape &new_shape);
   void addInput(const OperandIndex &ind, const std::string &name = "");
   void addOutput(const OperandIndex &ind, const std::string &name = "");
   void addLoss(const OperandIndex &loss_ind, const IOIndex &pred_io_ind);
@@ -119,7 +119,7 @@ public:
   const Operands &operands() const override { return _graph.operands(); }
   Operands &operands() { return _graph.operands(); } // TODO Remove this non-const accessor
   const Operations &operations() const override { return _graph.operations(); }
-  const Operands &back_props() const { return _back_props; }
+  const Operands &backward_operands() const { return _backward_operands; }
   OperandIndex getLossIndex(const IOIndex &pred_io_ind) const;
   Layout layout() const { return _graph.layout(); }
   const Graph &graph() const { return _graph; }
@@ -133,7 +133,7 @@ public:
 
 private:
   Graph _graph;
-  Operands _back_props;
+  Operands _backward_operands;
 
   std::unordered_map<IOIndex, OperandIndex> _losses;
 };

--- a/runtime/onert/core/include/ir/train/TrainableGraph.h
+++ b/runtime/onert/core/include/ir/train/TrainableGraph.h
@@ -84,7 +84,7 @@ public:
                                   std::unique_ptr<ITrainableOperation> &&operation);
 
   /**
-   * @brief Add a operand for backwarding to the graph with the given index and object
+   * @brief Add an operand for backwarding to the graph with the given index and object
    *
    * If the given index is available, it succeeds. And @c bwd_operand is moved which invalidates
    * the caller's pointer. If the given index is already taken, it fails. And @c bwd_operand will

--- a/runtime/onert/core/src/compiler/ExecutorFactory.cc
+++ b/runtime/onert/core/src/compiler/ExecutorFactory.cc
@@ -692,11 +692,11 @@ exec::IExecutor *ExecutorFactory::createTrainableExecutor(
       });
     data.graph->operands().iterate([&](const ir::OperandIndex &index, const ir::Operand &) {
       const auto &orig_tgraph = lowered_graph->trainable_graph();
-      if (orig_tgraph.back_props().exist(index))
+      if (orig_tgraph.backward_operands().exist(index))
       {
-        const auto &back_prop = orig_tgraph.back_props().at(index);
-        auto new_back_prop = std::make_unique<ir::Operand>(back_prop);
-        auto gen_index = tgraph->addBackProp(index, std::move(new_back_prop));
+        const auto &bwd_operand = orig_tgraph.backward_operands().at(index);
+        auto new_bwd_operand = std::make_unique<ir::Operand>(bwd_operand);
+        auto gen_index = tgraph->addBackwardOperand(index, std::move(new_bwd_operand));
         UNUSED_RELEASE(gen_index);
         assert(gen_index == index);
       }

--- a/runtime/onert/core/src/compiler/train/StaticBackwardShapeInferer.h
+++ b/runtime/onert/core/src/compiler/train/StaticBackwardShapeInferer.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef __ONERT_COMPILER_TRAIN_STATIC_BACK_PROP_SHAPE_INFERER_H__
-#define __ONERT_COMPILER_TRAIN_STATIC_BACK_PROP_SHAPE_INFERER_H__
+#ifndef __ONERT_COMPILER_TRAIN_STATIC_BACKWARD_SHAPE_INFERER_H__
+#define __ONERT_COMPILER_TRAIN_STATIC_BACKWARD_SHAPE_INFERER_H__
 
 #include "ir/train/TrainableOperationVisitor.h"
 
@@ -38,10 +38,10 @@ namespace train
  *        - if calculation cannot be done at compile time, mark the outputs to be dynamic, meaning
  *          shapes of outputs will be calculated during running kernels
  */
-class StaticBackPropShapeInferer : public ir::train::TrainableOperationVisitor
+class StaticBackwardShapeInferer : public ir::train::TrainableOperationVisitor
 {
 public:
-  StaticBackPropShapeInferer(compiler::train::LoweredTrainableGraph *lowered_subg)
+  StaticBackwardShapeInferer(compiler::train::LoweredTrainableGraph *lowered_subg)
     : _lowered_subg{lowered_subg}
   {
   }
@@ -77,4 +77,4 @@ private:
 } // namespace compiler
 } // namespace onert
 
-#endif // __ONERT_COMPILER_TRAIN_STATIC_BACK_PROP_SHAPE_INFERER_H__
+#endif // __ONERT_COMPILER_TRAIN_STATIC_BACKWARD_SHAPE_INFERER_H__

--- a/runtime/onert/core/src/ir/train/TrainableGraph.cc
+++ b/runtime/onert/core/src/ir/train/TrainableGraph.cc
@@ -31,7 +31,7 @@ namespace train
 TrainableGraph::TrainableGraph() : _graph{} {}
 
 TrainableGraph::TrainableGraph(const TrainableGraph &tgraph)
-  : _graph{tgraph._graph}, _back_props{tgraph._back_props}, _losses{tgraph._losses}
+  : _graph{tgraph._graph}, _backward_operands{tgraph._backward_operands}, _losses{tgraph._losses}
 {
   tgraph.operations().iterate(
     [&](const onert::ir::OperationIndex &index, const onert::ir::IOperation &op) {
@@ -62,9 +62,10 @@ OperationIndex TrainableGraph::replaceOperation(OperationIndex index,
   return _graph.replaceOperation(index, std::move(operation));
 }
 
-OperandIndex TrainableGraph::addBackProp(OperandIndex index, std::unique_ptr<Operand> &&back_prop)
+OperandIndex TrainableGraph::addBackwardOperand(OperandIndex index,
+                                                std::unique_ptr<Operand> &&bwd_operand)
 {
-  return _back_props.push(std::move(back_prop), index);
+  return _backward_operands.push(std::move(bwd_operand), index);
 }
 
 IOIndex TrainableGraph::getInputIndex(const std::string &name) const
@@ -82,10 +83,10 @@ void TrainableGraph::changeShape(const OperandIndex &index, const ir::Shape &new
   _graph.changeShape(index, new_shape);
 }
 
-void TrainableGraph::changeBackPropShape(const OperandIndex &index, const ir::Shape &new_shape)
+void TrainableGraph::changeBackwardShape(const OperandIndex &index, const ir::Shape &new_shape)
 {
-  assert(_back_props.exist(index));
-  _back_props.at(index).info().shape(new_shape);
+  assert(_backward_operands.exist(index));
+  _backward_operands.at(index).info().shape(new_shape);
 }
 
 void TrainableGraph::addInput(const OperandIndex &ind, const std::string &name)


### PR DESCRIPTION
This commit renames training operands from BackProp to Backward.
  - back_prop -> backward_operand or bwd_operand
  - BackPropShape -> BackwardShape

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>