### PR TITLE
[Draft][one-cmds] Add create-quant-dataset option to onecc

### DIFF
--- a/compiler/one-cmds/onecc
+++ b/compiler/one-cmds/onecc
@@ -47,6 +47,9 @@ subtool_list = {
         'profile': 'Profile backend model file',
         'infer': 'Infer backend model file'
     },
+    'tool': {
+        'create-quant-dataset': 'Create quantize dataset for our toolchain'
+    },
 }
 
 
@@ -102,6 +105,10 @@ def _get_parser():
     backend_group = parser.add_argument_group('run backend tools')
     for tool, desc in subtool_list['backend'].items():
         backend_group.add_argument(tool, action='store_true', help=desc)
+
+    tool_group = parser.add_argument_group('run tool for our toolchain')
+    for tool, desc in subtool_list['tool'].items():
+        tool_group.add_argument(tool, action='store_true', help=desc)
 
     return parser
 

--- a/compiler/one-cmds/tests/onecc_059.test
+++ b/compiler/one-cmds/tests/onecc_059.test
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# test onecc create-quant-dataset
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  echo "${filename_ext} FAILED"
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+outputfile="output_onecc_one-create-quant-dataset_testdata_001.h5"
+
+rm -f ${filename}.log
+rm -rf ${outputfile}
+
+# run test
+onecc create-quant-dataset \
+--input_data_format rawdata \
+--data_list datalist.txt \
+--output_path ${outputfile} > ${filename}.log 2>&1
+
+if [[ ! -s "${outputfile}" ]]; then
+  trap_err_onexit
+fi
+
+echo "${filename_ext} SUCCESS"

--- a/compiler/one-cmds/tests/onecc_neg_037.test
+++ b/compiler/one-cmds/tests/onecc_neg_037.test
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# negative usage with non-existing data_list file
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  if grep -q "No such file" "${filename}.log"; then
+    echo "${filename_ext} SUCCESS"
+    exit 0
+  fi
+
+  echo "${filename_ext} FAILED"
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+inputfile="./wronglist.txt"
+outputfile="output_onecc_one-create-quant-dataset_testdata_001.h5"
+
+rm -f ${filename}.log
+rm -rf ${outputfile}
+
+touch ${inputfile}
+echo "non-existing-file.data" >> ${inputfile}
+
+# run test
+onecc create-quant-dataset \
+--input_data_format rawdata \
+--data_list ${inputfile} \
+--output_path ${outputfile} > ${filename}.log 2>&1
+
+echo "${filename_ext} FAILED"
+exit 255


### PR DESCRIPTION
This commit adds create-quant-dataset option to onecc. 
Add, it contains test cases of onecc.

ONE-DCO-1.0-Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>

---
Related issue : https://github.com/Samsung/ONE/issues/12053