### PR TITLE
[enco/test] Skip if no nnkit_tflite_backend

### DIFF
--- a/compiler/enco/test/tflite/CMakeLists.txt
+++ b/compiler/enco/test/tflite/CMakeLists.txt
@@ -18,6 +18,10 @@ endfunction(get_test_configuration)
 ###
 ### Prepare test(s)
 ###
+if(NOT TARGET nnkit_tflite_backend)
+  return()
+endif(NOT TARGET nnkit_tflite_backend)
+
 if(NOT TARGET tflchef-file)
   return()
 endif(NOT TARGET tflchef-file)


### PR DESCRIPTION
This will revise enco/test to skip build if nnkit_tflite_backend is not found.

ONE-DCO-1.0-Signed-off-by: SaeHie Park <saehie.park@gmail.com>