### PR TITLE
[infra] Fix flatbuffers 2.0 package finding

### DIFF
--- a/infra/cmake/packages/FlatBuffers-2.0/FlatBuffersConfig.cmake
+++ b/infra/cmake/packages/FlatBuffers-2.0/FlatBuffersConfig.cmake
@@ -1,6 +1,5 @@
-# TODO Remove other Flatbuffers versions
 function(_FlatBuffers_import)
-  find_package(Flatbuffers 2.0 QUIET PATHS ${EXT_OVERLAY_DIR}/FLATBUFFERS-2.0)
+  find_package(Flatbuffers 2.0 EXACT QUIET PATHS ${EXT_OVERLAY_DIR}/FLATBUFFERS-2.0)
   set(FlatBuffers_FOUND ${Flatbuffers_FOUND} PARENT_SCOPE)
 endfunction(_FlatBuffers_import)
 


### PR DESCRIPTION
This commit updates FlatBuffersConfig.cmake to find flatbuffers exact 2.0 version.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

It resolves build fail #12933