### PR TITLE
[onert] Change FunctionMap to unordered_map

### DIFF
--- a/runtime/onert/backend/cl_common/include/cl_common/BackendContext.h
+++ b/runtime/onert/backend/cl_common/include/cl_common/BackendContext.h
@@ -54,7 +54,7 @@ public:
     for (auto &&op_ind : _data.op_order)
     {
       auto fn_seq = kernel_gen->generate(op_ind);
-      ret.emplace_back(op_ind, std::move(fn_seq));
+      ret.emplace(op_ind, std::move(fn_seq));
     }
 
     tensor_builder->allocate();

--- a/runtime/onert/backend/cpu/BackendContext.cc
+++ b/runtime/onert/backend/cpu/BackendContext.cc
@@ -40,7 +40,7 @@ FunctionMap BackendContext::genKernels()
   for (auto &&op_ind : _data.op_order)
   {
     auto fn_seq = kernel_gen->generate(op_ind);
-    ret.emplace_back(op_ind, std::move(fn_seq));
+    ret.emplace(op_ind, std::move(fn_seq));
   }
 
   basic::initConsts(*this);

--- a/runtime/onert/backend/gpu_cl/BackendContext.cc
+++ b/runtime/onert/backend/gpu_cl/BackendContext.cc
@@ -93,7 +93,7 @@ FunctionMap BackendContext::genKernels()
   for (auto &&op_ind : _data.op_order)
   {
     auto fn_seq = kernel_gen->generate(op_ind);
-    fn_map.emplace_back(op_ind, std::move(fn_seq));
+    fn_map.emplace(op_ind, std::move(fn_seq));
   }
 
   kernel_gen->get_operation(fn_map);

--- a/runtime/onert/backend/ruy/BackendContext.cc
+++ b/runtime/onert/backend/ruy/BackendContext.cc
@@ -40,7 +40,7 @@ FunctionMap BackendContext::genKernels()
   for (auto &&op_ind : _data.op_order)
   {
     auto fn_seq = kernel_gen->generate(op_ind);
-    ret.emplace_back(op_ind, std::move(fn_seq));
+    ret.emplace(op_ind, std::move(fn_seq));
   }
 
   basic::initConsts(*this);

--- a/runtime/onert/backend/train/BackendContext.cc
+++ b/runtime/onert/backend/train/BackendContext.cc
@@ -68,7 +68,7 @@ FunctionMap BackendContext::genKernels()
   for (const auto &op_ind : _tdata->op_order)
   {
     auto fn_seq = kernel_gen->generate(op_ind);
-    ret.emplace_back(op_ind, std::move(fn_seq));
+    ret.emplace(op_ind, std::move(fn_seq));
   }
 
   // Initialize TrainableTensors

--- a/runtime/onert/backend/trix/BackendContext.cc
+++ b/runtime/onert/backend/trix/BackendContext.cc
@@ -40,7 +40,7 @@ FunctionMap BackendContext::genKernels()
   for (auto &&op_ind : _data.op_order)
   {
     auto fn_seq = kernel_gen->generate(op_ind);
-    ret.emplace_back(op_ind, std::move(fn_seq));
+    ret.emplace(op_ind, std::move(fn_seq));
   }
 
   basic::initConsts(*this);

--- a/runtime/onert/backend/xnnpack/BackendContext.cc
+++ b/runtime/onert/backend/xnnpack/BackendContext.cc
@@ -40,7 +40,7 @@ FunctionMap BackendContext::genKernels()
   for (auto &&op_ind : _data.op_order)
   {
     auto fn_seq = kernel_gen->generate(op_ind);
-    ret.emplace_back(op_ind, std::move(fn_seq));
+    ret.emplace(op_ind, std::move(fn_seq));
   }
 
   basic::initConsts(*this);

--- a/runtime/onert/core/include/backend/BackendContext.h
+++ b/runtime/onert/core/include/backend/BackendContext.h
@@ -32,8 +32,7 @@ namespace backend
 class Backend;
 struct ITensorRegistry;
 
-using FunctionMap =
-  std::vector<std::pair<ir::OperationIndex, std::unique_ptr<exec::FunctionSequence>>>;
+using FunctionMap = std::unordered_map<ir::OperationIndex, std::unique_ptr<exec::FunctionSequence>>;
 
 struct ContextData
 {

--- a/runtime/onert/core/include/backend/train/TrainableBackendContext.h
+++ b/runtime/onert/core/include/backend/train/TrainableBackendContext.h
@@ -34,7 +34,7 @@ namespace train
 {
 
 using FunctionMap =
-  std::vector<std::pair<ir::OperationIndex, std::unique_ptr<exec::train::TrainableFnSequence>>>;
+  std::unordered_map<ir::OperationIndex, std::unique_ptr<exec::train::TrainableFnSequence>>;
 
 struct TrainableContextData
 {

--- a/runtime/onert/core/src/backend/builtin/BackendContext.cc
+++ b/runtime/onert/core/src/backend/builtin/BackendContext.cc
@@ -35,7 +35,7 @@ FunctionMap BackendContext::genKernels()
   for (auto &&op_ind : _data.op_order)
   {
     auto fn_seq = kernel_gen->generate(op_ind);
-    ret.emplace_back(op_ind, std::move(fn_seq));
+    ret.emplace(op_ind, std::move(fn_seq));
   }
 
   basic::initConsts(*this);

--- a/runtime/onert/core/src/backend/builtin/train/BackendContext.cc
+++ b/runtime/onert/core/src/backend/builtin/train/BackendContext.cc
@@ -50,7 +50,7 @@ backend::train::FunctionMap BackendContext::genKernels()
   for (auto &&op_ind : _tdata->op_order)
   {
     auto tn_seq = kernel_gen->generate(op_ind);
-    ret.emplace_back(op_ind, std::move(tn_seq));
+    ret.emplace(op_ind, std::move(tn_seq));
   }
 
   trainable_graph()->operands().iterate(


### PR DESCRIPTION
This commit changes FunctionMap to unordered_map for the following reasons:
   - Name mismatch : Although the name contains map, it was actually a vector, not a map
   - Search time : Searching by key will be added, search time needed to be improved.

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>

---

Related issue : #12945