### PR TITLE
[onert] Store trainable ops indexes in TrainingInfo IR

### DIFF
--- a/runtime/onert/core/include/ir/train/TrainingInfo.h
+++ b/runtime/onert/core/include/ir/train/TrainingInfo.h
@@ -18,9 +18,12 @@
 #ifndef __ONERT_IR_TRAIN_TRAINING_INFO_H__
 #define __ONERT_IR_TRAIN_TRAINING_INFO_H__
 
+#include "ir/Index.h"
 #include "ir/train/OptimizerCode.h"
 #include "ir/train/OptimizerInfo.h"
 #include "ir/train/LossInfo.h"
+
+#include <unordered_set>
 
 namespace onert
 {
@@ -32,7 +35,10 @@ namespace train
 class TrainingInfo final
 {
 public:
-  TrainingInfo() : _loss_info(), _optimizer_info(), _batch_size(0), _training_step{0} {}
+  TrainingInfo()
+    : _loss_info(), _optimizer_info(), _batch_size(0), _training_step{0}, _trainable_ops{}
+  {
+  }
   TrainingInfo(const TrainingInfo &) = default;
   TrainingInfo(TrainingInfo &&) = default;
   TrainingInfo &operator=(const TrainingInfo &) = default;
@@ -44,12 +50,17 @@ public:
   const OptimizerInfo &optimizerInfo() const { return _optimizer_info; }
   uint32_t batchSize() const { return _batch_size; }
   const uint32_t &trainingStep() const { return _training_step; }
+  const std::unordered_set<OperationIndex> &getTrainableOps() const { return _trainable_ops; }
 
   // setter
   void setBatchSize(const uint32_t batch_size) { _batch_size = batch_size; }
   void setLossInfo(const LossInfo &loss_info) { _loss_info = loss_info; }
   void setOptimizerInfo(const OptimizerInfo &optimizer_info) { _optimizer_info = optimizer_info; }
   uint32_t &trainingStep() { return _training_step; }
+  void setTrainableOps(const std::unordered_set<OperationIndex> &trainable_ops)
+  {
+    _trainable_ops = trainable_ops;
+  }
 
   bool isValid() const;
 
@@ -58,6 +69,7 @@ private:
   OptimizerInfo _optimizer_info;
   uint32_t _batch_size;
   uint32_t _training_step;
+  std::unordered_set<OperationIndex> _trainable_ops;
 };
 
 } // namespace train

--- a/runtime/onert/core/include/ir/train/TrainingInfo.h
+++ b/runtime/onert/core/include/ir/train/TrainingInfo.h
@@ -23,7 +23,7 @@
 #include "ir/train/OptimizerInfo.h"
 #include "ir/train/LossInfo.h"
 
-#include <unordered_set>
+#include <set>
 
 namespace onert
 {
@@ -50,14 +50,14 @@ public:
   const OptimizerInfo &optimizerInfo() const { return _optimizer_info; }
   uint32_t batchSize() const { return _batch_size; }
   const uint32_t &trainingStep() const { return _training_step; }
-  const std::unordered_set<OperationIndex> &getTrainableOps() const { return _trainable_ops; }
+  const std::set<OperationIndex> &getTrainableOps() const { return _trainable_ops; }
 
   // setter
   void setBatchSize(const uint32_t batch_size) { _batch_size = batch_size; }
   void setLossInfo(const LossInfo &loss_info) { _loss_info = loss_info; }
   void setOptimizerInfo(const OptimizerInfo &optimizer_info) { _optimizer_info = optimizer_info; }
   uint32_t &trainingStep() { return _training_step; }
-  void setTrainableOps(const std::unordered_set<OperationIndex> &trainable_ops)
+  void setTrainableOps(const std::set<OperationIndex> &trainable_ops)
   {
     _trainable_ops = trainable_ops;
   }
@@ -69,7 +69,7 @@ private:
   OptimizerInfo _optimizer_info;
   uint32_t _batch_size;
   uint32_t _training_step;
-  std::unordered_set<OperationIndex> _trainable_ops;
+  std::set<OperationIndex> _trainable_ops;
 };
 
 } // namespace train

--- a/runtime/onert/core/src/loader/TrainInfoLoader.cc
+++ b/runtime/onert/core/src/loader/TrainInfoLoader.cc
@@ -92,11 +92,11 @@ ir::train::LossInfo loadLossInfo(const circle::ModelTraining *circle_model)
   return ir_loss;
 }
 
-std::unordered_set<ir::OperationIndex> loadTrainableOps(const circle::ModelTraining *circle_model)
+std::set<ir::OperationIndex> loadTrainableOps(const circle::ModelTraining *circle_model)
 {
   assert(circle_model != nullptr);
 
-  std::unordered_set<ir::OperationIndex> ir_trainable_ops;
+  std::set<ir::OperationIndex> ir_trainable_ops;
   const auto lists = circle_model->trainable_ops();
   if (lists != nullptr)
   {

--- a/runtime/onert/core/src/loader/TrainInfoLoader.cc
+++ b/runtime/onert/core/src/loader/TrainInfoLoader.cc
@@ -91,6 +91,23 @@ ir::train::LossInfo loadLossInfo(const circle::ModelTraining *circle_model)
 
   return ir_loss;
 }
+
+std::unordered_set<ir::OperationIndex> loadTrainableOps(const circle::ModelTraining *circle_model)
+{
+  assert(circle_model != nullptr);
+
+  std::unordered_set<ir::OperationIndex> ir_trainable_ops;
+  const auto lists = circle_model->trainable_ops();
+  if (lists != nullptr)
+  {
+    for (::flatbuffers::uoffset_t i = 0; i < lists->size(); ++i)
+    {
+      const uint32_t op_index = lists->Get(i);
+      ir_trainable_ops.emplace(ir::OperationIndex{op_index});
+    }
+  }
+  return ir_trainable_ops;
+}
 } // namespace
 
 std::unique_ptr<ir::train::TrainingInfo> loadTrainingInfo(const uint8_t *buffer, const size_t size)
@@ -112,6 +129,7 @@ std::unique_ptr<ir::train::TrainingInfo> loadTrainingInfo(const uint8_t *buffer,
     tinfo->setBatchSize(circle_model->batch_size());
     tinfo->setOptimizerInfo(loadOptimizerInfo(circle_model));
     tinfo->setLossInfo(loadLossInfo(circle_model));
+    tinfo->setTrainableOps(loadTrainableOps(circle_model));
   }
   return tinfo;
 }


### PR DESCRIPTION
This commit stores the indexes of trainable ops from the TrainInfo of the given circle file in the TrainingInfo IR.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Draft: #12984 

/cc @mbencer 