### PR TITLE
[luci-pass-value-test] Enable test for fuse_add_with_conv

### DIFF
--- a/compiler/luci-pass-value-py-test/test.lst
+++ b/compiler/luci-pass-value-py-test/test.lst
@@ -10,6 +10,9 @@
 eval(FullyConnected_007 replace_non_const_fc_with_batch_matmul)
 eval(HardSwish_001 decompose_hardswish)
 eval(Net_Add_FloorMod_Gather_000 remove_gather_guard)
+eval(Net_Conv_Add_000 fuse_add_with_conv)
+eval(Net_Conv_Add_001 fuse_add_with_conv)
+# eval(Net_Conv_Add_002 fuse_add_with_conv) --> Conv2D w/o bias fails in tflite interpreter
 eval(Net_Conv_Add_Mul_000 fuse_batchnorm_with_conv)
 eval(Net_Conv_Add_Mul_000 fuse_batchnorm_with_conv)
 eval(Net_Conv_Add_Mul_001 fuse_batchnorm_with_conv)


### PR DESCRIPTION
This will enable pass value test for fuse_add_with_conv option.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>