### PR TITLE
[onert] Remove training info from nnfw_train_prepare

### DIFF
--- a/runtime/onert/api/include/nnfw_experimental.h
+++ b/runtime/onert/api/include/nnfw_experimental.h
@@ -234,15 +234,10 @@ NNFW_STATUS nnfw_train_set_traininfo(nnfw_session *session, const nnfw_train_inf
  * @note  The session will be entered into training mode
  *
  * @param[in] session The session to be prepared for training
- * @param[in] info    Training information.
- *                    If info is nullptr, it will not change training information.
- *                    If it is nullptr and model has not training information,
- *                    it will use default training information.
- *                    Default training information is {learning_rate = 0.001f, batch_size = 1}
  *
  * @return  @c NNFW_STATUS_NO_ERROR if successful
  */
-NNFW_STATUS nnfw_train_prepare(nnfw_session *session, const nnfw_train_info *info);
+NNFW_STATUS nnfw_train_prepare(nnfw_session *session);
 
 /**
  * @brief Set training input

--- a/runtime/onert/api/include/nnfw_experimental.h
+++ b/runtime/onert/api/include/nnfw_experimental.h
@@ -233,6 +233,9 @@ NNFW_STATUS nnfw_train_set_traininfo(nnfw_session *session, const nnfw_train_inf
  * @brief Prepare session to be ready for training
  * @note  The session will be entered into training mode
  *
+ *        If training info is NOT set in session, this function returns @c NNFW_STATUS_ERROR .
+ *        You should set training info using {@link nnfw_train_set_traininfo}.
+ *
  * @param[in] session The session to be prepared for training
  *
  * @return  @c NNFW_STATUS_NO_ERROR if successful

--- a/runtime/onert/api/src/nnfw_api.cc
+++ b/runtime/onert/api/src/nnfw_api.cc
@@ -394,10 +394,10 @@ NNFW_STATUS nnfw_train_set_traininfo(nnfw_session *session, const nnfw_train_inf
   return session->train_set_traininfo(info);
 }
 
-NNFW_STATUS nnfw_train_prepare(nnfw_session *session, const nnfw_train_info *info)
+NNFW_STATUS nnfw_train_prepare(nnfw_session *session)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->train_prepare(info);
+  return session->train_prepare();
 }
 
 NNFW_STATUS nnfw_train_input_tensorinfo(nnfw_session *session, uint32_t index,

--- a/runtime/onert/api/src/nnfw_api_internal.h
+++ b/runtime/onert/api/src/nnfw_api_internal.h
@@ -171,7 +171,7 @@ public:
   NNFW_STATUS set_backends_per_operation(const char *backend_settings);
 
   NNFW_STATUS train_set_traininfo(const nnfw_train_info *info);
-  NNFW_STATUS train_prepare(const nnfw_train_info *info);
+  NNFW_STATUS train_prepare();
   NNFW_STATUS train_input_tensorinfo(uint32_t index, nnfw_tensorinfo *ti);
   NNFW_STATUS train_expected_tensorinfo(uint32_t index, nnfw_tensorinfo *ti);
   NNFW_STATUS train_set_input(uint32_t index, const void *input,

--- a/tests/tools/onert_train/src/onert_train.cc
+++ b/tests/tools/onert_train/src/onert_train.cc
@@ -185,11 +185,13 @@ int main(const int argc, char **argv)
     std::cout << "== training parameter ==" << std::endl;
     std::cout << tri;
     std::cout << "========================" << std::endl;
+
+    NNPR_ENSURE_STATUS(nnfw_train_set_traininfo(session, &tri));
+
     // prepare execution
 
     // TODO When nnfw_{prepare|run} are failed, can't catch the time
-    measure.run(PhaseType::PREPARE,
-                [&]() { NNPR_ENSURE_STATUS(nnfw_train_prepare(session, &tri)); });
+    measure.run(PhaseType::PREPARE, [&]() { NNPR_ENSURE_STATUS(nnfw_train_prepare(session)); });
 
     // prepare input and expected tensor info lists
     std::vector<nnfw_tensorinfo> input_infos;


### PR DESCRIPTION
This PR removes training info from 'nnfw_train_prepare' argument.
It also makes 'nnfw_train_prepare' to use training info from session.

ONE-DCO-1.0-Signed-off-by: SeungHui Youn <sseung.youn@samsung.com>

related : https://github.com/Samsung/ONE/issues/11692 