### PR TITLE
[onert] Add workspace directory compiler option

### DIFF
--- a/runtime/onert/api/nnfw/include/nnfw.h
+++ b/runtime/onert/api/nnfw/include/nnfw.h
@@ -509,7 +509,9 @@ NNFW_STATUS nnfw_query_info_u32(nnfw_session *session, NNFW_INFO_ID id, uint32_t
  * @brief     Set runtime's workspace directory
  *
  * <p>This function sets the directory to be used as a workspace.
- * System should should allow read and write access to the directory for the runtime.</p>
+ * System should allow read and write access to the directory for the runtime.
+ * Default workspace is running directory of the application.
+ * This function should be called before {@link nnfw_prepare} is invoked.</p>
  *
  * @param[in] session session to be queried on.
  * @param[in] dir     workspace directory path

--- a/runtime/onert/api/nnfw/src/nnfw_api_internal.cc
+++ b/runtime/onert/api/nnfw/src/nnfw_api_internal.cc
@@ -248,8 +248,7 @@ uint64_t getBufSize(const nnfw_tensorinfo *info)
 nnfw_session::nnfw_session()
   : _nnpkg{nullptr}, _coptions{onert::compiler::CompilerOptions::fromGlobalConfig()},
     _compiler_artifact{nullptr}, _execution{nullptr}, _kernel_registry{nullptr},
-    _train_info{nullptr}, _quant_manager{nullptr}, _codegen_manager{nullptr}, _model_path{""},
-    _workspace_dir{""}
+    _train_info{nullptr}, _quant_manager{nullptr}, _codegen_manager{nullptr}, _model_path{""}
 {
   // DO NOTHING
 }
@@ -975,7 +974,7 @@ NNFW_STATUS nnfw_session::set_workspace(const char *dir)
   if (!dir)
     return NNFW_STATUS_UNEXPECTED_NULL;
 
-  _workspace_dir = std::string(dir);
+  _coptions->workspace_dir = std::string(dir);
 
   // TODO Set workspace dir to workspace user (ex. compiler, quantization manager, etc)
   //      if model is already loaded

--- a/runtime/onert/api/nnfw/src/nnfw_api_internal.h
+++ b/runtime/onert/api/nnfw/src/nnfw_api_internal.h
@@ -229,7 +229,6 @@ private:
   //     const uint8 *buf;
   //   }
   std::string _model_path;
-  std::string _workspace_dir;
 };
 
 #endif // __API_NNFW_API_INTERNAL_H__

--- a/runtime/onert/core/include/compiler/CompilerOptions.h
+++ b/runtime/onert/core/include/compiler/CompilerOptions.h
@@ -81,9 +81,10 @@ public:
   int graph_dump_level;       //< Graph dump level, values between 0 and 2 are valid
   std::string executor;       //< Executor name to use
   ManualSchedulerOptions manual_scheduler_options; //< Options for ManualScheduler
-  bool he_scheduler;      //< HEScheduler if true, ManualScheduler otherwise
-  bool he_profiling_mode; //< Whether HEScheduler profiling mode ON/OFF
-  bool fp16_enable;       //< Whether fp16 mode ON/OFF
+  bool he_scheduler;         //< HEScheduler if true, ManualScheduler otherwise
+  bool he_profiling_mode;    //< Whether HEScheduler profiling mode ON/OFF
+  bool fp16_enable;          //< Whether fp16 mode ON/OFF
+  std::string workspace_dir; //< Workspace directory path
 };
 
 } // namespace compiler

--- a/runtime/onert/core/include/util/Config.lst
+++ b/runtime/onert/core/include/util/Config.lst
@@ -36,6 +36,7 @@ CONFIG(FP16_ENABLE             , bool         , "0")
 CONFIG(RUY_THREADS             , int          , "-1")
 CONFIG(XNNPACK_THREADS         , int          , "-1")
 CONFIG(USE_MMAPED_DATA         , bool         , "0")
+CONFIG(WORKSPACE_DIR           , std::string  , ".")
 
 // Auto-generate all operations
 

--- a/runtime/onert/core/src/compiler/CompilerOptions.cc
+++ b/runtime/onert/core/src/compiler/CompilerOptions.cc
@@ -82,6 +82,7 @@ std::unique_ptr<CompilerOptions> CompilerOptions::fromGlobalConfig()
   o->he_scheduler = util::getConfigBool(util::config::USE_SCHEDULER);
   o->he_profiling_mode = util::getConfigBool(util::config::PROFILING_MODE);
   o->fp16_enable = util::getConfigBool(util::config::FP16_ENABLE);
+  o->workspace_dir = util::getConfigString(util::config::WORKSPACE_DIR);
   {
     // Backend for all
     auto &ms_options = o->manual_scheduler_options;


### PR DESCRIPTION
This commit adds workspace directory compiler option and global config. It replaces session's workspace_dir field.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

It requires #13053 merge