### PR TITLE
[infra] Introduce nncc install command

### DIFF
--- a/infra/nncc/command/install
+++ b/infra/nncc/command/install
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+import "build.configuration"
+
+BUILD_WORKSPACE_PATH="${NNCC_PROJECT_PATH}/${BUILD_WORKSPACE_RPATH}"
+
+if [[ ! -d "${BUILD_WORKSPACE_PATH}" ]]; then
+  echo "'${BUILD_WORKSPACE_RPATH}' does not exist. Please run 'configure' first"
+  exit 255
+fi
+
+# Check version
+# TODO Remove version check when we does not support 18.04 anymore
+cmp=3.15.0
+ver=$(cmake --version | head -1 | cut -f3 -d" ")
+
+mapfile -t sorted < <(printf "%s\n" "$ver" "$cmp" | sort -V)
+
+if [[ ${sorted[0]} == "$ver" ]]; then
+  echo "This command requires cmake version $cmp or upper."
+  exit 255
+fi
+
+cmake --install ${BUILD_WORKSPACE_PATH} "$@"


### PR DESCRIPTION
This commit introduces nncc install command.
It simplifies nncc install path setting on local environment by using "--prefix" option.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>