### PR TITLE
[onert/cpu] Fix handling PadData of Pad op

### DIFF
--- a/runtime/onert/backend/cpu/KernelGenerator.cc
+++ b/runtime/onert/backend/cpu/KernelGenerator.cc
@@ -794,25 +794,21 @@ void KernelGenerator::visit(const ir::operation::Pad &node)
   const auto input_index{node.getInputs().at(ir::operation::Pad::Input::INPUT)};
   const auto pad_index{node.getInputs().at(ir::operation::Pad::Input::PAD)};
   const auto output_index{node.getOutputs().at(0)};
-  assert(_ctx.at(pad_index).data());
 
   auto input = _tensor_reg->getPortableTensor(input_index);
+  auto pad = _tensor_reg->getPortableTensor(pad_index);
   auto output = _tensor_reg->getPortableTensor(output_index);
-  auto pad_rank = _ctx.at(pad_index).shape().dim(0);
-  auto pad_base = reinterpret_cast<const int32_t *>(_ctx.at(pad_index).data()->base());
 
   auto fn = std::make_unique<ops::PadLayer>();
 
-  bool isPadV2 = node.getInputs().size() == 3 ? true : false;
-  const void *value = nullptr;
-
-  if (isPadV2)
+  IPortableTensor *value = nullptr;
+  if (node.getInputs().size() == 3) // isPadV2
   {
     const auto value_index{node.getInputs().at(ir::operation::Pad::Input::VALUE)};
-    value = reinterpret_cast<const void *>(_ctx.at(value_index).data()->base());
+    value = _tensor_reg->getPortableTensor(value_index);
   }
 
-  fn->configure(input, output, pad_base, pad_rank, value);
+  fn->configure(input, pad, value, output);
   _return_fn = std::move(fn);
 }
 

--- a/runtime/onert/backend/cpu/ops/PadLayer.h
+++ b/runtime/onert/backend/cpu/ops/PadLayer.h
@@ -41,17 +41,16 @@ public:
 public:
   template <typename T> void padImpl(const T *constant_value_data);
 
-  void configure(const IPortableTensor *input, IPortableTensor *output, const int32_t *padData,
-                 int32_t padRank, const void *constantValueData = nullptr);
+  void configure(const IPortableTensor *input, const IPortableTensor *pad,
+                 const IPortableTensor *value, IPortableTensor *output);
 
   void run() override;
 
 protected:
   const IPortableTensor *_input;
+  const IPortableTensor *_pad;
+  const IPortableTensor *_value;
   IPortableTensor *_output;
-
-  int32_t _padData[8];
-  int32_t _padRank;
   ConstDataPtr _constantValueData;
 };
 

--- a/runtime/onert/backend/train/ops/PadLayer.cc
+++ b/runtime/onert/backend/train/ops/PadLayer.cc
@@ -34,16 +34,20 @@ PadLayer::PadLayer() : cpu::ops::PadLayer(), _back_prop_input{nullptr}, _back_pr
 
 template <typename T> void PadLayer::depad()
 {
-  nnfw::cker::train::Depad<T>(_padData, _padRank, getShape(_back_prop_output),
+  assert(_pad->data_type() == onert::ir::DataType::INT32);
+  assert(_pad->buffer());
+  const auto pad_data = reinterpret_cast<const int32_t *>(_pad->buffer());
+  auto pad_rank = _pad->getShape().dim(0);
+  nnfw::cker::train::Depad<T>(pad_data, pad_rank, getShape(_back_prop_output),
                               getBuffer<T>(_back_prop_output), getShape(_back_prop_input),
                               getBuffer<T>(_back_prop_input));
 }
 
-void PadLayer::configure(const IPortableTensor *input, IPortableTensor *output,
-                         const int32_t *padData, int32_t padRank, const void *constantValueData,
+void PadLayer::configure(const IPortableTensor *input, const IPortableTensor *pad,
+                         const IPortableTensor *value, IPortableTensor *output,
                          IPortableTensor *back_prop_input, const IPortableTensor *back_prop_output)
 {
-  cpu::ops::PadLayer::configure(input, output, padData, padRank, constantValueData);
+  cpu::ops::PadLayer::configure(input, pad, value, output);
   _back_prop_input = back_prop_input;
   _back_prop_output = back_prop_output;
 }

--- a/runtime/onert/backend/train/ops/PadLayer.h
+++ b/runtime/onert/backend/train/ops/PadLayer.h
@@ -42,9 +42,9 @@ public:
 public:
   template <typename T> void depad();
 
-  void configure(const IPortableTensor *input, IPortableTensor *output, const int32_t *padData,
-                 int32_t padRank, const void *constantValueData, IPortableTensor *back_prop_input,
-                 const IPortableTensor *back_prop_output);
+  void configure(const IPortableTensor *input, const IPortableTensor *pad,
+                 const IPortableTensor *value, IPortableTensor *output,
+                 IPortableTensor *back_prop_input, const IPortableTensor *back_prop_output);
   void forward(bool training) override;
   void backward() override;
 


### PR DESCRIPTION
This commit fixes handling PadData of Pad op.

_**To support PadData as Tensor and const, I move handling pointer of value from KernelGenerator to PadOp::run().**_

ONE-DCO-1.0-Signed-off-by: Yongseop Kim <yons.kim@samsung.com>

---

for https://github.com/Samsung/ONE/issues/12541