### PR TITLE
[onert] Merge _training_step into TrainingInfo

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -1264,8 +1264,8 @@ NNFW_STATUS nnfw_session::train_prepare()
     if (not _train_info->isValid())
       throw std::runtime_error{"training info is not valid"};
 
-    // initialize epoch count
-    _train_info->epoch() = 0;
+    // initialize trainingStep count
+    _train_info->trainingStep() = 0;
 
     auto compiler =
       onert::compiler::CompilerFactory::get().create(_nnpkg, _coptions, _train_info.get());
@@ -1452,7 +1452,7 @@ NNFW_STATUS nnfw_session::train_run(bool update_weights)
   {
     if (update_weights)
     {
-      auto &training_step = _train_info->epoch();
+      auto &training_step = _train_info->trainingStep();
       _execution->train(training_step++);
     }
     else

--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -1264,6 +1264,9 @@ NNFW_STATUS nnfw_session::train_prepare()
     if (not _train_info->isValid())
       throw std::runtime_error{"training info is not valid"};
 
+    // initialize epoch count
+    _train_info->epoch() = 0;
+
     auto compiler =
       onert::compiler::CompilerFactory::get().create(_nnpkg, _coptions, _train_info.get());
     _nnpkg.reset();
@@ -1449,7 +1452,8 @@ NNFW_STATUS nnfw_session::train_run(bool update_weights)
   {
     if (update_weights)
     {
-      _execution->train(_training_step++);
+      auto &training_step = _train_info->epoch();
+      _execution->train(training_step++);
     }
     else
       _execution->execute();

--- a/runtime/onert/api/src/nnfw_api_internal.h
+++ b/runtime/onert/api/src/nnfw_api_internal.h
@@ -210,7 +210,6 @@ private:
   std::unique_ptr<onert::exec::Execution> _execution;
   std::shared_ptr<onert::api::CustomKernelRegistry> _kernel_registry;
   std::vector<std::thread> _threads;
-  uint32_t _training_step{0};
   std::unique_ptr<onert::ir::train::TrainingInfo> _train_info;
   std::unique_ptr<onert::odc::QuantizeManager> _quant_manager;
   // Remember path to loaded original model

--- a/runtime/onert/core/include/ir/train/TrainingInfo.h
+++ b/runtime/onert/core/include/ir/train/TrainingInfo.h
@@ -32,7 +32,7 @@ namespace train
 class TrainingInfo final
 {
 public:
-  TrainingInfo() : _loss_info(), _optimizer_info(), _batch_size(0), _epoch(0) {}
+  TrainingInfo() : _loss_info(), _optimizer_info(), _batch_size(0), _training_step{0} {}
   TrainingInfo(const TrainingInfo &) = default;
   TrainingInfo(TrainingInfo &&) = default;
   TrainingInfo &operator=(const TrainingInfo &) = default;
@@ -43,7 +43,7 @@ public:
   const LossInfo &lossInfo() const { return _loss_info; }
   const OptimizerInfo &optimizerInfo() const { return _optimizer_info; }
   uint32_t batchSize() const { return _batch_size; }
-  uint32_t &epoch() { return _epoch; }
+  const uint32_t &trainingStep() const { return _training_step; }
 
   // setter
   void setBatchSize(const uint32_t batch_size) { _batch_size = batch_size; }
@@ -57,6 +57,7 @@ public:
       _loss_info.reduction_type = LossReductionType::SumOverBatchSize;
   }
   void setOptimizerInfo(const OptimizerInfo &optimizer_info) { _optimizer_info = optimizer_info; }
+  uint32_t &trainingStep() { return _training_step; }
 
   bool isValid() const;
 
@@ -64,7 +65,7 @@ private:
   LossInfo _loss_info;
   OptimizerInfo _optimizer_info;
   uint32_t _batch_size;
-  uint32_t _epoch;
+  uint32_t _training_step;
 };
 
 } // namespace train

--- a/runtime/onert/core/include/ir/train/TrainingInfo.h
+++ b/runtime/onert/core/include/ir/train/TrainingInfo.h
@@ -43,7 +43,7 @@ public:
   const LossInfo &lossInfo() const { return _loss_info; }
   const OptimizerInfo &optimizerInfo() const { return _optimizer_info; }
   uint32_t batchSize() const { return _batch_size; }
-  uint32_t epoch() const { return _epoch; }
+  uint32_t &epoch() { return _epoch; }
 
   // setter
   void setBatchSize(const uint32_t batch_size) { _batch_size = batch_size; }
@@ -57,7 +57,6 @@ public:
       _loss_info.reduction_type = LossReductionType::SumOverBatchSize;
   }
   void setOptimizerInfo(const OptimizerInfo &optimizer_info) { _optimizer_info = optimizer_info; }
-  void setEpoch(uint32_t epoch) { _epoch = epoch; }
 
   bool isValid() const;
 


### PR DESCRIPTION
This commit merges _training_step into TrainingInfo. It removes duplicated variable.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

related comment: https://github.com/Samsung/ONE/pull/12383#issuecomment-1871732299