### PR TITLE
[doc] Update the NNAPI paths

### DIFF
--- a/docs/howto/how-to-introduce-a-new-operation-into-runtime.md
+++ b/docs/howto/how-to-introduce-a-new-operation-into-runtime.md
@@ -278,7 +278,7 @@ If you want new operation to be loaded on only Circle Loader, you only need to i
 ### NNAPI
 
 1. Add to the OperationFactory to generate IR of new operation
-- [OperationFactory](/runtime/onert/frontend/nnapi/wrapper/OperationFactory.cc)
+- [OperationFactory](/runtime/onert/api/nnapi/wrapper/OperationFactory.cc)
 
 ```cpp
   _map[ANEURALNETWORKS_SELECT] = [](const OperationFactory::Param &init_param, Operands &) {

--- a/docs/howto/how-to-use-nnapi-binding.md
+++ b/docs/howto/how-to-use-nnapi-binding.md
@@ -1,5 +1,5 @@
 # How to Use NNAPI Binding
 
-Runtime supports [Android Neural Networks API](https://developer.android.com/ndk/guides/neuralnetworks) as a frontend. We provide the whole `NeuralNetworks.h` implementation. Its source code is located at `runtime/onert/frontend/nnapi`.
+Runtime supports [Android Neural Networks API](https://developer.android.com/ndk/guides/neuralnetworks) as a frontend. We provide the whole `NeuralNetworks.h` implementation. Its source code is located at `runtime/onert/api/nnapi`.
 
 So users can just use NN API in the same way as [the official guide](https://developer.android.com/ndk/guides/neuralnetworks), but should watch the version of `NeuralNetworks.h`. It may not be the latest. There is a copy of the file is located at `runtime/nnapi-header/include/NeuralNetworks.h`.


### PR DESCRIPTION
This commit updates the paths in the documentation that were moved in #12515

ONE-DCO-1.0-Signed-off-by: Piotr Fusik <piotr@fusion-lang.org>