### PR TITLE
[onert] Remove custom strip in cmake

### DIFF
--- a/runtime/contrib/gpu_cl/CMakeLists.txt
+++ b/runtime/contrib/gpu_cl/CMakeLists.txt
@@ -31,11 +31,6 @@ target_link_libraries(${LIB_ONERT_BACKEND_GPU_CL} PRIVATE nnfw_coverage)
 
 set_target_properties(${LIB_ONERT_BACKEND_GPU_CL} PROPERTIES OUTPUT_NAME backend_gpu_cl)
 
-if(CMAKE_BUILD_TYPE_LC STREQUAL "release")
-  add_custom_command(TARGET ${LIB_ONERT_BACKEND_GPU_CL} POST_BUILD
-                     COMMAND ${CMAKE_STRIP} "--strip-unneeded" $<TARGET_FILE_NAME:${LIB_ONERT_BACKEND_GPU_CL}>)
-endif()
-
 add_library(tflite_ignore_warnings INTERFACE)
 target_compile_options(tflite_ignore_warnings INTERFACE -Wno-unused-parameter -Wno-sign-compare)
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 10)

--- a/runtime/onert/api/nnapi/CMakeLists.txt
+++ b/runtime/onert/api/nnapi/CMakeLists.txt
@@ -12,11 +12,6 @@ target_link_libraries(${LIB_ONERT} PRIVATE nnfw_coverage)
 
 set_target_properties(${LIB_ONERT} PROPERTIES OUTPUT_NAME neuralnetworks)
 
-if(CMAKE_BUILD_TYPE_LC STREQUAL "release")
-  add_custom_command(TARGET ${LIB_ONERT} POST_BUILD
-                     COMMAND ${CMAKE_STRIP} "--strip-unneeded" $<TARGET_FILE_NAME:${LIB_ONERT}>)
-endif()
-
 install(TARGETS ${LIB_ONERT} DESTINATION lib)
 
 if(NOT ENABLE_TEST)

--- a/runtime/onert/api/nnfw/CMakeLists.txt
+++ b/runtime/onert/api/nnfw/CMakeLists.txt
@@ -24,11 +24,6 @@ endif (ANDROID)
 target_include_directories(${ONERT_DEV} PUBLIC include)
 set_target_properties(${ONERT_DEV} PROPERTIES PUBLIC_HEADER "${NNFW_API_HEADERS}")
 
-if(CMAKE_BUILD_TYPE_LC STREQUAL "release")
-  add_custom_command(TARGET ${ONERT_DEV} POST_BUILD
-                     COMMAND ${CMAKE_STRIP} "--strip-unneeded" $<TARGET_FILE_NAME:${ONERT_DEV}>)
-endif()
-
 install(TARGETS ${ONERT_DEV}
         LIBRARY DESTINATION lib
         PUBLIC_HEADER DESTINATION include/nnfw)

--- a/runtime/onert/api/python/CMakeLists.txt
+++ b/runtime/onert/api/python/CMakeLists.txt
@@ -31,10 +31,5 @@ pybind11_add_module(nnfw_api_pybind ${NNFW_API_PYBIND_SOURCES})
 target_include_directories(nnfw_api_pybind PRIVATE include)
 target_link_libraries(nnfw_api_pybind PRIVATE nnfw-dev)
 
-if(CMAKE_BUILD_TYPE_LC STREQUAL "release")
-  add_custom_command(TARGET nnfw_api_pybind POST_BUILD
-                     COMMAND ${CMAKE_STRIP} "--strip-unneeded" $<TARGET_FILE_NAME:nnfw_api_pybind>)
-endif()
-
 # Install the Python module
 install(TARGETS nnfw_api_pybind DESTINATION lib)

--- a/runtime/onert/backend/acl_cl/CMakeLists.txt
+++ b/runtime/onert/backend/acl_cl/CMakeLists.txt
@@ -16,9 +16,4 @@ target_link_libraries(${LIB_ONERT_BACKEND_ACL_CL} PRIVATE nnfw_coverage)
 
 set_target_properties(${LIB_ONERT_BACKEND_ACL_CL} PROPERTIES OUTPUT_NAME backend_acl_cl)
 
-if(CMAKE_BUILD_TYPE_LC STREQUAL "release")
-  add_custom_command(TARGET onert_backend_acl_cl POST_BUILD
-                     COMMAND ${CMAKE_STRIP} "--strip-unneeded" $<TARGET_FILE_NAME:onert_backend_acl_cl>)
-endif()
-
 install(TARGETS ${LIB_ONERT_BACKEND_ACL_CL} DESTINATION lib)

--- a/runtime/onert/backend/acl_neon/CMakeLists.txt
+++ b/runtime/onert/backend/acl_neon/CMakeLists.txt
@@ -16,9 +16,4 @@ target_link_libraries(${LIB_ONERT_BACKEND_ACL_NEON} PRIVATE nnfw_coverage)
 
 set_target_properties(${LIB_ONERT_BACKEND_ACL_NEON} PROPERTIES OUTPUT_NAME backend_acl_neon)
 
-if(CMAKE_BUILD_TYPE_LC STREQUAL "release")
-  add_custom_command(TARGET onert_backend_acl_neon POST_BUILD
-                     COMMAND ${CMAKE_STRIP} "--strip-unneeded" $<TARGET_FILE_NAME:onert_backend_acl_neon>)
-endif()
-
 install(TARGETS ${LIB_ONERT_BACKEND_ACL_NEON} DESTINATION lib)

--- a/runtime/onert/backend/cpu/CMakeLists.txt
+++ b/runtime/onert/backend/cpu/CMakeLists.txt
@@ -16,9 +16,4 @@ target_link_libraries(${LIB_ONERT_BACKEND_CPU} PRIVATE ndarray)
 set_target_properties(${LIB_ONERT_BACKEND_CPU} PROPERTIES OUTPUT_NAME backend_cpu)
 set_target_properties(${LIB_ONERT_BACKEND_CPU} PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
-if(CMAKE_BUILD_TYPE_LC STREQUAL "release")
-  add_custom_command(TARGET ${LIB_ONERT_BACKEND_CPU} POST_BUILD
-                     COMMAND ${CMAKE_STRIP} "--strip-unneeded" $<TARGET_FILE_NAME:${LIB_ONERT_BACKEND_CPU}>)
-endif()
-
 install(TARGETS ${LIB_ONERT_BACKEND_CPU} DESTINATION lib)

--- a/runtime/onert/backend/ruy/CMakeLists.txt
+++ b/runtime/onert/backend/ruy/CMakeLists.txt
@@ -14,9 +14,4 @@ target_link_libraries(${LIB_ONERT_BACKEND_RUY} PRIVATE ruy)
 
 set_target_properties(${LIB_ONERT_BACKEND_RUY} PROPERTIES OUTPUT_NAME backend_ruy)
 
-if(CMAKE_BUILD_TYPE_LC STREQUAL "release")
-  add_custom_command(TARGET ${LIB_ONERT_BACKEND_RUY} POST_BUILD
-                     COMMAND ${CMAKE_STRIP} "--strip-unneeded" $<TARGET_FILE_NAME:${LIB_ONERT_BACKEND_RUY}>)
-endif()
-
 install(TARGETS ${LIB_ONERT_BACKEND_RUY} DESTINATION lib)

--- a/runtime/onert/backend/train/CMakeLists.txt
+++ b/runtime/onert/backend/train/CMakeLists.txt
@@ -12,9 +12,4 @@ target_link_libraries(${LIB_ONERT_BACKEND_TRAIN} PRIVATE nnfw_coverage)
 
 set_target_properties(${LIB_ONERT_BACKEND_TRAIN} PROPERTIES OUTPUT_NAME backend_train)
 
-if(CMAKE_BUILD_TYPE_LC STREQUAL "release")
-  add_custom_command(TARGET ${LIB_ONERT_BACKEND_TRAIN} POST_BUILD
-                     COMMAND ${CMAKE_STRIP} "--strip-unneeded" $<TARGET_FILE_NAME:${LIB_ONERT_BACKEND_TRAIN}>)
-endif()
-
 install(TARGETS ${LIB_ONERT_BACKEND_TRAIN} DESTINATION lib)

--- a/runtime/onert/backend/trix/CMakeLists.txt
+++ b/runtime/onert/backend/trix/CMakeLists.txt
@@ -18,9 +18,4 @@ target_link_libraries(${LIB_ONERT_BACKEND_TRIX} PRIVATE nnfw_coverage)
 
 set_target_properties(${LIB_ONERT_BACKEND_TRIX} PROPERTIES OUTPUT_NAME backend_trix)
 
-if(CMAKE_BUILD_TYPE_LC STREQUAL "release")
-  add_custom_command(TARGET ${LIB_ONERT_BACKEND_TRIX} POST_BUILD
-                     COMMAND ${CMAKE_STRIP} "--strip-unneeded" $<TARGET_FILE_NAME:${LIB_ONERT_BACKEND_TRIX}>)
-endif()
-
 install(TARGETS ${LIB_ONERT_BACKEND_TRIX} DESTINATION lib)

--- a/runtime/onert/backend/xnnpack/CMakeLists.txt
+++ b/runtime/onert/backend/xnnpack/CMakeLists.txt
@@ -18,9 +18,4 @@ target_link_libraries(${LIB_ONERT_BACKEND_XNNPACK} PRIVATE XNNPACK)
 
 set_target_properties(${LIB_ONERT_BACKEND_XNNPACK} PROPERTIES OUTPUT_NAME backend_xnnpack)
 
-if(CMAKE_BUILD_TYPE_LC STREQUAL "release")
-  add_custom_command(TARGET ${LIB_ONERT_BACKEND_XNNPACK} POST_BUILD
-                     COMMAND ${CMAKE_STRIP} "--strip-unneeded" $<TARGET_FILE_NAME:${LIB_ONERT_BACKEND_XNNPACK}>)
-endif()
-
 install(TARGETS ${LIB_ONERT_BACKEND_XNNPACK} DESTINATION lib)

--- a/runtime/onert/core/CMakeLists.txt
+++ b/runtime/onert/core/CMakeLists.txt
@@ -40,11 +40,6 @@ if(BUILD_MINMAX_H5DUMPER)
   target_link_libraries(onert_core PRIVATE ${HDF5_CXX_LIBRARIES})
 endif(BUILD_MINMAX_H5DUMPER)
 
-if(CMAKE_BUILD_TYPE_LC STREQUAL "release")
-  add_custom_command(TARGET onert_core POST_BUILD
-                     COMMAND ${CMAKE_STRIP} "--strip-unneeded" $<TARGET_FILE_NAME:onert_core>)
-endif()
-
 # NOTE Below line is added to remove warning for android build
 #      It will be removed after android build uses gold linker
 if (ANDROID)

--- a/runtime/onert/loader/trix/CMakeLists.txt
+++ b/runtime/onert/loader/trix/CMakeLists.txt
@@ -18,9 +18,4 @@ target_link_libraries(tvn_loader PRIVATE onert_core)
 target_link_libraries(tvn_loader PRIVATE nnfw_common nnfw_coverage)
 target_link_libraries(tvn_loader PRIVATE trix_engine)
 
-if(CMAKE_BUILD_TYPE_LC STREQUAL "release")
-  add_custom_command(TARGET tvn_loader POST_BUILD
-                     COMMAND ${CMAKE_STRIP} "--strip-unneeded" $<TARGET_FILE_NAME:tvn_loader>)
-endif()
-
 install(TARGETS tvn_loader DESTINATION lib)

--- a/runtime/onert/odc/CMakeLists.txt
+++ b/runtime/onert/odc/CMakeLists.txt
@@ -13,11 +13,6 @@ target_link_libraries(onert_odc PRIVATE onert_core luci::import luci::export luc
 target_link_libraries(onert_odc PRIVATE nnfw_common)
 target_link_libraries(onert_odc PRIVATE nnfw_coverage)
 
-if(CMAKE_BUILD_TYPE_LC STREQUAL "release")
-  add_custom_command(TARGET onert_odc POST_BUILD
-                     COMMAND ${CMAKE_STRIP} "--strip-unneeded" $<TARGET_FILE_NAME:onert_odc>)
-endif()
-
 install(TARGETS onert_odc LIBRARY DESTINATION lib/nnfw/odc)
 set_target_properties(onert_odc PROPERTIES INSTALL_RPATH "$ORIGIN/../../:$ORIGIN/")
 

--- a/runtime/service/npud/backend/trix/CMakeLists.txt
+++ b/runtime/service/npud/backend/trix/CMakeLists.txt
@@ -18,9 +18,4 @@ if(ENVVAR_NPUD_CONFIG)
   target_compile_definitions(npud_backend_trix PRIVATE ENVVAR_FOR_DEFAULT_CONFIG)
 endif(ENVVAR_NPUD_CONFIG)
 
-if(CMAKE_BUILD_TYPE_LC STREQUAL "release")
-  add_custom_command(TARGET npud_backend_trix POST_BUILD
-                     COMMAND ${CMAKE_STRIP} "--strip-unneeded" $<TARGET_FILE_NAME:npud_backend_trix>)
-endif()
-
 install(TARGETS npud_backend_trix DESTINATION lib)


### PR DESCRIPTION
This commit removes cmake custom strip in cmake script. 
Strip is already supported by cmake command on release install, and used in makefile and spec file.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>