### PR TITLE
[onert] Rename loader file and namespace

### DIFF
--- a/runtime/onert/api/nnfw/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/nnfw/src/nnfw_api_internal.cc
@@ -21,10 +21,10 @@
 #include "util/Exceptions.h"
 #include "util/logging.h"
 #include "exec/Execution.h"
-#include "loader/circle_loader.h"
+#include "loader/CircleLoader.h"
 #include "loader/ModelLoader.h"
-#include "loader/tflite_loader.h"
-#include "loader/traininfo_loader.h"
+#include "loader/TFLiteLoader.h"
+#include "loader/TrainInfoLoader.h"
 #include "json/json.h"
 #include "ir/NNPkg.h"
 #include "ir/OpCode.h"
@@ -197,9 +197,9 @@ std::unique_ptr<onert::ir::Model> loadModel(const std::string filename,
   try
   {
     if (model_type == "tflite")
-      return onert::tflite_loader::loadModel(filename.c_str());
+      return onert::loader::loadTFLiteModel(filename.c_str());
     if (model_type == "circle")
-      return onert::circle_loader::loadModel(filename.c_str());
+      return onert::loader::loadCircleModel(filename.c_str());
     if (model_type == "tvn")
       return onert::trix_loader::loadModel(filename.c_str());
 
@@ -216,11 +216,11 @@ std::unique_ptr<onert::ir::Model> loadModel(const std::string filename,
 std::unique_ptr<onert::ir::train::TrainingInfo>
 loadTrainingInfo(const std::shared_ptr<onert::ir::Model> &model)
 {
-  const auto tinfo_name = onert::train::traininfo_loader::TRAININFO_METADATA_NAME;
+  const auto tinfo_name = onert::loader::TRAININFO_METADATA_NAME;
   if (model->exists_metadata(tinfo_name))
   {
     const auto buffer = model->extract_metadata(tinfo_name);
-    return onert::train::traininfo_loader::loadTrainingInfo(buffer->base(), buffer->size());
+    return onert::loader::loadTrainingInfo(buffer->base(), buffer->size());
   }
   return std::make_unique<onert::ir::train::TrainingInfo>();
 }
@@ -296,7 +296,7 @@ NNFW_STATUS nnfw_session::load_circle_from_buffer(uint8_t *buffer, size_t size)
 
   try
   {
-    auto model = onert::circle_loader::loadModel(buffer, size);
+    auto model = onert::loader::loadCircleModel(buffer, size);
     // TODO: Update _model_path if necessary
     _nnpkg = std::make_shared<onert::ir::NNPkg>(std::move(model));
     _coptions.push_back(onert::compiler::CompilerOptions::fromGlobalConfig());

--- a/runtime/onert/core/include/loader/CircleLoader.h
+++ b/runtime/onert/core/include/loader/CircleLoader.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef __TFLITE_TFLITE_LOADER_H__
-#define __TFLITE_TFLITE_LOADER_H__
+#ifndef __ONERT_LOADER_CIRCLE_LOADER_H__
+#define __ONERT_LOADER_CIRCLE_LOADER_H__
 
 #include "ir/Graph.h"
 
@@ -23,12 +23,11 @@
 
 namespace onert
 {
-namespace tflite_loader
+namespace loader
 {
-
-std::unique_ptr<ir::Model> loadModel(const std::string &filename);
-
-} // namespace tflite_loader
+std::unique_ptr<ir::Model> loadCircleModel(const std::string &filename);
+std::unique_ptr<ir::Model> loadCircleModel(uint8_t *buffer, size_t size);
+} // namespace loader
 } // namespace onert
 
-#endif // __TFLITE_TFLITE_LOADER_H__
+#endif // __ONERT_LOADER_CIRCLE_LOADER_H__

--- a/runtime/onert/core/include/loader/TFLiteLoader.h
+++ b/runtime/onert/core/include/loader/TFLiteLoader.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright (c) 2019 Samsung Electronics Co., Ltd. All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,26 +14,21 @@
  * limitations under the License.
  */
 
-#ifndef __CIRCLE_TRAININFO_LOADER_H__
-#define __CIRCLE_TRAININFO_LOADER_H__
+#ifndef __ONERT_LOADER_TFLITE_LOADER_H__
+#define __ONERT_LOADER_TFLITE_LOADER_H__
 
-#include "ir/train/TrainingInfo.h"
-#include "ir/Model.h"
+#include "ir/Graph.h"
+
+#include <memory>
 
 namespace onert
 {
-namespace train
-{
-namespace traininfo_loader
+namespace loader
 {
 
-// TODO change this line to use inline variable after C++17
-extern const char *const TRAININFO_METADATA_NAME;
+std::unique_ptr<ir::Model> loadTFLiteModel(const std::string &filename);
 
-std::unique_ptr<ir::train::TrainingInfo> loadTrainingInfo(const uint8_t *buffer, const size_t size);
-
-} // namespace traininfo_loader
-} // namespace train
+} // namespace loader
 } // namespace onert
 
-#endif // __CIRCLE_TRAININFO_LOADER_H__
+#endif // __ONERT_LOADER_TFLITE_LOADER_H__

--- a/runtime/onert/core/include/loader/TrainInfoLoader.h
+++ b/runtime/onert/core/include/loader/TrainInfoLoader.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,20 +14,24 @@
  * limitations under the License.
  */
 
-#ifndef __CIRCLE_CIRCLE_LOADER_H__
-#define __CIRCLE_CIRCLE_LOADER_H__
+#ifndef __ONERT_LOADER_CIRCLE_TRAININFO_LOADER_H__
+#define __ONERT_LOADER_CIRCLE_TRAININFO_LOADER_H__
 
-#include "ir/Graph.h"
+#include "ir/train/TrainingInfo.h"
 
 #include <memory>
 
 namespace onert
 {
-namespace circle_loader
+namespace loader
 {
-std::unique_ptr<ir::Model> loadModel(const std::string &filename);
-std::unique_ptr<ir::Model> loadModel(uint8_t *buffer, size_t size);
-} // namespace circle_loader
+
+// TODO change this line to use inline variable after C++17
+extern const char *const TRAININFO_METADATA_NAME;
+
+std::unique_ptr<ir::train::TrainingInfo> loadTrainingInfo(const uint8_t *buffer, const size_t size);
+
+} // namespace loader
 } // namespace onert
 
-#endif // __CIRCLE_CIRCLE_LOADER_H__
+#endif // __ONERT_LOADER_CIRCLE_TRAININFO_LOADER_H__

--- a/runtime/onert/core/src/loader/BaseLoader.h
+++ b/runtime/onert/core/src/loader/BaseLoader.h
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-#ifndef __BASE_LOADER_BASE_LOADER_H__
-#define __BASE_LOADER_BASE_LOADER_H__
+#ifndef __ONERT_LOADER_BASE_LOADER_H__
+#define __ONERT_LOADER_BASE_LOADER_H__
 
 #include "ir/Graph.h"
 #include "ir/Shape.h"
@@ -36,7 +36,7 @@
 
 namespace onert
 {
-namespace base_loader
+namespace loader
 {
 
 template <typename LoaderDomain> class BaseLoader
@@ -1778,7 +1778,7 @@ template <typename LoaderDomain> void BaseLoader<LoaderDomain>::loadModel()
   _model = std::move(model);
 }
 
-} // namespace base_loader
+} // namespace loader
 } // namespace onert
 
-#endif //__BASE_LOADER_BASE_LOADER_H__
+#endif //__ONERT_LOADER_BASE_LOADER_H__

--- a/runtime/onert/core/src/loader/CircleLoader.cc
+++ b/runtime/onert/core/src/loader/CircleLoader.cc
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-#include "loader/circle_loader.h"
+#include "loader/CircleLoader.h"
 
-#include "base_loader.h"
+#include "BaseLoader.h"
 #include "circle_schema_generated.h"
 
 namespace onert
 {
-namespace circle_loader
+namespace loader
 {
 
 namespace
@@ -58,7 +58,7 @@ struct LoaderDomain
   static bool VerifyModelBuffer(Verifier &verifier) { return circle::VerifyModelBuffer(verifier); }
 };
 
-class CircleLoader final : public base_loader::BaseLoader<LoaderDomain>
+class CircleLoader final : public loader::BaseLoader<LoaderDomain>
 {
 protected:
   // Different option name
@@ -219,7 +219,7 @@ void CircleLoader::loadBCQFullyConnected(const Operator *op, ir::Graph &subg)
 
 } // namespace
 
-std::unique_ptr<ir::Model> loadModel(const std::string &filename)
+std::unique_ptr<ir::Model> loadCircleModel(const std::string &filename)
 {
   auto model = std::make_unique<ir::Model>();
   CircleLoader loader(model);
@@ -227,7 +227,7 @@ std::unique_ptr<ir::Model> loadModel(const std::string &filename)
   return model;
 }
 
-std::unique_ptr<ir::Model> loadModel(uint8_t *buffer, size_t size)
+std::unique_ptr<ir::Model> loadCircleModel(uint8_t *buffer, size_t size)
 {
   auto model = std::make_unique<ir::Model>();
   CircleLoader loader(model);
@@ -235,5 +235,5 @@ std::unique_ptr<ir::Model> loadModel(uint8_t *buffer, size_t size)
   return model;
 }
 
-} // namespace circle_loader
+} // namespace loader
 } // namespace onert

--- a/runtime/onert/core/src/loader/TFLiteLoader.cc
+++ b/runtime/onert/core/src/loader/TFLiteLoader.cc
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-#include "loader/tflite_loader.h"
+#include "loader/TFLiteLoader.h"
 
-#include "base_loader.h"
+#include "BaseLoader.h"
 #include "tflite_schema_generated.h"
 
 namespace onert
 {
-namespace tflite_loader
+namespace loader
 {
 
 namespace
@@ -64,7 +64,7 @@ struct LoaderDomain
   }
 };
 
-class TFLiteLoader final : public base_loader::BaseLoader<LoaderDomain>
+class TFLiteLoader final : public loader::BaseLoader<LoaderDomain>
 {
 protected:
   // Different option name
@@ -155,7 +155,7 @@ void TFLiteLoader::loadBatchMatMul(const Operator *op, ir::Graph &subg)
 
 } // namespace
 
-std::unique_ptr<ir::Model> loadModel(const std::string &filename)
+std::unique_ptr<ir::Model> loadTFLiteModel(const std::string &filename)
 {
   auto model = std::make_unique<ir::Model>();
   TFLiteLoader loader(model);
@@ -163,5 +163,5 @@ std::unique_ptr<ir::Model> loadModel(const std::string &filename)
   return model;
 }
 
-} // namespace tflite_loader
+} // namespace loader
 } // namespace onert

--- a/runtime/onert/core/src/loader/TrainInfoLoader.cc
+++ b/runtime/onert/core/src/loader/TrainInfoLoader.cc
@@ -14,16 +14,14 @@
  * limitations under the License.
  */
 
-#include "loader/traininfo_loader.h"
+#include "loader/TrainInfoLoader.h"
 
 #include "circle_traininfo_generated.h"
 #include "flatbuffers/flatbuffers.h"
 
 namespace onert
 {
-namespace train
-{
-namespace traininfo_loader
+namespace loader
 {
 
 const char *const TRAININFO_METADATA_NAME = "CIRCLE_TRAINING";
@@ -118,6 +116,5 @@ std::unique_ptr<ir::train::TrainingInfo> loadTrainingInfo(const uint8_t *buffer,
   return tinfo;
 }
 
-} // namespace traininfo_loader
-} // namespace train
+} // namespace loader
 } // namespace onert


### PR DESCRIPTION
This commit renames loader file and namespace.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: https://github.com/Samsung/ONE/issues/12482
Draft: #12563