### PR TITLE
[tools/circle_plus_gen] Add tparam inject feature

### DIFF
--- a/tools/circle_plus_gen/README.md
+++ b/tools/circle_plus_gen/README.md
@@ -22,9 +22,57 @@ This tool tested on python3.8.
     python3 -m pip install -r requirements.txt
     ```
 
-## Inject training hpyerparameters using json file
+## Add training hyperparameters using json file
 
-<!--to be updated -->
+You can add a training hyperparameters to a circle file.
+To begin with, you need to write the hyperparameters in a json file. Here's [an example](./example/train_tparam.json) of a json file.
+
+```bash 
+cat example/train_tparam.json
+
+# {
+#   "optimizer": {
+#       "type": "adam",
+#       "args": {
+#           "learningRate": 0.01,
+#           "beta1": 0.9,
+#           "beta2": 0.999,
+#           "epsilon": 1e-07
+#       }
+#   },
+#   "loss": {
+#       "type": "categorical crossentropy",
+#       "args": {
+#           "fromLogits": true,
+#           "reduction": "sum over batch size"
+#       }
+#   },
+#   "batchSize": 32
+# }
+```
+
+Next, execute the `main.py` script to add the hyperparameters to the `*.circle` file.
+
+```bash
+python3 main.py example/sample.circle example/train_tparam.json out.circle
+
+# expected output
+# 
+# load training hyperparameters
+# {
+#     "optimizer": {
+#         "type": "adam",
+#         "args": {
+#          ... 
+#     },
+#     "batchSize": 32
+# }
+# succesfully add hyperparameters to the circle file
+# saved in out.circle
+```
+
+If you don't give `out.circle` as an argument, the input circle file(here, `example/sample.circle`) will be overwritten. 
+
 
 ## Print training hyperparameters in circle file
 

--- a/tools/circle_plus_gen/lib/circle_plus.py
+++ b/tools/circle_plus_gen/lib/circle_plus.py
@@ -1,3 +1,4 @@
+import flatbuffers
 import typing
 
 from schema import circle_schema_generated as cir_gen
@@ -7,6 +8,7 @@ from lib.train_param import TrainParam
 class CirclePlus():
     ''' Wrapper class of circle_schema_generated.ModelT'''
     TINFO_META_TAG = "CIRCLE_TRAINING"
+    CIRCLE_IDENTIFIER = b"CTR0"
 
     def __init__(self):
         self.model: cir_gen.ModelT = cir_gen.ModelT()
@@ -34,3 +36,41 @@ class CirclePlus():
                 return tparam
 
         return None
+
+    def _add_metadata(self, meta_name, meta_buf):
+        buffer_obj = cir_gen.BufferT()
+        buffer_obj.data = meta_buf
+
+        # If there are train_param, Replace it
+        if self.get_train_param() is not None:
+            for m in self.model.metadata:
+                if m.name.decode("utf-8") == self.TINFO_META_TAG:
+                    self.model.buffers[m.buffer] = buffer_obj
+
+        # There are no train_param, So add a new buffer and metadata
+        else:
+            if self.model.metadata == None:
+                self.model.metadata = []
+
+            if self.model.buffers == None:
+                self.model.buffers = []
+
+            self.model.buffers.append(buffer_obj)
+
+            metadata_obj = cir_gen.MetadataT()
+            metadata_obj.name = meta_name
+            metadata_obj.buffer = len(self.model.buffers) - 1
+            self.model.metadata.append(metadata_obj)
+
+    def set_train_param(self, train_param: TrainParam):
+        '''Add train_param to the model's metadata field'''
+        tparam_buff = train_param.to_buff()
+        self._add_metadata(self.TINFO_META_TAG, tparam_buff)
+
+    def export(self, circle_file: str):
+        '''Export model to the circle file'''
+        builder = flatbuffers.Builder(0)
+        builder.Finish(self.model.Pack(builder), self.CIRCLE_IDENTIFIER)
+
+        with open(circle_file, 'wb') as f:
+            f.write(builder.Output())

--- a/tools/circle_plus_gen/lib/circle_plus.py
+++ b/tools/circle_plus_gen/lib/circle_plus.py
@@ -8,7 +8,7 @@ from lib.train_param import TrainParam
 class CirclePlus():
     ''' Wrapper class of circle_schema_generated.ModelT'''
     TINFO_META_TAG = "CIRCLE_TRAINING"
-    CIRCLE_IDENTIFIER = b"CTR0"
+    CIRCLE_IDENTIFIER = b"CIR0"
 
     def __init__(self):
         self.model: cir_gen.ModelT = cir_gen.ModelT()

--- a/tools/circle_plus_gen/lib/train_param.py
+++ b/tools/circle_plus_gen/lib/train_param.py
@@ -1,3 +1,4 @@
+import flatbuffers
 import json
 
 from lib.utils import *
@@ -7,6 +8,7 @@ from schema import circle_traininfo_generated as ctr_gen
 
 class TrainParam():
     '''Wrapper class of circle_traninfo_generated.ModelTrainingT'''
+    TRAINING_PARAM_IDENTIFIER = b"CTR0"
 
     def __init__(self):
         self.train_param = ctr_gen.ModelTrainingT()
@@ -17,6 +19,12 @@ class TrainParam():
         new_tparam = cls()
         new_tparam.train_param = ctr_gen.ModelTrainingT.InitFromPackedBuf(bytearray(buff))
         return new_tparam
+
+    def to_buff(self):
+        '''Serialize train_param and return its buffer'''
+        builder = flatbuffers.Builder(0)
+        builder.Finish(self.train_param.Pack(builder), self.TRAINING_PARAM_IDENTIFIER)
+        return builder.Output()
 
     @classmethod
     def from_json(cls, json_file: str):

--- a/tools/circle_plus_gen/main.py
+++ b/tools/circle_plus_gen/main.py
@@ -50,13 +50,12 @@ def inject_hparams(in_file, hparams_file, out_file=None) -> None:
     print("load training hyperparameters")
     print(tparams.dump_as_json())
 
-    # TODO: Enable these lines after implementing the methods
-    # circle_model: CirclePlus = CirclePlus.from_file(in_file)
-    # circle_model.set_train_param(tparams)
-    # print("succesfully add hyperparameters to the circle file")
-    #
-    # circle_model.export(out_file)
-    # print(f"saved in {out_file}")
+    circle_model: CirclePlus = CirclePlus.from_file(in_file)
+    circle_model.set_train_param(tparams)
+    print("succesfully add hyperparameters to the circle file")
+
+    circle_model.export(out_file)
+    print(f"saved in {out_file}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds a feature
 - inject training parameters to a circle plus instance.
 - export circle plus instance as a *.circle file

ONE-DCO-1.0-Signed-off-by: seunghui youn <sseung.youn@samsung.com>

* related issue : https://github.com/Samsung/ONE/issues/12650 