### PR TITLE
[onert] Handle batch input shape inference on Reshape operator

### DIFF
--- a/runtime/onert/core/include/util/ShapeInference.h
+++ b/runtime/onert/core/include/util/ShapeInference.h
@@ -87,8 +87,8 @@ ir::Shape inferPoolShape(const ir::Shape &in_shape, const ir::operation::Pool2D:
 
 template <typename T> ir::Shape inferRangeShape(T start_val, T limit_val, T delta_val);
 
-ir::Shape inferReshapeShape(const int32_t *shape_buf, const int32_t shape_num_elements,
-                            const size_t total_num_elements);
+ir::Shape inferReshapeShape(const ir::Shape &input_shape, const int32_t *shape_buf,
+                            const int32_t shape_num_elements);
 
 ir::Shape inferReduceShape(const ir::Shape &input_shape, const std::vector<int> &axes,
                            bool keep_dims);

--- a/runtime/onert/core/src/compiler/StaticShapeInferer.cc
+++ b/runtime/onert/core/src/compiler/StaticShapeInferer.cc
@@ -978,8 +978,8 @@ void StaticShapeInferer::visit(const ir::operation::Reshape &op)
       const auto *shape_buf = reinterpret_cast<const int32_t *>(shape.data()->base());
       assert(shape_buf);
 
-      ir::Shape new_shape = shape_inference::inferReshapeShape(
-        shape_buf, shape.shape().num_elements(), input.shape().num_elements());
+      ir::Shape new_shape =
+        shape_inference::inferReshapeShape(input.shape(), shape_buf, shape.shape().num_elements());
 
       // if shape is from Const, TFLC put the shape of output into tensor
       if (new_shape != output.shape())
@@ -1000,7 +1000,7 @@ void StaticShapeInferer::visit(const ir::operation::Reshape &op)
     // Let's check the new_shape option
     auto shape = op.param().new_shape;
     ir::Shape new_shape =
-      shape_inference::inferReshapeShape(shape.data(), shape.size(), input.shape().num_elements());
+      shape_inference::inferReshapeShape(input.shape(), shape.data(), shape.size());
 
     if (new_shape != output.shape())
     {

--- a/runtime/onert/core/src/exec/DynamicShapeInferer.cc
+++ b/runtime/onert/core/src/exec/DynamicShapeInferer.cc
@@ -837,8 +837,8 @@ void DynamicShapeInferer::visit(const ir::operation::Reshape &op)
     int32_t *new_shape_buf = reinterpret_cast<int32_t *>(new_shape->buffer());
     assert(new_shape_buf);
 
-    auto output_shape = shape_inference::inferReshapeShape(
-      new_shape_buf, new_shape->getShape().num_elements(), input->getShape().num_elements());
+    auto output_shape = shape_inference::inferReshapeShape(input->getShape(), new_shape_buf,
+                                                           new_shape->getShape().num_elements());
 
     // if shape is changed, change output shape and reallocate output tensor memory
     if (output_shape != output->getShape() || output->buffer() == nullptr)
@@ -853,8 +853,8 @@ void DynamicShapeInferer::visit(const ir::operation::Reshape &op)
   {
     // Let's check the new_shape option
     auto shape = op.param().new_shape;
-    auto output_shape = shape_inference::inferReshapeShape(shape.data(), shape.size(),
-                                                           input->getShape().num_elements());
+    auto output_shape =
+      shape_inference::inferReshapeShape(input->getShape(), shape.data(), shape.size());
 
     // if shape is changed, change output shape and reallocate output tensor memory
     if (output_shape != output->getShape() || output->buffer() == nullptr)


### PR DESCRIPTION
This commit fixes to handle batch input shape inference on Reshape operator.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: #12859