### PR TITLE
[tflchef] Assert filler for sparse with INT4

### DIFF
--- a/compiler/tflchef/core/src/ModelChef.cpp
+++ b/compiler/tflchef/core/src/ModelChef.cpp
@@ -353,6 +353,7 @@ template <typename T> std::map<std::string, int32_t> cook_graph(const T &graph, 
       {
         assert(not operand.has_sparsity());
         assert(operand.has_shape());
+        assert(operand.type() != tflchef::TensorType::INT4);
 
         const int32_t dims_count = dims.size();
         std::vector<int> traversal_order_vec;


### PR DESCRIPTION
This will add assert filler for sparse with INT4 as currently we don't support this.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>