### PR TITLE
[runtime] Remove boost dependency on logging runtime

### DIFF
--- a/runtime/contrib/logging/CMakeLists.txt
+++ b/runtime/contrib/logging/CMakeLists.txt
@@ -4,9 +4,6 @@ endif(NOT BUILD_LOGGING)
 
 file(GLOB_RECURSE NNAPI_LOGGING_SRCS "src/*.cc")
 
-nnfw_find_package(Boost REQUIRED)
-
 add_library(neuralnetworks SHARED ${NNAPI_LOGGING_SRCS})
 target_include_directories(neuralnetworks PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
-target_include_directories(neuralnetworks PRIVATE ${Boost_INCLUDE_DIRS})
 target_link_libraries(neuralnetworks PUBLIC nnfw-nnapi-header)

--- a/runtime/contrib/logging/src/nnapi_logging.cc
+++ b/runtime/contrib/logging/src/nnapi_logging.cc
@@ -25,8 +25,6 @@
 
 #include <cassert>
 
-#include <boost/format.hpp>
-
 namespace
 {
 
@@ -72,7 +70,7 @@ std::string OperationCodeResolver::resolve(int code) const
 
   if (it == _table.end())
   {
-    return boost::str(boost::format("unknown(%d)") % code);
+    return "unknown(" + std::to_string(code) + ")";
   }
 
   return it->second;
@@ -120,7 +118,7 @@ std::string OperandCodeResolver::resolve(int code) const
 
   if (it == _table.end())
   {
-    return boost::str(boost::format("unknown(%d)") % code);
+    return "unknown(" + std::to_string(code) + ")";
   }
 
   return it->second;


### PR DESCRIPTION
This commit removes boost library depdency on logging runtime.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>