### PR TITLE
[onert] Run PermuteLayer in training mode

### DIFF
--- a/runtime/onert/core/src/backend/builtin/train/KernelGenerator.cc
+++ b/runtime/onert/core/src/backend/builtin/train/KernelGenerator.cc
@@ -67,12 +67,9 @@ void KernelGenerator::visit(const ir::train::operation::Permute &node)
   output_back_prop_tensors.emplace_back(output_back_prop_tensor);
   input_back_prop_tensors.emplace_back(input_back_prop_tensor);
 
-  // NOTE IOTensors of graph outputs for passing data to users must be ignored in training
-  //      because the buffers of those IOTensors are unnecessary and nullptr
-  bool ignore_forward_in_training = _whole_graph_outputs.contains(output_index);
-  auto fn = std::make_unique<kernel::PermuteLayer>(
-    input_tensors, output_tensors, input_back_prop_tensors, output_back_prop_tensors,
-    ignore_forward_in_training, _external_context);
+  auto fn =
+    std::make_unique<kernel::PermuteLayer>(input_tensors, output_tensors, input_back_prop_tensors,
+                                           output_back_prop_tensors, _external_context);
 
   _return_fn = std::move(fn);
 }

--- a/runtime/onert/core/src/backend/builtin/train/kernel/PermuteLayer.cc
+++ b/runtime/onert/core/src/backend/builtin/train/kernel/PermuteLayer.cc
@@ -33,12 +33,10 @@ PermuteLayer::PermuteLayer(const std::vector<ITensor *> &src_tensors,
                            const std::vector<ITensor *> &dst_tensors,
                            const std::vector<ITensor *> &input_back_prop_tensors,
                            const std::vector<ITensor *> &output_back_prop_tensors,
-                           bool ignore_forward_in_training,
                            const std::shared_ptr<ExternalContext> &external_context)
   : builtin::kernel::PermuteLayer{src_tensors, dst_tensors, external_context},
     _input_back_prop_tensors{input_back_prop_tensors},
-    _output_back_prop_tensors{output_back_prop_tensors},
-    _ignore_forward_in_training{ignore_forward_in_training}
+    _output_back_prop_tensors{output_back_prop_tensors}
 {
   assert(input_back_prop_tensors.size() == output_back_prop_tensors.size());
   assert(src_tensors.size() == dst_tensors.size());
@@ -51,13 +49,7 @@ void PermuteLayer::optimize()
   // TODO Calculate offsets of back propagation tensors if necessary
 }
 
-void PermuteLayer::forward(bool training)
-{
-  if (training && _ignore_forward_in_training)
-    return;
-
-  builtin::kernel::PermuteLayer::run();
-}
+void PermuteLayer::forward(bool) { builtin::kernel::PermuteLayer::run(); }
 
 void PermuteLayer::backward()
 {

--- a/runtime/onert/core/src/backend/builtin/train/kernel/PermuteLayer.h
+++ b/runtime/onert/core/src/backend/builtin/train/kernel/PermuteLayer.h
@@ -38,7 +38,6 @@ public:
   PermuteLayer(const std::vector<ITensor *> &src_tensors, const std::vector<ITensor *> &dst_tensors,
                const std::vector<ITensor *> &input_back_prop_tensors,
                const std::vector<ITensor *> &output_back_prop_tensors,
-               bool ignore_forward_in_training,
                const std::shared_ptr<ExternalContext> &external_context);
 
   void optimize() override;
@@ -49,7 +48,6 @@ public:
 private:
   std::vector<ITensor *> _input_back_prop_tensors;
   std::vector<ITensor *> _output_back_prop_tensors;
-  bool _ignore_forward_in_training;
 };
 
 } // namespace kernel

--- a/runtime/onert/core/src/exec/train/TrainableExecutor.cc
+++ b/runtime/onert/core/src/exec/train/TrainableExecutor.cc
@@ -82,18 +82,15 @@ void TrainableExecutor::forward(const IODescription &desc, bool training)
                           desc.inputs[i]->size);
   }
 
-  if (!training)
+  // Set output(s)
+  assert(_output_tensors.size() == desc.outputs.size());
+  for (uint32_t i = 0; i < _output_tensors.size(); ++i)
   {
-    // Set output(s)
-    assert(_output_tensors.size() == desc.outputs.size());
-    for (uint32_t i = 0; i < _output_tensors.size(); ++i)
-    {
-      auto tensor = _output_tensors[i];
+    auto tensor = _output_tensors[i];
 
-      if (desc.outputs[i] == nullptr)
-        throw std::runtime_error{"Output " + std::to_string(i) + "'s buffer is not set."};
-      tensor->setUserTensor(static_cast<uint8_t *>(desc.outputs[i]->buffer), desc.outputs[i]->size);
-    }
+    if (desc.outputs[i] == nullptr)
+      throw std::runtime_error{"Output " + std::to_string(i) + "'s buffer is not set."};
+    tensor->setUserTensor(static_cast<uint8_t *>(desc.outputs[i]->buffer), desc.outputs[i]->size);
   }
 
   forwardImpl(training);

--- a/tests/nnfw_api/lib/GenModelTrain.h
+++ b/tests/nnfw_api/lib/GenModelTrain.h
@@ -22,15 +22,33 @@
 
 struct SessionObjectTraining : public SessionObjectGeneric
 {
+  std::vector<std::vector<uint8_t>> expects;
   std::vector<std::vector<uint8_t>> losses;
 };
 
 struct TrainCaseData : public TestCaseData
 {
   /**
+   * @brief A vector of extect buffers
+   */
+  std::vector<std::vector<uint8_t>> expects;
+
+  /**
    * @brief A vector of losses buffers
    */
   std::vector<std::vector<uint8_t>> losses;
+
+  /**
+   * @brief Append vector data to expects
+   *
+   * @tparam T Data type
+   * @param data vector data array
+   */
+  template <typename T> TrainCaseData &addExpects(const std::vector<T> &data)
+  {
+    addData(expects, data);
+    return *this;
+  }
 
   /**
    * @brief Append vector data to losses
@@ -53,7 +71,7 @@ struct TrainCaseData : public TestCaseData
  *
  * @tparam T Uniform tensor type
  * @param inputs Inputs tensor buffers
- * @param expects Outputs tensor buffers
+ * @param expects Expects tensor buffers
  * @param losses Losses tensor buffers
  * @return TrainCaseData Generated train case data
  */
@@ -66,7 +84,7 @@ static TrainCaseData uniformTCD(const std::vector<std::vector<T>> &inputs,
   for (const auto &data : inputs)
     ret.addInput(data);
   for (const auto &data : expects)
-    ret.addOutput(data);
+    ret.addExpects(data);
   for (const auto &data : losses)
     ret.addLosses(data);
   return ret;
@@ -228,20 +246,20 @@ protected:
       }
 
       // Prepare expected output
-      _so.outputs.resize(num_expecteds);
+      _so.expects.resize(num_expecteds);
       std::vector<nnfw_tensorinfo> expected_infos(num_expecteds);
       for (uint32_t ind = 0; ind < num_expecteds; ind++)
       {
         nnfw_tensorinfo ti;
         NNFW_ENSURE_SUCCESS(nnfw_output_tensorinfo(_so.session, ind, &ti));
         uint64_t output_elements = num_elems(&ti);
-        _so.outputs[ind].resize(output_elements * sizeOfNnfwType(ti.dtype));
+        _so.expects[ind].resize(output_elements * sizeOfNnfwType(ti.dtype));
 
         // Setting the output buffer size of specified output tensor is not supported yet
         ASSERT_EQ(_context->hasOutputSizes(ind), false);
 
         NNFW_ENSURE_SUCCESS(
-          nnfw_train_set_expected(_so.session, ind, _so.outputs[ind].data(), &ti));
+          nnfw_train_set_expected(_so.session, ind, _so.expects[ind].data(), &ti));
 
         expected_infos.emplace_back(std::move(ti));
       }
@@ -268,13 +286,13 @@ protected:
         }
 
         // Expected outputs
-        const auto &ref_outputs = train_case.outputs;
-        ASSERT_EQ(_so.outputs.size(), ref_outputs.size());
-        for (uint32_t i = 0; i < _so.outputs.size(); i++)
+        const auto &ref_expects = train_case.expects;
+        ASSERT_EQ(_so.expects.size(), ref_expects.size());
+        for (uint32_t i = 0; i < _so.expects.size(); i++)
         {
           // Fill the values
-          ASSERT_EQ(_so.outputs[i].size(), ref_outputs[i].size());
-          memcpy(_so.outputs[i].data(), ref_outputs[i].data(), ref_outputs[i].size());
+          ASSERT_EQ(_so.expects[i].size(), ref_expects[i].size());
+          memcpy(_so.expects[i].data(), ref_expects[i].data(), ref_expects[i].size());
         }
 
         // Expected losses


### PR DESCRIPTION
This commit changes the output buffer behaviour in training mode. The output buffer is used for computaional accuracy values, so output buffer must be allocated. And the PermuteLayer must be executed to transmit the output data to the output buffer.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Draft: #13062 
Requires: #13091 