### PR TITLE
[luci/pass] Introduce a ResolveCustomOpAddPassTest class to use TEST_F

### DIFF
--- a/compiler/luci/pass/src/ResolveCustomOpAddPass.test.cpp
+++ b/compiler/luci/pass/src/ResolveCustomOpAddPass.test.cpp
@@ -18,9 +18,19 @@
 
 #include <gtest/gtest.h>
 
-TEST(ResolveCustomOpAddPassTest, name)
+namespace
 {
-  luci::ResolveCustomOpAddPass pass;
-  auto const name = pass.name();
+
+class ResolveCustomOpAddPassTest : public ::testing::Test
+{
+public:
+  luci::ResolveCustomOpAddPass _pass;
+};
+
+} // namespace
+
+TEST_F(ResolveCustomOpAddPassTest, name)
+{
+  auto const name = _pass.name();
   ASSERT_NE(nullptr, name);
 }


### PR DESCRIPTION
This commit introduces a dummy ResolveCustomOpAddPassTest to use TEST_F.

ONE-DCO-1.0-Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>

---
Related to Issue: https://github.com/Samsung/ONE/issues/10784
Draft PR: [#10737](https://github.com/Samsung/ONE/pull/11701)