### PR TITLE
[one-cmds] Support inline comment in the cfg file

### DIFF
--- a/compiler/one-cmds/one-build
+++ b/compiler/one-cmds/one-build
@@ -20,7 +20,6 @@
 # limitations under the License.
 
 import argparse
-import configparser
 import os
 import sys
 
@@ -89,8 +88,7 @@ def _get_driver_name(driver_name):
 
 
 def parse_cfg(args):
-    config = configparser.ConfigParser()
-    config.optionxform = str
+    config = oneutils.get_config_parser()
     parsed = config.read(os.path.expanduser(getattr(args, 'config')))
     if not parsed:
         raise FileNotFoundError('Not found given configuration file')
@@ -122,8 +120,7 @@ def _verify_cfg(driver_list, config):
 # verify given optimization option file
 def _verify_opt(args):
     if oneutils.is_valid_attr(args, 'O'):
-        config = configparser.ConfigParser()
-        config.optionxform = str
+        config = oneutils.get_config_parser()
         opt_name_path_dic = dict(
             zip(oneutils.get_optimization_list(get_name=True),
                 oneutils.get_optimization_list()))

--- a/compiler/one-cmds/onecc
+++ b/compiler/one-cmds/onecc
@@ -20,7 +20,6 @@
 # limitations under the License.
 
 import argparse
-import configparser
 import os
 import subprocess
 import sys
@@ -121,8 +120,7 @@ def _verify_backend_args(parser, args):
 
     This verification logic comes from each drivers' codes.
     """
-    cfgparser = configparser.ConfigParser()
-    cfgparser.optionxform = str
+    cfgparser = oneutils.get_config_parser()
     cfgparser.read(args.config)
 
     for driver in ['one-profile', 'one-codegen']:

--- a/compiler/one-cmds/onelib/CfgRunner.py
+++ b/compiler/one-cmds/onelib/CfgRunner.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import configparser
 import os
 import warnings
 
@@ -34,9 +33,7 @@ class CfgRunner:
     def __init__(self, path):
         self.path = path
         self.optparser = None
-        self.cfgparser = configparser.ConfigParser()
-        # make option names case sensitive
-        self.cfgparser.optionxform = str
+        self.cfgparser = oneutils.get_config_parser()
         parsed = self.cfgparser.read(os.path.expanduser(path))
         if not parsed:
             raise FileNotFoundError('Not found given configuration file')
@@ -74,9 +71,7 @@ class CfgRunner:
                                   and self.cfgparser.getboolean('one-build', driver))
 
     def add_opt(self, opt):
-        self.optparser = configparser.ConfigParser()
-        # make option names case sensitive
-        self.optparser.optionxform = str
+        self.optparser = oneutils.get_config_parser()
         opt_book = dict(
             zip(oneutils.get_optimization_list(get_name=True),
                 oneutils.get_optimization_list()))

--- a/compiler/one-cmds/onelib/utils.py
+++ b/compiler/one-cmds/onelib/utils.py
@@ -84,6 +84,18 @@ def is_valid_attr(args, attr):
     return hasattr(args, attr) and getattr(args, attr)
 
 
+def get_config_parser() -> configparser.ConfigParser:
+    """
+    Initialize configparser and set default option
+
+    This funciton has been introduced for all the one-cmds tools having same parsing option.
+    """
+    parser = configparser.ConfigParser(inline_comment_prefixes=('#', ';'))
+    parser.optionxform = str
+
+    return parser
+
+
 def parse_cfg(config_path: Union[str, None], section_to_parse: str, args):
     """
     parse configuration file and store the information to args
@@ -95,8 +107,7 @@ def parse_cfg(config_path: Union[str, None], section_to_parse: str, args):
     if config_path is None:
         return
 
-    parser = configparser.ConfigParser()
-    parser.optionxform = str
+    parser = get_config_parser()
     parser.read(config_path)
 
     if not parser.has_section(section_to_parse):


### PR DESCRIPTION
This commit supports inline comments in the cfg file.

Related: #12884
ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>