### PR TITLE
[infra] Remove android sdk in ubuntu 20.04 docker image

### DIFF
--- a/docs/howto/how-to-cross-build-runtime-for-android.md
+++ b/docs/howto/how-to-cross-build-runtime-for-android.md
@@ -15,10 +15,10 @@ Or you can use `tools/cross/install_android_sdk.sh` script to prepare Android SD
 ### Host Environment Requirements
 
 CMake 3.6.0 or later is required for Android NDK r20 CMake support.
-So if you want to use Docker, please use `infra/docker/focal/Dockerfile` which is based on Ubuntu 20.04. It has CMake 3.16.3.
+So if you want to use Docker, please use `infra/docker/android-sdk/Dockerfile`.
 
 ```
-$ ./nnas build-docker-image -t nnfw/one-devtools:focal
+$ ./nnas build-docker-image --codename android-sdk -t nnfw/one-devtools:android-sdk
 ```
 
 

--- a/infra/docker/focal/Dockerfile
+++ b/infra/docker/focal/Dockerfile
@@ -57,11 +57,6 @@ RUN cp tmp/data/tools/sdb /usr/bin/. && rm -rf tmp/*
 # ARM none eabi build tool
 RUN apt-get update && apt-get -qqy install gcc-arm-none-eabi
 
-# Install java for gradle and android sdk
-ARG OPENJDK_VERSION=11
-RUN apt-get install -y openjdk-${OPENJDK_VERSION}-jdk
-ENV JAVA_HOME /usr/lib/jvm/java-${OPENJDK_VERSION}-openjdk-amd64
-
 # Env for ko encoding build
 ENV LC_ALL "C.UTF-8"
 
@@ -78,38 +73,3 @@ RUN apt-get clean -y
 # Set user to the one we just created
 USER ${USER_ID}
 WORKDIR /home/ubuntu
-
-# download and install Gradle
-# https://services.gradle.org/distributions/
-ARG GRADLE_VERSION=6.4.1
-ARG GRADLE_DIST=bin
-RUN wget -q https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-${GRADLE_DIST}.zip && \
-    unzip gradle*.zip && \
-    ls -d */ | sed 's/\/*$//g' | xargs -I{} mv {} gradle && \
-    rm gradle*.zip
-
-# download and install Android SDK
-# https://developer.android.com/studio#command-tools
-ENV ANDROID_HOME /home/ubuntu/android-sdk
-RUN wget -q -O commandlinetools.zip https://dl.google.com/android/repository/commandlinetools-linux-6514223_latest.zip
-
-# Unzip bootstrap cmdline-tools (old version) to tmp dir and install cmdline-tools (latest openjdk supporting version)
-# accept the license agreements of the SDK components
-ARG CMDTOOLS_VERSION=10.0
-RUN unzip -d tmp commandlinetools.zip && rm commandlinetools.zip
-RUN yes | tmp/tools/bin/sdkmanager --sdk_root=${ANDROID_HOME} --licenses > /dev/null
-RUN tmp/tools/bin/sdkmanager --sdk_root=${ANDROID_HOME} "cmdline-tools;${CMDTOOLS_VERSION}"
-RUN rm -rf tmp
-
-# Install android ndk and tools (other packages will be installed by gradle build)
-ARG NDK_VERSION=20.0.5594570
-RUN ${ANDROID_HOME}/cmdline-tools/${CMDTOOLS_VERSION}/bin/sdkmanager --sdk_root=${ANDROID_HOME} "ndk;${NDK_VERSION}"
-RUN ${ANDROID_HOME}/cmdline-tools/${CMDTOOLS_VERSION}/bin/sdkmanager --sdk_root=${ANDROID_HOME} "platform-tools"
-
-# Env variable for android build (ndk, gradle)
-ENV NDK_DIR ${ANDROID_HOME}/ndk/${NDK_VERSION}
-ENV GRADLE_HOME /home/ubuntu/gradle
-ENV PATH ${PATH}:${GRADLE_HOME}/bin:${ANDROID_HOME}/cmdline-tools/10.0/bin:${ANDROID_HOME}/tools:${ANDROID_HOME}/tools/bin:${ANDROID_HOME}/platform-tools
-
-# setup adb server
-EXPOSE 5037


### PR DESCRIPTION
This commit removes android sdk and packages for android build in ubuntu 20.04 docker image.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>