### PR TITLE
[runtime/benchmark] Suppress auto-causes-copy warnings

### DIFF
--- a/runtime/libs/benchmark/src/Result.cpp
+++ b/runtime/libs/benchmark/src/Result.cpp
@@ -157,16 +157,16 @@ namespace benchmark
 
 Result::Result(const Phases &phases)
 {
-  const auto option = phases.option();
+  const auto &option = phases.option();
   {
     for (int i = PhaseEnum::MODEL_LOAD; i <= PhaseEnum::PREPARE; ++i)
     {
-      auto phase = phases.at(gPhaseStrings[i]);
+      const auto &phase = phases.at(gPhaseStrings[i]);
       time[i][FigureType::MEAN] = averageTimeMs(phase);
     }
 
     int i = PhaseEnum::EXECUTE;
-    auto exec_phase = phases.at(gPhaseStrings[i]);
+    const auto &exec_phase = phases.at(gPhaseStrings[i]);
     time[i][FigureType::MEAN] = averageTimeMs(exec_phase);
     time[i][FigureType::MAX] = maxTimeMs(exec_phase);
     time[i][FigureType::MIN] = minTimeMs(exec_phase);
@@ -177,7 +177,7 @@ Result::Result(const Phases &phases)
     print_memory = true;
     for (int i = PhaseEnum::MODEL_LOAD; i < PhaseEnum::EXECUTE; ++i)
     {
-      auto phase = phases.at(gPhaseStrings[i]);
+      const auto &phase = phases.at(gPhaseStrings[i]);
       for (int j = MemoryType::RSS; j <= MemoryType::PSS; ++j)
       {
         memory[i][j] = averageMemoryKb(phase, j);


### PR DESCRIPTION
It makes static analyzer happy by adding & to auto. It will remove unnecessary copy.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>