### PR TITLE
[onert-micro] Reduce duplicate code in comparison kernels

### DIFF
--- a/onert-micro/luci-interpreter/src/kernels/ComparisonCommon.h
+++ b/onert-micro/luci-interpreter/src/kernels/ComparisonCommon.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef LUCI_INTERPRETER_KERNELS_COMPARISONCOMMON_H
+#define LUCI_INTERPRETER_KERNELS_COMPARISONCOMMON_H
+
+#include "Builders.h"
+
+#include "kernels/Utils.h"
+#include "PALComparisons.h"
+
+namespace luci_interpreter
+{
+namespace kernels
+{
+
+template <typename T>
+void evalComparisonGeneric(const circle::Tensor *x, const circle::Tensor *y,
+                           const circle::Tensor *output, BaseRuntimeGraph *runtime_graph,
+                           bool F(T, T))
+{
+  auto x_data = kernels::getTensorData<T>(runtime_graph->getDataByTensor(x));
+  if (x_data == nullptr)
+    x_data = kernels::getTensorData<T>(runtime_graph->getConstDataByTensor(x));
+
+  assert(x_data != nullptr);
+
+  auto y_data = kernels::getTensorData<T>(runtime_graph->getDataByTensor(y));
+  if (y_data == nullptr)
+    y_data = kernels::getTensorData<T>(runtime_graph->getConstDataByTensor(y));
+
+  assert(y_data != nullptr);
+
+  auto output_data = kernels::getTensorData<bool>(runtime_graph->getDataByTensor(output));
+
+  luci_interpreter_pal::ComparisonParams op_params;
+  op_params.is_broadcast = Tensor::num_elements(x) != Tensor::num_elements(y);
+
+  if (op_params.is_broadcast)
+  {
+    luci_interpreter_pal::BroadcastComparison4DSlowNoScaling<T>(
+      op_params, kernels::getTensorShape(x), x_data, kernels::getTensorShape(y), y_data,
+      kernels::getTensorShape(output), output_data, F);
+  }
+  else
+  {
+    const int64_t flat_size = kernels::getTensorShape(x).flatSize();
+    luci_interpreter_pal::ComparisonNoScaling<T>(flat_size, x_data, y_data, output_data, F);
+  }
+}
+
+} // namespace kernels
+} // namespace luci_interpreter
+
+#endif // LUCI_INTERPRETER_KERNELS_COMPARISONCOMMON_H

--- a/onert-micro/luci-interpreter/src/kernels/Equal.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/Equal.cpp
@@ -15,53 +15,11 @@
  */
 
 #include "Builders.h"
-#include "kernels/Utils.h"
+#include "ComparisonCommon.h"
 #include "TISOKernel.h"
-
-#include "PALComparisons.h"
 
 namespace luci_interpreter
 {
-
-namespace
-{
-// TODO: reduce code duplication with less
-template <typename T>
-void evalGeneric(const circle::Tensor *x, const circle::Tensor *y, const circle::Tensor *output,
-                 BaseRuntimeGraph *runtime_graph)
-{
-  auto x_data = kernels::getTensorData<T>(runtime_graph->getDataByTensor(x));
-  if (x_data == nullptr)
-    x_data = kernels::getTensorData<T>(runtime_graph->getConstDataByTensor(x));
-
-  assert(x_data != nullptr);
-
-  auto y_data = kernels::getTensorData<T>(runtime_graph->getDataByTensor(y));
-  if (y_data == nullptr)
-    y_data = kernels::getTensorData<T>(runtime_graph->getConstDataByTensor(y));
-
-  assert(y_data != nullptr);
-
-  auto output_data = kernels::getTensorData<bool>(runtime_graph->getDataByTensor(output));
-
-  luci_interpreter_pal::ComparisonParams op_params;
-  op_params.is_broadcast = Tensor::num_elements(x) != Tensor::num_elements(y);
-
-  if (op_params.is_broadcast)
-  {
-    luci_interpreter_pal::BroadcastComparison4DSlowNoScaling<T>(
-      op_params, kernels::getTensorShape(x), x_data, kernels::getTensorShape(y), y_data,
-      kernels::getTensorShape(output), output_data, luci_interpreter_pal::EqualFn);
-  }
-  else
-  {
-    const int64_t flat_size = kernels::getTensorShape(x).flatSize();
-    luci_interpreter_pal::ComparisonNoScaling<T>(flat_size, x_data, y_data, output_data,
-                                                 luci_interpreter_pal::EqualFn);
-  }
-}
-
-} // namespace
 
 void configure_kernel_CircleEqual(const circle::Operator *cur_op, BaseRuntimeGraph *runtime_graph)
 {
@@ -79,14 +37,17 @@ void execute_kernel_CircleEqual(const circle::Operator *cur_op, BaseRuntimeGraph
   switch (Tensor::element_type(kernel.input1()))
   {
     case DataType::S64:
-      evalGeneric<int64_t>(kernel.input1(), kernel.input2(), kernel.output(), runtime_graph);
+      kernels::evalComparisonGeneric<int64_t>(kernel.input1(), kernel.input2(), kernel.output(),
+                                              runtime_graph, luci_interpreter_pal::EqualFn);
       break;
     case DataType::S32:
-      evalGeneric<int32_t>(kernel.input1(), kernel.input2(), kernel.output(), runtime_graph);
+      kernels::evalComparisonGeneric<int32_t>(kernel.input1(), kernel.input2(), kernel.output(),
+                                              runtime_graph, luci_interpreter_pal::EqualFn);
       break;
 #ifndef DIS_FLOAT
     case DataType::FLOAT32:
-      evalGeneric<float>(kernel.input1(), kernel.input2(), kernel.output(), runtime_graph);
+      kernels::evalComparisonGeneric<float>(kernel.input1(), kernel.input2(), kernel.output(),
+                                            runtime_graph, luci_interpreter_pal::EqualFn);
       break;
 #endif // DIS_FLOAT
     default:

--- a/onert-micro/luci-interpreter/src/kernels/Greater.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/Greater.cpp
@@ -15,44 +15,11 @@
  */
 
 #include "Builders.h"
-#include "kernels/Utils.h"
+#include "ComparisonCommon.h"
 #include "TISOKernel.h"
-
-#include "PALComparisons.h"
 
 namespace luci_interpreter
 {
-
-namespace
-{
-// TODO: reduce code duplication with less
-template <typename T>
-void evalGeneric(const circle::Tensor *x, const circle::Tensor *y, const circle::Tensor *output,
-                 BaseRuntimeGraph *runtime_graph)
-{
-  auto x_data = kernels::getTensorData<T>(runtime_graph->getDataByTensor(x));
-  if (x_data == nullptr)
-    x_data = kernels::getTensorData<T>(runtime_graph->getConstDataByTensor(x));
-
-  assert(x_data != nullptr);
-
-  auto y_data = kernels::getTensorData<T>(runtime_graph->getDataByTensor(y));
-  if (y_data == nullptr)
-    y_data = kernels::getTensorData<T>(runtime_graph->getConstDataByTensor(y));
-
-  assert(y_data != nullptr);
-
-  auto output_data = kernels::getTensorData<bool>(runtime_graph->getDataByTensor(output));
-
-  luci_interpreter_pal::ComparisonParams op_params;
-  op_params.is_broadcast = Tensor::num_elements(x) != Tensor::num_elements(y);
-
-  const int64_t flat_size = kernels::getTensorShape(x).flatSize();
-  luci_interpreter_pal::ComparisonNoScaling<T>(flat_size, x_data, y_data, output_data,
-                                               luci_interpreter_pal::GreaterFn);
-}
-
-} // namespace
 
 void configure_kernel_CircleGreater(const circle::Operator *cur_op, BaseRuntimeGraph *runtime_graph)
 {
@@ -70,14 +37,17 @@ void execute_kernel_CircleGreater(const circle::Operator *cur_op, BaseRuntimeGra
   switch (Tensor::element_type(kernel.input1()))
   {
     case DataType::S64:
-      evalGeneric<int64_t>(kernel.input1(), kernel.input2(), kernel.output(), runtime_graph);
+      kernels::evalComparisonGeneric<int64_t>(kernel.input1(), kernel.input2(), kernel.output(),
+                                              runtime_graph, luci_interpreter_pal::GreaterFn);
       break;
     case DataType::S32:
-      evalGeneric<int32_t>(kernel.input1(), kernel.input2(), kernel.output(), runtime_graph);
+      kernels::evalComparisonGeneric<int32_t>(kernel.input1(), kernel.input2(), kernel.output(),
+                                              runtime_graph, luci_interpreter_pal::GreaterFn);
       break;
 #ifndef DIS_FLOAT
     case DataType::FLOAT32:
-      evalGeneric<float>(kernel.input1(), kernel.input2(), kernel.output(), runtime_graph);
+      kernels::evalComparisonGeneric<float>(kernel.input1(), kernel.input2(), kernel.output(),
+                                            runtime_graph, luci_interpreter_pal::GreaterFn);
       break;
 #endif // DIS_FLOAT
     default:

--- a/onert-micro/luci-interpreter/src/kernels/GreaterEqual.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/GreaterEqual.cpp
@@ -15,44 +15,11 @@
  */
 
 #include "Builders.h"
-#include "kernels/Utils.h"
+#include "ComparisonCommon.h"
 #include "TISOKernel.h"
-
-#include "PALComparisons.h"
 
 namespace luci_interpreter
 {
-
-namespace
-{
-// TODO: reduce code duplication with less
-template <typename T>
-void evalGeneric(const circle::Tensor *x, const circle::Tensor *y, const circle::Tensor *output,
-                 BaseRuntimeGraph *runtime_graph)
-{
-  auto x_data = kernels::getTensorData<T>(runtime_graph->getDataByTensor(x));
-  if (x_data == nullptr)
-    x_data = kernels::getTensorData<T>(runtime_graph->getConstDataByTensor(x));
-
-  assert(x_data != nullptr);
-
-  auto y_data = kernels::getTensorData<T>(runtime_graph->getDataByTensor(y));
-  if (y_data == nullptr)
-    y_data = kernels::getTensorData<T>(runtime_graph->getConstDataByTensor(y));
-
-  assert(y_data != nullptr);
-
-  auto output_data = kernels::getTensorData<bool>(runtime_graph->getDataByTensor(output));
-
-  luci_interpreter_pal::ComparisonParams op_params;
-  op_params.is_broadcast = Tensor::num_elements(x) != Tensor::num_elements(y);
-
-  const int64_t flat_size = kernels::getTensorShape(x).flatSize();
-  luci_interpreter_pal::ComparisonNoScaling<T>(flat_size, x_data, y_data, output_data,
-                                               luci_interpreter_pal::GreaterEqualFn);
-}
-
-} // namespace
 
 void configure_kernel_CircleGreaterEqual(const circle::Operator *cur_op,
                                          BaseRuntimeGraph *runtime_graph)
@@ -72,14 +39,17 @@ void execute_kernel_CircleGreaterEqual(const circle::Operator *cur_op,
   switch (Tensor::element_type(kernel.input1()))
   {
     case DataType::S64:
-      evalGeneric<int64_t>(kernel.input1(), kernel.input2(), kernel.output(), runtime_graph);
+      kernels::evalComparisonGeneric<int64_t>(kernel.input1(), kernel.input2(), kernel.output(),
+                                              runtime_graph, luci_interpreter_pal::GreaterEqualFn);
       break;
     case DataType::S32:
-      evalGeneric<int32_t>(kernel.input1(), kernel.input2(), kernel.output(), runtime_graph);
+      kernels::evalComparisonGeneric<int32_t>(kernel.input1(), kernel.input2(), kernel.output(),
+                                              runtime_graph, luci_interpreter_pal::GreaterEqualFn);
       break;
 #ifndef DIS_FLOAT
     case DataType::FLOAT32:
-      evalGeneric<float>(kernel.input1(), kernel.input2(), kernel.output(), runtime_graph);
+      kernels::evalComparisonGeneric<float>(kernel.input1(), kernel.input2(), kernel.output(),
+                                            runtime_graph, luci_interpreter_pal::GreaterEqualFn);
       break;
 #endif // DIS_FLOAT
     default:

--- a/onert-micro/luci-interpreter/src/kernels/Less.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/Less.cpp
@@ -15,10 +15,8 @@
  */
 
 #include "Builders.h"
-#include "kernels/Utils.h"
+#include "ComparisonCommon.h"
 #include "TISOKernel.h"
-
-#include "PALComparisons.h"
 
 namespace luci_interpreter
 {
@@ -77,41 +75,6 @@ void evalQuantized(const circle::Tensor *x, const circle::Tensor *y, const circl
 }
 #endif // DIS_QUANT
 
-template <typename T>
-void evalGeneric(const circle::Tensor *x, const circle::Tensor *y, const circle::Tensor *output,
-                 BaseRuntimeGraph *runtime_graph)
-{
-  auto x_data = kernels::getTensorData<T>(runtime_graph->getDataByTensor(x));
-  if (x_data == nullptr)
-    x_data = kernels::getTensorData<T>(runtime_graph->getConstDataByTensor(x));
-
-  assert(x_data != nullptr);
-
-  auto y_data = kernels::getTensorData<T>(runtime_graph->getDataByTensor(y));
-  if (y_data == nullptr)
-    y_data = kernels::getTensorData<T>(runtime_graph->getConstDataByTensor(y));
-
-  assert(y_data != nullptr);
-
-  auto output_data = kernels::getTensorData<bool>(runtime_graph->getDataByTensor(output));
-
-  luci_interpreter_pal::ComparisonParams op_params;
-  op_params.is_broadcast = Tensor::num_elements(x) != Tensor::num_elements(y);
-
-  if (op_params.is_broadcast)
-  {
-    luci_interpreter_pal::BroadcastComparison4DSlowNoScaling<T>(
-      op_params, kernels::getTensorShape(x), x_data, kernels::getTensorShape(y), y_data,
-      kernels::getTensorShape(output), output_data, luci_interpreter_pal::LessFn);
-  }
-  else
-  {
-    const int64_t flat_size = kernels::getTensorShape(x).flatSize();
-    luci_interpreter_pal::ComparisonNoScaling<T>(flat_size, x_data, y_data, output_data,
-                                                 luci_interpreter_pal::LessFn);
-  }
-}
-
 } // namespace
 
 void configure_kernel_CircleLess(const circle::Operator *cur_op, BaseRuntimeGraph *runtime_graph)
@@ -130,10 +93,12 @@ void execute_kernel_CircleLess(const circle::Operator *cur_op, BaseRuntimeGraph 
   switch (Tensor::element_type(kernel.input1()))
   {
     case DataType::S64:
-      evalGeneric<int64_t>(kernel.input1(), kernel.input2(), kernel.output(), runtime_graph);
+      kernels::evalComparisonGeneric<int64_t>(kernel.input1(), kernel.input2(), kernel.output(),
+                                              runtime_graph, luci_interpreter_pal::LessFn);
       break;
     case DataType::S32:
-      evalGeneric<int32_t>(kernel.input1(), kernel.input2(), kernel.output(), runtime_graph);
+      kernels::evalComparisonGeneric<int32_t>(kernel.input1(), kernel.input2(), kernel.output(),
+                                              runtime_graph, luci_interpreter_pal::LessFn);
       break;
 #ifndef DIS_QUANT
     case DataType::U8:
@@ -142,7 +107,8 @@ void execute_kernel_CircleLess(const circle::Operator *cur_op, BaseRuntimeGraph 
 #endif // DIS_QUANT
 #ifndef DIS_FLOAT
     case DataType::FLOAT32:
-      evalGeneric<float>(kernel.input1(), kernel.input2(), kernel.output(), runtime_graph);
+      kernels::evalComparisonGeneric<float>(kernel.input1(), kernel.input2(), kernel.output(),
+                                            runtime_graph, luci_interpreter_pal::LessFn);
       break;
 #endif // DIS_FLOAT
     default:

--- a/onert-micro/luci-interpreter/src/kernels/LessEqual.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/LessEqual.cpp
@@ -15,44 +15,11 @@
  */
 
 #include "Builders.h"
-#include "kernels/Utils.h"
+#include "ComparisonCommon.h"
 #include "TISOKernel.h"
-
-#include "PALComparisons.h"
 
 namespace luci_interpreter
 {
-
-namespace
-{
-// TODO: reduce code duplication with less
-template <typename T>
-void evalGeneric(const circle::Tensor *x, const circle::Tensor *y, const circle::Tensor *output,
-                 BaseRuntimeGraph *runtime_graph)
-{
-  auto x_data = kernels::getTensorData<T>(runtime_graph->getDataByTensor(x));
-  if (x_data == nullptr)
-    x_data = kernels::getTensorData<T>(runtime_graph->getConstDataByTensor(x));
-
-  assert(x_data != nullptr);
-
-  auto y_data = kernels::getTensorData<T>(runtime_graph->getDataByTensor(y));
-  if (y_data == nullptr)
-    y_data = kernels::getTensorData<T>(runtime_graph->getConstDataByTensor(y));
-
-  assert(y_data != nullptr);
-
-  auto output_data = kernels::getTensorData<bool>(runtime_graph->getDataByTensor(output));
-
-  luci_interpreter_pal::ComparisonParams op_params;
-  op_params.is_broadcast = Tensor::num_elements(x) != Tensor::num_elements(y);
-
-  const int64_t flat_size = kernels::getTensorShape(x).flatSize();
-  luci_interpreter_pal::ComparisonNoScaling<T>(flat_size, x_data, y_data, output_data,
-                                               luci_interpreter_pal::LessEqualFn);
-}
-
-} // namespace
 
 void configure_kernel_CircleLessEqual(const circle::Operator *cur_op,
                                       BaseRuntimeGraph *runtime_graph)
@@ -71,14 +38,17 @@ void execute_kernel_CircleLessEqual(const circle::Operator *cur_op, BaseRuntimeG
   switch (Tensor::element_type(kernel.input1()))
   {
     case DataType::S64:
-      evalGeneric<int64_t>(kernel.input1(), kernel.input2(), kernel.output(), runtime_graph);
+      kernels::evalComparisonGeneric<int64_t>(kernel.input1(), kernel.input2(), kernel.output(),
+                                              runtime_graph, luci_interpreter_pal::LessEqualFn);
       break;
     case DataType::S32:
-      evalGeneric<int32_t>(kernel.input1(), kernel.input2(), kernel.output(), runtime_graph);
+      kernels::evalComparisonGeneric<int32_t>(kernel.input1(), kernel.input2(), kernel.output(),
+                                              runtime_graph, luci_interpreter_pal::LessEqualFn);
       break;
 #ifndef DIS_FLOAT
     case DataType::FLOAT32:
-      evalGeneric<float>(kernel.input1(), kernel.input2(), kernel.output(), runtime_graph);
+      kernels::evalComparisonGeneric<float>(kernel.input1(), kernel.input2(), kernel.output(),
+                                            runtime_graph, luci_interpreter_pal::LessEqualFn);
       break;
 #endif // DIS_FLOAT
     default:

--- a/onert-micro/luci-interpreter/src/kernels/NotEqual.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/NotEqual.cpp
@@ -15,44 +15,11 @@
  */
 
 #include "Builders.h"
-#include "kernels/Utils.h"
+#include "ComparisonCommon.h"
 #include "TISOKernel.h"
-
-#include "PALComparisons.h"
 
 namespace luci_interpreter
 {
-
-namespace
-{
-// TODO: reduce code duplication with less
-template <typename T>
-void evalGeneric(const circle::Tensor *x, const circle::Tensor *y, const circle::Tensor *output,
-                 BaseRuntimeGraph *runtime_graph)
-{
-  auto x_data = kernels::getTensorData<T>(runtime_graph->getDataByTensor(x));
-  if (x_data == nullptr)
-    x_data = kernels::getTensorData<T>(runtime_graph->getConstDataByTensor(x));
-
-  assert(x_data != nullptr);
-
-  auto y_data = kernels::getTensorData<T>(runtime_graph->getDataByTensor(y));
-  if (y_data == nullptr)
-    y_data = kernels::getTensorData<T>(runtime_graph->getConstDataByTensor(y));
-
-  assert(y_data != nullptr);
-
-  auto output_data = kernels::getTensorData<bool>(runtime_graph->getDataByTensor(output));
-
-  luci_interpreter_pal::ComparisonParams op_params;
-  op_params.is_broadcast = Tensor::num_elements(x) != Tensor::num_elements(y);
-
-  const int64_t flat_size = kernels::getTensorShape(x).flatSize();
-  luci_interpreter_pal::ComparisonNoScaling<T>(flat_size, x_data, y_data, output_data,
-                                               luci_interpreter_pal::NotEqualFn);
-}
-
-} // namespace
 
 void configure_kernel_CircleNotEqual(const circle::Operator *cur_op,
                                      BaseRuntimeGraph *runtime_graph)
@@ -71,14 +38,17 @@ void execute_kernel_CircleNotEqual(const circle::Operator *cur_op, BaseRuntimeGr
   switch (Tensor::element_type(kernel.input1()))
   {
     case DataType::S64:
-      evalGeneric<int64_t>(kernel.input1(), kernel.input2(), kernel.output(), runtime_graph);
+      kernels::evalComparisonGeneric<int64_t>(kernel.input1(), kernel.input2(), kernel.output(),
+                                              runtime_graph, luci_interpreter_pal::NotEqualFn);
       break;
     case DataType::S32:
-      evalGeneric<int32_t>(kernel.input1(), kernel.input2(), kernel.output(), runtime_graph);
+      kernels::evalComparisonGeneric<int32_t>(kernel.input1(), kernel.input2(), kernel.output(),
+                                              runtime_graph, luci_interpreter_pal::NotEqualFn);
       break;
 #ifndef DIS_FLOAT
     case DataType::FLOAT32:
-      evalGeneric<float>(kernel.input1(), kernel.input2(), kernel.output(), runtime_graph);
+      kernels::evalComparisonGeneric<float>(kernel.input1(), kernel.input2(), kernel.output(),
+                                            runtime_graph, luci_interpreter_pal::NotEqualFn);
       break;
 #endif // DIS_FLOAT
     default:


### PR DESCRIPTION
This commit reduces duplicate code in comparison kernels.
  - Introduce `evalComparisonGeneric()` that unifies comparison kernels.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>

---

For #11744 