### PR TITLE
[luci/export] Support GRU operation

### DIFF
--- a/compiler/luci/export/src/CircleBuiltinTypesExtractor.h
+++ b/compiler/luci/export/src/CircleBuiltinTypesExtractor.h
@@ -535,6 +535,12 @@ public:
     return circle::CreateBCQGatherOptions(_builder, node->input_hidden_size(), node->axis())
       .Union();
   }
+  flatbuffers::Offset<void> visit(luci::CircleGRU *node)
+  {
+    return circle::CreateGRUOptions(_builder, to_circle_actfunc(node->fusedActivationFunction()),
+                                    node->returnSequences(), node->timeMajor())
+      .Union();
+  }
   flatbuffers::Offset<void> visit(luci::CircleInstanceNorm *node)
   {
     return circle::CreateInstanceNormOptions(_builder, node->epsilon(),

--- a/compiler/luci/export/src/CircleOps.lst
+++ b/compiler/luci/export/src/CircleOps.lst
@@ -138,6 +138,7 @@ CIRCLE_NODE(CircleZerosLike, BuiltinOperator_ZEROS_LIKE, BuiltinOptions_ZerosLik
 // Circle Only
 CIRCLE_NODE(CircleBCQFullyConnected, BuiltinOperator_BCQ_FULLY_CONNECTED, BuiltinOptions_BCQFullyConnectedOptions)
 CIRCLE_NODE(CircleBCQGather, BuiltinOperator_BCQ_GATHER, BuiltinOptions_BCQGatherOptions)
+CIRCLE_NODE(CircleGRU, BuiltinOperator_GRU, BuiltinOptions_GRUOptions)
 CIRCLE_NODE(CircleInstanceNorm, BuiltinOperator_INSTANCE_NORM, BuiltinOptions_InstanceNormOptions)
 // Virtual node(s)
 CIRCLE_VNODE(CircleBidirectionalSequenceLSTMOut)


### PR DESCRIPTION
This adds support for GRU operation in luci export.

for issue: https://github.com/Samsung/ONE/issues/12320
from draft: https://github.com/Samsung/ONE/pull/12319

ONE-DCO-1.0-Signed-off-by: Artem Balyshev <a.balyshev@samsung.com>