### PR TITLE
[onert-micro] Add import part

### DIFF
--- a/onert-micro/onert-micro/include/import/OMConfigureArgs.h
+++ b/onert-micro/onert-micro/include/import/OMConfigureArgs.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ONERT_MICRO_IMPORT_CONFIGURE_ARGS_H
+#define ONERT_MICRO_IMPORT_CONFIGURE_ARGS_H
+
+#include "OMStatus.h"
+#include "OMConfig.h"
+#include "core/OMRuntimeStorage.h"
+#include "core/OMRuntimeContext.h"
+#include "core/OMRuntimeModule.h"
+
+namespace onert_micro
+{
+namespace import
+{
+
+struct OMConfigureArgs
+{
+  core::OMRuntimeStorage &runtime_storage;
+  core::OMRuntimeContext &runtime_context;
+  uint16_t kernel_index;
+  const OMConfig &configs;
+  core::OMRuntimeModule &runtime_module;
+};
+
+} // namespace import
+} // namespace onert_micro
+
+#endif // ONERT_MICRO_IMPORT_CONFIGURE_ARGS_H

--- a/onert-micro/onert-micro/include/import/OMExecutionPlanCreator.h
+++ b/onert-micro/onert-micro/include/import/OMExecutionPlanCreator.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ONERT_MICRO_IMPORT_EXECUTION_PLAN_CREATOR_H
+#define ONERT_MICRO_IMPORT_EXECUTION_PLAN_CREATOR_H
+
+#include "OMStatus.h"
+#include "OMConfig.h"
+#include "core/OMRuntimeStorage.h"
+#include "core/OMRuntimeContext.h"
+#include "core/memory/OMRuntimeAllocator.h"
+
+namespace onert_micro
+{
+namespace import
+{
+
+struct OMExecutionPlanCreator
+{
+
+  static OMStatus createExecutionPlan(core::OMRuntimeStorage &runtime_storage,
+                                      core::OMRuntimeContext &runtime_context,
+                                      core::memory::OMRuntimeAllocator &allocator,
+                                      const OMConfig &configs);
+};
+
+} // namespace import
+} // namespace onert_micro
+
+#endif // ONERT_MICRO_IMPORT_EXECUTION_PLAN_CREATOR_H

--- a/onert-micro/onert-micro/include/import/OMKernelConfiguration.h
+++ b/onert-micro/onert-micro/include/import/OMKernelConfiguration.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ONERT_MICRO_IMPORT_KERNEL_CONFIGURATION_H
+#define ONERT_MICRO_IMPORT_KERNEL_CONFIGURATION_H
+
+#include "OMStatus.h"
+#include "OMConfig.h"
+#include "core/OMRuntimeStorage.h"
+#include "core/OMRuntimeContext.h"
+#include "import/OMConfigureArgs.h"
+
+namespace onert_micro
+{
+namespace import
+{
+
+struct OMKernelConfiguration
+{
+  static OMStatus configureKernels(OMConfigureArgs &);
+};
+
+} // namespace import
+} // namespace onert_micro
+
+#endif // ONERT_MICRO_IMPORT_KERNEL_CONFIGURATION_H

--- a/onert-micro/onert-micro/include/import/OMKernelConfigureBuilder.h
+++ b/onert-micro/onert-micro/include/import/OMKernelConfigureBuilder.h
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ONERT_MICRO_IMPORT_KERNEL_CONFIGURE_BUILDER_H
+#define ONERT_MICRO_IMPORT_KERNEL_CONFIGURE_BUILDER_H
+
+#include "core/reader/OMCircleReader.h"
+#include "core/OMKernelType.h"
+#include "core/OMRuntimeStorage.h"
+#include "core/OMRuntimeContext.h"
+#include "core/OMRuntimeModule.h"
+#include "import/OMConfigureArgs.h"
+#include "OMConfig.h"
+
+namespace onert_micro
+{
+namespace import
+{
+
+using KernelConfigureFunc = OMStatus(const OMConfigureArgs &);
+
+#define REGISTER_KERNEL(builtin_operator, name) \
+  OMStatus configure_kernel_Circle##name(const OMConfigureArgs &);
+#include "KernelsToBuild.lst"
+#undef REGISTER_KERNEL
+
+#define REGISTER_CUSTOM_KERNEL(name, string_name) \
+  OMStatus configure_kernel_Circle##name(const OMConfigureArgs &);
+#include "CustomKernelsToBuild.lst"
+#undef REGISTER_CUSTOM_KERNEL
+
+class KernelBuiltinConfigureRegistry
+{
+public:
+  constexpr KernelBuiltinConfigureRegistry() : _operator_configure()
+  {
+#define REGISTER_KERNEL(builtin_operator, name)                                  \
+  registerKernelConfigure(core::OMBuilderID::BuiltinOperator_##builtin_operator, \
+                          configure_kernel_Circle##name);
+
+#include "KernelsToBuild.lst"
+
+#undef REGISTER_KERNEL
+  }
+
+public:
+  OMStatus getKernelConfigureFunc(core::OMBuilderID builderID,
+                                  KernelConfigureFunc **configure_func) const
+  {
+    const auto builder_id_opcode = size_t(builderID);
+    assert(builder_id_opcode < size_t(core::OMBuilderID::BuiltinOperatorsSize));
+    if (builder_id_opcode >= size_t(core::OMBuilderID::BuiltinOperatorsSize))
+    {
+      *configure_func = nullptr;
+      return UnknownError;
+    }
+    *configure_func = _operator_configure[builder_id_opcode];
+    return Ok;
+  }
+
+private:
+  constexpr void registerKernelConfigure(core::OMBuilderID id, KernelConfigureFunc *func)
+  {
+    assert(size_t(id) < size_t(core::OMBuilderID::BuiltinOperatorsSize));
+    _operator_configure[size_t(id)] = func;
+  }
+
+private:
+  KernelConfigureFunc *_operator_configure[size_t(core::OMBuilderID::BuiltinOperatorsSize)];
+};
+
+class KernelCustomConfigureRegistry
+{
+public:
+  constexpr KernelCustomConfigureRegistry() : _operator_configure()
+  {
+#define REGISTER_CUSTOM_KERNEL(name, string_name) \
+  registerKernelConfigure(core::OMBuilderID::CUSTOM_##name, configure_kernel_Circle##name);
+
+#include "CustomKernelsToBuild.lst"
+
+#undef REGISTER_CUSTOM_KERNEL
+  }
+
+public:
+  OMStatus getKernelConfigureFunc(core::OMBuilderID builderID,
+                                  KernelConfigureFunc **configure_func) const
+  {
+    auto builder_id_opcode = size_t(builderID);
+    if (builder_id_opcode >= size_t(core::OMBuilderID::Size))
+    {
+      *configure_func = nullptr;
+      return UnknownError;
+    }
+    const auto builder_id_offset = size_t(core::OMBuilderID::BuiltinOperatorsSize);
+    builder_id_opcode -= builder_id_offset - 1;
+    if (builder_id_opcode < 0)
+    {
+      *configure_func = nullptr;
+      return UnknownError;
+    }
+    *configure_func = _operator_configure[builder_id_opcode];
+    return Ok;
+  }
+
+private:
+  constexpr void registerKernelConfigure(core::OMBuilderID id, KernelConfigureFunc *func)
+  {
+    auto builder_id_opcode = size_t(id);
+    const auto builder_id_offset = size_t(core::OMBuilderID::BuiltinOperatorsSize);
+    builder_id_opcode = builder_id_opcode - builder_id_offset - 1;
+    _operator_configure[builder_id_opcode] = func;
+  }
+
+private:
+  KernelConfigureFunc *_operator_configure[size_t(core::OMBuilderID::Size) -
+                                           size_t(core::OMBuilderID::BuiltinOperatorsSize) - 1];
+};
+
+// Global constexpr kernel builtin and custom configure
+constexpr KernelBuiltinConfigureRegistry kernel_builtin_configure;
+constexpr KernelCustomConfigureRegistry kernel_custom_configure;
+
+} // namespace import
+} // namespace onert_micro
+
+#endif // ONERT_MICRO_IMPORT_KERNEL_CONFIGURE_BUILDER_H

--- a/onert-micro/onert-micro/src/import/CMakeLists.txt
+++ b/onert-micro/onert-micro/src/import/CMakeLists.txt
@@ -1,0 +1,29 @@
+message(STATUS "ONERT MICRO IMPORT BUILD BEGIN")
+
+set(SOURCES
+        OMExecutionPlanCreator.cpp
+        OMKernelConfiguration.cpp
+        OMKernelConfigureBuilder.cpp
+        )
+
+# Add configure kernels
+macro(REGISTER_KERNEL OPERATOR, NODE)
+    list(APPEND SOURCES "kernels/${NODE}.cpp")
+endmacro(REGISTER_KERNEL)
+
+# To add REGISTER_KERNEL list
+include(${KERNEL_REGISTER_FILE})
+
+macro(REGISTER_CUSTOM_KERNEL NODE)
+    list(APPEND SOURCES "kernels/${NODE}.cpp")
+endmacro(REGISTER_CUSTOM_KERNEL)
+
+# To add CUSTOM_REGISTER_KERNEL list
+include(${CUSTOM_KERNEL_REGISTER_FILE})
+
+add_library(${OM_IMPORT_LIB} STATIC ${SOURCES})
+
+target_include_directories(${OM_IMPORT_LIB} PUBLIC "${OM_INCLUDE_DIR}")
+target_link_libraries(${OM_IMPORT_LIB} PUBLIC ${OM_CORE_LIB})
+
+message(STATUS "ONERT MICRO IMPORT BUILD FINISHED")

--- a/onert-micro/onert-micro/src/import/OMExecutionPlanCreator.cpp
+++ b/onert-micro/onert-micro/src/import/OMExecutionPlanCreator.cpp
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "import/OMExecutionPlanCreator.h"
+
+#include <map>
+
+using namespace onert_micro::core;
+using namespace onert_micro::import;
+using namespace onert_micro;
+
+OMStatus OMExecutionPlanCreator::createExecutionPlan(core::OMRuntimeStorage &runtime_storage,
+                                                     core::OMRuntimeContext &runtime_context,
+                                                     core::memory::OMRuntimeAllocator &allocator,
+                                                     const OMConfig &configs)
+{
+  bool keep_input = configs.keep_input;
+
+  std::vector<std::vector<uint16_t>> &alloc_plan = allocator.getAllocPlan();
+  std::vector<std::vector<uint16_t>> &dealloc_plan = allocator.getDeallocPlan();
+
+  using Lifetime = std::pair<int32_t, int32_t>;
+
+  std::map<uint16_t, Lifetime> lifetimes;
+
+  const reader::CircleOperators *operators = runtime_context.getCircleOperators();
+
+  const size_t num_kernels = operators->size();
+
+  if (not keep_input)
+  {
+    auto graph_inputs = runtime_context.getCircleInputs();
+    for (const auto input_ind : *graph_inputs)
+    {
+      assert(lifetimes.count(input_ind) == 0);
+      lifetimes[input_ind] = Lifetime(-1, 0);
+    }
+  }
+
+  for (int32_t index = 0; index < num_kernels; ++index)
+  {
+    auto *cur_op = operators->operator[](index);
+
+    const auto *op_inputs = cur_op->inputs();
+    const auto *op_outputs = cur_op->outputs();
+    auto kernel_type = runtime_storage.getKernelType(index);
+    for (int32_t j = 0; j < op_inputs->size(); ++j)
+    {
+      const auto input_index = op_inputs->operator[](j);
+
+      if (input_index == -1)
+        continue;
+
+      // Pass constant tensors
+      if (runtime_context.isConstTensor(input_index))
+        continue;
+
+      if (lifetimes.count(input_index) > 0)
+      {
+        if (kernel_type == Inplace)
+          lifetimes.at(input_index).second = -1;
+        else
+          lifetimes.at(input_index).second = index;
+      }
+    }
+
+    for (int32_t j = 0; j < op_outputs->size(); ++j)
+    {
+      const auto output_index = op_outputs->operator[](j);
+
+      if (kernel_type == Inplace)
+        lifetimes[output_index] = Lifetime(-1, index);
+      else
+        lifetimes[output_index] = Lifetime(index, index);
+    }
+  }
+  auto graph_outputs = runtime_context.getCircleOutputs();
+  for (const auto output_ind : *graph_outputs)
+  {
+    if (lifetimes.count(output_ind) > 0)
+      lifetimes.at(output_ind).second = static_cast<int32_t>(num_kernels);
+  }
+
+  alloc_plan.assign(num_kernels, std::vector<uint16_t>());
+  dealloc_plan.assign(num_kernels + 1, std::vector<uint16_t>());
+
+  for (const auto &item : lifetimes)
+  {
+    if (item.second.first != -1)
+      alloc_plan[item.second.first].push_back(item.first);
+    if (item.second.second != -1)
+      dealloc_plan[item.second.second].push_back(item.first);
+  }
+
+  return Ok;
+}

--- a/onert-micro/onert-micro/src/import/OMKernelConfiguration.cpp
+++ b/onert-micro/onert-micro/src/import/OMKernelConfiguration.cpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "import/OMKernelConfiguration.h"
+#include "core/OMKernelType.h"
+#include "import/OMKernelConfigureBuilder.h"
+
+using namespace onert_micro::core;
+using namespace onert_micro::import;
+using namespace onert_micro;
+
+OMStatus OMKernelConfiguration::configureKernels(OMConfigureArgs &configure_args)
+{
+  OMRuntimeContext &runtime_context = configure_args.runtime_context;
+  const reader::CircleOperators *operators = runtime_context.getCircleOperators();
+
+  const auto num_operators = static_cast<uint16_t>(operators->size());
+  const auto op_codes = runtime_context.getCircleOpcodes();
+
+  OMStatus status = Ok;
+  for (uint16_t i = 0; i < num_operators; ++i)
+  {
+    OMBuilderID builder_id = core::OMBuilderID::Size;
+    const circle::Operator *op = operators->operator[](i);
+    uint32_t index = op->opcode_index();
+
+    assert(index < op_codes->size());
+
+    const auto opcode = op_codes->operator[](index);
+
+    status = core::getBuilderId(opcode, builder_id);
+
+    assert(status == Ok);
+    if (status != Ok)
+      return status;
+
+    KernelConfigureFunc *configure_func = nullptr;
+    if (size_t(builder_id) < size_t(core::OMBuilderID::BuiltinOperatorsSize))
+    {
+      // Builtin operator
+      status = kernel_builtin_configure.getKernelConfigureFunc(builder_id, &configure_func);
+    }
+    else
+    {
+      // Custom
+      status = kernel_custom_configure.getKernelConfigureFunc(builder_id, &configure_func);
+    }
+
+    assert(configure_func != nullptr);
+
+    if (status != Ok)
+      return status;
+
+    configure_args.kernel_index = i;
+    status = configure_func(configure_args);
+    assert(status == Ok && "");
+  }
+
+  return status;
+}

--- a/onert-micro/onert-micro/src/import/OMKernelConfigureBuilder.cpp
+++ b/onert-micro/onert-micro/src/import/OMKernelConfigureBuilder.cpp
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "import/OMKernelConfigureBuilder.h"


### PR DESCRIPTION
This pr adds import entities part to the onert-micro

from draft https://github.com/Samsung/ONE/pull/12426
for issue: https://github.com/Samsung/ONE/issues/12427

ONE-DCO-1.0-Signed-off-by: Artem Balyshev <a.balyshev@samsung.com>