### PR TITLE
[onert/libs] Add to_underlying to misc

### DIFF
--- a/runtime/libs/misc/include/misc/to_underlying.h
+++ b/runtime/libs/misc/include/misc/to_underlying.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __NNFW_MISC_TO_UNDERLYING_H__
+#define __NNFW_MISC_TO_UNDERLYING_H__
+
+#include <type_traits>
+
+namespace nnfw
+{
+namespace misc
+{
+
+template <typename E> constexpr auto to_underlying(E e) noexcept
+{
+  return static_cast<std::underlying_type_t<E>>(e);
+}
+
+} // namespace misc
+} // namespace nnfw
+
+#endif // __NNFW_MISC_TO_UNDERLYING_H__

--- a/tests/tools/onert_train/src/nnfw_util.h
+++ b/tests/tools/onert_train/src/nnfw_util.h
@@ -21,7 +21,6 @@
 #include "nnfw_experimental.h"
 
 #include <ostream>
-#include <type_traits>
 
 #define NNPR_ENSURE_STATUS(a)        \
   do                                 \
@@ -32,17 +31,11 @@
     }                                \
   } while (0)
 
-template <typename E> constexpr auto to_underlying(E e) noexcept
-{
-  return static_cast<std::underlying_type_t<E>>(e);
-}
-
 namespace onert_train
 {
 uint64_t num_elems(const nnfw_tensorinfo *ti);
 uint64_t bufsize_for(const nnfw_tensorinfo *ti);
 
-// TODO: Rename it to use snake case (to_string)
 std::string toString(NNFW_TRAIN_OPTIMIZER opt);
 std::string toString(NNFW_TRAIN_LOSS loss);
 std::string toString(NNFW_TRAIN_LOSS_REDUCTION loss_rdt);

--- a/tests/tools/onert_train/src/nnfw_util.h
+++ b/tests/tools/onert_train/src/nnfw_util.h
@@ -21,6 +21,7 @@
 #include "nnfw_experimental.h"
 
 #include <ostream>
+#include <type_traits>
 
 #define NNPR_ENSURE_STATUS(a)        \
   do                                 \
@@ -31,11 +32,17 @@
     }                                \
   } while (0)
 
+template <typename E> constexpr auto to_underlying(E e) noexcept
+{
+  return static_cast<std::underlying_type_t<E>>(e);
+}
+
 namespace onert_train
 {
 uint64_t num_elems(const nnfw_tensorinfo *ti);
 uint64_t bufsize_for(const nnfw_tensorinfo *ti);
 
+// TODO: Rename it to use snake case (to_string)
 std::string toString(NNFW_TRAIN_OPTIMIZER opt);
 std::string toString(NNFW_TRAIN_LOSS loss);
 std::string toString(NNFW_TRAIN_LOSS_REDUCTION loss_rdt);


### PR DESCRIPTION
This PR add to_underlying function to onert/libs/misc.
This function is to get underlying numeric value from enum types.

ONE-DCO-1.0-Signed-off-by: SeungHui Youn <sseung.youn@samsung.com> 

draft : https://github.com/Samsung/ONE/pull/12545 
in the process to resolve: https://github.com/Samsung/ONE/issues/12520  
