### PR TITLE
[one-cmds] Update onnx/onnxruntime versions

### DIFF
--- a/compiler/one-cmds/one-prepare-venv.aarch64
+++ b/compiler/one-cmds/one-prepare-venv.aarch64
@@ -34,8 +34,8 @@ fi
 # - https://github.com/onnx/onnx-tensorflow/blob/master/Versioning.md
 
 VER_TENSORFLOW=2.12.1
-VER_ONNX=1.14.0
-VER_ONNXRUNTIME=1.15.0
+VER_ONNX=1.16.0
+VER_ONNXRUNTIME=1.17.3
 VER_ONNX_TF=1.10.0
 VER_PYDOT=1.4.2
 

--- a/compiler/one-cmds/one-prepare-venv.u1804
+++ b/compiler/one-cmds/one-prepare-venv.u1804
@@ -34,8 +34,8 @@ fi
 # - https://github.com/onnx/onnx-tensorflow/blob/master/Versioning.md
 
 VER_TENSORFLOW=2.12.1
-VER_ONNX=1.14.0
-VER_ONNXRUNTIME=1.15.0
+VER_ONNX=1.16.0
+VER_ONNXRUNTIME=1.17.3
 VER_ONNX_TF=1.10.0
 VER_PYDOT=1.4.2
 


### PR DESCRIPTION
This will update onnx/onnxruntime versions for U18.04 and AArch64 one-prepare-venv files.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>