### PR TITLE
[luci/pass] Add FuseAddWithConv option

### DIFF
--- a/compiler/luci/pass/include/luci/CircleOptimizer.h
+++ b/compiler/luci/pass/include/luci/CircleOptimizer.h
@@ -34,6 +34,7 @@ public:
   {
     enum Algorithm
     {
+      FuseAddWithConv,
       FuseAddWithFullyConnected,
       FuseAddWithTConv,
       FuseBatchNormWithConv,

--- a/compiler/luci/pass/src/CircleOptimizer.cpp
+++ b/compiler/luci/pass/src/CircleOptimizer.cpp
@@ -31,6 +31,7 @@
 #include "luci/Pass/ForwardReshapeToUnaryOpPass.h"
 #include "luci/Pass/ForwardTransposeOpPass.h"
 #include "luci/Pass/FuseActivationFunctionPass.h"
+#include "luci/Pass/FuseAddWithConvPass.h"
 #include "luci/Pass/FuseAddWithFullyConnectedPass.h"
 #include "luci/Pass/FuseAddWithTConvPass.h"
 #include "luci/Pass/FuseBatchNormWithConvPass.h"
@@ -310,6 +311,10 @@ void CircleOptimizer::optimize(loco::Graph *g) const
   if (_options->query(Options::Algorithm::FuseSliceWithTConv))
   {
     phase.emplace_back(std::make_unique<FuseSliceWithTConvPass>());
+  }
+  if (_options->query(Options::Algorithm::FuseAddWithConv))
+  {
+    phase.emplace_back(std::make_unique<FuseAddWithConvPass>());
   }
   if (_options->query(Options::Algorithm::FuseAddWithFullyConnected))
   {


### PR DESCRIPTION
This will add FuseAddWithConv option to CircleOptimizer.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>