### PR TITLE
Add missing python file.

### DIFF
--- a/compiler/one-cmds/CMakeLists.txt
+++ b/compiler/one-cmds/CMakeLists.txt
@@ -125,6 +125,7 @@ set(ONE_PYTHON_FILES backends.py
                      export_constant.py
                      make_cmd.py
                      CfgRunner.py
+                     Command.py
                      OptionBuilder.py
                      TopologicalSortHelper.py
                      WorkflowRunner.py


### PR DESCRIPTION
- Add `Command.py` of onelib to cmake.