### PR TITLE
[luci-pass-value-py-test] Add fold_shape test

### DIFF
--- a/compiler/luci-pass-value-py-test/test.lst
+++ b/compiler/luci-pass-value-py-test/test.lst
@@ -60,6 +60,7 @@ eval(Softmax_001 decompose_softmax)
 eval(Softmax_002 decompose_softmax)
 eval(UnidirectionalSequenceLSTM_003 unroll_unidirseqlstm)
 eval(UnidirectionalSequenceLSTM_004 unroll_unidirseqlstm)
+eval(Net_Shape_Add_000 fold_shape)
 
 # test for limited support for FLOAT16
 eval(Net_Dequantize_Add_000 fold_dequantize)


### PR DESCRIPTION
This commit adds a fold_shape test with Net_Shape_Add_000 model to luci-pass-value-py-test

---
Related to: #12046
Draft: #12407

ONE-DCO-1.0-Signed-off-by: jihunnn-kim <jihunnn.kim@samsung.com>