### PR TITLE
[onert] Introduce DepthwiseConv2D trainable operation

### DIFF
--- a/runtime/onert/core/include/ir/train/Operations.Include.h
+++ b/runtime/onert/core/include/ir/train/Operations.Include.h
@@ -18,6 +18,7 @@
 #define __ONERT_IR_TRAIN_OPERATIONS_OPERATION_INCLUDE_H__
 
 #include "ir/train/operation/Conv2D.h"
+#include "ir/train/operation/DepthwiseConv2D.h"
 #include "ir/train/operation/ElementwiseActivation.h"
 #include "ir/train/operation/FullyConnected.h"
 #include "ir/train/operation/Loss.h"

--- a/runtime/onert/core/include/ir/train/Operations.lst
+++ b/runtime/onert/core/include/ir/train/Operations.lst
@@ -19,6 +19,7 @@
 #endif
 
 OP(Conv2D)
+OP(DepthwiseConv2D)
 OP(ElementwiseActivation)
 OP(FullyConnected)
 OP(Loss)

--- a/runtime/onert/core/include/ir/train/operation/DepthwiseConv2D.h
+++ b/runtime/onert/core/include/ir/train/operation/DepthwiseConv2D.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_IR_TRAIN_OPERATION_DEPTHWISECONV2D_H__
+#define __ONERT_IR_TRAIN_OPERATION_DEPTHWISECONV2D_H__
+
+#include "ir/operation/DepthwiseConv2D.h"
+#include "ir/train/ITrainableOperation.h"
+
+namespace onert
+{
+namespace ir
+{
+namespace train
+{
+namespace operation
+{
+
+class DepthwiseConv2D : public ir::operation::DepthwiseConv2D, public ITrainableOperation
+{
+private:
+  using OperationType = ir::operation::DepthwiseConv2D;
+
+public:
+  DepthwiseConv2D(const OperationType &operation);
+
+public:
+  std::unique_ptr<ITrainableOperation> clone() const override;
+  void accept(OperationVisitor &v) const override;
+  void accept(TrainableOperationVisitor &v) const override;
+};
+
+} // namespace operation
+} // namespace train
+} // namespace ir
+} // namespace onert
+
+#endif // __ONERT_IR_TRAIN_OPERATION_DEPTHWISECONV2D_H__

--- a/runtime/onert/core/include/ir/train/operation/DepthwiseConv2D.h
+++ b/runtime/onert/core/include/ir/train/operation/DepthwiseConv2D.h
@@ -48,4 +48,4 @@ public:
 } // namespace ir
 } // namespace onert
 
-#endif // __ONERT_IR_TRAIN_OPERATION_DEPTHWISECONV2D_H__
+#endif // __ONERT_IR_TRAIN_OPERATION_DEPTHWISE_CONV2D_H__

--- a/runtime/onert/core/include/ir/train/operation/DepthwiseConv2D.h
+++ b/runtime/onert/core/include/ir/train/operation/DepthwiseConv2D.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef __ONERT_IR_TRAIN_OPERATION_DEPTHWISECONV2D_H__
-#define __ONERT_IR_TRAIN_OPERATION_DEPTHWISECONV2D_H__
+#ifndef __ONERT_IR_TRAIN_OPERATION_DEPTHWISE_CONV2D_H__
+#define __ONERT_IR_TRAIN_OPERATION_DEPTHWISE_CONV2D_H__
 
 #include "ir/operation/DepthwiseConv2D.h"
 #include "ir/train/ITrainableOperation.h"

--- a/runtime/onert/core/src/compiler/train/TrainableOperationConverter.cc
+++ b/runtime/onert/core/src/compiler/train/TrainableOperationConverter.cc
@@ -39,6 +39,11 @@ void TrainableOperationConverter::visit(const ir::operation::Conv2D &node)
   _return_op = std::make_unique<ir::train::operation::Conv2D>(node);
 }
 
+void TrainableOperationConverter::visit(const ir::operation::DepthwiseConv2D &node)
+{
+  _return_op = std::make_unique<ir::train::operation::DepthwiseConv2D>(node);
+}
+
 void TrainableOperationConverter::visit(const ir::operation::ElementwiseActivation &node)
 {
   if (node.param().op_type == ir::operation::ElementwiseActivation::Type::RELU)

--- a/runtime/onert/core/src/compiler/train/TrainableOperationConverter.h
+++ b/runtime/onert/core/src/compiler/train/TrainableOperationConverter.h
@@ -38,6 +38,7 @@ public:
 
 private:
   void visit(const ir::operation::Conv2D &) override;
+  void visit(const ir::operation::DepthwiseConv2D &) override;
   void visit(const ir::operation::ElementwiseActivation &) override;
   void visit(const ir::operation::FullyConnected &) override;
   void visit(const ir::operation::Loss &node) override;

--- a/runtime/onert/core/src/ir/train/operation/DepthwiseConv2D.cc
+++ b/runtime/onert/core/src/ir/train/operation/DepthwiseConv2D.cc
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ir/train/operation/DepthwiseConv2D.h"
+
+#include "ir/OperationVisitor.h"
+#include "ir/train/TrainableOperationVisitor.h"
+
+namespace onert
+{
+namespace ir
+{
+namespace train
+{
+namespace operation
+{
+
+std::unique_ptr<ITrainableOperation> DepthwiseConv2D::clone() const
+{
+  return std::make_unique<DepthwiseConv2D>(*this);
+}
+
+void DepthwiseConv2D::accept(OperationVisitor &v) const { v.visit(*this); }
+
+void DepthwiseConv2D::accept(TrainableOperationVisitor &v) const { v.visit(*this); }
+
+DepthwiseConv2D::DepthwiseConv2D(const OperationType &operation)
+  : OperationType{operation.getInputs(), operation.getOutputs(), operation.param()}
+{
+  // DO NOTHING
+}
+
+} // namespace operation
+} // namespace train
+} // namespace ir
+} // namespace onert


### PR DESCRIPTION
This commit introduces DepthwiseConv2D train IR.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Draft: #12392
