### PR TITLE
[luci-interperter] Support S64 dtype on SelectV2

### DIFF
--- a/compiler/luci-interpreter/src/kernels/SelectV2.cpp
+++ b/compiler/luci-interpreter/src/kernels/SelectV2.cpp
@@ -59,6 +59,9 @@ void SelectV2::execute() const
     case DataType::S32:
       evaluate<int32_t>();
       break;
+    case DataType::S64:
+      evaluate<int64_t>();
+      break;
     default:
       throw std::runtime_error("luci-intp SelectV2 unsupported type.");
   }


### PR DESCRIPTION
This commit supports S64 dtype on SelectV2.

ONE-DCO-1.0-Signed-off-by: seongwoo <mhs4670go@naver.com>