### PR TITLE
[luci/import] Support GRU operation

### DIFF
--- a/compiler/luci/import/include/luci/Import/Nodes.h
+++ b/compiler/luci/import/include/luci/Import/Nodes.h
@@ -57,6 +57,7 @@
 #include "Nodes/CircleGelu.h"
 #include "Nodes/CircleGreater.h"
 #include "Nodes/CircleGreaterEqual.h"
+#include "Nodes/CircleGRU.h"
 #include "Nodes/CircleHardSwish.h"
 #include "Nodes/CircleIf.h"
 #include "Nodes/CircleInstanceNorm.h"

--- a/compiler/luci/import/include/luci/Import/Nodes/CircleGRU.h
+++ b/compiler/luci/import/include/luci/Import/Nodes/CircleGRU.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __LUCI_IMPORT_OP_CIRCLE_GRU_H__
+#define __LUCI_IMPORT_OP_CIRCLE_GRU_H__
+
+#include "luci/Import/GraphBuilder.h"
+
+namespace luci
+{
+
+class CircleGRUGraphBuilder : public GraphBuilder
+{
+public:
+  bool validate(const ValidateArgs &args) const final;
+
+private:
+  CircleNode *build_node(const circle::OperatorT &op, const std::vector<CircleNode *> &inputs,
+                         loco::Graph *graph) const final;
+};
+
+} // namespace luci
+
+#endif // __LUCI_IMPORT_OP_CIRCLE_GRU_H__

--- a/compiler/luci/import/src/GraphBuilderRegistry.cpp
+++ b/compiler/luci/import/src/GraphBuilderRegistry.cpp
@@ -66,6 +66,7 @@ GraphBuilderRegistry::GraphBuilderRegistry()
   CIRCLE_NODE(GELU, CircleGeluGraphBuilder);                                               // 150
   CIRCLE_NODE(GREATER, CircleGreaterGraphBuilder);                                         // 61
   CIRCLE_NODE(GREATER_EQUAL, CircleGreaterEqualGraphBuilder);                              // 62
+  CIRCLE_NODE(GRU, CircleGRUGraphBuilder);                                                 // 251
   CIRCLE_NODE(HARD_SWISH, CircleHardSwishGraphBuilder);                                    // 117
   CIRCLE_NODE(IF, CircleIfGraphBuilder);                                                   // 118
   CIRCLE_NODE(INSTANCE_NORM, CircleInstanceNormGraphBuilder);                              // 254

--- a/compiler/luci/import/src/Nodes/CircleGRU.cpp
+++ b/compiler/luci/import/src/Nodes/CircleGRU.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Import/Nodes/CircleGRU.h"
+
+#include <luci/IR/Nodes/CircleHardSwish.h>
+
+#include <loco.h>
+
+namespace luci
+{
+
+bool CircleGRUGraphBuilder::validate(const ValidateArgs &args) const
+{
+  return GraphBuilder::validate(args, 6);
+}
+
+CircleNode *CircleGRUGraphBuilder::build_node(const circle::OperatorT &,
+                                              const std::vector<CircleNode *> &inputs,
+                                              loco::Graph *graph) const
+{
+  auto *node = graph->nodes()->create<CircleGRU>();
+  node->input(inputs.at(0));
+  node->hidden_hidden(inputs.at(1));
+  node->hidden_hidden_bias(inputs.at(2));
+  node->hidden_input(inputs.at(3));
+  node->hidden_input_bias(inputs.at(4));
+  node->state(inputs.at(5));
+
+  return node;
+}
+
+} // namespace luci


### PR DESCRIPTION
This adds support for GRU operation in luci importer.

for issue: https://github.com/Samsung/ONE/issues/12320
from draft: https://github.com/Samsung/ONE/pull/12319

ONE-DCO-1.0-Signed-off-by: Artem Balyshev <a.balyshev@samsung.com>