### PR TITLE
Draft: compiler build issue in Ubuntu 24.04

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@
 
 # Makefile
 /Makefile
+
+/.cache/

--- a/compiler/arser/include/arser/arser.h
+++ b/compiler/arser/include/arser/arser.h
@@ -33,6 +33,7 @@
 #include <cstring>
 
 #include <cassert>
+#include <cstdint>
 
 namespace arser
 {

--- a/compiler/circle-partitioner/src/HelperPath.h
+++ b/compiler/circle-partitioner/src/HelperPath.h
@@ -18,6 +18,7 @@
 #define __CIRCLE_HELPER_PATH_H__
 
 #include <string>
+#include <cstdint>
 
 namespace partee
 {

--- a/compiler/common-artifacts/CMakeLists.txt
+++ b/compiler/common-artifacts/CMakeLists.txt
@@ -4,17 +4,29 @@
 #   Ubuntu20.04; default python3.8
 #   Ubuntu22.04; default python3.10
 #   refer https://github.com/Samsung/ONE/issues/9962
-find_package(PythonInterp 3.8 QUIET)
-find_package(PythonLibs 3.8 QUIET)
+find_package(Python3 3.8 QUIET COMPONENTS Interpreter Development)
 
-if(NOT ${PYTHONINTERP_FOUND})
+if(NOT Python3_FOUND)
   message(STATUS "Build common-artifacts: FALSE (Python3 is missing)")
   return()
 endif()
 
+execute_process(
+    COMMAND ${Python3_EXECUTABLE} -c "import sys; print(sys.version_info.minor)"
+    OUTPUT_VARIABLE PYTHON_VERSION_MINOR
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
 if(${PYTHON_VERSION_MINOR} LESS 8)
   message(STATUS "Build common-artifacts: FALSE (You need to install Python version higher than 3.8)")
   return()
+endif()
+
+set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE})
+
+# tensorflow 2.12.1 is not available for Python 3.12
+if(${PYTHON_VERSION_MINOR} GREATER_EQUAL 12)
+  set(PYTHON_EXECUTABLE python3.11)
 endif()
 
 # Create python virtual environment with tensorflow 2.12.1

--- a/compiler/crew/src/PConfigJson.h
+++ b/compiler/crew/src/PConfigJson.h
@@ -20,6 +20,7 @@
 #include <ostream>
 #include <string>
 #include <vector>
+#include <cstdint>
 
 namespace crew
 {

--- a/compiler/dalgona/CMakeLists.txt
+++ b/compiler/dalgona/CMakeLists.txt
@@ -3,13 +3,18 @@
 #   Ubuntu20.04; default python3.8
 #   Ubuntu22.04; default python3.10
 #   refer https://github.com/Samsung/ONE/issues/9962
-find_package(PythonInterp 3.8 QUIET)
-find_package(PythonLibs 3.8 QUIET)
+find_package(Python3 3.8 QUIET COMPONENTS Interpreter Development)
 
-if(NOT ${PYTHONINTERP_FOUND})
+if(NOT Python3_FOUND)
   message(STATUS "Build dalgona: FAILED (Python3 is missing)")
   return()
 endif()
+
+execute_process(
+  COMMAND ${Python3_EXECUTABLE} -c "import sys; print(sys.version_info.minor)"
+  OUTPUT_VARIABLE PYTHON_VERSION_MINOR
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
 
 if(${PYTHON_VERSION_MINOR} LESS 8)
   message(STATUS "Build dalgona: FAILED (Install Python version higher than or equal to 3.8)")
@@ -32,11 +37,11 @@ add_compile_options(-fvisibility=hidden)
 
 add_executable(dalgona ${DRIVER} ${SOURCES})
 target_include_directories(dalgona PRIVATE include)
-target_include_directories(dalgona PRIVATE ${PYTHON_INCLUDE_DIRS})
+target_include_directories(dalgona PRIVATE ${Python3_INCLUDE_DIRS})
 target_include_directories(dalgona PRIVATE ${Pybind11_INCLUDE_DIRS})
 
 target_link_libraries(dalgona INTERFACE pybind11::embed)
-target_link_libraries(dalgona PRIVATE ${PYTHON_LIBRARIES})
+target_link_libraries(dalgona PRIVATE Python3::Python)
 target_link_libraries(dalgona PRIVATE arser)
 target_link_libraries(dalgona PRIVATE safemain)
 target_link_libraries(dalgona PRIVATE foder)

--- a/compiler/one-cmds/CMakeLists.txt
+++ b/compiler/one-cmds/CMakeLists.txt
@@ -3,18 +3,25 @@
 #   Ubuntu20.04; default python3.8
 #   Ubuntu22.04; default python3.10
 #   refer https://github.com/Samsung/ONE/issues/9962
-find_package(PythonInterp 3.8 QUIET)
-find_package(PythonLibs 3.8 QUIET)
+find_package(Python3 3.8 QUIET COMPONENTS Interpreter Development)
 
-if(NOT ${PYTHONINTERP_FOUND})
+if(NOT Python3_FOUND)
   message(STATUS "Build one-cmds: FALSE (Python3 is missing)")
   return()
 endif()
+
+execute_process(
+    COMMAND ${Python3_EXECUTABLE} -c "import sys; print(sys.version_info.minor)"
+    OUTPUT_VARIABLE PYTHON_VERSION_MINOR
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
 
 if(${PYTHON_VERSION_MINOR} LESS 8)
   message(STATUS "Build one-cmds: FALSE (You need to install Python version higher than 3.8)")
   return()
 endif()
+
+set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE})
 
 # NOTE these files should not have extensions.
 #      below code will remove extension when copy and install.

--- a/compiler/oops/include/oops/InternalExn.h
+++ b/compiler/oops/include/oops/InternalExn.h
@@ -19,6 +19,7 @@
 
 #include <exception>
 #include <string>
+#include <cstdint>
 
 /// @ brief throw internal exception with message
 #define INTERNAL_EXN(msg) throw oops::InternalExn(__FILE__, __LINE__, msg)

--- a/compiler/souschef/src/LexicalCast.cpp
+++ b/compiler/souschef/src/LexicalCast.cpp
@@ -19,6 +19,7 @@
 #include <cassert>
 #include <limits>
 #include <stdexcept>
+#include <cstdint>
 
 namespace souschef
 {

--- a/compiler/tfldump/driver/Driver.cpp
+++ b/compiler/tfldump/driver/Driver.cpp
@@ -19,6 +19,7 @@
 #include <tfldump/Dump.h>
 
 #include <iostream>
+#include <cstdint>
 
 int entry(int argc, char **argv)
 {


### PR DESCRIPTION
I encountered some minor issues, when i build the one-compiler.

Issues
- Some modules use std sized integer types(uint32_t, uint64_t), but cc can't resolve the types.
- PYTHON_MINOR_VERSION, PYTHON_EXECUTABLE is not defined in my working environment.
- Ubuntu 24.04's default python version is python12.3, but tensorflow ~~2.16.2~~2.12.1  is not available for python12.

I'm not sure, It is right revision.

Please review my PR.
Thank you.