### PR TITLE
[onert] Introduce API to control trainability of operations

### DIFF
--- a/runtime/onert/core/include/ir/train/ITrainableOperation.h
+++ b/runtime/onert/core/include/ir/train/ITrainableOperation.h
@@ -40,7 +40,21 @@ public:
   virtual void accept(OperationVisitor &v) const override = 0;
   virtual void accept(TrainableOperationVisitor &v) const = 0;
   virtual bool hasTrainableParameter() const = 0;
-  // TODO Add virtual methods related to training
+
+  // Update of the node will be disabled during traning
+  virtual void disableWeightsUpdate() = 0;
+  // Note that the update is disabled by default
+  // Update of the node will be enabled during traning
+  virtual void enableWeightsUpdate() = 0;
+  // Check if the node is trainable
+  virtual bool isTrainable() const = 0;
+
+  // Mark the node as not needed for backward propagation part of the traning
+  virtual void disableBackward() = 0;
+  // Check if the nodes is required for backward propagation part of the traning.
+  // If returned false, it means that there are no node before (in topological sense) which is
+  // trainable.
+  virtual bool isRequiredForBackward() const = 0;
 };
 
 } // namespace train

--- a/runtime/onert/core/include/ir/train/ITrainableOperation.h
+++ b/runtime/onert/core/include/ir/train/ITrainableOperation.h
@@ -49,8 +49,8 @@ public:
   // Check if the node is trainable
   virtual bool isTrainable() const = 0;
 
-  // Mark the node as not needed for backward propagation part of the traning
-  virtual void disableBackward() = 0;
+  // Mark the node as needed for backward propagation part of the traning
+  virtual void enableBackward() = 0;
   // Check if the nodes is required for backward propagation part of the traning.
   // If returned false, it means that there are no node before (in topological sense) which is
   // trainable.

--- a/runtime/onert/core/include/ir/train/ITrainableOperation.h
+++ b/runtime/onert/core/include/ir/train/ITrainableOperation.h
@@ -47,7 +47,7 @@ public:
   // Update of the node will be enabled during traning
   virtual void enableWeightsUpdate() = 0;
   // Check if the node is trainable
-  virtual bool isTrainable() const = 0;
+  virtual bool isWeightsUpdateEnabled() const = 0;
 
   // Mark the node as needed for backward propagation part of the traning
   virtual void enableBackward() = 0;

--- a/runtime/onert/core/include/ir/train/TrainableOperation.h
+++ b/runtime/onert/core/include/ir/train/TrainableOperation.h
@@ -36,7 +36,7 @@ public:
 
   void enableWeightsUpdate() final { _trainable = true; }
 
-  virtual bool isTrainable() const final { return _trainable; }
+  virtual bool isWeightsUpdateEnabled() const final { return _trainable; }
 
   void enableBackward() final { _required_for_backward = true; }
   virtual bool isRequiredForBackward() const final { return _required_for_backward; }

--- a/runtime/onert/core/include/ir/train/TrainableOperation.h
+++ b/runtime/onert/core/include/ir/train/TrainableOperation.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_IR_TRAIN_TRAINABLE_OPERATION_H__
+#define __ONERT_IR_TRAIN_TRAINABLE_OPERATION_H__
+
+#include "ITrainableOperation.h"
+
+namespace onert
+{
+namespace ir
+{
+namespace train
+{
+
+class TrainableOperation : public virtual ITrainableOperation
+{
+public:
+  virtual ~TrainableOperation() = default;
+
+public:
+  virtual std::unique_ptr<ITrainableOperation> clone() const override = 0;
+  virtual void accept(OperationVisitor &v) const override = 0;
+  virtual void accept(TrainableOperationVisitor &v) const override = 0;
+
+  void disableWeightsUpdate() final { _trainable = false; }
+
+  void enableWeightsUpdate() final { _trainable = true; }
+
+  virtual bool isTrainable() const final { return _trainable; }
+
+  void disableBackward() final { _required_for_backward = false; }
+  virtual bool isRequiredForBackward() const final { return _required_for_backward; }
+
+private:
+  bool _trainable = false;
+  bool _required_for_backward = true;
+};
+
+} // namespace train
+} // namespace ir
+} // namespace onert
+
+#endif // __ONERT_IR_TRAIN_TRAINABLE_OPERATION_H__

--- a/runtime/onert/core/include/ir/train/TrainableOperation.h
+++ b/runtime/onert/core/include/ir/train/TrainableOperation.h
@@ -26,16 +26,12 @@ namespace ir
 namespace train
 {
 
-class TrainableOperation : public virtual ITrainableOperation
+class TrainableOperation : public ITrainableOperation
 {
 public:
   virtual ~TrainableOperation() = default;
 
 public:
-  virtual std::unique_ptr<ITrainableOperation> clone() const override = 0;
-  virtual void accept(OperationVisitor &v) const override = 0;
-  virtual void accept(TrainableOperationVisitor &v) const override = 0;
-
   void disableWeightsUpdate() final { _trainable = false; }
 
   void enableWeightsUpdate() final { _trainable = true; }

--- a/runtime/onert/core/include/ir/train/TrainableOperation.h
+++ b/runtime/onert/core/include/ir/train/TrainableOperation.h
@@ -42,12 +42,12 @@ public:
 
   virtual bool isTrainable() const final { return _trainable; }
 
-  void disableBackward() final { _required_for_backward = false; }
+  void enableBackward() final { _required_for_backward = true; }
   virtual bool isRequiredForBackward() const final { return _required_for_backward; }
 
 private:
   bool _trainable = false;
-  bool _required_for_backward = true;
+  bool _required_for_backward = false;
 };
 
 } // namespace train

--- a/runtime/onert/core/include/ir/train/TrainableOperation.h
+++ b/runtime/onert/core/include/ir/train/TrainableOperation.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Samsung Electronics Co., Ltd. All Rights Reserved
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/runtime/onert/core/include/ir/train/operation/BinaryArithmetic.h
+++ b/runtime/onert/core/include/ir/train/operation/BinaryArithmetic.h
@@ -18,7 +18,7 @@
 #define __ONERT_IR_TRAIN_OPERATION_BINARY_ARITHMETIC_H__
 
 #include "ir/operation/BinaryArithmetic.h"
-#include "ir/train/ITrainableOperation.h"
+#include "ir/train/TrainableOperation.h"
 
 namespace onert
 {
@@ -29,7 +29,7 @@ namespace train
 namespace operation
 {
 
-class BinaryArithmetic : public ir::operation::BinaryArithmetic, public ITrainableOperation
+class BinaryArithmetic : public ir::operation::BinaryArithmetic, public TrainableOperation
 {
 private:
   using OperationType = ir::operation::BinaryArithmetic;

--- a/runtime/onert/core/include/ir/train/operation/Conv2D.h
+++ b/runtime/onert/core/include/ir/train/operation/Conv2D.h
@@ -18,7 +18,7 @@
 #define __ONERT_IR_TRAIN_OPERATION_CONV2D_H__
 
 #include "ir/operation/Conv2D.h"
-#include "ir/train/ITrainableOperation.h"
+#include "ir/train/TrainableOperation.h"
 
 namespace onert
 {
@@ -29,7 +29,7 @@ namespace train
 namespace operation
 {
 
-class Conv2D : public ir::operation::Conv2D, public ITrainableOperation
+class Conv2D : public ir::operation::Conv2D, public TrainableOperation
 {
 private:
   using OperationType = ir::operation::Conv2D;

--- a/runtime/onert/core/include/ir/train/operation/DepthwiseConv2D.h
+++ b/runtime/onert/core/include/ir/train/operation/DepthwiseConv2D.h
@@ -18,7 +18,7 @@
 #define __ONERT_IR_TRAIN_OPERATION_DEPTHWISE_CONV2D_H__
 
 #include "ir/operation/DepthwiseConv2D.h"
-#include "ir/train/ITrainableOperation.h"
+#include "ir/train/TrainableOperation.h"
 
 namespace onert
 {
@@ -29,7 +29,7 @@ namespace train
 namespace operation
 {
 
-class DepthwiseConv2D : public ir::operation::DepthwiseConv2D, public ITrainableOperation
+class DepthwiseConv2D : public ir::operation::DepthwiseConv2D, public TrainableOperation
 {
 private:
   using OperationType = ir::operation::DepthwiseConv2D;

--- a/runtime/onert/core/include/ir/train/operation/ElementwiseActivation.h
+++ b/runtime/onert/core/include/ir/train/operation/ElementwiseActivation.h
@@ -18,7 +18,7 @@
 #define __ONERT_IR_TRAIN_OPERATION_ELEMENTWISE_ACTIVATION_H__
 
 #include "ir/operation/ElementwiseActivation.h"
-#include "ir/train/ITrainableOperation.h"
+#include "ir/train/TrainableOperation.h"
 
 namespace onert
 {
@@ -29,8 +29,7 @@ namespace train
 namespace operation
 {
 
-class ElementwiseActivation : public ir::operation::ElementwiseActivation,
-                              public ITrainableOperation
+class ElementwiseActivation : public ir::operation::ElementwiseActivation, public TrainableOperation
 {
 private:
   using OperationType = ir::operation::ElementwiseActivation;

--- a/runtime/onert/core/include/ir/train/operation/FullyConnected.h
+++ b/runtime/onert/core/include/ir/train/operation/FullyConnected.h
@@ -18,7 +18,7 @@
 #define __ONERT_IR_TRAIN_OPERATION_FULLYCONNECTED_H__
 
 #include "ir/operation/FullyConnected.h"
-#include "ir/train/ITrainableOperation.h"
+#include "ir/train/TrainableOperation.h"
 
 namespace onert
 {
@@ -29,7 +29,7 @@ namespace train
 namespace operation
 {
 
-class FullyConnected : public ir::operation::FullyConnected, public ITrainableOperation
+class FullyConnected : public ir::operation::FullyConnected, public TrainableOperation
 {
 private:
   using OperationType = ir::operation::FullyConnected;

--- a/runtime/onert/core/include/ir/train/operation/Loss.h
+++ b/runtime/onert/core/include/ir/train/operation/Loss.h
@@ -18,7 +18,7 @@
 #define __ONERT_IR_TRAIN_OPERATION_LOSS_H__
 
 #include "ir/operation/Loss.h"
-#include "ir/train/ITrainableOperation.h"
+#include "ir/train/TrainableOperation.h"
 
 #include "ir/train/LossCode.h"
 #include "ir/train/LossInfo.h"
@@ -32,7 +32,7 @@ namespace train
 namespace operation
 {
 
-class Loss : public ir::operation::Loss, public ITrainableOperation
+class Loss : public ir::operation::Loss, public TrainableOperation
 {
 private:
   using OperationType = ir::operation::Loss;

--- a/runtime/onert/core/include/ir/train/operation/Pad.h
+++ b/runtime/onert/core/include/ir/train/operation/Pad.h
@@ -18,7 +18,7 @@
 #define __ONERT_IR_TRAIN_OPERATION_PAD_H__
 
 #include "ir/operation/Pad.h"
-#include "ir/train/ITrainableOperation.h"
+#include "ir/train/TrainableOperation.h"
 
 namespace onert
 {
@@ -29,7 +29,7 @@ namespace train
 namespace operation
 {
 
-class Pad : public ir::operation::Pad, public ITrainableOperation
+class Pad : public ir::operation::Pad, public TrainableOperation
 {
 private:
   using OperationType = ir::operation::Pad;

--- a/runtime/onert/core/include/ir/train/operation/Permute.h
+++ b/runtime/onert/core/include/ir/train/operation/Permute.h
@@ -18,7 +18,7 @@
 #define __ONERT_IR_TRAIN_OPERATION_PERMUTE_H__
 
 #include "ir/operation/Permute.h"
-#include "ir/train/ITrainableOperation.h"
+#include "ir/train/TrainableOperation.h"
 
 namespace onert
 {
@@ -29,7 +29,7 @@ namespace train
 namespace operation
 {
 
-class Permute : public ir::operation::Permute, public ITrainableOperation
+class Permute : public ir::operation::Permute, public TrainableOperation
 {
 private:
   using OperationType = ir::operation::Permute;

--- a/runtime/onert/core/include/ir/train/operation/Pool2D.h
+++ b/runtime/onert/core/include/ir/train/operation/Pool2D.h
@@ -18,7 +18,7 @@
 #define __ONERT_IR_TRAIN_OPERATION_POOL2D_H__
 
 #include "ir/operation/Pool2D.h"
-#include "ir/train/ITrainableOperation.h"
+#include "ir/train/TrainableOperation.h"
 
 namespace onert
 {
@@ -29,7 +29,7 @@ namespace train
 namespace operation
 {
 
-class Pool2D : public ir::operation::Pool2D, public ITrainableOperation
+class Pool2D : public ir::operation::Pool2D, public TrainableOperation
 {
 private:
   using OperationType = ir::operation::Pool2D;

--- a/runtime/onert/core/include/ir/train/operation/Reduce.h
+++ b/runtime/onert/core/include/ir/train/operation/Reduce.h
@@ -18,7 +18,7 @@
 #define __ONERT_IR_TRAIN_OPERATION_REDUCE_H__
 
 #include "ir/operation/Reduce.h"
-#include "ir/train/ITrainableOperation.h"
+#include "ir/train/TrainableOperation.h"
 
 namespace onert
 {
@@ -29,7 +29,7 @@ namespace train
 namespace operation
 {
 
-class Reduce : public ir::operation::Reduce, public ITrainableOperation
+class Reduce : public ir::operation::Reduce, public TrainableOperation
 {
 private:
   using OperationType = ir::operation::Reduce;

--- a/runtime/onert/core/include/ir/train/operation/Reshape.h
+++ b/runtime/onert/core/include/ir/train/operation/Reshape.h
@@ -18,7 +18,7 @@
 #define __ONERT_IR_TRAIN_OPERATION_RESHAPE_H__
 
 #include "ir/operation/Reshape.h"
-#include "ir/train/ITrainableOperation.h"
+#include "ir/train/TrainableOperation.h"
 
 namespace onert
 {
@@ -29,7 +29,7 @@ namespace train
 namespace operation
 {
 
-class Reshape : public ir::operation::Reshape, public ITrainableOperation
+class Reshape : public ir::operation::Reshape, public TrainableOperation
 {
 private:
   using OperationType = ir::operation::Reshape;

--- a/runtime/onert/core/include/ir/train/operation/Softmax.h
+++ b/runtime/onert/core/include/ir/train/operation/Softmax.h
@@ -18,7 +18,7 @@
 #define __ONERT_IR_TRAIN_OPERATION_SOFTMAX_H__
 
 #include "ir/operation/Softmax.h"
-#include "ir/train/ITrainableOperation.h"
+#include "ir/train/TrainableOperation.h"
 
 namespace onert
 {
@@ -29,7 +29,7 @@ namespace train
 namespace operation
 {
 
-class Softmax : public ir::operation::Softmax, public ITrainableOperation
+class Softmax : public ir::operation::Softmax, public TrainableOperation
 {
 private:
   using OperationType = ir::operation::Softmax;

--- a/runtime/onert/core/include/ir/train/operation/UntrainableOperation.h
+++ b/runtime/onert/core/include/ir/train/operation/UntrainableOperation.h
@@ -17,7 +17,7 @@
 #ifndef __ONERT_IR_TRAIN_OPERATION_UNTRAINABLE_OPERATION_H__
 #define __ONERT_IR_TRAIN_OPERATION_UNTRAINABLE_OPERATION_H__
 
-#include "ir/train/ITrainableOperation.h"
+#include "ir/train/TrainableOperation.h"
 
 #include "ir/OperationVisitor.h"
 #include "ir/train/TrainableOperationVisitor.h"
@@ -37,7 +37,7 @@ namespace operation
 // This class can be removed if all operations are supported for training.
 template <typename OperationType,
           typename = std::enable_if_t<std::is_base_of<Operation, OperationType>::value>>
-class UntrainableOperation : public OperationType, public ITrainableOperation
+class UntrainableOperation : public OperationType, public TrainableOperation
 {
 public:
   UntrainableOperation(const OperationType &operation) : OperationType{operation} {}


### PR DESCRIPTION
This commits extend TrainableOperation API with methods to disable/enable weights update of some particular trainable operations. In trainable operations is stored also status about contribution in backward propagation phase.

ONE-DCO-1.0-Signed-off-by: Mateusz Bencer <m.bencer@partner.samsung.com>

Draft: https://github.com/Samsung/ONE/pull/12951
Issue: https://github.com/Samsung/ONE/issues/12386

/cc @jyoungyun 