### PR TITLE
[onert/odc] Introduce minmax embedder

### DIFF
--- a/Makefile.template
+++ b/Makefile.template
@@ -169,8 +169,10 @@ ifeq (,$(findstring android,$(TARGET_OS)))
 # install angkor TensorIndex and oops InternalExn header (TODO: Remove this)
 	@mkdir -p ${OVERLAY_FOLDER}/include/nncc/core/ADT/tensor
 	@mkdir -p ${OVERLAY_FOLDER}/include/oops
+	@mkdir -p ${OVERLAY_FOLDER}/include/luci/IR
 	@cp compiler/angkor/include/nncc/core/ADT/tensor/Index.h ${OVERLAY_FOLDER}/include/nncc/core/ADT/tensor
 	@cp compiler/oops/include/oops/InternalExn.h ${OVERLAY_FOLDER}/include/oops
+	@cp compiler/luci/lang/include/luci/IR/CircleNodes.lst ${OVERLAY_FOLDER}/include/luci/IR
 	@echo "Done prepare-nncc"
 endif
 

--- a/packaging/nnfw.spec
+++ b/packaging/nnfw.spec
@@ -225,8 +225,10 @@ cmake --install %{nncc_workspace} %{strip_options}
 # install angkor TensorIndex and oops InternalExn header (TODO: Remove this)
 mkdir -p %{overlay_path}/include/nncc/core/ADT/tensor
 mkdir -p %{overlay_path}/include/oops
+mkdir -p %{overlay_path}/include/luci/IR
 cp compiler/angkor/include/nncc/core/ADT/tensor/Index.h %{overlay_path}/include/nncc/core/ADT/tensor
 cp compiler/oops/include/oops/InternalExn.h %{overlay_path}/include/oops
+cp compiler/luci/lang/include/luci/IR/CircleNodes.lst %{overlay_path}/include/luci/IR
 
 # runtime build
 %{build_env} ./nnfw configure %{build_options}

--- a/runtime/onert/odc/Embedder.cc
+++ b/runtime/onert/odc/Embedder.cc
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Embedder.h"
+#include "MinMaxReader.h"
+
+#include <luci/CircleExporter.h>
+#include <luci/CircleFileExpContract.h>
+#include <luci/ImporterEx.h>
+#include <luci/IR/CircleNode.h>
+#include <luci/IR/CircleQuantParam.h>
+#include <luci/Profile/CircleNodeID.h>
+#include <luci/Service/Validate.h>
+
+#include <cassert>
+#include <cmath> // for std::floor
+#include <string>
+
+namespace
+{
+
+/* NOTE: getNthPercentile is copied from compiler/record-minmax/include/RecordFunction.h */
+/**
+ * @brief  getNthPercentile calculates the n-th percentile of input vector (0.0 <= n <= 100.0)
+ *         linear interpolation is used when the desired percentile lies between two data points
+ */
+float getNthPercentile(std::vector<float> &vector, float percentile)
+{
+  if (percentile < 0 || percentile > 100)
+    throw std::runtime_error("Percentile must be ranged from 0 to 100");
+
+  if (vector.empty())
+    throw std::runtime_error("Percentile must take a non-empty vector as an argument");
+
+  if (vector.size() == 1)
+    return vector[0];
+
+  std::vector<float> copy;
+  copy.assign(vector.begin(), vector.end());
+  std::sort(copy.begin(), copy.end());
+
+  if (percentile == 0.0)
+    return copy.front();
+
+  if (percentile == 100.0)
+    return copy.back();
+
+  int index = static_cast<int>(std::floor((copy.size() - 1) * percentile / 100.0));
+
+  float percent_i = static_cast<float>(index) / static_cast<float>(copy.size() - 1);
+  float fraction =
+    (percentile / 100.0 - percent_i) / ((index + 1.0) / (copy.size() - 1.0) - percent_i);
+  float res = copy[index] + fraction * (copy[index + 1] - copy[index]);
+  return res;
+}
+
+} // namespace
+
+namespace onert
+{
+namespace odc
+{
+
+void Embedder::embed(luci::Module *module, const std::string &minmax_path,
+                     const EmbedderOptions &opt)
+{
+  if (module == nullptr)
+    throw std::runtime_error{"Input module is nullptr"};
+
+  MinMaxReader mmr{minmax_path};
+
+  for (size_t idx = 0; idx < module->size(); ++idx)
+  {
+    auto graph = module->graph(idx);
+
+    /* read subgraph inputs */
+    const auto input_nodes = loco::input_nodes(graph);
+    const auto n_inputs = input_nodes.size();
+    for (size_t input_idx = 0; input_idx < n_inputs; ++input_idx)
+    {
+      const auto *circle_input = loco::must_cast<const luci::CircleInput *>(input_nodes[input_idx]);
+      if (circle_input->index() != input_idx)
+        throw std::runtime_error("Input order in minmax recording does not match to circle");
+
+      auto minmax = mmr.readInput(0, idx, input_idx);
+      auto min = getNthPercentile(minmax.min_vector, opt.min_percentile);
+      auto max = getNthPercentile(minmax.max_vector, opt.max_percentile);
+      auto quantparam = std::make_unique<luci::CircleQuantParam>();
+      quantparam->min.push_back(min);
+      quantparam->max.push_back(max);
+      const auto *circle_node = loco::must_cast<const luci::CircleNode *>(input_nodes[input_idx]);
+      auto mutable_node = const_cast<luci::CircleNode *>(circle_node);
+      mutable_node->quantparam(std::move(quantparam));
+    }
+
+    /* read op outputs */
+    uint32_t n_nodes = graph->nodes()->size();
+    for (uint32_t i = 0; i < n_nodes; ++i)
+    {
+      auto node = loco::must_cast<luci::CircleNode *>(graph->nodes()->at(i));
+      if (not luci::has_node_id(node)) // Skip non-op nodes (e.g. input/const/output)
+        continue;
+      auto op_idx = luci::get_node_id(node);
+      auto minmax = mmr.readOP(0, idx, op_idx);
+      auto min = getNthPercentile(minmax.min_vector, opt.min_percentile);
+      auto max = getNthPercentile(minmax.max_vector, opt.max_percentile);
+      auto quantparam = std::make_unique<luci::CircleQuantParam>();
+      quantparam->min.push_back(min);
+      quantparam->max.push_back(max);
+      auto mutable_node = const_cast<luci::CircleNode *>(node);
+      mutable_node->quantparam(std::move(quantparam));
+    }
+
+    if (!luci::validate(graph))
+      throw std::runtime_error{"Circle after embedding minmax is invalid"};
+  }
+}
+
+} // namespace odc
+} // namespace onert

--- a/runtime/onert/odc/Embedder.h
+++ b/runtime/onert/odc/Embedder.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_ODC_EMBEDDER_H__
+#define __ONERT_ODC_EMBEDDER_H__
+
+#include "luci/IR/Module.h"
+
+#include <string>
+
+namespace onert
+{
+namespace odc
+{
+struct EmbedderOptions
+{
+  float min_percentile = 0.0f; // dummy initial value to make SE tool happy
+  float max_percentile = 0.0f; // dummy initial value To make SE tool happy
+};
+
+class Embedder
+{
+public:
+  void embed(luci::Module *module, const std::string &minmax_path, const EmbedderOptions &opt);
+};
+} // namespace odc
+} // namespace onert
+
+#endif // __MINMAX_EMBEDDER_EMBEDDER_H__

--- a/runtime/onert/odc/MinMaxReader.cc
+++ b/runtime/onert/odc/MinMaxReader.cc
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "MinMaxReader.h"
+
+#include <stdexcept>
+#include <iostream>
+
+namespace
+{
+
+void inline readMMFile(void *ptr, size_t size, size_t count, FILE *fp, const std::string &err_msg)
+{
+  if (fread(ptr, size, count, fp) != count)
+    throw std::runtime_error(err_msg);
+}
+
+} // namespace
+
+namespace onert
+{
+namespace odc
+{
+
+MinMaxReader::MinMaxReader(const std::string &filepath) : _filepath(filepath)
+{
+  // DO NOTHING
+}
+
+// TODO: Handle multiple output
+MinMaxVectors MinMaxReader::readOP(uint32_t model_idx, uint32_t subg_idx, uint32_t op_idx) const
+{
+  // Find file to read
+  auto file = std::fopen(_filepath.c_str(), "rb");
+  if (!file)
+    throw std::runtime_error("Cannot open file: " + _filepath);
+
+  // Read num_run
+  uint32_t num_run = 0;
+  readMMFile(&num_run, sizeof(uint32_t), 1, file, "Cannot read num_run from file");
+
+  MinMaxVectors mmv;
+  float minmax[2];
+  size_t data_size = sizeof(float) * 2 + sizeof(uint32_t) * 3;
+
+  for (uint32_t r = 0; r < num_run; ++r)
+  {
+    // Read num of operations and num of inputs
+    uint32_t num_op = 0;
+    readMMFile(&num_op, sizeof(uint32_t), 1, file, "Cannot read num of operations");
+    uint32_t num_input = 0;
+    readMMFile(&num_input, sizeof(uint32_t), 1, file, "Cannot read num of inputs");
+
+    // Find operation
+    for (uint32_t i = 0; i < num_op; ++i)
+    {
+      uint32_t model_id_from_file = 0;
+      uint32_t subg_idx_from_file = 0;
+      uint32_t op_idx_from_file = 0;
+
+      readMMFile(&model_id_from_file, sizeof(uint32_t), 1, file, "Cannot read model_id from file");
+      readMMFile(&subg_idx_from_file, sizeof(uint32_t), 1, file, "Cannot read subg_idx from file");
+      readMMFile(&op_idx_from_file, sizeof(uint32_t), 1, file, "Cannot read op_idx from file");
+
+      if (model_id_from_file == model_idx && subg_idx_from_file == subg_idx &&
+          op_idx_from_file == op_idx)
+      {
+        // Read minmax data
+        readMMFile(minmax, sizeof(float), 2, file, "Cannot read minmax data from file");
+        mmv.min_vector.emplace_back(minmax[0]);
+        mmv.max_vector.emplace_back(minmax[1]);
+
+        // Skip remain operation minmax data
+        uint32_t remain_elem = num_op - i - 1;
+        std::fseek(file, data_size * remain_elem, SEEK_CUR);
+        break;
+      }
+
+      // Skip minmax data
+      std::fseek(file, sizeof(float) * 2, SEEK_CUR);
+    }
+
+    // Skip input minmax data
+    std::fseek(file, data_size * num_input, SEEK_CUR);
+  }
+
+  fclose(file);
+  return mmv;
+}
+
+MinMaxVectors MinMaxReader::readInput(uint32_t model_idx, uint32_t subg_idx,
+                                      uint32_t input_idx) const
+{
+  // Find file to read
+  auto file = std::fopen(_filepath.c_str(), "rb");
+  if (!file)
+    throw std::runtime_error("Cannot open file: " + _filepath);
+
+  // Read num_run
+  uint32_t num_run = 0;
+  readMMFile(&num_run, sizeof(uint32_t), 1, file, "Cannot read num_run from file");
+
+  MinMaxVectors mmv;
+  float minmax[2];
+  size_t data_size = sizeof(float) * 2 + sizeof(uint32_t) * 3;
+
+  for (uint32_t r = 0; r < num_run; ++r)
+  {
+    // Read num of operations and num of inputs
+    uint32_t num_op = 0;
+    readMMFile(&num_op, sizeof(uint32_t), 1, file, "Cannot read num of operations");
+    uint32_t num_input = 0;
+    readMMFile(&num_input, sizeof(uint32_t), 1, file, "Cannot read num of inputs");
+
+    // Skip operation minmax data
+    std::fseek(file, data_size * num_op, SEEK_CUR);
+
+    // Find operation
+    for (uint32_t i = 0; i < num_input; ++i)
+    {
+      uint32_t model_id_from_file = 0;
+      uint32_t subg_idx_from_file = 0;
+      uint32_t input_idx_from_file = 0;
+
+      readMMFile(&model_id_from_file, sizeof(uint32_t), 1, file, "Cannot read model_id from file");
+      readMMFile(&subg_idx_from_file, sizeof(uint32_t), 1, file, "Cannot read subg_idx from file");
+      readMMFile(&input_idx_from_file, sizeof(uint32_t), 1, file,
+                 "Cannot read input_idx from file");
+
+      if (model_id_from_file == model_idx && subg_idx_from_file == subg_idx &&
+          input_idx_from_file == input_idx)
+      {
+        // Read minmax data
+        readMMFile(minmax, sizeof(float), 2, file, "Cannot read minmax data from file");
+        mmv.min_vector.emplace_back(minmax[0]);
+        mmv.max_vector.emplace_back(minmax[1]);
+
+        // Skip remain input minmax data
+        uint32_t remain_elem = num_input - i - 1;
+        std::fseek(file, data_size * remain_elem, SEEK_CUR);
+        break;
+      }
+
+      // Skip minmax data
+      std::fseek(file, sizeof(float) * 2, SEEK_CUR);
+    }
+  }
+
+  fclose(file);
+  return mmv;
+}
+
+} // namespace odc
+} // namespace onert

--- a/runtime/onert/odc/MinMaxReader.h
+++ b/runtime/onert/odc/MinMaxReader.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __ONERT_ODC_MINMAX_READER_H__
+#define __ONERT_ODC_MINMAX_READER_H__
+
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace onert
+{
+namespace odc
+{
+
+// File structure
+// uint32_t num of runs
+
+// For each run
+// uint32_t num of operations
+// uint32_t num of inputs
+
+// For each operation
+// uint32_t model id
+// uint32_t subgraph id
+// uint32_t operation id
+// float min
+// float max
+
+// For each input
+// uint32_t model id
+// uint32_t subgraph id
+// uint32_t input id
+// float min
+// float max
+
+struct MinMaxVectors
+{
+  std::vector<float> min_vector;
+  std::vector<float> max_vector;
+};
+
+class MinMaxReader
+{
+public:
+  MinMaxReader(const std::string &filepath);
+  /**
+   * @brief Returns minmax recording for op {model_idx, subg_idx, op_idx}
+   *
+   * @return MinMaxVectors
+   */
+  MinMaxVectors readOP(uint32_t model_idx, uint32_t subg_idx, uint32_t op_idx) const;
+  /**
+   * @brief Returns minmax recording for input {model_idx, subg_idx, input_idx}
+   *
+   * @return MinMaxVectors
+   */
+  MinMaxVectors readInput(uint32_t model_idx, uint32_t subg_idx, uint32_t input_idx) const;
+
+private:
+  std::string _filepath;
+};
+
+} // namespace odc
+} // namespace onert
+
+#endif // __ONERT_ODC_MINMAX_READER_H__

--- a/runtime/onert/odc/Quantizer.cc
+++ b/runtime/onert/odc/Quantizer.cc
@@ -16,6 +16,9 @@
 
 #include "Quantizer.h"
 
+#include "Embedder.h"
+
+#include <util/ConfigSource.h>
 #include <luci/ImporterEx.h>
 #include <luci/CircleQuantizer.h>
 #include <luci/CircleExporter.h>
@@ -111,8 +114,10 @@ int Quantizer::quantize(const char *in, const char *out, QuantizeType qtype)
       quantizer.quantize(graph);
     }
 
-    // TODO Record minmax by minmax-embedder
-    throw std::runtime_error{"Not implemented yet"};
+    // Record minmax by minmax-embedder
+    // TODO use workspace to find minmax file
+    auto minmax_path = util::getConfigString(util::config::MINMAX_FILEPATH);
+    Embedder().embed(module.get(), minmax_path, {1.f, 99.f});
   }
 
   if (full_quantize)


### PR DESCRIPTION
This commit intrdocues minmax data embedder for circle model file into on-device quantizer. 
It uses raw file format to load minmax data, ant it will be saved by runtime.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Draft: #12903
Related issue: https://github.com/Samsung/ONE/issues/12904