### PR TITLE
[onert_run] Support different random input on each rerun

### DIFF
--- a/tests/tools/onert_run/src/args.cc
+++ b/tests/tools/onert_run/src/args.cc
@@ -272,6 +272,7 @@ void Args::Initialize(void)
         "If not given, the model's output sizes are used\n"
         "e.g. '[0, 40, 2, 80]' to set 0th tensor to 40 and 2nd tensor to 80.\n")
     ("num_runs,r", po::value<int>()->default_value(1)->notifier([&](const auto &v) { _num_runs = v; }), "The number of runs")
+    ("fixed_input", "Use same random input data on each run (avaliable on random input)")
     ("warmup_runs,w", po::value<int>()->default_value(0)->notifier([&](const auto &v) { _warmup_runs = v; }), "The number of warmup runs")
     ("run_delay,t", po::value<int>()->default_value(-1)->notifier([&](const auto &v) { _run_delay = v; }), "Delay time(us) between runs (as default no delay")
     ("gpumem_poll,g", po::value<bool>()->default_value(false)->notifier([&](const auto &v) { _gpumem_poll = v; }), "Check gpu memory polling separately")
@@ -366,6 +367,11 @@ void Args::Parse(const int argc, char **argv)
     if (!vm.count("modelfile") && !vm.count("nnpackage") && !vm.count("path"))
       throw boost::program_options::error(
         std::string("Require one of options modelfile, nnpackage, or path."));
+  }
+
+  if (vm.count("fixed_input"))
+  {
+    _fixed_input = true;
   }
 
   try

--- a/tests/tools/onert_run/src/args.h
+++ b/tests/tools/onert_run/src/args.h
@@ -58,6 +58,7 @@ public:
   const std::string &getDumpRawInputFilename(void) const { return _dump_raw_input_filename; }
   const std::string &getLoadRawFilename(void) const { return _load_raw_filename; }
   const int getNumRuns(void) const { return _num_runs; }
+  const bool getFixedInput(void) const { return _fixed_input; }
   const int getWarmupRuns(void) const { return _warmup_runs; }
   const int getRunDelay(void) const { return _run_delay; }
   std::unordered_map<uint32_t, uint32_t> getOutputSizes(void) const { return _output_sizes; }
@@ -96,6 +97,7 @@ private:
   TensorShapeMap _shape_prepare;
   TensorShapeMap _shape_run;
   int _num_runs;
+  bool _fixed_input = false;
   int _warmup_runs;
   int _run_delay;
   std::unordered_map<uint32_t, uint32_t> _output_sizes;

--- a/tests/tools/onert_run/src/randomgen.cc
+++ b/tests/tools/onert_run/src/randomgen.cc
@@ -36,33 +36,31 @@ template <class T> void randomData(benchmark::RandomGenerator &randgen, void *da
 void RandomGenerator::generate(std::vector<Allocation> &inputs)
 {
   // generate random data
-  const int seed = 1;
-  benchmark::RandomGenerator randgen{seed, 0.0f, 2.0f};
   for (uint32_t i = 0; i < inputs.size(); ++i)
   {
     auto input_size_in_bytes = inputs[i].size();
     switch (inputs[i].type())
     {
       case NNFW_TYPE_TENSOR_FLOAT32:
-        randomData<float>(randgen, inputs[i].data(), input_size_in_bytes);
+        randomData<float>(generator_, inputs[i].data(), input_size_in_bytes);
         break;
       case NNFW_TYPE_TENSOR_QUANT8_ASYMM:
-        randomData<uint8_t>(randgen, inputs[i].data(), input_size_in_bytes);
+        randomData<uint8_t>(generator_, inputs[i].data(), input_size_in_bytes);
         break;
       case NNFW_TYPE_TENSOR_BOOL:
-        randomData<bool>(randgen, inputs[i].data(), input_size_in_bytes);
+        randomData<bool>(generator_, inputs[i].data(), input_size_in_bytes);
         break;
       case NNFW_TYPE_TENSOR_UINT8:
-        randomData<uint8_t>(randgen, inputs[i].data(), input_size_in_bytes);
+        randomData<uint8_t>(generator_, inputs[i].data(), input_size_in_bytes);
         break;
       case NNFW_TYPE_TENSOR_INT32:
-        randomData<int32_t>(randgen, inputs[i].data(), input_size_in_bytes);
+        randomData<int32_t>(generator_, inputs[i].data(), input_size_in_bytes);
         break;
       case NNFW_TYPE_TENSOR_INT64:
-        randomData<int64_t>(randgen, inputs[i].data(), input_size_in_bytes);
+        randomData<int64_t>(generator_, inputs[i].data(), input_size_in_bytes);
         break;
       case NNFW_TYPE_TENSOR_QUANT16_SYMM_SIGNED:
-        randomData<int16_t>(randgen, inputs[i].data(), input_size_in_bytes);
+        randomData<int16_t>(generator_, inputs[i].data(), input_size_in_bytes);
         break;
       default:
         std::cerr << "Not supported input type" << std::endl;

--- a/tests/tools/onert_run/src/randomgen.h
+++ b/tests/tools/onert_run/src/randomgen.h
@@ -21,16 +21,21 @@
 #include <vector>
 
 #include "allocation.h"
-
-struct nnfw_session;
+#include "benchmark/RandomGenerator.h"
 
 namespace onert_run
 {
 class RandomGenerator
 {
 public:
-  RandomGenerator() = default;
+  RandomGenerator() : generator_(1, 0.0f, 2.0f)
+  {
+    // DO NOTHING
+  }
   void generate(std::vector<Allocation> &inputs);
+
+private:
+  benchmark::RandomGenerator generator_;
 };
 } // namespace onert_run
 


### PR DESCRIPTION
This commit updates random generator to support different random input on each rerun.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

Related issue: #13008