### PR TITLE
[onert/train] Add Pad to TrainableOperationConverter

### DIFF
--- a/runtime/onert/core/src/compiler/train/TrainableOperationConverter.cc
+++ b/runtime/onert/core/src/compiler/train/TrainableOperationConverter.cc
@@ -71,6 +71,11 @@ void TrainableOperationConverter::visit(const ir::operation::Loss &node)
   _return_op = std::make_unique<ir::train::operation::Loss>(node, _training_info->lossInfo());
 }
 
+void TrainableOperationConverter::visit(const ir::operation::Pad &node)
+{
+  _return_op = std::make_unique<ir::train::operation::Pad>(node);
+}
+
 void TrainableOperationConverter::visit(const ir::operation::Permute &node)
 {
   _return_op = std::make_unique<ir::train::operation::Permute>(node);

--- a/runtime/onert/core/src/compiler/train/TrainableOperationConverter.h
+++ b/runtime/onert/core/src/compiler/train/TrainableOperationConverter.h
@@ -43,6 +43,7 @@ private:
   void visit(const ir::operation::ElementwiseActivation &) override;
   void visit(const ir::operation::FullyConnected &) override;
   void visit(const ir::operation::Loss &node) override;
+  void visit(const ir::operation::Pad &node) override;
   void visit(const ir::operation::Permute &node) override;
   void visit(const ir::operation::Pool2D &node) override;
   void visit(const ir::operation::Reduce &node) override;


### PR DESCRIPTION
Let's add Pad to TrainableOperationConverter.

ONE-DCO-1.0-Signed-off-by: Yongseop Kim <yons.kim@samsung.com>

---

for https://github.com/Samsung/ONE/issues/12413
draft https://github.com/Samsung/ONE/pull/12499
