### PR TITLE
[onert/train] Add Pad op to KernelGerator in train backend

### DIFF
--- a/runtime/onert/backend/train/KernelGenerator.h
+++ b/runtime/onert/backend/train/KernelGenerator.h
@@ -52,6 +52,7 @@ public:
   void visit(const ir::train::operation::ElementwiseActivation &) override;
   void visit(const ir::train::operation::FullyConnected &) override;
   void visit(const ir::train::operation::Loss &) override;
+  void visit(const ir::train::operation::Pad &) override;
   void visit(const ir::train::operation::Pool2D &) override;
   void visit(const ir::train::operation::Reduce &node) override;
   void visit(const ir::train::operation::Reshape &node) override;


### PR DESCRIPTION
Let's add Pad op to KernelGerator in train backend.

ONE-DCO-1.0-Signed-off-by: Yongseop Kim <yons.kim@samsung.com>

---

for https://github.com/Samsung/ONE/issues/12413
draft https://github.com/Samsung/ONE/pull/12499