### PR TITLE
[common-artifacts] Exclude GRU operation

### DIFF
--- a/compiler/common-artifacts/exclude.lst
+++ b/compiler/common-artifacts/exclude.lst
@@ -169,5 +169,6 @@ tcgenerate(BCQFullyConnected_001)
 tcgenerate(BCQGather_000)
 tcgenerate(CircleBatchMatMul_I4_000)
 tcgenerate(CircleBatchMatMul_U4_000)
+tcgenerate(GRU_000) # luci-interpreter does not support custom GRU
 tcgenerate(InstanceNorm_000)
 tcgenerate(InstanceNorm_001)


### PR DESCRIPTION
This disables the test of GRU operation until it's fully supported.

for issue: https://github.com/Samsung/ONE/issues/12320

ONE-DCO-1.0-Signed-off-by: Artem Balyshev <a.balyshev@samsung.com>