### PR TITLE
[contrib/style_transfer_app] Remove boost filesystem dependency

### DIFF
--- a/runtime/contrib/style_transfer_app/CMakeLists.txt
+++ b/runtime/contrib/style_transfer_app/CMakeLists.txt
@@ -6,6 +6,10 @@ if(NOT BUILD_ONERT)
   return()
 endif(NOT BUILD_ONERT)
 
+# Use C++17 for style_transfer_app
+# TODO Remove this when we use C++17 for all runtime directories
+set(CMAKE_CXX_STANDARD 17)
+
 find_package(JPEG)
 if(JPEG_FOUND)
   add_definitions(-DNNFW_ST_APP_JPEG_SUPPORTED)
@@ -20,7 +24,7 @@ if(JPEG_FOUND)
   list(APPEND STYLE_TRANSFER_APP_SRCS "src/jpeg_helper.cc")
 endif(JPEG_FOUND)
 
-nnfw_find_package(Boost REQUIRED program_options system filesystem)
+nnfw_find_package(Boost REQUIRED program_options)
 
 add_executable(style_transfer_app ${STYLE_TRANSFER_APP_SRCS})
 target_include_directories(style_transfer_app PRIVATE src)
@@ -30,9 +34,9 @@ if(JPEG_FOUND)
 endif(JPEG_FOUND)
 
 target_link_libraries(style_transfer_app onert_core onert tflite_loader)
-target_link_libraries(style_transfer_app tensorflow-lite ${LIB_PTHREAD} dl nnfw_lib_tflite)
+target_link_libraries(style_transfer_app ${LIB_PTHREAD} dl nnfw_lib_tflite)
 target_link_libraries(style_transfer_app nnfw-dev)
-target_link_libraries(tflite_comparator ${Boost_PROGRAM_OPTIONS_LIBRARY} ${Boost_SYSTEM_LIBRARY} ${Boost_FILESYSTEM_LIBRARY})
+target_link_libraries(style_transfer_app ${Boost_PROGRAM_OPTIONS_LIBRARY})
 if(JPEG_FOUND)
   target_link_libraries(style_transfer_app ${JPEG_LIBRARIES})
 endif(JPEG_FOUND)

--- a/runtime/contrib/style_transfer_app/src/args.cc
+++ b/runtime/contrib/style_transfer_app/src/args.cc
@@ -17,7 +17,7 @@
 #include "args.h"
 
 #include <iostream>
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 namespace StyleTransferApp
 {
@@ -80,7 +80,7 @@ void Args::Parse(const int argc, char **argv)
     {
       _package_filename = vm["nnpackage"].as<std::string>();
 
-      if (!boost::filesystem::exists(_package_filename))
+      if (!std::filesystem::exists(_package_filename))
       {
         std::cerr << "nnpackage not found: " << _package_filename << "\n";
       }

--- a/runtime/contrib/style_transfer_app/src/jpeg_helper.cc
+++ b/runtime/contrib/style_transfer_app/src/jpeg_helper.cc
@@ -43,7 +43,7 @@ int JpegHelper::readJpeg(const std::string filename, std::vector<float> &raw_ima
 
   if (!infile)
   {
-    printf("Error opening jpeg file %s\n!", filename);
+    printf("Error opening jpeg file %s\n!", filename.c_str());
     return -1;
   }
 
@@ -93,7 +93,7 @@ int JpegHelper::writeJpeg(const std::string filename, std::vector<float> &raw_im
 
   if (!outfile)
   {
-    printf("Error opening output jpeg file %s\n!", filename);
+    printf("Error opening output jpeg file %s\n!", filename.c_str());
     return -1;
   }
   cinfo.err = jpeg_std_error(&jerr);


### PR DESCRIPTION
This commit removes boost::filesystem dependency.
It includes bug fix.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: https://github.com/Samsung/ONE/issues/12450