### PR TITLE
[onert/frontend] Revisit traininfo metadata name

### DIFF
--- a/runtime/onert/frontend/circle_traininfo/include/traininfo_loader.h
+++ b/runtime/onert/frontend/circle_traininfo/include/traininfo_loader.h
@@ -27,7 +27,7 @@ namespace train
 namespace traininfo_loader
 {
 
-static constexpr char *const TRAININFO_METADATA_NAME = "CIRCLE_TRAINING";
+static const char *const TRAININFO_METADATA_NAME = "CIRCLE_TRAINING";
 
 std::unique_ptr<ir::train::TrainingInfo> loadTrainingInfo(const uint8_t *buffer, const size_t size);
 

--- a/runtime/onert/frontend/circle_traininfo/include/traininfo_loader.h
+++ b/runtime/onert/frontend/circle_traininfo/include/traininfo_loader.h
@@ -27,7 +27,7 @@ namespace train
 namespace traininfo_loader
 {
 
-static const char *const TRAININFO_METADATA_NAME = "CIRCLE_TRAINING";
+extern const char *const TRAININFO_METADATA_NAME;
 
 std::unique_ptr<ir::train::TrainingInfo> loadTrainingInfo(const uint8_t *buffer, const size_t size);
 

--- a/runtime/onert/frontend/circle_traininfo/include/traininfo_loader.h
+++ b/runtime/onert/frontend/circle_traininfo/include/traininfo_loader.h
@@ -27,6 +27,7 @@ namespace train
 namespace traininfo_loader
 {
 
+// TODO change this line to use inline variable after C++17
 extern const char *const TRAININFO_METADATA_NAME;
 
 std::unique_ptr<ir::train::TrainingInfo> loadTrainingInfo(const uint8_t *buffer, const size_t size);

--- a/runtime/onert/frontend/circle_traininfo/src/traininfo_loader.cc
+++ b/runtime/onert/frontend/circle_traininfo/src/traininfo_loader.cc
@@ -25,6 +25,8 @@ namespace train
 namespace traininfo_loader
 {
 
+const char *const TRAININFO_METADATA_NAME = "CIRCLE_TRAINING";
+
 namespace
 {
 


### PR DESCRIPTION
This PR adds 'const' keyword to the traininfo metadata name.
It also adds 'extern' keyword to follow one-definition-rule.

ONE-DCO-1.0-Signed-off-by: SeungHui Youn <sseung.youn@samsung.com>

related issue : https://github.com/Samsung/ONE/issues/11692 