### PR TITLE
[common-artifacts] Exclude FullyConnected_I4_002

### DIFF
--- a/compiler/common-artifacts/exclude.lst
+++ b/compiler/common-artifacts/exclude.lst
@@ -39,6 +39,7 @@ tcgenerate(ExpandDims_002) # luci-interpreter doesn't support undefined shape
 tcgenerate(FakeQuant_000) # runtime and luci-interpreter doesn't support yet
 tcgenerate(FullyConnected_I4_000)
 tcgenerate(FullyConnected_I4_001)
+tcgenerate(FullyConnected_I4_002)
 tcgenerate(Fill_000)
 tcgenerate(Fill_001)
 tcgenerate(FloorMod_000)


### PR DESCRIPTION
This will add exclude tcgenerate for FullyConnected_I4_002.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>