### PR TITLE
[contrib/tflite_classify] Remove boost dependency

### DIFF
--- a/runtime/contrib/tflite_classify/CMakeLists.txt
+++ b/runtime/contrib/tflite_classify/CMakeLists.txt
@@ -2,13 +2,16 @@ if(NOT BUILD_TFLITE_CLASSIFY_APP)
   return()
 endif(NOT BUILD_TFLITE_CLASSIFY_APP)
 
+# Use C++17 for tflite_classify
+# TODO Remove this when we use C++17 for all runtime directories
+set(CMAKE_CXX_STANDARD 17)
+
 list(APPEND SOURCES "src/tflite_classify.cc")
 list(APPEND SOURCES "src/ImageClassifier.cc")
 list(APPEND SOURCES "src/InferenceInterface.cc")
 
 ## Required package
 find_package(OpenCV REQUIRED)
-find_package(Boost REQUIRED COMPONENTS system filesystem)
 
 # Without this line, this appliation couldn't search the opencv library that were already installed in ${ROOTFS_DIR}/usr/lib/arm-linux-gnueabihf directory
 set(CMAKE_EXE_LINKER_FLAGS "-Wl,--as-needed -Wl,--rpath=${ROOTFS_DIR}/usr/lib/arm-linux-gnueabihf -Wl,--rpath=${ROOTFS_DIR}/lib/arm-linux-gnueabihf")
@@ -16,7 +19,6 @@ set(CMAKE_EXE_LINKER_FLAGS "-Wl,--as-needed -Wl,--rpath=${ROOTFS_DIR}/usr/lib/ar
 add_executable(tflite_classify ${SOURCES})
 target_include_directories(tflite_classify PRIVATE src)
 target_link_libraries(tflite_classify tensorflow-lite ${LIB_PTHREAD} dl nnfw_lib_tflite)
-target_link_libraries(tflite_classify ${Boost_LIBRARIES})
 target_link_libraries(tflite_classify ${OpenCV_LIBRARIES})
 
 install(TARGETS tflite_classify DESTINATION bin)

--- a/runtime/contrib/tflite_classify/src/tflite_classify.cc
+++ b/runtime/contrib/tflite_classify/src/tflite_classify.cc
@@ -17,11 +17,11 @@
 #include "ImageClassifier.h"
 
 #include <iostream>
+#include <filesystem>
 
-#include <boost/filesystem.hpp>
 #include <opencv2/opencv.hpp>
 
-namespace fs = boost::filesystem;
+namespace fs = std::filesystem;
 
 int main(const int argc, char **argv)
 {


### PR DESCRIPTION
This commit removes boost:filesystem dependency.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: https://github.com/Samsung/ONE/issues/12450