### PR TITLE
[infra] Prepare clang-format version migration

### DIFF
--- a/.clang-format.16
+++ b/.clang-format.16
@@ -1,0 +1,93 @@
+Language:        Cpp
+BasedOnStyle: Google
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignEscapedNewlinesLeft: true
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: false
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterClass:             true
+  AfterCaseLabel:         true
+  AfterControlStatement:  true
+  AfterEnum:              true
+  AfterFunction:          true
+  AfterNamespace:         true
+  AfterObjCDeclaration:   false
+  AfterStruct:            true
+  AfterUnion:             false
+  AfterExternBlock:       false
+  BeforeCatch:            true
+  BeforeElse:             true
+  IndentBraces:           false
+BreakBeforeBraces: Custom
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     100
+CommentPragmas:  '^ IWYU pragma:'
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 2
+ContinuationIndentWidth: 2
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+  - Regex:           '^(<|"(gtest|isl|json)/)'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        1
+IndentCaseLabels: true
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Right
+ReflowComments:  true
+SortIncludes:    false
+SortUsingDeclarations: false
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+TabWidth:        2
+UseTab:          Never

--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -36,6 +36,11 @@ jobs:
           python -m pip install --upgrade pip
           pip install yapf==0.22.0
 
+          sudo apt-get install -y gnupg2 software-properties-common
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          sudo add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-16 main"
+          sudo apt-get update && sudo apt-get install -qqy clang-format-16
+
       - name: Check
         run: ./nnas format
 

--- a/infra/command/format
+++ b/infra/command/format
@@ -121,6 +121,20 @@ function check_cpp_files() {
     exit 1
   fi
 
+  # TODO Remove after migration
+  CLANG_FORMAT_MIGRATE=clang-format-16
+  if ! command_exists $CLANG_FORMAT_MIGRATE ; then
+    echo "[ERROR] $CLANG_FORMAT_MIGRATE is unavailable"
+    echo
+    echo "        Cannot find $CLANG_FORMAT_MIGRATE"
+    echo "        Please refer https://github.com/Samsung/ONE/issues/12311#issuecomment-1857503157 to install $CLANG_FORMAT_MIGRATE"
+    echo "        If you use docker for format checking, please pull or build latest version"
+    exit 1
+  fi
+  for DIR_CLANG_FORMAT_MIGRATE in $(git ls-files -co --exclude-standard '*/.clang-format'); do
+    DIRECTORIES_USE_CLANG_FORMAT_MIGRATE+=($(dirname "${DIR_CLANG_FORMAT_MIGRATE}"))
+  done
+
   # Check c++ files: replace ' ' with newline, check with grep
   FILES_TO_CHECK_CPP=`echo "$FILES_TO_CHECK" | tr ' ' '\n' | egrep '((\.c[cl]?)|(\.cpp)|(\.h(pp)?))$'`
   # Manually ignore style checking
@@ -133,8 +147,25 @@ function check_cpp_files() {
     FILES_TO_CHECK_CPP=(${FILES_TO_CHECK_CPP[*]/$s*/})
   done
 
+  # Divide for new version
+  # TODO Remove after migration
+  for s in ${DIRECTORIES_USE_CLANG_FORMAT_MIGRATE[@]}; do
+    FILES_TO_CHECK_CPP_NEW=(${FILES_TO_CHECK_CPP[*]/$s*/})
+  done
+  FILES_TO_CHECK_CPP_MIGRATE=(`echo ${FILES_TO_CHECK_CPP[@]} ${FILES_TO_CHECK_CPP_NEW[@]} | tr ' ' '\n' | sort | uniq -u`)
+  FILES_TO_CHECK_CPP=("${FILES_TO_CHECK_CPP_NEW[@]}")
+
   if [[ ${#FILES_TO_CHECK_CPP} -ne 0 ]]; then
     ${CLANG_FORMAT} -i ${FILES_TO_CHECK_CPP[@]}
+    EXIT_CODE=$?
+    if [[ ${EXIT_CODE} -ne 0 ]]; then
+      INVALID_EXIT=${EXIT_CODE}
+    fi
+  fi
+
+  # TODO Remove after migration
+  if [[ ${#FILES_TO_CHECK_CPP_MIGRATE} -ne 0 ]]; then
+    ${CLANG_FORMAT_MIGRATE} -i ${FILES_TO_CHECK_CPP_MIGRATE[@]}
     EXIT_CODE=$?
     if [[ ${EXIT_CODE} -ne 0 ]]; then
       INVALID_EXIT=${EXIT_CODE}

--- a/runtime/service/.clang-format
+++ b/runtime/service/.clang-format
@@ -1,0 +1,1 @@
+../../.clang-format.16


### PR DESCRIPTION
This commit updates format checker and github action workflow to use clang-format 16.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: #12311