### PR TITLE
[tflite_comparator] Remove unused header

### DIFF
--- a/tests/tools/tflite_comparator/CMakeLists.txt
+++ b/tests/tools/tflite_comparator/CMakeLists.txt
@@ -11,13 +11,13 @@ endif(NOT BUILD_ONERT)
 list(APPEND SOURCES "src/tflite_comparator.cc")
 list(APPEND SOURCES "src/args.cc")
 
-nnfw_find_package(Boost REQUIRED program_options system filesystem)
+nnfw_find_package(Boost REQUIRED program_options)
 
 add_executable(tflite_comparator ${SOURCES})
 target_include_directories(tflite_comparator PRIVATE ${Boost_INCLUDE_DIRS})
 
 target_link_libraries(tflite_comparator nnfw-dev)
 target_link_libraries(tflite_comparator nnfw_lib_tflite nnfw_lib_misc)
-target_link_libraries(tflite_comparator ${Boost_PROGRAM_OPTIONS_LIBRARY} ${Boost_SYSTEM_LIBRARY} ${Boost_FILESYSTEM_LIBRARY})
+target_link_libraries(tflite_comparator ${Boost_PROGRAM_OPTIONS_LIBRARY})
 
 install(TARGETS tflite_comparator DESTINATION bin)

--- a/tests/tools/tflite_comparator/src/args.cc
+++ b/tests/tools/tflite_comparator/src/args.cc
@@ -18,8 +18,6 @@
 
 #include <iostream>
 
-#include <boost/filesystem.hpp>
-
 namespace TFLiteRun
 {
 


### PR DESCRIPTION
This commit removes unused boost filesystem header and dependency.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Found this on #12423