### PR TITLE
[res] Introduce TransposeConv_002

### DIFF
--- a/res/TensorFlowLiteRecipes/TransposeConv_002/test.recipe
+++ b/res/TensorFlowLiteRecipes/TransposeConv_002/test.recipe
@@ -1,0 +1,48 @@
+operand {
+  name: "ifm"
+  type: FLOAT32
+  shape { dim: 1 dim: 4 dim: 4 dim: 3 }
+}
+operand {
+  name: "out_shape"
+  type: INT32
+  shape { dim: 4 }
+}
+operand {
+  name: "ker"
+  type: FLOAT32
+  shape { dim: 3 dim: 1 dim: 1 dim: 3 }
+  filler {
+    tag: "gaussian"
+    arg: "0.0"
+    arg: "1.0"
+  }
+}
+operand {
+  name: "ofm"
+  type: FLOAT32
+  shape { dim: 1 dim: 4 dim: 4 dim: 3 }
+}
+operation {
+  type: "Shape"
+  shape_options {
+    out_type: INT32
+  }
+  input: "ifm"
+  output: "out_shape"
+}
+operation {
+  type: "TransposeConv"
+  transpose_conv_options {
+    padding: SAME
+    stride_w: 1
+    stride_h: 1
+    activation: NONE
+  }
+  input: "out_shape"
+  input: "ker"
+  input: "ifm"
+  output: "ofm"
+}
+input: "ifm"
+output: "ofm"


### PR DESCRIPTION
This commit introduces TransposeConv_002 recipe for checking if non-constant out_shape can be inferred by the shape inference.

Related: https://github.com/Samsung/ONE/issues/12429#issuecomment-1884092665
Draft: #12434 
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>