### PR TITLE
[luci/lang] Add empty DataTypeHelper.cpp

### DIFF
--- a/compiler/luci/lang/src/DataTypeHelper.cpp
+++ b/compiler/luci/lang/src/DataTypeHelper.cpp
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This is to validate DataTypeHelper.h
+#include "luci/IR/DataTypeHelper.h"


### PR DESCRIPTION
This will add empty DataTypeHelper.cpp to validate header file.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>