### PR TITLE
[luci] Remove unused fields

### DIFF
--- a/compiler/luci/pass/src/QuantizeActivation.h
+++ b/compiler/luci/pass/src/QuantizeActivation.h
@@ -27,12 +27,8 @@ namespace luci
  */
 struct QuantizeActivation final : public luci::CircleNodeMutableVisitor<void>
 {
-  QuantizeActivation(loco::DataType input, loco::DataType output)
-    : input_type(input), output_type(output)
-  {
-  }
+  QuantizeActivation(loco::DataType output) : output_type(output) {}
 
-  loco::DataType input_type;
   loco::DataType output_type;
 
   // Quantize each node using recorded min/max
@@ -44,12 +40,8 @@ struct QuantizeActivation final : public luci::CircleNodeMutableVisitor<void>
  */
 struct QuantizeSpecialActivation final : public luci::CircleNodeMutableVisitor<void>
 {
-  QuantizeSpecialActivation(loco::DataType input, loco::DataType output)
-    : input_type(input), output_type(output)
-  {
-  }
+  QuantizeSpecialActivation(loco::DataType output) : output_type(output) {}
 
-  loco::DataType input_type;
   loco::DataType output_type;
 
   void visit(luci::CircleNode *node);

--- a/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
+++ b/compiler/luci/pass/src/QuantizeWithMinMaxPass.cpp
@@ -593,7 +593,7 @@ bool QuantizeWithMinMaxPass::run(loco::Graph *g)
   for (auto node : loco::all_nodes(g))
   {
     auto circle_node = loco::must_cast<luci::CircleNode *>(node);
-    QuantizeActivation qa(_ctx->input_model_dtype, quantize_dtype(circle_node));
+    QuantizeActivation qa(quantize_dtype(circle_node));
     circle_node->accept(&qa);
   }
 
@@ -646,7 +646,7 @@ bool QuantizeWithMinMaxPass::run(loco::Graph *g)
     if (circle_node->quantparam() == nullptr)
       continue;
 
-    QuantizeSpecialActivation qsa(_ctx->input_model_dtype, quantize_dtype(circle_node));
+    QuantizeSpecialActivation qsa(quantize_dtype(circle_node));
     circle_node->accept(&qsa);
   }
 


### PR DESCRIPTION
This removes unused fields in QuantizeActivation classes.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>