### PR TITLE
[onert] Add ReLU6 grad to OperationUtils

### DIFF
--- a/runtime/onert/backend/train/ops/OperationUtils.cc
+++ b/runtime/onert/backend/train/ops/OperationUtils.cc
@@ -52,7 +52,12 @@ const IPortableTensor *backpropActivation(const ir::Activation &activation,
                                   getShape(input_backprop), getBuffer<float>(input_backprop),
                                   getShape(output_backprop), getBuffer<float>(output_backprop));
       break;
-    // TODO: Add ReLU6
+    case ir::Activation::RELU6:
+      nnfw::cker::train::ReLU6Grad(getShape(output), getBuffer<float>(output),
+                                   getShape(input_backprop), getBuffer<float>(input_backprop),
+                                   getShape(output_backprop), getBuffer<float>(output_backprop));
+      break;
+    // TODO: Add other activation backpropagation here
     default:
       throw std::runtime_error("Unsupported activation type yet");
   }


### PR DESCRIPTION
This PR adds ReLU6 backpropagation(gradient) to OperationUtils. After this PR, onert supports training of fused ReLU6.

ONE-DCO-1.0-Signed-off-by: SeungHui Youn <sseung.youn@samsung.com>

issue : https://github.com/Samsung/ONE/issues/12388 
draft : https://github.com/Samsung/ONE/pull/12395  