### PR TITLE
[luci-interpreter] Prevent overflow from bit shifting

### DIFF
--- a/compiler/luci-interpreter/include/luci_interpreter/BuddyMemoryManager.h
+++ b/compiler/luci-interpreter/include/luci_interpreter/BuddyMemoryManager.h
@@ -114,7 +114,7 @@ private:
     const int32_t l = lowerLog2(block->size + sizeof(Block));
 
     const int64_t address = ((uint8_t *)block - (uint8_t *)_start_block);
-    buddy = (Block *)((address ^ (1 << l)) + (uint8_t *)_start_block);
+    buddy = (Block *)((address ^ (1LL << l)) + (uint8_t *)_start_block);
 
     if (!buddy->is_free || buddy->size != block->size)
       return nullptr;


### PR DESCRIPTION
This commit prevents an overflow from bit shifting.

This change is suggested by our static analysis tool.
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>