### PR TITLE
[tfl-inspect] Revise to use size()

### DIFF
--- a/compiler/tfl-inspect/src/Dump.cpp
+++ b/compiler/tfl-inspect/src/Dump.cpp
@@ -36,7 +36,7 @@ void DumpOperators::run(std::ostream &os, const tflite::Model *model)
     auto ops = reader.operators();
 
     // dump operators
-    for (uint32_t i = 0; i < ops->Length(); ++i)
+    for (uint32_t i = 0; i < ops->size(); ++i)
     {
       const auto op = ops->Get(i);
 
@@ -56,7 +56,7 @@ const tflite::Operator *operator_match_output(tflinspect::Reader &reader, const 
 {
   auto ops = reader.operators();
 
-  for (uint32_t i = 0; i < ops->Length(); ++i)
+  for (uint32_t i = 0; i < ops->size(); ++i)
   {
     const auto op = ops->Get(i);
 
@@ -75,7 +75,7 @@ size_t tensor_buffer_size(tflinspect::Reader &reader, const int32_t tensor_id)
 {
   auto tensors = reader.tensors();
 
-  if (tensor_id < 0 || tensor_id >= tensors->Length())
+  if (tensor_id < 0 || tensor_id >= tensors->size())
   {
     throw std::runtime_error("Invalid Tensor ID");
   }
@@ -105,7 +105,7 @@ void DumpConv2DWeight::run(std::ostream &os, const tflite::Model *model)
     auto ops = reader.operators();
 
     // dump Conv2D, DepthwiseConv2D and its weight input operator
-    for (uint32_t i = 0; i < ops->Length(); ++i)
+    for (uint32_t i = 0; i < ops->size(); ++i)
     {
       const auto op = ops->Get(i);
       auto bc = reader.builtin_code(op);
@@ -159,7 +159,7 @@ void DumpOperatorVersion::run(std::ostream &os, const tflite::Model *model)
     auto ops = reader.operators();
 
     // dump Conv2D, DepthwiseConv2D and its weight input operator
-    for (uint32_t i = 0; i < ops->Length(); ++i)
+    for (uint32_t i = 0; i < ops->size(); ++i)
     {
       const auto op = ops->Get(i);
 

--- a/compiler/tfl-inspect/src/Reader.cpp
+++ b/compiler/tfl-inspect/src/Reader.cpp
@@ -98,7 +98,7 @@ bool Reader::select_subgraph(uint32_t sgindex)
   _inputs.clear();
   _outputs.clear();
 
-  if (_subgraphs->Length() <= sgindex)
+  if (_subgraphs->size() <= sgindex)
   {
     assert(false);
     return false;

--- a/compiler/tfl-inspect/src/Reader.h
+++ b/compiler/tfl-inspect/src/Reader.h
@@ -28,8 +28,8 @@ namespace tflinspect
 
 template <typename T> std::vector<T> as_index_vector(const flatbuffers::Vector<T> *flat_array)
 {
-  std::vector<T> ret(flat_array->Length());
-  for (uint32_t i = 0; i < flat_array->Length(); i++)
+  std::vector<T> ret(flat_array->size());
+  for (uint32_t i = 0; i < flat_array->size(); i++)
   {
     ret[i] = flat_array->Get(i);
   }
@@ -60,7 +60,7 @@ public:
   const std::vector<int32_t> &inputs() const { return _inputs; }
   const std::vector<int32_t> &outputs() const { return _outputs; }
 
-  uint32_t num_subgraph() const { return _subgraphs->Length(); }
+  uint32_t num_subgraph() const { return _subgraphs->size(); }
 
   size_t buffer_info(uint32_t buf_idx, const uint8_t **buff_data);
   tflite::BuiltinOperator builtin_code(const tflite::Operator *op) const;


### PR DESCRIPTION
This will revise to use size() as Length() is going to be deprecated.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>