### PR TITLE
[res] Add Net_BroadcastTo_AddV2_002

### DIFF
--- a/res/TensorFlowLiteRecipes/Net_BroadcastTo_AddV2_002/test.recipe
+++ b/res/TensorFlowLiteRecipes/Net_BroadcastTo_AddV2_002/test.recipe
@@ -1,0 +1,69 @@
+# BroadcastTo Op supports op version 2 and 3.
+# BroadcastTo of Float type is version 2 and Quantized BroadcastTo is version 3.
+# We are using tflite kernels for float values. so, the version should be 2.
+# refer https://github.com/tensorflow/tensorflow/pull/46224/files
+operand {
+  name: "bc_input"
+  type: FLOAT32
+  shape { dim: 2 dim: 3 }
+}
+operand {
+  name: "bc_shape"
+  type: INT32
+  shape { dim: 3 }
+  filler { tag: "explicit" arg: "1" arg: "2" arg: "3" }
+}
+operand {
+  name: "bc_ofm"
+  type: FLOAT32
+  shape { dim: 1 dim: 2 dim: 3 }
+}
+operation {
+  type: "BroadcastTo"
+  input: "bc_input"
+  input: "bc_shape"
+  output: "bc_ofm"
+  version: 2
+}
+operand {
+  name: "reshape_data"
+  type: FLOAT32
+  shape { dim: 2 dim: 3 }
+}
+operand {
+  name: "reshape_shape"
+  type: INT32
+  shape { dim: 3 }
+  filler { tag: "explicit" arg: "1" arg: "2" arg: "3" }
+}
+operand {
+  name: "reshape_ofm"
+  type: FLOAT32
+  shape { dim: 1 dim: 2 dim: 3 }
+}
+operation {
+  type: "Reshape"
+  reshape_options {
+    new_shape: 1
+    new_shape: 2
+    new_shape: 3
+  }
+  input: "reshape_data"
+  input: "reshape_shape"
+  output: "reshape_ofm"
+}
+operand {
+  name: "ofm"
+  type: FLOAT32
+  shape { dim: 1 dim: 2 dim: 3 }
+}
+operation {
+  type: "Custom"
+  input: "bc_ofm"
+  input: "reshape_ofm"
+  output: "ofm"
+  custom_code: "AddV2"
+}
+input: "bc_input"
+input: "reshape_data"
+output: "ofm"

--- a/res/TensorFlowLiteRecipes/Net_BroadcastTo_AddV2_002/test.rule
+++ b/res/TensorFlowLiteRecipes/Net_BroadcastTo_AddV2_002/test.rule
@@ -1,0 +1,7 @@
+ To check if BroadcastTo and AddV2 are fused to Add op
+
+RULE    "VERIFY_FILE_FORMAT"      $(verify_file_format) '=' 1
+
+RULE    "ADD_EXIST"               $(op_count ADD) '=' 1
+RULE    "NO_BroadcastTo"          $(op_count 'BroadcastTo') '=' 0
+RULE    "NO_AddV2"                $(op_count 'CUSTOM(AddV2)') '=' 0


### PR DESCRIPTION
This commit adds Net_BroadcastTo_AddV2_002 network to TensorFlowLiteRecipes.

ONE-DCO-1.0-Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>

---
Related to Issue: https://github.com/Samsung/ONE/issues/10784
Draft PR: [#10737](https://github.com/Samsung/ONE/pull/11701)