### PR TITLE
[onert] Fix MinMaxRecorder header include

### DIFF
--- a/runtime/onert/odc/MinMaxReader.cc
+++ b/runtime/onert/odc/MinMaxReader.cc
@@ -16,8 +16,8 @@
 
 #include "MinMaxReader.h"
 
+#include <cstdio>
 #include <stdexcept>
-#include <iostream>
 
 namespace
 {

--- a/runtime/onert/odc/MinMaxReader.h
+++ b/runtime/onert/odc/MinMaxReader.h
@@ -17,8 +17,8 @@
 #ifndef __ONERT_ODC_MINMAX_READER_H__
 #define __ONERT_ODC_MINMAX_READER_H__
 
+#include <cstdint>
 #include <string>
-#include <utility>
 #include <vector>
 
 namespace onert


### PR DESCRIPTION
This commit fixes the header include of MinMaxRecorder.h/cc.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

---

It will resolve build fail on gcc >= 13.