### PR TITLE
[tools/onert_train] Update onert_train to use C++17

### DIFF
--- a/tests/tools/onert_train/CMakeLists.txt
+++ b/tests/tools/onert_train/CMakeLists.txt
@@ -6,6 +6,10 @@ if(NOT BUILD_ONERT)
   return()
 endif(NOT BUILD_ONERT)
 
+# Use C++17 for onert_train
+# TODO: Remove this when we use C++17 for all runtime directories
+set(CMAKE_CXX_STANDARD 17)
+
 list(APPEND ONERT_TRAIN_SRCS "src/onert_train.cc")
 list(APPEND ONERT_TRAIN_SRCS "src/args.cc")
 list(APPEND ONERT_TRAIN_SRCS "src/nnfw_util.cc")


### PR DESCRIPTION
This PR updates onert_train to use C++17.

ONE-DCO-1.0-Signed-off-by: SeungHui Youn <sseung.youn@samsung.com>

draft : https://github.com/Samsung/ONE/pull/12445 
in the process to resolve : https://github.com/Samsung/ONE/issues/12520  