### PR TITLE
[luci-interpreter] Support boolean type on BroadcastTo op

### DIFF
--- a/compiler/luci-interpreter/src/kernels/BroadcastTo.cpp
+++ b/compiler/luci-interpreter/src/kernels/BroadcastTo.cpp
@@ -107,6 +107,9 @@ void BroadcastTo::execute() const
     case DataType::FLOAT32:
       evalFloat();
       break;
+    case DataType::BOOL:
+      evalBool();
+      break;
     default:
       throw std::runtime_error("luci-intp BroadcastTo Unsupported type.");
   }
@@ -117,6 +120,13 @@ void BroadcastTo::evalFloat() const
   luci_interpreter_pal::BroadcastTo(getTensorShape(input()), getTensorData<char>(input()),
                                     getTensorShape(output()), getTensorData<char>(output()),
                                     TfLiteType::kTfLiteFloat32);
+}
+
+void BroadcastTo::evalBool() const
+{
+  luci_interpreter_pal::BroadcastTo(getTensorShape(input()), getTensorData<char>(input()),
+                                    getTensorShape(output()), getTensorData<char>(output()),
+                                    TfLiteType::kTfLiteBool);
 }
 
 } // namespace kernels

--- a/compiler/luci-interpreter/src/kernels/BroadcastTo.h
+++ b/compiler/luci-interpreter/src/kernels/BroadcastTo.h
@@ -39,6 +39,7 @@ public:
 
 private:
   void evalFloat() const;
+  void evalBool() const;
 };
 
 } // namespace kernels

--- a/compiler/luci-interpreter/src/kernels/BroadcastTo.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/BroadcastTo.test.cpp
@@ -52,6 +52,30 @@ void Check(std::initializer_list<int32_t> input_shape, std::initializer_list<int
   EXPECT_THAT(extractTensorData<float>(output_tensor), FloatArrayNear(output_data));
 }
 
+template <typename T>
+void Check_bool(std::initializer_list<int32_t> input_shape, std::initializer_list<int32_t> shape_shape,
+           std::initializer_list<int32_t> output_shape, std::initializer_list<uint8_t> input_data,
+           std::initializer_list<T> shape_data, std::initializer_list<uint8_t> output_data)
+{
+  std::unique_ptr<IMemoryManager> memory_manager = std::make_unique<TestMemoryManager>();
+  constexpr DataType element_type = DataType::BOOL;
+  constexpr DataType shape_type = getElementType<T>();
+
+  Tensor input_tensor =
+    makeInputTensor<element_type>(input_shape, input_data, memory_manager.get());
+  Tensor shape_tensor = makeInputTensor<shape_type>(shape_shape, shape_data, memory_manager.get());
+  Tensor output_tensor = makeOutputTensor(element_type);
+
+  BroadcastTo kernel(&input_tensor, &shape_tensor, &output_tensor);
+
+  kernel.configure();
+  memory_manager->allocate_memory(output_tensor);
+  kernel.execute();
+
+  EXPECT_THAT(extractTensorData<uint8_t>(output_tensor), ::testing::ElementsAreArray(output_data));
+  EXPECT_THAT(extractTensorShape(output_tensor), output_shape);
+}
+
 class BroadcastToTest : public ::testing::Test
 {
 };
@@ -82,6 +106,21 @@ TEST_F(BroadcastToTest, SimpleS64)
                  {
                    1, 2, 3, // Row 1
                    1, 2, 3, // Row 2
+                 });
+  SUCCEED();
+}
+
+TEST_F(BroadcastToTest, SimpleBool)
+{
+  Check_bool<int32_t>(/*input_shape*/ {1, 3}, /*shape_shape*/ {2}, /*output_shape*/ {2, 3},
+                 /*input_data*/
+                 {true, false, true},
+                 /*shape_data*/
+                 {2, 3},
+                 /*output_data*/
+                 {
+                   true, false, true, // Row 1
+                   true, false, true, // Row 2
                  });
   SUCCEED();
 }

--- a/compiler/luci-interpreter/src/kernels/BroadcastTo.test.cpp
+++ b/compiler/luci-interpreter/src/kernels/BroadcastTo.test.cpp
@@ -53,9 +53,11 @@ void Check(std::initializer_list<int32_t> input_shape, std::initializer_list<int
 }
 
 template <typename T>
-void Check_bool(std::initializer_list<int32_t> input_shape, std::initializer_list<int32_t> shape_shape,
-           std::initializer_list<int32_t> output_shape, std::initializer_list<uint8_t> input_data,
-           std::initializer_list<T> shape_data, std::initializer_list<uint8_t> output_data)
+void Check_bool(std::initializer_list<int32_t> input_shape,
+                std::initializer_list<int32_t> shape_shape,
+                std::initializer_list<int32_t> output_shape,
+                std::initializer_list<uint8_t> input_data, std::initializer_list<T> shape_data,
+                std::initializer_list<uint8_t> output_data)
 {
   std::unique_ptr<IMemoryManager> memory_manager = std::make_unique<TestMemoryManager>();
   constexpr DataType element_type = DataType::BOOL;
@@ -113,15 +115,15 @@ TEST_F(BroadcastToTest, SimpleS64)
 TEST_F(BroadcastToTest, SimpleBool)
 {
   Check_bool<int32_t>(/*input_shape*/ {1, 3}, /*shape_shape*/ {2}, /*output_shape*/ {2, 3},
-                 /*input_data*/
-                 {true, false, true},
-                 /*shape_data*/
-                 {2, 3},
-                 /*output_data*/
-                 {
-                   true, false, true, // Row 1
-                   true, false, true, // Row 2
-                 });
+                      /*input_data*/
+                      {true, false, true},
+                      /*shape_data*/
+                      {2, 3},
+                      /*output_data*/
+                      {
+                        true, false, true, // Row 1
+                        true, false, true, // Row 2
+                      });
   SUCCEED();
 }
 


### PR DESCRIPTION
This commit supports boolean type on BroadcastTo op. The op whose type is boolean is showed up in the LLM model.

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>