### PR TITLE
[onert-micro] Introduce OMTraining entities

### DIFF
--- a/onert-micro/onert-micro/include/OMConfig.h
+++ b/onert-micro/onert-micro/include/OMConfig.h
@@ -17,13 +17,86 @@
 #ifndef ONERT_MICRO_CONFIG_H
 #define ONERT_MICRO_CONFIG_H
 
+#include <stdint.h>
+#include <stdlib.h>
+
 namespace onert_micro
 {
 
+/*
+ * OMTrainOptimizer - enum to store optimizers supported by training with onert-micro
+ */
+enum OMTrainOptimizer
+{
+  SGD,
+  ADAM,
+};
+
+/*
+ * OMMetrics - enum to store metrics supported by training with onert-micro
+ */
+enum OMMetrics
+{
+  MSE_METRICS,
+  MAE_METRICS,
+  CROSS_ENTROPY_METRICS,
+  ACCURACY,
+};
+
+/*
+ * OMLoss - enum to store loss supported by training with onert-micro
+ */
+enum OMLoss
+{
+  BINARY_CROSS_ENTROPY,
+  CROSS_ENTROPY,
+  MSE,
+  MAE,
+};
+
+/*
+ * OMTrainingContext contains training specific parameters
+ * batch_size - batch size for training (Note: 1 - default one)
+ * num_of_train_layers - number of trainable last layers (Note: 0 - all layers will be trained)
+ * optimizer - optimizer which onert-micro training will be used (Note: SGD - default one)
+ * loss - loss which onert-micro training will be used (Note: CROSS_ENTROPY - default one)
+ * learning_rate - used by all optimizers
+ * beta - used by ADAM optimizer
+ * beta_squares - used by ADAM optimizer
+ * epsilon - used by ADAM optimizer
+ * num_Step - used by ADAM optimizer
+ */
+struct OMTrainingContext
+{
+  uint32_t batch_size = 1;
+  uint32_t num_of_train_layers = 0;
+  OMTrainOptimizer optimizer = SGD;
+  OMLoss loss = MSE;
+  float learning_rate = 0.f;
+  float beta = 0.9f;
+  float beta_squares = 0.9f;
+  float epsilon = 10e-8;
+  uint32_t num_step = batch_size;
+  uint32_t num_epoch = 0;
+};
+
+/*
+ * OMConfig - main config to store information for runtime and for training runtime
+ * keep_input - will the allocated memory be saved for the input data, or can it be deleted after
+ * use cmsis_nn - will CMSIS NN kernels be used or not (needed to some internal settings) wof_ptr -
+ * a pointer to the data that stores weights separate from the model train_mode - a flag to indicate
+ * whether we are currently in training mode or not
+ */
 struct OMConfig
 {
   bool keep_input = false;
   bool cmsis_nn = false;
+  // For case with divided weights and circle file
+  char *wof_ptr = nullptr;
+  bool train_mode = false;
+  char *model_ptr = nullptr;
+  size_t model_size = 0;
+  OMTrainingContext training_context = {};
 };
 
 } // namespace onert_micro

--- a/onert-micro/onert-micro/include/OMConfig.h
+++ b/onert-micro/onert-micro/include/OMConfig.h
@@ -72,11 +72,11 @@ struct OMTrainingContext
   uint32_t num_of_train_layers = 0;
   OMTrainOptimizer optimizer = SGD;
   OMLoss loss = MSE;
-  float learning_rate = 0.f;
+  float learning_rate = 0.001f;
   float beta = 0.9f;
   float beta_squares = 0.9f;
   float epsilon = 10e-8;
-  uint32_t num_step = batch_size;
+  uint32_t num_step = 0;
   uint32_t num_epoch = 0;
 };
 

--- a/onert-micro/onert-micro/include/OMStatus.h
+++ b/onert-micro/onert-micro/include/OMStatus.h
@@ -32,6 +32,8 @@ enum OMStatus
   FailedCheckCondition,
   NoQuantization,
   UnsupportedDynamicShapeCase,
+  FailReadWOFFile,
+  FailReadCheckpointFile,
 };
 
 } // namespace onert_micro

--- a/onert-micro/onert-micro/include/OMTrainingInterpreter.h
+++ b/onert-micro/onert-micro/include/OMTrainingInterpreter.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ONERT_MICRO_TRAINING_INTERPRETER_H
+#define ONERT_MICRO_TRAINING_INTERPRETER_H
+
+#include "OMStatus.h"
+#include "OMConfig.h"
+
+#include "core/OMTrainingRuntimeModule.h"
+
+namespace onert_micro
+{
+
+class OMTrainingInterpreter
+{
+private:
+  core::OMTrainingRuntimeModule _training_runtime_module;
+
+public:
+  OMTrainingInterpreter() = default;
+  OMTrainingInterpreter(const OMTrainingInterpreter &) = delete;
+  OMTrainingInterpreter(OMTrainingInterpreter &&) = delete;
+  OMTrainingInterpreter &operator=(const OMTrainingInterpreter &) = delete;
+  OMTrainingInterpreter &&operator=(const OMTrainingInterpreter &&) = delete;
+  ~OMTrainingInterpreter() = default;
+
+  // Import train model with current config settings
+  // Note: model ptr should be non-const to save result
+  OMStatus importTrainModel(char *model_ptr, const OMConfig &config);
+
+  // Set input data for input with input_index
+  // Note: number of the samples in data should be equal to the batch_size in config structure
+  void setInput(uint8_t *data, uint32_t input_index)
+  {
+    _training_runtime_module.setInputData(data, input_index);
+  }
+  // Set target data for output with target_index
+  // Note: number of the samples in data should be equal to the batch_size in config structure
+  void setTarget(uint8_t *data, uint32_t target_index)
+  {
+    _training_runtime_module.setTargetData(data, target_index);
+  }
+
+  // Train single step: run forward graph (with data which was set in SetInput) ->
+  // -> calculate error (with target data which was set in SetTarget) ->
+  // -> run backward graph -> update optimizer state -> after batch_size steps update weights
+  // Warning: before using trainSingleStep call: 1) importTrainModel; 2) setInput; 3) setTarget
+  OMStatus trainSingleStep(OMConfig &config);
+
+  // Reset all states and data saved into OMTrainingInterpreter (trained weights will not be reset)
+  OMStatus reset();
+
+  // Calculate and save metric into metric_val: run forward graph -> calculate metric
+  // Note: calculation will be done on test_size number of test samples
+  // Warning: before using evaluateMetric call: 1) importTrainModel; 2) setInput; 3) setTarget
+  // Note: number of the samples in data should be equal to the test_size
+  OMStatus evaluateMetric(OMMetrics metric, void *metric_val, uint32_t test_size)
+  {
+    return _training_runtime_module.evaluateMetric(metric, metric_val, test_size);
+  }
+
+  // To get input and output flat size
+  uint32_t getInputSizeAt(uint32_t position);
+  uint32_t getOutputSizeAt(uint32_t position);
+
+  // Save current model
+  OMStatus saveModel(const OMConfig &config, const char *save_path);
+
+  // Save current status as checkpoint
+  OMStatus saveCheckpoint(const OMConfig &config, const char *save_path);
+
+  // Load current status from checkpoint and save it in current model and in current config
+  OMStatus loadCheckpoint(OMConfig &config, const char *load_path);
+};
+
+} // namespace onert_micro
+
+#endif // ONERT_MICRO_TRAINING_INTERPRETER_H

--- a/onert-micro/onert-micro/include/core/OMTrainingRuntimeModule.h
+++ b/onert-micro/onert-micro/include/core/OMTrainingRuntimeModule.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ONERT_MICRO_CORE_TRAINING_RUNTIME_MODULE_H
+#define ONERT_MICRO_CORE_TRAINING_RUNTIME_MODULE_H
+
+#include "OMStatus.h"
+#include "OMConfig.h"
+#include "core/OMRuntimeModule.h"
+#include "core/train/OMTrainingHandler.h"
+
+#include <vector>
+
+namespace onert_micro
+{
+namespace core
+{
+/*
+ * Class to handle all training process
+ */
+class OMTrainingRuntimeModule : public OMRuntimeModule
+{
+private:
+  // Store backwards graphs
+  std::vector<OMRuntimeGraph> _backward_graphs;
+  // Store training handler
+  train::OMTrainingHandler _training_handler;
+
+public:
+  OMTrainingRuntimeModule() = default;
+  OMTrainingRuntimeModule(const OMTrainingRuntimeModule &) = delete;
+  OMTrainingRuntimeModule(OMTrainingRuntimeModule &&) = delete;
+  OMTrainingRuntimeModule &operator=(const OMTrainingRuntimeModule &) = delete;
+  OMTrainingRuntimeModule &&operator=(const OMTrainingRuntimeModule &&) = delete;
+  ~OMTrainingRuntimeModule() = default;
+
+  // Import train model with current config settings
+  // Note: model ptr should be non-const to save result
+  OMStatus importTrainModel(char *model_ptr, const OMConfig &config);
+
+  // Train single step: run forward graph (with data which was set in SetInput) ->
+  // -> calculate error (with target data which was set in SetTarget) ->
+  // -> run backward graph -> update optimizer state -> after batch_size steps update weights
+  // Warning: before using trainSingleStep call: 1) importTrainModel; 2) setInput; 3) setTarget
+  OMStatus trainSingleStep(OMConfig &config);
+
+  // Reset all states and data saved into OMTrainingInterpreter (trained weights will not be reset)
+  OMStatus reset();
+
+  // Calculate and save metric into metric_val: run forward graph -> calculate metric
+  // Note: calculation will be done on test_size number of test samples
+  // Warning: before using evaluateMetric call: 1) importTrainModel; 2) setInput; 3) setTarget
+  // Note: number of the samples in data should be equal to the test_size
+  // Warning: 1) assume that all metric_val for all OMMetrics types actually are float values.
+  //          2) metric_val should be initialized with some value before calling this method due to
+  //             after calculation for current batch_num (the sequence number of the current sample)
+  //             this value is added to metric_val
+  OMStatus evaluateMetric(OMMetrics metric, void *metric_val, uint32_t test_size);
+
+  // Set input data for input with input_index
+  // Note: number of the samples in data should be equal to the batch_size in config structure
+  void setInputData(uint8_t *data, uint32_t input_index)
+  {
+    _training_handler.setInputData(data, input_index);
+  }
+  // Set target data for output with target_index
+  // Note: number of the samples in data should be equal to the batch_size in config structure
+  void setTargetData(uint8_t *data, uint32_t target_index)
+  {
+    _training_handler.setTargetData(data, target_index);
+  }
+
+  // Create and save checkpoint data into data_buffer vector
+  // To check checkpoint file format please see https://github.com/Samsung/ONE/discussions/13037
+  OMStatus createCheckpointFile(const OMConfig &config, std::vector<char> &data_buffer);
+
+  // Load checkpoints data and save it in model data and in config
+  // To check checkpoint file format please see https://github.com/Samsung/ONE/discussions/13037
+  OMStatus loadCheckpointData(OMConfig &config, const char *data);
+};
+
+} // namespace core
+} // namespace onert_micro
+
+#endif // ONERT_MICRO_CORE_TRAINING_RUNTIME_MODULE_H

--- a/onert-micro/onert-micro/src/OMTrainingInterpreter.cpp
+++ b/onert-micro/onert-micro/src/OMTrainingInterpreter.cpp
@@ -66,7 +66,7 @@ OMStatus OMTrainingInterpreter::saveModel(const OMConfig &config, const char *sa
   // Close file
   out_file.close();
 #else
-  assert(fasle && "Not supported");
+  assert(false && "Not supported");
   return UnknownError;
 #endif // DIS_STREAM
 
@@ -107,7 +107,7 @@ OMStatus OMTrainingInterpreter::loadCheckpoint(OMConfig &config, const char *loa
     return UnknownError;
   }
 #else
-  assert(fasle && "Not supported");
+  assert(false && "Not supported");
   return UnknownError;
 #endif // DIS_STREAM
 
@@ -146,7 +146,7 @@ OMStatus OMTrainingInterpreter::saveCheckpoint(const OMConfig &config, const cha
   // Close file
   out_file.close();
 #else
-  assert(fasle && "Not supported");
+  assert(false && "Not supported");
   return UnknownError;
 #endif // DIS_STREAM
 

--- a/onert-micro/onert-micro/src/OMTrainingInterpreter.cpp
+++ b/onert-micro/onert-micro/src/OMTrainingInterpreter.cpp
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "OMTrainingInterpreter.h"
+
+#ifndef DIS_STREAM
+#include <fstream>
+#endif // DIS_STREAM
+
+using namespace onert_micro;
+
+OMStatus OMTrainingInterpreter::importTrainModel(char *model_ptr, const OMConfig &config)
+{
+  assert(model_ptr != nullptr && "Model ptr shouldn't be nullptr");
+  if (model_ptr == nullptr)
+    return UnknownError;
+
+  return _training_runtime_module.importTrainModel(model_ptr, config);
+}
+
+OMStatus OMTrainingInterpreter::trainSingleStep(OMConfig &config)
+{
+  return _training_runtime_module.trainSingleStep(config);
+}
+
+OMStatus OMTrainingInterpreter::reset() { return _training_runtime_module.reset(); }
+
+uint32_t OMTrainingInterpreter::getInputSizeAt(uint32_t position)
+{
+  return _training_runtime_module.getInputSizeAt(position);
+}
+
+uint32_t OMTrainingInterpreter::getOutputSizeAt(uint32_t position)
+{
+  return _training_runtime_module.getOutputSizeAt(position);
+}
+
+OMStatus OMTrainingInterpreter::saveModel(const OMConfig &config, const char *save_path)
+{
+  if (save_path == nullptr or config.model_size == 0 or config.model_ptr == nullptr)
+    return UnknownError;
+
+#ifndef DIS_STREAM
+  // Open or create file
+  // Note: if the file existed, it will be overwritten
+  std::ofstream out_file(save_path, std::ios::binary | std::ios::trunc);
+  if (not out_file.is_open())
+    return UnknownError;
+
+  // Write data
+  out_file.write(config.model_ptr, config.model_size);
+
+  // Close file
+  out_file.close();
+#else
+  assert(fasle && "Not supported");
+  return UnknownError;
+#endif // DIS_STREAM
+
+  // Saving done
+  return Ok;
+}
+
+OMStatus OMTrainingInterpreter::loadCheckpoint(OMConfig &config, const char *load_path)
+{
+  // Not imported or path is empty
+  if (load_path == nullptr or config.model_ptr == nullptr or config.model_size == 0)
+    return UnknownError;
+
+  // Get DataBuffer (vector of chars) of checkpoints
+  std::vector<char> checkpoint_data;
+
+  // Read data
+#ifndef DIS_STREAM
+  std::ifstream file(load_path, std::ios::binary | std::ios::in);
+  if (!file.good())
+  {
+    assert(false && "Fail to open");
+    return UnknownError;
+  }
+
+  file.seekg(0, std::ios::end);
+  auto fileSize = file.tellg();
+  file.seekg(0, std::ios::beg);
+
+  // reserve capacity
+  checkpoint_data.resize(fileSize);
+
+  // read the data
+  file.read(checkpoint_data.data(), fileSize);
+  if (file.fail())
+  {
+    assert(false && "Fail to read");
+    return UnknownError;
+  }
+#else
+  assert(fasle && "Not supported");
+  return UnknownError;
+#endif // DIS_STREAM
+
+  // Load data
+  OMStatus status = _training_runtime_module.loadCheckpointData(config, checkpoint_data.data());
+
+  return status;
+}
+
+OMStatus OMTrainingInterpreter::saveCheckpoint(const OMConfig &config, const char *save_path)
+{
+  // Not imported or path is empty
+  if (save_path == nullptr or config.model_ptr == nullptr or config.model_size == 0)
+    return UnknownError;
+
+  // Get DataBuffer (vector of chars) of checkpoints
+  std::vector<char> checkpoint_data;
+
+  OMStatus status = _training_runtime_module.createCheckpointFile(config, checkpoint_data);
+
+  assert(status == Ok);
+  if (status != Ok)
+    return status;
+
+    // Save it into save_path
+#ifndef DIS_STREAM
+  // Open or create file
+  // Note: if the file existed, it will be overwritten
+  std::ofstream out_file(save_path, std::ios::binary | std::ios::trunc);
+  if (not out_file.is_open())
+    return UnknownError;
+
+  // Write data
+  out_file.write(checkpoint_data.data(), checkpoint_data.size());
+
+  // Close file
+  out_file.close();
+#else
+  assert(fasle && "Not supported");
+  return UnknownError;
+#endif // DIS_STREAM
+
+  return Ok;
+}

--- a/onert-micro/onert-micro/src/core/OMTrainingRuntimeModule.cpp
+++ b/onert-micro/onert-micro/src/core/OMTrainingRuntimeModule.cpp
@@ -1,0 +1,304 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "core/OMTrainingRuntimeModule.h"
+#include "import/OMExecutionPlanCreator.h"
+#include "train/OMBackpropExecute.h"
+#include "core/train/OMCheckpointSaver.h"
+#include "core/train/OMCheckpointLoader.h"
+
+using namespace onert_micro::core;
+using namespace onert_micro;
+
+/*
+ * Import train model, validate it, prepare necessary structures and data for future calculations
+ */
+OMStatus OMTrainingRuntimeModule::importTrainModel(char *model_ptr, const OMConfig &config)
+{
+  // 1 - Import main model
+  // 2 - Import and create training entities
+
+  // 1 - Import main model
+  OMStatus status = importModel(model_ptr, config);
+  if (status != Ok)
+    return status;
+
+  // 2 - Import and create training entities
+  _backward_graphs.resize(_graphs.size());
+  for (uint32_t i = 0; i < _backward_graphs.size(); ++i)
+  {
+    // load default backward graph
+    OMRuntimeGraph &graph = _backward_graphs.at(i);
+
+    OMRuntimeContext &runtime_context = graph.getRuntimeContext();
+    OMRuntimeStorage &runtime_storage = graph.getRuntimeStorage();
+    memory::OMRuntimeAllocator &runtime_allocator = graph.getRuntimeAllocator();
+
+    runtime_context.setModel(model_ptr, i);
+
+    // Parse and validate WOF file if it is exist
+    // WARNING: setWofFile method of RuntimeContext should follow after setModel.
+    if (config.wof_ptr != nullptr)
+      runtime_context.setWofFile(config.wof_ptr);
+
+    // AllocDeallocPlan backward graph creation
+    status = import::OMExecutionPlanCreator::createBackwardExecutionPlan(
+      runtime_storage, runtime_context, runtime_allocator, config);
+    if (status != Ok)
+      return status;
+  }
+
+  // Set current optimizer
+  _training_handler.setOptimizer(config);
+
+  return Ok;
+}
+
+/*
+ *  Train single step: run forward graph (with data which was set in SetInput) ->
+ *  -> calculate error (with target data which was set in SetTarget) ->
+ *  -> run backward graph -> update optimizer state -> after batch_size steps update weights
+ *  Warning: before using trainSingleStep call: 1) importTrainModel; 2) setInput; 3) setTarget
+ */
+OMStatus OMTrainingRuntimeModule::trainSingleStep(OMConfig &config)
+{
+  OMStatus status = Ok;
+  uint32_t batch_size = config.training_context.batch_size;
+  config.training_context.num_step += 1;
+
+  // A - Run and update optimizers state batch_size times
+  //  a. Allocate forward inputs and memcopy current sample (in current batch) into forward inputs
+  //  b. Run forward graph
+  //  c. Handle (calculate) current error backpropagation function result
+  //  d. Run backward graph (calculate backpropagation values)
+  //  e. Update optimization state
+  //  f. Reset runtime graphs (to deallocate forward outputs)
+  // B - Update weights according chosen optimization strategy (after batch_size times)
+
+  // A
+  for (uint32_t b = 0; b < batch_size; ++b)
+  {
+    //  a. Allocate forward inputs and memcopy current sample (in current batch) into forward inputs
+    {
+      OMRuntimeGraph &forward_main_graph = _graphs.at(0);
+      forward_main_graph.allocateGraphInputs();
+      uint32_t input_nums = forward_main_graph.getNumberOfInputs();
+      for (uint32_t i = 0; i < input_nums; ++i)
+      {
+        uint8_t *allocated_input_data =
+          reinterpret_cast<uint8_t *>(forward_main_graph.getInputDataAt(i));
+        size_t type_size = forward_main_graph.getInputDataTypeSize(i);
+        size_t tensor_size = forward_main_graph.getInputSizeAt(i);
+        size_t offset = b * type_size * tensor_size;
+
+        uint8_t *input_data = _training_handler.getInputData(i);
+        std::memcpy(allocated_input_data, input_data + offset, tensor_size * type_size);
+      }
+    }
+
+    //  b. Run forward graph
+    {
+      status = run();
+      assert(status == Ok);
+      if (status != Ok)
+        return status;
+    }
+
+    if (_backward_graphs.empty())
+      return ModelNotImport;
+
+    for (uint32_t i = 0; i < _graphs.size(); ++i)
+    {
+      // Get forward entities
+      OMRuntimeGraph &forward_graph = _graphs.at(i);
+      OMRuntimeContext &forward_context = forward_graph.getRuntimeContext();
+      OMRuntimeStorage &forward_storage = forward_graph.getRuntimeStorage();
+
+      // Get backward entities
+      OMRuntimeGraph &backward_graph = _backward_graphs.at(i);
+      OMRuntimeContext &backward_context = backward_graph.getRuntimeContext();
+      OMRuntimeStorage &backward_storage = backward_graph.getRuntimeStorage();
+
+      //  c. Handle (calculate) current error backpropagation function result
+      {
+        status = _training_handler.handleError(config, forward_storage, backward_storage,
+                                               backward_context, b);
+        assert(status == Ok);
+        if (status != Ok)
+          return status;
+      }
+
+      //  d. Run backward graph
+      {
+        onert_micro::train::OMBackpropExecuteArgs backprop_execute_args = {
+          forward_storage, backward_storage, backward_context, false, 0};
+
+        status = onert_micro::train::OMBackpropExecute::runBackward(
+          config, backprop_execute_args, backward_graph.getRuntimeAllocator());
+        assert(status == Ok);
+        if (status != Ok)
+          return status;
+      }
+
+      //  e. Update optimization state
+      {
+        status = _training_handler.updateOptimizerState(config, backward_storage, backward_context);
+        assert(status == Ok);
+        if (status != Ok)
+          return status;
+      }
+
+      //  f. Reset runtime graphs
+      backward_graph.reset();
+      forward_graph.reset();
+    }
+  }
+
+  // B - Update weights according chosen optimization strategy
+  for (uint32_t i = 0; i < _graphs.size(); ++i)
+  {
+    // Get backward context
+    OMRuntimeGraph &backward_graph = _backward_graphs.at(i);
+    OMRuntimeContext &backward_context = backward_graph.getRuntimeContext();
+    status = _training_handler.updateWeights(config, backward_context);
+  }
+
+  return status;
+}
+
+/*
+ * Evaluate metrics
+ *
+ *  Warning: 1) assume that all metric_val for all OMMetrics types actually are float values.
+ *           2) metric_val should be initialized with some value before calling this method due to
+ *              after calculation for current batch_num (the sequence number of the current sample)
+ *              this value is added to metric_val
+ */
+OMStatus OMTrainingRuntimeModule::evaluateMetric(OMMetrics metric, void *metric_val,
+                                                 uint32_t test_size)
+{
+  OMStatus status = Ok;
+  OMRuntimeGraph &forward_main_graph = _graphs.at(0);
+
+  assert(test_size > 0);
+  if (test_size == 0)
+    return UnknownError;
+
+  uint32_t input_nums = forward_main_graph.getNumberOfInputs();
+  for (uint32_t b = 0; b < test_size; ++b)
+  {
+    //  a. Allocate forward inputs and memcopy current sample (in current batch) into forward inputs
+    {
+      forward_main_graph.allocateGraphInputs();
+      for (uint32_t i = 0; i < input_nums; ++i)
+      {
+        uint8_t *allocated_input_data =
+          reinterpret_cast<uint8_t *>(forward_main_graph.getInputDataAt(i));
+        size_t type_size = forward_main_graph.getInputDataTypeSize(i);
+        size_t tensor_size = forward_main_graph.getInputSizeAt(i);
+        size_t offset = b * type_size * tensor_size;
+
+        uint8_t *input_data = _training_handler.getInputData(i);
+        std::memcpy(allocated_input_data, input_data + offset, tensor_size * type_size);
+      }
+    }
+
+    //  b. Run forward graph
+    {
+      status = run();
+      assert(status == Ok);
+      if (status != Ok)
+        return status;
+    }
+
+    // c. Calculate loss on test_size data
+    _training_handler.evaluateMetric(metric, metric_val, forward_main_graph.getRuntimeStorage(),
+                                     forward_main_graph.getRuntimeContext(), b);
+
+    // Reset values
+    forward_main_graph.reset();
+  }
+
+  // Averaged result
+  {
+    float *f_metric_val = reinterpret_cast<float *>(metric_val);
+    *f_metric_val /= test_size;
+  }
+
+  return Ok;
+}
+
+/*
+ * Reset all forward and backward graphs
+ */
+OMStatus OMTrainingRuntimeModule::reset()
+{
+  OMStatus status = Ok;
+
+  if (_graphs.empty())
+    return ModelNotImport;
+
+  for (auto &graph : _graphs)
+  {
+    graph.reset();
+  }
+
+  for (auto &graph : _backward_graphs)
+  {
+    graph.reset();
+  }
+
+  _training_handler.reset();
+
+  return status;
+}
+
+/*
+ * Create and save checkpoint data into data_buffer vector
+ */
+OMStatus OMTrainingRuntimeModule::createCheckpointFile(const OMConfig &config,
+                                                       std::vector<char> &data_buffer)
+{
+  // Model wasn't imported
+  if (_backward_graphs.size() == 0 or _graphs.size() == 0)
+    return UnknownError;
+
+  OMRuntimeContext &context = _backward_graphs.at(0).getRuntimeContext();
+  train::OMTrainingStorage &train_storage = _training_handler.getTrainingStorage();
+
+  OMStatus status =
+    train::OMCheckpointSaver::createCheckpointData(context, train_storage, data_buffer, config);
+
+  return status;
+}
+
+/*
+ * Load checkpoint data and save in model data and config
+ */
+OMStatus OMTrainingRuntimeModule::loadCheckpointData(OMConfig &config, const char *data)
+{
+  // Model wasn't imported
+  if (_backward_graphs.size() == 0 or _graphs.size() == 0)
+    return UnknownError;
+
+  OMRuntimeContext &context = _backward_graphs.at(0).getRuntimeContext();
+  train::OMTrainingStorage &train_storage = _training_handler.getTrainingStorage();
+
+  OMStatus status =
+    train::OMCheckpointLoader::loadCheckpointData(context, train_storage, data, config);
+
+  return status;
+}


### PR DESCRIPTION
This pr introduces OMTrainingInterpreter, OMTrainingContext and OMTrainingRuntimeModule entities.

for issue #12873
from draft: #13107

ONE-DCO-1.0-Signed-off-by: Artem Balyshev <a.balyshev@samsung.com>