### PR TITLE
[circle-mpqsolver] Revise to use luci::size

### DIFF
--- a/compiler/circle-mpqsolver/src/core/ErrorMetric.cpp
+++ b/compiler/circle-mpqsolver/src/core/ErrorMetric.cpp
@@ -16,6 +16,7 @@
 
 #include "ErrorMetric.h"
 
+#include <luci/IR/DataTypeHelper.h>
 #include <loco/IR/DataType.h>
 #include <loco/IR/DataTypeTraits.h>
 
@@ -45,7 +46,7 @@ float MAEMetric::compute(const WholeOutput &first, const WholeOutput &second) co
       const Buffer &first_elementary = first[sample_index][out_index];
       const Buffer &second_elementary = second[sample_index][out_index];
       assert(first_elementary.size() == second_elementary.size());
-      size_t cur_size = first_elementary.size() / loco::size(loco::DataType::FLOAT32);
+      size_t cur_size = first_elementary.size() / luci::size(loco::DataType::FLOAT32);
 
       double output_error = 0.; // mean error oevr current output
 

--- a/compiler/circle-mpqsolver/src/core/Evaluator.cpp
+++ b/compiler/circle-mpqsolver/src/core/Evaluator.cpp
@@ -18,6 +18,8 @@
 
 #include "core/DataProvider.h"
 
+#include <luci/IR/DataTypeHelper.h>
+
 #include <luci_interpreter/Interpreter.h>
 
 #include <dio_hdf5/HDF5Importer.h>
@@ -33,7 +35,7 @@ using namespace luci;
 
 template <typename NodeT> size_t get_tensor_size(const NodeT *node)
 {
-  uint32_t tensor_size = loco::size(node->dtype());
+  uint32_t tensor_size = luci::size(node->dtype());
   for (uint32_t i = 0; i < node->rank(); ++i)
     tensor_size *= node->dim(i).value();
   return tensor_size;


### PR DESCRIPTION
This will revise to use luci::size for S4/U4.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>