### PR TITLE
[onert] Introduce DisposableBackPropTensor into TensorBuilder

### DIFF
--- a/runtime/onert/backend/train/TensorBuilder.h
+++ b/runtime/onert/backend/train/TensorBuilder.h
@@ -17,6 +17,7 @@
 #ifndef __ONERT_BACKEND_TRAIN_TENSOR_BUILDER_H__
 #define __ONERT_BACKEND_TRAIN_TENSOR_BUILDER_H__
 
+#include "DisposableTensorIndex.h"
 #include "TensorManager.h"
 #include "TensorRegistry.h"
 
@@ -54,10 +55,15 @@ public:
   void registerBackwardTensorInfo(const ir::OperandIndex &ind, const ir::OperandInfo &info,
                                   ir::Layout backend_layout);
 
+  void registerDisposableBackwardTensorInfo(const DisposableTensorIndex &index,
+                                            const ir::OperandInfo &info, ir::Layout layout);
+
   // TODO Support memory plan of all tensors
   void notifyFirstUse(const ir::OperandIndex &);
   void notifyLastUse(const ir::OperandIndex &);
   void notifyBackwardFirstUse(const ir::OperandIndex &);
+  void notifyDisposableBackPropFirstUse(const DisposableTensorIndex &);
+  void notifyDisposableBackPropLastUse(const DisposableTensorIndex &);
 
   bool isRegistered(const ir::OperandIndex &) const;
   bool isRegisteredBackward(const ir::OperandIndex &) const;


### PR DESCRIPTION
This commit introduces DisposableBackPropTensor into TensorBuilder.
  - Add a member function that can register disposable tensors to be used in backwarding
  - Add member functions that schedules memoies of disposable tensors for back-propagation

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>