### PR TITLE
[onert] Introduce DisposableMemoryManager into train backend

### DIFF
--- a/runtime/onert/backend/train/DisposableTensorIndex.h
+++ b/runtime/onert/backend/train/DisposableTensorIndex.h
@@ -19,6 +19,7 @@
 
 #include <cassert>
 #include <functional>
+#include <unordered_map>
 
 #include "ir/Index.h"
 

--- a/runtime/onert/backend/train/MemoryManager.cc
+++ b/runtime/onert/backend/train/MemoryManager.cc
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "MemoryManager.h"
+
+#include "MemoryPlannerFactory.h"
+
+#include <util/ConfigSource.h>
+
+#include <cassert>
+
+namespace onert
+{
+namespace backend
+{
+namespace train
+{
+
+DisposableMemoryManager::DisposableMemoryManager() : _mem_planner{createMemoryPlanner()}
+{
+  // DO NOTHING
+}
+
+DisposableMemoryManager::DisposableMemoryManager(const std::string planner_id)
+  : _mem_planner{createMemoryPlanner(planner_id)}
+{
+  // DO NOTHING
+}
+
+basic::IMemoryPlanner<DisposableTensorIndex> *DisposableMemoryManager::createMemoryPlanner()
+{
+  auto planner_id = util::getConfigString(util::config::CPU_MEMORY_PLANNER);
+  return MemoryPlannerFactory::get().create(planner_id);
+}
+
+basic::IMemoryPlanner<DisposableTensorIndex> *
+DisposableMemoryManager::createMemoryPlanner(const std::string planner_id)
+{
+  return MemoryPlannerFactory::get().create(planner_id);
+}
+
+void DisposableMemoryManager::claimPlan(const DisposableTensorIndex &ind, uint32_t size)
+{
+  _mem_planner->claim(ind, size);
+}
+
+void DisposableMemoryManager::releasePlan(const DisposableTensorIndex &ind)
+{
+  _mem_planner->release(ind);
+}
+
+void DisposableMemoryManager::allocate(void)
+{
+  _mem_alloc = std::make_shared<basic::Allocator>(_mem_planner->capacity());
+  assert(_mem_alloc->base());
+}
+
+uint8_t *DisposableMemoryManager::getBuffer(const DisposableTensorIndex &ind) const
+{
+  assert(_mem_planner->memory_plans().find(ind) != _mem_planner->memory_plans().end());
+  const auto &mem_blk = _mem_planner->memory_plans().at(ind);
+  return _mem_alloc->base() + mem_blk.offset;
+}
+
+} // namespace train
+} // namespace backend
+} // namespace onert

--- a/runtime/onert/backend/train/MemoryManager.h
+++ b/runtime/onert/backend/train/MemoryManager.h
@@ -19,6 +19,8 @@
 
 #include <backend/basic/MemoryManager.h>
 
+#include "DisposableTensorIndex.h"
+
 namespace onert
 {
 namespace backend
@@ -27,6 +29,30 @@ namespace train
 {
 
 using MemoryManager = backend::basic::MemoryManager;
+
+class DisposableMemoryManager
+{
+public:
+  DisposableMemoryManager();
+  DisposableMemoryManager(const std::string planner_id);
+
+  void allocate(void);
+  uint8_t *getBuffer(const DisposableTensorIndex &ind) const;
+  void deallocate(void) { _mem_alloc->release(); }
+
+  void claimPlan(const DisposableTensorIndex &ind, uint32_t size);
+  void releasePlan(const DisposableTensorIndex &ind);
+
+  std::shared_ptr<basic::Allocator> getMemAlloc() { return _mem_alloc; }
+
+private:
+  basic::IMemoryPlanner<DisposableTensorIndex> *createMemoryPlanner();
+  basic::IMemoryPlanner<DisposableTensorIndex> *createMemoryPlanner(const std::string planner_id);
+
+private:
+  std::shared_ptr<basic::IMemoryPlanner<DisposableTensorIndex>> _mem_planner;
+  std::shared_ptr<basic::Allocator> _mem_alloc;
+};
 
 } // namespace train
 } // namespace backend

--- a/runtime/onert/backend/train/TensorManager.h
+++ b/runtime/onert/backend/train/TensorManager.h
@@ -17,6 +17,7 @@
 #ifndef __ONERT_BACKEND_TRAIN_TENSOR_MANAGER_H__
 #define __ONERT_BACKEND_TRAIN_TENSOR_MANAGER_H__
 
+#include "DisposableTensorIndex.h"
 #include "MemoryManager.h"
 #include "TensorRegistry.h"
 
@@ -47,6 +48,7 @@ public:
   void allocateTrainableTensors();
   void allocateBackPropTensors();
   void allocateGradientTensors();
+  void allocateDisposableBackPropTensors();
   // TODO Add member functions to deallocate tensors
 
   void claimNonConstPlan(const ir::OperandIndex &ind);
@@ -57,12 +59,15 @@ public:
   void releaseBackPropPlan(const ir::OperandIndex &ind);
   void claimGradientPlan(const ir::OperandIndex &ind);
   void releaseGradientPlan(const ir::OperandIndex &ind);
+  void claimDisposableBackPropPlan(const DisposableTensorIndex &ind);
+  void releaseDisposableBackPropPlan(const DisposableTensorIndex &ind);
 
 private:
   std::unique_ptr<MemoryManager> _nonconst_mgr;
   std::unique_ptr<MemoryManager> _trainable_mgr;
   std::unique_ptr<MemoryManager> _back_prop_mgr;
   std::unique_ptr<MemoryManager> _gradient_mgr;
+  std::unique_ptr<DisposableMemoryManager> _disposable_back_prop_mgr;
   const std::shared_ptr<TensorRegistry> _tensors;
 };
 


### PR DESCRIPTION
This commit introduces DisposableMemoryManager that manages memories of disposable tensors
   - Introduce DisposableMemoryManager into train backend
   - Add DisposableMemoryManager to TensorManager

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>