### PR TITLE
[luci] Enable INT4 weight quantization in circle-quantizer

### DIFF
--- a/compiler/luci/pass/src/CircleQuantizer.cpp
+++ b/compiler/luci/pass/src/CircleQuantizer.cpp
@@ -627,7 +627,7 @@ void CircleQuantizer::quantize(loco::Graph *g) const
   if (_options->query(Options::Algorithm::QuantizeWeights))
   {
     static const std::vector<std::string> qw_supported_input_model_dtype{"float32"};
-    static const std::vector<std::string> qw_supported_output_model_dtype{"int8", "int16"};
+    static const std::vector<std::string> qw_supported_output_model_dtype{"int4", "int8", "int16"};
     static const std::vector<std::string> qw_supported_granularity{"channel"};
 
     auto input_model_dtype =


### PR DESCRIPTION
This commit enables INT4 weight quantization in circle-quantizer.

ONE-DCO-1.0-Signed-off-by: Vyacheslav Bazhenov <slavikmipt@gmail.com>