### PR TITLE
[luci] Copy qparam to circle output

### DIFF
--- a/compiler/luci/pass/src/CopyQuantParamPass.cpp
+++ b/compiler/luci/pass/src/CopyQuantParamPass.cpp
@@ -71,6 +71,12 @@ bool CopyQuantParamPass::run(loco::Graph *g)
 
     copy_quantparam(nodes.src, nodes.dst);
 
+    if (auto output = dynamic_cast<luci::CircleOutput *>(nodes.dst))
+    {
+      auto from_node = loco::must_cast<luci::CircleNode *>(output->from());
+      copy_quantparam(output, from_node);
+    }
+
     INFO(l) << "Quantparam of " << src << " is copied to " << dst << std::endl;
   }
 


### PR DESCRIPTION
This supports copying qparam to circle output.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>