### PR TITLE
[onert] Extract fused activation backprop to OperationUtils

### DIFF
--- a/runtime/onert/backend/train/ops/ConvolutionLayer.cc
+++ b/runtime/onert/backend/train/ops/ConvolutionLayer.cc
@@ -134,21 +134,16 @@ void ConvolutionLayer::backwardFloat32()
 {
   // Calculate gradient for activation
   const IPortableTensor *backprop_act;
-  switch (_activation)
+  try
   {
-    case ir::Activation::NONE:
-      backprop_act = _back_prop_output;
-      break;
-    case ir::Activation::RELU:
-      nnfw::cker::train::ReLUGrad(getShape(_output), getBuffer<float>(_output),
-                                  getShape(_back_prop_output), getBuffer<float>(_back_prop_output),
-                                  getShape(_act_back_prop_output.get()),
-                                  getBuffer<float>(_act_back_prop_output.get()));
-      backprop_act = _act_back_prop_output.get();
-      break;
-    default:
-      throw std::runtime_error("train ConvolutionLayer: Unsupported activation type yet");
+    backprop_act =
+      backpropActivation(_activation, _output, _back_prop_output, _act_back_prop_output.get());
   }
+  catch (const std::exception &e)
+  {
+    throw std::runtime_error{"train ConvolutionLayer: " + std::string(e.what())};
+  }
+  assert(backprop_act != nullptr);
 
   // Initialize conv params for training kernels
   nnfw::cker::ConvParams conv_train_params;

--- a/runtime/onert/backend/train/ops/FullyConnectedLayer.cc
+++ b/runtime/onert/backend/train/ops/FullyConnectedLayer.cc
@@ -134,21 +134,16 @@ void FullyConnectedLayer::backwardFloat32()
 {
   // Calculate gradient for activation
   const IPortableTensor *backprop_act;
-  switch (_activation)
+  try
   {
-    case ir::Activation::NONE:
-      backprop_act = _back_prop_output;
-      break;
-    case ir::Activation::RELU:
-      nnfw::cker::train::ReLUGrad(getShape(_output), getBuffer<float>(_output),
-                                  getShape(_back_prop_output), getBuffer<float>(_back_prop_output),
-                                  getShape(_act_back_prop_output.get()),
-                                  getBuffer<float>(_act_back_prop_output.get()));
-      backprop_act = _act_back_prop_output.get();
-      break;
-    default:
-      throw std::runtime_error("train FullyConnectedLayer: Unsupported activation type yet");
+    backprop_act =
+      backpropActivation(_activation, _output, _back_prop_output, _act_back_prop_output.get());
   }
+  catch (const std::exception &e)
+  {
+    throw std::runtime_error{"train FullyConnectedLayer: " + std::string(e.what())};
+  }
+  assert(backprop_act != nullptr);
 
   // Initialize TransposeParams
   nnfw::cker::TransposeParams transpose_param;

--- a/runtime/onert/backend/train/ops/OperationUtils.cc
+++ b/runtime/onert/backend/train/ops/OperationUtils.cc
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "OperationUtils.h"
+
+#include <cker/train/operation/ReLU.h>
+#include <cker/train/operation/ReLU6.h>
+
+namespace onert
+{
+namespace backend
+{
+namespace train
+{
+namespace ops
+{
+
+const IPortableTensor *backpropActivation(const ir::Activation &activation,
+                                          const IPortableTensor *output,
+                                          const IPortableTensor *input_backprop,
+                                          IPortableTensor *output_backprop)
+{
+  // handle NONE - just propagate incoming gradient
+  if (activation == ir::Activation::NONE)
+  {
+    return input_backprop;
+  }
+
+  // handle other activation
+  assert(output_backprop != nullptr);
+  switch (activation)
+  {
+    case ir::Activation::RELU:
+      nnfw::cker::train::ReLUGrad(getShape(output), getBuffer<float>(output),
+                                  getShape(input_backprop), getBuffer<float>(input_backprop),
+                                  getShape(output_backprop), getBuffer<float>(output_backprop));
+      break;
+    // TODO: Add ReLU6
+    default:
+      throw std::runtime_error("Unsupported activation type yet");
+  }
+  return output_backprop;
+}
+
+} // namespace ops
+} // namespace train
+} // namespace backend
+} // namespace onert

--- a/runtime/onert/backend/train/ops/OperationUtils.cc
+++ b/runtime/onert/backend/train/ops/OperationUtils.cc
@@ -33,14 +33,18 @@ const IPortableTensor *backpropActivation(const ir::Activation &activation,
                                           const IPortableTensor *input_backprop,
                                           IPortableTensor *output_backprop)
 {
+  assert(output != nullptr);
+  assert(input_backprop != nullptr);
+
   // handle NONE - just propagate incoming gradient
   if (activation == ir::Activation::NONE)
   {
     return input_backprop;
   }
 
-  // handle other activation
   assert(output_backprop != nullptr);
+
+  // handle other activation
   switch (activation)
   {
     case ir::Activation::RELU:

--- a/runtime/onert/backend/train/ops/OperationUtils.h
+++ b/runtime/onert/backend/train/ops/OperationUtils.h
@@ -52,14 +52,14 @@ using cpu::ops::getSizeOfDimension;
  *                        In other words, incoming gradient to current layer
  * @param output_backprop backward direction's output of activation,
  *                        In other words, outcoming gradient of current layer's acitvation
- *                        If activation is NONE, this param isn't necessary
+ *                        If activation is NONE, this param can be nullptr
  * @return tensor that holds backpropagate result of activation
  *         If activation is NONE, just return input_backprop
  */
 const IPortableTensor *backpropActivation(const ir::Activation &activation,
                                           const IPortableTensor *output,
                                           const IPortableTensor *input_backprop,
-                                          IPortableTensor *output_backprop = nullptr);
+                                          IPortableTensor *output_backprop);
 
 } // namespace ops
 } // namespace train

--- a/runtime/onert/backend/train/ops/OperationUtils.h
+++ b/runtime/onert/backend/train/ops/OperationUtils.h
@@ -36,6 +36,31 @@ using cpu::ops::getNumberOfDimensions;
 using cpu::ops::getNumberOfElements;
 using cpu::ops::getSizeOfDimension;
 
+/**
+ * @brief backpropagate acitvation
+ *
+ *             -- forward direction -->
+ *
+ *   [ current layer ]   ----   [ next layer ]
+ *   [ op    |  act  ]
+ *
+ *             <-- backward direction --
+ *
+ * @param activation      activation of current layer
+ * @param output          forward direction's output of current layer
+ * @param input_backprop  backward direction's output of next layer
+ *                        In other words, incoming gradient to current layer
+ * @param output_backprop backward direction's output of activation,
+ *                        In other words, outcoming gradient of current layer's acitvation
+ *                        If activation is NONE, this param isn't necessary
+ * @return tensor that holds backpropagate result of activation
+ *         If activation is NONE, just return input_backprop
+ */
+const IPortableTensor *backpropActivation(const ir::Activation &activation,
+                                          const IPortableTensor *output,
+                                          const IPortableTensor *input_backprop,
+                                          IPortableTensor *output_backprop = nullptr);
+
 } // namespace ops
 } // namespace train
 } // namespace backend

--- a/runtime/onert/backend/train/ops/PoolLayer.cc
+++ b/runtime/onert/backend/train/ops/PoolLayer.cc
@@ -103,21 +103,17 @@ public:
   {
     assert(back_prop_out->layout() == ir::Layout::NHWC);
 
-    // activation bacward
-    switch (_activation)
+    // activation backward
+    try
     {
-      case ir::Activation::NONE:
-        break;
-      case ir::Activation::RELU:
-        nnfw::cker::train::ReLUGrad(getShape(_output), getBuffer<float>(_output),
-                                    getShape(back_prop_out), getBuffer<float>(back_prop_out),
-                                    getShape(_act_back_prop_output.get()),
-                                    getBuffer<float>(_act_back_prop_output.get()));
-        back_prop_out = _act_back_prop_output.get();
-        break;
-      default:
-        throw std::runtime_error("PoolLayer: Unsupported activation type yet");
+      back_prop_out =
+        backpropActivation(_activation, _output, back_prop_out, _act_back_prop_output.get());
     }
+    catch (const std::exception &e)
+    {
+      throw std::runtime_error{"train PoolLayer: " + std::string(e.what())};
+    }
+    assert(back_prop_out != nullptr);
 
     // maxpool baackward
     auto arg_max_index = _arg_max_index.get();


### PR DESCRIPTION
This PR extracts fused activation backpropagation part to OperationUtils. 

ONE-DCO-1.0-Signed-off-by: SeungHui Youn <sseung.youn@samsung.com>

issue : https://github.com/Samsung/ONE/issues/12388 
draft : https://github.com/Samsung/ONE/pull/12395 