### PR TITLE
[luci/service] Support GRU operation

### DIFF
--- a/compiler/luci/service/src/CircleCloneNode.h
+++ b/compiler/luci/service/src/CircleCloneNode.h
@@ -257,6 +257,7 @@ public:
   luci::CircleNode *visit(const luci::CircleBCQFullyConnected *) final;
   luci::CircleNode *visit(const luci::CircleBCQGather *) final;
   luci::CircleNode *visit(const luci::CircleInstanceNorm *) final;
+  luci::CircleNode *visit(const luci::CircleGRU *) final;
 
   // NOTE CircleInput and CircleOutput are not handled here as these need
   //      link with graph I/O

--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -1752,6 +1752,7 @@ loco::NodeShape infer_circle_gru(const luci::CircleGRU *node)
   const auto state_shape = luci::shape_get(node->state()).as<loco::TensorShape>();
 
   auto rank = input_shape.rank();
+  assert(rank > 1);
   output_shape.rank(rank);
   for (uint32_t i = 0; i < rank - 1; i++)
   {

--- a/compiler/luci/service/src/CircleShapeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleShapeInferenceRule.cpp
@@ -1744,6 +1744,27 @@ loco::NodeShape infer_bcq_gather(const luci::CircleBCQGather *node)
   return loco::NodeShape{output_shape};
 }
 
+loco::NodeShape infer_circle_gru(const luci::CircleGRU *node)
+{
+  loco::TensorShape output_shape;
+
+  const auto input_shape = luci::shape_get(node->input()).as<loco::TensorShape>();
+  const auto state_shape = luci::shape_get(node->state()).as<loco::TensorShape>();
+
+  auto rank = input_shape.rank();
+  output_shape.rank(rank);
+  for (uint32_t i = 0; i < rank - 1; i++)
+  {
+    output_shape.dim(i) = input_shape.dim(i);
+  }
+  output_shape.dim(rank - 1) = state_shape.dim(1);
+
+  if (not node->returnSequences())
+    output_shape.dim(0) = 1;
+
+  return loco::NodeShape{output_shape};
+}
+
 // Virtual
 loco::NodeShape infer_input(const luci::CircleInput *node)
 {
@@ -2479,6 +2500,8 @@ public:
 
     return loco::NodeShape{input_shape};
   }
+
+  loco::NodeShape visit(const luci::CircleGRU *node) final { return infer_circle_gru(node); }
 
   // Virtual
   loco::NodeShape visit(const luci::CircleInput *node) final { return infer_input(node); }

--- a/compiler/luci/service/src/CircleTypeInferenceRule.cpp
+++ b/compiler/luci/service/src/CircleTypeInferenceRule.cpp
@@ -196,6 +196,8 @@ struct TypeInferenceAlgorithm final : public luci::CircleNodeVisitor<loco::DataT
     return luci::dtype_get(node->features());
   }
 
+  loco::DataType visit(const luci::CircleGRU *node) final { return luci::dtype_get(node->input()); }
+
   loco::DataType visit(const luci::CircleIf *node) final
   {
     // Type of If is not used. Just use input 0

--- a/compiler/luci/service/src/Nodes/CircleGRU.cpp
+++ b/compiler/luci/service/src/Nodes/CircleGRU.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "CircleCloneNode.h"
+
+namespace luci
+{
+
+luci::CircleNode *CloneNode::visit(const luci::CircleGRU *node)
+{
+  if (node->fusedActivationFunction() == luci::FusedActFunc::UNDEFINED)
+    return nullptr;
+
+  auto *cloned = _graph->nodes()->create<luci::CircleGRU>();
+  if (cloned != nullptr)
+  {
+    cloned->fusedActivationFunction(node->fusedActivationFunction());
+    cloned->returnSequences(node->returnSequences());
+    cloned->timeMajor(node->timeMajor());
+  }
+  return cloned;
+}
+
+} // namespace luci

--- a/compiler/luci/service/src/Nodes/CircleGRU.test.cpp
+++ b/compiler/luci/service/src/Nodes/CircleGRU.test.cpp
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Service/CircleNodeClone.h"
+
+#include <luci/IR/CircleNodes.h>
+#include <luci/Service/CircleShapeInference.h>
+#include <luci/Service/CircleTypeInference.h>
+
+#include <loco/IR/TensorShape.h>
+
+#include <gtest/gtest.h>
+
+TEST(ShapeRuleTest, simple_circle_gru)
+{
+  luci::CircleInput input;
+  luci::CircleConst hidden_hidden;
+  luci::CircleConst hidden_hidden_bias;
+  luci::CircleConst hidden_input;
+  luci::CircleConst hidden_input_bias;
+  luci::CircleConst state;
+  luci::CircleGRU circle_gru;
+
+  input.shape({10, 1, 4});
+  input.shape_status(luci::ShapeStatus::VALID);
+
+  hidden_hidden.shape({7, 32});
+  hidden_hidden.shape_status(luci::ShapeStatus::VALID);
+
+  hidden_hidden_bias.shape({7});
+  hidden_hidden_bias.shape_status(luci::ShapeStatus::VALID);
+
+  hidden_input.shape({7, 4});
+  hidden_input.shape_status(luci::ShapeStatus::VALID);
+
+  hidden_input_bias.shape({7});
+  hidden_input_bias.shape_status(luci::ShapeStatus::VALID);
+
+  state.shape({1, 32});
+  state.shape_status(luci::ShapeStatus::VALID);
+
+  circle_gru.input(&input);
+  circle_gru.hidden_hidden(&hidden_hidden);
+  circle_gru.hidden_hidden_bias(&hidden_hidden_bias);
+  circle_gru.hidden_input(&hidden_input);
+  circle_gru.hidden_input_bias(&hidden_input_bias);
+  circle_gru.state(&state);
+
+  loco::TensorShape shape;
+  luci::sinf::Rule shape_inf_rule;
+
+  ASSERT_TRUE(shape_inf_rule.infer(&circle_gru, shape));
+  ASSERT_EQ(3, shape.rank());
+  ASSERT_EQ(1, shape.dim(0).value());
+  ASSERT_EQ(1, shape.dim(1).value());
+  ASSERT_EQ(32, shape.dim(2).value());
+}
+
+TEST(DataTypeRuleTest, simple_circle_gru)
+{
+  luci::CircleInput input;
+  luci::CircleConst hidden_hidden;
+  luci::CircleConst hidden_hidden_bias;
+  luci::CircleConst hidden_input;
+  luci::CircleConst hidden_input_bias;
+  luci::CircleConst state;
+  luci::CircleGRU circle_gru;
+
+  input.dtype(loco::DataType::FLOAT32);
+  hidden_hidden.dtype(loco::DataType::FLOAT32);
+  hidden_hidden_bias.dtype(loco::DataType::FLOAT32);
+  hidden_input.dtype(loco::DataType::FLOAT32);
+  hidden_input_bias.dtype(loco::DataType::FLOAT32);
+  state.dtype(loco::DataType::FLOAT32);
+
+  circle_gru.input(&input);
+  circle_gru.hidden_hidden(&hidden_hidden);
+  circle_gru.hidden_hidden_bias(&hidden_hidden_bias);
+  circle_gru.hidden_input(&hidden_input);
+  circle_gru.hidden_input_bias(&hidden_input_bias);
+  circle_gru.state(&state);
+
+  loco::DataType dtype;
+  luci::tinf::Rule type_inf_rule;
+
+  ASSERT_TRUE(type_inf_rule.infer(&circle_gru, dtype));
+  ASSERT_EQ(loco::DataType::FLOAT32, dtype);
+}
+
+TEST(CloneNodeTest, clone_circel_gru)
+{
+  auto g = loco::make_graph();
+  auto node_circle_gru = g->nodes()->create<luci::CircleGRU>();
+  node_circle_gru->fusedActivationFunction(luci::FusedActFunc::NONE);
+
+  auto gc = loco::make_graph();
+  auto cloned = luci::clone_node(node_circle_gru, gc.get());
+  ASSERT_NE(nullptr, cloned);
+  ASSERT_EQ(gc.get(), cloned->graph());
+
+  auto cloned_circle_gru = dynamic_cast<luci::CircleGRU *>(cloned);
+  ASSERT_NE(nullptr, cloned_circle_gru);
+}


### PR DESCRIPTION
This adds support for GRU operation in luci service.

for issue: https://github.com/Samsung/ONE/issues/12320
from draft: https://github.com/Samsung/ONE/pull/12319

ONE-DCO-1.0-Signed-off-by: Artem Balyshev <a.balyshev@samsung.com>