### PR TITLE
[circle2circle-dredd-recipe-test] Add resolve_former_customop test

### DIFF
--- a/compiler/circle2circle-dredd-recipe-test/test.lst
+++ b/compiler/circle2circle-dredd-recipe-test/test.lst
@@ -10,6 +10,7 @@
 
 ## TFLITE RECIPE
 
+Add(BroadcastTo_000 PASS resolve_former_customop)
 Add(Net_Preactivation_BN_000 PASS fuse_preactivation_batchnorm)
 Add(Net_BroadcastTo_AddV2_000 PASS resolve_customop_add)
 Add(Net_BroadcastTo_AddV2_001 PASS resolve_customop_add)


### PR DESCRIPTION
This commit adds resolve_former_customop to circle2circle-dredd-recipe-test.

ONE-DCO-1.0-Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>

Related to Issue: https://github.com/Samsung/ONE/issues/10784
Draft PR: [#10737](https://github.com/Samsung/ONE/pull/11701)