### PR TITLE
[onert-micro] Remove unused include in MaxPool2D kernel

### DIFF
--- a/onert-micro/onert-micro/include/pal/common/PALMaxPool2DCommon.h
+++ b/onert-micro/onert-micro/include/pal/common/PALMaxPool2DCommon.h
@@ -18,7 +18,6 @@
 #ifndef ONERT_MICRO_EXECUTE_PAL_MAX_POOL_2D_COMMON_H
 #define ONERT_MICRO_EXECUTE_PAL_MAX_POOL_2D_COMMON_H
 
-#include "Params.h"
 #include "PALUtils.h"
 
 #include "core/OMKernelData.h"


### PR DESCRIPTION
This commit removes unused include in MaxPool2D kernel.

ONE-DCO-1.0-Signed-off-by: Vyacheslav Bazhenov <slavikmipt@gmail.com>
