### PR TITLE
[tflchef] Support int4 datatype

### DIFF
--- a/compiler/tflchef/core/src/Convert.cpp
+++ b/compiler/tflchef/core/src/Convert.cpp
@@ -79,6 +79,8 @@ tflite::TensorType as_tflite_tensortype(const tflchef::TensorType &value)
       return tflite::TensorType_INT16;
     case tflchef::INT8:
       return tflite::TensorType_INT8;
+    case tflchef::INT4:
+      return tflite::TensorType_INT4;
     default:
       break;
   }

--- a/compiler/tflchef/core/src/DataChef.def
+++ b/compiler/tflchef/core/src/DataChef.def
@@ -25,6 +25,10 @@ DATA_CHEF(INT16, gaussian, GaussianInt16DataChefFactory)
 DATA_CHEF(INT8, gaussian, GaussianInt8DataChefFactory)
 DATA_CHEF(UINT8, gaussian, GaussianUint8DataChefFactory)
 
+// INT4 support only for constant, explicit as int8_t
+DATA_CHEF(INT4, constant, ConstantDataChefFactory<int8_t>)
+DATA_CHEF(INT4, explicit, ExplicitDataChefFactory<int8_t>)
+
 // FLOAT16 support for only gaussian, explicit for now
 DATA_CHEF(FLOAT16, explicit, ExplicitFloat16DataChefFactory)
 DATA_CHEF(FLOAT16, gaussian, GaussianFloat16DataChefFactory)

--- a/compiler/tflchef/core/src/ModelChef.cpp
+++ b/compiler/tflchef/core/src/ModelChef.cpp
@@ -94,6 +94,7 @@ DataChefRegistry &data_chef_registry(const tflchef::TensorType &type)
   static DataChefRegistry s16;
   static DataChefRegistry fp16;
   static DataChefRegistry s8;
+  static DataChefRegistry s4;
 
   switch (type)
   {
@@ -115,6 +116,8 @@ DataChefRegistry &data_chef_registry(const tflchef::TensorType &type)
       return s16;
     case tflchef::INT8:
       return s8;
+    case tflchef::INT4:
+      return s4;
     default:
       break;
   }

--- a/compiler/tflchef/proto/tflchef.proto
+++ b/compiler/tflchef/proto/tflchef.proto
@@ -23,6 +23,7 @@ enum TensorType {
   BOOL = 6;
   INT16 = 7;
   INT8 = 9;
+  INT4 = 10;
 }
 
 enum DimensionType {

--- a/compiler/tflchef/tests/short_int4/test.recipe
+++ b/compiler/tflchef/tests/short_int4/test.recipe
@@ -1,0 +1,44 @@
+operand {
+  name: "ifm"
+  type: INT4
+  shape { dim: 1 dim: 5 dim: 5 dim: 1 }
+}
+operand {
+  name: "ker"
+  type: INT4
+  shape { dim: 1 dim: 3 dim: 3 dim: 1 }
+  filler {
+    tag: "explicit"
+    arg: "-1" arg: "0" arg: "1"
+    arg: "1" arg: "2" arg: "3"
+    arg: "-1" arg: "-2" arg: "-3"
+  }
+}
+operand {
+  name: "bias"
+  type: INT4
+  shape { dim: 1 }
+  filler {
+    tag: "constant"
+    arg: "1"
+  }
+}
+operand {
+  name: "ofm"
+  type: INT4
+  shape { dim: 1 dim: 3 dim: 3 dim: 1 }
+}
+operation {
+  type: "Conv2D"
+  conv2d_options {
+    padding: VALID
+    stride_w: 1
+    stride_h: 1
+  }
+  input: "ifm"
+  input: "ker"
+  input: "bias"
+  output: "ofm"
+}
+input: "ifm"
+output: "ofm"

--- a/compiler/tflchef/tests/short_int4_quant/test.recipe
+++ b/compiler/tflchef/tests/short_int4_quant/test.recipe
@@ -1,0 +1,46 @@
+operand {
+  name: "ifm"
+  type: INT4
+  shape { dim: 1 dim: 5 dim: 5 dim: 1 }
+}
+operand {
+  name: "ker"
+  type: INT4
+  shape { dim: 1 dim: 3 dim: 3 dim: 1 }
+  filler {
+    tag: "explicit"
+    arg: "-1" arg: "0" arg: "1"
+    arg: "1" arg: "2" arg: "3"
+    arg: "-1" arg: "-2" arg: "-3"
+  }
+  quant { min: -0.5 max: 0.5 zero_point: 0 }
+}
+operand {
+  name: "bias"
+  type: INT4
+  shape { dim: 1 }
+  filler {
+    tag: "constant"
+    arg: "1"
+  }
+  quant { min: -0.5 max: 0.5 zero_point: 0 }
+}
+operand {
+  name: "ofm"
+  type: INT4
+  shape { dim: 1 dim: 3 dim: 3 dim: 1 }
+}
+operation {
+  type: "Conv2D"
+  conv2d_options {
+    padding: VALID
+    stride_w: 1
+    stride_h: 1
+  }
+  input: "ifm"
+  input: "ker"
+  input: "bias"
+  output: "ofm"
+}
+input: "ifm"
+output: "ofm"


### PR DESCRIPTION
This will enable to support int4 datatype.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>