### PR TITLE
[onert] Separate forward and backward configuration of trainable ops

### DIFF
--- a/runtime/onert/backend/train/KernelGenerator.cc
+++ b/runtime/onert/backend/train/KernelGenerator.cc
@@ -86,12 +86,15 @@ void appendBackPropAccumulator(const ir::train::ITrainableOperation &op,
 {
   for (const auto &input_index : (op.getInputs() | ir::Remove::UNDEFINED))
   {
-    const auto disposable =
-      tensor_reg->getDisposableBackPropTensor(DisposableTensorIndex{op_index, input_index});
-    if (disposable != nullptr)
+    if (op.isRequiredForBackward())
     {
-      auto back_prop = tensor_reg->getBackPropTensor(input_index);
-      seq->append(generateBackPropAccumulator(disposable, back_prop));
+      const auto disposable =
+        tensor_reg->getDisposableBackPropTensor(DisposableTensorIndex{op_index, input_index});
+      if (disposable != nullptr)
+      {
+        auto back_prop = tensor_reg->getBackPropTensor(input_index);
+        seq->append(generateBackPropAccumulator(disposable, back_prop));
+      }
     }
   }
 }
@@ -170,14 +173,19 @@ void KernelGenerator::visit(const ir::train::operation::BinaryArithmetic &node)
   auto lhs_tensor = _tensor_reg->getPortableTensor(lhs_index);
   auto rhs_tensor = _tensor_reg->getPortableTensor(rhs_index);
 
-  auto back_prop_output_tensor = getBackPropOut(output_index);
-  auto back_prop_lhs_tensor = getBackPropIn(node, lhs_index);
-  auto back_prop_rhs_tensor = getBackPropIn(node, rhs_index);
-
   auto fn = std::make_unique<ops::BinaryArithmeticLayer>();
-  fn->configure(lhs_tensor, rhs_tensor, output_tensor, back_prop_lhs_tensor, back_prop_rhs_tensor,
-                back_prop_output_tensor, activation,
-                static_cast<train::ops::ArithmeticType>(arithmetic_type));
+  fn->configure(lhs_tensor, rhs_tensor, output_tensor, activation,
+                static_cast<cpu::ops::ArithmeticType>(arithmetic_type));
+
+  if (node.isRequiredForBackward())
+  {
+    auto back_prop_output_tensor = getBackPropOut(output_index);
+    auto back_prop_lhs_tensor = getBackPropIn(node, lhs_index);
+    auto back_prop_rhs_tensor = getBackPropIn(node, rhs_index);
+
+    fn->configureBackward(back_prop_lhs_tensor, back_prop_rhs_tensor, back_prop_output_tensor,
+                          activation, static_cast<train::ops::ArithmeticType>(arithmetic_type));
+  }
   _return_fn = std::move(fn);
 }
 
@@ -194,11 +202,6 @@ void KernelGenerator::visit(const ir::train::operation::Conv2D &node)
   auto in_tensor = _tensor_reg->getPortableTensor(in_index);
   auto ker_tensor = _tensor_reg->getTrainableTensor(ker_index);
   auto bias_tensor = _tensor_reg->getTrainableTensor(bias_index);
-
-  auto out_back_prop_tensor = getBackPropOut(out_index);
-  auto in_back_prop_tensor = getBackPropIn(node, in_index);
-  auto ker_grad_tensor = _tensor_reg->getGradientTensor(ker_index);
-  auto bias_grad_tensor = _tensor_reg->getGradientTensor(bias_index);
 
   // Generate kernel
   const auto stride = node.param().stride;
@@ -219,17 +222,32 @@ void KernelGenerator::visit(const ir::train::operation::Conv2D &node)
     ir::calculatePadding(param_padding, ifm_shape, ofm_shape, stride, ker_width, ker_height,
                          dilation.width_factor, dilation.height_factor);
 
-  fn->configure(in_tensor, ker_tensor, bias_tensor, out_tensor, in_back_prop_tensor,
-                ker_grad_tensor, bias_grad_tensor, out_back_prop_tensor, param_padding.type,
-                padding.left, padding.right, padding.top, padding.bottom, stride.horizontal,
-                stride.vertical, dilation.width_factor, dilation.height_factor, activation);
+  const bool is_cacheable_weights = false;
+  fn->configure(in_tensor, ker_tensor, bias_tensor, param_padding.type, padding.left, padding.right,
+                padding.top, padding.bottom, stride.horizontal, stride.vertical,
+                dilation.width_factor, dilation.height_factor, activation, out_tensor,
+                is_cacheable_weights);
+
+  auto ker_grad_tensor = _tensor_reg->getGradientTensor(ker_index);
+  auto bias_grad_tensor = _tensor_reg->getGradientTensor(bias_index);
+
+  if (node.isRequiredForBackward())
+  {
+
+    auto out_back_prop_tensor = getBackPropOut(out_index);
+    auto in_back_prop_tensor = getBackPropIn(node, in_index);
+
+    fn->configureBackward(ker_tensor, in_back_prop_tensor, ker_grad_tensor, bias_grad_tensor,
+                          out_back_prop_tensor, activation);
+
+    // Generate GradientApplier
+    if (bias_tensor)
+      _update_funcs.emplace_back(
+        generateGradientApplier(_optimizer, bias_grad_tensor, bias_tensor));
+    _update_funcs.emplace_back(generateGradientApplier(_optimizer, ker_grad_tensor, ker_tensor));
+  }
 
   _return_fn = std::move(fn);
-
-  // Generate GradientApplier
-  if (bias_tensor)
-    _update_funcs.emplace_back(generateGradientApplier(_optimizer, bias_grad_tensor, bias_tensor));
-  _update_funcs.emplace_back(generateGradientApplier(_optimizer, ker_grad_tensor, ker_tensor));
 }
 
 void KernelGenerator::visit(const ir::train::operation::DepthwiseConv2D &node)
@@ -245,11 +263,6 @@ void KernelGenerator::visit(const ir::train::operation::DepthwiseConv2D &node)
   auto ifm_tensor = _tensor_reg->getPortableTensor(ifm_index);
   auto ker_tensor = _tensor_reg->getTrainableTensor(ker_index);
   auto bias_tensor = _tensor_reg->getTrainableTensor(bias_index);
-
-  auto ofm_back_prop_tensor = getBackPropOut(ofm_index);
-  auto ifm_back_prop_tensor = getBackPropIn(node, ifm_index);
-  auto ker_grad_tensor = _tensor_reg->getGradientTensor(ker_index);
-  auto bias_grad_tensor = _tensor_reg->getGradientTensor(bias_index);
 
   const auto stride = node.param().stride;
   const auto &operands = _tgraph.operands();
@@ -268,17 +281,29 @@ void KernelGenerator::visit(const ir::train::operation::DepthwiseConv2D &node)
 
   auto fn = std::make_unique<ops::DepthwiseConvolutionLayer>();
 
-  fn->configure(ifm_tensor, ker_tensor, bias_tensor, ofm_tensor, ifm_back_prop_tensor,
-                ker_grad_tensor, bias_grad_tensor, ofm_back_prop_tensor, padding.left,
-                padding.right, padding.top, padding.bottom, stride.horizontal, stride.vertical,
-                multiplier, dilation_width, dilation_height, activation, _external_context);
+  fn->configure(ifm_tensor, ker_tensor, bias_tensor, padding.left, padding.right, padding.top,
+                padding.bottom, stride.horizontal, stride.vertical, multiplier, dilation_width,
+                dilation_height, activation, ofm_tensor, _external_context);
+
+  if (node.isRequiredForBackward())
+  {
+    auto ker_grad_tensor = _tensor_reg->getGradientTensor(ker_index);
+    auto bias_grad_tensor = _tensor_reg->getGradientTensor(bias_index);
+
+    auto ofm_back_prop_tensor = getBackPropOut(ofm_index);
+    auto ifm_back_prop_tensor = getBackPropIn(node, ifm_index);
+
+    fn->configureBackward(ifm_back_prop_tensor, ker_grad_tensor, bias_grad_tensor,
+                          ofm_back_prop_tensor, activation);
+
+    // Generate GradientApplier
+    if (bias_tensor)
+      _update_funcs.emplace_back(
+        generateGradientApplier(_optimizer, bias_grad_tensor, bias_tensor));
+    _update_funcs.emplace_back(generateGradientApplier(_optimizer, ker_grad_tensor, ker_tensor));
+  }
 
   _return_fn = std::move(fn);
-
-  // Generate GradientApplier
-  if (bias_tensor)
-    _update_funcs.emplace_back(generateGradientApplier(_optimizer, bias_grad_tensor, bias_tensor));
-  _update_funcs.emplace_back(generateGradientApplier(_optimizer, ker_grad_tensor, ker_tensor));
 }
 
 void KernelGenerator::visit(const ir::train::operation::ElementwiseActivation &node)
@@ -291,14 +316,30 @@ void KernelGenerator::visit(const ir::train::operation::ElementwiseActivation &n
   auto output_tensor = _tensor_reg->getPortableTensor(output_index);
   auto input_tensor = _tensor_reg->getPortableTensor(input_index);
 
-  auto back_prop_input_tensor = getBackPropIn(node, input_index);
-  auto back_prop_output_tensor = getBackPropOut(output_index);
-
   auto fn = std::make_unique<ops::ElementwiseActivationLayer>();
 
-  fn->configure(input_tensor, output_tensor, back_prop_input_tensor, back_prop_output_tensor,
-                node.param().alpha, node.param().beta,
-                convertElementwiseActivationType(node.param().op_type));
+  auto convertToInferActivationType = [](const ir::operation::ElementwiseActivation::Type &type) {
+    switch (type)
+    {
+      case ir::operation::ElementwiseActivation::Type::RELU:
+        return cpu::ops::ElementwiseActivationType::kReLU;
+      default:
+        throw std::invalid_argument("Unsupported ElementwiseActivation::Type");
+    }
+  };
+
+  fn->configure(input_tensor, output_tensor, node.param().alpha, node.param().beta,
+                convertToInferActivationType(node.param().op_type));
+
+  if (node.isRequiredForBackward())
+  {
+    auto back_prop_input_tensor = getBackPropIn(node, input_index);
+    auto back_prop_output_tensor = getBackPropOut(output_index);
+
+    fn->configureBackward(input_tensor, back_prop_input_tensor, back_prop_output_tensor,
+                          node.param().alpha, node.param().beta,
+                          convertElementwiseActivationType(node.param().op_type));
+  }
 
   _return_fn = std::move(fn);
 }
@@ -317,28 +358,35 @@ void KernelGenerator::visit(const ir::train::operation::FullyConnected &node)
   auto weights_tensor = _tensor_reg->getTrainableTensor(weights_index);
   auto bias_tensor = _tensor_reg->getTrainableTensor(bias_index);
 
-  auto out_back_prop_tensor = getBackPropOut(out_index);
-  auto in_back_prop_tensor = getBackPropIn(node, in_index);
-  auto weights_grad_tensor = _tensor_reg->getGradientTensor(weights_index);
-  auto bias_grad_tensor = _tensor_reg->getGradientTensor(bias_index);
-
   // Generate kernel
   const auto activation = node.param().activation;
   const auto weights_format = node.param().weights_format;
 
   auto fn = std::make_unique<ops::FullyConnectedLayer>();
 
-  fn->configure(in_tensor, weights_tensor, bias_tensor, out_tensor, in_back_prop_tensor,
-                weights_grad_tensor, bias_grad_tensor, out_back_prop_tensor, activation,
-                weights_format, _external_context);
+  fn->configure(in_tensor, weights_tensor, bias_tensor, activation, weights_format, out_tensor,
+                _external_context);
+
+  if (node.isRequiredForBackward())
+  {
+    auto out_back_prop_tensor = getBackPropOut(out_index);
+    auto in_back_prop_tensor = getBackPropIn(node, in_index);
+    auto weights_grad_tensor = _tensor_reg->getGradientTensor(weights_index);
+    auto bias_grad_tensor = _tensor_reg->getGradientTensor(bias_index);
+
+    fn->configureBackward(in_tensor, weights_tensor, out_tensor, in_back_prop_tensor,
+                          weights_grad_tensor, bias_grad_tensor, out_back_prop_tensor, activation,
+                          weights_format);
+
+    // Generate GradientAppliers
+    if (bias_tensor)
+      _update_funcs.emplace_back(
+        generateGradientApplier(_optimizer, bias_grad_tensor, bias_tensor));
+    _update_funcs.emplace_back(
+      generateGradientApplier(_optimizer, weights_grad_tensor, weights_tensor));
+  }
 
   _return_fn = std::move(fn);
-
-  // Generate GradientAppliers
-  if (bias_tensor)
-    _update_funcs.emplace_back(generateGradientApplier(_optimizer, bias_grad_tensor, bias_tensor));
-  _update_funcs.emplace_back(
-    generateGradientApplier(_optimizer, weights_grad_tensor, weights_tensor));
 }
 
 void KernelGenerator::visit(const ir::train::operation::Loss &node)
@@ -402,10 +450,13 @@ void KernelGenerator::visit(const ir::train::operation::Pad &node)
     value = _tensor_reg->getPortableTensor(value_index);
   }
 
-  auto out_back_prop_tensor = getBackPropOut(output_index);
-  auto in_back_prop_tensor = getBackPropIn(node, input_index);
-
-  fn->configure(input, pad, value, output, in_back_prop_tensor, out_back_prop_tensor);
+  fn->configure(input, pad, value, output);
+  if (node.isRequiredForBackward())
+  {
+    auto out_back_prop_tensor = getBackPropOut(output_index);
+    auto in_back_prop_tensor = getBackPropIn(node, input_index);
+    fn->configureBackward(in_back_prop_tensor, out_back_prop_tensor);
+  }
   _return_fn = std::move(fn);
 }
 
@@ -436,17 +487,33 @@ void KernelGenerator::visit(const ir::train::operation::Pool2D &node)
   auto out_tensor = _tensor_reg->getPortableTensor(output_index);
   auto in_tensor = _tensor_reg->getPortableTensor(input_index);
 
-  auto out_back_prop_tensor = getBackPropOut(output_index);
-  auto in_back_prop_tensor = getBackPropIn(node, input_index);
-
   const auto activation = node.param().activation;
   const auto pool_type = convertPoolType(node.param().op_type);
 
   auto fn = std::make_unique<ops::PoolLayer>();
 
+  auto convertToInferPoolType = [](const train::ops::PoolType &pool_type) {
+    switch (pool_type)
+    {
+      case train::ops::PoolType::kMax:
+        return cpu::ops::PoolType::kMax;
+      default:
+        throw std::runtime_error("PoolLayer: Unsupported pool type yet");
+    }
+  };
+
   fn->configure(in_tensor, padding.left, padding.right, padding.top, padding.bottom,
-                stride.horizontal, stride.vertical, kw, kh, activation, out_tensor, pool_type,
-                in_back_prop_tensor, out_back_prop_tensor);
+                stride.horizontal, stride.vertical, kw, kh, activation, out_tensor,
+                convertToInferPoolType(pool_type));
+
+  if (node.isRequiredForBackward())
+  {
+    auto out_back_prop_tensor = getBackPropOut(output_index);
+    auto in_back_prop_tensor = getBackPropIn(node, input_index);
+    fn->configureBackward(padding.left, padding.right, padding.top, padding.bottom,
+                          stride.horizontal, stride.vertical, kw, kh, activation, pool_type,
+                          out_tensor, in_back_prop_tensor, out_back_prop_tensor);
+  }
 
   _return_fn = std::move(fn);
 }
@@ -465,14 +532,16 @@ void KernelGenerator::visit(const ir::train::operation::Reduce &node)
   auto input_tensor = _tensor_reg->getPortableTensor(input_index);
   auto axes_tensor = _tensor_reg->getPortableTensor(axes_index);
 
-  auto back_prop_output_tensor = getBackPropOut(output_index);
-  auto back_prop_input_tensor = getBackPropIn(node, input_index);
-
   if (node.param().reduce_type == ir::operation::Reduce::ReduceType::MEAN)
   {
     auto fn = std::make_unique<ops::MeanLayer>();
-    fn->configure(input_tensor, axes_tensor, output_tensor, keep_dims, back_prop_input_tensor,
-                  back_prop_output_tensor);
+    fn->configure(input_tensor, axes_tensor, output_tensor, keep_dims);
+    if (node.isRequiredForBackward())
+    {
+      auto back_prop_output_tensor = getBackPropOut(output_index);
+      auto back_prop_input_tensor = getBackPropIn(node, input_index);
+      fn->configureBackward(back_prop_input_tensor, back_prop_output_tensor);
+    }
     _return_fn = std::move(fn);
   }
   else
@@ -491,9 +560,6 @@ void KernelGenerator::visit(const ir::train::operation::Reshape &node)
   auto output_tensor = _tensor_reg->getPortableTensor(output_index);
   auto input_tensor = _tensor_reg->getPortableTensor(input_index);
 
-  auto output_back_prop_tensor = getBackPropOut(output_index);
-  auto input_back_prop_tensor = getBackPropIn(node, input_index);
-
   // optional 2nd input
   IPortableTensor *shape_tensor = nullptr;
 
@@ -505,8 +571,13 @@ void KernelGenerator::visit(const ir::train::operation::Reshape &node)
 
   auto fn = std::make_unique<ops::ReshapeLayer>();
 
-  fn->configure(input_tensor, shape_tensor, output_tensor, input_back_prop_tensor,
-                output_back_prop_tensor);
+  fn->configure(input_tensor, shape_tensor, output_tensor);
+  if (node.isRequiredForBackward())
+  {
+    auto output_back_prop_tensor = getBackPropOut(output_index);
+    auto input_back_prop_tensor = getBackPropIn(node, input_index);
+    fn->configureBackward(input_back_prop_tensor, output_back_prop_tensor);
+  }
   _return_fn = std::move(fn);
 }
 
@@ -522,12 +593,16 @@ void KernelGenerator::visit(const ir::train::operation::Softmax &node)
   auto output_tensor = _tensor_reg->getPortableTensor(output_index);
   auto input_tensor = _tensor_reg->getPortableTensor(input_index);
 
-  auto output_back_prop_tensor = getBackPropOut(output_index);
-  auto input_back_prop_tensor = getBackPropIn(node, input_index);
-
   auto fn = std::make_unique<ops::SoftMaxLayer>();
 
-  fn->configure(input_tensor, beta, output_tensor, input_back_prop_tensor, output_back_prop_tensor);
+  fn->configure(input_tensor, beta, output_tensor);
+
+  if (node.isRequiredForBackward())
+  {
+    auto output_back_prop_tensor = getBackPropOut(output_index);
+    auto input_back_prop_tensor = getBackPropIn(node, input_index);
+    fn->configureBackward(input_back_prop_tensor, output_back_prop_tensor);
+  }
   _return_fn = std::move(fn);
 }
 

--- a/runtime/onert/backend/train/ops/BinaryArithmeticLayer.cc
+++ b/runtime/onert/backend/train/ops/BinaryArithmeticLayer.cc
@@ -41,16 +41,12 @@ BinaryArithmeticLayer::BinaryArithmeticLayer()
   // DO NOTHING
 }
 
-void BinaryArithmeticLayer::configure(const IPortableTensor *lhs, const IPortableTensor *rhs,
-                                      IPortableTensor *output, IPortableTensor *back_prop_lhs,
-                                      IPortableTensor *back_prop_rhs,
-                                      const IPortableTensor *back_prop_output,
-                                      const ir::Activation activation,
-                                      const ArithmeticType arithmetic_type)
+void BinaryArithmeticLayer::configureBackward(IPortableTensor *back_prop_lhs,
+                                              IPortableTensor *back_prop_rhs,
+                                              const IPortableTensor *back_prop_output,
+                                              const ir::Activation activation,
+                                              const ArithmeticType arithmetic_type)
 {
-  cpu::ops::BinaryArithmeticLayer::configure(
-    lhs, rhs, output, activation, static_cast<cpu::ops::ArithmeticType>(arithmetic_type));
-
   _back_prop_lhs = back_prop_lhs;
   _back_prop_rhs = back_prop_rhs;
   _back_prop_output = back_prop_output;

--- a/runtime/onert/backend/train/ops/BinaryArithmeticLayer.h
+++ b/runtime/onert/backend/train/ops/BinaryArithmeticLayer.h
@@ -47,10 +47,9 @@ public:
   BinaryArithmeticLayer();
 
 public:
-  void configure(const IPortableTensor *lhs, const IPortableTensor *rhs, IPortableTensor *output,
-                 IPortableTensor *back_prop_lhs, IPortableTensor *back_prop_rhs,
-                 const IPortableTensor *back_prop_output, const ir::Activation activation,
-                 const ArithmeticType arithmetic_type);
+  void configureBackward(IPortableTensor *back_prop_lhs, IPortableTensor *back_prop_rhs,
+                         const IPortableTensor *back_prop_output, const ir::Activation activation,
+                         const ArithmeticType arithmetic_type);
   void forward(bool training) override;
   void backward() override;
 

--- a/runtime/onert/backend/train/ops/ConvolutionLayer.cc
+++ b/runtime/onert/backend/train/ops/ConvolutionLayer.cc
@@ -65,21 +65,12 @@ ConvolutionLayer::ConvolutionLayer()
 
 ConvolutionLayer::~ConvolutionLayer() = default;
 
-void ConvolutionLayer::configure(
-  const IPortableTensor *input, const IPortableTensor *weights, const IPortableTensor *bias,
-  IPortableTensor *output, IPortableTensor *back_prop_input, IPortableTensor *grad_weights,
-  IPortableTensor *grad_bias, const IPortableTensor *back_prop_output, ir::PaddingType paddingType,
-  const uint32_t paddingLeft, const uint32_t paddingRight, const uint32_t paddingTop,
-  const uint32_t paddingBottom, const uint32_t strideWidth, const uint32_t strideHeight,
-  const uint32_t dilationWidthFactor, const uint32_t dilationHeightFactor,
-  const ir::Activation activation)
+void ConvolutionLayer::configureBackward(const IPortableTensor *weights,
+                                         IPortableTensor *back_prop_input,
+                                         IPortableTensor *grad_weights, IPortableTensor *grad_bias,
+                                         const IPortableTensor *back_prop_output,
+                                         const ir::Activation activation)
 {
-  const bool is_cacheable_weights = false;
-  cpu::ops::ConvolutionLayer::configure(input, weights, bias, paddingType, paddingLeft,
-                                        paddingRight, paddingTop, paddingBottom, strideWidth,
-                                        strideHeight, dilationWidthFactor, dilationHeightFactor,
-                                        activation, output, is_cacheable_weights);
-
   _back_prop_input = back_prop_input;
   _grad_weights = grad_weights;
   _grad_bias = grad_bias;

--- a/runtime/onert/backend/train/ops/ConvolutionLayer.h
+++ b/runtime/onert/backend/train/ops/ConvolutionLayer.h
@@ -38,15 +38,9 @@ public:
   ConvolutionLayer();
   ~ConvolutionLayer();
 
-  void configure(const IPortableTensor *input, const IPortableTensor *weights,
-                 const IPortableTensor *bias, IPortableTensor *output,
-                 IPortableTensor *back_prop_input, IPortableTensor *grad_weights,
-                 IPortableTensor *grad_bias, const IPortableTensor *back_prop_output,
-                 ir::PaddingType paddingType, const uint32_t paddingLeft,
-                 const uint32_t paddingRight, const uint32_t paddingTop,
-                 const uint32_t paddingBottom, const uint32_t strideWidth,
-                 const uint32_t strideHeight, const uint32_t dilationWidthFactor,
-                 const uint32_t dilationHeightFactor, const ir::Activation activation);
+  void configureBackward(const IPortableTensor *weights, IPortableTensor *back_prop_input,
+                         IPortableTensor *grad_weights, IPortableTensor *grad_bias,
+                         const IPortableTensor *back_prop_output, const ir::Activation activation);
   void forward(bool training) override;
   void backward() override;
 

--- a/runtime/onert/backend/train/ops/DepthwiseConvolutionLayer.cc
+++ b/runtime/onert/backend/train/ops/DepthwiseConvolutionLayer.cc
@@ -39,18 +39,12 @@ DepthwiseConvolutionLayer::DepthwiseConvolutionLayer()
   // DO NOTHING
 }
 
-void DepthwiseConvolutionLayer::configure(
-  const IPortableTensor *input, const IPortableTensor *kernel, const IPortableTensor *bias,
-  IPortableTensor *output, IPortableTensor *back_prop_input, IPortableTensor *grad_weights,
-  IPortableTensor *grad_bias, const IPortableTensor *back_prop_output, const uint32_t paddingLeft,
-  const uint32_t paddingRight, const uint32_t paddingTop, const uint32_t paddingBottom,
-  const uint32_t strideWidth, const uint32_t strideHeight, const uint32_t multiplier,
-  const uint32_t dilationWidth, const uint32_t dilationHeight, const ir::Activation activation,
-  const std::shared_ptr<ExternalContext> &external_context)
+void DepthwiseConvolutionLayer::configureBackward(IPortableTensor *back_prop_input,
+                                                  IPortableTensor *grad_weights,
+                                                  IPortableTensor *grad_bias,
+                                                  const IPortableTensor *back_prop_output,
+                                                  const ir::Activation activation)
 {
-  cpu::ops::DepthwiseConvolutionLayer::configure(
-    input, kernel, bias, paddingLeft, paddingRight, paddingTop, paddingBottom, strideWidth,
-    strideHeight, multiplier, dilationWidth, dilationHeight, activation, output, external_context);
   _back_prop_input = back_prop_input;
   _back_prop_output = back_prop_output;
   _grad_weights = grad_weights;

--- a/runtime/onert/backend/train/ops/DepthwiseConvolutionLayer.h
+++ b/runtime/onert/backend/train/ops/DepthwiseConvolutionLayer.h
@@ -40,16 +40,9 @@ class DepthwiseConvolutionLayer : public ::onert::exec::train::ITrainableFunctio
 public:
   DepthwiseConvolutionLayer();
 
-  void configure(const IPortableTensor *input, const IPortableTensor *kernel,
-                 const IPortableTensor *bias, IPortableTensor *output,
-                 IPortableTensor *back_prop_input, IPortableTensor *grad_weights,
-                 IPortableTensor *grad_bias, const IPortableTensor *back_prop_output,
-                 const uint32_t paddingLeft, const uint32_t paddingRight, const uint32_t paddingTop,
-                 const uint32_t paddingBottom, const uint32_t strideWidth,
-                 const uint32_t strideHeight, const uint32_t multiplier,
-                 const uint32_t dilationWidth, const uint32_t dilationHeight,
-                 const ir::Activation activation,
-                 const std::shared_ptr<ExternalContext> &external_context);
+  void configureBackward(IPortableTensor *back_prop_input, IPortableTensor *grad_weights,
+                         IPortableTensor *grad_bias, const IPortableTensor *back_prop_output,
+                         const ir::Activation activation);
   void forward(bool training) override;
   void backward() override;
 

--- a/runtime/onert/backend/train/ops/ElementwiseActivationLayer.cc
+++ b/runtime/onert/backend/train/ops/ElementwiseActivationLayer.cc
@@ -35,13 +35,13 @@ ElementwiseActivationLayer::ElementwiseActivationLayer() : cpu::ops::Elementwise
   // DO NOTHING
 }
 
-void ElementwiseActivationLayer::configure(const IPortableTensor *input, IPortableTensor *output,
-                                           IPortableTensor *back_prop_input,
-                                           const IPortableTensor *back_prop_output, float alpha,
-                                           float beta, ElementwiseActivationType op_type)
+void ElementwiseActivationLayer::configureBackward(const IPortableTensor *input,
+                                                   IPortableTensor *back_prop_input,
+                                                   const IPortableTensor *back_prop_output,
+                                                   float alpha, float beta,
+                                                   ElementwiseActivationType op_type)
 {
   assert(input != nullptr);
-  assert(output != nullptr);
   assert(back_prop_input != nullptr);
   assert(back_prop_output != nullptr);
 
@@ -57,9 +57,6 @@ void ElementwiseActivationLayer::configure(const IPortableTensor *input, IPortab
       {
         if ((alpha == std::numeric_limits<float>::infinity() || alpha == 6.0f) && beta == 0.f)
         {
-          cpu::ops::ElementwiseActivationLayer::configure(
-            input, output, alpha, beta, cpu::ops::ElementwiseActivationType::kReLU);
-
           auto relu_cker = [&alpha]() {
             if (alpha == std::numeric_limits<float>::infinity())
               return nnfw::cker::train::ReLUGrad;

--- a/runtime/onert/backend/train/ops/ElementwiseActivationLayer.h
+++ b/runtime/onert/backend/train/ops/ElementwiseActivationLayer.h
@@ -42,9 +42,9 @@ class ElementwiseActivationLayer : public ::onert::exec::train::ITrainableFuncti
 public:
   ElementwiseActivationLayer();
 
-  void configure(const IPortableTensor *input, IPortableTensor *output,
-                 IPortableTensor *back_prop_input, const IPortableTensor *back_prop_output,
-                 float alpha, float beta, ElementwiseActivationType op_type);
+  void configureBackward(const IPortableTensor *input, IPortableTensor *back_prop_input,
+                         const IPortableTensor *back_prop_output, float alpha, float beta,
+                         ElementwiseActivationType op_type);
   void forward(bool training) override;
   void backward() override;
 

--- a/runtime/onert/backend/train/ops/FullyConnectedLayer.cc
+++ b/runtime/onert/backend/train/ops/FullyConnectedLayer.cc
@@ -63,18 +63,12 @@ FullyConnectedLayer::FullyConnectedLayer()
 
 FullyConnectedLayer::~FullyConnectedLayer() = default;
 
-void FullyConnectedLayer::configure(const IPortableTensor *input, const IPortableTensor *weights,
-                                    const IPortableTensor *bias, IPortableTensor *output,
-                                    IPortableTensor *back_prop_input, IPortableTensor *grad_weights,
-                                    IPortableTensor *grad_bias,
-                                    const IPortableTensor *back_prop_output,
-                                    ir::Activation activation,
-                                    ir::FullyConnectedWeightsFormat weights_format,
-                                    const std::shared_ptr<train::ExternalContext> &external_context)
+void FullyConnectedLayer::configureBackward(
+  const IPortableTensor *input, const IPortableTensor *weights, IPortableTensor *output,
+  IPortableTensor *back_prop_input, IPortableTensor *grad_weights, IPortableTensor *grad_bias,
+  const IPortableTensor *back_prop_output, ir::Activation activation,
+  ir::FullyConnectedWeightsFormat weights_format)
 {
-  cpu::ops::FullyConnectedLayer::configure(input, weights, bias, activation, weights_format, output,
-                                           external_context);
-
   _back_prop_input = back_prop_input;
   _grad_weights = grad_weights;
   _grad_bias = grad_bias;

--- a/runtime/onert/backend/train/ops/FullyConnectedLayer.h
+++ b/runtime/onert/backend/train/ops/FullyConnectedLayer.h
@@ -40,12 +40,11 @@ public:
   ~FullyConnectedLayer();
 
 public:
-  void configure(const IPortableTensor *input, const IPortableTensor *weights,
-                 const IPortableTensor *bias, IPortableTensor *output,
-                 IPortableTensor *back_prop_input, IPortableTensor *grad_weights,
-                 IPortableTensor *grad_bias, const IPortableTensor *back_prop_output,
-                 ir::Activation activation, ir::FullyConnectedWeightsFormat weights_format,
-                 const std::shared_ptr<train::ExternalContext> &external_context);
+  void configureBackward(const IPortableTensor *input, const IPortableTensor *weights,
+                         IPortableTensor *output, IPortableTensor *back_prop_input,
+                         IPortableTensor *grad_weights, IPortableTensor *grad_bias,
+                         const IPortableTensor *back_prop_output, ir::Activation activation,
+                         ir::FullyConnectedWeightsFormat weights_format);
 
   void forward(bool training) override;
   void backward() override;

--- a/runtime/onert/backend/train/ops/MeanLayer.cc
+++ b/runtime/onert/backend/train/ops/MeanLayer.cc
@@ -37,12 +37,9 @@ MeanLayer::MeanLayer()
   // DO NOTHING
 }
 
-void MeanLayer::configure(const IPortableTensor *input, const IPortableTensor *axes,
-                          IPortableTensor *output, bool keep_dims, IPortableTensor *back_prop_input,
-                          const IPortableTensor *back_prop_output)
+void MeanLayer::configureBackward(IPortableTensor *back_prop_input,
+                                  const IPortableTensor *back_prop_output)
 {
-  cpu::ops::MeanLayer::configure(input, axes, output, keep_dims);
-
   _back_prop_input = back_prop_input;
   _back_prop_output = back_prop_output;
 }

--- a/runtime/onert/backend/train/ops/MeanLayer.h
+++ b/runtime/onert/backend/train/ops/MeanLayer.h
@@ -37,9 +37,7 @@ public:
   MeanLayer();
 
 public:
-  void configure(const IPortableTensor *input, const IPortableTensor *axes, IPortableTensor *output,
-                 bool keep_dims, IPortableTensor *back_prop_input,
-                 const IPortableTensor *back_prop_output);
+  void configureBackward(IPortableTensor *back_prop_input, const IPortableTensor *back_prop_output);
   void forward(bool training) override;
   void backward() override;
 

--- a/runtime/onert/backend/train/ops/PadLayer.cc
+++ b/runtime/onert/backend/train/ops/PadLayer.cc
@@ -43,11 +43,9 @@ template <typename T> void PadLayer::depad()
                               getBuffer<T>(_back_prop_input));
 }
 
-void PadLayer::configure(const IPortableTensor *input, const IPortableTensor *pad,
-                         const IPortableTensor *value, IPortableTensor *output,
-                         IPortableTensor *back_prop_input, const IPortableTensor *back_prop_output)
+void PadLayer::configureBackward(IPortableTensor *back_prop_input,
+                                 const IPortableTensor *back_prop_output)
 {
-  cpu::ops::PadLayer::configure(input, pad, value, output);
   _back_prop_input = back_prop_input;
   _back_prop_output = back_prop_output;
 }

--- a/runtime/onert/backend/train/ops/PadLayer.h
+++ b/runtime/onert/backend/train/ops/PadLayer.h
@@ -42,9 +42,7 @@ public:
 public:
   template <typename T> void depad();
 
-  void configure(const IPortableTensor *input, const IPortableTensor *pad,
-                 const IPortableTensor *value, IPortableTensor *output,
-                 IPortableTensor *back_prop_input, const IPortableTensor *back_prop_output);
+  void configureBackward(IPortableTensor *back_prop_input, const IPortableTensor *back_prop_output);
   void forward(bool training) override;
   void backward() override;
 

--- a/runtime/onert/backend/train/ops/PoolLayer.cc
+++ b/runtime/onert/backend/train/ops/PoolLayer.cc
@@ -34,17 +34,6 @@ namespace ops
 namespace
 {
 
-cpu::ops::PoolType convertToInfer(const train::ops::PoolType &pool_type)
-{
-  switch (pool_type)
-  {
-    case train::ops::PoolType::kMax:
-      return cpu::ops::PoolType::kMax;
-    default:
-      throw std::runtime_error("PoolLayer: Unsupported pool type yet");
-  }
-}
-
 class MaxPool2D final : public TrainingKernelRegistry
 {
 private:
@@ -131,24 +120,16 @@ PoolLayer::PoolLayer()
   // DO NOTHING
 }
 
-void PoolLayer::configure(const IPortableTensor *input, const uint32_t paddingLeft,
-                          const uint32_t paddingRight, const uint32_t paddingTop,
-                          const uint32_t paddingBottom, const uint32_t strideWidth,
-                          const uint32_t strideHeight, const uint32_t kernelWidth,
-                          const uint32_t kernelHeight, const ir::Activation activation,
-                          IPortableTensor *output, const PoolType op_type,
-                          IPortableTensor *back_prop_input, const IPortableTensor *back_prop_output)
+void PoolLayer::configureBackward(const uint32_t paddingLeft, const uint32_t paddingRight,
+                                  const uint32_t paddingTop, const uint32_t paddingBottom,
+                                  const uint32_t strideWidth, const uint32_t strideHeight,
+                                  const uint32_t kernelWidth, const uint32_t kernelHeight,
+                                  const ir::Activation activation, const PoolType op_type,
+                                  IPortableTensor *output, IPortableTensor *back_prop_input,
+                                  const IPortableTensor *back_prop_output)
 {
-  _input = input;
-  _output = output;
-
   _back_prop_output = back_prop_output;
   _back_prop_input = back_prop_input;
-
-  // ready inference kernel
-  cpu::ops::PoolLayer::configure(input, paddingLeft, paddingRight, paddingTop, paddingBottom,
-                                 strideWidth, strideHeight, kernelWidth, kernelHeight, activation,
-                                 output, convertToInfer(op_type));
 
   if (output->data_type() != OperandType::FLOAT32)
   {

--- a/runtime/onert/backend/train/ops/PoolLayer.h
+++ b/runtime/onert/backend/train/ops/PoolLayer.h
@@ -53,13 +53,13 @@ public:
   PoolLayer();
 
 public:
-  void configure(const IPortableTensor *input, const uint32_t paddingLeft,
-                 const uint32_t paddingRight, const uint32_t paddingTop,
-                 const uint32_t paddingBottom, const uint32_t strideWidth,
-                 const uint32_t strideHeight, const uint32_t kernelWidth,
-                 const uint32_t kernelHeight, const ir::Activation activation,
-                 IPortableTensor *output, const PoolType op_type, IPortableTensor *back_prop_input,
-                 const IPortableTensor *back_prop_output);
+  void configureBackward(const uint32_t paddingLeft, const uint32_t paddingRight,
+                         const uint32_t paddingTop, const uint32_t paddingBottom,
+                         const uint32_t strideWidth, const uint32_t strideHeight,
+                         const uint32_t kernelWidth, const uint32_t kernelHeight,
+                         const ir::Activation activation, const PoolType op_type,
+                         IPortableTensor *output, IPortableTensor *back_prop_input,
+                         const IPortableTensor *back_prop_output);
 
   void forward(bool training) override;
   void backward() override;

--- a/runtime/onert/backend/train/ops/ReshapeLayer.cc
+++ b/runtime/onert/backend/train/ops/ReshapeLayer.cc
@@ -39,14 +39,17 @@ void ReshapeLayer::reshapeGeneric(const IPortableTensor *input, IPortableTensor 
 }
 
 void ReshapeLayer::configure(const IPortableTensor *input, const IPortableTensor *shape,
-                             IPortableTensor *output, IPortableTensor *back_prop_input,
-                             const IPortableTensor *back_prop_output)
+                             IPortableTensor *output)
 {
   _input = input;
   /* note : shape is optional. If not provided from model, _shape is nullptr. */
   _shape = shape;
   _output = output;
+}
 
+void ReshapeLayer::configureBackward(IPortableTensor *back_prop_input,
+                                     const IPortableTensor *back_prop_output)
+{
   _back_prop_input = back_prop_input;
   _back_prop_output = back_prop_output;
 }

--- a/runtime/onert/backend/train/ops/ReshapeLayer.h
+++ b/runtime/onert/backend/train/ops/ReshapeLayer.h
@@ -37,8 +37,8 @@ public:
 
 public:
   void configure(const IPortableTensor *input, const IPortableTensor *shape,
-                 IPortableTensor *output, IPortableTensor *back_prop_input,
-                 const IPortableTensor *back_prop_output);
+                 IPortableTensor *output);
+  void configureBackward(IPortableTensor *back_prop_input, const IPortableTensor *back_prop_output);
   void forward(bool training) override;
   void backward() override;
 

--- a/runtime/onert/backend/train/ops/SoftMaxLayer.cc
+++ b/runtime/onert/backend/train/ops/SoftMaxLayer.cc
@@ -35,12 +35,9 @@ SoftMaxLayer::SoftMaxLayer()
   // DO NOTHING
 }
 
-void SoftMaxLayer::configure(const IPortableTensor *input, const float beta,
-                             IPortableTensor *output, IPortableTensor *back_prop_input,
-                             const IPortableTensor *back_prop_output)
+void SoftMaxLayer::configureBackward(IPortableTensor *back_prop_input,
+                                     const IPortableTensor *back_prop_output)
 {
-  cpu::ops::SoftMaxLayer::configure(input, beta, output);
-
   _back_prop_input = back_prop_input;
   _back_prop_output = back_prop_output;
 }

--- a/runtime/onert/backend/train/ops/SoftMaxLayer.h
+++ b/runtime/onert/backend/train/ops/SoftMaxLayer.h
@@ -37,8 +37,7 @@ public:
   SoftMaxLayer();
 
 public:
-  void configure(const IPortableTensor *input, const float beta, IPortableTensor *output,
-                 IPortableTensor *back_prop_input, const IPortableTensor *back_prop_output);
+  void configureBackward(IPortableTensor *back_prop_input, const IPortableTensor *back_prop_output);
   void forward(bool training) override;
   void backward() override;
 

--- a/runtime/onert/core/include/ir/train/TrainableOperation.h
+++ b/runtime/onert/core/include/ir/train/TrainableOperation.h
@@ -43,7 +43,8 @@ public:
 
 private:
   bool _trainable = false;
-  bool _required_for_backward = false;
+  // TODO: Change to false after merge other parts of fine-tuning feature
+  bool _required_for_backward = true;
 };
 
 } // namespace train


### PR DESCRIPTION
This PR separates forward and backward configuration of trainable ops in order to make possible disabling backward propagation of particular ops.

ONE-DCO-1.0-Signed-off-by: Mateusz Bencer <m.bencer@partner.samsung.com>

Draft: https://github.com/Samsung/ONE/pull/12951
Issue: https://github.com/Samsung/ONE/issues/12386