### PR TITLE
[tfldump] Revise to use size()

### DIFF
--- a/compiler/tfldump/src/Dump.cpp
+++ b/compiler/tfldump/src/Dump.cpp
@@ -129,7 +129,7 @@ void dump_sub_graph(std::ostream &os, tflread::Reader &reader)
   // dump operands(tensors)
   os << "Operands: T(subgraph index : tensor index) TYPE (shape) (shape_signature) "
      << "B(buffer index) (variable) OperandName" << std::endl;
-  for (uint32_t i = 0; i < tensors->Length(); ++i)
+  for (uint32_t i = 0; i < tensors->size(); ++i)
   {
     // TODO refactor to some better structure
     auto tensor = tensors->Get(i);
@@ -280,7 +280,7 @@ void dump_sub_graph(std::ostream &os, tflread::Reader &reader)
   os << "    Option(values) ... <-- depending on OpCode" << std::endl;
   os << "    I T(tensor index) OperandName <-- as input" << std::endl;
   os << "    O T(tensor index) OperandName <-- as output" << std::endl;
-  for (uint32_t i = 0; i < operators->Length(); ++i)
+  for (uint32_t i = 0; i < operators->size(); ++i)
   {
     const auto op = operators->Get(i);
     tflite::BuiltinOperator builtincode = reader.builtin_code(op);
@@ -377,7 +377,7 @@ void dump_model(std::ostream &os, const tflite::Model *model)
 
   // dump buffer
   os << "Buffers: B(index) (length) values, if any" << std::endl;
-  for (uint32_t i = 0; i < buffers->Length(); ++i)
+  for (uint32_t i = 0; i < buffers->size(); ++i)
   {
     const uint8_t *buff_data;
     size_t size = reader.buffer_info(i, &buff_data);
@@ -395,7 +395,7 @@ void dump_model(std::ostream &os, const tflite::Model *model)
   if (metadata != nullptr)
   {
     os << "metadata : B(index) name" << std::endl;
-    for (uint32_t i = 0; i < metadata->Length(); ++i)
+    for (uint32_t i = 0; i < metadata->size(); ++i)
     {
       os << "B(" << metadata->Get(i)->buffer() << ") " << metadata->Get(i)->name()->c_str()
          << std::endl;
@@ -407,14 +407,14 @@ void dump_model(std::ostream &os, const tflite::Model *model)
   if (signaturedefs != nullptr)
   {
     os << "SignatureDef" << std::endl;
-    for (uint32_t i = 0; i < signaturedefs->Length(); ++i)
+    for (uint32_t i = 0; i < signaturedefs->size(); ++i)
     {
       auto sign_i = signaturedefs->Get(i);
       os << "S(" << i << ") signature_key(" << sign_i->signature_key()->c_str() << "), sub_graph("
          << sign_i->subgraph_index() << ")" << std::endl;
 
       auto inputs_i = sign_i->inputs();
-      for (uint32_t t = 0; t < inputs_i->Length(); ++t)
+      for (uint32_t t = 0; t < inputs_i->size(); ++t)
       {
         auto inputs_i_t = inputs_i->Get(t);
         os << "    I(" << t << ")"
@@ -423,7 +423,7 @@ void dump_model(std::ostream &os, const tflite::Model *model)
       }
 
       auto outputs_i = sign_i->outputs();
-      for (uint32_t t = 0; t < outputs_i->Length(); ++t)
+      for (uint32_t t = 0; t < outputs_i->size(); ++t)
       {
         auto outputs_i_t = outputs_i->Get(t);
         os << "    O(" << t << ")"

--- a/compiler/tfldump/src/Read.cpp
+++ b/compiler/tfldump/src/Read.cpp
@@ -95,7 +95,7 @@ bool Reader::select_subgraph(uint32_t sgindex)
   _inputs.clear();
   _outputs.clear();
 
-  if (_subgraphs->Length() <= sgindex)
+  if (_subgraphs->size() <= sgindex)
   {
     assert(false);
     return false;

--- a/compiler/tfldump/src/Read.h
+++ b/compiler/tfldump/src/Read.h
@@ -28,8 +28,8 @@ namespace tflread
 
 template <typename T> std::vector<T> as_index_vector(const flatbuffers::Vector<T> *flat_array)
 {
-  std::vector<T> ret(flat_array->Length());
-  for (uint32_t i = 0; i < flat_array->Length(); i++)
+  std::vector<T> ret(flat_array->size());
+  for (uint32_t i = 0; i < flat_array->size(); i++)
   {
     ret[i] = flat_array->Get(i);
   }
@@ -66,7 +66,7 @@ public:
   const TFliteMetadata_t *metadata() const { return _metadata; }
   const TFliteSignatureDef_t *signaturedefs() const { return _signaturedefs; }
 
-  uint32_t num_subgraph() const { return _subgraphs->Length(); }
+  uint32_t num_subgraph() const { return _subgraphs->size(); }
 
   size_t buffer_info(uint32_t buf_idx, const uint8_t **buff_data);
   tflite::BuiltinOperator builtin_code(const tflite::Operator *op) const;


### PR DESCRIPTION
This will revise to use size() as Length() is going to be deprecated.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>