### PR TITLE
Draft: Remove default value from onert_train 

### DIFF
--- a/infra/cmake/packages/BoostConfig.cmake
+++ b/infra/cmake/packages/BoostConfig.cmake
@@ -60,7 +60,7 @@ endfunction(_Boost_Build)
 if (NOT BUILD_BOOST)
   # BoostConfig.cmake does not honor QUIET argument at least till cmake 1.70.0.
   # Thus, don't try to find_package if you're not entirely sure you have boost.
-  find_package(Boost 1.58.0 QUIET COMPONENTS log program_options filesystem system)
+  find_package(Boost 1.84.0 QUIET COMPONENTS log program_options filesystem system)
   if(Boost_FOUND)
     return()
   endif()
@@ -84,5 +84,5 @@ if(BUILD_BOOST)
   set(Boost_USE_STATIC_LIBS ON)
 
   # We built boost library so update Boost variables.
-  find_package(Boost 1.58.0 QUIET COMPONENTS log program_options filesystem system)
+  find_package(Boost 1.84.0 QUIET COMPONENTS log program_options filesystem system)
 endif(BUILD_BOOST)

--- a/infra/cmake/packages/BoostSourceConfig.cmake
+++ b/infra/cmake/packages/BoostSourceConfig.cmake
@@ -9,7 +9,7 @@ function(_BoostSource_import)
 
   # EXTERNAL_DOWNLOAD_SERVER will be overwritten by CI server to use mirror server.
   envoption(EXTERNAL_DOWNLOAD_SERVER "http://sourceforge.net")
-  envoption(BOOST_URL ${EXTERNAL_DOWNLOAD_SERVER}/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.gz)
+  envoption(BOOST_URL ${EXTERNAL_DOWNLOAD_SERVER}/projects/boost/files/boost/1.84.0/boost_1_84_0.tar.gz)
   ExternalSource_Download(BOOST ${BOOST_URL})
 
   set(BoostSource_DIR ${BOOST_SOURCE_DIR} PARENT_SCOPE)

--- a/tests/tools/onert_train/CMakeLists.txt
+++ b/tests/tools/onert_train/CMakeLists.txt
@@ -6,6 +6,10 @@ if(NOT BUILD_ONERT)
   return()
 endif(NOT BUILD_ONERT)
 
+# Use C++17 for onert_train
+# TODO Remove this when we use C++17 for all runtime directories
+set(CMAKE_CXX_STANDARD 17)
+
 list(APPEND ONERT_TRAIN_SRCS "src/onert_train.cc")
 list(APPEND ONERT_TRAIN_SRCS "src/args.cc")
 list(APPEND ONERT_TRAIN_SRCS "src/nnfw_util.cc")

--- a/tests/tools/onert_train/src/args.cc
+++ b/tests/tools/onert_train/src/args.cc
@@ -207,7 +207,8 @@ void Args::Initialize(void)
       if (i == value)
         return;
     }
-    throw std::runtime_error{arg_name + " " + std::to_string(value) + " is unsupported argument"};
+    std::cerr << arg_name + " " + std::to_string(value) + " is unsupported argument\n";
+    exit(1);
   };
 
   auto loss_help_msg = [](const std::initializer_list<int> arg_list) -> std::string {

--- a/tests/tools/onert_train/src/args.h
+++ b/tests/tools/onert_train/src/args.h
@@ -17,11 +17,13 @@
 #ifndef __ONERT_TRAIN_ARGS_H__
 #define __ONERT_TRAIN_ARGS_H__
 
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
 #include <boost/program_options.hpp>
 
+#include "nnfw_experimental.h"
 #include "types.h"
 
 namespace po = boost::program_options;
@@ -54,11 +56,17 @@ public:
   const std::string &getLoadRawExpectedFilename(void) const { return _load_raw_expected_filename; }
   const bool getMemoryPoll(void) const { return _mem_poll; }
   const int getEpoch(void) const { return _epoch; }
-  const int getBatchSize(void) const { return _batch_size; }
-  const float getLearningRate(void) const { return _learning_rate; }
-  const int getLossType(void) const { return _loss_type; }
-  const int getLossReductionType(void) const { return _loss_reduction_type; }
-  const int getOptimizerType(void) const { return _optimizer_type; }
+  const std::optional<int> &getBatchSize(void) const { return _batch_size; }
+  const std::optional<float> &getLearningRate(void) const { return _learning_rate; }
+  const std::optional<NNFW_TRAIN_LOSS> &getLossType(void) const { return _loss_type; }
+  const std::optional<NNFW_TRAIN_LOSS_REDUCTION> &getLossReductionType(void) const
+  {
+    return _loss_reduction_type;
+  }
+  const std::optional<NNFW_TRAIN_OPTIMIZER> &getOptimizerType(void) const
+  {
+    return _optimizer_type;
+  }
   const int getMetricType(void) const { return _metric_type; }
   const float getValidationSplit(void) const { return _validation_split; }
   const bool printVersion(void) const { return _print_version; }
@@ -81,11 +89,11 @@ private:
   std::string _load_raw_expected_filename;
   bool _mem_poll;
   int _epoch;
-  int _batch_size;
-  float _learning_rate;
-  int _loss_type;
-  int _loss_reduction_type;
-  int _optimizer_type;
+  std::optional<int> _batch_size;
+  std::optional<float> _learning_rate;
+  std::optional<NNFW_TRAIN_LOSS> _loss_type;
+  std::optional<NNFW_TRAIN_LOSS_REDUCTION> _loss_reduction_type;
+  std::optional<NNFW_TRAIN_OPTIMIZER> _optimizer_type;
   int _metric_type;
   float _validation_split;
   bool _print_version = false;

--- a/tests/tools/onert_train/src/nnfw_util.cc
+++ b/tests/tools/onert_train/src/nnfw_util.cc
@@ -17,6 +17,7 @@
 #include <cassert>
 #include <string>
 #include <iostream>
+#include <unordered_map>
 
 #include "nnfw.h"
 #include "nnfw_experimental.h"
@@ -49,63 +50,50 @@ uint64_t bufsize_for(const nnfw_tensorinfo *ti)
   return elmsize[ti->dtype] * num_elems(ti);
 }
 
+std::string toString(const NNFW_TRAIN_OPTIMIZER &opt)
+{
+  static const std::unordered_map<NNFW_TRAIN_OPTIMIZER, std::string> name_map{
+    {NNFW_TRAIN_OPTIMIZER_UNDEFINED, "undefined"},
+    {NNFW_TRAIN_OPTIMIZER_ADAM, "adam"},
+    {NNFW_TRAIN_OPTIMIZER_SGD, "sgd"},
+  };
+  return name_map.at(opt);
+}
+
+std::string toString(const NNFW_TRAIN_LOSS &loss)
+{
+  static const std::unordered_map<NNFW_TRAIN_LOSS, std::string> name_map{
+    {NNFW_TRAIN_LOSS_UNDEFINED, "undefined"},
+    {NNFW_TRAIN_LOSS_MEAN_SQUARED_ERROR, "mean squared error"},
+    {NNFW_TRAIN_LOSS_CATEGORICAL_CROSSENTROPY, "categorical crossentropy"},
+  };
+  return name_map.at(loss);
+}
+
+std::string toString(const NNFW_TRAIN_LOSS_REDUCTION &loss_rdt)
+{
+  static const std::unordered_map<NNFW_TRAIN_LOSS_REDUCTION, std::string> name_map{
+    {NNFW_TRAIN_LOSS_REDUCTION_UNDEFINED, "undefined"},
+    {NNFW_TRAIN_LOSS_REDUCTION_SUM_OVER_BATCH_SIZE, "sum over batch size"},
+    {NNFW_TRAIN_LOSS_REDUCTION_SUM, "sum"}};
+  return name_map.at(loss_rdt);
+}
+
 std::ostream &operator<<(std::ostream &os, const NNFW_TRAIN_OPTIMIZER &opt)
 {
-  switch (opt)
-  {
-    case NNFW_TRAIN_OPTIMIZER_UNDEFINED:
-      os << "undefined";
-      break;
-    case NNFW_TRAIN_OPTIMIZER_ADAM:
-      os << "adam";
-      break;
-    case NNFW_TRAIN_OPTIMIZER_SGD:
-      os << "sgd";
-      break;
-    default:
-      os << "unsupported optimizer";
-      break;
-  }
+  os << toString(opt);
   return os;
 }
 
 std::ostream &operator<<(std::ostream &os, const NNFW_TRAIN_LOSS &loss)
 {
-  switch (loss)
-  {
-    case NNFW_TRAIN_LOSS_UNDEFINED:
-      os << "undefined";
-      break;
-    case NNFW_TRAIN_LOSS_MEAN_SQUARED_ERROR:
-      os << "mean squared error";
-      break;
-    case NNFW_TRAIN_LOSS_CATEGORICAL_CROSSENTROPY:
-      os << "categorical crossentropy";
-      break;
-    default:
-      os << "unsupported loss";
-      break;
-  }
+  os << toString(loss);
   return os;
 }
 
 std::ostream &operator<<(std::ostream &os, const NNFW_TRAIN_LOSS_REDUCTION &loss_reduction)
 {
-  switch (loss_reduction)
-  {
-    case NNFW_TRAIN_LOSS_REDUCTION_UNDEFINED:
-      os << "undefined";
-      break;
-    case NNFW_TRAIN_LOSS_REDUCTION_SUM_OVER_BATCH_SIZE:
-      os << "sum over batch size";
-      break;
-    case NNFW_TRAIN_LOSS_REDUCTION_SUM:
-      os << "sum";
-      break;
-    default:
-      os << "unsupported reduction type";
-      break;
-  }
+  os << toString(loss_reduction);
   return os;
 }
 

--- a/tests/tools/onert_train/src/nnfw_util.h
+++ b/tests/tools/onert_train/src/nnfw_util.h
@@ -36,6 +36,10 @@ namespace onert_train
 uint64_t num_elems(const nnfw_tensorinfo *ti);
 uint64_t bufsize_for(const nnfw_tensorinfo *ti);
 
+std::string toString(const NNFW_TRAIN_OPTIMIZER &opt);
+std::string toString(const NNFW_TRAIN_LOSS &loss);
+std::string toString(const NNFW_TRAIN_LOSS_REDUCTION &loss_rdt);
 std::ostream &operator<<(std::ostream &os, const nnfw_train_info &info);
+
 } // end of namespace onert_train
 #endif // __ONERT_TRAIN_NNFW_UTIL_H__

--- a/tests/tools/onert_train/src/nnfw_util.h
+++ b/tests/tools/onert_train/src/nnfw_util.h
@@ -40,6 +40,5 @@ std::string toString(const NNFW_TRAIN_OPTIMIZER &opt);
 std::string toString(const NNFW_TRAIN_LOSS &loss);
 std::string toString(const NNFW_TRAIN_LOSS_REDUCTION &loss_rdt);
 std::ostream &operator<<(std::ostream &os, const nnfw_train_info &info);
-
 } // end of namespace onert_train
 #endif // __ONERT_TRAIN_NNFW_UTIL_H__

--- a/tests/tools/onert_train/src/onert_train.cc
+++ b/tests/tools/onert_train/src/onert_train.cc
@@ -121,45 +121,6 @@ int main(const int argc, char **argv)
     verifyInputTypes();
     verifyOutputTypes();
 
-    auto convertLossType = [](int type) {
-      switch (type)
-      {
-        case 1:
-          return NNFW_TRAIN_LOSS_MEAN_SQUARED_ERROR;
-        case 2:
-          return NNFW_TRAIN_LOSS_CATEGORICAL_CROSSENTROPY;
-        default:
-          std::cerr << "E: not supported loss type" << std::endl;
-          exit(-1);
-      }
-    };
-
-    auto convertLossReductionType = [](int type) {
-      switch (type)
-      {
-        case 1:
-          return NNFW_TRAIN_LOSS_REDUCTION_SUM_OVER_BATCH_SIZE;
-        case 2:
-          return NNFW_TRAIN_LOSS_REDUCTION_SUM;
-        default:
-          std::cerr << "E: not supported loss reduction type" << std::endl;
-          exit(-1);
-      }
-    };
-
-    auto convertOptType = [](int type) {
-      switch (type)
-      {
-        case 1:
-          return NNFW_TRAIN_OPTIMIZER_SGD;
-        case 2:
-          return NNFW_TRAIN_OPTIMIZER_ADAM;
-        default:
-          std::cerr << "E: not supported optimizer type" << std::endl;
-          exit(-1);
-      }
-    };
-
     auto getMetricTypeStr = [](int type) {
       if (type < 0)
         return "";
@@ -177,11 +138,12 @@ int main(const int argc, char **argv)
     NNPR_ENSURE_STATUS(nnfw_train_get_traininfo(session, &tri));
 
     // overwrite training information using the arguments
-    tri.batch_size = args.getBatchSize();
-    tri.learning_rate = args.getLearningRate();
-    tri.loss_info.loss = convertLossType(args.getLossType());
-    tri.loss_info.reduction_type = convertLossReductionType(args.getLossReductionType());
-    tri.opt = convertOptType(args.getOptimizerType());
+    tri.batch_size = args.getBatchSize().value_or(tri.batch_size);
+    tri.learning_rate = args.getLearningRate().value_or(tri.learning_rate);
+    tri.loss_info.loss = args.getLossType().value_or(tri.loss_info.loss);
+    tri.loss_info.reduction_type =
+      args.getLossReductionType().value_or(tri.loss_info.reduction_type);
+    tri.opt = args.getOptimizerType().value_or(tri.opt);
 
     std::cout << "== training parameter ==" << std::endl;
     std::cout << tri;

--- a/tests/tools/onert_train/src/onert_train.cc
+++ b/tests/tools/onert_train/src/onert_train.cc
@@ -138,7 +138,11 @@ int main(const int argc, char **argv)
     NNPR_ENSURE_STATUS(nnfw_train_get_traininfo(session, &tri));
 
     // overwrite training information using the arguments
-    tri.batch_size = args.getBatchSize().value_or(tri.batch_size);
+    if (tri.batch_size == -1)
+    {
+      // If user doesn't give a batch size, set batch  size 1
+      tri.batch_size = args.getBatchSize().value_or(1);
+    }
     tri.learning_rate = args.getLearningRate().value_or(tri.learning_rate);
     tri.loss_info.loss = args.getLossType().value_or(tri.loss_info.loss);
     tri.loss_info.reduction_type =


### PR DESCRIPTION
This draft tries
  * remove the default option for train_info
     * to avoid always overwriting model file train_info
  * update `onert_train/args` use NNFW_TRAIN_...  directly
     * to avoid additional parsing (int to NNFW_TRAIN_..) in onert_train main 
