### PR TITLE
[pics] Use FlatBuffer 23.5.26

### DIFF
--- a/compiler/pics/CMakeLists.txt
+++ b/compiler/pics/CMakeLists.txt
@@ -1,4 +1,4 @@
-nnas_find_package(FlatBuffers EXACT 2.0 QUIET)
+nnas_find_package(FlatBuffers EXACT 23.5.26 QUIET)
 if(NOT FlatBuffers_FOUND)
   message(STATUS "Configure pics: FAILED (missing FlatBuffers)")
   return()


### PR DESCRIPTION
This commit updates pics to use FlatBuffers 23.5.26.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>