### PR TITLE
[onert] Remove apply_tensorinfo

### DIFF
--- a/runtime/onert/api/nnfw/include/nnfw.h
+++ b/runtime/onert/api/nnfw/include/nnfw.h
@@ -123,6 +123,8 @@ typedef enum
   NNFW_STATUS_OUT_OF_MEMORY = 4,
   /** When it was given an insufficient output buffer */
   NNFW_STATUS_INSUFFICIENT_OUTPUT_SIZE = 5,
+  /** When API is deprecated */
+  NNFW_STATUS_DEPRECATED_API = 6,
 } NNFW_STATUS;
 
 /**

--- a/runtime/onert/api/nnfw/src/nnfw_api.cc
+++ b/runtime/onert/api/nnfw/src/nnfw_api.cc
@@ -268,11 +268,9 @@ NNFW_STATUS nnfw_register_custom_op_info(nnfw_session *session, const char *id,
   return session->register_custom_operation(id, info->eval_function);
 }
 
-NNFW_STATUS nnfw_apply_tensorinfo(nnfw_session *session, uint32_t index,
-                                  nnfw_tensorinfo tensor_info)
+NNFW_STATUS nnfw_apply_tensorinfo(nnfw_session *, uint32_t, nnfw_tensorinfo)
 {
-  NNFW_RETURN_ERROR_IF_NULL(session);
-  return session->apply_tensorinfo(index, tensor_info);
+  return NNFW_STATUS_DEPRECATED_API;
 }
 
 NNFW_STATUS nnfw_set_input_tensorinfo(nnfw_session *session, uint32_t index,

--- a/runtime/onert/api/nnfw/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/nnfw/src/nnfw_api_internal.cc
@@ -729,7 +729,7 @@ NNFW_STATUS nnfw_session::set_output_layout(uint32_t index, NNFW_LAYOUT layout)
   return NNFW_STATUS_NO_ERROR;
 }
 
-NNFW_STATUS nnfw_session::apply_tensorinfo(uint32_t index, nnfw_tensorinfo ti)
+NNFW_STATUS nnfw_session::set_input_tensorinfo(uint32_t index, const nnfw_tensorinfo *ti)
 {
   // sanity check
   {
@@ -740,25 +740,32 @@ NNFW_STATUS nnfw_session::apply_tensorinfo(uint32_t index, nnfw_tensorinfo ti)
       return NNFW_STATUS_INVALID_STATE;
     }
 
-    if (ti.rank <= 0 || ti.rank > NNFW_MAX_RANK)
+    if (ti == nullptr)
     {
-      std::cerr << "unsupported rank: " << ti.rank << std::endl;
+      std::cerr << "Error during nnfw_session::set_input_tensorinfo : tensorinfo is null"
+                << std::endl;
+      return NNFW_STATUS_UNEXPECTED_NULL;
+    }
+
+    if (ti->rank <= 0 || ti->rank > NNFW_MAX_RANK)
+    {
+      std::cerr << "unsupported rank: " << ti->rank << std::endl;
       return NNFW_STATUS_ERROR;
     }
 
-    for (int32_t i = 0; i < ti.rank; ++i)
+    for (int32_t i = 0; i < ti->rank; ++i)
     {
-      if (ti.dims[i] <= 0)
+      if (ti->dims[i] <= 0)
       {
-        std::cerr << "dim must be positive integer but was " << ti.dims[i] << std::endl;
+        std::cerr << "dim must be positive integer but was " << ti->dims[i] << std::endl;
         return NNFW_STATUS_ERROR;
       }
     }
   }
 
-  onert::ir::Shape new_shape(ti.rank);
-  for (int32_t i = 0; i < ti.rank; i++)
-    new_shape.dim(i) = ti.dims[i];
+  onert::ir::Shape new_shape(ti->rank);
+  for (int32_t i = 0; i < ti->rank; i++)
+    new_shape.dim(i) = ti->dims[i];
 
   if (!isStatePreparedOrFinishedRun())
   {
@@ -770,12 +777,6 @@ NNFW_STATUS nnfw_session::apply_tensorinfo(uint32_t index, nnfw_tensorinfo ti)
     _execution->changeInputShape(onert::ir::IOIndex(index), new_shape);
 
   return NNFW_STATUS_NO_ERROR;
-}
-
-NNFW_STATUS nnfw_session::set_input_tensorinfo(uint32_t index, const nnfw_tensorinfo *ti)
-{
-  nnfw_tensorinfo ti_copy = *ti;
-  return apply_tensorinfo(index, ti_copy);
 }
 
 NNFW_STATUS nnfw_session::input_tensorinfo(uint32_t index, nnfw_tensorinfo *ti)

--- a/runtime/onert/api/nnfw/src/nnfw_api_internal.h
+++ b/runtime/onert/api/nnfw/src/nnfw_api_internal.h
@@ -138,7 +138,6 @@ public:
   NNFW_STATUS set_input_layout(uint32_t index, NNFW_LAYOUT layout);
   NNFW_STATUS set_output_layout(uint32_t index, NNFW_LAYOUT layout);
 
-  NNFW_STATUS apply_tensorinfo(uint32_t index, nnfw_tensorinfo ti); // Will be deprecated
   NNFW_STATUS set_input_tensorinfo(uint32_t index, const nnfw_tensorinfo *ti);
 
   NNFW_STATUS input_tensorinfo(uint32_t index, nnfw_tensorinfo *ti);


### PR DESCRIPTION
This commit removes deprecated API implementation: apply_tensorinfo. 
If nnfw_apply_tensorinfo is called, it will return NNFW_STATUS_DEPRECATED_API status value.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>