### PR TITLE
[onert] Apply BackPropAccumulator layer

### DIFF
--- a/runtime/onert/backend/train/BackendContext.h
+++ b/runtime/onert/backend/train/BackendContext.h
@@ -81,6 +81,9 @@ public:
 private:
   FunctionMap generateFunctionMap();
 
+private:
+  void planDisposableBackPropTensors();
+
 public:
   // TODO Make it private
   std::shared_ptr<KernelGenerator> kernel_gen;

--- a/runtime/onert/backend/train/KernelGenerator.h
+++ b/runtime/onert/backend/train/KernelGenerator.h
@@ -59,11 +59,17 @@ public:
   void visit(const ir::train::operation::Softmax &node) override;
 
 private:
+  IPortableTensor *getBackPropIn(const ir::Operation &op_index,
+                                 const ir::OperandIndex &operand_index);
+  IPortableTensor *getBackPropOut(const ir::OperandIndex &index);
+
+private:
   ir::Layout _current_layout;
   std::shared_ptr<TensorRegistry> _tensor_reg;
   const std::shared_ptr<ExternalContext> _external_context;
   const exec::train::optimizer::Optimizer *_optimizer;
   std::vector<std::unique_ptr<exec::train::IGradientApplier>> _update_funcs;
+  std::unordered_map<const ir::IOperation *, ir::OperationIndex> _node_to_idx;
 };
 
 } // namespace train


### PR DESCRIPTION
This commit applies BackPropAccumulator layer to train backend.
  - Add registering and planing disposable tensors for back-propagation
  - Make layers use disposable tensors instread of original back-prop tensors
  - Apply BackPropAccumulator layer to each BackPropTensor

ONE-DCO-1.0-Signed-off-by: ragmani <ragmani0216@gmail.com>