### PR TITLE
[onert-micro] Add execute part

### DIFF
--- a/onert-micro/onert-micro/include/execute/OMExecuteArgs.h
+++ b/onert-micro/onert-micro/include/execute/OMExecuteArgs.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ONERT_MICRO_EXECUTE_EXECUTE_ARGS_H
+#define ONERT_MICRO_EXECUTE_EXECUTE_ARGS_H
+
+#include "OMStatus.h"
+#include "core/OMRuntimeContext.h"
+#include "core/OMRuntimeStorage.h"
+#include "core/OMRuntimeModule.h"
+
+namespace onert_micro
+{
+namespace execute
+{
+
+struct OMExecuteArgs
+{
+  core::OMRuntimeStorage &runtime_storage;
+  core::OMRuntimeContext &runtime_context;
+  uint16_t kernel_index;
+  core::OMRuntimeModule &runtime_module;
+};
+
+} // namespace execute
+} // namespace onert_micro
+
+#endif // ONERT_MICRO_EXECUTE_EXECUTE_ARGS_H

--- a/onert-micro/onert-micro/include/execute/OMKernelExecute.h
+++ b/onert-micro/onert-micro/include/execute/OMKernelExecute.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ONERT_MICRO_EXECUTE_KERNEL_EXECUTE_H
+#define ONERT_MICRO_EXECUTE_KERNEL_EXECUTE_H
+
+#include "OMStatus.h"
+#include "core/OMRuntimeContext.h"
+#include "core/OMRuntimeStorage.h"
+#include "execute/OMExecuteArgs.h"
+#include "core/memory/OMRuntimeAllocator.h"
+
+namespace onert_micro
+{
+namespace execute
+{
+
+struct OMKernelExecute
+{
+  static OMStatus executeKernel(OMExecuteArgs &, core::memory::OMRuntimeAllocator &allocator);
+};
+
+} // namespace execute
+} // namespace onert_micro
+
+#endif // ONERT_MICRO_EXECUTE_KERNEL_EXECUTE_H

--- a/onert-micro/onert-micro/include/execute/OMKernelExecutionBuilder.h
+++ b/onert-micro/onert-micro/include/execute/OMKernelExecutionBuilder.h
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ONERT_MICRO_EXECUTE_KERNEL_EXECUTION_BUILDER_H
+#define ONERT_MICRO_EXECUTE_KERNEL_EXECUTION_BUILDER_H
+
+#include "core/reader/OMCircleReader.h"
+#include "core/OMKernelType.h"
+#include "core/OMRuntimeStorage.h"
+#include "core/OMRuntimeContext.h"
+#include "execute/OMExecuteArgs.h"
+
+namespace onert_micro
+{
+namespace execute
+{
+
+using KernelExecuteFunc = OMStatus(const OMExecuteArgs &);
+
+#define REGISTER_KERNEL(builtin_operator, name) \
+  OMStatus execute_kernel_Circle##name(const OMExecuteArgs &);
+#include "KernelsToBuild.lst"
+#undef REGISTER_KERNEL
+
+#define REGISTER_CUSTOM_KERNEL(name, string_name) \
+  OMStatus execute_kernel_Circle##name(const OMExecuteArgs &);
+#include "CustomKernelsToBuild.lst"
+#undef REGISTER_CUSTOM_KERNEL
+
+class KernelBuiltinExecuteRegistry
+{
+public:
+  constexpr KernelBuiltinExecuteRegistry() : _operator_execute()
+  {
+#define REGISTER_KERNEL(builtin_operator, name)                                \
+  registerKernelExecute(core::OMBuilderID::BuiltinOperator_##builtin_operator, \
+                        execute_kernel_Circle##name);
+
+#include "KernelsToBuild.lst"
+
+#undef REGISTER_KERNEL
+  }
+
+public:
+  OMStatus getKernelExecuteFunc(core::OMBuilderID builderID, KernelExecuteFunc **execute_func) const
+  {
+    const auto builder_id_opcode = size_t(builderID);
+    assert(builder_id_opcode < size_t(core::OMBuilderID::BuiltinOperatorsSize));
+    if (builder_id_opcode >= size_t(core::OMBuilderID::BuiltinOperatorsSize))
+    {
+      *execute_func = nullptr;
+      return UnknownError;
+    }
+    *execute_func = _operator_execute[builder_id_opcode];
+    return Ok;
+  }
+
+private:
+  constexpr void registerKernelExecute(core::OMBuilderID id, KernelExecuteFunc *func)
+  {
+    assert(size_t(id) < size_t(core::OMBuilderID::BuiltinOperatorsSize));
+    _operator_execute[size_t(id)] = func;
+  }
+
+private:
+  KernelExecuteFunc *_operator_execute[size_t(core::OMBuilderID::BuiltinOperatorsSize)];
+};
+
+class KernelCustomExecuteRegistry
+{
+public:
+  constexpr KernelCustomExecuteRegistry() : _operator_execute()
+  {
+#define REGISTER_CUSTOM_KERNEL(name, string_name) \
+  registerKernelExecute(core::OMBuilderID::CUSTOM_##name, execute_kernel_Circle##name);
+
+#include "CustomKernelsToBuild.lst"
+
+#undef REGISTER_CUSTOM_KERNEL
+  }
+
+public:
+  OMStatus getKernelExecuteFunc(core::OMBuilderID builderID, KernelExecuteFunc **execute_func) const
+  {
+    auto builder_id_opcode = size_t(builderID);
+    if (builder_id_opcode >= size_t(core::OMBuilderID::Size))
+    {
+      *execute_func = nullptr;
+      return UnknownError;
+    }
+    const auto builder_id_offset = size_t(core::OMBuilderID::BuiltinOperatorsSize);
+    builder_id_opcode -= builder_id_offset - 1;
+    if (builder_id_opcode < 0)
+    {
+      *execute_func = nullptr;
+      return UnknownError;
+    }
+    *execute_func = _operator_execute[builder_id_opcode];
+    return Ok;
+  }
+
+private:
+  constexpr void registerKernelExecute(core::OMBuilderID id, KernelExecuteFunc *func)
+  {
+    auto builder_id_opcode = size_t(id);
+    const auto builder_id_offset = size_t(core::OMBuilderID::BuiltinOperatorsSize);
+    builder_id_opcode = builder_id_opcode - builder_id_offset - 1;
+    _operator_execute[builder_id_opcode] = func;
+  }
+
+private:
+  KernelExecuteFunc *_operator_execute[size_t(core::OMBuilderID::Size) -
+                                       size_t(core::OMBuilderID::BuiltinOperatorsSize) - 1];
+};
+
+// Global constexpr kernel builtin and custom execute
+constexpr KernelBuiltinExecuteRegistry kernel_builtin_execute;
+constexpr KernelCustomExecuteRegistry kernel_custom_execute;
+
+} // namespace execute
+} // namespace onert_micro
+
+#endif // ONERT_MICRO_EXECUTE_KERNEL_EXECUTION_BUILDER_H

--- a/onert-micro/onert-micro/include/execute/OMRuntimeKernel.h
+++ b/onert-micro/onert-micro/include/execute/OMRuntimeKernel.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ONERT_MICRO_EXECUTE_RUNTIME_KERNEL_H
+#define ONERT_MICRO_EXECUTE_RUNTIME_KERNEL_H
+
+#include "core/reader/OMCircleReader.h"
+#include "core/OMRuntimeContext.h"
+#include "core/OMRuntimeStorage.h"
+
+#include <cstdint>
+
+constexpr static uint32_t maxInputSize = 5;
+constexpr static uint32_t maxOutputSize = 5;
+
+namespace onert_micro
+{
+namespace execute
+{
+
+class OMRuntimeKernel
+{
+public:
+  OMRuntimeKernel() = default;
+  OMRuntimeKernel(const OMRuntimeKernel &) = delete;
+  OMRuntimeKernel(OMRuntimeKernel &&) = delete;
+  ~OMRuntimeKernel() = default;
+  OMRuntimeKernel &operator=(const OMRuntimeKernel &) = delete;
+  OMRuntimeKernel &&operator=(const OMRuntimeKernel &&) = delete;
+
+public:
+  OMStatus readKernel(uint16_t op_index, core::OMRuntimeContext &runtime_context);
+
+  OMStatus getDataFromStorage(uint16_t op_index, core::OMRuntimeStorage &storage,
+                              core::OMRuntimeContext &context);
+
+public:
+  const circle::Tensor *inputs[maxInputSize] = {nullptr};
+  const circle::Tensor *outputs[maxOutputSize] = {nullptr};
+
+  uint8_t *inputs_data[maxInputSize] = {nullptr};
+  uint8_t *outputs_data[maxOutputSize] = {nullptr};
+
+  int32_t inputs_index[maxInputSize] = {-1};
+  int32_t outputs_index[maxOutputSize] = {-1};
+
+  uint32_t outputs_num = -1;
+  uint32_t inputs_num = -1;
+
+  const circle::Operator *first_operator = nullptr;
+};
+
+} // namespace execute
+} // namespace onert_micro
+
+#endif // ONERT_MICRO_EXECUTE_RUNTIME_KERNEL_H

--- a/onert-micro/onert-micro/include/execute/OMTestUtils.h
+++ b/onert-micro/onert-micro/include/execute/OMTestUtils.h
@@ -37,20 +37,25 @@ namespace testing
                                                       float max_abs_error = 1.0e-5f);
 
 template <typename T, typename U = T>
-std::vector<U> checkSISOKernel(onert_micro::test_model::TestDataBase<T, U> *test_data_base)
+std::vector<U> checkKernel(uint32_t num_inputs,
+                           onert_micro::test_model::TestDataBase<T, U> *test_data_base)
 {
-
   onert_micro::OMInterpreter interpreter;
   onert_micro::OMConfig config;
 
   interpreter.importModel(reinterpret_cast<const char *>(test_data_base->get_model_ptr()), config);
 
-  T *input_data = reinterpret_cast<T *>(interpreter.getInputDataAt(0));
+  assert(num_inputs == interpreter.getNumberOfInputs());
 
-  // Set input data
+  for (uint32_t i = 0; i < num_inputs; ++i)
   {
-    std::copy(test_data_base->get_input_data_by_index(0).begin(),
-              test_data_base->get_input_data_by_index(0).end(), input_data);
+    T *input_data = reinterpret_cast<T *>(interpreter.getInputDataAt(i));
+
+    // Set input data
+    {
+      std::copy(test_data_base->get_input_data_by_index(i).begin(),
+                test_data_base->get_input_data_by_index(i).end(), input_data);
+    }
   }
 
   interpreter.run();
@@ -58,40 +63,6 @@ std::vector<U> checkSISOKernel(onert_micro::test_model::TestDataBase<T, U> *test
   U *output_data = reinterpret_cast<U *>(interpreter.getOutputDataAt(0));
   const size_t num_elements = interpreter.getOutputSizeAt(0);
   std::vector<U> output_data_vector(output_data, output_data + num_elements);
-  return output_data_vector;
-}
-
-template <typename T>
-std::vector<T> checkTISOKernel(onert_micro::test_model::TestDataBase<T> *test_data_base)
-{
-
-  onert_micro::OMInterpreter interpreter;
-  onert_micro::OMConfig config;
-
-  interpreter.importModel(reinterpret_cast<const char *>(test_data_base->get_model_ptr()), config);
-
-  interpreter.allocateInputs();
-
-  T *input1_data = reinterpret_cast<T *>(interpreter.getInputDataAt(0));
-  T *input2_data = reinterpret_cast<T *>(interpreter.getInputDataAt(1));
-
-  // Set input data
-  {
-    std::copy(test_data_base->get_input_data_by_index(0).begin(),
-              test_data_base->get_input_data_by_index(0).end(), input1_data);
-  }
-
-  // Set input data
-  {
-    std::copy(test_data_base->get_input_data_by_index(1).begin(),
-              test_data_base->get_input_data_by_index(1).end(), input2_data);
-  }
-
-  interpreter.run();
-
-  T *output_data = reinterpret_cast<T *>(interpreter.getOutputDataAt(0));
-  const size_t num_elements = interpreter.getOutputSizeAt(0);
-  std::vector<T> output_data_vector(output_data, output_data + num_elements);
   return output_data_vector;
 }
 

--- a/onert-micro/onert-micro/include/execute/OMTestUtils.h
+++ b/onert-micro/onert-micro/include/execute/OMTestUtils.h
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ONERT_MICRO_EXECUTE_TESTUTILS_H
+#define ONERT_MICRO_EXECUTE_TESTUTILS_H
+
+#include "test_models/TestDataBase.h"
+#include "OMInterpreter.h"
+
+#include <type_traits>
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+namespace onert_micro
+{
+namespace execute
+{
+namespace testing
+{
+
+// Array version of `::testing::FloatNear` matcher.
+::testing::Matcher<std::vector<float>> FloatArrayNear(const std::vector<float> &values,
+                                                      float max_abs_error = 1.0e-5f);
+
+template <typename T, typename U = T>
+std::vector<U> checkSISOKernel(onert_micro::test_model::TestDataBase<T, U> *test_data_base)
+{
+
+  onert_micro::OMInterpreter interpreter;
+  onert_micro::OMConfig config;
+
+  interpreter.importModel(reinterpret_cast<const char *>(test_data_base->get_model_ptr()), config);
+
+  T *input_data = reinterpret_cast<T *>(interpreter.getInputDataAt(0));
+
+  // Set input data
+  {
+    std::copy(test_data_base->get_input_data_by_index(0).begin(),
+              test_data_base->get_input_data_by_index(0).end(), input_data);
+  }
+
+  interpreter.run();
+
+  U *output_data = reinterpret_cast<U *>(interpreter.getOutputDataAt(0));
+  const size_t num_elements = interpreter.getOutputSizeAt(0);
+  std::vector<U> output_data_vector(output_data, output_data + num_elements);
+  return output_data_vector;
+}
+
+template <typename T>
+std::vector<T> checkTISOKernel(onert_micro::test_model::TestDataBase<T> *test_data_base)
+{
+
+  onert_micro::OMInterpreter interpreter;
+  onert_micro::OMConfig config;
+
+  interpreter.importModel(reinterpret_cast<const char *>(test_data_base->get_model_ptr()), config);
+
+  interpreter.allocateInputs();
+
+  T *input1_data = reinterpret_cast<T *>(interpreter.getInputDataAt(0));
+  T *input2_data = reinterpret_cast<T *>(interpreter.getInputDataAt(1));
+
+  // Set input data
+  {
+    std::copy(test_data_base->get_input_data_by_index(0).begin(),
+              test_data_base->get_input_data_by_index(0).end(), input1_data);
+  }
+
+  // Set input data
+  {
+    std::copy(test_data_base->get_input_data_by_index(1).begin(),
+              test_data_base->get_input_data_by_index(1).end(), input2_data);
+  }
+
+  interpreter.run();
+
+  T *output_data = reinterpret_cast<T *>(interpreter.getOutputDataAt(0));
+  const size_t num_elements = interpreter.getOutputSizeAt(0);
+  std::vector<T> output_data_vector(output_data, output_data + num_elements);
+  return output_data_vector;
+}
+
+void checkNEGSISOKernel(onert_micro::test_model::NegTestDataBase *test_data_base);
+
+} // namespace testing
+} // namespace execute
+} // namespace onert_micro
+
+#endif // ONERT_MICRO_EXECUTE_TESTUTILS_H

--- a/onert-micro/onert-micro/include/execute/OMUtils.h
+++ b/onert-micro/onert-micro/include/execute/OMUtils.h
@@ -63,6 +63,8 @@ inline double getQuantizedConvolutionMultipler(float input_scale, float filter_s
 
   assert(input_product_scale >= 0);
 
+  assert(output_scale != 0.f);
+
   return input_product_scale / static_cast<double>(output_scale);
 }
 

--- a/onert-micro/onert-micro/include/execute/OMUtils.h
+++ b/onert-micro/onert-micro/include/execute/OMUtils.h
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ONERT_MICRO_EXECUTE_UTILS_H
+#define ONERT_MICRO_EXECUTE_UTILS_H
+
+#include "OMStatus.h"
+#include "core/reader/OMCircleReader.h"
+#include "core/OMRuntimeShape.h"
+
+namespace onert_micro
+{
+namespace execute
+{
+
+template <typename T>
+OMStatus calculateActivationRange(circle::ActivationFunctionType activation, T *activation_min,
+                                  T *activation_max)
+{
+  switch (activation)
+  {
+    case circle::ActivationFunctionType::ActivationFunctionType_NONE:
+      *activation_min = std::numeric_limits<T>::lowest();
+      *activation_max = std::numeric_limits<T>::max();
+      break;
+    case circle::ActivationFunctionType::ActivationFunctionType_RELU:
+      *activation_min = 0;
+      *activation_max = std::numeric_limits<T>::max();
+      break;
+    case circle::ActivationFunctionType::ActivationFunctionType_RELU_N1_TO_1:
+      *activation_min = -1;
+      *activation_max = 1;
+      break;
+    case circle::ActivationFunctionType::ActivationFunctionType_RELU6:
+      *activation_min = 0;
+      *activation_max = 6;
+      break;
+    default:
+      assert(false && "Unsupported activation.");
+      return UnsupportedActivation;
+  }
+
+  return Ok;
+}
+
+inline double getQuantizedConvolutionMultipler(float input_scale, float filter_scale,
+                                               float output_scale)
+{
+  const double input_product_scale = static_cast<double>(input_scale * filter_scale);
+
+  assert(input_product_scale >= 0);
+
+  return input_product_scale / static_cast<double>(output_scale);
+}
+
+void quantizeMultiplier(double double_multiplier, int32_t *quantized_multiplier, int *shift);
+
+void calculateActivationRangeQuantized(circle::ActivationFunctionType activation,
+                                       int32_t output_zero_point, float output_scale,
+                                       circle::TensorType data_type, int32_t *activation_min,
+                                       int32_t *activation_max);
+
+inline int computeOutSize(circle::Padding padding, int image_size, int filter_size, int stride,
+                          int dilation_rate = 1)
+{
+  int effective_filter_size = (filter_size - 1) * dilation_rate + 1;
+
+  if (stride == 0)
+    return 0;
+
+  switch (padding)
+  {
+    case circle::Padding_SAME:
+      return (image_size + stride - 1) / stride;
+    case circle::Padding_VALID:
+      return (image_size + stride - effective_filter_size) / stride;
+    default:
+      return 0;
+  }
+}
+
+inline int computePadding(int32_t stride, int32_t dilation_rate, int32_t in_size,
+                          int32_t filter_size, int32_t out_size)
+{
+  int32_t effective_filter_size = (filter_size - 1) * dilation_rate + 1;
+  int32_t padding = ((out_size - 1) * stride + effective_filter_size - in_size) / 2;
+  return padding > 0 ? padding : 0;
+}
+
+inline void computePaddingHeightWidth(int32_t stride_height, int32_t stride_width,
+                                      int32_t dilation_rate_height, int32_t dilation_rate_width,
+                                      int32_t in_height, int32_t in_width, int32_t filter_height,
+                                      int32_t filter_width, circle::Padding padding,
+                                      int32_t *padding_h, int32_t *padding_w)
+{
+
+  int out_width =
+    computeOutSize(padding, in_width, filter_width, stride_width, dilation_rate_width);
+  int out_height =
+    computeOutSize(padding, in_height, filter_height, stride_height, dilation_rate_height);
+
+  *padding_h =
+    computePadding(stride_height, dilation_rate_height, in_height, filter_height, out_height);
+
+  *padding_w = computePadding(stride_width, dilation_rate_width, in_width, filter_width, out_width);
+}
+
+} // namespace execute
+} // namespace onert_micro
+
+#endif // ONERT_MICRO_EXECUTE_UTILS_H

--- a/onert-micro/onert-micro/src/execute/CMakeLists.txt
+++ b/onert-micro/onert-micro/src/execute/CMakeLists.txt
@@ -1,0 +1,67 @@
+message(STATUS "ONERT MICRO EXECUTE BUILD BEGIN")
+
+include("${OM_PAL_DIR}/pal.cmake")
+
+initialize_pal()
+
+if (NOT PAL_INITIALIZED)
+    message(STATUS "ERROR: PAL Failed to initialize, skip BUILD EXECUTE")
+    return()
+endif()
+
+set(SOURCES
+        OMKernelExecute.cpp
+        OMKernelExecutionBuilder.cpp
+        OMRuntimeKernel.cpp
+        OMUtils.cpp
+        )
+
+# Add configure kernels
+macro(REGISTER_KERNEL OPERATOR, NODE)
+    list(APPEND SOURCES "kernels/${NODE}.cpp")
+endmacro(REGISTER_KERNEL)
+
+# To add REGISTER_KERNEL list
+include(${KERNEL_REGISTER_FILE})
+
+macro(REGISTER_CUSTOM_KERNEL NODE)
+    list(APPEND SOURCES "kernels/${NODE}.cpp")
+endmacro(REGISTER_CUSTOM_KERNEL)
+
+# To add CUSTOM_REGISTER_KERNEL list
+include(${CUSTOM_KERNEL_REGISTER_FILE})
+
+add_library(${OM_EXECUTE_LIB} STATIC ${SOURCES})
+
+target_include_directories(${OM_EXECUTE_LIB} PUBLIC "${OM_INCLUDE_DIR}")
+target_link_libraries(${OM_EXECUTE_LIB} PUBLIC ${OM_CORE_LIB})
+
+target_include_directories(${OM_EXECUTE_LIB} PUBLIC ${OM_PAL_COMMON_DIR})
+add_pal_to_target(${OM_EXECUTE_LIB})
+
+message(STATUS "ONERT MICRO EXECUTE BUILD FINISHED")
+
+if(NOT ENABLE_TEST)
+    return()
+endif(NOT ENABLE_TEST)
+
+nnas_find_package(GTest REQUIRED)
+
+macro(REGISTER_KERNEL OPERATOR, NODE)
+    list(APPEND TEST_SOURCES "kernels/tests/${NODE}.test.cpp")
+endmacro(REGISTER_KERNEL)
+
+include(${KERNEL_REGISTER_FILE})
+
+macro(REGISTER_CUSTOM_KERNEL NODE)
+    list(APPEND TEST_SOURCES "kernels/tests/${NODE}.test.cpp")
+endmacro(REGISTER_CUSTOM_KERNEL)
+
+# To add CUSTOM_REGISTER_KERNEL list
+include(${CUSTOM_KERNEL_REGISTER_FILE})
+
+list(APPEND TEST_SOURCES OMTestUtils.cpp)
+
+GTest_AddTest(${OM_EXECUTE_LIB}_kernels_test ${TEST_SOURCES})
+target_include_directories(${OM_EXECUTE_LIB}_kernels_test PUBLIC "${OM_INCLUDE_DIR}")
+target_link_libraries(${OM_EXECUTE_LIB}_kernels_test ${OM_INTERPRETER_LIB})

--- a/onert-micro/onert-micro/src/execute/OMKernelExecute.cpp
+++ b/onert-micro/onert-micro/src/execute/OMKernelExecute.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "execute/OMKernelExecute.h"
+#include "core/OMKernelType.h"
+#include "execute/OMKernelExecutionBuilder.h"
+
+using namespace onert_micro::execute;
+using namespace onert_micro;
+
+OMStatus OMKernelExecute::executeKernel(OMExecuteArgs &execute_args,
+                                        core::memory::OMRuntimeAllocator &allocator)
+{
+  OMStatus status = Ok;
+
+  core::OMRuntimeContext &context = execute_args.runtime_context;
+  core::OMRuntimeStorage &storage = execute_args.runtime_storage;
+
+  const core::reader::CircleOperators *operators = context.getCircleOperators();
+
+  const auto num_operators = static_cast<uint16_t>(operators->size());
+  const auto *op_codes = context.getCircleOpcodes();
+
+  for (uint16_t i = 0; i < num_operators; ++i)
+  {
+    status = allocator.allocate(i, &context, &storage);
+
+    if (status != Ok)
+      return status;
+
+    core::OMBuilderID builder_id = core::OMBuilderID::Size;
+    const circle::Operator *op = operators->operator[](i);
+    uint32_t index = op->opcode_index();
+
+    assert(index < op_codes->size());
+
+    const auto opcode = op_codes->operator[](index);
+
+    status = core::getBuilderId(opcode, builder_id);
+
+    assert(status == Ok);
+    if (status != Ok)
+      return status;
+
+    execute_args.kernel_index = i;
+
+    KernelExecuteFunc *execute_func = nullptr;
+    if (size_t(builder_id) < size_t(core::OMBuilderID::BuiltinOperatorsSize))
+    {
+      // Builtin operator
+      status = kernel_builtin_execute.getKernelExecuteFunc(builder_id, &execute_func);
+    }
+    else
+    {
+      // Custom
+      status = kernel_custom_execute.getKernelExecuteFunc(builder_id, &execute_func);
+    }
+
+    assert(execute_func != nullptr);
+
+    if (status != Ok)
+      return status;
+
+    status = execute_func(execute_args);
+
+    assert(status == Ok);
+
+    if (status != Ok)
+      return status;
+
+    status = allocator.deallocate(i, &storage);
+  }
+
+  return status;
+}

--- a/onert-micro/onert-micro/src/execute/OMKernelExecutionBuilder.cpp
+++ b/onert-micro/onert-micro/src/execute/OMKernelExecutionBuilder.cpp
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "execute/OMKernelExecutionBuilder.h"

--- a/onert-micro/onert-micro/src/execute/OMRuntimeKernel.cpp
+++ b/onert-micro/onert-micro/src/execute/OMRuntimeKernel.cpp
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "execute/OMRuntimeKernel.h"
+
+using namespace onert_micro::execute;
+using namespace onert_micro;
+
+OMStatus onert_micro::execute::OMRuntimeKernel::readKernel(uint16_t op_index,
+                                                           core::OMRuntimeContext &runtime_context)
+{
+  first_operator = runtime_context.getCircleOperatorAt(op_index);
+  const circle::Operator *last_operator = runtime_context.getCircleOperatorAt(op_index);
+
+  inputs_num = first_operator->inputs()->size();
+  assert(inputs_num < maxInputSize);
+
+  if (inputs_num >= maxInputSize)
+    return UnknownError;
+
+  outputs_num = last_operator->outputs()->size();
+  assert(outputs_num < maxOutputSize);
+
+  if (outputs_num >= maxOutputSize)
+    return UnknownError;
+
+  assert(inputs_num > 0 and outputs_num > 0);
+
+  // Read inputs
+  {
+    const auto *inputs_op = first_operator->inputs();
+    for (uint32_t i = 0; i < inputs_num; ++i)
+    {
+      inputs_index[i] = inputs_op->operator[](i);
+      if (inputs_index[i] != -1)
+        inputs[i] = runtime_context.getTensorByIndex(inputs_index[i]);
+    }
+  }
+  // Read outputs
+  {
+    const auto *outputs_op = last_operator->outputs();
+    for (uint32_t i = 0; i < outputs_num; ++i)
+    {
+      outputs_index[i] = outputs_op->operator[](i);
+      if (outputs_index[i] != -1)
+        outputs[i] = runtime_context.getTensorByIndex(outputs_index[i]);
+    }
+  }
+
+  return Ok;
+}
+
+// Note: if inplace then first input and first output will be inplace
+OMStatus onert_micro::execute::OMRuntimeKernel::getDataFromStorage(uint16_t op_index,
+                                                                   core::OMRuntimeStorage &storage,
+                                                                   core::OMRuntimeContext &context)
+{
+  OMStatus status = Ok;
+
+  for (uint32_t i = 0; i < inputs_num; ++i)
+  {
+    if (inputs_index[i] == -1)
+      continue;
+    status = storage.getDataByTensorIndex(&inputs_data[i], inputs_index[i]);
+    if (inputs_data[i] == nullptr)
+      status = context.getConstDataByTensorIndex(&inputs_data[i], inputs_index[i]);
+    if (status != Ok)
+      return status;
+  }
+
+  for (uint32_t i = 0; i < outputs_num; ++i)
+  {
+    if (outputs_index[i] == -1)
+      continue;
+    status = storage.getDataByTensorIndex(&outputs_data[i], outputs_index[i]);
+
+    if (status != Ok)
+      return status;
+
+    if (storage.getKernelType(op_index) == core::Inplace)
+    {
+      outputs_data[i] = inputs_data[i];
+      status = storage.removeTensorFromTensorIndexToData(inputs_index[i]);
+
+      if (status != Ok)
+        return status;
+
+      status = storage.saveDataToTensorIndex(outputs_data[i], outputs_index[i]);
+    }
+  }
+
+  return status;
+}

--- a/onert-micro/onert-micro/src/execute/OMTestUtils.cpp
+++ b/onert-micro/onert-micro/src/execute/OMTestUtils.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "execute/OMTestUtils.h"
+
+#include "OMInterpreter.h"
+
+using ::testing::FloatNear;
+using ::testing::Matcher;
+
+using namespace onert_micro;
+
+Matcher<std::vector<float>> execute::testing::FloatArrayNear(const std::vector<float> &values,
+                                                             float max_abs_error)
+{
+  std::vector<Matcher<float>> matchers;
+  matchers.reserve(values.size());
+  for (const float v : values)
+  {
+    matchers.emplace_back(FloatNear(v, max_abs_error));
+  }
+  return ElementsAreArray(matchers);
+}
+
+void execute::testing::checkNEGSISOKernel(onert_micro::test_model::NegTestDataBase *test_data_base)
+{
+  onert_micro::OMInterpreter interpreter;
+  onert_micro::OMConfig config;
+
+  interpreter.importModel(reinterpret_cast<const char *>(test_data_base->get_model_ptr()), config);
+}

--- a/onert-micro/onert-micro/src/execute/OMUtils.cpp
+++ b/onert-micro/onert-micro/src/execute/OMUtils.cpp
@@ -64,6 +64,8 @@ static void calculateActivationRangeQuantizedImpl(circle::ActivationFunctionType
                                                   float scale, int32_t *activation_min,
                                                   int32_t *activation_max)
 {
+  assert(scale != 0.f);
+
   auto quantize = [scale, zero_point](float x) {
     return zero_point + static_cast<int32_t>(std::round(x / scale));
   };

--- a/onert-micro/onert-micro/src/execute/OMUtils.cpp
+++ b/onert-micro/onert-micro/src/execute/OMUtils.cpp
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "execute/OMUtils.h"
+#include <cmath>
+
+using namespace onert_micro::execute;
+using namespace onert_micro;
+
+void onert_micro::execute::quantizeMultiplier(double double_multiplier,
+                                              int32_t *quantized_multiplier, int *shift)
+{
+  if (double_multiplier == 0.0)
+  {
+    *quantized_multiplier = 0;
+    *shift = 0;
+    return;
+  }
+
+  const double q = std::frexp(double_multiplier, shift);
+  auto q_fixed = static_cast<int64_t>(std::round(q * (int64_t(1) << 31)));
+
+  if (q_fixed == (int64_t(1) << 31))
+  {
+    q_fixed /= 2;
+    ++*shift;
+  }
+  assert(q_fixed <= std::numeric_limits<int32_t>::max());
+  // A shift amount smaller than -31 would cause all bits to be shifted out
+  // and thus all results would be zero. We implement that instead with
+  // q_fixed==0, so as to avoid hitting issues with right-shift
+  // operations with shift amounts greater than 31. Note that this happens
+  // roughly when abs(double_multiplier) < 2^-31 and the present handling means
+  // that we're effectively flushing tiny double_multiplier's to zero.
+  // We could conceivably handle values in the range (roughly) [32, 63]
+  // as 'denormals' i.e. (shift==0, q_fixed < 2^30). In that point of view
+  // the present handling is just doing 'flush denormals to zero'. We could
+  // reconsider and actually generate nonzero denormals if a need arises.
+  if (*shift < -31)
+  {
+    *shift = 0;
+    q_fixed = 0;
+  }
+  *quantized_multiplier = static_cast<int32_t>(q_fixed);
+}
+
+namespace
+{
+static void calculateActivationRangeQuantizedImpl(circle::ActivationFunctionType activation,
+                                                  int32_t qmin, int32_t qmax, int32_t zero_point,
+                                                  float scale, int32_t *activation_min,
+                                                  int32_t *activation_max)
+{
+  auto quantize = [scale, zero_point](float x) {
+    return zero_point + static_cast<int32_t>(std::round(x / scale));
+  };
+
+  switch (activation)
+  {
+    case circle::ActivationFunctionType::ActivationFunctionType_NONE:
+    case circle::ActivationFunctionType::ActivationFunctionType_TANH:
+      *activation_min = qmin;
+      *activation_max = qmax;
+      break;
+    case circle::ActivationFunctionType::ActivationFunctionType_RELU:
+      *activation_min = std::max(qmin, quantize(0.0f));
+      *activation_max = qmax;
+      break;
+    case circle::ActivationFunctionType::ActivationFunctionType_RELU_N1_TO_1:
+      *activation_min = std::max(qmin, quantize(-1.0f));
+      *activation_max = std::min(qmax, quantize(1.0f));
+      break;
+    case circle::ActivationFunctionType::ActivationFunctionType_RELU6:
+      *activation_min = std::max(qmin, quantize(0.0f));
+      *activation_max = std::min(qmax, quantize(6.0f));
+      break;
+    default:
+      assert(false && "Unsupported activation.");
+  }
+}
+} // namespace
+
+void onert_micro::execute::calculateActivationRangeQuantized(
+  circle::ActivationFunctionType activation, int32_t output_zero_point, float output_scale,
+  circle::TensorType data_type, int32_t *activation_min, int32_t *activation_max)
+{
+  int32_t qmin;
+  int32_t qmax;
+  switch (data_type)
+  {
+    case circle::TensorType_UINT8:
+      qmin = 0;
+      qmax = std::numeric_limits<uint8_t>::max();
+      break;
+    case circle::TensorType_INT8:
+      qmin = std::numeric_limits<int8_t>::min();
+      qmax = std::numeric_limits<int8_t>::max();
+      break;
+    case circle::TensorType_INT16:
+      // For now, assume that signed int16 type implies signed symmetric quantization.
+      assert(output_zero_point == 0);
+      qmin = std::numeric_limits<int16_t>::min();
+      qmax = std::numeric_limits<int16_t>::max();
+      break;
+    default:
+      assert(false && "Unsupported type.");
+  }
+
+  calculateActivationRangeQuantizedImpl(activation, qmin, qmax, output_zero_point, output_scale,
+                                        activation_min, activation_max);
+}


### PR DESCRIPTION
This pr adds execute entities part to the onert-micro.

from draft https://github.com/Samsung/ONE/pull/12426
for issue: https://github.com/Samsung/ONE/issues/12427

ONE-DCO-1.0-Signed-off-by: Artem Balyshev <a.balyshev@samsung.com>