### PR TITLE
[mio-tflite2121] Use FlatBuffer 23.5.26

### DIFF
--- a/compiler/mio-tflite2121/CMakeLists.txt
+++ b/compiler/mio-tflite2121/CMakeLists.txt
@@ -1,7 +1,7 @@
-nnas_find_package(FlatBuffers EXACT 2.0 QUIET)
+nnas_find_package(FlatBuffers EXACT 23.5.26 QUIET)
 
 if(NOT FlatBuffers_FOUND)
-  message(STATUS "Build mio-tflite2121: FAILED (missing Flatbuffers 2.0)")
+  message(STATUS "Build mio-tflite2121: FAILED (missing Flatbuffers 23.5.26)")
   return()
 endif(NOT FlatBuffers_FOUND)
 


### PR DESCRIPTION
This commit updates mio-tflite2121 to use FlatBuffers 23.5.26.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>