### PR TITLE
[luci] Support Squeeze in QuantizeWithPredecessorPass

### DIFF
--- a/compiler/luci/pass/src/QuantizeWithPredecessorPass.cpp
+++ b/compiler/luci/pass/src/QuantizeWithPredecessorPass.cpp
@@ -74,6 +74,12 @@ struct QuantizeWithPredecessor final : public luci::CircleNodeMutableVisitor<boo
     return quantize_with_same_qparam(input_node, node);
   }
 
+  bool visit(luci::CircleSqueeze *node)
+  {
+    auto input_node = loco::must_cast<luci::CircleNode *>(node->input());
+    return quantize_with_same_qparam(input_node, node);
+  }
+
   bool visit(luci::CircleGather *node)
   {
     auto input_node = loco::must_cast<luci::CircleNode *>(node->params());


### PR DESCRIPTION
This supports Squeeze Op in QuantizeWithPredecessorPass.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/12834
Draft PR: https://github.com/Samsung/ONE/pull/12865