### PR TITLE
[onert-micro] Enable layer-wise hybrid FC

### DIFF
--- a/onert-micro/luci-interpreter/pal/common/PALFullyConnectedCommon.h
+++ b/onert-micro/luci-interpreter/pal/common/PALFullyConnectedCommon.h
@@ -110,7 +110,11 @@ inline void FullyConnected(const FullyConnectedParams &params, const int32_t *in
       }
       output_data[out_c + output_depth * b] =
         std::min(std::max(total + bias_value, output_activation_min), output_activation_max);
-      weight_scale_ptr++;
+      if (std::is_same<WeightType, int8_t>::value)
+      {
+        if (params.is_channel_wise_quant)
+          weight_scale_ptr++;
+      }
     }
   }
 }

--- a/onert-micro/luci-interpreter/pal/common/Params.h
+++ b/onert-micro/luci-interpreter/pal/common/Params.h
@@ -46,6 +46,7 @@ struct FullyConnectedParams
   int32_t input_offset;
   int32_t weights_offset;
   const float *weights_scales;
+  bool is_channel_wise_quant;
   int32_t output_offset;
   int32_t output_multiplier;
   int output_shift;

--- a/onert-micro/luci-interpreter/src/kernels/FullyConnected.cpp
+++ b/onert-micro/luci-interpreter/src/kernels/FullyConnected.cpp
@@ -102,6 +102,7 @@ void evalFloat(const circle::Tensor *input, const circle::Tensor *weights,
       // Hybrid mode
       params.weights_scales =
         reinterpret_cast<const float *>(weights->quantization()->scale()->data());
+      params.is_channel_wise_quant = weights->quantization()->scale()->size() > 1;
       luci_interpreter_pal::FullyConnected(
         params, input_shape, kernels::getTensorData<float>(input_data), weight_shape,
         kernels::getTensorData<int8_t>(weights_data), kernels::getTensorData<float>(bias_data),
@@ -249,8 +250,7 @@ void configure_kernel_CircleFullyConnected(const circle::Operator *cur_op,
     {
       // Check it is channel wise quantization
       LUCI_INTERPRETER_CHECK(weights->quantization() != nullptr);
-      LUCI_INTERPRETER_CHECK(weights->quantization()->scale()->size() ==
-                             weights->shape()->operator[](0));
+      LUCI_INTERPRETER_CHECK(weights->quantization()->scale() != nullptr);
     }
   }
 #endif // DIS_QUANT


### PR DESCRIPTION
This commit enables layer-wise hybrid FC.

Need for some internal models.

ONE-DCO-1.0-Signed-off-by: Artem Balyshev <a.balyshev@samsung.com>