### PR TITLE
[common-artifacts] Exclude for I4/U4 recipes

### DIFF
--- a/compiler/common-artifacts/exclude.lst
+++ b/compiler/common-artifacts/exclude.lst
@@ -37,6 +37,8 @@ tcgenerate(DepthwiseConv2D_U8_001)  # luci-interpreter doesn't support channel-w
 tcgenerate(ExpandDims_001) # luci-interpreter doesn't support undefined shape
 tcgenerate(ExpandDims_002) # luci-interpreter doesn't support undefined shape
 tcgenerate(FakeQuant_000) # runtime and luci-interpreter doesn't support yet
+tcgenerate(FullyConnected_I4_000)
+tcgenerate(FullyConnected_I4_001)
 tcgenerate(Fill_000)
 tcgenerate(Fill_001)
 tcgenerate(FloorMod_000)
@@ -165,5 +167,7 @@ tcgenerate(ZerosLike_000)
 tcgenerate(BCQFullyConnected_000)
 tcgenerate(BCQFullyConnected_001)
 tcgenerate(BCQGather_000)
+tcgenerate(CircleBatchMatMul_I4_000)
+tcgenerate(CircleBatchMatMul_U4_000)
 tcgenerate(InstanceNorm_000)
 tcgenerate(InstanceNorm_001)


### PR DESCRIPTION
This will revise exclude.lst tcgenerate for INT4/UINT4 recipes.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>