### PR TITLE
[onert] Update I/O info handling

### DIFF
--- a/runtime/onert/api/nnapi/wrapper/ANeuralNetworksExecution.cc
+++ b/runtime/onert/api/nnapi/wrapper/ANeuralNetworksExecution.cc
@@ -136,18 +136,10 @@ bool ANeuralNetworksExecution::setInput(uint32_t index, const ANeuralNetworksOpe
   try
   {
     onert::ir::IOIndex input_index{index};
-    const auto operand_index = getInputOperandIndex(index);
+    const auto shape =
+      (type != nullptr) ? NNAPIConvert::getShape(type) : _execution->getInputShape(input_index);
 
-    const auto &type_info = _execution->primary_subgraph().operands().at(operand_index).typeInfo();
-    const auto shape = (type != nullptr)
-                         ? NNAPIConvert::getShape(type)
-                         : _execution->primary_subgraph().operands().at(operand_index).shape();
-
-    // NOTE The nnapi does not provide setting io_layout and not support changing layout. In other
-    // words, we can assume that io_layout from nnapi always is the same as layout of the used
-    // model.
-    // TODO Set layout of model
-    _execution->setInput(input_index, type_info, shape, buffer, length, onert::ir::Layout::NHWC);
+    _execution->setInput(input_index, shape, buffer, length);
   }
   catch (const std::exception &e)
   {
@@ -169,11 +161,8 @@ bool ANeuralNetworksExecution::setOptionalInput(uint32_t index,
   try
   {
     onert::ir::IOIndex input_index{index};
-    const auto operand_index = getInputOperandIndex(index);
-
-    const auto shape = (type != nullptr)
-                         ? NNAPIConvert::getShape(type)
-                         : _execution->primary_subgraph().operands().at(operand_index).shape();
+    const auto shape =
+      (type != nullptr) ? NNAPIConvert::getShape(type) : _execution->getInputShape(input_index);
 
     // ANeuralNetworksExecution::setInput() uses only shape information
     ANeuralNetworksOperandType optional_input_type;
@@ -203,18 +192,10 @@ bool ANeuralNetworksExecution::setOutput(uint32_t index, const ANeuralNetworksOp
   try
   {
     onert::ir::IOIndex output_index{index};
-    const auto operand_index = getOutputOperandIndex(index);
+    const auto shape =
+      (type != nullptr) ? NNAPIConvert::getShape(type) : _execution->getOutputShape(output_index);
 
-    const auto &type_info = _execution->primary_subgraph().operands().at(operand_index).typeInfo();
-    const auto shape = (type != nullptr)
-                         ? NNAPIConvert::getShape(type)
-                         : _execution->primary_subgraph().operands().at(operand_index).shape();
-
-    // NOTE The nnapi does not provide setting io_layout and not support changing layout. In other
-    // words, we can assume that io_layout from nnapi always is the same as layout of the used
-    // model.
-    // TODO Set layout of model
-    _execution->setOutput(output_index, type_info, shape, buffer, length, onert::ir::Layout::NHWC);
+    _execution->setOutput(output_index, shape, buffer, length);
   }
   catch (const std::exception &e)
   {

--- a/runtime/onert/core/include/exec/Execution.h
+++ b/runtime/onert/core/include/exec/Execution.h
@@ -68,44 +68,35 @@ public:
    * @param[in] index   Input index
    * @param[in] buffer  Input data's buffer pointer
    * @param[in] length  Input data's length
-   * @param[in] layout  Input data's data format
    */
-  void setInput(const ir::IOIndex &index, const void *buffer, size_t length,
-                ir::Layout layout = ir::Layout::NHWC);
+  void setInput(const ir::IOIndex &index, const void *buffer, size_t length);
 
   /**
    * @brief     Set input data's information, especially to specify unknown dimensions on model
    * build time.
    * @param[in] index   Input index
-   * @param[in] type    Input data's type info
    * @param[in] shape   Input data's shape
    * @param[in] buffer  Input data's buffer pointer
    * @param[in] length  Input data's length
-   * @param[in] layout  Input data's data format
    */
-  void setInput(const ir::IOIndex &index, const ir::TypeInfo &type, const ir::Shape &shape,
-                const void *buffer, size_t length, ir::Layout layout = ir::Layout::NHWC);
+  void setInput(const ir::IOIndex &index, const ir::Shape &shape, const void *buffer,
+                size_t length);
   /**
    * @brief     Set output data's information
    * @param[in] index   Output index
    * @param[in] buffer  Output data's buffer pointer
    * @param[in] length  Output data's length
-   * @param[in] layout  Output data's data format
    */
-  void setOutput(const ir::IOIndex &index, void *buffer, size_t length,
-                 ir::Layout layout = ir::Layout::NHWC);
+  void setOutput(const ir::IOIndex &index, void *buffer, size_t length);
   /**
    * @brief     Set output data's information, especially to specify unknown dimensions on model
    * build time.
    * @param[in] index   Output index
-   * @param[in] type    Output data's type info
    * @param[in] shape   Output data's shape
    * @param[in] buffer  Output data's buffer pointer
    * @param[in] length  Output data's length
-   * @param[in] layout  Output data's data format
    */
-  void setOutput(const ir::IOIndex &index, const ir::TypeInfo &type, const ir::Shape &shape,
-                 void *buffer, size_t length, ir::Layout layout = ir::Layout::NHWC);
+  void setOutput(const ir::IOIndex &index, const ir::Shape &shape, void *buffer, size_t length);
   /**
    * @brief     Set input data's data format
    * @param[in] index   Input index
@@ -118,6 +109,18 @@ public:
    * @param[in] layout  Output data's data format
    */
   void setOutputLayout(const ir::IOIndex &index, ir::Layout layout);
+  /**
+   * @brief     Set input type information
+   * @param[in] index     Input index
+   * @param[in] typeInfo  Input type information
+   */
+  void setInputType(const ir::IOIndex &index, const ir::TypeInfo &typeInfo);
+  /**
+   * @brief     Set output type information
+   * @param[in] index     Output index
+   * @param[in] typeInfo  Output type information
+   */
+  void setOutputType(const ir::IOIndex &index, const ir::TypeInfo &typeInfo);
   /**
    * @brief  Execution
    * @note   It should be called after setting input and output buffer

--- a/runtime/onert/core/include/exec/IODescription.h
+++ b/runtime/onert/core/include/exec/IODescription.h
@@ -31,30 +31,28 @@ namespace exec
 
 struct InputDesc
 {
-  const ir::OperandInfo info;
+  ir::OperandInfo info;
   const void *buffer;
-  const size_t size;
-  const ir::Layout layout;
+  size_t size;
+  ir::Layout layout;
 
   InputDesc(void) = delete;
-  InputDesc(const ir::OperandInfo &info, const void *buffer, const size_t size, ir::Layout layout)
-    : info(info), buffer(buffer), size(size), layout(layout)
+  InputDesc(const ir::OperandInfo &info)
+    : info(info), buffer(nullptr), size(0), layout(ir::Layout::NHWC)
   {
   }
 };
 
 struct OutputDesc
 {
-  // not `const` because shape should be modified after execution in case when output is
-  // a dynamic tensor
   ir::OperandInfo info;
   void *buffer;
-  const size_t size;
-  const ir::Layout layout;
+  size_t size;
+  ir::Layout layout;
 
   OutputDesc(void) = delete;
-  OutputDesc(const ir::OperandInfo &info, void *buffer, const size_t size, ir::Layout layout)
-    : info(info), buffer(buffer), size(size), layout(layout)
+  OutputDesc(const ir::OperandInfo &info)
+    : info(info), buffer(nullptr), size(0), layout(ir::Layout::NHWC)
   {
   }
 };
@@ -63,8 +61,7 @@ struct IODescription
 {
   std::vector<std::unique_ptr<InputDesc>> inputs;
   std::vector<std::unique_ptr<OutputDesc>> outputs;
-  // Contains shape of input set by nnfw_set_input_tensorinfo(..)
-  std::unordered_map<ir::IOIndex, ir::Shape> dynamic_input_shapes;
+  bool updated; // Require shape inference and buffer size calculation
 };
 
 } // namespace exec

--- a/runtime/onert/core/include/ir/OperandInfo.h
+++ b/runtime/onert/core/include/ir/OperandInfo.h
@@ -108,6 +108,11 @@ public:
    */
   const TypeInfo &typeInfo() const { return _typeInfo; }
   /**
+   * @brief     Set type information
+   * @param[in] typeInfo Type information
+   */
+  void typeInfo(const ir::TypeInfo &typeInfo) { _typeInfo = typeInfo; }
+  /**
    * @brief   Set tensor data type
    */
   void type(const DataType type) { _typeInfo.type(type); }

--- a/runtime/onert/core/src/exec/Execution.test.cc
+++ b/runtime/onert/core/src/exec/Execution.test.cc
@@ -616,12 +616,15 @@ TEST(ExecInstance, multi_model_dequant_input_quant_output)
   onert::exec::Execution execution{executors};
 
   onert::ir::TypeInfo type_info{onert::ir::DataType::QUANT_UINT8_ASYMM, scale, zero_point};
-  execution.setInput(input1, type_info, execution.getInputShape(input1),
-                     reinterpret_cast<const void *>(input1_buffer), 4, onert::ir::Layout::NHWC);
-  execution.setInput(input2, type_info, execution.getInputShape(input2),
-                     reinterpret_cast<const void *>(input2_buffer), 4, onert::ir::Layout::NHWC);
-  execution.setOutput(output, type_info, execution.getOutputShape(output),
-                      reinterpret_cast<void *>(output_buffer), 4, onert::ir::Layout::NHWC);
+  execution.setInputType(input1, type_info);
+  execution.setInput(input1, execution.getInputShape(input1),
+                     reinterpret_cast<const void *>(input1_buffer), 4);
+  execution.setInputType(input2, type_info);
+  execution.setInput(input2, execution.getInputShape(input2),
+                     reinterpret_cast<const void *>(input2_buffer), 4);
+  execution.setOutputType(output, type_info);
+  execution.setOutput(output, execution.getOutputShape(output),
+                      reinterpret_cast<void *>(output_buffer), 4);
   execution.execute();
 
   for (auto i = 0; i < 4; i++)


### PR DESCRIPTION
This commit updates Execution and IODescription
- Remove input shape map in IODesciption (use InputDesc vector and updated field)
- Remove layout setting in Execution's setInput and setOutput
- Remove type setting in Execution's setInput and setOutput
- Introduce new method to set input/output type in Execution

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>