### PR TITLE
[onert-micro] Add core/memory part

### DIFF
--- a/onert-micro/onert-micro/include/core/memory/OMMemoryManager.h
+++ b/onert-micro/onert-micro/include/core/memory/OMMemoryManager.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ONERT_MICRO_CORE_MEMORY_MEMORY_MANAGER_H
+#define ONERT_MICRO_CORE_MEMORY_MEMORY_MANAGER_H
+
+#include "OMStatus.h"
+
+#include <cstdint>
+
+namespace onert_micro
+{
+namespace core
+{
+namespace memory
+{
+
+struct OMMemoryManager
+{
+  static OMStatus allocateMemory(uint32_t size, uint8_t **data);
+  static OMStatus deallocateMemory(uint8_t *data);
+};
+
+} // namespace memory
+} // namespace core
+} // namespace onert_micro
+
+#endif // ONERT_MICRO_CORE_MEMORY_MEMORY_MANAGER_H

--- a/onert-micro/onert-micro/include/core/memory/OMRuntimeAllocator.h
+++ b/onert-micro/onert-micro/include/core/memory/OMRuntimeAllocator.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ONERT_MICRO_CORE_MEMORY_RUNTIME_ALLOCATOR_H
+#define ONERT_MICRO_CORE_MEMORY_RUNTIME_ALLOCATOR_H
+
+#include "OMStatus.h"
+#include "core/OMRuntimeContext.h"
+#include "core/OMRuntimeStorage.h"
+
+#include <vector>
+#include <cstdint>
+
+namespace onert_micro
+{
+namespace core
+{
+namespace memory
+{
+
+class OMRuntimeAllocator
+{
+private:
+  std::vector<std::vector<uint16_t>> _alloc_plan;
+  std::vector<std::vector<uint16_t>> _dealloc_plan;
+
+public:
+  OMRuntimeAllocator() = default;
+  OMRuntimeAllocator(const OMRuntimeAllocator &) = delete;
+  OMRuntimeAllocator &operator=(const OMRuntimeAllocator &) = delete;
+  OMRuntimeAllocator &&operator=(const OMRuntimeAllocator &&) = delete;
+  OMRuntimeAllocator(OMRuntimeAllocator &&) = default;
+  ~OMRuntimeAllocator() = default;
+
+  void saveAllocPlan(std::vector<std::vector<uint16_t>> &&alloc_plan)
+  {
+    _alloc_plan.clear();
+    _alloc_plan = std::move(alloc_plan);
+  }
+
+  void saveDeallocPlan(std::vector<std::vector<uint16_t>> &&dealloc_plan)
+  {
+    _dealloc_plan.clear();
+    _dealloc_plan = std::move(dealloc_plan);
+  }
+
+  std::vector<std::vector<uint16_t>> &getAllocPlan() { return _alloc_plan; }
+
+  std::vector<std::vector<uint16_t>> &getDeallocPlan() { return _dealloc_plan; }
+
+  OMStatus allocateGraphInputs(OMRuntimeContext *context, OMRuntimeStorage *storage);
+
+  OMStatus clearAllTensorsData(OMRuntimeContext *context, OMRuntimeStorage *storage);
+
+  OMStatus allocate(size_t kernel_index, OMRuntimeContext *context, OMRuntimeStorage *storage);
+  OMStatus deallocate(size_t kernel_index, OMRuntimeStorage *storage);
+};
+
+} // namespace memory
+} // namespace core
+} // namespace onert_micro
+
+#endif // ONERT_MICRO_CORE_MEMORY_RUNTIME_ALLOCATOR_H

--- a/onert-micro/onert-micro/src/core/memory/OMMemoryManager.cpp
+++ b/onert-micro/onert-micro/src/core/memory/OMMemoryManager.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "core/memory/OMMemoryManager.h"
+
+using namespace onert_micro::core::memory;
+using namespace onert_micro;
+
+OMStatus OMMemoryManager::allocateMemory(uint32_t size, uint8_t **data)
+{
+  if (size == 0)
+    return UnknownError;
+  auto data_tmp = new uint8_t[size];
+
+  *data = data_tmp;
+
+  if (*data == nullptr)
+    return UnknownError;
+
+  return Ok;
+}
+
+OMStatus OMMemoryManager::deallocateMemory(uint8_t *data)
+{
+  delete[] data;
+  return Ok;
+}

--- a/onert-micro/onert-micro/src/core/memory/OMRuntimeAllocator.cpp
+++ b/onert-micro/onert-micro/src/core/memory/OMRuntimeAllocator.cpp
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "core/memory/OMRuntimeAllocator.h"
+#include "core/memory/OMMemoryManager.h"
+
+#include "core/OMDataType.h"
+
+using namespace onert_micro::core::memory;
+using namespace onert_micro;
+
+OMStatus OMRuntimeAllocator::clearAllTensorsData(OMRuntimeContext *context,
+                                                 OMRuntimeStorage *storage)
+{
+  auto tensor_index_to_data = storage->getTensorIndexToData();
+
+  for (auto &cur_tensor_index_data : tensor_index_to_data)
+  {
+    auto tensor_index = cur_tensor_index_data.first;
+    uint8_t *allocated_data = cur_tensor_index_data.second;
+
+    OMMemoryManager::deallocateMemory(allocated_data);
+  }
+
+  return Ok;
+}
+
+OMStatus OMRuntimeAllocator::allocate(size_t kernel_index, OMRuntimeContext *context,
+                                      OMRuntimeStorage *storage)
+{
+  assert(kernel_index < _alloc_plan.size() && "Wrong kernel index");
+  if (kernel_index >= _alloc_plan.size())
+    return UnknownError;
+
+  const std::vector<uint16_t> &current_allocate_plan = _alloc_plan[kernel_index];
+
+  for (const uint16_t tensor_index : current_allocate_plan)
+  {
+    const circle::Tensor *tensor = context->getTensorByIndex(tensor_index);
+    const OMRuntimeShape tensor_shape(tensor);
+
+    int32_t num_elements = tensor_shape.flatSize();
+
+#ifndef DIS_DYN_SHAPES
+    int32_t dynamic_tensor_size = storage->getDynamicTensorSize(tensor_index);
+    if (dynamic_tensor_size != -1)
+      num_elements = dynamic_tensor_size;
+#endif // DIS_DYN_SHAPES
+
+    assert(num_elements >= 0 && "Num elements should be positive");
+    if (num_elements < 0)
+      return UnknownError;
+    const auto casted_num_elements = static_cast<uint32_t>(num_elements);
+    const auto type_size =
+      static_cast<uint32_t>(getOMDataTypeSize(onertMicroDatatype(tensor->type())));
+
+    // allocate data
+    uint8_t *allocated_data = nullptr;
+    assert(storage->getDataByTensorIndex(&allocated_data, tensor_index) == Ok &&
+           allocated_data == nullptr && "Double allocate, memory leak");
+    OMStatus status =
+      OMMemoryManager::allocateMemory(casted_num_elements * type_size, &allocated_data);
+    if (status != Ok)
+      return status;
+
+    storage->saveDataToTensorIndex(allocated_data, tensor_index);
+  }
+
+  return Ok;
+}
+
+OMStatus OMRuntimeAllocator::deallocate(size_t kernel_index, OMRuntimeStorage *storage)
+{
+  assert(kernel_index < _alloc_plan.size() && "Wrong kernel index");
+  if (kernel_index >= _alloc_plan.size())
+    return UnknownError;
+
+  const std::vector<uint16_t> &current_deallocate_plan = _dealloc_plan[kernel_index];
+
+  for (const uint16_t tensor_index : current_deallocate_plan)
+  {
+    uint8_t *allocated_data = nullptr;
+    OMStatus status = storage->getDataByTensorIndex(&allocated_data, tensor_index);
+    if (status != Ok)
+      return status;
+
+    status = OMMemoryManager::deallocateMemory(allocated_data);
+    if (status != Ok)
+      return status;
+
+    status = storage->removeTensorFromTensorIndexToData(tensor_index);
+    if (status != Ok)
+      return status;
+  }
+
+  return Ok;
+}
+
+OMStatus OMRuntimeAllocator::allocateGraphInputs(OMRuntimeContext *context,
+                                                 OMRuntimeStorage *storage)
+{
+  OMStatus status = Ok;
+  const auto &graph_inputs = context->getCircleInputs();
+
+  for (uint i = 0; i < graph_inputs->size(); ++i)
+  {
+    auto tensor_index = graph_inputs->operator[](i);
+    const circle::Tensor *tensor = context->getTensorByIndex(tensor_index);
+    const OMRuntimeShape tensor_shape(tensor);
+
+    int32_t num_elements = tensor_shape.flatSize();
+    assert(num_elements >= 0 && "Num elements should be positive");
+    if (num_elements < 0)
+      return UnknownError;
+    const auto casted_num_elements = static_cast<uint32_t>(num_elements);
+    const auto type_size =
+      static_cast<uint32_t>(getOMDataTypeSize(onertMicroDatatype(tensor->type())));
+
+    uint8_t *allocated_data = nullptr;
+    // First clear if already allocated
+    status = storage->getDataByTensorIndex(&allocated_data, tensor_index);
+    if (status != Ok)
+      return status;
+
+    OMMemoryManager::deallocateMemory(allocated_data);
+
+    // Then Allocate
+    status = OMMemoryManager::allocateMemory(casted_num_elements * type_size, &allocated_data);
+    if (status != Ok)
+      return status;
+
+    storage->saveDataToTensorIndex(allocated_data, tensor_index);
+  }
+
+  return status;
+}


### PR DESCRIPTION
This pr adds core/memory part of the new onert-micro.

from draft https://github.com/Samsung/ONE/pull/12426
for issue: https://github.com/Samsung/ONE/issues/12427

ONE-DCO-1.0-Signed-off-by: Artem Balyshev <a.balyshev@samsung.com>