### PR TITLE
[runtime] Use c++17 for tests and tools

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,4 +2,8 @@ if(NOT ENABLE_TEST)
   return()
 endif(NOT ENABLE_TEST)
 
+# Use C++17 for tests
+# TODO: Remove this when we use C++17 for all runtime directories
+set(CMAKE_CXX_STANDARD 17)
+
 add_subdirectories()

--- a/tests/nnapi/CMakeLists.txt
+++ b/tests/nnapi/CMakeLists.txt
@@ -9,9 +9,6 @@ endif(NOT BUILD_ONERT)
 
 nnfw_find_package(GTest)
 
-# NNAPI gtest requires c++17
-set(CMAKE_CXX_STANDARD 17)
-
 set(GENERATED_CPPS "${CMAKE_CURRENT_SOURCE_DIR}/src/generated/all_generated_V1_2_cts_tests.cpp"
                    "${CMAKE_CURRENT_SOURCE_DIR}/src/generated/all_generated_V1_1_cts_tests.cpp"
                    "${CMAKE_CURRENT_SOURCE_DIR}/src/generated/all_generated_V1_0_cts_tests.cpp"

--- a/tests/tools/onert_train/CMakeLists.txt
+++ b/tests/tools/onert_train/CMakeLists.txt
@@ -6,10 +6,6 @@ if(NOT BUILD_ONERT)
   return()
 endif(NOT BUILD_ONERT)
 
-# Use C++17 for onert_train
-# TODO: Remove this when we use C++17 for all runtime directories
-set(CMAKE_CXX_STANDARD 17)
-
 list(APPEND ONERT_TRAIN_SRCS "src/onert_train.cc")
 list(APPEND ONERT_TRAIN_SRCS "src/args.cc")
 list(APPEND ONERT_TRAIN_SRCS "src/nnfw_util.cc")

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,1 +1,5 @@
+# Use C++17 for tools
+# TODO: Remove this when we use C++17 for all runtime directories
+set(CMAKE_CXX_STANDARD 17)
+
 add_subdirectories()

--- a/tools/kbenchmark/CMakeLists.txt
+++ b/tools/kbenchmark/CMakeLists.txt
@@ -1,7 +1,3 @@
-# Use C++17 for kbenchmark
-# TODO Remove this when we use C++17 for all runtime directories
-set(CMAKE_CXX_STANDARD 17)
-
 if(NOT BUILD_KBENCHMARK)
   return()
 endif(NOT BUILD_KBENCHMARK)


### PR DESCRIPTION
This commit updates cmake script to use c++17 for all tests and tools.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>