### PR TITLE
[onert/api] Introduce nnfw_compile and nnfw_set_compiled_model_path APIs

### DIFF
--- a/runtime/onert/api/nnfw/include/nnfw_experimental.h
+++ b/runtime/onert/api/nnfw/include/nnfw_experimental.h
@@ -449,52 +449,52 @@ NNFW_STATUS nnfw_set_quantized_model_path(nnfw_session *session, const char *pat
 NNFW_STATUS nnfw_quantize(nnfw_session *session);
 
 /**
- * @brief Preference for compilation
+ * @brief Preference for target-dependent code generation
  */
 typedef enum
 {
   /** Use the default configuration */
-  NNFW_COMPILE_PREF_DEFAULT,
-  // TODO Support Traffic and Cycle compile preference
-  /** Do best efforts to compile model for performance */
-  NNFW_COMPILE_PREF_PERFORMANCE_FIRST,
-  /** Do best efforts to compile model for reducing host memory usage */
-  NNFW_COMPILE_PREF_MEMORY_FIRST,
-  /** Do best efforts to compile model for reducing compilation time */
-  NNFW_COMPILE_PREF_COMPILE_TIME_FIRST,
-} NNFW_COMPILE_PREF;
+  NNFW_CODEGEN_PREF_DEFAULT,
+  // TODO Support Traffic and Cycle code generation preference
+  /** Do best efforts to generate target-dependent code for performance */
+  NNFW_CODEGEN_PREF_PERFORMANCE_FIRST,
+  /** Do best efforts to generate target-dependent code for reducing host memory usage */
+  NNFW_CODEGEN_PREF_MEMORY_FIRST,
+  /** Do best efforts to generate target-dependent code for reducing compilation time */
+  NNFW_CODEGEN_PREF_COMPILE_TIME_FIRST,
+} NNFW_CODEGEN_PREF;
 
 /**
- * @brief Set exported compiled model path
+ * @brief Set exported codegen model path
  *
- * This function should be called before {@link nnfw_compile} is invoked.
+ * This function should be called before {@link nnfw_codegen} is invoked.
  *
- * @param[in] session nnfw_session to set compiled model path
- * @param[in] path    Compiled model path
+ * @param[in] session nnfw_session to set codegen model path
+ * @param[in] path    Target-dependent model path
  * @return    @c NNFW_STATUS_NO_ERROR if successful, otherwise return @c NNFW_STATUS_ERROR
  */
-NNFW_STATUS nnfw_set_compiled_model_path(nnfw_session *session, const char *path);
+NNFW_STATUS nnfw_set_codegen_model_path(nnfw_session *session, const char *path);
 
 /**
- * @brief Compile the model
+ * @brief Generate target-dependent code
  *
  * This function opens a dynamic shared object. It searches for the object as flollows
- * ld.so(8) search rules. If the {@link nnfw_set_compiled_model_path} is not called before
- * this function, the compiled model path is automatically defined and used using the same
+ * ld.so(8) search rules. If the {@link nnfw_set_codegen_model_path} is not called before
+ * this function, the codegen model path is automatically defined and used using the same
  * directory of the original model/package with the target backend extension.
  *
  * @param[in] session nnfw_session the session which contains information about compilation
- * @param[in] target  Target backend to compile
+ * @param[in] target  Target backend to generate code
  *                    This target string will be used to find a backend library.
  *                    The name of target backend library should follow the following rules:
  *                      'lib' +  {backend extension} + '-gen' + {lib extension}
  *                    And the target string should be a name except 'lib' and {lib extension}.
  *                    For example, if the backend extension is 'aaa', the backend library should
  *                    be 'libaaa-gen.so', and the target string should be 'aaa-gen'.
- * @param[in] pref @c NNFW_COMPILE_PREF
+ * @param[in] pref @c NNFW_CODEGEN_PREF
  * @return    @c NNFW_STATUS_NO_ERROR if successful, otherwise return @c NNFW_STATUS_ERROR
  */
-NNFW_STATUS nnfw_compile(nnfw_session *session, const char *target, NNFW_COMPILE_PREF pref);
+NNFW_STATUS nnfw_codegen(nnfw_session *session, const char *target, NNFW_CODEGEN_PREF pref);
 
 #ifdef __cplusplus
 }

--- a/runtime/onert/api/nnfw/include/nnfw_experimental.h
+++ b/runtime/onert/api/nnfw/include/nnfw_experimental.h
@@ -448,6 +448,54 @@ NNFW_STATUS nnfw_set_quantized_model_path(nnfw_session *session, const char *pat
  */
 NNFW_STATUS nnfw_quantize(nnfw_session *session);
 
+/**
+ * @brief Preference for compilation
+ */
+typedef enum
+{
+  /** Use the default configuration */
+  NNFW_COMPILE_PREF_DEFAULT,
+  // TODO Support Traffic and Cycle compile preference
+  /** Do best efforts to compile model for performance */
+  NNFW_COMPILE_PREF_PERFORMANCE_FIRST,
+  /** Do best efforts to compile model for reducing host memory usage */
+  NNFW_COMPILE_PREF_MEMORY_FIRST,
+  /** Do best efforts to compile model for reducing compilation time */
+  NNFW_COMPILE_PREF_COMPILE_TIME_FIRST,
+} NNFW_COMPILE_PREF;
+
+/**
+ * @brief Set exported compiled model path
+ *
+ * This function should be called before {@link nnfw_compile} is invoked.
+ *
+ * @param[in] session nnfw_session to set compiled model path
+ * @param[in] path    Compiled model path
+ * @return    @c NNFW_STATUS_NO_ERROR if successful, otherwise return @c NNFW_STATUS_ERROR
+ */
+NNFW_STATUS nnfw_set_compiled_model_path(nnfw_session *session, const char *path);
+
+/**
+ * @brief Compile the model
+ *
+ * This function opens a dynamic shared object. It searches for the object as flollows
+ * ld.so(8) search rules. If the {@link nnfw_set_compiled_model_path} is not called before
+ * this function, the compiled model path is automatically defined and used using the same
+ * directory of the original model/package with the target backend extension.
+ *
+ * @param[in] session nnfw_session the session which contains information about compilation
+ * @param[in] target  Target backend to compile
+ *                    This target string will be used to find a backend library.
+ *                    The name of target backend library should follow the following rules:
+ *                      'lib' +  {backend extension} + '-gen' + {lib extension}
+ *                    And the target string should be a name except 'lib' and {lib extension}.
+ *                    For example, if the backend extension is 'aaa', the backend library should
+ *                    be 'libaaa-gen.so', and the target string should be 'aaa-gen'.
+ * @param[in] pref @c NNFW_COMPILE_PREF
+ * @return    @c NNFW_STATUS_NO_ERROR if successful, otherwise return @c NNFW_STATUS_ERROR
+ */
+NNFW_STATUS nnfw_compile(nnfw_session *session, const char *target, NNFW_COMPILE_PREF pref);
+
 #ifdef __cplusplus
 }
 #endif

--- a/runtime/onert/api/nnfw/src/nnfw_api.cc
+++ b/runtime/onert/api/nnfw/src/nnfw_api.cc
@@ -479,14 +479,14 @@ NNFW_STATUS nnfw_quantize(nnfw_session *session)
   return session->quantize();
 }
 
-NNFW_STATUS nnfw_set_compiled_model_path(nnfw_session *session, const char *path)
+NNFW_STATUS nnfw_set_codegen_model_path(nnfw_session *session, const char *path)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->set_compiled_model_path(path);
+  return session->set_codegen_model_path(path);
 }
 
-NNFW_STATUS nnfw_compile(nnfw_session *session, const char *target, NNFW_COMPILE_PREF pref)
+NNFW_STATUS nnfw_codegen(nnfw_session *session, const char *target, NNFW_CODEGEN_PREF pref)
 {
   NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->compile(target, pref);
+  return session->codegen(target, pref);
 }

--- a/runtime/onert/api/nnfw/src/nnfw_api.cc
+++ b/runtime/onert/api/nnfw/src/nnfw_api.cc
@@ -478,3 +478,15 @@ NNFW_STATUS nnfw_quantize(nnfw_session *session)
   NNFW_RETURN_ERROR_IF_NULL(session);
   return session->quantize();
 }
+
+NNFW_STATUS nnfw_set_compiled_model_path(nnfw_session *session, const char *path)
+{
+  NNFW_RETURN_ERROR_IF_NULL(session);
+  return session->set_compiled_model_path(path);
+}
+
+NNFW_STATUS nnfw_compile(nnfw_session *session, const char *target, NNFW_COMPILE_PREF pref)
+{
+  NNFW_RETURN_ERROR_IF_NULL(session);
+  return session->compile(target, pref);
+}

--- a/runtime/onert/api/nnfw/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/nnfw/src/nnfw_api_internal.cc
@@ -1840,7 +1840,7 @@ NNFW_STATUS nnfw_session::quantize()
   return NNFW_STATUS_NO_ERROR;
 }
 
-NNFW_STATUS nnfw_session::set_compiled_model_path(const char *path)
+NNFW_STATUS nnfw_session::set_codegen_model_path(const char *path)
 {
   try
   {
@@ -1855,47 +1855,47 @@ NNFW_STATUS nnfw_session::set_compiled_model_path(const char *path)
   }
   catch (const std::exception &e)
   {
-    std::cerr << "Error during nnfw_session::set_compiled_model_path : " << e.what() << std::endl;
+    std::cerr << "Error during nnfw_session::set_codegen_model_path : " << e.what() << std::endl;
     return NNFW_STATUS_ERROR;
   }
 
   return NNFW_STATUS_NO_ERROR;
 }
 
-NNFW_STATUS nnfw_session::compile(const char *target, NNFW_COMPILE_PREF pref)
+NNFW_STATUS nnfw_session::codegen(const char *target, NNFW_CODEGEN_PREF pref)
 {
   try
   {
     if (!isStateModelLoaded())
     {
-      std::cerr << "invalid state" << std::endl;
+      std::cerr << "Error during nnfw_session::codegen : Invalid state" << std::endl;
       return NNFW_STATUS_INVALID_STATE;
     }
 
     std::string target_str{target};
     if (target_str.empty() || target_str.substr(target_str.size() - 4) != "-gen")
     {
-      std::cerr << "invalid target" << std::endl;
+      std::cerr << "Error during nnfw_session::codegen : Invalid target" << std::endl;
       return NNFW_STATUS_ERROR;
     }
 
     onert::odc::CodegenPreference codegen_pref;
     switch (pref)
     {
-      case NNFW_COMPILE_PREF_DEFAULT:
+      case NNFW_CODEGEN_PREF_DEFAULT:
         codegen_pref = onert::odc::CodegenPreference::CODEGEN_PREF_DEFAULT;
         break;
-      case NNFW_COMPILE_PREF_PERFORMANCE_FIRST:
+      case NNFW_CODEGEN_PREF_PERFORMANCE_FIRST:
         codegen_pref = onert::odc::CodegenPreference::CODEGEN_PREF_PERFORMANCE_FIRST;
         break;
-      case NNFW_COMPILE_PREF_MEMORY_FIRST:
+      case NNFW_CODEGEN_PREF_MEMORY_FIRST:
         codegen_pref = onert::odc::CodegenPreference::CODEGEN_PREF_MEMORY_FIRST;
         break;
-      case NNFW_COMPILE_PREF_COMPILE_TIME_FIRST:
+      case NNFW_CODEGEN_PREF_COMPILE_TIME_FIRST:
         codegen_pref = onert::odc::CodegenPreference::CODEGEN_PREF_COMPILE_TIME_FIRST;
         break;
       default:
-        std::cerr << "invalid preference" << std::endl;
+        std::cerr << "Error during nnfw_session::codegen : Invalid preference" << std::endl;
         return NNFW_STATUS_ERROR;
     }
 
@@ -1924,7 +1924,8 @@ NNFW_STATUS nnfw_session::compile(const char *target, NNFW_COMPILE_PREF pref)
     auto dotidx = export_model_path.rfind('.');
     if (dotidx == std::string::npos)
     {
-      std::cerr << "Invalid compiled model path. Please use a path that includes the extension."
+      std::cerr << "Error during nnfw_session::codegen : Invalid compiled model path. Please use a "
+                   "path that includes the extension."
                 << std::endl;
       return NNFW_STATUS_ERROR;
     }

--- a/runtime/onert/api/nnfw/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/nnfw/src/nnfw_api_internal.cc
@@ -30,6 +30,7 @@
 #include "ir/train/TrainingInfo.h"
 #include "util/TracingCtx.h"
 #include "odc/QuantizeManager.h"
+#include "odc/CodegenManager.h"
 #include "circle_schema_generated.h"
 #include "trix_loader.h"
 
@@ -240,7 +241,8 @@ uint64_t getBufSize(const nnfw_tensorinfo *info)
 
 nnfw_session::nnfw_session()
   : _nnpkg{nullptr}, _coptions{}, _compiler_artifact{nullptr}, _execution{nullptr},
-    _kernel_registry{nullptr}, _train_info{nullptr}, _quant_manager{nullptr}
+    _kernel_registry{nullptr}, _train_info{nullptr}, _quant_manager{nullptr},
+    _codegen_manager{nullptr}
 {
   // DO NOTHING
 }
@@ -313,6 +315,8 @@ NNFW_STATUS nnfw_session::load_model_from_modelfile(const char *model_file_path)
 
   // Create quantize manager
   _quant_manager = std::make_unique<onert::odc::QuantizeManager>(std::string(model_file_path));
+  // Create codegen manager
+  _codegen_manager = std::make_unique<onert::odc::CodegenManager>(std::string{model_file_path});
 
   std::string filename{model_file_path};
   // TODO: Use std::filesystem::path when we can use c++17.
@@ -404,6 +408,8 @@ NNFW_STATUS nnfw_session::load_model_from_nnpackage(const char *package_dir)
     // TODO Support multiple models
     auto const model_filename = package_path + std::string("/") + models[0].asString();
     _quant_manager = std::make_unique<onert::odc::QuantizeManager>(model_filename);
+    // Create codegen manager
+    _codegen_manager = std::make_unique<onert::odc::CodegenManager>(model_filename);
 
     for (uint16_t i = 0; i < num_models; ++i)
     {
@@ -1828,6 +1834,112 @@ NNFW_STATUS nnfw_session::quantize()
   catch (const std::exception &e)
   {
     std::cerr << "Error during nnfw_session::quantize : " << e.what() << std::endl;
+    return NNFW_STATUS_ERROR;
+  }
+
+  return NNFW_STATUS_NO_ERROR;
+}
+
+NNFW_STATUS nnfw_session::set_compiled_model_path(const char *path)
+{
+  try
+  {
+    if (!isStateModelLoaded())
+    {
+      std::cerr << "invalid state" << std::endl;
+      return NNFW_STATUS_INVALID_STATE;
+    }
+
+    assert(_codegen_manager != nullptr);
+    _codegen_manager->exportModelPath(std::string(path));
+  }
+  catch (const std::exception &e)
+  {
+    std::cerr << "Error during nnfw_session::set_compiled_model_path : " << e.what() << std::endl;
+    return NNFW_STATUS_ERROR;
+  }
+
+  return NNFW_STATUS_NO_ERROR;
+}
+
+NNFW_STATUS nnfw_session::compile(const char *target, NNFW_COMPILE_PREF pref)
+{
+  try
+  {
+    if (!isStateModelLoaded())
+    {
+      std::cerr << "invalid state" << std::endl;
+      return NNFW_STATUS_INVALID_STATE;
+    }
+
+    std::string target_str{target};
+    if (target_str.empty() || target_str.substr(target_str.size() - 4) != "-gen")
+    {
+      std::cerr << "invalid target" << std::endl;
+      return NNFW_STATUS_ERROR;
+    }
+
+    onert::odc::CodegenPreference codegen_pref;
+    switch (pref)
+    {
+      case NNFW_COMPILE_PREF_DEFAULT:
+        codegen_pref = onert::odc::CodegenPreference::CODEGEN_PREF_DEFAULT;
+        break;
+      case NNFW_COMPILE_PREF_PERFORMANCE_FIRST:
+        codegen_pref = onert::odc::CodegenPreference::CODEGEN_PREF_PERFORMANCE_FIRST;
+        break;
+      case NNFW_COMPILE_PREF_MEMORY_FIRST:
+        codegen_pref = onert::odc::CodegenPreference::CODEGEN_PREF_MEMORY_FIRST;
+        break;
+      case NNFW_COMPILE_PREF_COMPILE_TIME_FIRST:
+        codegen_pref = onert::odc::CodegenPreference::CODEGEN_PREF_COMPILE_TIME_FIRST;
+        break;
+      default:
+        std::cerr << "invalid preference" << std::endl;
+        return NNFW_STATUS_ERROR;
+    }
+
+    assert(_codegen_manager != nullptr);
+    auto export_model_path = _codegen_manager->exportModelPath();
+    // If the export_model_path is not set, it generates a compiled model path
+    // automatically.
+    if (export_model_path.empty())
+    {
+      // model path always has a dot. (valid extension)
+      auto dotidx = _model_path.rfind('.');
+      assert(dotidx != std::string::npos);
+      auto genidx = target_str.rfind("-gen");
+      assert(genidx != std::string::npos);
+      // The compiled model path is the same directory of the original model/package with
+      // target backend extension.
+      export_model_path = _model_path.substr(0, dotidx + 1) + target_str.substr(0, genidx);
+      _codegen_manager->exportModelPath(export_model_path);
+    }
+
+    _codegen_manager->codegen(target, codegen_pref);
+
+    // Replace model
+    // TODO Support buffer replace, not file reload
+    // TODO: Use std::filesystem::path when we can use c++17.
+    auto dotidx = export_model_path.rfind('.');
+    if (dotidx == std::string::npos)
+    {
+      std::cerr << "Invalid compiled model path. Please use a path that includes the extension."
+                << std::endl;
+      return NNFW_STATUS_ERROR;
+    }
+
+    std::string model_type = export_model_path.substr(dotidx + 1); // + 1 to exclude dot
+    auto model = loadModel(export_model_path, model_type);
+    if (model == nullptr)
+      return NNFW_STATUS_ERROR;
+
+    // TODO: Update _model_path if necessary
+    _nnpkg->replaceModel(std::move(model));
+  }
+  catch (const std::exception &e)
+  {
+    std::cerr << "Error during nnfw_session::compile : " << e.what() << std::endl;
     return NNFW_STATUS_ERROR;
   }
 

--- a/runtime/onert/api/nnfw/src/nnfw_api_internal.h
+++ b/runtime/onert/api/nnfw/src/nnfw_api_internal.h
@@ -189,8 +189,8 @@ public:
   NNFW_STATUS set_quantized_model_path(const char *path);
   NNFW_STATUS quantize();
 
-  NNFW_STATUS set_compiled_model_path(const char *path);
-  NNFW_STATUS compile(const char *target, NNFW_COMPILE_PREF pref);
+  NNFW_STATUS set_codegen_model_path(const char *path);
+  NNFW_STATUS codegen(const char *target, NNFW_CODEGEN_PREF pref);
 
 private:
   const onert::ir::IGraph *primary_subgraph();

--- a/runtime/onert/api/nnfw/src/nnfw_api_internal.h
+++ b/runtime/onert/api/nnfw/src/nnfw_api_internal.h
@@ -55,6 +55,7 @@ class CompilerOptions;
 namespace odc
 {
 class QuantizeManager;
+class CodegenManager;
 } // namespace odc
 } // namespace onert
 
@@ -188,6 +189,9 @@ public:
   NNFW_STATUS set_quantized_model_path(const char *path);
   NNFW_STATUS quantize();
 
+  NNFW_STATUS set_compiled_model_path(const char *path);
+  NNFW_STATUS compile(const char *target, NNFW_COMPILE_PREF pref);
+
 private:
   const onert::ir::IGraph *primary_subgraph();
   uint32_t getInputSize();
@@ -213,6 +217,7 @@ private:
   std::vector<std::thread> _threads;
   std::unique_ptr<onert::ir::train::TrainingInfo> _train_info;
   std::unique_ptr<onert::odc::QuantizeManager> _quant_manager;
+  std::unique_ptr<onert::odc::CodegenManager> _codegen_manager;
   // Remember path to loaded original model
   // It may be used for on-device compiler / on-device training.
   //


### PR DESCRIPTION
This commit introduces nnfw_compile and nnfw_set_compiled_model_path.
It contains a detailed description of these APIs in the header file.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>
Co-authored-by: Sanggyu Lee <sg5.lee@samsung.com>

Related issue : #12505 
Draft PR: #12504