### PR TITLE
[luci/pass] Add note comments to know about ResolveCustomOpAddPass

### DIFF
--- a/compiler/luci/pass/src/ResolveCustomOpAddPass.cpp
+++ b/compiler/luci/pass/src/ResolveCustomOpAddPass.cpp
@@ -70,6 +70,8 @@ int32_t get_broadcastTo_index_among_inputs_of(luci::CircleCustom *cop)
   return -1;
 }
 
+// NOTE Broadcasting of input `Const` is skipped cause `Add` will do the broadcasting.
+// TODO Implement broadcasting to the `Const` input.
 /** BEFORE
  *                                  [CircleConst]
  *                                        |


### PR DESCRIPTION
This commit adds note comments to know about ResolveCustomOpAddPass.

ONE-DCO-1.0-Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>

---
Related to Issue: https://github.com/Samsung/ONE/issues/10784
Draft PR: [#10737](https://github.com/Samsung/ONE/pull/11701)
