### PR TITLE
[onert-micro] Reduce duplicate code in convolution kernels

### DIFF
--- a/onert-micro/luci-interpreter/src/kernels/CMakeLists.txt
+++ b/onert-micro/luci-interpreter/src/kernels/CMakeLists.txt
@@ -8,7 +8,8 @@ set(SOURCES
         SISOKernel.h
         TISOKernel.h
         MISOKernel.h
-        PadCommon.cpp)
+        PadCommon.cpp
+        ConvolutionCommon.cpp)
 
 macro(REGISTER_KERNEL OPERATOR, NODE)
   list(APPEND SOURCES "${NODE}.cpp")

--- a/onert-micro/luci-interpreter/src/kernels/ConvolutionCommon.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/ConvolutionCommon.cpp
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ConvolutionCommon.h"
+
+#include "Utils.h"
+
+namespace luci_interpreter
+{
+
+namespace
+{
+
+bool isSupportedQuantized(const circle::Tensor *input, const circle::Tensor *weights)
+{
+  return Tensor::element_type(input) == DataType::U8 and Tensor::scales(weights).size() == 1;
+}
+
+bool isSupportedQuantizedPerChannel(const circle::Tensor *input, const circle::Tensor *weights)
+{
+  return (Tensor::element_type(input) == DataType::U8 or
+          Tensor::element_type(input) == DataType::S8) and
+         Tensor::scales(weights).size() > 1;
+}
+
+} // namespace
+
+int32_t computeConvPadding(const circle::Tensor *input, const circle::Tensor *filter,
+                           circle::Padding padding_type, int32_t stride, int32_t dilation, int axis)
+{
+  const int32_t input_dim = Tensor::dim(input, axis);
+  const int32_t filter_dim = Tensor::dim(filter, axis);
+  const int32_t output_dim =
+    kernels::computeOutputSize(luci_padding(padding_type), input_dim, filter_dim, stride, dilation);
+
+  const auto padding = kernels::computePadding(stride, dilation, input_dim, filter_dim, output_dim);
+
+  return padding;
+}
+
+luci_interpreter_pal::ConvParams createConv2DParams(const circle::Tensor *input,
+                                                    const circle::Tensor *filter,
+                                                    const circle::Tensor *output,
+                                                    const circle::Conv2DOptions *options)
+{
+  luci_interpreter_pal::ConvParams params{};
+
+  if (isSupportedQuantized(input, filter))
+  {
+#ifndef DIS_QUANT
+    const auto input_scale = static_cast<double>(Tensor::scale(input));
+    const auto filter_scale = static_cast<double>(Tensor::scale(filter));
+    const auto output_scale = static_cast<double>(Tensor::scale(output));
+
+    const double real_multiplier = input_scale * filter_scale / output_scale;
+    int32_t output_multiplier{};
+    int output_shift{};
+    kernels::quantizeMultiplier(real_multiplier, &output_multiplier, &output_shift);
+
+    params.output_multiplier = output_multiplier;
+    params.output_shift = output_shift;
+
+    int32_t activation_min{};
+    int32_t activation_max{};
+    kernels::calculateActivationRangeQuantized(luci_actfunc(options->fused_activation_function()),
+                                               output, &activation_min, &activation_max);
+
+    // The kernel expects input and filter zero points to be negated.
+    params.input_offset = -Tensor::zero_point(input);    // Note the '-'.
+    params.weights_offset = -Tensor::zero_point(filter); // Note the '-'.
+    params.output_offset = Tensor::zero_point(output);
+    params.quantized_activation_min = activation_min;
+    params.quantized_activation_max = activation_max;
+#endif // DIS_QUANT
+  }
+  else if (isSupportedQuantizedPerChannel(input, filter))
+  {
+#ifndef DIS_QUANT
+    int32_t activation_min{};
+    int32_t activation_max{};
+    kernels::calculateActivationRangeQuantized(luci_actfunc(options->fused_activation_function()),
+                                               output, &activation_min, &activation_max);
+
+    const std::vector<double> effective_output_scale = kernels::getQuantizedConvolutionMultiplers(
+      Tensor::scale(input), Tensor::scales(filter), Tensor::scale(output));
+
+    size_t n = effective_output_scale.size();
+    params.per_channel_output_shift.resize(n);
+    params.per_channel_output_multiplier.resize(n);
+    for (size_t i = 0; i < n; ++i)
+    {
+      kernels::quantizeMultiplier(effective_output_scale[i],
+                                  &params.per_channel_output_multiplier[i],
+                                  &params.per_channel_output_shift[i]);
+
+      // The kernel expects input and filter zero points to be negated.
+      params.input_offset = -Tensor::zero_point(input);    // Note the '-'.
+      params.weights_offset = -Tensor::zero_point(filter); // Note the '-'.
+      params.output_offset = Tensor::zero_point(output);
+      params.quantized_activation_min = activation_min;
+      params.quantized_activation_max = activation_max;
+    }
+#endif // DIS_QUANT
+  }
+  else if (Tensor::element_type(input) == DataType::FLOAT32 and
+           Tensor::element_type(filter) == DataType::FLOAT32)
+  {
+#ifndef DIS_FLOAT
+    float activation_min{};
+    float activation_max{};
+    kernels::calculateActivationRange(luci_actfunc(options->fused_activation_function()),
+                                      &activation_min, &activation_max);
+
+    params.float_activation_min = activation_min;
+    params.float_activation_max = activation_max;
+#endif // DIS_FLOAT
+  }
+  else
+  {
+    assert(false && "Not supported type");
+  }
+
+  const auto padding = options->padding();
+  const auto stride_height = options->stride_h();
+  const auto stride_width = options->stride_w();
+  const auto dilation_height_factor = options->dilation_h_factor();
+  const auto dilation_width_factor = options->dilation_h_factor();
+
+  params.padding_values.height =
+    computeConvPadding(input, filter, padding, stride_height, dilation_height_factor, 1);
+  params.padding_values.width =
+    computeConvPadding(input, filter, padding, stride_width, dilation_width_factor, 2);
+  params.stride_height = stride_height;
+  params.stride_width = stride_width;
+  params.dilation_height_factor = dilation_height_factor;
+  params.dilation_width_factor = dilation_width_factor;
+
+  return params;
+}
+
+} // namespace luci_interpreter

--- a/onert-micro/luci-interpreter/src/kernels/ConvolutionCommon.h
+++ b/onert-micro/luci-interpreter/src/kernels/ConvolutionCommon.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef LUCI_INTERPRETER_KERNELS_CONVOLUTIONCOMMON_H
+#define LUCI_INTERPRETER_KERNELS_CONVOLUTIONCOMMON_H
+
+#include "Builders.h"
+#include "Utils.h"
+
+namespace luci_interpreter
+{
+
+int32_t computeConvPadding(const circle::Tensor *input, const circle::Tensor *filter,
+                           circle::Padding padding, int32_t stride, int32_t dilation, int axis);
+
+luci_interpreter_pal::ConvParams createConv2DParams(const circle::Tensor *input,
+                                                    const circle::Tensor *filter,
+                                                    const circle::Tensor *output,
+                                                    const circle::Conv2DOptions *options);
+
+namespace kernels
+{
+
+// Conv2D kernel for downsampling
+class DownsamplingConv2DKernel
+{
+public:
+  DownsamplingConv2DKernel() = delete;
+
+  explicit DownsamplingConv2DKernel(const circle::Operator *cur_op, BaseRuntimeGraph *runtime_graph)
+    : _runtime_graph(runtime_graph)
+  {
+    const auto input_index = cur_op->inputs()->operator[](0);
+    const auto filter_index = cur_op->inputs()->operator[](1);
+    const auto bias_index = cur_op->inputs()->operator[](2);
+    const auto output_index = cur_op->outputs()->operator[](0);
+
+    assert(input_index != -1);
+    assert(filter_index != -1);
+    assert(output_index != -1);
+
+    _input_tensor = _runtime_graph->getCircleTensorByIndex(input_index);
+    _filter_tensor = _runtime_graph->getCircleTensorByIndex(filter_index);
+    _bias_tensor = _runtime_graph->getCircleTensorByIndex(bias_index);
+    _output_tensor = _runtime_graph->getCircleTensorByIndex(output_index);
+
+    assert(_input_tensor != nullptr);
+    assert(_filter_tensor != nullptr);
+  }
+
+  const circle::Tensor *input() const { return _input_tensor; }
+  const circle::Tensor *filter() const { return _filter_tensor; }
+  const circle::Tensor *bias() const { return _bias_tensor; }
+  const circle::Tensor *output() const { return _output_tensor; }
+
+  BaseRuntimeGraph *runtime_graph() const { return _runtime_graph; }
+
+private:
+  const circle::Tensor *_input_tensor;
+  const circle::Tensor *_filter_tensor;
+  const circle::Tensor *_bias_tensor;
+  const circle::Tensor *_output_tensor;
+
+  BaseRuntimeGraph *_runtime_graph;
+};
+
+} // namespace kernels
+} // namespace luci_interpreter
+
+#endif // LUCI_INTERPRETER_KERNELS_CONVOLUTIONCOMMON_H


### PR DESCRIPTION
This commit reduces duplicate code in convolution kernels.
  - Introduce `ConvolutionCommon.h` that has functions for convolution kernels. 
    - Introduce `DownsamplingConv2DKernel` that unifies Conv2D kernels for downsampling. 
    - Introduce `createConvParams()` that creates `luci_interpreter_pal::ConvParams` from Conv2D op.
  - Apply common functions for convolution kernels.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>

---

For #11744