### PR TITLE
[onert] Introduce BackPropInitializer

### DIFF
--- a/runtime/onert/backend/train/ops/BackPropInitializer.cc
+++ b/runtime/onert/backend/train/ops/BackPropInitializer.cc
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "BackPropInitializer.h"
+
+namespace onert
+{
+namespace backend
+{
+namespace train
+{
+namespace ops
+{
+
+BackPropInitializer::BackPropInitializer(const std::vector<BackPropTensor *> back_props)
+  : _back_props{back_props}
+{
+  assert(std::all_of(back_props.cbegin(), back_props.cend(),
+                     [](const BackPropTensor *back_prop) { return back_prop != nullptr; }));
+}
+
+void BackPropInitializer::forward(bool)
+{
+  // DO NOTHING
+}
+
+void BackPropInitializer::backward()
+{
+  for (auto &&back_prop_tensor : _back_props)
+  {
+    assert(back_prop_tensor->buffer() != nullptr);
+    memset(back_prop_tensor->buffer(), 0, back_prop_tensor->total_size());
+  }
+}
+
+} // namespace ops
+} // namespace train
+} // namespace backend
+} // namespace onert

--- a/runtime/onert/backend/train/ops/BackPropInitializer.h
+++ b/runtime/onert/backend/train/ops/BackPropInitializer.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_BACKEND_TRAIN_OPS_BACKPROP_INITIALIZER_H__
+#define __ONERT_BACKEND_TRAIN_OPS_BACKPROP_INITIALIZER_H__
+
+#include <backend/IPortableTensor.h>
+#include <exec/train/ITrainableFunction.h>
+
+#include "../Tensor.h"
+
+namespace onert
+{
+namespace backend
+{
+namespace train
+{
+namespace ops
+{
+
+// TODO Introduce IFunction for only backwarding
+class BackPropInitializer : public exec::train::ITrainableFunction
+{
+public:
+  BackPropInitializer(const std::vector<BackPropTensor *> back_props);
+
+public:
+  void forward(bool training) override;
+  void backward() override;
+
+private:
+  const std::vector<BackPropTensor *> _back_props;
+};
+
+} // namespace ops
+} // namespace train
+} // namespace backend
+} // namespace onert
+
+#endif // __ONERT_BACKEND_TRAIN_OPS_BACKPROP_INITIALIZER_H__


### PR DESCRIPTION
This commit introduces BackPropInitilizer that initializes buffers of back-prop tensors.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>