### PR TITLE
[runtime/lib] Move Accumulator class

### DIFF
--- a/runtime/contrib/detection/CMakeLists.txt
+++ b/runtime/contrib/detection/CMakeLists.txt
@@ -7,5 +7,5 @@ nnfw_find_package(Tensorflow REQUIRED)
 list(APPEND SOURCES detection.cpp)
 
 add_executable(detection ${SOURCES})
-target_link_libraries(detection nnfw_lib_misc)
+target_link_libraries(detection nnfw_lib_benchmark)
 target_link_libraries(detection tensorflow-core)

--- a/runtime/contrib/detection/detection.cpp
+++ b/runtime/contrib/detection/detection.cpp
@@ -22,7 +22,7 @@
 #include <cassert>
 #include <cstring>
 
-#include "misc/benchmark.h"
+#include <benchmark/Accumulator.h>
 
 #define CHECK_TF(e)                                \
   {                                                \
@@ -63,7 +63,7 @@ int main(int argc, char **argv)
   {
     std::chrono::milliseconds elapsed(0);
 
-    nnfw::misc::benchmark::measure(elapsed) << [&](void) {
+    benchmark::measure(elapsed) << [&](void) {
       CHECK_TF(sess->Run({{"input_node", input}}, output_nodes, {}, &outputs));
     };
 

--- a/runtime/contrib/mlapse/tfl/CMakeLists.txt
+++ b/runtime/contrib/mlapse/tfl/CMakeLists.txt
@@ -5,7 +5,7 @@ file(GLOB_RECURSE SOURCES "*.cc")
 add_executable(mlapse-tfl ${SOURCES})
 target_include_directories(mlapse-tfl PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(mlapse-tfl nnfw_lib_tflite)
-target_link_libraries(mlapse-tfl nnfw_lib_misc)
+target_link_libraries(mlapse-tfl nnfw_lib_benchmark)
 target_link_libraries(mlapse-tfl tensorflow-lite)
 
 install(TARGETS mlapse-tfl DESTINATION bin)

--- a/runtime/contrib/mlapse/tfl/mlapse/benchmark_runner.cc
+++ b/runtime/contrib/mlapse/tfl/mlapse/benchmark_runner.cc
@@ -16,11 +16,12 @@
 
 #include "mlapse/benchmark_runner.h"
 
-// From 'nnfw_lib_misc'
-#include <misc/benchmark.h>
+// From 'nnfw_lib_benchmark'
+#include <benchmark/Accumulator.h>
 
 // From C++ Standard Library
 #include <cassert>
+#include <stdexcept>
 
 namespace mlapse
 {
@@ -61,7 +62,7 @@ void BenchmarkRunner::run(nnfw::tflite::Session *sess) const
         notify(arg);
       };
 
-      nnfw::misc::benchmark::measure(elapsed) << [&](void) {
+      benchmark::measure(elapsed) << [&](void) {
         if (!sess->run())
         {
           throw std::runtime_error{"run failed"};

--- a/tests/libs/benchmark/include/benchmark/Accumulator.h
+++ b/tests/libs/benchmark/include/benchmark/Accumulator.h
@@ -17,17 +17,13 @@
 /**
  * @file benchmark.h
  * @ingroup COM_AI_RUNTIME
- * @brief This file contains nnfw::misc::benchmark::Accumulator class
+ * @brief This file contains benchmark::Accumulator class
  */
-#ifndef __NNFW_MISC_BENCHMARK_H__
-#define __NNFW_MISC_BENCHMARK_H__
+#ifndef __NNFW_BENCHMARK_ACCUMULATOR_H__
+#define __NNFW_BENCHMARK_ACCUMULATOR_H__
 
 #include <chrono>
 
-namespace nnfw
-{
-namespace misc
-{
 // Benckmark support
 namespace benchmark
 {
@@ -81,7 +77,5 @@ Accumulator<T> &operator<<(Accumulator<T> &&acc, Callable cb)
 template <typename T> Accumulator<T> measure(T &out) { return Accumulator<T>(out); }
 
 } // namespace benchmark
-} // namespace misc
-} // namespace nnfw
 
-#endif // __NNFW_MISC_BENCHMARK_H__
+#endif // __NNFW_BENCHMARK_ACCUMULATOR_H__

--- a/tests/tools/tflite_run/src/tflite_run.cc
+++ b/tests/tools/tflite_run/src/tflite_run.cc
@@ -17,7 +17,6 @@
 #include "args.h"
 #include "tensor_dumper.h"
 #include "tensor_loader.h"
-#include "misc/benchmark.h"
 #include "misc/EnvVar.h"
 #include "misc/fp32.h"
 #include "tflite/Diff.h"


### PR DESCRIPTION
This commit moves the Accumulator class from runtime/libs/misc to tests/libs/benchmark.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: #13009