### PR TITLE
[infra] Install clang-format-16 on docker

### DIFF
--- a/infra/docker/focal/Dockerfile
+++ b/infra/docker/focal/Dockerfile
@@ -38,6 +38,12 @@ RUN apt-get update && \
 RUN python3 -m pip install --upgrade pip
 RUN python3 -m pip install yapf==0.22.0 numpy flatbuffers
 
+# Install clang-format
+RUN apt-get install -qqy gnupg2
+RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+RUN add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-16 main"
+RUN apt-get update && apt-get install -qqy clang-format-16
+
 # Install google test (source)
 RUN apt-get update && apt-get -qqy install libgtest-dev
 

--- a/infra/docker/focal/Dockerfile.aarch64
+++ b/infra/docker/focal/Dockerfile.aarch64
@@ -38,6 +38,12 @@ RUN apt-get update && \
 RUN python3 -m pip install --upgrade pip
 RUN python3 -m pip install yapf==0.22.0 numpy flatbuffers
 
+# Install clang-format
+RUN apt-get install -qqy gnupg2
+RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+RUN add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-16 main"
+RUN apt-get update && apt-get install -qqy clang-format-16
+
 # Install google test (source)
 RUN apt-get update && apt-get -qqy install libgtest-dev
 

--- a/infra/docker/jammy/Dockerfile
+++ b/infra/docker/jammy/Dockerfile
@@ -39,6 +39,12 @@ RUN apt-get update && \
 RUN python3 -m pip install --upgrade pip
 RUN python3 -m pip install yapf==0.22.0 numpy flatbuffers
 
+# Install clang-format
+RUN apt-get install -qqy gnupg2
+RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+RUN add-apt-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main"
+RUN apt-get update && apt-get install -qqy clang-format-16
+
 # Install google test (source)
 RUN apt-get update && apt-get -qqy install libgtest-dev
 

--- a/infra/docker/jammy/Dockerfile.aarch64
+++ b/infra/docker/jammy/Dockerfile.aarch64
@@ -39,6 +39,12 @@ RUN apt-get update && \
 RUN python3 -m pip install --upgrade pip
 RUN python3 -m pip install yapf==0.22.0 numpy flatbuffers
 
+# Install clang-format
+RUN apt-get install -qqy gnupg2
+RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+RUN add-apt-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main"
+RUN apt-get update && apt-get install -qqy clang-format-16
+
 # Install google test (source)
 RUN apt-get update && apt-get -qqy install libgtest-dev
 


### PR DESCRIPTION
This commit updates dockerfile to install clang-format-16.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: #12311