### PR TITLE
[mio-circle08] Use FlatBuffer 23.5.26

### DIFF
--- a/compiler/mio-circle08/CMakeLists.txt
+++ b/compiler/mio-circle08/CMakeLists.txt
@@ -1,7 +1,7 @@
-nnas_find_package(FlatBuffers EXACT 2.0 QUIET)
+nnas_find_package(FlatBuffers EXACT 23.5.26 QUIET)
 
 if(NOT FlatBuffers_FOUND)
-  message(STATUS "mio-circle08 skip: FlatBuffers 2.0 NOT FOUND")
+  message(STATUS "mio-circle08 skip: FlatBuffers 23.5.26 NOT FOUND")
   return()
 endif(NOT FlatBuffers_FOUND)
 


### PR DESCRIPTION
This commit updates mio-circle08 to use FlatBuffers 23.5.26.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>