### PR TITLE
[tools/onert_train] Remove default value from onert_train/args

### DIFF
--- a/tests/tools/onert_train/src/args.cc
+++ b/tests/tools/onert_train/src/args.cc
@@ -113,9 +113,9 @@ T checkValidation(const std::string &arg_name, const std::vector<T> &valid_args,
 
 // generate a help message based on the valid_args and default_arg
 template <typename T>
-std::string genHelpMsg(const std::string &arg_name, const std::vector<T> &valid_args, T default_arg)
+std::string genHelpMsg(const std::string &arg_name, const std::vector<T> &valid_args)
 {
-  std::string msg = arg_name + " (default: " + onert_train::to_string(default_arg) + ")\n";
+  std::string msg = arg_name + " (default: use model file parameter)\n";
   for (const auto arg : valid_args)
   {
     const auto num = nnfw::misc::to_underlying(arg);
@@ -251,22 +251,19 @@ void Args::Initialize(void)
     )
     ("mem_poll,m", po::value<bool>()->default_value(false)->notifier([&](const auto &v) { _mem_poll = v; }), "Check memory polling (default: false)")
     ("epoch", po::value<int>()->default_value(5)->notifier([&](const auto &v) { _epoch = v; }), "Epoch number (default: 5)")
-    ("batch_size", po::value<int>()->default_value(32)->notifier([&](const auto &v) { _batch_size = v; }), "Batch size (default: 32)")
-    ("learning_rate", po::value<float>()->default_value(0.001)->notifier([&](const auto &v) { _learning_rate = v; }), "Learning rate (default: 0.001)")
+    ("batch_size", po::value<int>()->notifier([&](const auto &v) { _batch_size = v; }), "Batch size (default: use model file parameter)")
+    ("learning_rate", po::value<float>()->notifier([&](const auto &v) { _learning_rate = v; }), "Learning rate (default: use model file parameter)")
     ("loss", po::value<int>()
-      ->default_value(default_loss)
       ->notifier([&](const auto& v){_loss_type = checkValidation("loss", valid_loss, v);}),
-      genHelpMsg("loss", valid_loss, default_loss).c_str()
+      genHelpMsg("loss", valid_loss).c_str()
     )
     ("loss_reduction_type", po::value<int>()
-      ->default_value(default_loss_rdt)
       ->notifier([&](const auto &v){_loss_reduction_type = checkValidation("loss_reduction_type", valid_loss_rdt, v);}),
-      genHelpMsg("loss_reduction_tye", valid_loss_rdt, default_loss_rdt).c_str()
+      genHelpMsg("loss_reduction_tye", valid_loss_rdt).c_str()
     )
     ("optimizer", po::value<int>()
-      ->default_value(default_optim)
       ->notifier([&](const auto& v){_optimizer_type = checkValidation("optimizer", valid_optim, v);}),
-      genHelpMsg("optimizer", valid_optim, default_optim).c_str()
+      genHelpMsg("optimizer", valid_optim).c_str()
     )
     ("metric", po::value<int>()->default_value(-1)->notifier([&] (const auto &v) { _metric_type = v; }),
       "Metric type\n"

--- a/tests/tools/onert_train/src/args.cc
+++ b/tests/tools/onert_train/src/args.cc
@@ -115,7 +115,8 @@ T checkValidation(const std::string &arg_name, const std::vector<T> &valid_args,
 template <typename T>
 std::string genHelpMsg(const std::string &arg_name, const std::vector<T> &valid_args)
 {
-  std::string msg = arg_name + " (default: use model file parameter)\n";
+  std::string msg = arg_name + "\n";
+  msg += "If not given, model's hyper parameter is used\n";
   for (const auto arg : valid_args)
   {
     const auto num = nnfw::misc::to_underlying(arg);
@@ -251,19 +252,23 @@ void Args::Initialize(void)
     )
     ("mem_poll,m", po::value<bool>()->default_value(false)->notifier([&](const auto &v) { _mem_poll = v; }), "Check memory polling (default: false)")
     ("epoch", po::value<int>()->default_value(5)->notifier([&](const auto &v) { _epoch = v; }), "Epoch number (default: 5)")
-    ("batch_size", po::value<int>()->notifier([&](const auto &v) { _batch_size = v; }), "Batch size (default: use model file parameter)")
-    ("learning_rate", po::value<float>()->notifier([&](const auto &v) { _learning_rate = v; }), "Learning rate (default: use model file parameter)")
+    ("batch_size", po::value<int>()->notifier([&](const auto &v) { _batch_size = v; }), 
+      "Batch size\n"
+      "If not given, model's hyper parameter is used")
+    ("learning_rate", po::value<float>()->notifier([&](const auto &v) { _learning_rate = v; }), 
+      "Learning rate\n"
+      "If not given, model's hyper parameter is used")
     ("loss", po::value<int>()
       ->notifier([&](const auto& v){_loss_type = checkValidation("loss", valid_loss, v);}),
-      genHelpMsg("loss", valid_loss).c_str()
+      genHelpMsg("Loss type", valid_loss).c_str()
     )
     ("loss_reduction_type", po::value<int>()
       ->notifier([&](const auto &v){_loss_reduction_type = checkValidation("loss_reduction_type", valid_loss_rdt, v);}),
-      genHelpMsg("loss_reduction_tye", valid_loss_rdt).c_str()
+      genHelpMsg("Loss Reduction type", valid_loss_rdt).c_str()
     )
     ("optimizer", po::value<int>()
       ->notifier([&](const auto& v){_optimizer_type = checkValidation("optimizer", valid_optim, v);}),
-      genHelpMsg("optimizer", valid_optim).c_str()
+      genHelpMsg("Optimizer type", valid_optim).c_str()
     )
     ("metric", po::value<int>()->default_value(-1)->notifier([&] (const auto &v) { _metric_type = v; }),
       "Metric type\n"

--- a/tests/tools/onert_train/src/args.h
+++ b/tests/tools/onert_train/src/args.h
@@ -17,6 +17,7 @@
 #ifndef __ONERT_TRAIN_ARGS_H__
 #define __ONERT_TRAIN_ARGS_H__
 
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -55,11 +56,14 @@ public:
   const std::string &getLoadRawExpectedFilename(void) const { return _load_raw_expected_filename; }
   const bool getMemoryPoll(void) const { return _mem_poll; }
   const int getEpoch(void) const { return _epoch; }
-  const int getBatchSize(void) const { return _batch_size; }
-  const float getLearningRate(void) const { return _learning_rate; }
-  const NNFW_TRAIN_LOSS getLossType(void) const { return _loss_type; }
-  const NNFW_TRAIN_LOSS_REDUCTION getLossReductionType(void) const { return _loss_reduction_type; }
-  const NNFW_TRAIN_OPTIMIZER getOptimizerType(void) const { return _optimizer_type; }
+  const std::optional<int> getBatchSize(void) const { return _batch_size; }
+  const std::optional<float> getLearningRate(void) const { return _learning_rate; }
+  const std::optional<NNFW_TRAIN_LOSS> getLossType(void) const { return _loss_type; }
+  const std::optional<NNFW_TRAIN_LOSS_REDUCTION> getLossReductionType(void) const
+  {
+    return _loss_reduction_type;
+  }
+  const std::optional<NNFW_TRAIN_OPTIMIZER> getOptimizerType(void) const { return _optimizer_type; }
   const int getMetricType(void) const { return _metric_type; }
   const float getValidationSplit(void) const { return _validation_split; }
   const bool printVersion(void) const { return _print_version; }
@@ -76,21 +80,18 @@ private:
     NNFW_TRAIN_LOSS_MEAN_SQUARED_ERROR,
     NNFW_TRAIN_LOSS_CATEGORICAL_CROSSENTROPY,
   };
-  const NNFW_TRAIN_LOSS default_loss = NNFW_TRAIN_LOSS_MEAN_SQUARED_ERROR;
 
   // supported loss reduction type list and it's default value
   const std::vector<NNFW_TRAIN_LOSS_REDUCTION> valid_loss_rdt = {
     NNFW_TRAIN_LOSS_REDUCTION_SUM_OVER_BATCH_SIZE,
     NNFW_TRAIN_LOSS_REDUCTION_SUM,
   };
-  const NNFW_TRAIN_LOSS_REDUCTION default_loss_rdt = NNFW_TRAIN_LOSS_REDUCTION_SUM_OVER_BATCH_SIZE;
 
   // supported optimizer list and it's default value
   const std::vector<NNFW_TRAIN_OPTIMIZER> valid_optim = {
     NNFW_TRAIN_OPTIMIZER_SGD,
     NNFW_TRAIN_OPTIMIZER_ADAM,
   };
-  const NNFW_TRAIN_OPTIMIZER default_optim = NNFW_TRAIN_OPTIMIZER_SGD;
 
 private:
   po::positional_options_description _positional;
@@ -104,11 +105,11 @@ private:
   std::string _load_raw_expected_filename;
   bool _mem_poll;
   int _epoch;
-  int _batch_size;
-  float _learning_rate;
-  NNFW_TRAIN_LOSS _loss_type;
-  NNFW_TRAIN_LOSS_REDUCTION _loss_reduction_type;
-  NNFW_TRAIN_OPTIMIZER _optimizer_type;
+  std::optional<int> _batch_size;
+  std::optional<float> _learning_rate;
+  std::optional<NNFW_TRAIN_LOSS> _loss_type;
+  std::optional<NNFW_TRAIN_LOSS_REDUCTION> _loss_reduction_type;
+  std::optional<NNFW_TRAIN_OPTIMIZER> _optimizer_type;
   int _metric_type;
   float _validation_split;
   bool _print_version = false;

--- a/tests/tools/onert_train/src/onert_train.cc
+++ b/tests/tools/onert_train/src/onert_train.cc
@@ -138,11 +138,11 @@ int main(const int argc, char **argv)
     NNPR_ENSURE_STATUS(nnfw_train_get_traininfo(session, &tri));
 
     // overwrite training information using the arguments
-    if (tri.batch_size == 0)
-    {
-      // If args doens't have a batch size, set batch size 1
-      tri.batch_size = args.getBatchSize().value_or(1);
-    }
+    if (tri.batch_size == 0 && !args.getBatchSize().has_value())
+      tri.batch_size = 1;
+    else
+      tri.batch_size = args.getBatchSize().value_or(tri.batch_size);
+
     tri.learning_rate = args.getLearningRate().value_or(tri.learning_rate);
     tri.loss_info.loss = args.getLossType().value_or(tri.loss_info.loss);
     tri.loss_info.reduction_type =

--- a/tests/tools/onert_train/src/onert_train.cc
+++ b/tests/tools/onert_train/src/onert_train.cc
@@ -138,11 +138,7 @@ int main(const int argc, char **argv)
     NNPR_ENSURE_STATUS(nnfw_train_get_traininfo(session, &tri));
 
     // overwrite training information using the arguments
-    if (tri.batch_size == 0 && !args.getBatchSize().has_value())
-      tri.batch_size = 1;
-    else
-      tri.batch_size = args.getBatchSize().value_or(tri.batch_size);
-
+    tri.batch_size = args.getBatchSize().value_or(tri.batch_size);
     tri.learning_rate = args.getLearningRate().value_or(tri.learning_rate);
     tri.loss_info.loss = args.getLossType().value_or(tri.loss_info.loss);
     tri.loss_info.reduction_type =

--- a/tests/tools/onert_train/src/onert_train.cc
+++ b/tests/tools/onert_train/src/onert_train.cc
@@ -138,11 +138,16 @@ int main(const int argc, char **argv)
     NNPR_ENSURE_STATUS(nnfw_train_get_traininfo(session, &tri));
 
     // overwrite training information using the arguments
-    tri.batch_size = args.getBatchSize();
-    tri.learning_rate = args.getLearningRate();
-    tri.loss_info.loss = args.getLossType();
-    tri.loss_info.reduction_type = args.getLossReductionType();
-    tri.opt = args.getOptimizerType();
+    if (tri.batch_size == 0)
+    {
+      // If args doens't have a batch size, set batch size 1
+      tri.batch_size = args.getBatchSize().value_or(1);
+    }
+    tri.learning_rate = args.getLearningRate().value_or(tri.learning_rate);
+    tri.loss_info.loss = args.getLossType().value_or(tri.loss_info.loss);
+    tri.loss_info.reduction_type =
+      args.getLossReductionType().value_or(tri.loss_info.reduction_type);
+    tri.opt = args.getOptimizerType().value_or(tri.opt);
 
     std::cout << "== training parameter ==" << std::endl;
     std::cout << tri;


### PR DESCRIPTION
This PR removes default value from onert_train's Args class. This is to use model file parameter as default value, if nothing is given from command line input.

ONE-DCO-1.0-Signed-off-by: SeungHui Youn <sseung.youn@samsung.com>

related with: https://github.com/Samsung/ONE/issues/12520 