### PR TITLE
[onert-micro] Add circle reader entities

### DIFF
--- a/onert-micro/onert-micro/include/core/OMDataType.h
+++ b/onert-micro/onert-micro/include/core/OMDataType.h
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ONERT_MICRO_CORE_OM_DATA_TYPE_H
+#define ONERT_MICRO_CORE_OM_DATA_TYPE_H
+
+#include "core/reader/OMCircleReader.h"
+
+#include <cstdint>
+#include <cstddef>
+#include <string>
+#include <cassert>
+
+namespace onert_micro
+{
+namespace core
+{
+/**
+ * @brief "scalar" value type
+ */
+enum class OMDataType
+{
+  Unknown, // Unknown type (serves as a default value)
+
+  U8,  // 8-bit unsigned integer
+  U16, // 16-bit unsigned integer
+  U32, // 32-bit unsigned integer
+  U64, // 64-bit unsigned integer
+
+  S8,  // 8-bit signed integer
+  S16, // 16-bit signed integer
+  S32, // 32-bit signed integer
+  S64, // 64-bit signed integer
+
+  FLOAT16, // IEEE 16-bit floating-point
+  FLOAT32, // IEEE 32-bit floating-point
+  FLOAT64, // IEEE 64-bit floating-point
+
+  BOOL, // Boolean
+};
+
+OMDataType onertMicroDatatype(const circle::TensorType type);
+
+/**
+ * @brief C++ scalar type corresponding to each OMDataType
+ */
+template <OMDataType DT> struct OMDataTypeImpl
+{
+  // using Type = ...
+};
+
+// TODO Support other enum values
+template <> struct OMDataTypeImpl<OMDataType::S8>
+{
+  // Use C++ int8_t type for 8bit integer
+  using Type = int8_t;
+};
+
+template <> struct OMDataTypeImpl<OMDataType::U8>
+{
+  // Use C++ uint8_t type for unsigned 8bit integer
+  using Type = uint8_t;
+};
+
+template <> struct OMDataTypeImpl<OMDataType::S16>
+{
+  // Use C++ int16_t type for 16bit integer
+  using Type = int16_t;
+};
+
+template <> struct OMDataTypeImpl<OMDataType::U16>
+{
+  // Use C++ uint16_t type for unsigned 16bit integer
+  using Type = uint16_t;
+};
+
+template <> struct OMDataTypeImpl<OMDataType::S32>
+{
+  // Use C++ int32_t type for 32bit integer
+  using Type = int32_t;
+};
+
+template <> struct OMDataTypeImpl<OMDataType::U32>
+{
+  // Use C++ uint32_t type for unsigned 32bit integer
+  using Type = uint32_t;
+};
+
+template <> struct OMDataTypeImpl<OMDataType::S64>
+{
+  // Use C++ int64_t type for 64bit integer
+  using Type = int64_t;
+};
+
+template <> struct OMDataTypeImpl<OMDataType::U64>
+{
+  // Use C++ uint64_t type for unsigned 64bit integer
+  using Type = uint64_t;
+};
+
+template <> struct OMDataTypeImpl<OMDataType::FLOAT16>
+{
+  // float16 type with 16bit value, encoded with help of FP16 library
+  // https://github.com/Maratyszcza/FP16/
+  using Type = uint16_t;
+};
+
+template <> struct OMDataTypeImpl<OMDataType::FLOAT32>
+{
+  // Use C++ float type for IEEE 32-bit floating-point numbers
+  using Type = float;
+};
+
+template <> struct OMDataTypeImpl<OMDataType::FLOAT64>
+{
+  // Use C++ double type for IEEE 64-bit floating-point numbers
+  using Type = double;
+};
+
+// NOTE OMDataTypeImpl for BOOL is subject to change
+template <> struct OMDataTypeImpl<OMDataType::BOOL>
+{
+  // Use C++ uint8_t type for bool
+  using Type = uint8_t;
+};
+
+/**
+ * @brief Returns the size of the data type.
+ * @note If you need the size at compile time, use `sizeof(typename OMDataTypeImpl<DT>::Type)`.
+ */
+inline uint32_t size(OMDataType data_type)
+{
+  switch (data_type)
+  {
+    case OMDataType::S8:
+      return sizeof(OMDataTypeImpl<OMDataType::S8>::Type);
+    case OMDataType::U8:
+      return sizeof(OMDataTypeImpl<OMDataType::U8>::Type);
+    case OMDataType::S16:
+      return sizeof(OMDataTypeImpl<OMDataType::S16>::Type);
+    case OMDataType::U16:
+      return sizeof(OMDataTypeImpl<OMDataType::U16>::Type);
+    case OMDataType::S32:
+      return sizeof(OMDataTypeImpl<OMDataType::S32>::Type);
+    case OMDataType::U32:
+      return sizeof(OMDataTypeImpl<OMDataType::U32>::Type);
+    case OMDataType::S64:
+      return sizeof(OMDataTypeImpl<OMDataType::S64>::Type);
+    case OMDataType::U64:
+      return sizeof(OMDataTypeImpl<OMDataType::U64>::Type);
+    case OMDataType::FLOAT16:
+      return sizeof(OMDataTypeImpl<OMDataType::FLOAT16>::Type);
+    case OMDataType::FLOAT32:
+      return sizeof(OMDataTypeImpl<OMDataType::FLOAT32>::Type);
+    case OMDataType::FLOAT64:
+      return sizeof(OMDataTypeImpl<OMDataType::FLOAT64>::Type);
+    case OMDataType::BOOL:
+      return sizeof(OMDataTypeImpl<OMDataType::BOOL>::Type);
+    default:
+      // TODO Support remaining data types.
+      assert(false);
+      return UINT32_MAX; // Avoid compiler warning.
+  }
+}
+
+inline size_t getOMDataTypeSize(OMDataType data_type) { return size(data_type); }
+
+} // namespace core
+} // namespace onert_micro
+
+#endif // ONERT_MICRO_CORE_OM_DATA_TYPE_H

--- a/onert-micro/onert-micro/include/core/OMKernelData.h
+++ b/onert-micro/onert-micro/include/core/OMKernelData.h
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ONERT_MICRO_CORE_KERNEL_DATA_H
+#define ONERT_MICRO_CORE_KERNEL_DATA_H
+
+#include "OMStatus.h"
+#include "reader/OMCircleReader.h"
+
+namespace onert_micro
+{
+namespace core
+{
+
+enum class BroadcastableOpCategory : uint8_t
+{
+  kNone,
+  kNonBroadcast,              // Matching input shapes.
+  kFirstInputBroadcastsFast,  // Fivefold nested loops.
+  kSecondInputBroadcastsFast, // Fivefold nested loops.
+  kGenericBroadcast,          // Fall-back.
+  kScalarFirstBroadcast,      // Scalar
+  kScalarSecondBroadcast,     // Scalar
+};
+
+struct ConcatenationParams
+{
+  uint32_t num_inputs;
+  uint32_t axis;
+};
+
+struct SoftmaxParams
+{
+  float beta;
+  int32_t input_multiplier;
+  int32_t input_left_shift;
+  int diff_min;
+  int num_rows;
+  int row_size;
+};
+
+struct Pool2DParams
+{
+  int32_t stride_w;
+  int32_t stride_h;
+  int32_t dilation_width_factor;
+  int32_t dilation_height_factor;
+  int32_t filter_h;
+  int32_t filter_w;
+  int32_t pad_h;
+  int32_t pad_w;
+  float activation_min;
+  float activation_max;
+  int32_t quantized_activation_min;
+  int32_t quantized_activation_max;
+};
+
+struct StridedSliceParams
+{
+  int8_t start_indices_count;
+  int32_t start_indices[5];
+  int8_t stop_indices_count;
+  int32_t stop_indices[5];
+  int8_t strides_count;
+  int32_t strides[5];
+
+  int16_t begin_mask;
+  int16_t ellipsis_mask;
+  int16_t end_mask;
+  int16_t new_axis_mask;
+  int16_t shrink_axis_mask;
+};
+
+struct BinaryArithmeticBroadcastParams
+{
+  // float activation params.
+  float float_activation_min;
+  float float_activation_max;
+  int32_t int32_activation_min;
+  int32_t int32_activation_max;
+  int64_t int64_activation_min;
+  int64_t int64_activation_max;
+  BroadcastableOpCategory broadcast_category;
+};
+
+struct FloatConv2D
+{
+  int32_t stride_w;
+  int32_t stride_h;
+  int32_t dilation_width_factor;
+  int32_t dilation_height_factor;
+  int32_t pad_h;
+  int32_t pad_w;
+  float activation_min;
+  float activation_max;
+};
+
+struct FullyConnectedParams
+{
+  // float activation params.
+  float float_activation_min;
+  float float_activation_max;
+
+  int32_t input_offset;
+  int32_t weights_offset;
+  int32_t output_offset;
+  int32_t output_multiplier;
+  int output_shift;
+  // uint8_t, etc, activation params.
+  int32_t quantized_activation_min;
+  int32_t quantized_activation_max;
+};
+
+} // namespace core
+} // namespace onert_micro
+
+#endif // ONERT_MICRO_CORE_KERNEL_DATA_H

--- a/onert-micro/onert-micro/include/core/OMKernelType.h
+++ b/onert-micro/onert-micro/include/core/OMKernelType.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ONERT_MICRO_CORE_KERNEL_TYPE_H
+#define ONERT_MICRO_CORE_KERNEL_TYPE_H
+
+#include "OMStatus.h"
+#include "reader/OMCircleReader.h"
+
+namespace onert_micro
+{
+namespace core
+{
+
+enum OMKernelType
+{
+  Normal,
+  Inplace,
+};
+
+enum OMBuilderCustomID
+{
+  CUSTOM_custom_gru,
+};
+
+#define REGISTER_KERNEL(builtin_operator, name) BuiltinOperator_##builtin_operator,
+#define REGISTER_CUSTOM_KERNEL(name, string_name) CUSTOM_##name,
+enum class OMBuilderID
+{
+#include "KernelsToBuild.lst"
+  BuiltinOperatorsSize, // casts to count of values in BuilderId enum
+#include "CustomKernelsToBuild.lst"
+  Size
+};
+#undef REGISTER_CUSTOM_KERNEL
+#undef REGISTER_KERNEL
+
+OMStatus getBuiltinOperatorBuilderId(const circle::BuiltinOperator &opcode,
+                                     core::OMBuilderID &builderID);
+
+OMStatus getCustomOperatorBuilderId(const flatbuffers::String *custom_opcode,
+                                    core::OMBuilderID &builderID);
+
+OMStatus getCustomOperatorByBuilderId(core::OMBuilderID &builderID, OMBuilderCustomID &opcode);
+
+OMStatus getBuilderId(const circle::OperatorCode *opcode, core::OMBuilderID &builderID);
+
+} // namespace core
+} // namespace onert_micro
+
+#endif // ONERT_MICRO_CORE_KERNEL_TYPE_H

--- a/onert-micro/onert-micro/include/core/reader/OMCircleReader.h
+++ b/onert-micro/onert-micro/include/core/reader/OMCircleReader.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ONERT_MICRO_CORE_READER_CIRCLE_READER_H
+#define ONERT_MICRO_CORE_READER_CIRCLE_READER_H
+
+#include "OMStatus.h"
+
+#include <circle-generated/circle/schema_generated.h>
+
+namespace onert_micro
+{
+namespace core
+{
+namespace reader
+{
+
+using CircleBuffers = flatbuffers::Vector<flatbuffers::Offset<circle::Buffer>>;
+using CircleTensors = flatbuffers::Vector<flatbuffers::Offset<circle::Tensor>>;
+using CircleOperators = flatbuffers::Vector<flatbuffers::Offset<circle::Operator>>;
+using CircleOperatorCodes = flatbuffers::Vector<flatbuffers::Offset<circle::OperatorCode>>;
+using CircleMetadataSet = flatbuffers::Vector<flatbuffers::Offset<circle::Metadata>>;
+using CircleValues = flatbuffers::Vector<int32_t>;
+
+/**
+ * @brief Loads Circle file and provides helpers to access attributes
+ */
+class OMCircleReader
+{
+public:
+  OMCircleReader() = default;
+  OMCircleReader(const OMCircleReader &) = delete;
+  OMCircleReader(OMCircleReader &&) = default;
+  OMCircleReader &operator=(const OMCircleReader &) = delete;
+  OMCircleReader &&operator=(const OMCircleReader &&) = delete;
+  ~OMCircleReader() = default;
+
+public: // direct API
+  const CircleOperatorCodes *opcodes() const { return _model->operator_codes(); }
+  const CircleBuffers *buffers() const { return _model->buffers(); }
+  const CircleTensors *tensors() const { return _current_subgraph->tensors(); }
+  const CircleOperators *operators() const { return _current_subgraph->operators(); }
+  const CircleValues *inputs() const { return _current_subgraph->inputs(); }
+  const CircleValues *outputs() const { return _current_subgraph->outputs(); }
+  const circle::DataFormat data_format() const { return _current_subgraph->data_format(); }
+  const CircleMetadataSet *metadata() const { return _model->metadata(); }
+
+  uint32_t num_subgraph() const { return _model->subgraphs()->size(); }
+  circle::BuiltinOperator builtin_code(const circle::Operator *op) const;
+
+public:
+  OMStatus parse(const char *model_ptr);
+  OMStatus select_subgraph(uint32_t subgraph);
+  uint32_t get_current_subgraph_index() const { return _current_subgraph_index; }
+
+  // helpers
+public:
+  bool isConstTensor(uint32_t tensor_index);
+
+private:
+  const circle::Model *_model{nullptr};
+  const circle::SubGraph *_current_subgraph{nullptr};
+  uint32_t _current_subgraph_index{0};
+};
+
+} // namespace reader
+} // namespace core
+} // namespace onert_micro
+
+#endif // ONERT_MICRO_CORE_READER_CIRCLE_READER_H

--- a/onert-micro/onert-micro/src/core/OMDataType.cpp
+++ b/onert-micro/onert-micro/src/core/OMDataType.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "core/OMDataType.h"
+
+onert_micro::core::OMDataType onert_micro::core::onertMicroDatatype(const circle::TensorType type)
+{
+  switch (type)
+  {
+    case circle::TensorType_FLOAT32:
+      return OMDataType::FLOAT32;
+    case circle::TensorType_FLOAT16:
+      return OMDataType::FLOAT16;
+    case circle::TensorType_INT32:
+      return OMDataType::S32;
+    case circle::TensorType_UINT8:
+      return OMDataType::U8;
+    case circle::TensorType_INT64:
+      return OMDataType::S64;
+    case circle::TensorType_BOOL:
+      return OMDataType::BOOL;
+    case circle::TensorType_INT16:
+      return OMDataType::S16;
+    case circle::TensorType_COMPLEX64:
+      break;
+    case circle::TensorType_INT8:
+      return OMDataType::S8;
+    default:
+      break;
+  }
+  assert(false);
+  return OMDataType::Unknown;
+}

--- a/onert-micro/onert-micro/src/core/OMKernelType.cpp
+++ b/onert-micro/onert-micro/src/core/OMKernelType.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "core/OMKernelType.h"
+
+using namespace onert_micro::core;
+using namespace onert_micro;
+
+OMStatus onert_micro::core::getBuiltinOperatorBuilderId(const circle::BuiltinOperator &opcode,
+                                                        core::OMBuilderID &builderID)
+{
+  switch (opcode)
+  {
+#define REGISTER_KERNEL(builtin_operator, name)                        \
+  case circle::BuiltinOperator_##builtin_operator:                     \
+    builderID = core::OMBuilderID::BuiltinOperator_##builtin_operator; \
+    break;
+#include "KernelsToBuild.lst"
+#undef REGISTER_KERNEL
+    default:
+      assert(false && "Unsupported operation");
+      return UnsupportedOp;
+  }
+  return Ok;
+}
+
+OMStatus onert_micro::core::getCustomOperatorByBuilderId(core::OMBuilderID &builderID,
+                                                         OMBuilderCustomID &opcode)
+{
+  switch (builderID)
+  {
+#define REGISTER_CUSTOM_KERNEL(name, string_name)    \
+  case core::OMBuilderID::CUSTOM_##name:             \
+    opcode = core::OMBuilderCustomID::CUSTOM_##name; \
+    break;
+#include "CustomKernelsToBuild.lst"
+#undef REGISTER_CUSTOM_KERNEL
+    default:
+      assert(false && "Unsupported operation");
+      return UnsupportedOp;
+  }
+  return Ok;
+}
+
+OMStatus onert_micro::core::getBuilderId(const circle::OperatorCode *opcode,
+                                         core::OMBuilderID &builderID)
+{
+  OMStatus status;
+
+  if (opcode->builtin_code() == circle::BuiltinOperator_CUSTOM)
+    status = core::getCustomOperatorBuilderId(opcode->custom_code(), builderID);
+  else
+    status = core::getBuiltinOperatorBuilderId(opcode->builtin_code(), builderID);
+
+  assert(status == Ok && "Unknown operation");
+  if (status == UnsupportedOp or builderID == core::OMBuilderID::Size)
+    return UnsupportedOp;
+
+  return status;
+}
+
+OMStatus onert_micro::core::getCustomOperatorBuilderId(const flatbuffers::String *custom_opcode,
+                                                       core::OMBuilderID &builderID)
+{
+#define REGISTER_CUSTOM_KERNEL(name, string_name)    \
+  const char arr[] = string_name;                    \
+  if (std::strcmp(custom_opcode->c_str(), arr) == 0) \
+  {                                                  \
+    builderID = core::OMBuilderID::CUSTOM_##name;    \
+    return Ok;                                       \
+  }
+#include "CustomKernelsToBuild.lst"
+#undef REGISTER_CUSTOM_KERNEL
+  assert(false && "Unsupported custom operation");
+  return UnsupportedOp;
+}

--- a/onert-micro/onert-micro/src/core/reader/OMCircleReader.cpp
+++ b/onert-micro/onert-micro/src/core/reader/OMCircleReader.cpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "core/reader/OMCircleReader.h"
+
+using namespace onert_micro::core::reader;
+using namespace onert_micro;
+
+namespace
+{
+
+circle::BuiltinOperator builtin_code_neutral(const ::circle::OperatorCode *opcode)
+{
+  assert(opcode != nullptr);
+  if (opcode->deprecated_builtin_code() == 127)
+  {
+    assert(opcode->builtin_code() >= 127);
+    return opcode->builtin_code();
+  }
+  // There was no 255(-1) value in v0.3
+  assert(opcode->deprecated_builtin_code() != -1);
+  return static_cast<::circle::BuiltinOperator>(opcode->deprecated_builtin_code());
+}
+
+} // namespace
+
+circle::BuiltinOperator OMCircleReader::builtin_code(const circle::Operator *op) const
+{
+  assert(op != nullptr);
+
+  const auto op_codes = opcodes();
+  uint32_t index = op->opcode_index();
+
+  assert(index < op_codes->size());
+
+  const auto opcode = op_codes->operator[](index);
+  assert(opcode != nullptr);
+
+  return builtin_code_neutral(opcode);
+}
+
+OMStatus OMCircleReader::parse(const char *model_ptr)
+{
+  assert(_model == nullptr && "Already init _model");
+  assert(model_ptr != nullptr && "Model pointer cannot be null");
+  if (model_ptr == nullptr or _model != nullptr)
+  {
+    return UnknownError;
+  }
+
+  _model = circle::GetModel(model_ptr);
+
+  return Ok;
+}
+
+OMStatus OMCircleReader::select_subgraph(uint32_t sgindex)
+{
+  if (num_subgraph() <= sgindex)
+    return UnknownError;
+
+  auto subgraphs = _model->subgraphs();
+  if (subgraphs == nullptr)
+    return UnknownError;
+
+  _current_subgraph = subgraphs->Get(sgindex);
+  if (_current_subgraph == nullptr)
+    return UnknownError;
+
+  _current_subgraph_index = sgindex;
+
+  return Ok;
+}
+
+bool OMCircleReader::isConstTensor(uint32_t tensor_index)
+{
+  if (tensor_index == -1)
+    return false;
+
+  const auto tmp_tensor = _current_subgraph->tensors()->operator[](tensor_index);
+  return _model->buffers()->operator[](tmp_tensor->buffer())->data() != nullptr;
+}


### PR DESCRIPTION
This pr adds circle reader entities: CircleReader class, data types and kernel types information classes.

from draft https://github.com/Samsung/ONE/pull/12426
for issue: https://github.com/Samsung/ONE/issues/12427

ONE-DCO-1.0-Signed-off-by: Artem Balyshev <a.balyshev@samsung.com>