### PR TITLE
[onert/test] Move RandomGenerator

### DIFF
--- a/tests/libs/benchmark/CMakeLists.txt
+++ b/tests/libs/benchmark/CMakeLists.txt
@@ -2,4 +2,4 @@ file(GLOB_RECURSE SOURCES "src/*.cpp")
 
 add_library(nnfw_lib_benchmark STATIC ${SOURCES})
 target_include_directories(nnfw_lib_benchmark PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
-target_link_libraries(nnfw_lib_benchmark PRIVATE ${LIB_PTHREAD})
+target_link_libraries(nnfw_lib_benchmark PRIVATE ${LIB_PTHREAD} nnfw_lib_misc)

--- a/tests/libs/benchmark/include/benchmark/RandomGenerator.h
+++ b/tests/libs/benchmark/include/benchmark/RandomGenerator.h
@@ -19,17 +19,15 @@
  * @brief This file contains classes for random value generation
  */
 
-#ifndef __NNFW_MISC_RANDOM_GENERATOR_H__
-#define __NNFW_MISC_RANDOM_GENERATOR_H__
+#ifndef __NNFW_BENCHMARK_RANDOM_GENERATOR_H__
+#define __NNFW_BENCHMARK_RANDOM_GENERATOR_H__
 
 #include "misc/tensor/Shape.h"
 #include "misc/tensor/Index.h"
 
 #include <random>
 
-namespace nnfw
-{
-namespace misc
+namespace benchmark
 {
 
 /**
@@ -82,7 +80,6 @@ template <> bool RandomGenerator::generate<bool>(void);
 template <> int32_t RandomGenerator::generate<int32_t>(void);
 template <> int64_t RandomGenerator::generate<int64_t>(void);
 
-} // namespace misc
-} // namespace nnfw
+} // namespace benchmark
 
-#endif // __NNFW_MISC_RANDOM_GENERATOR_H__
+#endif // __NNFW_BENCHMARK_RANDOM_GENERATOR_H__

--- a/tests/libs/benchmark/src/RandomGenerator.cpp
+++ b/tests/libs/benchmark/src/RandomGenerator.cpp
@@ -14,11 +14,9 @@
  * limitations under the License.
  */
 
-#include "misc/RandomGenerator.h"
+#include "benchmark/RandomGenerator.h"
 
-namespace nnfw
-{
-namespace misc
+namespace benchmark
 {
 
 template <> int8_t RandomGenerator::generate<int8_t>(void)
@@ -107,5 +105,4 @@ template <> int64_t RandomGenerator::generate<int64_t>(void)
   return dist(_rand);
 }
 
-} // namespace misc
-} // namespace nnfw
+} // namespace benchmark

--- a/tests/libs/tflite/CMakeLists.txt
+++ b/tests/libs/tflite/CMakeLists.txt
@@ -12,7 +12,7 @@ add_library(nnfw_lib_tflite STATIC ${SOURCES})
 set_target_properties(nnfw_lib_tflite PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_include_directories(nnfw_lib_tflite PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_link_libraries(nnfw_lib_tflite PUBLIC tensorflow-lite-2.8.0)
-target_link_libraries(nnfw_lib_tflite PUBLIC nnfw_lib_misc)
+target_link_libraries(nnfw_lib_tflite PUBLIC nnfw_lib_misc nnfw_lib_benchmark)
 target_link_libraries(nnfw_lib_tflite PRIVATE ${LIB_PTHREAD} dl)
 target_link_libraries(nnfw_lib_tflite PRIVATE nnfw_common)
 

--- a/tests/libs/tflite/include/tflite/RandomInputInitializer.h
+++ b/tests/libs/tflite/include/tflite/RandomInputInitializer.h
@@ -17,7 +17,7 @@
 #ifndef __NNFW_TFLITE_RANDOM_INPUT_INITIALIZER_H__
 #define __NNFW_TFLITE_RANDOM_INPUT_INITIALIZER_H__
 
-#include <misc/RandomGenerator.h>
+#include <benchmark/RandomGenerator.h>
 
 #include <tensorflow/lite/c/c_api.h>
 
@@ -29,7 +29,7 @@ namespace tflite
 class RandomInputInitializer
 {
 public:
-  RandomInputInitializer(misc::RandomGenerator &randgen) : _randgen{randgen}
+  RandomInputInitializer(benchmark::RandomGenerator &randgen) : _randgen{randgen}
   {
     // DO NOTHING
   }
@@ -37,7 +37,7 @@ public:
   void run(TfLiteInterpreter &interp);
 
 private:
-  nnfw::misc::RandomGenerator &_randgen;
+  benchmark::RandomGenerator &_randgen;
 };
 
 } // namespace tflite

--- a/tests/libs/tflite/src/RandomInputInitializer.cpp
+++ b/tests/libs/tflite/src/RandomInputInitializer.cpp
@@ -26,8 +26,7 @@ namespace tflite
 namespace
 {
 
-template <typename T>
-void setValue(nnfw::misc::RandomGenerator &randgen, const TfLiteTensor *tensor)
+template <typename T> void setValue(benchmark::RandomGenerator &randgen, const TfLiteTensor *tensor)
 {
   auto tensor_view = TensorView<T>::make(tensor);
 

--- a/tests/tools/onert_run/src/randomgen.cc
+++ b/tests/tools/onert_run/src/randomgen.cc
@@ -17,14 +17,14 @@
 #include "randomgen.h"
 #include "nnfw.h"
 #include "nnfw_util.h"
-#include "misc/RandomGenerator.h"
+#include "benchmark/RandomGenerator.h"
 
 #include <iostream>
 
 namespace onert_run
 {
 
-template <class T> void randomData(nnfw::misc::RandomGenerator &randgen, void *data, uint64_t size)
+template <class T> void randomData(benchmark::RandomGenerator &randgen, void *data, uint64_t size)
 {
   for (uint64_t i = 0; i < size; i++)
     reinterpret_cast<T *>(data)[i] = randgen.generate<T>();
@@ -34,7 +34,7 @@ void RandomGenerator::generate(std::vector<Allocation> &inputs)
 {
   // generate random data
   const int seed = 1;
-  nnfw::misc::RandomGenerator randgen{seed, 0.0f, 2.0f};
+  benchmark::RandomGenerator randgen{seed, 0.0f, 2.0f};
   for (uint32_t i = 0; i < inputs.size(); ++i)
   {
     nnfw_tensorinfo ti;

--- a/tests/tools/onert_train/src/randomgen.cc
+++ b/tests/tools/onert_train/src/randomgen.cc
@@ -17,14 +17,14 @@
 #include "randomgen.h"
 #include "nnfw.h"
 #include "nnfw_util.h"
-#include "misc/RandomGenerator.h"
+#include "benchmark/RandomGenerator.h"
 
 #include <iostream>
 
 namespace onert_train
 {
 
-template <class T> void randomData(nnfw::misc::RandomGenerator &randgen, void *data, uint64_t size)
+template <class T> void randomData(benchmark::RandomGenerator &randgen, void *data, uint64_t size)
 {
   for (uint64_t i = 0; i < size; i++)
     reinterpret_cast<T *>(data)[i] = randgen.generate<T>();
@@ -34,7 +34,7 @@ void RandomGenerator::generate(std::vector<Allocation> &inputs)
 {
   // generate random data
   const int seed = 1;
-  nnfw::misc::RandomGenerator randgen{seed, 0.0f, 2.0f};
+  benchmark::RandomGenerator randgen{seed, 0.0f, 2.0f};
   for (uint32_t i = 0; i < inputs.size(); ++i)
   {
     nnfw_tensorinfo ti;

--- a/tests/tools/tflite_comparator/src/tflite_comparator.cc
+++ b/tests/tools/tflite_comparator/src/tflite_comparator.cc
@@ -21,7 +21,7 @@
 
 #include <misc/EnvVar.h>
 #include <misc/fp32.h>
-#include <misc/RandomGenerator.h>
+#include <benchmark/RandomGenerator.h>
 
 #include <tflite/Assert.h>
 #include <tflite/InterpreterSession.h>
@@ -62,7 +62,7 @@ void readData(const std::string &path, std::vector<uint8_t> &dest)
 }
 
 template <typename T>
-void randomData(nnfw::misc::RandomGenerator &randgen, std::vector<uint8_t> &dest)
+void randomData(benchmark::RandomGenerator &randgen, std::vector<uint8_t> &dest)
 {
   size_t elements = dest.size() / sizeof(T);
   assert(dest.size() % sizeof(T) == 0);
@@ -75,7 +75,7 @@ void randomData(nnfw::misc::RandomGenerator &randgen, std::vector<uint8_t> &dest
   memcpy(dest.data(), vec.data(), elements * sizeof(T));
 }
 
-void randomBoolData(nnfw::misc::RandomGenerator &randgen, std::vector<uint8_t> &dest)
+void randomBoolData(benchmark::RandomGenerator &randgen, std::vector<uint8_t> &dest)
 {
   size_t elements = dest.size();
   std::vector<uint8_t> vec(elements);
@@ -242,7 +242,7 @@ int main(const int argc, char **argv)
   }
 
   const int seed = 1; /* TODO Add an option for seed value */
-  nnfw::misc::RandomGenerator randgen{seed, 0.0f, 2.0f};
+  benchmark::RandomGenerator randgen{seed, 0.0f, 2.0f};
 
   for (uint32_t i = 0; i < num_inputs; i++)
   {

--- a/tests/tools/tflite_run/src/tflite_run.cc
+++ b/tests/tools/tflite_run/src/tflite_run.cc
@@ -141,7 +141,7 @@ int main(const int argc, char **argv)
   else
   {
     const int seed = 1; /* TODO Add an option for seed value */
-    nnfw::misc::RandomGenerator randgen{seed, 0.0f, 2.0f};
+    benchmark::RandomGenerator randgen{seed, 0.0f, 2.0f};
 
     RandomInputInitializer initializer{randgen};
     initializer.run(*interpreter);


### PR DESCRIPTION
This commit moves RandomGenerator into tesets/libs/benchmark.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: https://github.com/Samsung/ONE/issues/13009