### PR TITLE
[infra] Disable onert luci build

### DIFF
--- a/Makefile.template
+++ b/Makefile.template
@@ -110,7 +110,8 @@ export NNCC_WORKSPACE=$(NNCC_FOLDER)
 ###
 ### Default target
 ###
-all: prepare-buildtool prepare-nncc configure build install
+#all: prepare-buildtool prepare-nncc configure build install
+all: prepare-buildtool configure build install
 
 ###
 ### Command (build step)

--- a/packaging/nnfw.spec
+++ b/packaging/nnfw.spec
@@ -35,7 +35,7 @@ Source3021: FLATBUFFERS-2.0.tar.gz
 %{!?build_type:     %define build_type      Release}
 %{!?npud_build:     %define npud_build      0}
 %{!?trix_support:   %define trix_support    1}
-%{!?odc_build:      %define odc_build       1}
+%{!?odc_build:      %define odc_build       0}
 %{!?coverage_build: %define coverage_build  0}
 %{!?test_build:     %define test_build      0}
 %{!?extra_option:   %define extra_option    %{nil}}


### PR DESCRIPTION
This commit disable luci build on onert build process temporarily for flatbuffer migration.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>