### PR TITLE
[circle-operator] Revise to use size()

### DIFF
--- a/compiler/circle-operator/src/Dump.cpp
+++ b/compiler/circle-operator/src/Dump.cpp
@@ -27,7 +27,7 @@ namespace
 void dump_ops(std::ostream &os, mio::circle::Reader &reader, const cirops::DumpOption &option)
 {
   auto ops = reader.operators();
-  for (uint32_t i = 0; i < ops->Length(); ++i)
+  for (uint32_t i = 0; i < ops->size(); ++i)
   {
     const auto op = ops->Get(i);
     const auto op_name = reader.opcode_name(op);


### PR DESCRIPTION
This will revise to use size() as Length() is going to be deprecated.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>