### PR TITLE
[onert] Introduce logic to control training flow

### DIFF
--- a/runtime/onert/backend/train/BackendContext.cc
+++ b/runtime/onert/backend/train/BackendContext.cc
@@ -65,8 +65,6 @@ void AddBackPropInitializers(const ir::train::TrainableGraph &tgraph, TensorRegi
 {
   util::Set<ir::OperandIndex> unvisited;
   tgraph.operands().iterate([&](const ir::OperandIndex &index, const ir::Operand &operand) {
-    // TODO Consider not adding BackPropInitializer if the coresponding BackPropTensors don't
-    //      require initilization (i.g. BackPropTensors that are not back-propagated)
     if (!tgraph.getInputs().contains(index) && !operand.isConstant())
       unvisited.add(index);
   });
@@ -93,12 +91,11 @@ void AddBackPropInitializers(const ir::train::TrainableGraph &tgraph, TensorRegi
           unvisited.remove(back_prop_index);
         }
       }
-
-      if (back_props.size() != 0)
-      {
-        auto initializer = std::make_unique<ops::BackPropInitializer>(back_props);
-        tn_seq->append(std::move(initializer));
-      }
+    }
+    if (back_props.size() != 0)
+    {
+      auto initializer = std::make_unique<ops::BackPropInitializer>(back_props);
+      tn_seq->append(std::move(initializer));
     }
   }
 }
@@ -120,7 +117,7 @@ backend::train::ITensorRegistry *BackendContext::genTrainingTensors()
     {
       return;
     }
-    for (auto &&ind : op.getInputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED)
+    for (const auto &ind : op.getInputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED)
     {
       if (tensor_builder->isRegisteredBackward(ind))
         continue;

--- a/runtime/onert/backend/train/BackendContext.cc
+++ b/runtime/onert/backend/train/BackendContext.cc
@@ -79,23 +79,26 @@ void AddBackPropInitializers(const ir::train::TrainableGraph &tgraph, TensorRegi
 
     // The function added lastest is executed first in a sequence during backwarding.
     std::vector<BackPropTensor *> back_props;
-    const auto &op = tgraph.operations().at(op_index);
+    const auto &op = tgraph.operation(op_index);
     for (const auto &back_prop_index :
          op.getInputs() | ir::Remove::UNDEFINED | ir::Remove::DUPLICATED)
     {
-      if (unvisited.contains(back_prop_index))
+      if (op.isRequiredForBackward())
       {
-        auto back_prop_tensor = tensor_reg.getBackPropTensor(back_prop_index);
-        assert(back_prop_tensor != nullptr);
-        back_props.emplace_back(back_prop_tensor);
-        unvisited.remove(back_prop_index);
+        if (unvisited.contains(back_prop_index))
+        {
+          auto back_prop_tensor = tensor_reg.getBackPropTensor(back_prop_index);
+          assert(back_prop_tensor != nullptr);
+          back_props.emplace_back(back_prop_tensor);
+          unvisited.remove(back_prop_index);
+        }
       }
-    }
 
-    if (back_props.size() != 0)
-    {
-      auto initializer = std::make_unique<ops::BackPropInitializer>(back_props);
-      tn_seq->append(std::move(initializer));
+      if (back_props.size() != 0)
+      {
+        auto initializer = std::make_unique<ops::BackPropInitializer>(back_props);
+        tn_seq->append(std::move(initializer));
+      }
     }
   }
 }
@@ -110,15 +113,27 @@ backend::train::ITensorRegistry *BackendContext::genTrainingTensors()
 {
   const ir::train::TrainableGraph &tgraph = *trainable_graph();
   auto tensor_builder = _tensor_builder;
-
-  tgraph.operands().iterate([&](const ir::OperandIndex &ind, const ir::Operand &obj) {
-    if (external_operands().contains(ind))
+  tgraph.operations().iterate([&](const ir::OperationIndex &, const ir::IOperation &op) {
+    const auto trainable_op = dynamic_cast<const ir::train::TrainableOperation *>(&op);
+    assert(trainable_op);
+    if (!trainable_op->isRequiredForBackward())
+    {
       return;
-    // NOTE Assuming there is no layout changes (Always assume NHWC or UNKNOWN)
-    assert(tgraph.layout() != ir::Layout::NCHW);
+    }
+    for (auto &&ind :
+         (op.getInputs() + op.getOutputs()) | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED)
+    {
+      if (tensor_builder->isRegisteredBackward(ind))
+        continue;
+      if (external_operands().contains(ind))
+        continue;
+      // NOTE Assuming there is no layout changes (Always assume NHWC or UNKNOWN)
+      assert(tgraph.layout() != ir::Layout::NCHW);
 
-    tensor_builder->registerBackwardTensorInfo(ind, createBackwardTensorInfo(obj),
-                                               ir::Layout::NHWC);
+      const auto &operand = tgraph.operands().at(ind);
+      tensor_builder->registerBackwardTensorInfo(ind, createBackwardTensorInfo(operand),
+                                                 ir::Layout::NHWC);
+    }
   });
 
   // TODO Plan tensor builds to reduce peak memory usage

--- a/runtime/onert/backend/train/BackendContext.cc
+++ b/runtime/onert/backend/train/BackendContext.cc
@@ -120,8 +120,7 @@ backend::train::ITensorRegistry *BackendContext::genTrainingTensors()
     {
       return;
     }
-    for (auto &&ind :
-         (op.getInputs() + op.getOutputs()) | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED)
+    for (auto &&ind : op.getInputs() | ir::Remove::DUPLICATED | ir::Remove::UNDEFINED)
     {
       if (tensor_builder->isRegisteredBackward(ind))
         continue;

--- a/runtime/onert/core/include/exec/train/TrainableFnSequence.h
+++ b/runtime/onert/core/include/exec/train/TrainableFnSequence.h
@@ -34,7 +34,7 @@ class TrainableFnSequence
 {
 public:
   void forward(bool training);
-  void backward(uint32_t training_step);
+  void backward(uint32_t training_step, bool weight_update_enabled);
 
   void append(std::unique_ptr<ITrainableFunction> &&fn);
   void append(std::unique_ptr<IGradientApplier> &&applier);

--- a/runtime/onert/core/include/ir/train/TrainableGraph.h
+++ b/runtime/onert/core/include/ir/train/TrainableGraph.h
@@ -109,6 +109,7 @@ public:
                  std::unordered_map<std::string, IOIndex> name_to_input);
   void setOutputs(OperandIndexSequence outputs,
                   std::unordered_map<std::string, IOIndex> name_to_output);
+  void enableBackward(const OperationIndex &index);
 
   // Accessors
 public:

--- a/runtime/onert/core/include/ir/train/TrainableOperation.h
+++ b/runtime/onert/core/include/ir/train/TrainableOperation.h
@@ -42,8 +42,8 @@ public:
   virtual bool isRequiredForBackward() const final { return _required_for_backward; }
 
 private:
-  bool _trainable = false;
-  // TODO: Change to false after merge other parts of fine-tuning feature
+  // TODO: Change _trainable and _required_for_backward to false after merge other parts of fine-tuning feature
+  bool _trainable = true;
   bool _required_for_backward = true;
 };
 

--- a/runtime/onert/core/include/ir/train/TrainableOperation.h
+++ b/runtime/onert/core/include/ir/train/TrainableOperation.h
@@ -42,7 +42,8 @@ public:
   virtual bool isRequiredForBackward() const final { return _required_for_backward; }
 
 private:
-  // TODO: Change _trainable and _required_for_backward to false after merge other parts of fine-tuning feature
+  // TODO: Change _trainable and _required_for_backward to false after merge other parts of
+  // fine-tuning feature
   bool _trainable = true;
   bool _required_for_backward = true;
 };

--- a/runtime/onert/core/src/compiler/train/LoweredTrainableGraph.cc
+++ b/runtime/onert/core/src/compiler/train/LoweredTrainableGraph.cc
@@ -111,6 +111,7 @@ void LoweredTrainableGraph::lowerGraph(const CompilerOptions &options)
       if (op.opcode() == ir::OpCode::Permute)
       {
         auto trainable_op = op_converter(op);
+        trainable_op->enableBackward();
         auto gen_index = _trainable_graph.replaceOperation(index, std::move(trainable_op));
         UNUSED_RELEASE(gen_index);
         assert(gen_index == index);

--- a/runtime/onert/core/src/compiler/train/TrainingCompiler.cc
+++ b/runtime/onert/core/src/compiler/train/TrainingCompiler.cc
@@ -114,13 +114,29 @@ std::shared_ptr<CompilerArtifact> TrainingCompiler::compile(void)
 
       // Convert operations to trainable operations
       auto converter = TrainableOperationConverter{*trainable_subg, &_training_info};
+      ir::OperationIndex min_trainable_op_idx;
       subg.operations().iterate(
         [&](const onert::ir::OperationIndex &op_index, const onert::ir::IOperation &op) {
           auto trainable_op = converter(op);
+          if (_training_info.getTrainableOps().find(op_index) !=
+              std::end(_training_info.getTrainableOps()))
+          {
+            trainable_op->enableWeightsUpdate();
+            if (op_index.value() < min_trainable_op_idx.value())
+            {
+              min_trainable_op_idx = op_index;
+            }
+          }
           auto gen_index = trainable_subg->replaceOperation(op_index, std::move(trainable_op));
           UNUSED_RELEASE(gen_index);
           assert(gen_index == op_index);
         });
+
+      for (ir::OperationIndex idx{min_trainable_op_idx};
+           idx.value() < trainable_subg->operations().size(); idx++)
+      {
+        trainable_subg->enableBackward(idx);
+      }
 
       trainable_subgraphs[subg_index] = std::move(trainable_subg);
     });

--- a/runtime/onert/core/src/compiler/train/pass/LossInsertionPass.cc
+++ b/runtime/onert/core/src/compiler/train/pass/LossInsertionPass.cc
@@ -66,6 +66,7 @@ void LossInsertionPass::run()
 
   auto loss_op = std::make_unique<ir::operation::Loss>(inputs, outputs);
   auto trainable_loss_op = std::make_unique<ir::train::operation::Loss>(*loss_op, loss_info);
+  trainable_loss_op->enableBackward();
 
   _trainable_graph.addOperation(std::move(trainable_loss_op));
 

--- a/runtime/onert/core/src/exec/train/TrainableExecutor.cc
+++ b/runtime/onert/core/src/exec/train/TrainableExecutor.cc
@@ -119,7 +119,7 @@ void TrainableExecutor::forwardImpl(bool training)
       _subject.notifyJobBegin(this, profiling_subg_index, code.op_ind, backend);
 
       auto &tn_seq = code.tn_seq;
-      tn_seq->forward(training);
+      tn_seq->forward(training && code.op->isRequiredForBackward());
 
       _subject.notifyJobEnd(this, profiling_subg_index, code.op_ind, backend);
     }
@@ -160,6 +160,10 @@ void TrainableExecutor::backwardImpl(uint32_t training_step)
     for (auto &&index : _backward_order)
     {
       const auto &code = _code_map.at(index);
+      if (!code.op->isRequiredForBackward())
+      {
+        continue;
+      }
       const auto backend = code.lower_info->backend();
 // TODO : Move ruy profiler into ExecutionObserver
 #ifdef RUY_PROFILER
@@ -168,7 +172,7 @@ void TrainableExecutor::backwardImpl(uint32_t training_step)
       _subject.notifyJobBegin(this, profiling_subg_index, code.op_ind, backend);
 
       auto &tn_seq = code.tn_seq;
-      tn_seq->backward(training_step);
+      tn_seq->backward(training_step, code.op->isWeightsUpdateEnabled());
 
       _subject.notifyJobEnd(this, profiling_subg_index, code.op_ind, backend);
     }
@@ -184,7 +188,7 @@ void TrainableExecutor::backwardImpl(uint32_t training_step)
       ruy::profiler::ScopeLabel label(code.op->name());
 #endif
       auto &tn_seq = code.tn_seq;
-      tn_seq->backward(training_step);
+      tn_seq->backward(training_step, code.op->isWeightsUpdateEnabled());
     }
   }
 }

--- a/runtime/onert/core/src/exec/train/TrainableFnSequence.cc
+++ b/runtime/onert/core/src/exec/train/TrainableFnSequence.cc
@@ -31,16 +31,18 @@ void TrainableFnSequence::forward(bool training)
   }
 }
 
-void TrainableFnSequence::backward(uint32_t training_step)
+void TrainableFnSequence::backward(uint32_t training_step, bool weight_update_enabled)
 {
   for (auto it = _functions.rbegin(); it != _functions.rend(); ++it)
   {
     (*it)->backward();
   }
-
-  for (const auto &applier : _appliers)
+  if (weight_update_enabled)
   {
-    applier->applyGradient(training_step);
+    for (const auto &applier : _appliers)
+    {
+      applier->applyGradient(training_step);
+    }
   }
 }
 

--- a/runtime/onert/core/src/ir/train/TrainableGraph.cc
+++ b/runtime/onert/core/src/ir/train/TrainableGraph.cc
@@ -127,6 +127,13 @@ const ITrainableOperation &TrainableGraph::operation(OperationIndex index) const
   return dynamic_cast<const ITrainableOperation &>(_graph.operations().at(index));
 }
 
+void TrainableGraph::enableBackward(const OperationIndex &index)
+{
+  auto op = dynamic_cast<ir::train::ITrainableOperation *>(&_graph.operations().at(index));
+  assert(op);
+  op->enableBackward();
+}
+
 void TrainableGraph::validateTopologicalOrder(std::vector<ir::OperationIndex> order,
                                               bool is_forward) const
 {


### PR DESCRIPTION
This commit adds logic to control training tensors allocation and enablement of operations backward propagation based on the trainability state of ops.

ONE-DCO-1.0-Signed-off-by: Mateusz Bencer <m.bencer@partner.samsung.com>

Draft: https://github.com/Samsung/ONE/pull/12951
Issue: https://github.com/Samsung/ONE/issues/12386