### PR TITLE
[onert/api] Add nnfw_train_set_traininfo()

### DIFF
--- a/runtime/onert/api/include/nnfw_experimental.h
+++ b/runtime/onert/api/include/nnfw_experimental.h
@@ -221,7 +221,7 @@ typedef struct nnfw_train_info
 } nnfw_train_info;
 
 /**
- * @brief Set train_info into session
+ * @brief Set training info into session
  * @note  This function should be called after calling {@link nnfw_load_model_from_file}
  *        and before calling {@link nnfw_train_prepare}
  *

--- a/runtime/onert/api/include/nnfw_experimental.h
+++ b/runtime/onert/api/include/nnfw_experimental.h
@@ -222,8 +222,8 @@ typedef struct nnfw_train_info
 
 /**
  * @brief Set train_info into session
- * @note  This function should be called in MODEL_LOADED state,
- *        after {@link nnfw_load_model_from_file} before {@link nnfw_prepare}
+ * @note  This function should be called after calling {@link nnfw_load_model_from_file}
+ *        and before calling {@link nnfw_train_prepare}
  *
  *  @return @c NNFW_STATUS_NO_ERROR If successful
  */

--- a/runtime/onert/api/include/nnfw_experimental.h
+++ b/runtime/onert/api/include/nnfw_experimental.h
@@ -221,6 +221,15 @@ typedef struct nnfw_train_info
 } nnfw_train_info;
 
 /**
+ * @brief Set train_info into session
+ * @note  This function should be called in MODEL_LOADED state,
+ *        after {@link nnfw_load_model_from_file} before {@link nnfw_prepare}
+ *
+ *  @return @c NNFW_STATUS_NO_ERROR If successful
+ */
+NNFW_STATUS nnfw_train_set_traininfo(nnfw_session *session, const nnfw_train_info *train_info);
+
+/**
  * @brief Prepare session to be ready for training
  * @note  The session will be entered into training mode
  *

--- a/runtime/onert/api/include/nnfw_experimental.h
+++ b/runtime/onert/api/include/nnfw_experimental.h
@@ -221,7 +221,7 @@ typedef struct nnfw_train_info
 } nnfw_train_info;
 
 /**
- * @brief Set training info into session
+ * @brief Set training info
  * @note  This function should be called after calling {@link nnfw_load_model_from_file}
  *        and before calling {@link nnfw_train_prepare}
  *

--- a/runtime/onert/api/src/nnfw_api.cc
+++ b/runtime/onert/api/src/nnfw_api.cc
@@ -388,6 +388,12 @@ NNFW_STATUS nnfw_pop_pipeline_output(nnfw_session *session, void *outputs)
 
 // Training
 
+NNFW_STATUS nnfw_train_set_traininfo(nnfw_session *session, const nnfw_train_info *info)
+{
+  NNFW_RETURN_ERROR_IF_NULL(session);
+  return session->train_set_traininfo(info);
+}
+
 NNFW_STATUS nnfw_train_prepare(nnfw_session *session, const nnfw_train_info *info)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);

--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -1178,8 +1178,6 @@ NNFW_STATUS nnfw_session::train_set_traininfo(const nnfw_train_info *info)
   if (not isStateModelLoaded())
   {
     std::cerr << "Error during nnfw_session::train_set_traininfo : invalid state" << std::endl;
-    std::cerr << "nnfw_session::train_set_traininfo must be called in MODEL_LOADED state"
-              << std::endl;
     return NNFW_STATUS_INVALID_STATE;
   }
 
@@ -1191,12 +1189,11 @@ NNFW_STATUS nnfw_session::train_set_traininfo(const nnfw_train_info *info)
 
   // after model loaded, it ensures that _train_info is not nullptr
   assert(_train_info != nullptr);
-  assert(info != nullptr);
 
   auto convertLossType = [](const int &type) {
     if (type == NNFW_TRAIN_LOSS_MEAN_SQUARED_ERROR)
       return onert::ir::train::LossCode::MeanSquaredError;
-    if (type == NNFW_TRAIN_LOSS_CATEGORICAL_CROSSENTROPY)
+    else if (type == NNFW_TRAIN_LOSS_CATEGORICAL_CROSSENTROPY)
       return onert::ir::train::LossCode::CategoricalCrossentropy;
     else
       throw std::runtime_error("not supported loss type");
@@ -1204,7 +1201,7 @@ NNFW_STATUS nnfw_session::train_set_traininfo(const nnfw_train_info *info)
 
   auto convertLossReductionType = [](const int &type) {
     if (type == NNFW_TRAIN_LOSS_REDUCTION_AUTO)
-      return onert::ir::train::LossReductionType::Invalid;
+      return onert::ir::train::LossReductionType::Auto;
     else if (type == NNFW_TRAIN_LOSS_REDUCTION_SUM_OVER_BATCH_SIZE)
       return onert::ir::train::LossReductionType::SumOverBatchSize;
     else if (type == NNFW_TRAIN_LOSS_REDUCTION_SUM)

--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -1173,6 +1173,78 @@ NNFW_STATUS nnfw_session::set_backends_per_operation(const char *backend_setting
   return NNFW_STATUS_NO_ERROR;
 }
 
+NNFW_STATUS nnfw_session::train_set_traininfo(const nnfw_train_info *info)
+{
+  if (not isStateModelLoaded())
+  {
+    std::cerr << "Error during nnfw_session::train_set_traininfo : invalid state" << std::endl;
+    std::cerr << "nnfw_session::train_set_traininfo must be called in MODEL_LOADED state"
+              << std::endl;
+    return NNFW_STATUS_INVALID_STATE;
+  }
+
+  if (info == nullptr)
+  {
+    std::cerr << "nnfw_session::train_set_traininfo : info is nullptr" << std::endl;
+    return NNFW_STATUS_UNEXPECTED_NULL;
+  }
+
+  // after model loaded, it ensures that _train_info is not nullptr
+  assert(_train_info != nullptr);
+  assert(info != nullptr);
+
+  auto convertLossType = [](const int &type) {
+    if (type == NNFW_TRAIN_LOSS_MEAN_SQUARED_ERROR)
+      return onert::ir::train::LossCode::MeanSquaredError;
+    if (type == NNFW_TRAIN_LOSS_CATEGORICAL_CROSSENTROPY)
+      return onert::ir::train::LossCode::CategoricalCrossentropy;
+    else
+      throw std::runtime_error("not supported loss type");
+  };
+
+  auto convertLossReductionType = [](const int &type) {
+    if (type == NNFW_TRAIN_LOSS_REDUCTION_AUTO)
+      return onert::ir::train::LossReductionType::Invalid;
+    else if (type == NNFW_TRAIN_LOSS_REDUCTION_SUM_OVER_BATCH_SIZE)
+      return onert::ir::train::LossReductionType::SumOverBatchSize;
+    else if (type == NNFW_TRAIN_LOSS_REDUCTION_SUM)
+      return onert::ir::train::LossReductionType::Sum;
+    else
+      throw std::runtime_error("not supported loss reduction type");
+  };
+
+  auto convertOptType = [](const int &type) {
+    if (type == NNFW_TRAIN_OPTIMIZER_SGD)
+      return onert::ir::train::OptimizerCode::SGD;
+    else if (type == NNFW_TRAIN_OPTIMIZER_ADAM)
+      return onert::ir::train::OptimizerCode::Adam;
+    else
+      throw std::runtime_error("not supported optimizer type");
+  };
+
+  try
+  {
+    onert::ir::train::LossInfo loss_info;
+    loss_info.loss_code = convertLossType(info->loss_info.loss);
+    loss_info.reduction_type = convertLossReductionType(info->loss_info.reduction_type);
+
+    onert::ir::train::OptimizerInfo opt_info;
+    opt_info.learning_rate = info->learning_rate;
+    opt_info.optim_code = convertOptType(info->opt);
+
+    _train_info->setBatchSize(info->batch_size);
+    _train_info->setLossInfo(loss_info);
+    _train_info->setOptimizerInfo(opt_info);
+  }
+  catch (const std::exception &e)
+  {
+    std::cerr << "Error during nnfw_session::train_set_traininfo : " << e.what() << std::endl;
+    return NNFW_STATUS_ERROR;
+  }
+
+  return NNFW_STATUS_NO_ERROR;
+}
+
 NNFW_STATUS nnfw_session::train_prepare(const nnfw_train_info *info)
 {
   // We may need different state to represent training model is loaded

--- a/runtime/onert/api/src/nnfw_api_internal.h
+++ b/runtime/onert/api/src/nnfw_api_internal.h
@@ -170,6 +170,7 @@ public:
    */
   NNFW_STATUS set_backends_per_operation(const char *backend_settings);
 
+  NNFW_STATUS train_set_traininfo(const nnfw_train_info *info);
   NNFW_STATUS train_prepare(const nnfw_train_info *info);
   NNFW_STATUS train_input_tensorinfo(uint32_t index, nnfw_tensorinfo *ti);
   NNFW_STATUS train_expected_tensorinfo(uint32_t index, nnfw_tensorinfo *ti);


### PR DESCRIPTION
This PR adds `nnfw_train_set_traininfo()` API into nnfw_experimental header. 
The `nnfw_train_set_traininfo()` API is to set train_info in the session.

ONE-DCO-1.0-Signed-off-by: SeungHui Youn sseung.youn@samsung.com

related issue : https://github.com/Samsung/ONE/issues/11692 
