### PR TITLE
[luci/pass] Introduce QuantizeWithPredecessorPass

### DIFF
--- a/compiler/luci/pass/src/QuantizeWithPredecessorPass.cpp
+++ b/compiler/luci/pass/src/QuantizeWithPredecessorPass.cpp
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "QuantizeWithPredecessorPass.h"
+
+#include "QuantizationUtils.h"
+
+#include <luci/IR/CircleNodes.h>
+#include <luci/IR/CircleNodeVisitor.h>
+#include <luci/Log.h>
+
+#include <iostream>
+
+namespace
+{
+
+// Quantize dst node using src node's qparam
+// Return true if dst node is quantized with src
+// Return false otherwise
+bool quantize_with_same_qparam(luci::CircleNode *src, luci::CircleNode *dst)
+{
+  // src node is not quantized. Skip this case.
+  auto src_qparam = src->quantparam();
+  if (not src_qparam)
+    return false;
+
+  auto dst_qparam = dst->quantparam();
+  // dst node is already quantized. Skip this case.
+  if (dst_qparam)
+    return false;
+
+  luci::copy_quantparam(src, dst);
+
+  dst->dtype(src->dtype());
+
+  return true;
+}
+
+//  Visitor to quantize nodes using predecessors qparams
+struct QuantizeWithPredecessor final : public luci::CircleNodeMutableVisitor<bool>
+{
+  QuantizeWithPredecessor() = default;
+
+  bool visit(luci::CircleNode *) { return false; }
+
+  bool visit(luci::CircleReshape *node)
+  {
+    auto input_node = loco::must_cast<luci::CircleNode *>(node->tensor());
+    return quantize_with_same_qparam(input_node, node);
+  }
+
+  bool visit(luci::CircleTranspose *node)
+  {
+    auto input_node = loco::must_cast<luci::CircleNode *>(node->a());
+    return quantize_with_same_qparam(input_node, node);
+  }
+
+  bool visit(luci::CircleStridedSlice *node)
+  {
+    auto input_node = loco::must_cast<luci::CircleNode *>(node->input());
+    return quantize_with_same_qparam(input_node, node);
+  }
+
+  bool visit(luci::CircleGather *node)
+  {
+    auto input_node = loco::must_cast<luci::CircleNode *>(node->params());
+    return quantize_with_same_qparam(input_node, node);
+  }
+
+  bool visit(luci::CircleNeg *node)
+  {
+    auto input_node = loco::must_cast<luci::CircleNode *>(node->x());
+    // Only support S16 for now
+    if (input_node->dtype() != loco::DataType::S16)
+      return false;
+
+    return quantize_with_same_qparam(input_node, node);
+  }
+
+  bool visit(luci::CircleConcatenation *node)
+  {
+    const auto num_inputs = node->numValues();
+
+    for (uint32_t i = 0; i < num_inputs; i++)
+    {
+      auto input = loco::must_cast<luci::CircleNode *>(node->values(i));
+      // Only support S16 for now
+      if (input->dtype() != loco::DataType::S16)
+        return false;
+
+      if (input->quantparam() == nullptr)
+        return false;
+
+      if (input->quantparam()->scale.size() != 1)
+        return false;
+    }
+
+    luci::CircleNode *max_scale_node = nullptr;
+    float max_scale = 0.0;
+    for (uint32_t i = 0; i < num_inputs; i++)
+    {
+      auto input = loco::must_cast<luci::CircleNode *>(node->values(i));
+      auto qparam = input->quantparam();
+      auto scale = qparam->scale.at(0);
+      if (max_scale < scale)
+      {
+        max_scale = scale;
+        max_scale_node = input;
+      }
+    }
+
+    assert(max_scale_node);
+
+    return quantize_with_same_qparam(max_scale_node, node);
+  }
+};
+
+} // namespace
+
+namespace luci
+{
+
+bool QuantizeWithPredecessorPass::run(loco::Graph *g)
+{
+  bool changed = false;
+
+  LOGGER(l);
+
+  for (auto node : loco::active_nodes(loco::output_nodes(g)))
+  {
+    auto circle_node = loco::must_cast<luci::CircleNode *>(node);
+    INFO(l) << "QuantizeWithPredecessorPass visit node: " << circle_node->name() << std::endl;
+
+    QuantizeWithPredecessor qwp;
+    if (circle_node->accept(&qwp))
+    {
+      changed = true;
+    }
+  }
+
+  return changed;
+}
+
+} // namespace luci

--- a/compiler/luci/pass/src/QuantizeWithPredecessorPass.h
+++ b/compiler/luci/pass/src/QuantizeWithPredecessorPass.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __LUCI_QUANTIZE_WITH_PREDECESSOR_PASS_H__
+#define __LUCI_QUANTIZE_WITH_PREDECESSOR_PASS_H__
+
+#include <logo/Pass.h>
+
+namespace luci
+{
+
+/**
+ * @brief  Class to quantize nodes using their predecessors' qparam
+ *
+ */
+struct QuantizeWithPredecessorPass final : public logo::Pass
+{
+  const char *name(void) const final { return "luci::QuantizeWithPredecessor"; }
+
+  bool run(loco::Graph *g) final;
+};
+
+} // namespace luci
+
+#endif // __LUCI_QUANTIZE_WITH_PREDECESSOR_PASS_H__

--- a/compiler/luci/pass/src/QuantizeWithPredecessorPass.test.cpp
+++ b/compiler/luci/pass/src/QuantizeWithPredecessorPass.test.cpp
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "QuantizeWithPredecessorPass.h"
+
+#include <luci/IR/CircleNodes.h>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+
+void addQuantParam(luci::CircleNode *node, const std::vector<float> &scale,
+                   const std::vector<int64_t> &zp)
+{
+  assert(node->quantparam() == nullptr);
+
+  auto quantparam = std::make_unique<luci::CircleQuantParam>();
+  quantparam->scale = scale;
+  quantparam->zerop = zp;
+  node->quantparam(std::move(quantparam));
+}
+
+/**
+ *  Simple graph for test
+ *
+ *  BEFORE
+ *
+ *        [Conv] (int16)
+ *           |
+ *       [Reshape] (fp32)
+ *
+ *  AFTER
+ *
+ *        [Conv] (int16)
+ *           |
+ *       [Reshape] (int16)
+ *
+ */
+class ConvReshapeGraph
+{
+public:
+  ConvReshapeGraph()
+  {
+    input = g.nodes()->create<luci::CircleInput>();
+    conv = g.nodes()->create<luci::CircleConv2D>();
+    reshape = g.nodes()->create<luci::CircleReshape>();
+    output = g.nodes()->create<luci::CircleOutput>();
+
+    auto graph_input = g.inputs()->create();
+    input->index(graph_input->index());
+    auto graph_output = g.outputs()->create();
+    output->index(graph_output->index());
+
+    conv->dtype(loco::DataType::S16);
+    reshape->dtype(loco::DataType::FLOAT32);
+
+    addQuantParam(conv, {1.0}, {0});
+
+    conv->input(input);
+    reshape->tensor(conv);
+    output->from(reshape);
+  }
+
+public:
+  loco::Graph g;
+  luci::CircleInput *input = nullptr;
+  luci::CircleConv2D *conv = nullptr;
+  luci::CircleReshape *reshape = nullptr;
+  luci::CircleOutput *output = nullptr;
+};
+
+} // namespace
+
+TEST(QuantizeWithPredecessor, reshape)
+{
+  ConvReshapeGraph g;
+
+  luci::QuantizeWithPredecessorPass pass;
+  while (pass.run(&g.g))
+    ;
+
+  EXPECT_NE(nullptr, g.reshape->quantparam());
+  EXPECT_FLOAT_EQ(1.0, g.reshape->quantparam()->scale[0]);
+  EXPECT_EQ(0, g.reshape->quantparam()->zerop[0]);
+}
+
+TEST(QuantizeWithPredecessor, reshape_NEG)
+{
+  ConvReshapeGraph g;
+  g.conv->quantparam(nullptr);
+
+  luci::QuantizeWithPredecessorPass pass;
+  EXPECT_FALSE(pass.run(&g.g));
+}


### PR DESCRIPTION
This introduces a pass to quantize with predecessors.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/12738
Draft PR: https://github.com/Samsung/ONE/pull/12806