### PR TITLE
DRAFT: Remove QDQ for mixed-precision operators

### DIFF
--- a/compiler/circle2circle/src/Circle2Circle.cpp
+++ b/compiler/circle2circle/src/Circle2Circle.cpp
@@ -129,6 +129,8 @@ int entry(int argc, char **argv)
   add_switch(arser, "--remove_gather_guard",
              "This will remove Add/FloorMod guards of Gather indices with certain conditions. "
              "CAUTION: user must guarantee that indices are all non-negative values.");
+  add_switch(arser, "--remove_qdq_for_mpo",
+             "This will remove QDQ to simulate mixed-precision operator");
   add_switch(arser, "--remove_quantdequant", "This will remove Quantize-Dequantize sequence");
   add_switch(arser, "--remove_redundant_quantize", "This will remove redundant Quantize operators");
   add_switch(arser, "--remove_redundant_reshape",
@@ -323,6 +325,8 @@ int entry(int argc, char **argv)
     options->enable(Algorithms::RemoveFakeQuant);
   if (arser.get<bool>("--remove_gather_guard"))
     options->enable(Algorithms::RemoveGatherGuard);
+  if (arser.get<bool>("--remove_qdq_for_mpo"))
+    options->enable(Algorithms::RemoveQDQForMixedPrecisionOp);
   if (arser.get<bool>("--remove_quantdequant"))
     options->enable(Algorithms::RemoveQuantDequantSeq);
   if (arser.get<bool>("--remove_redundant_quantize"))

--- a/compiler/luci/pass/include/luci/CircleOptimizer.h
+++ b/compiler/luci/pass/include/luci/CircleOptimizer.h
@@ -100,6 +100,7 @@ public:
       RemoveRedundantQuantize,
       RemoveRedundantReshape,
       RemoveFakeQuant,
+      RemoveQDQForMixedPrecisionOp,
       RemoveQuantDequantSeq,
       RemoveDuplicateConst,
       UnrollUnidirSeqLSTM,

--- a/compiler/luci/pass/include/luci/Pass/RemoveQDQForMixedPrecisionOpPass.h
+++ b/compiler/luci/pass/include/luci/Pass/RemoveQDQForMixedPrecisionOpPass.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __LUCI_REMOVE_QDQ_FOR_MIXED_PRECISION_OP_PASS_H__
+#define __LUCI_REMOVE_QDQ_FOR_MIXED_PRECISION_OP_PASS_H__
+
+#include <logo/Pass.h>
+
+namespace luci
+{
+
+/**
+ * @brief  Class to remove QDQ pattern for mixed-precision Ops
+ */
+struct RemoveQDQForMixedPrecisionOpPass final : public logo::Pass
+{
+  const char *name(void) const final { return "luci::RemoveQDQForMixedPrecisionOpPass"; }
+
+  bool run(loco::Graph *g) final;
+};
+
+} // namespace luci
+
+#endif // __LUCI_REMOVE_QDQ_FOR_MIXED_PRECISION_OP_PASS_H__

--- a/compiler/luci/pass/src/CircleOptimizer.cpp
+++ b/compiler/luci/pass/src/CircleOptimizer.cpp
@@ -53,6 +53,7 @@
 #include "luci/Pass/RemoveDuplicateConstPass.h"
 #include "luci/Pass/RemoveFakeQuantPass.h"
 #include "luci/Pass/RemoveGatherGuardPass.h"
+#include "luci/Pass/RemoveQDQForMixedPrecisionOpPass.h"
 #include "luci/Pass/RemoveQuantDequantSeqPass.h"
 #include "luci/Pass/RemoveRedundantReshapePass.h"
 #include "luci/Pass/RemoveRedundantTransposePass.h"
@@ -412,6 +413,10 @@ void CircleOptimizer::optimize(loco::Graph *g) const
   if (_options->query(Options::Algorithm::RemoveGatherGuard))
   {
     phase.emplace_back(std::make_unique<luci::RemoveGatherGuardPass>());
+  }
+  if (_options->query(Options::Algorithm::RemoveQDQForMixedPrecisionOp))
+  {
+    phase.emplace_back(std::make_unique<luci::RemoveQDQForMixedPrecisionOpPass>());
   }
   if (_options->query(Options::Algorithm::RemoveQuantDequantSeq))
   {

--- a/compiler/luci/pass/src/RemoveQDQForMixedPrecisionOpPass.cpp
+++ b/compiler/luci/pass/src/RemoveQDQForMixedPrecisionOpPass.cpp
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Pass/RemoveQDQForMixedPrecisionOpPass.h"
+
+#include <luci/IR/CircleNode.h>
+
+/**
+ *  Remove Quantize-Dequantize pattern for backends with mixed-precision operator.
+ *
+ *  BEFORE
+ *                                          [CircleNode_1]
+ *                                                |
+ *                             [CircleQuantize, dtype_1, scale_1, zero_point_1]
+ *                                                |
+ *                                       [CircleDequantize]
+ *                                                |
+ *                             [CircleQuantize, dtype_2, scale_2, zero_point_2]
+ *                                                |
+ *                                       [CircleDequantize]
+ *                                                |
+ *                                         [CircleNode_2]
+ *
+ *  AFTER
+ *
+ *                                          [CircleNode_1]
+ *                                                |
+ *                             [CircleQuantize, dtype_2, scale_2, zero_point_2]
+ *                                                |
+ *                                       [CircleDequantize]
+ *                                                |
+ *                                         [CircleNode_2]
+ *
+ */
+
+namespace
+{
+
+bool remove_qdq_for_mpo(luci::CircleDequantize *node)
+{
+  auto prev = dynamic_cast<luci::CircleQuantize *>(node->input());
+  if (not prev)
+    return false;
+
+  auto prev_prev = dynamic_cast<luci::CircleDequantize *>(prev->input());
+  if (not prev_prev)
+    return false;
+
+  auto prev_prev_prev = dynamic_cast<luci::CircleQuantize *>(prev_prev->input());
+  if (not prev_prev_prev)
+    return false;
+
+  auto input = loco::must_cast<luci::CircleNode *>(prev_prev_prev->input());
+
+  const static std::set<luci::CircleOpcode> supported_ops{luci::CircleOpcode::FULLY_CONNECTED,
+                                                          luci::CircleOpcode::BATCH_MATMUL};
+
+  if (supported_ops.find(input->opcode()) == supported_ops.end())
+    return false;
+
+  prev->input(input);
+
+  return true;
+}
+
+} // namespace
+
+namespace luci
+{
+
+bool RemoveQDQForMixedPrecisionOpPass::run(loco::Graph *g)
+{
+  bool changed = false;
+  for (auto node : loco::postorder_traversal(loco::output_nodes(g)))
+  {
+    if (auto dq = dynamic_cast<luci::CircleDequantize *>(node))
+    {
+      if (remove_qdq_for_mpo(dq))
+        changed = true;
+    }
+  }
+  return changed;
+}
+
+} // namespace luci

--- a/compiler/luci/pass/src/RemoveQDQForMixedPrecisionOpPass.test.cpp
+++ b/compiler/luci/pass/src/RemoveQDQForMixedPrecisionOpPass.test.cpp
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Pass/RemoveQDQForMixedPrecisionOpPass.h"
+
+#include <luci/IR/CircleNodes.h>
+
+#include <luci/test/TestIOGraph.h>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+
+using namespace luci::test;
+
+class QuantDequantGraphlet
+{
+public:
+  QuantDequantGraphlet() = default;
+
+public:
+  void init(loco::Graph *g)
+  {
+    _fc = g->nodes()->create<luci::CircleFullyConnected>();
+    _fc->name("fc");
+
+    _qu = g->nodes()->create<luci::CircleQuantize>();
+    _qu->name("qu");
+
+    _de = g->nodes()->create<luci::CircleDequantize>();
+    _de->name("de");
+
+    _qu_2 = g->nodes()->create<luci::CircleQuantize>();
+    _qu_2->name("qu");
+
+    _de_2 = g->nodes()->create<luci::CircleDequantize>();
+    _de_2->name("de");
+  }
+
+public:
+  luci::CircleFullyConnected *fc(void) { return _fc; }
+  luci::CircleQuantize *qu(void) { return _qu; }
+  luci::CircleQuantize *qu_2(void) { return _qu_2; }
+
+protected:
+  luci::CircleFullyConnected *_fc = nullptr;
+  luci::CircleQuantize *_qu = nullptr;
+  luci::CircleDequantize *_de = nullptr;
+  luci::CircleQuantize *_qu_2 = nullptr;
+  luci::CircleDequantize *_de_2 = nullptr;
+};
+
+class QuantDequantGraph : public TestIOGraph, public QuantDequantGraphlet
+{
+public:
+  QuantDequantGraph() = default;
+
+public:
+  void init(void)
+  {
+    TestIOGraph::init({1}, {1});
+    QuantDequantGraphlet::init(g());
+
+    _fc->input(input());
+    _qu->input(_fc);
+    _de->input(_qu);
+    _qu_2->input(_de);
+    _de_2->input(_qu_2);
+
+    output()->from(_de_2);
+  }
+};
+
+} // namespace
+
+TEST(RemoveQDQForMixedPrecisionOpPass, remove_qdq_FC)
+{
+  QuantDequantGraph g;
+  luci::RemoveQDQForMixedPrecisionOpPass pass;
+
+  g.init();
+
+  EXPECT_TRUE(pass.run(g.g()));
+
+  EXPECT_EQ(g.fc(), g.qu_2()->input());
+}
+
+TEST(RemoveQDQForMixedPrecisionOpPass, remove_qdq_wrong_op_NEG)
+{
+  QuantDequantGraph g;
+  luci::RemoveQDQForMixedPrecisionOpPass pass;
+
+  g.init();
+
+  g.qu()->input(g.input());
+
+  EXPECT_FALSE(pass.run(g.g()));
+}


### PR DESCRIPTION
On going draft to remove QDQ for MPO.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/12965