### PR TITLE
[infra/gbs] Add tizen 9.0 repo and 7.0 profile

### DIFF
--- a/infra/nnfw/config/gbs.conf
+++ b/infra/nnfw/config/gbs.conf
@@ -5,6 +5,9 @@ profile = profile.tizen
 [profile.tizen]
 repos = repo.base, repo.unified
 
+[profile.tizen_7]
+repos = repo.base_7, repo.unified_7
+
 [profile.tizen_8]
 repos = repo.base_8, repo.unified_8
 
@@ -15,9 +18,15 @@ repos = repo.base-dev, repo.unified-dev
 repos = repo.base-riscv, repo.unified-riscv
 
 [repo.unified]
-url = http://download.tizen.org/snapshots/TIZEN/Tizen-7.0/Tizen-7.0-Unified/reference/repos/standard/packages/
+url = http://download.tizen.org/snapshots/TIZEN/Tizen/Tizen-Unified/reference/repos/standard/packages/
 
 [repo.base]
+url = http://download.tizen.org/snapshots/TIZEN/Tizen/Tizen-Base/reference/repos/standard/packages/
+
+[repo.unified_7]
+url = http://download.tizen.org/snapshots/TIZEN/Tizen-7.0/Tizen-7.0-Unified/reference/repos/standard/packages/
+
+[repo.base_7]
 url = http://download.tizen.org/snapshots/TIZEN/Tizen-7.0/Tizen-7.0-Base/reference/repos/standard/packages/
 
 [repo.unified_8]


### PR DESCRIPTION
This commit adds tizen 7.0 profile and 9.0 repo to gbs.conf.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>