### PR TITLE
[vconone] Bump up to 1.27.0

### DIFF
--- a/compiler/vconone/CMakeLists.txt
+++ b/compiler/vconone/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (NOT VCONONE_VERSION)
-  set(VCONONE_VERSION 0x00000000001a0001)
+  set(VCONONE_VERSION 0x00000000001b0001)
   # NOTE order is [build patch minor major]
   # if VCONONE_VERSION is set with -D option, it will be cached
   # you may have to remove cache file if you remove -D option


### PR DESCRIPTION
This commit bumps up to 1.27.0.

Related: #12299
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>