### PR TITLE
[circle-tensordump] Revise to use mio-circle08

### DIFF
--- a/compiler/circle-tensordump/CMakeLists.txt
+++ b/compiler/circle-tensordump/CMakeLists.txt
@@ -1,6 +1,6 @@
-if(NOT TARGET mio_circle07)
+if(NOT TARGET mio_circle08)
   return()
-endif(NOT TARGET mio_circle07)
+endif(NOT TARGET mio_circle08)
 
 nnas_find_package(HDF5 COMPONENTS STATIC QUIET)
 
@@ -19,8 +19,8 @@ target_include_directories(circle-tensordump PRIVATE ${HDF5_INCLUDE_DIRS})
 target_link_libraries(circle-tensordump PRIVATE ${HDF5_CXX_LIBRARIES})
 target_link_libraries(circle-tensordump PRIVATE arser)
 target_link_libraries(circle-tensordump PRIVATE foder)
-target_link_libraries(circle-tensordump PRIVATE mio_circle07)
-target_link_libraries(circle-tensordump PRIVATE mio_circle07_helper)
+target_link_libraries(circle-tensordump PRIVATE mio_circle08)
+target_link_libraries(circle-tensordump PRIVATE mio_circle08_helper)
 target_link_libraries(circle-tensordump PRIVATE safemain)
 
 install(TARGETS circle-tensordump DESTINATION bin)

--- a/compiler/circle-tensordump/requires.cmake
+++ b/compiler/circle-tensordump/requires.cmake
@@ -1,4 +1,4 @@
 require("arser")
 require("foder")
-require("mio-circle07")
+require("mio-circle08")
 require("safemain")


### PR DESCRIPTION
This will revise to use mio-circle08.

for issue: https://github.com/Samsung/ONE/issues/12706
from draft: https://github.com/Samsung/ONE/pull/12707

ONE-DCO-1.0-Signed-off-by: Artem Balyshev <a.balyshev@samsung.com>