### PR TITLE
[tflchef] Revise INT4 TensorType

### DIFF
--- a/compiler/tflchef/proto/tflchef.proto
+++ b/compiler/tflchef/proto/tflchef.proto
@@ -23,7 +23,7 @@ enum TensorType {
   BOOL = 6;
   INT16 = 7;
   INT8 = 9;
-  INT4 = 10;
+  INT4 = 17;
 }
 
 enum DimensionType {


### PR DESCRIPTION
This will revise INT4 TensorType to 17 to follow FB scheme.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>