### PR TITLE
[ONERT] Add hasTrainableParameter member function

### DIFF
--- a/runtime/onert/core/include/ir/train/ITrainableOperation.h
+++ b/runtime/onert/core/include/ir/train/ITrainableOperation.h
@@ -39,6 +39,7 @@ public:
   virtual std::unique_ptr<ITrainableOperation> clone() const = 0;
   virtual void accept(OperationVisitor &v) const override = 0;
   virtual void accept(TrainableOperationVisitor &v) const = 0;
+  virtual bool hasTrainableParameter() const = 0;
   // TODO Add virtual methods related to training
 };
 

--- a/runtime/onert/core/include/ir/train/operation/BinaryArithmetic.h
+++ b/runtime/onert/core/include/ir/train/operation/BinaryArithmetic.h
@@ -41,6 +41,7 @@ public:
   std::unique_ptr<ITrainableOperation> clone() const override;
   void accept(OperationVisitor &v) const override;
   void accept(TrainableOperationVisitor &v) const override;
+  bool hasTrainableParameter() const override { return false; }
 };
 
 } // namespace operation

--- a/runtime/onert/core/include/ir/train/operation/Conv2D.h
+++ b/runtime/onert/core/include/ir/train/operation/Conv2D.h
@@ -41,6 +41,7 @@ public:
   std::unique_ptr<ITrainableOperation> clone() const override;
   void accept(OperationVisitor &v) const override;
   void accept(TrainableOperationVisitor &v) const override;
+  bool hasTrainableParameter() const override { return true; }
 };
 
 } // namespace operation

--- a/runtime/onert/core/include/ir/train/operation/DepthwiseConv2D.h
+++ b/runtime/onert/core/include/ir/train/operation/DepthwiseConv2D.h
@@ -41,6 +41,7 @@ public:
   std::unique_ptr<ITrainableOperation> clone() const override;
   void accept(OperationVisitor &v) const override;
   void accept(TrainableOperationVisitor &v) const override;
+  bool hasTrainableParameter() const override { return true; }
 };
 
 } // namespace operation

--- a/runtime/onert/core/include/ir/train/operation/ElementwiseActivation.h
+++ b/runtime/onert/core/include/ir/train/operation/ElementwiseActivation.h
@@ -42,6 +42,7 @@ public:
   std::unique_ptr<ITrainableOperation> clone() const override;
   void accept(OperationVisitor &v) const override;
   void accept(TrainableOperationVisitor &v) const override;
+  bool hasTrainableParameter() const override { return false; }
 };
 
 } // namespace operation

--- a/runtime/onert/core/include/ir/train/operation/FullyConnected.h
+++ b/runtime/onert/core/include/ir/train/operation/FullyConnected.h
@@ -41,6 +41,7 @@ public:
   std::unique_ptr<ITrainableOperation> clone() const override;
   void accept(OperationVisitor &v) const override;
   void accept(TrainableOperationVisitor &v) const override;
+  bool hasTrainableParameter() const override { return true; }
 };
 
 } // namespace operation

--- a/runtime/onert/core/include/ir/train/operation/Loss.h
+++ b/runtime/onert/core/include/ir/train/operation/Loss.h
@@ -44,6 +44,7 @@ public:
   std::unique_ptr<ITrainableOperation> clone() const override;
   void accept(OperationVisitor &v) const override;
   void accept(TrainableOperationVisitor &v) const override;
+  bool hasTrainableParameter() const override { return false; }
   std::string name() const override { return toString(_param.loss_code) + toString(opcode()); };
 
 public:

--- a/runtime/onert/core/include/ir/train/operation/Pad.h
+++ b/runtime/onert/core/include/ir/train/operation/Pad.h
@@ -41,6 +41,7 @@ public:
   std::unique_ptr<ITrainableOperation> clone() const override;
   void accept(OperationVisitor &v) const override;
   void accept(TrainableOperationVisitor &v) const override;
+  bool hasTrainableParameter() const override { return false; }
 };
 
 } // namespace operation

--- a/runtime/onert/core/include/ir/train/operation/Permute.h
+++ b/runtime/onert/core/include/ir/train/operation/Permute.h
@@ -41,6 +41,7 @@ public:
   std::unique_ptr<ITrainableOperation> clone() const override;
   void accept(OperationVisitor &v) const override;
   void accept(TrainableOperationVisitor &v) const override;
+  bool hasTrainableParameter() const override { return false; }
 };
 
 } // namespace operation

--- a/runtime/onert/core/include/ir/train/operation/Pool2D.h
+++ b/runtime/onert/core/include/ir/train/operation/Pool2D.h
@@ -41,6 +41,7 @@ public:
   std::unique_ptr<ITrainableOperation> clone() const override;
   void accept(OperationVisitor &v) const override;
   void accept(TrainableOperationVisitor &v) const override;
+  bool hasTrainableParameter() const override { return false; }
 };
 
 } // namespace operation

--- a/runtime/onert/core/include/ir/train/operation/Reduce.h
+++ b/runtime/onert/core/include/ir/train/operation/Reduce.h
@@ -41,6 +41,7 @@ public:
   std::unique_ptr<ITrainableOperation> clone() const override;
   void accept(OperationVisitor &v) const override;
   void accept(TrainableOperationVisitor &v) const override;
+  bool hasTrainableParameter() const override { return false; }
 };
 
 } // namespace operation

--- a/runtime/onert/core/include/ir/train/operation/Reshape.h
+++ b/runtime/onert/core/include/ir/train/operation/Reshape.h
@@ -41,6 +41,7 @@ public:
   std::unique_ptr<ITrainableOperation> clone() const override;
   void accept(OperationVisitor &v) const override;
   void accept(TrainableOperationVisitor &v) const override;
+  bool hasTrainableParameter() const override { return false; }
 };
 
 } // namespace operation

--- a/runtime/onert/core/include/ir/train/operation/Softmax.h
+++ b/runtime/onert/core/include/ir/train/operation/Softmax.h
@@ -41,6 +41,7 @@ public:
   std::unique_ptr<ITrainableOperation> clone() const override;
   void accept(OperationVisitor &v) const override;
   void accept(TrainableOperationVisitor &v) const override;
+  bool hasTrainableParameter() const override { return false; }
 };
 
 } // namespace operation

--- a/runtime/onert/core/include/ir/train/operation/UntrainableOperation.h
+++ b/runtime/onert/core/include/ir/train/operation/UntrainableOperation.h
@@ -53,6 +53,7 @@ public:
   {
     throw std::runtime_error(OperationType::name() + "operation is not trainable yet");
   }
+  bool hasTrainableParameter() const override { return false; }
 };
 
 } // namespace operation


### PR DESCRIPTION
This commit adds hasTrainableParameter member function to ITrainableOperation.

This member function will be used in subsequent commit to truncate nodes which are not reachable from any node with trainable parameters.

ONE-DCO-1.0-Signed-off-by: YongHyun An <yonghyunz.an@samsung.com>

---
From draft https://github.com/Samsung/ONE/pull/12621