### PR TITLE
[luci/pass] Revise FoldCastPass to early check

### DIFF
--- a/compiler/luci/pass/src/FoldCastPass.cpp
+++ b/compiler/luci/pass/src/FoldCastPass.cpp
@@ -26,6 +26,16 @@ luci::CircleConst *cast_const(luci::CircleConst *node, loco::DataType from_dtype
 {
   assert(node->dtype() == from_dtype);
 
+  bool do_casting = false;
+  if (from_dtype == loco::DataType::S64)
+  {
+    if (to_dtype == loco::DataType::S32)
+      do_casting = true;
+  }
+  // TODO: Support more data types
+  if (not do_casting)
+    return nullptr;
+
   auto name = node->name();
   assert(name.length() > 0);
 


### PR DESCRIPTION
This will revise FoldCastPass to earcky check types to skip casting,
not to unnecessary create CircleConst.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>