### PR TITLE
[circle-eval-diff] Revise to use luci::size

### DIFF
--- a/compiler/circle-eval-diff/src/InputDataLoader.cpp
+++ b/compiler/circle-eval-diff/src/InputDataLoader.cpp
@@ -19,6 +19,7 @@
 #include <dio_hdf5/HDF5Importer.h>
 #include <loco/IR/Graph.h>
 #include <luci/IR/CircleNodes.h>
+#include <luci/IR/DataTypeHelper.h>
 
 #include <cstring>
 #include <dirent.h>
@@ -55,7 +56,7 @@ std::vector<size_t> getEachByteSizeOf(const std::vector<loco::Node *> &nodes)
   for (const auto node : nodes)
   {
     const auto input_node = loco::must_cast<const luci::CircleInput *>(node);
-    const auto dtype_size = loco::size(input_node->dtype());
+    const auto dtype_size = luci::size(input_node->dtype());
     size_t element_size = 1;
 
     for (uint32_t index = 0; index < input_node->rank(); index++)
@@ -76,7 +77,7 @@ size_t getTotalByteSizeOf(const std::vector<loco::Node *> &nodes)
   for (const auto node : nodes)
   {
     const auto input_node = loco::must_cast<const luci::CircleInput *>(node);
-    size_t byte_size = loco::size(input_node->dtype());
+    size_t byte_size = luci::size(input_node->dtype());
 
     for (uint32_t index = 0; index < input_node->rank(); index++)
     {


### PR DESCRIPTION
This will revise to use luci::size for S4/U4.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>