### PR TITLE
[onert-micro] Reduce duplicate code in arithmetic kernels

### DIFF
--- a/onert-micro/luci-interpreter/pal/common/PALArithmeticOpCommon.h
+++ b/onert-micro/luci-interpreter/pal/common/PALArithmeticOpCommon.h
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef LUCI_INTERPRETER_PAL_ARITHMETICOPCOMMON_H
+#define LUCI_INTERPRETER_PAL_ARITHMETICOPCOMMON_H
+
+#include "Params.h"
+#include "PALUtils.h"
+#include "ProcessBroadcastShapes.h"
+
+namespace luci_interpreter_pal
+{
+
+template <typename T> struct AddFn
+{
+  T operator()(T lhs, T rhs) { return lhs + rhs; }
+};
+template <typename T> struct SubFn
+{
+  T operator()(T lhs, T rhs) { return lhs - rhs; }
+};
+template <typename T> struct MulFn
+{
+  T operator()(T lhs, T rhs) { return lhs * rhs; }
+};
+template <typename T> struct DivFn
+{
+  T operator()(T lhs, T rhs) { return lhs / rhs; }
+};
+
+// TODO: check if there real activation value
+template <typename T, typename Fn>
+inline void ArithmeticOp(const ArithmeticParams &params, const int flat_size, const T *input1_data,
+                         const T *input2_data, T *output_data)
+{
+  T activation_min, activation_max;
+  getActivationParams(params, &activation_min, &activation_max);
+
+  Fn func;
+  for (int i = 0; i < flat_size; ++i)
+    output_data[i] =
+      std::min(std::max(func(input1_data[i], input2_data[i]), activation_min), activation_max);
+}
+
+template <typename T, typename Fn>
+inline void ArithmeticOpScalar(const ArithmeticParams &params, const int flat_size,
+                               const T *input_data, const T scalar_value, T *output_data)
+{
+  T activation_min, activation_max;
+  getActivationParams(params, &activation_min, &activation_max);
+
+  for (int i = 0; i < flat_size; ++i)
+    output_data[i] =
+      std::min(std::max(func(input_data[i], scalar_value), activation_min), activation_max);
+}
+
+template <typename T, typename Fn>
+inline void BroadcastArithmeticOp4DSlow(
+  const ArithmeticParams &params, const luci_interpreter::RuntimeShape &input1_shape,
+  const T *input1_data, const luci_interpreter::RuntimeShape &input2_shape, const T *input2_data,
+  const luci_interpreter::RuntimeShape &output_shape, T *output_data)
+{
+  NdArrayDesc<4> desc1;
+  NdArrayDesc<4> desc2;
+  NdArrayDescsForElementwiseBroadcast(input1_shape, input2_shape, &desc1, &desc2);
+  const luci_interpreter::RuntimeShape extended_output_shape =
+    luci_interpreter::RuntimeShape::extendedShape(4, output_shape);
+
+  T activation_min, activation_max;
+  getActivationParams(params, &activation_min, &activation_max);
+
+  // In Tensorflow, the dimensions are canonically named (batch_number, row,
+  // col, channel), with extents (batches, height, width, depth), with the
+  // trailing dimension changing most rapidly (channels has the smallest stride,
+  // typically 1 element).
+  //
+  // In generated C code, we store arrays with the dimensions reversed. The
+  // first dimension has smallest stride.
+  //
+  // We name our variables by their Tensorflow convention, but generate C code
+  // nesting loops such that the innermost loop has the smallest stride for the
+  // best cache behavior.
+  Fn func;
+  for (int b = 0; b < extended_output_shape.dims(0); ++b)
+  {
+    for (int y = 0; y < extended_output_shape.dims(1); ++y)
+    {
+      for (int x = 0; x < extended_output_shape.dims(2); ++x)
+      {
+        for (int c = 0; c < extended_output_shape.dims(3); ++c)
+        {
+          const int output_data_offset =
+            ((b * extended_output_shape.dims(1) + y) * extended_output_shape.dims(2) + x) *
+              extended_output_shape.dims(3) +
+            c;
+
+          output_data[output_data_offset] =
+            std::min(std::max(func(input1_data[subscriptToIndex(desc1, b, y, x, c)],
+                                   input2_data[subscriptToIndex(desc2, b, y, x, c)]),
+                              activation_min),
+                     activation_max);
+        }
+      }
+    }
+  }
+}
+
+} // namespace luci_interpreter_pal
+
+#endif // LUCI_INTERPRETER_PAL_ARITHMETICOPCOMMON_H

--- a/onert-micro/luci-interpreter/pal/common/PALDiv.h
+++ b/onert-micro/luci-interpreter/pal/common/PALDiv.h
@@ -18,9 +18,7 @@
 #ifndef LUCI_INTERPRETER_PAL_DIV_COMMON_H
 #define LUCI_INTERPRETER_PAL_DIV_COMMON_H
 
-#include "Params.h"
-#include "PALUtils.h"
-#include "ProcessBroadcastShapes.h"
+#include "PALArithmeticOpCommon.h"
 
 namespace luci_interpreter_pal
 {
@@ -28,24 +26,14 @@ template <typename T>
 inline void Div(const ArithmeticParams &params, const int flat_size, const T *input1_data,
                 const T *input2_data, T *output_data)
 {
-  T activation_min, activation_max;
-  getActivationParams(params, &activation_min, &activation_max);
-
-  for (int i = 0; i < flat_size; ++i)
-    output_data[i] =
-      std::min(std::max(input1_data[i] / input2_data[i], activation_min), activation_max);
+  ArithmeticOp<T, DivFn<T>>(params, flat_size, input1_data, input2_data, output_data);
 }
 
 template <typename T>
 inline void DivScalar(const ArithmeticParams &params, const int flat_size, const T *input_data,
                       const T scalar_value, T *output_data)
 {
-  T activation_min, activation_max;
-  getActivationParams(params, &activation_min, &activation_max);
-
-  for (int i = 0; i < flat_size; ++i)
-    output_data[i] =
-      std::min(std::max(input_data[i] / scalar_value, activation_min), activation_max);
+  ArithmeticOpScalar<T, DivFn<T>>(params, flat_size, input_data, scalar_value, output_data);
 }
 
 template <typename T>
@@ -55,59 +43,8 @@ BroadcastDiv4DSlow(const ArithmeticParams &params,
                    const luci_interpreter::RuntimeShape &input2_shape, const T *input2_data,
                    const luci_interpreter::RuntimeShape &output_shape, T *output_data)
 {
-  const int flat_size = input1_shape.flatSize();
-
-  if (params.broadcast_category == BroadcastableOpCategory::kScalarFirstBroadcast)
-  {
-    return DivScalar(params, flat_size, input2_data, input1_data[0], output_data);
-  }
-  else if (params.broadcast_category == BroadcastableOpCategory::kScalarSecondBroadcast)
-  {
-    return DivScalar(params, flat_size, input1_data, input2_data[0], output_data);
-  }
-
-  NdArrayDesc<4> desc1;
-  NdArrayDesc<4> desc2;
-  NdArrayDescsForElementwiseBroadcast(input1_shape, input2_shape, &desc1, &desc2);
-  const luci_interpreter::RuntimeShape extended_output_shape =
-    luci_interpreter::RuntimeShape::extendedShape(4, output_shape);
-
-  T activation_min, activation_max;
-  getActivationParams(params, &activation_min, &activation_max);
-
-  // In Tensorflow, the dimensions are canonically named (batch_number, row,
-  // col, channel), with extents (batches, height, width, depth), with the
-  // trailing dimension changing most rapidly (channels has the smallest stride,
-  // typically 1 element).
-  //
-  // In generated C code, we store arrays with the dimensions reversed. The
-  // first dimension has smallest stride.
-  //
-  // We name our variables by their Tensorflow convention, but generate C code
-  // nesting loops such that the innermost loop has the smallest stride for the
-  // best cache behavior.
-  for (int b = 0; b < extended_output_shape.dims(0); ++b)
-  {
-    for (int y = 0; y < extended_output_shape.dims(1); ++y)
-    {
-      for (int x = 0; x < extended_output_shape.dims(2); ++x)
-      {
-        for (int c = 0; c < extended_output_shape.dims(3); ++c)
-        {
-          const int output_data_offset =
-            ((b * extended_output_shape.dims(1) + y) * extended_output_shape.dims(2) + x) *
-              extended_output_shape.dims(3) +
-            c;
-
-          output_data[output_data_offset] =
-            std::min(std::max(input1_data[subscriptToIndex(desc1, b, y, x, c)] /
-                                input2_data[subscriptToIndex(desc2, b, y, x, c)],
-                              activation_min),
-                     activation_max);
-        }
-      }
-    }
-  }
+  BroadcastArithmeticOp4DSlow<T, DivFn<T>>(params, input1_shape, input1_data, input2_shape,
+                                           input2_data, output_shape, output_data);
 }
 
 } // namespace luci_interpreter_pal

--- a/onert-micro/luci-interpreter/pal/common/PALMulCommon.h
+++ b/onert-micro/luci-interpreter/pal/common/PALMulCommon.h
@@ -18,9 +18,7 @@
 #ifndef LUCI_INTERPRETER_PAL_MUL_COMMON_H
 #define LUCI_INTERPRETER_PAL_MUL_COMMON_H
 
-#include "Params.h"
-#include "PALUtils.h"
-#include "ProcessBroadcastShapes.h"
+#include "PALArithmeticOpCommon.h"
 
 namespace luci_interpreter_pal
 {
@@ -28,24 +26,14 @@ template <typename T>
 inline void Mul(const ArithmeticParams &params, const int flat_size, const T *input1_data,
                 const T *input2_data, T *output_data)
 {
-  T activation_min, activation_max;
-  getActivationParams(params, &activation_min, &activation_max);
-
-  for (int i = 0; i < flat_size; ++i)
-    output_data[i] =
-      std::min(std::max(input1_data[i] * input2_data[i], activation_min), activation_max);
+  ArithmeticOp<T, MulFn<T>>(params, flat_size, input1_data, input2_data, output_data);
 }
 
 template <typename T>
 inline void MulScalar(const ArithmeticParams &params, const int flat_size, const T *input_data,
                       const T scalar_value, T *output_data)
 {
-  T activation_min, activation_max;
-  getActivationParams(params, &activation_min, &activation_max);
-
-  for (int i = 0; i < flat_size; ++i)
-    output_data[i] =
-      std::min(std::max(input_data[i] * scalar_value, activation_min), activation_max);
+  ArithmeticOpScalar<T, MulFn<T>>(params, flat_size, input_data, scalar_value, output_data);
 }
 
 template <typename T>
@@ -55,59 +43,8 @@ BroadcastMul4DSlow(const ArithmeticParams &params,
                    const luci_interpreter::RuntimeShape &input2_shape, const T *input2_data,
                    const luci_interpreter::RuntimeShape &output_shape, T *output_data)
 {
-  const int flat_size = input1_shape.flatSize();
-
-  if (params.broadcast_category == BroadcastableOpCategory::kScalarFirstBroadcast)
-  {
-    return MulScalar(params, flat_size, input2_data, input1_data[0], output_data);
-  }
-  else if (params.broadcast_category == BroadcastableOpCategory::kScalarSecondBroadcast)
-  {
-    return MulScalar(params, flat_size, input1_data, input2_data[0], output_data);
-  }
-
-  NdArrayDesc<4> desc1;
-  NdArrayDesc<4> desc2;
-  NdArrayDescsForElementwiseBroadcast(input1_shape, input2_shape, &desc1, &desc2);
-  const luci_interpreter::RuntimeShape extended_output_shape =
-    luci_interpreter::RuntimeShape::extendedShape(4, output_shape);
-
-  T activation_min, activation_max;
-  getActivationParams(params, &activation_min, &activation_max);
-
-  // In Tensorflow, the dimensions are canonically named (batch_number, row,
-  // col, channel), with extents (batches, height, width, depth), with the
-  // trailing dimension changing most rapidly (channels has the smallest stride,
-  // typically 1 element).
-  //
-  // In generated C code, we store arrays with the dimensions reversed. The
-  // first dimension has smallest stride.
-  //
-  // We name our variables by their Tensorflow convention, but generate C code
-  // nesting loops such that the innermost loop has the smallest stride for the
-  // best cache behavior.
-  for (int b = 0; b < extended_output_shape.dims(0); ++b)
-  {
-    for (int y = 0; y < extended_output_shape.dims(1); ++y)
-    {
-      for (int x = 0; x < extended_output_shape.dims(2); ++x)
-      {
-        for (int c = 0; c < extended_output_shape.dims(3); ++c)
-        {
-          const int output_data_offset =
-            ((b * extended_output_shape.dims(1) + y) * extended_output_shape.dims(2) + x) *
-              extended_output_shape.dims(3) +
-            c;
-
-          output_data[output_data_offset] =
-            std::min(std::max(input1_data[subscriptToIndex(desc1, b, y, x, c)] *
-                                input2_data[subscriptToIndex(desc2, b, y, x, c)],
-                              activation_min),
-                     activation_max);
-        }
-      }
-    }
-  }
+  BroadcastArithmeticOp4DSlow<T, MulFn<T>>(params, input1_shape, input1_data, input2_shape,
+                                           input2_data, output_shape, output_data);
 }
 
 } // namespace luci_interpreter_pal

--- a/onert-micro/luci-interpreter/pal/common/PALSub.h
+++ b/onert-micro/luci-interpreter/pal/common/PALSub.h
@@ -17,7 +17,7 @@
 #ifndef LUCI_INTERPRETER_PAL_SUB_COMMON_H
 #define LUCI_INTERPRETER_PAL_SUB_COMMON_H
 
-#include "PALUtils.h"
+#include "PALArithmeticOpCommon.h"
 
 namespace luci_interpreter_pal
 {
@@ -25,12 +25,7 @@ template <typename T>
 static inline void Sub(const ArithmeticParams &params, const int flat_size, const T *input1_data,
                        const T *input2_data, T *output_data)
 {
-  T activation_min, activation_max;
-  getActivationParams(params, &activation_min, &activation_max);
-
-  for (int i = 0; i < flat_size; ++i)
-    output_data[i] =
-      std::min(std::max(input1_data[i] - input2_data[i], activation_min), activation_max);
+  ArithmeticOp<T, SubFn<T>>(params, flat_size, input1_data, input2_data, output_data);
 }
 
 template <typename T>
@@ -40,48 +35,8 @@ BroadcastSub4DSlow(const ArithmeticParams &params,
                    const luci_interpreter::RuntimeShape &input2_shape, const T *input2_data,
                    const luci_interpreter::RuntimeShape &output_shape, T *output_data)
 {
-  NdArrayDesc<4> desc1;
-  NdArrayDesc<4> desc2;
-  NdArrayDescsForElementwiseBroadcast(input1_shape, input2_shape, &desc1, &desc2);
-  const luci_interpreter::RuntimeShape extended_output_shape =
-    luci_interpreter::RuntimeShape::extendedShape(4, output_shape);
-
-  T activation_min, activation_max;
-  getActivationParams(params, &activation_min, &activation_max);
-
-  // In Tensorflow, the dimensions are canonically named (batch_number, row,
-  // col, channel), with extents (batches, height, width, depth), with the
-  // trailing dimension changing most rapidly (channels has the smallest stride,
-  // typically 1 element).
-  //
-  // In generated C code, we store arrays with the dimensions reversed. The
-  // first dimension has smallest stride.
-  //
-  // We name our variables by their Tensorflow convention, but generate C code
-  // nesting loops such that the innermost loop has the smallest stride for the
-  // best cache behavior.
-  for (int b = 0; b < extended_output_shape.dims(0); ++b)
-  {
-    for (int y = 0; y < extended_output_shape.dims(1); ++y)
-    {
-      for (int x = 0; x < extended_output_shape.dims(2); ++x)
-      {
-        for (int c = 0; c < extended_output_shape.dims(3); ++c)
-        {
-          const int output_data_offset =
-            ((b * extended_output_shape.dims(1) + y) * extended_output_shape.dims(2) + x) *
-              extended_output_shape.dims(3) +
-            c;
-
-          output_data[output_data_offset] =
-            std::min(std::max(input1_data[subscriptToIndex(desc1, b, y, x, c)] -
-                                input2_data[subscriptToIndex(desc2, b, y, x, c)],
-                              activation_min),
-                     activation_max);
-        }
-      }
-    }
-  }
+  BroadcastArithmeticOp4DSlow<T, SubFn<T>>(params, input1_shape, input1_data, input2_shape,
+                                           input2_data, output_shape, output_data);
 }
 
 } // namespace luci_interpreter_pal

--- a/onert-micro/luci-interpreter/src/kernels/Add.test.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/Add.test.cpp
@@ -15,12 +15,18 @@
  * limitations under the License.
  */
 
+#include "BinaryOpCommon.h"
 #include "kernels/TestUtils.h"
 #include "luci_interpreter/test_models/add/FloatAddKernel.h"
 #include "luci_interpreter/test_models/add/IntAddKernel.h"
 #include "luci_interpreter/test_models/add/NegAddKernel.h"
 
 #include "loader/ModuleLoader.h"
+
+#include "PALAdd.h"
+
+#include <array>
+#include <numeric>
 
 namespace luci_interpreter
 {
@@ -164,13 +170,6 @@ TEST_F(AddTest, No_quant_params_NEG)
 
 } // namespace
 } // namespace luci_interpreter
-
-#include "PALAdd.h"
-
-#include "BinaryOpCommon.h"
-
-#include <array>
-#include <numeric>
 
 namespace luci_interpreter
 {

--- a/onert-micro/luci-interpreter/src/kernels/Add.test.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/Add.test.cpp
@@ -164,3 +164,79 @@ TEST_F(AddTest, No_quant_params_NEG)
 
 } // namespace
 } // namespace luci_interpreter
+
+#include "PALAdd.h"
+
+#include "BinaryOpCommon.h"
+
+#include <array>
+#include <numeric>
+
+namespace luci_interpreter
+{
+namespace
+{
+
+class PALAddTest : public ::testing::Test
+{
+  // Do nothing
+};
+
+TEST_F(PALAddTest, Float_P)
+{
+  // No broadcast
+  {
+    const bool is_with_broadcast = false;
+    test_kernel::TestDataFloatAdd test_data_float_add_no_broadcasting(is_with_broadcast);
+
+    luci_interpreter_pal::ArithmeticParams params{};
+    kernels::fillArithmeticActivationRange<float>(params, kernels::Activation::NONE);
+
+    const auto &input1 = test_data_float_add_no_broadcasting.get_input_data_by_index(0);
+    const auto &input2 = test_data_float_add_no_broadcasting.get_input_data_by_index(1);
+
+    const auto num_elements = input1.size();
+    EXPECT_EQ(num_elements, input2.size());
+
+    std::vector<float> output = std::vector<float>(num_elements);
+    luci_interpreter_pal::Add<float>(params, num_elements, input1.data(), input2.data(),
+                                     output.data());
+
+    EXPECT_THAT(output,
+                kernels::testing::FloatArrayNear(
+                  test_data_float_add_no_broadcasting.get_output_data_by_index(0), 0.0001f));
+  }
+
+  // With broadcast
+  {
+    const bool is_with_broadcast = true;
+    test_kernel::TestDataFloatAdd test_data_float_add_with_broadcasting(is_with_broadcast);
+
+    luci_interpreter_pal::ArithmeticParams params{};
+    kernels::fillArithmeticActivationRange<float>(params, kernels::Activation::NONE);
+
+    const auto &input1 = test_data_float_add_with_broadcasting.get_input_data_by_index(0);
+    const auto &input2 = test_data_float_add_with_broadcasting.get_input_data_by_index(1);
+
+    const int32_t shape[2] = {2, 5};
+    const int32_t shape_broadcast[2] = {2, 1};
+
+    assert(input1.size() ==
+           std::accumulate(std::begin(shape), std::end(shape), 1, std::multiplies<float>()));
+    assert(input2.size() == std::accumulate(std::begin(shape_broadcast), std::end(shape_broadcast),
+                                            1, std::multiplies<float>()));
+
+    std::vector<float> output = std::vector<float>(
+      std::accumulate(std::begin(shape), std::end(shape), 1, std::multiplies<float>()));
+    luci_interpreter_pal::BroadcastAdd4DSlow<float>(
+      params, RuntimeShape{2, shape}, input1.data(), RuntimeShape{2, shape_broadcast},
+      input2.data(), RuntimeShape{2, shape}, const_cast<float *>(output.data()));
+
+    EXPECT_THAT(output,
+                kernels::testing::FloatArrayNear(
+                  test_data_float_add_with_broadcasting.get_output_data_by_index(0), 0.0001f));
+  }
+}
+
+} // namespace
+} // namespace luci_interpreter

--- a/onert-micro/luci-interpreter/src/kernels/BinaryOpCommon.h
+++ b/onert-micro/luci-interpreter/src/kernels/BinaryOpCommon.h
@@ -19,8 +19,8 @@
 #define LUCI_INTERPRETER_KERNELS_BINARYOPUTILS_H
 
 #include "TISOKernel.h"
+#include "Params.h"
 #include "ProcessBroadcastShapes.h"
-
 #include "Utils.h"
 
 namespace luci_interpreter

--- a/onert-micro/luci-interpreter/src/kernels/Div.test.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/Div.test.cpp
@@ -120,3 +120,77 @@ TEST_F(DivTest, Wrong_Input2_Type_NEG)
 
 } // namespace
 } // namespace luci_interpreter
+
+#include "PALDiv.h"
+
+#include "BinaryOpCommon.h"
+
+#include <array>
+#include <numeric>
+
+namespace luci_interpreter
+{
+namespace
+{
+
+class PALDivTest : public ::testing::Test
+{
+  // Do nothing
+};
+
+TEST_F(PALDivTest, Float_P)
+{
+  // No broadcast
+  {
+    const bool is_with_broadcast = false;
+    test_kernel::TestDataFloatDiv test_data_kernel(is_with_broadcast);
+
+    luci_interpreter_pal::ArithmeticParams params{};
+    kernels::fillArithmeticActivationRange<float>(params, kernels::Activation::NONE);
+
+    const auto &input1 = test_data_kernel.get_input_data_by_index(0);
+    const auto &input2 = test_data_kernel.get_input_data_by_index(1);
+
+    const auto num_elements = input1.size();
+    EXPECT_EQ(num_elements, input2.size());
+
+    std::vector<float> output = std::vector<float>(num_elements);
+    luci_interpreter_pal::Div<float>(params, num_elements, input1.data(), input2.data(),
+                                     const_cast<float *>(output.data()));
+
+    EXPECT_THAT(output, kernels::testing::FloatArrayNear(
+                          test_data_kernel.get_output_data_by_index(0), 0.0001f));
+  }
+
+  // With broadcast
+  {
+    const bool is_with_broadcast = true;
+    test_kernel::TestDataFloatDiv test_data_kernel(is_with_broadcast);
+
+    luci_interpreter_pal::ArithmeticParams params{};
+    kernels::fillArithmeticActivationRange<float>(params, kernels::Activation::NONE);
+
+    const auto &input1 = test_data_kernel.get_input_data_by_index(0);
+    const auto &input2 = test_data_kernel.get_input_data_by_index(1);
+
+    const int32_t shape[2] = {2, 5};
+    const int32_t shape_broadcast[2] = {2, 1};
+
+    assert(input1.size() ==
+           std::accumulate(std::begin(shape), std::end(shape), 1, std::multiplies<float>()));
+    assert(input2.size() == std::accumulate(std::begin(shape_broadcast), std::end(shape_broadcast),
+                                            1, std::multiplies<float>()));
+
+    std::vector<float> output = std::vector<float>(
+      std::accumulate(std::begin(shape), std::end(shape), 1, std::multiplies<float>()));
+    luci_interpreter_pal::BroadcastDiv4DSlow<float>(
+      params, RuntimeShape{2, shape}, input1.data(), RuntimeShape{2, shape_broadcast},
+      input2.data(), RuntimeShape{2, shape}, const_cast<float *>(output.data()));
+
+    EXPECT_THAT(output, kernels::testing::FloatArrayNear(
+                          test_data_kernel.get_output_data_by_index(0), 0.0001f));
+  }
+}
+
+} // namespace
+} // namespace luci_interpreter

--- a/onert-micro/luci-interpreter/src/kernels/Div.test.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/Div.test.cpp
@@ -15,11 +15,17 @@
  * limitations under the License.
  */
 
+#include "BinaryOpCommon.h"
 #include "kernels/TestUtils.h"
 #include "luci_interpreter/test_models/div/FloatDivKernel.h"
 #include "luci_interpreter/test_models/div/NegDivKernel.h"
 
 #include "loader/ModuleLoader.h"
+
+#include "PALDiv.h"
+
+#include <array>
+#include <numeric>
 
 namespace luci_interpreter
 {
@@ -120,13 +126,6 @@ TEST_F(DivTest, Wrong_Input2_Type_NEG)
 
 } // namespace
 } // namespace luci_interpreter
-
-#include "PALDiv.h"
-
-#include "BinaryOpCommon.h"
-
-#include <array>
-#include <numeric>
 
 namespace luci_interpreter
 {

--- a/onert-micro/luci-interpreter/src/kernels/Mul.test.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/Mul.test.cpp
@@ -15,12 +15,18 @@
  * limitations under the License.
  */
 
+#include "BinaryOpCommon.h"
 #include "kernels/TestUtils.h"
 #include "luci_interpreter/test_models/mul/FloatMulKernel.h"
 #include "luci_interpreter/test_models/mul/IntMulKernel.h"
 #include "luci_interpreter/test_models/mul/NegMulKernel.h"
 
 #include "loader/ModuleLoader.h"
+
+#include "PALMul.h"
+
+#include <array>
+#include <numeric>
 
 namespace luci_interpreter
 {
@@ -153,13 +159,6 @@ TEST_F(MulTest, Wrong_Ouput_Type_NEG)
 
 } // namespace
 } // namespace luci_interpreter
-
-#include "PALMul.h"
-
-#include "BinaryOpCommon.h"
-
-#include <array>
-#include <numeric>
 
 namespace luci_interpreter
 {

--- a/onert-micro/luci-interpreter/src/kernels/Mul.test.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/Mul.test.cpp
@@ -153,3 +153,77 @@ TEST_F(MulTest, Wrong_Ouput_Type_NEG)
 
 } // namespace
 } // namespace luci_interpreter
+
+#include "PALMul.h"
+
+#include "BinaryOpCommon.h"
+
+#include <array>
+#include <numeric>
+
+namespace luci_interpreter
+{
+namespace
+{
+
+class PALMulTest : public ::testing::Test
+{
+  // Do nothing
+};
+
+TEST_F(PALMulTest, Float_P)
+{
+  // No broadcast
+  {
+    const bool is_with_broadcast = false;
+    test_kernel::TestDataFloatMul test_data_kernel(is_with_broadcast);
+
+    luci_interpreter_pal::ArithmeticParams params{};
+    kernels::fillArithmeticActivationRange<float>(params, kernels::Activation::NONE);
+
+    const auto &input1 = test_data_kernel.get_input_data_by_index(0);
+    const auto &input2 = test_data_kernel.get_input_data_by_index(1);
+
+    const auto num_elements = input1.size();
+    EXPECT_EQ(num_elements, input2.size());
+
+    std::vector<float> output = std::vector<float>(num_elements);
+    luci_interpreter_pal::Mul<float>(params, num_elements, input1.data(), input2.data(),
+                                     const_cast<float *>(output.data()));
+
+    EXPECT_THAT(output, kernels::testing::FloatArrayNear(
+                          test_data_kernel.get_output_data_by_index(0), 0.0001f));
+  }
+
+  // With broadcast
+  {
+    const bool is_with_broadcast = true;
+    test_kernel::TestDataFloatMul test_data_kernel(is_with_broadcast);
+
+    luci_interpreter_pal::ArithmeticParams params{};
+    kernels::fillArithmeticActivationRange<float>(params, kernels::Activation::NONE);
+
+    const auto &input1 = test_data_kernel.get_input_data_by_index(0);
+    const auto &input2 = test_data_kernel.get_input_data_by_index(1);
+
+    const int32_t shape[2] = {2, 5};
+    const int32_t shape_broadcast[2] = {2, 1};
+
+    assert(input1.size() ==
+           std::accumulate(std::begin(shape), std::end(shape), 1, std::multiplies<float>()));
+    assert(input2.size() == std::accumulate(std::begin(shape_broadcast), std::end(shape_broadcast),
+                                            1, std::multiplies<float>()));
+
+    std::vector<float> output = std::vector<float>(
+      std::accumulate(std::begin(shape), std::end(shape), 1, std::multiplies<float>()));
+    luci_interpreter_pal::BroadcastMul4DSlow<float>(
+      params, RuntimeShape{2, shape}, input1.data(), RuntimeShape{2, shape_broadcast},
+      input2.data(), RuntimeShape{2, shape}, const_cast<float *>(output.data()));
+
+    EXPECT_THAT(output, kernels::testing::FloatArrayNear(
+                          test_data_kernel.get_output_data_by_index(0), 0.0001f));
+  }
+}
+
+} // namespace
+} // namespace luci_interpreter

--- a/onert-micro/luci-interpreter/src/kernels/Sub.test.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/Sub.test.cpp
@@ -15,12 +15,18 @@
  * limitations under the License.
  */
 
+#include "BinaryOpCommon.h"
 #include "kernels/TestUtils.h"
 #include "luci_interpreter/test_models/sub/FloatSubKernel.h"
 #include "luci_interpreter/test_models/sub/IntSubKernel.h"
 #include "luci_interpreter/test_models/sub/NegSubKernel.h"
 
 #include "loader/ModuleLoader.h"
+
+#include "PALSub.h"
+
+#include <array>
+#include <numeric>
 
 namespace luci_interpreter
 {
@@ -150,13 +156,6 @@ TEST_F(SubTest, No_quant_params_NEG)
 
 } // namespace
 } // namespace luci_interpreter
-
-#include "PALSub.h"
-
-#include "BinaryOpCommon.h"
-
-#include <array>
-#include <numeric>
 
 namespace luci_interpreter
 {

--- a/onert-micro/luci-interpreter/src/kernels/Sub.test.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/Sub.test.cpp
@@ -150,3 +150,77 @@ TEST_F(SubTest, No_quant_params_NEG)
 
 } // namespace
 } // namespace luci_interpreter
+
+#include "PALSub.h"
+
+#include "BinaryOpCommon.h"
+
+#include <array>
+#include <numeric>
+
+namespace luci_interpreter
+{
+namespace
+{
+
+class PALSubTest : public ::testing::Test
+{
+  // Do nothing
+};
+
+TEST_F(PALSubTest, Float_P)
+{
+  // No broadcast
+  {
+    const bool is_with_broadcast = false;
+    test_kernel::TestDataFloatSub test_data_kernel(is_with_broadcast);
+
+    luci_interpreter_pal::ArithmeticParams params{};
+    kernels::fillArithmeticActivationRange<float>(params, kernels::Activation::NONE);
+
+    const auto &input1 = test_data_kernel.get_input_data_by_index(0);
+    const auto &input2 = test_data_kernel.get_input_data_by_index(1);
+
+    const auto num_elements = input1.size();
+    EXPECT_EQ(num_elements, input2.size());
+
+    std::vector<float> output = std::vector<float>(num_elements);
+    luci_interpreter_pal::Sub<float>(params, num_elements, input1.data(), input2.data(),
+                                     const_cast<float *>(output.data()));
+
+    EXPECT_THAT(output, kernels::testing::FloatArrayNear(
+                          test_data_kernel.get_output_data_by_index(0), 0.0001f));
+  }
+
+  // With broadcast
+  {
+    const bool is_with_broadcast = true;
+    test_kernel::TestDataFloatSub test_data_kernel(is_with_broadcast);
+
+    luci_interpreter_pal::ArithmeticParams params{};
+    kernels::fillArithmeticActivationRange<float>(params, kernels::Activation::NONE);
+
+    const auto &input1 = test_data_kernel.get_input_data_by_index(0);
+    const auto &input2 = test_data_kernel.get_input_data_by_index(1);
+
+    const int32_t shape[2] = {2, 5};
+    const int32_t shape_broadcast[2] = {2, 1};
+
+    assert(input1.size() ==
+           std::accumulate(std::begin(shape), std::end(shape), 1, std::multiplies<float>()));
+    assert(input2.size() == std::accumulate(std::begin(shape_broadcast), std::end(shape_broadcast),
+                                            1, std::multiplies<float>()));
+
+    std::vector<float> output = std::vector<float>(
+      std::accumulate(std::begin(shape), std::end(shape), 1, std::multiplies<float>()));
+    luci_interpreter_pal::BroadcastSub4DSlow<float>(
+      params, RuntimeShape{2, shape}, input1.data(), RuntimeShape{2, shape_broadcast},
+      input2.data(), RuntimeShape{2, shape}, const_cast<float *>(output.data()));
+
+    EXPECT_THAT(output, kernels::testing::FloatArrayNear(
+                          test_data_kernel.get_output_data_by_index(0), 0.0001f));
+  }
+}
+
+} // namespace
+} // namespace luci_interpreter


### PR DESCRIPTION
This commit reduces duplicate code in arithmetic kernels.
  - Introduce PALArithmeticOpCommon.h that has common functions for arithmetic kernels. - Introduce arithmetic function objects. 
    - Introduce `ArithmeticOp()` that unifies artithmetic kernels without broadcast. 
    - Introduce `BroadcastArithmeticOp4DSlow()` that unifies artithmetic kernels with broadcast.
  - Apply common functions for arithmetic kernels.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>

---

For #11744 