### PR TITLE
[tools/onert_train] Revise args to hold NNFW_TRAIN_* enum

### DIFF
--- a/tests/tools/onert_train/src/args.cc
+++ b/tests/tools/onert_train/src/args.cc
@@ -15,6 +15,8 @@
  */
 
 #include "args.h"
+#include "nnfw_util.h"
+#include "misc/to_underlying.h"
 
 #include <functional>
 #include <iostream>
@@ -94,6 +96,33 @@ void checkPackage(const std::string &package_filename)
       exit(1);
     }
   }
+}
+
+// check the value is in the valid_args list and return the corresponded enum
+template <typename T>
+T checkValidation(const std::string &arg_name, const std::vector<T> &valid_args, int value)
+{
+  for (const auto arg : valid_args)
+  {
+    if (value == nnfw::misc::to_underlying(arg))
+      return arg;
+  }
+  std::cerr << arg_name + " " + std::to_string(value) + " is unsupported argument\n";
+  exit(1);
+}
+
+// generate a help message based on the valid_args and default_arg
+template <typename T>
+std::string genHelpMsg(const std::string &arg_name, const std::vector<T> &valid_args, T default_arg)
+{
+  std::string msg = arg_name + " (default: " + onert_train::to_string(default_arg) + ")\n";
+  for (const auto arg : valid_args)
+  {
+    const auto num = nnfw::misc::to_underlying(arg);
+    msg += std::to_string(num) + ": " + onert_train::to_string(arg) + "\n";
+  }
+  msg.erase(msg.length() - 1); // remove last \n
+  return msg;
 }
 
 } // namespace
@@ -224,18 +253,21 @@ void Args::Initialize(void)
     ("epoch", po::value<int>()->default_value(5)->notifier([&](const auto &v) { _epoch = v; }), "Epoch number (default: 5)")
     ("batch_size", po::value<int>()->default_value(32)->notifier([&](const auto &v) { _batch_size = v; }), "Batch size (default: 32)")
     ("learning_rate", po::value<float>()->default_value(0.001)->notifier([&](const auto &v) { _learning_rate = v; }), "Learning rate (default: 0.001)")
-    ("loss", po::value<int>()->default_value(1)->notifier([&] (const auto &v) { _loss_type = v; }),
-        "Loss type\n"
-        "1: MEAN_SQUARED_ERROR (default)\n"
-        "2: CATEGORICAL_CROSSENTROPY")
-    ("loss_reduction_type", po::value<int>()->default_value(1)->notifier([&] (const auto &v) { _loss_reduction_type = v; }),
-        "Loss Reduction type\n"
-        "1: SUM_OVER_BATCH_SIZE(default)\n"
-        "2: SUM")
-    ("optimizer", po::value<int>()->default_value(1)->notifier([&] (const auto &v) { _optimizer_type = v; }),
-      "Optimizer type\n"
-      "1: SGD (default)\n"
-      "2: Adam")
+    ("loss", po::value<int>()
+      ->default_value(default_loss)
+      ->notifier([&](const auto& v){_loss_type = checkValidation("loss", valid_loss, v);}),
+      genHelpMsg("loss", valid_loss, default_loss).c_str()
+    )
+    ("loss_reduction_type", po::value<int>()
+      ->default_value(default_loss_rdt)
+      ->notifier([&](const auto &v){_loss_reduction_type = checkValidation("loss_reduction_type", valid_loss_rdt, v);}),
+      genHelpMsg("loss_reduction_tye", valid_loss_rdt, default_loss_rdt).c_str()
+    )
+    ("optimizer", po::value<int>()
+      ->default_value(default_optim)
+      ->notifier([&](const auto& v){_optimizer_type = checkValidation("optimizer", valid_optim, v);}),
+      genHelpMsg("optimizer", valid_optim, default_optim).c_str()
+    )
     ("metric", po::value<int>()->default_value(-1)->notifier([&] (const auto &v) { _metric_type = v; }),
       "Metric type\n"
       "Simply calculates the metric value using the variables (default: none)\n"

--- a/tests/tools/onert_train/src/args.h
+++ b/tests/tools/onert_train/src/args.h
@@ -22,6 +22,7 @@
 #include <vector>
 #include <boost/program_options.hpp>
 
+#include "nnfw_experimental.h"
 #include "types.h"
 
 namespace po = boost::program_options;
@@ -56,9 +57,9 @@ public:
   const int getEpoch(void) const { return _epoch; }
   const int getBatchSize(void) const { return _batch_size; }
   const float getLearningRate(void) const { return _learning_rate; }
-  const int getLossType(void) const { return _loss_type; }
-  const int getLossReductionType(void) const { return _loss_reduction_type; }
-  const int getOptimizerType(void) const { return _optimizer_type; }
+  const NNFW_TRAIN_LOSS getLossType(void) const { return _loss_type; }
+  const NNFW_TRAIN_LOSS_REDUCTION getLossReductionType(void) const { return _loss_reduction_type; }
+  const NNFW_TRAIN_OPTIMIZER getOptimizerType(void) const { return _optimizer_type; }
   const int getMetricType(void) const { return _metric_type; }
   const float getValidationSplit(void) const { return _validation_split; }
   const bool printVersion(void) const { return _print_version; }
@@ -68,6 +69,28 @@ public:
 private:
   void Initialize();
   void Parse(const int argc, char **argv);
+
+private:
+  // supported loss list and it's default value
+  const std::vector<NNFW_TRAIN_LOSS> valid_loss = {
+    NNFW_TRAIN_LOSS_MEAN_SQUARED_ERROR,
+    NNFW_TRAIN_LOSS_CATEGORICAL_CROSSENTROPY,
+  };
+  const NNFW_TRAIN_LOSS default_loss = NNFW_TRAIN_LOSS_MEAN_SQUARED_ERROR;
+
+  // supported loss reduction type list and it's default value
+  const std::vector<NNFW_TRAIN_LOSS_REDUCTION> valid_loss_rdt = {
+    NNFW_TRAIN_LOSS_REDUCTION_SUM_OVER_BATCH_SIZE,
+    NNFW_TRAIN_LOSS_REDUCTION_SUM,
+  };
+  const NNFW_TRAIN_LOSS_REDUCTION default_loss_rdt = NNFW_TRAIN_LOSS_REDUCTION_SUM_OVER_BATCH_SIZE;
+
+  // supported optimizer list and it's default value
+  const std::vector<NNFW_TRAIN_OPTIMIZER> valid_optim = {
+    NNFW_TRAIN_OPTIMIZER_SGD,
+    NNFW_TRAIN_OPTIMIZER_ADAM,
+  };
+  const NNFW_TRAIN_OPTIMIZER default_optim = NNFW_TRAIN_OPTIMIZER_SGD;
 
 private:
   po::positional_options_description _positional;
@@ -83,9 +106,9 @@ private:
   int _epoch;
   int _batch_size;
   float _learning_rate;
-  int _loss_type;
-  int _loss_reduction_type;
-  int _optimizer_type;
+  NNFW_TRAIN_LOSS _loss_type;
+  NNFW_TRAIN_LOSS_REDUCTION _loss_reduction_type;
+  NNFW_TRAIN_OPTIMIZER _optimizer_type;
   int _metric_type;
   float _validation_split;
   bool _print_version = false;

--- a/tests/tools/onert_train/src/onert_train.cc
+++ b/tests/tools/onert_train/src/onert_train.cc
@@ -121,45 +121,6 @@ int main(const int argc, char **argv)
     verifyInputTypes();
     verifyOutputTypes();
 
-    auto convertLossType = [](int type) {
-      switch (type)
-      {
-        case 1:
-          return NNFW_TRAIN_LOSS_MEAN_SQUARED_ERROR;
-        case 2:
-          return NNFW_TRAIN_LOSS_CATEGORICAL_CROSSENTROPY;
-        default:
-          std::cerr << "E: not supported loss type" << std::endl;
-          exit(-1);
-      }
-    };
-
-    auto convertLossReductionType = [](int type) {
-      switch (type)
-      {
-        case 1:
-          return NNFW_TRAIN_LOSS_REDUCTION_SUM_OVER_BATCH_SIZE;
-        case 2:
-          return NNFW_TRAIN_LOSS_REDUCTION_SUM;
-        default:
-          std::cerr << "E: not supported loss reduction type" << std::endl;
-          exit(-1);
-      }
-    };
-
-    auto convertOptType = [](int type) {
-      switch (type)
-      {
-        case 1:
-          return NNFW_TRAIN_OPTIMIZER_SGD;
-        case 2:
-          return NNFW_TRAIN_OPTIMIZER_ADAM;
-        default:
-          std::cerr << "E: not supported optimizer type" << std::endl;
-          exit(-1);
-      }
-    };
-
     auto getMetricTypeStr = [](int type) {
       if (type < 0)
         return "";
@@ -179,9 +140,9 @@ int main(const int argc, char **argv)
     // overwrite training information using the arguments
     tri.batch_size = args.getBatchSize();
     tri.learning_rate = args.getLearningRate();
-    tri.loss_info.loss = convertLossType(args.getLossType());
-    tri.loss_info.reduction_type = convertLossReductionType(args.getLossReductionType());
-    tri.opt = convertOptType(args.getOptimizerType());
+    tri.loss_info.loss = args.getLossType();
+    tri.loss_info.reduction_type = args.getLossReductionType();
+    tri.opt = args.getOptimizerType();
 
     std::cout << "== training parameter ==" << std::endl;
     std::cout << tri;


### PR DESCRIPTION
This PR revises Args class to hold NNFW_TRAIN_* enum directly, instead of holding integer value.

ONE-DCO-1.0-Signed-off-by: SeungHui Youn <sseung.youn@samsung.com>

draft : https://github.com/Samsung/ONE/pull/12445 
in the process to resolve : https://github.com/Samsung/ONE/issues/12520  
