### PR TITLE
[tools/onert_train] Add virtual destructor for DataLoader

### DIFF
--- a/tests/tools/onert_train/src/dataloader.h
+++ b/tests/tools/onert_train/src/dataloader.h
@@ -41,6 +41,7 @@ public:
   {
     // DO NOTHING
   }
+  virtual ~DataLoader() = default;
 
   virtual std::tuple<Generator, uint32_t>
   loadData(const uint32_t batch_size, const float from = 0.0f, const float to = 1.0f) = 0;


### PR DESCRIPTION
This PR adds a virtual destructor for the onert_train's DataLoader class. Since DataLoader is base class, it should have virtual destructor.

ONE-DCO-1.0-Signed-off-by: SeungHui Youn <sseung.youn@samsung.com>