### PR TITLE
[onert] Run PermuteLayer in training mode

### DIFF
--- a/runtime/onert/core/src/backend/builtin/train/kernel/PermuteLayer.cc
+++ b/runtime/onert/core/src/backend/builtin/train/kernel/PermuteLayer.cc
@@ -51,9 +51,9 @@ void PermuteLayer::optimize()
   // TODO Calculate offsets of back propagation tensors if necessary
 }
 
-void PermuteLayer::forward(bool training)
+void PermuteLayer::forward(bool)
 {
-  if (training && _ignore_forward_in_training)
+  if (_ignore_forward_in_training)
     return;
 
   builtin::kernel::PermuteLayer::run();

--- a/runtime/onert/core/src/exec/train/TrainableExecutor.cc
+++ b/runtime/onert/core/src/exec/train/TrainableExecutor.cc
@@ -88,9 +88,9 @@ void TrainableExecutor::forward(const IODescription &desc, bool training)
   {
     auto tensor = _output_tensors[i];
 
-    if (desc.outputs[i] == nullptr)
-      throw std::runtime_error{"Output " + std::to_string(i) + "'s buffer is not set."};
-    tensor->setUserTensor(static_cast<uint8_t *>(desc.outputs[i]->buffer), desc.outputs[i]->size);
+    assert(desc.outputs[i] != nullptr);
+    if (desc.outputs[i]->buffer != nullptr && desc.outputs[i]->size != 0)
+      tensor->setUserTensor(static_cast<uint8_t *>(desc.outputs[i]->buffer), desc.outputs[i]->size);
   }
 
   forwardImpl(training);

--- a/runtime/onert/core/src/exec/train/TrainableExecutor.cc
+++ b/runtime/onert/core/src/exec/train/TrainableExecutor.cc
@@ -82,18 +82,15 @@ void TrainableExecutor::forward(const IODescription &desc, bool training)
                           desc.inputs[i]->size);
   }
 
-  if (!training)
+  // Set output(s)
+  assert(_output_tensors.size() == desc.outputs.size());
+  for (uint32_t i = 0; i < _output_tensors.size(); ++i)
   {
-    // Set output(s)
-    assert(_output_tensors.size() == desc.outputs.size());
-    for (uint32_t i = 0; i < _output_tensors.size(); ++i)
-    {
-      auto tensor = _output_tensors[i];
+    auto tensor = _output_tensors[i];
 
-      if (desc.outputs[i] == nullptr)
-        throw std::runtime_error{"Output " + std::to_string(i) + "'s buffer is not set."};
-      tensor->setUserTensor(static_cast<uint8_t *>(desc.outputs[i]->buffer), desc.outputs[i]->size);
-    }
+    if (desc.outputs[i] == nullptr)
+      throw std::runtime_error{"Output " + std::to_string(i) + "'s buffer is not set."};
+    tensor->setUserTensor(static_cast<uint8_t *>(desc.outputs[i]->buffer), desc.outputs[i]->size);
   }
 
   forwardImpl(training);


### PR DESCRIPTION
This commit runs PermuteLayer when the output buffer is specified. This changes copies the output data from the model to the output buffer provided by the user.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Draft: #13062 