### PR TITLE
[onert] Fix android packaging fail

### DIFF
--- a/runtime/contrib/android/api/Prebuilt.mk
+++ b/runtime/contrib/android/api/Prebuilt.mk
@@ -26,7 +26,7 @@ include $(CLEAR_VARS)
 LOCAL_MODULE := backend_cpu
 PREBUILT_LIB += backend_cpu
 LOCAL_SRC_FILES := \
-		$(ONERT_PREBUILT_LIB_DIR)/libbackend_cpu.so
+		$(ONERT_PREBUILT_LIB_DIR)/nnfw/backend/libbackend_cpu.so
 include $(PREBUILT_SHARED_LIBRARY)
 
 # TODO Support backend acl


### PR DESCRIPTION
This commit fixes android packaging fail by invalid path in Prebuilt.mk

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: #13074