### PR TITLE
[luci] Insert Quantize Op to quantize mixed-precision onnx

### DIFF
--- a/compiler/luci/pass/src/InsertQuantizeOpOnDTypeMismatch.cpp
+++ b/compiler/luci/pass/src/InsertQuantizeOpOnDTypeMismatch.cpp
@@ -1,0 +1,259 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "InsertQuantizeOpOnDTypeMismatch.h"
+#include "QuantizationUtils.h"
+
+#include <luci/Profile/CircleNodeOrigin.h>
+#include <luci/Log.h>
+
+#include <limits> // std::numeric_limits
+
+using namespace luci;
+
+namespace
+{
+
+// Update u8 node to i16
+// Qparam of i16 is inferred from the qparam of u8
+void update_u8_to_i16(luci::CircleNode *node)
+{
+  assert(node->dtype() == loco::DataType::U8); // FIX_CALLER_UNLESS
+
+  node->dtype(loco::DataType::S16);
+
+  auto qparam = node->quantparam();
+  assert(qparam);
+  assert(qparam->scale.size() == 1);
+  assert(qparam->zerop.size() == 1);
+
+  auto u8_scale = qparam->scale[0];
+  auto u8_zerop = qparam->zerop[0];
+
+  auto min = u8_scale * (-u8_zerop);
+  auto max = u8_scale * (255 - u8_zerop);
+
+  float s16_scale{0};
+  int64_t s16_zerop{0};
+  float nudged_min{0};
+  float nudged_max{0};
+
+  compute_sym_scale(min, max, s16_scale, nudged_min, nudged_max);
+
+  auto quantparam = std::make_unique<CircleQuantParam>();
+  quantparam->scale.push_back(s16_scale);
+  quantparam->zerop.push_back(s16_zerop);
+
+  node->quantparam(std::move(quantparam));
+}
+
+// Update i16 node to u8 node
+// Qparam of u8 is inferred from the qparam of i16
+void update_i16_to_u8(luci::CircleNode *node)
+{
+  assert(node->dtype() == loco::DataType::S16); // FIX_CALLER_UNLESS
+
+  node->dtype(loco::DataType::U8);
+
+  auto qparam = node->quantparam();
+  assert(qparam);
+  assert(qparam->scale.size() == 1);
+  assert(qparam->zerop.size() == 1);
+
+  auto s16_scale = qparam->scale[0];
+  assert(qparam->zerop[0] == 0);
+
+  auto max = s16_scale * std::numeric_limits<int16_t>::max();
+  auto min = -max;
+
+  float u8_scale{0};
+  int64_t u8_zerop{0};
+  float nudged_min{0};
+  float nudged_max{0};
+
+  compute_asym_scale_zp(min, max, u8_scale, u8_zerop, nudged_min, nudged_max);
+
+  auto quantparam = std::make_unique<CircleQuantParam>();
+  quantparam->scale.push_back(u8_scale);
+  quantparam->zerop.push_back(u8_zerop);
+
+  node->quantparam(std::move(quantparam));
+}
+
+// Create a Quantize Op which has the same
+// dtype, shape, and qparam with node
+luci::CircleQuantize *create_quantize_op(luci::CircleNode *node)
+{
+  auto quantize = node->graph()->nodes()->create<CircleQuantize>();
+  quantize->name(node->name() + "_Quantize");
+  quantize->dtype(node->dtype());
+  quantize->rank(node->rank());
+  for (uint32_t i = 0; i < node->rank(); i++)
+    quantize->dim(i).set(node->dim(i).value());
+
+  quantize->shape_status(luci::ShapeStatus::VALID);
+
+  assert(node->quantparam()); // FIX_CALLER_UNLESS
+  copy_quantparam(node, quantize);
+
+  luci::add_origin(quantize, luci::get_origin(node));
+
+  return quantize;
+}
+
+} // namespace
+
+namespace luci
+{
+
+void InsertQuantizeOpOnDTypeMismatch::visit(luci::CircleFullyConnected *node)
+{
+  auto input = loco::must_cast<luci::CircleNode *>(node->input());
+
+  // Input dtype == Output dtype. No problem
+  if (input->dtype() == node->dtype())
+    return;
+
+  // Skip if node has bias
+  if (dynamic_cast<luci::CircleOutputExclude *>(node->bias()) == nullptr)
+    return;
+
+  if (node->fusedActivationFunction() != luci::FusedActFunc::NONE)
+    return;
+
+  // Only cares quantized case
+  if (not is_quantized(input))
+    return;
+
+  if (not is_quantized(node))
+    return;
+
+  // Let's support limited case
+  // TODO Extend this to another dtype
+  if (input->dtype() != loco::DataType::U8)
+    return;
+
+  if (node->dtype() != loco::DataType::S16)
+    return;
+
+  // Create Quantize Op
+  auto quant_op = create_quantize_op(node);
+
+  // Insert Quantize Op after node
+  loco::replace(node).with(quant_op);
+  quant_op->input(node);
+
+  // Update node's dtype and qparam from i16 to u8
+  // NOTE This would severely degrade accuracy. It is
+  // important to mitigate this accuracy drop in backend.
+  update_i16_to_u8(node);
+}
+
+void InsertQuantizeOpOnDTypeMismatch::visit(luci::CircleMul *node)
+{
+  auto x = loco::must_cast<luci::CircleNode *>(node->x());
+  auto y = loco::must_cast<luci::CircleNode *>(node->y());
+
+  assert(x->dtype() == y->dtype()); // FIX_CALLER_UNLESS
+
+  // Ignore invalid dtype
+  if (x->dtype() != y->dtype())
+    return;
+
+  if (node->fusedActivationFunction() != luci::FusedActFunc::NONE)
+    return;
+
+  // Input dtype == Output dtype. No problem
+  if (x->dtype() == node->dtype())
+    return;
+
+  // Only cares quantized case
+  if (not is_quantized(x))
+    return;
+
+  if (not is_quantized(y))
+    return;
+
+  if (not is_quantized(node))
+    return;
+
+  // Let's support limited case
+  // TODO Extend this to another dtype
+  if (x->dtype() != loco::DataType::S16)
+    return;
+
+  if (node->dtype() != loco::DataType::U8)
+    return;
+
+  // Create Quantize Op
+  auto quant_op = create_quantize_op(node);
+
+  // Insert Quantize Op after node
+  loco::replace(node).with(quant_op);
+  quant_op->input(node);
+
+  // Update node's dtype and qparam from u8 to i16
+  update_u8_to_i16(node);
+}
+
+void InsertQuantizeOpOnDTypeMismatch::visit(luci::CircleBatchMatMul *node)
+{
+  auto x = loco::must_cast<luci::CircleNode *>(node->x());
+  auto y = loco::must_cast<luci::CircleNode *>(node->y());
+
+  assert(x->dtype() == y->dtype()); // FIX_CALLER_UNLESS
+
+  // Ignore invalid dtype
+  if (x->dtype() != y->dtype())
+    return;
+
+  if (node->adj_x() or node->adj_y())
+    return;
+
+  // Input dtype == Output dtype. No problem
+  if (x->dtype() == node->dtype())
+    return;
+
+  // Only cares quantized case
+  if (not is_quantized(x))
+    return;
+
+  if (not is_quantized(y))
+    return;
+
+  if (not is_quantized(node))
+    return;
+
+  // Let's support limited case
+  // TODO Extend this to another dtype
+  if (x->dtype() != loco::DataType::S16)
+    return;
+
+  if (node->dtype() != loco::DataType::U8)
+    return;
+
+  // Create Quantize Op
+  auto quant_op = create_quantize_op(node);
+
+  // Insert Quantize Op after node
+  loco::replace(node).with(quant_op);
+  quant_op->input(node);
+
+  // Update node's dtype and qparam from i16 to u8
+  update_u8_to_i16(node);
+}
+
+} // namespace luci

--- a/compiler/luci/pass/src/InsertQuantizeOpOnDTypeMismatch.h
+++ b/compiler/luci/pass/src/InsertQuantizeOpOnDTypeMismatch.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __LUCI_INSERT_QUANTIZE_OP_ON_DTYPE_MISMATCH_H__
+#define __LUCI_INSERT_QUANTIZE_OP_ON_DTYPE_MISMATCH_H__
+
+#include <luci/IR/CircleNodeVisitor.h>
+
+namespace luci
+{
+
+struct InsertQuantizeOpOnDTypeMismatch final : public luci::CircleNodeMutableVisitor<void>
+{
+  InsertQuantizeOpOnDTypeMismatch() = default;
+
+private:
+  void visit(luci::CircleNode *) {}
+
+  void visit(luci::CircleFullyConnected *node);
+  void visit(luci::CircleMul *node);
+  void visit(luci::CircleBatchMatMul *node);
+
+  // TODO Support more operators
+};
+
+} // namespace luci
+
+#endif // __LUCI_INSERT_QUANTIZE_OP_ON_DTYPE_MISMATCH_H__

--- a/compiler/luci/pass/src/InsertQuantizeOpOnDTypeMismatch.test.cpp
+++ b/compiler/luci/pass/src/InsertQuantizeOpOnDTypeMismatch.test.cpp
@@ -129,3 +129,20 @@ TEST(InsertQuantizeOpOnDTypeMismatchTest, mul)
   // Mul's dtype is changed from U8 to S16
   EXPECT_EQ(loco::DataType::S16, g.mul()->dtype());
 }
+
+TEST(InsertQuantizeOpOnDTypeMismatchTest, mul_dtype_match_NEG)
+{
+  DtypeMisMatchMulTestGraph g;
+
+  luci::InsertQuantizeOpOnDTypeMismatch visitor;
+
+  g.init();
+
+  auto node = g.mul();
+  node->dtype(loco::DataType::S16);
+
+  node->accept(&visitor);
+
+  // Quantize Op is not created
+  EXPECT_EQ(nullptr, dynamic_cast<luci::CircleQuantize *>(g.output()->from()));
+}

--- a/compiler/luci/pass/src/InsertQuantizeOpOnDTypeMismatch.test.cpp
+++ b/compiler/luci/pass/src/InsertQuantizeOpOnDTypeMismatch.test.cpp
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "InsertQuantizeOpOnDTypeMismatch.h"
+#include "PassTestGraphs.h"
+
+#include <gtest/gtest.h>
+
+namespace
+{
+
+using namespace luci::test;
+
+std::unique_ptr<luci::CircleQuantParam> gen_qparam(float s, int64_t zp)
+{
+  auto qparam = std::make_unique<luci::CircleQuantParam>();
+  {
+    qparam->scale.push_back(s);
+    qparam->zerop.push_back(zp);
+  }
+
+  return std::move(qparam);
+}
+
+/**
+ *  Mul graph for test
+ *
+ * BEFORE
+ *
+ *   [Input(s16)]    [Const(s16)]
+ *             \      /
+ *            [Mul(u8)]
+ *                |
+ *           [Output(u8)]
+ *
+ * AFTER
+ *
+ *   [Input(s16)]    [Const(s16)]
+ *             \      /
+ *            [Mul(s16)]
+ *                |
+ *          [Quantize(u8)]
+ *                |
+ *           [Output(u8)]
+ */
+class MulGraphlet
+{
+public:
+  MulGraphlet() = default;
+
+  void init(loco::Graph *g)
+  {
+    _mul = g->nodes()->create<luci::CircleMul>();
+    _const = g->nodes()->create<luci::CircleConst>();
+
+    _mul->dtype(loco::DataType::U8);
+    _const->dtype(loco::DataType::S16);
+
+    _mul->quantparam(std::move(gen_qparam(1, 0)));
+    _const->quantparam(std::move(gen_qparam(1, 0)));
+
+    _mul->shape({2, 2, 2});
+
+    _mul->fusedActivationFunction(luci::FusedActFunc::NONE);
+
+    _mul->name("mul");
+    _const->name("const");
+  }
+
+public:
+  luci::CircleMul *mul(void) { return _mul; }
+
+protected:
+  luci::CircleMul *_mul = nullptr;
+  luci::CircleConst *_const = nullptr;
+};
+
+class DtypeMisMatchMulTestGraph : public TestIOGraph, public MulGraphlet
+{
+public:
+  void init(void)
+  {
+    TestIOGraph::init({2, 2, 2}, {2, 2, 2});
+
+    input()->dtype(loco::DataType::S16);
+    output()->dtype(loco::DataType::U8);
+
+    input()->quantparam(std::move(gen_qparam(1, 0)));
+    output()->quantparam(std::move(gen_qparam(1, 0)));
+
+    MulGraphlet::init(g());
+
+    _mul->x(input());
+    _mul->y(_const);
+
+    output()->from(_mul);
+  }
+};
+
+} // namespace
+
+TEST(InsertQuantizeOpOnDTypeMismatchTest, mul)
+{
+  DtypeMisMatchMulTestGraph g;
+
+  luci::InsertQuantizeOpOnDTypeMismatch visitor;
+
+  g.init();
+
+  auto node = g.mul();
+  node->accept(&visitor);
+
+  // Quantize Op is created
+  EXPECT_NE(nullptr, dynamic_cast<luci::CircleQuantize *>(g.output()->from()));
+
+  // Mul's dtype is changed from U8 to S16
+  EXPECT_EQ(loco::DataType::S16, g.mul()->dtype());
+}


### PR DESCRIPTION
This inserts Quantize Op to quantize mixed-precision onnx model.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/12834
Draft PR: https://github.com/Samsung/ONE/pull/12865