### PR TITLE
[onert] Initialize train BinaryArithmeticLayer

### DIFF
--- a/runtime/onert/backend/train/ops/BinaryArithmeticLayer.cc
+++ b/runtime/onert/backend/train/ops/BinaryArithmeticLayer.cc
@@ -35,7 +35,8 @@ namespace ops
 
 BinaryArithmeticLayer::BinaryArithmeticLayer()
   : cpu::ops::BinaryArithmeticLayer(), _back_prop_lhs{nullptr}, _back_prop_rhs{nullptr},
-    _back_prop_output{nullptr}
+    _back_prop_output{nullptr}, _arithmetic_type{ArithmeticType::kAdd},
+    _activation{ir::Activation::NONE}, _act_back_prop_output{nullptr}
 {
   // DO NOTHING
 }


### PR DESCRIPTION
This commit initialize train BinaryArithmeticLayer's `_arithmetic_type`, `_activation`, and `_act_back_prop_output`.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>