### PR TITLE
[one-cmds] Add test that checks if writing comments are enabled

### DIFF
--- a/compiler/one-cmds/tests/onecc_059.cfg
+++ b/compiler/one-cmds/tests/onecc_059.cfg
@@ -1,0 +1,23 @@
+[onecc]
+one-import-tf=True
+one-import-tflite=False
+one-import-bcq=False
+one-optimize=True
+one-quantize=False
+one-pack=False
+one-codegen=False
+
+[one-import-tf]
+input_path=inception_v3.pb # comment test
+output_path=inception_v3.onecc_059.circle #comment test
+input_arrays=input ; comment test
+input_shapes=1,299,299,3 ;comment test
+output_arrays=InceptionV3/Predictions/Reshape_1     ## test
+converter_version=v2       ## test
+# comment test
+[one-optimize]
+input_path=inception_v3.onecc_059.circle
+output_path=inception_v3.onecc_059.opt.circle
+
+# Note. there must be one or more space between the value and the comment
+# e.g. input_path=inception_v3.pb#THIS IS NOT ALLOWED

--- a/compiler/one-cmds/tests/onecc_059.test
+++ b/compiler/one-cmds/tests/onecc_059.test
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# test if writing comments are allowed in the configuration file.
+
+filename_ext="$(basename -- $0)"
+filename="${filename_ext%.*}"
+
+trap_err_onexit()
+{
+  echo "${filename_ext} FAILED"
+  exit 255
+}
+
+trap trap_err_onexit ERR
+
+configfile="onecc_059.cfg"
+outputfile="inception_v3.onecc_059.opt.circle"
+
+rm -f ${filename}.log
+rm -f ${outputfile}
+
+# run test
+onecc -C ${configfile} > ${filename}.log 2>&1
+
+if [[ ! -s "${outputfile}" ]]; then
+  trap_err_onexit
+fi
+
+echo "${filename_ext} SUCCESS"


### PR DESCRIPTION
This commit adds a test that checks if writing comments inside the cfg file are allowed.

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>