### PR TITLE
[onert] Use reinterpret_cast instead of the classic C casts

### DIFF
--- a/runtime/onert/core/src/exporter/CircleExporter.cc
+++ b/runtime/onert/core/src/exporter/CircleExporter.cc
@@ -60,7 +60,7 @@ void CircleExporter::finish()
   builder.Finish(::circle::Model::Pack(builder, _model.get()), ::circle::ModelIdentifier());
 
   std::ofstream dst(_path.c_str(), std::ios::binary);
-  dst.write((const char *)builder.GetBufferPointer(), builder.GetSize());
+  dst.write(reinterpret_cast<const char *>(builder.GetBufferPointer()), builder.GetSize());
   dst.close();
 }
 } // namespace exporter


### PR DESCRIPTION
This commit changes the classic C casts to the `reinterpret_cast`.

ONE-DCO-1.0-Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>

Related comment: https://github.com/Samsung/ONE/pull/13114#discussion_r1632561605