### PR TITLE
[res] Revise Net_BroadcastTo_AddV2_002 test.rule

### DIFF
--- a/res/TensorFlowLiteRecipes/Net_BroadcastTo_AddV2_002/test.rule
+++ b/res/TensorFlowLiteRecipes/Net_BroadcastTo_AddV2_002/test.rule
@@ -1,4 +1,4 @@
- To check if BroadcastTo and AddV2 are fused to Add op
+# To check if BroadcastTo and AddV2 are fused to Add op
 
 RULE    "VERIFY_FILE_FORMAT"      $(verify_file_format) '=' 1
 


### PR DESCRIPTION
This commit revises Net_BroadcastTo_AddV2_002 test.rule.

ONE-DCO-1.0-Signed-off-by: SeungHui Lee <shsh1004.lee@samsung.com>

---
Related to Issue: https://github.com/Samsung/ONE/issues/10784
Draft PR: [#10737](https://github.com/Samsung/ONE/pull/11701)