### PR TITLE
[onert] Add time measurement define

### DIFF
--- a/runtime/onert/core/include/util/logging.h
+++ b/runtime/onert/core/include/util/logging.h
@@ -83,4 +83,19 @@ inline std::string decorated_name(const char *input)
       METHOD;                                \
   } while (0)
 
+#define MEASURE_TIME_START(name) \
+  do                             \
+  {                              \
+  auto beg_##name = std::chrono::steady_clock::now()
+
+#define MEASURE_TIME_END(name)                                                      \
+  auto end_##name = std::chrono::steady_clock::now();                               \
+  auto dur_##name =                                                                 \
+    std::chrono::duration_cast<std::chrono::microseconds>(end_##name - beg_##name); \
+  if (::onert::util::logging::ctx.enabled())                                        \
+    std::cout << ::onert::util::logging::decorated_name(__func__) << #name          \
+              << " time = " << dur_##name.count() << std::endl;                     \
+  }                                                                                 \
+  while (0)
+
 #endif // __ONERT_UTIL_LOGGING_H__


### PR DESCRIPTION
This commit adds a time measurement define.
This definition is not focused on the runtime feature and may be useful for measuring the elapsed time in development.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>