### PR TITLE
[luci-pass-value-py-test] For remove_gather_guard option

### DIFF
--- a/compiler/luci-pass-value-py-test/test.lst
+++ b/compiler/luci-pass-value-py-test/test.lst
@@ -9,6 +9,7 @@
 # --> https://github.com/Samsung/ONE/issues/5782
 eval(FullyConnected_007 replace_non_const_fc_with_batch_matmul)
 eval(HardSwish_001 decompose_hardswish)
+eval(Net_Add_FloorMod_Gather_000 remove_gather_guard)
 eval(Net_Conv_Add_Mul_000 fuse_batchnorm_with_conv)
 eval(Net_Conv_Add_Mul_000 fuse_batchnorm_with_conv)
 eval(Net_Conv_Add_Mul_001 fuse_batchnorm_with_conv)


### PR DESCRIPTION
This will enable value test of remove_gather_guard option.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>