### PR TITLE
[onert-micro] Add losses functions

### DIFF
--- a/onert-micro/onert-micro/include/train/losses_functions/CrossEntropy.h
+++ b/onert-micro/onert-micro/include/train/losses_functions/CrossEntropy.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ONERT_MICRO_TRAIN_LOSSES_FUNCTIONS_CROSS_ENTROPY_H
+#define ONERT_MICRO_TRAIN_LOSSES_FUNCTIONS_CROSS_ENTROPY_H
+
+#include "OMStatus.h"
+
+#include <cstdint>
+
+namespace onert_micro
+{
+namespace train
+{
+namespace losses_functions
+{
+
+// Cross Entropy
+struct CrossEntropy
+{
+  // Calculate cross entropy error backpropagation between calculated and target data
+  static void calculateErrorBackpropagation(const uint32_t flat_size, const float *calculated_data,
+                                            const float *target_data, float *output_grad);
+};
+
+} // namespace losses_functions
+} // namespace train
+} // namespace onert_micro
+
+#endif // ONERT_MICRO_TRAIN_LOSSES_FUNCTIONS_CROSS_ENTROPY_H

--- a/onert-micro/onert-micro/include/train/losses_functions/MSE.h
+++ b/onert-micro/onert-micro/include/train/losses_functions/MSE.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ONERT_MICRO_TRAIN_LOSSES_FUNCTIONS_MSE_H
+#define ONERT_MICRO_TRAIN_LOSSES_FUNCTIONS_MSE_H
+
+#include "OMStatus.h"
+
+#include <cstdint>
+
+namespace onert_micro
+{
+namespace train
+{
+namespace losses_functions
+{
+
+// MSE- Mean Square Error
+struct MSE
+{
+  // Calculate mean square error backpropagation between calculated and target data
+  static void calculateErrorBackpropagation(const uint32_t flat_size, const float *calculated_data,
+                                            const float *target_data, float *output_grad);
+};
+
+} // namespace losses_functions
+} // namespace train
+} // namespace onert_micro
+
+#endif // ONERT_MICRO_TRAIN_LOSSES_FUNCTIONS_MSE_H

--- a/onert-micro/onert-micro/src/train/losses_functions/CrossEntropy.cpp
+++ b/onert-micro/onert-micro/src/train/losses_functions/CrossEntropy.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "train/losses_functions/CrossEntropy.h"
+
+using namespace onert_micro;
+using namespace onert_micro::train;
+using namespace onert_micro::train::losses_functions;
+
+/*
+ * dE/dY = Y_t / Y
+ * where Y - vector of calculated outputs,
+ *       Y_t - vector of target outputs
+ * Note: size of Y and Y_t should be the same and equal to flat_size
+ */
+void CrossEntropy::calculateErrorBackpropagation(const uint32_t flat_size,
+                                                 const float *calculated_data,
+                                                 const float *target_data, float *output_grad)
+{
+  for (uint32_t i = 0; i < flat_size; ++i)
+  {
+    output_grad[i] = -1.f * target_data[i] / (calculated_data[i] + float(10.0e-32));
+  }
+}

--- a/onert-micro/onert-micro/src/train/losses_functions/MSE.cpp
+++ b/onert-micro/onert-micro/src/train/losses_functions/MSE.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "train/losses_functions/MSE.h"
+
+using namespace onert_micro;
+using namespace onert_micro::train;
+using namespace onert_micro::train::losses_functions;
+
+/*
+ * dE/dY = (2 * (Y - Y_t)) / N
+ * where Y - vector of calculated outputs,
+ *       Y_t - vector of target outputs
+ * Note: size of Y and Y_t should be the same and equal to flat_size
+ */
+void MSE::calculateErrorBackpropagation(const uint32_t flat_size, const float *calculated_data,
+                                        const float *target_data, float *output_grad)
+{
+  for (uint32_t i = 0; i < flat_size; ++i)
+  {
+    output_grad[i] = (2 * (calculated_data[i] - target_data[i])) / static_cast<float>(flat_size);
+  }
+}


### PR DESCRIPTION
This pr adds losses - MSE and CrossEntropy functions.

for issue https://github.com/Samsung/ONE/issues/12873
from draft: https://github.com/Samsung/ONE/pull/13107

ONE-DCO-1.0-Signed-off-by: Artem Balyshev <a.balyshev@samsung.com>