### PR TITLE
[circledump] Add GRUPrinter

### DIFF
--- a/compiler/circledump/src/OpPrinter.cpp
+++ b/compiler/circledump/src/OpPrinter.cpp
@@ -791,6 +791,24 @@ public:
   }
 };
 
+class GRUPrinter : public OpPrinter
+{
+public:
+  void options(const circle::Operator *op, std::ostream &os) const override
+  {
+    if (auto *params = op->builtin_options_as_GRUOptions())
+    {
+      os << "    ";
+      os << "Activation(" << EnumNameActivationFunctionType(params->fused_activation_function())
+         << ") ";
+      os << "return_sequences(" << params->return_sequences() << ") ";
+      os << "time_major(" << params->time_major() << ") ";
+
+      os << std::endl;
+    }
+  }
+};
+
 class InstanceNormPrinter : public OpPrinter
 {
 public:
@@ -891,6 +909,7 @@ OpPrinterRegistry::OpPrinterRegistry()
   // Circle only
   _op_map[circle::BuiltinOperator_BCQ_FULLY_CONNECTED] = make_unique<BCQFullyConnectedPrinter>();
   _op_map[circle::BuiltinOperator_BCQ_GATHER] = make_unique<BCQGatherPrinter>();
+  _op_map[circle::BuiltinOperator_GRU] = make_unique<GRUPrinter>();
   _op_map[circle::BuiltinOperator_INSTANCE_NORM] = make_unique<InstanceNormPrinter>();
 }
 


### PR DESCRIPTION
This pr adds GRUPrinter in circledump.

for issue: https://github.com/Samsung/ONE/issues/12320
from draft: https://github.com/Samsung/ONE/pull/12319

ONE-DCO-1.0-Signed-off-by: Artem Balyshev <a.balyshev@samsung.com>