### PR TITLE
 [onert] Rename training ir Invalid to Undefined

### DIFF
--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -1194,7 +1194,7 @@ NNFW_STATUS nnfw_session::train_get_traininfo(nnfw_train_info *info)
   auto convertLossCode = [](const onert::ir::train::LossCode &code) -> NNFW_TRAIN_LOSS {
     switch (code)
     {
-      case onert::ir::train::LossCode::Invalid:
+      case onert::ir::train::LossCode::Undefined:
         return NNFW_TRAIN_LOSS_UNDEFINED;
       case onert::ir::train::LossCode::MeanSquaredError:
         return NNFW_TRAIN_LOSS_MEAN_SQUARED_ERROR;
@@ -1209,7 +1209,7 @@ NNFW_STATUS nnfw_session::train_get_traininfo(nnfw_train_info *info)
     [](const onert::ir::train::LossReductionType &type) -> NNFW_TRAIN_LOSS_REDUCTION {
     switch (type)
     {
-      case onert::ir::train::LossReductionType::Invalid:
+      case onert::ir::train::LossReductionType::Undefined:
         return NNFW_TRAIN_LOSS_REDUCTION_UNDEFINED;
       case onert::ir::train::LossReductionType::Auto:
         return NNFW_TRAIN_LOSS_REDUCTION_AUTO;
@@ -1227,7 +1227,7 @@ NNFW_STATUS nnfw_session::train_get_traininfo(nnfw_train_info *info)
     [](const onert::ir::train::OptimizerCode &code) -> NNFW_TRAIN_OPTIMIZER {
     switch (code)
     {
-      case onert::ir::train::OptimizerCode::Invalid:
+      case onert::ir::train::OptimizerCode::Undefined:
         return NNFW_TRAIN_OPTIMIZER_UNDEFINED;
       case onert::ir::train::OptimizerCode::SGD:
         return NNFW_TRAIN_OPTIMIZER_SGD;

--- a/runtime/onert/core/include/ir/train/LossCode.h
+++ b/runtime/onert/core/include/ir/train/LossCode.h
@@ -28,7 +28,7 @@ namespace train
 
 enum class LossCode
 {
-  Invalid,                //< Invalid
+  Undefined,              //< Undefined
   MeanSquaredError,       //< MeanSquaredError optimizer
   CategoricalCrossentropy //< CategoricalCrossentropy optimizer
 };

--- a/runtime/onert/core/include/ir/train/LossInfo.h
+++ b/runtime/onert/core/include/ir/train/LossInfo.h
@@ -28,7 +28,7 @@ namespace train
 
 enum class LossReductionType
 {
-  Invalid,          //< Invalid
+  Undefined,        //< Undefined
   Auto,             //< Auto
   SumOverBatchSize, //< SumOverBatchSize loss reduction type
   Sum,              //< Sum loss reduction type
@@ -49,7 +49,8 @@ struct LossInfo
   } loss_param;
 
   LossInfo()
-    : loss_code{LossCode::Invalid}, reduction_type{LossReductionType::Invalid}, loss_param{-1, 0.0f}
+    : loss_code{LossCode::Undefined}, reduction_type{LossReductionType::Undefined}, loss_param{-1,
+                                                                                               0.0f}
   {
   }
 };

--- a/runtime/onert/core/include/ir/train/OptimizerCode.h
+++ b/runtime/onert/core/include/ir/train/OptimizerCode.h
@@ -30,9 +30,9 @@ namespace train
 
 enum class OptimizerCode
 {
-  Invalid, //< Invalid
-  SGD,     //< SGD optimizer
-  Adam     //< Adam optimizer
+  Undefined, //< Undefined
+  SGD,       //< SGD optimizer
+  Adam       //< Adam optimizer
 };
 
 /**

--- a/runtime/onert/core/include/ir/train/OptimizerInfo.h
+++ b/runtime/onert/core/include/ir/train/OptimizerInfo.h
@@ -32,7 +32,7 @@ struct OptimizerInfo
   float learning_rate;
   // TODO Add properties
 
-  OptimizerInfo() : optim_code{OptimizerCode::Invalid}, learning_rate{0.0f} {}
+  OptimizerInfo() : optim_code{OptimizerCode::Undefined}, learning_rate{0.0f} {}
 };
 
 } // namespace train

--- a/runtime/onert/core/src/ir/train/LossCode.cc
+++ b/runtime/onert/core/src/ir/train/LossCode.cc
@@ -28,7 +28,7 @@ namespace train
 std::string toString(LossCode code)
 {
   static const std::unordered_map<LossCode, const char *> map{
-    {LossCode::Invalid, "Invalid"},
+    {LossCode::Undefined, "Undefined"},
     {LossCode::MeanSquaredError, "MeanSquaredError"},
     {LossCode::CategoricalCrossentropy, "CategoricalCrossentropy"}};
   return map.at(code);

--- a/runtime/onert/core/src/ir/train/OptimizerCode.cc
+++ b/runtime/onert/core/src/ir/train/OptimizerCode.cc
@@ -28,7 +28,7 @@ namespace train
 std::string toString(OptimizerCode code)
 {
   static const std::unordered_map<OptimizerCode, const char *> map{
-    {OptimizerCode::Invalid, "Invalid"},
+    {OptimizerCode::Undefined, "Undefined"},
     {OptimizerCode::SGD, "SGD"},
     {OptimizerCode::Adam, "Adam"}};
   return map.at(code);

--- a/runtime/onert/core/src/ir/train/TrainingInfo.cc
+++ b/runtime/onert/core/src/ir/train/TrainingInfo.cc
@@ -28,16 +28,16 @@ bool TrainingInfo::isValid() const
   if (_batch_size == 0)
     return false;
 
-  if (_optimizer_info.optim_code == onert::ir::train::OptimizerCode::Undefined)
+  if (_optimizer_info.optim_code == OptimizerCode::Undefined)
     return false;
 
   if (_optimizer_info.learning_rate <= 0.0f)
     return false;
 
-  if (_loss_info.loss_code == onert::ir::train::LossCode::Undefined)
+  if (_loss_info.loss_code == LossCode::Undefined)
     return false;
 
-  if (_loss_info.reduction_type == onert::ir::train::LossReductionType::Undefined)
+  if (_loss_info.reduction_type == LossReductionType::Undefined)
     return false;
 
   // If there are invalid combination, add more condition-check here

--- a/runtime/onert/core/src/ir/train/TrainingInfo.cc
+++ b/runtime/onert/core/src/ir/train/TrainingInfo.cc
@@ -28,16 +28,16 @@ bool TrainingInfo::isValid() const
   if (_batch_size == 0)
     return false;
 
-  if (_optimizer_info.optim_code == onert::ir::train::OptimizerCode::Invalid)
+  if (_optimizer_info.optim_code == onert::ir::train::OptimizerCode::Undefined)
     return false;
 
   if (_optimizer_info.learning_rate <= 0.0f)
     return false;
 
-  if (_loss_info.loss_code == onert::ir::train::LossCode::Invalid)
+  if (_loss_info.loss_code == onert::ir::train::LossCode::Undefined)
     return false;
 
-  if (_loss_info.reduction_type == onert::ir::train::LossReductionType::Invalid)
+  if (_loss_info.reduction_type == onert::ir::train::LossReductionType::Undefined)
     return false;
 
   // If there are invalid combination, add more condition-check here


### PR DESCRIPTION
This PR renames training IR's default value from 'Invalid' to 'Undefined'. 
The word 'Undefined' is more appropriate in this case: If nobody sets training information(ir), training information is invalid because it is 'not defined' yet.

ONE-DCO-1.0-Signed-off-by: SeungHui Youn <sseung.youn@samsung.com>