### PR TITLE
[onert] Change TracingObserver writing policy

### DIFF
--- a/runtime/onert/core/src/exec/ExecutionObservers.h
+++ b/runtime/onert/core/src/exec/ExecutionObservers.h
@@ -86,8 +86,9 @@ private:
   std::unique_ptr<EventRecorder> _recorder;
   EventCollector _collector;
   const ir::Graph &_graph;
-  EventWriter *_event_writer;
+  std::string _workspace_dir;
   const util::TracingCtx *_tracing_ctx;
+  bool _triggered;
 };
 
 } // namespace exec


### PR DESCRIPTION
This commit updates TracingObserver to write file when observer is used at least once.

ONE-DCO-1.0-Signed-off-by: Hyeongseok Oh <hseok82.oh@samsung.com>

--- 

Draft: #13013