### PR TITLE
[tests/nnfw_api] Add epochs and fix Conv2D test

### DIFF
--- a/tests/nnfw_api/lib/GenModelTrain.h
+++ b/tests/nnfw_api/lib/GenModelTrain.h
@@ -79,7 +79,7 @@ class GenModelTrainContext : public GenModelTestContext
 {
 public:
   GenModelTrainContext(CircleBuffers &&cbufs)
-    : GenModelTestContext(std::move(cbufs.circle)), _cpbuf{std::move(cbufs.circle_plus)}
+    : GenModelTestContext(std::move(cbufs.circle)), _cpbuf{std::move(cbufs.circle_plus)}, _epoch(0)
   {
     // DO NOTHING
   }
@@ -105,9 +105,21 @@ public:
    */
   void addTrainCase(const TrainCaseData &tc) { _train_cases.emplace_back(tc); }
 
+  int epoch() { return _epoch; }
+
+  void setEpoch(int32_t epoch)
+  {
+    if (epoch < 2)
+    {
+      throw std::runtime_error{"epoch should be equal or greater than 2"};
+    }
+    _epoch = epoch;
+  }
+
 private:
   CircleBuffer _cpbuf;
   std::vector<TrainCaseData> _train_cases;
+  int32_t _epoch;
 };
 
 /**
@@ -237,8 +249,8 @@ protected:
       // Prepare expected loss
       _so.losses.resize(num_expecteds);
 
-      const int num_epoch = 1;
-      ASSERT_EQ(num_epoch, 1); // for now, epoch is set to 1
+      const int num_epoch = _context->epoch();
+      ASSERT_GE(num_epoch, 2);
       const int num_step = num_expecteds / tri.batch_size;
       ASSERT_GE(num_step, 1);
 

--- a/tests/nnfw_api/src/GenModelTests/one_op_trains/Conv2D.test.cc
+++ b/tests/nnfw_api/src/GenModelTests/one_op_trains/Conv2D.test.cc
@@ -24,7 +24,7 @@ TEST_F(GenModelTrain, OneOp_Conv2D)
   uint32_t weight_buf = cgen.addBuffer(std::vector<float>(2 * 3 * 3, 0.f));
   int weight = cgen.addTensor({{2, 3, 3, 1}, circle::TensorType::TensorType_FLOAT32, weight_buf});
   uint32_t bias_buf = cgen.addBuffer(std::vector<float>(2, 0.f));
-  int bias = cgen.addTensor({{1, 1, 1, 2}, circle::TensorType::TensorType_FLOAT32, bias_buf});
+  int bias = cgen.addTensor({{2}, circle::TensorType::TensorType_FLOAT32, bias_buf});
   int out = cgen.addTensor({{1, 3, 3, 2}, circle::TensorType::TensorType_FLOAT32});
   cgen.addOperatorConv2D({{in, weight, bias}, {out}}, circle::Padding_VALID, 1, 1,
                          circle::ActivationFunctionType_NONE, 1, 1);
@@ -41,9 +41,11 @@ TEST_F(GenModelTrain, OneOp_Conv2D)
     {{4, 0,  -5, 1, 0,  4, -1, 1, -1, -3, 3,  -2, -4,
       1, -2, 2,  4, -4, 2, 2,  0, 4,  -1, -2, 4}},                               // inputs
     {{47, -4, -25, 9, 10, 10, -13, 11, -14, -26, -12, 26, 20, 40, 1, 3, 11, 4}}, // expected
-    {{403.333f}}                                                                 // loss
+    {{62469.609375f}}                                                            // loss
     ));
   _context->setBackends({"train"});
+  // To apply backward to loss, epoch should be >= 2
+  _context->setEpoch(2);
 
   SUCCEED();
 }


### PR DESCRIPTION
This commit adds epochs to CirclePlusGen and apply it to Conv2D test to pass the test. Additionaly bias shape is fixed.

ONE-DCO-1.0-Signed-off-by: Yongseop Kim <yons.kim@samsung.com>