### PR TITLE
[onert] Introduce ICodegen class

### DIFF
--- a/runtime/onert/core/include/odc/ICodegen.h
+++ b/runtime/onert/core/include/odc/ICodegen.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_ODC_ICODEGEN_H__
+#define __ONERT_ODC_ICODEGEN_H__
+
+// NOTE
+// Backend code generator must implement the following two functions.
+// #ifdef __cplusplus
+// extern "C"
+// {
+// #endif
+
+// ICodegen *create_codegen();
+// void destroy_codegen(ICodegen *codegen);
+
+// #ifdef __cplusplus
+// }
+// #endif
+
+namespace onert
+{
+namespace odc
+{
+
+class ICodegen
+{
+public:
+  virtual ~ICodegen() = default;
+
+  virtual int codegen(const char *in, const char *out) = 0;
+};
+
+} // namespace odc
+} // namespace onert
+
+#endif // __ONERT_ODC_ICODEGEN_H__


### PR DESCRIPTION
This commit introduces ICodegen class.
The backend target compiler and Codegen loader will refer to this file together and will be implemented with the same structure.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>
Co-authored-by: Sanggyu Lee <sg5.lee@samsung.com>

Related issue: #12505 
Draft PR: #12504