### PR TITLE
[luci/pass] Quantize const input of SelectV2

### DIFF
--- a/compiler/luci/pass/src/QuantizeActivation.cpp
+++ b/compiler/luci/pass/src/QuantizeActivation.cpp
@@ -275,6 +275,7 @@ QUANTIZE_TWO_CONST_INPUTS(luci::CircleMinimum, x, y)
 QUANTIZE_TWO_CONST_INPUTS(luci::CircleMul, x, y)
 QUANTIZE_TWO_CONST_INPUTS(luci::CircleNotEqual, x, y)
 QUANTIZE_TWO_CONST_INPUTS(luci::CirclePow, x, y)
+QUANTIZE_TWO_CONST_INPUTS(luci::CircleSelectV2, t, e)
 QUANTIZE_TWO_CONST_INPUTS(luci::CircleSub, x, y)
 
 // AddN has arbitrary number of inputs

--- a/compiler/luci/pass/src/QuantizeActivation.h
+++ b/compiler/luci/pass/src/QuantizeActivation.h
@@ -158,6 +158,7 @@ private:
   void visit(luci::CircleMul *node);
   void visit(luci::CircleNotEqual *node);
   void visit(luci::CirclePow *node);
+  void visit(luci::CircleSelectV2 *node);
   void visit(luci::CircleSub *node);
 
   // AddN has arbitrary number of inputs


### PR DESCRIPTION
This quantizes const input of SelectV2 Op.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/12738
Draft PR: https://github.com/Samsung/ONE/pull/12806