### PR TITLE
[onert] Implement BinaryArithmeticLayer in train backend

### DIFF
--- a/runtime/onert/backend/cpu/ops/BinaryArithmeticLayer.h
+++ b/runtime/onert/backend/cpu/ops/BinaryArithmeticLayer.h
@@ -53,7 +53,7 @@ public:
 
   void run() override;
 
-private:
+protected:
   const IPortableTensor *_lhs;
   const IPortableTensor *_rhs;
   IPortableTensor *_output;

--- a/runtime/onert/backend/train/KernelGenerator.h
+++ b/runtime/onert/backend/train/KernelGenerator.h
@@ -46,6 +46,7 @@ public:
 
   std::unique_ptr<exec::train::TrainableFnSequence> generate(ir::OperationIndex op_ind) override;
 
+  void visit(const ir::train::operation::BinaryArithmetic &) override;
   void visit(const ir::train::operation::Conv2D &) override;
   void visit(const ir::train::operation::DepthwiseConv2D &) override;
   void visit(const ir::train::operation::ElementwiseActivation &) override;

--- a/runtime/onert/backend/train/ops/BinaryArithmeticLayer.cc
+++ b/runtime/onert/backend/train/ops/BinaryArithmeticLayer.cc
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "BinaryArithmeticLayer.h"
+
+#include "OperationUtils.h"
+
+#include <cker/Shape.h>
+#include <cker/train/operation/BinaryArithmetic.h>
+#include <cker/operation/BinaryArithmeticOps.h>
+#include <cker/train/operation/BinaryArithmetic.h>
+#include <cker/train/operation/ReLU.h>
+
+namespace onert
+{
+namespace backend
+{
+namespace train
+{
+namespace ops
+{
+
+BinaryArithmeticLayer::BinaryArithmeticLayer()
+  : cpu::ops::BinaryArithmeticLayer(), _back_prop_lhs{nullptr}, _back_prop_rhs{nullptr},
+    _back_prop_output{nullptr}
+{
+  // DO NOTHING
+}
+
+void BinaryArithmeticLayer::configure(const IPortableTensor *lhs, const IPortableTensor *rhs,
+                                      IPortableTensor *output, IPortableTensor *back_prop_lhs,
+                                      IPortableTensor *back_prop_rhs,
+                                      const IPortableTensor *back_prop_output,
+                                      const ir::Activation activation,
+                                      const ArithmeticType arithmetic_type)
+{
+  cpu::ops::BinaryArithmeticLayer::configure(
+    lhs, rhs, output, activation, static_cast<cpu::ops::ArithmeticType>(arithmetic_type));
+
+  _back_prop_lhs = back_prop_lhs;
+  _back_prop_rhs = back_prop_rhs;
+  _back_prop_output = back_prop_output;
+  _arithmetic_type = arithmetic_type;
+  _activation = activation;
+}
+
+void BinaryArithmeticLayer::forward(bool) { cpu::ops::BinaryArithmeticLayer::run(); }
+
+void BinaryArithmeticLayer::backward()
+{
+  // Calculate gradient for activation
+  if (_back_prop_output->data_type() != OperandType::FLOAT32)
+    throw std::runtime_error{"Unsupported Data Type"};
+
+  const IPortableTensor *backprop_act;
+  try
+  {
+    backprop_act =
+      backpropActivation(_activation, _output, _back_prop_output, _act_back_prop_output.get());
+  }
+  catch (const std::exception &e)
+  {
+    throw std::runtime_error{"train BinaryArithmeticLayer: " + std::string(e.what())};
+  }
+  assert(backprop_act != nullptr);
+
+  nnfw::cker::train::BinaryArithmeticGrad(
+    getShape(backprop_act), getBuffer<float>(backprop_act), getShape(_back_prop_lhs),
+    getBuffer<float>(_back_prop_lhs), getShape(_back_prop_rhs), getBuffer<float>(_back_prop_rhs),
+    static_cast<nnfw::cker::train::ArithmeticType>(_arithmetic_type));
+}
+
+} // namespace ops
+} // namespace train
+} // namespace backend
+} // namespace onert

--- a/runtime/onert/backend/train/ops/BinaryArithmeticLayer.h
+++ b/runtime/onert/backend/train/ops/BinaryArithmeticLayer.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_BACKEND_TRAIN_OPS_BINARYARITHMETICLAYER_H__
+#define __ONERT_BACKEND_TRAIN_OPS_BINARYARITHMETICLAYER_H__
+
+#include <ops/BinaryArithmeticLayer.h>
+#include <backend/IPortableTensor.h>
+
+#include "../Tensor.h"
+#include <exec/train/ITrainableFunction.h>
+
+namespace onert
+{
+namespace backend
+{
+namespace train
+{
+namespace ops
+{
+
+enum class ArithmeticType
+{
+  kAdd,
+  kSub,
+  kMul,
+  kDiv,
+};
+
+class BinaryArithmeticLayer : public ::onert::exec::train::ITrainableFunction,
+                              public cpu::ops::BinaryArithmeticLayer
+{
+public:
+  BinaryArithmeticLayer();
+
+public:
+  void configure(const IPortableTensor *lhs, const IPortableTensor *rhs, IPortableTensor *output,
+                 IPortableTensor *back_prop_lhs, IPortableTensor *back_prop_rhs,
+                 const IPortableTensor *back_prop_output, const ir::Activation activation,
+                 const ArithmeticType arithmetic_type);
+  void forward(bool training) override;
+  void backward() override;
+
+private:
+  IPortableTensor *_back_prop_lhs;
+  IPortableTensor *_back_prop_rhs;
+  const IPortableTensor *_back_prop_output;
+
+  ArithmeticType _arithmetic_type;
+  ir::Activation _activation;
+  std::unique_ptr<BackPropTensor> _act_back_prop_output;
+};
+
+} // namespace ops
+} // namespace train
+} // namespace backend
+} // namespace onert
+
+#endif // __ONERT_BACKEND_TRAIN_OPS_BINARYARITHMETICLAYER_H__


### PR DESCRIPTION
This commit implements BinaryArithmeticLayer in train backend.

From draft https://github.com/Samsung/ONE/pull/12417