### PR TITLE
[onert/gbs] Change repo url to use latest

### DIFF
--- a/infra/nnfw/config/gbs.conf
+++ b/infra/nnfw/config/gbs.conf
@@ -18,31 +18,31 @@ repos = repo.base-dev, repo.unified-dev
 repos = repo.base-riscv, repo.unified-riscv
 
 [repo.unified]
-url = http://download.tizen.org/snapshots/TIZEN/Tizen/Tizen-Unified/reference/repos/standard/packages/
+url = http://download.tizen.org/snapshots/TIZEN/Tizen/Tizen-Unified/latest/repos/standard/packages/
 
 [repo.base]
-url = http://download.tizen.org/snapshots/TIZEN/Tizen/Tizen-Base/reference/repos/standard/packages/
+url = http://download.tizen.org/snapshots/TIZEN/Tizen/Tizen-Base/latest/repos/standard/packages/
 
 [repo.unified_7]
-url = http://download.tizen.org/snapshots/TIZEN/Tizen-7.0/Tizen-7.0-Unified/reference/repos/standard/packages/
+url = http://download.tizen.org/snapshots/TIZEN/Tizen-7.0/Tizen-7.0-Unified/latest/repos/standard/packages/
 
 [repo.base_7]
-url = http://download.tizen.org/snapshots/TIZEN/Tizen-7.0/Tizen-7.0-Base/reference/repos/standard/packages/
+url = http://download.tizen.org/snapshots/TIZEN/Tizen-7.0/Tizen-7.0-Base/latest/repos/standard/packages/
 
 [repo.unified_8]
-url = http://download.tizen.org/snapshots/TIZEN/Tizen-8.0/Tizen-8.0-Unified/reference/repos/standard/packages/
+url = http://download.tizen.org/snapshots/TIZEN/Tizen-8.0/Tizen-8.0-Unified/latest/repos/standard/packages/
 
 [repo.base_8]
-url = http://download.tizen.org/snapshots/TIZEN/Tizen-8.0/Tizen-8.0-Base/reference/repos/standard/packages/
+url = http://download.tizen.org/snapshots/TIZEN/Tizen-8.0/Tizen-8.0-Base/latest/repos/standard/packages/
 
 [repo.unified-dev]
-url = http://download.tizen.org/snapshots/TIZEN/Tizen/Tizen-Unified-Dev/reference/repos/standard/packages/
+url = http://download.tizen.org/snapshots/TIZEN/Tizen/Tizen-Unified-Dev/latest/repos/standard/packages/
 
 [repo.base-dev]
-url = http://download.tizen.org/snapshots/TIZEN/Tizen/Tizen-Base-Dev/reference/repos/standard/packages/
+url = http://download.tizen.org/snapshots/TIZEN/Tizen/Tizen-Base-Dev/latest/repos/standard/packages/
 
 [repo.unified-riscv]
-url = http://download.tizen.org/snapshots/TIZEN/Tizen/Tizen-Unified-RISCV/reference/repos/standard/packages/
+url = http://download.tizen.org/snapshots/TIZEN/Tizen/Tizen-Unified-RISCV/latest/repos/standard/packages/
 
 [repo.base-riscv]
-url = http://download.tizen.org/snapshots/TIZEN/Tizen/Tizen-Base-RISCV/reference/repos/standard/packages/
+url = http://download.tizen.org/snapshots/TIZEN/Tizen/Tizen-Base-RISCV/latest/repos/standard/packages/


### PR DESCRIPTION
This commit changes repo url to use latest instead of reference.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>