### PR TITLE
[tools/onert_run] Introduce compile and cpath arguments

### DIFF
--- a/tests/tools/onert_run/src/args.cc
+++ b/tests/tools/onert_run/src/args.cc
@@ -304,6 +304,15 @@ void Args::Initialize(void)
     ("qpath", po::value<std::string>()->default_value("")->notifier([&](const auto &v) { _quantized_model_path = v; }),
          "Path to export quantized model.\n"
          "If it is not set, the quantized model will be exported to the same directory of the original model/package with q8/q16 suffix.")
+    ("compile,c", po::value<std::string>()->default_value("")->notifier([&](const auto &v) { _compile = v; }),
+         "Target backend name to compile model\n"
+         "The target string will be used to find a backend library.\n"
+         "This string should be in the following format:\n"
+         "{backend extension} + '-gen'.\n"
+         "For detailed description, please see the description of nnfw_compile()")
+    ("cpath", po::value<std::string>()->default_value("")->notifier([&](const auto &v) { _compiled_model_path = v; }),
+         "Path to export compiled model.\n"
+         "If it is not set, the compiled model will be exported to the same directory of the original model/package with target backend extension.")
     ;
   // clang-format on
 

--- a/tests/tools/onert_run/src/args.h
+++ b/tests/tools/onert_run/src/args.h
@@ -72,6 +72,8 @@ public:
   const int getVerboseLevel(void) const { return _verbose_level; }
   const std::string &getQuantize(void) const { return _quantize; }
   const std::string &getQuantizedModelPath(void) const { return _quantized_model_path; }
+  const std::string &getCompile(void) const { return _compile; }
+  const std::string &getCompiledModelPath(void) const { return _compiled_model_path; }
 
 private:
   void Initialize();
@@ -105,6 +107,8 @@ private:
   bool _use_single_model = false;
   std::string _quantize;
   std::string _quantized_model_path;
+  std::string _compile;
+  std::string _compiled_model_path;
 };
 
 } // end of namespace onert_run


### PR DESCRIPTION
This commit introduces compile and cpath arguments for codegen.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Related issue : https://github.com/Samsung/ONE/issues/12505
Draft PR: https://github.com/Samsung/ONE/pull/12504