### PR TITLE
[rawdata2hdf5] Add warning to deprecate rawdata2hdf5

### DIFF
--- a/compiler/rawdata2hdf5/rawdata2hdf5
+++ b/compiler/rawdata2hdf5/rawdata2hdf5
@@ -24,6 +24,7 @@ import numpy as np
 import argparse
 import glob
 import os
+import warnings
 
 
 def get_parser():
@@ -105,6 +106,7 @@ def create_hdf5(data_list, output_path):
 
 
 def main():
+    warnings.warn("rawdata2hdf5 will be deprecated. Please use one-create-quant-dataset.");
     parser = get_parser()
 
     args = parser.parse_args()


### PR DESCRIPTION
This commit adds warning to deprecate rawdata2hdf5.

ONE-DCO-1.0-Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>

---
Related Issue: https://github.com/Samsung/ONE/issues/12053
Draft PR: https://github.com/Samsung/ONE/pull/12186