### PR TITLE
[luci/pass] Revise SubstitutePadV2ToPadPass

### DIFF
--- a/compiler/luci/pass/src/SubstitutePadV2ToPadPass.cpp
+++ b/compiler/luci/pass/src/SubstitutePadV2ToPadPass.cpp
@@ -215,9 +215,9 @@ bool positive_or_zero(loco::Node *ifm)
   // Since Relu.output[i] >= 0
   if (dynamic_cast<luci::CircleRelu *>(ifm))
     return true;
-  if (auto conv = dynamic_cast<luci::CircleConv2D *>(ifm))
+  if (auto node = dynamic_cast<luci::CircleNodeMixin<luci::CircleNodeTrait::FusedActFunc> *>(ifm))
   {
-    if (conv->fusedActivationFunction() == luci::FusedActFunc::RELU)
+    if (node->fusedActivationFunction() == luci::FusedActFunc::RELU)
       return true;
     // Add more FusedActFunc
   }


### PR DESCRIPTION
This will revise SubstitutePadV2ToPadPass to support all Ops that can have ReLU fused activation.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>