### PR TITLE
[tools/onert_run] Implement codegen function

### DIFF
--- a/tests/tools/onert_run/src/args.cc
+++ b/tests/tools/onert_run/src/args.cc
@@ -304,15 +304,15 @@ void Args::Initialize(void)
     ("qpath", po::value<std::string>()->default_value("")->notifier([&](const auto &v) { _quantized_model_path = v; }),
          "Path to export quantized model.\n"
          "If it is not set, the quantized model will be exported to the same directory of the original model/package with q8/q16 suffix.")
-    ("compile,c", po::value<std::string>()->default_value("")->notifier([&](const auto &v) { _compile = v; }),
-         "Target backend name to compile model\n"
+    ("codegen,c", po::value<std::string>()->default_value("")->notifier([&](const auto &v) { _codegen = v; }),
+         "Target backend name for code generation\n"
          "The target string will be used to find a backend library.\n"
          "This string should be in the following format:\n"
          "{backend extension} + '-gen'.\n"
-         "For detailed description, please see the description of nnfw_compile()")
-    ("cpath", po::value<std::string>()->default_value("")->notifier([&](const auto &v) { _compiled_model_path = v; }),
-         "Path to export compiled model.\n"
-         "If it is not set, the compiled model will be exported to the same directory of the original model/package with target backend extension.")
+         "For detailed description, please see the description of nnfw_codegen()")
+    ("cpath", po::value<std::string>()->default_value("")->notifier([&](const auto &v) { _codegen_model_path = v; }),
+         "Path to export target-dependent model.\n"
+         "If it is not set, the generated model will be exported to the same directory of the original model/package with target backend extension.")
     ;
   // clang-format on
 

--- a/tests/tools/onert_run/src/args.h
+++ b/tests/tools/onert_run/src/args.h
@@ -72,8 +72,8 @@ public:
   const int getVerboseLevel(void) const { return _verbose_level; }
   const std::string &getQuantize(void) const { return _quantize; }
   const std::string &getQuantizedModelPath(void) const { return _quantized_model_path; }
-  const std::string &getCompile(void) const { return _compile; }
-  const std::string &getCompiledModelPath(void) const { return _compiled_model_path; }
+  const std::string &getCodegen(void) const { return _codegen; }
+  const std::string &getCodegenModelPath(void) const { return _codegen_model_path; }
 
 private:
   void Initialize();
@@ -107,8 +107,8 @@ private:
   bool _use_single_model = false;
   std::string _quantize;
   std::string _quantized_model_path;
-  std::string _compile;
-  std::string _compiled_model_path;
+  std::string _codegen;
+  std::string _codegen_model_path;
 };
 
 } // end of namespace onert_run

--- a/tests/tools/onert_run/src/onert_run.cc
+++ b/tests/tools/onert_run/src/onert_run.cc
@@ -144,6 +144,14 @@ int main(const int argc, char **argv)
       NNPR_ENSURE_STATUS(nnfw_quantize(session));
     }
 
+    // Generate target backend code
+    auto codegen = args.getCodegen();
+    if (!codegen.empty())
+    {
+      NNPR_ENSURE_STATUS(nnfw_set_codegen_model_path(session, args.getCodegenModelPath().c_str()));
+      NNPR_ENSURE_STATUS(nnfw_codegen(session, codegen.c_str(), NNFW_CODEGEN_PREF_DEFAULT));
+    }
+
     char *available_backends = std::getenv("BACKENDS");
     if (available_backends)
       NNPR_ENSURE_STATUS(nnfw_set_available_backends(session, available_backends));


### PR DESCRIPTION
This commit implements codegen function in onert_run.
As discussed below, the `compile` string of functions and variables
has been changed to `codegen`.
https://github.com/Samsung/ONE/pull/12583#issuecomment-1920675804

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Related issue : #12505 
Draft PR: #12504