### PR TITLE
[onert/lib] Remove a sync line from circle_traininfo schema

### DIFF
--- a/runtime/libs/circle-schema/include/circle_traininfo.fbs
+++ b/runtime/libs/circle-schema/include/circle_traininfo.fbs
@@ -1,5 +1,3 @@
-// This file is from https://github.sec.samsung.net/one-project/circle-x/blob/5dd9665b3dab4652a0afed50da86bf6964a41bdd/spec/circle_training.fbs
-
 // Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
 // Copyright 2017 The TensorFlow Authors. All Rights Reserved.
 //


### PR DESCRIPTION
This PR removes a line to sync with inner source.
From now, traininfo schema file will be maintained here, not in inner source.

ONE-DCO-1.0-Signed-off-by: SeungHui Youn <sseung.youn@samsung.com>