### PR TITLE
[tools/onert_train] Add vdata_length check logic

### DIFF
--- a/tests/tools/onert_train/src/onert_train.cc
+++ b/tests/tools/onert_train/src/onert_train.cc
@@ -255,7 +255,10 @@ int main(const int argc, char **argv)
       exit(-1);
     }
 
-    if (vdata_length < tri.batch_size)
+    // If the user does not give the validation_split value,
+    // the vdata_length is 0 by default and it does not execute
+    // validation loop.
+    if (vdata_length != 0 && vdata_length < tri.batch_size)
     {
       std::cerr << "E: validation data is not enough for validation."
                    "Reduce batch_size or adjust validation_split value"


### PR DESCRIPTION
This commit adds vdata_length check logic.
If the user does not give the validation_split value, the vdata_length
is 0 by default and it does not execute validation loop. In this case,
the error check logic is meaningless.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>