### PR TITLE
[luci/logex] Implement to_str method for Dilation

### DIFF
--- a/compiler/luci/logex/src/CircleNodeSummaryBuilders.cpp
+++ b/compiler/luci/logex/src/CircleNodeSummaryBuilders.cpp
@@ -112,6 +112,11 @@ std::string to_str(const luci::Stride *stride)
   return std::to_string(stride->h()) + "," + std::to_string(stride->w());
 }
 
+std::string to_str(const luci::Dilation *dilation)
+{
+  return std::to_string(dilation->h()) + "," + std::to_string(dilation->w());
+}
+
 std::string to_str(const luci::Filter *filter)
 {
   return std::to_string(filter->h()) + "," + std::to_string(filter->w());


### PR DESCRIPTION
This commit adds to_str() method accepting luci::Dilation. Before that change dilation was implicitly converted to bool resulting in the meaningless output in logs: "dilation(h,w): true".

Desired output is similar to to_str(luci::Stride): "stride(h,w): 1,1".

Signed-off-by: Piotr Kotynia <p.kotynia@partner.samsung.com>
