### PR TITLE
[onert] Use unified compile option for multimodel

### DIFF
--- a/runtime/onert/api/nnapi/wrapper/ANeuralNetworksCompilation.cc
+++ b/runtime/onert/api/nnapi/wrapper/ANeuralNetworksCompilation.cc
@@ -23,7 +23,7 @@ using namespace onert;
 // TODO Support multiple subgraphs
 ANeuralNetworksCompilation::ANeuralNetworksCompilation(const ANeuralNetworksModel *model) noexcept
   : _model{model->getModel()}, _coptions{compiler::CompilerOptions::fromGlobalConfig()},
-    _compiler{std::make_shared<compiler::Compiler>(_model, *_coptions)}
+    _compiler{std::make_shared<compiler::Compiler>(_model, _coptions.get())}
 {
   if (model->allowedToFp16())
     _coptions->enableToFp16();

--- a/runtime/onert/api/nnfw/src/nnfw_api_internal.h
+++ b/runtime/onert/api/nnfw/src/nnfw_api_internal.h
@@ -211,7 +211,7 @@ private:
 private:
   State _state{State::INITIALIZED};
   std::shared_ptr<onert::ir::NNPkg> _nnpkg;
-  std::vector<std::unique_ptr<onert::compiler::CompilerOptions>> _coptions;
+  std::unique_ptr<onert::compiler::CompilerOptions> _coptions;
   std::shared_ptr<onert::compiler::CompilerArtifact> _compiler_artifact;
   std::unique_ptr<onert::exec::Execution> _execution;
   std::shared_ptr<onert::api::CustomKernelRegistry> _kernel_registry;

--- a/runtime/onert/core/include/compiler/Compiler.h
+++ b/runtime/onert/core/include/compiler/Compiler.h
@@ -39,18 +39,17 @@ class Compiler : public ICompiler
 public:
   /**
    * @brief     Construct a new Compiler object for single model
-   * @param[in] model     model to compile
-   * @param[in] coptions  Compiler Options
+   * @param[in] model model to compile
+   * @param[in] copts Compiler Options
    */
-  Compiler(const std::shared_ptr<ir::Model> &model, CompilerOptions &copt);
+  Compiler(const std::shared_ptr<ir::Model> &model, CompilerOptions *copts);
 
   /**
    * @brief     Construct a new Compiler object for NN package
-   * @param[in] nnpkg    NN package to compile
-   * @param[in] coptions Compiler option vector for each model in package
+   * @param[in] nnpkg NN package to compile
+   * @param[in] copts Compiler option for package
    */
-  Compiler(const std::shared_ptr<ir::NNPkg> &nnpkg,
-           std::vector<std::unique_ptr<CompilerOptions>> &copts);
+  Compiler(const std::shared_ptr<ir::NNPkg> &nnpkg, CompilerOptions *copts);
 
   /**
    * @brief Destroy the Compiler object

--- a/runtime/onert/core/include/compiler/CompilerFactory.h
+++ b/runtime/onert/core/include/compiler/CompilerFactory.h
@@ -34,8 +34,7 @@ public:
   static CompilerFactory &get();
 
 public:
-  std::unique_ptr<ICompiler> create(const std::shared_ptr<ir::NNPkg> &nnpkg,
-                                    std::vector<std::unique_ptr<CompilerOptions>> &copts,
+  std::unique_ptr<ICompiler> create(const std::shared_ptr<ir::NNPkg> &nnpkg, CompilerOptions *copts,
                                     const ir::train::TrainingInfo *training_info = nullptr);
 
 private:

--- a/runtime/onert/core/src/compiler/Compiler.cc
+++ b/runtime/onert/core/src/compiler/Compiler.cc
@@ -38,15 +38,14 @@ namespace onert
 namespace compiler
 {
 
-Compiler::Compiler(const std::shared_ptr<ir::Model> &model, CompilerOptions &copt)
-  : _model{model}, _options{&copt}
+Compiler::Compiler(const std::shared_ptr<ir::Model> &model, CompilerOptions *copts)
+  : _model{model}, _options{copts}
 {
   // DO NOTHING
 }
 
-Compiler::Compiler(const std::shared_ptr<ir::NNPkg> &nnpkg,
-                   std::vector<std::unique_ptr<CompilerOptions>> &copts)
-  : _model{nnpkg->primary_model()}, _options{copts[0].get()}
+Compiler::Compiler(const std::shared_ptr<ir::NNPkg> &nnpkg, CompilerOptions *copts)
+  : _model{nnpkg->primary_model()}, _options{copts}
 {
   // Use for single model only
   assert(nnpkg->model_count() == 1);

--- a/runtime/onert/core/src/compiler/CompilerFactory.cc
+++ b/runtime/onert/core/src/compiler/CompilerFactory.cc
@@ -31,10 +31,9 @@ CompilerFactory &CompilerFactory::get()
   return singleton;
 }
 
-std::unique_ptr<ICompiler>
-CompilerFactory::create(const std::shared_ptr<ir::NNPkg> &nnpkg,
-                        std::vector<std::unique_ptr<CompilerOptions>> &copts,
-                        const ir::train::TrainingInfo *training_info)
+std::unique_ptr<ICompiler> CompilerFactory::create(const std::shared_ptr<ir::NNPkg> &nnpkg,
+                                                   CompilerOptions *copts,
+                                                   const ir::train::TrainingInfo *training_info)
 {
   // Returing compiler for training
   if (training_info)

--- a/runtime/onert/core/src/compiler/MultiModelCompiler.h
+++ b/runtime/onert/core/src/compiler/MultiModelCompiler.h
@@ -39,11 +39,10 @@ class MultiModelCompiler final : public ICompiler
 public:
   /**
    * @brief     Construct a new Compiler object for NN package
-   * @param[in] nnpkg    NN package to compile
-   * @param[in] coptions Compiler option vector for each model in package
+   * @param[in] nnpkg NN package to compile
+   * @param[in] copts Compiler option for package
    */
-  MultiModelCompiler(const std::shared_ptr<ir::NNPkg> &nnpkg,
-                     std::vector<std::unique_ptr<CompilerOptions>> &copts);
+  MultiModelCompiler(const std::shared_ptr<ir::NNPkg> &nnpkg, CompilerOptions *copts);
 
   /**
    * @brief Destroy the MultiModelCompiler object
@@ -60,7 +59,7 @@ public:
 
 private:
   std::shared_ptr<ir::NNPkg> _nnpkg;
-  std::vector<CompilerOptions *> _voptions;
+  CompilerOptions *_options;
 };
 
 } // namespace compiler

--- a/runtime/onert/core/src/compiler/train/TrainingCompiler.cc
+++ b/runtime/onert/core/src/compiler/train/TrainingCompiler.cc
@@ -45,10 +45,9 @@ namespace compiler
 namespace train
 {
 
-TrainingCompiler::TrainingCompiler(const std::shared_ptr<ir::NNPkg> &nnpkg,
-                                   std::vector<std::unique_ptr<CompilerOptions>> &copts,
+TrainingCompiler::TrainingCompiler(const std::shared_ptr<ir::NNPkg> &nnpkg, CompilerOptions *copts,
                                    const ir::train::TrainingInfo &training_info)
-  : _model{nnpkg->primary_model()}, _options{copts[0].get()}, _training_info{training_info}
+  : _model{nnpkg->primary_model()}, _options{copts}, _training_info{training_info}
 {
   if (nnpkg->model_count() > 1)
     throw std::runtime_error("TrainingCompiler does not support multiple models yet");

--- a/runtime/onert/core/src/compiler/train/TrainingCompiler.h
+++ b/runtime/onert/core/src/compiler/train/TrainingCompiler.h
@@ -46,8 +46,7 @@ public:
    * @param[in] copts         compiler options
    * @param[in] training_info training information
    */
-  explicit TrainingCompiler(const std::shared_ptr<ir::NNPkg> &nnpkg,
-                            std::vector<std::unique_ptr<CompilerOptions>> &copts,
+  explicit TrainingCompiler(const std::shared_ptr<ir::NNPkg> &nnpkg, CompilerOptions *copts,
                             const ir::train::TrainingInfo &training_info);
 
   /**

--- a/runtime/onert/core/src/exec/Execution.test.cc
+++ b/runtime/onert/core/src/exec/Execution.test.cc
@@ -81,7 +81,7 @@ public:
     auto model = std::make_shared<onert::ir::Model>();
     model->push(onert::ir::SubgraphIndex{0}, graph);
     coptions = onert::compiler::CompilerOptions::fromGlobalConfig();
-    onert::compiler::Compiler compiler{model, *coptions};
+    onert::compiler::Compiler compiler{model, coptions.get()};
     artifact = compiler.compile();
   }
 
@@ -212,11 +212,10 @@ public:
   void compile()
   {
     auto nnpkg = std::make_shared<onert::ir::NNPkg>();
-    coptions.clear();
+    coptions = onert::compiler::CompilerOptions::fromGlobalConfig();
+
     for (uint16_t i = 0; i < graphs.size(); ++i)
     {
-      coptions.emplace_back(onert::compiler::CompilerOptions::fromGlobalConfig());
-
       auto model = std::make_shared<onert::ir::Model>();
       model->push(SubgraphIndex{0}, graphs[i]);
 
@@ -234,14 +233,14 @@ public:
     {
       nnpkg->addEdge(edge.from, edge.to);
     }
-    auto compiler = onert::compiler::CompilerFactory::get().create(nnpkg, coptions);
+    auto compiler = onert::compiler::CompilerFactory::get().create(nnpkg, coptions.get());
     nnpkg.reset();
     artifact = compiler->compile();
   }
 
 public:
   std::vector<std::shared_ptr<Graph>> graphs;
-  std::vector<std::unique_ptr<onert::compiler::CompilerOptions>> coptions;
+  std::unique_ptr<onert::compiler::CompilerOptions> coptions;
   std::shared_ptr<onert::compiler::CompilerArtifact> artifact;
   ModelEdges edges;
 };
@@ -298,7 +297,7 @@ TEST(ExecInstance, twoCompile)
   auto model = std::make_shared<onert::ir::Model>();
   model->push(onert::ir::SubgraphIndex{0}, graph);
   auto coptions = onert::compiler::CompilerOptions::fromGlobalConfig();
-  onert::compiler::Compiler compiler{model, *coptions};
+  onert::compiler::Compiler compiler{model, coptions.get()};
   std::shared_ptr<onert::compiler::CompilerArtifact> artifact = compiler.compile();
   onert::exec::Execution execution2{artifact->_executors};
 


### PR DESCRIPTION
This commit changes compile option vector to one compile option struct object for multimodel. 
Most compile option except backend mapping can be shared by all models, and multimodel's backend mapping to operator index is not supported yet.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>