### PR TITLE
[onert/train] Add PadLayer op to train backend

### DIFF
--- a/runtime/onert/backend/cpu/ops/PadLayer.h
+++ b/runtime/onert/backend/cpu/ops/PadLayer.h
@@ -46,7 +46,7 @@ public:
 
   void run() override;
 
-private:
+protected:
   const IPortableTensor *_input;
   IPortableTensor *_output;
 

--- a/runtime/onert/backend/train/ops/OperationUtils.h
+++ b/runtime/onert/backend/train/ops/OperationUtils.h
@@ -35,7 +35,6 @@ using cpu::ops::getShape;
 using cpu::ops::getNumberOfDimensions;
 using cpu::ops::getNumberOfElements;
 using cpu::ops::getSizeOfDimension;
-using cpu::ops::ConstDataPtr;
 
 /**
  * @brief backpropagate acitvation

--- a/runtime/onert/backend/train/ops/OperationUtils.h
+++ b/runtime/onert/backend/train/ops/OperationUtils.h
@@ -35,6 +35,7 @@ using cpu::ops::getShape;
 using cpu::ops::getNumberOfDimensions;
 using cpu::ops::getNumberOfElements;
 using cpu::ops::getSizeOfDimension;
+using cpu::ops::ConstDataPtr;
 
 /**
  * @brief backpropagate acitvation

--- a/runtime/onert/backend/train/ops/PadLayer.cc
+++ b/runtime/onert/backend/train/ops/PadLayer.cc
@@ -36,17 +36,15 @@ PadLayer::PadLayer()
 
 template <typename T> void PadLayer::padImpl(const T *constant_value_data)
 {
-  nnfw::cker::Pad<T>(_padData, _padRank,
-                            getShape(_input), getBuffer<T>(_input),
-                            getShape(_output), getBuffer<T>(_output),
-                            constant_value_data);
+  nnfw::cker::Pad<T>(_padData, _padRank, getShape(_input), getBuffer<T>(_input), getShape(_output),
+                     getBuffer<T>(_output), constant_value_data);
 }
 
 template <typename T> void PadLayer::depad()
 {
-  nnfw::cker::train::Depad<T>(_padData, _padRank,
-                              getShape(_back_prop_output), getBuffer<T>(_back_prop_output),
-                              getShape(_back_prop_input), getBuffer<T>(_back_prop_input));
+  nnfw::cker::train::Depad<T>(_padData, _padRank, getShape(_back_prop_output),
+                              getBuffer<T>(_back_prop_output), getShape(_back_prop_input),
+                              getBuffer<T>(_back_prop_input));
 }
 
 void PadLayer::configure(const IPortableTensor *input, IPortableTensor *output,

--- a/runtime/onert/backend/train/ops/PadLayer.cc
+++ b/runtime/onert/backend/train/ops/PadLayer.cc
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "PadLayer.h"
+
+#include <cker/train/operation/Pad.h>
+
+namespace onert
+{
+namespace backend
+{
+namespace train
+{
+namespace ops
+{
+
+PadLayer::PadLayer()
+  : _input(nullptr), _output(nullptr), _padData(), _padRank(), _constantValueData(),
+    _back_prop_input{nullptr}, _back_prop_output{nullptr}
+{
+  // DO NOTHING
+}
+
+template <typename T> void PadLayer::padImpl(const T *constant_value_data)
+{
+  nnfw::cker::Pad<T>(_padData, _padRank,
+                            getShape(_input), getBuffer<T>(_input),
+                            getShape(_output), getBuffer<T>(_output),
+                            constant_value_data);
+}
+
+template <typename T> void PadLayer::depad()
+{
+  nnfw::cker::train::Depad<T>(_padData, _padRank,
+                              getShape(_back_prop_output), getBuffer<T>(_back_prop_output),
+                              getShape(_back_prop_input), getBuffer<T>(_back_prop_input));
+}
+
+void PadLayer::configure(const IPortableTensor *input, IPortableTensor *output,
+                         const int32_t *padData, int32_t padRank, const void *constantValueData,
+                         IPortableTensor *back_prop_input, const IPortableTensor *back_prop_output)
+{
+  _input = input;
+  _output = output;
+  memcpy(_padData, padData, sizeof(_padData));
+  _padRank = padRank;
+  _constantValueData.v = constantValueData;
+  _back_prop_input = back_prop_input;
+  _back_prop_output = back_prop_output;
+}
+
+void PadLayer::forward(bool)
+{
+  switch (_input->data_type())
+  {
+    case OperandType::FLOAT32:
+      padImpl<float>(_constantValueData.f);
+      break;
+    case OperandType::QUANT_UINT8_ASYMM:
+      if (_constantValueData.u8 == nullptr)
+      {
+        uint8_t pad_value = static_cast<uint8_t>(_output->data_zero_point());
+        padImpl<uint8_t>(&pad_value);
+      }
+      else
+      {
+        padImpl<uint8_t>(_constantValueData.u8);
+      }
+      break;
+    case OperandType::QUANT_INT8_ASYMM:
+      if (_constantValueData.i8 == nullptr)
+      {
+        int8_t pad_value = static_cast<int8_t>(_output->data_zero_point());
+        padImpl<int8_t>(&pad_value);
+      }
+      else
+      {
+        padImpl<int8_t>(_constantValueData.i8);
+      }
+      break;
+    default:
+      throw std::runtime_error{"Pad: unsupported data type"};
+  }
+}
+
+void PadLayer::backward()
+{
+  switch (_back_prop_output->data_type())
+  {
+    case OperandType::FLOAT32:
+      depad<float>();
+      break;
+    case OperandType::QUANT_UINT8_ASYMM:
+      depad<uint8_t>();
+      break;
+    case OperandType::QUANT_INT8_ASYMM:
+      depad<int8_t>();
+      break;
+    default:
+      throw std::runtime_error{"Pad: unsupported data type"};
+  }
+}
+
+} // namespace ops
+} // namespace train
+} // namespace backend
+} // namespace onert

--- a/runtime/onert/backend/train/ops/PadLayer.h
+++ b/runtime/onert/backend/train/ops/PadLayer.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_BACKEND_TRAIN_OPS_PADLAYER_H__
+#define __ONERT_BACKEND_TRAIN_OPS_PADLAYER_H__
+
+#include <backend/IPortableTensor.h>
+#include "OperationUtils.h"
+
+#include <exec/train/ITrainableFunction.h>
+
+namespace onert
+{
+namespace backend
+{
+namespace train
+{
+namespace ops
+{
+
+// Note, this is pad with mode=`CONSTANT`: it doesn't support `REFLECT` and
+// `SYMMETRIC`
+class PadLayer : public ::onert::exec::train::ITrainableFunction
+{
+public:
+  PadLayer();
+
+public:
+  template <typename T> void padImpl(const T *constant_value_data);
+  template <typename T> void depad();
+
+  void configure(const IPortableTensor *input, IPortableTensor *output,
+                         const int32_t *padData, int32_t padRank, const void *constantValueData,
+                         IPortableTensor *back_prop_input, const IPortableTensor *back_prop_output);
+  void forward(bool training) override;
+  void backward() override;
+
+private:
+  const IPortableTensor *_input;
+  IPortableTensor *_output;
+
+  int32_t _padData[8];
+  int32_t _padRank;
+  ConstDataPtr _constantValueData;
+
+  IPortableTensor *_back_prop_input;
+  const IPortableTensor *_back_prop_output;
+};
+
+} // namespace ops
+} // namespace train
+} // namespace backend
+} // namespace onert
+
+#endif // __ONERT_BACKEND_TRAIN_OPS_PADLAYER_H__

--- a/runtime/onert/backend/train/ops/PadLayer.h
+++ b/runtime/onert/backend/train/ops/PadLayer.h
@@ -42,9 +42,9 @@ public:
   template <typename T> void padImpl(const T *constant_value_data);
   template <typename T> void depad();
 
-  void configure(const IPortableTensor *input, IPortableTensor *output,
-                         const int32_t *padData, int32_t padRank, const void *constantValueData,
-                         IPortableTensor *back_prop_input, const IPortableTensor *back_prop_output);
+  void configure(const IPortableTensor *input, IPortableTensor *output, const int32_t *padData,
+                 int32_t padRank, const void *constantValueData, IPortableTensor *back_prop_input,
+                 const IPortableTensor *back_prop_output);
   void forward(bool training) override;
   void backward() override;
 

--- a/runtime/onert/backend/train/ops/PadLayer.h
+++ b/runtime/onert/backend/train/ops/PadLayer.h
@@ -17,6 +17,7 @@
 #ifndef __ONERT_BACKEND_TRAIN_OPS_PADLAYER_H__
 #define __ONERT_BACKEND_TRAIN_OPS_PADLAYER_H__
 
+#include <ops/PadLayer.h>
 #include <backend/IPortableTensor.h>
 #include "OperationUtils.h"
 
@@ -33,13 +34,12 @@ namespace ops
 
 // Note, this is pad with mode=`CONSTANT`: it doesn't support `REFLECT` and
 // `SYMMETRIC`
-class PadLayer : public ::onert::exec::train::ITrainableFunction
+class PadLayer : public ::onert::exec::train::ITrainableFunction, public cpu::ops::PadLayer
 {
 public:
   PadLayer();
 
 public:
-  template <typename T> void padImpl(const T *constant_value_data);
   template <typename T> void depad();
 
   void configure(const IPortableTensor *input, IPortableTensor *output, const int32_t *padData,
@@ -49,13 +49,6 @@ public:
   void backward() override;
 
 private:
-  const IPortableTensor *_input;
-  IPortableTensor *_output;
-
-  int32_t _padData[8];
-  int32_t _padRank;
-  ConstDataPtr _constantValueData;
-
   IPortableTensor *_back_prop_input;
   const IPortableTensor *_back_prop_output;
 };


### PR DESCRIPTION
This commit adds PadLayer op to train backend.

ONE-DCO-1.0-Signed-off-by: Yongseop Kim <yons.kim@samsung.com>

---

for https://github.com/Samsung/ONE/issues/12413
draft https://github.com/Samsung/ONE/pull/12499