### PR TITLE
[circle2circle-dredd-recipe-test] Add fold_shape test

### DIFF
--- a/compiler/circle2circle-dredd-recipe-test/test.lst
+++ b/compiler/circle2circle-dredd-recipe-test/test.lst
@@ -76,6 +76,7 @@ Add(Net_Gelu_001 PASS fuse_gelu)
 Add(HardSwish_001 PASS decompose_hardswish)
 Add(Softmax_001 PASS decompose_softmax)
 Add(Softmax_002 PASS decompose_softmax)
+Add(Net_Shape_Add_000 PASS fold_shape)
 
 # CSE test
 


### PR DESCRIPTION
This commit adds a dredd test for fold_shape with Net_Shape_Add_000 model to circle2circle-dredd-recipe-test

---
Related to: #12046
Draft: #12407

ONE-DCO-1.0-Signed-off-by: jihunnn-kim <jihunnn.kim@samsung.com>