### PR TITLE
[luci/pass] Introduce QuantizeOnnxFakeQuantModelPass

### DIFF
--- a/compiler/luci/pass/include/luci/Pass/QuantizeOnnxFakeQuantModelPass.h
+++ b/compiler/luci/pass/include/luci/Pass/QuantizeOnnxFakeQuantModelPass.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __LUCI_QUANTIZE_ONNX_FAKE_QUANT_MODEL_PASS_H__
+#define __LUCI_QUANTIZE_ONNX_FAKE_QUANT_MODEL_PASS_H__
+
+#include <loco.h>
+
+#include <logo/Pass.h>
+
+#include <memory>
+
+namespace luci
+{
+
+/**
+ * @brief Pass to create a quantized graph from a graph fake-quantized on onnx
+ */
+class QuantizeOnnxFakeQuantModelPass : public logo::Pass
+{
+public:
+  struct Context
+  {
+    loco::DataType default_activation_dtype = loco::DataType::Unknown;
+  };
+
+public:
+  QuantizeOnnxFakeQuantModelPass(std::unique_ptr<Context> &&ctx) : _ctx{std::move(ctx)}
+  {
+    assert(_ctx);                           // FIX_CALLER_UNLESS
+    assert(_ctx->default_activation_dtype); // FIX_CALLER_UNLESS
+  }
+
+  virtual const char *name(void) const { return "luci::QuantizeOnnxFakeQuantModelPass"; }
+
+public:
+  bool run(loco::Graph *graph);
+
+private:
+  std::unique_ptr<Context> _ctx;
+};
+
+} // namespace luci
+
+#endif //__LUCI_QUANTIZE_ONNX_FAKE_QUANT_MODEL_PASS_H__

--- a/compiler/luci/pass/src/QuantizeOnnxFakeQuantModelPass.cpp
+++ b/compiler/luci/pass/src/QuantizeOnnxFakeQuantModelPass.cpp
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Pass/QuantizeOnnxFakeQuantModelPass.h"
+#include "QuantizeOnnxQDQPass.h"
+#include "QuantizeOnnxDequantizeLinearPass.h"
+#include "QuantizeWithPredecessorPass.h"
+#include "QuantizeActivation.h"
+#include "QuantizationUtils.h"
+
+#include <luci/IR/CircleNodes.h>
+#include <luci/Service/Nodes/CircleConst.h>
+#include <luci/Log.h>
+
+namespace luci
+{
+
+/**
+ * How QuantizeOnnxFakeQuantModel works?
+ *
+ * 1. Activation is quantized as below.
+ *
+ * Before
+ *
+ * [node(fp32)] -> [OnnxQuantizeLinear] -> [OnnxDequantizeLinear]
+ *
+ * After
+ *
+ * [node(q)]
+ *
+ *
+ * 2. Weight(constant) are quantized as below.
+ *
+ * Before
+ *
+ * [Const(q w/o qparam)] -> [OnnxDequantizeLinear]
+ *
+ * After
+ *
+ * [Const(q)]
+ *
+ * 3. Quantize constant activations
+ *
+ * 4. Quantize with predecessors' qparams
+ *
+ * 5. Update qparams of special operators
+ */
+bool QuantizeOnnxFakeQuantModelPass::run(loco::Graph *g)
+{
+  LOGGER(l);
+  INFO(l) << "QuantizeOnnxFakeQuantModelPass Start" << std::endl;
+
+  // Quantize Onnx QuantizeLinear-DequantizeLinear pattern
+  {
+    QuantizeOnnxQDQPass pass;
+    pass.run(g);
+  }
+
+  // Quantize Onnx const-DequantizeLinear pattern
+  {
+    QuantizeOnnxDequantizeLinearPass pass;
+    pass.run(g);
+  }
+
+  // Quantize const input activation
+  for (auto node : loco::active_nodes(loco::output_nodes(g)))
+  {
+    auto circle_node = loco::must_cast<luci::CircleNode *>(node);
+
+    QuantizeConstInputActivation qcia(_ctx->default_activation_dtype);
+    circle_node->accept(&qcia);
+  }
+
+  // Quantize nodes using their predecessors' qparams
+  {
+    QuantizeWithPredecessorPass pass;
+    pass.run(g);
+  }
+
+  // Update qparam of output of special Ops
+  for (auto node : loco::active_nodes(loco::output_nodes(g)))
+  {
+    auto circle_node = loco::must_cast<luci::CircleNode *>(node);
+
+    if (is_quantized(circle_node))
+    {
+      QuantizeSpecialActivation qsa(circle_node->dtype());
+      circle_node->accept(&qsa);
+    }
+  }
+
+  // Update output dtype
+  auto graph_outputs = g->outputs();
+  for (auto node : loco::output_nodes(g))
+  {
+    auto circle_node = loco::must_cast<luci::CircleOutput *>(node);
+    auto from = loco::must_cast<luci::CircleNode *>(circle_node->from());
+    circle_node->dtype(from->dtype());
+
+    auto graph_output = graph_outputs->at(circle_node->index());
+    graph_output->dtype(circle_node->dtype());
+  }
+
+  INFO(l) << "QuantizeOnnxFakeQuantModelPass End" << std::endl;
+  return false; // one time run
+}
+
+} // namespace luci

--- a/compiler/luci/pass/src/QuantizeOnnxFakeQuantModelPass.test.cpp
+++ b/compiler/luci/pass/src/QuantizeOnnxFakeQuantModelPass.test.cpp
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Pass/QuantizeOnnxFakeQuantModelPass.h"
+#include "PassTestGraphs.h"
+
+#include <gtest/gtest.h>
+
+namespace
+{
+
+using namespace luci::test;
+
+class S16OnnxFakeQuantGraphlet
+{
+public:
+  S16OnnxFakeQuantGraphlet() = default;
+
+  void init(loco::Graph *g)
+  {
+    _quantize = g->nodes()->create<luci::CircleCustom>(3, 1);
+    _quantize_out = g->nodes()->create<luci::CircleCustomOut>();
+    _dequantize = g->nodes()->create<luci::CircleCustom>(3, 1);
+    _dequantize_out = g->nodes()->create<luci::CircleCustomOut>();
+    _scale = g->nodes()->create<luci::CircleConst>();
+    _zerop = g->nodes()->create<luci::CircleConst>();
+
+    _quantize->dtype(loco::DataType::S16);
+    _quantize_out->dtype(loco::DataType::S16);
+    _dequantize->dtype(loco::DataType::FLOAT32);
+    _dequantize_out->dtype(loco::DataType::FLOAT32);
+    _scale->dtype(loco::DataType::FLOAT32);
+    _zerop->dtype(loco::DataType::S16);
+
+    _scale->shape({1});
+    _zerop->shape({1});
+
+    _scale->size<loco::DataType::FLOAT32>(1);
+    _scale->at<loco::DataType::FLOAT32>(0) = 5.0;
+
+    _zerop->size<loco::DataType::S16>(1);
+    _zerop->at<loco::DataType::S16>(0) = 0;
+
+    _quantize->custom_code("ONNXQuantizeLinear");
+    _quantize_out->index(0);
+
+    _dequantize->custom_code("ONNXDequantizeLinear");
+    _dequantize_out->index(0);
+
+    _scale->name("scale");
+    _zerop->name("zerop");
+    _quantize->name("quantize");
+    _quantize_out->name("quantize_out");
+    _dequantize->name("dequantize");
+    _dequantize_out->name("dequantize_out");
+  }
+
+protected:
+  luci::CircleCustom *_quantize = nullptr;
+  luci::CircleCustomOut *_quantize_out = nullptr;
+  luci::CircleCustom *_dequantize = nullptr;
+  luci::CircleCustomOut *_dequantize_out = nullptr;
+  luci::CircleConst *_scale = nullptr;
+  luci::CircleConst *_zerop = nullptr;
+};
+
+class S16QuantizeOnnxFakeQuantModelTestGraph : public TestIOGraph, public S16OnnxFakeQuantGraphlet
+{
+public:
+  void init(void)
+  {
+    TestIOGraph::init({2, 2, 2}, {2, 2, 2});
+    S16OnnxFakeQuantGraphlet::init(g());
+
+    _quantize->inputs(0, input());
+    _quantize->inputs(1, _scale);
+    _quantize->inputs(2, _zerop);
+    _quantize_out->input(_quantize);
+    _dequantize->inputs(0, _quantize_out);
+    _dequantize->inputs(1, _scale);
+    _dequantize->inputs(2, _zerop);
+    _dequantize_out->input(_dequantize);
+
+    output()->from(_dequantize_out);
+  }
+};
+
+} // namespace
+
+TEST(QuantizeOnnxFakeQuantModelTest, s16_quantize_onnx_qdq)
+{
+  S16QuantizeOnnxFakeQuantModelTestGraph g;
+
+  auto ctx = std::make_unique<luci::QuantizeOnnxFakeQuantModelPass::Context>();
+  {
+    ctx->default_activation_dtype = loco::DataType::S16;
+  }
+
+  luci::QuantizeOnnxFakeQuantModelPass pass(std::move(ctx));
+
+  g.init();
+
+  // Always return false
+  EXPECT_FALSE(pass.run(g.g()));
+
+  EXPECT_EQ(loco::DataType::S16, g.input()->dtype());
+}


### PR DESCRIPTION
This introduces a pass to quantize onnx-fake-quantized model.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/12738
Draft PR: https://github.com/Samsung/ONE/pull/12806