### PR TITLE
[onert] Change metadata pointer type to ExternalData

### DIFF
--- a/runtime/onert/core/include/ir/Model.h
+++ b/runtime/onert/core/include/ir/Model.h
@@ -177,7 +177,7 @@ private:
   std::shared_ptr<backend::custom::IKernelBuilder> _kernel_builder;
 
 public:
-  void add_metadata(const std::string &name, std::unique_ptr<const ir::Data> data)
+  void add_metadata(const std::string &name, std::unique_ptr<const ir::ExternalData> data)
   {
     _metadatas.emplace(name, std::move(data));
   }
@@ -187,8 +187,10 @@ public:
     return _metadatas.find(name) != _metadatas.end();
   }
 
+  bool exists_metadata() const { return _metadatas.size() != 0; }
+
   // NOTE The corresponding metadata is deleted from the model and returned
-  std::unique_ptr<const ir::Data> extract_metadata(const std::string name)
+  std::unique_ptr<const ir::ExternalData> extract_metadata(const std::string name)
   {
     auto m = _metadatas.find(name);
 
@@ -201,7 +203,7 @@ public:
   }
 
 private:
-  std::unordered_map<std::string, std::unique_ptr<const ir::Data>> _metadatas;
+  std::unordered_map<std::string, std::unique_ptr<const ir::ExternalData>> _metadatas;
 };
 } // namespace ir
 } // namespace onert

--- a/runtime/onert/frontend/base_loader/include/base_loader.h
+++ b/runtime/onert/frontend/base_loader/include/base_loader.h
@@ -123,7 +123,7 @@ protected:
   }
 
 private:
-  std::unique_ptr<ir::Data> loadMetadata(const uint32_t buffer_idx);
+  std::unique_ptr<ir::ExternalData> loadMetadata(const uint32_t buffer_idx);
   virtual std::unique_ptr<ir::Graph> loadSubgraph(const SubGraph *subg) = 0;
   // Operations
   template <typename OpIR, typename... Args>
@@ -246,7 +246,7 @@ void BaseLoader<LoaderDomain>::BaseLoader::loadFromBuffer(uint8_t *buffer, size_
 }
 
 template <typename LoaderDomain>
-std::unique_ptr<ir::Data>
+std::unique_ptr<ir::ExternalData>
 BaseLoader<LoaderDomain>::BaseLoader::loadMetadata(const uint32_t buffer_idx)
 {
   assert(_domain_model != nullptr);
@@ -1754,7 +1754,7 @@ template <typename LoaderDomain> void BaseLoader<LoaderDomain>::loadModel()
       if (metadata->name() == nullptr)
         continue; // metadata should have name
 
-      std::unique_ptr<const ir::Data> data = loadMetadata(metadata->buffer());
+      auto data = loadMetadata(metadata->buffer());
       model->add_metadata(metadata->name()->str(), std::move(data));
     }
   }


### PR DESCRIPTION
This commit changes metadata pointer type to ExternalData.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>