### PR TITLE
[circlechef] Support GRU operation

### DIFF
--- a/compiler/circlechef/circle/src/CircleOpChefs.h
+++ b/compiler/circlechef/circle/src/CircleOpChefs.h
@@ -21,6 +21,7 @@
 #include "Op/BatchMatMul.h"
 #include "Op/BCQFullyConnected.h"
 #include "Op/BCQGather.h"
+#include "Op/GRU.h"
 #include "Op/InstanceNorm.h"
 
 #endif // __CIRCLE_OP_CHEFS_H__

--- a/compiler/circlechef/circle/src/CircleOpRegistry.h
+++ b/compiler/circlechef/circle/src/CircleOpRegistry.h
@@ -58,6 +58,7 @@ private:
     REG_TFL_OP(BATCH_MATMUL, CircleOpBatchMatMul);
     REG_TFL_OP(BCQ_FULLY_CONNECTED, CircleOpBCQFullyConnected);
     REG_TFL_OP(BCQ_GATHER, CircleOpBCQGather);
+    REG_TFL_OP(GRU, CircleOpGRU);
     REG_TFL_OP(INSTANCE_NORM, CircleOpInstanceNorm);
 #undef REG_TFL_OP
   }

--- a/compiler/circlechef/circle/src/Op/GRU.cpp
+++ b/compiler/circlechef/circle/src/Op/GRU.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "GRU.h"
+
+#include "Convert.h"
+
+namespace circlechef
+{
+
+void CircleOpGRU::filler(const circle::Operator *op, CircleImport *import,
+                         circlechef::ModelRecipe *model_recipe) const
+{
+  // index 1, 2, 3, 4, 5 maybe constant
+  const std::vector<int32_t> &inputs = as_index_vector(op->inputs());
+  assert(inputs.size() == 6);
+
+  import->set_tensor_filler(inputs[1]); // set gaussian filler
+  import->set_tensor_filler(inputs[2]);
+  import->set_tensor_filler(inputs[3]);
+  import->set_tensor_filler(inputs[4]);
+  import->set_tensor_filler(inputs[5]);
+}
+
+circlechef::Operation *CircleOpGRU::build(const circle::Operator *op, CircleImport *import,
+                                          circlechef::ModelRecipe *model_recipe) const
+{
+  auto op_params = op->builtin_options_as_GRUOptions();
+  assert(op_params != nullptr);
+
+  auto operation = model_recipe->add_operation();
+
+  operation->set_type("GRU");
+
+  auto op_options = operation->mutable_gru_options();
+
+  op_options->set_activation(as_circlechef_activation(op_params->fused_activation_function()));
+  op_options->set_return_sequences(op_params->return_sequences());
+  op_options->set_time_major(op_params->time_major());
+
+  return operation;
+}
+
+} // namespace circlechef

--- a/compiler/circlechef/circle/src/Op/GRU.cpp
+++ b/compiler/circlechef/circle/src/Op/GRU.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/compiler/circlechef/circle/src/Op/GRU.h
+++ b/compiler/circlechef/circle/src/Op/GRU.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __CIRCLE_OP_CIRCLE_GRU_H__
+#define __CIRCLE_OP_CIRCLE_GRU_H__
+
+#include "CircleOpChef.h"
+
+namespace circlechef
+{
+
+/**
+ * @brief circlechef operator builder for GRU
+ */
+class CircleOpGRU : public CircleOpChef
+{
+public:
+  void filler(const circle::Operator *op, CircleImport *import,
+              circlechef::ModelRecipe *model_recipe) const override;
+  circlechef::Operation *build(const circle::Operator *op, CircleImport *import,
+                               circlechef::ModelRecipe *model_recipe) const override;
+};
+
+} // namespace circlechef
+
+#endif // __CIRCLE_OP_CIRCLE_GRU_H__

--- a/compiler/circlechef/circle/src/Op/GRU.h
+++ b/compiler/circlechef/circle/src/Op/GRU.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/compiler/circlechef/core/src/Op/GRU.cpp
+++ b/compiler/circlechef/core/src/Op/GRU.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "GRU.h"
+
+#include "Convert.h"
+
+flatbuffers::Offset<void> GRUChef::value(flatbuffers::FlatBufferBuilder &fbb) const
+{
+  auto &operation = (*_operation);
+
+  assert(operation.has_gru_options());
+  auto circle_activation = as_circle_activation(operation.gru_options().activation());
+  auto return_sequences = operation.gru_options().return_sequences();
+  auto time_major = operation.gru_options().time_major();
+
+  circle::GRUOptionsBuilder options_builder{fbb};
+  options_builder.add_fused_activation_function(circle_activation);
+  options_builder.add_return_sequences(return_sequences);
+  options_builder.add_time_major(time_major);
+
+  return options_builder.Finish().Union();
+}
+
+std::unique_ptr<OpChef> GRUChefFactory::create(const circlechef::Operation *operation) const
+{
+  return std::unique_ptr<OpChef>{new GRUChef{operation}};
+}

--- a/compiler/circlechef/core/src/Op/GRU.cpp
+++ b/compiler/circlechef/core/src/Op/GRU.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/compiler/circlechef/core/src/Op/GRU.h
+++ b/compiler/circlechef/core/src/Op/GRU.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __OP_CIRCLE_GRU_H__
+#define __OP_CIRCLE_GRU_H__
+
+#include "OpChef.h"
+
+class GRUChef final : public OpChef
+{
+public:
+  explicit GRUChef(const circlechef::Operation *operation) : _operation{operation}
+  {
+    // DO NOTHING
+  }
+
+public:
+  circle::BuiltinOperator code(void) const override { return circle::BuiltinOperator_GRU; }
+
+  circle::BuiltinOptions type(void) const override { return circle::BuiltinOptions_GRUOptions; }
+
+  flatbuffers::Offset<void> value(flatbuffers::FlatBufferBuilder &fbb) const override;
+
+private:
+  const circlechef::Operation *_operation;
+};
+
+struct GRUChefFactory final : public OpChefFactory
+{
+  std::unique_ptr<OpChef> create(const circlechef::Operation *operation) const override;
+};
+
+#endif // __OP_CIRCLE_GRU_H__

--- a/compiler/circlechef/core/src/Op/GRU.h
+++ b/compiler/circlechef/core/src/Op/GRU.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/compiler/circlechef/core/src/OpChef.def
+++ b/compiler/circlechef/core/src/OpChef.def
@@ -7,4 +7,5 @@
 OP_CHEF(BatchMatMul, BatchMatMulChefFactory)
 OP_CHEF(BCQFullyConnected, BCQFullyConnectedChefFactory)
 OP_CHEF(BCQGather, BCQGatherChefFactory)
+OP_CHEF(GRU, GRUChefFactory)
 OP_CHEF(InstanceNorm, InstanceNormChefFactory)

--- a/compiler/circlechef/core/src/OpChefs.h
+++ b/compiler/circlechef/core/src/OpChefs.h
@@ -20,6 +20,7 @@
 #include "Op/BatchMatMul.h"
 #include "Op/BCQFullyConnected.h"
 #include "Op/BCQGather.h"
+#include "Op/GRU.h"
 #include "Op/InstanceNorm.h"
 
 #endif // __OP_CHEFS_H__

--- a/compiler/circlechef/proto/circlechef.proto
+++ b/compiler/circlechef/proto/circlechef.proto
@@ -76,6 +76,12 @@ message InstanceNormOptions {
   optional Activation activation = 2 [default = NONE];
 }
 
+message GRUOptions {
+  optional Activation activation = 1 [default = NONE];
+  optional bool return_sequences = 2 [default = false];
+  optional bool time_major = 3 [default = false];
+}
+
 message BCQFullyConnectedOptions {
   optional int32 weights_hidden_size = 1 [default = 0];
   optional Activation activation = 2 [default = NONE];
@@ -97,6 +103,7 @@ message Operation {
   optional InstanceNormOptions instance_norm_options = 101;
   optional BCQFullyConnectedOptions bcq_fully_connected_options = 102;
   optional BCQGatherOptions bcq_gather_options = 103;
+  optional GRUOptions gru_options = 104;
 }
 
 // For additional subgraphs


### PR DESCRIPTION
This adds support for GRU operation in circlechef.

for issue: https://github.com/Samsung/ONE/issues/12320
from draft: https://github.com/Samsung/ONE/pull/12319

ONE-DCO-1.0-Signed-off-by: Artem Balyshev <a.balyshev@samsung.com>