### PR TITLE
[onert] Update DConvLayer to use backpropActivation

### DIFF
--- a/runtime/onert/backend/train/ops/DepthwiseConvolutionLayer.cc
+++ b/runtime/onert/backend/train/ops/DepthwiseConvolutionLayer.cc
@@ -136,21 +136,16 @@ void DepthwiseConvolutionLayer::backwardFloat32()
 {
   // Calculate gradient for activation
   const IPortableTensor *backprop_act;
-  switch (_activation)
+  try
   {
-    case ir::Activation::NONE:
-      backprop_act = _back_prop_output;
-      break;
-    case ir::Activation::RELU:
-      nnfw::cker::train::ReLUGrad(getShape(_output), getBuffer<float>(_output),
-                                  getShape(_back_prop_output), getBuffer<float>(_back_prop_output),
-                                  getShape(_act_back_prop_output.get()),
-                                  getBuffer<float>(_act_back_prop_output.get()));
-      backprop_act = _act_back_prop_output.get();
-      break;
-    default:
-      throw std::runtime_error("train DepthwiseConvolutionLayer: Unsupported activation type yet");
+    backprop_act =
+      backpropActivation(_activation, _output, _back_prop_output, _act_back_prop_output.get());
   }
+  catch (const std::exception &e)
+  {
+    throw std::runtime_error{"train DepthwiseConvolutionLayer: " + std::string(e.what())};
+  }
+  assert(backprop_act != nullptr);
 
   nnfw::cker::DepthwiseConvParams dconv_params;
   dconv_params.stride_width = _strideWidth;


### PR DESCRIPTION
This PR updates DConvLayer to use backpropActivation function in OperationUtils.

ONE-DCO-1.0-Signed-off-by: SeungHui Youn <sseung.youn@samsung.com>