### PR TITLE
[DRAFT] Add own shape branch into CircleTransposeConv shape inference

### DIFF
--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -1607,7 +1607,9 @@ loco::NodeShape infer_transpose(const luci::CircleTranspose *node)
 loco::NodeShape infer_transpose_conv(const luci::CircleTransposeConv *node)
 {
   // TransposeConv's output shape is written in its 'inputSizes' argument
-  auto input_sizes_const = loco::must_cast<luci::CircleConst *>(node->inputSizes());
+  auto input_sizes_const = dynamic_cast<luci::CircleConst *>(node->inputSizes());
+  if (not input_sizes_const)
+    return use_own(node);
   // TODO support non-const type
   LUCI_ASSERT(input_sizes_const->dtype() == loco::DataType::S32, "Only support S32 dtype")
   LUCI_ASSERT(input_sizes_const->rank() == 1 && input_sizes_const->dim(0).value() == 4,

--- a/res/TensorFlowLiteRecipes/TransposeConv_002/test.recipe
+++ b/res/TensorFlowLiteRecipes/TransposeConv_002/test.recipe
@@ -1,0 +1,48 @@
+operand {
+  name: "ifm"
+  type: FLOAT32
+  shape { dim: 1 dim: 4 dim: 4 dim: 3 }
+}
+operand {
+  name: "out_shape"
+  type: INT32
+  shape { dim: 4 }
+}
+operand {
+  name: "ker"
+  type: FLOAT32
+  shape { dim: 3 dim: 1 dim: 1 dim: 3 }
+  filler {
+    tag: "gaussian"
+    arg: "0.0"
+    arg: "1.0"
+  }
+}
+operand {
+  name: "ofm"
+  type: FLOAT32
+  shape { dim: 1 dim: 4 dim: 4 dim: 3 }
+}
+operation {
+  type: "Shape"
+  shape_options {
+    out_type: INT32
+  }
+  input: "ifm"
+  output: "out_shape"
+}
+operation {
+  type: "TransposeConv"
+  transpose_conv_options {
+    padding: SAME
+    stride_w: 1
+    stride_h: 1
+    activation: NONE
+  }
+  input: "out_shape"
+  input: "ker"
+  input: "ifm"
+  output: "ofm"
+}
+input: "ifm"
+output: "ofm"


### PR DESCRIPTION
This draft is to add a branch that uses its own shape when one of inputs is not constant in the shape inference of CircleTransposeConv.

Related: https://github.com/Samsung/ONE/issues/12429#issuecomment-1884092665
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>