### PR TITLE
[onert] Remove copy by auto in train_get_traininfo

### DIFF
--- a/runtime/onert/api/nnfw/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/nnfw/src/nnfw_api_internal.cc
@@ -1247,8 +1247,8 @@ NNFW_STATUS nnfw_session::train_get_traininfo(nnfw_train_info *info)
     }
   };
 
-  const auto loss = _train_info->lossInfo();
-  const auto optim = _train_info->optimizerInfo();
+  const auto &loss = _train_info->lossInfo();
+  const auto &optim = _train_info->optimizerInfo();
 
   try
   {


### PR DESCRIPTION
This commit removes copy by auto in train_get_traininfo API implementation.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>