### PR TITLE
[luci-ref-value-py-test] Enable circle test with FC_U4

### DIFF
--- a/compiler/luci-ref-value-py-test/CMakeLists.txt
+++ b/compiler/luci-ref-value-py-test/CMakeLists.txt
@@ -8,11 +8,15 @@ set(TEST_LIST_FILE "test.lst")
 nncc_find_resource(TensorFlowLiteRecipes)
 set(TFLITE_RECIPE_REPO "${TensorFlowLiteRecipes_DIR}")
 
+nncc_find_resource(CircleRecipes)
+set(CIRCLE_RECIPE_REPO "${CircleRecipes_DIR}")
+
 get_target_property(ARTIFACTS_BIN_PATH testDataGenerator BINARY_DIR)
 add_test(NAME luci_ref_value_py_test
     COMMAND ${VIRTUALENV}/bin/python -m pytest -sv test_luci_eval.py
             --test_list ${TEST_LIST_FILE}
             --tflrecipe ${TFLITE_RECIPE_REPO}
+            --circlerecipe ${CIRCLE_RECIPE_REPO}
             --artifacts ${ARTIFACTS_BIN_PATH}
             --binary ${CMAKE_CURRENT_BINARY_DIR}
             --luci_eval_driver $<TARGET_FILE:luci_eval_driver>

--- a/compiler/luci-ref-value-py-test/test.lst
+++ b/compiler/luci-ref-value-py-test/test.lst
@@ -1,2 +1,5 @@
 # test with given reference data
 eval(FullyConnected_I4_002 0.1 0.1)
+
+# circle recipes
+eval(CircleFullyConnected_U4_002 0.1 0.1)


### PR DESCRIPTION
This will enable circle model test with CircleFullyConnected_U4_002.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>