### PR TITLE
[luci] Introduce FoldReshapePass

### DIFF
--- a/compiler/luci/pass/include/luci/CircleOptimizer.h
+++ b/compiler/luci/pass/include/luci/CircleOptimizer.h
@@ -61,6 +61,7 @@ public:
       FoldFullyConnected,
       FoldDequantize,
       FoldGather,
+      FoldReshape,
       FoldShape,
       FoldSparseToDense,
       FoldSqueeze,

--- a/compiler/luci/pass/include/luci/Pass/FoldReshapePass.h
+++ b/compiler/luci/pass/include/luci/Pass/FoldReshapePass.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __LUCI_FOLD_RESHAPE_PASS_H__
+#define __LUCI_FOLD_RESHAPE_PASS_H__
+
+#include <logo/Pass.h>
+
+namespace luci
+{
+
+/**
+ * @brief  Class to fold Reshape to a constant tensor
+ *
+ */
+struct FoldReshapePass final : public logo::Pass
+{
+  const char *name(void) const final { return "luci::FoldReshapePass"; }
+
+  bool run(loco::Graph *g) final;
+};
+
+} // namespace luci
+
+#endif // __LUCI_FOLD_RESHAPE_PASS_H__

--- a/compiler/luci/pass/src/CircleOptimizer.cpp
+++ b/compiler/luci/pass/src/CircleOptimizer.cpp
@@ -26,6 +26,7 @@
 #include "luci/Pass/FoldDequantizePass.h"
 #include "luci/Pass/FoldFullyConnectedPass.h"
 #include "luci/Pass/FoldGatherPass.h"
+#include "luci/Pass/FoldReshapePass.h"
 #include "luci/Pass/FoldShapePass.h"
 #include "luci/Pass/FoldSparseToDensePass.h"
 #include "luci/Pass/FoldSqueezePass.h"
@@ -378,6 +379,10 @@ void CircleOptimizer::optimize(loco::Graph *g) const
   if (_options->query(Options::Algorithm::FoldGather))
   {
     phase.emplace_back(std::make_unique<luci::FoldGatherPass>());
+  }
+  if (_options->query(Options::Algorithm::FoldReshape))
+  {
+    phase.emplace_back(std::make_unique<luci::FoldReshapePass>());
   }
   if (_options->query(Options::Algorithm::FoldShape))
   {

--- a/compiler/luci/pass/src/FoldReshapePass.cpp
+++ b/compiler/luci/pass/src/FoldReshapePass.cpp
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Pass/FoldReshapePass.h"
+
+#include <luci/IR/CircleNodes.h>
+#include <luci/Profile/CircleNodeOrigin.h>
+#include <luci/Service/Nodes/CircleConst.h>
+
+namespace
+{
+
+/**
+ * Fold Reshape to const if it has const input
+ **/
+bool fold_reshape(luci::CircleReshape *reshape)
+{
+  // Check const input
+  auto const_input = dynamic_cast<luci::CircleConst *>(reshape->tensor());
+  if (not const_input)
+    return false;
+
+  // Check const shape
+  auto const_shape = dynamic_cast<luci::CircleConst *>(reshape->shape());
+  if (not const_shape)
+    return false;
+
+  // Check all dimensions are known
+  const auto input_rank = const_input->rank();
+  for (uint32_t i = 0; i < input_rank; i++)
+  {
+    if (not const_input->dim(i).known())
+      return false;
+  }
+
+  // Check all dimensions are known
+  const auto shape_rank = const_shape->rank();
+  if (shape_rank != 1)
+    return false;
+
+  if (not const_shape->dim(0).known())
+    return false;
+
+  std::vector<uint32_t> new_shape;
+  switch (const_shape->dtype())
+  {
+    case loco::DataType::S32:
+      for (uint32_t i = 0; i < const_shape->size<loco::DataType::S32>(); i++)
+      {
+        const auto val = const_shape->at<loco::DataType::S32>(i);
+        if (val < 0)
+          return false;
+
+        new_shape.push_back(static_cast<uint32_t>(val));
+      }
+      break;
+    // TODO Support S64
+    default:
+      return false;
+  }
+
+  if (auto input_qparam = const_input->quantparam())
+  {
+    // Only support per-tensor quantization
+    if (input_qparam->scale.size() != 1)
+      return false;
+
+    if (input_qparam->zerop.size() != 1)
+      return false;
+  }
+
+  auto new_const = luci::clone(const_input);
+  new_const->rank(new_shape.size());
+  for (uint32_t i = 0; i < new_shape.size(); i++)
+  {
+    new_const->dim(i).set(new_shape[i]);
+  }
+
+  new_const->shape_status(luci::ShapeStatus::VALID);
+
+  new_const->name(const_input->name() + "_reshaped");
+  luci::add_origin(
+    new_const, luci::composite_origin({luci::get_origin(reshape), luci::get_origin(const_input)}));
+
+  loco::replace(reshape).with(new_const);
+
+  return true;
+}
+
+} // namespace
+
+namespace luci
+{
+
+/**
+ * Constant Folding for Reshape Op
+ **/
+bool FoldReshapePass::run(loco::Graph *g)
+{
+  bool changed = false;
+  for (auto node : loco::active_nodes(loco::output_nodes(g)))
+  {
+    if (auto reshape = dynamic_cast<luci::CircleReshape *>(node))
+    {
+      if (fold_reshape(reshape))
+        changed = true;
+    }
+  }
+
+  return changed;
+}
+
+} // namespace luci

--- a/compiler/luci/pass/src/FoldReshapePass.test.cpp
+++ b/compiler/luci/pass/src/FoldReshapePass.test.cpp
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "luci/Pass/FoldReshapePass.h"
+#include "PassTestGraphs.h"
+
+#include <luci/IR/CircleNodes.h>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+
+std::unique_ptr<luci::CircleQuantParam> gen_qparam(const std::vector<float> &s,
+                                                   const std::vector<int64_t> &zp)
+{
+  auto qparam = std::make_unique<luci::CircleQuantParam>();
+  {
+    for (auto scale : s)
+      qparam->scale.push_back(scale);
+
+    for (auto zerop : zp)
+      qparam->zerop.push_back(zerop);
+  }
+
+  return std::move(qparam);
+}
+
+template <loco::DataType DT> class FoldReshapeTest : public luci::ConstantFoldingAddTestGraph
+{
+public:
+  FoldReshapeTest(std::initializer_list<uint32_t> input_shape,
+                  std::initializer_list<uint32_t> output_shape)
+    : luci::ConstantFoldingAddTestGraph(output_shape, DT)
+  {
+    _reshape = _g.nodes()->template create<luci::CircleReshape>();
+    _x = _g.nodes()->template create<luci::CircleConst>();
+    _shape = _g.nodes()->template create<luci::CircleConst>();
+
+    _reshape->dtype(DT);
+    _x->dtype(DT);
+    _shape->dtype(loco::DataType::S32);
+
+    _reshape->shape(_shape);
+    _x->shape(input_shape);
+    _shape->shape({static_cast<uint32_t>(output_shape.size())});
+
+    uint32_t num_elems = 1;
+    for (auto dim : input_shape)
+      num_elems *= dim;
+
+    _x->size<DT>(num_elems);
+    for (uint32_t i = 0; i < num_elems; i++)
+      _x->at<DT>(i) = i;
+
+    _shape->size<loco::DataType::S32>(output_shape.size());
+    uint32_t i = 0;
+    for (auto dim : output_shape)
+    {
+      _shape->at<loco::DataType::S32>(i++) = static_cast<int32_t>(dim);
+    }
+
+    if (DT == loco::DataType::S16)
+    {
+      _x->quantparam(gen_qparam({1.0}, {0}));
+      _reshape->quantparam(gen_qparam({1.0}, {0}));
+    }
+
+    _reshape->tensor(_x);
+    _reshape->shape(_shape);
+
+    _reshape->name("reshape");
+    _shape->name("shape");
+    _x->name("x");
+  }
+
+  loco::Node *createFoldedPattern() override { return _reshape; }
+
+public:
+  void set_unknown_dim() { _x->dim(0).unset(); }
+  void set_non_per_tensor() { _x->quantparam(gen_qparam({1.0, 2.0}, {0, 0})); }
+
+protected:
+  luci::CircleReshape *_reshape = nullptr;
+  luci::CircleConst *_x = nullptr;
+  luci::CircleConst *_shape = nullptr;
+};
+
+/**
+ *  Graph that has a Reshape Op with constant input
+ *
+ *    BEFORE
+ *
+ *         [CircleConst]
+ *               |
+ *            [Reshape]
+ *
+ *    AFTER
+ *
+ *         [CircleConst]
+ *
+ */
+class FoldFP32ReshapeTest : public FoldReshapeTest<loco::DataType::FLOAT32>, public ::testing::Test
+{
+public:
+  FoldFP32ReshapeTest() : FoldReshapeTest<loco::DataType::FLOAT32>({1, 3}, {3}) {}
+
+  virtual void SetUp() { init(); }
+};
+
+class FoldS16ReshapeTest : public FoldReshapeTest<loco::DataType::S16>, public ::testing::Test
+{
+public:
+  FoldS16ReshapeTest() : FoldReshapeTest<loco::DataType::S16>({1, 3}, {3}) {}
+
+  virtual void SetUp() { init(); }
+};
+
+} // namespace
+
+TEST_F(FoldFP32ReshapeTest, fold_reshape_fp32)
+{
+  luci::FoldReshapePass pass;
+  while (pass.run(graph()))
+    ;
+
+  auto folded_const = getFoldedPattern();
+  EXPECT_NE(nullptr, folded_const);
+
+  // Check type, shape, values of folded const
+  EXPECT_EQ(loco::DataType::FLOAT32, folded_const->dtype());
+  EXPECT_EQ(1, folded_const->rank());
+  EXPECT_EQ(3, folded_const->dim(0).value());
+  EXPECT_EQ(0, folded_const->at<loco::DataType::FLOAT32>(0));
+  EXPECT_EQ(1, folded_const->at<loco::DataType::FLOAT32>(1));
+  EXPECT_EQ(2, folded_const->at<loco::DataType::FLOAT32>(2));
+}
+
+TEST_F(FoldFP32ReshapeTest, fold_reshape_unkown_dim_NEG)
+{
+  set_unknown_dim();
+
+  luci::FoldReshapePass pass;
+  while (pass.run(graph()))
+    ;
+
+  auto folded_const = getFoldedPattern();
+  EXPECT_EQ(nullptr, folded_const);
+}
+
+TEST_F(FoldS16ReshapeTest, fold_reshape_s16)
+{
+  luci::FoldReshapePass pass;
+  while (pass.run(graph()))
+    ;
+
+  auto folded_const = getFoldedPattern();
+  EXPECT_NE(nullptr, folded_const);
+
+  // Check type, shape, values of folded const
+  EXPECT_EQ(loco::DataType::S16, folded_const->dtype());
+  EXPECT_EQ(1, folded_const->rank());
+  EXPECT_EQ(3, folded_const->dim(0).value());
+  EXPECT_EQ(0, folded_const->at<loco::DataType::S16>(0));
+  EXPECT_EQ(1, folded_const->at<loco::DataType::S16>(1));
+  EXPECT_EQ(2, folded_const->at<loco::DataType::S16>(2));
+
+  auto qparam = folded_const->quantparam();
+  EXPECT_NE(nullptr, qparam);
+  EXPECT_EQ(1.0, qparam->scale.at(0));
+  EXPECT_EQ(0, qparam->zerop.at(0));
+}
+
+TEST_F(FoldS16ReshapeTest, fold_non_per_tensor_quant_NEG)
+{
+  set_non_per_tensor();
+
+  luci::FoldReshapePass pass;
+  while (pass.run(graph()))
+    ;
+
+  auto folded_const = getFoldedPattern();
+  EXPECT_EQ(nullptr, folded_const);
+}


### PR DESCRIPTION
This enables constant folding for Reshape Op.

ONE-DCO-1.0-Signed-off-by: Hyukjin Jeong <hj1.jeong@samsung.com>

---
Related to: https://github.com/Samsung/ONE/issues/13016
Draft PR: #13019 