### PR TITLE
[tools/kbenchmark] Remove boost filesystem dependency

### DIFF
--- a/infra/cmake/packages/NoniusSourceConfig.cmake
+++ b/infra/cmake/packages/NoniusSourceConfig.cmake
@@ -16,7 +16,7 @@ function(_NoniusSource_import)
     # This header file is modified to show the html summary view according to the layer in kbenchmark.
     execute_process(COMMAND ${CMAKE_COMMAND} -E copy
                     "${CMAKE_CURRENT_LIST_DIR}/Nonius/html_report_template.g.h++"
-                    "${NoniusSource_DIR}/include/nonius/detail")
+                    "${Nonius_Source_DIR}/include/nonius/detail")
   endif(BUILD_KBENCHMARK)
 
   set(NoniusSource_DIR ${NONIUS_SOURCE_DIR} PARENT_SCOPE)

--- a/tools/kbenchmark/Args.cc
+++ b/tools/kbenchmark/Args.cc
@@ -17,7 +17,7 @@
 #include "Args.h"
 
 #include <iostream>
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 namespace kbenchmark
 {
@@ -73,7 +73,7 @@ void Args::Initialize(const int argc, char **argv)
       exit(1);
     }
 
-    if (!boost::filesystem::exists(_config))
+    if (!std::filesystem::exists(_config))
     {
       std::cerr << _config << " file not found" << std::endl;
       exit(1);
@@ -84,7 +84,7 @@ void Args::Initialize(const int argc, char **argv)
   {
     for (auto &k : _kernel)
     {
-      if (!boost::filesystem::exists(k))
+      if (!std::filesystem::exists(k))
       {
         std::cerr << k << " file not found" << std::endl;
         exit(1);

--- a/tools/kbenchmark/CMakeLists.txt
+++ b/tools/kbenchmark/CMakeLists.txt
@@ -1,14 +1,18 @@
+# Use C++17 for kbenchmark
+# TODO Remove this when we use C++17 for all runtime directories
+set(CMAKE_CXX_STANDARD 17)
+
 if(NOT BUILD_KBENCHMARK)
   return()
 endif(NOT BUILD_KBENCHMARK)
 
-nnas_find_package(Nonius QUIET)
+nnfw_find_package(Nonius QUIET)
 
 if(NOT Nonius_FOUND)
   return()
 endif(NOT Nonius_FOUND)
 
-nnfw_find_package(Boost REQUIRED program_options system filesystem)
+nnfw_find_package(Boost REQUIRED program_options)
 
 if(NOT Boost_FOUND)
   return()
@@ -22,7 +26,7 @@ target_compile_options(kbenchmark PRIVATE -Wno-psabi)
 target_include_directories(kbenchmark PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(kbenchmark PUBLIC nonius)
 target_link_libraries(kbenchmark PUBLIC dl)
-target_link_libraries(kbenchmark PUBLIC pthread boost_program_options boost_system boost_filesystem)
+target_link_libraries(kbenchmark PUBLIC pthread boost_program_options)
 install(TARGETS kbenchmark DESTINATION bin)
 
 # kernel libraries


### PR DESCRIPTION
This commit removes boost::filesystem dependency.
It includes typo fix in cmake.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: #12450 