### PR TITLE
[onert/api] Make a clone circle in nnfw_train_export_circle

### DIFF
--- a/runtime/onert/api/nnfw/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/nnfw/src/nnfw_api_internal.cc
@@ -1674,6 +1674,10 @@ NNFW_STATUS nnfw_session::train_export_circle(const char *path)
     size_t _buf_sz = 0;
   };
 
+  std::ifstream src(_model_path, std::ios::binary);
+  std::ofstream dst(path, std::ios::binary);
+  dst << src.rdbuf();
+
   MMappedFile mmapfile(path);
   if (!mmapfile.ensure_mmap())
     return NNFW_STATUS_ERROR;


### PR DESCRIPTION
It is a missing code segment.
It makes a copy of original circle before exporting circle.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>

- Code from https://github.com/Samsung/ONE/pull/12246/files#diff-6062b879f8bbfea9156587d03d744ae19cc190babd74b1afbb0a5fb2d84ab4fb
- Test with the same command from https://github.com/Samsung/ONE/pull/12323#issuecomment-1862131091