### PR TITLE
[onert] Remove AUTO from train loss reduction type

### DIFF
--- a/runtime/onert/api/include/nnfw_experimental.h
+++ b/runtime/onert/api/include/nnfw_experimental.h
@@ -185,8 +185,6 @@ typedef enum
 {
   /** Undefined */
   NNFW_TRAIN_LOSS_REDUCTION_UNDEFINED = 0,
-  /** Auto */
-  NNFW_TRAIN_LOSS_REDUCTION_AUTO = 1,
   /** Scalar sum divided by number of elements in losses */
   NNFW_TRAIN_LOSS_REDUCTION_SUM_OVER_BATCH_SIZE = 2,
   /** Scalar sum of weighted losses */
@@ -219,7 +217,7 @@ typedef struct nnfw_train_info
   uint32_t batch_size = 1;
   /** loss info */
   nnfw_loss_info loss_info{.loss = NNFW_TRAIN_LOSS_MEAN_SQUARED_ERROR,
-                           .reduction_type = NNFW_TRAIN_LOSS_REDUCTION_AUTO};
+                           .reduction_type = NNFW_TRAIN_LOSS_REDUCTION_SUM_OVER_BATCH_SIZE};
   /** optimizer type */
   NNFW_TRAIN_OPTIMIZER opt = NNFW_TRAIN_OPTIMIZER_SGD;
 } nnfw_train_info;

--- a/runtime/onert/api/include/nnfw_experimental.h
+++ b/runtime/onert/api/include/nnfw_experimental.h
@@ -186,9 +186,9 @@ typedef enum
   /** Undefined */
   NNFW_TRAIN_LOSS_REDUCTION_UNDEFINED = 0,
   /** Scalar sum divided by number of elements in losses */
-  NNFW_TRAIN_LOSS_REDUCTION_SUM_OVER_BATCH_SIZE = 2,
+  NNFW_TRAIN_LOSS_REDUCTION_SUM_OVER_BATCH_SIZE = 1,
   /** Scalar sum of weighted losses */
-  NNFW_TRAIN_LOSS_REDUCTION_SUM = 3,
+  NNFW_TRAIN_LOSS_REDUCTION_SUM = 2,
 } NNFW_TRAIN_LOSS_REDUCTION;
 
 typedef enum

--- a/runtime/onert/api/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/src/nnfw_api_internal.cc
@@ -1211,8 +1211,6 @@ NNFW_STATUS nnfw_session::train_get_traininfo(nnfw_train_info *info)
     {
       case onert::ir::train::LossReductionType::Undefined:
         return NNFW_TRAIN_LOSS_REDUCTION_UNDEFINED;
-      case onert::ir::train::LossReductionType::Auto:
-        return NNFW_TRAIN_LOSS_REDUCTION_AUTO;
       case onert::ir::train::LossReductionType::SumOverBatchSize:
         return NNFW_TRAIN_LOSS_REDUCTION_SUM_OVER_BATCH_SIZE;
       case onert::ir::train::LossReductionType::Sum:
@@ -1285,9 +1283,7 @@ NNFW_STATUS nnfw_session::train_set_traininfo(const nnfw_train_info *info)
   };
 
   auto convertLossReductionType = [](const int &type) {
-    if (type == NNFW_TRAIN_LOSS_REDUCTION_AUTO)
-      return onert::ir::train::LossReductionType::Auto;
-    else if (type == NNFW_TRAIN_LOSS_REDUCTION_SUM_OVER_BATCH_SIZE)
+    if (type == NNFW_TRAIN_LOSS_REDUCTION_SUM_OVER_BATCH_SIZE)
       return onert::ir::train::LossReductionType::SumOverBatchSize;
     else if (type == NNFW_TRAIN_LOSS_REDUCTION_SUM)
       return onert::ir::train::LossReductionType::Sum;

--- a/runtime/onert/core/include/ir/train/LossInfo.h
+++ b/runtime/onert/core/include/ir/train/LossInfo.h
@@ -29,7 +29,6 @@ namespace train
 enum class LossReductionType
 {
   Undefined,        //< Undefined
-  Auto,             //< Auto
   SumOverBatchSize, //< SumOverBatchSize loss reduction type
   Sum,              //< Sum loss reduction type
 };

--- a/runtime/onert/core/include/ir/train/TrainingInfo.h
+++ b/runtime/onert/core/include/ir/train/TrainingInfo.h
@@ -47,15 +47,7 @@ public:
 
   // setter
   void setBatchSize(const uint32_t batch_size) { _batch_size = batch_size; }
-  void setLossInfo(const LossInfo &loss_info)
-  {
-    _loss_info = loss_info;
-
-    // Always use SumOverBatchSize type
-    // TODO Support different type
-    if (_loss_info.reduction_type == LossReductionType::Auto)
-      _loss_info.reduction_type = LossReductionType::SumOverBatchSize;
-  }
+  void setLossInfo(const LossInfo &loss_info) { _loss_info = loss_info; }
   void setOptimizerInfo(const OptimizerInfo &optimizer_info) { _optimizer_info = optimizer_info; }
   uint32_t &trainingStep() { return _training_step; }
 

--- a/tests/tools/onert_train/src/args.cc
+++ b/tests/tools/onert_train/src/args.cc
@@ -228,10 +228,10 @@ void Args::Initialize(void)
         "Loss type\n"
         "0: MEAN_SQUARED_ERROR (default)\n"
         "1: CATEGORICAL_CROSSENTROPY\n")
-    ("loss_reduction_type", po::value<int>()->default_value(1)->notifier([&] (const auto &v) { _loss_reduction_type = v; }),
+    ("loss_reduction_type", po::value<int>()->default_value(0)->notifier([&] (const auto &v) { _loss_reduction_type = v; }),
         "Loss Reduction type\n"
-        "1: SUM_OVER_BATCH_SIZE(default)\n"
-        "2: SUM\n")
+        "0: SUM_OVER_BATCH_SIZE(default)\n"
+        "1: SUM\n")
     ("optimizer", po::value<int>()->default_value(0)->notifier([&] (const auto &v) { _optimizer_type = v; }),
       "Optimizer type\n"
       "0: SGD (default)\n"

--- a/tests/tools/onert_train/src/args.cc
+++ b/tests/tools/onert_train/src/args.cc
@@ -228,10 +228,10 @@ void Args::Initialize(void)
         "Loss type\n"
         "0: MEAN_SQUARED_ERROR (default)\n"
         "1: CATEGORICAL_CROSSENTROPY\n")
-    ("loss_reduction_type", po::value<int>()->default_value(0)->notifier([&] (const auto &v) { _loss_reduction_type = v; }),
+    ("loss_reduction_type", po::value<int>()->default_value(1)->notifier([&] (const auto &v) { _loss_reduction_type = v; }),
         "Loss Reduction type\n"
-        "0: SUM_OVER_BATCH_SIZE(default)\n"
-        "1: SUM\n")
+        "1: SUM_OVER_BATCH_SIZE(default)\n"
+        "2: SUM\n")
     ("optimizer", po::value<int>()->default_value(0)->notifier([&] (const auto &v) { _optimizer_type = v; }),
       "Optimizer type\n"
       "0: SGD (default)\n"

--- a/tests/tools/onert_train/src/args.cc
+++ b/tests/tools/onert_train/src/args.cc
@@ -228,10 +228,9 @@ void Args::Initialize(void)
         "Loss type\n"
         "0: MEAN_SQUARED_ERROR (default)\n"
         "1: CATEGORICAL_CROSSENTROPY\n")
-    ("loss_reduction_type", po::value<int>()->default_value(0)->notifier([&] (const auto &v) { _loss_reduction_type = v; }),
+    ("loss_reduction_type", po::value<int>()->default_value(1)->notifier([&] (const auto &v) { _loss_reduction_type = v; }),
         "Loss Reduction type\n"
-        "0: AUTO (default)\n"
-        "1: SUM_OVER_BATCH_SIZE\n"
+        "1: SUM_OVER_BATCH_SIZE(default)\n"
         "2: SUM\n")
     ("optimizer", po::value<int>()->default_value(0)->notifier([&] (const auto &v) { _optimizer_type = v; }),
       "Optimizer type\n"

--- a/tests/tools/onert_train/src/nnfw_util.cc
+++ b/tests/tools/onert_train/src/nnfw_util.cc
@@ -96,9 +96,6 @@ std::ostream &operator<<(std::ostream &os, const NNFW_TRAIN_LOSS_REDUCTION &loss
     case NNFW_TRAIN_LOSS_REDUCTION_UNDEFINED:
       os << "undefined";
       break;
-    case NNFW_TRAIN_LOSS_REDUCTION_AUTO:
-      os << "use automatic reduction type";
-      break;
     case NNFW_TRAIN_LOSS_REDUCTION_SUM_OVER_BATCH_SIZE:
       os << "sum over batch size";
       break;

--- a/tests/tools/onert_train/src/onert_train.cc
+++ b/tests/tools/onert_train/src/onert_train.cc
@@ -137,9 +137,9 @@ int main(const int argc, char **argv)
     auto convertLossReductionType = [](int type) {
       switch (type)
       {
-        case 0:
-          return NNFW_TRAIN_LOSS_REDUCTION_SUM_OVER_BATCH_SIZE;
         case 1:
+          return NNFW_TRAIN_LOSS_REDUCTION_SUM_OVER_BATCH_SIZE;
+        case 2:
           return NNFW_TRAIN_LOSS_REDUCTION_SUM;
         default:
           std::cerr << "E: not supported loss reduction type" << std::endl;

--- a/tests/tools/onert_train/src/onert_train.cc
+++ b/tests/tools/onert_train/src/onert_train.cc
@@ -137,8 +137,6 @@ int main(const int argc, char **argv)
     auto convertLossReductionType = [](int type) {
       switch (type)
       {
-        case 0:
-          return NNFW_TRAIN_LOSS_REDUCTION_AUTO;
         case 1:
           return NNFW_TRAIN_LOSS_REDUCTION_SUM_OVER_BATCH_SIZE;
         case 2:

--- a/tests/tools/onert_train/src/onert_train.cc
+++ b/tests/tools/onert_train/src/onert_train.cc
@@ -137,9 +137,9 @@ int main(const int argc, char **argv)
     auto convertLossReductionType = [](int type) {
       switch (type)
       {
-        case 1:
+        case 0:
           return NNFW_TRAIN_LOSS_REDUCTION_SUM_OVER_BATCH_SIZE;
-        case 2:
+        case 1:
           return NNFW_TRAIN_LOSS_REDUCTION_SUM;
         default:
           std::cerr << "E: not supported loss reduction type" << std::endl;


### PR DESCRIPTION
This PR removes AUTO from train loss reduction type.

ONE-DCO-1.0-Signed-off-by: SeungHui Youn <sseung.youn@samsung.com>

related issue : https://github.com/Samsung/ONE/issues/12418 