### PR TITLE
[luci-interpreter] Add a feature to infer the output shape

### DIFF
--- a/compiler/circle-interpreter/src/CircleInterpreter.cpp
+++ b/compiler/circle-interpreter/src/CircleInterpreter.cpp
@@ -136,8 +136,7 @@ int entry(int argc, char **argv)
   for (int i = 0; i < module->graph()->outputs()->size(); i++)
   {
     const auto *output_node = loco::must_cast<const luci::CircleOutput *>(output_nodes[i]);
-    size_t output_size = interpreter.getOutputTensorSize(output_node);
-    std::vector<char> output_data(output_size);
+    std::vector<char> output_data(getTensorSize(output_node));
     interpreter.readOutputTensor(output_node, output_data.data(), output_data.size());
 
     // Output data is written in ${output_file}n

--- a/compiler/circle-interpreter/src/CircleInterpreter.cpp
+++ b/compiler/circle-interpreter/src/CircleInterpreter.cpp
@@ -136,7 +136,8 @@ int entry(int argc, char **argv)
   for (int i = 0; i < module->graph()->outputs()->size(); i++)
   {
     const auto *output_node = loco::must_cast<const luci::CircleOutput *>(output_nodes[i]);
-    std::vector<char> output_data(getTensorSize(output_node));
+    size_t output_size = interpreter.getOutputTensorSize(output_node);
+    std::vector<char> output_data(output_size);
     interpreter.readOutputTensor(output_node, output_data.data(), output_data.size());
 
     // Output data is written in ${output_file}n

--- a/compiler/luci-interpreter/include/luci_interpreter/Interpreter.h
+++ b/compiler/luci-interpreter/include/luci_interpreter/Interpreter.h
@@ -60,6 +60,8 @@ public:
 
   void readOutputTensor(const luci::CircleOutput *output_node, void *data, size_t data_size);
 
+  size_t getOutputTensorSize(const luci::CircleOutput *output_node);
+
   void interpret();
 
   void attachObserver(ExecutionObserver *observer);

--- a/compiler/luci-interpreter/src/Interpreter.cpp
+++ b/compiler/luci-interpreter/src/Interpreter.cpp
@@ -125,6 +125,21 @@ void Interpreter::readOutputTensor(const luci::CircleOutput *output_node, void *
     tensor->readData(data, data_size);
 }
 
+size_t Interpreter::getOutputTensorSize(const luci::CircleOutput *output_node)
+{
+  Tensor *tensor = _runtime_module->getOutputTensors()[output_node->index()];
+  if (tensor == nullptr)
+  {
+    const std::string &name = output_node->name();
+    throw std::runtime_error("Cannot find tensor size for output node named \"" + name + "\".");
+  }
+
+  size_t tensor_size = luci::size(output_node->dtype());
+  for (int i = 0; i < tensor->shape().num_dims(); i++)
+    tensor_size *= tensor->shape().dim(i);
+  return tensor_size;
+}
+
 void Interpreter::interpret() { _runtime_module->execute(); }
 
 void Interpreter::attachObserver(ExecutionObserver *observer)


### PR DESCRIPTION
This PR makes a new interface `getOutputTensorSize` in the luci-interpreter.
This is to get the size of actual output size from the `_runtime_module`, which has the inferred and calculated output shape during the interprete process.

---

for issue #12979
from draft #12981 