### PR TITLE
[tflchef] Revise to use size()

### DIFF
--- a/compiler/tflchef/tflite/src/Convert.h
+++ b/compiler/tflchef/tflite/src/Convert.h
@@ -46,8 +46,8 @@ template <typename DT> std::vector<DT> extract_buffer(const tflite::Buffer *buff
 
 template <typename T> std::vector<T> as_index_vector(const flatbuffers::Vector<T> *flat_array)
 {
-  std::vector<T> ret(flat_array->Length());
-  for (uint32_t i = 0; i < flat_array->Length(); i++)
+  std::vector<T> ret(flat_array->size());
+  for (uint32_t i = 0; i < flat_array->size(); i++)
   {
     ret[i] = flat_array->Get(i);
   }

--- a/compiler/tflchef/tflite/src/RecipeChef.cpp
+++ b/compiler/tflchef/tflite/src/RecipeChef.cpp
@@ -82,7 +82,7 @@ std::unique_ptr<ModelRecipe> generate_recipe(const tflite::Model *model)
   auto operators = tflite_import.operators();
 
   // operand fillers for adding all operators
-  for (uint32_t i = 0; i < operators->Length(); ++i)
+  for (uint32_t i = 0; i < operators->size(); ++i)
   {
     const auto *op = operators->Get(i);
     tflite::BuiltinOperator builtincode = tflite_import.builtin_code(op);
@@ -99,7 +99,7 @@ std::unique_ptr<ModelRecipe> generate_recipe(const tflite::Model *model)
   }
 
   // add all operands(tensors)
-  for (uint32_t i = 0; i < tensors->Length(); ++i)
+  for (uint32_t i = 0; i < tensors->size(); ++i)
   {
     auto tensor = tensors->Get(i);
 
@@ -285,7 +285,7 @@ std::unique_ptr<ModelRecipe> generate_recipe(const tflite::Model *model)
   }
 
   // add all operators
-  for (uint32_t i = 0; i < operators->Length(); ++i)
+  for (uint32_t i = 0; i < operators->size(); ++i)
   {
     const auto *op = operators->Get(i);
     tflite::BuiltinOperator builtincode = tflite_import.builtin_code(op);

--- a/compiler/tflchef/tflite/src/TFliteImport.cpp
+++ b/compiler/tflchef/tflite/src/TFliteImport.cpp
@@ -44,7 +44,7 @@ bool TFliteImport::select_sub_graph(uint32_t sgindex)
   _inputs.clear();
   _outputs.clear();
 
-  if (_subgraphs->Length() <= sgindex)
+  if (_subgraphs->size() <= sgindex)
   {
     assert(false);
     return false;

--- a/compiler/tflchef/tflite/src/TFliteImport.h
+++ b/compiler/tflchef/tflite/src/TFliteImport.h
@@ -54,7 +54,7 @@ public:
   const std::vector<int32_t> &inputs() const { return _inputs; }
   const std::vector<int32_t> &outputs() const { return _outputs; }
 
-  uint32_t num_subgraph() const { return _subgraphs->Length(); }
+  uint32_t num_subgraph() const { return _subgraphs->size(); }
 
   tflite::BuiltinOperator builtin_code(const tflite::Operator *op) const;
   std::string opcode_name(const tflite::Operator *op) const;


### PR DESCRIPTION
This will revise to use size() as Length() is going to be deprecated.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>