### PR TITLE
[onert/api] Move model null check from export_circle

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -1548,8 +1548,11 @@ NNFW_STATUS nnfw_session::train_export_circle(const char *path)
     _execution->iterateTrainableTensors([&](const onert::ir::OperandIndex &idx,
                                             const onert::backend::train::ITrainableTensor *tensor) {
       auto model = ::circle::GetModel(mmapfile.buf());
+      if (!model)
+        throw std::runtime_error("Failed to get model from circle");
+
       auto subgs = model->subgraphs();
-      if (!model || !subgs || subgs->size() != 1)
+      if (!subgs || subgs->size() != 1)
         throw std::runtime_error("Circle does not has valid subgraph or has multiple subgraphs");
 
       auto subg = subgs->Get(0); // Get 1st subgraph


### PR DESCRIPTION
It moves model null check before dereferencing model.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>